### PR TITLE
fix(reposicao): fila estoque-não-confirmado ancora no ÚLTIMO run do motor

### DIFF
--- a/db/test-gate-estoque-nao-confirmado.sh
+++ b/db/test-gate-estoque-nao-confirmado.sh
@@ -63,6 +63,9 @@ CREATE TABLE public.pedido_compra_item (id bigserial PRIMARY KEY, pedido_id bigi
   estoque_fisico numeric, estoque_a_caminho numeric);
 CREATE TABLE public.reposicao_estoque_nao_confirmado_log (id uuid DEFAULT gen_random_uuid(), run_id uuid, criado_em timestamptz DEFAULT now(),
   empresa text, sku_codigo_omie text, sku_descricao text, grupo_codigo text, motivo text, estoque_efetivo numeric, ponto_pedido numeric, fonte_sync text);
+-- [FILA] marcador de run: a RPC carimba TODO run (limpo ou não) → a tela ancora no ÚLTIMO recálculo.
+CREATE TABLE public.reposicao_motor_run (id uuid DEFAULT gen_random_uuid(), run_id uuid, empresa text, data_ciclo date,
+  pedidos_gerados int, skus_incluidos int, suprimidos_n int, criado_em timestamptz DEFAULT now());
 SQL
 
 # ── ZONA 2: aplicar a função REAL (fixture viva = galão+gate) ──
@@ -134,6 +137,7 @@ G="s.status='pendente_aprovacao' AND COALESCE(s.tipo_ciclo,'normal')='normal'"
 conta()     { Pq -c "SELECT count(*) FROM pedido_compra_item i JOIN pedido_compra_sugerido s ON s.id=i.pedido_id WHERE i.sku_codigo_omie='$1' AND $G;"; }
 log_conta() { Pq -c "SELECT count(*) FROM reposicao_estoque_nao_confirmado_log WHERE sku_codigo_omie='$1';"; }
 log_motivo(){ Pq -c "SELECT motivo FROM reposicao_estoque_nao_confirmado_log WHERE sku_codigo_omie='$1' LIMIT 1;"; }
+marker_n()  { Pq -c "SELECT count(*) FROM reposicao_motor_run;"; }
 
 echo "── asserts (regra verdadeira) ──"
 P -q -c "TRUNCATE reposicao_estoque_nao_confirmado_log;"
@@ -164,12 +168,21 @@ eq "C7 âncora não logou"         "$(log_conta '300001')" "0"
 # total logado = C1 + C4 + C6
 eq "log total = 3"               "$(Pq -c 'SELECT count(*) FROM reposicao_estoque_nao_confirmado_log;')" "3"
 
