### PR TITLE
fix: 5 bugs P0/P1 (LGPD transcricao, fila offline, preco virgula, margem farmer)

### DIFF
--- a/src/components/unified-order/CartItemList.tsx
+++ b/src/components/unified-order/CartItemList.tsx
@@ -20,6 +20,7 @@ import { ReguaPrecoSinal } from '@/components/regua-preco/ReguaPrecoSinal';
 import type { ReguaCartItem } from '@/lib/regua-preco/regua-preco-ui';
 import { useReguaPrecoLog } from '@/hooks/useReguaPrecoLog';
 import { isInvalidProductPrice } from '@/services/orderSubmission/priceGuard';
+import { PriceInput } from './PriceInput';
 
 interface CartItemListProps {
   cart: { length: number };
@@ -220,7 +221,7 @@ export function CartItemList({
               </div>
               <div className="flex items-center gap-0.5 flex-1">
                 <span className="text-[10px] text-muted-foreground">R$</span>
-                <Input type="text" inputMode="decimal" pattern="[0-9]*\.?[0-9]*" value={item.unit_price} aria-invalid={invalidPrice} onFocus={e => e.target.select()} onChange={e => onUpdateProductPrice(cartIdx, parseFloat(e.target.value) || 0)} className={cn('h-6 text-xs', invalidPrice && 'border-status-error focus-visible:ring-status-error')} />
+                <PriceInput value={item.unit_price} invalid={invalidPrice} onValueChange={(preco) => onUpdateProductPrice(cartIdx, preco)} className={cn('h-6 text-xs', invalidPrice && 'border-status-error focus-visible:ring-status-error')} />
               </div>
               <span className="text-xs font-semibold shrink-0">{fmt(item.quantity * item.unit_price)}</span>
             </div>

--- a/src/components/unified-order/PriceInput.tsx
+++ b/src/components/unified-order/PriceInput.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { parseDecimalBR } from '@/lib/preco/parse-decimal-br';
+
+interface PriceInputProps {
+  value: number;
+  onValueChange: (value: number) => void;
+  invalid?: boolean;
+  className?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Input de preço que aceita vírgula decimal (teclado pt-BR). Mantém o texto digitado
+ * num buffer local enquanto o campo está em uso — sem isso, o `value` numérico controlado
+ * re-renderiza a cada tecla e DESCARTA a vírgula, transformando "12,5" em 125 (preço 10×).
+ * Só propaga quando o texto parseia para um número (nunca fabrica zero — money-path).
+ */
+export function PriceInput({
+  value,
+  onValueChange,
+  invalid,
+  className,
+  'aria-label': ariaLabel,
+}: PriceInputProps) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const display = draft ?? (value ? String(value) : '');
+
+  return (
+    <Input
+      type="text"
+      inputMode="decimal"
+      pattern="[0-9]*[.,]?[0-9]*"
+      value={display}
+      aria-invalid={invalid}
+      aria-label={ariaLabel}
+      onFocus={(e) => {
+        setDraft(display);
+        e.target.select();
+      }}
+      onChange={(e) => {
+        const raw = e.target.value;
+        setDraft(raw);
+        const parsed = parseDecimalBR(raw);
+        if (parsed !== null) onValueChange(parsed);
+      }}
+      onBlur={() => setDraft(null)}
+      className={className}
+    />
+  );
+}

--- a/src/components/unified-order/__tests__/PriceInput.test.tsx
+++ b/src/components/unified-order/__tests__/PriceInput.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PriceInput } from '../PriceInput';
+
+describe('PriceInput', () => {
+  it('propaga o número parseado da vírgula decimal (12,5 → 12.5, não 125)', () => {
+    const onValueChange = vi.fn();
+    render(<PriceInput value={0} onValueChange={onValueChange} aria-label="preco" />);
+    fireEvent.change(screen.getByLabelText('preco'), { target: { value: '12,5' } });
+    expect(onValueChange).toHaveBeenLastCalledWith(12.5);
+  });
+
+  it('preserva o texto digitado quando o value controlado muda no re-render (o buffer que impede o descarte da vírgula)', () => {
+    const { rerender } = render(
+      <PriceInput value={0} onValueChange={() => {}} aria-label="preco" />,
+    );
+    const input = screen.getByLabelText('preco') as HTMLInputElement;
+    fireEvent.focus(input);
+    // vírgula parcial ("12,") ainda não parseia — não deve propagar nem sumir do campo
+    fireEvent.change(input, { target: { value: '12,' } });
+    rerender(<PriceInput value={99} onValueChange={() => {}} aria-label="preco" />);
+    expect(input.value).toBe('12,'); // não virou "99" (controlado) nem "12" (vírgula descartada)
+  });
+
+  it('não propaga valor para entrada ilegível (não fabrica zero)', () => {
+    const onValueChange = vi.fn();
+    render(<PriceInput value={10} onValueChange={onValueChange} aria-label="preco" />);
+    fireEvent.change(screen.getByLabelText('preco'), { target: { value: 'abc' } });
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useTranscription.test.tsx
+++ b/src/hooks/__tests__/useTranscription.test.tsx
@@ -136,4 +136,38 @@ describe('useTranscription', () => {
     );
     expect(engineMock.TranscriptionEngine).not.toHaveBeenCalled();
   });
+
+  it('nova chamada NÃO herda os turns da chamada anterior (vazamento entre clientes/LGPD)', async () => {
+    const { result, rerender } = renderHook(
+      ({ enabled }) =>
+        useTranscription({
+          vendorStream: new MediaStream(),
+          clientStream: new MediaStream(),
+          enabled,
+        }),
+      { initialProps: { enabled: true } }
+    );
+
+    // Chamada A: engine ativa e gera um turno com conteúdo do cliente A
+    await waitFor(() => expect(result.current.status).toBe('active'));
+    act(() => {
+      (engineMock._handlers['turn'] ?? [])[0]?.({
+        id: 'clienteA-1',
+        speaker: 'cliente',
+        text: 'dado confidencial do cliente A',
+        isFinal: true,
+        startedAt: Date.now(),
+        endedAt: Date.now(),
+      });
+    });
+    expect(result.current.turns).toHaveLength(1);
+
+    // Fim da chamada A → início da chamada B (Provider WebRTC é global, não desmonta)
+    rerender({ enabled: false });
+    rerender({ enabled: true });
+    await waitFor(() => expect(result.current.status).toBe('active'));
+
+    // A transcrição do cliente A não pode sobreviver para a chamada B
+    expect(result.current.turns).toEqual([]);
+  });
 });

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { Tables } from '@/integrations/supabase/types';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
+import { accumulateMarginFromItems } from '@/lib/scoring/margin';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
 type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price' | 'cost_final'>;
@@ -241,15 +242,13 @@ export const useFarmerScoring = (farmerId?: string) => {
           ? (order.items as unknown as SalesOrderItem[])
           : [];
         for (const item of items) {
-          if (item.product_id) {
-            cd.categories.add(item.product_id);
-            const qty = Number(item.quantity || 1);
-            const price = Number(item.unit_price || 0);
-            const cost = costMap.get(item.product_id) || 0;
-            cd.totalRevenue += price * qty;
-            cd.totalCost += cost * qty;
-          }
+          if (item.product_id) cd.categories.add(item.product_id);
         }
+        // Margem só sobre SKU com custo CONHECIDO (custo ausente não vira 0 — inflaria a
+        // margem; ausente ≠ zero). Alinhado ao filtro do costMap acima (~linha 176).
+        const { revenue, cost } = accumulateMarginFromItems(items, costMap);
+        cd.totalRevenue += revenue;
+        cd.totalCost += cost;
       }
 
       // Aggregate call data

--- a/src/hooks/useTranscription.ts
+++ b/src/hooks/useTranscription.ts
@@ -60,6 +60,12 @@ export function useTranscription(opts: UseTranscriptionOptions): UseTranscriptio
     }
 
     let cancelled = false;
+    // Nova sessão: zera os turns/erro da chamada ANTERIOR. Sem isto, a transcrição de
+    // uma ligação vaza para a próxima (o Provider WebRTC é global e não desmonta entre
+    // chamadas) — persistiria conversa do cliente A em `farmer_calls` do cliente B e
+    // contaminaria os sinais/CRM (LGPD). Seguro: só executa quando engineRef é null,
+    // nunca no meio de uma chamada ativa.
+    setTurns([]);
     setStatus('connecting');
     setError(null);
 

--- a/src/lib/__tests__/offline-queue-flush.test.ts
+++ b/src/lib/__tests__/offline-queue-flush.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// track() chama analytics/posthog — neutraliza no teste.
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+import { enqueue, flush, getOfflineQueueDepth, getQueuedByKind } from '../offline-queue';
+
+beforeEach(() => localStorage.clear());
+
+describe('flush — segurança contra escrita concorrente', () => {
+  it('não descarta mutações enfileiradas DURANTE o flush', async () => {
+    await enqueue('picking.confirm', { n: 1 });
+
+    // Handler que, no meio do processamento (rede volta e cai de novo), enfileira uma
+    // nova mutação — exatamente o cenário do galpão com rede intermitente.
+    const handler = vi.fn(async () => {
+      await enqueue('picking.confirm', { n: 2 });
+      return true; // item 1 processado com sucesso
+    });
+
+    await flush(handler);
+
+    // O item 2 (enfileirado durante o flush) NÃO pode ser sobrescrito/perdido.
+    expect(await getOfflineQueueDepth()).toBe(1);
+    expect(getQueuedByKind<{ n: number }>('picking.confirm')[0].variables).toEqual({ n: 2 });
+  });
+
+  it('remove só os processados com sucesso e mantém os que falharam com attempts++', async () => {
+    await enqueue('a', { i: 1 });
+    await enqueue('a', { i: 2 });
+
+    // 1º item falha (handler retorna false), 2º sucede.
+    let call = 0;
+    const handler = vi.fn(async () => {
+      call += 1;
+      return call !== 1; // false no primeiro, true no segundo
+    });
+
+    const res = await flush(handler);
+
+    expect(res).toEqual({ success: 1, failed: 1 });
+    const remaining = getQueuedByKind<{ i: number }>('a');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].variables).toEqual({ i: 1 });
+    expect(remaining[0].attempts).toBe(1);
+  });
+});

