### PR TITLE
feat(valor-cockpit): folga contínua ao hurdle dos quase-frágeis (folga_hurdle_min_pp) — enxerto sobre #1049 [money-path]

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -34,3 +34,8 @@ PEGA | quase: teto da faixa removido (robusto-bom vira quase) | s/hurdle_break_e
 PEGA | quase: lado bom vira lado ruim (> kHi -> < kLo)        | s/hurdle_break_even > kHi \+ 1e-9 && hurdle_break_even <= kHi2/hurdle_break_even < kLo - 1e-9 && hurdle_break_even <= kHi2/
 PEGA | quase: rollup não agrega (contador morto)             | s/if \(cel\.quase_sensivel_hurdle\) acc\.qtdQuaseSensiveis\+\+/if (false) acc.qtdQuaseSensiveis++/
 PEGA | quase: empresa não agrega (contador morto)            | s/if \(cel\.quase_sensivel_hurdle\) qtdQuaseSensiveisEmp\+\+/if (false) qtdQuaseSensiveisEmp++/
+# folga_hurdle_min_pp (enxerto sobre #1049 2026-06-25): menor folga POSITIVA (locator do combo mais próximo do
+# hurdle por cima). Trava as 3 decisões Codex: (1) POSITIVA não |abs|; (2) MIN não max; (3) receita do MESMO combo.
+PEGA | folga_min: gate positivo invertido (entra folga negativa) | s/folga_hurdle_pp <= 1e-9/folga_hurdle_pp >= 1e-9/
+PEGA | folga_min: min vira max (combo mais distante, não o + próximo) | s/cel\.folga_hurdle_pp < acc\.pp/cel.folga_hurdle_pp > acc.pp/
+PEGA | folga_min: para de rastrear a receita do combo vencedor    | s/acc\.pp = cel\.folga_hurdle_pp; acc\.receita = cel\.receita_liquida;/acc.pp = cel.folga_hurdle_pp;/

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -1006,3 +1006,94 @@ describe('montarCelulasComboEVP — quase-sensibilidade ao hurdle (folga fina, l
     expect(r.empresa.qtd_combos_sensiveis).toBe(1);
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2026-06-25 — Enxerto sobre #1049: o #1049 CONTA os quase-frágeis na banda (k+δ, k+2δ];
+// isto acrescenta QUAL é o mais próximo do hurdle por cima e QUÃO perto (contínuo) + sua
+// receita (materialidade). Decisão Claude+Codex: menor folga POSITIVA (break_even − k > 0)
+// entre células 'real' — NÃO min|folga| (a negativa já é evp<0; o |abs| esconderia o blind
+// spot positivo). Locator, não severidade → carrega a receita do combo vencedor.
+// ═══════════════════════════════════════════════════════════════════════════
+describe('montarCelulasComboEVP — folga_hurdle_min_pp (menor folga POSITIVA; locator)', () => {
+  it('combo positivo FORA da banda (blind spot) → folga_min_pp = a folga, + receita do combo', () => {
+    // cm=380 (1000−6,2·100); cap=1000 (ar600+est400) → break_even 0,38; folga +0,08 (8pp, fora de [0,25;0,35])
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.celulas[0].sensivel_hurdle).toBe(false);              // NÃO acende na banda
+    expect(r.porCliente[0].qtd_combos_sensiveis).toBe(0);          // contagem da banda é cega
+    expect(r.porCliente[0].folga_hurdle_min_pp).toBeCloseTo(0.08, 6); // mas a folga REVELA
+    expect(r.porCliente[0].folga_hurdle_min_receita).toBeCloseTo(1000, 6);
+    expect(r.porSKU[0].folga_hurdle_min_pp).toBeCloseTo(0.08, 6);
+    expect(r.empresa.folga_hurdle_min_pp).toBeCloseTo(0.08, 6);
+    expect(r.empresa.folga_hurdle_min_receita).toBeCloseTo(1000, 6);
+  });
+  it('contínuo: combo DENTRO da banda (folga +2pp) é o mais próximo → folga_min = +0,02', () => {
+    // cm=320 → break_even 0,32; folga +0,02 (dentro da banda)
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.8 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.celulas[0].sensivel_hurdle).toBe(true);
+    expect(r.empresa.folga_hurdle_min_pp).toBeCloseTo(0.02, 6);
+  });
+  it('dois combos → folga_min = o mais próximo (menor folga positiva), não o mais distante', () => {
+    // S1 break_even 0,32 (folga +0,02) ; S2 break_even 0,38 (folga +0,08). min = +0,02.
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.8 },
+        { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 },
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 2000 }], // rc=2000 → a_cs 1000 cada
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 0 }, { sku: 'S2', estoque_valor: 0 }], k: 0.30,
+    });
+    expect(r.porCliente[0].folga_hurdle_min_pp).toBeCloseTo(0.02, 6);
+  });
+  it('FALSIFICAÇÃO min|abs|: folga negativa MENOR em módulo NÃO captura o blind spot positivo', () => {
+    // S1 break_even 0,27 → folga −0,03 (|0,03|, JÁ abaixo do hurdle: evp<0); S2 break_even 0,38 → folga +0,08.
+    // min|abs| devolveria −0,03 (ERRADO); a métrica certa devolve +0,08 (o combo frágil-mas-positivo).
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7.3 },
+        { cliente: 'C1', sku: 'S2', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 },
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 2000 }],
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 0 }, { sku: 'S2', estoque_valor: 0 }], k: 0.30,
+    });
+    expect(r.porCliente[0].folga_hurdle_min_pp).toBeCloseTo(0.08, 6); // +0,08, NÃO −0,03
+  });
+  it('só células com folga NEGATIVA (break_even<k, já-abaixo) → folga_min null (não é blind spot)', () => {
+    // cm=200 → break_even 0,20; folga −0,10. EVP já negativo → sinalizado por evp<0/perda; folga_min ignora.
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 8.0 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.porCliente[0].folga_hurdle_min_pp).toBeNull();
+    expect(r.porCliente[0].folga_hurdle_min_receita).toBeNull();
+    expect(r.empresa.folga_hurdle_min_pp).toBeNull();
+  });
+  it('k=null → folga_min null em rollup e empresa (ausente ≠ 0)', () => {
+    const r = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: null,
+    });
+    expect(r.porCliente[0].folga_hurdle_min_pp).toBeNull();
+    expect(r.empresa.folga_hurdle_min_pp).toBeNull();
+    expect(r.empresa.folga_hurdle_min_receita).toBeNull();
+  });
+  it('combo ÍNFIMO domina o min (locator, não severidade) → carrega receita p/ a UI contextualizar', () => {
+    // CA: receita 48, cm 30, cap 99 → break_even 0,3030, folga +0,0030 (o mais próximo, porém R$48).
+    // CB: receita 10000, break_even 0,36, folga +0,06. empresa.folga_min = +0,0030, receita = 48 (não 10000).
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'CA', sku: 'SA', receita_liquida: 48, quantidade: 1, custo_unitario: 18 },
+        { cliente: 'CB', sku: 'SB', receita_liquida: 10000, quantidade: 100, custo_unitario: 96.4 },
+      ],
+      capitalClientes: [{ cliente: 'CA', ar_medio: 99 }, { cliente: 'CB', ar_medio: 600 }],
+      capitalSKUs: [{ sku: 'SA', estoque_valor: 0 }, { sku: 'SB', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(r.empresa.folga_hurdle_min_pp).toBeCloseTo(30 / 99 - 0.30, 6); // ≈ +0,00303
+    expect(r.empresa.folga_hurdle_min_receita).toBeCloseTo(48, 6);        // contexto: é ínfimo
+  });
+});

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -169,8 +169,10 @@ export type CelulaEVP = {
 // (upper bound do grupo, preserva #961); `evp_incompleto` = ∃ célula omitida por otimismo (o `evp` do grupo
 // exclui essa fatia → pode ser maior). `encargo` (só células com cm) / `encargo_total` (todas) mantidos.
 // perda_garantida = ∃ célula 'teto_nao_positivo' no grupo (o evp inclui um teto≤0 → o prejuízo REAL pode ser maior).
-export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number };
-export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number };
+// folga_hurdle_min_pp/_receita (enxerto sobre #1049): COMPLEMENTA qtd_combos_quase_sensiveis (que CONTA os
+// quase-frágeis na banda) com QUAL é o mais próximo do hurdle por cima e QUÃO perto (folga contínua) + sua receita.
+export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; folga_hurdle_min_pp: number | null; folga_hurdle_min_receita: number | null };
+export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; folga_hurdle_min_pp: number | null; folga_hurdle_min_receita: number | null };
 // Empresa DECOMPOSTA (Codex: somar {reais + tetos≤0} excluindo os teto>0 não é teto nem piso → mentira contábil).
 // evp_conhecido = só capital completo; evp_teto_total = upper bound legado; evp_perda_garantida = piso da fatia
 // parcial-negativa; evp = null se há QUALQUER fatia não-afirmável (não finge um total).
