### PR TITLE
feat(omie-sync): pedido self-service lê view fresca account-correta + fallback fail-closed (P0-B-bis PR-1)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -435,3 +435,84 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
     ).toBe(mirrorBlockNamed(helper, 'omie doc-ambiguo'));
   });
 });
+
+// ── P0-B-bis PR-1 (omie-sync self-service USA a view fresca account-correta + helper espelhado) ──
+// O pedido self-service (conta colacor_sc) resolvia a identidade Omie pelo espelho poluído omie_clientes
+// (mix de contas, rótulo 'colacor' mentiroso) e fallback registros:1 (last-write-wins). Migrado p/ a view
+// fresca omie_customer_account_map_fresco + fallback API fail-closed (registros:2, rejeita doc-ambíguo)
+// via helper puro espelhado. A paridade textual aqui pega a reversão do deploy do Lovable (mesma armadilha
+// do #1272). Ver docs/superpowers/plans/2026-07-09-omie-sync-self-service-view-fresca-pr1.md.
+const OMIE_SYNC = 'supabase/functions/omie-sync/index.ts';
+const SYNC_IDENTIDADE = 'src/lib/omie/omie-sync-identidade.ts';
+
+describe('guardrail money-path: omie-sync self-service USA view fresca account-correta (P0-B-bis PR-1)', () => {
+  const src = read(OMIE_SYNC);
+  const helper = read(SYNC_IDENTIDADE);
+
+  it('sentinela: leu os arquivos reais (edge + helper)', () => {
+    expect(src).toContain('syncClienteOmie');
+    expect(helper).toContain('decidirIdentidadeSelfService');
+  });
+
+  it('o helper puro existe e exporta decidirIdentidadeSelfService', () => {
+    expect(helper).toMatch(/export function decidirIdentidadeSelfService/);
+  });
+
+  it('o edge USA o helper: define o espelho MIRROR E o chama (≥2 menções)', () => {
+    expect(src, 'edge não define mais o helper espelhado de identidade').toMatch(/function decidirIdentidadeSelfService/);
+    expect(
+      src,
+      'REGRESSÃO: edge não chama mais decidirIdentidadeSelfService — voltou a usar o espelho direto?',
+    ).toMatch(/decidirIdentidadeSelfService\(/);
+    expect(
+      count(src, 'decidirIdentidadeSelfService'),
+      'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('LÊ a view fresca account-correta (colacor_sc); omie_clientes só resta como WRITER', () => {
+    // As 3 leituras money-path (pedido, vendedor, check_client) usam a view fresca por conta.
+    expect(
+      count(src, '.from("omie_customer_account_map_fresco")'),
+      'REVERSÃO Lovable? sumiu leitura da view fresca account-correta (esperado 3: pedido, vendedor, check_client)',
+    ).toBe(3);
+    // O filtro de conta é o fail-closed por-conta (sem ele, voltaria a misturar contas).
+    expect(src, 'sumiu o filtro account=colacor_sc na view fresca').toMatch(/\.eq\("account", "colacor_sc"\)/);
+    // O espelho poluído só pode restar como WRITER (o write-back INSERT → Fatia 4), nunca como LEITOR.
+    expect(
+      count(src, '.from("omie_clientes")'),
+      'REGRESSÃO: omie_clientes voltou como LEITOR (deveria restar só o write-back INSERT)',
+    ).toBe(1);
+    expect(
+      src,
+      'REGRESSÃO: o único omie_clientes restante não é o write-back INSERT — leitura do espelho voltou?',
+    ).toMatch(/\.from\("omie_clientes"\)\s*\.insert\(/);
+    expect(
+      src,
+      'REVERSÃO Lovable? voltou a .select() do espelho poluído omie_clientes no caminho money-path',
+    ).not.toMatch(/\.from\("omie_clientes"\)\s*\.select/);
+  });
+
+  it('fallback API do PEDIDO é fail-closed: registros_por_pagina:2 (não 1=last-write-wins)', () => {
+    // Ancorado no log único do pedido self-service (evita casar outros handlers que legitimamente usam :1).
+    expect(
+      src,
+      'REVERSÃO Lovable? o fallback do pedido self-service não usa mais registros_por_pagina:2',
+    ).toMatch(/buscando no Omie por CPF\/CNPJ[\s\S]{0,300}registros_por_pagina:\s*2/);
+    expect(
+      src,
+      'REGRESSÃO: o fallback do pedido self-service voltou a registros_por_pagina:1 (last-write-wins)',
+    ).not.toMatch(/buscando no Omie por CPF\/CNPJ[\s\S]{0,300}registros_por_pagina:\s*1/);
+  });
+
+  it('fail-closed em doc-ambíguo presente (não chuta o 1º código na duplicata-CNPJ)', () => {
+    expect(src, 'sumiu o ramo fail-closed doc-ambíguo do pedido').toMatch(/erro === "doc-ambíguo"/);
+  });
+
+  it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlockNamed(src, 'omie-sync-identidade'),
+      'edge divergiu do helper de src/ — o Lovable reescreveu a lógica de identidade no deploy?',
+    ).toBe(mirrorBlockNamed(helper, 'omie-sync-identidade'));
+  });
+});

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -476,8 +476,12 @@ describe('guardrail money-path: omie-sync self-service USA view fresca account-c
       count(src, '.from("omie_customer_account_map_fresco")'),
       'REVERSÃO Lovable? sumiu leitura da view fresca account-correta (esperado 3: pedido, vendedor, check_client)',
     ).toBe(3);
