### PR TITLE
feat(vendas): sonda de counts (probe_count_pedidos) p/ o backfill colacor

### DIFF
--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1,7 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
-import { omieDateToIso, classifyOmieTransient, classifyPedidosPage } from "./pagination.ts";
+import { omieDateToIso, classifyOmieTransient, classifyPedidosPage, gerarJanelasMensais } from "./pagination.ts";
 
 type OmieGenericResponse = Record<string, unknown> & { faultstring?: string; codigo_status?: number | string; descricao_status?: string };
 
@@ -2474,6 +2474,33 @@ serve(async (req) => {
         if (pedidoIdsReparo.length === 0) throw new Error("reparar_orfaos_itens requer pedido_ids: number[] (omie_pedido_id dos órfãos)");
         const reparoResult = await repararOrfaosItens(supabaseAdmin, account, pedidoIdsReparo);
         result = { success: true, ...reparoResult };
+        break;
+      }
+
+      case "probe_count_pedidos": {
+        // SONDA read-only (Fase 2b): contagem APROXIMADA de pedidos/mês no Omie p/ achar janelas
+        // sub-sincronizadas SEM semear às cegas (achado Codex — o buraco do colacor é ~5 anos).
+        // NÃO escreve nada. registros_por_pagina:1 → total_de_paginas ≈ nº de pedidos (subreporta,
+        // mas serve de SCREEN: 0 vs tem-dado + ordem de grandeza); a contagem EXATA vem do backfill
+        // (paginar-até-vazio). Chunk por ~2-3 anos se a janela grande estourar o timeout (150s).
+        const pdFrom = String(params.date_from || "");
+        const pdTo = String(params.date_to || "");
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(pdFrom) || !/^\d{4}-\d{2}-\d{2}$/.test(pdTo)) {
+          throw new Error("probe_count_pedidos requer date_from/date_to ISO 'YYYY-MM-DD'");
+        }
+        const janelasProbe = gerarJanelasMensais(pdFrom, pdTo);
+        const probe: Array<{ mes: string; omie_aprox: number; tem_dado: boolean }> = [];
+        for (const w of janelasProbe) {
+          const rp = (await callOmieVendasApi(
+            "produtos/pedido/",
+            "ListarPedidos",
+            { pagina: 1, registros_por_pagina: 1, filtrar_apenas_inclusao: "N", filtrar_por_data_de: w.de, filtrar_por_data_ate: w.ate },
+            account,
+          )) as { total_de_paginas?: number; pedido_venda_produto?: unknown[] } | null;
+          const lista = Array.isArray(rp?.pedido_venda_produto) ? (rp!.pedido_venda_produto as unknown[]) : [];
+          probe.push({ mes: w.mes, omie_aprox: Number(rp?.total_de_paginas ?? 0), tem_dado: lista.length > 0 });
+        }
+        result = { success: true, account, meses: probe.length, probe };
         break;
       }
 

--- a/supabase/functions/omie-vendas-sync/pagination.ts
+++ b/supabase/functions/omie-vendas-sync/pagination.ts
@@ -27,6 +27,29 @@ export function omieDateToIso(ddmmyyyy: string): string | null {
   return iso;
 }
 
+// Gera janelas MENSAIS [de..ate] em DD/MM/YYYY entre duas datas ISO (YYYY-MM-DD), o mês de `ate`
+// INCLUSIVE — p/ a sonda de counts (action probe_count_pedidos, Fase 2b colacor): 1 ListarPedidos
+// por mês p/ achar janelas sub-sincronizadas SEM semear às cegas (veto do Codex ao buraco de ~5
+// anos). Último dia do mês via Date.UTC (calendário/bissexto correto, sem timezone local). Guard
+// anti-loop (600 meses ~50 anos) p/ input invertido/absurdo.
+export function gerarJanelasMensais(fromIso: string, toIso: string): Array<{ mes: string; de: string; ate: string }> {
+  const f = /^(\d{4})-(\d{2})-(\d{2})$/.exec(fromIso.trim());
+  const t = /^(\d{4})-(\d{2})-(\d{2})$/.exec(toIso.trim());
+  if (!f || !t) throw new Error(`gerarJanelasMensais: datas ISO inválidas: ${fromIso}..${toIso}`);
+  let y = Number(f[1]), m = Number(f[2]);
+  const ty = Number(t[1]), tm = Number(t[2]);
+  const out: Array<{ mes: string; de: string; ate: string }> = [];
+  let guard = 0;
+  while ((y < ty || (y === ty && m <= tm)) && guard++ < 600) {
+    const mm = String(m).padStart(2, "0");
+    const ultimo = String(new Date(Date.UTC(y, m, 0)).getUTCDate()).padStart(2, "0");
+    out.push({ mes: `${y}-${mm}`, de: `01/${mm}/${y}`, ate: `${ultimo}/${mm}/${y}` });
+    m++;
+    if (m > 12) { m = 1; y++; }
+  }
+  return out;
+}
+
 // Classifica o erro transitório do Omie a partir da mensagem do OMIE_TRANSIENT
 // (lançado por callOmieVendasApi quando throwOnTransient e os retries esgotaram).
 // Vira o `last_error_kind` gravado no cursor (rate_limit | transient).

