### PR TITLE
feat(sync): agenda sync_customers para colacor_vendas e servicos — proof-table fresca nas 3 contas

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **348** custom migrations totais
-- **1244** objetos esperados (criados por estas migrations)
+- **349** custom migrations totais
+- **1246** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 348
   - `rls_policy`: 277
   - `index`: 208
-  - `cron_job`: 144
+  - `cron_job`: 146
   - `table`: 135
   - `trigger`: 70
   - `view`: 58
@@ -2983,6 +2983,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `view` | `public.selfservice_catalogo` | — |
 | `view` | `public.selfservice_disponibilidade` | — |
 | `view` | `public.selfservice_meus_pedidos` | — |
+
+### `20260708234721_sync_customers_colacor_servicos_crons.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.sync-customers-colacor-vendas-daily` | — |
+| `cron_job` | `cron.sync-customers-servicos-daily` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 348
+-- Total de custom migrations: 349
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -387,7 +387,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260708202033', 'selfservice_pr01_allowlist_gate', '20260708202033_selfservice_pr01_allowlist_gate.sql'),
   ('20260708204820', 'fin_custo_rateio', '20260708204820_fin_custo_rateio.sql'),
   ('20260708210000', 'tint_cobertura_lista_email', '20260708210000_tint_cobertura_lista_email.sql'),
-  ('20260708212123', 'selfservice_pr02a_views_customer', '20260708212123_selfservice_pr02a_views_customer.sql')
+  ('20260708212123', 'selfservice_pr02a_views_customer', '20260708212123_selfservice_pr02a_views_customer.sql'),
+  ('20260708234721', 'sync_customers_colacor_servicos_crons', '20260708234721_sync_customers_colacor_servicos_crons.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1622,7 +1623,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('tint_cobertura_lista_email', 'function', 'public', 'data_health_watchdog', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_catalogo', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_disponibilidade', ''),
-  ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_meus_pedidos', '')
+  ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_meus_pedidos', ''),
+  ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-colacor-vendas-daily', ''),
+  ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-servicos-daily', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2905,7 +2908,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tint_cobertura_lista_email', 'function', 'public', 'data_health_watchdog', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_catalogo', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_disponibilidade', ''),
-  ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_meus_pedidos', '')
+  ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_meus_pedidos', ''),
+  ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-colacor-vendas-daily', ''),
+  ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-servicos-daily', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260708234721_sync_customers_colacor_servicos_crons.sql
+++ b/supabase/migrations/20260708234721_sync_customers_colacor_servicos_crons.sql
@@ -1,0 +1,77 @@
+-- 20260708234721_sync_customers_colacor_servicos_crons.sql
+-- Agenda `sync_customers` (edge omie-analytics-sync) para as contas colacor_vendas e servicos.
+--
+-- CONTEXTO: a proof-table omie_customer_account_map (mapa user_id→omie_codigo_cliente, lida por
+-- customer360/useCustomerPreferredItems e compare-customer-process) só se mantinha fresca na conta
+-- `vendas` (oben), via o cron sync-customers-vendas-daily (0 5). colacor_vendas (→colacor) e
+-- servicos (→colacor_sc) foram populadas UMA vez, manualmente, e ficavam ESTÁTICAS — cliente novo
+-- dessas empresas não entrava na proof-table até um sync manual. Estes 2 crons fecham essa lacuna.
+--
+-- SEGURANÇA (Fatia 4, PR #1254): o handler syncCustomers gate as escritas legadas do espelho
+-- omie_clientes + tags cliente_classificacao APENAS para account==='vendas'. Rodar colacor_vendas/
+-- servicos escreve SÓ a proof-table (document-first) — não toca o espelho velho. Seguro.
+--
+-- ESCALONAMENTO (anti-concorrência): cada sync enumera ~10k clientes e a edge processa em waitUntil
+-- (background, responde 202). 3 invocações pesadas simultâneas da MESMA edge arriscam
+-- WORKER_RESOURCE_LIMIT. Duração real medida (span do updated_at): ~1-2 min/conta. Horários
+-- espaçados 20 min (~10x folga), na janela 05:00-06:00 que só tem estes syncs batendo na edge:
+--   vendas 0 5 (existente, NÃO tocado)  →  colacor_vendas 20 5  →  servicos 40 5  →  (sync_all vendas 0 6).
+--
+-- net.http_post SÓ ENFILEIRA; a edge responde 202 e roda em background. timeout_milliseconds
+-- EXPLÍCITO (default 5s mata silencioso — CLAUDE.md/sync.md); 60000 replica o irmão vendas (104).
+-- Verdade HTTP vive em net._http_response, NÃO em cron.job_run_details (que só prova o ENQUEUE).
+--
+-- Idempotente: unschedule antes de re-agendar (cron.schedule já é upsert por nome; o unschedule
+-- limpa estado zumbi). Re-colar = no-op.
+
+-- ============================================================
+-- 1) colacor_vendas → grava company `colacor` na proof-table
+-- ============================================================
+DO $do$
+BEGIN
+  PERFORM cron.unschedule('sync-customers-colacor-vendas-daily');
+EXCEPTION WHEN OTHERS THEN NULL;  -- idempotente: ignora se o job ainda não existe
+END
+$do$;
+
+SELECT cron.schedule(
+  'sync-customers-colacor-vendas-daily',
+  '20 5 * * *',
+  $job$
+  SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)
+    ),
+    body := '{"action":"sync_customers","account":"colacor_vendas"}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+  $job$
+);
+
+-- ============================================================
+-- 2) servicos → grava company `colacor_sc` na proof-table
+-- ============================================================
+DO $do$
+BEGIN
+  PERFORM cron.unschedule('sync-customers-servicos-daily');
+EXCEPTION WHEN OTHERS THEN NULL;  -- idempotente: ignora se o job ainda não existe
+END
+$do$;
+
+SELECT cron.schedule(
+  'sync-customers-servicos-daily',
+  '40 5 * * *',
+  $job$
+  SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)
+    ),
+    body := '{"action":"sync_customers","account":"servicos"}'::jsonb,
+    timeout_milliseconds := 60000
+  );
+  $job$
+);


