### PR TITLE
feat(valor-cockpit): min_folga_positiva_pp — sinal contínuo do hurdle (complementa #1049) [money-path]

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -34,3 +34,7 @@ PEGA | quase: teto da faixa removido (robusto-bom vira quase) | s/hurdle_break_e
 PEGA | quase: lado bom vira lado ruim (> kHi -> < kLo)        | s/hurdle_break_even > kHi \+ 1e-9 && hurdle_break_even <= kHi2/hurdle_break_even < kLo - 1e-9 && hurdle_break_even <= kHi2/
 PEGA | quase: rollup não agrega (contador morto)             | s/if \(cel\.quase_sensivel_hurdle\) acc\.qtdQuaseSensiveis\+\+/if (false) acc.qtdQuaseSensiveis++/
 PEGA | quase: empresa não agrega (contador morto)            | s/if \(cel\.quase_sensivel_hurdle\) qtdQuaseSensiveisEmp\+\+/if (false) qtdQuaseSensiveisEmp++/
+# Menor folga POSITIVA fora do fio (min_folga, sobre o #1049): SÓ lado + (folga>δ); signed-min pegaria o mais
+# NEGATIVO (falsa robustez — achado do Codex). Mut. nas 2 vias (empresa E rollup, ancoradas por indentação — perl -pe é linha-a-linha).
+PEGA | min_folga: sem filtro folga>0 na empresa (pegaria o neg) | s/^    if \(cel\.evp_status === 'real' && !cel\.sensivel_hurdle && cel\.folga_hurdle_pp != null && cel\.folga_hurdle_pp > 0/    if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null/
+PEGA | min_folga: sem filtro folga>0 no rollup (pegaria o neg)  | s/^      if \(cel\.evp_status === 'real' && !cel\.sensivel_hurdle && cel\.folga_hurdle_pp != null && cel\.folga_hurdle_pp > 0/      if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null/

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -1006,3 +1006,65 @@ describe('montarCelulasComboEVP — quase-sensibilidade ao hurdle (folga fina, l
     expect(r.empresa.qtd_combos_sensiveis).toBe(1);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2026-06-24 — Follow-up (sobre o #1049): min_folga_positiva_pp — a MENOR folga POSITIVA fora do fio
+// (folga>δ), o sinal CONTÍNUO que complementa a contagem de quase-frágeis: "o próximo combo lucrativo
+// zera com +X pp de Ke". Sinal +, NÃO signed-min — que pegaria o mais NEGATIVO (falsa robustez — Codex).
+// ═══════════════════════════════════════════════════════════════════════════
+describe('montarCelulasComboEVP — min_folga_positiva_pp (sinal contínuo do hurdle)', () => {
+  // k=0,30; fio [0,25;0,35]. be 0,38→folga +0,08; be 0,50→folga +0,20; be 0,10→folga −0,20.
+  it('a MENOR folga positiva fora do fio (rollup + empresa)', () => {
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }, // cm 380 → be 0,38 folga +0,08
+        { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 100, custo_unitario: 5 },   // cm 500 → be 0,50 folga +0,20
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 1200 }], // rc=2000 → a_cs cada 600; +estoque 400 → capital 1000 cada
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }, { sku: 'S2', estoque_valor: 400 }],
+      k: 0.30,
+    });
+    expect(r.empresa.min_folga_positiva_pp).toBeCloseTo(0.08, 6);
+    expect(r.porCliente[0].min_folga_positiva_pp).toBeCloseTo(0.08, 6);
+  });
+  it('[P1 Codex] IGNORA o lado negativo — empresa E rollup (não pega o mais negativo)', () => {
+    // S1 folga +0,08; S2 folga −0,20. min = +0,08, NUNCA −0,20. C1 agrega ambos.
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }, // be 0,38
+        { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 100, custo_unitario: 9 },   // be 0,10 (folga −0,20)
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 1200 }],
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }, { sku: 'S2', estoque_valor: 400 }],
+      k: 0.30,
+    });
+    expect(r.celulas.find((c) => c.sku === 'S2')!.folga_hurdle_pp).toBeLessThan(0);
+    expect(r.empresa.min_folga_positiva_pp).toBeCloseTo(0.08, 6);       // empresa
+    expect(r.porCliente[0].min_folga_positiva_pp).toBeCloseTo(0.08, 6); // rollup (C1 agrega S1+S2; sem o filtro pegaria −0,20)
+  });
+  it('nenhum combo positivo fora do fio → null (NÃO 0)', () => {
+    // único combo sensível (be 0,2857 ∈ fio) → sem candidato positivo fora do fio
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.celulas[0].sensivel_hurdle).toBe(true);
+    expect(r.empresa.min_folga_positiva_pp).toBeNull();
+    expect(r.porCliente[0].min_folga_positiva_pp).toBeNull();
+  });
+  it('robusto sozinho (be 0,50) → min_folga_positiva = 0,20 (o positivo fora do fio mais próximo)', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 5 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.empresa.min_folga_positiva_pp).toBeCloseTo(0.20, 6);
+  });
+  it('k=null → min_folga_positiva_pp null (rollup + empresa)', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: null,
+    });
+    expect(r.empresa.min_folga_positiva_pp).toBeNull();
+    expect(r.porCliente[0].min_folga_positiva_pp).toBeNull();
+  });
+});

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -169,8 +169,8 @@ export type CelulaEVP = {
 // (upper bound do grupo, preserva #961); `evp_incompleto` = ∃ célula omitida por otimismo (o `evp` do grupo
 // exclui essa fatia → pode ser maior). `encargo` (só células com cm) / `encargo_total` (todas) mantidos.
 // perda_garantida = ∃ célula 'teto_nao_positivo' no grupo (o evp inclui um teto≤0 → o prejuízo REAL pode ser maior).
-export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number };
-export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number };
+export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; min_folga_positiva_pp: number | null };
+export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; min_folga_positiva_pp: number | null };
 // Empresa DECOMPOSTA (Codex: somar {reais + tetos≤0} excluindo os teto>0 não é teto nem piso → mentira contábil).
 // evp_conhecido = só capital completo; evp_teto_total = upper bound legado; evp_perda_garantida = piso da fatia
 // parcial-negativa; evp = null se há QUALQUER fatia não-afirmável (não finge um total).
