### PR TITLE
feat(reposição): split estoque efetivo em físico + a caminho no item do pedido [money-path]

### DIFF
--- a/db/test-pedido-item-split-estoque.sh
+++ b/db/test-pedido-item-split-estoque.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — split estoque_fisico/estoque_a_caminho no item do pedido         ║
+# ║  Migration: 20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql      ║
+# ║  Prova: a RPC gerar_pedidos_sugeridos_ciclo EXECUTA (late-bound) e grava os    ║
+# ║  componentes; invariante fisico+a_caminho=efetivo; a_caminho capta pendente E  ║
+# ║  em-trânsito; cálculo de compra inalterado. Falsifica esquecendo em_transito.  ║
+# ║  Rode: bash db/test-pedido-item-split-estoque.sh > /tmp/t.log 2>&1; echo $?    ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5466}"
+SLUG="pedido-item-split-estoque"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1 — pré-requisitos: stubs das 11 tabelas que a RPC lê/altera ──
+P -q <<'SQL'
+CREATE TABLE public.pedido_compra_sugerido (
+  id bigserial PRIMARY KEY,
+  empresa text, fornecedor_nome text, grupo_codigo text, data_ciclo date,
+  horario_corte_planejado timestamptz, valor_total numeric, num_skus int,
+  status text, condicao_pagamento_codigo text, condicao_pagamento_descricao text,
+  num_parcelas int, dias_parcelas text, condicao_origem text,
+  status_envio_portal text, portal_protocolo text, omie_pedido_compra_numero text,
+  tipo_ciclo text, atualizado_em timestamptz
+);
+CREATE TABLE public.pedido_compra_item (
+  id bigserial PRIMARY KEY,
+  pedido_id bigint, sku_codigo_omie text, sku_descricao text,
+  estoque_atual numeric, ponto_pedido numeric, estoque_maximo numeric,
+  qtde_sugerida numeric, qtde_final numeric, preco_unitario numeric,
+  valor_linha numeric, primeira_compra boolean
+);
+CREATE TABLE public.sku_parametros (
+  empresa text, sku_codigo_omie text, sku_descricao text, fornecedor_nome text,
+  ponto_pedido numeric, estoque_maximo numeric, minimo_forcado_manual numeric,
+  habilitado_reposicao_automatica boolean, tipo_reposicao text
+);
+CREATE TABLE public.sku_grupo_producao (empresa text, sku_codigo_omie text, grupo_codigo text);
+CREATE TABLE public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_pendente_entrada numeric);
+CREATE TABLE public.fornecedor_habilitado_reposicao (empresa text, fornecedor_nome text, horario_corte_pedido interval, valor_maximo_mensal numeric, delta_max_perc numeric);
+CREATE TABLE public.omie_products (omie_codigo_produto text, account text, ativo boolean, descricao text, familia text, tipo_produto text, metadata jsonb);
+CREATE TABLE public.familia_nao_comprada (id bigserial PRIMARY KEY, empresa text, familia text);
+CREATE TABLE public.inventory_position (omie_codigo_produto text, account text, cmc numeric, synced_at timestamptz);
+CREATE TABLE public.sku_status_omie (empresa text, sku_codigo_omie text, ativo_no_omie boolean);
+CREATE TABLE public.sku_leadtime_history (empresa text, sku_codigo_omie text, quantidade_recebida numeric, valor_total numeric);
+SQL
+
+# ── ZONA 2 — aplicar a migration REAL ──
+MIG="$REPO_ROOT/supabase/migrations/20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ── ZONA 3 — seed: SKU1 (pendente puro: fis=2,pend=1) e SKU2 (em-trânsito puro: fis=0,pend=0,transito=4) ──
+P -q <<'SQL'
+-- guard tipo_produto_unhealthy exige >=1 omie_products(account='oben') com tipo_produto não-nulo
+INSERT INTO public.omie_products(omie_codigo_produto,account,ativo,descricao,familia,tipo_produto) VALUES
+ ('8689723601','oben',true,'SELADORA SEMI-BRILHO NLO.9506.00LT','SELADORA','01'),
+ ('SKU2','oben',true,'PRODUTO EM TRANSITO','FAM2','01');
+
+INSERT INTO public.sku_parametros(empresa,sku_codigo_omie,sku_descricao,fornecedor_nome,ponto_pedido,estoque_maximo,minimo_forcado_manual,habilitado_reposicao_automatica,tipo_reposicao) VALUES
+ ('OBEN','8689723601','SELADORA SEMI-BRILHO NLO.9506.00LT','RENNER SAYERLACK S/A',5,5,NULL,true,'automatica'),
+ ('OBEN','SKU2','PRODUTO EM TRANSITO','RENNER SAYERLACK S/A',10,10,NULL,true,'automatica');
+
+INSERT INTO public.sku_estoque_atual(empresa,sku_codigo_omie,estoque_fisico,estoque_pendente_entrada) VALUES
+ ('OBEN','8689723601',2,1),
+ ('OBEN','SKU2',0,0);
+
+INSERT INTO public.fornecedor_habilitado_reposicao(empresa,fornecedor_nome,horario_corte_pedido,valor_maximo_mensal,delta_max_perc) VALUES
+ ('OBEN','RENNER SAYERLACK S/A', INTERVAL '18:00', NULL, NULL);
+
+INSERT INTO public.inventory_position(omie_codigo_produto,account,cmc,synced_at) VALUES
+ ('8689723601','oben',1421.064, now()),
+ ('SKU2','oben',100, now());
+
+-- em-trânsito p/ SKU2: 1 pedido DISPARADO hoje com item qtde_final=4 (entra no CTE em_transito)
+INSERT INTO public.pedido_compra_sugerido(id,empresa,fornecedor_nome,grupo_codigo,data_ciclo,status,tipo_ciclo)
+  VALUES (9001,'OBEN','RENNER SAYERLACK S/A',NULL,CURRENT_DATE,'disparado','normal');
+INSERT INTO public.pedido_compra_item(pedido_id,sku_codigo_omie,sku_descricao,estoque_atual,ponto_pedido,estoque_maximo,qtde_sugerida,qtde_final,preco_unitario,valor_linha,primeira_compra)
+  VALUES (9001,'SKU2','PRODUTO EM TRANSITO',0,10,10,4,4,100,400,false);
+SQL
+
+# ── ZONA 4 — asserts ──
+echo "── asserts ──"
+# A1 — a RPC EXECUTA (pega bug late-bound) e gera 1 pedido pai
+GER=$(Pq -c "SELECT pedidos_gerados FROM gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);")
+eq "A1 RPC executa + gera 1 pedido" "$GER" "1"
+
+# A2 — SKU1 (pendente puro): fisico=2, a_caminho=1, efetivo=3
+S1=$(Pq -c "SELECT i.estoque_fisico||'/'||i.estoque_a_caminho||'/'||i.estoque_atual FROM pedido_compra_item i JOIN pedido_compra_sugerido p ON p.id=i.pedido_id WHERE p.status='pendente_aprovacao' AND i.sku_codigo_omie='8689723601';")
+eq "A2 SKU1 split fis/caminho/efetivo" "$S1" "2/1/3"
+
+# A3 — SKU2 (em-trânsito puro): fisico=0, a_caminho=4 (capta em_transito!), efetivo=4
+S2=$(Pq -c "SELECT i.estoque_fisico||'/'||i.estoque_a_caminho||'/'||i.estoque_atual FROM pedido_compra_item i JOIN pedido_compra_sugerido p ON p.id=i.pedido_id WHERE p.status='pendente_aprovacao' AND i.sku_codigo_omie='SKU2';")
+eq "A3 SKU2 a_caminho capta em_transito" "$S2" "0/4/4"
+
+# A4 — invariante money-path: fisico + a_caminho = estoque_atual (efetivo) p/ TODOS os itens novos
+VIOL=$(Pq -c "SELECT count(*) FROM pedido_compra_item i JOIN pedido_compra_sugerido p ON p.id=i.pedido_id WHERE p.status='pendente_aprovacao' AND i.estoque_fisico IS NOT NULL AND (i.estoque_fisico + i.estoque_a_caminho) <> i.estoque_atual;")
+eq "A4 invariante fis+caminho=efetivo (0 violações)" "$VIOL" "0"
+
+# A5 — cálculo de compra INALTERADO (SKU1 qtde_sugerida=ceil(5-3)=2, qtde_final=2)
+Q1=$(Pq -c "SELECT i.qtde_sugerida||'/'||i.qtde_final FROM pedido_compra_item i JOIN pedido_compra_sugerido p ON p.id=i.pedido_id WHERE p.status='pendente_aprovacao' AND i.sku_codigo_omie='8689723601';")
+eq "A5 SKU1 qtde de compra inalterada" "$Q1" "2/2"
+
+# ── ZONA 5 — FALSIFICAÇÃO: sabota esquecendo o em_transito → invariante deve QUEBRAR no SKU2 ──
+echo "── falsificação ──"
+SAB=$(mktemp /tmp/sab-${SLUG}.XXXXXX.sql)
+# troca (sn.estoque_pendente + sn.qtde_em_transito_recente) por só sn.estoque_pendente
+sed 's/(sn.estoque_pendente + sn.qtde_em_transito_recente)/sn.estoque_pendente/' "$MIG" > "$SAB"
+GREP_OK=$(grep -c 'sn.estoque_fisico, sn.estoque_pendente$' "$SAB" || true)
+P -q -f "$SAB"
+P -q -c "SELECT gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);" >/dev/null
+VIOL_SAB=$(Pq -c "SELECT count(*) FROM pedido_compra_item i JOIN pedido_compra_sugerido p ON p.id=i.pedido_id WHERE p.status='pendente_aprovacao' AND i.estoque_fisico IS NOT NULL AND (i.estoque_fisico + i.estoque_a_caminho) <> i.estoque_atual;")
+if [ "$GREP_OK" = "1" ] && [ "$VIOL_SAB" -ge 1 ]; then
+  ok "FALSIFICAÇÃO mordeu: esquecer em_transito → $VIOL_SAB item(ns) violam o invariante"
+else
+  bad "FALSIFICAÇÃO NÃO mordeu (grep=$GREP_OK viol=$VIOL_SAB) — assert sem dente"
+fi
+# restaura a versão verdadeira
+P -q -f "$MIG"
+P -q -c "SELECT gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);" >/dev/null
+VIOL_REST=$(Pq -c "SELECT count(*) FROM pedido_compra_item i JOIN pedido_compra_sugerido p ON p.id=i.pedido_id WHERE p.status='pendente_aprovacao' AND i.estoque_fisico IS NOT NULL AND (i.estoque_fisico + i.estoque_a_caminho) <> i.estoque_atual;")
+eq "A6 restaurado: invariante volta a fechar (0 violações)" "$VIOL_REST" "0"
+rm -f "$SAB"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **294** custom migrations totais
-- **1025** objetos esperados (criados por estas migrations)
+- **295** custom migrations totais
+- **1026** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 296
+  - `function`: 297
   - `rls_policy`: 220
   - `index`: 187
   - `table`: 108
