### PR TITLE
fix(vendas): sync só mantém o espelho omie_clientes na conta oben (Fatia 4)

### DIFF
--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -361,14 +361,22 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
     }
 
     // Bulk upsert em chunks (onConflict user_id = unique_user_omie). empresa_omie NÃO é setado
-    // (preserva o default 'colacor' do comportamento anterior — fora do escopo deste fix).
+    // (preserva o default 'colacor' do comportamento anterior).
+    // Fatia 4 (money-path, Codex): SÓ 'vendas'(oben) mantém o espelho legado omie_clientes. Este
+    // upsert é CODE-FIRST (userByCodigo do espelho poluído vence o documento) e sem empresa_omie —
+    // para contas não-oben ele SOBRESCREVERIA (last-wins, 1 linha/user) a linha de um cliente
+    // multi-conta com o código de OUTRA conta, corrompendo o espelho que readers legados ainda leem
+    // (sync_pedidos sem filtro de conta, carteira-rebuild/ai-ops-agent via vendedor, hooks de UI). As
+    // demais contas alimentam SÓ a proof-table document-first (account-correta) abaixo.
     const rows = Array.from(upsertByUser.values());
     let totalSynced = 0;
-    for (let i = 0; i < rows.length; i += 500) {
-      const chunk = rows.slice(i, i + 500);
-      const { error: upErr } = await db.from("omie_clientes").upsert(chunk, { onConflict: "user_id" });
-      if (upErr) throw new Error(`upsert omie_clientes: ${upErr.message}`);
-      totalSynced += chunk.length;
+    if (account === "vendas") {
+      for (let i = 0; i < rows.length; i += 500) {
+        const chunk = rows.slice(i, i + 500);
+        const { error: upErr } = await db.from("omie_clientes").upsert(chunk, { onConflict: "user_id" });
+        if (upErr) throw new Error(`upsert omie_clientes: ${upErr.message}`);
+        totalSynced += chunk.length;
+      }
     }
 
     // Fatia 3 (proof-table ADITIVA): upsert em omie_customer_account_map por (user_id, account). NÃO
@@ -384,16 +392,22 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (mapErr) throw new Error(`upsert omie_customer_account_map: ${mapErr.message}`);
     }
     console.log(`[Sync ${account}] proof-table omie_customer_account_map: ${mapRows.length} vínculos por documento`);
+    // Fatia 4: para contas não-oben o espelho não é tocado; o "sincronizado" reportado é a proof-table.
+    if (account !== "vendas") totalSynced = mapRows.length;
 
     // Upsert das tags em cliente_classificacao (prova se o ListarClientes em lote retorna tags).
     // Grava user_id + tags_omie + tags_synced_at; as colunas derivadas (is_fornecedor,
     // excluir_da_carteira) ficam com o default da tabela e serão calculadas em outra tarefa.
+    // Fatia 4 (Codex): tags também são chaveadas pelo userId CODE-FIRST (mesmo userByCodigo poluído)
+    // → só 'vendas'(oben) grava, pelas mesmas razões do espelho acima. Não-oben: só a proof-table.
     const tagsNowIso = new Date().toISOString();
-    const tagRows = Array.from(tagsByUser.entries()).map(([user_id, tags_omie]) => ({
-      user_id,
-      tags_omie,
-      tags_synced_at: tagsNowIso,
-    }));
+    const tagRows = account === "vendas"
+      ? Array.from(tagsByUser.entries()).map(([user_id, tags_omie]) => ({
+          user_id,
+          tags_omie,
+          tags_synced_at: tagsNowIso,
+        }))
+      : [];
     for (let i = 0; i < tagRows.length; i += 500) {
       const { error: tagErr } = await db
         .from("cliente_classificacao")


### PR DESCRIPTION
## Problema (money-path, descoberto ao preparar o rollout da Fatia 3)

`syncCustomers` escrevia o espelho legado `omie_clientes` (upsert `onConflict user_id`, **code-first** via `userByCodigo` do espelho poluído, sem `empresa_omie`) para **qualquer** conta. `colacor_vendas`/`servicos` **nunca rodaram** (o cron só roda `vendas`). Rodá-los para popular a proof-table (Fatia 3) **sobrescreveria** (last-wins, 1 linha/user) a linha de **~489 clientes multi-conta** com o código de outra conta, corrompendo o espelho que readers legados ainda leem: `sync_pedidos` (sem filtro de conta), `carteira-rebuild`/`ai-ops-agent` (via vendedor), hooks de UI.

## Fix (edge puro)

Gate as **escritas legadas code-first** para `account === "vendas"` (oben — o único que já roda no cron e cujo namespace não colide consigo mesmo). As demais contas alimentam **só** a proof-table `omie_customer_account_map` (document-first, account-correta, da Fatia 3).

- `omie_clientes` upsert → gated `account==='vendas'`
- `cliente_classificacao` tags upsert → idem (mesmo `userId` code-first)
- proof-table → inalterada (roda p/ todas as contas)
- `total_synced` p/ não-oben → reporta os vínculos da proof-table

## Verificação

- `heavy heavy bun run typecheck` = 0 · `heavy bun run lint` = 0 · `heavy heavy bun run test` = **4704 passed (579 files)**
- **/codex** consult (decisão do rollout: "defer colacor/servicos, run only vendas; gate legacy writes to oben") + challenge do diff → **PASS, sem P1** (idêntico p/ oben; não-oben só escreve a proof-table; sem escrita legada residual). Único P3 cosmético: semântica de `total_synced` p/ não-oben (documentado no código).
- Sem SQL novo → sem prove-sql.

## ⚠️ Deploy PENDENTE (founder, APÓS merge)

- 💬 **chat do Lovable**: deploy `omie-analytics-sync` verbatim da main.
- 💬 Depois: rodar `sync_customers` p/ `vendas`, `colacor_vendas`, `servicos` (agora **seguro** nas 3).
- Sem migration, sem frontend nesta fatia.

Fatias 1 (#1227), 2 (#1233), 3 (#1244). Design: `docs/superpowers/specs/2026-07-07-espelho-omie-rotulo-por-conta-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
