### PR TITLE
docs(skill): bi/cfo-colacor pós-psql-ro (leitura direta) + léxico de embalagens + mapa do app

### DIFF
--- a/.claude/skills/bi-colacor/SKILL.md
+++ b/.claude/skills/bi-colacor/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: bi-colacor
 description: >-
-  BI executivo operacional do Grupo Colacor (Colacor, Oben, Colacor SC), operado em modo
-  MANUAL-ASSISTIDO porque o banco só é acessível pelo SQL Editor do Lovable (sem terminal,
-  curl, psql ou CLI). A skill GERA SQL read-only seguro e versionado → você cola no Lovable
-  → Run → cola o resultado de volta → a skill INTERPRETA e vira decisão. Use SEMPRE que o
+  BI executivo operacional do Grupo Colacor (Colacor, Oben, Colacor SC) que puxa e interpreta
+  NÚMEROS DE NEGÓCIO do banco de produção em modo LEITURA: traduz a pergunta em SQL read-only
+  versionado, RODA a query direto via psql-ro (acesso read-only ao Postgres de prod) e
+  interpreta o resultado em decisão — sem pedir ao founder para colar nada. Use SEMPRE que o
   usuário pedir números do negócio, "brief da semana", "foco da semana", "como estão as
   vendas", "tem cliente caindo / em queda", "ruptura de estoque", "estoque parado / capital
   empatado", "concentração de carteira", "inadimplência", "aging de recebíveis/pagar",
@@ -24,44 +24,49 @@ Você é o copiloto de BI do dono do Grupo Colacor. Seu trabalho é transformar 
 negócio em **SQL read-only correto**, guiar a execução pelo Lovable e **interpretar o
 resultado em decisão** — não em uma tabela crua.
 
-## Por que esta skill existe (a restrição que define tudo)
+## Por que esta skill existe
 
-**Não há acesso direto ao banco.** Conforme o CLAUDE.md §5, o Lucas não tem terminal, `curl`,
-`psql`, Supabase CLI nem acesso ao Dashboard da Supabase. **Todo** acesso a dados passa pelo
-**SQL Editor dentro do Lovable**. Logo, esta skill NUNCA tenta "conectar no banco". Ela opera
-num loop manual-assistido com SQL versionado e análise guiada. Isso é uma feature, não um
-contorno: SQL canônico + conhecimento de schema + ritual semanal são exatamente o que faz
-sentido empacotar como skill.
+**A leitura do banco é direta.** Desde 2026-06 há acesso read-only ao Postgres de produção pelo
+wrapper `~/.config/afiacao/psql-ro` (role `claude_ro`, blindado `SESSION READ ONLY` +
+`statement_timeout 30s`, `BYPASSRLS` — enxerga todos os dados; `docs/agent/database.md §1`).
+Logo, **EU rodo as queries de BI e entrego a análise pronta** — o founder não cola nada. O valor
+da skill não é contornar falta de acesso (isso acabou): é o **SQL canônico + conhecimento de
+schema + ritual semanal** — as 4 grafias de "empresa", a confiabilidade de cada número, as
+queries que evitam as armadilhas do money-path. Sem isso, todo pedido de número vira SQL ad-hoc
+que erra coluna ou fabrica zero.
 
 ## O loop de operação (sempre siga esta ordem)
 
 ```
 1. ENTENDER  → traduza a pergunta de negócio para a(s) query(ies) canônica(s) do catálogo.
-2. GERAR     → emita o SQL read-only num bloco ```sql copiável, com cabeçalho rotulado:
-               "🟣 Lovable → SQL Editor → New query → cola → Run".
+2. RODAR     → execute o SELECT read-only VOCÊ MESMO via psql-ro (não peça pro founder):
+               ~/.config/afiacao/psql-ro -c "SELECT ..."   (ou -f caminho/da/query.sql)
                Diga o que cada query responde e o nível de confiabilidade do dado.
