### PR TITLE
feat(customer360): proof-table omie_customer_account_map reconecta identidade por conta (Fatia 3, opção C)

### DIFF
--- a/db/omie_customer_account_map.sql
+++ b/db/omie_customer_account_map.sql
@@ -1,0 +1,42 @@
+-- ⚠️ DESTINO: 🟣 SQL Editor do Lovable (colar → Run). NÃO é auto-aplicada. NÃO vai em supabase/migrations/
+--    (essa pasta é a fonte de DR — o Lovable a materializa após o apply). Este arquivo é o registro
+--    versionado + a fonte do bloco de handoff. Prova: db/test-omie-customer-account-map.sh (PG17, 14/0).
+--
+-- Fatia 3 (opção C) — tabela nova ADITIVA: mapa (user_id, account) -> código Omie do cliente naquela conta.
+-- ADITIVA e REVERSÍVEL. NÃO toca omie_clientes (espelho poluído fica intocado). Populada por re-sync
+-- Omie DOCUMENT-FIRST (casa por profiles.document, nunca por código cross-account).
+-- Vocabulário account ∈ {'oben','colacor','colacor_sc'} = empresa_omie = account de customer_segments/preferred.
+-- Design: docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md
+
+CREATE TABLE IF NOT EXISTS public.omie_customer_account_map (
+  id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id               uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  account               text NOT NULL,
+  omie_codigo_cliente   bigint NOT NULL,
+  omie_codigo_vendedor  bigint,
+  source                text NOT NULL DEFAULT 'document',
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_ocam_account CHECK (account IN ('oben','colacor','colacor_sc')),
+  CONSTRAINT chk_ocam_source  CHECK (source IN ('document','code','manual')),
+  -- um código por (user, conta) e um dono por (código, conta) — impede colisão cross-account no CASAMENTO.
+  CONSTRAINT uq_ocam_user_account   UNIQUE (user_id, account),
+  CONSTRAINT uq_ocam_codigo_account UNIQUE (omie_codigo_cliente, account)
+);
+
+-- lookup dos consumidores: por user_id (todas as contas do cliente). O reverse-map (código->user) e o
+-- casamento (user,conta) já vêm dos UNIQUE acima.
+CREATE INDEX IF NOT EXISTS idx_ocam_user ON public.omie_customer_account_map (user_id);
+
+ALTER TABLE public.omie_customer_account_map ENABLE ROW LEVEL SECURITY;
+
+-- RLS espelha omie_clientes: staff (master/employee) gerencia tudo; o próprio user vê só a sua linha.
+-- authenticated (não public) — anon nunca vê. Edge (service_role) bypassa RLS para o sync.
+CREATE POLICY "Staff can manage account map"
+  ON public.omie_customer_account_map FOR ALL TO authenticated
+  USING (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role))
+  WITH CHECK (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+
+CREATE POLICY "Users can view their own account map"
+  ON public.omie_customer_account_map FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);

