### PR TITLE
feat(harness): porta 5 padrões do ECC (review · migration-imutável · threat-model · bash-destrutivo · stop-nudge)

### DIFF
--- a/.claude/hooks/destructive-bash-guard.sh
+++ b/.claude/hooks/destructive-bash-guard.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# destructive-bash-guard.sh — PreToolUse(Bash): trava comando IRREVERSÍVEL do agente sem confirmação.
+#
+# Defesa contra erro do AGENTE (eu/subagentes), não do founder: o terminal do Lucas NÃO passa por
+# este hook; scripts (wt:clean/reap) rodam seus resets INTERNAMENTE, fora do Bash tool, e não são
+# vistos. Só o comando que o agente passa ao Bash tool é interceptado.
+#
+# Pega o que destrói trabalho sem recuperação: git reset --hard, git clean -f, git push --force,
+# git branch -D, git checkout -f/--force, git stash clear/drop, e rm -r -f cujos alvos NÃO estão
+# todos sob /tmp. Complementa o heavy-guard (que trata `git *` como leitura e ignora).
+#
+# Detector HEURÍSTICO (não é parser de shell): cobre as formas comuns que o agente escreveria por
+# engano. Codex review 2026-06-24 fechou git-global-opts (git -C dir …), rm alvo-misto, variantes
+# de flag (-Rf/-r -f/--recursive), confirmação-por-substring, dry-run e pipeline de leitores. É
+# prevenção de acidente, não sandbox contra adversário determinado.
+#
+# Fail-CLOSED na decisão: destrutivo reconhecido → deny. Liberação por CONFIRMAÇÃO EXPLÍCITA como
+# env-assignment NO INÍCIO (CONFIRM_DESTRUCTIVE=1 …), exigida sempre — NÃO é bypass-on-retry.
+# Fail-open de infra: sem jq, ou erro → exit 0. Testes em scripts/test-destructive-bash-guard.sh.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -n "$cmd" ] || exit 0
+
+# confirmação explícita SÓ como env-assignment no INÍCIO (não substring solta tipo `echo CONFIRM… &&`)
+printf '%s' "$cmd" | grep -qE '^[[:space:]]*CONFIRM_DESTRUCTIVE=(1|true)([[:space:]]|$)' && exit 0
+
+# leitura pura: sem encadeamento real (; && || $() ``), e TODO segmento de pipe começa com leitor → allow
+# shellcheck disable=SC2016  # $( e ` são literais do glob (detecção de encadeamento), não expansão
+case "$cmd" in
+  *';'*|*'&&'*|*'||'*|*'$('*|*'`'*) ;;
+  *)
+    set -f; _ok=1; _oldifs="$IFS"; IFS='|'
+    for _s in $cmd; do
+      printf '%s' "$_s" | grep -qE '^[[:space:]]*(echo|printf|grep|rg|cat|head|tail|less|wc|nl|sort|uniq|jq|sed|awk|git[[:space:]]+(status|log|diff|show))([[:space:]]|$)' || _ok=0
+    done
+    IFS="$_oldifs"; set +f
+    [ "$_ok" = 1 ] && exit 0 ;;
+esac
+
+# Sanitiza ANTES de detectar: remove heredocs e conteúdo entre aspas (MENÇÃO ≠ execução). Sem isso,
+# `git commit <<'MSG' … git reset --hard … MSG` ou `git commit -m "… rm -rf …"` viram falso-positivo
+# (o guard chega a bloquear o commit que o documenta). Perde `bash -c "destrutivo"` (raro/deliberado)
+# — trade-off correto p/ prevenção-de-acidente. Sem perl → fallback só-strings (heredoc não removido).
+if command -v perl >/dev/null 2>&1; then
+  scan="$(printf '%s' "$cmd" | perl -0777 -pe "s/<<-?\s*([\x27\x22]?)(\w+)\1.*?^\2[ \t]*\$//gms; s/\x27[^\x27]*\x27//g; s/\x22[^\x22]*\x22//g" 2>/dev/null)"
+else
+  scan="$(printf '%s' "$cmd" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null)"
+fi
+[ -n "$scan" ] || scan="$cmd"
+
+det() { printf '%s' "$scan" | grep -qE "$1"; }
+B='(^|[^[:alnum:]_./-])'
+# opções globais do git (zero+) entre `git` e o subcomando: -C dir, -c x=y, --git-dir, --work-tree, etc.
+G='git([[:space:]]+(-C[[:space:]]+[^[:space:]]+|-c[[:space:]]+[^[:space:]]+|--git-dir[=[:space:]][^[:space:]]+|--work-tree[=[:space:]][^[:space:]]+|--no-pager|--paginate|-p))*[[:space:]]+'
+
+# rm -r -f cujos operandos NÃO estão todos sob /tmp → destrutivo. Recursão/force lidos só das FLAGS
+# (não dos operandos — senão um path tipo `dir-sem-force` dispararia falso-positivo).
+rm_destructive() {
+  local seg tok safe=1 saw=0 rec=0 frc=0
+  seg="$(printf '%s' "$scan" | grep -oE "${B}rm[[:space:]][^;&|]*" | head -1)"
+  [ -n "$seg" ] || return 1
+  set -f
+  seg="${seg#*rm}"
+  for tok in $seg; do
+    case "$tok" in
+      --recursive) rec=1 ;;
+      --force) frc=1 ;;
+      --*) ;;
+      -*) case "$tok" in *[rR]*) rec=1 ;; esac
+          case "$tok" in *f*) frc=1 ;; esac ;;
+      *) saw=1
+         # shellcheck disable=SC2016  # $TMPDIR/${TMPDIR} são literais (path não-expandido do agente)
+         case "$tok" in
+           /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*|"$TMPDIR"/*|'$TMPDIR'/*|'${TMPDIR}'/*) ;;
+           *) safe=0 ;;
+         esac ;;
+    esac
+  done
+  set +f
+  { [ "$rec" = 1 ] && [ "$frc" = 1 ]; } || return 1   # não é rm recursivo+force
+  [ "$saw" = 0 ] && return 0                          # rm -rf sem alvo explícito → destrutivo
+  [ "$safe" = 0 ] && return 0
+  return 1                                            # todos os alvos sob /tmp → seguro
+}
+
+deny=""
+if   det "${B}${G}reset[^;&|]*--hard";                                                          then deny="git reset --hard — descarta o working tree (mudanças não-commitadas somem)"
+elif det "${B}${G}clean[^;&|]*(-[a-zA-Z]*f|--force)" && ! det "${B}${G}clean[^;&|]*(-[a-zA-Z]*n|--dry-run)"; then deny="git clean -f — apaga arquivos untracked (irrecuperável)"
+elif det "${B}${G}push[^;&|]*(--force([^-]|\$)|[[:space:]]-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|\$)|[[:space:]][+][^[:space:]])"; then deny="git push --force — reescreve o remoto (use --force-with-lease se for mesmo preciso)"
+elif det "${B}${G}branch[^;&|]*(-[a-zA-Z]*D([[:space:]]|\$)|--delete[^;&|]*--force|--force[^;&|]*--delete)"; then deny="git branch -D — delete forçado de branch (perde commits não-mergeados)"
+elif det "${B}${G}checkout[^;&|]*(-f([[:space:]]|\$)|--force)";                                  then deny="git checkout -f/--force — descarta mudanças locais"
+elif det "${B}${G}stash[[:space:]][^;&|]*(clear|drop)";                                          then deny="git stash clear/drop — perde o stash"
+elif rm_destructive;                                                                             then deny="rm -r -f fora de /tmp — apaga recursivamente sem recuperação"
+fi
+
+[ -n "$deny" ] || exit 0
+
+reason="Comando destrutivo irreversível bloqueado: $deny.
+
+Se for INTENCIONAL e confirmado (com o founder, quando o risco é dele), prefixe a confirmação explícita NO INÍCIO do comando:
+  CONFIRM_DESTRUCTIVE=1 $cmd
+Exigida toda vez — o guard não guarda 'já confirmei antes'. Alternativas seguras: git stash (em vez de reset --hard), git push --force-with-lease (em vez de --force), mover pra /tmp (em vez de rm -rf)."
+jq -n --arg r "$reason" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+exit 0

--- a/.claude/hooks/migration-immutability-guard.sh
+++ b/.claude/hooks/migration-immutability-guard.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# migration-immutability-guard.sh — PreToolUse(Write|Edit|MultiEdit): migration committed é imutável.
+#
+# Bloqueia MODIFICAR uma migration que JÁ está no HEAD (committed). O snapshot supabase/migrations/
+# é a fonte de DR (CLAUDE.md / database.md) e o apply é manual no SQL Editor — editar um .sql já
+# committado diverge repo×banco e NÃO re-aplica. Correção é SEMPRE uma migration NOVA.
+#
+# Escopo estreito: só file_path ~ supabase/migrations/*.sql QUE EXISTE no HEAD. Migration nova
+# (não-committed/untracked) passa — preserva o fluxo lovable-db-operator (criar/iterar antes do
+# commit). Complementa migration-collision-guard (aquele olha CONTEÚDO p/ colisão RED entre
+# worktrees; este olha se-o-arquivo-já-é-committed).
+#
+# Fail-open: sem jq/git, fora de repo, path irresolvível, ou qualquer erro → exit 0 (nunca trava
+# trabalho por bug do próprio guard). Fail-closed na DECISÃO: committed reconhecido → deny.
+# Espelha o collision-guard: exit 0 + JSON permissionDecision="deny".
+# Testes em scripts/test-migration-immutability-guard.sh.
+set -u
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+fpath="$(printf '%s' "$input" | jq -r '.tool_input.file_path // empty' 2>/dev/null)"
+
+# só age em migrations
+case "$fpath" in
+  */supabase/migrations/*.sql | supabase/migrations/*.sql) ;;
+  *) exit 0 ;;
+esac
+
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+cd "$root" 2>/dev/null || exit 0
+
+# Resolução FÍSICA do path (Codex 2026-06-24): string-strip de prefixo (${fpath#$root/}) é
+# bypassável — './'-prefix, symlink, ou CLAUDE_PROJECT_DIR ≠ toplevel do git → rel errado →
+# cat-file falha → allow indevido. Deriva rel do TOPLEVEL físico real; `pwd -P` resolve symlink.
+top="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+toptop="$(cd "$top" 2>/dev/null && pwd -P)" || exit 0
+fdir="$(cd "$(dirname "$fpath")" 2>/dev/null && pwd -P)" || exit 0   # dir inexistente → allow (nova)
+abs="$fdir/$(basename "$fpath")"
+case "$abs" in
+  "$toptop"/*) rel="${abs#"$toptop"/}" ;;
+  *) exit 0 ;;   # fora do repo / irresolvível → fail-open
+esac
+
+# o arquivo existe no HEAD? (committed) — só então é imutável. Nova/untracked → fail-open (allow).
+git -C "$toptop" cat-file -e "HEAD:$rel" 2>/dev/null || exit 0
+
+reason="Migration committed é imutável: $rel já está no HEAD.
+
+O snapshot supabase/migrations/ é a fonte de DR e o apply é manual (SQL Editor) — editar um .sql já committado diverge repo×banco e NÃO re-aplica. Correção = uma migration NOVA (use a skill lovable-db-operator). Só inspeção/leitura? Abra o arquivo, não use Edit/Write."
+jq -n --arg r "$reason" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$r}}'
+exit 0

--- a/.claude/hooks/stop-moneypath-nudge.sh
+++ b/.claude/hooks/stop-moneypath-nudge.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# stop-moneypath-nudge.sh — Stop: lembrete NÃO-bloqueante se a sessão tocou money-path.
+#
+# Barato DE PROPÓSITO: só `git diff --name-only` + ls-files (zero typecheck/test/lint). Rodar pesado
+# no Stop brigaria com o semáforo `heavy`/RAM (M2 8GB × ~30 worktrees) e com a latência por turno.
+# NÃO bloqueia (sempre exit 0) — emite um systemMessage com o checklist money-path no fim do turno.
+# O CI segue sendo o gate bloqueante; isto é rede de segurança contra esquecimento, não um gate.
+# Testes em scripts/test-stop-moneypath-nudge.sh.
+set -u
+
+command -v git >/dev/null 2>&1 || exit 0
+command -v jq  >/dev/null 2>&1 || exit 0
+root="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+top="$(git -C "$root" rev-parse --show-toplevel 2>/dev/null)" || exit 0
+
+# trabalho uncommitted da sessão (modificados vs HEAD + novos não-rastreados). Pathspec `-- supabase
+# src` barateia em árvore grande de untracked (Codex 2026-06-24) — money-path só vive nesses dois.
+changed="$( { git -C "$top" diff --name-only HEAD -- supabase src 2>/dev/null; git -C "$top" ls-files --others --exclude-standard -- supabase src 2>/dev/null; } )"
+[ -n "$changed" ] || exit 0
+
+# filtra money-path: supabase/ + src/ financeiro/pricing/reposição/estoque/positivação/caixa
+mp="$(printf '%s\n' "$changed" | grep -iE 'supabase/|src/.*(financ|fatur|dre|pric|preco|reposic|estoque|compra|pedido|positiva|comiss|caixa|funding)' | sort -u)"
+[ -n "$mp" ] || exit 0
+
+n="$(printf '%s\n' "$mp" | grep -c .)"
+list="$(printf '%s\n' "$mp" | head -8 | sed 's/^/• /')"
+msg="🟡 Money-path tocado nesta sessão ($n arquivo(s) uncommitted). Antes de pedir review / tirar PR do draft:
+$list
+→ typecheck/teste: heavy bun run typecheck · heavy bun run test
+→ migration/RPC/trigger/policy nova? prove-sql-money-path (PG17 + falsificação)
+(lembrete não-bloqueante — docs/agent/money-path.md)"
+
+jq -n --arg m "$msg" '{systemMessage:$m}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/heavy-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/destructive-bash-guard.sh\""
           }
         ]
       },
@@ -59,6 +63,16 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/migration-immutability-guard.sh\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-moneypath-nudge.sh\""
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/migration-collision-guard.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/migration-immutability-guard.sh\""
+          }
+        ]
       }
     ]
   }

--- a/docs/agent/money-path.md
+++ b/docs/agent/money-path.md
@@ -4,7 +4,7 @@
 
 ## Os princípios
 
-1. **Precisão > recall.** Na ambiguidade, NÃO agir / NÃO mostrar — melhor uma ficha a menos que uma errada. Ex.: matching boletim↔SKU só com confirmação humana; a venda mostra ficha só pela view confirmada+aprovada, zero fuzzy em runtime.
+1. **Precisão > recall.** Na ambiguidade, NÃO agir / NÃO mostrar — melhor uma ficha a menos que uma errada. Ex.: matching boletim↔SKU só com confirmação humana; a venda mostra ficha só pela view confirmada+aprovada, zero fuzzy em runtime. Vale no **review** também: finding sem prova (trigger+linha+efeito) rebaixa, não bloqueia — barra em `docs/agent/review.md`.
 2. **Degradação honesta — ausente ≠ zero.** `Number(null)` é `0`; `cmc` ausente vira `null`, não R$0; NCG/hurdle/capital ausente → `null` + confiança baixa, **nunca** um número fabricado. O usuário vê "—" ou "falta dado", jamais uma recomendação inventada. (Frente inteira de consolidação financeira foi sobre isto: NCG/A2, hurdle/A3, caixa do snapshot.)
 3. **Nunca fabricar número no money-path.** LLM não inventa SKU/preço (pricing determinístico do Omie). A IA conversa/sugere; o número firme passa por gate determinístico/humano. Prosa do LLM é descartável; a evidência é o produto.
 4. **Gate humano na escrita.** O founder no loop pra escrita money-path (migration via SQL Editor; aprovação de compra). Exceção atual: a auto-aprovação Sayerlack (N3, piloto medido por taxa de veto — ver `docs/agent/reposicao.md`).
@@ -14,6 +14,7 @@
 
 - **Função/RPC/trigger/policy money-path → `prove-sql-money-path`** (PG17 local com falsificação) ANTES de entregar a migration. plpgsql é late-bound: `CREATE` passa com SQL inválido, só falha ao EXECUTAR. O teste aplica a migração REAL, semeia, faz asserts positivos E negativos (SQLSTATE + re-raise), prova RLS (`SET ROLE` + GUC), e **se sabota de propósito pra provar que os asserts têm dente**.
 - **Assert negativo** captura a `SQLSTATE`/condição ESPERADA e re-lança o resto. `WHEN OTHERS THEN 'OK'` é teatro (engole o erro real). Sentinela do teste nunca contém o texto que o código emite (anti-teatro de ILIKE).
+- **Engine nova que emite número de decisão → escreva o threat-model** (`docs/agent/threat-model-template.md`): o que prova / não prova / default fail-closed, com **um assert pra cada default declarado** (doc×código não podem divergir — achado aura: THREAT_MODEL diz reject, código faz DEFAULT_ALLOW).
 
 ## Segunda opinião adversária (Codex)
 

--- a/docs/agent/review.md
+++ b/docs/agent/review.md
@@ -1,0 +1,24 @@
+# Review — barra de evidência (anti-falso-positivo)
+
+> Critério de aceite de **todo finding** de review: humano, `/code-review`, `/codex` (consult/challenge), `triagem-3-modelos`. Money-path herda `precisão > recall` aqui também — no review, um falso-positivo custa confiança e tempo do founder; melhor **3 achados provados que 10 hipóteses**. Padrão destilado do `code-reviewer` do ECC (affaan-m), reescrito CC-puro + money-path (análise Codex 2026-06-23).
+
+## A barra — sem prova, rebaixa (nunca descarta caladamente)
+
+1. **Trigger concreto.** O input/estado que dispara o bug, não "pode acontecer". Ex.: `parseFloat('')||0` vira preço 0 — o trigger é *carrinho com `unit_price` string vazia*, não "parsing pode falhar". Sem o trigger nomeado, é hipótese, não finding.
+2. **Local exato + caminho até o efeito.** `arquivo:linha` e as **vias** que chegam lá (enumere TODAS, como money-path §5: o pedido tem ≥4 caminhos até o Omie). Um finding que aponta um caminho e ignora os outros 3 é meio-finding.
+3. **Severidade por blast-radius demonstrado.** `HIGH`/`CRITICAL` só com **repro ou caminho de exploração andado**. "Parece arriscado" sem caminho → `MEDIUM`/observação. Espelha "diagnosticado ≠ corrigido": severidade alta é afirmação de efeito, não de cheiro.
+4. **Confiança explícita.** Abaixo de ~80% e sem repro → rebaixa a **hipótese-a-investigar** com o que falta pra confirmar, não a finding. Rebaixar ≠ silenciar: o item continua visível, só muda de gaveta.
+
+## Anti-teatro (espelha o assert negativo do money-path)
+
+- O reviewer **demonstra**, não supõe. "Acho que pode dar problema" é o `WHEN OTHERS THEN 'OK'` do review: engole a falta de prova e parece cobertura. Se não consegue nomear trigger+linha+efeito, diga isso — "suspeita sem repro" é um estado honesto e útil; finding fabricado não.
+- **Falsifique o próprio finding** antes de subir a severidade: existe um caminho em que o código está certo? Se some sob 30s de leitura, era ruído. (Mesmo dente que a sabotagem-de-migração exige do `prove-sql-money-path`.)
+
+## Painel multi-modelo (triagem-3-modelos / Codex)
+
+- A barra é o **filtro ANTES da regra determinística**, não depois: finding sem prova **não entra no contrato JSON** do `triagem-3-modelos` — senão a decisão-por-regras herda lixo de três fontes em vez de uma. A divergência entre modelos é sinal (lentes diferentes), o falso-positivo de qualquer um não é.
+- Concordância cross-model é **recomendação, não decisão** — registre quem achou o quê; dois modelos errando junto continua errado. (No money-path, o Codex adversário é etapa obrigatória, mas o veredito final é do gate determinístico/humano.)
+
+## Quando relaxar — de propósito
+
+Brainstorm, spec exploratório, `/codex challenge` em modo "me mostre tudo que pode quebrar": aí a **hipótese é bem-vinda** — marque-a como hipótese e siga. A barra vale para o **gate de aceite** (o finding que vira trabalho/PR/bloqueio), não para a ideação que o alimenta. Confundir os dois mata recall onde recall é o objetivo.

--- a/docs/agent/threat-model-template.md
+++ b/docs/agent/threat-model-template.md
@@ -1,0 +1,19 @@
+# Threat-model de engine money-path — formato
+
+> Threat-model curto por engine que produz **número de decisão** (DRE/A1-A4, pricing, reposição, positivação/comissão, projeção de caixa). Destilado do `aura/THREAT_MODEL.md` do ECC (affaan-m), reescrito p/ o money-path (análise Codex 2026-06-23). O ponto: separar o que o número **prova** do que **não prova**, e travar o default em fail-closed ANTES de alguém tratar o output como verde.
+
+## O esqueleto (5 blocos)
+
+1. **O que o número prova** — a afirmação exata e o regime (competência? caixa? snapshot de quando?). Quase sempre *backward-looking*: descreve o passado registrado, não autoriza a ação presente.
+2. **O que NÃO prova** — os saltos que o consumidor faria por engano. Ex.: "DRE positivo" ≠ "tem caixa pra pagar"; "custo reposto" ≠ "custo da próxima compra"; "score de cliente" ≠ "vai pagar este pedido".
+3. **Failure-modes** — tabela `# | ameaça | mitigação na engine | risco residual do chamador`. Endpoint fora, dado stale, fonte trocada, gaming/sybil, over-trust. Cada linha deixa explícito o que a engine resolve e o que sobra pro chamador.
+4. **Default fail-closed** — ausente / ambíguo / timeout → `null` + confiança-baixa, **NUNCA** número fabricado (money-path §2: `Number(null)===0` é fabricação). O default é a linha que mais erra **silenciosamente** — declare-o aqui em uma frase.
+5. **Fronteira** — onde o número vira decisão (gate determinístico/humano) e onde **não pode** virar (UI ≠ guard; enumere TODAS as vias até o efeito, money-path §5). Assinatura/escrita/allow-deny ficam no seu código, auditáveis.
+
+## Invariante de consistência (o achado que motiva isto)
+
+Doc e código **não podem divergir no default**. No aura, o THREAT_MODEL diz que `new`/`unknown` são rejeitados por default, mas o adapter faz `DEFAULT_ALLOW` permitir `new` (`adapter.py:46` × `THREAT_MODEL.md:34`) — contradição que um teste pega e a prosa não. Regra: **todo default declarado neste doc tem assert correspondente** (`prove-sql-money-path` p/ SQL, vitest p/ helper TS). Se o doc afirma "fail-closed em ausência", existe um teste que semeia ausência e exige `null`.
+
+## Quando escrever um
+
+Toda engine **nova** que emite número de decisão money-path, antes do primeiro consumidor. Não é doc cerimonial: é o checklist que vira asserts e a barra que o `/codex` adversário ataca. Se a engine só transporta dado (sem decisão), pule — o formato é pro número que alguém vai *confiar*.

--- a/scripts/test-destructive-bash-guard.sh
+++ b/scripts/test-destructive-bash-guard.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# test-destructive-bash-guard.sh — TDD do hook .claude/hooks/destructive-bash-guard.sh
+#
+# Regra: comando irreversível (git reset --hard, clean -f, push --force, branch -D, checkout -f,
+# stash drop/clear, rm -r -f fora de /tmp) → deny. CONFIRM_DESTRUCTIVE=1 no início, comando seguro,
+# dry-run, ou menção/leitura pura → allow. Cobre as variações do Codex review 2026-06-24.
+#
+# Uso: bash scripts/test-destructive-bash-guard.sh   (exit 0 = verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$here/../.claude/hooks/destructive-bash-guard.sh"
+command -v jq >/dev/null 2>&1 || { echo "SKIP — jq ausente"; exit 0; }
+
+run() { # <command> → stdout do hook
+  local enc
+  enc="$(printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+  printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$enc" | bash "$HOOK" 2>/dev/null
+}
+is_deny() { grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; }
+fail=0
+d() { if run "$1" | is_deny; then echo "  ok    deny  | $1"; else echo "  FAIL  want deny  | $1"; fail=1; fi; }
+a() { if run "$1" | is_deny; then echo "  FAIL  want allow | $1"; fail=1; else echo "  ok    allow | $1"; fi; }
+
+echo "── destrutivo → deny (inclui variantes do Codex) ──"
+d 'git reset --hard'
+d 'git reset --hard HEAD~3'
+d 'git reset -q --hard'
+d 'git -C /tmp/outro/repo reset --hard'
+d 'git --git-dir=.git --work-tree=. reset --hard'
+d 'git -c advice.detachedHead=false checkout -f'
+d 'git clean -fd'
+d 'git clean -d -f'
+d 'git clean --force -d'
+d 'git push --force'
+d 'git push origin main -f'
+d 'git push origin +main'
+d 'git push -uf origin main'
+d 'git branch -D feature/x'
+d 'git branch --delete --force feature/x'
+d 'git checkout -f'
+d 'git checkout --force main'
+d 'git stash drop'
+d 'git stash --quiet drop stash@{0}'
+d 'git stash clear'
+d 'rm -rf /Users/lucas/repo/src'
+d 'rm -r -f /Users/lucas/repo'
+d 'rm -Rf /Users/lucas/repo'
+d 'rm --recursive --force /Users/lucas/repo'
+d 'rm -rf /tmp/foo /Users/lucas/repo'
+d 'rm -rf /tmp/foo .'
+d 'rm -rf ~/Documentos'
+d 'echo iniciando && git reset --hard'
+d 'echo CONFIRM_DESTRUCTIVE=1 && git reset --hard'
+d 'cd /tmp && git clean -fdx'
+
+echo "── seguro / dry-run / leitura → allow ──"
+a 'git status'
+a 'git reset --soft HEAD~1'
+a 'git reset HEAD arquivo.ts'
+a 'git push'
+a 'git push origin main'
+a 'git push --force-with-lease'
+a 'git checkout main'
+a 'git checkout -b nova-branch'
+a 'git branch -d ja-mergeada'
+a 'git clean -n'
+a 'git clean -fdn'
+a 'git stash'
+a 'git stash pop'
+a 'rm -rf /tmp/ecc-analysis'
+a 'rm -rf /tmp/foo /private/var/folders/x'
+a 'rm arquivo.txt'
+a 'rm -r dir-sem-force'
+a 'mygit reset --hard'
+a 'grep "rm -rf" Makefile'
+a 'rg "git reset --hard" . | head'
+a 'grep -R "rm -rf" . | head'
+a 'CONFIRM_DESTRUCTIVE=1 git reset --hard'
+
+echo "── menção (string/heredoc) ≠ execução → allow ──"
+a 'git commit -m "doc: git reset --hard e rm -rf no guard"'
+a "$(printf 'git commit -F - <<EOF\nfecha git push --force, rm -rf e git reset --hard\nEOF\n')"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — destructive-bash-guard"; else echo "FALHOU ($fail)"; fi
+exit "$fail"

--- a/scripts/test-migration-immutability-guard.sh
+++ b/scripts/test-migration-immutability-guard.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test-migration-immutability-guard.sh — TDD do hook .claude/hooks/migration-immutability-guard.sh
+#
+# Regra: Write/Edit/MultiEdit de supabase/migrations/*.sql que JÁ existe no HEAD (committed) → deny.
+# Migration nova (untracked), arquivo fora de migrations, ou fora de repo git → allow (fail-open).
+#
+# Uso: bash scripts/test-migration-immutability-guard.sh   (exit 0 = verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$here/../.claude/hooks/migration-immutability-guard.sh"
+
+command -v git >/dev/null 2>&1 || { echo "SKIP — git ausente"; exit 0; }
+command -v jq  >/dev/null 2>&1 || { echo "SKIP — jq ausente";  exit 0; }
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# repo com UMA migration committed + um arquivo committed fora de migrations
+repo="$tmp/repo"
+mkdir -p "$repo/supabase/migrations" "$repo/src"
+( cd "$repo" || exit 1
+  git init -q
+  git config user.email t@t.t; git config user.name t
+  echo "CREATE TABLE a();"   > supabase/migrations/20260101000000_committed.sql
+  echo "export const x = 1;" > src/foo.ts
+  git add -A; git commit -qm init )
+# migration NOVA, ainda não commitada (fluxo lovable-db-operator)
+echo "CREATE TABLE b();" > "$repo/supabase/migrations/20260202000000_new.sql"
+
+run() { # <file_path> <tool> → stdout do hook, com CLAUDE_PROJECT_DIR apontando pro repo
+  local fp="$1" tool="${2:-Edit}"
+  printf '{"tool_name":"%s","tool_input":{"file_path":"%s","new_string":"x","content":"x"}}' "$tool" "$fp" \
+    | CLAUDE_PROJECT_DIR="$repo" bash "$HOOK" 2>/dev/null
+}
+is_deny() { grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; }
+
+fail=0
+expect_deny()  { if run "$1" "${3:-Edit}" | is_deny; then echo "  ok    deny  | $2"; else echo "  FAIL  want deny  | $2"; fail=1; fi; }
+expect_allow() { if run "$1" "${3:-Edit}" | is_deny; then echo "  FAIL  want allow | $2"; fail=1; else echo "  ok    allow | $2"; fi; }
+
+echo "── modificar migration committed → deny ──"
+expect_deny  "$repo/supabase/migrations/20260101000000_committed.sql" "Edit de migration no HEAD"            Edit
+expect_deny  "$repo/supabase/migrations/20260101000000_committed.sql" "Write (overwrite) de migration no HEAD" Write
+expect_deny  "$repo/supabase/migrations/20260101000000_committed.sql" "MultiEdit de migration no HEAD"        MultiEdit
+
+echo "── fluxo legítimo / fora de escopo → allow ──"
+expect_allow "$repo/supabase/migrations/20260202000000_new.sql" "migration nova, untracked (lovable-db-operator)" Write
+expect_allow "$repo/src/foo.ts"                                  "arquivo committed fora de migrations"           Edit
+expect_allow "$repo/supabase/migrations/20260303000000_inexistente.sql" "migration que nem existe ainda"        Edit
+
+echo "── bypass de path normalizado (Codex 2026-06-24) → deny ──"
+expect_deny "./supabase/migrations/20260101000000_committed.sql" "path com ./ (resolve relativo ao root)" Edit
+# CLAUDE_PROJECT_DIR divergente do toplevel: rel tem de vir do git toplevel, não do prefixo textual
+if printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","new_string":"x"}}' \
+     "$repo/supabase/migrations/20260101000000_committed.sql" \
+   | CLAUDE_PROJECT_DIR="$repo/src" bash "$HOOK" 2>/dev/null | is_deny
+then echo "  ok    deny  | CLAUDE_PROJECT_DIR=subdir divergente do git toplevel"
+else echo "  FAIL  want deny  | CLAUDE_PROJECT_DIR=subdir"; fail=1; fi
+# acesso via symlink pro repo: pwd -P resolve pro físico sob o toplevel
+ln -s "$repo" "$tmp/link" 2>/dev/null
+if printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","new_string":"x"}}' \
+     "$tmp/link/supabase/migrations/20260101000000_committed.sql" \
+   | CLAUDE_PROJECT_DIR="$tmp/link" bash "$HOOK" 2>/dev/null | is_deny
+then echo "  ok    deny  | acesso via symlink pro repo"
+else echo "  FAIL  want deny  | symlink pro repo"; fail=1; fi
+
+echo "── fail-open: fora de repo git → allow ──"
+mkdir -p "$tmp/nogit/supabase/migrations"
+echo "x" > "$tmp/nogit/supabase/migrations/20260101000000_committed.sql"
+if printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","new_string":"x"}}' \
+     "$tmp/nogit/supabase/migrations/20260101000000_committed.sql" \
+   | CLAUDE_PROJECT_DIR="$tmp/nogit" bash "$HOOK" 2>/dev/null | is_deny
+then echo "  FAIL  want allow | sem repo git deveria fail-open"; fail=1
+else echo "  ok    allow | sem repo git → fail-open"; fi
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — migration-immutability-guard"; else echo "FALHOU"; fi
+exit "$fail"

--- a/scripts/test-stop-moneypath-nudge.sh
+++ b/scripts/test-stop-moneypath-nudge.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# test-stop-moneypath-nudge.sh — TDD do hook .claude/hooks/stop-moneypath-nudge.sh
+#
+# Regra: se há arquivo money-path (supabase/ ou src/ financeiro/pricing/…) uncommitted → emite
+# systemMessage (nudge). Sem money-path tocado, ou repo limpo, ou sem git → silêncio (exit 0).
+# NUNCA bloqueia (não emite decision:block).
+#
+# Uso: bash scripts/test-stop-moneypath-nudge.sh   (exit 0 = verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$here/../.claude/hooks/stop-moneypath-nudge.sh"
+command -v git >/dev/null 2>&1 || { echo "SKIP — git ausente"; exit 0; }
+command -v jq  >/dev/null 2>&1 || { echo "SKIP — jq ausente";  exit 0; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+repo="$tmp/repo"; mkdir -p "$repo"
+( cd "$repo" || exit 1
+  git init -q; git config user.email t@t.t; git config user.name t
+  echo "# repo" > README.md; git add -A; git commit -qm init )
+
+run() { printf '{"hook_event_name":"Stop"}' | CLAUDE_PROJECT_DIR="$repo" bash "$HOOK" 2>/dev/null; }
+has_msg()   { grep -q 'systemMessage'; }
+is_block()  { grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; }
+
+fail=0
+mk() { mkdir -p "$repo/$(dirname "$1")"; echo "x" > "$repo/$1"; }
+clean() { ( cd "$repo" && git clean -fdq && git checkout -q -- . 2>/dev/null ); }
+
+want_msg()   { clean; mk "$1"; if run | has_msg; then echo "  ok    nudge | $1"; else echo "  FAIL  want nudge | $1"; fail=1; fi; }
+want_quiet() { clean; mk "$1"; if run | has_msg; then echo "  FAIL  want quiet | $1"; fail=1; else echo "  ok    quiet | $1"; fi; }
+
+echo "── money-path tocado → nudge ──"
+want_msg "supabase/migrations/20260101000000_x.sql"
+want_msg "supabase/functions/omie-sync/index.ts"
+want_msg "src/pages/financeiro/Dre.tsx"
+want_msg "src/hooks/useReposicaoEstoque.ts"
+
+echo "── fora do money-path / limpo → silêncio ──"
+want_quiet "src/components/ui/Botao.tsx"
+want_quiet "docs/agent/foo.md"
+clean; if run | has_msg; then echo "  FAIL  want quiet | repo limpo"; fail=1; else echo "  ok    quiet | repo limpo"; fi
+
+echo "── nunca bloqueia ──"
+clean; mk "supabase/migrations/x.sql"
+if run | is_block; then echo "  FAIL  nudge NÃO pode bloquear"; fail=1; else echo "  ok    não-bloqueante (sem decision:block)"; fi
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — stop-moneypath-nudge"; else echo "FALHOU"; fi
+exit "$fail"


### PR DESCRIPTION
Porta **5 padrões** do [affaan-m/ECC](https://github.com/affaan-m/ECC) (análise Claude + Codex adversário), reescritos CC-puro + fail-closed. **Draft de propósito** — porquê no fim.

## O que entra
**Docs (risco zero):**
- **#1 `docs/agent/review.md`** — barra de evidência anti-falso-positivo (trigger+linha+repro) + cross-ref `money-path.md` §1.
- **#3 `docs/agent/threat-model-template.md`** — formato de threat-model por engine money-path + cross-ref.

**Hooks (fail-closed na decisão · fail-open na infra):**
- **#2 `migration-immutability-guard.sh`** — bloqueia `Edit/Write/MultiEdit` de migration já no HEAD (imutável; snapshot=DR). Normalização física de path anti-bypass. 10 casos + 2 falsif.
- **#4 `destructive-bash-guard.sh`** — trava comando irreversível do agente (reset/clean/push-force/branch-D/checkout-f/stash-drop, `rm -rf` fora de /tmp); libera só com `CONFIRM_DESTRUCTIVE=1`. Sanitiza heredoc/strings (menção≠execução). 54 casos + 3 falsif.
- **#5 `stop-moneypath-nudge.sh`** — Stop **não-bloqueante**; nudge money-path via `git diff` (zero typecheck — respeita o semáforo heavy/RAM). 8 casos + falsif.

## Prova (local — o CI é cego a este diff)
- 4 suítes `scripts/test-*.sh` verdes + **falsificação em cada hook** (incl. "sempre-allow"/"sempre-silêncio" e regressão dos bypasses)
- shellcheck limpo; `CLAUDE.md` **intocado** (size budget preservado)
- **2 bugs achados pelo Codex e corrigidos:** bypass de normalização de path (#2) e 6 bypasses de detector (#4: git-global-opts, alvo-misto, variantes de flag, confirmação-substring, …)

## Por que DRAFT
O CI `validate` é **cego** (typecheck/vitest/build/lint/size — não roda shellcheck nem os `test-*.sh`; este diff é puro `.claude/`+`docs/`). Mergear ativa os 3 hooks nas **~30 worktrees**. O draft é o seu gate humano — marque **"Ready for review"** quando aprovar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
