### PR TITLE
feat(venda-ia): casamento do catalisador — destrava preço catalisado no selo (Fatia 3)

### DIFF
--- a/db/test-kb_catalisador_links.sh
+++ b/db/test-kb_catalisador_links.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# PROVA PG17 — migration 20260629150000_kb_catalisador_links.sql (casamento do catalisador, money-path/auth)
+#   bash db/test-kb_catalisador_links.sh > /tmp/t.log 2>&1; echo "exit=$?"
+# Lei de Ferro: aplica a migration REAL · assert negativo via efeito/SQLSTATE · falsifica cada defesa.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5466}"
+SLUG="kb_catalisador_links"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ── ZONA 1: pré-requisitos (app_role, user_roles, has_role) ──
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('employee','customer','master');
+CREATE TABLE public.user_roles (user_id uuid, role public.app_role);
+CREATE OR REPLACE FUNCTION public.has_role(p_uid uuid, p_role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $f$
+  SELECT EXISTS(SELECT 1 FROM public.user_roles WHERE user_id = p_uid AND role = p_role);
+$f$;
+SQL
+
+# ── ZONA 2: aplica a migration REAL ──
+MIG="$REPO_ROOT/supabase/migrations/20260629150000_kb_catalisador_links.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ── ZONA 3: seeds + grants ──
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),  -- não-staff
+  ('22222222-2222-2222-2222-222222222222'),  -- employee
+  ('33333333-3333-3333-3333-333333333333')   -- master
+  ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('22222222-2222-2222-2222-222222222222','employee'),
+  ('33333333-3333-3333-3333-333333333333','master');
+GRANT SELECT ON public.kb_catalisador_links, public.user_roles TO authenticated, anon;
+SQL
+
+echo "── asserts ──"
+
+# A1-A3 — normalizador consolida variantes (money-path: chave do lookup == chave da gravação)
+eq "A1 normaliza FC.6975"   "$(Pq -c "SELECT public.kb_normalizar_catalisador('FC.6975');")"   "FC6975"
+eq "A2 normaliza 'FC 6975'" "$(Pq -c "SELECT public.kb_normalizar_catalisador('FC 6975');")"   "FC6975"
+eq "A3 normaliza FC.5202.RA" "$(Pq -c "SELECT public.kb_normalizar_catalisador('FC.5202.RA');")" "FC5202RA"
+
+# A4 — master confirma FC.6975 p/ (colacor,111) → 1, grava normalizado
+V=$(P -tA <<'SQL' | tail -1
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('FC.6975', '[{"account":"colacor","omie_codigo_produto":111}]'::jsonb);
+SQL
+)
+eq "A4 confirmar retorna 1" "$V" "1"
+eq "A4b norm gravado" "$(Pq -c "SELECT catalisador_codigo_norm FROM public.kb_catalisador_links WHERE account='colacor' AND omie_codigo_produto=111;")" "FC6975"
+
+# A5 — idempotente: confirmar de novo não duplica
+P -q <<'SQL'
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('FC.6975', '[{"account":"colacor","omie_codigo_produto":111}]'::jsonb);
+SQL
+eq "A5 idempotente (1 linha)" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE account='colacor' AND omie_codigo_produto=111 AND status='confirmed';")" "1"
+
+# A6 — variante 'FC 6975' p/ (colacor,222) consolida na MESMA chave normalizada
+P -q <<'SQL'
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('FC 6975', '[{"account":"colacor","omie_codigo_produto":222}]'::jsonb);
+SQL
+eq "A6 consolida variante (2 SKUs em FC6975)" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE catalisador_codigo_norm='FC6975' AND status='confirmed';")" "2"
+
+# A7-A9 — RLS (2 confirmados): não-staff 0, staff vê tudo, anon 0
+eq "A7 não-staff não lê"  "$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.kb_catalisador_links;" | tail -1)" "0"
+eq "A8 staff lê tudo"     "$(Pq -c "SET test.uid='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated; SELECT count(*) FROM public.kb_catalisador_links;" | tail -1)" "2"
+eq "A9 anon não lê"       "$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.kb_catalisador_links;" | tail -1)" "0"
+
+# N1 — gate: employee NÃO confirma (efeito: nenhuma linha p/ 555)
+P -q <<'SQL' 2>/dev/null || true
+SET test.uid='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('FC.7777', '[{"account":"colacor","omie_codigo_produto":555}]'::jsonb);
+SQL
+eq "N1 gate nega employee (sem linha)" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE omie_codigo_produto=555;")" "0"
+
+# N2 — ≤1 catalisador por SKU: PC.2992 num SKU que já é FC6975 → falha (não vira 2 catalisadores)
+P -q <<'SQL' 2>/dev/null || true
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('PC.2992', '[{"account":"colacor","omie_codigo_produto":111}]'::jsonb);
+SQL
+eq "N2 SKU não vira 2 catalisadores" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE account='colacor' AND omie_codigo_produto=111 AND status='confirmed';")" "1"
+
+# N3 — código vazio após normalização → RAISE (efeito: nenhuma linha p/ 556)
+P -q <<'SQL' 2>/dev/null || true
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('   ', '[{"account":"colacor","omie_codigo_produto":556}]'::jsonb);
+SQL
+eq "N3 código vazio rejeitado (sem linha)" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE omie_codigo_produto=556;")" "0"
+
+# N4 — gate: employee NÃO desvincula (efeito: linha 111 continua)
+P -q <<'SQL' 2>/dev/null || true
+SET test.uid='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated;
+SELECT public.desvincular_catalisador('colacor', 111, 'FC 6975');
+SQL
+eq "N4 gate nega employee no desvincular" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE account='colacor' AND omie_codigo_produto=111 AND status='confirmed';")" "1"
+
+# N5 — anti-stale: desvincular com norm ERRADO → 0 linhas, não remove
+V=$(P -tA <<'SQL' | tail -1
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.desvincular_catalisador('colacor', 111, 'PC.2992');
+SQL
+)
+eq "N5 anti-stale retorna 0" "$V" "0"
+eq "N5b linha preservada" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE account='colacor' AND omie_codigo_produto=111 AND status='confirmed';")" "1"
+
+# A10 — desvincular correto (variante 'FC 6975' normaliza p/ FC6975) → 1, remove
+V=$(P -tA <<'SQL' | tail -1
+SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;
+SELECT public.desvincular_catalisador('colacor', 111, 'FC 6975');
+SQL
+)
+eq "A10 desvincular retorna 1" "$V" "1"
+eq "A10b linha removida (sobra só 222)" "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE catalisador_codigo_norm='FC6975' AND status='confirmed';")" "1"
+
+# ── ZONA 5: FALSIFICAÇÃO (sabota → exige vermelho → restaura) ──
+echo "── falsificação ──"
+
+# F1 — gate master: sabota (remove has_role) → employee passa a gravar (N1 tem dente)
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.confirmar_catalisador_vinculo(p_catalisador_codigo text, p_skus jsonb)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $fn$
+DECLARE v_norm text := public.kb_normalizar_catalisador(p_catalisador_codigo); v_item jsonb;
+BEGIN
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_skus) LOOP
+    INSERT INTO public.kb_catalisador_links(catalisador_codigo_norm, account, omie_codigo_produto, status)
+    VALUES (v_norm, v_item->>'account', (v_item->>'omie_codigo_produto')::bigint, 'confirmed') ON CONFLICT DO NOTHING;
+  END LOOP;
+  RETURN 1;
+END $fn$;
+SQL
+P -q <<'SQL' 2>/dev/null || true
+SET test.uid='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated;
+SELECT public.confirmar_catalisador_vinculo('FC.7777', '[{"account":"colacor","omie_codigo_produto":777}]'::jsonb);
+SQL
+case "$(Pq -c "SELECT count(*) FROM public.kb_catalisador_links WHERE omie_codigo_produto=777;")" in
+  1) ok "F1 gate furado deixou employee gravar (N1 tem dente)";;
+  *) bad "F1 sabotei o gate e nada mudou → N1 é fraco";;
+esac
+P -q -f "$MIG"; P -q -c "DELETE FROM public.kb_catalisador_links WHERE omie_codigo_produto=777;" >/dev/null
+
+# F3 — RLS: sabota a policy (USING true) → não-staff passa a ver (A7 tem dente)
+P -q <<'SQL'
+DROP POLICY IF EXISTS kb_catalisador_links_select_staff ON public.kb_catalisador_links;
+CREATE POLICY kb_catalisador_links_select_staff ON public.kb_catalisador_links FOR SELECT USING (true);
+SQL
+case "$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.kb_catalisador_links;" | tail -1)" in
+  0) bad "F3 furei a RLS e não-staff AINDA vê 0 → A7 é fraco";;
+  *) ok "F3 RLS furada vazou p/ não-staff (A7 tem dente)";;
+esac
+P -q -f "$MIG"
+
+# F4 — normalizador: sabota (só upper, sem strip) → 'FC 6975' != 'FC6975' (A2 tem dente)
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.kb_normalizar_catalisador(p text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $f$ SELECT upper(coalesce(p,'')); $f$;
+SQL
+case "$(Pq -c "SELECT public.kb_normalizar_catalisador('FC 6975');")" in
+  FC6975) bad "F4 sabotei o normalizador e ainda deu FC6975 → A2 é fraco";;
+  *) ok "F4 normalizador furado não consolida 'FC 6975' (A2 tem dente)";;
+esac
+P -q -f "$MIG"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **315** custom migrations totais
-- **1061** objetos esperados (criados por estas migrations)
+- **316** custom migrations totais
+- **1069** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 311
-  - `rls_policy`: 227
-  - `index`: 190
-  - `table`: 112
+  - `function`: 314
+  - `rls_policy`: 228
+  - `index`: 193
+  - `table`: 113
   - `cron_job`: 110
   - `view`: 55
   - `trigger`: 52
