### PR TITLE
chore(crm): tipa as views v_cliente_interacoes + v_carteira_sla (remove `as never`) — follow-up #1040

### DIFF
--- a/src/components/customer360/hooks.ts
+++ b/src/components/customer360/hooks.ts
@@ -127,10 +127,8 @@ export function useCustomerInteractions(customerId: string | undefined) {
     enabled: !!customerId,
     staleTime: 30_000,
     queryFn: async () => {
-      // v_cliente_interacoes ainda não consta nos tipos gerados do Supabase → cast pontual
-      // + .returns(). TODO(tipos): remover o `as never` após regenerar types.ts.
       const { data, error } = await supabase
-        .from('v_cliente_interacoes' as never)
+        .from('v_cliente_interacoes')
         .select('at, canal, titulo, resumo, revenue')
         .eq('customer_user_id', customerId!)
         .order('at', { ascending: false })

--- a/src/hooks/useCarteiraSla.ts
+++ b/src/hooks/useCarteiraSla.ts
@@ -18,17 +18,13 @@ export interface CarteiraSlaRow {
 // Fila de "SLA de contato vencido" da carteira (view read-only v_carteira_sla).
 // security_invoker=true → a RLS de farmer_client_scores já escopa por carteira;
 // o vendedor vê a carteira dele, o gestor vê tudo.
-//
-// NOTA(tipos): v_carteira_sla é uma view nova; enquanto os tipos do Supabase não
-// forem regenerados, o nome não consta no schema gerado → cast pontual em `.from`
-// + `.returns<T>()`. TODO: remover o `as never` após regenerar types.ts.
 export function useCarteiraSla() {
   return useQuery({
     queryKey: ['carteira-sla'],
     staleTime: 60_000,
     queryFn: async (): Promise<CarteiraSlaRow[]> => {
       const { data, error } = await supabase
-        .from('v_carteira_sla' as never)
+        .from('v_carteira_sla')
         .select(
           'customer_user_id, farmer_id, health_class, churn_risk, last_contact_at, dias_sem_contato, sla_dias, vencido, priority_score',
         )

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14382,6 +14382,34 @@ export type Database = {
         }
         Relationships: []
       }
+      v_carteira_sla: {
+        Row: {
+          churn_risk: number | null
+          customer_user_id: string | null
+          dias_sem_contato: number | null
+          farmer_id: string | null
+          health_class: string | null
+          last_contact_at: string | null
+          priority_score: number | null
+          sla_dias: number | null
+          vencido: boolean | null
+        }
+        Relationships: []
+      }
+      v_cliente_interacoes: {
+        Row: {
+          at: string | null
+          autor_id: string | null
+          canal: string | null
+          customer_user_id: string | null
+          ref_id: string | null
+          ref_tabela: string | null
+          resumo: string | null
+          revenue: number | null
+          titulo: string | null
+        }
+        Relationships: []
+      }
       v_clientes_nao_vinculados_atual: {
         Row: {
           cidade: string | null


### PR DESCRIPTION
Follow-up de higiene do #1040 (já no ar). Os tipos do Supabase ainda não foram regenerados via Lovable, então:

- Adiciona `v_cliente_interacoes` e `v_carteira_sla` à seção `Views` de `src/integrations/supabase/types.ts`, no formato do gerador (colunas em ordem alfabética, todas `| null`, `Relationships: []`).
- Remove o cast temporário `as never` das duas queries (`useCustomerInteractions`, `useCarteiraSla`); o `.returns<T>()` segue reancorando para o tipo preciso.

Quando o Lovable regenerar os tipos, o conteúdo bate (mesmo banco) — diff zero/trivial. Sem mudança de runtime.

typecheck ✅ · eslint ✅ · 0 ocorrências de `as never`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)