### PR TITLE
fix(security): gate o caso degenerado de wildcard nos .or() de busca (follow-up #1062)

### DIFF
--- a/src/components/reposicao/aplicacao/SubstituicaoModal.tsx
+++ b/src/components/reposicao/aplicacao/SubstituicaoModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { eqInt, ilike, orFilter } from "@/lib/postgrest";
+import { eqInt, ilike, isSearchablePostgrestTerm, orFilter } from "@/lib/postgrest";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -42,7 +42,8 @@ export function SubstituicaoModal({
   const { data: opcoes } = useQuery({
     queryKey: ["sku-busca", busca],
     queryFn: async () => {
-      if (!busca || busca.length < 2) return [];
+      // só-wildcard (`**`, passa o length>=2) → ilike do `.or()` vira match-all (#1062); busca vazia
+      if (!busca || busca.length < 2 || !isSearchablePostgrestTerm(busca)) return [];
       const { data } = await supabase
         .from("sku_parametros")
         .select("sku_codigo_omie, sku_descricao")

--- a/src/components/reposicao/promocaoDetail/MapeamentoStatusCell.tsx
+++ b/src/components/reposicao/promocaoDetail/MapeamentoStatusCell.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { eqInt, ilike, ilikeOr, orFilter } from "@/lib/postgrest";
+import { eqInt, ilike, ilikeOr, isSearchablePostgrestTerm, orFilter } from "@/lib/postgrest";
 import { toast } from "sonner";
 import { Check, Sparkles, Loader2, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -50,6 +50,9 @@ export function MapeamentoStatusCell({
     const t = setTimeout(async () => {
       setSearching(true);
       const term = searchQuery.trim();
+      // só-wildcard (`**`) sanitiza pra vazio → o ilike do `.or()` viraria match-all (#1062);
+      // busca pura: não-pesquisável = sem resultados (número sobrevive, segue pelo ramo isNumeric).
+      if (!isSearchablePostgrestTerm(term)) { setSearchResults([]); setSearching(false); return; }
       // Busca por descrição OU código OU sku omie (numérico). account no banco é lowercase.
       const isNumeric = /^\d+$/.test(term);
       type OmieSearchRow = { omie_codigo_produto: number; descricao: string; codigo: string };

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { ilikeOr } from '@/lib/postgrest';
+import { ilikeOr, isSearchablePostgrestTerm } from '@/lib/postgrest';
 import { useTintPricing, useTintPrices } from '@/hooks/useTintPricing';
 import { selectTintPrice, type TintPriceSource } from '@/lib/tint/select-price';
 import type { Product } from '@/hooks/useUnifiedOrder';
@@ -93,6 +93,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
     staleTime: 5 * 60 * 1000,
     enabled: !!skuId && debouncedSearch.length >= 2,
     queryFn: async () => {
+      if (!isSearchablePostgrestTerm(debouncedSearch)) return []; // só-wildcard → match-all (#1062); busca vazia
       const { data } = await supabase
         .from('tint_formulas')
         .select('id, cor_id, nome_cor, preco_final_sayersystem')
@@ -115,6 +116,8 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
     // família e mostra todas as bases vendáveis — nunca esconde a cor em silêncio.
     enabled: !!colorNotFoundInBase,
     queryFn: async (): Promise<{ matches: AlternativePackaging[]; colorExists: boolean }> => {
+      // só-wildcard → `.or()` match-all (#1062); busca vazia não acha cor nenhuma
+      if (!isSearchablePostgrestTerm(debouncedSearch)) return { matches: [], colorExists: false };
       // Search formulas across all SKUs
       const { data: globalFormulas } = await supabase
         .from('tint_formulas')

--- a/src/hooks/useGlobalSearch.ts
+++ b/src/hooks/useGlobalSearch.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
-import { ilikeOr, sanitizeIlikeTerm } from '@/lib/postgrest';
+import { ilikeOr, isSearchablePostgrestTerm, sanitizeIlikeTerm } from '@/lib/postgrest';
 
 /**
  * Busca global pra Cmd-K — pesquisa simultânea em 3 entidades:
@@ -58,6 +58,9 @@ export function useGlobalSearch(query: string, enabled = true) {
     enabled: isActive,
     staleTime: 30_000,
     queryFn: async () => {
+      // Termo só-wildcard (`**`, passa o length>=2) sanitiza pra vazio → `.or()` viraria match-all
+      // dos profiles (PII) (#1062). Busca pura: não-pesquisável = sem resultados.
+      if (!isSearchablePostgrestTerm(trimmed)) return [];
       // Busca por nome OU document OU email — ilikeOr sanitiza (anti-injeção)
       const { data } = await supabase
         .from('profiles')
@@ -81,6 +84,7 @@ export function useGlobalSearch(query: string, enabled = true) {
     enabled: isActive,
     staleTime: 60_000,
     queryFn: async () => {
+      if (!isSearchablePostgrestTerm(trimmed)) return []; // só-wildcard → match-all (#1062); busca vazia
       const { data } = await supabase
         .from('tint_formulas')
         .select('id, cor_id, nome_cor')

--- a/src/lib/__tests__/postgrest.test.ts
+++ b/src/lib/__tests__/postgrest.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeForPostgrestOr,
   sanitizeIlikeTerm,
   ilikeContainsPattern,
+  isSearchablePostgrestTerm,
   ilike,
   ilikeOr,
   eqInt,
@@ -148,6 +149,66 @@ describe('ilikeContainsPattern', () => {
   });
 });
 
+// Gate do contexto `.or()`: o análogo do `ilikeContainsPattern→null` do .ilike() único.
+// `ilikeOr`/`ilike`/`orFilter(...ilike...)` NÃO se defendem do termo só-de-wildcards
+// (vide hazard nos describes de ilikeOr/ilike abaixo) — quem decide aplicar ou não o
+// `.or()` é o caller, e isto responde "tem termo pesquisável?". A condição degenerada é
+// EXATAMENTE `sanitizeForPostgrestOr(term) === ''` (= match-all `%%`), cobrindo as 3 formas
+// de `.or()` com ilike de uma vez (ilikeOr puro · ilike único · orFilter eqInt+ilike misto).
+describe('isSearchablePostgrestTerm', () => {
+  it('termo com conteúdo real → true (texto, acento, número p/ shape eqInt+ilike)', () => {
+    expect(isSearchablePostgrestTerm('tinta')).toBe(true);
+    expect(isSearchablePostgrestTerm('abrasivo 120')).toBe(true);
+    expect(isSearchablePostgrestTerm('ção-1.5')).toBe(true);
+    expect(isSearchablePostgrestTerm('42')).toBe(true);
+    expect(isSearchablePostgrestTerm('007')).toBe(true);
+  });
+
+  it('conteúdo + metacaractere no meio → true (sobra texto: a%b → ab)', () => {
+    // O gate só barra o caso DEGENERADO (sanitiza pra vazio); termo com qualquer conteúdo
+    // real sobrevive — o `*`/`%` do meio vira literal e a busca continua.
+    expect(isSearchablePostgrestTerm('a%b')).toBe(true);
+    expect(isSearchablePostgrestTerm('4*2')).toBe(true);
+  });
+
+  it('input só-de-metacaracteres do .or() → false (o caso degenerado) — derivado da gramática', () => {
+    // Cada metacaractere que sanitizeForPostgrestOr strippa, sozinho, colapsa pra vazio.
+    // Itera META (não payload escolhido a dedo): esquecer qualquer um faz o laço falhar.
+    for (const ch of META) expect(isSearchablePostgrestTerm(ch)).toBe(false);
+    for (const s of ['**', '%%', '%_*', '()', '(),', '*,()', '%,(', META.join('')]) {
+      expect(isSearchablePostgrestTerm(s)).toBe(false);
+    }
+  });
+
+  it('vírgula/parênteses-só → false (usa sanitizeForPostgrestOr, NÃO sanitizeIlikeTerm)', () => {
+    // Falsificação embutida: sanitizeIlikeTerm PRESERVA , ( ) " — se o helper usasse ELE,
+    // `(),` sobreviveria como '(),' (≠ vazio) e isto viraria true. O contexto .or() parseia
+    // esses chars, então têm que zerar → false.
+    expect(isSearchablePostgrestTerm('(),')).toBe(false);
+    expect(isSearchablePostgrestTerm(',,,')).toBe(false);
+    expect(isSearchablePostgrestTerm('"\\"')).toBe(false);
+  });
+
+  it('string vazia → false', () => {
+    expect(isSearchablePostgrestTerm('')).toBe(false);
+  });
+
+  it('contrato gate⟺hazard: false ⟺ ilikeOr/ilike colapsariam pro %% (match-all)', () => {
+    // Liga o gate ao hazard: quando false, o predicado que o caller DEIXA de aplicar seria
+    // o match-all degenerado; quando true, sobra conteúdo e não há `%%`.
+    const cols = ['a', 'b'];
+    for (const t of ['*', '%%', '**', '(),', '']) {
+      expect(isSearchablePostgrestTerm(t)).toBe(false);
+      expect(ilikeOr(cols, t)).toBe('a.ilike.%%,b.ilike.%%');
+      expect(ilike('a', t)).toBe('a.ilike.%%');
+    }
+    for (const t of ['tinta', '42', 'a%b']) {
+      expect(isSearchablePostgrestTerm(t)).toBe(true);
+      expect(ilikeOr(cols, t)).not.toContain('.ilike.%%');
+    }
+  });
+});
+
 describe('ilike', () => {
   it('monta col.ilike.%termo%', () => {
     expect(ilike('nome', 'abc')).toBe('nome.ilike.%abc%');
@@ -156,6 +217,13 @@ describe('ilike', () => {
   it('sanitiza o termo sem quebrar a estrutura', () => {
     expect(ilike('nome', 'a,b')).toBe('nome.ilike.%ab%');
     expect(ilike('nome', 'x,id.gt.0')).toBe('nome.ilike.%xid.gt.0%');
+  });
+
+  it('HAZARD: termo só-wildcard colapsa pro %% (match-all) — caller deve gatear com isSearchablePostgrestTerm', () => {
+    // ilike() não se defende sozinho: `*`/`()` sanitizam pra vazio → `col.ilike.%%`, que
+    // dentro do `.or()` casa todo valor não-nulo da coluna. A defesa vive no gate do caller.
+    expect(ilike('a', '*')).toBe('a.ilike.%%');
+    expect(ilike('a', '()')).toBe('a.ilike.%%');
   });
 });
 
@@ -173,6 +241,14 @@ describe('ilikeOr', () => {
 
   it('lista de colunas vazia → string vazia', () => {
     expect(ilikeOr([], 'abc')).toBe('');
+  });
+
+  it('HAZARD: termo só-wildcard colapsa cada cláusula pro %% (match-all) — caller deve gatear', () => {
+    // `*`/`%%`/`**` → cada coluna vira `col.ilike.%%` = match-all dos não-nulos dentro do
+    // `.or()`. ilikeOr não se defende; a defesa é o gate `isSearchablePostgrestTerm` no caller
+    // (espelha o ilikeContainsPattern→null que o #1062 usou no .ilike() único).
+    expect(ilikeOr(['a', 'b'], '*')).toBe('a.ilike.%%,b.ilike.%%');
+    expect(ilikeOr(['a', 'b'], '%%')).toBe('a.ilike.%%,b.ilike.%%');
   });
 });
 

--- a/src/lib/postgrest.ts
+++ b/src/lib/postgrest.ts
@@ -26,6 +26,23 @@ export function sanitizeForPostgrestOr(input: string): string {
 }
 
 /**
+ * `true` quando `term` ainda tem conteúdo após `sanitizeForPostgrestOr` — i.e. gera um predicado
+ * `.or()` de ILIKE útil. `false` no caso DEGENERADO: termo vazio OU só-de-metacaracteres do `.or()`
+ * (`*`, `%%`, `**`, `(),`…), em que `ilikeOr`/`ilike` colapsariam pra `col.ilike.%%` = match-all dos
+ * valores não-nulos da coluna. Como o `.or(pred)` não tem como virar no-op por dentro (string vazia
+ * não dropa o filtro), a defesa vive no CALLER, que gateia o `.or()` por isto:
+ *   - lista c/ filtro opcional → `if (isSearchablePostgrestTerm(t)) q = q.or(…)` (senão = lista base)
+ *   - busca pura            → `if (!isSearchablePostgrestTerm(t)) return []` (senão = linhas arbitrárias)
+ * É o análogo, no contexto `.or()`, do `ilikeContainsPattern(t) === null` do `.ilike()` único (#1062);
+ * um booleano (não pattern-or-null) porque a condição degenerada — `sanitizeForPostgrestOr(term)===''`
+ * — é a MESMA pras 3 formas de `.or()` com ilike, inclusive o `orFilter` misto (eqInt+ilike), onde
+ * não há um pattern único a retornar (aí o eqInt vira `eq.0`, inerte, e dropar o `.or()` é correto).
+ */
+export function isSearchablePostgrestTerm(term: string): boolean {
+  return sanitizeForPostgrestOr(term) !== '';
+}
+
+/**
  * Sanitiza um termo pra um `.ilike(coluna, `%${termo}%`)` ÚNICO (fora de `.or()`).
  * Remove só os wildcards do operador LIKE/ILIKE: `%` (qualquer sequência), `_` (um
  * caractere) e `*` — alias de `%` que o PostgREST aceita pra evitar URL-encoding (logo

--- a/src/pages/AdminReposicaoAlertas.tsx
+++ b/src/pages/AdminReposicaoAlertas.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { ilikeOr } from "@/lib/postgrest";
+import { ilikeOr, isSearchablePostgrestTerm } from "@/lib/postgrest";
 import { useAuth } from "@/contexts/AuthContext";
 import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
 import { toast } from "sonner";
@@ -68,7 +68,9 @@ export default function AdminReposicaoAlertas() {
       if (filtroTipo !== "__all__") q = q.eq("tipo", filtroTipo);
       if (filtroSev !== "__all__") q = q.eq("severidade", filtroSev);
       if (filtroStatus !== "__all__") q = q.eq("status", filtroStatus);
-      if (busca.trim()) {
+      // Termo só-wildcard (`*`/`%%`) sanitiza pra vazio → `.or()` viraria match-all (#1062).
+      // Não-pesquisável = pula o filtro (mostra a lista base), igual ao demais filtros opcionais.
+      if (isSearchablePostgrestTerm(busca.trim())) {
         q = q.or(ilikeOr(["sku_codigo_omie", "sku_descricao"], busca.trim()));
       }
 

--- a/src/pages/AdminReposicaoGruposProducao.tsx
+++ b/src/pages/AdminReposicaoGruposProducao.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { eqInt, ilike, orFilter } from "@/lib/postgrest";
+import { eqInt, ilike, isSearchablePostgrestTerm, orFilter } from "@/lib/postgrest";
 import { toast } from "sonner";
 import { Plus, Factory } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -71,8 +71,10 @@ export default function AdminReposicaoGruposProducao() {
         .eq("ativo", true);
 
       if (filtroFornecedor !== ALL) q = q.eq("fornecedor_nome", filtroFornecedor);
-      if (busca.trim()) {
-        const t = busca.trim();
+      // Termo só-wildcard sanitiza pra vazio → o ilike do `.or()` viraria match-all (#1062);
+      // o eqInt já cairia em `eq.0` (inerte). Não-pesquisável = pula o filtro (lista base).
+      const t = busca.trim();
+      if (isSearchablePostgrestTerm(t)) {
         q = q.or(orFilter(ilike("sku_descricao", t), eqInt("sku_codigo_omie", t)));
       }
 

--- a/src/pages/FarmerCallsPendingLink.tsx
+++ b/src/pages/FarmerCallsPendingLink.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useLinkCallToCustomer } from '@/hooks/useLinkCallToCustomer';
-import { ilikeOr } from '@/lib/postgrest';
+import { ilikeOr, isSearchablePostgrestTerm } from '@/lib/postgrest';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -98,6 +98,8 @@ function PendingRow({
     queryKey: ['profiles-search', search],
     enabled: open && search.length >= 2,
     queryFn: async (): Promise<ProfileMatch[]> => {
+      // só-wildcard (`**`, passa o length>=2) → `.or()` match-all dos profiles (#1062); busca vazia
+      if (!isSearchablePostgrestTerm(search)) return [];
       // `search` é input do usuário — ilikeOr sanitiza (anti-injeção PostgREST)
       const { data } = await supabase.from('profiles')
         .select('user_id, name, phone')

--- a/src/pages/TintFormulas.tsx
+++ b/src/pages/TintFormulas.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { ilikeOr } from '@/lib/postgrest';
+import { ilikeOr, isSearchablePostgrestTerm } from '@/lib/postgrest';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -110,7 +110,8 @@ export default function TintFormulas() {
         .order('cor_id')
         .range(page * PAGE_SIZE, (page + 1) * PAGE_SIZE - 1);
 
-      if (search) q = q.or(ilikeOr(['cor_id', 'nome_cor'], search));
+      // só-wildcard (`*`/`%%`) → `.or()` match-all (#1062); não-pesquisável pula o filtro (lista base)
+      if (isSearchablePostgrestTerm(search)) q = q.or(ilikeOr(['cor_id', 'nome_cor'], search));
       if (produtoFilter) q = q.eq('produto_id', produtoFilter);
       if (baseFilter) q = q.eq('base_id', baseFilter);
       if (onlyPersonalizada) q = q.eq('personalizada', true);

--- a/src/queries/useRadarLista.ts
+++ b/src/queries/useRadarLista.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
-import { ilike, ilikeOr } from '@/lib/postgrest';
+import { ilike, ilikeOr, isSearchablePostgrestTerm } from '@/lib/postgrest';
 import { presetParaParams, digitosCnae, type PresetRadar } from '@/lib/radar/ui-helpers';
 import type { Database } from '@/integrations/supabase/types';
 
@@ -27,12 +27,13 @@ export function useRadarLista(filtros: RadarFiltros, hojeISO: string) {
       const p = presetParaParams(filtros.preset, hojeISO);
       let q = supabase.from('radar_empresas').select('*');
 
-      if (filtros.busca.trim()) q = q.or(ilikeOr(['razao_social', 'nome_fantasia'], filtros.busca.trim()));
+      // só-wildcard (`*`/`%%`) sanitiza pra vazio → `.or()` match-all (#1062); pula o filtro (lista base)
+      if (isSearchablePostgrestTerm(filtros.busca.trim())) q = q.or(ilikeOr(['razao_social', 'nome_fantasia'], filtros.busca.trim()));
       if (filtros.uf) q = q.eq('uf', filtros.uf);
       // Município: o banco guarda em MAIÚSCULAS (dump RFB, "BELO HORIZONTE"); o usuário
       // digita como quiser → ilike (case-insensitive + parcial, sanitizado). Limitação
       // conhecida: ilike não é acento-insensitive ("sao" não casa "SÃO") — v2 com unaccent.
-      if (filtros.municipio.trim()) q = q.or(ilike('municipio_nome', filtros.municipio.trim()));
+      if (isSearchablePostgrestTerm(filtros.municipio.trim())) q = q.or(ilike('municipio_nome', filtros.municipio.trim()));
       // CNAE: o banco guarda 7 dígitos puros; o usuário digita o formato oficial
       // (3101-2/00). Normaliza p/ dígitos. Completo (7) = match exato pelo índice;
       // parcial = prefix match (a família do CNAE). cnaeDigitos é só-dígitos (seguro).


### PR DESCRIPTION
Follow-up do #1062, que fechou o caso degenerado de wildcard nos `.ilike()` **únicos**. Durante o `/codex review` daquele PR, o Codex (gpt-5.5) apontou que o **mesmo** caso degenerado existe nos helpers do `.or()`.

## O problema
No PostgREST, `*` é alias de `%` em like/ilike. Os helpers `ilikeOr(cols, term)` e `ilike(col, term)` usam `sanitizeForPostgrestOr(term)`; quando `term` é **só-de-wildcards** (`*`, `%%`, `**`, `(),`…) ele sanitiza pra `''`, e o predicado vira `col.ilike.%%` — **match-all** dos valores não-nulos da coluna **dentro do `.or()`**. Um usuário digitando `*` na busca alarga o resultado pra (quase) tudo que a RLS libera.

## A correção
Novo helper **`isSearchablePostgrestTerm(term): boolean`** (`= sanitizeForPostgrestOr(term) !== ''`) — o análogo, no contexto `.or()`, do `ilikeContainsPattern(t) === null` que o #1062 usou no `.ilike()` único.

**Por que um booleano e não um `ilikeOrOrNull` null-returning** (as duas opções que o briefing levantou): a condição degenerada é a MESMA — `sanitizeForPostgrestOr(term) === ''` — pras **3 formas** de `.or()` com ilike:
- `ilikeOr(cols, term)` puro
- `ilike(col, term)` único dentro de `.or()`
- `orFilter(eqInt(...), ilike(...))` **misto** — onde NÃO há um pattern único a retornar como null. Aí o `eqInt` já vira `eq.0` (inerte) quando o termo é só-wildcard, então dropar o `.or()` inteiro é correto e não perde match numérico legítimo.

Um booleano cobre as 3 uniformemente e deixa `ilikeOr`/`ilike`/`orFilter` **byte-idênticos** (zero risco aos predicados existentes; o diff é puramente guards aditivos).

## Comportamento por sítio (espelha o #1062)
- **Páginas de LISTA** (filtro opcional + paginação) → não-pesquisável **pula o filtro** → lista base. (`AdminReposicaoAlertas`, `AdminReposicaoGruposProducao`, `TintFormulas`, `useRadarLista`×2)
- **Buscas PURAS** (o ilike *é* a query) → não-pesquisável **retorna vazio** (mostrar N linhas arbitrárias num Cmd-K pra `**` seria leak de PII/absurdo — igual ao `TintPricing` do #1062). (`useGlobalSearch`×2, `useTintColorSelect`×2, `MapeamentoStatusCell`, `SubstituicaoModal`, `FarmerCallsPendingLink`)

**13 call-sites / 9 arquivos.** NÃO toca `.or()` com constante (`buildFamiliaExclusionOrFilter` — `%` intencional) nem `.or(eqText('document', …))` (3 sítios — `eq.` vazio é match-exato, não match-all).

## Verificação
- TDD derivado da **gramática** do PostgREST + **dupla falsificação**: (1) `return true` sempre → vermelho nos casos só-wildcard; (2) trocar `sanitizeForPostgrestOr` por `sanitizeIlikeTerm` → vermelho **só** no teste discriminante de `(),` (que distingue os dois sanitizadores). +8 testes em `postgrest.test.ts` (34→42), incluindo âncoras do hazard (`ilikeOr('*') === '…%%,…%%'`).
- typecheck → **0 erros**
- suite completa (vitest run) → **4112 testes verdes** (528 arquivos)
- lint → **0 erros** (warnings pré-existentes, nenhuma nos arquivos tocados)

## Severidade
**BAIXA** — segurança-de-busca, não autorização. As superfícies já são staff-gated, com `.limit()` e RLS; isto remove o footgun de *alargamento* dentro do que a RLS já permite.

## Deploy
Só **frontend TS** → **Publish** no Lovable. Sem migration, sem edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
