### PR TITLE
feat(governanca): Painel Iceberg de iniciativas — cadastro + KPIs (mínimo)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,16 +21,16 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **316** custom migrations totais
-- **1069** objetos esperados (criados por estas migrations)
+- **318** custom migrations totais
+- **1078** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 314
-  - `rls_policy`: 228
-  - `index`: 193
-  - `table`: 113
+  - `function`: 315
+  - `rls_policy`: 233
+  - `index`: 194
+  - `table`: 114
   - `cron_job`: 110
   - `view`: 55
-  - `trigger`: 52
+  - `trigger`: 53
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -2653,6 +2653,24 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.kb_catalisador_links_unique_quad` | `kb_catalisador_links` |
 | `index` | `public.kb_catalisador_links_norm` | `kb_catalisador_links` |
 | `rls_policy` | `public.kb_catalisador_links_select_staff` | `kb_catalisador_links` |
+
+### `20260702210000_gov_iniciativas_iceberg.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gov_iniciativas_set_updated_at` | — |
+| `table` | `public.gov_iniciativas` | — |
+| `index` | `public.idx_gov_iniciativas_empresa_status` | `gov_iniciativas` |
+| `trigger` | `public.trg_gov_iniciativas_updated_at` | `gov_iniciativas` |
+| `rls_policy` | `public.gov_iniciativas_select_staff` | `gov_iniciativas` |
+| `rls_policy` | `public.gov_iniciativas_insert_master` | `gov_iniciativas` |
+| `rls_policy` | `public.gov_iniciativas_update_master_ou_dono` | `gov_iniciativas` |
+| `rls_policy` | `public.gov_iniciativas_delete_master` | `gov_iniciativas` |
+| `rls_policy` | `public.gov_iniciativas_service_all` | `gov_iniciativas` |
+
+### `20260702213000_gov_iniciativas_check_ganhos.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 316
+-- Total de custom migrations: 318
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -357,7 +357,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260627200000', 'fix_refresh_sku_ranking_gate_cron', '20260627200000_fix_refresh_sku_ranking_gate_cron.sql'),
   ('20260629120000', 'seg_customer_metrics_viewgate', '20260629120000_seg_customer_metrics_viewgate.sql'),
   ('20260629140000', 'reposicao_preco_ausente_null', '20260629140000_reposicao_preco_ausente_null.sql'),
-  ('20260629150000', 'kb_catalisador_links', '20260629150000_kb_catalisador_links.sql')
+  ('20260629150000', 'kb_catalisador_links', '20260629150000_kb_catalisador_links.sql'),
+  ('20260702210000', 'gov_iniciativas_iceberg', '20260702210000_gov_iniciativas_iceberg.sql'),
+  ('20260702213000', 'gov_iniciativas_check_ganhos', '20260702213000_gov_iniciativas_check_ganhos.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1415,7 +1417,16 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_one_confirmed', 'kb_catalisador_links'),
   ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_unique_quad', 'kb_catalisador_links'),
   ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_norm', 'kb_catalisador_links'),
-  ('kb_catalisador_links', 'rls_policy', 'public', 'kb_catalisador_links_select_staff', 'kb_catalisador_links')
+  ('kb_catalisador_links', 'rls_policy', 'public', 'kb_catalisador_links_select_staff', 'kb_catalisador_links'),
+  ('gov_iniciativas_iceberg', 'function', 'public', 'gov_iniciativas_set_updated_at', ''),
+  ('gov_iniciativas_iceberg', 'table', 'public', 'gov_iniciativas', ''),
+  ('gov_iniciativas_iceberg', 'index', 'public', 'idx_gov_iniciativas_empresa_status', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'trigger', 'public', 'trg_gov_iniciativas_updated_at', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_select_staff', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_insert_master', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_update_master_ou_dono', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_delete_master', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_service_all', 'gov_iniciativas')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2521,7 +2532,16 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_one_confirmed', 'kb_catalisador_links'),
   ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_unique_quad', 'kb_catalisador_links'),
   ('kb_catalisador_links', 'index', 'public', 'kb_catalisador_links_norm', 'kb_catalisador_links'),
-  ('kb_catalisador_links', 'rls_policy', 'public', 'kb_catalisador_links_select_staff', 'kb_catalisador_links')
+  ('kb_catalisador_links', 'rls_policy', 'public', 'kb_catalisador_links_select_staff', 'kb_catalisador_links'),
+  ('gov_iniciativas_iceberg', 'function', 'public', 'gov_iniciativas_set_updated_at', ''),
+  ('gov_iniciativas_iceberg', 'table', 'public', 'gov_iniciativas', ''),
+  ('gov_iniciativas_iceberg', 'index', 'public', 'idx_gov_iniciativas_empresa_status', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'trigger', 'public', 'trg_gov_iniciativas_updated_at', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_select_staff', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_insert_master', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_update_master_ou_dono', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_delete_master', 'gov_iniciativas'),
+  ('gov_iniciativas_iceberg', 'rls_policy', 'public', 'gov_iniciativas_service_all', 'gov_iniciativas')
 )
 SELECT
   e.migration,

