### PR TITLE
test(money-path): canária doc_ambiguo_probe (P1b) no edge omie-analytics-sync

### DIFF
--- a/docs/agent/money-path.md
+++ b/docs/agent/money-path.md
@@ -30,7 +30,7 @@
 
 Helper TS puro (testado com vitest) **espelhado verbatim** no edge (Deno não importa de `src/`) e/ou em SQL. Para lógica replicada, **provar paridade** (harness diferencial TS×SQL, ex.: `db/test-city-norm-paridade.sh`) — não institucionalizar "copiar verbatim" como fim.
 
-Edge só-TS (sem contraparte SQL): a paridade vira **textual no CI** — bloco entre `// MIRROR-START/END` comparado normalizado src×edge (pega reescrita do Lovable no deploy) — **mais** uma **canária comportamental** `{canary:true}` staff-gated que roda o helper REAL deployado com fixture fixo e retorna `{resolved, expected, ok}`. Probe HTTP = única prova do COMPORTAMENTO em produção: o guard textual cobre a FONTE, a canária cobre o DEPLOY. ⚠️ A canária prova "helper deployado + lógica certa", **não** que o real-path usa o helper (isso é o guard textual + paridade). Ex.: merge de preço do `analyze-unified-order` (#1089).
+Edge só-TS (sem contraparte SQL): a paridade vira **textual no CI** — bloco entre `// MIRROR-START/END` comparado normalizado src×edge (pega reescrita do Lovable no deploy) — **mais** uma **canária comportamental** `{canary:true}` staff-gated que roda o helper REAL deployado com fixture fixo e retorna `{resolved, expected, ok}`. Probe HTTP = única prova do COMPORTAMENTO em produção: o guard textual cobre a FONTE, a canária cobre o DEPLOY. ⚠️ A canária prova "helper deployado + lógica certa", **não** que o real-path usa o helper (isso é o guard textual + paridade). Ex.: merge de preço do `analyze-unified-order` (#1089); `identidade_probe` (`omie-vendas-sync`); `doc_ambiguo_probe` (`omie-analytics-sync`, P1b — indispensável ali: a ausência do helper é invisível no dado, a proof-table só encolhe com duplicata-CNPJ real na conta, que não há).
 
 ## Diagnóstico
 

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -404,11 +404,23 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
     expect(helper).toMatch(/export function docsComCodigoAmbiguoNoOmie/);
   });
 
