### PR TITLE
feat(scoring): guard de contrato full-update em apply_score_updates [money-path]

### DIFF
--- a/db/test-apply-score-updates.sh
+++ b/db/test-apply-score-updates.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ════════════════════════════════════════════════════════════════════════════════
-# PROVA — apply_score_updates(jsonb): recompute UPDATE-only, anti-ressurreição + recência-viva
-# Migration (v2): supabase/migrations/20260622140000_apply_score_updates_persiste_base_vendas.sql
+# PROVA — apply_score_updates(jsonb): UPDATE-only, anti-ressurreição + recência-viva + guard de contrato
+# Migration (v3): supabase/migrations/20260622160000_apply_score_updates_guard_full_update.sql
 # Roda:  bash db/test-apply-score-updates.sh > /tmp/t.log 2>&1; echo "exit=$?"
 #
 # Invariantes:
@@ -10,6 +10,9 @@
 #   P13-15 (recência-viva, #970): days_since_last_purchase / avg_monthly_spend_180d / category_count
 #       são PERSISTIDOS frescos (o #971 os congelava — regressão fechada aqui). Falsificação F4:
 #       sabota recriando a RPC de 9 campos (#971) → EXIGE a base CONGELADA (vermelho).
+#   G1 (guard de contrato full-update, v3): payload PARCIAL (chave ausente/null) → RAISE check_violation
+#       ANTES do UPDATE, linha INTOCADA (NÃO grava NULL). Falsificação F5: recria a RPC SEM o guard
+#       → EXIGE que o payload parcial volte a gravar NULL (vermelho). Captura a CONDIÇÃO, não o texto.
 #
 # Nota: interpolação de uuid é feita pelo SHELL ('$VAR'); psql -c não expande :'var'.
 # Heredocs com $$/$fn$ ficam aspados <<'SQL' (não usam ids).
@@ -102,7 +105,7 @@ SQL
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
 # ══════════════════════════════════════════════════════════════════════════════
-MIG="$REPO_ROOT/supabase/migrations/20260622140000_apply_score_updates_persiste_base_vendas.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260622160000_apply_score_updates_guard_full_update.sql"
 P -q -f "$MIG" >/dev/null
 echo "migration aplicada: $(basename "$MIG")"
 
@@ -206,20 +209,30 @@ SQL
 case "$R" in *REVOKE_OK*) ok "N3b anon BARRADO (REVOKE)";; *) bad "N3b — veio: $R";; esac
 eq "N3c service_role EXECUTA (0 linhas, vazio)" "$(Pq -c "SET ROLE service_role; SELECT public.apply_score_updates('[]'::jsonb);" | tail -n1)" "0"
 
