### PR TITLE
perf: Onda 2 — timers isolados, virtualização do financeiro, memo no shell

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -371,7 +371,10 @@ function SidebarItem({
   return button;
 }
 
-function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
+// memo: com props estáveis (onToggle é useCallback no AppShell), re-renders do
+// shell (mobileOpen, lente, contexts) não re-renderizam os 80+ itens da nav.
+// Navegação e badges continuam re-renderizando por dentro (useLocation/queries).
+const AppSidebar = React.memo(function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () => void }) {
   const location = useLocation();
   const navigate = useNavigate();
   const { isStaff, isMaster, user } = useAuth();
@@ -680,10 +683,10 @@ function AppSidebar({ collapsed, onToggle }: { collapsed: boolean; onToggle: () 
       )}
     </aside>
   );
-}
+});
 
 /* ─── Topbar ─── */
-function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed: boolean; onMobileMenuToggle: () => void }) {
+const AppTopbar = React.memo(function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed: boolean; onMobileMenuToggle: () => void }) {
   const navigate = useNavigate();
   const { signOut } = useAuth();
   const { isImpersonating } = useImpersonation();
@@ -742,10 +745,10 @@ function AppTopbar({ sidebarCollapsed, onMobileMenuToggle }: { sidebarCollapsed:
 
     </header>
   );
-}
+});
 
 /* ─── Mobile overlay ─── */
