### PR TITLE
feat(valor-cockpit): quase-frágeis ao hurdle (faixa (k+δ,k+2δ]) — tira a falsa robustez residual [money-path]

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -27,3 +27,10 @@ PEGA | confianca: limiar omitido-por-receita 5% afrouxa p/15%| s/omitidoPct > 0\
 # Sensibilidade ao hurdle (bônus 2026-06-24): fio da navalha = break-even cm/capital ∈ [k−δ, k+δ], SÓ p/ 'real'.
 PEGA | sensibilidade: banda sem teto (kHi removido)          | s/hurdle_break_even >= kLo - 1e-9 && hurdle_break_even <= kHi \+ 1e-9/hurdle_break_even >= kLo - 1e-9/
 PEGA | sensibilidade: gate 'real' removido (parcial entra)   | s/evp_status === 'real' && capital_cs > 0 && cm != null/capital_cs > 0 && cm != null/
+# Quase-sensibilidade (follow-up 2026-06-24): quase-frágil = break-even ∈ (k+δ, k+2δ], SÓ lado bom (gera valor,
+# folga fina). Tira a falsa robustez que sobra quando qtd_sensiveis=0. Mut. exclusivo do 'no fio'. Institucionaliza
+# as falsificações F1 (teto) e F3 (escopo lado-bom) provadas à mão + a agregação por rollup/empresa.
+PEGA | quase: teto da faixa removido (robusto-bom vira quase) | s/hurdle_break_even > kHi \+ 1e-9 && hurdle_break_even <= kHi2 \+ 1e-9/hurdle_break_even > kHi + 1e-9/
+PEGA | quase: lado bom vira lado ruim (> kHi -> < kLo)        | s/hurdle_break_even > kHi \+ 1e-9 && hurdle_break_even <= kHi2/hurdle_break_even < kLo - 1e-9 && hurdle_break_even <= kHi2/
+PEGA | quase: rollup não agrega (contador morto)             | s/if \(cel\.quase_sensivel_hurdle\) acc\.qtdQuaseSensiveis\+\+/if (false) acc.qtdQuaseSensiveis++/
+PEGA | quase: empresa não agrega (contador morto)            | s/if \(cel\.quase_sensivel_hurdle\) qtdQuaseSensiveisEmp\+\+/if (false) qtdQuaseSensiveisEmp++/

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -901,3 +901,108 @@ describe('montarCelulasComboEVP — qtd_combos_sensiveis (granularidade, não ag
     expect(r.empresa.capital_conhecido).toBeNull();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2026-06-24 — Follow-up: quase-frágeis ao hurdle (folga fina). Tira a FALSA ROBUSTEZ
+// que sobra quando qtd_combos_sensiveis=0 mas há combo logo FORA da banda. Escopo SÓ
+// LADO BOM (gera valor, frágil): break_even ∈ (k+δ, k+2δ] = (0,35; 0,40] a k=0,30.
+// O lado ruim (break_even<k → evp<0) já é visível na tabela (ordenada piores-primeiro)
+// → contá-lo duplicaria sinal. Mutuamente exclusivo de sensivel_hurdle (banda estreita).
+// ═══════════════════════════════════════════════════════════════════════════
+describe('montarCelulasComboEVP — quase-sensibilidade ao hurdle (folga fina, lado bom)', () => {
+  // 1 combo: capital_cs = ar_medio + estoque_valor = 600 + 400 = 1000 → break_even = cm/1000.
+  const cap = { capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30 };
+  const cel1 = (custo_unitario: number) => montarCelulasComboEVP({
+    combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario }], ...cap,
+  }).celulas[0];
+
+  it('break_even na faixa (k+δ, k+2δ] (0,38) → quase=true, sensivel=false (gera valor, folga fina)', () => {
+    const c = cel1(6.2); // cm 380 → be 0,38, folga +0,08 ∈ (δ,2δ]
+    expect(c.evp_status).toBe('real');
+    expect(c.hurdle_break_even).toBeCloseTo(0.38, 6);
+    expect(c.sensivel_hurdle).toBe(false);
+    expect(c.quase_sensivel_hurdle).toBe(true);
+    expect(c.folga_hurdle_pp).toBeCloseTo(0.08, 6);
+  });
+  it('exemplo do briefing: break_even 0,355 (logo ACIMA de kHi=0,35) → quase=true (era invisível)', () => {
+    const c = cel1(6.45); // cm 355 → be 0,355
+    expect(c.hurdle_break_even).toBeCloseTo(0.355, 6);
+    expect(c.sensivel_hurdle).toBe(false);
+    expect(c.quase_sensivel_hurdle).toBe(true);
+  });
+  it('BORDA kHi (0,35): sensivel=true E quase=false (mutuamente exclusivos, sem overlap)', () => {
+    const c = cel1(6.5); // cm 350 → be 0,35 = kHi
+    expect(c.hurdle_break_even).toBeCloseTo(0.35, 9);
+    expect(c.sensivel_hurdle).toBe(true);
+    expect(c.quase_sensivel_hurdle).toBe(false);
+  });
+  it('BORDA kHi2 (k+2δ=0,40): quase=true (inclusivo, epsilon contra float)', () => {
+    const c = cel1(6.0); // cm 400 → be 0,40 = kHi2
+    expect(c.hurdle_break_even).toBeCloseTo(0.40, 9);
+    expect(c.quase_sensivel_hurdle).toBe(true);
+    expect(c.sensivel_hurdle).toBe(false);
+  });
+  it('break_even acima de k+2δ (0,42, robusto-bom) → quase=false', () => {
+    const c = cel1(5.8); // cm 420 → be 0,42
+    expect(c.hurdle_break_even).toBeCloseTo(0.42, 6);
+    expect(c.sensivel_hurdle).toBe(false);
+    expect(c.quase_sensivel_hurdle).toBe(false);
+  });
+  it('LADO RUIM: break_even 0,22 (|folga|∈(δ,2δ] mas destrói valor) → quase=false (escopo só lado bom)', () => {
+    const c = cel1(7.8); // cm 220 → be 0,22, folga −0,08
+    expect(c.hurdle_break_even).toBeCloseTo(0.22, 6);
+    expect(c.folga_hurdle_pp).toBeCloseTo(-0.08, 6);
+    expect(c.sensivel_hurdle).toBe(false);
+    expect(c.quase_sensivel_hurdle).toBe(false); // já visível via evp<0 → não duplica
+  });
+  it('no fio (break_even=0,30=k) → sensivel=true, quase=false', () => {
+    const c = cel1(7.0); // cm 300 → be 0,30
+    expect(c.hurdle_break_even).toBeCloseTo(0.30, 9);
+    expect(c.sensivel_hurdle).toBe(true);
+    expect(c.quase_sensivel_hurdle).toBe(false);
+  });
+  it('célula parcial (estoque ausente) → quase=false (fora do escopo, como sensivel)', () => {
+    const c = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: null }], k: 0.30,
+    }).celulas[0];
+    expect(c.evp_status).not.toBe('real');
+    expect(c.quase_sensivel_hurdle).toBe(false);
+  });
+  it('k=null → quase=false em célula/rollup/empresa', () => {
+    // O 0 aqui é cardinalidade de conjunto vazio (sem hurdle não há faixa), NÃO fabricação de valor:
+    // "ausente ≠ zero" rege R$/%/taxa (onde 0 é número plausível mas falso), não CONTAGEM. Consistente
+    // com qtd_combos_sensiveis (number, #1044); a UI gateia por hurdle_banda → nunca exibe o 0 como
+    // "medi e não há". (resposta ao /codex challenge P2, 2026-06-24 — mantido number, não number|null.)
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: null,
+    });
+    expect(r.celulas[0].quase_sensivel_hurdle).toBe(false);
+    expect(r.porCliente[0].qtd_combos_quase_sensiveis).toBe(0);
+    expect(r.empresa.qtd_combos_quase_sensiveis).toBe(0);
+  });
+  it('rollup/empresa: qtd_combos_quase_sensiveis conta o quase (lado bom), separado do no-fio', () => {
+    // C1: S1 quase (be 0,38), S2 robusto-bom (be 0,50), S3 no fio (be 0,30). rc=3000 → a_cs cada=600; i_cs cada=400.
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }, // be 0,38 quase
+        { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 100, custo_unitario: 5.0 }, // be 0,50 robusto
+        { cliente: 'C1', sku: 'S3', receita_liquida: 1000, quantidade: 100, custo_unitario: 7.0 }, // be 0,30 no fio
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 1800 }],
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }, { sku: 'S2', estoque_valor: 400 }, { sku: 'S3', estoque_valor: 400 }],
+      k: 0.30,
+    });
+    const s1 = r.celulas.find((c) => c.sku === 'S1')!;
+    const s2 = r.celulas.find((c) => c.sku === 'S2')!;
+    const s3 = r.celulas.find((c) => c.sku === 'S3')!;
+    expect(s1.quase_sensivel_hurdle).toBe(true);  expect(s1.sensivel_hurdle).toBe(false);
+    expect(s2.quase_sensivel_hurdle).toBe(false); expect(s2.sensivel_hurdle).toBe(false);
+    expect(s3.sensivel_hurdle).toBe(true);        expect(s3.quase_sensivel_hurdle).toBe(false);
+    expect(r.porCliente[0].qtd_combos_quase_sensiveis).toBe(1); // só S1
+    expect(r.porCliente[0].qtd_combos_sensiveis).toBe(1);       // só S3 (regressão da contagem existente)
+    expect(r.empresa.qtd_combos_quase_sensiveis).toBe(1);
+    expect(r.empresa.qtd_combos_sensiveis).toBe(1);
+  });
+});

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -163,13 +163,14 @@ export type CelulaEVP = {
   hurdle_break_even: number | null; // o k onde evp=0 (= cm/capital_cs); null se não-real / capital_cs=0 / cm null
   sensivel_hurdle: boolean;         // break-even ∈ [k−δ, k+δ] → "fio da navalha" (recomendação frágil ao hurdle)
   folga_hurdle_pp: number | null;   // break_even − k (em pontos; >0 = folga acima do hurdle, <0 = já abaixo)
+  quase_sensivel_hurdle: boolean;   // break_even ∈ (k+δ, k+2δ]: gera valor HOJE mas folga fina (tira a falsa robustez residual). SÓ lado bom (o ruim já é visível via evp<0); mut. exclusivo de sensivel_hurdle.
 };
 // Rollup: `evp` = Σ células AFIRMÁVEIS (real + teto≤0 mantido) — NÃO inclui omitidas; `evp_teto` = Σ tetos
 // (upper bound do grupo, preserva #961); `evp_incompleto` = ∃ célula omitida por otimismo (o `evp` do grupo
 // exclui essa fatia → pode ser maior). `encargo` (só células com cm) / `encargo_total` (todas) mantidos.
 // perda_garantida = ∃ célula 'teto_nao_positivo' no grupo (o evp inclui um teto≤0 → o prejuízo REAL pode ser maior).
