### PR TITLE
feat(venda-ia): Fatia 2 v1 — selo "preparado" por produto no wizard (+ montarBaseEmbalagens)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-venda-assistida-fatia2-selo.md
+++ b/docs/superpowers/plans/2026-06-29-venda-assistida-fatia2-selo.md
@@ -1,0 +1,38 @@
+# Venda assistida — Fatia 2 v1: selo "preparado" por produto no wizard
+
+> Slice escolhido pelo founder (2026-06-29): surfacing per-produto, vendedor-only, reusando a plumbing da casar.
+> Design do programa: `docs/superpowers/specs/2026-06-14-venda-assistida-ia-design.md`. Motor: Fatia 1 (`resolverOpcaoVenda`/`montarBaseEmbalagens`, 41 testes, Codex-blindado).
+
+## Decisão
+Mostrar, ao lado do botão **Ficha** de cada produto com boletim aprovado, um **selo vendedor-only**:
+- `SELLABLE_NOW` → 🟢 **Em estoque** · "Preparado: R$ X,XX/L (teórico)"
+- `ORDERABLE` → 🟡 **Encomenda** · preço ou "sob consulta"
+- preço `incomplete` → "Preparado: **sob consulta**"
+
+## Fluxo de dados (tudo já em memória no wizard — zero query nova)
+1. `specsByKey` (view `v_omie_product_current_spec`, já montada pela casar) → agrupar por `kb_product_spec_id` = embalagens de cada boletim.
+2. Por SKU do boletim, pegar `descricao/valor_unitario/estoque` do **catálogo carregado** (`useProductCatalog`, completo/paginado) → `montarBaseEmbalagens(rows, customerPrices)`.
+3. `customerPrices` = merge `customerPricesColacor` + `customerPricesOben` (último praticado).
+4. `catalisador_codigo`/`proporcao` do próprio spec. **v1:** `catalisadorEmbalagens: []` → produto que exige catalisador **degrada honesto a "sob consulta"** (até a fatia do casamento do catalisador).
+5. `resolverOpcaoVenda(...)` → opção `{estado, preco}` → espalhar pra cada SKU do boletim num `Map<keyDeSku, OpcaoResolvida>`.
+
+## Regras / honestidade money-path
+- `temSkuConfirmado: true` sempre (a view é confirmed+approved).
+- Boletim **sem nenhuma embalagem no catálogo** → **não emite selo** (não polui com "sob consulta" quando só faltou carregar dado).
+- `catalisador_codigo` vazio/whitespace → tratado como **sem catalisador** (base-only).
+- Preço **nunca fabricado** — herda o motor Codex-blindado (ausente → `incomplete` → "sob consulta").
+- Rótulo **"(teórico)"** + "baseado no último praticado" — nunca "preço fechado".
+
+## Arquivos (2 puros + 2 fiações, espelhando a casar)
+- **Criar** `src/lib/venda-assistida/selos.ts` — `montarSelosVendaAssistida(specs, catalogByKey, customerPrices)` + `descreverSelo(opcao)` (puros).
+- **Criar** `src/components/unified-order/VendaAssistidaSelo.tsx` — wrapper trivial que renderiza `descreverSelo` (formata o R$/L com o formatter do repo).
+- **Editar** `src/components/unified-order/ProductItemForm.tsx` — +props `selosByKey?` / `canSeeVendaAssistida?`, lookup `selosByKey.get(keyDeSku(account, cod))` igual ao da Ficha.
+- **Editar** `src/pages/UnifiedOrder.tsx` — `useMemo` monta `selosByKey` (catálogo→Map + merge de preços + `montarSelosVendaAssistida`); passa `canSeeVendaAssistida={h.isStaff}` aos dois ProductItemForm.
+
+## Gate / verificação
+- Vendedor-only = `isStaff` (espelha `canSeeFicha`; nada pro cliente).
+- Lógica 100% por testes puros agora. "Na tela" acende quando os vínculos forem populados em prod.
+
+## Deferido (fatia própria)
+- **Casamento do catalisador** (catalisador_codigo→SKU, founder aprova) → destrava preço CATALISADO completo.
+- Camada viva / "mostrar todas as alternativas" (Fatia 3 — NeedFrame + busca + gate; depende do pgvector da Fatia 0).

--- a/docs/superpowers/plans/2026-06-29-venda-assistida-fatia2-selo.md
+++ b/docs/superpowers/plans/2026-06-29-venda-assistida-fatia2-selo.md
@@ -33,6 +33,12 @@ Mostrar, ao lado do botão **Ficha** de cada produto com boletim aprovado, um **
 - Vendedor-only = `isStaff` (espelha `canSeeFicha`; nada pro cliente).
 - Lógica 100% por testes puros agora. "Na tela" acende quando os vínculos forem populados em prod.
 
+## Codex adversarial (2026-06-29, xhigh) — 2 P0 + 1 P1 na camada nova, fechados
+- **P0 (auto-scan, antes do Codex) — preço-do-cliente cross-account:** `omie_codigo_produto` colide entre Oben/Colacor (contas Omie separadas) → o merge `{...colacor, ...oben}` vazava o preço da Oben pra um SKU da Colacor de mesmo código. Fix: ler o preço da CONTA de cada SKU + teste de regressão.
+- **P0 (Codex) — agrupar só por boletim mistura contas:** um boletim vinculado a SKU Oben E Colacor resolvia junto → mostrava o estoque/preço de uma conta no produto da outra. Fix: agrupar por `(conta, kb_product_spec_id)` — cada conta é sua própria opção. + teste de regressão.
+- **P1 (Codex) — "Encomenda" com preço incompleto:** `ORDERABLE + incomplete` mostrava "sob consulta · Encomenda". Fix: preço incompleto DOMINA a apresentação → "Sob consulta" (muted); só mostra "Em estoque"/"Encomenda" quando o preço fecha (`ok`).
+- ⚠️ **P0 NÃO-fechado (pré-existente, FORA do escopo do selo):** `useCustomerSelection.ts:534` manda o MESMO mapa de preço local pras 2 contas (limitação **documentada no código**: "corrigida na Fase 2 account-aware"). Afeta também o preço que o wizard já exibe hoje — não é introduzido pelo selo. O read-por-conta do selo fica forward-compatible. **→ flaggar pro founder / fatia própria.**
+
 ## Deferido (fatia própria)
 - **Casamento do catalisador** (catalisador_codigo→SKU, founder aprova) → destrava preço CATALISADO completo.
 - Camada viva / "mostrar todas as alternativas" (Fatia 3 — NeedFrame + busca + gate; depende do pgvector da Fatia 0).

