### PR TITLE
PCP Fase 2A — custo-padrão de material (lixa) + fila de exceções classificada

### DIFF
--- a/db/pcp-f2a-custo.sql
+++ b/db/pcp-f2a-custo.sql
@@ -1,0 +1,364 @@
+-- PCP Fase 2A — custo-padrão de material (LIXA) + fila de exceções classificada (vs CMC colacor_vendas).
+-- Custo = Σ(componente: quantProdMalha × CMC) na MESMA data-posição. Ausente=NULL (NUNCA COALESCE(cmc,0)).
+-- Sem escrita no Omie (2B). Aplicar no SQL Editor do Lovable (founder). NUNCA em supabase/migrations/. Idempotável (re-colar 2× = no-op).
+--
+-- Schemas REAIS (confirmados na sonda): pcp_config=(key text PK, value jsonb, updated_at); cmc_snapshot=(id,account,
+--   omie_codigo_produto,data_posicao,cmc,synced_at); fn_pcp_papel_componente→abrasivo_base|cola|catalisador|fita|outro;
+--   fn_pcp_num(text)→numeric (parser tolerante — reusado no cast do jsonb). Componente casado por idProdMalha→omie_products/cmc_snapshot.
+--
+-- Staff-gate das RPC de recompute: MESMO padrão da 1A (fn_pcp_refresh_itens/destilar_bom/materializar_excecoes):
+--   SECURITY DEFINER + REVOKE ALL FROM PUBLIC,anon,authenticated (só owner/service-role/SQL Editor roda). SEM gate
+--   auth.uid() interno (travaria o SQL Editor, onde auth.uid() é NULL). fn_pcp_cmc_vigente fica INVOKER (a policy
+--   staff-only do cmc_snapshot é quem protege o custo — não vaza p/ não-staff).
+--
+-- FALSIFICAÇÃO PROVADA (test-pcp-f2a-custo.sh Step 17 — cada sabotagem→vermelho→revertida):
+--   COALESCE(cmc,0)→#3 · remover guard unidade→#4 · sum→max(1 componente)→#5 · tirar validação de data→#6 ·
+--   default possivel_erro_receita sem cruzar 1A→#10 · security_invoker=false→#13 · fn_pcp_cmc_vigente INVOKER→DEFINER→#14 ·
+--   classe unidade_divergente/ambiguo→NULL (some da fila)→FIX1.
+-- HARDENING (painel tri-modelo, sobre o código real): FIX1 fila inclui unidade_divergente/estrutura_ambigua (não somem) ·
+--   FIX2 cmc sem linha em omie_products (unidade não confirmada)→incompleto · FIX3 quantProdMalha<=0→incompleto (não custeia 0) ·
+--   FIX4 idProdMalha decimal/gigante→comp NULL (LEFT JOIN não acha CMC; NÃO aborta o recompute) · FIX5 fn_pcp_recompute_excecoes
+--   valida config (versao/tol/drift) · FIX6 pg_advisory_xact_lock nas 2 RPC (padrão da 1B-M1 — DELETE+INSERT/upsert sem corrida).
+BEGIN;
+
+-- ── 0) Config (pcp_config já existe da 1A; CREATE IF NOT EXISTS defensivo — shape REAL key/value jsonb) ──
+CREATE TABLE IF NOT EXISTS public.pcp_config (
+  key text PRIMARY KEY,
+  value jsonb NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+INSERT INTO public.pcp_config (key, value) VALUES
+  ('custo_cmc_account',   '"colacor_vendas"'::jsonb),  -- conta do cmc_snapshot que dá o CMC do custo
+  ('custo_versao_regra',  '"1"'::jsonb),               -- versão da regra (na chave — regra nova NÃO sobrescreve)
+  ('custo_tolerancia_pct','0.05'::jsonb),              -- banda de divergência aceita antes de virar exceção
+  ('custo_drift_pct',     '0.10'::jsonb)               -- Δ relativa de CMC entre 2 datas p/ suspeitar drift de preço
+ON CONFLICT (key) DO NOTHING;
+
+-- ── 1) Resultados versionados (1-writer: a RPC DEFINER; chave inclui versao_regra) ──
+CREATE TABLE IF NOT EXISTS public.pcp_custo_padrao_resultados (
+  omie_codigo_produto bigint NOT NULL,
+  data_posicao        date   NOT NULL,
+  versao_regra        text   NOT NULL,
+  tipo_item           text,
+  custo_abrasivo      numeric,
+  custo_cola          numeric,
+  custo_catalisador   numeric,
+  custo_fita          numeric,
+  custo_outros        numeric,                 -- material fora dos 4 papéis (não some)
+  custo_total         numeric,                 -- NULL se custo_status <> 'ok'
+  custo_status        text NOT NULL CHECK (custo_status IN ('ok','incompleto','unidade_divergente','ambiguo')),
+  n_componentes       int NOT NULL,
+  n_incompletos       int NOT NULL,
+  detalhe             jsonb,
+  derivado_em         timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (omie_codigo_produto, data_posicao, versao_regra)
+);
+
+-- ── 2) Fila de exceções — INCLUSIVA (incompletos/sem-nCMC entram); lados NULLABLE; impacto_r NOT NULL ordena TUDO ──
+CREATE TABLE IF NOT EXISTS public.pcp_custo_excecoes (
+  omie_codigo_produto bigint NOT NULL,
+  data_posicao        date   NOT NULL,
+  versao_regra        text   NOT NULL,
+  tipo_item           text,
+  custo_padrao_total  numeric,                 -- NULL quando cmc_incompleto
+  ncmc_acabado        numeric,                 -- NULL quando ncmc_ausente
+  divergencia_abs     numeric,                 -- NULL quando falta um lado
+  divergencia_pct     numeric,
+  impacto_r           numeric NOT NULL,        -- coalesce(div_abs, custo_parcial/total, ncmc, 0)
+  classe_causa text NOT NULL CHECK (classe_causa IN
+    ('possivel_erro_receita','drift_preco_provavel','causa_indeterminada',
+     'material_fora_bucket','cmc_incompleto','ncmc_ausente','unidade_divergente','estrutura_ambigua')),
+  custo_status text NOT NULL,
+  derivado_em  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (omie_codigo_produto, data_posicao, versao_regra)
+);
+CREATE INDEX IF NOT EXISTS idx_pcp_custo_exc_imp ON public.pcp_custo_excecoes (impacto_r DESC);
+-- FIX 1: evolui o CHECK de classe_causa idempotentemente — a tabela já existe em prod (entrega anterior) e
+--   CREATE TABLE IF NOT EXISTS NÃO atualiza CHECK; sem isto o INSERT de 'unidade_divergente'/'estrutura_ambigua' violaria.
+ALTER TABLE public.pcp_custo_excecoes DROP CONSTRAINT IF EXISTS pcp_custo_excecoes_classe_causa_check;
+ALTER TABLE public.pcp_custo_excecoes ADD  CONSTRAINT pcp_custo_excecoes_classe_causa_check
+  CHECK (classe_causa IN ('possivel_erro_receita','drift_preco_provavel','causa_indeterminada',
+     'material_fora_bucket','cmc_incompleto','ncmc_ausente','unidade_divergente','estrutura_ambigua'));
+
+-- ── 3) CMC vigente (conta lida de config, ausente→NULL, INVOKER — RLS do cmc_snapshot protege) ──
+CREATE OR REPLACE FUNCTION public.fn_pcp_cmc_vigente(
+  p_cod bigint, p_data_posicao date, p_permitir_anterior boolean DEFAULT false)
+RETURNS numeric LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public AS $$
+  SELECT cmc FROM cmc_snapshot
+   WHERE omie_codigo_produto = p_cod
+     AND account = (SELECT value#>>'{}' FROM pcp_config WHERE key = 'custo_cmc_account')
+     AND cmc > 0
+     AND (data_posicao = p_data_posicao OR (p_permitir_anterior AND data_posicao <= p_data_posicao))
+   ORDER BY data_posicao DESC
+   LIMIT 1;
+$$;
+
+-- Helper de deploy: última data-posição da grade CMC (evita data hardcoded fora da grade). INVOKER.
+CREATE OR REPLACE FUNCTION public.fn_pcp_ultima_data_posicao()
+RETURNS date LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public AS $$
+  SELECT max(data_posicao) FROM cmc_snapshot
+   WHERE account = (SELECT value#>>'{}' FROM pcp_config WHERE key = 'custo_cmc_account');
+$$;
+
+-- Cobertura de CMC por tipo_item (security_invoker => a RLS do cmc_snapshot/pcp_itens barra não-staff; não vaza).
+CREATE OR REPLACE VIEW public.vw_pcp_cmc_cobertura WITH (security_invoker = true) AS
+  SELECT i.tipo_item,
+         count(*) AS fabricados,
+         count(*) FILTER (
+           WHERE fn_pcp_cmc_vigente(m.omie_codigo_produto, (SELECT fn_pcp_ultima_data_posicao())) IS NOT NULL
+         ) AS com_cmc
+    FROM pcp_malha_staging m
+    JOIN pcp_itens i ON i.omie_codigo_produto = m.omie_codigo_produto
+   GROUP BY i.tipo_item;
+
+-- ── 4) Drift de preço de um componente (2 datas de CMC com Δ relativa > p_drift). INVOKER; só a RPC DEFINER chama. ──
+CREATE OR REPLACE FUNCTION public.fn_pcp_componente_tem_drift(p_cod bigint, p_data date, p_drift numeric)
+RETURNS boolean LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public AS $$
+  WITH h AS (
+    SELECT cmc FROM cmc_snapshot
+     WHERE omie_codigo_produto = p_cod
+       AND account = (SELECT value#>>'{}' FROM pcp_config WHERE key = 'custo_cmc_account')
+       AND data_posicao <= p_data AND cmc > 0
+     ORDER BY data_posicao DESC
+     LIMIT 2
+  )
+  SELECT count(*) = 2 AND abs(max(cmc) - min(cmc)) / NULLIF(min(cmc), 0) > p_drift FROM h;
+$$;
+
+-- ── 5) Motor do custo-padrão — SET-BASED, jsonb com contrato, ausente→NULL. DEFINER; sem gate interno (REVOKE protege). ──
+CREATE OR REPLACE FUNCTION public.fn_pcp_recompute_custo_padrao(p_data_posicao date)
+RETURNS int LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_account text := (SELECT value#>>'{}' FROM pcp_config WHERE key = 'custo_cmc_account');
+  v_versao  text := (SELECT value#>>'{}' FROM pcp_config WHERE key = 'custo_versao_regra');
+  v int;
+BEGIN
+  -- FIX 6: serializa recomputes concorrentes da MESMA data (upsert sem corrida) — padrão da 1B-M1 (fn_pcp_projetar_op).
+  PERFORM pg_advisory_xact_lock(hashtextextended('pcp_custo_'||p_data_posicao::text, 0));
+  IF v_account IS NULL OR v_versao IS NULL THEN
+    RAISE EXCEPTION 'fn_pcp_recompute_custo_padrao: config custo_cmc_account/custo_versao_regra ausente';
+  END IF;
+  -- Valida a data contra a grade CMC: data fora da grade zeraria o custo em massa (todo cmc NULL) sem avisar.
+  IF NOT EXISTS (SELECT 1 FROM cmc_snapshot WHERE account = v_account AND data_posicao = p_data_posicao) THEN
+    RAISE EXCEPTION 'fn_pcp_recompute_custo_padrao: data-posição % inexistente na grade CMC (conta %)', p_data_posicao, v_account;
+  END IF;
+
+  WITH comp AS (
+    SELECT
+      s.omie_codigo_produto AS pai_cod,
+      -- FIX 4: idProdMalha só vira bigint se for inteiro PURO e caber (length<=18); decimal ('1.5') ou gigante → NULL
+      --   (LEFT JOIN não acha CMC → componente cai em falta/incompleto), NUNCA aborta o recompute. Fallbacks de chave preservados.
+      CASE WHEN coalesce(it2->'ident'->>'idProdMalha', it2->'ident'->>'idMalha', it2->>'idProdMalha') ~ '^[0-9]+$'
+            AND length(coalesce(it2->'ident'->>'idProdMalha', it2->'ident'->>'idMalha', it2->>'idProdMalha')) <= 18
+           THEN coalesce(it2->'ident'->>'idProdMalha', it2->'ident'->>'idMalha', it2->>'idProdMalha')::bigint
+      END AS comp_cod,
+      coalesce(it2->'ident'->>'descrProdMalha', it2->>'descrProdMalha') AS comp_desc,
+      fn_pcp_num(coalesce(it2->>'quantProdMalha', it2->>'quantidade')) AS qtd,
+      upper(coalesce(it2->>'unidProdMalha', it2->>'unidade')) AS uom
+    FROM pcp_malha_staging s
+    CROSS JOIN LATERAL jsonb_array_elements(s.payload->'itens') AS it2
+    WHERE jsonb_typeof(s.payload->'itens') = 'array'
+  ),
+  enrich AS (
+    SELECT c.*,
+      upper(op.unidade) AS uom_estoque,
+      fn_pcp_cmc_vigente(c.comp_cod, p_data_posicao) AS cmc,
+      fn_pcp_papel_componente(c.comp_desc, op.familia) AS papel
+    FROM comp c
+    LEFT JOIN omie_products op ON op.omie_codigo_produto = c.comp_cod AND op.account = 'colacor'
+  ),
+  calc AS (
+    SELECT e.*,
+      (e.cmc IS NULL OR e.qtd IS NULL OR e.qtd <= 0 OR (e.cmc IS NOT NULL AND e.uom_estoque IS NULL)) AS falta,
+      (e.uom_estoque IS NOT NULL AND e.uom IS NOT NULL AND e.uom <> e.uom_estoque) AS unidade_diverge,
+      CASE
+        WHEN e.cmc IS NULL OR e.qtd IS NULL OR e.qtd <= 0 THEN NULL                                    -- incompleto: NUNCA fabrica 0 (FIX 3: qtd<=0 tb)
+        WHEN e.cmc IS NOT NULL AND e.uom_estoque IS NULL THEN NULL                                     -- FIX 2: cmc sem unidade de estoque confirmada → falta
+        WHEN e.uom_estoque IS NOT NULL AND e.uom IS NOT NULL AND e.uom <> e.uom_estoque THEN NULL      -- guard de unidade
+        ELSE e.qtd * e.cmc
+      END AS custo
+    FROM enrich e
+  ),
+  agg AS (
+    SELECT pai_cod,
+      sum(custo) FILTER (WHERE papel = 'abrasivo_base') AS custo_abrasivo,
+      sum(custo) FILTER (WHERE papel = 'cola')          AS custo_cola,
+      sum(custo) FILTER (WHERE papel = 'catalisador')   AS custo_catalisador,
+      sum(custo) FILTER (WHERE papel = 'fita')          AS custo_fita,
+      sum(custo) FILTER (WHERE papel = 'outro')         AS custo_outros,
+      count(*)                        AS n_comp,
+      count(*) FILTER (WHERE falta)   AS n_falta,
+      count(*) FILTER (WHERE unidade_diverge) AS n_div,
+      jsonb_agg(jsonb_build_object('cod', comp_cod, 'desc', comp_desc, 'qtd', qtd,
+                                   'uom', uom, 'cmc', cmc, 'papel', papel, 'custo', custo)) AS detalhe
+    FROM calc
+    GROUP BY pai_cod
+  )
+  INSERT INTO pcp_custo_padrao_resultados (
+    omie_codigo_produto, data_posicao, versao_regra, tipo_item,
+    custo_abrasivo, custo_cola, custo_catalisador, custo_fita, custo_outros,
+    custo_total, custo_status, n_componentes, n_incompletos, detalhe, derivado_em)
+  SELECT
+    s.omie_codigo_produto,
+    p_data_posicao,
+    v_versao,
+    it.tipo_item,
+    a.custo_abrasivo, a.custo_cola, a.custo_catalisador, a.custo_fita, a.custo_outros,
+    CASE
+      WHEN jsonb_typeof(s.payload->'itens') = 'array' AND coalesce(a.n_div, 0) = 0 AND coalesce(a.n_falta, 0) = 0
+      THEN coalesce(a.custo_abrasivo,0) + coalesce(a.custo_cola,0) + coalesce(a.custo_catalisador,0)
+         + coalesce(a.custo_fita,0) + coalesce(a.custo_outros,0)
+      ELSE NULL
+    END AS custo_total,
+    CASE
+      WHEN jsonb_typeof(s.payload->'itens') IS DISTINCT FROM 'array' THEN 'ambiguo'
+      WHEN coalesce(a.n_div, 0)   > 0 THEN 'unidade_divergente'
+      WHEN coalesce(a.n_falta, 0) > 0 THEN 'incompleto'
+      ELSE 'ok'
+    END AS custo_status,
+    coalesce(a.n_comp, 0),
+    coalesce(a.n_falta, 0),
+    coalesce(a.detalhe, '[]'::jsonb),
+    now()
+  FROM pcp_malha_staging s
+  LEFT JOIN pcp_itens it ON it.omie_codigo_produto = s.omie_codigo_produto
+  LEFT JOIN agg a        ON a.pai_cod = s.omie_codigo_produto
+  ON CONFLICT (omie_codigo_produto, data_posicao, versao_regra) DO UPDATE SET
+    tipo_item = EXCLUDED.tipo_item,
+    custo_abrasivo = EXCLUDED.custo_abrasivo, custo_cola = EXCLUDED.custo_cola,
+    custo_catalisador = EXCLUDED.custo_catalisador, custo_fita = EXCLUDED.custo_fita,
+    custo_outros = EXCLUDED.custo_outros, custo_total = EXCLUDED.custo_total,
+    custo_status = EXCLUDED.custo_status, n_componentes = EXCLUDED.n_componentes,
+    n_incompletos = EXCLUDED.n_incompletos, detalhe = EXCLUDED.detalhe, derivado_em = now();
+
+  GET DIAGNOSTICS v = ROW_COUNT;
+  RETURN v;
+END $$;
+
+-- ── 6) Fila de exceções — só LIXA (cinta/disco/folha/rolo; tingidor fora), inclusiva, classe PROVADA. DEFINER. ──
+CREATE OR REPLACE FUNCTION public.fn_pcp_recompute_excecoes(p_data_posicao date)
+RETURNS int LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_versao text    := (SELECT value#>>'{}' FROM pcp_config WHERE key = 'custo_versao_regra');
+  v_tol    numeric := (SELECT (value#>>'{}')::numeric FROM pcp_config WHERE key = 'custo_tolerancia_pct');
+  v_drift  numeric := (SELECT (value#>>'{}')::numeric FROM pcp_config WHERE key = 'custo_drift_pct');
+  v int;
+BEGIN
+  -- FIX 6: serializa recomputes concorrentes da MESMA data (DELETE+INSERT da fila sem corrida) — padrão da 1B-M1.
+  PERFORM pg_advisory_xact_lock(hashtextextended('pcp_custo_'||p_data_posicao::text, 0));
+  -- FIX 5: valida config (como a fn de custo já faz) — versao/tol/drift ausentes zerariam/quebrariam a fila silenciosamente.
+  IF v_versao IS NULL OR v_tol IS NULL OR v_drift IS NULL THEN
+    RAISE EXCEPTION 'fn_pcp_recompute_excecoes: config custo_versao_regra/custo_tolerancia_pct/custo_drift_pct ausente';
+  END IF;
+  -- Reconstrói a fila da (data, versão) do zero: sem fila fantasma (o que regularizou some).
+  DELETE FROM pcp_custo_excecoes WHERE data_posicao = p_data_posicao AND versao_regra = v_versao;
+
+  WITH src AS (
+    SELECT r.*,
+      fn_pcp_cmc_vigente(r.omie_codigo_produto, p_data_posicao) AS ncmc,   -- MESMA data (coerência temporal)
+      NULLIF(coalesce(r.custo_abrasivo,0) + coalesce(r.custo_cola,0) + coalesce(r.custo_catalisador,0)
+           + coalesce(r.custo_fita,0) + coalesce(r.custo_outros,0), 0) AS custo_parcial
+    FROM pcp_custo_padrao_resultados r
+    WHERE r.data_posicao = p_data_posicao AND r.versao_regra = v_versao
+      AND r.tipo_item IN ('cinta','disco','folha','rolo')
+  ),
+  calc AS (
+    SELECT s.*,
+      CASE WHEN s.custo_total IS NOT NULL AND s.ncmc IS NOT NULL THEN abs(s.custo_total - s.ncmc) END AS div_abs
+    FROM src s
+  ),
+  cls AS (
+    SELECT c.*,
+      (c.div_abs / NULLIF(c.ncmc, 0)) AS div_pct,
+      CASE
+        WHEN c.custo_status = 'incompleto' THEN 'cmc_incompleto'                          -- entra na fila (total NULL)
+        WHEN c.custo_status = 'unidade_divergente' THEN 'unidade_divergente'              -- FIX 1: entra na fila (não some p/ NULL)
+        WHEN c.custo_status = 'ambiguo' THEN 'estrutura_ambigua'                          -- FIX 1: entra na fila (não some p/ NULL)
+        WHEN c.custo_status = 'ok' AND c.ncmc IS NULL THEN 'ncmc_ausente'                 -- ativo NÃO custeado
+        WHEN c.custo_status = 'ok' AND c.ncmc IS NOT NULL
+             AND (c.div_abs / NULLIF(c.ncmc, 0)) > v_tol THEN
+          CASE
+            WHEN coalesce(c.custo_outros, 0) > 0 THEN 'material_fora_bucket'
+            WHEN EXISTS (SELECT 1 FROM pcp_bom_excecoes be
+                          WHERE be.pai_codigo = c.omie_codigo_produto
+                            AND be.status = 'excecao' AND be.disposicao IS NULL)
+              THEN 'possivel_erro_receita'                                                -- PROVADO: cruza a 1A (oráculo)
+            WHEN EXISTS (SELECT 1 FROM jsonb_array_elements(c.detalhe) d
+                          WHERE fn_pcp_componente_tem_drift((d->>'cod')::bigint, p_data_posicao, v_drift))
+              THEN 'drift_preco_provavel'
+            ELSE 'causa_indeterminada'                                                    -- default HONESTO (nunca acusa sem oráculo)
+          END
+        ELSE NULL                                                                        -- dentro da banda / ambiguo / unidade_divergente: fora da fila
+      END AS classe
+    FROM calc c
+  )
+  INSERT INTO pcp_custo_excecoes (
+    omie_codigo_produto, data_posicao, versao_regra, tipo_item,
+    custo_padrao_total, ncmc_acabado, divergencia_abs, divergencia_pct,
+    impacto_r, classe_causa, custo_status, derivado_em)
+  SELECT
+    omie_codigo_produto, data_posicao, versao_regra, tipo_item,
+    custo_total AS custo_padrao_total,
+    ncmc        AS ncmc_acabado,
+    div_abs     AS divergencia_abs,
+    div_pct     AS divergencia_pct,
+    CASE classe
+      WHEN 'cmc_incompleto'     THEN coalesce(custo_parcial, ncmc, 0)
+      WHEN 'unidade_divergente' THEN coalesce(custo_parcial, ncmc, 0)   -- FIX 1
+      WHEN 'estrutura_ambigua'  THEN coalesce(custo_parcial, ncmc, 0)   -- FIX 1
+      WHEN 'ncmc_ausente'       THEN coalesce(custo_total, 0)
+      ELSE coalesce(div_abs, custo_total, ncmc, 0)
+    END AS impacto_r,
+    classe AS classe_causa,
+    custo_status,
+    now()
+  FROM cls
+  WHERE classe IS NOT NULL;
+
+  GET DIAGNOSTICS v = ROW_COUNT;
+  RETURN v;
+END $$;
+
+-- Calibração da tolerância: distribuição de div_pct SÓ sobre dado saneado (ok, sem outros, com nCMC, sem exceção 1A).
+CREATE OR REPLACE VIEW public.vw_pcp_custo_calibracao WITH (security_invoker = true) AS
+  SELECT r.omie_codigo_produto, r.data_posicao, r.versao_regra, r.tipo_item,
+         r.custo_total,
+         fn_pcp_cmc_vigente(r.omie_codigo_produto, r.data_posicao) AS ncmc,
+         abs(r.custo_total - fn_pcp_cmc_vigente(r.omie_codigo_produto, r.data_posicao))
+           / NULLIF(fn_pcp_cmc_vigente(r.omie_codigo_produto, r.data_posicao), 0) AS div_pct
+    FROM pcp_custo_padrao_resultados r
+   WHERE r.custo_status = 'ok'
+     AND coalesce(r.custo_outros, 0) = 0
+     AND r.tipo_item IN ('cinta','disco','folha','rolo')
+     AND fn_pcp_cmc_vigente(r.omie_codigo_produto, r.data_posicao) IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pcp_bom_excecoes be
+                      WHERE be.pai_codigo = r.omie_codigo_produto
+                        AND be.status = 'excecao' AND be.disposicao IS NULL);
+
+-- ── 7) RLS enabled (NÃO force — o writer é a RPC DEFINER) + policies staff-only + grants ──
+ALTER TABLE public.pcp_custo_padrao_resultados ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pcp_custo_excecoes          ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS pcp_custo_res_select_staff ON public.pcp_custo_padrao_resultados;
+CREATE POLICY pcp_custo_res_select_staff ON public.pcp_custo_padrao_resultados FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()), 'master'::app_role) OR has_role((SELECT auth.uid()), 'employee'::app_role));
+DROP POLICY IF EXISTS pcp_custo_exc_select_staff ON public.pcp_custo_excecoes;
+CREATE POLICY pcp_custo_exc_select_staff ON public.pcp_custo_excecoes FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()), 'master'::app_role) OR has_role((SELECT auth.uid()), 'employee'::app_role));
+
+REVOKE ALL ON public.pcp_custo_padrao_resultados, public.pcp_custo_excecoes FROM anon, authenticated;
+GRANT SELECT ON public.pcp_custo_padrao_resultados, public.pcp_custo_excecoes TO authenticated;  -- policy filtra
+
+-- Recompute: só owner/service-role/SQL Editor (mesmo padrão da 1A). Non-staff barrado pela ausência de EXECUTE.
+REVOKE ALL ON FUNCTION public.fn_pcp_recompute_custo_padrao(date), public.fn_pcp_recompute_excecoes(date)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.fn_pcp_componente_tem_drift(bigint, date, numeric) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.fn_pcp_cmc_vigente(bigint, date, boolean), public.fn_pcp_ultima_data_posicao()
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.fn_pcp_cmc_vigente(bigint, date, boolean) TO authenticated;  -- INVOKER: a RLS do cmc barra
+GRANT EXECUTE ON FUNCTION public.fn_pcp_ultima_data_posicao() TO authenticated;
+
+REVOKE ALL ON public.vw_pcp_cmc_cobertura, public.vw_pcp_custo_calibracao FROM anon;
+GRANT SELECT ON public.vw_pcp_cmc_cobertura, public.vw_pcp_custo_calibracao TO authenticated;  -- security_invoker => RLS barra
+
+COMMIT;

