### PR TITLE
fix(harness): #5 additionalContext pro agente + #4 rm-guard catastrófico-only

### DIFF
--- a/.claude/hooks/destructive-bash-guard.sh
+++ b/.claude/hooks/destructive-bash-guard.sh
@@ -56,34 +56,28 @@ B='(^|[^[:alnum:]_./-])'
 # opções globais do git (zero+) entre `git` e o subcomando: -C dir, -c x=y, --git-dir, --work-tree, etc.
 G='git([[:space:]]+(-C[[:space:]]+[^[:space:]]+|-c[[:space:]]+[^[:space:]]+|--git-dir[=[:space:]][^[:space:]]+|--work-tree[=[:space:]][^[:space:]]+|--no-pager|--paginate|-p))*[[:space:]]+'
 
-# rm -r -f cujos operandos NÃO estão todos sob /tmp → destrutivo. Recursão/force lidos só das FLAGS
-# (não dos operandos — senão um path tipo `dir-sem-force` dispararia falso-positivo).
+# rm recursivo+force com alvo CATASTRÓFICO literal (/ ~ $HOME . .. *) → destrutivo. Inverti a lógica
+# original ("tudo não-/tmp → deny"): aquilo barrava `rm -rf node_modules`/`dist`/`"$tmpvar"` — a
+# sanitização apaga o alvo entre aspas e o rm parecia "sem alvo" (falso-positivo visto ao vivo
+# 2026-06-24). Agora fail-open no alvo opaco/comum; só os clássicos "apaguei meu home/raiz/cwd"
+# travam. rm de repo/subpasta é recuperável (git) — fora do escopo de prevenção-de-acidente.
 rm_destructive() {
-  local seg tok safe=1 saw=0 rec=0 frc=0
+  local seg tok
   seg="$(printf '%s' "$scan" | grep -oE "${B}rm[[:space:]][^;&|]*" | head -1)"
   [ -n "$seg" ] || return 1
+  printf '%s' "$seg" | grep -qE '(-[a-zA-Z]*[rR]|--recursive)' || return 1   # tem recursão?
+  printf '%s' "$seg" | grep -qE '(-[a-zA-Z]*f|--force)'        || return 1   # tem force?
   set -f
   seg="${seg#*rm}"
   for tok in $seg; do
+    case "$tok" in -*) continue ;; esac
+    # shellcheck disable=SC2016,SC2088  # ~ e $HOME são literais (token cru do agente, não expandir)
     case "$tok" in