-echo "── N4: CONTRATO full-update (chave de base AUSENTE no JSON → coluna vira NULL) ──"
-# Documenta o gume do contrato que o header da migration avisa (achado /codex P2#3): jsonb_to_recordset
-# NÃO faz COALESCE → chave ausente vira SQL NULL e sobrescreve. O edge SEMPRE manda as 12 (?? sentinel),
-# então isto NUNCA dispara em prod; o teste prova o que acontece SE um caller driftar (= a classe de bug
-# do #971). NÃO há falsificação: N4 documenta um hazard, não protege um invariante.
-P -q -c "DELETE FROM public.farmer_client_scores WHERE id='$B_ID'; INSERT INTO public.farmer_client_scores (id, customer_user_id, farmer_id, days_since_last_purchase, avg_monthly_spend_180d, category_count) VALUES ('$B_ID','$B_CUST','$FARMER', 42, 111, 9);"
-# payload OMITE days_since_last_purchase (manda só spend+category dos 3 de base)
-P -q <<SQL
-SELECT public.apply_score_updates(jsonb_build_array(jsonb_build_object(
-  'id','$B_ID','health_score',88,'health_class','saudavel','churn_risk',12,'priority_score',77,'rf_score',90,'m_score',80,'g_score',70,'avg_monthly_spend_180d',2500,'category_count',4,'calculated_at','2026-06-18T20:00:00Z','updated_at','2026-06-18T20:00:00Z'
-)));
+echo "── G1: GUARD DE CONTRATO full-update (payload parcial → RAISE check_violation, linha INTOCADA) ──"
+# O #987 documentava o gume "chave ausente → NULL" (era N4, doc-only). O guard (v3, achado /codex P1,
+# deferido no #987, implementado pós-challenge) o FECHA: rejeita o LOTE com RAISE ANTES do UPDATE.
+# jsonb_to_recordset funde "ausente" e "null explícito" no mesmo SQL NULL → o guard pega os dois.
+# Captura a CONDIÇÃO check_violation (não o texto da msg — anti-teatro). Falsificado em F5.
+P -q -c "DELETE FROM public.farmer_client_scores WHERE id='$B_ID'; INSERT INTO public.farmer_client_scores (id, customer_user_id, farmer_id, health_score, days_since_last_purchase, avg_monthly_spend_180d, category_count) VALUES ('$B_ID','$B_CUST','$FARMER', 10, 42, 111, 9);"
+# payload OMITE days_since_last_purchase (1 das 13 chaves) → deve ser REJEITADO antes do UPDATE
+R=$(P -tA 2>&1 <<SQL
+SET ROLE service_role;
+DO \$\$
+BEGIN
+  PERFORM public.apply_score_updates(jsonb_build_array(jsonb_build_object(
+    'id','$B_ID','health_score',88,'health_class','saudavel','churn_risk',12,'priority_score',77,'rf_score',90,'m_score',80,'g_score',70,'avg_monthly_spend_180d',2500,'category_count',4,'calculated_at','2026-06-18T20:00:00Z','updated_at','2026-06-18T20:00:00Z'
+  )));
+  RAISE NOTICE 'SEM_GUARD_PASSOU';  -- sem RAISE EXCEPTION: o caminho sem-guard COMMITA o NULL (G1b/c ganham dente)
+EXCEPTION
+  WHEN check_violation THEN RAISE NOTICE 'GUARD_OK';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
 SQL
-eq "N4a chave ausente → days_since_last_purchase vira NULL (contrato: caller DEVE mandar as 12)" "$(Pq -c "SELECT days_since_last_purchase IS NULL FROM public.farmer_client_scores WHERE id='$B_ID';")" "t"
-eq "N4b campos presentes ainda aplicam (spend=2500)"                                             "$(Pq -c "SELECT avg_monthly_spend_180d FROM public.farmer_client_scores WHERE id='$B_ID';")" "2500"
+) || true
+case "$R" in *GUARD_OK*) ok "G1a payload parcial REJEITADO (check_violation, antes do UPDATE)";; *) bad "G1a — esperava check_violation, veio: $R";; esac
+eq "G1b linha INTOCADA: days continua 42 (NÃO virou NULL)"           "$(Pq -c "SELECT days_since_last_purchase FROM public.farmer_client_scores WHERE id='$B_ID';")" "42"
+eq "G1c linha INTOCADA: health_score continua 10 (UPDATE não rodou)" "$(Pq -c "SELECT health_score FROM public.farmer_client_scores WHERE id='$B_ID';")" "10"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 5 — FALSIFICAÇÃO (Lei #3: sabota → exige VERMELHO → restaura)
@@ -327,6 +340,38 @@ case "$(Pq -c "SELECT days_since_last_purchase||'/'||avg_monthly_spend_180d||'/'
   *)        bad "F4 omiti os 3 campos de base e eles mudaram mesmo assim → P13-15 fraco";;
 esac
 P -q -f "$MIG" >/dev/null                                              # restaura a RPC verdadeira (12 campos)
