### PR TITLE
feat(omie-vendas-sync): syncPedidos resolve user pela view fresca account-correta (P0-B-bis PR-2)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -545,11 +545,20 @@ describe('guardrail money-path: syncPedidos resolve user pela view fresca accoun
     expect(src).toContain('clientCache');
   });
 
-  it('o cache codigo->user vem da VIEW FRESCA account-correta, filtrada por conta, com .order estável', () => {
+  it('o cache codigo->user vem da VIEW FRESCA account-correta, por conta, paginado por KEYSET', () => {
+    // Exige a cadeia keyset completa: from(fresco) → eq(account) → gt(codigo) → limit. Fecha o furo Codex P3
+    // (o regex antigo não exigia paginação: remover o .limit truncaria o cache em 1 página e passaria).
     expect(
       src,
-      'REVERSÃO Lovable? o cache do syncPedidos não lê mais a view fresca com .eq(account) + .order estável',
-    ).toMatch(/from\('omie_customer_account_map_fresco'\)[\s\S]{0,140}\.eq\('account', account\)[\s\S]{0,80}\.order\('omie_codigo_cliente'\)/);
+      'REVERSÃO Lovable? o cache do syncPedidos não lê a view fresca por conta com paginação keyset (.gt+.limit)',
+    ).toMatch(/from\('omie_customer_account_map_fresco'\)[\s\S]{0,180}\.eq\('account', account\)[\s\S]{0,80}\.gt\('omie_codigo_cliente'[\s\S]{0,80}\.limit\(/);
+  });
+
+  it('o pré-load do cache é FAIL-CLOSED em erro de query (não engole o error → cache parcial, Codex P2)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o pré-load engole o erro da query — cache parcial silencioso → rate-limit no fallback',
+    ).toMatch(/if \(cacheErr\) throw new Error/);
   });
 
   it('o cache NÃO voltou a carregar do espelho poluído omie_clientes (anti-reversão do bug #4)', () => {

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -526,3 +526,50 @@ describe('guardrail money-path: omie-sync self-service USA view fresca account-c
     ).toBe(mirrorBlockNamed(helper, 'omie-sync-identidade'));
   });
 });
