### PR TITLE
feat(reposicao): badge lê o count materializado da Fase 2 (MV via view-gate) [money-path]

### DIFF
--- a/src/hooks/useReposicaoSessao.ts
+++ b/src/hooks/useReposicaoSessao.ts
@@ -111,12 +111,16 @@ export function useOportunidadesAtivasCount(options?: { enabled?: boolean }) {
   return useQuery<number | null>({
     queryKey: ["oportunidades-ativas-count", REPOSICAO_EMPRESA],
     queryFn: async () => {
-      const { count, error } = await supabase
-        .from("v_oportunidade_economica_hoje")
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", REPOSICAO_EMPRESA);
-      if (error) return null; // degrada honesto: indeterminado, não 0, não throw
-      return count ?? null;
+      // Fase 2: lê o count materializado (MV em private, refresh por cron 2h) através da
+      // view-gate, em vez do count(*) caro (880ms estrutural) da view tempo-real. A tela de
+      // Oportunidades segue tempo-real. Degradação honesta preservada (erro → null, ≠ 0).
+      const { data, error } = await supabase
+        .from("v_oportunidade_economica_hoje_badge_cached")
+        .select("oportunidade_count")
+        .eq("empresa", REPOSICAO_EMPRESA)
+        .maybeSingle();
+      if (error) return null; // indeterminado (≠ 0)
+      return data?.oportunidade_count ?? 0; // sem linha = empresa sem oportunidade = 0 legítimo
     },
     enabled: options?.enabled ?? true,
     staleTime: 30_000,


### PR DESCRIPTION
Frontend da Fase 2 — fecha o ciclo do badge. O hook `useOportunidadesAtivasCount` troca o `count(*)` caro (880ms da view tempo-real) pela leitura do count pré-computado na view-gate `v_oportunidade_economica_hoje_badge_cached` (MV em `private`, refresh cron 2h). Degradação honesta preservada (erro → null; sem-linha → 0). A tela de Oportunidades segue tempo-real.

**A migration (#1115) já está aplicada em prod** (confirmado via psql-ro: MV populada OBEN=12, anti-vazamento ok, gate ok). A view-gate já está no `types.ts` (regen do Lovable). typecheck + lint + testes verdes. Vai a produção no próximo Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)