### PR TITLE
feat(valor-cockpit): min_folga_positiva_receita — locator material do headline (aditivo ao #1058) [money-path]

### DIFF
--- a/scripts/mutcheck.d/valor-cockpit-helpers.mut
+++ b/scripts/mutcheck.d/valor-cockpit-helpers.mut
@@ -38,3 +38,8 @@ PEGA | quase: empresa não agrega (contador morto)            | s/if \(cel\.quas
 # NEGATIVO (falsa robustez — achado do Codex). Mut. nas 2 vias (empresa E rollup, ancoradas por indentação — perl -pe é linha-a-linha).
 PEGA | min_folga: sem filtro folga>0 na empresa (pegaria o neg) | s/^    if \(cel\.evp_status === 'real' && !cel\.sensivel_hurdle && cel\.folga_hurdle_pp != null && cel\.folga_hurdle_pp > 0/    if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null/
 PEGA | min_folga: sem filtro folga>0 no rollup (pegaria o neg)  | s/^      if \(cel\.evp_status === 'real' && !cel\.sensivel_hurdle && cel\.folga_hurdle_pp != null && cel\.folga_hurdle_pp > 0/      if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null/
+# min_folga_positiva_RECEITA (companheiro locator, aditivo ao #1058 2026-06-25): a receita tem de seguir o MESMO
+# combo do min (não o de maior folga/soma) — senão a UI não consegue suprimir o headline imaterial (/codex #1044).
+# Mut: o combo do min é achado mas a receita PARA de ser rastreada (vira null) → o assert toBe(1000) fica vermelho.
+PEGA | min_folga_receita: empresa para de rastrear a receita do combo | s/minFolgaPositivaEmp = cel\.folga_hurdle_pp; minFolgaPositivaReceitaEmp = cel\.receita_liquida;/minFolgaPositivaEmp = cel.folga_hurdle_pp;/
+PEGA | min_folga_receita: rollup para de rastrear a receita do combo  | s/acc\.minFolgaPositiva = cel\.folga_hurdle_pp; acc\.minFolgaPositivaReceita = cel\.receita_liquida;/acc.minFolgaPositiva = cel.folga_hurdle_pp;/

--- a/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-helpers.test.ts
@@ -1068,3 +1068,49 @@ describe('montarCelulasComboEVP — min_folga_positiva_pp (sinal contínuo do hu
     expect(r.porCliente[0].min_folga_positiva_pp).toBeNull();
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// 2026-06-25 — Follow-up aditivo ao #1058: min_folga_positiva_RECEITA — a receita_liquida do combo DONO
+// do min_folga_positiva_pp. É LOCATOR, não severidade: sem a receita, o headline AMBER dispara mesmo p/ um
+// combo ínfimo (R$50 a +6pp = alarme falso) — /codex challenge do #1044. A receita tem de seguir o MESMO
+// combo do min (não o de maior folga, não a soma) → a UI suprime o headline quando imaterial (< sample).
+// ═══════════════════════════════════════════════════════════════════════════
+describe('montarCelulasComboEVP — min_folga_positiva_receita (companheiro locator do min_folga_positiva_pp)', () => {
+  it('a receita acompanha o combo do MIN (não o de maior folga nem a soma) — rollup + empresa', () => {
+    // C1/S1: cm 380 → be 0,38 folga +0,08 receita 1000 (VENCEDOR do min). C2/S2: cm 500 → be 0,50 folga +0,20 receita 5000.
+    // min pega S1 → a receita companheira é 1000 (NÃO 5000 do maior folga, NÃO 6000 da soma).
+    const r = montarCelulasComboEVP({
+      combos: [
+        { cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 },
+        { cliente: 'C2', sku: 'S2', receita_liquida: 5000, quantidade: 100, custo_unitario: 45 },
+      ],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }, { cliente: 'C2', ar_medio: 600 }], // rc=receita → a_cs=600 cada
+      capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }, { sku: 'S2', estoque_valor: 400 }],     // i_cs=400 cada → capital 1000
+      k: 0.30,
+    });
+    expect(r.empresa.min_folga_positiva_pp).toBeCloseTo(0.08, 6);
+    expect(r.empresa.min_folga_positiva_receita).toBe(1000); // a receita do MENOR folga, não 5000 (maior) nem 6000 (soma)
+    const c1 = r.porCliente.find((c) => c.cliente === 'C1')!;
+    const c2 = r.porCliente.find((c) => c.cliente === 'C2')!;
+    expect(c1.min_folga_positiva_pp).toBeCloseTo(0.08, 6);
+    expect(c1.min_folga_positiva_receita).toBe(1000);
+    expect(c2.min_folga_positiva_pp).toBeCloseTo(0.20, 6);
+    expect(c2.min_folga_positiva_receita).toBe(5000);
+  });
+  it('a receita companheira é null sempre que o pp é null (k=null E sem positivo fora do fio)', () => {
+    const semK = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 6.2 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 600 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: null,
+    });
+    expect(semK.empresa.min_folga_positiva_pp).toBeNull();
+    expect(semK.empresa.min_folga_positiva_receita).toBeNull();
+    expect(semK.porCliente[0].min_folga_positiva_receita).toBeNull();
+    // único combo sensível (be ∈ fio) → sem candidato positivo → pp E receita null
+    const semPos = montarCelulasComboEVP({
+      combos: [{ cliente: 'C1', sku: 'S1', receita_liquida: 1000, quantidade: 100, custo_unitario: 7 }],
+      capitalClientes: [{ cliente: 'C1', ar_medio: 650 }], capitalSKUs: [{ sku: 'S1', estoque_valor: 400 }], k: 0.30,
+    });
+    expect(semPos.empresa.min_folga_positiva_pp).toBeNull();
+    expect(semPos.empresa.min_folga_positiva_receita).toBeNull();
+  });
+});

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -169,8 +169,8 @@ export type CelulaEVP = {
 // (upper bound do grupo, preserva #961); `evp_incompleto` = ∃ célula omitida por otimismo (o `evp` do grupo
 // exclui essa fatia → pode ser maior). `encargo` (só células com cm) / `encargo_total` (todas) mantidos.
 // perda_garantida = ∃ célula 'teto_nao_positivo' no grupo (o evp inclui um teto≤0 → o prejuízo REAL pode ser maior).
-export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; min_folga_positiva_pp: number | null };
-export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; min_folga_positiva_pp: number | null };
+export type RollupCliente = { cliente: string; receita: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; min_folga_positiva_pp: number | null; min_folga_positiva_receita: number | null };
+export type RollupSKU = { sku: string; receita: number; quantidade: number; cm: number | null; encargo: number | null; encargo_total: number | null; evp: number | null; evp_teto: number | null; evp_incompleto: boolean; perda_garantida: boolean; cm_incompleto: boolean; qtd_combos_sensiveis: number; qtd_combos_quase_sensiveis: number; min_folga_positiva_pp: number | null; min_folga_positiva_receita: number | null };
 // Empresa DECOMPOSTA (Codex: somar {reais + tetos≤0} excluindo os teto>0 não é teto nem piso → mentira contábil).
 // evp_conhecido = só capital completo; evp_teto_total = upper bound legado; evp_perda_garantida = piso da fatia
 // parcial-negativa; evp = null se há QUALQUER fatia não-afirmável (não finge um total).
