### PR TITLE
feat(financeiro): F4 antecipação de recebíveis — custo money-weighted + comparação de funding (Codex 5P1+2P2, prova PG17)

### DIFF
--- a/db/test-fin-antecipacoes.sh
+++ b/db/test-fin-antecipacoes.sh
@@ -140,6 +140,50 @@ Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; INSERT INTO public.fin_an
 V=$(Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; SELECT updated_by||'/'||created_by FROM public.fin_antecipacoes WHERE company='oben' AND valor_bruto=2000;" | tail -1)
 eq "A10 trigger força created_by/updated_by=auth.uid()" "$V" "$MASTER/$MASTER"
 
+# ── P2-b (Codex): mais dentes de CHECK/dedup ──────────────────────────────────────────────────
+# A11 valores: custos_avulsos < 0 → check_violation (isola o CHECK de valores; liquido_chk passa)
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',1000,-1,900,'2026-01-01','2026-02-01');
+  RAISE EXCEPTION 'AVULSOS_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'AVULSOS_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *AVULSOS_BARROU*) ok "A11 CHECK rejeita custos_avulsos < 0" ;; *) bad "A11 avulsos — veio: $R" ;; esac
+
+# A12 valores: valor_liquido <= 0 → check_violation (liquido=0, bruto=1000: só o valores_chk falha)
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',1000,0,'2026-01-01','2026-02-01');
+  RAISE EXCEPTION 'LIQZERO_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'LIQZERO_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *LIQZERO_BARROU*) ok "A12 CHECK rejeita valor_liquido <= 0" ;; *) bad "A12 liq-zero — veio: $R" ;; esac
+
+# A13 dedup com banco NULL: coalesce(banco,'') deduplica mesmo sem banco (2ª igual → unique_violation)
+Pq -c "INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,referencia) VALUES ('colacor','duplicata',5000,4900,'2026-01-01','2026-02-01','NB-1');" >/dev/null
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,referencia)
+    VALUES ('colacor','duplicata',5000,4900,'2026-03-01','2026-04-01','NB-1');
+  RAISE EXCEPTION 'NB_NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'NB_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *NB_BARROU*) ok "A13 dedup com banco NULL (coalesce '')" ;; *) bad "A13 nb — veio: $R" ;; esac
+
+# A14 dedup libera re-registro APÓS soft-delete (índice parcial WHERE deleted_at IS NULL)
+Pq -c "INSERT INTO public.fin_antecipacoes(company,banco,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,referencia) VALUES ('colacor_sc','Itaú','duplicata',3000,2900,'2026-01-01','2026-02-01','SD-1');" >/dev/null
+Pq -c "UPDATE public.fin_antecipacoes SET deleted_at=now() WHERE company='colacor_sc' AND referencia='SD-1';" >/dev/null
+if P -q -c "INSERT INTO public.fin_antecipacoes(company,banco,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,referencia) VALUES ('colacor_sc','Itaú','duplicata',3000,2900,'2026-03-01','2026-04-01','SD-1');" >/dev/null 2>&1; then
+  ok "A14 dedup libera re-registro após soft-delete"
+else
+  bad "A14 re-registro após soft-delete foi bloqueado (índice não exclui deletados)"
+fi
+
 # ══ FALSIFICAÇÃO (Lei #3) — sabota → exige VERMELHO → restaura ══
 echo "── falsificação ──"
 

