### PR TITLE
test(guard): invariantes money-path dos edges no CI (pega reversão do Lovable)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// repo root: src/__tests__ → src → repo (2 níveis).
+const CWD = resolve(__dirname, '../..');
+const read = (rel: string) => readFileSync(resolve(CWD, rel), 'utf8');
+const count = (hay: string, needle: string) => hay.split(needle).length - 1;
+
+// ── Guard de invariante money-path dos EDGES (Deno, fora do typecheck/vitest do src) ──
+// Por que TEXTUAL: edge function roda no Lovable Cloud; o deploy via chat pode REVERTER um
+// fix mergeado e COMMITAR a reversão na `main` como "Changes" (mordido 2026-06-26: o fallback
+// do analyze #1077 voltou a override no deploy; re-aplicado #1080 — ver docs/agent/deploy.md).
+// Este teste roda no CI (`validate`) e FALHA se o invariante sumir da `main` → a reversão do
+// bot fica visível em vez de mascarada. NÃO substitui a canária de comportamento, só a fonte.
+
+const ANALYZE = 'supabase/functions/analyze-unified-order/index.ts';
+const AUDIT = 'supabase/functions/algorithm-a-audit/index.ts';
+
+describe('guardrail money-path: analyze-unified-order (price path)', () => {
+  const src = read(ANALYZE);
+
+  it('sentinela: leu o arquivo real do edge', () => {
+    // pega CWD errado / arquivo movido (que passaria falso nos "não contém").
+    expect(src).toContain('Merge Omie prices');
+    expect(src).toContain('priceMap');
+  });
+
+  it('Omie é FALLBACK, não override: gate `&& !priceMap[productId]` nos 2 loops de merge', () => {
+    expect(
+      count(src, '&& !priceMap[productId]'),
+      'o fallback do Omie sumiu (revertido p/ override?) — ver docs/agent/deploy.md',
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('NÃO tem o marcador do override revertido', () => {
+    expect(src).not.toContain('// Omie overrides local');
+  });
+
+  it('NÃO lê sales_price_history no price path (lê order_items, fonte de verdade)', () => {
+    expect(src).not.toContain('from("sales_price_history")');
+    expect(src).not.toContain("from('sales_price_history')");
+  });
+});
+
+describe('guardrail money-path: algorithm-a-audit (margem)', () => {
+  const src = read(AUDIT);
+
+  it('sentinela: leu o arquivo real do edge', () => {
+    expect(src).toContain('bestPriceMap');
+    expect(src).toContain('margin_audit_log');
+  });
+
+  it('bestPriceMap (potencial) só de pedidos praticados: filtra excludedOrderIds', () => {
+    expect(
+      src,
+      'o filtro de praticados sumiu do bestPriceMap — orçamento de preço absurdo voltaria a inflar margin_potential',
+    ).toContain('excludedOrderIds.has(sp.sales_order_id)');
+  });
+
+  it('margem real só de pedidos praticados: filtra excludedOrderIds no agrupamento', () => {
+    expect(
+      src,
+      'o filtro de praticados sumiu do recentOrders — orçamento absurdo voltaria a inflar margin_real',
+    ).toContain('excludedOrderIds.has(oi.sales_order_id)');
+  });
+
+  it('bestPriceMap lê order_items (não a sph poluída)', () => {
+    expect(src).toContain("'order_items', 'product_id, unit_price, sales_order_id'");
+  });
+});


### PR DESCRIPTION
Follow-up #2 do Codex: CI que falha se o invariante money-path sumir de um edge — pega automaticamente a reversão que o deploy do Lovable pode commitar na `main` (mordido 2026-06-26: fallback do analyze #1077 → ver [#1083](https://github.com/LucasSardenbergL/afiacao/pull/1083)).

## O que cobre (lê os arquivos dos edges, roda no `validate`)
- **analyze-unified-order:** 2 gates do Omie fallback (`&& !priceMap[productId]`); ausência do marcador de override; não lê `sales_price_history` no price path.
- **algorithm-a-audit:** filtro de praticados no `bestPriceMap` E no `recentOrders`; lê `order_items`.

## Robustez
- **Sentinelas anti-teatro:** cada bloco assert que leu o arquivo real (pega CWD errado / arquivo movido que passaria falso nos "não contém").
- **Falsificado:** sabotei os gates (simulando a reversão) → **1 vermelho** (linha 33); restaurei → **8 verde**.

## Limite (honesto)
Verifica a **fonte na `main`**, não o comportamento DEPLOYADO. O failure mode "Lovable deploya da cópia interna sem refletir na main" precisa de probe HTTP (canária — follow-up separado).

Doc/test-only, sem deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)