### PR TITLE
fix(valor-cockpit): edge lia cockpit_config de coluna inexistente → default explícito [money-path]

### DIFF
--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -382,17 +382,12 @@ serve(async (req: Request) => {
     const k = resolverHurdleCockpit(vi);
     const hurdle_indisponivel = k == null;
 
-    // Config (limiares)
-    const { data: cfgRow } = await db.from("fin_config_cashflow").select("cockpit_config").eq("company", COMPANY).maybeSingle();
-    const cfgRaw = ((cfgRow as { cockpit_config?: Record<string, unknown> } | null)?.cockpit_config ?? {}) as Record<string, unknown>;
-    const numOr = (x: unknown, d: number) => (typeof x === "number" && Number.isFinite(x) ? x : typeof x === "string" && x.trim() !== "" && Number.isFinite(Number(x)) ? Number(x) : d);
-    const config: CockpitConfig = {
-      margem_minima_pct: numOr(cfgRaw.margem_minima_pct, CONFIG_DEFAULT.margem_minima_pct),
-      desconto_max_pct: numOr(cfgRaw.desconto_max_pct, CONFIG_DEFAULT.desconto_max_pct),
-      prazo_alvo_dias: numOr(cfgRaw.prazo_alvo_dias, CONFIG_DEFAULT.prazo_alvo_dias),
-      dias_estoque_max: numOr(cfgRaw.dias_estoque_max, CONFIG_DEFAULT.dias_estoque_max),
-      sample_min_receita: numOr(cfgRaw.sample_min_receita, CONFIG_DEFAULT.sample_min_receita),
-    };
+    // Config (limiares). Config POR-EMPRESA ainda NÃO é persistida: não existe coluna `cockpit_config`
+    // em fin_config_cashflow — nem coluna, nem writer no app, nem UI (confirmado psql-ro 2026-06-25). O
+    // `.select("cockpit_config")` antigo lia uma coluna inexistente → 400 silencioso (erro ignorado) e
+    // caía nos defaults. Aqui o default fica EXPLÍCITO: mesmo comportamento efetivo, sem o 400 nem a falsa
+    // promessa de configurabilidade. Quando virar configurável: criar coluna + UI e ler aqui (com guard numOr).
+    const config: CockpitConfig = { ...CONFIG_DEFAULT };
 
     // FILTRO OBEN obrigatório: um pedido do app mistura itens das 3 empresas (Oben/Colacor/Colacor SC),
     // enviados separadamente. Sem o filtro por produto, o cockpit da Oben fica contaminado.


### PR DESCRIPTION
## O quê
O edge `fin-valor-cockpit` lia `cockpit_config` de `fin_config_cashflow`, mas **essa coluna nunca existiu**.

## Diagnóstico (psql-ro 2026-06-25)
- Nenhuma coluna `cockpit_config` em **nenhuma** tabela (`information_schema`: 0 linhas).
- **Ninguém** no frontend escreve `cockpit_config` (grep `src/`: 0).
- `thresholds` de `fin_config_cashflow` é config de **cashflow**, não cockpit.

→ O `.select("cockpit_config")` disparava **400 (42703)** a cada request; o edge ignorava o `error` e caía no `CONFIG_DEFAULT`. Erro silencioso + falsa promessa de config por-empresa.

## Fix (edge-only, sem migration)
Remove a query morta + `cfgRaw` + `numOr` local; usa `CONFIG_DEFAULT` explícito. **Comportamento efetivo idêntico** (sempre foi default, incluindo o `sample_min_receita=5000` que o gate do #1066 consome), agora sem o 400. Comentário documenta como tornar configurável (coluna + UI + leitura) se um dia for preciso.

## Verificação
- `deno check` 0 · sem refs órfãs (`numOrNull` do hurdle preservado)
- Sem migration · não toca frontend (sem Publish)

## Deploy (manual, pós-merge)
- Edge `fin-valor-cockpit` (chat Lovable, verbatim) — deployar **junto** com o #1066 (mesmo edge, uma vez só).

Achado durante a medição do #1066. Resolve o chip `task_6e7a74bc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
