### PR TITLE
fix(carteira): semáforo mede a carteira operacional + cron mensal cai pro efeito

### DIFF
--- a/db/test-carteira-saude-eligible-efeito.sh
+++ b/db/test-carteira-saude-eligible-efeito.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA: get_carteira_saude() v2                                 ║
+# ║  Migration 20260710012337_carteira_saude_eligible_e_efeito_mensal.sql          ║
+# ║  (1) sync/coverage medem só a carteira operacional (eligible=true)             ║
+# ║  (2) cron mensal cai pro EFEITO (max created_at do snapshot) quando o purge    ║
+# ║      do cron.job_run_details expurgou o run — sem vazar pros nightly           ║
+# ║  (3) gate SECURITY DEFINER: NULL p/ anon e p/ não-staff                        ║
+# ║                                                                                ║
+# ║  Rode:  bash db/test-carteira-saude-eligible-efeito.sh > /tmp/t.log 2>&1; echo $?  ║
+# ║  Lei de Ferro: 1) migration REAL  2) negativo com condição esperada            ║
+# ║                3) FALSIFICAÇÃO (sabota → exige vermelho → restaura).           ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="carteira-saude-eligible"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "/tmp/fn-${SLUG}"-*.sql 2>/dev/null || true; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: enum/role, has_role (semântica da prod), tabelas lidas
+# (cron.job / cron.job_run_details já vêm do stubs-supabase.sql)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role public.app_role);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS
+$f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+CREATE TABLE public.carteira_assignments (
+  customer_user_id uuid,
+  eligible boolean NOT NULL DEFAULT true,
+  last_synced_at timestamptz
+);
+CREATE TABLE public.farmer_client_scores  (customer_user_id uuid);
+CREATE TABLE public.customer_visit_scores (customer_user_id uuid);
+CREATE TABLE public.carteira_positivacao_snapshot (created_at timestamptz);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260710012337_carteira_saude_eligible_e_efeito_mensal.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED
+#   staff aaaa… (employee) · cust bbbb… (customer)
+#   elegíveis: c1(fcs+cvs) c2(fcs+cvs) c3(fcs, SEM cvs) — synced há 5h
+#   não-elegíveis: c4 (last_synced_at NULL → stale se contasse)
+#                  c5 (synced AGORA → seria o max se contasse)
+#   fcs extra: c9 fora da carteira (não conta)
+#   crons: 4 da lista + 1 fora; run só do rebuild (succeeded há 10h)
+#   snapshot: efeito há 9d (≈216h) e há 40d — run do mensal NÃO existe (purgado)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO public.user_roles VALUES
+  ('aaaaaaaa-0000-0000-0000-000000000001','employee'),
+  ('bbbbbbbb-0000-0000-0000-000000000001','customer');
+
+INSERT INTO public.carteira_assignments (customer_user_id, eligible, last_synced_at) VALUES
+  ('00000000-0000-0000-0000-000000000001', true,  now() - interval '5 hours'),
+  ('00000000-0000-0000-0000-000000000002', true,  now() - interval '5 hours'),
+  ('00000000-0000-0000-0000-000000000003', true,  now() - interval '5 hours'),
+  ('00000000-0000-0000-0000-000000000004', false, NULL),
+  ('00000000-0000-0000-0000-000000000005', false, now());
+
+INSERT INTO public.farmer_client_scores VALUES
+  ('00000000-0000-0000-0000-000000000001'),
+  ('00000000-0000-0000-0000-000000000002'),
+  ('00000000-0000-0000-0000-000000000003'),
+  ('00000000-0000-0000-0000-000000000009');
+
+INSERT INTO public.customer_visit_scores VALUES
+  ('00000000-0000-0000-0000-000000000001'),
+  ('00000000-0000-0000-0000-000000000002');
+
+INSERT INTO cron.job (jobid, jobname, active) VALUES
+  (1, 'carteira-rebuild-nightly',             true),
+  (2, 'scoring-recalc-batch-nightly',         true),
+  (3, 'visit-score-recalc-batch-nightly',     true),
+  (4, 'carteira-positivacao-snapshot-mensal', true),
+  (5, 'fin-sync-cp-2x',                       true);
+
+INSERT INTO cron.job_run_details (jobid, runid, status, return_message, start_time) VALUES
+  (1, 101, 'succeeded', NULL, now() - interval '10 hours');
+
+INSERT INTO public.carteira_positivacao_snapshot (created_at) VALUES
+  (now() - interval '9 days'),
+  (now() - interval '40 days');
+SQL
+
+# helper: campo do cron <jobname> a partir do resultado da RPC (como staff)
+cron_field() { # $1 jobname  $2 expr jsonb sobre o elemento c
+  Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001';
+         SELECT coalesce(${2}, '(null)')
+         FROM jsonb_array_elements(public.get_carteira_saude()->'crons') c
+         WHERE c->>'jobname' = '${1}';" | tail -1
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── gate (SECURITY DEFINER) ──"
+V=$(Pq -c "SELECT public.get_carteira_saude() IS NULL;" | tail -1)
+eq "A1 anon (uid NULL) → NULL" "$V" "t"
+V=$(Pq -c "SET test.uid='bbbbbbbb-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude() IS NULL;" | tail -1)
+eq "A2 customer (não-staff) → NULL" "$V" "t"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude() IS NOT NULL;" | tail -1)
+eq "A3 employee → resultado" "$V" "t"
+
+echo "── score_coverage (eligible-only) ──"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude()->'score_coverage'->>'carteira';" | tail -1)
+eq "A4 carteira = só elegíveis" "$V" "3"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude()->'score_coverage'->>'fcs_clientes';" | tail -1)
+eq "A5 fcs_clientes = elegíveis com farmer score" "$V" "3"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude()->'score_coverage'->>'cvs_clientes';" | tail -1)
+eq "A6 cvs_clientes = elegíveis com visit score" "$V" "2"
+
+echo "── sync (eligible-only) ──"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude()->'sync'->>'stale_count';" | tail -1)
+eq "A7 stale_count ignora não-elegível NULL" "$V" "0"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001';
+           SELECT CASE WHEN (public.get_carteira_saude()->'sync'->>'age_hours')::numeric BETWEEN 4.9 AND 5.1
+                       THEN 'ok' ELSE 'ERR:' || (public.get_carteira_saude()->'sync'->>'age_hours') END;" | tail -1)
+eq "A8 max_last_synced_at ignora não-elegível de agora (age≈5h)" "$V" "ok"
+
+echo "── crons (fallback por efeito só no mensal) ──"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT jsonb_array_length(public.get_carteira_saude()->'crons');" | tail -1)
+eq "A9 só os 4 crons da lista" "$V" "4"
+V=$(cron_field 'carteira-rebuild-nightly' "c->>'last_status'")
+eq "A10 rebuild usa o run real (succeeded)" "$V" "succeeded"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_status'")
+eq "A11 mensal sem run + efeito → succeeded (fallback)" "$V" "succeeded"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' \
+  "CASE WHEN (c->>'age_hours')::numeric BETWEEN 215 AND 217 THEN 'ok' ELSE 'ERR:' || (c->>'age_hours') END")
+eq "A12 mensal reporta idade do efeito MAIS RECENTE (≈216h, não 40d)" "$V" "ok"
+V=$(cron_field 'scoring-recalc-batch-nightly' "c->>'last_status'")
+eq "A13 nightly sem run NÃO herda o fallback (null)" "$V" "(null)"
+
+# A14: run FAILED recente do mensal VENCE o efeito (falha real não é mascarada)
+P -q -c "INSERT INTO cron.job_run_details (jobid, runid, status, return_message, start_time)
+         VALUES (4, 401, 'failed', 'boom-mensal', now() - interval '1 hour');"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_status'")
+eq "A14a mensal com run failed → failed (efeito não mascara)" "$V" "failed"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_error'")
+eq "A14b last_error propagado" "$V" "boom-mensal"
+P -q -c "DELETE FROM cron.job_run_details WHERE runid = 401;"
+
+# A15: sem run E sem efeito → 'nunca rodou' verdadeiro (null/null)
+P -q -c "TRUNCATE public.carteira_positivacao_snapshot;"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_status'")
+eq "A15a sem efeito → last_status null" "$V" "(null)"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_run_at'")
+eq "A15b sem efeito → last_run_at null" "$V" "(null)"
+P -q -c "INSERT INTO public.carteira_positivacao_snapshot (created_at)
+         VALUES (now() - interval '9 days'), (now() - interval '40 days');"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (sabota a migration → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+
+# F1: remove o filtro eligible (regressão pra v1) → A4 tem que divergir de 3
+SAB1="/tmp/fn-${SLUG}-f1.sql"
+perl -0pe 's/WHERE ca\.eligible\s+AND /WHERE /g; s/\n\s*WHERE eligible\n/\n/g; s/carteira_assignments WHERE eligible\)/carteira_assignments)/g' "$MIG" > "$SAB1"
+if grep -qE 'WHERE (ca\.)?eligible' "$SAB1"; then bad "F1 sabotagem não removeu o filtro (perl falhou)"; fi
+P -q -f "$SAB1"
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude()->'score_coverage'->>'carteira';" | tail -1)
+if [ "$V" = "3" ]; then bad "F1 SEM DENTE — sabotei o eligible e A4 seguiu 3"; else ok "F1 sabotagem detectada (carteira=$V ≠ 3 → assert tem dente)"; fi
+P -q -f "$MIG"   # restaura a versão verdadeira
+V=$(Pq -c "SET test.uid='aaaaaaaa-0000-0000-0000-000000000001'; SELECT public.get_carteira_saude()->'score_coverage'->>'carteira';" | tail -1)
+eq "F1-restore migration real de volta (carteira=3)" "$V" "3"
+
+# F2: mata o fallback por efeito (effect_at ← NULL) → A11 tem que sair de 'succeeded'
+SAB2="/tmp/fn-${SLUG}-f2.sql"
+perl -0pe 's/max\(s\.created_at\) AS effect_at/NULL::timestamptz AS effect_at/' "$MIG" > "$SAB2"
+if grep -q 'max(s.created_at)' "$SAB2"; then bad "F2 sabotagem não trocou o effect_at (perl falhou)"; fi
+P -q -f "$SAB2"
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_status'")
+if [ "$V" = "succeeded" ]; then bad "F2 SEM DENTE — matei o fallback e A11 seguiu succeeded"; else ok "F2 sabotagem detectada (mensal=$V → assert tem dente)"; fi
+P -q -f "$MIG"   # restaura
+V=$(cron_field 'carteira-positivacao-snapshot-mensal' "c->>'last_status'")
+eq "F2-restore migration real de volta (mensal=succeeded)" "$V" "succeeded"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **350** custom migrations totais
-- **1247** objetos esperados (criados por estas migrations)
+- **354** custom migrations totais
+- **1251** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 349
+  - `function`: 353
   - `rls_policy`: 277
   - `index`: 208
   - `cron_job`: 146
