### PR TITLE
refactor(ux): Loader2 full-page → PageSkeleton em 61 páginas (auditoria 2026-07-06)

### DIFF
--- a/src/pages/Addresses.tsx
+++ b/src/pages/Addresses.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { supabase } from '@/integrations/supabase/client';
 import { MapPin, Plus, Loader2, Home, Building, Trash2, Cloud, Truck } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { toast } from 'sonner';
@@ -209,8 +210,10 @@ const Addresses = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -6,7 +6,8 @@ import { KanbanBoard } from '@/components/KanbanBoard';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import { Loader2, Users, ChevronRight, Clock, MapPin, Mail, BarChart3, Trophy, Gamepad2, BookOpen, DollarSign, Phone, FlaskConical } from 'lucide-react';
+import { Users, ChevronRight, Clock, MapPin, Mail, BarChart3, Trophy, Gamepad2, BookOpen, DollarSign, Phone, FlaskConical } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface OrderWithProfile {
   id: string;
@@ -120,9 +121,9 @@ const Admin = () => {
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-4xl mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminApprovals.tsx
+++ b/src/pages/AdminApprovals.tsx
@@ -7,6 +7,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Loader2, Check, X, UserCheck, Clock, Link2, AlertTriangle } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface PendingUser {
   id: string;
@@ -222,8 +223,10 @@ const AdminApprovals = () => {
 
   if (authLoading || loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-4xl mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminCustomers.tsx
+++ b/src/pages/AdminCustomers.tsx
@@ -1,7 +1,7 @@
 // Clientes (admin) — carteira com scoring, lista densa e perfil 360.
 // Composição: useAdminCustomers (queries/loads/handlers) + CustomerListView / Customer360View.
 // God-component split de src/pages/AdminCustomers.tsx (comportamento 1:1).
-import { Loader2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { AddToolDialog } from '@/components/AddToolDialog';
 import { useAdminCustomers } from '@/components/adminCustomers/useAdminCustomers';
 import { CustomerListView } from '@/components/adminCustomers/CustomerListView';
@@ -35,9 +35,7 @@ const AdminCustomers = () => {
 
   if (authLoading || loading) {
     return (
-      <div className="flex items-center justify-center py-32">
-        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/src/pages/AdminDemandForecast.tsx
+++ b/src/pages/AdminDemandForecast.tsx
@@ -5,11 +5,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { 
-  Loader2, 
-  AlertTriangle, 
+import {
+  AlertTriangle,
   Clock, 
   Calendar, 
   Phone, 
@@ -209,9 +209,9 @@ const AdminDemandForecast = () => {
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="cockpit" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminEstoquePicking.tsx
+++ b/src/pages/AdminEstoquePicking.tsx
@@ -6,7 +6,6 @@ import { shouldRedirectToMobile, getForceFullPref, setForceFull } from "@/lib/pi
 import { supabase } from "@/integrations/supabase/client";
 import {
   Boxes,
-  Loader2,
   ClipboardList,
   Clock,
   AlertTriangle,
@@ -21,6 +20,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -226,11 +226,7 @@ function PedidosASepararTab({ account }: { account: string }) {
     );
 
   if (isLoading)
-    return (
-      <div className="flex justify-center py-12 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin mr-2" /> Carregando...
-      </div>
-    );
+    return <PageSkeleton variant="list" />;
 
   const pedidos = data ?? [];
 
@@ -345,11 +341,7 @@ function PickingTab({ account }: { account: string }) {
   };
 
   if (isLoading)
-    return (
-      <div className="flex justify-center py-12 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin mr-2" /> Carregando...
-      </div>
-    );
+    return <PageSkeleton variant="list" />;
 
   return (
     <div className="space-y-4">
@@ -493,9 +485,7 @@ function EstoqueTab({ account }: { account: string }) {
           />
         </div>
         {isLoading ? (
-          <div className="flex justify-center py-8 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin mr-2" /> Carregando...
-          </div>
+          <PageSkeleton variant="list" />
         ) : (
           <Table>
             <TableHeader>
@@ -555,11 +545,7 @@ function MovimentacoesTab() {
   });
 
   if (isLoading)
-    return (
-      <div className="flex justify-center py-12 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin mr-2" /> Carregando...
-      </div>
-    );
+    return <PageSkeleton variant="list" />;
 
   return (
     <Card>
@@ -639,11 +625,7 @@ function AuditoriaTab({ account }: { account: string }) {
   });
 
   if (isLoading)
-    return (
-      <div className="flex justify-center py-12 text-muted-foreground">
-        <Loader2 className="h-5 w-5 animate-spin mr-2" /> Carregando...
-      </div>
-    );
+    return <PageSkeleton variant="list" />;
 
   return (
     <Card>

--- a/src/pages/AdminEstoqueRecebimento.tsx
+++ b/src/pages/AdminEstoqueRecebimento.tsx
@@ -5,7 +5,6 @@ import { supabase } from "@/integrations/supabase/client";
 import { spDayRangeUtc } from "@/lib/time/sp-day";
 import {
   PackageCheck,
-  Loader2,
   FileWarning,
   Truck,
   CheckCircle2,
@@ -14,6 +13,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -30,12 +30,7 @@ const WAREHOUSE_BY_EMPRESA: Record<string, string> = {
   COLACOR: "b6d3569b-5952-4547-a118-4ddfe0a85ba3",
 };
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 function KpiCards({ empresa }: { empresa: string }) {
   const warehouseId = WAREHOUSE_BY_EMPRESA[empresa];

--- a/src/pages/AdminKnowledgeBase.tsx
+++ b/src/pages/AdminKnowledgeBase.tsx
@@ -15,7 +15,8 @@ import {
   TabsTrigger,
   TabsContent,
 } from '@/components/ui/tabs';
-import { Upload, Loader2, FileText } from 'lucide-react';
+import { Upload, FileText } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 export default function AdminKnowledgeBase() {
   const { data, isLoading } = useKnowledgeBaseList();
@@ -85,9 +86,7 @@ export default function AdminKnowledgeBase() {
 
           {/* Lista de documentos */}
           {isLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-            </div>
+            <PageSkeleton variant="list" />
           ) : !data || data.length === 0 ? (
             <Card className="p-8 text-center text-xs text-muted-foreground">
               <FileText className="w-8 h-8 mx-auto mb-2 opacity-40" />

--- a/src/pages/AdminKnowledgeBaseDetail.tsx
+++ b/src/pages/AdminKnowledgeBaseDetail.tsx
@@ -8,7 +8,8 @@ import { KbSpecsEditButton } from '@/components/knowledge-base/KbSpecsEditButton
 import { Badge } from '@/components/ui/badge';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
-import { Loader2, Database, Sparkles } from 'lucide-react';
+import { Database, Sparkles } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import type { KbDocument } from '@/lib/knowledge-base/types';
 import { useKbProductSpecs } from '@/hooks/useKbProductSpecs';
 import { VersionHistory } from '@/components/knowledge-base/VersionHistory';
@@ -49,8 +50,8 @@ export default function AdminKnowledgeBaseDetail() {
 
   if (isLoading) {
     return (
-      <div className="container mx-auto p-4 flex justify-center">
-        <Loader2 className="animate-spin" />
+      <div className="container mx-auto p-4">
+        <PageSkeleton variant="detail" />
       </div>
     );
   }

--- a/src/pages/AdminLoyalty.tsx
+++ b/src/pages/AdminLoyalty.tsx
@@ -1,7 +1,7 @@
 // Fidelidade (loyalty) — pontos, tiers, ajustes e visão econômica.
 // Composição: useAdminLoyalty (dados/estado) + stats + insights + lista/detalhe + dialog.
 // God-component split de src/pages/AdminLoyalty.tsx (comportamento 1:1).
-import { Loader2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useAdminLoyalty } from '@/components/loyalty/useAdminLoyalty';
 import { AdjustDialog } from '@/components/loyalty/AdjustDialog';
 import { CustomerDetail } from '@/components/loyalty/CustomerDetail';
@@ -42,9 +42,9 @@ export default function AdminLoyalty() {
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminOrderDetail.tsx
+++ b/src/pages/AdminOrderDetail.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'react-router-dom';
 import { OrderChat } from '@/components/OrderChat';
 import { SendingQualityChecklist } from '@/components/SendingQualityChecklist';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Loader2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useAdminOrderDetail } from '@/hooks/useAdminOrderDetail';
 import { OrderCustomerHeader } from '@/components/admin-order/OrderCustomerHeader';
 import { OrderStatusSelect } from '@/components/admin-order/OrderStatusSelect';
@@ -35,9 +35,9 @@ const AdminOrderDetail = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="detail" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminPriceTable.tsx
+++ b/src/pages/AdminPriceTable.tsx
@@ -9,6 +9,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Loader2, Save, DollarSign } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface DefaultPrice {
   id: string;
@@ -136,9 +137,9 @@ const AdminPriceTable = () => {
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminProductivity.tsx
+++ b/src/pages/AdminProductivity.tsx
@@ -3,7 +3,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
-import { Loader2, BarChart3, Clock, Wrench, Star, TrendingUp, CheckCircle2 } from 'lucide-react';
+import { BarChart3, Clock, Wrench, Star, TrendingUp, CheckCircle2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, CartesianGrid, PieChart, Pie, Cell } from 'recharts';
 import { format, subDays, differenceInHours } from 'date-fns';
 
@@ -123,9 +124,9 @@ const AdminProductivity = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="cockpit" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminReposicaoCadastros.tsx
+++ b/src/pages/AdminReposicaoCadastros.tsx
@@ -2,9 +2,10 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { Database, Loader2, ShoppingCart, Network, Layers, Send, Building2, AlertTriangle, Link2 } from "lucide-react";
+import { Database, ShoppingCart, Network, Layers, Send, Building2, AlertTriangle, Link2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -25,12 +26,7 @@ const AdminReposicaoGruposProducao = lazy(() => import("./AdminReposicaoGruposPr
 const AdminReposicaoAplicacao = lazy(() => import("./AdminReposicaoAplicacao"));
 const AdminSkuMapeamento = lazy(() => import("./AdminSkuMapeamento"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 /* ─── KPI Cards ─── */
 function KpiCards() {
@@ -333,9 +329,7 @@ function HistoricoPedidosCiclos() {
         </div>
 
         {isLoading ? (
-          <div className="flex items-center justify-center py-12 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin mr-2" /> Carregando ciclos...
-          </div>
+          <PageSkeleton variant="list" />
         ) : rows.length === 0 ? (
           <div className="py-12 text-center text-sm text-muted-foreground">
             Nenhum ciclo encontrado para o período

--- a/src/pages/AdminReposicaoHistorico.tsx
+++ b/src/pages/AdminReposicaoHistorico.tsx
@@ -13,7 +13,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ChevronLeft, ChevronRight, ArrowLeft, Loader2 } from "lucide-react";
+import { ChevronLeft, ChevronRight, ArrowLeft } from "lucide-react";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 
 const PAGE_SIZE = 50;
 
@@ -95,9 +96,7 @@ export default function AdminReposicaoHistorico() {
         </CardHeader>
         <CardContent>
           {isLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="h-6 w-6 animate-spin" />
-            </div>
+            <PageSkeleton variant="list" />
           ) : (
             <Table>
               <TableHeader>

--- a/src/pages/AdminReposicaoMercado.tsx
+++ b/src/pages/AdminReposicaoMercado.tsx
@@ -2,9 +2,10 @@ import { lazy, Suspense, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { TrendingUp, Loader2, Tag, ArrowUpRight, Handshake, Sparkles, Building2 } from "lucide-react";
+import { TrendingUp, Tag, ArrowUpRight, Handshake, Sparkles, Building2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -24,12 +25,7 @@ const AdminReposicaoPromocoes = lazy(() => import("./AdminReposicaoPromocoes"));
 const AdminReposicaoAumentos = lazy(() => import("./AdminReposicaoAumentos"));
 const AdminReposicaoNegociacaoParalela = lazy(() => import("./AdminReposicaoNegociacaoParalela"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 /* ─── KPI Cards ─── */
 function KpiCards() {

--- a/src/pages/AdminReposicaoParametros.tsx
+++ b/src/pages/AdminReposicaoParametros.tsx
@@ -2,10 +2,11 @@ import { lazy, Suspense, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
-import { Settings, Loader2, AlertTriangle, Truck, Building2, Sparkles, ArrowRight } from "lucide-react";
+import { Settings, AlertTriangle, Truck, Building2, Sparkles, ArrowRight } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -29,12 +30,7 @@ const AdminReposicaoHistorico = lazy(() => import("./AdminReposicaoHistorico"));
 const AdminReposicaoAlertas = lazy(() => import("./AdminReposicaoAlertas"));
 const AdminReposicaoSlaFornecedor = lazy(() => import("./AdminReposicaoSlaFornecedor"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 /* ─── KPI Cards ─── */
 function KpiCards() {

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -20,6 +20,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Clock, CloudDownload, Eye, Loader2, Zap } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
@@ -676,9 +677,7 @@ export default function AdminReposicaoPedidos() {
             </CardHeader>
             <CardContent>
               {isLoading ? (
-                <div className="flex items-center justify-center py-12">
-                  <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-                </div>
+                <PageSkeleton variant="list" />
               ) : ativos.length === 0 ? (
                 <div className="text-center py-12 text-muted-foreground">
                   {historico.length > 0

--- a/src/pages/AdminRoutePlanner.tsx
+++ b/src/pages/AdminRoutePlanner.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, Navigation, CheckCircle2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { formatDuration } from '@/components/reposicao/routePlanner/renderHelpers';
@@ -276,9 +277,9 @@ const AdminRoutePlanner = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-4xl mx-auto">
+          <PageSkeleton variant="auto" />
+        </main>
       </div>
     );
   }

--- a/src/pages/AdminStandardProcesses.tsx
+++ b/src/pages/AdminStandardProcesses.tsx
@@ -5,7 +5,8 @@ import { StandardProcessRow } from '@/components/standard-process/StandardProces
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Plus, Loader2, Factory, Search } from 'lucide-react';
+import { Plus, Factory, Search } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { StandardProcessStatus } from '@/lib/standard-process/types';
 
@@ -72,9 +73,7 @@ export default function AdminStandardProcesses() {
       </div>
 
       {isLoading ? (
-        <div className="flex justify-center py-8">
-          <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
-        </div>
+        <PageSkeleton variant="list" />
       ) : filtered.length === 0 ? (
         <Card className="p-8 text-center text-xs text-muted-foreground">
           <Factory className="w-8 h-8 mx-auto mb-2 opacity-40" />

--- a/src/pages/AdminTraining.tsx
+++ b/src/pages/AdminTraining.tsx
@@ -12,6 +12,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Loader2, Plus, Trash2, BookOpen, Edit, GripVertical } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface QuizQuestion {
   question: string;
@@ -156,9 +157,9 @@ const AdminTraining = () => {
   if (authLoading || loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-4xl mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { Loader2, Wrench } from 'lucide-react';
+import { Wrench } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { supabase } from '@/integrations/supabase/client';
 import { cn } from '@/lib/utils';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { LoginForm } from '@/components/auth/LoginForm';
 import { SignupForm } from '@/components/auth/SignupForm';
 import { handleInputFormat, INITIAL_FORM_DATA } from '@/components/auth/authSchemas';
@@ -142,11 +143,8 @@ const Auth = () => {
 
   if (authLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="w-10 h-10 animate-spin text-primary" />
-          <p className="text-sm text-muted-foreground">Carregando...</p>
-        </div>
+      <div className="min-h-screen bg-background">
+        <PageSkeleton variant="auto" />
       </div>
     );
   }

--- a/src/pages/ExecutiveDashboard.tsx
+++ b/src/pages/ExecutiveDashboard.tsx
@@ -12,6 +12,7 @@ import {
   Loader2, TrendingUp, DollarSign, BarChart3, Users,
   RefreshCw, Brain, Eye, Activity
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
@@ -56,8 +57,10 @@ const ExecutiveDashboard = () => {
 
   if (roleLoading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="px-4 py-4 max-w-lg mx-auto">
+          <PageSkeleton variant="cockpit" />
+        </main>
       </div>
     );
   }
@@ -135,9 +138,7 @@ const ExecutiveDashboard = () => {
         </div>
 
         {loading ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="w-6 h-6 animate-spin text-primary" />
-          </div>
+          <PageSkeleton variant="list" />
         ) : filteredScores.length === 0 ? (
           <Card>
             <CardContent className="p-6 text-center">

--- a/src/pages/FarmerBundles.tsx
+++ b/src/pages/FarmerBundles.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Loader2, Package, RefreshCw, BarChart3 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useFarmerBundles } from '@/components/farmer/bundles/useFarmerBundles';
 import { CustomerBundleCard } from '@/components/farmer/bundles/CustomerBundleCard';
 import { RuleCard } from '@/components/farmer/bundles/RuleCard';
@@ -64,7 +65,7 @@ const FarmerBundles = () => {
 
           <TabsContent value="bundles" className="space-y-3 mt-3">
             {loading && !customerBundles.length ? (
-              <div className="flex justify-center py-8"><Loader2 className="w-6 h-6 animate-spin text-primary" /></div>
+              <PageSkeleton variant="list" />
             ) : customerBundles.length === 0 ? (
               <Card><CardContent className="p-6 text-center"><Package className="w-8 h-8 mx-auto mb-2 opacity-40" /><p className="text-xs text-muted-foreground">Clique em "Calcular" para gerar bundles.</p></CardContent></Card>
             ) : (

--- a/src/pages/FarmerIPFDashboard.tsx
+++ b/src/pages/FarmerIPFDashboard.tsx
@@ -10,6 +10,7 @@ import {
   Loader2, TrendingUp, DollarSign, BarChart3, ShieldCheck,
   RefreshCw, Layers, Target, type LucideIcon
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 
@@ -63,9 +64,7 @@ const FarmerIPFDashboard = () => {
         </Button>
 
         {loading ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="w-6 h-6 animate-spin text-primary" />
-          </div>
+          <PageSkeleton variant="auto" />
         ) : !latestScore ? (
           <Card>
             <CardContent className="p-6 text-center">

--- a/src/pages/FarmerLOCC.tsx
+++ b/src/pages/FarmerLOCC.tsx
@@ -7,9 +7,10 @@ import { useFarmerScoring } from '@/hooks/useFarmerScoring';
 import { useFarmerMetrics } from '@/hooks/useFarmerMetrics';
 import { useAuth } from '@/contexts/AuthContext';
 import {
-  Loader2, Heart, Target, Shield, FlaskConical,
+  Heart, Target, Shield, FlaskConical,
   Phone, Package, Radio, Zap, DollarSign,
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { type TabKey } from '@/components/farmer/locc/types';
 import { TabSkeleton } from '@/components/farmer/locc/primitives';
 import { OverviewTab } from '@/components/farmer/locc/OverviewTab';
@@ -42,8 +43,10 @@ const FarmerLOCC = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="px-4 py-4 max-w-lg mx-auto">
+          <PageSkeleton variant="cockpit" />
+        </main>
       </div>
     );
   }

--- a/src/pages/FarmerTacticalPlan.tsx
+++ b/src/pages/FarmerTacticalPlan.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
-import { Loader2, Target, FileText } from 'lucide-react';
+import { Target, FileText } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Card, CardContent } from '@/components/ui/card';
 import { useAuth } from '@/contexts/AuthContext';
 import { useFarmerTacticalPlan } from '@/components/farmer/tacticalPlan/useFarmerTacticalPlan';
@@ -65,9 +66,7 @@ const FarmerTacticalPlan = () => {
 
         {/* Plans List */}
         {loading ? (
-          <div className="flex justify-center py-8">
-            <Loader2 className="w-6 h-6 animate-spin text-primary" />
-          </div>
+          <PageSkeleton variant="list" />
         ) : plans.length === 0 ? (
           <Card>
             <CardContent className="p-6 text-center">

--- a/src/pages/FinanceiroAnalise.tsx
+++ b/src/pages/FinanceiroAnalise.tsx
@@ -2,7 +2,6 @@ import { lazy, Suspense, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
   BarChart3,
-  Loader2,
   Tags,
   ArrowLeftRight,
   Receipt,
@@ -11,6 +10,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -25,12 +25,7 @@ const FinanceiroTributario = lazy(() => import("./FinanceiroTributario"));
 const FinanceiroMapping = lazy(() => import("./FinanceiroMapping"));
 const FinanceiroSync = lazy(() => import("./FinanceiroSync"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 function KpiCards({ empresa }: { empresa: string }) {
   // TODO: buscar contagens reais do Supabase filtradas por empresa={empresa}

--- a/src/pages/FinanceiroAnalytics.tsx
+++ b/src/pages/FinanceiroAnalytics.tsx
@@ -8,9 +8,10 @@ import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContex
 import { getAnaliseDimensional, type Dimensao, type AnaliseDimensional } from '@/services/financeiroV2Service';
 import { downloadCSV } from '@/services/financeiroService';
 import {
-  Loader2, Building2, BarChart3, PieChart, Download,
+  Building2, BarChart3, PieChart, Download,
   ArrowDownCircle, ArrowUpCircle
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 const fmtCompact = (v: number) => {
@@ -184,9 +185,7 @@ const FinanceiroAnalytics = () => {
       <Card>
         <CardContent className="p-0">
           {loading ? (
-            <div className="flex items-center justify-center py-16">
-              <Loader2 className="w-6 h-6 animate-spin" />
-            </div>
+            <PageSkeleton variant="list" className="p-4" />
           ) : data.length === 0 ? (
             <div className="text-center py-16 text-muted-foreground">
               <BarChart3 className="w-10 h-10 mx-auto mb-3 opacity-40" />

--- a/src/pages/FinanceiroConciliacao.tsx
+++ b/src/pages/FinanceiroConciliacao.tsx
@@ -9,10 +9,11 @@ import { COMPANIES, ALL_COMPANIES, type Company } from '@/contexts/CompanyContex
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import {
-  Loader2, CheckCircle2, XCircle, AlertTriangle, ArrowLeftRight,
+  CheckCircle2, XCircle, AlertTriangle, ArrowLeftRight,
   Building2, Search, Ban,
   type LucideIcon,
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import type {
   FinConciliacaoRow,
   FinContaCorrenteRow,
@@ -271,7 +272,7 @@ const FinanceiroConciliacao = () => {
       <Card>
         <CardContent className="p-0">
           {loading ? (
-            <div className="flex items-center justify-center py-16"><Loader2 className="w-6 h-6 animate-spin" /></div>
+            <PageSkeleton variant="list" className="p-4" />
           ) : filtered.length === 0 ? (
             <div className="text-center py-16 text-muted-foreground">
               {total === 0

--- a/src/pages/FinanceiroGestao.tsx
+++ b/src/pages/FinanceiroGestao.tsx
@@ -6,7 +6,6 @@ import { somarSaldoAberto } from "@/services/financeiroService";
 import type { Company } from "@/contexts/CompanyContext";
 import {
   Wallet,
-  Loader2,
   TrendingDown,
   TrendingUp,
   Banknote,
@@ -15,6 +14,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -29,12 +29,7 @@ const FinanceiroConciliacao = lazy(() => import("./FinanceiroConciliacao"));
 const FinanceiroOrcamento = lazy(() => import("./FinanceiroOrcamento"));
 const FinanceiroFechamento = lazy(() => import("./FinanceiroFechamento"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 const fmtBRL = (v: number) =>
   v.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });

--- a/src/pages/FinanceiroMapping.tsx
+++ b/src/pages/FinanceiroMapping.tsx
@@ -15,6 +15,7 @@ import {
 import {
   Loader2, Save, Trash2, Building2, Search, Layers, AlertTriangle, History
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { AuditTrailDrawer } from '@/components/financeiro/AuditTrailDrawer';
 import { useSuggestedMapping } from '@/hooks/useSuggestedMapping';
 import { useQueryClient } from '@tanstack/react-query';
@@ -310,9 +311,7 @@ const FinanceiroMapping = () => {
         </CardHeader>
         <CardContent className="p-0">
           {loading ? (
-            <div className="p-8 text-center">
-              <Loader2 className="w-6 h-6 animate-spin mx-auto text-muted-foreground" />
-            </div>
+            <PageSkeleton variant="list" className="p-4" />
           ) : (
             <div className="overflow-x-auto">
               <Table>

--- a/src/pages/FinanceiroOrcamento.tsx
+++ b/src/pages/FinanceiroOrcamento.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useState, useEffect, useCallback, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -311,7 +312,7 @@ const FinanceiroOrcamento = () => {
   };
 
   if (loading) {
-    return <div className="flex items-center justify-center py-24"><Loader2 className="w-8 h-8 animate-spin" /></div>;
+    return <PageSkeleton variant="list" />;
   }
 
   return (

--- a/src/pages/FinanceiroTributario.tsx
+++ b/src/pages/FinanceiroTributario.tsx
@@ -7,8 +7,9 @@ import { Progress } from '@/components/ui/progress';
 import { COMPANIES, ALL_COMPANIES } from '@/contexts/CompanyContext';
 import { getDRE, type FinDRE } from '@/services/financeiroService';
 import {
-  Loader2, Calendar, AlertTriangle, Receipt
+  Calendar, AlertTriangle, Receipt
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 const fmtCompact = (v: number) => {
@@ -71,7 +72,7 @@ const FinanceiroTributario = () => {
   };
 
   if (loading) {
-    return <div className="flex items-center justify-center py-24"><Loader2 className="w-8 h-8 animate-spin" /></div>;
+    return <PageSkeleton variant="cockpit" />;
   }
 
   return (

--- a/src/pages/Gamification.tsx
+++ b/src/pages/Gamification.tsx
@@ -11,8 +11,9 @@ import { useAuth } from '@/contexts/AuthContext';
 import { 
   Trophy, Shield, Target, BookOpen, Users, Zap, 
   Heart, ChevronRight, Star, Award, TrendingUp,
-  Loader2, Lock, Lightbulb, ArrowRight
+  Lock, Lightbulb, ArrowRight
 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 const LEVEL_CONFIG = [
   { level: 1, name: 'Operacional', icon: Target, color: 'text-muted-foreground', bg: 'bg-muted' },
@@ -94,9 +95,9 @@ const Gamification = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/GestaoAdmin.tsx
+++ b/src/pages/GestaoAdmin.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Shield,
-  Loader2,
   CheckCircle2,
   FileBarChart,
   RefreshCw,
@@ -12,6 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -25,12 +25,7 @@ const AdminPanel = lazy(() => import("./Admin"));
 const AdminMonthlyReports = lazy(() => import("./AdminMonthlyReports"));
 const AdminAnalyticsSync = lazy(() => import("./AdminAnalyticsSync"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 const safeQuery = async <T,>(fn: () => Promise<T>, fallback: T): Promise<T> => {
   try {

--- a/src/pages/GestaoGovernanca.tsx
+++ b/src/pages/GestaoGovernanca.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   ShieldCheck,
-  Loader2,
   Users,
   KeyRound,
   Sliders,
@@ -12,6 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -28,12 +28,7 @@ const GovernanceAudit = lazy(() => import("./GovernanceAudit"));
 const GovernanceIniciativas = lazy(() => import("./GovernanceIniciativas"));
 const Settings = lazy(() => import("./SettingsConfig"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 const safeQuery = async <T,>(fn: () => Promise<T>, fallback: T): Promise<T> => {
   try {

--- a/src/pages/GestaoGruposCliente.tsx
+++ b/src/pages/GestaoGruposCliente.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { Users, Plus, Trash2, ArrowRight, Building2, Loader2 } from 'lucide-react';
+import { Users, Plus, Trash2, ArrowRight, Building2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -104,11 +105,7 @@ export default function GestaoGruposCliente() {
         </Button>
       </header>
 
-      {isLoading && (
-        <div className="flex justify-center py-12">
-          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-        </div>
-      )}
+      {isLoading && <PageSkeleton variant="list" />}
 
       {error && (
         <p className="text-sm text-status-error">Não consegui carregar os grupos: {error instanceof Error ? error.message : 'erro'}.</p>

--- a/src/pages/GovernanceCompanies.tsx
+++ b/src/pages/GovernanceCompanies.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Loader2, Building2, Save } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface CompanyProfile {
   id: string;
@@ -73,9 +74,7 @@ export default function GovernanceCompanies() {
 
   if (authLoading || roleLoading || loading) {
     return (
-      <div className="flex items-center justify-center py-32">
-        <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/src/pages/GrupoCliente360.tsx
+++ b/src/pages/GrupoCliente360.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, Loader2, BarChart3 } from 'lucide-react';
+import { ArrowLeft, Building2, Plus, Trash2, Wallet, Users, BarChart3 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -33,9 +34,7 @@ export default function GrupoCliente360() {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-16">
-        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-      </div>
+      <PageSkeleton variant="detail" />
     );
   }
 

--- a/src/pages/Loyalty.tsx
+++ b/src/pages/Loyalty.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { ArrowLeft, Star, Gift, Trophy, TrendingUp, Loader2, BookOpen, Target } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -99,8 +100,10 @@ export default function Loyalty() {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <Loader2 className="w-6 h-6 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/OAuthConsent.tsx
+++ b/src/pages/OAuthConsent.tsx
@@ -10,6 +10,7 @@ import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';
 import { Loader2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
 
 // Wrapper tipado local pro namespace `supabase.auth.oauth` (ainda em beta no
@@ -78,8 +79,10 @@ export default function OAuthConsent() {
 
   if (!details) {
     return (
-      <main className="min-h-screen flex items-center justify-center">
-        <Loader2 className="w-6 h-6 animate-spin text-primary" />
+      <main className="min-h-screen bg-background px-4 pt-16">
+        <div className="max-w-lg mx-auto">
+          <PageSkeleton variant="auto" />
+        </div>
       </main>
     );
   }

--- a/src/pages/OrderDetail.tsx
+++ b/src/pages/OrderDetail.tsx
@@ -1,5 +1,6 @@
 import { useParams, useNavigate } from 'react-router-dom';
 import { Phone, MessageCircle, Copy, Check, RefreshCw, Camera, Loader2, AlertTriangle, ExternalLink } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useState, useEffect } from 'react';
 
 // Shape de cada item do pedido (jsonb em orders.items). Só campos consumidos no UI.
@@ -153,8 +154,10 @@ const OrderDetail = () => {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <Loader2 className="w-6 h-6 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="detail" />
+        </main>
       </div>
     );
   }

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -4,6 +4,7 @@ import { OrderCard } from '@/components/OrderCard';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { Loader2, Package, Plus, AlertCircle, Search } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { supabase } from '@/integrations/supabase/client';
@@ -152,8 +153,10 @@ const Orders = () => {
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
+      <div className="min-h-screen bg-background pb-24">
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/PedidoProgramadoDetalhe.tsx
+++ b/src/pages/PedidoProgramadoDetalhe.tsx
@@ -9,7 +9,8 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
-import { ChevronLeft, Loader2, Send, Trash2, XCircle } from 'lucide-react';
+import { ChevronLeft, Send, Trash2, XCircle } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { toast } from 'sonner';
 import {
   usePedidoProgramadoDetalhe,
@@ -50,9 +51,7 @@ const PedidoProgramadoDetalhe = () => {
 
   if (isPending || !data) {
     return (
-      <div className="flex items-center justify-center pt-32">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      <PageSkeleton variant="detail" />
     );
   }
   const { pedido, itens, envios } = data;

--- a/src/pages/PedidosProgramados.tsx
+++ b/src/pages/PedidosProgramados.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/EmptyState';
 import { CalendarClock, CalendarDays, ChevronLeft, FileUp, List, Loader2, Settings2 } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { usePedidosProgramadosLista, usePedidosProgramadosMutations } from '@/hooks/usePedidosProgramados';
 import { PedidosProgramadosConfigDialog } from '@/components/pedidosProgramados/ConfigDialog';
 import { CalendarioFaturamento } from '@/components/pedidosProgramados/CalendarioFaturamento';
@@ -89,9 +90,7 @@ const PedidosProgramados = () => {
           onMudarMes={(mes) => setUrlState({ mes })}
         />
       ) : isPending ? (
-        <div className="flex items-center justify-center pt-24">
-          <Loader2 className="w-6 h-6 animate-spin text-primary" />
-        </div>
+        <PageSkeleton variant="list" />
       ) : !pedidos || pedidos.length === 0 ? (
         <EmptyState
           icon={CalendarClock}

--- a/src/pages/PerformanceHub.tsx
+++ b/src/pages/PerformanceHub.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Activity,
-  Loader2,
   Trophy,
   Target,
   Phone,
@@ -12,6 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -26,12 +26,7 @@ const FarmerCalls = lazy(() => import("./FarmerCalls"));
 const CoachingSPIN = lazy(() => import("./CoachingSPIN"));
 const FarmerCopilot = lazy(() => import("./FarmerCopilot"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 // Helper para queries em tabelas que podem nao existir nos types
 const safeQuery = async <T,>(fn: () => Promise<T>, fallback: T): Promise<T> => {

--- a/src/pages/ProducaoBomExcecoes.tsx
+++ b/src/pages/ProducaoBomExcecoes.tsx
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { supabase } from '@/integrations/supabase/client';
 import { Loader2, AlertTriangle, Search, CheckCircle2, Wrench, ListChecks, PackageSearch } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { toast } from 'sonner';
 import { decodeHtmlEntities } from '@/lib/utils';
 
@@ -165,9 +166,7 @@ const ProducaoBomExcecoes = () => {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/src/pages/ProductionOrders.tsx
+++ b/src/pages/ProductionOrders.tsx
@@ -6,6 +6,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { Loader2, CheckCircle2, Clock, Package, Factory } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { toast } from 'sonner';
@@ -96,9 +97,7 @@ const ProductionOrders = () => {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { MapPin, Phone, Mail, ChevronRight, LogOut, HelpCircle, Loader2, Wrench, Camera, Pencil, Check, X, Plus, Clock } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -204,9 +205,9 @@ const Profile = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="form" />
+        </main>
       </div>
     );
   }

--- a/src/pages/QualityChecklist.tsx
+++ b/src/pages/QualityChecklist.tsx
@@ -10,6 +10,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { Loader2, Camera, CheckCircle2, XCircle, Upload, Shield } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface OrderItem {
   category: string;
@@ -202,9 +203,9 @@ const QualityChecklist = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="form" />
+        </main>
       </div>
     );
   }

--- a/src/pages/RecurringSchedules.tsx
+++ b/src/pages/RecurringSchedules.tsx
@@ -10,6 +10,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { CalendarClock, Plus, Loader2, Trash2, Wrench, Pause, Play } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { format, addDays } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { DELIVERY_OPTIONS, TIME_SLOTS } from '@/types';
@@ -159,9 +160,9 @@ const RecurringSchedules = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/SalesOrderEdit.tsx
+++ b/src/pages/SalesOrderEdit.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, Save, Plus, AlertCircle, X } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useSalesOrderEdit } from '@/components/salesOrderEdit/useSalesOrderEdit';
 import { PaymentComboboxEdit } from '@/components/salesOrderEdit/PaymentComboboxEdit';
 import { AddProductSearch } from '@/components/salesOrderEdit/AddProductSearch';
@@ -43,9 +44,9 @@ const SalesOrderEdit = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="form" />
+        </main>
       </div>
     );
   }

--- a/src/pages/SalesOrders.tsx
+++ b/src/pages/SalesOrders.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Loader2, ShoppingCart, Trash2, ChevronLeft, TriangleAlert } from 'lucide-react';
+import { ShoppingCart, Trash2, ChevronLeft, TriangleAlert } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { EmptyState } from '@/components/EmptyState';
 import { BulkActionsBar } from '@/components/ui/bulk-actions-bar';
 import { decodeHtml, type OrderFeedRow } from '@/components/salesOrders/types';
@@ -41,9 +42,7 @@ const SalesOrders = () => {
 
   if (authLoading || loading) {
     return (
-      <div className="flex items-center justify-center pt-32">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/src/pages/SalesPrintDashboard.tsx
+++ b/src/pages/SalesPrintDashboard.tsx
@@ -5,7 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { supabase } from '@/integrations/supabase/client';
 import { useQuery } from '@tanstack/react-query';
-import { Loader2, Printer, ArrowLeft } from 'lucide-react';
+import { Printer, ArrowLeft } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { format } from 'date-fns';
 import { janelaQueryDiaCivil, pedidoNoDiaCivil } from '@/lib/pedido/dia-civil';
 import { openPrintOrder } from '@/components/OrderPrintLayout';
@@ -402,9 +403,7 @@ const SalesPrintDashboard = () => {
 
         {/* Orders grouped by company + period */}
         {isLoading ? (
-          <div className="flex justify-center py-12">
-            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
-          </div>
+          <PageSkeleton variant="list" />
         ) : filteredOrders.length === 0 ? (
           <Card>
             <CardContent className="py-12 text-center text-muted-foreground">

--- a/src/pages/SalesProducts.tsx
+++ b/src/pages/SalesProducts.tsx
@@ -8,7 +8,8 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import { Loader2, Search, RefreshCw, Package, ShoppingCart, BarChart3, Building2, ChevronLeft } from 'lucide-react';
+import { Search, RefreshCw, Package, ShoppingCart, BarChart3, Building2, ChevronLeft } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 type Account = 'oben' | 'colacor';
 
@@ -138,9 +139,7 @@ const SalesProducts = () => {
 
   if (authLoading || loading) {
     return (
-      <div className="flex items-center justify-center pt-32">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
+      <PageSkeleton variant="list" />
     );
   }
 

--- a/src/pages/TintCatalogo.tsx
+++ b/src/pages/TintCatalogo.tsx
@@ -1,9 +1,10 @@
 import { lazy, Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Palette, Loader2, FlaskConical, Package, Droplet } from "lucide-react";
+import { Palette, FlaskConical, Package, Droplet } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import { supabase } from "@/integrations/supabase/client";
 
 const TintFormulas = lazy(() => import("./TintFormulas"));
@@ -11,12 +12,7 @@ const TintCorantes = lazy(() => import("./TintCorantes"));
 const TintMapping = lazy(() => import("./TintMapping"));
 const TintPricing = lazy(() => import("./TintPricing"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 function KpiCards() {
   const { data } = useQuery({

--- a/src/pages/TintIntegracao.tsx
+++ b/src/pages/TintIntegracao.tsx
@@ -1,9 +1,10 @@
 import { lazy, Suspense } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { Plug, Loader2, RefreshCw, CheckCircle2, AlertCircle } from "lucide-react";
+import { Plug, RefreshCw, CheckCircle2, AlertCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import { supabase } from "@/integrations/supabase/client";
 
 const TintImport = lazy(() => import("./TintImport"));
@@ -12,12 +13,7 @@ const TintSyncRuns = lazy(() => import("./TintSyncRuns"));
 const TintReconciliation = lazy(() => import("./TintReconciliation"));
 const TintApiContract = lazy(() => import("./TintApiContract"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 function KpiCards() {
   const { data } = useQuery({

--- a/src/pages/Tools.tsx
+++ b/src/pages/Tools.tsx
@@ -7,7 +7,8 @@ import { AddToolDialog } from '@/components/AddToolDialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
-import { Loader2, Plus, Wrench, Calendar, Trash2, Hash, Users, AlertTriangle, ShieldCheck, Clock, HelpCircle } from 'lucide-react';
+import { Plus, Wrench, Calendar, Trash2, Hash, Users, AlertTriangle, ShieldCheck, Clock, HelpCircle } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { differenceInDays, format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
@@ -109,9 +110,9 @@ const Tools = () => {
   if (loading) {
     return (
       <div className="min-h-screen bg-background pb-24">
-        <div className="flex items-center justify-center pt-32">
-          <Loader2 className="w-8 h-8 animate-spin text-primary" />
-        </div>
+        <main className="pt-16 px-4 max-w-lg mx-auto">
+          <PageSkeleton variant="list" />
+        </main>
       </div>
     );
   }

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Loader2, CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
+import { CheckCircle, Building2, Scissors, Wifi } from 'lucide-react';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Badge } from '@/components/ui/badge';
 import { track } from '@/lib/analytics';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -274,7 +275,7 @@ const UnifiedOrder = () => {
   };
 
   if (h.authLoading) {
-    return <div className="flex items-center justify-center py-32"><Loader2 className="w-6 h-6 animate-spin text-muted-foreground" /></div>;
+    return <PageSkeleton variant="form" />;
   }
 
   /* ─── Derived flags to keep UI clean ─── */

--- a/src/pages/VendasFerramentas.tsx
+++ b/src/pages/VendasFerramentas.tsx
@@ -3,7 +3,6 @@ import { useSearchParams } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
   Wrench,
-  Loader2,
   FileText,
   Package,
   Network,
@@ -12,6 +11,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageSkeleton } from "@/components/ui/page-skeleton";
 import {
   Select,
   SelectContent,
@@ -26,12 +26,7 @@ const SalesPrint = lazy(() => import("./SalesPrintDashboard"));
 const FarmerRecommendations = lazy(() => import("./FarmerRecommendations"));
 const FarmerBundles = lazy(() => import("./FarmerBundles"));
 
-const TabFallback = () => (
-  <div className="flex items-center justify-center py-16 text-muted-foreground">
-    <Loader2 className="h-5 w-5 animate-spin mr-2" />
-    Carregando...
-  </div>
-);
+const TabFallback = () => <PageSkeleton variant="auto" />;
 
 const safeQuery = async <T,>(fn: () => Promise<T>, fallback: T): Promise<T> => {
   try {


### PR DESCRIPTION
## Resumo

Resolve o item da auditoria health 2026-07-06 (~52 páginas com `<Loader2 animate-spin>` de página inteira onde a convenção do CLAUDE.md pede `<PageSkeleton variant>`). Foram migradas **61 páginas** neste PR, em 4 padrões:

| Padrão | Troca | Exemplos |
|---|---|---|
| Early-return sob layout | `return <PageSkeleton variant="X" />` limpo (precedente FarmerDashboard) | AdminCustomers, SalesOrders, UnifiedOrder (form), GrupoCliente360 (detail) |
| Página mobile standalone | wrapper `min-h-screen bg-background pb-24` + `<main>` com o container real da página (`pt-16 px-4 max-w-lg/4xl mx-auto`) | Admin, Orders, Profile (form), ToolHistory (detail) |
| Hub com `TabFallback` de Suspense | `const TabFallback = () => <PageSkeleton variant="auto" />;` | GestaoAdmin, FinanceiroGestao, PerformanceHub, TintCatalogo (12 hubs) |
| Miolo principal (tabela em Card, aba) | `variant="list"` (com `className="p-4"` dentro de `CardContent p-0`) | FinanceiroConciliacao, AdminReposicaoPedidos, AdminEstoquePicking (5 abas) |

**Ficam de propósito** (inline legítimo): spinners de botão/upload/refetch, seções com mensagem contextual (AdminRoutePlanner scoring, AdminReposicaoNegociacaoParalela "Calculando…"), ResetPassword (feedback de redirect), TintSyncRuns (Loader2 como ícone de status `running`), FinanceiroDashboard:300 (toast flutuante), DesignSystem (documentação viva do pattern).

## Fora deste PR (follow-up planejado)

9 páginas da auditoria conflitam com PRs **draft** em voo e ficam para um follow-up pós-merge deles (os edits são micro — import + early-return — e o rebase barato é o deste lado):
- #1207 (react-query): SavingsDashboard, ToolHistory, ToolPublicHistory, ToolReports, Training
- #1208 (tokens de cor): AdminGamification, AdminStandardProcessDetail, FarmerGovernance, FarmerRecommendations

A doc `docs/historico/auditoria-health-2026-07-06.md` também vai no follow-up (o #1207 edita linha adjacente).

## Verificação (via heavy, semáforo de RAM)

- typecheck → **0**
- suite vitest completa → **571 files / 4610 tests passed**
- ESLint → **0 erros** (78 warnings pré-existentes `exhaustive-deps`/`react-refresh`, contagem idêntica à documentada — nenhum warning novo)
- Sem migration/RPC/trigger/RLS no diff (100% visual .tsx) — prove-sql não se aplica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)