@@ -2506,6 +2506,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.get_ultimos_precos_cliente` | — |
+
+### `20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
 
 ## Próximos passos quando algo der `❌`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 294
+-- Total de custom migrations: 295
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -313,7 +313,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260624020000', 'tactical_plans_split_rls_escrita', '20260624020000_tactical_plans_split_rls_escrita.sql'),
   ('20260624040000', 'tactical_plan_rpc_hardening_codex', '20260624040000_tactical_plan_rpc_hardening_codex.sql'),
   ('20260624170000', 'recencia_fonte_trigger_backfill', '20260624170000_recencia_fonte_trigger_backfill.sql'),
-  ('20260625120000', 'get_ultimos_precos_cliente', '20260625120000_get_ultimos_precos_cliente.sql')
+  ('20260625120000', 'get_ultimos_precos_cliente', '20260625120000_get_ultimos_precos_cliente.sql'),
+  ('20260626150457', 'pedido_item_split_estoque_fisico_a_caminho', '20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql')
 )
 SELECT
   e.version,
@@ -1356,7 +1357,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tactical_plan_rpc_hardening_codex', 'function', 'public', 'registrar_resultado_plano', ''),
   ('recencia_fonte_trigger_backfill', 'function', 'public', 'order_items_herdar_created_at_omie', ''),
   ('recencia_fonte_trigger_backfill', 'trigger', 'public', 'trg_order_items_created_at_omie', 'order_items'),
