### PR TITLE
feat(pricing): canária comportamental do merge de preço no edge analyze [money-path]

### DIFF
--- a/docs/agent/money-path.md
+++ b/docs/agent/money-path.md
@@ -27,6 +27,8 @@
 
 Helper TS puro (testado com vitest) **espelhado verbatim** no edge (Deno não importa de `src/`) e/ou em SQL. Para lógica replicada, **provar paridade** (harness diferencial TS×SQL, ex.: `db/test-city-norm-paridade.sh`) — não institucionalizar "copiar verbatim" como fim.
 
+Edge só-TS (sem contraparte SQL): a paridade vira **textual no CI** — bloco entre `// MIRROR-START/END` comparado normalizado src×edge (pega reescrita do Lovable no deploy) — **mais** uma **canária comportamental** `{canary:true}` staff-gated que roda o helper REAL deployado com fixture fixo e retorna `{resolved, expected, ok}`. Probe HTTP = única prova do COMPORTAMENTO em produção: o guard textual cobre a FONTE, a canária cobre o DEPLOY. ⚠️ A canária prova "helper deployado + lógica certa", **não** que o real-path usa o helper (isso é o guard textual + paridade). Ex.: merge de preço do `analyze-unified-order` (#1089).
+
 ## Diagnóstico
 
 "Diagnosticado ≠ corrigido" — ver `diagnose-supabase-sync` (estados rígidos de saída; só declara RECUPERADO com novo ciclo + efeito no dado; a ação corretiva é entregue ao humano, nunca aplicada às cegas).

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -16,30 +16,75 @@ const count = (hay: string, needle: string) => hay.split(needle).length - 1;
 
 const ANALYZE = 'supabase/functions/analyze-unified-order/index.ts';
 const AUDIT = 'supabase/functions/algorithm-a-audit/index.ts';
+const HELPER = 'src/lib/pricing/mergeCustomerPrices.ts';
 
-describe('guardrail money-path: analyze-unified-order (price path)', () => {
+// Extrai o bloco espelhado entre os marcadores-COMENTÁRIO `// MIRROR-START`/`// MIRROR-END` e
+// normaliza (remove `export `, comentários e whitespace) para comparar o helper de src/ × a cópia
+// no edge. O `// ` ancora no comentário-marcador real (a prosa de JSDoc menciona o token sem `//`).
+function mirrorBlock(s: string): string {
+  const m = s.match(/\/\/ MIRROR-START[^\n]*\n([\s\S]*?)\n[^\n]*\/\/ MIRROR-END/);
+  if (!m) throw new Error('bloco // MIRROR-START.../END não encontrado');
+  return m[1]
+    .replace(/\bexport\s+/g, '')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('//'))
+    .join('\n');
+}
+
+// O merge de preço (order_items vence, Omie só preenche gap) foi extraído para um helper puro
+// (src/lib/pricing/mergeCustomerPrices.ts, testado por vitest) e ESPELHADO verbatim no edge,
+// porque o Deno do edge não importa de src/. Estes testes provam que o edge USA o helper (não
+// só que tem os gates) e que a cópia NÃO divergiu — a canária {canary:true} fecha o ciclo
+// provando o comportamento DEPLOYADO. Ver docs/agent/money-path.md (§ "Helper espelhado").
+describe('guardrail money-path: analyze-unified-order USA o helper de merge de preço', () => {
   const src = read(ANALYZE);
+  const helper = read(HELPER);
 
-  it('sentinela: leu o arquivo real do edge', () => {
-    // pega CWD errado / arquivo movido (que passaria falso nos "não contém").
-    expect(src).toContain('Merge Omie prices');
+  it('sentinela: leu os arquivos reais (edge + helper)', () => {
     expect(src).toContain('priceMap');
+    expect(src).toContain('mergeCustomerPrices');
+    expect(helper).toContain('mergeCustomerPrices');
   });
 
-  it('Omie é FALLBACK, não override: gate `&& !priceMap[productId]` nos 2 loops de merge', () => {
+  it('o helper puro existe e exporta mergeCustomerPrices + isValidUnitPrice', () => {
+    expect(helper).toMatch(/export function mergeCustomerPrices/);
+    expect(helper).toMatch(/export function isValidUnitPrice/);
+  });
+
+  it('o edge USA o helper: define o espelho E o chama (não só define)', () => {
+    expect(src, 'edge não define mais o helper espelhado').toMatch(/function mergeCustomerPrices/);
+    expect(src, 'REGRESSÃO: edge não chama mais mergeCustomerPrices — voltou à lógica inline?')
+      .toMatch(/priceMap\s*=\s*mergeCustomerPrices\(/);
     expect(
-      count(src, '&& !priceMap[productId]'),
-      'o fallback do Omie sumiu (revertido p/ override?) — ver docs/agent/deploy.md',
+      count(src, 'mergeCustomerPrices'),
+      'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
     ).toBeGreaterThanOrEqual(2);
   });
 
-  it('NÃO tem o marcador do override revertido', () => {
+  it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlock(src),
+      'edge divergiu do helper de src/ — o Lovable reescreveu o merge no deploy?',
+    ).toBe(mirrorBlock(helper));
+  });
+
+  it('Omie é FALLBACK, não override: o helper preserva o gate de gap `!(… in priceMap)`', () => {
+    expect(
+      mirrorBlock(helper),
+      'sumiu o gate de gap — Omie voltaria a sobrescrever order_items (override)',
+    ).toMatch(/!\(\s*\w+\s+in\s+priceMap\s*\)/);
     expect(src).not.toContain('// Omie overrides local');
   });
 
   it('NÃO lê sales_price_history no price path (lê order_items, fonte de verdade)', () => {
     expect(src).not.toContain('from("sales_price_history")');
     expect(src).not.toContain("from('sales_price_history')");
+  });
+
+  it('canária comportamental {canary:true} prova o merge DEPLOYADO (123 local vence 999 Omie)', () => {
+    expect(src, 'canária {canary:true} ausente — sem prova do comportamento deployado').toContain('canary');
+    expect(src, 'canária sem o valor esperado 123 — não prova local-vence-Omie').toMatch(/expected[^0-9]*123/);
   });
 });
 

--- a/src/lib/pricing/__tests__/mergeCustomerPrices.test.ts
+++ b/src/lib/pricing/__tests__/mergeCustomerPrices.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { mergeCustomerPrices, isValidUnitPrice, type LocalPriceRow } from "../mergeCustomerPrices";
+
+// MONEY-PATH. Este helper resolve o "último preço praticado por produto" que o edge
+// `analyze-unified-order` injeta nas sugestões de pedido do vendedor. Regra:
+//   - order_items (local) é a FONTE DE VERDADE → vence o Omie;
+//   - o Omie só PREENCHE GAPS (produtos sem preço local);
+//   - preço inválido (≤0, NaN, Infinity, não-numérico) é IGNORADO (ausente ≠ zero, money-path #2/#5).
+// É espelhado VERBATIM no edge (Deno não importa de src/) — a paridade/uso é vigiada por
+// src/__tests__/edge-money-path-invariants.test.ts, e a canária {canary:true} roda ESTE
+// merge com o fixture 123/999 contra o código REALMENTE DEPLOYADO.
+
+describe("mergeCustomerPrices — order_items vence, Omie preenche gap", () => {
+  it("local vence o Omie quando ambos têm o produto (123 local × 999 Omie → 123)", () => {
+    const local: LocalPriceRow[] = [{ product_id: "P1", unit_price: 123 }];
+    expect(mergeCustomerPrices(local, { P1: 999 })).toEqual({ P1: 123 });
+  });
+
+  it("produto só no Omie → fallback para o preço do Omie", () => {
+    expect(mergeCustomerPrices([], { P1: 999 })).toEqual({ P1: 999 });
+  });
+
+  it("produto só no local → usa o preço local", () => {
+    expect(mergeCustomerPrices([{ product_id: "P1", unit_price: 123 }], {})).toEqual({ P1: 123 });
+  });
+
+  it("mistura: P1 em ambos (local vence) + P2 só no Omie (gap preenchido)", () => {
+    const local: LocalPriceRow[] = [{ product_id: "P1", unit_price: 123 }];
+    expect(mergeCustomerPrices(local, { P1: 999, P2: 50 })).toEqual({ P1: 123, P2: 50 });
+  });
+
+  it("múltiplos order_items do mesmo produto → first-wins (o mais recente; created_at DESC)", () => {
+    const local: LocalPriceRow[] = [
+      { product_id: "P1", unit_price: 200 }, // mais recente (chega primeiro)
+      { product_id: "P1", unit_price: 180 }, // antigo — ignorado
+    ];
+    expect(mergeCustomerPrices(local, {})).toEqual({ P1: 200 });
+  });
+
+  it("preço local ≤ 0 é ignorado → cai no fallback do Omie", () => {
+    expect(mergeCustomerPrices([{ product_id: "P1", unit_price: 0 }], { P1: 999 })).toEqual({ P1: 999 });
+    expect(mergeCustomerPrices([{ product_id: "P1", unit_price: -5 }], { P1: 999 })).toEqual({ P1: 999 });
+  });
+
+  it("preço Omie ≤ 0 é ignorado → produto fica SEM preço (ausente ≠ zero)", () => {
+    expect(mergeCustomerPrices([], { P1: 0, P2: -10 })).toEqual({});
+  });
+
+  it("NaN/Infinity são ignorados em ambos os lados (money-path #5)", () => {
+    const local: LocalPriceRow[] = [
+      { product_id: "P1", unit_price: NaN }, // inválido → cai no Omie
+      { product_id: "P2", unit_price: Infinity }, // inválido, sem Omie → ausente
+    ];
+    expect(mergeCustomerPrices(local, { P1: 999, P3: Infinity })).toEqual({ P1: 999 });
+  });
+
+  it("product_id vazio/null no local é ignorado", () => {
+    const local: LocalPriceRow[] = [
+      { product_id: null, unit_price: 123 },
+      { product_id: "", unit_price: 123 },
+      { product_id: "P1", unit_price: 123 },
+    ];
+    expect(mergeCustomerPrices(local, {})).toEqual({ P1: 123 });
+  });
+
+  it("unit_price null/undefined no local é ignorado → fallback Omie", () => {
+    expect(mergeCustomerPrices([{ product_id: "P1", unit_price: null }], { P1: 999 })).toEqual({ P1: 999 });
+  });
+
+  it("inputs vazios → objeto vazio", () => {
+    expect(mergeCustomerPrices([], {})).toEqual({});
+  });
+
+  it("não muta os inputs", () => {
+    const local: LocalPriceRow[] = [{ product_id: "P1", unit_price: 123 }];
+    const omie = { P2: 50 };
+    mergeCustomerPrices(local, omie);
+    expect(local).toEqual([{ product_id: "P1", unit_price: 123 }]);
+    expect(omie).toEqual({ P2: 50 });
+  });
+});
+
+describe("isValidUnitPrice — guard money-path (finito e > 0)", () => {
+  it("aceita número positivo finito", () => {
+    expect(isValidUnitPrice(123)).toBe(true);
+    expect(isValidUnitPrice(0.01)).toBe(true);
+  });
+
+  it("rejeita 0, negativo, NaN, ±Infinity", () => {
+    for (const bad of [0, -1, NaN, Infinity, -Infinity]) {
+      expect(isValidUnitPrice(bad)).toBe(false);
+    }
+  });
+
+  it("rejeita não-números (null, undefined, string)", () => {
+    for (const bad of [null, undefined, "123"]) {
+      expect(isValidUnitPrice(bad)).toBe(false);
+    }
+  });
+});

--- a/src/lib/pricing/mergeCustomerPrices.ts
+++ b/src/lib/pricing/mergeCustomerPrices.ts
@@ -1,0 +1,39 @@
+/**
+ * Helper money-path: resolve o "último preço praticado por produto" que o edge
+ * `analyze-unified-order` injeta nas sugestões de pedido do vendedor.
+ *
+ * Regra (NÃO reverter — já foi revertida 1× pelo deploy do Lovable, 08431871):
+ *   - order_items (local) é a FONTE DE VERDADE → VENCE;
+ *   - o Omie só PREENCHE GAPS (produtos sem preço local);
+ *   - preço inválido (≤0, NaN, ±Infinity, não-numérico) é IGNORADO em ambos os lados
+ *     (money-path: ausente ≠ zero — nunca sugerir R$0 como "praticado").
+ *
+ * O bloco entre os marcadores MIRROR-START/END é ESPELHADO VERBATIM no edge (Deno não
+ * importa de src/). A paridade src×edge e o uso real são vigiados por
+ * src/__tests__/edge-money-path-invariants.test.ts; a canária {canary:true} prova o
+ * comportamento DEPLOYADO via probe HTTP. Ver docs/agent/money-path.md (§ "Helper espelhado").
+ */
+
+/** Conveniência de tipo para os testes/edge (uma linha de order_items). */
+export type LocalPriceRow = { product_id?: string | null; unit_price?: number | null };
+
+// MIRROR-START mergeCustomerPrices — manter IDÊNTICO no edge analyze-unified-order/index.ts (sem `export`)
+export function isValidUnitPrice(p: unknown): p is number {
+  return typeof p === "number" && Number.isFinite(p) && p > 0;
+}
+export function mergeCustomerPrices(
+  localPrices: ReadonlyArray<{ product_id?: string | null; unit_price?: number | null }>,
+  omiePrices: Record<string, number>,
+): Record<string, number> {
+  const priceMap: Record<string, number> = {};
+  for (const row of localPrices) {
+    const id = row?.product_id;
+    const price = row?.unit_price;
+    if (id && isValidUnitPrice(price) && !(id in priceMap)) priceMap[id] = price;
+  }
+  for (const [productId, price] of Object.entries(omiePrices)) {
+    if (productId && isValidUnitPrice(price) && !(productId in priceMap)) priceMap[productId] = price;
+  }
+  return priceMap;
+}
+// MIRROR-END mergeCustomerPrices

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -21,6 +21,29 @@ function ilikeOr(term: string, ...cols: string[]): string {
   return cols.map((c) => `${c}.ilike.%${safe}%`).join(",");
 }
 
+// MIRROR-START mergeCustomerPrices — manter IDÊNTICO ao helper de src/lib/pricing/mergeCustomerPrices.ts
+// (Deno não importa de src/). MONEY-PATH: order_items VENCE, Omie só preenche gap, preço inválido
+// (≤0/NaN/Infinity) ignorado. A paridade deste bloco × src é vigiada pelo CI (edge-money-path-invariants).
+function isValidUnitPrice(p: unknown): p is number {
+  return typeof p === "number" && Number.isFinite(p) && p > 0;
+}
+function mergeCustomerPrices(
+  localPrices: ReadonlyArray<{ product_id?: string | null; unit_price?: number | null }>,
+  omiePrices: Record<string, number>,
+): Record<string, number> {
+  const priceMap: Record<string, number> = {};
+  for (const row of localPrices) {
+    const id = row?.product_id;
+    const price = row?.unit_price;
+    if (id && isValidUnitPrice(price) && !(id in priceMap)) priceMap[id] = price;
+  }
+  for (const [productId, price] of Object.entries(omiePrices)) {
+    if (productId && isValidUnitPrice(price) && !(productId in priceMap)) priceMap[productId] = price;
+  }
+  return priceMap;
+}
+// MIRROR-END mergeCustomerPrices
+
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
@@ -169,7 +192,23 @@ serve(async (req) => {
       }
     }
 
-    const { text, imageBase64, imagesBase64, products, userTools, customerUserId, searchCustomer } = await req.json();
+    const { text, imageBase64, imagesBase64, products, userTools, customerUserId, searchCustomer, canary } = await req.json();
+
+    // CANÁRIA COMPORTAMENTAL (staff-gated — já passou pelo gate de auth+staff acima). Prova que o
+    // merge de preço REALMENTE DEPLOYADO honra "order_items vence o Omie": local=123 deve vencer
+    // Omie=999. Probe HTTP = única evidência de que o deploy do Lovable não reverteu a lógica.
+    // Roda o helper REAL (não uma cópia do teste) e não toca LLM/Omie/DB. Ver edge-money-path-invariants.
+    if (canary === true) {
+      const resolved = mergeCustomerPrices(
+        [{ product_id: "CANARY", unit_price: 123 }],
+        { CANARY: 999 },
+      ).CANARY;
+      const expected = 123;
+      return new Response(
+        JSON.stringify({ canary: true, resolved, expected, ok: resolved === expected }),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
 
     // Support single image (imageBase64) or multiple images (imagesBase64)
     const allImages: string[] = [];
@@ -1197,15 +1236,17 @@ Responda SEMPRE usando a função identify_order_items.`;
     // Enrich products and suggestions with customer-specific last practiced prices
     if (validCustomer?.user_id || validCustomer?.codigo_cliente) {
       try {
-        const priceMap: Record<string, number> = {};
-
-        // 1) Local DB: order_items (FONTE DE VERDADE). `sales_price_history` REMOVIDO daqui — o
+        // FONTE DE VERDADE: order_items (último praticado). `sales_price_history` REMOVIDO daqui — o
         // writer legado omie-analytics-sync (aposentado) poluiu a sph com created_at de CARGA, e a
         // leitura por created_at DESC mascarava o preço (3.995 duplicatas com-pedido; 854 com
         // unit_price divergente = ambíguo, intocável sem identidade de linha Omie). order_items
         // cobre 99,84% dos pares (cliente,produto) da sph; o resto cai no fallback Omie abaixo.
         // Espelha o Caminho B já feito no hook (RPC get_ultimos_precos_cliente). created_at de
         // order_items = data real do pedido (trigger #1047), não data de carga.
+        const localPrices: Array<{ product_id?: string | null; unit_price?: number | null }> = [];
+        // Omie (fallback) colapsado p/ Record<productId, price>; o MERGE final passa pelo helper.
+        const omiePricesByProductId: Record<string, number> = {};
+
         if (validCustomer?.user_id) {
           const { data: orderItemsData } = await supabase
             .from("order_items")
@@ -1216,9 +1257,7 @@ Responda SEMPRE usando a função identify_order_items.`;
 
           if (orderItemsData) {
             for (const ph of orderItemsData) {
-              if (ph.product_id && !priceMap[ph.product_id]) {
-                priceMap[ph.product_id] = ph.unit_price;
-              }
+              localPrices.push({ product_id: ph.product_id, unit_price: ph.unit_price });
             }
           }
         }
@@ -1300,54 +1339,47 @@ Responda SEMPRE usando a função identify_order_items.`;
             }
 
             const omieResults = await Promise.all(omiePricePromises);
-            
-            // Merge Omie prices — FALLBACK: só preenche produtos SEM preço local (order_items vence).
-            // Era OVERRIDE, mas fetchOmiePrices pega o "primeiro encontrado" do ListarPedidos (pagina 1,
-            // 50 reg, SEM ordenar_por) = ordem NÃO garantida → podia mascarar o último preço PRATICADO
-            // (order_items, ordenado por created_at real DESC, trigger #1047). order_items é a fonte de
-            // verdade do praticado; o Omie cobre só os gaps (produtos sem pedido local). Alinha com o
-            // hook useCustomerSelection (#1065, que já tirou o overlay do Omie do preço-cliente).
-            // ⚠️ NÃO reverter p/ override no deploy do Lovable (já foi revertido 1× — 08431871 pós-#1077).
+
+            // Resolve mappings faltantes (omieCode→productId) ANTES de colapsar — antes isto era um
+            // 2º "re-apply" incremental; agora resolvemos tudo e colapsamos UMA vez (mesmo resultado).
+            const allOmieCodes = omieResults.flatMap((r) => Object.keys(r).map(Number));
+            const missingCodes = allOmieCodes.filter((c) => !omieCodeMap[c]);
+            if (missingCodes.length > 0) {
+              const { data: extraMappings } = await supabase
+                .from("omie_products")
+                .select("id, omie_codigo_produto")
+                .in("omie_codigo_produto", missingCodes);
+              if (extraMappings) {
+                for (const pm of extraMappings) {
+                  omieCodeMap[pm.omie_codigo_produto] = pm.id;
+                }
+              }
+            }
+
+            // Colapsa omieResults → Record<productId, price> (first-wins por produto, só preços
+            // válidos). fetchOmiePrices pega o "primeiro encontrado" do ListarPedidos (ordem NÃO
+            // garantida); por isso o MERGE com order_items é FALLBACK — o helper espelhado abaixo faz
+            // order_items VENCER e o Omie só preencher gap. ⚠️ NÃO reverter p/ override no deploy do
+            // Lovable (já foi revertido 1× — 08431871 pós-#1077; alinhado ao hook #1065).
+            // Resolver o omieCodeMap completo e colapsar 1× é equivalente ao re-apply incremental
+            // anterior: omie_products.id é PK e omie_codigo_produto↔id é bijeção (0 colisões —
+            // conferido via psql-ro), logo cada productId tem 1 código Omie e a ordem é irrelevante.
             for (const omiePrices of omieResults) {
               for (const [omieCode, price] of Object.entries(omiePrices)) {
                 const productId = omieCodeMap[Number(omieCode)];
-                if (productId && price > 0 && !priceMap[productId]) {
-                  priceMap[productId] = price; // só preenche gap
+                if (productId && isValidUnitPrice(price) && !(productId in omiePricesByProductId)) {
+                  omiePricesByProductId[productId] = price;
                 }
               }
             }
-
-            // Also build a broader omie code map for all products in catalog (for items not yet in omieCodeMap)
-            if (Object.keys(omieResults.reduce((acc, r) => ({ ...acc, ...r }), {})).length > 0) {
-              const allOmieCodes = omieResults.flatMap(r => Object.keys(r).map(Number));
-              const missingCodes = allOmieCodes.filter(c => !omieCodeMap[c]);
-              if (missingCodes.length > 0) {
-                const { data: extraMappings } = await supabase
-                  .from("omie_products")
-                  .select("id, omie_codigo_produto")
-                  .in("omie_codigo_produto", missingCodes);
-                if (extraMappings) {
-                  for (const pm of extraMappings) {
-                    omieCodeMap[pm.omie_codigo_produto] = pm.id;
-                  }
-                  // Re-apply Omie prices with new mappings (mesma semântica FALLBACK: só gaps)
-                  for (const omiePrices of omieResults) {
-                    for (const [omieCode, price] of Object.entries(omiePrices)) {
-                      const productId = omieCodeMap[Number(omieCode)];
-                      if (productId && price > 0 && !priceMap[productId]) {
-                        priceMap[productId] = price;
-                      }
-                    }
-                  }
-                }
-              }
-            }
-
-            console.log(`[analyze-unified-order] Omie price enrichment: found ${Object.keys(priceMap).length} prices`);
           } catch (omieErr) {
             console.error("Error fetching Omie prices for AI response:", omieErr);
           }
         }
+
+        // MERGE money-path (helper espelhado): order_items VENCE, Omie só preenche gap, ≤0 ignorado.
+        const priceMap = mergeCustomerPrices(localPrices, omiePricesByProductId);
+        console.log(`[analyze-unified-order] Price enrichment: ${Object.keys(priceMap).length} prices (order_items vence; Omie preenche gap)`);
 
         // Apply prices to products
         for (const vp of validProducts) {


### PR DESCRIPTION
## O quê
Canária comportamental que prova o **comportamento DEPLOYADO** do merge de preço no edge `analyze-unified-order` (money-path). Follow-up do #1084 (guard textual na fonte).

## Por quê
O deploy de edge no Lovable pode reverter um fix money-path e commitar a reversão na `main` (fallback→override do merge de preço — mordido em `08431871` pós-#1077). O guard textual #1084 pega a reversão na **fonte**. Faltava o nível de **comportamento**: o failure mode "Lovable deploya da cópia interna sem refletir na main" só uma canária pega.

## O que mudou
- **`src/lib/pricing/mergeCustomerPrices.ts`** (novo): helper puro. `order_items` VENCE, Omie só preenche gap, preço `≤0/NaN/Infinity` ignorado (money-path #5). 15 testes vitest.
- **edge `analyze-unified-order`**: bloco `MIRROR-START/END` (espelho **verbatim** do helper — Deno não importa de `src/`) + merge via helper (1 chamada; resolve `omieCodeMap` completo antes de colapsar) + canária `{canary:true}` staff-gated.
- **CI guard #1084** (`edge-money-path-invariants.test.ts`): agora verifica que o edge **USA** o helper + **PARIDADE** src×edge (pega reescrita do Lovable no deploy) + presença da canária — não só os gates textuais. O `describe` do `algorithm-a-audit` foi preservado.

## Mudança de comportamento intencional
O gate `≤0` agora vale para o lado **LOCAL** também (antes só o Omie tinha `> 0`). Efeito: `order_item` com preço **negativo** deixa de ser sugerido ao vendedor (antes exibia `-5`); `0` nunca foi aplicado de fato (gate truthy na aplicação final). Alinhado com money-path #5 (preço > 0 e finito).
**Decisão de produto**: se `0`/negativo for sinal legítimo (bonificação/crédito/ajuste), me avise que reabro.

## Ritual money-path
- `prove-sql`: N/A (é TS, não SQL).
- **Codex challenge** (gpt-5.5, high): 7 findings, **nenhum bug acionável**.
  - **Finding 1** (colapso Omie divergiria do re-apply incremental): **provado impossível** — `omie_products.id` é PK e `omie_codigo_produto↔id` é bijeção (0 colisões, conferido via `psql-ro`) → cada `productId` tem 1 código Omie, ordem do colapso irrelevante. Invariante documentada no código.
  - **Findings 2/6** (gate `≤0`): mudança intencional acima.
  - **Finding 4** (canária estreita): **limitação conhecida** — a canária prova "helper deployado + local-vence-Omie", mas NÃO pega um real-path que ignore o helper mantendo a canária intacta. O guard textual (paridade + `priceMap = mergeCustomerPrices(`) cobre isso na **fonte**.
  - Findings 3/5/7: caracterizações corretas, sem bug.
- Verificação local: **4147 testes**, typecheck 0 erros, lint 0 erros.

## Pendente do founder — critério de pronto
1. **Deploy do edge** `analyze-unified-order` pelo chat do Lovable (verbatim do repo, **após o merge na main**). ⚠️ Conferir os 2 gates `!(… in priceMap)` no código deployado antes de confirmar — o Lovable pode reverter.
2. **Verificação 2-camadas** (`docs/agent/deploy.md`):
   - **Fonte**: CI guard valida a main automaticamente.
   - **Comportamento**: probe HTTP staff-gated:
     ```bash
     curl -sS -X POST "https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/analyze-unified-order" \
       -H "Authorization: Bearer <SEU_JWT_DE_STAFF>" \
       -H "Content-Type: application/json" \
       -d '{"canary":true}'
     # esperado: {"canary":true,"resolved":123,"expected":123,"ok":true}
     ```
     `ok:true` (resolved=123) = o merge deployado honra "order_items vence o Omie". `ok:false` (resolved=999) = reversão para override no deploy.

⚠️ **DRAFT**: segura o auto-merge. Tire do draft quando quiser que o CI valide + auto-mergeie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
