### PR TITLE
feat(valor-cockpit): Por SKU mostra descrição do produto (não o código)

### DIFF
--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -135,10 +135,11 @@ export default function FinanceiroValorCockpit() {
                   aba === 'cliente'
                     ? (row as CockpitRollupCliente).cliente
                     : (row as CockpitRollupSKU).sku;
+                const label = aba === 'sku' ? ((row as CockpitRollupSKU).descricao || id) : id;
                 const recs = aba === 'cliente' ? (recPorCliente.get(id) ?? []) : [];
                 return (
                   <tr key={id} className="border-t border-border">
-                    <td className="py-1 font-tabular">{id}</td>
+                    <td className={`py-1 ${aba === 'sku' ? '' : 'font-tabular'}`} title={aba === 'sku' ? id : undefined}>{label}</td>
                     <td className="text-right">{brl(row.receita)}</td>
                     <td className="text-right">{brl(row.cm)}</td>
                     <td className="text-right text-muted-foreground">{brl(row.encargo)}</td>

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1006,6 +1006,7 @@ export interface CockpitRollupSKU {
   encargo: number | null;
   encargo_total: number | null;
   evp: number | null;
+  descricao?: string | null;  // descrição do produto (omie_products) — UI mostra no lugar do código SKU
 }
 export interface ValorCockpitResult {
   company: string;

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -306,8 +306,8 @@ serve(async (req: Request) => {
 
     // FILTRO OBEN obrigatório: um pedido do app mistura itens das 3 empresas (Oben/Colacor/Colacor SC),
     // enviados separadamente. Sem o filtro por produto, o cockpit da Oben fica contaminado.
-    type Prod = { id: string; omie_codigo_produto: number; account: string };
-    const prods = await fetchAll<Prod>((f, t) => db.from("omie_products").select("id, omie_codigo_produto, account").eq("account", COMPANY).order("id", { ascending: true }).range(f, t), "omie_products");
+    type Prod = { id: string; omie_codigo_produto: number; account: string; descricao: string | null };
+    const prods = await fetchAll<Prod>((f, t) => db.from("omie_products").select("id, omie_codigo_produto, account, descricao").eq("account", COMPANY).order("id", { ascending: true }).range(f, t), "omie_products");
     const obenProductIds = new Set(prods.map((p) => p.id));
     const obenSkus = new Set(prods.map((p) => String(p.omie_codigo_produto)));
     // Bug D: SKU→product_id da Oben p/ recuperar linhas com product_id NULL (gap de FK histórico — 2026-03,
@@ -500,9 +500,12 @@ serve(async (req: Request) => {
     const cobertura_receita = ar_por_app; // retrocompat: mesmo valor de antes
     const confianca = scoreConfiancaCockpit({ cobertura_receita, cobertura_app_por_ar: app_por_ar, custo_ausente_pct, custo_baixa_confianca_pct, ar_indisponivel_pct, estoque_ausente_pct, imposto_estimado: true, hurdle_indisponivel, evp_teto_receita_pct: res.evp_teto_receita_pct });
 
+    // Descrição do produto (omie_products) p/ a UI exibir o nome em vez do código na visão Por SKU.
+    const descricaoPorSKU = new Map(prods.map((p) => [String(p.omie_codigo_produto), p.descricao]));
+    const porSKUcomDescricao = res.porSKU.map((s) => ({ ...s, descricao: descricaoPorSKU.get(s.sku) ?? null }));
     return jsonResponse({
       company: COMPANY, k, hurdle_indisponivel, ttm: { inicio: ttm_inicio, fim: ttm_fim },
-      porCliente: res.porCliente, porSKU: res.porSKU, empresa: res.empresa,
+      porCliente: res.porCliente, porSKU: porSKUcomDescricao, empresa: res.empresa,
       recomendacoesCliente, confianca, cobertura_receita, cobertura_app_por_ar: app_por_ar,
       cobertura_baixa_ar: coberturaBaixaAR, // Fase 3: fração da AR liquidada com baixa derivada REAL (vs vencimento-proxy)
       evp_teto_receita_pct: res.evp_teto_receita_pct, // fração da receita-com-EVP cujo EVP é teto (UI entrega 2)


### PR DESCRIPTION
Visão **Por SKU** do Cockpit de Valor passa a mostrar a **descrição do produto** (`omie_products.descricao`, 100% preenchido na Oben) no lugar do código numérico — pedido do founder para identificar qual produto ajustar o preço. O edge enriquece `porSKU` com `descricao` (helper de EVP **intocado**, sem mudança de número); a UI exibe a descrição (hover mostra o código como referência).

⚠️ **Visão Por cliente fica com código por ora:** o nome de cliente NÃO está no banco (`omie_clientes` sem campo de nome; `fin_contas_receber.nome_cliente` 0/12.514) — vira follow-up (achar a fonte do nome).

Verificação: deno check + typecheck OK (sem teste novo — é passagem de dado). ⚠️ **Deploy 2 canais** (Publish frontend + edge `fin-valor-cockpit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)