### PR TITLE
docs(sync): ponteiro pra dívida do baseline de crons stale (#1178)

### DIFF
--- a/docs/agent/sync.md
+++ b/docs/agent/sync.md
@@ -12,6 +12,7 @@
 - `cron.schedule(nome, schedule, comando)` faz **upsert por nome** → idempotente.
 - **Todo cron `net.http_post` PRECISA de `timeout_milliseconds` explícito** — o default do `pg_net` é **5s** e mata SILENCIOSAMENTE qualquer função >5s (o `job_run_details` ainda diz "succeeded"). Teto padrão da casa: **150000** (150s).
 - **Crons devem ser versionados em migration** — um cron que vive só no banco some sem rastro (já aconteceu: vendas ficou 8 dias morto porque o cron nunca foi versionado).
+- ⚠️ **O safety-net `20260527230000_cron_baseline.sql` está STALE** (46 statements no repo vs **75** crons ativos em prod, 2026-07-04) → regen pendente, com dono/gatilho/procedimento na **issue #1178**. NÃO editar os statements à mão: rodar o generator de prod (`string_agg` de `cron.job WHERE active`) + **PR SEPARADO que MERGEIA**. Re-aplicar troca o jobid → só sob demanda.
 
 ## Enumeração pesada do Omie (paginação)
 


### PR DESCRIPTION
## O quê
Ponteiro de 1 bullet em `docs/agent/sync.md` (seção *Padrão de cron*) apontando pra dívida do safety-net de crons: o baseline `20260527230000_cron_baseline.sql` tem **46** crons no repo vs **75** ativos em prod (verificado read-only 2026-07-04).

Dono, gatilho de execução e procedimento de regen ficam na issue #1178. **Este PR não executa o baseline** — só deixa o rastro durável pra próxima sessão de cron não perder a dívida entre as ~25 worktrees.

## Por que só ponteiro
Regenerar agora arriscaria versionar crons de PRs de infra ainda em voo (#947/#928) — decisão eu+/codex de adiar até as frentes de sync/cron fecharem (detalhe na #1178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)