@@ -181,6 +181,7 @@ export type EmpresaEVP = {
   qtd_combos_sensiveis: number;       // combos REAIS no fio da navalha (a granularidade que o agregado robusto esconde)
   qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break_even ∈ (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
   min_folga_positiva_pp: number | null; // menor folga POSITIVA fora do fio (folga>δ): "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum (sinal contínuo, complementa a contagem — Codex)
+  min_folga_positiva_receita: number | null; // receita_liquida do combo DONO do min_folga_positiva_pp — LOCATOR, não severidade: a UI suprime o headline quando imaterial (< sample_min_receita). null junto com o pp (/codex #1044)
   capital_conhecido: number | null;   // Σ capital_cs das células 'real' → UI deriva evp_conhecido(k') = evp_conhecido + (k − k')·capital_conhecido
 };
 export type ComboEVPResult = {
@@ -279,10 +280,10 @@ export function montarCelulasComboEVP(input: {
   });
 
   const rollup = (keyFn: (c: CelulaEVP) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; minFolgaPositiva: number | null }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; minFolgaPositiva: number | null; minFolgaPositivaReceita: number | null }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, minFolgaPositiva: null };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, minFolgaPositiva: null, minFolgaPositivaReceita: null };
       acc.receita += cel.receita_liquida;
       acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true; // grupo tem célula sem margem (excluída do EVP)
