### PR TITLE
fix(vendas): edge não confia no espelho omie_clientes 'colacor' poluído (BUG-1 P0, Fatia 1)

### DIFF
--- a/docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md
+++ b/docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md
@@ -1,0 +1,61 @@
+# Espelho Omie — rótulo `empresa_omie` por conta (mislabel oben/colacor_sc) — design
+
+> money-path (identidade de cliente no pedido). Conduzido por Claude + `/codex consult`×2 (metodologia + design refinado), high. Deploy PENDENTE do founder. `REVISÃO INDEPENDENTE DO DIFF PENDENTE` (Codex challenge do diff, após implementação de cada fatia).
+
+## 1. Problema
+
+`omie_clientes` é o espelho `user_id → omie_codigo_cliente`. A coluna `empresa_omie` (NOT NULL DEFAULT `'colacor'`) deveria dizer de qual conta Omie é o código — mas **nenhum dos 5 writers a seta**, então as 6909 linhas caem no default `'colacor'`. O código físico é um **MIX de duas contas**, nenhuma colacor real:
+
+| Writer | App key / conta | Código | Rótulo hoje |
+|---|---|---|---|
+| `omie-analytics-sync:334` `syncCustomers` (bulk, cron `account:"vendas"`) | `OMIE_OBEN_APP_KEY` | **oben** | `'colacor'` (default) |
+| `omie-cliente:829`, `omie-sync:282`, `Auth.tsx:129` (signup), `AdminApprovals.tsx:109` (via `omie-cliente`) | `OMIE_COLACOR_SC_APP_KEY` | **colacor_sc** | `'colacor'` (default) |
+
+Códigos Omie têm numeração independente por conta (colidem entre contas). O rótulo `'colacor'` é uma mentira uniforme sobre dois namespaces.
+
+### Evidência (psql-ro, produção, 2026-07-07)
+- `omie_clientes`: 6909 linhas, 100% `'colacor'` (0 oben, 0 colacor_sc).
+- Crons `sync-customers-vendas-daily` / `sync-products-customers-daily`: ambos `account:"vendas"` (=oben).
+- Overlap de códigos de `customer_preferred_items` com o espelho: oben 20/21 (95%), colacor 0/23 (0%). `customer_segments` (100% oben): 29/30 casam por código, todas sob `'colacor'`.
+
+## 2. Impacto money-path (2 bugs ATIVOS + features inertes)
+
+Consumidor `omie-vendas-sync` (pedido): `type Account="oben"|"colacor"`; lê o espelho com `.eq('empresa_omie',account)`.
+
+- **BUG-1 — pedido colacor no cliente errado** (integridade, silencioso). `deriveOmieAccountIdentity` verifica contra o Omie só com `suppliedCodigo===null` (`:1699`). Para colacor, o mirror `.eq('colacor')` devolve a linha envenenada; se o payload trouxe o código (as vias-cliente do P0-B filtram `empresa_omie`, então mandam), `decideAccountIdentity:1613` aceita `source='mirror'` sem verificar → `criarPedidoVenda` usa o código na conta colacor.
+- **BUG-2 — pedido oben legítimo bloqueado** (disponibilidade). `codeBelongsToWrongAccount:1574`: pedido oben, código oben correto, linha rotulada `'colacor'` → existe row com o código e empresa≠oben → `true` → bloqueia.
+- **Features inertes**: `compare-customer-process` e `customer360` cruzam o espelho com `customer_segments`/`customer_preferred_items` (namespace oben). Voltam quando o oben for identificável.
+
+## 3. Fatiamento (3 fatias — Codex derrubou "re-rotular na Fatia A")
+
+**Insight do Codex (2ª rodada):** re-rotular dados sob `unique_user_omie` (1 linha/user) é inseguro — `fetchOmieClienteUserMap:230` casa por código sem account (colisão prova user errado) e `onConflict:'user_id'` faz re-rótulo × writers brigarem por last-wins. Multi-conta EXIGE a constraint composta. Logo: **fechar os bugs por CÓDIGO (defesa), não por dados**; re-rótulo só na fatia que traz a composta.
+
+### Fatia 1 — fechar o BUG-1 (integridade) (edge, código puro, SEM dados/migration) ✅ IMPLEMENTADA
+1. **BUG-1**: em `deriveOmieAccountIdentity`, no query do espelho (`omie-vendas-sync:1687`), guard `userIds.length===1 && account !== "colacor"` → para colacor `mirrorRows=[]` → `needOmie` → verificação Omie por documento. DENTRO da função → cobre criação (`:2388`) E edição (`:2596`).
+2. **BUG-1 (backfill)**: backfill desabilitado para colacor (`:1710`, `&& account !== "colacor"`) enquanto `unique_user_omie` existir — senão a verificação forçada dispara upsert `p_empresa:'colacor'` que pode contest/fail e **bloquear** o pedido colacor legítimo (Codex #4).
+- **Gate**: teste textual em `edge-money-path-invariants.test.ts` (pega reversão do Lovable no deploy) + typecheck + test. Sem SQL, sem helper puro tocado → sem prove-sql, sem paridade nova.
+
+> **BUG-2 (false-reject oben) NÃO entra na Fatia 1 — DIVERGÊNCIA JUSTIFICADA do Codex (#5, round-2).** Fechá-lo agora exige mexer em `codeBelongsToWrongAccount`, o que **inverte o teste P0-A** (`account-coherence.test.ts:14`, validado por Codex) e **desliga a proteção** sobre 100% das linhas (todas `'colacor'` hoje). BUG-2 é disponibilidade (fail-closed, trava venda, NÃO perde dinheiro), não integridade. O re-rótulo da **Fatia 3** o resolve na RAIZ (linha vira `'oben'` → `matchesTarget` → guard não bloqueia) sem desligar nada. Precisão>recall: não desligo defesa money-path sem necessidade crítica. `REVISÃO INDEPENDENTE DESTA DIVERGÊNCIA PENDENTE` (Codex round-3).
+
+### Fatia 2 — reconectar features oben (UI, código)
+- `compare-customer-process`: remover `.eq('empresa_omie','oben')` → lookup por `user_id` + **fail-close exigindo exatamente 1 linha** (não `.maybeSingle()` cego) + `.eq('account','oben')` em `customer_segments` (segment lookup `:237` e reverse-map `:267`).
+- `hooks.ts useCustomerPreferredItems`: de `[]` para lookup por `user_id` + `.eq('account','oben')` em `customer_preferred_items` + fail-close 1-linha.
+- Funciona hoje (espelho é oben-majority sob `'colacor'`; user cuja linha é colacor_sc → código não casa segments/preferred oben → null honesto).
+- **Gate**: typecheck + test.
+
+### Fatia 3 — re-rótulo + suportar colacor real (migration + prove-sql + Codex)
+- `fetchOmieClienteUserMap:230` account-scoped (doc-match, não code-match cross-account) — Codex #1/#7.
+- `onConflict:'(user_id,empresa_omie)'`; drop `unique_user_omie` (composta já existe como índice).
+- `syncCustomers` seta `empresa_omie=accountToEmpresa(account)`; writers manuais setam `'colacor_sc'` (sem clobber de `'oben'` — só possível pós-composta).
+- Popular colacor via `colacor_vendas`. Reverter defesas 1/2/3 da Fatia 1 (mirror colacor confiável).
+- **Gate**: prove-sql PG17 (drop constraint + onConflict + re-rótulo derivado) com falsificação + Codex challenge.
+
+## 4. Threat model (Fatia 1)
+- **Prova**: verificação Omie por documento no colacor (fail-closed em ausência/ambiguidade/divergência). Guard oben continua provando wrong-account por rótulos CONFIÁVEIS (`'oben'`/`'colacor_sc'` explícitos), só ignora o default `'colacor'`.
+- **NÃO prova**: identidade colacor via mirror (ignorado de propósito). Não fabrica: colacor sem match Omie → pedido bloqueado.
+- **Default fail-closed**: colacor não-provado via Omie → bloqueia; ambiguidade → bloqueia.
+
+## 5. Decisões (resolvidas com Codex)
+- Forçar todo pedido colacor via Omie: **SIM** (gate em "mirror tem colacor" é errado — `'colacor'` é o default envenenado, não prova). Custo: 1 chamada Omie/pedido colacor (infrequente).
+- Re-rotular colacor_sc histórico: **NÃO na Fatia 1** (blind relabel inseguro sob a constraint singular) → Fatia 3.
+- Deploy: Fatia 1 (edge) primeiro; Fatia 3 corrige o sync/relabel; UI a qualquer momento (fail-safe).

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -350,3 +350,33 @@ describe('guardrail money-path: derivação de identidade Omie por conta (edge U
     expect(bloco, 'a probe deveria cobrir o omie-path com backfill (source omie)').toContain('backfill: true');
   });
 });
