### PR TITLE
fix(scoring): dropdowns de plano/copiloto incluem clientes cobertos (cobertura)

### DIFF
--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import { useScribe, CommitStrategy } from '@elevenlabs/react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { useMyActiveCoverage } from '@/hooks/useCoverage';
 import { useCopilotEngine, type CopilotContext } from '@/hooks/useCopilotEngine';
 import { useTacticalPlan, type TacticalPlan } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
@@ -20,6 +21,11 @@ export function useFarmerCopilot() {
   // lente, o próprio usuário fora). Iniciar a sessão (startSession persiste + invoca
   // edge) é write — bloqueado na lente pelo write-guard + botão "Iniciar" disabled.
   const { effectiveUserId, isImpersonating } = useImpersonation();
+  // Cobertura: dropdown inclui clientes que EU cubro agora (paridade com useMyCarteiraScores).
+  const { data: coverage } = useMyActiveCoverage();
+  const coveredIds = (coverage ?? []).map((c) => c.covered_user_id);
+  const coveredKey = coveredIds.join(',');
+  const ownerIds = isImpersonating && effectiveUserId ? [effectiveUserId] : (user ? [user.id, ...coveredIds] : []);
   const copilot = useCopilotEngine();
   const { getActivePlan } = useTacticalPlan();
   const [selectedCustomer, setSelectedCustomer] = useState<string>('');
@@ -50,12 +56,12 @@ export function useFarmerCopilot() {
 
   // Load customers (dropdown da carteira — segue o id efetivo na lente)
   useEffect(() => {
-    if (!effectiveUserId || !isStaff) return;
+    if (!ownerIds.length || !isStaff) return;
     (async () => {
       const { data: scores } = await supabase
         .from('farmer_client_scores')
         .select('customer_user_id')
-        .eq('farmer_id', effectiveUserId);
+        .in('farmer_id', ownerIds);
       if (!scores?.length) return;
       const ids = scores.map((s) => s.customer_user_id).filter((id): id is string => id !== null);
       const { data: profiles } = await supabase
@@ -66,7 +72,7 @@ export function useFarmerCopilot() {
         setCustomers(profiles.map((p) => ({ id: p.user_id, name: p.name ?? '' })));
       }
     })();
-  }, [effectiveUserId, isStaff]);
+  }, [effectiveUserId, isStaff, coveredKey]);
 
   // Auto-scroll transcript
   useEffect(() => {

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -4,6 +4,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { useMyActiveCoverage } from '@/hooks/useCoverage';
 import { useTacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
 import type { FarmerClientScoreRow, ProfileRow, CustomerLite } from './types';
@@ -13,7 +14,13 @@ export function useFarmerTacticalPlan() {
   // Lente "Ver como": o dropdown de clientes da carteira segue o id efetivo (o ALVO na
   // lente, o próprio usuário fora). A geração de plano (botões em GerarPlanoCard) é write
   // — bloqueada na lente pelo write-guard + disabled. Fora da lente effectiveUserId === user.id.
-  const { effectiveUserId } = useImpersonation();
+  const { effectiveUserId, isImpersonating } = useImpersonation();
+  // Cobertura: o dropdown inclui também os clientes que EU cubro agora (paridade com
+  // useMyCarteiraScores). Fora da lente: [eu, ...cobertos]; na lente: só o alvo.
+  const { data: coverage } = useMyActiveCoverage();
+  const coveredIds = (coverage ?? []).map((c) => c.covered_user_id);
+  const coveredKey = coveredIds.join(',');
+  const ownerIds = isImpersonating && effectiveUserId ? [effectiveUserId] : (user ? [user.id, ...coveredIds] : []);
   const { plans, loading, generating, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
   const [customers, setCustomers] = useState<CustomerLite[]>([]);
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
@@ -26,16 +33,17 @@ export function useFarmerTacticalPlan() {
       loadPlans();
       loadCustomers();
     }
-    // effectiveUserId na dep: ao entrar/sair da lente, recarrega planos + dropdown do alvo.
+    // effectiveUserId/coveredKey na dep: ao entrar/sair da lente OU mudar a cobertura,
+    // recarrega planos + dropdown (que passa a incluir os clientes cobertos).
 
-  }, [user, isStaff, effectiveUserId]);
+  }, [user, isStaff, effectiveUserId, coveredKey]);
 
   const loadCustomers = async () => {
-    if (!effectiveUserId) return;
+    if (!ownerIds.length) return;
     const { data: scoresData } = await supabase
       .from('farmer_client_scores')
       .select('customer_user_id, health_score, churn_risk')
-      .eq('farmer_id', effectiveUserId)
+      .in('farmer_id', ownerIds)
       .order('priority_score', { ascending: false });
     const scores = (scoresData ?? []) as FarmerClientScoreRow[];
     if (!scores.length) return;

--- a/src/hooks/__tests__/lens-tactical-plan.test.tsx
+++ b/src/hooks/__tests__/lens-tactical-plan.test.tsx
@@ -35,7 +35,7 @@ vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impM
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'master-id' }, isStaff: true }) }));
 
 // Cobertura controlada (evita useQuery/QueryClientProvider no teste do hook).
