### PR TITLE
feat(valor-cockpit): sensibilidade do EVP ao hurdle (combos no fio da navalha) [money-path]

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -24,3 +24,6 @@ PEGA | assimetria: teto≤0 mantido vira teto>0 (sinal, F1)    | s/evp_teto <= 0
 PEGA | guard denominador AR: remove rc>0 da perna ausente    | s/rc > 0 && Number\.isFinite\(c\.receita_liquida\)/Number.isFinite(c.receita_liquida)/
 PEGA | empresa.evp: remove gate empresaCompleta (finge total)| s/empresaCompleta && !conhecidoNull \? conhecido/!conhecidoNull ? conhecido/
 PEGA | confianca: limiar omitido-por-receita 5% afrouxa p/15%| s/omitidoPct > 0\.05/omitidoPct > 0.15/
+# Sensibilidade ao hurdle (bônus 2026-06-24): fio da navalha = break-even cm/capital ∈ [k−δ, k+δ], SÓ p/ 'real'.
+PEGA | sensibilidade: banda sem teto (kHi removido)          | s/hurdle_break_even >= kLo && hurdle_break_even <= kHi/hurdle_break_even >= kLo/
+PEGA | sensibilidade: gate 'real' removido (parcial entra)   | s/evp_status === 'real' && capital_cs > 0 && cm != null/capital_cs > 0 && cm != null/

--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -25,5 +25,5 @@ PEGA | guard denominador AR: remove rc>0 da perna ausente    | s/rc > 0 && Numbe
 PEGA | empresa.evp: remove gate empresaCompleta (finge total)| s/empresaCompleta && !conhecidoNull \? conhecido/!conhecidoNull ? conhecido/
 PEGA | confianca: limiar omitido-por-receita 5% afrouxa p/15%| s/omitidoPct > 0\.05/omitidoPct > 0.15/
 # Sensibilidade ao hurdle (bônus 2026-06-24): fio da navalha = break-even cm/capital ∈ [k−δ, k+δ], SÓ p/ 'real'.
