### PR TITLE
fix(venda): trava de crédito — log durável + canária de deploy + anti-duplicação na edição [money-path]

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -114,3 +114,83 @@ describe('guardrail money-path: algorithm-a-audit (margem)', () => {
     expect(src).toContain("'order_items', 'product_id, unit_price, sales_order_id'");
   });
 });
+
+// ── Trava de crédito Fase 2: log de bloqueio DURÁVEL + canária de deploy ──
+// O gate mora no edge (Deno, fora do vitest/typecheck do src). Dois invariantes money-path que
+// o deploy do Lovable pode reverter em silêncio (e o CI `validate` reexpõe na main):
+//  1. (a) bloqueio sem log gravado vira ERRO, não {blocked} silencioso — a aprovação remota do
+//     gestor depende do último log do pedido; bloqueio sem rastro = gestor sem form.
+//  2. a canária `credito_gate_probe` existe, chama a RPC (prova de mordida) e é read-only (não
+//     cria PV nem toca o Omie) — é a prova do gate DEPLOYADO, mais forte que o commit de deploy.
+const VENDAS = 'supabase/functions/omie-vendas-sync/index.ts';
+
+describe('guardrail money-path: trava de crédito Fase 2 (gate + log durável + canária)', () => {
+  const src = read(VENDAS);
+
+  it('sentinela: leu o edge real e o gate/log existem', () => {
+    expect(src).toContain('gateCredito');
+    expect(src).toContain('venda_gate_credito');
+    expect(src).toContain('venda_bloqueio_credito_log');
+  });
+
+  it('(a) LOG DE BLOQUEIO DURÁVEL: falha do insert vira ERRO, não console.warn best-effort', () => {
+    expect(
+      src,
+      'REGRESSÃO: o log de bloqueado voltou a best-effort (console.warn) — bloqueio ficaria sem rastro',
+    ).not.toMatch(/log bloqueado falhou/);
+    expect(
+      src,
+      'sumiu o throw durável do log de bloqueio (aprovação remota do gestor perde a evidência)',
+    ).toMatch(/Bloqueio de crédito sem log durável/);
+  });
+
+  it('CANÁRIA de deploy: credito_gate_probe existe, expõe gate_no_ar e chama a RPC do gate', () => {
+    expect(
+      src,
+      'canária credito_gate_probe ausente/renomeada — sem prova do gate DEPLOYADO (só o commit, mais fraco)',
+    ).toContain('case "credito_gate_probe":');
+    expect(src, 'a probe deveria expor gate_no_ar (existência do gate no build deployado)').toContain('gate_no_ar');
+    expect(
+      src,
+      'a probe não chama mais a RPC venda_gate_credito — deixou de provar mordida',
+    ).toMatch(/case "credito_gate_probe":[\s\S]{0,700}venda_gate_credito/);
+  });
+
+  it('CANÁRIA read-only: a probe NÃO cria PV nem chama o Omie (dry-run seguro mesmo com gate fora do ar)', () => {
+    // bloco INTEIRO da action (até o próximo case) — a action tem 2 breaks (early-return + fim).
+    const m = src.match(/case "credito_gate_probe":[\s\S]*?\n {6}case /);
+    expect(m, 'bloco da action credito_gate_probe não encontrado').toBeTruthy();
+    const bloco = m![0];
+    expect(bloco, 'a probe NÃO pode criar PV (criarPedidoVenda) — deixaria de ser dry-run').not.toContain('criarPedidoVenda');
+    expect(bloco, 'a probe NÃO pode chamar o Omie (callOmieVendasApi) — deixaria de ser dry-run').not.toContain('callOmieVendasApi');
+    // [P2 Codex] codigo obrigatório: sem código a probe recusa (não dá gate_no_ar sozinho como prova).
+    expect(bloco, 'a probe deveria exigir `codigo` (senão falsa-tranquilidade)').toMatch(/requer `codigo`/);
+  });
+
+  it('gate é CHAMADO em criar_pedido E alterar_pedido (não só definido)', () => {
+    // 1 definição (async function gateCredito) + ≥2 chamadas (criação + edição).
+    expect(
+      count(src, 'await gateCredito('),
+      'gateCredito não é mais chamado nas 2 vias de pedido (criar + alterar) — gate furado',
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('(a) o throw durável está NO ramo do insert de "bloqueado" (não solto em outro lugar)', () => {
+    const m = src.match(/acao: contexto === "edicao"[\s\S]*?return \{ permitido: false/);
+    expect(m, 'ramo do log de bloqueado não encontrado').toBeTruthy();
+    expect(m![0], 'o throw durável saiu do ramo do insert de bloqueado').toMatch(/Bloqueio de crédito sem log durável/);
+  });
+
+  it('P1+P2 anti-duplicação: alterar_pedido aborta se consult falha, sem itens OU item sem id deletável', () => {
+    expect(
+      src,
+      'sumiu o guard anti-duplicação — edição com estado incerto voltaria a duplicar itens no Omie',
+    ).toMatch(/!consultEditOk \|\| omieCurrentItems\.length === 0 \|\| itemSemIdDeletavel/);
+    // [P2 Codex] item sem chave deletável (ide.codigo_item/codigo_item_integracao) → aborta antes do delete+add.
+    expect(
+      src,
+      'sumiu o guard de identificador deletável — item sem id seria pulado no delete e duplicado no add',
+    ).toMatch(/itemSemIdDeletavel = omieCurrentItems\.some/);
+    expect(src, 'o guard anti-duplicação perdeu o rótulo').toMatch(/anti-duplicação/);
+  });
+});

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1837,7 +1837,15 @@ async function gateCredito(
     titulos: gate.titulos,
     user_id: userId,
   });
-  if (logErr) console.warn(`[gate-credito] log bloqueado falhou: ${logErr.message}`);
+  if (logErr) {
+    // (a) Log de bloqueio DURÁVEL — simétrico ao ramo gate_indisponivel acima. A aprovação
+    // REMOTA do gestor (SalesOrderDetailSheet → useBloqueioCreditoLog) resolve o contexto do
+    // form pelo ÚLTIMO log do pedido; um bloqueio sem rastro deixaria o gestor SEM form
+    // (exceção às cegas não). Se nem o log grava = infra degradada → ERRO, nunca devolver
+    // {blocked:'credito'} silencioso e irrastreável. O caller (submitOrder) reexecuta — o
+    // gate é STABLE/idempotente e reprova o mesmo bloqueio (com log, na retentativa saudável).
+    throw new Error(`Bloqueio de crédito sem log durável (${logErr.message}) — tente novamente.`);
+  }
   return { permitido: false, gate };
 }
 
@@ -2345,61 +2353,84 @@ serve(async (req) => {
           console.warn(`[Omie Vendas][${editAccount}] Erro ao consultar pedido: ${msg}`);
         }
 
-        // Trava de crédito Fase 2 na EDIÇÃO — antes da fase destrutiva (delete de itens).
-        // Só bloqueia AUMENTO de exposição: total atual provado pelo ConsultarPedido do
-        // Omie (nunca client/DB local — veredito Codex); reduzir dívida sempre pode.
-        if (consultEditOk) {
-          const totalAtualOmie = omieCurrentItems.reduce(
-            (s, oi) =>
-              s + (Number(oi?.produto?.quantidade) || 0) * (Number(oi?.produto?.valor_unitario) || 0),
-            0,
-          );
-          if (updatedSubtotal > totalAtualOmie) {
-            if (omieCodigoClienteEdit === null) {
-              // P1 do review Codex: aumento PROVADO mas consult veio sem codigo_cliente —
-              // gate(null) responderia 'sem_codigo' e liberaria por AUSÊNCIA de dado.
-              // Mesmo contrato do consult-falhou: allow SÓ com log durável.
-              const { error: logErr } = await supabaseAdmin.from("venda_bloqueio_credito_log").insert({
-                company: editAccount,
-                omie_codigo_cliente: null,
-                sales_order_id: editSoId,
-                acao: "gate_indisponivel",
-                user_id: userId,
-                detalhe: "edicao: aumento provado, mas ConsultarPedido sem codigo_cliente — gate não avaliável",
-              });
-              if (logErr) {
-                throw new Error(
-                  `Gate de crédito sem cliente identificado na edição e sem log (${logErr.message}) — tente novamente.`,
-                );
-              }
-            } else {
-              const creditoEdit = await gateCredito(
-                supabaseAdmin,
-                editAccount,
-                omieCodigoClienteEdit,
-                editSoId,
-                userId,
-                "edicao",
-              );
-              if (!creditoEdit.permitido) {
-                result = { success: false, blocked: "credito", contexto: "edicao", gate: creditoEdit.gate };
-                break;
-              }
-            }
-          }
-        } else {
-          // Sem o consult não há como provar redução → fail-open OBSERVÁVEL: allow
-          // só com log durável (mesmo contrato do gate; log falhou → erro).
+        // Guard anti-duplicação [P1+P2 Codex 2026-07-04]: a edição é DESTRUTIVA — o Step 2 apaga
+        // TODOS os itens que o ConsultarPedido revelou e o Step 3 re-inclui a lista nova. Ela
+        // ASSUME que `omieCurrentItems` reflete o pedido real E que cada item é deletável. Três
+        // formas de o estado ser NÃO confiável, todas levando a DUPLICAÇÃO no Omie (dobra o valor
+        // faturado) se seguíssemos para o delete+add:
+        //   (1) consult FALHOU (rate-limit/transiente → catch acima): lista `[]`, o delete não acha
+        //       nada e os novos entram por cima dos antigos;
+        //   (2) consult voltou SEM itens (shape drift): idem — e um PV existente sempre tem ≥1
+        //       item, então lista vazia aqui já é sinal de estado não confiável;
+        //   (3) [P2 Codex] algum item atual SEM identificador deletável (ide.codigo_item /
+        //       codigo_item_integracao): o Step 2 o PULA em silêncio e o Step 3 inclui os novos →
+        //       duplicação PARCIAL (a validação final pegaria, mas só DEPOIS da mutação).
+        // Qualquer uma → ABORTAR antes de qualquer mutação. Fail-closed OBSERVÁVEL (log durável +
+        // erro; o transiente do Omie passa no reenvio). NÃO é o gate de crédito: é integridade da
+        // edição destrutiva (antes, o ramo `else` fazia fail-open e SEGUIA — a duplicação).
+        const itemSemIdDeletavel = omieCurrentItems.some(
+          (oi) => !oi?.ide?.codigo_item && !oi?.ide?.codigo_item_integracao,
+        );
+        if (!consultEditOk || omieCurrentItems.length === 0 || itemSemIdDeletavel) {
           const { error: logErr } = await supabaseAdmin.from("venda_bloqueio_credito_log").insert({
             company: editAccount,
-            omie_codigo_cliente: null,
+            omie_codigo_cliente: omieCodigoClienteEdit,
             sales_order_id: editSoId,
             acao: "gate_indisponivel",
             user_id: userId,
-            detalhe: "edicao: ConsultarPedido falhou — total atual não provado",
+            detalhe: !consultEditOk
+              ? "edicao: ConsultarPedido falhou — itens atuais desconhecidos, edição abortada (anti-duplicação)"
+              : omieCurrentItems.length === 0
+                ? "edicao: ConsultarPedido sem itens — estado do Omie não confiável, edição abortada (anti-duplicação)"
+                : "edicao: item atual sem identificador deletável — delete+add duplicaria, edição abortada (anti-duplicação)",
           });
           if (logErr) {
-            throw new Error(`Gate de crédito sem prova na edição e sem log (${logErr.message}) — tente novamente.`);
+            throw new Error(`Edição não aplicada e sem log durável (${logErr.message}) — tente novamente.`);
+          }
+          throw new Error(
+            "Edição não aplicada: não foi possível confirmar com segurança os itens atuais do pedido no Omie. Nada foi alterado — tente novamente.",
+          );
+        }
+
+        // Trava de crédito Fase 2 na EDIÇÃO — sobre estado CONFIÁVEL (consult ok + itens provados),
+        // antes da fase destrutiva. Só bloqueia AUMENTO de exposição: total atual provado pelo
+        // ConsultarPedido do Omie (nunca client/DB local — veredito Codex); reduzir dívida sempre pode.
+        const totalAtualOmie = omieCurrentItems.reduce(
+          (s, oi) =>
+            s + (Number(oi?.produto?.quantidade) || 0) * (Number(oi?.produto?.valor_unitario) || 0),
+          0,
+        );
+        if (updatedSubtotal > totalAtualOmie) {
+          if (omieCodigoClienteEdit === null) {
+            // Aumento PROVADO mas consult veio sem codigo_cliente — gate(null) responderia
+            // 'sem_codigo' e liberaria por AUSÊNCIA de dado. Fail-open do CRÉDITO (os itens já
+            // são confiáveis pelo guard acima; só o gate é pulado) — allow SÓ com log durável.
+            const { error: logErr } = await supabaseAdmin.from("venda_bloqueio_credito_log").insert({
+              company: editAccount,
+              omie_codigo_cliente: null,
+              sales_order_id: editSoId,
+              acao: "gate_indisponivel",
+              user_id: userId,
+              detalhe: "edicao: aumento provado, mas ConsultarPedido sem codigo_cliente — gate não avaliável",
+            });
+            if (logErr) {
+              throw new Error(
+                `Gate de crédito sem cliente identificado na edição e sem log (${logErr.message}) — tente novamente.`,
+              );
+            }
+          } else {
+            const creditoEdit = await gateCredito(
+              supabaseAdmin,
+              editAccount,
+              omieCodigoClienteEdit,
+              editSoId,
+              userId,
+              "edicao",
+            );
+            if (!creditoEdit.permitido) {
+              result = { success: false, blocked: "credito", contexto: "edicao", gate: creditoEdit.gate };
+              break;
+            }
           }
         }
 
@@ -2691,6 +2722,46 @@ serve(async (req) => {
           probe.push({ mes: w.mes, omie_aprox: Number(rp?.total_de_paginas ?? 0), tem_dado: lista.length > 0 });
         }
         result = { success: true, account, meses: probe.length, probe };
+        break;
+      }
+
+      case "credito_gate_probe": {
+        // CANÁRIA de deploy da trava de crédito Fase 2 — NÃO escreve, NÃO chama o Omie, NÃO
+        // cria PV. Prova, sobre o edge DEPLOYADO (não a `main`), duas coisas que o commit de
+        // deploy não prova: (1) esta action RESPONDE → o gate subiu no MESMO build (senão viria
+        // "ação desconhecida" = binário velho); (2) a RPC venda_gate_credito MORDE — para um par
+        // sabidamente bloqueável ela retorna bloqueado=true. A RPC é STABLE (100% read-only), o
+        // sales_order_id é sintético (sem exceção → bloqueia se o par é bloqueável). Gated por
+        // authorizeCronOrStaff como toda action.
+        // [P2 Codex] `codigo` é OBRIGATÓRIO: sem ele, um gate_no_ar:true sozinho daria falsa
+        // tranquilidade (só provaria que a action respondeu, não a MORDIDA). E a resposta expõe
+        // apenas {bloqueado, motivo} — NÃO vencido/títulos: a canária não precisa ser um oracle
+        // de saldo por código arbitrário.
+        const codigoProbe = Number(params.codigo) || null;
+        if (!codigoProbe) {
+          result = {
+            success: false,
+            gate_no_ar: true, // a action respondeu → o gate da Fase 2 está no build deployado
+            account,
+            erro: "credito_gate_probe requer `codigo` de um cliente sabidamente bloqueável (senão não prova a mordida)",
+          };
+          break;
+        }
+        const { data, error } = await supabaseAdmin.rpc("venda_gate_credito", {
+          p_company: account,
+          p_codigo: codigoProbe,
+          p_sales_order_id: crypto.randomUUID(),
+        });
+        if (error) throw new Error(`credito_gate_probe: RPC venda_gate_credito falhou: ${error.message}`);
+        const gp = data as { bloqueado?: boolean; motivo?: string } | null;
+        result = {
+          success: true,
+          gate_no_ar: true, // a action respondeu → o gate está no build deployado
+          account,
+          codigo: codigoProbe,
+          provado_morde: gp?.bloqueado === true, // true = a RPC bloqueou o par bloqueável (morde)
+          motivo: gp?.motivo ?? null,
+        };
         break;
       }
 


### PR DESCRIPTION
## Contexto

Item 6 do "back to basics" — os P2s da Fase 2 da **trava de crédito**. Antes de tocar código, **medi prod** (psql-ro): a trava está no ar mas **nunca disparou** — 0 bloqueios / 0 exceções, apesar de 510 pedidos/30d e 43 clientes bloqueáveis (idêntico à spec §0).

O Codex (`xhigh`) reordenou a prioridade: **PROVAR-DEPLOY-PRIMEIRO**. Adiar sem provar que o gate morde = usar um cliente inadimplente real como cobaia do deploy manual (Lovable = edge deploy manual). Isso é falta de smoke num controle financeiro, não YAGNI.

## O que muda (só o edge `omie-vendas-sync` + teste)

- **🎯 Canária `credito_gate_probe`** (dry-run, gated): chama a RPC `venda_gate_credito` com um par bloqueável → `{gate_no_ar, provado_morde}` **sem tocar o Omie / criar PV**. Prova sobre o edge DEPLOYADO que o gate subiu (a action responde) e morde. `codigo` obrigatório; payload reduzido a `{bloqueado, motivo}` (não é oracle de saldo).
- **🔒 (a) Log de bloqueio durável**: falha do INSERT vira **erro** (simétrico ao `gate_indisponivel`), nunca `{blocked}` silencioso — a aprovação remota do gestor depende do último log do pedido.
- **🔴 [P1+P2 Codex, pré-existente] anti-duplicação em `alterar_pedido`**: aborta antes do delete+add quando o `ConsultarPedido` falha, volta sem itens, OU traz item sem id deletável. Antes, o fail-open seguia para a mutação com lista vazia → **pedido duplicado no Omie** (dobra o faturado).
- **🧪 Teste de invariante** (CI `validate`): asserts textuais que pegam reversão do Lovable no deploy. Falsificação: sabotar guard/throw/canária → vermelho; restaurar → 18/18.

**Adiados com aval do Codex:** (b) UX pós-exceção na edição; (c) RPC "pedir aprovação" (gatilho de telemetria de atrito não satisfeito — 0 bloqueios).

## Gates
`deno check` ✓ · typecheck 0 erros ✓ · lint 0 errors ✓ · invariantes 18/18 + falsificação ✓ · suíte completa (4.3k) ✓

## Review Codex (xhigh)
Direção (challenge): **PROVAR-DEPLOY-PRIMEIRO**. Diff (2 rodadas): reprovou por P1 pré-existente → corrigido → **APROVADA-COM-RESSALVAS**; ressalva P2 (id deletável) aplicada e provada.

## ⚠️ Deploy pós-merge (Lei de Ferro: edge só depois do merge)
- [ ] **Deploy do edge `omie-vendas-sync`** via chat do Lovable, **verbatim** da main.
- [ ] Rodar a canária pós-deploy (código bloqueável de teste: colacor `4421340383`) → esperar `provado_morde: true`.
- **Sem migration, sem Publish** — o diff é só edge + teste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)