### PR TITLE
fix(reposicao): remove gate auth.uid de refresh_sku_ranking_negociacao (ressuscita o cron de ranking morto desde 22/06) [money-path]

### DIFF
--- a/db/test-refresh-ranking-gate-cron.sh
+++ b/db/test-refresh-ranking-gate-cron.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA: migration 20260627200000_fix_refresh_sku_ranking_gate_cron.sql         ║
+# ║  Remove o gate auth.uid() que matava o cron. Prova:                            ║
+# ║  (A1) cron-context (auth.uid()=NULL) refresca — NÃO dá 42501;                  ║
+# ║  (A2) authenticated NÃO executa (REVOKE); (A3) service_role executa (GRANT).   ║
+# ║  Falsifica (F1): a versão COM o gate falha sob NULL (= o bug que consertamos). ║
+# ║  Rodar:  bash db/test-refresh-ranking-gate-cron.sh > /tmp/t.log 2>&1; echo $?  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5481}"
+SLUG="rank-gate"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -X -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+
+echo "═══ setup (PG17 :$PORT) ═══"
+# ZONA 1 — pré-requisitos: app_role/has_role, schema private, MV stub (o alvo do refresh)
+P -q <<'SQL'
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='app_role') THEN
+  CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); END IF; END $$;
+CREATE TABLE public.user_roles (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id=_user_id AND role=_role) $f$;
+GRANT EXECUTE ON FUNCTION public.has_role(uuid, app_role) TO authenticated, anon;
+CREATE SCHEMA IF NOT EXISTS private;
+-- MV alvo (stub) + índice único (exigido pelo REFRESH CONCURRENTLY)
+CREATE MATERIALIZED VIEW private.mv_sku_ranking_negociacao_paralela AS SELECT g AS sku_id FROM generate_series(1,5) g;
+CREATE UNIQUE INDEX mv_rank_sku_uq ON private.mv_sku_ranking_negociacao_paralela (sku_id);
+SQL
+
+# ZONA 2 — aplicar a migration REAL
+MIG="$REPO_ROOT/supabase/migrations/20260627200000_fix_refresh_sku_ranking_gate_cron.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+# ZONA 3 — asserts
+echo "── A1 CRON-CONTEXT: auth.uid()=NULL refresca (NÃO dá 42501) ──"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SET test.role=''; SELECT skus_ranqueados FROM public.refresh_sku_ranking_negociacao();" || true)
+case "$R" in *42501*|*"Acesso negado"*) bad "A1 cron AINDA morre sob NULL: $R";; *5*) ok "A1 refresca sob auth.uid()=NULL (cron recuperado; retornou skus=$R)";; *) bad "A1 retorno inesperado: $R";; esac
+
+echo "── A2 authenticated NÃO executa o refresh (REVOKE) ──"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SET ROLE authenticated; SELECT public.refresh_sku_ranking_negociacao();" || true)
+case "$R" in *denied*|*permission*) ok "A2 authenticated barrado (REVOKE EXECUTE)";; *) bad "A2 authenticated executou? $R";; esac
+
+echo "── A3 service_role executa (GRANT) ──"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SET ROLE service_role; SELECT public.refresh_sku_ranking_negociacao();" || true)
+case "$R" in *denied*|*permission*) bad "A3 service_role barrado (grant faltando): $R";; *) ok "A3 service_role executa (GRANT EXECUTE)";; esac
+
+# ZONA 4 — falsificação
+echo "── F1: a versão COM o gate auth.uid() falha sob NULL (= o bug que consertamos) ──"
+P -q -c "CREATE OR REPLACE FUNCTION public.refresh_sku_ranking_negociacao() RETURNS TABLE(skus_ranqueados integer, atualizado_em timestamptz) LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','private' AS \$f\$
+  BEGIN IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(),'employee'::app_role) OR public.has_role(auth.uid(),'master'::app_role)) THEN RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE='42501'; END IF;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_sku_ranking_negociacao_paralela; RETURN QUERY SELECT COUNT(*)::int, now() FROM private.mv_sku_ranking_negociacao_paralela; END \$f\$;"
+R=$(P -tA 2>&1 -c "SET test.uid=''; SELECT public.refresh_sku_ranking_negociacao();" || true)
+case "$R" in *42501*|*"Acesso negado"*) ok "F1 dente (gate auth.uid() reproduz o cron morto: 42501 sob NULL)";; *) bad "F1 não reproduziu o bug: $R";; esac
+P -q -f "$MIG" >/dev/null  # restaura a versão real (sem gate)
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **304** custom migrations totais
-- **1045** objetos esperados (criados por estas migrations)
+- **305** custom migrations totais
+- **1046** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 305
+  - `function`: 306
   - `rls_policy`: 224
   - `index`: 188
   - `table`: 111
