### PR TITLE
feat(reposição): gate de estoque-não-confirmado no motor [money-path]

### DIFF
--- a/db/test-embalagem-motor.sh
+++ b/db/test-embalagem-motor.sh
@@ -40,7 +40,7 @@ P -q <<'SQL'
 CREATE TABLE public.sku_parametros (empresa text, sku_codigo_omie bigint, sku_descricao text, fornecedor_nome text,
   ponto_pedido numeric, estoque_maximo numeric, minimo_forcado_manual numeric,
   habilitado_reposicao_automatica boolean, tipo_reposicao text, demanda_media_diaria numeric);
-CREATE TABLE public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_pendente_entrada numeric);
+CREATE TABLE public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_pendente_entrada numeric, fonte_sync text);
 CREATE TABLE public.sku_embalagem_equivalencia (empresa text, grupo_id uuid, sku_codigo_omie text, fator_para_base numeric, ativo boolean);
 CREATE TABLE public.sku_preco_fornecedor_capturado (empresa text, sku_codigo_omie text, preco numeric, status text, capturado_em timestamptz);
 CREATE TABLE public.sku_fornecedor_externo (empresa text, sku_omie text, sku_portal text, ativo boolean);
@@ -60,6 +60,10 @@ CREATE TABLE public.pedido_compra_item (id bigserial PRIMARY KEY, pedido_id bigi
   sku_codigo_omie text, sku_descricao text, estoque_atual numeric, ponto_pedido numeric, estoque_maximo numeric,
   qtde_sugerida numeric, qtde_final numeric, preco_unitario numeric, valor_linha numeric, primeira_compra boolean,
   estoque_fisico numeric, estoque_a_caminho numeric);
+-- [GATE estoque-não-confirmado] a função agora LOGA os suprimidos aqui (CTE log_ins). Stub mínimo (sem RLS no harness).
+-- Os seeds deste teste NÃO setam fonte_sync (→ NULL) → o gate não dispara → asserts do galão (a-k) intactos.
+CREATE TABLE public.reposicao_estoque_nao_confirmado_log (id uuid DEFAULT gen_random_uuid(), run_id uuid, criado_em timestamptz DEFAULT now(),
+  empresa text, sku_codigo_omie text, sku_descricao text, grupo_codigo text, motivo text, estoque_efetivo numeric, ponto_pedido numeric, fonte_sync text);
 SQL
 
 # ── ZONA 2: aplicar a migration REAL ──