-PEGA | sensibilidade: banda sem teto (kHi removido)          | s/hurdle_break_even >= kLo && hurdle_break_even <= kHi/hurdle_break_even >= kLo/
+PEGA | sensibilidade: banda sem teto (kHi removido)          | s/hurdle_break_even >= kLo - 1e-9 && hurdle_break_even <= kHi \+ 1e-9/hurdle_break_even >= kLo - 1e-9/
 PEGA | sensibilidade: gate 'real' removido (parcial entra)   | s/evp_status === 'real' && capital_cs > 0 && cm != null/capital_cs > 0 && cm != null/

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -770,3 +770,118 @@ describe('montarCelulasComboEVP — rollup.perda_garantida (P2 Codex: UI sinaliz
     expect(r.porCliente[0].perda_garantida).toBe(false);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2026-06-24 — Bônus: sensibilidade do EVP ao hurdle (combos no fio da navalha).
+// Granularidade por combo REAL (capital completo) — o agregado é robusto e MASCARA os frágeis (Codex).
+// hurdle_break_even = cm/capital_cs (o k onde evp=0); sensível = break_even na banda [k−δ, k+δ], δ=0,05.
+// Parciais FORA desta entrega (classificação muda com k). 30% é o número principal.
+// ═══════════════════════════════════════════════════════════════════════════
+describe('montarCelulasComboEVP — sensibilidade ao hurdle (célula real)', () => {
+  // k=0,30, banda default 0,05 → banda [0,25; 0,35]
+  it('break_even DENTRO da banda → sensivel_hurdle=true + break_even + folga', () => {
+    // cm=300 (1000−7·100); a_cs=650, i_cs=400 → capital_cs=1050; break_even=300/1050≈0,2857 ∈ [0,25;0,35]
+    const c = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    }).celulas[0];
+    expect(c.capital_cs).toBeCloseTo(1050, 6);
+    expect(c.evp_status).toBe('real');
+    expect(c.hurdle_break_even).toBeCloseTo(300 / 1050, 6);
+    expect(c.sensivel_hurdle).toBe(true);
+    expect(c.folga_hurdle_pp).toBeCloseTo(300 / 1050 - 0.30, 6); // negativa: break-even abaixo do hurdle atual
+  });
+  it('break_even ACIMA da banda (robustamente bom) → sensivel_hurdle=false', () => {
+    // cm=500; capital=1000 → break_even=0,50 > 0,35
+    const c = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 5 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    }).celulas[0];
+    expect(c.hurdle_break_even).toBeCloseTo(0.5, 6);
+    expect(c.sensivel_hurdle).toBe(false);
+    expect(c.folga_hurdle_pp).toBeCloseTo(0.2, 6); // folga positiva
+  });
+  it('break_even ABAIXO da banda (robustamente ruim) → sensivel_hurdle=false', () => {
+    // cm=100; capital=1000 → break_even=0,10 < 0,25
+    const c = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 9 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    }).celulas[0];
+    expect(c.hurdle_break_even).toBeCloseTo(0.1, 6);
+    expect(c.sensivel_hurdle).toBe(false);
+  });
+  it('célula PARCIAL (estoque ausente) → break_even null, sensivel_hurdle false (fora do escopo)', () => {
+    const c = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: null }], k: 0.30,
+    }).celulas[0];
+    expect(c.evp_status).not.toBe('real');
+    expect(c.hurdle_break_even).toBeNull();
+    expect(c.sensivel_hurdle).toBe(false);
+  });
+  it('capital_cs=0 (AR e estoque 0 conhecidos) → break_even null, sensivel false (EVP plano)', () => {
+    const c = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 0 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 0 }], k: 0.30,
+    }).celulas[0];
+    expect(c.evp_status).toBe('real');
+    expect(c.capital_cs).toBe(0);
+    expect(c.hurdle_break_even).toBeNull();
+    expect(c.sensivel_hurdle).toBe(false);
+  });
+  it('k=null → sem banda, break_even null, sensivel false; hurdle_banda null', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: null,
+    });
+    expect(r.celulas[0].sensivel_hurdle).toBe(false);
+    expect(r.celulas[0].hurdle_break_even).toBeNull();
+    expect(r.hurdle_banda).toBeNull();
+  });
+  it('hurdle_banda reflete k ± δ (0,30 ± 0,05 = [0,25; 0,35])', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.hurdle_banda).toEqual({ base: 0.30, lo: 0.25, hi: 0.35 });
+  });
+  it('banda custom (δ=0,10 → [0,20; 0,40]) muda quem é sensível', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 5 }], // break_even 0,50
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30, banda_hurdle: 0.10,
+    });
+    expect(r.hurdle_banda).toEqual({ base: 0.30, lo: 0.20, hi: 0.40 });
+    expect(r.celulas[0].sensivel_hurdle).toBe(false); // 0,50 ainda fora de [0,20;0,40]
+  });
+});
+
+describe('montarCelulasComboEVP — qtd_combos_sensiveis (granularidade, não agregado)', () => {
+  it('rollup conta combos frágeis; agregado robusto NÃO mascara', () => {
+    // C1: S1 sensível (be 0,2857), S2 robusto-bom (be 0,50). Soma dos 2 pode ser robusta, mas qtd capta o frágil.
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }, // cm 300
+        { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 100, custo_unitario: 5 }, // cm 500
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 1300 }], // rc=2000 → a_cs S1=650, S2=650
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }, { sku: 'S2', estoque_valor: 400 }],
+      k: 0.30,
+    });
+    const s1 = r.celulas.find((c) => c.sku === 'S1')!;
+    const s2 = r.celulas.find((c) => c.sku === 'S2')!;
+    expect(s1.sensivel_hurdle).toBe(true);
+    expect(s2.sensivel_hurdle).toBe(false);
+    expect(r.porCliente[0].qtd_combos_sensiveis).toBe(1);
+    expect(r.empresa.qtd_combos_sensiveis).toBe(1);
+    expect(r.empresa.capital_conhecido).toBeCloseTo(s1.capital_cs + s2.capital_cs, 6);
+  });
+  it('k=null → qtd_combos_sensiveis=0 em rollup/empresa; capital_conhecido null', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: null,
+    });
+    expect(r.porCliente[0].qtd_combos_sensiveis).toBe(0);
+    expect(r.empresa.qtd_combos_sensiveis).toBe(0);
+    expect(r.empresa.capital_conhecido).toBeNull();
+  });
+});

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -853,6 +853,22 @@ describe('montarCelulasComboEVP — sensibilidade ao hurdle (célula real)', () 
     expect(r.hurdle_banda).toEqual({ base: 0.30, lo: 0.20, hi: 0.40 });
     expect(r.celulas[0].sensivel_hurdle).toBe(false); // 0,50 ainda fora de [0,20;0,40]
   });