-const coverageMock = vi.fn<[], { data: Array<{ covered_user_id: string }> }>(() => ({ data: [] }));
+const coverageMock = vi.fn((): { data: Array<{ covered_user_id: string }> } => ({ data: [] }));
 vi.mock('@/hooks/useCoverage', () => ({ useMyActiveCoverage: () => coverageMock() }));
 
 import { useTacticalPlan } from '../useTacticalPlan';

--- a/src/hooks/__tests__/lens-tactical-plan.test.tsx
+++ b/src/hooks/__tests__/lens-tactical-plan.test.tsx
@@ -7,17 +7,23 @@ import { renderHook, waitFor, act } from '@testing-library/react';
  * carteira, estatísticas de efetividade) devem filtrar pelo id EFETIVO: o ALVO na lente,
  * o próprio usuário fora. A geração de plano e o registro de resultado são writes —
  * bloqueados na lente pelo write-guard + botões disabled (não exercidos aqui).
+ *
+ * Cobertura (opcional do roadmap farmer_id): FORA da lente o dropdown expande para
+ * [eu, ...cobertos] via useMyActiveCoverage (.in('farmer_id', ownerIds)), paridade com
+ * useMyCarteiraScores. NA lente, só o alvo (sem cobertura do alvo — espelha o display).
  */
 const eqCalls: Array<[string, unknown]> = [];
+const inCalls: Array<[string, unknown]> = [];
 
 function stubChain(): unknown {
   const chain: Record<string, unknown> = {};
   const passthrough = [
-    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order',
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'order',
     'limit', 'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
   ];
   for (const m of passthrough) chain[m] = () => chain;
   chain.eq = (col: string, val: unknown) => { eqCalls.push([col, val]); return chain; };
+  chain.in = (col: string, val: unknown) => { inCalls.push([col, val]); return chain; };
   chain.then = (resolve: (v: unknown) => void) => resolve({ data: [], error: null, count: 0 });
   return chain;
 }
@@ -28,12 +34,23 @@ const impMock = vi.fn();
 vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: 'master-id' }, isStaff: true }) }));
 
+// Cobertura controlada (evita useQuery/QueryClientProvider no teste do hook).
+const coverageMock = vi.fn<[], { data: Array<{ covered_user_id: string }> }>(() => ({ data: [] }));
+vi.mock('@/hooks/useCoverage', () => ({ useMyActiveCoverage: () => coverageMock() }));
+
 import { useTacticalPlan } from '../useTacticalPlan';
 import { useFarmerTacticalPlan } from '@/components/farmer/tacticalPlan/useFarmerTacticalPlan';
 
 beforeEach(() => {
   eqCalls.length = 0;
+  inCalls.length = 0;
+  coverageMock.mockReturnValue({ data: [] });
 });
