### PR TITLE
feat(custo): CMC_UNIDADE_SUSPEITA — separa descasamento-de-unidade de margem atípica (impl do #994)

### DIFF
--- a/src/lib/custo/__tests__/costCompute.test.ts
+++ b/src/lib/custo/__tests__/costCompute.test.ts
@@ -149,3 +149,61 @@ describe('montarUpsertsDeCusto — catálogo INTEIRO (a montagem não impõe cap
     expect(rows.filter((r) => r.cost_source === 'CMC')).toHaveLength(N - 1000); // 500
   });
 });
+
+describe('montarUpsertsDeCusto — CMC_UNIDADE_SUSPEITA (descasamento de unidade, decorator pós-escada)', () => {
+  // Jumbo M2: cmc é por m2 (31), price (218) está noutra unidade → a escada vê "margem 86%"
+  // (CMC_MARGEM_ATIPICA), mas é DESCASAMENTO DE UNIDADE, não prejuízo real. Com unidade
+  // geométrica (H1) + dimensão LxC na descrição (H3), o decorator re-rotula: cost_final
+  // degrada ao proxy de família, cost_price=null (cmc não comparável ao price), cmc cru preservado.
+  it('jumbo M2 com dimensão na descrição → CMC_UNIDADE_SUSPEITA (cost_final=proxy família, cost_price=null, cmc cru)', () => {
+    const produtos: ProdutoCusto[] = [
+      { id: 'a1', valor_unitario: 100, familia: 'A' },
+      { id: 'a2', valor_unitario: 100, familia: 'A' },
+      { id: 'a3', valor_unitario: 100, familia: 'A' }, // 3 CMCs reais (margem 0.4) → proxy de família
+      { id: 'jumbo', valor_unitario: 218, familia: 'A', unidade: 'M2', descricao: 'JUMBO KA169 1410X50000MM P80' },
+    ];
+    const invMap = { a1: { cmc: 60 }, a2: { cmc: 60 }, a3: { cmc: 60 }, jumbo: { cmc: 31 } };
+    const r = byId(montarUpsertsDeCusto(produtos, {}, invMap, cfg, NOW).rows, 'jumbo');
+    expect(r.cost_source).toBe('CMC_UNIDADE_SUSPEITA');
+    expect(r.cost_price).toBeNull(); // cmc não comparável ao price → não semeia cost_price
+    expect(r.cmc).toBe(31); // cmc cru preservado (auditoria)
+    expect(r.cost_final).toBeCloseTo(218 * (1 - 0.4), 6); // proxy de família (margem média 0.4)
+    expect(r.cost_confidence).toBe(0.5); // herda do FAMILY_MARGIN_PROXY
+  });
+
+  // O CORAÇÃO money-path: o gatilho é ESTREITO. Marcar um prejuízo real como unidade-suspeita e
+  // rebaixá-lo a proxy reintroduziria o bug do #988 (esconder prejuízo) por outra porta.
+  it('M2 SEM dimensão na descrição (H3 ausente) → NÃO re-mascara: continua CMC_MARGEM_ATIPICA', () => {
+    // ROLO BTT: unidade M2 mas descrição sem medida LxC. cmc 38 vs price 8.50 = prejuízo real visível.
+    const produtos: ProdutoCusto[] = [
+      { id: 'btt', valor_unitario: 8.5, familia: 'B', unidade: 'M2', descricao: 'ROLO BTT VERDE' },
+    ];
+    const r = byId(montarUpsertsDeCusto(produtos, {}, { btt: { cmc: 38 } }, cfg, NOW).rows, 'btt');
+    expect(r.cost_source).toBe('CMC_MARGEM_ATIPICA');
+    expect(r.cost_price).toBe(38); // prejuízo real preservado, NÃO mascarado
+  });
+
+  it('unidade UN (discreta) com margem atípica + dimensão na descrição → continua CMC_MARGEM_ATIPICA (H1 falha)', () => {
+    const produtos: ProdutoCusto[] = [
+      { id: 'un', valor_unitario: 100, familia: 'C', unidade: 'UN', descricao: 'CHAPA 100X200MM' },
+    ];
+    const r = byId(montarUpsertsDeCusto(produtos, {}, { un: { cmc: 96 } }, cfg, NOW).rows, 'un');
+    expect(r.cost_source).toBe('CMC_MARGEM_ATIPICA'); // margem 4% real, visível
+  });
+
+  it('M2 + dimensão mas margem NORMAL (dentro da banda) → CMC normal (decorator só atua sobre atípico)', () => {
+    const produtos: ProdutoCusto[] = [
+      { id: 'm2', valor_unitario: 100, familia: 'D', unidade: 'M2', descricao: 'LIXA 300X50000MM' },
+    ];
+    const r = byId(montarUpsertsDeCusto(produtos, {}, { m2: { cmc: 60 } }, cfg, NOW).rows, 'm2');
+    expect(r.cost_source).toBe('CMC'); // margem 0.4, dentro da banda — intocado
+  });
+
+  it('unidade L (líquido) fora da 1a versão → NÃO marca, mesmo com dimensão (falso-positivo do litro evitado)', () => {
+    const produtos: ProdutoCusto[] = [
+      { id: 'liq', valor_unitario: 100, familia: 'E', unidade: 'L', descricao: 'VERNIZ 10X10MM' },
+    ];
+    const r = byId(montarUpsertsDeCusto(produtos, {}, { liq: { cmc: 8 } }, cfg, NOW).rows, 'liq');
+    expect(r.cost_source).toBe('CMC_MARGEM_ATIPICA'); // margem 92% real fica visível, não mascarada
+  });
+});

