### PR TITLE
docs(agent/deploy): 2 armadilhas de edge do Lovable (config.toml dup + edge "fantasma")

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -13,6 +13,8 @@
 - **Deploy SÓ depois do merge** — o chat lê a `main`; deployar antes pega o código velho.
 - **Proibir "melhorias"** — instrua o chat a deployar **verbatim** o arquivo do repo (o Lovable tende a reescrever a função).
 - **Verificar por comportamento/bytes, não pela palavra do Lovable** — `503 LOAD_FUNCTION_ERROR` + zero `running` no log = a edge não BOOTA → fix é **redeploy**, não código (ver `docs/agent/sync.md`).
+- **`config.toml` pode vir com `[functions.<x>]` DUPLICADO** (bug do bot do Lovable) → TOML inválido (`redefine an already defined table`) que **quebra o `supabase` CLI** no parse. Fix: apagar a 2ª entrada (se idêntica = no-op de comportamento) — pode reaparecer num "Changes" do bot. (#974)
+- **Edge "fantasma" (deployada, mas sem invocador):** *deployada/gerenciada pelo Lovable* = commits `gpt-engineer-app[bot]` tocando `<x>/index.ts` (+ commit "Deployou edge function `<x>`"); *invocada* = `cron.job` + `net._http_response` (+ `pg_proc`/código/CI). Antes de apagar um `supabase/functions/<x>/` órfão do repo: prove os DOIS lados E **delete no Lovable PRIMEIRO** (senão o bot regenera o diretório no próximo deploy de scoring). (#974: `n` era clone byte-idêntico de `calculate-scores` — deployado, zero invocador.)
 
 ## Verificação de deploy
 


### PR DESCRIPTION
Persiste como regra viva (docs/agent, não engorda o CLAUDE.md) duas lições da caça à edge `n` (#974):

1. **`config.toml` duplicado pelo bot** → TOML inválido que quebra o `supabase` CLI. Fix de 1 linha; pode reaparecer num "Changes".
2. **Edge "fantasma"** (deployada, sem invocador): como distinguir *gerenciada pelo Lovable* (commits do bot tocando `index.ts`) de *invocada* (`cron.job` + `net._http_response`), e **deletar no Lovable antes** de apagar do repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)