### PR TITLE
test(agente): testes com stub+sabotagem para pr-watch, codex-async e hooks SessionStart

### DIFF
--- a/scripts/codex-async.sh
+++ b/scripts/codex-async.sh
@@ -66,7 +66,10 @@ for backoff in "${backoffs[@]}"; do
   codex exec --model "$modelo" -c model_reasoning_effort="$reasoning" \
     --sandbox read-only "$prompt" >"$out" 2>"$err" &
   pid=$!
-  ( sleep "$timeout_s" && kill "$pid" 2>/dev/null ) &
+  # fds do watchdog → /dev/null: o sleep interno sobrevive ao kill do subshell
+  # e, se herdasse o stdout/stderr do chamador, seguraria o pipe aberto até o
+  # timeout inteiro (chamador em foreground ficaria esperando EOF)
+  ( sleep "$timeout_s" && kill "$pid" 2>/dev/null ) >/dev/null 2>&1 &
   watchdog=$!
   wait "$pid"; rc=$?
   kill "$watchdog" 2>/dev/null

--- a/scripts/codex-async.sh
+++ b/scripts/codex-async.sh
@@ -56,7 +56,9 @@ trap 'rm -f "$err"' EXIT
 
 rc=1
 tentativa=0
-for backoff in 0 20 60; do
+# backoffs sobrescritíveis por env (testes usam "0 0 0" pra não esperar de verdade)
+read -ra backoffs <<< "${CODEX_ASYNC_BACKOFFS:-0 20 60}"
+for backoff in "${backoffs[@]}"; do
   tentativa=$((tentativa+1))
   [ "$backoff" -gt 0 ] && { echo "retry em ${backoff}s (tentativa $tentativa)…" >&2; sleep "$backoff"; }
 

