### PR TITLE
fix(sync): re-aplica P1b doc-ambíguo revertido pelo deploy do Lovable (#1268)

### DIFF
--- a/supabase/functions/compare-customer-process/index.ts
+++ b/supabase/functions/compare-customer-process/index.ts
@@ -227,7 +227,7 @@ Deno.serve(async (req) => {
       // conta 'oben' no mapa. Fail-safe: sem linha 'oben' no mapa (sync não populou) → omieMap null →
       // sem segmento (degradação honesta, precisão>recall — melhor que colisão trazer segmento de OUTRO).
       const { data: omieMap } = await supabase
-        .from('omie_customer_account_map')
+        .from('omie_customer_account_map_fresco') // view fresca (P1a): só vínculo visto no Omie nos últimos 7d
         .select('omie_codigo_cliente')
         .eq('user_id', body.customer_user_id)
         .eq('account', 'oben')
@@ -280,7 +280,7 @@ Deno.serve(async (req) => {
         // account-correta. Fail-safe: mapa 'oben' vazio → sem lookalikes (honesto), casa certo quando
         // o sync popular. (Antes lia o espelho omie_clientes, que colidia namespaces.)
         const { data: maps } = await supabase
-          .from('omie_customer_account_map')
+          .from('omie_customer_account_map_fresco') // view fresca (P1a): reverse-map só de vínculos frescos
           .select('user_id, omie_codigo_cliente')
           .eq('account', 'oben')
           .in('omie_codigo_cliente', codes);

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -279,6 +279,28 @@ async function fetchProfileDocUserMap(db: SupabaseClient): Promise<Map<string, s
   return map;
 }
 
+// MIRROR-START omie doc-ambiguo — espelhado verbatim de src/lib/omie/omie-doc-ambiguo.ts
+// P1b (fail-closed money-path): documentos que aparecem em 2+ registros Omie com códigos de cliente
+// DISTINTOS na MESMA conta são AMBÍGUOS — não provam identidade. Espelha o fail-closed do lado profile
+// (fetchProfileDocUserMap: 2 users no mesmo doc → não mapeia). Sem isto, o último da paginação vencia por
+// last-write-wins e gravava um código arbitrário na proof-table. Espelhado no edge (Deno não importa de
+// src/); paridade textual no CI em src/__tests__/edge-money-path-invariants.test.ts.
+function docsComCodigoAmbiguoNoOmie(
+  registros: ReadonlyArray<{ doc: string; codigo: number }>,
+): Set<string> {
+  const codigosPorDoc = new Map<string, Set<number>>();
+  for (const r of registros) {
+    if (!r.doc) continue; // doc vazio não vira chave (o boundary já filtra sem-doc)
+    const s = codigosPorDoc.get(r.doc) ?? new Set<number>();
+    s.add(r.codigo);
+    codigosPorDoc.set(r.doc, s);
+  }
+  const ambiguos = new Set<string>();
+  for (const [doc, cods] of codigosPorDoc) if (cods.size > 1) ambiguos.add(doc);
+  return ambiguos;
+}
+// MIRROR-END
+
 async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "customers", account, { status: "running", error_message: null });
 
@@ -310,6 +332,9 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       source: string;
       updated_at: string;
     }>();
+    // P1b: acumula (doc, código) de TODO registro Omie com doc — inclusive os SEM profile casado — p/
+    // detectar doc ambíguo no lado Omie (2+ códigos DISTINTOS na mesma conta) e fail-closar depois.
+    const registrosOmieDoc: { doc: string; codigo: number }[] = [];
     let pagina = 1;
     let totalPaginas = 1;
 
@@ -324,6 +349,7 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       for (const c of result.clientes_cadastro || []) {
         const doc = (c.cnpj_cpf || "").replace(/\D/g, "");
         if (!doc || c.codigo_cliente_omie == null) continue;
+        registrosOmieDoc.push({ doc, codigo: c.codigo_cliente_omie });
         // mapeado por código (atualiza vendedor) OU vinculável por documento (cria vínculo).
         // Não-vinculado (sem código nem profile) é fora de escopo — é o syncNaoVinculados.
         const userId = userByCodigo.get(Number(c.codigo_cliente_omie)) ?? userByDoc.get(doc);
@@ -360,6 +386,47 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       pagina++;
     }
 
+    // P1b (fail-closed): doc que aparece em 2+ registros Omie com códigos DISTINTOS na MESMA conta é
+    // AMBÍGUO — não dá p/ saber qual código é o do profile. Espelha o lado profile. Remove o user do mapa
+    // (não grava código errado) e coleta p/ o DELETE cirúrgico do vínculo pré-existente (o upsert-only
+    // deixaria a linha antiga viva até o TTL — furo P1 do Codex). Escopado a users PROVADOS ambíguos NESTA
+    // conta (≠ delete-em-massa: run parcial vê menos ocorrências → detecta menos → deleta menos, fail-safe).
+    const docsAmbiguosOmie = docsComCodigoAmbiguoNoOmie(registrosOmieDoc);
+    const usersAmbiguosOmie = new Set<string>();
+    for (const docAmb of docsAmbiguosOmie) {
+      const uid = userByDoc.get(docAmb);
+      if (uid) {
+        accountMapByUser.delete(uid);
+        usersAmbiguosOmie.add(uid);
+      }
+    }
+    if (docsAmbiguosOmie.size > 0) {
+      // amostra SANITIZADA (só os 4 últimos dígitos) — observabilidade da perda de recall sem PII em texto.
+      const amostra = Array.from(docsAmbiguosOmie).slice(0, 5).map((d) => `***${d.slice(-4)}`);
+      console.warn(
+        `[Sync ${account}] P1b fail-closed: ${docsAmbiguosOmie.size} doc(s) ambíguo(s) no Omie (2+ códigos/conta) → ${usersAmbiguosOmie.size} user(s) NÃO-mapeado(s). Amostra: ${amostra.join(", ")}`,
+      );
+    }
+
+    // P1b: DELETE cirúrgico do vínculo PRÉ-EXISTENTE dos users ambíguos NESTA conta, ANTES do upsert
+    // (delete-first fail-closed: remove o código errado antes de gravar o bom — se o upsert falhar depois,
+    // o errado já saiu; challenge Codex item 1/7). Escopado por (account, user_id) PROVADOS ambíguos, e SÓ
+    // source='document' (preserva override humano source='manual' — challenge Codex item 3). Não é
+    // delete-em-massa: run parcial vê menos ocorrências → detecta menos → deleta menos (fail-safe).
+    if (usersAmbiguosOmie.size > 0) {
+      const ambiguosList = Array.from(usersAmbiguosOmie);
+      for (let i = 0; i < ambiguosList.length; i += 200) {
+        const { error: delErr } = await db
+          .from("omie_customer_account_map")
+          .delete()
+          .eq("account", empresaMap)
+          .eq("source", "document")
+          .in("user_id", ambiguosList.slice(i, i + 200));
+        if (delErr) throw new Error(`delete ambíguos omie_customer_account_map: ${delErr.message}`);
+      }
+      console.log(`[Sync ${account}] P1b: ${ambiguosList.length} user(s) ambíguo(s) — vínculo document removido da proof-table`);
+    }
+
     // Bulk upsert em chunks (onConflict user_id = unique_user_omie). empresa_omie NÃO é setado
     // (preserva o default 'colacor' do comportamento anterior).
     // Fatia 4 (money-path, Codex): SÓ 'vendas'(oben) mantém o espelho legado omie_clientes. Este
@@ -392,6 +459,7 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (mapErr) throw new Error(`upsert omie_customer_account_map: ${mapErr.message}`);
     }
     console.log(`[Sync ${account}] proof-table omie_customer_account_map: ${mapRows.length} vínculos por documento`);
+
     // Fatia 4: para contas não-oben o espelho não é tocado; o "sincronizado" reportado é a proof-table.
     if (account !== "vendas") totalSynced = mapRows.length;
 


### PR DESCRIPTION
## 🚨 Incidente: o deploy do Lovable reverteu o fix P1b money-path

O `#1268` (fix P1a staleness + P1b doc-ambíguo-Omie) mergeou às **00:00 UTC**. Às **00:08**, o commit `e05ddc87 "Changes"` (autor `gpt-engineer-app[bot]` = Lovable) sobrescreveu 2 edges com a versão **pré-#1268** e commitou direto na `main` (sem passar pelo CI). Reverteu:

| edge | o que o Lovable desfez |
|---|---|
| `omie-analytics-sync` | **todo** o P1b: helper `docsComCodigoAmbiguoNoOmie` (MIRROR) + `registrosOmieDoc` + detecção + **DELETE cirúrgico** |
| `compare-customer-process` | `omie_customer_account_map_fresco` (view fresca) → tabela base (2 pontos) |

**Impacto money-path:** a proof-table `omie_customer_account_map` voltou a gravar código **ambíguo** por last-write-wins (2+ registros Omie, mesmo doc, mesma conta → código arbitrário) → Customer360/compare pegam itens do **par errado**. E o compare reabriu o staleness (lê a base, não a view 7d).

## Correção

`git checkout 6ade2dbb -- <os 2 arquivos>` — restaura o estado **exato** do #1268 (conteúdo verbatim, já validado no CI original). Sem lógica nova.

## Evidência

O canário `edge-money-path-invariants.test.ts` foi feito para *"pegar reversão do Lovable"*:
- **Antes** (main): `3 failed | 36 passed` — `× PARIDADE: pega reversão do Lovable`
- **Depois** (este PR): `46 passed (2 files)` ✅

## ⚠️ DEPLOY DO FOUNDER (obrigatório — senão reverte de novo)

O merge **não** basta: o Lovable não lê edges do GitHub no deploy — foi essa a causa raiz. Após o merge:

1. **Re-deployar os 2 edges no chat do Lovable, colando o código VERBATIM do repo:**
   - `supabase/functions/omie-analytics-sync/index.ts`
   - `supabase/functions/compare-customer-process/index.ts`
2. **Verificar anti-reversão** (`lovable-deploy-verify`): confirmar que o commit "Changes"/"Deployed" gerado pelo Lovable **não** removeu o helper de novo (`grep docsComCodigoAmbiguoNoOmie` no bundle deployado).
3. **Forçar 1 run do `syncCustomers`** (3 contas) para o DELETE cirúrgico limpar vínculos ambíguos pré-existentes na proof-table.

Sem migration nova (a view fresca do P1a já está no banco desde o #1268).

🤖 Generated with [Claude Code](https://claude.com/claude-code)