+# ── [MARCADOR DE RUN] a fila ancora no ÚLTIMO recálculo, não no último COM supressão ──
+echo "── marcador de run (fila) ──"
+# M1 — o run 1 (acima) teve 3 supressões → carimba 1 linha em reposicao_motor_run com suprimidos_n=3
+eq "M1 marker do run existe"     "$(Pq -c 'SELECT count(*) FROM reposicao_motor_run;')" "1"
+eq "M1 suprimidos_n=3"           "$(Pq -c 'SELECT suprimidos_n FROM reposicao_motor_run;')" "3"
+eq "M1 pedidos_gerados coerente" "$(Pq -c 'SELECT (pedidos_gerados > 0)::int FROM reposicao_motor_run;')" "1"
+# run_id do marcador == run_id do log (mesma execução carimbou os dois)
+eq "M1 run_id casa o log"        "$(Pq -c 'SELECT count(*) FROM reposicao_motor_run r WHERE r.run_id = (SELECT run_id FROM reposicao_estoque_nao_confirmado_log LIMIT 1);')" "1"
+
 # ── ZONA 5: FALSIFICAÇÃO (sabota → exige VERMELHO → restaura) ──
 echo "── falsificação ──"
 falsify() { # $1 desc | $2 sed-expr | $3 SQL-valor (eval) | $4 valor_são (deve MUDAR após sabotar)
   sed "$2" "$MIG" > /tmp/mig-gate-sab.sql
   P -q -f /tmp/mig-gate-sab.sql >/dev/null
-  P -q -c "TRUNCATE reposicao_estoque_nao_confirmado_log;" >/dev/null
+  P -q -c "TRUNCATE reposicao_estoque_nao_confirmado_log, reposicao_motor_run;" >/dev/null
   run_ciclo
   local got; got="$(eval "$3")"
   if [ "$got" != "$4" ]; then ok "FALSIFY $1 (são=$4 → furado=$got)"; else bad "FALSIFY $1 — assert SEM DENTE (seguiu $4)"; fi
@@ -192,6 +205,23 @@ falsify "suprime-tudo" \
 falsify "inativo-vota" \
   's/AND COALESCE(ssg.ativo_no_omie, true) = true//' \
   'conta 300001' "1"
+# FAL5 — marker-off: remove o INSERT do carimbo → reposicao_motor_run fica VAZIO (a fila perderia a âncora do run)
+falsify "marker-off" \
+  '/INSERT INTO public.reposicao_motor_run/,/v_run_id));/d' \
+  'marker_n' "1"
+
+# ── [MARCADOR DE RUN] M2 — run LIMPO apaga o fantasma (o conserto do bug reportado) ──
+echo "── marcador: run limpo apaga o fantasma ──"
+P -q -c "TRUNCATE reposicao_estoque_nao_confirmado_log, reposicao_motor_run;" >/dev/null
+run_ciclo   # run A: 3 supressões (estado original dos seeds: C1 linha, C4 galão, C6 sea-ausente)
+P -q -c "UPDATE sku_estoque_atual SET fonte_sync='ListarPosEstoque' WHERE sku_codigo_omie IN ('100001','200002');" >/dev/null
+P -q -c "INSERT INTO sku_estoque_atual (empresa,sku_codigo_omie,estoque_fisico,estoque_pendente_entrada,fonte_sync) VALUES ('OBEN','100006',0,0,'ListarPosEstoque');" >/dev/null
+run_ciclo   # run B: LIMPO — o sync confirmou os 3
+eq "M2 dois markers (A+B)"       "$(marker_n)" "2"
+eq "M2 run limpo tem n=0"        "$(Pq -c 'SELECT count(*) FROM reposicao_motor_run WHERE suprimidos_n=0;')" "1"
+eq "M2 run A mantém n=3"         "$(Pq -c 'SELECT count(*) FROM reposicao_motor_run WHERE suprimidos_n=3;')" "1"
+# a FILA ancorada no ÚLTIMO run (limpo) fica VAZIA: nenhuma linha de log pertence a um run com suprimidos_n=0
+eq "M2 fila do último=vazia"     "$(Pq -c 'SELECT count(*) FROM reposicao_estoque_nao_confirmado_log l JOIN reposicao_motor_run r ON r.run_id=l.run_id WHERE r.suprimidos_n=0;')" "0"
 
 echo "──────────────────────────────"
 echo "RESULTADO: $PASS ok / $FAIL fail"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **341** custom migrations totais
-- **1220** objetos esperados (criados por estas migrations)
+- **342** custom migrations totais
+- **1225** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 342
-  - `rls_policy`: 269
-  - `index`: 206
+  - `function`: 343
+  - `rls_policy`: 271
+  - `index`: 207
   - `cron_job`: 144
-  - `table`: 132
+  - `table`: 133
   - `trigger`: 68
   - `view`: 55
   - `enum_value`: 4
@@ -2926,6 +2926,16 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `rls_policy` | `public.fin_antecipacoes_select_master` | `fin_antecipacoes` |
 | `rls_policy` | `public.fin_antecipacoes_write_master` | `fin_antecipacoes` |
 | `rls_policy` | `public.fin_antecipacoes_service_all` | `fin_antecipacoes` |
+
+### `20260708171049_reposicao_motor_run_marker.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
+| `table` | `public.reposicao_motor_run` | — |
+| `index` | `public.idx_reposicao_motor_run_empresa_data` | `reposicao_motor_run` |
+| `rls_policy` | `public.reposicao_motor_run_sel` | `reposicao_motor_run` |
+| `rls_policy` | `public.reposicao_motor_run_ins` | `reposicao_motor_run` |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 341
+-- Total de custom migrations: 342
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -380,7 +380,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260705120000', 'fin_dre_custo_tipo', '20260705120000_fin_dre_custo_tipo.sql'),
   ('20260705211043', 'omie_identidade_por_conta', '20260705211043_omie_identidade_por_conta.sql'),
   ('20260707120000', 'seed_fin_dre_custo_tipo_oben', '20260707120000_seed_fin_dre_custo_tipo_oben.sql'),
-  ('20260708120000', 'fin_antecipacoes', '20260708120000_fin_antecipacoes.sql')
+  ('20260708120000', 'fin_antecipacoes', '20260708120000_fin_antecipacoes.sql'),
+  ('20260708171049', 'reposicao_motor_run_marker', '20260708171049_reposicao_motor_run_marker.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1591,7 +1592,12 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('fin_antecipacoes', 'trigger', 'public', 'trg_fin_antecipacoes_autor', 'fin_antecipacoes'),
   ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_select_master', 'fin_antecipacoes'),
   ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_write_master', 'fin_antecipacoes'),
-  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_service_all', 'fin_antecipacoes')
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_service_all', 'fin_antecipacoes'),
+  ('reposicao_motor_run_marker', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_motor_run_marker', 'table', 'public', 'reposicao_motor_run', ''),
+  ('reposicao_motor_run_marker', 'index', 'public', 'idx_reposicao_motor_run_empresa_data', 'reposicao_motor_run'),
+  ('reposicao_motor_run_marker', 'rls_policy', 'public', 'reposicao_motor_run_sel', 'reposicao_motor_run'),
+  ('reposicao_motor_run_marker', 'rls_policy', 'public', 'reposicao_motor_run_ins', 'reposicao_motor_run')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2850,7 +2856,12 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_antecipacoes', 'trigger', 'public', 'trg_fin_antecipacoes_autor', 'fin_antecipacoes'),
   ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_select_master', 'fin_antecipacoes'),
   ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_write_master', 'fin_antecipacoes'),
-  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_service_all', 'fin_antecipacoes')
+  ('fin_antecipacoes', 'rls_policy', 'public', 'fin_antecipacoes_service_all', 'fin_antecipacoes'),
+  ('reposicao_motor_run_marker', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
+  ('reposicao_motor_run_marker', 'table', 'public', 'reposicao_motor_run', ''),
+  ('reposicao_motor_run_marker', 'index', 'public', 'idx_reposicao_motor_run_empresa_data', 'reposicao_motor_run'),
+  ('reposicao_motor_run_marker', 'rls_policy', 'public', 'reposicao_motor_run_sel', 'reposicao_motor_run'),
+  ('reposicao_motor_run_marker', 'rls_policy', 'public', 'reposicao_motor_run_ins', 'reposicao_motor_run')
 )
 SELECT
   e.migration,

--- a/src/components/reposicao/pedidos/__tests__/ultimo-run-suprimido.test.ts
+++ b/src/components/reposicao/pedidos/__tests__/ultimo-run-suprimido.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { selecionarUltimoRunSuprimido } from '../shared';
+
+// Linha do log de estoque-não-confirmado (só os campos que o helper toca).
+const linha = (run_id: string, sku: string) => ({
+  run_id,
+  sku_codigo_omie: sku,
+  motivo: 'linha_seed_only' as const,
+  criado_em: '2026-07-08T09:15:00Z',
+});
+
+describe('selecionarUltimoRunSuprimido — a fila ancora no ÚLTIMO run do motor, não no último COM supressão', () => {
+  // O bug reportado: às 06:15 o run RUN_0615 suprimiu 2 SKUs (log). Depois o sync confirmou o estoque e o
+  // recálculo das 15:15 (RUN_1515) foi LIMPO — não gravou no log. A fila deve refletir RUN_1515 (vazio), não RUN_0615.
+  it('run limpo (marcador suprimidos_n=0): a mensagem SOME — ancora no run limpo, sem linhas no log', () => {
+    const log = [linha('RUN_0615', '8690166141'), linha('RUN_0615', '8689725397')];
+    const { runId, linhas } = selecionarUltimoRunSuprimido({ run_id: 'RUN_1515' }, log);
+    expect(runId).toBe('RUN_1515');
+    expect(linhas).toEqual([]); // ← o conserto: run mais recente não suprimiu → fila vazia mesmo com log de 24h
+  });
+
+  it('marcador aponta run COM supressão: mostra só as linhas daquele run', () => {
+    const log = [linha('RUN_NOVO', 'A'), linha('RUN_ANTIGO', 'B')];
+    const { runId, linhas } = selecionarUltimoRunSuprimido({ run_id: 'RUN_NOVO' }, log);
+    expect(runId).toBe('RUN_NOVO');
+    expect(linhas.map((l) => l.sku_codigo_omie)).toEqual(['A']);
+  });
+
+  it('marcador AUSENTE (1º deploy, ainda não populou): fallback legado = run mais recente do log', () => {
+    const log = [linha('RUN_RECENTE', 'A'), linha('RUN_ANTIGO', 'B')];
+    const { runId, linhas } = selecionarUltimoRunSuprimido(null, log);
+    expect(runId).toBe('RUN_RECENTE');
+    expect(linhas.map((l) => l.sku_codigo_omie)).toEqual(['A']);
+  });
+
+  it('marcador presente mas log vazio (run limpo, sem histórico recente): fila vazia', () => {
+    const { runId, linhas } = selecionarUltimoRunSuprimido({ run_id: 'RUN_LIMPO' }, []);
+    expect(runId).toBe('RUN_LIMPO');
+    expect(linhas).toEqual([]);
+  });
+
+  it('sem marcador e log vazio: runId null, linhas vazias (nada a mostrar)', () => {
+    const { runId, linhas } = selecionarUltimoRunSuprimido(null, []);
+    expect(runId).toBeNull();
+    expect(linhas).toEqual([]);
+  });
+
+  it('não confunde runs: só as linhas do run ancorado (não vaza de outro run do log de 24h)', () => {
+    const log = [
+      linha('RUN_NOVO', 'A1'),
+      linha('RUN_NOVO', 'A2'),
+      linha('RUN_ANTIGO', 'B1'),
+    ];
+    const { linhas } = selecionarUltimoRunSuprimido({ run_id: 'RUN_NOVO' }, log);
+    expect(linhas.map((l) => l.sku_codigo_omie)).toEqual(['A1', 'A2']);
+  });
+});

--- a/src/components/reposicao/pedidos/shared.ts
+++ b/src/components/reposicao/pedidos/shared.ts
@@ -279,6 +279,21 @@ export function particionarAtencao<T extends {
   return { vermelha, abaixoMinimo };
 }
 
+// [FILA estoque-não-confirmado] Seleciona as linhas de supressão do ÚLTIMO recálculo do motor.
+// A fila reflete o resultado do ÚLTIMO run (limpo OU não) — não o último run que TEVE supressão:
+// reposicao_estoque_nao_confirmado_log só grava EXCEÇÕES, então um recálculo limpo pós-sync não deixa rastro
+// e a mensagem "N fora da compra" grudava por até 24h. Ancoramos no run carimbado em reposicao_motor_run.
+//  - marcador com suprimidos_n=0 (run limpo): seu run_id não tem linhas no log → retorna [] (a mensagem SOME). ← o fix
+//  - marcador com supressões: retorna só as linhas daquele run.
+//  - marcador AUSENTE (1º deploy, ainda não populou): fallback legado = run mais recente do log.
+export function selecionarUltimoRunSuprimido<T extends { run_id: string | null }>(
+  ultimoRunMotor: { run_id: string } | null | undefined,
+  supLinhas: readonly T[],
+): { runId: string | null; linhas: T[] } {
+  const runId = ultimoRunMotor?.run_id ?? supLinhas[0]?.run_id ?? null;
+  return { runId, linhas: runId ? supLinhas.filter((s) => s.run_id === runId) : [] };
+}
+
 /* ─── Split (PR5) — esconder o pai da lista ─── */
 //
 // Quando um pedido grande é dividido em chunks, o PAI vira status='split_em_filhos':

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -25,7 +25,7 @@ import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { PedidoSugerido } from '@/components/reposicao/pedidos/types';
-import { EMPRESA, edgeSyncOk, formatBRL, frescorEstoque, interpretarRespostaDisparo, particionarCicloHoje, pedidosVisiveis, resumoSyncRecalc, type RespostaDisparo } from '@/components/reposicao/pedidos/shared';
+import { EMPRESA, edgeSyncOk, formatBRL, frescorEstoque, interpretarRespostaDisparo, particionarCicloHoje, pedidosVisiveis, resumoSyncRecalc, selecionarUltimoRunSuprimido, type RespostaDisparo } from '@/components/reposicao/pedidos/shared';
 import { CycleIndicator } from '@/components/reposicao/pedidos/CycleIndicator';
 import { PedidoRow } from '@/components/reposicao/pedidos/PedidoRow';
 import { StatusComMotivo, PortalBadge } from '@/components/reposicao/pedidos/badges';
@@ -255,10 +255,10 @@ export default function AdminReposicaoPedidos() {
   };
 
   // [GATE estoque-não-confirmado] fila de exceção PÓS-geração: o que o motor EFETIVAMENTE suprimiu, gravado em
-  // reposicao_estoque_nao_confirmado_log pela RPC. O preflight acima é preditivo (antes do Recalcular); esta é a
-  // verdade do último ciclo — sem ela o gate suprime no escuro e vira subcompra invisível (Codex consult 019f0a38).
-  // count exato p/ o total 24h (honesto mesmo com a lista capada em 500); a lista cobre folgado 1 run (OBEN ~64).
-  // Key sob 'pedidos-ciclo' de propósito: syncRecalcMutation invalida ['pedidos-ciclo'] → re-busca após recalcular.
+  // reposicao_estoque_nao_confirmado_log pela RPC (append-only, run-stamped). count exato p/ o total 24h (honesto
+  // mesmo com a lista capada em 500). Key sob 'pedidos-ciclo' de propósito: syncRecalcMutation invalida
+  // ['pedidos-ciclo'] → re-busca após recalcular. A fila ANCORA no último run do motor (reposicao_motor_run, abaixo)
+  // — não no último run COM supressão daqui; senão a mensagem grudava por 24h após o sync confirmar (Codex 2026-07-08).
   const { data: suprimidos } = useQuery({
     queryKey: ['pedidos-ciclo', 'estoque-nao-confirmado-log', EMPRESA],
     queryFn: async () => {
@@ -272,6 +272,26 @@ export default function AdminReposicaoPedidos() {
         .limit(500);
       if (error) throw error;
       return { linhas: data ?? [], total24h: count ?? 0 };
+    },
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
+
+  // [FILA] o ÚLTIMO recálculo do motor (limpo OU com supressão), carimbado em reposicao_motor_run pela RPC. A fila
+  // ancora AQUI: se o último run teve suprimidos_n=0 (sync já confirmou), a mensagem some na hora — em vez de mostrar
+  // o último run que teve supressão, que só grava exceções e ficava preso na janela de 24h. Codex 2026-07-08 (Opção 2).
+  const { data: ultimoRunMotor } = useQuery({
+    queryKey: ['pedidos-ciclo', 'motor-run', EMPRESA],
+    queryFn: async (): Promise<{ run_id: string; suprimidos_n: number; criado_em: string } | null> => {
+      const { data, error } = await supabase
+        .from('reposicao_motor_run' as never)
+        .select('run_id, suprimidos_n, criado_em')
+        .eq('empresa', EMPRESA)
+        .order('criado_em', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (error) throw error;
+      return (data as unknown as { run_id: string; suprimidos_n: number; criado_em: string } | null) ?? null;
     },
     refetchInterval: 60_000,
     staleTime: 30_000,
@@ -334,7 +354,7 @@ export default function AdminReposicaoPedidos() {
       else toast.success(message);
       track('reposicao.sync_recalc_manual', { empresa: EMPRESA, estoqueOk, statusOk, recalculou: recalc?.ok ?? false });
       queryClient.invalidateQueries({ queryKey: ['estoque-frescor'] });
-      queryClient.invalidateQueries({ queryKey: ['estoque-nao-confirmado'] });
+      // 'pedidos-ciclo' cobre por prefixo a fila de suprimidos E o marcador de run (ambos keyed sob ela).
       queryClient.invalidateQueries({ queryKey: ['pedidos-ciclo'] });
       queryClient.invalidateQueries({ queryKey: ['pedido-itens'] });
     },
@@ -413,15 +433,16 @@ export default function AdminReposicaoPedidos() {
     staleTime: 30_000,
   });
 
-  // [GATE estoque-não-confirmado] suprimidos do ÚLTIMO recálculo (reflete os pedidos na tela) + contexto 24h
-  // (crônico?). supLinhas vem ordenado por criado_em desc → [0] é o run mais recente; filtra esse run_id.
+  // [GATE estoque-não-confirmado] suprimidos do ÚLTIMO recálculo do motor (reflete os pedidos na tela) + contexto
+  // 24h (crônico?). ultimoRunId vem do carimbo em reposicao_motor_run (o último recálculo REAL, limpo ou não) — não
+  // de supLinhas[0] (último run do LOG, que só grava exceções → a mensagem grudava 24h). Fallback legado se o
+  // marcador ainda não populou. Run limpo ⇒ ultimoRunId sem linhas no log ⇒ supUltimoRun vazio ⇒ mensagem some.
   const supLinhas = suprimidos?.linhas ?? [];
-  const ultimoRunId = supLinhas[0]?.run_id ?? null;
-  const supUltimoRun = ultimoRunId ? supLinhas.filter((s) => s.run_id === ultimoRunId) : [];
+  const { runId: ultimoRunId, linhas: supUltimoRun } = selecionarUltimoRunSuprimido(ultimoRunMotor, supLinhas);
   const supLinhaQtd = supUltimoRun.filter((s) => s.motivo === 'linha_seed_only').length;
   const supGrupoQtd = supUltimoRun.filter((s) => s.motivo === 'grupo_membro_seed_only').length;
   const supTotal24h = suprimidos?.total24h ?? 0;
-  const ultimoSupEm = supLinhas[0]?.criado_em ?? null;
+  const ultimoSupEm = supUltimoRun[0]?.criado_em ?? null;
 
   // Telemetria: quantos o gate suprimiu por recálculo — detecta sync cronicamente atrasado (Codex consult
   // 019f0a38). A ref garante 1 disparo por run distinto mesmo com o effect reativo a todas as deps (lint-clean).

--- a/supabase/migrations/20260708171049_reposicao_motor_run_marker.sql
+++ b/supabase/migrations/20260708171049_reposicao_motor_run_marker.sql
@@ -1,45 +1,46 @@
--- Migration: embalagem econômica DENTRO do motor de pedidos (QT↔GL) + consolidação de estoque de grupo
--- ⚠️ APLICADA MANUALMENTE no SQL Editor do Lovable em 2026-06-26 (NÃO vai em supabase/migrations/ — CLAUDE.md §5;
---     é CREATE OR REPLACE de função existente). Este arquivo é a FONTE versionada + fixture da regressão db/test-embalagem-motor.sh.
--- Spec: docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
--- Money-path. Recria gerar_pedidos_sugeridos_ciclo (pré-flight pg_get_functiondef feito; base = prod 26/06).
---
--- DUAS mudanças cirúrgicas, tudo o mais PRESERVADO:
---   1) CONSOLIDA o estoque no nível do grupo de equivalência (Σ membros: GREATEST(inv,sea) físico + pendente + trânsito).
---      O gatilho passa a olhar o estoque do GRUPO → para de comprar quando há galão parado.
---   2) ESCOLHE a embalagem mais barata por unidade-base (galão), ESTRITO: só troca o quartinho pelo galão
---      quando AMBOS têm preço-app fresco (≤ N dias) + portal-map + catálogo OK, e o galão é estritamente mais barato/base.
---      Senão mantém o quartinho. Custo da linha do galão = preço-app (R$/embalagem), nunca 0.
---
--- Unidade (cravada em prod): qtde_final = nº de EMBALAGENS do SKU; preco_unitario = R$/embalagem; o disparo
--- consome ceil(qtde_final) direto (fator_conversao=1). Quartinho NÃO é tocado (mantém cmc cru).
--- ⚠️ Case: equivalencia/preço_capturado = lower(empresa); parametros/estoque/fornecedor_externo = empresa (upper).
---
--- Revisão pós-Codex (xhigh) — 6 correções vs. o 1º rascunho:
---   P0-a GREATEST(inventory_position.saldo, sku_estoque_atual): galão parado vive em fontes DIFERENTES por SKU.
---   P0-b em_transito do galão × fator_para_base (2 galões em voo = 8 unidades-base, não 2) → anti double-buy.
---   P1-c âncora NÃO pode ser membro fator>1 (galão) de um grupo → impede 2 linhas do mesmo GL.
---   P1-d anti-duplicidade de oportunidade cobre a âncora E o SKU escolhido (galão).
---   P1-e minimo_forcado_manual respeitado também na troca p/ galão (piso aplicado ANTES de dividir pelo fator).
---   P1-f filtros de catálogo (ativo/tipo 04/família/status omie) aplicados ao MEMBRO escolhido, não só à âncora.
--- Granularidade (P2 Codex, aceito): nº_galões = ceil(necessidade / fator) na escala "unidades-âncora" — NUNCA
---   compra menos que o legado QT (herda o descasamento litros↔embalagem pré-existente, fora de escopo).
---
--- ➕ 2026-06-27 — GATE de estoque-NÃO-CONFIRMADO (money-path; spec 2026-06-27-reposicao-gate-estoque-nao-confirmado).
---   Bug provado: cold-start semeia sku_estoque_atual de omie_products.estoque (82% zerado na OBEN), fonte_sync=
---   'cold_start_seed'. Se o motor roda na janela cold-start→ListarPosEstoque, lê o seed=0 e compra por cima de
---   estoque existente. FIX (Codex consult 019f0968 + ausente≠zero): estoque cuja ÚNICA fonte é cold_start_seed (sem
---   inventory_position) é DESCONHECIDO → o motor SUPRIME a sugestão (nível LINHA e GRUPO) + LOGA em
---   reposicao_estoque_nao_confirmado_log. Zero CONFIRMADO (ListarPosEstoque/0) segue comprando — auto-liberante.
---   ⚠️ Esta fixture é SÓ a função; a tabela de log + RLS vivem na migration formal (e nos harnesses de teste).
---   Migration: supabase/migrations/20260627180000_reposicao_gate_estoque_nao_confirmado.sql (corpo da função idêntico).
---
--- ➕ 2026-07-08 — MARCADOR DE RUN (reposicao_motor_run) — a fila da tela ancora no ÚLTIMO recálculo, NÃO no último
---   recálculo QUE TEVE supressão. Bug: run limpo não grava no log de suprimidos → a mensagem "N fora da compra"
---   grudava por até 24h após o sync já ter confirmado o estoque (Codex 2026-07-08 → Opção 2: fonte-de-verdade, não
---   render). A RPC carimba TODO run (limpo ou não) ao fim; a tela lê o último marker (some quando suprimidos_n=0).
---   Tabela reposicao_motor_run + RLS na migration *_reposicao_motor_run_marker.sql (mesmo padrão do log; corpo idêntico).
+-- ============================================================================
+-- reposicao_motor_run — marcador de execução do motor de reposição (observabilidade da fila)
+-- ============================================================================
+-- A fila "estoque não confirmado" da tela de Pedidos ancorava no run mais recente QUE TEVE supressão
+-- (reposicao_estoque_nao_confirmado_log só grava EXCEÇÕES). Um recálculo LIMPO pós-sync não deixa rastro,
+-- então a mensagem "N SKUs fora da compra" grudava por até 24h após o estoque já ter sido confirmado.
+-- FIX (Codex 2026-07-08, Opção 2 = fonte-de-verdade, não render): a RPC carimba TODO run (limpo ou não)
+-- em reposicao_motor_run; a tela ancora no ÚLTIMO run e a mensagem some quando suprimidos_n=0.
+-- Escrita SÓ pela RPC gerar_pedidos_sugeridos_ciclo (single-writer). RLS espelha o log (20260627180000):
+-- SELECT staff (pode_ver_carteira_completa), INSERT authenticated WITH CHECK true (não aborta a RPC INVOKER).
+-- ⚠️ Recria gerar_pedidos_sugeridos_ciclo JUNTO — corpo IDÊNTICO à fixture db/embalagem-motor-rpc.sql, provado
+--    em db/test-gate-estoque-nao-confirmado.sh (29 asserts + falsificação). Pré-flight: repo==prod 2026-07-08.
+-- ============================================================================
 
+CREATE TABLE IF NOT EXISTS public.reposicao_motor_run (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid NOT NULL,
+  empresa text NOT NULL,
+  data_ciclo date NOT NULL,
+  pedidos_gerados integer NOT NULL DEFAULT 0,
+  skus_incluidos integer NOT NULL DEFAULT 0,
+  suprimidos_n integer NOT NULL DEFAULT 0,
+  criado_em timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reposicao_motor_run_empresa_data
+  ON public.reposicao_motor_run (empresa, criado_em DESC);
+
+ALTER TABLE public.reposicao_motor_run ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS reposicao_motor_run_sel ON public.reposicao_motor_run;
+CREATE POLICY reposicao_motor_run_sel ON public.reposicao_motor_run
+  FOR SELECT TO authenticated
+  USING ((SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS reposicao_motor_run_ins ON public.reposicao_motor_run;
+CREATE POLICY reposicao_motor_run_ins ON public.reposicao_motor_run
+  FOR INSERT TO authenticated WITH CHECK (true);
+
+GRANT SELECT, INSERT ON public.reposicao_motor_run TO authenticated;
+GRANT ALL ON public.reposicao_motor_run TO service_role;
+
+-- ── RPC recriada (corpo idêntico à fixture provada) ──────────────────────────
 CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
  RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)
  LANGUAGE plpgsql


### PR DESCRIPTION
## Problema
A mensagem **"N SKUs fora da compra — estoque não confirmado"** grudava por até **24h** mesmo depois de o sync confirmar o estoque e o motor voltar a comprar (reportado em prod: SUPER REMOVEDOR `8689725397` e BASE MICROTEX `8690166141`).

**Causa (fonte-de-verdade, não render):** a fila lia `reposicao_estoque_nao_confirmado_log` (append-only, só grava exceções) e ancorava no run mais recente **COM supressão**. Um recálculo limpo pós-sync não deixa rastro → o run antigo ficava preso na janela de 24h.

## Fix (Codex Opção 2)
A RPC `gerar_pedidos_sugeridos_ciclo` carimba **TODO** run (limpo ou não) em nova tabela `reposicao_motor_run`; a fila ancora no **último** run e a mensagem some quando `suprimidos_n=0`. Cobre botão **e** cron, sem duplicar o predicado do gate no client.

- **Backend:** tabela `reposicao_motor_run` (RLS espelha o log: SELECT staff, INSERT authenticated) + RPC recriada com `INSERT` aditivo no fim, **fora dos CTEs de decisão** (não altera a compra).
- **Frontend:** helper puro `selecionarUltimoRunSuprimido` + query do marcador (fallback legado se ausente); deadcode órfão limpo.

## Evidência
- **PG17** (`db/test-gate-estoque-nao-confirmado.sh`): 29 asserts + falsificação com dente (FAL5: sem o carimbo o marcador some; M2: run limpo → fila vazia)
- **vitest**: 6/6 do helper + suite **4669/4669** · typecheck 0 · lint 0
- DDL aplica 2× idempotente · pré-voo PROD ok

## ⚠️ Migration manual necessária
Mergear **NÃO** aplica no banco. Aplicar `supabase/migrations/20260708171049_reposicao_motor_run_marker.sql` no **SQL Editor do Lovable** + **Publish** do frontend. Validação pós-apply:

\`\`\`sql
SELECT CASE WHEN
  EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='reposicao_motor_run')
  AND EXISTS (SELECT 1 FROM pg_proc WHERE proname='gerar_pedidos_sugeridos_ciclo' AND pg_get_functiondef(oid) LIKE '%reposicao_motor_run%')
THEN '✅ tabela + carimbo na RPC OK' ELSE '❌ FALTANDO' END AS status;
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)