### PR TITLE
perf(bundle): SDKs de voz/OCR fora dos chunks de página — Onda 5 (FarmerCopilot −95%)

### DIFF
--- a/docs/historico/perf-ondas.md
+++ b/docs/historico/perf-ondas.md
@@ -31,3 +31,13 @@ Padrão: nas duas, a 1ª review achou o P1, corrigi, re-review confirmou "SEGURO
 ## Deploy
 
 As 5 são **frontend** → precisam de **Publish do frontend no Lovable** (nenhuma migration/edge). A Onda 4 tem uma **transição única**: clientes com o SW antigo (autoUpdate) auto-recarregam **uma última vez** ao pegar o build com modo prompt; daí em diante, toda atualização vira o toast. Inerente à troca.
+
+## Onda 5 — SDKs de voz/OCR fora dos chunks de página (2026-07-07, PR #NNNN)
+
+Maior chunk do app era a página `FarmerCopilot` (478,77 kB raw / 126,31 kB gzip): `useFarmerCopilot.ts` importava `@elevenlabs/react` (useScribe) ESTATICAMENTE — o SDK de voz baixava só para ABRIR a página (vendedor externo em 4G). Menor, mesmo padrão: `tesseract.js` estático no `LoteScannerOCR` (dentro do chunk da `RecebimentoConferencia`, tela precacheada).
+
+**Fix**: useScribe é hook (não pode ser condicional) → o corte é o componente **headless** `MotorVozScribe` (retorna null; connect no mount / disconnect no unmount, refs "latest", guards single-fire), montado via `React.lazy` só ao iniciar sessão de voz — o chunk baixa em PARALELO ao roundtrip do token, e falha de download cai no fallback voz→texto já existente. A UI da sessão **não** foi movida (é compartilhada com o modo texto, o fallback). No scanner, `createWorker` virou dynamic import no `capture()` (1º scan). **Armadilha que a auditoria não via**: sem `vendor-elevenlabs`/`vendor-tesseract` nomeados (manualChunks, precedente do vendor-posthog) + `globIgnores`, o **precache do PWA baixaria o SDK de voz para TODO usuário** na instalação do SW.
+
+**Medido nos bytes**: FarmerCopilot 478,77→23,72 kB raw (−95%; gzip 126,31→7,52); RecebimentoConferencia 34,79→21,44 kB; `vendor-elevenlabs` 455,53 kB (só no clique); `vendor-tesseract` 16,33 kB (só no 1º scan); precache 5.486→5.474 KiB. Provas estruturais: 0 import estático do vendor no chunk da página (única menção = array de deps do `__vitePreload`), 0 `modulepreload` no boot, 0 menção no `sw.js`.
+
+**Codex pegou de novo (3 achados em 3 rodadas, todos corrigidos)**: (1) erros fatais por EVENTO pós-`connect()` (auth/quota) deixavam a sessão de voz "surda" sem fallback → handlers fatais específicos; o agregador `onError` do SDK foi deliberadamente evitado (dispara também para transientes — throttle/silêncio derrubariam a sessão à toa); (2) toast "Copiloto ativado" saía no `connect()` resolvido, que pode preceder o OPEN real → sucesso sinalizado só por evento (`onConnect`/`onSessionStarted`, single-fire); (3) troca de token com o motor montado vazaria guards entre conexões → `key={token}` no call-site (1 instância = 1 conexão). Lição repetida das Ondas 3/4: **em ciclo de vida de conexão, a review independente paga**.

--- a/docs/historico/perf-ondas.md
+++ b/docs/historico/perf-ondas.md
@@ -32,7 +32,7 @@ Padrão: nas duas, a 1ª review achou o P1, corrigi, re-review confirmou "SEGURO
 
 As 5 são **frontend** → precisam de **Publish do frontend no Lovable** (nenhuma migration/edge). A Onda 4 tem uma **transição única**: clientes com o SW antigo (autoUpdate) auto-recarregam **uma última vez** ao pegar o build com modo prompt; daí em diante, toda atualização vira o toast. Inerente à troca.
 