-      --recursive) rec=1 ;;
-      --force) frc=1 ;;
-      --*) ;;
-      -*) case "$tok" in *[rR]*) rec=1 ;; esac
-          case "$tok" in *f*) frc=1 ;; esac ;;
-      *) saw=1
-         # shellcheck disable=SC2016  # $TMPDIR/${TMPDIR} são literais (path não-expandido do agente)
-         case "$tok" in
-           /tmp/*|/private/tmp/*|/var/folders/*|/private/var/folders/*|"$TMPDIR"/*|'$TMPDIR'/*|'${TMPDIR}'/*) ;;
-           *) safe=0 ;;
-         esac ;;
+      "/"|"/*"|"~"|"~/"|"~/"*|'$HOME'|'$HOME/'*|'${HOME}'|'${HOME}/'*|"."|"./"|".."|"../"|"../"*|"*") set +f; return 0 ;;
     esac
   done
   set +f
-  { [ "$rec" = 1 ] && [ "$frc" = 1 ]; } || return 1   # não é rm recursivo+force
-  [ "$saw" = 0 ] && return 0                          # rm -rf sem alvo explícito → destrutivo
-  [ "$safe" = 0 ] && return 0
-  return 1                                            # todos os alvos sob /tmp → seguro
+  return 1
 }
 
 deny=""
@@ -93,7 +87,7 @@ elif det "${B}${G}push[^;&|]*(--force([^-]|\$)|[[:space:]]-[a-zA-Z]*f[a-zA-Z]*([
 elif det "${B}${G}branch[^;&|]*(-[a-zA-Z]*D([[:space:]]|\$)|--delete[^;&|]*--force|--force[^;&|]*--delete)"; then deny="git branch -D — delete forçado de branch (perde commits não-mergeados)"
 elif det "${B}${G}checkout[^;&|]*(-f([[:space:]]|\$)|--force)";                                  then deny="git checkout -f/--force — descarta mudanças locais"
 elif det "${B}${G}stash[[:space:]][^;&|]*(clear|drop)";                                          then deny="git stash clear/drop — perde o stash"
-elif rm_destructive;                                                                             then deny="rm -r -f fora de /tmp — apaga recursivamente sem recuperação"
+elif rm_destructive;                                                                             then deny="rm -r -f de alvo catastrófico (/ ~ \$HOME . .. *) — apaga sem recuperação"
 fi
 
 [ -n "$deny" ] || exit 0

--- a/.claude/hooks/stop-moneypath-nudge.sh
+++ b/.claude/hooks/stop-moneypath-nudge.sh
@@ -24,11 +24,16 @@ mp="$(printf '%s\n' "$changed" | grep -iE 'supabase/|src/.*(financ|fatur|dre|pri
 
 n="$(printf '%s\n' "$mp" | grep -c .)"
 list="$(printf '%s\n' "$mp" | head -8 | sed 's/^/• /')"
+files="$(printf '%s' "$mp" | head -8 | tr '\n' ',' | sed 's/,$//')"
 msg="🟡 Money-path tocado nesta sessão ($n arquivo(s) uncommitted). Antes de pedir review / tirar PR do draft:
 $list
 → typecheck/teste: heavy bun run typecheck · heavy bun run test
 → migration/RPC/trigger/policy nova? prove-sql-money-path (PG17 + falsificação)
 (lembrete não-bloqueante — docs/agent/money-path.md)"
+# additionalContext injeta o lembrete pro AGENTE agir no próximo turno (NÃO bloqueia o stop — confirmado
+# na doc Stop hook 2026-06-24: sem decision:block não há loop). systemMessage avisa o founder; os dois somam.
+ctx="Money-path foi tocado nesta sessão ($n arquivo(s) uncommitted: $files). Antes de declarar a tarefa pronta ou pedir review/PR: rode 'heavy bun run typecheck' e 'heavy bun run test'; se criou ou alterou migration, função/RPC, trigger ou RLS policy, PROVE com prove-sql-money-path (PG17 + falsificação) antes de entregar. Precisão > recall — ver docs/agent/money-path.md. Lembrete não-bloqueante."
 
-jq -n --arg m "$msg" '{systemMessage:$m}'
+jq -n --arg m "$msg" --arg c "$ctx" \
+  '{systemMessage:$m, hookSpecificOutput:{hookEventName:"Stop", additionalContext:$c}}'
 exit 0

--- a/scripts/test-destructive-bash-guard.sh
+++ b/scripts/test-destructive-bash-guard.sh
@@ -6,6 +6,7 @@
 # dry-run, ou menção/leitura pura → allow. Cobre as variações do Codex review 2026-06-24.
 #
 # Uso: bash scripts/test-destructive-bash-guard.sh   (exit 0 = verde)
+# shellcheck disable=SC2016  # os comandos testados são strings literais passadas ao hook; $VAR/til NÃO devem expandir
 set -u
 
 here="$(cd "$(dirname "$0")" && pwd)"
@@ -43,13 +44,15 @@ d 'git checkout --force main'
 d 'git stash drop'
 d 'git stash --quiet drop stash@{0}'
 d 'git stash clear'
-d 'rm -rf /Users/lucas/repo/src'
-d 'rm -r -f /Users/lucas/repo'
-d 'rm -Rf /Users/lucas/repo'
-d 'rm --recursive --force /Users/lucas/repo'
-d 'rm -rf /tmp/foo /Users/lucas/repo'
-d 'rm -rf /tmp/foo .'
+d 'rm -rf /'
+d 'rm -rf ~'
 d 'rm -rf ~/Documentos'
+d 'rm -rf $HOME'
+d 'rm -rf $HOME/Projetos'
+d 'rm -rf .'
+d 'rm -rf ../..'
+d 'rm -Rf *'
+d 'rm -rf /tmp/foo .'
 d 'echo iniciando && git reset --hard'
 d 'echo CONFIRM_DESTRUCTIVE=1 && git reset --hard'
 d 'cd /tmp && git clean -fdx'
@@ -70,6 +73,10 @@ a 'git stash'
 a 'git stash pop'
 a 'rm -rf /tmp/ecc-analysis'
 a 'rm -rf /tmp/foo /private/var/folders/x'
+a 'rm -rf node_modules'
+a 'rm -rf dist .next'
+a 'rm -rf "$TMPVAR"'
+a 'rm -rf /Users/lucas/Projetos/afiacao/dist'
 a 'rm arquivo.txt'
 a 'rm -r dir-sem-force'
 a 'mygit reset --hard'

--- a/scripts/test-stop-moneypath-nudge.sh
+++ b/scripts/test-stop-moneypath-nudge.sh
@@ -22,13 +22,15 @@ repo="$tmp/repo"; mkdir -p "$repo"
 run() { printf '{"hook_event_name":"Stop"}' | CLAUDE_PROJECT_DIR="$repo" bash "$HOOK" 2>/dev/null; }
 has_msg()   { grep -q 'systemMessage'; }
 is_block()  { grep -q '"decision"[[:space:]]*:[[:space:]]*"block"'; }
+has_ctx()   { grep -q 'additionalContext'; }
+has_stopevt(){ grep -q '"hookEventName"[[:space:]]*:[[:space:]]*"Stop"'; }
 
 fail=0
 mk() { mkdir -p "$repo/$(dirname "$1")"; echo "x" > "$repo/$1"; }
 clean() { ( cd "$repo" && git clean -fdq && git checkout -q -- . 2>/dev/null ); }
 
-want_msg()   { clean; mk "$1"; if run | has_msg; then echo "  ok    nudge | $1"; else echo "  FAIL  want nudge | $1"; fail=1; fi; }
-want_quiet() { clean; mk "$1"; if run | has_msg; then echo "  FAIL  want quiet | $1"; fail=1; else echo "  ok    quiet | $1"; fi; }
+want_msg()   { clean; mk "$1"; out="$(run)"; if printf '%s' "$out" | has_msg && printf '%s' "$out" | has_ctx && printf '%s' "$out" | has_stopevt && ! printf '%s' "$out" | is_block; then echo "  ok    nudge(msg+ctx) | $1"; else echo "  FAIL  want msg+ctx, no-block | $1"; fail=1; fi; }
+want_quiet() { clean; mk "$1"; out="$(run)"; if printf '%s' "$out" | has_msg || printf '%s' "$out" | has_ctx; then echo "  FAIL  want quiet | $1"; fail=1; else echo "  ok    quiet | $1"; fi; }
 
 echo "── money-path tocado → nudge ──"
 want_msg "supabase/migrations/20260101000000_x.sql"


### PR DESCRIPTION
Dois refinamentos pós-[#1039](https://github.com/LucasSardenbergL/afiacao/pull/1039) dos hooks do ECC, ambos achados **verificando ao vivo** (não em teoria).

## #5 — `additionalContext` pro agente
O nudge money-path do Stop hook emitia só `systemMessage` (o founder vê). Agora emite também `hookSpecificOutput.additionalContext` — confirmado na doc oficial que **não bloqueia o stop nem loopa** (passivo, injetado pro próximo turno). Resultado: o **agente** também é lembrado de rodar typecheck/teste/prove-sql antes de entregar, não só o founder.

## #4 — rm-guard catastrófico-only (corrige falso-positivo já em produção)
O `destructive-bash-guard` (já na main) barrava `rm -rf "$tmpvar"`, `rm -rf node_modules`, `rm -rf dist` — a regra "tudo fora de /tmp → deny" somada à sanitização de strings cegava o alvo. **Travou o próprio fluxo desta sessão ao vivo** (limpar um tempdir). Reescrito para alvo catastrófico literal (raiz, til, `$HOME`, ponto, parent, glob); fail-open no alvo opaco/comum. `rm` de repo segue recuperável via git, fora do escopo de prevenção-de-acidente.

## Prova
- `test-destructive-bash-guard.sh` + `test-stop-moneypath-nudge.sh` verdes; shellcheck limpo
- falsificações com dente: gate catastrófico (9 FAIL), `additionalContext` ausente (4 FAIL)
- `rm -rf "$T"` testado ao vivo pelo hook ativo → passa

🤖 Generated with [Claude Code](https://claude.com/claude-code)
