### PR TITLE
fix(farmer): guard fail-closed suspende IEE/IPF sob cobertura (dívida D1 latente) [money-path]

### DIFF
--- a/src/hooks/__tests__/farmer-performance-cobertura-guard.test.tsx
+++ b/src/hooks/__tests__/farmer-performance-cobertura-guard.test.tsx
@@ -103,6 +103,21 @@ describe('calculateScores — guard de cobertura (dívida D1 latente)', () => {
     expect(insertedScore()).toBeFalsy();
   });
 
+  it('COBERTURA active mas EXPIRADA (valid_until no passado) → persiste (cobertura efetiva = active E não-expirada, igual ao resto do repo)', async () => {
+    covCoveredRows = [{ id: 'cov-exp', valid_until: '2020-01-01T00:00:00Z' }];
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(FARMER); });
+    expect(insertedScore()).toBeTruthy();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it('COBERTURA active SEM prazo (valid_until null) → NÃO persiste (vigente perpétua)', async () => {
+    covCoveringRows = [{ id: 'cov-perp', valid_until: null }];
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(FARMER); });
+    expect(insertedScore()).toBeFalsy();
+  });
+
   it('master calculando p/ terceiro SEM cobertura → persiste (master enxerga a cobertura via RLS)', async () => {
     authState = { user: { id: 'master-x' }, role: 'master' };
     const { result: r } = renderHook(() => useFarmerPerformance());

--- a/src/hooks/__tests__/farmer-performance-cobertura-guard.test.tsx
+++ b/src/hooks/__tests__/farmer-performance-cobertura-guard.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Guard money-path — IEE/IPF de `useFarmerPerformance.calculateScores` sob COBERTURA (#980).
+ *
+ * Follow-up da decisão D1 (`farmer_tactical_plans.farmer_id` = DONO). `calculateScores` lê
+ * plans/client_scores por DONO mas calls/copilot por EXECUTOR — sob cobertura cruzada o
+ * IEE (`plans/calls`) e o IPF (`margem plans+calls`) misturariam semânticas e o score
+ * corrompido se propaga pros 4 consumidores (Executive/IPF/Intelligence). Enquanto a
+ * semântica dono×executor não for decidida (generated_by ausente por YAGNI), precisão>recall:
+ * sob cobertura NÃO persistir o score — degradar honesto. Fail-closed: leitura de cobertura
+ * que falha, ou cálculo p/ terceiro sem ser master (RLS de carteira_coverage cega o viewer),
+ * também suspendem. Conduzido com /codex (challenge, money-path).
+ */
+const FARMER = 'farmer-self';
+const OTHER = 'outro-farmer';
+
+type Q = { table: string; eq: Array<[string, unknown]>; insert?: Record<string, unknown> };
+let queries: Q[] = [];
+
+// Estado controlável por teste
+let covCoveredRows: unknown[] = [];   // linhas de carteira_coverage onde covered_user_id = alvo
+let covCoveringRows: unknown[] = [];  // linhas onde covering_user_id = alvo
+let covError: unknown = null;         // força erro na leitura de cobertura (fail-closed)
+let authState: { user: { id: string } | null; role: string | null } = { user: { id: FARMER }, role: 'employee' };
+
+function result(q: Q): { data: unknown; error: unknown } {
+  if (q.table === 'carteira_coverage') {
+    if (covError) return { data: null, error: covError };
+    const byCovered = q.eq.some(([c]) => c === 'covered_user_id');
+    return { data: byCovered ? covCoveredRows : covCoveringRows, error: null };
+  }
+  // Todas as fontes de cálculo vazias (feature morta em prod) — o foco é o guard, não a aritmética.
+  return { data: [], error: null };
+}
+
+function chain(table: string): unknown {
+  const q: Q = { table, eq: [] };
+  queries.push(q);
+  const c: Record<string, unknown> = {};
+  for (const m of ['select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit', 'range', 'or', 'filter', 'single', 'maybeSingle']) c[m] = () => c;
+  c.eq = (col: string, val: unknown) => { q.eq.push([col, val]); return c; };
+  c.insert = (payload: Record<string, unknown>) => { q.insert = payload; return c; };
+  c.then = (resolve: (v: unknown) => void) => resolve(result(q));
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => chain(t) },
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: authState.user, role: authState.role }) }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
+
+import { useFarmerPerformance } from '../useFarmerPerformance';
+import { toast } from 'sonner';
+
+const insertedScore = () => queries.find((q) => q.table === 'farmer_performance_scores' && q.insert);
+
+beforeEach(() => {
+  queries = [];
+  covCoveredRows = [];
+  covCoveringRows = [];
+  covError = null;
+  authState = { user: { id: FARMER }, role: 'employee' };
+  vi.clearAllMocks();
+});
+
+describe('calculateScores — guard de cobertura (dívida D1 latente)', () => {
+  it('SEM cobertura → calcula e persiste o score normalmente', async () => {
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(FARMER); });
+    expect(insertedScore()).toBeTruthy();
+    expect(toast.warning).not.toHaveBeenCalled();
+  });
+
+  it('COBERTURA ativa do próprio alvo (covered) → NÃO persiste + degrada honesto', async () => {
+    covCoveredRows = [{ id: 'cov-1' }];
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(FARMER); });
+    expect(insertedScore()).toBeFalsy();
+    expect(toast.warning).toHaveBeenCalled();
+  });
+
+  it('COBERTURA ativa onde o alvo é o cobridor (covering) → NÃO persiste', async () => {
+    covCoveringRows = [{ id: 'cov-2' }];
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(FARMER); });
+    expect(insertedScore()).toBeFalsy();
+  });
+
+  it('FAIL-CLOSED: leitura de carteira_coverage falha → NÃO persiste (não fabrica score)', async () => {
+    covError = { message: 'rls/conn boom' };
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(FARMER); });
+    expect(insertedScore()).toBeFalsy();
+  });
+
+  it('FAIL-CLOSED: cálculo p/ TERCEIRO sem ser master (RLS cega a cobertura) → NÃO persiste', async () => {
+    authState = { user: { id: FARMER }, role: 'employee' };
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(OTHER); });
+    expect(insertedScore()).toBeFalsy();
+  });
+
+  it('master calculando p/ terceiro SEM cobertura → persiste (master enxerga a cobertura via RLS)', async () => {
+    authState = { user: { id: 'master-x' }, role: 'master' };
+    const { result: r } = renderHook(() => useFarmerPerformance());
+    await act(async () => { await r.current.calculateScores(OTHER); });
+    expect(insertedScore()).toBeTruthy();
+  });
+});