-## Onda 5 — SDKs de voz/OCR fora dos chunks de página (2026-07-07, PR #NNNN)
+## Onda 5 — SDKs de voz/OCR fora dos chunks de página (2026-07-07, PR #1211)
 
 Maior chunk do app era a página `FarmerCopilot` (478,77 kB raw / 126,31 kB gzip): `useFarmerCopilot.ts` importava `@elevenlabs/react` (useScribe) ESTATICAMENTE — o SDK de voz baixava só para ABRIR a página (vendedor externo em 4G). Menor, mesmo padrão: `tesseract.js` estático no `LoteScannerOCR` (dentro do chunk da `RecebimentoConferencia`, tela precacheada).
 

--- a/src/components/farmer/copilot/MotorVozScribe.tsx
+++ b/src/components/farmer/copilot/MotorVozScribe.tsx
@@ -1,0 +1,111 @@
+// Motor de voz do copiloto (ElevenLabs Scribe) — componente HEADLESS (retorna null).
+// Existe como componente separado para o code-split tirar o SDK @elevenlabs/react
+// (~119KB gzip) do chunk da página FarmerCopilot: useScribe é hook (não pode ser
+// condicional), então o corte é montar/desmontar ESTE componente. A página monta
+// via React.lazy apenas quando há sessão de voz; o unmount desconecta (cleanup).
+// A UI da sessão NÃO vive aqui de propósito: ela é compartilhada com o modo texto
+// (fallback quando a voz falha) e não pode depender do chunk do SDK de voz.
+import { useCallback, useEffect, useRef } from 'react';
+import { useScribe, CommitStrategy } from '@elevenlabs/react';
+
+export interface MotorVozScribeProps {
+  /** Imutável por instância: o call-site monta com key={token} — trocar o token
+   *  REMONTA o componente (1 instância = 1 conexão; guards nunca são
+   *  compartilhados entre conexões diferentes). */
+  token: string;
+  onPartialTranscript: (text: string) => void;
+  onCommittedTranscript: (text: string) => void;
+  onConnected: () => void;
+  onError: (err: unknown) => void;
+}
+
+export default function MotorVozScribe({
+  token,
+  onPartialTranscript,
+  onCommittedTranscript,
+  onConnected,
+  onError,
+}: MotorVozScribeProps) {
+  // Refs "latest": o effect de conexão não pode re-rodar quando os callbacks
+  // trocam de identidade a cada render — conexão é 1x por montagem/token.
+  const callbacksRef = useRef({ onConnected, onError });
+  callbacksRef.current = { onConnected, onError };
+
+  // Fallback de erro dispara UMA vez por conexão: o connect() rejeitado e o
+  // evento onError do SDK podem reportar o MESMO erro — sem o guard, o toast
+  // e a troca voz→texto duplicariam. O cleanup "queima" o guard para eventos
+  // emitidos pelo teardown do disconnect() não dispararem fallback espúrio.
+  const erroJaDisparadoRef = useRef(false);
+  const dispararErro = useCallback((err: unknown) => {
+    if (erroJaDisparadoRef.current) return;
+    erroJaDisparadoRef.current = true;
+    callbacksRef.current.onError(err);
+  }, []);
+
+  // Sucesso é sinalizado pelo EVENTO do SDK (abertura/sessão REAL), nunca pelo
+  // connect() resolvido: no 0.14.0 o connect() pode resolver antes do OPEN —
+  // sinalizar ali geraria "Copiloto ativado" seguido do erro de auth quando o
+  // token é recusado pós-open. onConnect e onSessionStarted apontam ambos pra
+  // cá; o guard single-fire deixa passar só o primeiro.
+  const conexaoJaSinalizadaRef = useRef(false);
+  const sinalizarConectado = useCallback(() => {
+    if (conexaoJaSinalizadaRef.current || erroJaDisparadoRef.current) return;
+    conexaoJaSinalizadaRef.current = true;
+    callbacksRef.current.onConnected();
+  }, []);
+
+  const scribe = useScribe({
+    modelId: 'scribe_v2_realtime',
+    commitStrategy: CommitStrategy.VAD,
+    onPartialTranscript: (data) => {
+      if (data.text) onPartialTranscript(data.text);
+    },
+    onCommittedTranscript: (data) => {
+      if (data.text) onCommittedTranscript(data.text);
+    },
+    onConnect: () => sinalizarConectado(),
+    onSessionStarted: () => sinalizarConectado(),
+    // Erros FATAIS que chegam por EVENTO depois do connect() resolver (token
+    // recusado pós-open, quota, termos, limite de sessão, recursos esgotados):
+    // sem estes handlers a sessão fica em modo voz "surda", sem cair pro texto.
+    // O agregador onError do SDK NÃO serve aqui — dispara também para erros
+    // transientes (commit throttled, silêncio prolongado) que não podem
+    // derrubar a sessão de voz.
+    onAuthError: (data) => dispararErro(new Error(data.error)),
+    onQuotaExceededError: (data) => dispararErro(new Error(data.error)),
+    onUnacceptedTermsError: (data) => dispararErro(new Error(data.error)),
+    onSessionTimeLimitExceededError: (data) => dispararErro(new Error(data.error)),
+    onResourceExhaustedError: (data) => dispararErro(new Error(data.error)),
+  });
+  const scribeRef = useRef(scribe);
+  scribeRef.current = scribe;
+
+  useEffect(() => {
+    // Re-arma os guards a cada (re)conexão.
+    erroJaDisparadoRef.current = false;
+    conexaoJaSinalizadaRef.current = false;
+    (async () => {
+      try {
+        await scribeRef.current.connect({
+          token,
+          microphone: {
+            echoCancellation: true,
+            noiseSuppression: true,
+          },
+        });
+        // Sucesso NÃO é sinalizado aqui — só pelo evento (onConnect/onSessionStarted).
+      } catch (err) {
+        dispararErro(err);
+      }
+    })();
+    return () => {
+      // Queima os guards: eventos emitidos pelo teardown do disconnect() (ou
+      // atrasados, pós-unmount) não disparam toast/fallback espúrios.
+      erroJaDisparadoRef.current = true;
+      conexaoJaSinalizadaRef.current = true;
+      scribeRef.current.disconnect();
+    };
+  }, [token, dispararErro]);
+
+  return null;
+}

