### PR TITLE
fix(cockpit/2b): serializa as 2 datas do smoke (lock de concorrência do Omie)

### DIFF
--- a/supabase/functions/cmc-snapshot-smoke/index.ts
+++ b/supabase/functions/cmc-snapshot-smoke/index.ts
@@ -64,7 +64,7 @@ async function callOmie(
   if (!creds.key || !creds.secret) throw new Error(`Credenciais Omie (${account}) não configuradas`);
   const body = { call, app_key: creds.key, app_secret: creds.secret, param: [params] };
 
-  const maxAttempts = 3;
+  const maxAttempts = 5;
   let lastErr: Error | null = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -82,9 +82,12 @@ async function callOmie(
       const transient = msg.includes("broken response") || msg.includes("soap-error") ||
         msg.includes("timeout") || msg.includes("timed out") || msg.includes("network") ||
         msg.includes("connection") || msg.includes("fetch failed") ||
-        msg.includes("502") || msg.includes("503") || msg.includes("504") || msg.includes("500");
+        msg.includes("502") || msg.includes("503") || msg.includes("504") || msg.includes("500") ||
+        // Lock de concorrência do Omie: recusa 2 chamadas simultâneas do mesmo método.
+        msg.includes("já existe uma requisição") || msg.includes("sendo executada") ||
+        msg.includes("tente novamente");
       if (transient && attempt < maxAttempts) {
-        await new Promise((r) => setTimeout(r, 600 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
       throw lastErr;
@@ -159,10 +162,10 @@ Deno.serve(async (req: Request) => {
     const dA = normalizaDataPosicao(String(body.dataA));
     const dB = normalizaDataPosicao(String(body.dataB));
 
-    const [a, b] = await Promise.all([
-      cmcPorData(account, dA, maxPaginas, codProdAlvo),
-      cmcPorData(account, dB, maxPaginas, codProdAlvo),
-    ]);
+    // Serializado de propósito: o Omie recusa 2 chamadas simultâneas do mesmo
+    // método/app_key ("Já existe uma requisição desse método sendo executada").
+    const a = await cmcPorData(account, dA, maxPaginas, codProdAlvo);
+    const b = await cmcPorData(account, dB, maxPaginas, codProdAlvo);
 
     // Cruza só SKUs presentes (com CMC>0) nas DUAS datas.
     const EPS = 0.005;


### PR DESCRIPTION
## Fix do smoke do GATE 1 — concorrência no Omie

O `cmc-snapshot-smoke` retornava **HTTP 500**:
> Omie (colacor_vendas): ERROR: Já existe uma requisição desse método sendo executada e você pode tentar novamente em alguns instantes.

**Causa:** a edge disparava `dataA` e `dataB` via `Promise.all` → 2 chamadas simultâneas de `ListarPosEstoque` com a mesma `app_key`, que o Omie **recusa**. A edge colidia consigo mesma e nem chegava a testar o `dDataPosicao`.

**Fix:**
- Serializa: `await cmcPorData(A)` → depois `await cmcPorData(B)`.
- Trata o lock ("já existe uma requisição" / "sendo executada" / "tente novamente") como transitório no retry — 5 tentativas, backoff até 8s — robustez contra colisão com os crons de sync do Omie.

Diagnóstico-only, read-only no Omie, staff/cron-gated. `deno check` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)