@@ -181,6 +183,8 @@ export type EmpresaEVP = {
   qtd_combos_sensiveis: number;       // combos REAIS no fio da navalha (a granularidade que o agregado robusto esconde)
   qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break_even ∈ (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
   capital_conhecido: number | null;   // Σ capital_cs das células 'real' → UI deriva evp_conhecido(k') = evp_conhecido + (k − k')·capital_conhecido
+  folga_hurdle_min_pp: number | null;      // menor folga POSITIVA (break_even − k > 0) entre células 'real' — o combo mais próximo do hurdle por cima (complementa a contagem do #1049)
+  folga_hurdle_min_receita: number | null; // receita_liquida do combo dono do folga_min (contexto: locator, não severidade — ínfimo não vira alarme)
 };
 export type ComboEVPResult = {
   celulas: CelulaEVP[];
@@ -196,6 +200,16 @@ export type ComboEVPResult = {
   // banda do hurdle p/ a sensibilidade (k ± δ; null se k indisponível). A UI rotula 25/30/35% (30 = principal).
   hurdle_banda: { base: number; lo: number; hi: number } | null;
 };
+
+// Acumula a MENOR folga POSITIVA ao hurdle (break_even − k > 0) entre células 'real'. NÃO usa min|folga|:
+// folga negativa já está abaixo do hurdle (evp<0/perda_garantida já sinalizam), e o |abs| devolveria a negativa,
+// escondendo o blind spot positivo — o combo que "parece seguro, está frágil" (decisão Codex xhigh 2026-06-24).
+// Locator, não severidade → guarda a receita do combo vencedor (combo ínfimo pode dominar o min; a UI usa pra
+// contextualizar). Epsilon 1e-9: exclui o break-even==k (folga 0, já dentro da banda/sensível) e o lixo de float.
+function acumularFolgaMinPositiva(acc: { pp: number | null; receita: number | null }, cel: CelulaEVP): void {
+  if (cel.evp_status !== 'real' || cel.folga_hurdle_pp == null || cel.folga_hurdle_pp <= 1e-9) return;
+  if (acc.pp == null || cel.folga_hurdle_pp < acc.pp) { acc.pp = cel.folga_hurdle_pp; acc.receita = cel.receita_liquida; }
+}
 
 export function montarCelulasComboEVP(input: {
   combos: ComboInput[];
@@ -278,10 +292,10 @@ export function montarCelulasComboEVP(input: {
   });
 
   const rollup = (keyFn: (c: CelulaEVP) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; folgaMin: { pp: number | null; receita: number | null } }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0 };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, folgaMin: { pp: null, receita: null } };
       acc.receita += cel.receita_liquida;
       acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true; // grupo tem célula sem margem (excluída do EVP)
@@ -296,6 +310,7 @@ export function montarCelulasComboEVP(input: {
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;                     // evp inclui um teto≤0 → real pode ser pior
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;                                                // combo real no fio da navalha
       if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++;                                      // combo real quase-frágil (folga fina, lado bom)
+      acumularFolgaMinPositiva(acc.folgaMin, cel);                                                 // o combo real mais próximo do hurdle por cima
       m.set(key, acc);
     }
     return m;
@@ -303,8 +318,8 @@ export function montarCelulasComboEVP(input: {
 
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
-  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
+  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, folga_hurdle_min_pp: a.folgaMin.pp, folga_hurdle_min_receita: a.folgaMin.receita }));
+  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, folga_hurdle_min_pp: a.folgaMin.pp, folga_hurdle_min_receita: a.folgaMin.receita }));
 
   // Empresa decomposta + pcts por receita total elegível.
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
@@ -312,6 +327,7 @@ export function montarCelulasComboEVP(input: {
   let evpIncompletoEmp = false, cmIncompletoEmp = false;
   let recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
   let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0;
+  const folgaMinEmp: { pp: number | null; receita: number | null } = { pp: null, receita: null };
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -323,6 +339,7 @@ export function montarCelulasComboEVP(input: {
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
     if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
+    acumularFolgaMinPositiva(folgaMinEmp, cel);
   }
   // empresa.evp só é um total honesto se NADA foi omitido/indisponível; senão null (Codex: não fingir total).
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null;
@@ -334,6 +351,7 @@ export function montarCelulasComboEVP(input: {
     evp: empresaCompleta && !conhecidoNull ? conhecido : null,
     evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp,
     qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
+    folga_hurdle_min_pp: folgaMinEmp.pp, folga_hurdle_min_receita: folgaMinEmp.receita,
   };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return {

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -122,6 +122,13 @@ export default function FinanceiroValorCockpit() {
           {data.empresa.qtd_combos_quase_sensiveis > 0 && (
             <> · <span className="text-muted-foreground">{data.empresa.qtd_combos_quase_sensiveis} quase-frágil(eis) (folga fina, +5 a +10pp do hurdle)</span></>
           )}
+          {/* Enxerto: além da CONTAGEM acima, QUAL é o combo mais próximo do hurdle por cima e QUÃO perto (contínuo).
+              Locator → só mostra se o combo vencedor é MATERIAL (≥ sample_min_receita); senão um ínfimo (R$48 a ~0pp)
+              viraria alarme falso (Codex). O sinal por-grupo, contextualizado, vive na coluna da tabela. */}
+          {data.empresa.folga_hurdle_min_pp != null && data.empresa.folga_hurdle_min_receita != null
+            && data.empresa.folga_hurdle_min_receita >= data.config.sample_min_receita && (
+            <> · <span className="text-muted-foreground">mais próximo do hurdle: <span className="font-tabular text-foreground">+{(data.empresa.folga_hurdle_min_pp * 100).toFixed(1)}pp</span> ({brl(data.empresa.folga_hurdle_min_receita)}, capital completo)</span></>
+          )}
         </p>
       )}
 
@@ -203,6 +210,9 @@ export default function FinanceiroValorCockpit() {
                       {row.qtd_combos_quase_sensiveis > 0 && (
                         <div className="text-[10px] leading-tight text-muted-foreground">
                           {row.qtd_combos_quase_sensiveis} quase-frágil(eis)
+                          {/* enxerto: o mais próximo do hurdle (folga contínua) + receita, só se material */}
+                          {row.folga_hurdle_min_pp != null && row.folga_hurdle_min_receita != null && row.folga_hurdle_min_receita >= data.config.sample_min_receita
+                            && <> · mais próx. +{(row.folga_hurdle_min_pp * 100).toFixed(1)}pp ({brl(row.folga_hurdle_min_receita)})</>}
                         </div>
                       )}
                     </td>

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1005,6 +1005,8 @@ export interface CockpitRollupCliente {
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
+  folga_hurdle_min_pp: number | null;      // combo mais próximo do hurdle por cima (folga contínua) — complementa a contagem do #1049
+  folga_hurdle_min_receita: number | null; // receita do combo dono do folga_min (locator, não severidade)
   nome?: string | null;  // nome do cliente (profiles via customer_user_id) — UI mostra no lugar do código
 }
 export interface CockpitRollupSKU {
@@ -1021,6 +1023,8 @@ export interface CockpitRollupSKU {
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
+  folga_hurdle_min_pp: number | null;      // combo mais próximo do hurdle por cima (folga contínua) — complementa a contagem do #1049
+  folga_hurdle_min_receita: number | null; // receita do combo dono do folga_min (locator, não severidade)
   descricao?: string | null;  // descrição do produto (omie_products) — UI mostra no lugar do código SKU
 }
 // Empresa DECOMPOSTA (capital parcial → um único evp seria mentira contábil; Codex 2026-06-23).
@@ -1038,6 +1042,8 @@ export interface CockpitEmpresaEVP {
   cm_incompleto: boolean;
   qtd_combos_sensiveis: number;     // combos REAIS no fio da navalha (granularidade que o agregado robusto esconde)
   qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break-even em (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
+  folga_hurdle_min_pp: number | null;      // combo mais próximo do hurdle por cima (folga contínua) — complementa qtd_combos_quase_sensiveis
+  folga_hurdle_min_receita: number | null; // receita do combo dono do folga_min (contexto: locator, não severidade)
   capital_conhecido: number | null; // Σ capital das células reais → deriva EVP a outros hurdles
 }
 export interface ValorCockpitResult {

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -137,6 +137,13 @@ type CapitalCliente = { cliente: string; ar_medio: number | null };
 type CapitalSKU = { sku: string; estoque_valor: number | null };
 // Status do EVP afirmável (espelho VERBATIM de src/lib/financeiro/valor-cockpit-helpers.ts).
 type EvpStatus = 'real' | 'teto_nao_positivo' | 'omitido_teto_positivo' | 'indisponivel_cm' | 'indisponivel_hurdle';
+// Espelho de src/lib/financeiro/valor-cockpit-helpers.ts: menor folga POSITIVA ao hurdle (break_even − k > 0)
+// entre células 'real' — combo "parece seguro, está frágil". NÃO min|folga| (negativa já é evp<0; o |abs| a
+// devolveria, escondendo o blind spot positivo — Codex). Locator → guarda a receita do combo vencedor.
+function acumularFolgaMinPositiva(acc: { pp: number | null; receita: number | null }, cel: { evp_status: string; folga_hurdle_pp: number | null; receita_liquida: number }): void {
+  if (cel.evp_status !== 'real' || cel.folga_hurdle_pp == null || cel.folga_hurdle_pp <= 1e-9) return;
+  if (acc.pp == null || cel.folga_hurdle_pp < acc.pp) { acc.pp = cel.folga_hurdle_pp; acc.receita = cel.receita_liquida; }
+}
 function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: CapitalCliente[]; capitalSKUs: CapitalSKU[]; k: number | null; banda_hurdle?: number }) {
   const arPorCliente = new Map(input.capitalClientes.map((c) => [c.cliente, c.ar_medio]));
   const estoquePorSKU = new Map(input.capitalSKUs.map((s) => [s.sku, s.estoque_valor]));
@@ -193,10 +200,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
   });
   type Cel = typeof celulas[number];
   const rollup = (keyFn: (c: Cel) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; folgaMin: { pp: number | null; receita: number | null } }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0 };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, folgaMin: { pp: null, receita: null } };
       acc.receita += cel.receita_liquida; acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true;
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; }
@@ -207,18 +214,20 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;
       if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++; // espelho de src (quase-frágil, lado bom)
+      acumularFolgaMinPositiva(acc.folgaMin, cel);
       m.set(key, acc);
     }
     return m;
   };
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
-  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis }));
+  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, folga_hurdle_min_pp: a.folgaMin.pp, folga_hurdle_min_receita: a.folgaMin.receita }));
+  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, folga_hurdle_min_pp: a.folgaMin.pp, folga_hurdle_min_receita: a.folgaMin.receita }));
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false, recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
   let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0;
