### PR TITLE
fix(custo): pagina a 3ª leitura do computeCosts (inventory_position) [money-path]

### DIFF
--- a/src/lib/custo/__tests__/costCompute.parity.test.ts
+++ b/src/lib/custo/__tests__/costCompute.parity.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// O helper de montagem de custo roda em DOIS runtimes: vitest/Vite (canônico em src/) e
+// Deno (espelho no edge). Este teste prova que os dois arquivos são idênticos EXCETO a
+// linha de import do helper de escada — que difere só no specifier do módulo:
+//   src:  from './costLadder'
+//   edge: from './cost-ladder.ts'   (Deno exige extensão; o arquivo usa kebab-case)
+// Normalizamos o specifier do edge antes de comparar; qualquer OUTRA divergência =
+// CI vermelho (o modo de falha que money-path.md alerta: fix entra num runtime, não no outro).
+const ROOT = process.cwd();
+const CANONICO = resolve(ROOT, 'src/lib/custo/costCompute.ts');
+const ESPELHO = resolve(ROOT, 'supabase/functions/_shared/cost-compute.ts');
+
+describe('paridade: costCompute (src) × cost-compute (edge)', () => {
+  it('os dois arquivos são idênticos a menos do specifier de import da escada', () => {
+    const canonico = readFileSync(CANONICO, 'utf8');
+    const espelhoNormalizado = readFileSync(ESPELHO, 'utf8').replace(
+      "} from './cost-ladder.ts';",
+      "} from './costLadder';",
+    );
+    expect(espelhoNormalizado).toBe(canonico);
+  });
+});

