### PR TITLE
fix(sync): resolução de product_id account-aware no syncInventory(Full) — anti-contaminação de CMC cross-company [money-path]

### DIFF
--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -3,6 +3,7 @@ import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { montarUpsertsDeCusto } from "../_shared/cost-compute.ts";
+import { buildProductIdMap } from "./product-idmap.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -37,6 +38,10 @@ function accountToEmpresa(account: OmieAccount): Empresa {
       return "colacor";
     case "servicos":
       return "colacor_sc";
+    default:
+      // fail-closed: account fora do enum (input inválido no boundary JSON) NÃO pode virar
+      // .eq("account", undefined) — aborta em vez de resolver product_id contra a empresa errada.
+      throw new Error(`accountToEmpresa: OmieAccount inválido: ${String(account)}`);
   }
 }
 
@@ -743,8 +748,8 @@ async function syncInventory(db: SupabaseClient, account: OmieAccount) {
       const produtos = result.produtos || [];
 
       for (const prod of produtos) {
-        const codProd = prod.nCodProd;
-        if (!codProd) continue;
+        const codProd = Number(prod.nCodProd); // normaliza: a API Omie pode devolver string; a chave do idMap é number
+        if (!Number.isSafeInteger(codProd) || codProd <= 0) continue;
         posicoes.set(codProd, {
           saldo: prod.nSaldo ?? 0,
           cmc: prod.nCMC ?? 0,
@@ -769,22 +774,31 @@ async function syncInventory(db: SupabaseClient, account: OmieAccount) {
       return { totalSynced: 0 };
     }
 
-    // 2) RESOLVE product_id em LOTE. Preserva a semântica do .maybeSingle() anterior:
-    //    exatamente 1 match → id; 0 ou 2+ (ambíguo — omie_products é UNIQUE por (código,account)) → null.
-    const idByCod = new Map<number, string | null>();
+    // 2) RESOLVE product_id em LOTE, ESCOPADO À EMPRESA da account (accountToEmpresa).
+    //    omie_products é UNIQUE(omie_codigo_produto, account=EMPRESA): sem o filtro, a resolução
+    //    account-blind poderia mapear o código para o product_id de OUTRA empresa (mesmo número em
+    //    empresas distintas, OU código que só existe na empresa errada) → CMC/saldo no produto
+    //    errado. Com .eq("account", empresa), dentro da empresa o código é único.
+    //    buildProductIdMap nulifica qualquer ambíguo residual (defense-in-depth: se o filtro/UNIQUE
+    //    falhar, degrada p/ null em vez de gravar no errado — esperado 0 com o filtro).
+    const empresa = accountToEmpresa(account);
+    const prodRows: Array<{ id: string | null; omie_codigo_produto: number | string | null }> = [];
     for (const chunk of chunked(codProds, 300)) {
       const { data, error } = await db
         .from("omie_products")
         .select("id, omie_codigo_produto")
+        .eq("account", empresa)
         .in("omie_codigo_produto", chunk);
       if (error) {
         console.error(`[Sync ${account}] resolve product_id:`, error);
         continue;
       }
-      for (const r of data || []) {
-        const cod = r.omie_codigo_produto as number;
-        idByCod.set(cod, idByCod.has(cod) ? null : (r.id as string)); // 2+ ocorrências → null (ambíguo)
-      }
+      prodRows.push(...(data ?? []));
+    }
+    const idByCod = buildProductIdMap(prodRows);
+    const ambiguos = [...idByCod.values()].filter((v) => v === null).length;
+    if (ambiguos > 0) {
+      console.warn(`[Sync ${account}] ${ambiguos} código(s) ambíguo(s) em omie_products(${empresa}) — product_id nulificado (esperado 0 com filtro account-aware)`);
     }
 
     // 3) inventory_position — upsert em LOTE (onConflict (omie_codigo_produto, account)).
@@ -878,17 +892,31 @@ async function syncInventory(db: SupabaseClient, account: OmieAccount) {
 async function syncInventoryFull(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "inventory_full", account, { status: "running", error_message: null });
   try {
-    // 1) Map omie_products: omie_codigo_produto -> id (bulk paginado, fura o cap de 1000 do PostgREST)
-    const idMap = new Map<number, string>();
+    // 1) Map omie_products: omie_codigo_produto -> id, ESCOPADO À EMPRESA da account
+    //    (accountToEmpresa). omie_products é UNIQUE(omie_codigo_produto, account=EMPRESA); sem o
+    //    filtro, a resolução account-blind gravaria CMC/saldo no product_id de OUTRA empresa
+    //    (mesmo número em empresas distintas, OU código que só existe na empresa errada — caso do
+    //    `servicos`, que não tem catálogo colacor_sc em omie_products). Bulk paginado fura o cap de
+    //    1000 do PostgREST; .order("id") = paginação estável exigida pelo .range() (mesmo padrão de
+    //    computeCosts). buildProductIdMap nulifica ambíguo residual (defense-in-depth).
+    const empresa = accountToEmpresa(account);
+    const allProdRows: Array<{ id: string | null; omie_codigo_produto: number | string | null }> = [];
     for (let from = 0; ; from += 1000) {
       const { data, error } = await db
         .from("omie_products")
         .select("id, omie_codigo_produto")
+        .eq("account", empresa)
+        .order("id", { ascending: true })
         .range(from, from + 999);
       if (error) throw error;
       const rows = data ?? [];
-      for (const r of rows) idMap.set(Number(r.omie_codigo_produto), r.id as string);
+      allProdRows.push(...rows);
       if (rows.length < 1000) break;
+    }
+    const idMap = buildProductIdMap(allProdRows);
+    const ambiguos = [...idMap.values()].filter((v) => v === null).length;
+    if (ambiguos > 0) {
+      console.warn(`[Sync ${account}] ${ambiguos} código(s) ambíguo(s) em omie_products(${empresa}) — product_id nulificado (esperado 0 com filtro account-aware)`);
     }
 
     // 2) Paginar ListarPosEstoque com cExibeTodos:"S" (callOmie já tem retry/backoff p/ falha transitória)
@@ -915,8 +943,8 @@ async function syncInventoryFull(db: SupabaseClient, account: OmieAccount) {
       totalPaginas = result.nTotPaginas || 1;
       const now = new Date().toISOString();
       for (const prod of result.produtos || []) {
-        const codProd = prod.nCodProd;
-        if (!codProd) continue;
+        const codProd = Number(prod.nCodProd); // normaliza: a API Omie pode devolver string; a chave do idMap é number
+        if (!Number.isSafeInteger(codProd) || codProd <= 0) continue;
         invRows.push({
           omie_codigo_produto: codProd,
           product_id: idMap.get(codProd) ?? null,

--- a/supabase/functions/omie-analytics-sync/product-idmap.ts
+++ b/supabase/functions/omie-analytics-sync/product-idmap.ts
@@ -1,0 +1,32 @@
+// Resolve omie_codigo_produto -> product_id a partir de linhas de omie_products, NULIFICANDO
+// o código AMBÍGUO. money-path: omie_products é UNIQUE (omie_codigo_produto, account) e
+// `account` é convenção EMPRESA (oben/colacor/colacor_sc — docs/agent/database.md §5), então o
+// MESMO número de código pode existir em >1 empresa. Resolver account-blind com last-wins
+// gravaria o CMC/saldo lido de UMA empresa no product_id de OUTRA (contaminação cross-company →
+// custo errado no EOQ da Reposição). Precisão > recall: na dúvida, não grava (product_id null).
+// O caller filtra omie_products por empresa (.eq("account", accountToEmpresa(account))) ANTES de
+// chamar isto — então, com UNIQUE(código,account), NÃO deve sobrar ambíguo; este guard é o
+// defense-in-depth se o filtro/constraint falhar (degrada p/ null, nunca grava no errado).
+//
+// "Ambíguo" = 2+ product_ids DISTINTOS para o mesmo código (NÃO "2+ ocorrências"): a paginação
+// .range() do syncInventoryFull pode repetir a MESMA linha (mesmo id) — repetição de paginação
+// não pode custar a cobertura de CMC de um produto legítimo. É o mesmo guard que o syncInventory
+// já fazia inline (idByCod.set(cod, has(cod) ? null : id)), agora unificado e testado.
+export function buildProductIdMap(
+  rows: Array<{ id: string | null; omie_codigo_produto: number | string | null }>,
+): Map<number, string | null> {
+  const map = new Map<number, string | null>();
+  for (const r of rows) {
+    if (r.omie_codigo_produto == null || r.id == null) continue;
+    const cod = Number(r.omie_codigo_produto);
+    if (!Number.isSafeInteger(cod) || cod <= 0) continue; // só inteiro positivo SEGURO (0/neg/frac/NaN/>2^53 fora — Number(null/"")===0 nunca vira entrada)
+    const id = String(r.id);
+    if (!map.has(cod)) {
+      map.set(cod, id);
+    } else {
+      const atual = map.get(cod);
+      if (atual !== null && atual !== id) map.set(cod, null); // 2+ ids distintos → ambíguo
+    }
+  }
+  return map;
+}

--- a/supabase/functions/omie-analytics-sync/product-idmap_test.ts
+++ b/supabase/functions/omie-analytics-sync/product-idmap_test.ts
@@ -1,0 +1,111 @@
+// Testa o CÓDIGO REAL de product-idmap.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test supabase/functions/omie-analytics-sync/product-idmap_test.ts
+//
+// Money-path: buildProductIdMap resolve omie_codigo_produto -> product_id NULIFICANDO o
+// código AMBÍGUO (mesmo número em >1 account — omie_products é UNIQUE (omie_codigo_produto,
+// account)). Sem isso, o CMC/saldo lido de UMA empresa seria gravado no product_id de OUTRA
+// (contaminação de custo cross-company → EOQ/reposição errado). É a paridade que faltava
+// entre syncInventoryFull (que NÃO tinha o guard) e syncInventory (que já nulifica ambíguo).
+import { buildProductIdMap } from "./product-idmap.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+// ── Caso 1:1 (realidade de produção hoje: 7921 códigos, cada um em 1 só account) ──
+Deno.test("1:1 — código único mapeia para seu product_id", () => {
+  const map = buildProductIdMap([
+    { id: "id-a", omie_codigo_produto: 100 },
+    { id: "id-b", omie_codigo_produto: 200 },
+  ]);
+  assertEquals(map.get(100), "id-a");
+  assertEquals(map.get(200), "id-b");
+  assertEquals(map.size, 2);
+});
+
+// ── O BUG: mesmo código em 2 accounts (2 product_ids DISTINTOS) → null (não grava no errado) ──
+Deno.test("ambíguo — código 12345 em oben E colacor → null (paridade syncInventory)", () => {
+  const map = buildProductIdMap([
+    { id: "id-oben", omie_codigo_produto: 12345 },
+    { id: "id-colacor", omie_codigo_produto: 12345 },
+  ]);
+  assertEquals(map.get(12345), null); // NÃO 'id-colacor' (last-wins) nem 'id-oben'
+});
+
+// ── A ambiguidade NÃO depende da ordem da paginação (qual veio por último) ──
+Deno.test("ambíguo — independe da ordem das linhas", () => {
+  const ab = buildProductIdMap([
+    { id: "id-oben", omie_codigo_produto: 12345 },
+    { id: "id-colacor", omie_codigo_produto: 12345 },
+  ]);
+  const ba = buildProductIdMap([
+    { id: "id-colacor", omie_codigo_produto: 12345 },
+    { id: "id-oben", omie_codigo_produto: 12345 },
+  ]);
+  assertEquals(ab.get(12345), null);
+  assertEquals(ba.get(12345), null);
+});
+
+// ── 3 accounts (3 ids distintos) → null ──
+Deno.test("ambíguo — 3 product_ids distintos para o mesmo código → null", () => {
+  const map = buildProductIdMap([
+    { id: "id-1", omie_codigo_produto: 7 },
+    { id: "id-2", omie_codigo_produto: 7 },
+    { id: "id-3", omie_codigo_produto: 7 },
+  ]);
+  assertEquals(map.get(7), null);
+});
+
+// ── ROBUSTEZ: a MESMA linha (mesmo product_id) repetida NÃO é ambígua ──
+// Distingue "2+ ids DISTINTOS" (ambíguo de verdade) de "2+ ocorrências" (que a paginação
+// .range() SEM .order() do syncInventoryFull pode produzir ao repetir uma linha). Repetição
+// de paginação não pode custar a cobertura de CMC de um produto legítimo.
+Deno.test("robustez — mesma linha (mesmo id) repetida → mantém o id, NÃO vira ambíguo", () => {
+  const map = buildProductIdMap([
+    { id: "id-x", omie_codigo_produto: 999 },
+    { id: "id-x", omie_codigo_produto: 999 },
+  ]);
+  assertEquals(map.get(999), "id-x");
+});
+
+// ── Bordas: linha sem código ou sem id é ignorada; código numérico-string normaliza ──
+Deno.test("borda — omie_codigo_produto null/id null são ignorados", () => {
+  const map = buildProductIdMap([
+    { id: "id-a", omie_codigo_produto: null },
+    { id: null, omie_codigo_produto: 5 },
+    { id: "id-b", omie_codigo_produto: 6 },
+  ]);
+  assertEquals(map.has(0), false); // Number(null)===0 NÃO pode virar uma entrada fabricada
+  assertEquals(map.has(5), false); // id null → não mapeia
+  assertEquals(map.get(6), "id-b");
+});
+
+Deno.test("borda — código vindo como string numérica normaliza; não-numérico é ignorado", () => {
+  const map = buildProductIdMap([
+    { id: "id-a", omie_codigo_produto: "42" },
+    { id: "id-b", omie_codigo_produto: "abc" },
+  ]);
+  assertEquals(map.get(42), "id-a");
+  assertEquals(map.has(NaN), false);
+  assertEquals(map.size, 1);
+});
+
+// ── Só código INTEIRO POSITIVO SEGURO entra (0 / negativo / fracional / "" / >2^53 → fora) ──
+Deno.test("borda — 0, negativo, fracional, string vazia e inteiro inseguro são rejeitados", () => {
+  const map = buildProductIdMap([
+    { id: "id-zero", omie_codigo_produto: 0 },
+    { id: "id-neg", omie_codigo_produto: -3 },
+    { id: "id-frac", omie_codigo_produto: 4.5 },
+    { id: "id-empty", omie_codigo_produto: "" }, // Number("")===0 → não pode virar entrada
+    { id: "id-big", omie_codigo_produto: Number.MAX_SAFE_INTEGER + 1 }, // >2^53 arredondaria → fora
+    { id: "id-ok", omie_codigo_produto: 7 },
+  ]);
+  assertEquals(map.has(0), false);
+  assertEquals(map.has(-3), false);
+  assertEquals(map.has(4.5), false);
+  assertEquals(map.has(Number.MAX_SAFE_INTEGER + 1), false);
+  assertEquals(map.get(7), "id-ok");
+  assertEquals(map.size, 1);
+});


### PR DESCRIPTION
## O quê
Resolução de `omie_codigo_produto → product_id` agora é **account-aware** em `syncInventory` e `syncInventoryFull` (edge `omie-analytics-sync`): `.eq("account", accountToEmpresa(account))`. Antes era account-blind (last-wins no `Full`, sem o guard que o `syncInventory` tinha) → risco de gravar CMC/saldo de uma empresa no `product_id` de OUTRA (`omie_products` é UNIQUE(omie_codigo_produto, account=EMPRESA)). Custo errado alimentaria o EOQ da Reposição.

## Por quê / prova
- Prova de produção (psql-ro): **0 códigos ambíguos, 0 contaminação ativa** hoje → hardening defensivo (não-vivo), porém estrutural. `servicos` (49 linhas / 0 product_id, sem catálogo `colacor_sc`) é o ponto mais frágil.
- Codex challenge adversário (xhigh, 2 rodadas): elevou o achado original [P1] para a **raiz account-blind** e validou a versão account-aware (sem regressão/contaminação residual). Fail-closed + `isSafeInteger` aplicados a pedido dele.

## Mudanças
- `.eq("account", accountToEmpresa(account))` na resolução de `omie_products` nos **2 syncs** (cura a raiz).
- `accountToEmpresa` **fail-closed** (throw no default — input inválido não vira `.eq(undefined)`).
- `buildProductIdMap` (função pura, deno-testada): nulifica ambíguo residual = **defense-in-depth** + `console.warn` (esperado 0).
- `.order("id")` na paginação do `Full`; normalização `Number()` + `isSafeInteger() && >0` na ingestão (a API Omie pode devolver string).

## Verificação
- `deno check` ✅ · suíte Deno do edge **32/32** ✅ (TDD red→green em `product-idmap_test.ts`).
- ⚠️ Os testes Deno do edge **não rodam no CI** (gap pré-existente; convenção manual `deno test`).

## ⚠️ Deploy manual (pós-merge) — só camada Edge
Edge `omie-analytics-sync` via **chat do Lovable**, **verbatim**. Inclui **arquivo NOVO** `supabase/functions/omie-analytics-sync/product-idmap.ts` (o `index.ts` importa via `./product-idmap.ts`) — sem ele, `503 LOAD_FUNCTION_ERROR` no boot. **Sem migration, sem frontend.**

## Follow-ups (Codex [P1], fora de escopo)
- `syncInventory` marca `complete` após falha de DB (robustez de erro).
- `syncOrdersIncremental` ainda resolve account-blind (mesma classe, via pedidos/preço).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
