### PR TITLE
docs(db): reconcilia 20260626150457 no schema_migrations + manifest do snapshot

### DIFF
--- a/docs/agent/database.md
+++ b/docs/agent/database.md
@@ -34,6 +34,7 @@ As migrations em `supabase/migrations/` **NÃO são uma cadeia restaurável** �
 - **Fonte de DR/auditoria:** `supabase/schema-snapshot.sql` (`pg_dump` schema-only de prod, gerado pelo chat do Lovable). Ler `supabase/README-schema.md` antes de restaurar.
 - **Validação de restore:** `db/verify-snapshot-replay.sh` (Postgres 17 local + stubs) — prova ordem/dependência/sintaxe + RLS amostrado.
 - ⚠️ **NUNCA mexer em `supabase/migrations/`** (não mover snapshot pra lá, não arquivar) — a pasta é reconhecida pelo ecossistema Lovable.
+- **Reconciliar migration/RPC aplicada à mão (SQL Editor) exige DOIS passos, não um:** (1) `INSERT` em `supabase_migrations.schema_migrations` (senão o audit §1 do `audit-custom-migrations.sql` marca `❌ MISSING` com o objeto **já existindo** em prod) — conserta o *audit*; (2) **re-gerar o `schema-snapshot.sql`** — conserta o *DR*. Registrar no `schema_migrations` ≠ reproduzir prod. Caso `20260626150457` (colunas em prod fora do snapshot até o re-dump → o bot do Lovable regenerou `types.ts` de um estado sem elas e **quebrou o typecheck da `main`**). E o **snapshot é um retrato DATADO, prod é alvo móvel:** o dump de 26/06 20:20 UTC já nasceu stale (às 00:13 UTC o #1090 recriou `gerar_pedidos_sugeridos_ciclo` via `db/embalagem-motor-rpc.sql`, **sem migration formal** em `supabase/migrations/` → essa versão do motor só existe no DR pelo snapshot). Quando o motor money-path importa, confira `md5(pg_get_functiondef())` **prod × snapshot** antes de confiar no dump.
 
 ## 4. RLS (padrões)
 

--- a/supabase/schema-snapshot.manifest.md
+++ b/supabase/schema-snapshot.manifest.md
@@ -4,12 +4,12 @@
 
 | Campo | Valor |
 |---|---|
-| Gerado em | 2026-06-24 |
+| Gerado em | 2026-06-26 |
 | Fonte | produção (Supabase Lovable, `fzvklzpomgnyikkfkzai`) — regen via chat do Lovable; conteúdo **cross-validado** por um `pg_dump` independente via `~/.config/afiacao/psql-ro` (idêntico objeto-por-objeto, só difere no header/token) |
 | Versão do banco | PostgreSQL 17.6 |
 | pg_dump | 17.9 |
 | Flags | `--schema-only --schema=public --schema=private --no-owner --no-privileges` |
-| Linhas do arquivo | 36.129 (geração +`private`; anterior 2026-06-19: 35.485) |
+| Linhas do arquivo | 36.235 (geração +`private`; anterior 2026-06-24: 36.129) |
 | Tamanho | ~1,3 MB |
 
 > **Geração anterior (2026-05-24, pg_dump 17.9, 23.745 linhas) estava gravemente stale:** faltavam ~60 tabelas, ~124 funções, ~105 policies, ~75 índices criados por migrations posteriores (inclui o drift da Opção A: `farmer_client_scores`/`customer_visit_scores` → `UNIQUE(customer_user_id)` + `idx_fcs_customer`/`idx_cvs_customer`). As ~16 policies + 1 matview que "sumiram" são **remoções reais** em prod (hardening de RLS substituiu as policies amplas `"Staff can manage …"` pelas granulares por carteira; matview `mv_sku_ranking_negociacao_paralela` **movida para o schema `private`** — NÃO dropada; ver §"Schema `private`" abaixo) — confirmado via psql-ro.
@@ -21,7 +21,7 @@
 | `CREATE TABLE` | 274 |
 | `CREATE VIEW` | 55 |
 | `CREATE MATERIALIZED VIEW` | 3 (public; +1 `private.mv_sku_ranking_negociacao_paralela` = 4 no texto) |
-| `CREATE FUNCTION` | 218 |
+| `CREATE FUNCTION` | 219 |
 | `CREATE TRIGGER` | 95 |
 | `CREATE TYPE` | 14 |
 | `CREATE POLICY` | 579 |
@@ -35,6 +35,8 @@ A geração **+`private`** (35.485 linhas) dumpa o schema `private`: `CREATE SCH
 > **Replay VALIDADO em 2026-06-19** (`db/verify-snapshot-replay.sh`, PG17 descartável + prelude + stubs, transação única `ON_ERROR_STOP`): restore **limpo** + contagens públicas batem (272/53/3/210/91/14/579) + **enforcement RLS amostrado OK** (own-scope=1 / staff-gate=2 / anon-deny=0). **Limitação:** prova ordem/dependência/sintaxe + RLS amostrada do `public`; **não** o runtime Supabase completo ("Gold" pede projeto vazio/docker).
 
 > **Re-validado em 2026-06-24** (geração 36.129 linhas): `db/verify-snapshot-replay.sh` → restore **limpo** + RLS amostrada OK (own=1/staff=2/anon=0); contagens públicas **274/55/3/218/95/14/579** (drift desde 06-19: +2 tabelas, +2 views, +8 funções, +4 triggers — vários PRs mergeados). ✅ A policy ALL antiga de `farmer_tactical_plans` saiu (split [#1043](https://github.com/LucasSardenbergL/afiacao/pull/1043)) e as RPCs v2 hardened entraram ([#1046](https://github.com/LucasSardenbergL/afiacao/pull/1046): FOR UPDATE + status-guard) — confirmado no snapshot. **Fecha o #6 do `/codex challenge`.**
+
+> **Re-validado em 2026-06-26** (geração 36.235 linhas, +106 vs 06-24): `db/verify-snapshot-replay.sh` → restore **limpo** + RLS amostrada OK (own=1/staff=2/anon=0); contagens públicas **274/55/3/219/95/14/579** (drift desde 06-24: **+1 função**). Diff do drift (06-24→06-26): (1) colunas `estoque_fisico`/`estoque_a_caminho` + COMMENTs em `pedido_compra_item` e o INSERT correspondente em `gerar_pedidos_sugeridos_ciclo` — migration `20260626150457` (PR #1079), **agora registrada em `supabase_migrations.schema_migrations`** (era apply manual via SQL Editor, sem registro; reconciliada nesta sessão); (2) função nova `get_ultimos_precos_cliente` (migration `20260625120000`); (3) check `pedidos_compra_sync` no `_data_health_compute`/`data_health_watchdog` — migration `20260626150000` ([#1081](https://github.com/LucasSardenbergL/afiacao/pull/1081), mergeado 27/06). ⚠️ **Snapshot é retrato de ~26/06 20:20 UTC — já stale p/ #1090:** [#1090](https://github.com/LucasSardenbergL/afiacao/pull/1090) (motor galão econômico, mergeado 27/06 00:13 UTC) recriou `gerar_pedidos_sugeridos_ciclo` em prod (md5 `b4eff3ec…`→`00663b74…`) via `db/embalagem-motor-rpc.sql`, **sem migration formal** em `supabase/migrations/` → **fora deste snapshot**. Contagens seguem válidas (REPLACE não muda nº de objeto); só o corpo dessa função está defasado. **Pendente: re-dump p/ capturar #1090.**
 
 ## Extensions referenciadas pelo `public` (ver `schema-extensions-prelude.sql`)
 


### PR DESCRIPTION
## O quê

Reconcilia a migration `20260626150457` (split estoque físico/a-caminho em `pedido_compra_item`, #1079), que estava **aplicada em prod mas sem registro** em `supabase_migrations.schema_migrations` — o audit marcava `❌ MISSING` apesar das colunas existirem (confirmado via `psql-ro`). O `INSERT` de registro já foi aplicado em prod nesta sessão; este PR persiste a documentação:

- **manifest** (`schema-snapshot.manifest.md`): re-validado 2026-06-26 — snapshot regenerado (36.235 linhas), `db/verify-snapshot-replay.sh` restaura **limpo** + RLS amostrada OK, contagens `274/55/3/219/95/14/579`. Documenta o drift 24→26/06.
- **database.md §3**: nota durável — reconciliar migration manual exige os **dois** passos (INSERT no `schema_migrations` + re-dump do snapshot); o snapshot é retrato datado.

## ⚠️ Pendência (não bloqueia este PR — é só doc)

O snapshot (dump 26/06 20:20 UTC) **já está stale para o #1090** (mergeado 27/06 00:13 UTC): o #1090 recriou `gerar_pedidos_sugeridos_ciclo` em prod (md5 `b4eff3ec…`→`00663b74…`) via `db/embalagem-motor-rpc.sql`, **sem migration formal** em `supabase/migrations/`. As contagens seguem válidas (REPLACE não muda nº de objeto); só o **corpo dessa função** está defasado no snapshot. **Recomendado: re-dump do snapshot para capturar o #1090.**

## Verificação

- `typecheck` EXIT=0
- `test` 4121/4121
- replay do snapshot: restore limpo + RLS amostrada OK (own=1/staff=2/anon=0)

Só docs — sem mudança de runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
