### PR TITLE
fix(audit): margem REAL também só de pedidos praticados (completa o #1077) [money-path]

### DIFF
--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -100,6 +100,7 @@ interface OrderItemRow {
   quantity: number | null;
   unit_price: number | null;
   discount: number | null;
+  sales_order_id: string;
 }
 
 interface SalesPriceRow {
@@ -182,7 +183,7 @@ Deno.serve(async (req) => {
     periodStartDate.setDate(periodStartDate.getDate() - 365);
 
     const recentOrders = await fetchAllPaginated<OrderItemRow>(supabase, 'order_items',
-      'customer_user_id, product_id, quantity, unit_price, discount',
+      'customer_user_id, product_id, quantity, unit_price, discount, sales_order_id',
       (q) => q.gte('created_at', periodStartDate.toISOString()) as SupabaseQuery);
     console.log(`[algorithm-a-audit] Found ${recentOrders.length} order items (365d)`);
 
@@ -225,9 +226,13 @@ Deno.serve(async (req) => {
     const costMap: Record<string, ProductCostRow> = {};
     productCosts.forEach(pc => { costMap[pc.product_id] = pc; });
 
-    // Group orders by customer
+    // Group orders by customer — só pedidos PRATICADOS (mesmo excludedOrderIds do bestPriceMap).
+    // A margem REAL também não pode incluir orçamento/cancelado/deletado: medido psql-ro, há 26 linhas
+    // de não-pedidos na janela 365d, uma com unit_price de R$ 615 MI (erro de digitação num orçamento)
+    // que destruiria margin_real do cliente. Consistente com o potencial (ambos = praticado).
     const customerOrders: Record<string, typeof recentOrders> = {};
     recentOrders.forEach(oi => {
+      if (excludedOrderIds.has(oi.sales_order_id)) return;   // não-praticado
       if (!customerOrders[oi.customer_user_id]) customerOrders[oi.customer_user_id] = [];
       customerOrders[oi.customer_user_id].push(oi);
     });


### PR DESCRIPTION
Continuação do [#1077](https://github.com/LucasSardenbergL/afiacao/pull/1077): o `recentOrders` (margem REAL) ficou de fora do squash do #1077 (auto-merge pegou os commits anteriores antes deste chegar). Este PR o traz.

## O bug
O `recentOrders` (base da `margin_real`) lia `order_items` 365d **sem filtrar status** — mesmo bug que o `bestPriceMap` (corrigido no #1077). Medição psql-ro: **26 linhas de não-pedidos (orçamento/cancelado/deletado) na janela, uma com `unit_price` = R$ 615 MILHÕES** (erro de digitação) que destruiria a `margin_real` do cliente.

## A correção
Reusa o `excludedOrderIds` já computado no #1077 (Set dos ~16 pedidos cancelado/orcamento/deletado) e pula esses no agrupamento de `customerOrders`. Agora **potencial E real = praticado** → `margin_gap` consistente (sem isso, o #1077 deixaria gap = potencial-praticado − real-cru).

## Verificação
`deno check`: 0 erros. Mudança: +sales_order_id no tipo/select do recentOrders + skip no agrupamento.

## Handoff
Mesmo deploy do edge `algorithm-a-audit` do #1077 — agora deploya os DOIS fixes juntos (espere este mergear antes do deploy). Smoke: rodar o audit 1× e conferir que `margin_audit_log` não tem valor absurdo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)