+
+/** Valor do filtro .in('farmer_id', [...]) do dropdown (loadCustomers). */
+function farmerInValue(): string[] {
+  return (inCalls.find(([col]) => col === 'farmer_id')?.[1] as string[]) ?? [];
+}
 
 describe('useTacticalPlan — lente "Ver como"', () => {
   it('na lente: loadPlans filtra pelo ALVO, nunca o master', async () => {
@@ -62,20 +79,36 @@ describe('useTacticalPlan — lente "Ver como"', () => {
   });
 });
 
-describe('useFarmerTacticalPlan — lente "Ver como"', () => {
-  it('na lente: o dropdown de clientes (loadCustomers) filtra pelo ALVO, nunca o master', async () => {
+describe('useFarmerTacticalPlan — lente "Ver como" + cobertura', () => {
+  it('na lente: o dropdown (loadCustomers) filtra só pelo ALVO, nunca o master', async () => {
     impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
     renderHook(() => useFarmerTacticalPlan());
-    await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
-    const valores = eqCalls.map((c) => c[1]);
-    expect(valores).toContain('alvo-id');
-    expect(valores).not.toContain('master-id');
+    await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
+    expect(farmerInValue()).toContain('alvo-id');
+    expect(farmerInValue()).not.toContain('master-id');
   });
 
-  it('fora da lente: filtra pelo próprio usuário', async () => {
+  it('fora da lente sem cobertura: filtra pelo próprio usuário', async () => {
     impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
     renderHook(() => useFarmerTacticalPlan());
-    await waitFor(() => expect(eqCalls.length).toBeGreaterThan(0));
-    expect(eqCalls.map((c) => c[1])).toContain('master-id');
+    await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
+    expect(farmerInValue()).toContain('master-id');
+  });
+
+  it('fora da lente COM cobertura: dropdown inclui o coberto (eu + cobertos)', async () => {
+    impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
+    coverageMock.mockReturnValue({ data: [{ covered_user_id: 'coberto-id' }] });
+    renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
+    expect(farmerInValue()).toEqual(expect.arrayContaining(['master-id', 'coberto-id']));
+  });
+
+  it('na lente NÃO vaza a cobertura do master (só o alvo)', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
+    coverageMock.mockReturnValue({ data: [{ covered_user_id: 'coberto-id' }] });
+    renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
+    expect(farmerInValue()).toEqual(['alvo-id']);
+    expect(farmerInValue()).not.toContain('coberto-id');
   });
 });


### PR DESCRIPTION
## O quê
Opcional do roadmap de `farmer_id` — **paridade de cobertura nos dropdowns**.

`useFarmerTacticalPlan` e `useFarmerCopilot` listavam o dropdown da carteira com `.eq('farmer_id', effectiveUserId)` → um **gestor que cobre outra carteira não via os clientes cobertos** nos dropdowns de plano tático e copiloto, ao contrário do `useMyCarteiraScores` (que já expande pra cobertura). Fix: `ownerIds = lente ? [alvo] : [eu, ...cobertos]` (via `useMyActiveCoverage`) + `.in('farmer_id', ownerIds)`, espelhando o `useMyCarteiraScores`. `coveredKey` entra na dep do `useEffect` → o dropdown recarrega quando a cobertura muda.

## Escopo / o que NÃO entra
**Experiments fica OWN-BOOK de propósito** (`useFarmerExperiments.startExperiment` segue `user.id`): cobertura é transitória (Tati cobre Regina por N dias) e poluiria os grupos A/B de um experimento longo. Decisão registrada no spec.

## Verificação
`bun run typecheck` limpo (exit 0). Mudança espelha o padrão já provado do `useMyCarteiraScores`.

## ⚠️ DEPLOY
Frontend — **Publish frontend** no Lovable (não é edge nem SQL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