-  it('o edge USA o helper: define o espelho E o chama (não só define)', () => {
+  // Bloco INTEIRO da action doc_ambiguo_probe (até o próximo case/default). A probe TAMBÉM chama o
+  // helper — sem removê-la, o assert de "o edge chama o helper" abaixo passaria mesmo se a chamada do
+  // REAL-PATH (syncCustomers) sumisse. Ver o `it` da canária no fim deste describe.
+  const PROBE_RE = /case "doc_ambiguo_probe":[\s\S]*?\n {6}(?=case |default:)/;
+
+  it('o edge USA o helper: define o espelho E o chama NO REAL-PATH (não só define, nem só na probe)', () => {
     expect(src, 'edge não define mais o helper espelhado de doc-ambíguo').toMatch(/function docsComCodigoAmbiguoNoOmie/);
     expect(
       src,
       'REGRESSÃO: edge não chama mais docsComCodigoAmbiguoNoOmie — P1b voltou a gravar last-write-wins?',
+    ).toMatch(/docsComCodigoAmbiguoNoOmie\(/);
+    // precisão: a chamada tem de existir FORA da canária. Senão a probe (que chama o helper para
+    // testá-lo) mascararia a remoção do fail-closed do syncCustomers — o guard viraria teatro.
+    const semProbe = src.replace(PROBE_RE, '');
+    expect(
+      semProbe,
+      'REGRESSÃO: a ÚNICA chamada a docsComCodigoAmbiguoNoOmie está na canária — o real-path (syncCustomers) parou de aplicar o fail-closed',
     ).toMatch(/docsComCodigoAmbiguoNoOmie\(/);
     expect(
       count(src, 'docsComCodigoAmbiguoNoOmie'),
@@ -433,6 +445,39 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
       mirrorBlockNamed(src, 'omie doc-ambiguo'),
       'edge divergiu do helper de src/ — o Lovable reescreveu a detecção no deploy?',
     ).toBe(mirrorBlockNamed(helper, 'omie doc-ambiguo'));
+  });
+
+  // ── Canária comportamental: os asserts acima cobrem a FONTE na main (paridade textual src×edge). A
+  // probe HTTP `doc_ambiguo_probe` é a única prova do COMPORTAMENTO no build DEPLOYADO — e aqui ela é
+  // indispensável: a ausência do helper NÃO aparece no dado (a proof-table só encolhe se houver
+  // duplicata-CNPJ real na conta, e não há — colacor_sc 5275→5275, psql-ro 2026-07-10). Sem a probe, uma
+  // reversão do Lovable (como #1272) seria invisível em prod. Ver docs/agent/money-path.md (§ canária).
+  it('CANÁRIA de deploy: doc_ambiguo_probe existe, expõe probe_no_ar e roda o helper {resolved,expected,ok}', () => {
+    expect(
+      src,
+      'canária doc_ambiguo_probe ausente/renomeada — sem prova do COMPORTAMENTO deployado (só o commit + paridade textual, mais fraco)',
+    ).toContain('case "doc_ambiguo_probe":');
+    const m = src.match(PROBE_RE);
+    expect(m, 'bloco da action doc_ambiguo_probe não encontrado').toBeTruthy();
+    const bloco = m![0];
+    expect(bloco, 'a probe deveria expor probe_no_ar (existência do helper P1b no build deployado)').toContain('probe_no_ar');
+    expect(bloco, 'a probe não roda mais docsComCodigoAmbiguoNoOmie — deixou de provar o helper deployado').toContain('docsComCodigoAmbiguoNoOmie(');
+    expect(bloco, 'a probe perdeu o contrato {resolved, expected, ok}').toMatch(/resolved[\s\S]{0,160}expected[\s\S]{0,80}ok:/);
+  });
+
+  it('CANÁRIA read-only: doc_ambiguo_probe é dry-run puro e cobre a tabela-verdade (+/- se falsificam)', () => {
+    const m = src.match(PROBE_RE);
+    expect(m, 'bloco da action doc_ambiguo_probe não encontrado').toBeTruthy();
+    const bloco = m![0];
+    expect(bloco, 'a probe NÃO pode tocar o client supabase (supabaseAdmin) — deixaria de ser dry-run puro').not.toContain('supabaseAdmin');
+    expect(bloco, 'a probe NÃO pode escrever/consultar o DB (.insert/.update/.delete/.upsert/.rpc)').not.toMatch(/\.(insert|update|delete|upsert|rpc)\(/);
+    expect(bloco, 'a probe NÃO pode chamar o Omie — deixaria de ser dry-run determinístico').not.toMatch(/callOmie|fetchOmie/);
+    // precisão>recall: a probe só morde se cobrir os DOIS lados. Um helper sempre-∅ (o que a reversão do
+    // Lovable produz) passa nos casos limpos; um que marca tudo passa no caso ambíguo. Exigir ambos.
+    expect(bloco, 'a probe deveria cobrir o caso AMBÍGUO (2 códigos distintos) — senão um helper sempre-∅ passaria').toContain('doc_2_codigos_distintos');
+    expect(bloco, 'a probe deveria cobrir o doc de 1 código (limpo) — senão um helper que marca tudo passaria').toContain('doc_1_codigo');
+    expect(bloco, 'a probe deveria cobrir o MESMO código repetido (duplicata da paginação ≠ ambiguidade)').toContain('doc_mesmo_codigo_repetido');
+    expect(bloco, 'a probe deveria cobrir o doc vazio (não vira chave)').toContain('doc_vazio_ignorado');
   });
 });
 

--- a/src/lib/omie/omie-doc-ambiguo.test.ts
+++ b/src/lib/omie/omie-doc-ambiguo.test.ts
@@ -60,3 +60,61 @@ describe('docsComCodigoAmbiguoNoOmie (P1b fail-closed money-path)', () => {
     expect(docsComCodigoAmbiguoNoOmie([]).size).toBe(0);
   });
 });
+
+// ── Mecânica da canária `doc_ambiguo_probe` (edge omie-analytics-sync, case doc_ambiguo_probe) ──────
+// O probe roda o helper DEPLOYADO (bloco MIRROR do edge) sobre fixtures fixos e compara com o esperado
+// via `canon` + `stableId`. Ele existe porque a ausência do helper é INDETECTÁVEL por sonda de dados: a
+// proof-table só encolhe quando há duplicata-CNPJ real na conta, e não há (colacor_sc: 5275→5275 no run).
+// `deno check` prova que o edge COMPILA; o guard textual (edge-money-path-invariants) prova a
+// EXISTÊNCIA/paridade. Falta o que só a execução pega: (1) a comparação MORDE (senão o probe daria
+// ok:true sempre — falsa tranquilidade); (2) os `expected` escritos à mão CORRESPONDEM ao comportamento
+// real (trocar ∅↔{doc} compila mas faria o probe gritar ok:false em prod com a lógica certa). Roda a
+// função REAL de src/ (idêntica ao edge por paridade) sobre os MESMOS fixtures. Espelha o `canon`/
+// `stableId` do edge.
+const stableId = (o: unknown): string =>
+  JSON.stringify(o, (_k, v) =>
+    v && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(Object.entries(v as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)))
+      : v);
+
+const canon = (xs: Iterable<string>): string[] => [...xs].sort();
+
+// Espelha VERBATIM os 7 fixtures do edge (case doc_ambiguo_probe) — a enumeração completa do oráculo.
+const PROBE_FIXTURES: Array<{ caso: string; registros: Array<{ doc: string; codigo: number }>; expected: string[] }> = [
+  { caso: 'doc_1_codigo', registros: [{ doc: '111', codigo: 100 }], expected: [] },
+  { caso: 'doc_2_codigos_distintos', registros: [{ doc: '111', codigo: 100 }, { doc: '111', codigo: 200 }], expected: ['111'] },
+  { caso: 'doc_mesmo_codigo_repetido', registros: [{ doc: '111', codigo: 100 }, { doc: '111', codigo: 100 }], expected: [] },
+  { caso: 'doc_3_codigos', registros: [{ doc: '111', codigo: 100 }, { doc: '111', codigo: 200 }, { doc: '111', codigo: 300 }], expected: ['111'] },
+  { caso: 'doc_vazio_ignorado', registros: [{ doc: '', codigo: 100 }, { doc: '', codigo: 200 }], expected: [] },
+  { caso: 'mistura_so_ambiguos', registros: [{ doc: 'A', codigo: 1 }, { doc: 'B', codigo: 2 }, { doc: 'B', codigo: 3 }, { doc: 'C', codigo: 4 }, { doc: 'C', codigo: 4 }], expected: ['B'] },
+  { caso: 'lista_vazia', registros: [], expected: [] },
+];
+
+describe('canária doc_ambiguo_probe: mecânica de comparação + fixtures (mesma lógica do edge)', () => {
+  it('canon+stableId é order-insensitive (conjunto: ordem de inserção não é sinal)', () => {
+    expect(stableId(canon(new Set(['B', 'A'])))).toBe(stableId(canon(['A', 'B'])));
+  });
+
+  it('canon+stableId TEM DENTE: conteúdo diferente → string diferente (senão o probe nunca morderia)', () => {
+    // ∅ vs {doc}: a diferença entre "vira vínculo" e "fail-closed" — o coração do P1b
+    expect(stableId(canon([]))).not.toBe(stableId(canon(['111'])));
+    // doc diferente (QUAL doc é ambíguo importa: marca o cliente errado)
+    expect(stableId(canon(['111']))).not.toBe(stableId(canon(['222'])));
+    // subconjunto não passa por igual (marcar 1 de 2 ambíguos deixaria um last-write-wins vivo)
+    expect(stableId(canon(['A']))).not.toBe(stableId(canon(['A', 'B'])));
+  });
+
+  it('os 7 fixtures do probe rodam a função REAL e batem no esperado (probe → ok:true pós-deploy)', () => {
+    for (const f of PROBE_FIXTURES) {
+      const resolved = canon(docsComCodigoAmbiguoNoOmie(f.registros));
+      expect(stableId(resolved), `fixture ${f.caso}: resolved diverge do expected`).toBe(stableId(canon(f.expected)));
+    }
+  });
+
+  it('FALSIFICAÇÃO: expected sabotado → probe reportaria ok:false (a canária pega helper deployado errado)', () => {
+    const f = PROBE_FIXTURES[1]; // doc_2_codigos_distintos → ['111']
+    const resolved = canon(docsComCodigoAmbiguoNoOmie(f.registros));
+    // um helper deployado que NÃO detecta ambiguidade (revertido pelo Lovable) devolveria ∅ aqui
+    expect(stableId(resolved)).not.toBe(stableId(canon([])));
+  });
+});

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -2123,6 +2123,64 @@ serve(async (req) => {
           status: 202, headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }
+      case "doc_ambiguo_probe": {
+        // CANÁRIA COMPORTAMENTAL do P1b (doc-ambíguo-Omie) — NÃO escreve, NÃO chama o Omie, NÃO toca o
+        // DB. Roda o helper puro `docsComCodigoAmbiguoNoOmie` DEPLOYADO (o bloco MIRROR deste arquivo,
+        // não o de src/) sobre fixtures fixos e compara com o esperado.
+        // Por que existe: o Lovable JÁ reverteu este helper num deploy (#1272/#1273), e a ausência dele
+        // é INDETECTÁVEL por sonda de dados — a proof-table só encolhe quando há duplicata-CNPJ real na
+        // conta, e não há (colacor_sc: 5275→5275 no run, verificado via psql-ro em 2026-07-10). Ou seja:
+        // no run normal o guard nunca é exercitado, e some sem deixar rastro no dado. Só executar o
+        // helper deployado sobre um fixture sintético prova que ele está no bundle.
+        // Prova duas coisas que o commit de deploy NÃO prova: (1) esta action RESPONDE → o bundle no ar
+        // é o desta árvore (senão viria "Ação desconhecida" = binário velho); (2) a tabela-verdade
+        // deployada está certa. É a contraparte-DEPLOY do guard TEXTUAL (edge-money-path-invariants,
+        // describe "P1b doc-ambíguo-Omie"), que cobre a FONTE na main. Gated por authorizeCronOrStaff
+        // como toda action. Account-agnóstico de propósito: o helper recebe registros JÁ escopados por
+        // conta pelo chamador (syncCustomers) — a probe testa a decisão, não o escopo.
+        // Igualdade estrutural ESTÁVEL (mesma mecânica do `identidade_probe` em omie-vendas-sync).
+        const stableId = (o: unknown): string =>
+          JSON.stringify(o, (_k, v) =>
+            v && typeof v === "object" && !Array.isArray(v)
+              ? Object.fromEntries(Object.entries(v as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)))
+              : v);
+        // O helper retorna Set<string> (JSON.stringify de Set daria "{}") → canonizo ambos os lados como
+        // array ORDENADO: ordem é semanticamente irrelevante num conjunto, e sem o sort a comparação
+        // daria falso-negativo dependendo da ordem de inserção.
+        const canon = (xs: Iterable<string>): string[] => [...xs].sort();
+        // Enumeração COMPLETA do oráculo (espelha src/lib/omie/omie-doc-ambiguo.test.ts): os casos +/- se
+        // falsificam MUTUAMENTE — um helper sempre-∅ reprova o caso ambíguo; um que marca tudo reprova os
+        // casos limpos. Cobrir só um lado deixaria um helper deployado quebrado passar como ok:true.
+        const fixturesDoc: Array<{ caso: string; registros: Array<{ doc: string; codigo: number }>; expected: string[] }> = [
+          // 1 código no doc → não ambíguo (o caminho normal: vira vínculo na proof-table)
+          { caso: "doc_1_codigo", registros: [{ doc: "111", codigo: 100 }], expected: [] },
+          // 2 códigos DISTINTOS no mesmo doc → AMBÍGUO (o coração do P1b: fecha o last-write-wins)
+          { caso: "doc_2_codigos_distintos", registros: [{ doc: "111", codigo: 100 }, { doc: "111", codigo: 200 }], expected: ["111"] },
+          // MESMO código repetido (duplicata do Omie na paginação) → NÃO ambíguo (senão zeraria o mapa)
+          { caso: "doc_mesmo_codigo_repetido", registros: [{ doc: "111", codigo: 100 }, { doc: "111", codigo: 100 }], expected: [] },
+          // 3+ códigos → ambíguo (o >1 não é um off-by-one em 2)
+          { caso: "doc_3_codigos", registros: [{ doc: "111", codigo: 100 }, { doc: "111", codigo: 200 }, { doc: "111", codigo: 300 }], expected: ["111"] },
+          // doc vazio não vira chave (o boundary já filtra sem-doc) — 2 códigos sob "" não são ambíguos
+          { caso: "doc_vazio_ignorado", registros: [{ doc: "", codigo: 100 }, { doc: "", codigo: 200 }], expected: [] },
+          // mistura: só os ambíguos entram; os limpos ficam de fora (precisão do escopo do fail-closed)
+          { caso: "mistura_so_ambiguos", registros: [{ doc: "A", codigo: 1 }, { doc: "B", codigo: 2 }, { doc: "B", codigo: 3 }, { doc: "C", codigo: 4 }, { doc: "C", codigo: 4 }], expected: ["B"] },
+          // lista vazia → ∅ (nenhum doc marcado por acidente)
+          { caso: "lista_vazia", registros: [], expected: [] },
+        ];
+        const casosDoc = fixturesDoc.map((c) => {
+          const resolved = canon(docsComCodigoAmbiguoNoOmie(c.registros));
+          const expected = canon(c.expected);
+          return { caso: c.caso, resolved, expected, ok: stableId(resolved) === stableId(expected) };
+        });
+        result = {
+          success: true,
+          probe_no_ar: true, // a action respondeu → o helper P1b está no build deployado
+          ok: casosDoc.every((c) => c.ok), // true = a tabela-verdade deployada bate em TODOS os fixtures
+          casos: casosDoc,
+        };
+        break;
+      }
+
       default:
         return new Response(JSON.stringify({ error: "Ação desconhecida" }), {
           status: 400,


### PR DESCRIPTION
## O quê
Probe HTTP staff-gated **`doc_ambiguo_probe`** no handler do `omie-analytics-sync` (atrás do `authorizeCronOrStaff` existente), análogo ao `identidade_probe` do `omie-vendas-sync`. Roda o helper MIRROR **deployado** `docsComCodigoAmbiguoNoOmie` sobre fixtures fixos e retorna `{resolved, expected, ok}` por caso. Dry-run puro (não toca DB/Omie/PV).

## Por quê
O **P1b** é fail-closed money-path: documento com 2+ registros Omie de códigos **distintos** na mesma conta é ambíguo → **não** pode virar vínculo na proof-table `omie_customer_account_map` (senão o last-write-wins grava um código arbitrário → pedido no cliente errado).

O Lovable **já reverteu** esse helper num deploy (#1272/#1273). Tínhamos **dois** guards antes deste PR: paridade **textual** no CI (cobre a FONTE na `main`) e — nada cobrindo o **BUNDLE DEPLOYADO**. A ausência do helper é **indetectável por sonda de dados**: a proof-table só encolhe quando há duplicata-CNPJ real na conta, e não há (`colacor_sc` 5275→5275, verificado via psql-ro em 2026-07-10). Só executar o helper deployado sobre um fixture sintético prova que ele está no bundle.

## Mudanças
- **edge** `omie-analytics-sync/index.ts`: novo `case "doc_ambiguo_probe"` (7 fixtures = enumeração do oráculo; comparação por `canon`+`stableId` canônico ordenado)
- **vitest** `omie-doc-ambiguo.test.ts`: espelha os MESMOS fixtures rodando a função **REAL** de `src/` (prova que os `expected` à mão batem no comportamento real)
- **canário** `edge-money-path-invariants.test.ts`: asserts de existência / read-only / cobertura da tabela-verdade do case (pega rename/remoção) **+ reforço** no assert de real-path (exige a chamada do helper **fora** da probe — senão a própria probe mascararia a remoção do fail-closed no `syncCustomers`)
- **doc** `money-path.md`: nota das duas canárias deployadas

## Prova (falsificação 2×)
- `expected` sabotado (`{doc}`→∅, a reversão que o Lovable faz) → o teste "roda a função REAL" ficou **vermelho** nomeando o fixture
- `case` renomeado no edge → as 2 canárias textuais ficaram **vermelhas**

## Gates — todos verdes
`deno check omie-analytics-sync` · `bun run typecheck` · `heavy heavy bun run test` (588 files / **4837 tests**) · `bun run lint` (0 errors). **Sem migration** (edge TS puro).

## ⚠️ Deploy (manual, pós-merge)
1. Edge `omie-analytics-sync` **verbatim** pelo chat do Lovable (merge ≠ produção)
2. Invocar como staff `{"action":"doc_ambiguo_probe"}` e confirmar `data.ok === true` (e cada `caso.ok`). `"Ação desconhecida"` = binário velho; `ok:false` = Lovable reverteu o helper no bundle (é o que a canária existe para pegar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)