+  it('BORDA: break_even exatamente em kLo (0,25) e kHi (0,35) → sensível (inclusivo, epsilon contra float)', () => {
+    // break_even 0,25: cm=250 (1000−7,5·100), capital=1000 → na borda lo
+    const lo = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7.5 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    }).celulas[0];
+    expect(lo.hurdle_break_even).toBeCloseTo(0.25, 9);
+    expect(lo.sensivel_hurdle).toBe(true);
+    // break_even 0,35: cm=350 (1000−6,5·100), capital=1000 → na borda hi
+    const hi = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.5 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    }).celulas[0];
+    expect(hi.hurdle_break_even).toBeCloseTo(0.35, 9);
+    expect(hi.sensivel_hurdle).toBe(true);
+  });
 });
 
 describe('montarCelulasComboEVP — qtd_combos_sensiveis (granularidade, não agregado)', () => {

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -157,13 +157,19 @@ export type CelulaEVP = {
   ar_indisponivel: boolean; estoque_indisponivel: boolean;
   capital_parcial: boolean;  // ar_indisponivel || estoque_indisponivel (desacoplado do sinal do evp — sucede evp_parcial)
   evp_status: EvpStatus;
+  // Sensibilidade ao hurdle (bônus 2026-06-24): SÓ p/ célula 'real' (capital completo). O agregado é robusto
+  // e mascara os frágeis → mede-se POR COMBO (Codex). Parciais ficam fora (a classificação muda com k).
+  capital_cs: number;               // a_cs + i_cs (capital alocado total da célula)
+  hurdle_break_even: number | null; // o k onde evp=0 (= cm/capital_cs); null se não-real / capital_cs=0 / cm null
+  sensivel_hurdle: boolean;         // break-even ∈ [k−δ, k+δ] → "fio da navalha" (recomendação frágil ao hurdle)
+  folga_hurdle_pp: number | null;   // break_even − k (em pontos; >0 = folga acima do hurdle, <0 = já abaixo)
 };
 // Rollup: `evp` = Σ células AFIRMÁVEIS (real + teto≤0 mantido) — NÃO inclui omitidas; `evp_teto` = Σ tetos
 // (upper bound do grupo, preserva #961); `evp_incompleto` = ∃ célula omitida por otimismo (o `evp` do grupo
 // exclui essa fatia → pode ser maior). `encargo` (só células com cm) / `encargo_total` (todas) mantidos.
 // perda_garantida = ∃ célula 'teto_nao_positivo' no grupo (o evp inclui um teto≤0 → o prejuízo REAL pode ser maior).
-export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean };
-export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean };
+export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number };
+export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number };
 // Empresa DECOMPOSTA (Codex: somar {reais + tetos≤0} excluindo os teto>0 não é teto nem piso → mentira contábil).
 // evp_conhecido = só capital completo; evp_teto_total = upper bound legado; evp_perda_garantida = piso da fatia
 // parcial-negativa; evp = null se há QUALQUER fatia não-afirmável (não finge um total).