--- a/scripts/test-codex-async.sh
+++ b/scripts/test-codex-async.sh
@@ -51,8 +51,8 @@ caso_exit() { # nome want_exit rc
 echo "── caminho feliz ──"
 out="$(run ok "pergunta qualquer" 2>/dev/null)"; rc=$?
 caso_exit "parecer entregue → 0" 0 "$rc"
-printf '%s' "$out" | grep -q "parecer: aprovado" && echo "  ok    stdout contém o parecer" \
-  || { echo "  FAIL  parecer ausente do stdout"; fail=1; }
+if printf '%s' "$out" | grep -q "parecer: aprovado"; then echo "  ok    stdout contém o parecer"
+else echo "  FAIL  parecer ausente do stdout"; fail=1; fi
 
 echo "── preflight ──"
 run ok 2>/dev/null; caso_exit "prompt vazio → 64" 64 $?
@@ -65,20 +65,20 @@ caso_exit "sem auth (nem env, nem auth.json) → 77" 77 $?
 echo "── cota e retry ──"
 run quota "x" >/dev/null 2>&1; rc=$?
 caso_exit "cota esgotada → 75" 75 "$rc"
-[ "$(invocacoes)" -eq 1 ] && echo "  ok    cota NÃO faz retry (1 invocação)" \
-  || { echo "  FAIL  cota fez retry ($(invocacoes) invocações)"; fail=1; }
+if [ "$(invocacoes)" -eq 1 ]; then echo "  ok    cota NÃO faz retry (1 invocação)"
+else echo "  FAIL  cota fez retry ($(invocacoes) invocações)"; fail=1; fi
 
 out="$(run ratelimit "x" 2>/dev/null)"; rc=$?
 caso_exit "rate limit transitório → retry → 0" 0 "$rc"
-[ "$(invocacoes)" -eq 2 ] && echo "  ok    exatamente 1 retry (2 invocações)" \
-  || { echo "  FAIL  invocações=$(invocacoes), esperava 2"; fail=1; }
+if [ "$(invocacoes)" -eq 2 ]; then echo "  ok    exatamente 1 retry (2 invocações)"
+else echo "  FAIL  invocações=$(invocacoes), esperava 2"; fail=1; fi
 
 echo "── watchdog (execução travada) ──"
 run trava -t 1 "x" >/dev/null 2>&1; rc=$?
 if [ "$rc" -ne 0 ] && [ "$rc" -ne 75 ]; then echo "  ok    exit $rc ≠ 0 (matou o processo travado)"
 else echo "  FAIL  watchdog não matou (exit $rc)"; fail=1; fi
-[ "$(invocacoes)" -eq 3 ] && echo "  ok    esgotou as 3 tentativas" \
-  || { echo "  FAIL  invocações=$(invocacoes), esperava 3"; fail=1; }
+if [ "$(invocacoes)" -eq 3 ]; then echo "  ok    esgotou as 3 tentativas"
+else echo "  FAIL  invocações=$(invocacoes), esperava 3"; fail=1; fi
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi

--- a/scripts/test-codex-async.sh
+++ b/scripts/test-codex-async.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test-codex-async.sh — TDD do scripts/codex-async.sh com `codex` STUBADO (sem quota).
+#
+# Contrato testado: 0=parecer entregue · 64=uso errado · 69=binário ausente ·
+# 75=cota esgotada (SEM retry) · 77=sem auth · retry só em transitório ·
+# watchdog mata execução travada.
+#
+# Uso: bash scripts/test-codex-async.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+ASYNC="$here/codex-async.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin" "$tmp/codexhome_ok" "$tmp/codexhome_vazio"
+: > "$tmp/codexhome_ok/auth.json"
+
+# stub de codex: comportamento por CODEX_STUB_MODE; conta invocações em CODEX_STUB_COUNT
+cat >"$tmp/bin/codex" <<'STUB'
+#!/bin/sh
+echo x >> "$CODEX_STUB_COUNT"
+case "$CODEX_STUB_MODE" in
+  ok)        echo "parecer: aprovado com ressalvas"; exit 0 ;;
+  quota)     echo "You have reached your usage limit" >&2; exit 1 ;;
+  ratelimit) n=$(wc -l < "$CODEX_STUB_COUNT" | tr -d ' ')
+             if [ "$n" -ge 2 ]; then echo "parecer pós-retry"; exit 0
+             else echo "429 rate limit exceeded" >&2; exit 1; fi ;;
+  trava)     sleep 30 ;;
+  *)         echo "erro desconhecido" >&2; exit 1 ;;
+esac
+STUB
+chmod +x "$tmp/bin/codex"
+
+fail=0
+# ambiente controlado: PATH mínimo com o stub; sem env keys; backoffs zerados
+run() {
+  local mode="$1"; shift
+  : > "$tmp/count"
+  env -i PATH="$tmp/bin:/usr/bin:/bin" HOME="$HOME" TMPDIR="$tmp" \
+    CODEX_HOME="$tmp/codexhome_ok" CODEX_STUB_MODE="$mode" CODEX_STUB_COUNT="$tmp/count" \
+    CODEX_ASYNC_BACKOFFS="0 0 0" bash "$ASYNC" "$@" </dev/null
+}
+invocacoes() { wc -l < "$tmp/count" | tr -d ' '; }
+
+caso_exit() { # nome want_exit rc
+  if [ "$3" -eq "$2" ]; then echo "  ok    exit $3 | $1"
+  else echo "  FAIL  want exit $2, got $3 | $1"; fail=1; fi
+}
+
+echo "── caminho feliz ──"
+out="$(run ok "pergunta qualquer" 2>/dev/null)"; rc=$?
+caso_exit "parecer entregue → 0" 0 "$rc"
+printf '%s' "$out" | grep -q "parecer: aprovado" && echo "  ok    stdout contém o parecer" \
+  || { echo "  FAIL  parecer ausente do stdout"; fail=1; }
+
+echo "── preflight ──"
+run ok 2>/dev/null; caso_exit "prompt vazio → 64" 64 $?
+env -i PATH="/usr/bin:/bin" HOME="$HOME" TMPDIR="$tmp" bash "$ASYNC" "x" >/dev/null 2>&1
+caso_exit "codex ausente do PATH → 69" 69 $?
+env -i PATH="$tmp/bin:/usr/bin:/bin" HOME="$HOME" TMPDIR="$tmp" CODEX_HOME="$tmp/codexhome_vazio" \
+  CODEX_STUB_MODE=ok CODEX_STUB_COUNT="$tmp/count" bash "$ASYNC" "x" >/dev/null 2>&1
+caso_exit "sem auth (nem env, nem auth.json) → 77" 77 $?
+
+echo "── cota e retry ──"
+run quota "x" >/dev/null 2>&1; rc=$?
+caso_exit "cota esgotada → 75" 75 "$rc"
+[ "$(invocacoes)" -eq 1 ] && echo "  ok    cota NÃO faz retry (1 invocação)" \
+  || { echo "  FAIL  cota fez retry ($(invocacoes) invocações)"; fail=1; }
+
+out="$(run ratelimit "x" 2>/dev/null)"; rc=$?
+caso_exit "rate limit transitório → retry → 0" 0 "$rc"
+[ "$(invocacoes)" -eq 2 ] && echo "  ok    exatamente 1 retry (2 invocações)" \
+  || { echo "  FAIL  invocações=$(invocacoes), esperava 2"; fail=1; }
+
+echo "── watchdog (execução travada) ──"
+run trava -t 1 "x" >/dev/null 2>&1; rc=$?
+if [ "$rc" -ne 0 ] && [ "$rc" -ne 75 ]; then echo "  ok    exit $rc ≠ 0 (matou o processo travado)"
+else echo "  FAIL  watchdog não matou (exit $rc)"; fail=1; fi
+[ "$(invocacoes)" -eq 3 ] && echo "  ok    esgotou as 3 tentativas" \
+  || { echo "  FAIL  invocações=$(invocacoes), esperava 3"; fail=1; }
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi
+exit "$fail"

