### PR TITLE
fix(financeiro): FOLHA_AMBIGUA marca INSS+IRRF retidos, não o adiantamento (F3 v2)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-f3-rateio-folha-compartilhada-design.md
+++ b/docs/superpowers/specs/2026-07-08-f3-rateio-folha-compartilhada-design.md
@@ -2,6 +2,13 @@
 
 > Extensão do F3 (`2026-07-04-ponto-equilibrio-dre-design.md`). **Fato de negócio** (confirmado pelo founder, 2026-07-08): a folha dos funcionários da OBEN **roda na Colacor SC** (empresa do Simples — os funcionários estão fichados lá). Consequência: a DRE da OBEN **não** carrega o custo de mão de obra que faz a operação da OBEN girar → o PE lido isolado subestima o custo fixo e infla a margem de segurança. **Money-path** (muda o PE): precisão > recall — o rateio é **input humano** (não fabricamos a parcela); sem rateio, o card **vela o número** com aviso, em vez de exibir a margem inflada. Decisão Claude + Lucas (velar nº; valor R$ fixo mensal). Read-only sobre o snapshot: o rateio é um **overlay aditivo**, não reescreve `montarDRE`/edge.
 
+> **⚠️ Errata contábil — 2026-07-09** (Codex+Claude sobre dados de prod, `colacor_sc` TTM competência). A marcação de "ambíguos" da folha usada em §0.3, §6 e §10-C6 estava **errada**; o código foi corrigido (`FOLHA_AMBIGUA` em `usePontoEquilibrio.ts`, pinado em `ponto-equilibrio-folha-ambigua.test.ts`):
+> - O **Adiantamento de Salário (2.03.02) NÃO é ambíguo** — os dados provam que é a **2ª parcela do MESMO salário**: co-ocorre com Salários (2.03.01) todo mês até dez/25 e **some** quando a folha consolidou numa parcela só em jan/26 (2.03.01 sozinho ≈ 2.03.01+2.03.02 dos meses anteriores). É **custo real** → contar, não excluir (excluí-lo subestimava a folha em ~R$4–5,6k/mês).
+> - A retenção do empregado (já embutida no Salário **bruto**, não custo patronal extra no Simples: sem INSS patronal) é o **INSS (2.03.06)** + **IRRF (2.03.08)** — esse é o par marcado agora. FGTS (2.03.07) é custo patronal real e **não** é marcado.
+> - `FOLHA_AMBIGUA = {2.03.06, 2.03.08}` (era `{2.03.02, 2.03.08}`); o rótulo do dialog virou "retenção do empregado (já no salário bruto)".
+>
+> O texto de §0.3/§6/§10-C6 abaixo fica **preservado como registro do entendimento da época**.
+
 ## 0. Achados de banco (aterrados via `psql-ro`, TTM abr/25–mar/26, regime competência)
 
 | # | Fato | Consequência |