+
+// ── P0-B-bis PR-2 (omie-vendas-sync syncPedidos: cache codigo->user pela view fresca account-correta) ──
+// O cache que resolve codigo_cliente->user_id nos pedidos vinha do espelho poluído omie_clientes SEM filtro
+// de conta. Código Omie é numerado POR conta → o mesmo número em contas diferentes colidia na chave global
+// do cache e mapeava o user_id ERRADO (bug #4 do design; o espelho é sobrescrito ao longo do dia pelos
+// writers colacor_sc, então a colisão é intermitente). Migrado p/ a view fresca account-correta
+// (.eq('account', account)) + .order estável no .range (armadilha PostgREST). A paridade textual aqui pega
+// a reversão do deploy do Lovable. As leituras de omie_clientes em ~:1703/~:2393 são o guard
+// codeBelongsToWrongAccount (P0-A, precisa ver TODAS as contas) — FORA desta PR, intocadas. Ver design §4/§5.
+const VENDAS_SYNC = 'supabase/functions/omie-vendas-sync/index.ts';
+
+describe('guardrail money-path: syncPedidos resolve user pela view fresca account-correta (P0-B-bis PR-2)', () => {
+  const src = read(VENDAS_SYNC);
+
+  it('sentinela: leu o arquivo real (edge)', () => {
+    expect(src).toContain('syncPedidos');
+    expect(src).toContain('clientCache');
+  });
+
+  it('o cache codigo->user vem da VIEW FRESCA account-correta, filtrada por conta, com .order estável', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? o cache do syncPedidos não lê mais a view fresca com .eq(account) + .order estável',
+    ).toMatch(/from\('omie_customer_account_map_fresco'\)[\s\S]{0,140}\.eq\('account', account\)[\s\S]{0,80}\.order\('omie_codigo_cliente'\)/);
+  });
+
+  it('o cache NÃO voltou a carregar do espelho poluído omie_clientes (anti-reversão do bug #4)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o cache do syncPedidos voltou a carregar do espelho omie_clientes (bug #4 reaberto)',
+    ).not.toMatch(/Client cache from omie_clientes/);
+    expect(
+      src,
+      'sentinela do log novo: o cache reporta a fonte account-correta',
+    ).toMatch(/Client cache from omie_customer_account_map_fresco/);
+  });
+
+  it('o guard codeBelongsToWrongAccount (FORA desta PR) segue lendo TODAS as contas do espelho', () => {
+    // Precisão>recall: o guard PRECISA ver linhas de outras contas p/ provar que o código é de outra conta.
+    // Filtrar só a conta-alvo o desligaria (design §4 FORA). Este assert trava a NÃO-migração dele.
+    expect(src, 'REGRESSÃO: sumiu o guard codeBelongsToWrongAccount').toMatch(/codeBelongsToWrongAccount\(/);
+    expect(
+      src,
+      'REGRESSÃO: o guard parou de ler o espelho por user (sem filtro de conta) — proteção desligada?',
+    ).toMatch(/\.from\("omie_clientes"\)\s*\.select\("omie_codigo_cliente, empresa_omie"\)/);
+  });
+});

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -926,25 +926,31 @@ async function syncPedidos(
   // chave global codigo->user) mapeava o user_id ERRADO — pedido atribuído ao cliente errado (bug #4 do
   // design; o espelho é sobrescrito ao longo do dia pelos writers colacor_sc, então a colisão é intermitente).
   // A view omie_customer_account_map_fresco é account-correta (UNIQUE(codigo,account)) e document-first; o
-  // miss aqui cai no resolveClientUserId → API ConsultarCliente (fail-safe). .order estável no código
-  // (UNIQUE garante determinismo) p/ o .range NÃO pular/repetir linha (armadilha PostgREST do CLAUDE.md).
+  // miss aqui cai no resolveClientUserId → API ConsultarCliente (fail-safe).
+  // Paginação KEYSET (.gt no código + .limit), não offset: a view filtra updated_at>=now()-7d, então uma
+  // linha pode cruzar o TTL ENTRE páginas; keyset é imune a esse deslocamento (offset .range pularia/repetiria
+  // — Codex P2). O código é UNIQUE(codigo,account) → ordenação sem empate. Erro de query é FAIL-CLOSED (throw):
+  // engolir o error (capa silenciosa do PostgREST) deixaria um cache parcial → milhares de miss → rate-limit
+  // no Omie → skip/atribuição arbitrária no fallback. Melhor abortar o run e retomar na próxima janela.
   const clientCache = new Map<number, string | null>();
-  let ocPage = 0;
+  let lastCodigo = 0;
   hasMore = true;
   while (hasMore) {
-    const { data: batch } = await supabase
+    const { data: batch, error: cacheErr } = await supabase
       .from('omie_customer_account_map_fresco')
       .select('omie_codigo_cliente, user_id')
       .eq('account', account)
+      .gt('omie_codigo_cliente', lastCodigo)
       .order('omie_codigo_cliente')
-      .range(ocPage * pgSize, (ocPage + 1) * pgSize - 1);
+      .limit(pgSize);
+    if (cacheErr) throw new Error(`pre-load client cache (${account}): ${cacheErr.message}`);
     if (!batch || batch.length === 0) { hasMore = false; }
     else {
       for (const oc of batch) {
         clientCache.set(oc.omie_codigo_cliente, oc.user_id);
       }
+      lastCodigo = batch[batch.length - 1].omie_codigo_cliente;
       if (batch.length < pgSize) hasMore = false;
-      ocPage++;
     }
   }
   console.log(`[sync_pedidos][${account}] Client cache from omie_customer_account_map_fresco: ${clientCache.size}`);

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -920,14 +920,23 @@ async function syncPedidos(
   // era pulado pelo hash do pai e os itens nunca eram restaurados.
   const seenHashes = new Set<string>();
 
-  // ── Pre-load omie_clientes mapping (codigo_cliente -> user_id) to AVOID API calls ──
+  // ── Pre-load mapping (codigo_cliente -> user_id) da VIEW FRESCA account-correta p/ EVITAR chamadas API ──
+  // P0-B-bis PR-2: a fonte era o espelho poluído omie_clientes SEM filtro de conta. Como o código Omie é
+  // numerado POR conta, um código desta conta podia colidir com o mesmo número em OUTRA conta e o cache (1
+  // chave global codigo->user) mapeava o user_id ERRADO — pedido atribuído ao cliente errado (bug #4 do
+  // design; o espelho é sobrescrito ao longo do dia pelos writers colacor_sc, então a colisão é intermitente).
+  // A view omie_customer_account_map_fresco é account-correta (UNIQUE(codigo,account)) e document-first; o
+  // miss aqui cai no resolveClientUserId → API ConsultarCliente (fail-safe). .order estável no código
+  // (UNIQUE garante determinismo) p/ o .range NÃO pular/repetir linha (armadilha PostgREST do CLAUDE.md).
   const clientCache = new Map<number, string | null>();
   let ocPage = 0;
   hasMore = true;
   while (hasMore) {
     const { data: batch } = await supabase
-      .from('omie_clientes')
+      .from('omie_customer_account_map_fresco')
       .select('omie_codigo_cliente, user_id')
+      .eq('account', account)
+      .order('omie_codigo_cliente')
       .range(ocPage * pgSize, (ocPage + 1) * pgSize - 1);
     if (!batch || batch.length === 0) { hasMore = false; }
     else {
@@ -938,7 +947,7 @@ async function syncPedidos(
       ocPage++;
     }
   }
-  console.log(`[sync_pedidos][${account}] Client cache from omie_clientes: ${clientCache.size}`);
+  console.log(`[sync_pedidos][${account}] Client cache from omie_customer_account_map_fresco: ${clientCache.size}`);
 
   // ── Pre-load product mapping ──
   const productMap = new Map<number, string>();


### PR DESCRIPTION
## P0-B-bis PR-2 — `syncPedidos` resolve user pela view fresca account-correta

Segunda fatia do P0-B-bis (leituras money-path saindo do espelho poluído `omie_clientes`). Migra o **cache `codigo_cliente → user_id`** do `syncPedidos` (`omie-vendas-sync`) para a view fresca account-correta.

### Problema (bug #4 do design)
O código Omie é numerado **por conta**. O cache antigo lia `omie_clientes` (PK `user_id` única, mix de contas sem rótulo confiável) e indexava `codigo → user_id` numa **chave global**. O mesmo número em contas diferentes colidia → last-write-wins → **pedido atribuído ao cliente errado**. Intermitente (o espelho é sobrescrito ao longo do dia pelos writers colacor_sc).

### Correção
```diff
- .from('omie_clientes')
+ .from('omie_customer_account_map_fresco')
+ .eq('account', account)
+ .order('omie_codigo_cliente')   // .range estável (armadilha PostgREST)
```
- Vocabulário de conta bate direto: `type Account = "oben" | "colacor"` = coluna `account`.
- Miss → `resolveClientUserId` → API `ConsultarCliente` (fail-safe).
- **Guard `codeBelongsToWrongAccount` (:1703/:2393) INTOCADO** — lê todas as contas de propósito (prova positiva); migrá-lo o desligaria → PR próprio com prove-sql (design §4 FORA).

### Evidência (psql-ro produção, 2026-07-10)
- Cobertura: base oben 5238 == fresca oben 5238; colacor 5148==5148 → **nada expira em 7d, zero regressão de cobertura**.
- Espelho tinha 6909 códigos (mix); a view oben tem os 5238 úteis. Os ~1671 a menos eram de outras contas/órfãos — **a fonte do bug**, não clientes oben válidos.
- `UNIQUE(omie_codigo_cliente, account)` → `.order` por código é determinístico para o `.range`.

### Gate
- ✅ canário anti-reversão-Lovable (`edge-money-path-invariants`, describe PR-2) + **falsificação** (sabotei a fonte → vermelho)
- ✅ deno check · typecheck · lint · test (50/50)
- 🔄 /codex challenge (rodando, `-r xhigh`) — incorporo antes de tirar do draft

### ⚠️ Deploy (Lovable, manual)
Após o merge, deploy do edge **verbatim** no chat do Lovable:
> Faça o deploy da edge function `omie-vendas-sync` exatamente como está na `main`. Leia `supabase/functions/omie-vendas-sync/index.ts` e publique verbatim.

Sem Publish (frontend não muda), sem migration (sem SQL).

### 🔀 Colisão de merge conhecida
Toca `src/__tests__/edge-money-path-invariants.test.ts` (fim), assim como a sessão do chip "Canária de deploy do P1b no omie-analytics-sync". Duas adições no fim → conflito trivial no segundo a mergear; resolvo mantendo ambos os describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