@@ -297,9 +298,10 @@ export function montarCelulasComboEVP(input: {
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;                     // evp inclui um teto≤0 → real pode ser pior
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;                                                // combo real no fio da navalha
       if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++;                                      // combo real quase-frágil (folga fina, lado bom)
-      // menor folga POSITIVA fora do fio (real && !sensivel && folga>0 ⟺ folga>δ): "o próximo a virar a +X pp" (Codex: só lado +, não signed-min)
+      // menor folga POSITIVA fora do fio (real && !sensivel && folga>0 ⟺ folga>δ): "o próximo a virar a +X pp" (Codex: só lado +, não signed-min).
+      // Guarda a receita do MESMO combo vencedor (locator, não severidade): a UI suprime o headline quando imaterial (/codex #1044).
       if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
-          && (acc.minFolgaPositiva == null || cel.folga_hurdle_pp < acc.minFolgaPositiva)) acc.minFolgaPositiva = cel.folga_hurdle_pp;
+          && (acc.minFolgaPositiva == null || cel.folga_hurdle_pp < acc.minFolgaPositiva)) { acc.minFolgaPositiva = cel.folga_hurdle_pp; acc.minFolgaPositivaReceita = cel.receita_liquida; }
       m.set(key, acc);
     }
     return m;
@@ -307,15 +309,15 @@ export function montarCelulasComboEVP(input: {
 
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
-  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
+  const porCliente: RollupCliente[] = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva, min_folga_positiva_receita: a.minFolgaPositivaReceita }));
+  const porSKU: RollupSKU[] = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva, min_folga_positiva_receita: a.minFolgaPositivaReceita }));
 
   // Empresa decomposta + pcts por receita total elegível.
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false;
   let recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