-  ('get_ultimos_precos_cliente', 'function', 'public', 'get_ultimos_precos_cliente', '')
+  ('get_ultimos_precos_cliente', 'function', 'public', 'get_ultimos_precos_cliente', ''),
+  ('pedido_item_split_estoque_fisico_a_caminho', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
 )
 SELECT
   e.migration,

--- a/src/components/reposicao/pedidos/ItensTable.tsx
+++ b/src/components/reposicao/pedidos/ItensTable.tsx
@@ -40,7 +40,12 @@ export function ItensTable({
       <TableHeader>
         <TableRow>
           <TableHead className="w-[34%] min-w-[300px]">SKU / Descrição</TableHead>
-          <TableHead className="text-right">Estoque atual</TableHead>
+          <TableHead
+            className="text-right"
+            title="Estoque efetivo = físico (saldo Omie) + a caminho (pendente de entrada + em trânsito). É o que o motor compara com o ponto de pedido — por isso pode ser maior que o saldo do Omie."
+          >
+            Estoque efetivo
+          </TableHead>
           <TableHead className="text-right">EM</TableHead>
           <TableHead className="text-right">PP</TableHead>
           <TableHead className="text-right">Emax</TableHead>
@@ -58,6 +63,11 @@ export function ItensTable({
           const pp = Number(l.ponto_pedido ?? 0);
           const zoneClass = getEstoqueZoneClass(estoque, minimo, pp);
           const sugerida = Number(l.qtde_sugerida ?? 0);
+          // Snapshot do split (físico + a caminho). Só decompõe quando há algo a caminho:
+          // sem isso o efetivo == físico e a sublinha seria ruído.
+          const fisico = l.estoque_fisico;
+          const aCaminho = l.estoque_a_caminho;
+          const temSplit = fisico != null && aCaminho != null && Number(aCaminho) > 0;
           return (
           <TableRow key={l.id}>
             <TableCell className="align-top whitespace-normal">
@@ -82,7 +92,19 @@ export function ItensTable({
                 )}
               </div>
             </TableCell>
-            <TableCell className={`text-right tabular-nums ${zoneClass}`}>{estoque.toFixed(0)}</TableCell>
+            <TableCell
+              className={`text-right tabular-nums ${zoneClass}`}
+              title={temSplit
+                ? `Estoque efetivo ${estoque.toFixed(0)} = ${Number(fisico).toFixed(0)} físico (saldo Omie) + ${Number(aCaminho).toFixed(0)} a caminho (pendente de entrada + em trânsito). O motor compara o efetivo com o ponto de pedido.`
+                : undefined}
+            >
+              {estoque.toFixed(0)}
+              {temSplit && (
+                <div className="text-[10px] font-normal text-muted-foreground leading-tight">
+                  {Number(fisico).toFixed(0)} + {Number(aCaminho).toFixed(0)} a caminho
+                </div>
+              )}
+            </TableCell>
             <TableCell className="text-right tabular-nums text-muted-foreground">{minimo.toFixed(0)}</TableCell>
             <TableCell className="text-right tabular-nums">{pp.toFixed(0)}</TableCell>
             <TableCell className="text-right tabular-nums">{Number(l.estoque_maximo ?? 0).toFixed(0)}</TableCell>

--- a/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
@@ -10,6 +10,8 @@ function linha(partial: Partial<Linha>): Linha {
     sku_codigo_omie: '555',
     sku_descricao: 'Verniz X',
     estoque_atual: 5,
+    estoque_fisico: null,
+    estoque_a_caminho: null,
     estoque_minimo: 2,
     ponto_pedido: 8,
     estoque_maximo: 20,
@@ -93,5 +95,22 @@ describe('ItensTable', () => {
   it('item COM custo válido: preço fica read-only mesmo com podeEditarPreco', () => {
     setup({ podeEditar: false, podeEditarPreco: true, linhas: [linha({ preco_unitario: 9, _preco: 9 })] });
     expect(screen.queryByPlaceholderText('custo')).toBeNull();
+  });
+
+  it('decompõe o efetivo em "físico + a caminho" quando há algo a caminho', () => {
+    // efetivo 3 = 2 físico (saldo Omie) + 1 a caminho — o caso que confundia ("Omie diz 2, pedido diz 3")
+    setup({ podeEditar: false, linhas: [linha({ estoque_atual: 3, estoque_fisico: 2, estoque_a_caminho: 1 })] });
+    expect(screen.getByText('3')).toBeTruthy(); // efetivo continua sendo o número principal (cor/decisão)
+    expect(screen.getByText('2 + 1 a caminho')).toBeTruthy();
+  });
+
+  it('NÃO decompõe quando nada está a caminho (efetivo == físico)', () => {
+    setup({ podeEditar: false, linhas: [linha({ estoque_atual: 2, estoque_fisico: 2, estoque_a_caminho: 0 })] });
+    expect(screen.queryByText(/a caminho/)).toBeNull();
+  });
+
+  it('item antigo (split NULL): cai no efetivo sem sublinha', () => {
+    setup({ podeEditar: false, linhas: [linha({ estoque_atual: 5, estoque_fisico: null, estoque_a_caminho: null })] });
+    expect(screen.queryByText(/a caminho/)).toBeNull();
   });
 });

--- a/src/components/reposicao/pedidos/types.ts
+++ b/src/components/reposicao/pedidos/types.ts
@@ -81,7 +81,10 @@ export interface PedidoItem {
   pedido_id: number;
   sku_codigo_omie: string;
   sku_descricao: string | null;
-  estoque_atual: number | null;
+  estoque_atual: number | null; // efetivo no momento da geração = estoque_fisico + estoque_a_caminho
+  // Snapshot do split do efetivo (migration 20260626150457). NULL em itens anteriores → UI cai no efetivo.
+  estoque_fisico: number | null; // saldo físico = o que aparece no Omie
+  estoque_a_caminho: number | null; // pendente de entrada + em trânsito
   estoque_minimo: number | null;
   ponto_pedido: number | null;
   estoque_maximo: number | null;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -7766,7 +7766,9 @@ export type Database = {
           criado_em: string | null
           desconto_perc_aplicado: number | null
           economia_estimada_valor: number | null
+          estoque_a_caminho: number | null
           estoque_atual: number | null
+          estoque_fisico: number | null
           estoque_maximo: number | null
           id: number
           modo_promocao: string | null
@@ -7788,7 +7790,9 @@ export type Database = {
           criado_em?: string | null
           desconto_perc_aplicado?: number | null
           economia_estimada_valor?: number | null
+          estoque_a_caminho?: number | null
           estoque_atual?: number | null
+          estoque_fisico?: number | null
           estoque_maximo?: number | null
           id?: number
           modo_promocao?: string | null
@@ -7810,7 +7814,9 @@ export type Database = {
           criado_em?: string | null
           desconto_perc_aplicado?: number | null
           economia_estimada_valor?: number | null
+          estoque_a_caminho?: number | null
           estoque_atual?: number | null
+          estoque_fisico?: number | null
           estoque_maximo?: number | null
           id?: number
           modo_promocao?: string | null

--- a/supabase/migrations/20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql
+++ b/supabase/migrations/20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql
@@ -1,0 +1,177 @@
+-- ============================================================
+-- pedido_compra_item — split do estoque efetivo em snapshot fiel
+-- Hoje o item grava só estoque_atual = estoque_efetivo (físico + pendente + em trânsito).
+-- Na tela isso confunde: "Omie diz 2, pedido diz 3". Persistimos os componentes
+-- no MOMENTO da geração para a UI mostrar "2 físico + 1 a caminho" fiel ao pedido.
+-- Invariante (itens novos): estoque_fisico + estoque_a_caminho = estoque_atual (efetivo).
+-- Itens antigos ficam NULL → a UI cai no comportamento atual (só o efetivo).
+-- Mudança ADITIVA: não altera qtde_sugerida/qtde_final nem o gate de compra.
+-- ============================================================
+
+ALTER TABLE public.pedido_compra_item
+  ADD COLUMN IF NOT EXISTS estoque_fisico numeric,
+  ADD COLUMN IF NOT EXISTS estoque_a_caminho numeric;
+
+COMMENT ON COLUMN public.pedido_compra_item.estoque_fisico
+  IS 'Snapshot do estoque físico no momento da geração (= saldo do Omie). NULL em itens anteriores à migration.';
+COMMENT ON COLUMN public.pedido_compra_item.estoque_a_caminho
+  IS 'Snapshot do pendente de entrada + em trânsito no momento da geração. estoque_fisico + estoque_a_caminho = estoque_atual (efetivo).';
+
+CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
+ RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_pedidos INT := 0;
+  v_skus INT := 0;
+  v_valor NUMERIC := 0;
+  v_bloqueados INT := 0;
+BEGIN
+  -- [INTRADAY 1/4] serializa execuções concorrentes (cron 2/2h × botão "Recalcular" × retry).
+  PERFORM pg_advisory_xact_lock(hashtext('gerar_pedidos_sugeridos_ciclo:' || lower(p_empresa)));
+
+  IF (SELECT count(*) FILTER (WHERE tipo_produto IS NOT NULL) FROM public.omie_products WHERE account = lower(p_empresa)) = 0 THEN
+    RAISE EXCEPTION 'tipo_produto_unhealthy: sinal de classificação ausente em omie_products(account=%) — recusando gerar compras p/ não tratar Produto Acabado como comprável', lower(p_empresa);
+  END IF;
+
+  -- [INTRADAY 2/4] expira pendentes NORMAIS de ciclos anteriores (zumbis pós-corte).
+  UPDATE pedido_compra_sugerido
+  SET status = 'expirado_sem_aprovacao', atualizado_em = now()
+  WHERE empresa = p_empresa
+    AND data_ciclo < p_data_ciclo
+    AND status = 'pendente_aprovacao'
+    AND COALESCE(tipo_ciclo, 'normal') = 'normal';
+
+  -- [INTRADAY 3/4] limpeza do dia: só ciclo NORMAL (preserva oportunidade/promoção pendentes) e
+  -- INCLUI bloqueado_guardrail do dia (re-avaliado a cada rodada; anti compra dupla).
+  DELETE FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo
+    AND status IN ('pendente_aprovacao', 'bloqueado_guardrail')
+    AND COALESCE(tipo_ciclo, 'normal') = 'normal';
+
+  WITH em_transito AS (
+    SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+    FROM pedido_compra_item pci
+    JOIN pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+    WHERE pcs2.empresa = p_empresa
+      AND (
+        (pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido') AND pcs2.data_ciclo >= (p_data_ciclo - INTERVAL '7 days'))
+        OR (pcs2.status_envio_portal IN ('sucesso_portal','enviado_portal') AND pcs2.portal_protocolo IS NOT NULL AND pcs2.omie_pedido_compra_numero IS NULL AND pcs2.status NOT IN ('cancelado','expirado_sem_aprovacao'))
+      )
+    GROUP BY pcs2.empresa, pci.sku_codigo_omie
+  ),
+  preco_medio AS (
+    SELECT slh.empresa::text AS empresa, slh.sku_codigo_omie::text AS sku_codigo_omie,
+           AVG(slh.valor_total / NULLIF(slh.quantidade_recebida, 0)) AS preco_unitario, COUNT(*) AS n
+    FROM sku_leadtime_history slh
+    WHERE slh.quantidade_recebida > 0 AND slh.valor_total > 0
+    GROUP BY slh.empresa, slh.sku_codigo_omie
+  ),
+  skus_necessitando AS (
+    SELECT sp.empresa, sp.sku_codigo_omie::text AS sku_codigo_omie, sp.sku_descricao, sp.fornecedor_nome,
+           sg.grupo_codigo, sp.ponto_pedido, sp.estoque_maximo,
+           COALESCE(sea.estoque_fisico, 0) AS estoque_fisico,
+           COALESCE(sea.estoque_pendente_entrada, 0) AS estoque_pendente,
+           COALESCE(et.qtde, 0) AS qtde_em_transito_recente,
+           (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS estoque_efetivo,
+           ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))) AS qtde_sugerida,
+           CASE WHEN sp.minimo_forcado_manual IS NOT NULL AND sp.minimo_forcado_manual > 0
+                THEN ceil(GREATEST(
+                       (sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))),
+                       sp.minimo_forcado_manual))
+                ELSE ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)))
+           END AS qtde_final,
+           COALESCE(
+             ( SELECT ipc.cmc FROM inventory_position ipc
+               WHERE ipc.omie_codigo_produto::text = sp.sku_codigo_omie::text
+                 AND ipc.account = ANY (CASE lower(p_empresa)
+                       WHEN 'oben' THEN ARRAY['vendas'::text,'oben'::text]
+                       WHEN 'colacor' THEN ARRAY['colacor_vendas'::text,'colacor'::text]
+                       WHEN 'colacor_sc' THEN ARRAY['servicos'::text,'colacor_sc'::text]
+                       ELSE ARRAY[lower(p_empresa)] END)
+                 AND ipc.cmc > 0
+               ORDER BY ipc.synced_at DESC NULLS LAST
+               LIMIT 1 ),
+             pm.preco_unitario, 0) AS preco_unitario,
+           (pm.n IS NULL) AS primeira_compra,
+           fh.horario_corte_pedido, fh.valor_maximo_mensal, fh.delta_max_perc
+    FROM sku_parametros sp
+    LEFT JOIN sku_grupo_producao sg ON sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN sku_estoque_atual sea ON sea.empresa = sp.empresa AND sea.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN fornecedor_habilitado_reposicao fh ON fh.empresa = sp.empresa AND fh.fornecedor_nome = sp.fornecedor_nome
+    LEFT JOIN omie_products op ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text AND op.account = lower(p_empresa)
+    LEFT JOIN familia_nao_comprada fnc ON fnc.empresa = sp.empresa AND fnc.familia = op.familia
+    LEFT JOIN em_transito et ON et.empresa = sp.empresa AND et.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN preco_medio pm ON pm.empresa = sp.empresa AND pm.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN inventory_position ip ON ip.omie_codigo_produto::text = sp.sku_codigo_omie::text AND ip.account = lower(p_empresa)
+    LEFT JOIN sku_status_omie sso ON sso.empresa = sp.empresa AND sso.sku_codigo_omie = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+      AND sp.habilitado_reposicao_automatica = TRUE
+      AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+      AND sp.fornecedor_nome IS NOT NULL
+      AND btrim(sp.fornecedor_nome) <> ''
+      AND fnc.id IS NULL
+      AND COALESCE(op.ativo, true) = true
+      AND COALESCE(sso.ativo_no_omie, true) = true
+      AND COALESCE(op.descricao, '') NOT ILIKE '%450ML'
+      AND COALESCE(op.descricao, '') NOT ILIKE '%405ML'
+      AND COALESCE((
+            SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
+            FROM omie_products op04
+            WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text
+              AND op04.account = lower(p_empresa)
+            LIMIT 1
+          ), '') <> '04'
+      -- [INTRADAY 4/4] não re-sugerir SKU presente em pedido pendente/bloqueado de oportunidade.
+      AND NOT EXISTS (
+            SELECT 1
+            FROM pedido_compra_item pci9
+            JOIN pedido_compra_sugerido pcs9 ON pcs9.id = pci9.pedido_id
+            WHERE pcs9.empresa = p_empresa
+              AND pcs9.status IN ('pendente_aprovacao', 'bloqueado_guardrail')
+              AND COALESCE(pcs9.tipo_ciclo, 'normal') <> 'normal'
+              AND pci9.sku_codigo_omie = sp.sku_codigo_omie::text
+          )
+      AND sp.ponto_pedido IS NOT NULL
+      AND sp.estoque_maximo IS NOT NULL
+      AND (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) <= sp.ponto_pedido
+  ),
+  pedidos_por_fornecedor_grupo AS (
+    INSERT INTO pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo, horario_corte_planejado,
+      valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao,
+      num_parcelas, dias_parcelas, condicao_origem
+    )
+    SELECT sn.empresa, sn.fornecedor_nome, sn.grupo_codigo, p_data_ciclo,
+           (p_data_ciclo + MAX(sn.horario_corte_pedido))::timestamptz,
+           SUM(sn.qtde_final * sn.preco_unitario), COUNT(*),
+           'pendente_aprovacao', '000', 'À Vista', 1, NULL, 'default_a_vista'
+    FROM skus_necessitando sn
+    WHERE sn.qtde_sugerida > 0
+    GROUP BY sn.empresa, sn.fornecedor_nome, sn.grupo_codigo
+    RETURNING id, fornecedor_nome, grupo_codigo
+  )
+  INSERT INTO pedido_compra_item (
+    pedido_id, sku_codigo_omie, sku_descricao, estoque_atual, ponto_pedido, estoque_maximo,
+    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra,
+    estoque_fisico, estoque_a_caminho
+  )
+  SELECT pfg.id, sn.sku_codigo_omie, sn.sku_descricao, sn.estoque_efetivo, sn.ponto_pedido, sn.estoque_maximo,
+         sn.qtde_sugerida, sn.qtde_final, sn.preco_unitario, sn.qtde_final * sn.preco_unitario, sn.primeira_compra,
+         sn.estoque_fisico, (sn.estoque_pendente + sn.qtde_em_transito_recente)
+  FROM skus_necessitando sn
+  JOIN pedidos_por_fornecedor_grupo pfg
+    ON pfg.fornecedor_nome = sn.fornecedor_nome AND COALESCE(pfg.grupo_codigo,'') = COALESCE(sn.grupo_codigo,'')
+  WHERE sn.qtde_sugerida > 0;
+
+  SELECT COUNT(*), COALESCE(SUM(num_skus),0), COALESCE(SUM(valor_total),0)
+  INTO v_pedidos, v_skus, v_valor
+  FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';
+
+  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados;
+END;
+$function$
+


### PR DESCRIPTION
## O que muda

A tela do pedido de reposição mostrava só `estoque_atual` = **estoque efetivo** (físico + pendente de entrada + em trânsito). Isso confundia com o Omie: *"Omie diz 2, pedido diz 3"*. Agora o item guarda o **snapshot decomposto** e a UI mostra **"2 + 1 a caminho"**.

### Diagnóstico (caso real)
SKU `NLO.9506.00LT` (cód. Omie `8689723601`, PRD00312, OBEN): Omie = **2** (físico); pedido = **3** (efetivo). A diferença = **1 unidade já pedida com previsão de entrada futura**. Não era bug — o motor compara o efetivo (não o físico) com o ponto de pedido pra não recomprar o que já vem chegando. O que confundia era o rótulo.

## Implementação
- **Migration `20260626150457`** (aditiva, money-path):
  - `+colunas` `estoque_fisico` / `estoque_a_caminho` em `pedido_compra_item`
  - `CREATE OR REPLACE` de `gerar_pedidos_sugeridos_ciclo` (corpo **byte-a-byte de prod** via `pg_get_functiondef` + 2 linhas no INSERT) gravando os componentes. **Não altera** `qtde_sugerida`/`qtde_final` nem o gate de compra.
- **Invariante:** `estoque_fisico + estoque_a_caminho = estoque_atual` (efetivo).
- **Frontend** `ItensTable`: header "Estoque efetivo" + tooltip + sublinha "fís + a caminho". Itens antigos ficam NULL → cai no efetivo (comportamento atual).

## Prova (money-path)
- **PG17** (`db/test-pedido-item-split-estoque.sh`): **7/7 asserts + falsificação** (sabota esquecendo o `em_transito` → invariante fica vermelho).
- `typecheck` 0 erros · `test` 4116/4117 (o 1 fail é flake de timeout de worker, passa isolado) · `lint` ok.
- 🧭 **REVISÃO INDEPENDENTE (Codex) PENDENTE** — classificador de Bash fora do ar; PG17 cobre o intervalo (Caminho B).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260626150457_pedido_item_split_estoque_fisico_a_caminho.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Cole no SQL Editor do Lovable e rode. Depois **Publish** do frontend.

<details><summary>SQL pra aplicar (SQL Editor → Run)</summary>

```sql
-- ============================================================
-- pedido_compra_item — split do estoque efetivo em snapshot fiel
-- Hoje o item grava só estoque_atual = estoque_efetivo (físico + pendente + em trânsito).
-- Na tela isso confunde: "Omie diz 2, pedido diz 3". Persistimos os componentes
-- no MOMENTO da geração para a UI mostrar "2 físico + 1 a caminho" fiel ao pedido.
-- Invariante (itens novos): estoque_fisico + estoque_a_caminho = estoque_atual (efetivo).
-- Itens antigos ficam NULL → a UI cai no comportamento atual (só o efetivo).
-- Mudança ADITIVA: não altera qtde_sugerida/qtde_final nem o gate de compra.
-- ============================================================

ALTER TABLE public.pedido_compra_item
  ADD COLUMN IF NOT EXISTS estoque_fisico numeric,
  ADD COLUMN IF NOT EXISTS estoque_a_caminho numeric;

COMMENT ON COLUMN public.pedido_compra_item.estoque_fisico
  IS 'Snapshot do estoque físico no momento da geração (= saldo do Omie). NULL em itens anteriores à migration.';
COMMENT ON COLUMN public.pedido_compra_item.estoque_a_caminho
  IS 'Snapshot do pendente de entrada + em trânsito no momento da geração. estoque_fisico + estoque_a_caminho = estoque_atual (efetivo).';

CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
 RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
 LANGUAGE plpgsql
 SET search_path TO 'public', 'pg_temp'
 SET statement_timeout TO '120s'
AS $function$
DECLARE
  v_pedidos INT := 0;
  v_skus INT := 0;
  v_valor NUMERIC := 0;
  v_bloqueados INT := 0;
BEGIN
  -- [INTRADAY 1/4] serializa execuções concorrentes (cron 2/2h × botão "Recalcular" × retry).
  PERFORM pg_advisory_xact_lock(hashtext('gerar_pedidos_sugeridos_ciclo:' || lower(p_empresa)));

  IF (SELECT count(*) FILTER (WHERE tipo_produto IS NOT NULL) FROM public.omie_products WHERE account = lower(p_empresa)) = 0 THEN
    RAISE EXCEPTION 'tipo_produto_unhealthy: sinal de classificação ausente em omie_products(account=%) — recusando gerar compras p/ não tratar Produto Acabado como comprável', lower(p_empresa);
  END IF;

  -- [INTRADAY 2/4] expira pendentes NORMAIS de ciclos anteriores (zumbis pós-corte).
  UPDATE pedido_compra_sugerido
  SET status = 'expirado_sem_aprovacao', atualizado_em = now()
  WHERE empresa = p_empresa
    AND data_ciclo < p_data_ciclo
    AND status = 'pendente_aprovacao'
    AND COALESCE(tipo_ciclo, 'normal') = 'normal';

  -- [INTRADAY 3/4] limpeza do dia: só ciclo NORMAL (preserva oportunidade/promoção pendentes) e
  -- INCLUI bloqueado_guardrail do dia (re-avaliado a cada rodada; anti compra dupla).
  DELETE FROM pedido_compra_sugerido
  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo
    AND status IN ('pendente_aprovacao', 'bloqueado_guardrail')
    AND COALESCE(tipo_ciclo, 'normal') = 'normal';

  WITH em_transito AS (
    SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
    FROM pedido_compra_item pci
    JOIN pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
    WHERE pcs2.empresa = p_empresa
      AND (
        (pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido') AND pcs2.data_ciclo >= (p_data_ciclo - INTERVAL '7 days'))
        OR (pcs2.status_envio_portal IN ('sucesso_portal','enviado_portal') AND pcs2.portal_protocolo IS NOT NULL AND pcs2.omie_pedido_compra_numero IS NULL AND pcs2.status NOT IN ('cancelado','expirado_sem_aprovacao'))
      )
    GROUP BY pcs2.empresa, pci.sku_codigo_omie
  ),
  preco_medio AS (
    SELECT slh.empresa::text AS empresa, slh.sku_codigo_omie::text AS sku_codigo_omie,
           AVG(slh.valor_total / NULLIF(slh.quantidade_recebida, 0)) AS preco_unitario, COUNT(*) AS n
    FROM sku_leadtime_history slh
    WHERE slh.quantidade_recebida > 0 AND slh.valor_total > 0
    GROUP BY slh.empresa, slh.sku_codigo_omie
  ),
  skus_necessitando AS (
    SELECT sp.empresa, sp.sku_codigo_omie::text AS sku_codigo_omie, sp.sku_descricao, sp.fornecedor_nome,
           sg.grupo_codigo, sp.ponto_pedido, sp.estoque_maximo,
           COALESCE(sea.estoque_fisico, 0) AS estoque_fisico,
           COALESCE(sea.estoque_pendente_entrada, 0) AS estoque_pendente,
           COALESCE(et.qtde, 0) AS qtde_em_transito_recente,
           (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS estoque_efetivo,
           ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))) AS qtde_sugerida,
           CASE WHEN sp.minimo_forcado_manual IS NOT NULL AND sp.minimo_forcado_manual > 0
                THEN ceil(GREATEST(
                       (sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0))),
                       sp.minimo_forcado_manual))
                ELSE ceil(sp.estoque_maximo - (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)))
           END AS qtde_final,
           COALESCE(
             ( SELECT ipc.cmc FROM inventory_position ipc
               WHERE ipc.omie_codigo_produto::text = sp.sku_codigo_omie::text
                 AND ipc.account = ANY (CASE lower(p_empresa)
                       WHEN 'oben' THEN ARRAY['vendas'::text,'oben'::text]
                       WHEN 'colacor' THEN ARRAY['colacor_vendas'::text,'colacor'::text]
                       WHEN 'colacor_sc' THEN ARRAY['servicos'::text,'colacor_sc'::text]
                       ELSE ARRAY[lower(p_empresa)] END)
                 AND ipc.cmc > 0
               ORDER BY ipc.synced_at DESC NULLS LAST
               LIMIT 1 ),
             pm.preco_unitario, 0) AS preco_unitario,
           (pm.n IS NULL) AS primeira_compra,
           fh.horario_corte_pedido, fh.valor_maximo_mensal, fh.delta_max_perc
    FROM sku_parametros sp
    LEFT JOIN sku_grupo_producao sg ON sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
    LEFT JOIN sku_estoque_atual sea ON sea.empresa = sp.empresa AND sea.sku_codigo_omie = sp.sku_codigo_omie::text
    LEFT JOIN fornecedor_habilitado_reposicao fh ON fh.empresa = sp.empresa AND fh.fornecedor_nome = sp.fornecedor_nome
    LEFT JOIN omie_products op ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text AND op.account = lower(p_empresa)
    LEFT JOIN familia_nao_comprada fnc ON fnc.empresa = sp.empresa AND fnc.familia = op.familia
    LEFT JOIN em_transito et ON et.empresa = sp.empresa AND et.sku_codigo_omie = sp.sku_codigo_omie::text
    LEFT JOIN preco_medio pm ON pm.empresa = sp.empresa AND pm.sku_codigo_omie = sp.sku_codigo_omie::text
    LEFT JOIN inventory_position ip ON ip.omie_codigo_produto::text = sp.sku_codigo_omie::text AND ip.account = lower(p_empresa)
    LEFT JOIN sku_status_omie sso ON sso.empresa = sp.empresa AND sso.sku_codigo_omie = sp.sku_codigo_omie::text
    WHERE sp.empresa = p_empresa
      AND sp.habilitado_reposicao_automatica = TRUE
      AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
      AND sp.fornecedor_nome IS NOT NULL
      AND btrim(sp.fornecedor_nome) <> ''
      AND fnc.id IS NULL
      AND COALESCE(op.ativo, true) = true
      AND COALESCE(sso.ativo_no_omie, true) = true
      AND COALESCE(op.descricao, '') NOT ILIKE '%450ML'
      AND COALESCE(op.descricao, '') NOT ILIKE '%405ML'
      AND COALESCE((
            SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
            FROM omie_products op04
            WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text
              AND op04.account = lower(p_empresa)
            LIMIT 1
          ), '') <> '04'
      -- [INTRADAY 4/4] não re-sugerir SKU presente em pedido pendente/bloqueado de oportunidade.
      AND NOT EXISTS (
            SELECT 1
            FROM pedido_compra_item pci9
            JOIN pedido_compra_sugerido pcs9 ON pcs9.id = pci9.pedido_id
            WHERE pcs9.empresa = p_empresa
              AND pcs9.status IN ('pendente_aprovacao', 'bloqueado_guardrail')
              AND COALESCE(pcs9.tipo_ciclo, 'normal') <> 'normal'
              AND pci9.sku_codigo_omie = sp.sku_codigo_omie::text
          )
      AND sp.ponto_pedido IS NOT NULL
      AND sp.estoque_maximo IS NOT NULL
      AND (COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) <= sp.ponto_pedido
  ),
  pedidos_por_fornecedor_grupo AS (
    INSERT INTO pedido_compra_sugerido (
      empresa, fornecedor_nome, grupo_codigo, data_ciclo, horario_corte_planejado,
      valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao,
      num_parcelas, dias_parcelas, condicao_origem
    )
    SELECT sn.empresa, sn.fornecedor_nome, sn.grupo_codigo, p_data_ciclo,
           (p_data_ciclo + MAX(sn.horario_corte_pedido))::timestamptz,
           SUM(sn.qtde_final * sn.preco_unitario), COUNT(*),
           'pendente_aprovacao', '000', 'À Vista', 1, NULL, 'default_a_vista'
    FROM skus_necessitando sn
    WHERE sn.qtde_sugerida > 0
    GROUP BY sn.empresa, sn.fornecedor_nome, sn.grupo_codigo
    RETURNING id, fornecedor_nome, grupo_codigo
  )
  INSERT INTO pedido_compra_item (
    pedido_id, sku_codigo_omie, sku_descricao, estoque_atual, ponto_pedido, estoque_maximo,
    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra,
    estoque_fisico, estoque_a_caminho
  )
  SELECT pfg.id, sn.sku_codigo_omie, sn.sku_descricao, sn.estoque_efetivo, sn.ponto_pedido, sn.estoque_maximo,
         sn.qtde_sugerida, sn.qtde_final, sn.preco_unitario, sn.qtde_final * sn.preco_unitario, sn.primeira_compra,
         sn.estoque_fisico, (sn.estoque_pendente + sn.qtde_em_transito_recente)
  FROM skus_necessitando sn
  JOIN pedidos_por_fornecedor_grupo pfg
    ON pfg.fornecedor_nome = sn.fornecedor_nome AND COALESCE(pfg.grupo_codigo,'') = COALESCE(sn.grupo_codigo,'')
  WHERE sn.qtde_sugerida > 0;

  SELECT COUNT(*), COALESCE(SUM(num_skus),0), COALESCE(SUM(valor_total),0)
  INTO v_pedidos, v_skus, v_valor
  FROM pedido_compra_sugerido
  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';

  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados;
END;
$function$

```
</details>

Validação pós-apply (read-only):

```sql
SELECT
  (SELECT count(*) FROM information_schema.columns
     WHERE table_schema='public' AND table_name='pedido_compra_item'
       AND column_name IN ('estoque_fisico','estoque_a_caminho')) AS colunas,
  (SELECT count(*) FROM pg_proc
     WHERE proname='gerar_pedidos_sugeridos_ciclo'
       AND pg_get_functiondef(oid) ILIKE '%estoque_a_caminho%') AS rpc_grava;
```
Esperado: `colunas=2`, `rpc_grava=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