--- a/src/lib/custo/__tests__/costCompute.test.ts
+++ b/src/lib/custo/__tests__/costCompute.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import {
+  montarUpsertsDeCusto,
+  type ProdutoCusto,
+  type UpsertCusto,
+} from '@/lib/custo/costCompute';
+import type { CostLadderConfig } from '@/lib/custo/costLadder';
+
+// Config canônica (defaults de recommendation_config em prod: 0.35 / 0.05 / 0.85).
+// Com price=100 a faixa de sanidade do CMC é (price*0.15, price*0.95) = (15, 95).
+const cfg: CostLadderConfig = { margemDefault: 0.35, margemMin: 0.05, margemMax: 0.85 };
+const NOW = '2026-06-21T00:00:00.000Z';
+
+const byId = (rows: UpsertCusto[], id: string): UpsertCusto => {
+  const r = rows.find((x) => x.product_id === id);
+  if (!r) throw new Error(`row ausente: ${id}`);
+  return r;
+};
+
+describe('montarUpsertsDeCusto — escada por produto (CMC real vence)', () => {
+  it('CMC real no inventory → cost_source=CMC e SEMEIA cost_price com o CMC', () => {
+    const produtos: ProdutoCusto[] = [{ id: 'p1', valor_unitario: 100, familia: 'A' }];
+    const { rows, updated } = montarUpsertsDeCusto(produtos, {}, { p1: { cmc: 60 } }, cfg, NOW);
+    expect(updated).toBe(1);
+    const r = byId(rows, 'p1');
+    expect(r.cost_source).toBe('CMC');
+    expect(r.cost_price).toBe(60);
+    expect(r.cost_final).toBe(60);
+    expect(r.cmc).toBe(60); // cmc persistido (a view v_caca lê product_costs.cmc)
+    expect(r.family_category).toBe('A');
+    expect(r.updated_at).toBe(NOW);
+  });
+
+  // O CORAÇÃO DO FIX (equivale ao "não rebaixar item fora do truncamento" da tarefa):
+  // um produto que ANTES sumia do costMap truncado (cauda > 1000 linhas de product_costs)
+  // agora chega no map e seu CMC persistido é preservado — não vira proxy.
+  it('CMC só persistido (costMap), inventory ausente → cmcPreferido preserva o CMC real', () => {
+    const produtos: ProdutoCusto[] = [{ id: 'p1', valor_unitario: 100, familia: 'A' }];
+    const { rows } = montarUpsertsDeCusto(produtos, { p1: { cmc: 60 } }, {}, cfg, NOW);
+    expect(byId(rows, 'p1').cost_source).toBe('CMC');
+    expect(byId(rows, 'p1').cost_price).toBe(60);
+  });
+
+  it('inv.cmc=0 (posição sem custo) NÃO rebaixa custo real: cai para o persistido', () => {
+    const { rows } = montarUpsertsDeCusto(
+      [{ id: 'p1', valor_unitario: 100, familia: 'A' }],
+      { p1: { cmc: 60 } },
+      { p1: { cmc: 0 } },
+      cfg,
+      NOW,
+    );
+    expect(byId(rows, 'p1').cost_source).toBe('CMC');
+    expect(byId(rows, 'p1').cost_price).toBe(60);
+  });
+});
+
+describe('montarUpsertsDeCusto — degradação honesta (ausente ≠ zero)', () => {
+  it('sem CMC e sem família → DEFAULT_PROXY com cost_price=null (não fabrica custo)', () => {
+    const { rows } = montarUpsertsDeCusto(
+      [{ id: 'p1', valor_unitario: 100, familia: 'A' }],
+      {},
+      {},
+      cfg,
+      NOW,
+    );
+    const r = byId(rows, 'p1');
+    expect(r.cost_source).toBe('DEFAULT_PROXY');
+    expect(r.cost_price).toBeNull();
+    expect(r.cmc).toBe(0); // sem CMC: cost_price null, mas a coluna cmc grava 0 (ausente)
+  });
+
+  it('produto com price<=0 não gera upsert (guard money-path)', () => {
+    const { rows, updated } = montarUpsertsDeCusto(
+      [
+        { id: 'p1', valor_unitario: 0, familia: 'A' },
+        { id: 'p2', valor_unitario: -5, familia: 'A' },
+      ],
+      {},
+      {},
+      cfg,
+      NOW,
+    );
+    expect(updated).toBe(0);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe('montarUpsertsDeCusto — média de família computada do CONJUNTO COMPLETO', () => {
+  it('≥3 CMCs reais na família → FAMILY_MARGIN_PROXY para o produto sem CMC da família', () => {
+    const produtos: ProdutoCusto[] = [
+      { id: 'a1', valor_unitario: 100, familia: 'A' },
+      { id: 'a2', valor_unitario: 100, familia: 'A' },
+      { id: 'a3', valor_unitario: 100, familia: 'A' },
+      { id: 'a4', valor_unitario: 100, familia: 'A' }, // sem CMC → herda proxy da família
+    ];
+    const invMap = { a1: { cmc: 60 }, a2: { cmc: 60 }, a3: { cmc: 60 } }; // margem 0.4 cada
+    const { rows } = montarUpsertsDeCusto(produtos, {}, invMap, cfg, NOW);
+    const r = byId(rows, 'a4');
+    expect(r.cost_source).toBe('FAMILY_MARGIN_PROXY');
+    expect(r.cost_final).toBeCloseTo(60, 6); // 100*(1-0.4)
+    expect(r.cost_price).toBeNull();
+  });
+
+  it('<3 amostras de CMC real na família → não forma proxy de família (cai p/ DEFAULT_PROXY)', () => {
+    const produtos: ProdutoCusto[] = [
+      { id: 'a1', valor_unitario: 100, familia: 'A' },
+      { id: 'a2', valor_unitario: 100, familia: 'A' },
+      { id: 'a3', valor_unitario: 100, familia: 'A' }, // sem CMC
+    ];
+    const invMap = { a1: { cmc: 60 }, a2: { cmc: 60 } }; // só 2 amostras
+    const { rows } = montarUpsertsDeCusto(produtos, {}, invMap, cfg, NOW);
+    expect(byId(rows, 'a3').cost_source).toBe('DEFAULT_PROXY');
+  });
+
+  it('proxy de família NÃO se autoalimenta: produto sem CMC não entra na média da própria família', () => {
+    // 3 com CMC + 1 sem. Se o sem-CMC contasse, a média/contagem mudaria.
+    const produtos: ProdutoCusto[] = [
+      { id: 'a1', valor_unitario: 100, familia: 'A' },
+      { id: 'a2', valor_unitario: 100, familia: 'A' },
+      { id: 'a3', valor_unitario: 100, familia: 'A' },
+      { id: 'a4', valor_unitario: 100, familia: 'A' },
+    ];
+    const invMap = { a1: { cmc: 70 }, a2: { cmc: 70 }, a3: { cmc: 70 } }; // margem 0.3 cada
+    const { rows } = montarUpsertsDeCusto(produtos, {}, invMap, cfg, NOW);
+    expect(byId(rows, 'a4').cost_final).toBeCloseTo(70, 6); // 100*(1-0.3), média só dos 3 reais
+  });
+});
+
+describe('montarUpsertsDeCusto — catálogo INTEIRO (a montagem não impõe cap próprio)', () => {
+  // Combinado com paginate_test.ts (fetchAll entrega a cauda inteira), fecha a cadeia:
+  // destruncar a LEITURA + a montagem usar tudo = a cauda > 1000 deixa de virar proxy.
+  it('processa N=1500 produtos e preserva CMC real só presente na cauda (índices ≥1000)', () => {
+    const N = 1500;
+    const produtos: ProdutoCusto[] = Array.from({ length: N }, (_, i) => ({
+      id: `p${i}`,
+      valor_unitario: 100,
+      familia: 'A',
+    }));
+    const invMap: Record<string, { cmc: number }> = {};
+    for (let i = 1000; i < N; i++) invMap[`p${i}`] = { cmc: 60 }; // só a cauda tem CMC
+
+    const { rows, updated } = montarUpsertsDeCusto(produtos, {}, invMap, cfg, NOW);
+
+    expect(updated).toBe(N);
+    expect(rows).toHaveLength(N);
+    expect(byId(rows, 'p1499').cost_source).toBe('CMC'); // o último item da cauda sobrevive
+    expect(byId(rows, 'p1499').cost_price).toBe(60);
+    expect(rows.filter((r) => r.cost_source === 'CMC')).toHaveLength(N - 1000); // 500
+  });
+});

--- a/src/lib/custo/costCompute.ts
+++ b/src/lib/custo/costCompute.ts
@@ -1,0 +1,116 @@
+// Montagem dos upserts de custo (camada de orquestração do fallback engine de custo).
+//
+// ESPELHADO VERBATIM em supabase/functions/_shared/cost-compute.ts (Deno não importa
+// de src/). A paridade é provada por costCompute.parity.test.ts — divergência = CI
+// vermelho. A ÚNICA diferença permitida entre os dois arquivos é a linha de import do
+// helper de escada (`./costLadder` no src, `./cost-ladder.ts` no edge); o parity test
+// normaliza essa linha antes de comparar.
+//
+// Por que existe: o edge `omie-analytics-sync/computeCosts` carrega o catálogo inteiro
+// (paginado via fetchAll — o PostgREST capa em 1000 silencioso) e DEPOIS monta os
+// upserts. Esta função é a parte PURA dessa montagem (sem I/O), testável com vitest:
+// dado o conjunto COMPLETO, prova que a cauda > 1000 é processada e que CMC real não
+// é rebaixado a proxy (money-path: ausente ≠ zero, nunca fabricar custo).
+import {
+  computeCostLadder,
+  cmcPreferido,
+  type CostLadderConfig,
+  type CostSource,
+} from './costLadder';
+
+export interface ProdutoCusto {
+  id: string;
+  valor_unitario: number;
+  familia: string | null;
+}
+
+/** Só `cmc` importa do product_costs persistido (pós-#977 o cost_price legado não é mais lido). */
+export interface CustoPersistidoCmc {
+  cmc?: number | null;
+}
+
+/** Só `cmc` importa da posição de inventário para a escada de custo. */
+export interface PosicaoCmc {
+  cmc?: number | null;
+}
+
+export interface UpsertCusto {
+  product_id: string;
+  cost_price: number | null;
+  cmc: number;
+  cost_final: number;
+  cost_source: CostSource;
+  cost_confidence: number;
+  family_category: string | null;
+  updated_at: string;
+}
+
+export function montarUpsertsDeCusto(
+  produtos: ProdutoCusto[],
+  costMap: Record<string, CustoPersistidoCmc>,
+  invMap: Record<string, PosicaoCmc>,
+  cfg: CostLadderConfig,
+  nowIso: string,
+): { rows: UpsertCusto[]; updated: number } {
+  // Margem média por família — calculada SÓ de custos REAIS (CMC do inventory). Usar
+  // cost_price/proxy aqui reinjetava proxy lavado na média e tornava o motor
+  // autorreferencial (proxy gerava proxy). Achado Codex 2026-06-19.
+  const familyMargins: Record<string, { totalMargin: number; count: number }> = {};
+  for (const p of produtos) {
+    if (!(p.valor_unitario > 0)) continue;
+    const fam = p.familia || 'default';
+    const cmcReal = invMap[p.id]?.cmc ?? 0;
+    if (cmcReal > 0) {
+      const margin = 1 - cmcReal / p.valor_unitario;
+      if (margin > cfg.margemMin && margin < cfg.margemMax) {
+        if (!familyMargins[fam]) familyMargins[fam] = { totalMargin: 0, count: 0 };
+        familyMargins[fam].totalMargin += margin;
+        familyMargins[fam].count++;
+      }
+    }
+  }
+
+  const rows: UpsertCusto[] = [];
+  for (const product of produtos) {
+    const price = product.valor_unitario;
+    if (!price || price <= 0) continue;
+
+    const existing = costMap[product.id];
+    const inv = invMap[product.id];
+    // CMC a usar: atual do inventory se >0; senão o último persistido. 0 do inventory =
+    // "esta posição não traz custo", não "custo é zero" — preservar o CMC real persistido
+    // (não rebaixar custo real a proxy). Ver cmcPreferido (Codex review P1).
+    const cmc = cmcPreferido(inv?.cmc, existing?.cmc);
+
+    const fam = product.familia || 'default';
+    const famData = familyMargins[fam];
+    const familyTargetMargin =
+      famData && famData.count >= 3 ? famData.totalMargin / famData.count : null;
+
+    const { costFinal, costSource, costConfidence, costPriceToPersist } = computeCostLadder({
+      price,
+      cmc,
+      familyTargetMargin,
+      cfg,
+    });
+
+    // cost_price guarda SÓ custo real: o CMC quando há, senão null (NUNCA proxy — era a
+    // causa da lavagem de proveniência). PRODUCT_COST saiu da escada; o motor não o emite.
+    // cmc é PERSISTIDO de propósito: além do fallback de cmcPreferido, a view v_caca_compradores
+    // lê product_costs.cmc p/ o lucro da Caça, e este é o único writer que copia o cmc do
+    // catálogo inteiro (syncInventoryFull não toca product_costs). Há uma race conhecida com o
+    // syncInventory neste campo (2 writers) — pré-existente, tratada na eleição do PR irmão.
+    rows.push({
+      product_id: product.id,
+      cost_price: costPriceToPersist,
+      cmc: cmc ?? 0,
+      cost_final: costFinal,
+      cost_source: costSource,
+      cost_confidence: costConfidence,
+      family_category: product.familia || null,
+      updated_at: nowIso,
+    });
+  }
+
+  return { rows, updated: rows.length };
+}

--- a/supabase/functions/_shared/cost-compute.ts
+++ b/supabase/functions/_shared/cost-compute.ts
@@ -1,0 +1,116 @@
+// Montagem dos upserts de custo (camada de orquestração do fallback engine de custo).
+//
+// ESPELHADO VERBATIM em supabase/functions/_shared/cost-compute.ts (Deno não importa
+// de src/). A paridade é provada por costCompute.parity.test.ts — divergência = CI
+// vermelho. A ÚNICA diferença permitida entre os dois arquivos é a linha de import do
+// helper de escada (`./costLadder` no src, `./cost-ladder.ts` no edge); o parity test
+// normaliza essa linha antes de comparar.
+//
+// Por que existe: o edge `omie-analytics-sync/computeCosts` carrega o catálogo inteiro
+// (paginado via fetchAll — o PostgREST capa em 1000 silencioso) e DEPOIS monta os
+// upserts. Esta função é a parte PURA dessa montagem (sem I/O), testável com vitest:
+// dado o conjunto COMPLETO, prova que a cauda > 1000 é processada e que CMC real não
+// é rebaixado a proxy (money-path: ausente ≠ zero, nunca fabricar custo).
+import {
+  computeCostLadder,
+  cmcPreferido,
+  type CostLadderConfig,
+  type CostSource,
+} from './cost-ladder.ts';
+
+export interface ProdutoCusto {
+  id: string;
+  valor_unitario: number;
+  familia: string | null;
+}
+
+/** Só `cmc` importa do product_costs persistido (pós-#977 o cost_price legado não é mais lido). */
+export interface CustoPersistidoCmc {
+  cmc?: number | null;
+}
+
+/** Só `cmc` importa da posição de inventário para a escada de custo. */
+export interface PosicaoCmc {
+  cmc?: number | null;
+}
+
+export interface UpsertCusto {
+  product_id: string;
+  cost_price: number | null;
+  cmc: number;
+  cost_final: number;
+  cost_source: CostSource;
+  cost_confidence: number;
+  family_category: string | null;
+  updated_at: string;
+}
+
+export function montarUpsertsDeCusto(
+  produtos: ProdutoCusto[],
+  costMap: Record<string, CustoPersistidoCmc>,
+  invMap: Record<string, PosicaoCmc>,
+  cfg: CostLadderConfig,
+  nowIso: string,
+): { rows: UpsertCusto[]; updated: number } {
+  // Margem média por família — calculada SÓ de custos REAIS (CMC do inventory). Usar
+  // cost_price/proxy aqui reinjetava proxy lavado na média e tornava o motor
+  // autorreferencial (proxy gerava proxy). Achado Codex 2026-06-19.
+  const familyMargins: Record<string, { totalMargin: number; count: number }> = {};
+  for (const p of produtos) {
+    if (!(p.valor_unitario > 0)) continue;
+    const fam = p.familia || 'default';
+    const cmcReal = invMap[p.id]?.cmc ?? 0;
+    if (cmcReal > 0) {
+      const margin = 1 - cmcReal / p.valor_unitario;
+      if (margin > cfg.margemMin && margin < cfg.margemMax) {
+        if (!familyMargins[fam]) familyMargins[fam] = { totalMargin: 0, count: 0 };
+        familyMargins[fam].totalMargin += margin;
+        familyMargins[fam].count++;
+      }
+    }
+  }
+
+  const rows: UpsertCusto[] = [];
+  for (const product of produtos) {
+    const price = product.valor_unitario;
+    if (!price || price <= 0) continue;
+
+    const existing = costMap[product.id];
+    const inv = invMap[product.id];
+    // CMC a usar: atual do inventory se >0; senão o último persistido. 0 do inventory =
+    // "esta posição não traz custo", não "custo é zero" — preservar o CMC real persistido
+    // (não rebaixar custo real a proxy). Ver cmcPreferido (Codex review P1).
+    const cmc = cmcPreferido(inv?.cmc, existing?.cmc);
+
+    const fam = product.familia || 'default';
+    const famData = familyMargins[fam];
+    const familyTargetMargin =
+      famData && famData.count >= 3 ? famData.totalMargin / famData.count : null;
+
+    const { costFinal, costSource, costConfidence, costPriceToPersist } = computeCostLadder({
+      price,
+      cmc,
+      familyTargetMargin,
+      cfg,
+    });
+
+    // cost_price guarda SÓ custo real: o CMC quando há, senão null (NUNCA proxy — era a
+    // causa da lavagem de proveniência). PRODUCT_COST saiu da escada; o motor não o emite.
+    // cmc é PERSISTIDO de propósito: além do fallback de cmcPreferido, a view v_caca_compradores
+    // lê product_costs.cmc p/ o lucro da Caça, e este é o único writer que copia o cmc do
+    // catálogo inteiro (syncInventoryFull não toca product_costs). Há uma race conhecida com o
+    // syncInventory neste campo (2 writers) — pré-existente, tratada na eleição do PR irmão.
+    rows.push({
+      product_id: product.id,
+      cost_price: costPriceToPersist,
+      cmc: cmc ?? 0,
+      cost_final: costFinal,
+      cost_source: costSource,
+      cost_confidence: costConfidence,
+      family_category: product.familia || null,
+      updated_at: nowIso,
+    });
+  }
+
+  return { rows, updated: rows.length };
+}

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -995,9 +995,20 @@ async function computeCosts(db: SupabaseClient) {
   const costMap: Record<string, { cmc?: number | null }> = {};
   for (const c of costsRaw) costMap[c.product_id] = c;
 
-  // Get inventory for CMC
-  const { data: inventoryRaw } = await db.from("inventory_position").select("product_id, cmc, saldo");
-  const inventory = (inventoryRaw ?? []) as unknown as InventoryPositionRow[];
+  // Inventário p/ o CMC — PAGINADO (igual a products/product_costs acima): o .select() cru
+  // capa em 1000 silencioso (PostgREST) e há ~3x isso → a cauda da escada virava proxy/zero
+  // (ausente ≠ zero). .order pela UNIQUE (omie_codigo_produto, account) é o cursor estável —
+  // product_id NÃO serve (repete por conta-alias e admite null). 3ª leitura da função; o #985
+  // paginou as duas primeiras e deixou esta. Link cross-vocabulário (vendas→oben / colacor_vendas
+  // →colacor) é correto — invMap é 1:1 por product_id; divergência de valor provada 0 (psql-ro).
+  const inventory = await fetchAll<InventoryPositionRow>(
+    (from, to) =>
+      db.from("inventory_position").select("product_id, cmc, saldo")
+        .order("omie_codigo_produto", { ascending: true })
+        .order("account", { ascending: true })
+        .range(from, to),
+    "inventory_position",
+  );
   const invMap: Record<string, InventoryPositionRow> = {};
   for (const i of inventory) if (i.product_id) invMap[i.product_id] = i;
 

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1,7 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
-import { computeCostLadder, cmcPreferido } from "../_shared/cost-ladder.ts";
+import { fetchAll } from "../_shared/paginate.ts";
+import { montarUpsertsDeCusto } from "../_shared/cost-compute.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -148,13 +149,6 @@ interface OmieListarPosEstoqueResponse {
 interface OmieApiResponseBase {
   faultstring?: string;
   faultcode?: string;
-}
-
-interface ProductCostRow {
-  id: string;
-  product_id: string;
-  cost_price?: number;
-  cmc?: number;
 }
 
 interface InventoryPositionRow {
@@ -972,15 +966,34 @@ async function computeCosts(db: SupabaseClient) {
   const margemMin = cfg.margem_minima ?? 0.05;
   const margemMax = cfg.margem_maxima ?? 0.85;
 
-  // Get all products with their costs and inventory
-  const { data: products } = await db.from("omie_products").select("id, valor_unitario, familia").eq("ativo", true);
-  if (!products?.length) return { updated: 0 };
+  // Catálogo ATIVO inteiro — PAGINADO: o PostgREST capa o .select() em 1000 linhas em
+  // SILÊNCIO (docs/agent/database.md §5). Sem isto, ~2/3 dos ~3k produtos ativos nunca
+  // eram recalculados. .order("id") = coluna estável exigida pelo .range() entre páginas.
+  const products = await fetchAll<{ id: string; valor_unitario: number; familia: string | null }>(
+    (from, to) =>
+      db
+        .from("omie_products")
+        .select("id, valor_unitario, familia")
+        .eq("ativo", true)
+        .order("id", { ascending: true })
+        .range(from, to),
+    "omie_products(ativos)",
+  );
+  if (!products.length) return { updated: 0 };
 
-  // Get all product costs
-  const { data: costsRaw } = await db.from("product_costs").select("*");
-  const costs = (costsRaw ?? []) as unknown as ProductCostRow[];
-  const costMap: Record<string, ProductCostRow> = {};
-  for (const c of costs) costMap[c.product_id] = c;
+  // product_costs inteiro — PAGINADO pelo mesmo motivo: um costMap truncado perdia o CMC
+  // persistido da cauda e cmcPreferido rebaixava custo real a proxy. Só `cmc` é lido aqui.
+  const costsRaw = await fetchAll<{ product_id: string; cmc: number | null }>(
+    (from, to) =>
+      db
+        .from("product_costs")
+        .select("product_id, cmc")
+        .order("product_id", { ascending: true })
+        .range(from, to),
+    "product_costs",
+  );
+  const costMap: Record<string, { cmc?: number | null }> = {};
+  for (const c of costsRaw) costMap[c.product_id] = c;
 
   // Get inventory for CMC
   const { data: inventoryRaw } = await db.from("inventory_position").select("product_id, cmc, saldo");
@@ -988,65 +1001,40 @@ async function computeCosts(db: SupabaseClient) {
   const invMap: Record<string, InventoryPositionRow> = {};
   for (const i of inventory) if (i.product_id) invMap[i.product_id] = i;
 
-  // Margem média por família — calculada SÓ de custos REAIS (CMC). Usar cost_price aqui
-  // reinjetava proxy lavado na média e tornava o motor autorreferencial (proxy gerava
-  // proxy). Achado Codex 2026-06-19.
-  const familyMargins: Record<string, { totalMargin: number; count: number }> = {};
-  for (const p of products) {
-    if (!(p.valor_unitario > 0)) continue;
-    const fam = p.familia || "default";
-    const cmcReal = invMap[p.id]?.cmc ?? 0;
-    if (cmcReal > 0) {
-      const margin = 1 - cmcReal / p.valor_unitario;
-      if (margin > margemMin && margin < margemMax) {
-        if (!familyMargins[fam]) familyMargins[fam] = { totalMargin: 0, count: 0 };
-        familyMargins[fam].totalMargin += margin;
-        familyMargins[fam].count++;
-      }
+  // Montagem PURA dos upserts (testada em src/lib/custo/costCompute.test.ts; espelho
+  // verbatim em _shared/cost-compute.ts). Recebe o catálogo COMPLETO (paginado acima) —
+  // a cauda > 1000 deixa de virar proxy e o CMC real é preservado (ausente ≠ zero).
+  const nowIso = new Date().toISOString();
+  const { rows } = montarUpsertsDeCusto(
+    products,
+    costMap,
+    invMap as unknown as Record<string, { cmc?: number | null }>,
+    { margemDefault, margemMin, margemMax },
+    nowIso,
+  );
+
+  // Upsert em LOTE (chunks de 500). Antes: N+1 (1 upsert por produto DENTRO do loop) —
+  // com o catálogo destruncado (~3k) isso estouraria o tempo do edge.
+  // Money-path (Codex P1): um lote que falha derruba 500 linhas ATOMICAMENTE — não
+  // reportar sucesso falso. Conta só o que PERSISTIU e LANÇA se algum lote falhou (o
+  // caller vira status=error; o data_health não marca "fresco" sobre gravação parcial).
+  const lotes = chunked(rows, 500);
+  let updated = 0;
+  const errosUpsert: string[] = [];
+  for (const chunk of lotes) {
+    const { error } = await db.from("product_costs").upsert(chunk, { onConflict: "product_id" });
+    if (error) {
+      errosUpsert.push(error.message);
+      console.error("[computeCosts] upsert product_costs (lote):", error);
+    } else {
+      updated += chunk.length;
     }
   }
-
-  let updated = 0;
-  const cfgMargens = { margemDefault, margemMin, margemMax };
-
-  for (const product of products) {
-    const price = product.valor_unitario;
-    if (!price || price <= 0) continue;
-
-    const existing = costMap[product.id];
-    const inv = invMap[product.id];
-    // CMC a usar: atual do inventory se >0; senão o último persistido (existing.cmc). 0 do
-    // inventory = "esta linha de posição não traz custo", não "custo é zero" — preservar o CMC
-    // real persistido (não rebaixar custo real a proxy). Ver cmcPreferido (Codex review P1).
-    const cmc = cmcPreferido(inv?.cmc, existing?.cmc);
-
-    const fam = product.familia || "default";
-    const famData = familyMargins[fam];
-    const familyTargetMargin =
-      famData && famData.count >= 3 ? famData.totalMargin / famData.count : null;
-
-    const { costFinal, costSource, costConfidence, costPriceToPersist } = computeCostLadder({
-      price,
-      cmc,
-      familyTargetMargin,
-      cfg: cfgMargens,
-    });
-
-    // cost_price guarda SÓ custo real: o CMC quando há, senão null (NUNCA proxy — era a
-    // causa da lavagem de proveniência). PRODUCT_COST saiu da escada; o motor não o emite.
-    const upsertData: Record<string, unknown> = {
-      product_id: product.id,
-      cost_price: costPriceToPersist,
-      cmc: cmc ?? 0,
-      cost_final: costFinal,
-      cost_source: costSource,
-      cost_confidence: costConfidence,
-      family_category: product.familia || null,
-      updated_at: new Date().toISOString(),
-    };
-
-    await db.from("product_costs").upsert(upsertData, { onConflict: "product_id" });
-    updated++;
+  if (errosUpsert.length) {
+    throw new Error(
+      `computeCosts: ${errosUpsert.length}/${lotes.length} lotes de upsert falharam ` +
+        `(${updated}/${rows.length} persistidos). 1º erro: ${errosUpsert[0]}`,
+    );
   }
 
   return { updated };


### PR DESCRIPTION
## Problema

`computeCosts` (omie-analytics-sync) tem 3 leituras grandes. O #985 paginou `omie_products` e `product_costs`, mas **deixou a 3ª** — `inventory_position`, a que alimenta o `invMap` da escada de custo (CMC→proxy). O `.select()` cru capa em **1000 silencioso** (PostgREST) com **~2959 linhas** → a cauda da escada virava proxy/zero (ausente ≠ zero).

## Fix

Reusa `fetchAll` (mesmo helper das outras 2 leituras) com `.order('omie_codigo_produto').order('account').range()` — cursor estável pela UNIQUE `inventory_position_produto_account_uq`. `product_id` **não** serve de cursor (repete por conta-alias e admite null).

## Prova (read-only, `psql-ro`)

A investigação descartou um falso-alarme inicial (cheguei a medir 73% de "mis-stamp"):

- **B — natureza:** o "mismatch" `op.account ≠ ip.account` é **alias de vocabulário**, não dano — pares 1:1 limpos `colacor_vendas→colacor` (1394) e `vendas→oben` (760). `inventory_position.account` guarda o nome da conta-Omie; `omie_products.account` o nome da empresa. O `product_id` linka o produto **certo**.
- **A — valor:** dos **700** produtos com CMC exato, **`difere_gt10pct = 0`** — zero corrupção de valor; `invMap` é 1:1 por `product_id`.
- Impacto do cap hoje: ~33 produtos com CMC real exibindo proxy + latência **não-determinística** (qual fatia de 1000 volta muda por ordem física da tabela).

Bônus money-path: `fetchAll` **lança em erro** — a leitura antiga (`const { data } = await…`) engolia erro em silêncio e poderia fabricar sucesso parcial.

## Escopo / não-objetivos

- ✅ Só a paginação da leitura. **Não** toca `syncInventoryFull` (linka certo na prática — código Omie é por-instância), **não** mexe no invMap/eleição (cerca preservada), **sem migration**.
- A race de 3 writers em `product_costs.cmc` é staleness **benigna** (link correto → valores convergem, provado por A) — documentada, não corrigida aqui.

## Verificação

- `deno check` do edge → **0**
- `typecheck` / `lint` (0 errors) / `vitest` (**3955** passando) → **0**

## Deploy (manual, pós-merge — Lovable)

1. Deploy do edge `omie-analytics-sync` (chat do Lovable, verbatim do repo).
2. Rodar `sync_all` (ou aguardar o cron) → re-stampa + recomputa `product_costs` com a cauda visível.

## Pendente

⏳ **Codex challenge** (norma money-path) — bloqueado pelo classificador instável de hoje; rodo quando a infra voltar. **DRAFT** até lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