-  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0, minFolgaPositivaEmp: number | null = null;
+  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0, minFolgaPositivaEmp: number | null = null, minFolgaPositivaReceitaEmp: number | null = null;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -328,7 +330,7 @@ export function montarCelulasComboEVP(input: {
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
     if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
     if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
-        && (minFolgaPositivaEmp == null || cel.folga_hurdle_pp < minFolgaPositivaEmp)) minFolgaPositivaEmp = cel.folga_hurdle_pp;
+        && (minFolgaPositivaEmp == null || cel.folga_hurdle_pp < minFolgaPositivaEmp)) { minFolgaPositivaEmp = cel.folga_hurdle_pp; minFolgaPositivaReceitaEmp = cel.receita_liquida; }
   }
   // empresa.evp só é um total honesto se NADA foi omitido/indisponível; senão null (Codex: não fingir total).
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null;
@@ -339,7 +341,7 @@ export function montarCelulasComboEVP(input: {
     evp_perda_garantida: perdaNull ? null : perda,
     evp: empresaCompleta && !conhecidoNull ? conhecido : null,
     evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp,
-    qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, min_folga_positiva_pp: minFolgaPositivaEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
+    qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, min_folga_positiva_pp: minFolgaPositivaEmp, min_folga_positiva_receita: minFolgaPositivaReceitaEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido,
   };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return {

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -122,8 +122,11 @@ export default function FinanceiroValorCockpit() {
           {data.empresa.qtd_combos_quase_sensiveis > 0 && (
             <> · <span className="text-muted-foreground">{data.empresa.qtd_combos_quase_sensiveis} quase-frágil(eis) (folga fina, +5 a +10pp do hurdle)</span></>
           )}
-          {data.empresa.min_folga_positiva_pp != null && (
-            <> · <span className="text-status-warning">próximo combo lucrativo zera com +{(data.empresa.min_folga_positiva_pp * 100).toFixed(1)}pp de Ke</span></>
+          {/* Locator, NÃO severidade (/codex challenge #1044): só mostra quando o combo vencedor é MATERIAL (≥ sample_min_receita);
+              senão um combo ínfimo (R$50 a +6pp) viraria alarme falso AMBER. Por isso muted-foreground + a receita no texto. */}
+          {data.empresa.min_folga_positiva_pp != null && data.empresa.min_folga_positiva_receita != null
+            && data.empresa.min_folga_positiva_receita >= data.config.sample_min_receita && (
+            <> · <span className="text-muted-foreground">próximo combo lucrativo ({brl(data.empresa.min_folga_positiva_receita)}) zera com +{(data.empresa.min_folga_positiva_pp * 100).toFixed(1)}pp de Ke</span></>
           )}
         </p>
       )}

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1006,6 +1006,7 @@ export interface CockpitRollupCliente {
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
   min_folga_positiva_pp: number | null;  // menor folga POSITIVA fora do fio: "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum
+  min_folga_positiva_receita: number | null;  // receita do combo DONO do min — LOCATOR: a UI suprime o headline quando imaterial (< sample_min_receita)
   nome?: string | null;  // nome do cliente (profiles via customer_user_id) — UI mostra no lugar do código
 }
 export interface CockpitRollupSKU {
@@ -1023,6 +1024,7 @@ export interface CockpitRollupSKU {
   qtd_combos_sensiveis: number;  // combos REAIS frágeis ao hurdle (break-even na banda 25-35%)
   qtd_combos_quase_sensiveis: number;  // combos REAIS quase-frágeis (break-even na faixa 35-40%): geram valor mas folga fina ao hurdle
   min_folga_positiva_pp: number | null;  // menor folga POSITIVA fora do fio: "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum
+  min_folga_positiva_receita: number | null;  // receita do combo DONO do min — LOCATOR: a UI suprime o headline quando imaterial (< sample_min_receita)
   descricao?: string | null;  // descrição do produto (omie_products) — UI mostra no lugar do código SKU
 }
 // Empresa DECOMPOSTA (capital parcial → um único evp seria mentira contábil; Codex 2026-06-23).
@@ -1041,6 +1043,7 @@ export interface CockpitEmpresaEVP {
   qtd_combos_sensiveis: number;     // combos REAIS no fio da navalha (granularidade que o agregado robusto esconde)
   qtd_combos_quase_sensiveis: number; // combos REAIS quase-frágeis (break-even em (k+δ, k+2δ]): geram valor mas folga fina — tira a falsa robustez residual
   min_folga_positiva_pp: number | null; // menor folga POSITIVA fora do fio: "próximo combo lucrativo zera com +X pp de Ke"; null se nenhum (sinal contínuo, complementa a contagem)
+  min_folga_positiva_receita: number | null; // receita do combo DONO do min — LOCATOR, não severidade: a UI suprime o headline quando imaterial (< sample_min_receita)
   capital_conhecido: number | null; // Σ capital das células reais → deriva EVP a outros hurdles
 }
 export interface ValorCockpitResult {

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -193,10 +193,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
   });
   type Cel = typeof celulas[number];
   const rollup = (keyFn: (c: Cel) => string) => {
-    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; minFolgaPositiva: number | null }>();
+    const m = new Map<string, { receita: number; quantidade: number; cm: number; cmNull: boolean; encargo: number; encargoNull: boolean; encargoTotal: number; encargoTotalNull: boolean; evp: number; evpNull: boolean; evpTeto: number; evpTetoNull: boolean; evpIncompleto: boolean; perdaGarantida: boolean; cmIncompleto: boolean; qtdSensiveis: number; qtdQuaseSensiveis: number; minFolgaPositiva: number | null; minFolgaPositivaReceita: number | null }>();
     for (const cel of celulas) {
       const key = keyFn(cel);
-      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, minFolgaPositiva: null };
+      const acc = m.get(key) ?? { receita: 0, quantidade: 0, cm: 0, cmNull: true, encargo: 0, encargoNull: true, encargoTotal: 0, encargoTotalNull: true, evp: 0, evpNull: true, evpTeto: 0, evpTetoNull: true, evpIncompleto: false, perdaGarantida: false, cmIncompleto: false, qtdSensiveis: 0, qtdQuaseSensiveis: 0, minFolgaPositiva: null, minFolgaPositivaReceita: null };
       acc.receita += cel.receita_liquida; acc.quantidade += cel.quantidade;
       if (cel.cm == null) acc.cmIncompleto = true;
       if (cel.encargo != null) { acc.encargoTotal += cel.encargo; acc.encargoTotalNull = false; }
@@ -207,20 +207,21 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
       if (cel.evp_status === 'teto_nao_positivo') acc.perdaGarantida = true;
       if (cel.sensivel_hurdle) acc.qtdSensiveis++;
       if (cel.quase_sensivel_hurdle) acc.qtdQuaseSensiveis++; // espelho de src (quase-frágil, lado bom)
+      // espelho de src: min folga POSITIVA fora do fio + receita do MESMO combo vencedor (locator p/ a UI suprimir headline imaterial — /codex #1044)
       if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
-          && (acc.minFolgaPositiva == null || cel.folga_hurdle_pp < acc.minFolgaPositiva)) acc.minFolgaPositiva = cel.folga_hurdle_pp;
+          && (acc.minFolgaPositiva == null || cel.folga_hurdle_pp < acc.minFolgaPositiva)) { acc.minFolgaPositiva = cel.folga_hurdle_pp; acc.minFolgaPositivaReceita = cel.receita_liquida; }
       m.set(key, acc);
     }
     return m;
   };
   const mc = rollup((c) => c.cliente);
   const ms = rollup((c) => c.sku);
