### PR TITLE
docs(worktrees): lição — PR DRAFT parado em domínio QUENTE é ultrapassado

### DIFF
--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -8,6 +8,7 @@
 - Worktrees de `.claude/worktrees/*` (criados pelo Claude Code) isolam automático. Helper: `bun run wt <branch> [base]` (`scripts/new-worktree.sh`, sibling `../afiacao-<branch>` a partir de `origin/main`).
 - Rede de segurança: hook global `~/.claude/hooks/concurrent-session-guard.sh` (SessionStart) **avisa** 2ª sessão no principal (worktrees isentas).
 - ⚠️ **Antes de tocar arquivo/função QUENTE:** `origin/main` atualizado + `gh pr list` + checar migrations de sessões paralelas. Colisão de migration agora tem rede automática — ver "Colisão de migration multi-sessão" abaixo.
+- ⚠️ **PR DRAFT parado em domínio QUENTE envelhece:** segurar um PR money-path em draft (gate humano) enquanto sessões paralelas avançam o MESMO domínio pode torná-lo redundante + caro (N rebases num alvo móvel). Antes de **retomar/reabrir** um PR parado — não só ao criá-lo — rechecar `gh pr list` + commits do domínio em `origin/main`; se o núcleo já mergeou, **fechar > reconciliar** (evita sinal/detector duplicado no mesmo helper). Caso real: #959 (`custo_proxy` do cockpit) suplantado em ~1 dia por #1003 (confiança por custo proxy) + #977 (lavagem de proveniência) — fechado, não reconciliado.
 
 ## Colisão de migration multi-sessão (`wt:preflight` + hook)
 


### PR DESCRIPTION
Uma linha em `docs/agent/worktrees.md` (§Uma sessão por working tree), capturando a lição desta sessão.

**Caso real:** o #959 (`custo_proxy` do cockpit de valor) ficou em DRAFT por gate humano money-path enquanto ~5 sessões paralelas retrabalharam o domínio de custo em ~1 dia. O núcleo (degradar confiança por custo proxy/legado) foi entregue pelo **#1003** e o P1 (lavagem de proveniência `proxy→PRODUCT_COST`) corrigido pelo **#977** — então o #959 foi **fechado, não reconciliado** (reconciliar duplicaria o detector de proxy).

**Regra registrada:** rechecar `gh pr list` + commits do domínio em `origin/main` **antes de retomar/reabrir** um PR parado — não só ao criá-lo; se o núcleo já mergeou, **fechar > reconciliar**.

Só doc — sem código, sem money-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)