### PR TITLE
fix(offline): revalida queries após o flush da fila drenar (dívida P1-c)

### DIFF
--- a/src/hooks/__tests__/offline-flow-integration.test.tsx
+++ b/src/hooks/__tests__/offline-flow-integration.test.tsx
@@ -4,8 +4,10 @@
  * + confirmPickItem. Só o cliente Supabase é mockado. Substitui (deterministicamente)
  * a parte do QA de browser que fica atrás de auth/seed de dados.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
+import type { ReactNode } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
 vi.mock('@/integrations/supabase/client', () => ({ supabase: { rpc: vi.fn() } }));
@@ -17,6 +19,13 @@ import { useOfflineFlush, __clearHandlersForTest } from '@/hooks/useOfflineFlush
 import type { ConfirmPickItemVars } from '@/services/picking-confirm';
 
 const mockedRpc = vi.mocked((supabase as unknown as { rpc: ReturnType<typeof vi.fn> }).rpc);
+
+// useOfflineFlush usa useQueryClient() → provider + spy pra checar a revalidação pós-flush.
+let queryClient: QueryClient;
+let invalidateSpy: MockInstance;
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
 
 const vars: ConfirmPickItemVars = {
   eventId: 'evt-int-1',
@@ -35,6 +44,8 @@ beforeEach(() => {
   localStorage.clear();
   __clearHandlersForTest();
   mockedRpc.mockReset();
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
   Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
 });
 
@@ -50,13 +61,20 @@ describe('ciclo offline→reconnect do picking', () => {
     expect(await getOfflineQueueDepth()).toBe(1);
 
     // 3. Reconecta: montar useOfflineFlush dispara o flush (fila não-vazia + online).
-    renderHook(() => useOfflineFlush());
+    renderHook(() => useOfflineFlush(), { wrapper });
 
     // 4. O handler processa via confirmPickItem (RPC atômica) e a fila zera.
     await waitFor(async () => expect(await getOfflineQueueDepth()).toBe(0));
     expect(mockedRpc).toHaveBeenCalledWith('confirmar_item_picking', expect.objectContaining({
       p_event_id: 'evt-int-1', p_item_id: 'item-int-1', p_quantidade_separada: 6,
     }));
+
+    // 5. P1-c: após drenar, as queries do picking são revalidadas (senão o que foi
+    // confirmado offline só apareceria no próximo refetch natural).
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['touch-pk-items'] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['touch-pk-tasks'] });
+    });
   });
 
   it('handler que falha mantém na fila SEM loop infinito (guard de re-entrância)', async () => {
@@ -66,7 +84,7 @@ describe('ciclo offline→reconnect do picking', () => {
     registerAllOfflineHandlers();
     await enqueue('picking.confirm-item', vars);
 
-    renderHook(() => useOfflineFlush());
+    renderHook(() => useOfflineFlush(), { wrapper });
 
     // Dá tempo do flush rodar; a fila NÃO deve zerar (operação preservada).
     await new Promise((r) => setTimeout(r, 100));

--- a/src/hooks/__tests__/useOfflineFlush.test.tsx
+++ b/src/hooks/__tests__/useOfflineFlush.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
 import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const mockFlushImpl = vi.fn();
 const mockSubscribe = vi.fn();
@@ -10,6 +12,12 @@ vi.mock('@/lib/offline-queue', () => ({
 }));
 
 import { useOfflineFlush, registerOfflineHandler, __clearHandlersForTest } from '../useOfflineFlush';
+
+// useOfflineFlush usa useQueryClient() → precisa do provider.
+const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+);
 
 beforeEach(() => {
   mockFlushImpl.mockReset();
@@ -22,14 +30,14 @@ beforeEach(() => {
 describe('useOfflineFlush', () => {
   it('registers online event listener on mount', () => {
     const addSpy = vi.spyOn(window, 'addEventListener');
-    renderHook(() => useOfflineFlush());
+    renderHook(() => useOfflineFlush(), { wrapper });
     expect(addSpy).toHaveBeenCalledWith('online', expect.any(Function));
     addSpy.mockRestore();
   });
 
   it('calls flush when online event fires', async () => {
     mockFlushImpl.mockResolvedValue({ success: 2, failed: 0 });
-    renderHook(() => useOfflineFlush());
+    renderHook(() => useOfflineFlush(), { wrapper });
 
     await act(async () => {
       window.dispatchEvent(new Event('online'));
@@ -48,7 +56,7 @@ describe('useOfflineFlush', () => {
       return { success: ok ? 1 : 0, failed: ok ? 0 : 1 };
     });
 
-    renderHook(() => useOfflineFlush());
+    renderHook(() => useOfflineFlush(), { wrapper });
 
     await act(async () => {
       window.dispatchEvent(new Event('online'));
@@ -63,7 +71,7 @@ describe('useOfflineFlush', () => {
       return { success: ok ? 1 : 0, failed: ok ? 0 : 1 };
     });
 
-    renderHook(() => useOfflineFlush());
+    renderHook(() => useOfflineFlush(), { wrapper });
 
     await act(async () => {
       window.dispatchEvent(new Event('online'));

--- a/src/hooks/useOfflineFlush.ts
+++ b/src/hooks/useOfflineFlush.ts
@@ -1,11 +1,18 @@
 import { useEffect } from 'react';
+import { useQueryClient, type QueryKey } from '@tanstack/react-query';
 import { flush, subscribeToOfflineQueue, type QueuedMutation } from '@/lib/offline-queue';
 import { logger } from '@/lib/logger';
 
 type Handler = (variables: unknown) => Promise<boolean>;
 
+interface HandlerEntry {
+  handler: Handler;
+  /** Query keys (prefixos) a invalidar quando um item deste kind drena com sucesso. */
+  invalidateKeys?: readonly QueryKey[];
+}
+
 /** Registry global de handlers por kind. */
-const handlers = new Map<string, Handler>();
+const handlers = new Map<string, HandlerEntry>();
 
 /**
  * Registra um handler que processará mutations enfileiradas de um determinado kind.
@@ -15,12 +22,18 @@ const handlers = new Map<string, Handler>();
  *  - true: mutação aplicou; item é removido da fila
  *  - false: mutação ainda falha; item fica na fila com attempts++
  *  - throw: idem
+ *
+ * `invalidateKeys`: quando o flush drena um item deste kind com sucesso, estas
+ * query keys são invalidadas — sem isso, o cache do React Query fica com o estado
+ * pré-sync (unidade conferida offline "some" até um refetch natural). Prefixo:
+ * ['nfe_conferencia'] casa ['nfe_conferencia', id].
  */
 export function registerOfflineHandler<TVars>(
   kind: string,
   handler: (variables: TVars) => Promise<boolean>,
+  invalidateKeys?: readonly QueryKey[],
 ): () => void {
-  handlers.set(kind, handler as Handler);
+  handlers.set(kind, { handler: handler as Handler, invalidateKeys });
   return () => handlers.delete(kind);
 }
 
@@ -30,24 +43,8 @@ export function registerOfflineHandler<TVars>(
  * Kinds sem handler registrado ficam na fila (não-destrutivo).
  */
 export function useOfflineFlush(): void {
+  const queryClient = useQueryClient();
   useEffect(() => {
-    const dispatcher = async (m: QueuedMutation): Promise<boolean> => {
-      const h = handlers.get(m.kind);
-      if (!h) {
-        logger.warn('Offline flush: nenhum handler para kind', { kind: m.kind });
-        return false;
-      }
-      try {
-        return await h(m.variables);
-      } catch (e) {
-        logger.warn('Offline flush: handler throw', {
-          kind: m.kind,
-          error: e instanceof Error ? e.message : String(e),
-        });
-        return false;
-      }
-    };
-
     // Guard de re-entrância: flush() chama writeQueue(), que re-emite pra fila.
     // Sem isso, um item que FALHA persistentemente (ex. RLS) fica na fila → o re-emit
     // re-dispara o flush → loop infinito martelando o backend. O guard garante que o
@@ -56,8 +53,37 @@ export function useOfflineFlush(): void {
     const runFlush = async () => {
       if (flushing) return;
       flushing = true;
+      // Kinds que drenaram nesta rodada → suas query keys são revalidadas ao fim,
+      // pra UI refletir a verdade do servidor após a fila esvaziar.
+      const succeededKinds = new Set<string>();
+      const dispatcher = async (m: QueuedMutation): Promise<boolean> => {
+        const entry = handlers.get(m.kind);
+        if (!entry) {
+          logger.warn('Offline flush: nenhum handler para kind', { kind: m.kind });
+          return false;
+        }
+        try {
+          const ok = await entry.handler(m.variables);
+          if (ok) succeededKinds.add(m.kind);
+          return ok;
+        } catch (e) {
+          logger.warn('Offline flush: handler throw', {
+            kind: m.kind,
+            error: e instanceof Error ? e.message : String(e),
+          });
+          return false;
+        }
+      };
       try {
         await flush(dispatcher);
+        // Revalidação pós-flush (non-blocking): reconcilia o cache com o servidor
+        // pros kinds que efetivamente drenaram. Sem isto, o que foi confirmado
+        // offline só aparecia no próximo refetch natural (dívida corrigida).
+        for (const kind of succeededKinds) {
+          for (const key of handlers.get(kind)?.invalidateKeys ?? []) {
+            void queryClient.invalidateQueries({ queryKey: key });
+          }
+        }
       } finally {
         flushing = false;
       }
@@ -80,7 +106,7 @@ export function useOfflineFlush(): void {
       window.removeEventListener('online', onOnline);
       unsub();
     };
-  }, []);
+  }, [queryClient]);
 }
 
 /** Helper de teste — não exportar via barrel. */

--- a/src/lib/offline-handlers.ts
+++ b/src/lib/offline-handlers.ts
@@ -15,23 +15,26 @@ import { confirmPickItem, type ConfirmPickItemVars } from '@/services/picking-co
  * Retorna uma cleanup que desregistra todos.
  */
 export function registerAllOfflineHandlers(): () => void {
+  // O 3º arg (invalidateKeys) é revalidado quando o item drena no flush pós-reconnect
+  // — assim o que foi confirmado offline aparece na UI sem esperar refetch natural.
+  // Keys por prefixo (casam ['nfe_conferencia', id] etc.).
   const unsubs = [
     registerOfflineHandler<ConfirmUnitVars>('recebimento.confirm-unit', async (v) => {
       await confirmUnit(v);
       return true;
-    }),
+    }, [['nfe_conferencia'], ['nfe_lotes']]),
     registerOfflineHandler<ReportDivergenciaVars>('recebimento.report-divergencia', async (v) => {
       await reportDivergencia(v);
       return true;
-    }),
+    }, [['nfe_conferencia']]),
     registerOfflineHandler<AddCteVars>('recebimento.add-cte', async (v) => {
       await addCte(v);
       return true;
-    }),
+    }, [['nfe_conferencia']]),
     registerOfflineHandler<ConfirmPickItemVars>('picking.confirm-item', async (v) => {
       await confirmPickItem(v);
       return true;
-    }),
+    }, [['touch-pk-items'], ['touch-pk-tasks']]),
   ];
   return () => unsubs.forEach((u) => u());
 }


### PR DESCRIPTION
## Contexto

Fecha a dívida **P1-c** que o Codex flagou (como pré-existente) na revisão da [Onda 3 (#1167)](https://github.com/LucasSardenbergL/afiacao/pull/1167).

## Problema

Ao reconectar, o `useOfflineFlush` drena a fila offline chamando os handlers (`confirmUnit`, `confirmPickItem`, …) — que persistem no servidor e retornam `true`. Mas **nada invalidava as queries do React Query**. Resultado: o que o conferente/separador confirmou offline só reaparecia no próximo refetch natural. Na prática, uma unidade confirmada offline "sumia" da tela até remontar a página.

## Correção

- `registerOfflineHandler` ganha um 3º argumento opcional `invalidateKeys` — prefixos de query key a revalidar quando um item daquele kind drena com sucesso.
- `useOfflineFlush` passa a usar `useQueryClient()`: rastreia os kinds que drenaram na rodada de flush e invalida suas keys ao final (non-blocking).
- `offline-handlers` registra as keys por kind:

| kind | keys revalidadas |
|---|---|
| `recebimento.confirm-unit` | `['nfe_conferencia']`, `['nfe_lotes']` |
| `recebimento.report-divergencia` / `add-cte` | `['nfe_conferencia']` |
| `picking.confirm-item` | `['touch-pk-items']`, `['touch-pk-tasks']` |

## Testes

- Os 2 testes de offline agora envolvem o hook em `QueryClientProvider` (ele passou a usar `useQueryClient()`).
- **Asserção nova** no ciclo `offline→reconnect` do picking: prova que `touch-pk-items`/`touch-pk-tasks` são invalidadas após o drain.
- Suíte completa **4.381/4.381** ✅ · typecheck strict ✅.

Sem migration/RPC/RLS — só wiring de client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
