### PR TITLE
fix(sync): retry transitório no omie-sync-nfes-recebidas (destrava OBEN)

### DIFF
--- a/supabase/functions/omie-sync-nfes-recebidas/index.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/index.ts
@@ -22,6 +22,7 @@
 //   { "empresa": "OBEN" | "COLACOR" | "ALL", "dias": 30, "fornecedor_codigo_omie": 8689681266 }
 
 import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { classifyOmieResponse, computeBackoffMs } from "./retry.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -33,7 +34,6 @@ const corsHeaders = {
 const OMIE_ENDPOINT = "https://app.omie.com.br/api/v1/produtos/recebimentonfe/";
 const PAGE_SIZE = 50;
 const RATE_LIMIT_DELAY_MS = 1100;
-const RETRY_DELAY_MS = 5000;
 const MAX_RETRIES = 3;
 
 type Empresa = "OBEN" | "COLACOR";
@@ -69,6 +69,10 @@ interface EmpresaSummary {
 }
 
 const TIMEOUT_GUARD_MS = 130_000;
+// Guard do loop PRINCIPAL (syncEmpresa). Com retry em transitório, o loop pode
+// consumir toda a janela e deixar a linha fin_sync_log 'running' órfã (sem
+// completeSync). Cede ANTES do backfill (130s) p/ sobrar tempo ao completeSync.
+const MAIN_LOOP_GUARD_MS = 120_000;
 
 // Tipos minimos pra responses da Omie (campos opcionais — Omie nem sempre devolve tudo)
 interface OmieNFeCabec {
@@ -181,9 +185,12 @@ async function callOmie(
 ): Promise<OmieGenericResponse> {
   const body = { call, app_key, app_secret, param: [param] };
 
-  let attempt = 0;
-  while (attempt < MAX_RETRIES) {
-    attempt++;
+  // Retry alinhado às edges irmãs (omie-vendas-sync): retenta rate-limit E
+  // transitório da Omie (SOAP-ERROR/Application Server/timeout) E HTTP 5xx, com
+  // backoff. 4xx (não-429) falha alto. Após esgotar, LANÇA (OMIE_TRANSIENT) —
+  // nunca devolve faultstring transitório ao caller, senão o syncEmpresa o leria
+  // como erro de negócio e abortaria a página (o incidente OBEN de 05/07).
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     const res = await fetch(OMIE_ENDPOINT, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -193,17 +200,25 @@ async function callOmie(
     let json: OmieGenericResponse;
     try { json = JSON.parse(text) as OmieGenericResponse; } catch { json = { raw: text }; }
 
-    if (res.status === 429 || (json?.faultstring && /rate limit/i.test(json.faultstring))) {
-      console.warn(`[sync-nfes] ${call} rate limit (try ${attempt}/${MAX_RETRIES}) wait ${RETRY_DELAY_MS}ms`);
-      await sleep(RETRY_DELAY_MS);
-      continue;
+    const fs = json?.faultstring ? String(json.faultstring) : undefined;
+    const verdict = classifyOmieResponse(res.status, fs);
+
+    if (verdict.kind === "retry") {
+      if (attempt < MAX_RETRIES) {
+        const delay = computeBackoffMs(fs ?? "", attempt);
+        console.warn(`[sync-nfes] ${call} ${verdict.reason} (retry ${attempt + 1}/${MAX_RETRIES}) wait ${delay / 1000}s`);
+        await sleep(delay);
+        continue;
+      }
+      throw new Error(`OMIE_TRANSIENT ${call}: ${verdict.reason === "rate_limit" ? "rate limit" : "erro transitório"} persistiu após ${MAX_RETRIES} retries`);
     }
-    if (!res.ok) {
+    if (verdict.kind === "permanent") {
       throw new Error(`Omie ${call} HTTP ${res.status}: ${text.slice(0, 400)}`);
     }
+    // "ok" | "fault" → devolve ao caller (fault: ex.: "sem registros" tratado no syncEmpresa)
     return json;
   }
-  throw new Error(`Omie ${call}: rate limit excedido após ${MAX_RETRIES} tentativas`);
+  throw new Error(`Omie ${call}: retries esgotados`); // inalcançável — o loop sempre retorna ou lança
 }
 
 interface MappedNFe {
@@ -386,6 +401,7 @@ async function syncEmpresa(
   empresa: Empresa,
   dias: number,
   fornecedorCodigo: number | undefined,
+  t0: number,
   dataInicialOverride?: string,
   dataFinalOverride?: string,
 ): Promise<EmpresaSummary> {
@@ -421,8 +437,14 @@ async function syncEmpresa(
 
   let pagina = 1;
   let totalPaginas = 1;
+  let interrompidoPorTempo = false;
 
   while (pagina <= totalPaginas) {
+    if (Date.now() - t0 > MAIN_LOOP_GUARD_MS) {
+      console.warn(`[sync-nfes] ${empresa} MAIN_LOOP_GUARD na pág ${pagina} — interrompido p/ garantir completeSync`);
+      interrompidoPorTempo = true;
+      break;
+    }
     let resp: OmieListRecebimentosResponse;
     try {
       const param: Record<string, unknown> = {
@@ -459,6 +481,11 @@ async function syncEmpresa(
     console.log(`[sync-nfes] ${empresa} pag=${pagina}/${totalPaginas} nfes=${nfes.length}`);
 
     for (const nfe of nfes) {
+      if (Date.now() - t0 > MAIN_LOOP_GUARD_MS) {
+        console.warn(`[sync-nfes] ${empresa} MAIN_LOOP_GUARD no meio da pág ${pagina} — interrompido`);
+        interrompidoPorTempo = true;
+        break;
+      }
       const nIdReceb = Number(nfe?.cabec?.nIdReceb ?? 0);
       if (!nIdReceb) {
         summary.erros++;
@@ -475,17 +502,30 @@ async function syncEmpresa(
 
         // ConsultarRecebimento → busca itens e nNumPedCompra
         await sleep(RATE_LIMIT_DELAY_MS);
-        let detalhe: OmieConsultarRecebimentoResponse | null;
+        let detalhe: OmieConsultarRecebimentoResponse;
         try {
           detalhe = (await callOmie(app_key, app_secret, "ConsultarRecebimento", { nIdReceb })) as OmieConsultarRecebimentoResponse;
-          summary.consultas_detalhadas++;
         } catch (errDet) {
           const msgDet = errDet instanceof Error ? errDet.message : String(errDet);
-          console.warn(`[sync-nfes] ${empresa} nIdReceb=${nIdReceb} ConsultarRecebimento falhou: ${msgDet} — tratando como órfã`);
-          detalhe = null;
+          // Falha esgotada/transitória do ConsultarRecebimento NÃO prova ausência de
+          // pedido. Gravar órfã aqui fabricaria dado FALSO (money-path): a NFe pode ter
+          // pedido vinculado que só não pudemos ler agora. Marca erro e PULA — a NFe
+          // volta no próximo run quando a Omie estabilizar.
+          console.warn(`[sync-nfes] ${empresa} nIdReceb=${nIdReceb} ConsultarRecebimento exceção: ${msgDet} — pulando (NÃO vira órfã)`);
+          summary.erros++;
+          continue;
         }
+        // A Omie também devolve erro de negócio como PAYLOAD (faultstring, HTTP 200, sem
+        // exceção). Isso igualmente NÃO prova ausência de pedido → mesmo tratamento: pula,
+        // não vira órfã. Espelha o guard do backfill (if !detalhe || detalhe?.faultstring).
+        if (detalhe?.faultstring) {
+          console.warn(`[sync-nfes] ${empresa} nIdReceb=${nIdReceb} ConsultarRecebimento faultstring: ${String(detalhe.faultstring)} — pulando (NÃO vira órfã)`);
+          summary.erros++;
+          continue;
+        }
+        summary.consultas_detalhadas++;
 
-        const numerosPedido = detalhe ? extractPedidosFromDetalhe(detalhe) : [];
+        const numerosPedido = extractPedidosFromDetalhe(detalhe);
 
         if (numerosPedido.length >= 2) {
           console.log(
@@ -527,11 +567,15 @@ async function syncEmpresa(
       }
     }
 
+    if (interrompidoPorTempo) break;
+
     pagina++;
     if (pagina <= totalPaginas) {
       await sleep(RATE_LIMIT_DELAY_MS);
     }
   }
+
+  if (interrompidoPorTempo) summary.interrompido_por_timeout = true;
 
   return summary;
 }
@@ -807,7 +851,7 @@ Deno.serve(async (req) => {
             erros: 0,
           };
         } else {
-          s = await syncEmpresa(supabase, empresa, dias, fornecedorCodigo, dataInicial, dataFinal);
+          s = await syncEmpresa(supabase, empresa, dias, fornecedorCodigo, t0, dataInicial, dataFinal);
           console.log(
             `[sync-nfes] ${empresa} TOTAL: nfes=${s.nfes_processadas} ` +
             `consultas=${s.consultas_detalhadas} vinculadas=${s.pedidos_vinculados} ` +
@@ -816,7 +860,13 @@ Deno.serve(async (req) => {
           );
         }
 
-        if (!pularBackfill) {
+        // Se o loop principal já estourou o guard de tempo, PULA o backfill: ele só
+        // consumiria a margem que resta p/ o completeSync rodar (senão a linha fica
+        // 'running' órfã). O backfill retroativo pega no próximo ciclo.
+        if (s.interrompido_por_timeout && !pularBackfill) {
+          console.warn(`[sync-nfes] ${empresa} main loop interrompido por tempo — pulando backfill p/ garantir completeSync`);
+        }
+        if (!pularBackfill && !s.interrompido_por_timeout) {
           try {
             const bf = await backfillRawData(supabase, empresa, fornecedorCodigo, t0);
             s.backfill = bf;

--- a/supabase/functions/omie-sync-nfes-recebidas/retry.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/retry.ts
@@ -1,0 +1,58 @@
+// Classificação de erro da Omie para retry — vocabulário alinhado às edges irmãs
+// (omie-vendas-sync/index.ts). PURO e testável (retry_test.ts) porque a decisão
+// "retentar × devolver × falhar alto" é onde os bugs de money-path moram: retentar
+// um 4xx permanente esconde erro de credencial/param; NÃO retentar um SOAP-ERROR
+// transitório aborta o sync (o incidente OBEN de 05/07). O callOmie é só o
+// encanamento que executa o veredito.
+
+// Rate-limit / consumo redundante da Omie → retry com backoff.
+export function isRateLimitOmieFault(fs: string): boolean {
+  return /rate limit/i.test(fs)
+    || fs.includes("Já existe uma requisição desse método")
+    || /consumo redundante/i.test(fs)
+    || fs.includes("REDUNDANT");
+}
+
+// Transitório do lado da Omie (SOAP/app server/timeout) → retry com backoff.
+export function isTransientOmieFault(fs: string): boolean {
+  return fs.includes("SOAP-ERROR")
+    || fs.includes("Broken response")
+    || fs.includes("Application Server")
+    || /timeout/i.test(fs);
+}
+
+export type OmieRetryVerdict =
+  | { kind: "ok" }                                          // 2xx sem faultstring → seguir
+  | { kind: "retry"; reason: "rate_limit" | "transient" }  // transitório → backoff + retry
+  | { kind: "fault" }                                       // faultstring de negócio (ex.: "sem registros") → caller decide
+  | { kind: "permanent" };                                 // 4xx não-429 → falha alta (param/auth/contrato)
+
+// Decide o que fazer com uma resposta da Omie a partir do status HTTP + faultstring.
+// Ordem importa: faultstring transitório/rate-limit vence o status (a Omie devolve
+// HTTP 200 + faultstring transitório). 429 e 5xx SEM faultstring também retentam;
+// 4xx (400/401/403/404) é permanente e precisa falhar alto, nunca ser mascarado
+// por retry. "fault" devolve ao caller — o syncEmpresa distingue "sem registros"
+// (fim normal) de erro de negócio.
+export function classifyOmieResponse(
+  status: number,
+  faultstring: string | undefined,
+): OmieRetryVerdict {
+  if (faultstring) {
+    const fs = String(faultstring);
+    if (isRateLimitOmieFault(fs)) return { kind: "retry", reason: "rate_limit" };
+    if (isTransientOmieFault(fs)) return { kind: "retry", reason: "transient" };
+    return { kind: "fault" };
+  }
+  if (status === 429) return { kind: "retry", reason: "rate_limit" };
+  if (status >= 500) return { kind: "retry", reason: "transient" };
+  if (status >= 400) return { kind: "permanent" };
+  return { kind: "ok" };
+}
+
+// Delay de backoff (ms). Parseia "Aguarde N segundos" da Omie; senão progressivo
+// por tentativa. Mesma fórmula das irmãs: min(requested + 2, 15) * 1000 (teto 15s).
+export function computeBackoffMs(fs: string, attempt: number): number {
+  const waitMatch = fs.match(/Aguarde (\d+) segundos/);
+  const requestedDelay = waitMatch ? parseInt(waitMatch[1], 10) : (attempt + 1) * 5;
+  return Math.min(requestedDelay + 2, 15) * 1000;
+}

--- a/supabase/functions/omie-sync-nfes-recebidas/retry_test.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/retry_test.ts
@@ -1,0 +1,86 @@
+// Testa o CÓDIGO REAL de retry.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test supabase/functions/omie-sync-nfes-recebidas/retry_test.ts
+//
+// Cobre a decisão money-path do incidente OBEN de 05/07 (sync_nfes_recebidas caiu
+// 12x): a Omie devolve HTTP 200 + faultstring transitório e o callOmie antigo só
+// retentava rate-limit → abortava o ListarRecebimentos na 1ª página. As falsificações
+// que importam: (a) "sem registros" NÃO pode virar retry (loop infinito / nunca
+// completa); (b) 4xx NÃO pode virar retry (esconde credencial/param quebrado).
+import {
+  classifyOmieResponse,
+  computeBackoffMs,
+  isRateLimitOmieFault,
+  isTransientOmieFault,
+} from "./retry.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+// ── classifyOmieResponse: o coração da decisão de retry ──
+Deno.test("classifyOmieResponse: faultstring transitório (HTTP 200) → retry (o incidente OBEN)", () => {
+  assertEquals(classifyOmieResponse(200, "SOAP-ERROR: Encoding: string ..."), { kind: "retry", reason: "transient" });
+  assertEquals(classifyOmieResponse(200, "ERROR: Application Server temporariamente indisponível"), { kind: "retry", reason: "transient" });
+  assertEquals(classifyOmieResponse(200, "Broken response from upstream"), { kind: "retry", reason: "transient" });
+  assertEquals(classifyOmieResponse(200, "connection timeout"), { kind: "retry", reason: "transient" });
+});
+
+Deno.test("classifyOmieResponse: rate-limit → retry/rate_limit", () => {
+  assertEquals(classifyOmieResponse(200, "You have hit the rate limit"), { kind: "retry", reason: "rate_limit" });
+  assertEquals(classifyOmieResponse(200, "Consumo redundante detectado"), { kind: "retry", reason: "rate_limit" });
+  assertEquals(classifyOmieResponse(200, "REDUNDANT call"), { kind: "retry", reason: "rate_limit" });
+  assertEquals(classifyOmieResponse(429, undefined), { kind: "retry", reason: "rate_limit" });
+});
+
+Deno.test("classifyOmieResponse: HTTP 5xx sem faultstring → retry/transient", () => {
+  assertEquals(classifyOmieResponse(500, undefined), { kind: "retry", reason: "transient" });
+  assertEquals(classifyOmieResponse(502, undefined), { kind: "retry", reason: "transient" });
+  assertEquals(classifyOmieResponse(503, undefined), { kind: "retry", reason: "transient" });
+});
+
+// FALSIFICAÇÃO 1: "sem registros" é fim NORMAL — jamais retry (senão o sync nunca
+// completa e gasta os 3 retries em toda página vazia).
+Deno.test("classifyOmieResponse: 'sem registros' NÃO é transitório → fault (caller decide fim)", () => {
+  assertEquals(classifyOmieResponse(200, "Não existem registros para a página"), { kind: "fault" });
+  assertEquals(classifyOmieResponse(200, "Nenhum registro encontrado"), { kind: "fault" });
+});
+
+// FALSIFICAÇÃO 2: 4xx permanente jamais retry — precisa falhar alto (credencial/param).
+Deno.test("classifyOmieResponse: 4xx (não-429) → permanent, nunca mascarado por retry", () => {
+  assertEquals(classifyOmieResponse(400, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(401, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(403, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(404, undefined), { kind: "permanent" });
+});
+
+Deno.test("classifyOmieResponse: 2xx limpo → ok", () => {
+  assertEquals(classifyOmieResponse(200, undefined), { kind: "ok" });
+});
+
+// Precedência: faultstring transitório vence o status HTTP (Omie manda 200 + fault).
+Deno.test("classifyOmieResponse: faultstring de negócio (não transitório) → fault", () => {
+  assertEquals(classifyOmieResponse(200, "Cliente não cadastrado no ERP"), { kind: "fault" });
+});
+
+// ── computeBackoffMs: parse "Aguarde N" + progressivo, teto 15s ──
+Deno.test("computeBackoffMs: parseia 'Aguarde N segundos' e aplica +2, teto 15s", () => {
+  assertEquals(computeBackoffMs("Aguarde 3 segundos e tente novamente", 0), 5000);   // (3+2)*1000
+  assertEquals(computeBackoffMs("Aguarde 20 segundos", 0), 15000);                    // (20+2) capado em 15
+});
+
+Deno.test("computeBackoffMs: sem 'Aguarde' → progressivo por tentativa, teto 15s", () => {
+  assertEquals(computeBackoffMs("SOAP-ERROR", 0), 7000);   // (1*5+2)*1000
+  assertEquals(computeBackoffMs("SOAP-ERROR", 1), 12000);  // (2*5+2)*1000
+  assertEquals(computeBackoffMs("SOAP-ERROR", 2), 15000);  // (3*5+2)=17 → teto 15
+});
+
+// ── helpers de vocabulário (sanidade) ──
+Deno.test("isTransientOmieFault / isRateLimitOmieFault: vocabulário e negativos", () => {
+  assertEquals(isTransientOmieFault("SOAP-ERROR"), true);
+  assertEquals(isTransientOmieFault("Application Server down"), true);
+  assertEquals(isTransientOmieFault("sem registros"), false);
+  assertEquals(isRateLimitOmieFault("rate limit exceeded"), true);
+  assertEquals(isRateLimitOmieFault("SOAP-ERROR"), false);
+});


### PR DESCRIPTION
## Problema

Sync `sync_nfes_recebidas` (OBEN) falhou **12 runs consecutivas** em 05/07 (a cada 2h): `0 NFes processadas`, status `error`. Diagnóstico confirmado via `fin_sync_log` + edge logs de produção.

**Causa raiz:** a Omie devolve faultstrings transitórias intermitentes (`SOAP-ERROR` / `Application Server`) como HTTP 200. O `callOmie` do nfes só retentava rate-limit (429) → o faultstring transitório passava direto, o `syncEmpresa` o lia como erro de negócio e abortava o `ListarRecebimentos` na 1ª página. As edges irmãs (`omie-vendas-sync`) já classificam esse vocabulário como transitório e retentam — por isso só o nfes caía (as outras runs OBEN ficavam verdes no mesmo horário).

## Correção (2ª opinião Codex: consult + review do diff)

- **`retry.ts`** (novo, puro/testável): `classifyOmieResponse(status, faultstring)` → `retry` (transitório/rate-limit/5xx) · `fault` (devolve ao caller; ex.: "sem registros") · `permanent` (4xx → falha alto) · `ok`.
- **`callOmie`**: retenta com backoff adaptativo (parseia "Aguarde N segundos", igual às irmãs) e **lança** `OMIE_TRANSIENT` após esgotar — nunca devolve faultstring transitório ao caller.
- **`syncEmpresa`**: guard de tempo no loop principal (evita execução morta sem `completeSync` → linha `running` órfã) + backfill pulado quando interrompido.
- **Órfã falsa** (P1 do Codex review): `ConsultarRecebimento` falho — por exceção **ou** por faultstring-payload — não vira mais órfã; incrementa erro e pula a NFe (money-path: não ter o detalhe ≠ não ter pedido). A NFe volta no próximo run.

## Verificação

- `deno test retry_test.ts` → **10/10** (inclui falsificações: "sem registros" ≠ retry; 4xx ≠ retry; sabotei a classificação de 4xx → vermelho no caso certo → revertido → verde).
- `deno check index.ts` → **OK**.
- `heavy bun run test` → **4525/4525** (zero regressão colateral). Edge Deno fica fora do escopo do `tsc`/`vitest` (`include: ["src/**"]`), por isso o `deno` é o canônico aqui.

## ⚠️ Deploy (manual, pós-merge)

Edge **não** auto-deploya no merge. Após mergear, deployar a função `omie-sync-nfes-recebidas` pelo **chat do Lovable** (ler do repo, verbatim — a pasta inteira, agora com `retry.ts` junto). Validar sem escrever nada: `{ "empresa": "OBEN", "dias": 1, "pular_backfill": true }` → `nfes_processadas > 0` confirma que destravou.

## Nota (não-bloqueante, escopo separado)

O `heavy bun run typecheck` está vermelho, mas **só** em `src/lib/mcp/*` (dep `@lovable.dev/mcp-js` ausente, commit `a708ccc8` de outro PR, idêntico na `main`) — nada tocado aqui. Isso bloqueia o CI/auto-merge de **todo** o repo até ser resolvido em separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