+  const folgaMinEmp: { pp: number | null; receita: number | null } = { pp: null, receita: null };
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -230,9 +239,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     else if (cel.evp_status === 'omitido_teto_positivo') { evpIncompletoEmp = true; recOmitido += cel.receita_liquida; }
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
     if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
+    acumularFolgaMinPositiva(folgaMinEmp, cel);
   }
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null; // evp único só se nada omitido/indisponível (Codex)
-  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
+  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido, folga_hurdle_min_pp: folgaMinEmp.pp, folga_hurdle_min_receita: folgaMinEmp.receita };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return { celulas, porCliente, porSKU, empresa, evp_conhecido_receita_pct: pct(recConhecido), evp_omitido_otimista_receita_pct: pct(recOmitido), evp_perda_garantida_receita_pct: pct(recPerda), sem_cm_receita_pct: pct(recSemCm), hurdle_banda: k != null ? { base: k, lo: kLo, hi: kHi } : null };
 }


### PR DESCRIPTION
## O quê (enxerto sobre #1049)

O **#1049** já shippou os "quase-frágeis" ao hurdle como **contagem** numa banda `(k+δ, k+2δ]` (`qtd_combos_quase_sensiveis`). Isto **complementa** essa contagem com o que ela não diz: **qual** é o combo mais próximo do hurdle por cima, **quão** perto (folga contínua) e **quão** material (receita).

