### PR TITLE
feat(inteligencia): UTI de Contas — triagem de clientes críticos por 3 sinais (Fatia 1a)

### DIFF
--- a/src/components/intelligence/IntelligenceUtiTab.tsx
+++ b/src/components/intelligence/IntelligenceUtiTab.tsx
@@ -1,0 +1,220 @@
+import { useMemo, useState } from 'react';
+import { formatDistanceToNow } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import { CircleDollarSign, HeartPulse, Info, ListPlus, TrendingDown } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { EmptyState } from '@/components/EmptyState';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { CriarTarefaDialog } from '@/components/tarefas/CriarTarefaDialog';
+import { useCompany } from '@/contexts/CompanyContext';
+import { useUrlState } from '@/hooks/useUrlState';
+import { useUtiContas, UTI_CRITERIOS, type SinalUti, type UtiConta } from '@/hooks/useUtiContas';
+import { formatBRL } from '@/lib/reposicao';
+import { formatDoc } from '@/lib/grupos/format';
+import { track } from '@/lib/analytics';
+
+function FrescorBadge({ label, at }: { label: string; at: string | null }) {
+  return (
+    <Badge variant="outline" className="text-[10px] font-normal text-muted-foreground">
+      {label}:{' '}
+      {at ? formatDistanceToNow(new Date(at), { locale: ptBR, addSuffix: true }) : 'sem registro'}
+    </Badge>
+  );
+}
+
+function SinalBadge({ ativo, label }: { ativo: SinalUti; label: string }) {
+  if (ativo === null) {
+    return <Badge variant="outline" className="text-[10px] text-muted-foreground border-dashed">{label}: sem dado</Badge>;
+  }
+  if (!ativo) {
+    return <Badge variant="outline" className="text-[10px] text-muted-foreground">{label} ok</Badge>;
+  }
+  return <Badge className="text-[10px] bg-status-error/10 text-status-error border-status-error/30">{label}</Badge>;
+}
+
+export function IntelligenceUtiTab() {
+  const { activeCompany } = useCompany();
+  const { data, isLoading, error } = useUtiContas(true);
+  const [filtros, setFiltros] = useUrlState({ lista: 'uti' });
+  // Busca fica FORA da URL: pode conter CNPJ (PII não vai pra search params/logs).
+  const [busca, setBusca] = useState('');
+  const [tarefaCliente, setTarefaCliente] = useState<UtiConta | null>(null);
+
+  const { uti, observacao, exposicao } = useMemo(() => {
+    const contas = data?.contas ?? [];
+    const utiRows = contas.filter((c) => c.status === 'uti');
+    return {
+      uti: utiRows,
+      observacao: contas.filter((c) => c.status === 'observacao'),
+      exposicao: utiRows.reduce((acc, c) => acc + c.vencido31, 0),
+    };
+  }, [data]);
+
+  const visiveis = useMemo(() => {
+    const base = filtros.lista === 'observacao' ? observacao : uti;
+    const q = busca.trim().toLowerCase();
+    if (!q) return base;
+    const qDoc = q.replace(/\D/g, '');
+    return base.filter((c) => c.nome.toLowerCase().includes(q) || (qDoc.length > 0 && (c.documento ?? '').includes(qDoc)));
+  }, [uti, observacao, filtros.lista, busca]);
+
+  if (isLoading) return <PageSkeleton variant="cockpit" />;
+  if (error) {
+    return <p className="text-sm text-status-error">Não consegui carregar a UTI: {error instanceof Error ? error.message : 'erro'}.</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Critérios explícitos — entrada e alta são determinísticos, não score mágico */}
+      <div className="flex items-start gap-2 rounded-md border border-status-info/30 bg-status-info/5 px-3 py-2 text-xs text-muted-foreground">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-status-info" />
+        <span>
+          <strong>Entrada na UTI:</strong> {UTI_CRITERIOS.sinaisParaEntrar}+ sinais ativos entre churn (risco ≥ {UTI_CRITERIOS.churnRiskMin} ou saúde crítica),
+          inadimplência (vencido há {UTI_CRITERIOS.diasVencidoMin}+ dias) e positivação (elegível sem pedido há {UTI_CRITERIOS.mesesSemPedidoMin}+ meses).{' '}
+          <strong>Alta:</strong> nenhum sinal ativo. Sinal sem dado na fonte aparece como "sem dado" — não conta a favor nem contra.
+        </span>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-1.5">
+        <FrescorBadge label="Scores" at={data?.frescor.scoresCalculatedAt ?? null} />
+        <FrescorBadge label="Recebíveis (Omie)" at={data?.frescor.receberSyncAt ?? null} />
+        <Badge variant="outline" className="text-[10px] font-normal text-muted-foreground">
+          Positivação: {data?.frescor.positivacaoMes ? `mês ${data.frescor.positivacaoMes.slice(0, 7)}` : 'sem snapshot'}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        <Card>
+          <CardContent className="p-3">
+            <p className="text-xs text-muted-foreground">Na UTI</p>
+            <p className="mt-0.5 text-lg font-semibold tabular-nums text-status-error">{uti.length}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-3">
+            <p className="text-xs text-muted-foreground">Em observação</p>
+            <p className="mt-0.5 text-lg font-semibold tabular-nums text-status-warning">{observacao.length}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-3">
+            <p className="text-xs text-muted-foreground">Exposição vencida 31+ (UTI)</p>
+            <p className="mt-0.5 text-lg font-semibold tabular-nums">{formatBRL(exposicao)}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1">
+          <Button
+            size="sm"
+            variant={filtros.lista !== 'observacao' ? 'default' : 'outline'}
+            className="h-7 text-xs"
+            onClick={() => setFiltros({ lista: 'uti' })}
+          >
+            UTI ({uti.length})
+          </Button>
+          <Button
+            size="sm"
+            variant={filtros.lista === 'observacao' ? 'default' : 'outline'}
+            className="h-7 text-xs"
+            onClick={() => setFiltros({ lista: 'observacao' })}
+          >
+            Observação ({observacao.length})
+          </Button>
+        </div>
+        <Input
+          placeholder="Buscar por nome ou CNPJ…"
+          value={busca}
+          onChange={(e) => setBusca(e.target.value)}
+          className="h-7 w-56 text-xs"
+        />
+      </div>
+
+      {visiveis.length === 0 ? (
+        <EmptyState
+          icon={HeartPulse}
+          title={busca ? 'Nenhum cliente encontrado' : filtros.lista === 'observacao' ? 'Ninguém em observação' : 'UTI vazia'}
+          description={
+            busca
+              ? 'Ajuste a busca ou troque de lista.'
+              : 'Nenhum cliente atende os critérios de entrada no momento.'
+          }
+          tone="operational"
+        />
+      ) : (
+        <div className="rounded-md border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="text-xs">Cliente</TableHead>
+                <TableHead className="text-xs">Sinais</TableHead>
+                <TableHead className="text-xs text-right">Churn</TableHead>
+                <TableHead className="text-xs text-right">Vencido 31+</TableHead>
+                <TableHead className="text-xs text-right">Meses s/ pedido</TableHead>
+                <TableHead className="text-xs text-right">Dias s/ comprar</TableHead>
+                <TableHead className="text-xs text-right">Ação</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {visiveis.map((c) => (
+                <TableRow key={c.customerUserId}>
+                  <TableCell className="py-1.5">
+                    <p className="text-sm font-medium leading-tight">{c.nome}</p>
+                    {c.documento && <p className="text-[11px] text-muted-foreground font-mono">{formatDoc(c.documento)}</p>}
+                  </TableCell>
+                  <TableCell className="py-1.5">
+                    <div className="flex flex-wrap gap-1">
+                      <SinalBadge ativo={c.sinalChurn} label="Churn" />
+                      <SinalBadge ativo={c.sinalInadimplencia} label="Inadimpl." />
+                      <SinalBadge ativo={c.sinalPositivacao} label="Positiv." />
+                    </div>
+                  </TableCell>
+                  <TableCell className="py-1.5 text-right tabular-nums text-sm">
+                    {c.churnRisk != null ? `${Math.round(c.churnRisk)}%` : '—'}
+                  </TableCell>
+                  <TableCell className={`py-1.5 text-right tabular-nums text-sm ${c.vencido31 > 0 ? 'text-status-error font-medium' : ''}`}>
+                    {c.sinalInadimplencia === null ? 'sem dado' : formatBRL(c.vencido31)}
+                  </TableCell>
+                  <TableCell className="py-1.5 text-right tabular-nums text-sm">{c.mesesSemPedido ?? '—'}</TableCell>
+                  <TableCell className="py-1.5 text-right tabular-nums text-sm">{c.diasSemComprar ?? '—'}</TableCell>
+                  <TableCell className="py-1.5 text-right">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-6 text-xs"
+                      onClick={() => {
+                        track('inteligencia.uti_criar_tarefa', { sinais: c.sinaisAtivos });
+                        setTarefaCliente(c);
+                      }}
+                    >
+                      <ListPlus className="w-3 h-3 mr-1" /> Tarefa
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <div className="flex items-center gap-3 text-[11px] text-muted-foreground">
+        <span className="inline-flex items-center gap-1"><HeartPulse className="w-3 h-3" /> churn = scores de carteira</span>
+        <span className="inline-flex items-center gap-1"><CircleDollarSign className="w-3 h-3" /> inadimplência = títulos Omie por CNPJ</span>
+        <span className="inline-flex items-center gap-1"><TrendingDown className="w-3 h-3" /> positivação = snapshot mensal</span>
+      </div>
+
+      <CriarTarefaDialog
+        open={tarefaCliente !== null}
+        onOpenChange={(o) => { if (!o) setTarefaCliente(null); }}
+        cliente={tarefaCliente ? { customer_user_id: tarefaCliente.customerUserId, nome: tarefaCliente.nome } : null}
+        assignedTo={tarefaCliente?.farmerId ?? ''}
+        empresa={activeCompany}
+      />
+    </div>
+  );
+}

--- a/src/hooks/__tests__/useUtiContas.test.ts
+++ b/src/hooks/__tests__/useUtiContas.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { montarContasUti, UTI_CRITERIOS, type ProfileRow, type ScoreRow, type SnapshotRow, type TituloRow } from '../useUtiContas';
+
+const score = (over: Partial<ScoreRow> & { customer_user_id: string }): ScoreRow => ({
+  farmer_id: 'farmer-1',
+  health_score: 50,
+  health_class: 'estavel',
+  priority_score: 10,
+  churn_risk: 0,
+  days_since_last_purchase: 10,
+  calculated_at: '2026-07-01T00:00:00Z',
+  ...over,
+});
+
+const perfil = (over: Partial<ProfileRow> & { user_id: string }): ProfileRow => ({
+  name: 'Cliente Teste',
+  razao_social: null,
+  document: '12.345.678/0001-90',
+  cnpj: null,
+  ...over,
+});
+
+const titulo = (cnpj: string, saldo: number): TituloRow => ({ cnpj_cpf: cnpj, saldo });
+
+const snap = (customer: string, mes: string, hadOrder: boolean, eligible = true): SnapshotRow => ({
+  customer_user_id: customer,
+  mes,
+  eligible,
+  had_order_in_month: hadOrder,
+});
+
+describe('montarContasUti', () => {
+  it('entra na UTI com 2 sinais (churn + inadimplência), casando CNPJ normalizado', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: UTI_CRITERIOS.churnRiskMin })],
+      perfis: [perfil({ user_id: 'c1' })],
+      // Omie manda formatado diferente do profile — o match é só-dígitos
+      titulos: [titulo('12345678000190', 500), titulo('12.345.678/0001-90', 250)],
+      snapshots: [],
+    });
+    expect(contas).toHaveLength(1);
+    expect(contas[0].status).toBe('uti');
+    expect(contas[0].sinalChurn).toBe(true);
+    expect(contas[0].sinalInadimplencia).toBe(true);
+    expect(contas[0].vencido31).toBe(750);
+    expect(contas[0].sinalPositivacao).toBeNull(); // sem snapshot = sem dado, não false
+  });
+
+  it('health_class critico ativa churn mesmo com churn_risk baixo', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 5, health_class: 'critico' })],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [],
+    });
+    expect(contas[0]?.sinalChurn).toBe(true);
+  });
+
+  it('1 sinal só = observação, não UTI', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 90 })],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [],
+    });
+    expect(contas[0].status).toBe('observacao');
+  });
+
+  it('0 sinais = alta (não aparece na lista)', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 10 })],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [],
+    });
+    expect(contas).toHaveLength(0);
+  });
+
+  it('ausente ≠ zero: cliente sem CNPJ tem sinal de inadimplência null, não false', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 90 })],
+      perfis: [perfil({ user_id: 'c1', document: null, cnpj: null })],
+      titulos: [titulo('12345678000190', 999)],
+      snapshots: [],
+    });
+    expect(contas[0].sinalInadimplencia).toBeNull();
+    expect(contas[0].vencido31).toBe(0);
+    expect(contas[0].status).toBe('observacao'); // null não conta como sinal ativo
+  });
+
+  it('positivação ativa com 2 meses elegíveis sem pedido', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 90 })],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [snap('c1', '2026-06-01', false), snap('c1', '2026-05-01', false), snap('c1', '2026-04-01', true)],
+    });
+    expect(contas[0].sinalPositivacao).toBe(true);
+    expect(contas[0].mesesSemPedido).toBe(2);
+    expect(contas[0].status).toBe('uti');
+  });
+
+  it('positivação com pedido no mês mais recente fica false (não null)', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 90 })],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [snap('c1', '2026-06-01', true), snap('c1', '2026-05-01', false)],
+    });
+    expect(contas[0].sinalPositivacao).toBe(false);
+    expect(contas[0].mesesSemPedido).toBe(0);
+  });
+
+  it('histórico insuficiente (1 mês elegível) = sem dado, não conclui', () => {
+    const { contas } = montarContasUti({
+      scores: [score({ customer_user_id: 'c1', churn_risk: 90 })],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [snap('c1', '2026-06-01', false), snap('c1', '2026-05-01', false, false)],
+    });
+    expect(contas[0].sinalPositivacao).toBeNull();
+    expect(contas[0].mesesSemPedido).toBeNull();
+  });
+
+  it('dedup de spine: cliente com score por 2 farmers fica com o de maior prioridade', () => {
+    const { contas } = montarContasUti({
+      scores: [
+        score({ customer_user_id: 'c1', farmer_id: 'farmer-a', priority_score: 5, churn_risk: 90 }),
+        score({ customer_user_id: 'c1', farmer_id: 'farmer-b', priority_score: 20, churn_risk: 90 }),
+      ],
+      perfis: [perfil({ user_id: 'c1' })],
+      titulos: [],
+      snapshots: [],
+    });
+    expect(contas).toHaveLength(1);
+    expect(contas[0].farmerId).toBe('farmer-b');
+  });
+
+  it('ordena por sinais ativos e depois por exposição vencida', () => {
+    const { contas } = montarContasUti({
+      scores: [
+        score({ customer_user_id: 'c1', churn_risk: 90 }),
+        score({ customer_user_id: 'c2', churn_risk: 90 }),
+        score({ customer_user_id: 'c3', churn_risk: 90 }),
+      ],
+      perfis: [
+        perfil({ user_id: 'c1', document: '11111111000111' }),
+        perfil({ user_id: 'c2', document: '22222222000122' }),
+        perfil({ user_id: 'c3', document: '33333333000133' }),
+      ],
+      titulos: [titulo('22222222000122', 100), titulo('33333333000133', 900)],
+      snapshots: [],
+    });
+    expect(contas.map((c) => c.customerUserId)).toEqual(['c3', 'c2', 'c1']);
+  });
+
+  it('frescor: scoresCalculatedAt é o mais recente e positivacaoMes o maior mês', () => {
+    const r = montarContasUti({
+      scores: [
+        score({ customer_user_id: 'c1', churn_risk: 90, calculated_at: '2026-06-01T00:00:00Z' }),
+        score({ customer_user_id: 'c2', churn_risk: 90, calculated_at: '2026-07-01T12:00:00Z' }),
+      ],
+      perfis: [],
+      titulos: [],
+      snapshots: [snap('c1', '2026-05-01', true), snap('c1', '2026-06-01', true)],
+    });
+    expect(r.scoresCalculatedAt).toBe('2026-07-01T12:00:00Z');
+    expect(r.positivacaoMes).toBe('2026-06-01');
+  });
+});