+
+# F5 — dente do GUARD (G1): recria a RPC SEM o guard (= v2 #987 pura, só o UPDATE). EXIGE que o
+# payload PARCIAL volte a GRAVAR NULL (corrompe) → prova que o guard é o que barra, não o teste.
+# Anti-teatro: comparo o EFEITO (days vira NULL), não a presença do RAISE no código.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.apply_score_updates(p_updates jsonb)
+RETURNS integer LANGUAGE plpgsql SECURITY INVOKER SET search_path = public AS $fn$
+DECLARE v_count int;
+BEGIN
+  UPDATE public.farmer_client_scores f SET                 -- SEM guard (= v2 #987 pura)
+    health_score = u.health_score, health_class = u.health_class, churn_risk = u.churn_risk,
+    priority_score = u.priority_score, rf_score = u.rf_score, m_score = u.m_score, g_score = u.g_score,
+    days_since_last_purchase = u.days_since_last_purchase, avg_monthly_spend_180d = u.avg_monthly_spend_180d,
+    category_count = u.category_count, calculated_at = u.calculated_at, updated_at = u.updated_at
+  FROM jsonb_to_recordset(p_updates) AS u(id uuid, health_score numeric, health_class text, churn_risk numeric, priority_score numeric, rf_score numeric, m_score numeric, g_score numeric, days_since_last_purchase integer, avg_monthly_spend_180d numeric, category_count integer, calculated_at timestamptz, updated_at timestamptz)
+  WHERE f.id = u.id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END $fn$;
+SQL
+P -q -c "DELETE FROM public.farmer_client_scores WHERE id='$B_ID'; INSERT INTO public.farmer_client_scores (id, customer_user_id, farmer_id, days_since_last_purchase, avg_monthly_spend_180d, category_count) VALUES ('$B_ID','$B_CUST','$FARMER', 42, 111, 9);"
+# payload PARCIAL (omite days_since_last_purchase) — SEM guard, deve gravar NULL
+P -q <<SQL
+SELECT public.apply_score_updates(jsonb_build_array(jsonb_build_object(
+  'id','$B_ID','health_score',88,'health_class','saudavel','churn_risk',12,'priority_score',77,'rf_score',90,'m_score',80,'g_score',70,'avg_monthly_spend_180d',2500,'category_count',4,'calculated_at','2026-06-18T20:00:00Z','updated_at','2026-06-18T20:00:00Z'
+)));
+SQL
+case "$(Pq -c "SELECT days_since_last_purchase IS NULL FROM public.farmer_client_scores WHERE id='$B_ID';")" in
+  t) ok "F5 sem guard, payload parcial GRAVA NULL → G1 tem dente (o guard é o que barra)";;
+  *) bad "F5 removi o guard e o payload parcial NÃO corrompeu → G1 é teatro/fraco";;
+esac
+P -q -f "$MIG" >/dev/null                                              # restaura a RPC verdadeira (com guard)
 
 # ── veredito ──
 echo "──────────────────────────────"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **276** custom migrations totais
-- **1002** objetos esperados (criados por estas migrations)
+- **277** custom migrations totais
+- **1003** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 282
+  - `function`: 283
   - `rls_policy`: 219
   - `index`: 186
   - `table`: 108
@@ -2391,6 +2391,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `trigger` | `public.trg_carteira_cleanup_orphan_score` | `carteira_assignments` |
 
 ### `20260622140000_apply_score_updates_persiste_base_vendas.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.apply_score_updates` | — |
+
+### `20260622160000_apply_score_updates_guard_full_update.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 276
+-- Total de custom migrations: 277
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -295,7 +295,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260621120000', 'seed_targets_faltantes_rpc', '20260621120000_seed_targets_faltantes_rpc.sql'),
   ('20260621130000', 'fcs_guard_flagged_insert', '20260621130000_fcs_guard_flagged_insert.sql'),
   ('20260622120000', 'trigger_cleanup_orphan_score_on_carteira_delete', '20260622120000_trigger_cleanup_orphan_score_on_carteira_delete.sql'),
-  ('20260622140000', 'apply_score_updates_persiste_base_vendas', '20260622140000_apply_score_updates_persiste_base_vendas.sql')
+  ('20260622140000', 'apply_score_updates_persiste_base_vendas', '20260622140000_apply_score_updates_persiste_base_vendas.sql'),
+  ('20260622160000', 'apply_score_updates_guard_full_update', '20260622160000_apply_score_updates_guard_full_update.sql')
 )
 SELECT
   e.version,
@@ -1315,7 +1316,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fcs_guard_flagged_insert', 'trigger', 'public', 'trg_fcs_block_flagged_insert', 'farmer_client_scores'),
   ('trigger_cleanup_orphan_score_on_carteira_delete', 'function', 'public', 'cleanup_orphan_score_on_carteira_delete', ''),
   ('trigger_cleanup_orphan_score_on_carteira_delete', 'trigger', 'public', 'trg_carteira_cleanup_orphan_score', 'carteira_assignments'),
