### PR TITLE
feat(cockpit/2b): smoke do GATE 1 (dDataPosicao) + spec v2 da defasagem por cliente

### DIFF
--- a/docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md
+++ b/docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md
@@ -1,7 +1,7 @@
 # Cockpit de preço — Fase 2b: defasagem de repasse POR CLIENTE — design
 
 > Sub-projeto da Onda 1 (co-piloto de venda ao vivo). Continuação da Fase 2a (saúde de markup sobre CMC atual, já em produção). Esta spec é o ciclo próprio da **2b**.
-> **Status do Codex:** o challenge adversário da metodologia está **PENDENTE** (cota do Codex estourou em 2026-06-15, volta 18/06). Foldei aqui o **meu** passe adversário (Q1-Q5); o passe do Codex **gateia o BUILD**, não a spec.
+> **Status do Codex:** challenge adversário da metodologia **RODADO em 2026-06-15** (gpt-5.5, xhigh, 131k tok). Veredito: *"não pronto pro build, precisa de fix antes"*. **Todos os achados válidos foldados nesta v2** (changelog §12), aterrados no schema REAL via leitura read-only.
 
 ## 1. Objetivo
 
@@ -9,18 +9,24 @@ Na ligação, quando a vendedora monta um pedido pra um cliente que **já compro
 
 **Não-objetivo:** defasagem global por produto, meta-margem absoluta (é a 2a), bloquear venda.
 
+**Doutrina (money-path):** **PRECISÃO > recall.** Um alerta ERRADO na frente do cliente (mandar repassar sem motivo) é PIOR que silêncio. "Ausente ≠ zero": nunca fabricar número. Na dúvida → **neutro**.
+
 ## 2. Decisões travadas (founder, 2026-06-15)
 
 - **D1 — escopo:** defasagem **POR CLIENTE** (âncora = último pedido **deste cliente** pra **este item**). Casa com a ligação. (Global descartado pro v1.)
-- **D2 — sem histórico do cliente:** **neutro/silencioso** (a 2b só fala em recompra; a 2a cobre a saúde absoluta). Precisão > recall.
+- **D2 — sem histórico do cliente:** **neutro/silencioso** (a 2b só fala em recompra; a 2a cobre a saúde absoluta).
 - **D3 — UI:** **linha do carrinho** (estende o badge da 2a). `P_req` visível pra vendedora (ação dela); CMC absoluto continua só pro gestor.
-- **D4 — decisão delegada a "mim + Codex":** knobs/regra/guards (founder: "decida você e codex").
+- **D4 — knobs/regra/guards delegados a "mim + Codex"** (founder: "decida você e codex"). Defaults conservadores em §5.2, tunáveis na revisão.
 
-## 3. Premissa de dado (CORRIGIDA) + pré-requisito
+## 3. Premissa de dado + pré-requisitos (2 GATES de build)
 
 **O CMC histórico EXISTE no Omie.** `estoque/consulta/ListarPosEstoque` é parametrizado por **`dDataPosicao`** e devolve o `nCMC` **como estava naquela data**. O `omie-analytics-sync` (~L716) só pede "hoje". → dá pra puxar o CMC de qualquer data passada (e backfillar).
 
-⚠️ **PRÉ-REQUISITO DO BUILD (smoke):** confirmar com 1 chamada real que `dDataPosicao` passada devolve `nCMC` **histórico** (não o atual com rótulo de data). Sem isso confirmado, NÃO construir o backfill. (Não temos acesso ao Omie pela RPC/terminal — roda numa edge pontual ou o founder testa.)
+⚠️ **GATE 1 — smoke `dDataPosicao` (prova de 2 datas):** pegar 1 SKU que comprovadamente **mudou de CMC** entre duas datas e confirmar que `dDataPosicao` devolve os **dois valores distintos** — não o atual com rótulo de data. (Codex: subir de "1 chamada" pra prova de duas datas.) Não temos Omie pela RPC/terminal → roda numa edge pontual ou o founder testa.
+
+⚠️ **GATE 2 — smoke semântica de desconto do Omie:** provar como `order_items.discount` e `sales_orders.discount` representam o desconto (**R$ vs %**, **por-linha vs por-pedido**) ANTES de computar o `P_last` líquido. Enquanto não provado, **linha com desconto > 0 → neutro** (§5.1).
+
+Sem os 2 gates confirmados, NÃO construir o backfill/RPC.
 
 ## 4. Arquitetura
 
@@ -28,71 +34,101 @@ Na ligação, quando a vendedora monta um pedido pra um cliente que **já compro
 
 | Unidade | Cria/usa | Responsabilidade |
 |---|---|---|