@@ -171,6 +177,8 @@ export type EmpresaEVP = {
   receita: number; cm: number | null; encargo: number | null; encargo_total: number | null;
   evp_conhecido: number | null; evp_teto_total: number | null; evp_perda_garantida: number | null;
   evp: number | null; evp_incompleto: boolean; cm_incompleto: boolean;
+  qtd_combos_sensiveis: number;       // combos REAIS no fio da navalha (a granularidade que o agregado robusto esconde)
+  capital_conhecido: number | null;   // Σ capital_cs das células 'real' → UI deriva evp_conhecido(k') = evp_conhecido + (k − k')·capital_conhecido
 };
 export type ComboEVPResult = {
   celulas: CelulaEVP[];
@@ -183,6 +191,8 @@ export type ComboEVPResult = {
   evp_omitido_otimista_receita_pct: number;
   evp_perda_garantida_receita_pct: number;
   sem_cm_receita_pct: number;
+  // banda do hurdle p/ a sensibilidade (k ± δ; null se k indisponível). A UI rotula 25/30/35% (30 = principal).
+  hurdle_banda: { base: number; lo: number; hi: number } | null;
 };
 
 export function montarCelulasComboEVP(input: {
@@ -190,10 +200,16 @@ export function montarCelulasComboEVP(input: {
   capitalClientes: CapitalCliente[];
   capitalSKUs: CapitalSKU[];
   k: number | null;   // hurdle; null → encargo/EVP indisponíveis (não fabricados)
+  banda_hurdle?: number; // δ p/ a sensibilidade (default 0,05 → 25/35% a k=0,30)
 }): ComboEVPResult {
   // Guard de hurdle: k inválido (não-finito ou <=0) → indisponível (NÃO fabrica encargo). 0% = capital
   // grátis; resolverHurdleCockpit já barra — isto é defense-in-depth na fronteira (Codex 2026-06-18).
   const k = input.k != null && Number.isFinite(input.k) && input.k > 0 ? input.k : null;
+  // Banda do hurdle p/ a sensibilidade (combos no fio da navalha). kLo/kHi só são usados quando k != null.
+  const banda = input.banda_hurdle != null && Number.isFinite(input.banda_hurdle) && input.banda_hurdle > 0 ? input.banda_hurdle : 0.05;
+  const round4 = (x: number) => Math.round(x * 1e4) / 1e4; // evita lixo de float (0,30−0,10=0,19999…) no contrato/UI
+  const kLo = k != null ? round4(Math.max(0, k - banda)) : 0;
+  const kHi = k != null ? round4(k + banda) : 0;
   const arPorCliente = new Map(input.capitalClientes.map((c) => [c.cliente, c.ar_medio]));
   const estoquePorSKU = new Map(input.capitalSKUs.map((s) => [s.sku, s.estoque_valor]));
   // totais pra alocação
@@ -243,14 +259,22 @@ export function montarCelulasComboEVP(input: {
       if (evp_teto <= 0 && estoqueAlocOk && arAlocOk) { evp = evp_teto; evp_status = 'teto_nao_positivo'; }
       else { evp = null; evp_status = 'omitido_teto_positivo'; }                       // teto>0 OU alocação inválida
     }
-    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status };
+    // Sensibilidade ao hurdle: break-even = cm/capital_cs (o k onde evp=0), SÓ p/ célula 'real' (capital
+    // completo, cm conhecido). capital_cs=0 → EVP plano (= cm), insensível. Parcial/indisponível → null
+    // (a sensibilidade do TETO de parciais fica fora desta entrega — a classificação muda com k, Codex).
+    const capital_cs = a_cs + i_cs;
+    const hurdle_break_even = evp_status === 'real' && capital_cs > 0 && cm != null && Number.isFinite(cm / capital_cs)
+      ? cm / capital_cs : null;
+    const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo && hurdle_break_even <= kHi;
+    const folga_hurdle_pp = hurdle_break_even != null && k != null ? hurdle_break_even - k : null;
+    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp };
   });
 
   const rollup = (keyFn: (c: CelulaEVP) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0 };
       acc.receita += cel.receita_liquida;
       acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true; // grupo tem célula sem margem (excluída do EVP)
@@ -263,6 +287,7 @@ export function montarCelulasComboEVP(input: {
       if (cel.evp != null) { acc.evp += cel.evp; acc.evpNull = false; }                         // só afirmável (real + teto≤0 mantido)
       if (cel.evp_status === 'omitido_teto_positivo') acc.evpIncompleto = true;                 // fatia otimista fora do evp
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;                     // evp inclui um teto≤0 → real pode ser pior
+      if (cel.sensivel_hurdle) acc.qtdSensiveis++;                                                // combo real no fio da navalha
       m.set(key, acc);
     }
     return m;
@@ -270,23 +295,25 @@ export function montarCelulasComboEVP(input: {
 
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto }));
-  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto }));
+  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
+  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
 
   // Empresa decomposta + pcts por receita total elegível.
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false;
   let recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