-function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
+const MobileNav = React.memo(function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
   const location = useLocation();
   const navigate = useNavigate();
   const { displayIsStaff: isStaff, displayIsMaster: isMaster, displayIsGestorComercial: isGestorComercial, displayIsSalesOnly: isSalesOnly, displayLoading } = useDisplayAccess();
@@ -820,7 +823,7 @@ function MobileNav({ open, onClose }: { open: boolean; onClose: () => void }) {
       </div>
     </>
   );
-}
+});
 
 /* ─── Main Shell ─── */
 export function AppShell({ children }: { children: React.ReactNode }) {
@@ -831,6 +834,10 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const { isImpersonating } = useImpersonation();
+  // Handlers estáveis: pré-condição dos React.memo de AppSidebar/AppTopbar/MobileNav.
+  const toggleSidebar = React.useCallback(() => setCollapsed((c) => !c), []);
+  const openMobileNav = React.useCallback(() => setMobileOpen(true), []);
+  const closeMobileNav = React.useCallback(() => setMobileOpen(false), []);
 
   // Aplica .legacy-visual no <html> quando feature flag newVisual = false
   useFeatureFlagBodyClass('newVisual', 'legacy-visual', /* invert */ true);
@@ -843,14 +850,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             <ImpersonationBanner />
             {/* Desktop sidebar */}
             <div className="hidden lg:block">
-              <AppSidebar collapsed={collapsed} onToggle={() => setCollapsed(!collapsed)} />
+              <AppSidebar collapsed={collapsed} onToggle={toggleSidebar} />
             </div>
 
             {/* Mobile nav */}
-            <MobileNav open={mobileOpen} onClose={() => setMobileOpen(false)} />
+            <MobileNav open={mobileOpen} onClose={closeMobileNav} />
 
             {/* Topbar */}
-            <AppTopbar sidebarCollapsed={collapsed} onMobileMenuToggle={() => setMobileOpen(true)} />
+            <AppTopbar sidebarCollapsed={collapsed} onMobileMenuToggle={openMobileNav} />
 
             {/* Main content */}
             <main

--- a/src/components/farmer/calls/CallListPanel.tsx
+++ b/src/components/farmer/calls/CallListPanel.tsx
@@ -1,5 +1,6 @@
 // Lista de ligações + painel de detalhe (split estilo Gong) da página de Ligações.
 // Extraído de src/pages/FarmerCalls.tsx (god-component split).
+import { memo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -10,7 +11,9 @@ import { cn } from '@/lib/utils';
 import { CallDetailPanel } from './CallDetailPanel';
 import { CALL_TYPES, CALL_RESULTS, fmt, formatTimer, type CallLog } from './types';
 
-export function CallListPanel({
+// memo: o pai (FarmerCalls) re-renderiza a 1Hz durante chamada ativa (cronômetro);
+// com props estáveis (filteredLogs memoizado + setters), a lista não re-renderiza.
+export const CallListPanel = memo(function CallListPanel({
   filterType, setFilterType, filteredLogs, loadingLogs, selectedCall, setSelectedCall,
 }: {
   filterType: string;
@@ -101,4 +104,4 @@ export function CallListPanel({
       )}
     </div>
   );
-}
+});

--- a/src/components/financeiro/dashboard/ContasPagarTab.tsx
+++ b/src/components/financeiro/dashboard/ContasPagarTab.tsx
@@ -1,9 +1,11 @@
 // Conteúdo da aba "Contas a Pagar" do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
+import { useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Clock, AlertTriangle, DollarSign, Download, History } from 'lucide-react';
 import { COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { type FinanceiroView } from '@/hooks/useFinanceiro';
@@ -28,6 +30,27 @@ export function ContasPagarTab({
   loading: boolean;
   onAudit: (t: { table: string; id: string; title: string }) => void;
 }) {
+  // Virtualização — mesmo racional da ContasReceberTab (tabs gêmeas): acima de
+  // 100 linhas só as visíveis viram DOM; abaixo, renderização integral (idêntica
+  // à original — inclusive em jsdom/testes, onde o container mede 0px).
+  const virtualizar = contasPagar.length > 100;
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: contasPagar.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 48,
+    overscan: 12,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const linhas = virtualizar
+    ? virtualRows.map((vr) => ({ conta: contasPagar[vr.index], index: vr.index }))
+    : contasPagar.map((conta, index) => ({ conta, index }));
+  const paddingTop = virtualizar && virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom = virtualizar && virtualRows.length > 0
+    ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+    : 0;
+  const colSpan = view === 'all' ? 9 : 8;
+
   return (
     <>
       <div className="flex items-center justify-between flex-wrap gap-2">
@@ -99,9 +122,11 @@ export function ContasPagarTab({
 
       <Card>
         <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
+          {/* table crua (não <Table>): o wrapper interno do shadcn tem overflow
+              próprio e roubaria o scroll do virtualizador. Classes idênticas. */}
+          <div ref={parentRef} className="relative w-full overflow-auto rounded-md max-h-[65vh]">
+            <table className="w-full caption-bottom text-sm">
+              <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-card">
                 <TableRow>
                   {view === 'all' && <TableHead className="w-20">Empresa</TableHead>}
                   <TableHead>Fornecedor</TableHead>
@@ -115,8 +140,14 @@ export function ContasPagarTab({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {contasPagar.map((cp) => (
-                  <TableRow key={cp.id}>
+                {paddingTop > 0 && (
+                  <tr aria-hidden>
+                    <td colSpan={colSpan} style={{ height: paddingTop, padding: 0, border: 0 }} />
+                  </tr>
+                )}
+                {linhas.map(({ conta: cp, index }) => {
+                  return (
+                  <TableRow key={cp.id} data-index={index} ref={virtualizar ? rowVirtualizer.measureElement : undefined}>
                     {view === 'all' && (
                       <TableCell>
                         <Badge variant="outline" className="text-xs">
@@ -163,16 +194,22 @@ export function ContasPagarTab({
                       </Button>
                     </TableCell>
                   </TableRow>
-                ))}
+                  );
+                })}
+                {paddingBottom > 0 && (
+                  <tr aria-hidden>
+                    <td colSpan={colSpan} style={{ height: paddingBottom, padding: 0, border: 0 }} />
+                  </tr>
+                )}
                 {contasPagar.length === 0 && !loading && (
                   <TableRow>
-                    <TableCell colSpan={view === 'all' ? 9 : 8} className="text-center py-8 text-muted-foreground">
+                    <TableCell colSpan={colSpan} className="text-center py-8 text-muted-foreground">
                       Nenhum título encontrado. Sincronize os dados primeiro.
                     </TableCell>
                   </TableRow>
                 )}
               </TableBody>
-            </Table>
+            </table>
           </div>
         </CardContent>
       </Card>

--- a/src/components/financeiro/dashboard/ContasReceberTab.tsx
+++ b/src/components/financeiro/dashboard/ContasReceberTab.tsx
@@ -1,9 +1,11 @@
 // Conteúdo da aba "Contas a Receber" do dashboard financeiro.
 // Extraído de src/pages/FinanceiroDashboard.tsx (god-component split).
+import { useRef } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Clock, AlertTriangle, DollarSign, Download, History } from 'lucide-react';
 import { COMPANIES, type Company } from '@/contexts/CompanyContext';
 import { type FinanceiroView } from '@/hooks/useFinanceiro';
@@ -28,6 +30,30 @@ export function ContasReceberTab({
   loading: boolean;
   onAudit: (t: { table: string; id: string; title: string }) => void;
 }) {
+  // Virtualização: sem limit na query o PostgREST entrega até 1.000 títulos e
+  // TODOS viravam <tr> no DOM (~9.000 células) — filtro/scroll com jank. Acima
+  // do limiar, só as linhas visíveis (+overscan) existem no DOM; abaixo dele a
+  // renderização é integral (idêntica à original — inclusive em jsdom/testes,
+  // onde o container mede 0px e o virtualizador não veria linha nenhuma).
+  // NOTA: a tabela ganhou scroll interno (max-h) — necessário pro virtualizador.
+  const virtualizar = contasReceber.length > 100;
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: contasReceber.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 48,
+    overscan: 12,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const linhas = virtualizar
+    ? virtualRows.map((vr) => ({ conta: contasReceber[vr.index], index: vr.index }))
+    : contasReceber.map((conta, index) => ({ conta, index }));
+  const paddingTop = virtualizar && virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom = virtualizar && virtualRows.length > 0
+    ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+    : 0;
+  const colSpan = view === 'all' ? 9 : 8;
+
   return (
     <>
       <div className="flex items-center justify-between flex-wrap gap-2">
@@ -101,9 +127,12 @@ export function ContasReceberTab({
 
       <Card>
         <CardContent className="p-0">
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
+          {/* table crua (não <Table>): o wrapper interno do shadcn tem overflow
+              próprio e roubaria o scroll do virtualizador — o ref precisa estar
+              no container que de fato scrolla. Classes idênticas às do ui/table. */}
+          <div ref={parentRef} className="relative w-full overflow-auto rounded-md max-h-[65vh]">
+            <table className="w-full caption-bottom text-sm">
+              <TableHeader className="[&_th]:sticky [&_th]:top-0 [&_th]:z-10 [&_th]:bg-card">
                 <TableRow>
                   {view === 'all' && <TableHead className="w-20">Empresa</TableHead>}
                   <TableHead>Cliente</TableHead>
@@ -117,8 +146,14 @@ export function ContasReceberTab({
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {contasReceber.map((cr) => (
-                  <TableRow key={cr.id}>
+                {paddingTop > 0 && (
+                  <tr aria-hidden>
+                    <td colSpan={colSpan} style={{ height: paddingTop, padding: 0, border: 0 }} />
+                  </tr>
+                )}
+                {linhas.map(({ conta: cr, index }) => {
+                  return (
+                  <TableRow key={cr.id} data-index={index} ref={virtualizar ? rowVirtualizer.measureElement : undefined}>
                     {view === 'all' && (
                       <TableCell>
                         <Badge variant="outline" className="text-xs">
@@ -165,16 +200,22 @@ export function ContasReceberTab({
                       </Button>
                     </TableCell>
                   </TableRow>
-                ))}
+                  );
+                })}
+                {paddingBottom > 0 && (
+                  <tr aria-hidden>
+                    <td colSpan={colSpan} style={{ height: paddingBottom, padding: 0, border: 0 }} />
+                  </tr>
+                )}
                 {contasReceber.length === 0 && !loading && (
                   <TableRow>
-                    <TableCell colSpan={view === 'all' ? 9 : 8} className="text-center py-8 text-muted-foreground">
+                    <TableCell colSpan={colSpan} className="text-center py-8 text-muted-foreground">
                       Nenhum título encontrado. Sincronize os dados primeiro.
                     </TableCell>
                   </TableRow>
                 )}
               </TableBody>
-            </Table>
+            </table>
           </div>
         </CardContent>
       </Card>

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -44,6 +44,43 @@ type SkuSemFornecedor = {
   ponto_pedido: number | null;
 };
 
+/* ─── Relógio isolado ───
+ * O tick de minuto vivia como state da PÁGINA: a cada 60s o setNow re-renderizava
+ * a árvore inteira (~500 linhas de pedidos) só pra atualizar data/ciclo/frescor no
+ * header. Isolado aqui, cada tick re-renderiza apenas estes componentes minúsculos. */
+function useNowMinuto() {
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(t);
+  }, []);
+  return now;
+}
+
+function DataDeHojeLive() {
+  const now = useNowMinuto();
+  return <>{format(now, 'dd/MM/yyyy', { locale: ptBR })}</>;
+}
+
+function CycleIndicatorLive() {
+  const now = useNowMinuto();
+  return <CycleIndicator now={now} />;
+}
+
+function FrescorEstoqueLive({ ultimaSync }: { ultimaSync: string | null | undefined }) {
+  const now = useNowMinuto();
+  const frescor = frescorEstoque(ultimaSync, now);
+  const cor = { ok: 'text-muted-foreground', warning: 'text-status-warning', error: 'text-status-error' }[frescor.tone];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs ${cor}`}
+      title={ultimaSync ? `Último sync: ${format(new Date(ultimaSync), "dd/MM 'às' HH:mm", { locale: ptBR })}` : undefined}
+    >
+      <Clock className="w-3.5 h-3.5" /> Estoque Omie: {frescor.label}
+    </span>
+  );
+}
+
 /* ─── Página principal ─── */
 export default function AdminReposicaoPedidos() {
   const queryClient = useQueryClient();
@@ -52,7 +89,6 @@ export default function AdminReposicaoPedidos() {
   const { isMaster, isGestorComercial } = useAuth();
   const podeOverride = isMaster || isGestorComercial;
   const [searchParams, setSearchParams] = useSearchParams();
-  const [now, setNow] = useState(new Date());
   const [detalhesPedido, setDetalhesPedido] = useState<PedidoSugerido | null>(null);
   const [cancelarPedido, setCancelarPedido] = useState<PedidoSugerido | null>(null);
   const [portalPedido, setPortalPedido] = useState<PedidoSugerido | null>(null);
@@ -60,12 +96,17 @@ export default function AdminReposicaoPedidos() {
   const [mostrarAtencao, setMostrarAtencao] = useState(false);
   const [histAberto, setHistAberto] = useState(false);
 
+  // Vira a queryKey na meia-noite SEM re-render por minuto: setState com a MESMA
+  // string faz o React pular o re-render (bailout) nos outros 1.439 ticks do dia.
+  // O relógio visual do header vive nos componentes *Live acima, isolados.
+  const [dataHoje, setDataHoje] = useState(() => format(new Date(), 'yyyy-MM-dd'));
   useEffect(() => {
-    const t = setInterval(() => setNow(new Date()), 60_000);
+    const t = setInterval(() => {
+      const novaData = format(new Date(), 'yyyy-MM-dd');
+      setDataHoje((atual) => (atual === novaData ? atual : novaData));
+    }, 60_000);
     return () => clearInterval(t);
   }, []);
-
-  const dataHoje = format(now, 'yyyy-MM-dd');
 
   const { data: pedidos, isLoading, refetch } = useQuery({
     queryKey: ['pedidos-ciclo', dataHoje],
@@ -408,9 +449,9 @@ export default function AdminReposicaoPedidos() {
       <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">
-            Pedidos de compra — CICLO DE HOJE ({format(now, 'dd/MM/yyyy', { locale: ptBR })})
+            Pedidos de compra — CICLO DE HOJE (<DataDeHojeLive />)
           </h1>
-          <div className="mt-2"><CycleIndicator now={now} /></div>
+          <div className="mt-2"><CycleIndicatorLive /></div>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {atencaoCount > 0 ? (
@@ -428,18 +469,7 @@ export default function AdminReposicaoPedidos() {
               <CheckCircle2 className="w-3.5 h-3.5" /> Tudo em dia
             </span>
           )}
-          {frescorCarregado && (() => {
-            const frescor = frescorEstoque(ultimaSyncEstoque, now);
-            const cor = { ok: 'text-muted-foreground', warning: 'text-status-warning', error: 'text-status-error' }[frescor.tone];
-            return (
-              <span
-                className={`inline-flex items-center gap-1 text-xs ${cor}`}
-                title={ultimaSyncEstoque ? `Último sync: ${format(new Date(ultimaSyncEstoque), "dd/MM 'às' HH:mm", { locale: ptBR })}` : undefined}
-              >
-                <Clock className="w-3.5 h-3.5" /> Estoque Omie: {frescor.label}
-              </span>
-            );
-          })()}
+          {frescorCarregado && <FrescorEstoqueLive ultimaSync={ultimaSyncEstoque} />}
           <Button
             variant="outline"
             onClick={() => syncEstoqueMutation.mutate()}

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
@@ -392,7 +392,13 @@ const FarmerCalls = () => {
   const todayRevenue = todayCalls.reduce((s, c) => s + Number(c.revenue_generated), 0);
   const avgDuration = todayCalls.length > 0 ? Math.round(todayCalls.reduce((s, c) => s + c.duration_seconds, 0) / todayCalls.length) : 0;
 
-  const filteredLogs = filterType === 'all' ? callLogs : callLogs.filter(c => c.call_type === filterType);
+  // Memoizado: durante chamada ativa a página re-renderiza a 1Hz (cronômetro/nvoip).
+  // Referência estável aqui + React.memo no CallListPanel blindam a lista de 100+
+  // ligações desse tick — sem isto ela re-renderizava inteira a cada segundo.
+  const filteredLogs = useMemo(
+    () => (filterType === 'all' ? callLogs : callLogs.filter(c => c.call_type === filterType)),
+    [callLogs, filterType],
+  );
 
   if (authLoading) {
     // PageSkeleton (não Loader2 full-page): o Suspense da rota já mostrou um


### PR DESCRIPTION
## Contexto

**Onda 2** da auditoria de performance ([Onda 1 = #1160](https://github.com/LucasSardenbergL/afiacao/pull/1160), mergeada). Foco: eliminar re-renders recorrentes (timers) e DOM gigante (tabelas), nas telas onde o jank é sentido.

## Mudanças

| Tela | Problema medido | Correção |
|---|---|---|
| `AdminReposicaoPedidos` | `setInterval` de 60s como state da página → re-render de ~500 linhas de pedidos **a cada minuto, o dia inteiro** (1.440×/dia), só para atualizar relógio/frescor no header | `dataHoje` com bailout (setState da mesma string → React pula o render; página só re-renderiza na virada do dia) + relógio isolado em 3 componentes `*Live` minúsculos com tick próprio |
| `FarmerCalls` | durante chamada ativa a página re-renderiza a **1Hz** (cronômetro manual/nvoip) — incluindo a lista de 100+ ligações atrás do dialog | `filteredLogs` memoizado (era `.filter` inline) + `React.memo` no `CallListPanel` → a lista fica imune ao tick |
| Financeiro **CR/CP** | sem `limit` na query o PostgREST entrega até 1.000 títulos → **~9.000 células no DOM** por tab; filtro/scroll com jank | virtualização (`@tanstack/react-virtual`, já instalada) **acima de 100 linhas**; abaixo do limiar a renderização é integral e idêntica à original. Tabela ganhou scroll interno (`max-h-[65vh]`) + header sticky |
| `AppShell` | qualquer re-render do shell (mobileOpen, lente, contexts) re-renderizava os 80+ itens da nav + topbar | `React.memo` em `AppSidebar`/`AppTopbar`/`MobileNav` + handlers `useCallback` |

## Decisões de desenho

- **Limiar de virtualização (100 linhas)** em vez de virtualizar sempre: os testes existentes das tabs falharam de verdade na 1ª rodada (jsdom não faz layout → container mede 0px → zero linhas renderizadas). O limiar resolve pela raiz — fixtures pequenas e listas curtas usam o caminho integral (DOM idêntico ao original), produção com 500-1.000 títulos virtualiza. Não é hack de teste: virtualização só paga seu custo em lista grande.
- **`<table>` cru nas tabs** (não `<Table>` shadcn): o wrapper interno do shadcn tem `overflow-auto` próprio e roubaria o scroll do virtualizador. Classes copiadas 1:1 do `ui/table`.
- **Relógio do AdminReposicaoPedidos continua vivo** (data, indicador de ciclo e frescor do estoque atualizam por minuto como antes) — só que agora re-renderizam 3 componentes minúsculos, não a página.
- **UX que mudou de propósito**: tabelas CR/CP têm scroll interno com header fixo (padrão fintech/Retool) em vez de crescer com a página.

## Validação (money-path tocado — gate completo)

- `typecheck` strict ✅ · **suíte completa 4.362/4.362** ✅ · lint: **0 warnings nos 6 arquivos alterados**
- A 1ª rodada da suíte **pegou 4 falhas reais** nas tabs (virtualização × jsdom) → corrigidas com o limiar; re-run completo verde (`--maxWorkers=2` após um SIGKILL por pressão de RAM na M2)
- Nenhuma migration/RPC/trigger/RLS tocada — mudanças 100% de UI de leitura (`prove-sql-money-path` não se aplica)

## Fica para a Onda 3 (data layer)

Projeções nos 7 piores `select('*')` · waterfall/N+1 em `useExcecoesGestor` · `.limit()` em `useRoutePlanner` · optimistic update no recebimento · índice local no ScanBar · decisão do founder sobre `skipWaiting` do PWA (recomendação Codex pendente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
