### PR TITLE
F5 — Concentração de recebíveis por cliente (monitor de crédito, master-only)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-concentracao-recebiveis.md
+++ b/docs/superpowers/plans/2026-07-05-concentracao-recebiveis.md
@@ -1,0 +1,112 @@
+# F5 Concentração de recebíveis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans (inline TDD).
+> Steps use checkbox (`- [ ]`) syntax. Spec: `docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md`.
+
+**Goal:** Monitor master-only de concentração de crédito por código Omie (proxy de sacado) no `/financeiro`, com money-path blindado (empty≠zero, sem fabricar número/nome).
+
+**Architecture:** Helper TS puro (`concentracao-helpers.ts`, vitest) faz toda a matemática + gates de fonte. Hook fino (`useConcentracaoRecebiveis`) lê `fin_contas_receber` (sem tabela nova), atesta `FonteStatus` (guarda o cap PostgREST) e chama o helper. UI = aba no `FinanceiroDashboard`. **v1 = códigos** ("Cliente #código"); nome rico = fast-follow (Codex F).
+
+**Tech Stack:** React 18 + TS strict + @tanstack/react-query + supabase-js + vitest + shadcn/ui.
+
+---
+
+## Escopo v1 (o que ENTRA) vs fast-follow
+
+- **Entra:** helper puro (métricas + gates), hook de leitura com `FonteStatus`, aba UI master-only, testes vitest (money-path + falsificação).
+- **Fast-follow (fora do v1, Codex F):** resolução de nome rico `(company,código)`-scoped; grupo econômico; concentração de receita; semáforo forte. v1 mostra `Cliente #código` sempre — zero risco de nome fabricado.
+- **Sem migration** (lê `fin_contas_receber`; RLS já provado pela aba `contas-receber`). Se a leitura client bater RLS/perf → RPC `SECURITY DEFINER` + prove-sql (decidir na Task 3).
+
+---
+
+## Task 1: Tipos (`concentracao-types.ts`)
+
+**Files:**
+- Create: `src/lib/financeiro/concentracao-types.ts`
+
+- [ ] **Step 1: Criar o arquivo de tipos** (verbatim da spec §3): `Company`, `FonteStatus` (`'ok'|'indisponivel'|'parcial'`), `TituloAberto`, `MotivoConcentracao`, `ImpactoAbsoluto`, `LinhaExposicao`, `ConcentracaoResult`. Sem lógica — só `export type`/`interface`.
+- [ ] **Step 2: `bun run typecheck`** → PASS (tipos compilam isolados).
+- [ ] **Step 3: Commit** `feat(concentracao): tipos F5`.
+
+---
+
+## Task 2: Helper puro (`concentracao-helpers.ts`) — TDD, o núcleo money-path
+
+**Files:**
+- Create: `src/lib/financeiro/concentracao-helpers.ts`
+- Test: `src/lib/financeiro/__tests__/concentracao-helpers.test.ts`
+
+Funções puras exportadas: `c50(sharesDesc: number[])`, `hhi(shares: number[])`, e a orquestradora `concentracaoEmpresa(titulos, fonte, opts)`. Constantes de política `PISO_MODERADO=25000`, `PISO_ALTO=75000` (exportadas, tunáveis).
+
+- [ ] **Step 1 (gates de fonte — a prova P0-1): escrever testes que FALHAM.**
+  - `fonte='indisponivel'` + `[]` → `{motivo:'fonte_indisponivel', totalAberto:null, topN:[]}`.
+  - `fonte='indisponivel'` + `[títulos válidos]` → **não calcula** (`motivo:'fonte_indisponivel'`, métricas null).
+  - `fonte='ok'` + `[]` → `{motivo:'sem_carteira', totalAberto:0, top1Pct:null, topN:[]}`.
+  - `fonte='parcial'` + `[]` → `{motivo:'fonte_parcial', totalAberto:null}` (não `sem_carteira`).
+- [ ] **Step 2: rodar** `heavy bun run test concentracao-helpers` → FAIL (função não existe).
+- [ ] **Step 3: implementar o esqueleto de `concentracaoEmpresa`** com a ordem de gates da spec §3 (1: indisponivel→null; 2: particiona válidas/inválidas; 3: vazio+ok+0inv→sem_carteira; 4: vazio+parcial→fonte_parcial; 5: com válidas→calcula). Retornar métricas null nos ramos sem cálculo.
+- [ ] **Step 4: rodar** → PASS os testes de fonte.
+- [ ] **Step 5 (agregação + primárias): testes que FALHAM** para: 3 códigos com saldos `[100,60,40]` (total 200) → `totalAberto:200`, `maiorExposicao:100`, `top1Pct:0.5`, `clientes:3`; `top5Pct` com <5 códigos = soma dos existentes (=1.0 aqui).
+- [ ] **Step 6: implementar** agregação por `omie_codigo_cliente` (Map), ordenação desc por saldo, `totalAberto/maiorExposicao/top1Pct/top5Pct/clientes`. Rodar → PASS.
+- [ ] **Step 7 (C50): testes que FALHAM.** `c50([0.6,0.3,0.1])→1` (um >50%); `c50([0.25,0.25,0.25,0.25])→2` (acumula ≥50% em 2); `c50([0.34,0.33,0.33])→2`. Empate estável.
+- [ ] **Step 8: implementar `c50`** (ordena desc, acumula share até `>=0.5`, conta). Wire no `concentracaoEmpresa`. Rodar → PASS.
+- [ ] **Step 9 (HHI/nº efetivo — secundário): testes.** `hhi([0.5,0.5])→0.5`, `nEfetivo=2`; `hhi([1])→1`, `nEfetivo=1`. Rodar FAIL→implementar→PASS.
+- [ ] **Step 10 (overlay vencido): testes.** código com saldo 100 e 30 ATRASADO → `vencido:30, pctVencidoProprio:0.3`; código sem ATRASADO → `vencido:0, pctVencidoProprio:0` (**não** null). FAIL→implementar (agrega `vencido` por `atrasado===true`)→PASS.
+- [ ] **Step 11 (linha inválida — Codex E): testes.** título com `saldo:NaN` / `saldo:-5` / `saldo:Infinity` / `omie_codigo_cliente:null` (com fonte `ok`) → `linhasInvalidas>=1`, `motivo:'fonte_parcial'`, a linha **não** entra em `totalAberto`, o total das válidas permanece correto. FAIL→implementar (partição + `Number.isFinite && saldo>0 && codigo!=null`)→PASS.
+- [ ] **Step 12 (impactoAbsoluto = tom keyed na maiorExposicao): testes.** maior=20000→`'baixo'`; 54000→`'moderado'`; 80000→`'alto'`; e em todos os casos `topN` continua preenchido (nunca oculta — P1-5). FAIL→implementar→PASS.
+- [ ] **Step 13 (falsificação — dente dos asserts):** temporariamente sabotar (a) o gate `indisponivel` (deixar calcular) → o teste de Step 1 fica **VERMELHO**; (b) fazer a linha inválida ser dropada sem `fonte_parcial` → Step 11 **VERMELHO**. Restaurar → verde. Documentar no comentário do teste.
+- [ ] **Step 14: `heavy bun run test concentracao-helpers`** → tudo PASS; `bun run typecheck` PASS.
+- [ ] **Step 15: Commit** `feat(concentracao): helper puro + vitest (money-path, falsificação)`.
+
+---
+
+## Task 3: Camada de leitura (`useConcentracaoRecebiveis`) + classificação de fonte
+
+**Files:**
+- Create: `src/hooks/useConcentracaoRecebiveis.ts`
+- Modify: `src/lib/financeiro/concentracao-helpers.ts` (adicionar `classificarFonte` pura)
+- Test: `src/lib/financeiro/__tests__/concentracao-helpers.test.ts` (append)
+
+- [ ] **Step 1: pure `classificarFonte({error, rows, limitAtingido})` → FonteStatus** — testes: `error!=null → 'indisponivel'`; `limitAtingido → 'parcial'`; senão `'ok'`. FAIL→implementar→PASS. (O cap PostgREST 1.000 vira `'parcial'`, não silêncio.)
+- [ ] **Step 2: hook** `useConcentracaoRecebiveis()` com `useQuery` por empresa: `select('omie_codigo_cliente,saldo,status_titulo').in('status_titulo',['A VENCER','ATRASADO']).eq('company', c)` com `.range(0, LIMIT-1)` estável; `limitAtingido = data.length >= LIMIT`. Mapeia `TituloAberto` (`atrasado = status_titulo==='ATRASADO'`), chama `classificarFonte` + `concentracaoEmpresa`. Retorna `Record<Company, ConcentracaoResult>`. **Confirmar RLS master lê fin_contas_receber (aba contas-receber já lê); se NÃO → RPC SECURITY DEFINER + prove-sql** (documentar decisão aqui).
+- [ ] **Step 3: `bun run typecheck`** PASS.
+- [ ] **Step 4: Commit** `feat(concentracao): hook de leitura + classificarFonte`.
+
+---
+
+## Task 4: UI — aba no FinanceiroDashboard
+
+**Files:**
+- Read first: `src/pages/FinanceiroDashboard.tsx` (padrão de `TabsList`/`TabsContent` + como a `DRETab` é montada).
+- Create: `src/components/financeiro/ConcentracaoTab.tsx` (ou o dir onde vive `DRETab`).
+- Modify: `src/pages/FinanceiroDashboard.tsx` (registrar a aba `concentracao`, master-only).
+
+- [ ] **Step 1: ler** `FinanceiroDashboard.tsx` + o componente da `DRETab` pra copiar o padrão (gate master, seletor de empresa, cards, tabela, skeleton).
+- [ ] **Step 2: `ConcentracaoTab`** — por empresa: cards primários (maior R$, top5%, C50) + badge `impactoAbsoluto` (tom, `text-status-*`) + tabela `topN` (`Cliente #código`, R$ aberto, R$ vencido, %vencido, share%) + bloco secundário HHI/nº efetivo. Estados honestos: `fonte_indisponivel` → `<EmptyState>` "não foi possível ler a carteira" (**não** "sem concentração"); `fonte_parcial` → banner "leitura parcial (N inválidas/truncada)"; `sem_carteira` → `<EmptyState tone="operational">` "sem recebíveis abertos". Copy fixa: **"Concentração por código Omie (sacado) — não consolida grupo econômico."** `<PageSkeleton>` no loading.
+- [ ] **Step 3: registrar a aba** `concentracao` no `FinanceiroDashboard` (label "Concentração"), master-only (mesmo gate da DRE/endividamento).
+- [ ] **Step 4: `bun run typecheck` + `bun run lint`** PASS.
+- [ ] **Step 5: Commit** `feat(concentracao): aba UI no FinanceiroDashboard (v1 códigos)`.
+
+---
+
+## Task 5: Verde total + Codex adversarial no código
+
+- [ ] **Step 1: `heavy bun run test` (suíte inteira) + `bun run typecheck` + `bun run lint`** → 0 fail.
+- [ ] **Step 2: Codex adversarial NO CÓDIGO** (`codex exec -m gpt-5.5 -c model_reasoning_effort=xhigh -s read-only`, padrão F1 §11) apontando os arquivos novos + a spec; atacar: fabricação de fonte, cap não-guardado, C50/HHI errados, tom ocultando painel, RLS. Acatar P1; documentar no fim da spec.
+- [ ] **Step 3: aplicar correções do Codex** (se houver) com testes de regressão.
+
+---
+
+## Task 6: PR + handoff Lovable
+
+- [ ] **Step 1: push + PR** (não-draft → auto-merge no verde). Corpo: resumo + "sem migration; deploy = Publish frontend (1 camada)".
+- [ ] **Step 2: nota de deploy** — F5 **não tem migration** (só lê `fin_contas_receber`). Deploy Lovable = **só Publish frontend**. Sem SQL Editor, sem validação de banco.
+- [ ] **Step 3: registrar em `docs/historico/`** (entrega F5) — não engordar CLAUDE.md.
+
+---
+
+## Self-review (writing-plans)
+
+- **Cobertura da spec:** §3 helper→Task 2; §5 degradação→Task 2 (steps 1,11)+Task 4 (estados); §6 RLS→Task 3 step 2; §7 UI→Task 4; §8 prova→Task 2 (steps 1-14); §0/§10 copy honesta→Task 4 step 2. ✅
+- **Sem placeholder:** todos os steps têm código/comando/critério explícito. ✅
+- **Consistência de tipos:** `ConcentracaoResult`/`FonteStatus`/`TituloAberto` idênticos entre Task 1/2/3. ✅