### PR DESCRIPTION
## O quê

Agenda a action `sync_customers` (edge `omie-analytics-sync`) para as contas **`colacor_vendas`** e **`servicos`**, mantendo a proof-table `omie_customer_account_map` fresca nas **3 contas** — não só em `vendas`.

A proof-table (mapa `user_id → omie_codigo_cliente`, lida por customer360 `useCustomerPreferredItems` e `compare-customer-process`) só se mantinha fresca em `vendas` (oben), via o cron `sync-customers-vendas-daily`. `colacor_vendas` (→`colacor`) e `servicos` (→`colacor_sc`) foram populadas manualmente uma vez e ficavam **estáticas** — cliente novo dessas empresas não entrava até um sync manual.

## Design — 2 crons dedicados escalonados

| account (edge) | company (proof-table) | jobname | horário |
|---|---|---|---|
| `vendas` | `oben` | `sync-customers-vendas-daily` *(existente, intocado)* | 05:00 |
| `colacor_vendas` | `colacor` | `sync-customers-colacor-vendas-daily` *(novo)* | **05:20** |
| `servicos` | `colacor_sc` | `sync-customers-servicos-daily` *(novo)* | **05:40** |

Crons dedicados (não estende o 104) → menor blast radius + simetria com o padrão `sync-inventory-<account>` do repo. Gap de 20 min evita concorrência na mesma edge (`WORKER_RESOURCE_LIMIT`; a edge processa `sync_customers` em `waitUntil`/background). Duração real medida (span do `updated_at`): **~1–2 min/conta** → 20 min é ~10× folga. Janela 05:00–06:00 não tem outro sync batendo na `omie-analytics-sync`.

## Segurança (Fatia 4, #1254)

O handler `syncCustomers` gate as escritas legadas do espelho `omie_clientes` + tags `cliente_classificacao` **apenas para `account === "vendas"`** (index.ts l.373/396/404). Logo, rodar `colacor_vendas`/`servicos` escreve **SÓ a proof-table** (document-first) — **não toca o espelho velho**. Risco residual é fail-safe: cron falho = proof-table não atualiza aquela conta (= estado atual), sem fabricar/corromper número.

## Verificação

- `typecheck` ✅ · `test` ✅ (582 arquivos, 4.735 testes) · `wt:preflight` 🟢 (sem colisão)
- Contrato confirmado na fonte: `type OmieAccount`, `accountToEmpresa` (mapa), gate Fatia 4
- Empírico: populada manual de hoje usou esses accounts via `sync_customers`, gravou 5.156 (colacor) + 5.275 (colacor_sc) linhas, `202` success

## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260708234721_sync_customers_colacor_servicos_crons.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Alguém precisa colar no SQL Editor do Lovable e rodar.

<details><summary>SQL pra aplicar</summary>

```sql
-- ver o arquivo supabase/migrations/20260708234721_sync_customers_colacor_servicos_crons.sql
-- (2 crons: sync-customers-colacor-vendas-daily @ 20 5 * * *, sync-customers-servicos-daily @ 40 5 * * *)
```
</details>

Validação pós-apply:

```sql
SELECT jobname, schedule, active,
       CASE WHEN active THEN '✅' ELSE '❌ inativo' END AS status
FROM cron.job
WHERE jobname IN ('sync-customers-colacor-vendas-daily','sync-customers-servicos-daily')
ORDER BY schedule;
```

Esperado: 2 linhas ✅ (`20 5 * * *` e `40 5 * * *`).

---

📌 **Draft proposital:** money-path — segurando p/ revisão do founder. Marque *ready* p/ liberar o auto-merge. O cron só entra no ar quando o SQL for colado no Editor (independe do merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
