### PR TITLE
fix(reposição): omie-sync-estoque trata HTTP 500 sem-registros como fim de páginas (hotfix #2 do #979)

### DIFF
--- a/supabase/functions/omie-sync-estoque/index.ts
+++ b/supabase/functions/omie-sync-estoque/index.ts
@@ -240,6 +240,11 @@ async function callOmiePedidos(
       await new Promise((r) => setTimeout(r, 5000));
       continue;
     }
+    // [fix 2026-06-23] O Omie sinaliza FIM DE PÁGINAS com HTTP 500 + faultstring "Não existem registros para a
+    // página [N]" (faultcode 5113), NÃO com 200+lista-vazia. Sem isto, o throw em !res.ok matava a paginação-até-
+    // vazia na 1ª página-além-do-fim → sync abortava (fail-closed, mas nunca completava). Devolve o json p/ o loop
+    // tratar como fim via FIM_SEM_REGISTROS (conservadora — só o "fim" casa; erro real do Omie ainda lança abaixo).
+    if (!res.ok && json?.faultstring && FIM_SEM_REGISTROS.test(json.faultstring)) return json;
     if (!res.ok) throw new Error(`PesquisarPedCompra HTTP ${res.status}: ${text.slice(0, 300)}`);
     return json;
   }


### PR DESCRIPTION
## Hotfix #2 do #979 — o Omie sinaliza "fim de páginas" com HTTP 500

Após o re-deploy (com `nRegsPorPagina=100`), o sync OBEN **ainda abortava**. Diagnóstico confirmado no deploy real:

O `PesquisarPedCompra` do Omie devolve **fim de páginas** como **HTTP 500** + `faultstring "Não existem registros para a página [N]"` (faultcode 5113), **não** como `200` + lista vazia. O `callOmiePedidos` dava `throw` em qualquer `!res.ok` **antes** da checagem `FIM_SEM_REGISTROS` (que só rodava sobre respostas 200) → a paginação-até-vazia (#979) abortava na 1ª página-além-do-fim.

A edge antiga (`nTotalPaginas`) nunca pedia a página seguinte, então nunca batia nisso — só a paginação-até-vazia expôs o comportamento real do Omie, e só no deploy.

**Fix (5 linhas):** no `callOmiePedidos`, se `!res.ok` **e** a faultstring casa `FIM_SEM_REGISTROS` (regex conservadora), devolve o json pro loop tratar como fim — em vez de lançar. Erro real do Omie ainda lança. `deno check` verde. O fail-closed preservou o pendente o tempo todo (zero corrupção).

⚠️ **Pós-merge (founder):** re-deploy da edge `omie-sync-estoque` + 1 sync OBEN → eu confirmo o smoke.

🔑 **Lição:** a integração `callOmiePedidos` com o Omie não tem cobertura de teste — mocks não refletem o comportamento real (HTTP 500 para "fim"). É o **2º limite do Omie que só o deploy real revela** (o 1º foi `nRegsPorPagina` ≤ 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