--- a/src/lib/offline-queue.ts
+++ b/src/lib/offline-queue.ts
@@ -96,20 +96,22 @@ export async function flush(
   handler: (mutation: QueuedMutation) => Promise<boolean>,
 ): Promise<{ success: number; failed: number }> {
   const items = readQueue();
-  const remaining: QueuedMutation[] = [];
+  const succeeded = new Set<string>();
+  const failedById = new Map<string, QueuedMutation>();
   let success = 0;
   let failed = 0;
   for (const item of items) {
     try {
       const ok = await handler(item);
       if (ok) {
+        succeeded.add(item.id);
         success++;
       } else {
-        remaining.push({ ...item, attempts: item.attempts + 1 });
+        failedById.set(item.id, { ...item, attempts: item.attempts + 1 });
         failed++;
       }
     } catch (e) {
-      remaining.push({
+      failedById.set(item.id, {
         ...item,
         attempts: item.attempts + 1,
         lastError: e instanceof Error ? e.message : String(e),
@@ -117,6 +119,13 @@ export async function flush(
       failed++;
     }
   }
+  // Re-lê a fila ATUAL em vez de sobrescrever com o snapshot: `enqueue()` pode ter
+  // rodado durante os awaits do handler (rede intermitente do galpão). Remove só os
+  // processados com sucesso (por id), aplica attempts++ nos que falharam, e preserva
+  // intactos os que chegaram durante o flush.
+  const remaining = readQueue()
+    .filter((m) => !succeeded.has(m.id))
+    .map((m) => failedById.get(m.id) ?? m);
   writeQueue(remaining);
   track('offline.flushed', { success, failed, remaining: remaining.length });
   return { success, failed };

--- a/src/lib/preco/parse-decimal-br.test.ts
+++ b/src/lib/preco/parse-decimal-br.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { parseDecimalBR } from './parse-decimal-br';
+
+describe('parseDecimalBR', () => {
+  it('aceita vírgula como separador decimal (teclado pt-BR)', () => {
+    expect(parseDecimalBR('12,5')).toBe(12.5);
+    expect(parseDecimalBR('0,99')).toBe(0.99);
+  });
+
+  it('aceita ponto como separador decimal', () => {
+    expect(parseDecimalBR('12.5')).toBe(12.5);
+  });
+
+  it('trata ponto como milhar quando há vírgula decimal', () => {
+    expect(parseDecimalBR('1.234,56')).toBe(1234.56);
+    expect(parseDecimalBR('1.000,00')).toBe(1000);
+  });
+
+  it('aceita inteiro sem separador', () => {
+    expect(parseDecimalBR('1234')).toBe(1234);
+  });
+
+  it('retorna null para vazio ou lixo (não fabrica zero)', () => {
+    expect(parseDecimalBR('')).toBeNull();
+    expect(parseDecimalBR('   ')).toBeNull();
+    expect(parseDecimalBR('abc')).toBeNull();
+    expect(parseDecimalBR('12,5,6')).toBeNull();
+  });
+});

--- a/src/lib/preco/parse-decimal-br.test.ts
+++ b/src/lib/preco/parse-decimal-br.test.ts
@@ -26,4 +26,27 @@ describe('parseDecimalBR', () => {
     expect(parseDecimalBR('abc')).toBeNull();
     expect(parseDecimalBR('12,5,6')).toBeNull();
   });
+
+  it('interpreta corretamente formato en-US (vírgula milhar + ponto decimal)', () => {
+    // o ÚLTIMO separador é o decimal — antes virava 1.23456 (subprecificação 1000x)
+    expect(parseDecimalBR('1,234.56')).toBe(1234.56);
+    expect(parseDecimalBR('1,234,567')).toBe(1234567);
+  });
+
+  it('aceita milhar pt-BR completo', () => {
+    expect(parseDecimalBR('1.234.567,89')).toBe(1234567.89);
+  });
+
+  it('REJEITA agrupamento ambíguo em vez de fabricar preço errado (money-path)', () => {
+    // "1.234" em pt-BR normalmente é 1234; como decimal seria 1.234 — ambíguo → null
+    expect(parseDecimalBR('1.234')).toBeNull();
+    expect(parseDecimalBR('12.345')).toBeNull();
+    // grupos de milhar mal formados também são rejeitados
+    expect(parseDecimalBR('1,23.456')).toBeNull();
+  });
+
+  it('NÃO rejeita decimal legítimo com 3 casas quando não parece milhar', () => {
+    expect(parseDecimalBR('0,999')).toBe(0.999);
+    expect(parseDecimalBR('0.999')).toBe(0.999); // inteiro "0" não é grupo de milhar válido
+  });
 });

--- a/src/lib/preco/parse-decimal-br.ts
+++ b/src/lib/preco/parse-decimal-br.ts
@@ -1,21 +1,69 @@
 /**
- * Converte um número digitado à mão (pt-BR ou en) para `number`, ou `null` se ilegível.
+ * Converte um número digitado à mão (pt-BR ou en) para `number`, ou `null` se ilegível
+ * OU ambíguo. Nunca fabrica um número errado a partir de entrada ambígua — money-path:
+ * um preço silenciosamente errado é pior que exigir o usuário redigitar.
  *
- * Regra: se houver vírgula, ela é o separador DECIMAL e os pontos são milhar
- * (`"1.234,56"` → `1234.56`); sem vírgula, o ponto é o separador decimal
- * (`"12.5"` → `12.5`). Lixo/vazio → `null` (nunca fabrica zero — money-path).
+ * Regras:
+ *  - Ambos separadores presentes: o ÚLTIMO é o decimal, o outro é milhar (grupos de 3).
+ *    `"1.234,56"` → 1234.56 (pt-BR) · `"1,234.56"` → 1234.56 (en-US).
+ *  - Só vírgula: uma vírgula = decimal pt-BR (`"12,5"`→12.5); várias = milhar (`"1,234,567"`→1234567).
+ *  - Só ponto: 1-2 casas ou inteiro "0…" = decimal (`"12.5"`,`"0.999"`); vários pontos = milhar pt-BR.
+ *    Exatamente 3 casas com inteiro que parece grupo de milhar (`"1.234"`) é AMBÍGUO → `null`.
+ *  - Agrupamento mal formado (grupos ≠ 3 dígitos) → `null`.
  *
  * Existe porque `parseFloat("12,5")` = 12 (engole a vírgula do teclado decimal pt-BR),
  * transformando 12,50 em 1250 no input de preço do pedido.
  */
 export function parseDecimalBR(input: string): number | null {
   if (typeof input !== 'string') return null;
-  let s = input.trim();
+  const s = input.trim();
   if (s === '') return null;
-  if (s.includes(',')) {
-    s = s.replace(/\./g, '').replace(',', '.');
+  if (!/^-?[\d.,]+$/.test(s)) return null;
+
+  const neg = s.startsWith('-');
+  const body = neg ? s.slice(1) : s;
+
+  const finish = (intPart: string, frac: string): number | null => {
+    const norm = frac ? `${intPart}.${frac}` : intPart;
+    if (!/^\d+(\.\d+)?$/.test(norm)) return null;
+    const n = Number((neg ? '-' : '') + norm);
+    return Number.isFinite(n) ? n : null;
+  };
+  // Agrupamento de milhar válido: primeiro grupo 1-3 dígitos, os demais exatamente 3.
+  const validGrouping = (groups: string[]): boolean =>
+    groups.length > 1 &&
+    groups[0].length >= 1 && groups[0].length <= 3 &&
+    groups.slice(1).every((g) => g.length === 3);
+
+  const lastComma = body.lastIndexOf(',');
+  const lastDot = body.lastIndexOf('.');
+
+  if (lastComma >= 0 && lastDot >= 0) {
+    const decSep = lastComma > lastDot ? ',' : '.';
+    const grpSep = decSep === ',' ? '.' : ',';
+    const parts = body.split(decSep);
+    if (parts.length !== 2) return null; // 2+ separadores decimais = malformado
+    const groups = parts[0].split(grpSep);
+    if (!validGrouping(groups)) return null;
+    return finish(groups.join(''), parts[1]);
   }
-  if (!/^-?\d*\.?\d+$/.test(s)) return null;
-  const n = Number(s);
-  return Number.isFinite(n) ? n : null;
+
+  if (lastComma >= 0) {
+    const parts = body.split(',');
+    if (parts.length === 2) return finish(parts[0], parts[1]);
+    return validGrouping(parts) ? finish(parts.join(''), '') : null;
+  }
+
+  if (lastDot >= 0) {
+    const parts = body.split('.');
+    if (parts.length === 2) {
+      const [intP, frac] = parts;
+      // "1.234" (3 casas + inteiro 1-3 díg sem zero à esquerda) é ambíguo: 1234 ou 1.234 → null.
+      if (frac.length === 3 && /^[1-9]\d{0,2}$/.test(intP)) return null;
+      return finish(intP, frac);
+    }
+    return validGrouping(parts) ? finish(parts.join(''), '') : null;
+  }
+
+  return finish(body, '');
 }

--- a/src/lib/preco/parse-decimal-br.ts
+++ b/src/lib/preco/parse-decimal-br.ts
@@ -1,0 +1,21 @@
+/**
+ * Converte um número digitado à mão (pt-BR ou en) para `number`, ou `null` se ilegível.
+ *
+ * Regra: se houver vírgula, ela é o separador DECIMAL e os pontos são milhar
+ * (`"1.234,56"` → `1234.56`); sem vírgula, o ponto é o separador decimal
+ * (`"12.5"` → `12.5`). Lixo/vazio → `null` (nunca fabrica zero — money-path).
+ *
+ * Existe porque `parseFloat("12,5")` = 12 (engole a vírgula do teclado decimal pt-BR),
+ * transformando 12,50 em 1250 no input de preço do pedido.
+ */
+export function parseDecimalBR(input: string): number | null {
+  if (typeof input !== 'string') return null;
+  let s = input.trim();
+  if (s === '') return null;
+  if (s.includes(',')) {
+    s = s.replace(/\./g, '').replace(',', '.');
+  }
+  if (!/^-?\d*\.?\d+$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}

--- a/src/lib/scoring/__tests__/margin.test.ts
+++ b/src/lib/scoring/__tests__/margin.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { accumulateMarginFromItems } from '../margin';
+
+describe('accumulateMarginFromItems', () => {
+  it('soma receita e custo dos itens com custo conhecido', () => {
+    const costMap = new Map([['A', 10]]);
+    const { revenue, cost } = accumulateMarginFromItems(
+      [{ product_id: 'A', quantity: 2, unit_price: 25 }],
+      costMap,
+    );
+    expect(revenue).toBe(50);
+    expect(cost).toBe(20);
+  });
+
+  it('SKU sem custo conhecido NÃO entra na margem (não infla com custo zero)', () => {
+    const costMap = new Map([['A', 10]]);
+    const { revenue, cost } = accumulateMarginFromItems(
+      [
+        { product_id: 'A', quantity: 1, unit_price: 20 }, // custo conhecido
+        { product_id: 'B', quantity: 1, unit_price: 100 }, // sem custo → excluído
+      ],
+      costMap,
+    );
+    // Só o item A entra: margem 50%. Com o bug (|| 0): revenue 120, cost 10 → 92% inflado.
+    expect(revenue).toBe(20);
+    expect(cost).toBe(10);
+  });
+
+  it('cliente que só compra SKU sem custo → receita e custo zerados (margem indefinida, não 100%)', () => {
+    const { revenue, cost } = accumulateMarginFromItems(
+      [{ product_id: 'B', quantity: 3, unit_price: 100 }],
+      new Map(),
+    );
+    expect(revenue).toBe(0);
+    expect(cost).toBe(0);
+  });
+
+  it('aceita quantity/unit_price como string (jsonb) e ignora item sem product_id', () => {
+    const costMap = new Map([['A', 5]]);
+    const { revenue, cost } = accumulateMarginFromItems(
+      [
+        { product_id: 'A', quantity: '2', unit_price: '10' },
+        { quantity: 5, unit_price: 999 }, // sem product_id → ignorado
+      ],
+      costMap,
+    );
+    expect(revenue).toBe(20);
+    expect(cost).toBe(10);
+  });
+});

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -1,0 +1,31 @@
+interface MarginItem {
+  product_id?: string;
+  quantity?: number | string;
+  unit_price?: number | string;
+}
+
+/**
+ * Acumula receita e custo de itens de pedido para o cálculo de margem do cliente,
+ * contando SOMENTE os SKUs com custo conhecido no `costMap`.
+ *
+ * SKU sem custo é EXCLUÍDO (receita e custo) em vez de virar custo 0 — senão a margem
+ * bruta infla silenciosamente (ausente ≠ zero, money-path). O cliente que só compra SKU
+ * sem custo fica com receita/custo 0 → margem indefinida (não 100%).
+ */
+export function accumulateMarginFromItems(
+  items: MarginItem[],
+  costMap: Map<string, number>,
+): { revenue: number; cost: number } {
+  let revenue = 0;
+  let cost = 0;
+  for (const item of items) {
+    if (!item.product_id) continue;
+    const c = costMap.get(item.product_id);
+    if (c == null) continue;
+    const qty = Number(item.quantity || 1);
+    const price = Number(item.unit_price || 0);
+    revenue += price * qty;
+    cost += c * qty;
+  }
+  return { revenue, cost };
+}


### PR DESCRIPTION
Correções de bugs P0/P1 (frontend) saídas da revisão completa do app. Cada uma com TDD (teste que falha antes → fix → verde) e a superfície money-path passada pelo **Codex challenge** (2ª opinião obrigatória), que pegou e me fez corrigir um P1 real no meu próprio parser de preço.

## Correções

- **P0 — Transcrição vazava entre chamadas de clientes diferentes (LGPD).** `useTranscription` nunca resetava `turns` e o Provider WebRTC é global; a conversa do cliente A era persistida em `farmer_calls` do cliente B e contaminava sinais/CRM. Reset ao iniciar nova sessão (só quando não há chamada ativa).
- **P0 — Fila offline descartava mutações enfileiradas durante o flush.** `flush()` sobrescrevia a fila com o snapshot do início; um `enqueue()` durante os awaits de rede (galpão com conexão intermitente) era apagado — mutação de picking/recebimento perdida. Agora re-lê a fila e remove só os processados por id.
- **P1 — Preço 10× por vírgula pt-BR.** No teclado decimal do celular, `parseFloat('12,5')=12` engolia a vírgula e `12,50` virava `1250` (passava o priceGuard, ia ao Omie). Novo `PriceInput` com buffer de texto + `parseDecimalBR` (fail-closed: lixo/ambiguidade → `null`, nunca fabrica número).
- **P1 — Margem do farmer inflada por custo zero.** `costMap.get(id) || 0` fabricava custo R$0 para SKU sem custo, inflando a margem e classificando cliente de margem ruim como saudável. `accumulateMarginFromItems` (pura, testada) exclui SKU sem custo da margem.
- **P1 (Codex) — `parseDecimalBR` fabricava preço errado de entrada ambígua.** `'1,234.56'` (en-US) virava `1.23456` (subprecificação 1000×). Agora o último separador é o decimal e agrupamento ambíguo retorna `null`.

## Validação

- Typecheck ✅ · lint ✅ (0 erros)
- Suíte completa ✅ — a única falha (`SalesQuotes.priceGuard`) é um teste flaky pré-existente (timeout sob carga da suíte paralela; passa isolado, não importa nada tocado aqui).
- Novos testes: `useTranscription` (vazamento entre chamadas), `offline-queue-flush` (concorrência), `parse-decimal-br` (locale + ambiguidade), `PriceInput` (buffer), `scoring/margin` (SKU sem custo).

Deploy: **frontend → precisa de Publish no Lovable** (sem migration/edge neste PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
