### PR TITLE
fix(security): sanitiza `*` e fecha caso degenerado nos .ilike() crus de busca

### DIFF
--- a/src/components/reposicao/aumentos/useAumentos.ts
+++ b/src/components/reposicao/aumentos/useAumentos.ts
@@ -8,6 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { agruparPorMes, chavesUltimosNMeses } from "@/lib/agruparPorMes";
+import { ilikeContainsPattern } from "@/lib/postgrest";
 import { EMPRESA, FORNECEDOR_DEFAULT, ALL } from "./config";
 import type { Aumento, AumentoComAgg, FornecedorRow, AumentoItemAgg } from "./types";
 
@@ -59,7 +60,8 @@ export function useAumentos() {
         // default: todos exceto expirado
         q = q.neq("estado", "expirado");
       }
-      if (busca.trim()) q = q.ilike("nome", `%${busca.trim()}%`);
+      const buscaPat = ilikeContainsPattern(busca.trim());
+      if (buscaPat) q = q.ilike("nome", buscaPat);
 
       const { data, error } = await q;
       if (error) throw error;

--- a/src/components/reposicao/revisao/useRevisaoParametros.ts
+++ b/src/components/reposicao/revisao/useRevisaoParametros.ts
@@ -8,6 +8,7 @@ import { useDebouncedValue } from "@/hooks/useDebouncedValue";
 import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
 import { toast } from "sonner";
 import { type SkuParam, type RowWithPrice, type StatusFilterValue, reativarPayload } from "@/lib/reposicao/sku-param";
+import { ilikeContainsPattern } from "@/lib/postgrest";
 import { PAGE_SIZE, type SkuSugeridoView } from "./types";
 
 export function useRevisaoParametros() {
@@ -45,7 +46,8 @@ export function useRevisaoParametros() {
           if (/^\d+$/.test(s)) {
             q = q.eq("sku_codigo_omie", Number(s));
           } else {
-            q = q.ilike("sku_descricao", `%${s}%`);
+            const pat = ilikeContainsPattern(s);
+            if (pat) q = q.ilike("sku_descricao", pat);
           }
         }
 
@@ -114,7 +116,8 @@ export function useRevisaoParametros() {
           if (/^\d+$/.test(s)) {
             q = q.eq("sku_codigo_omie", Number(s));
           } else {
-            q = q.ilike("sku_descricao", `%${s}%`);
+            const pat = ilikeContainsPattern(s);
+            if (pat) q = q.ilike("sku_descricao", pat);
           }
         }
 
@@ -201,7 +204,8 @@ export function useRevisaoParametros() {
         if (/^\d+$/.test(s)) {
           q = q.eq("sku_codigo_omie", Number(s));
         } else {
-          q = q.ilike("sku_descricao", `%${s}%`);
+          const pat = ilikeContainsPattern(s);
+          if (pat) q = q.ilike("sku_descricao", pat);
         }
       }
 

--- a/src/hooks/useBuscaClienteOmie.ts
+++ b/src/hooks/useBuscaClienteOmie.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { eqText, orFilter } from '@/lib/postgrest';
+import { eqText, orFilter, ilikeContainsPattern } from '@/lib/postgrest';
 
 /** Resultado da busca de cliente (Omie ERP + perfis locais), antes de resolver user_id. */
 export type ClienteBusca = {
@@ -41,8 +41,11 @@ export function useBuscaClienteOmie() {
         omie_codigo_cliente: c.codigo_cliente,
         empresa_omie: empresaByCode[c.codigo_cliente] ?? null,
       }));