-3. AGUARDAR  → peça ao usuário para rodar e COLAR o resultado de volta (tabela/CSV/JSON).
-               Não invente números. Não prossiga sem o retorno.
-4. INTERPRETAR → leia o resultado LITERALMENTE. Traduza em achados, ordene por impacto,
-               marque confiabilidade e ressalvas. Se vazio, diga "sem linhas" — não fabrique.
+3. LER       → leia o resultado LITERALMENTE. Se vazio, diga "sem linhas" — não fabrique.
+4. INTERPRETAR → traduza em achados, ordene por impacto, marque confiabilidade e ressalvas.
 5. DECIDIR   → termine com "o que fazer com isso" (ação concreta), não só descrição.
 ```
 
-Quando a pergunta exigir várias queries (ex.: o brief semanal), **gere todas de uma vez** num
-conjunto ordenado e numerado. O SQL Editor do Lovable executa **um statement por vez** (cada
-query termina em `;`), então instrua o usuário a **rodar uma de cada vez e colar cada resultado
-identificado pelo número** (ex.: "#1: …", "#10a: …") — ele pode colar tudo de volta junto. O
-copia/cola do usuário é o gargalo, não o SQL: emitir o pacote inteiro de uma vez evita idas e
-vindas, mas a execução continua sendo query a query.
+**Nunca peça ao founder o que o psql-ro responde.** Se a resposta está no banco (qualquer
+leitura), VOCÊ busca e já entrega interpretada — "roda isso e me cola o resultado" para uma
+consulta é regressão ao mundo pré-psql-ro. Só envolva o founder quando o pedido exigir ESCRITA
+(mutação, aplicar correção, classificar na tela): aí é ele no SQL Editor do Lovable, gate humano
+do money-path.
+
+Quando a pergunta exigir várias queries (ex.: o brief semanal), rode-as em sequência via psql-ro
+e sintetize — não há mais gargalo de copia/cola. Tudo cabe no `statement_timeout 30s` do wrapper;
+se uma query de BI pesada estourar, enxugue a janela ou peça um índice. **Fallback** (só se o
+psql-ro estiver fora do ar): gere o bloco ` ```sql ` rotulado `🟣 Lovable → SQL Editor → cola →
+Run` e aí sim peça pro founder rodar — a exceção, nunca o fluxo.
 
 ## Guardrails inegociáveis
 