@@ -2573,6 +2573,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_estoque_nao_confirmado_log_empresa_data` | `reposicao_estoque_nao_confirmado_log` |
 | `rls_policy` | `public.estoque_nao_confirmado_log_sel` | `reposicao_estoque_nao_confirmado_log` |
 | `rls_policy` | `public.estoque_nao_confirmado_log_ins` | `reposicao_estoque_nao_confirmado_log` |
+
+### `20260627200000_fix_refresh_sku_ranking_gate_cron.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.refresh_sku_ranking_negociacao` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 304
+-- Total de custom migrations: 305
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -345,7 +345,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260627150000', 'tint_formulas_rls_initplan', '20260627150000_tint_formulas_rls_initplan.sql'),
   ('20260627150100', 'tint_formulas_autovacuum_agressivo', '20260627150100_tint_formulas_autovacuum_agressivo.sql'),
   ('20260627170000', 'reposicao_rls_initplan', '20260627170000_reposicao_rls_initplan.sql'),
-  ('20260627180000', 'reposicao_gate_estoque_nao_confirmado', '20260627180000_reposicao_gate_estoque_nao_confirmado.sql')
+  ('20260627180000', 'reposicao_gate_estoque_nao_confirmado', '20260627180000_reposicao_gate_estoque_nao_confirmado.sql'),
+  ('20260627200000', 'fix_refresh_sku_ranking_gate_cron', '20260627200000_fix_refresh_sku_ranking_gate_cron.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1379,7 +1380,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('reposicao_gate_estoque_nao_confirmado', 'table', 'public', 'reposicao_estoque_nao_confirmado_log', ''),
   ('reposicao_gate_estoque_nao_confirmado', 'index', 'public', 'idx_estoque_nao_confirmado_log_empresa_data', 'reposicao_estoque_nao_confirmado_log'),
   ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_sel', 'reposicao_estoque_nao_confirmado_log'),
-  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log')
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log'),
+  ('fix_refresh_sku_ranking_gate_cron', 'function', 'public', 'refresh_sku_ranking_negociacao', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2461,7 +2463,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_gate_estoque_nao_confirmado', 'table', 'public', 'reposicao_estoque_nao_confirmado_log', ''),
   ('reposicao_gate_estoque_nao_confirmado', 'index', 'public', 'idx_estoque_nao_confirmado_log_empresa_data', 'reposicao_estoque_nao_confirmado_log'),
   ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_sel', 'reposicao_estoque_nao_confirmado_log'),
-  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log')
+  ('reposicao_gate_estoque_nao_confirmado', 'rls_policy', 'public', 'estoque_nao_confirmado_log_ins', 'reposicao_estoque_nao_confirmado_log'),
+  ('fix_refresh_sku_ranking_gate_cron', 'function', 'public', 'refresh_sku_ranking_negociacao', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260627200000_fix_refresh_sku_ranking_gate_cron.sql
+++ b/supabase/migrations/20260627200000_fix_refresh_sku_ranking_gate_cron.sql
@@ -1,0 +1,44 @@
+-- =============================================================================
+-- FIX: refresh_sku_ranking_negociacao() — remove o gate auth.uid() que MATAVA o cron.
+-- ⚠️ APLICAÇÃO MANUAL: colar no SQL Editor do Lovable.
+--
+-- Bug (achado 2026-06-27 via psql-ro): o cron `afiacao_ranking_refresh_semanal` está
+-- FALHANDO desde 2026-06-22 com "Acesso negado: requer perfil staff" (42501). A função
+-- (SECURITY DEFINER) tinha um gate `IF auth.uid() IS NULL OR NOT has_role(...) RAISE 42501`;
+-- o pg_cron roda como `postgres` SEM JWT → auth.uid()=NULL → 42501 → cron morto SILENCIOSO.
+-- A MV private.mv_sku_ranking_negociacao_paralela (alimenta v_sugestao_negociacao_ativa,
+-- badge de sugestões de negociação) ficou stale ~5 dias.
+--
+-- Fix (lição docs/agent/reposicao.md "gate auth.uid/auth.role MATA cron SQL-local"):
+-- remover o gate runtime; proteger por REVOKE/GRANT (o `postgres` do cron passa por cima
+-- dos grants; um authenticated não-staff não chama via PostgREST porque o EXECUTE é revogado).
+-- Só o cron chama (verificado: zero consumidor de código). Corpo = pré-flight de prod, sem o IF.
+-- Provado em PG17: db/test-refresh-ranking-gate-cron.sh
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.refresh_sku_ranking_negociacao()
+ RETURNS TABLE(skus_ranqueados integer, atualizado_em timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'private'
+AS $function$
+BEGIN
+  -- SEM gate auth.uid() interno: matava o cron (postgres sem JWT → 42501). A proteção é
+  -- o REVOKE/GRANT abaixo (NÃO um gate runtime). Lição reposicao.md.
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.mv_sku_ranking_negociacao_paralela;
+  RETURN QUERY SELECT COUNT(*)::int, now() FROM private.mv_sku_ranking_negociacao_paralela;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.refresh_sku_ranking_negociacao() FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.refresh_sku_ranking_negociacao() TO service_role;
+
+-- Validação pós-apply: gate removido + grants corretos. Esperado: ✅ / f / t.
+SELECT
+  CASE WHEN pg_get_functiondef('public.refresh_sku_ranking_negociacao'::regproc) ILIKE '%Acesso negado%'
+       THEN '❌ ainda tem o gate auth.uid()' ELSE '✅ gate removido (cron volta a refrescar)' END AS gate_status,
+  has_function_privilege('authenticated', 'public.refresh_sku_ranking_negociacao()', 'EXECUTE') AS authenticated_exec_esperado_f,
+  has_function_privilege('service_role',  'public.refresh_sku_ranking_negociacao()', 'EXECUTE') AS service_role_exec_esperado_t;
+
+-- ⚠️ Depois de aplicar, FORCE 1 refresh p/ recuperar a MV stale (rodar como service_role/no SQL Editor):
+--   SELECT public.refresh_sku_ranking_negociacao();


### PR DESCRIPTION
## O quê / por quê

O cron `afiacao_ranking_refresh_semanal` está **morto desde 2026-06-22** (confirmado via `psql-ro` em `cron.job_run_details`): falha com `Acesso negado: requer perfil staff` (42501). A função `refresh_sku_ranking_negociacao()` (SECURITY DEFINER) tinha um gate `IF auth.uid() IS NULL OR NOT has_role(...) RAISE 42501`; o **pg_cron roda como `postgres` sem JWT** → `auth.uid()=NULL` → 42501 → cron morto **silencioso**. A MV `private.mv_sku_ranking_negociacao_paralela` (alimenta `v_sugestao_negociacao_ativa`, o badge de sugestões de negociação) ficou **stale ~5 dias**.

**Fix** (lição `reposicao.md`: *gate auth.uid/auth.role mata cron SQL-local*): remove o gate runtime; protege por `REVOKE EXECUTE` de anon/authenticated + `GRANT service_role` (o `postgres` do cron passa por cima dos grants). **Só o cron chama** (zero consumidor de código, verificado). Corpo = pré-flight de prod, sem o `IF`.

## Prova (PG17 — `db/test-refresh-ranking-gate-cron.sh`, 4/4)

- **A1** cron-context: refresca sob `auth.uid()=NULL` (não dá 42501) — o cron recupera.
- **A2** `authenticated` barrado (REVOKE) · **A3** `service_role` executa (GRANT).
- **F1** falsificação: a versão **com** o gate reproduz o 42501 sob NULL (= o bug).

## ⚠️ Migration MANUAL + recuperar a MV stale

1. Copie [`supabase/migrations/20260627200000_fix_refresh_sku_ranking_gate_cron.sql`](https://github.com/LucasSardenbergL/afiacao/blob/claude/fix-cron-ranking-refresh-gate/supabase/migrations/20260627200000_fix_refresh_sku_ranking_gate_cron.sql) → SQL Editor → Run. Validação embutida: `gate_status` deve vir ✅, `authenticated_exec` = `f`, `service_role_exec` = `t`.
2. **Force 1 refresh** pra recuperar a MV (rode no SQL Editor):
   ```sql
   SELECT public.refresh_sku_ranking_negociacao();
   ```
   Depois eu confiro via `psql-ro` que `cron.job_run_details` volta a `succeeded` e a MV fica fresca.

## Achado relacionado (NÃO tocado neste PR)

`refresh_customer_metrics` tem o **mesmo** gate `auth.uid()`, mas é chamada por staff via frontend (`useAnalyticsSync`) — ali o gate é **apropriado** (não é cron). Vale verificar separado se o edge `ai-ops-agent` a chama com `service_role` (aí falharia 42501). Fora do escopo deste fix.

**DRAFT** até você aplicar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