-      const { data: localProfiles } = await supabase.from('profiles')
-        .select('user_id, name, email, phone').ilike('name', `%${query}%`).limit(10);
+      const namePat = ilikeContainsPattern(query);
+      const { data: localProfiles } = namePat
+        ? await supabase.from('profiles')
+          .select('user_id, name, email, phone').ilike('name', namePat).limit(10)
+        : { data: null };
       const local: ClienteBusca[] = (localProfiles || []).map((p) => ({
         user_id: p.user_id, nome: p.name ?? 'Cliente', documento: null,
         telefone: p.phone ?? null, email: p.email ?? null,

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
-import { ilikeOr } from '@/lib/postgrest';
+import { ilikeOr, sanitizeIlikeTerm } from '@/lib/postgrest';
 
 /**
  * Busca global pra Cmd-K — pesquisa simultânea em 3 entidades:
@@ -105,8 +105,8 @@ export function useGlobalSearch(query: string, enabled = true) {
     enabled: isActive && isNumericQuery,
     staleTime: 30_000,
     queryFn: async () => {
-      // .ilike() único — só wildcards do ILIKE precisam ser strippados
-      const q = trimmed.replace(/[%_]/g, '');
+      // .ilike() único — sanitizeIlikeTerm strippa os wildcards do ILIKE (% _ *)
+      const q = sanitizeIlikeTerm(trimmed);
       const { data } = await supabase
         .from('sales_orders')
         .select('id, omie_numero_pedido, total, customer_user_id')

--- a/src/lib/__tests__/postgrest.test.ts
+++ b/src/lib/__tests__/postgrest.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   sanitizeForPostgrestOr,
+  sanitizeIlikeTerm,
+  ilikeContainsPattern,
   ilike,
   ilikeOr,
   eqInt,
@@ -46,6 +48,74 @@ describe('sanitizeForPostgrestOr', () => {
 
   it('string vazia → string vazia', () => {
     expect(sanitizeForPostgrestOr('')).toBe('');
+  });
+});
+
+// Os 3 wildcards do operador LIKE/ILIKE, derivados da GRAMÁTICA do PostgREST (não da
+// memória do autor): `%` (qualquer sequência), `_` (um caractere) e `*` — alias de `%`
+// em like/ilike pra evitar URL-encoding (postgrest.org, tables_views). Foi derivar da
+// intuição (só `%`/`_`) e ESQUECER o `*` que abriu o gap nos `.ilike()` crus.
+const ILIKE_WILDCARDS = ['%', '_', '*'];
+
+describe('sanitizeIlikeTerm', () => {
+  it('remove cada wildcard do ILIKE — entrada derivada da própria gramática', () => {
+    // Deriva tanto a entrada quanto a verificação da constante: se o helper esquecer
+    // QUALQUER wildcard da lista (como o `*` original), este laço falha.
+    for (const w of ILIKE_WILDCARDS) {
+      expect(sanitizeIlikeTerm(`a${w}b`)).toBe('ab');
+    }
+    expect(sanitizeIlikeTerm(`x${ILIKE_WILDCARDS.join('')}y`)).toBe('xy');
+  });
+
+  it('remove o asterisco — alias de % (o gap que o .replace(/[%_]/g) deixou passar)', () => {
+    // `.ilike('col', `%${'*'}%`)` → o servidor traduz `%*%` em `%%%` = match-all dos
+    // valores não-nulos da coluna. Strippar só `%`/`_` NÃO cobre esse vetor.
+    expect(sanitizeIlikeTerm('*')).toBe('');
+    expect(sanitizeIlikeTerm('a*b*c')).toBe('abc');
+  });
+
+  it('PRESERVA vírgula/parênteses/aspas — num .ilike() único não são metacaracteres (≠ sanitizeForPostgrestOr)', () => {
+    // Contraste de CONTRATO: o `.or()` parseia vírgula/parênteses (separador/grupo), então
+    // sanitizeForPostgrestOr os remove. Num `.ilike()` único o pattern é o valor de UM
+    // predicado — esses caracteres são literais legítimos da busca e devem sobreviver.
+    expect(sanitizeIlikeTerm('a,b(c)"d')).toBe('a,b(c)"d');
+  });
+
+  it('texto limpo passa inalterado (espaço, dígito, acento, hífen, ponto)', () => {
+    expect(sanitizeIlikeTerm('abrasivo 120')).toBe('abrasivo 120');
+    expect(sanitizeIlikeTerm('ção-1.5')).toBe('ção-1.5');
+  });
+
+  it('propriedade de segurança: NENHUM wildcard do ILIKE sobra, qualquer que seja a entrada', () => {
+    const sujo = 'cor*_50%off_(a)';
+    const limpo = sanitizeIlikeTerm(sujo);
+    for (const w of ILIKE_WILDCARDS) expect(limpo.includes(w)).toBe(false);
+  });
+
+  it('string vazia → string vazia', () => {
+    expect(sanitizeIlikeTerm('')).toBe('');
+  });
+});
+
+describe('ilikeContainsPattern', () => {
+  it('termo com texto → `%termo%` com wildcards strippados', () => {
+    expect(ilikeContainsPattern('abc')).toBe('%abc%');
+    expect(ilikeContainsPattern('a*b')).toBe('%ab%'); // wildcard no meio vira literal
+    expect(ilikeContainsPattern('ção 120')).toBe('%ção 120%');
+  });
+
+  it('input só-de-wildcards → null (NÃO vira `%%` match-all) — o gap que o /codex achou', () => {
+    // `%${sanitizeIlikeTerm('*')}%` seria `%%` = match-all dos não-nulos da coluna.
+    // Retornar null sinaliza ao caller pra NÃO aplicar o .ilike (busca sem texto).
+    expect(ilikeContainsPattern('*')).toBeNull();
+    expect(ilikeContainsPattern('%')).toBeNull();
+    expect(ilikeContainsPattern('_')).toBeNull();
+    expect(ilikeContainsPattern('**')).toBeNull();
+    expect(ilikeContainsPattern('%_*')).toBeNull();
+  });
+
+  it('input vazio → null', () => {
+    expect(ilikeContainsPattern('')).toBeNull();
   });
 });
 

--- a/src/lib/postgrest.ts
+++ b/src/lib/postgrest.ts
@@ -25,6 +25,34 @@ export function sanitizeForPostgrestOr(input: string): string {
   return input.replace(/[%_,()\\"*]/g, '');
 }
 
+/**
+ * Sanitiza um termo pra um `.ilike(coluna, `%${termo}%`)` ÚNICO (fora de `.or()`).
+ * Remove só os wildcards do operador LIKE/ILIKE: `%` (qualquer sequência), `_` (um
+ * caractere) e `*` — alias de `%` que o PostgREST aceita pra evitar URL-encoding (logo
+ * `*` do usuário vira `%*%` → `%%%` = match-all dos valores não-nulos da coluna). Strippar
+ * só `%`/`_` (intuição) NÃO cobre o `*`: foi esse o gap nos `.ilike()` crus.
+ *
+ * Ao contrário do sanitizeForPostgrestOr, NÃO remove vírgula/parênteses/aspas: num `.ilike()`
+ * único o pattern é o valor de UM predicado — não há parsing de cláusula (isso é exclusivo
+ * do `.or()`), então esses caracteres são literais legítimos da busca e devem sobreviver.
+ */
+export function sanitizeIlikeTerm(input: string): string {
+  return input.replace(/[%_*]/g, '');
+}
+
+/**
+ * Pattern `%termo%` pra um `.ilike(coluna, …)` de "contém", com o termo sanitizado
+ * (`sanitizeIlikeTerm`) — ou `null` quando o termo fica VAZIO após sanitizar (input vazio
+ * OU só-de-wildcards: `*`, `%`, `_`, `**`, …). Os callers DEVEM gatear:
+ * `const p = ilikeContainsPattern(t); if (p) q = q.ilike(col, p)`. Retornar null evita o
+ * `%${''}%` = `%%`, que casaria todo valor não-nulo da coluna (match-all) — o caso degenerado
+ * do wildcard-only input, que strippar os wildcards do MEIO do termo sozinho não cobre.
+ */
+export function ilikeContainsPattern(input: string): string | null {
+  const safe = sanitizeIlikeTerm(input);
+  return safe ? `%${safe}%` : null;
+}
+
 /** Uma cláusula `coluna.ilike.%termo%` com o termo sanitizado. */
 export function ilike(column: string, term: string): string {
   return `${column}.ilike.%${sanitizeForPostgrestOr(term)}%`;

--- a/src/pages/AdminReposicaoPromocoes.tsx
+++ b/src/pages/AdminReposicaoPromocoes.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Percent, Upload, FilePlus, Handshake, AlertTriangle } from "lucide-react";
 import { agruparPorMes, chavesUltimosNMeses } from "@/lib/agruparPorMes";
+import { ilikeContainsPattern } from "@/lib/postgrest";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EMPRESA, ALL, type Campanha, type CampanhaComContagem } from "@/components/reposicao/promocoes/types";
@@ -37,7 +38,8 @@ export default function AdminReposicaoPromocoes() {
 
       if (filtroEstado !== ALL) q = q.eq("estado", filtroEstado);
       if (filtroFornecedor !== ALL) q = q.eq("fornecedor_nome", filtroFornecedor);
-      if (busca.trim()) q = q.ilike("nome", `%${busca.trim()}%`);
+      const buscaPat = ilikeContainsPattern(busca.trim());
+      if (buscaPat) q = q.ilike("nome", buscaPat);
 
       const { data, error } = await q;
       if (error) throw error;

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
 import { supabase } from '@/integrations/supabase/client';
-import { eqText, orFilter } from '@/lib/postgrest';
+import { eqText, orFilter, ilikeContainsPattern } from '@/lib/postgrest';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { useFarmerScoring, type AgendaItem } from '@/hooks/useFarmerScoring';
@@ -171,16 +171,19 @@ const FarmerCalls = () => {
       // profiles): os perfis locais, instantâneos, ficavam presos atrás da
       // roundtrip ao ERP — agora aparecem assim que chegam e o merge com o
       // Omie completa depois.
-      const localPromise = supabase
-        .from('profiles')
-        .select('user_id, name, email, phone')
-        .ilike('name', `%${query}%`)
-        .limit(10);
+      const namePat = ilikeContainsPattern(query);
+      const localPromise = namePat
+        ? supabase
+            .from('profiles')
+            .select('user_id, name, email, phone')
+            .ilike('name', namePat)
+            .limit(10)
+        : null;
       const omiePromise = supabase.functions.invoke('omie-vendas-sync', {
         body: { action: 'listar_clientes', search: query },
       });
 
-      const { data: localProfiles } = await localPromise;
+      const { data: localProfiles } = localPromise ? await localPromise : { data: null };
       const local: Customer[] = (localProfiles || []).map(p => ({
         user_id: p.user_id,
         name: p.name,

--- a/src/pages/TintPricing.tsx
+++ b/src/pages/TintPricing.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { ilikeContainsPattern } from '@/lib/postgrest';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -82,6 +83,8 @@ function useFormulaSearch(corId: string) {
     queryKey: ['tint-formula-search', corId],
     enabled: corId.length >= 2,
     queryFn: async () => {
+      const pat = ilikeContainsPattern(corId);
+      if (!pat) return [];
       const { data } = await supabase
         .from('tint_formulas')
         .select(`
@@ -97,7 +100,7 @@ function useFormulaSearch(corId: string) {
         `)
         .eq('account', ACCOUNT)
         .is('desativada_em', null)
-        .ilike('cor_id', `%${corId}%`)
+        .ilike('cor_id', pat)
         .limit(20);
       return data ?? [];
     },


### PR DESCRIPTION
## O gap
PostgREST trata `*` como alias de `%` em like/ilike. Os `.ilike()` **crus** com input de usuário sanitizavam wildcard de forma inconsistente — alguns só `%`/`_`, outros nada — deixando o usuário alargar o match intra-coluna (dentro do que a RLS já libera). Severidade **BAIXA** (segurança-de-busca, não autorização): não injeta cláusula, não cruza coluna, não bypassa RLS. Confirmado por Claude + Codex/gpt-5.5 lendo o source do PostgREST.

## Fix (2 camadas)
- **`sanitizeIlikeTerm`** (strippa `% _ *`) nos **8 call-sites** de `.ilike()` com input de usuário (useGlobalSearch, useBuscaClienteOmie, useAumentos, useRevisaoParametros×3, AdminReposicaoPromocoes, FarmerCalls, TintPricing).
- **`ilikeContainsPattern`** (retorna `null` se o termo fica vazio) fecha o **caso degenerado** apontado no `/codex review`: input só-de-wildcards (`*`/`%%`/`**`) virava `%%` = match-all dos não-nulos. Aplicado nos **6 sites** afetados; `useGlobalSearch` já era imune (guard `/^\d+$/`).

## Fora de escopo
- `sanitizeForPostgrestOr` / `.or()` já tratado em #1051 (remove `*`). Não tocado.
- `.ilike()` com constante (`%SAYERLACK%`/`oben`) — sem gap, não tocado.
- O Codex notou que o `.or()` (`ilikeOr`/`ilike`) tem a **mesma classe** de caso degenerado → follow-up separado.

## Verificação (money-path)
- `typecheck` = 0 · **528 suítes / 4111 testes** verdes · `lint` 0 errors
- Teste derivado da **gramática do PostgREST** (`% _ *`) + **dupla falsificação**: tirei o `*` do helper → 3 testes vermelhos; tirei o null-check → 2 vermelhos no caso degenerado; restaurei ambos → verde.

## Deploy
Só frontend TS → **Publish no editor do Lovable** (sem migration, sem edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)