### PR TITLE
feat(reposicao): motor escolhe galão econômico + consolida estoque de grupo (QT↔GL) [money-path]

### DIFF
--- a/db/embalagem-motor-rpc.sql
+++ b/db/embalagem-motor-rpc.sql
@@ -1,0 +1,323 @@
+-- Migration: embalagem econômica DENTRO do motor de pedidos (QT↔GL) + consolidação de estoque de grupo
+-- ⚠️ APLICADA MANUALMENTE no SQL Editor do Lovable em 2026-06-26 (NÃO vai em supabase/migrations/ — CLAUDE.md §5;
+--     é CREATE OR REPLACE de função existente). Este arquivo é a FONTE versionada + fixture da regressão db/test-embalagem-motor.sh.
+-- Spec: docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
+-- Money-path. Recria gerar_pedidos_sugeridos_ciclo (pré-flight pg_get_functiondef feito; base = prod 26/06).
+--
+-- DUAS mudanças cirúrgicas, tudo o mais PRESERVADO:
+--   1) CONSOLIDA o estoque no nível do grupo de equivalência (Σ membros: GREATEST(inv,sea) físico + pendente + trânsito).
+--      O gatilho passa a olhar o estoque do GRUPO → para de comprar quando há galão parado.
+--   2) ESCOLHE a embalagem mais barata por unidade-base (galão), ESTRITO: só troca o quartinho pelo galão
+--      quando AMBOS têm preço-app fresco (≤ N dias) + portal-map + catálogo OK, e o galão é estritamente mais barato/base.
+--      Senão mantém o quartinho. Custo da linha do galão = preço-app (R$/embalagem), nunca 0.
+--
+-- Unidade (cravada em prod): qtde_final = nº de EMBALAGENS do SKU; preco_unitario = R$/embalagem; o disparo
+-- consome ceil(qtde_final) direto (fator_conversao=1). Quartinho NÃO é tocado (mantém cmc cru).
+-- ⚠️ Case: equivalencia/preço_capturado = lower(empresa); parametros/estoque/fornecedor_externo = empresa (upper).
+--
+-- Revisão pós-Codex (xhigh) — 6 correções vs. o 1º rascunho:
+--   P0-a GREATEST(inventory_position.saldo, sku_estoque_atual): galão parado vive em fontes DIFERENTES por SKU.
+--   P0-b em_transito do galão × fator_para_base (2 galões em voo = 8 unidades-base, não 2) → anti double-buy.
+--   P1-c âncora NÃO pode ser membro fator>1 (galão) de um grupo → impede 2 linhas do mesmo GL.
+--   P1-d anti-duplicidade de oportunidade cobre a âncora E o SKU escolhido (galão).
+--   P1-e minimo_forcado_manual respeitado também na troca p/ galão (piso aplicado ANTES de dividir pelo fator).
+--   P1-f filtros de catálogo (ativo/tipo 04/família/status omie) aplicados ao MEMBRO escolhido, não só à âncora.
+-- Granularidade (P2 Codex, aceito): nº_galões = ceil(necessidade / fator) na escala "unidades-âncora" — NUNCA
+--   compra menos que o legado QT (herda o descasamento litros↔embalagem pré-existente, fora de escopo).
+
+CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
+ RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
+ LANGUAGE plpgsql
+ SET search_path TO 'public', 'pg_temp'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_pedidos INT := 0;
+  v_skus INT := 0;
+  v_valor NUMERIC := 0;
+  v_bloqueados INT := 0;
+  v_stale_dias INT := 45;  -- motor confia no preço-app por N dias (painel usa 24h; manual precisa folga). Config abaixo.
+BEGIN
+  -- [INTRADAY 1/4] serializa execuções concorrentes (cron 2/2h × botão "Recalcular" × retry).
+  PERFORM pg_advisory_xact_lock(hashtext('gerar_pedidos_sugeridos_ciclo:' || lower(p_empresa)));
+
+  IF (SELECT count(*) FILTER (WHERE tipo_produto IS NOT NULL) FROM public.omie_products WHERE account = lower(p_empresa)) = 0 THEN
+    RAISE EXCEPTION 'tipo_produto_unhealthy: sinal de classificação ausente em omie_products(account=%) — recusando gerar compras p/ não tratar Produto Acabado como comprável', lower(p_empresa);
+  END IF;
+
+  -- Janela de frescor do preço-app que o motor aceita p/ trocar a embalagem (decisão B da spec). Global.
+  SELECT COALESCE((SELECT NULLIF(btrim(value), '')::int
+                   FROM company_config WHERE key = 'embalagem_preco_motor_stale_dias' LIMIT 1), 45)
+    INTO v_stale_dias;
+
+  -- [INTRADAY 2/4] expira pendentes NORMAIS de ciclos anteriores (zumbis pós-corte).
+  UPDATE pedido_compra_sugerido
+  SET status = 'expirado_sem_aprovacao', atualizado_em = now()
+  WHERE empresa = p_empresa
+    AND data_ciclo < p_data_ciclo
+    AND status = 'pendente_aprovacao'
+    AND COALESCE(tipo_ciclo, 'normal') = 'normal';
+
+  -- [INTRADAY 3/4] limpeza do dia: só ciclo NORMAL (preserva oportunidade/promoção pendentes) e
+  -- INCLUI bloqueado_guardrail do dia (re-avaliado a cada rodada; anti compra dupla).
+  DELETE FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo
+    AND status IN ('pendente_aprovacao', 'bloqueado_guardrail')
+    AND COALESCE(tipo_ciclo, 'normal') = 'normal';
+
+  WITH em_transito AS (
+    SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+    FROM pedido_compra_item pci
+    JOIN pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+    WHERE pcs2.empresa = p_empresa
+      AND (
+        (pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido') AND pcs2.data_ciclo >= (p_data_ciclo - INTERVAL '7 days'))
+        OR (pcs2.status_envio_portal IN ('sucesso_portal','enviado_portal') AND pcs2.portal_protocolo IS NOT NULL AND pcs2.omie_pedido_compra_numero IS NULL AND pcs2.status NOT IN ('cancelado','expirado_sem_aprovacao'))
+      )
+    GROUP BY pcs2.empresa, pci.sku_codigo_omie
+  ),
+  preco_medio AS (
+    SELECT slh.empresa::text AS empresa, slh.sku_codigo_omie::text AS sku_codigo_omie,
+           AVG(slh.valor_total / NULLIF(slh.quantidade_recebida, 0)) AS preco_unitario, COUNT(*) AS n
+    FROM sku_leadtime_history slh
+    WHERE slh.quantidade_recebida > 0 AND slh.valor_total > 0
+    GROUP BY slh.empresa, slh.sku_codigo_omie
+  ),
+  -- ── EMBALAGEM (novo) ─────────────────────────────────────────────────────────────────────
+  -- Membros ativos dos grupos de equivalência (empresa = lower).
+  equiv AS (
+    SELECT grupo_id, sku_codigo_omie::text AS sku, fator_para_base
+    FROM sku_embalagem_equivalencia
+    WHERE empresa = lower(p_empresa) AND ativo = TRUE AND fator_para_base > 0
+  ),
+  -- Só grupos com >= 2 membros têm decisão de embalagem.
+  equiv_grupos AS (
+    SELECT grupo_id FROM equiv GROUP BY grupo_id HAVING count(*) >= 2
+  ),
+  -- Preço-app mais recente por SKU (empresa = lower), líquido e > 0.
+  preco_app AS (
+    SELECT DISTINCT ON (sku_codigo_omie) sku_codigo_omie::text AS sku, preco, capturado_em
+    FROM sku_preco_fornecedor_capturado
+    WHERE empresa = lower(p_empresa) AND status = 'ok' AND preco > 0
+    ORDER BY sku_codigo_omie, capturado_em DESC
+  ),
+  -- Portal-map ativo por SKU (empresa = upper). Sem map → não dá pra emitir ao portal → inelegível.
+  portal_map AS (
+    SELECT DISTINCT sku_omie::text AS sku
+    FROM sku_fornecedor_externo
+    WHERE empresa = p_empresa AND ativo = TRUE AND sku_portal IS NOT NULL AND btrim(sku_portal) <> ''
+  ),
+  -- [P0-a] Saldo físico do Omie por SKU (account-aware; 1 linha/SKU, a mais recente). As 2 fontes de estoque
+  -- DIVERGEM: inventory_position tem alguns galões (WP87/WP04), sku_estoque_atual tem outros (WP01). GREATEST
+  -- (adiante) pega o galão real de onde estiver.
+  inv_saldo AS (
+    SELECT DISTINCT ON (omie_codigo_produto) omie_codigo_produto::text AS sku, saldo
+    FROM inventory_position
+    WHERE account = ANY (CASE lower(p_empresa)
+            WHEN 'oben' THEN ARRAY['vendas'::text,'oben'::text]
+            WHEN 'colacor' THEN ARRAY['colacor_vendas'::text,'colacor'::text]
+            WHEN 'colacor_sc' THEN ARRAY['servicos'::text,'colacor_sc'::text]
+            ELSE ARRAY[lower(p_empresa)] END)
+    ORDER BY omie_codigo_produto, synced_at DESC NULLS LAST
+  ),
+  -- [P1-f] Membro ELEGÍVEL p/ a decisão: preço-app FRESCO + portal-map + CATÁLOGO OK (ativo, tipo≠04, família
+  -- comprável, ativo_no_omie) — os MESMOS filtros que protegem a âncora, agora também no SKU que pode ser escolhido.
+  membro_elegivel AS (
+    SELECT e.grupo_id, e.sku, e.fator_para_base, pa.preco,
+           (pa.preco / e.fator_para_base) AS custo_base
+    FROM equiv e
+    JOIN equiv_grupos eg ON eg.grupo_id = e.grupo_id
+    JOIN preco_app pa ON pa.sku = e.sku AND pa.capturado_em >= now() - make_interval(days => v_stale_dias)
+    JOIN portal_map pm ON pm.sku = e.sku
+    JOIN omie_products opm ON opm.omie_codigo_produto::text = e.sku AND opm.account = lower(p_empresa)
+    LEFT JOIN sku_status_omie ssom ON ssom.empresa = p_empresa AND ssom.sku_codigo_omie = e.sku
+    LEFT JOIN familia_nao_comprada fncm ON fncm.empresa = p_empresa AND fncm.familia = opm.familia
+    WHERE COALESCE(opm.ativo, TRUE) = TRUE
+      AND COALESCE(ssom.ativo_no_omie, TRUE) = TRUE
+      AND fncm.id IS NULL
+      AND COALESCE(opm.tipo_produto, opm.metadata->>'tipo_produto', '') <> '04'
+      AND COALESCE(opm.descricao, '') NOT ILIKE '%450ML'   -- [P1-f] os MESMOS filtros de catálogo da âncora
+      AND COALESCE(opm.descricao, '') NOT ILIKE '%405ML'
+  ),
+  -- Melhor embalagem do grupo (menor custo_base; empate → embalagem maior).
+  embalagem_escolhida AS (
+    SELECT DISTINCT ON (grupo_id)
+           grupo_id, sku AS sku_escolhido, fator_para_base AS fator_escolhido,
+           preco AS preco_escolhido, custo_base AS custo_base_escolhido
+    FROM membro_elegivel
+    ORDER BY grupo_id, custo_base ASC, fator_para_base DESC
+  ),
+  -- [P0-a/P0-b] Estoque consolidado por grupo (escala unidades-âncora):
+  --   físico = Σ GREATEST(inv.saldo, sea.estoque_fisico)   ← pega o galão real de onde estiver
+  --   a caminho = Σ [pendente(sea) + em_transito × fator]  ← galão em voo conta em unidades-base (2 GL = 8), não cru
+  grupo_estoque AS (
+    SELECT e.grupo_id,
+           SUM(GREATEST(COALESCE(inv.saldo, 0), COALESCE(sea.estoque_fisico, 0)))                              AS fisico_grupo,
+           SUM(COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0) * e.fator_para_base)           AS acaminho_grupo,
+           SUM(GREATEST(COALESCE(inv.saldo, 0), COALESCE(sea.estoque_fisico, 0))
+               + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0) * e.fator_para_base)         AS estoque_grupo
+    FROM equiv e
+    LEFT JOIN sku_estoque_atual sea ON sea.empresa = p_empresa AND sea.sku_codigo_omie = e.sku
+    LEFT JOIN inv_saldo inv        ON inv.sku = e.sku
+    LEFT JOIN em_transito et       ON et.sku_codigo_omie = e.sku
+    GROUP BY e.grupo_id
+  ),
+  -- ── BASE: 1 linha por ÂNCORA (SKU com sku_parametros, i.e. o quartinho) que dispara ──────────
+  sku_base AS (
+    SELECT sp.empresa, sp.sku_codigo_omie::text AS ancora_sku, sp.sku_descricao, sp.fornecedor_nome,
+           sg.grupo_codigo, sp.ponto_pedido, sp.estoque_maximo, sp.minimo_forcado_manual,
+           COALESCE(sea.estoque_fisico, 0) AS estoque_fisico_proprio,
+           (COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS acaminho_proprio,
+           ea.grupo_id AS equiv_grupo,
+           ge.estoque_grupo, ge.fisico_grupo, ge.acaminho_grupo,
+           -- estoque efetivo: do GRUPO quando a âncora pertence a um grupo; senão o próprio (no-op p/ a maioria).
+           COALESCE(ge.estoque_grupo,
+                    COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) AS estoque_efetivo,
+           ee.sku_escolhido, ee.fator_escolhido, ee.preco_escolhido, ee.custo_base_escolhido,
+           me_anc.custo_base AS ancora_custo_base,  -- NULL = âncora não-elegível → estrito (não troca)
+           -- custo da linha p/ a ÂNCORA (mantém comportamento atual: cmc account-aware, senão preço médio, senão 0).
+           COALESCE(
+             ( SELECT ipc.cmc FROM inventory_position ipc
+               WHERE ipc.omie_codigo_produto::text = sp.sku_codigo_omie::text
+                 AND ipc.account = ANY (CASE lower(p_empresa)
+                       WHEN 'oben' THEN ARRAY['vendas'::text,'oben'::text]
+                       WHEN 'colacor' THEN ARRAY['colacor_vendas'::text,'colacor'::text]
+                       WHEN 'colacor_sc' THEN ARRAY['servicos'::text,'colacor_sc'::text]
+                       ELSE ARRAY[lower(p_empresa)] END)
+                 AND ipc.cmc > 0
+               ORDER BY ipc.synced_at DESC NULLS LAST
+               LIMIT 1 ),
+             pm.preco_unitario, 0) AS preco_unitario_ancora,
+           (pm.n IS NULL) AS primeira_compra,
+           fh.horario_corte_pedido, fh.valor_maximo_mensal, fh.delta_max_perc
+    FROM sku_parametros sp
+    LEFT JOIN sku_grupo_producao sg ON sg.empresa = sp.empresa AND sg.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN sku_estoque_atual sea ON sea.empresa = sp.empresa AND sea.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN fornecedor_habilitado_reposicao fh ON fh.empresa = sp.empresa AND fh.fornecedor_nome = sp.fornecedor_nome
+    LEFT JOIN omie_products op ON op.omie_codigo_produto::text = sp.sku_codigo_omie::text AND op.account = lower(p_empresa)
+    LEFT JOIN familia_nao_comprada fnc ON fnc.empresa = sp.empresa AND fnc.familia = op.familia
+    LEFT JOIN em_transito et ON et.empresa = sp.empresa AND et.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN preco_medio pm ON pm.empresa = sp.empresa AND pm.sku_codigo_omie = sp.sku_codigo_omie::text
+    LEFT JOIN inventory_position ip ON ip.omie_codigo_produto::text = sp.sku_codigo_omie::text AND ip.account = lower(p_empresa)
+    LEFT JOIN sku_status_omie sso ON sso.empresa = sp.empresa AND sso.sku_codigo_omie = sp.sku_codigo_omie::text
+    -- equivalência da âncora + estoque consolidado + escolha de embalagem (NULL p/ SKU sem grupo).
+    LEFT JOIN equiv ea ON ea.sku = sp.sku_codigo_omie::text
+    LEFT JOIN grupo_estoque ge ON ge.grupo_id = ea.grupo_id
+    LEFT JOIN embalagem_escolhida ee ON ee.grupo_id = ea.grupo_id
+    LEFT JOIN membro_elegivel me_anc ON me_anc.grupo_id = ea.grupo_id AND me_anc.sku = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+      AND sp.habilitado_reposicao_automatica = TRUE
+      AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+      AND sp.fornecedor_nome IS NOT NULL
+      AND btrim(sp.fornecedor_nome) <> ''
+      AND fnc.id IS NULL
+      AND COALESCE(op.ativo, true) = true
+      AND COALESCE(sso.ativo_no_omie, true) = true
+      AND COALESCE(op.descricao, '') NOT ILIKE '%450ML'
+      AND COALESCE(op.descricao, '') NOT ILIKE '%405ML'
+      AND COALESCE((
+            SELECT COALESCE(op04.tipo_produto, op04.metadata->>'tipo_produto')
+            FROM omie_products op04
+            WHERE op04.omie_codigo_produto::text = sp.sku_codigo_omie::text
+              AND op04.account = lower(p_empresa)
+            LIMIT 1
+          ), '') <> '04'
+      -- [P1-c] A âncora NÃO pode ser um galão (membro fator>1 de um grupo): senão um GL com ponto/max viraria
+      -- âncora E seria escolhido por outro membro → 2 linhas do mesmo GL (uma com custo CMC/0). A âncora é
+      -- sempre a unidade-base (fator 1). (Hoje no-op: galões têm ponto/max NULL; isto blinda o futuro.)
+      AND NOT EXISTS (
+            SELECT 1 FROM equiv eg2
+            WHERE eg2.sku = sp.sku_codigo_omie::text AND eg2.fator_para_base > 1
+          )
+      -- [INTRADAY 4/4] o anti-dup de oportunidade foi MOVIDO p/ depois da decisão (skus_necessitando), porque
+      -- precisa olhar o SKU FINAL (âncora OU galão escolhido), não o candidato — senão bloquearia o quartinho
+      -- mantido por causa de uma oportunidade do galão que nem vai ser comprado. [P1-d, refinado pós-re-Codex]
+      AND sp.ponto_pedido IS NOT NULL
+      AND sp.estoque_maximo IS NOT NULL
+      -- GATILHO consolidado: estoque do GRUPO (ou próprio) <= ponto_pedido da âncora.
+      AND COALESCE(ge.estoque_grupo,
+                   COALESCE(sea.estoque_fisico, 0) + COALESCE(sea.estoque_pendente_entrada, 0) + COALESCE(et.qtde, 0)) <= sp.ponto_pedido
+  ),
+  -- ── DECISÃO: troca p/ galão só se ESTRITAMENTE mais barato/base e a âncora também é elegível ──
+  skus_necessitando AS (
+    SELECT b.empresa,
+           CASE WHEN trocou THEN b.sku_escolhido ELSE b.ancora_sku END AS sku_codigo_omie,
+           CASE WHEN trocou
+                THEN COALESCE((SELECT op2.descricao FROM omie_products op2
+                               WHERE op2.omie_codigo_produto::text = b.sku_escolhido
+                                 AND op2.account = lower(p_empresa) LIMIT 1), b.sku_descricao)
+                ELSE b.sku_descricao END AS sku_descricao,
+           b.fornecedor_nome, b.grupo_codigo, b.ponto_pedido, b.estoque_maximo,
+           COALESCE(b.fisico_grupo, b.estoque_fisico_proprio)  AS estoque_fisico,
+           COALESCE(b.acaminho_grupo, b.acaminho_proprio)      AS estoque_a_caminho,
+           b.estoque_efetivo,
+           ceil(b.estoque_maximo - b.estoque_efetivo) AS qtde_sugerida,  -- gate >0 (unidades-âncora)
+           -- nº de embalagens do SKU escolhido: galão = ceil(necessidade / fator); quartinho = lógica atual.
+           -- [P1-e] minimo_forcado_manual (unidades-âncora) aplicado como piso ANTES de dividir pelo fator.
+           CASE
+             WHEN trocou THEN ceil(GREATEST(b.estoque_maximo - b.estoque_efetivo,
+                                            COALESCE(b.minimo_forcado_manual, 0)) / b.fator_escolhido)
+             WHEN b.minimo_forcado_manual IS NOT NULL AND b.minimo_forcado_manual > 0
+                  THEN ceil(GREATEST(b.estoque_maximo - b.estoque_efetivo, b.minimo_forcado_manual))
+             ELSE ceil(b.estoque_maximo - b.estoque_efetivo)
+           END AS qtde_final,
+           -- custo da linha: galão → preço-app (R$/embalagem, nunca 0); quartinho → cmc atual.
+           CASE WHEN trocou THEN b.preco_escolhido ELSE b.preco_unitario_ancora END AS preco_unitario,
+           b.primeira_compra, b.horario_corte_pedido, b.valor_maximo_mensal, b.delta_max_perc
+    FROM (
+      SELECT b0.*,
+             ( b0.sku_escolhido IS NOT NULL
+               AND b0.sku_escolhido <> b0.ancora_sku
+               AND b0.ancora_custo_base IS NOT NULL                 -- âncora elegível (comparável)
+               AND b0.custo_base_escolhido < b0.ancora_custo_base   -- galão estritamente mais barato/base
+             ) AS trocou
+      FROM sku_base b0
+    ) b
+    -- [P1-d] [INTRADAY 4/4] anti-dup de oportunidade sobre o SKU FINAL (o que SERÁ gravado: âncora ou galão).
+    -- Aqui já se sabe "trocou", então não bloqueia o quartinho mantido por uma oportunidade do galão não-usado.
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM pedido_compra_item pci9
+      JOIN pedido_compra_sugerido pcs9 ON pcs9.id = pci9.pedido_id
+      WHERE pcs9.empresa = b.empresa
+        AND pcs9.status IN ('pendente_aprovacao', 'bloqueado_guardrail')
+        AND COALESCE(pcs9.tipo_ciclo, 'normal') <> 'normal'
+        AND pci9.sku_codigo_omie = CASE WHEN b.trocou THEN b.sku_escolhido ELSE b.ancora_sku END
+    )
+  ),
+  pedidos_por_fornecedor_grupo AS (
+    INSERT INTO pedido_compra_sugerido (
+      empresa, fornecedor_nome, grupo_codigo, data_ciclo, horario_corte_planejado,
+      valor_total, num_skus, status, condicao_pagamento_codigo, condicao_pagamento_descricao,
+      num_parcelas, dias_parcelas, condicao_origem
+    )
+    SELECT sn.empresa, sn.fornecedor_nome, sn.grupo_codigo, p_data_ciclo,
+           (p_data_ciclo + MAX(sn.horario_corte_pedido))::timestamptz,
+           SUM(sn.qtde_final * sn.preco_unitario), COUNT(*),
+           'pendente_aprovacao', '000', 'À Vista', 1, NULL, 'default_a_vista'
+    FROM skus_necessitando sn
+    WHERE sn.qtde_sugerida > 0
+    GROUP BY sn.empresa, sn.fornecedor_nome, sn.grupo_codigo
+    RETURNING id, fornecedor_nome, grupo_codigo
+  )
+  INSERT INTO pedido_compra_item (
+    pedido_id, sku_codigo_omie, sku_descricao, estoque_atual, ponto_pedido, estoque_maximo,
+    qtde_sugerida, qtde_final, preco_unitario, valor_linha, primeira_compra,
+    estoque_fisico, estoque_a_caminho
+  )
+  SELECT pfg.id, sn.sku_codigo_omie, sn.sku_descricao, sn.estoque_efetivo, sn.ponto_pedido, sn.estoque_maximo,
+         sn.qtde_sugerida, sn.qtde_final, sn.preco_unitario, sn.qtde_final * sn.preco_unitario, sn.primeira_compra,
+         sn.estoque_fisico, sn.estoque_a_caminho
+  FROM skus_necessitando sn
+  JOIN pedidos_por_fornecedor_grupo pfg
+    ON pfg.fornecedor_nome = sn.fornecedor_nome AND COALESCE(pfg.grupo_codigo,'') = COALESCE(sn.grupo_codigo,'')
+  WHERE sn.qtde_sugerida > 0;
+
+  SELECT COUNT(*), COALESCE(SUM(num_skus),0), COALESCE(SUM(valor_total),0)
+  INTO v_pedidos, v_skus, v_valor
+  FROM pedido_compra_sugerido
+  WHERE empresa = p_empresa AND data_ciclo = p_data_ciclo AND status = 'pendente_aprovacao';
+
+  RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados;
+END;
+$function$;