--- a/src/hooks/useUtiContas.ts
+++ b/src/hooks/useUtiContas.ts
@@ -1,0 +1,291 @@
+import { useQuery } from '@tanstack/react-query';
+import { format, subDays, subMonths } from 'date-fns';
+import { supabase } from '@/integrations/supabase/client';
+import { OPEN_TITLE_STATUSES } from '@/lib/financeiro/titulo-status';
+
+/**
+ * UTI de Contas — triagem de clientes críticos por 3 sinais independentes
+ * (inspirado na "UTI de lojas" do turnaround da Pernambucanas).
+ *
+ * Critérios DETERMINÍSTICOS e visíveis na UI (nada de "score mágico"):
+ *   1. Churn      — churn_risk ≥ 70 OU health_class = 'critico' (farmer_client_scores)
+ *   2. Inadimplência — saldo em aberto vencido há 31+ dias > 0 (fin_contas_receber,
+ *      casado por CNPJ/documento do profile — normalizado só-dígitos)
+ *   3. Positivação — elegível e SEM pedido nos 2 meses mais recentes com snapshot
+ *      (carteira_positivacao_snapshot)
+ *
+ * Entrada na UTI: ≥ 2 sinais ativos. 1 sinal: "em observação". Alta: 0 sinais.
+ *
+ * Money-path (ausente ≠ zero): sinal sem dado na fonte fica `null` ("sem dado"),
+ * nunca vira `false` fabricado — cliente sem CNPJ no profile não ganha "adimplente"
+ * de graça, e positivação com menos de 2 meses elegíveis de histórico não conclui nada.
+ */
+
+export type SinalUti = boolean | null;
+
+export const UTI_CRITERIOS = {
+  churnRiskMin: 70,
+  diasVencidoMin: 31,
+  mesesSemPedidoMin: 2,
+  sinaisParaEntrar: 2,
+} as const;
+
+export interface UtiConta {
+  customerUserId: string;
+  farmerId: string;
+  nome: string;
+  documento: string | null;
+  churnRisk: number | null;
+  healthClass: string | null;
+  diasSemComprar: number | null;
+  /** R$ em aberto vencido há 31+ dias (0 quando sinal indisponível). */
+  vencido31: number;
+  /** Meses recentes elegíveis sem pedido (0–3; null = histórico insuficiente). */
+  mesesSemPedido: number | null;
+  sinalChurn: SinalUti;
+  sinalInadimplencia: SinalUti;
+  sinalPositivacao: SinalUti;
+  sinaisAtivos: number;
+  status: 'uti' | 'observacao';
+}
+
+export interface UtiFrescor {
+  /** Último recálculo dos scores de carteira. */
+  scoresCalculatedAt: string | null;
+  /** Último sync de contas a receber concluído (fin_sync_log, status 'complete'). */
+  receberSyncAt: string | null;
+  /** Mês mais recente com snapshot de positivação (YYYY-MM-DD). */
+  positivacaoMes: string | null;
+}
+
+export interface UtiContasResult {
+  contas: UtiConta[];
+  frescor: UtiFrescor;
+}
+
+const PAGE = 1000;
+
+/** Pagina além da capa silenciosa de 1.000 linhas do PostgREST (ordem estável obrigatória). */
+async function fetchAll<T>(
+  build: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await build(from, from + PAGE - 1);
+    if (error) throw new Error(error.message);
+    const rows = data ?? [];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return out;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+const normDoc = (d: string | null | undefined): string | null => {
+  const clean = (d ?? '').replace(/\D/g, '');
+  return clean.length >= 11 ? clean : null;
+};
+
+export interface ScoreRow {
+  customer_user_id: string;
+  farmer_id: string;
+  health_score: number | null;
+  health_class: string | null;
+  priority_score: number | null;
+  churn_risk: number | null;
+  days_since_last_purchase: number | null;
+  calculated_at: string | null;
+}
+
+export interface ProfileRow {
+  user_id: string;
+  name: string;
+  razao_social: string | null;
+  document: string | null;
+  cnpj: string | null;
+}
+
+export interface TituloRow {
+  cnpj_cpf: string | null;
+  saldo: number | null;
+}
+
+export interface SnapshotRow {
+  customer_user_id: string;
+  mes: string;
+  eligible: boolean;
+  had_order_in_month: boolean;
+}
+
+/**
+ * Cômputo puro dos sinais e do status UTI/observação (testável sem Supabase).
+ * `titulos` já deve vir filtrado (em aberto + vencido 31+ + saldo > 0 — o filtro é do query).
+ */
+export function montarContasUti(input: {
+  scores: ScoreRow[];
+  perfis: ProfileRow[];
+  titulos: TituloRow[];
+  snapshots: SnapshotRow[];
+}): { contas: UtiConta[]; scoresCalculatedAt: string | null; positivacaoMes: string | null } {
+  // Dedup do spine: um cliente pode ter score por mais de um farmer — fica o de maior prioridade.
+  const porCliente = new Map<string, ScoreRow>();
+  for (const s of input.scores) {
+    const atual = porCliente.get(s.customer_user_id);
+    if (!atual || (s.priority_score ?? 0) > (atual.priority_score ?? 0)) porCliente.set(s.customer_user_id, s);
+  }
+
+  const perfis = new Map<string, ProfileRow>();
+  for (const p of input.perfis) perfis.set(p.user_id, p);
+
+  // Vencido 31+ por documento normalizado (soma across empresas — exposição do grupo).
+  const vencidoPorDoc = new Map<string, number>();
+  for (const t of input.titulos) {
+    const doc = normDoc(t.cnpj_cpf);
+    if (!doc) continue;
+    vencidoPorDoc.set(doc, (vencidoPorDoc.get(doc) ?? 0) + Number(t.saldo ?? 0));
+  }
+
+  // Snapshots por cliente, do mês mais recente pro mais antigo.
+  const snapsPorCliente = new Map<string, SnapshotRow[]>();
+  let positivacaoMes: string | null = null;
+  for (const s of input.snapshots) {
+    const list = snapsPorCliente.get(s.customer_user_id) ?? [];
+    list.push(s);
+    snapsPorCliente.set(s.customer_user_id, list);
+    if (!positivacaoMes || s.mes > positivacaoMes) positivacaoMes = s.mes;
+  }
+
+  let scoresCalculatedAt: string | null = null;
+  const contas: UtiConta[] = [];
+
+  for (const [customerUserId, score] of porCliente) {
+    if (score.calculated_at && (!scoresCalculatedAt || score.calculated_at > scoresCalculatedAt)) {
+      scoresCalculatedAt = score.calculated_at;
+    }
+
+    const sinalChurn: SinalUti =
+      score.churn_risk == null && score.health_class == null
+        ? null
+        : (score.churn_risk ?? 0) >= UTI_CRITERIOS.churnRiskMin || score.health_class === 'critico';
+
+    const perfil = perfis.get(customerUserId);
+    const doc = normDoc(perfil?.document) ?? normDoc(perfil?.cnpj);
+    const vencido31 = doc ? (vencidoPorDoc.get(doc) ?? 0) : 0;
+    const sinalInadimplencia: SinalUti = doc ? vencido31 > 0 : null;
+
+    const snaps = (snapsPorCliente.get(customerUserId) ?? [])
+      .filter((s) => s.eligible)
+      .sort((a, b) => (a.mes < b.mes ? 1 : -1));
+    let sinalPositivacao: SinalUti = null;
+    let mesesSemPedido: number | null = null;
+    if (snaps.length >= UTI_CRITERIOS.mesesSemPedidoMin) {
+      mesesSemPedido = 0;
+      for (const s of snaps) {
+        if (s.had_order_in_month) break;
+        mesesSemPedido += 1;
+      }
+      sinalPositivacao = mesesSemPedido >= UTI_CRITERIOS.mesesSemPedidoMin;
+    }
+
+    const sinaisAtivos = [sinalChurn, sinalInadimplencia, sinalPositivacao].filter((s) => s === true).length;
+    if (sinaisAtivos === 0) continue;
+
+    contas.push({
+      customerUserId,
+      farmerId: score.farmer_id,
+      nome: perfil?.razao_social || perfil?.name || 'Cliente sem perfil',
+      documento: doc,
+      churnRisk: score.churn_risk,
+      healthClass: score.health_class,
+      diasSemComprar: score.days_since_last_purchase,
+      vencido31,
+      mesesSemPedido,
+      sinalChurn,
+      sinalInadimplencia,
+      sinalPositivacao,
+      sinaisAtivos,
+      status: sinaisAtivos >= UTI_CRITERIOS.sinaisParaEntrar ? 'uti' : 'observacao',
+    });
+  }
+
+  contas.sort((a, b) => b.sinaisAtivos - a.sinaisAtivos || b.vencido31 - a.vencido31 || (b.churnRisk ?? 0) - (a.churnRisk ?? 0));
+  return { contas, scoresCalculatedAt, positivacaoMes };
+}
+
+export function useUtiContas(enabled: boolean) {
+  return useQuery({
+    queryKey: ['uti-contas'],
+    enabled,
+    staleTime: 60_000,
+    queryFn: async (): Promise<UtiContasResult> => {
+      const hoje = new Date();
+      const corteVencido = format(subDays(hoje, UTI_CRITERIOS.diasVencidoMin), 'yyyy-MM-dd');
+      const cortePositivacao = format(subMonths(hoje, 3), 'yyyy-MM-01');
+
+      const [scores, titulos, snapshots, syncRes] = await Promise.all([
+        fetchAll<ScoreRow>((from, to) =>
+          supabase
+            .from('farmer_client_scores')
+            .select('customer_user_id, farmer_id, health_score, health_class, priority_score, churn_risk, days_since_last_purchase, calculated_at')
+            .order('customer_user_id', { ascending: true })
+            .order('id', { ascending: true })
+            .range(from, to),
+        ),
+        fetchAll<TituloRow>((from, to) =>
+          supabase
+            .from('fin_contas_receber')
+            .select('cnpj_cpf, saldo')
+            .in('status_titulo', [...OPEN_TITLE_STATUSES])
+            .lt('data_vencimento', corteVencido)
+            .gt('saldo', 0)
+            .order('id', { ascending: true })
+            .range(from, to),
+        ),
+        fetchAll<SnapshotRow>((from, to) =>
+          supabase
+            .from('carteira_positivacao_snapshot')
+            .select('customer_user_id, mes, eligible, had_order_in_month')
+            .gte('mes', cortePositivacao)
+            .order('id', { ascending: true })
+            .range(from, to),
+        ),
+        supabase
+          .from('fin_sync_log')
+          .select('completed_at')
+          .in('action', ['sync_contas_receber', 'sync_all'])
+          .eq('status', 'complete')
+          .order('completed_at', { ascending: false })
+          .limit(1),
+      ]);
+      if (syncRes.error) throw new Error(syncRes.error.message);
+
+      const ids = [...new Set(scores.map((s) => s.customer_user_id))];
+      const profileChunks = await Promise.all(
+        chunk(ids, 150).map((c) =>
+          supabase.from('profiles').select('user_id, name, razao_social, document, cnpj').in('user_id', c),
+        ),
+      );
+      const perfis: ProfileRow[] = [];
+      for (const res of profileChunks) {
+        if (res.error) throw new Error(res.error.message);
+        perfis.push(...((res.data ?? []) as ProfileRow[]));
+      }
+
+      const { contas, scoresCalculatedAt, positivacaoMes } = montarContasUti({ scores, perfis, titulos, snapshots });
+
+      return {
+        contas,
+        frescor: {
+          scoresCalculatedAt,
+          receberSyncAt: (syncRes.data?.[0]?.completed_at as string | null) ?? null,
+          positivacaoMes,
+        },
+      };
+    },
+  });
+}

--- a/src/pages/IntelligenceDashboard.tsx
+++ b/src/pages/IntelligenceDashboard.tsx
@@ -6,12 +6,13 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
-import { Activity, BarChart3, ShieldCheck, RefreshCw } from 'lucide-react';
+import { Activity, BarChart3, HeartPulse, ShieldCheck, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { IntelligenceOperationalTab } from '@/components/intelligence/IntelligenceOperationalTab';
 import { IntelligenceManagerialTab } from '@/components/intelligence/IntelligenceManagerialTab';
 import { IntelligenceStrategicTab } from '@/components/intelligence/IntelligenceStrategicTab';
+import { IntelligenceUtiTab } from '@/components/intelligence/IntelligenceUtiTab';
 import { IntelligenceUserSimulator } from '@/components/intelligence/IntelligenceUserSimulator';
 
 export default function IntelligenceDashboard() {
@@ -89,6 +90,11 @@ export default function IntelligenceDashboard() {
               <ShieldCheck className="w-3 h-3 mr-1" /> Estratégico
             </TabsTrigger>
           )}
+          {(canViewManagerial || isAdmin) && (
+            <TabsTrigger value="uti" className="text-xs px-3 h-7">
+              <HeartPulse className="w-3 h-3 mr-1" /> UTI de Contas
+            </TabsTrigger>
+          )}
         </TabsList>
 
         <TabsContent value="operational" className="mt-4">
@@ -104,6 +110,12 @@ export default function IntelligenceDashboard() {
         {(canViewStrategic || isAdmin) && (
           <TabsContent value="strategic" className="mt-4">
             <IntelligenceStrategicTab />
+          </TabsContent>
+        )}
+
+        {(canViewManagerial || isAdmin) && (
+          <TabsContent value="uti" className="mt-4">
+            <IntelligenceUtiTab />
           </TabsContent>
         )}
       </Tabs>


### PR DESCRIPTION
## O que é

Primeira entrega do programa **"back to basics"** (inspirado no artigo do Brazil Journal sobre o turnaround da Pernambucanas). Ordem do programa decidida em consulta ao Codex: **UTI de contas → alerta de crédito no wizard → painel iceberg → bloqueio de crédito com aprovação → preço por tier**.

Aba nova **"UTI de Contas"** em `/intelligence` (gate: gerencial/admin) que consolida 3 sinais que já existem no banco em uma triagem de clientes críticos.

## Critérios (determinísticos, visíveis na UI)

| Sinal | Regra | Fonte |
|---|---|---|
| Churn | `churn_risk ≥ 70` OU `health_class = 'critico'` | `farmer_client_scores` |
| Inadimplência | saldo em aberto vencido há **31+ dias** > 0 | `fin_contas_receber` (vocabulário `OPEN_TITLE_STATUSES`), casado por CNPJ só-dígitos com `profiles.document`/`cnpj` |
| Positivação | elegível e **sem pedido nos 2 meses** mais recentes | `carteira_positivacao_snapshot` |

**Entrada na UTI:** ≥ 2 sinais ativos · **Observação:** 1 sinal · **Alta:** 0 sinais.

## Decisões money-path

- **Ausente ≠ zero:** sinal sem dado na fonte fica `null` ("sem dado" na UI) — cliente sem CNPJ não ganha "adimplente" fabricado; positivação com menos de 2 meses elegíveis não conclui nada.
- **Frescor visível por fonte** (pedido do Codex): último recálculo de scores, último `fin_sync_log` com `status='complete'` (⚠️ o valor real é `complete`, não `success`) e mês do snapshot.
- **Capa PostgREST de 1.000 linhas:** todas as leituras paginam com `.range()` + ordem estável.
- Busca por nome/CNPJ fica **fora** da URL (aviso de PII do `useUrlState`).

## Ação por linha

Botão "Tarefa" reusa o `CriarTarefaDialog` (dono = farmer da conta, empresa ativa) — a UTI já nasce acionável, não vira BI passivo (fatia 1c aprofunda a integração).

## Verificação

- typecheck ✅ · eslint ✅ · suíte completa (4.239) ✅
- Cômputo extraído em função pura `montarContasUti` + **11 casos novos** (entrada/alta, ausente≠zero, dedup por prioridade, normalização de CNPJ, ordenação, frescor)
- **Falsificado:** sabotei a regra ausente≠zero → vermelho; restaurei → verde.

## Deploy

Só frontend — precisa de **Publish** no Lovable após o merge (sem migration, sem edge).

## Próximas fatias do programa

1b detalhe do cliente com sinais explicáveis · 1c/1d ritual semanal + alta registrada · depois Fase 1 da trava de crédito (alerta auditável no wizard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