-    // O filtro de conta é o fail-closed por-conta (sem ele, voltaria a misturar contas).
-    expect(src, 'sumiu o filtro account=colacor_sc na view fresca').toMatch(/\.eq\("account", "colacor_sc"\)/);
+    // O filtro de conta é o fail-closed por-conta. Codex P2: contar == 3 (uma por leitura), não um toMatch
+    // genérico — senão o pedido poderia perder o filtro e o teste passar só porque check_client o mantém.
+    expect(
+      count(src, '.eq("account", "colacor_sc")'),
+      'cada uma das 3 leituras da view DEVE filtrar account=colacor_sc (fail-closed por-conta)',
+    ).toBe(3);
     // O espelho poluído só pode restar como WRITER (o write-back INSERT → Fatia 4), nunca como LEITOR.
     expect(
       count(src, '.from("omie_clientes")'),
@@ -485,15 +489,15 @@ describe('guardrail money-path: omie-sync self-service USA view fresca account-c
     ).toBe(1);
     expect(
       src,
-      'REGRESSÃO: o único omie_clientes restante não é o write-back INSERT — leitura do espelho voltou?',
-    ).toMatch(/\.from\("omie_clientes"\)\s*\.insert\(/);
+      'REGRESSÃO: o único omie_clientes restante não é o write-back (upsert) — leitura do espelho voltou?',
+    ).toMatch(/\.from\("omie_clientes"\)\s*\.upsert\(/);
     expect(
       src,
       'REVERSÃO Lovable? voltou a .select() do espelho poluído omie_clientes no caminho money-path',
     ).not.toMatch(/\.from\("omie_clientes"\)\s*\.select/);
   });
 