--- a/src/lib/custo/costCompute.ts
+++ b/src/lib/custo/costCompute.ts
@@ -18,10 +18,30 @@ import {
   type CostSource,
 } from './costLadder';
 
+/** cost_source da escada + a fonte do decorator de unidade-suspeita (mantém costLadder.ts intacto). */
+export type CostSourceComUnidade = CostSource | 'CMC_UNIDADE_SUSPEITA';
+
+// Decorator de unidade-suspeita — unidades geométricas (área/comprimento) cujo custo (cmc) é por
+// sub-unidade enquanto o price está noutra unidade. KG/L/G/ML ficam de FORA da 1a versão (falso-
+// positivo: líquido custeado E vendido por litro com margem real alta). Spec 2026-06-22.
+const UNIDADES_GEOMETRICAS = new Set(['M2', 'M', 'MT', 'CM', 'CM2']);
+const DIMENSAO_RE = /([0-9]+) *[Xx] *([0-9]+) *MM/;
+
+/** H1 (unidade geométrica) ∧ H3 (dimensão LxC MM na descrição). Gatilho do decorator (junto de H4). */
+function unidadeSuspeita(unidade?: string | null, descricao?: string | null): boolean {
+  const u = unidade?.trim().toUpperCase();
+  if (!u || !UNIDADES_GEOMETRICAS.has(u)) return false;
+  return descricao != null && DIMENSAO_RE.test(descricao);
+}
+
 export interface ProdutoCusto {
   id: string;
   valor_unitario: number;
   familia: string | null;
+  /** Unidade de medida do Omie (M2/M/UN/KG/L...). Sinal H1 do decorator de unidade-suspeita. */
+  unidade?: string | null;
+  /** Descrição do produto — fonte do sinal H3 (dimensão LxC MM) do decorator de unidade-suspeita. */
+  descricao?: string | null;
 }
 
 /** Só `cmc` importa do product_costs persistido (pós-#977 o cost_price legado não é mais lido). */
