### PR TITLE
fix(pricing): analyze-unified-order para de ler sph poluída no price path [money-path]

### DIFF
--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -529,10 +529,11 @@ export function useCustomerSelection({
       }
 
       // ── Publica preço (LOCAL) + parcela ANTES do auto-cadastro ──
-      // Fase 1: o preço-cliente = último preço praticado do `sales_price_history`
-      // (rápido, estável, determinístico). Sem overlay do Omie (removido p/ matar a
-      // colisão de rate-limit). O mesmo mapa local vai p/ as 2 contas — limitação
-      // pré-existente (produtos são account-aware); corrigida na Fase 2 account-aware.
+      // Fase 1: o preço-cliente = último preço praticado lido de `order_items` (FONTE DE VERDADE,
+      // via RPC get_ultimos_precos_cliente — NÃO mais `sales_price_history`, poluída pelo writer
+      // legado aposentado). Rápido, estável, determinístico. Sem overlay do Omie (removido p/ matar
+      // a colisão de rate-limit). O mesmo mapa local vai p/ as 2 contas — limitação pré-existente
+      // (produtos são account-aware); corrigida na Fase 2 account-aware.
       const localPricesByOmie = await resolveLocalPricesByOmieCode(localPriceResult.data || null);
       if (isStale()) return;
 

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -1199,34 +1199,25 @@ Responda SEMPRE usando a função identify_order_items.`;
       try {
         const priceMap: Record<string, number> = {};
 
-        // 1) Local DB: order_items + sales_price_history
+        // 1) Local DB: order_items (FONTE DE VERDADE). `sales_price_history` REMOVIDO daqui — o
+        // writer legado omie-analytics-sync (aposentado) poluiu a sph com created_at de CARGA, e a
+        // leitura por created_at DESC mascarava o preço (3.995 duplicatas com-pedido; 854 com
+        // unit_price divergente = ambíguo, intocável sem identidade de linha Omie). order_items
+        // cobre 99,84% dos pares (cliente,produto) da sph; o resto cai no fallback Omie abaixo.
+        // Espelha o Caminho B já feito no hook (RPC get_ultimos_precos_cliente). created_at de
+        // order_items = data real do pedido (trigger #1047), não data de carga.
         if (validCustomer?.user_id) {
-          const [orderItemsRes, salesPricesRes] = await Promise.all([
-            supabase
-              .from("order_items")
-              .select("product_id, unit_price")
-              .eq("customer_user_id", validCustomer.user_id)
-              .order("created_at", { ascending: false })
-              .limit(200),
-            supabase
-              .from("sales_price_history")
-              .select("product_id, unit_price")
-              .eq("customer_user_id", validCustomer.user_id)
-              .order("created_at", { ascending: false })
-              .limit(200),
-          ]);
+          const { data: orderItemsData } = await supabase
+            .from("order_items")
+            .select("product_id, unit_price")
+            .eq("customer_user_id", validCustomer.user_id)
+            .order("created_at", { ascending: false })
+            .limit(200);
 
-          if (orderItemsRes.data) {
-            for (const ph of orderItemsRes.data) {
+          if (orderItemsData) {
+            for (const ph of orderItemsData) {
               if (ph.product_id && !priceMap[ph.product_id]) {
                 priceMap[ph.product_id] = ph.unit_price;
-              }
-            }
-          }
-          if (salesPricesRes.data) {
-            for (const sp of salesPricesRes.data) {
-              if (!priceMap[sp.product_id]) {
-                priceMap[sp.product_id] = sp.unit_price;
               }
             }
           }


### PR DESCRIPTION
Fecha o resíduo da Fase 2f — mas **não** via dedup (que seria teatro money-path), e sim removendo o leitor.

## O que muda
- **`analyze-unified-order` (edge):** remove a leitura de `sales_price_history` do price path. Sobra `order_items` (created_at real via trigger #1047) → fallback Omie. order_items cobre **99,84%** dos pares (cliente,produto) da sph; o resto degrada p/ Omie/sem-sugestão (precision>recall).
- **`useCustomerSelection.ts` (hook):** corrige comentário stale que ainda apontava `sph` como fonte de preço (já é a RPC `get_ultimos_precos_cliente` sobre order_items).

## Por que não dedup
A dedup só pode tocar os **931 grupos de preço IGUAL** — que já devolvem o preço certo em todo leitor (analyze first-wins, audit MAX, hook presença). Os **854 ambíguos** (preço divergente) são intocáveis sem identidade de linha Omie. Logo a dedup é higiene cosmética que **não elimina o resíduo**. Remover o leitor elimina, sem `DELETE` nem perda de dado.

## Codex challenge (2ª opinião money-path, adversarial)
Confirmou "dedup = teatro". Me corrigiu em 2 fatos: o Omie faz **OVERRIDE** (não fallback) do preço local (linha 1318), e o `algorithm-a-audit` `MAX` **pode inflar** pelos divergentes (não é imune). Preferiu migrar p/ a RPC — **divergi**: a RPC tem gate `has_role(auth.uid())` e o edge roda com **service_role** (`auth.uid()`=null → `42501`); migrar = mexer em auth por ganho marginal (o Omie override já domina o preço final).

## Verificação
- `deno check` no edge: **15 erros = 15 na main** (pré-existentes, edit type-neutral; diff de mensagens vazio).
- `typecheck` (src): exit 0. `eslint` hook: exit 0.

## Handoff (founder)
- **Deploy do edge `analyze-unified-order`** via chat do Lovable (verbatim da main pós-merge). SEM migration. O hook é só comentário (não muda bytes → Publish opcional).

## Achados SEPARADOS do Codex (follow-up, fora deste escopo)
1. **Omie OVERRIDE → fallback**: o Omie sobrescreve o preço local praticado. Decisão de produto (autoridade: Omie atual vs último praticado), ortogonal à poluição sph.
2. **`algorithm-a-audit` lê sph** p/ `bestPriceMap=MAX`: os 854 divergentes podem inflar. Auditoria (não runtime de pedido); migrar muda semântica de janela.
3. **Migrar analyze p/ a RPC**: melhoria de janela 200, mas esbarra no gate has_role vs service_role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)