### PR TITLE
fix(pricing): RESTAURA o Omie fallback no analyze (revertido no deploy do Lovable) [money-path]

### DIFF
--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -1301,12 +1301,18 @@ Responda SEMPRE usando a função identify_order_items.`;
 
             const omieResults = await Promise.all(omiePricePromises);
             
-            // Merge Omie prices - Omie takes priority over local
+            // Merge Omie prices — FALLBACK: só preenche produtos SEM preço local (order_items vence).
+            // Era OVERRIDE, mas fetchOmiePrices pega o "primeiro encontrado" do ListarPedidos (pagina 1,
+            // 50 reg, SEM ordenar_por) = ordem NÃO garantida → podia mascarar o último preço PRATICADO
+            // (order_items, ordenado por created_at real DESC, trigger #1047). order_items é a fonte de
+            // verdade do praticado; o Omie cobre só os gaps (produtos sem pedido local). Alinha com o
+            // hook useCustomerSelection (#1065, que já tirou o overlay do Omie do preço-cliente).
+            // ⚠️ NÃO reverter p/ override no deploy do Lovable (já foi revertido 1× — 08431871 pós-#1077).
             for (const omiePrices of omieResults) {
               for (const [omieCode, price] of Object.entries(omiePrices)) {
                 const productId = omieCodeMap[Number(omieCode)];
-                if (productId && price > 0) {
-                  priceMap[productId] = price; // Omie overrides local
+                if (productId && price > 0 && !priceMap[productId]) {
+                  priceMap[productId] = price; // só preenche gap
                 }
               }
             }
@@ -1324,11 +1330,11 @@ Responda SEMPRE usando a função identify_order_items.`;
                   for (const pm of extraMappings) {
                     omieCodeMap[pm.omie_codigo_produto] = pm.id;
                   }
-                  // Re-apply Omie prices with new mappings
+                  // Re-apply Omie prices with new mappings (mesma semântica FALLBACK: só gaps)
                   for (const omiePrices of omieResults) {
                     for (const [omieCode, price] of Object.entries(omiePrices)) {
                       const productId = omieCodeMap[Number(omieCode)];
-                      if (productId && price > 0) {
+                      if (productId && price > 0 && !priceMap[productId]) {
                         priceMap[productId] = price;
                       }
                     }


### PR DESCRIPTION
⚠️ **Regressão money-path detectada e corrigida.**

## O que aconteceu
[#1077](https://github.com/LucasSardenbergL/afiacao/pull/1077) mergeou o Omie **fallback** no `analyze-unified-order` (order_items vence, Omie só preenche gaps). Mas no deploy, o Lovable commitou **`08431871 'Changes'`** que **reverteu** o fallback de volta pra **override** (`// Omie overrides local`, sem o gate `&& !priceMap[productId]`). Confirmado: o commit tocou só o analyze, 5+/10−, exatamente o diff inverso do #1.

Resultado: o bug do #1 **voltou ao ar** — o Omie sobrescreve o último preço praticado com um preço de ordem arbitrária do `ListarPedidos`.

## A correção
Re-aplica os 2 gates `&& !priceMap[productId]` + nota anti-reversão no comentário. `deno check` type-neutral (15=15).

## ⚠️ Handoff — re-deploy COM verificação
O deploy de edge no Lovable pode reverter de novo se o estado do Lovable divergir da main. **Antes de confirmar o deploy**, conferir no editor do Lovable que o bloco `Merge Omie prices` tem **`if (productId && price > 0 && !priceMap[productId])`** (com o `&& !priceMap[productId]`) nos DOIS loops. Se aparecer `// Omie overrides local` sem o gate, é a versão revertida — não confirmar.

## Lição (vou registrar no CLAUDE.md)
Deploy de edge no Lovable não é fire-and-forget: pode reverter mudanças via commit 'Changes' se a working copy do Lovable diverge. Verificar bytes/trecho-alvo pós-deploy é obrigatório.

🤖 Generated with [Claude Code](https://claude.com/claude-code)