@@ -2640,6 +2640,19 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.reposicao_pedido_auto_aprovavel` | — |
 | `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
+
+### `20260629150000_kb_catalisador_links.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.kb_normalizar_catalisador` | — |
+| `function` | `public.confirmar_catalisador_vinculo` | — |
+| `function` | `public.desvincular_catalisador` | — |
+| `table` | `public.kb_catalisador_links` | — |
+| `index` | `public.kb_catalisador_links_one_confirmed` | `kb_catalisador_links` |
+| `index` | `public.kb_catalisador_links_unique_quad` | `kb_catalisador_links` |
+| `index` | `public.kb_catalisador_links_norm` | `kb_catalisador_links` |
+| `rls_policy` | `public.kb_catalisador_links_select_staff` | `kb_catalisador_links` |
 
 ## Próximos passos por status
 

--- a/docs/superpowers/plans/2026-06-29-venda-assistida-catalisador-casamento.md
+++ b/docs/superpowers/plans/2026-06-29-venda-assistida-catalisador-casamento.md
@@ -1,0 +1,46 @@
+# Venda assistida — Casamento do catalisador (destrava preço catalisado)
+
+> Fatia escolhida pelo founder (2026-06-29). Destrava o preço CATALISADO no selo (hoje degrada a "sob consulta").
+> Design do programa: `docs/superpowers/specs/2026-06-14-venda-assistida-ia-design.md`. Selo v1: PR #1135.
+
+## Problema (dado real de produção)
+`catalisador_codigo` em `kb_product_specs` é texto SUJO: um catalisador serve muitos boletins (FC.6975 = 13);
+há variantes de separador (`FC.6975` vs `FC 6975`, `YC.1401` vs `YC 1401`); e multi-código/free-text
+(`FC.6930 ou FC.7090`, `FCA.7002 (...50%), FCA.7077 (...35%), ...`). A `buscar_skus_candidatos` busca só na
+**descrição** do `omie_products`.
+
+## Decisões do founder (2026-06-29)
+- **Chave NORMALIZADA:** `UPPER + só alfanumérico` (`FC.6975`→`FC6975`, `FC 6975`→`FC6975`). Variantes consolidam;
+  multi-código/free-text normaliza pra algo que não casa SKU → **"sob consulta" honesto** (v1 não parseia o monstro).
+- **UI no detalhe do boletim:** painel irmão do vínculo da base; mostra o catalisador do boletim + status + busca-e-aprova.
+  Grava no mapa **GLOBAL** (serve todos os boletins com aquele código). Master-gated, "eu sugiro, você aprova".
+
+## Modelo de dados (simétrico à casar da base)
+- O catalisador tem embalagens (GL/QT/BH…) = vários SKUs, igual à base → o mapa é **(conta, omie_codigo_produto) → código normalizado**.
+- **Tabela `kb_catalisador_links`**: `catalisador_codigo_norm text`, `account text`, `omie_codigo_produto bigint`,
+  `status ('confirmed'|'rejected')`, `confirmed_by`, timestamps. Unique confirmado em **(account, omie_codigo_produto)**
+  (≤1 catalisador por SKU; muitos SKUs por catalisador — espelha `omie_product_spec_links`). RLS SELECT staff.
+- **Fn `kb_normalizar_catalisador(text)`** IMMUTABLE: `upper(regexp_replace(p,'[^a-zA-Z0-9]','','g'))`.
+- **RPCs (master-gated, SECURITY DEFINER):** `confirmar_catalisador_vinculo(p_catalisador_codigo text, p_skus jsonb)`
+  (normaliza + upsert confirmado) · `desvincular_catalisador(p_account, p_omie_codigo_produto, p_expected_norm)` (anti-stale).
+- Reusa `buscar_skus_candidatos` pra achar os SKUs do catalisador (busca por descrição).
+
+## Ligação no selo
+Por grupo **(conta, boletim)**: normaliza `boletim.catalisador_codigo` → busca os SKUs confirmados em `kb_catalisador_links`
+para (norm, conta) → `montarBaseEmbalagens(catalisadorRows, preços-da-conta)` → `catalisadorEmbalagens` →
+`resolverOpcaoVenda`. Sem mapa → `catalisadorEmbalagens: []` → "sob consulta" (como hoje).
+
+## Money-path
+- Nunca fabrica preço (herda o motor). Catalisador obrigatório sem casamento/sem preço/sem litros → `incomplete` → "sob consulta".
+- Normalização IMMUTABLE e usada NOS DOIS lados (gravação e lookup) — chave consistente.
+- Aprovação master-gated no servidor (RPC), não confiar no gate do front.
+
+## Fatias
+1. **Migration** (`kb_catalisador_links` + fn normaliza + 2 RPCs + RLS) — prove-sql PG17 (falsificado) + lovable-db-operator (paste no SQL Editor).
+2. **Hooks** (`useCatalisadorLinksMap` global + `useConfirmar/DesvincularCatalisador`) — `as never` (não editar types.ts).
+3. **UI** painel no detalhe do boletim (irmão do `SpecLinkPanel`), master-only, lente-aware.
+4. **Ligar no selo** (`montarSelosVendaAssistida` passa a alimentar `catalisadorEmbalagens`).
+
+## Deferido
+- Multi-catalisador por substrato + markup-pra-migração ("tabela de catálise") — o monstro free-text.
+- Estender `buscar_skus_candidatos` pra buscar por `codigo` (hoje só descrição) se a cobertura ficar baixa.

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 315
+-- Total de custom migrations: 316
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -356,7 +356,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260627190000', 'reposicao_fase2_badge_oportunidade_mv', '20260627190000_reposicao_fase2_badge_oportunidade_mv.sql'),
   ('20260627200000', 'fix_refresh_sku_ranking_gate_cron', '20260627200000_fix_refresh_sku_ranking_gate_cron.sql'),
   ('20260629120000', 'seg_customer_metrics_viewgate', '20260629120000_seg_customer_metrics_viewgate.sql'),