--- a/db/test-gate-estoque-nao-confirmado.sh
+++ b/db/test-gate-estoque-nao-confirmado.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Prova PG17 — GATE de estoque-NÃO-CONFIRMADO em gerar_pedidos_sugeridos_ciclo (money-path).
+# Spec: docs/superpowers/specs/2026-06-27-reposicao-gate-estoque-nao-confirmado-spec.md
+# Rodar: bash db/test-gate-estoque-nao-confirmado.sh > /tmp/t.log 2>&1; echo "exit=$?"  (NÃO pipe pra tail — engole exit)
+# Lei de Ferro: aplica a função REAL (db/embalagem-motor-rpc.sql = fixture viva galão+gate); FALSIFICA (sabota → vermelho → restaura).
+# Invariante: estoque cuja ÚNICA fonte é 'cold_start_seed' (sem inventory_position) é DESCONHECIDO → o motor SUPRIME
+#   a sugestão (LINHA e GRUPO) + LOGA. Zero CONFIRMADO (ListarPosEstoque/0) e inventory_position presente seguem comprando.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5468}"
+SLUG="gate-estoque"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+MIG="$REPO_ROOT/db/embalagem-motor-rpc.sql"   # fixture VIVA: galão + gate estoque-não-confirmado
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1: stubs (sku_estoque_atual TEM fonte_sync; tabela de log presente) ──
+P -q <<'SQL'
+CREATE TABLE public.sku_parametros (empresa text, sku_codigo_omie bigint, sku_descricao text, fornecedor_nome text,
+  ponto_pedido numeric, estoque_maximo numeric, minimo_forcado_manual numeric,
+  habilitado_reposicao_automatica boolean, tipo_reposicao text, demanda_media_diaria numeric);
+CREATE TABLE public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_pendente_entrada numeric, fonte_sync text);
+CREATE TABLE public.sku_embalagem_equivalencia (empresa text, grupo_id uuid, sku_codigo_omie text, fator_para_base numeric, ativo boolean);
+CREATE TABLE public.sku_preco_fornecedor_capturado (empresa text, sku_codigo_omie text, preco numeric, status text, capturado_em timestamptz);
+CREATE TABLE public.sku_fornecedor_externo (empresa text, sku_omie text, sku_portal text, ativo boolean);
+CREATE TABLE public.inventory_position (omie_codigo_produto bigint, account text, saldo numeric DEFAULT 0, cmc numeric, synced_at timestamptz);
+CREATE TABLE public.company_config (key text, value text);
+CREATE TABLE public.omie_products (omie_codigo_produto bigint, account text, descricao text, familia text, ativo boolean, tipo_produto text, metadata jsonb DEFAULT '{}');
+CREATE TABLE public.sku_grupo_producao (empresa text, sku_codigo_omie text, grupo_codigo text);
+CREATE TABLE public.sku_leadtime_history (empresa text, sku_codigo_omie text, quantidade_recebida numeric, valor_total numeric);
+CREATE TABLE public.fornecedor_habilitado_reposicao (empresa text, fornecedor_nome text, horario_corte_pedido interval, valor_maximo_mensal numeric, delta_max_perc numeric, lt_logistica_dias int);
+CREATE TABLE public.familia_nao_comprada (id bigserial PRIMARY KEY, empresa text, familia text);
+CREATE TABLE public.sku_status_omie (empresa text, sku_codigo_omie text, ativo_no_omie boolean);
+CREATE TABLE public.pedido_compra_sugerido (id bigserial PRIMARY KEY, empresa text, fornecedor_nome text, grupo_codigo text,
+  data_ciclo date, horario_corte_planejado timestamptz, valor_total numeric, num_skus int, status text,
+  condicao_pagamento_codigo text, condicao_pagamento_descricao text, num_parcelas int, dias_parcelas text, condicao_origem text,
+  tipo_ciclo text, status_envio_portal text, portal_protocolo text, omie_pedido_compra_numero text, atualizado_em timestamptz);
+CREATE TABLE public.pedido_compra_item (id bigserial PRIMARY KEY, pedido_id bigint REFERENCES pedido_compra_sugerido(id) ON DELETE CASCADE,
+  sku_codigo_omie text, sku_descricao text, estoque_atual numeric, ponto_pedido numeric, estoque_maximo numeric,
+  qtde_sugerida numeric, qtde_final numeric, preco_unitario numeric, valor_linha numeric, primeira_compra boolean,
+  estoque_fisico numeric, estoque_a_caminho numeric);
+CREATE TABLE public.reposicao_estoque_nao_confirmado_log (id uuid DEFAULT gen_random_uuid(), run_id uuid, criado_em timestamptz DEFAULT now(),
+  empresa text, sku_codigo_omie text, sku_descricao text, grupo_codigo text, motivo text, estoque_efetivo numeric, ponto_pedido numeric, fonte_sync text);
+SQL
+
+# ── ZONA 2: aplicar a função REAL (fixture viva = galão+gate) ──
+P -q -f "$MIG"
+echo "migration aplicada"
+
+# ── ZONA 3: seeds dos 5 cenários do gate (todos: ativo, tipo 00, Sayerlack, ponto 5/max 10, dispara compra) ──
+P -q <<'SQL'
+INSERT INTO fornecedor_habilitado_reposicao (empresa, fornecedor_nome, horario_corte_pedido, lt_logistica_dias)
+VALUES ('OBEN','Sayerlack', interval '18:00:00', 7);
+INSERT INTO company_config (key, value) VALUES ('embalagem_preco_motor_stale_dias','45');
+
+INSERT INTO omie_products (omie_codigo_produto, account, descricao, familia, ativo, tipo_produto) VALUES
+ (100001,'oben','C1 SEED-ONLY','Concentrados',true,'00'),        -- C1: cold_start_seed sem inv → SUPRIME (linha)
+ (100002,'oben','C2 CONFIRM ZERO','Concentrados',true,'00'),     -- C2: ListarPosEstoque/0 sem inv → COMPRA
+ (100003,'oben','C3 CONFIRM SALDO','Concentrados',true,'00'),    -- C3: ListarPosEstoque/2 → COMPRA
+ (100005,'oben','C5 SEED+INV','Concentrados',true,'00'),         -- C5: cold_start_seed MAS inv presente → COMPRA
+ (200001,'oben','C4 ANCORA QT','Concentrados',true,'00'),        -- C4 âncora (confirmada) — grupo tem membro seed-only
+ (200002,'oben','C4 GALAO GL','Concentrados',true,'00');         -- C4 galão (cold_start_seed) → GRUPO SUPRIME
+
+INSERT INTO sku_parametros (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, ponto_pedido, estoque_maximo, minimo_forcado_manual, habilitado_reposicao_automatica, tipo_reposicao) VALUES
+ ('OBEN',100001,'C1 SEED-ONLY','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',100002,'C2 CONFIRM ZERO','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',100003,'C3 CONFIRM SALDO','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',100005,'C5 SEED+INV','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',200001,'C4 ANCORA QT','Sayerlack',5,10,NULL,true,'automatica');   -- só a âncora tem parâmetro (galão não)
+
+-- sku_estoque_atual com fonte_sync (a chave do gate)
+INSERT INTO sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada, fonte_sync) VALUES
+ ('OBEN','100001',0,0,'cold_start_seed'),     -- C1: seed-only
+ ('OBEN','100002',0,0,'ListarPosEstoque'),    -- C2: zero CONFIRMADO
+ ('OBEN','100003',2,0,'ListarPosEstoque'),    -- C3: saldo confirmado abaixo do ponto
+ ('OBEN','100005',0,0,'cold_start_seed'),     -- C5: seed MAS terá inv presente
+ ('OBEN','200001',0,0,'ListarPosEstoque'),    -- C4 âncora: CONFIRMADA (não é ela que suprime)
+ ('OBEN','200002',0,0,'cold_start_seed');     -- C4 galão: seed-only → contamina o grupo
+
+-- inventory_position: SÓ C5 tem (saldo 0, mas presente = confirma). C1/C2/C3/C4 NÃO têm.
+INSERT INTO inventory_position (omie_codigo_produto, account, saldo, cmc, synced_at) VALUES
+ (100005,'vendas',0,50, now());
+
+-- C4: grupo de equivalência (âncora fator 1 + galão fator 4)
+INSERT INTO sku_embalagem_equivalencia (empresa, grupo_id, sku_codigo_omie, fator_para_base, ativo) VALUES
+ ('oben','c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4','200001',1,true),
+ ('oben','c4c4c4c4-c4c4-c4c4-c4c4-c4c4c4c4c4c4','200002',4,true);
+SQL
+
+# ── seeds das correções pós-Codex (xhigh): C6 missing-sea, C7 membro inativo não envenena ──
+P -q <<'SQL'
+INSERT INTO omie_products (omie_codigo_produto, account, descricao, familia, ativo, tipo_produto) VALUES
+ (100006,'oben','C6 MISSING-SEA','Concentrados',true,'00'),   -- C6: SEM linha em sku_estoque_atual (sea ausente)
+ (300001,'oben','C7 ANCORA','Concentrados',true,'00'),        -- C7 âncora (confirmada)
+ (300002,'oben','C7 GALAO INATIVO','Concentrados',true,'00'); -- C7 galão seed-only MAS inativo no Omie → não vota
+INSERT INTO sku_parametros (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, ponto_pedido, estoque_maximo, minimo_forcado_manual, habilitado_reposicao_automatica, tipo_reposicao) VALUES
+ ('OBEN',100006,'C6 MISSING-SEA','Sayerlack',5,10,NULL,true,'automatica'),
+ ('OBEN',300001,'C7 ANCORA','Sayerlack',5,10,NULL,true,'automatica');
+-- C6: NENHUMA linha em sku_estoque_atual (sea ausente = desconhecido). C7: âncora confirmada + galão seed.
+INSERT INTO sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada, fonte_sync) VALUES
+ ('OBEN','300001',0,0,'ListarPosEstoque'),
+ ('OBEN','300002',0,0,'cold_start_seed');
+-- C7: galão 300002 INATIVO no Omie → NÃO deve votar no gate de grupo (senão envenenaria a âncora p/ sempre)
+INSERT INTO sku_status_omie (empresa, sku_codigo_omie, ativo_no_omie) VALUES ('OBEN','300002',false);
+INSERT INTO sku_embalagem_equivalencia (empresa, grupo_id, sku_codigo_omie, fator_para_base, ativo) VALUES
+ ('oben','c7c7c7c7-c7c7-c7c7-c7c7-c7c7c7c7c7c7','300001',1,true),
+ ('oben','c7c7c7c7-c7c7-c7c7-c7c7-c7c7c7c7c7c7','300002',4,true);
+SQL
+
+run_ciclo() { Pq -c "SELECT 1 FROM gerar_pedidos_sugeridos_ciclo('OBEN', CURRENT_DATE);" >/dev/null; }
+G="s.status='pendente_aprovacao' AND COALESCE(s.tipo_ciclo,'normal')='normal'"
+conta()     { Pq -c "SELECT count(*) FROM pedido_compra_item i JOIN pedido_compra_sugerido s ON s.id=i.pedido_id WHERE i.sku_codigo_omie='$1' AND $G;"; }
+log_conta() { Pq -c "SELECT count(*) FROM reposicao_estoque_nao_confirmado_log WHERE sku_codigo_omie='$1';"; }
+log_motivo(){ Pq -c "SELECT motivo FROM reposicao_estoque_nao_confirmado_log WHERE sku_codigo_omie='$1' LIMIT 1;"; }
+
+echo "── asserts (regra verdadeira) ──"
+P -q -c "TRUNCATE reposicao_estoque_nao_confirmado_log;"
+run_ciclo
+
+# C1 — LINHA seed-only: NÃO compra + loga linha_seed_only
+eq "C1 seed-only NÃO gera"       "$(conta '100001')" "0"
+eq "C1 logou suprimido"          "$(log_conta '100001')" "1"
+eq "C1 motivo=linha_seed_only"   "$(log_motivo '100001')" "linha_seed_only"
+# C2 — zero CONFIRMADO (ListarPosEstoque/0): COMPRA (1ª compra legítima, não trapeia zero-real)
+eq "C2 confirm-zero COMPRA"      "$(conta '100002')" "1"
+eq "C2 não logou"                "$(log_conta '100002')" "0"
+# C3 — saldo CONFIRMADO abaixo do ponto: COMPRA normalmente
+eq "C3 confirm-saldo COMPRA"     "$(conta '100003')" "1"
+# C4 — GRUPO com membro seed-only: âncora NÃO compra + loga grupo_membro_seed_only
+eq "C4 grupo SUPRIME âncora"     "$(conta '200001')" "0"
+eq "C4 logou grupo"              "$(log_conta '200001')" "1"
+eq "C4 motivo=grupo_membro"      "$(log_motivo '200001')" "grupo_membro_seed_only"
+# C5 — cold_start_seed MAS inventory_position presente: CONFIRMADO → COMPRA
+eq "C5 seed+inv COMPRA"          "$(conta '100005')" "1"
+eq "C5 não logou"                "$(log_conta '100005')" "0"
+# C6 — missing-sea (sem linha de estoque): NÃO compra (desconhecido ≠ zero confirmado) + loga
+eq "C6 missing-sea NÃO gera"     "$(conta '100006')" "0"
+eq "C6 logou suprimido"          "$(log_conta '100006')" "1"
+# C7 — grupo com membro seed-only INATIVO no Omie: NÃO envenena → âncora ativa COMPRA
+eq "C7 inativo não envenena"     "$(conta '300001')" "1"
+eq "C7 âncora não logou"         "$(log_conta '300001')" "0"
+# total logado = C1 + C4 + C6
+eq "log total = 3"               "$(Pq -c 'SELECT count(*) FROM reposicao_estoque_nao_confirmado_log;')" "3"
+
+# ── ZONA 5: FALSIFICAÇÃO (sabota → exige VERMELHO → restaura) ──
+echo "── falsificação ──"
+falsify() { # $1 desc | $2 sed-expr | $3 SQL-valor (eval) | $4 valor_são (deve MUDAR após sabotar)
+  sed "$2" "$MIG" > /tmp/mig-gate-sab.sql
+  P -q -f /tmp/mig-gate-sab.sql >/dev/null
+  P -q -c "TRUNCATE reposicao_estoque_nao_confirmado_log;" >/dev/null
+  run_ciclo
+  local got; got="$(eval "$3")"
+  if [ "$got" != "$4" ]; then ok "FALSIFY $1 (são=$4 → furado=$got)"; else bad "FALSIFY $1 — assert SEM DENTE (seguiu $4)"; fi
+  P -q -f "$MIG" >/dev/null
+}
+
+# FAL1 — gate-off: remove "AND NOT sn.suprimido" (os 2 inserts) → C1 seed-only volta a GERAR pedido
+falsify "gate-off" \
+  's/ AND NOT sn.suprimido//g' \
+  'conta 100001' "0"
+# FAL2 — grupo-blind: ignora grupo_nao_confirmado (usa só a linha) → C4 âncora (confirmada) deixa de ser suprimida → GERA
+falsify "grupo-blind" \
+  's/COALESCE(b.grupo_nao_confirmado, b.linha_nao_confirmada) AS suprimido/COALESCE(b.linha_nao_confirmada, b.linha_nao_confirmada) AS suprimido/' \
+  'conta 200001' "0"
+# FAL3 — suprime-tudo: suprimido := true → C2 (zero CONFIRMADO) deixa de comprar (gate super-restritivo)
+falsify "suprime-tudo" \
+  's/COALESCE(b.grupo_nao_confirmado, b.linha_nao_confirmada) AS suprimido/true AS suprimido/' \
+  'conta 100002' "1"
+# FAL4 — inativo-vota: remove "membro inativo não vota" → C7 galão inativo passa a envenenar → âncora SUPRIME
+falsify "inativo-vota" \
+  's/AND COALESCE(ssg.ativo_no_omie, true) = true//' \
+  'conta 300001' "1"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **303** custom migrations totais
-- **1040** objetos esperados (criados por estas migrations)
+- **304** custom migrations totais
+- **1045** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 304
-  - `rls_policy`: 222
-  - `index`: 187
-  - `table`: 110
+  - `function`: 305
+  - `rls_policy`: 224
+  - `index`: 188
+  - `table`: 111
   - `cron_job`: 109
   - `view`: 52
   - `trigger`: 52