+  let qtdSensiveisEmp = 0, capitalConhecido = 0;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
     if (cel.encargo != null) { encTotalEmp += cel.encargo; encTotalNull = false; }
     if (cel.cm != null) { cmEmp += cel.cm; cmNull = false; if (cel.encargo != null) { encEmp += cel.encargo; encNull = false; } }
     if (cel.evp_teto != null) { tetoTotal += cel.evp_teto; tetoTotalNull = false; }
-    if (cel.evp_status === 'real') { conhecido += cel.evp as number; conhecidoNull = false; recConhecido += cel.receita_liquida; }
+    if (cel.evp_status === 'real') { conhecido += cel.evp as number; conhecidoNull = false; recConhecido += cel.receita_liquida; capitalConhecido += cel.capital_cs; }
     else if (cel.evp_status === 'teto_nao_positivo') { perda += cel.evp as number; perdaNull = false; recPerda += cel.receita_liquida; }
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
+    if (cel.sensivel_hurdle) qtdSensiveisEmp++;
   }
   // empresa.evp só é um total honesto se NADA foi omitido/indisponível; senão null (Codex: não fingir total).
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null;
@@ -297,6 +324,7 @@ export function montarCelulasComboEVP(input: {
     evp_perda_garantida: perdaNull ? null : perda,
     evp: empresaCompleta && !conhecidoNull ? conhecido : null,
     evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp,
+    qtd_combos_sensiveis: qtdSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
   };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return {
@@ -305,6 +333,7 @@ export function montarCelulasComboEVP(input: {
     evp_omitido_otimista_receita_pct: pct(recOmitido),
     evp_perda_garantida_receita_pct: pct(recPerda),
     sem_cm_receita_pct: pct(recSemCm),
+    hurdle_banda: k != null ? { base: k, lo: kLo, hi: kHi } : null,
   };
 }
 

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -265,7 +265,7 @@ export function montarCelulasComboEVP(input: {
     const capital_cs = a_cs + i_cs;
     const hurdle_break_even = evp_status === 'real' && capital_cs > 0 && cm != null && Number.isFinite(cm / capital_cs)
       ? cm / capital_cs : null;
-    const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo && hurdle_break_even <= kHi;
+    const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo - 1e-9 && hurdle_break_even <= kHi + 1e-9; // epsilon: borda inclusiva apesar do float (/codex)
     const folga_hurdle_pp = hurdle_break_even != null && k != null ? hurdle_break_even - k : null;
     return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp };
   });

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -111,6 +111,17 @@ export default function FinanceiroValorCockpit() {
         </p>
       )}
 
+      {data.hurdle_banda != null && data.empresa.capital_conhecido != null && data.empresa.evp_conhecido != null && (
+        <p className="text-xs text-muted-foreground">
+          Sensibilidade ao hurdle: a {(data.hurdle_banda.lo * 100).toFixed(0)}% <span className="font-tabular">{brl(data.empresa.evp_conhecido + (data.hurdle_banda.base - data.hurdle_banda.lo) * data.empresa.capital_conhecido)}</span>
+          {' · '}<span className="font-tabular text-foreground">a {(data.hurdle_banda.base * 100).toFixed(0)}% {brl(data.empresa.evp_conhecido)}</span>
+          {' · '}a {(data.hurdle_banda.hi * 100).toFixed(0)}% <span className="font-tabular">{brl(data.empresa.evp_conhecido + (data.hurdle_banda.base - data.hurdle_banda.hi) * data.empresa.capital_conhecido)}</span>
+          {data.empresa.qtd_combos_sensiveis > 0 && (
+            <> · <span className="text-status-warning">{data.empresa.qtd_combos_sensiveis} combo(s) no fio da navalha (recomendação frágil ao hurdle)</span></>
+          )}
+        </p>
+      )}
+
       <div className="flex gap-2">
         <Button
           variant={aba === 'cliente' ? 'default' : 'outline'}