--- a/docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
+++ b/docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
@@ -281,5 +281,26 @@ RLS `SET ROLE` + falsificação) antes de entregar.
   de exposição aberta por código Omie… Não é F4: aqui o número-base existe; o buraco é
   identificação/semântica, não ausência do sinal."*
 
-**Revisão independente:** ✅ Codex (design) 2026-07-05. Pendente: Codex adversarial **no código**
-após implementar (padrão F1 §11) + prove-sql se houver RPC.
+**Revisão independente:** ✅ Codex design + ✅ Codex código (2026-07-05). Sem migration → sem prove-sql.
+
+## 11. Challenge Codex no CÓDIGO (2026-07-05, xhigh — 3 P1, todos acatados)
+
+Após implementar (helper + hook + UI), o Codex adversarial no código achou 3 P1:
+
+1. **UI fabricava R$0 em leitura parcial sem métrica** — `fonte_parcial` sem linha válida
+   (`maiorExposicao=null`) caía em `fmt(?? 0)` → "R$ 0,00" (viola ausente≠zero). Fix: `—` +
+   estado dedicado "leitura parcial — sem métricas calculáveis". Teste: parcial+vazio → null.
+2. **Cap-guard furava com `count` ausente** — se o PostgREST capa em 1.000 e `count` vem
+   null, `rows=1000 < limit=5000` retornava `ok` (truncada-como-completa). Fix fail-closed:
+   `count==null && rows>=1000 → parcial`. **Falsificado** (sabotar → vermelho exato → revertido).
+3. **`PARCIAL` virava vencido por complemento** — `atrasado = aberto && !não-vencido` marcava
+   'PARCIAL' como vencido sem prova, inflando a coluna. Fix: lista POSITIVA
+   `isOverdueTitleStatus ∈ {ATRASADO, VENCIDO}`. Teste explícito PARCIAL → false.
+
+Confirmados **sem furo** pelo Codex: `Number(saldo)` não fabrica total (null → inválida →
+`fonte_parcial`); gate `indisponivel` não calcula; `sem_carteira` só com fonte `ok`;
+C50/HHI/topN corretos; nome v1 seguro (só "Cliente #código").
+
+Prova total: **32 testes vitest** (helper + `classificarFonte` + `isOverdueTitleStatus`) +
+falsificação dos gates de fonte e do cap-guard. **Sem migration** (lê `fin_contas_receber`) →
+sem prove-sql. Deploy Lovable = só **Publish frontend** (1 camada, sem SQL Editor).

