### PR TITLE
fix(sync): P1a staleness (view fresca 7d) + P1b doc-ambíguo-Omie no syncCustomers (proof-table)

### DIFF
--- a/db/omie_customer_account_map_fresco.sql
+++ b/db/omie_customer_account_map_fresco.sql
@@ -24,5 +24,7 @@ WHERE updated_at >= now() - interval '7 days';
 
 -- security_invoker=true é OBRIGATÓRIO: a view roda com os privilégios do CHAMADOR → a RLS da tabela base
 -- se aplica (staff ALL, user vê próprio). Sem isso a view rodaria como owner e BYPASSARIA a RLS (vazamento).
--- GRANT espelha a base: authenticated/anon têm SELECT, mas a RLS herdada nega anon (sem policy) → 0 linhas.
-GRANT SELECT ON public.omie_customer_account_map_fresco TO authenticated, anon;
+-- GRANT espelha a base: authenticated/anon têm SELECT (a RLS herdada nega anon — sem policy — → 0 linhas);
+-- service_role EXPLÍCITO (challenge Codex): o edge compare-customer-process lê a view via service_role —
+-- sem o grant cairia em permission denied e degradaria SILENCIOSO (sem segmento/lookalikes).
+GRANT SELECT ON public.omie_customer_account_map_fresco TO authenticated, anon, service_role;

--- a/db/omie_customer_account_map_fresco.sql
+++ b/db/omie_customer_account_map_fresco.sql
@@ -1,0 +1,28 @@
+-- ⚠️ DESTINO: 🟣 SQL Editor do Lovable (colar → Run). NÃO é auto-aplicada. NÃO vai em supabase/migrations/
+--    (essa pasta é a fonte de DR — o Lovable a materializa após o apply). Registro versionado + fonte do
+--    bloco de handoff. Prova: db/test-omie-customer-account-map-fresco.sh (PG17, falsificação).
+--
+-- P1a (staleness) — view FRESCA sobre omie_customer_account_map. Fecha o débito do syncCustomers
+-- (upsert-only nunca invalida row órfã) levantado pelo Codex no PR #1260. Os 2 consumidores de LEITURA
+-- (src/components/customer360/hooks.ts useCustomerPreferredItems, supabase/functions/compare-customer-process)
+-- leem ESTA view, não a tabela: a invariante de frescor vive PERTO DO DADO (não duplicada na UI) e usa
+-- now() do BANCO (elimina clock-skew de new Date() no browser — furo 6d do Codex).
+--
+-- CONTRATO: updated_at desta tabela = "última vez que o sync VIU a linha no Omie". O writer syncCustomers
+-- refresca updated_at a cada run que vê a linha (upsert); NÃO há trigger na tabela (psql-ro 2026-07-09:
+-- pg_trigger=0; 15669/15669 linhas com updated_at>created_at). Válido enquanto o sync (edge service_role)
+-- for o ÚNICO writer — se surgir 2º writer / edição manual (source='manual'), promover coluna dedicada
+-- last_seen_sync_at (NÃO antes; Codex P2). Threshold 7d = 7 runs do cron diário de folga (o
+-- data_health_watchdog grita "sync parado" muito antes).
+-- Design: docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md
+
+CREATE OR REPLACE VIEW public.omie_customer_account_map_fresco
+WITH (security_invoker = true) AS
+SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
+FROM public.omie_customer_account_map
+WHERE updated_at >= now() - interval '7 days';
+
+-- security_invoker=true é OBRIGATÓRIO: a view roda com os privilégios do CHAMADOR → a RLS da tabela base
+-- se aplica (staff ALL, user vê próprio). Sem isso a view rodaria como owner e BYPASSARIA a RLS (vazamento).
+-- GRANT espelha a base: authenticated/anon têm SELECT, mas a RLS herdada nega anon (sem policy) → 0 linhas.
+GRANT SELECT ON public.omie_customer_account_map_fresco TO authenticated, anon;

