### PR TITLE
fix(reposicao/pedidos): valor_linha NULL em edição só-de-quantidade de item sem custo

### DIFF
--- a/src/components/reposicao/pedidos/__tests__/preco-edit.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/preco-edit.test.ts
@@ -74,3 +74,34 @@ describe('preco-edit — montarUpdateItem (money-path: não reescrever preço v�
     expect(u.preco_unitario).toBe(25.35);
   });
 });
+
+describe('preco-edit — montarUpdateItem (money-path: custo ausente ≠ zero)', () => {
+  // Invariante: valor_linha NULL = custo desconhecido. Numa edição só-de-quantidade
+  // de item de primeira compra (preço null/0), NÃO fabricar valor_linha = qtd*0 = 0
+  // (Number(null)===0 é fabricação) — degradar valor_linha para null. Codex 019f146d.
+  it('quantity-only sobre custo desconhecido (null): grava valor_linha null, não 0', () => {
+    const u = montarUpdateItem({ qtde_final: 5, qtde_sugerida: 8, preco_unitario: null }, 7, undefined);
+    expect(u.qtde_final).toBe(7);
+    expect(u.valor_linha).toBeNull();
+    expect('preco_unitario' in u).toBe(false);
+  });
+
+  it('quantity-only sobre custo desconhecido (0 legado): grava valor_linha null', () => {
+    const u = montarUpdateItem({ qtde_final: 5, qtde_sugerida: 8, preco_unitario: 0 }, 7, undefined);
+    expect(u.qtde_final).toBe(7);
+    expect(u.valor_linha).toBeNull();
+    expect('preco_unitario' in u).toBe(false);
+  });
+
+  it('price-only sobre custo desconhecido (null): custo passa a ser conhecido → valor_linha = qtd*preço', () => {
+    const u = montarUpdateItem({ qtde_final: 5, qtde_sugerida: 8, preco_unitario: null }, undefined, 25.35);
+    expect(u.preco_unitario).toBe(25.35);
+    expect(u.valor_linha).toBeCloseTo(5 * 25.35);
+  });
+
+  it('quantity-only sobre custo conhecido (>0): valor_linha = qtd*preço (não null)', () => {
+    const u = montarUpdateItem({ qtde_final: 5, qtde_sugerida: 8, preco_unitario: 20 }, 7, undefined);
+    expect(u.valor_linha).toBe(7 * 20);
+    expect('preco_unitario' in u).toBe(false);
+  });
+});

--- a/src/components/reposicao/pedidos/preco-edit.ts
+++ b/src/components/reposicao/pedidos/preco-edit.ts
@@ -37,7 +37,11 @@ export function precoEditValido(v: number): boolean {
 
 export interface ItemUpdate {
   qtde_final: number;
-  valor_linha: number;
+  // null = custo desconhecido (item de primeira compra sem preço). Money-path:
+  // ausente ≠ zero — numa edição só-de-quantidade de item sem custo NÃO fabricamos
+  // valor_linha = qtd*0 = 0 (preservaria o invariante "valor_linha null = custo
+  // desconhecido"). Só vira número quando há preço conhecido (editado ou já no item).
+  valor_linha: number | null;
   ajustado_humano: true;
   // Só presente quando o usuário editou o preço — NUNCA reescrito a partir de um
   // ajuste só-de-quantidade (senão um quantity-only edit poderia zerar um preço
@@ -58,9 +62,13 @@ export function montarUpdateItem(
   // do qtde_final legado (poeira decimal do estoque do Omie) podem persistir fração no pedido.
   const qtd = quantidadeCompraInteira(qtdEdit ?? Number(item.qtde_final ?? item.qtde_sugerida ?? 0));
   const preco = temPrecoEdit ? (precoEdit as number) : Number(item.preco_unitario ?? 0);
+  // Custo desconhecido = sem edição de preço E preço atual ausente/<=0 (item de primeira
+  // compra). Aí valor_linha degrada para null (não fabrica qtd*0=0); o disparo já barra
+  // o item por preco_unitario null/0 — aqui é só manter o dado consistente. Codex 019f146d.
+  const custoDesconhecido = !temPrecoEdit && !(preco > 0);
   const update: ItemUpdate = {
     qtde_final: qtd,
-    valor_linha: qtd * preco,
+    valor_linha: custoDesconhecido ? null : qtd * preco,
     ajustado_humano: true,
   };
   if (temPrecoEdit) update.preco_unitario = preco;

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -129,6 +129,10 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
           .eq('id', itemId);
         if (error) throw error;
       }
+      // Header null-safe: _valor já trata custo desconhecido (preco_unitario null/0)
+      // como 0, então valor_total = SUM(COALESCE(valor_linha,0)) — consistente com o
+      // valor_linha null que montarUpdateItem grava nessas linhas (ausente ≠ zero).
+      // Não trocar o `?? 0` do _valor por propagação de null (viraria NaN no total). Codex 019f146d.
       const novoTotal = linhas.reduce((acc, l) => acc + l._valor, 0);
       const { error: errPed } = await supabase
         .from('pedido_compra_sugerido')


### PR DESCRIPTION
## Contexto

Follow-up do fix money-path que faz o motor gravar `preco_unitario = NULL` (custo desconhecido, em vez de 0 fabricado) para SKUs de primeira compra. Nuance de frontend apontado pelo **Codex (challenge 019f146d)**.

## Problema

Em `montarUpdateItem` (`src/components/reposicao/pedidos/preco-edit.ts`), uma edição **só-de-quantidade** (sem editar preço) de um item com `preco_unitario = NULL` fazia `const preco = Number(item.preco_unitario ?? 0)` → `0` e gravava `valor_linha = qtd * 0 = 0`. Resultado: item com `preco_unitario = NULL` mas `valor_linha = 0` — inconsistente, enfraquecendo o invariante **"valor_linha NULL = custo desconhecido"**.

Não é escape de disparo — **só consistência de dado/relatório**.

## Fix

- **`preco-edit.ts`**: `ItemUpdate.valor_linha: number | null`; em `montarUpdateItem`, `custoDesconhecido = !temPrecoEdit && !(preco > 0)` → grava `valor_linha: null` em vez de `qtd*0`. Mesmo critério do `precoEditavelDaLinha`.
- **`useDetalhesModal.ts`**: recompute do header já era null-safe (`_valor = qtd*(preco ?? 0)` = `SUM(COALESCE(valor_linha,0))`); documentei a invariante para impedir regressão.
- **`preco-edit.test.ts`**: +4 testes (quantity-only sobre custo desconhecido null/0 → `valor_linha null`; price-only sobre null → vira número; quantity-only sobre custo conhecido → preserva).

## Invariantes confirmados

- 🔒 **Disparo segue barrando** — a edge filtra por `preco_unitario` (`supabase/functions/disparar-pedidos-aprovados/index.ts:701`), não por `valor_linha`; e o quantity-only não grava `preco_unitario` (segue NULL).
- 🔒 **Header soma certo** — `valor_total = SUM(COALESCE(valor_linha,0))`; coluna `valor_linha` já é nullable no schema → `.update()` sem erro de tipo.

## Verificação

- typecheck → **0** ✅
- suite completa de testes → **536 arquivos / 4196 testes** ✅
- `eslint` nos 3 arquivos tocados → **0** ✅
- Sem migration/SQL/RPC/trigger/RLS → prova PG17 não se aplica (mudança 100% frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
