### PR TITLE
docs(skill): sentinela de bytes p/ refactor visual (lovable-deploy-verify)

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -108,6 +108,20 @@ Montar pro founder colar no chat do Lovable (um por edge tocada):
 # exit 0 = no ar · 1 = ausente (Publish pendente / alvo não-literal) · 2 = enumeração quebrada
 ```
 
+**Escolher a string-alvo — refactor visual NÃO tem texto novo.** A sentinela ideal é texto de UI
+literal e único do commit. Mas refactor puramente visual (spinner→skeleton, cor→token, troca de
+layout) não adiciona texto — e a string precisa estar em **JSX renderizado**: comentário (`//`),
+teste e edge NÃO entram no bundle (mordido em prod 2026-07-07: `'identidade não provada'` só vivia
+num comentário → falso "ausente", não prova nada). Duas saídas:
+- **Calibrar** com uma string RENDERIZADA já existente da própria página (um `<h2>`/label antigo) —
+  prova que o chunk certo está no ar + o método enumera (não é falso-negativo). Não prova a versão.
+- **Provar a versão** por **assinatura estrutural** no chunk da página, baixado direto
+  (`curl .../assets/<Página>-<hash>.js`): a **prop/classe NOVA presente E a marca REMOVIDA ausente**,
+  as duas no MESMO chunk (uma só pode dar falso-positivo por reuso). Ex. spinner→skeleton (provado
+  #1215): `variant:"detail"` presente (o `<PageSkeleton>` novo) **+** `animate-spin` ausente (o
+  `<Loader2>` que saiu). Pela atomicidade do Publish (build da `main` inteira), 1 página provada ⇒ o
+  lote todo no ar.
+
 ⚠️ Guard embutido (exit 2): contagem 0/1 = enumeração quebrada (formato do bundler/Workbox mudou) —
 NÃO conclua "não está no ar"; conserte o script primeiro. O `/browse` do gstack NÃO renderiza esta
 SPA (React não monta) — a verificação visual fica no Chrome real do founder; o maior sinal sem o


### PR DESCRIPTION
## Contexto

Durante a verificação do Publish da migração PageSkeleton (#1210/#1215), a técnica de bytes do Passo 4 da skill mostrou um furo: ela assume uma **string de texto literal única** do commit, mas um refactor **puramente visual** (spinner→skeleton, cor→token, troca de layout) **não adiciona texto nenhum**. Pior: a primeira sentinela que tentei (`'identidade não provada'`) só vivia num **comentário** — removido na minificação — e deu falso "ausente".

## O que muda

Uma nota no Passo 4 documentando as duas saídas, ambas **provadas em produção nesta sessão**:

1. **Calibrar** com uma string RENDERIZADA (JSX, não `//`) já existente da própria página → confirma que o chunk está no ar e o método enumera.
2. **Provar a versão** por **assinatura estrutural** no chunk baixado: a prop/classe **nova presente** E a marca **removida ausente**, no mesmo chunk. Exemplo real (#1215, `ToolPublicHistory`): `variant:"detail"` presente (o `<PageSkeleton>` novo) + `animate-spin` ausente (o `<Loader2>` que saiu). Pela atomicidade do Publish, 1 página provada ⇒ o lote no ar.

Só edição de markdown da skill — sem frontend/edge/migration, sem deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)