--- a/db/test-embalagem-motor.sh
+++ b/db/test-embalagem-motor.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# Prova PG17 — gerar_pedidos_sugeridos_ciclo: consolidação de estoque de grupo + escolha de embalagem (QT↔GL).
+# Spec: docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
+# Rodar: bash db/test-embalagem-motor.sh > /tmp/t.log 2>&1; echo "exit=$?"   (NÃO pipe pra tail — engole exit)
+# Lei de Ferro: aplica a função REAL; asserts numéricos; FALSIFICA (sabota → exige vermelho → restaura).
+# Cobre os 6 achados do Codex: GREATEST(2 fontes), em_transito×fator, galão-âncora, oportunidade, minimo, filtro-membro.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5466}"
+SLUG="embalagem-motor"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+MIG="$REPO_ROOT/db/embalagem-motor-rpc.sql"   # fonte versionada da função (aplicada manual em prod 26/06)
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1: stubs mínimos (tipos replicam o snapshot; inventory_position TEM saldo; item com FK CASCADE p/ a função limpar) ──
+P -q <<'SQL'
+CREATE TABLE public.sku_parametros (empresa text, sku_codigo_omie bigint, sku_descricao text, fornecedor_nome text,
+  ponto_pedido numeric, estoque_maximo numeric, minimo_forcado_manual numeric,
+  habilitado_reposicao_automatica boolean, tipo_reposicao text, demanda_media_diaria numeric);
+CREATE TABLE public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_pendente_entrada numeric);
+CREATE TABLE public.sku_embalagem_equivalencia (empresa text, grupo_id uuid, sku_codigo_omie text, fator_para_base numeric, ativo boolean);
+CREATE TABLE public.sku_preco_fornecedor_capturado (empresa text, sku_codigo_omie text, preco numeric, status text, capturado_em timestamptz);
+CREATE TABLE public.sku_fornecedor_externo (empresa text, sku_omie text, sku_portal text, ativo boolean);
+CREATE TABLE public.inventory_position (omie_codigo_produto bigint, account text, saldo numeric DEFAULT 0, cmc numeric, synced_at timestamptz);
+CREATE TABLE public.company_config (key text, value text);
+CREATE TABLE public.omie_products (omie_codigo_produto bigint, account text, descricao text, familia text, ativo boolean, tipo_produto text, metadata jsonb DEFAULT '{}');
+CREATE TABLE public.sku_grupo_producao (empresa text, sku_codigo_omie text, grupo_codigo text);
+CREATE TABLE public.sku_leadtime_history (empresa text, sku_codigo_omie text, quantidade_recebida numeric, valor_total numeric);
+CREATE TABLE public.fornecedor_habilitado_reposicao (empresa text, fornecedor_nome text, horario_corte_pedido interval, valor_maximo_mensal numeric, delta_max_perc numeric, lt_logistica_dias int);
+CREATE TABLE public.familia_nao_comprada (id bigserial PRIMARY KEY, empresa text, familia text);
+CREATE TABLE public.sku_status_omie (empresa text, sku_codigo_omie text, ativo_no_omie boolean);
+CREATE TABLE public.pedido_compra_sugerido (id bigserial PRIMARY KEY, empresa text, fornecedor_nome text, grupo_codigo text,
+  data_ciclo date, horario_corte_planejado timestamptz, valor_total numeric, num_skus int, status text,
+  condicao_pagamento_codigo text, condicao_pagamento_descricao text, num_parcelas int, dias_parcelas text, condicao_origem text,
+  tipo_ciclo text, status_envio_portal text, portal_protocolo text, omie_pedido_compra_numero text, atualizado_em timestamptz);
+CREATE TABLE public.pedido_compra_item (id bigserial PRIMARY KEY, pedido_id bigint REFERENCES pedido_compra_sugerido(id) ON DELETE CASCADE,
+  sku_codigo_omie text, sku_descricao text, estoque_atual numeric, ponto_pedido numeric, estoque_maximo numeric,
+  qtde_sugerida numeric, qtde_final numeric, preco_unitario numeric, valor_linha numeric, primeira_compra boolean,
+  estoque_fisico numeric, estoque_a_caminho numeric);
+SQL
+
+# ── ZONA 2: aplicar a migration REAL ──
+P -q -f "$MIG"
+echo "migration aplicada"
+
+# ── ZONA 3: seeds ──
+# Estoque DIVERGENTE (como em prod): galão WP87/WP04 SÓ em inventory_position; galão WP01 SÓ em sku_estoque_atual.
+P -q <<'SQL'
+INSERT INTO omie_products (omie_codigo_produto, account, descricao, familia, ativo, tipo_produto) VALUES
+ (8689775044,'oben','WP01 QT','Concentrados',true,'00'),  (12078998671,'oben','WP01 GL','Concentrados',true,'00'),
+ (8689775019,'oben','WP87 QT','Concentrados',true,'00'),  (12097949925,'oben','WP87 GL','Concentrados',true,'00'),
+ (8689733271,'oben','WP04 QT','Concentrados',true,'00'),  (12101098529,'oben','WP04 GL','Concentrados',true,'00'),
+ (9999999001,'oben','CTRL QT','Concentrados',true,'00'),
+ (8888888001,'oben','STALE QT','Concentrados',true,'00'), (8888888002,'oben','STALE GL','Concentrados',true,'00'),
+ (7777777001,'oben','NOMAP QT','Concentrados',true,'00'), (7777777002,'oben','NOMAP GL','Concentrados',true,'00'),
+ (6666666001,'oben','TRANS QT','Concentrados',true,'00'), (6666666002,'oben','TRANS GL','Concentrados',true,'00'),
+ (5555555001,'oben','INAT QT','Concentrados',true,'00'),  (5555555002,'oben','INAT GL','Concentrados',false,'00'),  -- GL INATIVO
+ (4444444001,'oben','ANC QT','Concentrados',true,'00'),   (4444444002,'oben','ANC GL','Concentrados',true,'00'),
+ (3333333001,'oben','MIN QT','Concentrados',true,'00'),   (3333333002,'oben','MIN GL','Concentrados',true,'00'),
+ (2222222001,'oben','OPORT QT','Concentrados',true,'00'), (2222222002,'oben','OPORT GL','Concentrados',true,'00'),
+ (1111111001,'oben','OPQT QT','Concentrados',true,'00'), (1111111002,'oben','OPQT GL','Concentrados',true,'00');
+
+INSERT INTO fornecedor_habilitado_reposicao (empresa, fornecedor_nome, horario_corte_pedido, lt_logistica_dias)
+VALUES ('OBEN','Sayerlack', interval '18:00:00', 7);
+INSERT INTO company_config (key, value) VALUES ('embalagem_preco_motor_stale_dias','45');
+
+-- âncoras QT (+ ANCORA-GL tem PARÂMETRO no GL p/ testar o guard P1-c)
+INSERT INTO sku_parametros (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, ponto_pedido, estoque_maximo, minimo_forcado_manual, habilitado_reposicao_automatica, tipo_reposicao) VALUES
+ ('OBEN',8689775044,'WP01 QT','Sayerlack',6,10,NULL,true,'automatica'),
+ ('OBEN',8689775019,'WP87 QT','Sayerlack',2,4,NULL,true,'automatica'),
+ ('OBEN',8689733271,'WP04 QT','Sayerlack',1,2,NULL,true,'automatica'),
+ ('OBEN',9999999001,'CTRL QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',8888888001,'STALE QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',7777777001,'NOMAP QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',6666666001,'TRANS QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',5555555001,'INAT QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',4444444001,'ANC QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',4444444002,'ANC GL','Sayerlack',3,6,NULL,true,'automatica'),   -- galão COM parâmetro: NÃO pode virar âncora
+ ('OBEN',3333333001,'MIN QT','Sayerlack',5,6,8,true,'automatica'),       -- minimo_forcado_manual=8
+ ('OBEN',2222222001,'OPORT QT','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',1111111001,'OPQT QT','Sayerlack',5,10,NULL,true,'automatica');  -- OPQT: âncora SEM preço-app → mantém QT mesmo com GL barato
+
+-- sku_estoque_atual: galão WP87/WP04/etc AUSENTE (vive em inventory_position); galão WP01 presente (pendente 2)
+INSERT INTO sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada) VALUES
+ ('OBEN','8689775044',3.24,0),  ('OBEN','12078998671',0,2),
+ ('OBEN','8689775019',1.62,0),
+ ('OBEN','8689733271',0.81,0),
+ ('OBEN','9999999001',1,0),
+ ('OBEN','8888888001',1,0),
+ ('OBEN','7777777001',1,0),
+ ('OBEN','6666666001',0,0),
+ ('OBEN','5555555001',0,0),
+ ('OBEN','4444444001',0,0),
+ ('OBEN','3333333001',5,0),
+ ('OBEN','2222222001',0,0),
+ ('OBEN','1111111001',0,0);
+
+-- inventory_position (saldo): galão WP87 (9.72) e WP04 (3.24) vivem AQUI. WP01 GL NÃO (só em sea).
+INSERT INTO inventory_position (omie_codigo_produto, account, saldo, cmc, synced_at) VALUES
+ (8689775044,'vendas',3.24,100.174718, now()),
+ (8689775019,'vendas',1.62,116.388937, now()),  (12097949925,'vendas',9.72,115.2, now()),  -- WP87 GL parado SÓ aqui
+ (8689733271,'vendas',0.81,121.963016, now()),  (12101098529,'vendas',3.24,114.1, now()),  -- WP04 GL parado SÓ aqui
+ (9999999001,'vendas',1,50, now()),
+ (8888888001,'vendas',1,45, now()),
+ (7777777001,'vendas',1,45, now()),
+ (6666666001,'vendas',0,45, now()),
+ (5555555001,'vendas',0,45, now()),
+ (4444444001,'vendas',0,45, now()),
+ (3333333001,'vendas',5,45, now()),
+ (2222222001,'vendas',0,45, now()),
+ (1111111001,'vendas',0,45, now());  -- OPQT QT tem cmc 45 (custo da linha) mas SEM preço-app → não-elegível
+
+INSERT INTO sku_embalagem_equivalencia (empresa, grupo_id, sku_codigo_omie, fator_para_base, ativo) VALUES
+ ('oben','11111111-1111-1111-1111-111111111111','8689775044',1,true),  ('oben','11111111-1111-1111-1111-111111111111','12078998671',4,true),
+ ('oben','22222222-2222-2222-2222-222222222222','8689775019',1,true),  ('oben','22222222-2222-2222-2222-222222222222','12097949925',4,true),
+ ('oben','33333333-3333-3333-3333-333333333333','8689733271',1,true),  ('oben','33333333-3333-3333-3333-333333333333','12101098529',4,true),
+ ('oben','44444444-4444-4444-4444-444444444444','8888888001',1,true),  ('oben','44444444-4444-4444-4444-444444444444','8888888002',4,true),
+ ('oben','55555555-5555-5555-5555-555555555555','7777777001',1,true),  ('oben','55555555-5555-5555-5555-555555555555','7777777002',4,true),
+ ('oben','66666666-6666-6666-6666-666666666666','6666666001',1,true),  ('oben','66666666-6666-6666-6666-666666666666','6666666002',4,true),
+ ('oben','77777777-7777-7777-7777-777777777777','5555555001',1,true),  ('oben','77777777-7777-7777-7777-777777777777','5555555002',4,true),
+ ('oben','88888888-8888-8888-8888-888888888888','4444444001',1,true),  ('oben','88888888-8888-8888-8888-888888888888','4444444002',4,true),
+ ('oben','99999999-9999-9999-9999-999999999999','3333333001',1,true),  ('oben','99999999-9999-9999-9999-999999999999','3333333002',4,true),
+ ('oben','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','2222222001',1,true),  ('oben','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','2222222002',4,true),
+ ('oben','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','1111111001',1,true),  ('oben','bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','1111111002',4,true);
+
+-- preço-app (oben): galões mais baratos/base; STALE GL com 100 dias
+INSERT INTO sku_preco_fornecedor_capturado (empresa, sku_codigo_omie, preco, status, capturado_em) VALUES
+ ('oben','8689775044',81.7068,'ok', now()-interval '10 days'),  ('oben','12078998671',306.4977,'ok', now()-interval '10 days'),
+ ('oben','8689775019',97.5684,'ok', now()-interval '10 days'),  ('oben','12097949925',348.2099,'ok', now()-interval '10 days'),
+ ('oben','8689733271',106,'ok', now()-interval '1 days'),       ('oben','12101098529',345,'ok', now()-interval '1 days'),
+ ('oben','8888888001',40,'ok', now()-interval '5 days'),        ('oben','8888888002',100,'ok', now()-interval '100 days'),
+ ('oben','7777777001',40,'ok', now()-interval '5 days'),        ('oben','7777777002',100,'ok', now()-interval '5 days'),
+ ('oben','6666666001',40,'ok', now()-interval '5 days'),        ('oben','6666666002',100,'ok', now()-interval '5 days'),
+ ('oben','5555555001',40,'ok', now()-interval '5 days'),        ('oben','5555555002',100,'ok', now()-interval '5 days'),
+ ('oben','4444444001',40,'ok', now()-interval '5 days'),        ('oben','4444444002',100,'ok', now()-interval '5 days'),
+ ('oben','3333333001',40,'ok', now()-interval '5 days'),        ('oben','3333333002',100,'ok', now()-interval '5 days'),
+ ('oben','2222222001',40,'ok', now()-interval '5 days'),        ('oben','2222222002',100,'ok', now()-interval '5 days'),
+ ('oben','1111111002',100,'ok', now()-interval '5 days');  -- OPQT: SÓ o GL tem preço-app (a âncora QT NÃO) → trocou=false
+
+-- portal-map (OBEN). NOMAP: só QT. INAT: ambos (o filtro de catálogo é que barra).
+INSERT INTO sku_fornecedor_externo (empresa, sku_omie, sku_portal, ativo) VALUES
+ ('OBEN','8689775044','WP01QT',true),  ('OBEN','12078998671','WP01GL',true),
+ ('OBEN','8689775019','WP87QT',true),  ('OBEN','12097949925','WP87GL',true),
+ ('OBEN','8689733271','WP04QT',true),  ('OBEN','12101098529','WP04GL',true),
+ ('OBEN','8888888001','SQT',true),     ('OBEN','8888888002','SGL',true),
+ ('OBEN','7777777001','NQT',true),
+ ('OBEN','6666666001','TQT',true),     ('OBEN','6666666002','TGL',true),
+ ('OBEN','5555555001','IQT',true),     ('OBEN','5555555002','IGL',true),
+ ('OBEN','4444444001','AQT',true),     ('OBEN','4444444002','AGL',true),
+ ('OBEN','3333333001','MQT',true),     ('OBEN','3333333002','MGL',true),
+ ('OBEN','2222222001','OQT',true),     ('OBEN','2222222002','OGL',true),
+ ('OBEN','1111111001','OPQTQT',true),  ('OBEN','1111111002','OPQTGL',true);
+
+-- PEDIDOS-SEED (sobrevivem ao ciclo): TRANS tem 2 galões EM VOO (disparado); OPORT tem galão em pedido OPORTUNIDADE.
+INSERT INTO pedido_compra_sugerido (id, empresa, fornecedor_nome, data_ciclo, status, tipo_ciclo) VALUES
+ (90001,'OBEN','Sayerlack',CURRENT_DATE,'disparado','normal'),          -- TRANS: 2 galões a caminho
+ (90002,'OBEN','Sayerlack',CURRENT_DATE,'pendente_aprovacao','oportunidade'),  -- OPORT: galão (será escolhido) em oportunidade
+ (90003,'OBEN','Sayerlack',CURRENT_DATE,'pendente_aprovacao','oportunidade');  -- OPQT: galão (NÃO escolhido) em oportunidade
+INSERT INTO pedido_compra_item (pedido_id, sku_codigo_omie, qtde_final, preco_unitario) VALUES
+ (90001,'6666666002',2,100),
+ (90002,'2222222002',1,345),
+ (90003,'1111111002',1,345);
+SELECT setval('pedido_compra_sugerido_id_seq', 100000);  -- a função gera ids acima dos seeds
+SQL
+
+# run_ciclo NÃO trunca: a função limpa os pendentes NORMAIS do dia (FK CASCADE limpa os itens); os pedidos-seed
+# (disparado / oportunidade) sobrevivem — exatamente como em prod.
+run_ciclo() { Pq -c "SELECT 1 FROM gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);" >/dev/null; }
+# leitura SÓ do que o ciclo NORMAL gerou (exclui os pedidos-seed disparado/oportunidade)
+G="s.status='pendente_aprovacao' AND COALESCE(s.tipo_ciclo,'normal')='normal'"
+sku_grp() { Pq -c "SELECT i.sku_codigo_omie FROM pedido_compra_item i JOIN pedido_compra_sugerido s ON s.id=i.pedido_id WHERE i.sku_codigo_omie IN ($1) AND $G ORDER BY i.sku_codigo_omie;" | tr '\n' ',' ; }
+campo()  { Pq -c "SELECT $1 FROM pedido_compra_item i JOIN pedido_compra_sugerido s ON s.id=i.pedido_id WHERE i.sku_codigo_omie='$2' AND $G;"; }
+conta()  { Pq -c "SELECT count(*) FROM pedido_compra_item i JOIN pedido_compra_sugerido s ON s.id=i.pedido_id WHERE i.sku_codigo_omie IN ($1) AND $G;"; }
+
+echo "── asserts (regra verdadeira) ──"
+run_ciclo
+
+# (a) WP01 → GALÃO, 2 galões, custo=preço-app (galão sem cmc → não fabricou 0). [estoque QT bate inv=sea; GL pendente em sea]
+eq "a1 WP01 escolheu GALÃO"      "$(sku_grp "'8689775044','12078998671'")" "12078998671,"
+eq "a2 WP01 qtde=2 galões"       "$(campo 'qtde_final::int' '12078998671')" "2"
+eq "a3 WP01 custo=preço-app"     "$(campo 'round(preco_unitario,4)' '12078998671')" "306.4977"
+
+# (b) [P0-a GREATEST] WP87/WP04 NÃO compram — galão parado vive em inventory_position, não em sku_estoque_atual
+eq "b1 WP87 não gera (GL inv)"   "$(conta "'8689775019','12097949925'")" "0"
+eq "b2 WP04 não gera (GL inv)"   "$(conta "'8689733271','12101098529'")" "0"
+
+# (c) galão STALE → mantém QT (estrito)
+eq "c1 STALE mantém QT"          "$(sku_grp "'8888888001','8888888002'")" "8888888001,"
+# (d) galão SEM portal-map → mantém QT
+eq "d1 NOMAP mantém QT"          "$(sku_grp "'7777777001','7777777002'")" "7777777001,"
+# (e) controle SEM grupo → idêntico legado (QT, cmc, ceil(10-1)=9)
+eq "e1 CTRL QT, qtde=9, cmc"     "$(sku_grp "'9999999001'")$(campo 'qtde_final::int' '9999999001')$(campo 'round(preco_unitario,2)' '9999999001')" "9999999001,950.00"
+
+# (f) [P0-b em_transito×fator] TRANS tem 2 galões em voo (=8 unid-base) > ponto 5 → NÃO compra (anti double-buy)
+eq "f1 TRANS não recompra"       "$(conta "'6666666001','6666666002'")" "0"
+
+# (g) [P1-f filtro membro] galão INATIVO no omie_products → inelegível → mantém QT
+eq "g1 INAT mantém QT"           "$(sku_grp "'5555555001','5555555002'")" "5555555001,"
+
+# (h) [P1-c guard] galão COM parâmetro NÃO vira âncora → exatamente 1 linha do GL (do QT), sem duplicar
+eq "h1 ANCORA 1 linha GL"        "$(conta "'4444444001','4444444002'")" "1"
+eq "h2 ANCORA é o GL"            "$(sku_grp "'4444444001','4444444002'")" "4444444002,"
+
+# (i) [P1-e minimo no galão] necessidade 1 mas minimo_forcado 8 → ceil(GREATEST(1,8)/4)=2 galões (não 1)
+eq "i1 MINIMO 2 galões"          "$(campo 'qtde_final::int' '3333333002')" "2"
+
+# (j) [P1-d oportunidade] galão ESCOLHIDO em pedido oportunidade → bloqueia a compra normal do grupo
+eq "j1 OPORT bloqueado"          "$(conta "'2222222001','2222222002'")" "0"
+
+# (k) [P1-d regressão re-Codex] galão em oportunidade MAS resultado é QT (âncora sem preço-app) → QT É comprado
+#     (o anti-dup olha o SKU FINAL=QT, não o candidato GL; senão bloquearia o quartinho indevidamente)
+eq "k1 OPQT compra QT"           "$(sku_grp "'1111111001','1111111002'")" "1111111001,"
+
+# ── ZONA 5: FALSIFICAÇÃO (sabota → exige que o assert vire VERMELHO → restaura) ──
+echo "── falsificação ──"
+falsify() { # $1 desc | $2 sed-expr | $3 SQL-valor | $4 valor_são (deve MUDAR após sabotar)
+  sed "$2" "$MIG" > /tmp/mig-sab.sql
+  P -q -f /tmp/mig-sab.sql >/dev/null
+  run_ciclo
+  local got; got="$(eval "$3")"
+  if [ "$got" != "$4" ]; then ok "FALSIFY $1 (são=$4 → furado=$got)"; else bad "FALSIFY $1 — assert SEM DENTE (seguiu $4)"; fi
+  P -q -f "$MIG" >/dev/null
+}
+
+# F1 — consolidação furada (equiv vazia): WP87 volta a comprar
+falsify "consolidacao" \
+  's/AND ativo = TRUE AND fator_para_base > 0/AND ativo = TRUE AND fator_para_base > 0 AND FALSE/' \
+  'conta "'"'"'8689775019'"'"','"'"'12097949925'"'"'"' "0"
+# F2 — [P0-a] GREATEST sabotado (só sku_estoque_atual): WP87 GL (que vive em inventory) some → WP87 compra
+falsify "greatest-2fontes" \
+  's/GREATEST(COALESCE(inv.saldo, 0), COALESCE(sea.estoque_fisico, 0))/COALESCE(sea.estoque_fisico, 0)/g' \
+  'conta "'"'"'8689775019'"'"','"'"'12097949925'"'"'"' "0"
+# F3 — [P0-b] em_transito SEM ×fator (galão em voo conta 2 cru, não 8): TRANS recompra
+falsify "transito-fator" \
+  's/COALESCE(et.qtde, 0) \* e.fator_para_base/COALESCE(et.qtde, 0)/g' \
+  'conta "'"'"'6666666001'"'"','"'"'6666666002'"'"'"' "0"
+# F4 — frescor removido: galão STALE vira elegível e troca
+falsify "frescor" \
+  's/AND pa.capturado_em >= now() - make_interval(days => v_stale_dias)//' \
+  'sku_grp "'"'"'8888888001'"'"','"'"'8888888002'"'"'"' "8888888001,"
+# F5 — portal-map ignorado: galão NOMAP vira elegível e troca
+falsify "portal-map" \
+  's/JOIN portal_map pm ON pm.sku = e.sku//' \
+  'sku_grp "'"'"'7777777001'"'"','"'"'7777777002'"'"'"' "7777777001,"
+# F6 — [P1-f] filtro de ativo no membro neutralizado (vira TRUE): galão INATIVO vira elegível e troca
+falsify "filtro-membro-ativo" \
+  's/COALESCE(opm.ativo, TRUE) = TRUE/TRUE/' \
+  'sku_grp "'"'"'5555555001'"'"','"'"'5555555002'"'"'"' "5555555001,"
+# F7 — [P1-c] guard âncora-galão removido: ANC GL vira âncora → 2 linhas do GL
+falsify "guard-ancora-galao" \
+  's/AND eg2.fator_para_base > 1/AND eg2.fator_para_base > 99999/' \
+  'conta "'"'"'4444444001'"'"','"'"'4444444002'"'"'"' "1"
+# F8 — [P1-e] minimo ignorado no galão (zera o piso na branch trocou): MINIMO compra 1 (não 2)
+falsify "minimo-no-galao" \
+  's/COALESCE(b.minimo_forcado_manual, 0)) \/ b.fator_escolhido/0) \/ b.fator_escolhido/' \
+  'campo "qtde_final::int" "3333333002"' "2"
+# F9 — [P1-d] anti-dup ignora o galão escolhido (só âncora): OPORT (galão escolhido em oportunidade) deixa de bloquear
+falsify "oportunidade-escolhido" \
+  's/CASE WHEN b.trocou THEN b.sku_escolhido ELSE b.ancora_sku END/b.ancora_sku/' \
+  'conta "'"'"'2222222001'"'"','"'"'2222222002'"'"'"' "0"
+# F10 — [P1-d regressão] anti-dup usa o CANDIDATO (não o SKU final): OPQT bloqueia o QT indevidamente
+falsify "oportunidade-sku-final" \
+  's/CASE WHEN b.trocou THEN b.sku_escolhido ELSE b.ancora_sku END/b.sku_escolhido/' \
+  'sku_grp "'"'"'1111111001'"'"','"'"'1111111002'"'"'"' "1111111001,"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
+++ b/docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
@@ -1,0 +1,138 @@
+# Embalagem econômica DENTRO do motor de pedidos (QT↔GL) — spec
+
+> Money-path. Reverte a §14.2 de `2026-06-04-embalagem-economica-design.md` (o painel era conselheiro e
+> NÃO tocava o pedido automático). Agora `gerar_pedidos_sugeridos_ciclo` (1) **consolida o estoque no nível
+> do grupo** e (2) **escolhe a embalagem mais barata por litro**. Decisões do founder (Lucas, 26/06):
+> (a) **motor escolhe a embalagem**; (b) **estrito** — na dúvida mantém o quartinho, nunca fabrica custo;
+> (c) **base de custo = preço do portal cadastrado no app**; (d) **galões parados são estoque REAL** (confirmado).
+
+## Dois problemas (relato + descoberta)
+
+1. **Embalagem cara:** mesmo concentrado em QT (quartinho 0,81 L) e GL (galão 3,24 L = 4 QT). O galão é mais
+   barato por litro, mas o pedido sugerido insiste no QT (WP01, WP87, WP04…).
+2. **Galão parado ignorado (descoberto 26/06):** o motor olha só o estoque do quartinho e é cego aos galões
+   em estoque → manda comprar WP87/WP04 mesmo com galão parado na prateleira (super-compra / compra desnecessária).
+
+## Causa-raiz (provada em prod via psql-ro)
+
+`gerar_pedidos_sugeridos_ciclo` lê **só `sku_parametros`** (só o QT tem parâmetro de reposição) e:
+- nunca consulta `sku_embalagem_equivalencia` / `sku_preco_fornecedor_capturado` → **cego a embalagem**
+  (sugere o QT porque é o único parametrizado; o GL nem tem `ponto_pedido`/`estoque_maximo`);
+- conta o estoque só do SKU âncora (QT) → **cego ao estoque do grupo** (ignora o galão parado).
+
+Não é julgamento de custo; é cegueira de catálogo + de estoque.
+
+## Dados reais (prod, 26/06) — empresa OBEN, fornecedor Renner Sayerlack
+
+| Concentrado | SKU QT / GL | estoque QT | estoque GL (Omie) | ponto/máx (QT) | cmc QT→GL (R$/L) | preço app QT→GL÷4 (R$/L) |
+|---|---|---|---|---|---|---|
+| WP01 preto | 8689775044 / 12078998671 | 3,24 | 0 (+2 a caminho) | 6 / 10 | 100,17 → **ausente** | 81,71 → **76,62** (−6,2%) |
+| WP87 ocre  | 8689775019 / 12097949925 | 1,62 | **9,72 (3 galões)** | 2 / 4 | 116,39 → 115,20 (−1%) | 97,57 → **87,05** (−10,8%) |
+| WP04 azul  | 8689733271 / 12101098529 | 0,81 | **3,24 (1 galão)** | 1 / 2 | 121,96 → 114,13 (−6,4%) | 106,00 → **86,25** (−18,6%) |
+
+- Equivalência (`sku_embalagem_equivalencia`, 'oben'): unidade_base `QT`, fator QT=1 / GL=4. 1 QT=0,81 L, 1 GL=3,24 L.
+- Portal-map (`sku_fornecedor_externo`, **'OBEN'**): QT+GL dos 3 mapeados (`WPxx.3900QT/GL`, `UN`, fator_conversao 1).
+- Preço app (`sku_preco_fornecedor_capturado`, **'oben'**, `manual_usuario`): WP01/WP87 05/06; WP04 26/06.
+- ⚠️ Case-sensitivity: `sku_parametros`/`sku_estoque_atual`/`sku_fornecedor_externo` = **'OBEN'**; `sku_embalagem_equivalencia`/`sku_preco_fornecedor_capturado` = **'oben'**.
+
+## Base de custo (DECIDIDO: preço do app decide, cmc valoriza)
+
+- **Decisão da embalagem** = menor `sku_preco_fornecedor_capturado.preco / fator_para_base` — o preço líquido do
+  portal que o founder cadastra no app (mesma data → comparação limpa). Os 3 dão galão.
+- **Por que não o cmc pra decidir:** o cmc é custo cheio (com impostos) e histórico → *achata* o desconto
+  (WP87: −1% no cmc vs −11% no preço de tabela) e não tem o galão do WP01 (nunca comprado em galão). O cmc
+  do Omie serve pra **valorizar a linha** (como hoje), NÃO pra decidir a embalagem.
+
+## Estoque de grupo (DECIDIDO: GREATEST das 2 fontes; galões reais)
+
+- As 2 tabelas de estoque DIVERGEM nos galões: `inventory_position.saldo` tem WP87/WP04 GL (9,72 / 3,24) mas
+  não WP01 GL; `sku_estoque_atual.estoque_fisico` tem WP01 GL mas não WP87/WP04 GL. Os QT batem nas duas.
+- **Founder confirmou (26/06): os galões parados são estoque físico REAL.**
+- Estoque por membro = `GREATEST(COALESCE(inventory_position.saldo,0), COALESCE(sku_estoque_atual.estoque_fisico,0))`
+  (pega o galão real de onde estiver; contar a mais = comprar a menos = lado seguro money-path). Mais `em_transito`
+  e `pendente` do grupo. ⚠️ `inventory_position` é account-aware (oben → `vendas`/`oben`).
+
+## Comportamento desejado (por grupo de equivalência)
+
+1. **Estoque do GRUPO** (litros) = Σ membros [GREATEST(inv,sea) + em_transito + pendente].
+2. **Gatilho** = estoque_grupo ≤ `ponto_pedido` da âncora (QT). Necessidade = `estoque_maximo` âncora − estoque_grupo.
+3. **Escolha** = menor preço-app/fator entre membros com preço **FRESCO (≤45 d)** + fator + portal-map presente.
+   Senão **estrito** → âncora (QT) + flag `embalagem_economica_indisponivel:<motivo>`. Nunca CMC ausente como 0.
+4. **Dimensionar** = `ceil(necessidade / fator_para_base_do_galão)` (necessidade na escala da RPC; galão = 4× a âncora →
+   WP01: `ceil(4,76/4)=2` galões). Grava `qtde_final = nº de embalagens` do SKU escolhido.
+5. **Custo da linha** = **preço-app do SKU escolhido** (R$/embalagem; galão sempre tem preço-app fresco quando é escolhido);
+   **nunca 0**. `preco_unitario` casa a unidade de `qtde_final` (R$/galão × nº galões = R$ real). Afeta `valor_total`/alerta R$3k.
+   *(quartinho NÃO é tocado — mantém `cmc` cru como hoje; só passa a somar estoque do grupo.)*
+
+**Prova viva dos 3 (com consolidação):**
+- **WP01:** grupo 3,24+0 = 3,24 (+2 a caminho = 5,24) ≤ ponto 6 → **DISPARA**. Nec 10−5,24 = 4,76 → `ceil(4,76/3,24)` = **2 galões**. (sem galão parado → compra galão, legítimo)
+- **WP87:** grupo 1,62+9,72 = 11,34 > ponto 2 → **NÃO compra** (galão parado).
+- **WP04:** grupo 0,81+3,24 = 4,05 > ponto 1 → **NÃO compra** (galão parado).
+
+## Unidade do envio (CRAVADA empiricamente — pendência resolvida 26/06)
+
+Lidos `disparar-pedidos-aprovados` (Omie `nQtde=ceil(qtde_final)`, `nValUnit=preco_unitario`, `nCodProd=sku`) e
+`enviar-pedido-portal-sayerlack` (portal `qtde=ceil(qtde_final × fator_conversao)`; `fator_conversao=1` p/ QT e GL).
+Provas em prod:
+- **`qtde_final` = nº de EMBALAGENS do SKU** (não litros). Prova: WP01.3900GL já virou pedido em 14-15/05 com
+  `qtde_final=2` (2 galões), `preco_unitario=0` → **cancelado** (3 linhas em `pedido_compra_item`). O cancelamento
+  foi por **custo 0** (cmc do galão ausente viraria 0) — exatamente o que a decisão "nunca fabricar, usar preço-app" mata.
+- **`cmc` é R$/L** (100,17 × 3,24 L = R$324,5 = 4 QT × ~R$81). Quantidades históricas no `sku_leadtime_history` são
+  sempre múltiplos de 0,81 (0,81/2,43/3,24/5,67/7,29) com `valor_unitario` em R$/L → compra-se embalagem inteira, registra-se volume.
+- **Convenção vigente da RPC (mantida, NÃO "consertada"):** estoque vem em litros do Omie (`op.unidade='L'`) e a RPC
+  subtrai `estoque_maximo − estoque_efetivo` tratando o resultado como "unidades a comprar" (descasamento litros↔embalagem
+  pré-existente, tolerado, fora de escopo). Dimensiono o galão na MESMA escala: `nº_galões = ceil(necessidade / fator_galão)`.
+
+**Decisão de unidade:** grava-se `qtde_final = nº de embalagens` e `preco_unitario = R$/embalagem` do SKU escolhido.
+Galão → `preco_unitario = preço-app do galão` (R$/galão, líquido, sempre presente quando se escolhe galão, > 0). Omie/portal
+recebem o nº de embalagens direto (`fator_conversao=1` mantido). Isso espelha o que o quartinho já faz hoje — não introduz
+descasamento novo. ⚠️ a precisão de granularidade (`/fator_galão` vs `/volume_real`) é o ponto a stress-testar no Codex/prove.
+
+## Decisões cravadas
+
+- **A. Custo da linha:** preço-app do SKU escolhido (R$/embalagem), na unidade de `qtde_final`; nunca 0. *(Prova viva: galão
+  com preço 0 foi cancelado em 14-15/05 — o preço-app > 0 mata isso. cmc fica fora: é R$/L e exigiria volume da embalagem.)*
+- **B. Frescor:** motor confia no preço app por **45 dias** (painel usa 24h, apertado pra cadastro manual). Config
+  `embalagem_preco_motor_stale_dias`. Stale → estrito (QT). *(Founder pode ajustar o prazo.)*
+- **C. Estoque:** GREATEST das 2 fontes, somado no grupo.
+- **D. Local:** dentro da RPC (CTEs de consolidação por grupo), não pós-passo (idempotência + gate mínimo/3k coerentes).
+
+## Provar antes de aplicar (PG17 falsificável)
+
+Asserts (seeds = dados reais acima):
+- (a) **WP01:** sem galão parado, galão fresco+mapeado+mais barato → gera **2 galões** WP01, custo ≠ 0.
+- (b) **WP87/WP04:** galão parado faz estoque_grupo > ponto → **NÃO gera pedido** (anti super-compra).
+- (c) galão sem preço fresco → mantém QT + flag (estrito).
+- (d) galão sem portal-map → mantém QT + flag.
+- (e) cmc E preço app ausentes → custo **NÃO** vira 0 (degradação honesta).
+- (f) consolidação não double-conta `em_transito`.
+- **Falsificar:** sabotar o gate estrito (`IF false`) e a consolidação (somar só QT) → exigir VERMELHO em (b)/(c)/(d).
+- Threat-model (`docs/agent/threat-model-template.md`): default fail-closed = âncora; 1 assert por default.
+- Codex `/codex` (xhigh, adversarial) no diff + metodologia. **NÃO** deixar varrer o schema-snapshot.
+
+## Revisão adversarial (Codex xhigh + teste-contra-prod) — 7 correções vs. o 1º rascunho
+
+O 1º rascunho passou no PG17 com seeds idealizados, mas **um dry-check contra prod** (a query de validação rodada
+read-only) e o **Codex (gpt-5.5 xhigh)** convergiram em achados que o seed mascarava. Corrigidos e re-provados:
+
+- **P0-a `GREATEST(inventory_position.saldo, sku_estoque_atual.estoque_fisico)`** — as 2 fontes DIVERGEM por SKU:
+  galão WP87/WP04 vive SÓ em `inventory_position` (9,72/3,24); WP01 GL SÓ em `sku_estoque_atual` (pendente 2). O
+  rascunho lia só `sku_estoque_atual` → WP87/WP04 voltariam a comprar. (Pego pelo dry-check-contra-prod ANTES de aplicar.)
+- **P0-b `em_transito` do galão × `fator_para_base`** — 2 galões em voo = 8 unidades-base, não 2. Sem isso, o ciclo
+  seguinte re-dispararia (double-buy). `inv_saldo` é account-aware (oben → vendas/oben), 1 linha/SKU (mais recente).
+- **P1-c âncora NÃO pode ser galão** (membro `fator>1`): senão um GL com `ponto_pedido` viraria âncora E seria
+  escolhido por outro → 2 linhas do mesmo GL (uma com custo CMC/0). *(Latente real: o WP01 GL já tem `sku_parametros` habilitado.)*
+- **P1-d anti-duplicidade de oportunidade** cobre a âncora **E** o SKU escolhido (galão) — senão a troca driblava o gate.
+- **P1-e `minimo_forcado_manual`** respeitado na troca: `ceil(GREATEST(necessidade, minimo)/fator)` (piso ANTES de dividir).
+- **P1-f filtros de catálogo** (ativo/tipo 04/família/`ativo_no_omie`) aplicados ao MEMBRO escolhido, não só à âncora
+  (senão compraria galão descontinuado).
+- **P2 (aceito):** granularidade `/fator` nunca compra menos que o legado QT (herda o descasamento litros↔embalagem); campos
+  de estoque do item passam a representar o grupo (o disparo não os usa). Documentados, não bloqueiam.
+
+Prova final: `db/test-embalagem-motor.sh` (PG17, divergência de fontes real + pedido em voo + oportunidade) — 14 asserts
++ 9 falsificações com dente (cada fix tem uma sabotagem que o vira vermelho).
+
+## Não-objetivos
+
+Não mexer no painel frontend (já correto). Não auto-aprovar. Não cadastrar os pares por código (cadastro é
+founder/portal). Não tocar a via de venda assistida.


