### PR TITLE
feat(reposição): badge de baixo giro mostra capital parado (R$) no cockpit

### DIFF
--- a/src/components/reposicao/BaixoGiroBadge.tsx
+++ b/src/components/reposicao/BaixoGiroBadge.tsx
@@ -1,39 +1,33 @@
-import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { Boxes, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { supabase } from "@/integrations/supabase/client";
-import { REPOSICAO_EMPRESA } from "@/hooks/useReposicaoSessao";
-import { BAIXO_GIRO_OR_FILTER } from "@/lib/reposicao/baixo-giro-helpers";
+import { useBaixoGiro } from "@/components/reposicao/baixoGiro/useBaixoGiro";
+
+const fmtBRLCompacto = (v: number) =>
+  new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(v);
 
 /**
  * Atalho discreto do cockpit para o painel "Baixo giro & estoque parado".
  * Substituiu a antiga faixa amarela de "SKUs sem parâmetro" (SmartAlertsSection):
  * aquela parecia pendência de automação sem ser — itens de baixo giro NÃO são falha
  * do auto-apply, são cauda longa sem venda recente, já tratados no painel dedicado.
- * Aqui fica só o pulso (quantos itens) + o caminho, sem cara de alerta.
- * A contagem reusa o MESMO filtro do painel (BAIXO_GIRO_OR_FILTER) para bater com a lista.
+ * Aqui fica só o pulso (quantos itens + R$ de capital parado) + o caminho, sem alerta.
+ *
+ * Reusa o hook `useBaixoGiro` do painel — mesma queryKey → cache compartilhado e
+ * números IDÊNTICOS aos do painel (fonte única do universo e do capital, via
+ * somarCapitalParado). Nada de query/soma própria: dois cálculos de dinheiro que
+ * podem divergir é o pecado recorrente do domínio.
  */
 export function BaixoGiroBadge() {
   const navigate = useNavigate();
+  const { kpis, isLoading } = useBaixoGiro();
 
-  const { data: total = 0 } = useQuery({
-    queryKey: ["cockpit-baixo-giro-total", REPOSICAO_EMPRESA],
-    queryFn: async () => {
-      const { count, error } = await supabase
-        .from("sku_parametros")
-        .select("*", { count: "exact", head: true })
-        .eq("empresa", REPOSICAO_EMPRESA)
-        .eq("ativo", true)
-        .or(BAIXO_GIRO_OR_FILTER);
-      if (error) throw error;
-      return count ?? 0;
-    },
-    staleTime: 60_000,
-  });
-
-  if (total === 0) return null;
+  if (isLoading || kpis.totalItens === 0) return null;
 
   return (
     <Button
@@ -45,10 +39,19 @@ export function BaixoGiroBadge() {
     >
       <Boxes className="h-4 w-4 mr-1.5" />
       Baixo giro &amp; estoque parado
-      <Badge variant="secondary" className="ml-2 tabular-nums">
-        {total}
-      </Badge>
-      <ChevronRight className="h-4 w-4 ml-1 opacity-60" />
+      <span className="mx-1.5 opacity-40" aria-hidden="true">·</span>
+      <span className="tabular-nums">
+        {kpis.totalItens} {kpis.totalItens === 1 ? "item" : "itens"}
+      </span>
+      {kpis.totalRs > 0 && (
+        <>
+          <span className="mx-1.5 opacity-40" aria-hidden="true">·</span>
+          <span className="font-medium text-foreground tabular-nums">
+            {fmtBRLCompacto(kpis.totalRs)} parado
+          </span>
+        </>
+      )}
+      <ChevronRight className="h-4 w-4 ml-1.5 opacity-60" />
     </Button>
   );
 }


### PR DESCRIPTION
## Contexto

Follow-up do #1219 (badge de baixo giro no cockpit). O badge mostrava só a contagem de itens; agora exibe também o **capital parado (R$)** — o dado de negócio mais forte de "como está o baixo giro" (dinheiro empatado pesa mais que número de itens).

## O que muda

- O badge passa a reusar o hook **`useBaixoGiro`** do painel (mesma queryKey → cache compartilhado + números **idênticos** aos do painel). Fonte única do universo **e** do capital via `somarCapitalParado` — zero query/soma própria, pra não haver dois cálculos de dinheiro divergindo (inclusive a nuance `account='vendas'` acompanha o painel sozinha).
- O R$ só aparece quando `> 0` (**ausente ≠ zero**: item sem estoque/custo → omite, não fabrica R$ 0).

Resultado: `📦 Baixo giro e estoque parado · 402 itens · R$ 188,3 mil parado ›`

## Verificação

- `typecheck` ✅ · `lint` ✅ (0 erros) · `test` ✅ (822 testes, 0 falhas)
- Capital parado confirmado no banco de produção (OBEN): **R$ 188.308** em 401 itens com estoque+custo, `com_estoque_sem_custo = 0` (sem degradação).
- **Frontend puro**: sem migration, sem edge function.

## Deploy (Lovable)

Só **Publish do frontend** — não há edge nem migration. Merge na main ≠ produção.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
