### PR TITLE
fix(venda): alerta de crédito por (company, código Omie) + types.ts da main restaurado

### DIFF
--- a/src/components/unified-order/AlertaCreditoCliente.tsx
+++ b/src/components/unified-order/AlertaCreditoCliente.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { AlertTriangle } from 'lucide-react';
-import { useAlertaCreditoCliente, ALERTA_CREDITO } from '@/hooks/useAlertaCreditoCliente';
+import {
+  useAlertaCreditoCliente,
+  paresDoCliente,
+  ALERTA_CREDITO,
+  type ClienteComCodigos,
+} from '@/hooks/useAlertaCreditoCliente';
 import { formatBRL, formatDate } from '@/lib/reposicao';
 import { track } from '@/lib/analytics';
 
@@ -9,23 +14,26 @@ import { track } from '@/lib/analytics';
  * Só renderiza com evidência positiva de vencido 60+ (precisão > recall: sem dado,
  * silêncio — nada de "cliente OK" fabricado). Auditável via track() para medir
  * exibição × reação antes de a Fase 2 introduzir bloqueio com aprovação.
+ * Casa por (company, omie_codigo_cliente) — os títulos do Omie não carregam CNPJ.
  */
-export function AlertaCreditoCliente({ documento }: { documento: string | null | undefined }) {
-  const { data: alerta, error } = useAlertaCreditoCliente(documento);
+export function AlertaCreditoCliente({ cliente }: { cliente: ClienteComCodigos | null | undefined }) {
+  const { data: alerta, error } = useAlertaCreditoCliente(cliente);
+  const chave = paresDoCliente(cliente)
+    .map((p) => `${p.company}:${p.codigo}`)
+    .join('|');
 
   // Auditoria: 1 evento por cliente selecionado (não por re-render).
-  const trackedDoc = useRef<string | null>(null);
+  const trackedKey = useRef<string | null>(null);
   useEffect(() => {
-    const doc = (documento ?? '').replace(/\D/g, '');
-    if (alerta && doc && trackedDoc.current !== doc) {
-      trackedDoc.current = doc;
+    if (alerta && chave && trackedKey.current !== chave) {
+      trackedKey.current = chave;
       track('venda.alerta_credito_exibido', {
         vencido: alerta.vencido,
         titulos: alerta.titulos,
         dado_defasado: alerta.dadoDefasado,
       });
     }
-  }, [alerta, documento]);
+  }, [alerta, chave]);
 
   useEffect(() => {
     if (error) track('venda.alerta_credito_erro', { message: error instanceof Error ? error.message : 'erro' });

--- a/src/components/unified-order/__tests__/AlertaCreditoCliente.test.tsx
+++ b/src/components/unified-order/__tests__/AlertaCreditoCliente.test.tsx
@@ -6,7 +6,7 @@ import type { AlertaCredito } from '@/hooks/useAlertaCreditoCliente';
 const mockUseAlerta = vi.fn();
 vi.mock('@/hooks/useAlertaCreditoCliente', async (importOriginal) => {
   const mod = await importOriginal<typeof import('@/hooks/useAlertaCreditoCliente')>();
-  return { ...mod, useAlertaCreditoCliente: (doc: string | null | undefined) => mockUseAlerta(doc) };
+  return { ...mod, useAlertaCreditoCliente: (cliente: unknown) => mockUseAlerta(cliente) };
 });
 
 const mockTrack = vi.fn();
@@ -29,7 +29,7 @@ describe('AlertaCreditoCliente', () => {
 
   it('com evidência de vencido 60+ renderiza valor, títulos e recomendação', () => {
     mockUseAlerta.mockReturnValue({ data: alerta(), error: null });
-    render(<AlertaCreditoCliente documento="12345678000190" />);
+    render(<AlertaCreditoCliente cliente={{ codigo_cliente: 111 }} />);
     expect(screen.getByTestId('alerta-credito-cliente')).toBeTruthy();
     expect(screen.getByText(/vencido há 60\+ dias/)).toBeTruthy();
     expect(screen.getByText(/2 títulos em aberto/)).toBeTruthy();
@@ -38,27 +38,27 @@ describe('AlertaCreditoCliente', () => {
 
   it('sem alerta (null) não renderiza NADA — nem "cliente OK" fabricado', () => {
     mockUseAlerta.mockReturnValue({ data: null, error: null });
-    const { container } = render(<AlertaCreditoCliente documento="12345678000190" />);
+    const { container } = render(<AlertaCreditoCliente cliente={{ codigo_cliente: 111 }} />);
     expect(container.firstChild).toBeNull();
   });
 
   it('erro na fonte → silêncio (não trava a venda) + track de erro', () => {
     mockUseAlerta.mockReturnValue({ data: undefined, error: new Error('boom') });
-    const { container } = render(<AlertaCreditoCliente documento="12345678000190" />);
+    const { container } = render(<AlertaCreditoCliente cliente={{ codigo_cliente: 111 }} />);
     expect(container.firstChild).toBeNull();
     expect(mockTrack).toHaveBeenCalledWith('venda.alerta_credito_erro', expect.objectContaining({ message: 'boom' }));
   });
 
   it('dado defasado mostra o aviso de sync velho', () => {
     mockUseAlerta.mockReturnValue({ data: alerta({ dadoDefasado: true, syncAt: null }), error: null });
-    render(<AlertaCreditoCliente documento="12345678000190" />);
+    render(<AlertaCreditoCliente cliente={{ codigo_cliente: 111 }} />);
     expect(screen.getByText(/Sync há mais de 24h/)).toBeTruthy();
   });
 
   it('audita a exibição 1x por cliente (não por re-render)', () => {
     mockUseAlerta.mockReturnValue({ data: alerta(), error: null });
-    const { rerender } = render(<AlertaCreditoCliente documento="12345678000190" />);
-    rerender(<AlertaCreditoCliente documento="12345678000190" />);
+    const { rerender } = render(<AlertaCreditoCliente cliente={{ codigo_cliente: 111 }} />);
+    rerender(<AlertaCreditoCliente cliente={{ codigo_cliente: 111 }} />);
     const exibicoes = mockTrack.mock.calls.filter((c) => c[0] === 'venda.alerta_credito_exibido');
     expect(exibicoes).toHaveLength(1);
     expect(exibicoes[0][1]).toMatchObject({ vencido: 1234.56, titulos: 2, dado_defasado: false });

--- a/src/hooks/__tests__/useAlertaCreditoCliente.test.ts
+++ b/src/hooks/__tests__/useAlertaCreditoCliente.test.ts
@@ -1,26 +1,33 @@
 import { describe, expect, it } from 'vitest';
-import { computeAlertaCredito, variantesDocumento, ALERTA_CREDITO } from '../useAlertaCreditoCliente';
+import { computeAlertaCredito, paresDoCliente, ALERTA_CREDITO } from '../useAlertaCreditoCliente';
 
 const AGORA = new Date('2026-07-02T12:00:00Z');
 
-describe('variantesDocumento', () => {
-  it('CNPJ só-dígitos gera as duas variantes (dígitos + formatado)', () => {
-    expect(variantesDocumento('12345678000190')).toEqual(['12345678000190', '12.345.678/0001-90']);
+describe('paresDoCliente', () => {
+  it('monta o par de cada conta que o cliente tem (oben/colacor/colacor_sc)', () => {
+    expect(
+      paresDoCliente({ codigo_cliente: 111, codigo_cliente_colacor: 222, codigo_cliente_afiacao: 333 }),
+    ).toEqual([
+      { company: 'oben', codigo: 111 },
+      { company: 'colacor', codigo: 222 },
+      { company: 'colacor_sc', codigo: 333 },
+    ]);
   });
 
-  it('CNPJ formatado normaliza e gera as mesmas variantes', () => {
-    expect(variantesDocumento('12.345.678/0001-90')).toEqual(['12345678000190', '12.345.678/0001-90']);
+  it('conta sem código não gera par (parcial é normal)', () => {
+    expect(paresDoCliente({ codigo_cliente: 111 })).toEqual([{ company: 'oben', codigo: 111 }]);
+    expect(paresDoCliente({ codigo_cliente_colacor: 222 })).toEqual([
+      { company: 'colacor', codigo: 222 },
+    ]);
   });
 
-  it('CPF gera variantes de CPF', () => {
-    expect(variantesDocumento('12345678901')).toEqual(['12345678901', '123.456.789-01']);
+  it('código 0 (cliente sintético do autoatendimento) e null são ignorados', () => {
+    expect(paresDoCliente({ codigo_cliente: 0, codigo_cliente_colacor: null })).toEqual([]);
   });
 
-  it('documento inválido/ausente → null (sem query, sem alerta)', () => {
-    expect(variantesDocumento('1234')).toBeNull();
-    expect(variantesDocumento('')).toBeNull();
-    expect(variantesDocumento(null)).toBeNull();
-    expect(variantesDocumento(undefined)).toBeNull();
+  it('cliente ausente → sem pares (sem query, sem alerta)', () => {
+    expect(paresDoCliente(null)).toEqual([]);
+    expect(paresDoCliente(undefined)).toEqual([]);
   });
 });
 

--- a/src/hooks/useAlertaCreditoCliente.ts
+++ b/src/hooks/useAlertaCreditoCliente.ts
@@ -5,13 +5,18 @@ import { OPEN_TITLE_STATUSES } from '@/lib/financeiro/titulo-status';
 
 /**
  * Alerta de crédito no wizard de venda — FASE 1 do programa "back to basics"
- * (não bloqueia nada; Fase 2 é que adiciona aprovação de exceção).
+ * (não bloqueia nada; a Fase 2 adiciona o enforcement na fronteira).
  *
  * Critério: cliente com saldo em aberto vencido há 60+ dias (mesma régua que a
- * Fase 2 vai endurecer — não mudar o critério entre fases).
+ * Fase 2 endurece — não mudar o critério entre fases).
+ *
+ * ⚠️ Join por (company, omie_codigo_cliente), NUNCA por CNPJ: o ListarContasReceber
+ * do Omie não retorna cnpj_cpf (verificado em prod: vazio nos 43k títulos, código
+ * 100% populado) — o filtro por CNPJ da primeira versão casava 0 linhas SEMPRE.
+ * O cliente do wizard carrega os códigos das 3 contas (oben/colacor/afiacao).
  *
  * Money-path (precisão > recall): só alerta com EVIDÊNCIA POSITIVA de vencido.
- * Sem documento, sem títulos ou erro na fonte → null (silêncio) — nunca um
+ * Sem códigos, sem títulos ou erro na fonte → null (silêncio) — nunca um
  * "cliente OK" fabricado, e nunca acusação sem dado. O frescor do sync é
  * exibido junto (dados do Omie podem atrasar) com flag explícita de defasagem.
  */
@@ -21,13 +26,44 @@ export const ALERTA_CREDITO = {
   defasagemMaxHoras: 24,
 } as const;
 
+export interface ParCliente {
+  company: 'oben' | 'colacor' | 'colacor_sc';
+  codigo: number;
+}
+
+/** Campos de código que o OmieCustomer do wizard carrega (cada conta Omie tem o seu). */
+export interface ClienteComCodigos {
+  codigo_cliente?: number | null;
+  codigo_cliente_colacor?: number | null;
+  codigo_cliente_afiacao?: number | null;
+}
+
+/**
+ * Pares (company, código) do cliente para casar com `fin_contas_receber`.
+ * Código 0/null é ignorado (cliente sintético do autoatendimento usa 0).
+ */
+export function paresDoCliente(cliente: ClienteComCodigos | null | undefined): ParCliente[] {
+  if (!cliente) return [];
+  const pares: ParCliente[] = [];
+  if (cliente.codigo_cliente && cliente.codigo_cliente > 0) {
+    pares.push({ company: 'oben', codigo: cliente.codigo_cliente });
+  }
+  if (cliente.codigo_cliente_colacor && cliente.codigo_cliente_colacor > 0) {
+    pares.push({ company: 'colacor', codigo: cliente.codigo_cliente_colacor });
+  }
+  if (cliente.codigo_cliente_afiacao && cliente.codigo_cliente_afiacao > 0) {
+    pares.push({ company: 'colacor_sc', codigo: cliente.codigo_cliente_afiacao });
+  }
+  return pares;
+}
+
 export interface TituloVencidoRow {
   saldo: number | null;
   data_vencimento: string | null;
 }
 
 export interface AlertaCredito {
-  /** R$ total em aberto vencido há 60+ dias. */
+  /** R$ total em aberto vencido há 60+ dias (todas as contas do grupo que o cliente tem). */
   vencido: number;
   titulos: number;
   /** Vencimento mais antigo (yyyy-MM-dd). */
@@ -36,22 +72,6 @@ export interface AlertaCredito {
   syncAt: string | null;
   /** true quando o sync está a mais de 24h (ou sem registro) — dado pode estar defasado. */
   dadoDefasado: boolean;
-}
-
-/**
- * Variantes do documento para casar com `fin_contas_receber.cnpj_cpf` sem `.or()`
- * cru (armadilha PostgREST): só-dígitos + formatado CNPJ/CPF. Retorna null se o
- * documento não tem 11 (CPF) ou 14 (CNPJ) dígitos — sem documento válido, sem query.
- */
-export function variantesDocumento(documento: string | null | undefined): string[] | null {
-  const digits = (documento ?? '').replace(/\D/g, '');
-  if (digits.length === 14) {
-    return [digits, digits.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5')];
-  }
-  if (digits.length === 11) {
-    return [digits, digits.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4')];
-  }
-  return null;
 }
 
 /** Cômputo puro (testável sem Supabase). `titulos` já vem filtrado pelo query (aberto + 60d + saldo > 0). */
@@ -80,14 +100,15 @@ export function computeAlertaCredito(
 
 const PAGE = 1000;
 
-/** Pagina além da capa silenciosa de 1.000 linhas do PostgREST (achado Codex — nunca truncar soma money-path). */
-async function fetchTitulosVencidos(variantes: string[], corte: string): Promise<TituloVencidoRow[]> {
+/** Pagina além da capa silenciosa de 1.000 linhas do PostgREST (nunca truncar soma money-path). */
+async function fetchTitulosVencidosPar(par: ParCliente, corte: string): Promise<TituloVencidoRow[]> {
   const out: TituloVencidoRow[] = [];
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
       .from('fin_contas_receber')
       .select('saldo, data_vencimento')
-      .in('cnpj_cpf', variantes)
+      .eq('company', par.company)
+      .eq('omie_codigo_cliente', par.codigo)
       .in('status_titulo', [...OPEN_TITLE_STATUSES])
       .lt('data_vencimento', corte)
       .gt('saldo', 0)
@@ -101,19 +122,20 @@ async function fetchTitulosVencidos(variantes: string[], corte: string): Promise
   return out;
 }
 
-export function useAlertaCreditoCliente(documento: string | null | undefined) {
-  const variantes = variantesDocumento(documento);
+export function useAlertaCreditoCliente(cliente: ClienteComCodigos | null | undefined) {
+  const pares = paresDoCliente(cliente);
+  const chave = pares.map((p) => `${p.company}:${p.codigo}`).join('|');
 
   return useQuery({
-    queryKey: ['alerta-credito', variantes?.[0] ?? null],
-    enabled: variantes !== null,
+    queryKey: ['alerta-credito', chave],
+    enabled: pares.length > 0,
     staleTime: 60_000,
     queryFn: async (): Promise<AlertaCredito | null> => {
-      if (!variantes) return null;
+      if (pares.length === 0) return null;
       const corte = format(subDays(new Date(), ALERTA_CREDITO.diasVencidoMin), 'yyyy-MM-dd');
 
-      const [titulos, syncRes] = await Promise.all([
-        fetchTitulosVencidos(variantes, corte),
+      const [porPar, syncRes] = await Promise.all([
+        Promise.all(pares.map((p) => fetchTitulosVencidosPar(p, corte))),
         supabase
           .from('fin_sync_log')
           .select('completed_at')
@@ -125,7 +147,7 @@ export function useAlertaCreditoCliente(documento: string | null | undefined) {
       if (syncRes.error) throw new Error(syncRes.error.message);
 
       return computeAlertaCredito(
-        titulos,
+        porPar.flat(),
         (syncRes.data?.[0]?.completed_at as string | null) ?? null,
         new Date(),
       );

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5785,6 +5785,60 @@ export type Database = {
         }
         Relationships: []
       }
+      gov_iniciativas: {
+        Row: {
+          alavanca: string
+          created_at: string
+          created_by: string | null
+          descricao: string | null
+          dono_id: string | null
+          empresa: string
+          evidencia: string | null
+          ganho_esperado_mensal: number | null
+          ganho_recorrente_mensal: number | null
+          id: string
+          inicio_em: string | null
+          recorrente_desde: string | null
+          status: string
+          titulo: string
+          updated_at: string
+        }
+        Insert: {
+          alavanca?: string
+          created_at?: string
+          created_by?: string | null
+          descricao?: string | null
+          dono_id?: string | null
+          empresa: string
+          evidencia?: string | null
+          ganho_esperado_mensal?: number | null
+          ganho_recorrente_mensal?: number | null
+          id?: string
+          inicio_em?: string | null
+          recorrente_desde?: string | null
+          status?: string
+          titulo: string
+          updated_at?: string
+        }
+        Update: {
+          alavanca?: string
+          created_at?: string
+          created_by?: string | null
+          descricao?: string | null
+          dono_id?: string | null
+          empresa?: string
+          evidencia?: string | null
+          ganho_esperado_mensal?: number | null
+          ganho_recorrente_mensal?: number | null
+          id?: string
+          inicio_em?: string | null
+          recorrente_desde?: string | null
+          status?: string
+          titulo?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       health_score_history: {
         Row: {
           calculated_at: string

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -336,7 +336,7 @@ const UnifiedOrder = () => {
 
           {/* Alerta de crédito (Fase 1 — informativo, não bloqueia) */}
           {showCustomerSearch && h.selectedCustomer && (
-            <AlertaCreditoCliente documento={h.selectedCustomer.cnpj_cpf} />
+            <AlertaCreditoCliente cliente={h.selectedCustomer} />
           )}
 
           {/* Cores já pedidas pelo cliente — busca + re-pedido (staff) */}


### PR DESCRIPTION
## Dois fixes urgentes (main vermelha + alerta de crédito morto)

### 1. `fix(types)`: main estava com typecheck quebrado

O commit `9d97d0ff` ("Changes", bot do Lovable) regenerou `src/integrations/supabase/types.ts` a partir de um snapshot do banco **anterior** ao apply manual das migrations do #1145 — apagando a entrada `gov_iniciativas` e quebrando o typecheck da main (mesmo padrão do caso `20260626150457` documentado em `docs/agent/database.md` §3). A tabela **existe em prod** (validação pós-apply toda ✅), então restaurar a entrada é o estado correto; a próxima regeneração do Lovable vai preservá-la.

### 2. `fix(venda)`: o alerta de crédito da Fase 1 (#1141) nunca disparou em prod

Achado durante o desenho da Fase 2 (trava de crédito), verificado em prod via `psql-ro`:

- **`fin_contas_receber.cnpj_cpf` está vazio nos 43.049 títulos** — o `ListarContasReceber` do Omie não retorna o campo; o mapper grava `""`.
- `omie_codigo_cliente` está **100% populado** e nenhum código mapeia para 2 clientes na mesma company.

O filtro `.in('cnpj_cpf', variantes)` casava **0 linhas sempre** → o alerta era um falso-negativo permanente (silêncio indistinguível de "cliente OK"). Meus testes unitários não pegaram porque mockam a fonte — a lição está registrada na spec da Fase 2.

**Fix:** o hook agora recebe o cliente do wizard e casa por pares `(company, omie_codigo_cliente)` das contas que o cliente tem (`codigo_cliente`→oben, `codigo_cliente_colacor`→colacor, `codigo_cliente_afiacao`→colacor_sc), uma query paginada por par (sem `.or()` cru). Código `0` (cliente sintético do autoatendimento) é ignorado. Critério, defasagem e silêncio-em-erro inalterados.

### Verificação

- 15 testes (4 novos de `paresDoCliente`) + **falsificação**: sabotei o guard do código 0 → vermelho → restaurei → verde.
- Typecheck estrito: **vermelho na main → verde neste PR**.
- Spec e veredito do challenge Codex da Fase 2: `docs/superpowers/specs/trava-credito-fase2.md`.

**Deploy:** só **Publish** no Lovable após o merge (sem migration, sem edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