--- a/docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
+++ b/docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
@@ -1,0 +1,285 @@
+# Spec — F5 Concentração de recebíveis abertos por código Omie (monitor de exposição)
+
+> Frente 5 do pacote "PEGN — 9 erros que estrangulam a margem". Fecha o erro
+> **concentração de crédito** (carteira de recebíveis dependente de poucos sacados).
+> Money-path: precisão > recall, **ausente ≠ zero**, degradação honesta, nunca fabricar
+> número **nem nome** (money-path.md). Design + challenge Codex (`gpt-5.5`, xhigh,
+> 2026-07-05) — **veredito CONSTRUIR** (monitor lean; ≠ F4, o sinal EXISTE) com **2 P0 +
+> 4 P1, todos acatados** (§10). Não é "alerta de HHI": é monitor honesto de exposição
+> aberta por código Omie, com identificação como enriquecimento parcial account-scoped.
+
+## 0. Achado que fixa o desenho (verificado em prod via psql-ro, 2026-07-05)
+
+**O sinal de concentração existe e é limpo; a IDENTIFICAÇÃO do sacado é que é gap.**
+
+- **Recebível ABERTO = `fin_contas_receber WHERE status_titulo IN ('A VENCER','ATRASADO')`.**
+  O `saldo` **não zera na baixa** (títulos `RECEBIDO`/`CANCELADO` ficam com `saldo>0`
+  histórico) → filtrar por **status**, nunca por `saldo>0`. Em título aberto,
+  `saldo ≈ valor_documento` e `valor_recebido ≈ 0`. Volume por empresa (títulos abertos):
+  oben 522, colacor 231, colacor_sc 29 — **todos < 1.000** (cap PostgREST não morde hoje;
+  o read layer ainda tem de guardar o cap — §7).
+- **Concentração por empresa (AR aberto, agrupado por `omie_codigo_cliente`):**
+
+  | empresa | códigos | AR aberto | top1 | top5 | C50 (aprox) | HHI | nº efetivo |
+  |---|---|---|---|---|---|---|---|
+  | oben | 142 | R$ 380k | 14,3% | 34,1% | ~8–10 | 0,039 | ~25 |
+  | colacor | 85 | R$ 144k | 14,0% | 48,4% | ~5–6 | 0,059 | ~17 |
+  | colacor_sc | 18 | R$ 8,9k | 33,9% | 68,1% | ~2–3 | 0,156 | ~6 |
+
+  Leitura: oben/colacor **diversificadas hoje** (sem alerta forte); colacor_sc concentra em
+  ratio, mas **R$9k é imaterial** — daí o gate de materialidade ser **tom, não alarme**.
+- **Nome do sacado é GAP de dado (todos os caminhos vazios ou inseguros):**
+  `fin_contas_receber.nome_cliente` **100% vazio**; `cnpj_cpf` **100% vazio** no AR aberto;
+  `omie_clientes` é **100% `empresa_omie='colacor'`** (tabela-elo `omie_codigo_cliente`→
+  `user_id`, **sem nome/CNPJ**) → joinar por `omie_codigo_cliente` **sem escopo de conta
+  FABRICA nome errado** (colisão numérica entre contas Omie). Confirmado pelo helper
+  `src/lib/omie/account-coherence.ts` (money-path.md P0-A 2026-07-05): *"oben/colacor_sc
+  resolvem o código via API do Omie e podem não estar no espelho local"*.
+
+**Consequência que fixa o desenho:** a chave confiável para **AGREGAR** é
+`(company, omie_codigo_cliente)` — um **proxy de cliente**, não CNPJ único nem grupo
+econômico. Nome é **enriquecimento parcial** resolvido via Omie API por `(empresa, código)`.
+A copy é honesta: **"concentração por código Omie/sacado — não consolida grupo econômico"**.
+
+## 1. O que entra (escopo v1)
+
+| Entrega | Fecha |
+|---|---|
+| Helper puro `concentracao-helpers.ts` (+ types), por-empresa, vitest | base |
+| **Métricas primárias:** `totalAberto`, `maiorExposicao R$`, `top1%`, `top5%`, **`C50`** | concentração de crédito |
+| **Tabela top-N** por código: `{código, R$ aberto, R$ vencido, %vencido próprio, share%}` | idem |
+| **HHI / nº efetivo — SECUNDÁRIO** (tendência/sanidade, nunca headline nem threshold) | idem |
+| **Metadata de fonte** (`ok`/`indisponivel`/`parcial`) → degradação honesta (empty ≠ zero) | money-path (P0-1) |
+| **Gate de materialidade = TOM** (`baixo`/`moderado`/`alto` impacto absoluto), **nunca oculta** | money-path (P1-5) |
+| **Nome:** enriquecimento parcial `(company,código)`-scoped; degrada "Cliente #código" | identificação (P0-2) |
+
+**Fora da v1** (Codex F): nomes ricos completos; **grupo econômico** (`cliente_grupo_membros`)
+— só entra com prova positiva `(company, omie_codigo_cliente) → grupo_id`; **semáforo forte**
+(depende de apetite de risco explícito); **concentração de RECEITA** (histórico `RECEBIDO` — é
+dependência comercial, não risco de crédito).
+
+## 2. Modelo de dados
+
+**Nenhuma tabela nova.** Lê `fin_contas_receber` direto (read path + RLS já provados — a aba
+`contas-receber` do `FinanceiroDashboard` já lê essa tabela). Decisão client-vs-RPC no plano:
+- **v1 client-side** (preferido): master lê os títulos abertos por empresa (≤522 linhas hoje)
+  sob RLS existente e agrega no helper puro. Simples, sem migration.
+- **RPC agregada** só se a leitura client bater RLS/perf/cap — aí `SECURITY DEFINER` + gate
+  master, **provada em `prove-sql-money-path`** antes de entregar.
+
+**Pisos de materialidade = POLÍTICA EXPLÍCITA** (Codex C — não há piso "científico"). O tom de
+impacto é keyed na **maior exposição absoluta** (`maiorExposicao`, R$) — o dinheiro em risco no
+maior sacado, a medida direta da severidade da concentração (um livro grande e pulverizado não
+deve "gritar" pelo tamanho total; um sacado de R$54k importa mesmo com top1=14%). **Política v1**
+(constante documentada, tunável pelo founder, **nunca número mágico solto**):
+**`baixo` < R$ 25.000 · `moderado` R$ 25k–75k · `alto` > R$ 75.000**. Hoje: oben top-1 ≈R$54k →
+`moderado`; colacor ≈R$20k → `baixo`; colacor_sc R$3k → `baixo` — **nada `alto`** (honesto, sem
+incêndio). Política única (não por-empresa): R$54k de risco é R$54k independente do CNPJ; a
+imaterialidade da colacor_sc já vem do próprio valor baixo, não de um piso especial por entidade.
+
+## 3. Indicadores (helper puro `src/lib/financeiro/concentracao-helpers.ts`, vitest)
+
+### Tipos (`concentracao-types.ts`)
+
+```ts
+export type Company = 'oben' | 'colacor' | 'colacor_sc';
+
+/** Status da LEITURA da fonte (atestado pela camada de read). O helper NUNCA calcula
+ *  sobre fonte não provada — lista vazia pode ser erro/RLS/timeout, não zero (P0-1). */
+export type FonteStatus = 'ok' | 'indisponivel' | 'parcial';
+
+/** Título de recebível ABERTO, já filtrado pela camada de leitura. */
+export interface TituloAberto {
+  omie_codigo_cliente: number | null;
+  saldo: number;
+  atrasado: boolean; // status_titulo === 'ATRASADO'
+}
+
+export type MotivoConcentracao =
+  | 'ok'
+  | 'sem_carteira'        // fonte ok + 0 títulos válidos → zero PROVADO
+  | 'fonte_indisponivel'  // leitura falhou/RLS/timeout → NÃO é zero, não calcula
+  | 'fonte_parcial';      // truncada (cap) ou linha(s) inválida(s) → calcula flagueado
+
+export type ImpactoAbsoluto = 'baixo' | 'moderado' | 'alto';
+
+export interface LinhaExposicao {
+  codigo: number;
+  saldo: number;             // R$ aberto do código
+  vencido: number;           // R$ ATRASADO do código
+  pctVencidoProprio: number; // vencido/saldo ∈ [0,1]
+  share: number;             // saldo/totalAberto ∈ [0,1]
+}
+
+export interface ConcentracaoResult {
+  motivo: MotivoConcentracao;
+  clientes: number | null;                 // nº de códigos distintos válidos
+  totalAberto: number | null;              // 0 em sem_carteira; null em indisponivel
+  maiorExposicao: number | null;           // R$ do maior código
+  top1Pct: number | null;
+  top5Pct: number | null;
+  c50: number | null;                      // menor nº de códigos que somam ≥50%
+  hhi: number | null;                      // SECUNDÁRIO
+  nEfetivo: number | null;                 // 1/hhi, SECUNDÁRIO
+  impactoAbsoluto: ImpactoAbsoluto | null; // TOM de materialidade (nunca oculta topN)
+  topN: LinhaExposicao[];                  // [] fora de ok/parcial; sempre VISÍVEL na UI
+  linhasInvalidas: number;                 // saldos/códigos inválidos (dispara fonte_parcial)
+}
+```
+
+### Função principal
+
+```ts
+export function concentracaoEmpresa(
+  titulos: TituloAberto[],
+  fonte: FonteStatus,
+  opts: { topN?: number; pisoModerado: number; pisoAlto: number },
+): ConcentracaoResult
+```
+
+**Ordem de gates (money-path):**
+1. `fonte === 'indisponivel'` → tudo `null`, `motivo:'fonte_indisponivel'`, `topN:[]`. **Não
+   calcula nada** (P0-1: empty pode ser falha, não zero).
+2. Particiona linhas: **válida** = `omie_codigo_cliente != null && Number.isFinite(saldo) &&
+   saldo > 0`. `linhasInvalidas = total − válidas`. Linha inválida **nunca some silenciosa** —
+   conta e, se houver ≥1, força `fonte_parcial` (Codex E).
+3. Sem linha válida **e** `fonte === 'ok'` **e** `linhasInvalidas === 0` → `motivo:'sem_carteira'`,
+   `totalAberto: 0`, demais métricas `null`, `topN:[]` (zero **provado**).
+4. Sem linha válida mas `fonte === 'parcial'` ou `linhasInvalidas>0` → `fonte_parcial` com métricas `null`.
+5. Com linha válida → agrega por código, calcula, e
+   `motivo = (fonte === 'parcial' || linhasInvalidas > 0) ? 'fonte_parcial' : 'ok'`. Métricas
+   não-nulas, **flagueadas** quando parcial.
+
+**Métricas (funções puras separadas, testáveis):**
+- `totalAberto = Σ saldo (válidos)`; `clientes = nº códigos distintos`.
+- Agrega saldo e vencido (`atrasado`) por código; ordena desc por saldo.
+- `maiorExposicao`, `top1Pct = maior/total`, `top5Pct = Σ top5/total`.
+- **`c50`** = menor nº de códigos (ordenados desc) cujo share acumulado **≥ 0,5** (um código
+  >50% → C50=1). Melhor que HHI no viés de cauda e legível (Codex P1-4/B).
+- `hhi = Σ share²` (secundário); `nEfetivo = 1/hhi` (secundário).
+- `impactoAbsoluto` (keyed na **`maiorExposicao`**, não no total — é o risco single-name):
+  `maiorExposicao < pisoModerado → 'baixo'`; `< pisoAlto → 'moderado'`; senão `'alto'`.
+  Política v1: `pisoModerado=25000`, `pisoAlto=75000` (tunável). É **tom**, nunca oculta o `topN` (P1-5).
+- `topN[i]`: `{codigo, saldo, vencido, pctVencidoProprio: vencido/saldo, share: saldo/total}`.
+  Código sem vencido → `vencido:0`, `pctVencidoProprio:0` (não `null` — zero real).
+
+**Nome NÃO entra no helper puro** — é enriquecimento de apresentação (assíncrono, API,
+`(company,código)`-scoped). O helper opera só sobre códigos. Isola money-path de I/O.
+
+## 4. A armadilha (o que fixa o método) — identificação vs agregação
+
+**Análogo à armadilha-mãe do F1 (double-count), aqui é dupla:**
+1. **`empty` fabricando zero** — o helper puro não distingue "carteira zerada" de
+   "query falhou / RLS / timeout / filtro errado / sync parcial". Sem metadata de fonte, um
+   `sem_carteira` é um zero inventado (P0-1).
+2. **Nome cross-account fabricado** — resolver por código puro devolve nome de OUTRA conta
+   Omie (colisão numérica). Só `(company, código)` + cache por par + guard account-coherence
+   é seguro; ausência local **não valida** identidade (P0-2).
+
+**Decisão v1 (3 camadas):**
+1. Helper recebe **`FonteStatus`** atestado pela camada de leitura; só calcula com fonte
+   provada; `sem_carteira` exige `fonte='ok'` + 0 inválidas.
+2. Agregação por `(company, omie_codigo_cliente)` — **proxy de sacado**, não grupo econômico.
+   Limitação **explícita** na copy; grupo fora do v1 (P1-6).
+3. Nome = enriquecimento parcial `(company,código)`-scoped, degrada "Cliente #código"; guard
+   `codeBelongsToWrongAccount` reaproveitado se necessário (P0-2).
+
+## 5. Degradação honesta (invariantes money-path)
+
+- `fonte='indisponivel'` → `null` + motivo; **nunca calcula** (empty ≠ zero — P0-1).
+- lista vazia só é `sem_carteira` com **fonte provada `ok`** e zero linha inválida.
+- linha com `saldo`/`código` inválido → conta em `linhasInvalidas` + `fonte_parcial`;
+  **nunca some silenciosa** (Codex E).
+- leitura truncada (cap PostgREST 1.000) → camada de read reporta `fonte='parcial'`.
+- nome não resolve `(company,código)` → **"Cliente #código"**, jamais nome de outra conta (P0-2).
+- materialidade → **tom** (`baixo`/`moderado`/`alto`), **nunca oculta** o painel (P1-5).
+- código ≠ cliente/CNPJ/grupo → copy explícita "por código Omie, não consolida grupo" (P1-3/6).
+- HHI/nº efetivo → **secundário**, nunca headline nem threshold antitruste (P1-4).
+
+## 6. Segurança / RLS
+
+- **Master-only** (dado financeiro), padrão do módulo. v1 client-side reusa o read path já
+  provado da aba `contas-receber` (RLS existente). Se virar RPC agregada → `SECURITY DEFINER`
+  + gate `master` explícito, provada no PG17.
+- **Resolver de nome:** credencial/scope por `(empresa, código)`; **cache keyed `(company,código)`**,
+  nunca só código; guard account-coherence por prova positiva de conta errada.
+
+## 7. Arquitetura e superfície de UI
+
+- **Helper:** `src/lib/financeiro/concentracao-helpers.ts` + `concentracao-types.ts` (puro, vitest).
+- **Camada de leitura (hook `useConcentracaoRecebiveis`):** lê `fin_contas_receber` por empresa
+  (filtro por `status_titulo`), **produz o `FonteStatus`**: `ok` só quando a query resolve **e
+  não truncou**. Guarda o **cap PostgREST**: se `rows.length === limit` (ou `count ≥ cap`) →
+  `fonte='parcial'` (ou pagina com `.range()` estável). Erro/timeout → `fonte='indisponivel'`.
+  Chama o helper. Enriquece só o `topN` com nome via resolver `(company,código)`-scoped
+  (degrada "Cliente #código").
+- **UI:** aba/section **master-only** no `/financeiro` (`FinanceiroDashboard`, padrão de abas
+  onde a DRE/F3 vive). Cards de métrica **primária** (maior R$, top5, C50) + **badge de impacto
+  absoluto** (tom) + tabela `topN` (R$ aberto, R$ vencido, %vencido, share, nome/"#código") +
+  HHI/nº efetivo em bloco **secundário** de tendência. Estados honestos: `fonte_indisponivel`
+  → `<EmptyState>` "não foi possível ler a carteira" (não "sem concentração"); `fonte_parcial`
+  → banner "leitura parcial — N linhas inválidas/truncada". Copy fixa: **"Concentração por
+  código Omie (sacado) — não consolida grupo econômico."**
+- House style: `text-status-*`, `useUrlState`, `sonner`, `<PageSkeleton>`, `<EmptyState>`.
+
+## 8. Prova (vitest do helper puro; prove-sql só se houver RPC) + threat-model
+
+**Vitest (helper puro) — asserts:**
+- `C50`: 1 código >50% → C50=1; carteira uniforme de N → C50≈N/2; empates estáveis.
+- `top1`/`top5`/`share`: corretos; `top5` com <5 códigos = soma dos existentes.
+- `hhi`/`nEfetivo`: corretos; secundários.
+- **P0-1 (a prova central):** `[] + fonte='ok'` → `sem_carteira`; `[] + fonte='indisponivel'`
+  → `fonte_indisponivel` (**NÃO** `sem_carteira`); `[...] + fonte='indisponivel'` → não calcula.
+- **Codex E:** linha `saldo=NaN/-1/Infinity` ou `codigo=null` → `linhasInvalidas≥1` +
+  `fonte_parcial`; a linha **não** entra no total; total dos válidos permanece correto.
+- vencido: `pctVencidoProprio` correto; código sem ATRASADO → `vencido:0` (não `null`).
+- materialidade: `totalAberto < pisoModerado` → `'baixo'` **e** `topN` continua preenchido.
+- **Falsificação:** (a) fazer o helper calcular com `fonte='indisponivel'` → teste fica
+  **vermelho**; (b) fazer linha inválida sumir sem `fonte_parcial` → **vermelho**; restaurar → verde.
+
+**Threat-model (1 assert cada):**
+
+| Situação | Default | Racional |
+|---|---|---|
+| `fonte` não provada `ok` | `null` + motivo, não calcula | empty pode ser falha, não zero (P0-1) |
+| lista vazia + `fonte='ok'` | `sem_carteira`, total 0 | zero **provado** |
+| saldo/código inválido numa linha | `fonte_parcial` + contagem | linha nunca some (Codex E) |
+| AR > 1.000 títulos (cap PostgREST) | `fonte_parcial` | leitura truncada ≠ completa |
+| nome não resolve `(company,código)` | "Cliente #código" | jamais nome de outra conta (P0-2) |
+| materialidade baixa | tom "baixo impacto", `topN` visível | nunca oculta (P1-5) |
+| não-master lê | 0 linhas / bloqueado | financeiro master-only |
+
+Se a leitura virar RPC agregada `SECURITY DEFINER` → **prove-sql-money-path** (asserts +
+RLS `SET ROLE` + falsificação) antes de entregar.
+
+## 9. Decisões (resolvidas com o Codex, §10)
+
+1. **Construir vs adiar:** CONSTRUIR (monitor lean) — o sinal existe, ≠ F4. ✅
+2. **Headline:** maior R$ + top1/top5 + **C50**; HHI/nº efetivo secundários. ✅ (P1-4)
+3. **Materialidade:** **tom** (baixo/moderado/alto) keyed na maior exposição R$; política v1
+   25k/75k (única, tunável); nunca oculta o painel. ✅ (P1-5, C)
+4. **Chave:** `(company, omie_codigo_cliente)` p/ agregar; grupo econômico **fora do v1**. ✅ (P1-6/D)
+5. **Nome:** enriquecimento parcial `(company,código)`-scoped; degrada "Cliente #código". ✅ (P0-2)
+6. **Metadata de fonte** no helper (empty ≠ zero; inválida ≠ some). ✅ (P0-1/E)
+7. **Copy honesta:** "por código Omie, não consolida grupo econômico". ✅ (P1-3)
+8. **Sem tabela nova** (lê `fin_contas_receber`); RPC só se necessário, provada. ✅
+
+## 10. Veredito do challenge Codex (2026-07-05, xhigh — CONSTRUIR + 2 P0 + 4 P1, todos acatados)
+
+- **P0-1** — `empty → sem_carteira` **fabrica zero**. Helper recebe metadata de fonte; só
+  calcula com fonte provada; senão `null + fonte_indisponivel/parcial`.
+- **P0-2** — nome via API por código puro → **nome de outra conta**. Resolver
+  `(company,código)`-scoped + cache por par + guard account-coherence.
+- **P1-3** — "cliente" é forte demais → copy "por código Omie/sacado, não consolida grupo".
+- **P1-4** — HHI headline dá falsa tranquilidade → primárias maior R$ + top1/top5 + **C50**;
+  HHI secundário.
+- **P1-5** — materialidade não pode **esconder** o painel → controla tom, não visibilidade.
+- **P1-6** — agrupar por código **subconta** grupo econômico → limitação explícita; grupo
+  fora do v1 salvo prova positiva `(company,código)→grupo_id`.
+- **E** — linha com saldo/código inválido **não some** → `fonte_parcial` + contagem.
+- **Veredito literal:** *"CONSTRUIR, mas não como 'alerta de HHI'. Construir como monitor lean
+  de exposição aberta por código Omie… Não é F4: aqui o número-base existe; o buraco é
+  identificação/semântica, não ausência do sinal."*
+
+**Revisão independente:** ✅ Codex (design) 2026-07-05. Pendente: Codex adversarial **no código**
+após implementar (padrão F1 §11) + prove-sql se houver RPC.

