### PR TITLE
feat(crm): board da carteira /farmer/carteira — 3 colunas (risco/expansão/follow-up) [CRM passo 3]

### DIFF
--- a/docs/superpowers/plans/2026-06-24-crm-board-carteira.md
+++ b/docs/superpowers/plans/2026-06-24-crm-board-carteira.md
@@ -1,0 +1,296 @@
+# Board da Carteira (CRM passo 3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) ou superpowers:executing-plans, task-by-task. Steps usam checkbox (`- [ ]`).
+> **Deploy:** só **Publish** do frontend (sem banco). Verificar com `lovable-deploy-verify` (bytes do bundle). NÃO há migration nesta entrega.
+
+**Goal:** Uma tela `/farmer/carteira` com a fila de trabalho do vendedor em 3 colunas (risco / expansão / follow-up), cards acionáveis (ligar + abrir 360), reusando dados que já existem — sem tocar o banco.
+
+**Architecture:** Front puro. `useFarmerScoring()` dá `agenda` (agrupável por `agendaType`) + `clientScores` (nome/phone/health/churn); `useCarteiraSla()` (#1040) dá o badge de SLA. Um helper PURO `montarColunasBoard` cruza as 3 fontes por `customer_user_id` e devolve as colunas; componentes só renderizam. Decisão e justificativa em `docs/superpowers/specs/2026-06-24-crm-board-carteira-design.md` (§Virada).
+
+**Tech Stack:** React 18 + TS strict + react-router 6 (lazy) + @tanstack/react-query; vitest; tokens `text-status-*`; deploy Lovable (Publish).
+
+**Escopo:** board + helpers + card + página + rota + link de entrada. **Fora:** drag-drop, mobile dedicado, concluir-agenda, qualquer view/migration, refatorar FarmerDashboard.
+
+---
+
+## File Structure
+
+| Arquivo | Responsabilidade | Ação |
+|---|---|---|
+| `src/lib/carteira/board.ts` | Helpers PUROS: `AGENDA_TIPOS`, `healthBadge`, tipos VM, `montarColunasBoard` | Create |
+| `src/lib/carteira/board.test.ts` | vitest dos helpers (cruzamento, agrupamento, badge) | Create |
+| `src/components/farmer/CardCarteira.tsx` | Card de um cliente: nome, saúde, churn, badge SLA, ligar + 360 | Create |
+| `src/components/farmer/BoardCarteira.tsx` | 3 colunas + EmptyState por coluna | Create |
+| `src/pages/CarteiraBoard.tsx` | Página: chama hooks + `montarColunasBoard` + render | Create |
+| `src/App.tsx` | Registrar rota lazy `/farmer/carteira` (espelhar `/farmer/calls`) | Modify |
+| `src/pages/FarmerDashboard.tsx:~92` | 1 botão de entrada "Board da carteira" (após `<SlaVencidoCard>`) | Modify |
+
+---
+
+## Pré-requisitos
+- [ ] Branch `claude/crm-board-carteira` (já criado). `bun install` se `node_modules` ausente.
+- [ ] Conferir `origin/main` (domínio farmer quente — PRs #1037/#1043/#1046).
+
+---
+
+## Task 1: Helpers puros do board (`board.ts`) — TDD
+
+**Files:** Create `src/lib/carteira/board.ts`, `src/lib/carteira/board.test.ts`
+
+- [ ] **Step 1: Teste que falha** — `src/lib/carteira/board.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { healthBadge, montarColunasBoard } from './board';
+
+describe('carteira/board', () => {
+  it('healthBadge usa tokens de status', () => {
+    expect(healthBadge('critico').className).toContain('text-status-error');
+    expect(healthBadge('saudavel').label).toBe('Saudável');
+  });
+
+  it('monta 3 colunas na ordem risco/expansao/follow_up (vazias)', () => {
+    const cols = montarColunasBoard([], [], []);
+    expect(cols.map((c) => c.tipo)).toEqual(['risco', 'expansao', 'follow_up']);
+    expect(cols.every((c) => c.cards.length === 0)).toBe(true);
+  });
+
+  it('cruza agenda × scores × sla no card', () => {
+    const agenda = [
+      { customer_user_id: 'a', customer_name: 'Cliente A', priorityScore: 80, agendaType: 'risco' as const, healthClass: 'critico' },
+      { customer_user_id: 'b', customer_name: 'Cliente B', priorityScore: 50, agendaType: 'expansao' as const, healthClass: 'saudavel' },
+    ];
+    const scores = [
+      { customer_user_id: 'a', customer_name: 'Cliente A', customer_phone: '11999', healthClass: 'critico', churnRisk: 90, priorityScore: 80 },
+      { customer_user_id: 'b', customer_name: 'Cliente B', customer_phone: null, healthClass: 'saudavel', churnRisk: 5, priorityScore: 50 },
+    ] as never[];
+    const sla = [{ customer_user_id: 'a', vencido: true, dias_sem_contato: 30 }] as never[];
+    const cols = montarColunasBoard(agenda as never[], scores, sla);
+    const risco = cols.find((c) => c.tipo === 'risco')!;
+    expect(risco.cards).toHaveLength(1);
+    expect(risco.cards[0]).toMatchObject({ nome: 'Cliente A', phone: '11999', churnRisk: 90, slaVencido: true, diasSemContato: 30 });
+    const exp = cols.find((c) => c.tipo === 'expansao')!;
+    expect(exp.cards[0]).toMatchObject({ nome: 'Cliente B', slaVencido: false, diasSemContato: null });
+  });
+});
+```
+
+- [ ] **Step 2: Ver falhar** — `heavy bun run test src/lib/carteira/board.test.ts` → FAIL (módulo não existe).
+
+- [ ] **Step 3: Implementar** — `src/lib/carteira/board.ts`:
+```ts
+import type { AgendaItem, ClientScore } from '@/hooks/useFarmerScoring';
+import type { CarteiraSlaRow, HealthClass } from '@/hooks/useCarteiraSla';
+
+export type AgendaTipo = 'risco' | 'expansao' | 'follow_up';
+
+export const AGENDA_TIPOS: { tipo: AgendaTipo; label: string; tom: string }[] = [
+  { tipo: 'risco', label: 'Risco', tom: 'text-status-error' },
+  { tipo: 'expansao', label: 'Expansão', tom: 'text-status-success' },
+  { tipo: 'follow_up', label: 'Follow-up', tom: 'text-status-info' },
+];
+
+export function healthBadge(h: HealthClass): { label: string; className: string } {
+  const map: Record<HealthClass, { label: string; className: string }> = {
+    saudavel: { label: 'Saudável', className: 'text-status-success' },
+    estavel: { label: 'Estável', className: 'text-status-info' },
+    atencao: { label: 'Atenção', className: 'text-status-warning' },
+    critico: { label: 'Crítico', className: 'text-status-error' },
+  };
+  return map[h] ?? { label: String(h), className: 'text-muted-foreground' };
+}
+
+export interface CardCarteiraVM {
+  customer_user_id: string;
+  nome: string;
+  agendaType: AgendaTipo;
+  healthClass: HealthClass;
+  churnRisk: number | null;
+  phone: string | null;
+  slaVencido: boolean;
+  diasSemContato: number | null;
+  priorityScore: number;
+}
+
+export interface ColunaBoard {
+  tipo: AgendaTipo;
+  label: string;
+  tom: string;
+  cards: CardCarteiraVM[];
+}
+
+export function montarColunasBoard(
+  agenda: AgendaItem[],
+  clientScores: ClientScore[],
+  slaRows: CarteiraSlaRow[],
+): ColunaBoard[] {
+  const scoreById = new Map(clientScores.map((c) => [c.customer_user_id, c]));
+  const slaById = new Map(slaRows.map((r) => [r.customer_user_id, r]));
+
+  const cards: CardCarteiraVM[] = agenda.map((a) => {
+    const sc = scoreById.get(a.customer_user_id);
+    const sla = slaById.get(a.customer_user_id);
+    return {
+      customer_user_id: a.customer_user_id,
+      nome: a.customer_name,
+      agendaType: a.agendaType,
+      healthClass: sc?.healthClass ?? (a.healthClass as HealthClass),
+      churnRisk: sc?.churnRisk ?? null,
+      phone: sc?.customer_phone ?? null,
+      slaVencido: sla?.vencido ?? false,
+      diasSemContato: sla?.dias_sem_contato ?? null,
+      priorityScore: a.priorityScore,
+    };
+  });
+
+  return AGENDA_TIPOS.map(({ tipo, label, tom }) => ({
+    tipo, label, tom,
+    cards: cards.filter((c) => c.agendaType === tipo),
+  }));
+}
+```
+
+- [ ] **Step 4: Ver passar** — `heavy bun run test src/lib/carteira/board.test.ts` → PASS (3 testes).
+- [ ] **Step 5: Commit** — `git add src/lib/carteira/board.ts src/lib/carteira/board.test.ts && git commit -m "feat(crm): helpers puros do board da carteira (montarColunasBoard) + testes"`
+
+---
+
+## Task 2: Componentes `CardCarteira` + `BoardCarteira`
+
+**Files:** Create `src/components/farmer/CardCarteira.tsx`, `src/components/farmer/BoardCarteira.tsx`
+
+- [ ] **Step 1: `CardCarteira.tsx`**
+```tsx
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Eye } from 'lucide-react';
+import { CallButton } from '@/components/call/CallButton';
+import { healthBadge, type CardCarteiraVM } from '@/lib/carteira/board';
+
+export function CardCarteira({ card }: { card: CardCarteiraVM }) {
+  const navigate = useNavigate();
+  const hb = healthBadge(card.healthClass);
+  return (
+    <div className="rounded-md border p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium truncate">{card.nome}</span>
+        <span className={`text-xs ${hb.className}`}>{hb.label}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        {card.churnRisk != null && <span>Churn {Math.round(card.churnRisk)}%</span>}
+        {card.slaVencido && (
+          <Badge variant="outline" className="text-status-error border-status-error/30">
+            SLA vencido{card.diasSemContato != null ? ` (${card.diasSemContato}d)` : ''}
+          </Badge>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {card.phone && <CallButton phone={card.phone} customerName={card.nome} variant="icon" />}
+        <Button size="sm" variant="outline" onClick={() => navigate(`/admin/customers/${card.customer_user_id}/360`)}>
+          <Eye className="w-3.5 h-3.5 mr-1" /> 360
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: `BoardCarteira.tsx`**
+```tsx
+import { Users } from 'lucide-react';
+import { EmptyState } from '@/components/EmptyState';
+import { CardCarteira } from './CardCarteira';
+import type { ColunaBoard } from '@/lib/carteira/board';
+
+export function BoardCarteira({ colunas }: { colunas: ColunaBoard[] }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {colunas.map((col) => (
+        <section key={col.tipo} aria-label={col.label} className="space-y-2">
+          <header className="flex items-center justify-between">
+            <h2 className={`font-display text-base ${col.tom}`}>{col.label}</h2>
+            <span className="text-sm text-muted-foreground">{col.cards.length}</span>
+          </header>
+          {col.cards.length === 0 ? (
+            <EmptyState icon={Users} title="Nada aqui" description="Sem clientes nesta coluna." tone="operational" />
+          ) : (
+            <div className="space-y-2">
+              {col.cards.map((card) => <CardCarteira key={card.customer_user_id} card={card} />)}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}
+```
+> Confirmar a API real de `<EmptyState>` (props `icon/title/description/tone`) lendo `src/components/EmptyState.tsx` — ajustar se divergir. Confirmar que `CallButton` aceita `variant="icon"` (já verificado: `src/components/call/CallButton.tsx:3-10`).
+
+- [ ] **Step 3: Verificar** — `heavy bun run typecheck` → PASS.
+- [ ] **Step 4: Commit** — `git add src/components/farmer/CardCarteira.tsx src/components/farmer/BoardCarteira.tsx && git commit -m "feat(crm): CardCarteira + BoardCarteira (3 colunas, ligar + 360)"`
+
+---
+
+## Task 3: Página `CarteiraBoard` + rota + link de entrada
+
+**Files:** Create `src/pages/CarteiraBoard.tsx`; Modify `src/App.tsx`, `src/pages/FarmerDashboard.tsx`
+
+- [ ] **Step 1: `CarteiraBoard.tsx`**
+```tsx
+import { useMemo } from 'react';
+import { useFarmerScoring } from '@/hooks/useFarmerScoring';
+import { useCarteiraSla } from '@/hooks/useCarteiraSla';
+import { montarColunasBoard } from '@/lib/carteira/board';
+import { BoardCarteira } from '@/components/farmer/BoardCarteira';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function CarteiraBoard() {
+  const { agenda, clientScores, loading } = useFarmerScoring();
+  const { data: slaRows, isLoading: slaLoading } = useCarteiraSla();
+  const colunas = useMemo(
+    () => montarColunasBoard(agenda, clientScores, slaRows ?? []),
+    [agenda, clientScores, slaRows],
+  );
+  if (loading || slaLoading) return <PageSkeleton variant="cockpit" />;
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="px-4 py-4 space-y-4 max-w-6xl mx-auto">
+        <h1 className="font-display text-xl">Board da carteira</h1>
+        <BoardCarteira colunas={colunas} />
+      </main>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Rota em `src/App.tsx`** — adicionar o lazy import junto aos outros e a `<Route>` **espelhando exatamente** a linha de `/farmer/calls` (mesmo wrapper de auth/Suspense):
+```tsx
+const CarteiraBoard = lazy(() => import('./pages/CarteiraBoard'));
+// ...na lista de rotas, ao lado das /farmer/*:
+<Route path="/farmer/carteira" element={/* MESMO wrapper de /farmer/calls */ <CarteiraBoard />} />
+```
+> Ler a linha real de `path="/farmer/calls"` em `src/App.tsx` e replicar o wrapper idêntico (Suspense/guard). Não inventar um wrapper novo.
+
+- [ ] **Step 3: Link de entrada no `FarmerDashboard.tsx`** — adicionar, logo após o `<SlaVencidoCard .../>` (≈ linha 92), um botão discreto (NÃO mexer no grid de quick actions):
+```tsx
+<Button variant="outline" size="sm" className="w-full" onClick={() => navigate('/farmer/carteira')}>
+  Abrir board da carteira
+</Button>
+```
+
+- [ ] **Step 4: Verificar** — `heavy bun run typecheck && heavy bun run lint` → PASS. Smoke: abrir `/farmer/carteira` e ver 3 colunas com cards; abrir `/farmer` e ver o botão de entrada.
+- [ ] **Step 5: Commit** — `git add src/pages/CarteiraBoard.tsx src/App.tsx src/pages/FarmerDashboard.tsx && git commit -m "feat(crm): rota /farmer/carteira (board) + link de entrada no FarmerDashboard"`
+
+---
+
+## Deploy
+- [ ] **Publish** do frontend no editor do Lovable (sem migration nesta entrega). Verificar pelos bytes com `lovable-deploy-verify` (alvo: string única, ex.: `Board da carteira`).
+
+## Self-Review (autor)
+1. **Cobertura:** board 3 colunas ✓ (Task 2-3); cards com ligar+360 ✓ (Task 2); badge SLA ✓ (helper+card); link de entrada ✓ (Task 3). Concluir-agenda fora por design ✓.
+2. **Placeholders:** dois pontos marcados como "ler a linha real e espelhar" (rota `/farmer/calls`, API do `EmptyState`) — são referências a padrões existentes concretos, não lógica omitida.
+3. **Tipos:** `AgendaTipo` consistente em `AGENDA_TIPOS`, `CardCarteiraVM`, `montarColunasBoard` e nos componentes; `CardCarteiraVM` deriva de `AgendaItem`/`ClientScore`/`CarteiraSlaRow` reais (campos verificados nos hooks). `CallButton` props conferem.
+4. **Risco:** sem banco/RLS; o único toque em arquivo quente (FarmerDashboard) é 1 botão isolado, fora do grid.
+
+## Execution Handoff
+Após salvar: **subagent-driven** (1 subagente por task + review spec→qualidade) — recomendado; ou **inline**. As 3 tasks são pequenas e o trabalho é só front (typecheck/lint/vitest verificam localmente; nada depende do founder até o Publish).

--- a/docs/superpowers/specs/2026-06-24-crm-board-carteira-design.md
+++ b/docs/superpowers/specs/2026-06-24-crm-board-carteira-design.md
@@ -1,0 +1,66 @@
+# Board da Carteira (CRM — passo 3) — Design Spec
+
+**Status:** design ratificado em conversa (2026-06-24). Próximo passo: `superpowers:writing-plans`.
+**Antecede:** [#1040](timeline 360 `v_cliente_interacoes` + fila de SLA `v_carteira_sla`) e [#1045](tipagem). Esta é a 3ª e última peça da fatia de CRM da carteira.
+
+## Problema / dor
+O vendedor inside sales não tem uma **visão única acionável** da carteira. Hoje a priorização existe (`farmer_agenda` + `farmer_client_scores`) mas está espalhada em abas do `FarmerDashboard`. Falta a "fila de trabalho do dia" — ver, de uma vez, o que recuperar, o que expandir e o que dar follow-up, e agir sem trocar de tela.
+
+NÃO é pipeline de oportunidades (negócio é B2B recorrente, decidido no painel triagem-3-modelos). NÃO é gestão de time. É a tela operacional do vendedor sobre a própria carteira.
+
+## Decisões travadas
+1. **Agrupamento por tipo de ação** (`agenda_type`: `risco` | `expansao` | `follow_up`) — 3 colunas lado a lado. (Founder delegou; decidido com justificativa abaixo.)
+2. **Read-only + ações no card** (founder). Sem drag-drop, sem writer de estado **novo**. As ações reusam writers que já existem.
+3. **Read-model no banco** (`v_carteira_board`), coerente com a família `v_cliente_interacoes`/`v_carteira_sla`. Sem 2ª fonte de verdade.
+
+### Por que agrupar por ação (e não por saúde nem por SLA)
+- **Saúde** (`health_class`) é *urgência*, não *tarefa* — é atributo do card (badge + ordenação), não eixo de coluna.
+- **SLA** já tem o card dedicado (#1040) e vira **badge/filtro** dentro do board, não eixo concorrente.
+- **`agenda_type`** é o eixo de **ação** (recuperar / expandir / manter cadência) — muda o script da ligação. Reusa dado que já existe e o board fica *superior* às abas atuais ao mostrar os três **lado a lado** (balanço da carteira de relance), não escondidos em abas.
+
+## Arquitetura
+
+### Banco — nova view `v_carteira_board` (read-only)
+`create or replace view public.v_carteira_board with (security_invoker = true)` consolidando:
+- **Driver:** `farmer_agenda` com `status` ativo (exclui `completed`/cancelado) → `agenda_id`, `agenda_type`, `priority_score`, `farmer_id`, `customer_user_id`.
+- **JOIN `farmer_client_scores`** (por `customer_user_id` + `farmer_id`) → `health_class`, `churn_risk`.
+- **JOIN `profiles`** (por `customer_user_id`) → `customer_name`.
+- **Colunas expostas:** `agenda_id, customer_user_id, customer_name, agenda_type, priority_score, health_class, churn_risk, farmer_id`.
+
+**Gate de autorização (crítico — RLS de `farmer_agenda` é staff-ampla):** a policy real de `farmer_agenda` é `"Staff can manage agenda"` (`employee`/`master`, **sem escopo de carteira**). Logo, igual a `order_messages` em #1040, **o gate da view é a cerca real**. Espelhar o modelo de 3 ramos:
+```
+pode_ver_carteira_completa(auth.uid())
+  OR fa.farmer_id = auth.uid()
+  OR carteira_visivel_para(fa.customer_user_id, auth.uid())
+```
+`grant select on public.v_carteira_board to authenticated;`
+
+**SLA fora da view (DRY):** `dias_sem_contato`/`vencido` **não** são recalculados aqui — o front cruza com a `v_carteira_sla` (já existe) por `customer_user_id` para o badge. Evita duplicar a lógica de "contato efetivo" que já vive em `v_carteira_sla`.
+
+### Front (rota própria, desktop)
+- **Rota** `/farmer/carteira` (`RequireStaff`, lazy) — link a partir do `FarmerDashboard`.
+- **`useCarteiraBoard`** (`src/hooks/useCarteiraBoard.ts`): react-query lendo `v_carteira_board` (tipada — as views entram em `types.ts` na regeneração; usar o tipo gerado, sem `as never`, já que estamos pós-#1045).
+- **`BoardCarteira`** (`src/components/farmer/BoardCarteira.tsx`): 3 colunas por `agenda_type`, cada uma ordenada por `priority_score desc`, cabeçalho com contagem. Filtro opcional via `useUrlState` ("só SLA vencido").
+- **`CardCarteira`** (`src/components/farmer/CardCarteira.tsx`): `customer_name`; badge de saúde (`text-status-*`, sem cor crua); `churn_risk` %; badge **"SLA vencido"** + dias sem contato (cruzando `useCarteiraSla`). Ações:
+  - **Ligar** — reusa o `CallButton`/fluxo de telefonia existente.
+  - **Abrir Customer360** — `navigate('/admin/customers/:id/360')` (rota existe).
+  - **Concluir agenda** — `UPDATE farmer_agenda SET status='completed', completed_at=now() WHERE id`. **Reusar** o fluxo de conclusão de agenda do `FarmerDashboard` se já existir; senão, hook mínimo `useConcluirAgenda`. (É writer **existente** no domínio, não novo conceito.)
+- **Reuso:** `CallButton`, `EmptyState`, `PageSkeleton`, `useUrlState`, tokens `text-status-*`.
+
+## Escopo
+**Inclui (v1):** view `v_carteira_board` + prova PG17; rota/hook/board/card; badge de SLA; ações ligar/360/concluir.
+**Fora (YAGNI):** drag-drop / reclassificação; mobile (v1 é desktop, tela analítica); gestão de time/multi-vendedor; qualquer estágio de "pipeline".
+
+## Provas / verificação
+- **`v_carteira_board`** via `prove-sql-money-path` (PG17): (1) vendedor V1 vê só agenda da carteira/própria; (2) V2 não vê a de V1 (isolamento); (3) gestor vê tudo; (4) **falsificação**: remover o gate → vazamento entre vendedores fica VERMELHO. Estender `db/test-crm-carteira.sh`.
+- **Front:** `typecheck` + `lint` + smoke manual em `/farmer/carteira`.
+- **Deploy (Lovable):** migration no SQL Editor (handoff `lovable-db-operator`) + validação `psql-ro` (view existe, `security_invoker=true`, grant) + **Publish** + verificação por bytes (`lovable-deploy-verify`).
+
+## Riscos / pontos de atenção
+- **Domínio farmer quente** (PRs #1037/#1043/#1046 mexeram em RLS/plano tático de farmer): conferir `origin/main` antes de implementar; o gate usa `carteira_visivel_para`/`pode_ver_carteira_completa` (estáveis), mas reconfirmar que não mudaram.
+- **`farmer_agenda` é gerada por scoring (TOP N por tipo)** — o board mostra a *fila priorizada*, não a carteira inteira. Confirmar que é o comportamento desejado (é: fila de trabalho, não lista exaustiva).
+- **Concluir agenda** é o único toque de escrita — garantir que reusa o fluxo/permissão existente, sem inventar writer.
+
+## Open questions (ratificar no review do spec)
+1. "Concluir agenda" deve **gerar a próxima** (recadastrar na agenda) ou só marcar concluída? (v1 sugerido: só marcar; o scoring regenera no próximo ciclo.)
+2. Filtro/ordenação default da coluna: `priority_score` desc (sugerido) — confirmar se prefere SLA vencido no topo.

--- a/docs/superpowers/specs/2026-06-24-crm-board-carteira-design.md
+++ b/docs/superpowers/specs/2026-06-24-crm-board-carteira-design.md
@@ -1,66 +1,49 @@
 # Board da Carteira (CRM — passo 3) — Design Spec
 
-**Status:** design ratificado em conversa (2026-06-24). Próximo passo: `superpowers:writing-plans`.
-**Antecede:** [#1040](timeline 360 `v_cliente_interacoes` + fila de SLA `v_carteira_sla`) e [#1045](tipagem). Esta é a 3ª e última peça da fatia de CRM da carteira.
+**Status:** design ratificado (2026-06-24); **revisado** após achado de implementação (ver §Virada). Próximo: `superpowers:writing-plans`.
+**Antecede:** [#1040](timeline 360 `v_cliente_interacoes` + fila de SLA `v_carteira_sla`) e [#1045](tipagem). 3ª e última peça da fatia de CRM da carteira.
 
 ## Problema / dor
-O vendedor inside sales não tem uma **visão única acionável** da carteira. Hoje a priorização existe (`farmer_agenda` + `farmer_client_scores`) mas está espalhada em abas do `FarmerDashboard`. Falta a "fila de trabalho do dia" — ver, de uma vez, o que recuperar, o que expandir e o que dar follow-up, e agir sem trocar de tela.
+O vendedor inside sales não tem uma **visão única acionável** da carteira. A priorização existe (`useFarmerScoring` → agenda + scores) mas vive numa **aba** do `FarmerDashboard` (tela mobile compacta). Falta a "fila de trabalho do dia" lado a lado — recuperar / expandir / follow-up — com ação direta no card.
 
-NÃO é pipeline de oportunidades (negócio é B2B recorrente, decidido no painel triagem-3-modelos). NÃO é gestão de time. É a tela operacional do vendedor sobre a própria carteira.
+NÃO é pipeline de oportunidades (B2B recorrente; decidido no painel triagem-3-modelos). NÃO é gestão de time.
 
 ## Decisões travadas
-1. **Agrupamento por tipo de ação** (`agenda_type`: `risco` | `expansao` | `follow_up`) — 3 colunas lado a lado. (Founder delegou; decidido com justificativa abaixo.)
-2. **Read-only + ações no card** (founder). Sem drag-drop, sem writer de estado **novo**. As ações reusam writers que já existem.
-3. **Read-model no banco** (`v_carteira_board`), coerente com a família `v_cliente_interacoes`/`v_carteira_sla`. Sem 2ª fonte de verdade.
+1. **Agrupamento por tipo de ação** (`agendaType`: `risco` | `expansao` | `follow_up`) — 3 colunas lado a lado. Saúde e SLA são *sinais no card* (badge), não eixos.
+2. **Read-only + ações no card** (founder): **Ligar** (CallButton, que já registra a ligação) + **Abrir Customer360**. Sem drag-drop, sem writer novo.
+3. **Front puro — sem banco** (ver Virada).
 
-### Por que agrupar por ação (e não por saúde nem por SLA)
-- **Saúde** (`health_class`) é *urgência*, não *tarefa* — é atributo do card (badge + ordenação), não eixo de coluna.
-- **SLA** já tem o card dedicado (#1040) e vira **badge/filtro** dentro do board, não eixo concorrente.
-- **`agenda_type`** é o eixo de **ação** (recuperar / expandir / manter cadência) — muda o script da ligação. Reusa dado que já existe e o board fica *superior* às abas atuais ao mostrar os três **lado a lado** (balanço da carteira de relance), não escondidos em abas.
+## Virada de design (achado de implementação — 2026-06-24)
+O spec inicial assumia uma view `v_carteira_board` sobre a tabela `farmer_agenda`. **Leitura do código mostrou que a agenda viva é recalculada no client** por `useFarmerScoring` (`src/hooks/useFarmerScoring.ts:393-446`); o hook é **display-only** e **não lê nem escreve `farmer_agenda`** (comentário `:448-454`). Basear o board em `farmer_agenda` seria frágil (pode não estar populada no fluxo atual).
 
-## Arquitetura
+**Decisão:** o board é **100% front**, reusando o que já existe e é a fonte viva:
+- `useFarmerScoring()` → `agenda` (já agrupável por `agendaType`) + `clientScores` (nome, `customer_phone`, `healthClass`, `churnRisk`, `priorityScore`).
+- `useCarteiraSla()` (#1040) → badge de SLA por `customer_user_id`.
 
-### Banco — nova view `v_carteira_board` (read-only)
-`create or replace view public.v_carteira_board with (security_invoker = true)` consolidando:
-- **Driver:** `farmer_agenda` com `status` ativo (exclui `completed`/cancelado) → `agenda_id`, `agenda_type`, `priority_score`, `farmer_id`, `customer_user_id`.
-- **JOIN `farmer_client_scores`** (por `customer_user_id` + `farmer_id`) → `health_class`, `churn_risk`.
-- **JOIN `profiles`** (por `customer_user_id`) → `customer_name`.
-- **Colunas expostas:** `agenda_id, customer_user_id, customer_name, agenda_type, priority_score, health_class, churn_risk, farmer_id`.
+**Ganho:** zero migration, zero deploy de banco, zero risco de RLS — só `Publish`. Mesmo resultado visual, muito menos superfície. A ação "concluir agenda" (que não faz sentido com agenda recalculada) é substituída por **Ligar** (o registro da ligação naturalmente tira o cliente do "vencido" no próximo recálculo).
 
-**Gate de autorização (crítico — RLS de `farmer_agenda` é staff-ampla):** a policy real de `farmer_agenda` é `"Staff can manage agenda"` (`employee`/`master`, **sem escopo de carteira**). Logo, igual a `order_messages` em #1040, **o gate da view é a cerca real**. Espelhar o modelo de 3 ramos:
-```
-pode_ver_carteira_completa(auth.uid())
-  OR fa.farmer_id = auth.uid()
-  OR carteira_visivel_para(fa.customer_user_id, auth.uid())
-```
-`grant select on public.v_carteira_board to authenticated;`
-
-**SLA fora da view (DRY):** `dias_sem_contato`/`vencido` **não** são recalculados aqui — o front cruza com a `v_carteira_sla` (já existe) por `customer_user_id` para o badge. Evita duplicar a lógica de "contato efetivo" que já vive em `v_carteira_sla`.
-
-### Front (rota própria, desktop)
-- **Rota** `/farmer/carteira` (`RequireStaff`, lazy) — link a partir do `FarmerDashboard`.
-- **`useCarteiraBoard`** (`src/hooks/useCarteiraBoard.ts`): react-query lendo `v_carteira_board` (tipada — as views entram em `types.ts` na regeneração; usar o tipo gerado, sem `as never`, já que estamos pós-#1045).
-- **`BoardCarteira`** (`src/components/farmer/BoardCarteira.tsx`): 3 colunas por `agenda_type`, cada uma ordenada por `priority_score desc`, cabeçalho com contagem. Filtro opcional via `useUrlState` ("só SLA vencido").
-- **`CardCarteira`** (`src/components/farmer/CardCarteira.tsx`): `customer_name`; badge de saúde (`text-status-*`, sem cor crua); `churn_risk` %; badge **"SLA vencido"** + dias sem contato (cruzando `useCarteiraSla`). Ações:
-  - **Ligar** — reusa o `CallButton`/fluxo de telefonia existente.
-  - **Abrir Customer360** — `navigate('/admin/customers/:id/360')` (rota existe).
-  - **Concluir agenda** — `UPDATE farmer_agenda SET status='completed', completed_at=now() WHERE id`. **Reusar** o fluxo de conclusão de agenda do `FarmerDashboard` se já existir; senão, hook mínimo `useConcluirAgenda`. (É writer **existente** no domínio, não novo conceito.)
-- **Reuso:** `CallButton`, `EmptyState`, `PageSkeleton`, `useUrlState`, tokens `text-status-*`.
+## Arquitetura (front)
+- **Página/rota** `/farmer/carteira` (lazy, mesmo wrapper de auth das rotas `/farmer/*` vizinhas, ex.: `/farmer/calls`). Tela **desktop/analítica** (3 colunas), distinta do FarmerDashboard mobile.
+- **`src/lib/carteira/board.ts`** (helpers PUROS, testáveis): `AGENDA_TIPOS` (ordem + label + tom) e `healthBadge(healthClass)` → `{label, className}` com tokens `text-status-*`. + `montarColunasBoard(agenda, clientScores, slaRows)` → 3 colunas com os cards já cruzados.
+- **`src/components/farmer/CardCarteira.tsx`**: nome, badge de saúde, `churnRisk` %, badge **"SLA vencido (N d)"** quando aplicável; ações `CallButton` (phone do clientScore, `variant="icon"`) + botão "Abrir 360" (`navigate('/admin/customers/:id/360')`).
+- **`src/components/farmer/BoardCarteira.tsx`**: 3 colunas (`risco`/`expansao`/`follow_up`), cabeçalho com contagem, `<EmptyState>` por coluna vazia; filtro opcional "só SLA vencido" via `useUrlState`.
+- **`src/pages/CarteiraBoard.tsx`**: chama os 2 hooks, `montarColunasBoard`, `<PageSkeleton variant="cockpit">` no loading.
+- **Reuso:** `CallButton` (`{phone, customerName, variant}`), `useFarmerScoring`, `useCarteiraSla`, `EmptyState`, `PageSkeleton`, `useUrlState`, tokens `text-status-*`, `HealthClass` (de `useCarteiraSla.ts`).
 
 ## Escopo
-**Inclui (v1):** view `v_carteira_board` + prova PG17; rota/hook/board/card; badge de SLA; ações ligar/360/concluir.
-**Fora (YAGNI):** drag-drop / reclassificação; mobile (v1 é desktop, tela analítica); gestão de time/multi-vendedor; qualquer estágio de "pipeline".
+**Inclui (v1):** página/rota; helpers puros + testes; board 3 colunas; card com badge de SLA; ações ligar + 360; link de entrada a partir do FarmerDashboard.
+**Fora (YAGNI):** drag-drop/reclassificação; mobile dedicado (v1 desktop); "concluir agenda"; qualquer view/migration; refatorar o FarmerDashboard (os helpers `healthColors`/`agendaTypeConfig` ficam duplicados por ora — follow-up para unificar, evita tocar arquivo quente agora).
 
 ## Provas / verificação
-- **`v_carteira_board`** via `prove-sql-money-path` (PG17): (1) vendedor V1 vê só agenda da carteira/própria; (2) V2 não vê a de V1 (isolamento); (3) gestor vê tudo; (4) **falsificação**: remover o gate → vazamento entre vendedores fica VERMELHO. Estender `db/test-crm-carteira.sh`.
-- **Front:** `typecheck` + `lint` + smoke manual em `/farmer/carteira`.
-- **Deploy (Lovable):** migration no SQL Editor (handoff `lovable-db-operator`) + validação `psql-ro` (view existe, `security_invoker=true`, grant) + **Publish** + verificação por bytes (`lovable-deploy-verify`).
+- **vitest** nos helpers puros: `healthBadge`, `montarColunasBoard` (cruzamento agenda×scores×SLA, agrupamento nas 3 colunas, badge de vencido correto, coluna vazia).
+- **`typecheck` + `lint`** verdes; **smoke manual** em `/farmer/carteira`.
+- **Deploy:** só **Publish** do frontend (sem banco). Verificar com `lovable-deploy-verify` (bytes do bundle).
 
-## Riscos / pontos de atenção
-- **Domínio farmer quente** (PRs #1037/#1043/#1046 mexeram em RLS/plano tático de farmer): conferir `origin/main` antes de implementar; o gate usa `carteira_visivel_para`/`pode_ver_carteira_completa` (estáveis), mas reconfirmar que não mudaram.
-- **`farmer_agenda` é gerada por scoring (TOP N por tipo)** — o board mostra a *fila priorizada*, não a carteira inteira. Confirmar que é o comportamento desejado (é: fila de trabalho, não lista exaustiva).
-- **Concluir agenda** é o único toque de escrita — garantir que reusa o fluxo/permissão existente, sem inventar writer.
+## Riscos / atenção
+- `useFarmerScoring` é **client-side pesado** (carrega sales_orders/scores e recalcula) — é o **status quo** do FarmerDashboard; o board não piora. Melhoria futura: migrar para react-query/cache compartilhado.
+- **Divergência mínima** possível: `useFarmerScoring` recalcula health no client; `useCarteiraSla` lê `farmer_client_scores` do cron. Mesmos dados de origem; divergência desprezível para a v1 (badge de SLA vem do SLA; saúde vem do scoring).
+- **Domínio farmer quente** (PRs #1037/#1043/#1046): conferir `origin/main` antes de implementar.
 
-## Open questions (ratificar no review do spec)
-1. "Concluir agenda" deve **gerar a próxima** (recadastrar na agenda) ou só marcar concluída? (v1 sugerido: só marcar; o scoring regenera no próximo ciclo.)
-2. Filtro/ordenação default da coluna: `priority_score` desc (sugerido) — confirmar se prefere SLA vencido no topo.
+## Open questions (defaults ratificados)
+1. Ação do card: **Ligar + Abrir 360** (default). "Concluir agenda" descartado pela virada.
+2. Ordenação da coluna: ordem da `agenda` (já priorizada) — default; opção de pôr SLA vencido no topo dentro da coluna.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,7 @@ const MeuDia = lazy(() => import("./pages/MeuDia"));
 const Tarefas = lazy(() => import("./pages/Tarefas"));
 const TarefasTemplates = lazy(() => import("./pages/TarefasTemplates"));
 const FarmerCalls = lazy(() => import("./pages/FarmerCalls"));
+const CarteiraBoard = lazy(() => import("./pages/CarteiraBoard"));
 const FarmerCallsPendingLink = lazy(() => import("./pages/FarmerCallsPendingLink"));
 const FarmerGovernance = lazy(() => import("./pages/FarmerGovernance"));
 const FarmerRecommendations = lazy(() => import("./pages/FarmerRecommendations"));
@@ -302,6 +303,7 @@ const App = () => {
                 <Route path="farmer" element={<FarmerDashboard />} />
                 <Route path="meu-dia" element={<MeuDia />} />
                 <Route path="farmer/calls" element={<FarmerCalls />} />
+                <Route path="farmer/carteira" element={<CarteiraBoard />} />
                 <Route path="farmer/calls/pending-link" element={<FarmerCallsPendingLink />} />
                 <Route path="farmer/governance" element={<FarmerGovernance />} />
                 <Route path="farmer/recommendations" element={<FarmerRecommendations />} />

--- a/src/components/farmer/BoardCarteira.tsx
+++ b/src/components/farmer/BoardCarteira.tsx
@@ -1,0 +1,33 @@
+import { Users } from 'lucide-react';
+import { EmptyState } from '@/components/EmptyState';
+import { CardCarteira } from './CardCarteira';
+import type { ColunaBoard } from '@/lib/carteira/board';
+
+export function BoardCarteira({ colunas }: { colunas: ColunaBoard[] }) {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      {colunas.map((col) => (
+        <section key={col.tipo} aria-label={col.label} className="space-y-2">
+          <header className="flex items-center justify-between">
+            <h2 className={`font-display text-base ${col.tom}`}>{col.label}</h2>
+            <span className="text-sm text-muted-foreground">{col.cards.length}</span>
+          </header>
+          {col.cards.length === 0 ? (
+            <EmptyState
+              icon={Users}
+              title="Nada aqui"
+              description="Sem clientes nesta coluna."
+              tone="operational"
+            />
+          ) : (
+            <div className="space-y-2">
+              {col.cards.map((card) => (
+                <CardCarteira key={card.customer_user_id} card={card} />
+              ))}
+            </div>
+          )}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/components/farmer/CardCarteira.tsx
+++ b/src/components/farmer/CardCarteira.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Eye } from 'lucide-react';
+import { CallButton } from '@/components/call/CallButton';
+import { healthBadge, type CardCarteiraVM } from '@/lib/carteira/board';
+
+export function CardCarteira({ card }: { card: CardCarteiraVM }) {
+  const navigate = useNavigate();
+  const hb = healthBadge(card.healthClass);
+  return (
+    <div className="rounded-md border p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium truncate">{card.nome}</span>
+        <span className={`text-xs ${hb.className}`}>{hb.label}</span>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        {card.churnRisk != null && <span>Churn {Math.round(card.churnRisk)}%</span>}
+        {card.slaVencido && (
+          <Badge variant="outline" className="text-status-error border-status-error/30">
+            SLA vencido{card.diasSemContato != null ? ` (${card.diasSemContato}d)` : ''}
+          </Badge>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {card.phone && <CallButton phone={card.phone} customerName={card.nome} variant="icon" />}
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => navigate(`/admin/customers/${card.customer_user_id}/360`)}
+        >
+          <Eye className="w-3.5 h-3.5 mr-1" /> 360
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/carteira/board.test.ts
+++ b/src/lib/carteira/board.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { healthBadge, montarColunasBoard } from './board';
+
+describe('carteira/board', () => {
+  it('healthBadge usa tokens de status', () => {
+    expect(healthBadge('critico').className).toContain('text-status-error');
+    expect(healthBadge('saudavel').label).toBe('Saudável');
+  });
+
+  it('monta 3 colunas na ordem risco/expansao/follow_up (vazias)', () => {
+    const cols = montarColunasBoard([], [], []);
+    expect(cols.map((c) => c.tipo)).toEqual(['risco', 'expansao', 'follow_up']);
+    expect(cols.every((c) => c.cards.length === 0)).toBe(true);
+  });
+
+  it('cruza agenda × scores × sla no card', () => {
+    const agenda = [
+      { customer_user_id: 'a', customer_name: 'Cliente A', priorityScore: 80, agendaType: 'risco' as const, healthClass: 'critico' },
+      { customer_user_id: 'b', customer_name: 'Cliente B', priorityScore: 50, agendaType: 'expansao' as const, healthClass: 'saudavel' },
+    ];
+    const scores = [
+      { customer_user_id: 'a', customer_name: 'Cliente A', customer_phone: '11999', healthClass: 'critico', churnRisk: 90, priorityScore: 80 },
+      { customer_user_id: 'b', customer_name: 'Cliente B', customer_phone: null, healthClass: 'saudavel', churnRisk: 5, priorityScore: 50 },
+    ] as never[];
+    const sla = [{ customer_user_id: 'a', vencido: true, dias_sem_contato: 30 }] as never[];
+    const cols = montarColunasBoard(agenda as never[], scores, sla);
+    const risco = cols.find((c) => c.tipo === 'risco')!;
+    expect(risco.cards).toHaveLength(1);
+    expect(risco.cards[0]).toMatchObject({ nome: 'Cliente A', phone: '11999', churnRisk: 90, slaVencido: true, diasSemContato: 30 });
+    const exp = cols.find((c) => c.tipo === 'expansao')!;
+    expect(exp.cards[0]).toMatchObject({ nome: 'Cliente B', slaVencido: false, diasSemContato: null });
+  });
+});

--- a/src/lib/carteira/board.ts
+++ b/src/lib/carteira/board.ts
@@ -1,0 +1,76 @@
+import type { AgendaItem, ClientScore } from '@/hooks/useFarmerScoring';
+import type { CarteiraSlaRow, HealthClass } from '@/hooks/useCarteiraSla';
+
+export type AgendaTipo = 'risco' | 'expansao' | 'follow_up';
+
+export const AGENDA_TIPOS: { tipo: AgendaTipo; label: string; tom: string }[] = [
+  { tipo: 'risco', label: 'Risco', tom: 'text-status-error' },
+  { tipo: 'expansao', label: 'Expansão', tom: 'text-status-success' },
+  { tipo: 'follow_up', label: 'Follow-up', tom: 'text-status-info' },
+];
+
+export function healthBadge(h: HealthClass): { label: string; className: string } {
+  const map: Record<HealthClass, { label: string; className: string }> = {
+    saudavel: { label: 'Saudável', className: 'text-status-success' },
+    estavel: { label: 'Estável', className: 'text-status-info' },
+    atencao: { label: 'Atenção', className: 'text-status-warning' },
+    critico: { label: 'Crítico', className: 'text-status-error' },
+  };
+  return map[h] ?? { label: String(h), className: 'text-muted-foreground' };
+}
+
+export interface CardCarteiraVM {
+  customer_user_id: string;
+  nome: string;
+  agendaType: AgendaTipo;
+  healthClass: HealthClass;
+  churnRisk: number | null;
+  phone: string | null;
+  slaVencido: boolean;
+  diasSemContato: number | null;
+  priorityScore: number;
+}
+
+export interface ColunaBoard {
+  tipo: AgendaTipo;
+  label: string;
+  tom: string;
+  cards: CardCarteiraVM[];
+}
+
+/**
+ * Cruza a agenda (useFarmerScoring) com os scores (nome/phone/churn) e a fila de
+ * SLA (useCarteiraSla) por customer_user_id, e agrupa nas 3 colunas por agendaType.
+ * Helper PURO — sem efeitos, testável isolado.
+ */
+export function montarColunasBoard(
+  agenda: AgendaItem[],
+  clientScores: ClientScore[],
+  slaRows: CarteiraSlaRow[],
+): ColunaBoard[] {
+  const scoreById = new Map(clientScores.map((c) => [c.customer_user_id, c]));
+  const slaById = new Map(slaRows.map((r) => [r.customer_user_id, r]));
+
+  const cards: CardCarteiraVM[] = agenda.map((a) => {
+    const sc = scoreById.get(a.customer_user_id);
+    const sla = slaById.get(a.customer_user_id);
+    return {
+      customer_user_id: a.customer_user_id,
+      nome: a.customer_name,
+      agendaType: a.agendaType,
+      healthClass: sc?.healthClass ?? (a.healthClass as HealthClass),
+      churnRisk: sc?.churnRisk ?? null,
+      phone: sc?.customer_phone ?? null,
+      slaVencido: sla?.vencido ?? false,
+      diasSemContato: sla?.dias_sem_contato ?? null,
+      priorityScore: a.priorityScore,
+    };
+  });
+
+  return AGENDA_TIPOS.map(({ tipo, label, tom }) => ({
+    tipo,
+    label,
+    tom,
+    cards: cards.filter((c) => c.agendaType === tipo),
+  }));
+}

--- a/src/pages/CarteiraBoard.tsx
+++ b/src/pages/CarteiraBoard.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from 'react';
+import { useFarmerScoring } from '@/hooks/useFarmerScoring';
+import { useCarteiraSla } from '@/hooks/useCarteiraSla';
+import { montarColunasBoard } from '@/lib/carteira/board';
+import { BoardCarteira } from '@/components/farmer/BoardCarteira';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function CarteiraBoard() {
+  const { agenda, clientScores, loading } = useFarmerScoring();
+  const { data: slaRows, isLoading: slaLoading } = useCarteiraSla();
+  const colunas = useMemo(
+    () => montarColunasBoard(agenda, clientScores, slaRows ?? []),
+    [agenda, clientScores, slaRows],
+  );
+  if (loading || slaLoading) return <PageSkeleton variant="cockpit" />;
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="px-4 py-4 space-y-4 max-w-6xl mx-auto">
+        <h1 className="font-display text-xl">Board da carteira</h1>
+        <BoardCarteira colunas={colunas} />
+      </main>
+    </div>
+  );
+}

--- a/src/pages/FarmerDashboard.tsx
+++ b/src/pages/FarmerDashboard.tsx
@@ -91,6 +91,16 @@ const FarmerDashboard = () => {
           onClienteClick={(id) => navigate(`/admin/customers/${id}/360`)}
         />
 
+        {/* Entrada para o board da carteira (visão 3 colunas: risco/expansão/follow-up) */}
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
+          onClick={() => navigate('/farmer/carteira')}
+        >
+          Abrir board da carteira
+        </Button>
+
         {/* Health Summary */}
         <Card>
           <CardContent className="p-3">


### PR DESCRIPTION
## O que é
Board operacional da carteira do vendedor inside sales em `/farmer/carteira`: 3 colunas por tipo de ação (**Risco / Expansão / Follow-up**), cards com nome, saúde, churn % e **badge de SLA vencido**, e ações diretas: **Ligar** (CallButton, que já registra a ligação) + **Abrir Customer360**. Fecha a fatia de CRM da carteira (passo 3), após #1040 (timeline 360 + fila de SLA) e #1045 (tipagem).

## Como (front puro — sem banco)
Reusa o que já existe e é a fonte viva: `useFarmerScoring()` (agenda + scores) + `useCarteiraSla()` (badge de SLA). Um helper **puro** `montarColunasBoard` cruza as fontes por `customer_user_id` e agrupa nas 3 colunas; os componentes só renderizam.

**Virada de design (documentada no spec):** o desenho inicial previa uma view `v_carteira_board` sobre `farmer_agenda`. A leitura do código mostrou que a agenda viva é **recalculada no client** por `useFarmerScoring` (a tabela `farmer_agenda` não é a fonte do front). Logo: **zero migration, zero deploy de banco, zero RLS nova** — só `Publish`.

## Verificação
- `vitest` helpers puros: **3/3** (cruzamento, agrupamento nas 3 colunas, badge de vencido).
- `typecheck` ✅ · `lint` ✅.

## Deploy
- **Só Publish** do frontend (sem migration). Smoke: abrir `/farmer/carteira` (3 colunas) e o botão "Abrir board da carteira" no FarmerDashboard.

## Docs
Spec: `docs/superpowers/specs/2026-06-24-crm-board-carteira-design.md` · Plano: `docs/superpowers/plans/2026-06-24-crm-board-carteira.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)