### PR DESCRIPTION
## O que muda

`gerar_pedidos_sugeridos_ciclo` (motor de compras sugeridas) passa a tratar embalagens equivalentes (quartinho QT ↔ galão GL do mesmo concentrado):

1. **Consolida o estoque no nível do grupo** — `GREATEST(inventory_position.saldo, sku_estoque_atual.estoque_fisico)` por membro + pendente + `em_transito × fator`. O gatilho passa a olhar o estoque do GRUPO → **para de comprar quando há galão parado**.
2. **Escolhe a embalagem mais barata por litro** (galão), **ESTRITO**: só troca o quartinho pelo galão quando ambos têm preço-app fresco (≤ `embalagem_preco_motor_stale_dias`, default 45) + portal-map + catálogo OK, e o galão é estritamente mais barato/base. Senão mantém o quartinho. **Nunca fabrica custo** (usa o preço-app do galão, > 0).

Efeito (provado contra prod, OBEN/Sayerlack): **WP01 → 2 galões** (−6%/L); **WP87/WP04 → não compram** (galão parado lido do `inventory_position`).

## ⚠️ JÁ aplicada manualmente — NÃO precisa re-aplicar

A função foi recriada no SQL Editor do Lovable em **2026-06-26** e está **ativa em prod** (confirmado via `pg_get_functiondef`). `db/embalagem-motor-rpc.sql` é a **fonte versionada** — não vai em `supabase/migrations/` (é `CREATE OR REPLACE` de função existente; CLAUDE.md §5).

## Prova

`db/test-embalagem-motor.sh` (PG17 descartável): **25 asserts + 10 falsificações com dente**. Semeia a **divergência real de estoque** (galão em `inventory_position` vs `sku_estoque_atual`), pedido em voo (`em_transito`) e pedido de oportunidade.

Revisão **Codex xhigh (2 rodadas)** → 7 achados corrigidos:
- **2 P0**: faltava o `GREATEST` das 2 fontes (galão parado invisível) · `em_transito` do galão na escala errada (double-buy no ciclo seguinte)
- **5 P1**: galão virando âncora (linha dupla) · anti-dup de oportunidade sobre o SKU final · `minimo_forcado_manual` na troca · filtros de catálogo (ativo/tipo 04/família/status) no membro escolhido

🤖 Generated with [Claude Code](https://claude.com/claude-code)