-| `cmc_snapshot(account, omie_codigo_produto, data_posicao date, cmc, synced_at)` | Cria | CMC por data (mensal). PK/unique `(account, omie_codigo_produto, data_posicao)`. |
-| Edge `cmc-snapshot-backfill` | Cria | Chama `ListarPosEstoque` com `dDataPosicao` = fim de cada mês (1 chamada/mês/conta = catálogo inteiro, paginado); upsert idempotente. Backfill (~12-18 meses) + cron mensal. |
-| RPC `get_defasagem_cliente(p_itens jsonb, p_customer_user_id uuid)` | Cria | **Separada** da `get_preco_cockpit** (não toca a RPC de markup recém-estabilizada; single-responsibility). Batch, SECURITY DEFINER, staff-gated. |
+| `cmc_snapshot(account, omie_codigo_produto, data_posicao date, cmc, synced_at)` | Cria | CMC por data. PK/unique `(account, omie_codigo_produto, data_posicao)`. |
+| Edge `cmc-snapshot-backfill` | Cria | **(a) modo exato:** pra cada pedido-âncora candidato, CMC as-of a **data REAL do pedido** (`dDataPosicao` na data exata). **(b) grade mensal** de fallback p/ cobertura. Paginação até página vazia + guard; upsert idempotente. Backfill (~12-18 meses) + cron mensal. |
+| RPC `get_defasagem_cliente(p_itens jsonb, p_customer_user_id uuid)` | Cria | **Separada** da `get_preco_cockpit` (não toca a RPC de markup recém-estabilizada; single-responsibility). Batch, SECURITY DEFINER, staff-gated, REVOKE anon. |
 | Hook + UI | Modifica | `CartItemList` chama a RPC nova (1 batch por carrinho) + badge de defasagem na linha. |
 
-**Por que RPC separada (não estender a 2a):** a `get_preco_cockpit` acabou de passar por challenge + fixes; mexer nela arrisca regressão money-path. A defasagem é outra responsabilidade (por-cliente, histórico). Custo: 2 chamadas por carrinho (aceitável; react-query dedupe).
+**Por que snapshot exato-por-âncora (não só grade mensal):** a grade mensal é a **fonte do falso-positivo crítico** (Codex #1) — se a âncora é 20/05 mas o snapshot mais próximo ≤ data é 30/04 (custo ainda baixo), a RPC vê alta-fantasma. O `dDataPosicao` aceita **qualquer** data, então backfillamos a data exata de cada âncora. A RPC lê o snapshot da data da âncora (janela **±7 dias**); fora da janela → **neutro** (não arrisca FP).
+
+**Por que RPC separada:** a `get_preco_cockpit` acabou de passar por challenge + fixes; mexer arrisca regressão money-path. Custo: 2 chamadas por carrinho (aceitável; react-query dedupe).
 
 ## 5. Metodologia
 
-### 5.1 Âncora (do cliente, do real)
-- **Price side:** última linha de `order_items` do `(customer_user_id, omie_codigo_produto)` **JOIN `sales_orders`** por `sales_order_id`, filtrando **pedido real** (`omie_pedido_id IS NOT NULL`, `status NOT IN ('cancelado','rascunho')`, `deleted_at IS NULL`), conta certa. → `P_last` (líquido) + **data real do pedido = `sales_orders.order_date_kpi`** (NÃO `order_items.created_at`, que é hora de sync). Mais recente por `order_date_kpi`, tiebreak determinístico.
-  - ⚠️ Build: confirmar o **líquido** — `order_items.unit_price = prod.valor_unitario` + `discount` separado; definir `P_last` líquido (subtrair desconto se for R$; cuidar se for %).
-- **Cost side:** `C_last` = `cmc_snapshot` mais próximo **≤ `order_date_kpi`** (mesma ponte de conta da 2a); `C_now` = `inventory_position` atual (freshest por `synced_at`, igual à 2a).
+### 5.1 Âncora (do cliente, do real) — aterrada no schema
+`order_items` tem **`customer_user_id` direto** + `quantity`, `unit_price`, `discount`, `omie_codigo_produto`, `sales_order_id`. `sales_orders` tem `status`, `account`, `order_date_kpi (date)`, `omie_pedido_id`, `omie_payload (jsonb)`, `discount`, `deleted_at`.
 
-### 5.2 Regra (à prova de catraca) — só quando o custo SUBIU
-Avalia **só se `C_now > C_last`** (custo realmente subiu — a dor do founder; custo flat/caiu → neutro, sem alerta de margem invertida).
+- **Âncora:** última linha de `order_items` do `(customer_user_id, omie_codigo_produto)` **JOIN `sales_orders`** por `sales_order_id`, **account-aware** (`account` = ponte da empresa, igual à 2a — Oben→['vendas','oben'] etc.). → `P_last` (líquido) + data real.
+- **Status allowlist (aterrada):** `status IN ('faturado','importado','separacao','enviado')` — vendas reais. Exclui `cancelado`/`rascunho`/`orcamento`. + `omie_pedido_id IS NOT NULL` + `deleted_at IS NULL`. (Lista **positiva**, não denylist — Codex #6. `importado`=1206 pedidos reais do Omie, mantidos: são a recompra histórica.)
+- **Data da âncora (proveniência — Codex #7):** preferir **`dInc` extraído do `omie_payload`** (verdade canônica do Omie) → fallback `order_date_kpi` → se nenhum confiável, **neutro**. (Grounded: **89%** dos `order_date_kpi` == `created_at::date` → proveniência impura; não confiar cega no `order_date_kpi`.)
+- **`P_last` líquido (Codex #4):** `unit_price` − desconto da linha (− rateio do `sales_orders.discount` por pedido). São **2 camadas** de desconto. Enquanto o **GATE 2** não provar a semântica (R$ vs %) → **linha com `discount > 0` em qualquer camada = neutro**.
+- **Multi-pedido no mesmo dia (Codex #8):** `order_date_kpi` é `date` (sem hora) → empate possível. Resolver por **média ponderada pela `quantity`** do preço líquido; se a divergência de preço entre as linhas do dia for alta → **neutro**.
+- **Custo:** `C_last` = `cmc_snapshot` da **data exata da âncora** (janela ±7 dias; senão neutro); `C_now` = `inventory_position` atual (freshest por `synced_at`, igual à 2a).
 
-`defasado` SE `(P_now/P_last − 1) < (C_now/C_last − 1) − tolerância`, onde `P_now` = preço que a vendedora vai praticar (carrinho).
+### 5.2 Regra (à prova de catraca) — só quando o custo SUBIU + tolerância EXPLÍCITA
+Avalia **só se `C_now > C_last`** E a alta passa de um **piso** (custo subiu **≥ 2%**; abaixo disso é ruído de CMC → neutro).
 
-Mostra **`P_req = P_last × (C_now/C_last)`** = o preço que **preserva o markup antigo** (repasse pleno). UI: "custo +Y% desde MM/AA · repassar p/ R$ P_req".
+`defasado` SE `(P_now/P_last − 1) < (C_now/C_last − 1) − tol_pp`, onde:
+- **`tol_pp` = 3 pontos percentuais** (default conservador, tunável — Codex #5).
+- `P_now` = preço que a vendedora vai praticar (carrinho).
 
-### 5.3 Guards (meu passe adversário — Q1/Q3/Q5)
-- **G1 âncora ruim por desconto/promo:** se `P_last ≤ C_last` (vendeu no/abaixo do custo) → a catraca herdaria markup ruim → **neutro/baixa-confiança** (não ancora num prejuízo).
-- **G2 só pedido real:** filtro de status/omie_pedido_id/deleted_at (acima) — cancelado/rascunho/devolvido não vira âncora.
-- **G3 âncora velha:** `order_date_kpi` > **18 meses** → caveat "âncora antiga" (ou neutro) — repasse acumulado de anos não é crível como 1 número.
-- **G4 quarentena de salto:** `C_now/C_last − 1 > +50%` (provável erro de cadastro/unidade) → **"revisar"**, NÃO alerta de repasse. Idem salto de preço absurdo.
-- **G5 unidade:** assume mesmo SKU/unidade entre âncora e agora (mesmo `omie_codigo_produto`). Mudança de unidade (caixa↔un) é risco conhecido → quarentena pega o ratio absurdo. (v2: validar `unidade`.)
-- **G6 múltiplos no mesmo dia / qty diferente:** pega o mais recente por `order_date_kpi` + tiebreak; ignora diferença de quantidade no v1 (compara preço unitário) — risco de faixa de volume documentado.
+**Piso de ação (anti-arredondamento — Codex #5):** só sinaliza se `P_req − P_now ≥ max(2% de P_now, R$ 1,00)`, comparado em **reais arredondados a centavo** → arredondamento de centavo **nunca** dispara alerta.
+
+Mostra **`P_req = P_last × (C_now/C_last)`** (arredondado) = preço que **preserva o markup antigo**. UI: "custo +Y% desde MM/AA · repassar p/ R$ P_req".
+
+### 5.3 Guards
+- **G1 (sólido — Codex confirmou):** `P_last ≤ C_last` (vendeu no/abaixo do custo) → **neutro** (não herda markup de prejuízo).
+- **G2:** allowlist de status + filtros (§5.1).
+- **G3:** `data âncora` > **18 meses** → caveat "âncora antiga" ou neutro.
+- **G4 quarentena:** `C_now/C_last − 1 > +50%` (provável erro de cadastro/unidade) → **"revisar"**, NÃO alerta de repasse. Idem salto de preço absurdo.
+- **G5 unidade (HONESTO — limitação real):** `order_items` **NÃO tem coluna de unidade** → não dá pra comparar unidade âncora vs atual. Mitigação: a quarentena (G4) pega troca **grossa** (caixa↔un dá ratio absurdo); pra troca **sutil** (<50%) ou faixa de volume, exigir âncora em **faixa de quantidade comparável** (`quantity` âncora vs carrinho na mesma ordem de grandeza) — divergência grande → neutro. **Risco residual documentado** (§10 #7).
+- **G6 frescor do `C_now` (NOVO — Codex #9):** `inventory_position.synced_at` stale → **neutro/`sem_custo_atual_fresco`** (mesma guarda da 2a; sync atrasado não vira falso negativo nem snapshot contaminado vira FP).
+- **G7 data confiável (NOVO — Codex #7):** sem `dInc`/proveniência boa da data → **neutro/`sem_data_confiavel`**.
 
 ### 5.4 Degradação honesta
-Sem `order_items` real do cliente → **neutro/sem_historico**; sem `cmc_snapshot` cobrindo a data → **neutro/sem_custo_historico**; `P_last`/`C_last` ≤ 0 ou NaN → neutro; `C_now ≤ C_last` → **neutro/sem_alta** (não é defasagem). Nunca fabricar alerta.
+**neutro** quando: sem `order_items` real do cliente (`sem_historico`); sem `cmc_snapshot` na janela da data (`sem_custo_historico`); `P_last`/`C_last` ≤ 0 ou NaN; `C_now ≤ C_last` (`sem_alta`); alta < piso 2%; linha com desconto não-provado (`desconto_nao_provado`); data não confiável (`sem_data_confiavel`); `C_now` stale (`sem_custo_atual_fresco`); unidade/qty incerta (`revisar`). **Nunca fabricar alerta.**
 
 ### 5.5 CMC histórico = visão ATUAL do Omie (nota)
 O `cmc_snapshot` guarda o que o Omie devolve **hoje** pra uma data passada. Se o Omie recalcula o CMC retroativo, é "a melhor visão atual do custo passado" — e comparar `C_last` e `C_now` na **mesma base** (ambos via Omie hoje) é mais consistente que misturar um congelado-na-época com um vivo. Aceito.
 
-## 6. Segurança / vazamento (Q4)
-`P_req` revela `C_now/C_last` (a **razão** de alta do custo), não os valores absolutos. A vendedora deduz "o custo subiu Y%", não o CMC. O founder **aceitou o risco do oráculo** na 2a; aqui não é pior (não dá pra deduzir o CMC absoluto de `P_req` + `P_last`). CMC absoluto continua **gestor-only**; a RPC é staff-gated + REVOKE anon (igual à 2a).
+## 6. Segurança / vazamento (Codex #3 + #10)
+- **Sólido (Codex confirmou):** `P_req` revela a **razão** `C_now/C_last` (% de alta), não os valores absolutos. CMC absoluto (`c_last`/`c_now`) **não** vaza pra vendedora.
+- **Escopo de autorização (Codex #10):** campos numéricos absolutos gated por **`pode_ver_carteira_completa`** (gate da 2a); `p_req`/`alta_custo_perc` visíveis pra vendedora pro cliente **em contexto** (ação dela). Consulta out-of-band de cliente arbitrário continua **staff-gated** + REVOKE anon (mesma postura que o founder **aceitou na 2a**). Refinar pra escopo-de-carteira fica como v2 se virar necessidade real.
 
 ## 7. Faixas / saída da RPC (por item)
-`status_defasagem`: `defasado | em_dia | sem_historico | sem_alta | revisar | neutro`. Sempre: `status`, `tem_ancora`, `calculated_at`. Role-gated (gestor): `p_last`, `c_last`, `c_now`, `markup_anterior`, `alta_custo_perc`, `data_ancora`. **`p_req` e `alta_custo_perc` visíveis pra vendedora** (ação dela). `motivo` honesto.
+`status_defasagem`: `defasado | em_dia | sem_historico | sem_alta | revisar | sem_custo_atual_fresco | sem_data_confiavel | neutro`. Sempre: `status`, `tem_ancora`, `calculated_at`. **Visível pra vendedora:** `p_req`, `alta_custo_perc`, `data_ancora` (mês/ano), `motivo` honesto. **Role-gated (gestor, `pode_ver_carteira_completa`):** `p_last`, `c_last`, `c_now`, `markup_anterior`.
 
 ## 8. Testes
-- **Helper puro TDD** (`defasagem.ts`): a regra + guards (oráculo). Casos: defasado, em-dia, sem-alta (custo caiu→neutro), G1 (P_last≤C_last), G3 (âncora velha), G4 (quarentena +50%), tolerância na fronteira.
-- **PG17** (`db/test-defasagem.sh`): RPC lê `cmc_snapshot`/`order_items`/`sales_orders` (stubs); âncora pega o pedido real mais recente (ignora cancelado/rascunho); ponte de conta; degradação; quarentena; role-gate (gestor vê números, vendedora vê só `p_req`/faixa) + falsificação; REVOKE anon.
-- **Backfill edge:** testado contra o Omie no smoke (paginação até página vazia + guard; idempotência do upsert).
+- **Helper puro TDD** (`defasagem.ts`): regra + guards + a **tolerância/piso** (oráculo). Casos: defasado, em-dia, sem-alta (custo caiu→neutro), G1 (P_last≤C_last), G3 (âncora velha), G4 (quarentena +50%), **fronteira da tolerância** (custo +10% / preço +9,96% por centavo → NÃO dispara), **piso de ação** (gap < R$1 → não dispara).
+- **PG17** (`db/test-defasagem.sh`): RPC lê `cmc_snapshot`/`order_items`/`sales_orders` (stubs) + **falsificações** (Codex):
+  - mesmo `omie_codigo_cliente` em **2 contas** → âncora vem da conta certa (account-aware);
+  - snapshot **longe** da data da âncora (>±7d) → **neutro**, não FP (Codex #1);
+  - linha com **desconto** → neutro (Codex #4);
+  - **cent-rounding** não dispara (Codex #5);
+  - `C_now` **stale** → neutro (Codex #9);
+  - **multi-pedido no mesmo dia** → média ponderada (Codex #8);
+  - status **não-final** (`rascunho`/`cancelado`/`orcamento`) **excluído** da âncora (Codex #6);
+  - role-gate (gestor vê `c_*`, vendedora vê só `p_req`/faixa) + falsificação; REVOKE anon.
+- **Backfill edge:** smoke dos 2 gates (dDataPosicao 2 datas + desconto) + paginação até página vazia + idempotência do upsert.
 
 ## 9. Sequência de build (gated)
-1. **Smoke `dDataPosicao`** (pré-req — confirma o dado). 🚧 gate.
-2. **Codex challenge da metodologia** (cota volta 18/06 ou créditos). 🚧 gate money-path.
-3. `cmc_snapshot` + edge backfill + cron.
-4. Helper TDD + RPC `get_defasagem_cliente` + PG17.
-5. Hook + badge no `CartItemList`.
+1. **GATE 1 — smoke `dDataPosicao`** (prova de 2 datas). 🚧
+2. **GATE 2 — smoke semântica de desconto Omie.** 🚧
+3. **Codex challenge da metodologia** — ✅ **FEITO (15/06)**, achados foldados nesta v2.
+4. `cmc_snapshot` + edge backfill (exato-por-âncora + grade mensal) + cron.
+5. Helper TDD + RPC `get_defasagem_cliente` + PG17 (+falsificações §8).
+6. Hook + badge no `CartItemList`.
 
-## 10. Riscos (P1) e mitigação
+## 10. Riscos (atualizado pós-Codex) e mitigação
 | # | Risco | Mitigação |
 |---|---|---|
-| 1 | `dDataPosicao` não devolve histórico de verdade | **smoke obrigatório** antes do backfill (gate) |
-| 2 | Âncora de pedido promocional/atípico → P_req inflado | G1 (P_last≤C_last→neutro) + G4 quarentena |
-| 3 | Data errada (`order_items.created_at`=sync) | usar `sales_orders.order_date_kpi` (canônico) |
-| 4 | Cancelado/rascunho/devolvido como âncora | filtro de status/omie_pedido_id/deleted_at |
-| 5 | CMC retroativo recalculado | base consistente (ambos via Omie hoje); aceito (§5.5) |
-| 6 | Granularidade mensal perde repasse | suficiente p/ âncora de meses atrás; v2 refina |
-| 7 | Mudança de unidade (caixa↔un) | G5 + quarentena do ratio absurdo |
-| 8 | Líquido vs bruto no `unit_price` | confirmar `desconto` no build (§5.1) |
-| 9 | Identidade do cliente mismapeada | `customer_user_id` mapeado (Fase 0); risco herdado |
+| 1 | `dDataPosicao` não devolve histórico de verdade | **GATE 1** (prova de 2 datas) antes do backfill |
+| 2 | **CMC mensal → FP** (Codex crít #1) | backfill **exato por âncora** + janela ±7d, senão neutro |
+| 3 | **Âncora no cliente errado por conta** (Codex crít #2) | âncora **account-aware** + teste de falsificação (mesmo código, 2 contas). Raiz da identidade = contrato da Fase 0 (herdado) |
+| 4 | Âncora de pedido promocional/atípico → P_req inflado | G1 (P_last≤C_last→neutro) + G4 quarentena |
+| 5 | **Líquido vs bruto** no `unit_price` (Codex #4) | **GATE 2** + neutralizar linha com desconto até provar; 2 camadas (linha+pedido) |
+| 6 | **Tolerância indefinida / cent-rounding** (Codex #5) | tol_pp=3 + piso de ação em reais arredondados |
+| 7 | **Troca de unidade** caixa↔un (Codex alta) | G4 (ratio absurdo) + G5 faixa de qty. **Residual: sem coluna `unidade` → troca sutil não detectável** |
+| 8 | **Status não-final / devolução** como âncora (Codex #6) | allowlist positiva. **Residual: devolução pós-`faturado` não tem status → não detectável** |
+| 9 | **`order_date_kpi` impuro** (89% == created_at; Codex #7) | preferir `dInc` do `omie_payload`; G7 neutro sem data confiável |
+| 10 | Multi-pedido mesmo dia inverte âncora (Codex #8) | média ponderada por `quantity` ou neutro |
+| 11 | `C_now` stale (Codex #9) | G6 frescor por `synced_at` → neutro |
+| 12 | RPC vira oráculo amplo de cliente (Codex #10) | staff-gate + `pode_ver_carteira_completa` nos absolutos (postura 2a aceita) |
+| 13 | CMC retroativo recalculado | base consistente (ambos via Omie hoje); aceito (§5.5) |
+| 14 | Identidade do cliente mismapeada | `customer_user_id` mapeado (Fase 0); risco herdado |
 
 ## 11. Refs
-Spec 2a: `docs/superpowers/specs/2026-06-14-cockpit-preco-markup-cmc-design.md` (§4.4/§9 esboço — esta spec o supera). Ponte de conta: RPC `get_preco_cockpit` + reposição `20260606190000`. `order_date_kpi`: roadmap §3 (data canônica TZ-safe). Sync de `order_items`/`order_date_kpi`: `omie-vendas-sync`.
+Spec 2a: `docs/superpowers/specs/2026-06-14-cockpit-preco-markup-cmc-design.md`. Ponte de conta: RPC `get_preco_cockpit` + reposição `20260606190000`. `order_date_kpi`/`dInc`: `omie-vendas-sync`. Challenge Codex 2b: `/tmp/codex-2b-challenge.log` (15/06).
+
+## 12. Changelog do challenge Codex (2026-06-15)
+Rodado gpt-5.5 xhigh (131k tok). **9 achados** (2 crít · 5 alta · 3 média) + 4 pontos confirmados sólidos. **Todos os válidos foldados.** Aterrados no schema real (status vocab; **sem coluna `unidade`**; **89% `order_date_kpi`==`created_at`**; `discount` em 2 camadas; `customer_user_id` direto em `order_items`; `omie_payload` tem `dInc`). **Residuais honestos (sem dado pra fechar):** troca de unidade sutil (sem coluna de unidade) e devolução pós-faturado (sem status de devolução) — ambos mitigados por quarentena/allowlist mas não 100% elimináveis no v1.

--- a/docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md
+++ b/docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md
@@ -1,0 +1,98 @@
+# Cockpit de preço — Fase 2b: defasagem de repasse POR CLIENTE — design
+
+> Sub-projeto da Onda 1 (co-piloto de venda ao vivo). Continuação da Fase 2a (saúde de markup sobre CMC atual, já em produção). Esta spec é o ciclo próprio da **2b**.
+> **Status do Codex:** o challenge adversário da metodologia está **PENDENTE** (cota do Codex estourou em 2026-06-15, volta 18/06). Foldei aqui o **meu** passe adversário (Q1-Q5); o passe do Codex **gateia o BUILD**, não a spec.
+
+## 1. Objetivo
+
+Na ligação, quando a vendedora monta um pedido pra um cliente que **já comprou aquele item antes**, avisar se **o custo subiu desde a última compra dele e o preço não acompanhou** — e mostrar o **preço de equilíbrio do repasse** (o que preserva o markup antigo). Decisão do founder (regra-mãe): "só alerta se a pessoa não subir pelo menos o % que o CMC subiu".
+
+**Não-objetivo:** defasagem global por produto, meta-margem absoluta (é a 2a), bloquear venda.
+
+## 2. Decisões travadas (founder, 2026-06-15)
+
+- **D1 — escopo:** defasagem **POR CLIENTE** (âncora = último pedido **deste cliente** pra **este item**). Casa com a ligação. (Global descartado pro v1.)
+- **D2 — sem histórico do cliente:** **neutro/silencioso** (a 2b só fala em recompra; a 2a cobre a saúde absoluta). Precisão > recall.
+- **D3 — UI:** **linha do carrinho** (estende o badge da 2a). `P_req` visível pra vendedora (ação dela); CMC absoluto continua só pro gestor.
+- **D4 — decisão delegada a "mim + Codex":** knobs/regra/guards (founder: "decida você e codex").
+
+## 3. Premissa de dado (CORRIGIDA) + pré-requisito
+
+**O CMC histórico EXISTE no Omie.** `estoque/consulta/ListarPosEstoque` é parametrizado por **`dDataPosicao`** e devolve o `nCMC` **como estava naquela data**. O `omie-analytics-sync` (~L716) só pede "hoje". → dá pra puxar o CMC de qualquer data passada (e backfillar).
+
+⚠️ **PRÉ-REQUISITO DO BUILD (smoke):** confirmar com 1 chamada real que `dDataPosicao` passada devolve `nCMC` **histórico** (não o atual com rótulo de data). Sem isso confirmado, NÃO construir o backfill. (Não temos acesso ao Omie pela RPC/terminal — roda numa edge pontual ou o founder testa.)
+
+## 4. Arquitetura
+
+**Restrição-pivô:** uma RPC Postgres **não chama a API do Omie** → o CMC-por-data tem que estar **no banco**. O `cmc_ledger` (2a) só acumula desde 14/06 (sem passado). Logo: **backfill do Omie → tabela de snapshot**, e a RPC lê do banco.
+
+| Unidade | Cria/usa | Responsabilidade |
+|---|---|---|
+| `cmc_snapshot(account, omie_codigo_produto, data_posicao date, cmc, synced_at)` | Cria | CMC por data (mensal). PK/unique `(account, omie_codigo_produto, data_posicao)`. |
+| Edge `cmc-snapshot-backfill` | Cria | Chama `ListarPosEstoque` com `dDataPosicao` = fim de cada mês (1 chamada/mês/conta = catálogo inteiro, paginado); upsert idempotente. Backfill (~12-18 meses) + cron mensal. |
+| RPC `get_defasagem_cliente(p_itens jsonb, p_customer_user_id uuid)` | Cria | **Separada** da `get_preco_cockpit** (não toca a RPC de markup recém-estabilizada; single-responsibility). Batch, SECURITY DEFINER, staff-gated. |
+| Hook + UI | Modifica | `CartItemList` chama a RPC nova (1 batch por carrinho) + badge de defasagem na linha. |
+
+**Por que RPC separada (não estender a 2a):** a `get_preco_cockpit` acabou de passar por challenge + fixes; mexer nela arrisca regressão money-path. A defasagem é outra responsabilidade (por-cliente, histórico). Custo: 2 chamadas por carrinho (aceitável; react-query dedupe).
+
+## 5. Metodologia
+
+### 5.1 Âncora (do cliente, do real)
+- **Price side:** última linha de `order_items` do `(customer_user_id, omie_codigo_produto)` **JOIN `sales_orders`** por `sales_order_id`, filtrando **pedido real** (`omie_pedido_id IS NOT NULL`, `status NOT IN ('cancelado','rascunho')`, `deleted_at IS NULL`), conta certa. → `P_last` (líquido) + **data real do pedido = `sales_orders.order_date_kpi`** (NÃO `order_items.created_at`, que é hora de sync). Mais recente por `order_date_kpi`, tiebreak determinístico.
+  - ⚠️ Build: confirmar o **líquido** — `order_items.unit_price = prod.valor_unitario` + `discount` separado; definir `P_last` líquido (subtrair desconto se for R$; cuidar se for %).
+- **Cost side:** `C_last` = `cmc_snapshot` mais próximo **≤ `order_date_kpi`** (mesma ponte de conta da 2a); `C_now` = `inventory_position` atual (freshest por `synced_at`, igual à 2a).
+
+### 5.2 Regra (à prova de catraca) — só quando o custo SUBIU
+Avalia **só se `C_now > C_last`** (custo realmente subiu — a dor do founder; custo flat/caiu → neutro, sem alerta de margem invertida).
+
+`defasado` SE `(P_now/P_last − 1) < (C_now/C_last − 1) − tolerância`, onde `P_now` = preço que a vendedora vai praticar (carrinho).
+
+Mostra **`P_req = P_last × (C_now/C_last)`** = o preço que **preserva o markup antigo** (repasse pleno). UI: "custo +Y% desde MM/AA · repassar p/ R$ P_req".
+
+### 5.3 Guards (meu passe adversário — Q1/Q3/Q5)
+- **G1 âncora ruim por desconto/promo:** se `P_last ≤ C_last` (vendeu no/abaixo do custo) → a catraca herdaria markup ruim → **neutro/baixa-confiança** (não ancora num prejuízo).
+- **G2 só pedido real:** filtro de status/omie_pedido_id/deleted_at (acima) — cancelado/rascunho/devolvido não vira âncora.
+- **G3 âncora velha:** `order_date_kpi` > **18 meses** → caveat "âncora antiga" (ou neutro) — repasse acumulado de anos não é crível como 1 número.
+- **G4 quarentena de salto:** `C_now/C_last − 1 > +50%` (provável erro de cadastro/unidade) → **"revisar"**, NÃO alerta de repasse. Idem salto de preço absurdo.
+- **G5 unidade:** assume mesmo SKU/unidade entre âncora e agora (mesmo `omie_codigo_produto`). Mudança de unidade (caixa↔un) é risco conhecido → quarentena pega o ratio absurdo. (v2: validar `unidade`.)
+- **G6 múltiplos no mesmo dia / qty diferente:** pega o mais recente por `order_date_kpi` + tiebreak; ignora diferença de quantidade no v1 (compara preço unitário) — risco de faixa de volume documentado.
+
+### 5.4 Degradação honesta
+Sem `order_items` real do cliente → **neutro/sem_historico**; sem `cmc_snapshot` cobrindo a data → **neutro/sem_custo_historico**; `P_last`/`C_last` ≤ 0 ou NaN → neutro; `C_now ≤ C_last` → **neutro/sem_alta** (não é defasagem). Nunca fabricar alerta.
+
+### 5.5 CMC histórico = visão ATUAL do Omie (nota)
+O `cmc_snapshot` guarda o que o Omie devolve **hoje** pra uma data passada. Se o Omie recalcula o CMC retroativo, é "a melhor visão atual do custo passado" — e comparar `C_last` e `C_now` na **mesma base** (ambos via Omie hoje) é mais consistente que misturar um congelado-na-época com um vivo. Aceito.
+
+## 6. Segurança / vazamento (Q4)
+`P_req` revela `C_now/C_last` (a **razão** de alta do custo), não os valores absolutos. A vendedora deduz "o custo subiu Y%", não o CMC. O founder **aceitou o risco do oráculo** na 2a; aqui não é pior (não dá pra deduzir o CMC absoluto de `P_req` + `P_last`). CMC absoluto continua **gestor-only**; a RPC é staff-gated + REVOKE anon (igual à 2a).
+
+## 7. Faixas / saída da RPC (por item)
+`status_defasagem`: `defasado | em_dia | sem_historico | sem_alta | revisar | neutro`. Sempre: `status`, `tem_ancora`, `calculated_at`. Role-gated (gestor): `p_last`, `c_last`, `c_now`, `markup_anterior`, `alta_custo_perc`, `data_ancora`. **`p_req` e `alta_custo_perc` visíveis pra vendedora** (ação dela). `motivo` honesto.
+
+## 8. Testes
+- **Helper puro TDD** (`defasagem.ts`): a regra + guards (oráculo). Casos: defasado, em-dia, sem-alta (custo caiu→neutro), G1 (P_last≤C_last), G3 (âncora velha), G4 (quarentena +50%), tolerância na fronteira.
+- **PG17** (`db/test-defasagem.sh`): RPC lê `cmc_snapshot`/`order_items`/`sales_orders` (stubs); âncora pega o pedido real mais recente (ignora cancelado/rascunho); ponte de conta; degradação; quarentena; role-gate (gestor vê números, vendedora vê só `p_req`/faixa) + falsificação; REVOKE anon.
+- **Backfill edge:** testado contra o Omie no smoke (paginação até página vazia + guard; idempotência do upsert).
+
+## 9. Sequência de build (gated)
+1. **Smoke `dDataPosicao`** (pré-req — confirma o dado). 🚧 gate.
+2. **Codex challenge da metodologia** (cota volta 18/06 ou créditos). 🚧 gate money-path.
+3. `cmc_snapshot` + edge backfill + cron.
+4. Helper TDD + RPC `get_defasagem_cliente` + PG17.
+5. Hook + badge no `CartItemList`.
+
+## 10. Riscos (P1) e mitigação
+| # | Risco | Mitigação |
+|---|---|---|
+| 1 | `dDataPosicao` não devolve histórico de verdade | **smoke obrigatório** antes do backfill (gate) |
+| 2 | Âncora de pedido promocional/atípico → P_req inflado | G1 (P_last≤C_last→neutro) + G4 quarentena |
+| 3 | Data errada (`order_items.created_at`=sync) | usar `sales_orders.order_date_kpi` (canônico) |
+| 4 | Cancelado/rascunho/devolvido como âncora | filtro de status/omie_pedido_id/deleted_at |
+| 5 | CMC retroativo recalculado | base consistente (ambos via Omie hoje); aceito (§5.5) |
+| 6 | Granularidade mensal perde repasse | suficiente p/ âncora de meses atrás; v2 refina |
+| 7 | Mudança de unidade (caixa↔un) | G5 + quarentena do ratio absurdo |
+| 8 | Líquido vs bruto no `unit_price` | confirmar `desconto` no build (§5.1) |
+| 9 | Identidade do cliente mismapeada | `customer_user_id` mapeado (Fase 0); risco herdado |
+
+## 11. Refs
+Spec 2a: `docs/superpowers/specs/2026-06-14-cockpit-preco-markup-cmc-design.md` (§4.4/§9 esboço — esta spec o supera). Ponte de conta: RPC `get_preco_cockpit` + reposição `20260606190000`. `order_date_kpi`: roadmap §3 (data canônica TZ-safe). Sync de `order_items`/`order_date_kpi`: `omie-vendas-sync`.