@@ -2563,6 +2563,16 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260627170000_reposicao_rls_initplan.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260627180000_reposicao_gate_estoque_nao_confirmado.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
+| `table` | `public.reposicao_estoque_nao_confirmado_log` | — |
+| `index` | `public.idx_estoque_nao_confirmado_log_empresa_data` | `reposicao_estoque_nao_confirmado_log` |
+| `rls_policy` | `public.estoque_nao_confirmado_log_sel` | `reposicao_estoque_nao_confirmado_log` |
+| `rls_policy` | `public.estoque_nao_confirmado_log_ins` | `reposicao_estoque_nao_confirmado_log` |
 
 ## Próximos passos por status
 

--- a/docs/superpowers/specs/2026-06-27-reposicao-gate-estoque-nao-confirmado-spec.md
+++ b/docs/superpowers/specs/2026-06-27-reposicao-gate-estoque-nao-confirmado-spec.md
@@ -1,0 +1,128 @@
+# Spec — Gate de estoque-não-confirmado no motor de reposição (money-path)
+
+> Status: DRAFT (metodologia validada por Codex consult 019f0968, jun/2026). Próximo: migration + prove-sql PG17 + challenge Codex xhigh.
+> Domínio: `docs/agent/reposicao.md` + `docs/agent/money-path.md`. RPC alvo: `gerar_pedidos_sugeridos_ciclo`.
+
+## 1. Problema (provado em produção, 2026-06-27)
+
+O motor `gerar_pedidos_sugeridos_ciclo` gera compra quando `estoque_efetivo <= ponto_pedido`, lendo
+`GREATEST(inventory_position.saldo, sku_estoque_atual.estoque_fisico) + pendente + em_transito`.
+
+A função cold-start (`reposicao_cold_start_parametros`) faz SKU de primeira-compra aparecer na fila:
+habilita + **semeia `sku_estoque_atual` de `omie_products.estoque`** (catálogo), `fonte_sync='cold_start_seed'`,
+`ON CONFLICT DO NOTHING`. **Defeito:** `omie_products.estoque` está **82% zerado na OBEN** (681/3670 com saldo);
+o estoque real vive em `inventory_position` (761/762) e no sync `ListarPosEstoque`. O seed grava 0 mesmo
+quando o Omie tem saldo.
+
+**Cronologia do incidente (UTC):** 13:14 cold-start criou 64 SKUs (seed=0) → 13:31 motor gerou pedido #775
+lendo 0 → 13:40 `ListarPosEstoque` revelou saldo real (10, 8, 6, 4...). **31 de 43 itens** tinham saldo real
+que o snapshot não viu → pedido compra o que já temos (capital empatado).
+
+**Por que o fix óbvio falha:** "trocar a fonte do seed p/ inventory_position" não resolve — no instante da
+geração, `inventory_position` TAMBÉM está vazio p/ o SKU recém-criado (9 dos 64 ainda ausentes; os outros
+só foram preenchidos pelo `ListarPosEstoque` às 13:40, DEPOIS da geração). Ambas as fontes boas estão vazias
+porque o SKU é novo.
+
+## 2. Decisão (Codex consult, convergência)
+
+O fix **não** é a fonte do seed. É: **o motor não pode tratar estoque DESCONHECIDO como zero numa decisão de
+compra** (money-path: ausente ≠ zero, precisão > recall). `cold_start_seed` não é inventário — é um hack de
+enfileiramento e deve contar como `unknown`.
+
+**Gate no MOTOR, não no cold-start** (cold-start tem que seguir habilitando, senão o sync — que só cobre
+habilitados — nunca pega o SKU → deadlock). O motor **suprime a sugestão** quando a decisão de compra se
+apoiaria em estoque não-confirmado, e **loga** o suprimido (senão vira subcompra silenciosa).
+
+## 3. Design
+
+### 3.1 Fonte CONFIRMADA vs NÃO-CONFIRMADA (por SKU)
+- **Confirmada** se QUALQUER: `sku_estoque_atual.fonte_sync LIKE 'ListarPosEstoque%'` (sync real do Omie,
+  inclui 0 confirmado via `cExibeTodos:"S"`), OU `inventory_position` presente (`inv_saldo` não-nulo).
+- **Não-confirmada** se a ÚNICA fonte é `fonte_sync='cold_start_seed'` E `inventory_position` ausente.
+- (Linha sem `sku_estoque_atual` e sem `inventory_position` = também não-confirmada — não ocorre p/ habilitado,
+  mas o gate trata fail-closed.)
+
+### 3.2 Regra de supressão (fail-closed)
+- **SKU isolado (sem grupo de equivalência):** se dispara compra (`estoque_efetivo <= ponto_pedido`) E a fonte
+  é não-confirmada → **suprime + loga**.
+- **Grupo de equivalência (≥2 membros):** o gate é no GRUPO (Codex). Se `estoque_grupo <= ponto_pedido` E
+  QUALQUER membro contribuinte é não-confirmado → **suprime o grupo + loga**. (Membro não-confirmado pode ter
+  saldo que levaria o grupo acima do ponto; assumir 0 = compra-fantasma.)
+- Se o estoque CONFIRMADO já está acima do ponto, o `WHERE` existente já não inclui — gate não atua. ✓
+
+### 3.3 Implementação na RPC (pontos exatos)
+1. `grupo_estoque` (CTE): adicionar `bool_or(sea.fonte_sync='cold_start_seed' AND inv.saldo IS NULL)
+   AS grupo_nao_confirmado`.
+2. `sku_base`: trazer `sea.fonte_sync` + `ip.saldo IS NULL` → derivar `linha_nao_confirmada`; e `ge.grupo_nao_confirmado`.
+3. Separar em CTE `avaliados` com flag `suprimido` (= dispara compra E não-confirmado, linha OU grupo) + `motivo`.
+4. INSERT de pedido SÓ p/ `NOT suprimido`. INSERT no log p/ `suprimido`.
+
+### 3.4 Tabela de log (observabilidade — Codex: senão é subcompra silenciosa)
+`reposicao_estoque_nao_confirmado_log` (run-stamped): empresa, sku_codigo_omie, grupo_id, motivo
+(`linha_seed_only`|`grupo_membro_seed_only`), estoque_efetivo, ponto_pedido, fonte_sync, criado_em. RLS
+`pode_ver_carteira_completa`. Surface numa fila de exceção na tela de Reposição.
+
+### 3.5 Preflight de geração manual (frontend)
+Antes do "Recalcular": contar SKUs habilitados OBEN com `fonte_sync='cold_start_seed'` sem `inventory_position`.
+Se > 0, avisar "N SKUs com estoque não confirmado serão pulados; rode o sync de estoque antes p/ não subcomprar."
+(Defense-in-depth de UX — o gate do motor é a proteção real.)
+
+## 4. Threat model (engine que emite decisão — `docs/agent/threat-model-template.md`)
+
+| O que PROVA | O que NÃO prova | Default fail-closed |
+|---|---|---|
+| Não compra com estoque só-seed | Que o sync real está fresco (camada do Sentinela) | Estoque não-confirmado ⇒ **NÃO compra** (suprime) |
+| Zero-real (ListarPosEstoque/0) ainda compra | Que o Omie nunca omite um SKU ativo | SKU omitido ⇒ `ativo_no_omie=false` ⇒ sai do motor |
+| Grupo com membro seed-only não compra | — | Qualquer dúvida no grupo ⇒ suprime o grupo |
+
+**1 assert por default declarado** (doc×código não podem divergir). Cobertura de zero-confirmado: empírica —
+448 SKUs OBEN sincronizados, 120 com `ListarPosEstoque/estoque_fisico=0` (a API retorna zeros via `cExibeTodos:"S"`).
+
+## 5. Plano de prova PG17 (`prove-sql-money-path`, com falsificação)
+
+Cenários (asserts positivos E negativos):
+1. **Seed-only dispara compra** (cold_start_seed=0, sem inv) → **suprimido** + linha no log. (positivo do gate)
+2. **Confirmado-zero compra** (ListarPosEstoque/0, sem inv) → **incluído** (compra legítima de 1ª compra). (não trapeia zero-real)
+3. **Confirmado-com-saldo acima do ponto** → não incluído (já era). (regressão)
+4. **Grupo: 1 membro ListarPosEstoque c/ saldo + 1 membro seed-only**, grupo <= ponto → **grupo suprimido**.
+5. **Grupo: todos confirmados, abaixo do ponto** → incluído normalmente.
+6. **inventory_position presente + sea=cold_start_seed** → confirmado (inv conta) → incluído/avaliado normal.
+**Falsificação:** remover a cláusula do gate → cenário 1 PASSA a comprar (vermelho). Trocar `bool_or` por
+`bool_and` no grupo → cenário 4 vaza (vermelho). Sem o vermelho, o assert não tem dente.
+
+## 6. Modos de falha (Codex) + mitigação
+
+- **Starvation:** sync parado por dias ⇒ motor suprime 1ª-compra p/ sempre. Correto (fail-closed) MAS **precisa
+  alertar** → o Sentinela já vigia sync congelado (`diagnose-supabase-sync`); o log de suprimidos dá visibilidade.
+- **Sync parcial:** run paginada/falha parcial pode deixar uns seed. A edge `omie-sync-estoque` já é fail-closed
+  (erro de varredura é FATAL → throw → Sentinela). Não tratar parcial como confirmação. ✓ (já vale)
+- **Confirmação stale:** `ListarPosEstoque` de semana passada conta como confirmado? V1: sim (binário). V2 (futuro):
+  regra de frescor `ultima_sincronizacao`. Registrar como dívida.
+- **Snapshot já gravado (#775):** o gate só age em pedidos FUTUROS. Ação imediata: Recalcular (apaga+regera).
+- **inventory_position aparece depois, sea continua seed:** `inv` presente ⇒ confirmado (Codex: sim se fresco). ✓
+- **Race trigger manual:** geração logo após cold-start pula linhas (seguro). Preflight (3.5) dá visibilidade.
+
+## 7.5 Hardening pós-Codex challenge (xhigh, sessão 019f0968 — 209k tokens)
+
+Corrigido (P1 de lógica, provado em `db/test-gate-estoque-nao-confirmado.sh` C6/C7 + FAL4):
+- **Missing `sku_estoque_atual` (LINHA):** `sea` ausente = estoque DESCONHECIDO, não zero confirmado → suprime
+  (C6). Só na LINHA isolada; no GRUPO **não** conta (galão legitimamente vive sem `sea` próprio — o estoque vem de
+  outro membro; tratar como não-confirmado regredia 7 grupos do galão: STALE/NOMAP/INAT/ANC/MIN/OPQT).
+- **`inv` por PRESENÇA da linha, não `saldo`:** linha e grupo usam `.sku IS NULL` (existe linha de
+  `inventory_position`?), não `saldo IS NULL` — senão um `saldo` NULL faria a linha comprar e o grupo suprimir
+  (Codex P1, inconsistência).
+- **Membro INATIVO não envenena (GRUPO):** membro seed-only com `ativo_no_omie=false` NÃO vota no
+  `grupo_nao_confirmado` (senão um galão descontinuado bloquearia a âncora ativa p/ sempre — Codex P1 starvation). FAL4.
+
+Dívida conhecida (V2, NÃO bloqueante — registrada):
+- **Frescor da confirmação:** `inv_saldo` aceita a linha mais recente sem bound de frescor — herança do motor galão
+  (o `GREATEST(inv.saldo, sea)` já usa `inv_saldo` sem frescor). Stale severo é pego pelo Sentinela. V2: regra de frescor.
+- **Log mostra a âncora, não o membro culpado (P2):** após troca p/ galão, o log grava `sku`/`fonte_sync` da âncora;
+  o membro seed-only que causou a supressão não aparece. Observabilidade; o pedido/grupo ainda é identificável.
+
+## 7.6 Coordenação / aplicação
+- NÃO toca `omie-sync-estoque` (cobertura já OK) nem `reposicao_cold_start_parametros` (seed segue, só vira inócuo).
+- RPC `gerar_pedidos_sugeridos_ciclo` é função QUENTE (já sofreu PR duplicado) → pré-flight `pg_get_functiondef`
+  da prod antes de `CREATE OR REPLACE` (a última a recriar vence). PR aberto #1102 mexe em sync pedidos-compra
+  (disjunto). Timestamp de migration > `20260627130000`.
+- Escrita money-path = handoff p/ o founder colar no SQL Editor (gate humano).

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 303
+-- Total de custom migrations: 304
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -328,7 +328,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260627132029', 'reposicao_embalagem_motor_galao', '20260627132029_reposicao_embalagem_motor_galao.sql'),
   ('20260627150000', 'tint_formulas_rls_initplan', '20260627150000_tint_formulas_rls_initplan.sql'),
   ('20260627150100', 'tint_formulas_autovacuum_agressivo', '20260627150100_tint_formulas_autovacuum_agressivo.sql'),
-  ('20260627170000', 'reposicao_rls_initplan', '20260627170000_reposicao_rls_initplan.sql')
+  ('20260627170000', 'reposicao_rls_initplan', '20260627170000_reposicao_rls_initplan.sql'),
+  ('20260627180000', 'reposicao_gate_estoque_nao_confirmado', '20260627180000_reposicao_gate_estoque_nao_confirmado.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1370,7 +1371,12 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('reposicao_cold_start_parametros', 'cron_job', 'cron', 'reposicao-cold-start-parametros', ''),
   ('reposicao_cold_start_parametros', 'rls_policy', 'public', 'cold_start_log_sel', 'reposicao_cold_start_log'),
   ('reposicao_cold_start_fix_gate_cron', 'function', 'public', 'reposicao_cold_start_parametros', ''),
-  ('reposicao_embalagem_motor_galao', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
+  ('reposicao_embalagem_motor_galao', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_gate_estoque_nao_confirmado', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_gate_estoque_nao_confirmado', 'table', 'public', 'reposicao_estoque_nao_confirmado_log', ''),
+  ('reposicao_gate_estoque_nao_confirmado', 'index', 'public', 'idx_estoque_nao_confirmado_log_empresa_data', 'reposicao_estoque_nao_confirmado_log'),
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_sel', 'reposicao_estoque_nao_confirmado_log'),
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2460,7 +2466,12 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_cold_start_parametros', 'cron_job', 'cron', 'reposicao-cold-start-parametros', ''),
   ('reposicao_cold_start_parametros', 'rls_policy', 'public', 'cold_start_log_sel', 'reposicao_cold_start_log'),
   ('reposicao_cold_start_fix_gate_cron', 'function', 'public', 'reposicao_cold_start_parametros', ''),
-  ('reposicao_embalagem_motor_galao', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
+  ('reposicao_embalagem_motor_galao', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_gate_estoque_nao_confirmado', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_gate_estoque_nao_confirmado', 'table', 'public', 'reposicao_estoque_nao_confirmado_log', ''),
+  ('reposicao_gate_estoque_nao_confirmado', 'index', 'public', 'idx_estoque_nao_confirmado_log_empresa_data', 'reposicao_estoque_nao_confirmado_log'),
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_sel', 'reposicao_estoque_nao_confirmado_log'),
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log')
 )
 SELECT
   e.migration,

--- a/src/lib/reposicao/__tests__/embalagem-motor-paridade.test.ts
+++ b/src/lib/reposicao/__tests__/embalagem-motor-paridade.test.ts
@@ -5,20 +5,19 @@ import { describe, expect, it } from "vitest";
 /**
  * Guard de paridade — corpo de gerar_pedidos_sugeridos_ciclo (money-path).
  *
- * O #1090 (motor escolhe galão econômico + consolida grupo) entrou em PROD via
- * db/embalagem-motor-rpc.sql, FORA de supabase/migrations/. Ao formalizá-lo como migration
- * (reconciliação retroativa), o SQL da função passou a viver em DOIS arquivos:
- *   - db/embalagem-motor-rpc.sql                                    ← fixture de db/test-embalagem-motor.sh
- *   - supabase/migrations/<ts>_reposicao_embalagem_motor_galao.sql ← migration formal
- * Como o teste PG17 só exercita a fixture, sem este guard os dois driftam em SILÊNCIO
- * (database.md §2). Editar um sem o outro quebra o CI aqui. Mantenha-os byte-idênticos do
- * CREATE OR REPLACE até o fim do arquivo (inclui qualquer ALTER/GRANT que venha DEPOIS da função
- * — blind spot apontado pelo /codex challenge: comparar só até $function$; ignoraria SQL extra).
+ * A função vive em DOIS lugares que TÊM de casar:
+ *   - db/embalagem-motor-rpc.sql                       ← fixture VIVA (motor galão + gate estoque-não-confirmado),
+ *                                                         exercitada por db/test-embalagem-motor.sh e db/test-gate-*.sh
+ *   - a ÚLTIMA migration que recria a função (maior ts) ← o que vai a prod ("última a recriar vence", database.md §2)
+ *
+ * O #1090 (galão) entrou em prod via db/embalagem-motor-rpc.sql FORA de supabase/migrations/; depois foi
+ * formalizado como migration. O gate (2026-06-27) recria a função numa migration POSTERIOR. Sem este guard a
+ * fixture e a migration que vence em prod driftam em SILÊNCIO. Editar um sem o outro quebra o CI aqui.
+ * Compara do CREATE OR REPLACE até o FIM do arquivo (pega ALTER/GRANT após $function$; — blind spot do /codex).
  */
 const ROOT = process.cwd();
 const FIXTURE = join(ROOT, "db", "embalagem-motor-rpc.sql");
 const MIG_DIR = join(ROOT, "supabase", "migrations");
-const MIG_SUFFIX = "_reposicao_embalagem_motor_galao.sql";
 const ABRE = "CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo";
 
 /** Do CREATE OR REPLACE até o FIM do arquivo (pega SQL extra após $function$;), com exatamente 1 CREATE. */
@@ -29,22 +28,23 @@ function sqlDaFuncao(sql: string, origem: string): string {
   return sql.slice(ini).trimEnd();
 }
 
-/** Resolve a migration por sufixo, exigindo que exista EXATAMENTE uma (find() silencioso pegaria a 1ª). */
-function migrationUnica(): string {
-  const matches = readdirSync(MIG_DIR).filter((f) => f.endsWith(MIG_SUFFIX));
-  expect(matches, `esperava 1 migration *${MIG_SUFFIX}, achei ${matches.length}: ${matches.join(", ")}`).toHaveLength(1);
-  return matches[0];
+/**
+ * A migration de MAIOR timestamp que recria a função — a que VENCE em prod. Os nomes começam com o timestamp
+ * (ordenáveis lexicograficamente), então o último do sort é o mais recente. Exige >= 1 (find() silencioso mascararia).
+ */
+function ultimaMigrationDaFuncao(): string {
+  const matches = readdirSync(MIG_DIR)
+    .filter((f) => f.endsWith(".sql") && readFileSync(join(MIG_DIR, f), "utf8").includes(ABRE))
+    .sort();
+  expect(matches.length, `nenhuma migration recria ${ABRE} (esperava >= 1)`).toBeGreaterThan(0);
+  return matches[matches.length - 1];
 }
 
-describe("paridade embalagem-motor (fixture db/ ↔ migration formal)", () => {
-  it("existe exatamente UMA migration *_reposicao_embalagem_motor_galao.sql", () => {
-    migrationUnica();
-  });
-
-  it("SQL da função (CREATE → fim do arquivo) é idêntico nos dois", () => {
+describe("paridade do motor (fixture db/ ↔ última migration que recria a função)", () => {
+  it("a fixture viva bate com a última migration que recria a função", () => {
     const fix = sqlDaFuncao(readFileSync(FIXTURE, "utf8"), "db/embalagem-motor-rpc.sql");
-    const migName = migrationUnica();
+    const migName = ultimaMigrationDaFuncao();
     const mig = sqlDaFuncao(readFileSync(join(MIG_DIR, migName), "utf8"), migName);
-    expect(mig).toBe(fix);
+    expect(mig, `db/embalagem-motor-rpc.sql diverge da migration ${migName} (corpo da função money-path)`).toBe(fix);
   });
 });

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -201,6 +201,23 @@ export default function AdminReposicaoPedidos() {
     }
   };
 
+  // [GATE estoque-não-confirmado] preflight: quantos SKUs ainda estão com estoque do cold-start (fonte_sync=
+  // 'cold_start_seed', não confirmado pelo ListarPosEstoque). A geração vai PULÁ-los (o motor não compra com
+  // estoque seed) — avisa antes do Recalcular p/ o operador rodar o sync se quiser incluí-los. Aproximação
+  // barata (não cruza inventory_position); o gate real (precisão) está na RPC.
+  const { data: naoConfirmadosCount = 0 } = useQuery({
+    queryKey: ['estoque-nao-confirmado', EMPRESA],
+    queryFn: async () => {
+      const { count, error } = await supabase
+        .from('sku_estoque_atual')
+        .select('*', { count: 'exact', head: true })
+        .eq('empresa', EMPRESA)
+        .eq('fonte_sync', 'cold_start_seed');
+      if (error) throw error;
+      return count ?? 0;
+    },
+  });
+
   const gerarMutation = useMutation({
     mutationFn: async () => {
       const { data, error } = await supabase.rpc('gerar_pedidos_sugeridos_ciclo', {
@@ -333,6 +350,17 @@ export default function AdminReposicaoPedidos() {
                   use só se você mudou um parâmetro (ponto de pedido, mínimo forçado etc.).
                 </AlertDialogDescription>
               </AlertDialogHeader>
+              {naoConfirmadosCount > 0 && (
+                <Alert className="border-status-warning/40 bg-status-warning/5">
+                  <AlertTriangle className="h-4 w-4 text-status-warning" />
+                  <AlertTitle className="text-status-warning">Estoque não confirmado pelo sync</AlertTitle>
+                  <AlertDescription>
+                    {naoConfirmadosCount} SKU(s) ainda com estoque do cold-start (catálogo), não confirmado pelo
+                    ListarPosEstoque. A geração vai <strong>pulá-los</strong> (não compra com estoque não confirmado)
+                    e registrá-los. Rode o sync de estoque do Omie antes, se quiser incluí-los neste ciclo.
+                  </AlertDescription>
+                </Alert>
+              )}
               <AlertDialogFooter>
                 <AlertDialogCancel>Voltar</AlertDialogCancel>
                 <AlertDialogAction onClick={() => gerarMutation.mutate()}>Recalcular</AlertDialogAction>

--- a/supabase/migrations/20260627180000_reposicao_gate_estoque_nao_confirmado.sql
+++ b/supabase/migrations/20260627180000_reposicao_gate_estoque_nao_confirmado.sql
@@ -1,39 +1,58 @@
--- Migration: embalagem econômica DENTRO do motor de pedidos (QT↔GL) + consolidação de estoque de grupo
--- ⚠️ APLICADA MANUALMENTE no SQL Editor do Lovable em 2026-06-26 (NÃO vai em supabase/migrations/ — CLAUDE.md §5;
---     é CREATE OR REPLACE de função existente). Este arquivo é a FONTE versionada + fixture da regressão db/test-embalagem-motor.sh.
--- Spec: docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
--- Money-path. Recria gerar_pedidos_sugeridos_ciclo (pré-flight pg_get_functiondef feito; base = prod 26/06).
+-- Reposição — GATE de estoque-NÃO-CONFIRMADO no motor de pedidos (money-path)
+-- ============================================================================
+-- Bug provado em prod 2026-06-27 (pedido #775): o cold-start (reposicao_cold_start_parametros) semeia
+-- sku_estoque_atual de omie_products.estoque (catálogo, 82% ZERADO na OBEN), fonte_sync='cold_start_seed'.
+-- Se o motor gera o pedido na janela cold-start→ListarPosEstoque, lê o seed=0 e COMPRA por cima de estoque
+-- existente (31/43 itens do #775 com saldo real 10/8/6… apareciam 0). Trocar a fonte do seed NÃO resolve
+-- (inventory_position também vazio p/ SKU recém-criado — provado).
 --
--- DUAS mudanças cirúrgicas, tudo o mais PRESERVADO:
---   1) CONSOLIDA o estoque no nível do grupo de equivalência (Σ membros: GREATEST(inv,sea) físico + pendente + trânsito).
---      O gatilho passa a olhar o estoque do GRUPO → para de comprar quando há galão parado.
---   2) ESCOLHE a embalagem mais barata por unidade-base (galão), ESTRITO: só troca o quartinho pelo galão
---      quando AMBOS têm preço-app fresco (≤ N dias) + portal-map + catálogo OK, e o galão é estritamente mais barato/base.
---      Senão mantém o quartinho. Custo da linha do galão = preço-app (R$/embalagem), nunca 0.
+-- FIX (Codex consult 019f0968 + money-path "ausente≠zero / precisão>recall"): estoque cuja ÚNICA fonte é
+-- 'cold_start_seed' (sem inventory_position) é DESCONHECIDO → o motor SUPRIME a sugestão (nível LINHA e GRUPO)
+-- + LOGA em reposicao_estoque_nao_confirmado_log. Zero CONFIRMADO (ListarPosEstoque/0) segue comprando.
+-- Gate no MOTOR (não no cold-start: ele segue habilitando, senão o sync — que só cobre habilitados — nunca
+-- pega o SKU → deadlock). Auto-liberante: o próximo ListarPosEstoque (cExibeTodos:"S") confirma o saldo (real
+-- ou 0) e fonte_sync vira 'ListarPosEstoque' → libera.
 --
--- Unidade (cravada em prod): qtde_final = nº de EMBALAGENS do SKU; preco_unitario = R$/embalagem; o disparo
--- consome ceil(qtde_final) direto (fator_conversao=1). Quartinho NÃO é tocado (mantém cmc cru).
--- ⚠️ Case: equivalencia/preço_capturado = lower(empresa); parametros/estoque/fornecedor_externo = empresa (upper).
---
--- Revisão pós-Codex (xhigh) — 6 correções vs. o 1º rascunho:
---   P0-a GREATEST(inventory_position.saldo, sku_estoque_atual): galão parado vive em fontes DIFERENTES por SKU.
---   P0-b em_transito do galão × fator_para_base (2 galões em voo = 8 unidades-base, não 2) → anti double-buy.
---   P1-c âncora NÃO pode ser membro fator>1 (galão) de um grupo → impede 2 linhas do mesmo GL.
---   P1-d anti-duplicidade de oportunidade cobre a âncora E o SKU escolhido (galão).
---   P1-e minimo_forcado_manual respeitado também na troca p/ galão (piso aplicado ANTES de dividir pelo fator).
---   P1-f filtros de catálogo (ativo/tipo 04/família/status omie) aplicados ao MEMBRO escolhido, não só à âncora.
--- Granularidade (P2 Codex, aceito): nº_galões = ceil(necessidade / fator) na escala "unidades-âncora" — NUNCA
---   compra menos que o legado QT (herda o descasamento litros↔embalagem pré-existente, fora de escopo).
---
--- ➕ 2026-06-27 — GATE de estoque-NÃO-CONFIRMADO (money-path; spec 2026-06-27-reposicao-gate-estoque-nao-confirmado).
---   Bug provado: cold-start semeia sku_estoque_atual de omie_products.estoque (82% zerado na OBEN), fonte_sync=
---   'cold_start_seed'. Se o motor roda na janela cold-start→ListarPosEstoque, lê o seed=0 e compra por cima de
---   estoque existente. FIX (Codex consult 019f0968 + ausente≠zero): estoque cuja ÚNICA fonte é cold_start_seed (sem
---   inventory_position) é DESCONHECIDO → o motor SUPRIME a sugestão (nível LINHA e GRUPO) + LOGA em
---   reposicao_estoque_nao_confirmado_log. Zero CONFIRMADO (ListarPosEstoque/0) segue comprando — auto-liberante.
---   ⚠️ Esta fixture é SÓ a função; a tabela de log + RLS vivem na migration formal (e nos harnesses de teste).
---   Migration: supabase/migrations/20260627180000_reposicao_gate_estoque_nao_confirmado.sql (corpo da função idêntico).
+-- ⚠️ PARIDADE (database.md §2): o corpo do CREATE OR REPLACE abaixo é BYTE-IDÊNTICO a db/embalagem-motor-rpc.sql
+--    (a fixture viva da função). embalagem-motor-paridade.test.ts compara os dois do CREATE até o FIM do arquivo
+--    → NÃO ponha NADA depois do $function$; (nem COMMIT/validação). A validação pós-apply vai no handoff.
+-- Spec: docs/superpowers/specs/2026-06-27-reposicao-gate-estoque-nao-confirmado-spec.md
+-- Provado PG17: db/test-gate-estoque-nao-confirmado.sh (gate) + db/test-embalagem-motor.sh (galão não-regride).
+-- Aplicar manual no SQL Editor do Lovable. É a ÚLTIMA a recriar a função (depois da 132029) → vence.
+-- ============================================================================
 
+-- ─── Tabela de log dos SKUs suprimidos pelo gate (observabilidade — senão subcompra silenciosa) ───
+CREATE TABLE IF NOT EXISTS public.reposicao_estoque_nao_confirmado_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid,
+  criado_em timestamptz NOT NULL DEFAULT now(),
+  empresa text NOT NULL,
+  sku_codigo_omie text NOT NULL,
+  sku_descricao text,
+  grupo_codigo text,
+  motivo text NOT NULL CHECK (motivo IN ('linha_seed_only','grupo_membro_seed_only')),
+  estoque_efetivo numeric,
+  ponto_pedido numeric,
+  fonte_sync text
+);
+CREATE INDEX IF NOT EXISTS idx_estoque_nao_confirmado_log_empresa_data
+  ON public.reposicao_estoque_nao_confirmado_log (empresa, criado_em DESC);
+
+ALTER TABLE public.reposicao_estoque_nao_confirmado_log ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS estoque_nao_confirmado_log_sel ON public.reposicao_estoque_nao_confirmado_log;
+CREATE POLICY estoque_nao_confirmado_log_sel ON public.reposicao_estoque_nao_confirmado_log
+  FOR SELECT TO authenticated
+  USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));
+-- INSERT via a RPC (SECURITY INVOKER) rodando como o chamador (staff no "Recalcular", ou service_role/postgres
+-- no cron que bypassa RLS). WITH CHECK(true): não bloquear a geração — a escrita real só vem da função, e quem
+-- chega aqui já passou pelo gate de EXECUTE da RPC.
+DROP POLICY IF EXISTS estoque_nao_confirmado_log_ins ON public.reposicao_estoque_nao_confirmado_log;
+CREATE POLICY estoque_nao_confirmado_log_ins ON public.reposicao_estoque_nao_confirmado_log
+  FOR INSERT TO authenticated WITH CHECK (true);
+GRANT SELECT, INSERT ON public.reposicao_estoque_nao_confirmado_log TO authenticated;
+GRANT ALL ON public.reposicao_estoque_nao_confirmado_log TO service_role;
+
+-- ─── Função VIVA (galão + gate) — corpo BYTE-IDÊNTICO a db/embalagem-motor-rpc.sql (paridade no CI) ───
 CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
  RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
  LANGUAGE plpgsql


### PR DESCRIPTION
## Problema (provado em prod — pedido #775)
O cold-start semeia `sku_estoque_atual` de `omie_products.estoque` (82% zerado na OBEN) com `fonte_sync='cold_start_seed'`. Se o motor gera o pedido na janela cold-start→`ListarPosEstoque`, lê o seed=0 e **compra por cima de estoque real** — 31/43 itens do #775 tinham saldo (10/8/6/4...) e apareciam 0.

Trocar a fonte do seed **não** resolve: `inventory_position` também está vazio p/ SKU recém-criado (provado).

## Fix (Codex consult 019f0968 + money-path "ausente≠zero / precisão>recall")
Estoque cuja **única** fonte é `cold_start_seed` (sem `inventory_position` account-aware) é DESCONHECIDO → o motor **suprime** a sugestão (nível **linha** e **grupo**) e **loga** em `reposicao_estoque_nao_confirmado_log`. Zero **confirmado** (`ListarPosEstoque/0`) segue comprando (1ª compra legítima). Gate no motor (não no cold-start → evita deadlock); auto-liberante no próximo sync.

## O que tem aqui
- **Migration `20260627180000`**: tabela de log + RPC galão+gate. Corpo **byte-idêntico** à fixture viva `db/embalagem-motor-rpc.sql` (paridade no CI passa a comparar a fixture com a **última** migration que recria a função).
- **Prova PG17** `db/test-gate-estoque-nao-confirmado.sh` — 7 cenários + 4 falsificações (todas viram vermelho quando o gate é sabotado). Galão **não-regride**: `db/test-embalagem-motor.sh` 25/25.
- **Hardening pós-Codex `xhigh`**: missing-sea (linha), `inv` por presença (saldo NULL), membro inativo não envenena o grupo. Dívida V2 registrada (frescor da confirmação).
- **Preflight UX**: aviso na tela de pedidos antes do Recalcular quando há SKUs com estoque seed.
- Verificação: vitest 4175/4175, typecheck, lint, shellcheck, paridade — todos verdes.

## ⚠️ Handoff (migration custom NÃO auto-aplica)
Após o merge, **colar `supabase/migrations/20260627180000_reposicao_gate_estoque_nao_confirmado.sql` no SQL Editor do Lovable**. É a última a recriar a função (depois da 132029, já em prod) → vence. Validação pós-apply rodada via `psql-ro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)