-  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
-  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva }));
+  const porCliente = [...mc.entries()].map(([cliente, a]) => ({ cliente, receita: a.receita, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva, min_folga_positiva_receita: a.minFolgaPositivaReceita }));
+  const porSKU = [...ms.entries()].map(([sku, a]) => ({ sku, receita: a.receita, quantidade: a.quantidade, cm: a.cmNull ? null : a.cm, encargo: a.encargoNull ? null : a.encargo, encargo_total: a.encargoTotalNull ? null : a.encargoTotal, evp: a.evpNull ? null : a.evp, evp_teto: a.evpTetoNull ? null : a.evpTeto, evp_incompleto: a.evpIncompleto, perda_garantida: a.perdaGarantida, cm_incompleto: a.cmIncompleto, qtd_combos_sensiveis: a.qtdSensiveis, qtd_combos_quase_sensiveis: a.qtdQuaseSensiveis, min_folga_positiva_pp: a.minFolgaPositiva, min_folga_positiva_receita: a.minFolgaPositivaReceita }));
   let cmEmp = 0, cmNull = true, encEmp = 0, encNull = true, encTotalEmp = 0, encTotalNull = true, recEmp = 0;
   let conhecido = 0, conhecidoNull = true, tetoTotal = 0, tetoTotalNull = true, perda = 0, perdaNull = true;
   let evpIncompletoEmp = false, cmIncompletoEmp = false, recConhecido = 0, recOmitido = 0, recPerda = 0, recSemCm = 0;