--- a/src/components/financeiro/dashboard/RateioFolhaDialog.tsx
+++ b/src/components/financeiro/dashboard/RateioFolhaDialog.tsx
@@ -111,7 +111,7 @@ export function RateioFolhaDialog({
                     {l.descricao || l.codigo}
                     {l.ambiguo && (
                       <span className="ml-1 inline-flex items-center gap-0.5 text-status-warning">
-                        <AlertTriangle className="w-2.5 h-2.5" /> pagamento, não custo econômico
+                        <AlertTriangle className="w-2.5 h-2.5" /> retenção do empregado (já no salário bruto)
                       </span>
                     )}
                   </span>

--- a/src/hooks/__tests__/ponto-equilibrio-folha-ambigua.test.ts
+++ b/src/hooks/__tests__/ponto-equilibrio-folha-ambigua.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { FOLHA_AMBIGUA } from '@/hooks/usePontoEquilibrio';
+
+// FOLHA_AMBIGUA marca, na "referência viva" da folha da CSC (RateioFolhaDialog), os códigos
+// 2.03.* que NÃO são custo patronal EXTRA — são RETENÇÃO do empregado, já embutida no Salário
+// bruto (2.03.01). Na CSC (Simples) não há INSS patronal, então o INSS/IRRF lançados são a parte
+// retida do funcionário; somá-los ao bruto dobraria. O "totalLimpoMes" do dialog exclui esses.
+//
+// Correção 2026-07-09 (Codex+Claude sobre dados de prod, colacor_sc, TTM competência):
+//  • Adiantamento de Salário (2.03.02) NÃO é ambíguo — é a 2ª parcela do MESMO salário: co-ocorre
+//    com 2.03.01 até dez/25 e some quando a folha consolidou numa parcela só em jan/26. Custo real.
+//  • O par de retenções é INSS (2.03.06) + IRRF (2.03.08) — antes só o IRRF estava marcado.
+// Este teste tê-lo-ia pego: o set antigo {2.03.02, 2.03.08} falha as duas primeiras asserções.
+describe('FOLHA_AMBIGUA — retenções do empregado (já no salário bruto)', () => {
+  it('marca o INSS retido (2.03.06) e o IRRF retido (2.03.08)', () => {
+    expect(FOLHA_AMBIGUA.has('2.03.06')).toBe(true); // INSS
+    expect(FOLHA_AMBIGUA.has('2.03.08')).toBe(true); // IRRF
+  });
+
+  it('NÃO marca o Adiantamento de Salário (2.03.02) — é salário real, não duplicação', () => {
+    expect(FOLHA_AMBIGUA.has('2.03.02')).toBe(false);
+  });
+
+  it('NÃO marca custo patronal real: Salários bruto (2.03.01) nem FGTS (2.03.07)', () => {
+    expect(FOLHA_AMBIGUA.has('2.03.01')).toBe(false);
+    expect(FOLHA_AMBIGUA.has('2.03.07')).toBe(false);
+  });
+});

--- a/src/hooks/usePontoEquilibrio.ts
+++ b/src/hooks/usePontoEquilibrio.ts
@@ -350,8 +350,14 @@ export interface FolhaRefLinha {
   mediaMes: number;
   ambiguo: boolean;
 }
-/** Adiantamento de Salário (antecipação compensável) e IRRF (retenção do empregado) — não custo econômico limpo. */
-const FOLHA_AMBIGUA = new Set(['2.03.02', '2.03.08']);
+/**
+ * Retenções do empregado — INSS (2.03.06) e IRRF (2.03.08) — já embutidas no Salário bruto (2.03.01),
+ * NÃO custo patronal extra (a CSC é Simples: sem INSS patronal; o lançado é a parte retida do funcionário).
+ * Somá-las ao bruto dobraria → o `totalLimpoMes` do dialog as exclui. NÃO inclui o Adiantamento (2.03.02):
+ * é a 2ª parcela do MESMO salário (dados de prod, Codex+Claude 2026-07-09), logo custo real.
+ * Pinado em `ponto-equilibrio-folha-ambigua.test.ts`.
+ */
+export const FOLHA_AMBIGUA = new Set(['2.03.06', '2.03.08']);
 
 /** Composição da folha (2.03.*) da empresa de origem, TTM, p/ o dialog dimensionar o rateio (referência, não input). */
 export function useFolhaReferencia(origem: string): {

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -109,6 +109,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useFinanceiroRegime.test.tsx",
       "src/hooks/__tests__/usePeriodOverride.test.tsx",
       "src/hooks/__tests__/useUtiContas.test.ts",
+      "src/hooks/__tests__/ponto-equilibrio-folha-ambigua.test.ts",
       "src/services/__tests__/getCapitalDeGiro.test.ts",
       "src/services/__tests__/getResumoFinanceiro.test.ts",
       "src/services/__tests__/getTopInadimplentes.test.ts",


### PR DESCRIPTION
## Bug (money-path · F3 v2 · #1243)

A "referência viva" da folha da CSC no `RateioFolhaDialog` marcava os códigos errados como ambíguos ("não custo econômico"):

- Marcava o **Adiantamento de Salário (2.03.02)** — mas ele **é salário** (2ª parcela do mesmo salário), não duplicação.
- **Não** marcava o **INSS retido (2.03.06)** — a retenção do empregado que, essa sim, já está no salário bruto.

## Correção

- `FOLHA_AMBIGUA`: `{2.03.02, 2.03.08}` → `{2.03.06, 2.03.08}` (INSS + IRRF retidos do empregado — parte do bruto, não custo patronal extra no Simples).
- Rótulo do dialog: "pagamento, não custo econômico" → "retenção do empregado (já no salário bruto)".
- O helper `pontoEquilibrio` **não muda** (soma todo `2.03.*` via `somaCodigosPorPrefixo(...FAMILIA_FOLHA)`) — só o wiring e o dialog.

## Verificação contra a prod (`psql-ro`)

- Mapa código→descrição (`colacor_sc`): `2.03.06 = INSS`, `2.03.08 = IRRF`, `2.03.02 = Adiantamento`, `2.03.07 = FGTS` → o novo par é exatamente as retenções; FGTS (custo patronal real) fica de fora.
- Padrão do adiantamento: co-ocorre com `2.03.01` todo mês até dez/25 e **some em jan/26** quando a folha vira parcela única → é a 2ª parcela do mesmo salário. Excluí-lo subestimava a folha em ~R$4–5,6k/mês.
- Efeito colateral coerente: o `totalLimpoMes` do dialog vira um anti-double-count correto (INSS/IRRF aparecem no bruto **e** como linha própria → excluir; adiantamento não → incluir).

## Provas

- Teste novo `ponto-equilibrio-folha-ambigua.test.ts` fixa o invariante (RED→GREEN — falhava com o set antigo `{2.03.02, 2.03.08}`).
- `bun run test -- ponto-equilibrio` → **24/24**; `bun run typecheck` limpo; `eslint` dos arquivos tocados limpo.
- Errata datada na spec F3 v2 (§0.3/§6/§10-C6 carregavam o raciocínio antigo; texto de época preservado).

## Deploy

**Frontend-only** → basta **Publish** no Lovable. Sem migration, sem edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
