### PR TITLE
fix(auth): logout não trava quando o service worker não fica pronto

### DIFF
--- a/src/lib/push/device.test.ts
+++ b/src/lib/push/device.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// device.ts (e o logger que ele importa) tocam o supabase client no topo do
+// módulo — mockamos o mínimo pra o import não quebrar e pra observar a RPC.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(() => Promise.resolve({ data: { session: null }, error: null })),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+    },
+    rpc: vi.fn(() => Promise.resolve({ data: null, error: null })),
+  },
+}));
+
+import { limparPushDoDevice } from './device';
+import { supabase } from '@/integrations/supabase/client';
+
+function defineGlobal(alvo: object, prop: string, value: unknown) {
+  Object.defineProperty(alvo, prop, { configurable: true, value });
+}
+
+describe('limparPushDoDevice — logout best-effort', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // suportaPush() exige serviceWorker + PushManager + Notification presentes.
+    defineGlobal(window, 'PushManager', {});
+    defineGlobal(window, 'Notification', {});
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    Reflect.deleteProperty(window, 'PushManager');
+    Reflect.deleteProperty(window, 'Notification');
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+  });
+
+  // O bug: no preview/iframe o service worker nunca fica "ready"; como o signOut
+  // faz `await limparPushDoDevice()`, um ready pendurado trava o logout pra sempre.
+  // O try/catch original só protege contra THROW — não contra HANG.
+  it('resolve mesmo quando serviceWorker.ready nunca resolve (logout não pode travar)', async () => {
+    defineGlobal(navigator, 'serviceWorker', { ready: new Promise(() => {}) });
+
+    const PENDURADO = Symbol('pendurado');
+    const corrida = Promise.race([
+      limparPushDoDevice().then(() => 'resolveu' as const),
+      new Promise<typeof PENDURADO>((r) => setTimeout(() => r(PENDURADO), 5_000)),
+    ]);
+
+    // Avança o relógio além de qualquer teto interno razoável. Sem o fix,
+    // limparPushDoDevice segue pendurada e só o marcador PENDURADO vence.
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    await expect(corrida).resolves.toBe('resolveu');
+  });
+
+  // Não-regressão: o teto não pode ter quebrado o fluxo normal.
+  it('caminho feliz: desinscreve o device e apaga a linha via RPC', async () => {
+    const unsubscribe = vi.fn(() => Promise.resolve(true));
+    defineGlobal(navigator, 'serviceWorker', {
+      ready: Promise.resolve({
+        pushManager: {
+          getSubscription: () => Promise.resolve({ endpoint: 'https://push/abc', unsubscribe }),
+        },
+      }),
+    });
+
+    await limparPushDoDevice();
+
+    expect(vi.mocked(supabase.rpc)).toHaveBeenCalledWith('delete_push_subscription', {
+      p_endpoint: 'https://push/abc',
+    });
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('retorna cedo (sem tocar a RPC) quando o navegador não suporta push', async () => {
+    Reflect.deleteProperty(window, 'PushManager'); // deixa suportaPush() falso
+
+    await limparPushDoDevice();
+
+    expect(vi.mocked(supabase.rpc)).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/push/device.ts
+++ b/src/lib/push/device.ts
@@ -6,22 +6,45 @@ export function suportaPush(): boolean {
   return 'serviceWorker' in navigator && 'PushManager' in window && 'Notification' in window;
 }
 
+/** Teto de tempo do best-effort de logout. Rede de balcão (3G) resolve bem
+ * antes; o teto só existe pra um await pendurado não travar o logout. */
+const TETO_LIMPEZA_MS = 2_000;
+
+/** Corre uma promessa com teto de tempo; rejeita se estourar. Necessário porque
+ * `try/catch` só protege contra THROW — um `await` que nunca resolve (ex.:
+ * `serviceWorker.ready` num preview/iframe sem SW ativo, ou uma RPC sem rede)
+ * fica pendurado pra sempre e trava quem deu `await`. */
+function comTeto<T>(p: Promise<T>, ms: number, rotulo: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`timeout ${ms}ms: ${rotulo}`)), ms)
+    ),
+  ]);
+}
+
 /**
  * Limpeza no LOGOUT (chamada pelo AuthContext, best-effort): desinscreve o
  * device e apaga a linha — senão a próxima pessoa que logar neste device
  * recebe os pushes de quem saiu (device compartilhado de balcão). Vive em
  * lib/ (não no hook) pra não criar ciclo AuthContext → hook → AuthContext.
- * Nunca lança (logout não pode travar).
+ * Nunca lança E nunca trava (o logout não pode depender de SW/rede) — daí o teto.
  */
 export async function limparPushDoDevice(): Promise<void> {
   try {
     if (!suportaPush()) return;
-    const reg = await navigator.serviceWorker.ready;
-    const sub = await reg.pushManager.getSubscription();
-    if (!sub) return;
-    // RPC antes do unsubscribe (precisa da sessão ainda válida).
-    await supabase.rpc('delete_push_subscription', { p_endpoint: sub.endpoint });
-    await sub.unsubscribe();
+    await comTeto(
+      (async () => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        if (!sub) return;
+        // RPC antes do unsubscribe (precisa da sessão ainda válida).
+        await supabase.rpc('delete_push_subscription', { p_endpoint: sub.endpoint });
+        await sub.unsubscribe();
+      })(),
+      TETO_LIMPEZA_MS,
+      'limparPushDoDevice',
+    );
   } catch (error) {
     logger.warn('Falha ao limpar push no logout (best-effort)', { stage: 'push_logout', error });
   }


### PR DESCRIPTION
## Problema

O botão **"Sair"** não deslogava (reproduzido no preview do Lovable, mas é bug real de qualquer device). `signOut()` faz `await limparPushDoDevice()` **antes** de encerrar a sessão — e essa limpeza dava `await navigator.serviceWorker.ready` + uma RPC de push **sem teto de tempo**.

O `try/catch` do `limparPushDoDevice` só protege contra **throw**, não contra **hang**: num preview/iframe onde o service worker nunca fica `ready` (ou com rede ruim), o `await` fica pendurado pra sempre → o `supabase.auth.signOut()` nunca roda → "Sair" sem efeito.

## Fix

Teto de 2s (`Promise.race`) em volta do corpo inteiro do `limparPushDoDevice`. Qualquer `await` pendurado (service worker OU RPC sem rede) cai no `catch` best-effort e o logout **sempre** prossegue. O comentário da função prometia "não trava o logout" — agora é verdade.

## Test Plan

- [x] Teste que **falsifica** o bug: `serviceWorker.ready` que nunca resolve → `limparPushDoDevice()` resolve mesmo assim (sem o fix, ficava pendurada → RED limpo).
- [x] Não-regressão: caminho feliz (chama `delete_push_subscription` + `unsubscribe`) e early-return sem suporte a push.
- [x] Suíte completa: 4239 testes verdes · typecheck strict · ESLint limpos.

> Só frontend — sem edge/migration. Pra ir a produção falta o **Publish do frontend** no Lovable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)