### PR TITLE
feat(reposicao): particiona fila de atenção — "barrados por mínimo" saem do vermelho

### DIFF
--- a/src/components/reposicao/pedidos/AbaixoMinimoCard.tsx
+++ b/src/components/reposicao/pedidos/AbaixoMinimoCard.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { Ban, ChevronDown, ChevronRight, Eye } from 'lucide-react';
+import { format } from 'date-fns';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { formatBRL } from './shared';
+import { OverrideMinimoButton } from './OverrideMinimoButton';
+import type { PedidoSugerido } from './types';
+
+// Seção NEUTRA (recolhida) da fila de atenção: pedidos barrados pelo gate de
+// mínimo de faturamento Sayerlack (< R$3k). São benignos — o motor re-sugere o
+// SKU no próximo ciclo se ele seguir abaixo do ponto, ou o estoque normaliza —
+// então NÃO ficam no vermelho de "precisa de atenção". Mas seguem VISÍVEIS
+// (contador + total + mais antigo + ação), porque o risco residual é stockout
+// silencioso, não compra-dupla.
+//
+// ⚠️ Copy honesta (Codex xhigh): NÃO prometemos "vai acumular até R$3k" — nos
+// dados reais, pedidos já tinham normalizado sem aguardar nada. Só descrevemos o
+// estado factual (barrado; pode reaparecer OU sumir).
+export function AbaixoMinimoCard({
+  pedidos,
+  podeOverride,
+  onDetalhes,
+  onOverride,
+  disparandoLinha,
+}: {
+  pedidos: PedidoSugerido[];
+  podeOverride: boolean;
+  onDetalhes: (p: PedidoSugerido) => void;
+  onOverride: (id: number) => void;
+  disparandoLinha: (id: number) => boolean;
+}) {
+  const [aberto, setAberto] = useState(false);
+  if (pedidos.length === 0) return null;
+
+  const total = pedidos.reduce((s, p) => s + Number(p.valor_total ?? 0), 0);
+  // Mais antigo pela data do ciclo (YYYY-MM-DD ordena lexicograficamente).
+  const maisAntigo = pedidos.reduce(
+    (min, p) => (p.data_ciclo < min ? p.data_ciclo : min),
+    pedidos[0].data_ciclo,
+  );
+
+  return (
+    <Card className="border-border">
+      <CardHeader className="cursor-pointer select-none" onClick={() => setAberto((v) => !v)}>
+        <CardTitle className="text-base flex items-center gap-2 text-muted-foreground">
+          {aberto ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+          <Ban className="w-4 h-4" />
+          Barrados pelo mínimo de faturamento ({pedidos.length})
+        </CardTitle>
+        <p className="text-sm text-muted-foreground">
+          Não enviados porque ficaram abaixo do mínimo do fornecedor (R$3k). Podem reaparecer
+          sozinhos se o SKU continuar abaixo do ponto — ou somem quando o estoque normaliza. Não
+          exigem ação. Total {formatBRL(total)} · mais antigo{' '}
+          {format(new Date(maisAntigo + 'T12:00:00'), 'dd/MM/yyyy')}.
+        </p>
+      </CardHeader>
+      {aberto && (
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Ciclo</TableHead>
+                <TableHead>Fornecedor / Grupo</TableHead>
+                <TableHead className="text-right">Nº SKUs</TableHead>
+                <TableHead className="text-right">Valor</TableHead>
+                <TableHead className="text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {pedidos.map((p) => (
+                <TableRow key={p.id}>
+                  <TableCell className="text-xs tabular-nums whitespace-nowrap">
+                    {format(new Date(p.data_ciclo + 'T12:00:00'), 'dd/MM/yyyy')}
+                  </TableCell>
+                  <TableCell>
+                    <div className="font-medium">{p.fornecedor_nome}</div>
+                    <div className="text-xs text-muted-foreground">{p.grupo_codigo ?? '—'}</div>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">{p.num_skus}</TableCell>
+                  <TableCell className="text-right tabular-nums font-medium">{formatBRL(p.valor_total)}</TableCell>
+                  <TableCell>
+                    <div className="flex justify-end gap-1">
+                      <Button size="sm" variant="ghost" onClick={() => onDetalhes(p)}>
+                        <Eye className="w-4 h-4 mr-1" />Detalhes
+                      </Button>
+                      {podeOverride && (
+                        <OverrideMinimoButton
+                          fornecedorNome={p.fornecedor_nome}
+                          valorTotal={p.valor_total}
+                          onConfirm={() => onOverride(p.id)}
+                          disabled={disparandoLinha(p.id) || p.status_envio_portal === 'enviando_portal'}
+                        />
+                      )}
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/src/components/reposicao/pedidos/__tests__/atencao-particao.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/atencao-particao.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { ehAbaixoMinimoBenigno, particionarAtencao } from '../shared';
+import type { StatusEnvioPortal } from '../types';
+
+// Helper: pedido mínimo p/ os predicados de partição da fila de atenção.
+// gate='minimo_faturamento' só "conta" quando status='falha_envio' (contrato de
+// ehGateMinimoFaturamento). resposta_canal é a coluna jsonb (gate mora nela).
+const mk = (
+  status: string,
+  portal: StatusEnvioPortal | null | undefined = null,
+  gate: string | null = null,
+) => ({
+  status,
+  status_envio_portal: portal,
+  resposta_canal: gate ? { gate } : null,
+});
+
+const GATE = 'minimo_faturamento';
+
+describe('ehAbaixoMinimoBenigno (A′ · partição da fila de atenção)', () => {
+  it('gate de mínimo puro (portal nao_aplicavel/null) → benigno', () => {
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', null, GATE))).toBe(true);
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'nao_aplicavel', GATE))).toBe(true);
+  });
+
+  it('gate de mínimo + erro_retentavel → benigno (o retry-órfãos re-tenta; não é fila de atenção)', () => {
+    // Espelha o caso REAL do pedido 1002: falha_envio + gate + erro_retentavel.
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'erro_retentavel', GATE))).toBe(true);
+  });
+
+  // ── O achado do Codex (xhigh): PORTAL VENCE SEMPRE ──
+  // Um pedido pode ser gate-mínimo E estar em conciliação (PO talvez já exista
+  // no fornecedor). Recolhê-lo no balde neutro esconderia risco de compra-dupla.
+  it('gate de mínimo + estado de conciliação → NÃO benigno (portal vence)', () => {
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'aceito_portal_sem_protocolo', GATE))).toBe(false);
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'indeterminado_requer_conciliacao', GATE))).toBe(false);
+  });
+
+  it('gate de mínimo + falha dura do portal → NÃO benigno (portal vence)', () => {
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'falha_envio_portal', GATE))).toBe(false);
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'erro_nao_retentavel', GATE))).toBe(false);
+  });
+
+  it('falha_envio SEM gate de mínimo (SKU sem custo / erro Omie) → NÃO benigno', () => {
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', null, null))).toBe(false);
+    expect(ehAbaixoMinimoBenigno(mk('falha_envio', 'nao_aplicavel', 'outro_gate'))).toBe(false);
+  });
+
+  it('conciliação pura sem gate (disparado + portal ambíguo) → NÃO benigno', () => {
+    expect(ehAbaixoMinimoBenigno(mk('disparado', 'aceito_portal_sem_protocolo', null))).toBe(false);
+  });
+});
+
+describe('particionarAtencao', () => {
+  it('separa vermelha (ação real) × abaixoMinimo (benigno) e preserva todos', () => {
+    const lista = [
+      mk('falha_envio', null, GATE), // benigno
+      mk('falha_envio', 'indeterminado_requer_conciliacao', GATE), // portal vence → vermelha
+      mk('falha_envio', null, null), // SKU sem custo → vermelha
+      mk('disparado', 'aceito_portal_sem_protocolo', null), // conciliação → vermelha
+      mk('falha_envio', 'erro_retentavel', GATE), // benigno
+    ];
+    const { vermelha, abaixoMinimo } = particionarAtencao(lista);
+    expect(abaixoMinimo).toHaveLength(2);
+    expect(vermelha).toHaveLength(3);
+    // nada some
+    expect(vermelha.length + abaixoMinimo.length).toBe(lista.length);
+  });
+
+  it('lista vazia → duas listas vazias', () => {
+    const { vermelha, abaixoMinimo } = particionarAtencao([]);
+    expect(vermelha).toEqual([]);
+    expect(abaixoMinimo).toEqual([]);
+  });
+});

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -236,6 +236,49 @@ export function ehGateMinimoFaturamento(p: {
   return p.status === 'falha_envio' && p.resposta_canal?.gate === 'minimo_faturamento';
 }
 
+/* ─── Partição da fila de atenção: ação real × barrado por mínimo (A′) ─── */
+//
+// A fila "precisa de atenção" mistura dois animais com risco money-path MUITO
+// diferente:
+//  - BENIGNO: falha_envio por gate de mínimo de faturamento Sayerlack (fornecedor
+//    não fatura < R$3k). O pedido NÃO foi comprado e o motor re-sugere o SKU no
+//    ciclo seguinte se ele seguir abaixo do ponto (ou o estoque normaliza). Não há
+//    risco de compra-dupla — só de stockout silencioso. Vira RUÍDO vermelho que
+//    acumula (o gate não dedup) e gera fadiga de alerta.
+//  - AÇÃO REAL: conciliação de PO (aceito_portal_sem_protocolo / requer_conciliacao
+//    — o pedido PODE já existir no fornecedor), falhas duras do portal, e qualquer
+//    OUTRO falha_envio (SKU sem custo, qtde 0, erro do Omie).
+//
+// ⚠️ PORTAL VENCE SEMPRE (Codex xhigh, money-path): um pedido pode ser gate-mínimo
+// E TAMBÉM estar em conciliação de portal. Recolhê-lo no balde benigno esconderia
+// risco de comprar 2× no fornecedor. Só é benigno quem é gate-mínimo E não tem
+// NENHUM status_envio_portal de atenção.
+export function ehAbaixoMinimoBenigno(p: {
+  status: string;
+  status_envio_portal: StatusEnvioPortal | null | undefined;
+  resposta_canal: { gate?: unknown; [key: string]: unknown } | null | undefined;
+}): boolean {
+  return (
+    ehGateMinimoFaturamento(p) &&
+    !STATUS_PORTAL_PRECISA_ATENCAO.has((p.status_envio_portal ?? 'nao_aplicavel') as StatusEnvioPortal)
+  );
+}
+
+// Particiona a fila (JÁ filtrada por pedidoPrecisaAtencao na query) em:
+//  - vermelha: exige ação humana AGORA (alarme no topo conta ISTO).
+//  - abaixoMinimo: barrado por mínimo do fornecedor, benigno (seção neutra recolhida).
+// Nada some — a soma das duas é a lista de entrada.
+export function particionarAtencao<T extends {
+  status: string;
+  status_envio_portal: StatusEnvioPortal | null | undefined;
+  resposta_canal: { gate?: unknown; [key: string]: unknown } | null | undefined;
+}>(lista: readonly T[]): { vermelha: T[]; abaixoMinimo: T[] } {
+  const vermelha: T[] = [];
+  const abaixoMinimo: T[] = [];
+  for (const p of lista) (ehAbaixoMinimoBenigno(p) ? abaixoMinimo : vermelha).push(p);
+  return { vermelha, abaixoMinimo };
+}
+
 /* ─── Split (PR5) — esconder o pai da lista ─── */
 //
 // Quando um pedido grande é dividido em chunks, o PAI vira status='split_em_filhos':

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -34,7 +34,8 @@ import { CancelarModal } from '@/components/reposicao/pedidos/CancelarModal';
 import { PortalDrawer } from '@/components/reposicao/pedidos/PortalDrawer';
 import { CiclosAnteriores } from '@/components/reposicao/pedidos/CiclosAnteriores';
 import { OverrideMinimoButton } from '@/components/reposicao/pedidos/OverrideMinimoButton';
-import { ehGateMinimoFaturamento } from '@/components/reposicao/pedidos/shared';
+import { ehGateMinimoFaturamento, particionarAtencao } from '@/components/reposicao/pedidos/shared';
+import { AbaixoMinimoCard } from '@/components/reposicao/pedidos/AbaixoMinimoCard';
 import { useAuth } from '@/contexts/AuthContext';
 import { track } from '@/lib/analytics';
 
@@ -175,7 +176,12 @@ export default function AdminReposicaoPedidos() {
   // construção nunca entra (pedidoPrecisaAtencao só dispara em falha_envio/portal),
   // mas filtramos por defesa em profundidade — coerente com o render do ciclo.
   const atencaoVisivel = pedidosVisiveis(atencao ?? []);
-  const atencaoCount = atencaoVisivel.length;
+  // A′ (Codex xhigh): parte a fila em ação-real (vermelho) × barrado-por-mínimo
+  // (neutro, benigno). O alarme do topo conta SÓ a vermelha — gate de mínimo de
+  // faturamento não é pendência que exige o founder (o motor re-sugere sozinho).
+  const { vermelha: atencaoVermelha, abaixoMinimo: atencaoAbaixoMinimo } =
+    particionarAtencao(atencaoVisivel);
+  const atencaoCount = atencaoVermelha.length;
 
   // Deep link cross-ciclo: aceita ?id=N (ou ?pedido=N como alias usado por links do
   // portal). Se o pedido não está na lista de hoje, busca o pedido único por id.
@@ -604,7 +610,7 @@ export default function AdminReposicaoPedidos() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {atencaoVisivel.map((p) => (
+                {atencaoVermelha.map((p) => (
                   <TableRow key={p.id}>
                     <TableCell className="text-xs tabular-nums whitespace-nowrap">
                       {format(new Date(p.data_ciclo + 'T12:00:00'), 'dd/MM/yyyy')}
@@ -663,6 +669,14 @@ export default function AdminReposicaoPedidos() {
           </CardContent>
         </Card>
       )}
+
+      <AbaixoMinimoCard
+        pedidos={atencaoAbaixoMinimo}
+        podeOverride={podeOverride}
+        onDetalhes={setDetalhesPedido}
+        onOverride={(id) => dispararOverrideMutation.mutate(id)}
+        disparandoLinha={disparandoLinha}
+      />
 
       <Tabs defaultValue="hoje">
         <TabsList>


### PR DESCRIPTION
## Contexto

A seção "Precisam de atenção" da tela de pedidos de compra (`/admin/reposicao/pedidos`) misturava dois casos com risco money-path **muito** diferente, gerando fadiga de alerta:

- **Benigno** — `falha_envio` por **gate de mínimo de faturamento Sayerlack** (fornecedor não fatura < R$3k). O pedido NÃO foi comprado; o motor re-sugere o SKU no próximo ciclo se ele seguir abaixo do ponto, ou o estoque normaliza. Sem risco de compra-dupla. Acumula (o gate não dedup) e vira ruído vermelho permanente.
- **Ação real** — conciliação de PO (pode já existir no fornecedor), falhas duras do portal, e outros `falha_envio` (SKU sem custo, erro do Omie).

Diagnóstico read-only em prod (07/07): os 4 pedidos travados eram **todos** gate de mínimo. Rastreamento confirmou o comportamento auto-corretivo: 1 SKU reapareceu em 23 ciclos (segue abaixo do ponto); 2 não reapareceram porque **normalizaram** (estoque ≥ ponto). Nenhum era pista de item perdido.

## Mudança (Opção A′ — validada por Codex xhigh, money-path)

Reparticiona a fila **só no frontend** (zero migration/edge):

- **"Precisam de atenção"** (vermelho) = ação humana real. O contador do topo passa a contar só isto.
- **"Barrados pelo mínimo de faturamento"** (neutro, recolhido) = gate-mínimo benigno, com contador + valor total + mais antigo + ação (Detalhes / Disparar mesmo assim).

### Refinamentos do Codex (`xhigh`)
1. **Portal vence sempre** — um pedido gate-mínimo que TAMBÉM esteja em conciliação de portal fica no **vermelho** (senão esconderia risco de comprar 2×). Predicado: `ehGateMinimoFaturamento(p) && !STATUS_PORTAL_PRECISA_ATENCAO.has(portal)`.
2. **Copy honesta** — "Barrados pelo mínimo de faturamento" + "podem reaparecer se o SKU seguir abaixo do ponto, ou somem quando o estoque normaliza". NÃO promete "aguardando acumular R$3k" (mentiria: 2 já tinham normalizado).
3. **Neutro ≠ invisível** — a seção segue visível (risco residual = stockout silencioso).

Ranking do Codex: **A > B > C**. B (dedup no gate da edge) fica no backlog se o contador neutro crescer; C (auto-expiração) não fazer (cancelamento por leitura derivada = risco de apagar sinal).

## Testes
`atencao-particao.test.ts` — 8 casos, incl. o adversário "portal vence" e "falha_envio sem gate continua vermelho". Predicados puros em `shared.ts`.

## Falta pra ir ao ar
- [ ] **Publish do frontend** no editor do Lovable (mudança de UI não auto-deploya no push).

Sem migration, sem edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
