### PR TITLE
chore(audit): registra fin_antecipacoes (F4) no inventário de migrations

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **340** custom migrations totais
-- **1212** objetos esperados (criados por estas migrations)
+- **341** custom migrations totais
+- **1220** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 341
-  - `rls_policy`: 266
-  - `index`: 204
+  - `function`: 342
+  - `rls_policy`: 269
+  - `index`: 206
   - `cron_job`: 144
-  - `table`: 131
-  - `trigger`: 67
+  - `table`: 132
+  - `trigger`: 68
   - `view`: 55
   - `enum_value`: 4
 
@@ -2913,6 +2913,19 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260707120000_seed_fin_dre_custo_tipo_oben.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260708120000_fin_antecipacoes.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.fin_antecipacoes_set_autor` | — |
+| `table` | `public.fin_antecipacoes` | — |
+| `index` | `public.fin_antecipacoes_ref_uq` | `fin_antecipacoes` |
+| `index` | `public.idx_fin_antecipacoes_company_viva` | `fin_antecipacoes` |
+| `trigger` | `public.trg_fin_antecipacoes_autor` | `fin_antecipacoes` |
+| `rls_policy` | `public.fin_antecipacoes_select_master` | `fin_antecipacoes` |
+| `rls_policy` | `public.fin_antecipacoes_write_master` | `fin_antecipacoes` |
+| `rls_policy` | `public.fin_antecipacoes_service_all` | `fin_antecipacoes` |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 340
+-- Total de custom migrations: 341
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -379,7 +379,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260704190500', 'fin_regua_condicao_prazo', '20260704190500_fin_regua_condicao_prazo.sql'),
   ('20260705120000', 'fin_dre_custo_tipo', '20260705120000_fin_dre_custo_tipo.sql'),
   ('20260705211043', 'omie_identidade_por_conta', '20260705211043_omie_identidade_por_conta.sql'),
-  ('20260707120000', 'seed_fin_dre_custo_tipo_oben', '20260707120000_seed_fin_dre_custo_tipo_oben.sql')
+  ('20260707120000', 'seed_fin_dre_custo_tipo_oben', '20260707120000_seed_fin_dre_custo_tipo_oben.sql'),
+  ('20260708120000', 'fin_antecipacoes', '20260708120000_fin_antecipacoes.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1582,7 +1583,15 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_select_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_write_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo'),
-  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', '')
+  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', ''),
+  ('fin_antecipacoes', 'function', 'public', 'fin_antecipacoes_set_autor', ''),
+  ('fin_antecipacoes', 'table', 'public', 'fin_antecipacoes', ''),
+  ('fin_antecipacoes', 'index', 'public', 'fin_antecipacoes_ref_uq', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'index', 'public', 'idx_fin_antecipacoes_company_viva', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'trigger', 'public', 'trg_fin_antecipacoes_autor', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_select_master', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_write_master', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_service_all', 'fin_antecipacoes')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2833,7 +2842,15 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_select_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_write_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo'),
-  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', '')
+  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', ''),
+  ('fin_antecipacoes', 'function', 'public', 'fin_antecipacoes_set_autor', ''),
+  ('fin_antecipacoes', 'table', 'public', 'fin_antecipacoes', ''),
+  ('fin_antecipacoes', 'index', 'public', 'fin_antecipacoes_ref_uq', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'index', 'public', 'idx_fin_antecipacoes_company_viva', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'trigger', 'public', 'trg_fin_antecipacoes_autor', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_select_master', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_write_master', 'fin_antecipacoes'),
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_service_all', 'fin_antecipacoes')
 )
 SELECT
   e.migration,


### PR DESCRIPTION
Follow-up do #1235 (Passo 6 do ritual lovable-db-operator). Regenera `docs/migrations-audit.md` + `scripts/audit-custom-migrations.sql` via `bun run audit:migrations` pra incluir os objetos da migration `fin_antecipacoes` no cross-check. Só docs/audit — não toca banco nem código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)