-  it('fallback API do PEDIDO é fail-closed: registros_por_pagina:2 (não 1=last-write-wins)', () => {
+  it('fallback API do PEDIDO é fail-closed: registros:2 + guard de truncamento (não 1=last-write-wins)', () => {
     // Ancorado no log único do pedido self-service (evita casar outros handlers que legitimamente usam :1).
     expect(
       src,
@@ -503,6 +507,12 @@ describe('guardrail money-path: omie-sync self-service USA view fresca account-c
       src,
       'REGRESSÃO: o fallback do pedido self-service voltou a registros_por_pagina:1 (last-write-wins)',
     ).not.toMatch(/buscando no Omie por CPF\/CNPJ[\s\S]{0,300}registros_por_pagina:\s*1/);
+    // Codex P1: registros:2 não prova unicidade se truncado → o edge deriva omieTruncado de total_de_paginas
+    // e passa ao helper. Sem isso, [200,200] na pág.1 esconderia um 201 na pág.2 (chuta 200).
+    expect(
+      src,
+      'REGRESSÃO: sumiu o guard de truncamento (total_de_paginas → omieTruncado) — furo do registros:2 reaberto',
+    ).toMatch(/omieTruncado\s*=\s*\(searchResult\.total_de_paginas[\s\S]{0,140}omieTruncado/);
   });
 
   it('fail-closed em doc-ambíguo presente (não chuta o 1º código na duplicata-CNPJ)', () => {

--- a/src/lib/omie/omie-sync-identidade.test.ts
+++ b/src/lib/omie/omie-sync-identidade.test.ts
@@ -48,7 +48,7 @@ describe('decidirIdentidadeSelfService (P0-B-bis fail-closed money-path)', () =>
     expect(r).toEqual({ ok: false, erro: 'doc-ambíguo' });
   });
 
-  it('view ausente, API 2 matches com o MESMO código (duplicata na paginação) → ok (não é ambíguo)', () => {
+  it('view ausente, API 2 matches com o MESMO código (duplicata na paginação, sem mais páginas) → ok', () => {
     const r = decidirIdentidadeSelfService({
       viewRow: null,
       omieMatches: [
@@ -57,6 +57,35 @@ describe('decidirIdentidadeSelfService (P0-B-bis fail-closed money-path)', () =>
       ],
     });
     expect(r).toEqual({ ok: true, codigo_cliente: 200, codigo_vendedor: 7 });
+  });
+
+  it('view ausente, 1 código visto MAS busca TRUNCADA (há mais páginas) → fail-closed doc-ambíguo (Codex P1)', () => {
+    // registros:2 sozinho não prova unicidade: [200,200] na pág.1 pode esconder um 201 na pág.2.
+    // total_de_paginas>1 → não posso provar código único → precisão>recall bloqueia.
+    const r = decidirIdentidadeSelfService({
+      viewRow: null,
+      omieMatches: [{ codigo_cliente: 200, codigo_vendedor: 7 }, { codigo_cliente: 200, codigo_vendedor: 7 }],
+      omieTruncado: true,
+    });
+    expect(r).toEqual({ ok: false, erro: 'doc-ambíguo' });
+  });
+
+  it('view ausente, 1 match e NÃO truncado → ok (o caso normal do fluxo)', () => {
+    const r = decidirIdentidadeSelfService({
+      viewRow: null,
+      omieMatches: [{ codigo_cliente: 200, codigo_vendedor: 7 }],
+      omieTruncado: false,
+    });
+    expect(r).toEqual({ ok: true, codigo_cliente: 200, codigo_vendedor: 7 });
+  });
+
+  it('view PRESENTE ignora omieTruncado (a view não é paginada) → ok', () => {
+    const r = decidirIdentidadeSelfService({
+      viewRow: { codigo_cliente: 100, codigo_vendedor: null },
+      omieMatches: null,
+      omieTruncado: true,
+    });
+    expect(r).toEqual({ ok: true, codigo_cliente: 100, codigo_vendedor: null });
   });
 
   it('view ausente, API 0 match (ausência confirmada) → fail-closed sem-vinculo', () => {

--- a/src/lib/omie/omie-sync-identidade.test.ts
+++ b/src/lib/omie/omie-sync-identidade.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { decidirIdentidadeSelfService, type MatchOmie } from './omie-sync-identidade';
+
+// P0-B-bis PR-1 — identidade Omie do PEDIDO SELF-SERVICE (conta colacor_sc) resolvida pela VIEW FRESCA
+// account-correta + fallback API fail-closed (registros_por_pagina:2). Precisão>recall.
+// Falsificação: os casos +/- se falsificam MUTUAMENTE — um helper que sempre pega o 1º match reprova o
+// caso doc-ambíguo (esperaria ok:false, veria ok:true); um que sempre rejeita reprova os casos ok.
+// Ver docs/superpowers/plans/2026-07-09-omie-sync-self-service-view-fresca-pr1.md (Task 1).
+describe('decidirIdentidadeSelfService (P0-B-bis fail-closed money-path)', () => {
+  it('view fresca presente → ok com o código da view (fonte account-correta, sem API)', () => {
+    const r = decidirIdentidadeSelfService({
+      viewRow: { codigo_cliente: 100, codigo_vendedor: 9 },
+      omieMatches: null,
+    });
+    expect(r).toEqual({ ok: true, codigo_cliente: 100, codigo_vendedor: 9 });
+  });
+
+  it('view presente com vendedor NULL → ok com vendedor null (colacor_sc não tem vendedor)', () => {
+    // Caso REAL: a proof colacor_sc tem omie_codigo_vendedor 100% NULL (psql-ro 2026-07-09).
+    const r = decidirIdentidadeSelfService({
+      viewRow: { codigo_cliente: 100, codigo_vendedor: null },
+      omieMatches: null,
+    });
+    expect(r).toEqual({ ok: true, codigo_cliente: 100, codigo_vendedor: null });
+  });
+
+  it('view ausente e API ainda não buscada → pede Omie (needOmie)', () => {
+    const r = decidirIdentidadeSelfService({ viewRow: null, omieMatches: null });
+    expect(r).toEqual({ ok: false, needOmie: true });
+  });
+
+  it('view ausente, API 1 match → ok com o código do Omie', () => {
+    const r = decidirIdentidadeSelfService({
+      viewRow: null,
+      omieMatches: [{ codigo_cliente: 200, codigo_vendedor: 7 }],
+    });
+    expect(r).toEqual({ ok: true, codigo_cliente: 200, codigo_vendedor: 7 });
+  });
+
+  it('view ausente, API 2 matches com códigos DISTINTOS → fail-closed doc-ambíguo (fecha last-write-wins)', () => {
+    const r = decidirIdentidadeSelfService({
+      viewRow: null,
+      omieMatches: [
+        { codigo_cliente: 200, codigo_vendedor: 7 },
+        { codigo_cliente: 201, codigo_vendedor: 7 },
+      ],
+    });
+    expect(r).toEqual({ ok: false, erro: 'doc-ambíguo' });
+  });
+
+  it('view ausente, API 2 matches com o MESMO código (duplicata na paginação) → ok (não é ambíguo)', () => {
+    const r = decidirIdentidadeSelfService({
+      viewRow: null,
+      omieMatches: [
+        { codigo_cliente: 200, codigo_vendedor: 7 },
+        { codigo_cliente: 200, codigo_vendedor: 7 },
+      ],
+    });
+    expect(r).toEqual({ ok: true, codigo_cliente: 200, codigo_vendedor: 7 });
+  });
+
+  it('view ausente, API 0 match (ausência confirmada) → fail-closed sem-vinculo', () => {
+    const r = decidirIdentidadeSelfService({ viewRow: null, omieMatches: [] });
+    expect(r).toEqual({ ok: false, erro: 'sem-vinculo' });
+  });
+
+  it('código não SafeInteger (bigint ≥ 2^53) → fail-closed codigo-inseguro (não trunca p/ o Omie)', () => {
+    // Alinhado ao guard do irmão decideAccountIdentity: Number perde precisão ≥ 2^53 → cliente errado.
+    const r = decidirIdentidadeSelfService({
+      viewRow: { codigo_cliente: Number.MAX_SAFE_INTEGER + 1, codigo_vendedor: null },
+      omieMatches: null,
+    });
+    expect(r).toEqual({ ok: false, erro: 'codigo-inseguro' });
+  });
+
+  it('código zero/negativo → fail-closed codigo-inseguro', () => {
+    expect(decidirIdentidadeSelfService({ viewRow: { codigo_cliente: 0, codigo_vendedor: null }, omieMatches: null }))
+      .toEqual({ ok: false, erro: 'codigo-inseguro' });
+  });
+
+  // ── FALSIFICAÇÃO explícita: um helper que ignora a ambiguidade e pega o 1º match daria ok:true no caso
+  //    doc-ambíguo. Este teste crava que o resultado ambíguo NÃO é o 1º código (o assert tem dente).
+  it('FALSIFICAÇÃO: no caso 2-códigos-distintos, NÃO retorna ok com o 1º código (senão seria last-write-wins)', () => {
+    const matches: MatchOmie[] = [
+      { codigo_cliente: 200, codigo_vendedor: 7 },
+      { codigo_cliente: 201, codigo_vendedor: 7 },
+    ];
+    const r = decidirIdentidadeSelfService({ viewRow: null, omieMatches: matches });
+    expect(r.ok).toBe(false);
+    // um helper ingênuo retornaria { ok:true, codigo_cliente:200, ... } — provamos que NÃO é isso.
+    expect(r).not.toEqual({ ok: true, codigo_cliente: 200, codigo_vendedor: 7 });
+  });
+});

--- a/src/lib/omie/omie-sync-identidade.ts
+++ b/src/lib/omie/omie-sync-identidade.ts
@@ -15,12 +15,15 @@ export type IdentidadeSelfService =
 export function decidirIdentidadeSelfService(args: {
   viewRow: MatchOmie | null;
   omieMatches: MatchOmie[] | null;
+  /** A busca API foi TRUNCADA (Omie indicou mais registros que os buscados)? Se sim, registros:2 não
+   *  prova unicidade — pode haver um código distinto nas páginas não vistas (Codex P1). */
+  omieTruncado?: boolean;
 }): IdentidadeSelfService {
-  const { viewRow, omieMatches } = args;
+  const { viewRow, omieMatches, omieTruncado } = args;
 
   let cand: MatchOmie;
   if (viewRow) {
-    // View fresca já é account-correta (1 linha por (user_id, account)) — resolve sem API.
+    // View fresca já é account-correta (1 linha por (user_id, account)) — resolve sem API, não pagina.
     cand = viewRow;
   } else {
     // Ausência na view → o chamador precisa buscar a API Omie por documento.
@@ -29,6 +32,9 @@ export function decidirIdentidadeSelfService(args: {
     const distintos = [...new Map(omieMatches.map((m) => [String(m.codigo_cliente), m])).values()];
     if (distintos.length > 1) return { ok: false, erro: 'doc-ambíguo' };
     if (distintos.length === 0) return { ok: false, erro: 'sem-vinculo' };
+    // 1 código distinto nos matches vistos. Se a busca foi TRUNCADA, um código diferente pode existir
+    // nas páginas não vistas → registros:2 não prova unicidade → fail-closed (não arrisca cliente errado).
+    if (omieTruncado) return { ok: false, erro: 'doc-ambíguo' };
     cand = distintos[0];
   }
 

--- a/src/lib/omie/omie-sync-identidade.ts
+++ b/src/lib/omie/omie-sync-identidade.ts
@@ -1,0 +1,43 @@
+// MIRROR-START omie-sync-identidade — espelhado verbatim em supabase/functions/omie-sync/index.ts
+// Decisão de identidade Omie do PEDIDO SELF-SERVICE (conta colacor_sc) — money-path P0-B-bis. PURA:
+// recebe a linha da VIEW FRESCA account-correta (omie_customer_account_map_fresco) já buscada + os
+// matches da API Omie (registros_por_pagina:2) e decide o código autoritativo OU fail-closed.
+// Precisão>recall: doc-ambíguo (2+ códigos distintos), ausência confirmada, ou código bigint não
+// representável = REJECT. NÃO lê o espelho poluído omie_clientes. A âncora (user_id, account) e o I/O
+// (buscar a view, buscar a API, write-back) ficam no chamador; aqui só a decisão. Espelhado no edge
+// (Deno não importa de src/); paridade textual no CI em src/__tests__/edge-money-path-invariants.test.ts.
+export interface MatchOmie { codigo_cliente: number; codigo_vendedor: number | null }
+export type IdentidadeSelfService =
+  | { ok: true; codigo_cliente: number; codigo_vendedor: number | null }
+  | { ok: false; needOmie: true }
+  | { ok: false; erro: 'doc-ambíguo' | 'sem-vinculo' | 'codigo-inseguro' };
+
+export function decidirIdentidadeSelfService(args: {
+  viewRow: MatchOmie | null;
+  omieMatches: MatchOmie[] | null;
+}): IdentidadeSelfService {
+  const { viewRow, omieMatches } = args;
+
+  let cand: MatchOmie;
+  if (viewRow) {
+    // View fresca já é account-correta (1 linha por (user_id, account)) — resolve sem API.
+    cand = viewRow;
+  } else {
+    // Ausência na view → o chamador precisa buscar a API Omie por documento.
+    if (omieMatches === null) return { ok: false, needOmie: true };
+    // Dedup por código: 2+ códigos DISTINTOS no mesmo doc = ambíguo — chutar o 1º seria last-write-wins.
+    const distintos = [...new Map(omieMatches.map((m) => [String(m.codigo_cliente), m])).values()];
+    if (distintos.length > 1) return { ok: false, erro: 'doc-ambíguo' };
+    if (distintos.length === 0) return { ok: false, erro: 'sem-vinculo' };
+    cand = distintos[0];
+  }
+
+  // Segurança de representação (bigint): códigos Omie são bigint; Number perde precisão ≥ 2^53. Um código
+  // truncado mandaria o pedido pro cliente errado — fail-closed em vez de arriscar (espelha o guard do
+  // decideAccountIdentity). Vendedor é secundário (não é âncora de identidade) → passa como veio.
+  if (!Number.isSafeInteger(cand.codigo_cliente) || cand.codigo_cliente <= 0) {
+    return { ok: false, erro: 'codigo-inseguro' };
+  }
+  return { ok: true, codigo_cliente: cand.codigo_cliente, codigo_vendedor: cand.codigo_vendedor };
+}
+// MIRROR-END

--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -853,12 +853,16 @@ serve(async (req) => {
           // Use vendedor passed from frontend if available (already resolved per-account)
           let omieCodigoVendedor: number | undefined = staffContext.customerCodigoVendedor || undefined;
 
-          // Fallback: look up from omie_clientes if not passed
+          // P0-B-bis: fallback do vendedor pela VIEW FRESCA account-correta (colacor_sc), não o espelho
+          // poluído omie_clientes (poderia devolver vendedor de OUTRA conta). Nota: colacor_sc hoje tem
+          // omie_codigo_vendedor 100% NULL (psql-ro) → na prática cai no fallback API abaixo — que é mais
+          // correto que herdar um vendedor de conta errada.
           if (!omieCodigoVendedor && staffContext.customerUserId) {
             const { data: mapping } = await supabaseAdmin
-              .from("omie_clientes")
+              .from("omie_customer_account_map_fresco")
               .select("omie_codigo_vendedor")
               .eq("user_id", staffContext.customerUserId)
+              .eq("account", "colacor_sc")
               .maybeSingle();
             omieCodigoVendedor = mapping?.omie_codigo_vendedor || undefined;
           }
@@ -1050,14 +1054,18 @@ serve(async (req) => {
       }
 
       case "check_client": {
+        // P0-B-bis: view fresca account-correta (colacor_sc), não o espelho poluído. Ausência → honesto
+        // (exists:false); sem fallback API — não há consumidor money-path (o pedido resolve via
+        // syncClienteOmie, que já tem fallback API fail-closed). exists sse há código na conta do fluxo.
         const { data: mapping } = await supabaseAdmin
-          .from("omie_clientes")
+          .from("omie_customer_account_map_fresco")
           .select("omie_codigo_cliente")
           .eq("user_id", userId)
+          .eq("account", "colacor_sc")
           .maybeSingle();
 
         result = {
-          exists: !!mapping,
+          exists: !!mapping?.omie_codigo_cliente,
           omie_codigo_cliente: mapping?.omie_codigo_cliente || null,
         };
         break;

--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -222,12 +222,15 @@ type IdentidadeSelfService =
 function decidirIdentidadeSelfService(args: {
   viewRow: MatchOmie | null;
   omieMatches: MatchOmie[] | null;
+  /** A busca API foi TRUNCADA (Omie indicou mais registros que os buscados)? Se sim, registros:2 não
+   *  prova unicidade — pode haver um código distinto nas páginas não vistas (Codex P1). */
+  omieTruncado?: boolean;
 }): IdentidadeSelfService {
-  const { viewRow, omieMatches } = args;
+  const { viewRow, omieMatches, omieTruncado } = args;
 
   let cand: MatchOmie;
   if (viewRow) {
-    // View fresca já é account-correta (1 linha por (user_id, account)) — resolve sem API.
+    // View fresca já é account-correta (1 linha por (user_id, account)) — resolve sem API, não pagina.
     cand = viewRow;
   } else {
     // Ausência na view → o chamador precisa buscar a API Omie por documento.
@@ -236,6 +239,9 @@ function decidirIdentidadeSelfService(args: {
     const distintos = [...new Map(omieMatches.map((m) => [String(m.codigo_cliente), m])).values()];
     if (distintos.length > 1) return { ok: false, erro: 'doc-ambíguo' };
     if (distintos.length === 0) return { ok: false, erro: 'sem-vinculo' };
+    // 1 código distinto nos matches vistos. Se a busca foi TRUNCADA, um código diferente pode existir
+    // nas páginas não vistas → registros:2 não prova unicidade → fail-closed (não arrisca cliente errado).
+    if (omieTruncado) return { ok: false, erro: 'doc-ambíguo' };
     cand = distintos[0];
   }
 
@@ -280,12 +286,15 @@ async function syncClienteOmie(
   // omie_clientes (mix de contas, rótulo 'colacor' mentiroso). Ausência na view → fallback API
   // fail-closed (registros:2, rejeita doc-ambíguo — o :1 antigo era last-write-wins). Ver
   // docs/superpowers/specs/2026-07-09-omie-leituras-money-path-p0b-bis-design.md.
-  const { data: viewRow } = await supabase
+  const { data: viewRow, error: viewErr } = await supabase
     .from("omie_customer_account_map_fresco")
     .select("omie_codigo_cliente, omie_codigo_vendedor")
     .eq("user_id", userId)
     .eq("account", "colacor_sc")
     .maybeSingle();
+  // Erro de leitura (schema/RLS/indisponibilidade) NÃO é ausência — loga e degrada p/ a API fail-closed
+  // (Codex P2: não mascarar erro de leitura como "sem vínculo"; o pedido nunca usa código não-provado).
+  if (viewErr) console.error("[Omie] Erro lendo view fresca (colacor_sc), degradando p/ API:", viewErr.message);
 
   const viaView = decidirIdentidadeSelfService({
     viewRow: viewRow?.omie_codigo_cliente
@@ -323,7 +332,10 @@ async function syncClienteOmie(
       codigo_vendedor: c.recomendacoes?.codigo_vendedor ?? c.codigo_vendedor ?? null,
     }));
 
-  const viaOmie = decidirIdentidadeSelfService({ viewRow: null, omieMatches });
+  // registros:2 lê só a 1ª página; se o Omie indica mais páginas, um código distinto pode estar escondido
+  // além dos 2 vistos (Codex P1) → sinaliza truncado p/ o helper fechar fail-closed em vez de chutar.
+  const omieTruncado = (searchResult.total_de_paginas ?? 1) > 1;
+  const viaOmie = decidirIdentidadeSelfService({ viewRow: null, omieMatches, omieTruncado });
   if (!viaOmie.ok) {
     if ("erro" in viaOmie && viaOmie.erro === "doc-ambíguo") {
       // Fail-closed: 2+ cadastros DISTINTOS no mesmo CNPJ/CPF → não chuta (o 1º seria last-write-wins,
@@ -351,12 +363,19 @@ async function syncClienteOmie(
   // TODO Fatia 4: este write-back é WRITER do espelho poluído omie_clientes (grava sem conta, rótulo
   // 'colacor' default) — será migrado/aposentado na Fatia 4. Mantido por ora: não corrompe leitor que
   // já lê a view fresca, e ainda serve o cache legado até todos os leitores migrarem.
-  await supabase.from("omie_clientes").insert({
-    user_id: userId,
-    omie_codigo_cliente: omieCodigoCliente,
-    omie_codigo_cliente_integracao: cliente?.codigo_cliente_integracao || null,
-    omie_codigo_vendedor: omieCodigoVendedor,
-  });
+  // upsert ON CONFLICT DO NOTHING (ignoreDuplicates): o fluxo agora entra aqui após ausência na VIEW, e
+  // ~24% dos users (1634) têm linha antiga no espelho (UNIQUE(user_id)) — insert cru colidiria e engoliria
+  // o erro (Codex P2). DO NOTHING não sobrescreve a linha existente (não corrompe leitor ainda-não-migrado
+  // que poderia esperar o código de outra conta) e não deixa erro silencioso.
+  const { error: writeErr } = await supabase
+    .from("omie_clientes")
+    .upsert({
+      user_id: userId,
+      omie_codigo_cliente: omieCodigoCliente,
+      omie_codigo_cliente_integracao: cliente?.codigo_cliente_integracao || null,
+      omie_codigo_vendedor: omieCodigoVendedor,
+    }, { onConflict: "user_id", ignoreDuplicates: true });
+  if (writeErr) console.error("[Omie] write-back no espelho falhou (não bloqueia o pedido):", writeErr.message);
 
   return {
     omieCodigoCliente,
@@ -858,12 +877,13 @@ serve(async (req) => {
           // omie_codigo_vendedor 100% NULL (psql-ro) → na prática cai no fallback API abaixo — que é mais
           // correto que herdar um vendedor de conta errada.
           if (!omieCodigoVendedor && staffContext.customerUserId) {
-            const { data: mapping } = await supabaseAdmin
+            const { data: mapping, error: vendErr } = await supabaseAdmin
               .from("omie_customer_account_map_fresco")
               .select("omie_codigo_vendedor")
               .eq("user_id", staffContext.customerUserId)
               .eq("account", "colacor_sc")
               .maybeSingle();
+            if (vendErr) console.error("[Omie] Erro lendo vendedor na view (colacor_sc), tentará API:", vendErr.message);
             omieCodigoVendedor = mapping?.omie_codigo_vendedor || undefined;
           }
 
@@ -1057,12 +1077,13 @@ serve(async (req) => {
         // P0-B-bis: view fresca account-correta (colacor_sc), não o espelho poluído. Ausência → honesto
         // (exists:false); sem fallback API — não há consumidor money-path (o pedido resolve via
         // syncClienteOmie, que já tem fallback API fail-closed). exists sse há código na conta do fluxo.
-        const { data: mapping } = await supabaseAdmin
+        const { data: mapping, error: checkErr } = await supabaseAdmin
           .from("omie_customer_account_map_fresco")
           .select("omie_codigo_cliente")
           .eq("user_id", userId)
           .eq("account", "colacor_sc")
           .maybeSingle();
+        if (checkErr) console.error("[Omie] Erro lendo check_client na view (colacor_sc):", checkErr.message);
 
         result = {
           exists: !!mapping?.omie_codigo_cliente,

--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -205,6 +205,50 @@ interface ClienteOmieResult {
   omieCodigoVendedor?: number;
 }
 
+// MIRROR-START omie-sync-identidade — espelhado verbatim de src/lib/omie/omie-sync-identidade.ts
+// Decisão de identidade Omie do PEDIDO SELF-SERVICE (conta colacor_sc) — money-path P0-B-bis. PURA:
+// recebe a linha da VIEW FRESCA account-correta (omie_customer_account_map_fresco) já buscada + os
+// matches da API Omie (registros_por_pagina:2) e decide o código autoritativo OU fail-closed.
+// Precisão>recall: doc-ambíguo (2+ códigos distintos), ausência confirmada, ou código bigint não
+// representável = REJECT. NÃO lê o espelho poluído omie_clientes. A âncora (user_id, account) e o I/O
+// (buscar a view, buscar a API, write-back) ficam no chamador; aqui só a decisão. Espelhado no edge
+// (Deno não importa de src/); paridade textual no CI em src/__tests__/edge-money-path-invariants.test.ts.
+interface MatchOmie { codigo_cliente: number; codigo_vendedor: number | null }
+type IdentidadeSelfService =
+  | { ok: true; codigo_cliente: number; codigo_vendedor: number | null }
+  | { ok: false; needOmie: true }
+  | { ok: false; erro: 'doc-ambíguo' | 'sem-vinculo' | 'codigo-inseguro' };
+
+function decidirIdentidadeSelfService(args: {
+  viewRow: MatchOmie | null;
+  omieMatches: MatchOmie[] | null;
+}): IdentidadeSelfService {
+  const { viewRow, omieMatches } = args;
+
+  let cand: MatchOmie;
+  if (viewRow) {
+    // View fresca já é account-correta (1 linha por (user_id, account)) — resolve sem API.
+    cand = viewRow;
+  } else {
+    // Ausência na view → o chamador precisa buscar a API Omie por documento.
+    if (omieMatches === null) return { ok: false, needOmie: true };
+    // Dedup por código: 2+ códigos DISTINTOS no mesmo doc = ambíguo — chutar o 1º seria last-write-wins.
+    const distintos = [...new Map(omieMatches.map((m) => [String(m.codigo_cliente), m])).values()];
+    if (distintos.length > 1) return { ok: false, erro: 'doc-ambíguo' };
+    if (distintos.length === 0) return { ok: false, erro: 'sem-vinculo' };
+    cand = distintos[0];
+  }
+
+  // Segurança de representação (bigint): códigos Omie são bigint; Number perde precisão ≥ 2^53. Um código
+  // truncado mandaria o pedido pro cliente errado — fail-closed em vez de arriscar (espelha o guard do
+  // decideAccountIdentity). Vendedor é secundário (não é âncora de identidade) → passa como veio.
+  if (!Number.isSafeInteger(cand.codigo_cliente) || cand.codigo_cliente <= 0) {
+    return { ok: false, erro: 'codigo-inseguro' };
+  }
+  return { ok: true, codigo_cliente: cand.codigo_cliente, codigo_vendedor: cand.codigo_vendedor };
+}
+// MIRROR-END
+
 // Função para buscar cliente no Omie (apenas existentes)
 async function syncClienteOmie(
   supabase: SupabaseClient,
@@ -232,63 +276,91 @@ async function syncClienteOmie(
 
   const documentClean = profile.document.replace(/\D/g, "");
 
-  // Verificar se já existe mapeamento local
-  const { data: existingMapping } = await supabase
-    .from("omie_clientes")
+  // P0-B-bis: identidade Omie pela VIEW FRESCA account-correta (colacor_sc), NÃO o espelho poluído
+  // omie_clientes (mix de contas, rótulo 'colacor' mentiroso). Ausência na view → fallback API
+  // fail-closed (registros:2, rejeita doc-ambíguo — o :1 antigo era last-write-wins). Ver
+  // docs/superpowers/specs/2026-07-09-omie-leituras-money-path-p0b-bis-design.md.
+  const { data: viewRow } = await supabase
+    .from("omie_customer_account_map_fresco")
     .select("omie_codigo_cliente, omie_codigo_vendedor")
     .eq("user_id", userId)
+    .eq("account", "colacor_sc")
     .maybeSingle();
 
-  if (existingMapping?.omie_codigo_cliente) {
-    console.log(`[Omie] Cliente já mapeado localmente: ${existingMapping.omie_codigo_cliente}, vendedor: ${existingMapping.omie_codigo_vendedor || 'N/A'}`);
+  const viaView = decidirIdentidadeSelfService({
+    viewRow: viewRow?.omie_codigo_cliente
+      ? { codigo_cliente: viewRow.omie_codigo_cliente, codigo_vendedor: viewRow.omie_codigo_vendedor ?? null }
+      : null,
+    omieMatches: null,
+  });
+  if (viaView.ok) {
+    console.log(`[Omie] Cliente resolvido pela view fresca (colacor_sc): ${viaView.codigo_cliente}, vendedor: ${viaView.codigo_vendedor ?? 'N/A'}`);
     return {
-      omieCodigoCliente: existingMapping.omie_codigo_cliente,
-      omieCodigoVendedor: existingMapping.omie_codigo_vendedor || undefined,
+      omieCodigoCliente: viaView.codigo_cliente,
+      omieCodigoVendedor: viaView.codigo_vendedor ?? undefined,
     };
   }
 
-  // Buscar cliente existente no Omie pelo CPF/CNPJ
-  console.log(`[Omie] Buscando cliente existente por CPF/CNPJ: ${documentClean}`);
-  
+  // Sem vínculo fresco na view (ausência ou código inseguro) → buscar no Omie por CPF/CNPJ com
+  // registros_por_pagina:2 para detectar duplicata-CNPJ (o :1 antigo pegava só o 1º = last-write-wins).
+  console.log(`[Omie] Sem vínculo fresco na view p/ colacor_sc; buscando no Omie por CPF/CNPJ: ${documentClean}`);
   const searchResult = await callOmieApi(
     "geral/clientes/",
     "ListarClientes",
     {
       pagina: 1,
-      registros_por_pagina: 1,
+      registros_por_pagina: 2,
       clientesFiltro: {
         cnpj_cpf: documentClean
       }
     }
   ) as unknown as OmieListarClientesResponse;
 
-  if (!searchResult.clientes_cadastro?.[0]?.codigo_cliente_omie) {
-    // Cliente NÃO encontrado no Omie - não permitir criar pedido
+  const omieMatches: MatchOmie[] = (searchResult.clientes_cadastro ?? [])
+    .filter((c) => c.codigo_cliente_omie)
+    .map((c) => ({
+      codigo_cliente: c.codigo_cliente_omie as number,
+      codigo_vendedor: c.recomendacoes?.codigo_vendedor ?? c.codigo_vendedor ?? null,
+    }));
+
+  const viaOmie = decidirIdentidadeSelfService({ viewRow: null, omieMatches });
+  if (!viaOmie.ok) {
+    if ("erro" in viaOmie && viaOmie.erro === "doc-ambíguo") {
+      // Fail-closed: 2+ cadastros DISTINTOS no mesmo CNPJ/CPF → não chuta (o 1º seria last-write-wins,
+      // podendo mandar o pedido pro cliente errado). Precisão>recall no money-path.
+      throw new Error(
+        `CNPJ/CPF (${documentClean}) tem 2+ cadastros distintos na conta colacor_sc — cadastro ambíguo, ` +
+        `pedido bloqueado por segurança. Entre em contato conosco para consolidar o cadastro.`
+      );
+    }
+    // sem-vinculo | codigo-inseguro → cliente não utilizável para pedido.
     throw new Error(
       `Cliente não encontrado no Omie com o CPF/CNPJ informado (${documentClean}). ` +
       `Por favor, verifique se você está cadastrado como cliente ou entre em contato conosco.`
     );
   }
 
-  // Cliente encontrado - extrair dados incluindo vendedor
-  const cliente = searchResult.clientes_cadastro[0];
-  const omieCodigoCliente = cliente.codigo_cliente_omie;
-  const omieCodigoVendedor = cliente.recomendacoes?.codigo_vendedor || cliente.codigo_vendedor || null;
-  
-  console.log(`[Omie] Cliente encontrado: ${omieCodigoCliente} - ${cliente.razao_social}`);
-  console.log(`[Omie] Vendedor associado: ${omieCodigoVendedor || 'Nenhum'}`);
-  
-  // Criar mapeamento local incluindo o vendedor
+  const omieCodigoCliente = viaOmie.codigo_cliente;
+  const omieCodigoVendedor = viaOmie.codigo_vendedor;
+  // Cliente cru correspondente (há exatamente 1 match não-ambíguo aqui) — preserva o integração no write-back.
+  const cliente = (searchResult.clientes_cadastro ?? []).find((c) => c.codigo_cliente_omie === omieCodigoCliente);
+
+  console.log(`[Omie] Cliente encontrado no Omie: ${omieCodigoCliente} - ${cliente?.razao_social ?? ''}`);
+  console.log(`[Omie] Vendedor associado: ${omieCodigoVendedor ?? 'Nenhum'}`);
+
+  // TODO Fatia 4: este write-back é WRITER do espelho poluído omie_clientes (grava sem conta, rótulo
+  // 'colacor' default) — será migrado/aposentado na Fatia 4. Mantido por ora: não corrompe leitor que
+  // já lê a view fresca, e ainda serve o cache legado até todos os leitores migrarem.
   await supabase.from("omie_clientes").insert({
     user_id: userId,
     omie_codigo_cliente: omieCodigoCliente,
-    omie_codigo_cliente_integracao: cliente.codigo_cliente_integracao || null,
+    omie_codigo_cliente_integracao: cliente?.codigo_cliente_integracao || null,
     omie_codigo_vendedor: omieCodigoVendedor,
   });
 
   return {
     omieCodigoCliente,
-    omieCodigoVendedor: omieCodigoVendedor || undefined,
+    omieCodigoVendedor: omieCodigoVendedor ?? undefined,
   };
 }
 


### PR DESCRIPTION
## P0-B-bis PR-1 — `omie-sync` self-service lê a view fresca account-correta

Migra as **3 leituras money-path** do edge `omie-sync` (pedido self-service, conta **colacor_sc**) do espelho poluído `omie_clientes` para a **view fresca account-correta** `omie_customer_account_map_fresco`, com **fallback API fail-closed** em doc-ambíguo. Resíduo do P0-B (§4 do design `2026-07-09-omie-leituras-money-path-p0b-bis-design.md`).

### Por quê

`omie_clientes` é um espelho legado `user_id → código` cujo rótulo `empresa_omie` é 100% `'colacor'` (mentira uniforme — nenhum writer o seta) sobre um **mix de contas**. Ler por `user_id` sem conta devolve um código que pode ser de **outra conta** que não a do fluxo (colacor_sc), silenciosamente. A view fresca tem o código **correto por conta** (só o vínculo visto no Omie nos últimos 7d).

### O que muda (só LEITURA)

| Call-site | Antes | Depois |
|---|---|---|
| pedido self-service (`syncClienteOmie`) | `omie_clientes` + fallback API `registros:1` (last-write-wins) | view `(user_id, account='colacor_sc')` + fallback API `registros:2` fail-closed (rejeita doc-ambíguo) |
| fallback vendedor (staff) | `omie_clientes` | view `omie_codigo_vendedor` `account='colacor_sc'` |
| `check_client` | `omie_clientes` | view `account='colacor_sc'`; ausência → honesto (`exists:false`) |

Decisão encapsulada num **helper puro** `decidirIdentidadeSelfService` (`src/lib/omie/omie-sync-identidade.ts`, testado por vitest) **espelhado verbatim** no edge (bloco MIRROR, paridade textual no CI). Guard bigint (`Number.isSafeInteger`) alinhado ao irmão `decideAccountIdentity`.

### Gate (verde)

- **vitest** helper (10 testes +/- com **falsificação real**: sabotei o guard de ambiguidade → 2 asserts vermelhos).
- **canário** `edge-money-path-invariants` (+7 asserts anti-reversão-Lovable: usa `_fresco` não `omie_clientes`; `registros:2` não `1`; paridade MIRROR; **falsificado** sabotando `registros:2→1` → vermelho no assert certo).
- **typecheck** PASS · **lint** PASS · **`deno check` omie-sync** PASS · suíte omie 114/114.
- **/codex challenge** (xhigh) do diff — 6 findings, ver abaixo.

### Codex challenge (gpt-5.5 xhigh) — 6 findings, 4 incorporados

| # | Finding | Ação |
|---|---|---|
| P1 | `registros:2` não prova unicidade se truncado (`[200,200]` pág.1 esconde `201` pág.2) | ✅ helper ganha `omieTruncado` (`total_de_paginas>1` → fail-closed) |
| P1 | staleness: view é cache ≤7d, retorna antes da API | ⚖️ **já aceito no design §10 P2** (≥ status quo diário-sem-TTL; watchdog grita antes). Alternativa "API sempre" disponível se você priorizar precisão absoluta |
| P2 | write-back `insert` cru colide com `UNIQUE(user_id)` p/ **1634 users** (24%) ausentes na view → erro engolido | ✅ `upsert onConflict ignoreDuplicates` (DO NOTHING — não corrompe leitor não-migrado) |
| P2 | 3 leituras da view ignoram `error` (mascara erro como ausência) | ✅ capturam+logam (comportamento já degradava fail-closed) |
| P2 | bigint como string → `codigo-inseguro` | ⚖️ latente aceito (P0-B **já em prod** prova PostgREST→`number`; degrada seguro) |
| P2 | canário: `.eq(account)` genérico (falso-negativo) | ✅ `count==3` (uma por leitura) + assert do guard de truncamento |

Parecer cru arquivado. Falsifiquei o guard de truncamento (sabotei → vermelho no caso certo).

### ⚠️ Deploy (MANUAL — sua mão, mesma armadilha do #1272)

Merge na `main` **não** deploya o edge. Após o merge:
1. **Chat do Lovable:** deployar o edge `omie-sync` **verbatim** do repo (o deploy do Lovable já reverteu fix money-path antes — #1272).
2. **Verificar anti-reversão:** o canário `edge-money-path-invariants` roda no CI; se o Lovable reescrever no deploy, o próximo CI fica vermelho. Confirmar via psql-ro que o pedido self-service resolve pela view.

### Riscos aceitos (design §10)

- **Staleness 7d:** a view é cache ≤7d. Risco assumido explicitamente (§10 P2) — ≥ status quo (espelho diário sem TTL) + watchdog grita antes de 7d + fallback API fail-closed.

### Fora de escopo (design §4 FORA)

- Write-back `omie_clientes` (:354) = writer → Fatia 4.
- Guard `codeBelongsToWrongAccount` (multi-conta + prove-sql) → PR próprio.
- Bug semântico `ai-ops-agent` (`farmer_id`) → fix próprio.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
