### PR TITLE
fix(money-path): custo ausente ≠ R$0 em recommend + algorithm-a-audit (cost_source-aware)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-recommend-audit-cost-source-contract.md
+++ b/docs/superpowers/plans/2026-06-19-recommend-audit-cost-source-contract.md
@@ -1,0 +1,973 @@
+# Contrato de custo `recommend` + `algorithm-a-audit` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminar a fabricação de custo R$0 nos dois edges (`recommend`, `algorithm-a-audit`) — custo ausente vira `null`/indisponível respeitando `cost_source`, sem distorcer ranking nem auditoria.
+
+**Architecture:** Régua de custo confiável num helper puro novo (`src/lib/custos/cost-source.ts`, vitest), espelhada **verbatim** nos edges Deno. `recommend` separa custo de margem (exibido/logado → `null` quando não confiável) de custo de ranking (`estimated_cost_for_ranking`, estimativa rotulada). `algorithm-a-audit` calcula gap/gap% cost-free (já cost-invariante) e níveis absolutos só sob cobertura de custo ≥85% (helper puro `auditoria-margem.ts`). Frontend torna `fmt` null-safe e mostra "—".
+
+**Tech Stack:** TypeScript strict · vitest · Supabase Edge Functions (Deno 2.7) · React 18. Sem migration (colunas `recommendation_log.*` e `margin_audit_log.*` já nullable).
+
+**Spec:** [docs/superpowers/specs/2026-06-19-recommend-audit-cost-source-contract-design.md](../specs/2026-06-19-recommend-audit-cost-source-contract-design.md)
+
+---
+
+### Task 1: Helper puro `cost-source.ts` (régua de custo confiável + estimativa de ranking)
+
+**Files:**
+- Create: `src/lib/custos/cost-source.ts`
+- Test: `src/lib/custos/__tests__/cost-source.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/custos/__tests__/cost-source.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolverCustoConfiavel, estimarCustoParaRanking, derivarMargensCandidato, type CostRow } from '../cost-source';
+
+const row = (o: Partial<CostRow>): CostRow => ({ cost_price: null, cost_final: null, cost_source: null, cost_confidence: null, ...o });
+
+describe('resolverCustoConfiavel', () => {
+  it('PRODUCT_COST com cost_final>0 → cost_final', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: 12.5 }))).toBe(12.5);
+  });
+  it('CMC com cost_final>0 → cost_final', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: 8 }))).toBe(8);
+  });
+  it('CMC com cost_final=0 mas cost_price>0 → cost_price (os 14 do syncInventory)', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: 0, cost_price: 9.9 }))).toBe(9.9);
+  });
+  it('PRODUCT_COST com cost_final inválido NÃO cai p/ cost_price → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: 0, cost_price: 9.9 }))).toBeNull();
+  });
+  it('FAMILY_MARGIN_PROXY → null (não fabrica margem)', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 50 }))).toBeNull();
+  });
+  it('DEFAULT_PROXY → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'DEFAULT_PROXY', cost_final: 50 }))).toBeNull();
+  });
+  it('UNKNOWN / source null / row null → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'UNKNOWN', cost_final: 50 }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: null, cost_final: 50 }))).toBeNull();
+    expect(resolverCustoConfiavel(null)).toBeNull();
+    expect(resolverCustoConfiavel(undefined)).toBeNull();
+  });
+  it('falsificação: cost_final negativo/NaN/Infinity → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: -5 }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: NaN }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: Infinity }))).toBeNull();
+  });
+  it('falsificação CMC: cost_final E cost_price inválidos → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: 0, cost_price: 0 }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: NaN, cost_price: -1 }))).toBeNull();
+  });
+  it('normaliza espaço/caixa do backfill', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: '  product_cost  ', cost_final: 7 }))).toBe(7);
+  });
+});
+
+describe('estimarCustoParaRanking', () => {
+  it('custo real presente → custo real', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'PRODUCT_COST', cost_final: 30 }), 100)).toBe(30);
+  });
+  it('sem real, proxy cost_final válido (<price) → proxy cost_final', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 60 }), 100)).toBe(60);
+    expect(estimarCustoParaRanking(row({ cost_source: 'DEFAULT_PROXY', cost_final: 75 }), 100)).toBe(75);
+  });
+  it('proxy cost_final ≥ price (margem estimada ≤0) → null', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'DEFAULT_PROXY', cost_final: 120 }), 100)).toBeNull();
+  });
+  it('UNKNOWN / sem row / proxy sem cost_final → null', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'UNKNOWN', cost_final: 50 }), 100)).toBeNull();
+    expect(estimarCustoParaRanking(null, 100)).toBeNull();
+    expect(estimarCustoParaRanking(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: null }), 100)).toBeNull();
+  });
+});
+
+describe('derivarMargensCandidato', () => {
+  it('custo real → exibida e ranking iguais (margem real)', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'PRODUCT_COST', cost_final: 30 }), 100))
+      .toEqual({ custoConfiavel: 30, custoRanking: 30, margemExibida: 70, margemRanking: 70 });
+  });
+  it('proxy → exibida null, ranking via estimativa (não fabrica margem exibida)', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 60 }), 100))
+      .toEqual({ custoConfiavel: null, custoRanking: 60, margemExibida: null, margemRanking: 40 });
+  });
+  it('UNKNOWN/sem sinal → tudo null (EIP será neutralizado pelo motor)', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'UNKNOWN' }), 100))
+      .toEqual({ custoConfiavel: null, custoRanking: null, margemExibida: null, margemRanking: null });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `heavy bun run test src/lib/custos/__tests__/cost-source.test.ts`
+Expected: FAIL — "Cannot find module '../cost-source'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/custos/cost-source.ts`:
+
+```ts
+// Contrato de custo dos motores de recomendação/auditoria (Codex P2 cost-final-ignorado; follow-up da
+// spec do cockpit). Régua IDÊNTICA a resolverCustoCockpit (src/lib/financeiro/valor-cockpit-helpers.ts):
+// ausente ≠ R$0; proxy não é custo de margem confiável. Módulo puro — espelhado VERBATIM nas edges Deno
+// recommend/index.ts e algorithm-a-audit/index.ts (Deno não importa de src/).
+// Resíduo: convergir resolverCustoCockpit → este módulo pós-merge do #959 (fonte única).
+
+export type CostRow = {
+  cost_price: number | null;
+  cost_final: number | null;
+  cost_source: string | null;
+  cost_confidence: number | null;
+};
+
+const COST_SOURCES_REAIS = new Set(['PRODUCT_COST', 'CMC']);
+const COST_SOURCES_PROXY = new Set(['FAMILY_MARGIN_PROXY', 'DEFAULT_PROXY']);
+
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === 'number' && Number.isFinite(x) && x > 0;
+}
+
+function normalizarSource(source: string | null | undefined): string | null {
+  const s = source?.trim().toUpperCase();
+  return s ? s : null;
+}
+
+// Custo de MARGEM (exibido/logado). Ausente → null (NÃO fabrica margem).
+//   1. source∈REAIS e finitePositive(cost_final) → cost_final (vivo, preferido)
+//   2. source=CMC e finitePositive(cost_price)   → cost_price (fallback dos 14 do syncInventory)
+//   3. resto (PROXY/UNKNOWN/null/fonte nova)      → null
+export function resolverCustoConfiavel(row: CostRow | null | undefined): number | null {
+  const source = normalizarSource(row?.cost_source);
+  if (row == null || source == null || !COST_SOURCES_REAIS.has(source)) return null;
+  if (finitePositive(row.cost_final)) return row.cost_final;
+  if (source === 'CMC' && finitePositive(row.cost_price)) return row.cost_price;
+  return null;
+}
+
+// Custo de RANKING (só EIP/score; NUNCA exibido/logado como margem firme). Aceita estimativa proxy
+// sanity-bounded (< price → margem estimada positiva). real ?? proxy cost_final válido ?? null.
+export function estimarCustoParaRanking(row: CostRow | null | undefined, price: number): number | null {
+  const real = resolverCustoConfiavel(row);
+  if (real != null) return real;
+  const source = normalizarSource(row?.cost_source);
+  const cf = row?.cost_final ?? null;
+  if (source != null && COST_SOURCES_PROXY.has(source) && finitePositive(cf) && cf < price) return cf;
+  return null;
+}
+
+export type MargensCandidato = {
+  custoConfiavel: number | null;
+  custoRanking: number | null;
+  margemExibida: number | null;
+  margemRanking: number | null;
+};
+
+// Split por candidato (recommend). Helper HONESTO (null); o motor aplica o neutro (eip = margemRanking ?? 0).
+export function derivarMargensCandidato(row: CostRow | null | undefined, price: number): MargensCandidato {
+  const custoConfiavel = resolverCustoConfiavel(row);
+  const custoRanking = estimarCustoParaRanking(row, price);
+  return {
+    custoConfiavel,
+    custoRanking,
+    margemExibida: custoConfiavel != null ? price - custoConfiavel : null,
+    margemRanking: custoRanking != null ? price - custoRanking : null,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `heavy bun run test src/lib/custos/__tests__/cost-source.test.ts`
+Expected: PASS (todos os describes verdes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/custos/cost-source.ts src/lib/custos/__tests__/cost-source.test.ts
+git commit -m "feat(custos): resolverCustoConfiavel + estimarCustoParaRanking (régua de custo, vitest)"
+```
+
+---
+
+### Task 2: Helper puro `auditoria-margem.ts` (gap cost-free + margens cobertura-gated)
+
+**Files:**
+- Create: `src/lib/custos/auditoria-margem.ts`
+- Test: `src/lib/custos/__tests__/auditoria-margem.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/custos/__tests__/auditoria-margem.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { calcularAuditoriaMargemCliente, type AuditOrderLine } from '../auditoria-margem';
+import type { CostRow } from '../cost-source';
+
+const realRow = (cf: number): CostRow => ({ cost_price: null, cost_final: cf, cost_source: 'PRODUCT_COST', cost_confidence: 0.95 });
+const proxyRow = (cf: number): CostRow => ({ cost_price: null, cost_final: cf, cost_source: 'DEFAULT_PROXY', cost_confidence: 0.25 });
+
+// A: actual 80, best 100, qty 2 → leak (100-80)*2 = 40 ; B: actual 50, best 50, qty 1 → leak 0
+const orders: AuditOrderLine[] = [
+  { product_id: 'A', unit_price: 80, discount: 0, quantity: 2 },
+  { product_id: 'B', unit_price: 50, discount: 0, quantity: 1 },
+];
+const best = (id: string): number | null => (({ A: 100, B: 50 }) as Record<string, number>)[id] ?? null;
+
+describe('calcularAuditoriaMargemCliente — cost-invariância do gap (falsificação)', () => {
+  it('margin_gap, top_gap e gap_pct NÃO dependem do custo (cancela); níveis absolutos SIM', () => {
+    const c10 = calcularAuditoriaMargemCliente({ orders, custoPorProduto: () => realRow(10), bestPrice: best });
+    const c40 = calcularAuditoriaMargemCliente({ orders, custoPorProduto: () => realRow(40), bestPrice: best });
+    // cost-invariante:
+    expect(c10.margin_gap).toBe(40);
+    expect(c40.margin_gap).toBe(40);
+    expect(c10.gap_pct).toBe(16);   // 40 / (100*2 + 50*1) * 100
+    expect(c40.gap_pct).toBe(16);
+    expect(c10.top_gap_products).toEqual([{ product_id: 'A', gap: 40 }]);
+    expect(c40.top_gap_products).toEqual([{ product_id: 'A', gap: 40 }]);
+    // cost-dependente (níveis absolutos mudam):
+    expect(c10.margin_real).toBe(180);      // (80-10)*2 + (50-10)*1
+    expect(c40.margin_real).toBe(90);       // (80-40)*2 + (50-40)*1
+    expect(c10.margin_potential).toBe(220); // (100-10)*2 + (50-10)*1
+  });
+});
+
+describe('calcularAuditoriaMargemCliente — gate de cobertura', () => {
+  it('cobertura <85% (maioria proxy) → margin_real/potential null, mas gap/gap_pct seguem', () => {
+    const mixed: AuditOrderLine[] = [
+      { product_id: 'A', unit_price: 80, discount: 0, quantity: 1 },  // real
+      { product_id: 'P', unit_price: 90, discount: 0, quantity: 1 },  // proxy → sem custo confiável
+    ];
+    const cost = (id: string): CostRow => id === 'A' ? realRow(10) : proxyRow(45);
+    const bestM = (id: string): number | null => (({ A: 100, P: 100 }) as Record<string, number>)[id] ?? null;
+    const r = calcularAuditoriaMargemCliente({ orders: mixed, custoPorProduto: cost, bestPrice: bestM });
+    expect(r.margin_real).toBeNull();
+    expect(r.margin_potential).toBeNull();
+    expect(r.margin_gap).toBe(30);               // leak A (100-80)*1=20 + P (100-90)*1=10
+    expect(r.gap_pct).toBe(15);                  // 30 / (100+100) * 100
+    expect(r.cobertura_custo).toBeCloseTo(80 / 170, 5); // receitaComCusto 80 / receita 170
+  });
+
+  it('cobertura ≥85% → níveis presentes', () => {
+    const r = calcularAuditoriaMargemCliente({ orders, custoPorProduto: () => realRow(10), bestPrice: best });
+    expect(r.cobertura_custo).toBe(1);
+    expect(r.margin_real).toBe(180);
+  });
+});
+
+describe('calcularAuditoriaMargemCliente — degenerados', () => {
+  it('sem linha válida (product_id null) → gap 0, gap_pct null, margins null', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [{ product_id: null, unit_price: 1, discount: 0, quantity: 1 }],
+      custoPorProduto: () => null,
+      bestPrice: () => null,
+    });
+    expect(r.margin_gap).toBe(0);
+    expect(r.gap_pct).toBeNull();
+    expect(r.margin_real).toBeNull();
+  });
+  it('sem best price → bestPrice = actualPrice → leak 0', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [{ product_id: 'X', unit_price: 70, discount: 0, quantity: 1 }],
+      custoPorProduto: () => realRow(20),
+      bestPrice: () => null,
+    });
+    expect(r.margin_gap).toBe(0);
+    expect(r.gap_pct).toBe(0);
+    expect(r.margin_real).toBe(50); // (70-20)*1
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `heavy bun run test src/lib/custos/__tests__/auditoria-margem.test.ts`
+Expected: FAIL — "Cannot find module '../auditoria-margem'".
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/custos/auditoria-margem.ts`:
+
+```ts
+// Auditoria de margem (Algorithm A — margin_audit_log). Núcleo puro espelhado VERBATIM na edge
+// algorithm-a-audit/index.ts. Custo ausente ≠ R$0 (resolverCustoConfiavel). margin_gap e
+// top_gap_products são COST-INVARIANTES ((bestPrice−cost)−(actualPrice−cost)=bestPrice−actualPrice);
+// gap_pct = vazamento-de-receita % (cost-free). Níveis absolutos margin_real/potential só sob
+// cobertura de custo ≥0.85 (espelha o gate do cockpit); senão null (ausente ≠ fabricar).
+
+import { resolverCustoConfiavel, type CostRow } from './cost-source';
+
+export type AuditOrderLine = {
+  product_id: string | null;
+  unit_price: number | null;
+  discount: number | null;
+  quantity: number | null;
+};
+
+export type AuditoriaCliente = {
+  margin_real: number | null;
+  margin_potential: number | null;
+  margin_gap: number;
+  gap_pct: number | null;
+  top_gap_products: { product_id: string; gap: number }[];
+  cobertura_custo: number;
+};
+
+const COBERTURA_CUSTO_MIN = 0.85;
+const round2 = (x: number) => Math.round(x * 100) / 100;
+
+export function calcularAuditoriaMargemCliente(input: {
+  orders: AuditOrderLine[];
+  custoPorProduto: (productId: string) => CostRow | null | undefined;
+  bestPrice: (productId: string) => number | null | undefined;
+}): AuditoriaCliente {
+  let marginGap = 0;
+  let bestRevenue = 0;
+  let receita = 0;
+  let marginRealKnown = 0;
+  let marginPotentialKnown = 0;
+  let receitaComCusto = 0;
+  const topGap: { product_id: string; gap: number }[] = [];
+
+  for (const o of input.orders) {
+    if (!o.product_id) continue;
+    const qty = Number(o.quantity);
+    const up = Number(o.unit_price);
+    if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
+    const actualPrice = up * (1 - Number(o.discount || 0) / 100);
+    const bp = input.bestPrice(o.product_id);
+    const bestPrice = typeof bp === 'number' && Number.isFinite(bp) ? bp : actualPrice;
+
+    // cost-free (sempre): vazamento de preço
+    const leak = (bestPrice - actualPrice) * qty;
+    marginGap += leak;
+    bestRevenue += bestPrice * qty;
+    receita += actualPrice * qty;
+    if (leak > 0) topGap.push({ product_id: o.product_id, gap: leak });
+
+    // níveis absolutos: só com custo REAL (proxy/UNKNOWN/null não conta)
+    const custo = resolverCustoConfiavel(input.custoPorProduto(o.product_id));
+    if (custo != null) {
+      marginRealKnown += (actualPrice - custo) * qty;
+      marginPotentialKnown += (bestPrice - custo) * qty;
+      receitaComCusto += actualPrice * qty;
+    }
+  }
+
+  topGap.sort((a, b) => b.gap - a.gap);
+  const cobertura_custo = receita > 0 ? receitaComCusto / receita : 0;
+  const temCobertura = cobertura_custo >= COBERTURA_CUSTO_MIN;
+
+  return {
+    margin_real: temCobertura ? round2(marginRealKnown) : null,
+    margin_potential: temCobertura ? round2(marginPotentialKnown) : null,
+    margin_gap: round2(marginGap),
+    gap_pct: bestRevenue > 0 ? round2((marginGap / bestRevenue) * 100) : null,
+    top_gap_products: topGap.slice(0, 5),
+    cobertura_custo,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `heavy bun run test src/lib/custos/__tests__/auditoria-margem.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/custos/auditoria-margem.ts src/lib/custos/__tests__/auditoria-margem.test.ts
+git commit -m "feat(custos): calcularAuditoriaMargemCliente — gap cost-free + margens cobertura-gated (vitest)"
+```
+
+---
+
+### Task 3: `recommend` edge — espelhar helper + split ranking/exibição
+
+**Files:**
+- Modify: `supabase/functions/recommend/index.ts`
+
+> Deno não importa de `src/` → as 3 funções + tipos de `cost-source.ts` são coladas **verbatim** no topo do edge.
+
+- [ ] **Step 1: Colar o bloco-espelho do helper**
+
+Em `supabase/functions/recommend/index.ts`, logo após a função `minMaxNorm` (linha ~27, antes de `// ======== RECOMMENDATION ENGINE ========`), inserir:
+
+```ts
+// ======== COST CONTRACT (espelho VERBATIM de src/lib/custos/cost-source.ts — manter idêntico) ========
+type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
+const COST_SOURCES_REAIS = new Set(["PRODUCT_COST", "CMC"]);
+const COST_SOURCES_PROXY = new Set(["FAMILY_MARGIN_PROXY", "DEFAULT_PROXY"]);
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === "number" && Number.isFinite(x) && x > 0;
+}
+function normalizarSource(source: string | null | undefined): string | null {
+  const s = source?.trim().toUpperCase();
+  return s ? s : null;
+}
+function resolverCustoConfiavel(row: CostRow | null | undefined): number | null {
+  const source = normalizarSource(row?.cost_source);
+  if (row == null || source == null || !COST_SOURCES_REAIS.has(source)) return null;
+  if (finitePositive(row.cost_final)) return row.cost_final;
+  if (source === "CMC" && finitePositive(row.cost_price)) return row.cost_price;
+  return null;
+}
+function estimarCustoParaRanking(row: CostRow | null | undefined, price: number): number | null {
+  const real = resolverCustoConfiavel(row);
+  if (real != null) return real;
+  const source = normalizarSource(row?.cost_source);
+  const cf = row?.cost_final ?? null;
+  if (source != null && COST_SOURCES_PROXY.has(source) && finitePositive(cf) && cf < price) return cf;
+  return null;
+}
+type MargensCandidato = { custoConfiavel: number | null; custoRanking: number | null; margemExibida: number | null; margemRanking: number | null };
+function derivarMargensCandidato(row: CostRow | null | undefined, price: number): MargensCandidato {
+  const custoConfiavel = resolverCustoConfiavel(row);
+  const custoRanking = estimarCustoParaRanking(row, price);
+  return {
+    custoConfiavel,
+    custoRanking,
+    margemExibida: custoConfiavel != null ? price - custoConfiavel : null,
+    margemRanking: custoRanking != null ? price - custoRanking : null,
+  };
+}
+// ======== /COST CONTRACT ========
+```
+
+- [ ] **Step 2: Buscar `cost_price`, tipar `costMap` como `CostRow`, e tornar `Candidate` nullable**
+
+**(a) Incluir `cost_price` no SELECT de custos** — a régua usa o fallback CMC→`cost_price` (os 14 do syncInventory). Hoje a coluna não é buscada. Linha ~74, trocar:
+
+```ts
+    db.from("product_costs").select("product_id, cost_final, cost_source, cost_confidence"),
+```
+por:
+```ts
+    db.from("product_costs").select("product_id, cost_price, cost_final, cost_source, cost_confidence"),
+```
+
+**(b) Tipar `costMap` como `CostRow`** (linha ~103), trocar:
+
+```ts
+  const costMap: Record<string, { cost_final: number; cost_source: string; cost_confidence: number }> = {};
+```
+por:
+```ts
+  const costMap: Record<string, CostRow> = {};
+```
+(o loop `for (const c of costs || []) costMap[c.product_id] = c;` na linha ~104 permanece — `costs` é frouxamente tipado pelo client sem `<Database>`.)
+
+**(c) `interface Candidate`** (linhas ~31-54): trocar `cost_final: number` → `cost_final: number | null`; inserir `cost_ranking: number | null;` após `cost_confidence: number;`; trocar `margin: number;` → `margin: number | null;`. (`cost_source: string` e `cost_confidence: number` permanecem — recebem default no push.)
+
+- [ ] **Step 3: Trocar o cálculo de custo/margem no loop de candidatos**
+
+Substituir o bloco (linhas ~153-158):
+
+```ts
+    const cost = costMap[p.id];
+    const costFinal = cost?.cost_final || 0;
+    const price = p.valor_unitario || 0;
+    if (price <= 0) continue;
+
+    const margin = price - costFinal;
+```
+
+por:
+
+```ts
+    const cost = costMap[p.id];
+    const price = p.valor_unitario || 0;
+    if (price <= 0) continue;
+
+    const { custoConfiavel, custoRanking, margemExibida, margemRanking } = derivarMargensCandidato(cost ?? null, price);
+    const margemRank = margemRanking ?? 0; // EIP neutro (0, não máximo) quando custo de ranking ausente
+```
+
+- [ ] **Step 4: EIP/EILTV usam a margem de ranking**
+
+Trocar (linha ~174): `const eip = probability * margin;` → `const eip = probability * margemRank;`
+
+Trocar (linha ~176): `const eiltv = probability * (margin + kappa * recurrenceScore * margin);` → `const eiltv = probability * (margemRank + kappa * recurrenceScore * margemRank);`
+
+- [ ] **Step 5: Explicação de margem gateada por margem REAL conhecida**
+
+Trocar (linhas ~195-197):
+
+```ts
+    } else if (margin > 50) {
+      explanationKey = "margin";
+      explanationText = `${p.descricao} tem alto potencial de margem (R$ ${margin.toFixed(2)})`;
+```
+
+por:
+
+```ts
+    } else if (margemExibida != null && margemExibida > 50) {
+      explanationKey = "margin";
+      explanationText = `${p.descricao} tem alto potencial de margem (R$ ${margemExibida.toFixed(2)})`;
+```
+
+- [ ] **Step 6: `candidates.push` usa custo confiável (exibido) + ranking**
+
+No objeto `candidates.push({ ... })` (linhas ~205-214), trocar:
+- `cost_final: costFinal,` → `cost_final: custoConfiavel,`
+- `cost_confidence: cost?.cost_confidence || 0, familia: p.familia,` → `cost_confidence: cost?.cost_confidence || 0, cost_ranking: custoRanking, familia: p.familia,`
+- `estoque: p.estoque || 0, margin, assoc_score: assoc,` → `estoque: p.estoque || 0, margin: margemExibida, assoc_score: assoc,`
+
+- [ ] **Step 7: Resposta expõe `estimated_cost_for_ranking`**
+
+No `_admin` da resposta (linhas ~274-279), trocar:
+
+```ts
+      _admin: {
+        cost_final: c.cost_final, cost_source: c.cost_source,
+        cost_confidence: c.cost_confidence, assoc_score: c.assoc_score,
+```
+
+por:
+
+```ts
+      _admin: {
+        cost_final: c.cost_final, cost_source: c.cost_source,
+        cost_confidence: c.cost_confidence, estimated_cost_for_ranking: c.cost_ranking,
+        assoc_score: c.assoc_score,
+```
+
+> O log (`unit_cost: c.cost_final`, `margin: c.margin`, linhas ~252/254) **não muda de forma** — os valores agora são `number | null` e as colunas `recommendation_log.unit_cost/margin` já são nullable.
+
+- [ ] **Step 8: Verificar tipos do edge (deno) + lint**
+
+Run: `deno check supabase/functions/recommend/index.ts`
+Expected: sem erros de tipo (downloads de `npm:` na 1ª vez são normais).
+
+Run: `bun run lint -- supabase/functions/recommend/index.ts` (ou `bun run lint` e confirmar que o arquivo não introduz erro)
+Expected: 0 erros novos.
+
+**Paridade verbatim:** confirmar que o bloco entre os marcadores `COST CONTRACT` é byte-idêntico às funções de `src/lib/custos/cost-source.ts` (mesma lógica; só sem `export`).
+
+Run: `git diff --no-index <(sed -n '/COST CONTRACT (espelho/,/\/COST CONTRACT/p' supabase/functions/recommend/index.ts | grep -E 'return|finitePositive|COST_SOURCES|normalizarSource|cost_final|cost_price') <(grep -E 'return|finitePositive|COST_SOURCES|normalizarSource|cost_final|cost_price' src/lib/custos/cost-source.ts) || echo "revisar manualmente as diferenças acima"`
+Expected: diferenças só de `export ` (esperado) — nenhuma diferença de lógica.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add supabase/functions/recommend/index.ts
+git commit -m "fix(recommend): custo ausente ≠ R\$0 — margem exibida null + estimated_cost_for_ranking (espelho verbatim)"
+```
+
+---
+
+### Task 4: `algorithm-a-audit` edge — espelhar helpers + gap cost-free
+
+**Files:**
+- Modify: `supabase/functions/algorithm-a-audit/index.ts`
+
+- [ ] **Step 1: Colar o bloco-espelho dos helpers**
+
+Em `supabase/functions/algorithm-a-audit/index.ts`, após os imports (linha ~2, depois de `import { authorizeCronOrStaff }...`), inserir o bloco-espelho de `cost-source` (idêntico ao Step 1 da Task 3) E o de `auditoria-margem`:
+
+```ts
+// ======== COST CONTRACT (espelho VERBATIM de src/lib/custos/cost-source.ts — manter idêntico) ========
+type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
+const COST_SOURCES_REAIS = new Set(["PRODUCT_COST", "CMC"]);
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === "number" && Number.isFinite(x) && x > 0;
+}
+function normalizarSource(source: string | null | undefined): string | null {
+  const s = source?.trim().toUpperCase();
+  return s ? s : null;
+}
+function resolverCustoConfiavel(row: CostRow | null | undefined): number | null {
+  const source = normalizarSource(row?.cost_source);
+  if (row == null || source == null || !COST_SOURCES_REAIS.has(source)) return null;
+  if (finitePositive(row.cost_final)) return row.cost_final;
+  if (source === "CMC" && finitePositive(row.cost_price)) return row.cost_price;
+  return null;
+}
+// ======== AUDIT CORE (espelho VERBATIM de src/lib/custos/auditoria-margem.ts — manter idêntico) ========
+type AuditOrderLine = { product_id: string | null; unit_price: number | null; discount: number | null; quantity: number | null };
+type AuditoriaCliente = {
+  margin_real: number | null; margin_potential: number | null; margin_gap: number;
+  gap_pct: number | null; top_gap_products: { product_id: string; gap: number }[]; cobertura_custo: number;
+};
+const COBERTURA_CUSTO_MIN = 0.85;
+const round2 = (x: number) => Math.round(x * 100) / 100;
+function calcularAuditoriaMargemCliente(input: {
+  orders: AuditOrderLine[];
+  custoPorProduto: (productId: string) => CostRow | null | undefined;
+  bestPrice: (productId: string) => number | null | undefined;
+}): AuditoriaCliente {
+  let marginGap = 0, bestRevenue = 0, receita = 0, marginRealKnown = 0, marginPotentialKnown = 0, receitaComCusto = 0;
+  const topGap: { product_id: string; gap: number }[] = [];
+  for (const o of input.orders) {
+    if (!o.product_id) continue;
+    const qty = Number(o.quantity);
+    const up = Number(o.unit_price);
+    if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
+    const actualPrice = up * (1 - Number(o.discount || 0) / 100);
+    const bp = input.bestPrice(o.product_id);
+    const bestPrice = typeof bp === "number" && Number.isFinite(bp) ? bp : actualPrice;
+    const leak = (bestPrice - actualPrice) * qty;
+    marginGap += leak;
+    bestRevenue += bestPrice * qty;
+    receita += actualPrice * qty;
+    if (leak > 0) topGap.push({ product_id: o.product_id, gap: leak });
+    const custo = resolverCustoConfiavel(input.custoPorProduto(o.product_id));
+    if (custo != null) {
+      marginRealKnown += (actualPrice - custo) * qty;
+      marginPotentialKnown += (bestPrice - custo) * qty;
+      receitaComCusto += actualPrice * qty;
+    }
+  }
+  topGap.sort((a, b) => b.gap - a.gap);
+  const cobertura_custo = receita > 0 ? receitaComCusto / receita : 0;
+  const temCobertura = cobertura_custo >= COBERTURA_CUSTO_MIN;
+  return {
+    margin_real: temCobertura ? round2(marginRealKnown) : null,
+    margin_potential: temCobertura ? round2(marginPotentialKnown) : null,
+    margin_gap: round2(marginGap),
+    gap_pct: bestRevenue > 0 ? round2((marginGap / bestRevenue) * 100) : null,
+    top_gap_products: topGap.slice(0, 5),
+    cobertura_custo,
+  };
+}
+// ======== /AUDIT CORE ========
+```
+
+- [ ] **Step 2: Ampliar `ProductCostRow` e o select**
+
+Trocar a interface (linhas ~17-21):
+
+```ts
+interface ProductCostRow {
+  product_id: string;
+  cost_final: number | null;
+  family_category: string | null;
+}
+```
+
+por:
+
+```ts
+interface ProductCostRow {
+  product_id: string;
+  cost_price: number | null;
+  cost_final: number | null;
+  cost_source: string | null;
+  cost_confidence: number | null;
+  family_category: string | null;
+}
+```
+
+Trocar o select (linha ~103):
+
+```ts
+    const productCosts = await fetchAllPaginated<ProductCostRow>(supabase, 'product_costs', 'product_id, cost_final, family_category');
+```
+
+por:
+
+```ts
+    const productCosts = await fetchAllPaginated<ProductCostRow>(supabase, 'product_costs', 'product_id, cost_price, cost_final, cost_source, cost_confidence, family_category');
+```
+
+- [ ] **Step 3: `costMap` guarda a linha inteira (não `Number(cost_final||0)`)**
+
+Trocar (linhas ~129-133):
+
+```ts
+    // Build cost map
+    const costMap: Record<string, number> = {};
+    productCosts.forEach(pc => {
+      costMap[pc.product_id] = Number(pc.cost_final || 0);
+    });
+```
+
+por:
+
+```ts
+    // Build cost map (linha inteira — a régua resolverCustoConfiavel decide o custo confiável)
+    const costMap: Record<string, ProductCostRow> = {};
+    productCosts.forEach(pc => { costMap[pc.product_id] = pc; });
+```
+
+- [ ] **Step 4: `AuditRecord` nullable nos níveis absolutos**
+
+Trocar (linhas ~36-46) os 3 campos:
+- `margin_real: number;` → `margin_real: number | null;`
+- `margin_potential: number;` → `margin_potential: number | null;`
+- `gap_pct: number;` → `gap_pct: number | null;`
+(`margin_gap: number;` permanece — sempre numérico.)
+
+- [ ] **Step 5: Substituir o loop por-cliente pelo helper**
+
+Trocar o corpo do loop (linhas ~152-190, do `let marginReal = 0;` até o `auditRecords.push({...})` inclusive):
+
+```ts
+      let marginReal = 0;
+      let marginPotential = 0;
+      const topGapProducts: { product_id: string; gap: number }[] = [];
+
+      for (const order of orders) {
+        if (!order.product_id) continue;
+        const cost = costMap[order.product_id] || 0;
+        const actualPrice = Number(order.unit_price) * (1 - Number(order.discount || 0) / 100);
+        const bestPrice = bestPriceMap[order.product_id] || actualPrice;
+        const qty = Number(order.quantity);
+
+        const realMargin = (actualPrice - cost) * qty;
+        const potentialMargin = (bestPrice - cost) * qty;
+
+        marginReal += realMargin;
+        marginPotential += potentialMargin;
+
+        const gap = potentialMargin - realMargin;
+        if (gap > 0) {
+          topGapProducts.push({ product_id: order.product_id, gap });
+        }
+      }
+
+      const marginGap = marginPotential - marginReal;
+      const gapPct = marginPotential > 0 ? (marginGap / marginPotential) * 100 : 0;
+
+      topGapProducts.sort((a, b) => b.gap - a.gap);
+
+      auditRecords.push({
+        customer_user_id: client.customer_user_id,
+        farmer_id: client.farmer_id,
+        period_start: periodStart,
+        period_end: periodEnd,
+        margin_real: Math.round(marginReal * 100) / 100,
+        margin_potential: Math.round(marginPotential * 100) / 100,
+        margin_gap: Math.round(marginGap * 100) / 100,
+        gap_pct: Math.round(gapPct * 100) / 100,
+        top_gap_products: topGapProducts.slice(0, 5),
+      });
+```
+
+por:
+
+```ts
+      const a = calcularAuditoriaMargemCliente({
+        orders,
+        custoPorProduto: (id) => costMap[id] ?? null,
+        bestPrice: (id) => bestPriceMap[id] ?? null,
+      });
+
+      auditRecords.push({
+        customer_user_id: client.customer_user_id,
+        farmer_id: client.farmer_id,
+        period_start: periodStart,
+        period_end: periodEnd,
+        margin_real: a.margin_real,
+        margin_potential: a.margin_potential,
+        margin_gap: a.margin_gap,
+        gap_pct: a.gap_pct,
+        top_gap_products: a.top_gap_products,
+      });
+```
+
+> `bestPriceMap` continua sendo `Record<string, number>` construído acima (linhas ~122-127), inalterado.
+
+- [ ] **Step 6: Verificar tipos do edge (deno) + paridade**
+
+Run: `deno check supabase/functions/algorithm-a-audit/index.ts`
+Expected: sem erros de tipo.
+
+**Paridade:** confirmar que os blocos `COST CONTRACT` e `AUDIT CORE` são idênticos (lógica) aos `src/lib/custos/*.ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add supabase/functions/algorithm-a-audit/index.ts
+git commit -m "fix(algorithm-a-audit): custo ausente ≠ R\$0 — gap cost-free + margens cobertura-gated (espelho verbatim)"
+```
+
+---
+
+### Task 5: Frontend `recommend` — tipos nullable + `fmt` null-safe
+
+**Files:**
+- Modify: `src/hooks/useRecommendationEngine.ts:10,18-28`
+- Modify: `src/components/RecommendationCard.tsx:10`
+
+- [ ] **Step 1: Tipos do hook nullable + novo campo**
+
+Em `src/hooks/useRecommendationEngine.ts`, no `interface RecommendationItem`:
+- `margin: number;` (linha 10) → `margin: number | null;`
+- No bloco `_admin?`: `cost_final: number;` (linha 19) → `cost_final: number | null;`
+- Adicionar após essa linha: `estimated_cost_for_ranking: number | null;`
+
+Resultado do `_admin`:
+
+```ts
+  _admin?: {
+    cost_final: number | null;
+    estimated_cost_for_ranking: number | null;
+    cost_source: string;
+    cost_confidence: number;
+    assoc_score: number;
+    sim_score: number;
+    ctx_score: number;
+    penalties: number;
+    familia: string | null;
+    eiltv: number;
+  };
+```
+
+- [ ] **Step 2: `fmt` null-safe no card**
+
+Em `src/components/RecommendationCard.tsx`, trocar (linha 10):
+
+```ts
+const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+```
+
+por:
+
+```ts
+const fmt = (v: number | null | undefined) => v == null ? '—' : v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+```
+
+> Isso cobre `fmt(item.margin)` (linha 81 → "—" quando custo não confiável), `fmt(item._admin.cost_final)` (linha 120) e os `fmt(item.eip)`/`fmt(item._admin.eiltv)` (sempre numéricos, inalterados na prática). Nenhuma outra mudança no card.
+
+- [ ] **Step 3: Verificar tipos + lint**
+
+Run: `heavy bun run typecheck`
+Expected: PASS (sem erro novo em useRecommendationEngine/RecommendationCard).
+
+Run: `bun run lint`
+Expected: 0 erros novos.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useRecommendationEngine.ts src/components/RecommendationCard.tsx
+git commit -m "fix(recommend-ui): margin/cost_final nullable → '—' (fmt null-safe) + estimated_cost_for_ranking"
+```
+
+---
+
+### Task 6: Frontend auditoria — "—" para níveis null
+
+**Files:**
+- Modify: `src/components/intelligence/IntelligenceStrategicTab.tsx:184-187`
+- Modify: `src/pages/GovernanceAudit.tsx:430-436`
+
+- [ ] **Step 1: `IntelligenceStrategicTab` — células null-safe**
+
+Em `src/components/intelligence/IntelligenceStrategicTab.tsx`, trocar as 4 células (linhas 184-187):
+
+```tsx
+                      <td className="text-center py-2">R$ {Number(row.margin_real).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
+                      <td className="text-center py-2">R$ {Number(row.margin_potential).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
+                      <td className="text-center py-2 text-destructive">R$ {Number(row.margin_gap).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
+                      <td className="text-center py-2">{Number(row.gap_pct).toFixed(1)}%</td>
+```
+
+por:
+
+```tsx
+                      <td className="text-center py-2">{row.margin_real == null ? '—' : `R$ ${Number(row.margin_real).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`}</td>
+                      <td className="text-center py-2">{row.margin_potential == null ? '—' : `R$ ${Number(row.margin_potential).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`}</td>
+                      <td className="text-center py-2 text-destructive">R$ {Number(row.margin_gap).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
+                      <td className="text-center py-2">{row.gap_pct == null ? '—' : `${Number(row.gap_pct).toFixed(1)}%`}</td>
+```
+
+> `margin_gap` permanece (sempre numérico). As somas `totalMarginReal`/`Potential` (linhas 65-66) já usam `Number(r.margin_real || 0)` → null é pulado (total parcial; aceitável).
+
+- [ ] **Step 2: `GovernanceAudit` — células + badge null-safe**
+
+Em `src/pages/GovernanceAudit.tsx`, trocar (linhas 430-437):
+
+```tsx
+                            <td className="text-center py-2">R$ {Number(row.margin_real).toLocaleString('pt-BR')}</td>
+                            <td className="text-center py-2">R$ {Number(row.margin_potential).toLocaleString('pt-BR')}</td>
+                            <td className="text-center py-2 text-destructive font-medium">R$ {Number(row.margin_gap).toLocaleString('pt-BR')}</td>
+                            <td className="text-center py-2">
+                              <Badge variant={Number(row.gap_pct) > 20 ? 'destructive' : 'secondary'} className="text-2xs">
+                                {Number(row.gap_pct).toFixed(1)}%
+                              </Badge>
+                            </td>
+```
+
+por:
+
+```tsx
+                            <td className="text-center py-2">{row.margin_real == null ? '—' : `R$ ${Number(row.margin_real).toLocaleString('pt-BR')}`}</td>
+                            <td className="text-center py-2">{row.margin_potential == null ? '—' : `R$ ${Number(row.margin_potential).toLocaleString('pt-BR')}`}</td>
+                            <td className="text-center py-2 text-destructive font-medium">R$ {Number(row.margin_gap).toLocaleString('pt-BR')}</td>
+                            <td className="text-center py-2">
+                              {row.gap_pct == null ? <span className="text-muted-foreground">—</span> : (
+                                <Badge variant={Number(row.gap_pct) > 20 ? 'destructive' : 'secondary'} className="text-2xs">
+                                  {Number(row.gap_pct).toFixed(1)}%
+                                </Badge>
+                              )}
+                            </td>
+```
+
+- [ ] **Step 3: Verificar tipos + lint**
+
+Run: `heavy bun run typecheck`
+Expected: PASS.
+
+Run: `bun run lint`
+Expected: 0 erros novos.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/intelligence/IntelligenceStrategicTab.tsx src/pages/GovernanceAudit.tsx
+git commit -m "fix(auditoria-ui): níveis margin_real/potential/gap_pct null → '—' (vazamento% cost-free)"
+```
+
+---
+
+### Task 7: Verificação final + Codex challenge + handoff de deploy
+
+**Files:** nenhum (gate de qualidade).
+
+- [ ] **Step 1: Suite completa verde**
+
+Run: `heavy bun run typecheck && bun run lint && heavy bun run test src/lib/custos`
+Expected: typecheck PASS · lint 0 erro · vitest dos 2 helpers PASS.
+
+- [ ] **Step 2: Re-check dos edges (deno)**
+
+Run: `deno check supabase/functions/recommend/index.ts supabase/functions/algorithm-a-audit/index.ts`
+Expected: sem erros.
+
+- [ ] **Step 3: `/codex challenge` no diff (adversarial money-path)**
+
+Run: `git diff main...HEAD` e submeter ao Codex (`gpt-5.5`, reasoning `xhigh` — money-path). Foco adversário: (a) algum caminho ainda fabrica custo 0? (b) `estimated_cost_for_ranking` vaza como margem firme em algum lugar? (c) a mudança de semântica do `gap_pct` (vazamento%) está coerente com numerador/denominador? (d) paridade edge×src é byte-idêntica?
+Registrar o veredito no corpo do PR. Se a cota do Codex estiver esgotada → Caminho B (auto-challenge + `REVISÃO INDEPENDENTE PENDENTE`).
+
+- [ ] **Step 4: Abrir PR (NÃO-draft só após Codex verde)**
+
+```bash
+git push -u origin claude/agitated-ellis-ff1133
+gh pr create --title "fix(money-path): custo ausente ≠ R\$0 em recommend + algorithm-a-audit (cost_source-aware)" --body "<resumo + link spec/plano + veredito Codex + checklist de deploy manual>"
+```
+> Auto-merge (squash) dispara no CI verde. Para segurar, manter DRAFT.
+
+- [ ] **Step 5: Handoff de deploy MANUAL (merge ≠ produção)**
+
+Após o merge, lembrar o founder (não auto-aplica):
+1. **Edge `recommend`** — chat do Lovable, colar verbatim de `supabase/functions/recommend/index.ts`.
+2. **Edge `algorithm-a-audit`** — idem.
+3. **Frontend** — Publish no editor do Lovable (RecommendationCard + as 2 telas de auditoria).
+4. **Sem migration.** Verificar pós-deploy: uma recomendação de produto sem custo mostra "Margem —" (não R$ cheio); painel de governança mostra "Vazamento %".
+
+---
+
+## Notas de execução
+
+- **`heavy`** prefixa test/typecheck (semáforo de RAM M2 8GB).
+- **Não tocar** `src/lib/financeiro/valor-cockpit-helpers.ts` (QUENTE — PR #959).
+- Ordem importa: Tasks 1-2 (helpers provados) antes de 3-4 (edges espelham) antes de 5-6 (frontend consome). Task 3 e 4 são independentes entre si; 5 e 6 idem.
+- `bun run lint -- <arquivo>` pode não filtrar por arquivo dependendo do script; na dúvida rodar `bun run lint` inteiro e conferir que o delta de erros é 0.

--- a/docs/superpowers/specs/2026-06-19-recommend-audit-cost-source-contract-design.md
+++ b/docs/superpowers/specs/2026-06-19-recommend-audit-cost-source-contract-design.md
@@ -1,0 +1,139 @@
+# `recommend` + `algorithm-a-audit` — contrato de custo: ausente ≠ R$0, respeitando `cost_source`
+
+> Spec/design. Money-path (ranking de recomendação + auditoria de margem). Follow-up sancionado da spec do cockpit (`2026-06-18-valor-cockpit-cost-final-contract-design.md` §"Fora de escopo").
+> 2ª opinião: `/codex challenge` no diff final (adversarial money-path) — pendente.
+
+## Problema
+
+Dois edges tratam custo ausente como **R$0**, o que vira "margem cheia" (anti-padrão money-path: ausente ≠ zero, `docs/agent/money-path.md` §2):
+
+1. **`recommend/index.ts:154`** — `const costFinal = cost?.cost_final || 0;` → `margin = price − 0 = preço cheio`.
+   - `eip = probability × margin` é o sinal de ranking (peso `w_eip = 0.35`). Produto sem custo → **EIP máximo → rankeia no topo** (fantasma de lucro).
+   - `margin` e `_admin.cost_final` são **exibidos como número firme** no `RecommendationCard` (linhas 81/120) e logados em `recommendation_log` (treino/medição). Custo `UNKNOWN`/sem-row aparece como "alto potencial de margem".
+2. **`algorithm-a-audit/index.ts:132`** — `costMap[pc.product_id] = Number(pc.cost_final || 0);` (idem; e ignora `cost_source`, então **proxy entra como custo real** na auditoria).
+
+### Escada de `cost_source` (writer `omie-analytics-sync` `reprocessRecommendationCosts`, linhas ~1004-1076)
+
+| source | conf | `cost_final` | natureza |
+|---|---|---|---|
+| `PRODUCT_COST` | 0.95 | custo real (passa sanity) | **real** |
+| `CMC` | 0.80/0.85 | cmc | **real** |
+| `CMC` (via `syncInventory`, linha 848) | 0.70 | **0** (grava só `cost_price=cmc`) | **real, mas em `cost_price`** |
+| `FAMILY_MARGIN_PROXY` | 0.50 | `price×(1−margem_família)` | **inventado** |
+| `DEFAULT_PROXY` | 0.25 | `price×(1−margem_default)` | **inventado** |
+| `UNKNOWN` | 0 | 0 | sem sinal |
+
+`cost_price = existing?.cost_price || costFinal` → **sticky** (congela no 1º valor). Proxy tem `cost_final` **não-zero** (é estimativa). O `|| 0` morde em: linha sem row, `UNKNOWN`, e os 14 CMC com `cost_final=0 & cost_price>0`.
+
+## Evidência de produção (psql-ro, 2026-06-18; recorte oben TTM, da spec do cockpit)
+
+- 475 SKU: CMC 43% · DEFAULT_PROXY 22% · PRODUCT_COST 21% · FAMILY_MARGIN_PROXY 14% → **36% proxy inventado**.
+- `cost_price>0 & cost_final=0`: **14** (todos CMC 0.70 do `syncInventory`) → exige fallback p/ `cost_price`.
+- Concentração de receita: real 78,3% · proxy 16,4% · sem-custo 5,4%.
+
+### Achado não-óbvio — a auditoria já é parcialmente robusta
+
+`margin_gap` e `top_gap_products` são **cost-invariantes**:
+
+```
+gap = potentialMargin − realMargin
+    = (bestPrice − cost)·qty − (actualPrice − cost)·qty
+    = (bestPrice − actualPrice)·qty            ← o custo CANCELA
+```
+
+Logo o *headline* da auditoria (vazamento de preço) está correto mesmo com custo 0. O `|| 0` só distorce: (a) `gap_pct` (denominador `margin_potential` infla → gap% **subestimado**) e (b) `margin_real`/`margin_potential` absolutos (receita cheia como margem). Colunas `margin_audit_log.{margin_real,margin_potential,margin_gap,gap_pct}` são **nullable** → degradar p/ null **sem migration**.
+
+## Decisão
+
+Régua única de custo confiável (idêntica a `resolverCustoCockpit` do #959), separando **custo de margem** (exibido/logado, ausente→null) de **custo de ranking** (estimativa rotulada, sugestão do Codex `estimated_cost_for_ranking`). Auditoria: gap/gap% cost-free (robusto); margens absolutas só sob alta cobertura de custo.
+
+### 1. Helper puro novo `src/lib/custos/cost-source.ts` (vitest), espelhado **verbatim** nos 2 edges
+
+> **Não** edito `src/lib/financeiro/valor-cockpit-helpers.ts` (QUENTE — PR #959 DRAFT). Módulo novo, desacoplado. Régua de custo idêntica → 2 cópias TS temporárias; **resíduo:** pós-merge do #959, convergir `resolverCustoCockpit` → este módulo (fonte única). Edges Deno não importam de `src/` → espelho verbatim.
+
+```ts
+export type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
+const COST_SOURCES_REAIS = new Set(['PRODUCT_COST', 'CMC']);
+const COST_SOURCES_PROXY = new Set(['FAMILY_MARGIN_PROXY', 'DEFAULT_PROXY']);
+function finitePositive(x): x is number  // > 0, finito; rejeita ≤0/NaN/Infinity
+
+// Custo de MARGEM (exibido/logado). Ausente ≠ fabricar margem.
+//   1. source∈REAIS e finitePositive(cost_final)  → cost_final   (vivo, preferido)
+//   2. source=CMC e finitePositive(cost_price)     → cost_price   (fallback dos 14 do syncInventory)
+//   3. resto (PROXY/UNKNOWN/null/fonte nova)       → null
+resolverCustoConfiavel(row: CostRow | null | undefined): number | null
+
+// Custo de RANKING (só EIP/score; NUNCA exibido/logado como margem firme).
+//   real (resolverCustoConfiavel) ?? proxy cost_final válido (source∈PROXY, finitePositive) ?? null
+estimarCustoParaRanking(row: CostRow | null | undefined, price: number): number | null
+
+// Split por candidato (recommend). Mantém o helper HONESTO (null); o motor aplica o neutro.
+//   custoConfiavel/margemExibida → display/log; custoRanking/margemRanking → eip/eiltv.
+//   margemExibida = custoConfiavel!=null ? price−custoConfiavel : null
+//   margemRanking = custoRanking!=null   ? price−custoRanking   : null
+derivarMargensCandidato(row, price): { custoConfiavel: number|null; custoRanking: number|null; margemExibida: number|null; margemRanking: number|null }
+```
+
+`source` normalizado (`trim().toUpperCase()`) p/ tolerar backfill. Fallback (passo 2) é **só CMC** — `PRODUCT_COST` com `cost_final` inválido NÃO cai p/ `cost_price` (o reprocess pode tê-lo rejeitado por sanity).
+
+### 2. `recommend/index.ts` — split ranking vs exibição
+
+- Substitui `cost?.cost_final || 0` por `derivarMargensCandidato(cost, price)`.
+- **EIP/EILTV** usam `margemRanking ?? 0` → sem estimativa alguma o EIP é **neutro (0), não máximo** → o produto rankeia só por assoc/sim/ctx (nunca por margem-fantasma). `eiltv` idem (usa a mesma `margemRanking`).
+- **Exibido/logado**: `Candidate.margin → number|null = margemExibida`; `_admin.cost_final = custoConfiavel` (number|null); novo `_admin.estimated_cost_for_ranking = custoRanking` (number|null, transparência). `cost_source` mantido (mostra PROXY/UNKNOWN).
+- `recommendation_log`: `unit_cost = custoConfiavel`, `margin = margemExibida` (ambos nullable ✅). `eip` segue número.
+- Branch de explicação de margem (linha ~195) gateado: `else if (margemExibida != null && margemExibida > 50)` — não afirma "alto potencial de margem" sobre null.
+- `Candidate.cost_final`/`margin` → `number | null` na interface.
+
+### 3. `algorithm-a-audit/index.ts` — gap cost-free + margens cobertura-gated
+
+Núcleo extraído p/ helper puro **`src/lib/custos/auditoria-margem.ts`** (vitest; cost-invariância falsificável), espelhado verbatim no edge:
+
+```ts
+calcularAuditoriaMargemCliente(input: { orders: {product_id; unit_price; discount; quantity}[]; custoPorProduto: (id)=>number|null; bestPrice: (id)=>number|null })
+  → { margin_real: number|null; margin_potential: number|null; margin_gap: number; gap_pct: number|null; top_gap_products: {product_id; gap}[]; cobertura_custo: number }
+```
+
+Por linha: `actualPrice = unit_price×(1−discount/100)`, `bestPrice = best ?? actualPrice`.
+- **Sempre (cost-free):** `leak = (bestPrice − actualPrice)×qty` → `margin_gap += leak`; `bestRevenue += bestPrice×qty`; `receita += actualPrice×qty`; se `leak>0` push em `top_gap_products`.
+- **Só com custo real** (`custo = resolverCustoConfiavel`): `marginRealKnown += (actualPrice−custo)×qty`; `marginPotentialKnown += (bestPrice−custo)×qty`; `receitaComCusto += actualPrice×qty`.
+
+Agregado:
+- `margin_gap` = Σ leak (cost-free, **sempre**). `top_gap_products` cost-free (inalterado).
+- `gap_pct` = `bestRevenue>0 ? margin_gap/bestRevenue×100 : null` — **vazamento de receita %** (cost-free, undistorted).
+- `cobertura_custo` = `receita>0 ? receitaComCusto/receita : 0`.
+- `margin_real`/`margin_potential` = `cobertura_custo ≥ 0.85 ? round(known) : null` (espelha o gate do cockpit; ausente ≠ fabricar).
+
+⚠️ **Mudança de semântica:** `gap_pct` deixa de ser "margem-gap %" e vira "vazamento de receita %". Coerente e mais honesto (o gap% atual é subestimado pelo custo fabricado). Linha com custo majoritariamente proxy mostra `— / — / R$X gap / Y% vazamento` (honesto: "não sei a margem absoluta, mas você está vazando R$X no preço").
+
+### 4. Frontend honesto (`fmt` null-safe + "—")
+
+- `src/components/RecommendationCard.tsx`: `fmt = (v: number|null|undefined) => v==null ? '—' : v.toLocaleString(...)` (hoje estoura em null). Linhas 81 (`margin`), 120 (`_admin.cost_final`), 85 (`eip`, segue número) cobertas.
+- `src/hooks/useRecommendationEngine.ts`: `margin: number → number|null`; `_admin.cost_final: number → number|null`; novo `estimated_cost_for_ranking?: number|null`.
+- `src/components/intelligence/IntelligenceStrategicTab.tsx` (184-187) e `src/pages/GovernanceAudit.tsx` (430-435): render "—" p/ `margin_real/potential/gap_pct` null (helper local `fmtBRL(v)`/`fmtPct(v)`). Somas (linhas 65-66) já usam `|| 0` → null é pulado (total parcial; aceitável p/ KPI). **Opcional:** renomear header "Gap %" → "Vazamento %" (alinha à nova semântica). Os 3 são leitura staff-only.
+
+## Riscos residuais aceitos (registrados)
+
+- **2 cópias TS da régua** (este módulo + `resolverCustoCockpit` do #959) até a convergência pós-merge. Lógica byte-idêntica; risco de divergência mitigado por vitest nos dois lados. Resíduo rastreado.
+- **`gap_pct` muda de semântica** no painel de governança (margem%→vazamento%) — decidido pelo founder (2026-06-19). Sem migration; sem coluna nova.
+- **EIP neutro (0) p/ custo desconhecido** pode sub-rankear um produto legítimo sem custo cadastrado. Aceito (precisão>recall: melhor não promover por margem-fantasma; o produto ainda surge por assoc/sim/ctx). O fix de fundo é cadastrar custo.
+- **EIP exibido (card linha 85) pode ser baseado em estimativa** (proxy) quando `margemExibida` é null — é grandeza ESPERADA de ranking, não margem firme; o `cost_source`/`estimated_cost_for_ranking` no `_admin` sinalizam a proveniência. O número que muda de firme→"—" é o `margin`, que era a mentira real.
+- **Soma de `margin_real` no Strategic/Governance** vira total parcial quando há clientes null. Aceito (KPI grosseiro; a tabela por-linha mostra "—").
+
+## Fora de escopo
+
+- Convergência `resolverCustoCockpit` → `cost-source.ts` (follow-up pós-merge #959).
+- Coluna `cobertura_custo` persistida em `margin_audit_log` (YAGNI; o gate roda no edge, null comunica).
+- Re-treino/recompute histórico do `recommendation_log` já gravado com margem fabricada (telemetria velha; novos eventos saem corretos).
+
+## Prova & entrega
+
+- **vitest** `src/lib/custos/__tests__/cost-source.test.ts` + `auditoria-margem.test.ts`:
+  - `resolverCustoConfiavel`: todos os branches + **falsificação** (neg/NaN/Infinity/0; PROXY→null; CMC fallback; PRODUCT_COST inválido NÃO cai p/ cost_price; source com espaço/caixa).
+  - `estimarCustoParaRanking`: real→real; sem-real+proxy→proxy cost_final; sem-real+sem-proxy→null; proxy inválido→null.
+  - `derivarMargensCandidato`: margemExibida null + margemRanking via estimativa (caso UNKNOWN/proxy); ambos null sem sinal.
+  - `calcularAuditoriaMargemCliente`: **cost-invariância** (mudar custo NÃO muda `margin_gap`/`top_gap`); `gap_pct` cost-free; gate de cobertura (proxy→null em margin_real/potential; real≥0.85→número); proxy não conta como real.
+- **Paridade edge×src**: o bloco espelhado nos edges é byte-idêntico ao helper (revisão manual no diff; sem harness diferencial dedicado — YAGNI, é cópia verbatim de função pura).
+- **`/codex challenge`** no diff final (adversarial money-path).
+- `bun run typecheck` + `bun run lint` + `bun run test`.
+- **Deploy MANUAL das 2 edges no chat do Lovable após merge** (merge ≠ produção; `recommend` + `algorithm-a-audit`). Frontend via Publish. Sem migration.

--- a/docs/superpowers/specs/2026-06-19-recommend-audit-cost-source-contract-design.md
+++ b/docs/superpowers/specs/2026-06-19-recommend-audit-cost-source-contract-design.md
@@ -117,8 +117,8 @@ Agregado:
 - **2 cópias TS da régua** (este módulo + `resolverCustoCockpit` do #959) até a convergência pós-merge. Lógica byte-idêntica; risco de divergência mitigado por vitest nos dois lados. Resíduo rastreado.
 - **`gap_pct` muda de semântica** no painel de governança (margem%→vazamento%) — decidido pelo founder (2026-06-19). Sem migration; sem coluna nova.
 - **EIP neutro (0) p/ custo desconhecido** pode sub-rankear um produto legítimo sem custo cadastrado. Aceito (precisão>recall: melhor não promover por margem-fantasma; o produto ainda surge por assoc/sim/ctx). O fix de fundo é cadastrar custo.
-- **EIP exibido (card linha 85) pode ser baseado em estimativa** (proxy) quando `margemExibida` é null — é grandeza ESPERADA de ranking, não margem firme; o `cost_source`/`estimated_cost_for_ranking` no `_admin` sinalizam a proveniência. O número que muda de firme→"—" é o `margin`, que era a mentira real.
-- **Soma de `margin_real` no Strategic/Governance** vira total parcial quando há clientes null. Aceito (KPI grosseiro; a tabela por-linha mostra "—").
+- **EIP/EILTV exibidos/logados degradam p/ null quando `margemExibida` é null** (Codex challenge #1 — resolvido) — eram R$ (lucro esperado) derivado de custo proxy. Só `score_eip` (score de ranking) e o `c.eip` interno (alimenta o min-max do `score_final`) seguem numéricos → **ranking inalterado**.
+- **Somas `margin_real`/`potential` no Strategic são covered-only** (parcial sob baixa cobertura) — os cards disclosam "N/M clientes c/ custo" (Codex #8). O headline "Gap de Margem" = Σ`margin_gap` (cost-free; NÃO deriva de potential−real, senão sumiria em baixa cobertura — Codex #5). Tabela por-linha mostra "—".
 
 ## Fora de escopo
 
@@ -137,3 +137,19 @@ Agregado:
 - **`/codex challenge`** no diff final (adversarial money-path).
 - `bun run typecheck` + `bun run lint` + `bun run test`.
 - **Deploy MANUAL das 2 edges no chat do Lovable após merge** (merge ≠ produção; `recommend` + `algorithm-a-audit`). Frontend via Publish. Sem migration.
+
+## Codex challenge — veredito (2 passes adversários, gpt-5.5 reasoning high, 8 achados, todos resolvidos)
+
+**Pass 1** (diff inicial, 834k tok) → 5 achados, **todos REAIS** (testes não pegavam edge-cases de dado):
+- **#1** `eip`/`eiltv` exibidos/logados eram R$ derivado de custo proxy → gateados p/ `null` qd `margin` null (`score_eip` + `c.eip` interno seguem numéricos; ranking intacto).
+- **#2** `bestPrice ≤ 0` poisonava o gap (perdi o guard `|| actualPrice` ao trocar p/ `?? null`) → guard `bp>0` (fallback `actualPrice`).
+- **#3** gate de cobertura instável com receita **sinalizada** (devolução/`discount>100` faziam cobertura passar de 1) → só linha de venda válida entra.
+- **#4** `log_accept/reject` omitiam `unit_cost/margin` → DEFAULT 0 do schema fabricava R$0 → `null` explícito.
+- **#5** KPI Strategic derivava gap de `potential−real` (sumia em baixa cobertura) → `Σ margin_gap` (cost-free).
+
+**Pass 2** (confirmação, 232k tok) → os 5 **VERIFICADOS** + 3 refinamentos:
+- **#6** ordem do `...extras` no `logEvent` (clobber teórico do null) → spread **antes** dos nulls (autoritativo).
+- **#7** item **GRÁTIS** (`actualPrice 0`, qty>0) era dropado pelo `actualPrice>0` — é o **MAIOR** leakage (deu o best price inteiro) → guard exclui só preço **negativo** (`< 0`).
+- **#8** cards Margem Real/Potencial/Global sem disclosure do parcial → subtitle "N/M clientes c/ custo".
+
+**Falsificação:** cada fix de helper (#2/#3/#7) entrou por teste **vermelho→verde** (vitest 27/27). Sem Caminho B — Codex respondeu nos 2 passes (cota OK).

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -7,7 +7,7 @@ import { Plus, TrendingUp, Package, ArrowUpRight, Sparkles } from 'lucide-react'
 import { cn } from '@/lib/utils';
 import type { RecommendationItem } from '@/hooks/useRecommendationEngine';
 
-const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+const fmt = (v: number | null | undefined) => v == null ? '—' : v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 const fmtPct = (v: number) => `${(v * 100).toFixed(0)}%`;
 
 const EXPLANATION_ICONS: Record<string, typeof Sparkles> = {

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -68,6 +68,10 @@ export function IntelligenceStrategicTab() {
   // Gap headline = Σ margin_gap (cost-free, presente em TODA linha). NÃO derivar de potential−real:
   // linhas de baixa cobertura têm margens null→0 mas margin_gap real, e o gap sumiria (Codex challenge).
   const totalGap = marginAudit?.reduce((a, r) => a + Number(r.margin_gap || 0), 0) || 0;
+  // Quantos clientes têm margem absoluta computável (custo real ≥85% da receita) — disclosure de que
+  // Margem Real/Potencial/Global são PARCIAIS sob baixa cobertura (Codex #8: não esconder o parcial).
+  const auditComCusto = marginAudit?.filter(r => r.margin_real != null).length || 0;
+  const auditTotal = marginAudit?.length || 0;
 
   const avgSpend = allScores?.length
     ? allScores.reduce((a, c) => a + Number(c.avg_monthly_spend_180d || 0), 0) / allScores.length
@@ -137,8 +141,8 @@ export function IntelligenceStrategicTab() {
           </Button>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <KpiCard title="Margem Real" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} />
-          <KpiCard title="Margem Potencial" value={`R$ ${totalMarginPotential.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingUp} />
+          <KpiCard title="Margem Real" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle={`parcial — ${auditComCusto}/${auditTotal} clientes c/ custo`} />
+          <KpiCard title="Margem Potencial" value={`R$ ${totalMarginPotential.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingUp} subtitle={`parcial — ${auditComCusto}/${auditTotal} clientes c/ custo`} />
           <KpiCard title="Gap de Margem" value={`R$ ${totalGap.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingDown} subtitle="vazamento de preço (todas as linhas)" />
           <KpiCard title="Registros" value={String(marginAudit?.length || 0)} icon={Eye} />
         </div>
@@ -156,7 +160,7 @@ export function IntelligenceStrategicTab() {
         <KpiCard title="Elasticidade de Preço" value={`${priceElasticity.toFixed(1)}%`} icon={TrendingUp} subtitle="Δ qty c/ desconto" />
         <KpiCard title="Sensibilidade a Desconto" value={`${discountSensitivity.toFixed(1)}%`} icon={Percent} subtitle={`${ordersWithDiscount} de ${salesOrders?.length || 0} pedidos`} />
         <KpiCard title="Market Share Est." value={`${marketSharePct.toFixed(1)}%`} icon={Target} subtitle={`${uniqueCustomers} de ~${estimatedMarket} clientes`} />
-        <KpiCard title="Margem Global" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle="Período auditado" />
+        <KpiCard title="Margem Global" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle={`parcial — ${auditComCusto}/${auditTotal} c/ custo`} />
       </div>
 
       {/* Margin Audit Table */}

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -181,10 +181,10 @@ export function IntelligenceStrategicTab() {
                   {marginAudit.slice(0, 20).map(row => (
                     <tr key={row.id} className="border-b border-border/50 hover:bg-muted/50">
                       <td className="py-2 font-mono">{clientNameMap[row.customer_user_id] ?? `${row.customer_user_id.slice(0, 8)}...`}</td>
-                      <td className="text-center py-2">R$ {Number(row.margin_real).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
-                      <td className="text-center py-2">R$ {Number(row.margin_potential).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
+                      <td className="text-center py-2">{row.margin_real == null ? '—' : `R$ ${Number(row.margin_real).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`}</td>
+                      <td className="text-center py-2">{row.margin_potential == null ? '—' : `R$ ${Number(row.margin_potential).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`}</td>
                       <td className="text-center py-2 text-destructive">R$ {Number(row.margin_gap).toLocaleString('pt-BR', { minimumFractionDigits: 0 })}</td>
-                      <td className="text-center py-2">{Number(row.gap_pct).toFixed(1)}%</td>
+                      <td className="text-center py-2">{row.gap_pct == null ? '—' : `${Number(row.gap_pct).toFixed(1)}%`}</td>
                       <td className="text-right py-2 text-muted-foreground">{new Date(row.calculated_at).toLocaleDateString('pt-BR')}</td>
                     </tr>
                   ))}

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -62,10 +62,12 @@ export function IntelligenceStrategicTab() {
     return acc;
   }, {} as Record<string, string>);
 
+  // margin_real/potential agora são null sob baixa cobertura de custo → somas são PARCIAIS (covered-only).
   const totalMarginReal = marginAudit?.reduce((a, r) => a + Number(r.margin_real || 0), 0) || 0;
   const totalMarginPotential = marginAudit?.reduce((a, r) => a + Number(r.margin_potential || 0), 0) || 0;
-  const totalGap = totalMarginPotential - totalMarginReal;
-  const gapPct = totalMarginPotential > 0 ? ((totalGap / totalMarginPotential) * 100) : 0;
+  // Gap headline = Σ margin_gap (cost-free, presente em TODA linha). NÃO derivar de potential−real:
+  // linhas de baixa cobertura têm margens null→0 mas margin_gap real, e o gap sumiria (Codex challenge).
+  const totalGap = marginAudit?.reduce((a, r) => a + Number(r.margin_gap || 0), 0) || 0;
 
   const avgSpend = allScores?.length
     ? allScores.reduce((a, c) => a + Number(c.avg_monthly_spend_180d || 0), 0) / allScores.length
@@ -137,7 +139,7 @@ export function IntelligenceStrategicTab() {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           <KpiCard title="Margem Real" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} />
           <KpiCard title="Margem Potencial" value={`R$ ${totalMarginPotential.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingUp} />
-          <KpiCard title="Gap de Margem" value={`R$ ${totalGap.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingDown} trend="down" trendValue={`${gapPct.toFixed(1)}%`} />
+          <KpiCard title="Gap de Margem" value={`R$ ${totalGap.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingDown} subtitle="vazamento de preço (todas as linhas)" />
           <KpiCard title="Registros" value={String(marginAudit?.length || 0)} icon={Eye} />
         </div>
       </div>

--- a/src/hooks/useRecommendationEngine.ts
+++ b/src/hooks/useRecommendationEngine.ts
@@ -9,7 +9,7 @@ export interface RecommendationItem {
   price: number;
   margin: number | null;
   probability: number;
-  eip: number;
+  eip: number | null;
   score_final: number;
   recommendation_type: string;
   explanation_text: string;
@@ -25,7 +25,7 @@ export interface RecommendationItem {
     ctx_score: number;
     penalties: number;
     familia: string | null;
-    eiltv: number;
+    eiltv: number | null;
   };
 }
 

--- a/src/hooks/useRecommendationEngine.ts
+++ b/src/hooks/useRecommendationEngine.ts
@@ -7,7 +7,7 @@ export interface RecommendationItem {
   codigo: string;
   descricao: string;
   price: number;
-  margin: number;
+  margin: number | null;
   probability: number;
   eip: number;
   score_final: number;
@@ -16,7 +16,8 @@ export interface RecommendationItem {
   explanation_key: string;
   estoque: number;
   _admin?: {
-    cost_final: number;
+    cost_final: number | null;
+    estimated_cost_for_ranking: number | null;
     cost_source: string;
     cost_confidence: number;
     assoc_score: number;

--- a/src/lib/custos/__tests__/auditoria-margem.test.ts
+++ b/src/lib/custos/__tests__/auditoria-margem.test.ts
@@ -108,6 +108,19 @@ describe('calcularAuditoriaMargemCliente — robustez de qualidade-de-dado (Code
     expect(r.margin_gap).toBe(40);
     expect(r.cobertura_custo).toBe(1);
   });
+  it('item GRÁTIS (discount 100 → actualPrice 0, qty>0) CONTA — é o maior leakage (Codex #7)', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [
+        { product_id: 'A', unit_price: 100, discount: 0, quantity: 1 },   // venda normal: leak 0
+        { product_id: 'B', unit_price: 100, discount: 100, quantity: 1 }, // GRÁTIS: actualPrice 0, leak (100-0)*1=100
+      ],
+      custoPorProduto: () => realRow(30),
+      bestPrice: bestOf({ A: 100, B: 100 }),
+    });
+    expect(r.margin_gap).toBe(100);                             // o grátis NÃO some (seria 0 se dropado)
+    expect(r.top_gap_products).toEqual([{ product_id: 'B', gap: 100 }]);
+    expect(r.cobertura_custo).toBe(1);                          // receita 100 estável, ambas com custo
+  });
   it('discount>100 (actualPrice negativo) é ignorado; cobertura fica em [0,1]', () => {
     const r = calcularAuditoriaMargemCliente({
       orders: [

--- a/src/lib/custos/__tests__/auditoria-margem.test.ts
+++ b/src/lib/custos/__tests__/auditoria-margem.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { calcularAuditoriaMargemCliente, type AuditOrderLine } from '../auditoria-margem';
+import type { CostRow } from '../cost-source';
+
+const realRow = (cf: number): CostRow => ({ cost_price: null, cost_final: cf, cost_source: 'PRODUCT_COST', cost_confidence: 0.95 });
+const proxyRow = (cf: number): CostRow => ({ cost_price: null, cost_final: cf, cost_source: 'DEFAULT_PROXY', cost_confidence: 0.25 });
+
+// A: actual 80, best 100, qty 2 → leak (100-80)*2 = 40 ; B: actual 50, best 50, qty 1 → leak 0
+const orders: AuditOrderLine[] = [
+  { product_id: 'A', unit_price: 80, discount: 0, quantity: 2 },
+  { product_id: 'B', unit_price: 50, discount: 0, quantity: 1 },
+];
+const best = (id: string): number | null => (({ A: 100, B: 50 }) as Record<string, number>)[id] ?? null;
+
+describe('calcularAuditoriaMargemCliente — cost-invariância do gap (falsificação)', () => {
+  it('margin_gap, top_gap e gap_pct NÃO dependem do custo (cancela); níveis absolutos SIM', () => {
+    const c10 = calcularAuditoriaMargemCliente({ orders, custoPorProduto: () => realRow(10), bestPrice: best });
+    const c40 = calcularAuditoriaMargemCliente({ orders, custoPorProduto: () => realRow(40), bestPrice: best });
+    // cost-invariante:
+    expect(c10.margin_gap).toBe(40);
+    expect(c40.margin_gap).toBe(40);
+    expect(c10.gap_pct).toBe(16);   // 40 / (100*2 + 50*1) * 100
+    expect(c40.gap_pct).toBe(16);
+    expect(c10.top_gap_products).toEqual([{ product_id: 'A', gap: 40 }]);
+    expect(c40.top_gap_products).toEqual([{ product_id: 'A', gap: 40 }]);
+    // cost-dependente (níveis absolutos mudam):
+    expect(c10.margin_real).toBe(180);      // (80-10)*2 + (50-10)*1
+    expect(c40.margin_real).toBe(90);       // (80-40)*2 + (50-40)*1
+    expect(c10.margin_potential).toBe(220); // (100-10)*2 + (50-10)*1
+  });
+});
+
+describe('calcularAuditoriaMargemCliente — gate de cobertura', () => {
+  it('cobertura <85% (maioria proxy) → margin_real/potential null, mas gap/gap_pct seguem', () => {
+    const mixed: AuditOrderLine[] = [
+      { product_id: 'A', unit_price: 80, discount: 0, quantity: 1 },  // real
+      { product_id: 'P', unit_price: 90, discount: 0, quantity: 1 },  // proxy → sem custo confiável
+    ];
+    const cost = (id: string): CostRow => id === 'A' ? realRow(10) : proxyRow(45);
+    const bestM = (id: string): number | null => (({ A: 100, P: 100 }) as Record<string, number>)[id] ?? null;
+    const r = calcularAuditoriaMargemCliente({ orders: mixed, custoPorProduto: cost, bestPrice: bestM });
+    expect(r.margin_real).toBeNull();
+    expect(r.margin_potential).toBeNull();
+    expect(r.margin_gap).toBe(30);               // leak A (100-80)*1=20 + P (100-90)*1=10
+    expect(r.gap_pct).toBe(15);                  // 30 / (100+100) * 100
+    expect(r.cobertura_custo).toBeCloseTo(80 / 170, 5); // receitaComCusto 80 / receita 170
+  });
+
+  it('cobertura ≥85% → níveis presentes', () => {
+    const r = calcularAuditoriaMargemCliente({ orders, custoPorProduto: () => realRow(10), bestPrice: best });
+    expect(r.cobertura_custo).toBe(1);
+    expect(r.margin_real).toBe(180);
+  });
+});
+
+describe('calcularAuditoriaMargemCliente — degenerados', () => {
+  it('sem linha válida (product_id null) → gap 0, gap_pct null, margins null', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [{ product_id: null, unit_price: 1, discount: 0, quantity: 1 }],
+      custoPorProduto: () => null,
+      bestPrice: () => null,
+    });
+    expect(r.margin_gap).toBe(0);
+    expect(r.gap_pct).toBeNull();
+    expect(r.margin_real).toBeNull();
+  });
+  it('sem best price → bestPrice = actualPrice → leak 0', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [{ product_id: 'X', unit_price: 70, discount: 0, quantity: 1 }],
+      custoPorProduto: () => realRow(20),
+      bestPrice: () => null,
+    });
+    expect(r.margin_gap).toBe(0);
+    expect(r.gap_pct).toBe(0);
+    expect(r.margin_real).toBe(50); // (70-20)*1
+  });
+});

--- a/src/lib/custos/__tests__/auditoria-margem.test.ts
+++ b/src/lib/custos/__tests__/auditoria-margem.test.ts
@@ -75,3 +75,50 @@ describe('calcularAuditoriaMargemCliente — degenerados', () => {
     expect(r.margin_real).toBe(50); // (70-20)*1
   });
 });
+
+describe('calcularAuditoriaMargemCliente — robustez de qualidade-de-dado (Codex challenge)', () => {
+  const bestOf = (m: Record<string, number | null>) => (id: string): number | null => m[id] ?? null;
+  it('bestPrice ≤ 0 (dado ruim) → fallback actualPrice → leak 0 (não poisona gap)', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [{ product_id: 'A', unit_price: 80, discount: 0, quantity: 1 }],
+      custoPorProduto: () => realRow(10),
+      bestPrice: bestOf({ A: 0 }), // best price zerado/inválido — NÃO virar (0-80)*1 = -80
+    });
+    expect(r.margin_gap).toBe(0);
+    expect(r.gap_pct).toBe(0);
+    expect(r.margin_real).toBe(70);
+  });
+  it('bestPrice negativo → fallback actualPrice → leak 0', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [{ product_id: 'A', unit_price: 80, discount: 0, quantity: 1 }],
+      custoPorProduto: () => realRow(10),
+      bestPrice: bestOf({ A: -5 }),
+    });
+    expect(r.margin_gap).toBe(0);
+  });
+  it('devolução (qty negativa) é ignorada — não distorce gap nem cobertura', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [
+        { product_id: 'A', unit_price: 80, discount: 0, quantity: 2 },  // venda: leak (100-80)*2=40
+        { product_id: 'A', unit_price: 80, discount: 0, quantity: -1 }, // devolução: ignorada
+      ],
+      custoPorProduto: () => realRow(10),
+      bestPrice: bestOf({ A: 100 }),
+    });
+    expect(r.margin_gap).toBe(40);
+    expect(r.cobertura_custo).toBe(1);
+  });
+  it('discount>100 (actualPrice negativo) é ignorado; cobertura fica em [0,1]', () => {
+    const r = calcularAuditoriaMargemCliente({
+      orders: [
+        { product_id: 'A', unit_price: 100, discount: 0, quantity: 1 },   // válida, com custo
+        { product_id: 'B', unit_price: 100, discount: 150, quantity: 1 }, // actualPrice -50 → ignorada
+      ],
+      custoPorProduto: (id) => id === 'A' ? realRow(40) : null,
+      bestPrice: bestOf({ A: 120, B: 120 }),
+    });
+    expect(r.cobertura_custo).toBe(1);          // só a linha A válida, e tem custo
+    expect(r.cobertura_custo).toBeLessThanOrEqual(1);
+    expect(r.margin_real).toBe(60);             // (100-40)*1
+  });
+});

--- a/src/lib/custos/__tests__/cost-source.test.ts
+++ b/src/lib/custos/__tests__/cost-source.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { resolverCustoConfiavel, estimarCustoParaRanking, derivarMargensCandidato, type CostRow } from '../cost-source';
+
+const row = (o: Partial<CostRow>): CostRow => ({ cost_price: null, cost_final: null, cost_source: null, cost_confidence: null, ...o });
+
+describe('resolverCustoConfiavel', () => {
+  it('PRODUCT_COST com cost_final>0 → cost_final', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: 12.5 }))).toBe(12.5);
+  });
+  it('CMC com cost_final>0 → cost_final', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: 8 }))).toBe(8);
+  });
+  it('CMC com cost_final=0 mas cost_price>0 → cost_price (os 14 do syncInventory)', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: 0, cost_price: 9.9 }))).toBe(9.9);
+  });
+  it('PRODUCT_COST com cost_final inválido NÃO cai p/ cost_price → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: 0, cost_price: 9.9 }))).toBeNull();
+  });
+  it('FAMILY_MARGIN_PROXY → null (não fabrica margem)', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 50 }))).toBeNull();
+  });
+  it('DEFAULT_PROXY → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'DEFAULT_PROXY', cost_final: 50 }))).toBeNull();
+  });
+  it('UNKNOWN / source null / row null → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'UNKNOWN', cost_final: 50 }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: null, cost_final: 50 }))).toBeNull();
+    expect(resolverCustoConfiavel(null)).toBeNull();
+    expect(resolverCustoConfiavel(undefined)).toBeNull();
+  });
+  it('falsificação: cost_final negativo/NaN/Infinity → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: -5 }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: NaN }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: 'PRODUCT_COST', cost_final: Infinity }))).toBeNull();
+  });
+  it('falsificação CMC: cost_final E cost_price inválidos → null', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: 0, cost_price: 0 }))).toBeNull();
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC', cost_final: NaN, cost_price: -1 }))).toBeNull();
+  });
+  it('normaliza espaço/caixa do backfill', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: '  product_cost  ', cost_final: 7 }))).toBe(7);
+  });
+});
+
+describe('estimarCustoParaRanking', () => {
+  it('custo real presente → custo real', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'PRODUCT_COST', cost_final: 30 }), 100)).toBe(30);
+  });
+  it('sem real, proxy cost_final válido (<price) → proxy cost_final', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 60 }), 100)).toBe(60);
+    expect(estimarCustoParaRanking(row({ cost_source: 'DEFAULT_PROXY', cost_final: 75 }), 100)).toBe(75);
+  });
+  it('proxy cost_final ≥ price (margem estimada ≤0) → null', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'DEFAULT_PROXY', cost_final: 120 }), 100)).toBeNull();
+  });
+  it('UNKNOWN / sem row / proxy sem cost_final → null', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'UNKNOWN', cost_final: 50 }), 100)).toBeNull();
+    expect(estimarCustoParaRanking(null, 100)).toBeNull();
+    expect(estimarCustoParaRanking(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: null }), 100)).toBeNull();
+  });
+});
+
+describe('derivarMargensCandidato', () => {
+  it('custo real → exibida e ranking iguais (margem real)', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'PRODUCT_COST', cost_final: 30 }), 100))
+      .toEqual({ custoConfiavel: 30, custoRanking: 30, margemExibida: 70, margemRanking: 70 });
+  });
+  it('proxy → exibida null, ranking via estimativa (não fabrica margem exibida)', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'FAMILY_MARGIN_PROXY', cost_final: 60 }), 100))
+      .toEqual({ custoConfiavel: null, custoRanking: 60, margemExibida: null, margemRanking: 40 });
+  });
+  it('UNKNOWN/sem sinal → tudo null (EIP será neutralizado pelo motor)', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'UNKNOWN' }), 100))
+      .toEqual({ custoConfiavel: null, custoRanking: null, margemExibida: null, margemRanking: null });
+  });
+});

--- a/src/lib/custos/auditoria-margem.ts
+++ b/src/lib/custos/auditoria-margem.ts
@@ -44,8 +44,14 @@ export function calcularAuditoriaMargemCliente(input: {
     const up = Number(o.unit_price);
     if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
     const actualPrice = up * (1 - Number(o.discount || 0) / 100);
+    // Só audita VENDA válida: qty>0 e preço líquido>0. Devolução (qty<0), discount>100 (preço
+    // negativo) ou linha-garbage não é venda a auditar — excluir de TODAS as métricas, senão a
+    // receita SINALIZADA quebra a cobertura (>1 ou <0) e o gap (Codex challenge).
+    if (!(qty > 0) || !(actualPrice > 0)) continue;
     const bp = input.bestPrice(o.product_id);
-    const bestPrice = typeof bp === 'number' && Number.isFinite(bp) ? bp : actualPrice;
+    // bestPrice precisa ser positivo; 0/negativo/NaN é dado ruim → fallback actualPrice (leak 0),
+    // nunca virar numerador/denominador do gap (Codex challenge: best price inválido poisona gap_pct).
+    const bestPrice = typeof bp === 'number' && Number.isFinite(bp) && bp > 0 ? bp : actualPrice;
 
     // cost-free (sempre): vazamento de preço
     const leak = (bestPrice - actualPrice) * qty;

--- a/src/lib/custos/auditoria-margem.ts
+++ b/src/lib/custos/auditoria-margem.ts
@@ -1,0 +1,78 @@
+// Auditoria de margem (Algorithm A — margin_audit_log). Núcleo puro espelhado VERBATIM na edge
+// algorithm-a-audit/index.ts. Custo ausente ≠ R$0 (resolverCustoConfiavel). margin_gap e
+// top_gap_products são COST-INVARIANTES ((bestPrice−cost)−(actualPrice−cost)=bestPrice−actualPrice);
+// gap_pct = vazamento-de-receita % (cost-free). Níveis absolutos margin_real/potential só sob
+// cobertura de custo ≥0.85 (espelha o gate do cockpit); senão null (ausente ≠ fabricar).
+
+import { resolverCustoConfiavel, type CostRow } from './cost-source';
+
+export type AuditOrderLine = {
+  product_id: string | null;
+  unit_price: number | null;
+  discount: number | null;
+  quantity: number | null;
+};
+
+export type AuditoriaCliente = {
+  margin_real: number | null;
+  margin_potential: number | null;
+  margin_gap: number;
+  gap_pct: number | null;
+  top_gap_products: { product_id: string; gap: number }[];
+  cobertura_custo: number;
+};
+
+const COBERTURA_CUSTO_MIN = 0.85;
+const round2 = (x: number) => Math.round(x * 100) / 100;
+
+export function calcularAuditoriaMargemCliente(input: {
+  orders: AuditOrderLine[];
+  custoPorProduto: (productId: string) => CostRow | null | undefined;
+  bestPrice: (productId: string) => number | null | undefined;
+}): AuditoriaCliente {
+  let marginGap = 0;
+  let bestRevenue = 0;
+  let receita = 0;
+  let marginRealKnown = 0;
+  let marginPotentialKnown = 0;
+  let receitaComCusto = 0;
+  const topGap: { product_id: string; gap: number }[] = [];
+
+  for (const o of input.orders) {
+    if (!o.product_id) continue;
+    const qty = Number(o.quantity);
+    const up = Number(o.unit_price);
+    if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
+    const actualPrice = up * (1 - Number(o.discount || 0) / 100);
+    const bp = input.bestPrice(o.product_id);
+    const bestPrice = typeof bp === 'number' && Number.isFinite(bp) ? bp : actualPrice;
+
+    // cost-free (sempre): vazamento de preço
+    const leak = (bestPrice - actualPrice) * qty;
+    marginGap += leak;
+    bestRevenue += bestPrice * qty;
+    receita += actualPrice * qty;
+    if (leak > 0) topGap.push({ product_id: o.product_id, gap: leak });
+
+    // níveis absolutos: só com custo REAL (proxy/UNKNOWN/null não conta)
+    const custo = resolverCustoConfiavel(input.custoPorProduto(o.product_id));
+    if (custo != null) {
+      marginRealKnown += (actualPrice - custo) * qty;
+      marginPotentialKnown += (bestPrice - custo) * qty;
+      receitaComCusto += actualPrice * qty;
+    }
+  }
+
+  topGap.sort((a, b) => b.gap - a.gap);
+  const cobertura_custo = receita > 0 ? receitaComCusto / receita : 0;
+  const temCobertura = cobertura_custo >= COBERTURA_CUSTO_MIN;
+
+  return {
+    margin_real: temCobertura ? round2(marginRealKnown) : null,
+    margin_potential: temCobertura ? round2(marginPotentialKnown) : null,
+    margin_gap: round2(marginGap),
+    gap_pct: bestRevenue > 0 ? round2((marginGap / bestRevenue) * 100) : null,
+    top_gap_products: topGap.slice(0, 5),
+    cobertura_custo,
+  };
+}

--- a/src/lib/custos/auditoria-margem.ts
+++ b/src/lib/custos/auditoria-margem.ts
@@ -44,10 +44,11 @@ export function calcularAuditoriaMargemCliente(input: {
     const up = Number(o.unit_price);
     if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
     const actualPrice = up * (1 - Number(o.discount || 0) / 100);
-    // Só audita VENDA válida: qty>0 e preço líquido>0. Devolução (qty<0), discount>100 (preço
-    // negativo) ou linha-garbage não é venda a auditar — excluir de TODAS as métricas, senão a
-    // receita SINALIZADA quebra a cobertura (>1 ou <0) e o gap (Codex challenge).
-    if (!(qty > 0) || !(actualPrice > 0)) continue;
+    // Só audita VENDA válida: qty>0 e preço líquido >= 0. Devolução (qty<0) e discount>100 (preço
+    // NEGATIVO = garbage) saem; item GRÁTIS (actualPrice 0, qty>0) FICA — é leakage real (deu o best
+    // price inteiro). Excluir só o inválido evita a receita SINALIZADA quebrar a cobertura (>1 ou <0)
+    // e o gap (Codex challenge #3 instabilidade de sinal, #7 não sub-reportar item grátis).
+    if (!(qty > 0) || actualPrice < 0) continue;
     const bp = input.bestPrice(o.product_id);
     // bestPrice precisa ser positivo; 0/negativo/NaN é dado ruim → fallback actualPrice (leak 0),
     // nunca virar numerador/denominador do gap (Codex challenge: best price inválido poisona gap_pct).

--- a/src/lib/custos/cost-source.ts
+++ b/src/lib/custos/cost-source.ts
@@ -1,0 +1,66 @@
+// Contrato de custo dos motores de recomendação/auditoria (Codex P2 cost-final-ignorado; follow-up da
+// spec do cockpit). Régua IDÊNTICA a resolverCustoCockpit (src/lib/financeiro/valor-cockpit-helpers.ts):
+// ausente ≠ R$0; proxy não é custo de margem confiável. Módulo puro — espelhado VERBATIM nas edges Deno
+// recommend/index.ts e algorithm-a-audit/index.ts (Deno não importa de src/).
+// Resíduo: convergir resolverCustoCockpit → este módulo pós-merge do #959 (fonte única).
+
+export type CostRow = {
+  cost_price: number | null;
+  cost_final: number | null;
+  cost_source: string | null;
+  cost_confidence: number | null;
+};
+
+const COST_SOURCES_REAIS = new Set(['PRODUCT_COST', 'CMC']);
+const COST_SOURCES_PROXY = new Set(['FAMILY_MARGIN_PROXY', 'DEFAULT_PROXY']);
+
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === 'number' && Number.isFinite(x) && x > 0;
+}
+
+function normalizarSource(source: string | null | undefined): string | null {
+  const s = source?.trim().toUpperCase();
+  return s ? s : null;
+}
+
+// Custo de MARGEM (exibido/logado). Ausente → null (NÃO fabrica margem).
+//   1. source∈REAIS e finitePositive(cost_final) → cost_final (vivo, preferido)
+//   2. source=CMC e finitePositive(cost_price)   → cost_price (fallback dos 14 do syncInventory)
+//   3. resto (PROXY/UNKNOWN/null/fonte nova)      → null
+export function resolverCustoConfiavel(row: CostRow | null | undefined): number | null {
+  const source = normalizarSource(row?.cost_source);
+  if (row == null || source == null || !COST_SOURCES_REAIS.has(source)) return null;
+  if (finitePositive(row.cost_final)) return row.cost_final;
+  if (source === 'CMC' && finitePositive(row.cost_price)) return row.cost_price;
+  return null;
+}
+
+// Custo de RANKING (só EIP/score; NUNCA exibido/logado como margem firme). Aceita estimativa proxy
+// sanity-bounded (< price → margem estimada positiva). real ?? proxy cost_final válido ?? null.
+export function estimarCustoParaRanking(row: CostRow | null | undefined, price: number): number | null {
+  const real = resolverCustoConfiavel(row);
+  if (real != null) return real;
+  const source = normalizarSource(row?.cost_source);
+  const cf = row?.cost_final ?? null;
+  if (source != null && COST_SOURCES_PROXY.has(source) && finitePositive(cf) && cf < price) return cf;
+  return null;
+}
+
+export type MargensCandidato = {
+  custoConfiavel: number | null;
+  custoRanking: number | null;
+  margemExibida: number | null;
+  margemRanking: number | null;
+};
+
+// Split por candidato (recommend). Helper HONESTO (null); o motor aplica o neutro (eip = margemRanking ?? 0).
+export function derivarMargensCandidato(row: CostRow | null | undefined, price: number): MargensCandidato {
+  const custoConfiavel = resolverCustoConfiavel(row);
+  const custoRanking = estimarCustoParaRanking(row, price);
+  return {
+    custoConfiavel,
+    custoRanking,
+    margemExibida: custoConfiavel != null ? price - custoConfiavel : null,
+    margemRanking: custoRanking != null ? price - custoRanking : null,
+  };
+}

--- a/src/pages/GovernanceAudit.tsx
+++ b/src/pages/GovernanceAudit.tsx
@@ -427,13 +427,15 @@ export default function GovernanceAudit() {
                         {marginLog?.map(row => (
                           <tr key={row.id} className="border-b border-border/50 hover:bg-muted/50">
                             <td className="py-2">{resolveName(row.customer_user_id)}</td>
-                            <td className="text-center py-2">R$ {Number(row.margin_real).toLocaleString('pt-BR')}</td>
-                            <td className="text-center py-2">R$ {Number(row.margin_potential).toLocaleString('pt-BR')}</td>
+                            <td className="text-center py-2">{row.margin_real == null ? '—' : `R$ ${Number(row.margin_real).toLocaleString('pt-BR')}`}</td>
+                            <td className="text-center py-2">{row.margin_potential == null ? '—' : `R$ ${Number(row.margin_potential).toLocaleString('pt-BR')}`}</td>
                             <td className="text-center py-2 text-destructive font-medium">R$ {Number(row.margin_gap).toLocaleString('pt-BR')}</td>
                             <td className="text-center py-2">
-                              <Badge variant={Number(row.gap_pct) > 20 ? 'destructive' : 'secondary'} className="text-2xs">
-                                {Number(row.gap_pct).toFixed(1)}%
-                              </Badge>
+                              {row.gap_pct == null ? <span className="text-muted-foreground">—</span> : (
+                                <Badge variant={Number(row.gap_pct) > 20 ? 'destructive' : 'secondary'} className="text-2xs">
+                                  {Number(row.gap_pct).toFixed(1)}%
+                                </Badge>
+                              )}
                             </td>
                             <td className="text-right py-2 text-muted-foreground">{formatDateShort(row.calculated_at)}</td>
                           </tr>

--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -39,8 +39,9 @@ function calcularAuditoriaMargemCliente(input: {
     const up = Number(o.unit_price);
     if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
     const actualPrice = up * (1 - Number(o.discount || 0) / 100);
-    // Só venda válida (qty>0, preço líquido>0): devolução/discount>100/garbage não distorce gap/cobertura.
-    if (!(qty > 0) || !(actualPrice > 0)) continue;
+    // Só venda válida (qty>0, preço líquido>=0): devolução(qty<0)/discount>100(preço<0) saem; item
+    // grátis (0) FICA (leakage real). Excluir só o inválido evita quebrar cobertura/gap (Codex #3,#7).
+    if (!(qty > 0) || actualPrice < 0) continue;
     const bp = input.bestPrice(o.product_id);
     // bestPrice>0 obrigatório: 0/negativo/NaN é dado ruim → fallback actualPrice (não poisona gap).
     const bestPrice = typeof bp === "number" && Number.isFinite(bp) && bp > 0 ? bp : actualPrice;

--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -39,8 +39,11 @@ function calcularAuditoriaMargemCliente(input: {
     const up = Number(o.unit_price);
     if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
     const actualPrice = up * (1 - Number(o.discount || 0) / 100);
+    // Só venda válida (qty>0, preço líquido>0): devolução/discount>100/garbage não distorce gap/cobertura.
+    if (!(qty > 0) || !(actualPrice > 0)) continue;
     const bp = input.bestPrice(o.product_id);
-    const bestPrice = typeof bp === "number" && Number.isFinite(bp) ? bp : actualPrice;
+    // bestPrice>0 obrigatório: 0/negativo/NaN é dado ruim → fallback actualPrice (não poisona gap).
+    const bestPrice = typeof bp === "number" && Number.isFinite(bp) && bp > 0 ? bp : actualPrice;
     const leak = (bestPrice - actualPrice) * qty;
     marginGap += leak;
     bestRevenue += bestPrice * qty;

--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -1,6 +1,72 @@
 import { createClient, type SupabaseClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
+// ======== COST CONTRACT (espelho VERBATIM de src/lib/custos/cost-source.ts — manter idêntico) ========
+type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
+const COST_SOURCES_REAIS = new Set(["PRODUCT_COST", "CMC"]);
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === "number" && Number.isFinite(x) && x > 0;
+}
+function normalizarSource(source: string | null | undefined): string | null {
+  const s = source?.trim().toUpperCase();
+  return s ? s : null;
+}
+function resolverCustoConfiavel(row: CostRow | null | undefined): number | null {
+  const source = normalizarSource(row?.cost_source);
+  if (row == null || source == null || !COST_SOURCES_REAIS.has(source)) return null;
+  if (finitePositive(row.cost_final)) return row.cost_final;
+  if (source === "CMC" && finitePositive(row.cost_price)) return row.cost_price;
+  return null;
+}
+// ======== AUDIT CORE (espelho VERBATIM de src/lib/custos/auditoria-margem.ts — manter idêntico) ========
+type AuditOrderLine = { product_id: string | null; unit_price: number | null; discount: number | null; quantity: number | null };
+type AuditoriaCliente = {
+  margin_real: number | null; margin_potential: number | null; margin_gap: number;
+  gap_pct: number | null; top_gap_products: { product_id: string; gap: number }[]; cobertura_custo: number;
+};
+const COBERTURA_CUSTO_MIN = 0.85;
+const round2 = (x: number) => Math.round(x * 100) / 100;
+function calcularAuditoriaMargemCliente(input: {
+  orders: AuditOrderLine[];
+  custoPorProduto: (productId: string) => CostRow | null | undefined;
+  bestPrice: (productId: string) => number | null | undefined;
+}): AuditoriaCliente {
+  let marginGap = 0, bestRevenue = 0, receita = 0, marginRealKnown = 0, marginPotentialKnown = 0, receitaComCusto = 0;
+  const topGap: { product_id: string; gap: number }[] = [];
+  for (const o of input.orders) {
+    if (!o.product_id) continue;
+    const qty = Number(o.quantity);
+    const up = Number(o.unit_price);
+    if (!Number.isFinite(qty) || !Number.isFinite(up)) continue;
+    const actualPrice = up * (1 - Number(o.discount || 0) / 100);
+    const bp = input.bestPrice(o.product_id);
+    const bestPrice = typeof bp === "number" && Number.isFinite(bp) ? bp : actualPrice;
+    const leak = (bestPrice - actualPrice) * qty;
+    marginGap += leak;
+    bestRevenue += bestPrice * qty;
+    receita += actualPrice * qty;
+    if (leak > 0) topGap.push({ product_id: o.product_id, gap: leak });
+    const custo = resolverCustoConfiavel(input.custoPorProduto(o.product_id));
+    if (custo != null) {
+      marginRealKnown += (actualPrice - custo) * qty;
+      marginPotentialKnown += (bestPrice - custo) * qty;
+      receitaComCusto += actualPrice * qty;
+    }
+  }
+  topGap.sort((a, b) => b.gap - a.gap);
+  const cobertura_custo = receita > 0 ? receitaComCusto / receita : 0;
+  const temCobertura = cobertura_custo >= COBERTURA_CUSTO_MIN;
+  return {
+    margin_real: temCobertura ? round2(marginRealKnown) : null,
+    margin_potential: temCobertura ? round2(marginPotentialKnown) : null,
+    margin_gap: round2(marginGap),
+    gap_pct: bestRevenue > 0 ? round2((marginGap / bestRevenue) * 100) : null,
+    top_gap_products: topGap.slice(0, 5),
+    cobertura_custo,
+  };
+}
+// ======== /AUDIT CORE ========
+
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
@@ -16,7 +82,10 @@ interface ClientScoreRow {
 
 interface ProductCostRow {
   product_id: string;
+  cost_price: number | null;
   cost_final: number | null;
+  cost_source: string | null;
+  cost_confidence: number | null;
   family_category: string | null;
 }
 
@@ -38,10 +107,10 @@ interface AuditRecord {
   farmer_id: string | null;
   period_start: string;
   period_end: string;
-  margin_real: number;
-  margin_potential: number;
+  margin_real: number | null;
+  margin_potential: number | null;
   margin_gap: number;
-  gap_pct: number;
+  gap_pct: number | null;
   top_gap_products: { product_id: string; gap: number }[];
 }
 
@@ -100,7 +169,7 @@ Deno.serve(async (req) => {
     console.log(`[algorithm-a-audit] Found ${clients.length} clients`);
 
     // Get product costs (paginated)
-    const productCosts = await fetchAllPaginated<ProductCostRow>(supabase, 'product_costs', 'product_id, cost_final, family_category');
+    const productCosts = await fetchAllPaginated<ProductCostRow>(supabase, 'product_costs', 'product_id, cost_price, cost_final, cost_source, cost_confidence, family_category');
     console.log(`[algorithm-a-audit] Found ${productCosts.length} product costs`);
 
     // Get order items for each client (last 365 days) - paginated
@@ -126,11 +195,9 @@ Deno.serve(async (req) => {
       }
     });
 
-    // Build cost map
-    const costMap: Record<string, number> = {};
-    productCosts.forEach(pc => {
-      costMap[pc.product_id] = Number(pc.cost_final || 0);
-    });
+    // Build cost map (linha inteira — a régua resolverCustoConfiavel decide o custo confiável)
+    const costMap: Record<string, ProductCostRow> = {};
+    productCosts.forEach(pc => { costMap[pc.product_id] = pc; });
 
     // Group orders by customer
     const customerOrders: Record<string, typeof recentOrders> = {};
@@ -149,44 +216,22 @@ Deno.serve(async (req) => {
       const orders = customerOrders[client.customer_user_id] || [];
       if (orders.length === 0) continue;
 
-      let marginReal = 0;
-      let marginPotential = 0;
-      const topGapProducts: { product_id: string; gap: number }[] = [];
-
-      for (const order of orders) {
-        if (!order.product_id) continue;
-        const cost = costMap[order.product_id] || 0;
-        const actualPrice = Number(order.unit_price) * (1 - Number(order.discount || 0) / 100);
-        const bestPrice = bestPriceMap[order.product_id] || actualPrice;
-        const qty = Number(order.quantity);
-
-        const realMargin = (actualPrice - cost) * qty;
-        const potentialMargin = (bestPrice - cost) * qty;
-
-        marginReal += realMargin;
-        marginPotential += potentialMargin;
-
-        const gap = potentialMargin - realMargin;
-        if (gap > 0) {
-          topGapProducts.push({ product_id: order.product_id, gap });
-        }
-      }
-
-      const marginGap = marginPotential - marginReal;
-      const gapPct = marginPotential > 0 ? (marginGap / marginPotential) * 100 : 0;
-
-      topGapProducts.sort((a, b) => b.gap - a.gap);
+      const aud = calcularAuditoriaMargemCliente({
+        orders,
+        custoPorProduto: (id) => costMap[id] ?? null,
+        bestPrice: (id) => bestPriceMap[id] ?? null,
+      });
 
       auditRecords.push({
         customer_user_id: client.customer_user_id,
         farmer_id: client.farmer_id,
         period_start: periodStart,
         period_end: periodEnd,
-        margin_real: Math.round(marginReal * 100) / 100,
-        margin_potential: Math.round(marginPotential * 100) / 100,
-        margin_gap: Math.round(marginGap * 100) / 100,
-        gap_pct: Math.round(gapPct * 100) / 100,
-        top_gap_products: topGapProducts.slice(0, 5),
+        margin_real: aud.margin_real,
+        margin_potential: aud.margin_potential,
+        margin_gap: aud.margin_gap,
+        gap_pct: aud.gap_pct,
+        top_gap_products: aud.top_gap_products,
       });
     }
 

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -345,11 +345,12 @@ async function logEvent(
     customer_user_id: customerId,
     product_id: productId,
     event_type: eventType,
-    // Evento (accept/reject) não carrega custo/margem (a impressão carregou) → null EXPLÍCITO,
-    // senão o DEFAULT 0 do schema fabrica R$0 (Codex challenge). ...extras nunca traz unit_cost/margin.
+    ...extras,
+    // Evento (accept/reject) não carrega custo/margem (a impressão carregou) → null EXPLÍCITO e
+    // DEPOIS de ...extras (autoritativo, não clobberável), senão o DEFAULT 0 do schema fabrica R$0
+    // (Codex #4 fabricação + #6 ordem do spread).
     unit_cost: null,
     margin: null,
-    ...extras,
   });
   return { logged: true };
 }

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -26,6 +26,45 @@ function minMaxNorm(values: number[]): number[] {
   return values.map((v) => (v - min) / (max - min));
 }
 
+// ======== COST CONTRACT (espelho VERBATIM de src/lib/custos/cost-source.ts — manter idêntico) ========
+type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
+const COST_SOURCES_REAIS = new Set(["PRODUCT_COST", "CMC"]);
+const COST_SOURCES_PROXY = new Set(["FAMILY_MARGIN_PROXY", "DEFAULT_PROXY"]);
+function finitePositive(x: number | null | undefined): x is number {
+  return typeof x === "number" && Number.isFinite(x) && x > 0;
+}
+function normalizarSource(source: string | null | undefined): string | null {
+  const s = source?.trim().toUpperCase();
+  return s ? s : null;
+}
+function resolverCustoConfiavel(row: CostRow | null | undefined): number | null {
+  const source = normalizarSource(row?.cost_source);
+  if (row == null || source == null || !COST_SOURCES_REAIS.has(source)) return null;
+  if (finitePositive(row.cost_final)) return row.cost_final;
+  if (source === "CMC" && finitePositive(row.cost_price)) return row.cost_price;
+  return null;
+}
+function estimarCustoParaRanking(row: CostRow | null | undefined, price: number): number | null {
+  const real = resolverCustoConfiavel(row);
+  if (real != null) return real;
+  const source = normalizarSource(row?.cost_source);
+  const cf = row?.cost_final ?? null;
+  if (source != null && COST_SOURCES_PROXY.has(source) && finitePositive(cf) && cf < price) return cf;
+  return null;
+}
+type MargensCandidato = { custoConfiavel: number | null; custoRanking: number | null; margemExibida: number | null; margemRanking: number | null };
+function derivarMargensCandidato(row: CostRow | null | undefined, price: number): MargensCandidato {
+  const custoConfiavel = resolverCustoConfiavel(row);
+  const custoRanking = estimarCustoParaRanking(row, price);
+  return {
+    custoConfiavel,
+    custoRanking,
+    margemExibida: custoConfiavel != null ? price - custoConfiavel : null,
+    margemRanking: custoRanking != null ? price - custoRanking : null,
+  };
+}
+// ======== /COST CONTRACT ========
+
 // ======== RECOMMENDATION ENGINE ========
 
 interface Candidate {
@@ -34,12 +73,13 @@ interface Candidate {
   descricao: string;
   codigo: string;
   price: number;
-  cost_final: number;
+  cost_final: number | null;
   cost_source: string;
   cost_confidence: number;
+  cost_ranking: number | null;
   familia: string | null;
   estoque: number;
-  margin: number;
+  margin: number | null;
   assoc_score: number;
   sim_score: number;
   ctx_score: number;
@@ -71,7 +111,7 @@ async function recommend(
     db.from("recommendation_config").select("key, value"),
     db.from("order_items").select("product_id, quantity, unit_price").eq("customer_user_id", customerId),
     db.from("omie_products").select("id, omie_codigo_produto, descricao, codigo, valor_unitario, estoque, familia, subfamilia").eq("ativo", true),
-    db.from("product_costs").select("product_id, cost_final, cost_source, cost_confidence"),
+    db.from("product_costs").select("product_id, cost_price, cost_final, cost_source, cost_confidence"),
     db.from("farmer_association_rules").select("*").gte("lift", 1.2).gte("support", 0.01),
     db.from("farmer_client_scores").select("health_class, category_count").eq("customer_user_id", customerId).maybeSingle(),
   ]);
@@ -100,7 +140,7 @@ async function recommend(
   }
 
   // Cost map
-  const costMap: Record<string, { cost_final: number; cost_source: string; cost_confidence: number }> = {};
+  const costMap: Record<string, CostRow> = {};
   for (const c of costs || []) costMap[c.product_id] = c;
 
   // Association scores
@@ -151,11 +191,11 @@ async function recommend(
     if ((p.estoque || 0) <= 0) continue;
 
     const cost = costMap[p.id];
-    const costFinal = cost?.cost_final || 0;
     const price = p.valor_unitario || 0;
     if (price <= 0) continue;
 
-    const margin = price - costFinal;
+    const { custoConfiavel, custoRanking, margemExibida, margemRanking } = derivarMargensCandidato(cost ?? null, price);
+    const margemRank = margemRanking ?? 0; // EIP neutro (0, não máximo) quando custo de ranking ausente
     const assoc = assocScores[p.id] || 0;
     const simCustomers = clusterProductCounts[p.id]?.size || 0;
     const sim = simCustomers / clusterSize;
@@ -171,9 +211,9 @@ async function recommend(
     const ctxNorm = Math.min(ctx, 1);
 
     const probability = sigmoid(-1.5 + 2.0 * assocNorm + 1.5 * simNorm + 1.0 * ctxNorm);
-    const eip = probability * margin;
+    const eip = probability * margemRank;
     const recurrenceScore = Math.min(purchaseCount / 5, 1);
-    const eiltv = probability * (margin + kappa * recurrenceScore * margin);
+    const eiltv = probability * (margemRank + kappa * recurrenceScore * margemRank);
 
     let penalties = 0;
     const familia = p.familia || "other";
@@ -192,9 +232,9 @@ async function recommend(
     } else if (sim > 0.2) {
       explanationKey = "cluster";
       explanationText = `${Math.round(sim * 100)}% dos clientes similares compram ${p.descricao}`;
-    } else if (margin > 50) {
+    } else if (margemExibida != null && margemExibida > 50) {
       explanationKey = "margin";
-      explanationText = `${p.descricao} tem alto potencial de margem (R$ ${margin.toFixed(2)})`;
+      explanationText = `${p.descricao} tem alto potencial de margem (R$ ${margemExibida.toFixed(2)})`;
     } else if (ctx > 0.2) {
       explanationKey = "context";
       explanationText = `Baseado no histórico de compras, ${p.descricao} complementa bem o mix`;
@@ -205,9 +245,9 @@ async function recommend(
     candidates.push({
       product_id: p.id, omie_codigo_produto: p.omie_codigo_produto,
       descricao: p.descricao, codigo: p.codigo, price,
-      cost_final: costFinal, cost_source: cost?.cost_source || "UNKNOWN",
-      cost_confidence: cost?.cost_confidence || 0, familia: p.familia,
-      estoque: p.estoque || 0, margin, assoc_score: assoc, sim_score: sim,
+      cost_final: custoConfiavel, cost_source: cost?.cost_source || "UNKNOWN",
+      cost_confidence: cost?.cost_confidence || 0, cost_ranking: custoRanking, familia: p.familia,
+      estoque: p.estoque || 0, margin: margemExibida, assoc_score: assoc, sim_score: sim,
       ctx_score: ctx, probability, eip, eiltv, score_final: 0,
       explanation_text: explanationText, explanation_key: explanationKey,
       recommendation_type: recType, penalties,
@@ -273,7 +313,8 @@ async function recommend(
       estoque: c.estoque,
       _admin: {
         cost_final: c.cost_final, cost_source: c.cost_source,
-        cost_confidence: c.cost_confidence, assoc_score: c.assoc_score,
+        cost_confidence: c.cost_confidence, estimated_cost_for_ranking: c.cost_ranking,
+        assoc_score: c.assoc_score,
         sim_score: c.sim_score, ctx_score: c.ctx_score,
         penalties: c.penalties, familia: c.familia, eiltv: c.eiltv,
       },

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -293,7 +293,9 @@ async function recommend(
     cost_source: c.cost_source,
     margin: c.margin,
     probability: c.probability,
-    eip: c.eip,
+    // EIP é money (R$ lucro esperado): null quando o custo não é confiável (margin null) — só
+    // score_eip (acima) segue numérico, é o SCORE de ranking, não uma afirmação de lucro firme.
+    eip: c.margin != null ? c.eip : null,
     event_type: "impression",
     mode: mode === 0 ? "profit" : "ltv",
     weights: { wA, wP, wS, wC },
@@ -307,7 +309,7 @@ async function recommend(
     recommendations: topCandidates.map((c) => ({
       product_id: c.product_id, codigo: c.codigo, descricao: c.descricao,
       price: c.price, margin: c.margin, probability: c.probability,
-      eip: c.eip, score_final: c.score_final,
+      eip: c.margin != null ? c.eip : null, score_final: c.score_final,
       recommendation_type: c.recommendation_type,
       explanation_text: c.explanation_text, explanation_key: c.explanation_key,
       estoque: c.estoque,
@@ -316,7 +318,7 @@ async function recommend(
         cost_confidence: c.cost_confidence, estimated_cost_for_ranking: c.cost_ranking,
         assoc_score: c.assoc_score,
         sim_score: c.sim_score, ctx_score: c.ctx_score,
-        penalties: c.penalties, familia: c.familia, eiltv: c.eiltv,
+        penalties: c.penalties, familia: c.familia, eiltv: c.margin != null ? c.eiltv : null,
       },
     })),
     meta: {
@@ -343,6 +345,10 @@ async function logEvent(
     customer_user_id: customerId,
     product_id: productId,
     event_type: eventType,
+    // Evento (accept/reject) não carrega custo/margem (a impressão carregou) → null EXPLÍCITO,
+    // senão o DEFAULT 0 do schema fabrica R$0 (Codex challenge). ...extras nunca traz unit_cost/margin.
+    unit_cost: null,
+    margin: null,
     ...extras,
   });
   return { logged: true };


### PR DESCRIPTION
## Problema

Dois edges tratavam custo ausente como **R$0**, virando "margem cheia" (anti-padrão money-path: ausente ≠ zero):

- `recommend/index.ts:154` — `cost?.cost_final || 0` → produto sem custo aparecia maximamente lucrativo e **rankeava no topo** (EIP = preço cheio), além de exibir/logar margem fabricada.
- `algorithm-a-audit/index.ts:132` — `Number(pc.cost_final || 0)` (idem; e ignorava `cost_source`, então proxy entrava como custo real).

Em produção (psql-ro, oben TTM): **36% dos SKU são proxy inventado** (`FAMILY_MARGIN_PROXY`/`DEFAULT_PROXY`).

## Solução

Régua única de custo confiável (idêntica a `resolverCustoCockpit` do #959) num helper puro novo, espelhado **verbatim** nos 2 edges (Deno não importa de `src/`):

- **`src/lib/custos/cost-source.ts`** — `resolverCustoConfiavel` (REAIS={PRODUCT_COST,CMC}→`cost_final`; fallback `cost_price` só p/ CMC; proxy/UNKNOWN/null→**null**) · `estimarCustoParaRanking` · `derivarMargensCandidato`.
- **`src/lib/custos/auditoria-margem.ts`** — `calcularAuditoriaMargemCliente`: `margin_gap`/`top_gap` são **cost-invariantes** (o custo cancela); `gap_pct` vira **vazamento-de-receita % cost-free**; `margin_real/potential` só sob cobertura de custo ≥85%, senão null.
- **`recommend`** separa **custo de margem** (exibido/logado → null quando não-confiável → "—") de **`estimated_cost_for_ranking`** (alimenta só EIP/EILTV; neutro 0 quando ausente → rankeia por assoc/sim/ctx, nunca por margem-fantasma).
- **Frontend** null-safe (`fmt` → "—") em `RecommendationCard`, `useRecommendationEngine`, `IntelligenceStrategicTab`, `GovernanceAudit`.

Sem migration (colunas `recommendation_log.*` e `margin_audit_log.*` já nullable).

## 2ª opinião — Codex challenge (adversarial money-path, 2 passes, gpt-5.5 high)

**8 achados, todos resolvidos** (cada fix de helper entrou por teste vermelho→verde):
1. `eip`/`eiltv` exibidos/logados eram R$ derivado de custo proxy → gateados p/ null (`score_eip` + ranking interno intactos).
2. `bestPrice ≤ 0` poisonava o gap → guard `bp>0` (fallback `actualPrice`).
3. Gate de cobertura instável com receita sinalizada (devolução/`discount>100`) → só linha de venda válida.
4. `log_accept/reject` fabricavam R$0 via DEFAULT do schema → null explícito.
5. KPI Strategic derivava gap de `potential−real` (sumia em baixa cobertura) → `Σ margin_gap`.
6. Ordem do `...extras` no `logEvent` (clobber teórico) → spread antes dos nulls.
7. Item **grátis** (`actualPrice 0`) era dropado — é o **maior** leakage → guard exclui só preço negativo.
8. Cards Margem Real/Potencial/Global sem disclosure do parcial → subtitle "N/M clientes c/ custo".

## Verificação

- **vitest** 27 testes nos helpers (todos os branches + falsificação neg/NaN/Inf/0; cost-invariância; gate de cobertura; item-grátis; bestPrice inválido).
- **Suite completa: 511 arquivos / 3885 testes, 0 falhas.**
- `typecheck` 0 · `lint` 0 erros · `deno check` 0 erros novos vs baseline (ambos edges) · paridade edge×src confirmada (lógica idêntica).

## Deploy MANUAL pós-merge (merge ≠ produção) ⚠️

1. **Edge `recommend`** — chat do Lovable, colar verbatim de `supabase/functions/recommend/index.ts`.
2. **Edge `algorithm-a-audit`** — idem.
3. **Frontend** — Publish no editor do Lovable.
4. **Sem migration.** Verificar: recomendação de SKU sem custo mostra "Margem —" (não R$ cheio); painel de governança mostra "Vazamento %".

Spec: `docs/superpowers/specs/2026-06-19-recommend-audit-cost-source-contract-design.md` · Plano: `docs/superpowers/plans/2026-06-19-recommend-audit-cost-source-contract.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