--- a/src/components/financeiro/dashboard/ConcentracaoTab.tsx
+++ b/src/components/financeiro/dashboard/ConcentracaoTab.tsx
@@ -67,6 +67,23 @@ function EmpresaCard({ company, r }: { company: Company; r: ConcentracaoResult }
     );
   }
 
+  // fonte_parcial SEM linha válida → não há métrica calculável (nunca fabricar R$0 — Codex P1).
+  if (r.maiorExposicao == null) {
+    return (
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">{nome}</CardTitle></CardHeader>
+        <CardContent>
+          <EmptyState
+            icon={AlertTriangle}
+            tone="operational"
+            title="Leitura parcial — sem métricas calculáveis"
+            description={`A carteira não pôde ser lida por completo${r.linhasInvalidas > 0 ? ` (${r.linhasInvalidas} linha(s) inválida(s))` : ''}. Não há concentração calculável — isto não é zero.`}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
   const imp = r.impactoAbsoluto ? IMPACTO[r.impactoAbsoluto] : null;
   return (
     <Card>
@@ -83,14 +100,14 @@ function EmpresaCard({ company, r }: { company: Company; r: ConcentracaoResult }
       </CardHeader>
       <CardContent className="space-y-4">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <Metric label="Maior exposição" value={fmt(r.maiorExposicao ?? 0)} />
+          <Metric label="Maior exposição" value={r.maiorExposicao == null ? '—' : fmt(r.maiorExposicao)} />
           <Metric label="Top-5" value={pct(r.top5Pct)} />
           <Metric
             label="C50"
             value={r.c50 == null ? '—' : `${r.c50} cliente${r.c50 === 1 ? '' : 's'}`}
             hint="somam 50% da carteira"
           />
-          <Metric label="Carteira aberta" value={fmt(r.totalAberto ?? 0)} />
+          <Metric label="Carteira aberta" value={r.totalAberto == null ? '—' : fmt(r.totalAberto)} />
         </div>
 
         {r.topN.length > 0 && (

--- a/src/components/financeiro/dashboard/ConcentracaoTab.tsx
+++ b/src/components/financeiro/dashboard/ConcentracaoTab.tsx
@@ -1,0 +1,163 @@
+// F5 — Concentração de recebíveis abertos por código Omie (sacado), por empresa.
+// Spec: docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
+// Monitor de concentração de crédito. Money-path: estados honestos (fonte
+// indisponível/parcial nunca vira "sem concentração"); v1 mostra código ("Cliente #N"),
+// nome rico é próxima iteração; copy explícita "não consolida grupo econômico".
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { EmptyState } from '@/components/EmptyState';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { AlertTriangle, Users, Layers } from 'lucide-react';
+import { COMPANIES, ALL_COMPANIES } from '@/contexts/CompanyContext';
+import { fmt } from '@/components/financeiro/dashboard/format';
+import { useConcentracaoRecebiveis } from '@/hooks/useConcentracaoRecebiveis';
+import type { Company, ConcentracaoResult, ImpactoAbsoluto } from '@/lib/financeiro/concentracao-types';
+
+const IMPACTO: Record<ImpactoAbsoluto, { label: string; cls: string }> = {
+  baixo: { label: 'Impacto baixo', cls: 'bg-status-success-bg text-status-success border-transparent' },
+  moderado: { label: 'Impacto moderado', cls: 'bg-status-warning-bg text-status-warning border-transparent' },
+  alto: { label: 'Impacto alto', cls: 'bg-status-error-bg text-status-error border-transparent' },
+};
+
+const pct = (x: number | null) => (x == null ? '—' : `${(x * 100).toFixed(1)}%`);
+
+function Metric({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <div className="rounded-lg border border-border p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-lg font-semibold tabular-nums">{value}</div>
+      {hint && <div className="text-[10px] text-muted-foreground/70">{hint}</div>}
+    </div>
+  );
+}
+
+function EmpresaCard({ company, r }: { company: Company; r: ConcentracaoResult }) {
+  const nome = COMPANIES[company].shortName;
+
+  if (r.motivo === 'fonte_indisponivel') {
+    return (
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">{nome}</CardTitle></CardHeader>
+        <CardContent>
+          <EmptyState
+            icon={AlertTriangle}
+            tone="operational"
+            title="Não foi possível ler a carteira"
+            description="A leitura de recebíveis falhou (sem dados / RLS / timeout). Isto NÃO é ausência de concentração — sincronize e tente de novo."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (r.motivo === 'sem_carteira') {
+    return (
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">{nome}</CardTitle></CardHeader>
+        <CardContent>
+          <EmptyState
+            icon={Users}
+            tone="operational"
+            title="Sem recebíveis abertos"
+            description="Nenhum título em aberto nesta empresa hoje."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const imp = r.impactoAbsoluto ? IMPACTO[r.impactoAbsoluto] : null;
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base flex items-center gap-2 flex-wrap">
+          {nome}
+          {imp && <Badge className={imp.cls}>{imp.label}</Badge>}
+          {r.motivo === 'fonte_parcial' && (
+            <Badge variant="outline" className="text-status-warning border-status-warning/40">
+              Leitura parcial{r.linhasInvalidas > 0 ? ` · ${r.linhasInvalidas} inválida(s)` : ''}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <Metric label="Maior exposição" value={fmt(r.maiorExposicao ?? 0)} />
+          <Metric label="Top-5" value={pct(r.top5Pct)} />
+          <Metric
+            label="C50"
+            value={r.c50 == null ? '—' : `${r.c50} cliente${r.c50 === 1 ? '' : 's'}`}
+            hint="somam 50% da carteira"
+          />
+          <Metric label="Carteira aberta" value={fmt(r.totalAberto ?? 0)} />
+        </div>
+
+        {r.topN.length > 0 && (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Sacado (código Omie)</TableHead>
+                  <TableHead className="text-right">Aberto</TableHead>
+                  <TableHead className="text-right">Vencido</TableHead>
+                  <TableHead className="text-right">% venc.</TableHead>
+                  <TableHead className="text-right">Share</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {r.topN.map((l) => (
+                  <TableRow key={l.codigo}>
+                    <TableCell className="font-mono text-xs">Cliente #{l.codigo}</TableCell>
+                    <TableCell className="text-right tabular-nums">{fmt(l.saldo)}</TableCell>
+                    <TableCell
+                      className={`text-right tabular-nums ${l.vencido > 0 ? 'text-status-error' : 'text-muted-foreground'}`}
+                    >
+                      {l.vencido > 0 ? fmt(l.vencido) : '—'}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {(l.pctVencidoProprio * 100).toFixed(0)}%
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums font-medium">
+                      {(l.share * 100).toFixed(1)}%
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        {/* Secundário — tendência/sanidade (nunca headline). */}
+        <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
+          <span>Top-1: <b className="text-foreground">{pct(r.top1Pct)}</b></span>
+          <span>Nº efetivo de clientes: <b className="text-foreground">{r.nEfetivo == null ? '—' : r.nEfetivo.toFixed(0)}</b></span>
+          <span>HHI: <b className="text-foreground">{r.hhi == null ? '—' : r.hhi.toFixed(3)}</b></span>
+          <span>Clientes: <b className="text-foreground">{r.clientes ?? '—'}</b></span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ConcentracaoTab() {
+  const { data, isLoading } = useConcentracaoRecebiveis();
+
+  if (isLoading || !data) return <PageSkeleton variant="cockpit" />;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 text-xs text-muted-foreground">
+        <Layers className="w-4 h-4 mt-0.5 shrink-0 opacity-60" />
+        <p>
+          Concentração de crédito por <b>código Omie (sacado)</b> sobre os recebíveis em aberto —{' '}
+          <b>não consolida grupo econômico</b>. Ranqueado por exposição absoluta; o tom de impacto é
+          keyed na maior exposição (política 25k/75k, tunável). Identificação por nome: próxima iteração.
+        </p>
+      </div>
+      {ALL_COMPANIES.map((co) => (
+        <EmpresaCard key={co} company={co} r={data[co]} />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useConcentracaoRecebiveis.ts
+++ b/src/hooks/useConcentracaoRecebiveis.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { OPEN_TITLE_STATUSES } from '@/lib/financeiro/titulo-status';
 import {
-  isOpenTitleStatus,
-  isOpenNotOverdueTitleStatus,
-  OPEN_TITLE_STATUSES,
-} from '@/lib/financeiro/titulo-status';
-import { concentracaoEmpresa, classificarFonte } from '@/lib/financeiro/concentracao-helpers';
+  concentracaoEmpresa,
+  classificarFonte,
+  isOverdueTitleStatus,
+} from '@/lib/financeiro/concentracao-helpers';
 import type { Company, ConcentracaoResult, TituloAberto } from '@/lib/financeiro/concentracao-types';
 
 const LIMIT = 5000;
@@ -49,9 +49,9 @@ export function useConcentracaoRecebiveis() {
         porEmpresa[co].push({
           omie_codigo_cliente: row.omie_codigo_cliente,
           saldo: Number(row.saldo), // null/''→0/NaN → cai como INVÁLIDA no helper (não some)
-          // vencido = aberto E não "a vencer" (ATRASADO/VENCIDO), pelos helpers canônicos.
-          atrasado:
-            isOpenTitleStatus(row.status_titulo) && !isOpenNotOverdueTitleStatus(row.status_titulo),
+          // vencido por lista POSITIVA (ATRASADO/VENCIDO), não por complemento — 'PARCIAL' é
+          // aberto mas não necessariamente vencido; complemento inflaria o vencido (Codex).
+          atrasado: isOverdueTitleStatus(row.status_titulo),
         });
       }
 

--- a/src/hooks/useConcentracaoRecebiveis.ts
+++ b/src/hooks/useConcentracaoRecebiveis.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import {
+  isOpenTitleStatus,
+  isOpenNotOverdueTitleStatus,
+  OPEN_TITLE_STATUSES,
+} from '@/lib/financeiro/titulo-status';
+import { concentracaoEmpresa, classificarFonte } from '@/lib/financeiro/concentracao-helpers';
+import type { Company, ConcentracaoResult, TituloAberto } from '@/lib/financeiro/concentracao-types';
+
+const LIMIT = 5000;
+
+/**
+ * F5 — concentração de recebíveis ABERTOS por código Omie (proxy de sacado), por empresa.
+ * Spec: docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
+ *
+ * Lê `fin_contas_receber` (RLS já provado — a aba "A Receber" do mesmo dashboard lê a
+ * mesma tabela), atesta o FonteStatus (guarda o cap PostgREST via `count: 'exact'`) e
+ * delega TODA a matemática ao helper puro. Money-path: leitura incompleta/erro NÃO vira
+ * zero (fonte 'indisponivel'/'parcial'), o helper não fabrica.
+ *
+ * Filtro de aberto = `isOpenTitleStatus` (superset canônico espelhado no cashflow engine)
+ * — evita silêncio caso o ingest grave 'VENCIDO'/'PARCIAL' em vez de só 'A VENCER'/'ATRASADO'.
+ */
+export function useConcentracaoRecebiveis() {
+  return useQuery({
+    queryKey: ['concentracao-recebiveis'],
+    staleTime: 60_000,
+    queryFn: async (): Promise<Record<Company, ConcentracaoResult>> => {
+      const { data, error, count } = await supabase
+        .from('fin_contas_receber')
+        .select('omie_codigo_cliente, saldo, status_titulo, company', { count: 'exact' })
+        .in('status_titulo', [...OPEN_TITLE_STATUSES])
+        .order('id', { ascending: true })
+        .range(0, LIMIT - 1);
+
+      const rows = data ?? [];
+      const fonte = classificarFonte({
+        error: !!error,
+        rowsRetornadas: rows.length,
+        countTotal: count ?? null,
+        limit: LIMIT,
+      });
+
+      const porEmpresa: Record<Company, TituloAberto[]> = { oben: [], colacor: [], colacor_sc: [] };
+      for (const row of rows) {
+        const co = row.company as Company;
+        if (!(co in porEmpresa)) continue; // empresa desconhecida: ignora, não quebra
+        porEmpresa[co].push({
+          omie_codigo_cliente: row.omie_codigo_cliente,
+          saldo: Number(row.saldo), // null/''→0/NaN → cai como INVÁLIDA no helper (não some)
+          // vencido = aberto E não "a vencer" (ATRASADO/VENCIDO), pelos helpers canônicos.
+          atrasado:
+            isOpenTitleStatus(row.status_titulo) && !isOpenNotOverdueTitleStatus(row.status_titulo),
+        });
+      }
+
+      return {
+        oben: concentracaoEmpresa(porEmpresa.oben, fonte),
+        colacor: concentracaoEmpresa(porEmpresa.colacor, fonte),
+        colacor_sc: concentracaoEmpresa(porEmpresa.colacor_sc, fonte),
+      };
+    },
+  });
+}

--- a/src/lib/financeiro/__tests__/concentracao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/concentracao-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   concentracaoEmpresa,
   c50,
   hhi,
+  classificarFonte,
   PISO_MODERADO,
   PISO_ALTO,
 } from '../concentracao-helpers';
@@ -137,4 +138,15 @@ describe('impactoAbsoluto = TOM keyed na maiorExposicao (P1-5, nunca oculta)', (
     expect(PISO_MODERADO).toBe(25000);
     expect(PISO_ALTO).toBe(75000);
   });
+});
+
+describe('classificarFonte — leitura incompleta ≠ zero (P0-1 na camada de read)', () => {
+  it('error → indisponivel', () =>
+    expect(classificarFonte({ error: true, rowsRetornadas: 0, countTotal: null, limit: 5000 })).toBe('indisponivel'));
+  it('count total > linhas retornadas → parcial (truncado)', () =>
+    expect(classificarFonte({ error: false, rowsRetornadas: 1000, countTotal: 1500, limit: 5000 })).toBe('parcial'));
+  it('bateu o limite pedido sem count → parcial (defensivo)', () =>
+    expect(classificarFonte({ error: false, rowsRetornadas: 5000, countTotal: null, limit: 5000 })).toBe('parcial'));
+  it('leitura completa → ok', () =>
+    expect(classificarFonte({ error: false, rowsRetornadas: 782, countTotal: 782, limit: 5000 })).toBe('ok'));
 });

--- a/src/lib/financeiro/__tests__/concentracao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/concentracao-helpers.test.ts
@@ -4,6 +4,7 @@ import {
   c50,
   hhi,
   classificarFonte,
+  isOverdueTitleStatus,
   PISO_MODERADO,
   PISO_ALTO,
 } from '../concentracao-helpers';
@@ -39,6 +40,8 @@ describe('concentracaoEmpresa — gates de fonte (P0-1: empty ≠ zero)', () => 
     const r = concentracaoEmpresa([], 'parcial');
     expect(r.motivo).toBe('fonte_parcial');
     expect(r.totalAberto).toBeNull();
+    expect(r.maiorExposicao).toBeNull(); // UI não pode fabricar R$0 (Codex P1)
+    expect(r.topN).toEqual([]);
   });
 });
 
@@ -147,6 +150,23 @@ describe('classificarFonte — leitura incompleta ≠ zero (P0-1 na camada de re
     expect(classificarFonte({ error: false, rowsRetornadas: 1000, countTotal: 1500, limit: 5000 })).toBe('parcial'));
   it('bateu o limite pedido sem count → parcial (defensivo)', () =>
     expect(classificarFonte({ error: false, rowsRetornadas: 5000, countTotal: null, limit: 5000 })).toBe('parcial'));
+  it('sem count + bateu o cap padrão (1000) → parcial (fail-closed, Codex P1)', () =>
+    expect(classificarFonte({ error: false, rowsRetornadas: 1000, countTotal: null, limit: 5000 })).toBe('parcial'));
   it('leitura completa → ok', () =>
     expect(classificarFonte({ error: false, rowsRetornadas: 782, countTotal: 782, limit: 5000 })).toBe('ok'));
+});
+
+describe('isOverdueTitleStatus — vencido por lista positiva (não complemento, Codex P1)', () => {
+  it('ATRASADO / VENCIDO → true', () => {
+    expect(isOverdueTitleStatus('ATRASADO')).toBe(true);
+    expect(isOverdueTitleStatus('VENCIDO')).toBe(true);
+  });
+  it('PARCIAL → false (aberto, mas não prova de vencido)', () =>
+    expect(isOverdueTitleStatus('PARCIAL')).toBe(false));
+  it('A VENCER / VENCE HOJE / ABERTO / null → false', () => {
+    expect(isOverdueTitleStatus('A VENCER')).toBe(false);
+    expect(isOverdueTitleStatus('VENCE HOJE')).toBe(false);
+    expect(isOverdueTitleStatus('ABERTO')).toBe(false);
+    expect(isOverdueTitleStatus(null)).toBe(false);
+  });
 });

--- a/src/lib/financeiro/__tests__/concentracao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/concentracao-helpers.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  concentracaoEmpresa,
+  c50,
+  hhi,
+  PISO_MODERADO,
+  PISO_ALTO,
+} from '../concentracao-helpers';
+import type { TituloAberto } from '../concentracao-types';
+
+const t = (
+  omie_codigo_cliente: number | null,
+  saldo: number,
+  atrasado = false,
+): TituloAberto => ({ omie_codigo_cliente, saldo, atrasado });
+
+describe('concentracaoEmpresa — gates de fonte (P0-1: empty ≠ zero)', () => {
+  it('fonte indisponivel + vazio → fonte_indisponivel, NÃO sem_carteira', () => {
+    const r = concentracaoEmpresa([], 'indisponivel');
+    expect(r.motivo).toBe('fonte_indisponivel');
+    expect(r.totalAberto).toBeNull();
+    expect(r.topN).toEqual([]);
+  });
+  it('fonte indisponivel + títulos válidos → NÃO calcula (não fabrica sobre fonte podre)', () => {
+    const r = concentracaoEmpresa([t(1, 100), t(2, 50)], 'indisponivel');
+    expect(r.motivo).toBe('fonte_indisponivel');
+    expect(r.totalAberto).toBeNull();
+    expect(r.maiorExposicao).toBeNull();
+  });
+  it('fonte ok + vazio → sem_carteira (zero PROVADO), total 0', () => {
+    const r = concentracaoEmpresa([], 'ok');
+    expect(r.motivo).toBe('sem_carteira');
+    expect(r.totalAberto).toBe(0);
+    expect(r.top1Pct).toBeNull();
+    expect(r.topN).toEqual([]);
+  });
+  it('fonte parcial + vazio → fonte_parcial, NÃO sem_carteira (truncado ≠ zero)', () => {
+    const r = concentracaoEmpresa([], 'parcial');
+    expect(r.motivo).toBe('fonte_parcial');
+    expect(r.totalAberto).toBeNull();
+  });
+});
+
+describe('concentracaoEmpresa — agregação + primárias', () => {
+  it('agrega por código: total/maior/top1/clientes', () => {
+    const r = concentracaoEmpresa([t(1, 100), t(2, 60), t(3, 40)], 'ok');
+    expect(r.motivo).toBe('ok');
+    expect(r.totalAberto).toBe(200);
+    expect(r.maiorExposicao).toBe(100);
+    expect(r.top1Pct).toBeCloseTo(0.5);
+    expect(r.clientes).toBe(3);
+  });
+  it('mesmo código em 2 títulos soma (1 sacado, não 2)', () => {
+    const r = concentracaoEmpresa([t(1, 100), t(1, 50), t(2, 50)], 'ok');
+    expect(r.clientes).toBe(2);
+    expect(r.maiorExposicao).toBe(150);
+    expect(r.totalAberto).toBe(200);
+  });
+  it('top5 com <5 códigos = soma existente (=1.0)', () => {
+    const r = concentracaoEmpresa([t(1, 100), t(2, 60), t(3, 40)], 'ok');
+    expect(r.top5Pct).toBeCloseTo(1.0);
+  });
+});
+
+describe('c50 — menor nº de códigos que somam ≥50%', () => {
+  it('um código >50% → 1', () => expect(c50([0.6, 0.3, 0.1])).toBe(1));
+  it('4 iguais 25% → 2', () => expect(c50([0.25, 0.25, 0.25, 0.25])).toBe(2));
+  it('0.34/0.33/0.33 → 2', () => expect(c50([0.34, 0.33, 0.33])).toBe(2));
+  it('via concentracaoEmpresa (maior=60%)', () => {
+    const r = concentracaoEmpresa([t(1, 60), t(2, 30), t(3, 10)], 'ok');
+    expect(r.c50).toBe(1);
+  });
+});
+
+describe('hhi / nº efetivo (SECUNDÁRIO)', () => {
+  it('hhi([0.5,0.5]) = 0.5', () => expect(hhi([0.5, 0.5])).toBeCloseTo(0.5));
+  it('2 códigos iguais → hhi 0.5, nEfetivo 2', () => {
+    const r = concentracaoEmpresa([t(1, 50), t(2, 50)], 'ok');
+    expect(r.hhi).toBeCloseTo(0.5);
+    expect(r.nEfetivo).toBeCloseTo(2);
+  });
+  it('1 código → hhi 1, nEfetivo 1', () => {
+    const r = concentracaoEmpresa([t(1, 100)], 'ok');
+    expect(r.hhi).toBeCloseTo(1);
+    expect(r.nEfetivo).toBeCloseTo(1);
+  });
+});
+
+describe('overlay de vencido (ATRASADO)', () => {
+  it('código com ATRASADO parcial → vencido + pctVencidoProprio', () => {
+    const r = concentracaoEmpresa([t(1, 70, false), t(1, 30, true), t(2, 100, false)], 'ok');
+    const c1 = r.topN.find((l) => l.codigo === 1)!;
+    expect(c1.saldo).toBe(100);
+    expect(c1.vencido).toBe(30);
+    expect(c1.pctVencidoProprio).toBeCloseTo(0.3);
+  });
+  it('código sem ATRASADO → vencido 0, pct 0 (NÃO null)', () => {
+    const r = concentracaoEmpresa([t(1, 100, false)], 'ok');
+    expect(r.topN[0].vencido).toBe(0);
+    expect(r.topN[0].pctVencidoProprio).toBe(0);
+  });
+});
+
+describe('linha inválida (Codex E) — NÃO some, vira fonte_parcial', () => {
+  for (const bad of [NaN, -5, Infinity]) {
+    it(`saldo ${bad} → linhasInvalidas + fonte_parcial, fora do total`, () => {
+      const r = concentracaoEmpresa([t(1, 100), t(2, bad)], 'ok');
+      expect(r.linhasInvalidas).toBe(1);
+      expect(r.motivo).toBe('fonte_parcial');
+      expect(r.totalAberto).toBe(100);
+      expect(r.clientes).toBe(1);
+    });
+  }
+  it('omie_codigo_cliente null → inválida (não atribuível)', () => {
+    const r = concentracaoEmpresa([t(1, 100), t(null, 50)], 'ok');
+    expect(r.linhasInvalidas).toBe(1);
+    expect(r.motivo).toBe('fonte_parcial');
+    expect(r.totalAberto).toBe(100);
+  });
+});
+
+describe('impactoAbsoluto = TOM keyed na maiorExposicao (P1-5, nunca oculta)', () => {
+  it('maior 20k → baixo (e topN preenchido)', () => {
+    const r = concentracaoEmpresa([t(1, 20000), t(2, 5000)], 'ok');
+    expect(r.impactoAbsoluto).toBe('baixo');
+    expect(r.topN.length).toBeGreaterThan(0);
+  });
+  it('maior 54k → moderado', () => {
+    const r = concentracaoEmpresa([t(1, 54000)], 'ok');
+    expect(r.impactoAbsoluto).toBe('moderado');
+  });
+  it('maior 80k → alto', () => {
+    const r = concentracaoEmpresa([t(1, 80000)], 'ok');
+    expect(r.impactoAbsoluto).toBe('alto');
+  });
+  it('política v1 exposta e tunável', () => {
+    expect(PISO_MODERADO).toBe(25000);
+    expect(PISO_ALTO).toBe(75000);
+  });
+});

--- a/src/lib/financeiro/concentracao-helpers.ts
+++ b/src/lib/financeiro/concentracao-helpers.ts
@@ -1,0 +1,142 @@
+// F5 Concentração de recebíveis — helper puro (testado em vitest).
+// Spec: docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
+// Money-path: empty ≠ zero (o helper recebe FonteStatus e NÃO calcula sobre fonte
+// podre → nunca fabrica 'sem_carteira'); linha inválida NÃO some (vira fonte_parcial);
+// nunca fabrica número. Nome NÃO entra aqui (é enriquecimento de apresentação).
+
+import type {
+  FonteStatus,
+  TituloAberto,
+  ConcentracaoResult,
+  ImpactoAbsoluto,
+  LinhaExposicao,
+} from './concentracao-types';
+
+/** Política de materialidade (TOM, nunca oculta). Keyed na maior exposição absoluta.
+ *  Tunável — não é verdade científica (Codex C). */
+export const PISO_MODERADO = 25000;
+export const PISO_ALTO = 75000;
+
+/** menor nº de códigos (share desc) cujo acumulado atinge ≥ 50% da carteira. */
+export function c50(sharesDesc: number[]): number {
+  let acc = 0;
+  for (let i = 0; i < sharesDesc.length; i++) {
+    acc += sharesDesc[i];
+    if (acc >= 0.5) return i + 1;
+  }
+  return sharesDesc.length;
+}
+
+/** HHI = Σ share². Secundário (tendência/sanidade, nunca headline). */
+export function hhi(shares: number[]): number {
+  return shares.reduce((s, x) => s + x * x, 0);
+}
+
+function impactoDaMaior(maior: number, pisoModerado: number, pisoAlto: number): ImpactoAbsoluto {
+  if (maior < pisoModerado) return 'baixo';
+  if (maior < pisoAlto) return 'moderado';
+  return 'alto';
+}
+
+function resultadoSemCalculo(
+  motivo: ConcentracaoResult['motivo'],
+  totalAberto: number | null,
+  linhasInvalidas: number,
+): ConcentracaoResult {
+  return {
+    motivo,
+    clientes: null,
+    totalAberto,
+    maiorExposicao: null,
+    top1Pct: null,
+    top5Pct: null,
+    c50: null,
+    hhi: null,
+    nEfetivo: null,
+    impactoAbsoluto: null,
+    topN: [],
+    linhasInvalidas,
+  };
+}
+
+/**
+ * Concentração de crédito por código Omie (proxy de sacado), por empresa.
+ * `fonte` é atestado pela camada de leitura: 'ok' (query completa), 'parcial'
+ * (truncada/dados suspeitos) ou 'indisponivel' (falha/RLS/timeout). Ordem dos gates
+ * na spec §3 — cada ramo justificado por money-path.
+ */
+export function concentracaoEmpresa(
+  titulos: TituloAberto[],
+  fonte: FonteStatus,
+  opts: { topN?: number; pisoModerado?: number; pisoAlto?: number } = {},
+): ConcentracaoResult {
+  const topNLimit = opts.topN ?? 10;
+  const pisoModerado = opts.pisoModerado ?? PISO_MODERADO;
+  const pisoAlto = opts.pisoAlto ?? PISO_ALTO;
+
+  // Gate 1 (P0-1): fonte indisponível → NÃO calcula. Lista vazia aqui pode ser falha,
+  // não carteira zerada — afirmar zero seria fabricar.
+  if (fonte === 'indisponivel') return resultadoSemCalculo('fonte_indisponivel', null, 0);
+
+  // Gate 2 (Codex E): particiona válidas/inválidas. Linha inválida NUNCA some — conta.
+  const validas: TituloAberto[] = [];
+  let linhasInvalidas = 0;
+  for (const it of titulos) {
+    if (it.omie_codigo_cliente != null && Number.isFinite(it.saldo) && it.saldo > 0) {
+      validas.push(it);
+    } else {
+      linhasInvalidas++;
+    }
+  }
+  const temInvalida = linhasInvalidas > 0;
+
+  // Gate 3/4: sem linha válida.
+  if (validas.length === 0) {
+    // Zero PROVADO: só quando a fonte é 'ok' E não houve linha inválida escondida.
+    if (fonte === 'ok' && !temInvalida) return resultadoSemCalculo('sem_carteira', 0, 0);
+    // Truncada, ou tudo inválido → não afirma zero.
+    return resultadoSemCalculo('fonte_parcial', null, linhasInvalidas);
+  }
+
+  // Gate 5: agrega por código (saldo + parcela vencida) e ordena desc por saldo.
+  const porCodigo = new Map<number, { saldo: number; vencido: number }>();
+  for (const it of validas) {
+    const cod = it.omie_codigo_cliente as number;
+    const cur = porCodigo.get(cod) ?? { saldo: 0, vencido: 0 };
+    cur.saldo += it.saldo;
+    if (it.atrasado) cur.vencido += it.saldo;
+    porCodigo.set(cod, cur);
+  }
+  const linhas = [...porCodigo.entries()]
+    .map(([codigo, v]) => ({ codigo, saldo: v.saldo, vencido: v.vencido }))
+    .sort((a, b) => b.saldo - a.saldo);
+
+  const totalAberto = linhas.reduce((s, l) => s + l.saldo, 0);
+  const shares = linhas.map((l) => l.saldo / totalAberto);
+  const maiorExposicao = linhas[0].saldo;
+  const hhiVal = hhi(shares);
+
+  const topN: LinhaExposicao[] = linhas.slice(0, topNLimit).map((l) => ({
+    codigo: l.codigo,
+    saldo: l.saldo,
+    vencido: l.vencido,
+    pctVencidoProprio: l.saldo > 0 ? l.vencido / l.saldo : 0,
+    share: l.saldo / totalAberto,
+  }));
+
+  return {
+    // fonte 'parcial' ou linha inválida rebaixa o motivo, mesmo com métricas calculadas.
+    motivo: fonte === 'parcial' || temInvalida ? 'fonte_parcial' : 'ok',
+    clientes: linhas.length,
+    totalAberto,
+    maiorExposicao,
+    top1Pct: shares[0],
+    top5Pct: shares.slice(0, 5).reduce((s, x) => s + x, 0),
+    c50: c50(shares),
+    hhi: hhiVal,
+    nEfetivo: hhiVal > 0 ? 1 / hhiVal : null,
+    impactoAbsoluto: impactoDaMaior(maiorExposicao, pisoModerado, pisoAlto),
+    topN,
+    linhasInvalidas,
+  };
+}

--- a/src/lib/financeiro/concentracao-helpers.ts
+++ b/src/lib/financeiro/concentracao-helpers.ts
@@ -32,6 +32,23 @@ export function hhi(shares: number[]): number {
   return shares.reduce((s, x) => s + x * x, 0);
 }
 
+/**
+ * Classifica o FonteStatus da LEITURA (money-path P0-1: leitura incompleta ≠ zero).
+ * error → 'indisponivel'; count total > linhas retornadas (ou bateu o limite pedido) →
+ * 'parcial' (truncada pelo cap PostgREST); senão 'ok'. Pura, testável.
+ */
+export function classificarFonte(p: {
+  error: boolean;
+  rowsRetornadas: number;
+  countTotal: number | null;
+  limit: number;
+}): FonteStatus {
+  if (p.error) return 'indisponivel';
+  if (p.countTotal != null && p.countTotal > p.rowsRetornadas) return 'parcial';
+  if (p.rowsRetornadas >= p.limit) return 'parcial';
+  return 'ok';
+}
+
 function impactoDaMaior(maior: number, pisoModerado: number, pisoAlto: number): ImpactoAbsoluto {
   if (maior < pisoModerado) return 'baixo';
   if (maior < pisoAlto) return 'moderado';

--- a/src/lib/financeiro/concentracao-helpers.ts
+++ b/src/lib/financeiro/concentracao-helpers.ts
@@ -17,6 +17,17 @@ import type {
 export const PISO_MODERADO = 25000;
 export const PISO_ALTO = 75000;
 
+/** Cap padrão do PostgREST (CLAUDE.md: capa em 1.000 linhas silencioso). */
+const CAP_POSTGREST = 1000;
+
+/** Títulos VENCIDOS (coluna "vencido" da concentração). Lista POSITIVA — NÃO derivar por
+ *  complemento de "não-vencido": 'PARCIAL' é aberto mas não necessariamente vencido, e
+ *  classificá-lo por complemento inflaria a coluna vencido (achado Codex no código). */
+const OVERDUE_STATUSES = new Set(['ATRASADO', 'VENCIDO']);
+export function isOverdueTitleStatus(status: string | null | undefined): boolean {
+  return status != null && OVERDUE_STATUSES.has(status);
+}
+
 /** menor nº de códigos (share desc) cujo acumulado atinge ≥ 50% da carteira. */
 export function c50(sharesDesc: number[]): number {
   let acc = 0;
@@ -46,6 +57,8 @@ export function classificarFonte(p: {
   if (p.error) return 'indisponivel';
   if (p.countTotal != null && p.countTotal > p.rowsRetornadas) return 'parcial';
   if (p.rowsRetornadas >= p.limit) return 'parcial';
+  // fail-closed (Codex): sem count E batendo o cap padrão do PostgREST → provável truncagem.
+  if (p.countTotal == null && p.rowsRetornadas >= CAP_POSTGREST) return 'parcial';
   return 'ok';
 }
 

--- a/src/lib/financeiro/concentracao-types.ts
+++ b/src/lib/financeiro/concentracao-types.ts
@@ -1,0 +1,47 @@
+// F5 Concentração de recebíveis — tipos puros.
+// Spec: docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md
+// Money-path: ausente ≠ zero — o helper NUNCA calcula sobre fonte não provada.
+
+export type Company = 'oben' | 'colacor' | 'colacor_sc';
+
+/** Status da LEITURA da fonte, atestado pela camada de read (hook). O helper só
+ *  calcula com 'ok'/'parcial'; 'indisponivel' (query falhou/RLS/timeout) NÃO é zero. */
+export type FonteStatus = 'ok' | 'indisponivel' | 'parcial';
+
+/** Título de recebível ABERTO (status_titulo ∈ {A VENCER, ATRASADO}), já filtrado. */
+export interface TituloAberto {
+  omie_codigo_cliente: number | null;
+  saldo: number;
+  atrasado: boolean; // status_titulo === 'ATRASADO'
+}
+
+export type MotivoConcentracao =
+  | 'ok' //            fonte ok/parcial + carteira com linhas válidas
+  | 'sem_carteira' //  fonte ok + 0 títulos válidos → zero PROVADO
+  | 'fonte_indisponivel' // leitura falhou/RLS/timeout → NÃO é zero, não calcula
+  | 'fonte_parcial'; // truncada (cap) ou linha(s) inválida(s) → calcula flagueado
+
+export type ImpactoAbsoluto = 'baixo' | 'moderado' | 'alto';
+
+export interface LinhaExposicao {
+  codigo: number;
+  saldo: number; //             R$ aberto do código
+  vencido: number; //           R$ ATRASADO do código
+  pctVencidoProprio: number; // vencido/saldo ∈ [0,1]
+  share: number; //             saldo/totalAberto ∈ [0,1]
+}
+
+export interface ConcentracaoResult {
+  motivo: MotivoConcentracao;
+  clientes: number | null; //                 nº de códigos distintos válidos
+  totalAberto: number | null; //              0 em sem_carteira; null em indisponivel
+  maiorExposicao: number | null; //           R$ do maior código
+  top1Pct: number | null;
+  top5Pct: number | null;
+  c50: number | null; //                      menor nº de códigos que somam ≥50%
+  hhi: number | null; //                      SECUNDÁRIO
+  nEfetivo: number | null; //                 1/hhi, SECUNDÁRIO
+  impactoAbsoluto: ImpactoAbsoluto | null; //  TOM (nunca oculta topN)
+  topN: LinhaExposicao[]; //                  [] fora de ok/parcial
+  linhasInvalidas: number; //                 saldos/códigos inválidos (dispara fonte_parcial)
+}

--- a/src/lib/financeiro/concentracao-types.ts
+++ b/src/lib/financeiro/concentracao-types.ts
@@ -12,7 +12,7 @@ export type FonteStatus = 'ok' | 'indisponivel' | 'parcial';
 export interface TituloAberto {
   omie_codigo_cliente: number | null;
   saldo: number;
-  atrasado: boolean; // status_titulo === 'ATRASADO'
+  atrasado: boolean; // vencido: status_titulo ∈ {ATRASADO, VENCIDO} (lista positiva)
 }
 
 export type MotivoConcentracao =

--- a/src/pages/FinanceiroDashboard.tsx
+++ b/src/pages/FinanceiroDashboard.tsx
@@ -19,6 +19,8 @@ import { DREComparativo } from '@/components/financeiro/dashboard/DREComparativo
 import { VisaoGeralTab } from '@/components/financeiro/dashboard/VisaoGeralTab';
 import { ContasReceberTab } from '@/components/financeiro/dashboard/ContasReceberTab';
 import { ContasPagarTab } from '@/components/financeiro/dashboard/ContasPagarTab';
+import { ConcentracaoTab } from '@/components/financeiro/dashboard/ConcentracaoTab';
+import { useAuth } from '@/contexts/AuthContext';
 
 const today = new Date();
 const sixMonthsAgo = new Date(today.getFullYear(), today.getMonth() - 6, 1);
@@ -40,6 +42,7 @@ const FinanceiroDashboard = ({ embedded = false }: { embedded?: boolean } = {}) 
   } = useFinanceiro('all');
 
   const { regime } = useFinanceiroRegime();
+  const { isMaster } = useAuth();
   const lockHandler = usePeriodLockHandler();
 
   const [tab, setTab] = useState('visao-geral');
@@ -162,12 +165,15 @@ const FinanceiroDashboard = ({ embedded = false }: { embedded?: boolean } = {}) 
 
       {/* Tabs */}
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList className="grid grid-cols-5 w-full">
+        <TabsList className={isMaster ? 'grid grid-cols-6 w-full' : 'grid grid-cols-5 w-full'}>
           <TabsTrigger value="visao-geral" className="text-xs sm:text-sm">Visão Geral</TabsTrigger>
           <TabsTrigger value="contas-receber" className="text-xs sm:text-sm">A Receber</TabsTrigger>
           <TabsTrigger value="contas-pagar" className="text-xs sm:text-sm">A Pagar</TabsTrigger>
           <TabsTrigger value="fluxo-caixa" className="text-xs sm:text-sm">Fluxo Caixa</TabsTrigger>
           <TabsTrigger value="dre" className="text-xs sm:text-sm">DRE</TabsTrigger>
+          {isMaster && (
+            <TabsTrigger value="concentracao" className="text-xs sm:text-sm">Concentração</TabsTrigger>
+          )}
         </TabsList>
 
         {/* ═══════════ TAB: VISÃO GERAL ═══════════ */}
@@ -280,6 +286,13 @@ const FinanceiroDashboard = ({ embedded = false }: { embedded?: boolean } = {}) 
             <DREComparativo data={drePorEmpresa} ano={dreAno} />
           )}
         </TabsContent>
+
+        {/* ═══════════ TAB: CONCENTRAÇÃO (F5 — master-only) ═══════════ */}
+        {isMaster && (
+          <TabsContent value="concentracao" className="space-y-4 mt-4">
+            <ConcentracaoTab />
+          </TabsContent>
+        )}
       </Tabs>
 
       {loading && (


### PR DESCRIPTION
## F5 — Concentração de recebíveis por cliente (erro PEGN "concentração de crédito")

Frente 5 do pacote anti-endividamento. **Monitor** de concentração de crédito por **código Omie (sacado)** sobre os recebíveis em aberto — aba master-only no `/financeiro`.

### O que entra
- **Helper puro** `concentracao-helpers.ts` (+ tipos), **32 testes vitest** com falsificação.
- **Hook** `useConcentracaoRecebiveis` — lê `fin_contas_receber` (RLS já provado), atesta `FonteStatus` (guarda o cap PostgREST via `count:exact`), filtro aberto = `isOpenTitleStatus` canônico (espelhado no cashflow engine).
- **Aba UI** "Concentração" (master-only) — cards **maior exposição R$ · top-5 · C50 · carteira**, tabela top-N por código (aberto/vencido/%venc/share), HHI/nº efetivo como secundário.

### Money-path (precisão > recall, ausente ≠ zero)
- **Metadata de fonte:** leitura incompleta/erro **nunca vira zero** (`fonte_indisponivel`/`parcial` → não calcula ou flagueia; jamás "sem concentração" fabricado).
- **Linha inválida não some** → `fonte_parcial` + contagem.
- **Materialidade = tom** (baixo/moderado/alto, keyed na maior exposição, política 25k/75k) — **nunca oculta** o painel.
- **Nome v1 = "Cliente #código"** (nome rico é fast-follow) → **zero risco** de nome de outra conta Omie (colisão de código entre contas — confirmado no grounding).
- Copy honesta: **"por código Omie, não consolida grupo econômico"**.

### Revisão
- **Codex adversarial ×2** (xhigh): design (veredito **CONSTRUIR** + 2 P0 + 4 P1) e código (**3 P1** — R$0 fabricado / cap-guard / PARCIAL→vencido — todos corrigidos + falsificados).
- Spec: `docs/superpowers/specs/2026-07-05-concentracao-recebiveis-design.md` (§10 design, §11 código).

### ⚠️ Deploy Lovable
**Sem migration** (só lê `fin_contas_receber`). Deploy = **apenas Publish frontend** (1 camada) — sem SQL Editor, sem validação de banco. Merge na `main` ≠ produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
