### PR TITLE
feat(tint): marca cobertura MixMachine ao fim do omie-sync-metadados (corrige na fonte)

### DIFF
--- a/supabase/functions/omie-sync-metadados/index.ts
+++ b/supabase/functions/omie-sync-metadados/index.ts
@@ -154,6 +154,31 @@ async function syncMetadadosAccount(
     { onConflict: "entity_type,account" },
   );
 
+  // Follow-up 3 (spec 2026-06-15-tint-vigia-cobertura): corrigir a cobertura tint
+  // NA FONTE. Só a conta 'oben' tem famílias "Bases/Concentrados MixMachine"; marcar
+  // logo após o sync gravar os produtos fecha a janela de drift ANTES de o watchdog
+  // alertar (o cron diário tint-marcar-bases-diario/jobid 132 segue como rede de
+  // segurança). tint_marcar_bases_mixmachine() é idempotente/aditiva, nunca desmarca.
+  // Falha aqui NÃO pode derrubar o sync (produtos já gravados) → try/catch isolado.
+  let basesTintMarcadas: number | null = null;
+  if (acctValue === "oben") {
+    try {
+      const { data: marcadas, error: tintError } = await db.rpc(
+        "tint_marcar_bases_mixmachine",
+      );
+      if (tintError) throw tintError;
+      basesTintMarcadas = typeof marcadas === "number" ? marcadas : null;
+      console.log(
+        `[metadados ${account}] cobertura tint: ${basesTintMarcadas ?? "?"} base(s)/concentrado(s) marcado(s)`,
+      );
+    } catch (tintError) {
+      console.error(
+        `[metadados ${account}] tint_marcar_bases_mixmachine falhou (sync preservado):`,
+        tintError,
+      );
+    }
+  }
+
   return {
     account: acctValue,
     paginas: totalPaginas,
@@ -161,6 +186,7 @@ async function syncMetadadosAccount(
     inativos: totalInativos,
     classificados: typedCount,
     produto_acabado_04: tipo04Count,
+    bases_tint_marcadas: basesTintMarcadas,
     tempo_ms: Date.now() - t0,
   };
 }


### PR DESCRIPTION
## Follow-up 3 do vigia de cobertura tint — corrige na FONTE

Quando o `omie-sync-metadados` traz uma base/concentrado MixMachine novo (ou reclassificado), grava `familia` mas **não** a marca tint (`is_tintometric`/`tint_type`). Até o cron diário `tint-marcar-bases-diario` (08:00 BRT) rodar, a cobertura fica em drift — e o vigia `tint_cobertura_bases` alertava (auto-curável, mas gerava e-mail recorrente: 2× em 23 dias, sempre self-heal por timing do heartbeat 30min antes do auto-dismiss).

**Fix:** ao fim de `syncMetadadosAccount`, quando a conta é a que popula produtos `oben`, chama a RPC `tint_marcar_bases_mixmachine()` — marca na fonte, fechando a janela **antes** de o watchdog alertar. O cron diário segue como rede de segurança.

### Garantias
- RPC idempotente/aditiva (SECURITY DEFINER, `RETURNS integer`), **nunca desmarca**.
- `try/catch` isolado: falha na marcação **não** derruba o sync (produtos já gravados).
- Só roda quando `acctValue==='oben'` (única conta com famílias MixMachine).

### Validação
- `deno check`: os 3 erros de tipo são **pré-existentes** (supabase-js sem generics → `.upsert` vira `never`), confirmado por `git stash` + check da versão original. Esta mudança **não introduz nenhum**; a linha `db.rpc(...)` type-checa limpo.
- ⚠️ Edge **não** entra no `tsc`/`vitest` do app (Deno) — validação = `deno check` + build do Lovable.

### Deploy (manual, pós-merge)
**Publish/deploy de `omie-sync-metadados` pelo chat do Lovable** (ler `supabase/functions/omie-sync-metadados/index.ts` verbatim). Sem migration, sem frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)