-export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number };
-export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number };
+export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number };
+export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number };
 // Empresa DECOMPOSTA (Codex: somar {reais + tetos≤0} excluindo os teto>0 não é teto nem piso → mentira contábil).
 // evp_conhecido = só capital completo; evp_teto_total = upper bound legado; evp_perda_garantida = piso da fatia
 // parcial-negativa; evp = null se há QUALQUER fatia não-afirmável (não finge um total).
@@ -178,6 +179,7 @@ export type EmpresaEVP = {
   evp_conhecido: number | null; evp_teto_total: number | null; evp_perda_garantida: number | null;
   evp: number | null; evp_incompleto: boolean; cm_incompleto: boolean;
   qtd_combos_sensiveis: number;       // combos REAIS no fio da navalha (a granularidade que o agregado robusto esconde)
+  qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break_even ∈ (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
   capital_conhecido: number | null;   // Σ capital_cs das células 'real' → UI deriva evp_conhecido(k') = evp_conhecido + (k − k')·capital_conhecido
 };
 export type ComboEVPResult = {
@@ -210,6 +212,7 @@ export function montarCelulasComboEVP(input: {
   const round4 = (x: number) => Math.round(x * 1e4) / 1e4; // evita lixo de float (0,30−0,10=0,19999…) no contrato/UI
   const kLo = k != null ? round4(Math.max(0, k - banda)) : 0;
   const kHi = k != null ? round4(k + banda) : 0;
+  const kHi2 = k != null ? round4(k + 2 * banda) : 0; // teto da faixa quase-frágil (k+2δ); só usado quando k != null
   const arPorCliente = new Map(input.capitalClientes.map((c) => [c.cliente, c.ar_medio]));
   const estoquePorSKU = new Map(input.capitalSKUs.map((s) => [s.sku, s.estoque_valor]));
   // totais pra alocação
@@ -267,14 +270,18 @@ export function montarCelulasComboEVP(input: {
       ? cm / capital_cs : null;
     const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo - 1e-9 && hurdle_break_even <= kHi + 1e-9; // epsilon: borda inclusiva apesar do float (/codex)
     const folga_hurdle_pp = hurdle_break_even != null && k != null ? hurdle_break_even - k : null;
-    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp };
+    // Quase-frágil: break_even na faixa externa (kHi, kHi2] = (k+δ, k+2δ] — gera valor HOJE mas folga fina.
+    // SÓ lado bom (acima de kHi); o lado ruim (break_even<k → evp<0) já é visível na tabela. Borda inferior
+    // exclusiva (kHi já é 'sensível') e superior inclusiva, mesmo epsilon → mut. exclusivo de sensivel_hurdle, sem gap.
+    const quase_sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even > kHi + 1e-9 && hurdle_break_even <= kHi2 + 1e-9;
+    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp, quase_sensivel_hurdle };
   });
 
   const rollup = (keyFn: (c: CelulaEVP) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0 };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0 };
       acc.receita += cel.receita_liquida;
       acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true; // grupo tem célula sem margem (excluída do EVP)
@@ -288,6 +295,7 @@ export function montarCelulasComboEVP(input: {
       if (cel.evp_status === 'omitido_teto_positivo') acc.evpIncompleto = true;                 // fatia otimista fora do evp
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;                     // evp inclui um teto≤0 → real pode ser pior
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;                                                // combo real no fio da navalha
+      if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++;                                      // combo real quase-frágil (folga fina, lado bom)
       m.set(key, acc);
     }
     return m;
@@ -295,15 +303,15 @@ export function montarCelulasComboEVP(input: {
 
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
-  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
+  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
+  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
 
   // Empresa decomposta + pcts por receita total elegível.
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false;
   let recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
-  let qtdSensiveisEmp = 0, capitalConhecido = 0;
+  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -314,6 +322,7 @@ export function montarCelulasComboEVP(input: {
     else if (cel.evp_status === 'teto_nao_positivo') { perda += cel.evp as number; perdaNull = false; recPerda += cel.receita_liquida; }
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
+    if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
   }
   // empresa.evp só é um total honesto se NADA foi omitido/indisponível; senão null (Codex: não fingir total).
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null;
@@ -324,7 +333,7 @@ export function montarCelulasComboEVP(input: {
     evp_perda_garantida: perdaNull ? null : perda,
     evp: empresaCompleta && !conhecidoNull ? conhecido : null,
     evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp,
-    qtd_combos_sensiveis: qtdSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
+    qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
   };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return {

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -119,6 +119,9 @@ export default function FinanceiroValorCockpit() {
           {data.empresa.qtd_combos_sensiveis > 0 && (
             <> · <span className="text-status-warning">{data.empresa.qtd_combos_sensiveis} combo(s) no fio da navalha (recomendação frágil ao hurdle)</span></>
           )}
+          {data.empresa.qtd_combos_quase_sensiveis > 0 && (
+            <> · <span className="text-muted-foreground">{data.empresa.qtd_combos_quase_sensiveis} quase-frágil(eis) (folga fina, +5 a +10pp do hurdle)</span></>
+          )}
         </p>
       )}
 
@@ -195,6 +198,11 @@ export default function FinanceiroValorCockpit() {
                       {row.qtd_combos_sensiveis > 0 && (
                         <div className="text-[10px] leading-tight text-status-warning">
                           {row.qtd_combos_sensiveis} frágil(eis) ao hurdle
+                        </div>
+                      )}
+                      {row.qtd_combos_quase_sensiveis > 0 && (
+                        <div className="text-[10px] leading-tight text-muted-foreground">
+                          {row.qtd_combos_quase_sensiveis} quase-frágil(eis)
                         </div>
                       )}
                     </td>

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1004,6 +1004,7 @@ export interface CockpitRollupCliente {
   perda_garantida: boolean;
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
+  qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
   nome?: string | null;  // nome do cliente (profiles via customer_user_id) — UI mostra no lugar do código
 }
 export interface CockpitRollupSKU {
@@ -1019,6 +1020,7 @@ export interface CockpitRollupSKU {
   perda_garantida: boolean;
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
+  qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
   descricao?: string | null;  // descrição do produto (omie_products) — UI mostra no lugar do código SKU
 }
 // Empresa DECOMPOSTA (capital parcial → um único evp seria mentira contábil; Codex 2026-06-23).
@@ -1035,6 +1037,7 @@ export interface CockpitEmpresaEVP {
   perda_garantida: boolean;
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;     // combos REAIS no fio da navalha (granularidade que o agregado robusto esconde)
+  qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break-even em (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
   capital_conhecido: number | null; // Σ capital das células reais → deriva EVP a outros hurdles
 }
 export interface ValorCockpitResult {

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -151,6 +151,7 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
   const round4 = (x: number) => Math.round(x * 1e4) / 1e4;
   const kLo = k != null ? round4(Math.max(0, k - banda)) : 0;
   const kHi = k != null ? round4(k + banda) : 0;
+  const kHi2 = k != null ? round4(k + 2 * banda) : 0; // teto da faixa quase-frágil (k+2δ); só usado quando k != null
   const celulas = input.combos.map((c) => {
     const cm = margemContribuicao({ receita_liquida: c.receita_liquida, custo_unitario: c.custo_unitario, quantidade: c.quantidade });
     const arCraw = arPorCliente.get(c.cliente) ?? null;
@@ -186,14 +187,16 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     const hurdle_break_even = evp_status === 'real' && capital_cs > 0 && cm != null && Number.isFinite(cm / capital_cs) ? cm / capital_cs : null;
     const sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even >= kLo - 1e-9 && hurdle_break_even <= kHi + 1e-9; // epsilon: borda inclusiva apesar do float (/codex)
     const folga_hurdle_pp = hurdle_break_even != null && k != null ? hurdle_break_even - k : null;
-    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp };
+    // Quase-frágil (espelho de src): break_even ∈ (kHi, kHi2] = (k+δ, k+2δ] — gera valor mas folga fina; SÓ lado bom, mut. exclusivo de sensivel_hurdle.
+    const quase_sensivel_hurdle = k != null && hurdle_break_even != null && hurdle_break_even > kHi + 1e-9 && hurdle_break_even <= kHi2 + 1e-9;
+    return { cliente: c.cliente, sku: c.sku, receita_liquida: c.receita_liquida, quantidade: c.quantidade, cm, a_cs, i_cs, encargo, evp_teto, evp, ar_indisponivel, estoque_indisponivel, capital_parcial, evp_status, capital_cs, hurdle_break_even, sensivel_hurdle, folga_hurdle_pp, quase_sensivel_hurdle };
   });
   type Cel = typeof celulas[number];
   const rollup = (keyFn: (c: Cel) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0 };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0 };
       acc.receita += cel.receita_liquida; acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true;
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; }
@@ -203,18 +206,19 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
       if (cel.evp_status === 'omitido_teto_positivo') acc.evpIncompleto = true;
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;
+      if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++; // espelho de src (quase-frágil, lado bom)
       m.set(key, acc);
     }
     return m;
   };
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
-  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis }));
+  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
+  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false, recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
-  let qtdSensiveisEmp = 0, capitalConhecido = 0;
+  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -225,9 +229,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     else if (cel.evp_status === 'teto_nao_positivo') { perda += cel.evp as number; perdaNull = false; recPerda += cel.receita_liquida; }
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
+    if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
   }
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null; // evp único só se nada omitido/indisponível (Codex)
-  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
+  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return { celulas, porCliente, porSKU, empresa, evp_conhecido_receita_pct: pct(recConhecido), evp_omitido_otimista_receita_pct: pct(recOmitido), evp_perda_garantida_receita_pct: pct(recPerda), sem_cm_receita_pct: pct(recSemCm), hurdle_banda: k != null ? { base: k, lo: kLo, hi: kHi } : null };
 }


