### PR TITLE
feat(valor-cockpit): nome do cliente no cockpit + nome/descrição e código juntos

### DIFF
--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -135,11 +135,15 @@ export default function FinanceiroValorCockpit() {
                   aba === 'cliente'
                     ? (row as CockpitRollupCliente).cliente
                     : (row as CockpitRollupSKU).sku;
-                const label = aba === 'sku' ? ((row as CockpitRollupSKU).descricao || id) : id;
+                const nome = aba === 'cliente' ? (row as CockpitRollupCliente).nome : (row as CockpitRollupSKU).descricao;
+                const temNome = !!nome && nome !== id;
                 const recs = aba === 'cliente' ? (recPorCliente.get(id) ?? []) : [];
                 return (
                   <tr key={id} className="border-t border-border">
-                    <td className={`py-1 ${aba === 'sku' ? '' : 'font-tabular'}`} title={aba === 'sku' ? id : undefined}>{label}</td>
+                    <td className="py-1">
+                      <div className={temNome ? '' : 'font-tabular'}>{temNome ? nome : id}</div>
+                      {temNome && !id.startsWith('app:') && <div className="text-xs text-muted-foreground font-tabular">{id}</div>}
+                    </td>
                     <td className="text-right">{brl(row.receita)}</td>
                     <td className="text-right">{brl(row.cm)}</td>
                     <td className="text-right text-muted-foreground">{brl(row.encargo)}</td>

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -997,6 +997,7 @@ export interface CockpitRollupCliente {
   encargo: number | null;
   encargo_total: number | null;
   evp: number | null;
+  nome?: string | null;  // nome do cliente (profiles via customer_user_id) — UI mostra no lugar do código
 }
 export interface CockpitRollupSKU {
   sku: string;

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -350,6 +350,14 @@ serve(async (req: Request) => {
     // Mapas de apoio (paginados, sem .in para evitar URL gigante + truncamento)
     const clientesAll = await fetchAll<{ user_id: string; omie_codigo_cliente: number }>((f, t) => db.from("omie_clientes").select("user_id, omie_codigo_cliente").order("id", { ascending: true }).range(f, t), "omie_clientes");
     const userToOmie = new Map(clientesAll.map((c) => [c.user_id, String(c.omie_codigo_cliente)]));
+    // Nome do cliente: profiles.user_id = order_items.customer_user_id (~98% cobertura na Oben; psql-ro
+    // 2026-06-23). razao_social tem prioridade, senão name. service_role bypassa a RLS de profiles.
+    const profilesAll = await fetchAll<{ user_id: string | null; razao_social: string | null; name: string | null }>((f, t) => db.from("profiles").select("user_id, razao_social, name").order("id", { ascending: true }).range(f, t), "profiles");
+    const userParaNome = new Map<string, string>();
+    for (const p of profilesAll) {
+      const nome = (p.razao_social?.trim() || p.name?.trim() || "");
+      if (p.user_id && nome) userParaNome.set(p.user_id, nome);
+    }
     // Custo canônico = cost_final (saída do motor de custo). SOURCE-BLIND de propósito: usa cost_final>0 de
     // QUALQUER cost_source (inclusive proxy) — NÃO é a régua resolverCustoConfiavel do recommend/audit
     // (src/lib/custos/cost-source.ts), que gateia source∈REAIS e nulifica proxy. Coincidem nas linhas reais
@@ -410,8 +418,11 @@ serve(async (req: Request) => {
 
     // Combos cliente×SKU — cliente não-mapeado vira 'app:<uuid>' (NÃO funde clientes distintos).
     const comboMap = new Map<string, { cliente: string; sku: string; receita: number; qtd: number; desconto: number; product_id: string | null }>();
+    const clienteParaNome = new Map<string, string>(); // cliente (omie/app) → nome do profile (1º encontrado)
     for (const l of linhas) {
       const cliente = userToOmie.get(l.customer_user_id) ?? `app:${l.customer_user_id}`;
+      const nomeCli = userParaNome.get(l.customer_user_id);
+      if (nomeCli && !clienteParaNome.has(cliente)) clienteParaNome.set(cliente, nomeCli);
       const sku = l.omie_codigo_produto != null ? String(l.omie_codigo_produto) : "sem_sku";
       const key = `${cliente}|${sku}`;
       const receita = l.unit_price * l.quantity - (l.discount ?? 0);
@@ -503,9 +514,10 @@ serve(async (req: Request) => {
     // Descrição do produto (omie_products) p/ a UI exibir o nome em vez do código na visão Por SKU.
     const descricaoPorSKU = new Map(prods.map((p) => [String(p.omie_codigo_produto), p.descricao]));
     const porSKUcomDescricao = res.porSKU.map((s) => ({ ...s, descricao: descricaoPorSKU.get(s.sku) ?? null }));
+    const porClienteComNome = res.porCliente.map((c) => ({ ...c, nome: clienteParaNome.get(c.cliente) ?? null }));
     return jsonResponse({
       company: COMPANY, k, hurdle_indisponivel, ttm: { inicio: ttm_inicio, fim: ttm_fim },
-      porCliente: res.porCliente, porSKU: porSKUcomDescricao, empresa: res.empresa,
+      porCliente: porClienteComNome, porSKU: porSKUcomDescricao, empresa: res.empresa,
       recomendacoesCliente, confianca, cobertura_receita, cobertura_app_por_ar: app_por_ar,
       cobertura_baixa_ar: coberturaBaixaAR, // Fase 3: fração da AR liquidada com baixa derivada REAL (vs vencimento-proxy)
       evp_teto_receita_pct: res.evp_teto_receita_pct, // fração da receita-com-EVP cujo EVP é teto (UI entrega 2)


### PR DESCRIPTION
Estende o #1013 (já em main, que trouxe a descrição no Por SKU). Agora: (1) **Por cliente** mostra o **NOME** do cliente, via `profiles.user_id = customer_user_id` (~98% de cobertura na Oben, medido por psql-ro); (2) as **duas visões** mostram nome/descrição (linha principal) **E** o código (linha secundária, menor/cinza) juntos, em vez de só um. Fallback honesto: sem nome → só o código.

Edge carrega `profiles` (só `user_id, razao_social, name` — campos não-sensíveis; service_role bypassa a RLS). Helper de EVP **intocado** (sem mudança de número). Validação: checagem do edge (Deno) + checagem estática de tipos do frontend, ambas verdes.

⚠️ **Deploy 2 canais** (edge `fin-valor-cockpit` + Publish). Um re-deploy cobre **#958 + #1013 + este** de uma vez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)