@@ -179,6 +190,11 @@ export default function FinanceiroValorCockpit() {
                           {row.evp_incompleto
                             ? `${row.evp == null ? 'capital não medido' : 'parcial'}${row.evp_teto != null ? ` · teto ≤ ${brl(row.evp_teto)}` : ''}`
                             : 'prejuízo real pode ser maior (teto)'}
+                        </div>
+                      )}
+                      {row.qtd_combos_sensiveis > 0 && (
+                        <div className="text-[10px] leading-tight text-status-warning">
+                          {row.qtd_combos_sensiveis} frágil(eis) ao hurdle
                         </div>
                       )}
                     </td>

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1003,6 +1003,7 @@ export interface CockpitRollupCliente {
   evp_incompleto: boolean;
   perda_garantida: boolean;
   cm_incompleto: boolean;
+  qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   nome?: string | null;  // nome do cliente (profiles via customer_user_id) — UI mostra no lugar do código
 }
 export interface CockpitRollupSKU {
@@ -1017,6 +1018,7 @@ export interface CockpitRollupSKU {
   evp_incompleto: boolean;
   perda_garantida: boolean;
   cm_incompleto: boolean;
+  qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   descricao?: string | null;  // descrição do produto (omie_products) — UI mostra no lugar do código SKU
 }
 // Empresa DECOMPOSTA (capital parcial → um único evp seria mentira contábil; Codex 2026-06-23).
@@ -1032,6 +1034,8 @@ export interface CockpitEmpresaEVP {
   evp_incompleto: boolean;
   perda_garantida: boolean;
   cm_incompleto: boolean;
+  qtd_combos_sensiveis: number;     // combos REAIS no fio da navalha (granularidade que o agregado robusto esconde)
+  capital_conhecido: number | null; // Σ capital das células reais → deriva EVP a outros hurdles
 }
 export interface ValorCockpitResult {
   company: string;
@@ -1052,6 +1056,7 @@ export interface ValorCockpitResult {
   evp_omitido_otimista_receita_pct?: number;
   evp_perda_garantida_receita_pct?: number;
   sem_cm_receita_pct?: number;
+  hurdle_banda?: { base: number; lo: number; hi: number } | null; // banda da sensibilidade (lo/base/hi → 25/30/35%)
   config: CockpitConfig;
 }
 

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -184,7 +184,7 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     // Sensibilidade ao hurdle (espelho de src): break-even = cm/capital_cs SÓ p/ célula 'real'; parcial → null.
     const capital_cs = a_cs + i_cs;
     const hurdle_break_even = evp_status === 'real' && capital_cs > 0 && cm != null && Number.isFinite(cm / capital_cs) ? cm / capital_cs : null;
-    const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo && hurdle_break_even <= kHi;
+    const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo - 1e-9 && hurdle_break_even <= kHi + 1e-9; // epsilon: borda inclusiva apesar do float (/codex)
     const folga_hurdle_pp = hurdle_break_even != null && k != null ? hurdle_break_even - k : null;
     return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp };
   });