--- a/db/test-fin-antecipacoes.sh
+++ b/db/test-fin-antecipacoes.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — fin_antecipacoes (F4 antecipação de recebíveis). Money-path:     ║
+# ║  RLS master-only + CHECK do líquido (P1-1 igualdade VÁLIDA) + CHECK do prazo   ║
+# ║  + unique de dedup + trigger de autor (created_by/updated_by). Com             ║
+# ║  FALSIFICAÇÃO. bash db/test-fin-antecipacoes.sh > /tmp/t.log 2>&1; echo $?     ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="fin-antecipacoes"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ── ZONA 1 — pré-requisito: user_roles (a RLS lê; a migration NÃO cria) ─────────────────────────
+P -q <<'SQL'
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role text);
+SQL
+
+# ── ZONA 2 — aplica a migration REAL (Lei #1) ─────────────────────────────────────────────────────
+MIG="$REPO_ROOT/supabase/migrations/20260708120000_fin_antecipacoes.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+# ── ZONA 3 — seed + grants ──────────────────────────────────────────────────────────────────────
+MASTER='33333333-3333-3333-3333-333333333333'
+NAOMASTER='22222222-2222-2222-2222-222222222222'
+OUTRO='99999999-9999-9999-9999-999999999999'
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$MASTER'),('$NAOMASTER') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES ('$MASTER','master') ON CONFLICT DO NOTHING;
+-- seed como postgres (bypassa RLS): 2 linhas p/ os asserts de RLS lerem. A 2ª tem líquido==bruto (custo 0, P1-1).
+INSERT INTO public.fin_antecipacoes(company,banco,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento,referencia) VALUES
+  ('oben','Itaú','duplicata',100000,0,97000,'2026-01-01','2026-01-31','DUP-1'),
+  ('oben','Itaú','linha',     50000,0,50000,'2026-02-01','2026-04-02','LINHA-1');
+-- migration é --no-privileges → conceda p/ os asserts de RLS (a RLS filtra por cima)
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fin_antecipacoes TO authenticated, anon;
+GRANT SELECT ON public.user_roles TO authenticated, anon;
+SQL
+
+echo "── asserts ──"
+
+# A1 POSITIVO: tabela existe, 2 linhas (inclui a de custo zero — P1-1 igualdade VÁLIDA)
+V=$(Pq -c "SELECT count(*) FROM public.fin_antecipacoes;")
+eq "A1 tabela existe, 2 linhas (uma com líquido==bruto, custo 0)" "$V" "2"
+
+# A2 NEGATIVO: líquido > bruto+avulsos → check_violation (P1-1: inválido SÓ quando MAIOR)
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',100000,0,100001,'2026-01-01','2026-02-01');
+  RAISE EXCEPTION 'LIQ_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'LIQ_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *LIQ_BARROU*) ok "A2 CHECK rejeita líquido > bruto+avulsos" ;; *) bad "A2 liq — veio: $R" ;; esac
+
+# A3 POSITIVO: líquido == bruto+avulsos é ACEITO (custo zero é válido, não inválido)
+Pq -c "INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento) VALUES ('colacor','duplicata',10000,100,10100,'2026-03-01','2026-04-01');" >/dev/null
+V=$(Pq -c "SELECT count(*) FROM public.fin_antecipacoes WHERE company='colacor';")
+eq "A3 líquido == bruto+avulsos aceito (P1-1)" "$V" "1"
+
+# A4 NEGATIVO: prazo não-positivo (venc <= operação) → check_violation
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',1000,990,'2026-01-10','2026-01-10');
+  RAISE EXCEPTION 'PRAZO_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'PRAZO_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *PRAZO_BARROU*) ok "A4 CHECK exige prazo positivo" ;; *) bad "A4 prazo — veio: $R" ;; esac
+
+# A5 NEGATIVO: dedup — mesma (company,banco,referencia) viva → unique_violation
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,banco,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,referencia)
+    VALUES ('oben','Itaú','duplicata',100000,97000,'2026-05-01','2026-06-01','DUP-1');
+  RAISE EXCEPTION 'DEDUP_NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'DEDUP_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *DEDUP_BARROU*) ok "A5 unique parcial dedup por referência" ;; *) bad "A5 dedup — veio: $R" ;; esac
+
+# A6 RLS: master vê; A7 não-master 0; A8 anon 0  (3 linhas: 2 oben + 1 colacor do A3)
+MASTERV=$(Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+NMV=$(Pq -c "SET test.uid='$NAOMASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+ANONV=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+eq "A6 master vê"           "$MASTERV" "3"
+eq "A7 não-master NÃO vê"   "$NMV"     "0"
+eq "A8 anon NÃO vê"         "$ANONV"   "0"
+
+# A9 RLS: não-master NÃO escreve → insufficient_privilege
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$NAOMASTER'; SET ROLE authenticated;
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',1000,990,'2026-01-01','2026-02-01');
+  RAISE EXCEPTION 'RLS_WRITE_NAO_BARROU';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'RLS_WRITE_BARROU'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *RLS_WRITE_BARROU*) ok "A9 RLS nega escrita de não-master" ;; *) bad "A9 rls-write — veio: $R" ;; esac
+
+# A10 TRIGGER: master insere passando created_by/updated_by falsos → trigger sobrescreve p/ auth.uid()
+Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,created_by,updated_by) VALUES ('oben','duplicata',2000,1900,'2026-07-01','2026-08-01','$OUTRO','$OUTRO');" >/dev/null
+V=$(Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; SELECT updated_by||'/'||created_by FROM public.fin_antecipacoes WHERE company='oben' AND valor_bruto=2000;" | tail -1)
+eq "A10 trigger força created_by/updated_by=auth.uid()" "$V" "$MASTER/$MASTER"
+
+# ══ FALSIFICAÇÃO (Lei #3) — sabota → exige VERMELHO → restaura ══
+echo "── falsificação ──"
+
+# F1: policy SELECT furada (USING true) → não-master passa a VER → A7 perde o dente
+P -q <<'SQL'
+DROP POLICY IF EXISTS fin_antecipacoes_select_master ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_select_master ON public.fin_antecipacoes FOR SELECT USING (true);
+SQL
+NMV2=$(Pq -c "SET test.uid='$NAOMASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+if [ "$NMV2" != "0" ]; then ok "F1 policy furada deixou não-master ver ($NMV2) → A7 tem dente"; else bad "F1 sabotei e não-master AINDA não vê → A7 fraco"; fi
+P -q -f "$MIG" >/dev/null
+NMV3=$(Pq -c "SET test.uid='$NAOMASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+eq "F1' restaurada: não-master volta a NÃO ver" "$NMV3" "0"
+
+# F2: dropa o CHECK do líquido → líquido > bruto+avulsos passa → A2 perde o dente
+P -q -c "ALTER TABLE public.fin_antecipacoes DROP CONSTRAINT fin_antecipacoes_liquido_chk;"
+if P -q -c "INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento) VALUES ('colacor_sc','duplicata',100,200,'2026-01-01','2026-02-01');" >/dev/null 2>&1; then
+  ok "F2 sem o CHECK, líquido > bruto passou → A2 tinha dente"
+else
+  bad "F2 droppei o CHECK e o INSERT AINDA falhou → A2 não provava o CHECK"
+fi
+P -q -c "DELETE FROM public.fin_antecipacoes WHERE company='colacor_sc';"
+P -q -c "ALTER TABLE public.fin_antecipacoes ADD CONSTRAINT fin_antecipacoes_liquido_chk CHECK (valor_liquido <= valor_bruto + custos_avulsos);"
+
+# F3: dropa o trigger → created_by do cliente NÃO é sobrescrito → A10 perde o dente
+P -q -c "DROP TRIGGER IF EXISTS trg_fin_antecipacoes_autor ON public.fin_antecipacoes;"
+Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,created_by) VALUES ('colacor','linha',3000,2900,'2026-09-01','2026-10-01','$OUTRO');" >/dev/null
+V=$(Pq -c "SELECT created_by FROM public.fin_antecipacoes WHERE company='colacor' AND valor_bruto=3000;")
+if [ "$V" = "$OUTRO" ]; then ok "F3 sem o trigger, created_by do cliente persistiu → A10 tinha dente"; else bad "F3 droppei o trigger e created_by AINDA foi sobrescrito → A10 fraco"; fi
+P -q -f "$MIG" >/dev/null
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/superpowers/plans/2026-07-08-antecipacao-recebiveis.md
+++ b/docs/superpowers/plans/2026-07-08-antecipacao-recebiveis.md
@@ -1,0 +1,1110 @@
+# F4 — Antecipação de recebíveis — Plano de implementação
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Medir o custo real de antecipar recebíveis (R$ + taxa período + taxa a.a. money-weighted) e comparar o custo de funding da oferta vs um hurdle, a partir de operações registradas manualmente — money-path com degradação honesta, nunca fabricando número.
+
+**Architecture:** Overlay analítico manual, molde do F1 (endividamento). Tabela `fin_antecipacoes` (master-only, RLS, trigger de autor, CHECKs, soft delete) só ARMAZENA os fatos brutos; TODO derivado (custo, taxa, agregação, comparação) vive num helper PURO `antecipacao-helpers.ts` (vitest, falsificável). Hook `useAntecipacoes` faz o I/O (cast-through-unknown, tabela fora dos tipos gerados) e deriva o hurdle-sugestão do F1 (`fin_dividas.cet_aa`). Página dedicada `/financeiro/antecipacao` (não aba — F4 é CRUD-pesado idêntico ao F1) monta lista/CRUD + card medidor (Job A) + calculadora de funding (Job B). Nada reescreve sync/DRE/edge.
+
+**Tech Stack:** React 18 + TS strict + Vite + react-router 6 (lazy) + @tanstack/react-query v5 + shadcn/ui + Tailwind (tokens v3 `text-status-*`) + Supabase (PostgREST via cast-through-unknown) + sonner (toast) + vitest (helper) + PG17 local (prove-sql-money-path).
+
+## Global Constraints
+
+- **Idioma pt-BR** em tudo: código, rotas (`/financeiro/antecipacao`), comentários, commits, PR. (CLAUDE.md)
+- **Money-path: ausente ≠ zero.** `Number(null)===0` é fabricação → degradar para `null` + `motivo`, nunca um R$0 travestido de "custo zero". (CLAUDE.md, spec §3/§5)
+- **Precisão > recall.** Sem operação registrada = sem custo. Linha inválida → excluída + `dados_parciais`, nunca agregado "ok" com operação ignorada em silêncio. (spec §1/§3/§5)
+- **Datas ISO `YYYY-MM-DD`** puras (sem TZ), comparadas lexicograficamente — molde `endividamento-types.ts`. `dias` = diferença de datas por UTC-midnight (sem drift de fuso).
+- **Tabela master-only** fora dos tipos gerados do Supabase → `supabase as unknown as <ShapeMínimo>` (molde `useEndividamento.ts` — ESLint barra `any`). RLS: `EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master')` + `service_role` bypass. (spec §8, `database.md`)
+- **Trigger de autor SECURITY DEFINER `SET search_path = ''`** (INVOKER quebra `auth.uid()` — "permission denied for schema auth", pego pela prova PG17). Molde `fin_dre_custo_tipo`. (migration F3)
+- **Nunca tocar `supabase/migrations/` já existentes** nem aplicar migration (escrita = SQL Editor do founder). O plano ENTREGA o arquivo + handoff. (CLAUDE.md, `deploy.md`)
+- **Status colors** `text-status-*`; **toast** só `sonner`; **skeleton** `<PageSkeleton>`; **empty** `<EmptyState tone="operational">`. (CLAUDE.md Design System)
+- **Os 5 P1 do Codex (spec §11) são lei** — reproduzidos nas tasks que os implementam.
+
+---
+
+## File Structure
+
+| Arquivo | Responsabilidade | Task |
+|---|---|---|
+| `src/lib/financeiro/antecipacao-types.ts` | tipos puros (`Antecipacao`, `HurdleUnidade`, resultados, motivos) | 1 |
+| `src/lib/financeiro/antecipacao-helpers.ts` | derivados puros: custo/taxa por op, Job A (money-weighted), Job B (funding + unidade), hurdle-sugestão, guard de fluxo | 1–4 |
+| `src/lib/financeiro/__tests__/antecipacao-helpers.test.ts` | vitest: fórmula, todos os motivos §5, money-weighted reconcilia, unidade do hurdle, igualdade válida, falsificável | 1–4 |
+| `supabase/migrations/20260708120000_fin_antecipacoes.sql` | tabela + CHECKs + trigger autor + RLS master + unique dedup + soft delete | 5 |
+| `db/test-fin-antecipacoes.sh` | prove-sql PG17: RLS nega authenticated, CHECKs (igualdade VÁLIDA), trigger, unique, **falsificação** | 5 |
+| `src/hooks/useAntecipacoes.ts` | react-query: lista (exclui soft-deleted), upsert, soft-delete, hurdle-sugestão do F1 | 6 |
+| `src/pages/FinanceiroAntecipacao.tsx` | página master-only: header + seletor empresa + lista/CRUD + Job A + Job B | 7 |
+| `src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx` | dialog cadastro/edição (com guard `fluxo_nao_suportado`) | 7 |
+| `src/components/financeiro/antecipacao/MedidorCustoCard.tsx` | card Job A (R$ + taxa período + a.a. + tendência + motivo honesto) | 7 |
+| `src/components/financeiro/antecipacao/CalculadoraFunding.tsx` | Job B (oferta → custo + comparação com hurdle editável, F1 sugere) | 7 |
+| `src/App.tsx` | registrar `<Route path="financeiro/antecipacao" …>` (lazy) | 7 |
+
+---
+
+## Interfaces canônicas (contrato entre tasks — copie exato)
+
+```typescript
+// antecipacao-types.ts
+export type Company = 'oben' | 'colacor' | 'colacor_sc';
+export type TipoAntecipacao = 'duplicata' | 'linha';
+/** Unidade EXPLÍCITA do hurdle/oferta (P1-3: sem unidade a comparação é lixo). */
+export type HurdleUnidade = 'efetiva_aa' | 'nominal_aa' | 'efetiva_am';
+
+export interface Antecipacao {
+  id: string;
+  company: Company;
+  banco: string | null;
+  tipo: TipoAntecipacao;
+  valor_bruto: number;          // FACE ANTECIPADA (não a face total do título)
+  custos_avulsos: number;       // >= 0 — IOF/tarifa FORA do líquido (P1-4)
+  valor_liquido: number;        // > 0 — o que caiu na conta
+  data_operacao: string;        // ISO
+  data_vencimento: string;      // ISO
+  operacao_origem_id: string | null;
+  referencia: string | null;
+  observacao: string | null;
+  deleted_at: string | null;
+}
+
+export type MotivoOperacao = 'ok' | 'dados_invalidos';
+export interface CustoOperacao {
+  motivo: MotivoOperacao;
+  custo: number | null;         // bruto + avulsos − liquido
+  dias: number | null;
+  taxa_periodo: number | null;  // (bruto+avulsos)/liquido − 1
+  taxa_efetiva_aa: number | null;
+}
+
+export type MotivoMedidor = 'ok' | 'sem_operacoes' | 'dados_parciais';
+export interface MesAntecipacao { ano: number; mes: number; custo: number; volume: number; }
+export interface MedidorResult {
+  motivo: MotivoMedidor;
+  custo_total: number | null;
+  volume_antecipado: number | null;
+  taxa_realizada_aa: number | null;   // money-weighted (P1-2)
+  num_operacoes: number;              // válidas incluídas
+  num_excluidas: number;              // inválidas excluídas (dados_parciais)
+  tendencia: MesAntecipacao[];        // por data_operacao (base declarada, P1)
+}
+
+export interface Hurdle { valor: number; unidade: HurdleUnidade; }
+export type MotivoFunding =
+  | 'ok' | 'dados_invalidos' | 'inputs_conflitantes'
+  | 'hurdle_unidade_invalida' | 'hurdle_indisponivel' | 'fluxo_nao_suportado';
+export interface FundingInput {
+  valor_titulo: number;         // face antecipada da oferta
+  dias: number;
+  custos_avulsos?: number;      // default 0
+  liquido_ofertado?: number | null;   // oferta como líquido
+  taxa_ofertada?: Hurdle | null;       // OU oferta como taxa (com unidade)
+  hurdle?: Hurdle | null;              // editável PRIMÁRIO; ausente → hurdle_indisponivel
+  lote?: boolean;               // true = lote multi-venc num prazo só → fluxo_nao_suportado
+}
+export interface FundingResult {
+  motivo: MotivoFunding;
+  custo: number | null;
+  taxa_periodo: number | null;
+  taxa_efetiva_aa: number | null;
+  hurdle_taxa_periodo: number | null;  // hurdle convertido p/ os mesmos `dias`
+  veredito: 'mais_caro' | 'dentro' | null;  // SÓ de funding (P1-3), nunca "vale a pena"
+}
+
+export type MotivoHurdleSugerido = 'ok' | 'sem_dados';
+export interface HurdleSugerido { valor: number | null; unidade: HurdleUnidade | null; motivo: MotivoHurdleSugerido; }
+```
+
+**Funções puras produzidas** (todas em `antecipacao-helpers.ts`):
+- `diasEntre(operISO: string, vencISO: string): number`
+- `custoOperacao(op: Pick<Antecipacao,'valor_bruto'|'custos_avulsos'|'valor_liquido'|'data_operacao'|'data_vencimento'>): CustoOperacao`
+- `taxaParaPeriodo(valor: number, unidade: HurdleUnidade, dias: number): number` (converte qualquer unidade → taxa do período de `dias`)
+- `medirCusto(ops: Antecipacao[]): MedidorResult` (Job A)
+- `compararFunding(input: FundingInput): FundingResult` (Job B)
+- `motivoFluxoRegistro(input: { lote?: boolean }): 'ok' | 'fluxo_nao_suportado'`
+- `sugerirHurdle(dividas: Array<{ saldo: number; cet_aa: number | null }>): HurdleSugerido`
+
+---
+
+### Task 1: Tipos + custo por operação (`custoOperacao` + `diasEntre`)
+
+**Files:**
+- Create: `src/lib/financeiro/antecipacao-types.ts`
+- Create: `src/lib/financeiro/antecipacao-helpers.ts`
+- Test: `src/lib/financeiro/__tests__/antecipacao-helpers.test.ts`
+
+**Interfaces:**
+- Produces: `diasEntre`, `custoOperacao`, todos os tipos do contrato acima.
+- Consumes: nada (raiz da cadeia).
+
+- [ ] **Step 1: Escrever `antecipacao-types.ts`** — cole o bloco "Interfaces canônicas" inteiro (tipos, sem funções). Cabeçalho:
+
+```typescript
+// F4 — Antecipação de recebíveis. Tipos PUROS (helper testado em vitest).
+// Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md
+// Money-path: ausente ≠ zero; sem operação = sem custo (degrada por motivo, nunca fabrica).
+// Datas ISO YYYY-MM-DD puras (sem TZ). Os 5 P1 do Codex (spec §11) são lei.
+```
+
+- [ ] **Step 2: Escrever o teste que falha** (`__tests__/antecipacao-helpers.test.ts`):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { diasEntre, custoOperacao } from '../antecipacao-helpers';
+
+const op = (over: Partial<Parameters<typeof custoOperacao>[0]> = {}) => ({
+  valor_bruto: 100_000, custos_avulsos: 0, valor_liquido: 97_000,
+  data_operacao: '2026-01-01', data_vencimento: '2026-01-31', ...over,
+});
+
+describe('diasEntre', () => {
+  it('conta dias corridos entre datas ISO (sem drift de TZ)', () => {
+    expect(diasEntre('2026-01-01', '2026-01-31')).toBe(30);
+    expect(diasEntre('2026-03-01', '2026-03-01')).toBe(0);
+  });
+});
+
+describe('custoOperacao — caminho feliz', () => {
+  it('custo = bruto+avulsos−liquido; taxa período e a.a. de caso conhecido', () => {
+    const r = custoOperacao(op());
+    expect(r.motivo).toBe('ok');
+    expect(r.custo).toBeCloseTo(3_000, 2);
+    expect(r.dias).toBe(30);
+    expect(r.taxa_periodo).toBeCloseTo(100_000 / 97_000 - 1, 6); // ~0,030928
+    expect(r.taxa_efetiva_aa).toBeCloseTo(Math.pow(100_000 / 97_000, 365 / 30) - 1, 6); // ~0,4486
+  });
+
+  it('custos_avulsos (IOF/tarifa FORA do líquido) entram no custo (P1-4)', () => {
+    const r = custoOperacao(op({ custos_avulsos: 500 }));
+    expect(r.custo).toBeCloseTo(3_500, 2); // 100000+500−97000
+    expect(r.taxa_periodo).toBeCloseTo(100_500 / 97_000 - 1, 6);
+  });
+
+  it('líquido == bruto+avulsos → custo 0 / taxa 0, VÁLIDO (P1-1: igualdade não é inválida)', () => {
+    const r = custoOperacao(op({ valor_liquido: 100_000, custos_avulsos: 0 }));
+    expect(r.motivo).toBe('ok');
+    expect(r.custo).toBeCloseTo(0, 6);
+    expect(r.taxa_periodo).toBeCloseTo(0, 6);
+    expect(r.taxa_efetiva_aa).toBeCloseTo(0, 6);
+  });
+});
+
+describe('custoOperacao — dados_invalidos (helper blinda além do CHECK)', () => {
+  it('líquido > bruto+avulsos → dados_invalidos (P1-1: inválido só quando MAIOR)', () => {
+    const r = custoOperacao(op({ valor_liquido: 100_001 }));
+    expect(r.motivo).toBe('dados_invalidos');
+    expect(r.custo).toBeNull();
+  });
+  it('dias ≤ 0 (venc ≤ operação) → dados_invalidos', () => {
+    const r = custoOperacao(op({ data_vencimento: '2026-01-01' }));
+    expect(r.motivo).toBe('dados_invalidos');
+  });
+  it('valores ≤ 0 ou custos_avulsos < 0 → dados_invalidos', () => {
+    expect(custoOperacao(op({ valor_bruto: 0 })).motivo).toBe('dados_invalidos');
+    expect(custoOperacao(op({ valor_liquido: 0 })).motivo).toBe('dados_invalidos');
+    expect(custoOperacao(op({ custos_avulsos: -1 })).motivo).toBe('dados_invalidos');
+  });
+});
+```
+
+- [ ] **Step 3: Rodar o teste — deve FALHAR** (`Cannot find module` / função indefinida):
+
+Run: `heavy bun run test antecipacao`
+Expected: FAIL (módulo/funções não existem)
+
+- [ ] **Step 4: Implementar em `antecipacao-helpers.ts`**:
+
+```typescript
+// F4 — Antecipação de recebíveis. Helper PURO (vitest). Sem I/O.
+// Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md
+// Precisão > recall: degrada por motivo (nunca fabrica R$). Datas ISO puras (UTC-midnight).
+import type {
+  Antecipacao, CustoOperacao, HurdleUnidade,
+  MedidorResult, MesAntecipacao, FundingInput, FundingResult, HurdleSugerido,
+} from './antecipacao-types';
+
+const MS_DIA = 86_400_000;
+/** Dias corridos entre duas datas ISO puras, ancoradas em UTC-midnight (sem drift de fuso). */
+export function diasEntre(operISO: string, vencISO: string): number {
+  const a = Date.parse(operISO + 'T00:00:00Z');
+  const b = Date.parse(vencISO + 'T00:00:00Z');
+  return Math.round((b - a) / MS_DIA);
+}
+
+type OpCusto = Pick<Antecipacao,
+  'valor_bruto' | 'custos_avulsos' | 'valor_liquido' | 'data_operacao' | 'data_vencimento'>;
+
+const INVALIDO: CustoOperacao = {
+  motivo: 'dados_invalidos', custo: null, dias: null, taxa_periodo: null, taxa_efetiva_aa: null,
+};
+
+/** Custo e taxas de UMA operação. Blinda os invariantes (o CHECK barra no banco; aqui defende o agregado). */
+export function custoOperacao(op: OpCusto): CustoOperacao {
+  const bruto = Number(op.valor_bruto);
+  const avulsos = Number(op.custos_avulsos);
+  const liquido = Number(op.valor_liquido);
+  if (![bruto, avulsos, liquido].every(Number.isFinite)) return INVALIDO;
+  if (!(bruto > 0) || !(liquido > 0) || avulsos < 0) return INVALIDO;   // P1-1: valores positivos
+  const base = bruto + avulsos;
+  if (liquido > base) return INVALIDO;                                   // P1-1: inválido SÓ se líquido > base
+  const dias = diasEntre(op.data_operacao, op.data_vencimento);
+  if (!(dias > 0)) return INVALIDO;                                      // prazo positivo
+  const custo = base - liquido;                                         // P1-4: avulsos entram
+  const taxa_periodo = base / liquido - 1;
+  const taxa_efetiva_aa = Math.pow(1 + taxa_periodo, 365 / dias) - 1;    // normalização (nunca métrica única, §3)
+  return { motivo: 'ok', custo, dias, taxa_periodo, taxa_efetiva_aa };
+}
+```
+
+- [ ] **Step 5: Rodar o teste — deve PASSAR:**
+
+Run: `heavy bun run test antecipacao`
+Expected: PASS (todos os `it` de Task 1)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/financeiro/antecipacao-types.ts src/lib/financeiro/antecipacao-helpers.ts src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+git commit -m "feat(financeiro): F4 custo por operação de antecipação (helper puro, P1-1/P1-4)"
+```
+
+---
+
+### Task 2: Job A — medidor money-weighted (`medirCusto`)
+
+**Files:**
+- Modify: `src/lib/financeiro/antecipacao-helpers.ts`
+- Test: `src/lib/financeiro/__tests__/antecipacao-helpers.test.ts`
+
+**Interfaces:**
+- Consumes: `custoOperacao`, `Antecipacao`, `MedidorResult`, `MesAntecipacao` (Task 1).
+- Produces: `medirCusto(ops: Antecipacao[]): MedidorResult`.
+
+- [ ] **Step 1: Escrever o teste que falha** (adicionar ao mesmo arquivo):
+
+```typescript
+import { medirCusto } from '../antecipacao-helpers';
+import type { Antecipacao } from '../antecipacao-types';
+
+const full = (over: Partial<Antecipacao>): Antecipacao => ({
+  id: crypto.randomUUID(), company: 'oben', banco: 'Itaú', tipo: 'duplicata',
+  valor_bruto: 100_000, custos_avulsos: 0, valor_liquido: 97_000,
+  data_operacao: '2026-01-05', data_vencimento: '2026-02-04',
+  operacao_origem_id: null, referencia: null, observacao: null, deleted_at: null, ...over,
+});
+
+describe('medirCusto — Job A money-weighted (P1-2)', () => {
+  it('taxa realizada reconcilia com R$: custo_total / (Σ líquido×dias / 365)', () => {
+    const ops = [
+      full({ valor_liquido: 97_000, data_operacao: '2026-01-01', data_vencimento: '2026-01-31' }), // custo 3000, 30d
+      full({ valor_bruto: 52_000, valor_liquido: 50_000, data_operacao: '2026-02-01', data_vencimento: '2026-04-02' }), // custo 2000, 60d
+    ];
+    const r = medirCusto(ops);
+    expect(r.motivo).toBe('ok');
+    expect(r.custo_total).toBeCloseTo(5_000, 2);
+    expect(r.volume_antecipado).toBeCloseTo(147_000, 2);
+    const capitalTempo = (97_000 * 30 + 50_000 * 60) / 365; // 16191,78 R$·ano
+    expect(r.taxa_realizada_aa).toBeCloseTo(5_000 / capitalTempo, 6); // ~0,3088
+    expect(r.num_operacoes).toBe(2);
+  });
+
+  it('uma op curtíssima com EAR absurda NÃO infla a taxa (money-weighted, não média de EAR)', () => {
+    // Op curta (1 dia, EAR gigante) + op grande longa. A média de EAR explodiria; a money-weighted não.
+    const ops = [
+      full({ valor_bruto: 1_000, valor_liquido: 990, data_operacao: '2026-01-01', data_vencimento: '2026-01-02' }), // 1d, EAR enorme
+      full({ valor_bruto: 100_000, valor_liquido: 97_000, data_operacao: '2026-01-01', data_vencimento: '2026-01-31' }), // 30d
+    ];
+    const r = medirCusto(ops);
+    const capitalTempo = (990 * 1 + 97_000 * 30) / 365;
+    expect(r.taxa_realizada_aa).toBeCloseTo((10 + 3_000) / capitalTempo, 6); // dominada pela op grande
+    expect(r.taxa_realizada_aa!).toBeLessThan(1); // < 100% a.a. — não explodiu
+  });
+
+  it('tendência mensal por data_operacao (base declarada)', () => {
+    const ops = [
+      full({ valor_liquido: 97_000, data_operacao: '2026-01-10', data_vencimento: '2026-02-09' }), // jan custo 3000
+      full({ valor_bruto: 52_000, valor_liquido: 50_000, data_operacao: '2026-02-10', data_vencimento: '2026-03-12' }), // fev custo 2000
+    ];
+    const r = medirCusto(ops);
+    expect(r.tendencia).toEqual([
+      { ano: 2026, mes: 1, custo: 3_000, volume: 97_000 },
+      { ano: 2026, mes: 2, custo: 2_000, volume: 50_000 },
+    ]);
+  });
+});
+
+describe('medirCusto — degradação honesta', () => {
+  it('sem operações → sem_operacoes (≠ economia/custo zero; P1-6)', () => {
+    const r = medirCusto([]);
+    expect(r.motivo).toBe('sem_operacoes');
+    expect(r.custo_total).toBeNull();
+    expect(r.num_operacoes).toBe(0);
+  });
+
+  it('soft-deleted é ignorado (não conta no custo)', () => {
+    const r = medirCusto([full({ deleted_at: '2026-03-01T00:00:00Z' })]);
+    expect(r.motivo).toBe('sem_operacoes');
+  });
+
+  it('linha inválida excluída → dados_parciais, agregado só das válidas (nunca "ok" com op ignorada)', () => {
+    const ops = [
+      full({ valor_liquido: 97_000, data_operacao: '2026-01-01', data_vencimento: '2026-01-31' }), // válida, custo 3000
+      full({ valor_bruto: 100_000, valor_liquido: 100_001 }), // inválida (líquido > bruto)
+    ];
+    const r = medirCusto(ops);
+    expect(r.motivo).toBe('dados_parciais');
+    expect(r.num_operacoes).toBe(1);
+    expect(r.num_excluidas).toBe(1);
+    expect(r.custo_total).toBeCloseTo(3_000, 2);
+  });
+
+  it('todas inválidas → dados_parciais com agregados null (temos ops, nenhuma custeável)', () => {
+    const r = medirCusto([full({ valor_bruto: 100_000, valor_liquido: 100_050 })]);
+    expect(r.motivo).toBe('dados_parciais');
+    expect(r.num_operacoes).toBe(0);
+    expect(r.num_excluidas).toBe(1);
+    expect(r.custo_total).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar — deve FALHAR** (`medirCusto` não existe). Run: `heavy bun run test antecipacao` → FAIL.
+
+- [ ] **Step 3: Implementar `medirCusto`** (append em `antecipacao-helpers.ts`):
+
+```typescript
+/** Job A — medidor de custo do período. Métrica primária = caixa (R$), taxa money-weighted (P1-2).
+ *  Exclui soft-deleted; linhas inválidas são excluídas e sinalizadas (dados_parciais). */
+export function medirCusto(ops: Antecipacao[]): MedidorResult {
+  const vivos = ops.filter((o) => o.deleted_at == null);
+  if (vivos.length === 0) {
+    return { motivo: 'sem_operacoes', custo_total: null, volume_antecipado: null,
+      taxa_realizada_aa: null, num_operacoes: 0, num_excluidas: 0, tendencia: [] };
+  }
+  let custoTotal = 0, volume = 0, capitalTempo = 0, excluidas = 0;
+  const porMes = new Map<string, MesAntecipacao>();
+  for (const o of vivos) {
+    const c = custoOperacao(o);
+    if (c.motivo !== 'ok' || c.custo == null || c.dias == null) { excluidas++; continue; }
+    custoTotal += c.custo;
+    volume += o.valor_liquido;
+    capitalTempo += (o.valor_liquido * c.dias) / 365;
+    const [ano, mes] = [Number(o.data_operacao.slice(0, 4)), Number(o.data_operacao.slice(5, 7))];
+    const k = `${ano}-${mes}`;
+    const m = porMes.get(k) ?? { ano, mes, custo: 0, volume: 0 };
+    m.custo += c.custo; m.volume += o.valor_liquido; porMes.set(k, m);
+  }
+  const validas = vivos.length - excluidas;
+  const tendencia = [...porMes.values()].sort((a, b) => a.ano * 12 + a.mes - (b.ano * 12 + b.mes));
+  if (validas === 0) {
+    return { motivo: 'dados_parciais', custo_total: null, volume_antecipado: null,
+      taxa_realizada_aa: null, num_operacoes: 0, num_excluidas: excluidas, tendencia: [] };
+  }
+  const taxa = capitalTempo > 0 ? custoTotal / capitalTempo : null; // money-weighted anualizada
+  return {
+    motivo: excluidas > 0 ? 'dados_parciais' : 'ok',
+    custo_total: custoTotal, volume_antecipado: volume, taxa_realizada_aa: taxa,
+    num_operacoes: validas, num_excluidas: excluidas, tendencia,
+  };
+}
+```
+
+- [ ] **Step 4: Rodar — deve PASSAR.** Run: `heavy bun run test antecipacao` → PASS (Task 1 + Task 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/financeiro/antecipacao-helpers.ts src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+git commit -m "feat(financeiro): F4 Job A medidor money-weighted (P1-2, dados_parciais honesto)"
+```
+
+---
+
+### Task 3: Job B — funding + conversão de unidade + guard de fluxo
+
+**Files:**
+- Modify: `src/lib/financeiro/antecipacao-helpers.ts`
+- Test: `src/lib/financeiro/__tests__/antecipacao-helpers.test.ts`
+
+**Interfaces:**
+- Consumes: `FundingInput`, `FundingResult`, `HurdleUnidade` (Task 1).
+- Produces: `taxaParaPeriodo`, `compararFunding`, `motivoFluxoRegistro`.
+
+**Convenções de unidade (documentadas — Codex vetará):** conversão de qualquer unidade → taxa efetiva do período de `dias`:
+- `efetiva_aa` (efetiva a.a., composta): `(1+v)^(dias/365) − 1`
+- `efetiva_am` (efetiva a.m., composta): `(1+v)^(dias/30) − 1`
+- `nominal_aa` (nominal a.a., **linear/proporcional** — juros simples): `v × dias/365`
+
+- [ ] **Step 1: Escrever o teste que falha:**
+
+```typescript
+import { taxaParaPeriodo, compararFunding, motivoFluxoRegistro } from '../antecipacao-helpers';
+
+describe('taxaParaPeriodo — converte unidade → taxa do período de `dias` (P1-3)', () => {
+  it('efetiva_aa composta', () => {
+    expect(taxaParaPeriodo(0.30, 'efetiva_aa', 30)).toBeCloseTo(Math.pow(1.30, 30 / 365) - 1, 8);
+  });
+  it('efetiva_am composta: 2% a.m. em 30 dias ≈ 2%', () => {
+    expect(taxaParaPeriodo(0.02, 'efetiva_am', 30)).toBeCloseTo(0.02, 8);
+  });
+  it('nominal_aa linear: 36,5% a.a. em 30 dias = 3%', () => {
+    expect(taxaParaPeriodo(0.365, 'nominal_aa', 30)).toBeCloseTo(0.03, 8);
+  });
+});
+
+describe('compararFunding — Job B (comparação de FUNDING, nunca "vale a pena")', () => {
+  const base = { valor_titulo: 100_000, dias: 30 };
+
+  it('oferta como líquido: custo + taxas; hurdle efetiva_aa convertido p/ 30d → veredito só de funding', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 97_000, hurdle: { valor: 0.30, unidade: 'efetiva_aa' } });
+    expect(r.motivo).toBe('ok');
+    expect(r.custo).toBeCloseTo(3_000, 2);
+    expect(r.taxa_periodo).toBeCloseTo(100_000 / 97_000 - 1, 6); // ~3,09%
+    expect(r.hurdle_taxa_periodo).toBeCloseTo(Math.pow(1.30, 30 / 365) - 1, 6); // ~2,18%
+    expect(r.veredito).toBe('mais_caro'); // 3,09% > 2,18%
+  });
+
+  it('oferta dentro do hurdle → "dentro" (não "vale a pena")', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 99_000, hurdle: { valor: 0.60, unidade: 'efetiva_aa' } });
+    expect(r.veredito).toBe('dentro');
+  });
+
+  it('oferta como taxa (com unidade) reconstrói o líquido e custa igual', () => {
+    const r = compararFunding({ ...base, taxa_ofertada: { valor: 0.02, unidade: 'efetiva_am' }, hurdle: { valor: 0.30, unidade: 'efetiva_aa' } });
+    expect(r.motivo).toBe('ok');
+    expect(r.taxa_periodo).toBeCloseTo(0.02, 6); // 2% a.m. em 30d
+    expect(r.custo).toBeCloseTo(100_000 - 100_000 / 1.02, 2);
+  });
+
+  it('custos_avulsos entram no custo da oferta (P1-4)', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 97_000, custos_avulsos: 500, hurdle: { valor: 0.30, unidade: 'efetiva_aa' } });
+    expect(r.custo).toBeCloseTo(3_500, 2); // 100000+500−97000
+  });
+
+  it('hurdle ausente → hurdle_indisponivel: mostra custo, sem veredito', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 97_000 });
+    expect(r.motivo).toBe('hurdle_indisponivel');
+    expect(r.custo).toBeCloseTo(3_000, 2);
+    expect(r.veredito).toBeNull();
+  });
+
+  it('hurdle sem unidade válida → hurdle_unidade_invalida', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 97_000, hurdle: { valor: 0.30, unidade: 'xpto' as HurdleUnidade } });
+    expect(r.motivo).toBe('hurdle_unidade_invalida');
+    expect(r.veredito).toBeNull();
+  });
+
+  it('taxa E líquido informados que não reconciliam → inputs_conflitantes', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 90_000, taxa_ofertada: { valor: 0.02, unidade: 'efetiva_am' }, hurdle: { valor: 0.30, unidade: 'efetiva_aa' } });
+    expect(r.motivo).toBe('inputs_conflitantes');
+  });
+
+  it('lote multi-venc num prazo só → fluxo_nao_suportado (inventa prazo, P1-5)', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 97_000, lote: true, hurdle: { valor: 0.30, unidade: 'efetiva_aa' } });
+    expect(r.motivo).toBe('fluxo_nao_suportado');
+  });
+
+  it('dados inválidos (dias ≤ 0, valores ≤ 0, líquido > face+avulsos) → dados_invalidos', () => {
+    expect(compararFunding({ valor_titulo: 100_000, dias: 0, liquido_ofertado: 97_000 }).motivo).toBe('dados_invalidos');
+    expect(compararFunding({ valor_titulo: 100_000, dias: 30, liquido_ofertado: 100_001 }).motivo).toBe('dados_invalidos');
+  });
+});
+
+describe('motivoFluxoRegistro — guard de entrada (form)', () => {
+  it('lote=true → fluxo_nao_suportado; senão ok', () => {
+    expect(motivoFluxoRegistro({ lote: true })).toBe('fluxo_nao_suportado');
+    expect(motivoFluxoRegistro({})).toBe('ok');
+  });
+});
+```
+
+- [ ] **Step 2: Rodar — deve FALHAR.** Run: `heavy bun run test antecipacao` → FAIL.
+
+- [ ] **Step 3: Implementar** (append em `antecipacao-helpers.ts`):
+
+```typescript
+const UNIDADES: readonly HurdleUnidade[] = ['efetiva_aa', 'nominal_aa', 'efetiva_am'];
+
+/** Converte uma taxa na sua unidade → taxa EFETIVA do período de `dias` (comparação no MESMO período, P1-3). */
+export function taxaParaPeriodo(valor: number, unidade: HurdleUnidade, dias: number): number {
+  switch (unidade) {
+    case 'efetiva_aa': return Math.pow(1 + valor, dias / 365) - 1;   // composta anual
+    case 'efetiva_am': return Math.pow(1 + valor, dias / 30) - 1;    // composta mensal
+    case 'nominal_aa': return valor * (dias / 365);                  // linear/proporcional (juros simples)
+  }
+}
+
+const FUNDING_INVALIDO = (m: FundingResult['motivo']): FundingResult => ({
+  motivo: m, custo: null, taxa_periodo: null, taxa_efetiva_aa: null,
+  hurdle_taxa_periodo: null, veredito: null,
+});
+
+/** Job B — comparação de custo de FUNDING (nunca "vale a pena"; isso depende do uso do caixa, §4). */
+export function compararFunding(input: FundingInput): FundingResult {
+  if (input.lote === true) return FUNDING_INVALIDO('fluxo_nao_suportado');   // P1-5: prazo inventado
+  const face = Number(input.valor_titulo);
+  const dias = Number(input.dias);
+  const avulsos = Number(input.custos_avulsos ?? 0);
+  if (![face, dias, avulsos].every(Number.isFinite) || !(face > 0) || !(dias > 0) || avulsos < 0) {
+    return FUNDING_INVALIDO('dados_invalidos');
+  }
+  const base = face + avulsos;
+
+  // Resolve o líquido da oferta: pode vir como líquido, como taxa (c/ unidade), ou ambos (reconciliar).
+  let liquido: number | null = null;
+  const temLiquido = input.liquido_ofertado != null;
+  const temTaxa = input.taxa_ofertada != null;
+  if (!temLiquido && !temTaxa) return FUNDING_INVALIDO('dados_invalidos');
+
+  let liquidoDeTaxa: number | null = null;
+  if (temTaxa) {
+    const u = input.taxa_ofertada!.unidade;
+    if (!UNIDADES.includes(u)) return FUNDING_INVALIDO('hurdle_unidade_invalida');
+    const tp = taxaParaPeriodo(input.taxa_ofertada!.valor, u, dias);
+    if (!(tp > -1)) return FUNDING_INVALIDO('dados_invalidos');
+    liquidoDeTaxa = base / (1 + tp);
+  }
+  if (temLiquido) {
+    liquido = Number(input.liquido_ofertado);
+    if (!Number.isFinite(liquido) || !(liquido > 0) || liquido > base) return FUNDING_INVALIDO('dados_invalidos');
+    // taxa E líquido: reconciliar (tolerância relativa 0,5% sobre a face)
+    if (liquidoDeTaxa != null && Math.abs(liquido - liquidoDeTaxa) > 0.005 * base) {
+      return FUNDING_INVALIDO('inputs_conflitantes');
+    }
+  } else {
+    liquido = liquidoDeTaxa;
+  }
+  if (liquido == null || !(liquido > 0) || liquido > base) return FUNDING_INVALIDO('dados_invalidos');
+
+  const custo = base - liquido;
+  const taxa_periodo = base / liquido - 1;
+  const taxa_efetiva_aa = Math.pow(1 + taxa_periodo, 365 / dias) - 1;
+
+  // Hurdle editável PRIMÁRIO (P1-3): ausente → só custo; unidade inválida → sem veredito.
+  if (input.hurdle == null) {
+    return { motivo: 'hurdle_indisponivel', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo: null, veredito: null };
+  }
+  if (!UNIDADES.includes(input.hurdle.unidade)) {
+    return { motivo: 'hurdle_unidade_invalida', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo: null, veredito: null };
+  }
+  const hurdle_taxa_periodo = taxaParaPeriodo(input.hurdle.valor, input.hurdle.unidade, dias);
+  const veredito = taxa_periodo > hurdle_taxa_periodo ? 'mais_caro' : 'dentro';
+  return { motivo: 'ok', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo, veredito };
+}
+
+/** Guard de entrada: lote multi-venc num prazo só inventa prazo → não suportado em v1 (registrar 1 por título). */
+export function motivoFluxoRegistro(input: { lote?: boolean }): 'ok' | 'fluxo_nao_suportado' {
+  return input.lote === true ? 'fluxo_nao_suportado' : 'ok';
+}
+```
+
+- [ ] **Step 4: Rodar — deve PASSAR.** Run: `heavy bun run test antecipacao` → PASS (Tasks 1–3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/financeiro/antecipacao-helpers.ts src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+git commit -m "feat(financeiro): F4 Job B funding + conversão de unidade do hurdle (P1-3/P1-4/P1-5)"
+```
+
+---
+
+### Task 4: Hurdle-sugestão do F1 (`sugerirHurdle`)
+
+**Files:**
+- Modify: `src/lib/financeiro/antecipacao-helpers.ts`
+- Test: `src/lib/financeiro/__tests__/antecipacao-helpers.test.ts`
+
+**Interfaces:**
+- Consumes: `HurdleSugerido` (Task 1).
+- Produces: `sugerirHurdle(dividas: Array<{ saldo: number; cet_aa: number | null }>): HurdleSugerido`.
+
+**Nota (P1-3):** F1 é SUGESTÃO/fallback, não o primário. `cet_aa` do `fin_dividas` é CET (Custo Efetivo Total) → unidade `efetiva_aa`. Média ponderada pelo saldo devedor em aberto.
+
+- [ ] **Step 1: Escrever o teste que falha:**
+
+```typescript
+import { sugerirHurdle } from '../antecipacao-helpers';
+
+describe('sugerirHurdle — média ponderada do CET do F1 (fallback, unidade explícita)', () => {
+  it('pondera cet_aa pelo saldo; unidade efetiva_aa', () => {
+    const r = sugerirHurdle([{ saldo: 100_000, cet_aa: 0.20 }, { saldo: 300_000, cet_aa: 0.30 }]);
+    expect(r.motivo).toBe('ok');
+    expect(r.valor).toBeCloseTo(0.275, 6); // (100k*0,20 + 300k*0,30)/400k
+    expect(r.unidade).toBe('efetiva_aa');
+  });
+  it('ignora dívidas sem cet_aa ou sem saldo (ausente ≠ zero)', () => {
+    const r = sugerirHurdle([{ saldo: 100_000, cet_aa: null }, { saldo: 0, cet_aa: 0.5 }, { saldo: 200_000, cet_aa: 0.25 }]);
+    expect(r.valor).toBeCloseTo(0.25, 6); // só a 3ª entra
+  });
+  it('nenhuma dívida com CET → sem_dados (não fabrica 0)', () => {
+    const r = sugerirHurdle([{ saldo: 100_000, cet_aa: null }]);
+    expect(r.motivo).toBe('sem_dados');
+    expect(r.valor).toBeNull();
+    expect(r.unidade).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Rodar — deve FALHAR.** Run: `heavy bun run test antecipacao` → FAIL.
+
+- [ ] **Step 3: Implementar** (append):
+
+```typescript
+/** Sugere um hurdle a partir do custo médio ponderado (por saldo) do CET das dívidas do F1.
+ *  FALLBACK (P1-3): custo médio de dívida ativa ≠ custo marginal de hoje — o editável é primário.
+ *  CET = efetiva a.a. → unidade 'efetiva_aa'. Ausente ≠ zero: ignora sem cet/saldo; nenhuma → sem_dados. */
+export function sugerirHurdle(dividas: Array<{ saldo: number; cet_aa: number | null }>): HurdleSugerido {
+  let pesoTotal = 0, somaPond = 0;
+  for (const d of dividas) {
+    const saldo = Number(d.saldo);
+    const cet = d.cet_aa;
+    if (cet == null || !Number.isFinite(cet) || !Number.isFinite(saldo) || saldo <= 0) continue;
+    pesoTotal += saldo;
+    somaPond += saldo * cet;
+  }
+  if (pesoTotal <= 0) return { valor: null, unidade: null, motivo: 'sem_dados' };
+  return { valor: somaPond / pesoTotal, unidade: 'efetiva_aa', motivo: 'ok' };
+}
+```
+
+- [ ] **Step 4: Rodar TODA a suíte do helper + typecheck:**
+
+Run: `heavy bun run test antecipacao` → PASS (Tasks 1–4)
+Run: `heavy bun run typecheck` → 0 erros
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/financeiro/antecipacao-helpers.ts src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+git commit -m "feat(financeiro): F4 hurdle-sugestão ponderada do CET (F1 fallback, unidade explícita)"
+```
+
+---
+
+### Task 5: Migration `fin_antecipacoes` + prova PG17
+
+**Files:**
+- Create: `supabase/migrations/20260708120000_fin_antecipacoes.sql`
+- Create: `db/test-fin-antecipacoes.sh`
+
+**Interfaces:**
+- Consumes: nada (SQL puro). Deve casar 1:1 com o tipo `Antecipacao` (Task 1) — colunas = campos.
+- Produces: tabela `public.fin_antecipacoes` (o hook da Task 6 lê/escreve).
+
+- [ ] **Step 1: Escrever a migration** (molde `fin_dre_custo_tipo`):
+
+```sql
+-- supabase/migrations/20260708120000_fin_antecipacoes.sql
+-- F4 — Antecipação de recebíveis: registro MANUAL da operação (desconto de duplicata / linha rotativa).
+-- Overlay analítico; NADA reescreve sync/DRE. Derivados (custo/taxa) moram no helper puro — a tabela
+-- só guarda os fatos brutos. master-only (molde fin_dre_custo_tipo/fin_dividas). Idempotente (re-colável).
+-- Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md (§2, §7, §8). Os 5 P1 no CHECK.
+
+CREATE TABLE IF NOT EXISTS public.fin_antecipacoes (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company            text NOT NULL CHECK (company IN ('oben','colacor','colacor_sc')),
+  banco              text,
+  tipo               text NOT NULL CHECK (tipo IN ('duplicata','linha')),
+  valor_bruto        numeric(15,2) NOT NULL,   -- FACE ANTECIPADA (suporta parcial — não a face total)
+  custos_avulsos     numeric(15,2) NOT NULL DEFAULT 0,  -- IOF/tarifa FORA do líquido (P1-4)
+  valor_liquido      numeric(15,2) NOT NULL,   -- o que efetivamente caiu na conta
+  data_operacao      date NOT NULL,
+  data_vencimento    date NOT NULL,
+  operacao_origem_id uuid REFERENCES public.fin_antecipacoes(id) ON DELETE SET NULL, -- rollover (§7)
+  referencia         text,                     -- contrato/banco (dedup manual)
+  observacao         text,
+  created_by         uuid,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_by         uuid,
+  updated_at         timestamptz NOT NULL DEFAULT now(),
+  deleted_at         timestamptz,              -- soft delete (preserva histórico de custo)
+  CONSTRAINT fin_antecipacoes_valores_chk
+    CHECK (valor_bruto > 0 AND valor_liquido > 0 AND custos_avulsos >= 0),
+  -- P1-1: '=' é custo zero, VÁLIDO; inválido SÓ quando líquido > (bruto+avulsos).
+  CONSTRAINT fin_antecipacoes_liquido_chk
+    CHECK (valor_liquido <= valor_bruto + custos_avulsos),
+  CONSTRAINT fin_antecipacoes_prazo_chk
+    CHECK (data_vencimento > data_operacao)
+);
+
+COMMENT ON TABLE public.fin_antecipacoes IS
+  'F4: operações de antecipação de recebíveis (registro manual master-only). Uma linha = uma operação = um vencimento (lote multi-venc → split). Derivados (custo/taxa) no helper puro; a tabela só guarda os fatos.';
+
+-- Dedup: mesma referência não duplica (coalesce banco p/ deduplicar mesmo com banco nulo). Ignora soft-deleted.
+CREATE UNIQUE INDEX IF NOT EXISTS fin_antecipacoes_ref_uq
+  ON public.fin_antecipacoes (company, coalesce(banco, ''), referencia)
+  WHERE referencia IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_fin_antecipacoes_company_viva
+  ON public.fin_antecipacoes (company, data_operacao) WHERE deleted_at IS NULL;
+
+-- Trigger de autor/carimbo no servidor (SECURITY DEFINER + search_path='' — INVOKER quebra auth.uid(),
+-- "permission denied for schema auth", pego pela prova PG17; molde fin_dre_custo_tipo).
+CREATE OR REPLACE FUNCTION public.fin_antecipacoes_set_autor()
+RETURNS trigger LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    NEW.created_by := auth.uid();
+    NEW.created_at := now();
+  END IF;
+  NEW.updated_by := auth.uid();
+  NEW.updated_at := now();
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_fin_antecipacoes_autor ON public.fin_antecipacoes;
+CREATE TRIGGER trg_fin_antecipacoes_autor
+  BEFORE INSERT OR UPDATE ON public.fin_antecipacoes
+  FOR EACH ROW EXECUTE FUNCTION public.fin_antecipacoes_set_autor();
+
+-- RLS master-only (verbatim ao padrão proven de fin_dre_custo_tipo).
+ALTER TABLE public.fin_antecipacoes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS fin_antecipacoes_select_master ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_select_master ON public.fin_antecipacoes
+  FOR SELECT USING (EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master'));
+
+DROP POLICY IF EXISTS fin_antecipacoes_write_master ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_write_master ON public.fin_antecipacoes
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master'));
+
+DROP POLICY IF EXISTS fin_antecipacoes_service_all ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_service_all ON public.fin_antecipacoes
+  FOR ALL USING (auth.role() = 'service_role');
+
+SELECT 'fin_antecipacoes OK' AS status,
+  (SELECT count(*) FROM pg_policies WHERE tablename = 'fin_antecipacoes') AS policies;
+```
+
+- [ ] **Step 2: Escrever o harness prove-sql** (`db/test-fin-antecipacoes.sh`) — copie `db/test-fin-dre-custo-tipo.sh` verbatim das linhas 1–56 (setup PG17, stubs, `auth.uid()`/`auth.role()`, `user_roles`) trocando `SLUG="fin-antecipacoes"` e `MIG=".../20260708120000_fin_antecipacoes.sql"`. Depois os asserts:
+
+```bash
+# ── ZONA 3 — seed + grants ──────────────────────────────────────────────────────────────────────
+MASTER='33333333-3333-3333-3333-333333333333'
+NAOMASTER='22222222-2222-2222-2222-222222222222'
+OUTRO='99999999-9999-9999-9999-999999999999'
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$MASTER'),('$NAOMASTER') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES ('$MASTER','master') ON CONFLICT DO NOTHING;
+INSERT INTO public.fin_antecipacoes(company,banco,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento,referencia) VALUES
+  ('oben','Itaú','duplicata',100000,0,97000,'2026-01-01','2026-01-31','DUP-1'),
+  ('oben','Itaú','linha',     50000,0,50000,'2026-02-01','2026-04-02','LINHA-1'); -- líquido==bruto: custo 0 VÁLIDO
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fin_antecipacoes TO authenticated, anon;
+GRANT SELECT ON public.user_roles TO authenticated, anon;
+SQL
+
+echo "── asserts ──"
+
+# A1 POSITIVO: tabela existe, 2 linhas (inclui a de custo zero — P1-1 igualdade VÁLIDA)
+V=$(Pq -c "SELECT count(*) FROM public.fin_antecipacoes;")
+eq "A1 tabela existe, 2 linhas (uma com líquido==bruto, custo 0)" "$V" "2"
+
+# A2 NEGATIVO: líquido > bruto+avulsos → check_violation (P1-1: inválido SÓ quando MAIOR)
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',100000,0,100001,'2026-01-01','2026-02-01');
+  RAISE EXCEPTION 'LIQ_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'LIQ_CHK_OK'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *LIQ_CHK_OK*) ok "A2 CHECK rejeita líquido > bruto+avulsos" ;; *) bad "A2 liq — veio: $R" ;; esac
+
+# A3 POSITIVO: líquido == bruto+avulsos é ACEITO (custo zero é válido, não inválido)
+Pq -c "INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,custos_avulsos,valor_liquido,data_operacao,data_vencimento) VALUES ('colacor','duplicata',10000,100,10100,'2026-03-01','2026-04-01');" >/dev/null
+V=$(Pq -c "SELECT count(*) FROM public.fin_antecipacoes WHERE company='colacor';")
+eq "A3 líquido == bruto+avulsos aceito (P1-1)" "$V" "1"
+
+# A4 NEGATIVO: prazo não-positivo (venc <= operação) → check_violation
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',1000,990,'2026-01-10','2026-01-10');
+  RAISE EXCEPTION 'PRAZO_NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'PRAZO_CHK_OK'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *PRAZO_CHK_OK*) ok "A4 CHECK exige prazo positivo" ;; *) bad "A4 prazo — veio: $R" ;; esac
+
+# A5 NEGATIVO: dedup — mesma (company,banco,referencia) viva → unique_violation
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,banco,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,referencia)
+    VALUES ('oben','Itaú','duplicata',100000,97000,'2026-05-01','2026-06-01','DUP-1');
+  RAISE EXCEPTION 'DEDUP_NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'DEDUP_OK'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *DEDUP_OK*) ok "A5 unique parcial dedup por referência" ;; *) bad "A5 dedup — veio: $R" ;; esac
+
+# A6 RLS: master vê; A7 não-master 0; A8 anon 0
+MASTERV=$(Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+NMV=$(Pq -c "SET test.uid='$NAOMASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+ANONV=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+eq "A6 master vê"           "$MASTERV" "3"
+eq "A7 não-master NÃO vê"   "$NMV"     "0"
+eq "A8 anon NÃO vê"         "$ANONV"   "0"
+
+# A9 RLS: não-master NÃO escreve → insufficient_privilege
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$NAOMASTER'; SET ROLE authenticated;
+DO \$\$ BEGIN
+  INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento)
+    VALUES ('oben','duplicata',1000,990,'2026-01-01','2026-02-01');
+  RAISE EXCEPTION 'RLS_WRITE_NAO_BARROU';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'RLS_WRITE_OK'; WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in *RLS_WRITE_OK*) ok "A9 RLS nega escrita de não-master" ;; *) bad "A9 rls-write — veio: $R" ;; esac
+
+# A10 TRIGGER: master insere passando created_by/updated_by falsos → trigger sobrescreve p/ auth.uid()
+Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,created_by,updated_by) VALUES ('oben','duplicata',2000,1900,'2026-07-01','2026-08-01','$OUTRO','$OUTRO');" >/dev/null
+V=$(Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; SELECT updated_by||'/'||created_by FROM public.fin_antecipacoes WHERE company='oben' AND valor_bruto=2000;" | tail -1)
+eq "A10 trigger força created_by/updated_by=auth.uid()" "$V" "$MASTER/$MASTER"
+
+# ══ FALSIFICAÇÃO (Lei #3) — sabota → exige VERMELHO → restaura ══
+echo "── falsificação ──"
+
+# F1: policy SELECT furada (USING true) → não-master passa a VER → A7 perde o dente
+P -q <<'SQL'
+DROP POLICY IF EXISTS fin_antecipacoes_select_master ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_select_master ON public.fin_antecipacoes FOR SELECT USING (true);
+SQL
+NMV2=$(Pq -c "SET test.uid='$NAOMASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+if [ "$NMV2" != "0" ]; then ok "F1 policy furada deixou não-master ver ($NMV2) → A7 tem dente"; else bad "F1 sabotei e não-master AINDA não vê → A7 fraco"; fi
+P -q -f "$MIG" >/dev/null
+NMV3=$(Pq -c "SET test.uid='$NAOMASTER'; SET ROLE authenticated; SELECT count(*) FROM public.fin_antecipacoes;" | tail -1)
+eq "F1' restaurada: não-master volta a NÃO ver" "$NMV3" "0"
+
+# F2: dropa o CHECK do líquido → líquido > bruto+avulsos passa → A2 perde o dente
+P -q -c "ALTER TABLE public.fin_antecipacoes DROP CONSTRAINT fin_antecipacoes_liquido_chk;"
+if P -q -c "INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento) VALUES ('colacor_sc','duplicata',100,200,'2026-01-01','2026-02-01');" >/dev/null 2>&1; then
+  ok "F2 sem o CHECK, líquido > bruto passou → A2 tinha dente"
+else
+  bad "F2 droppei o CHECK e o INSERT AINDA falhou → A2 não provava o CHECK"
+fi
+P -q -c "DELETE FROM public.fin_antecipacoes WHERE company='colacor_sc';"
+P -q -c "ALTER TABLE public.fin_antecipacoes ADD CONSTRAINT fin_antecipacoes_liquido_chk CHECK (valor_liquido <= valor_bruto + custos_avulsos);"
+
+# F3: dropa o trigger → created_by do cliente NÃO é sobrescrito → A10 perde o dente
+P -q -c "DROP TRIGGER IF EXISTS trg_fin_antecipacoes_autor ON public.fin_antecipacoes;"
+Pq -c "SET test.uid='$MASTER'; SET ROLE authenticated; INSERT INTO public.fin_antecipacoes(company,tipo,valor_bruto,valor_liquido,data_operacao,data_vencimento,created_by) VALUES ('colacor','linha',3000,2900,'2026-09-01','2026-10-01','$OUTRO');" >/dev/null
+V=$(Pq -c "SELECT created_by FROM public.fin_antecipacoes WHERE company='colacor' AND valor_bruto=3000;")
+if [ "$V" = "$OUTRO" ]; then ok "F3 sem o trigger, created_by do cliente persistiu → A10 tinha dente"; else bad "F3 droppei o trigger e created_by AINDA foi sobrescrito → A10 fraco"; fi
+P -q -f "$MIG" >/dev/null
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"
+```
+
+- [ ] **Step 3: Rodar a prova PG17 — deve dar VERDE (asserts + falsificação):**
+
+Run: `bash db/test-fin-antecipacoes.sh > /tmp/f4-prove.log 2>&1; echo "exit=$?"`
+Expected: `exit=0` e `✅ HARNESS VERDE` (todos os A1–A10 ok, F1/F2/F3 com dente)
+
+- [ ] **Step 4: Falsificar a falsificação** — sabotar a migration DE PROPÓSITO e exigir VERMELHO. Troque no arquivo o CHECK do líquido para `>=` (o bug que o Codex pegou), rode o harness, confirme que A2/A3 ficam VERMELHOS, depois **reverta**:
+
+Run: (editar `<=`→`>=` no `fin_antecipacoes_liquido_chk`) `bash db/test-fin-antecipacoes.sh; echo exit=$?`
+Expected: `exit=1` / `❌ HARNESS VERMELHO` — prova que o harness tem dente. **Reverter para `<=`** e rodar de novo → VERDE.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260708120000_fin_antecipacoes.sql db/test-fin-antecipacoes.sh
+git commit -m "feat(financeiro): F4 migration fin_antecipacoes + prova PG17 (RLS/CHECKs/trigger/dedup, falsificada)"
+```
+
+---
+
+### Task 6: Hook `useAntecipacoes` (CRUD + soft delete + hurdle do F1)
+
+**Files:**
+- Create: `src/hooks/useAntecipacoes.ts`
+
+**Interfaces:**
+- Consumes: `Antecipacao`, `Company`, `HurdleSugerido`, `sugerirHurdle` (Tasks 1/4); `useDividas` de `@/hooks/useEndividamento`; `saldoDevedorEmAberto` de `@/lib/financeiro/endividamento-helpers`.
+- Produces: `useAntecipacoes(company)`, `useUpsertAntecipacao()`, `useSoftDeleteAntecipacao()`, `useHurdleSugerido(company)`.
+
+Molde: `useEndividamento.ts` (cast-through-unknown, react-query, invalidate). Escrita passa `deleted_at: null` no insert; soft delete = UPDATE `deleted_at = now()` (não DELETE). Lista filtra `deleted_at IS NULL` no cliente (a RLS não filtra soft-delete).
+
+- [ ] **Step 1: Implementar o hook** (sem teste unitário — molde sem teste de hook; a prova é typecheck+lint+build+Codex):
+
+```typescript
+// src/hooks/useAntecipacoes.ts
+// F4 — camada de dados (react-query). fin_antecipacoes é master-only (RLS) e NÃO está nos tipos
+// gerados → cast through unknown (molde verbatim de useEndividamento.ts; ESLint barra `any`).
+// Soft delete: UPDATE deleted_at (nunca DELETE — preserva histórico de custo). Hurdle-sugestão
+// derivada do F1 (fin_dividas.cet_aa ponderado pelo saldo devedor em aberto — fallback, P1-3).
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { sugerirHurdle } from '@/lib/financeiro/antecipacao-helpers';
+import { saldoDevedorEmAberto } from '@/lib/financeiro/endividamento-helpers';
+import { useDividas, useParcelas } from '@/hooks/useEndividamento';
+import type { Antecipacao, Company, HurdleSugerido } from '@/lib/financeiro/antecipacao-types';
+import { useMemo } from 'react';
+
+const STALE = 60_000;
+
+type SelectClient = { from: (t: string) => { select: (c: string) => {
+  eq: (col: string, val: string) => { order: (col: string, o?: { ascending?: boolean }) =>
+    Promise<{ data: unknown[] | null; error: { message: string } | null }> } } } };
+type UpsertClient = { from: (t: string) => { upsert: (
+  v: Record<string, unknown>, o?: { onConflict: string }) => Promise<{ error: { message: string } | null }> } };
+type UpdateClient = { from: (t: string) => { update: (v: Record<string, unknown>) => {
+  eq: (col: string, val: string) => Promise<{ error: { message: string } | null }> } } };
+
+/** Operações vivas (deleted_at IS NULL) de uma empresa, mais recentes primeiro. */
+export function useAntecipacoes(company: Company | string) {
+  return useQuery({
+    queryKey: ['antecipacoes', company],
+    enabled: Boolean(company),
+    staleTime: STALE,
+    queryFn: async (): Promise<Antecipacao[]> => {
+      const client = supabase as unknown as SelectClient;
+      const { data, error } = await client
+        .from('fin_antecipacoes').select('*')
+        .eq('company', company).order('data_operacao', { ascending: false });
+      if (error) throw new Error(error.message);
+      return ((data ?? []) as Antecipacao[]).filter((a) => a.deleted_at == null);
+    },
+  });
+}
+
+/** Insert (sem id) ou update (com id). Trigger cuida de created_by/updated_by/at. */
+export function useUpsertAntecipacao() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (op: Partial<Antecipacao> & { company: Company }) => {
+      const client = supabase as unknown as UpsertClient;
+      const { error } = await client.from('fin_antecipacoes').upsert({ ...op }, { onConflict: 'id' });
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: (_d, v) => { qc.invalidateQueries({ queryKey: ['antecipacoes', v.company] }); toast.success('Operação salva.'); },
+    onError: (e) => toast.error('Falha ao salvar operação', { description: e instanceof Error ? e.message : String(e) }),
+  });
+}
+
+/** Soft delete: marca deleted_at (não apaga — preserva histórico de custo). */
+export function useSoftDeleteAntecipacao() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id }: { id: string; company: Company }) => {
+      const client = supabase as unknown as UpdateClient;
+      const { error } = await client.from('fin_antecipacoes')
+        .update({ deleted_at: new Date().toISOString() }).eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: (_d, v) => { qc.invalidateQueries({ queryKey: ['antecipacoes', v.company] }); toast.success('Operação removida.'); },
+    onError: (e) => toast.error('Falha ao remover operação', { description: e instanceof Error ? e.message : String(e) }),
+  });
+}
+
+/** Hurdle-sugestão a partir do custo médio ponderado do CET das dívidas do F1 (fallback com unidade). */
+export function useHurdleSugerido(company: Company | string): HurdleSugerido {
+  const { data: dividas } = useDividas(company);
+  const dividaIds = useMemo(() => (dividas ?? []).map((d) => d.id), [dividas]);
+  const { data: parcelas } = useParcelas(dividaIds);
+  return useMemo<HurdleSugerido>(() => {
+    if (!dividas) return { valor: null, unidade: null, motivo: 'sem_dados' };
+    return sugerirHurdle(
+      dividas.filter((d) => d.ativo).map((d) => ({ saldo: saldoDevedorEmAberto(d, parcelas ?? []), cet_aa: d.cet_aa })),
+    );
+  }, [dividas, parcelas]);
+}
+```
+
+- [ ] **Step 2: Verificar typecheck + lint:**
+
+Run: `heavy bun run typecheck` → 0 erros
+Run: `bun run lint` → 0 erros (atenção ao `no-restricted-syntax`/`no-explicit-any` — o cast é através de `unknown`, sem `any`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useAntecipacoes.ts
+git commit -m "feat(financeiro): F4 hook useAntecipacoes (CRUD, soft delete, hurdle do F1)"
+```
+
+---
+
+### Task 7: UI — página `/financeiro/antecipacao` (lista/CRUD + Job A + Job B) + rota
+
+**Files:**
+- Create: `src/pages/FinanceiroAntecipacao.tsx`
+- Create: `src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx`
+- Create: `src/components/financeiro/antecipacao/MedidorCustoCard.tsx`
+- Create: `src/components/financeiro/antecipacao/CalculadoraFunding.tsx`
+- Modify: `src/App.tsx` (registrar rota lazy, ~linha 122 e ~281)
+
+**Interfaces:**
+- Consumes: hooks da Task 6; helpers `medirCusto`/`compararFunding`/`motivoFluxoRegistro` (Tasks 2/3); `fmt`/`fmtCompact`/`fmtDate` de `@/components/financeiro/dashboard/format`; `useAuth().isMaster`; `useCompany`/`COMPANIES`.
+- Produces: rota `/financeiro/antecipacao`.
+
+Molde estrutural: `src/pages/FinanceiroEndividamento.tsx` (header + `<select>` de empresa + `PageSkeleton` + lista `Table` + `AntecipacaoFormDialog` + `AlertDialog` de confirmação → mas soft delete). Dialog: molde `DividaFormDialog`/`ClassificacaoCustoDialog`. Card Job A: molde `PontoEquilibrioCard` (motivo honesto por `MOTIVO_MSG`, sempre R$ + taxa período + a.a.). Calculadora Job B: `Card` com inputs (valor, dias, líquido OU taxa+unidade, custos avulsos, hurdle editável com botão "usar sugestão do F1 {valor}% efetiva a.a.").
+
+**Regras de UI (money-path honesto — spec §3/§4/§5):**
+- `!isMaster` → `<EmptyState tone="operational">` "Acesso restrito" (molde F1).
+- Job A: se `motivo !== 'ok'` mostrar mensagem honesta (`sem_operacoes` → "sem antecipações **registradas** no período"; `dados_parciais` → aviso "{n} operação(ões) inválida(s) excluída(s)"). SEMPRE exibir R$ + taxa do período + taxa a.a. juntos; nunca só a a.a.
+- Job B: `veredito==='mais_caro'` → "mais caro que sua alternativa de crédito" (`text-status-warning`); `'dentro'` → "dentro do seu custo de funding" (`text-status-success`). NUNCA "vale a pena". Motivos `hurdle_indisponivel`/`hurdle_unidade_invalida`/`inputs_conflitantes`/`fluxo_nao_suportado` → mensagem honesta, sem veredito.
+- Form: ao marcar "é um lote de vários vencimentos?", `motivoFluxoRegistro` bloqueia o submit com orientação "registre uma operação por título/vencimento".
+
+- [ ] **Step 1: Escrever `AntecipacaoFormDialog.tsx`** (molde `DividaFormDialog`; campos = colunas de `fin_antecipacoes` exceto auditoria/id; `react-hook-form`+`zod`; guard de lote via `motivoFluxoRegistro`; chama `useUpsertAntecipacao`). Reproduzir o padrão de dialog de `ClassificacaoCustoDialog` (Dialog/DialogContent/Input/Select/Button).
+
+- [ ] **Step 2: Escrever `MedidorCustoCard.tsx`** (molde `PontoEquilibrioCard`): recebe `ops: Antecipacao[]`, chama `medirCusto`, renderiza `MOTIVO_MSG` honesto ou os 3 números (custo_total R$, taxa do período implícita da média, taxa_realizada_aa) + mini-tendência mensal. Reusar `fmt`/`fmtCompact`.
+
+- [ ] **Step 3: Escrever `CalculadoraFunding.tsx`**: form controlado (`useState`/`useUrlState` não necessário — é efêmero), chama `compararFunding` a cada mudança (`useMemo`), mostra custo R$ + taxa período + a.a. + comparação com hurdle. Botão "usar sugestão do F1" injeta `useHurdleSugerido(company)` (rotulando a unidade). Select de unidade do hurdle e da taxa ofertada (`efetiva_aa`/`nominal_aa`/`efetiva_am`) com rótulos pt-BR.
+
+- [ ] **Step 4: Escrever `FinanceiroAntecipacao.tsx`** (molde `FinanceiroEndividamento`): header "Antecipação de recebíveis" + `<select>` empresa + botão "Nova operação"; `MedidorCustoCard` (Job A) no topo; `CalculadoraFunding` (Job B); lista `Table` das operações (banco, tipo, face antecipada, líquido, custo derivado, dias, venc, ações editar/remover); `AntecipacaoFormDialog`; `AlertDialog` de confirmação de soft delete. Gate `!isMaster` → EmptyState.
+
+- [ ] **Step 5: Registrar a rota no `App.tsx`** — adicionar o lazy import junto aos demais (~linha 122) e a `<Route>` junto às de financeiro (~linha 281):
+
+```typescript
+// junto aos outros lazy imports de Financeiro (~linha 122):
+const FinanceiroAntecipacao = lazy(() => import("./pages/FinanceiroAntecipacao"));
+```
+```typescript
+// junto às <Route> de financeiro (~linha 281, depois de endividamento):
+<Route path="financeiro/antecipacao" element={<FinanceiroAntecipacao />} />
+```
+
+- [ ] **Step 6: Verificar toda a stack:**
+
+Run: `heavy bun run typecheck` → 0 erros
+Run: `bun run lint` → 0 erros
+Run: `heavy bun run test` → suíte cheia verde (helper F4 + regressões)
+Run: `heavy bun run build` → build passa (rota lazy resolve)
+
+- [ ] **Step 7: /verify** — subir o app, logar como master, abrir `/financeiro/antecipacao`, registrar 1 operação, ver o Job A recalcular, rodar a calculadora Job B com e sem hurdle, confirmar veredito de funding (não "vale a pena"), remover (soft delete) e confirmar que some da lista.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/FinanceiroAntecipacao.tsx src/components/financeiro/antecipacao/ src/App.tsx
+git commit -m "feat(financeiro): F4 UI antecipação — página, medidor (Job A), calculadora funding (Job B)"
+```
+
+---
+
+## Verificação final (antes do PR)
+
+- [ ] `heavy bun run test antecipacao` — helper verde (fórmula, TODOS os motivos §5, money-weighted reconcilia com R$, unidade do hurdle, igualdade válida).
+- [ ] `heavy bun run typecheck` + `bun run lint` — limpos.
+- [ ] `bash db/test-fin-antecipacoes.sh; echo exit=$?` — `exit=0` VERDE (com a falsificação provada em T5S4).
+- [ ] `heavy bun run test` (suíte cheia) — verde (sem regressão).
+- [ ] `heavy bun run build` — passa.
+- [ ] **Codex adversarial NO CÓDIGO** (`scripts/codex-async.sh -r xhigh -` em background) sobre o diff completo (helper money-math + migration + hook + UI) — endereçar P1/P2 antes do PR.
+- [ ] Abrir PR (não-draft → auto-merge no verde) + `scripts/pr-watch.sh <nº>` em background.
+
+## Handoff do founder (DEPOIS do merge) — spec §6, `deploy.md`
+
+- 🟣 **SQL Editor:** aplicar `20260708120000_fin_antecipacoes.sql` (empacotar via `lovable-db-operator` + query de validação `SELECT count(*) FROM pg_policies WHERE tablename='fin_antecipacoes'` = 3).
+- 🖱️ **Publish frontend** (Lovable) — nova rota/página. Sem edge (só frontend + banco).
+
+## Self-review (feito na escrita do plano)
+
+- **Cobertura da spec:** §2 modelo → T5 (migration) + T1 (tipos). §3 Job A money-weighted → T2. §4 Job B funding + hurdle unidade → T3. §5 TODOS os motivos → T1 (`dados_invalidos`), T2 (`sem_operacoes`/`dados_parciais`), T3 (`hurdle_unidade_invalida`/`inputs_conflitantes`/`hurdle_indisponivel`/`fluxo_nao_suportado`), T6 hook (`erro_consulta`/`permissao_negada` via throw→UI). §6 conexão F1→hurdle → T4+T6. §7 escopo v1 (1 venc/op, rollover incremental, parcial, avulsos) → T5 schema + T3 guard. §8 wiring → T5–T7. §9 provas → tests + prove-sql. §11 os 5 P1 → marcados inline (P1-1..P1-5).
+- **Placeholders:** nenhum — todo step de código tem o código; migration e prove-sql completos; UI referencia molde exato + regras concretas.
+- **Consistência de tipos:** `custoOperacao`/`medirCusto`/`compararFunding`/`sugerirHurdle`/`taxaParaPeriodo`/`motivoFluxoRegistro` e os tipos do contrato batem entre T1–T7 e o hook. `HurdleUnidade` usada igual em oferta e hurdle. `deleted_at` filtrado no helper (T2) e no hook (T6).
+- **Decisões documentadas p/ Codex:** unidade `nominal_aa` = linear/proporcional; dedup com `coalesce(banco,'')`; `fluxo_nao_suportado` via sinal explícito `lote` (único lugar onde a info existe).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -120,6 +120,7 @@ const FinanceiroProximaAcao = lazy(() => import("./pages/FinanceiroProximaAcao")
 const FinanceiroRegimeTributario = lazy(() => import("./pages/FinanceiroRegimeTributario"));
 const FinanceiroFunding = lazy(() => import("./pages/FinanceiroFunding"));
 const FinanceiroEndividamento = lazy(() => import("./pages/FinanceiroEndividamento"));
+const FinanceiroAntecipacao = lazy(() => import("./pages/FinanceiroAntecipacao"));
 const Recebimento = lazy(() => import("./pages/Recebimento"));
 const RecebimentoConferencia = lazy(() => import("./pages/RecebimentoConferencia"));
 const ProductionOrders = lazy(() => import("./pages/ProductionOrders"));
@@ -279,6 +280,7 @@ const App = () => {
                 <Route path="financeiro/regime-tributario" element={<FinanceiroRegimeTributario />} />
                 <Route path="financeiro/funding" element={<FinanceiroFunding />} />
                 <Route path="financeiro/endividamento" element={<FinanceiroEndividamento />} />
+                <Route path="financeiro/antecipacao" element={<FinanceiroAntecipacao />} />
                 <Route path="financeiro/gestao" element={<FinanceiroGestao />} />
                 <Route path="financeiro/analise" element={<FinanceiroAnalise />} />
                 {/* Grupo de Cliente 360 (mesmo gate do financeiro — mostra recebível) */}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { ImpersonationBanner } from '@/components/impersonation/ImpersonationBanner';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { BookOpen, Lock, Calculator, Palette, LayoutDashboard, Users, ShoppingCart, Phone, BarChart3, Settings, ChevronLeft, ChevronRight, Bell, User, LogOut, Package, TrendingUp, Target, Menu, X, PlusCircle, Shield, Wrench, Award, DollarSign, UserCheck, FileCheck, Factory, Percent, Database, Library, Crosshair, ListChecks, Landmark, UserX, ShieldCheck, MessageCircle, MessageSquareText, ClipboardList, History, Lightbulb, Radar, AlertTriangle } from 'lucide-react';
+import { BookOpen, Lock, Calculator, Palette, LayoutDashboard, Users, ShoppingCart, Phone, BarChart3, Settings, ChevronLeft, ChevronRight, Bell, User, LogOut, Package, TrendingUp, Target, Menu, X, PlusCircle, Shield, Wrench, Award, DollarSign, UserCheck, FileCheck, Factory, Percent, Database, Library, Crosshair, ListChecks, Landmark, Banknote, UserX, ShieldCheck, MessageCircle, MessageSquareText, ClipboardList, History, Lightbulb, Radar, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { AppShellProvider } from '@/contexts/AppShellContext';
@@ -155,6 +155,7 @@ const unifiedNavSections: { title: string; items: NavItem[] }[] = [
       { icon: TrendingUp, label: 'Retorno & Valor', path: '/financeiro/valor', masterOnly: true },
       { icon: Percent, label: 'Regime Tributário', path: '/financeiro/regime-tributario', masterOnly: true },
       { icon: Landmark, label: 'Custo de Funding', path: '/financeiro/funding', masterOnly: true },
+      { icon: Banknote, label: 'Antecipação', path: '/financeiro/antecipacao', masterOnly: true },
       { icon: Crosshair, label: 'Cockpit de Valor', path: '/financeiro/valor-cockpit', gestorComercialOuMaster: true },
       { icon: ListChecks, label: 'Próxima Ação', path: '/financeiro/proxima-acao', gestorComercialOuMaster: true },
     ],

--- a/src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx
+++ b/src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx
@@ -1,0 +1,347 @@
+// src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx
+// F4 — cadastro/edição de uma operação de antecipação. Espelha DividaFormDialog (react-hook-form +
+// zodResolver + Controller; toast sonner). Valida os invariantes money-path no cliente (P1-1 líquido ≤
+// face+avulsos; prazo positivo) ANTES do banco, e bloqueia lote multi-vencimento (fluxo_nao_suportado).
+// Mostra o custo/taxa derivados AO VIVO (helper puro) — o número é honesto, nunca gravado.
+import { useEffect } from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { Loader2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { COMPANIES } from '@/contexts/CompanyContext';
+import { useUpsertAntecipacao } from '@/hooks/useAntecipacoes';
+import { custoOperacao, motivoFluxoRegistro } from '@/lib/financeiro/antecipacao-helpers';
+import type { Antecipacao, Company, TipoAntecipacao } from '@/lib/financeiro/antecipacao-types';
+
+const TIPO_LABEL: Record<TipoAntecipacao, string> = {
+  duplicata: 'Desconto de duplicata',
+  linha: 'Linha rotativa',
+};
+
+// '' → null; número quando presente. Ausente ≠ zero (money-path).
+const numOpcional = (v: string): number | null => {
+  const t = v.trim();
+  if (t === '') return null;
+  const n = Number(t.replace(',', '.'));
+  return Number.isFinite(n) ? n : null;
+};
+const num = (v: string): number => numOpcional(v) ?? 0;
+
+const VALOR_REGEX = /^\d{1,15}([.,]\d{1,2})?$/;
+const valorObrig = z
+  .string()
+  .trim()
+  .refine((s) => VALOR_REGEX.test(s), 'Informe um valor (ex.: 100000 ou 100000,00)')
+  .refine((s) => num(s) > 0, 'Deve ser maior que zero');
+const valorOpc = z
+  .string()
+  .trim()
+  .refine((s) => s === '' || VALOR_REGEX.test(s), 'Valor inválido (ex.: 500,00)');
+
+const antecipSchema = z
+  .object({
+    company: z.enum(['colacor', 'oben', 'colacor_sc']),
+    banco: z.string(),
+    tipo: z.enum(['duplicata', 'linha']),
+    valor_bruto: valorObrig,
+    custos_avulsos: valorOpc,
+    valor_liquido: valorObrig,
+    data_operacao: z.string().min(1, 'Informe a data da operação'),
+    data_vencimento: z.string().min(1, 'Informe o vencimento'),
+    referencia: z.string(),
+    observacao: z.string(),
+    lote: z.boolean(),
+  })
+  .superRefine((v, ctx) => {
+    const bruto = num(v.valor_bruto);
+    const avulsos = num(v.custos_avulsos);
+    const liq = num(v.valor_liquido);
+    // P1-1: líquido == face+avulsos é VÁLIDO (custo zero); inválido só se MAIOR.
+    if (liq > bruto + avulsos) {
+      ctx.addIssue({
+        path: ['valor_liquido'],
+        code: z.ZodIssueCode.custom,
+        message: 'Líquido não pode exceder face + custos avulsos (isso seria ganho, não custo).',
+      });
+    }
+    if (v.data_operacao && v.data_vencimento && v.data_vencimento <= v.data_operacao) {
+      ctx.addIssue({
+        path: ['data_vencimento'],
+        code: z.ZodIssueCode.custom,
+        message: 'O vencimento deve ser depois da data da operação.',
+      });
+    }
+    if (motivoFluxoRegistro({ lote: v.lote }) !== 'ok') {
+      ctx.addIssue({
+        path: ['lote'],
+        code: z.ZodIssueCode.custom,
+        message: 'Lote com vários vencimentos inventa prazo. Registre uma operação por título/vencimento.',
+      });
+    }
+  });
+
+type AntecipFormValues = z.infer<typeof antecipSchema>;
+
+function toForm(a: Antecipacao | null): AntecipFormValues {
+  return {
+    company: (a?.company as Company) ?? 'oben',
+    banco: a?.banco ?? '',
+    tipo: (a?.tipo as TipoAntecipacao) ?? 'duplicata',
+    valor_bruto: a?.valor_bruto != null ? String(a.valor_bruto) : '',
+    custos_avulsos: a?.custos_avulsos ? String(a.custos_avulsos) : '',
+    valor_liquido: a?.valor_liquido != null ? String(a.valor_liquido) : '',
+    data_operacao: a?.data_operacao ?? '',
+    data_vencimento: a?.data_vencimento ?? '',
+    referencia: a?.referencia ?? '',
+    observacao: a?.observacao ?? '',
+    lote: false,
+  };
+}
+
+const pct = (v: number) => `${(v * 100).toFixed(2)}%`;
+const brl = (v: number) =>
+  v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 2 });
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** null = criar nova. */
+  antecipacao: Antecipacao | null;
+  /** Empresa pré-selecionada ao criar. */
+  defaultCompany: Company;
+}
+
+export function AntecipacaoFormDialog({ open, onOpenChange, antecipacao, defaultCompany }: Props) {
+  const upsert = useUpsertAntecipacao();
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<AntecipFormValues>({
+    resolver: zodResolver(antecipSchema),
+    defaultValues: toForm(antecipacao),
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    reset({ ...toForm(antecipacao), company: antecipacao?.company ?? defaultCompany });
+  }, [open, antecipacao, defaultCompany, reset]);
+
+  // Preview do custo/taxa AO VIVO (helper puro; nunca gravado).
+  const w = watch();
+  const preview = custoOperacao({
+    valor_bruto: num(w.valor_bruto ?? ''),
+    custos_avulsos: num(w.custos_avulsos ?? ''),
+    valor_liquido: num(w.valor_liquido ?? ''),
+    data_operacao: w.data_operacao ?? '',
+    data_vencimento: w.data_vencimento ?? '',
+  });
+
+  const onSubmit = async (v: AntecipFormValues) => {
+    const id = antecipacao?.id ?? crypto.randomUUID();
+    const payload: Partial<Antecipacao> & { company: Company } = {
+      id,
+      company: v.company,
+      banco: v.banco.trim() || null,
+      tipo: v.tipo,
+      valor_bruto: num(v.valor_bruto),
+      custos_avulsos: num(v.custos_avulsos),
+      valor_liquido: num(v.valor_liquido),
+      data_operacao: v.data_operacao,
+      data_vencimento: v.data_vencimento,
+      referencia: v.referencia.trim() || null,
+      observacao: v.observacao.trim() || null,
+    };
+    try {
+      await upsert.mutateAsync(payload);
+      onOpenChange(false);
+    } catch {
+      // toast já disparado no onError do hook
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl max-h-[92vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{antecipacao ? 'Editar operação' : 'Nova antecipação'}</DialogTitle>
+          <DialogDescription>
+            Registre uma operação de antecipação (uma face antecipada, um vencimento). O custo e a taxa são
+            calculados a partir dos valores — não os digite.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label>Empresa</Label>
+              <Controller
+                control={control}
+                name="company"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.keys(COMPANIES) as Array<keyof typeof COMPANIES>).map((c) => (
+                        <SelectItem key={c} value={c}>
+                          {COMPANIES[c].name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Tipo</Label>
+              <Controller
+                control={control}
+                name="tipo"
+                render={({ field }) => (
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {(Object.keys(TIPO_LABEL) as TipoAntecipacao[]).map((t) => (
+                        <SelectItem key={t} value={t}>
+                          {TIPO_LABEL[t]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="ant-bruto">Face antecipada (R$)</Label>
+              <Input id="ant-bruto" inputMode="decimal" placeholder="Ex.: 100000" {...register('valor_bruto')} />
+              {errors.valor_bruto && (
+                <p className="text-xs text-status-error">{errors.valor_bruto.message}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ant-avulsos">Custos avulsos (IOF/tarifa, R$)</Label>
+              <Input id="ant-avulsos" inputMode="decimal" placeholder="Fora do líquido" {...register('custos_avulsos')} />
+              {errors.custos_avulsos && (
+                <p className="text-xs text-status-error">{errors.custos_avulsos.message}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ant-liquido">Líquido recebido (R$)</Label>
+              <Input id="ant-liquido" inputMode="decimal" placeholder="O que caiu na conta" {...register('valor_liquido')} />
+              {errors.valor_liquido && (
+                <p className="text-xs text-status-error">{errors.valor_liquido.message}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="ant-oper">Data da operação (dinheiro entrou)</Label>
+              <Input id="ant-oper" type="date" {...register('data_operacao')} />
+              {errors.data_operacao && (
+                <p className="text-xs text-status-error">{errors.data_operacao.message}</p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ant-venc">Vencimento do título</Label>
+              <Input id="ant-venc" type="date" {...register('data_vencimento')} />
+              {errors.data_vencimento && (
+                <p className="text-xs text-status-error">{errors.data_vencimento.message}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Preview do custo derivado (helper puro) */}
+          {preview.motivo === 'ok' && preview.custo != null && (
+            <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
+              <span className="text-muted-foreground">Custo desta operação: </span>
+              <strong className="tabular-nums">{brl(preview.custo)}</strong>
+              <span className="text-muted-foreground">
+                {' '}
+                em {preview.dias} dias · taxa do período {pct(preview.taxa_periodo ?? 0)} ·{' '}
+                {pct(preview.taxa_efetiva_aa ?? 0)} a.a.
+              </span>
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <Label htmlFor="ant-ref">Referência (contrato/banco)</Label>
+              <Input id="ant-ref" placeholder="Dedup — ex.: nº do contrato" {...register('referencia')} />
+            </div>
+            <div className="space-y-1">
+              <Label htmlFor="ant-banco">Banco</Label>
+              <Input id="ant-banco" placeholder="Ex.: Itaú" {...register('banco')} />
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="ant-obs">Observação</Label>
+            <Textarea id="ant-obs" rows={2} {...register('observacao')} />
+          </div>
+
+          {/* Guard de lote (fluxo_nao_suportado) */}
+          <Controller
+            control={control}
+            name="lote"
+            render={({ field }) => (
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="ant-lote"
+                    checked={field.value}
+                    onCheckedChange={(c) => field.onChange(c === true)}
+                  />
+                  <Label htmlFor="ant-lote" className="font-normal text-sm">
+                    Esta operação cobre vários títulos com vencimentos diferentes?
+                  </Label>
+                </div>
+                {errors.lote && <p className="text-xs text-status-warning">{errors.lote.message}</p>}
+              </div>
+            )}
+          />
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={upsert.isPending}>
+              {upsert.isPending && <Loader2 className="w-4 h-4 mr-2 animate-spin" />}
+              {antecipacao ? 'Salvar' : 'Registrar'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx
+++ b/src/components/financeiro/antecipacao/AntecipacaoFormDialog.tsx
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { Checkbox } from '@/components/ui/checkbox';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import {
   Select,
   SelectContent,
@@ -46,6 +46,13 @@ const numOpcional = (v: string): number | null => {
   return Number.isFinite(n) ? n : null;
 };
 const num = (v: string): number => numOpcional(v) ?? 0;
+// Preview ao vivo: texto inválido → NaN (custoOperacao degrada e o preview some); '' → 0 (P1-a/Codex).
+const numPreview = (v: string): number => {
+  const t = (v ?? '').trim();
+  if (t === '') return 0;
+  const n = Number(t.replace(',', '.'));
+  return Number.isFinite(n) ? n : NaN;
+};
 
 const VALOR_REGEX = /^\d{1,15}([.,]\d{1,2})?$/;
 const valorObrig = z
@@ -70,7 +77,9 @@ const antecipSchema = z
     data_vencimento: z.string().min(1, 'Informe o vencimento'),
     referencia: z.string(),
     observacao: z.string(),
-    lote: z.boolean(),
+    // Fluxo declarado sem default (P1-e): força a escolha; lote bloqueia; rollover exige origem.
+    fluxo: z.enum(['um_vencimento', 'lote', 'rollover']).optional(),
+    operacao_origem_id: z.string(),
   })
   .superRefine((v, ctx) => {
     const bruto = num(v.valor_bruto);
@@ -91,11 +100,16 @@ const antecipSchema = z
         message: 'O vencimento deve ser depois da data da operação.',
       });
     }
-    if (motivoFluxoRegistro({ lote: v.lote }) !== 'ok') {
+    if (!v.fluxo) {
+      ctx.addIssue({ path: ['fluxo'], code: z.ZodIssueCode.custom, message: 'Escolha o tipo de operação.' });
+    } else if (motivoFluxoRegistro({ fluxo: v.fluxo, operacao_origem_id: v.operacao_origem_id || null }) !== 'ok') {
       ctx.addIssue({
-        path: ['lote'],
+        path: [v.fluxo === 'lote' ? 'fluxo' : 'operacao_origem_id'],
         code: z.ZodIssueCode.custom,
-        message: 'Lote com vários vencimentos inventa prazo. Registre uma operação por título/vencimento.',
+        message:
+          v.fluxo === 'lote'
+            ? 'Lote com vários vencimentos inventa prazo. Registre uma operação por título/vencimento.'
+            : 'Selecione a operação de origem do rollover (registra só o caixa novo).',
       });
     }
   });
@@ -114,7 +128,8 @@ function toForm(a: Antecipacao | null): AntecipFormValues {
     data_vencimento: a?.data_vencimento ?? '',
     referencia: a?.referencia ?? '',
     observacao: a?.observacao ?? '',
-    lote: false,
+    fluxo: a ? (a.operacao_origem_id ? 'rollover' : 'um_vencimento') : undefined,
+    operacao_origem_id: a?.operacao_origem_id ?? '',
   };
 }
 
@@ -129,9 +144,17 @@ interface Props {
   antecipacao: Antecipacao | null;
   /** Empresa pré-selecionada ao criar. */
   defaultCompany: Company;
+  /** Operações vivas da empresa (p/ o seletor de origem do rollover, P1-e). */
+  operacoes: Antecipacao[];
 }
 
-export function AntecipacaoFormDialog({ open, onOpenChange, antecipacao, defaultCompany }: Props) {
+export function AntecipacaoFormDialog({
+  open,
+  onOpenChange,
+  antecipacao,
+  defaultCompany,
+  operacoes,
+}: Props) {
   const upsert = useUpsertAntecipacao();
   const {
     register,
@@ -150,12 +173,13 @@ export function AntecipacaoFormDialog({ open, onOpenChange, antecipacao, default
     reset({ ...toForm(antecipacao), company: antecipacao?.company ?? defaultCompany });
   }, [open, antecipacao, defaultCompany, reset]);
 
-  // Preview do custo/taxa AO VIVO (helper puro; nunca gravado).
+  // Preview do custo/taxa AO VIVO (helper puro; nunca gravado). numPreview: inválido → NaN (some).
   const w = watch();
+  const origens = operacoes.filter((o) => o.id !== antecipacao?.id);
   const preview = custoOperacao({
-    valor_bruto: num(w.valor_bruto ?? ''),
-    custos_avulsos: num(w.custos_avulsos ?? ''),
-    valor_liquido: num(w.valor_liquido ?? ''),
+    valor_bruto: numPreview(w.valor_bruto ?? ''),
+    custos_avulsos: numPreview(w.custos_avulsos ?? ''),
+    valor_liquido: numPreview(w.valor_liquido ?? ''),
     data_operacao: w.data_operacao ?? '',
     data_vencimento: w.data_vencimento ?? '',
   });
@@ -174,6 +198,7 @@ export function AntecipacaoFormDialog({ open, onOpenChange, antecipacao, default
       data_vencimento: v.data_vencimento,
       referencia: v.referencia.trim() || null,
       observacao: v.observacao.trim() || null,
+      operacao_origem_id: v.fluxo === 'rollover' ? v.operacao_origem_id || null : null,
     };
     try {
       await upsert.mutateAsync(payload);
@@ -310,26 +335,74 @@ export function AntecipacaoFormDialog({ open, onOpenChange, antecipacao, default
             <Textarea id="ant-obs" rows={2} {...register('observacao')} />
           </div>
 
-          {/* Guard de lote (fluxo_nao_suportado) */}
-          <Controller
-            control={control}
-            name="lote"
-            render={({ field }) => (
-              <div className="space-y-1">
-                <div className="flex items-center gap-2">
-                  <Checkbox
-                    id="ant-lote"
-                    checked={field.value}
-                    onCheckedChange={(c) => field.onChange(c === true)}
-                  />
-                  <Label htmlFor="ant-lote" className="font-normal text-sm">
-                    Esta operação cobre vários títulos com vencimentos diferentes?
-                  </Label>
-                </div>
-                {errors.lote && <p className="text-xs text-status-warning">{errors.lote.message}</p>}
+          {/* Fluxo declarado (P1-e): sem default silencioso — lote bloqueia, rollover exige a origem. */}
+          <div className="space-y-2 rounded-md border border-border p-3">
+            <Label className="text-sm">Tipo de operação</Label>
+            <Controller
+              control={control}
+              name="fluxo"
+              render={({ field }) => (
+                <RadioGroup
+                  value={field.value ?? ''}
+                  onValueChange={field.onChange}
+                  className="grid gap-2"
+                >
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="um_vencimento" id="fluxo-um" />
+                    <Label htmlFor="fluxo-um" className="font-normal text-sm">
+                      Um único vencimento
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="lote" id="fluxo-lote" />
+                    <Label htmlFor="fluxo-lote" className="font-normal text-sm">
+                      Lote de vários vencimentos
+                    </Label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroupItem value="rollover" id="fluxo-roll" />
+                    <Label htmlFor="fluxo-roll" className="font-normal text-sm">
+                      Renovação/rollover de operação existente
+                    </Label>
+                  </div>
+                </RadioGroup>
+              )}
+            />
+            {errors.fluxo && <p className="text-xs text-status-warning">{errors.fluxo.message}</p>}
+
+            {w.fluxo === 'rollover' && (
+              <div className="space-y-1 pt-1">
+                <Label className="text-sm">Operação de origem (registra só o caixa NOVO)</Label>
+                <Controller
+                  control={control}
+                  name="operacao_origem_id"
+                  render={({ field }) => (
+                    <Select value={field.value || undefined} onValueChange={field.onChange}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Selecione a operação renovada" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {origens.length === 0 ? (
+                          <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                            Nenhuma operação para renovar.
+                          </div>
+                        ) : (
+                          origens.map((o) => (
+                            <SelectItem key={o.id} value={o.id}>
+                              {o.banco ?? '—'} · {o.valor_bruto.toLocaleString('pt-BR')} · venc {o.data_vencimento}
+                            </SelectItem>
+                          ))
+                        )}
+                      </SelectContent>
+                    </Select>
+                  )}
+                />
+                {errors.operacao_origem_id && (
+                  <p className="text-xs text-status-warning">{errors.operacao_origem_id.message}</p>
+                )}
               </div>
             )}
-          />
+          </div>
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/src/components/financeiro/antecipacao/CalculadoraFunding.tsx
+++ b/src/components/financeiro/antecipacao/CalculadoraFunding.tsx
@@ -1,0 +1,229 @@
+// src/components/financeiro/antecipacao/CalculadoraFunding.tsx
+// F4 Job B — comparação de custo de FUNDING de uma oferta hipotética. NUNCA "vale a pena" (isso
+// depende do uso do caixa, §4) — só "mais caro / dentro do seu custo de funding". Compara no MESMO
+// período (P1-3): a taxa da oferta vs o hurdle convertido para os mesmos dias. Hurdle editável é
+// PRIMÁRIO; o F1 (custo médio do CET) apenas SUGERE, com unidade explícita.
+import { useMemo, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Calculator, ArrowRight } from 'lucide-react';
+import { compararFunding } from '@/lib/financeiro/antecipacao-helpers';
+import { useHurdleSugerido } from '@/hooks/useAntecipacoes';
+import type { Company, FundingInput, HurdleUnidade } from '@/lib/financeiro/antecipacao-types';
+
+const num = (v: string): number => {
+  const n = Number(v.trim().replace(',', '.'));
+  return Number.isFinite(n) ? n : 0;
+};
+const pctToDec = (v: string): number => num(v) / 100; // usuário digita 2,5 → 0,025
+const pct = (v: number | null) => (v == null ? '—' : `${(v * 100).toFixed(2)}%`);
+const brl = (v: number | null) =>
+  v == null ? '—' : v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+const UNIDADE_LABEL: Record<HurdleUnidade, string> = {
+  efetiva_aa: '% a.a. (efetiva)',
+  nominal_aa: '% a.a. (nominal/linear)',
+  efetiva_am: '% a.m. (efetiva)',
+};
+
+const MOTIVO_MSG: Record<string, string> = {
+  dados_invalidos: 'Preencha a face, o prazo e a oferta (líquido ou taxa) para calcular.',
+  inputs_conflitantes: 'A taxa e o líquido informados não batem — deixe só um deles.',
+  hurdle_unidade_invalida: 'Selecione a unidade do hurdle para comparar.',
+  hurdle_indisponivel: 'Informe um hurdle (ou use a sugestão do F1) para comparar o funding.',
+  fluxo_nao_suportado: 'Fluxo não suportado nesta calculadora.',
+};
+
+export function CalculadoraFunding({ company }: { company: Company }) {
+  const [valorTitulo, setValorTitulo] = useState('');
+  const [dias, setDias] = useState('');
+  const [custosAvulsos, setCustosAvulsos] = useState('');
+  const [modo, setModo] = useState<'liquido' | 'taxa'>('liquido');
+  const [liquido, setLiquido] = useState('');
+  const [taxaOfertada, setTaxaOfertada] = useState('');
+  const [taxaUnidade, setTaxaUnidade] = useState<HurdleUnidade>('efetiva_am');
+  const [hurdleValor, setHurdleValor] = useState('');
+  const [hurdleUnidade, setHurdleUnidade] = useState<HurdleUnidade>('efetiva_aa');
+
+  const sugestao = useHurdleSugerido(company);
+
+  const input: FundingInput = useMemo(
+    () => ({
+      valor_titulo: num(valorTitulo),
+      dias: Math.round(num(dias)),
+      custos_avulsos: num(custosAvulsos),
+      liquido_ofertado: modo === 'liquido' ? num(liquido) : null,
+      taxa_ofertada:
+        modo === 'taxa' ? { valor: pctToDec(taxaOfertada), unidade: taxaUnidade } : null,
+      hurdle: hurdleValor.trim() ? { valor: pctToDec(hurdleValor), unidade: hurdleUnidade } : null,
+    }),
+    [valorTitulo, dias, custosAvulsos, modo, liquido, taxaOfertada, taxaUnidade, hurdleValor, hurdleUnidade],
+  );
+
+  const r = useMemo(() => compararFunding(input), [input]);
+  const temCusto = r.custo != null; // custo aparece mesmo sem hurdle
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Calculator className="w-4 h-4 text-status-info" />
+          Comparar uma oferta de antecipação
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="space-y-1">
+            <Label htmlFor="cf-face">Face do título (R$)</Label>
+            <Input id="cf-face" inputMode="decimal" placeholder="Ex.: 100000" value={valorTitulo} onChange={(e) => setValorTitulo(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="cf-dias">Prazo (dias)</Label>
+            <Input id="cf-dias" inputMode="numeric" placeholder="Ex.: 30" value={dias} onChange={(e) => setDias(e.target.value)} />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="cf-avulsos">Custos avulsos (R$)</Label>
+            <Input id="cf-avulsos" inputMode="decimal" placeholder="IOF/tarifa" value={custosAvulsos} onChange={(e) => setCustosAvulsos(e.target.value)} />
+          </div>
+        </div>
+
+        <div className="space-y-2 rounded-md border border-border p-3">
+          <Label className="text-sm">Como o banco informou a oferta?</Label>
+          <RadioGroup value={modo} onValueChange={(v) => setModo(v as 'liquido' | 'taxa')} className="flex gap-4">
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="liquido" id="cf-modo-liq" />
+              <Label htmlFor="cf-modo-liq" className="font-normal text-sm">Líquido a receber</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="taxa" id="cf-modo-taxa" />
+              <Label htmlFor="cf-modo-taxa" className="font-normal text-sm">Taxa</Label>
+            </div>
+          </RadioGroup>
+
+          {modo === 'liquido' ? (
+            <div className="space-y-1">
+              <Label htmlFor="cf-liquido">Líquido ofertado (R$)</Label>
+              <Input id="cf-liquido" inputMode="decimal" placeholder="Ex.: 97000" value={liquido} onChange={(e) => setLiquido(e.target.value)} />
+            </div>
+          ) : (
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Label htmlFor="cf-taxa">Taxa da oferta</Label>
+                <Input id="cf-taxa" inputMode="decimal" placeholder="Ex.: 2,0" value={taxaOfertada} onChange={(e) => setTaxaOfertada(e.target.value)} />
+              </div>
+              <div className="space-y-1">
+                <Label>Unidade</Label>
+                <Select value={taxaUnidade} onValueChange={(v) => setTaxaUnidade(v as HurdleUnidade)}>
+                  <SelectTrigger><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {(Object.keys(UNIDADE_LABEL) as HurdleUnidade[]).map((u) => (
+                      <SelectItem key={u} value={u}>{UNIDADE_LABEL[u]}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Hurdle editável (primário); F1 sugere */}
+        <div className="space-y-2 rounded-md border border-border p-3">
+          <div className="flex items-center justify-between">
+            <Label className="text-sm">Seu custo de funding alternativo (hurdle)</Label>
+            {sugestao.motivo === 'ok' && sugestao.valor != null && (
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs"
+                onClick={() => {
+                  setHurdleValor((sugestao.valor! * 100).toFixed(2).replace('.', ','));
+                  setHurdleUnidade('efetiva_aa');
+                }}
+              >
+                Usar F1 ({pct(sugestao.valor)} a.a.)
+              </Button>
+            )}
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div className="space-y-1">
+              <Label htmlFor="cf-hurdle">Taxa</Label>
+              <Input id="cf-hurdle" inputMode="decimal" placeholder="Ex.: 18,5" value={hurdleValor} onChange={(e) => setHurdleValor(e.target.value)} />
+            </div>
+            <div className="space-y-1">
+              <Label>Unidade</Label>
+              <Select value={hurdleUnidade} onValueChange={(v) => setHurdleUnidade(v as HurdleUnidade)}>
+                <SelectTrigger><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(UNIDADE_LABEL) as HurdleUnidade[]).map((u) => (
+                    <SelectItem key={u} value={u}>{UNIDADE_LABEL[u]}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </div>
+
+        {/* Resultado */}
+        <div className="rounded-md border border-border p-3 space-y-2">
+          {temCusto ? (
+            <>
+              <div className="grid grid-cols-3 gap-3">
+                <Metric label="Custo da oferta" value={brl(r.custo)} tone="error" />
+                <Metric label="Taxa do período" value={pct(r.taxa_periodo)} />
+                <Metric label="Efetiva (a.a.)" value={pct(r.taxa_efetiva_aa)} />
+              </div>
+              {r.motivo === 'ok' && r.veredito != null ? (
+                <div
+                  className={`flex items-center gap-2 text-sm rounded p-2 ${
+                    r.veredito === 'mais_caro'
+                      ? 'bg-status-warning-bg text-status-warning-fg'
+                      : 'bg-status-success-bg text-status-success'
+                  }`}
+                >
+                  <ArrowRight className="w-4 h-4 shrink-0" />
+                  <span>
+                    Oferta {pct(r.taxa_periodo)} vs seu funding {pct(r.hurdle_taxa_periodo)} no mesmo prazo —{' '}
+                    <strong>
+                      {r.veredito === 'mais_caro'
+                        ? 'mais caro que sua alternativa de crédito'
+                        : 'dentro do seu custo de funding'}
+                    </strong>
+                    .
+                  </span>
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">{MOTIVO_MSG[r.motivo] ?? ''}</p>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-muted-foreground">{MOTIVO_MSG[r.motivo] ?? MOTIVO_MSG.dados_invalidos}</p>
+          )}
+        </div>
+        <p className="text-[11px] text-muted-foreground">
+          Comparação de <strong>custo de funding</strong> — não é um veredito de "vale a pena" (isso depende do
+          uso do caixa: cobrir buraco, aproveitar desconto de fornecedor, etc.).
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({ label, value, tone }: { label: string; value: string; tone?: 'error' }) {
+  return (
+    <div className="space-y-0.5">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className={`text-base font-semibold tabular-nums ${tone === 'error' ? 'text-status-error' : ''}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/components/financeiro/antecipacao/CalculadoraFunding.tsx
+++ b/src/components/financeiro/antecipacao/CalculadoraFunding.tsx
@@ -22,8 +22,10 @@ import { useHurdleSugerido } from '@/hooks/useAntecipacoes';
 import type { Company, FundingInput, HurdleUnidade } from '@/lib/financeiro/antecipacao-types';
 
 const num = (v: string): number => {
-  const n = Number(v.trim().replace(',', '.'));
-  return Number.isFinite(n) ? n : 0;
+  const t = v.trim();
+  if (t === '') return 0; // ausente → 0 (campo opcional); required será pego por !(x > 0) no helper
+  const n = Number(t.replace(',', '.'));
+  return Number.isFinite(n) ? n : NaN; // texto inválido → NaN (o helper degrada; nunca 0 silencioso, P1-a)
 };
 const pctToDec = (v: string): number => num(v) / 100; // usuário digita 2,5 → 0,025
 const pct = (v: number | null) => (v == null ? '—' : `${(v * 100).toFixed(2)}%`);

--- a/src/components/financeiro/antecipacao/CalculadoraFunding.tsx
+++ b/src/components/financeiro/antecipacao/CalculadoraFunding.tsx
@@ -62,9 +62,12 @@ export function CalculadoraFunding({ company }: { company: Company }) {
       valor_titulo: num(valorTitulo),
       dias: Math.round(num(dias)),
       custos_avulsos: num(custosAvulsos),
-      liquido_ofertado: modo === 'liquido' ? num(liquido) : null,
+      // Campo vazio = oferta NÃO informada (null) — nunca num('')=0 travestido de "oferta de R$0/0%".
+      liquido_ofertado: modo === 'liquido' && liquido.trim() ? num(liquido) : null,
       taxa_ofertada:
-        modo === 'taxa' ? { valor: pctToDec(taxaOfertada), unidade: taxaUnidade } : null,
+        modo === 'taxa' && taxaOfertada.trim()
+          ? { valor: pctToDec(taxaOfertada), unidade: taxaUnidade }
+          : null,
       hurdle: hurdleValor.trim() ? { valor: pctToDec(hurdleValor), unidade: hurdleUnidade } : null,
     }),
     [valorTitulo, dias, custosAvulsos, modo, liquido, taxaOfertada, taxaUnidade, hurdleValor, hurdleUnidade],

--- a/src/components/financeiro/antecipacao/MedidorCustoCard.tsx
+++ b/src/components/financeiro/antecipacao/MedidorCustoCard.tsx
@@ -1,0 +1,110 @@
+// src/components/financeiro/antecipacao/MedidorCustoCard.tsx
+// F4 Job A — medidor de custo do período. Headline = R$ (custo_total); a taxa a.a. é money-weighted
+// (P1-2) e nunca aparece sozinha. Degrada honesto por motivo (sem_operacoes/dados_parciais) — nunca
+// um R$0 travestido de "custo zero" (P1-6: "registradas", o dado é manual).
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { TrendingDown, AlertTriangle, Inbox } from 'lucide-react';
+import { medirCusto } from '@/lib/financeiro/antecipacao-helpers';
+import type { Antecipacao } from '@/lib/financeiro/antecipacao-types';
+import { fmt, fmtCompact } from '@/components/financeiro/dashboard/format';
+
+const pct = (v: number | null) => (v == null ? '—' : `${(v * 100).toFixed(1)}%`);
+const MESES = ['jan', 'fev', 'mar', 'abr', 'mai', 'jun', 'jul', 'ago', 'set', 'out', 'nov', 'dez'];
+
+export function MedidorCustoCard({ ops }: { ops: Antecipacao[] }) {
+  const r = medirCusto(ops);
+
+  return (
+    <Card>
+      <CardHeader className="pb-3 flex-row items-center justify-between space-y-0">
+        <CardTitle className="text-base flex items-center gap-2">
+          <TrendingDown className="w-4 h-4 text-status-info" />
+          Custo da antecipação
+          {r.motivo !== 'sem_operacoes' && r.num_operacoes > 0 && (
+            <Badge variant="outline" className="text-[10px] font-normal">
+              {r.num_operacoes} {r.num_operacoes === 1 ? 'operação' : 'operações'}
+            </Badge>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {r.motivo === 'sem_operacoes' ? (
+          <div className="flex items-start gap-3 py-2">
+            <Inbox className="w-5 h-5 text-muted-foreground mt-0.5 shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              Sem antecipações registradas — nenhum custo a medir. (O dado é manual: registre as operações
+              para acompanhar o custo.)
+            </p>
+          </div>
+        ) : r.custo_total == null ? (
+          <div className="flex items-start gap-3 py-2">
+            <AlertTriangle className="w-5 h-5 text-status-warning mt-0.5 shrink-0" />
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-status-warning-fg">Operações inválidas</p>
+              <p className="text-sm text-muted-foreground">
+                As {r.num_excluidas} operação(ões) registradas têm líquido maior que a face ou prazo não
+                positivo. Corrija-as para medir o custo.
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+              <Metric label="Custo total" value={fmt(r.custo_total)} tone="error" hint="Soma dos custos das operações no período" />
+              <Metric label="Volume antecipado" value={fmt(r.volume_antecipado ?? 0)} hint="Líquido recebido" />
+              <Metric label="Taxa realizada (a.a.)" value={pct(r.taxa_realizada_aa)} hint="Money-weighted sobre capital×tempo" />
+            </div>
+
+            {r.num_excluidas > 0 && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-status-warning-bg border border-status-warning/30">
+                <AlertTriangle className="w-4 h-4 text-status-warning mt-0.5 shrink-0" />
+                <p className="text-xs text-status-warning-fg">
+                  {r.num_excluidas} operação(ões) inválida(s) foram excluídas do total — o número acima é só
+                  das válidas.
+                </p>
+              </div>
+            )}
+
+            {r.tendencia.length > 1 && (
+              <div className="space-y-1">
+                <p className="text-[11px] text-muted-foreground">Por mês (data da operação):</p>
+                <div className="flex flex-wrap gap-2">
+                  {r.tendencia.map((m) => (
+                    <span
+                      key={`${m.ano}-${m.mes}`}
+                      className="text-xs px-2 py-0.5 rounded bg-muted text-muted-foreground tabular-nums"
+                    >
+                      {MESES[m.mes - 1]}/{String(m.ano).slice(2)}: {fmtCompact(m.custo)}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  hint,
+  tone,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  tone?: 'error';
+}) {
+  const color = tone === 'error' ? 'text-status-error' : '';
+  return (
+    <div className="space-y-0.5">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className={`text-lg font-semibold tabular-nums ${color}`}>{value}</p>
+      {hint && <p className="text-[10px] text-muted-foreground leading-tight">{hint}</p>}
+    </div>
+  );
+}

--- a/src/hooks/useAntecipacoes.ts
+++ b/src/hooks/useAntecipacoes.ts
@@ -1,0 +1,124 @@
+// src/hooks/useAntecipacoes.ts
+// F4 — camada de dados (react-query). fin_antecipacoes é master-only (RLS) e NÃO está nos tipos
+// gerados → cast through unknown (molde verbatim de useEndividamento.ts; ESLint barra `any`).
+// Soft delete: UPDATE deleted_at (nunca DELETE — preserva histórico de custo). Hurdle-sugestão
+// derivada do F1 (fin_dividas.cet_aa ponderado pelo saldo devedor em aberto — fallback, P1-3).
+import { useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { sugerirHurdle } from '@/lib/financeiro/antecipacao-helpers';
+import { saldoDevedorEmAberto } from '@/lib/financeiro/endividamento-helpers';
+import { useDividas, useParcelas } from '@/hooks/useEndividamento';
+import type { Antecipacao, Company, HurdleSugerido } from '@/lib/financeiro/antecipacao-types';
+
+const STALE = 60_000;
+
+// ─── Shapes mínimos do client (cast através de unknown, sem `any`) ──────────────────────────────
+type SelectClient = {
+  from: (t: string) => {
+    select: (c: string) => {
+      eq: (
+        col: string,
+        val: string,
+      ) => {
+        order: (
+          col: string,
+          o?: { ascending?: boolean },
+        ) => Promise<{ data: unknown[] | null; error: { message: string } | null }>;
+      };
+    };
+  };
+};
+type UpsertClient = {
+  from: (t: string) => {
+    upsert: (
+      v: Record<string, unknown>,
+      o?: { onConflict: string },
+    ) => Promise<{ error: { message: string } | null }>;
+  };
+};
+type UpdateClient = {
+  from: (t: string) => {
+    update: (v: Record<string, unknown>) => {
+      eq: (col: string, val: string) => Promise<{ error: { message: string } | null }>;
+    };
+  };
+};
+
+/** Operações vivas (deleted_at IS NULL) de uma empresa, mais recentes primeiro. */
+export function useAntecipacoes(company: Company | string) {
+  return useQuery({
+    queryKey: ['antecipacoes', company],
+    enabled: Boolean(company),
+    staleTime: STALE,
+    queryFn: async (): Promise<Antecipacao[]> => {
+      const client = supabase as unknown as SelectClient;
+      const { data, error } = await client
+        .from('fin_antecipacoes')
+        .select('*')
+        .eq('company', company as string)
+        .order('data_operacao', { ascending: false });
+      if (error) throw new Error(error.message);
+      return ((data ?? []) as Antecipacao[]).filter((a) => a.deleted_at == null);
+    },
+  });
+}
+
+/** Insert (sem id) ou update (com id). Trigger cuida de created_by/updated_by/at. */
+export function useUpsertAntecipacao() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (op: Partial<Antecipacao> & { company: Company }) => {
+      const client = supabase as unknown as UpsertClient;
+      const { error } = await client.from('fin_antecipacoes').upsert({ ...op }, { onConflict: 'id' });
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: (_d, v) => {
+      qc.invalidateQueries({ queryKey: ['antecipacoes', v.company] });
+      toast.success('Operação salva.');
+    },
+    onError: (e) =>
+      toast.error('Falha ao salvar operação', {
+        description: e instanceof Error ? e.message : String(e),
+      }),
+  });
+}
+
+/** Soft delete: marca deleted_at (não apaga — preserva histórico de custo). */
+export function useSoftDeleteAntecipacao() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id }: { id: string; company: Company }) => {
+      const client = supabase as unknown as UpdateClient;
+      const { error } = await client
+        .from('fin_antecipacoes')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: (_d, v) => {
+      qc.invalidateQueries({ queryKey: ['antecipacoes', v.company] });
+      toast.success('Operação removida.');
+    },
+    onError: (e) =>
+      toast.error('Falha ao remover operação', {
+        description: e instanceof Error ? e.message : String(e),
+      }),
+  });
+}
+
+/** Hurdle-sugestão a partir do custo médio ponderado do CET das dívidas do F1 (fallback com unidade). */
+export function useHurdleSugerido(company: Company | string): HurdleSugerido {
+  const { data: dividas } = useDividas(company);
+  const dividaIds = useMemo(() => (dividas ?? []).map((d) => d.id), [dividas]);
+  const { data: parcelas } = useParcelas(dividaIds);
+  return useMemo<HurdleSugerido>(() => {
+    if (!dividas) return { valor: null, unidade: null, motivo: 'sem_dados' };
+    return sugerirHurdle(
+      dividas
+        .filter((d) => d.ativo)
+        .map((d) => ({ saldo: saldoDevedorEmAberto(d, parcelas ?? []), cet_aa: d.cet_aa })),
+    );
+  }, [dividas, parcelas]);
+}

--- a/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { diasEntre, custoOperacao } from '../antecipacao-helpers';
+
+const op = (over: Partial<Parameters<typeof custoOperacao>[0]> = {}) => ({
+  valor_bruto: 100_000,
+  custos_avulsos: 0,
+  valor_liquido: 97_000,
+  data_operacao: '2026-01-01',
+  data_vencimento: '2026-01-31',
+  ...over,
+});
+
+describe('diasEntre', () => {
+  it('conta dias corridos entre datas ISO (sem drift de TZ)', () => {
+    expect(diasEntre('2026-01-01', '2026-01-31')).toBe(30);
+    expect(diasEntre('2026-03-01', '2026-03-01')).toBe(0);
+  });
+});
+
+describe('custoOperacao — caminho feliz', () => {
+  it('custo = bruto+avulsos−liquido; taxa período e a.a. de caso conhecido', () => {
+    const r = custoOperacao(op());
+    expect(r.motivo).toBe('ok');
+    expect(r.custo).toBeCloseTo(3_000, 2);
+    expect(r.dias).toBe(30);
+    expect(r.taxa_periodo).toBeCloseTo(100_000 / 97_000 - 1, 6); // ~0,030928
+    expect(r.taxa_efetiva_aa).toBeCloseTo(Math.pow(100_000 / 97_000, 365 / 30) - 1, 6); // ~0,4486
+  });
+
+  it('custos_avulsos (IOF/tarifa FORA do líquido) entram no custo (P1-4)', () => {
+    const r = custoOperacao(op({ custos_avulsos: 500 }));
+    expect(r.custo).toBeCloseTo(3_500, 2); // 100000+500−97000
+    expect(r.taxa_periodo).toBeCloseTo(100_500 / 97_000 - 1, 6);
+  });
+
+  it('líquido == bruto+avulsos → custo 0 / taxa 0, VÁLIDO (P1-1: igualdade não é inválida)', () => {
+    const r = custoOperacao(op({ valor_liquido: 100_000, custos_avulsos: 0 }));
+    expect(r.motivo).toBe('ok');
+    expect(r.custo).toBeCloseTo(0, 6);
+    expect(r.taxa_periodo).toBeCloseTo(0, 6);
+    expect(r.taxa_efetiva_aa).toBeCloseTo(0, 6);
+  });
+});
+
+describe('custoOperacao — dados_invalidos (helper blinda além do CHECK)', () => {
+  it('líquido > bruto+avulsos → dados_invalidos (P1-1: inválido só quando MAIOR)', () => {
+    const r = custoOperacao(op({ valor_liquido: 100_001 }));
+    expect(r.motivo).toBe('dados_invalidos');
+    expect(r.custo).toBeNull();
+  });
+  it('dias ≤ 0 (venc ≤ operação) → dados_invalidos', () => {
+    const r = custoOperacao(op({ data_vencimento: '2026-01-01' }));
+    expect(r.motivo).toBe('dados_invalidos');
+  });
+  it('valores ≤ 0 ou custos_avulsos < 0 → dados_invalidos', () => {
+    expect(custoOperacao(op({ valor_bruto: 0 })).motivo).toBe('dados_invalidos');
+    expect(custoOperacao(op({ valor_liquido: 0 })).motivo).toBe('dados_invalidos');
+    expect(custoOperacao(op({ custos_avulsos: -1 })).motivo).toBe('dados_invalidos');
+  });
+});

--- a/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { diasEntre, custoOperacao, medirCusto } from '../antecipacao-helpers';
-import type { Antecipacao } from '../antecipacao-types';
+import {
+  diasEntre,
+  custoOperacao,
+  medirCusto,
+  taxaParaPeriodo,
+  compararFunding,
+  motivoFluxoRegistro,
+} from '../antecipacao-helpers';
+import type { Antecipacao, HurdleUnidade } from '../antecipacao-types';
 
 const op = (over: Partial<Parameters<typeof custoOperacao>[0]> = {}) => ({
   valor_bruto: 100_000,
@@ -158,5 +165,117 @@ describe('medirCusto — degradação honesta', () => {
     expect(r.num_operacoes).toBe(0);
     expect(r.num_excluidas).toBe(1);
     expect(r.custo_total).toBeNull();
+  });
+});
+
+describe('taxaParaPeriodo — converte unidade → taxa do período de `dias` (P1-3)', () => {
+  it('efetiva_aa composta', () => {
+    expect(taxaParaPeriodo(0.3, 'efetiva_aa', 30)).toBeCloseTo(Math.pow(1.3, 30 / 365) - 1, 8);
+  });
+  it('efetiva_am composta: 2% a.m. em 30 dias ≈ 2%', () => {
+    expect(taxaParaPeriodo(0.02, 'efetiva_am', 30)).toBeCloseTo(0.02, 8);
+  });
+  it('nominal_aa linear: 36,5% a.a. em 30 dias = 3%', () => {
+    expect(taxaParaPeriodo(0.365, 'nominal_aa', 30)).toBeCloseTo(0.03, 8);
+  });
+});
+
+describe('compararFunding — Job B (comparação de FUNDING, nunca "vale a pena")', () => {
+  const base = { valor_titulo: 100_000, dias: 30 };
+
+  it('oferta como líquido: custo + taxas; hurdle efetiva_aa convertido p/ 30d → veredito só de funding', () => {
+    const r = compararFunding({
+      ...base,
+      liquido_ofertado: 97_000,
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('ok');
+    expect(r.custo).toBeCloseTo(3_000, 2);
+    expect(r.taxa_periodo).toBeCloseTo(100_000 / 97_000 - 1, 6); // ~3,09%
+    expect(r.hurdle_taxa_periodo).toBeCloseTo(Math.pow(1.3, 30 / 365) - 1, 6); // ~2,18%
+    expect(r.veredito).toBe('mais_caro'); // 3,09% > 2,18%
+  });
+
+  it('oferta dentro do hurdle → "dentro" (não "vale a pena")', () => {
+    const r = compararFunding({
+      ...base,
+      liquido_ofertado: 99_000,
+      hurdle: { valor: 0.6, unidade: 'efetiva_aa' },
+    });
+    expect(r.veredito).toBe('dentro');
+  });
+
+  it('oferta como taxa (com unidade) reconstrói o líquido e custa igual', () => {
+    const r = compararFunding({
+      ...base,
+      taxa_ofertada: { valor: 0.02, unidade: 'efetiva_am' },
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('ok');
+    expect(r.taxa_periodo).toBeCloseTo(0.02, 6); // 2% a.m. em 30d
+    expect(r.custo).toBeCloseTo(100_000 - 100_000 / 1.02, 2);
+  });
+
+  it('custos_avulsos entram no custo da oferta (P1-4)', () => {
+    const r = compararFunding({
+      ...base,
+      liquido_ofertado: 97_000,
+      custos_avulsos: 500,
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.custo).toBeCloseTo(3_500, 2); // 100000+500−97000
+  });
+
+  it('hurdle ausente → hurdle_indisponivel: mostra custo, sem veredito', () => {
+    const r = compararFunding({ ...base, liquido_ofertado: 97_000 });
+    expect(r.motivo).toBe('hurdle_indisponivel');
+    expect(r.custo).toBeCloseTo(3_000, 2);
+    expect(r.veredito).toBeNull();
+  });
+
+  it('hurdle sem unidade válida → hurdle_unidade_invalida', () => {
+    const r = compararFunding({
+      ...base,
+      liquido_ofertado: 97_000,
+      hurdle: { valor: 0.3, unidade: 'xpto' as HurdleUnidade },
+    });
+    expect(r.motivo).toBe('hurdle_unidade_invalida');
+    expect(r.veredito).toBeNull();
+  });
+
+  it('taxa E líquido informados que não reconciliam → inputs_conflitantes', () => {
+    const r = compararFunding({
+      ...base,
+      liquido_ofertado: 90_000,
+      taxa_ofertada: { valor: 0.02, unidade: 'efetiva_am' },
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('inputs_conflitantes');
+  });
+
+  it('lote multi-venc num prazo só → fluxo_nao_suportado (inventa prazo, P1-5)', () => {
+    const r = compararFunding({
+      ...base,
+      liquido_ofertado: 97_000,
+      lote: true,
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('fluxo_nao_suportado');
+  });
+
+  it('dados inválidos (dias ≤ 0, líquido > face+avulsos) → dados_invalidos', () => {
+    expect(compararFunding({ valor_titulo: 100_000, dias: 0, liquido_ofertado: 97_000 }).motivo).toBe(
+      'dados_invalidos',
+    );
+    expect(
+      compararFunding({ valor_titulo: 100_000, dias: 30, liquido_ofertado: 100_001 }).motivo,
+    ).toBe('dados_invalidos');
+  });
+});
+
+describe('motivoFluxoRegistro — guard de entrada (form)', () => {
+  it('lote=true → fluxo_nao_suportado; senão ok', () => {
+    expect(motivoFluxoRegistro({ lote: true })).toBe('fluxo_nao_suportado');
+    expect(motivoFluxoRegistro({})).toBe('ok');
   });
 });

--- a/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
@@ -6,6 +6,7 @@ import {
   taxaParaPeriodo,
   compararFunding,
   motivoFluxoRegistro,
+  sugerirHurdle,
 } from '../antecipacao-helpers';
 import type { Antecipacao, HurdleUnidade } from '../antecipacao-types';
 
@@ -277,5 +278,31 @@ describe('motivoFluxoRegistro — guard de entrada (form)', () => {
   it('lote=true → fluxo_nao_suportado; senão ok', () => {
     expect(motivoFluxoRegistro({ lote: true })).toBe('fluxo_nao_suportado');
     expect(motivoFluxoRegistro({})).toBe('ok');
+  });
+});
+
+describe('sugerirHurdle — média ponderada do CET do F1 (fallback, unidade explícita)', () => {
+  it('pondera cet_aa pelo saldo; unidade efetiva_aa', () => {
+    const r = sugerirHurdle([
+      { saldo: 100_000, cet_aa: 0.2 },
+      { saldo: 300_000, cet_aa: 0.3 },
+    ]);
+    expect(r.motivo).toBe('ok');
+    expect(r.valor).toBeCloseTo(0.275, 6); // (100k*0,20 + 300k*0,30)/400k
+    expect(r.unidade).toBe('efetiva_aa');
+  });
+  it('ignora dívidas sem cet_aa ou sem saldo (ausente ≠ zero)', () => {
+    const r = sugerirHurdle([
+      { saldo: 100_000, cet_aa: null },
+      { saldo: 0, cet_aa: 0.5 },
+      { saldo: 200_000, cet_aa: 0.25 },
+    ]);
+    expect(r.valor).toBeCloseTo(0.25, 6); // só a 3ª entra
+  });
+  it('nenhuma dívida com CET → sem_dados (não fabrica 0)', () => {
+    const r = sugerirHurdle([{ saldo: 100_000, cet_aa: null }]);
+    expect(r.motivo).toBe('sem_dados');
+    expect(r.valor).toBeNull();
+    expect(r.unidade).toBeNull();
   });
 });

--- a/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
@@ -227,6 +227,44 @@ describe('compararFunding — Job B (comparação de FUNDING, nunca "vale a pena
     expect(r.custo).toBeCloseTo(3_500, 2); // 100000+500−97000
   });
 
+  it('taxa da oferta incide sobre a FACE — avulsos entram no custo à parte (P1-c/Codex)', () => {
+    // face 100000, 2% a.m. em 30d, avulsos 500. líquido = 100000/1.02 (NÃO 100500/1.02); custo = 100500 − líquido.
+    const r = compararFunding({
+      valor_titulo: 100_000,
+      dias: 30,
+      custos_avulsos: 500,
+      taxa_ofertada: { valor: 0.02, unidade: 'efetiva_am' },
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('ok');
+    const liq = 100_000 / 1.02;
+    expect(r.custo).toBeCloseTo(100_500 - liq, 2); // ~2460,78 — NÃO ~1970,59 (que seria base/(1+tp))
+  });
+
+  it('hurdle com valor NaN → hurdle_unidade_invalida, veredito null (não "dentro" falso, P1-b/Codex)', () => {
+    const r = compararFunding({
+      valor_titulo: 100_000,
+      dias: 30,
+      liquido_ofertado: 99_000,
+      hurdle: { valor: NaN, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('hurdle_unidade_invalida');
+    expect(r.veredito).toBeNull();
+    expect(r.custo).toBeCloseTo(1_000, 2); // o custo ainda aparece
+  });
+
+  it('taxa E líquido com conflito de centenas de R$ → inputs_conflitantes (tolerância apertada, P1-d/Codex)', () => {
+    // taxa 2% a.m. em 30d → líquido esperado 98039,22; usuário passa 97600 (diff ~439) → conflito real.
+    const r = compararFunding({
+      valor_titulo: 100_000,
+      dias: 30,
+      liquido_ofertado: 97_600,
+      taxa_ofertada: { valor: 0.02, unidade: 'efetiva_am' },
+      hurdle: { valor: 0.3, unidade: 'efetiva_aa' },
+    });
+    expect(r.motivo).toBe('inputs_conflitantes');
+  });
+
   it('hurdle ausente → hurdle_indisponivel: mostra custo, sem veredito', () => {
     const r = compararFunding({ ...base, liquido_ofertado: 97_000 });
     expect(r.motivo).toBe('hurdle_indisponivel');
@@ -274,10 +312,19 @@ describe('compararFunding — Job B (comparação de FUNDING, nunca "vale a pena
   });
 });
 
-describe('motivoFluxoRegistro — guard de entrada (form)', () => {
-  it('lote=true → fluxo_nao_suportado; senão ok', () => {
-    expect(motivoFluxoRegistro({ lote: true })).toBe('fluxo_nao_suportado');
-    expect(motivoFluxoRegistro({})).toBe('ok');
+describe('motivoFluxoRegistro — guard de entrada (form, P1-e)', () => {
+  it('um_vencimento → ok', () => {
+    expect(motivoFluxoRegistro({ fluxo: 'um_vencimento' })).toBe('ok');
+  });
+  it('lote → fluxo_nao_suportado (inventa prazo)', () => {
+    expect(motivoFluxoRegistro({ fluxo: 'lote' })).toBe('fluxo_nao_suportado');
+  });
+  it('rollover sem operação de origem → fluxo_nao_suportado', () => {
+    expect(motivoFluxoRegistro({ fluxo: 'rollover' })).toBe('fluxo_nao_suportado');
+    expect(motivoFluxoRegistro({ fluxo: 'rollover', operacao_origem_id: null })).toBe('fluxo_nao_suportado');
+  });
+  it('rollover COM operação de origem → ok', () => {
+    expect(motivoFluxoRegistro({ fluxo: 'rollover', operacao_origem_id: 'abc' })).toBe('ok');
   });
 });
 

--- a/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
+++ b/src/lib/financeiro/__tests__/antecipacao-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { diasEntre, custoOperacao } from '../antecipacao-helpers';
+import { diasEntre, custoOperacao, medirCusto } from '../antecipacao-helpers';
+import type { Antecipacao } from '../antecipacao-types';
 
 const op = (over: Partial<Parameters<typeof custoOperacao>[0]> = {}) => ({
   valor_bruto: 100_000,
@@ -56,5 +57,106 @@ describe('custoOperacao — dados_invalidos (helper blinda além do CHECK)', () 
     expect(custoOperacao(op({ valor_bruto: 0 })).motivo).toBe('dados_invalidos');
     expect(custoOperacao(op({ valor_liquido: 0 })).motivo).toBe('dados_invalidos');
     expect(custoOperacao(op({ custos_avulsos: -1 })).motivo).toBe('dados_invalidos');
+  });
+});
+
+// ── Job A (medirCusto): operação completa (id não é usado pelo helper — fixo por determinismo) ──
+const full = (over: Partial<Antecipacao>): Antecipacao => ({
+  id: 'op',
+  company: 'oben',
+  banco: 'Itaú',
+  tipo: 'duplicata',
+  valor_bruto: 100_000,
+  custos_avulsos: 0,
+  valor_liquido: 97_000,
+  data_operacao: '2026-01-05',
+  data_vencimento: '2026-02-04',
+  operacao_origem_id: null,
+  referencia: null,
+  observacao: null,
+  deleted_at: null,
+  ...over,
+});
+
+describe('medirCusto — Job A money-weighted (P1-2)', () => {
+  it('taxa realizada reconcilia com R$: custo_total / (Σ líquido×dias / 365)', () => {
+    const ops = [
+      full({ valor_liquido: 97_000, data_operacao: '2026-01-01', data_vencimento: '2026-01-31' }), // custo 3000, 30d
+      full({
+        valor_bruto: 52_000,
+        valor_liquido: 50_000,
+        data_operacao: '2026-02-01',
+        data_vencimento: '2026-04-02',
+      }), // custo 2000, 60d
+    ];
+    const r = medirCusto(ops);
+    expect(r.motivo).toBe('ok');
+    expect(r.custo_total).toBeCloseTo(5_000, 2);
+    expect(r.volume_antecipado).toBeCloseTo(147_000, 2);
+    const capitalTempo = (97_000 * 30 + 50_000 * 60) / 365; // 16191,78 R$·ano
+    expect(r.taxa_realizada_aa).toBeCloseTo(5_000 / capitalTempo, 6); // ~0,3088
+    expect(r.num_operacoes).toBe(2);
+  });
+
+  it('uma op curtíssima com EAR absurda NÃO infla a taxa (money-weighted, não média de EAR)', () => {
+    const ops = [
+      full({ valor_bruto: 1_000, valor_liquido: 990, data_operacao: '2026-01-01', data_vencimento: '2026-01-02' }), // 1d
+      full({ valor_bruto: 100_000, valor_liquido: 97_000, data_operacao: '2026-01-01', data_vencimento: '2026-01-31' }), // 30d
+    ];
+    const r = medirCusto(ops);
+    const capitalTempo = (990 * 1 + 97_000 * 30) / 365;
+    expect(r.taxa_realizada_aa).toBeCloseTo((10 + 3_000) / capitalTempo, 6); // dominada pela op grande
+    expect(r.taxa_realizada_aa!).toBeLessThan(1); // < 100% a.a. — não explodiu
+  });
+
+  it('tendência mensal por data_operacao (base declarada)', () => {
+    const ops = [
+      full({ valor_liquido: 97_000, data_operacao: '2026-01-10', data_vencimento: '2026-02-09' }), // jan custo 3000
+      full({
+        valor_bruto: 52_000,
+        valor_liquido: 50_000,
+        data_operacao: '2026-02-10',
+        data_vencimento: '2026-03-12',
+      }), // fev custo 2000
+    ];
+    const r = medirCusto(ops);
+    expect(r.tendencia).toEqual([
+      { ano: 2026, mes: 1, custo: 3_000, volume: 97_000 },
+      { ano: 2026, mes: 2, custo: 2_000, volume: 50_000 },
+    ]);
+  });
+});
+
+describe('medirCusto — degradação honesta', () => {
+  it('sem operações → sem_operacoes (≠ economia/custo zero; P1-6)', () => {
+    const r = medirCusto([]);
+    expect(r.motivo).toBe('sem_operacoes');
+    expect(r.custo_total).toBeNull();
+    expect(r.num_operacoes).toBe(0);
+  });
+
+  it('soft-deleted é ignorado (não conta no custo)', () => {
+    const r = medirCusto([full({ deleted_at: '2026-03-01T00:00:00Z' })]);
+    expect(r.motivo).toBe('sem_operacoes');
+  });
+
+  it('linha inválida excluída → dados_parciais, agregado só das válidas (nunca "ok" com op ignorada)', () => {
+    const ops = [
+      full({ valor_liquido: 97_000, data_operacao: '2026-01-01', data_vencimento: '2026-01-31' }), // válida, custo 3000
+      full({ valor_bruto: 100_000, valor_liquido: 100_001 }), // inválida (líquido > bruto)
+    ];
+    const r = medirCusto(ops);
+    expect(r.motivo).toBe('dados_parciais');
+    expect(r.num_operacoes).toBe(1);
+    expect(r.num_excluidas).toBe(1);
+    expect(r.custo_total).toBeCloseTo(3_000, 2);
+  });
+
+  it('todas inválidas → dados_parciais com agregados null (temos ops, nenhuma custeável)', () => {
+    const r = medirCusto([full({ valor_bruto: 100_000, valor_liquido: 100_050 })]);
+    expect(r.motivo).toBe('dados_parciais');
+    expect(r.num_operacoes).toBe(0);
+    expect(r.num_excluidas).toBe(1);
+    expect(r.custo_total).toBeNull();
   });
 });

--- a/src/lib/financeiro/antecipacao-helpers.ts
+++ b/src/lib/financeiro/antecipacao-helpers.ts
@@ -4,6 +4,9 @@
 import type {
   Antecipacao,
   CustoOperacao,
+  FundingInput,
+  FundingResult,
+  HurdleUnidade,
   MedidorResult,
   MesAntecipacao,
 } from './antecipacao-types';
@@ -106,4 +109,88 @@ export function medirCusto(ops: Antecipacao[]): MedidorResult {
     num_excluidas: excluidas,
     tendencia,
   };
+}
+
+const UNIDADES: readonly HurdleUnidade[] = ['efetiva_aa', 'nominal_aa', 'efetiva_am'];
+
+/** Converte uma taxa na sua unidade → taxa EFETIVA do período de `dias` (comparação no MESMO período, P1-3). */
+export function taxaParaPeriodo(valor: number, unidade: HurdleUnidade, dias: number): number {
+  switch (unidade) {
+    case 'efetiva_aa':
+      return Math.pow(1 + valor, dias / 365) - 1; // composta anual
+    case 'efetiva_am':
+      return Math.pow(1 + valor, dias / 30) - 1; // composta mensal
+    case 'nominal_aa':
+      return valor * (dias / 365); // linear/proporcional (juros simples)
+  }
+}
+
+const FUNDING_INVALIDO = (m: FundingResult['motivo']): FundingResult => ({
+  motivo: m,
+  custo: null,
+  taxa_periodo: null,
+  taxa_efetiva_aa: null,
+  hurdle_taxa_periodo: null,
+  veredito: null,
+});
+
+/** Job B — comparação de custo de FUNDING (nunca "vale a pena"; isso depende do uso do caixa, §4). */
+export function compararFunding(input: FundingInput): FundingResult {
+  if (input.lote === true) return FUNDING_INVALIDO('fluxo_nao_suportado'); // P1-5: prazo inventado
+  const face = Number(input.valor_titulo);
+  const dias = Number(input.dias);
+  const avulsos = Number(input.custos_avulsos ?? 0);
+  if (![face, dias, avulsos].every(Number.isFinite) || !(face > 0) || !(dias > 0) || avulsos < 0) {
+    return FUNDING_INVALIDO('dados_invalidos');
+  }
+  const base = face + avulsos;
+
+  // Resolve o líquido da oferta: pode vir como líquido, como taxa (c/ unidade), ou ambos (reconciliar).
+  const temLiquido = input.liquido_ofertado != null;
+  const temTaxa = input.taxa_ofertada != null;
+  if (!temLiquido && !temTaxa) return FUNDING_INVALIDO('dados_invalidos');
+
+  let liquidoDeTaxa: number | null = null;
+  if (temTaxa) {
+    const u = input.taxa_ofertada!.unidade;
+    if (!UNIDADES.includes(u)) return FUNDING_INVALIDO('hurdle_unidade_invalida');
+    const tp = taxaParaPeriodo(input.taxa_ofertada!.valor, u, dias);
+    if (!(tp > -1)) return FUNDING_INVALIDO('dados_invalidos');
+    liquidoDeTaxa = base / (1 + tp);
+  }
+
+  let liquido: number | null;
+  if (temLiquido) {
+    liquido = Number(input.liquido_ofertado);
+    if (!Number.isFinite(liquido) || !(liquido > 0) || liquido > base) {
+      return FUNDING_INVALIDO('dados_invalidos');
+    }
+    // taxa E líquido: reconciliar (tolerância relativa 0,5% sobre a face)
+    if (liquidoDeTaxa != null && Math.abs(liquido - liquidoDeTaxa) > 0.005 * base) {
+      return FUNDING_INVALIDO('inputs_conflitantes');
+    }
+  } else {
+    liquido = liquidoDeTaxa;
+  }
+  if (liquido == null || !(liquido > 0) || liquido > base) return FUNDING_INVALIDO('dados_invalidos');
+
+  const custo = base - liquido;
+  const taxa_periodo = base / liquido - 1;
+  const taxa_efetiva_aa = Math.pow(1 + taxa_periodo, 365 / dias) - 1;
+
+  // Hurdle editável PRIMÁRIO (P1-3): ausente → só custo; unidade inválida → sem veredito.
+  if (input.hurdle == null) {
+    return { motivo: 'hurdle_indisponivel', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo: null, veredito: null };
+  }
+  if (!UNIDADES.includes(input.hurdle.unidade)) {
+    return { motivo: 'hurdle_unidade_invalida', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo: null, veredito: null };
+  }
+  const hurdle_taxa_periodo = taxaParaPeriodo(input.hurdle.valor, input.hurdle.unidade, dias);
+  const veredito = taxa_periodo > hurdle_taxa_periodo ? 'mais_caro' : 'dentro';
+  return { motivo: 'ok', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo, veredito };
+}
+
+/** Guard de entrada: lote multi-venc num prazo só inventa prazo → não suportado em v1 (registrar 1 por título). */
+export function motivoFluxoRegistro(input: { lote?: boolean }): 'ok' | 'fluxo_nao_suportado' {
+  return input.lote === true ? 'fluxo_nao_suportado' : 'ok';
 }

--- a/src/lib/financeiro/antecipacao-helpers.ts
+++ b/src/lib/financeiro/antecipacao-helpers.ts
@@ -1,0 +1,42 @@
+// F4 — Antecipação de recebíveis. Helper PURO (vitest). Sem I/O.
+// Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md
+// Precisão > recall: degrada por motivo (nunca fabrica R$). Datas ISO puras (UTC-midnight).
+import type { Antecipacao, CustoOperacao } from './antecipacao-types';
+
+const MS_DIA = 86_400_000;
+/** Dias corridos entre duas datas ISO puras, ancoradas em UTC-midnight (sem drift de fuso). */
+export function diasEntre(operISO: string, vencISO: string): number {
+  const a = Date.parse(operISO + 'T00:00:00Z');
+  const b = Date.parse(vencISO + 'T00:00:00Z');
+  return Math.round((b - a) / MS_DIA);
+}
+
+type OpCusto = Pick<
+  Antecipacao,
+  'valor_bruto' | 'custos_avulsos' | 'valor_liquido' | 'data_operacao' | 'data_vencimento'
+>;
+
+const INVALIDO: CustoOperacao = {
+  motivo: 'dados_invalidos',
+  custo: null,
+  dias: null,
+  taxa_periodo: null,
+  taxa_efetiva_aa: null,
+};
+
+/** Custo e taxas de UMA operação. Blinda os invariantes (o CHECK barra no banco; aqui defende o agregado). */
+export function custoOperacao(op: OpCusto): CustoOperacao {
+  const bruto = Number(op.valor_bruto);
+  const avulsos = Number(op.custos_avulsos);
+  const liquido = Number(op.valor_liquido);
+  if (![bruto, avulsos, liquido].every(Number.isFinite)) return INVALIDO;
+  if (!(bruto > 0) || !(liquido > 0) || avulsos < 0) return INVALIDO; // P1-1: valores positivos
+  const base = bruto + avulsos;
+  if (liquido > base) return INVALIDO; // P1-1: inválido SÓ se líquido > base
+  const dias = diasEntre(op.data_operacao, op.data_vencimento);
+  if (!(dias > 0)) return INVALIDO; // prazo positivo
+  const custo = base - liquido; // P1-4: avulsos entram
+  const taxa_periodo = base / liquido - 1;
+  const taxa_efetiva_aa = Math.pow(1 + taxa_periodo, 365 / dias) - 1; // normalização (nunca métrica única, §3)
+  return { motivo: 'ok', custo, dias, taxa_periodo, taxa_efetiva_aa };
+}

--- a/src/lib/financeiro/antecipacao-helpers.ts
+++ b/src/lib/financeiro/antecipacao-helpers.ts
@@ -6,6 +6,7 @@ import type {
   CustoOperacao,
   FundingInput,
   FundingResult,
+  HurdleSugerido,
   HurdleUnidade,
   MedidorResult,
   MesAntecipacao,
@@ -193,4 +194,23 @@ export function compararFunding(input: FundingInput): FundingResult {
 /** Guard de entrada: lote multi-venc num prazo só inventa prazo → não suportado em v1 (registrar 1 por título). */
 export function motivoFluxoRegistro(input: { lote?: boolean }): 'ok' | 'fluxo_nao_suportado' {
   return input.lote === true ? 'fluxo_nao_suportado' : 'ok';
+}
+
+/** Sugere um hurdle a partir do custo médio ponderado (por saldo) do CET das dívidas do F1.
+ *  FALLBACK (P1-3): custo médio de dívida ativa ≠ custo marginal de hoje — o editável é primário.
+ *  CET = efetiva a.a. → unidade 'efetiva_aa'. Ausente ≠ zero: ignora sem cet/saldo; nenhuma → sem_dados. */
+export function sugerirHurdle(
+  dividas: Array<{ saldo: number; cet_aa: number | null }>,
+): HurdleSugerido {
+  let pesoTotal = 0;
+  let somaPond = 0;
+  for (const d of dividas) {
+    const saldo = Number(d.saldo);
+    const cet = d.cet_aa;
+    if (cet == null || !Number.isFinite(cet) || !Number.isFinite(saldo) || saldo <= 0) continue;
+    pesoTotal += saldo;
+    somaPond += saldo * cet;
+  }
+  if (pesoTotal <= 0) return { valor: null, unidade: null, motivo: 'sem_dados' };
+  return { valor: somaPond / pesoTotal, unidade: 'efetiva_aa', motivo: 'ok' };
 }

--- a/src/lib/financeiro/antecipacao-helpers.ts
+++ b/src/lib/financeiro/antecipacao-helpers.ts
@@ -1,7 +1,12 @@
 // F4 — Antecipação de recebíveis. Helper PURO (vitest). Sem I/O.
 // Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md
 // Precisão > recall: degrada por motivo (nunca fabrica R$). Datas ISO puras (UTC-midnight).
-import type { Antecipacao, CustoOperacao } from './antecipacao-types';
+import type {
+  Antecipacao,
+  CustoOperacao,
+  MedidorResult,
+  MesAntecipacao,
+} from './antecipacao-types';
 
 const MS_DIA = 86_400_000;
 /** Dias corridos entre duas datas ISO puras, ancoradas em UTC-midnight (sem drift de fuso). */
@@ -39,4 +44,66 @@ export function custoOperacao(op: OpCusto): CustoOperacao {
   const taxa_periodo = base / liquido - 1;
   const taxa_efetiva_aa = Math.pow(1 + taxa_periodo, 365 / dias) - 1; // normalização (nunca métrica única, §3)
   return { motivo: 'ok', custo, dias, taxa_periodo, taxa_efetiva_aa };
+}
+
+/** Job A — medidor de custo do período. Métrica primária = caixa (R$), taxa money-weighted (P1-2).
+ *  Exclui soft-deleted; linhas inválidas são excluídas e sinalizadas (dados_parciais). */
+export function medirCusto(ops: Antecipacao[]): MedidorResult {
+  const vivos = ops.filter((o) => o.deleted_at == null);
+  if (vivos.length === 0) {
+    return {
+      motivo: 'sem_operacoes',
+      custo_total: null,
+      volume_antecipado: null,
+      taxa_realizada_aa: null,
+      num_operacoes: 0,
+      num_excluidas: 0,
+      tendencia: [],
+    };
+  }
+  let custoTotal = 0;
+  let volume = 0;
+  let capitalTempo = 0;
+  let excluidas = 0;
+  const porMes = new Map<string, MesAntecipacao>();
+  for (const o of vivos) {
+    const c = custoOperacao(o);
+    if (c.motivo !== 'ok' || c.custo == null || c.dias == null) {
+      excluidas++;
+      continue;
+    }
+    custoTotal += c.custo;
+    volume += o.valor_liquido;
+    capitalTempo += (o.valor_liquido * c.dias) / 365;
+    const ano = Number(o.data_operacao.slice(0, 4));
+    const mes = Number(o.data_operacao.slice(5, 7));
+    const k = `${ano}-${mes}`;
+    const m = porMes.get(k) ?? { ano, mes, custo: 0, volume: 0 };
+    m.custo += c.custo;
+    m.volume += o.valor_liquido;
+    porMes.set(k, m);
+  }
+  const validas = vivos.length - excluidas;
+  const tendencia = [...porMes.values()].sort((a, b) => a.ano * 12 + a.mes - (b.ano * 12 + b.mes));
+  if (validas === 0) {
+    return {
+      motivo: 'dados_parciais',
+      custo_total: null,
+      volume_antecipado: null,
+      taxa_realizada_aa: null,
+      num_operacoes: 0,
+      num_excluidas: excluidas,
+      tendencia: [],
+    };
+  }
+  const taxa = capitalTempo > 0 ? custoTotal / capitalTempo : null; // money-weighted anualizada
+  return {
+    motivo: excluidas > 0 ? 'dados_parciais' : 'ok',
+    custo_total: custoTotal,
+    volume_antecipado: volume,
+    taxa_realizada_aa: taxa,
+    num_operacoes: validas,
+    num_excluidas: excluidas,
+    tendencia,
+  };
 }

--- a/src/lib/financeiro/antecipacao-helpers.ts
+++ b/src/lib/financeiro/antecipacao-helpers.ts
@@ -154,10 +154,14 @@ export function compararFunding(input: FundingInput): FundingResult {
   let liquidoDeTaxa: number | null = null;
   if (temTaxa) {
     const u = input.taxa_ofertada!.unidade;
+    const tv = Number(input.taxa_ofertada!.valor);
     if (!UNIDADES.includes(u)) return FUNDING_INVALIDO('hurdle_unidade_invalida');
-    const tp = taxaParaPeriodo(input.taxa_ofertada!.valor, u, dias);
+    if (!Number.isFinite(tv) || tv < 0) return FUNDING_INVALIDO('dados_invalidos'); // P1-b: NaN/negativa
+    const tp = taxaParaPeriodo(tv, u, dias);
     if (!(tp > -1)) return FUNDING_INVALIDO('dados_invalidos');
-    liquidoDeTaxa = base / (1 + tp);
+    // P1-c: a taxa da oferta incide sobre a FACE; os custos avulsos são custo À PARTE (fora do líquido).
+    // Usar base=(face+avulsos) aqui subcontaria o custo quando há avulsos.
+    liquidoDeTaxa = face / (1 + tp);
   }
 
   let liquido: number | null;
@@ -166,8 +170,9 @@ export function compararFunding(input: FundingInput): FundingResult {
     if (!Number.isFinite(liquido) || !(liquido > 0) || liquido > base) {
       return FUNDING_INVALIDO('dados_invalidos');
     }
-    // taxa E líquido: reconciliar (tolerância relativa 0,5% sobre a face)
-    if (liquidoDeTaxa != null && Math.abs(liquido - liquidoDeTaxa) > 0.005 * base) {
+    // taxa E líquido: reconciliar. Tolerância de ARREDONDAMENTO (limitada pela precisão da taxa,
+    // 2 casas de %), não comercial — P1-d: 0,5% da face escondia conflito real de centenas de R$.
+    if (liquidoDeTaxa != null && Math.abs(liquido - liquidoDeTaxa) > Math.max(0.01, 1e-4 * base)) {
       return FUNDING_INVALIDO('inputs_conflitantes');
     }
   } else {
@@ -183,7 +188,12 @@ export function compararFunding(input: FundingInput): FundingResult {
   if (input.hurdle == null) {
     return { motivo: 'hurdle_indisponivel', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo: null, veredito: null };
   }
-  if (!UNIDADES.includes(input.hurdle.unidade)) {
+  // P1-b: unidade inválida OU valor não-finito/negativo → sem veredito (nunca um 'dentro' falso por NaN).
+  if (
+    !UNIDADES.includes(input.hurdle.unidade) ||
+    !Number.isFinite(input.hurdle.valor) ||
+    input.hurdle.valor < 0
+  ) {
     return { motivo: 'hurdle_unidade_invalida', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo: null, veredito: null };
   }
   const hurdle_taxa_periodo = taxaParaPeriodo(input.hurdle.valor, input.hurdle.unidade, dias);
@@ -191,9 +201,18 @@ export function compararFunding(input: FundingInput): FundingResult {
   return { motivo: 'ok', custo, taxa_periodo, taxa_efetiva_aa, hurdle_taxa_periodo, veredito };
 }
 
-/** Guard de entrada: lote multi-venc num prazo só inventa prazo → não suportado em v1 (registrar 1 por título). */
-export function motivoFluxoRegistro(input: { lote?: boolean }): 'ok' | 'fluxo_nao_suportado' {
-  return input.lote === true ? 'fluxo_nao_suportado' : 'ok';
+export type FluxoRegistro = 'um_vencimento' | 'lote' | 'rollover';
+
+/** Guard de entrada (P1-e). O fluxo é declarado explicitamente (sem default silencioso):
+ *  - 'lote' (vários vencimentos num prazo só) inventa prazo → não suportado (registrar 1 por título);
+ *  - 'rollover' exige a operação de origem (senão o principal rolado seria re-contado). */
+export function motivoFluxoRegistro(input: {
+  fluxo?: FluxoRegistro;
+  operacao_origem_id?: string | null;
+}): 'ok' | 'fluxo_nao_suportado' {
+  if (input.fluxo === 'lote') return 'fluxo_nao_suportado';
+  if (input.fluxo === 'rollover' && !input.operacao_origem_id) return 'fluxo_nao_suportado';
+  return 'ok';
 }
 
 /** Sugere um hurdle a partir do custo médio ponderado (por saldo) do CET das dívidas do F1.

--- a/src/lib/financeiro/antecipacao-types.ts
+++ b/src/lib/financeiro/antecipacao-types.ts
@@ -1,0 +1,87 @@
+// F4 — Antecipação de recebíveis. Tipos PUROS (helper testado em vitest).
+// Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md
+// Money-path: ausente ≠ zero; sem operação = sem custo (degrada por motivo, nunca fabrica).
+// Datas ISO YYYY-MM-DD puras (sem TZ). Os 5 P1 do Codex (spec §11) são lei.
+
+export type Company = 'oben' | 'colacor' | 'colacor_sc';
+export type TipoAntecipacao = 'duplicata' | 'linha';
+/** Unidade EXPLÍCITA do hurdle/oferta (P1-3: sem unidade a comparação é lixo). */
+export type HurdleUnidade = 'efetiva_aa' | 'nominal_aa' | 'efetiva_am';
+
+export interface Antecipacao {
+  id: string;
+  company: Company;
+  banco: string | null;
+  tipo: TipoAntecipacao;
+  valor_bruto: number; // FACE ANTECIPADA (não a face total do título)
+  custos_avulsos: number; // >= 0 — IOF/tarifa FORA do líquido (P1-4)
+  valor_liquido: number; // > 0 — o que caiu na conta
+  data_operacao: string; // ISO
+  data_vencimento: string; // ISO
+  operacao_origem_id: string | null;
+  referencia: string | null;
+  observacao: string | null;
+  deleted_at: string | null;
+}
+
+export type MotivoOperacao = 'ok' | 'dados_invalidos';
+export interface CustoOperacao {
+  motivo: MotivoOperacao;
+  custo: number | null; // bruto + avulsos − liquido
+  dias: number | null;
+  taxa_periodo: number | null; // (bruto+avulsos)/liquido − 1
+  taxa_efetiva_aa: number | null;
+}
+
+export type MotivoMedidor = 'ok' | 'sem_operacoes' | 'dados_parciais';
+export interface MesAntecipacao {
+  ano: number;
+  mes: number;
+  custo: number;
+  volume: number;
+}
+export interface MedidorResult {
+  motivo: MotivoMedidor;
+  custo_total: number | null;
+  volume_antecipado: number | null;
+  taxa_realizada_aa: number | null; // money-weighted (P1-2)
+  num_operacoes: number; // válidas incluídas
+  num_excluidas: number; // inválidas excluídas (dados_parciais)
+  tendencia: MesAntecipacao[]; // por data_operacao (base declarada, P1)
+}
+
+export interface Hurdle {
+  valor: number;
+  unidade: HurdleUnidade;
+}
+export type MotivoFunding =
+  | 'ok'
+  | 'dados_invalidos'
+  | 'inputs_conflitantes'
+  | 'hurdle_unidade_invalida'
+  | 'hurdle_indisponivel'
+  | 'fluxo_nao_suportado';
+export interface FundingInput {
+  valor_titulo: number; // face antecipada da oferta
+  dias: number;
+  custos_avulsos?: number; // default 0
+  liquido_ofertado?: number | null; // oferta como líquido
+  taxa_ofertada?: Hurdle | null; // OU oferta como taxa (com unidade)
+  hurdle?: Hurdle | null; // editável PRIMÁRIO; ausente → hurdle_indisponivel
+  lote?: boolean; // true = lote multi-venc num prazo só → fluxo_nao_suportado
+}
+export interface FundingResult {
+  motivo: MotivoFunding;
+  custo: number | null;
+  taxa_periodo: number | null;
+  taxa_efetiva_aa: number | null;
+  hurdle_taxa_periodo: number | null; // hurdle convertido p/ os mesmos `dias`
+  veredito: 'mais_caro' | 'dentro' | null; // SÓ de funding (P1-3), nunca "vale a pena"
+}
+
+export type MotivoHurdleSugerido = 'ok' | 'sem_dados';
+export interface HurdleSugerido {
+  valor: number | null;
+  unidade: HurdleUnidade | null;
+  motivo: MotivoHurdleSugerido;
+}

--- a/src/pages/FinanceiroAntecipacao.tsx
+++ b/src/pages/FinanceiroAntecipacao.tsx
@@ -1,0 +1,248 @@
+// src/pages/FinanceiroAntecipacao.tsx
+// F4 — página master-only: registro de antecipações + medidor de custo (Job A) + calculadora de
+// funding (Job B). Espelha FinanceiroEndividamento (header, seletor de empresa, PageSkeleton, Table).
+// Soft delete (deleted_at) — o histórico de custo nunca é apagado.
+import { useState } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useCompany, COMPANIES } from '@/contexts/CompanyContext';
+import { useAntecipacoes, useSoftDeleteAntecipacao } from '@/hooks/useAntecipacoes';
+import { custoOperacao } from '@/lib/financeiro/antecipacao-helpers';
+import { AntecipacaoFormDialog } from '@/components/financeiro/antecipacao/AntecipacaoFormDialog';
+import { MedidorCustoCard } from '@/components/financeiro/antecipacao/MedidorCustoCard';
+import { CalculadoraFunding } from '@/components/financeiro/antecipacao/CalculadoraFunding';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { EmptyState } from '@/components/EmptyState';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Banknote, Plus, Pencil, Trash2, AlertTriangle } from 'lucide-react';
+import { fmt, fmtDate } from '@/components/financeiro/dashboard/format';
+import type { Antecipacao, Company, TipoAntecipacao } from '@/lib/financeiro/antecipacao-types';
+
+const TIPO_LABEL: Record<TipoAntecipacao, string> = {
+  duplicata: 'Duplicata',
+  linha: 'Linha',
+};
+
+export default function FinanceiroAntecipacao() {
+  const { isMaster } = useAuth();
+  const { activeCompany } = useCompany();
+  const [selectedCompany, setSelectedCompany] = useState<Company>(activeCompany ?? 'oben');
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editando, setEditando] = useState<Antecipacao | null>(null);
+  const [excluindo, setExcluindo] = useState<Antecipacao | null>(null);
+
+  const { data: ops, isLoading, error } = useAntecipacoes(selectedCompany);
+  const softDelete = useSoftDeleteAntecipacao();
+
+  if (!isMaster) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon={Banknote}
+          tone="operational"
+          title="Acesso restrito"
+          description="O módulo de antecipação de recebíveis é visível apenas para master."
+        />
+      </div>
+    );
+  }
+
+  const lista = ops ?? [];
+  const abrirNova = () => {
+    setEditando(null);
+    setDialogOpen(true);
+  };
+  const abrirEdicao = (a: Antecipacao) => {
+    setEditando(a);
+    setDialogOpen(true);
+  };
+
+  return (
+    <div className="p-4 lg:p-6 space-y-4">
+      {/* ── Header ── */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="font-display text-3xl">Antecipação de recebíveis</h1>
+          <p className="text-sm text-muted-foreground">
+            Registro manual das operações de antecipação. Mede o custo real (R$ + taxa) e compara o funding —
+            não substitui o extrato do banco.
+          </p>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <select
+            className="text-sm border border-border rounded px-2 py-1 bg-background"
+            value={selectedCompany}
+            onChange={(e) => setSelectedCompany(e.target.value as Company)}
+          >
+            {Object.values(COMPANIES).map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.shortName}
+              </option>
+            ))}
+          </select>
+          <Button size="sm" onClick={abrirNova}>
+            <Plus className="w-4 h-4 mr-1" />
+            Nova antecipação
+          </Button>
+        </div>
+      </div>
+
+      {isLoading ? (
+        <PageSkeleton variant="cockpit" />
+      ) : error ? (
+        // §5: erro de leitura/RLS NÃO é "sem operações" — surfacear distinto (nunca confundir).
+        <Card>
+          <CardContent className="flex items-start gap-3 py-4">
+            <AlertTriangle className="w-5 h-5 text-status-warning mt-0.5 shrink-0" />
+            <p className="text-sm text-muted-foreground">
+              Não foi possível carregar as antecipações. Se a migração{' '}
+              <code className="text-xs">fin_antecipacoes</code> ainda não foi aplicada, aplique-a primeiro.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <>
+          {/* Job A — medidor */}
+          <MedidorCustoCard ops={lista} />
+
+          {/* Job B — calculadora de funding */}
+          <CalculadoraFunding company={selectedCompany} />
+
+          {/* Lista de operações */}
+          {lista.length === 0 ? (
+            <EmptyState
+              icon={Banknote}
+              tone="operational"
+              title="Nenhuma antecipação registrada"
+              description={`Registre as operações de ${COMPANIES[selectedCompany].name} para medir o custo.`}
+            />
+          ) : (
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base">
+                  Operações de {COMPANIES[selectedCompany].shortName} ({lista.length})
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-0 overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Banco</TableHead>
+                      <TableHead>Tipo</TableHead>
+                      <TableHead className="text-right">Face</TableHead>
+                      <TableHead className="text-right">Líquido</TableHead>
+                      <TableHead className="text-right">Custo</TableHead>
+                      <TableHead className="text-right">Dias</TableHead>
+                      <TableHead>Vencimento</TableHead>
+                      <TableHead className="text-right">Ações</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {lista.map((a) => {
+                      const c = custoOperacao(a);
+                      return (
+                        <TableRow key={a.id}>
+                          <TableCell className="font-medium">{a.banco ?? '—'}</TableCell>
+                          <TableCell className="text-muted-foreground">
+                            {TIPO_LABEL[a.tipo] ?? a.tipo}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">{fmt(a.valor_bruto)}</TableCell>
+                          <TableCell className="text-right tabular-nums">{fmt(a.valor_liquido)}</TableCell>
+                          <TableCell className="text-right tabular-nums">
+                            {c.motivo === 'ok' && c.custo != null ? (
+                              fmt(c.custo)
+                            ) : (
+                              <Badge variant="outline" className="text-[10px] text-status-error border-status-error/40">
+                                inválida
+                              </Badge>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-right tabular-nums">{c.dias ?? '—'}</TableCell>
+                          <TableCell>{fmtDate(a.data_vencimento)}</TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8"
+                                onClick={() => abrirEdicao(a)}
+                                aria-label="Editar operação"
+                              >
+                                <Pencil className="w-3.5 h-3.5" />
+                              </Button>
+                              <Button
+                                size="icon"
+                                variant="ghost"
+                                className="h-8 w-8"
+                                onClick={() => setExcluindo(a)}
+                                aria-label="Remover operação"
+                              >
+                                <Trash2 className="w-3.5 h-3.5 text-status-error" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      )}
+
+      {/* ── Dialog de cadastro/edição ── */}
+      <AntecipacaoFormDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        antecipacao={editando}
+        defaultCompany={selectedCompany}
+      />
+
+      {/* ── Confirmação de remoção (soft delete) ── */}
+      <AlertDialog open={excluindo != null} onOpenChange={(o) => !o && setExcluindo(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remover operação?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {excluindo
+                ? `A operação ${excluindo.banco ? `no ${excluindo.banco} ` : ''}sai da lista e dos totais. O histórico de custo é preservado (soft delete).`
+                : ''}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (excluindo) softDelete.mutate({ id: excluindo.id, company: selectedCompany });
+                setExcluindo(null);
+              }}
+            >
+              Remover
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/pages/FinanceiroAntecipacao.tsx
+++ b/src/pages/FinanceiroAntecipacao.tsx
@@ -217,6 +217,7 @@ export default function FinanceiroAntecipacao() {
         onOpenChange={setDialogOpen}
         antecipacao={editando}
         defaultCompany={selectedCompany}
+        operacoes={lista}
       />
 
       {/* ── Confirmação de remoção (soft delete) ── */}
@@ -234,7 +235,8 @@ export default function FinanceiroAntecipacao() {
             <AlertDialogCancel>Cancelar</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
-                if (excluindo) softDelete.mutate({ id: excluindo.id, company: selectedCompany });
+                // P2-a: invalida o cache da empresa DA OPERAÇÃO (não do seletor, que pode ter mudado).
+                if (excluindo) softDelete.mutate({ id: excluindo.id, company: excluindo.company });
                 setExcluindo(null);
               }}
             >

--- a/supabase/migrations/20260708120000_fin_antecipacoes.sql
+++ b/supabase/migrations/20260708120000_fin_antecipacoes.sql
@@ -1,0 +1,81 @@
+-- supabase/migrations/20260708120000_fin_antecipacoes.sql
+-- F4 — Antecipação de recebíveis: registro MANUAL da operação (desconto de duplicata / linha rotativa).
+-- Overlay analítico; NADA reescreve sync/DRE. Derivados (custo/taxa) moram no helper puro — a tabela
+-- só guarda os fatos brutos. master-only (molde fin_dre_custo_tipo/fin_dividas). Idempotente (re-colável).
+-- Spec: docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md (§2, §7, §8). Os 5 P1 no CHECK.
+
+CREATE TABLE IF NOT EXISTS public.fin_antecipacoes (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company            text NOT NULL CHECK (company IN ('oben','colacor','colacor_sc')),
+  banco              text,
+  tipo               text NOT NULL CHECK (tipo IN ('duplicata','linha')),
+  valor_bruto        numeric(15,2) NOT NULL,   -- FACE ANTECIPADA (suporta parcial — não a face total)
+  custos_avulsos     numeric(15,2) NOT NULL DEFAULT 0,  -- IOF/tarifa FORA do líquido (P1-4)
+  valor_liquido      numeric(15,2) NOT NULL,   -- o que efetivamente caiu na conta
+  data_operacao      date NOT NULL,
+  data_vencimento    date NOT NULL,
+  operacao_origem_id uuid REFERENCES public.fin_antecipacoes(id) ON DELETE SET NULL, -- rollover (§7)
+  referencia         text,                     -- contrato/banco (dedup manual)
+  observacao         text,
+  created_by         uuid,
+  created_at         timestamptz NOT NULL DEFAULT now(),
+  updated_by         uuid,
+  updated_at         timestamptz NOT NULL DEFAULT now(),
+  deleted_at         timestamptz,              -- soft delete (preserva histórico de custo)
+  CONSTRAINT fin_antecipacoes_valores_chk
+    CHECK (valor_bruto > 0 AND valor_liquido > 0 AND custos_avulsos >= 0),
+  -- P1-1: '=' é custo zero, VÁLIDO; inválido SÓ quando líquido > (bruto+avulsos).
+  CONSTRAINT fin_antecipacoes_liquido_chk
+    CHECK (valor_liquido <= valor_bruto + custos_avulsos),
+  CONSTRAINT fin_antecipacoes_prazo_chk
+    CHECK (data_vencimento > data_operacao)
+);
+
+COMMENT ON TABLE public.fin_antecipacoes IS
+  'F4: operações de antecipação de recebíveis (registro manual master-only). Uma linha = uma operação = um vencimento (lote multi-venc → split). Derivados (custo/taxa) no helper puro; a tabela só guarda os fatos.';
+
+-- Dedup: mesma referência não duplica (coalesce banco p/ deduplicar mesmo com banco nulo). Ignora soft-deleted.
+CREATE UNIQUE INDEX IF NOT EXISTS fin_antecipacoes_ref_uq
+  ON public.fin_antecipacoes (company, coalesce(banco, ''), referencia)
+  WHERE referencia IS NOT NULL AND deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_fin_antecipacoes_company_viva
+  ON public.fin_antecipacoes (company, data_operacao) WHERE deleted_at IS NULL;
+
+-- Trigger de autor/carimbo no servidor (SECURITY DEFINER + search_path='' — INVOKER quebra auth.uid(),
+-- "permission denied for schema auth", pego pela prova PG17; molde fin_dre_custo_tipo).
+CREATE OR REPLACE FUNCTION public.fin_antecipacoes_set_autor()
+RETURNS trigger LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = '' AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    NEW.created_by := auth.uid();
+    NEW.created_at := now();
+  END IF;
+  NEW.updated_by := auth.uid();
+  NEW.updated_at := now();
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_fin_antecipacoes_autor ON public.fin_antecipacoes;
+CREATE TRIGGER trg_fin_antecipacoes_autor
+  BEFORE INSERT OR UPDATE ON public.fin_antecipacoes
+  FOR EACH ROW EXECUTE FUNCTION public.fin_antecipacoes_set_autor();
+
+-- RLS master-only (verbatim ao padrão proven de fin_dre_custo_tipo).
+ALTER TABLE public.fin_antecipacoes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS fin_antecipacoes_select_master ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_select_master ON public.fin_antecipacoes
+  FOR SELECT USING (EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master'));
+
+DROP POLICY IF EXISTS fin_antecipacoes_write_master ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_write_master ON public.fin_antecipacoes
+  FOR ALL USING (EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master'))
+  WITH CHECK (EXISTS (SELECT 1 FROM user_roles WHERE user_id = auth.uid() AND role = 'master'));
+
+DROP POLICY IF EXISTS fin_antecipacoes_service_all ON public.fin_antecipacoes;
+CREATE POLICY fin_antecipacoes_service_all ON public.fin_antecipacoes
+  FOR ALL USING (auth.role() = 'service_role');
+
+SELECT 'fin_antecipacoes OK' AS status,
+  (SELECT count(*) FROM pg_policies WHERE tablename = 'fin_antecipacoes') AS policies;


### PR DESCRIPTION
## F4 — Antecipação de recebíveis (custo + comparação de funding)

Frente 4 do pacote PEGN. Overlay analítico **manual** (antecipação não tem footprint no banco — §0 da spec): registra operações de antecipação, mede o **custo real** (R$ + taxa período + taxa a.a. money-weighted) e compara o **custo de funding** de uma oferta vs um hurdle editável. Precisão > recall: **nunca fabrica número** (ausente ≠ zero → degrada por motivo).

Spec: `docs/superpowers/specs/2026-07-07-antecipacao-recebiveis-design.md` (#1231). Plano TDD: `docs/superpowers/plans/2026-07-08-antecipacao-recebiveis.md`.

### O que entra
- **Helper puro** `antecipacao-helpers.ts` — custo/taxa por operação, Job A (medidor money-weighted), Job B (funding + conversão de unidade do hurdle), hurdle-sugestão do F1. **36 testes vitest**.
- **Migration** `fin_antecipacoes` (master-only RLS, trigger de autor, CHECKs, unique de dedup, soft delete) — **prova PG17 18/18 com falsificação**.
- **Hook** `useAntecipacoes` (CRUD, soft-delete via `deleted_at`, hurdle derivado do F1).
- **UI** página `/financeiro/antecipacao` (master-only) + nav: lista/CRUD + card medidor (Job A) + calculadora de funding (Job B).

### Os 5 P1 do Codex (spec §11) — implementados e provados
- **P1-1** `líquido == face+avulsos` é custo zero VÁLIDO (inválido só se maior) — testado no vitest **e** no CHECK do PG17.
- **P1-2** taxa realizada = money-weighted `custo/(Σlíquido×dias/365)` — reconcilia com R$ (não média de EAR).
- **P1-3** hurdle com **unidade explícita**, comparado no mesmo período; editável primário, F1 (CET médio) só sugestão.
- **P1-4** `custos_avulsos` (IOF/tarifa fora do líquido) entram no custo.
- **P1-5** 1 vencimento por operação; lote → `fluxo_nao_suportado`; rollover via `operacao_origem_id`.

### Revisão adversarial do Codex no código (xhigh) — 0 P0, 5 P1 + 2 P2, **todos endereçados**
- **P1-a** input inválido (`'abc'`) virava `0` silencioso → parser tri-state (inválido→NaN, degrada).
- **P1-b** hurdle `NaN` → veredito `dentro` falso → guard `Number.isFinite && >= 0`.
- **P1-c** reconstrução por taxa usava `base=(face+avulsos)` e **subcontava** o custo → `face/(1+tp)` (taxa incide sobre a face; avulsos à parte).
- **P1-d** tolerância de reconciliação 0,5% escondia conflito de centenas de R$ → tolerância de arredondamento.
- **P1-e** lote escapava pelo checkbox default-false → **fluxo obrigatório 3-vias** (sem default); rollover exposto com picker de origem.
- **P2-a** soft-delete invalidava cache da empresa errada → usa `excluindo.company`.
- **P2-b** prova PG17 +4 dentes (avulsos<0, líquido≤0, dedup banco-NULL, dedup pós-soft-delete).

### Decisões
- `nominal_aa` = linear/proporcional (a UI rotula "nominal/linear"). `coalesce(banco,'')` na dedup. **Follow-up v1.1** (deferido — migration committada é imutável): normalizar `lower(btrim(banco))` no índice de dedup.
- **Página dedicada** (não aba) espelhando o F1 — F4 é CRUD-pesado idêntico.

### Provas (verdes)
`heavy bun run test` **4663/4663** · helper F4 **36/36** · `db/test-fin-antecipacoes.sh` **18/18** (falsificação in-harness + meta-falsificação da migration) · typecheck 0 · lint 0 erros · build OK.

### ⚠️ Pendências do founder DEPOIS do merge (Lovable = deploy manual)
1. 🟣 **SQL Editor:** aplicar `supabase/migrations/20260708120000_fin_antecipacoes.sql` (empacoto via `lovable-db-operator` + query de validação).
2. 🖱️ **Publish frontend** (Lovable) — nova rota/página. **Sem edge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