--- a/db/test-omie-customer-account-map.sh
+++ b/db/test-omie-customer-account-map.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA da migration Fatia 3 (opção C): omie_customer_account_map ║
+# ║  Tabela nova ADITIVA (user_id, account) -> código Omie. Money-path (identidade  ║
+# ║  de cliente p/ segments/preferred). Rodar:                                      ║
+# ║      bash db/test-omie-customer-account-map.sh > /tmp/t.log 2>&1; echo "exit=$?"║
+# ║  Lei de Ferro: (1) migration REAL; (2) negativo c/ SQLSTATE+re-raise;           ║
+# ║  (3) falsificação → exige VERMELHO → restaura.                                  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5457}"
+SLUG="omie-customer-account-map"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (a migration lê has_role/app_role/user_roles + auth.users)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('master','employee','customer');
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+-- has_role fiel (SECURITY DEFINER como no repo): a RLS da migration chama has_role(auth.uid(), '...').
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $f$
+  SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role)
+$f$;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATION REAL (o .sql que vai VERBATIM pro SQL Editor; não vive em
+# supabase/migrations/ — proibido tocar, snapshot é DR)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="/private/tmp/claude-501/-Users-lucassardenberg-Projetos-afiacao--claude-worktrees-vibrant-davinci-bbc187/cdc5fb94-cdf9-4f6c-b3d2-263bcda6cb9e/scratchpad/f3-migration.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED + GRANT
+# ══════════════════════════════════════════════════════════════════════════════
+# user1=customer multi-conta · user2=customer · user3=master · user4=employee
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222'),
+  ('33333333-3333-3333-3333-333333333333'),
+  ('44444444-4444-4444-4444-444444444444') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('33333333-3333-3333-3333-333333333333','master'),
+  ('44444444-4444-4444-4444-444444444444','employee') ON CONFLICT DO NOTHING;
+INSERT INTO public.omie_customer_account_map(user_id, account, omie_codigo_cliente) VALUES
+  ('11111111-1111-1111-1111-111111111111','oben',    100),
+  ('11111111-1111-1111-1111-111111111111','colacor', 200),
+  ('22222222-2222-2222-2222-222222222222','oben',    300);
+-- migration é --no-privileges (Supabase concede em runtime) → conceder p/ os asserts de RLS lerem.
+-- has_role é SECURITY DEFINER, então não precisa GRANT em user_roles p/ a policy.
+GRANT SELECT ON public.omie_customer_account_map TO authenticated, anon;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts positivos ──"
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map WHERE user_id='11111111-1111-1111-1111-111111111111';")
+eq "A1 multi-conta: user1 tem 2 linhas (oben+colacor)" "$V" "2"
+
+# mesmo código (300) em contas DIFERENTES é permitido (namespaces Omie independentes)
+Pq -c "INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente) VALUES ('22222222-2222-2222-2222-222222222222','colacor',300);" >/dev/null
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map WHERE omie_codigo_cliente=300;")
+eq "A2 código 300 coexiste em oben+colacor (namespaces independentes)" "$V" "2"
+
+echo "── asserts negativos (SQLSTATE + re-raise; sentinela própria) ──"
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente) VALUES ('11111111-1111-1111-1111-111111111111','oben',999);
+  RAISE NOTICE 'NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'UQ_USER_OK'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *UQ_USER_OK*) ok "A3 UNIQUE(user,account) barra 2ª linha na MESMA conta" ;; *NAO_BARROU*) bad "A3 NÃO barrou" ;; *) bad "A3 inesperado: $R" ;; esac
+
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente) VALUES ('33333333-3333-3333-3333-333333333333','oben',100);
+  RAISE NOTICE 'NAO_BARROU';
+EXCEPTION WHEN unique_violation THEN RAISE NOTICE 'UQ_COD_OK'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *UQ_COD_OK*) ok "A4 UNIQUE(codigo,account): 1 dono por código/conta (anti-colisão)" ;; *NAO_BARROU*) bad "A4 NÃO barrou" ;; *) bad "A4 inesperado: $R" ;; esac
+
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente) VALUES ('33333333-3333-3333-3333-333333333333','conta_x',1);
+  RAISE NOTICE 'NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'CHK_ACC_OK'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *CHK_ACC_OK*) ok "A5 CHECK account rejeita fora de {oben,colacor,colacor_sc}" ;; *NAO_BARROU*) bad "A5 NÃO barrou" ;; *) bad "A5 inesperado: $R" ;; esac
+
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente,source) VALUES ('33333333-3333-3333-3333-333333333333','oben',7,'xpto');
+  RAISE NOTICE 'NAO_BARROU';
+EXCEPTION WHEN check_violation THEN RAISE NOTICE 'CHK_SRC_OK'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *CHK_SRC_OK*) ok "A6 CHECK source rejeita valor inválido" ;; *NAO_BARROU*) bad "A6 NÃO barrou" ;; *) bad "A6 inesperado: $R" ;; esac
+
+echo "── asserts RLS (SET ROLE + GUC auth.uid; estado após A2: total=4, user1=2, user2=2) ──"
+OWN=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map;" | tail -1)
+STAFF=$(Pq -c "SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map;" | tail -1)
+EMP=$(Pq -c "SET test.uid='44444444-4444-4444-4444-444444444444'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map;" | tail -1)
+ANON=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.omie_customer_account_map;" | tail -1)
+eq "A7 own-scope: user1 (customer) vê só as próprias" "$OWN" "2"
+eq "A8 staff master vê tudo"    "$STAFF" "4"
+eq "A9 staff employee vê tudo"  "$EMP"   "4"
+eq "A10 anon não vê nada"       "$ANON"  "0"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (sabota → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+# F1: RLS own-scope furada (USING true) → user1 passaria a ver tudo (3 agora, pós-CASCADE de user2)
+TOTAL=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map;")
+P -q <<'SQL'
+DROP POLICY "Users can view their own account map" ON public.omie_customer_account_map;
+CREATE POLICY "Users can view their own account map" ON public.omie_customer_account_map FOR SELECT TO authenticated USING (true);
+SQL
+OWN_SAB=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map;" | tail -1)
+if [ "$OWN_SAB" = "$TOTAL" ] && [ "$OWN_SAB" != "2" ]; then ok "F1 own-scope furado: user1 vê $OWN_SAB (=total) → A7 tem dente"; else bad "F1 sabotei own-scope e user1 vê $OWN_SAB → A7 fraco"; fi
+P -q <<'SQL'
+DROP POLICY "Users can view their own account map" ON public.omie_customer_account_map;
+CREATE POLICY "Users can view their own account map" ON public.omie_customer_account_map FOR SELECT TO authenticated USING (auth.uid() = user_id);
+SQL
+
+# F2: sem UNIQUE(codigo,account) o insert-dup (código 100 em oben p/ outro user) passa
+P -q -c "ALTER TABLE public.omie_customer_account_map DROP CONSTRAINT uq_ocam_codigo_account;"
+if P -q -c "INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente) VALUES ('33333333-3333-3333-3333-333333333333','oben',100);" >/dev/null 2>&1; then
+  ok "F2 sem UNIQUE(codigo,account) o dup passa → A4 tinha dente"
+else bad "F2 droppei o UNIQUE e o insert AINDA falhou → A4 não provava a constraint"; fi
+P -q -c "DELETE FROM public.omie_customer_account_map WHERE user_id='33333333-3333-3333-3333-333333333333' AND account='oben' AND omie_codigo_cliente=100;" >/dev/null 2>&1 || true
+P -q -c "ALTER TABLE public.omie_customer_account_map ADD CONSTRAINT uq_ocam_codigo_account UNIQUE (omie_codigo_cliente, account);"
+
+# F3: sem CHECK account o insert com conta inválida passa
+P -q -c "ALTER TABLE public.omie_customer_account_map DROP CONSTRAINT chk_ocam_account;"
+if P -q -c "INSERT INTO public.omie_customer_account_map(user_id,account,omie_codigo_cliente) VALUES ('33333333-3333-3333-3333-333333333333','conta_x',5);" >/dev/null 2>&1; then
+  ok "F3 sem CHECK account o valor inválido passa → A5 tinha dente"
+else bad "F3 droppei o CHECK e o insert AINDA falhou → A5 não provava o CHECK"; fi
+P -q -c "DELETE FROM public.omie_customer_account_map WHERE account='conta_x';" >/dev/null 2>&1 || true
+P -q -c "ALTER TABLE public.omie_customer_account_map ADD CONSTRAINT chk_ocam_account CHECK (account IN ('oben','colacor','colacor_sc'));"
+
+echo "── CASCADE (por último: deleta user2, não interfere na F1 acima) ──"
+Pq -c "DELETE FROM auth.users WHERE id='22222222-2222-2222-2222-222222222222';" >/dev/null
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map WHERE user_id='22222222-2222-2222-2222-222222222222';")
+eq "A11 ON DELETE CASCADE: apagar user zera o mapa dele" "$V" "0"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md
+++ b/docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md
@@ -43,12 +43,25 @@ Consumidor `omie-vendas-sync` (pedido): `type Account="oben"|"colacor"`; lê o e
 - Funciona hoje (espelho é oben-majority sob `'colacor'`; user cuja linha é colacor_sc → código não casa segments/preferred oben → null honesto).
 - **Gate**: typecheck + test.
 
-### Fatia 3 — re-rótulo + suportar colacor real (migration + prove-sql + Codex)
-- `fetchOmieClienteUserMap:230` account-scoped (doc-match, não code-match cross-account) — Codex #1/#7.
-- `onConflict:'(user_id,empresa_omie)'`; drop `unique_user_omie` (composta já existe como índice).
-- `syncCustomers` seta `empresa_omie=accountToEmpresa(account)`; writers manuais setam `'colacor_sc'` (sem clobber de `'oben'` — só possível pós-composta).
-- Popular colacor via `colacor_vendas`. Reverter defesas 1/2/3 da Fatia 1 (mirror colacor confiável).
-- **Gate**: prove-sql PG17 (drop constraint + onConflict + re-rótulo derivado) com falsificação + Codex challenge.
+### Fatia 3 — **opção C: tabela nova aditiva `omie_customer_account_map`** (migration aditiva + prove-sql + Codex)
+
+> **Decisão (Codex consult high, 2026-07-08): C sobre A e B.** B (proof-table derivada de `sales_orders`) está **morta**: `omie_payload->'cabecalho'->>'codigo_cliente'` só existe em **6 (colacor) + 14 (oben)** pedidos de ~30k → cobre ~17 users (psql-ro). A (re-rótulo in-place do espelho) é arriscada: `DROP unique_user_omie` quebra `onConflict:'user_id'` em ~5 pontos, `.eq('user_id').maybeSingle()` vira 406-ambíguo em `omie-sync`/`omie-cliente`, colisão de linha 'colacor' stale, e o rebuild precisa ser document-first ou casa no user errado. **C é aditiva e reversível**: cria uma tabela nova, não dropa constraint, não muta o espelho poluído, não toca o caminho money-path do pedido (Fatia 1 já o blinda).
+
+**Fonte (igual a A):** re-sync do Omie **por documento** (`profiles.document`, 5276/5276 com doc) — NÃO por código (evita colisão cross-account). Vocabulário `account ∈ {'oben','colacor','colacor_sc'}` = `empresa_omie` (mesmos valores de `customer_segments`/`customer_preferred_items`).
+
+1. **Migration (aditiva, SQL Editor):** `CREATE TABLE omie_customer_account_map (id, user_id→auth.users ON DELETE CASCADE, account text CHECK(∈3), omie_codigo_cliente bigint, omie_codigo_vendedor bigint, source text CHECK('document'|'code'|'manual'), created_at, updated_at)`. `UNIQUE(user_id, account)` + `UNIQUE(omie_codigo_cliente, account)`. RLS ON espelhando `omie_clientes`: Staff ALL (`has_role master|employee`) + user SELECT próprio (`auth.uid()=user_id`). Índice `(user_id)`.
+2. **Sync document-first (edge):** função/modo que enumera `ListarClientes(account)` (reusa paginação do `syncCustomers`), casa por **documento** → `user_id`, upsert `(user_id, account=accountToEmpresa(account), omie_codigo_cliente, omie_codigo_vendedor, source='document')` `onConflict (user_id, account)`. Roda p/ `vendas`(oben)+`colacor_vendas`(colacor)+`servicos`(colacor_sc). Cron próprio ou anexado.
+3. **Consumidores de LEITURA que migram (só 2 arquivos):**
+   - `hooks.ts useCustomerPreferredItems`: de `[]` → lê as linhas da tabela nova por `user_id` (N contas/user) → `.in(códigos)×.in(accounts)` em `customer_preferred_items` + **filtro dos PARES exatos `(código,account)` em memória** (o produto cartesiano do `.in×.in` traz colisão cross-account; o filtro descarta — SEM `.or()` cru, guard-rail CLAUDE.md). **Traz oben E colacor** (preferred tem 523 oben + 979 colacor).
+   - `compare-customer-process`: 2 pontos (segment lookup :229, lookalikes reverse-map :281) trocam `omie_clientes` → `omie_customer_account_map`, mantendo `account='oben'`. `.maybeSingle()` seguro na tabela nova.
+   - (`useCustomerSegments.ts` é localStorage de filtros de UI — NÃO é consumidor da tabela; falso-positivo.)
+4. **Espelho velho `omie_clientes` INTOCADO.** Nada de drop, nada de re-rótulo, nada de deleção.
+
+**Escopo / o que NÃO entra (→ Fatia 4 futura):** o caminho do **PEDIDO** (`omie-vendas-sync`) NÃO migra aqui — continua no espelho velho + Fatia 1. Logo **BUG-2 (oben false-reject no pedido) PERSISTE** como resíduo conhecido (disponibilidade, fail-closed, não perde dinheiro). Fatia 4 migra o pedido p/ a tabela nova, fecha BUG-2 na raiz, reverte a Fatia 1 e aposenta o espelho.
+
+- **Deploy (ordem):** (1) migration aditiva (SQL Editor); (2) edge (sync novo + compare migrado); (3) rodar o sync → popula; (4) validar no banco (psql-ro: cobertura, sem ambiguidade `(user,account)`); (5) Publish frontend (hooks migrado). Aditivo → cada passo é fail-safe (tabela vazia = consumidores degradam a `[]`/null, como hoje).
+- **Gate:** prove-sql PG17 (CREATE TABLE real + RLS sob `SET ROLE authenticated` + GUC; UNIQUE(user,account) e UNIQUE(codigo,account); asserts +/- com SQLSTATE; falsificação: sabotar CHECK/UNIQUE → exigir vermelho) + Codex challenge do diff + typecheck + test.
+- **Codex challenge do diff (2026-07-08, high): sem P1.** Corrigidos os P2: (1) `fetchProfileDocUserMap` fail-closed em documento com 2+ users (ambíguo → não mapeia, afeta espelho E proof-table); (2) `.eq('account','oben')` nas 2 leituras de `customer_segments` no compare (à prova de futuro se surgir segment colacor). **Resíduo P2 aceito:** `UNIQUE(código,account)` pode abortar um chunk de 500 do upsert se um código mudar de dono entre syncs (raro; fail-closed é correto — não sobrescreve; consumidores degradam a vazio, nunca dado errado). P3: filtro de pares do hook é mecanicamente correto (chave dos mesmos campos nos 2 lados).
 
 ## 4. Threat model (Fatia 1)
 - **Prova**: verificação Omie por documento no colacor (fail-closed em ausência/ambiguidade/divergência). Guard oben continua provando wrong-account por rótulos CONFIÁVEIS (`'oben'`/`'colacor_sc'` explícitos), só ignora o default `'colacor'`.
@@ -59,3 +72,5 @@ Consumidor `omie-vendas-sync` (pedido): `type Account="oben"|"colacor"`; lê o e
 - Forçar todo pedido colacor via Omie: **SIM** (gate em "mirror tem colacor" é errado — `'colacor'` é o default envenenado, não prova). Custo: 1 chamada Omie/pedido colacor (infrequente).
 - Re-rotular colacor_sc histórico: **NÃO na Fatia 1** (blind relabel inseguro sob a constraint singular) → Fatia 3.
 - Deploy: Fatia 1 (edge) primeiro; Fatia 3 corrige o sync/relabel; UI a qualquer momento (fail-safe).
+- **Fatia 3 = C (tabela nova aditiva), NÃO A (re-rótulo in-place) nem B (proof-table de `sales_orders`)** — Codex consult high, 2026-07-08. B morta (17 users de cobertura); A arriscada (drop de constraint + `.maybeSingle()` ambíguo + colisão stale + rebuild colisão-inseguro); C aditiva/reversível/sem tocar o money-path do pedido. Fonte de C = re-sync Omie por documento (mesma de A). BUG-2 fica p/ Fatia 4 (migrar o pedido p/ a tabela nova).
+- **Fatia 4 (futura, não agora):** migrar `omie-vendas-sync` p/ ler `omie_customer_account_map` (fecha BUG-1 e BUG-2 na raiz), reverter defesas da Fatia 1, aposentar o espelho `omie_clientes`.

--- a/src/components/customer360/hooks.ts
+++ b/src/components/customer360/hooks.ts
@@ -86,22 +86,45 @@ interface PreferredItem {
   omie_codigo_produto: number;
 }
 
-/** Itens preferidos via Omie. FAIL-CLOSED enquanto a identidade Omie por conta não for resolvível
- *  (Fatia 2 do fix de rótulo — BUG de colisão de namespace). customer_preferred_items é chaveada por
- *  (omie_codigo_cliente, account) da conta de VENDA. O espelho omie_clientes rotula TUDO 'colacor' (o
- *  default que nenhum writer seta), mas é um MIX de código oben (bulk syncCustomers) + colacor_sc
- *  (writers manuais), de numeração INDEPENDENTE que colide entre contas. Casar preferred_items pelo
- *  código do espelho sem account confiável traz item de OUTRO cliente por colisão — provado via
- *  psql-ro (2026-07): filtrar account='oben' casou 100% ERRADO (~20 fichas), 'colacor' 0 match.
- *  Precisão>recall: não exibimos nada até a proof-table (omie_customer_account_map) / re-rótulo por
- *  conta (Fatia 3) casarem por (user_id, account, código). Ver
- *  docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md. */
+/** Itens preferidos via Omie, casados pela proof-table omie_customer_account_map (Fatia 3 do fix de
+ *  rótulo). A tabela nova mapeia (user_id, account) -> código Omie do cliente NAQUELA conta, populada
+ *  DOCUMENT-FIRST pelo sync (sem a colisão de namespace do espelho omie_clientes poluído).
+ *  customer_preferred_items é chaveada por (omie_codigo_cliente, account) da conta de VENDA; casamos
+ *  pelos PARES (código, account) do mapa, cobrindo oben E colacor. Fail-safe (precisão>recall): mapa
+ *  vazio (sync ainda não populou) -> []. NÃO usa .or() cru (guard-rail CLAUDE.md): .in×.in é produto
+ *  cartesiano e traria (código de uma conta × account de outra) por colisão — o filtro de pares
+ *  exatos em memória descarta esses. Ver docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md. */
 export function useCustomerPreferredItems(customerId: string | undefined) {
   return useQuery({
     queryKey: ['c360-preferred', customerId],
     enabled: !!customerId,
     staleTime: 5 * 60_000,
-    queryFn: (): PreferredItem[] => [],
+    queryFn: async (): Promise<PreferredItem[]> => {
+      // 1. mapa (account -> código) do cliente, por conta (tabela nova, account-correta).
+      const { data: maps } = await supabase
+        .from('omie_customer_account_map')
+        .select('account, omie_codigo_cliente')
+        .eq('user_id', customerId!);
+      const pares = (maps ?? []) as Array<{ account: string; omie_codigo_cliente: number }>;
+      if (pares.length === 0) return [];
+
+      const codigos = [...new Set(pares.map((p) => p.omie_codigo_cliente))];
+      const accounts = [...new Set(pares.map((p) => p.account))];
+      const paresValidos = new Set(pares.map((p) => `${p.omie_codigo_cliente}::${p.account}`));
+
+      // 2. preferred_items pelos códigos+contas do cliente; .in×.in (sem interpolar em .or()).
+      const { data } = await supabase
+        .from('customer_preferred_items')
+        .select('product_codigo, product_descricao, familia, order_count, last_ordered_at, account, omie_codigo_produto, omie_codigo_cliente')
+        .in('omie_codigo_cliente', codigos)
+        .in('account', accounts)
+        .order('last_ordered_at', { ascending: false, nullsFirst: false });
+
+      // 3. filtra os PARES EXATOS (código,account) — descarta o cruzamento cartesiano cross-account.
+      return ((data ?? []) as Array<PreferredItem & { omie_codigo_cliente: number }>)
+        .filter((it) => paresValidos.has(`${it.omie_codigo_cliente}::${it.account}`))
+        .slice(0, 10);
+    },
   });
 }
 

--- a/supabase/functions/compare-customer-process/index.ts
+++ b/supabase/functions/compare-customer-process/index.ts
@@ -217,20 +217,20 @@ Deno.serve(async (req) => {
       });
     }
 