@@ -2984,6 +2984,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `view` | `public.selfservice_disponibilidade` | — |
 | `view` | `public.selfservice_meus_pedidos` | — |
 
+### `20260708234100_tint_gate_custo_staff.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_tint_price` | — |
+| `function` | `public.get_tint_prices` | — |
+
 ### `20260708234721_sync_customers_colacor_servicos_crons.sql`
 
 | Tipo | Objeto | Parent |
@@ -2996,6 +3003,22 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.fin_estimar_estoque_omie` | — |
+
+### `20260709163000_selfservice_pr00bis_a_rpc_staff_payload.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.staff_get_sales_order_payload` | — |
+
+### `20260709163500_selfservice_pr00bis_b_revoke_omie_payload.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260710012337_carteira_saude_eligible_e_efeito_mensal.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_carteira_saude` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 350
+-- Total de custom migrations: 354
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -388,8 +388,12 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260708204820', 'fin_custo_rateio', '20260708204820_fin_custo_rateio.sql'),
   ('20260708210000', 'tint_cobertura_lista_email', '20260708210000_tint_cobertura_lista_email.sql'),
   ('20260708212123', 'selfservice_pr02a_views_customer', '20260708212123_selfservice_pr02a_views_customer.sql'),
+  ('20260708234100', 'tint_gate_custo_staff', '20260708234100_tint_gate_custo_staff.sql'),
   ('20260708234721', 'sync_customers_colacor_servicos_crons', '20260708234721_sync_customers_colacor_servicos_crons.sql'),
-  ('20260709120500', 'authz_estimar_estoque_omie', '20260709120500_authz_estimar_estoque_omie.sql')
+  ('20260709120500', 'authz_estimar_estoque_omie', '20260709120500_authz_estimar_estoque_omie.sql'),
+  ('20260709163000', 'selfservice_pr00bis_a_rpc_staff_payload', '20260709163000_selfservice_pr00bis_a_rpc_staff_payload.sql'),
+  ('20260709163500', 'selfservice_pr00bis_b_revoke_omie_payload', '20260709163500_selfservice_pr00bis_b_revoke_omie_payload.sql'),
+  ('20260710012337', 'carteira_saude_eligible_e_efeito_mensal', '20260710012337_carteira_saude_eligible_e_efeito_mensal.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1625,9 +1629,13 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_catalogo', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_disponibilidade', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_meus_pedidos', ''),
+  ('tint_gate_custo_staff', 'function', 'public', 'get_tint_price', ''),
+  ('tint_gate_custo_staff', 'function', 'public', 'get_tint_prices', ''),
   ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-colacor-vendas-daily', ''),
   ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-servicos-daily', ''),
-  ('authz_estimar_estoque_omie', 'function', 'public', 'fin_estimar_estoque_omie', '')
+  ('authz_estimar_estoque_omie', 'function', 'public', 'fin_estimar_estoque_omie', ''),
+  ('selfservice_pr00bis_a_rpc_staff_payload', 'function', 'public', 'staff_get_sales_order_payload', ''),
+  ('carteira_saude_eligible_e_efeito_mensal', 'function', 'public', 'get_carteira_saude', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2911,9 +2919,13 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_catalogo', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_disponibilidade', ''),
   ('selfservice_pr02a_views_customer', 'view', 'public', 'selfservice_meus_pedidos', ''),
+  ('tint_gate_custo_staff', 'function', 'public', 'get_tint_price', ''),
+  ('tint_gate_custo_staff', 'function', 'public', 'get_tint_prices', ''),
   ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-colacor-vendas-daily', ''),
   ('sync_customers_colacor_servicos_crons', 'cron_job', 'cron', 'sync-customers-servicos-daily', ''),
-  ('authz_estimar_estoque_omie', 'function', 'public', 'fin_estimar_estoque_omie', '')
+  ('authz_estimar_estoque_omie', 'function', 'public', 'fin_estimar_estoque_omie', ''),
+  ('selfservice_pr00bis_a_rpc_staff_payload', 'function', 'public', 'staff_get_sales_order_payload', ''),
+  ('carteira_saude_eligible_e_efeito_mensal', 'function', 'public', 'get_carteira_saude', '')
 )
 SELECT
   e.migration,

--- a/src/components/carteira/CarteiraSaudePanel.tsx
+++ b/src/components/carteira/CarteiraSaudePanel.tsx
@@ -13,6 +13,10 @@ const DOT: Record<SaudeNivel, string> = {
 };
 
 const NIGHTLY_MAX_AGE = 48;
+// Mensal alerta se o snapshot mais recente passa de ~35 dias. A RPC cai pro EFEITO
+// (max created_at do snapshot) quando o purge do job_run_details apaga o run mensal —
+// então idade grande aqui é atraso REAL, não cegueira de histórico.
+const MENSAL_MAX_AGE = 24 * 35;
 const MENSAL = 'carteira-positivacao-snapshot-mensal';
 
 function Row({ nivel, label, detail, acao }: { nivel: SaudeNivel; label: string; detail: string; acao: string }) {
@@ -37,7 +41,7 @@ export function CarteiraSaudePanel() {
     if (!data || tracked.current) return;
     tracked.current = true;
     const niveis = [
-      ...data.crons.map((c) => statusCron(c, c.jobname === MENSAL ? null : NIGHTLY_MAX_AGE).nivel),
+      ...data.crons.map((c) => statusCron(c, c.jobname === MENSAL ? MENSAL_MAX_AGE : NIGHTLY_MAX_AGE).nivel),
       statusSync(data.sync).nivel,
       statusCoverage(data.score_coverage).nivel,
     ];
@@ -54,7 +58,7 @@ export function CarteiraSaudePanel() {
   if (!data) return null;
 
   const cronRows = data.crons.map((c) => {
-    const st = statusCron(c, c.jobname === MENSAL ? null : NIGHTLY_MAX_AGE);
+    const st = statusCron(c, c.jobname === MENSAL ? MENSAL_MAX_AGE : NIGHTLY_MAX_AGE);
     const detail = c.last_run_at ? `${c.last_status ?? '?'} · há ${c.age_hours ?? '?'}h` : 'nunca rodou';
     return { ...st, label: c.jobname, detail };
   });

--- a/src/lib/carteira-saude/__tests__/status.test.ts
+++ b/src/lib/carteira-saude/__tests__/status.test.ts
@@ -15,8 +15,19 @@ describe('statusCron', () => {
   it('sucesso recente → green', () => {
     expect(statusCron({ last_status: 'succeeded', age_hours: 10 }, 48).nivel).toBe('green');
   });
-  it('maxAge null (mensal) não alerta por idade → green', () => {
+  it('maxAge null não alerta por idade → green', () => {
     expect(statusCron({ last_status: 'succeeded', age_hours: 600 }, null).nivel).toBe('green');
+  });
+  it('mensal dentro de 35d → green', () => {
+    expect(statusCron({ last_status: 'succeeded', age_hours: 700 }, 24 * 35).nivel).toBe('green');
+  });
+  it('mensal além de 35d → red, idade em dias', () => {
+    const st = statusCron({ last_status: 'succeeded', age_hours: 912 }, 24 * 35);
+    expect(st.nivel).toBe('red');
+    expect(st.acao).toContain('38d');
+  });
+  it('atraso curto mantém idade em horas', () => {
+    expect(statusCron({ last_status: 'succeeded', age_hours: 60 }, 48).acao).toContain('60h');
   });
 });
 

--- a/src/lib/carteira-saude/status.ts
+++ b/src/lib/carteira-saude/status.ts
@@ -15,7 +15,8 @@ export function statusCron(
     return { nivel: 'red', acao: 'Última execução falhou — ver logs / reinvocar no Lovable.' };
   }
   if (maxAgeHours != null && c.age_hours != null && c.age_hours > maxAgeHours) {
-    return { nivel: 'red', acao: `Atrasado — não roda há ${Math.round(c.age_hours)}h.` };
+    const idade = c.age_hours >= 72 ? `${Math.round(c.age_hours / 24)}d` : `${Math.round(c.age_hours)}h`;
+    return { nivel: 'red', acao: `Atrasado — não roda há ${idade}.` };
   }
   return { nivel: 'green', acao: 'OK.' };
 }

--- a/supabase/migrations/20260710012337_carteira_saude_eligible_e_efeito_mensal.sql
+++ b/supabase/migrations/20260710012337_carteira_saude_eligible_e_efeito_mensal.sql
@@ -1,0 +1,102 @@
+-- ============================================================
+-- get_carteira_saude() v2 — conserta 2 falsos alarmes do semáforo
+-- (diagnóstico 2026-07-09, painel /admin/analytics-sync)
+--
+-- (1) score_coverage/sync: o denominador contava a carteira INTEIRA
+--     (6.909), mas 2.107 assignments são eligible=false (clones Colacor SC,
+--     fornecedores flaggeados, órfãos) — escondidos da tela POR DESIGN do
+--     carteira-rebuild e nunca processados pelos motores de score.
+--     Resultado: "Cobertura de score incompleta" vermelho PERMANENTE mesmo
+--     com 100% dos elegíveis cobertos (4.802/4.802 farmer no diagnóstico).
+--     Agora os 3 blocos medem só a carteira operacional (eligible=true) —
+--     o mesmo recorte que a tela mostra.
+--
+-- (2) crons: o purge-cron-job-run-details (diário 04:00, retenção ~8d)
+--     expurga o run de um cron MENSAL na maior parte do mês → o painel
+--     mentia "nunca rodou" para carteira-positivacao-snapshot-mensal
+--     (rodou 2026-07-01 08:00; efeito: 20.726 linhas no snapshot).
+--     Fallback pro EFEITO: quando job_run_details não tem linha, o cron
+--     mensal reporta max(created_at) de carteira_positivacao_snapshot
+--     como last_run_at (status 'succeeded' — o efeito é a prova).
+--     O front passa a alertar snapshot atrasado (>35d) — antes era surdo.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_carteira_saude()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  uid uuid := auth.uid();
+  result jsonb;
+BEGIN
+  IF uid IS NULL THEN RETURN NULL; END IF;
+  IF NOT (has_role(uid, 'master'::app_role) OR has_role(uid, 'employee'::app_role)) THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT jsonb_build_object(
+    'crons', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'jobname', j.jobname,
+        'last_status', COALESCE(r.status,
+                                CASE WHEN ef.effect_at IS NOT NULL THEN 'succeeded' END),
+        'last_run_at', COALESCE(r.start_time, ef.effect_at),
+        'age_hours', CASE WHEN COALESCE(r.start_time, ef.effect_at) IS NULL THEN NULL
+                          ELSE round(extract(epoch FROM (now() - COALESCE(r.start_time, ef.effect_at))) / 3600.0, 1) END,
+        'last_error', CASE WHEN lower(coalesce(r.status, '')) IN ('failed','failure','error')
+                           THEN r.return_message ELSE NULL END
+      ) ORDER BY j.jobname)
+      FROM cron.job j
+      LEFT JOIN LATERAL (
+        SELECT d.status, d.start_time, d.return_message
+        FROM cron.job_run_details d
+        WHERE d.jobid = j.jobid
+        ORDER BY d.start_time DESC NULLS LAST
+        LIMIT 1
+      ) r ON true
+      LEFT JOIN LATERAL (
+        -- Fallback por EFEITO (só o cron mensal): o purge diário de
+        -- job_run_details apaga o run mensal na maior parte do mês; o
+        -- snapshot gravado é a verdade de que ele rodou.
+        SELECT max(s.created_at) AS effect_at
+        FROM public.carteira_positivacao_snapshot s
+        WHERE j.jobname = 'carteira-positivacao-snapshot-mensal'
+      ) ef ON true
+      WHERE j.jobname IN (
+        'carteira-rebuild-nightly',
+        'scoring-recalc-batch-nightly',
+        'visit-score-recalc-batch-nightly',
+        'carteira-positivacao-snapshot-mensal'
+      )
+    ), '[]'::jsonb),
+    'sync', (
+      SELECT jsonb_build_object(
+        'max_last_synced_at', max(last_synced_at),
+        'age_hours', CASE WHEN max(last_synced_at) IS NULL THEN NULL
+                          ELSE round(extract(epoch FROM (now() - max(last_synced_at))) / 3600.0, 1) END,
+        'stale_count', count(*) FILTER (
+          WHERE last_synced_at IS NULL OR last_synced_at < now() - interval '48 hours')
+      )
+      FROM public.carteira_assignments
+      WHERE eligible
+    ),
+    'score_coverage', jsonb_build_object(
+      'carteira', (SELECT count(*) FROM public.carteira_assignments WHERE eligible),
+      'fcs_clientes', (
+        SELECT count(*) FROM public.carteira_assignments ca
+        WHERE ca.eligible
+          AND EXISTS (SELECT 1 FROM public.farmer_client_scores f WHERE f.customer_user_id = ca.customer_user_id)
+      ),
+      'cvs_clientes', (
+        SELECT count(*) FROM public.carteira_assignments ca
+        WHERE ca.eligible
+          AND EXISTS (SELECT 1 FROM public.customer_visit_scores c WHERE c.customer_user_id = ca.customer_user_id)
+      )
+    )
+  ) INTO result;
+
+  RETURN result;
+END;
+$function$;


### PR DESCRIPTION
## Contexto

Painel **Saúde da carteira** (`/admin/analytics-sync`) mostrava dois alarmes permanentes. Diagnóstico direto na prod (psql-ro, skill diagnose-supabase-sync): **nenhum sync está quebrado** — são dois falsos alarmes do próprio check.

| Alarme no painel | Realidade na prod |
|---|---|
| 🔴 Cobertura de score 6261/6909 · 6253/6909 | Denominador conta 2.107 assignments `eligible=false` (clones Colacor SC, fornecedores, órfãos — escondidos da tela por design do carteira-rebuild). Entre **elegíveis**: farmer **4.802/4.802 = 100%**, visita 4.794/4.802 |
| 🟡 carteira-positivacao-snapshot-mensal "nunca rodou" | **Rodou em 01/07 08:00 UTC** (efeito: 20.726 linhas em `carteira_positivacao_snapshot`). O `purge-cron-job-run-details` (diário, retenção ~8d) expurga o run de um cron MENSAL na maior parte do mês |

## Mudanças

- **Migration** `20260710012337_carteira_saude_eligible_e_efeito_mensal.sql` — `get_carteira_saude()` v2:
  - `sync`/`score_coverage` filtram `eligible=true` (o recorte que a tela mostra e que os motores de score processam);
  - cron mensal cai pro **efeito** (`max(created_at)` do snapshot) quando `job_run_details` foi expurgado; run `failed` recente continua vencendo (falha real não é mascarada); nightlies **não** herdam o fallback.
- **Front**: mensal deixa de ser surdo — `MENSAL_MAX_AGE = 35d` (antes `null`, nunca alertaria snapshot atrasado); mensagem de atraso formata em dias quando ≥72h.

## Prova

- **PG17** `db/test-carteira-saude-eligible-efeito.sh`: **21/21** — gate SECDEF (anon/não-staff → NULL), coverage/sync eligible-only, fallback só no mensal, `failed` vence efeito, "nunca rodou" verdadeiro quando não há efeito, e **2 falsificações com dente** (sabotar o filtro eligible → carteira=5≠3 detectado; matar o fallback → mensal null detectado).
- **Vitest** status.test.ts 19/19 · typecheck 0 · eslint 0.
- **Pré-voo PROD** (read-only): v2 reportará carteira=4.802, fcs=4.802, cvs=4.794, stale=0, mensal age≈209h (verde).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260710012337_carteira_saude_eligible_e_efeito_mensal.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. É preciso colar no SQL Editor do Lovable e rodar (bloco de handoff entregue no chat da sessão, junto com o INSERT one-off que enfileira os 8 elegíveis sem visit score).

Validação pós-apply (read-only):

```sql
SELECT CASE WHEN pg_get_functiondef('public.get_carteira_saude()'::regprocedure) ILIKE '%WHERE ca.eligible%'
            AND  pg_get_functiondef('public.get_carteira_saude()'::regprocedure) ILIKE '%effect_at%'
       THEN '✅ v2 aplicada' ELSE '❌ ainda v1 — migration não aplicada' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)