### PR TITLE
docs(skill): lovable-deploy-verify — assinatura de ausência p/ marca não-única + controle positivo (esteira #1232)

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -132,6 +132,13 @@ num comentário → falso "ausente", não prova nada). Duas saídas:
   #1215): `variant:"detail"` presente (o `<PageSkeleton>` novo) **+** `animate-spin` ausente (o
   `<Loader2>` que saiu). Pela atomicidade do Publish (build da `main` inteira), 1 página provada ⇒ o
   lote todo no ar.
+  - **Marca removida não-única** (componente eager / classe Tailwind reusada em chunks lazy): a ausência
+    **global** não prova nada. Ancore o chunk-alvo pela string renderizada única do mesmo fluxo (a *Calibrar*
+    acima, como localizador) e valide as TRÊS no MESMO chunk: (i) marca removida ausente, (ii) unicidade dela
+    naquele escopo provada antes (`git grep` no commit pai), (iii) um **controle positivo irmão** ainda
+    presente — senão chunk vazio / leitura quebrada lê como "removido". Ex. #1232 (spinner→skeleton no
+    `ProtectedRoute` eager): `animate-spin text-primary`=0 (removido) **+** `animate-spin text-muted-foreground`≥1
+    (gates vizinhos intocados = controle).
 
 ⚠️ Guard embutido (exit 2): contagem 0/1 = enumeração quebrada (formato do bundler/Workbox mudou) —
 NÃO conclua "não está no ar"; conserte o script primeiro. Os bytes provam que o **código subiu**; se a


### PR DESCRIPTION
## O quê

`.claude/skills/lovable-deploy-verify/SKILL.md` — Passo 4 (verificação de deploy por bytes do bundle).

O padrão (2) "assinatura estrutural" assumia a marca de remoção **única globalmente**. No #1232 (spinner→skeleton no `ProtectedRoute`, componente **eager**) isso quebrou: a className removida (`animate-spin text-primary`) aparecia em **13 telas lazy** — varrer todos os chunks e achá-la não prova nada.

## A nuance acrescentada (1 sub-item, +7 linhas)

Para marca de remoção **não-única**:
1. Ancorar o chunk-alvo pela **string renderizada única** do mesmo fluxo (reusa a saída "Calibrar" como localizador).
2. Validar as **três** no MESMO chunk: (i) marca removida ausente, (ii) unicidade dela **naquele escopo** provada antes (`git grep` no commit pai), (iii) um **controle positivo irmão** presente — senão chunk vazio / leitura quebrada lê como "removido".

Ex. #1232: `animate-spin text-primary`=0 (removido) **+** `animate-spin text-muted-foreground`≥1 (gates vizinhos intocados = controle).

## Procedência

Decisão via ritual `/codex` (2ª opinião, gpt-5.5, reasoning high): **cross-model agreement** — ambos "registra, 1 frase no padrão (2), não seção". O Codex tornou explícita a condição (ii) unicidade-no-escopo, que o rascunho inicial deixava implícita.

Doc-only (a skill ship do repo direto): **sem** Publish, **sem** edge, **sem** migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
