### PR TITLE
feat(reposicao): Fase 2 — materializa o count do badge de oportunidade (MV private + view-gate) [money-path]

### DIFF
--- a/db/test-reposicao-fase2-badge-mv.sh
+++ b/db/test-reposicao-fase2-badge-mv.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA: migration 20260627190000_reposicao_fase2_badge_oportunidade_mv.sql     ║
+# ║  MV em private (count) + view-gate em public + função de refresh. Prova:       ║
+# ║  (A1) gate replica a RLS (staff/service_role vê, não-staff/anon NÃO);          ║
+# ║  (A2) authenticated NÃO lê a MV crua (REVOKE — anti-vazamento);                ║
+# ║  (A3) paridade: oportunidade_count == count(*) da fonte por empresa;           ║
+# ║  (A4) cron-context: refresh roda sob auth.uid()=NULL (NÃO dá 42501);           ║
+# ║  (A5) REFRESH CONCURRENTLY funciona. Falsifica F1-F4.                          ║
+# ║  Rodar:  bash db/test-reposicao-fase2-badge-mv.sh > /tmp/t.log 2>&1; echo $?   ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5480}"
+SLUG="repo-f2"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -X -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+MASTER='11111111-1111-1111-1111-111111111111'
+EMP='22222222-2222-2222-2222-222222222222'
+CUST='33333333-3333-3333-3333-333333333333'
+NOROLE='44444444-4444-4444-4444-444444444444'
+
+echo "═══ setup (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: roles, has_role, schema private, stub cron, stub fonte
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='app_role') THEN
+  CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); END IF; END $$;
+CREATE TABLE public.user_roles (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id=_user_id AND role=_role) $f$;
+INSERT INTO auth.users(id) VALUES ('11111111-1111-1111-1111-111111111111'),('22222222-2222-2222-2222-222222222222'),
+  ('33333333-3333-3333-3333-333333333333'),('44444444-4444-4444-4444-444444444444') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('11111111-1111-1111-1111-111111111111','master'),('22222222-2222-2222-2222-222222222222','employee'),
+  ('33333333-3333-3333-3333-333333333333','customer');
+GRANT EXECUTE ON FUNCTION public.has_role(uuid, app_role) TO authenticated, anon;
+
+-- schema private existe em prod; authenticated NÃO tem USAGE (defense-in-depth)
+CREATE SCHEMA IF NOT EXISTS private;
+REVOKE ALL ON SCHEMA private FROM PUBLIC;
+
+-- pg_cron: o stubs-supabase.sql já cria o schema cron + tabela cron.job (jobid bigint).
+-- Só faltam as funções schedule/unschedule (não no stubs) — stubadas p/ a migration aplicar.
+CREATE FUNCTION cron.schedule(jobname text, schedule text, command text) RETURNS bigint
+  LANGUAGE sql AS $f$ INSERT INTO cron.job(jobid, jobname, schedule, command, active)
+    VALUES ((SELECT coalesce(max(jobid),0)+1 FROM cron.job), $1, $2, $3, true) RETURNING jobid $f$;
+CREATE FUNCTION cron.unschedule(jobname text) RETURNS boolean
+  LANGUAGE plpgsql AS $f$ BEGIN DELETE FROM cron.job j WHERE j.jobname=$1; RETURN true; END $f$;
+
+-- FONTE FIEL (achado Codex #1): tabela base com RLS "staff vê tudo" + view security_invoker
+-- (como em prod). Prova a dependência crítica: o refresh DEVE ver TODAS as linhas → roda como
+-- role BYPASSRLS (postgres/superuser); sob caller não-bypass não-staff a fonte dá 0 → MV vazia.
+CREATE TABLE public._oport_base (empresa text, sku_codigo_omie text);
+ALTER TABLE public._oport_base ENABLE ROW LEVEL SECURITY;
+CREATE POLICY staff_oport_base ON public._oport_base FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(),'master'::app_role) OR public.has_role(auth.uid(),'employee'::app_role));
+GRANT SELECT ON public._oport_base TO authenticated;
+INSERT INTO public._oport_base SELECT 'OBEN',    'SKU'||g FROM generate_series(1,12) g;
+INSERT INTO public._oport_base SELECT 'COLACOR', 'SKU'||g FROM generate_series(1,3)  g;
+CREATE VIEW public.v_oportunidade_economica_hoje WITH (security_invoker=on) AS
+  SELECT empresa, sku_codigo_omie FROM public._oport_base;
+GRANT SELECT ON public.v_oportunidade_economica_hoje TO authenticated;
+SQL
+echo "fonte stub: $(Pq -c "select empresa||'='||count(*) from public.v_oportunidade_economica_hoje group by empresa order by 1" | tr '\n' ' ')"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260627190000_reposicao_fase2_badge_oportunidade_mv.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+# ── helper: count de linhas visíveis na VIEW-GATE p/ um caller (uid + role GUC) ──
+gate() { Pq -c "SET test.uid='$1'; SET test.role='$2'; SET ROLE authenticated; SELECT count(*) FROM public.v_oportunidade_economica_hoje_badge_cached;" | tail -1; }
+gate_sr() { Pq -c "SET test.uid=''; SET test.role='service_role'; SET ROLE service_role; SELECT count(*) FROM public.v_oportunidade_economica_hoje_badge_cached;" | tail -1; }
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── A1 GATE replica a RLS (2 empresas visíveis p/ staff/service_role; 0 p/ resto) ──"
+eq "A1 master vê 2 empresas"   "$(gate "$MASTER" '')" "2"
+eq "A1 employee vê 2 empresas" "$(gate "$EMP" '')"    "2"
+eq "A1 customer vê 0"          "$(gate "$CUST" '')"   "0"
+eq "A1 sem-role vê 0"          "$(gate "$NOROLE" '')" "0"
+eq "A1 NULL uid vê 0"          "$(gate '' '')"        "0"
+eq "A1 service_role vê 2"      "$(gate_sr)"           "2"
+
+echo "── A2 ANTI-VAZAMENTO: authenticated NÃO lê a MV crua — pelo REVOKE da MV, não só do schema ──"
+P -q -c "GRANT USAGE ON SCHEMA private TO authenticated;"   # mesmo com USAGE no schema, a MV barra
+R=$(P -tA 2>&1 -c "SET test.uid='$MASTER'; SET ROLE authenticated; DO \$\$ BEGIN PERFORM 1 FROM private.mv_oportunidade_badge; RAISE EXCEPTION 'VAZOU'; EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'BLOQUEADO_OK'; WHEN OTHERS THEN RAISE; END \$\$;" || true)
+case "$R" in *BLOQUEADO_OK*) ok "A2 master barrado na MV crua MESMO com USAGE no schema (prova o REVOKE da MV)";; *) bad "A2 NÃO barrou a MV crua: $R";; esac
+P -q -c "REVOKE USAGE ON SCHEMA private FROM authenticated;"
+
+echo "── A3 PARIDADE: oportunidade_count == count(*) da fonte por empresa ──"
+PAR=$(Pq -c "select count(*) from private.mv_oportunidade_badge m join (select empresa, count(*)::int c from public.v_oportunidade_economica_hoje group by empresa) s on s.empresa=m.empresa where m.oportunidade_count <> s.c;")
+eq "A3 zero divergências de count" "$PAR" "0"
+eq "A3 OBEN=12 na MV" "$(Pq -c "select oportunidade_count from private.mv_oportunidade_badge where empresa='OBEN';")" "12"
+
+echo "── A4 CRON-CONTEXT: refresh roda sob auth.uid()=NULL (NÃO dá 42501) ──"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SET test.role=''; SELECT public.refresh_oportunidade_badge();" || true)
+case "$R" in *42501*|*"Acesso negado"*|*denied*) bad "A4 refresh DEU erro de acesso sob NULL: $R";; *) ok "A4 refresh rodou sob auth.uid()=NULL (cron não morre)";; esac
+
+echo "── A5 REFRESH CONCURRENTLY funciona (muda refreshed_at) ──"
+Pq -c "INSERT INTO public._oport_base VALUES ('OBEN','SKU_NOVO');" >/dev/null
+Pq -c "SELECT public.refresh_oportunidade_badge();" >/dev/null
+N=$(Pq -c "select oportunidade_count from private.mv_oportunidade_badge where empresa='OBEN';")
+eq "A5 refresh recomputou OBEN (12→13)" "$N" "13"
+
+echo "── A6 GRANTS do refresh: authenticated NÃO executa; service_role executa ──"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SET ROLE authenticated; SELECT public.refresh_oportunidade_badge();" || true)
+case "$R" in *denied*|*permission*|*42501*) ok "A6 authenticated barrado de executar o refresh (REVOKE EXECUTE)";; *) bad "A6 authenticated executou o refresh? $R";; esac
+R=$(P -tA 2>&1 -c "SET test.uid=''; SET ROLE service_role; SELECT public.refresh_oportunidade_badge();" || true)
+case "$R" in *denied*|*permission*) bad "A6 service_role NÃO executou (grant faltando): $R";; *) ok "A6 service_role executa o refresh (GRANT EXECUTE)";; esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — FALSIFICAÇÃO
+# ══════════════════════════════════════════════════════════════════════════════
+restore_view() { P -q -c "DROP VIEW IF EXISTS public.v_oportunidade_economica_hoje_badge_cached;
+  CREATE VIEW public.v_oportunidade_economica_hoje_badge_cached WITH (security_invoker=false, security_barrier=true) AS
+    SELECT empresa, oportunidade_count, refreshed_at FROM private.mv_oportunidade_badge
+    WHERE ((SELECT auth.role())='service_role' OR COALESCE((SELECT public.has_role((SELECT auth.uid()),'master'::app_role)),false) OR COALESCE((SELECT public.has_role((SELECT auth.uid()),'employee'::app_role)),false));
+  GRANT SELECT ON public.v_oportunidade_economica_hoje_badge_cached TO authenticated, service_role;"; }
+
+echo "── F1: gate USING(true) → não-staff vaza → A1 tem de morder ──"
+P -q -c "DROP VIEW public.v_oportunidade_economica_hoje_badge_cached;
+  CREATE VIEW public.v_oportunidade_economica_hoje_badge_cached WITH (security_invoker=false) AS SELECT empresa, oportunidade_count, refreshed_at FROM private.mv_oportunidade_badge WHERE true;
+  GRANT SELECT ON public.v_oportunidade_economica_hoje_badge_cached TO authenticated, service_role;"
+SAB=$(gate "$CUST" '')
+if [ "$SAB" != "0" ]; then ok "F1 A1 tem dente (gate(true) vazou ${SAB} p/ customer)"; else bad "F1 customer ainda vê 0 com gate(true)"; fi
+restore_view
+
+echo "── F2: gate SEM service_role → service_role perde acesso → tem de morder ──"
+P -q -c "DROP VIEW public.v_oportunidade_economica_hoje_badge_cached;
+  CREATE VIEW public.v_oportunidade_economica_hoje_badge_cached WITH (security_invoker=false) AS SELECT empresa, oportunidade_count, refreshed_at FROM private.mv_oportunidade_badge WHERE (COALESCE((SELECT public.has_role((SELECT auth.uid()),'master'::app_role)),false) OR COALESCE((SELECT public.has_role((SELECT auth.uid()),'employee'::app_role)),false));
+  GRANT SELECT ON public.v_oportunidade_economica_hoje_badge_cached TO authenticated, service_role;"
+SAB=$(gate_sr)
+if [ "$SAB" = "0" ]; then ok "F2 dente (sem disjunct service_role, service_role perde acesso: vê 0)"; else bad "F2 service_role ainda vê $SAB sem o disjunct"; fi
+restore_view
+
+echo "── F3: função COM gate auth.uid() → falha sob NULL (prova que o anti-bug seria pego) ──"
+P -q -c "CREATE OR REPLACE FUNCTION public.refresh_oportunidade_badge() RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','private' AS \$f\$
+  BEGIN IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(),'employee'::app_role) OR public.has_role(auth.uid(),'master'::app_role)) THEN RAISE EXCEPTION 'Acesso negado' USING ERRCODE='42501'; END IF;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_oportunidade_badge; END \$f\$;"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SELECT public.refresh_oportunidade_badge();" || true)
+case "$R" in *42501*|*"Acesso negado"*) ok "F3 dente (gate auth.uid() mataria o cron: 42501 sob NULL)";; *) bad "F3 não pegou o gate auth.uid(): $R";; esac
+P -q -f "$MIG" >/dev/null  # restaura a função real (sem gate)
+
+echo "── F4: índice não-único → REFRESH CONCURRENTLY falha → tem de morder ──"
+P -q -c "DROP INDEX private.mv_oportunidade_badge_empresa_uq;"
+R=$(P -tA 2>&1 -c "SELECT public.refresh_oportunidade_badge();" || true)
+case "$R" in *concurrent*|*unique*|*"could not"*|*CONCURRENTLY*) ok "F4 dente (CONCURRENTLY exige índice único: falhou sem ele)";; *) bad "F4 CONCURRENTLY não exigiu o índice: $R";; esac
+P -q -c "CREATE UNIQUE INDEX mv_oportunidade_badge_empresa_uq ON private.mv_oportunidade_badge (empresa);"
+
+echo "── F5: a FONTE security_invoker+RLS dá 0 p/ não-staff → refresh DEVE rodar como BYPASSRLS ──"
+SAB=$(Pq -c "SET test.uid='$CUST'; SET ROLE authenticated; SELECT count(*) FROM public.v_oportunidade_economica_hoje;" | tail -1)
+if [ "$SAB" = "0" ]; then ok "F5 não-staff vê 0 na fonte → owner não-bypass cacheria MV vazia (por isso o refresh é bypass + validação mv_status)"; else bad "F5 customer viu $SAB na fonte (RLS não barrou)"; fi
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **304** custom migrations totais
-- **1045** objetos esperados (criados por estas migrations)
+- **305** custom migrations totais
+- **1050** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 305
+  - `function`: 306
   - `rls_policy`: 224
