### PR TITLE
fix(tipos): restaura colunas de pedido_compra_item nos tipos Supabase (regressão do bot Lovable) — destrava a main

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -7766,7 +7766,9 @@ export type Database = {
           criado_em: string | null
           desconto_perc_aplicado: number | null
           economia_estimada_valor: number | null
+          estoque_a_caminho: number | null
           estoque_atual: number | null
+          estoque_fisico: number | null
           estoque_maximo: number | null
           id: number
           modo_promocao: string | null
@@ -7788,7 +7790,9 @@ export type Database = {
           criado_em?: string | null
           desconto_perc_aplicado?: number | null
           economia_estimada_valor?: number | null
+          estoque_a_caminho?: number | null
           estoque_atual?: number | null
+          estoque_fisico?: number | null
           estoque_maximo?: number | null
           id?: number
           modo_promocao?: string | null
@@ -7810,7 +7814,9 @@ export type Database = {
           criado_em?: string | null
           desconto_perc_aplicado?: number | null
           economia_estimada_valor?: number | null
+          estoque_a_caminho?: number | null
           estoque_atual?: number | null
+          estoque_fisico?: number | null
           estoque_maximo?: number | null
           id?: number
           modo_promocao?: string | null


### PR DESCRIPTION
O bot do Lovable (61a49f57) removeu estoque_fisico/estoque_a_caminho de pedido_compra_item em src/integrations/supabase/types.ts — colunas que EXISTEM no banco (psql: numeric) e que o #1079 usa. Quebrou o typecheck da main inteira (useDetalhesModal.ts:75), bloqueando o auto-merge de todos os PRs. Restaura o types.ts de 71dab92e (pré-dano; o bot foi a última mão no arquivo). typecheck volta a passar. Decisão Claude + Codex. Follow-up: migration 20260626150457 não está em schema_migrations.