--- a/src/components/unified-order/ProductItemForm.tsx
+++ b/src/components/unified-order/ProductItemForm.tsx
@@ -8,6 +8,8 @@ import { keyDeSku, type CurrentSpec } from '@/lib/knowledge-base/spec-link';
 import { FichaTecnicaSheet } from '@/components/unified-order/FichaTecnicaSheet';
 import { usePrecoCockpit, type ItemCockpitInput } from '@/hooks/usePrecoCockpit';
 import { FAIXA_UI } from '@/lib/preco/faixa-ui';
+import { VendaAssistidaSelo } from '@/components/unified-order/VendaAssistidaSelo';
+import type { OpcaoResolvida } from '@/lib/venda-assistida/resolver-opcao';
 import { cn } from '@/lib/utils';
 import type { Product, ProductCartItem } from '@/hooks/useUnifiedOrder';
 import { fmt } from '@/hooks/useUnifiedOrder';
@@ -31,12 +33,17 @@ interface ProductItemFormProps {
   specsByKey?: Map<string, CurrentSpec>;
   /** Mostra "Ver ficha" só p/ staff (a view RLS já é staff; isto evita o affordance p/ não-staff). */
   canSeeFicha?: boolean;
+  /** Mapa de opções de venda assistida por keyDeSku(account, cod) — selo "preparado". */
+  selosByKey?: Map<string, OpcaoResolvida>;
+  /** Mostra o selo "preparado" só p/ staff (vendedor-only; nada pro cliente). */
+  canSeeVendaAssistida?: boolean;
 }
 
 export function ProductItemForm({
   title, products, prices, loading, productSearch, onSearchChange,
   productItems, onAddProduct, customerPurchaseHistory = {},
   customerPricesLoading = false, specsByKey, canSeeFicha = false,
+  selosByKey, canSeeVendaAssistida = false,
 }: ProductItemFormProps) {
   const [quantities, setQuantities] = useState<Record<string, number>>({});
   const [fichaAberta, setFichaAberta] = useState<string | null>(null);
@@ -102,6 +109,9 @@ export function ProductItemForm({
                 ? specsByKey?.get(keyDeSku(product.account, product.omie_codigo_produto))
                 : undefined;
               const health = cockpitByCode?.get(product.omie_codigo_produto);
+              const selo = canSeeVendaAssistida
+                ? selosByKey?.get(keyDeSku(product.account, product.omie_codigo_produto))
+                : undefined;
               return (
                 <div
                   key={product.id}
@@ -192,6 +202,7 @@ export function ProductItemForm({
                       {isInCart ? 'Adicionar +' : 'Adicionar'}
                     </Button>
                   </div>
+                  {selo && <VendaAssistidaSelo option={selo} />}
                   {ficha && (
                     <FichaTecnicaSheet
                       spec={ficha}

--- a/src/components/unified-order/VendaAssistidaSelo.tsx
+++ b/src/components/unified-order/VendaAssistidaSelo.tsx
@@ -15,6 +15,12 @@ import type { OpcaoResolvida } from '@/lib/venda-assistida/resolver-opcao';
  */
 export function VendaAssistidaSelo({ option }: { option: OpcaoResolvida }) {
   const selo = descreverSelo(option);
+  const toneClass = cn(
+    'font-medium',
+    selo.estadoTone === 'success' && 'text-status-success',
+    selo.estadoTone === 'warning' && 'text-status-warning',
+    selo.estadoTone === 'muted' && 'text-muted-foreground',
+  );
   return (
     <div
       className="mt-1.5 flex items-center gap-1.5 text-[10px]"
@@ -23,22 +29,16 @@ export function VendaAssistidaSelo({ option }: { option: OpcaoResolvida }) {
       <Sparkles className="w-3 h-3 text-primary shrink-0" aria-hidden />
       <span className="text-muted-foreground">Preparado:</span>
       {selo.temPreco && selo.valorLitro != null ? (
-        <span className="font-medium font-mono tabular-nums">{fmt(selo.valorLitro)}/L</span>
+        <>
+          <span className="font-medium font-mono tabular-nums">{fmt(selo.valorLitro)}/L</span>
+          <span className="text-muted-foreground/60">(teórico)</span>
+          <span className="text-muted-foreground/60" aria-hidden>·</span>
+          <span className={toneClass}>{selo.estadoLabel}</span>
+        </>
       ) : (
-        <span className="font-medium">sob consulta</span>
+        // Preço incompleto → "Sob consulta" domina (P1 Codex); não mostra "Encomenda"/"Em estoque".
+        <span className={toneClass}>{selo.estadoLabel}</span>
       )}
-      <span className="text-muted-foreground/60" aria-hidden>·</span>
-      <span
-        className={cn(
-          'font-medium',
-          selo.estadoTone === 'success' && 'text-status-success',
-          selo.estadoTone === 'warning' && 'text-status-warning',
-          selo.estadoTone === 'muted' && 'text-muted-foreground',
-        )}
-      >
-        {selo.estadoLabel}
-      </span>
-      {selo.temPreco && <span className="text-muted-foreground/60">(teórico)</span>}
     </div>
   );
 }

--- a/src/components/unified-order/VendaAssistidaSelo.tsx
+++ b/src/components/unified-order/VendaAssistidaSelo.tsx
@@ -1,0 +1,44 @@
+import { Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { fmt } from '@/hooks/useUnifiedOrder';
+import { descreverSelo } from '@/lib/venda-assistida/selos';
+import type { OpcaoResolvida } from '@/lib/venda-assistida/resolver-opcao';
+
+/**
+ * Selo "preparado" VENDEDOR-ONLY no card do produto (Fatia 2 v1 da venda assistida).
+ *
+ * Mostra o estado (em estoque / encomenda) + o R$/litro preparado **teórico** — ou
+ * "sob consulta" quando o motor não fecha preço (catalisador obrigatório sem casamento,
+ * componente ausente, etc.). Toda a lógica vive em `descreverSelo` (puro/testado); aqui
+ * é só a apresentação. O preço é **teórico** (baseado no último praticado pra o cliente +
+ * maior embalagem disponível), nunca um preço fechado — daí o rótulo "(teórico)".
+ */
+export function VendaAssistidaSelo({ option }: { option: OpcaoResolvida }) {
+  const selo = descreverSelo(option);
+  return (
+    <div
+      className="mt-1.5 flex items-center gap-1.5 text-[10px]"
+      data-testid="venda-assistida-selo"
+    >
+      <Sparkles className="w-3 h-3 text-primary shrink-0" aria-hidden />
+      <span className="text-muted-foreground">Preparado:</span>
+      {selo.temPreco && selo.valorLitro != null ? (
+        <span className="font-medium font-mono tabular-nums">{fmt(selo.valorLitro)}/L</span>
+      ) : (
+        <span className="font-medium">sob consulta</span>
+      )}
+      <span className="text-muted-foreground/60" aria-hidden>·</span>
+      <span
+        className={cn(
+          'font-medium',
+          selo.estadoTone === 'success' && 'text-status-success',
+          selo.estadoTone === 'warning' && 'text-status-warning',
+          selo.estadoTone === 'muted' && 'text-muted-foreground',
+        )}
+      >
+        {selo.estadoLabel}
+      </span>
+      {selo.temPreco && <span className="text-muted-foreground/60">(teórico)</span>}
+    </div>
+  );
+}

--- a/src/components/unified-order/__tests__/VendaAssistidaSelo.test.tsx
+++ b/src/components/unified-order/__tests__/VendaAssistidaSelo.test.tsx
@@ -20,7 +20,7 @@ describe('VendaAssistidaSelo', () => {
     expect(screen.getByText('(teórico)')).toBeTruthy();
   });
 
-  it('catalisador obrigatório sem casamento → "sob consulta", "Encomenda", sem (teórico)', () => {
+  it('catalisador obrigatório sem casamento → "Sob consulta" domina (sem "Encomenda", sem teórico)', () => {
     const opcao = resolverOpcaoVenda({
       temSkuConfirmado: true,
       temCatalisador: true,
@@ -29,8 +29,8 @@ describe('VendaAssistidaSelo', () => {
       catalisadorEmbalagens: [], // catalisador obrigatório sem casamento → incomplete
     });
     render(<VendaAssistidaSelo option={opcao} />);
-    expect(screen.getByText('sob consulta')).toBeTruthy();
-    expect(screen.getByText('Encomenda')).toBeTruthy();
+    expect(screen.getByText('Sob consulta')).toBeTruthy();
+    expect(screen.queryByText('Encomenda')).toBeNull();
     expect(screen.queryByText('(teórico)')).toBeNull();
   });
 });

--- a/src/components/unified-order/__tests__/VendaAssistidaSelo.test.tsx
+++ b/src/components/unified-order/__tests__/VendaAssistidaSelo.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { VendaAssistidaSelo } from '../VendaAssistidaSelo';
+import { resolverOpcaoVenda } from '@/lib/venda-assistida/resolver-opcao';
+
+afterEach(cleanup);
+
+describe('VendaAssistidaSelo', () => {
+  it('em estoque + preço → mostra R$/L e "Em estoque" (teórico)', () => {
+    const opcao = resolverOpcaoVenda({
+      temSkuConfirmado: true,
+      temCatalisador: false,
+      proporcaoPct: null,
+      baseEmbalagens: [{ valor: 360, litros: 3.6, estoque: 5 }],
+      catalisadorEmbalagens: [],
+    });
+    render(<VendaAssistidaSelo option={opcao} />);
+    expect(screen.getByText('Em estoque')).toBeTruthy();
+    expect(screen.getByText(/\/L/)).toBeTruthy(); // "R$ 100,00/L"
+    expect(screen.getByText('(teórico)')).toBeTruthy();
+  });
+
+  it('catalisador obrigatório sem casamento → "sob consulta", "Encomenda", sem (teórico)', () => {
+    const opcao = resolverOpcaoVenda({
+      temSkuConfirmado: true,
+      temCatalisador: true,
+      proporcaoPct: 10,
+      baseEmbalagens: [{ valor: 360, litros: 3.6, estoque: 5 }],
+      catalisadorEmbalagens: [], // catalisador obrigatório sem casamento → incomplete
+    });
+    render(<VendaAssistidaSelo option={opcao} />);
+    expect(screen.getByText('sob consulta')).toBeTruthy();
+    expect(screen.getByText('Encomenda')).toBeTruthy();
+    expect(screen.queryByText('(teórico)')).toBeNull();
+  });
+});

--- a/src/lib/venda-assistida/__tests__/montar-embalagens.test.ts
+++ b/src/lib/venda-assistida/__tests__/montar-embalagens.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { montarBaseEmbalagens, type ProdutoLinhaOmie } from '../montar-embalagens';
+
+const prod = (omie_codigo_produto: number, descricao: string, valor_unitario: number, estoque: number): ProdutoLinhaOmie =>
+  ({ omie_codigo_produto, descricao, valor_unitario, estoque });
+
+describe('montarBaseEmbalagens', () => {
+  it('extrai sufixo Sayerlack → litros (base GL = 3,24) e passa estoque', () => {
+    const [emb] = montarBaseEmbalagens([prod(1, 'BASE PU METALLIC WFOB.6736GL', 324, 7)], {});
+    expect(emb.litros).toBe(3.24);
+    expect(emb.estoque).toBe(7);
+    expect(emb.valor).toBe(324); // sem preço-do-cliente → tabela
+  });
+
+  it('QT não-base = 0,9; fracionado 405ML = 0,405 (descrição manda)', () => {
+    const [qt] = montarBaseEmbalagens([prod(2, 'WP12.3900QT CONCENTRADO PRETO', 90, 3)], {});
+    expect(qt.litros).toBe(0.9);
+    const [frac] = montarBaseEmbalagens([prod(3, 'ISOLANTE PU FI.6197 405ML', 40, 1)], {});
+    expect(frac.litros).toBe(0.405);
+  });
+
+  it('preço-do-cliente (>0) vence a tabela; 0/ausente → tabela', () => {
+    const rows = [prod(10, 'PRIMER PU FL.6269.02GL', 300, 5)];
+    expect(montarBaseEmbalagens(rows, { 10: 270 })[0].valor).toBe(270); // último praticado
+    expect(montarBaseEmbalagens(rows, { 10: 0 })[0].valor).toBe(300);   // 0 → tabela
+    expect(montarBaseEmbalagens(rows, {})[0].valor).toBe(300);          // ausente → tabela
+  });
+
+  it('SKU sem código Sayerlack reconhecível → litros null (sob consulta)', () => {
+    const [emb] = montarBaseEmbalagens([prod(4, 'PRODUTO GENERICO SEM CODIGO', 50, 2)], {});
+    expect(emb.litros).toBeNull();
+  });
+
+  it('estoque inválido (NaN) → 0', () => {
+    const [emb] = montarBaseEmbalagens([prod(5, 'PRIMER PU FL.6269.02GL', 300, NaN)], {});
+    expect(emb.estoque).toBe(0);
+  });
+
+  it('lista vazia → []', () => {
+    expect(montarBaseEmbalagens([], {})).toEqual([]);
+  });
+});

--- a/src/lib/venda-assistida/__tests__/selos.test.ts
+++ b/src/lib/venda-assistida/__tests__/selos.test.ts
@@ -131,6 +131,22 @@ describe('montarSelosVendaAssistida', () => {
     if (so?.preco.status === 'ok') expect(so.preco.precoLitroBase).toBe(50);
   });
 
+  it('🔴 MESMO boletim em duas contas → resolve por conta (Oben em estoque ≠ Colacor sem estoque)', () => {
+    // Um boletim (kb_product_spec_id) vinculado a SKU Oben (em estoque) E Colacor (sem estoque).
+    const specs = [
+      spec({ account: 'oben', omie_codigo_produto: 10, kb_product_spec_id: 'BX' }),
+      spec({ account: 'colacor', omie_codigo_produto: 20, kb_product_spec_id: 'BX' }),
+    ];
+    const cat = catalog(
+      { account: 'oben', row: row(10, 'PRIMER PU FL.6269.02GL', 360, 5) }, //    em estoque
+      { account: 'colacor', row: row(20, 'PRIMER PU FL.6269.02GL', 360, 0) }, // sem estoque
+    );
+    const selos = montarSelosVendaAssistida(specs, cat, {});
+    expect(selos.get(keyDeSku('oben', 10))?.estado).toBe('SELLABLE_NOW');
+    // NÃO pode herdar o estoque da Oben (no agrupamento só-por-boletim daria SELLABLE_NOW — bug P0).
+    expect(selos.get(keyDeSku('colacor', 20))?.estado).toBe('ORDERABLE');
+  });
+
   it('boletim sem NENHUMA embalagem no catálogo → não emite selo', () => {
     const specs = [spec({ account: 'colacor', omie_codigo_produto: 99, kb_product_spec_id: 'B9' })];
     const selos = montarSelosVendaAssistida(specs, catalog(), {});
@@ -184,5 +200,7 @@ describe('descreverSelo', () => {
     const d = descreverSelo(opcao);
     expect(d.temPreco).toBe(false);
     expect(d.valorLitro).toBeNull();
+    expect(d.estadoLabel).toBe('Sob consulta'); // preço incompleto domina (P1)
+    expect(d.estadoTone).toBe('muted');
   });
 });

--- a/src/lib/venda-assistida/__tests__/selos.test.ts
+++ b/src/lib/venda-assistida/__tests__/selos.test.ts
@@ -105,9 +105,30 @@ describe('montarSelosVendaAssistida', () => {
   it('preço-do-cliente (último praticado) vence a tabela no selo', () => {
     const specs = [spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B1' })];
     const cat = catalog({ account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) });
-    const s = montarSelosVendaAssistida(specs, cat, { 1: 180 }).get(keyDeSku('colacor', 1));
+    const s = montarSelosVendaAssistida(specs, cat, { colacor: { 1: 180 } }).get(keyDeSku('colacor', 1));
     // 180 / 3,6 L = 50/L (cliente) em vez de 360/3,6 = 100/L (tabela)
     if (s?.preco.status === 'ok') expect(s.preco.precoLitroBase).toBe(50);
+  });
+
+  it('🔴 preço-do-cliente é POR CONTA — omie_codigo_produto colidido Oben↔Colacor não vaza', () => {
+    // Mesmo cod (1) em contas Omie diferentes (ids numéricos colidem) — preços DIFERENTES por conta.
+    const specs = [
+      spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'BC' }),
+      spec({ account: 'oben', omie_codigo_produto: 1, kb_product_spec_id: 'BO' }),
+    ];
+    const cat = catalog(
+      { account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 999, 5) },
+      { account: 'oben', row: row(1, 'PRIMER PU FL.6269.02GL', 999, 5) },
+    );
+    const selos = montarSelosVendaAssistida(specs, cat, {
+      colacor: { 1: 360 }, // 360 / 3,6 = 100/L
+      oben: { 1: 180 }, //    180 / 3,6 = 50/L
+    });
+    const sc = selos.get(keyDeSku('colacor', 1));
+    const so = selos.get(keyDeSku('oben', 1));
+    // Com o merge antigo {...colacor, ...oben} ambos pegariam 180→50/L (vazamento). Por conta: cada um o seu.
+    if (sc?.preco.status === 'ok') expect(sc.preco.precoLitroBase).toBe(100);
+    if (so?.preco.status === 'ok') expect(so.preco.precoLitroBase).toBe(50);
   });
 
   it('boletim sem NENHUMA embalagem no catálogo → não emite selo', () => {

--- a/src/lib/venda-assistida/__tests__/selos.test.ts
+++ b/src/lib/venda-assistida/__tests__/selos.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import { montarSelosVendaAssistida, descreverSelo } from '../selos';
+import { resolverOpcaoVenda } from '../resolver-opcao';
+import type { ProdutoLinhaOmie } from '../montar-embalagens';
+import { keyDeSku, type CurrentSpec } from '@/lib/knowledge-base/spec-link';
+
+// ── factories ────────────────────────────────────────────────────────────────
+const spec = (
+  p: Partial<CurrentSpec> &
+    Pick<CurrentSpec, 'account' | 'omie_codigo_produto' | 'kb_product_spec_id'>,
+): CurrentSpec => ({
+  product_code: null,
+  product_name: null,
+  supplier: null,
+  product_category: null,
+  rendimento_m2_por_litro: null,
+  demaos_recomendadas: null,
+  pot_life_horas: null,
+  validade_dias: null,
+  catalisador_codigo: null,
+  catalisador_proporcao_pct: null,
+  diluente_codigo: null,
+  substrato: null,
+  equipamentos_aplicacao: null,
+  diferenciais_chave: null,
+  uso_recomendado: null,
+  ...p,
+});
+
+const row = (
+  omie_codigo_produto: number,
+  descricao: string,
+  valor_unitario: number,
+  estoque: number,
+): ProdutoLinhaOmie => ({ omie_codigo_produto, descricao, valor_unitario, estoque });
+
+const catalog = (
+  ...entries: { account: string; row: ProdutoLinhaOmie }[]
+): Map<string, ProdutoLinhaOmie> => {
+  const m = new Map<string, ProdutoLinhaOmie>();
+  for (const { account, row: r } of entries) {
+    m.set(keyDeSku(account, r.omie_codigo_produto), r);
+  }
+  return m;
+};
+
+// ── montarSelosVendaAssistida ────────────────────────────────────────────────
+describe('montarSelosVendaAssistida', () => {
+  it('boletim base-only em estoque → SELLABLE_NOW + preço ok, espalhado pra cada SKU', () => {
+    const specs = [
+      spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B1' }),
+      spec({ account: 'colacor', omie_codigo_produto: 2, kb_product_spec_id: 'B1' }),
+    ];
+    const cat = catalog(
+      { account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) }, // GL 3,6 L → 100/L
+      { account: 'colacor', row: row(2, 'PRIMER PU FL.6269.02QT', 100, 5) }, // QT 0,9 L
+    );
+
+    const selos = montarSelosVendaAssistida(specs, cat, {});
+    const s1 = selos.get(keyDeSku('colacor', 1));
+    expect(s1?.estado).toBe('SELLABLE_NOW');
+    expect(s1?.preco.status).toBe('ok');
+    // fan-out: o SKU 2 do MESMO boletim referencia a MESMA opção
+    expect(selos.get(keyDeSku('colacor', 2))).toBe(s1);
+  });
+
+  it('boletim base-only sem estoque → ORDERABLE (encomenda)', () => {
+    const specs = [spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B1' })];
+    const cat = catalog({ account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 0) });
+    const s = montarSelosVendaAssistida(specs, cat, {}).get(keyDeSku('colacor', 1));
+    expect(s?.estado).toBe('ORDERABLE');
+  });
+
+  it('boletim COM catalisador (v1 sem casamento) → ORDERABLE + "sob consulta"', () => {
+    const specs = [
+      spec({
+        account: 'colacor',
+        omie_codigo_produto: 1,
+        kb_product_spec_id: 'B2',
+        catalisador_codigo: 'FC.1',
+        catalisador_proporcao_pct: 10,
+      }),
+    ];
+    const cat = catalog({ account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) });
+    const s = montarSelosVendaAssistida(specs, cat, {}).get(keyDeSku('colacor', 1));
+    expect(s?.estado).toBe('ORDERABLE');
+    expect(s?.preco.status).toBe('incomplete'); // catalisador obrigatório sem casamento
+  });
+
+  it('catalisador_codigo vazio/whitespace → tratado como base-only', () => {
+    const specs = [
+      spec({
+        account: 'colacor',
+        omie_codigo_produto: 1,
+        kb_product_spec_id: 'B3',
+        catalisador_codigo: '   ',
+      }),
+    ];
+    const cat = catalog({ account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) });
+    const s = montarSelosVendaAssistida(specs, cat, {}).get(keyDeSku('colacor', 1));
+    expect(s?.estado).toBe('SELLABLE_NOW');
+    expect(s?.preco.status).toBe('ok');
+  });
+
+  it('preço-do-cliente (último praticado) vence a tabela no selo', () => {
+    const specs = [spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B1' })];
+    const cat = catalog({ account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) });
+    const s = montarSelosVendaAssistida(specs, cat, { 1: 180 }).get(keyDeSku('colacor', 1));
+    // 180 / 3,6 L = 50/L (cliente) em vez de 360/3,6 = 100/L (tabela)
+    if (s?.preco.status === 'ok') expect(s.preco.precoLitroBase).toBe(50);
+  });
+
+  it('boletim sem NENHUMA embalagem no catálogo → não emite selo', () => {
+    const specs = [spec({ account: 'colacor', omie_codigo_produto: 99, kb_product_spec_id: 'B9' })];
+    const selos = montarSelosVendaAssistida(specs, catalog(), {});
+    expect(selos.has(keyDeSku('colacor', 99))).toBe(false);
+  });
+
+  it('lista vazia → Map vazio', () => {
+    expect(montarSelosVendaAssistida([], catalog(), {}).size).toBe(0);
+  });
+});
+
+// ── descreverSelo ────────────────────────────────────────────────────────────
+describe('descreverSelo', () => {
+  it('SELLABLE_NOW + ok → "Em estoque", tone success, com preço', () => {
+    const opcao = resolverOpcaoVenda({
+      temSkuConfirmado: true,
+      temCatalisador: false,
+      proporcaoPct: null,
+      baseEmbalagens: [{ valor: 360, litros: 3.6, estoque: 5 }],
+      catalisadorEmbalagens: [],
+    });
+    const d = descreverSelo(opcao);
+    expect(d.estadoLabel).toBe('Em estoque');
+    expect(d.estadoTone).toBe('success');
+    expect(d.temPreco).toBe(true);
+    expect(d.valorLitro).toBe(100);
+  });
+
+  it('ORDERABLE + ok → "Encomenda", tone warning', () => {
+    const opcao = resolverOpcaoVenda({
+      temSkuConfirmado: true,
+      temCatalisador: false,
+      proporcaoPct: null,
+      baseEmbalagens: [{ valor: 360, litros: 3.6, estoque: 0 }],
+      catalisadorEmbalagens: [],
+    });
+    const d = descreverSelo(opcao);
+    expect(d.estadoLabel).toBe('Encomenda');
+    expect(d.estadoTone).toBe('warning');
+    expect(d.temPreco).toBe(true);
+  });
+
+  it('preço incomplete → temPreco false, valorLitro null ("sob consulta")', () => {
+    const opcao = resolverOpcaoVenda({
+      temSkuConfirmado: true,
+      temCatalisador: true,
+      proporcaoPct: 10,
+      baseEmbalagens: [{ valor: 360, litros: 3.6, estoque: 5 }],
+      catalisadorEmbalagens: [], // catalisador obrigatório sem casamento
+    });
+    const d = descreverSelo(opcao);
+    expect(d.temPreco).toBe(false);
+    expect(d.valorLitro).toBeNull();
+  });
+});

--- a/src/lib/venda-assistida/montar-embalagens.ts
+++ b/src/lib/venda-assistida/montar-embalagens.ts
@@ -1,0 +1,46 @@
+import { resolverSayerlack } from '@/lib/reposicao/sayerlack-sku';
+import { litrosDaEmbalagem } from './preco-preparado';
+import type { EmbalagemComEstoque } from './resolver-opcao';
+
+/**
+ * Monta as embalagens da base/catalisador pro resolver da venda assistida (Fatia 2).
+ *
+ * Liga os SKUs do casamento (linhas de omie_products) ao de-para de litros (via parser Sayerlack) e
+ * ao **preço-do-cliente** do wizard. PURO/testável — a query Supabase é um wrapper fino por cima.
+ *
+ * Litros: extrai o código Sayerlack da descrição → sufixo → `litrosDaEmbalagem`. SKU sem código
+ * Sayerlack reconhecível → litros null → o resolver degrada honesto a "sob consulta".
+ * Preço: último praticado pro cliente (se > 0) senão tabela (valor_unitario). ⚠️ Codex: o
+ * preço-do-cliente NÃO é contratual (é o último praticado, copiado Oben↔Colacor) — a UI rotula.
+ */
+
+export interface ProdutoLinhaOmie {
+  omie_codigo_produto: number;
+  descricao: string;
+  valor_unitario: number;
+  estoque: number;
+}
+
+function precoDoCliente(
+  cod: number,
+  valorUnitario: number,
+  customerPrices: Record<number, number>,
+): number {
+  const cp = customerPrices[cod];
+  return typeof cp === 'number' && Number.isFinite(cp) && cp > 0 ? cp : valorUnitario;
+}
+
+export function montarBaseEmbalagens(
+  produtos: ProdutoLinhaOmie[],
+  customerPrices: Record<number, number>,
+): EmbalagemComEstoque[] {
+  return (produtos ?? []).map((p): EmbalagemComEstoque => {
+    const res = resolverSayerlack(p.descricao);
+    const sufixo = res.status === 'ok' ? res.sufixo : '';
+    return {
+      valor: precoDoCliente(p.omie_codigo_produto, p.valor_unitario, customerPrices ?? {}),
+      litros: litrosDaEmbalagem(sufixo, p.descricao),
+      estoque: Number.isFinite(p.estoque) ? p.estoque : 0,
+    };
+  });
+}

--- a/src/lib/venda-assistida/selos.ts
+++ b/src/lib/venda-assistida/selos.ts
@@ -30,17 +30,20 @@ export function montarSelosVendaAssistida(
   /** Preço-do-cliente (último praticado) POR CONTA: account (minúsculo) → omie_codigo_produto → preço. */
   customerPricesByAccount: Record<string, Record<number, number>>,
 ): Map<string, OpcaoResolvida> {
-  // Agrupa os SKUs vinculados por boletim (kb_product_spec_id).
-  const porBoletim = new Map<string, CurrentSpec[]>();
+  // Agrupa por (CONTA, boletim): um boletim pode estar vinculado a SKU Oben E Colacor (mesmo produto
+  // via os dois distribuidores). Resolver junto mostraria o estoque/preço de uma conta no produto da
+  // outra (P0 Codex) — cada conta vira sua própria opção.
+  const porGrupo = new Map<string, CurrentSpec[]>();
   for (const s of specs ?? []) {
-    const arr = porBoletim.get(s.kb_product_spec_id);
+    const grupo = `${(s.account ?? '').toLowerCase()}|${s.kb_product_spec_id}`;
+    const arr = porGrupo.get(grupo);
     if (arr) arr.push(s);
-    else porBoletim.set(s.kb_product_spec_id, [s]);
+    else porGrupo.set(grupo, [s]);
   }
 
   const selos = new Map<string, OpcaoResolvida>();
-  for (const boletimSpecs of porBoletim.values()) {
-    const ref = boletimSpecs[0];
+  for (const grupoSpecs of porGrupo.values()) {
+    const ref = grupoSpecs[0];
     if (!ref) continue;
 
     // Embalagens da base = linhas do catálogo dos SKUs vinculados (ignora SKU fora do catálogo).
@@ -48,7 +51,7 @@ export function montarSelosVendaAssistida(
     // separados) → nunca achatar num Record só; lê do mapa da conta de CADA SKU.
     const rows: ProdutoLinhaOmie[] = [];
     const pricesForBoletim: Record<number, number> = {};
-    for (const s of boletimSpecs) {
+    for (const s of grupoSpecs) {
       const row = catalogByKey.get(keyDeSku(s.account, s.omie_codigo_produto));
       if (!row) continue;
       rows.push(row);
@@ -71,7 +74,7 @@ export function montarSelosVendaAssistida(
       catalisadorEmbalagens: [], // v1 — casamento do catalisador é fatia própria
     });
 
-    for (const s of boletimSpecs) {
+    for (const s of grupoSpecs) {
       selos.set(keyDeSku(s.account, s.omie_codigo_produto), opcao);
     }
   }
@@ -80,22 +83,16 @@ export function montarSelosVendaAssistida(
 
 /** Descreve o selo (rótulo + tom + preço) de uma opção resolvida. Puro, sem formatação de moeda. */
 export function descreverSelo(opcao: OpcaoResolvida): SeloDescricao {
-  const estadoLabel =
-    opcao.estado === 'SELLABLE_NOW'
-      ? 'Em estoque'
-      : opcao.estado === 'ORDERABLE'
-        ? 'Encomenda'
-        : 'Alternativa técnica';
-  const estadoTone: SeloTone =
-    opcao.estado === 'SELLABLE_NOW'
-      ? 'success'
-      : opcao.estado === 'ORDERABLE'
-        ? 'warning'
-        : 'muted';
+  // Money-path: preço incompleto DOMINA a apresentação → "Sob consulta" (não "Encomenda"/"Em estoque"),
+  // pra não induzir o vendedor a tratar como encomenda normal de preço conhecido (P1 Codex).
+  if (opcao.preco.status !== 'ok') {
+    return { estadoLabel: 'Sob consulta', estadoTone: 'muted', temPreco: false, valorLitro: null };
+  }
+  const sellable = opcao.estado === 'SELLABLE_NOW';
   return {
-    estadoLabel,
-    estadoTone,
-    temPreco: opcao.preco.status === 'ok',
-    valorLitro: opcao.preco.status === 'ok' ? opcao.preco.valorLitroPreparado : null,
+    estadoLabel: sellable ? 'Em estoque' : 'Encomenda',
+    estadoTone: sellable ? 'success' : 'warning',
+    temPreco: true,
+    valorLitro: opcao.preco.valorLitroPreparado,
   };
 }

--- a/src/lib/venda-assistida/selos.ts
+++ b/src/lib/venda-assistida/selos.ts
@@ -27,7 +27,8 @@ export interface SeloDescricao {
 export function montarSelosVendaAssistida(
   specs: CurrentSpec[],
   catalogByKey: Map<string, ProdutoLinhaOmie>,
-  customerPrices: Record<number, number>,
+  /** Preço-do-cliente (último praticado) POR CONTA: account (minúsculo) → omie_codigo_produto → preço. */
+  customerPricesByAccount: Record<string, Record<number, number>>,
 ): Map<string, OpcaoResolvida> {
   // Agrupa os SKUs vinculados por boletim (kb_product_spec_id).
   const porBoletim = new Map<string, CurrentSpec[]>();
@@ -43,16 +44,22 @@ export function montarSelosVendaAssistida(
     if (!ref) continue;
 
     // Embalagens da base = linhas do catálogo dos SKUs vinculados (ignora SKU fora do catálogo).
+    // Preço-do-cliente POR CONTA: omie_codigo_produto colide entre Oben e Colacor (Omie accounts
+    // separados) → nunca achatar num Record só; lê do mapa da conta de CADA SKU.
     const rows: ProdutoLinhaOmie[] = [];
+    const pricesForBoletim: Record<number, number> = {};
     for (const s of boletimSpecs) {
       const row = catalogByKey.get(keyDeSku(s.account, s.omie_codigo_produto));
-      if (row) rows.push(row);
+      if (!row) continue;
+      rows.push(row);
+      const p = customerPricesByAccount[(s.account ?? '').toLowerCase()]?.[s.omie_codigo_produto];
+      if (typeof p === 'number') pricesForBoletim[s.omie_codigo_produto] = p;
     }
     // Boletim sem nenhuma embalagem conhecida → não emite selo (não polui com "sob consulta"
     // quando o problema é só dado de catálogo ausente, não falta de mapeamento).
     if (rows.length === 0) continue;
 
-    const baseEmbalagens = montarBaseEmbalagens(rows, customerPrices);
+    const baseEmbalagens = montarBaseEmbalagens(rows, pricesForBoletim);
     const cod = ref.catalisador_codigo;
     const temCatalisador = typeof cod === 'string' && cod.trim() !== '';
 

--- a/src/lib/venda-assistida/selos.ts
+++ b/src/lib/venda-assistida/selos.ts
@@ -1,0 +1,94 @@
+import { keyDeSku, type CurrentSpec } from '@/lib/knowledge-base/spec-link';
+import { montarBaseEmbalagens, type ProdutoLinhaOmie } from './montar-embalagens';
+import { resolverOpcaoVenda, type OpcaoResolvida } from './resolver-opcao';
+
+/**
+ * Selo "preparado" por produto no wizard — Fatia 2 v1 da venda assistida.
+ *
+ * Resolve a opção de venda (estado + preço) de CADA boletim presente e espalha o
+ * resultado pra cada SKU do boletim, devolvendo `Map<keyDeSku, OpcaoResolvida>` —
+ * pronto pro lookup por produto no ProductItemForm (igual ao `specsByKey` da ficha).
+ *
+ * PURO/testável. Reusa o catálogo já carregado pelo wizard (sem query nova).
+ * **v1:** catalisador sem casamento → `catalisadorEmbalagens: []` → o motor degrada
+ * honesto a "sob consulta" (nunca fabrica preço).
+ */
+
+export type SeloTone = 'success' | 'warning' | 'muted';
+
+export interface SeloDescricao {
+  estadoLabel: string;
+  estadoTone: SeloTone;
+  /** false → preço "sob consulta" (motor devolveu incomplete). */
+  temPreco: boolean;
+  valorLitro: number | null;
+}
+
+export function montarSelosVendaAssistida(
+  specs: CurrentSpec[],
+  catalogByKey: Map<string, ProdutoLinhaOmie>,
+  customerPrices: Record<number, number>,
+): Map<string, OpcaoResolvida> {
+  // Agrupa os SKUs vinculados por boletim (kb_product_spec_id).
+  const porBoletim = new Map<string, CurrentSpec[]>();
+  for (const s of specs ?? []) {
+    const arr = porBoletim.get(s.kb_product_spec_id);
+    if (arr) arr.push(s);
+    else porBoletim.set(s.kb_product_spec_id, [s]);
+  }
+
+  const selos = new Map<string, OpcaoResolvida>();
+  for (const boletimSpecs of porBoletim.values()) {
+    const ref = boletimSpecs[0];
+    if (!ref) continue;
+
+    // Embalagens da base = linhas do catálogo dos SKUs vinculados (ignora SKU fora do catálogo).
+    const rows: ProdutoLinhaOmie[] = [];
+    for (const s of boletimSpecs) {
+      const row = catalogByKey.get(keyDeSku(s.account, s.omie_codigo_produto));
+      if (row) rows.push(row);
+    }
+    // Boletim sem nenhuma embalagem conhecida → não emite selo (não polui com "sob consulta"
+    // quando o problema é só dado de catálogo ausente, não falta de mapeamento).
+    if (rows.length === 0) continue;
+
+    const baseEmbalagens = montarBaseEmbalagens(rows, customerPrices);
+    const cod = ref.catalisador_codigo;
+    const temCatalisador = typeof cod === 'string' && cod.trim() !== '';
+
+    const opcao = resolverOpcaoVenda({
+      temSkuConfirmado: true, // a view v_omie_product_current_spec é confirmed+approved
+      temCatalisador,
+      proporcaoPct: ref.catalisador_proporcao_pct,
+      baseEmbalagens,
+      catalisadorEmbalagens: [], // v1 — casamento do catalisador é fatia própria
+    });
+
+    for (const s of boletimSpecs) {
+      selos.set(keyDeSku(s.account, s.omie_codigo_produto), opcao);
+    }
+  }
+  return selos;
+}
+
+/** Descreve o selo (rótulo + tom + preço) de uma opção resolvida. Puro, sem formatação de moeda. */
+export function descreverSelo(opcao: OpcaoResolvida): SeloDescricao {
+  const estadoLabel =
+    opcao.estado === 'SELLABLE_NOW'
+      ? 'Em estoque'
+      : opcao.estado === 'ORDERABLE'
+        ? 'Encomenda'
+        : 'Alternativa técnica';
+  const estadoTone: SeloTone =
+    opcao.estado === 'SELLABLE_NOW'
+      ? 'success'
+      : opcao.estado === 'ORDERABLE'
+        ? 'warning'
+        : 'muted';
+  return {
+    estadoLabel,
+    estadoTone,
+    temPreco: opcao.preco.status === 'ok',
+    valorLitro: opcao.preco.status === 'ok' ? opcao.preco.valorLitroPreparado : null,
+  };
+}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -28,6 +28,9 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { ProductItemForm } from '@/components/unified-order/ProductItemForm';
 import { useCurrentSpecsMap } from '@/hooks/useProductSpecLink';
+import { keyDeSku } from '@/lib/knowledge-base/spec-link';
+import { montarSelosVendaAssistida } from '@/lib/venda-assistida/selos';
+import type { ProdutoLinhaOmie } from '@/lib/venda-assistida/montar-embalagens';
 import { ServiceItemForm } from '@/components/unified-order/ServiceItemForm';
 import { CartItemList } from '@/components/unified-order/CartItemList';
 import { CartSummaryBar } from '@/components/unified-order/CartSummaryBar';
@@ -57,6 +60,22 @@ const UnifiedOrder = () => {
   const { user } = useAuth();
   // Fichas técnicas (boletim↔SKU): mapa pequeno (só vínculos confirmados+aprovados), 1 query.
   const { byKey: fichasByKey } = useCurrentSpecsMap();
+  // Venda assistida (Fatia 2 v1): selo "preparado" por produto. Resolve estado+preço de cada
+  // boletim reusando o catálogo JÁ carregado (zero query nova) e espalha por SKU. Vendedor-only.
+  const selosByKey = useMemo(() => {
+    const catalogByKey = new Map<string, ProdutoLinhaOmie>();
+    for (const p of [...h.obenProducts, ...h.colacorProducts]) {
+      catalogByKey.set(keyDeSku(p.account, p.omie_codigo_produto), {
+        omie_codigo_produto: p.omie_codigo_produto,
+        descricao: p.descricao,
+        valor_unitario: p.valor_unitario,
+        estoque: p.estoque ?? 0,
+      });
+    }
+    // Preço-do-cliente (último praticado), copiado Oben↔Colacor — merge p/ lookup por omie_codigo_produto.
+    const customerPrices = { ...h.customerPricesColacor, ...h.customerPricesOben };
+    return montarSelosVendaAssistida([...fichasByKey.values()], catalogByKey, customerPrices);
+  }, [fichasByKey, h.obenProducts, h.colacorProducts, h.customerPricesOben, h.customerPricesColacor]);
   const [restoreOpen, setRestoreOpen] = useState(false);
 
   // "Cores do cliente": histórico de cores + pré-preenchimento do dialog de tingir.
@@ -347,14 +366,16 @@ const UnifiedOrder = () => {
                       loading={h.loadingObenProducts} productSearch={h.productSearch} onSearchChange={h.setProductSearch}
                       productItems={h.productItems} onAddProduct={h.addProductToCart}
                       customerPurchaseHistory={h.customerPurchaseHistory} customerPricesLoading={h.loadingCustomer}
-                      specsByKey={fichasByKey} canSeeFicha={h.isStaff} />
+                      specsByKey={fichasByKey} canSeeFicha={h.isStaff}
+                      selosByKey={selosByKey} canSeeVendaAssistida={h.isStaff} />
                   </TabsContent>
                   <TabsContent value="colacor">
                     <ProductItemForm title="Produtos Colacor" products={h.filteredColacorProducts} prices={h.customerPricesColacor}
                       loading={h.loadingColacorProducts} productSearch={h.productSearch} onSearchChange={h.setProductSearch}
                       productItems={h.productItems} onAddProduct={h.addProductToCart}
                       customerPurchaseHistory={h.customerPurchaseHistory} customerPricesLoading={h.loadingCustomer}
-                      specsByKey={fichasByKey} canSeeFicha={h.isStaff} />
+                      specsByKey={fichasByKey} canSeeFicha={h.isStaff}
+                      selosByKey={selosByKey} canSeeVendaAssistida={h.isStaff} />
                   </TabsContent>
                   <TabsContent value="services">
                     <ServiceItemForm

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -72,9 +72,10 @@ const UnifiedOrder = () => {
         estoque: p.estoque ?? 0,
       });
     }
-    // Preço-do-cliente (último praticado), copiado Oben↔Colacor — merge p/ lookup por omie_codigo_produto.
-    const customerPrices = { ...h.customerPricesColacor, ...h.customerPricesOben };
-    return montarSelosVendaAssistida([...fichasByKey.values()], catalogByKey, customerPrices);
+    // Preço-do-cliente (último praticado) POR CONTA — omie_codigo_produto colide entre Oben/Colacor,
+    // então o helper lê do mapa da conta de cada SKU (não achata num Record só).
+    const customerPricesByAccount = { oben: h.customerPricesOben, colacor: h.customerPricesColacor };
+    return montarSelosVendaAssistida([...fichasByKey.values()], catalogByKey, customerPricesByAccount);
   }, [fichasByKey, h.obenProducts, h.colacorProducts, h.customerPricesOben, h.customerPricesColacor]);
   const [restoreOpen, setRestoreOpen] = useState(false);
 


### PR DESCRIPTION
## O quê
Surfacing da **venda assistida** (Fatia 2 v1): um **selo "preparado" vendedor-only** ao lado do botão Ficha de cada produto com boletim aprovado, mostrando **estado** (em estoque / encomenda / sob consulta) + **R$/litro preparado (teórico)**.

Reusa o motor da Fatia 1 (`resolverOpcaoVenda`/`montarBaseEmbalagens`, Codex-blindado) e a plumbing da casar (`specsByKey` no wizard). **Zero query nova** — resolve sobre o catálogo já carregado.

> Inclui **`montarBaseEmbalagens`**, que ficou de fora do squash do #830 (entrou no branch depois do auto-merge) e é dependência do selo.

## Fluxo
1. `specsByKey` (view `v_omie_product_current_spec`) → agrupa por **(conta, boletim)**.
2. Embalagens de cada grupo via catálogo já carregado → `montarBaseEmbalagens(rows, preço-do-cliente-por-conta)`.
3. `catalisador_codigo`/proporção do spec. **v1:** sem casamento do catalisador → degrada honesto a **"sob consulta"**.
4. `resolverOpcaoVenda` → `{estado, preco}` → espalha por SKU → `<VendaAssistidaSelo>`.

## Money-path (honestidade)
- **Nunca fabrica preço** — herda o motor (ausente → `incomplete` → "sob consulta").
- **Preço-do-cliente por conta** — `omie_codigo_produto` colide entre Oben/Colacor; nunca achata num Record só.
- **Agrupa por (conta, boletim)** — um boletim em duas contas não vaza estoque/preço de uma na outra.
- **Vendedor-only** (`isStaff`); nada pro cliente. Preço rotulado **"(teórico)"** (último praticado + maior embalagem).

## Codex adversarial (xhigh) — 2 P0 + 1 P1 fechados
- **P0** preço cross-account (auto-scan, antes do Codex) → lê preço da conta de cada SKU.
- **P0** (Codex) agrupar só por boletim misturava contas → agrupa por (conta, boletim) + teste de regressão.
- **P1** (Codex) "Encomenda" com preço incompleto → "Sob consulta" domina a apresentação.
- ⚠️ **P0 pré-existente, FORA de escopo (flag):** `useCustomerSelection.ts:534` manda o mesmo mapa de preço pras 2 contas (limitação **documentada no código**, "corrigida na Fase 2 account-aware"). Afeta o preço que o wizard **já exibe** hoje — não é introduzido pelo selo. Merece fatia própria.

## Verificação
- **4222/4222** testes (vitest), **typecheck** e **lint** 0. 12 testes novos (selo + montar-embalagens), incl. regressões dos 3 achados money-path.

## Pendente do founder
- **Popular vínculos** (boletim↔SKU no detalhe do boletim aprovado) → o selo acende com dado real.
- **Publish** após merge (merge na `main` ≠ produção).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