### PR DESCRIPTION
## O quê

Follow-up money-path do #1044 (sensibilidade do EVP ao hurdle — Cockpit de Valor A3, Oben).

**Ângulo cego corrigido:** a UI só mostrava `qtd_combos_sensiveis` (combos "no fio" = break-even na banda [k−δ, k+δ]). Combos com break-even logo **fora** da banda (ex. 0,355 com k+δ=0,35) ficavam invisíveis → **falsa robustez**: o operador lia "0 frágeis" e confiava, mesmo havendo combos quase no fio.

**Solução:** agrega `qtd_combos_quase_sensiveis` = células `'real'` (capital completo) com break-even ∈ **(k+δ, k+2δ]** — geram valor HOJE mas com folga fina até o hurdle. Exposto por cliente/SKU/empresa; UI em tom brando (`muted`), ao lado do "no fio" (warning).

### Decisões de design (validadas com o founder)
- **Forma:** contagem em faixa separada (não folga-mínima escalar) — legível na tabela densa, análoga ao que já existe.
- **Escopo:** SÓ lado bom (break-even > k). O lado ruim (break-even < k) já aparece via `evp<0` (linhas ordenadas piores-primeiro) → contá-lo duplicaria sinal. `sensivel_hurdle` segue simétrico (semântica distinta: na banda estreita a recomendação flipa de qualquer lado).
- **Mutuamente exclusivo** de `sensivel_hurdle` (bordas com epsilon, sem overlap nem gap).