@@ -39,7 +59,7 @@ export interface UpsertCusto {
   cost_price: number | null;
   cmc: number;
   cost_final: number;
-  cost_source: CostSource;
+  cost_source: CostSourceComUnidade;
   cost_confidence: number;
   family_category: string | null;
   updated_at: string;
@@ -87,12 +107,24 @@ export function montarUpsertsDeCusto(
     const familyTargetMargin =
       famData && famData.count >= 3 ? famData.totalMargin / famData.count : null;
 
-    const { costFinal, costSource, costConfidence, costPriceToPersist } = computeCostLadder({
-      price,
-      cmc,
-      familyTargetMargin,
-      cfg,
-    });
+    const base = computeCostLadder({ price, cmc, familyTargetMargin, cfg });
+    let costFinal = base.costFinal;
+    let costConfidence = base.costConfidence;
+    let costPriceToPersist = base.costPriceToPersist;
+    let costSource: CostSourceComUnidade = base.costSource;
+
+    // Decorator de unidade-suspeita (money-path): um CMC_MARGEM_ATIPICA cujo "atipismo" vem de
+    // DESCASAMENTO DE UNIDADE (cmc por m²/m vs price noutra unidade), não de prejuízo real. Re-chama
+    // a escada com cmc=null para herdar o proxy honesto (família/default) e re-rotula a proveniência:
+    // cost_final=proxy, cost_price=null (cmc não comparável ao price), confiança do proxy. O cmc cru
+    // segue preservado no campo cmc (auditoria). costLadder.ts permanece intacto (decisão do spec).
+    if (base.costSource === 'CMC_MARGEM_ATIPICA' && unidadeSuspeita(product.unidade, product.descricao)) {
+      const proxy = computeCostLadder({ price, cmc: null, familyTargetMargin, cfg });
+      costFinal = proxy.costFinal;
+      costConfidence = proxy.costConfidence;
+      costPriceToPersist = null;
+      costSource = 'CMC_UNIDADE_SUSPEITA';
+    }
 
     // cost_price guarda SÓ custo real: o CMC quando há, senão null (NUNCA proxy — era a
     // causa da lavagem de proveniência). PRODUCT_COST saiu da escada; o motor não o emite.

--- a/src/lib/custos/__tests__/cost-source.test.ts
+++ b/src/lib/custos/__tests__/cost-source.test.ts
@@ -96,3 +96,23 @@ describe('CMC_MARGEM_ATIPICA — custo real atípico propaga como real (margem n
     expect(resolverCustoConfiavel(row({ cost_source: 'CMC_MARGEM_ATIPICA', cost_final: 0, cost_price: 0 }))).toBeNull();
   });
 });
+
+// CMC_UNIDADE_SUSPEITA é DESCASAMENTO DE UNIDADE (cmc por m² vs price noutra unidade). O cost_final é
+// PROXY de família — NÃO é custo real comparável: fica FORA de COST_SOURCES_REAIS (margem exibida null),
+// mas ENTRA como proxy p/ ranking (decisão D3 + achado do Codex: estimarCustoParaRanking retornava null
+// p/ a fonte nova). Diferente do CMC_MARGEM_ATIPICA, que é real e propaga.
+describe('CMC_UNIDADE_SUSPEITA — descasamento de unidade: proxy p/ ranking, nunca margem exibida', () => {
+  it('resolverCustoConfiavel → null (cmc não comparável ao price; não é custo real de margem)', () => {
+    expect(resolverCustoConfiavel(row({ cost_source: 'CMC_UNIDADE_SUSPEITA', cost_final: 60 }))).toBeNull();
+  });
+  it('estimarCustoParaRanking usa o cost_final proxy (<price) p/ ranking', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'CMC_UNIDADE_SUSPEITA', cost_final: 60 }), 100)).toBe(60);
+  });
+  it('derivarMargensCandidato: margem exibida null (não fabrica), ranking via proxy', () => {
+    expect(derivarMargensCandidato(row({ cost_source: 'CMC_UNIDADE_SUSPEITA', cost_final: 60 }), 100))
+      .toEqual({ custoConfiavel: null, custoRanking: 60, margemExibida: null, margemRanking: 40 });
+  });
+  it('proxy ≥ price (margem estimada ≤0) → ranking null (sanity bound do proxy vale aqui também)', () => {
+    expect(estimarCustoParaRanking(row({ cost_source: 'CMC_UNIDADE_SUSPEITA', cost_final: 120 }), 100)).toBeNull();
+  });
+});