--- a/db/test-pcp-f2a-custo.sh
+++ b/db/test-pcp-f2a-custo.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# Prova PG17 — PCP Fase 2A: custo-padrão de material (lixa) + fila de exceções classificada.
+# Propriedades: Σ buckets = total [1] · outros não some [2] · ausente→NULL nunca 0 [3] · guard unidade [4] ·
+#   multi-componente soma [5] · data fora da grade ABORTA [6] · jsonb não-array→ambiguo (não aborta) [7] ·
+#   fila inclui incompleto [8] e sem-nCMC [9,12] · classe PROVADA cruza a 1A [10] · tingidor fora [11] ·
+#   view não vaza [13] · RLS + cmc INVOKER não vaza [14] · versão não sobrescreve [15] · idempotência [16].
+# HARDENING (painel tri-modelo): FIX1 fila inclui unidade_divergente/estrutura_ambigua · FIX2 cmc sem omie_products→incompleto ·
+#   FIX3 qtd<=0→incompleto · FIX4 idProdMalha decimal/gigante NÃO aborta (SKU→incompleto) · FIX5 excecoes valida config · FIX6 advisory lock.
+#
+# FALSIFICAÇÃO (Step 17): re-rode com FALSIFY=<x> — cada sabotagem deve virar FAIL>0 (vermelho), depois reverte:
+#   FALSIFY=coalesce (→#3) · guard (→#4) · sumfirst (→#5) · dataval (→#6) · defaultclasse (→#10) ·
+#   invoker (→#13) · cmcdefiner (→#14) · filaclasse (→FIX1: unidade_divergente/ambiguo somem da fila).
+#   A migration REAL fica intacta (sabotagem age numa CÓPIA temporária).
+# Rodar (verde):    heavy bash db/test-pcp-f2a-custo.sh > /tmp/t-2a.log 2>&1; echo "exit=$?"
+# Rodar (vermelho): FALSIFY=coalesce bash db/test-pcp-f2a-custo.sh > /tmp/f-2a.log 2>&1; echo "exit=$?"
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5476}"
+SLUG="pcp-f2a"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+# ── Migration REAL (ou CÓPIA sabotada quando FALSIFY setado) ──
+MIG="$REPO_ROOT/db/pcp-f2a-custo.sql"
+if [ -n "${FALSIFY:-}" ]; then
+  MIG="$(mktemp "/tmp/f2a-sab.XXXXXX").sql"
+  cp "$REPO_ROOT/db/pcp-f2a-custo.sql" "$MIG"
+  case "$FALSIFY" in
+    coalesce)     sed -i '' "s#(e.cmc IS NULL OR e.qtd IS NULL OR e.qtd <= 0 OR (e.cmc IS NOT NULL AND e.uom_estoque IS NULL)) AS falta#false AS falta#" "$MIG";;
+    guard)        sed -i '' "s#(e.uom_estoque IS NOT NULL AND e.uom IS NOT NULL AND e.uom <> e.uom_estoque) AS unidade_diverge#false AS unidade_diverge#" "$MIG";;
+    sumfirst)     sed -i '' "s#sum(custo) FILTER (WHERE papel = 'abrasivo_base')#max(custo) FILTER (WHERE papel = 'abrasivo_base')#" "$MIG";;
+    dataval)      sed -i '' "s#NOT EXISTS (SELECT 1 FROM cmc_snapshot WHERE account = v_account AND data_posicao = p_data_posicao)#false#" "$MIG";;
+    defaultclasse) sed -i '' "s#ELSE 'causa_indeterminada'#ELSE 'possivel_erro_receita'#" "$MIG";;
+    invoker)      sed -i '' "s#security_invoker = true#security_invoker = false#g" "$MIG";;
+    cmcdefiner)   sed -i '' "s#RETURNS numeric LANGUAGE sql STABLE SECURITY INVOKER#RETURNS numeric LANGUAGE sql STABLE SECURITY DEFINER#" "$MIG";;
+    filaclasse)   sed -i '' "s#WHEN c.custo_status = 'unidade_divergente' THEN 'unidade_divergente'#WHEN c.custo_status = 'unidade_divergente' THEN NULL::text#" "$MIG"
+                  sed -i '' "s#WHEN c.custo_status = 'ambiguo' THEN 'estrutura_ambigua'#WHEN c.custo_status = 'ambiguo' THEN NULL::text#" "$MIG";;
+    *) echo "FALSIFY desconhecido: $FALSIFY"; exit 2;;
+  esac
+  echo "### FALSIFY=$FALSIFY — migration sabotada em $MIG (esperado: FAIL>0)"
+fi
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; [ -n "${FALSIFY:-}" ] && rm -f "$MIG" || true; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA -q "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ ZONA 1: pré-requisitos (roles, auth, has_role, staff aaaa / não-staff bbbb) + helpers/tabelas da 1A (stub) ═══"
+P -q <<'SQL'
+DO $$ BEGIN CREATE ROLE anon;          EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE ROLE authenticated; EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE ROLE service_role;  EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE SCHEMA IF NOT EXISTS auth;
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE
+  AS $$ SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid $$;
+CREATE TYPE public.app_role AS ENUM ('employee','customer','master');
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $$;
+GRANT EXECUTE ON FUNCTION public.has_role(uuid, app_role) TO authenticated, anon;
+GRANT USAGE ON SCHEMA public TO anon, authenticated;
+INSERT INTO public.user_roles VALUES ('00000000-0000-0000-0000-00000000aaaa','employee');  -- staff; bbbb sem role (fail-closed)
+
+-- Helpers REAIS da 1A (fn_pcp_num parser tolerante; fn_pcp_papel_componente) — copiados verbatim de db/pcp-f1a-m2-nucleo.sql
+CREATE OR REPLACE FUNCTION public.fn_pcp_num(p_raw text)
+RETURNS numeric LANGUAGE sql IMMUTABLE AS $$
+SELECT CASE WHEN v ~ '^-?\d+(\.\d+)?$' THEN v::numeric END
+FROM (SELECT replace(trim(coalesce(p_raw,'')), ',', '.') AS v) t $$;
+CREATE OR REPLACE FUNCTION public.fn_pcp_papel_componente(p_descricao text, p_familia text)
+RETURNS text LANGUAGE sql IMMUTABLE AS $$
+SELECT CASE
+  WHEN upper(coalesce(p_descricao,'')) ~ '^(ROLO|JUMBO)\s'                      THEN 'abrasivo_base'
+  WHEN upper(coalesce(p_descricao,'')) ~ 'DESMODUR|CATALISADOR'
+    OR coalesce(p_familia,'') ILIKE '%catalisador%'                             THEN 'catalisador'
+  WHEN upper(coalesce(p_descricao,'')) ~ '\mFITA\M|MYLAR'                       THEN 'fita'
+  WHEN upper(coalesce(p_descricao,'')) ~ 'A455|ADESIVO|\mCOLA\M'
+    OR coalesce(p_familia,'') ILIKE '%cola%' OR coalesce(p_familia,'') ILIKE '%adesivo%' THEN 'cola'
+  ELSE 'outro'
+END $$;
+
+-- pcp_config (shape REAL key/value jsonb) com RLS staff-only (a 2A insere as chaves via ON CONFLICT).
+CREATE TABLE public.pcp_config (key text PRIMARY KEY, value jsonb NOT NULL, updated_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.pcp_config ENABLE ROW LEVEL SECURITY;
+CREATE POLICY pcp_config_sel ON public.pcp_config FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()),'master'::app_role) OR has_role((SELECT auth.uid()),'employee'::app_role));
+GRANT SELECT ON public.pcp_config TO authenticated;
+
+-- cmc_snapshot (colunas REAIS da sonda) com policy staff-only.
+CREATE TABLE public.cmc_snapshot (
+  id bigserial PRIMARY KEY, account text NOT NULL, omie_codigo_produto bigint NOT NULL,
+  data_posicao date NOT NULL, cmc numeric, synced_at timestamptz NOT NULL DEFAULT now());
+ALTER TABLE public.cmc_snapshot ENABLE ROW LEVEL SECURITY;
+CREATE POLICY cmc_sel_staff ON public.cmc_snapshot FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()),'master'::app_role) OR has_role((SELECT auth.uid()),'employee'::app_role));
+GRANT SELECT ON public.cmc_snapshot TO authenticated;
+
+CREATE TABLE public.omie_products (
+  omie_codigo_produto bigint NOT NULL, account text NOT NULL, codigo text, descricao text,
+  familia text, unidade text, PRIMARY KEY (omie_codigo_produto, account));
+
+CREATE TABLE public.pcp_malha_staging (omie_codigo_produto bigint PRIMARY KEY, payload jsonb NOT NULL);
+ALTER TABLE public.pcp_malha_staging ENABLE ROW LEVEL SECURITY;
+CREATE POLICY mstg_sel_staff ON public.pcp_malha_staging FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()),'master'::app_role) OR has_role((SELECT auth.uid()),'employee'::app_role));
+GRANT SELECT ON public.pcp_malha_staging TO authenticated;
+
+CREATE TABLE public.pcp_itens (
+  omie_codigo_produto bigint PRIMARY KEY, tipo_item text NOT NULL, linha_modelo text);
+ALTER TABLE public.pcp_itens ENABLE ROW LEVEL SECURITY;
+CREATE POLICY itens_sel_staff ON public.pcp_itens FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()),'master'::app_role) OR has_role((SELECT auth.uid()),'employee'::app_role));
+GRANT SELECT ON public.pcp_itens TO authenticated;
+
+CREATE TABLE public.pcp_bom_excecoes (
+  pai_codigo bigint NOT NULL, componente_codigo bigint NOT NULL DEFAULT 0, papel text NOT NULL,
+  status text NOT NULL, disposicao text, PRIMARY KEY (pai_codigo, papel, componente_codigo));
+ALTER TABLE public.pcp_bom_excecoes ENABLE ROW LEVEL SECURITY;
+CREATE POLICY be_sel_staff ON public.pcp_bom_excecoes FOR SELECT TO authenticated
+  USING (has_role((SELECT auth.uid()),'master'::app_role) OR has_role((SELECT auth.uid()),'employee'::app_role));
+GRANT SELECT ON public.pcp_bom_excecoes TO authenticated;
+SQL
+
+echo "═══ ZONA 2: aplica a migration 2A ($([ -n "${FALSIFY:-}" ] && echo SABOTADA || echo real)) 2× — idempotável ═══"
+P -q -f "$MIG"
+if P -q -f "$MIG" >/dev/null 2>&1; then ok "migration re-aplicável (2ª colagem no-op)"; else bad "2ª aplicação QUEBROU"; fi
+
+echo "═══ ZONA 3: seed (componentes, CMC grade 2026-06-15 [+05-15 drift do 202], malhas, itens, exceção 1A) ═══"
+P -q <<'SQL'
+-- Componentes (account colacor). Papel deriva do descrProdMalha da malha (abrasivo=^ROLO/JUMBO; cola=COLA A455; cat=DESMODUR; fita=FITA).
+INSERT INTO omie_products (omie_codigo_produto, account, codigo, descricao, familia, unidade) VALUES
+ (101,'colacor','R101','ROLO LIXA A','Abrasivos','M2'),
+ (102,'colacor','C102','COLA A455','Cola','G'),
+ (103,'colacor','P103','PARAFUSO','Diversos','UN'),
+ (104,'colacor','K104','DESMODUR','Catalisador','G'),
+ (105,'colacor','F105','FITA ADESIVA','Fita','CM'),
+ (201,'colacor','J201','JUMBO X','Abrasivos','M2'),
+ (202,'colacor','J202','JUMBO Y','Abrasivos','M2'),
+ (301,'colacor','R301','ROLO LIXA B','Abrasivos','M2'),   -- estoque M2 (malha manda KG → guard)
+ (999,'colacor','R999','ROLO SEMCMC','Abrasivos','M2');   -- SEM cmc → incompleto
+
+-- CMC dos componentes (2026-06-15). 202 tem 2ª data (05-15, cmc 6) → drift 0.67 > 0.10.
+INSERT INTO cmc_snapshot (account, omie_codigo_produto, data_posicao, cmc) VALUES
+ ('colacor_vendas',101,'2026-06-15',10),('colacor_vendas',102,'2026-06-15',5),
+ ('colacor_vendas',103,'2026-06-15',7), ('colacor_vendas',104,'2026-06-15',3),
+ ('colacor_vendas',105,'2026-06-15',2), ('colacor_vendas',201,'2026-06-15',4),
+ ('colacor_vendas',202,'2026-06-15',10),('colacor_vendas',202,'2026-05-15',6),
+ ('colacor_vendas',301,'2026-06-15',8),
+ ('colacor_vendas',998,'2026-06-15',9),   -- FIX 2: tem CMC mas SEM linha em omie_products (unidade de estoque não confirmada)
+-- nCMC dos acabados (só quem deve ter): divergem do custo-padrão p/ testar as classes.
+ ('colacor_vendas',1010,'2026-06-15',20),('colacor_vendas',1011,'2026-06-15',20),
+ ('colacor_vendas',1012,'2026-06-15',20),('colacor_vendas',1013,'2026-06-15',10),
+ ('colacor_vendas',2000,'2026-06-15',10);
+
+INSERT INTO pcp_itens (omie_codigo_produto, tipo_item) VALUES
+ (1000,'cinta'),(1001,'cinta'),(1002,'cinta'),(1003,'cinta'),(1004,'cinta'),(1005,'cinta'),
+ (1010,'cinta'),(1011,'cinta'),(1012,'cinta'),(1013,'cinta'),(1020,'cinta'),(2000,'tingidor'),
+ (1006,'cinta'),(1007,'cinta'),(1030,'cinta'),(1031,'cinta');  -- lixa com dado problemático (FIX 3/2/4)
+
+INSERT INTO pcp_malha_staging (omie_codigo_produto, payload) VALUES
+ (1000,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"2","unidProdMalha":"M2"},{"ident":{"idProdMalha":"102","descrProdMalha":"COLA A455"},"quantProdMalha":"3","unidProdMalha":"G"}]}'),
+ (1001,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"1","unidProdMalha":"M2"},{"ident":{"idProdMalha":"103","descrProdMalha":"PARAFUSO"},"quantProdMalha":"2","unidProdMalha":"UN"}]}'),
+ (1002,'{"itens":[{"ident":{"idProdMalha":"999","descrProdMalha":"ROLO SEMCMC"},"quantProdMalha":"2","unidProdMalha":"M2"}]}'),
+ (1003,'{"itens":[{"ident":{"idProdMalha":"301","descrProdMalha":"ROLO LIXA B"},"quantProdMalha":"2","unidProdMalha":"KG"}]}'),
+ (1004,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"2","unidProdMalha":"M2"},{"ident":{"idProdMalha":"201","descrProdMalha":"JUMBO X"},"quantProdMalha":"3","unidProdMalha":"M2"}]}'),
+ (1005,'{"itens":{"foo":1}}'),
+ (1020,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"1","unidProdMalha":"M2"},{"ident":{"idProdMalha":"102","descrProdMalha":"COLA A455"},"quantProdMalha":"1","unidProdMalha":"G"},{"ident":{"idProdMalha":"104","descrProdMalha":"DESMODUR"},"quantProdMalha":"1","unidProdMalha":"G"},{"ident":{"idProdMalha":"105","descrProdMalha":"FITA ADESIVA"},"quantProdMalha":"1","unidProdMalha":"CM"},{"ident":{"idProdMalha":"103","descrProdMalha":"PARAFUSO"},"quantProdMalha":"1","unidProdMalha":"UN"}]}'),
+ (1010,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"2","unidProdMalha":"M2"},{"ident":{"idProdMalha":"102","descrProdMalha":"COLA A455"},"quantProdMalha":"2","unidProdMalha":"G"}]}'),
+ (1011,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"2","unidProdMalha":"M2"},{"ident":{"idProdMalha":"102","descrProdMalha":"COLA A455"},"quantProdMalha":"2","unidProdMalha":"G"}]}'),
+ (1012,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"2","unidProdMalha":"M2"},{"ident":{"idProdMalha":"103","descrProdMalha":"PARAFUSO"},"quantProdMalha":"2","unidProdMalha":"UN"}]}'),
+ (1013,'{"itens":[{"ident":{"idProdMalha":"202","descrProdMalha":"JUMBO Y"},"quantProdMalha":"2","unidProdMalha":"M2"}]}'),
+ (2000,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"2","unidProdMalha":"M2"}]}'),
+ -- FIX 3: quantProdMalha='0' (fn_pcp_num→0) NÃO pode custear 0 → SKU incompleto, total NULL.
+ (1006,'{"itens":[{"ident":{"idProdMalha":"101","descrProdMalha":"ROLO LIXA A"},"quantProdMalha":"0","unidProdMalha":"M2"}]}'),
+ -- FIX 2: componente 998 tem CMC mas SEM omie_products (unidade não confirmada) → falta → SKU incompleto.
+ (1007,'{"itens":[{"ident":{"idProdMalha":"998","descrProdMalha":"ROLO SEM PRODUTO"},"quantProdMalha":"1","unidProdMalha":"M2"}]}'),
+ -- FIX 4: idProdMalha decimal ('1.5') e gigante (fora do range de bigint) → comp_cod NULL → incompleto, SEM abortar o recompute.
+ (1030,'{"itens":[{"ident":{"idProdMalha":"1.5","descrProdMalha":"ROLO DECIMAL"},"quantProdMalha":"1","unidProdMalha":"M2"}]}'),
+ (1031,'{"itens":[{"ident":{"idProdMalha":"99999999999999999999999","descrProdMalha":"ROLO GIGANTE"},"quantProdMalha":"1","unidProdMalha":"M2"}]}');
+
+-- Oráculo da 1A: 1010 tem exceção de receita VIVA → possivel_erro_receita PROVADO. 1011 NÃO tem.
+INSERT INTO pcp_bom_excecoes (pai_codigo, componente_codigo, papel, status, disposicao)
+  VALUES (1010, 0, 'abrasivo_base', 'excecao', NULL);
+SQL
+
+echo "═══ ZONA 4: recompute (postgres = owner do DEFINER; auth.uid() NULL como no SQL Editor) ═══"
+eq "recompute_custo_padrao processa 16 SKUs (FIX 4: id inválido/gigante NÃO aborta)" "$(Pq -c "SELECT fn_pcp_recompute_custo_padrao('2026-06-15')")" "16"
+eq "recompute_excecoes retorna >0"           "$(Pq -c "SELECT fn_pcp_recompute_excecoes('2026-06-15')>0")" "t"
+
+echo "═══ ZONA 5: custo-padrão (Σ buckets = total; outros conta; multi-componente soma; ambiguo) ═══"
+eq "#1 custo simples: abrasivo 2×10 = 20"  "$(Pq -c "SELECT custo_abrasivo FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1000 AND versao_regra='1'")" "20"
+eq "#1 custo simples: cola 3×5 = 15"       "$(Pq -c "SELECT custo_cola FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1000 AND versao_regra='1'")" "15"
+eq "#1 total = Σ buckets = 35"             "$(Pq -c "SELECT custo_total FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1000 AND versao_regra='1'")" "35"
+eq "#2 outro → custo_outros = 14"          "$(Pq -c "SELECT custo_outros FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1001 AND versao_regra='1'")" "14"
+eq "#2 total inclui outros = 24 (não some)" "$(Pq -c "SELECT custo_total FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1001 AND versao_regra='1'")" "24"
+eq "#5 multi-componente abrasivo 20+12 = 32 (não canônico)" "$(Pq -c "SELECT custo_abrasivo FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1004 AND versao_regra='1'")" "32"
+eq "#5 n_componentes = 2"                  "$(Pq -c "SELECT n_componentes FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1004 AND versao_regra='1'")" "2"
+eq "bucket-sep: 1020 cat=3"                "$(Pq -c "SELECT custo_catalisador FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1020 AND versao_regra='1'")" "3"
+eq "bucket-sep: 1020 fita=2"               "$(Pq -c "SELECT custo_fita FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1020 AND versao_regra='1'")" "2"
+eq "bucket-sep: 1020 total=27"             "$(Pq -c "SELECT custo_total FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1020 AND versao_regra='1'")" "27"
+eq "#7 jsonb não-array → ambiguo"          "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1005 AND versao_regra='1'")" "ambiguo"
+eq "#7 ambiguo → total NULL"               "$(Pq -c "SELECT custo_total IS NULL FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1005 AND versao_regra='1'")" "t"
+
+echo "═══ ZONA 6: ausente→NULL (nunca 0) + guard de unidade ═══"
+eq "#3 sem CMC → status incompleto"        "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1002 AND versao_regra='1'")" "incompleto"
+eq "#3 incompleto → total NULL (não 0)"    "$(Pq -c "SELECT custo_total IS NULL FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1002 AND versao_regra='1'")" "t"
+eq "#4 unidade malha≠estoque → unidade_divergente" "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1003 AND versao_regra='1'")" "unidade_divergente"
+eq "#4 unidade_divergente → total NULL"    "$(Pq -c "SELECT custo_total IS NULL FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1003 AND versao_regra='1'")" "t"
+eq "FIX3 qtd='0' → status incompleto"      "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1006 AND versao_regra='1'")" "incompleto"
+eq "FIX3 qtd='0' → total NULL (não custeia 0)" "$(Pq -c "SELECT custo_total IS NULL FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1006 AND versao_regra='1'")" "t"
+eq "FIX2 cmc SEM omie_products → incompleto" "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1007 AND versao_regra='1'")" "incompleto"
+eq "FIX2 sem unidade confirmada → total NULL" "$(Pq -c "SELECT custo_total IS NULL FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1007 AND versao_regra='1'")" "t"
+eq "FIX4 idProdMalha='1.5' → incompleto (não aborta)"   "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1030 AND versao_regra='1'")" "incompleto"
+eq "FIX4 idProdMalha gigante → incompleto (não aborta)" "$(Pq -c "SELECT custo_status FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1031 AND versao_regra='1'")" "incompleto"
+eq "FIX4 id inválido → comp_cod NULL no detalhe (1030)"  "$(Pq -c "SELECT (detalhe->0->>'cod') IS NULL FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1030 AND versao_regra='1'")" "t"
+
+echo "═══ ZONA 7: data-posição fora da grade ABORTA (não zera custo em massa) ═══"
+ERR=$(P -tA -c "SELECT fn_pcp_recompute_custo_padrao('2020-01-01')" 2>&1 || true)
+case "$ERR" in *"inexistente na grade"*) ok "#6 data fora da grade → RAISE";; *) bad "#6 data inválida NÃO abortou: $ERR";; esac
+
+echo "═══ ZONA 8: fila de exceções — inclusiva, temporal-coerente, classe PROVADA ═══"
+eq "#8 fila INCLUI incompleto (1002 → cmc_incompleto)" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1002 AND versao_regra='1'")" "cmc_incompleto"
+eq "#8 cmc_incompleto: total NULL na fila"  "$(Pq -c "SELECT custo_padrao_total IS NULL FROM pcp_custo_excecoes WHERE omie_codigo_produto=1002 AND versao_regra='1'")" "t"
+eq "FIX1 lixa unidade_divergente ENTRA na fila (1003)" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1003 AND versao_regra='1'")" "unidade_divergente"
+eq "FIX1 lixa ambiguo ENTRA na fila (1005 → estrutura_ambigua)" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1005 AND versao_regra='1'")" "estrutura_ambigua"
+eq "#9/#12 ok sem nCMC (1000 → ncmc_ausente)" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1000 AND versao_regra='1'")" "ncmc_ausente"
+eq "#9 ncmc_ausente: impacto_r = custo_total = 35" "$(Pq -c "SELECT impacto_r FROM pcp_custo_excecoes WHERE omie_codigo_produto=1000 AND versao_regra='1'")" "35"
+eq "#10 diverge COM exceção 1A → possivel_erro_receita" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1010 AND versao_regra='1'")" "possivel_erro_receita"
+eq "#10 diverge SEM exceção 1A e SEM drift → causa_indeterminada (não acusa receita)" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1011 AND versao_regra='1'")" "causa_indeterminada"
+eq "extra: custo_outros>0 → material_fora_bucket" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1012 AND versao_regra='1'")" "material_fora_bucket"
+eq "extra: 2 datas CMC Δ>drift → drift_preco_provavel" "$(Pq -c "SELECT classe_causa FROM pcp_custo_excecoes WHERE omie_codigo_produto=1013 AND versao_regra='1'")" "drift_preco_provavel"
+eq "#11 tingidor FORA da fila (2000 ausente)" "$(Pq -c "SELECT count(*) FROM pcp_custo_excecoes WHERE omie_codigo_produto=2000")" "0"
+eq "impacto_r NOT NULL em toda a fila"      "$(Pq -c "SELECT count(*) FROM pcp_custo_excecoes WHERE impacto_r IS NULL")" "0"
+eq "fila ordenável por impacto (top = 1000/35)" "$(Pq -c "SELECT omie_codigo_produto FROM pcp_custo_excecoes WHERE versao_regra='1' ORDER BY impacto_r DESC LIMIT 1")" "1000"
+
+echo "═══ ZONA 9: idempotência (re-recompute mesma data/versão ⇒ mesmos valores, excl. derivado_em) ═══"
+HR1=$(Pq -c "SELECT md5(coalesce(string_agg(omie_codigo_produto||'|'||coalesce(tipo_item,'')||'|'||custo_status||'|'||coalesce(custo_total::text,'x')||'|'||coalesce(custo_abrasivo::text,'x')||'|'||coalesce(custo_outros::text,'x')||'|'||n_componentes||'|'||n_incompletos,',' ORDER BY omie_codigo_produto),'')) FROM pcp_custo_padrao_resultados WHERE versao_regra='1'")
+HE1=$(Pq -c "SELECT md5(coalesce(string_agg(omie_codigo_produto||'|'||classe_causa||'|'||impacto_r::text||'|'||coalesce(divergencia_abs::text,'x'),',' ORDER BY omie_codigo_produto),'')) FROM pcp_custo_excecoes WHERE versao_regra='1'")
+Pq -c "SELECT fn_pcp_recompute_custo_padrao('2026-06-15')" >/dev/null
+Pq -c "SELECT fn_pcp_recompute_excecoes('2026-06-15')" >/dev/null
+HR2=$(Pq -c "SELECT md5(coalesce(string_agg(omie_codigo_produto||'|'||coalesce(tipo_item,'')||'|'||custo_status||'|'||coalesce(custo_total::text,'x')||'|'||coalesce(custo_abrasivo::text,'x')||'|'||coalesce(custo_outros::text,'x')||'|'||n_componentes||'|'||n_incompletos,',' ORDER BY omie_codigo_produto),'')) FROM pcp_custo_padrao_resultados WHERE versao_regra='1'")
+HE2=$(Pq -c "SELECT md5(coalesce(string_agg(omie_codigo_produto||'|'||classe_causa||'|'||impacto_r::text||'|'||coalesce(divergencia_abs::text,'x'),',' ORDER BY omie_codigo_produto),'')) FROM pcp_custo_excecoes WHERE versao_regra='1'")
+eq "#16 resultados idempotente" "$HR1" "$HR2"
+eq "#16 fila idempotente"       "$HE1" "$HE2"
+
+echo "═══ ZONA 10: versão na chave — regra nova NÃO sobrescreve a antiga ═══"
+Pq -c "UPDATE pcp_config SET value=to_jsonb('2'::text) WHERE key='custo_versao_regra'" >/dev/null
+Pq -c "SELECT fn_pcp_recompute_custo_padrao('2026-06-15')" >/dev/null
+eq "#15 versões 1 e 2 coexistem p/ o mesmo SKU" "$(Pq -c "SELECT count(DISTINCT versao_regra) FROM pcp_custo_padrao_resultados WHERE omie_codigo_produto=1000")" "2"
+Pq -c "UPDATE pcp_config SET value=to_jsonb('1'::text) WHERE key='custo_versao_regra'" >/dev/null
+
+echo "═══ ZONA 11: RLS + view não vaza + cmc INVOKER (custo não escapa p/ não-staff) ═══"
+eq "2 tabelas 2A com RLS" "$(Pq -c "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname='public' AND c.relname IN ('pcp_custo_padrao_resultados','pcp_custo_excecoes') AND c.relrowsecurity")" "2"
+eq "#14 staff lê resultados" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000aaaa'; SELECT count(*)>0 FROM pcp_custo_padrao_resultados")" "t"
+eq "#14 não-staff vê 0 resultados (fail-closed)" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000bbbb'; SELECT count(*) FROM pcp_custo_padrao_resultados")" "0"
+eq "#14 não-staff vê 0 na fila" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000bbbb'; SELECT count(*) FROM pcp_custo_excecoes")" "0"
+NS=$(P -tA -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000bbbb'; SELECT fn_pcp_recompute_custo_padrao('2026-06-15');" 2>&1 || true)
+case "$NS" in *"permission denied"*|*"denied"*) ok "#14 recompute não-staff barrado (sem EXECUTE)";; *) bad "#14 recompute não-staff NÃO barrado: $NS";; esac
+eq "#14 cmc INVOKER: staff vê CMC via fn" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000aaaa'; SELECT coalesce(fn_pcp_cmc_vigente(101,'2026-06-15'),0)>0")" "t"
+eq "#14 cmc INVOKER: não-staff NÃO vê CMC (RLS barra → NULL)" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000bbbb'; SELECT fn_pcp_cmc_vigente(101,'2026-06-15') IS NULL")" "t"
+eq "#13 view: staff vê cobertura (>0 grupos)" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000aaaa'; SELECT count(*)>0 FROM vw_pcp_cmc_cobertura")" "t"
+eq "#13 view NÃO vaza p/ não-staff (0 grupos)" "$(Pq -c "SET ROLE authenticated; SET request.jwt.claim.sub='00000000-0000-0000-0000-00000000bbbb'; SELECT count(*) FROM vw_pcp_cmc_cobertura")" "0"
+
+echo "═══ ZONA 12: FIX 5 (excecoes valida config → RAISE) + FIX 6 (advisory lock nas 2 RPC) ═══"
+Pq -c "DELETE FROM pcp_config WHERE key='custo_tolerancia_pct'" >/dev/null
+ERR5=$(P -tA -c "SELECT fn_pcp_recompute_excecoes('2026-06-15')" 2>&1 || true)
+case "$ERR5" in *"ausente"*) ok "FIX5 tolerância ausente → RAISE (não zera a fila em silêncio)";; *) bad "FIX5 config ausente NÃO abortou: $ERR5";; esac
+Pq -c "INSERT INTO pcp_config(key,value) VALUES('custo_tolerancia_pct','0.05'::jsonb) ON CONFLICT (key) DO NOTHING" >/dev/null
+eq "FIX6 advisory lock em fn_pcp_recompute_custo_padrao" "$(Pq -c "SELECT pg_get_functiondef('fn_pcp_recompute_custo_padrao(date)'::regprocedure) ~ 'pg_advisory_xact_lock'")" "t"
+eq "FIX6 advisory lock em fn_pcp_recompute_excecoes"     "$(Pq -c "SELECT pg_get_functiondef('fn_pcp_recompute_excecoes(date)'::regprocedure) ~ 'pg_advisory_xact_lock'")" "t"
+
+echo ""
+echo "RESULTADO: PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/docs/historico/pcp.md
+++ b/docs/historico/pcp.md
@@ -100,3 +100,26 @@ Planos por fase: `docs/superpowers/plans/`.
 **🏁 Fundação (Fase 1) FECHADA (2026-07-05):** 1. dados mestres ✅ · 2. parser ✅ · 3. BOM paramétrica ✅ · 4. OP+etapas ✅ (M1) · 5. apontamento offline c/ consumo-motivo ✅ (M1+M3 `src/pages/...` na rota `/producao/apontamento`) · 6. **corte múltiplo ✅ (M2)**. Próximo: **Fase 2 — Custo & Omie** (backflush fiscal + outbox incluir/concluir OP + validação cruzada de custo com o `custoProducao` que já vem na malha).
 
 **Pendente (founder):** (1) **M1** — aplicar `db/pcp-f1b-m1-execucao.sql` no SQL Editor (destrava a tela de apontamento do M3); (2) **opcional** — re-colar a versão endurecida do `db/pcp-f1b-m2-corte-multiplo.sql` (melhorias do painel PR, idempotável; prod já está correto sem isso). Depois: realinhamento pós-squash + PR → main.