--- a/scripts/test-hooks-sessionstart.sh
+++ b/scripts/test-hooks-sessionstart.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# test-hooks-sessionstart.sh — os 2 hooks de SessionStart emitem JSON VÁLIDO
+# em qualquer circunstância (hook com stdout inválido é ignorado pelo harness,
+# ou pior, polui o boot da sessão — o contrato é: sempre JSON parseável).
+#
+# Uso: bash scripts/test-hooks-sessionstart.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOKS="$here/../.claude/hooks"
+fail=0
+
+echo "── pos-compact-ptbr.sh ──"
+out="$(bash "$HOOKS/pos-compact-ptbr.sh" 2>/dev/null)"
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "SessionStart"' >/dev/null 2>&1; then
+  echo "  ok    JSON válido com hookEventName=SessionStart"
+else
+  echo "  FAIL  saída não é o JSON esperado: $out"; fail=1
+fi
+if printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext' | grep -q "pt-BR"; then
+  echo "  ok    contexto reforça pt-BR"
+else
+  echo "  FAIL  contexto sem o reforço de pt-BR"; fail=1
+fi
+
+echo "── vigia-worktree.sh ──"
+# num diretório SEM package.json: não dispara install e deve emitir JSON válido ('{}' ou aviso)
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+out="$(cd "$tmp" && bash "$HOOKS/vigia-worktree.sh" 2>/dev/null)"
+if printf '%s' "$out" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  echo "  ok    JSON válido fora de worktree (sem package.json)"
+else
+  echo "  FAIL  saída inválida fora de worktree: $out"; fail=1
+fi
+# num diretório COM package.json e SEM node_modules: precisa avisar (e disparar install em bg)
+mkdir -p "$tmp/wt"; echo '{}' > "$tmp/wt/package.json"
+out="$(cd "$tmp/wt" && bash "$HOOKS/vigia-worktree.sh" 2>/dev/null)"
+if printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // ""' | grep -q "node_modules AUSENTE"; then
+  echo "  ok    avisa node_modules ausente (e dispara install em background)"
+else
+  echo "  FAIL  não avisou node_modules ausente: $out"; fail=1
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi
+exit "$fail"