-  ('20260629140000', 'reposicao_preco_ausente_null', '20260629140000_reposicao_preco_ausente_null.sql')
+  ('20260629140000', 'reposicao_preco_ausente_null', '20260629140000_reposicao_preco_ausente_null.sql'),
+  ('20260629150000', 'kb_catalisador_links', '20260629150000_kb_catalisador_links.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1406,7 +1407,15 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('seg_customer_metrics_viewgate', 'function', 'public', 'refresh_customer_metrics', ''),
   ('seg_customer_metrics_viewgate', 'view', 'public', 'customer_metrics_mv', ''),
   ('reposicao_preco_ausente_null', 'function', 'public', 'reposicao_pedido_auto_aprovavel', ''),
-  ('reposicao_preco_ausente_null', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
+  ('reposicao_preco_ausente_null', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('kb_catalisador_links', 'function', 'public', 'kb_normalizar_catalisador', ''),
+  ('kb_catalisador_links', 'function', 'public', 'confirmar_catalisador_vinculo', ''),
+  ('kb_catalisador_links', 'function', 'public', 'desvincular_catalisador', ''),
+  ('kb_catalisador_links', 'table', 'public', 'kb_catalisador_links', ''),
+  ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_one_confirmed', 'kb_catalisador_links'),
+  ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_unique_quad', 'kb_catalisador_links'),
+  ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_norm', 'kb_catalisador_links'),
+  ('kb_catalisador_links', 'rls_policy', 'public', 'kb_catalisador_links_select_staff', 'kb_catalisador_links')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2504,7 +2513,15 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('seg_customer_metrics_viewgate', 'function', 'public', 'refresh_customer_metrics', ''),
   ('seg_customer_metrics_viewgate', 'view', 'public', 'customer_metrics_mv', ''),
   ('reposicao_preco_ausente_null', 'function', 'public', 'reposicao_pedido_auto_aprovavel', ''),
-  ('reposicao_preco_ausente_null', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
+  ('reposicao_preco_ausente_null', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('kb_catalisador_links', 'function', 'public', 'kb_normalizar_catalisador', ''),
+  ('kb_catalisador_links', 'function', 'public', 'confirmar_catalisador_vinculo', ''),
+  ('kb_catalisador_links', 'function', 'public', 'desvincular_catalisador', ''),
+  ('kb_catalisador_links', 'table', 'public', 'kb_catalisador_links', ''),
+  ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_one_confirmed', 'kb_catalisador_links'),
+  ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_unique_quad', 'kb_catalisador_links'),
+  ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_norm', 'kb_catalisador_links'),
+  ('kb_catalisador_links', 'rls_policy', 'public', 'kb_catalisador_links_select_staff', 'kb_catalisador_links')
 )
 SELECT
   e.migration,

--- a/src/components/knowledge-base/CatalisadorLinkPanel.tsx
+++ b/src/components/knowledge-base/CatalisadorLinkPanel.tsx
@@ -1,0 +1,186 @@
+import { useState, useMemo } from 'react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Loader2, FlaskConical, Unlink } from 'lucide-react';
+import { toast } from 'sonner';
+import { useBuscarSkusCandidatos } from '@/hooks/useProductSpecLink';
+import {
+  useCatalisadorLinks,
+  useConfirmarCatalisador,
+  useDesvincularCatalisador,
+} from '@/hooks/useCatalisadorLink';
+import { keyDeSku, type SkuCandidato } from '@/lib/knowledge-base/spec-link';
+
+interface Props {
+  /** catalisador_codigo cru do boletim (ex.: 'FC.6975' / 'FC 6975'). */
+  catalisadorCodigo: string;
+  disabled?: boolean;
+}
+
+/**
+ * Painel master-only para casar o catalisador do boletim ↔ SKU(s) Omie.
+ * Grava no mapa GLOBAL (kb_catalisador_links, normalizado) → serve todos os boletins com o mesmo
+ * código. Montado no detalhe do boletim, irmão do SpecLinkPanel da base.
+ */
+export function CatalisadorLinkPanel({ catalisadorCodigo, disabled }: Props) {
+  const [termo, setTermo] = useState(catalisadorCodigo ?? '');
+  const [candidatos, setCandidatos] = useState<SkuCandidato[]>([]);
+  const [selecionados, setSelecionados] = useState<Set<string>>(new Set());
+
+  const buscar = useBuscarSkusCandidatos();
+  const confirmar = useConfirmarCatalisador();
+  const desvincular = useDesvincularCatalisador();
+  const { links, norm, isLoading } = useCatalisadorLinks(catalisadorCodigo);
+
+  const linksSet = useMemo(
+    () => new Set(links.map((l) => keyDeSku(l.account, l.omie_codigo_produto))),
+    [links],
+  );
+  const selecionadosNaoVinculados = [...selecionados].filter((k) => !linksSet.has(k)).length;
+
+  const toggle = (key: string) => {
+    setSelecionados((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const handleBuscar = async () => {
+    const t = termo.trim();
+    if (!t) return;
+    const result = await buscar.mutateAsync([t]);
+    setCandidatos(result);
+    setSelecionados(new Set());
+  };
+
+  const handleConfirmar = async () => {
+    const skus = candidatos
+      .filter(
+        (c) =>
+          selecionados.has(keyDeSku(c.account, c.omie_codigo_produto)) &&
+          !linksSet.has(keyDeSku(c.account, c.omie_codigo_produto)),
+      )
+      .map((c) => ({ account: c.account, omie_codigo_produto: c.omie_codigo_produto }));
+    if (skus.length === 0) return;
+    const count = await confirmar.mutateAsync({ codigo: catalisadorCodigo, skus });
+    if (count > 0) toast.success(`${count} SKU(s) de catalisador casado(s).`);
+    setSelecionados(new Set());
+    setCandidatos([]);
+  };
+
+  return (
+    <Card className="p-3 space-y-2">
+      <div className="flex items-center gap-2">
+        <FlaskConical className="w-4 h-4 text-muted-foreground" />
+        <span className="text-sm font-medium">Catalisador</span>
+        <Badge variant="outline" className="text-2xs font-mono">{catalisadorCodigo}</Badge>
+        {norm && norm !== catalisadorCodigo && (
+          <span className="text-2xs text-muted-foreground">norm: {norm}</span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />
+      ) : links.length === 0 ? (
+        <p className="text-2xs text-muted-foreground">
+          Catalisador ainda não casado — a venda mostra "sob consulta" até vincular o SKU.
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {links.map((l) => {
+            const key = keyDeSku(l.account, l.omie_codigo_produto);
+            return (
+              <li key={key} className="flex items-center gap-1.5 text-2xs">
+                <Badge variant="outline" className="text-2xs">{l.account}</Badge>
+                <span className="font-mono">{l.codigo ?? l.omie_codigo_produto}</span>
+                <span className="text-muted-foreground truncate max-w-[200px]">{l.descricao ?? '—'}</span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="ml-auto h-5 px-1 text-2xs gap-1"
+                  disabled={disabled || desvincular.isPending}
+                  onClick={() =>
+                    desvincular.mutate({
+                      account: l.account,
+                      omie_codigo_produto: l.omie_codigo_produto,
+                      expectedNorm: norm,
+                    })
+                  }
+                >
+                  <Unlink className="w-3 h-3" />
+                  Desvincular
+                </Button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="border-t border-border pt-2 space-y-2">
+        <p className="text-2xs font-medium text-muted-foreground">Casar SKU do catalisador</p>
+        <div className="flex gap-1.5">
+          <Input
+            value={termo}
+            onChange={(e) => setTermo(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleBuscar();
+            }}
+            placeholder="Código ou descrição do catalisador"
+            className="text-xs h-7"
+            disabled={disabled || buscar.isPending}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-7 text-xs"
+            onClick={() => void handleBuscar()}
+            disabled={disabled || buscar.isPending || !termo.trim()}
+          >
+            {buscar.isPending ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Buscar'}
+          </Button>
+        </div>
+
+        {candidatos.length > 0 && (
+          <ul className="space-y-1 max-h-40 overflow-y-auto">
+            {candidatos.map((c) => {
+              const key = keyDeSku(c.account, c.omie_codigo_produto);
+              const jaVinculado = linksSet.has(key);
+              return (
+                <li key={key} className="flex items-center gap-1.5 text-2xs">
+                  <Checkbox
+                    checked={jaVinculado || selecionados.has(key)}
+                    disabled={disabled || jaVinculado}
+                    onCheckedChange={() => toggle(key)}
+                  />
+                  <Badge variant="outline" className="text-2xs">{c.account}</Badge>
+                  <span className="font-mono">{c.codigo ?? c.omie_codigo_produto}</span>
+                  <span className="text-muted-foreground truncate max-w-[160px]">{c.descricao ?? '—'}</span>
+                  {jaVinculado && (
+                    <Badge variant="secondary" className="text-2xs ml-auto shrink-0">já vinculado</Badge>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {candidatos.length > 0 && (
+          <Button
+            size="sm"
+            className="h-7 text-xs gap-1.5"
+            onClick={() => void handleConfirmar()}
+            disabled={disabled || confirmar.isPending || selecionadosNaoVinculados === 0}
+          >
+            {confirmar.isPending && <Loader2 className="w-3 h-3 animate-spin" />}
+            Casar catalisador ({selecionadosNaoVinculados})
+          </Button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/src/hooks/useCatalisadorLink.ts
+++ b/src/hooks/useCatalisadorLink.ts
@@ -45,16 +45,27 @@ export function useCatalisadorLinksMap() {
   const { data, isLoading } = useQuery<MapRow[]>({
     queryKey: ['kb-catalisador-map'],
     staleTime: 5 * 60_000,
-    queryFn: async () => {
-      const { data: rows, error } = (await supabase
-        .from('kb_catalisador_links' as never)
-        .select('catalisador_codigo_norm, account, omie_codigo_produto')
-        .eq('status', 'confirmed')) as {
-        data: MapRow[] | null;
-        error: { message: string } | null;
-      };
-      if (error) throw new Error(error.message);
-      return rows ?? [];
+    queryFn: async (): Promise<MapRow[]> => {
+      // Pagina (PostgREST capa em 1000 linhas SILENCIOSO — database.md): sem isto, vínculos além da
+      // 1ª página somem do mapa e o selo degrada a "sob consulta" mesmo com casamento (Codex P1).
+      const PAGE = 1000;
+      const all: MapRow[] = [];
+      for (let from = 0; ; from += PAGE) {
+        const { data: rows, error } = (await supabase
+          .from('kb_catalisador_links' as never)
+          .select('catalisador_codigo_norm, account, omie_codigo_produto')
+          .eq('status', 'confirmed')
+          .order('id')
+          .range(from, from + PAGE - 1)) as {
+          data: MapRow[] | null;
+          error: { message: string } | null;
+        };
+        if (error) throw new Error(error.message);
+        const batch = rows ?? [];
+        all.push(...batch);
+        if (batch.length < PAGE) break;
+      }
+      return all;
     },
   });
 

--- a/src/hooks/useCatalisadorLink.ts
+++ b/src/hooks/useCatalisadorLink.ts
@@ -1,0 +1,193 @@
+/**
+ * Hooks de dados para o casamento catalisador_codigo (normalizado) ↔ SKU Omie — venda assistida Fatia 3.
+ *
+ *  1. useCatalisadorLinksMap   — mapa GLOBAL (todos os confirmados) p/ o selo: keyDeCatalisador → SKUs
+ *  2. useCatalisadorLinks      — links de UM código (com nome/código do omie_products) p/ a UI do detalhe
+ *  3. useConfirmarCatalisador  — confirmar casamento (master)
+ *  4. useDesvincularCatalisador— remover um SKU do catalisador (master, anti-stale)
+ *
+ * Busca de candidatos: reusa `useBuscarSkusCandidatos` de useProductSpecLink (mesma RPC).
+ * ⚠️ Tabela/RPCs novas NÃO estão no types.ts → cast `as never` (lição §10 — não editar types.ts).
+ */
+
+import { useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  normalizarCatalisador,
+  keyDeCatalisador,
+  type CatalisadorLink,
+} from '@/lib/knowledge-base/catalisador-link';
+
+type RpcFn = typeof supabase.rpc;
+
+interface MapRow {
+  catalisador_codigo_norm: string;
+  account: string;
+  omie_codigo_produto: number;
+}
+interface LinkRow {
+  account: string;
+  omie_codigo_produto: number;
+}
+interface ProdutoRow {
+  account: string;
+  omie_codigo_produto: number;
+  codigo: string;
+  descricao: string;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. useCatalisadorLinksMap — mapa global p/ o selo da venda assistida
+// ─────────────────────────────────────────────────────────────────────────────
+export function useCatalisadorLinksMap() {
+  const { data, isLoading } = useQuery<MapRow[]>({
+    queryKey: ['kb-catalisador-map'],
+    staleTime: 5 * 60_000,
+    queryFn: async () => {
+      const { data: rows, error } = (await supabase
+        .from('kb_catalisador_links' as never)
+        .select('catalisador_codigo_norm, account, omie_codigo_produto')
+        .eq('status', 'confirmed')) as {
+        data: MapRow[] | null;
+        error: { message: string } | null;
+      };
+      if (error) throw new Error(error.message);
+      return rows ?? [];
+    },
+  });
+
+  const byKey = useMemo(() => {
+    const m = new Map<string, number[]>();
+    for (const r of data ?? []) {
+      const k = keyDeCatalisador(r.catalisador_codigo_norm, r.account);
+      const arr = m.get(k);
+      if (arr) arr.push(r.omie_codigo_produto);
+      else m.set(k, [r.omie_codigo_produto]);
+    }
+    return m;
+  }, [data]);
+
+  return { byKey, isLoading };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. useCatalisadorLinks — links de UM código (p/ a UI do detalhe do boletim)
+// ─────────────────────────────────────────────────────────────────────────────
+export function useCatalisadorLinks(codigoRaw?: string | null) {
+  const norm = normalizarCatalisador(codigoRaw);
+  const {
+    data: links = [],
+    isLoading,
+    refetch,
+  } = useQuery<CatalisadorLink[]>({
+    queryKey: ['kb-catalisador-links', norm],
+    enabled: norm !== '',
+    queryFn: async (): Promise<CatalisadorLink[]> => {
+      const { data: linkRows, error: linkErr } = (await supabase
+        .from('kb_catalisador_links' as never)
+        .select('account, omie_codigo_produto')
+        .eq('catalisador_codigo_norm', norm)
+        .eq('status', 'confirmed')) as {
+        data: LinkRow[] | null;
+        error: { message: string } | null;
+      };
+      if (linkErr) throw new Error(linkErr.message);
+      if (!linkRows || linkRows.length === 0) return [];
+
+      const codes = linkRows.map((r) => r.omie_codigo_produto);
+      const { data: prodRows, error: prodErr } = (await supabase
+        .from('omie_products')
+        .select('account, omie_codigo_produto, codigo, descricao')
+        .in('omie_codigo_produto', codes)) as unknown as {
+        data: ProdutoRow[] | null;
+        error: { message: string } | null;
+      };
+      if (prodErr) throw new Error(prodErr.message);
+
+      const prodMap = new Map<string, ProdutoRow>();
+      for (const p of prodRows ?? []) {
+        prodMap.set(keyDeCatalisador(String(p.omie_codigo_produto), p.account), p);
+      }
+      return linkRows.map((l): CatalisadorLink => {
+        const match = prodMap.get(keyDeCatalisador(String(l.omie_codigo_produto), l.account));
+        return {
+          catalisador_codigo_norm: norm,
+          account: l.account,
+          omie_codigo_produto: l.omie_codigo_produto,
+          codigo: match?.codigo ?? null,
+          descricao: match?.descricao ?? null,
+        };
+      });
+    },
+  });
+
+  return { links, norm, isLoading, refetch };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. useConfirmarCatalisador — gravar o casamento (master)
+// ─────────────────────────────────────────────────────────────────────────────
+interface ConfirmarArgs {
+  codigo: string;
+  skus: { account: string; omie_codigo_produto: number }[];
+}
+export function useConfirmarCatalisador() {
+  const queryClient = useQueryClient();
+  return useMutation<number, Error, ConfirmarArgs>({
+    mutationFn: async ({ codigo, skus }: ConfirmarArgs) => {
+      const { data, error } = (await (supabase.rpc as RpcFn)(
+        'confirmar_catalisador_vinculo' as never,
+        { p_catalisador_codigo: codigo, p_skus: skus } as never,
+      )) as { data: number | null; error: { message: string } | null };
+      if (error) throw new Error(error.message);
+      return data ?? 0;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['kb-catalisador-links'] });
+      queryClient.invalidateQueries({ queryKey: ['kb-catalisador-map'] });
+    },
+    onError: (e) => {
+      toast.error(e instanceof Error ? e.message : 'Falha ao casar o catalisador');
+    },
+  });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. useDesvincularCatalisador — remover um SKU do catalisador (master, anti-stale)
+// ─────────────────────────────────────────────────────────────────────────────
+interface DesvincularArgs {
+  account: string;
+  omie_codigo_produto: number;
+  expectedNorm: string;
+}
+export function useDesvincularCatalisador() {
+  const queryClient = useQueryClient();
+  return useMutation<number, Error, DesvincularArgs>({
+    mutationFn: async ({ account, omie_codigo_produto, expectedNorm }: DesvincularArgs) => {
+      const { data, error } = (await (supabase.rpc as RpcFn)(
+        'desvincular_catalisador' as never,
+        {
+          p_account: account,
+          p_omie_codigo_produto: omie_codigo_produto,
+          p_expected_norm: expectedNorm,
+        } as never,
+      )) as { data: number | null; error: { message: string } | null };
+      if (error) throw new Error(error.message);
+      return data ?? 0;
+    },
+    onSuccess: (deleted) => {
+      if (deleted === 0) {
+        toast.message('Nada mudou (talvez já tenha sido reatribuído).');
+      } else {
+        toast.success('Catalisador desvinculado.');
+      }
+      queryClient.invalidateQueries({ queryKey: ['kb-catalisador-links'] });
+      queryClient.invalidateQueries({ queryKey: ['kb-catalisador-map'] });
+    },
+    onError: (e) => {
+      toast.error(e instanceof Error ? e.message : 'Falha ao desvincular o catalisador');
+    },
+  });
+}

--- a/src/lib/knowledge-base/__tests__/catalisador-link.test.ts
+++ b/src/lib/knowledge-base/__tests__/catalisador-link.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { normalizarCatalisador, keyDeCatalisador } from '../catalisador-link';
+
+describe('normalizarCatalisador (espelha o SQL kb_normalizar_catalisador)', () => {
+  it('UPPER + tira separadores → consolida variantes', () => {
+    expect(normalizarCatalisador('FC.6975')).toBe('FC6975');
+    expect(normalizarCatalisador('FC 6975')).toBe('FC6975'); // variante de espaço
+    expect(normalizarCatalisador('fc.6975')).toBe('FC6975'); // minúsculo
+    expect(normalizarCatalisador('FC.5202.RA')).toBe('FC5202RA');
+  });
+
+  it('vazio/whitespace/null/undefined → ""', () => {
+    expect(normalizarCatalisador('')).toBe('');
+    expect(normalizarCatalisador('   ')).toBe('');
+    expect(normalizarCatalisador(null)).toBe('');
+    expect(normalizarCatalisador(undefined)).toBe('');
+  });
+
+  it('multi-código/free-text normaliza pra algo que não casa SKU (degrada a sob consulta)', () => {
+    expect(normalizarCatalisador('FC.6930 ou FC.7090')).toBe('FC6930OUFC7090');
+  });
+});
+
+describe('keyDeCatalisador', () => {
+  it('chave estável (norm|conta minúscula)', () => {
+    expect(keyDeCatalisador('FC6975', 'colacor')).toBe('FC6975|colacor');
+    expect(keyDeCatalisador('FC6975', 'OBEN')).toBe('FC6975|oben');
+  });
+});

--- a/src/lib/knowledge-base/catalisador-link.ts
+++ b/src/lib/knowledge-base/catalisador-link.ts
@@ -1,0 +1,35 @@
+/**
+ * Helper puro + tipos para o casamento catalisador_codigo ↔ SKU Omie (venda assistida — Fatia 3).
+ *
+ * Contratos de backend (migration 20260629150000_kb_catalisador_links.sql, já em prod):
+ *   - Tabela `kb_catalisador_links` (staff SELECT) — (catalisador_codigo_norm, account, omie_codigo_produto)
+ *   - Fn `kb_normalizar_catalisador(text)` IMMUTABLE — UPPER + só alfanumérico
+ *   - RPC `confirmar_catalisador_vinculo(p_catalisador_codigo text, p_skus jsonb)` → int (master)
+ *   - RPC `desvincular_catalisador(p_account text, p_omie_codigo_produto bigint, p_expected_norm text)` → int (master)
+ *
+ * ⚠️ View/tabela/RPCs novas NÃO estão no types.ts gerado → cast `as never` nos callsites.
+ */
+
+/**
+ * Espelha o SQL `public.kb_normalizar_catalisador`: UPPER + só alfanumérico.
+ * ⚠️ TEM que casar byte-a-byte com a fn SQL — a chave GRAVADA (no confirmar) e a chave do
+ * LOOKUP (no selo) passam por aqui; divergir vazaria/perderia o casamento (money-path).
+ * `FC.6975` e `FC 6975` → `FC6975`. Multi-código/free-text → algo que não casa SKU → "sob consulta".
+ */
+export function normalizarCatalisador(codigo: string | null | undefined): string {
+  return (codigo ?? '').replace(/[^a-zA-Z0-9]/g, '').toUpperCase();
+}
+
+/** Chave estável do mapa de catalisador: `norm|conta` (conta minúscula). */
+export function keyDeCatalisador(norm: string, account: string | null | undefined): string {
+  return `${norm}|${(account ?? '').toLowerCase()}`;
+}
+
+/** Linha do merge kb_catalisador_links ↔ omie_products (codigo/descricao = null se SKU sumiu). */
+export interface CatalisadorLink {
+  catalisador_codigo_norm: string;
+  account: string;
+  omie_codigo_produto: number;
+  codigo: string | null;
+  descricao: string | null;
+}

--- a/src/lib/venda-assistida/__tests__/selos.test.ts
+++ b/src/lib/venda-assistida/__tests__/selos.test.ts
@@ -3,6 +3,7 @@ import { montarSelosVendaAssistida, descreverSelo } from '../selos';
 import { resolverOpcaoVenda } from '../resolver-opcao';
 import type { ProdutoLinhaOmie } from '../montar-embalagens';
 import { keyDeSku, type CurrentSpec } from '@/lib/knowledge-base/spec-link';
+import { keyDeCatalisador } from '@/lib/knowledge-base/catalisador-link';
 
 // ── factories ────────────────────────────────────────────────────────────────
 const spec = (
@@ -41,6 +42,14 @@ const catalog = (
   for (const { account, row: r } of entries) {
     m.set(keyDeSku(account, r.omie_codigo_produto), r);
   }
+  return m;
+};
+
+const catLinks = (
+  ...entries: { norm: string; account: string; skus: number[] }[]
+): Map<string, number[]> => {
+  const m = new Map<string, number[]>();
+  for (const e of entries) m.set(keyDeCatalisador(e.norm, e.account), e.skus);
   return m;
 };
 
@@ -155,6 +164,45 @@ describe('montarSelosVendaAssistida', () => {
 
   it('lista vazia → Map vazio', () => {
     expect(montarSelosVendaAssistida([], catalog(), {}).size).toBe(0);
+  });
+
+  it('catalisador mapeado → preço CATALISADO fecha (não "sob consulta")', () => {
+    const specs = [
+      spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B',
+             catalisador_codigo: 'FC.6975', catalisador_proporcao_pct: 10 }),
+    ];
+    const cat = catalog(
+      { account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) },     // base GL → 100/L, em estoque
+      { account: 'colacor', row: row(50, 'CATALISADOR FL.6269.02GL', 180, 5) },  // catalisador GL → 50/L, em estoque
+    );
+    const links = catLinks({ norm: 'FC6975', account: 'colacor', skus: [50] });
+    const s = montarSelosVendaAssistida(specs, cat, {}, links).get(keyDeSku('colacor', 1));
+    expect(s?.estado).toBe('SELLABLE_NOW');
+    expect(s?.preco.status).toBe('ok'); // catalisado fecha, não "sob consulta"
+  });
+
+  it('catalisador NÃO mapeado → continua "sob consulta"', () => {
+    const specs = [
+      spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B',
+             catalisador_codigo: 'FC.6975', catalisador_proporcao_pct: 10 }),
+    ];
+    const cat = catalog({ account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) });
+    const s = montarSelosVendaAssistida(specs, cat, {}, new Map()).get(keyDeSku('colacor', 1));
+    expect(s?.preco.status).toBe('incomplete');
+  });
+
+  it('variante "FC 6975" no boletim casa o catalisador via normalização', () => {
+    const specs = [
+      spec({ account: 'colacor', omie_codigo_produto: 1, kb_product_spec_id: 'B',
+             catalisador_codigo: 'FC 6975', catalisador_proporcao_pct: 10 }),
+    ];
+    const cat = catalog(
+      { account: 'colacor', row: row(1, 'PRIMER PU FL.6269.02GL', 360, 5) },
+      { account: 'colacor', row: row(50, 'CATALISADOR FL.6269.02GL', 180, 5) },
+    );
+    const links = catLinks({ norm: 'FC6975', account: 'colacor', skus: [50] });
+    const s = montarSelosVendaAssistida(specs, cat, {}, links).get(keyDeSku('colacor', 1));
+    expect(s?.preco.status).toBe('ok'); // 'FC 6975' → FC6975 → casa
   });
 });
 

--- a/src/lib/venda-assistida/selos.ts
+++ b/src/lib/venda-assistida/selos.ts
@@ -1,6 +1,7 @@
 import { keyDeSku, type CurrentSpec } from '@/lib/knowledge-base/spec-link';
+import { normalizarCatalisador, keyDeCatalisador } from '@/lib/knowledge-base/catalisador-link';
 import { montarBaseEmbalagens, type ProdutoLinhaOmie } from './montar-embalagens';
-import { resolverOpcaoVenda, type OpcaoResolvida } from './resolver-opcao';
+import { resolverOpcaoVenda, type OpcaoResolvida, type EmbalagemComEstoque } from './resolver-opcao';
 
 /**
  * Selo "preparado" por produto no wizard — Fatia 2 v1 da venda assistida.
@@ -10,8 +11,8 @@ import { resolverOpcaoVenda, type OpcaoResolvida } from './resolver-opcao';
  * pronto pro lookup por produto no ProductItemForm (igual ao `specsByKey` da ficha).
  *
  * PURO/testável. Reusa o catálogo já carregado pelo wizard (sem query nova).
- * **v1:** catalisador sem casamento → `catalisadorEmbalagens: []` → o motor degrada
- * honesto a "sob consulta" (nunca fabrica preço).
+ * O catalisador é resolvido pelo mapa de casamento (kb_catalisador_links, normalizado); sem
+ * casamento → `catalisadorEmbalagens: []` → o motor degrada honesto a "sob consulta" (nunca fabrica).
  */
 
 export type SeloTone = 'success' | 'warning' | 'muted';
@@ -29,6 +30,8 @@ export function montarSelosVendaAssistida(
   catalogByKey: Map<string, ProdutoLinhaOmie>,
   /** Preço-do-cliente (último praticado) POR CONTA: account (minúsculo) → omie_codigo_produto → preço. */
   customerPricesByAccount: Record<string, Record<number, number>>,
+  /** Casamento do catalisador: `keyDeCatalisador(norm, account)` → omie_codigo_produto[] (SKUs do catalisador). */
+  catalisadorLinksByKey: Map<string, number[]> = new Map(),
 ): Map<string, OpcaoResolvida> {
   // Agrupa por (CONTA, boletim): um boletim pode estar vinculado a SKU Oben E Colacor (mesmo produto
   // via os dois distribuidores). Resolver junto mostraria o estoque/preço de uma conta no produto da
@@ -46,32 +49,42 @@ export function montarSelosVendaAssistida(
     const ref = grupoSpecs[0];
     if (!ref) continue;
 
-    // Embalagens da base = linhas do catálogo dos SKUs vinculados (ignora SKU fora do catálogo).
-    // Preço-do-cliente POR CONTA: omie_codigo_produto colide entre Oben e Colacor (Omie accounts
-    // separados) → nunca achatar num Record só; lê do mapa da conta de CADA SKU.
+    // Grupo é (conta, boletim) → conta ÚNICA → usa o mapa de preço DAQUELA conta (omie_codigo_produto
+    // colide entre Oben/Colacor; escopar por conta evita o vazamento cross-account).
+    const accountPrices = customerPricesByAccount[(ref.account ?? '').toLowerCase()] ?? {};
+
+    // Embalagens da BASE = linhas do catálogo dos SKUs vinculados (ignora SKU fora do catálogo).
     const rows: ProdutoLinhaOmie[] = [];
-    const pricesForBoletim: Record<number, number> = {};
     for (const s of grupoSpecs) {
       const row = catalogByKey.get(keyDeSku(s.account, s.omie_codigo_produto));
-      if (!row) continue;
-      rows.push(row);
-      const p = customerPricesByAccount[(s.account ?? '').toLowerCase()]?.[s.omie_codigo_produto];
-      if (typeof p === 'number') pricesForBoletim[s.omie_codigo_produto] = p;
+      if (row) rows.push(row);
     }
     // Boletim sem nenhuma embalagem conhecida → não emite selo (não polui com "sob consulta"
     // quando o problema é só dado de catálogo ausente, não falta de mapeamento).
     if (rows.length === 0) continue;
+    const baseEmbalagens = montarBaseEmbalagens(rows, accountPrices);
 
-    const baseEmbalagens = montarBaseEmbalagens(rows, pricesForBoletim);
+    // Embalagens do CATALISADOR (Fatia 3): normaliza o código do boletim → mapa de casamento →
+    // SKUs do catalisador → catálogo. Sem casamento → [] → o motor degrada a "sob consulta".
     const cod = ref.catalisador_codigo;
     const temCatalisador = typeof cod === 'string' && cod.trim() !== '';
+    let catalisadorEmbalagens: EmbalagemComEstoque[] = [];
+    if (temCatalisador) {
+      const chave = keyDeCatalisador(normalizarCatalisador(cod), ref.account);
+      const catRows: ProdutoLinhaOmie[] = [];
+      for (const c of catalisadorLinksByKey.get(chave) ?? []) {
+        const row = catalogByKey.get(keyDeSku(ref.account, c));
+        if (row) catRows.push(row);
+      }
+      catalisadorEmbalagens = montarBaseEmbalagens(catRows, accountPrices);
+    }
 
     const opcao = resolverOpcaoVenda({
       temSkuConfirmado: true, // a view v_omie_product_current_spec é confirmed+approved
       temCatalisador,
       proporcaoPct: ref.catalisador_proporcao_pct,
       baseEmbalagens,
-      catalisadorEmbalagens: [], // v1 — casamento do catalisador é fatia própria
+      catalisadorEmbalagens,
     });
 
     for (const s of grupoSpecs) {

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -14,6 +14,7 @@ import { useKbProductSpecs } from '@/hooks/useKbProductSpecs';
 import { VersionHistory } from '@/components/knowledge-base/VersionHistory';
 import { CompletudeBadge } from '@/components/knowledge-base/CompletudeBadge';
 import { SpecLinkPanel } from '@/components/knowledge-base/SpecLinkPanel';
+import { CatalisadorLinkPanel } from '@/components/knowledge-base/CatalisadorLinkPanel';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 
@@ -169,6 +170,11 @@ function DetailContent({ data, chunkCount }: { data: KbDocument; chunkCount: num
           spec={{ id: existingSpecs.id, product_code: existingSpecs.product_code, product_name: existingSpecs.product_name }}
           disabled={isImpersonating}
         />
+      )}
+
+      {/* Casamento do catalisador — só master, ficha aprovada, e só se o boletim tem catalisador. */}
+      {existingSpecs?.approved_at && isMaster && existingSpecs.catalisador_codigo && (
+        <CatalisadorLinkPanel catalisadorCodigo={existingSpecs.catalisador_codigo} disabled={isImpersonating} />
       )}
 
       {/* Histórico de versões do produto (Fase B1) — null quando não há versões */}

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -174,7 +174,13 @@ function DetailContent({ data, chunkCount }: { data: KbDocument; chunkCount: num
 
       {/* Casamento do catalisador — só master, ficha aprovada, e só se o boletim tem catalisador. */}
       {existingSpecs?.approved_at && isMaster && existingSpecs.catalisador_codigo && (
-        <CatalisadorLinkPanel catalisadorCodigo={existingSpecs.catalisador_codigo} disabled={isImpersonating} />
+        // key por código → painel remonta ao trocar de boletim (reseta termo/seleção; evita
+        // casar SKU no código errado por estado stale — Codex P1).
+        <CatalisadorLinkPanel
+          key={existingSpecs.catalisador_codigo}
+          catalisadorCodigo={existingSpecs.catalisador_codigo}
+          disabled={isImpersonating}
+        />
       )}
 
       {/* Histórico de versões do produto (Fase B1) — null quando não há versões */}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -28,6 +28,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { ProductItemForm } from '@/components/unified-order/ProductItemForm';
 import { useCurrentSpecsMap } from '@/hooks/useProductSpecLink';
+import { useCatalisadorLinksMap } from '@/hooks/useCatalisadorLink';
 import { keyDeSku } from '@/lib/knowledge-base/spec-link';
 import { montarSelosVendaAssistida } from '@/lib/venda-assistida/selos';
 import type { ProdutoLinhaOmie } from '@/lib/venda-assistida/montar-embalagens';
@@ -60,8 +61,10 @@ const UnifiedOrder = () => {
   const { user } = useAuth();
   // Fichas técnicas (boletim↔SKU): mapa pequeno (só vínculos confirmados+aprovados), 1 query.
   const { byKey: fichasByKey } = useCurrentSpecsMap();
-  // Venda assistida (Fatia 2 v1): selo "preparado" por produto. Resolve estado+preço de cada
-  // boletim reusando o catálogo JÁ carregado (zero query nova) e espalha por SKU. Vendedor-only.
+  // Casamento do catalisador (Fatia 3): mapa global keyDeCatalisador → SKUs (destrava preço catalisado).
+  const { byKey: catalisadorByKey } = useCatalisadorLinksMap();
+  // Venda assistida: selo "preparado" por produto. Resolve estado+preço de cada boletim reusando o
+  // catálogo JÁ carregado (zero query nova) e espalha por SKU. Vendedor-only.
   const selosByKey = useMemo(() => {
     const catalogByKey = new Map<string, ProdutoLinhaOmie>();
     for (const p of [...h.obenProducts, ...h.colacorProducts]) {
@@ -75,8 +78,8 @@ const UnifiedOrder = () => {
     // Preço-do-cliente (último praticado) POR CONTA — omie_codigo_produto colide entre Oben/Colacor,
     // então o helper lê do mapa da conta de cada SKU (não achata num Record só).
     const customerPricesByAccount = { oben: h.customerPricesOben, colacor: h.customerPricesColacor };
-    return montarSelosVendaAssistida([...fichasByKey.values()], catalogByKey, customerPricesByAccount);
-  }, [fichasByKey, h.obenProducts, h.colacorProducts, h.customerPricesOben, h.customerPricesColacor]);
+    return montarSelosVendaAssistida([...fichasByKey.values()], catalogByKey, customerPricesByAccount, catalisadorByKey);
+  }, [fichasByKey, catalisadorByKey, h.obenProducts, h.colacorProducts, h.customerPricesOben, h.customerPricesColacor]);
   const [restoreOpen, setRestoreOpen] = useState(false);
 
   // "Cores do cliente": histórico de cores + pré-preenchimento do dialog de tingir.

--- a/supabase/migrations/20260629150000_kb_catalisador_links.sql
+++ b/supabase/migrations/20260629150000_kb_catalisador_links.sql
@@ -1,0 +1,112 @@
+-- ============================================================
+-- kb_catalisador_links — casamento catalisador_codigo (normalizado) ↔ SKU Omie
+-- Venda assistida: destrava o preço CATALISADO no selo. Espelha o padrão de
+-- omie_product_spec_links / confirmar_vinculo_boletim (20260611140000_kb_fundacao_casamento.sql).
+-- Plano: docs/superpowers/plans/2026-06-29-venda-assistida-catalisador-casamento.md
+-- ============================================================
+
+-- ── Normalizador da chave do catalisador (UPPER + só alfanumérico) ──
+-- IMMUTABLE: usada na gravação E no lookup → 'FC.6975' e 'FC 6975' viram 'FC6975'.
+CREATE OR REPLACE FUNCTION public.kb_normalizar_catalisador(p text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+  SELECT upper(regexp_replace(coalesce(p, ''), '[^a-zA-Z0-9]', '', 'g'));
+$$;
+
+-- ── Tabela: catalisador (normalizado) → SKU Omie (a chave Omie é COMPOSTA account+cod) ──
+CREATE TABLE IF NOT EXISTS public.kb_catalisador_links (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalisador_codigo_norm text NOT NULL,
+  account text NOT NULL,
+  omie_codigo_produto bigint NOT NULL,
+  status text NOT NULL DEFAULT 'confirmed' CHECK (status IN ('confirmed','rejected')),
+  confirmed_by uuid REFERENCES auth.users(id),
+  confirmed_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ≤1 catalisador CONFIRMADO por SKU (account+cod). Múltiplos 'rejected' permitidos.
+CREATE UNIQUE INDEX IF NOT EXISTS kb_catalisador_links_one_confirmed
+  ON public.kb_catalisador_links (account, omie_codigo_produto)
+  WHERE status = 'confirmed';
+
+-- Não duplicar o mesmo quarteto (norm, sku, status).
+CREATE UNIQUE INDEX IF NOT EXISTS kb_catalisador_links_unique_quad
+  ON public.kb_catalisador_links (catalisador_codigo_norm, account, omie_codigo_produto, status);
+
+-- Lookup do selo: por (código normalizado, conta) entre os confirmados.
+CREATE INDEX IF NOT EXISTS kb_catalisador_links_norm
+  ON public.kb_catalisador_links (catalisador_codigo_norm, account)
+  WHERE status = 'confirmed';
+
+-- ── RLS: staff lê; escrita só via RPC SECURITY DEFINER (master) ──
+ALTER TABLE public.kb_catalisador_links ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS kb_catalisador_links_select_staff ON public.kb_catalisador_links;
+CREATE POLICY kb_catalisador_links_select_staff
+  ON public.kb_catalisador_links FOR SELECT
+  USING (public.has_role(auth.uid(), 'employee'::app_role)
+      OR public.has_role(auth.uid(), 'master'::app_role));
+
+-- ── RPC: confirmar o casamento do catalisador. Gate MASTER. Normaliza a chave. ──
+CREATE OR REPLACE FUNCTION public.confirmar_catalisador_vinculo(
+  p_catalisador_codigo text, p_skus jsonb
+) RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_norm text := public.kb_normalizar_catalisador(p_catalisador_codigo);
+  v_item jsonb; v_account text; v_cod bigint; v_count integer := 0; v_dono text;
+BEGIN
+  IF NOT public.has_role(v_uid, 'master'::app_role) THEN
+    RAISE EXCEPTION 'forbidden: somente master';
+  END IF;
+  IF v_norm = '' THEN
+    RAISE EXCEPTION 'catalisador_codigo vazio apos normalizacao';
+  END IF;
+  FOR v_item IN SELECT * FROM jsonb_array_elements(p_skus) LOOP
+    v_account := v_item->>'account';
+    v_cod := (v_item->>'omie_codigo_produto')::bigint;
+    -- ≤1 catalisador por SKU: se o SKU já é catalisador de OUTRO código, barra.
+    SELECT catalisador_codigo_norm INTO v_dono FROM public.kb_catalisador_links
+      WHERE account = v_account AND omie_codigo_produto = v_cod AND status = 'confirmed';
+    IF v_dono IS NOT NULL AND v_dono <> v_norm THEN
+      RAISE EXCEPTION 'SKU %/% ja e catalisador de outro codigo (%)', v_account, v_cod, v_dono;
+    END IF;
+    INSERT INTO public.kb_catalisador_links
+      (catalisador_codigo_norm, account, omie_codigo_produto, status, confirmed_by)
+    VALUES (v_norm, v_account, v_cod, 'confirmed', v_uid)
+    ON CONFLICT (catalisador_codigo_norm, account, omie_codigo_produto, status) DO NOTHING;
+    v_count := v_count + 1;
+  END LOOP;
+  RETURN v_count;
+END;
+$$;
+
+-- ── RPC: desvincular um SKU do catalisador. Gate MASTER. Guard anti-stale (norm esperado). ──
+CREATE OR REPLACE FUNCTION public.desvincular_catalisador(
+  p_account text, p_omie_codigo_produto bigint, p_expected_norm text
+) RETURNS integer
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE v_deleted integer;
+BEGIN
+  IF NOT public.has_role(auth.uid(), 'master'::app_role) THEN
+    RAISE EXCEPTION 'forbidden: somente master';
+  END IF;
+  DELETE FROM public.kb_catalisador_links
+   WHERE account = p_account
+     AND omie_codigo_produto = p_omie_codigo_produto
+     AND status = 'confirmed'
+     AND catalisador_codigo_norm = public.kb_normalizar_catalisador(p_expected_norm);
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN v_deleted;
+END;
+$$;
+
+-- ── Grants (espelha a casar) ──
+REVOKE ALL ON FUNCTION public.kb_normalizar_catalisador(text) FROM anon, public;
+REVOKE ALL ON FUNCTION public.confirmar_catalisador_vinculo(text, jsonb) FROM anon, public;
+REVOKE ALL ON FUNCTION public.desvincular_catalisador(text, bigint, text) FROM anon, public;
+GRANT EXECUTE ON FUNCTION public.kb_normalizar_catalisador(text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.confirmar_catalisador_vinculo(text, jsonb) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.desvincular_catalisador(text, bigint, text) TO authenticated;


### PR DESCRIPTION
## O quê
**Casamento do catalisador** — destrava o preço CATALISADO no selo da venda assistida (antes degradava a "sob consulta"). O boletim tem `catalisador_codigo` (texto sujo); este PR mapeia esse código (normalizado) → SKU(s) Omie, com aprovação master ("eu sugiro, você aprova"), e liga no selo.

## Slices
1. **Migration** `kb_catalisador_links` + fn `kb_normalizar_catalisador` + RPCs master `confirmar_catalisador_vinculo`/`desvincular_catalisador`. **Provada em PG17** (`db/test-kb_catalisador_links.sh`): 21 asserts + falsificação do gate/RLS/normalizador. **✅ JÁ aplicada e validada em prod.**
2. **Hooks** `useCatalisadorLink` — mapa global (selo) + links-por-código (UI) + confirmar/desvincular.
3. **UI** `CatalisadorLinkPanel` — painel master-only no detalhe do boletim (irmão do vínculo da base).
4. **Selo** `montarSelosVendaAssistida` resolve `catalisadorEmbalagens` via o mapa (normalizado, por conta).

## Decisões (founder)
- **Chave normalizada** (`UPPER` + só alfanumérico) → `FC.6975` = `FC 6975`; multi-código/free-text → "sob consulta".
- **Mapa global por código** (FC.6975 serve 13 boletins) — mapeia 1×.
- **UI no detalhe do boletim**, grava no mapa global.

## Money-path
- TS `normalizarCatalisador` espelha o SQL **byte-a-byte** (chave gravada == chave do lookup).
- Catalisador resolvido por **(norm, MESMA conta)** do grupo; preço-do-cliente da conta certa.
- Sem casamento / SKU fora do catálogo → `catalisadorEmbalagens: []` → "sob consulta" (nunca fabrica).

## Codex adversarial (xhigh) — sem P0; 2 P1 fechados
- Confirmou: normalizador TS == SQL, lookup do selo por (norm, conta) correto, merge links↔omie_products inclui conta.
- **P1** mapa sem paginação → paginado (cap 1000 do PostgREST, silencioso).
- **P1** estado stale no painel ao trocar de boletim → remonta por `key={catalisador_codigo}`.

## Verificação
- **PG17** 21 asserts + falsificação · **4229/4229** vitest · typecheck/lint 0.

## ⚠️ Migration manual (já aplicada)
A migration `supabase/migrations/20260629150000_kb_catalisador_links.sql` **já foi colada no SQL Editor e validada (`✅`)** nesta sessão. Merge na `main` não reaplica — nada a fazer no banco.

## Pendente do founder
- **Casar catalisadores** no detalhe dos boletins (painel "Catalisador") → o preço catalisado acende no selo.
- **Publish** após merge (merge ≠ produção).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