+
+// ── Fatia 1 do fix de rótulo (BUG-1): edge não confia no espelho 'colacor' POLUÍDO ──
+// empresa_omie='colacor' é o default nunca-setado pelos 5 writers → MIX de código oben (bulk
+// syncCustomers) + colacor_sc (writers manuais), ZERO colacor real (provado via psql-ro 2026-07-07).
+// Confiar nele rotearia o pedido colacor ao cliente ERRADO (BUG-1, integridade, silencioso). Para
+// account='colacor' o derive NÃO usa o espelho (força verificação Omie por documento) e NÃO backfilla
+// (evitando contest/block sob unique_user_omie). O deploy do Lovable pode reverter isso na main; este
+// guard textual reexpõe no CI. Temporário: a Fatia 3 re-rotula por conta e reverte. Ver
+// docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md.
+describe('guardrail money-path: edge ignora o espelho colacor poluído (BUG-1, Fatia 1)', () => {
+  const src = read(VENDAS);
+
+  it('sentinela: leu o edge e o derive existe', () => {
+    expect(src).toContain('deriveOmieAccountIdentity');
+  });
+
+  it('mirror do derive NÃO é usado para account=colacor (força needOmie → Omie por documento)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o derive voltou a usar o espelho para colacor — pedido colacor rotearia ao cliente errado (BUG-1)',
+    ).toMatch(/userIds\.length === 1 && account !== "colacor"/);
+  });
+
+  it('backfill do espelho é desabilitado para colacor (evita contest/block sob unique_user_omie)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o backfill colacor voltou — a verificação forçada poderia bloquear pedido colacor legítimo',
+    ).toMatch(/decision\.backfill && userIds\.length === 1 && account !== "colacor"/);
+  });
+});

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1683,7 +1683,14 @@ async function deriveOmieAccountIdentity(
   // Espelho SÓ com 1 dono do documento: dup-profiles (mesmo doc, user_ids distintos) podem ter uma linha
   // de espelho de perfil ERRADO/stale que não vale como prova (Codex P1 #5) → força o Omie autoritativo
   // (regs:2, dup-safe). Alinha com o gate do backfill (também 1 dono).
-  const mirrorRows: MirrorRow[] = userIds.length === 1
+  // Fatia 1 do fix de rótulo (BUG-1, money-path): empresa_omie='colacor' no espelho é o DEFAULT
+  // POLUÍDO — os 5 writers gravam sem setar a coluna, então 'colacor' é um MIX de código oben (bulk
+  // syncCustomers, conta 'vendas') + colacor_sc (writers manuais), ZERO colacor real (provado via
+  // psql-ro 2026-07-07). Confiar nele rotearia o pedido colacor ao cliente ERRADO. Para account=
+  // 'colacor' NÃO usa o espelho → mirrorRows=[] força a verificação Omie por documento (needOmie).
+  // Temporário: a Fatia 3 re-rotula por conta e reverte. Ver docs/superpowers/specs/2026-07-07-
+  // espelho-omie-rotulo-por-conta-design.md.
+  const mirrorRows: MirrorRow[] = (userIds.length === 1 && account !== "colacor")
     ? (((await supabase.from("omie_clientes").select("omie_codigo_cliente, omie_codigo_vendedor, empresa_omie").in("user_id", userIds).eq("empresa_omie", account)).data ?? []) as MirrorRow[])
     : [];
 
@@ -1707,7 +1714,11 @@ async function deriveOmieAccountIdentity(
 
   // Backfill gated (auto-cura do espelho): só derivação inequívoca por Omie E com user confiável
   // (exatamente 1 dono do documento). Contested (código de outro/diferente) → fail-closa o PV.
-  if (decision.backfill && userIds.length === 1) {
+  // Fatia 1 (BUG-1): NÃO backfilla colacor enquanto unique_user_omie (1 linha/user) existir. A
+  // verificação Omie forçada acima produz decision.backfill=true; o upsert p_empresa='colacor' sob a
+  // constraint singular poderia CONTESTAR/falhar (a linha do user já existe como 'colacor' poluído) e
+  // BLOQUEAR um pedido colacor legítimo (Codex). A Fatia 3 (onConflict composto) reverte.
+  if (decision.backfill && userIds.length === 1 && account !== "colacor") {
     const { data: status } = await supabase.rpc("omie_cliente_upsert_mapping", {
       p_user_id: userIds[0], p_empresa: account, p_codigo_cliente: decision.codigo_cliente, p_codigo_vendedor: decision.codigo_vendedor,
     });


### PR DESCRIPTION
## Problema (money-path, integridade)

`omie_clientes.empresa_omie` é `NOT NULL DEFAULT 'colacor'`, mas **nenhum dos 5 writers seta a coluna** → as 6909 linhas caem no default. O código físico é um **MIX de duas contas Omie de numeração independente**: oben (bulk `syncCustomers`, cron `account:"vendas"`) + colacor_sc (writers manuais), **ZERO colacor real** (provado via psql-ro 2026-07-07). O rótulo `'colacor'` é uma mentira uniforme sobre dois namespaces que colidem.

**BUG-1 (integridade, silencioso):** em `omie-vendas-sync`, o pedido `colacor` lê o espelho com `.eq('empresa_omie','colacor')` e recebe a linha **envenenada** (código de outra conta). `deriveOmieAccountIdentity` só verifica contra o Omie quando `suppliedCodigo===null`; com código no payload, `decideAccountIdentity` aceita `source='mirror'` sem verificar → o PV vai ao **cliente ERRADO** na conta colacor.

## Esta Fatia (1 de 3 — edge, código puro, SEM dados/migration)

- **mirror do derive:** guard `userIds.length === 1 && account !== "colacor"` → para colacor `mirrorRows=[]` → força `needOmie` → **verificação Omie por documento** (fail-closed em ausência/ambiguidade/divergência). Cobre criação **e** edição.
- **backfill desabilitado para colacor** enquanto `unique_user_omie` (1 linha/user) existir — o upsert `p_empresa='colacor'` sob a constraint singular poderia contestar/falhar e **bloquear pedido colacor legítimo** (Codex).
- **teste textual** em `edge-money-path-invariants.test.ts` reexpõe os 2 guards no CI (tripwire de reversão do deploy Lovable).

## Divergência JUSTIFICADA do Codex

**BUG-2 (false-reject oben) NÃO entra aqui.** Fechá-lo via `codeBelongsToWrongAccount` inverteria o teste P0-A validado (`account-coherence.test.ts:14`) e **desligaria a proteção sobre 100% das linhas** (todas `'colacor'` hoje). BUG-2 é disponibilidade (fail-closed, não perde dinheiro); a **Fatia 3** (re-rótulo por conta) o fecha na RAIZ. Precisão > recall — não desligo defesa money-path sem necessidade crítica.

## Roadmap das fatias

- **Fatia 1 (este PR):** fecha BUG-1 na edge. ✅
- **Fatia 2 (UI, código):** reconectar features oben (`compare-customer-process`, `customer360/hooks`) com lookup por `user_id` + `.eq('account','oben')` + fail-close 1-linha.
- **Fatia 3 (migration + prove-sql + Codex):** re-rótulo `empresa_omie` por conta, `onConflict` composto, drop `unique_user_omie`, popular colacor real, reverter defesas da Fatia 1 — fecha BUG-2 na raiz.

## Verificação

- `heavy bun run typecheck` = 0
- `heavy bun run test` = **4627 passed (572 files)**
- `/codex consult`×2 (metodologia + design) + `/codex challenge` do diff → **PASS, sem P1**

## ⚠️ Deploy PENDENTE (manual, Lovable — APÓS o merge)

- 💬 **chat do Lovable:** deploy da edge `omie-vendas-sync` (verbatim da main). **Merge na main ≠ produção.**
- Verificação pós-deploy: `{action:'identidade_probe'}` do console staff → esperar `{probe_no_ar:true, ok:true}` (canária #1213).
- Sem frontend (Publish) e sem migration nesta fatia.

Design completo: `docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