--- a/src/hooks/useFarmerPerformance.ts
+++ b/src/hooks/useFarmerPerformance.ts
@@ -171,11 +171,15 @@ export const useFarmerPerformance = () => {
       let suspenderPorCobertura = calculandoParaTerceiro && role !== 'master';
       if (!suspenderPorCobertura) {
         const [cov1, cov2] = await Promise.all([
-          supabase.from('carteira_coverage').select('id').eq('active', true).eq('covered_user_id', farmerId).limit(1),
-          supabase.from('carteira_coverage').select('id').eq('active', true).eq('covering_user_id', farmerId).limit(1),
+          supabase.from('carteira_coverage').select('id, valid_until').eq('active', true).eq('covered_user_id', farmerId),
+          supabase.from('carteira_coverage').select('id, valid_until').eq('active', true).eq('covering_user_id', farmerId),
         ]);
-        suspenderPorCobertura = !!cov1.error || !!cov2.error
-          || (cov1.data?.length ?? 0) > 0 || (cov2.data?.length ?? 0) > 0;
+        // Cobertura EFETIVA = active E não-expirada — mesma definição de useCoverage/escopo-clientes
+        // (active sem flip pós-prazo não pode fail-close pra sempre). nowIso no client, como o repo.
+        const nowIso = new Date().toISOString();
+        const vigente = (rows: { valid_until: string | null }[] | null) =>
+          (rows ?? []).some((c) => !c.valid_until || c.valid_until > nowIso);
+        suspenderPorCobertura = !!cov1.error || !!cov2.error || vigente(cov1.data) || vigente(cov2.data);
       }
       if (suspenderPorCobertura) {
         toast.warning('Índices de performance indisponíveis sob cobertura de carteira', {

--- a/src/hooks/useFarmerPerformance.ts
+++ b/src/hooks/useFarmerPerformance.ts
@@ -89,7 +89,7 @@ interface CopilotSessionRow {
 }
 
 export const useFarmerPerformance = () => {
-  const { user } = useAuth();
+  const { user, role } = useAuth();
   const [scores, setScores] = useState<PerformanceScore[]>([]);
   const [loading, setLoading] = useState(false);
   const [calculating, setCalculating] = useState(false);
@@ -158,6 +158,33 @@ export const useFarmerPerformance = () => {
     setCalculating(true);
 
     try {
+      // [GUARD money-path — dívida D1 latente, ver docs/historico/bugs-resolvidos.md §D1]
+      // Sob cobertura de carteira (#980) o farmer_id DIVERGE entre as fontes: farmer_tactical_plans
+      // e farmer_client_scores = DONO; farmer_calls e farmer_copilot_sessions = EXECUTOR. O IEE
+      // (totalPlans/totalCalls) e o IPF (margem de plans + calls) misturariam dono×executor e o
+      // score corrompido se propaga pros consumidores (Executive/IPF/Intelligence) → avaliação/comissão.
+      // Enquanto a semântica não for decidida (generated_by ausente por YAGNI), precisão>recall:
+      // sob cobertura NÃO persistir — degradar honesto. Fail-closed: leitura de cobertura que falha,
+      // ou cálculo p/ TERCEIRO sem ser master (a RLS de carteira_coverage cega o viewer não-envolvido),
+      // também suspendem (assumir o pior, nunca fabricar). Conduzido com /codex (challenge).
+      const calculandoParaTerceiro = farmerId !== user.id;
+      let suspenderPorCobertura = calculandoParaTerceiro && role !== 'master';
+      if (!suspenderPorCobertura) {
+        const [cov1, cov2] = await Promise.all([
+          supabase.from('carteira_coverage').select('id').eq('active', true).eq('covered_user_id', farmerId).limit(1),
+          supabase.from('carteira_coverage').select('id').eq('active', true).eq('covering_user_id', farmerId).limit(1),
+        ]);
+        suspenderPorCobertura = !!cov1.error || !!cov2.error
+          || (cov1.data?.length ?? 0) > 0 || (cov2.data?.length ?? 0) > 0;
+      }
+      if (suspenderPorCobertura) {
+        toast.warning('Índices de performance indisponíveis sob cobertura de carteira', {
+          description: 'A métrica mistura dono e executor sob cobertura; cálculo suspenso até a semântica ser decidida (dívida D1).',
+        });
+        setCalculating(false);
+        return;
+      }
+
       const periodEnd = new Date();
       const periodStart = new Date();
       periodStart.setDate(periodStart.getDate() - periodDays);
@@ -317,7 +344,7 @@ export const useFarmerPerformance = () => {
     } finally {
       setCalculating(false);
     }
-  }, [user, loadScores]);
+  }, [user, role, loadScores]);
 
   // Get latest score for current user (IPF only view)
   const getMyLatestScore = useCallback((): PerformanceScore | null => {


### PR DESCRIPTION
## Contexto — follow-up da decisão D1 (`claude/relaxed-panini-cc012c`)

O D1 mudou `farmer_tactical_plans.farmer_id` para semântica de **DONO** da carteira. Consequência conhecida e documentada (confirmada como [P1 latente] no `/codex challenge` do D1): `useFarmerPerformance.calculateScores(farmerId)` lê **plans/client_scores por DONO** mas **calls/copilot por EXECUTOR**. Sob cobertura cruzada (#980), o IEE (`totalPlans/totalCalls`) e o IPF (`margem plans + calls`) misturam semânticas → score corrompido que se propaga pros **4 consumidores** (`ExecutiveDashboard`, `FarmerIPFDashboard`, `IntelligenceManagerialTab`, `IntelligenceOperationalTab`) → avaliação/comissão.

## Estado real (psql-ro, prod) — **triplamente latente**

| Tabela | Linhas |
|---|---|
| `farmer_tactical_plans` | 0 |
| `farmer_performance_scores` | 0 (IEE/IPF nunca rodou) |
| `farmer_calls` · `farmer_copilot_sessions` | 0 · 0 |
| `carteira_coverage` | 0 |

Mais: D1 ainda **não está em `origin/main`**.

## Decisão (`eu + /codex`, delegada pelo founder)

- **NÃO** adicionar `generated_by` nem refatorar a semântica das métricas agora (YAGNI; "medir por executor" não é requisito confirmado).
- O tripwire-por-coluna que eu propus foi **descartado** pelo codex (teatro parcial: pega a reabertura consciente, não o uso silencioso; e frágil — `types.ts` é regenerado manual no Lovable).
- **Blindar o ponto de escrita** com um runtime guard fail-closed.

## O guard (`useFarmerPerformance.calculateScores`)

Antes de persistir, consulta `carteira_coverage`. Suspende o cálculo (toast honesto, não grava) quando:
1. há cobertura ativa onde o alvo é **coberto** ou **cobridor**;
2. **fail-closed** — a leitura de cobertura falha;
3. **fail-closed** — calcula pra **terceiro** sem ser `master` (a RLS de `carteira_coverage` cegaria o viewer não-envolvido).

Não decide dono×executor — só **recusa fabricar** um número que sabe ser mistura (`precisão>recall`, idêntico ao fail-closed de `useFarmerScoring`).

## Verificação

- **TDD**: red → green → **falsificação cirúrgica** (desligar a detecção → só os 2 testes de cobertura ficam vermelhos; prova que não é teatro).
- `farmer-performance-cobertura-guard.test.tsx`: **6/6**.
- Suite hooks + impersonation: **175/175**. Typecheck strict + lint: limpos.

## 🚩 Flags de coordenação pro fecho do D1 (fora deste branch)

- **F1:** a edge `generate-tactical-plan` (modo cron) grava `farmer_id: body.farmerId` — confirmar que o enfileirador passa o **DONO** (`carteira_assignments`), não o executor.
- **F2 (crítico ao reabrir):** `DEFAULT auth.uid()` **não** basta pra "adicionar sem backfill" — inserts via cron/edge rodam como `service_role` → `auth.uid()` é **NULL**. `generated_by` terá que ser setado **explícito** no writer.

## Adiado até "medir por executor" virar requisito real

`generated_by uuid NOT NULL` (setado explícito, ver F2) + escopar cada métrica (carteira-por-dono × esforço-por-executor) em `calculateScores`/`getEffectivenessStats` + alinhar `calls`/`copilot`. A entrada do diário (`bugs-resolvidos.md`) deve ser **anexada à entrada D1 quando o D1 mergear** (evita conflito no arquivo-ímã).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