@@ -180,6 +180,7 @@ export type EmpresaEVP = {
   evp: number | null; evp_incompleto: boolean; cm_incompleto: boolean;
   qtd_combos_sensiveis: number;       // combos REAIS no fio da navalha (a granularidade que o agregado robusto esconde)
   qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break_even ∈ (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
+  min_folga_positiva_pp: number | null; // menor folga POSITIVA fora do fio (folga>δ): "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum (sinal contínuo, complementa a contagem — Codex)
   capital_conhecido: number | null;   // Σ capital_cs das células 'real' → UI deriva evp_conhecido(k') = evp_conhecido + (k − k')·capital_conhecido
 };
 export type ComboEVPResult = {
@@ -278,10 +279,10 @@ export function montarCelulasComboEVP(input: {
   });
 
   const rollup = (keyFn: (c: CelulaEVP) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; minFolgaPositiva: number | null }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0 };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, minFolgaPositiva: null };
       acc.receita += cel.receita_liquida;
       acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true; // grupo tem célula sem margem (excluída do EVP)
@@ -296,6 +297,9 @@ export function montarCelulasComboEVP(input: {
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;                     // evp inclui um teto≤0 → real pode ser pior
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;                                                // combo real no fio da navalha
       if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++;                                      // combo real quase-frágil (folga fina, lado bom)
+      // menor folga POSITIVA fora do fio (real && !sensivel && folga>0 ⟺ folga>δ): "o próximo a virar a +X pp" (Codex: só lado +, não signed-min)
+      if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
+          && (acc.minFolgaPositiva == null || cel.folga_hurdle_pp < acc.minFolgaPositiva)) acc.minFolgaPositiva = cel.folga_hurdle_pp;
       m.set(key, acc);
     }
     return m;
@@ -303,15 +307,15 @@ export function montarCelulasComboEVP(input: {
 
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
-  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
+  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
+  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
 
   // Empresa decomposta + pcts por receita total elegível.
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false;
   let recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
-  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0;
+  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0, minFolgaPositivaEmp: number | null = null;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -323,6 +327,8 @@ export function montarCelulasComboEVP(input: {
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
     if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
+    if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
+        && (minFolgaPositivaEmp == null || cel.folga_hurdle_pp < minFolgaPositivaEmp)) minFolgaPositivaEmp = cel.folga_hurdle_pp;
   }
   // empresa.evp só é um total honesto se NADA foi omitido/indisponível; senão null (Codex: não fingir total).
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null;
@@ -333,7 +339,7 @@ export function montarCelulasComboEVP(input: {
     evp_perda_garantida: perdaNull ? null : perda,
     evp: empresaCompleta && !conhecidoNull ? conhecido : null,
     evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp,
-    qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
+    qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, min_folga_positiva_pp: minFolgaPositivaEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
   };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return {

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -122,6 +122,9 @@ export default function FinanceiroValorCockpit() {
           {data.empresa.qtd_combos_quase_sensiveis > 0 && (
             <> · <span className="text-muted-foreground">{data.empresa.qtd_combos_quase_sensiveis} quase-frágil(eis) (folga fina, +5 a +10pp do hurdle)</span></>
           )}
+          {data.empresa.min_folga_positiva_pp != null && (
+            <> · <span className="text-status-warning">próximo combo lucrativo zera com +{(data.empresa.min_folga_positiva_pp * 100).toFixed(1)}pp de Ke</span></>
+          )}
         </p>
       )}
 

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1005,6 +1005,7 @@ export interface CockpitRollupCliente {
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
+  min_folga_positiva_pp: number | null;  // menor folga POSITIVA fora do fio: "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum
   nome?: string | null;  // nome do cliente (profiles via customer_user_id) — UI mostra no lugar do código
 }
 export interface CockpitRollupSKU {
@@ -1021,6 +1022,7 @@ export interface CockpitRollupSKU {
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
+  min_folga_positiva_pp: number | null;  // menor folga POSITIVA fora do fio: "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum
   descricao?: string | null;  // descrição do produto (omie_products) — UI mostra no lugar do código SKU
 }
 // Empresa DECOMPOSTA (capital parcial → um único evp seria mentira contábil; Codex 2026-06-23).
@@ -1038,6 +1040,7 @@ export interface CockpitEmpresaEVP {
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;     // combos REAIS no fio da navalha (granularidade que o agregado robusto esconde)
   qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break-even em (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
+  min_folga_positiva_pp: number | null; // menor folga POSITIVA fora do fio: "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum (sinal contínuo, complementa a contagem)
   capital_conhecido: number | null; // Σ capital das células reais → deriva EVP a outros hurdles
 }
 export interface ValorCockpitResult {

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -193,10 +193,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
   });
   type Cel = typeof celulas[number];
   const rollup = (keyFn: (c: Cel) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; minFolgaPositiva: number | null }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0 };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, minFolgaPositiva: null };
       acc.receita += cel.receita_liquida; acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true;
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; }
@@ -207,18 +207,20 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;
       if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++; // espelho de src (quase-frágil, lado bom)
+      if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
+          && (acc.minFolgaPositiva == null || cel.folga_hurdle_pp < acc.minFolgaPositiva)) acc.minFolgaPositiva = cel.folga_hurdle_pp;
       m.set(key, acc);
     }
     return m;
   };
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
-  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
+  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
+  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false, recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
-  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0;
+  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0, minFolgaPositivaEmp: number | null = null;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -230,9 +232,11 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
     if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
