### PR TITLE
feat(reposição): horário exato da sincronização no badge de estoque

### DIFF
--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -71,12 +71,16 @@ function FrescorEstoqueLive({ ultimaSync }: { ultimaSync: string | null | undefi
   const now = useNowMinuto();
   const frescor = frescorEstoque(ultimaSync, now);
   const cor = { ok: 'text-muted-foreground', warning: 'text-status-warning', error: 'text-status-error' }[frescor.tone];
+  // Horário exato VISÍVEL no texto (dd/MM HH:mm) + segundos no tooltip — o "há X" arredonda e
+  // deixava o founder na dúvida do minuto certo.
+  const d = ultimaSync ? new Date(ultimaSync) : null;
+  const quando = d && !Number.isNaN(d.getTime()) ? format(d, 'dd/MM HH:mm', { locale: ptBR }) : null;
   return (
     <span
       className={`inline-flex items-center gap-1 text-xs ${cor}`}
-      title={ultimaSync ? `Último sync: ${format(new Date(ultimaSync), "dd/MM 'às' HH:mm", { locale: ptBR })}` : undefined}
+      title={d && quando ? `Sincronizado ${format(d, "dd/MM 'às' HH:mm:ss", { locale: ptBR })}` : undefined}
     >
-      <Clock className="w-3.5 h-3.5" /> Estoque Omie: {frescor.label}
+      <Clock className="w-3.5 h-3.5" /> Estoque Omie: {frescor.label}{quando ? ` · ${quando}` : ''}
     </span>
   );
 }


### PR DESCRIPTION
## Por quê
O badge "Estoque Omie: sincronizado **há menos de 1h**" arredonda, e o founder ficava na dúvida do minuto exato.

## Mudança
- Horário exato agora **visível no texto**: "Estoque Omie: sincronizado há menos de 1h · **05/07 15:56**".
- Tooltip (hover) ganha os **segundos**: "Sincronizado 05/07 às 15:56:07". *(O tooltip básico já existia; agora o horário está visível sem precisar passar o mouse.)*
- Trata data ausente/inválida (sem horário nesses casos).

## Verificação
typecheck · lint · 1 arquivo (`AdminReposicaoPedidos.tsx`, +6/-2). Sem migration.

## ⚠️ Deploy Lovable
Só **Publish** (frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)