### PR TITLE
fix(tint-sync): dedup itens por corante na promoção — estanca re-loop [money-path]

### DIFF
--- a/db/test-tint-promote-dedup-itens.sh
+++ b/db/test-tint-promote-dedup-itens.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260622210000_tint_promote_dedup_itens_corante.sql              ║
+# ║  Invariante: a promoção DEDUPLICA itens por (formula_id, corante_id). Fórmula  ║
+# ║  com o MESMO corante em 2 slots NÃO aborta o run; o item fica com a qtd de     ║
+# ║  MAIOR ORDEM (idempotente com o oficial CSV-import; NÃO soma, NÃO maior-valor).║
+# ║  Falsificação: SEM o DISTINCT ON, o INSERT viola o unique (23505) e derruba o  ║
+# ║  run inteiro (= o re-loop que isto conserta).                                  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="tint-dedup"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+P0() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" | grep -vE '^\\(un)?restrict ' > "$RR"
+P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" 2>/dev/null || true
+P0 -q -f "$RR" >/tmp/snap-apply.log 2>&1 || true
+rm -f "$RR"
+P -q <<'SQL'
+CREATE TABLE IF NOT EXISTS public.tint_staging_precos_base (
+  id uuid NOT NULL DEFAULT gen_random_uuid(), sync_run_id uuid, account text NOT NULL, store_code text NOT NULL,
+  cod_produto text NOT NULL, id_base text NOT NULL, id_embalagem text NOT NULL,
+  custo numeric, imposto_pct numeric, margem_pct numeric, raw_data jsonb, staging_status text,
+  created_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.tint_formulas ADD COLUMN IF NOT EXISTS desativada_em timestamptz;
+SQL
+for m in 20260609150000_tint_sync_promote 20260611190000_tint_sync_codex_fixes \
+         20260615140000_tint_promote_indices_timeout 20260615160000_tint_promote_set_based; do
+  P0 -q -f "$REPO_ROOT/supabase/migrations/${m}.sql" >>/tmp/mig-apply.log 2>&1 || true
+done
+echo "snapshot + cadeia aplicados"
+
+# ── ZONA 2: a migration REAL sob teste (CREATE OR REPLACE — corpo completo com o dedup) ──
+P -q -f "$REPO_ROOT/supabase/migrations/20260622210000_tint_promote_dedup_itens_corante.sql"
+echo "migration aplicada: 20260622210000_tint_promote_dedup_itens_corante.sql"
+
+# ── ZONA 3: seed — catálogo + 1 fórmula PADRÃO com corante REPETIDO ──
+# vol_formulacao = vol_embalagem = 900 → fator = 1 → qtd expandida = qtd da formulação (asserts diretos).
+# C1 repetido DISTINTO: ordem 1 = 40.0, ordem 3 = 1.5  → maior-ordem(3)=1.5; soma=41.5; maior-valor=40.0
+# C3 repetido IDÊNTICO: ordem 4 = 0.77, ordem 5 = 0.77 → dedup=0.77; soma=1.54 (duplicação ⇒ não somar)
+# C2 normal: ordem 2 = 7.5 (controle: corante não-repetido fica intacto)
+P -q <<'SQL'
+INSERT INTO tint_produtos (id, account, cod_produto, descricao) VALUES ('a0000000-0000-0000-0000-000000000001','colacor','P1','Produto 1');
+INSERT INTO tint_bases (id, account, id_base_sayersystem, descricao) VALUES ('b0000000-0000-0000-0000-000000000001','colacor','B1','Base 1');
+INSERT INTO tint_embalagens (id, account, id_embalagem_sayersystem, volume_ml) VALUES ('c0000000-0000-0000-0000-000000000001','colacor','E1',900);
+INSERT INTO tint_corantes (id, account, id_corante_sayersystem, descricao, volume_total_ml) VALUES
+ ('d0000000-0000-0000-0000-000000000001','colacor','C1','Corante 1',1000),
+ ('d0000000-0000-0000-0000-000000000002','colacor','C2','Corante 2',1000),
+ ('d0000000-0000-0000-0000-000000000003','colacor','C3','Corante 3',1000);
+INSERT INTO tint_skus (id, account, produto_id, base_id, embalagem_id) VALUES ('e0000000-0000-0000-0000-000000000001','colacor','a0000000-0000-0000-0000-000000000001','b0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001');
+INSERT INTO tint_integration_settings (id, account, store_code) VALUES ('10000000-0000-0000-0000-000000000001','colacor','M01');
+
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-000000000001','10000000-0000-0000-0000-000000000001','colacor','M01','formulas','running');
+INSERT INTO tint_staging_produtos (sync_run_id, account, store_code, cod_produto) VALUES ('20000000-0000-0000-0000-000000000001','colacor','M01','P1');
+INSERT INTO tint_staging_bases (sync_run_id, account, store_code, id_base_sayersystem, descricao) VALUES ('20000000-0000-0000-0000-000000000001','colacor','M01','B1','Base 1');
+INSERT INTO tint_staging_embalagens (sync_run_id, account, store_code, id_embalagem_sayersystem, volume_ml) VALUES ('20000000-0000-0000-0000-000000000001','colacor','M01','E1',900);
+INSERT INTO tint_staging_corantes (sync_run_id, account, store_code, id_corante_sayersystem, descricao, custo, volume_ml) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','C1','Corante 1',NULL,1000),
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','C2','Corante 2',NULL,1000),
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','C3','Corante 3',NULL,1000);
+INSERT INTO tint_staging_skus (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem) VALUES ('20000000-0000-0000-0000-000000000001','colacor','M01','P1','B1','E1');
+INSERT INTO tint_staging_formulas (id, sync_run_id, account, store_code, cor_id, nome_cor, cod_produto, id_base, id_embalagem, volume_final_ml, preco_final, personalizada) VALUES
+ ('50000000-0000-0000-0000-000000000001','20000000-0000-0000-0000-000000000001','colacor','M01','344M - BS','Cor Teste','P1','B1','E1',900,NULL,false);
+INSERT INTO tint_staging_formula_itens (sync_run_id, staging_formula_id, id_corante, qtd_ml, ordem) VALUES
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C1',40.0,1),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C2', 7.5,2),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C1', 1.5,3),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C3',0.77,4),
+ ('20000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-000000000001','C3',0.77,5);
+SQL
+echo "seed pronto (fórmula PADRÃO 344M com C1 repetido distinto 40/1.5 + C3 idêntico 0.77/0.77)"
+
+# ── ZONA 4: ASSERTS ──
+echo "── asserts ──"
+RES=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-000000000001'))->>'ok';")
+eq "A1 promove SEM abortar (corante repetido)" "$RES" "true"
+
+NC1=$(Pq -c "SELECT count(*) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id JOIN tint_corantes co ON co.id=fi.corante_id WHERE f.account='colacor' AND f.cor_id='344M - BS' AND co.id_corante_sayersystem='C1';")
+eq "A2 dedup: 1 item por (formula, C1) — sem duplicate" "$NC1" "1"
+
+A3=$(Pq -c "SELECT (fi.qtd_ml = 1.5) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id JOIN tint_corantes co ON co.id=fi.corante_id WHERE f.account='colacor' AND f.cor_id='344M - BS' AND co.id_corante_sayersystem='C1';")
+eq "A3 C1 = MAIOR ORDEM (1.5; NÃO soma 41.5, NÃO maior-valor 40)" "$A3" "t"
+
+A4=$(Pq -c "SELECT fi.ordem FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id JOIN tint_corantes co ON co.id=fi.corante_id WHERE f.account='colacor' AND f.cor_id='344M - BS' AND co.id_corante_sayersystem='C1';")
+eq "A4 ordem armazenada = a do item escolhido (maior ordem = 3)" "$A4" "3"
+
+A5=$(Pq -c "SELECT (fi.qtd_ml = 0.77) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id JOIN tint_corantes co ON co.id=fi.corante_id WHERE f.account='colacor' AND f.cor_id='344M - BS' AND co.id_corante_sayersystem='C3';")
+eq "A5 idênticos dedup p/ 0.77 (NÃO soma 1.54)" "$A5" "t"
+
+A6=$(Pq -c "SELECT (fi.qtd_ml = 7.5) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id JOIN tint_corantes co ON co.id=fi.corante_id WHERE f.account='colacor' AND f.cor_id='344M - BS' AND co.id_corante_sayersystem='C2';")
+eq "A6 corante normal (C2) intacto = 7.5" "$A6" "t"
+
+# Idempotência: re-rodar a promoção do MESMO run não muda nada (DELETE+INSERT dedup determinístico).
+Pq -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-000000000001');" >/dev/null
+A7=$(Pq -c "SELECT count(*) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id WHERE f.account='colacor' AND f.cor_id='344M - BS';")
+eq "A7 idempotente: 3 itens (C1,C2,C3) após re-promover" "$A7" "3"
+
+# A8 — DEDUP DO _preco (Codex P1): com precos_base + custo, o preço usa MAX-ordem (não soma).
+# C1=10/L, C2=20/L, C3=30/L; base custo=100 imp=0 marg=0; fator=1 (vol_form=vol_emb=900).
+#   max-ordem: 100 + (10/1000*1.5) + (20/1000*7.5) + (30/1000*0.77) = 100.1881 -> 100.19
+#   soma(bug): 100 + (10/1000*41.5) + 0.15 + (30/1000*1.54)         = 100.6112 -> 100.61
+P -q <<'SQL'
+UPDATE tint_staging_corantes SET custo=10, volume_ml=1000 WHERE sync_run_id='20000000-0000-0000-0000-000000000001' AND id_corante_sayersystem='C1';
+UPDATE tint_staging_corantes SET custo=20, volume_ml=1000 WHERE sync_run_id='20000000-0000-0000-0000-000000000001' AND id_corante_sayersystem='C2';
+UPDATE tint_staging_corantes SET custo=30, volume_ml=1000 WHERE sync_run_id='20000000-0000-0000-0000-000000000001' AND id_corante_sayersystem='C3';
+INSERT INTO tint_staging_precos_base (sync_run_id, account, store_code, cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct) VALUES
+ ('20000000-0000-0000-0000-000000000001','colacor','M01','P1','B1','E1',100,0,0);
+SQL
+Pq -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-000000000001');" >/dev/null
+A8=$(Pq -c "SELECT preco_final_sayersystem FROM tint_formulas WHERE account='colacor' AND cor_id='344M - BS';")
+eq "A8 preço usa itens MAX-ordem (100.19; NÃO a soma 100.61)" "$A8" "100.19"
+
+# ── ZONA 5: FALSIFICAÇÃO (Lei #3) ──
+echo "── falsificação ──"
+# 1) SABOTA: aplica a versão ANTERIOR (20260622130000), que NÃO tem o DISTINCT ON no INSERT de itens.
+P -q -f "$REPO_ROOT/supabase/migrations/20260622130000_tint_promote_nome_cor_fallback.sql"
+# novo run com OUTRA fórmula de corante repetido (997M, C1 em ordem 2 e 5) no MESMO par P1/B1.
+P -q <<'SQL'
+INSERT INTO tint_sync_runs (id, setting_id, account, store_code, sync_type, status) VALUES
+ ('20000000-0000-0000-0000-0000000000ff','10000000-0000-0000-0000-000000000001','colacor','M01','formulas','running');
+INSERT INTO tint_staging_formulas (id, sync_run_id, account, store_code, cor_id, nome_cor, cod_produto, id_base, id_embalagem, volume_final_ml, preco_final, personalizada) VALUES
+ ('50000000-0000-0000-0000-0000000000ff','20000000-0000-0000-0000-0000000000ff','colacor','M01','997M - BS','Cor Teste 2','P1','B1','E1',900,NULL,false);
+INSERT INTO tint_staging_formula_itens (sync_run_id, staging_formula_id, id_corante, qtd_ml, ordem) VALUES
+ ('20000000-0000-0000-0000-0000000000ff','50000000-0000-0000-0000-0000000000ff','C1',0.385,2),
+ ('20000000-0000-0000-0000-0000000000ff','50000000-0000-0000-0000-0000000000ff','C1',14.09,5);
+SQL
+# 2+3) re-roda e EXIGE o 23505 (duplicate key) — a SQLSTATE real do PG, não uma sentinela inventada.
+FALSO=$(P0 -tA -c "SELECT tint_promote_sync_run('20000000-0000-0000-0000-0000000000ff');" 2>&1 || true)
+if echo "$FALSO" | grep -qiE "23505|duplicate key value|tint_formula_itens_formula_id_corante_id_key"; then
+  ok "F1 falsificação TEM DENTE: sem o dedup, o INSERT estoura 23505 (duplicate key) e derruba o run"
+else
+  bad "F1 falsificação FRACA: esperava 23505/duplicate key, veio [$FALSO]"
+fi
+# 4) RESTAURA a versão verdadeira (com dedup) e prova que o run que falhava AGORA promove.
+P -q -f "$REPO_ROOT/supabase/migrations/20260622210000_tint_promote_dedup_itens_corante.sql"
+RES2=$(Pq -c "SELECT (tint_promote_sync_run('20000000-0000-0000-0000-0000000000ff'))->>'ok';")
+eq "F2 com o dedup restaurado, o run que falhava agora promove" "$RES2" "true"
+A8=$(Pq -c "SELECT (fi.qtd_ml = 14.09) FROM tint_formula_itens fi JOIN tint_formulas f ON f.id=fi.formula_id JOIN tint_corantes co ON co.id=fi.corante_id WHERE f.account='colacor' AND f.cor_id='997M - BS' AND co.id_corante_sayersystem='C1';")
+eq "F3 997M C1 = maior ordem (14.09 = ordem 5; espelha o oficial de prod)" "$A8" "t"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/historico/tintometrico.md
+++ b/docs/historico/tintometrico.md
@@ -4,6 +4,43 @@ Narrativa das entregas do módulo tintométrico (`/tintometrico/*`, account `obe
 
 ---
 
+## Re-envio residual de fórmulas — promoção aborta por corante repetido (duplicate key) → re-loop (2026-06-22, migration `20260622210000`, prova PG17 + Codex)
+
+### Sintoma
+Pós-#914 (loop de 485k morto), re-envios residuais em batches CHEIOS (`total_records=1000`) em dias esparsos (06-18=113k, 06-22=75k); `tint_staging_formulas` 121k→406k. ~1000× menor que o loop original, sem dano visível — mas ATIVO (~10 runs `error`/h, 5-10k regs/h re-staged à toa).
+
+### Diagnóstico (read-only psql-ro + código)
+- O conector (`syncFormulas`) só cacheia o lote se a edge confirma `ok:true`. Em `automatic_primary` a edge (`tint-sync-agent`) promove **por batch** e devolve **500 se a promoção falha** → o conector **não cacheia o lote** → **re-envia o batch CHEIO no ciclo seguinte** (re-loop). Confirmado: 22/06 = 116 runs `formulas` status=`error` (75.082 regs) vs 16 `complete`; **1000 chaves re-staged 41×** (1 batch refém).
+- Erros (`tint_sync_errors` entity_type='promotion'): `nome_cor NULL` (80 — **resolvido pelo #992**, parou 20:22, fix 20:45), `duplicate key tint_formula_itens_formula_id_corante_id_key` (15), `lock timeout` 55P03 (34, **colateral** da contention do re-loop).
+- **Causa do duplicate key:** 4 cores PADRÃO ATIVAS (`344M/629N/638S/997M - BS`) têm fórmula com o **mesmo corante em 2 slots/ordens** (dosagem em 2 etapas; ex. 997M corante 3 = 0.385[ord2] + 14.09[ord5]). `aggregateFlatFormulaItems` (pg.go) envia 2 itens; o INSERT de `tint_formula_itens` **não deduplica** → viola o unique `(formula_id, corante_id)` → **rollback do batch**. A promoção monta `_formulas_latest` por **latest-per-key restrito aos PARES tocados** → essas 4 cores envenenam TODO batch que toca seus pares (18 produtos/51 bases ≈ 1000 fórmulas reféns).
+- Por que "erros baixos" enganava: a coluna `errors` do run conta erro de ITEM no staging (=0, o staging aceita tudo); o abort é na PROMOÇÃO (marca status='error', não toca `errors`).
+
+### Respostas (perguntas da investigação)
+1. Mesmas chaves a cada evento? **SIM** (re-loop do mesmo batch). 2. Personalizadas? **NÃO** (99,86% padrão; nome_cor era problema separado, resolvido #992). 3. Re-scan de domingo? **NÃO** (qui/sex/seg; é promoção falhando). 4. Hash não-determinístico? **NÃO** — o hash está correto; o bug é na promoção SQL.
+
+### Decisão de semântica (founder delegou "você e codex decidirem")
+O oficial (CSV-import histórico) grava **1 item por corante = o de MAIOR ORDEM** — validado em prod no caso que distingue: 344M corante 1 = ordem3=**1.54** (NÃO maior-valor 40.05, NÃO soma 41.59); 997M = ordem5=14.09; 638S idênticos. Fix replica isso: `DISTINCT ON (formula_id, corante_id) ORDER BY ordem DESC` → **idempotente, ZERO mudança de dosagem de cor ativa** (precisão > recall). **NÃO somar** (mudaria preço/dosagem de cor ativa + erra os casos de duplicação 629N/638S idênticos).
+
+### Fix
+Migration `20260622210000_tint_promote_dedup_itens_corante.sql` (CREATE OR REPLACE, 6ª da cadeia — herda nome_cor + E4 + reexpand + preço VERBATIM). Muda só o INSERT de `tint_formula_itens`. Resolve o duplicate key → o batch promove → cessa o re-loop → some o lock timeout colateral. **NÃO toca o conector** (sem redeploy no balcão).
+
+### Verificação
+PG17 `db/test-tint-promote-dedup-itens.sh` — **11/11 verde**: promove sem abortar · dedup 1 item/corante · maior-ordem (1.5, não soma/maior-valor) · idênticos→0.77 · corante normal intacto · idempotente · preço usa max-ordem (A8). **Falsificação com dente:** sem o `DISTINCT ON`, o INSERT estoura **23505** (= o re-loop real). **Idempotência catalog-wide provada** (read-only vs prod): as **4 cores/192 fórmulas** têm fração-normalizada staging-max-ordem == oficial (15/15 corantes batem) → no-op de dosagem. **Codex consult (medium):** validou max-ordem como o hotfix certo (não somar, não corrigir a 344M agora) e levantou 3 achados, **todos incorporados** — [P1] dedup do `_preco` p/ alinhar item↔preço (era 2 BOMs: item=max-ordem, preço=Σ-todos; dead-code hoje pois `precos_base` vazio, mas bomba latente); [P1] a prova de idempotência catalog-wide acima; [P2] tie-break determinístico (`ordem DESC, qtd_ml DESC, id DESC`) no DISTINCT ON.
+
+### Achado lateral (decisão de domínio, fora do escopo do fix)
+"Maior ordem" faz a **344M usar 1.54 ml de corante 1** em vez de 40.05 (ordem 1) ou 41.59 (soma) — provável **subdosagem** se as 2 dosagens forem reais. O oficial já é assim (não-regressão; ninguém reclamou). Avaliar com o balcão/SayerSystem se aquelas 2 dosagens distintas (344M, 997M) deveriam **somar** — se sim, é OUTRA mudança money-path (mudaria a cor ativa).
+
+### Lições (reutilizáveis)
+1. **Edge promove por-batch e devolve 500 → conector não cacheia → re-loop de batch CHEIO.** "batches cheios re-enviando" ⇒ olhar `tint_sync_runs.status='error'` + `tint_sync_errors entity_type='promotion'`, NÃO a coluna `errors` (conta só erro de item no staging; a promoção falha DEPOIS).
+2. **`INSERT...SELECT` em tabela com unique deve deduplicar a chave.** Corante repetido na fórmula é dado REAL do SayerSystem (2 dosagens do mesmo pigmento); via latest-per-key, 1 fórmula venenosa derruba o BATCH inteiro de 1000.
+3. **Identidade > "correto teórico" no money-path:** o oficial usa maior-ordem (talvez subdosando); o fix replica (idempotente) em vez de "consertar" somando — corrigir dosagem de cor ativa é decisão de domínio, não efeito colateral de um fix de re-loop.
+4. **`data_atualizacao` sempre-NULL ⇒ hash-filter sempre ativo** (formula E formulaperson) → re-envio nunca é delta-timestamp. **Staging append + latest-per-key + purge-30d** → crescimento da staging (121k→406k) é re-staging acumulado, **auto-limitado** (sintoma, não dano).
+
+### Pendência do founder
+Deploy money-path: **migration no SQL Editor** (pré-flight `pg_get_functiondef` confirmou prod==repo, sem drift). Após aplicar + próximo sync: o re-loop cessa (`status='error'` some) e o item das 4 cores segue maior-ordem (inalterado). **Decisão de domínio separada** (não bloqueia o fix): avaliar com o balcão se as 2 dosagens distintas (344M corante 1 = 40.05+1.54; 997M corante 3 = 0.385+14.09) deveriam **somar** — se sim, é outra mudança money-path (mudaria a cor ativa).
+
+---
+
 ## Catálogo automático (tint) — fase de reconciliação: dry-run global + auditoria das 252 cores fantasma (2026-06-17, análise; flip pendente)
 
 Preparação para flipar `integration_mode` `shadow_mode`→`automatic_primary` (store `M01`, account `oben`). Análise 100% read-only (psql-ro) + 2ª opinião do Codex (consult); a execução (escrita) é via SQL Editor.

--- a/docs/historico/tintometrico.md
+++ b/docs/historico/tintometrico.md
@@ -37,7 +37,21 @@ PG17 `db/test-tint-promote-dedup-itens.sh` — **11/11 verde**: promove sem abor
 4. **`data_atualizacao` sempre-NULL ⇒ hash-filter sempre ativo** (formula E formulaperson) → re-envio nunca é delta-timestamp. **Staging append + latest-per-key + purge-30d** → crescimento da staging (121k→406k) é re-staging acumulado, **auto-limitado** (sintoma, não dano).
 
 ### Pendência do founder
-Deploy money-path: **migration no SQL Editor** (pré-flight `pg_get_functiondef` confirmou prod==repo, sem drift). Após aplicar + próximo sync: o re-loop cessa (`status='error'` some) e o item das 4 cores segue maior-ordem (inalterado). **Decisão de domínio separada** (não bloqueia o fix): avaliar com o balcão se as 2 dosagens distintas (344M corante 1 = 40.05+1.54; 997M corante 3 = 0.385+14.09) deveriam **somar** — se sim, é outra mudança money-path (mudaria a cor ativa).
+Deploy money-path: **migration no SQL Editor** (pré-flight `pg_get_functiondef` confirmou prod==repo, sem drift). Após aplicar + próximo sync: o re-loop cessa (`status='error'` some) e o item das 4 cores segue maior-ordem (inalterado).
+
+### Decisão de domínio (FECHADA — Claude + Codex, unânime: A = manter max-ordem)
+A 344M usa **1.54ml de corante 1** (ordem 3) em vez de 40.05 (ordem 1) ou 41.59 (soma) — possível subdosagem se as 2 dosagens forem reais. **Decisão: MANTER max-ordem** (= o que o fix já faz; NÃO somar). Razão: está em 1.54 desde o CSV-import **sem reclamação**, `tint_staging_preparacoes` está **vazia** (zero sinal de uso), e mudar **27×** uma cor ativa sem falha observada é pior governança que manter o status quo suspeito-mas-não-contestado (Codex: *"a bigger governance error"*). Auditoria confirma a **344M como ÚNICO caso** no catálogo (descartada/mantida ≥ 5 → razão 26×; 629N/638S = duplicação idêntica, 997M descartou a menor). Se o balcão um dia contestar a cor, é `UPDATE` pontual de 1 linha. Safeguard periódico (sugestão do Codex):
+```sql
+WITH r AS (SELECT si.staging_formula_id, si.id_corante, si.qtd_ml,
+  row_number() OVER (PARTITION BY si.staging_formula_id, si.id_corante ORDER BY si.ordem DESC, si.qtd_ml DESC, si.id DESC) rn
+  FROM tint_staging_formula_itens si JOIN tint_staging_formulas s ON s.id=si.staging_formula_id
+  WHERE s.account='oben' AND s.store_code='M01' AND s.personalizada=false),
+agg AS (SELECT staging_formula_id, id_corante, max(qtd_ml) FILTER (WHERE rn=1) kept,
+  max(qtd_ml) FILTER (WHERE rn>1) maior_descartada FROM r GROUP BY 1,2 HAVING count(*)>1)
+SELECT s.cor_id, a.id_corante, a.kept, a.maior_descartada, round((a.maior_descartada/nullif(a.kept,0))::numeric,1) razao
+FROM agg a JOIN tint_staging_formulas s ON s.id=a.staging_formula_id
+WHERE a.maior_descartada/nullif(a.kept,0) >= 5 ORDER BY razao DESC;  -- hoje: só 344M (26x)
+```
 
 ---
 

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **277** custom migrations totais
-- **1003** objetos esperados (criados por estas migrations)
+- **279** custom migrations totais
+- **1005** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 283
+  - `function`: 285
   - `rls_policy`: 219
   - `index`: 186
   - `table`: 108
@@ -2390,6 +2390,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.cleanup_orphan_score_on_carteira_delete` | — |
 | `trigger` | `public.trg_carteira_cleanup_orphan_score` | `carteira_assignments` |
 
+### `20260622130000_tint_promote_nome_cor_fallback.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tint_promote_sync_run` | — |
+
 ### `20260622140000_apply_score_updates_persiste_base_vendas.sql`
 
 | Tipo | Objeto | Parent |
@@ -2401,6 +2407,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.apply_score_updates` | — |
+
+### `20260622210000_tint_promote_dedup_itens_corante.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tint_promote_sync_run` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 277
+-- Total de custom migrations: 279
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -295,8 +295,10 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260621120000', 'seed_targets_faltantes_rpc', '20260621120000_seed_targets_faltantes_rpc.sql'),
   ('20260621130000', 'fcs_guard_flagged_insert', '20260621130000_fcs_guard_flagged_insert.sql'),
   ('20260622120000', 'trigger_cleanup_orphan_score_on_carteira_delete', '20260622120000_trigger_cleanup_orphan_score_on_carteira_delete.sql'),
+  ('20260622130000', 'tint_promote_nome_cor_fallback', '20260622130000_tint_promote_nome_cor_fallback.sql'),
   ('20260622140000', 'apply_score_updates_persiste_base_vendas', '20260622140000_apply_score_updates_persiste_base_vendas.sql'),
-  ('20260622160000', 'apply_score_updates_guard_full_update', '20260622160000_apply_score_updates_guard_full_update.sql')
+  ('20260622160000', 'apply_score_updates_guard_full_update', '20260622160000_apply_score_updates_guard_full_update.sql'),
+  ('20260622210000', 'tint_promote_dedup_itens_corante', '20260622210000_tint_promote_dedup_itens_corante.sql')
 )
 SELECT
   e.version,
@@ -1316,8 +1318,10 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fcs_guard_flagged_insert', 'trigger', 'public', 'trg_fcs_block_flagged_insert', 'farmer_client_scores'),
   ('trigger_cleanup_orphan_score_on_carteira_delete', 'function', 'public', 'cleanup_orphan_score_on_carteira_delete', ''),
   ('trigger_cleanup_orphan_score_on_carteira_delete', 'trigger', 'public', 'trg_carteira_cleanup_orphan_score', 'carteira_assignments'),
+  ('tint_promote_nome_cor_fallback', 'function', 'public', 'tint_promote_sync_run', ''),
   ('apply_score_updates_persiste_base_vendas', 'function', 'public', 'apply_score_updates', ''),
-  ('apply_score_updates_guard_full_update', 'function', 'public', 'apply_score_updates', '')
+  ('apply_score_updates_guard_full_update', 'function', 'public', 'apply_score_updates', ''),
+  ('tint_promote_dedup_itens_corante', 'function', 'public', 'tint_promote_sync_run', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260622210000_tint_promote_dedup_itens_corante.sql
+++ b/supabase/migrations/20260622210000_tint_promote_dedup_itens_corante.sql
@@ -1,0 +1,715 @@
+-- 20260622210000_tint_promote_dedup_itens_corante.sql
+-- MUDANÇA money-path (estanca RE-LOOP): a promoção DEDUPLICA itens por (formula_id, corante_id) no
+-- INSERT de tint_formula_itens. Revelado 22/06 investigando re-envio residual (~75k re-stagings/dia em
+-- batches CHEIOS de 1000): 4 cores PADRÃO ATIVAS (344M/629N/638S/997M - BS) têm o MESMO corante em 2
+-- slots (dosagem em 2 etapas). O conector manda 2 itens; o INSERT SEM dedup viola o unique
+-- tint_formula_itens_formula_id_corante_id_key (23505) → ROLLBACK do batch → a edge devolve 500 → o
+-- conector não cacheia o lote → re-envia o batch CHEIO p/ sempre. Como a promoção usa latest-per-key
+-- restrito aos PARES tocados, essas 4 cores envenenam TODO batch que toca seus pares (18 prod/51 bases
+-- ≈ 1000 fórmulas reféns, re-staged 41×/dia). lock timeout (55P03) era colateral da contention → cessa
+-- junto. Fix: DISTINCT ON (formula_id, corante_id) ORDER BY ordem DESC = MAIOR ORDEM VENCE — idêntico
+-- ao oficial CSV-import (prod: 344M c1=ordem3=1.54, 997M c3=ordem5=14.09) → IDEMPOTENTE, zero mudança
+-- de dosagem. CREATE OR REPLACE — a última vence; inclui tudo da cadeia. PG17
+-- db/test-tint-promote-dedup-itens.sh + Codex. SQL Editor (§deploy.md).
+--
+-- [HERDADO da 20260622130000_tint_promote_nome_cor_fallback.sql:]
+-- MUDANÇA money-path (ROBUSTEZ): a promoção tolera nome_cor VAZIO. Revelado 22/06 pela prova de
+-- tempo-real: cor PERSONALIZADA nova (TESTE CLAUDE, conta oben) chegou com nome_cor NULL (o conector
+-- não resolveu o lookup CorPerson p/ a personcor) → o INSERT em tint_formulas violava a constraint
+-- NOT NULL de nome_cor (23502) e derrubava o RUN INTEIRO (rollback; padrão OK, mas a personalizada
+-- nunca entrava). Fix: no _formulas_latest, nome_cor = COALESCE(NULLIF(btrim(nome_cor),''), cor_id) —
+-- stub p/ o código quando vazio (espelha o stub de corante). O nome real entra no próximo upsert
+-- quando o conector for corrigido (mandar o nome + incluí-lo no hash). INCLUI tudo das migrations
+-- anteriores (_skus_novos + COALESCE preço + E4 custo). CREATE OR REPLACE — a última vence. PG17 + Codex.
+--
+-- [HERDADO da 20260618130000_tint_promote_e4_so_com_custo.sql:]
+-- MUDANÇA money-path (CARGA, parte 2): o E4 (recálculo de preço por corante) só dispara quando há
+-- CUSTO no staging_corantes. Incidente 18/06 (no 2º re-flip): o re-envio promoveu 94% das fórmulas
+-- (E2/E3 + COALESCE OK em prod), mas o run de CORANTES travou — a condição antiga
+-- (custo IS NOT NULL OR volume_ml IS NOT NULL) disparava por volume_ml (sempre presente) e recalculava
+-- ~481k fórmulas por corante, uma a uma, num único run → gateway timeout → advisory lock preso →
+-- cascata 55P03. O SayerSystem NÃO manda custo (§14, preço vem do Omie) → sem custo o recálculo dá
+-- NULL e o COALESCE preserva o piso: era carga 100% inútil. Fix: condição vira só `custo IS NOT NULL`.
+-- INCLUI tudo da 20260617150000 (re-expansão só skus novos) + da 130000 (COALESCE preço). CREATE OR
+-- REPLACE — a última a recriar vence. Provado em PG17 + Codex.
+--
+-- [HERDADO da 20260617150000_tint_promote_reexpand_skus_novos.sql:]
+-- MUDANÇA money-path (CARGA): a re-expansão de fórmulas (E2/E3) dispara SÓ para pares de skus
+-- REALMENTE NOVOS (embalagem nova p/ o par), não para TODO sku tocado no run. Incidente 17/06: o
+-- flip→automatic_primary + re-envio em massa fez o run de catalogs (todos os 220 skus) re-expandir
+-- TODAS as ~121k fórmulas de uma vez → gateway timeout → conexão idle-in-transaction segurando o
+-- advisory lock → cascata de lock timeout (55P03) → a promoção NUNCA completou. Fix: _skus_novos
+-- (pares de _tp_sku que ainda NÃO existem em tint_skus) entra no _pares no lugar de _tp_sku. Re-envio:
+-- catalogs re-expande 0 (skus já existem); formulas distribuem a carga por lote. Embalagem NOVA →
+-- re-expande só aquele par (§11 P1-C preservado). INCLUI o COALESCE de preço da 20260617130000
+-- (CREATE OR REPLACE — a última a recriar vence). Provado em PG17 + Codex.
+--
+-- [HERDADO da 20260617130000_tint_promote_preserva_preco.sql:]
+-- MUDANÇA money-path (PREÇO): a promoção PRESERVA preco_final_sayersystem quando o recálculo dá
+-- NULL — COALESCE(novo, atual) em E2 (upsert) e E4 (recálculo por insumo). Motivo: a fonte de
+-- preço da base (tint_staging_precos_base) NUNCA é populada (precos_base não existe no SayerSystem;
+-- o preço do balcão vem do Omie via get_tint_price). Sem este COALESCE, o flip→automatic_primary
+-- gravaria preco_final_sayersystem=NULL em TODA fórmula promovida, derrubando o PISO que
+-- select-price.ts usa (regra 3: mantém o MAIOR entre calc e CSV) → subfaturaria ~19k cores onde
+-- calc<CSV. Com o COALESCE, a promoção atualiza o CATÁLOGO (cores/fórmulas/itens) SEM tocar no
+-- preço existente; cor NOVA fica com preço NULL (degradação honesta — sem piso histórico, o balcão
+-- usa o calc do Omie). Espelha o padrão COALESCE já usado p/ corantes (preco_litro) nesta função.
+-- Provado em PG17: db/test-tint-promote-preserva-preco.sh (preservação · cor-nova-NULL · recálculo
+-- legítimo com precos_base · falsificação). Codex challenge (sem P1): NULL NÃO vira R$0/venda
+-- indevida (gate de select-price.ts + useTintColorSelect) e o RHS do ON CONFLICT lê a linha
+-- pré-update. 3 [P2] da classe "piso stale" (o COALESCE mantém o CSV quando o recálculo dá NULL
+-- → o balcão, regra 3 MAIOR, pode vender CARO demais se o preço devia baixar) = a decisão §14(3)
+-- (manter o CSV, NÃO baixar por engano), não regressão. Follow-up conhecido: reativação
+-- (desativada_em=NULL) de cor que volta com receita diferente preserva o preço antigo como piso.
+-- O RESTO é VERBATIM da 20260615160000 (a última a recriar vence; §database.md).
+--
+-- [HERDADO de 20260615160000_tint_promote_set_based.sql:]
+-- Reescreve o MOTOR de fórmulas (E2/E3) da tint_promote_sync_run de PROCEDURAL (FOR LOOP
+-- aninhado: O(fórmulas × embalagens), com tint_calc_preco_final por linha) para SET-BASED
+-- (INSERT...SELECT em massa). Mesma regra de negócio, executada em lote.
+--
+-- Motivo (flip 15/06): o loop processava ~481k expansões 1-a-1 chamando tint_calc_preco_final
+-- (subqueries por chamada) — inviável dentro do request do gateway na carga inicial (statement
+-- timeout 57014 → depois lock timeout + upstream timeout em cascata). Os índices de
+-- 20260615140000 ajudaram mas não bastaram: o gargalo é a NATUREZA procedural. Set-based, a
+-- mesma carga roda em segundos (1 INSERT...SELECT com joins, não 481k iterações).
+--
+-- IDENTIDADE (money-path, precisão > recall): o conjunto de fórmulas/itens/preços promovido é
+-- IDÊNTICO ao do loop. Espelho dos oráculos src/lib/tint/sync-promote.ts (expandirFormula /
+-- precoFinalSayer) — mesma regra de 3 (fator = vol_destino / vol_formulacao), mesmo preço pág 9
+-- (base×(1+imp/100)×(1+marg/100) + Σ corante×qtd/vol), MESMO NULL-honesto (base ausente OU
+-- qualquer corante sem custo/volume → preço NULL, NUNCA 0). Provado em PG17:
+-- db/test-tint-promote.sh — os 12 cenários C1-C12 (valores do oráculo, inalterados) + um cenário
+-- de VOLUME que roda o loop ANTIGO (preservado via RENAME no teste) e o set-based sobre o MESMO
+-- seed e exige EXCEPT vazio nos dois sentidos (identidade contábil) + falsificação.
+--
+-- O QUE NÃO MUDA (copiado VERBATIM da 20260611190000 — a última a recriar vence; §database.md):
+--   S1 advisory lock · upsert de importação · latest-staging-por-chave (_tp_*) · E1 catálogo +
+--   loop de skus · E4 recálculo por insumo (tint_recalc_preco_oficial) · E5 contadores/purge.
+--   Os helpers (tint_calc_preco_final / tint_recalc_preco_oficial / tint_ensure_corante_stub /
+--   tint_apply_keys_snapshot) ficam como estão (20260609150000/20260611190000) — esta migration
+--   só faz CREATE OR REPLACE da tint_promote_sync_run. tint_calc_preco_final deixa de ser chamada
+--   pela promoção (o preço virou CTE em massa), mas continua definida (sem DROP).
+--
+-- SET statement_timeout='300s' fica NO CABEÇALHO da função: CREATE OR REPLACE substitui as
+-- cláusulas SET, então sem isto o ALTER de 20260615140000 seria perdido. Carga inicial é pesada
+-- por natureza; deltas diários são leves. Migration manual via SQL Editor (§deploy.md).
+
+CREATE OR REPLACE FUNCTION public.tint_promote_sync_run(p_sync_run_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER
+SET search_path = public
+SET statement_timeout = '300s'
+AS $$
+DECLARE
+  v_run            record;
+  v_account        text;
+  v_store          text;
+  v_importacao_id  uuid;
+  v_promovidas     int := 0;
+  v_erros          int := 0;
+  v_recalc         int := 0;
+  v_tmp            int := 0;
+  v_zero_uuid      constant uuid := '00000000-0000-0000-0000-000000000000';
+  r                record;
+  v_produto_id     uuid;
+  v_base_id        uuid;
+  v_subcolecao_id  uuid;
+  v_sku_id         uuid;
+  v_emb_id         uuid;
+  v_formula_id     uuid;
+  v_fator          numeric;
+  v_preco          numeric;
+  v_qtd_vendaveis  int;
+BEGIN
+  SELECT * INTO v_run FROM tint_sync_runs WHERE id = p_sync_run_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'run não encontrado');
+  END IF;
+  v_account := v_run.account;
+  v_store   := v_run.store_code;
+
+  -- S1 (codex P1-7): serializa promoções concorrentes do mesmo (account+store). Sem isto, dois
+  -- runs simultâneos do mesmo par leem o latest-staging e escrevem o oficial interleavados (o mais
+  -- VELHO podia vencer). Lock de transação → libera automaticamente no commit/rollback.
+  PERFORM pg_advisory_xact_lock(hashtext('tint_sync:' || v_account || ':' || v_store));
+
+  -- Cria/reusa o registro de importação (reusa a tela de histórico). arquivo_hash = run_id
+  -- colide com UNIQUE(account, arquivo_hash) em re-execução → ON CONFLICT reusa a linha (idempotente).
+  INSERT INTO tint_importacoes (account, tipo, arquivo_nome, arquivo_hash, status)
+  VALUES (v_account, 'sync_agent', 'sync:' || p_sync_run_id::text, p_sync_run_id::text, 'processando')
+  ON CONFLICT (account, arquivo_hash) DO UPDATE
+    SET status = 'processando', registros_importados = 0, registros_erro = 0
+  RETURNING id INTO v_importacao_id;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- LATEST-STAGING-POR-CHAVE: views temporárias com a linha mais recente por chave
+  -- natural (across TODOS os runs do mesmo account+store), restritas às chaves
+  -- tocadas POR ESTE run (§11 P1-C). DISTINCT ON (chave) ORDER BY created_at DESC, id DESC.
+  -- ──────────────────────────────────────────────────────────────────────────
+
+  -- Produtos tocados pelo run → latest (descrição mais recente; stub se ausente).
+  CREATE TEMP TABLE _tp_prod ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto FROM tint_staging_produtos
+    WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto) s.cod_produto, s.descricao
+    FROM tint_staging_produtos s
+    JOIN chaves c ON c.cod_produto = s.cod_produto
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_base ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_base_sayersystem FROM tint_staging_bases
+    WHERE sync_run_id = p_sync_run_id AND id_base_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_base_sayersystem) s.id_base_sayersystem, s.descricao
+    FROM tint_staging_bases s
+    JOIN chaves c ON c.id_base_sayersystem = s.id_base_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_base_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_base_sayersystem, descricao FROM latest;
+
+  CREATE TEMP TABLE _tp_emb ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_embalagem_sayersystem FROM tint_staging_embalagens
+    WHERE sync_run_id = p_sync_run_id AND id_embalagem_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_embalagem_sayersystem) s.id_embalagem_sayersystem, s.descricao, s.volume_ml
+    FROM tint_staging_embalagens s
+    JOIN chaves c ON c.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_embalagem_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_embalagem_sayersystem, descricao, volume_ml FROM latest;
+
+  -- Corantes tocados → latest (descricao + preco_litro + custo/volume p/ preço).
+  CREATE TEMP TABLE _tp_cor ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT id_corante_sayersystem FROM tint_staging_corantes
+    WHERE sync_run_id = p_sync_run_id AND id_corante_sayersystem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.id_corante_sayersystem)
+           s.id_corante_sayersystem, s.descricao, s.preco_litro, s.custo, s.volume_ml
+    FROM tint_staging_corantes s
+    JOIN chaves c ON c.id_corante_sayersystem = s.id_corante_sayersystem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.id_corante_sayersystem, s.created_at DESC, s.id DESC
+  )
+  SELECT id_corante_sayersystem, descricao, preco_litro, custo, volume_ml FROM latest;
+
+  -- Skus tocados → latest por (cod_produto,id_base,id_embalagem).
+  CREATE TEMP TABLE _tp_sku ON COMMIT DROP AS
+  WITH chaves AS (
+    SELECT DISTINCT cod_produto, id_base, id_embalagem FROM tint_staging_skus
+    WHERE sync_run_id = p_sync_run_id
+      AND cod_produto IS NOT NULL AND id_base IS NOT NULL AND id_embalagem IS NOT NULL
+  ),
+  latest AS (
+    SELECT DISTINCT ON (s.cod_produto, s.id_base, s.id_embalagem)
+           s.cod_produto, s.id_base, s.id_embalagem
+    FROM tint_staging_skus s
+    JOIN chaves c ON c.cod_produto = s.cod_produto AND c.id_base = s.id_base AND c.id_embalagem = s.id_embalagem
+    WHERE s.account = v_account AND s.store_code = v_store
+    ORDER BY s.cod_produto, s.id_base, s.id_embalagem, s.created_at DESC, s.id DESC
+  )
+  SELECT cod_produto, id_base, id_embalagem FROM latest;
+
+  -- 20260617 (fix CARGA): pares de skus REALMENTE NOVOS (ainda não existem no oficial). SÓ esses
+  -- precisam re-expandir (embalagem nova p/ o par). Capturado ANTES do upsert de skus (E1/loop) —
+  -- depois eles já existiriam. Sem isto, um run de catalogs com TODOS os skus re-expandiria TODAS as
+  -- fórmulas de uma vez → gateway timeout → advisory lock preso → lock timeout (incidente 17/06).
+  CREATE TEMP TABLE _skus_novos ON COMMIT DROP AS
+  SELECT DISTINCT t.cod_produto, t.id_base
+  FROM _tp_sku t
+  WHERE NOT EXISTS (
+    SELECT 1 FROM tint_skus sk
+    JOIN tint_produtos   p ON p.id = sk.produto_id  AND p.account = v_account AND p.cod_produto             = t.cod_produto
+    JOIN tint_bases      b ON b.id = sk.base_id      AND b.account = v_account AND b.id_base_sayersystem     = t.id_base
+    JOIN tint_embalagens e ON e.id = sk.embalagem_id AND e.account = v_account AND e.id_embalagem_sayersystem = t.id_embalagem
+  );
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E1) Catálogo: upsert oficial a partir do latest-staging (espelha onConflict do tint-import).
+  -- ──────────────────────────────────────────────────────────────────────────
+  INSERT INTO tint_produtos (account, cod_produto, descricao)
+  SELECT v_account, cod_produto, COALESCE(descricao, cod_produto) FROM _tp_prod
+  ON CONFLICT (account, cod_produto) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+  SELECT v_account, id_base_sayersystem, COALESCE(descricao, id_base_sayersystem) FROM _tp_base
+  ON CONFLICT (account, id_base_sayersystem) DO UPDATE SET descricao = EXCLUDED.descricao;
+
+  -- volume_ml NULL/0 do staging NUNCA rebaixa o volume oficial existente (espelha o
+  -- COALESCE/NULLIF do corante): senão a expansão (guard volume_ml>0) dropa as fórmulas
+  -- da embalagem silenciosamente. INSERT de embalagem nova com volume NULL → stub 0 (não
+  -- vendável, não satisfaz o guard de expansão). descricao idem (NULL não apaga a oficial).
+  INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+  SELECT v_account, id_embalagem_sayersystem, COALESCE(descricao, id_embalagem_sayersystem), COALESCE(volume_ml, 0) FROM _tp_emb
+  ON CONFLICT (account, id_embalagem_sayersystem) DO UPDATE
+    SET descricao = COALESCE(EXCLUDED.descricao, tint_embalagens.descricao),
+        volume_ml = COALESCE(NULLIF(EXCLUDED.volume_ml, 0), tint_embalagens.volume_ml);
+
+  -- Corantes: volume_total_ml é NOT NULL no oficial → preferir staging volume_ml, senão preservar
+  -- o existente, senão 1000 (default do CSV-import p/ stub). preco_litro derivado de custo/volume
+  -- (R$/L) quando os dois presentes; senão preserva o staging.preco_litro.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml, preco_litro)
+  SELECT
+    v_account,
+    c.id_corante_sayersystem,
+    COALESCE(c.descricao, c.id_corante_sayersystem),
+    COALESCE(c.volume_ml, ex.volume_total_ml, 1000),
+    CASE
+      WHEN c.custo IS NOT NULL AND c.volume_ml IS NOT NULL AND c.volume_ml > 0
+        THEN round((c.custo / c.volume_ml * 1000)::numeric, 2)
+      ELSE c.preco_litro
+    END
+  FROM _tp_cor c
+  LEFT JOIN tint_corantes ex ON ex.account = v_account AND ex.id_corante_sayersystem = c.id_corante_sayersystem
+  ON CONFLICT (account, id_corante_sayersystem) DO UPDATE
+    SET descricao        = EXCLUDED.descricao,
+        volume_total_ml  = EXCLUDED.volume_total_ml,
+        preco_litro      = COALESCE(EXCLUDED.preco_litro, tint_corantes.preco_litro);
+
+  -- Skus de produto_base_embalagem: resolve FKs (cria stub de produto/base/embalagem se a
+  -- linha do sku referenciar id ainda não-visto no run — espelha ensure* do CSV).
+  FOR r IN SELECT cod_produto, id_base, id_embalagem FROM _tp_sku LOOP
+    INSERT INTO tint_produtos (account, cod_produto, descricao)
+    VALUES (v_account, r.cod_produto, r.cod_produto)
+    ON CONFLICT (account, cod_produto) DO NOTHING;
+    INSERT INTO tint_bases (account, id_base_sayersystem, descricao)
+    VALUES (v_account, r.id_base, r.id_base)
+    ON CONFLICT (account, id_base_sayersystem) DO NOTHING;
+    INSERT INTO tint_embalagens (account, id_embalagem_sayersystem, descricao, volume_ml)
+    VALUES (v_account, r.id_embalagem, r.id_embalagem, 0)
+    ON CONFLICT (account, id_embalagem_sayersystem) DO NOTHING;
+
+    SELECT id INTO v_produto_id FROM tint_produtos WHERE account = v_account AND cod_produto = r.cod_produto;
+    SELECT id INTO v_base_id    FROM tint_bases    WHERE account = v_account AND id_base_sayersystem = r.id_base;
+    SELECT id INTO v_emb_id     FROM tint_embalagens WHERE account = v_account AND id_embalagem_sayersystem = r.id_embalagem;
+
+    INSERT INTO tint_skus (account, produto_id, base_id, embalagem_id)
+    VALUES (v_account, v_produto_id, v_base_id, v_emb_id)
+    ON CONFLICT (account, produto_id, base_id, embalagem_id) DO NOTHING;
+  END LOOP;
+
+  -- ══════════════════════════════════════════════════════════════════════════
+  -- E2/E3) Fórmulas — SET-BASED (substitui o FOR LOOP aninhado procedural).
+  --   Mesma regra de negócio do loop, em massa. Pares afetados + latest-staging por chave de
+  --   fórmula são VERBATIM do loop; o que muda é a expansão/preço/upsert/itens (INSERT...SELECT).
+  -- ══════════════════════════════════════════════════════════════════════════
+
+  -- Pares (cod_produto, id_base) afetados = pares com fórmula tocada NESTE run ∪ pares de sku
+  -- NOVO (§11 P1-C: embalagem nova ⇒ re-expandir). 20260617 (fix CARGA): _skus_novos no lugar de
+  -- _tp_sku — sku re-enviado (já existente) NÃO dispara re-expansão; senão um run de catalogs com
+  -- todos os skus re-expandiria TODAS as fórmulas de uma vez (lock timeout, incidente 17/06).
+  CREATE TEMP TABLE _pares ON COMMIT DROP AS
+  SELECT DISTINCT cod_produto, id_base FROM (
+    SELECT cod_produto, id_base FROM tint_staging_formulas
+      WHERE sync_run_id = p_sync_run_id AND cod_produto IS NOT NULL AND id_base IS NOT NULL
+    UNION
+    SELECT cod_produto, id_base FROM _skus_novos
+  ) u;
+
+  -- Latest staging de fórmula por (cor_id, cod_produto, id_base, sub_norm, personalizada),
+  -- restrita aos pares afetados — across TODOS os runs.
+  CREATE TEMP TABLE _formulas_latest ON COMMIT DROP AS
+  WITH alvo AS (
+    SELECT s.*
+    FROM tint_staging_formulas s
+    JOIN _pares p ON p.cod_produto = s.cod_produto AND p.id_base = s.id_base
+    WHERE s.account = v_account AND s.store_code = v_store
+      AND s.cor_id IS NOT NULL AND s.cod_produto IS NOT NULL AND s.id_base IS NOT NULL
+  )
+  SELECT DISTINCT ON (cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada)
+         id AS staging_formula_id, cor_id,
+         -- 20260622 (fix nome_cor NULL): nome de cor PERSONALIZADA pode vir VAZIO do conector (lookup
+         -- CorPerson não resolveu) → a constraint NOT NULL de tint_formulas.nome_cor derrubava o RUN
+         -- INTEIRO (23502). Fallback p/ cor_id (stub, espelha o corante stub). Nunca abortar a promoção
+         -- por um campo de DISPLAY ausente; o nome real entra no próximo upsert quando o conector resolver.
+         -- Codex 22/06: CASE (não COALESCE+btrim) p/ NÃO trimar nome legítimo com espaço — só
+         -- substitui quando NULL/vazio, preservando o nome_cor original VERBATIM.
+         CASE WHEN nome_cor IS NULL OR btrim(nome_cor) = '' THEN cor_id ELSE nome_cor END AS nome_cor,
+         cod_produto, id_base, id_embalagem,
+         subcolecao, volume_final_ml, personalizada
+  FROM alvo
+  ORDER BY cor_id, cod_produto, id_base, COALESCE(subcolecao, ''), personalizada,
+           created_at DESC, id DESC;
+
+  -- Resolve FK produto/base por JOIN (não SELECT por linha). LEFT JOIN p/ separar os não-resolvidos.
+  CREATE TEMP TABLE _fl_resolved ON COMMIT DROP AS
+  SELECT fl.*, p.id AS produto_id, b.id AS base_id
+  FROM _formulas_latest fl
+  LEFT JOIN tint_produtos p ON p.account = v_account AND p.cod_produto = fl.cod_produto
+  LEFT JOIN tint_bases    b ON b.account = v_account AND b.id_base_sayersystem = fl.id_base;
+
+  -- Guard 1 — produto/base não resolvido (catálogo incompleto). Espelha o 1º CONTINUE do loop.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'produto/base não resolvido (catálogo incompleto)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NULL OR fl.base_id IS NULL;
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Subcoleções: ensure p/ fórmulas com produto/base resolvido e subcoleção não-vazia (o loop
+  -- ensura DEPOIS do guard de produto/base, ANTES dos guards de volume/vendável). id = texto CRU.
+  INSERT INTO tint_subcolecoes (account, id_subcolecao_sayersystem, descricao)
+  SELECT DISTINCT v_account, fl.subcolecao, fl.subcolecao
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+  ON CONFLICT (account, id_subcolecao_sayersystem) DO NOTHING;
+
+  -- Guard 2 — volume de formulação <= 0/nulo (entre os resolvidos). Espelha o 2º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'volume de formulação <= 0 ou nulo',
+         jsonb_build_object('volume_final_ml', fl.volume_final_ml)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND (fl.volume_final_ml IS NULL OR fl.volume_final_ml <= 0);
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Guard 3 — zero embalagens vendáveis para o par (entre resolvidos com volume OK). 3º CONTINUE.
+  INSERT INTO tint_sync_errors (sync_run_id, entity_type, entity_id, error_message, error_details)
+  SELECT p_sync_run_id, 'formula_promote', fl.cor_id,
+         'zero embalagens vendáveis para o par (produto,base)',
+         jsonb_build_object('cod_produto', fl.cod_produto, 'id_base', fl.id_base)
+  FROM _fl_resolved fl
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND NOT EXISTS (
+      SELECT 1 FROM tint_skus sk
+      JOIN tint_embalagens e ON e.id = sk.embalagem_id
+      WHERE sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+        AND e.volume_ml IS NOT NULL AND e.volume_ml > 0
+    );
+  GET DIAGNOSTICS v_tmp = ROW_COUNT; v_erros := v_erros + v_tmp;
+
+  -- Expansão (regra de 3): 1 linha por (fórmula que passou TODOS os guards × embalagem vendável).
+  -- fator = vol_destino / vol_formulacao (espelho expandirFormula). subcolecao_id resolvido por
+  -- LEFT JOIN (NULL quando vazio). eid = chave surrogate p/ casar o preço.
+  CREATE TEMP TABLE _expand ON COMMIT DROP AS
+  SELECT
+    row_number() OVER () AS eid,
+    fl.staging_formula_id, fl.cor_id, fl.nome_cor, fl.cod_produto, fl.id_base, fl.personalizada,
+    fl.subcolecao,  -- texto CRU (p/ o desempate espelhar a ordem do loop; ver _expand_uniq)
+    fl.produto_id, fl.base_id,
+    sub.id AS subcolecao_id,
+    sk.id  AS sku_id,
+    sk.embalagem_id AS emb_id,
+    e.id_embalagem_sayersystem AS id_emb,
+    e.volume_ml AS vol_destino,
+    (e.volume_ml / fl.volume_final_ml) AS fator
+  FROM _fl_resolved fl
+  JOIN tint_skus sk ON sk.account = v_account AND sk.produto_id = fl.produto_id AND sk.base_id = fl.base_id
+  JOIN tint_embalagens e ON e.id = sk.embalagem_id
+  LEFT JOIN tint_subcolecoes sub
+    ON sub.account = v_account
+   AND fl.subcolecao IS NOT NULL AND btrim(fl.subcolecao) <> ''
+   AND sub.id_subcolecao_sayersystem = fl.subcolecao
+  WHERE fl.produto_id IS NOT NULL AND fl.base_id IS NOT NULL
+    AND fl.volume_final_ml IS NOT NULL AND fl.volume_final_ml > 0
+    AND e.volume_ml IS NOT NULL AND e.volume_ml > 0;
+
+  -- v_promovidas = nº de expansões (= incrementos do loop interno, inclui colisão personalizada).
+  SELECT count(*) INTO v_promovidas FROM _expand;
+
+  -- Preço pág 9 por expansão — SET-BASED, NULL-honesto (espelho precoFinalSayer + S2 store + S3
+  -- latest não-nulo). base ausente OU qualquer corante sem custo/volume(>0)/finito → preço NULL.
+  CREATE TEMP TABLE _preco ON COMMIT DROP AS
+  WITH base_latest AS (   -- S2: store_code; S3: custo IS NOT NULL. Latest por chave de base.
+    SELECT DISTINCT ON (cod_produto, id_base, id_embalagem)
+           cod_produto, id_base, id_embalagem, custo, imposto_pct, margem_pct
+    FROM tint_staging_precos_base
+    WHERE account = v_account AND store_code = v_store AND custo IS NOT NULL
+    ORDER BY cod_produto, id_base, id_embalagem, created_at DESC, id DESC
+  ),
+  cor_latest AS (         -- S2: store_code; S3: custo+volume NÃO-NULOS. Latest por corante.
+    SELECT DISTINCT ON (id_corante_sayersystem)
+           id_corante_sayersystem, custo, volume_ml
+    FROM tint_staging_corantes
+    WHERE account = v_account AND store_code = v_store
+      AND custo IS NOT NULL AND volume_ml IS NOT NULL
+    ORDER BY id_corante_sayersystem, created_at DESC, id DESC
+  ),
+  -- 20260622210000 (Codex P1 — consistência item↔preço): deduplica os itens por
+  -- (staging_formula_id, id_corante) = MAX-ordem, IGUAL ao INSERT de tint_formula_itens. Senão o preço
+  -- somaria o corante repetido (BOM "todos os itens") enquanto o item ARMAZENADO guarda só o max-ordem
+  -- (BOM "1 por corante") — duas definições de fórmula na mesma promoção. Hoje é dead-code em prod
+  -- (precos_base vazio → soma NULL → COALESCE preserva o piso), mas alinha os 2 caminhos para o dia em
+  -- que precos_base for populado. Mesma ordem de desempate do INSERT de itens.
+  itens_dedup AS (
+    SELECT DISTINCT ON (staging_formula_id, id_corante) staging_formula_id, id_corante, qtd_ml
+      FROM tint_staging_formula_itens
+     WHERE id_corante IS NOT NULL AND id_corante <> '' AND COALESCE(qtd_ml, 0) > 0
+     ORDER BY staging_formula_id, id_corante, ordem DESC, qtd_ml DESC, id DESC
+  ),
+  itens AS (              -- Σ corantes por expansão; flag de corante faltante (NULL-honesto).
+    SELECT ex.eid,
+           bool_or(
+             cl.id_corante_sayersystem IS NULL
+             OR cl.volume_ml IS NULL OR cl.volume_ml <= 0
+             OR NOT (cl.custo > '-Infinity'::numeric AND cl.custo < 'Infinity'::numeric)
+           ) AS faltante,
+           sum(CASE WHEN cl.volume_ml > 0 THEN (cl.custo / cl.volume_ml) * (si.qtd_ml * ex.fator) ELSE 0 END) AS soma
+    FROM _expand ex
+    JOIN itens_dedup si ON si.staging_formula_id = ex.staging_formula_id
+    LEFT JOIN cor_latest cl ON cl.id_corante_sayersystem = si.id_corante
+    GROUP BY ex.eid
+  )
+  SELECT
+    ex.eid,
+    CASE
+      WHEN bl.custo IS NULL THEN NULL                                                   -- base ausente
+      WHEN NOT (bl.custo > '-Infinity'::numeric AND bl.custo < 'Infinity'::numeric) THEN NULL  -- custo não-finito
+      WHEN COALESCE(it.faltante, false) THEN NULL                                       -- corante sem preço
+      ELSE round(
+        ( bl.custo * (1 + COALESCE(bl.imposto_pct, 0) / 100) * (1 + COALESCE(bl.margem_pct, 0) / 100) )
+        + COALESCE(it.soma, 0)
+      , 2)
+    END AS preco
+  FROM _expand ex
+  LEFT JOIN base_latest bl
+    ON bl.cod_produto = ex.cod_produto AND bl.id_base = ex.id_base AND bl.id_embalagem = ex.id_emb
+  LEFT JOIN itens it ON it.eid = ex.eid;
+
+  -- Dedup pela CHAVE OFICIAL (uq_tint_formulas_chave — SEM personalizada): INSERT...SELECT não pode
+  -- ter a mesma chave 2× no mesmo comando (cardinality violation). O loop processa _formulas_latest
+  -- em ORDER BY ... COALESCE(subcolecao,'') ASC, personalizada ASC e o ÚLTIMO vence o upsert. A chave
+  -- oficial COLAPSA subcoleções que resolvem ao MESMO subcolecao_id (NULL e whitespace-only viram
+  -- NULL → btrim vazio), então a colisão pode ser entre linhas com COALESCE(subcolecao,'') DIFERENTE
+  -- (não só personalizada). Para escolher o MESMO vencedor do loop, desempata por COALESCE(subcolecao,
+  -- '') DESC PRIMEIRO, depois personalizada DESC (= o último que o loop processaria), eid DESC final.
+  CREATE TEMP TABLE _expand_uniq ON COMMIT DROP AS
+  SELECT DISTINCT ON (ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id)
+         ex.staging_formula_id, ex.cor_id, ex.nome_cor, ex.personalizada,
+         ex.produto_id, ex.base_id, ex.subcolecao_id, ex.sku_id, ex.emb_id, ex.vol_destino, ex.fator,
+         pr.preco
+  FROM _expand ex
+  JOIN _preco pr ON pr.eid = ex.eid
+  ORDER BY ex.cor_id, ex.produto_id, ex.base_id, COALESCE(ex.subcolecao_id, v_zero_uuid), ex.emb_id,
+           COALESCE(ex.subcolecao, '') DESC, ex.personalizada DESC, ex.eid DESC;
+
+  -- Corante stubs em massa ANTES dos itens (espelha tint_ensure_corante_stub: volume 1000).
+  -- A partir de _expand (todas as expansões, inclui colisão) p/ casar o side-effect do loop.
+  INSERT INTO tint_corantes (account, id_corante_sayersystem, descricao, volume_total_ml)
+  SELECT DISTINCT v_account, si.id_corante, si.id_corante, 1000
+  FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (SELECT DISTINCT staging_formula_id FROM _expand)
+    AND si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+  ON CONFLICT (account, id_corante_sayersystem) DO NOTHING;
+
+  -- Upsert oficial em massa por uq_tint_formulas_chave; desativada_em = NULL (reativa). Captura
+  -- formula_id ↔ (staging_formula_id, fator) p/ os itens (RETURNING casado de volta ao _expand_uniq).
+  CREATE TEMP TABLE _promoted ON COMMIT DROP AS
+  WITH ups AS (
+    INSERT INTO tint_formulas (
+      account, cor_id, nome_cor, produto_id, base_id, embalagem_id, subcolecao_id, sku_id,
+      volume_final_ml, preco_final_sayersystem, personalizada, importacao_id, updated_at, desativada_em
+    )
+    SELECT
+      v_account, eu.cor_id, eu.nome_cor, eu.produto_id, eu.base_id, eu.emb_id, eu.subcolecao_id, eu.sku_id,
+      eu.vol_destino, eu.preco, eu.personalizada, v_importacao_id, now(), NULL
+    FROM _expand_uniq eu
+    ON CONFLICT (account, cor_id, produto_id, base_id, COALESCE(subcolecao_id, '00000000-0000-0000-0000-000000000000'::uuid), embalagem_id)
+    DO UPDATE SET
+      nome_cor                = EXCLUDED.nome_cor,
+      sku_id                  = EXCLUDED.sku_id,
+      volume_final_ml         = EXCLUDED.volume_final_ml,
+      -- 20260617: PRESERVA o preço existente quando o novo é NULL (precos_base vazio → eu.preco NULL).
+      -- Sem isto o flip zeraria o piso de ~19k cores (calc<CSV). Espelha o COALESCE de preco_litro acima.
+      preco_final_sayersystem = COALESCE(EXCLUDED.preco_final_sayersystem, tint_formulas.preco_final_sayersystem),
+      personalizada           = EXCLUDED.personalizada,
+      importacao_id           = EXCLUDED.importacao_id,
+      updated_at              = now(),
+      desativada_em           = NULL
+    RETURNING id, cor_id, produto_id, base_id, subcolecao_id, embalagem_id
+  )
+  SELECT u.id AS formula_id, eu.staging_formula_id, eu.fator
+  FROM ups u
+  JOIN _expand_uniq eu
+    ON eu.cor_id = u.cor_id AND eu.produto_id = u.produto_id AND eu.base_id = u.base_id
+   AND COALESCE(eu.subcolecao_id, v_zero_uuid) = COALESCE(u.subcolecao_id, v_zero_uuid)
+   AND eu.emb_id = u.embalagem_id;
+
+  -- Itens em massa: limpa + reinsere (espelha o delete+insert por fórmula do loop). qtd expandida
+  -- = qtd_formulacao × fator, arredondada a 6 casas (sub-µL — elimina artefato de escala da divisão
+  -- numeric sem mudar o valor prático). Corante já garantido (stub acima) → JOIN resolve o id.
+  DELETE FROM tint_formula_itens fi USING _promoted pr WHERE fi.formula_id = pr.formula_id;
+
+  INSERT INTO tint_formula_itens (formula_id, corante_id, ordem, qtd_ml)
+  -- 20260622210000 (estanca RE-LOOP): DEDUP por (formula_id, corante_id). A FORMULA do SayerSystem
+  -- pode trazer o MESMO corante em 2 slots/ordens (dosagem em 2 etapas; ex. 997M corante 3 = 0.385 +
+  -- 14.09). aggregateFlatFormulaItems envia 2 itens; SEM dedup o INSERT viola o unique
+  -- tint_formula_itens_formula_id_corante_id_key (23505) → ROLLBACK do batch → edge 500 → o conector
+  -- não cacheia o lote → re-envia o batch CHEIO p/ sempre (re-loop). DISTINCT ON ... ORDER BY ordem DESC
+  -- = MAIOR ORDEM VENCE: idêntico ao que o CSV-import já gravou no oficial (validado em prod: 344M
+  -- c1=ordem3, 997M c3=ordem5, 638S) → IDEMPOTENTE, zero mudança de dosagem. NÃO somar (mudaria a
+  -- dosagem/preço de cor ativa; somar dosagens distintas é decisão de domínio separada).
+  SELECT DISTINCT ON (pr.formula_id, co.id)
+         pr.formula_id, co.id, si.ordem, round((si.qtd_ml * pr.fator)::numeric, 6)
+  FROM _promoted pr
+  JOIN tint_staging_formula_itens si ON si.staging_formula_id = pr.staging_formula_id
+  JOIN tint_corantes co ON co.account = v_account AND co.id_corante_sayersystem = si.id_corante
+  WHERE si.id_corante IS NOT NULL AND si.id_corante <> '' AND COALESCE(si.qtd_ml, 0) > 0
+  -- tie-break determinístico (Codex P2): se 2 itens compartilham (formula,corante,ordem) — dado sujo —
+  -- qtd_ml DESC, id DESC torna o pick estável em vez de não-determinístico num caminho money-path.
+  ORDER BY pr.formula_id, co.id, si.ordem DESC, si.qtd_ml DESC, si.id DESC;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E4) Recálculo de preço por mudança de INSUMO (§11 P1-A — caso de uso PRINCIPAL).
+  --   Run tocou precos_base/corantes → recalcula preco_final_sayersystem das fórmulas
+  --   oficiais ATIVAS afetadas, SEM re-expandir itens. NÃO mexe nas fórmulas que E2 já
+  --   tocou (importacao_id = v_importacao_id) — essas já saíram com o preço novo.
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- Pares (produto,base,embalagem oficial) afetados por precos_base deste run.
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, p.cod_produto, b.id_base_sayersystem AS id_base, e.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_precos_base sp
+    JOIN tint_produtos   p ON p.account = v_account AND p.cod_produto = sp.cod_produto
+    JOIN tint_bases      b ON b.account = v_account AND b.id_base_sayersystem = sp.id_base
+    JOIN tint_embalagens e ON e.account = v_account AND e.id_embalagem_sayersystem = sp.id_embalagem
+    JOIN tint_formulas   f ON f.account = v_account AND f.produto_id = p.id AND f.base_id = b.id AND f.embalagem_id = e.id
+    WHERE sp.sync_run_id = p_sync_run_id
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- Fórmulas que usam um corante cujo CUSTO mudou neste run (volume sem custo → preço NULL: inútil).
+  FOR r IN
+    SELECT DISTINCT f.id AS formula_id, f.cor_id, pr.cod_produto, ba.id_base_sayersystem AS id_base, em.id_embalagem_sayersystem AS id_emb
+    FROM tint_staging_corantes sc
+    JOIN tint_corantes      co ON co.account = v_account AND co.id_corante_sayersystem = sc.id_corante_sayersystem
+    JOIN tint_formula_itens fi ON fi.corante_id = co.id
+    JOIN tint_formulas      f  ON f.id = fi.formula_id
+    JOIN tint_produtos      pr ON pr.id = f.produto_id
+    JOIN tint_bases         ba ON ba.id = f.base_id
+    JOIN tint_embalagens    em ON em.id = f.embalagem_id
+    WHERE sc.sync_run_id = p_sync_run_id
+      -- 20260618 (fix CARGA E4): SÓ recalcula quando há CUSTO. O SayerSystem não manda custo (preço vem
+      -- do Omie, §14) → sem isto o re-envio (volume_ml sempre presente) recalculava ~481k fórmulas por
+      -- corante, uma a uma, num único run → gateway timeout → advisory lock preso → cascata (incidente
+      -- 18/06). Sem custo o recálculo dá NULL e o COALESCE preserva o piso — ou seja, seria carga inútil.
+      AND sc.custo IS NOT NULL
+      AND f.account = v_account
+      AND f.desativada_em IS NULL
+      AND (f.importacao_id IS DISTINCT FROM v_importacao_id)
+  LOOP
+    -- S2: +v_store.
+    v_preco := tint_recalc_preco_oficial(v_account, v_store, r.formula_id, r.cod_produto, r.id_base, r.id_emb);
+    -- 20260617: só baixa/sobe se o recálculo deu valor; NULL (sem precos_base) PRESERVA o piso atual.
+    UPDATE tint_formulas SET preco_final_sayersystem = COALESCE(v_preco, preco_final_sayersystem), updated_at = now() WHERE id = r.formula_id;
+    v_recalc := v_recalc + 1;
+  END LOOP;
+
+  -- ──────────────────────────────────────────────────────────────────────────
+  -- E5) Contadores + purge staging SUPERSEDED >30d (preserva latest-per-key) +
+  --     runs órfãos >30min → error.
+  -- ──────────────────────────────────────────────────────────────────────────
+  UPDATE tint_importacoes
+    SET status = 'concluido', registros_importados = v_promovidas, registros_erro = v_erros
+  WHERE id = v_importacao_id;
+
+  UPDATE tint_sync_runs
+    SET inserts = v_promovidas, errors = v_erros, metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('recalculadas', v_recalc)
+  WHERE id = p_sync_run_id;
+
+  -- PURGE: NUNCA apaga a linha MAIS RECENTE por chave natural (account+store) — a promoção
+  -- lê latest-staging-por-chave PRA SEMPRE (recalc por insumo + re-expansão por sku novo
+  -- dependem dela mesmo que o insumo não mude por >30d → nunca é re-enviado). Só remove
+  -- linhas SUPERSEDED (>30d E com uma linha mais nova da MESMA chave). §11 P2-1.
+  -- Ordem de chave: (created_at, id) — idêntica ao DISTINCT ON da promoção.
+  DELETE FROM tint_staging_produtos s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_produtos n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_bases s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_bases n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_base_sayersystem = s.id_base_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_embalagens s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_embalagens n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_embalagem_sayersystem = s.id_embalagem_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_corantes s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_corantes n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.id_corante_sayersystem = s.id_corante_sayersystem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_skus s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_skus n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- Fórmulas: chave = (cod_produto,id_base,cor_id,COALESCE(subcolecao,''),personalizada),
+  -- idêntica ao DISTINCT ON de _formulas_latest. Itens cascateiam pela formula-pai apagada.
+  DELETE FROM tint_staging_formula_itens si
+  WHERE si.staging_formula_id IN (
+    SELECT s.id FROM tint_staging_formulas s
+    WHERE s.created_at < now() - interval '30 days'
+      AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+        WHERE n.account = s.account AND n.store_code = s.store_code
+          AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+          AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+          AND n.personalizada = s.personalizada
+          AND (n.created_at, n.id) > (s.created_at, s.id)));
+
+  DELETE FROM tint_staging_formulas s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_formulas n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cor_id = s.cor_id AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base
+        AND COALESCE(n.subcolecao, '') = COALESCE(s.subcolecao, '')
+        AND n.personalizada = s.personalizada
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  DELETE FROM tint_staging_precos_base s
+  WHERE s.created_at < now() - interval '30 days'
+    AND EXISTS (SELECT 1 FROM tint_staging_precos_base n
+      WHERE n.account = s.account AND n.store_code = s.store_code
+        AND n.cod_produto = s.cod_produto AND n.id_base = s.id_base AND n.id_embalagem = s.id_embalagem
+        AND (n.created_at, n.id) > (s.created_at, s.id));
+
+  -- keys-snapshot: point-in-time (não latest-per-key) → purge por tempo é correto.
+  DELETE FROM tint_keys_snapshots          WHERE created_at < now() - interval '30 days';
+
+  UPDATE tint_sync_runs
+    SET status = 'error', completed_at = COALESCE(completed_at, now())
+  WHERE status = 'running' AND started_at < now() - interval '30 minutes';
+
+  RETURN jsonb_build_object(
+    'ok', true, 'promovidas', v_promovidas, 'recalculadas', v_recalc,
+    'erros', v_erros, 'importacao_id', v_importacao_id);
+END $$;
+REVOKE EXECUTE ON FUNCTION public.tint_promote_sync_run(uuid) FROM anon, authenticated, PUBLIC;
+
+SELECT 'tint_promote_sync_run SET-BASED OK' AS status;


### PR DESCRIPTION
## Problema
Re-envio residual de fórmulas em batches CHEIOS (~75k re-stagings/dia, 116 runs `error` em 22/06). Causa: a `tint_promote_sync_run` abortava com `duplicate key` (23505) em `tint_formula_itens` para **4 cores padrão ATIVAS** (`344M/629N/638S/997M - BS`) que têm o **mesmo corante em 2 ordens** (dosagem em 2 etapas). Rollback do batch → edge devolve 500 → o conector não cacheia o lote → re-envia o batch de 1000 p/ sempre. Via latest-per-key (restrito aos pares tocados), essas 4 cores envenenam todo batch que toca seus pares (~1000 fórmulas reféns, re-staged 41×).

Investigação: o `nome_cor` das personalizadas (problema separado) já fora resolvido pelo #992; o `lock timeout` era colateral da contenção do próprio re-loop.

## Fix
`CREATE OR REPLACE` da `tint_promote_sync_run` (6ª da cadeia, herda tudo VERBATIM). Muda só:
- **INSERT de `tint_formula_itens`**: `DISTINCT ON (formula_id, corante_id) ORDER BY ordem DESC, qtd_ml DESC, id DESC` (max-ordem vence) — idêntico ao que o oficial CSV-import já gravou → **idempotente, zero mudança de dosagem** de cor ativa (precisão > recall).
- **`_preco`** (Codex P1): deduplica os itens igual — antes eram 2 BOMs (item=max-ordem, preço=Σ-todos). Dead-code hoje (`precos_base` sempre vazio) mas elimina bomba latente.
- **tie-break** determinístico no `DISTINCT ON` (Codex P2).

Não toca o conector (sem redeploy no balcão).

## Verificação
- PG17 `db/test-tint-promote-dedup-itens.sh` — **11/11 verde** + falsificação (sem o `DISTINCT ON` → 23505 reproduzido).
- **Idempotência catalog-wide provada** (read-only vs prod): as 4 cores / 192 fórmulas têm fração-normalizada staging-max-ordem == oficial (15/15 corantes batem) → no-op de dosagem.
- **Codex consult**: validou max-ordem como o hotfix certo (não somar, não corrigir a 344M agora); os 3 achados incorporados.
- Pré-flight `pg_get_functiondef` confirmou prod == repo (sem drift).

Detalhe completo: `docs/historico/tintometrico.md`.

## Deploy (manual — money-path)
🚧 **DRAFT até o founder aplicar a migration no SQL Editor** (Lovable não auto-aplica migration custom). Depois do apply + próximo sync: o re-loop cessa (`tint_sync_runs.status='error'` → ~0).

## Fora de escopo (decisão de domínio)
Max-ordem replica uma provável **subdosagem histórica** (344M usa 1.54ml de corante 1 vs soma 41.59). Avaliar com o balcão se as 2 dosagens distintas (344M/997M) deveriam **somar** — seria outra mudança money-path (mudaria a cor ativa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