-  ('apply_score_updates_persiste_base_vendas', 'function', 'public', 'apply_score_updates', '')
+  ('apply_score_updates_persiste_base_vendas', 'function', 'public', 'apply_score_updates', ''),
+  ('apply_score_updates_guard_full_update', 'function', 'public', 'apply_score_updates', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260622160000_apply_score_updates_guard_full_update.sql
+++ b/supabase/migrations/20260622160000_apply_score_updates_guard_full_update.sql
@@ -1,0 +1,147 @@
+-- ============================================================================
+-- apply_score_updates(p_updates jsonb) — v3: GUARD DE CONTRATO full-update.
+-- Money-path · hardening. Recria a v2 (#987) NA ÍNTEGRA + um guard de runtime.
+--
+-- PROBLEMA (gume documentado, achado /codex P1 no review do #987): jsonb_to_recordset
+-- NÃO faz COALESCE. Uma chave AUSENTE num elemento do array — ou presente com `null` —
+-- vira SQL NULL e SOBRESCREVE a coluna. O contrato é "full-update" (as 13 chaves: id + 12
+-- colunas do SET, obrigatórias em TODA linha). Hoje o ÚNICO caller (edge calculate-scores)
+-- sempre manda as 13 não-nulas (?? sentinel / || 0 / Number.isFinite), então o gume NUNCA
+-- dispara em prod — mas é doc-only: nada no banco IMPEDE um payload parcial de corromper.
+--
+-- POR QUE FECHAR (decisão pós-challenge adversário /codex `xhigh`, 2026-06-22): o #987 deixou
+-- este guard DEFERIDO (desenho lean). Reavaliado: o gume defende contra DRIFT do caller, que é
+-- SISTÊMICO — se o edge (ou um caller futuro) parar de mandar uma chave, NÃO é 1 linha, são
+-- TODAS (~6,4k) gravando NULL silenciosamente. E "apply_score_updates" é um nome que CONVIDA
+-- um backfill/admin futuro (via service_role) a usá-la como patch parcial. Money-path: falhar
+-- alto e visível, preservando o valor velho, vence gravar NULL como verdade (ex.: um filtro
+-- `WHERE days_since_last_purchase > 60` exclui silenciosamente a linha NULL → cliente vencido
+-- some da fila comercial). Princípio #5: o guard mora na FRONTEIRA que toda via cruza (a RPC),
+-- não na disciplina do caller.
+--
+-- COMO: ANTES do UPDATE, conta elementos cujas 13 chaves são TODAS não-nulas (jsonb_to_recordset
+-- funde "ausente" e "null explícito" no mesmo SQL NULL → um único IS NOT NULL pega os dois). Se
+-- algum elemento falhar, RAISE (ERRCODE check_violation) e ABORTA o lote inteiro — nada é gravado.
+-- Custo: 1 passada extra de jsonb_to_recordset por batch (≤500 elementos) — irrelevante.
+--
+-- O QUE NÃO MUDA vs #987: o SET (12 colunas), a chave de match (WHERE f.id=u.id) e a garantia
+-- anti-ressurreição (#971) ficam IDÊNTICOS — UPDATE-only por id, não re-insere linha deletada
+-- mid-run, nunca 23505. Lote vazio ('[]') segue retornando 0 (0 de 0 válidos → não dispara).
+--
+-- ORDEM DE APLICAÇÃO (Lovable SQL Editor): a v2 (#987, 20260622140000) JÁ está em prod. Esta
+-- migration é auto-suficiente (recria a função inteira) e tem timestamp POSTERIOR de propósito:
+-- como "o último CREATE OR REPLACE vence", aplicar SÓ esta por cima da v2. NUNCA reaplicar a v2
+-- depois desta (mataria o guard). Pré-flight pg_get_functiondef confere o estado (handoff db-operator).
+--
+-- SEGURANÇA: idêntica ao #971/#987 — SECURITY INVOKER (menor privilégio) + REVOKE de PUBLIC/
+-- anon/authenticated + GRANT EXECUTE só a service_role. Chamada SÓ pelo edge via service_role.
+--
+-- Provado em PG17 local com falsificação: db/test-apply-score-updates.sh
+--   G1: payload parcial → check_violation + linha INTOCADA (captura a CONDIÇÃO, não o texto).
+--   F5: recria a RPC SEM o guard → EXIGE que o payload parcial volte a gravar NULL (vermelho)
+--       → prova que G1 tem dente (o guard é o que barra, não o teste).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.apply_score_updates(p_updates jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_count int;
+  v_total int;
+  v_valid int;
+BEGIN
+  -- ── GUARD DE CONTRATO (full-update only): as 13 chaves são obrigatórias em TODA linha ──
+  -- jsonb_to_recordset NÃO faz COALESCE → chave ausente OU `null` explícito = SQL NULL.
+  -- Conta elementos 100% completos e compara com o total; diferença = drift → aborta o lote.
+  v_total := jsonb_array_length(p_updates);
+
+  SELECT count(*) INTO v_valid
+  FROM jsonb_to_recordset(p_updates) AS u(
+    id                       uuid,
+    health_score             numeric,
+    health_class             text,
+    churn_risk               numeric,
+    priority_score           numeric,
+    rf_score                 numeric,
+    m_score                  numeric,
+    g_score                  numeric,
+    days_since_last_purchase integer,
+    avg_monthly_spend_180d   numeric,
+    category_count           integer,
+    calculated_at            timestamptz,
+    updated_at               timestamptz
+  )
+  WHERE id                       IS NOT NULL
+    AND health_score             IS NOT NULL
+    AND health_class             IS NOT NULL
+    AND churn_risk               IS NOT NULL
+    AND priority_score           IS NOT NULL
+    AND rf_score                 IS NOT NULL
+    AND m_score                  IS NOT NULL
+    AND g_score                  IS NOT NULL
+    AND days_since_last_purchase IS NOT NULL
+    AND avg_monthly_spend_180d   IS NOT NULL
+    AND category_count           IS NOT NULL
+    AND calculated_at            IS NOT NULL
+    AND updated_at               IS NOT NULL;
+
+  IF v_valid <> v_total THEN
+    RAISE EXCEPTION
+      'apply_score_updates: contrato full-update violado — % de % elemento(s) com campo obrigatorio nulo/ausente (as 13 chaves sao obrigatorias; jsonb_to_recordset nao faz COALESCE)',
+      (v_total - v_valid), v_total
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- ── UPDATE-only por id (anti-ressurreição #971), persistindo base de vendas (#987) ──
+  UPDATE public.farmer_client_scores f SET
+    health_score             = u.health_score,
+    health_class             = u.health_class,
+    churn_risk               = u.churn_risk,
+    priority_score           = u.priority_score,
+    rf_score                 = u.rf_score,
+    m_score                  = u.m_score,
+    g_score                  = u.g_score,
+    days_since_last_purchase = u.days_since_last_purchase,
+    avg_monthly_spend_180d   = u.avg_monthly_spend_180d,
+    category_count           = u.category_count,
+    calculated_at            = u.calculated_at,
+    updated_at               = u.updated_at
+  FROM jsonb_to_recordset(p_updates) AS u(
+    id                       uuid,
+    health_score             numeric,
+    health_class             text,
+    churn_risk               numeric,
+    priority_score           numeric,
+    rf_score                 numeric,
+    m_score                  numeric,
+    g_score                  numeric,
+    days_since_last_purchase integer,
+    avg_monthly_spend_180d   numeric,
+    category_count           integer,
+    calculated_at            timestamptz,
+    updated_at               timestamptz
+  )
+  WHERE f.id = u.id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END $$;
+
+REVOKE ALL    ON FUNCTION public.apply_score_updates(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_score_updates(jsonb) TO service_role;
+
+-- ============================================================
+-- Validação (cole no SQL Editor; confira: existe=1, tem_guard=t, tem_base=t,
+-- exec_service=t, exec_auth=f, exec_anon=f)
+-- ============================================================
+SELECT 'apply_score_updates v3 (guard) OK' AS status,
+  (SELECT count(*) FROM pg_proc WHERE proname = 'apply_score_updates')                       AS existe,
+  pg_get_functiondef('public.apply_score_updates(jsonb)'::regprocedure)
+    LIKE '%contrato full-update violado%'                                                    AS tem_guard,
+  pg_get_functiondef('public.apply_score_updates(jsonb)'::regprocedure)
+    LIKE '%days_since_last_purchase = u.days_since_last_purchase%'                            AS tem_base,
+  has_function_privilege('service_role',  'public.apply_score_updates(jsonb)', 'EXECUTE')     AS exec_service,
+  has_function_privilege('authenticated', 'public.apply_score_updates(jsonb)', 'EXECUTE')     AS exec_auth,
+  has_function_privilege('anon',          'public.apply_score_updates(jsonb)', 'EXECUTE')     AS exec_anon;


### PR DESCRIPTION
## O quê

Guard de contrato full-update na RPC `public.apply_score_updates(jsonb)`. Recria a v2 (#987) na íntegra + um guard de runtime: antes do UPDATE, conta os elementos cujas **13 chaves** são todas não-nulas via `jsonb_to_recordset` (que funde "chave ausente" e "`null` explícito" no mesmo SQL NULL); se algum elemento falhar, `RAISE EXCEPTION … USING ERRCODE='check_violation'` e **aborta o lote** — nada é gravado. O SET, a chave de match (`WHERE f.id=u.id`) e a garantia anti-ressurreição (#971) ficam idênticos.

## Por quê

Achado `/codex` (P1) no review do #987, **deferido** lá (desenho lean). Reavaliado nesta sessão com challenge adversário (`/codex challenge --xhigh`), que furou o argumento de manter deferido:

- O drift que o guard defende é **sistêmico** — se o edge (ou um caller futuro, ex.: backfill/admin via `service_role`, que o nome `apply_score_updates` convida a usar como patch parcial) parar de mandar uma chave, são **~6,4k linhas gravando NULL silenciosamente**, não 1.
- Money-path: falhar alto e visível (run 500 idempotente, valor velho preservado) **vence** gravar NULL como verdade — um filtro `WHERE days_since_last_purchase > 60` exclui silenciosamente a linha NULL → cliente vencido **some da fila comercial**.
- O guard mora na **fronteira que todo caller cruza** (princípio #5 do money-path), não na disciplina do caller (`?? sentinel` no edge) nem só na doc.

## Prova (PG17 + falsificação)

`db/test-apply-score-updates.sh` — **32 asserts, 0 fail**:

- **G1a** payload parcial → `check_violation` (captura a *condição*, não o texto da mensagem — anti-teatro).
- **G1b / G1c** linha **intocada** (days=42, health=10 — UPDATE não rodou).
- **F5** (falsificação embutida): recria a RPC **sem** o guard → exige que o payload parcial volte a gravar NULL.
- **Falsificação manual da migration real** (`IF v_valid <> v_total` → `IF false`): G1a/b/c **todos vermelhos** → restaurado → verde. Os 3 asserts têm dente. (A sabotagem revelou e corrigiu um teatro: `RAISE EXCEPTION` no `DO` block fazia rollback que mascarava G1b/c → trocado por `RAISE NOTICE`.)
- **Zero regressão**: P0-P15 (caminho feliz), N1 (anti-ressurreição #971), N2 (anti-23505), N3 (grants), F1-F4.

## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260622160000_apply_score_updates_guard_full_update.sql`. **Lovable não aplica automaticamente** — mergear **NÃO** toca o banco. Cole no SQL Editor do Lovable e rode.

A v2 (#987) **já está em produção** (`tem_base=t`); esta migration é a **última** a recriar a RPC — aplicar por cima da v2, nunca reaplicar a v2 depois dela ("o último `CREATE OR REPLACE` vence").

Validação (no fim do `.sql`):

```
existe=1 · tem_guard=t · tem_base=t · exec_service=t · exec_auth=f · exec_anon=f
```

Audit regenerado (`docs/migrations-audit.md` + `scripts/audit-custom-migrations.sql`): 277 migrations, 1003 objetos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