--- a/docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md
+++ b/docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md
@@ -22,11 +22,11 @@ Na ligação, quando a vendedora monta um pedido pra um cliente que **já compro
 
 **O CMC histórico EXISTE no Omie.** `estoque/consulta/ListarPosEstoque` é parametrizado por **`dDataPosicao`** e devolve o `nCMC` **como estava naquela data**. O `omie-analytics-sync` (~L716) só pede "hoje". → dá pra puxar o CMC de qualquer data passada (e backfillar).
 
-⚠️ **GATE 1 — smoke `dDataPosicao` (prova de 2 datas):** pegar 1 SKU que comprovadamente **mudou de CMC** entre duas datas e confirmar que `dDataPosicao` devolve os **dois valores distintos** — não o atual com rótulo de data. (Codex: subir de "1 chamada" pra prova de duas datas.) Não temos Omie pela RPC/terminal → roda numa edge pontual ou o founder testa.
+🚧 **GATE 1 — smoke `dDataPosicao` (prova de 2 datas):** pegar SKUs que comprovadamente **mudaram de CMC** entre duas datas e confirmar que `dDataPosicao` devolve os **valores distintos** — não o atual com rótulo de data. (Codex: subir de "1 chamada" pra prova de duas datas.) Não temos Omie pela RPC/terminal → **edge `cmc-snapshot-smoke` já rascunhado** (só lê o Omie, staff-gated, deno-check ok): basta deploy + 1 invoke com `{account, dataA, dataB}`. Veredito `PROVADO`/`SUSPEITO`/`INCONCLUSIVO` no JSON.
 