--- a/src/components/governanca/IniciativaDialog.tsx
+++ b/src/components/governanca/IniciativaDialog.tsx
@@ -1,0 +1,344 @@
+// Dialog de criar/editar iniciativa do Painel Iceberg.
+// Espelha no client o CHECK do banco: status 'recorrente' exige evidência.
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useAuth } from '@/contexts/AuthContext';
+import { COMPANIES } from '@/contexts/CompanyContext';
+import { useStaffUsersWithDept } from '@/hooks/useDepartmentsAdmin';
+import {
+  ALAVANCA_INICIATIVA,
+  STATUS_INICIATIVA,
+  useIniciativaMutations,
+  type IniciativaIceberg,
+  type NovaIniciativa,
+} from '@/hooks/useIniciativasIceberg';
+import { track } from '@/lib/analytics';
+
+const SEM_DONO = '__sem_dono__';
+const VALOR_REGEX = /^\d{1,12}([.,]\d{1,2})?$/;
+
+const valorOpcional = z
+  .string()
+  .trim()
+  .refine((s) => s === '' || VALOR_REGEX.test(s), 'Valor inválido (use 1234,56)');
+
+/** Exportado para teste: espelha o CHECK gov_iniciativas_recorrente_exige_evidencia. */
+export const iniciativaSchema = z
+  .object({
+    titulo: z.string().trim().min(3, 'Dê um título (mín. 3 caracteres)'),
+    empresa: z.enum(['colacor', 'oben', 'colacor_sc']),
+    alavanca: z.enum(['receita', 'margem', 'custo', 'caixa', 'risco', 'outro']),
+    status: z.enum(['ideia', 'em_execucao', 'maturando', 'recorrente', 'pausada', 'cancelada']),
+    dono_id: z.string(),
+    ganho_esperado_mensal: valorOpcional,
+    ganho_recorrente_mensal: valorOpcional,
+    inicio_em: z.string(),
+    recorrente_desde: z.string(),
+    descricao: z.string(),
+    evidencia: z.string(),
+  })
+  .superRefine((v, ctx) => {
+    if (v.status === 'recorrente' && v.evidencia.trim() === '') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['evidencia'],
+        message: 'Marcar "Recorrente" exige registrar a evidência do ganho.',
+      });
+    }
+  });
+
+export type IniciativaFormValues = z.infer<typeof iniciativaSchema>;
+
+/** '' → null (ausente ≠ zero: campo vazio nunca vira 0). */
+function parseValor(s: string): number | null {
+  const t = s.trim();
+  return t === '' ? null : Number(t.replace(',', '.'));
+}
+
+function rowToForm(i: IniciativaIceberg | null): IniciativaFormValues {
+  return {
+    titulo: i?.titulo ?? '',
+    empresa: (i?.empresa as IniciativaFormValues['empresa']) ?? 'colacor',
+    alavanca: (i?.alavanca as IniciativaFormValues['alavanca']) ?? 'outro',
+    status: (i?.status as IniciativaFormValues['status']) ?? 'ideia',
+    dono_id: i?.dono_id ?? SEM_DONO,
+    ganho_esperado_mensal: i?.ganho_esperado_mensal != null ? String(i.ganho_esperado_mensal) : '',
+    ganho_recorrente_mensal:
+      i?.ganho_recorrente_mensal != null ? String(i.ganho_recorrente_mensal) : '',
+    inicio_em: i?.inicio_em ?? '',
+    recorrente_desde: i?.recorrente_desde ?? '',
+    descricao: i?.descricao ?? '',
+    evidencia: i?.evidencia ?? '',
+  };
+}
+
+interface IniciativaDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** null = criar nova. */
+  iniciativa: IniciativaIceberg | null;
+}
+
+export function IniciativaDialog({ open, onOpenChange, iniciativa }: IniciativaDialogProps) {
+  const { criar, atualizar } = useIniciativaMutations();
+  const { isMaster } = useAuth();
+  const { data: staff } = useStaffUsersWithDept();
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<IniciativaFormValues>({
+    resolver: zodResolver(iniciativaSchema),
+    defaultValues: rowToForm(iniciativa),
+  });
+
+  useEffect(() => {
+    if (open) reset(rowToForm(iniciativa));
+  }, [open, iniciativa, reset]);
+
+  const statusAtual = watch('status');
+  const salvando = criar.isPending || atualizar.isPending;
+
+  const onSubmit = (v: IniciativaFormValues) => {
+    const payload: NovaIniciativa = {
+      titulo: v.titulo.trim(),
+      empresa: v.empresa,
+      alavanca: v.alavanca,
+      status: v.status,
+      dono_id: v.dono_id === SEM_DONO ? null : v.dono_id,
+      ganho_esperado_mensal: parseValor(v.ganho_esperado_mensal),
+      ganho_recorrente_mensal: parseValor(v.ganho_recorrente_mensal),
+      inicio_em: v.inicio_em || null,
+      recorrente_desde: v.recorrente_desde || null,
+      descricao: v.descricao.trim() || null,
+      evidencia: v.evidencia.trim() || null,
+    };
+
+    const opts = {
+      onSuccess: () => {
+        toast.success(iniciativa ? 'Iniciativa atualizada.' : 'Iniciativa criada.');
+        track(iniciativa ? 'governanca.iniciativa_atualizada' : 'governanca.iniciativa_criada', {
+          empresa: payload.empresa,
+          alavanca: payload.alavanca,
+          status: payload.status,
+        });
+        onOpenChange(false);
+      },
+      onError: (e: Error) => toast.error(`Falha ao salvar: ${e.message}`),
+    };
+
+    if (iniciativa) atualizar.mutate({ id: iniciativa.id, patch: payload }, opts);
+    else criar.mutate(payload, opts);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{iniciativa ? 'Editar iniciativa' : 'Nova iniciativa'}</DialogTitle>
+          <DialogDescription>
+            Ganho esperado é aposta; só vira resultado quando o status chega a "Recorrente" com
+            evidência registrada.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-3">
+          <div className="space-y-1">
+            <Label htmlFor="ini-titulo">Título</Label>
+            <Input id="ini-titulo" {...register('titulo')} placeholder="Ex.: Renegociar frete Sayerlack" />
+            {errors.titulo && <p className="text-xs text-status-error">{errors.titulo.message}</p>}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label>Empresa</Label>
+              <Controller
+                control={control}
+                name="empresa"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.keys(COMPANIES) as Array<keyof typeof COMPANIES>).map((c) => (
+                        <SelectItem key={c} value={c}>
+                          {COMPANIES[c].name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Alavanca</Label>
+              <Controller
+                control={control}
+                name="alavanca"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(ALAVANCA_INICIATIVA).map(([k, label]) => (
+                        <SelectItem key={k} value={k}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label>Status</Label>
+              <Controller
+                control={control}
+                name="status"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Object.entries(STATUS_INICIATIVA).map(([k, label]) => (
+                        <SelectItem key={k} value={k}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Dono</Label>
+              {/* Só master reatribui dono — o WITH CHECK da RLS rejeitaria o repasse (achado Codex). */}
+              <Controller
+                control={control}
+                name="dono_id"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange} disabled={!isMaster}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={SEM_DONO}>Sem dono</SelectItem>
+                      {(staff ?? []).map((s) => (
+                        <SelectItem key={s.user_id} value={s.user_id}>
+                          {s.name ?? s.email ?? s.user_id.slice(0, 8)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="ini-esperado">Ganho esperado (R$/mês)</Label>
+              <Input
+                id="ini-esperado"
+                inputMode="decimal"
+                placeholder="Em branco = sem estimativa"
+                {...register('ganho_esperado_mensal')}
+              />
+              {errors.ganho_esperado_mensal && (
+                <p className="text-xs text-status-error">{errors.ganho_esperado_mensal.message}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ini-recorrente">Ganho recorrente (R$/mês)</Label>
+              <Input
+                id="ini-recorrente"
+                inputMode="decimal"
+                placeholder="Só quando comprovado"
+                {...register('ganho_recorrente_mensal')}
+              />
+              {errors.ganho_recorrente_mensal && (
+                <p className="text-xs text-status-error">
+                  {errors.ganho_recorrente_mensal.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="ini-inicio">Início da execução</Label>
+              <Input id="ini-inicio" type="date" {...register('inicio_em')} />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ini-desde">Recorrente desde</Label>
+              <Input id="ini-desde" type="date" {...register('recorrente_desde')} />
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="ini-descricao">Descrição</Label>
+            <Textarea id="ini-descricao" rows={2} {...register('descricao')} />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="ini-evidencia">
+              Evidência do ganho{statusAtual === 'recorrente' ? ' (obrigatória)' : ''}
+            </Label>
+            <Textarea
+              id="ini-evidencia"
+              rows={2}
+              placeholder="Como o ganho foi comprovado: relatório, query, comparativo…"
+              {...register('evidencia')}
+            />
+            {errors.evidencia && (
+              <p className="text-xs text-status-error">{errors.evidencia.message}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={salvando}>
+              {salvando && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {iniciativa ? 'Salvar' : 'Criar'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/governanca/__tests__/IniciativaDialog.test.ts
+++ b/src/components/governanca/__tests__/IniciativaDialog.test.ts
@@ -1,0 +1,53 @@
+// Testa o schema do form — o espelho client-side do CHECK
+// gov_iniciativas_recorrente_exige_evidencia da migration.
+import { describe, expect, it } from 'vitest';
+import { iniciativaSchema, type IniciativaFormValues } from '../IniciativaDialog';
+
+const valido: IniciativaFormValues = {
+  titulo: 'Renegociar frete',
+  empresa: 'oben',
+  alavanca: 'custo',
+  status: 'em_execucao',
+  dono_id: '__sem_dono__',
+  ganho_esperado_mensal: '1200,50',
+  ganho_recorrente_mensal: '',
+  inicio_em: '',
+  recorrente_desde: '',
+  descricao: '',
+  evidencia: '',
+};
+
+describe('iniciativaSchema (espelho do CHECK do banco)', () => {
+  it('aceita iniciativa de pipeline sem evidência', () => {
+    expect(iniciativaSchema.safeParse(valido).success).toBe(true);
+  });
+
+  it('REJEITA status recorrente sem evidência (como o banco rejeitaria)', () => {
+    const r = iniciativaSchema.safeParse({ ...valido, status: 'recorrente', evidencia: '   ' });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues.some((i) => i.path.includes('evidencia'))).toBe(true);
+    }
+  });
+
+  it('aceita recorrente com evidência registrada', () => {
+    const r = iniciativaSchema.safeParse({
+      ...valido,
+      status: 'recorrente',
+      evidencia: 'DRE de junho mostra a economia',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejeita valor monetário malformado e aceita vírgula decimal', () => {
+    expect(
+      iniciativaSchema.safeParse({ ...valido, ganho_esperado_mensal: 'abc' }).success,
+    ).toBe(false);
+    expect(
+      iniciativaSchema.safeParse({ ...valido, ganho_esperado_mensal: '1234.56' }).success,
+    ).toBe(true);
+    expect(iniciativaSchema.safeParse({ ...valido, ganho_esperado_mensal: '' }).success).toBe(
+      true,
+    );
+  });
+});

--- a/src/hooks/__tests__/useIniciativasIceberg.test.ts
+++ b/src/hooks/__tests__/useIniciativasIceberg.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { resumirIceberg, type IniciativaIceberg } from '../useIniciativasIceberg';
+
+const ini = (over: Partial<IniciativaIceberg>): IniciativaIceberg => ({
+  id: crypto.randomUUID(),
+  empresa: 'colacor',
+  titulo: 'iniciativa',
+  descricao: null,
+  alavanca: 'outro',
+  dono_id: null,
+  ganho_esperado_mensal: null,
+  ganho_recorrente_mensal: null,
+  status: 'ideia',
+  inicio_em: null,
+  recorrente_desde: null,
+  evidencia: null,
+  created_by: null,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+  ...over,
+});
+
+describe('resumirIceberg', () => {
+  it('soma recorrente comprovado só de recorrentes COM valor; sem valor conta à parte (ausente ≠ zero)', () => {
+    const r = resumirIceberg([
+      ini({ status: 'recorrente', ganho_recorrente_mensal: 5000, evidencia: 'relatório' }),
+      ini({ status: 'recorrente', ganho_recorrente_mensal: 1500.5, evidencia: 'query' }),
+      ini({ status: 'recorrente', ganho_recorrente_mensal: null, evidencia: 'case' }),
+    ]);
+    expect(r.recorrenteMensal).toBeCloseTo(6500.5);
+    expect(r.recorrentesSemValor).toBe(1);
+    expect(r.porStatus.recorrente).toBe(3);
+  });
+
+  it('pipeline soma esperado de ideia/em execução/maturando; sem estimativa conta à parte', () => {
+    const r = resumirIceberg([
+      ini({ status: 'ideia', ganho_esperado_mensal: 1000 }),
+      ini({ status: 'em_execucao', ganho_esperado_mensal: 2000 }),
+      ini({ status: 'maturando', ganho_esperado_mensal: 3000 }),
+      ini({ status: 'maturando', ganho_esperado_mensal: null }),
+    ]);
+    expect(r.pipelineMensal).toBe(6000);
+    expect(r.pipelineSemEstimativa).toBe(1);
+  });
+
+  it('pausada e cancelada não entram em nenhuma soma', () => {
+    const r = resumirIceberg([
+      ini({ status: 'pausada', ganho_esperado_mensal: 9999 }),
+      ini({ status: 'cancelada', ganho_esperado_mensal: 9999, ganho_recorrente_mensal: 9999 }),
+    ]);
+    expect(r.pipelineMensal).toBe(0);
+    expect(r.recorrenteMensal).toBe(0);
+    expect(r.porStatus.pausada).toBe(1);
+    expect(r.porStatus.cancelada).toBe(1);
+  });
+
+  it('recorrente não dobra no pipeline (o esperado dela fica fora da soma de pipeline)', () => {
+    const r = resumirIceberg([
+      ini({
+        status: 'recorrente',
+        ganho_esperado_mensal: 4000,
+        ganho_recorrente_mensal: 3500,
+        evidencia: 'dre',
+      }),
+    ]);
+    expect(r.pipelineMensal).toBe(0);
+    expect(r.recorrenteMensal).toBe(3500);
+  });
+
+  it('status fora do vocabulário não fabrica contagem nem soma, mas entra no total', () => {
+    const r = resumirIceberg([
+      ini({ status: 'zumbi', ganho_esperado_mensal: 1234 }),
+      ini({ status: 'ideia', ganho_esperado_mensal: 100 }),
+    ]);
+    expect(r.pipelineMensal).toBe(100);
+    expect(r.total).toBe(2);
+    expect(Object.values(r.porStatus).reduce((a, b) => a + b, 0)).toBe(1);
+  });
+
+  it('portfólio NÃO-vazio com todos os valores null → null, não R$0 fabricado (achado Codex P1)', () => {
+    const r = resumirIceberg([
+      ini({ status: 'recorrente', ganho_recorrente_mensal: null, evidencia: 'case' }),
+      ini({ status: 'recorrente', ganho_recorrente_mensal: null, evidencia: 'case' }),
+      ini({ status: 'maturando', ganho_esperado_mensal: null }),
+    ]);
+    expect(r.recorrenteMensal).toBeNull();
+    expect(r.pipelineMensal).toBeNull();
+    expect(r.recorrentesSemValor).toBe(2);
+    expect(r.pipelineSemEstimativa).toBe(1);
+  });
+
+  it('soma parcial continua numérica quando pelo menos 1 valor existe', () => {
+    const r = resumirIceberg([
+      ini({ status: 'recorrente', ganho_recorrente_mensal: 100, evidencia: 'dre' }),
+      ini({ status: 'recorrente', ganho_recorrente_mensal: null, evidencia: 'case' }),
+    ]);
+    expect(r.recorrenteMensal).toBe(100);
+    expect(r.recorrentesSemValor).toBe(1);
+  });
+
+  it('lista vazia → somas zero (zero legítimo de conjunto vazio) e contagens zeradas', () => {
+    const r = resumirIceberg([]);
+    expect(r.recorrenteMensal).toBe(0);
+    expect(r.pipelineMensal).toBe(0);
+    expect(r.recorrentesSemValor).toBe(0);
+    expect(r.pipelineSemEstimativa).toBe(0);
+    expect(r.total).toBe(0);
+  });
+});

--- a/src/hooks/useIniciativasIceberg.ts
+++ b/src/hooks/useIniciativasIceberg.ts
@@ -1,0 +1,177 @@
+// src/hooks/useIniciativasIceberg.ts
+// Painel Iceberg de iniciativas (programa "back to basics"): portfólio de
+// iniciativas de melhoria com ganho esperado (pipeline maturando, "abaixo da
+// linha d'água") × ganho recorrente comprovado ("acima"). O método: ganho só
+// conta quando vira RECORRENTE com evidência registrada (CHECK no banco).
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import type { Database } from '@/integrations/supabase/types';
+
+export type IniciativaIceberg = Database['public']['Tables']['gov_iniciativas']['Row'];
+export type NovaIniciativa = Omit<
+  Database['public']['Tables']['gov_iniciativas']['Insert'],
+  'id' | 'created_by' | 'created_at' | 'updated_at'
+>;
+export type PatchIniciativa = Omit<
+  Database['public']['Tables']['gov_iniciativas']['Update'],
+  'id' | 'created_by' | 'created_at' | 'updated_at'
+>;
+
+export const STATUS_INICIATIVA = {
+  ideia: 'Ideia',
+  em_execucao: 'Em execução',
+  maturando: 'Maturando',
+  recorrente: 'Recorrente',
+  pausada: 'Pausada',
+  cancelada: 'Cancelada',
+} as const;
+export type StatusIniciativa = keyof typeof STATUS_INICIATIVA;
+
+export const ALAVANCA_INICIATIVA = {
+  receita: 'Receita',
+  margem: 'Margem',
+  custo: 'Custo',
+  caixa: 'Caixa',
+  risco: 'Risco',
+  outro: 'Outro',
+} as const;
+export type AlavancaIniciativa = keyof typeof ALAVANCA_INICIATIVA;
+
+/** Status que compõem o pipeline "abaixo da linha d'água" (ganho ainda não comprovado). */
+export const STATUS_PIPELINE: readonly StatusIniciativa[] = ['ideia', 'em_execucao', 'maturando'];
+
+export interface ResumoIceberg {
+  /**
+   * R$/mês recorrente COMPROVADO (só status 'recorrente' com valor registrado).
+   * null = há recorrentes mas NENHUMA com valor — sem dado não se fabrica R$0
+   * (achado Codex P1); 0 só para conjunto vazio ou zeros de verdade.
+   */
+  recorrenteMensal: number | null;
+  /** Recorrentes sem valor registrado — não somam (ausente ≠ zero), ficam contadas. */
+  recorrentesSemValor: number;
+  /** R$/mês esperado no pipeline. null = há pipeline mas nenhuma com estimativa. */
+  pipelineMensal: number | null;
+  /** Iniciativas de pipeline sem estimativa — não somam, ficam contadas. */
+  pipelineSemEstimativa: number;
+  porStatus: Record<StatusIniciativa, number>;
+  total: number;
+}
+
+function isStatusIniciativa(s: string): s is StatusIniciativa {
+  return Object.prototype.hasOwnProperty.call(STATUS_INICIATIVA, s);
+}
+
+/** Cômputo puro dos KPIs do iceberg (testável sem Supabase). */
+export function resumirIceberg(iniciativas: IniciativaIceberg[]): ResumoIceberg {
+  const porStatus = Object.fromEntries(
+    Object.keys(STATUS_INICIATIVA).map((s) => [s, 0]),
+  ) as Record<StatusIniciativa, number>;
+
+  let somaRecorrente = 0;
+  let recorrentesComValor = 0;
+  let recorrentesSemValor = 0;
+  let somaPipeline = 0;
+  let pipelineComEstimativa = 0;
+  let pipelineSemEstimativa = 0;
+
+  for (const i of iniciativas) {
+    if (!isStatusIniciativa(i.status)) continue; // status fora do vocabulário: não fabricar
+    porStatus[i.status] += 1;
+
+    if (i.status === 'recorrente') {
+      if (i.ganho_recorrente_mensal != null) {
+        somaRecorrente += i.ganho_recorrente_mensal;
+        recorrentesComValor += 1;
+      } else {
+        recorrentesSemValor += 1;
+      }
+    } else if (STATUS_PIPELINE.includes(i.status)) {
+      if (i.ganho_esperado_mensal != null) {
+        somaPipeline += i.ganho_esperado_mensal;
+        pipelineComEstimativa += 1;
+      } else {
+        pipelineSemEstimativa += 1;
+      }
+    }
+  }
+
+  // Bucket habitado sem NENHUM valor conhecido → null (não fabricar R$0).
+  const recorrenteMensal =
+    porStatus.recorrente > 0 && recorrentesComValor === 0 ? null : somaRecorrente;
+  const totalPipeline = STATUS_PIPELINE.reduce((n, s) => n + porStatus[s], 0);
+  const pipelineMensal = totalPipeline > 0 && pipelineComEstimativa === 0 ? null : somaPipeline;
+
+  return {
+    recorrenteMensal,
+    recorrentesSemValor,
+    pipelineMensal,
+    pipelineSemEstimativa,
+    porStatus,
+    total: iniciativas.length,
+  };
+}
+
+const PAGE = 1000;
+
+/** Pagina além da capa silenciosa de 1.000 linhas do PostgREST (KPIs somam — nunca truncar). */
+async function fetchIniciativas(): Promise<IniciativaIceberg[]> {
+  const out: IniciativaIceberg[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from('gov_iniciativas')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(error.message);
+    const rows = (data ?? []) as IniciativaIceberg[];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return out;
+}
+
+const QUERY_KEY = ['gov-iniciativas'] as const;
+
+export function useIniciativasIceberg() {
+  return useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: fetchIniciativas,
+    staleTime: 60_000,
+  });
+}
+
+export function useIniciativaMutations() {
+  const qc = useQueryClient();
+  const { user } = useAuth();
+  const invalidate = () => qc.invalidateQueries({ queryKey: QUERY_KEY });
+
+  const criar = useMutation({
+    mutationFn: async (payload: NovaIniciativa) => {
+      const { error } = await supabase
+        .from('gov_iniciativas')
+        .insert({ ...payload, created_by: user?.id ?? null });
+      if (error) throw new Error(error.message);
+    },
+    onSettled: invalidate,
+  });
+
+  const atualizar = useMutation({
+    mutationFn: async ({ id, patch }: { id: string; patch: PatchIniciativa }) => {
+      const { error } = await supabase.from('gov_iniciativas').update(patch).eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSettled: invalidate,
+  });
+
+  const excluir = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase.from('gov_iniciativas').delete().eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSettled: invalidate,
+  });
+
+  return { criar, atualizar, excluir };
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5752,6 +5752,60 @@ export type Database = {
         }
         Relationships: []
       }
+      gov_iniciativas: {
+        Row: {
+          alavanca: string
+          created_at: string
+          created_by: string | null
+          descricao: string | null
+          dono_id: string | null
+          empresa: string
+          evidencia: string | null
+          ganho_esperado_mensal: number | null
+          ganho_recorrente_mensal: number | null
+          id: string
+          inicio_em: string | null
+          recorrente_desde: string | null
+          status: string
+          titulo: string
+          updated_at: string
+        }
+        Insert: {
+          alavanca?: string
+          created_at?: string
+          created_by?: string | null
+          descricao?: string | null
+          dono_id?: string | null
+          empresa: string
+          evidencia?: string | null
+          ganho_esperado_mensal?: number | null
+          ganho_recorrente_mensal?: number | null
+          id?: string
+          inicio_em?: string | null
+          recorrente_desde?: string | null
+          status?: string
+          titulo: string
+          updated_at?: string
+        }
+        Update: {
+          alavanca?: string
+          created_at?: string
+          created_by?: string | null
+          descricao?: string | null
+          dono_id?: string | null
+          empresa?: string
+          evidencia?: string | null
+          ganho_esperado_mensal?: number | null
+          ganho_recorrente_mensal?: number | null
+          id?: string
+          inicio_em?: string | null
+          recorrente_desde?: string | null
+          status?: string
+          titulo?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       health_score_history: {
         Row: {
           calculated_at: string

--- a/src/pages/GestaoGovernanca.tsx
+++ b/src/pages/GestaoGovernanca.tsx
@@ -25,6 +25,7 @@ const GovernanceUsers = lazy(() => import("./GovernanceUsers"));
 const GovernancePermissions = lazy(() => import("./GovernancePermissions"));
 const GovernanceMath = lazy(() => import("./GovernanceMathParams"));
 const GovernanceAudit = lazy(() => import("./GovernanceAudit"));
+const GovernanceIniciativas = lazy(() => import("./GovernanceIniciativas"));
 const Settings = lazy(() => import("./SettingsConfig"));
 
 const TabFallback = () => (
@@ -140,11 +141,12 @@ export default function GestaoGovernanca() {
       <KpiCards empresa={empresa} />
 
       <Tabs value={tab} onValueChange={handleTab} className="space-y-4">
-        <TabsList className="grid grid-cols-2 sm:grid-cols-5 w-full">
+        <TabsList className="grid grid-cols-2 sm:grid-cols-6 w-full">
           <TabsTrigger value="usuarios">Usuários</TabsTrigger>
           <TabsTrigger value="permissoes">Permissões</TabsTrigger>
           <TabsTrigger value="parametros">Parâmetros</TabsTrigger>
           <TabsTrigger value="auditoria">Auditoria</TabsTrigger>
+          <TabsTrigger value="iniciativas">Iniciativas</TabsTrigger>
           <TabsTrigger value="configuracoes">Configurações</TabsTrigger>
         </TabsList>
 
@@ -166,6 +168,11 @@ export default function GestaoGovernanca() {
         <TabsContent value="auditoria" className="m-0">
           <Suspense fallback={<TabFallback />}>
             <GovernanceAudit />
+          </Suspense>
+        </TabsContent>
+        <TabsContent value="iniciativas" className="m-0">
+          <Suspense fallback={<TabFallback />}>
+            <GovernanceIniciativas />
           </Suspense>
         </TabsContent>
         <TabsContent value="configuracoes" className="m-0">

--- a/src/pages/GovernanceIniciativas.tsx
+++ b/src/pages/GovernanceIniciativas.tsx
@@ -1,0 +1,360 @@
+// Painel Iceberg — aba de Governança (programa "back to basics").
+// Portfólio de iniciativas: pipeline maturando ("abaixo da linha d'água") ×
+// ganho recorrente comprovado ("acima"). Nenhum valor é fabricado: iniciativa
+// sem estimativa/valor fica CONTADA à parte, nunca somada como zero.
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { MountainSnow, Pencil, Plus, Trash2, Waves } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { EmptyState } from '@/components/EmptyState';
+import { IniciativaDialog } from '@/components/governanca/IniciativaDialog';
+import { useAuth } from '@/contexts/AuthContext';
+import { COMPANIES } from '@/contexts/CompanyContext';
+import { useStaffUsersWithDept } from '@/hooks/useDepartmentsAdmin';
+import { useUrlState } from '@/hooks/useUrlState';
+import {
+  ALAVANCA_INICIATIVA,
+  STATUS_INICIATIVA,
+  STATUS_PIPELINE,
+  resumirIceberg,
+  useIniciativaMutations,
+  useIniciativasIceberg,
+  type IniciativaIceberg,
+  type StatusIniciativa,
+} from '@/hooks/useIniciativasIceberg';
+import { formatBRL, formatDate } from '@/lib/reposicao';
+import { track } from '@/lib/analytics';
+
+const STATUS_BADGE: Record<StatusIniciativa, string> = {
+  ideia: 'text-muted-foreground border-border',
+  em_execucao: 'text-status-info border-status-info/40',
+  maturando: 'text-status-info border-status-info/40',
+  recorrente: 'text-status-success border-status-success/40',
+  pausada: 'text-status-warning border-status-warning/40',
+  cancelada: 'text-muted-foreground border-border line-through',
+};
+
+export default function GovernanceIniciativas() {
+  const { user, isMaster } = useAuth();
+  const { data: iniciativas, isLoading, error } = useIniciativasIceberg();
+  const { data: staff } = useStaffUsersWithDept();
+  const { excluir } = useIniciativaMutations();
+
+  const [filtros, setFiltros] = useUrlState({ ini_empresa: 'todas', ini_status: 'ativas' });
+  const [dialogAberto, setDialogAberto] = useState(false);
+  const [editando, setEditando] = useState<IniciativaIceberg | null>(null);
+  const [excluindo, setExcluindo] = useState<IniciativaIceberg | null>(null);
+
+  const nomeDono = useMemo(() => {
+    const map = new Map<string, string>();
+    (staff ?? []).forEach((s) => map.set(s.user_id, s.name ?? s.email ?? '—'));
+    return map;
+  }, [staff]);
+
+  const daEmpresa = useMemo(
+    () =>
+      (iniciativas ?? []).filter(
+        (i) => filtros.ini_empresa === 'todas' || i.empresa === filtros.ini_empresa,
+      ),
+    [iniciativas, filtros.ini_empresa],
+  );
+
+  // KPIs refletem o portfólio da empresa filtrada; o filtro de status refina só a tabela.
+  const resumo = useMemo(() => resumirIceberg(daEmpresa), [daEmpresa]);
+
+  const visiveis = useMemo(() => {
+    if (filtros.ini_status === 'todas') return daEmpresa;
+    if (filtros.ini_status === 'ativas') {
+      return daEmpresa.filter((i) => i.status !== 'pausada' && i.status !== 'cancelada');
+    }
+    return daEmpresa.filter((i) => i.status === filtros.ini_status);
+  }, [daEmpresa, filtros.ini_status]);
+
+  // Adoção: 1 evento por montagem com dados (não por re-render).
+  const jaTrackeou = useRef(false);
+  useEffect(() => {
+    if (iniciativas && !jaTrackeou.current) {
+      jaTrackeou.current = true;
+      track('governanca.iceberg_aberto', { total: iniciativas.length });
+    }
+  }, [iniciativas]);
+
+  if (isLoading) return <PageSkeleton variant="cockpit" />;
+
+  if (error) {
+    return (
+      <EmptyState
+        icon={MountainSnow}
+        title="Não deu para carregar as iniciativas"
+        description={error instanceof Error ? error.message : 'Erro ao consultar o banco.'}
+      />
+    );
+  }
+
+  const ativas = STATUS_PIPELINE.reduce((n, s) => n + resumo.porStatus[s], 0);
+  // null = bucket habitado sem nenhum valor conhecido → "—" (nunca R$0 fabricado).
+  const valorMensal = (v: number | null) => (v === null ? '—' : `${formatBRL(v)}/mês`);
+
+  const kpis = [
+    {
+      label: 'Recorrente comprovado',
+      value: valorMensal(resumo.recorrenteMensal),
+      sub:
+        resumo.recorrentesSemValor > 0
+          ? `${resumo.recorrentesSemValor} recorrente(s) sem valor registrado`
+          : 'Acima da linha d’água',
+      icon: MountainSnow,
+    },
+    {
+      label: 'Pipeline maturando',
+      value: valorMensal(resumo.pipelineMensal),
+      sub:
+        resumo.pipelineSemEstimativa > 0
+          ? `${resumo.pipelineSemEstimativa} sem estimativa (não somam)`
+          : 'Abaixo da linha d’água',
+      icon: Waves,
+    },
+    { label: 'Em andamento', value: String(ativas), sub: 'ideia · execução · maturando', icon: null },
+    {
+      label: 'Recorrentes',
+      value: String(resumo.porStatus.recorrente),
+      sub: 'com evidência registrada',
+      icon: null,
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {kpis.map((k) => (
+          <Card key={k.label} className="border-border">
+            <CardContent className="pt-4">
+              <div className="flex items-center justify-between">
+                <div className="text-xs text-muted-foreground">{k.label}</div>
+                {k.icon && <k.icon className="h-4 w-4 text-muted-foreground opacity-60" />}
+              </div>
+              <div className="text-xl font-bold mt-1">{k.value}</div>
+              <div className="text-[11px] text-muted-foreground mt-0.5">{k.sub}</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-2 sm:items-center justify-between">
+        <div className="flex gap-2">
+          <Select
+            value={filtros.ini_empresa}
+            onValueChange={(v) => setFiltros({ ini_empresa: v })}
+          >
+            <SelectTrigger className="w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="todas">Todas as empresas</SelectItem>
+              {(Object.keys(COMPANIES) as Array<keyof typeof COMPANIES>).map((c) => (
+                <SelectItem key={c} value={c}>
+                  {COMPANIES[c].name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={filtros.ini_status} onValueChange={(v) => setFiltros({ ini_status: v })}>
+            <SelectTrigger className="w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ativas">Ativas</SelectItem>
+              <SelectItem value="todas">Todas</SelectItem>
+              {Object.entries(STATUS_INICIATIVA).map(([k, label]) => (
+                <SelectItem key={k} value={k}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        {isMaster && (
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditando(null);
+              setDialogAberto(true);
+            }}
+          >
+            <Plus className="w-4 h-4 mr-1" />
+            Nova iniciativa
+          </Button>
+        )}
+      </div>
+
+      {visiveis.length === 0 ? (
+        <EmptyState
+          icon={MountainSnow}
+          title="Nenhuma iniciativa aqui"
+          description={
+            isMaster
+              ? 'Cadastre a primeira iniciativa do iceberg: o que está sendo construído e quanto deve render por mês.'
+              : 'Nenhuma iniciativa cadastrada para este filtro.'
+          }
+          actionLabel={isMaster ? 'Nova iniciativa' : undefined}
+          onAction={
+            isMaster
+              ? () => {
+                  setEditando(null);
+                  setDialogAberto(true);
+                }
+              : undefined
+          }
+        />
+      ) : (
+        <div className="border border-border rounded-lg overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Iniciativa</TableHead>
+                <TableHead>Empresa</TableHead>
+                <TableHead>Dono</TableHead>
+                <TableHead className="text-right">Esperado/mês</TableHead>
+                <TableHead className="text-right">Recorrente/mês</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Início</TableHead>
+                <TableHead className="w-[88px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {visiveis.map((i) => {
+                const podeEditar = isMaster || (user?.id != null && i.dono_id === user.id);
+                return (
+                  <TableRow key={i.id}>
+                    <TableCell className="max-w-[260px]">
+                      <div className="font-medium truncate" title={i.descricao ?? i.titulo}>
+                        {i.titulo}
+                      </div>
+                      <div className="text-[11px] text-muted-foreground">
+                        {ALAVANCA_INICIATIVA[i.alavanca as keyof typeof ALAVANCA_INICIATIVA] ??
+                          i.alavanca}
+                        {i.evidencia && (
+                          <span title={i.evidencia}> · evidência registrada</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {COMPANIES[i.empresa as keyof typeof COMPANIES]?.name ?? i.empresa}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {i.dono_id ? nomeDono.get(i.dono_id) ?? '—' : '—'}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-xs">
+                      {formatBRL(i.ganho_esperado_mensal)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-xs font-medium">
+                      {formatBRL(i.ganho_recorrente_mensal)}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="outline"
+                        className={STATUS_BADGE[i.status as StatusIniciativa] ?? ''}
+                      >
+                        {STATUS_INICIATIVA[i.status as StatusIniciativa] ?? i.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {i.inicio_em ? formatDate(i.inicio_em) : '—'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1 justify-end">
+                        {podeEditar && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            onClick={() => {
+                              setEditando(i);
+                              setDialogAberto(true);
+                            }}
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </Button>
+                        )}
+                        {isMaster && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-status-error"
+                            onClick={() => setExcluindo(i)}
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <IniciativaDialog open={dialogAberto} onOpenChange={setDialogAberto} iniciativa={editando} />
+
+      <AlertDialog open={excluindo !== null} onOpenChange={(o) => !o && setExcluindo(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Excluir iniciativa?</AlertDialogTitle>
+            <AlertDialogDescription>
+              "{excluindo?.titulo}" será removida do painel. Se ela só saiu do ar temporariamente,
+              prefira o status "Pausada".
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (!excluindo) return;
+                excluir.mutate(excluindo.id, {
+                  onSuccess: () => {
+                    toast.success('Iniciativa excluída.');
+                    track('governanca.iniciativa_excluida', { empresa: excluindo.empresa });
+                  },
+                  onError: (e: Error) => toast.error(`Falha ao excluir: ${e.message}`),
+                });
+                setExcluindo(null);
+              }}
+            >
+              Excluir
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/supabase/migrations/20260702210000_gov_iniciativas_iceberg.sql
+++ b/supabase/migrations/20260702210000_gov_iniciativas_iceberg.sql
@@ -1,0 +1,104 @@
+-- ============================================================
+-- gov_iniciativas — Painel Iceberg de iniciativas (programa "back to basics")
+-- Cadastro do portfólio de iniciativas de melhoria: ganho esperado (pipeline
+-- maturando, "abaixo da linha d'água") × ganho recorrente comprovado ("acima").
+-- Método: uma iniciativa só vira 'recorrente' COM evidência registrada.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.gov_iniciativas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text NOT NULL CHECK (empresa IN ('colacor', 'oben', 'colacor_sc')),
+  titulo text NOT NULL,
+  descricao text,
+  alavanca text NOT NULL DEFAULT 'outro'
+    CHECK (alavanca IN ('receita', 'margem', 'custo', 'caixa', 'risco', 'outro')),
+  dono_id uuid REFERENCES auth.users(id),
+  -- R$/mês. NULL = sem estimativa/sem comprovação (ausente ≠ zero — nunca gravar 0 no lugar).
+  ganho_esperado_mensal numeric,
+  ganho_recorrente_mensal numeric,
+  status text NOT NULL DEFAULT 'ideia'
+    CHECK (status IN ('ideia', 'em_execucao', 'maturando', 'recorrente', 'pausada', 'cancelada')),
+  inicio_em date,
+  recorrente_desde date,
+  evidencia text,
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  -- Método iceberg: marcar 'recorrente' exige a evidência do ganho registrada.
+  CONSTRAINT gov_iniciativas_recorrente_exige_evidencia
+    CHECK (status <> 'recorrente' OR (evidencia IS NOT NULL AND btrim(evidencia) <> ''))
+);
+
+CREATE INDEX IF NOT EXISTS idx_gov_iniciativas_empresa_status
+  ON public.gov_iniciativas(empresa, status);
+
+-- updated_at automático
+CREATE OR REPLACE FUNCTION public.gov_iniciativas_set_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_gov_iniciativas_updated_at ON public.gov_iniciativas;
+CREATE TRIGGER trg_gov_iniciativas_updated_at
+  BEFORE UPDATE ON public.gov_iniciativas
+  FOR EACH ROW EXECUTE FUNCTION public.gov_iniciativas_set_updated_at();
+
+-- RLS (obrigatória em tabela nova)
+ALTER TABLE public.gov_iniciativas ENABLE ROW LEVEL SECURITY;
+
+-- Staff lê (transparência interna: employee + master)
+DROP POLICY IF EXISTS "gov_iniciativas_select_staff" ON public.gov_iniciativas;
+CREATE POLICY "gov_iniciativas_select_staff"
+  ON public.gov_iniciativas FOR SELECT
+  USING (
+    EXISTS (SELECT 1 FROM public.user_roles
+            WHERE user_id = (SELECT auth.uid())
+              AND role IN ('employee'::public.app_role, 'master'::public.app_role))
+  );
+
+-- Master cria
+DROP POLICY IF EXISTS "gov_iniciativas_insert_master" ON public.gov_iniciativas;
+CREATE POLICY "gov_iniciativas_insert_master"
+  ON public.gov_iniciativas FOR INSERT
+  WITH CHECK (
+    EXISTS (SELECT 1 FROM public.user_roles
+            WHERE user_id = (SELECT auth.uid())
+              AND role = 'master'::public.app_role)
+  );
+
+-- Master OU o dono atualizam (o dono mantém status/evidência da própria iniciativa;
+-- o WITH CHECK impede o dono de repassar a linha pra outro dono_id)
+DROP POLICY IF EXISTS "gov_iniciativas_update_master_ou_dono" ON public.gov_iniciativas;
+CREATE POLICY "gov_iniciativas_update_master_ou_dono"
+  ON public.gov_iniciativas FOR UPDATE
+  USING (
+    dono_id = (SELECT auth.uid())
+    OR EXISTS (SELECT 1 FROM public.user_roles
+               WHERE user_id = (SELECT auth.uid())
+                 AND role = 'master'::public.app_role)
+  )
+  WITH CHECK (
+    dono_id = (SELECT auth.uid())
+    OR EXISTS (SELECT 1 FROM public.user_roles
+               WHERE user_id = (SELECT auth.uid())
+                 AND role = 'master'::public.app_role)
+  );
+
+-- Master deleta
+DROP POLICY IF EXISTS "gov_iniciativas_delete_master" ON public.gov_iniciativas;
+CREATE POLICY "gov_iniciativas_delete_master"
+  ON public.gov_iniciativas FOR DELETE
+  USING (
+    EXISTS (SELECT 1 FROM public.user_roles
+            WHERE user_id = (SELECT auth.uid())
+              AND role = 'master'::public.app_role)
+  );
+
+-- Edge functions / cron
+DROP POLICY IF EXISTS "gov_iniciativas_service_all" ON public.gov_iniciativas;
+CREATE POLICY "gov_iniciativas_service_all"
+  ON public.gov_iniciativas FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');

--- a/supabase/migrations/20260702213000_gov_iniciativas_check_ganhos.sql
+++ b/supabase/migrations/20260702213000_gov_iniciativas_check_ganhos.sql
@@ -1,0 +1,30 @@
+-- ============================================================
+-- gov_iniciativas — CHECK de domínio nos ganhos (achado Codex P2 do PR do Painel Iceberg)
+-- O form (zod) já barra valor negativo, mas escrita direta via PostgREST não
+-- passaria por ele — sem o CHECK, um ganho negativo distorceria as somas do
+-- iceberg silenciosamente. NULL continua permitido (ausente ≠ zero).
+-- Padrão idempotente por nome em pg_constraint (nunca DROP+ADD — house style).
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gov_iniciativas_ganho_esperado_nao_negativo'
+      AND conrelid = 'public.gov_iniciativas'::regclass
+  ) THEN
+    ALTER TABLE public.gov_iniciativas
+      ADD CONSTRAINT gov_iniciativas_ganho_esperado_nao_negativo
+      CHECK (ganho_esperado_mensal IS NULL OR ganho_esperado_mensal >= 0);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gov_iniciativas_ganho_recorrente_nao_negativo'
+      AND conrelid = 'public.gov_iniciativas'::regclass
+  ) THEN
+    ALTER TABLE public.gov_iniciativas
+      ADD CONSTRAINT gov_iniciativas_ganho_recorrente_nao_negativo
+      CHECK (ganho_recorrente_mensal IS NULL OR ganho_recorrente_mensal >= 0);
+  END IF;
+END $$;


### PR DESCRIPTION
## Painel Iceberg — item 3 do programa "back to basics" (Pernambucanas)

Aba **Iniciativas** em `/gestao/governanca?tab=iniciativas`: portfólio de iniciativas de melhoria com **ganho esperado** (pipeline maturando, "abaixo da linha d'água") × **ganho recorrente comprovado** ("acima"). O método do artigo codificado no banco: uma iniciativa só vira `recorrente` **com evidência registrada** (CHECK + espelho zod no form).

### O que entra

- **Migration `gov_iniciativas`** — empresa (`colacor|oben|colacor_sc`, minúscula = convenção do CompanyContext), título, alavanca (receita/margem/custo/caixa/risco/outro), dono, ganho esperado/mês, ganho recorrente/mês, status (`ideia → em_execucao → maturando → recorrente | pausada | cancelada`), evidência, trigger `updated_at`.
- **RLS split (anti-BFLA):** SELECT staff · INSERT/DELETE master · UPDATE master **ou dono** (WITH CHECK impede o dono de repassar a linha) · service_role ALL. `auth.uid()` sempre em `(SELECT ...)` (InitPlan).
- **Frontend:** KPIs (recorrente comprovado, pipeline maturando, contagens), tabela densa, CRUD via dialog (react-hook-form+zod), filtros por empresa/status via `useUrlState`, botão criar/excluir gated master, editar gated master-ou-dono. Entrada de `gov_iniciativas` adicionada manualmente ao `types.ts` (Lovable regenera no próximo sync).
- **Ausente ≠ zero nos KPIs:** iniciativa sem estimativa/valor **não soma** — fica contada à parte ("n sem estimativa"); bucket habitado sem nenhum valor conhecido rende `—`, nunca `R$ 0,00` fabricado.

### Codex review (gate)

`codex exec` read-only sobre o diff (542k tokens): **1 P1 + 2 P2 — todos corrigidos** neste PR:
1. **[P1]** `resumirIceberg` fabricava `R$ 0,00` com portfólio não-vazio todo-null → agora retorna `null` e a UI mostra `—` (teste novo vermelho→verde).
2. **[P2]** faltava CHECK `>= 0` nos ganhos (PostgREST direto aceitaria negativo) → migration `20260702213000` com constraints idempotentes por nome.
3. **[P2]** dono não-master via o select "Dono" que a RLS rejeitaria → select `disabled` para não-master.

### Verificação

- 12 testes novos (agregação + schema zod espelhando o CHECK), com **falsificação**: sabotei a soma (null→0) e o superRefine → 2 vermelhos → restaurei → verde; fix do P1 provado vermelho→verde.
- Suíte completa, lint e tsc estrito verdes localmente (logs na sessão).
- `wt:preflight --full` 🟢 nas duas migrations (sem colisão com worktrees/origin).
- `audit:migrations` regenerado e commitado.

## ⚠️ ATENÇÃO: migration manual necessária (2 arquivos, colar em sequência)

Este PR adiciona `supabase/migrations/20260702210000_gov_iniciativas_iceberg.sql` e `supabase/migrations/20260702213000_gov_iniciativas_check_ganhos.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Colar no SQL Editor do Lovable e rodar (as duas, nesta ordem; são idempotentes).

<details><summary>SQL pra aplicar (1/2 — tabela + RLS)</summary>

Conteúdo integral de `supabase/migrations/20260702210000_gov_iniciativas_iceberg.sql` (ver arquivo no diff).

</details>

<details><summary>SQL pra aplicar (2/2 — CHECKs de ganho >= 0)</summary>

Conteúdo integral de `supabase/migrations/20260702213000_gov_iniciativas_check_ganhos.sql` (ver arquivo no diff).

</details>

Validação pós-apply (read-only):

```sql
SELECT
  CASE WHEN EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='gov_iniciativas')
    THEN '✅ tabela' ELSE '❌ tabela FALTANDO' END AS tabela,
  CASE WHEN (SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='gov_iniciativas') >= 5
    THEN '✅ policies' ELSE '❌ policies FALTANDO' END AS rls_policies,
  CASE WHEN (SELECT relrowsecurity FROM pg_class WHERE oid='public.gov_iniciativas'::regclass)
    THEN '✅ RLS on' ELSE '❌ RLS OFF' END AS rls,
  CASE WHEN EXISTS (SELECT 1 FROM pg_constraint WHERE conname='gov_iniciativas_recorrente_exige_evidencia')
    THEN '✅ CHECK evidência' ELSE '❌ CHECK evidência FALTANDO' END AS chk_evidencia,
  CASE WHEN EXISTS (SELECT 1 FROM pg_constraint WHERE conname='gov_iniciativas_ganho_esperado_nao_negativo')
       AND EXISTS (SELECT 1 FROM pg_constraint WHERE conname='gov_iniciativas_ganho_recorrente_nao_negativo')
    THEN '✅ CHECKs ganho' ELSE '❌ CHECKs ganho FALTANDO' END AS chk_ganhos,
  CASE WHEN EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_gov_iniciativas_updated_at')
    THEN '✅ trigger' ELSE '❌ trigger FALTANDO' END AS trigger_updated_at;
```

Deploy: **só Publish** no frontend depois do apply (sem edge function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
