### PR TITLE
fix(valor-cockpit): trata erro de leitura da cockpit_config + expõe config_fallback [money-path]

### DIFF
--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1064,6 +1064,7 @@ export interface ValorCockpitResult {
   sem_cm_receita_pct?: number;
   hurdle_banda?: { base: number; lo: number; hi: number } | null; // banda da sensibilidade (lo/base/hi → 25/30/35%)
   config: CockpitConfig;
+  config_fallback?: boolean; // true = cockpit_config lida com ERRO/ausência → CONFIG_DEFAULT usado por FALHA, não por escolha (degradação honesta money-path)
 }
 
 // ═══════════════ A4 — Próxima Melhor Ação (contrato com fin-next-best-action) ═══════════════

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -381,8 +381,14 @@ serve(async (req: Request) => {
     const k = resolverHurdleCockpit(vi);
     const hurdle_indisponivel = k == null;
 
-    // Config (limiares)
-    const { data: cfgRow } = await db.from("fin_config_cashflow").select("cockpit_config").eq("company", COMPANY).maybeSingle();
+    // Config (limiares). Degradação HONESTA (money-path: ausente≠silencioso): captura o error do
+    // PostgREST em vez de engolir. config_fallback distingue "default por FALHA de leitura/ausência"
+    // de "default por config vazia LEGÍTIMA" ({} explícito). Era um silent-discard: coluna
+    // cockpit_config ausente (migration custom não-aplicada no Lovable) → 42703 mudo a cada request
+    // (página + composição A4) → sempre CONFIG_DEFAULT sem nenhum sinal. Coluna lida defensiva (numOr).
+    const { data: cfgRow, error: cfgError } = await db.from("fin_config_cashflow").select("cockpit_config").eq("company", COMPANY).maybeSingle();
+    const config_fallback = cfgError != null || cfgRow == null;
+    if (config_fallback) console.warn(`[ValorCockpit][${COMPANY}] cockpit_config indisponível (${cfgError ? `erro ${cfgError.code ?? "?"}: ${cfgError.message}` : "linha de config ausente"}) → usando CONFIG_DEFAULT`);
     const cfgRaw = ((cfgRow as { cockpit_config?: Record<string, unknown> } | null)?.cockpit_config ?? {}) as Record<string, unknown>;
     const numOr = (x: unknown, d: number) => (typeof x === "number" && Number.isFinite(x) ? x : typeof x === "string" && x.trim() !== "" && Number.isFinite(Number(x)) ? Number(x) : d);
     const config: CockpitConfig = {
@@ -603,6 +609,7 @@ serve(async (req: Request) => {
       sem_cm_receita_pct: res.sem_cm_receita_pct,
       hurdle_banda: res.hurdle_banda, // banda da sensibilidade (sem isto a UI nunca mostra 25/30/35 — P1 /codex)
       config,
+      config_fallback, // money-path: true = config caiu no default por FALHA de leitura (erro/ausência), não por escolha
     }, 200);
   } catch (e) {
     return jsonResponse({ error: e instanceof Error ? e.message : String(e) }, 500);


### PR DESCRIPTION
## Problema

A migration `20260524000000_fin_a3_cockpit_config.sql` ficou **órfã**: o Lovable não auto-aplica migration de nome custom, então a coluna `fin_config_cashflow.cockpit_config` nunca existiu no banco. O edge `fin-valor-cockpit` (A3, Oben — money-path) fazia `.select("cockpit_config")` → PostgREST **42703** → o `error` era **descartado** → `cfgRaw={}` → o cockpit caía **sempre** no `CONFIG_DEFAULT`.

Efeito: a config do cockpit (limiares de margem/desconto/prazo/estoque que alimentam `recomendarAcaoComercial`) era **não-configurável**, e o 42703 disparava a cada abertura da página **e** na composição do A4. Causa raiz confirmada via psql-ro (`information_schema`: 0 colunas `cockpit_config`).

## Fix

- **Edge** (`supabase/functions/fin-valor-cockpit/index.ts`): captura o `error` do PostgREST (degradação honesta — money-path: ausente≠silencioso), `console.warn` ao cair no default, e expõe `config_fallback` no JSON (distingue "default por **falha** de leitura" de "config vazia **legítima**").
- **Contrato** (`src/services/financeiroService.ts`): `config_fallback?: boolean` em `ValorCockpitResult`.
- **Banco**: a coluna é criada pela migration órfã existente — **dedicada** (não dentro de `thresholds`, que é multi-writer A1/funding → risco de upsert destrutivo), **sem seed** (`{}`, o código segue fonte do default). **Já aplicada e verificada nesta sessão** via psql-ro (`jsonb NOT NULL DEFAULT '{}'`, 3 linhas com `{}`).

2ª opinião: **Codex consult (high)** convergiu na coluna dedicada + hardening; o seed foi deixado de fora por acoplamento banco↔código.

## Verificação

- `bun run typecheck` ✅
- `deno check` do edge ✅
- `bun run test` ✅ (4104 testes, incl. paridade espelhada src×edge: `cost-source.parity.test.ts`)

## ⚠️ Deploy manual (Lovable não auto-deploya)

- **DB** ✅ **já aplicado**: `ALTER TABLE fin_config_cashflow ADD COLUMN IF NOT EXISTS cockpit_config jsonb NOT NULL DEFAULT '{}'` (migration `20260524000000`). Validado: coluna existe.
- **Edge** ⏳ **pendente**: redeploy de `fin-valor-cockpit` pelo chat do Lovable (ler o arquivo do repo verbatim) — habilita o `config_fallback`/warn. O bug **já está resolvido só com a coluna**; o redeploy é o hardening.
- **Frontend**: sem Publish (só tipo TS, runtime inalterado).

## Follow-up

- `sample_min_receita` é **dead config** (declarada, propagada, nunca consumida em runtime; o headline usa `min_folga_positiva_pp`) — chip `task_10f4e25a`: implementar o gate de materialidade ou remover do contrato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