-⚠️ **GATE 2 — smoke semântica de desconto do Omie:** provar como `order_items.discount` e `sales_orders.discount` representam o desconto (**R$ vs %**, **por-linha vs por-pedido**) ANTES de computar o `P_last` líquido. Enquanto não provado, **linha com desconto > 0 → neutro** (§5.1).
+✅ **GATE 2 — semântica de desconto: RESOLVIDO no dado (15/06).** Forense read-only: `order_items.discount > 0` = **0 de 13.627**; `sales_orders.discount > 0` = **0 de 6.687**. Nenhum pedido carrega desconto → `P_last = unit_price` é o líquido pra **100%** das âncoras atuais, e a RPC lê as **colunas** (não o payload cru). O guard "`discount > 0` → neutro" (§5.1) permanece como **proteção futura de custo zero** (neutraliza 0 linhas hoje). **Sem edge/smoke.**
 
-Sem os 2 gates confirmados, NÃO construir o backfill/RPC.
+Sem o GATE 1 confirmado, NÃO construir o backfill/RPC.
 
 ## 4. Arquitetura
 
@@ -51,7 +51,7 @@ Sem os 2 gates confirmados, NÃO construir o backfill/RPC.
 - **Âncora:** última linha de `order_items` do `(customer_user_id, omie_codigo_produto)` **JOIN `sales_orders`** por `sales_order_id`, **account-aware** (`account` = ponte da empresa, igual à 2a — Oben→['vendas','oben'] etc.). → `P_last` (líquido) + data real.
 - **Status allowlist (aterrada):** `status IN ('faturado','importado','separacao','enviado')` — vendas reais. Exclui `cancelado`/`rascunho`/`orcamento`. + `omie_pedido_id IS NOT NULL` + `deleted_at IS NULL`. (Lista **positiva**, não denylist — Codex #6. `importado`=1206 pedidos reais do Omie, mantidos: são a recompra histórica.)
 - **Data da âncora (proveniência — Codex #7):** preferir **`dInc` extraído do `omie_payload`** (verdade canônica do Omie) → fallback `order_date_kpi` → se nenhum confiável, **neutro**. (Grounded: **89%** dos `order_date_kpi` == `created_at::date` → proveniência impura; não confiar cega no `order_date_kpi`.)
-- **`P_last` líquido (Codex #4):** `unit_price` − desconto da linha (− rateio do `sales_orders.discount` por pedido). São **2 camadas** de desconto. Enquanto o **GATE 2** não provar a semântica (R$ vs %) → **linha com `discount > 0` em qualquer camada = neutro**.
+- **`P_last` líquido (Codex #4):** **empírico (15/06): desconto é sempre 0 no histórico** (0/13.627 linhas, 0/6.687 pedidos) → `P_last = unit_price` hoje. O guard **`discount > 0` (qualquer das 2 camadas: linha `order_items.discount` + pedido `sales_orders.discount`) → neutro** permanece como proteção futura de custo zero (se o Omie passar a mandar desconto, neutraliza até a semântica R$/% ser provada).
 - **Multi-pedido no mesmo dia (Codex #8):** `order_date_kpi` é `date` (sem hora) → empate possível. Resolver por **média ponderada pela `quantity`** do preço líquido; se a divergência de preço entre as linhas do dia for alta → **neutro**.
 - **Custo:** `C_last` = `cmc_snapshot` da **data exata da âncora** (janela ±7 dias; senão neutro); `C_now` = `inventory_position` atual (freshest por `synced_at`, igual à 2a).
 
@@ -102,8 +102,8 @@ O `cmc_snapshot` guarda o que o Omie devolve **hoje** pra uma data passada. Se o
 - **Backfill edge:** smoke dos 2 gates (dDataPosicao 2 datas + desconto) + paginação até página vazia + idempotência do upsert.
 
 ## 9. Sequência de build (gated)
-1. **GATE 1 — smoke `dDataPosicao`** (prova de 2 datas). 🚧
-2. **GATE 2 — smoke semântica de desconto Omie.** 🚧
+1. **GATE 1 — smoke `dDataPosicao`** (prova de 2 datas). 🚧 edge `cmc-snapshot-smoke` pronto → deploy + invoke.
+2. **GATE 2 — semântica de desconto** — ✅ **RESOLVIDO no dado** (15/06; desconto sempre 0 → guard de custo zero).
 3. **Codex challenge da metodologia** — ✅ **FEITO (15/06)**, achados foldados nesta v2.
 4. `cmc_snapshot` + edge backfill (exato-por-âncora + grade mensal) + cron.
 5. Helper TDD + RPC `get_defasagem_cliente` + PG17 (+falsificações §8).

--- a/supabase/functions/cmc-snapshot-smoke/index.ts
+++ b/supabase/functions/cmc-snapshot-smoke/index.ts
@@ -1,0 +1,225 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// cmc-snapshot-smoke — GATE 1 da Fase 2b (defasagem por cliente).
+//
+// PROVA (ou refuta) a premissa-pivô da 2b: que `ListarPosEstoque` parametrizado
+// por `dDataPosicao` devolve o CMC **como estava naquela data** (histórico), e
+// não o CMC atual com um rótulo de data.
+//
+// Método (Codex pediu prova de 2 datas, não 1 chamada): pagina o catálogo em
+// DUAS datas distintas, cruza por nCodProd, e mostra quantos SKUs têm nCMC
+// DIFERENTE entre as datas. Se vários diferem → dDataPosicao é histórico-real.
+// Se ZERO diferem sobre datas bem separadas → SUSPEITO (Omie pode estar
+// ignorando o parâmetro) e o backfill da 2b NÃO deve ser construído.
+//
+// É um edge de DIAGNÓSTICO: só LÊ o Omie, não escreve no banco. Staff-gated.
+// Pode ser apagado depois que o gate fechar.
+//
+// Invocar (exemplo):
+//   POST /functions/v1/cmc-snapshot-smoke
+//   Authorization: Bearer <JWT staff ou SERVICE_ROLE_KEY>
+//   { "account": "colacor_vendas", "dataA": "2026-01-15", "dataB": "2026-06-15",
+//     "maxPaginas": 10, "codProdAlvo": 1234567890 }
+//   (datas aceitam ISO YYYY-MM-DD ou DD/MM/YYYY; o Omie recebe DD/MM/YYYY)
+// ─────────────────────────────────────────────────────────────────────────────
+import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
+
+const OMIE_API_URL = "https://app.omie.com.br/api/v1";
+
+type OmieAccount = "vendas" | "servicos" | "colacor_vendas";
+const CONTAS_VALIDAS: OmieAccount[] = ["vendas", "servicos", "colacor_vendas"];
+
+interface OmieEstoqueProduto {
+  nCodProd?: number;
+  nSaldo?: number;
+  nCMC?: number;
+  nPrecoMedio?: number;
+}
+interface OmieListarPosEstoqueResponse {
+  produtos?: OmieEstoqueProduto[];
+  nTotPaginas?: number;
+  faultstring?: string;
+}
+
+// Mesmas credenciais por conta que o omie-analytics-sync (vendas=Oben,
+// colacor_vendas=Colacor, servicos=Colacor SC).
+function getCredentials(account: OmieAccount) {
+  if (account === "vendas") {
+    return { key: Deno.env.get("OMIE_OBEN_APP_KEY"), secret: Deno.env.get("OMIE_OBEN_APP_SECRET") };
+  }
+  if (account === "colacor_vendas") {
+    return { key: Deno.env.get("OMIE_COLACOR_APP_KEY"), secret: Deno.env.get("OMIE_COLACOR_APP_SECRET") };
+  }
+  return { key: Deno.env.get("OMIE_COLACOR_SC_APP_KEY"), secret: Deno.env.get("OMIE_COLACOR_SC_APP_SECRET") };
+}
+
+// Chamada Omie com retry curto p/ flakiness transitória (mesma família de erros
+// que o analytics-sync trata: "broken response"/SOAP/timeout/5xx).
+async function callOmie(
+  account: OmieAccount,
+  endpoint: string,
+  call: string,
+  params: Record<string, unknown>,
+): Promise<OmieListarPosEstoqueResponse> {
+  const creds = getCredentials(account);
+  if (!creds.key || !creds.secret) throw new Error(`Credenciais Omie (${account}) não configuradas`);
+  const body = { call, app_key: creds.key, app_secret: creds.secret, param: [params] };
+
+  const maxAttempts = 3;
+  let lastErr: Error | null = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const res = await fetch(`${OMIE_API_URL}/${endpoint}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const result = (await res.json()) as OmieListarPosEstoqueResponse;
+      if (result.faultstring) throw new Error(`Omie (${account}): ${result.faultstring}`);
+      return result;
+    } catch (e) {
+      lastErr = e instanceof Error ? e : new Error(String(e));
+      const msg = lastErr.message.toLowerCase();
+      const transient = msg.includes("broken response") || msg.includes("soap-error") ||
+        msg.includes("timeout") || msg.includes("timed out") || msg.includes("network") ||
+        msg.includes("connection") || msg.includes("fetch failed") ||
+        msg.includes("502") || msg.includes("503") || msg.includes("504") || msg.includes("500");
+      if (transient && attempt < maxAttempts) {
+        await new Promise((r) => setTimeout(r, 600 * Math.pow(2, attempt - 1)));
+        continue;
+      }
+      throw lastErr;
+    }
+  }
+  throw lastErr ?? new Error(`Omie (${account}): falha após ${maxAttempts} tentativas`);
+}
+
+// Aceita ISO (YYYY-MM-DD) ou pt-BR (DD/MM/YYYY) e devolve o que o Omie espera (DD/MM/YYYY).
+function normalizaDataPosicao(s: string): string {
+  const iso = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+  if (iso) return `${iso[3]}/${iso[2]}/${iso[1]}`;
+  if (/^\d{2}\/\d{2}\/\d{4}$/.test(s)) return s;
+  throw new Error(`Data inválida "${s}" — use YYYY-MM-DD ou DD/MM/YYYY`);
+}
+
+// Pagina ListarPosEstoque numa data e devolve mapa nCodProd -> nCMC (só com CMC > 0).
+async function cmcPorData(
+  account: OmieAccount,
+  dDataPosicao: string,
+  maxPaginas: number,
+  codAlvo: number | null,
+): Promise<{ mapa: Map<number, number>; paginasLidas: number; totalPaginas: number; alvoVisto: boolean }> {
+  const mapa = new Map<number, number>();
+  let pagina = 1;
+  let totalPaginas = 1;
+  let alvoVisto = false;
+
+  while (pagina <= totalPaginas && pagina <= maxPaginas) {
+    const result = await callOmie(account, "estoque/consulta/", "ListarPosEstoque", {
+      nPagina: pagina,
+      nRegPorPagina: 100,
+      dDataPosicao,
+    });
+    totalPaginas = result.nTotPaginas || 1;
+    for (const prod of result.produtos || []) {
+      const cod = prod.nCodProd;
+      if (!cod) continue;
+      if (cod === codAlvo) alvoVisto = true;
+      // Só guardamos CMC presente e > 0 — "ausente ≠ zero" (não fabricar custo).
+      if (typeof prod.nCMC === "number" && prod.nCMC > 0) mapa.set(cod, prod.nCMC);
+    }
+    pagina++;
+  }
+  return { mapa, paginasLidas: pagina - 1, totalPaginas, alvoVisto };
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const json = (payload: unknown, status = 200) =>
+    new Response(JSON.stringify(payload, null, 2), {
+      status,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+
+  try {
+    const body = await req.json().catch(() => ({}));
+    const account = body.account as OmieAccount;
+    const maxPaginas = Math.min(Math.max(Number(body.maxPaginas) || 10, 1), 200);
+    const codProdAlvo = body.codProdAlvo != null ? Number(body.codProdAlvo) : null;
+
+    if (!CONTAS_VALIDAS.includes(account)) {
+      return json({ ok: false, erro: `account inválida — use uma de ${CONTAS_VALIDAS.join(", ")}` }, 400);
+    }
+    if (!body.dataA || !body.dataB) {
+      return json({ ok: false, erro: "informe dataA e dataB (YYYY-MM-DD ou DD/MM/YYYY)" }, 400);
+    }
+    const dA = normalizaDataPosicao(String(body.dataA));
+    const dB = normalizaDataPosicao(String(body.dataB));
+
+    const [a, b] = await Promise.all([
+      cmcPorData(account, dA, maxPaginas, codProdAlvo),
+      cmcPorData(account, dB, maxPaginas, codProdAlvo),
+    ]);
+
+    // Cruza só SKUs presentes (com CMC>0) nas DUAS datas.
+    const EPS = 0.005;
+    const exemplos: Array<{ cod: number; cmcA: number; cmcB: number; deltaPerc: number }> = [];
+    let comparados = 0;
+    let mudaram = 0;
+    for (const [cod, cmcA] of a.mapa) {
+      const cmcB = b.mapa.get(cod);
+      if (cmcB == null) continue;
+      comparados++;
+      if (Math.abs(cmcB - cmcA) > EPS) {
+        mudaram++;
+        exemplos.push({ cod, cmcA, cmcB, deltaPerc: Math.round(((cmcB - cmcA) / cmcA) * 1000) / 10 });
+      }
+    }
+    exemplos.sort((x, y) => Math.abs(y.deltaPerc) - Math.abs(x.deltaPerc));
+
+    const alvo = codProdAlvo != null
+      ? {
+          cod: codProdAlvo,
+          cmcA: a.mapa.get(codProdAlvo) ?? null,
+          cmcB: b.mapa.get(codProdAlvo) ?? null,
+          encontrado: a.alvoVisto || b.alvoVisto,
+        }
+      : null;
+
+    // Veredito do gate.
+    let veredito: string;
+    let provado = false;
+    if (comparados === 0) {
+      veredito =
+        "INCONCLUSIVO — nenhum SKU com CMC>0 nas duas datas (aumente maxPaginas, ou as datas/contas não têm catálogo comum).";
+    } else if (mudaram > 0) {
+      provado = true;
+      veredito =
+        `PROVADO — ${mudaram}/${comparados} SKUs têm CMC diferente entre ${dA} e ${dB}. dDataPosicao devolve histórico-real → backfill da 2b é viável.`;
+    } else {
+      veredito =
+        `SUSPEITO — 0/${comparados} SKUs mudaram entre ${dA} e ${dB}. Sobre datas bem separadas isso indica que o Omie pode estar IGNORANDO dDataPosicao (devolvendo o atual). NÃO construir o backfill sem investigar.`;
+    }
+
+    return json({
+      ok: true,
+      gate: "GATE-1 dDataPosicao (Fase 2b)",
+      account,
+      datas: { A: dA, B: dB },
+      paginas: { A: `${a.paginasLidas}/${a.totalPaginas}`, B: `${b.paginasLidas}/${b.totalPaginas}`, maxPaginas },
+      skusComCmc: { A: a.mapa.size, B: b.mapa.size },
+      comparados,
+      mudaram,
+      provado,
+      veredito,
+      exemplos: exemplos.slice(0, 12),
+      alvo,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return json({ ok: false, erro: msg }, 500);
+  }
+});


### PR DESCRIPTION
## Fundação da Fase 2b — defasagem de repasse por cliente

Onda 1 / cockpit de preço. Esta entrega é **fundação + instrumento de gate**, não a feature 2b em si.

- **Spec v2** (`docs/superpowers/specs/2026-06-15-cockpit-defasagem-2b-design.md`): challenge adversarial do Codex foldado e aterrado no schema real (decisões D1–D4, premissa `dDataPosicao`, 2 GATES, metodologia da catraca, guards, riscos).
- **GATE 2 (desconto) resolvido no dado**: desconto é 0 em 13.627 linhas / 6.687 pedidos → `P_last = unit_price` é a âncora líquida correta; guard fica como future-proofing.
- **Edge `cmc-snapshot-smoke`** (`supabase/functions/cmc-snapshot-smoke/index.ts`): diagnóstico do **GATE 1** — prova/refuta que `ListarPosEstoque` por `dDataPosicao` devolve CMC histórico-real, cruzando o `nCMC` de 2 datas. **Read-only no Omie, staff/cron-gated, sem escrita no banco.** Descartável depois do gate fechar.

**Não** há código de produção da 2b (sem RPC, sem tabela, sem frontend) — o build segue atrás do HARD-GATE (aprovação da spec + smoke `PROVADO`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)