--- a/src/lib/custos/cost-source.ts
+++ b/src/lib/custos/cost-source.ts
@@ -14,7 +14,9 @@ export type CostRow = {
 // CMC_MARGEM_ATIPICA é CMC REAL fora da banda de margem comercial (prejuízo/baixa/alta) — custo real
 // de confiança rebaixada. É REAL (propaga como custo): a margem ruim fica VISÍVEL, nunca mascarada por proxy.
 const COST_SOURCES_REAIS = new Set(['PRODUCT_COST', 'CMC', 'CMC_MARGEM_ATIPICA']);
-const COST_SOURCES_PROXY = new Set(['FAMILY_MARGIN_PROXY', 'DEFAULT_PROXY']);
+// CMC_UNIDADE_SUSPEITA é descasamento de unidade (cmc por m²/m vs price noutra unidade): o cost_final é
+// proxy de família, NÃO custo real — fica fora de REAIS (sem margem exibida) mas conta como PROXY p/ ranking.
+const COST_SOURCES_PROXY = new Set(['FAMILY_MARGIN_PROXY', 'DEFAULT_PROXY', 'CMC_UNIDADE_SUSPEITA']);
 
 function finitePositive(x: number | null | undefined): x is number {
   return typeof x === 'number' && Number.isFinite(x) && x > 0;

--- a/supabase/functions/_shared/cost-compute.ts
+++ b/supabase/functions/_shared/cost-compute.ts
@@ -18,10 +18,30 @@ import {
   type CostSource,
 } from './cost-ladder.ts';
 
+/** cost_source da escada + a fonte do decorator de unidade-suspeita (mantém costLadder.ts intacto). */
+export type CostSourceComUnidade = CostSource | 'CMC_UNIDADE_SUSPEITA';
+
+// Decorator de unidade-suspeita — unidades geométricas (área/comprimento) cujo custo (cmc) é por
+// sub-unidade enquanto o price está noutra unidade. KG/L/G/ML ficam de FORA da 1a versão (falso-
+// positivo: líquido custeado E vendido por litro com margem real alta). Spec 2026-06-22.
+const UNIDADES_GEOMETRICAS = new Set(['M2', 'M', 'MT', 'CM', 'CM2']);
+const DIMENSAO_RE = /([0-9]+) *[Xx] *([0-9]+) *MM/;
+
+/** H1 (unidade geométrica) ∧ H3 (dimensão LxC MM na descrição). Gatilho do decorator (junto de H4). */
+function unidadeSuspeita(unidade?: string | null, descricao?: string | null): boolean {
+  const u = unidade?.trim().toUpperCase();
+  if (!u || !UNIDADES_GEOMETRICAS.has(u)) return false;
+  return descricao != null && DIMENSAO_RE.test(descricao);
+}
+
 export interface ProdutoCusto {
   id: string;
   valor_unitario: number;
   familia: string | null;
+  /** Unidade de medida do Omie (M2/M/UN/KG/L...). Sinal H1 do decorator de unidade-suspeita. */
+  unidade?: string | null;
+  /** Descrição do produto — fonte do sinal H3 (dimensão LxC MM) do decorator de unidade-suspeita. */
+  descricao?: string | null;
 }
 
 /** Só `cmc` importa do product_costs persistido (pós-#977 o cost_price legado não é mais lido). */
@@ -39,7 +59,7 @@ export interface UpsertCusto {
   cost_price: number | null;
   cmc: number;
   cost_final: number;
-  cost_source: CostSource;
+  cost_source: CostSourceComUnidade;
   cost_confidence: number;
   family_category: string | null;
   updated_at: string;
@@ -87,12 +107,24 @@ export function montarUpsertsDeCusto(
     const familyTargetMargin =
       famData && famData.count >= 3 ? famData.totalMargin / famData.count : null;
 
-    const { costFinal, costSource, costConfidence, costPriceToPersist } = computeCostLadder({
-      price,
-      cmc,
-      familyTargetMargin,
-      cfg,
-    });
+    const base = computeCostLadder({ price, cmc, familyTargetMargin, cfg });
+    let costFinal = base.costFinal;
+    let costConfidence = base.costConfidence;
+    let costPriceToPersist = base.costPriceToPersist;
+    let costSource: CostSourceComUnidade = base.costSource;
+
+    // Decorator de unidade-suspeita (money-path): um CMC_MARGEM_ATIPICA cujo "atipismo" vem de
+    // DESCASAMENTO DE UNIDADE (cmc por m²/m vs price noutra unidade), não de prejuízo real. Re-chama
+    // a escada com cmc=null para herdar o proxy honesto (família/default) e re-rotula a proveniência:
+    // cost_final=proxy, cost_price=null (cmc não comparável ao price), confiança do proxy. O cmc cru
+    // segue preservado no campo cmc (auditoria). costLadder.ts permanece intacto (decisão do spec).
+    if (base.costSource === 'CMC_MARGEM_ATIPICA' && unidadeSuspeita(product.unidade, product.descricao)) {
+      const proxy = computeCostLadder({ price, cmc: null, familyTargetMargin, cfg });
+      costFinal = proxy.costFinal;
+      costConfidence = proxy.costConfidence;
+      costPriceToPersist = null;
+      costSource = 'CMC_UNIDADE_SUSPEITA';
+    }
 
     // cost_price guarda SÓ custo real: o CMC quando há, senão null (NUNCA proxy — era a
     // causa da lavagem de proveniência). PRODUCT_COST saiu da escada; o motor não o emite.

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -975,11 +975,11 @@ async function computeCosts(db: SupabaseClient) {
   // Catálogo ATIVO inteiro — PAGINADO: o PostgREST capa o .select() em 1000 linhas em
   // SILÊNCIO (docs/agent/database.md §5). Sem isto, ~2/3 dos ~3k produtos ativos nunca
   // eram recalculados. .order("id") = coluna estável exigida pelo .range() entre páginas.
-  const products = await fetchAll<{ id: string; valor_unitario: number; familia: string | null }>(
+  const products = await fetchAll<{ id: string; valor_unitario: number; familia: string | null; unidade: string | null; descricao: string | null }>(
     (from, to) =>
       db
         .from("omie_products")
-        .select("id, valor_unitario, familia")
+        .select("id, valor_unitario, familia, unidade, descricao")
         .eq("ativo", true)
         .order("id", { ascending: true })
         .range(from, to),

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -30,7 +30,9 @@ function minMaxNorm(values: number[]): number[] {
 type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
 // CMC_MARGEM_ATIPICA = CMC real fora da banda de margem (prejuízo/baixa/alta) — REAL, propaga como custo.
 const COST_SOURCES_REAIS = new Set(["PRODUCT_COST", "CMC", "CMC_MARGEM_ATIPICA"]);
-const COST_SOURCES_PROXY = new Set(["FAMILY_MARGIN_PROXY", "DEFAULT_PROXY"]);
+// CMC_UNIDADE_SUSPEITA é descasamento de unidade (cmc por m²/m vs price noutra unidade): o cost_final é
+// proxy de família, NÃO custo real — fica fora de REAIS (sem margem exibida) mas conta como PROXY p/ ranking.
+const COST_SOURCES_PROXY = new Set(["FAMILY_MARGIN_PROXY", "DEFAULT_PROXY", "CMC_UNIDADE_SUSPEITA"]);
 function finitePositive(x: number | null | undefined): x is number {
   return typeof x === "number" && Number.isFinite(x) && x > 0;
 }


### PR DESCRIPTION
Implementa o CMC_UNIDADE_SUSPEITA (spec #994). Fecha o follow-up técnico do #988.

PROBLEMA: ~40 dos 116 CMC_MARGEM_ATIPICA são jumbos/rolos de lixa M2 cujo cmc é por m² (~R$31) e o price está noutra unidade (~R$220) — a escada vê "margem 86%" sem sentido. É descasamento de unidade, não prejuízo real.

SOLUÇÃO (decorator pós-escada — costLadder.ts INTACTO):
- montarUpsertsDeCusto: após a escada retornar CMC_MARGEM_ATIPICA, se unidade geométrica (M2/M/MT/CM/CM2) + dimensão LxC na descrição → re-rotula CMC_UNIDADE_SUSPEITA: cost_final degrada ao proxy de família, cost_price=null, cmc cru preservado, confiança do proxy.
- Gatilho ESTREITO (money-path, precisão>recall): M2 SEM dimensão continua CMC_MARGEM_ATIPICA (não re-mascara prejuízo real — não reintroduz o bug do #988). KG/L fora da 1a versão (falso-positivo do litro).
- cost-source.ts: CMC_UNIDADE_SUSPEITA em COST_SOURCES_PROXY (proxy p/ ranking, fora de REAIS = sem margem exibida) — achado do Codex sobre estimarCustoParaRanking.

Decisões batidas: /codex consult + Claude (D1-D5, spec #994).

ESPELHOS: _shared/cost-compute.ts (paridade byte-a-byte) + recommend/index.ts. omie-analytics-sync: select +unidade +descricao. algorithm-a-audit inalterado (só usa REAIS).

VERIFICAÇÃO: TDD + falsificação (sabotagem → 3 vermelhos nos casos certos → revertida). typecheck strict 0; suíte completa 3995/3995 (2 paridades); deno check omie-analytics-sync 0 (recommend/algorithm-a-audit têm 39 erros PRÉ-EXISTENTES, provados sem a mudança — não-regressão).

DEPLOY MANUAL pós-merge:
1. Edges omie-analytics-sync + recommend (chat Lovable, verbatim) — algorithm-a-audit NÃO mudou.
2. Recompute compute_costs (/admin/analytics-sync → Recalcular Custos).
3. Publish frontend (cost-source.ts mudou a régua de margem).
Sem migration (cost_source é text livre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)