### PR TITLE
feat(ci): fecha Issue ci-main-red quando a main volta a verde (fase 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,23 @@ jobs:
               await github.rest.issues.create({ owner, repo, title: '🔴 CI vermelho na main', body, labels: [label] });
             }
 
+      # Fase 2 do Componente 1: quando a main VOLTA a verde, fecha a(s) Issue(s)
+      # ci-main-red abertas (senão a Issue fica órfã e o sinal perde valor). Idempotente:
+      # sem Issue aberta = no-op. success() é false se qualquer step do job falhou.
+      - name: main voltou a verde → fecha Issue ci-main-red
+        if: success() && github.ref == 'refs/heads/main'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner, repo = context.repo.repo;
+            const sha = context.sha.slice(0, 8);
+            const label = 'ci-main-red';
+            const open = await github.rest.issues.listForRepo({ owner, repo, state: 'open', labels: label, per_page: 100 });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({ owner, repo, issue_number: issue.number, body: `✅ CI da \`main\` voltou a verde em \`${sha}\`. Fechando automaticamente.` });
+              await github.rest.issues.update({ owner, repo, issue_number: issue.number, state: 'closed' });
+            }
+
   # ─── Job NÃO-bloqueante (informativo, sinal próprio) ────────────────
   # Gate de regressão de COBERTURA money-path (≠ os checks do `validate`, que
   # cobrem tipos/comportamento/build/lint). Roda os contratos scripts/mutcheck.d/*.mut


### PR DESCRIPTION
## Opcional 1 — fase 2 do Componente 1 (mitigação de reversão do Lovable, #1092)

O alerta de `main` vermelha (#1092) abre/atualiza uma Issue `ci-main-red`. Faltava o **fechamento**: sem isto, a Issue fica órfã depois que a `main` é consertada e o sinal perde valor.

**Mudança:** um step `if: success() && github.ref == 'refs/heads/main'` no job `validate` que comenta `✅ voltou a verde em <sha>` + fecha a(s) Issue(s) `ci-main-red` aberta(s).

- **Idempotente:** sem Issue aberta = no-op.
- **Não conflita com o alerta de falha:** `success()` é false se qualquer step do job falhou, então em falha só o alerta roda; em sucesso só o fechamento.
- **Só age na `main`:** em PR ambos os steps são skipped (`if main`).

## Verificação
- ✅ YAML validado (ruby)
- Não testável sem a `main` verde de verdade (mesma limitação dos alertas — spec §5); lógica análoga ao alerta de falha já em prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)