### PR TITLE
feat(venda): alerta de crédito no wizard — Fase 1, informativo e auditável

### DIFF
--- a/src/components/unified-order/AlertaCreditoCliente.tsx
+++ b/src/components/unified-order/AlertaCreditoCliente.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useRef } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { useAlertaCreditoCliente, ALERTA_CREDITO } from '@/hooks/useAlertaCreditoCliente';
+import { formatBRL, formatDate } from '@/lib/reposicao';
+import { track } from '@/lib/analytics';
+
+/**
+ * Banner informativo de crédito no passo de cliente do wizard (Fase 1 — NÃO bloqueia).
+ * Só renderiza com evidência positiva de vencido 60+ (precisão > recall: sem dado,
+ * silêncio — nada de "cliente OK" fabricado). Auditável via track() para medir
+ * exibição × reação antes de a Fase 2 introduzir bloqueio com aprovação.
+ */
+export function AlertaCreditoCliente({ documento }: { documento: string | null | undefined }) {
+  const { data: alerta, error } = useAlertaCreditoCliente(documento);
+
+  // Auditoria: 1 evento por cliente selecionado (não por re-render).
+  const trackedDoc = useRef<string | null>(null);
+  useEffect(() => {
+    const doc = (documento ?? '').replace(/\D/g, '');
+    if (alerta && doc && trackedDoc.current !== doc) {
+      trackedDoc.current = doc;
+      track('venda.alerta_credito_exibido', {
+        vencido: alerta.vencido,
+        titulos: alerta.titulos,
+        dado_defasado: alerta.dadoDefasado,
+      });
+    }
+  }, [alerta, documento]);
+
+  useEffect(() => {
+    if (error) track('venda.alerta_credito_erro', { message: error instanceof Error ? error.message : 'erro' });
+  }, [error]);
+
+  // Erro na fonte ou sem evidência → silêncio (o alerta informativo não pode travar a venda).
+  if (!alerta) return null;
+
+  return (
+    <div
+      className="bg-status-warning/10 border border-status-warning/30 rounded-lg p-3"
+      data-testid="alerta-credito-cliente"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="w-4 h-4 text-status-warning flex-shrink-0 mt-0.5" />
+        <div className="text-xs">
+          <p className="font-semibold text-status-warning">
+            Crédito: {formatBRL(alerta.vencido)} vencido há {ALERTA_CREDITO.diasVencidoMin}+ dias
+          </p>
+          <p className="text-muted-foreground mt-1">
+            {alerta.titulos} título{alerta.titulos > 1 ? 's' : ''} em aberto
+            {alerta.vencimentoMaisAntigo && <> · mais antigo desde {formatDate(alerta.vencimentoMaisAntigo)}</>}
+            {' '}· recomendação: alinhar com o financeiro antes de novo faturamento.
+          </p>
+          <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+            Dados do Omie{alerta.syncAt ? ` sincronizados em ${formatDate(alerta.syncAt.slice(0, 10))}` : ''}.
+            {alerta.dadoDefasado && (
+              <span className="text-status-warning"> Sync há mais de {ALERTA_CREDITO.defasagemMaxHoras}h — confirme no Omie antes de decidir.</span>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/unified-order/__tests__/AlertaCreditoCliente.test.tsx
+++ b/src/components/unified-order/__tests__/AlertaCreditoCliente.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AlertaCreditoCliente } from '../AlertaCreditoCliente';
+import type { AlertaCredito } from '@/hooks/useAlertaCreditoCliente';
+
+const mockUseAlerta = vi.fn();
+vi.mock('@/hooks/useAlertaCreditoCliente', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/hooks/useAlertaCreditoCliente')>();
+  return { ...mod, useAlertaCreditoCliente: (doc: string | null | undefined) => mockUseAlerta(doc) };
+});
+
+const mockTrack = vi.fn();
+vi.mock('@/lib/analytics', () => ({ track: (...args: unknown[]) => mockTrack(...args) }));
+
+const alerta = (over: Partial<AlertaCredito> = {}): AlertaCredito => ({
+  vencido: 1234.56,
+  titulos: 2,
+  vencimentoMaisAntigo: '2026-03-15',
+  syncAt: '2026-07-02T08:00:00Z',
+  dadoDefasado: false,
+  ...over,
+});
+
+describe('AlertaCreditoCliente', () => {
+  beforeEach(() => {
+    mockUseAlerta.mockReset();
+    mockTrack.mockReset();
+  });
+
+  it('com evidência de vencido 60+ renderiza valor, títulos e recomendação', () => {
+    mockUseAlerta.mockReturnValue({ data: alerta(), error: null });
+    render(<AlertaCreditoCliente documento="12345678000190" />);
+    expect(screen.getByTestId('alerta-credito-cliente')).toBeTruthy();
+    expect(screen.getByText(/vencido há 60\+ dias/)).toBeTruthy();
+    expect(screen.getByText(/2 títulos em aberto/)).toBeTruthy();
+    expect(screen.getByText(/alinhar com o financeiro/)).toBeTruthy();
+  });
+
+  it('sem alerta (null) não renderiza NADA — nem "cliente OK" fabricado', () => {
+    mockUseAlerta.mockReturnValue({ data: null, error: null });
+    const { container } = render(<AlertaCreditoCliente documento="12345678000190" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('erro na fonte → silêncio (não trava a venda) + track de erro', () => {
+    mockUseAlerta.mockReturnValue({ data: undefined, error: new Error('boom') });
+    const { container } = render(<AlertaCreditoCliente documento="12345678000190" />);
+    expect(container.firstChild).toBeNull();
+    expect(mockTrack).toHaveBeenCalledWith('venda.alerta_credito_erro', expect.objectContaining({ message: 'boom' }));
+  });
+
+  it('dado defasado mostra o aviso de sync velho', () => {
+    mockUseAlerta.mockReturnValue({ data: alerta({ dadoDefasado: true, syncAt: null }), error: null });
+    render(<AlertaCreditoCliente documento="12345678000190" />);
+    expect(screen.getByText(/Sync há mais de 24h/)).toBeTruthy();
+  });
+
+  it('audita a exibição 1x por cliente (não por re-render)', () => {
+    mockUseAlerta.mockReturnValue({ data: alerta(), error: null });
+    const { rerender } = render(<AlertaCreditoCliente documento="12345678000190" />);
+    rerender(<AlertaCreditoCliente documento="12345678000190" />);
+    const exibicoes = mockTrack.mock.calls.filter((c) => c[0] === 'venda.alerta_credito_exibido');
+    expect(exibicoes).toHaveLength(1);
+    expect(exibicoes[0][1]).toMatchObject({ vencido: 1234.56, titulos: 2, dado_defasado: false });
+  });
+});

--- a/src/hooks/__tests__/useAlertaCreditoCliente.test.ts
+++ b/src/hooks/__tests__/useAlertaCreditoCliente.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { computeAlertaCredito, variantesDocumento, ALERTA_CREDITO } from '../useAlertaCreditoCliente';
+
+const AGORA = new Date('2026-07-02T12:00:00Z');
+
+describe('variantesDocumento', () => {
+  it('CNPJ só-dígitos gera as duas variantes (dígitos + formatado)', () => {
+    expect(variantesDocumento('12345678000190')).toEqual(['12345678000190', '12.345.678/0001-90']);
+  });
+
+  it('CNPJ formatado normaliza e gera as mesmas variantes', () => {
+    expect(variantesDocumento('12.345.678/0001-90')).toEqual(['12345678000190', '12.345.678/0001-90']);
+  });
+
+  it('CPF gera variantes de CPF', () => {
+    expect(variantesDocumento('12345678901')).toEqual(['12345678901', '123.456.789-01']);
+  });
+
+  it('documento inválido/ausente → null (sem query, sem alerta)', () => {
+    expect(variantesDocumento('1234')).toBeNull();
+    expect(variantesDocumento('')).toBeNull();
+    expect(variantesDocumento(null)).toBeNull();
+    expect(variantesDocumento(undefined)).toBeNull();
+  });
+});
+
+describe('computeAlertaCredito', () => {
+  it('sem títulos → null (silêncio, não "cliente OK")', () => {
+    expect(computeAlertaCredito([], '2026-07-02T10:00:00Z', AGORA)).toBeNull();
+  });
+
+  it('soma saldos, conta títulos e acha o vencimento mais antigo', () => {
+    const alerta = computeAlertaCredito(
+      [
+        { saldo: 100, data_vencimento: '2026-04-10' },
+        { saldo: 250.5, data_vencimento: '2026-03-01' },
+        { saldo: 50, data_vencimento: null },
+      ],
+      '2026-07-02T10:00:00Z',
+      AGORA,
+    );
+    expect(alerta).not.toBeNull();
+    expect(alerta!.vencido).toBeCloseTo(400.5);
+    expect(alerta!.titulos).toBe(3);
+    expect(alerta!.vencimentoMaisAntigo).toBe('2026-03-01');
+    expect(alerta!.dadoDefasado).toBe(false);
+  });
+
+  it('saldo null não fabrica número (ausente ≠ zero: soma ignora, não inventa)', () => {
+    // Só títulos com saldo null/0 → total 0 → null (sem evidência positiva, sem alerta)
+    expect(computeAlertaCredito([{ saldo: null, data_vencimento: '2026-01-01' }], null, AGORA)).toBeNull();
+  });
+
+  it('sync a mais de 24h marca dadoDefasado', () => {
+    const alerta = computeAlertaCredito(
+      [{ saldo: 100, data_vencimento: '2026-01-01' }],
+      '2026-06-30T10:00:00Z',
+      AGORA,
+    );
+    expect(alerta!.dadoDefasado).toBe(true);
+  });
+
+  it('sem registro de sync marca dadoDefasado (não assume frescor)', () => {
+    const alerta = computeAlertaCredito([{ saldo: 100, data_vencimento: '2026-01-01' }], null, AGORA);
+    expect(alerta!.dadoDefasado).toBe(true);
+    expect(alerta!.syncAt).toBeNull();
+  });
+
+  it('sync dentro da janela de 24h não marca defasagem', () => {
+    const dentroDaJanela = new Date(AGORA.getTime() - (ALERTA_CREDITO.defasagemMaxHoras - 1) * 3_600_000).toISOString();
+    const alerta = computeAlertaCredito([{ saldo: 100, data_vencimento: '2026-01-01' }], dentroDaJanela, AGORA);
+    expect(alerta!.dadoDefasado).toBe(false);
+  });
+});

--- a/src/hooks/useAlertaCreditoCliente.ts
+++ b/src/hooks/useAlertaCreditoCliente.ts
@@ -1,0 +1,134 @@
+import { useQuery } from '@tanstack/react-query';
+import { format, subDays } from 'date-fns';
+import { supabase } from '@/integrations/supabase/client';
+import { OPEN_TITLE_STATUSES } from '@/lib/financeiro/titulo-status';
+
+/**
+ * Alerta de crédito no wizard de venda — FASE 1 do programa "back to basics"
+ * (não bloqueia nada; Fase 2 é que adiciona aprovação de exceção).
+ *
+ * Critério: cliente com saldo em aberto vencido há 60+ dias (mesma régua que a
+ * Fase 2 vai endurecer — não mudar o critério entre fases).
+ *
+ * Money-path (precisão > recall): só alerta com EVIDÊNCIA POSITIVA de vencido.
+ * Sem documento, sem títulos ou erro na fonte → null (silêncio) — nunca um
+ * "cliente OK" fabricado, e nunca acusação sem dado. O frescor do sync é
+ * exibido junto (dados do Omie podem atrasar) com flag explícita de defasagem.
+ */
+
+export const ALERTA_CREDITO = {
+  diasVencidoMin: 60,
+  defasagemMaxHoras: 24,
+} as const;
+
+export interface TituloVencidoRow {
+  saldo: number | null;
+  data_vencimento: string | null;
+}
+
+export interface AlertaCredito {
+  /** R$ total em aberto vencido há 60+ dias. */
+  vencido: number;
+  titulos: number;
+  /** Vencimento mais antigo (yyyy-MM-dd). */
+  vencimentoMaisAntigo: string | null;
+  /** Último sync de recebíveis concluído (fin_sync_log status 'complete'). */
+  syncAt: string | null;
+  /** true quando o sync está a mais de 24h (ou sem registro) — dado pode estar defasado. */
+  dadoDefasado: boolean;
+}
+
+/**
+ * Variantes do documento para casar com `fin_contas_receber.cnpj_cpf` sem `.or()`
+ * cru (armadilha PostgREST): só-dígitos + formatado CNPJ/CPF. Retorna null se o
+ * documento não tem 11 (CPF) ou 14 (CNPJ) dígitos — sem documento válido, sem query.
+ */
+export function variantesDocumento(documento: string | null | undefined): string[] | null {
+  const digits = (documento ?? '').replace(/\D/g, '');
+  if (digits.length === 14) {
+    return [digits, digits.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5')];
+  }
+  if (digits.length === 11) {
+    return [digits, digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4')];
+  }
+  return null;
+}
+
+/** Cômputo puro (testável sem Supabase). `titulos` já vem filtrado pelo query (aberto + 60d + saldo > 0). */
+export function computeAlertaCredito(
+  titulos: TituloVencidoRow[],
+  syncAt: string | null,
+  agora: Date,
+): AlertaCredito | null {
+  if (titulos.length === 0) return null;
+
+  let vencido = 0;
+  let vencimentoMaisAntigo: string | null = null;
+  for (const t of titulos) {
+    vencido += Number(t.saldo ?? 0);
+    if (t.data_vencimento && (!vencimentoMaisAntigo || t.data_vencimento < vencimentoMaisAntigo)) {
+      vencimentoMaisAntigo = t.data_vencimento;
+    }
+  }
+  if (vencido <= 0) return null;
+
+  const dadoDefasado =
+    !syncAt || agora.getTime() - new Date(syncAt).getTime() > ALERTA_CREDITO.defasagemMaxHoras * 3_600_000;
+
+  return { vencido, titulos: titulos.length, vencimentoMaisAntigo, syncAt, dadoDefasado };
+}
+
+const PAGE = 1000;
+
+/** Pagina além da capa silenciosa de 1.000 linhas do PostgREST (achado Codex — nunca truncar soma money-path). */
+async function fetchTitulosVencidos(variantes: string[], corte: string): Promise<TituloVencidoRow[]> {
+  const out: TituloVencidoRow[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('fin_contas_receber')
+      .select('saldo, data_vencimento')
+      .in('cnpj_cpf', variantes)
+      .in('status_titulo', [...OPEN_TITLE_STATUSES])
+      .lt('data_vencimento', corte)
+      .gt('saldo', 0)
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(error.message);
+    const rows = (data ?? []) as TituloVencidoRow[];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return out;
+}
+
+export function useAlertaCreditoCliente(documento: string | null | undefined) {
+  const variantes = variantesDocumento(documento);
+
+  return useQuery({
+    queryKey: ['alerta-credito', variantes?.[0] ?? null],
+    enabled: variantes !== null,
+    staleTime: 60_000,
+    queryFn: async (): Promise<AlertaCredito | null> => {
+      if (!variantes) return null;
+      const corte = format(subDays(new Date(), ALERTA_CREDITO.diasVencidoMin), 'yyyy-MM-dd');
+
+      const [titulos, syncRes] = await Promise.all([
+        fetchTitulosVencidos(variantes, corte),
+        supabase
+          .from('fin_sync_log')
+          .select('completed_at')
+          .in('action', ['sync_contas_receber', 'sync_all'])
+          .eq('status', 'complete')
+          .order('completed_at', { ascending: false })
+          .limit(1),
+      ]);
+      if (syncRes.error) throw new Error(syncRes.error.message);
+
+      return computeAlertaCredito(
+        titulos,
+        (syncRes.data?.[0]?.completed_at as string | null) ?? null,
+        new Date(),
+      );
+    },
+  });
+}

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -19,6 +19,7 @@ import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useOfflineSubmit } from '@/hooks/useOfflineSubmit';
 import { RestoreDraftDialog } from '@/components/unified-order/RestoreDraftDialog';
 import { CustomerSearch } from '@/components/unified-order/CustomerSearch';
+import { AlertaCreditoCliente } from '@/components/unified-order/AlertaCreditoCliente';
 import { CoresDoClienteCard } from '@/components/unified-order/CoresDoClienteCard';
 import { useCoresDoCliente } from '@/hooks/unifiedOrder/useCoresDoCliente';
 import type { CorDoCliente, OcorrenciaCor } from '@/lib/tint/cores-do-cliente';
@@ -331,6 +332,11 @@ const UnifiedOrder = () => {
               vendedorDivergencias={h.vendedorDivergencias}
               onSelectCustomer={h.selectCustomer} onClearCustomer={h.clearCustomer}
             />
+          )}
+
+          {/* Alerta de crédito (Fase 1 — informativo, não bloqueia) */}
+          {showCustomerSearch && h.selectedCustomer && (
+            <AlertaCreditoCliente documento={h.selectedCustomer.cnpj_cpf} />
           )}
 
           {/* Cores já pedidas pelo cliente — busca + re-pedido (staff) */}


### PR DESCRIPTION
## O que é

**Item 2 do programa "back to basics"** (Pernambucanas → [PR #1140](https://github.com/LucasSardenbergL/afiacao/pull/1140) trouxe a UTI; ordem do programa decidida com Codex): a trava de crédito nasce em **duas fases** — esta é a **Fase 1, alerta informativo e auditável**, que prova dado/UX/falsos positivos ANTES de qualquer bloqueio (Fase 2: bloqueio com aprovação de gestor).

Ao selecionar um cliente no wizard de venda com **saldo em aberto vencido há 60+ dias**, aparece um banner (warning, não bloqueante) com: valor vencido, nº de títulos, vencimento mais antigo, recomendação ("alinhar com o financeiro antes de novo faturamento") e o **frescor do sync do Omie** com flag explícita quando o dado tem mais de 24h.

## Decisões money-path

- **Precisão > recall:** alerta só com **evidência positiva** — sem CNPJ válido, sem títulos 60+ ou erro na fonte → silêncio total (nunca "cliente OK" fabricado, nunca acusação sem dado).
- **Régua única entre fases:** 60+ dias já é o critério que a Fase 2 endurece — não muda a régua no meio do caminho.
- **Vocabulário canônico:** `OPEN_TITLE_STATUSES` + coluna gerada `saldo` (não repete o padrão frágil visto no cockpit de filtrar só `'ATRASADO'` e recalcular `doc − recebido` na mão — bug #396).
- **Match de documento por variantes** (só-dígitos + formatado) via `.in()` — sem `.or()` cru.
- **Paginação `.range()` + ordem estável** na soma (achado do `codex review` — nunca truncar soma money-path na capa de 1.000 do PostgREST).
- **Auditável:** `track('venda.alerta_credito_exibido')` 1x por cliente (com valor/títulos/defasagem) e `track('venda.alerta_credito_erro')` — o funil exibido × pedido-submetido sai no PostHog e calibra a Fase 2.

## Wizard (arquivo quente) — toque mínimo

`UnifiedOrder.tsx`: **1 import + 3 linhas de JSX** (entre `CustomerSearch` e `CoresDoClienteCard`). Toda a lógica vive em `useAlertaCreditoCliente.ts` + `AlertaCreditoCliente.tsx` (arquivos novos). Estratégia do Codex: "funções/hooks isolados fora do wizard; alteração pequena no wizard".

## Verificação

- typecheck ✅ · eslint ✅ (1 warning pré-existente no wizard, linha não tocada) · suíte completa **4.265** ✅
- Cômputo puro (`computeAlertaCredito`, `variantesDocumento`) + **15 casos novos** (variantes CNPJ/CPF, ausente≠zero, defasagem, silêncio-em-erro, auditoria 1x)
- **Falsificado:** guard de evidência sabotado → vermelho; restaurado → verde
- **`codex review` no diff: GATE PASS** (0 críticos; o único advisory — paginação da soma — foi aplicado)

## Vias NÃO cobertas (anotação para a Fase 2)

O alerta vive no wizard (via principal). As demais vias até o Omie — conversão de orçamento (`SalesQuotes.convertToOrder`), edição (`useSalesOrderEdit`) e retry — **não** mostram o alerta; a Fase 2 (enforcement) precisa gatear **na fronteira comum** (`omie-vendas-sync`), não na UI, exatamente como manda o `money-path.md` §5.

## Deploy

Só frontend — **Publish** no Lovable após o merge (sem migration, sem edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