--- a/db/test-omie-customer-account-map-fresco.sh
+++ b/db/test-omie-customer-account-map-fresco.sh
@@ -88,7 +88,9 @@ INSERT INTO public.omie_customer_account_map(user_id, account, omie_codigo_clien
   ('11111111-1111-1111-1111-111111111111','oben',    100, now()),
   ('11111111-1111-1111-1111-111111111111','colacor', 200, now() - interval '10 days'),
   ('22222222-2222-2222-2222-222222222222','oben',    300, now());
-GRANT SELECT ON public.omie_customer_account_map TO authenticated, anon;
+-- service_role com SELECT na BASE simula o default do Supabase (grant amplo); o security_invoker faz o
+-- edge (service_role) resolver a query subjacente com o PRÓPRIO privilégio — sem grant na base, permission denied.
+GRANT SELECT ON public.omie_customer_account_map TO authenticated, anon, service_role;
 SQL
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -109,10 +111,12 @@ OWN=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authe
 STAFF=$(Pq -c "SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
 EMP=$(Pq -c "SET test.uid='44444444-4444-4444-4444-444444444444'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
 ANON=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+SVC=$(Pq -c "SET ROLE service_role; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
 eq "V4 own-scope+frescor: user1 vê só a PRÓPRIA FRESCA (1 de suas 2 linhas)" "$OWN" "1"
 eq "V5 staff master vê todas as frescas"    "$STAFF" "2"
 eq "V6 staff employee vê todas as frescas"  "$EMP"   "2"
 eq "V7 anon não vê nada (RLS herdada nega)" "$ANON"  "0"
+eq "V8 service_role (edge compare) lê a view: todas as frescas (grant explícito + BYPASSRLS)" "$SVC" "2"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 5 — FALSIFICAÇÃO (sabota → exige VERMELHO → restaura)

--- a/db/test-omie-customer-account-map-fresco.sh
+++ b/db/test-omie-customer-account-map-fresco.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA da view omie_customer_account_map_fresco (P1a staleness)  ║
+# ║  View FRESCA sobre a proof-table (user_id,account)->código Omie. Money-path     ║
+# ║  (identidade de cliente p/ Customer360/reposição). Rodar:                       ║
+# ║      bash db/test-omie-customer-account-map-fresco.sh > /tmp/t.log 2>&1; echo $?║
+# ║  Lei de Ferro: (1) migration REAL (versionada); (2) negativo c/ SQLSTATE;       ║
+# ║  (3) falsificação → exige VERMELHO → restaura.                                  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5458}"   # 5458 (o harness da tabela usa 5457) — não colide se rodarem juntos
+SLUG="omie-customer-account-map-fresco"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (has_role/app_role/user_roles + auth.users — a RLS da
+# tabela base, herdada pela view via security_invoker, chama has_role(auth.uid(),…))
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('master','employee','customer');
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $f$
+  SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role)
+$f$;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATIONS REAIS (versionadas — vão VERBATIM pro SQL Editor)
+#   1) a tabela base (db/omie_customer_account_map.sql)
+#   2) a view fresca sob teste (db/omie_customer_account_map_fresco.sql)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q -f "$REPO_ROOT/db/omie_customer_account_map.sql"
+P -q -f "$REPO_ROOT/db/omie_customer_account_map_fresco.sql"
+echo "migrations aplicadas: tabela + view fresca"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED (frescor controlado via updated_at explícito)
+#   user1=customer multi-conta (1 FRESCA oben + 1 VELHA colacor) · user2=customer (FRESCA)
+#   user3=master · user4=employee
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222'),
+  ('33333333-3333-3333-3333-333333333333'),
+  ('44444444-4444-4444-4444-444444444444') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('33333333-3333-3333-3333-333333333333','master'),
+  ('44444444-4444-4444-4444-444444444444','employee') ON CONFLICT DO NOTHING;
+-- código 100 (oben) FRESCA; código 200 (colacor) VELHA (>7d); código 300 (oben, user2) FRESCA.
+INSERT INTO public.omie_customer_account_map(user_id, account, omie_codigo_cliente, updated_at) VALUES
+  ('11111111-1111-1111-1111-111111111111','oben',    100, now()),
+  ('11111111-1111-1111-1111-111111111111','colacor', 200, now() - interval '10 days'),
+  ('22222222-2222-2222-2222-222222222222','oben',    300, now());
+GRANT SELECT ON public.omie_customer_account_map TO authenticated, anon;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts positivos: a VIEW filtra por frescor (rodados como superuser, sem RLS) ──"
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map_fresco WHERE omie_codigo_cliente=100;")
+eq "V1 fresca (código 100, updated_at=now) APARECE na view" "$V" "1"
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map_fresco WHERE omie_codigo_cliente=200;")
+eq "V2 velha (código 200, updated_at=now-10d) NÃO aparece na view" "$V" "0"
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map WHERE omie_codigo_cliente=200;")
+eq "V3 a velha EXISTE na tabela base (é a VIEW que filtra, não a ausência)" "$V" "1"
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map_fresco;")
+eq "V3b view = só as 2 frescas de 3 linhas totais" "$V" "2"
+
+echo "── asserts RLS herdada via security_invoker (SET ROLE authenticated + GUC auth.uid) ──"
+OWN=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+STAFF=$(Pq -c "SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+EMP=$(Pq -c "SET test.uid='44444444-4444-4444-4444-444444444444'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+ANON=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+eq "V4 own-scope+frescor: user1 vê só a PRÓPRIA FRESCA (1 de suas 2 linhas)" "$OWN" "1"
+eq "V5 staff master vê todas as frescas"    "$STAFF" "2"
+eq "V6 staff employee vê todas as frescas"  "$EMP"   "2"
+eq "V7 anon não vê nada (RLS herdada nega)" "$ANON"  "0"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (sabota → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+# F1: view SEM o filtro de frescor → a velha (código 200) passa a aparecer → V2 tinha dente
+P -q <<'SQL'
+CREATE OR REPLACE VIEW public.omie_customer_account_map_fresco
+WITH (security_invoker = true) AS
+SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
+FROM public.omie_customer_account_map;
+SQL
+V=$(Pq -c "SELECT count(*) FROM public.omie_customer_account_map_fresco WHERE omie_codigo_cliente=200;")
+if [ "$V" = "1" ]; then ok "F1 sem WHERE updated_at a velha aparece (=1) → V2 tinha dente"; else bad "F1 sabotei o filtro e a velha ainda não aparece (=$V) → V2 fraco"; fi
+
+# F2: view com security_invoker=FALSE → roda como owner (postgres/superuser, BYPASSRLS) → user1 vê TODAS
+#     as frescas (2), não só a própria (1) → V4 tinha dente (o security_invoker é o que segura a RLS).
+P -q <<'SQL'
+CREATE OR REPLACE VIEW public.omie_customer_account_map_fresco
+WITH (security_invoker = false) AS
+SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
+FROM public.omie_customer_account_map
+WHERE updated_at >= now() - interval '7 days';
+GRANT SELECT ON public.omie_customer_account_map_fresco TO authenticated, anon;
+SQL
+OWN_SAB=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+if [ "$OWN_SAB" = "2" ]; then ok "F2 security_invoker=false: user1 vê 2 (RLS bypassada) → V4 tinha dente"; else bad "F2 sabotei security_invoker e user1 vê $OWN_SAB (≠2) → V4 fraco"; fi
+
+# restaura a view VERDADEIRA (versionada)
+P -q -f "$REPO_ROOT/db/omie_customer_account_map_fresco.sql"
+REST=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.omie_customer_account_map_fresco;" | tail -1)
+eq "F3 restaurada: user1 volta a ver só a própria fresca (1)" "$REST" "1"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-omie-customer-account-map.sh
+++ b/db/test-omie-customer-account-map.sh
@@ -64,9 +64,8 @@ SQL
 # ZONA 2 — MIGRATION REAL (o .sql que vai VERBATIM pro SQL Editor; não vive em
 # supabase/migrations/ — proibido tocar, snapshot é DR)
 # ══════════════════════════════════════════════════════════════════════════════
-MIG="/private/tmp/claude-501/-Users-lucassardenberg-Projetos-afiacao--claude-worktrees-vibrant-davinci-bbc187/cdc5fb94-cdf9-4f6c-b3d2-263bcda6cb9e/scratchpad/f3-migration.sql"
-P -q -f "$MIG"
-echo "migration aplicada: $(basename "$MIG")"
+P -q -f "$REPO_ROOT/db/omie_customer_account_map.sql"
+echo "migration aplicada: db/omie_customer_account_map.sql"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 3 — SEED + GRANT

--- a/docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md
+++ b/docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md
@@ -1,0 +1,126 @@
+# Proof-table `omie_customer_account_map` — staleness (P1a) + doc-ambíguo-no-Omie (P1b) — design
+
+> **money-path** (identidade de cliente → Customer360/reposição). 2 débitos **PRÉ-EXISTENTES** do algoritmo `syncCustomers`, levantados pela 2ª opinião Codex durante o PR #1260 (crons de `sync_customers` p/ colacor_vendas/servicos). NÃO introduzidos pelo #1260. Conduzido por Claude + `/codex consult high` (convergiu; parecer cru registrado na §7). Deploy PENDENTE do founder.
+
+## 1. Problema (2 débitos do `syncCustomers`)
+
+`syncCustomers` (`supabase/functions/omie-analytics-sync/index.ts:282-430`) popula a proof-table aditiva `public.omie_customer_account_map` (Fatia 3 do fix de rótulo — spec `2026-07-07-espelho-omie-rotulo-por-conta-design.md`), fonte account-correta de identidade Omie por conta. Roda **por conta** (`vendas`→oben, `colacor_vendas`→colacor, `servicos`→colacor_sc), casa **document-first** (`profiles.document` → `user_id`), e faz **upsert-only** `onConflict(user_id, account)`.
+
+- **P1a — STALENESS: a proof-table nunca invalida row órfã.** Upsert-only nunca deleta/invalida linhas de clientes que sumiram do Omie, trocaram de documento, ou cujo código foi reatribuído a outro dono. Um vínculo `(user_id, account, omie_codigo_cliente)` obsoleto vive para sempre como verdade. Os consumidores confiam em **qualquer** row existente sem checar frescor: `useCustomerPreferredItems` (`hooks.ts:104-107`) lê só por `user_id`; `compare-customer-process` (`:229-234`, `:282-286`) idem. Viola "ausente ≠ zero" (serve dado stale como fresco).
+
+- **P1b — DOCUMENTO DUPLICADO no lado Omie (last-write-wins silencioso).** O lado **profile** é fail-closed p/ documento ambíguo (`fetchProfileDocUserMap:270-274`: 2 profiles/users distintos no mesmo doc → removido do mapa). O lado **Omie NÃO**: se 2 registros Omie **distintos** (códigos diferentes) na **mesma conta** compartilham o mesmo doc normalizado → ambos resolvem para o mesmo `userIdByDoc` → `accountMapByUser.set(userIdByDoc, ...)` (`:348-355`) **sobrescreve** — o último da paginação vence, gravando um `omie_codigo_cliente` arbitrário. Customer360 então busca itens preferidos do **par errado** (código ERRADO, não só stale).
+
+Ambos valem p/ as **3 contas** da proof-table.
+
+## 2. Estado atual (evidência psql-ro, produção, 2026-07-09)
+
+- Tabela **populada e consumida**: colacor 5156, colacor_sc 5275, oben 5238 linhas — todas `source='document'`, todas `updated_at` de hoje 05:00-05:40 UTC. Deploy da Fatia 3 + crons do #1260 já rodaram.
+- Crons **DIÁRIOS**: `sync-customers-vendas-daily` 05:00, `-colacor-vendas-daily` 05:20, `-servicos-daily` 05:40. Runs completam limpo (sem cauda de timestamp velho).
+- **Sem trigger** na tabela (`pg_trigger` = 0) → `updated_at` é 100% controlado pelo writer.
+- **15669/15669 linhas** têm `updated_at > created_at + 1min` → o writer **comprovadamente refresca `updated_at` a cada run** que vê a linha. `updated_at` já **é**, factualmente, o `last_seen_sync_at`.
+- Consumidores de LEITURA da proof-table: exatamente **2** (`hooks.ts` `useCustomerPreferredItems` + `compare-customer-process`) + 1 writer. Superfície pequena.
+
+## 3. Design P1a — view fresca (frescor no relógio do banco)
+
+**Reusar `updated_at` como `last_seen_sync_at`** (§2 prova que já o é) — sem coluna nova, sem tocar o writer p/ P1a. **Contrato explícito** (documentado aqui e no código): `updated_at` desta tabela = "última vez que o sync viu a linha no Omie". Válido enquanto o **sync (edge service_role) for o único writer**. Se surgir 2º writer / edição manual (`source='manual'`), promover a coluna dedicada `last_seen_sync_at` (não antes — YAGNI; Codex concordou, P2).
+
+**View `omie_customer_account_map_fresco`** — os 2 consumidores leem a view, não a tabela. A invariante de frescor vive **perto do dado** (não duplicada na UI) e usa `now()` do **Postgres** (elimina clock-skew de `new Date()` no browser — furo 6d do Codex):
+
+```sql
+-- ⚠️ DESTINO: SQL Editor do Lovable. NÃO auto-aplica. NÃO vai em supabase/migrations/.
+CREATE OR REPLACE VIEW public.omie_customer_account_map_fresco
+WITH (security_invoker = true) AS
+SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
+FROM public.omie_customer_account_map
+WHERE updated_at >= now() - interval '7 days';
+
+GRANT SELECT ON public.omie_customer_account_map_fresco TO authenticated;
+-- anon NÃO (espelha a tabela base — anon nunca vê).
+```
+
+- **`security_invoker = true`** é obrigatório: a view roda com os privilégios do CHAMADOR → a **RLS da tabela base se aplica** (staff ALL, user vê próprio). Sem isso, a view rodaria como owner e **bypassaria RLS** (vazamento). Edge (`service_role`, BYPASSRLS) vê todas as frescas; front staff vê todas as frescas; customer veria só a própria.
+- **Threshold: 7 dias** (constante de produto, não env). Cron diário → 7 runs de folga; o `data_health_watchdog` grita "sync parado" muito antes de 7d. `30d` (minha proposta inicial) é folgado demais p/ money-path — Codex corrigiu (P2), aceito. Consistência garantida por ser **um único ponto** (a view).
+- **Sem índice novo**: os consumidores filtram por `user_id` (idx_ocam_user) ou `(codigo,account)` (uq_ocam_codigo_account) e o frescor recai sobre as poucas linhas resultantes.
+
+**Auto-cura / fail-safe:** o writer nunca deleta p/ P1a. Um run parcial (ex.: Omie mentindo `total_de_paginas` — alerta do CLAUDE.md) só deixa de refrescar algumas linhas; o próximo run completo as revive. Sync inteiro parado → tudo expira junto em 7d (degradação honesta acoplada ao frescor). **Zero risco de colapso de mapa** (contraste com delete-ativo, rejeitado — Codex §2).
+
+## 4. Design P1b — fail-closed no doc-dup-Omie + **delete cirúrgico** do vínculo pré-existente
+
+Espelhar o fail-closed do lado profile no lado Omie, **por conta**, dentro do run. **Furo P1 do Codex (6a):** "só não upsertar" NÃO fecha o P1b — deixa a linha antiga (código do last-write-wins) viva até o TTL expirar (7d). Fail-closed **de verdade** exige invalidar o `(user_id, account)` ambíguo **imediatamente**.
+
+**Helper puro** (testável) — detecção nomeada, calculada 1× no laço:
+
+```ts
+// src/lib/omie/omie-doc-ambiguo.ts (+ espelho verbatim no edge, paridade textual no CI)
+/** Docs que aparecem em 2+ registros Omie com códigos de cliente DISTINTOS na MESMA conta
+ *  (ambíguos → não provam identidade). Espelha o fail-closed do lado profile (Codex P1b). */
+export function docsComCodigoAmbiguoNoOmie(
+  registros: Array<{ doc: string; codigo: number }>,
+): Set<string> {
+  const codigosPorDoc = new Map<string, Set<number>>();
+  for (const r of registros) {
+    if (!r.doc) continue;
+    const s = codigosPorDoc.get(r.doc) ?? new Set<number>();
+    s.add(r.codigo);
+    codigosPorDoc.set(r.doc, s);
+  }
+  const ambiguos = new Set<string>();
+  for (const [doc, cods] of codigosPorDoc) if (cods.size > 1) ambiguos.add(doc);
+  return ambiguos;
+}
+```
+
+**Integração no `syncCustomers`** (ordem):
+1. No laço de paginação, acumular `registrosOmie: {doc, codigo}[]` (além do que já faz).
+2. Após o laço: `ambiguos = docsComCodigoAmbiguoNoOmie(registrosOmie)`. Para cada doc ambíguo: `uid = userByDoc.get(doc)` → (a) `accountMapByUser.delete(uid)` (não grava código errado novo) + (b) coletar `uid` em `usersAmbiguosParaDeletar`.
+3. Upsert `accountMapByUser` (linhas boas) — como hoje.
+4. **DELETE cirúrgico** do vínculo pré-existente: `db.from('omie_customer_account_map').delete().eq('account', empresaMap).in('user_id', [...usersAmbiguosParaDeletar])` (chunk se necessário; ambíguos são raros). Fecha o furo P1.
+5. **Log** (furo 6b): contagem de docs ambíguos + amostra **sanitizada** (doc mascarado, ex.: `***`+4 últimos dígitos) — fail-closed perde recall (matriz/filial, duplicata legítima); observabilidade sem PII em texto plano.
+
+**Segurança do delete (≠ delete-ativo do P1a):** escopado a users **comprovadamente ambíguos NESTA conta**, não "tudo que não vi". Run parcial → vê menos ocorrências → detecta **menos** ambiguidades → deleta **menos** (fail-safe na direção certa). Conjuntos disjuntos: um user ou é bom-e-upserted, ou é ambíguo-e-deletado (sem conflito entre passos 3 e 4). Auto-cura: doc deixa de ser ambíguo no Omie → user re-mapeado no próximo run.
+
+**Escopo:** só a proof-table (`accountMapByUser`). O espelho legado `omie_clientes`/`upsertByUser` (só `vendas`, CODE-FIRST, doc é fallback) **NÃO** é tocado — dívida consciente, aposentado na Fatia 4 (Codex §5, P2; nomeado p/ não parecer que o sistema todo virou fail-closed).
+
+## 5. Consumidores que migram (view)
+
+- `src/components/customer360/hooks.ts` `useCustomerPreferredItems`: fonte `omie_customer_account_map` → `omie_customer_account_map_fresco` (1 linha; select/`.eq('user_id')` idênticos).
+- `supabase/functions/compare-customer-process/index.ts`: 2 pontos (segment lookup `:229`, reverse-map lookalikes `:282`) trocam a fonte p/ a view.
+- `src/integrations/supabase/types.ts`: adicionar a view (o front tipa `.from('...')`).
+
+## 6. Prova (gate)
+
+- **`prove-sql-money-path` (PG17 + falsificação)** — estender `db/test-omie-customer-account-map.sh`:
+  - Aplicar a view real. Seed: linha **fresca** (`updated_at=now()`) + linha **velha** (`now()-10d`).
+  - Assert +: view retorna só a fresca; a tabela base retorna ambas.
+  - Assert RLS na view (`SET ROLE authenticated` + GUC): user vê só a própria fresca; staff vê todas frescas; anon 0.
+  - **Falsificação**: (1) view sem o `WHERE updated_at` → a velha aparece → vermelho; (2) `security_invoker=false` → user vê linha de outro → vermelho.
+- **vitest (helper puro)** `docsComCodigoAmbiguoNoOmie`: casos +/− (1 doc/1 código → ø; 1 doc/2 códigos → ambíguo; mesmo código 2× → ø; doc vazio ignorado) + **falsificação** (helper que retorna `∅` sempre → teste vermelho). Paridade textual src↔edge no CI (MIRROR-START/END).
+- **typecheck + test + lint**.
+
+## 7. Decisões (Codex consult high, 2026-07-09)
+
+Parecer cru arquivado (transporte `scripts/codex-async.sh`). **Convergiu com a direção**; 4 refinamentos aceitos (1 crítico):
+
+- **(6a, P1 — ACEITO, crítico):** P1b precisa **deletar o vínculo pré-existente ambíguo**, não só "não upsertar" — senão a linha antiga vive até o TTL. → §4 passo 4 (delete cirúrgico).
+- **(4/6d/6e, P2 — ACEITO):** centralizar frescor numa **view** (não filtro duplicado nos 2 consumidores). Argumento decisivo: `now()` do banco elimina clock-skew do browser + threshold único. → §3.
+- **(3, P2 — ACEITO):** threshold **7d**, não 30d (cron diário; money-path pende p/ precisão). → §3.
+- **(6b, P2 — ACEITO):** logar contagem + amostra sanitizada da ambiguidade Omie (fail-closed perde recall). → §4 passo 5.
+- **(1, P2 — ACEITO com contrato):** reusar `updated_at` agora; coluna dedicada só com 2º writer. → §3.
+- **(5, P2 — ACEITO):** P1b só na proof-table (dívida consciente, Fatia 4). → §4.
+
+**Resíduos conscientes** (documentados, fora de escopo destes 2 débitos):
+- **Reatribuição de código pura** (doc NÃO-ambíguo, código muda de dono) ainda pode abortar um chunk de upsert no `uq_ocam_codigo_account` (P2 pré-existente do design da Fatia 3). Visível: o upsert lança → `sync_state.status='error'` → `data_health_watchdog`. Não resolvido aqui (exigiria run-ledger; escopo Fatia 4).
+- **P1b não tocado no espelho `omie_clientes`** (Fatia 4 o aposenta).
+
+## 8. Deploy (ordem — aditivo, cada passo fail-safe)
+
+1. **Migration da view** (SQL Editor do Lovable) — aditiva; ninguém lê ainda.
+2. **Edge** `omie-analytics-sync` (P1b) + `compare-customer-process` (view) — deploy pelo chat do Lovable (verbatim do repo).
+3. **Publish frontend** (`hooks.ts` lê a view) — só funciona após passo 1.
+4. **Validar** (psql-ro): `omie_customer_account_map_fresco` existe, `security_invoker=on`, contagem fresca ≈ tabela; próximo run do sync não muda outcomes (guard de borda, não regressão).
+
+Aditivo: view ausente → o front tiparia erro (por isso a ordem); mas nenhum passo corrompe dado. P1b endurece o writer sem quebrar casamento legítimo (só remove ambíguo provado).
+
+## 9. Fatiamento (PR)
+
+1 PR coeso (os 2 débitos são pequenos e relacionados) com **ordem de deploy explícita** no corpo: migration da view → edge → Publish. Auto-merge (squash) no CI verde. `db/omie_customer_account_map_fresco.sql` (view) + harness estendido + helper+teste + 3 consumidores (hooks, compare, types).

--- a/docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md
+++ b/docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md
@@ -108,9 +108,22 @@ Parecer cru arquivado (transporte `scripts/codex-async.sh`). **Convergiu com a d
 - **(1, P2 — ACEITO com contrato):** reusar `updated_at` agora; coluna dedicada só com 2º writer. → §3.
 - **(5, P2 — ACEITO):** P1b só na proof-table (dívida consciente, Fatia 4). → §4.
 
+### Codex challenge do diff (2026-07-09, high) — 8 achados, 4 corrigidos no código
+
+- **[item 1/7, P2 — CORRIGIDO]** Ordem/atomicidade: o DELETE cirúrgico rodava DEPOIS do upsert → se o upsert lançasse (colisão), o delete não rodava. → **delete-first**: o DELETE agora roda ANTES do upsert (remove o código errado antes de gravar o bom; falha do upsert não deixa o errado vivo).
+- **[item 3, P2 — CORRIGIDO]** O DELETE apagaria uma linha `source='manual'` (override humano). → `.eq('source','document')` no delete (só remove o que o sync gravou; preserva correção manual).
+- **[item 4, P3 — CORRIGIDO]** A view não concedia SELECT a `service_role` → o edge `compare-customer-process` cairia em permission denied e degradaria silencioso. → `GRANT ... TO ... service_role` + assert V8 no PG17.
+- **[item 8, P3 — CORRIGIDO]** CI não pegava a preservação de `manual`. → assert textual `.eq("source","document")` no delete.
+- **[item 5, P3 — contrato]** `updated_at` só é last_seen enquanto o sync for o único writer (edição manual furaria). Já é o contrato documentado (§3).
+- **[item 6, P2 — comportamento desejado]** Sync parado > 7d → a conta some da view (Customer360 `[]`, compare sem segmento). É degradação honesta; o **alerta de "sync parado" é do `data_health_watchdog`** (canal dedicado), não do consumidor.
+- **[item 2, P3 — TTL é o backstop]** Se um doc ambíguo não resolve `userByDoc` (profile mudou de doc/foi apagado), o delete não acha o user → a linha antiga não é removida; o **frescor (7d) é o backstop** desse canto.
+
+**[item extra do challenge, P1 — RESÍDUO PRÉ-EXISTENTE, fora de escopo → decisão do founder]**
+Para `account='vendas'`, o MESMO doc-dup-Omie ainda grava código arbitrário no **espelho legado `omie_clientes`** (`upsertByUser`), que tem leitores legados ativos (sync_pedidos, carteira-rebuild, ai-ops-agent). NÃO fechado aqui, de propósito: (a) a tarefa foi escopada à proof-table; (b) o design da Fatia 3 manda o espelho **INTOCADO** (sem delete/re-rótulo); (c) o espelho é **CODE-FIRST** — remover cegamente o user ambíguo teria **falso-positivo** (um vínculo resolvido por CÓDIGO, confiável, não é invalidado por doc ambíguo); (d) o fix seria **incompleto** (outros writers do espelho — `omie-cliente`, `omie-sync`, `Auth` signup — também gravam por doc). Fechamento correto = **Fatia 4** (aposenta o espelho e migra o pedido p/ a proof-table). Elevado à visibilidade do founder.
+
 **Resíduos conscientes** (documentados, fora de escopo destes 2 débitos):
 - **Reatribuição de código pura** (doc NÃO-ambíguo, código muda de dono) ainda pode abortar um chunk de upsert no `uq_ocam_codigo_account` (P2 pré-existente do design da Fatia 3). Visível: o upsert lança → `sync_state.status='error'` → `data_health_watchdog`. Não resolvido aqui (exigiria run-ledger; escopo Fatia 4).
-- **P1b não tocado no espelho `omie_clientes`** (Fatia 4 o aposenta).
+- **P1b não tocado no espelho `omie_clientes`** (ver [item extra] acima; Fatia 4 o aposenta).
 
 ## 8. Deploy (ordem — aditivo, cada passo fail-safe)
 

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -380,3 +380,54 @@ describe('guardrail money-path: edge ignora o espelho colacor poluído (BUG-1, F
     ).toMatch(/decision\.backfill && userIds\.length === 1 && account !== "colacor"/);
   });
 });
+
+// ── P1b (fail-closed no doc-dup-Omie) — syncCustomers USA o helper espelhado ──
+// A proof-table omie_customer_account_map é populada document-first. Se 2 registros Omie DISTINTOS na
+// MESMA conta compartilham o mesmo doc normalizado, o last-write-wins gravava um código arbitrário (o lado
+// profile já era fail-closed; o lado Omie não). O helper puro (vitest) espelhado no edge detecta o doc
+// ambíguo; a paridade textual aqui pega a reversão do deploy do Lovable. Fail-closed COMPLETO exige remover
+// do mapa E deletar o vínculo pré-existente (furo P1 do Codex — "só não upsertar" deixa a linha antiga viva
+// até o TTL). Ver docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md.
+const ANALYTICS = 'supabase/functions/omie-analytics-sync/index.ts';
+const DOC_AMBIGUO = 'src/lib/omie/omie-doc-ambiguo.ts';
+
+describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helper espelhado)', () => {
+  const src = read(ANALYTICS);
+  const helper = read(DOC_AMBIGUO);
+
+  it('sentinela: leu os arquivos reais (edge + helper)', () => {
+    expect(src).toContain('omie_customer_account_map');
+    expect(helper).toContain('docsComCodigoAmbiguoNoOmie');
+  });
+
+  it('o helper puro existe e exporta docsComCodigoAmbiguoNoOmie', () => {
+    expect(helper).toMatch(/export function docsComCodigoAmbiguoNoOmie/);
+  });
+
+  it('o edge USA o helper: define o espelho E o chama (não só define)', () => {
+    expect(src, 'edge não define mais o helper espelhado de doc-ambíguo').toMatch(/function docsComCodigoAmbiguoNoOmie/);
+    expect(
+      src,
+      'REGRESSÃO: edge não chama mais docsComCodigoAmbiguoNoOmie — P1b voltou a gravar last-write-wins?',
+    ).toMatch(/docsComCodigoAmbiguoNoOmie\(/);
+    expect(
+      count(src, 'docsComCodigoAmbiguoNoOmie'),
+      'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('fail-closed COMPLETO: remove o user do mapa E deleta o vínculo pré-existente (furo P1 do Codex)', () => {
+    expect(src, 'sumiu a remoção do accountMapByUser — voltaria a gravar código ambíguo').toMatch(/accountMapByUser\.delete\(/);
+    expect(
+      src,
+      'REGRESSÃO: sumiu o DELETE cirúrgico — a linha antiga do last-write-wins viveria até o TTL (furo P1)',
+    ).toMatch(/\.delete\(\)[\s\S]{0,160}\.in\("user_id", ambiguosList/);
+  });
+
+  it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlockNamed(src, 'omie doc-ambiguo'),
+      'edge divergiu do helper de src/ — o Lovable reescreveu a detecção no deploy?',
+    ).toBe(mirrorBlockNamed(helper, 'omie doc-ambiguo'));
+  });
+});

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -416,12 +416,16 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
     ).toBeGreaterThanOrEqual(2);
   });
 
