### PR TITLE
fix(mutcheck): atualiza contrato .mut do cockpit de valor pós-#1024 [money-path]

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -15,8 +15,12 @@ PEGA | gate evpConhecivel (remove o ! da negação)        | s/= !input\.hurdle_
 PEGA | pedidoContaNoFaturamento: guard soft-delete (!=->==)  | s/if \(deletedAt != null\) return false/if (deletedAt == null) return false/
 PEGA | pedidoContaNoFaturamento: status NULL exclui (==->!=) | s/if \(status == null\) return false/if (status != null) return false/
 PEGA | pedidoContaNoFaturamento: blocklist→allowlist (tira !)| s/return !STATUS_NAO_FATURAVEL\.includes/return STATUS_NAO_FATURAVEL.includes/
-# EVP-teto marcado (#961): capital ausente vira teto DECLARADO, não R$0. Institucionaliza as 3
-# falsificações provadas à mão (guard de sinal anti-piso, evp_parcial, limiar de confiança ponderado).
-PEGA | evp_parcial: OU-de-pernas-ausentes vira E          | s/ar_indisponivel \|\| estoque_indisponivel/ar_indisponivel && estoque_indisponivel/
-PEGA | guard anti-piso: capital negativo entra como num   | s/Number\.isFinite\(estSraw\) && estSraw >= 0/Number.isFinite(estSraw)/
-PEGA | confianca: limiar teto-por-receita 5% afrouxa p/15%| s/tetoPct > 0\.05/tetoPct > 0.15/
+# Omissão honesta do EVP otimista (#1024, sucede #961): teto>0 omitido (evp=null); teto≤0 mantido SE a perna
+# AUSENTE alocaria ≥0 (numerador receita/qtd≥0 E denominador rc/qs>0); agregado decomposto que não finge
+# total. Institucionaliza as falsificações provadas (F1 sinal, F2 anti-piso, F3 denominador) + a agregação (Codex 2026-06-23).
+PEGA | capital_parcial: OU-de-pernas-ausentes vira E         | s/const capital_parcial = ar_indisponivel \|\| estoque_indisponivel/const capital_parcial = ar_indisponivel && estoque_indisponivel/
+PEGA | guard anti-piso: capital negativo entra como num      | s/Number\.isFinite\(estSraw\) && estSraw >= 0/Number.isFinite(estSraw)/
+PEGA | assimetria: teto≤0 mantido vira teto>0 (sinal, F1)    | s/evp_teto <= 0 && estoqueAlocOk/evp_teto > 0 && estoqueAlocOk/
+PEGA | guard denominador AR: remove rc>0 da perna ausente    | s/rc > 0 && Number\.isFinite\(c\.receita_liquida\)/Number.isFinite(c.receita_liquida)/
+PEGA | empresa.evp: remove gate empresaCompleta (finge total)| s/empresaCompleta && !conhecidoNull \? conhecido/!conhecidoNull ? conhecido/
+PEGA | confianca: limiar omitido-por-receita 5% afrouxa p/15%| s/omitidoPct > 0\.05/omitidoPct > 0.15/


### PR DESCRIPTION
Follow-up do [#1024](https://github.com/LucasSardenbergL/afiacao/pull/1024). O #1024 renomeou/refatorou `valor-cockpit-helpers.ts` e deixou 2 mutações do contrato `.mut` **stale** → `mutation-check` vermelho na `main` (não bloqueia o auto-merge, que espera só o `validate`, mas suja a saúde do CI).

## Conserto (2 stale)
- `tetoPct > 0.05` → a var foi renomeada p/ `omitidoPct` (padrão não casava → "não casou").
- `ar_indisponivel || estoque_indisponivel` → o regex largo casava o **comentário (linha 158) + o código (220)** = 2 linhas; ancorei em `const capital_parcial = ...`.

## + 3 invariantes NOVAS institucionalizadas (boil the ocean money-path)
As que provei por falsificação no #1024, agora no contrato de mutação:
- **assimetria de sinal** — `teto≤0 mantido` vira `teto>0` (falsificação F1).
- **guard de DENOMINADOR** da perna ausente — remove `rc>0` (falsificação F3 / achado do `/codex challenge`).
- **agregado honesto** — `empresa.evp` deixa de fingir total (remove o gate `empresaCompleta`).

## Verificação
`bash scripts/mutcheck.sh ...` local: **17 mutações · 17 pegas · 0 sobreviventes · 0 inválidas · 0 problemas**. Só toca `scripts/mutcheck.d/valor-cockpit-helpers.mut` (contrato de teste; zero runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)