+    if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
+        && (minFolgaPositivaEmp == null || cel.folga_hurdle_pp < minFolgaPositivaEmp)) minFolgaPositivaEmp = cel.folga_hurdle_pp;
   }
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null; // evp único só se nada omitido/indisponível (Codex)
-  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
+  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, min_folga_positiva_pp: minFolgaPositivaEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return { celulas, porCliente, porSKU, empresa, evp_conhecido_receita_pct: pct(recConhecido), evp_omitido_otimista_receita_pct: pct(recOmitido), evp_perda_garantida_receita_pct: pct(recPerda), sem_cm_receita_pct: pct(recSemCm), hurdle_banda: k != null ? { base: k, lo: kLo, hi: kHi } : null };
 }


### PR DESCRIPTION
## Contexto
Complementa o #1049 (já na `main`), que entregou a **contagem** de quase-frágeis (`qtd_combos_quase_sensiveis`, faixa (k+δ, k+2δ]). Adiciona o sinal que faltava: o **`min_folga_positiva_pp`**.

> Nota: houve colisão de 2 sessões paralelas no mesmo follow-up — o #1049 venceu na contagem; este PR entrega o **diferencial** sobre ele (é o que sobrou útil do #1056, fechado).

## O que adiciona
**`min_folga_positiva_pp`** (por rollup/empresa) — a MENOR folga **POSITIVA** fora do fio (folga > δ): *"o próximo combo lucrativo zera com +X pp de Ke"*.

Foi a recomendação do **Codex no consult**: o sinal **contínuo** é mais honesto que a contagem (não depende do limiar 2δ arbitrário), mostra a margem exata do combo mais próximo, e pega combos logo fora da faixa de contagem. Sinal **+**, NÃO signed-min — que pegaria o mais **negativo** (falsa robustez; o Codex marcou como `[P1]` potencial no consult). `null` quando vazio (ausente≠zero).

UI: uma linha no resumo da empresa, ao lado da contagem do #1049.

## Money-path
- Espelhado **VERBATIM** no edge — paridade da lógica 100% (diff das 4 linhas de acumulação vazio).
- **TDD com falsificação** — 5 testes novos (incl. o caso do `min` ignorar o lado negativo em **empresa E rollup**: C1 com S1 +0,08 e S2 −0,20 → min = +0,08).
- **mutcheck** — 2 mutações novas (folga>0 na empresa E no rollup, ancoradas por indentação; ambas matam).
- Reusa o `quase_sensivel_hurdle`/`kHi2` do #1049 (zero duplicação).
- A lógica do `min_folga` é **byte-idêntica** à já validada no Codex challenge do #1056 (lá: *"min_folga_positiva_pp: correto no código; null vazio; k=null/capital_cs=0/cm null não fabricam número"*).

## Verificação
helper 130 testes · suite completa · typecheck 0 · deno check 0 · lint 0 · mutcheck (com as 2 novas) · paridade helper↔edge 100%.

## Deploy (manual, pós-merge — sem migration)
- **Edge** `fin-valor-cockpit` verbatim (chat do Lovable) — o campo viaja via spread (`...c`/`...s`) e `empresa: res.empresa` inteiro.
- **Publish** do frontend (a UI ganhou 1 linha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)