-  it('fail-closed COMPLETO: remove o user do mapa E deleta o vínculo pré-existente (furo P1 do Codex)', () => {
+  it('fail-closed COMPLETO: remove do mapa, deleta o vínculo pré-existente E preserva source=manual (Codex)', () => {
     expect(src, 'sumiu a remoção do accountMapByUser — voltaria a gravar código ambíguo').toMatch(/accountMapByUser\.delete\(/);
     expect(
       src,
       'REGRESSÃO: sumiu o DELETE cirúrgico — a linha antiga do last-write-wins viveria até o TTL (furo P1)',
-    ).toMatch(/\.delete\(\)[\s\S]{0,160}\.in\("user_id", ambiguosList/);
+    ).toMatch(/\.delete\(\)[\s\S]{0,220}\.in\("user_id", ambiguosList/);
+    expect(
+      src,
+      'REGRESSÃO: o DELETE não preserva mais source=document — apagaria override humano manual (Codex item 3)',
+    ).toMatch(/\.delete\(\)[\s\S]{0,160}\.eq\("source", "document"\)/);
   });
 
   it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {

--- a/src/components/customer360/hooks.ts
+++ b/src/components/customer360/hooks.ts
@@ -86,9 +86,10 @@ interface PreferredItem {
   omie_codigo_produto: number;
 }
 
-/** Itens preferidos via Omie, casados pela proof-table omie_customer_account_map (Fatia 3 do fix de
- *  rótulo). A tabela nova mapeia (user_id, account) -> código Omie do cliente NAQUELA conta, populada
- *  DOCUMENT-FIRST pelo sync (sem a colisão de namespace do espelho omie_clientes poluído).
+/** Itens preferidos via Omie, casados pela view fresca omie_customer_account_map_fresco (Fatia 3 do fix
+ *  de rótulo + P1a staleness). A proof-table mapeia (user_id, account) -> código Omie do cliente NAQUELA
+ *  conta, populada DOCUMENT-FIRST pelo sync (sem a colisão de namespace do espelho omie_clientes poluído);
+ *  a view expõe só as linhas frescas (updated_at nos últimos 7d) — vínculo órfão stale não vaza.
  *  customer_preferred_items é chaveada por (omie_codigo_cliente, account) da conta de VENDA; casamos
  *  pelos PARES (código, account) do mapa, cobrindo oben E colacor. Fail-safe (precisão>recall): mapa
  *  vazio (sync ainda não populou) -> []. NÃO usa .or() cru (guard-rail CLAUDE.md): .in×.in é produto
@@ -100,9 +101,10 @@ export function useCustomerPreferredItems(customerId: string | undefined) {
     enabled: !!customerId,
     staleTime: 5 * 60_000,
     queryFn: async (): Promise<PreferredItem[]> => {
-      // 1. mapa (account -> código) do cliente, por conta (tabela nova, account-correta).
+      // 1. mapa (account -> código) do cliente, por conta. Lê a VIEW FRESCA (P1a): só vínculos que o sync
+      //    viu no Omie nos últimos 7d (frescor no relógio do banco) — órfã stale não vaza como verdade.
       const { data: maps } = await supabase
-        .from('omie_customer_account_map')
+        .from('omie_customer_account_map_fresco')
         .select('account, omie_codigo_cliente')
         .eq('user_id', customerId!);
       const pares = (maps ?? []) as Array<{ account: string; omie_codigo_cliente: number }>;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -15717,6 +15717,19 @@ export type Database = {
         }
         Relationships: []
       }
+      omie_customer_account_map_fresco: {
+        Row: {
+          account: string | null
+          created_at: string | null
+          id: string | null
+          omie_codigo_cliente: number | null
+          omie_codigo_vendedor: number | null
+          source: string | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Relationships: []
+      }
       order_feed: {
         Row: {
           account: string | null

--- a/src/lib/omie/omie-doc-ambiguo.test.ts
+++ b/src/lib/omie/omie-doc-ambiguo.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { docsComCodigoAmbiguoNoOmie } from './omie-doc-ambiguo';
+
+// P1b (fail-closed no doc-dup-Omie) — espelha o fail-closed do lado profile (fetchProfileDocUserMap).
+// Falsificação: os casos +/- se falsificam MUTUAMENTE — um helper que retorna sempre-∅ reprova o caso
+// ambíguo; um que marca tudo reprova os casos não-ambíguos. Ver
+// docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md
+describe('docsComCodigoAmbiguoNoOmie (P1b fail-closed money-path)', () => {
+  it('doc com 1 só código → NÃO ambíguo (∅)', () => {
+    const r = docsComCodigoAmbiguoNoOmie([{ doc: '111', codigo: 100 }]);
+    expect(r.size).toBe(0);
+  });
+
+  it('doc com 2 códigos DISTINTOS na mesma conta → AMBÍGUO (fecha o last-write-wins)', () => {
+    const r = docsComCodigoAmbiguoNoOmie([
+      { doc: '111', codigo: 100 },
+      { doc: '111', codigo: 200 },
+    ]);
+    expect(r.has('111')).toBe(true);
+    expect(r.size).toBe(1);
+  });
+
+  it('doc com o MESMO código repetido (duplicata do Omie na paginação) → NÃO ambíguo', () => {
+    const r = docsComCodigoAmbiguoNoOmie([
+      { doc: '111', codigo: 100 },
+      { doc: '111', codigo: 100 },
+    ]);
+    expect(r.size).toBe(0);
+  });
+
+  it('3+ códigos no mesmo doc → ambíguo', () => {
+    const r = docsComCodigoAmbiguoNoOmie([
+      { doc: '111', codigo: 100 },
+      { doc: '111', codigo: 200 },
+      { doc: '111', codigo: 300 },
+    ]);
+    expect(r.has('111')).toBe(true);
+  });
+
+  it('doc vazio é ignorado (não vira chave)', () => {
+    const r = docsComCodigoAmbiguoNoOmie([
+      { doc: '', codigo: 100 },
+      { doc: '', codigo: 200 },
+    ]);
+    expect(r.size).toBe(0);
+  });
+
+  it('mistura: só os docs ambíguos entram; os limpos ficam de fora (precisão do escopo)', () => {
+    const r = docsComCodigoAmbiguoNoOmie([
+      { doc: 'A', codigo: 1 }, // limpo
+      { doc: 'B', codigo: 2 }, // ambíguo (2 códigos)
+      { doc: 'B', codigo: 3 },
+      { doc: 'C', codigo: 4 }, // limpo
+      { doc: 'C', codigo: 4 }, // repetição do mesmo → segue limpo
+    ]);
+    expect([...r].sort()).toEqual(['B']);
+  });
+
+  it('lista vazia → ∅', () => {
+    expect(docsComCodigoAmbiguoNoOmie([]).size).toBe(0);
+  });
+});

--- a/src/lib/omie/omie-doc-ambiguo.ts
+++ b/src/lib/omie/omie-doc-ambiguo.ts
@@ -1,0 +1,21 @@
+// MIRROR-START omie doc-ambiguo — espelhado verbatim em supabase/functions/omie-analytics-sync/index.ts
+// P1b (fail-closed money-path): documentos que aparecem em 2+ registros Omie com códigos de cliente
+// DISTINTOS na MESMA conta são AMBÍGUOS — não provam identidade. Espelha o fail-closed do lado profile
+// (fetchProfileDocUserMap: 2 users no mesmo doc → não mapeia). Sem isto, o último da paginação vencia por
+// last-write-wins e gravava um código arbitrário na proof-table. Espelhado no edge (Deno não importa de
+// src/); paridade textual no CI em src/__tests__/edge-money-path-invariants.test.ts.
+export function docsComCodigoAmbiguoNoOmie(
+  registros: ReadonlyArray<{ doc: string; codigo: number }>,
+): Set<string> {
+  const codigosPorDoc = new Map<string, Set<number>>();
+  for (const r of registros) {
+    if (!r.doc) continue; // doc vazio não vira chave (o boundary já filtra sem-doc)
+    const s = codigosPorDoc.get(r.doc) ?? new Set<number>();
+    s.add(r.codigo);
+    codigosPorDoc.set(r.doc, s);
+  }
+  const ambiguos = new Set<string>();
+  for (const [doc, cods] of codigosPorDoc) if (cods.size > 1) ambiguos.add(doc);
+  return ambiguos;
+}
+// MIRROR-END

--- a/supabase/functions/compare-customer-process/index.ts
+++ b/supabase/functions/compare-customer-process/index.ts
@@ -227,7 +227,7 @@ Deno.serve(async (req) => {
       // conta 'oben' no mapa. Fail-safe: sem linha 'oben' no mapa (sync não populou) → omieMap null →
       // sem segmento (degradação honesta, precisão>recall — melhor que colisão trazer segmento de OUTRO).
       const { data: omieMap } = await supabase
-        .from('omie_customer_account_map')
+        .from('omie_customer_account_map_fresco') // view fresca (P1a): só vínculo visto no Omie nos últimos 7d
         .select('omie_codigo_cliente')
         .eq('user_id', body.customer_user_id)
         .eq('account', 'oben')
@@ -280,7 +280,7 @@ Deno.serve(async (req) => {
         // account-correta. Fail-safe: mapa 'oben' vazio → sem lookalikes (honesto), casa certo quando
         // o sync popular. (Antes lia o espelho omie_clientes, que colidia namespaces.)
         const { data: maps } = await supabase
-          .from('omie_customer_account_map')
+          .from('omie_customer_account_map_fresco') // view fresca (P1a): reverse-map só de vínculos frescos
           .select('user_id, omie_codigo_cliente')
           .eq('account', 'oben')
           .in('omie_codigo_cliente', codes);

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -279,6 +279,28 @@ async function fetchProfileDocUserMap(db: SupabaseClient): Promise<Map<string, s
   return map;
 }
 
+// MIRROR-START omie doc-ambiguo — espelhado verbatim de src/lib/omie/omie-doc-ambiguo.ts
+// P1b (fail-closed money-path): documentos que aparecem em 2+ registros Omie com códigos de cliente
+// DISTINTOS na MESMA conta são AMBÍGUOS — não provam identidade. Espelha o fail-closed do lado profile
+// (fetchProfileDocUserMap: 2 users no mesmo doc → não mapeia). Sem isto, o último da paginação vencia por
+// last-write-wins e gravava um código arbitrário na proof-table. Espelhado no edge (Deno não importa de
+// src/); paridade textual no CI em src/__tests__/edge-money-path-invariants.test.ts.
+function docsComCodigoAmbiguoNoOmie(
+  registros: ReadonlyArray<{ doc: string; codigo: number }>,
+): Set<string> {
+  const codigosPorDoc = new Map<string, Set<number>>();
+  for (const r of registros) {
+    if (!r.doc) continue; // doc vazio não vira chave (o boundary já filtra sem-doc)
+    const s = codigosPorDoc.get(r.doc) ?? new Set<number>();
+    s.add(r.codigo);
+    codigosPorDoc.set(r.doc, s);
+  }
+  const ambiguos = new Set<string>();
+  for (const [doc, cods] of codigosPorDoc) if (cods.size > 1) ambiguos.add(doc);
+  return ambiguos;
+}
+// MIRROR-END
+
 async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "customers", account, { status: "running", error_message: null });
 
@@ -310,6 +332,9 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       source: string;
       updated_at: string;
     }>();
+    // P1b: acumula (doc, código) de TODO registro Omie com doc — inclusive os SEM profile casado — p/
+    // detectar doc ambíguo no lado Omie (2+ códigos DISTINTOS na mesma conta) e fail-closar depois.
+    const registrosOmieDoc: { doc: string; codigo: number }[] = [];
     let pagina = 1;
     let totalPaginas = 1;
 
@@ -324,6 +349,7 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       for (const c of result.clientes_cadastro || []) {
         const doc = (c.cnpj_cpf || "").replace(/\D/g, "");
         if (!doc || c.codigo_cliente_omie == null) continue;
+        registrosOmieDoc.push({ doc, codigo: c.codigo_cliente_omie });
         // mapeado por código (atualiza vendedor) OU vinculável por documento (cria vínculo).
         // Não-vinculado (sem código nem profile) é fora de escopo — é o syncNaoVinculados.
         const userId = userByCodigo.get(Number(c.codigo_cliente_omie)) ?? userByDoc.get(doc);
@@ -360,6 +386,28 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       pagina++;
     }
 
+    // P1b (fail-closed): doc que aparece em 2+ registros Omie com códigos DISTINTOS na MESMA conta é
+    // AMBÍGUO — não dá p/ saber qual código é o do profile. Espelha o lado profile. Remove o user do mapa
+    // (não grava código errado) e coleta p/ o DELETE cirúrgico do vínculo pré-existente (o upsert-only
+    // deixaria a linha antiga viva até o TTL — furo P1 do Codex). Escopado a users PROVADOS ambíguos NESTA
+    // conta (≠ delete-em-massa: run parcial vê menos ocorrências → detecta menos → deleta menos, fail-safe).
+    const docsAmbiguosOmie = docsComCodigoAmbiguoNoOmie(registrosOmieDoc);
+    const usersAmbiguosOmie = new Set<string>();
+    for (const docAmb of docsAmbiguosOmie) {
+      const uid = userByDoc.get(docAmb);
+      if (uid) {
+        accountMapByUser.delete(uid);
+        usersAmbiguosOmie.add(uid);
+      }
+    }
+    if (docsAmbiguosOmie.size > 0) {
+      // amostra SANITIZADA (só os 4 últimos dígitos) — observabilidade da perda de recall sem PII em texto.
+      const amostra = Array.from(docsAmbiguosOmie).slice(0, 5).map((d) => `***${d.slice(-4)}`);
+      console.warn(
+        `[Sync ${account}] P1b fail-closed: ${docsAmbiguosOmie.size} doc(s) ambíguo(s) no Omie (2+ códigos/conta) → ${usersAmbiguosOmie.size} user(s) NÃO-mapeado(s). Amostra: ${amostra.join(", ")}`,
+      );
+    }
+
     // Bulk upsert em chunks (onConflict user_id = unique_user_omie). empresa_omie NÃO é setado
     // (preserva o default 'colacor' do comportamento anterior).
     // Fatia 4 (money-path, Codex): SÓ 'vendas'(oben) mantém o espelho legado omie_clientes. Este
@@ -392,6 +440,23 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (mapErr) throw new Error(`upsert omie_customer_account_map: ${mapErr.message}`);
     }
     console.log(`[Sync ${account}] proof-table omie_customer_account_map: ${mapRows.length} vínculos por documento`);
+
+    // P1b: DELETE cirúrgico do vínculo PRÉ-EXISTENTE dos users ambíguos NESTA conta (fecha o furo P1: o
+    // upsert só deixa de GRAVAR o código errado novo, mas a linha antiga do last-write-wins seguiria viva
+    // até o TTL). Escopado por (account, user_id) PROVADOS ambíguos → seguro (não é delete-em-massa).
+    if (usersAmbiguosOmie.size > 0) {
+      const ambiguosList = Array.from(usersAmbiguosOmie);
+      for (let i = 0; i < ambiguosList.length; i += 200) {
+        const { error: delErr } = await db
+          .from("omie_customer_account_map")
+          .delete()
+          .eq("account", empresaMap)
+          .in("user_id", ambiguosList.slice(i, i + 200));
+        if (delErr) throw new Error(`delete ambíguos omie_customer_account_map: ${delErr.message}`);
+      }
+      console.log(`[Sync ${account}] P1b: ${ambiguosList.length} vínculo(s) ambíguo(s) removido(s) da proof-table`);
+    }
+
     // Fatia 4: para contas não-oben o espelho não é tocado; o "sincronizado" reportado é a proof-table.
     if (account !== "vendas") totalSynced = mapRows.length;
 

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -408,6 +408,25 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       );
     }
 
+    // P1b: DELETE cirúrgico do vínculo PRÉ-EXISTENTE dos users ambíguos NESTA conta, ANTES do upsert
+    // (delete-first fail-closed: remove o código errado antes de gravar o bom — se o upsert falhar depois,
+    // o errado já saiu; challenge Codex item 1/7). Escopado por (account, user_id) PROVADOS ambíguos, e SÓ
+    // source='document' (preserva override humano source='manual' — challenge Codex item 3). Não é
+    // delete-em-massa: run parcial vê menos ocorrências → detecta menos → deleta menos (fail-safe).
+    if (usersAmbiguosOmie.size > 0) {
+      const ambiguosList = Array.from(usersAmbiguosOmie);
+      for (let i = 0; i < ambiguosList.length; i += 200) {
+        const { error: delErr } = await db
+          .from("omie_customer_account_map")
+          .delete()
+          .eq("account", empresaMap)
+          .eq("source", "document")
+          .in("user_id", ambiguosList.slice(i, i + 200));
+        if (delErr) throw new Error(`delete ambíguos omie_customer_account_map: ${delErr.message}`);
+      }
+      console.log(`[Sync ${account}] P1b: ${ambiguosList.length} user(s) ambíguo(s) — vínculo document removido da proof-table`);
+    }
+
     // Bulk upsert em chunks (onConflict user_id = unique_user_omie). empresa_omie NÃO é setado
     // (preserva o default 'colacor' do comportamento anterior).
     // Fatia 4 (money-path, Codex): SÓ 'vendas'(oben) mantém o espelho legado omie_clientes. Este
@@ -440,22 +459,6 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (mapErr) throw new Error(`upsert omie_customer_account_map: ${mapErr.message}`);
     }
     console.log(`[Sync ${account}] proof-table omie_customer_account_map: ${mapRows.length} vínculos por documento`);
-
-    // P1b: DELETE cirúrgico do vínculo PRÉ-EXISTENTE dos users ambíguos NESTA conta (fecha o furo P1: o
-    // upsert só deixa de GRAVAR o código errado novo, mas a linha antiga do last-write-wins seguiria viva
-    // até o TTL). Escopado por (account, user_id) PROVADOS ambíguos → seguro (não é delete-em-massa).
-    if (usersAmbiguosOmie.size > 0) {
-      const ambiguosList = Array.from(usersAmbiguosOmie);
-      for (let i = 0; i < ambiguosList.length; i += 200) {
-        const { error: delErr } = await db
-          .from("omie_customer_account_map")
-          .delete()
-          .eq("account", empresaMap)
-          .in("user_id", ambiguosList.slice(i, i + 200));
-        if (delErr) throw new Error(`delete ambíguos omie_customer_account_map: ${delErr.message}`);
-      }
-      console.log(`[Sync ${account}] P1b: ${ambiguosList.length} vínculo(s) ambíguo(s) removido(s) da proof-table`);
-    }
 
     // Fatia 4: para contas não-oben o espelho não é tocado; o "sincronizado" reportado é a proof-table.
     if (account !== "vendas") totalSynced = mapRows.length;


### PR DESCRIPTION
## O quê

Corrige **2 débitos money-path PRÉ-EXISTENTES** do algoritmo `syncCustomers` (edge `omie-analytics-sync`), levantados pela 2ª opinião Codex durante o PR #1260. **Não** introduzidos por aquele PR — são do algoritmo. Valem p/ as 3 contas da proof-table `omie_customer_account_map` (money-path → Customer360/reposição).

### P1a — STALENESS (upsert-only nunca invalidava row órfã)
Um vínculo `(user_id, account, código)` de cliente que sumiu do Omie vivia para sempre como verdade; os consumidores confiavam em qualquer row sem checar frescor.

- **view `omie_customer_account_map_fresco`** (`security_invoker`, RLS herdada, `updated_at >= now()-interval '7 days'`). Frescor no **relógio do banco** (elimina clock-skew do browser), threshold único. Reusa `updated_at` como `last_seen` — provado em prod (sem trigger; 15669/15669 linhas com `updated_at>created_at`). O writer nunca deleta p/ P1a → **fail-safe a run parcial** (Omie mentindo `total_de_paginas` não colapsa o mapa).
- Os 2 consumidores leem a view: `customer360/hooks.ts` + `compare-customer-process` (×2) + `types.ts`.

### P1b — DOC DUPLICADO no lado Omie (last-write-wins gravava código arbitrário)
2 registros Omie distintos na mesma conta com o mesmo doc → o último da paginação vencia. O lado profile já era fail-closed; o lado Omie não.

- helper puro `docsComCodigoAmbiguoNoOmie` (`src/lib/omie`, vitest) **espelhado verbatim no edge** (paridade textual no CI).
- fail-closed **completo**: remove o user do mapa **E DELETE cirúrgico** (delete-first) do vínculo pré-existente ambíguo — furo P1 do Codex ("só não upsertar" deixaria a linha antiga viva até o TTL). Escopado a users provados ambíguos **nesta conta**, só `source='document'` (preserva override `manual`). Log sanitizado.

## Prova (gates)
- **PG17** `db/test-omie-customer-account-map-fresco.sh` **12/12** + falsificação (F1 sem `WHERE` → velha aparece; F2 sem `security_invoker` → user vê linha alheia; V8 service_role lê a view).
- **vitest 46/46** (helper 7 + `edge-money-path-invariants` 39, incl. paridade src↔edge).
- typecheck · lint · shellcheck ok.

## 2ª opinião Codex (money-path)
- **consult** high (design): convergiu; 4 refinamentos aceitos (view em vez de filtro duplicado; 7d em vez de 30d; delete cirúrgico; reusar `updated_at`).
- **challenge** high (diff): 4 achados corrigidos — delete-first, preserva `source='manual'`, grant `service_role`, assert textual. Detalhe na spec §7.

## ⚠️ ATENÇÃO: migration manual necessária
Este PR adiciona `db/omie_customer_account_map_fresco.sql` (padrão do projeto — **não** `supabase/migrations/`). **Lovable não aplica automaticamente** — mergear NÃO toca o banco nem deploya edge/front.

**Ordem de deploy (aditiva, cada passo fail-safe):**
1. **SQL Editor** — cola e roda a view:
```sql
CREATE OR REPLACE VIEW public.omie_customer_account_map_fresco
WITH (security_invoker = true) AS
SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
FROM public.omie_customer_account_map
WHERE updated_at >= now() - interval '7 days';

GRANT SELECT ON public.omie_customer_account_map_fresco TO authenticated, anon, service_role;
```
2. **Edge** (chat do Lovable, verbatim): `omie-analytics-sync` + `compare-customer-process`.
3. **Publish frontend** (`hooks.ts` lê a view) — só funciona após o passo 1.

Validação pós-apply (read-only):
```sql
SELECT
  CASE WHEN EXISTS (SELECT 1 FROM pg_views WHERE schemaname='public' AND viewname='omie_customer_account_map_fresco')
       THEN '✅ view existe' ELSE '❌ FALTANDO' END AS existe,
  CASE WHEN EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
    WHERE n.nspname='public' AND c.relname='omie_customer_account_map_fresco'
      AND c.reloptions @> ARRAY['security_invoker=true'])
       THEN '✅ security_invoker=on' ELSE '❌ SEM security_invoker' END AS invoker;
```

## Resíduo conhecido (fora de escopo → Fatia 4)
Para `account='vendas'`, o MESMO doc-dup-Omie ainda grava no **espelho legado `omie_clientes`** (débito P1 pré-existente). NÃO fechado aqui de propósito: design manda o espelho INTOCADO; é code-first (fix ingênuo tem falso-positivo); incompleto sem os outros writers. → **Fatia 4** (aposenta o espelho). Detalhe na spec §7.

Spec: `docs/superpowers/specs/2026-07-09-omie-proof-table-staleness-doc-ambiguo-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
