### PR TITLE
feat(reposicao): seleção em massa de itens do pedido + remoção em lote

### DIFF
--- a/src/components/reposicao/pedidos/ConfirmacaoDialogs.tsx
+++ b/src/components/reposicao/pedidos/ConfirmacaoDialogs.tsx
@@ -46,6 +46,56 @@ export function RemoverItemDialog({
   );
 }
 
+// Confirmação em LOTE: mesma semântica de N remoções individuais (delete + recálculo do
+// cabeçalho; pedido vazio cancela), mas com UMA confirmação. Lista até 5 SKUs + excedente.
+export function RemoverItensLoteDialog({
+  itens,
+  onOpenChange,
+  pending,
+  onConfirm,
+}: {
+  itens: PedidoItem[] | null;
+  onOpenChange: (v: boolean) => void;
+  pending: boolean;
+  onConfirm: () => void;
+}) {
+  const lista = itens ?? [];
+  const n = lista.length;
+  const rotulo = `${n} ${n === 1 ? 'item' : 'itens'}`;
+  return (
+    <AlertDialog open={n > 0} onOpenChange={(v) => !v && onOpenChange(false)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remover {rotulo} do pedido?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div>
+              <ul className="list-disc pl-5 space-y-0.5">
+                {lista.slice(0, 5).map((it) => (
+                  <li key={it.id}>
+                    <span className="font-mono">{it.sku_codigo_omie}</span> — {it.sku_descricao ?? '—'}
+                  </li>
+                ))}
+              </ul>
+              {n > 5 && <p className="mt-1">+{n - 5} outro(s)</p>}
+              <p className="mt-2">
+                O valor total do pedido será recalculado. Se remover todos os itens, o pedido será
+                cancelado automaticamente.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={pending}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction disabled={pending} onClick={onConfirm}>
+            {pending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
+            Remover {rotulo}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 export function DescontinuarItemDialog({
   item,
   onOpenChange,

--- a/src/components/reposicao/pedidos/DetalhesModal.tsx
+++ b/src/components/reposicao/pedidos/DetalhesModal.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AlertTriangle, Loader2 } from 'lucide-react';
+import { AlertTriangle, Loader2, Trash2 } from 'lucide-react';
 import { PedidoSugerido } from './types';
 import { formatBRL, formatTime } from './shared';
 import { StatusBadge, SplitInfo } from './badges';
@@ -12,7 +12,7 @@ import { HistoricoAcoesPanel } from './HistoricoAcoesPanel';
 import { CondicaoPagamentoPanel } from './CondicaoPagamentoPanel';
 import { ItensTable } from './ItensTable';
 import { EmbalagemPanel } from './EmbalagemPanel';
-import { RemoverItemDialog, DescontinuarItemDialog } from './ConfirmacaoDialogs';
+import { RemoverItemDialog, DescontinuarItemDialog, RemoverItensLoteDialog } from './ConfirmacaoDialogs';
 
 /* ─── Detalhes Modal ─── */
 export function DetalhesModal({
@@ -53,6 +53,13 @@ export function DetalhesModal({
     podeEditar,
     podeEditarCondicao,
     podeEditarPreco,
+    selecionados,
+    toggleSelecionado,
+    toggleTodos,
+    linhasSelecionadas,
+    confirmarRemocaoLote,
+    setConfirmarRemocaoLote,
+    removerLoteMutation,
   } = useDetalhesModal({ pedido, open, onOpenChange, onApproved });
 
   if (!pedido) return null;
@@ -111,18 +118,41 @@ export function DetalhesModal({
             <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
           </div>
         ) : (
-          <ItensTable
-            linhas={linhas}
-            podeEditar={podeEditar}
-            totalAtual={totalAtual}
-            onEditQty={onEditQty}
-            podeEditarPreco={podeEditarPreco}
-            onEditPreco={onEditPreco}
-            onRemover={(l) => setRemoverItem(l)}
-            onDescontinuar={(l) => setDescontinuarItem(l)}
-            removerPending={removerItemMutation.isPending}
-            descontinuarPending={descontinuarMutation.isPending}
-          />
+          <>
+            {podeEditar && linhasSelecionadas.length > 0 && (
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-status-warning/40 bg-status-warning/5 px-3 py-2 text-sm">
+                <span>
+                  <strong>{linhasSelecionadas.length}</strong>{' '}
+                  {linhasSelecionadas.length === 1 ? 'item selecionado' : 'itens selecionados'} —{' '}
+                  {formatBRL(linhasSelecionadas.reduce((acc, l) => acc + l._valor, 0))}
+                </span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => setConfirmarRemocaoLote(true)}
+                  disabled={removerLoteMutation.isPending}
+                >
+                  <Trash2 className="w-4 h-4 mr-1" />
+                  Remover selecionados
+                </Button>
+              </div>
+            )}
+            <ItensTable
+              linhas={linhas}
+              podeEditar={podeEditar}
+              totalAtual={totalAtual}
+              onEditQty={onEditQty}
+              podeEditarPreco={podeEditarPreco}
+              onEditPreco={onEditPreco}
+              onRemover={(l) => setRemoverItem(l)}
+              onDescontinuar={(l) => setDescontinuarItem(l)}
+              removerPending={removerItemMutation.isPending}
+              descontinuarPending={descontinuarMutation.isPending}
+              selecionados={selecionados}
+              onToggleSelecionado={toggleSelecionado}
+              onToggleTodos={toggleTodos}
+            />
+          </>
         )}
 
         {!isLoading && <EmbalagemPanel empresa={pedido.empresa} itens={linhas} />}
@@ -180,6 +210,14 @@ export function DetalhesModal({
         onOpenChange={() => setDescontinuarItem(null)}
         pending={descontinuarMutation.isPending}
         onConfirm={() => descontinuarItem && descontinuarMutation.mutate(descontinuarItem)}
+      />
+
+      {/* Confirmação: remover selecionados em lote */}
+      <RemoverItensLoteDialog
+        itens={confirmarRemocaoLote ? linhasSelecionadas : null}
+        onOpenChange={() => setConfirmarRemocaoLote(false)}
+        pending={removerLoteMutation.isPending}
+        onConfirm={() => removerLoteMutation.mutate()}
       />
     </Dialog>
   );

--- a/src/components/reposicao/pedidos/ItensTable.tsx
+++ b/src/components/reposicao/pedidos/ItensTable.tsx
@@ -3,6 +3,7 @@
 import { Ban, Trash2 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { cn } from '@/lib/utils';
@@ -21,6 +22,10 @@ interface ItensTableProps {
   onDescontinuar: (l: Linha) => void;
   removerPending: boolean;
   descontinuarPending: boolean;
+  // Seleção em massa (só em pedido editável): marcar N itens → "Remover selecionados".
+  selecionados: ReadonlySet<number>;
+  onToggleSelecionado: (id: number) => void;
+  onToggleTodos: () => void;
 }
 
 export function ItensTable({
@@ -34,11 +39,25 @@ export function ItensTable({
   onDescontinuar,
   removerPending,
   descontinuarPending,
+  selecionados,
+  onToggleSelecionado,
+  onToggleTodos,
 }: ItensTableProps) {
+  const todosSelecionados = linhas.length > 0 && linhas.every((l) => selecionados.has(l.id));
+  const algumSelecionado = linhas.some((l) => selecionados.has(l.id));
   return (
     <Table>
       <TableHeader>
         <TableRow>
+          {podeEditar && (
+            <TableHead className="w-8">
+              <Checkbox
+                aria-label="Selecionar todos os itens"
+                checked={todosSelecionados ? true : algumSelecionado ? 'indeterminate' : false}
+                onCheckedChange={onToggleTodos}
+              />
+            </TableHead>
+          )}
           <TableHead className="w-[34%] min-w-[300px]">SKU / Descrição</TableHead>
           <TableHead
             className="text-right"
@@ -69,7 +88,16 @@ export function ItensTable({
           const aCaminho = l.estoque_a_caminho;
           const temSplit = fisico != null && aCaminho != null && Number(aCaminho) > 0;
           return (
-          <TableRow key={l.id}>
+          <TableRow key={l.id} data-state={selecionados.has(l.id) ? 'selected' : undefined}>
+            {podeEditar && (
+              <TableCell className="align-top">
+                <Checkbox
+                  aria-label={`Selecionar item ${l.sku_codigo_omie}`}
+                  checked={selecionados.has(l.id)}
+                  onCheckedChange={() => onToggleSelecionado(l.id)}
+                />
+              </TableCell>
+            )}
             <TableCell className="align-top whitespace-normal">
               <div className="font-mono text-xs text-muted-foreground">{l.sku_codigo_omie}</div>
               <div className="text-sm font-medium whitespace-normal break-words leading-snug">
@@ -171,7 +199,7 @@ export function ItensTable({
           );
         })}
         <TableRow>
-          <TableCell colSpan={8} className="text-right font-medium">Total</TableCell>
+          <TableCell colSpan={podeEditar ? 9 : 8} className="text-right font-medium">Total</TableCell>
           <TableCell className="text-right font-bold tabular-nums">{formatBRL(totalAtual)}</TableCell>
           {podeEditar && <TableCell />}
         </TableRow>

--- a/src/components/reposicao/pedidos/__tests__/ConfirmacaoDialogs.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/ConfirmacaoDialogs.test.tsx
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { RemoverItemDialog, DescontinuarItemDialog } from '../ConfirmacaoDialogs';
+import { RemoverItemDialog, DescontinuarItemDialog, RemoverItensLoteDialog } from '../ConfirmacaoDialogs';
 import type { PedidoItem } from '../types';
 
 const item = { id: 3, sku_codigo_omie: '777', sku_descricao: 'Catalisador' } as unknown as PedidoItem;
+
+const itemLote = (id: number, sku: string) =>
+  ({ id, sku_codigo_omie: sku, sku_descricao: `Produto ${sku}` }) as unknown as PedidoItem;
 
 describe('RemoverItemDialog', () => {
   it('fechado (item null) não renderiza título', () => {
@@ -33,5 +36,38 @@ describe('DescontinuarItemDialog', () => {
   it('desabilita ações quando pending', () => {
     render(<DescontinuarItemDialog item={item} onOpenChange={() => {}} pending onConfirm={() => {}} />);
     expect(screen.getByRole('button', { name: /Descontinuar e remover/ })).toHaveProperty('disabled', true);
+  });
+});
+
+describe('RemoverItensLoteDialog', () => {
+  it('fechado (null ou lista vazia) não renderiza título', () => {
+    render(<RemoverItensLoteDialog itens={null} onOpenChange={() => {}} pending={false} onConfirm={() => {}} />);
+    expect(screen.queryByText(/Remover .* itens do pedido\?/)).toBeNull();
+    render(<RemoverItensLoteDialog itens={[]} onOpenChange={() => {}} pending={false} onConfirm={() => {}} />);
+    expect(screen.queryByText(/Remover .* itens do pedido\?/)).toBeNull();
+  });
+
+  it('aberto: mostra contagem, lista até 5 SKUs e resume o excedente', () => {
+    const itens = ['111', '222', '333', '444', '555', '666', '777'].map((sku, i) => itemLote(i + 1, sku));
+    render(<RemoverItensLoteDialog itens={itens} onOpenChange={() => {}} pending={false} onConfirm={() => {}} />);
+    expect(screen.getByText('Remover 7 itens do pedido?')).toBeTruthy();
+    expect(screen.getByText('111')).toBeTruthy();
+    expect(screen.getByText('555')).toBeTruthy();
+    expect(screen.queryByText('666')).toBeNull();
+    expect(screen.getByText(/\+2 outro\(s\)/)).toBeTruthy();
+  });
+
+  it('confirma dispara onConfirm; pending desabilita', () => {
+    const onConfirm = vi.fn();
+    const { unmount } = render(
+      <RemoverItensLoteDialog itens={[itemLote(1, '111')]} onOpenChange={() => {}} pending={false} onConfirm={onConfirm} />,
+    );
+    expect(screen.getByText('Remover 1 item do pedido?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /^Remover 1 item$/ }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    unmount();
+
+    render(<RemoverItensLoteDialog itens={[itemLote(1, '111')]} onOpenChange={() => {}} pending onConfirm={() => {}} />);
+    expect(screen.getByRole('button', { name: /^Remover 1 item$/ })).toHaveProperty('disabled', true);
   });
 });

--- a/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
+++ b/src/components/reposicao/pedidos/__tests__/ItensTable.test.tsx
@@ -40,6 +40,9 @@ function setup(overrides: Partial<React.ComponentProps<typeof ItensTable>> = {})
     onDescontinuar: vi.fn(),
     removerPending: false,
     descontinuarPending: false,
+    selecionados: new Set<number>(),
+    onToggleSelecionado: vi.fn(),
+    onToggleTodos: vi.fn(),
     ...overrides,
   };
   render(<ItensTable {...props} />);
@@ -112,5 +115,31 @@ describe('ItensTable', () => {
   it('item antigo (split NULL): cai no efetivo sem sublinha', () => {
     setup({ podeEditar: false, linhas: [linha({ estoque_atual: 5, estoque_fisico: null, estoque_a_caminho: null })] });
     expect(screen.queryByText(/a caminho/)).toBeNull();
+  });
+});
+
+describe('ItensTable — seleção em massa', () => {
+  it('editável: 1 checkbox por linha + selecionar-todos no cabeçalho', () => {
+    setup({ linhas: [linha({ id: 1 }), linha({ id: 2, sku_codigo_omie: '556' })] });
+    // 2 linhas + 1 cabeçalho
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+  });
+
+  it('toggle de linha chama onToggleSelecionado com o id; cabeçalho chama onToggleTodos', () => {
+    const props = setup({ linhas: [linha({ id: 7 })] });
+    fireEvent.click(screen.getByLabelText('Selecionar item 555'));
+    expect(props.onToggleSelecionado).toHaveBeenCalledWith(7);
+    fireEvent.click(screen.getByLabelText('Selecionar todos os itens'));
+    expect(props.onToggleTodos).toHaveBeenCalledTimes(1);
+  });
+
+  it('linha selecionada renderiza checkbox marcado', () => {
+    setup({ linhas: [linha({ id: 7 })], selecionados: new Set([7]) });
+    expect(screen.getByLabelText('Selecionar item 555').getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('sem permissão de edição: nenhum checkbox', () => {
+    setup({ podeEditar: false });
+    expect(screen.queryAllByRole('checkbox')).toHaveLength(0);
   });
 });

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -29,6 +29,9 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
   const [condicaoCodigo, setCondicaoCodigo] = useState<string>('');
   const [removerItem, setRemoverItem] = useState<PedidoItem | null>(null);
   const [descontinuarItem, setDescontinuarItem] = useState<PedidoItem | null>(null);
+  // Seleção em massa p/ remoção em lote (ids de pedido_compra_item).
+  const [selecionados, setSelecionados] = useState<ReadonlySet<number>>(new Set());
+  const [confirmarRemocaoLote, setConfirmarRemocaoLote] = useState(false);
 
   // Catálogo de condições de pagamento Omie (carregado uma vez)
   const { data: condicoes = [] } = useQuery({
@@ -86,6 +89,8 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
       setPrecoEdits({});
       setObs('');
       setCondicaoCodigo('');
+      setSelecionados(new Set());
+      setConfirmarRemocaoLote(false);
     } else if (pedido) {
       setCondicaoCodigo(pedido.condicao_pagamento_codigo ?? '');
     }
@@ -281,6 +286,58 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
     },
   });
 
+  // Só ids que ainda existem em linhas contam (item removido individualmente sai da
+  // seleção sozinho — a seleção "válida" é derivada, não estado duplicado).
+  const linhasSelecionadas = useMemo(
+    () => linhas.filter((l) => selecionados.has(l.id)),
+    [linhas, selecionados],
+  );
+
+  const toggleSelecionado = (id: number) => {
+    setSelecionados((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  // Todos visíveis selecionados → limpa; senão seleciona todos.
+  const toggleTodos = () => {
+    setSelecionados((prev) => {
+      const todos = linhas.length > 0 && linhas.every((l) => prev.has(l.id));
+      return todos ? new Set() : new Set(linhas.map((l) => l.id));
+    });
+  };
+
+  // Remoção em LOTE: mesma semântica de N remoções individuais, com UM delete (.in é
+  // filtro simples — a armadilha PostgREST é o .or em UPDATE) e UM recálculo do cabeçalho.
+  const removerLoteMutation = useMutation({
+    mutationFn: async () => {
+      const ids = linhasSelecionadas.map((l) => l.id);
+      if (ids.length === 0) return { vazio: false, removidos: 0 };
+      const { error } = await supabase.from('pedido_compra_item').delete().in('id', ids);
+      if (error) throw error;
+      const res = await recalcularPedido();
+      return { vazio: res?.vazio ?? false, removidos: ids.length };
+    },
+    onSuccess: (res) => {
+      toast.success(
+        res.vazio
+          ? `${res.removidos} itens removidos. Pedido cancelado (sem itens restantes).`
+          : `${res.removidos} ${res.removidos === 1 ? 'item removido' : 'itens removidos'}`,
+      );
+      queryClient.invalidateQueries({ queryKey: ['pedido-itens', pedido?.id] });
+      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
+      setSelecionados(new Set());
+      setConfirmarRemocaoLote(false);
+      if (res.vazio) onOpenChange(false);
+    },
+    onError: (e: Error) => {
+      toast.error(`Erro ao remover itens: ${e.message}`);
+    },
+  });
+
   const descontinuarMutation = useMutation({
     mutationFn: async (item: PedidoItem) => {
       // 1. descontinua o SKU
@@ -367,5 +424,12 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
     podeEditar,
     podeEditarCondicao,
     podeEditarPreco,
+    selecionados,
+    toggleSelecionado,
+    toggleTodos,
+    linhasSelecionadas,
+    confirmarRemocaoLote,
+    setConfirmarRemocaoLote,
+    removerLoteMutation,
   };
 }


### PR DESCRIPTION
## O que muda

Pedido do founder: *"marcar os itens que eu quero que sejam excluídos do pedido de compra em vez de um a um"*. Hoje excluir vários itens = N cliques na lixeira + N dialogs de confirmação + N recálculos do cabeçalho.

Agora, no modal de detalhes do pedido (status editável):

- **Coluna de checkbox** por item + **selecionar-todos** no cabeçalho (estado `indeterminate` em seleção parcial).
- **Barra de ação** quando há seleção: "N itens selecionados — R$ X" + botão **Remover selecionados**.
- **Uma confirmação** (lista até 5 SKUs + "+N outro(s)") → **um** `DELETE ... IN (ids)` + **um** `recalcularPedido()` — exatamente a mesma semântica da remoção individual (valor_total/num_skus recalculados; pedido esvaziado → `cancelado_humano` com higiene do sub-fluxo do portal).

## Notas de implementação

- Seleção **derivada** (`linhas.filter(selecionados.has)`): item removido individualmente sai da seleção sozinho; ids órfãos nunca chegam ao delete. Seleção limpa ao fechar o modal.
- `.in()` é filtro simples do PostgREST — a armadilha conhecida é `.or()` em UPDATE, não se aplica.
- Sem mudança de banco/edge; gates de status (`podeEditar`) idênticos aos botões por linha.

## Verificação

- TDD: 7 testes novos (seleção na `ItensTable`, dialog de lote) — RED antes da implementação, GREEN depois.
- Suíte da área 114/114; typecheck (strict) 0; eslint 0.

## Deploy (Lovable)

Frontend-only → **1 Publish** após o merge. Sem migration, sem deploy de edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
