### PR TITLE
perf(pwa): registerType prompt — fim do reload-surpresa no turno do operador (Onda 4)

### DIFF
--- a/src/lib/pwa-update.ts
+++ b/src/lib/pwa-update.ts
@@ -1,0 +1,60 @@
+import { registerSW } from 'virtual:pwa-register';
+import { toast } from 'sonner';
+
+/**
+ * Registra o service worker em modo PROMPT: quando uma nova versão instala e
+ * fica em *waiting*, mostra um toast pro operador ATUALIZAR quando ele quiser —
+ * em vez do reload-surpresa do antigo `registerType: 'autoUpdate'` + skipWaiting,
+ * que recarregava o app no meio do turno e matava o estado local do formulário
+ * (a fila offline sobrevive no localStorage; o lote meio-digitado, não).
+ *
+ * Chamado SÓ em produção non-preview (main.tsx, guard `__PWA_ENABLED__`): em dev
+ * e no preview Lovable o plugin PWA não é incluído, então `virtual:pwa-register`
+ * nem existe — o import dinâmico guardado é removido pelo DCE do Vite.
+ *
+ * Reload é seguro pra fila: as mutações pendentes ficam no localStorage e o
+ * useOfflineFlush drena de novo ao remontar (confirmUnit/picking são idempotentes).
+ * Por isso NÃO gateamos por fila pendente (gatear arriscaria "fila travada nunca
+ * atualiza"); só exigimos estar ONLINE, senão o reload só re-serviria o cache velho.
+ */
+/** id fixo → o Sonner deduplica: reabrir NÃO empilha, apenas atualiza o mesmo toast. */
+const UPDATE_TOAST_ID = 'pwa-update-available';
+
+export function setupPwaUpdatePrompt(): void {
+  // Fica true enquanto houver um SW novo em waiting. NÃO usamos um latch
+  // "shown" (que travaria o reaparecimento se o operador dispensasse o toast):
+  // o id fixo evita empilhar, e o listener de 'online' reabre se ainda pendente.
+  let needsUpdate = false;
+
+  // registerSW roda ANTES de showPrompt no texto, mas onNeedRefresh só é chamado
+  // depois (nunca no install) — por isso showPrompt é `function` (hoisted): quebra
+  // o ciclo sem precisar de `let updateSW` (que o prefer-const rejeitaria).
+  const updateSW = registerSW({
+    onNeedRefresh() {
+      needsUpdate = true;
+      showPrompt();
+    },
+  });
+
+  function showPrompt() {
+    // Offline: reabre no evento 'online' (reload agora só re-serviria cache velho).
+    if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+    toast('Nova versão disponível', {
+      id: UPDATE_TOAST_ID,
+      description: 'Atualize quando terminar a tarefa atual.',
+      duration: Infinity,
+      action: {
+        label: 'Atualizar',
+        onClick: () => {
+          void updateSW(true); // posta SKIP_WAITING e recarrega
+        },
+      },
+    });
+  }
+
+  if (typeof window !== 'undefined') {
+    window.addEventListener('online', () => {
+      if (needsUpdate) showPrompt();
+    });
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,10 @@ import "./index.css";
  *  da main nos bytes servidos → responde "o ar == origin/main?" sem adivinhar um ALVO. */
 declare const __COMMIT_SHA__: string;
 declare const __BUILD_ENV_KEYS__: string;
+/** Constante de build: true só no build de produção non-preview (onde o VitePWA
+ *  existe). Guarda o import de 'virtual:pwa-register' — quando false, o Vite DCE
+ *  remove o bloco e o módulo virtual (ausente em dev/preview) nunca é referenciado. */
+declare const __PWA_ENABLED__: boolean;
 
 declare global {
   interface Window {
@@ -68,6 +72,25 @@ window.addEventListener("vite:preloadError", () => {
 });
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+// PWA em modo prompt: registra o SW e arma o toast de "atualização disponível"
+// (substitui o injectRegister automático, agora `false`). Guardado por constante
+// de build — em dev/preview o bloco some no DCE e nada importa virtual:pwa-register.
+if (__PWA_ENABLED__) {
+  import("./lib/pwa-update")
+    .then((m) => m.setupPwaUpdatePrompt())
+    .catch(() => {
+      // Fallback offline-first: se o chunk do prompt falhar ao carregar (rede
+      // instável no boot, chunk 404 pós-deploy), registra o SW direto — sem o
+      // toast de update, mas o offline-first (não-negociável) é preservado.
+      // Perder o SW porque um import lazy falhou seria uma regressão pior.
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("/sw.js").catch(() => {
+          // best-effort: registro falhou de vez; não pode derrubar o app
+        });
+      }
+    });
+}
 
 // Sinaliza pro watchdog de boot (no index.html) que o bundle executou e o React
 // montou. Limpar as guardas de recuperação permite que o watchdog/preloadError

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 declare module '*.md?raw' {
   const content: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,11 @@ export default defineConfig(({ mode }) => ({
     __COMMIT_SHA__: JSON.stringify(commitSha),
     // PROBE temporário — remover quando a env de SHA do Lovable for identificada.
     __BUILD_ENV_KEYS__: JSON.stringify(buildEnvKeys),
+    // Casa EXATAMENTE a condição de inclusão do VitePWA abaixo. main.tsx só
+    // importa 'virtual:pwa-register' (via @/lib/pwa-update) quando true — em dev
+    // e no preview Lovable o plugin não existe, então o módulo virtual não
+    // resolve; sendo constante de build, o Vite DCE remove o import quando false.
+    __PWA_ENABLED__: JSON.stringify(mode === "production" && !isLovablePreview),
   },
   server: {
     host: "::",
@@ -64,8 +69,15 @@ export default defineConfig(({ mode }) => ({
     react(),
     mode === "development" && componentTagger(),
     mode === "production" && !isLovablePreview && VitePWA({
-      registerType: "autoUpdate",
-      injectRegister: "script-defer",
+      // 'prompt' (não 'autoUpdate'): o SW novo INSTALA mas ESPERA — quem decide
+      // recarregar é o operador, via PwaUpdatePrompt (toast "Atualizar"). Com
+      // autoUpdate + skipWaiting, um deploy no meio do turno recarregava o app
+      // embaixo do conferente e matava o estado local do formulário (a fila
+      // offline sobrevive no localStorage, mas o lote meio-digitado não).
+      registerType: "prompt",
+      // false: registramos o SW nós mesmos via useRegisterSW() (virtual:pwa-register)
+      // no PwaUpdatePrompt — sem isto o script auto-injetado registraria em dobro.
+      injectRegister: false,
       includeAssets: ["favicon.ico", "robots.txt"],
       manifest: {
         name: "Colacor",
@@ -128,7 +140,15 @@ export default defineConfig(({ mode }) => ({
         // importScripts passa pelo HTTP cache (updateViaCache default 'imports')
         // e um max-age na hospedagem serviria bytes velhos do handler.
         importScripts: ["push-sw.js"],
-        skipWaiting: true,
+        // skipWaiting REMOVIDO (era true): com registerType 'prompt' o SW novo precisa
+        // FICAR em waiting até o operador confirmar (updateServiceWorker() posta o
+        // SKIP_WAITING no clique). skipWaiting:true pularia a espera e recriaria o
+        // reload-surpresa que estamos evitando.
+        // clientsClaim MANTIDO: NÃO causa reload-surpresa (só o skipWaiting causava);
+        // ele faz o SW já-ativado assumir o controle da aba atual. Sem ele, na 1ª
+        // instalação (operador sem SW ainda) a aba fica SEM controle até o próximo
+        // reload → se a rede cair na mesma sessão, offline-first não funciona no
+        // primeiro acesso. Na atualização, o claim só ocorre após o operador aceitar.
         clientsClaim: true,
         cleanupOutdatedCaches: true,
         navigateFallbackDenylist: [/^\/~oauth/, /^\/__/],


### PR DESCRIPTION
## Contexto

**Onda 4** da auditoria de performance — a pendência de UX/operacional que ficou das ondas anteriores. Recomendação original do Codex (Onda 1).

## Problema

O PWA usava `registerType: 'autoUpdate'` + `skipWaiting: true`. Um deploy no meio do turno ativava o Service Worker novo e **recarregava o app embaixo do conferente**. A fila offline sobrevive (localStorage), mas o formulário meio-preenchido (lote sendo digitado, sheet aberta) morria no reload-surpresa.

## Solução — modo prompt

O SW novo **instala mas espera**; o operador clica "Atualizar" quando termina a tarefa.

| Mudança | Porquê |
|---|---|
| `registerType: 'prompt'` | SW novo fica em `waiting` até confirmação |
| `injectRegister: false` | registramos via `virtual:pwa-register` (senão registro em dobro) |
| `skipWaiting: true` **removido** | era isto que forçava a ativação/reload no meio do turno |
| `clientsClaim: true` **mantido** | offline-first no 1º acesso — sem ele a aba não fica controlada até um reload (não causa reload-surpresa; só o skipWaiting causava) |
| `define __PWA_ENABLED__` | casa a condição de inclusão do plugin (`production && !preview`) |
| `src/lib/pwa-update.ts` (novo) | `registerSW({onNeedRefresh})` → toast persistente "Atualizar" → `updateSW(true)` |
| `main.tsx` | import dinâmico guardado por `__PWA_ENABLED__` (DCE em dev/preview) + **fallback** `serviceWorker.register('/sw.js')` no catch |

### Decisões

- **Não gateia por fila offline pendente**: reload é seguro pra fila (localStorage + flush idempotente). Gatear arriscaria "fila travada nunca atualiza". Só exige estar **online** (offline, o toast reabre no evento `online`).
- **Fallback de registro**: se o chunk lazy do prompt falhar, o SW ainda registra direto — offline-first (não-negociável) não pode depender de um import dinâmico resolver.
- **`__PWA_ENABLED__` (build const)**: o plugin PWA só existe em build de produção non-preview, então `virtual:pwa-register` não resolve em dev/preview; o guard garante que o Vite DCE remova o import lá.

## Verificação de deploy — INTACTA

Confirmei que `verify-frontend.sh` usa `curl` direto no host (sem service worker) → mede os **bytes do servidor**, não de um cliente. Então prompt mode **não** cega a checagem de deploy por SHA (a preocupação do Codex na Onda 1 não se aplica — o cron não é um browser).

## Prova de build

`dist/sw.js` gerado com `skipWaiting` **só dentro do listener de `message`** (não no `install`) + `clientsClaim` presente → o SW espera na atualização e controla a aba no 1º acesso. `dist/index.html` sem auto-register (injectRegister false). Chunk `pwa-update-*.js` gerado (virtual module resolveu em prod). typecheck ✅ · suíte **4.381/4.381** ✅.

## Revisão Codex

1ª review achou **2 P1** (removi `clientsClaim` por engano → quebrava offline-first no 1º acesso; registro do SW sem fallback) + 1 P2 (latch do toast). Corrigidos → **re-review: SEGURO PRA MERGE**, nenhum P1 novo.

⚠️ **Nota de deploy**: mudança em `vite.config.ts`/SW → após merge, o founder precisa dar **Publish do frontend** no Lovable (como toda mudança de frontend). O novo comportamento de update só vale a partir do build publicado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