-  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0, minFolgaPositivaEmp: number | null = null;
+  let qtdSensiveisEmp = 0, qtdQuaseSensiveisEmp = 0, capitalConhecido = 0, minFolgaPositivaEmp: number | null = null, minFolgaPositivaReceitaEmp: number | null = null;
   for (const cel of celulas) {
     recEmp += cel.receita_liquida;
     if (cel.cm == null) { cmIncompletoEmp = true; recSemCm += cel.receita_liquida; }
@@ -233,10 +234,10 @@ function montarCelulasComboEVP(input: { combos: ComboInput[]; capitalClientes: C
     if (cel.sensivel_hurdle) qtdSensiveisEmp++;
     if (cel.quase_sensivel_hurdle) qtdQuaseSensiveisEmp++;
     if (cel.evp_status === 'real' && !cel.sensivel_hurdle && cel.folga_hurdle_pp != null && cel.folga_hurdle_pp > 0
-        && (minFolgaPositivaEmp == null || cel.folga_hurdle_pp < minFolgaPositivaEmp)) minFolgaPositivaEmp = cel.folga_hurdle_pp;
+        && (minFolgaPositivaEmp == null || cel.folga_hurdle_pp < minFolgaPositivaEmp)) { minFolgaPositivaEmp = cel.folga_hurdle_pp; minFolgaPositivaReceitaEmp = cel.receita_liquida; }
   }
   const empresaCompleta = !evpIncompletoEmp && !cmIncompletoEmp && k != null; // evp único só se nada omitido/indisponível (Codex)
-  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, min_folga_positiva_pp: minFolgaPositivaEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
+  const empresa = { receita: recEmp, cm: cmNull ? null : cmEmp, encargo: encNull ? null : encEmp, encargo_total: encTotalNull ? null : encTotalEmp, evp_conhecido: conhecidoNull ? null : conhecido, evp_teto_total: tetoTotalNull ? null : tetoTotal, evp_perda_garantida: perdaNull ? null : perda, evp: empresaCompleta && !conhecidoNull ? conhecido : null, evp_incompleto: evpIncompletoEmp, cm_incompleto: cmIncompletoEmp, qtd_combos_sensiveis: qtdSensiveisEmp, qtd_combos_quase_sensiveis: qtdQuaseSensiveisEmp, min_folga_positiva_pp: minFolgaPositivaEmp, min_folga_positiva_receita: minFolgaPositivaReceitaEmp, capital_conhecido: conhecidoNull ? null : capitalConhecido };
   const pct = (x: number) => (recEmp > 0 ? x / recEmp : 0);
   return { celulas, porCliente, porSKU, empresa, evp_conhecido_receita_pct: pct(recConhecido), evp_omitido_otimista_receita_pct: pct(recOmitido), evp_perda_garantida_receita_pct: pct(recPerda), sem_cm_receita_pct: pct(recSemCm), hurdle_banda: k != null ? { base: k, lo: kLo, hi: kHi } : null };
 }


### PR DESCRIPTION
## O quê
Completa o #1058 (`min_folga_positiva_pp`) com o **companheiro de receita** `min_folga_positiva_receita`: a `receita_liquida` do combo dono do min. Implementa o **/codex challenge do #1044** — o headline é **locator, não severidade**.

## Por quê
O headline AMBER "próximo combo lucrativo zera com +X pp de Ke" dispara sempre que `min_folga_positiva_pp != null` — inclusive para combos ínfimos (R$50 a +6pp = alarme falso). Sem a receita do combo, vira ruído.

**Medição (psql-ro, Oben):** dos **3512 combos** cliente×SKU no TTM, **94,4% (3316) têm receita < R$5.000** (mediana R$373). Sem o gate, o headline seria ruído na esmagadora maioria.

## Mudança (cirúrgica, aditiva)
- **helper + edge (espelho verbatim):** ao escolher o min, guarda a `receita_liquida` do **mesmo combo vencedor** (não o de maior folga, não a soma), em porCliente/porSKU/empresa. `null` junto com o pp (ausente≠zero).
- **service:** 3 contratos tipados.
- **UI:** headline só quando **material** (`min_folga_positiva_receita >= sample_min_receita`) e em `text-muted-foreground`, exibindo a receita: "próximo combo lucrativo (R$Y) zera com +X,Xpp de Ke".

## Verificação
- helper **132 testes** (2 novos, TDD c/ falsificação — receita segue o min, não max/soma)
- suite **4106** · typecheck 0 · lint 0 · **deno check 0** · **mutcheck 27/27** (2 novas, ambas PEGAS)
- paridade helper×edge byte-idêntica · direção com bênção Codex tripla (#1044/#1058/#1061)

## Deploy (manual, pós-merge)
- Edge `fin-valor-cockpit` (chat Lovable, verbatim do repo) · Publish do frontend · **sem migration**

## Achado lateral (fora do escopo → follow-up)
O edge lê `cockpit_config` de `fin_config_cashflow`, mas essa coluna **não existe** → o cockpit sempre usa `CONFIG_DEFAULT` (sample_min_receita=5000). Erro silencioso pré-existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