--- a/supabase/functions/omie-vendas-sync/pagination_test.ts
+++ b/supabase/functions/omie-vendas-sync/pagination_test.ts
@@ -4,7 +4,7 @@
 // Cobre a discriminação money-path do spec (defeito #1: null ambíguo): a página do
 // loop de sync_pedidos deve distinguir FIM REAL (null/vazio → completa) de TRANSITÓRIO
 // (throw → pausa, não completa), e converter as datas do cursor sem ambiguidade.
-import { omieDateToIso, classifyOmieTransient, classifyPedidosPage } from "./pagination.ts";
+import { omieDateToIso, classifyOmieTransient, classifyPedidosPage, gerarJanelasMensais } from "./pagination.ts";
 
 function assertEquals(a: unknown, b: unknown, msg?: string) {
   if (JSON.stringify(a) !== JSON.stringify(b)) {
@@ -17,6 +17,25 @@ Deno.test("omieDateToIso: converte DD/MM/YYYY → YYYY-MM-DD", () => {
   assertEquals(omieDateToIso("17/06/2026"), "2026-06-17");
   assertEquals(omieDateToIso("01/01/2025"), "2025-01-01");
   assertEquals(omieDateToIso("31/12/2024"), "2024-12-31");
+});
+
+// ── gerarJanelasMensais: janelas mensais p/ a sonda de counts (Fase 2b colacor) ──
+Deno.test("gerarJanelasMensais: meses inclusive, DD/MM/YYYY, último dia certo (bissexto)", () => {
+  const j = gerarJanelasMensais("2024-01-15", "2024-03-01");
+  assertEquals(j.map((x) => x.mes), ["2024-01", "2024-02", "2024-03"]);
+  assertEquals(j[0], { mes: "2024-01", de: "01/01/2024", ate: "31/01/2024" });
+  assertEquals(j[1].ate, "29/02/2024", "fev 2024 bissexto");
+  assertEquals(j[2], { mes: "2024-03", de: "01/03/2024", ate: "31/03/2024" });
+});
+
+Deno.test("gerarJanelasMensais: vira o ano + fev não-bissexto", () => {
+  const j = gerarJanelasMensais("2024-11-01", "2025-02-28");
+  assertEquals(j.map((x) => x.mes), ["2024-11", "2024-12", "2025-01", "2025-02"]);
+  assertEquals(j[3].ate, "28/02/2025", "fev 2025 não-bissexto");
+});
+
+Deno.test("gerarJanelasMensais: janela invertida → vazio (guard)", () => {
+  assertEquals(gerarJanelasMensais("2025-06-01", "2024-01-01"), []);
 });
 
 Deno.test("omieDateToIso: tolera espaços nas bordas", () => {


### PR DESCRIPTION
## Fase 2b colacor — a sonda de counts (read-only)

Próximo passo decidido (eu + Codex) após o #B + backfill Oben: o backfill do **colacor**. Escopo medido (psql-ro): colacor tem **~5 anos quase vazios** no banco — **2021-2024 = 0 pedidos**, parcial 2020/2025 — entre 2020 (417) e 2025-09+ (cheio). Uma indústria de abrasivos não para 4 anos → é gap de sync, não de operação.

O Codex **vetou semear às cegas** (~60 janelas/5 anos): exige medir o Omie ANTES, p/ (a) resolver *real-mas-não-sincronizado vs genuinamente-vazio* e (b) validar **completude** (não só crescimento).

### Esta PR
Ação **read-only** `probe_count_pedidos` no `omie-vendas-sync`:
- input `{account, date_from, date_to}` (ISO);
- `gerarJanelasMensais` (em `pagination.ts`, **testado**: bissexto, vira-ano, guard) → 1 `ListarPedidos(registros_por_pagina:1)` por mês → `{mes, omie_aprox, tem_dado}`;
- **não escreve nada** (a contagem exata vem do backfill); chunk por ~2-3 anos se estourar 150s.

Validado: `deno check` · `eslint` (gate CI) · `pagination_test` 13 verdes. Read-only → sem prove-sql/Codex.

### Próximos passos (após esta merge)
1. **Deploy** do `omie-vendas-sync` (chat Lovable, verbatim) — inclui a ação nova.
2. **Rodar a sonda** (colacor 2020-2025) — eu leio o resultado, comparo com o banco, monto a lista de mismatches.
3. **Semear** os mismatches no `vendas_sync_cursor` — **só após a FONTE landar** (backfill limpo, sem patch de recência).
4. Cron+lease processa → validar (dups/outliers/soma/cliente/item) → refresh MV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)