-- **Read-only, sempre.** Toda saída é `SELECT` / `WITH ... SELECT`. **NUNCA** emita
-  `INSERT`, `UPDATE`, `DELETE`, `TRUNCATE`, `ALTER`, `DROP`, `CREATE`, `GRANT`, `REFRESH
-  MATERIALIZED VIEW` nem `;` seguido de DML — **nem mesmo** se o usuário insistir invocando o
-  fluxo manual do CLAUDE.md §5. O §5 descreve *como* o usuário roda DDL/DML por conta própria
-  no Lovable; ele não te autoriza a escrever o comando destrutivo para ele copiar. Você é a
-  camada de leitura: o DML não nasce aqui.
+- **Read-only, sempre.** Toda query que você roda é `SELECT` / `WITH ... SELECT`. O próprio
+  wrapper te protege: `INSERT`/`UPDATE`/`DELETE`/`TRUNCATE`/`ALTER`/`DROP`/`CREATE`/`GRANT`/
+  `REFRESH MATERIALIZED VIEW` falham com `cannot execute ... in a read-only transaction`
+  (inclusive via RPC `SECURITY DEFINER`). Escrita é **sempre** do founder, no SQL Editor do
+  Lovable (gate humano do money-path, `docs/agent/database.md §1`) — você não escreve o comando
+  destrutivo para ele colar. Você é a camada de leitura: o DML não nasce aqui.
 - **Ao recusar uma mutação, ofereça uma saída read-only que resolva a dor real.** Quase todo
   pedido de "apagar/limpar/corrigir" é, no fundo, um problema de *relatório* ou de *diagnóstico*.
   Em vez de só dizer não: (1) gere um `SELECT` que dimensione o problema (quantas linhas, qual
@@ -135,8 +140,8 @@ Para pedidos fora do catálogo: parta da query canônica mais próxima, valide c
 ## Weekly Owner Brief (o entregável-âncora)
 
 Quando o usuário pedir "brief da semana", "foco da semana", "o que eu olho essa semana" ou
-um panorama executivo, rode o ritual completo: gere o **pacote de queries do brief**, aguarde os
-resultados colados, e sintetize **exatamente neste formato**. O pacote é (números exatos, com
+um panorama executivo, rode o ritual completo: rode o **pacote de queries do brief** via psql-ro
+e sintetize **exatamente neste formato**. O pacote é (números exatos, com
 sufixos — não deixe o leitor adivinhar): **#1 + #1b** (faturamento + momentum), **#2**
 (concentração), **#3** (clientes em queda), **#4** (ruptura), **#5** (estoque parado), **#7 + #8
 + #9** (reposição), **#10a + #10b** (inadimplência + top devedores), **#11a + #11b** (contas a
@@ -179,8 +184,8 @@ Regras do brief:
   impacto financeiro, cada uma ancorada num número do resultado.
 - **Seja honesto sobre confiabilidade.** A seção "Onde NÃO confiar" é obrigatória — o dono
   precisa saber a diferença entre faturamento fiscal (alta) e margem por produto (parcial).
-- **Números vêm do resultado colado, nunca da sua memória.** Se uma query não foi rodada,
-  marque a linha como "(pendente — rode #X)".
+- **Números vêm do resultado da query que você rodou, nunca da sua memória.** Se uma query
+  ainda não foi rodada, marque a linha como "(pendente — rode #X)".
 
 Se o usuário quiser uma fatia só (ex.: "só vendas e inadimplência"), gere apenas o
 sub-pacote e produza um mini-brief com as seções relevantes — não force o pacote inteiro.

--- a/.claude/skills/bi-colacor/references/queries-vendas.md
+++ b/.claude/skills/bi-colacor/references/queries-vendas.md
@@ -1,7 +1,7 @@
 # Queries canônicas — Vendas & Clientes
 
-Todas read-only. Período com defaults sensatos; o comentário diz onde ajustar. Cole no
-🟣 Lovable → SQL Editor → Run e cole o resultado de volta.
+Todas read-only. Período com defaults sensatos; o comentário diz onde ajustar. Eu rodo cada
+uma via psql-ro (`~/.config/afiacao/psql-ro -c "..."`); fallback: cola no SQL Editor do Lovable.
 
 ---
 

--- a/.claude/skills/cfo-colacor/SKILL.md
+++ b/.claude/skills/cfo-colacor/SKILL.md
@@ -12,8 +12,9 @@ description: >-
   simulação tributária, "como está o caixa", "rodar o fechamento", "quanto vou pagar de
   imposto", "perto do teto do Simples", "perguntas pro contador", ou qualquer diagnóstico
   financeiro gerencial das 3 empresas — mesmo sem citar "CFO". Trabalha 100% READ-ONLY:
-  gera SELECT pra colar no SQL Editor do Lovable e interpreta o resultado; NÃO apura imposto
-  final, NÃO substitui contador, NÃO faz planejamento fiscal agressivo.
+  roda os SELECT direto via psql-ro (acesso read-only ao Postgres de prod) e interpreta o
+  resultado — sem pedir ao founder pra colar; NÃO apura imposto final, NÃO substitui contador,
+  NÃO faz planejamento fiscal agressivo.
   NÃO use (são outras skills) para: debugar erro/falha de sync do Omie (→ investigate),
   escrever no banco — migrations, cron, INSERT/UPDATE (→ supabase), refatorar código do
   módulo financeiro (.tsx), planilhas xlsx avulsas, comissão de vendedor, gráficos de vendas,
@@ -54,9 +55,11 @@ risco de compliance). Sempre que chegar perto da fronteira, pare e marque
 3. **Não faz planejamento fiscal agressivo.** Nada de "abre tal CNPJ", "muda o regime pra
    pagar menos", "distribui assim pra escapar de X". Se o usuário pedir, redirecione pra uma
    pergunta a ser levada ao contador, conservadoramente.
-4. **Tudo que toca o banco é READ-ONLY e via Lovable.** Você NUNCA escreve no banco. Você
-   gera `SELECT` (e só `SELECT`) pra o usuário colar no **SQL Editor do Lovable**. Sem
-   terminal, sem `curl`, sem CLI, sem `INSERT/UPDATE/DELETE/DDL`. Ver §5 do CLAUDE.md.
+4. **Tudo que toca o banco é READ-ONLY.** Leitura você RODA direto via
+   `~/.config/afiacao/psql-ro` (read-only blindado). Você NUNCA escreve: o wrapper barra
+   `INSERT/UPDATE/DELETE/DDL` (`cannot execute ... in a read-only transaction`, inclusive via
+   RPC `SECURITY DEFINER`) e, se um dia surgir uma mutação necessária, ela é do founder no
+   **SQL Editor do Lovable** (gate do money-path). Ver `docs/agent/database.md §1`.
 5. **Quando não souber a regra tributária/contábil, pergunte ou marque "confirmar com
    contador".** Não invente alíquota, presunção, anexo de Simples, ou tratamento contábil.
 
@@ -76,16 +79,20 @@ Nas tabelas `fin_*` a empresa é a coluna `company text` com exatamente estas st
 
 ## Como você acessa os dados (importante)
 
-Você **não tem acesso ao banco**. O fluxo é sempre o mesmo, e você o conduz:
+Você tem **leitura direta** do Postgres de produção via `~/.config/afiacao/psql-ro` (role
+`claude_ro`, read-only blindado, `BYPASSRLS` — enxerga tudo, sem depender de perfil de app;
+`docs/agent/database.md §1`). O fluxo:
 
-1. Você entrega ao usuário um bloco SQL **read-only** (a partir de `assets/sql/`, adaptando
-   período/empresa). Rotule sempre: **"🟣 Lovable → SQL Editor → cola → Run"**.
-2. O usuário roda no Lovable e cola o resultado de volta no chat.
-3. Você interpreta o resultado, aplica os thresholds, e avança no ritual.
+1. Pegue o `SELECT` read-only de `assets/sql/`, adapte período/empresa, e RODE você mesmo:
+   `~/.config/afiacao/psql-ro -f .claude/skills/cfo-colacor/assets/sql/00-sanity-status.sql`
+   (ou `-c "SELECT ..."`).
+2. Leia o resultado, aplique os thresholds, e avance no ritual.
+3. **Só peça algo ao founder quando for ESCRITA** (aplicar correção, classificar categoria em
+   `/financeiro/mapping`, fechar período) ou dado fora do banco — **nunca** peça pra ele rodar
+   ou colar uma leitura que o psql-ro já responde.
 
-Trabalhe em **lotes**: entregue as queries de uma etapa, espere os resultados, interprete,
-e só então passe pra próxima. Não despeje 8 queries de uma vez — o usuário roda uma de cada
-vez no Lovable.
+Rode as queries de uma etapa em sequência (o gargalo do copia/cola do founder acabou); só
+respeite o `statement_timeout 30s` do wrapper — query pesada que estourar, enxugue a janela.
 
 **Primeira query sempre é a de sanidade** (`assets/sql/00-sanity-status.sql`): valida os valores reais de `status_titulo` e a data do último sync. **Armadilha-mãe (money-path):** o `saldo` **NÃO zera na baixa** — só o `status_titulo` muda; filtre "aberto" por `status_titulo`, **NUNCA por `saldo > 0`** (senão conta quitado como aberto e infla tudo). Os status vêm **com espaço**. Os valores exatos de status, as 8 armadilhas e o caso real (CR da Colacor: R$129k que aparecia como R$17,7M) em `references/schema-financeiro.md` — **leia antes do fechamento**.
 
@@ -192,8 +199,9 @@ Pergunta: "o resultado gerencial do mês é confiável o suficiente pra eu usar?
 Pergunta: "o que está caindo no balde errado do DRE?".
 A query (a) do template lê **direto** as categorias Omie com movimento no período sem linha
 explícita em `fin_categoria_dre_mapping` (que então caem em heurística por palavra-chave, sujeita
-a erro). ⚠️ **Não use a RPC `fin_categorias_sem_mapping`** no SQL Editor: ela tem gate "requer
-perfil financeiro" e devolve `42501: Acesso negado` na sessão do Lovable — a query direta é a
+a erro). ⚠️ **Não chame a RPC `fin_categorias_sem_mapping`**: é `SECURITY DEFINER` com gate
+"requer perfil financeiro" e devolve `42501: Acesso negado` em QUALQUER sessão sem `auth.uid()`
+do app — tanto o `psql-ro` quanto o SQL Editor do Lovable (`database.md §5`). A query direta é a
 mesma lógica (CR+CP por `data_emissao`, fallback `_default`), sem gate.
 - Toda categoria com valor relevante sem mapeamento vira: (a) uma recomendação de classificar
   em `/financeiro/mapping`, e (b) uma candidata a **pergunta pro contador** ("a categoria X é

--- a/.claude/skills/cfo-colacor/assets/sql/00-sanity-status.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/00-sanity-status.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 00 — SANIDADE (rode SEMPRE primeiro)
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- Valida os valores REAIS de status_titulo e o frescor dos dados antes de tudo.
 -- Status reais (COM espaço): receber = 'A VENCER'/'ATRASADO'/'VENCE HOJE'/'RECEBIDO'/'CANCELADO';

--- a/.claude/skills/cfo-colacor/assets/sql/01-caixa-13-semanas.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/01-caixa-13-semanas.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 01 — CAIXA: projeção 13 semanas + TRIANGULAÇÃO (saldo por conta + fluxo real)
--- 🟣 Lovable → SQL Editor → cola → Run  (rode uma query por vez)
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- ⚠️ CORRIGIDO (1º fechamento real, 2026-06-16):
 --  • "Aberto" filtra por status_titulo, NUNCA por saldo>0 — o saldo NÃO zera na

--- a/.claude/skills/cfo-colacor/assets/sql/02-ncg-capital-giro.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/02-ncg-capital-giro.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 02 — NCG / CAPITAL DE GIRO (decomposição ACO − PCO), por empresa
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- NCG = ACO − PCO
 --   ACO = CR aberto + estoque + adiantamentos a fornecedor

--- a/.claude/skills/cfo-colacor/assets/sql/03-inadimplencia-aging.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/03-inadimplencia-aging.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 03 — INADIMPLÊNCIA POR AGING (recebíveis)
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- Política do dono: flag desde o 1º dia de atraso, ação graduada por faixa:
 --   D+1 a D+7   → WhatsApp/e-mail   | D+8 a D+30 → ligação

--- a/.claude/skills/cfo-colacor/assets/sql/04-dre-confiabilidade.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/04-dre-confiabilidade.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 04 — DRE GERENCIAL + CONFIABILIDADE
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- fin_dre_snapshots tem 1 linha por (company, ano, mes, regime). SEMPRE filtre
 -- regime ('caixa' | 'competencia') — senão soma os dois e dobra tudo.

--- a/.claude/skills/cfo-colacor/assets/sql/05-categorias-sem-mapeamento.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/05-categorias-sem-mapeamento.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 05 — CATEGORIAS SEM MAPEAMENTO DRE
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- Categorias Omie com movimento no período que NÃO têm linha explícita em
 -- fin_categoria_dre_mapping — caem na heurística por palavra-chave (sujeita a
@@ -8,12 +8,12 @@
 -- (b) candidata a pergunta pro contador ("X é CMV ou despesa operacional?").
 -- READ-ONLY.
 --
--- ⚠️ NÃO use a RPC fin_categorias_sem_mapping(company,start,end) no SQL Editor:
+-- ⚠️ NÃO chame a RPC fin_categorias_sem_mapping(company,start,end):
 --    ela é SECURITY DEFINER com gate "requer perfil financeiro"
 --    (auth.role()='service_role' OR fin_user_can_access(company)) e dá
---    `ERROR: 42501: Acesso negado: requer perfil financeiro` na sessão do SQL
---    Editor (sem perfil). A query (a) abaixo é a MESMA lógica, direta nas
---    tabelas — roda sem gate.
+--    `ERROR: 42501: Acesso negado: requer perfil financeiro` em QUALQUER sessão
+--    sem auth.uid() do app — tanto o psql-ro quanto o SQL Editor. A query (a)
+--    abaixo é a MESMA lógica, direta nas tabelas — roda sem gate.
 -- ============================================================================
 
 -- (a) Categorias com movimento no período SEM linha no DRE (nem na empresa nem

--- a/.claude/skills/cfo-colacor/assets/sql/06-carga-tributaria.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/06-carga-tributaria.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 06 — CARGA TRIBUTÁRIA OBSERVADA (NÃO é apuração — ver guardrail 1 do SKILL.md)
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- Isto é um TERMÔMETRO gerencial: alíquota efetiva = impostos ÷ receita_bruta do
 -- DRE. NÃO é o imposto a pagar (DAS/DARF), que é do contador. Divergência grande

--- a/.claude/skills/cfo-colacor/assets/sql/07-intercompany.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/07-intercompany.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 07 — INTERCOMPANY (operações entre Colacor, Oben e Colacor SC)
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- Divergências aqui distorcem o consolidado e quase sempre viram pergunta pro
 -- contador (ex.: "a NF da Colacor pra Oben está lançada nas duas pontas pelo

--- a/.claude/skills/cfo-colacor/assets/sql/08-orcamento-fechamento.sql
+++ b/.claude/skills/cfo-colacor/assets/sql/08-orcamento-fechamento.sql
@@ -1,6 +1,6 @@
 -- ============================================================================
 -- 08 — ORÇADO vs REALIZADO + STATUS DE FECHAMENTO
--- 🟣 Lovable → SQL Editor → cola → Run
+-- 🟢 read-only → eu rodo via psql-ro (fallback: cola no SQL Editor do Lovable)
 -- ----------------------------------------------------------------------------
 -- Fecha o ritual mensal: (a) o mês já foi formalmente fechado/aprovado no sistema?
 -- (b) o realizado bateu com o orçamento por linha do DRE? Só roda se houver

--- a/.claude/skills/cfo-colacor/references/schema-financeiro.md
+++ b/.claude/skills/cfo-colacor/references/schema-financeiro.md
@@ -186,9 +186,10 @@ estoque no ACO/NCG (mas o engine não lê — usa 0). Pega o `valor` mais recent
 ## RPCs e views úteis
 - **`fin_categorias_sem_mapping(p_company text, p_start date, p_end date)`** → `(omie_codigo,
   categoria_nome, valor_periodo)` de categorias com valor sem linha em `fin_categoria_dre_mapping`.
-  Filtra por `data_emissao`. ⚠️ **NÃO usar no SQL Editor** — é SECURITY DEFINER com gate de perfil
+  Filtra por `data_emissao`. ⚠️ **NÃO chamar** — é SECURITY DEFINER com gate de perfil
   (`auth.role()='service_role' OR fin_user_can_access(company)`; senão `RAISE 'Acesso negado: requer
-  perfil financeiro'`, SQLSTATE **42501**), e a sessão do SQL Editor do Lovable não tem perfil. O
+  perfil financeiro'`, SQLSTATE **42501**) que barra QUALQUER sessão sem `auth.uid()` do app —
+  tanto o `psql-ro` quanto o SQL Editor do Lovable. O
   **bloco 5 usa a query DIRETA equivalente** nas tabelas (CR+CP por `data_emissao` + categoria sem
   `dre_linha` no mapping, com fallback `_default`), não a RPC.
 - `fin_calcular_confiabilidade(p_company, p_ano, p_mes)` — popula `fin_confiabilidade` (write —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@
 | lente "Ver como" (impersonação, write-guard) | [impersonation.md](docs/agent/impersonation.md) |
 | telefonia (WebRTC, SIP, LGPD) | [telefonia.md](docs/agent/telefonia.md) |
 | skills & MCPs (roteamento canônico) | [skills.md](docs/agent/skills.md) |
+| **mapa do app** ("onde faço X" · rotas/módulos por gate) | [mapa-do-app.md](docs/agent/mapa-do-app.md) |
 | worktrees · multi-sessão · RAM/Node · `heavy` | [worktrees.md](docs/agent/worktrees.md) |
 
 Diário de PR/entregas: `docs/historico/` (`bugs-resolvidos.md`, `programas-vendas.md`, `auditoria-ux-redesign.md`, `estoque-picking-recebimento.md`). Runbook passo-a-passo de banco/deploy: `docs/runbooks/lovable-supabase.md`.

--- a/docs/agent/mapa-do-app.md
+++ b/docs/agent/mapa-do-app.md
@@ -1,0 +1,45 @@
+# Mapa do app — "onde eu faço X?" (rotas/funcionalidades)
+
+> Índice de alto nível dos módulos e rotas do Afiação/Colacor, para responder "onde que eu faço isso mesmo?" sem varrer o código. **Fonte viva: `src/App.tsx`** (~119 rotas lazy, agrupadas por gate). Este mapa é de MÓDULO/PREFIXO — para a rota exata de uma tela nova, `grep` no `App.tsx`. Roles/gates em `useAuth()` (CLAUDE.md §Auth). **Não** listar as 119 rotas aqui (apodrece) — manter alto nível.
+
+## Como o `App.tsx` está organizado (gates)
+
+Tudo autenticado vive em `<ProtectedRoute><AppShellLayout>` e se divide em faixas de acesso:
+- **Abertas (cliente + staff)** — loja/afiação, tarefas.
+- **`RequireFinanceiroAccess`** — tudo em `/financeiro`.
+- **`RequireStaff`** (fail-closed: todo o resto) — o grosso do sistema operacional.
+- Sub-gates: `RequireCaca` (`/caca`), sub-layout de sessão na Reposição.
+
+## Módulos → prefixo → o que é
+
+| Módulo | Prefixo de rota | Gate | Telas-chave |
+|---|---|---|---|
+| Afiação / Loja (cliente) | `/`, `/orders`, `/new-order`, `/tools`, `/loyalty`, `/gamification`, `/training`, `/savings` | aberto | pedido de afiação, histórico de ferramenta, fidelidade, treinamento |
+| Tarefas | `/tarefas`, `/tarefas/templates` | aberto | tarefas operacionais + templates |
+| Financeiro | `/financeiro/*` | `RequireFinanceiroAccess` | `capital-giro` (fluxo 13s/NCG), DRE, `tributario`, `mapping` de categoria, fechamento |
+| Vendas | `/sales/*` | staff | pipeline / venda assistida por IA |
+| Farmer / Inteligência | `/farmer/*`, `/meu-dia`, `/coaching`, `/intelligence`, `/executive/dashboard`, `/radar` | staff | plano tático, bundles, IPF, radar de empresas |
+| Admin / CRM | `/admin/*` (customers, orders, approvals, price-table, demand-forecast) | staff | clientes, aprovações, tabela de preço, previsão de demanda |
+| Tintométrico | `/tintometrico/*` | staff | catálogo, integração, fórmulas |
+| Estoque / Recebimento | `/admin/estoque/*`, `/recebimento/*` | staff | picking, recebimento (offline-first) |
+| Produção | `/producao/*` | staff | ordens de produção |
+| Reposição / Compras | `/admin/reposicao/*`, `/admin/sku-mapeamento` | staff | pedidos do ciclo, sessão de compra, de-para Sayerlack |
+| Governança / Gestão | `/governance/*`, `/gestao/*` | staff | saúde de dados, melhorias, grupos de cliente |
+| Base de Conhecimento / Processos | `/admin/knowledge-base/*`, `/admin/standard-processes/*` | staff | boletim↔SKU, processos-padrão |
+| Telefonia / WhatsApp / Rota | `/telefonia`, `/whatsapp/*`, `/rota/*` | staff | discador WebRTC, atendimento, roteirização |
+| Caça (prospecção) | `/caca` | `RequireCaca` | prospecção de leads |
+| Plataforma (config/design/docs) | `/ai-ops`, `/design-system`, `/settings`, `/docs`, `/admin/ajuda` | staff | ai-ops, design system, docs técnicas, ajuda |
+
+## "Onde eu faço X?" (por intenção → módulo)
+
+- **Caixa / DRE / inadimplência / fluxo 13 semanas** → `/financeiro`. Para ANÁLISE sem abrir tela, use as skills `cfo-colacor` (fechamento/controladoria) e `bi-colacor` (número rápido) — elas rodam via `psql-ro`.
+- **Aprovar/disparar pedido de compra, ver ruptura/sugestões, estoque parado** → `/admin/reposicao` (número/diagnóstico sem tela → `bi-colacor`).
+- **Picking / receber mercadoria** (chão de fábrica, offline-first) → `/recebimento`, `/admin/estoque`.
+- **Preço de tinta / fórmula tintométrica** → `/tintometrico`.
+- **Cadastro/aprovação de cliente, tabela de preço, previsão de demanda** → `/admin` (customers, approvals, price-table, demand-forecast).
+- **Boletim técnico ↔ SKU (base de conhecimento)** → `/admin/knowledge-base`.
+- **Saúde dos dados / sync / backlog de melhorias** → Governança/Gestão (`/gestao`, `/governance`). Sync quebrado → skill `diagnose-supabase-sync`.
+- **Plano do dia do vendedor, radar de oportunidade, coaching** → `/meu-dia`, `/radar`, `/farmer`.
+- **Telefonar (WebRTC) / WhatsApp / roteiro de visita** → `/telefonia`, `/whatsapp`, `/rota`.
+
+> Manutenção: quando um módulo NOVO nascer (prefixo novo no `App.tsx`), acrescente 1 linha aqui. Telas individuais que mudam de rota NÃO precisam entrar — o `grep` no `App.tsx` é a fonte exata.

--- a/docs/agent/reposicao.md
+++ b/docs/agent/reposicao.md
@@ -2,6 +2,30 @@
 
 > Motor de pedidos sugeridos + portal Sayerlack. Princípios em `docs/agent/money-path.md`. Specs: `docs/superpowers/specs/2026-0*-reposicao-*` e `*sayerlack*`. Diário em `docs/historico/bugs-resolvidos.md`.
 
+## Léxico de embalagens & fornecedores (dicionário de domínio)
+
+Vocabulário que o founder assume ao falar de reposição (antes re-explicado a cada sessão). Dado VIVO (litragem por SKU, LT por grupo, taxa de fornecedor) eu puxo via `psql-ro` — não peço ao founder.
+
+**Embalagens — sufixo Sayerlack → litros.** Fonte-de-verdade: `litrosDaEmbalagem` em `src/lib/venda-assistida/preco-preparado.ts` (**confirmado pelo founder 2026-06-14**). A versão **"base"** (concentrado; detectada pela palavra "base" na descrição) rende MENOS líquido e só existe em QT/GL/BH:
+
+| Sufixo | Nome | Litros | Litros (base) |
+|---|---|---|---|
+| `QT` | quartinho | 0,9 | 0,81 |
+| `GL` | galão | 3,6 | 3,24 |
+| `BH` | balde | 20 | 18 |
+| `LT` | — | 18 | — |
+| `L5` / `BB` | — | 5 | — |
+| `BD` | — | 18 | — |
+| `405ML` | fracionado (pai é QT; manda a descrição) | 0,405 | — |
+
+`CGL` **não existe** → `null` ("sob consulta"); sufixo fora da tabela → `null`. **Nunca chute litragem** (é money-path de pricing: litro errado = preço errado). Em ml (a linha de tint fala em ml, versão base): QT 810 · GL 3240 · BH 18000.
+
+**Fator do motor ≠ litragem.** O motor consolida grupo/escolhe embalagem pelo fator RELATIVO `sku_embalagem_equivalencia.fator_para_base` (QT=1, GL=4 — bate com 3,6÷0,9), não pela litragem absoluta; `qtde_final` do pedido é **nº de embalagens**, não litros (§Motor). Âncora = sempre o fator-1 (galão nunca é âncora).
+
+**Lead time por grupo — computado, não tabelado.** Sai do histórico (`sku_leadtime_history.grupo_leadtime`) → `sku_parametros` (`lt_medio_dias_uteis`, `lt_p95_dias`, `lt_desvio_padrao_dias`, `fonte_leadtime`) via `v_sku_leadtime_estatisticas`/`v_sku_lt_teorico`. `v_sku_lt_teorico` só dá LT com linha em `sku_grupo_producao` **E** fornecedor do grupo (senão `SEM_LEADTIME_DEFINIDO`, ver §Outras frentes). Para o LT de um grupo hoje, rode `psql-ro`.
+
+**Fornecedores OBEN recorrentes.** **Sayerlack** é o especial (portal/scraping, auto-aprovação N3, alerta R$3k, corte de pedido — §Portal Sayerlack); além dele, **Acre Caxias**, **Beta**, **Sapiranga**. Todos com **baixa taxa de auto-aprovação** (global 17% — superdimensionamento sistêmico do motor, não de um fornecedor; percentuais por fornecedor em §Mínimo forçado). A **Oben paga a maioria à vista** (com desconto à vista). Cadastro/limites por fornecedor (horário de corte, valor máx mensal, delta máx): `fornecedor_habilitado_reposicao`.
+
 ## Motor de pedidos de compra
 
 - RPC **`gerar_pedidos_sugeridos_ciclo`** gera as sugestões do ciclo. **JOIN `omie_products` account-aware** — `omie_products.account` é convenção EMPRESA (`oben`/`colacor`/`colacor_sc`); JOIN account-blind **duplica silenciosamente** (sem UNIQUE no item) — ver `docs/agent/database.md`.


### PR DESCRIPTION
## O quê / porquê

`bi-colacor` e `cfo-colacor` ainda se descreviam como "MANUAL-ASSISTIDO / banco só acessível pelo SQL Editor" — o mundo pré-`psql-ro` (14/jun). Resultado medido: pedido de margem respondido com SQL ad-hoc, sem skill. Escopo em §11 de `docs/historico/melhorias-code-2026-07.md`.

## Mudanças

- **bi/cfo-colacor (description + corpo):** leitura migrada de "gera SQL → founder cola no SQL Editor → cola de volta" para **"EU rodo o SELECT via `~/.config/afiacao/psql-ro` e interpreto"**. Escrita continua do founder no SQL Editor (gate humano do money-path). Regra nova: **"nunca peça ao founder o que o psql-ro responde"**.
- **Armadilha preservada:** RPC `SECURITY DEFINER` gateada (42501) falha **também no psql-ro** (sem `auth.uid()`), não só no SQL Editor → a query direta nas tabelas segue sendo o caminho (ajustado em SKILL.md, schema-financeiro.md, 05*.sql).
- **9 `assets/sql/*.sql` + `queries-vendas.md`:** cabeçalho `🟣 SQL Editor` → `🟢 psql-ro (fallback: SQL Editor)`.
- **`docs/agent/reposicao.md`:** nova seção **Léxico de embalagens & fornecedores** (código→litragem QT/GL/BH/LT + bases, fator do motor ≠ litragem, LT por grupo, fornecedores). Litragem da fonte-de-verdade `litrosDaEmbalagem` (`preco-preparado.ts`), confirmada 2026-06-14 — sem fabricar número.
- **`docs/agent/mapa-do-app.md` (novo)** + 1 linha no índice do `CLAUDE.md`: "onde faço X?" por módulo/prefixo/gate, `App.tsx` como fonte viva.

## Prova (RED→GREEN)

Subagente fresco lendo só a `SKILL.md`, mesma tarefa ("margem por empresa" / "pulso semanal"):
- **RED** (skill antiga): *"quem roda é o dono, no SQL Editor... cola o resultado de volta"*.
- **GREEN** (skill nova): *"eu mesmo executo via `psql-ro -c/-f`; não peço ao founder pra colar"*.

`bun run claude:size` ✅ (13.103/20.480 B). Sem código TS tocado; nenhum teste referencia as skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)