--- a/scripts/test-pr-watch.sh
+++ b/scripts/test-pr-watch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# test-pr-watch.sh — TDD do scripts/pr-watch.sh com `gh` STUBADO (sem rede).
+#
+# Contrato testado (exit codes): 0=MERGED · 2=CLOSED · 3=DIRTY(conflito) ·
+# 4=CI vermelho · 5=timeout sem desfecho (inclusive gh falhando sempre).
+#
+# Uso: bash scripts/test-pr-watch.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+WATCH="$here/pr-watch.sh"
+
+stub="$(mktemp -d)"
+trap 'rm -rf "$stub"' EXIT
+
+# stub de gh: devolve o JSON do cenário (GH_STUB_FILE) ou falha (GH_STUB_EXIT)
+cat >"$stub/gh" <<'STUB'
+#!/bin/sh
+[ -n "${GH_STUB_EXIT:-}" ] && exit "$GH_STUB_EXIT"
+cat "$GH_STUB_FILE"
+STUB
+chmod +x "$stub/gh"
+export PATH="$stub:$PATH"
+
+fail=0
+
+# roda o watcher com timeout curtíssimo (0 min) e poll de 1s
+caso() {
+  local nome="$1" want_exit="$2" json="$3" out rc
+  printf '%s' "$json" > "$stub/cenario.json"
+  out="$(GH_STUB_FILE="$stub/cenario.json" bash "$WATCH" 999 0 1 2>/dev/null)"; rc=$?
+  if [ "$rc" -eq "$want_exit" ]; then
+    echo "  ok    exit $rc | $nome"
+  else
+    echo "  FAIL  want exit $want_exit, got $rc | $nome | $out"; fail=1
+  fi
+}
+
+echo "── desfechos terminais ──"
+caso "MERGED → 0" 0 '{"state":"MERGED","mergeStateStatus":"CLEAN","statusCheckRollup":[],"title":"t","url":"u"}'
+caso "CLOSED sem merge → 2" 2 '{"state":"CLOSED","mergeStateStatus":"","statusCheckRollup":[],"title":"t","url":"u"}'
+caso "conflito (DIRTY) → 3" 3 '{"state":"OPEN","mergeStateStatus":"DIRTY","statusCheckRollup":[],"title":"t","url":"u"}'
+caso "CI vermelho (conclusion FAILURE) → 4" 4 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","conclusion":"FAILURE"}],"title":"t","url":"u"}'
+caso "CI vermelho (state ERROR, sem conclusion) → 4" 4 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"context":"ci","state":"error"}],"title":"t","url":"u"}'
+
+echo "── sem desfecho ──"
+caso "OPEN limpo até o deadline → 5" 5 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","conclusion":null}],"title":"t","url":"u"}'
+
+# gh falhando sempre (rede fora) → timeout 5, nunca trava
+out="$(GH_STUB_EXIT=1 GH_STUB_FILE=/dev/null bash "$WATCH" 999 0 1 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 5 ]; then echo "  ok    exit 5 | gh falhando sempre (rede)"
+else echo "  FAIL  want exit 5, got $rc | gh falhando sempre"; fail=1; fi
+
+# check pendente NÃO pode contar como vermelho (falso-positivo)
+caso "check pendente ≠ vermelho → 5" 5 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","state":"PENDING"}],"title":"t","url":"u"}'
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi
+exit "$fail"


### PR DESCRIPTION
Complemento da 1ª leva (#1205): os scripts novos viraram regra viva do CLAUDE.md mas não tinham testes comportamentais — agora seguem o padrão da casa (stub no PATH + sabotagem, como test-heavy-guard):

- **`test-pr-watch.sh`** (8 casos, `gh` stubado): MERGED/CLOSED/DIRTY/CI-vermelho (2 formatos de rollup), timeout, rede fora sempre-falhando, e o anti-falso-positivo: check **pendente** ≠ vermelho.
- **`test-codex-async.sh`** (9 casos, `codex` stubado): caminho feliz, 3 preflights (64/69/77), **cota esgotada → exit 75 SEM retry** (provado por contador de invocações), transitório → exatamente 1 retry, watchdog mata execução travada (exit 143) e esgota as 3 tentativas.
- **`test-hooks-sessionstart.sh`**: os 2 hooks emitem JSON válido em qualquer cenário + aviso de node_modules ausente.
- `codex-async.sh`: backoffs sobrescritíveis via `CODEX_ASYNC_BACKOFFS` (testes não esperam 20s reais).

Validação extra: transporte real exercitado ponta-a-ponta (consulta mínima ao Codex de verdade — exit 0, parecer na 1ª tentativa, formato correto).

Resultado local: **21/21 PASS** + shellcheck limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)