@@ -592,6 +592,7 @@ serve(async (req: Request) => {
       evp_omitido_otimista_receita_pct: res.evp_omitido_otimista_receita_pct,
       evp_perda_garantida_receita_pct: res.evp_perda_garantida_receita_pct,
       sem_cm_receita_pct: res.sem_cm_receita_pct,
+      hurdle_banda: res.hurdle_banda, // banda da sensibilidade (sem isto a UI nunca mostra 25/30/35 — P1 /codex)
       config,
     }, 200);
   } catch (e) {

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -137,7 +137,7 @@ type CapitalCliente = { cliente: string; ar_medio: number | null };
 type CapitalSKU = { sku: string; estoque_valor: number | null };
 // Status do EVP afirmável (espelho VERBATIM de src/lib/financeiro/valor-cockpit-helpers.ts).
 type EvpStatus = 'real' | 'teto_nao_positivo' | 'omitido_teto_positivo' | 'indisponivel_cm' | 'indisponivel_hurdle';
-function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: CapitalCliente[]; capitalSKUs: CapitalSKU[]; k: number | null }) {
+function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: CapitalCliente[]; capitalSKUs: CapitalSKU[]; k: number | null; banda_hurdle?: number }) {
   const arPorCliente = new Map(input.capitalClientes.map((c) => [c.cliente, c.ar_medio]));
   const estoquePorSKU = new Map(input.capitalSKUs.map((s) => [s.sku, s.estoque_valor]));
   const receitaPorCliente = new Map<string, number>();
@@ -147,6 +147,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     qtdPorSKU.set(c.sku, (qtdPorSKU.get(c.sku) ?? 0) + c.quantidade);
   }
   const k = input.k != null && Number.isFinite(input.k) && input.k > 0 ? input.k : null; // guard de hurdle (espelho)
+  const banda = input.banda_hurdle != null && Number.isFinite(input.banda_hurdle) && input.banda_hurdle > 0 ? input.banda_hurdle : 0.05;
+  const round4 = (x: number) => Math.round(x * 1e4) / 1e4;
+  const kLo = k != null ? round4(Math.max(0, k - banda)) : 0;
+  const kHi = k != null ? round4(k + banda) : 0;
   const celulas = input.combos.map((c) => {
     const cm = margemContribuicao({ receita_liquida: c.receita_liquida, custo_unitario: c.custo_unitario, quantidade: c.quantidade });
     const arCraw = arPorCliente.get(c.cliente) ?? null;
@@ -177,14 +181,19 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
       if (evp_teto <= 0 && estoqueAlocOk && arAlocOk) { evp = evp_teto; evp_status = 'teto_nao_positivo'; }
       else { evp = null; evp_status = 'omitido_teto_positivo'; }
     }
-    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status };
+    // Sensibilidade ao hurdle (espelho de src): break-even = cm/capital_cs SÓ p/ célula 'real'; parcial → null.
+    const capital_cs = a_cs + i_cs;
+    const hurdle_break_even = evp_status === 'real' && capital_cs > 0 && cm != null && Number.isFinite(cm / capital_cs) ? cm / capital_cs : null;
+    const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo && hurdle_break_even <= kHi;
+    const folga_hurdle_pp = hurdle_break_even != null && k != null ? hurdle_break_even - k : null;
+    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp };
   });
   type Cel = typeof celulas[number];
   const rollup = (keyFn: (c: Cel) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0 };
       acc.receita += cel.receita_liquida; acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true;
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; }
@@ -193,31 +202,34 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
       if (cel.evp != null) { acc.evp += cel.evp; acc.evpNull = false; }
       if (cel.evp_status === 'omitido_teto_positivo') acc.evpIncompleto = true;
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;
+      if (cel.sensivel_hurdle) acc.qtdSensiveis++;
       m.set(key, acc);
     }
     return m;
   };
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto }));
-  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto }));
+  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
+  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false, recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
+  let qtdSensiveisEmp = 0, capitalConhecido = 0;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
     if (cel.encargo != null) { encTotalEmp += cel.encargo; encTotalNull = false; }
     if (cel.cm != null) { cmEmp += cel.cm; cmNull = false; if (cel.encargo != null) { encEmp += cel.encargo; encNull = false; } }
     if (cel.evp_teto != null) { tetoTotal += cel.evp_teto; tetoTotalNull = false; }