--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -2,7 +2,6 @@
 // Extraída verbatim de src/pages/FarmerCopilot.tsx (god-component split).
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useScribe, CommitStrategy } from '@elevenlabs/react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useMyActiveCoverage } from '@/hooks/useCoverage';
@@ -13,6 +12,7 @@ import { toast } from 'sonner';
 import { Minus } from 'lucide-react';
 import { directionConfig, suggestionTypeIcons, fallbackSuggestionIcon } from './config';
 import type { InputMode } from './types';
+import type { MotorVozScribeProps } from './MotorVozScribe';
 
 export function useFarmerCopilot() {
   const navigate = useNavigate();
@@ -42,17 +42,9 @@ export function useFarmerCopilot() {
   const [isManualAnalyzing, setIsManualAnalyzing] = useState(false);
   const [riskFlash, setRiskFlash] = useState(false);
 
-  // ElevenLabs realtime scribe
-  const scribe = useScribe({
-    modelId: 'scribe_v2_realtime',
-    commitStrategy: CommitStrategy.VAD,
-    onPartialTranscript: (data) => {
-      if (data.text) copilot.addTranscript(data.text, true);
-    },
-    onCommittedTranscript: (data) => {
-      if (data.text) copilot.addTranscript(data.text, false);
-    },
-  });
+  // Sessão de voz: token != null ⇒ a página monta o MotorVozScribe (React.lazy),
+  // que embute o useScribe — o SDK ElevenLabs fica FORA deste chunk de página.
+  const [scribeToken, setScribeToken] = useState<string | null>(null);
 
   // Load customers (dropdown da carteira — segue o id efetivo na lente)
   useEffect(() => {
@@ -148,6 +140,12 @@ export function useFarmerCopilot() {
   const handleStartVoice = useCallback(async () => {
     setIsConnecting(true);
     try {
+      // Chunk do motor de voz (SDK ElevenLabs) baixa em PARALELO ao roundtrip do
+      // token; o branch com catch noop evita unhandled rejection se o fluxo
+      // falhar antes do await dele.
+      const motorPromise = import('./MotorVozScribe');
+      motorPromise.catch(() => {});
+
       const { data: tokenData, error: tokenError } = await supabase.functions.invoke('elevenlabs-scribe-token');
       if (tokenError || !tokenData?.token) throw new Error('Falha ao obter token de transcrição');
 
@@ -160,15 +158,11 @@ export function useFarmerCopilot() {
         bundleContext,
       });
 
-      await scribe.connect({
-        token: tokenData.token,
-        microphone: {
-          echoCancellation: true,
-          noiseSuppression: true,
-        },
-      });
-
-      toast.success('Copiloto ativado', { description: 'Transcrição em tempo real iniciada' });
+      // Garante o chunk baixado ANTES de montar; falha cai no catch (modo texto).
+      await motorPromise;
+      // Monta o motor → connect acontece no mount; o toast de "Copiloto ativado"
+      // sai no onConnected (conexão real), como antes saía após o connect.
+      setScribeToken(tokenData.token);
     } catch (err) {
       console.error('Start error:', err);
       // Auto-fallback to text mode
@@ -179,7 +173,7 @@ export function useFarmerCopilot() {
     } finally {
       setIsConnecting(false);
     }
-  }, [selectedCustomer, copilot, scribe, prepareSessionContext]);
+  }, [selectedCustomer, copilot, prepareSessionContext]);
 
   // Start text mode session
   const handleStartText = useCallback(async () => {
@@ -230,12 +224,10 @@ export function useFarmerCopilot() {
 
   // Stop recording
   const handleStop = useCallback(async () => {
-    if (inputMode === 'voice') {
-      scribe.disconnect();
-    }
+    setScribeToken(null); // desmonta o motor de voz → cleanup desconecta o scribe
     await copilot.endSession();
     toast.success('Sessão encerrada');
-  }, [scribe, copilot, inputMode]);
+  }, [copilot]);
 
   // Copy suggestion
   const handleCopySuggestion = useCallback((text: string) => {
@@ -244,6 +236,30 @@ export function useFarmerCopilot() {
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }, [copilot]);
+
+  // Props do motor de voz montado pela página (null = sem sessão de voz).
+  const handleScribePartial = useCallback((text: string) => copilot.addTranscript(text, true), [copilot]);
+  const handleScribeCommitted = useCallback((text: string) => copilot.addTranscript(text, false), [copilot]);
+  const handleScribeConnected = useCallback(() => {
+    toast.success('Copiloto ativado', { description: 'Transcrição em tempo real iniciada' });
+  }, []);
+  const handleScribeError = useCallback((err: unknown) => {
+    console.error('Scribe error:', err);
+    setScribeToken(null);
+    setInputMode('text');
+    toast.error('Voz indisponível', {
+      description: 'Transcrição por voz falhou. Modo texto ativado automaticamente.',
+    });
+  }, []);
+  const motorVozProps: MotorVozScribeProps | null = scribeToken
+    ? {
+        token: scribeToken,
+        onPartialTranscript: handleScribePartial,
+        onCommittedTranscript: handleScribeCommitted,
+        onConnected: handleScribeConnected,
+        onError: handleScribeError,
+      }
+    : null;
 
   const analysis = copilot.currentAnalysis;
   const dir = analysis ? directionConfig[analysis.direction] : null;
@@ -256,6 +272,7 @@ export function useFarmerCopilot() {
     isImpersonating,
     userId: user?.id ?? null,
     copilot,
+    motorVozProps,
     selectedCustomer,
     setSelectedCustomer,
     customers,

--- a/src/components/recebimento/LoteScannerOCR.tsx
+++ b/src/components/recebimento/LoteScannerOCR.tsx
@@ -1,5 +1,4 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
-import { createWorker } from 'tesseract.js';
 import { Camera, X, Loader2, ScanLine, CheckCircle2, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -104,6 +103,10 @@ export default function LoteScannerOCR({ onLoteCapturado, onCancelar }: LoteScan
     ctx.drawImage(video, 0, 0);
 
     try {
+      // Dynamic import: o core JS do tesseract só baixa no 1º scan (fora do chunk
+      // da página; worker/wasm/traineddata já vinham da rede em runtime). Falha de
+      // download cai no catch abaixo → caminho manual (degradação honesta).
+      const { createWorker } = await import('tesseract.js');
       const worker = await createWorker('por');
       const { data: { text } } = await worker.recognize(canvas);
       await worker.terminate();

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -12,6 +13,10 @@ import { ManualTextInput } from '@/components/farmer/copilot/ManualTextInput';
 import { TranscriptCard } from '@/components/farmer/copilot/TranscriptCard';
 import { AnalysisHistoryCard } from '@/components/farmer/copilot/AnalysisHistoryCard';
 
+// Motor de voz headless (embute o SDK @elevenlabs/react): lazy para o SDK não
+// entrar no chunk desta página — só baixa ao iniciar uma sessão de voz.
+const MotorVozScribe = lazy(() => import('@/components/farmer/copilot/MotorVozScribe'));
+
 const FarmerCopilot = () => {
   const {
     navigate,
@@ -19,6 +24,7 @@ const FarmerCopilot = () => {
     isImpersonating,
     userId,
     copilot,
+    motorVozProps,
     selectedCustomer,
     setSelectedCustomer,
     customers,
@@ -50,6 +56,15 @@ const FarmerCopilot = () => {
     <div className="min-h-screen bg-background pb-24">
 
       <main className="px-4 py-4 space-y-3 max-w-lg mx-auto">
+        {/* Motor de voz (headless, retorna null) — montado só com sessão de voz.
+            key={token}: troca de token REMONTA o motor (1 instância = 1 conexão;
+            guards não vazam entre conexões — achado Codex, 3ª rodada). */}
+        {motorVozProps && (
+          <Suspense fallback={null}>
+            <MotorVozScribe key={motorVozProps.token} {...motorVozProps} />
+          </Suspense>
+        )}
+
         {/* Session Controls */}
         {!copilot.isActive ? (
           <SessionStartCard

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -122,7 +122,9 @@ export default defineConfig(({ mode }) => ({
         // Quem sai do precache ganha cobertura PROGRESSIVA pelo runtime
         // caching de /assets/ (CacheFirst) abaixo: visitou 1× online, fica.
         globIgnores: [
-          "**/FarmerCopilot-*.js", // ~465KB — copilot de voz (ElevenLabs), exige rede
+          "**/FarmerCopilot-*.js", // copilot de voz, exige rede (o SDK pesado saiu daqui → vendor-elevenlabs)
+          "**/vendor-elevenlabs-*.js", // ~465KB — SDK de voz; só o copilot usa, lazy no iniciar sessão
+          "**/vendor-tesseract-*.js", // OCR core (LoteScannerOCR, lazy no 1º scan); wasm/traineddata já vêm da rede
           "**/AdminRoutePlanner-*.js", // ~188KB — Leaflet; tiles do mapa exigem rede
           "**/AdminRoutePlanner-*.css", // CSS do Leaflet (único ignorado com CSS próprio)
           "**/vendor-posthog-*.js", // ~186KB — posthog-js core (analytics; lazy via analytics.ts)
@@ -308,6 +310,11 @@ export default defineConfig(({ mode }) => ({
             // entry ESM do pacote) — nome genérico que o globIgnores do
             // precache não consegue mirar com segurança.
             if (id.includes('posthog-js')) return 'vendor-posthog';
+            // Mesmo racional do vendor-posthog: SDKs pesados atrás de dynamic
+            // import (voz ElevenLabs no MotorVozScribe; OCR no LoteScannerOCR) —
+            // nome explícito pro globIgnores do precache conseguir mirá-los.
+            if (/node_modules[\\/]@elevenlabs[\\/]/.test(id)) return 'vendor-elevenlabs';
+            if (/node_modules[\\/]tesseract\.js[\\/]/.test(id)) return 'vendor-tesseract';
             if (id.includes('framer-motion')) return 'vendor-motion';
             if (id.includes('@radix-ui/')) return 'vendor-ui';
             if (id.includes('lucide-react')) return 'vendor-icons';


### PR DESCRIPTION
## O quê

Split de bundle dos dois SDKs pesados que entravam em chunk de página (achado de auditoria 2026-07-06; método das ondas de perf de 04/07 — ganho provado nos bytes):

| Chunk | Antes (raw / gzip) | Depois (raw / gzip) |
|---|---|---|
| `FarmerCopilot` (página) | 478,77 / 126,31 kB | **23,72 / 7,52 kB (−95%)** |
| `RecebimentoConferencia` | 34,79 / 12,07 kB | **21,44 / 6,82 kB (−38%)** |
| `vendor-elevenlabs` (novo — baixa no **clique de iniciar voz**) | — | 455,53 / 119,30 kB |
| `vendor-tesseract` (novo — baixa no **1º scan**) | — | 16,33 / 6,92 kB |
| `MotorVozScribe` (wrapper headless) | — | ~1 kB |
| Precache PWA | 312 entries / 5.486,50 KiB | 313 / 5.474,17 KiB |

1. **FarmerCopilot**: `@elevenlabs/react` (useScribe) saiu do chunk da página. Como `useScribe` é hook (não pode ser condicional), o corte é o componente **headless** `MotorVozScribe` (retorna `null`; connect no mount, disconnect no unmount, refs "latest"), montado via `React.lazy` só quando a sessão de voz inicia. O chunk baixa em **paralelo** ao roundtrip do token (`import()` disparado no início do `handleStartVoice`); falha de download cai no fallback voz→texto já existente.
2. **LoteScannerOCR**: `createWorker` do tesseract.js virou dynamic import dentro do `capture()`. Falha de download cai no catch existente → preenchimento manual (degradação honesta). O wasm/worker/traineddata já vinham da rede em runtime.

## Decisões de desenho

- **UI da sessão NÃO foi movida pro lazy** (a auditoria sugeria mover): ela é compartilhada com o modo texto — que é o fallback quando a voz falha — e não pode depender do chunk do SDK de voz.
- **PWA**: sem os vendors nomeados (`vendor-elevenlabs`, `vendor-tesseract` no `manualChunks` — precedente do `vendor-posthog`) + entradas no `globIgnores`, o service worker passaria a **precachear o SDK de voz para todo usuário** na instalação (regressão do precache enxuto). Verificado no artefato: 0 menções no `sw.js`.
- **Paridade de comportamento**: fallback voz→texto preservado (falha de chunk OU de connect); toast "Copiloto ativado" só após conexão real; sessão do copilot permanece ativa quando a voz falha (comportamento anterior).

## Codex (4 rodadas — selo "SEGURO PRA MERGE" na 4ª)

- **1ª (P2 real)**: erros fatais que chegam por **evento** depois do `connect()` resolver (token recusado pós-open, quota) deixavam a sessão de voz "surda", sem fallback — comportamento pré-existente que o novo desenho torna trivial de corrigir. **Fix**: handlers fatais específicos (`onAuthError`, `onQuotaExceededError`, `onUnacceptedTermsError`, `onSessionTimeLimitExceededError`, `onResourceExhaustedError`) com guard de disparo único (queimado no teardown). O agregador `onError` do SDK foi **deliberadamente não usado**: dispara também para erros transientes (commit throttled, silêncio prolongado) e derrubaria a sessão à toa. `onDisconnect` idem (dispara no teardown intencional; auto-reconnect incerto).
- **2ª**: validou guards e decisões deliberadas; P3 residual — o toast "Copiloto ativado" saía no `connect()` resolvido, que pode preceder a abertura real do WS (token inválido mostraria sucesso e depois erro). **Fix**: sucesso sinalizado só por **evento** (`onConnect`/`onSessionStarted`, single-fire; não dispara se um erro fatal já disparou).
- **3ª**: validou o delta do toast para o fluxo real; P3 teórico — troca da prop `token` com o motor montado vazaria guards entre a conexão antiga e a nova. **Fix**: `key={token}` no call-site (troca de token = remontagem; 1 instância = 1 conexão — o "identificador por conexão" que a review pediu, resolvido pelo React).
- **4ª**: "Fechado. […] **SEGURO PRA MERGE**" — sem efeito colateral da remontagem (componente headless, sem UI/estado visível).

## Validação

- `build` / `typecheck` (strict) / `lint` / `test` (4610) — todos verdes localmente; bateria final pós-patch idem.
- Provas estruturais nos artefatos: 0 import estático do vendor no chunk da página (única menção = array de deps do `__vitePreload`); 0 `modulepreload` no boot; 0 menção no `sw.js`.

## Deploy (Lovable)

Frontend puro → **Publish manual** no editor do Lovable. Sem migration/edge.

## Teste manual (founder — mic/câmera reais)

- [ ] FarmerCopilot: iniciar sessão de **voz** real → transcrição em tempo real aparece; encerrar → desconecta limpo
- [ ] FarmerCopilot: negar permissão do microfone → cai pro modo texto com toast "Voz indisponível"
- [ ] Recebimento: scan OCR real de etiqueta de lote (1º scan baixa o OCR; leitura preenche o formulário)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
