### PR TITLE
fix(mutcheck): re-ancora contrato valor-cockpit ao texto pós-#1024 — 9/9 honrados

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -17,6 +17,6 @@ PEGA | pedidoContaNoFaturamento: status NULL exclui (==->!=) | s/if \(status == 
 PEGA | pedidoContaNoFaturamento: blocklist→allowlist (tira !)| s/return !STATUS_NAO_FATURAVEL\.includes/return STATUS_NAO_FATURAVEL.includes/
 # EVP-teto marcado (#961): capital ausente vira teto DECLARADO, não R$0. Institucionaliza as 3
 # falsificações provadas à mão (guard de sinal anti-piso, evp_parcial, limiar de confiança ponderado).
-PEGA | evp_parcial: OU-de-pernas-ausentes vira E          | s/ar_indisponivel \|\| estoque_indisponivel/ar_indisponivel && estoque_indisponivel/
+PEGA | capital_parcial: OU-perna-ausente vira E          | s/capital_parcial = ar_indisponivel \|\| estoque_indisponivel/capital_parcial = ar_indisponivel && estoque_indisponivel/
 PEGA | guard anti-piso: capital negativo entra como num   | s/Number\.isFinite\(estSraw\) && estSraw >= 0/Number.isFinite(estSraw)/
-PEGA | confianca: limiar teto-por-receita 5% afrouxa p/15%| s/tetoPct > 0\.05/tetoPct > 0.15/
+PEGA | confianca: limiar EVP-omitido 5% afrouxa p/15%     | s/omitidoPct > 0\.05/omitidoPct > 0.15/


### PR DESCRIPTION
## Problema
O refactor do #1024 (Cockpit de Valor A3 — omissão honesta do EVP otimista) deixou 2 mutações do contrato `scripts/mutcheck.d/valor-cockpit-helpers.mut` **STALE**, deixando o job `mutation-check` do CI **vermelho em toda PR** (não-required, mas ruído — detectado no #1028, que só herdou a dessincronia ao mergear o #1024 do main).

## Causa
- **mut1 (`evp_parcial`→`capital_parcial`)**: o regex casava o texto sem âncora `ar_indisponivel || estoque_indisponivel`, que o #1024 passou a repetir num **comentário novo** → a mutação tocava **2 linhas** → o guard de *substituição única* reprovava (`INVÁLIDO — tocou 2 linhas`).
- **mut2 (`confianca`)**: o #1024 trocou `evp_teto_receita_pct` por `evp_omitido_otimista_receita_pct` e decompôs o agregado; o regex buscava `tetoPct > 0.05`, que deixou de existir → `INVÁLIDO (não casou)`.

## Fix
Re-ancoragem no texto novo, **sem afrouxar o contrato**:
- mut1 → âncora `capital_parcial = …` (1 linha exata, [220](https://github.com/LucasSardenbergL/afiacao/blob/main/src/lib/financeiro/valor-cockpit-helpers.ts)).
- mut2 → `omitidoPct > 0.05` (o limiar de 5% de EVP omitido que rebaixa a confiança p/ média).

**Prova de que não afrouxou:** ambas re-ancoradas seguem **✓ PEGA** (a suíte mata o mutante). Se a âncora tivesse alargado para um trecho sem cobertura, daria SOBREVIVE.

## Verificação
- `mutcheck` isolado (valor-cockpit): **14/14 PEGA · 0 inválidas · 0 problema(s)**
- `bun run mutcheck:selftest`: **✓ mecânica ok**
- `bun run mutcheck` (gate completo): **✓ 9/9 contratos honrados**
- Escopo: só o `.mut` mudou (2 linhas); `.ts` de produção intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
