### PR TITLE
fix(pricing): Omie fallback no analyze + audit lê order_items praticados [money-path]

### DIFF
--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -186,11 +186,15 @@ Deno.serve(async (req) => {
       (q) => q.gte('created_at', periodStartDate.toISOString()) as SupabaseQuery);
     console.log(`[algorithm-a-audit] Found ${recentOrders.length} order items (365d)`);
 
-    // Get best prices per product (paginated)
-    const allSalesPrices = await fetchAllPaginated<SalesPriceRow>(supabase, 'sales_price_history',
+    // Get best prices per product (paginated). FONTE = order_items (verdade), NÃO sales_price_history:
+    // o writer legado aposentado poluiu a sph com duplicatas divergentes que inflavam o MAX (medido
+    // psql-ro: 5 produtos com MAX(sph) > MAX(order_items), 1 em 2,45×) → margin_potential/margin_gap
+    // superestimados. order_items dá o mesmo "best price achieved", sem poluição. unit_price>0 corta
+    // linhas zeradas. Mesma semântica (MAX por produto, all-time).
+    const allSalesPrices = await fetchAllPaginated<SalesPriceRow>(supabase, 'order_items',
       'product_id, unit_price',
-      (q) => q.order('unit_price', { ascending: false }) as SupabaseQuery);
-    console.log(`[algorithm-a-audit] Found ${allSalesPrices.length} sales price records`);
+      (q) => q.gt('unit_price', 0).order('unit_price', { ascending: false }) as SupabaseQuery);
+    console.log(`[algorithm-a-audit] Found ${allSalesPrices.length} order_items price records`);
 
     // Build best price map (highest price achieved per product = potential)
     const bestPriceMap: Record<string, number> = {};

--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -186,19 +186,36 @@ Deno.serve(async (req) => {
       (q) => q.gte('created_at', periodStartDate.toISOString()) as SupabaseQuery);
     console.log(`[algorithm-a-audit] Found ${recentOrders.length} order items (365d)`);
 
-    // Get best prices per product (paginated). FONTE = order_items (verdade), NÃO sales_price_history:
-    // o writer legado aposentado poluiu a sph com duplicatas divergentes que inflavam o MAX (medido
-    // psql-ro: 5 produtos com MAX(sph) > MAX(order_items), 1 em 2,45×) → margin_potential/margin_gap
-    // superestimados. order_items dá o mesmo "best price achieved", sem poluição. unit_price>0 corta
-    // linhas zeradas. Mesma semântica (MAX por produto, all-time).
-    const allSalesPrices = await fetchAllPaginated<SalesPriceRow>(supabase, 'order_items',
-      'product_id, unit_price',
-      (q) => q.gt('unit_price', 0).order('unit_price', { ascending: false }) as SupabaseQuery);
-    console.log(`[algorithm-a-audit] Found ${allSalesPrices.length} order_items price records`);
+    // Best price por produto, de order_items PRATICADOS (verdade) — NÃO sales_price_history (poluída
+    // pelo writer legado aposentado). DOIS filtros importam:
+    //  (a) fonte = order_items, não sph: as duplicatas divergentes da sph inflavam o MAX (medido
+    //      psql-ro: 5 produtos com MAX(sph) > MAX(order_items)).
+    //  (b) só pedidos PRATICADOS (exclui cancelado/orcamento/deletado; espelha get_ultimos_precos_cliente):
+    //      sem isso, um order_item de orçamento com preço absurdo (medido: 1 produto em 822.326× o
+    //      praticado = erro de digitação num não-pedido) destruiria margin_potential/margin_gap.
+    // Só ~16 pedidos excluídos no total → Set client-side é trivial (evita .or()/embedded frágil; o
+    // .not()/COALESCE de status é NULL-blind no PostgREST — filtrar em memória trata NULL como praticado).
+    const [deletedOrders, naoPraticados] = await Promise.all([
+      fetchAllPaginated<{ id: string }>(supabase, 'sales_orders', 'id',
+        (q) => q.not('deleted_at', 'is', null) as SupabaseQuery),
+      fetchAllPaginated<{ id: string }>(supabase, 'sales_orders', 'id',
+        (q) => q.in('status', ['cancelado', 'orcamento']) as SupabaseQuery),
+    ]);
+    const excludedOrderIds = new Set<string>([
+      ...deletedOrders.map((o) => o.id),
+      ...naoPraticados.map((o) => o.id),
+    ]);
 
-    // Build best price map (highest price achieved per product = potential)
+    const allSalesPrices = await fetchAllPaginated<SalesPriceRow & { sales_order_id: string }>(
+      supabase, 'order_items', 'product_id, unit_price, sales_order_id',
+      (q) => q.gt('unit_price', 0).order('unit_price', { ascending: false }) as SupabaseQuery);
+    console.log(`[algorithm-a-audit] Found ${allSalesPrices.length} order_items price records (${excludedOrderIds.size} pedidos excluídos: cancelado/orcamento/deletado)`);
+
+    // Build best price map (highest PRACTICED price per product = potential)
     const bestPriceMap: Record<string, number> = {};
     allSalesPrices.forEach(sp => {
+      if (excludedOrderIds.has(sp.sales_order_id)) return;   // não-praticado (cancelado/orcamento/deletado)
+      if (sp.unit_price == null) return;
       if (!bestPriceMap[sp.product_id] || sp.unit_price > bestPriceMap[sp.product_id]) {
         bestPriceMap[sp.product_id] = Number(sp.unit_price);
       }

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -1301,12 +1301,17 @@ Responda SEMPRE usando a função identify_order_items.`;
 
             const omieResults = await Promise.all(omiePricePromises);
             
-            // Merge Omie prices - Omie takes priority over local
+            // Merge Omie prices — FALLBACK: só preenche produtos SEM preço local (order_items vence).
+            // Era OVERRIDE, mas fetchOmiePrices pega o "primeiro encontrado" do ListarPedidos (pagina 1,
+            // 50 reg, SEM ordenar_por) = ordem NÃO garantida → podia mascarar o último preço PRATICADO
+            // (order_items, ordenado por created_at real DESC, trigger #1047). order_items é a fonte de
+            // verdade do praticado; o Omie cobre só os gaps (produtos sem pedido local). Alinha com o
+            // hook useCustomerSelection (#1065, que já tirou o overlay do Omie do preço-cliente).
             for (const omiePrices of omieResults) {
               for (const [omieCode, price] of Object.entries(omiePrices)) {
                 const productId = omieCodeMap[Number(omieCode)];
-                if (productId && price > 0) {
-                  priceMap[productId] = price; // Omie overrides local
+                if (productId && price > 0 && !priceMap[productId]) {
+                  priceMap[productId] = price; // só preenche gap
                 }
               }
             }
@@ -1324,11 +1329,11 @@ Responda SEMPRE usando a função identify_order_items.`;
                   for (const pm of extraMappings) {
                     omieCodeMap[pm.omie_codigo_produto] = pm.id;
                   }
-                  // Re-apply Omie prices with new mappings
+                  // Re-apply Omie prices with new mappings (mesma semântica FALLBACK: só gaps)
                   for (const omiePrices of omieResults) {
                     for (const [omieCode, price] of Object.entries(omiePrices)) {
                       const productId = omieCodeMap[Number(omieCode)];
-                      if (productId && price > 0) {
+                      if (productId && price > 0 && !priceMap[productId]) {
                         priceMap[productId] = price;
                       }
                     }


### PR DESCRIPTION
Resolve os 3 follow-ups do Codex (do #1074). Dois Codex challenges (decisão + diff) conduzidos; o 2º pegou um bug que **corrigi antes do deploy**.

## #1 — analyze-unified-order: Omie OVERRIDE → FALLBACK ✅
O merge do Omie sobrescrevia o preço local. Mas `fetchOmiePrices` pega o "primeiro encontrado" do `ListarPedidos` (pagina 1, 50 reg, **sem** `ordenar_por`) = ordem não-garantida → mascarava o último preço **praticado** (`order_items`, `created_at` real via trigger #1047). Vira **fallback** (`&& !priceMap[productId]` nos 2 loops): order_items vence, Omie só preenche gaps. Alinha com o hook (#1065).
- **Codex:** confirmou; o único risco é preço stale em janela de **sync-lag** (pedido novo ainda não sincronizado). Aceito — precision>recall (último praticado conhecido > preço de ordem arbitrária do Omie). Não bloqueia deploy.

## #2 — algorithm-a-audit: bestPriceMap de `order_items` PRATICADOS ✅
`bestPriceMap` (MAX por produto → `margin_potential`/`margin_gap`) lia `sales_price_history` poluída. Troca pra `order_items`, **mas com filtro de praticados**:
- **Codex pegou:** `order_items` cru inclui orçamentos/cancelados. **Medição psql-ro: 1 produto com MAX(todos) = 822.326× o MAX(praticados)** — um order_item de não-pedido (erro de digitação) que **destruiria** a auditoria de margem.
- **Correção:** exclui `deleted_at`/`cancelado`/`orcamento` (espelha `get_ultimos_precos_cliente`) via `Set` dos ~16 pedidos excluídos (evita `.or()`/embedded NULL-blind). Medido: o filtro resolve o caso 822k×.

## #3 — migrar analyze pra RPC ❌ (não feito, documentado)
A RPC `get_ultimos_precos_cliente` tem gate `has_role(auth.uid())` e o edge roda com **service_role** (`auth.uid()`=null → `42501`). Migrar = mexer em auth por ganho marginal.

## Verificação
- `deno check`: analyze **15=15** (type-neutral); audit **0 erros** (conserta o `TS18047` pré-existente).
- 2× Codex challenge (719k tokens). 2º não conseguiu falsificar como bloqueador; o achado do filtro foi corrigido.

## Handoff (founder) — deploy de 2 edges (verbatim da main pós-merge, via chat do Lovable)
1. `analyze-unified-order` (preço sugerido no pedido)
2. `algorithm-a-audit` (cron de margem) — **smoke pós-deploy:** rodar 1× e conferir que `margin_audit_log` novo não tem gap absurdo. SEM migration.

## Achado pré-existente (fora de escopo, reporto)
`recentOrders` (margem REAL, linha ~184) também lê `order_items` sem filtrar status — mesmo padrão. Não toquei; candidato a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)