### PR TITLE
docs(scoring): fecha chip P2 leak history/log — auditoria sem leitor money-path

### DIFF
--- a/supabase/functions/calculate-scores/index.ts
+++ b/supabase/functions/calculate-scores/index.ts
@@ -532,6 +532,14 @@ Deno.serve(async (req) => {
     // Insert history in batches of 500. FORA da fronteira fail-closed: history/priority-log são
     // audit append-only (time-series), NÃO estado money-path (a fonte é farmer_client_scores).
     // Se um insert falhar, LOGA warning e segue — não vira 500 (evitaria retry duplicando a série).
+    // [auditoria 2026-06-18, follow-up Codex/#954] Estes records vêm do SNAPSHOT lido no início do
+    // run — NÃO filtrados pelos ids que sobreviveram ao UPDATE — então uma linha de fornecedor
+    // excluído mid-run (cron aplicar_exclusao_fornecedores) pode vazar p/ a série. TOLERADO de
+    // propósito: a varredura (frontend src/ + pg_proc/pg_views/pg_matviews em PROD + crons) não
+    // achou NENHUM leitor money-path destas tabelas — são série-temporal de display/tendência. SE
+    // algum dia surgir um leitor que decida algo FIRME (priorização/comissão/agenda) lendo daqui
+    // direto: filtrar estes inserts pelos ids efetivamente atualizados (ex.: a RPC update-only
+    // anti-ressurreição retornar os ids afetados) ou re-checar excluir_da_carteira. Precisão > recall.
     for (let i = 0; i < healthHistoryRecords.length; i += 500) {
       const { error: hErr } = await supabase.from('health_score_history').insert(healthHistoryRecords.slice(i, i + 500));
       if (hErr) console.warn(`[calculate-scores] health_score_history insert warn @${i}: ${hErr.message}`);


### PR DESCRIPTION
## Contexto
Achado P2 (advisory) do Codex na revisão adversarial da RPC `apply_score_updates` (#954): no edge `calculate-scores`, os inserts em `health_score_history`/`priority_score_log` vêm do **snapshot lido no início do run** e não são filtrados pelos ids que sobreviveram ao UPDATE. Uma linha de fornecedor excluído mid-run (cron `aplicar_exclusao_fornecedores`) pode vazar p/ a série.

Risco **condicional**: só morde *se* algum leitor money-path consumir essas tabelas direto e decidir algo firme (priorização/comissão/agenda).

## Auditoria (fase 1) — conclusiva e negativa
Varredura completa de consumidores das duas tabelas:

| Camada | Verificação | Resultado |
|---|---|---|
| Frontend `src/**` | grep | 0 leitores (só `types.ts` gerado) |
| SQL do repo | grep FROM/JOIN em migrations + snapshot | 0 |
| **SQL em produção** | `pg_proc` + `pg_views` + `pg_matviews` (psql-ro) | **0 — vazio no banco real** |
| Edges | leitura | só `.insert()` — writers |
| Crons | `cron.job` real | nenhum lê; o de scoring escreve via `calculate-scores` |

→ As tabelas são **append-only de auditoria/tendência**, sem nenhum consumidor money-path. A condição do risco é **falsa hoje**.

## Decisão (precisão > recall)
- **Fase 2 (filtrar inserts):** não se aplica — sem consumidor, e a receita preferida (RPC `apply_score_updates` retornar ids) depende de migration que **não está na main**.
- **Fase 3 (prove-sql):** não se aplica — sem SQL novo.
- Mesmo padrão do #957 (fechar chip por verificação, sem mudança funcional).

## O que este PR contém
Apenas o **comentário-âncora** no ponto dos inserts, documentando a tolerância e o **gatilho de reabertura**: se algum dia surgir leitor money-path direto, filtrar os inserts pelos ids efetivamente atualizados ou re-checar `excluir_da_carteira`. Sem mudança funcional (não toca runtime; redeploy do edge opcional).

## Pendências laterais (fora deste chip)
- `supabase/functions/n/index.ts` é duplicata órfã do bot do Lovable (não invocada por nada; o cron real chama `calculate-scores`) — candidata a limpeza após confirmar que não há deploy `n` ativo.
- Chip pré-existente: trocar `upsert(onConflict:'id')` pela RPC `apply_score_updates` (UPDATE-only anti-ressurreição, sessão vibrant-antonelli) — ortogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)