### PR TITLE
fix(venda): preço-cliente account-aware no wizard (Oben/Colacor não compartilham mapa)

### DIFF
--- a/src/hooks/unifiedOrder/__tests__/precos-por-conta.test.ts
+++ b/src/hooks/unifiedOrder/__tests__/precos-por-conta.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { montarPrecosLocaisPorConta } from '../precos-por-conta';
+
+/**
+ * Regressão money-path: o preço-do-cliente (último praticado) tem de ficar
+ * CONFINADO à conta Omie onde foi praticado. Oben e Colacor são contas Omie
+ * SEPARADAS cujo `omie_codigo_produto` pode COLIDIR numericamente — achatar os
+ * dois espaços de chave num Record só (e injetar nas 2 contas) vaza o preço de
+ * uma conta no produto da outra. O `product_id` (uuid de omie_products) JÁ é
+ * account-aware; o helper preserva isso separando por `account`.
+ */
+describe('montarPrecosLocaisPorConta', () => {
+  it('colisão cross-account: mesmo omie_codigo_produto em Oben e Colacor → cada conta vê o SEU preço', () => {
+    const out = montarPrecosLocaisPorConta(
+      { 'uuid-oben': 100, 'uuid-colacor': 150 },
+      [
+        { id: 'uuid-oben', omie_codigo_produto: 123, account: 'oben' },
+        { id: 'uuid-colacor', omie_codigo_produto: 123, account: 'colacor' },
+      ],
+    );
+
+    expect(out.oben[123]).toBe(100);
+    expect(out.colacor[123]).toBe(150);
+  });
+
+  it('NÃO contamina: código praticado SÓ em Oben fica AUSENTE do mapa Colacor (ausência por chave)', () => {
+    const out = montarPrecosLocaisPorConta(
+      { 'uuid-oben': 100 },
+      [{ id: 'uuid-oben', omie_codigo_produto: 123, account: 'oben' }],
+    );
+
+    expect(out.oben[123]).toBe(100);
+    // O flatten antigo injetava o MESMO mapa nas 2 contas → out.colacor[123] === 100.
+    // Account-aware: a chave Oben NÃO existe no mapa Colacor — prova ausência por
+    // chave (tem dente contra a re-introdução do flatten), não só "valor diferente".
+    expect(123 in out.colacor).toBe(false);
+    expect(out.colacor).toEqual({});
+  });
+
+  it('códigos disjuntos (estado de hoje): cada código cai só na sua conta', () => {
+    const out = montarPrecosLocaisPorConta(
+      { 'uuid-a': 80, 'uuid-b': 200 },
+      [
+        { id: 'uuid-a', omie_codigo_produto: 10000000001, account: 'oben' },
+        { id: 'uuid-b', omie_codigo_produto: 500, account: 'colacor' },
+      ],
+    );
+
+    expect(out.oben).toEqual({ 10000000001: 80 });
+    expect(out.colacor).toEqual({ 500: 200 });
+  });
+
+  it('money-path: preço ausente/0/negativo/NaN NUNCA vira preço (não fabricar)', () => {
+    const out = montarPrecosLocaisPorConta(
+      {
+        'uuid-zero': 0,
+        'uuid-neg': -5,
+        'uuid-nan': Number.NaN,
+        // 'uuid-ausente' propositalmente sem entrada no mapa de preço
+        'uuid-ok': 42,
+      },
+      [
+        { id: 'uuid-zero', omie_codigo_produto: 1, account: 'oben' },
+        { id: 'uuid-neg', omie_codigo_produto: 2, account: 'oben' },
+        { id: 'uuid-nan', omie_codigo_produto: 3, account: 'colacor' },
+        { id: 'uuid-ausente', omie_codigo_produto: 4, account: 'colacor' },
+        { id: 'uuid-ok', omie_codigo_produto: 5, account: 'oben' },
+      ],
+    );
+
+    expect(out.oben).toEqual({ 5: 42 });
+    expect(out.colacor).toEqual({});
+  });
+
+  it('account desconhecido/null → descartado (não vaza pra nenhuma conta)', () => {
+    const out = montarPrecosLocaisPorConta(
+      { 'uuid-x': 99, 'uuid-y': 77 },
+      [
+        { id: 'uuid-x', omie_codigo_produto: 7, account: null },
+        { id: 'uuid-y', omie_codigo_produto: 8, account: 'colacor_sc' },
+      ],
+    );
+
+    expect(out.oben).toEqual({});
+    expect(out.colacor).toEqual({});
+  });
+
+  it('account tolera caixa/espaço divergente (mesma normalização do selo)', () => {
+    const out = montarPrecosLocaisPorConta(
+      { 'uuid-x': 99 },
+      [{ id: 'uuid-x', omie_codigo_produto: 7, account: 'OBEN' }],
+    );
+
+    expect(out.oben).toEqual({ 7: 99 });
+  });
+
+  it('entrada vazia → mapas vazios por conta (sem throw)', () => {
+    expect(montarPrecosLocaisPorConta({}, [])).toEqual({ oben: {}, colacor: {} });
+  });
+});

