### PR TITLE
refactor(ui): ProtectedRoute usa PageSkeleton no loading (esteira #1215, último gate full-page)

### DIFF
--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,8 +1,9 @@
 import { Navigate, useLocation } from 'react-router-dom';
-import { Loader2, Clock, RefreshCw } from 'lucide-react';
+import { Clock, RefreshCw } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -13,11 +14,7 @@ export const ProtectedRoute = ({ children }: ProtectedRouteProps) => {
   const location = useLocation();
 
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <Loader2 className="w-8 h-8 animate-spin text-primary" />
-      </div>
-    );
+    return <PageSkeleton variant="auto" />;
   }
 
   if (!user) {


### PR DESCRIPTION
## O quê

`src/components/ProtectedRoute.tsx` — o branch `if (loading)` renderizava um spinner de página inteira (`<Loader2 animate-spin>`), o **último gate full-page** ainda fora da convenção do design system v3 do CLAUDE.md ("Skeleton: `<PageSkeleton>` — não `<Loader2 spin>` de página inteira").

Troca por `<PageSkeleton variant="auto" />` — o **mesmo** fallback do Suspense de rota (`App.tsx:187`). Elimina o flash duplo no boot/pós-login: **spinner → skeleton → conteúdo** vira **skeleton → conteúdo**, coeso.

## Escopo cirúrgico

- ✅ Só o branch `loading`.
- ⛔ `!user` (redirect `/auth`) e `!isApproved` (card "Cadastro Pendente de Aprovação") **intocados** — têm UI própria intencional.
- `Loader2` removido do import (ficou órfão); `Clock`/`RefreshCw` seguem em uso nos outros branches.

Diff: **1 arquivo, +3 / −6**.

## Verificação

- `typecheck` (tsc strict) ✅ EXIT=0
- `build` (Vite prod) ✅ EXIT=0 — "✓ built in 18.26s", 315 entries no precache PWA
- Assinatura estrutural no arquivo: `Loader2`/`animate-spin` = **0** ocorrências; `variant="auto"` presente no branch loading (l.17).

## Deploy

Frontend puro → precisa **Publish** no Lovable pra ir ao ar (merge na `main` ≠ produção). **Sem** edge function, **sem** migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
