### PR TITLE
chore(f3): seed versionado da classificação de custo OBEN

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **339** custom migrations totais
+- **340** custom migrations totais
 - **1212** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 341
@@ -2909,6 +2909,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.omie_cliente_upsert_mapping` | — |
+
+### `20260707120000_seed_fin_dre_custo_tipo_oben.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 336
+-- Total de custom migrations: 340
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -375,7 +375,11 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260704160000', 'fin_dividas', '20260704160000_fin_dividas.sql'),
   ('20260704160000', 'fin_sync_watchdog_retry_sem_efeito', '20260704160000_fin_sync_watchdog_retry_sem_efeito.sql'),
   ('20260704160500', 'fin_divida_replace_parcelas', '20260704160500_fin_divida_replace_parcelas.sql'),
-  ('20260705120000', 'fin_dre_custo_tipo', '20260705120000_fin_dre_custo_tipo.sql')
+  ('20260704190000', 'fin_regua_custo_capital', '20260704190000_fin_regua_custo_capital.sql'),
+  ('20260704190500', 'fin_regua_condicao_prazo', '20260704190500_fin_regua_condicao_prazo.sql'),
+  ('20260705120000', 'fin_dre_custo_tipo', '20260705120000_fin_dre_custo_tipo.sql'),
+  ('20260705211043', 'omie_identidade_por_conta', '20260705211043_omie_identidade_por_conta.sql'),
+  ('20260707120000', 'seed_fin_dre_custo_tipo_oben', '20260707120000_seed_fin_dre_custo_tipo_oben.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1570,12 +1574,15 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('fin_dividas', 'rls_policy', 'public', '%I_write_master', 'public'),
   ('fin_sync_watchdog_retry_sem_efeito', 'function', 'public', 'fin_sync_watchdog_check', ''),
   ('fin_divida_replace_parcelas', 'function', 'public', 'fin_divida_replace_parcelas', ''),
+  ('fin_regua_custo_capital', 'function', 'public', 'fin_regua_custo_capital', ''),
+  ('fin_regua_condicao_prazo', 'function', 'public', 'fin_regua_condicao_prazo', ''),
   ('fin_dre_custo_tipo', 'function', 'public', 'fin_dre_custo_tipo_set_autor', ''),
   ('fin_dre_custo_tipo', 'table', 'public', 'fin_dre_custo_tipo', ''),
   ('fin_dre_custo_tipo', 'trigger', 'public', 'trg_fin_dre_custo_tipo_autor', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_select_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_write_master', 'fin_dre_custo_tipo'),
-  ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo')
+  ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo'),
+  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2818,12 +2825,15 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_dividas', 'rls_policy', 'public', '%I_write_master', 'public'),
   ('fin_sync_watchdog_retry_sem_efeito', 'function', 'public', 'fin_sync_watchdog_check', ''),
   ('fin_divida_replace_parcelas', 'function', 'public', 'fin_divida_replace_parcelas', ''),
+  ('fin_regua_custo_capital', 'function', 'public', 'fin_regua_custo_capital', ''),
+  ('fin_regua_condicao_prazo', 'function', 'public', 'fin_regua_condicao_prazo', ''),
   ('fin_dre_custo_tipo', 'function', 'public', 'fin_dre_custo_tipo_set_autor', ''),
   ('fin_dre_custo_tipo', 'table', 'public', 'fin_dre_custo_tipo', ''),
   ('fin_dre_custo_tipo', 'trigger', 'public', 'trg_fin_dre_custo_tipo_autor', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_select_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_write_master', 'fin_dre_custo_tipo'),
-  ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo')
+  ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo'),
+  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260707120000_seed_fin_dre_custo_tipo_oben.sql
+++ b/supabase/migrations/20260707120000_seed_fin_dre_custo_tipo_oben.sql
@@ -1,0 +1,41 @@
+-- supabase/migrations/20260707120000_seed_fin_dre_custo_tipo_oben.sql
+-- F3 — SEED da classificacao de comportamento de custo da OBEN (fixo/variavel/nao_operacional).
+-- Baseline v1 aplicado em producao 2026-07-06 (validado: cobertura 99,0%, 0 categoria material
+-- sem classe). Aterrado no TTM real (12m competencia) das categorias de detalhamento.despesas
+-- da OBEN puxadas via psql-ro. Escopo OBEN-only (spec §5).
+--
+-- Idempotente (ON CONFLICT DO UPDATE): re-aplicar RESTAURA este baseline. A fonte de verdade
+-- corrente e o BANCO (master refina pela UI "Classificar custos" no card de Ponto de Equilibrio);
+-- este arquivo e o baseline reproduzivel para DR, nao um trava de edicoes posteriores.
+--
+-- Deixados INTENCIONALMENTE sem classe (imateriais, ~0,6%): 2.06.98 (CSLL, imposto sobre lucro,
+-- abaixo da linha operacional) e "Sem categoria" (sem descricao — nao chutar). Nao puxam
+-- inconclusivo: nenhum e material (>5% despesas / >2% receita).
+-- Spec: docs/superpowers/specs/2026-07-04-ponto-equilibrio-dre-design.md (§3, §5).
+
+INSERT INTO public.fin_dre_custo_tipo (company, categoria_codigo, tipo, observacao) VALUES
+  ('oben','2.01.01','variavel',NULL),                                                       -- Compras Mercadorias p/ Revenda (CMV)
+  ('oben','2.06.01','variavel',NULL),                                                       -- ICMS
+  ('oben','2.06.96','variavel',NULL),                                                       -- ICMS Dif. aliquota
+  ('oben','2.06.04','variavel',NULL),                                                       -- COFINS
+  ('oben','2.06.03','variavel',NULL),                                                       -- PIS
+  ('oben','2.01.02','variavel',NULL),                                                       -- Frete
+  ('oben','2.01.04','variavel',NULL),                                                       -- Compra de Servicos
+  ('oben','2.09.01','variavel',NULL),                                                       -- Devolucoes de Vendas
+  ('oben','2.01.98','variavel',NULL),                                                       -- Devolucao de Clientes
+  ('oben','2.05.03','nao_operacional','Amortizacao de principal de emprestimo — financiamento, nao e custo da operacao'),
+  ('oben','2.06.94','nao_operacional','Quitacao parcelada de divida tributaria federal — financiamento, nao imposto corrente'),
+  ('oben','2.03.99','fixo',NULL),                                                           -- Pro Labore
+  ('oben','2.04.01','fixo',NULL),                                                           -- Aluguel
+  ('oben','2.04.11','fixo',NULL),                                                           -- Advogados
+  ('oben','2.01.99','fixo',NULL),                                                           -- Material de Uso e Consumo
+  ('oben','2.03.01','fixo',NULL),                                                           -- Salarios
+  ('oben','2.04.10','fixo',NULL),                                                           -- Contabilidade
+  ('oben','2.08.02','fixo',NULL),                                                           -- Softwares
+  ('oben','2.04.98','fixo',NULL),                                                           -- Manutencao e Reparos
+  ('oben','2.04.14','fixo',NULL),                                                           -- Limpeza
+  ('oben','2.11.98','fixo',NULL),                                                           -- Alimentacao e Lanches
+  ('oben','2.04.97','fixo',NULL),                                                           -- Manutencao de Veiculos
+  ('oben','2.10.99','fixo',NULL)                                                            -- Outras Despesas de Viagem
+ON CONFLICT (company, categoria_codigo)
+DO UPDATE SET tipo = EXCLUDED.tipo, observacao = EXCLUDED.observacao;


### PR DESCRIPTION
## F3 — Seed versionado da classificação de custo da OBEN

Versiona (baseline reprodutível p/ DR) a classificação fixo/variável/não-operacional das categorias de despesa da OBEN que destrava o Ponto de Equilíbrio (F3).

**⚠️ JÁ APLICADO EM PRODUÇÃO** (2026-07-06, SQL Editor) — validado: **cobertura 99,0%, 0 categoria material sem classe**. Este PR só versiona o `.sql`; **não precisa re-rodar** salvo rebuild do banco. Idempotente (`ON CONFLICT DO UPDATE`).

Fonte de verdade corrente = o banco (master refina pela UI "Classificar custos"). Escopo OBEN-only (spec §5). CSLL + "Sem categoria" deixados sem classe de propósito (imateriais).

🤖 Generated with [Claude Code](https://claude.com/claude-code)