### PR TITLE
docs(self-service): PR0.2b (RPC de preço) adiado — comprador solicita cotação

### DIFF
--- a/docs/superpowers/plans/2026-07-08-self-service-comprador-fase0-plano.md
+++ b/docs/superpowers/plans/2026-07-08-self-service-comprador-fase0-plano.md
@@ -171,7 +171,7 @@ COMMIT;
 
 **DIVIDIDO em 2 (o preço é o ponto de maior risco — merece foco isolado):**
 - **✅ PR0.2a — as 3 views-gate** (EXECUTADO 2026-07-08): `20260708212123_selfservice_pr02a_views_customer.sql` + `db/test-selfservice-pr02a-views.sh` **VERDE 16/16** (isolamento A×B, projeção sem valor_unitario/saldo/cmc/omie_payload, gate fecha não-habilitado, anon barrado, falsificação com dente). Codex xhigh incorporado: **#5** `account = ANY(accounts)` em `meus_pedidos` (senão pedido do PRÓPRIO cliente em conta não-habilitada vaza) + **#6** grants fail-closed (`REVOKE FROM PUBLIC,anon,authenticated`). ⏳ a aplicar via SQL Editor.
-- **⏳ PR0.2b — RPC `selfservice_preco_produto`** (Step 2 abaixo): a peça delicada (número final sem rederivar CMC; reusa `resolve_markup_policy`, NÃO `get_regua_preco`). Sessão dedicada recomendada.
+- **⏸️ PR0.2b — RPC de preço: ADIADO (decisão do founder, 2026-07-08).** O pré-flight revelou que NÃO existe "preço final do cliente" pronto: `get_regua_preco` é staff-only e só **assessora** a vendedora (mostra `cmc`, piso `cmc/(1-aliquota)`, comparáveis); o preço é DECIDIDO na venda assistida (`order_items.unit_price`). `resolve_markup_policy` devolve markups sobre o custo → qualquer preço automático seria **oráculo de CMC**. Expor um número de preço é decisão COMERCIAL, não técnica. Decisão: o comprador vê catálogo/disponibilidade/histórico (PR0.2a, no ar) e **solicita cotação** (a vendedora precifica) — como a spec/Codex recomendaram ("não começar por pedido/preço direto"). A RPC de preço volta quando definirmos recompra-reprecificada / pedido-direto (Fases 1+/3).
 
 **Files:**
 - Create: `supabase/migrations/20260708HHMMSS_selfservice_pr02_views_customer.sql`


### PR DESCRIPTION
Registra a decisão do founder (2026-07-08): a RPC de preço automática sai do escopo da Fase 0. O pré-flight mostrou que não há preço-final pronto (get_regua_preco é staff-only e assessora com cmc/piso/comparáveis; o preço é decidido na venda assistida) e que markup sobre custo faria o número virar oráculo de CMC. O comprador usa o catálogo/disponibilidade/histórico (PR0.2a, já no ar) e **solicita cotação**; a RPC volta com recompra/pedido-direto. Só doc — sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)