### PR TITLE
refactor(reposição): UM botão "Sincronizar e recalcular" (remove os 2 redundantes)

### DIFF
--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -19,7 +19,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
-import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Clock, CloudDownload, Eye, Loader2, RefreshCw, Zap } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Clock, CloudDownload, Eye, Loader2, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -108,7 +108,7 @@ export default function AdminReposicaoPedidos() {
     return () => clearInterval(t);
   }, []);
 
-  const { data: pedidos, isLoading, refetch } = useQuery({
+  const { data: pedidos, isLoading } = useQuery({
     queryKey: ['pedidos-ciclo', dataHoje],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -243,28 +243,11 @@ export default function AdminReposicaoPedidos() {
     }
   };
 
-  // [GATE estoque-não-confirmado] preflight: quantos SKUs ainda estão com estoque do cold-start (fonte_sync=
-  // 'cold_start_seed', não confirmado pelo ListarPosEstoque). A geração vai PULÁ-los (o motor não compra com
-  // estoque seed) — avisa antes do Recalcular p/ o operador rodar o sync se quiser incluí-los. Aproximação
-  // barata (não cruza inventory_position); o gate real (precisão) está na RPC.
-  const { data: naoConfirmadosCount = 0 } = useQuery({
-    queryKey: ['estoque-nao-confirmado', EMPRESA],
-    queryFn: async () => {
-      const { count, error } = await supabase
-        .from('sku_estoque_atual')
-        .select('*', { count: 'exact', head: true })
-        .eq('empresa', EMPRESA)
-        .eq('fonte_sync', 'cold_start_seed');
-      if (error) throw error;
-      return count ?? 0;
-    },
-  });
-
   // [GATE estoque-não-confirmado] fila de exceção PÓS-geração: o que o motor EFETIVAMENTE suprimiu, gravado em
   // reposicao_estoque_nao_confirmado_log pela RPC. O preflight acima é preditivo (antes do Recalcular); esta é a
   // verdade do último ciclo — sem ela o gate suprime no escuro e vira subcompra invisível (Codex consult 019f0a38).
   // count exato p/ o total 24h (honesto mesmo com a lista capada em 500); a lista cobre folgado 1 run (OBEN ~64).
-  // Key sob 'pedidos-ciclo' de propósito: gerarMutation invalida ['pedidos-ciclo'] → re-busca após Recalcular.
+  // Key sob 'pedidos-ciclo' de propósito: syncRecalcMutation invalida ['pedidos-ciclo'] → re-busca após recalcular.
   const { data: suprimidos } = useQuery({
     queryKey: ['pedidos-ciclo', 'estoque-nao-confirmado-log', EMPRESA],
     queryFn: async () => {
@@ -281,25 +264,6 @@ export default function AdminReposicaoPedidos() {
     },
     refetchInterval: 60_000,
     staleTime: 30_000,
-  });
-
-  const gerarMutation = useMutation({
-    mutationFn: async () => {
-      const { data, error } = await supabase.rpc('gerar_pedidos_sugeridos_ciclo', {
-        p_empresa: EMPRESA,
-        p_data_ciclo: dataHoje,
-      });
-      if (error) throw error;
-      return data;
-    },
-    onSuccess: (data) => {
-      const r = Array.isArray(data) ? data[0] : data;
-      toast.success(`${r?.pedidos_gerados ?? 0} pedidos gerados — ${r?.bloqueados ?? 0} bloqueados`);
-      queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
-    },
-    onError: (e: Error) => {
-      toast.error(`Erro ao gerar: ${e.message}`);
-    },
   });
 
   // Frescor do snapshot que o Recalcular usa (max ultima_sincronizacao da empresa).
@@ -320,12 +284,12 @@ export default function AdminReposicaoPedidos() {
     refetchInterval: 60_000,
   });
 
-  // Botão "Sincronizar e recalcular": SALDO (omie-sync-estoque) + STATUS ativo/inativo
-  // (omie-sync-status-produtos) em paralelo e, SÓ SE ambas deram certo, recalcula o ciclo (a MESMA
-  // RPC do "Recalcular sugestões"). Antes o botão só puxava saldo e não recalculava — o founder
-  // tinha de sincronizar numa tela, recalcular noutra. Se uma sync falhar, NÃO recalcula (regenerar
-  // com saldo/status velho geraria pedido errado = money-path); o resumoSyncRecalc reporta e o
-  // usuário reexecuta ou usa "Recalcular sugestões" à parte. Idempotente. ~1–2 min.
+  // ÚNICO botão de ação da tela — "Sincronizar e recalcular": SALDO (omie-sync-estoque) + STATUS
+  // ativo/inativo (omie-sync-status-produtos) em paralelo e, SÓ SE ambas deram certo, recalcula o
+  // ciclo (RPC gerar_pedidos_sugeridos_ciclo). Consolidou os 3 botões antigos (sincronizar / atualizar
+  // lista / recalcular) num só, a pedido do founder — a lista tem refetchInterval 30s (atualiza
+  // sozinha). Se uma sync falhar, NÃO recalcula (regenerar com saldo/status velho = pedido errado,
+  // money-path); o resumoSyncRecalc reporta e o usuário reexecuta. Idempotente. ~1–2 min.
   const syncRecalcMutation = useMutation({
     mutationFn: async () => {
       const [estoque, status] = await Promise.allSettled([
@@ -523,42 +487,6 @@ export default function AdminReposicaoPedidos() {
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
-          <Button variant="outline" onClick={() => refetch()} disabled={isLoading}>
-            <RefreshCw className={`w-4 h-4 mr-1 ${isLoading ? 'animate-spin' : ''}`} />Atualizar lista
-          </Button>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="outline" disabled={gerarMutation.isPending}>
-                {gerarMutation.isPending && <Loader2 className="w-4 h-4 mr-1 animate-spin" />}
-                Recalcular sugestões
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Recalcular sugestões de hoje?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  Recalcula as sugestões de compra a partir do estoque atual. Não altera pedidos
-                  já aprovados, disparados ou cancelados. O sistema já faz isso sozinho 1×/dia —
-                  use só se você mudou um parâmetro (ponto de pedido, mínimo forçado etc.).
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              {naoConfirmadosCount > 0 && (
-                <Alert className="border-status-warning/40 bg-status-warning/5">
-                  <AlertTriangle className="h-4 w-4 text-status-warning" />
-                  <AlertTitle className="text-status-warning">Estoque não confirmado pelo sync</AlertTitle>
-                  <AlertDescription>
-                    {naoConfirmadosCount} SKU(s) ainda com estoque do cold-start (catálogo), não confirmado pelo
-                    ListarPosEstoque. A geração vai <strong>pulá-los</strong> (não compra com estoque não confirmado)
-                    e registrá-los. Rode o sync de estoque do Omie antes, se quiser incluí-los neste ciclo.
-                  </AlertDescription>
-                </Alert>
-              )}
-              <AlertDialogFooter>
-                <AlertDialogCancel>Voltar</AlertDialogCancel>
-                <AlertDialogAction onClick={() => gerarMutation.mutate()}>Recalcular</AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
         </div>
       </div>
 
@@ -618,7 +546,7 @@ export default function AdminReposicaoPedidos() {
               </p>
             )}
             <p className="mb-2 text-sm">
-              <strong>O que fazer:</strong> rode o sync de estoque do Omie e clique em <em>Recalcular sugestões</em>. Os
+              <strong>O que fazer:</strong> clique em <em>Sincronizar e recalcular</em> (puxa o estoque do Omie e regenera). Os
               que tiverem saldo real entram no ciclo; os genuinamente zerados voltam a comprar sozinhos assim que o
               sync confirmar.
             </p>
@@ -751,7 +679,7 @@ export default function AdminReposicaoPedidos() {
                 <div className="text-center py-12 text-muted-foreground">
                   {historico.length > 0
                     ? 'Nenhum pedido ativo hoje — veja o Histórico de hoje abaixo.'
-                    : 'Nenhum pedido gerado para o ciclo de hoje. Use "Recalcular sugestões" para criar.'}
+                    : 'Nenhum pedido gerado para o ciclo de hoje. Use "Sincronizar e recalcular" para criar.'}
                 </div>
               ) : (
                 <Table>


### PR DESCRIPTION
## O quê / por quê
A pedido do founder: **um botão só** com as 3 funcionalidades. O "Sincronizar e recalcular" já faz as 3 — puxa saldo+status do Omie, recalcula, e atualiza a lista (invalidate + `refetchInterval: 30s`). Eu tinha deixado os outros 2 do lado, poluindo a tela.

## Mudança
- **Removidos** os botões **"Atualizar lista"** (refetch puro — a query já auto-atualiza a cada 30s) e **"Recalcular sugestões"** (contido no fundido).
- Limpa a `gerarMutation` e a query `naoConfirmadosCount` que ficaram órfãs.
- O aviso de estoque não-confirmado segue vindo da **fila de exceção pós-recálculo** (mais precisa que o preflight que saiu).
- Sobra **1 botão de ação** na tela + o indicador "precisam de atenção" + o badge de frescor.

## Verificação
typecheck · lint · (só `AdminReposicaoPedidos.tsx`, +11/-83).

## ⚠️ Deploy Lovable
Só **Publish** (frontend). Sem edge, sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)