-  - `index`: 188
+  - `index`: 189
   - `table`: 111
-  - `cron_job`: 109
-  - `view`: 52
+  - `cron_job`: 110
+  - `view`: 54
   - `trigger`: 52
   - `enum_value`: 4
 
@@ -2573,6 +2573,16 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_estoque_nao_confirmado_log_empresa_data` | `reposicao_estoque_nao_confirmado_log` |
 | `rls_policy` | `public.estoque_nao_confirmado_log_sel` | `reposicao_estoque_nao_confirmado_log` |
 | `rls_policy` | `public.estoque_nao_confirmado_log_ins` | `reposicao_estoque_nao_confirmado_log` |
+
+### `20260627190000_reposicao_fase2_badge_oportunidade_mv.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.refresh_oportunidade_badge` | — |
+| `view` | `private.mv_oportunidade_badge` | — |
+| `view` | `public.v_oportunidade_economica_hoje_badge_cached` | — |
+| `index` | `private.mv_oportunidade_badge_empresa_uq` | `mv_oportunidade_badge` |
+| `cron_job` | `cron.afiacao_oportunidade_badge_refresh_2h` | — |
 
 ## Próximos passos por status
 

--- a/docs/superpowers/specs/2026-06-27-reposicao-fase2-materializar-badge-design.md
+++ b/docs/superpowers/specs/2026-06-27-reposicao-fase2-materializar-badge-design.md
@@ -1,0 +1,100 @@
+# Reposição Fase 2 — materializar o COUNT do badge de oportunidade (MV em `private` + view-gate) — design
+
+**Data:** 2026-06-27 · **Escopo:** badge de oportunidade econômica (OBEN, money-path + **autorização**) · **Origem:** Fase 2 de `2026-06-27-reposicao-rls-initplan-oportunidade-economica-design.md` — a Fase 1 (RLS→InitPlan) matou o 500, sobrou **880ms estrutural** no `count(*)` do badge. Founder decidiu (2026-06-27) fazer a Fase 2: **cachear só o badge, tela tempo-real, refresh 2h**. Codex (gpt-5.x high) consultado na metodologia.
+
+> **STATUS 2026-06-27:** spec escrita. Decisões do founder: **Opção B** (cachear só o badge; a tela de Oportunidades segue tempo-real) + **refresh 2h**. Codex endureceu o design (count em vez de rowset, schema private, gate hardened, watchdog timestamp).
+
+## 1. Por que (o que sobrou da Fase 1)
+
+A Fase 1 derrubou os buffers de 495.426 → 11.419 e eliminou o 500. Resta **880ms quente** (estrutural: `generate_series` de 180d explode ~537k linhas intermediárias pra devolver **12 linhas**). O badge faz `count(*)` exact dessa view a cada 60s (agora dedupado em 1 request/60s, #1108) → paga 880ms de CPU por poll. **Não é erro, é latência** — Fase 2 ataca isso só no caminho do badge.
+
+**Quem consome a view (verificado read-only):**
+- **Badge** (`useOportunidadesAtivasCount`, [useReposicaoSessao.ts](../../../src/hooks/useReposicaoSessao.ts)) — lê a view DIRETO. ← alvo da Fase 2.
+- **Tela de Oportunidades** ([AdminReposicaoOportunidades.tsx](../../../src/pages/AdminReposicaoOportunidades.tsx)) via `v_otimizador_compras_insumos` (que depende da view) — **fica tempo-real** (decisão de compra; staleness é ruim).
+
+## 2. Design (Opção B, endurecido pós-Codex)
+
+Materializar **só o COUNT por empresa** (não as 25 colunas sensíveis — superfície de vazamento mínima), em schema **`private`** (não exposto ao PostgREST), atrás de uma **view-gate** em `public`.
+
+| Objeto | Definição |
+|---|---|
+| `private.mv_oportunidade_badge` (MV) | `SELECT empresa, count(*)::int AS oportunidade_count, now() AS refreshed_at, CURRENT_DATE AS calculado_em FROM public.v_oportunidade_economica_hoje GROUP BY empresa` · `WITH DATA` · **UNIQUE INDEX (empresa)** (provado único) · `REVOKE ALL FROM PUBLIC, anon, authenticated` |
+| `public.v_oportunidade_economica_hoje_badge_cached` (view-gate) | `WITH (security_invoker=off, security_barrier=true)` · `SELECT empresa, oportunidade_count, refreshed_at FROM private.mv_oportunidade_badge WHERE (gate)` · `GRANT SELECT TO authenticated` |
+| `public.refresh_oportunidade_badge()` | `SECURITY DEFINER`, `search_path public,private` · advisory-lock + `REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_oportunidade_badge` · **sem gate `auth.uid()` interno** · `REVOKE EXECUTE FROM anon,authenticated,PUBLIC` + `GRANT service_role` |
+| cron | `cron.schedule('afiacao_oportunidade_badge_refresh_2h','20 */2 * * *','SELECT public.refresh_oportunidade_badge()')` |
+| frontend | `useOportunidadesAtivasCount` lê a `_badge_cached` (count pré-computado), degradação honesta preservada |
+| watchdog | alerta se `now() - max(refreshed_at) > interval '150 min'` (cron travado = número stale silencioso) |
+
+O padrão **MV em `private` + view-gate em `public` + função de refresh** já existe no repo (`private.mv_sku_ranking_negociacao_paralela`).
+
+## 3. Gate de acesso (o ponto crítico — MV não tem RLS)
+
+O **gate** (null-hardened, InitPlan) replica EXATAMENTE a semântica da RLS original (todas as 15 bases eram "staff vê tudo"; `service_role` bypassa):
+
+```sql
+WHERE (
+      (SELECT auth.role()) = 'service_role'
+   OR COALESCE((SELECT public.has_role((SELECT auth.uid()), 'master'::app_role)),   false)
+   OR COALESCE((SELECT public.has_role((SELECT auth.uid()), 'employee'::app_role)), false)
+)
+```
+
+- **não-staff / anon** (`auth.uid()` NULL) → `has_role(NULL)=false`, `auth.role()≠'service_role'` → **0 linhas**.
+- **staff** (master/employee) / **service_role** → todas as linhas.
+- `security_invoker=off` → a view lê a MV como **owner** (a MV é `REVOKE`ada de `authenticated`, então o caller NÃO lê a MV crua — só via a view-gate). `security_barrier=true` impede vazamento por ordem de avaliação de predicado (não dependemos do PostgREST como modelo de segurança — Codex).
+- **Defense-in-depth:** MV em `private` (PostgREST não expõe) **+** `REVOKE ALL FROM PUBLIC` **+** grant só do que precisa.
+
+## 4. Refresh (sem matar o cron; sem bloquear o badge)
+
+- **Sem gate `auth.uid()` interno** na função — lição `reposicao.md`: o cron roda como `postgres` (sem JWT), um gate `auth.uid() IS NULL → RAISE` mataria o cron silenciosamente. (É o bug que pegamos AGORA no `refresh_sku_ranking_negociacao` — cron morto desde 2026-06-22, registrado em tarefa separada.) Proteção = `REVOKE EXECUTE` de anon/authenticated + `GRANT service_role`; o `postgres` do cron passa por cima dos grants.
+- **`CONCURRENTLY`** (não bloqueia o badge; readers veem a versão antiga até o swap) — exige o índice único. MV criada `WITH DATA` (nasce populada → o 1º `CONCURRENTLY` funciona).
+- **Advisory lock** (`pg_try_advisory_lock`): runs sobrepostas dão skip em vez de enfileirar.
+- **Sem fallback non-concurrent cego** (Codex): bloquearia o badge. Se o `CONCURRENTLY` falhar (ex.: índice violado), **mantém o estado antigo** (stale-served) e o **watchdog** alerta — recovery manual, não mascarar.
+
+## 5. Frescor / watchdog
+
+- **Timestamp-based**, não `CURRENT_DATE` (Codex): `now() - max(refreshed_at) > 150min` pega cron travado no MESMO dia (o `MAX(calculado_em) < CURRENT_DATE` só pegaria a virada). Plugar no `_data_health_compute`/Sentinela (sync.md).
+- **TZ:** o banco é **UTC**; `CURRENT_DATE`/`calculado_em` viram o dia às 21h BR — já é o comportamento da view atual (não muda). O refresh 2h cobre a virada UTC.
+
+## 6. Frontend
+
+`useOportunidadesAtivasCount` passa a ler a view-gate (count pré-computado), **preservando a degradação honesta** (#1108): erro → `null`, sem-linha → `0`, com-linha → count. Distinção: `if (error) return null; return data?.oportunidade_count ?? 0` (sem-linha = empresa sem oportunidade = 0 legítimo; erro = indisponível = null/"—").
+
+```ts
+const { data, error } = await supabase
+  .from("v_oportunidade_economica_hoje_badge_cached")
+  .select("oportunidade_count").eq("empresa", REPOSICAO_EMPRESA).maybeSingle();
+if (error) return null;            // indeterminado (≠ 0)
+return data?.oportunidade_count ?? 0;  // sem linha = 0 oportunidades
+```
+
+## 7. Prova (PG17, `prove-sql-money-path`)
+
+A migração REAL, com asserts positivos/negativos + falsificação:
+1. **Gate / autz:** staff (master/employee) vê N; customer/sem-role/**anon (uid NULL)** vê **0**; `service_role` vê N. Equivalência com a semântica da view original.
+2. **Vazamento:** `authenticated` **não** lê `private.mv_oportunidade_badge` direto (REVOKE) — só via a view-gate. (Provar `permission denied` no acesso cru.)
+3. **Paridade:** `oportunidade_count` da MV == `count(*)` da view original por empresa.
+4. **Cron-context (o anti-bug):** a função `refresh_oportunidade_badge()` roda com `auth.uid()=NULL` (stubar NULL, **não** 'service_role' — senão mascara) e **refresca** (não dá 42501).
+5. **REFRESH CONCURRENTLY** funciona com o índice único; advisory lock serializa.
+6. **Falsificação:** (a) gate `USING(true)` → não-staff vaza → assert morde; (b) gate sem `service_role` → service_role/cron perde acesso → morde; (c) função COM gate `auth.uid()` → falha sob NULL (prova que o anti-bug seria pego); (d) índice não-único → `CONCURRENTLY` falha.
+
+## 8. Handoff
+
+Via `lovable-db-operator`: migration custom (MV + índice + view-gate + função + cron + grants) + bloco SQL Editor + validação pós-apply (MV existe + populada, view-gate retorna sob staff, cron agendado) + audit. **Frontend** = PR-irmão (muda 1 hook). Pós-apply: forçar 1 refresh + conferir via psql-ro.
+
+## 9. Codex — challenge da metodologia (2026-06-27, high)
+
+Convergente. Acatado: (1) **count-por-empresa em vez do rowset de 25 colunas** (superfície de vazamento mínima); (2) schema `private` + `REVOKE ALL FROM PUBLIC` + grants explícitos; (3) gate null-hardened + `security_barrier`; (4) watchdog **timestamp-based** (não `CURRENT_DATE`); (5) advisory lock + sem fallback bloqueante. Pendente p/ adversarial do código: provar o gate não vaza + cron-context.
+
+## 10. Não-objetivos / achados laterais
+
+- **Não** materializar a tela de Oportunidades (fica tempo-real — decisão de compra).
+- **Não** recriar `v_oportunidade_economica_hoje` nem tocar `v_otimizador_compras_insumos`.
+- **Achado lateral (tarefa separada):** `refresh_sku_ranking_negociacao` tem o gate `auth.uid()` que matou o cron `afiacao_ranking_refresh_semanal` desde 2026-06-22 (MV de ranking stale). Registrado.
+
+## 11. Riscos
+
+- **Vazamento** (MV sem RLS) — mitigado por private + REVOKE ALL + view-gate + security_barrier; **provado** no §7.2.
+- **Cron morto silencioso** — mitigado por watchdog timestamp (§5) + sem gate `auth.uid()` (§4).
+- **Stale do badge** (até 2h) — aceito (badge é navegacional; a tela decisória é tempo-real).
+- **Drift de colunas da view** — a MV é `SELECT count(*)` (não depende das 25 colunas), imune.

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 304
+-- Total de custom migrations: 305
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -345,7 +345,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260627150000', 'tint_formulas_rls_initplan', '20260627150000_tint_formulas_rls_initplan.sql'),
   ('20260627150100', 'tint_formulas_autovacuum_agressivo', '20260627150100_tint_formulas_autovacuum_agressivo.sql'),
   ('20260627170000', 'reposicao_rls_initplan', '20260627170000_reposicao_rls_initplan.sql'),
-  ('20260627180000', 'reposicao_gate_estoque_nao_confirmado', '20260627180000_reposicao_gate_estoque_nao_confirmado.sql')
+  ('20260627180000', 'reposicao_gate_estoque_nao_confirmado', '20260627180000_reposicao_gate_estoque_nao_confirmado.sql'),
+  ('20260627190000', 'reposicao_fase2_badge_oportunidade_mv', '20260627190000_reposicao_fase2_badge_oportunidade_mv.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1379,7 +1380,12 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('reposicao_gate_estoque_nao_confirmado', 'table', 'public', 'reposicao_estoque_nao_confirmado_log', ''),
   ('reposicao_gate_estoque_nao_confirmado', 'index', 'public', 'idx_estoque_nao_confirmado_log_empresa_data', 'reposicao_estoque_nao_confirmado_log'),
   ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_sel', 'reposicao_estoque_nao_confirmado_log'),
-  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log')
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log'),
+  ('reposicao_fase2_badge_oportunidade_mv', 'function', 'public', 'refresh_oportunidade_badge', ''),
+  ('reposicao_fase2_badge_oportunidade_mv', 'view', 'private', 'mv_oportunidade_badge', ''),
+  ('reposicao_fase2_badge_oportunidade_mv', 'view', 'public', 'v_oportunidade_economica_hoje_badge_cached', ''),
+  ('reposicao_fase2_badge_oportunidade_mv', 'index', 'private', 'mv_oportunidade_badge_empresa_uq', 'mv_oportunidade_badge'),
+  ('reposicao_fase2_badge_oportunidade_mv', 'cron_job', 'cron', 'afiacao_oportunidade_badge_refresh_2h', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2461,7 +2467,12 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_gate_estoque_nao_confirmado', 'table', 'public', 'reposicao_estoque_nao_confirmado_log', ''),
   ('reposicao_gate_estoque_nao_confirmado', 'index', 'public', 'idx_estoque_nao_confirmado_log_empresa_data', 'reposicao_estoque_nao_confirmado_log'),
   ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_sel', 'reposicao_estoque_nao_confirmado_log'),
-  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log')
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log'),
+  ('reposicao_fase2_badge_oportunidade_mv', 'function', 'public', 'refresh_oportunidade_badge', ''),
+  ('reposicao_fase2_badge_oportunidade_mv', 'view', 'private', 'mv_oportunidade_badge', ''),
+  ('reposicao_fase2_badge_oportunidade_mv', 'view', 'public', 'v_oportunidade_economica_hoje_badge_cached', ''),
+  ('reposicao_fase2_badge_oportunidade_mv', 'index', 'private', 'mv_oportunidade_badge_empresa_uq', 'mv_oportunidade_badge'),
+  ('reposicao_fase2_badge_oportunidade_mv', 'cron_job', 'cron', 'afiacao_oportunidade_badge_refresh_2h', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260627190000_reposicao_fase2_badge_oportunidade_mv.sql
+++ b/supabase/migrations/20260627190000_reposicao_fase2_badge_oportunidade_mv.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- REPOSIÇÃO FASE 2 — materializa o COUNT do badge de oportunidade econômica.
+-- ⚠️ APLICAÇÃO MANUAL: colar no SQL Editor do Lovable.
+--
+-- A Fase 1 (RLS→InitPlan, 20260627170000) matou o 500; sobrou 880ms estrutural
+-- (generate_series 180d → 537k linhas p/ devolver 12) que o badge paga no
+-- count(*) a cada 60s. Fase 2: cachear SÓ o count do badge; a tela de
+-- Oportunidades segue tempo-real (decisão de compra).
+--
+-- Desenho (endurecido pós-Codex): materializa só count-por-empresa (não as 25
+-- colunas sensíveis), em schema `private` (não exposto ao PostgREST), atrás de
+-- uma view-gate em `public` (security_invoker=off + security_barrier + gate
+-- null-hardened que replica a RLS "staff vê tudo / service_role bypassa").
+-- Refresh SEM gate auth.uid() interno (senão mata o cron, igual ao bug do
+-- refresh_sku_ranking) — protegido por REVOKE/GRANT. Provado: db/test-reposicao-fase2-badge-mv.sh.
+-- Spec: docs/superpowers/specs/2026-06-27-reposicao-fase2-materializar-badge-design.md
+-- =============================================================================
+
+-- A view-gate depende da MV → dropar a view ANTES da MV (idempotência: re-colar no SQL Editor
+-- é esperado no Lovable; sem isto o DROP MATERIALIZED VIEW falha com "view depends on it").
+DROP VIEW IF EXISTS public.v_oportunidade_economica_hoje_badge_cached;
+
+-- 1) MV em private: count por empresa (superfície de vazamento = 1 inteiro, não 25 colunas)
+DROP MATERIALIZED VIEW IF EXISTS private.mv_oportunidade_badge;
+CREATE MATERIALIZED VIEW private.mv_oportunidade_badge AS
+  SELECT empresa,
+         count(*)::int AS oportunidade_count,
+         now()        AS refreshed_at,
+         CURRENT_DATE AS calculado_em
+  FROM public.v_oportunidade_economica_hoje
+  GROUP BY empresa;
+
+-- índice único (empresa) — provado único; exigido pelo REFRESH CONCURRENTLY
+CREATE UNIQUE INDEX IF NOT EXISTS mv_oportunidade_badge_empresa_uq
+  ON private.mv_oportunidade_badge (empresa);
+
+-- a MV crua NÃO é exposta a ninguém além do owner (defense-in-depth além do schema private)
+REVOKE ALL ON private.mv_oportunidade_badge FROM PUBLIC;
+REVOKE ALL ON private.mv_oportunidade_badge FROM anon, authenticated;
+
+-- 2) view-gate em public: replica a semântica da RLS original (staff vê / service_role bypassa)
+CREATE VIEW public.v_oportunidade_economica_hoje_badge_cached
+  WITH (security_invoker = false, security_barrier = true) AS
+  SELECT empresa, oportunidade_count, refreshed_at
+  FROM private.mv_oportunidade_badge
+  WHERE (
+        (SELECT auth.role()) = 'service_role'
+     OR COALESCE((SELECT public.has_role((SELECT auth.uid()), 'master'::app_role)),   false)
+     OR COALESCE((SELECT public.has_role((SELECT auth.uid()), 'employee'::app_role)), false)
+  );
+GRANT SELECT ON public.v_oportunidade_economica_hoje_badge_cached TO authenticated, service_role;
+
+-- 3) função de refresh: SEM gate auth.uid() interno (mataria o cron — postgres não tem JWT);
+--    proteção via REVOKE/GRANT. Advisory lock evita pile-up; CONCURRENTLY não bloqueia o badge.
+CREATE OR REPLACE FUNCTION public.refresh_oportunidade_badge()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'private'
+AS $function$
+BEGIN
+  -- Advisory lock de TRANSAÇÃO (auto-libera no commit/rollback — NÃO vaza em
+  -- cancelamento/statement_timeout, ≠ lock de sessão; achado Codex xhigh). Sem
+  -- fallback non-concurrent cego: stale-served > travar o badge; erro propaga +
+  -- watchdog alerta.
+  IF NOT pg_try_advisory_xact_lock(hashtext('refresh_oportunidade_badge')) THEN
+    RAISE NOTICE 'refresh_oportunidade_badge: refresh já em curso, pulando';
+    RETURN;
+  END IF;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_oportunidade_badge;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.refresh_oportunidade_badge() FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.refresh_oportunidade_badge() TO service_role;
+
+-- 4) cron a cada 2h (escalonado aos :20). Idempotente.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'afiacao_oportunidade_badge_refresh_2h') THEN
+    PERFORM cron.unschedule('afiacao_oportunidade_badge_refresh_2h');
+  END IF;
+END $$;
+SELECT cron.schedule('afiacao_oportunidade_badge_refresh_2h', '20 */2 * * *',
+                     'SELECT public.refresh_oportunidade_badge()');
+
+-- Validação pós-apply. ⚠️ mv_status DEVE vir ✅: se a MV nascer VAZIA, o owner que
+-- aplicou/refresca NÃO tem BYPASSRLS (a fonte é security_invoker + RLS; sob auth.uid()=NULL
+-- um role não-bypass vê 0 linhas) — não confiar no badge até investigar o owner.
+SELECT
+  CASE WHEN (SELECT count(*) FROM private.mv_oportunidade_badge) > 0
+       THEN '✅ MV populada (' || (SELECT count(*) FROM private.mv_oportunidade_badge)::text || ' empresa(s))'
+       ELSE '❌ MV VAZIA — owner do refresh sem BYPASSRLS? RLS barrou a leitura da fonte. NÃO confiar no badge.'
+  END AS mv_status,
+  (SELECT count(*) FROM pg_matviews WHERE schemaname='private' AND matviewname='mv_oportunidade_badge') AS mv_existe_1,
+  (SELECT count(*) FROM pg_views WHERE schemaname='public' AND viewname='v_oportunidade_economica_hoje_badge_cached') AS view_existe_1,
+  (SELECT count(*) FROM cron.job WHERE jobname='afiacao_oportunidade_badge_refresh_2h')     AS cron_agendado_1;


### PR DESCRIPTION
## O quê / por quê (Fase 2 da reposição — segue #1106 RLS InitPlan)

A Fase 1 matou o 500; sobraram **880ms estruturais** (o `generate_series` de 180d explode ~537k linhas pra devolver 12) que o badge paga no `count(*)`. Fase 2 cacheia **só o count do badge**; a tela de Oportunidades segue **tempo-real** (decisão de compra).

**Desenho (endurecido pelo Codex xhigh):** materializa só `count` por empresa (não as 25 colunas sensíveis), em schema **`private`** (fora do PostgREST), atrás de uma **view-gate** em `public` (`security_invoker=off` + `security_barrier` + gate `has_role` null-hardened que replica a RLS "staff vê / service_role bypassa"). Refresh **sem gate `auth.uid()` interno** (REVOKE/GRANT — pra não morrer como o cron do ranking), advisory **xact-lock**, `REFRESH CONCURRENTLY`. Spec: `docs/superpowers/specs/2026-06-27-reposicao-fase2-materializar-badge-design.md`.

## Prova (PG17 — `db/test-reposicao-fase2-badge-mv.sh`, 18 asserts / 0 fail)

- Gate replica a RLS: staff/service_role veem; **customer/sem-role/anon/NULL-uid veem 0**.
- **Anti-vazamento:** `authenticated` não lê a MV crua mesmo com USAGE no schema (prova o REVOKE da MV).
- Paridade do count · cron-context (refresh sob `auth.uid()=NULL` **não** dá 42501) · grants do refresh · `REFRESH CONCURRENTLY` · 5 falsificações com dente.
- Fonte **fiel** (view `security_invoker` + RLS) prova a dependência: o refresh **precisa** rodar como `BYPASSRLS` (senão MV vazia). Pegou um **bug real de idempotência** (DROP MV bloqueado pela view-gate).

## ⚠️ Migration MANUAL

Copie [`supabase/migrations/20260627190000_reposicao_fase2_badge_oportunidade_mv.sql`](https://github.com/LucasSardenbergL/afiacao/blob/claude/reposicao-fase2-materializar-badge/supabase/migrations/20260627190000_reposicao_fase2_badge_oportunidade_mv.sql) → SQL Editor → Run. A própria migration termina com uma validação: **`mv_status` deve vir ✅** (se vier ❌ "MV VAZIA", o owner que aplicou não tem BYPASSRLS — me avise, não confie no badge). Esperado: `mv_existe_1=1`, `view_existe_1=1`, `cron_agendado_1=1`.

## Frontend (PÓS-APPLY — só depois do apply + regen do `types.ts` pelo Lovable)

Trocar o hook `useOportunidadesAtivasCount` ([useReposicaoSessao.ts](src/hooks/useReposicaoSessao.ts)) pra ler o count materializado:

```ts
export function useOportunidadesAtivasCount(options?: { enabled?: boolean }) {
  return useQuery<number | null>({
    queryKey: ["oportunidades-ativas-count", REPOSICAO_EMPRESA],
    queryFn: async () => {
      // Fase 2: count materializado (MV em private, refresh 2h) via view-gate — em vez do
      // count(*) caro (880ms) da view tempo-real. Degradação honesta preservada.
      const { data, error } = await supabase
        .from("v_oportunidade_economica_hoje_badge_cached")
        .select("oportunidade_count")
        .eq("empresa", REPOSICAO_EMPRESA)
        .maybeSingle();
      if (error) return null;                // indeterminado (≠ 0)
      return data?.oportunidade_count ?? 0;  // sem linha = empresa sem oportunidade = 0
    },
    enabled: options?.enabled ?? true,
    staleTime: 30_000, refetchInterval: 60_000, refetchIntervalInBackground: false, retry: 1,
  });
}
```

## Pós-apply (reconciliação)

`INSERT` no `schema_migrations` (`'20260627190000'`) + re-dump do snapshot (chat do Lovable) + forçar 1 refresh (`SELECT public.refresh_oportunidade_badge();` como service_role) e conferir o badge. **DRAFT** até você aplicar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