--- a/src/hooks/unifiedOrder/precos-por-conta.ts
+++ b/src/hooks/unifiedOrder/precos-por-conta.ts
@@ -1,0 +1,49 @@
+/**
+ * Preço-do-cliente (último praticado) separado POR CONTA Omie.
+ *
+ * Oben e Colacor são contas Omie SEPARADAS cujo `omie_codigo_produto` pode
+ * COLIDIR numericamente. Achatar os dois espaços de chave num `Record` só (e
+ * injetar nas 2 contas) faz o preço praticado numa conta vazar no produto de
+ * mesmo código da outra — bug money-path (preço errado na tela do vendedor) e,
+ * dentro do mesmo mapa, sobrescrita NÃO-determinística (vence quem a query
+ * devolver por último). O `product_id` (uuid de `omie_products`) JÁ é
+ * account-aware; este helper preserva isso, dividindo em um mapa por conta.
+ *
+ * Espelha a normalização de conta do selo (`montarSelosVendaAssistida`):
+ * `account` minúsculo. Puro/testável — sem React/supabase.
+ */
+
+export interface PrecosLocaisPorConta {
+  oben: Record<number, number>;
+  colacor: Record<number, number>;
+}
+
+/** Linha de `omie_products` projetada para resolver a conta de cada preço. */
+export interface ProductAccountMapping {
+  id: string;
+  omie_codigo_produto: number;
+  account: string | null;
+}
+
+export function montarPrecosLocaisPorConta(
+  /** uuid de omie_products → preço praticado (já deduplicado por product_id). */
+  precoPorProductId: Record<string, number>,
+  productMappings: ProductAccountMapping[],
+): PrecosLocaisPorConta {
+  // omie_products tem UNIQUE(omie_codigo_produto, account) — logo, por conta, cada
+  // código tem no máximo 1 product_id: a atribuição "último vence" abaixo nunca
+  // colide de fato dentro da mesma conta (o constraint garante a determinação).
+  const out: PrecosLocaisPorConta = { oben: {}, colacor: {} };
+  for (const pm of productMappings) {
+    const price = precoPorProductId[pm.id];
+    // Money-path: ausente/0/negativo/NaN/Infinity NUNCA vira preço (não fabricar).
+    // Mesmo invariante do guard de fronteira: !(Number.isFinite(p) && p > 0).
+    if (!(Number.isFinite(price) && price > 0)) continue;
+    const conta = (pm.account ?? '').trim().toLowerCase();
+    if (conta === 'oben') out.oben[pm.omie_codigo_produto] = price;
+    else if (conta === 'colacor') out.colacor[pm.omie_codigo_produto] = price;
+    // Conta desconhecida/null (ex.: 'colacor_sc') → descartada de propósito: o
+    // wizard só vende Oben e Colacor; injetar em qualquer uma vazaria preço.
+  }
+  return out;
+}

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -6,6 +6,7 @@ import { logger } from '@/lib/logger';
 import { maskDocument } from '@/lib/format';
 import { eqText, orFilter } from '@/lib/postgrest';
 import { deveCriarClienteNaConta } from './ensure-helpers';