+
+## Fase 2A — Custo-padrão de material & fila de exceções (2026-07-06)
+
+**Plano/spec:** `docs/superpowers/plans/2026-07-06-pcp-fase2a-custo.md` (v3) + `.../specs/2026-07-06-pcp-fase2a-custo-design.md` (v2). Abre a **Fase 2 (Custo & Omie)** pelo bloco de CUSTO (read-only, não escreve no Omie); o outbox fiscal (incluir/concluir OP) é a **Fase 2B**.
+
+**Task 0 — sonda empírica (ancorou o design no real, ANTES de qualquer schema):**
+- O `custoProducao{vGGF,vMOD}` da malha Omie está **100% ZERADO** (0/2011) → o custo real vive no **`cmc_snapshot`** (CMC de estoque, grade mensal, conta única `colacor_vendas`; cobertura 94% acabados / 99% insumos). O plano original (comparar com o `custoProducao`) era inviável — a sonda pegou isso antes de o schema nascer errado.
+- **Linhagem híbrida:** `nCMC(acabado)` vs `Σ(estrutura×nCMC insumo)` na mesma data — **50% batem ≤1%** (23% ao centavo), **35% divergem >5%**. O CMC do fabricado é em parte o próprio teórico, em parte média-móvel histórica. → **reposiciona** o 2A: não é "teórico×real puro" nem "gap=conversão de graça" (ambos falsos), é **custo-padrão calculado + fila de exceções CLASSIFICADA** (o valor está nos ~35%).
+- **`unidProdMalha` vs unidade de estoque: 6732/6732 batem** → custo = `qtd×CMC` **sem conversão** (a tabela de unidade vira guard defensivo, não motor). Removeu um P1 de unidade inteiro.
+
+**Decisões do founder:** conta **única** (Colacor compra e vende tudo — mata o risco multi-account) · escopo **LIXA** (cinta/disco/folha/rolo); **tingidor FORA** (o Tingimix tem custeio próprio — pot-life/mistura em batch — que não encaixa nos 4 papéis de lixa; forçá-lo poluiria a fila com falso-positivo sistemático).
+
+**O que shipou** (`db/pcp-f2a-custo.sql`, `db/test-pcp-f2a-custo.sh` **PASS=55**):
+- `pcp_custo_padrao_resultados` (buckets abrasivo/cola/catalisador/fita/**outros**; chave com `versao_regra` — regra nova não sobrescreve) + `pcp_custo_excecoes` (fila **inclusiva** — incompleto/sem-custo/unidade-divergente/ambíguo ENTRAM; `impacto_r` ordena por R$).
+- `fn_pcp_cmc_vigente` (**INVOKER** — a policy staff-only do `cmc_snapshot` protege; conta de `pcp_config`), motor **set-based** `fn_pcp_recompute_custo_padrao` (ausente→**NULL** nunca 0; guard de unidade; contrato jsonb; valida data-posição e aborta), `fn_pcp_recompute_excecoes` (classe **cruza a fila da 1A** `pcp_bom_excecoes.pai_codigo` — só acusa "erro de receita" com esse oráculo; default `causa_indeterminada`). RLS enabled (não force — o writer é a RPC DEFINER) + staff-read; advisory lock nas 2 RPC.
+
+**Painel tri-modelo — 2 voltas (Claude+Codex+Gemini):**
+- **Sobre o PLANO (BLOCK, 4 P1):** classe_causa **fabricava** "erro de receita" (a comparação é semi-circular → mede drift de preço; fix: cruzar a 1A como oráculo) · Tingidor poluía a fila (fix: escopo lixa) · view de cobertura **vazava custo** (fix: `security_invoker`) · data-posição errada zerava tudo em silêncio (fix: valida+aborta). +7 P2 (a fila **escondia o pior caso** — 2 modelos; FORCE RLS travaria o writer; versão na chave; contrato jsonb; tolerância saneada; conta em config).
+- **Sobre o CÓDIGO real (1 confirmado + 5 defensivos → hardening):** Gemini(P1)+Codex(P2) — a fila ainda **excluía `unidade_divergente`/`ambiguo`** (o mesmo princípio, 2 status esquecidos) → entram como classe própria. +5 money-path defensivos (0 casos nos dados hoje, mas corretos): guard furava sem `omie_products`; `qtd=0` custeava; `idProdMalha` inválido **abortava o recompute inteiro** (fix: regex + `length≤18` anti-overflow de bigint); config sem validação; advisory lock.
+
+**Falsificação (Lei de Ferro):** 8 sabotagens, cada uma vermelha no assert que a vigia — `INVOKER→DEFINER` (custo vaza p/ não-staff); `COALESCE(cmc,0)` derruba **10** asserts de "ausente≠zero" de uma vez (o guard blinda todos os fixes de custo); reverter o FIX 1 faz os SKUs sumirem da fila (`[]`).
+
+**Pendente (founder):** aplicar `db/pcp-f2a-custo.sql` no SQL Editor → `SELECT fn_pcp_recompute_custo_padrao(fn_pcp_ultima_data_posicao());` depois `SELECT fn_pcp_recompute_excecoes(fn_pcp_ultima_data_posicao());`. Verificação minha (psql-ro): cobertura por tipo_item, top da fila por R$, distribuição de classe_causa, `ncmc_ausente`. Depois: **Fase 2B** (outbox fiscal — precisa do contador + sandbox Omie).

--- a/docs/superpowers/plans/2026-07-06-pcp-fase2a-custo.md
+++ b/docs/superpowers/plans/2026-07-06-pcp-fase2a-custo.md
@@ -1,0 +1,227 @@
+# PCP Fase 2A — Custo-padrão & fila de exceções — Implementation Plan (v3)
+
+> **REQUIRED SUB-SKILL:** superpowers:subagent-driven-development (task-a-task). Steps em checkbox.
+> Baseado na spec `docs/superpowers/specs/2026-07-06-pcp-fase2a-custo-design.md` (v2) + **Task 0 empírico** + **painel tri-modelo sobre o plano v2** (`scratchpad/painel-2a-plano/agregacao.md` — BLOCK: 4 P1).
+> **v3** — incorpora as correções do painel: classe_causa cruza a 1A (não fabrica "erro de receita"), fila NÃO esconde incompletos/sem-nCMC, view sem vazamento, data-posição validada, RLS enabled (não forced — forced trava o writer), versão na chave, jsonb com contrato, tolerância saneada, conta em config. **Escopo (decisão founder): LIXA (cinta/disco/folha/rolo); tingidor FORA da fila** (Tingimix tem custeio próprio — F2 tardia). Money-path → prova PG17 executando + falsificação. SQL no SQL Editor; NUNCA em supabase/migrations/.
+
+**Goal:** custo-padrão de material por SKU fabricado (Σ componentes × CMC vigente, por bucket, ausente→NULL), **versionado**, + **fila de exceções** priorizada por R$ que **inclui os incompletos/sem-custo** (visibilidade), com **classe de causa provada** (cruza `pcp_bom_excecoes` da 1A), comparando na **mesma data-posição**. Sem escrever no Omie (2B).
+
+**Architecture:** `pcp_custo_padrao_resultados` (1-writer, chave inclui `versao_regra`) + `pcp_custo_excecoes` (fila derivada, inclui lixa incompleta/sem-nCMC). Leitura de CMC data-aware (`fn_pcp_cmc_vigente`, conta de `pcp_config`, INVOKER). Motor **set-based** (`fn_pcp_recompute_custo_padrao`) + derivador (`fn_pcp_recompute_excecoes`), staff-gated. Reusa `fn_pcp_papel_componente` (1A), `pcp_malha_staging.payload->itens`, `pcp_itens.tipo_item`, `pcp_bom_excecoes.pai_codigo`.
+
+**Fora de escopo:** outbox/escrita Omie, backflush, veículo do desvio (2B); tingidor (custeio próprio); MOD/GGF por tempo (F3+); virar fonte na escada `cost_source`.
+
+---
+
+## Task 0: Sonda empírica — ✅ EXECUTADA (achados cravados)
+
+- **Policy `cmc_snapshot`:** `select_staff: employee OR master` → **staff-only** ✅. `fn_pcp_cmc_vigente` INVOKER protege o custo.
+- **Colunas `cmc_snapshot`:** `id, account, omie_codigo_produto, data_posicao, cmc, synced_at`. Sem unidade — CMC é R$/unidade-de-estoque (`omie_products.unidade`).
+- **`unidProdMalha` vs `omie_products.unidade`:** **6732/6732 batem, 0 divergem** ⇒ custo = `qtd × CMC` **sem conversão**; `pcp_custo_unidade` vira **guard defensivo** (nunca dispara hoje).
+- **Fabricados (com estrutura):** cinta 1407 · disco 248 · rolo 123 · tingidor 111 · folha 51. **Lixa = cinta/disco/folha/rolo** (escopo); tingidor fora.
+- **`pcp_bom_excecoes`:** liga por **`pai_codigo` = SKU acabado**; `status`, `disposicao`. **166 SKUs com exceção viva** (0 dispostas) — o oráculo de "receita suspeita".
+- **`percPerdaProdMalha`:** único ≠0 = `0.6`; perda NÃO aplicada (linhagem bateu 50% ao centavo sem ela); teste compara com/sem.
+- **`data_posicao` mais recente:** `2026-06-15` (grade mensal, histórico ≥2 datas p/ drift).
+
+---
+
+## Task 1: Schema — resultados versionados + fila inclusiva
+
+**Files:** Create `db/pcp-f2a-custo.sql`
+
+- [ ] **Step 1: cabeçalho + config**
+
+```sql
+-- PCP Fase 2A — custo-padrão de material (LIXA) + fila de exceções (vs CMC colacor_vendas).
+-- Custo = Σ(componente: quantProdMalha × CMC) na MESMA data-posição. Ausente=NULL. Sem escrita Omie (2B).
+-- Aplicar no SQL Editor. NUNCA em supabase/migrations/. Idempotável.
+BEGIN;
+INSERT INTO pcp_config(chave,valor) VALUES ('custo_cmc_account','colacor_vendas') ON CONFLICT (chave) DO NOTHING;
+INSERT INTO pcp_config(chave,valor) VALUES ('custo_versao_regra','1')            ON CONFLICT (chave) DO NOTHING;
+INSERT INTO pcp_config(chave,valor) VALUES ('custo_tolerancia_pct','0.05')       ON CONFLICT (chave) DO NOTHING;
+INSERT INTO pcp_config(chave,valor) VALUES ('custo_drift_pct','0.10')            ON CONFLICT (chave) DO NOTHING;
+```
+
+- [ ] **Step 2: `pcp_custo_padrao_resultados` (versão na chave — Codex P2-6)**
+
+```sql
+CREATE TABLE IF NOT EXISTS public.pcp_custo_padrao_resultados (
+  omie_codigo_produto bigint NOT NULL,
+  data_posicao        date   NOT NULL,
+  versao_regra        text   NOT NULL,          -- de pcp_config; regra nova NÃO sobrescreve
+  tipo_item           text,                     -- pcp_itens.tipo_item (segrega lixa × resto)
+  custo_abrasivo numeric, custo_cola numeric, custo_catalisador numeric, custo_fita numeric,
+  custo_outros   numeric,                        -- material fora dos 4 papéis (não some)
+  custo_total    numeric,                        -- NULL se custo_status<>'ok'
+  custo_status   text NOT NULL CHECK (custo_status IN ('ok','incompleto','unidade_divergente','ambiguo')),
+  n_componentes int NOT NULL, n_incompletos int NOT NULL,
+  detalhe jsonb, derivado_em timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (omie_codigo_produto, data_posicao, versao_regra)
+);
+```
+
+- [ ] **Step 3: `pcp_custo_excecoes` (fila — INCLUI incompletos/sem-nCMC; lados NULLABLE — Codex/Gemini P2-5)**
+
+```sql
+CREATE TABLE IF NOT EXISTS public.pcp_custo_excecoes (
+  omie_codigo_produto bigint NOT NULL,
+  data_posicao        date   NOT NULL,
+  versao_regra        text   NOT NULL,
+  tipo_item           text,
+  custo_padrao_total  numeric,                   -- NULL quando cmc_incompleto
+  ncmc_acabado        numeric,                   -- NULL quando ncmc_ausente
+  divergencia_abs     numeric,                   -- NULL quando falta um lado
+  divergencia_pct     numeric,
+  impacto_r           numeric NOT NULL,          -- coalesce(divergencia_abs, custo_padrao_total, ncmc) — ordena TUDO
+  classe_causa text NOT NULL CHECK (classe_causa IN
+    ('possivel_erro_receita','drift_preco_provavel','causa_indeterminada',
+     'material_fora_bucket','cmc_incompleto','ncmc_ausente')),
+  custo_status text NOT NULL, derivado_em timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (omie_codigo_produto, data_posicao, versao_regra)
+);
+CREATE INDEX IF NOT EXISTS idx_pcp_custo_exc_imp ON public.pcp_custo_excecoes (impacto_r DESC);
+```
+
+---
+
+## Task 2: CMC vigente (conta de config, ausente→NULL) + helper de data + cobertura
+
+**Files:** Modify `db/pcp-f2a-custo.sql`
+
+- [ ] **Step 1: `fn_pcp_cmc_vigente(p_cod, p_data_posicao, p_permitir_anterior=false)`** — conta lida de `pcp_config` (`custo_cmc_account`), não hardcoded (Gemini P2-10). INVOKER; ausente→NULL; sem fallback salvo `p_permitir_anterior`.
+
+```sql
+CREATE OR REPLACE FUNCTION public.fn_pcp_cmc_vigente(
+  p_cod bigint, p_data_posicao date, p_permitir_anterior boolean DEFAULT false)
+RETURNS numeric LANGUAGE sql STABLE SECURITY INVOKER SET search_path = public AS $$
+  SELECT cmc FROM cmc_snapshot
+   WHERE omie_codigo_produto = p_cod
+     AND account = (SELECT valor FROM pcp_config WHERE chave='custo_cmc_account')
+     AND cmc > 0
+     AND (data_posicao = p_data_posicao OR (p_permitir_anterior AND data_posicao <= p_data_posicao))
+   ORDER BY data_posicao DESC LIMIT 1;
+$$;
+```
+
+- [ ] **Step 2: `fn_pcp_ultima_data_posicao()`** → `max(data_posicao)` do CMC da conta (helper de deploy — evita data hardcoded fora da grade, Codex P1-4).
+
+- [ ] **Step 3: `vw_pcp_cmc_cobertura` com `security_invoker` (Codex P1-3 — não vazar)**
+
+```sql
+CREATE OR REPLACE VIEW public.vw_pcp_cmc_cobertura WITH (security_invoker = true) AS
+  SELECT i.tipo_item,
+         count(*) AS fabricados,
+         count(*) FILTER (WHERE fn_pcp_cmc_vigente(m.omie_codigo_produto,(SELECT fn_pcp_ultima_data_posicao())) IS NOT NULL) AS com_cmc
+    FROM pcp_malha_staging m JOIN pcp_itens i ON i.omie_codigo_produto=m.omie_codigo_produto
+   GROUP BY i.tipo_item;
+REVOKE ALL ON public.vw_pcp_cmc_cobertura FROM anon, authenticated;
+GRANT SELECT ON public.vw_pcp_cmc_cobertura TO authenticated;  -- security_invoker => RLS do cmc_snapshot barra não-staff
+```
+
+---
+
+## Task 3: Motor do custo-padrão — SET-BASED, jsonb com contrato, ausente→NULL
+
+**Files:** Modify `db/pcp-f2a-custo.sql`
+
+- [ ] **Step 1: `fn_pcp_recompute_custo_padrao(p_data_posicao date)`** — SECURITY DEFINER, staff-gate (`auth.uid()` + has_role master|employee), `SET search_path=public`.
+  - **Validar data-posição** (Codex P1-4): `IF NOT EXISTS(SELECT 1 FROM cmc_snapshot WHERE account=<config> AND data_posicao=p_data_posicao) THEN RAISE EXCEPTION 'data-posição % inexistente na grade CMC'`.
+  - **Contrato jsonb** (Codex P2-8): só processa `WHERE jsonb_typeof(payload->'itens')='array'`; SKU com itens ausente/objeto ⇒ `custo_status='ambiguo'`, custo_total NULL (não aborta, não fabrica).
+  - **Motor set-based** (Codex/Claude P3) — `INSERT...SELECT` com CTEs:
+    ```
+    comp:   pcp_malha_staging × LATERAL jsonb_array_elements(payload->'itens') → cod, qtd(::numeric seguro), uom
+    enrich: LEFT JOIN omie_products (unidade), fn_pcp_cmc_vigente(cod,p_data) AS cmc, fn_pcp_papel_componente(...) AS papel
+    calc:   custo = CASE WHEN cmc IS NULL THEN NULL                       -- incompleto
+                        WHEN uom_estoque IS NOT NULL AND uom<>uom_estoque THEN NULL  -- guard unidade
+                        ELSE qtd*cmc END ; flags falta_cmc, unidade_diverge
+    agg:    GROUP BY sku → sum(custo) FILTER por papel (abrasivo/cola/catalisador/fita/outros),
+            n_comp, n_falta, n_div, jsonb_agg(detalhe)
+    ```
+    `custo_status` = `unidade_divergente` se n_div>0; `incompleto` se n_falta>0; `ambiguo` se itens não-array; senão `ok`. `custo_total` = Σ buckets **só se ok**, senão NULL. **Somar TODOS os componentes de cada papel** (não "canônico"). `tipo_item` de pcp_itens. Upsert por PK `(sku,data,versao)` (versão de config).
+- [ ] **Step 2:** cola/catalisador (consumível indireto, spec §1.5): custo já sai de `qtd×CMC` da estrutura; **não** re-derivar por coeficiente. Fator de perda de mistura (se o founder der o número) multiplicaria a `qtd` da cola, de fonte independente, **nunca** calibrado pela divergência (Codex J). Ponto aberto — não implementar sem número.
+
+---
+
+## Task 4: Fila de exceções — inclusiva, temporal-coerente, classe PROVADA
+
+**Files:** Modify `db/pcp-f2a-custo.sql`
+
+- [ ] **Step 1: `fn_pcp_recompute_excecoes(p_data_posicao date)`** — staff-gated. Opera **só sobre LIXA** (`tipo_item IN ('cinta','disco','folha','rolo')` — tingidor fora, decisão founder). Para cada SKU de lixa em `_resultados` da data/versão:
+  - **nCMC do acabado** = `fn_pcp_cmc_vigente(sku, p_data_posicao)` (mesma data — coerência temporal, Codex/Gemini B).
+  - **Classe (precedência — não esconder o pior caso):**
+    1. `custo_status='incompleto'` ⇒ **`cmc_incompleto`** (entra na fila; total NULL; `impacto_r = coalesce(custo_parcial, nCMC)`). Codex/Gemini P2-5.
+    2. senão `custo_status='ok'` E `nCMC IS NULL` ⇒ **`ncmc_ausente`** (produto ativo NÃO custeado; `impacto_r = custo_total`). Gemini P2.
+    3. senão (`ok` + nCMC): `div_abs=abs(total-nCMC)`, `div_pct=div_abs/NULLIF(nCMC,0)` (Codex P3). Só segue se `div_pct > tolerancia` (config, saneada).
+       - `custo_outros>0` ⇒ **`material_fora_bucket`** (componente não-lixa numa receita de lixa — genuíno agora que tingidor saiu).
+       - senão `pai_codigo ∈ pcp_bom_excecoes (status='excecao', disposicao vazia)` ⇒ **`possivel_erro_receita`** PROVADO (Codex P1-1 + Claude). A 1A é o oráculo de "estrutura suspeita".
+       - senão ≥2 datas-posição de CMC com Δ componente > `custo_drift_pct` ⇒ **`drift_preco_provavel`**.
+       - senão ⇒ **`causa_indeterminada`** (default HONESTO — nunca acusa receita sem oráculo).
+  - Upsert idempotente; ordena por `impacto_r DESC`.
+- [ ] **Step 2:** limpar da fila (mesma data/versão) o que saiu da banda/regularizou (sem fila fantasma).
+- [ ] **Step 3: `vw_pcp_custo_calibracao`** (Codex P2-9) — a distribuição de `div_pct` **só sobre dado saneado** (`custo_status='ok'`, `custo_outros=0` ou NULL, `nCMC` presente, sem exceção 1A) — a base para calibrar `custo_tolerancia_pct`. Materializada como view p/ o founder inspecionar antes de fixar a banda.
+
+---
+
+## Task 5: RLS enabled (NÃO forced) + grants
+
+**Files:** Modify `db/pcp-f2a-custo.sql`
+
+- [ ] **Step 1:** (Codex P2-7 — FORCE trava o writer DEFINER; enabled + policy staff + revoke DML basta)
+
+```sql
+ALTER TABLE public.pcp_custo_padrao_resultados ENABLE ROW LEVEL SECURITY;  -- NÃO force: o writer é a RPC DEFINER
+ALTER TABLE public.pcp_custo_excecoes          ENABLE ROW LEVEL SECURITY;
+-- DROP POLICY IF EXISTS + CREATE staff-only (master|employee) SELECT em cada.
+REVOKE ALL ON public.pcp_custo_padrao_resultados, public.pcp_custo_excecoes FROM anon, authenticated;
+GRANT SELECT ON public.pcp_custo_padrao_resultados, public.pcp_custo_excecoes TO authenticated;  -- policy filtra
+REVOKE ALL ON FUNCTION public.fn_pcp_recompute_custo_padrao(date), public.fn_pcp_recompute_excecoes(date)
+  FROM PUBLIC, anon, authenticated;                    -- só staff/cron via SQL Editor
+REVOKE ALL ON FUNCTION public.fn_pcp_cmc_vigente(bigint,date,boolean), public.fn_pcp_ultima_data_posicao() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.fn_pcp_cmc_vigente(bigint,date,boolean) TO authenticated;  -- RLS do cmc barra
+COMMIT;
+```
+
+---
+
+## Task 6: Prova PG17 (propriedades + falsificação)
+
+**Files:** Create `db/test-pcp-f2a-custo.sh`
+
+Harness PG17; roles; stub `auth.uid()/has_role` staff `..aaaa`/não-staff `..bbbb`; stubs `cmc_snapshot` (policy staff-only), `omie_products`, `pcp_malha_staging`, `pcp_itens`, `pcp_config`, `pcp_bom_excecoes`, `fn_pcp_papel_componente`. Asserts:
+
+- [ ] **1 custo simples** — abrasivo(2×10)+cola(3×5) → 20/15, total 35 (**total = Σ buckets**).
+- [ ] **2 soma completa** — componente `outro` → `custo_outros` (não some).
+- [ ] **3 ausente→NULL** — sem CMC ⇒ `incompleto`, total NULL (não 0).
+- [ ] **4 guard unidade** — `unidProdMalha`≠estoque ⇒ `unidade_divergente`, total NULL.
+- [ ] **5 multi-componente** — 2 abrasivos somam (não "canônico").
+- [ ] **6 data-posição inválida ABORTA** (Codex P1-4) — recompute em data fora da grade ⇒ RAISE (não NULL em massa).
+- [ ] **7 jsonb malformado** (Codex P2-8) — itens objeto/ausente ⇒ `ambiguo`, não aborta.
+- [ ] **8 fila inclui incompleto** (P2-5) — SKU lixa incompleto ⇒ linha `cmc_incompleto` na fila (não some).
+- [ ] **9 fila inclui sem-nCMC** — SKU lixa ok sem nCMC ⇒ `ncmc_ausente`.
+- [ ] **10 classe PROVADA** (P1-1) — SKU lixa que diverge **com** exceção 1A ⇒ `possivel_erro_receita`; **sem** exceção 1A e sem drift ⇒ `causa_indeterminada` (NÃO erro_receita).
+- [ ] **11 tingidor fora** — SKU tingidor NÃO entra na fila.
+- [ ] **12 coerência temporal** — acabado sem nCMC na data ⇒ ncmc_ausente (não exceção falsa de divergência).
+- [ ] **13 view não vaza** (P1-3) — não-staff: `SELECT count(*) FROM vw_pcp_cmc_cobertura` respeita RLS (0/erro).
+- [ ] **14 RLS** — staff lê; não-staff 0 linhas; recompute não-staff barra.
+- [ ] **15 versão não sobrescreve** (P2-6) — recompute versão '2' coexiste com '1'.
+- [ ] **16 idempotência** — recompute 2× mesma data/versão ⇒ igual.
+- [ ] **17 FALSIFICAÇÃO** (sabota→vermelho→reverte): `COALESCE(cmc,0)`→#3; remover guard→#4; só 1º componente→#5; tirar validação de data→#6; default `possivel_erro_receita` sem cruzar 1A→#10; `security_invoker`off→#13; INVOKER→DEFINER no cmc→#14. Documentar no cabeçalho.
+- [ ] **18** `heavy bash db/test-pcp-f2a-custo.sh > /tmp/t-2a.log 2>&1; echo exit=$?` → `PASS=N FAIL=0`.
+- [ ] **19 commit** `feat(pcp): F2A — custo-padrão lixa (estrutura×CMC) + fila classificada (cruza 1A, inclui incompletos) + RLS + prova PG17`.
+
+---
+
+## Task 7: Diário
+
+- [ ] `docs/historico/pcp.md` seção "Fase 2A": 2 tabelas, reposicionamento (híbrido→fila classificada), Task 0 (6732/6732), painel (BLOCK 4 P1 → v3), escopo lixa, classe cruzando 1A, conta única, PASS=N.
+
+---
+
+## Deploy (founder, manual)
+1. `db/pcp-f2a-custo.sql` no SQL Editor → Run (idempotável).
+2. `SELECT fn_pcp_recompute_custo_padrao(fn_pcp_ultima_data_posicao());` depois `SELECT fn_pcp_recompute_excecoes(fn_pcp_ultima_data_posicao());`
+3. Verificação minha (psql-ro): cobertura por tipo_item, top-10 fila por impacto_r, distribuição de classe_causa, ncmc_ausente, RLS.
+
+## Self-Review (autor)
+- **4 P1 resolvidos:** classe cruza 1A + default indeterminado (T4) · tingidor fora + família (T1/T4) · view security_invoker (T2) · data-posição valida/aborta (T3/T6#6).
+- **7 P2/P3:** fila inclui incompletos/sem-nCMC (T1/T4) · versao_regra (T1) · RLS enabled não forced (T5) · jsonb contrato (T3) · calibração saneada (T4#3) · conta em config (T2) · set-based/NULLIF/guard (T3). Guard unidade mantido (0 casos hoje).
+- **Escopo:** lixa; tingidor fora (decisão founder). **Pendências:** fator de perda (sem número → não implementado); calibração da tolerância (view pronta p/ o founder).

--- a/docs/superpowers/specs/2026-07-06-pcp-fase2a-custo-design.md
+++ b/docs/superpowers/specs/2026-07-06-pcp-fase2a-custo-design.md
@@ -1,0 +1,64 @@
+# PCP Fase 2A — Custo-padrão & fila de exceções de custo — Design (v2)
+
+> Spec de **design** (o quê/por quê). O **como** (migration, provas) vai no plano.
+> **v2** — reescrita após o painel tri-modelo sobre a v1 (BLOCK: 5 P1 do Codex + confirmações Claude/Gemini) e a **sonda de linhagem** que redefiniu o valor. Ver `scratchpad/painel-2a/agregacao.md` e `achado-fase2-custo.md`.
+
+## 1. Contexto & os dois achados que definiram o design
+
+**Achado 1 — a fonte de custo (sonda 2026-07-06).** O `custoProducao{vGGF,vMOD}` da malha Omie está **100% ZERADO** (0/2011). O custo real está no `cmc_snapshot` (CMC de estoque via `ListarPosEstoque`/`nCMC`, edge `cmc-snapshot-backfill`), grade **mensal**, conta **única `colacor_vendas`** (founder confirmou: Colacor compra e vende tudo). Cobertura: **94% acabados, 99% insumos**.
+
+**Achado 2 — o CMC do acabado é HÍBRIDO (sonda de linhagem, mesma data-posição).** Comparando `nCMC(acabado)` vs `Σ(estrutura × nCMC insumo)` em 1863 produtos: **50% batem ≤1%** (idênticos ao centavo em 23%), mas **35% divergem >5%**. Ou seja, o `nCMC` do fabricado é **em parte o custo teórico da estrutura, em parte um custo próprio** (média móvel de OPs históricas + apuração + perda). **Consequência:** a v1 vendia "teórico × real puro" e "gap = conversão de graça" — **falso**: para metade dos SKUs o CMC é o próprio teórico, e o "gap" é ~zero. O valor real está nos **~35% que divergem**.
+
+**Reposicionamento (v2):** o 2A entrega **(1)** o **custo-padrão calculado por SKU** (a base de custo estruturada que hoje não existe — item 1 da Fase 2) e **(2)** uma **fila de exceções** onde o custo-padrão diverge do custo-de-estoque do Omie, **com a causa provável classificada**. NÃO promete "conversão observada de graça" — o resíduo é ambíguo (drift de preço + apuração + material omitido) e é **classificado, não interpretado como MOD/GGF**.
+
+## 2. Objetivo & não-objetivos
+
+**Objetivo:** para cada SKU fabricado, **(a)** calcular o **custo-padrão** = Σ de TODOS os componentes de material × CMC (na mesma data-posição), por bucket, com unidade normalizada e ausente→NULL; **(b)** persistir o resultado **versionado** (auditável, reprocessável); **(c)** comparar com o `nCMC` do acabado e emitir uma **fila de exceções priorizada por R$**, com **classe de causa provável** (drift de preço · material fora do bucket · CMC incompleto · possível erro de receita).
+
+**Não-objetivos:** escrever no Omie (2B); MOD/GGF calculada por tempo (Fase 3+, do apontamento M1); virar fonte na escada `cost_source` multi-writer (o CMC não entra na escada — 1 writer); custo real por OP individual (2B); tratar o resíduo como conversão (rebaixado a `residuo_classificado`).
+
+## 3. Arquitetura — dois módulos
+
+### 2A.0 — Base de custo (leitura data-aware sobre o CMC)
+- **`fn_pcp_cmc_vigente(p_cod bigint, p_data_posicao date)` → numeric**: o CMC de `account='colacor_vendas'` na **exata `data_posicao`** pedida (a grade é mensal e comum); fallback para a data-posição imediatamente anterior **só** se explicitado, marcando staleness. **NULL se ausente** (jamais 0). Conta é fixa (não é parâmetro aberto — remove o risco de conta errada).
+- **Unidade é CONTRATO, não sonda** (Codex P1): uma tabela `pcp_custo_unidade(papel, uom_coef, uom_cmc, fator_conversao, fonte, vigente_em)` com constraint; o cálculo **recusa (→ NULL/exceção)** quando falta conversão conhecida entre a unidade do coeficiente e a unidade comercial do CMC. Cola/catalisador em G vs CMC por KG/L = fator 1000 barrado aqui.
+- **Cobertura/frescor:** `vw_pcp_cmc_cobertura` reporta % com CMC vigente e idade — o 2A sabe onde **não pode** afirmar custo.
+
+### 2A.1 — Motor de custo-padrão + fila de exceções
+- **Custo-padrão, TODOS os componentes, bucketizado:** `pcp_custo_padrao_resultados` (versionada — 1 writer) com, por (SKU, data_posicao, versao_regra): custo por bucket (`abrasivo | cola | catalisador | fita | outros_materiais`), total, `custo_status` (`ok | incompleto | unidade_indefinida | ambiguo`), insumos usados. **Soma de TODOS os componentes de cada papel** (não um "canônico" — Codex/Claude E): a classificação canônica roteia, não escolhe o custo. **Qualquer componente fora dos buckets conhecidos vai para `outros_materiais`** (Codex H) — nada cai silenciosamente no resíduo. Componente com CMC/unidade NULL ⇒ SKU `incompleto` (não soma como zero).
+- **Cola/catalisador (consumível indireto, spec §1.5):** o fator de perda de mistura **multiplica** o coeficiente cru por área/emenda (preserva a diferença física entre larguras — Gemini J), **não** substitui; o fator vem de **fonte empírica independente**, versionado em `pcp_config` — **proibido calibrá-lo pela própria divergência** contra o CMC (circularidade — Codex J).
+- **Comparação temporal-coerente:** custo-padrão e `nCMC` do acabado **na MESMA `data_posicao`** (elimina o lag Gemini/Codex B). Flag `comparacao_temporalmente_valida`; SKU sem CMC comparável na data ⇒ fora da fila (não vira exceção falsa).
+- **Fila `pcp_custo_excecoes`** (derivada dos resultados, não fonte paralela — Codex I): SKU, custo_padrao (buckets+total), nCMC, `divergencia_abs` (R$), `divergencia_pct`, `classe_causa`, `custo_status`, `data_posicao`, `derivado_em`. **Ordenável por R$.**
+- **`classe_causa`** (Codex D — o resíduo é classificado, não "conversão"): `material_fora_bucket` (havia `outros`?) · `cmc_incompleto` · `drift_preco_provavel` (insumos mudaram muito desde a última posição) · `possivel_erro_receita` (resto). Nenhuma vira "MOD/GGF" sem prova.
+
+## 4. Invariantes money-path (não-negociáveis)
+1. **Ausente = NULL, nunca 0.** Sem `COALESCE(cmc,0)` em caminho de custo. Faltou CMC/unidade ⇒ `incompleto`, exceção visível, **não** validado.
+2. **Unidade = contrato de dados.** Constraint + tabela de conversão; cálculo bloqueado sem conversão conhecida. Assert PG17.
+3. **Coerência temporal.** Custo-padrão e nCMC do acabado na mesma `data_posicao`; sem comparar janelas diferentes.
+4. **Soma completa.** Todo componente de material entra em algum bucket (inclusive `outros_materiais`); nada evapora no resíduo.
+5. **1 writer, sem circularidade.** `pcp_custo_padrao_resultados`/`_excecoes` têm produtor único; o CMC não entra na escada `cost_source`; o fator de perda NÃO é calibrado pela divergência que ele deveria validar.
+6. **RLS = contrato explícito** (Codex G): tabelas de custo com RLS **enabled + FORCED**, policies staff-only; funções de leitura **SECURITY INVOKER** (ou wrapper com gate `auth.uid()` staff, nunca DEFINER cru); `REVOKE ALL` de public/authenticated; grant só a role interna. Não-staff → 0 linhas/erro, **nunca NULL seletivo** (inferência por SKU). Vendedor não vê custo (CLAUDE.md).
+7. **Tolerância saneada.** A banda por família só se calibra sobre SKUs com comparação **válida** (unidade provada, CMC presente, sem `outros` faltante, sem ambiguidade). Percentis sobre dado contaminado normalizam erro sistêmico (Codex K).
+
+## 5. O resíduo (ex-"gap de conversão")
+`residuo = nCMC_acabado − custo_padrao_total`. **Não** é conversão/MOD-GGF: contém drift de preço, apuração de OPs antigas, ajustes, arredondamento e material eventualmente omitido. É **exposto e classificado** (§3 `classe_causa`), **nunca** promovido a conversão-padrão nem alimenta a escada — até que (a) a linhagem do CMC seja provada e (b) os outros efeitos sejam isolados. Fica como sinal de investigação, não como número contábil.
+
+## 6. Testes a provar (PG17, com falsificação)
+- CMC vigente por data-posição exata; fallback só quando pedido; ausente → NULL.
+- **Propriedades de conservação:** total = Σ buckets; nenhum componente de material sem bucket; componente duplicado não duplica custo indevido; **recompute idempotente** (mesma data → mesmo resultado).
+- **Unidade:** componente sem conversão conhecida ⇒ `unidade_indefinida` (NÃO custo 0). Falsificar: remover a conversão de cola e exigir vermelho.
+- **Soma completa:** componente fora dos 4 buckets vai para `outros_materiais` (não some).
+- **Coerência temporal:** comparar em data-posição diferente ⇒ fora da fila (não exceção falsa).
+- **RLS:** staff vê; não-staff 0 linhas (falsificar INVOKER→DEFINER → vermelho).
+- **Cola/catalisador:** fator multiplica (custo varia com a largura); falsificar substituindo por fixo → teste de duas larguras fica vermelho.
+- **Falsificação geral:** trocar NULL por 0 quebra o teste de `incompleto`; calibrar tolerância sobre dado contaminado muda a fila (documentar).
+
+## 7. Pontos abertos (plano/sonda — não bloqueiam o design)
+1. **Fator de perda de mistura** (cola/catalisador): valor inicial + fonte empírica independente (com founder/dados) — nunca da divergência.
+2. **Tolerância por família:** rodar a distribuição **saneada** das divergências sobre os acabados válidos para fixar a banda.
+3. **`classe_causa` drift:** heurística de "insumos mudaram muito" precisa de ≥2 datas-posição de CMC (a grade mensal já dá histórico).
+4. **Cadência de recompute:** cron encadeado após o backfill mensal de CMC + on-demand staff (marca de frescor visível).
+5. **Linhagem do CMC (opcional, rigor extra):** se o founder quiser, confirmar com o contador como o Omie forma o `nCMC` do fabricado (média móvel? recálculo por estrutura? inclui overhead?) — afina a interpretação das exceções, mas o design já é honesto sem isso (trata o resíduo como ambíguo).
+
+## 8. Fora de escopo
+Outbox/escrita no Omie, backflush, veículo fiscal do desvio, custo real por OP → **Fase 2B**. MOD/GGF calculada por tempo → Fase 3+. Motor de rota → Fase 3.


### PR DESCRIPTION
## O que

Abre a **Fase 2 (Custo & Omie)** do PCP pelo bloco de **custo** (read-only, não escreve no Omie). Calcula o **custo-padrão de material** por SKU de lixa (cinta/disco/folha/rolo) = Σ(estrutura Omie × CMC de estoque `colacor_vendas`) na mesma data-posição, bucketizado (abrasivo/cola/catalisador/fita/outros), e deriva uma **fila de exceções classificada** priorizada por R$.

## Por que assim (o método pegou o design errado antes do código)

- **Sonda empírica (Task 0):** o `custoProducao{vGGF,vMOD}` da malha Omie está **100% zerado** (0/2011) → o custo real vive no `cmc_snapshot`. O plano original (comparar com o `custoProducao`) era inviável; a sonda pegou isso **antes** de o schema nascer errado. E `unidProdMalha` bate com a unidade de estoque em **6732/6732** → custo direto, sem conversão (removeu um P1 de unidade inteiro).
- **Linhagem híbrida:** o CMC do acabado é em parte o próprio teórico (50% batem ≤1%, 23% ao centavo), em parte média-móvel histórica (35% divergem). Reposicionou o 2A de "teórico×real puro" para **custo-padrão calculado + fila classificada** (o valor está nos ~35%).

## Invariantes money-path

- `ausente=NULL` (nunca `COALESCE(cmc,0)`); guard de unidade; contrato jsonb (`ambiguo`, não aborta nem fabrica).
- Classe **cruza a fila da 1A** (`pcp_bom_excecoes.pai_codigo`) — só acusa "erro de receita" com esse oráculo; default `causa_indeterminada`.
- Fila **inclui o pior caso** (SKU sem custo `ncmc_ausente`, insumo sem CMC `cmc_incompleto`, unidade divergente) — não esconde.
- RLS enabled+staff; `fn_pcp_cmc_vigente` **INVOKER** (custo não vaza p/ vendedor); advisory lock; data-posição valida+aborta; idempotável.

## Verificação

- **2 voltas de painel tri-modelo** (Claude+Codex+Gemini): plano **BLOCK 4 P1** → v3; código real **1 confirmado + 5 defensivos** → hardening.
- **Prova PG17 `PASS=55 FAIL=0`** (idempotência 2×) + **8 sabotagens falsificadas** (`INVOKER→DEFINER` vaza custo; `COALESCE(cmc,0)` derruba 10 asserts de "ausente≠zero"; reverter o FIX-1 some da fila).

## Deploy (founder, manual — pós-merge, 1 camada SQL)

1. Colar `db/pcp-f2a-custo.sql` no SQL Editor → Run (idempotável).
2. `SELECT fn_pcp_recompute_custo_padrao(fn_pcp_ultima_data_posicao());` depois `SELECT fn_pcp_recompute_excecoes(fn_pcp_ultima_data_posicao());`

## Fora de escopo

**Fase 2B** (outbox fiscal: incluir/concluir OP, backflush nativo, veículo do desvio — precisa do contador + sandbox Omie); tingidor (custeio próprio, F2 tardia); MOD/GGF por tempo (F3+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