-    // 2. Segmento/tags via customer_segments + omie_clientes (cliente atual)
+    // 2. Segmento/tags via customer_segments + omie_customer_account_map (cliente atual)
     let customerSegment: string | null = null;
     let customerTags: string[] = [];
     try {
-      // P0-B follow-up (conta corrigida via Codex): customer_segments é gravado na conta 'oben'
-      // (salvar_segmento_cliente, account default 'oben') — então o código do cliente que CASA com
-      // customer_segments é o da linha OBEN do espelho, NÃO o colacor. Filtra 'oben': hoje 0 linhas
-      // oben → omieMap null → sem segmento (degradação honesta, precisão>recall — melhor que casar
-      // o código colacor_sc por colisão numérica e trazer o segmento de OUTRO cliente).
+      // Fatia 3 do fix de rótulo: casa via a proof-table omie_customer_account_map (account-correta,
+      // populada document-first), não mais o espelho omie_clientes poluído. customer_segments é gravado
+      // na conta 'oben' (salvar_segmento_cliente, account default 'oben') → o código que CASA é o da
+      // conta 'oben' no mapa. Fail-safe: sem linha 'oben' no mapa (sync não populou) → omieMap null →
+      // sem segmento (degradação honesta, precisão>recall — melhor que colisão trazer segmento de OUTRO).
       const { data: omieMap } = await supabase
-        .from('omie_clientes')
+        .from('omie_customer_account_map')
         .select('omie_codigo_cliente')
         .eq('user_id', body.customer_user_id)
-        .eq('empresa_omie', 'oben')
+        .eq('account', 'oben')
         .maybeSingle();
 
       if (omieMap && (omieMap as { omie_codigo_cliente: number }).omie_codigo_cliente) {
@@ -238,6 +238,7 @@ Deno.serve(async (req) => {
           .from('customer_segments')
           .select('segment, tags')
           .eq('omie_codigo_cliente', (omieMap as { omie_codigo_cliente: number }).omie_codigo_cliente)
+          .eq('account', 'oben') // Codex P2: customer_segments é conta 'oben'; escopo à prova de futuro
           .maybeSingle();
         customerSegment = (seg as { segment: string | null } | null)?.segment ?? null;
         customerTags = (seg as { tags: string[] | null } | null)?.tags ?? [];
@@ -263,8 +264,10 @@ Deno.serve(async (req) => {
     let lookalikes: LookalikeRow[] = [];
     const hasFilters = customerTags.length > 0 || customerSegment !== null;
     if (hasFilters) {
+      // Codex P2: escopo à conta 'oben' (customer_segments é gravado na conta oben) — à prova de futuro
+      // se surgirem segments colacor (senão o casamento traria linha de outra conta).
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let candidQ = supabase.from('customer_segments').select('omie_codigo_cliente, segment, tags') as any;
+      let candidQ = supabase.from('customer_segments').select('omie_codigo_cliente, segment, tags').eq('account', 'oben') as any;
       if (customerSegment) candidQ = candidQ.eq('segment', customerSegment);
       if (customerTags.length > 0) candidQ = candidQ.overlaps('tags', customerTags);
       candidQ = candidQ.limit(50);
@@ -272,15 +275,14 @@ Deno.serve(async (req) => {
 
       if (candids && (candids as Array<unknown>).length > 0) {
         const codes = (candids as Array<{ omie_codigo_cliente: number }>).map((c) => c.omie_codigo_cliente);
-        // P0-B follow-up (conta corrigida via Codex): `codes` vêm de customer_segments (conta 'oben'),
-        // então resolvê-los de volta para user_id exige a linha OBEN do espelho (mesmo namespace).
-        // Filtra 'oben': hoje 0 linhas oben → sem lookalikes (honesto); casa certo quando o espelho
-        // oben existir. Filtrar 'colacor' aqui casaria por colisão (user errado) e rejeitaria o
-        // namespace que de fato bate — pior, não melhor.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { data: maps } = await (supabase.from('omie_clientes') as any)
+        // Fatia 3 do fix de rótulo: `codes` vêm de customer_segments (conta 'oben'); resolvê-los de
+        // volta para user_id usa a conta 'oben' do mapa (mesmo namespace), via a proof-table
+        // account-correta. Fail-safe: mapa 'oben' vazio → sem lookalikes (honesto), casa certo quando
+        // o sync popular. (Antes lia o espelho omie_clientes, que colidia namespaces.)
+        const { data: maps } = await supabase
+          .from('omie_customer_account_map')
           .select('user_id, omie_codigo_cliente')
-          .eq('empresa_omie', 'oben')
+          .eq('account', 'oben')
           .in('omie_codigo_cliente', codes);
 
         const candidateUserIds = ((maps as Array<{ user_id: string }> | null) ?? [])

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -250,6 +250,10 @@ async function fetchOmieClienteUserMap(db: SupabaseClient): Promise<Map<number, 
 // Map<documento_normalizado, user_id> de profiles (p/ vincular cliente novo via documento).
 async function fetchProfileDocUserMap(db: SupabaseClient): Promise<Map<string, string>> {
   const map = new Map<string, string>();
+  // Fatia 3 (Codex P2): documento com 2+ profiles (users distintos) é AMBÍGUO — não prova identidade.
+  // Fail-closed: remove do mapa (melhor não vincular que vincular o user ERRADO). Afeta o espelho E a
+  // proof-table document-first — ambos param de mapear docs duplicados (precisão>recall).
+  const ambiguous = new Set<string>();
   const pageSize = 1000;
   let from = 0;
   while (true) {
@@ -262,7 +266,12 @@ async function fetchProfileDocUserMap(db: SupabaseClient): Promise<Map<string, s
     const rows = (data ?? []) as { document: string | null; user_id: string | null }[];
     for (const r of rows) {
       const d = (r.document ?? "").replace(/\D/g, "");
-      if (d && r.user_id && !map.has(d)) map.set(d, r.user_id); // 1º documento vence (defensivo contra duplicado)
+      if (!d || !r.user_id) continue;
+      if (ambiguous.has(d)) continue;
+      const prev = map.get(d);
+      if (prev === r.user_id) continue;                       // mesma pessoa repetida (idempotente)
+      if (prev) { map.delete(d); ambiguous.add(d); continue; } // 2º user no mesmo doc → ambíguo, fail-closed
+      map.set(d, r.user_id);
     }
     if (rows.length < pageSize) break;
     from += pageSize;
@@ -289,6 +298,18 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       updated_at: string;
     }>();
     const tagsByUser = new Map<string, string[]>();
+    // Fatia 3 (proof-table aditiva omie_customer_account_map): mapa DOCUMENT-FIRST (user_id -> código
+    // Omie NESTA conta). Só vínculo por DOCUMENTO entra — casar por código é cross-account no espelho
+    // poluído e traria o user errado (Codex). account é FIXO neste run (=empresaMap).
+    const empresaMap = accountToEmpresa(account); // vendas->oben, colacor_vendas->colacor, servicos->colacor_sc
+    const accountMapByUser = new Map<string, {
+      user_id: string;
+      account: string;
+      omie_codigo_cliente: number;
+      omie_codigo_vendedor: number | null;
+      source: string;
+      updated_at: string;
+    }>();
     let pagina = 1;
     let totalPaginas = 1;
 
@@ -319,6 +340,20 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
           .map((t) => (typeof t === "string" ? t : (t.tag ?? "")))
           .filter((t) => t.length > 0);
         tagsByUser.set(userId, tags);
+
+        // Fatia 3 (proof-table): DOCUMENT-FIRST — só quem casa por DOCUMENTO entra no mapa por conta
+        // (código seria cross-account no espelho poluído → user errado, Codex). account fixo = empresaMap.
+        const userIdByDoc = userByDoc.get(doc);
+        if (userIdByDoc) {
+          accountMapByUser.set(userIdByDoc, {
+            user_id: userIdByDoc,
+            account: empresaMap,
+            omie_codigo_cliente: c.codigo_cliente_omie,
+            omie_codigo_vendedor: c.codigo_vendedor || null,
+            source: "document",
+            updated_at: new Date().toISOString(),
+          });
+        }
       }
 
       console.log(`[Sync ${account}] Clientes página ${pagina}/${totalPaginas}`);
@@ -335,6 +370,20 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (upErr) throw new Error(`upsert omie_clientes: ${upErr.message}`);
       totalSynced += chunk.length;
     }
+
+    // Fatia 3 (proof-table ADITIVA): upsert em omie_customer_account_map por (user_id, account). NÃO
+    // toca omie_clientes (o espelho poluído fica intocado) — esta tabela é a fonte account-correta dos
+    // consumidores de leitura. onConflict composto = uq_ocam_user_account; UNIQUE(código,account) barra
+    // colisão cross-account no casamento. document-first → dedup por user_id basta (account é fixo).
+    const mapRows = Array.from(accountMapByUser.values());
+    for (let i = 0; i < mapRows.length; i += 500) {
+      const chunk = mapRows.slice(i, i + 500);
+      const { error: mapErr } = await db
+        .from("omie_customer_account_map")
+        .upsert(chunk, { onConflict: "user_id,account" });
+      if (mapErr) throw new Error(`upsert omie_customer_account_map: ${mapErr.message}`);
+    }
+    console.log(`[Sync ${account}] proof-table omie_customer_account_map: ${mapRows.length} vínculos por documento`);
 
     // Upsert das tags em cliente_classificacao (prova se o ListarClientes em lote retorna tags).
     // Grava user_id + tags_omie + tags_synced_at; as colunas derivadas (is_fornecedor,


### PR DESCRIPTION
## Problema (colisão de namespace, money-path de identidade)

O espelho `omie_clientes` rotula tudo `'colacor'` (default nunca-setado) mas é um MIX de código **oben** (bulk sync) + **colacor_sc** (writers manuais), de numeração **independente que colide entre contas**. Os consumidores de leitura (`customer_segments`, `customer_preferred_items`, chaveados por `(omie_codigo_cliente, account)`) não conseguiam casar por conta sem trazer dado de **outro cliente** por colisão. Fatia 2 deixou `useCustomerPreferredItems` fail-closed (`[]`); esta fatia **reconecta** de forma correta.

## Decisão: opção C (Codex consult high, 2026-07-08)

| Opção | Veredito |
|---|---|
| **B** proof-table de `sales_orders` | ❌ **morta** — código só existe em 6+14 pedidos de ~30k (~17 users) |
| **A** re-rótulo in-place do espelho | ⚠️ arriscada — `DROP unique_user_omie` quebra `onConflict:'user_id'` em ~5 pontos, `.maybeSingle()` vira 406-ambíguo, colisão de linha stale |
| **C** tabela nova aditiva (esta) | ✅ **aditiva e reversível** — não dropa constraint, não muta o espelho, não toca o pedido |

## O que muda (5 arquivos)

- **`db/omie_customer_account_map.sql`** → 🟣 **SQL Editor** (aditiva; não vai em `supabase/migrations/`). `(user_id, account) → código`, `UNIQUE(user,account)` + `UNIQUE(código,account)` anti-colisão, RLS (staff ALL, user vê a própria; authenticated), FK CASCADE.
- **`omie-analytics-sync`** → `syncCustomers` também popula a tabela nova **document-first** (só `userByDoc`, nunca por código — evita cross-account), `onConflict (user_id,account)`. Espelho velho intocado.
- **`hooks.ts`** `useCustomerPreferredItems`: `[]` → lê o mapa por `user_id` (N contas) → `.in(códigos)×.in(accounts)` + **filtro dos PARES exatos `(código,account)`** (descarta o cartesiano cross-account; **sem `.or()` cru**). Traz oben E colacor.
- **`compare-customer-process`**: 2 leituras migram de `omie_clientes.eq(empresa_omie,oben)` → `omie_customer_account_map.eq(account,oben)`.
- **`types.ts`**: tipos da tabela nova.

## Prova (money-path)

- **prove-sql PG17 VERDE 14/0** (`db/test-omie-customer-account-map.sh`): asserts +/- com SQLSTATE, RLS sob `SET ROLE authenticated` + GUC, **falsificação F1/F2/F3 com dente** (sabotei RLS own-scope, `UNIQUE(código,account)` e `CHECK account` → cada assert virou vermelho).
- `heavy bun run typecheck` = 0 · `heavy bun run test` = **verde**
- **Codex challenge do diff (high): SEM P1.** P2 corrigidos no diff: (1) `fetchProfileDocUserMap` **fail-closed** em documento ambíguo (2+ users no mesmo doc → não mapeia); (2) `.eq('account','oben')` nas 2 leituras de `customer_segments`. Resíduo P2 aceito: `UNIQUE(código,account)` pode abortar 1 chunk se um código mudar de dono entre syncs (raro, fail-closed — nunca dado errado).

## ⚠️ Escopo — o que NÃO entra (→ Fatia 4 futura)

O caminho do **PEDIDO** (`omie-vendas-sync`) **NÃO migra** — continua no espelho + defesa da Fatia 1. Logo **BUG-2** (oben false-reject no pedido) **persiste** como resíduo conhecido (disponibilidade, fail-closed, **não perde dinheiro**). Fatia 4 migra o pedido, fecha BUG-2 na raiz, reverte a Fatia 1 e aposenta o espelho.

## ⚠️ Deploy PENDENTE (manual, Lovable — nesta ORDEM, APÓS o merge)

1. 🟣 **SQL Editor**: aplicar `db/omie_customer_account_map.sql` (aditiva)
2. 💬 **chat do Lovable**: deploy das edges `omie-analytics-sync` + `compare-customer-process` (verbatim)
3. 💬 **rodar o sync** das 3 contas: `{action:'sync_customers', account:'vendas'}`, depois `'colacor_vendas'`, depois `'servicos'` → popula a tabela
4. 🔎 **validar** no banco (cobertura por conta, sem ambiguidade `(user,account)`)
5. 🖱️ **Publish** do frontend (hooks migrado)

Aditivo → cada passo é fail-safe: tabela vazia (antes do sync) → hooks `[]` e compare `null`, **idêntico ao comportamento de hoje**. **Merge na main ≠ produção.**

Design: `docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md` · Fatias anteriores: #1227 (1), #1233 (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