+import { montarPrecosLocaisPorConta, type PrecosLocaisPorConta } from './precos-por-conta';
 import type {
   OmieCustomer,
   AddressData,
@@ -350,27 +351,33 @@ export function useCustomerSelection({
     if (promises.length > 0) await Promise.all(promises);
   }, []);
 
-  /** Resolve last-practiced local prices into the omie_codigo_produto map */
+  /** Resolve o último preço praticado local em DOIS mapas account-aware
+   *  (oben/colacor). O product_id (uuid de omie_products) já é por-conta;
+   *  trazemos `account` p/ NÃO achatar omie_codigo_produto (colide entre as
+   *  contas Omie) num Record único — separação em montarPrecosLocaisPorConta. */
   const resolveLocalPricesByOmieCode = useCallback(async (
     localPriceRows: Array<{ product_id: string; unit_price: number }> | null,
-  ): Promise<Record<number, number>> => {
-    if (!localPriceRows || localPriceRows.length === 0) return {};
+  ): Promise<PrecosLocaisPorConta> => {
+    if (!localPriceRows || localPriceRows.length === 0) return { oben: {}, colacor: {} };
     const localPricesByProduct: Record<string, number> = {};
     for (const row of localPriceRows) {
       if (!localPricesByProduct[row.product_id]) localPricesByProduct[row.product_id] = row.unit_price;
     }
-    const result: Record<number, number> = {};
     const productIds = Object.keys(localPricesByProduct);
-    if (productIds.length === 0) return result;
-    const { data: productMappings } = await supabase
-      .from('omie_products').select('id, omie_codigo_produto').in('id', productIds);
-    if (productMappings) {
-      for (const pm of productMappings) {
-        const price = localPricesByProduct[pm.id];
-        if (price && price > 0) result[pm.omie_codigo_produto] = price;
-      }
+    if (productIds.length === 0) return { oben: {}, colacor: {} };
+    const { data: productMappings, error } = await supabase
+      .from('omie_products').select('id, omie_codigo_produto, account').in('id', productIds);
+    // Falha do mapeamento → degrada honesto (cada conta cai p/ o preço de tabela
+    // `valor_unitario`, nunca R$0), mas deixa RASTRO: sem ele o preço-cliente
+    // sumiria silencioso mesmo com a RPC tendo retornado preços (Codex P2).
+    if (error) {
+      logger.warn('resolveLocalPricesByOmieCode: mapeamento omie_products falhou (degrada p/ preço de tabela)', {
+        stage: 'resolve_local_prices_omie_map',
+        productIdsCount: productIds.length,
+        error,
+      });
     }
-    return result;
+    return montarPrecosLocaisPorConta(localPricesByProduct, productMappings ?? []);
   }, []);
 
   // Purchase history (local + Omie) agora vem do useQuery acima
@@ -532,13 +539,14 @@ export function useCustomerSelection({
       // Fase 1: o preço-cliente = último preço praticado lido de `order_items` (FONTE DE VERDADE,
       // via RPC get_ultimos_precos_cliente — NÃO mais `sales_price_history`, poluída pelo writer
       // legado aposentado). Rápido, estável, determinístico. Sem overlay do Omie (removido p/ matar
-      // a colisão de rate-limit). O mesmo mapa local vai p/ as 2 contas — limitação pré-existente
-      // (produtos são account-aware); corrigida na Fase 2 account-aware.
-      const localPricesByOmie = await resolveLocalPricesByOmieCode(localPriceResult.data || null);
+      // a colisão de rate-limit). ACCOUNT-AWARE (Fase 2): cada conta recebe SÓ os preços praticados
+      // nela — omie_codigo_produto colide entre Oben e Colacor (contas Omie separadas), então
+      // achatar num mapa só vazaria o preço de uma conta no produto de mesmo código da outra.
+      const precosPorConta = await resolveLocalPricesByOmieCode(localPriceResult.data || null);
       if (isStale()) return;
 
-      setCustomerPricesOben({ ...localPricesByOmie });
-      setCustomerPricesColacor({ ...localPricesByOmie });
+      setCustomerPricesOben({ ...precosPorConta.oben });
+      setCustomerPricesColacor({ ...precosPorConta.colacor });
 
       if (parcelaOben.data?.ultima_parcela) setSelectedParcelaOben(parcelaOben.data.ultima_parcela);
       if (parcelaOben.data?.parcela_ranking) setCustomerParcelaRankingOben(parcelaOben.data.parcela_ranking.map((r: ParcelaRankingItem) => r.codigo));


### PR DESCRIPTION
## Problema (money-path)
O wizard de venda mostra o último-preço-praticado por produto. `resolveLocalPricesByOmieCode`
([useCustomerSelection.ts](src/hooks/unifiedOrder/useCustomerSelection.ts)) montava **um** mapa
keyed só por `omie_codigo_produto` (sem `account`) e injetava o **mesmo mapa** nas duas contas
Omie (`setCustomerPricesOben` + `setCustomerPricesColacor`). Como `omie_codigo_produto` pode
colidir entre Oben e Colacor (contas Omie separadas), o preço praticado numa conta poderia
aparecer no produto de mesmo código da outra — preço errado na tela do vendedor — além de uma
sobrescrita **não-determinística** dentro do mapa achatado (vencia quem a query devolvesse por último).

## Fix
- Helper puro `montarPrecosLocaisPorConta` → `{ oben, colacor }` pelo `account` de `omie_products`
  (o `product_id` da RPC `get_ultimos_precos_cliente` já é account-aware: FK `order_items.product_id → omie_products.id`).
- `resolveLocalPricesByOmieCode` agora seleciona `account` e cada setter recebe só o seu mapa.
- Money-path: `!(Number.isFinite(p) && p>0)` descarta 0/neg/NaN/ausente (degrada p/ `valor_unitario`, **nunca R$0**); conta desconhecida (`colacor_sc`/null) é descartada.

## Latência (honestidade)
Hoje os ranges de `omie_codigo_produto` são disjuntos (colacor 394M–5.1bi, oben 8.7bi–12bi) →
**0 colisões** → bug **latente**, não ativo. É a "Fase 2 account-aware" já antecipada no código;
`montarSelosVendaAssistida` já era account-aware (a origem era a única peça assimétrica). Guard
na origem para não depender do acidente de ranges.

## Verificação
- typecheck ✅ · lint ✅ (0 errors) · test ✅ (**4229**, inclui 7 novos do helper)
- TDD (RED→GREEN) no helper puro
- **Codex challenge adversarial**: `GATE PASS` (0 P1). 3 P2 resolvidos:
  - F1 (duplicata intra-conta) impossível por `UNIQUE(omie_codigo_produto, account)` → documentado
  - F2 (erro do select ignorado) → `logger.warn` de observabilidade (degradação honesta mantida)
  - F3 (assert fraco) → teste reforçado p/ **ausência-por-chave**

## Deploy
100% frontend → após o merge, **Publish manual no Lovable** (sem migration/edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