Campo novo `folga_hurdle_min_pp` (+ `folga_hurdle_min_receita`) em `porCliente` / `porSKU` / `empresa`. **Aditivo** — não remove nem altera nada do #1049.

> Contexto: duas sessões resolveram o mesmo P2 (achado de `/codex challenge` no #1044) por caminhos diferentes — #1049 pela 2ª banda (opção b), esta linha pela folga contínua (opção a). Decisão do founder: **enxertar só o que falta** (o locator contínuo + materialidade), mantendo a contagem do #1049.

## Por que folga POSITIVA (não `min|folga|`)

Decisão Claude + `/codex` (xhigh, money-path): a métrica é a **menor folga POSITIVA** (`break_even − k > 0`) entre células `'real'`, não `min|folga|`. Uma folga negativa já está **abaixo** do hurdle (EVP<0, já sinalizado por `evp<0`/`perda_garantida`); `min|abs|` devolveria essa negativa, **escondendo** o blind spot positivo — o combo que "parece seguro, está frágil".

É **locator, não severidade** → carrega a `receita` do combo vencedor. A medição (psql-ro, helpers reais) confirmou: o min da empresa vem de um combo de **R$48** — sem o contexto de receita seria alarme falso. Por isso a UI só mostra o headline-empresa quando material (≥ `sample_min_receita`).

## Medição (psql-ro + helpers REAIS, validada)

Receita reproduzida a **R$4.853.131** (idêntica à âncora), cobertura-AR 100%. 2904 células `'real'`; **15/390 clientes** e **15/552 SKUs** têm um combo material próximo do hurdle por cima.

## Mudanças (6 arquivos, todos aditivos ao #1049)

- `folga_hurdle_min_pp` / `_receita` em `porCliente`/`porSKU`/`empresa` (helper) + **espelho verbatim** no edge `fin-valor-cockpit`
- service (`CockpitRollup*` / `CockpitEmpresaEVP`) + UI: headline-empresa "mais próximo do hurdle: +X,Xpp (R$Y)" (material-gated) e, na coluna, enxerto inline na linha do quase-frágil do #1049 ("· mais próx. +X,Xpp (R$Y)")

## Provas

- TDD 7 testes (inclui **falsificação** `min|abs|` → positiva)
- `.mut` +3 mutações → **PEGA** (mutcheck do helper, 0 sobreviventes)
- typecheck ✓ · suíte do cockpit 132/132 ✓ · lint 0 erros ✓

## Deploy (manual, pós-merge — SEM migration)

1. **edge** `fin-valor-cockpit` (chat do Lovable, verbatim do repo) — põe a folga no payload
2. **Publish** frontend — service + UI leem o payload novo

🤖 Generated with [Claude Code](https://claude.com/claude-code)
