### PR TITLE
docs(skill): lovable-deploy-verify — carimbo SHA vem "dev" em prod (sentinela obrigatória)

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -148,8 +148,11 @@ O build **carimba o commit no bundle** (`vite.config` → `define __COMMIT_SHA__
 - **Agendar** (cron de sistema, sem gastar Claude): `*/30 * * * * cd <repo> && bash .../monitor-deploy.sh
   >> ~/.config/afiacao/deploy-monitor.log 2>&1` (exit 3/4 = avisar; combine com `osascript`/email).
 
-⚠️ O carimbo só vale a partir do **1º Publish que inclua o `vite.config` novo** — e depende de o build do
-Lovable ter `.git` (senão o SHA vira `"dev"` e o monitor usa a sentinela). Provado local; o ar confirma no 1º Publish.
+⚠️ **Confirmado em prod (2026-06-26):** o ar serve `__BUILD_SHA__="dev"` — o build do Lovable roda **sem
+`.git`**, então o carimbo nunca materializa um SHA real e o caminho determinístico é **inviável neste host**.
+Consequência operacional: o monitor **depende SEMPRE da sentinela** (2º arg) — sem ela, exit 4 ("indeterminado")
+a cada run. E **passe a URL com `https://`**: sem esquema, o `curl` (sem `-L`) volta vazio e o monitor reporta
+falso `"fora do ar"` (exit 2) — não é o site caído, é a URL malformada.
 
 ## Referências
 - CLAUDE.md §"Deploy do FRONTEND (app) — Publish MANUAL no Lovable" (a técnica dos bytes; armadilha do chunk de nome inesperado)
@@ -162,5 +165,5 @@ Lovable ter `.git` (senão o SHA vira `"dev"` e o monitor usa a sentinela). Prov
 - [x] `evals/` com classificação de diff (8 casos + runner + mutation-check; espelha `lovable-db-operator/evals`).
 - [x] Domínio canônico `steu.lovable.app` confirmado (HTTP 200).
 - [x] **Edge:** verificação por escada — N1 existência (`verify-edge.sh`, OPTIONS, automático) · N2 versão (Management API, handoff de PAT) · N3 comportamento (probe gated). Fecha a assimetria com o frontend.
-- [x] **Smoke E2E autônomo:** carimbo de SHA no build (`__BUILD_SHA__`) + `monitor-deploy.sh` (cron) compara o ar vs `origin/main`. Provado local; **falta o 1º Publish ativar o carimbo no ar** (e confirmar que o Lovable tem `.git` no build — senão cai pra sentinela).
+- [x] **Smoke E2E autônomo:** carimbo de SHA no build (`__BUILD_SHA__`) + `monitor-deploy.sh` (cron) compara o ar vs `origin/main`. **Exercido em prod 2026-06-26** (pós-Publish do #1065): o carimbo está no ar mas vem `"dev"` (Lovable builda sem `.git`) ⇒ SHA determinístico inviável neste host; **fallback de sentinela validado ponta-a-ponta** (`get_ultimos_precos_cliente` PRESENTE → exit 0). Regra firmada: no cron, **sentinela obrigatória + URL com `https://`** (ver ⚠️ acima).
 - [ ] (menor) Confirmar se há ambiente de **preview** distinto do publicado a checar.


### PR DESCRIPTION
Fecha a *"pendência única"* da skill (smoke E2E num Publish real), com achado concreto.

## Exercido em prod (2026-06-26, pós-Publish do #1065)
- `monitor-deploy.sh` rodou ponta-a-ponta: `main=9a3780bd · ar=dev · fallback sentinela PRESENTE → exit 0`.
- **Achado:** o carimbo `__BUILD_SHA__` **está no ar, mas vem `"dev"`** → o build do Lovable roda **sem `.git`**. Logo o caminho **determinístico por SHA é inviável neste host**; o **fallback de sentinela é o caminho** e foi validado (`get_ultimos_precos_cliente` presente nos bytes).
- **Bug operacional documentado:** URL sem `https://` → `curl` sem esquema volta vazio → falso `"fora do ar"` (exit 2). No cron: **sentinela obrigatória + URL completa**.

## Mudança
Doc-only na `SKILL.md` (⚠️ do carimbo + entrada "Estado/pendências"). Sem código/script alterado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)