-    if (cel.evp_status === 'real') { conhecido += cel.evp as number; conhecidoNull = false; recConhecido += cel.receita_liquida; }
+    if (cel.evp_status === 'real') { conhecido += cel.evp as number; conhecidoNull = false; recConhecido += cel.receita_liquida; capitalConhecido += cel.capital_cs; }
     else if (cel.evp_status === 'teto_nao_positivo') { perda += cel.evp as number; perdaNull = false; recPerda += cel.receita_liquida; }
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
+    if (cel.sensivel_hurdle) qtdSensiveisEmp++;
   }
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null; // evp único só se nada omitido/indisponível (Codex)
-  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp };
+  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
-  return { celulas, porCliente, porSKU, empresa, evp_conhecido_receita_pct: pct(recConhecido), evp_omitido_otimista_receita_pct: pct(recOmitido), evp_perda_garantida_receita_pct: pct(recPerda), sem_cm_receita_pct: pct(recSemCm) };
+  return { celulas, porCliente, porSKU, empresa, evp_conhecido_receita_pct: pct(recConhecido), evp_omitido_otimista_receita_pct: pct(recOmitido), evp_perda_garantida_receita_pct: pct(recPerda), sem_cm_receita_pct: pct(recSemCm), hurdle_banda: k != null ? { base: k, lo: kLo, hi: kHi } : null };
 }
 type CockpitConfig = { margem_minima_pct: number; desconto_max_pct: number; prazo_alvo_dias: number; dias_estoque_max: number; sample_min_receita: number };
 type Recomendacao = { acao: string; motivo: string; impacto_rs: number | null };


### PR DESCRIPTION
Bônus do [#1024](https://github.com/LucasSardenbergL/afiacao/pull/1024): identifica combos cuja recomendação é **frágil ao hurdle** (gera valor a 25%, destrói a 35%).

## Decisão (Claude + `/codex consult`)
**Medição (psql-ro):** o EVP **agregado** da Oben é robusto (R$1,72M @25% → R$1,63M @35%; capital ~R$888k vs margem ~R$1,94M). Logo o valor está na **granularidade** — combos individuais frágeis que o agregado **mascara** (achado Codex).
- `hurdle_break_even = cm/capital_cs` (o k onde evp=0); `sensivel_hurdle = break-even ∈ [k−δ, k+δ]` (δ=0,05 → 25/35%).
- **SÓ células `real`** (capital completo). Parciais **fora** (a classificação omitido/mantido muda com k → sensibilidade do teto seria perigosa).
- `qtd_combos_sensiveis` por rollup/empresa; `capital_conhecido` + `hurdle_banda` → a UI deriva @25/30/35.
- **UI:** badge "N frágil(eis) ao hurdle" por linha + resumo de sensibilidade (30% principal; 25/35 secundários).

## `/codex` (2 rounds)
- **consult (design):** granularidade por combo (não agregado); `capital_conhecido` como base (não encargo); parciais fora.
- **challenge (diff):** **[P1]** `hurdle_banda` não era serializado no payload do edge → a UI **nunca** mostraria 25/30/35 em produção (os testes do helper não pegam — só o Codex lendo o edge). **CORRIGIDO.** **[P2]** epsilon na borda 0,25/0,35 — **CORRIGIDO** + teste. **[P2]** folga/quase-frágeis na UI — **DEFERIDO** (follow-up abaixo).

## Verificação
- **TDD + FALSIFICAÇÃO** (banda sem teto + gate-`real` removido → 5 vermelhos exatos).
- **116 testes** helper · suíte **4078** · typecheck **0** · `deno check` **0** · lint **0** · **mutcheck 19/19** (+2 da sensibilidade) · paridade helper↔edge conferida.

## ⚠️ Deploy MANUAL pós-merge
1. **Edge** `fin-valor-cockpit` verbatim (chat do Lovable). 2. **Publish** (UI/tipo/helper). Sem migration.

## Follow-up deferido (Codex P2)
Expor `folga_hurdle_pp` / "combo mais perto da borda" na UI — a flag binária não sinaliza um combo a 0,355 (logo acima da banda). A célula já calcula a folga; falta agregar/exibir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)