### Medição (psql-ro, Oben, k=0,30)
Reconstrução aproximada do pipeline. Ressalva honesta: `ar_medio` aproximado por saldo em aberto (vs. time-weighted TTM do edge) tende a **subestimar** capital → **subcontar** fragilidade, então os números são **piso**:
- 1.620 células reais · **34** no fio [0,25;0,35] · **~20** quase-frágeis lado bom (0,35;0,40] · 1.473 robustos.
- Ordem comparável aos "no fio" → ângulo cego material, não teatro.

### Rigor money-path
- **TDD com falsificação:** RED → GREEN → sabotagens **F1** (remover teto da faixa) e **F3** (inverter escopo lado-bom→lado-ruim), cada uma com vermelho exato e revertida.
- **Paridade helper↔edge:** lógica nova idêntica (pré-flight linha-a-linha); serialização via spread `...c`/`...s` + `res.empresa` no `jsonResponse` (campos aninhados, sem whitelist que os dropasse).
- **mutcheck:** 4 mutações novas → **23/23 pegas**, 0 sobreviventes.
- **Verde:** typecheck (strict) · 4100 testes · lint (0 errors) · mutcheck 100%.
- **/codex challenge (xhigh): sem P1.** 2×P2 endereçados:
  - *"qtd=0 com k=null fabrica zero"* → **rejeitado**: cardinalidade de conjunto vazio ≠ valor monetário; "ausente≠zero" rege R$/%/taxa, não contagem; consistente com `qtd_combos_sensiveis` (number); a UI gateia por `hurdle_banda` → nunca exibe o 0. Decisão cristalizada no teste.
  - *"paridade não byte-idêntica"* → débito **pré-existente** e amplo (os `export type` nunca foram espelhados; edge sempre condensado). Lógica nova tem paridade provada. Harness diferencial TS↔Deno é melhoria separada (cobre a função inteira), fora deste escopo.

## Deploy MANUAL no Lovable (founder)
- [ ] **Edge** `fin-valor-cockpit`: colar verbatim do repo no chat do Lovable (re-deploy).
- [ ] **Frontend**: Publish no editor do Lovable.
- [ ] **SEM migration** (nada toca o banco).

> Draft proposital (gate money-path). Promova para ready quando aprovar — aí o auto-merge cuida do squash no verde do CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
