### PR TITLE
fix(omie-vendas-sync): hardening fail-closed do resolver de identidade do syncPedidos (P1/P2)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -481,6 +481,87 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
   });
 });
 
+// ── P1/P2 hardening do resolver de identidade do syncPedidos (omie-vendas-sync) — Codex xhigh 2026-07-10 ──
+// Dois furos PRÉ-EXISTENTES no resolver de identidade dos pedidos (fora do escopo da PR-2 #1285, que migrou
+// só o cache codigo->user): (P1) o docToUserMap (doc->user de profiles) fazia last-write-wins → doc
+// compartilhado por 2 users mapeava o ARBITRÁRIO, e um pedido no fallback ConsultarCliente ia pro cliente
+// ERRADO. (P2) o resolveClientUserId só passava throwOnTransient no modo cursor → no incremental um
+// transitório do ConsultarCliente virava null cacheado + skip PERMANENTE (success:true). Fail-closed via
+// helper puro espelhado (buildDocUserMapFailClosed) + throwOnTransient incondicional. A paridade textual
+// aqui pega a reversão do deploy do Lovable (mesma armadilha do #1272). Ver docs/agent/money-path.md.
+const DOC_USER_MAP = 'src/lib/omie/omie-doc-user-map.ts';
+
+describe('guardrail money-path: syncPedidos resolve identidade fail-closed (P1 doc-ambíguo + P2 transitório)', () => {
+  const src = read(VENDAS);
+  const helper = read(DOC_USER_MAP);
+
+  it('sentinela: leu os arquivos reais (edge + helper)', () => {
+    expect(src).toContain('async function syncPedidos');
+    expect(helper).toContain('buildDocUserMapFailClosed');
+  });
+
+  it('o helper puro existe e exporta buildDocUserMapFailClosed', () => {
+    expect(helper).toMatch(/export function buildDocUserMapFailClosed/);
+  });
+
+  // ── P1: docToUserMap fail-closed (helper) + keyset estável + error-throw ──
+  it('P1: o docToUserMap vem do helper fail-closed (não mais last-write-wins com .set direto)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o docToUserMap não é mais montado pelo helper fail-closed — last-write-wins reintroduzido?',
+    ).toMatch(/docToUserMap = buildDocUserMapFailClosed\(/);
+    expect(
+      src,
+      'REGRESSÃO: voltou docToUserMap.set(...) direto no pré-load — o fail-closed do helper foi contornado',
+    ).not.toMatch(/docToUserMap\.set\(/);
+  });
+
+  it('P1: o edge USA o helper — define o MIRROR E chama (≥2 menções)', () => {
+    expect(src, 'edge não define mais o helper espelhado').toMatch(/function buildDocUserMapFailClosed/);
+    expect(
+      count(src, 'buildDocUserMapFailClosed'),
+      'helper deve ser DEFINIDO (MIRROR) e CHAMADO (real-path) — ≥2 menções',
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('P1: o pré-load de profiles pagina por KEYSET estável (.order + .gt) e é FAIL-CLOSED em erro de query', () => {
+    // Sem .order o PostgREST não garante ordem entre páginas → profile pulado (some do mapa). Codex.
+    expect(
+      src,
+      'REVERSÃO Lovable? o pré-load do docToUserMap não pagina mais por keyset (.order(user_id) + .gt)',
+    ).toMatch(/from\('profiles'\)[\s\S]{0,200}\.order\('user_id'\)[\s\S]{0,120}\.gt\('user_id', lastUserId\)/);
+    expect(
+      src,
+      'REGRESSÃO: o pré-load do docToUserMap engole o erro da query — mapa parcial silencioso (fail-open)',
+    ).toMatch(/if \(profErr\) throw new Error/);
+  });
+
+  it('P1 PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlockNamed(src, 'omie doc-user-fail-closed'),
+      'edge divergiu do helper de src/ — o Lovable reescreveu a detecção fail-closed no deploy?',
+    ).toBe(mirrorBlockNamed(helper, 'omie doc-user-fail-closed'));
+  });
+
+  // ── P2: resolveClientUserId fail-safe em transitório nos DOIS modos (cursor E incremental) ──
+  it('P2: resolveClientUserId passa throwOnTransient INCONDICIONAL (não só no cursor) e sem catch fail-open', () => {
+    const bloco = src.match(/async function resolveClientUserId[\s\S]*?async function getClientAddressPhone/)?.[0] ?? '';
+    expect(bloco, 'não achei o corpo de resolveClientUserId (âncora quebrada)').not.toBe('');
+    expect(
+      bloco,
+      'REGRESSÃO P2: resolveClientUserId voltou a condicionar throwOnTransient ao cursor — transitório no incremental vira skip permanente',
+    ).not.toMatch(/cursor \?/);
+    expect(
+      bloco,
+      'REGRESSÃO P2: resolveClientUserId não passa mais { throwOnTransient: true } ao ConsultarCliente',
+    ).toMatch(/\{ throwOnTransient: true \}/);
+    expect(
+      bloco,
+      'REGRESSÃO P2: voltou o catch que engole o transitório no incremental (fail-open → null cacheado + skip)',
+    ).not.toMatch(/catch\s*\(/);
+  });
+});
+
 // ── P0-B-bis PR-1 (omie-sync self-service USA a view fresca account-correta + helper espelhado) ──
 // O pedido self-service (conta colacor_sc) resolvia a identidade Omie pelo espelho poluído omie_clientes
 // (mix de contas, rótulo 'colacor' mentiroso) e fallback registros:1 (last-write-wins). Migrado p/ a view

--- a/src/lib/omie/omie-doc-user-map.test.ts
+++ b/src/lib/omie/omie-doc-user-map.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { buildDocUserMapFailClosed } from './omie-doc-user-map';
+
+// P1 (Codex xhigh 2026-07-10, money-path fail-closed): no syncPedidos do omie-vendas-sync o docToUserMap
+// (doc normalizado -> user_id de profiles) alimenta o fallback resolveClientUserId (ConsultarCliente -> doc
+// -> user). Com last-write-wins, se 2 profiles compartilham o mesmo CPF/CNPJ o ÚLTIMO da paginação vencia e
+// o pedido money-path era atribuído ao user ARBITRÁRIO. Este helper puro (espelhado verbatim no edge) é o
+// análogo VENDAS do fetchProfileDocUserMap (P1b lado profile): doc ambíguo (2+ users distintos) fica FORA do
+// mapa — precisão > recall. FALSIFICAÇÃO no rodapé (sabote o helper e exija vermelho).
+describe('buildDocUserMapFailClosed (P1 fail-closed money-path — resolver de identidade do syncPedidos)', () => {
+  it('doc com 1 user distinto entra no mapa', () => {
+    const m = buildDocUserMapFailClosed([{ doc: '11111111111', userId: 'u1' }]);
+    expect(m.get('11111111111')).toBe('u1');
+    expect(m.size).toBe(1);
+  });
+
+  it('FAIL-CLOSED: doc compartilhado por 2 users DISTINTOS não entra (não chuta o arbitrário)', () => {
+    const m = buildDocUserMapFailClosed([
+      { doc: '99999999999999', userId: 'u1' },
+      { doc: '99999999999999', userId: 'u2' },
+    ]);
+    expect(
+      m.has('99999999999999'),
+      'doc ambíguo jamais deve mapear — last-write-wins reintroduzido?',
+    ).toBe(false);
+  });
+
+  it('mesmo user repetido no doc (duplicata de paginação) NÃO é ambiguidade — mapeia', () => {
+    const m = buildDocUserMapFailClosed([
+      { doc: '11111111111', userId: 'u1' },
+      { doc: '11111111111', userId: 'u1' },
+    ]);
+    expect(m.get('11111111111')).toBe('u1');
+  });
+
+  it('3+ users no mesmo doc → fora do mapa', () => {
+    const m = buildDocUserMapFailClosed([
+      { doc: 'd', userId: 'u1' },
+      { doc: 'd', userId: 'u2' },
+      { doc: 'd', userId: 'u3' },
+    ]);
+    expect(m.has('d')).toBe(false);
+  });
+
+  it('ambiguidade é STICKY: uma 3ª ocorrência do 1º user não ressuscita o doc', () => {
+    const m = buildDocUserMapFailClosed([
+      { doc: 'd', userId: 'u1' },
+      { doc: 'd', userId: 'u2' },
+      { doc: 'd', userId: 'u1' },
+    ]);
+    expect(
+      m.has('d'),
+      'doc já marcado ambíguo voltou ao mapa — fail-closed não é sticky',
+    ).toBe(false);
+  });
+
+  it('doc ambíguo não contamina doc limpo (isolamento por chave)', () => {
+    const m = buildDocUserMapFailClosed([
+      { doc: 'ambig', userId: 'u1' },
+      { doc: 'ambig', userId: 'u2' },
+      { doc: 'limpo', userId: 'u3' },
+    ]);
+    expect(m.has('ambig')).toBe(false);
+    expect(m.get('limpo')).toBe('u3');
+  });
+
+  it('ordem de aparição não altera o resultado (comutativo no fail-closed)', () => {
+    const a = buildDocUserMapFailClosed([
+      { doc: 'd', userId: 'u2' },
+      { doc: 'd', userId: 'u1' },
+    ]);
+    expect(a.has('d')).toBe(false);
+  });
+
+  it('doc vazio não vira chave (o boundary do edge já filtra doc<11)', () => {
+    const m = buildDocUserMapFailClosed([{ doc: '', userId: 'u1' }]);
+    expect(m.size).toBe(0);
+  });
+
+  it('userId vazio não vira vínculo (sem user não há identidade)', () => {
+    const m = buildDocUserMapFailClosed([{ doc: '11111111111', userId: '' }]);
+    expect(m.has('11111111111')).toBe(false);
+  });
+
+  it('array vazio → mapa vazio', () => {
+    expect(buildDocUserMapFailClosed([]).size).toBe(0);
+  });
+});

--- a/src/lib/omie/omie-doc-user-map.ts
+++ b/src/lib/omie/omie-doc-user-map.ts
@@ -1,0 +1,25 @@
+// MIRROR-START omie doc-user-fail-closed — espelhado verbatim em supabase/functions/omie-vendas-sync/index.ts
+// P1 (fail-closed money-path): no syncPedidos, o docToUserMap (doc normalizado -> user_id de profiles)
+// alimenta o fallback resolveClientUserId (ConsultarCliente devolve o doc -> docToUserMap.get(doc)). Se 2
+// profiles DISTINTOS compartilham o mesmo CPF/CNPJ, o last-write-wins gravava o user do ÚLTIMO da paginação
+// e o pedido money-path era atribuído ao cliente ARBITRÁRIO. Fail-closed: doc com 2+ users distintos fica
+// FORA do mapa (precisão > recall — melhor cair no skip/log que atribuir errado). Análogo VENDAS do lado
+// profile (fetchProfileDocUserMap, P1b). Espelhado no edge (Deno não importa de src/); paridade textual no
+// CI em src/__tests__/edge-money-path-invariants.test.ts.
+export function buildDocUserMapFailClosed(
+  registros: ReadonlyArray<{ doc: string; userId: string }>,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const ambiguos = new Set<string>();
+  for (const r of registros) {
+    if (!r.doc || !r.userId) continue;         // sem doc ou sem user → não vira vínculo
+    if (ambiguos.has(r.doc)) continue;          // já ambíguo → permanece FORA (sticky)
+    const prev = map.get(r.doc);
+    if (prev === undefined) { map.set(r.doc, r.userId); continue; }
+    if (prev === r.userId) continue;            // mesmo user repetido (duplicata de paginação, idempotente)
+    map.delete(r.doc);                          // 2º user DISTINTO → ambíguo, fail-closed
+    ambiguos.add(r.doc);
+  }
+  return map;
+}
+// MIRROR-END

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -893,10 +893,13 @@ async function syncPedidos(
   // last-write-wins gravava um user ARBITRÁRIO e um pedido no fallback resolveClientUserId (ConsultarCliente
   // -> doc -> docToUserMap.get) era atribuído ao cliente ERRADO (money-path). Fail-closed via helper puro
   // espelhado buildDocUserMapFailClosed (análogo VENDAS do fetchProfileDocUserMap P1b): doc ambíguo fica FORA
-  // do mapa. Paginação KEYSET (.order('user_id') + .gt), não offset .range: sem .order o PostgREST não
-  // garante ordem estável entre páginas → um profile podia ser PULADO (some do mapa) sob inserção concorrente.
-  // Erro de query é FAIL-CLOSED (throw): engolir o error deixaria um mapa PARCIAL silencioso → miss no
-  // fallback → skip/atribuição arbitrária. Melhor abortar o run e retomar na próxima janela.
+  // do mapa. Paginação KEYSET (.order('user_id') + .gt) troca o offset .range: elimina o pular/duplicar por
+  // DESLOCAMENTO (uma linha inserida/removida entre páginas desloca as janelas .range sem .order). ATENÇÃO
+  // (Codex xhigh): a leitura multi-página NÃO é atômica — um profile que nasce/muda ENTRE páginas com user_id
+  // < cursor ainda escapa desta janela (mesma limitação do fetchProfileDocUserMap P1b, que usa offset). O
+  // fechamento TOTAL da corrida exige resolver a unicidade num único snapshot server-side (RPC GROUP BY doc
+  // HAVING count(distinct user)=1) — follow-up v2. Erro de query é FAIL-CLOSED (throw): engolir o error
+  // deixaria um mapa PARCIAL silencioso → miss no fallback → skip/atribuição arbitrária. Aborta e retoma.
   const pgSize = 1000;
   const profileDocRegistros: Array<{ doc: string; userId: string }> = [];
   let lastUserId: string | null = null;
@@ -923,8 +926,13 @@ async function syncPedidos(
       if (batch.length < pgSize) hasMore = false;
     }
   }
+  const docsDistintos = new Set(profileDocRegistros.map((r) => r.doc)).size;
   const docToUserMap = buildDocUserMapFailClosed(profileDocRegistros);
-  console.log(`[sync_pedidos][${account}] Document map: ${docToUserMap.size} profiles (fail-closed)`);
+  // Observabilidade do fail-closed (Codex): todo doc distinto (todos têm user_id) ou vira 1 entry (não-ambíguo)
+  // ou é removido (2+ users) → docsAmbiguos = distintos - map.size. Hoje 0 (docs_com_2mais_users=0), mas
+  // quando surgir a 1ª duplicata-doc no lado profile este log é o 1º sinal (o dado não denuncia sozinho).
+  const docsAmbiguos = docsDistintos - docToUserMap.size;
+  console.log(`[sync_pedidos][${account}] Document map: ${docToUserMap.size} profiles (fail-closed; ${docsAmbiguos} doc(s) ambíguo(s) excluído(s))`);
 
   // Dedupe DENTRO da run (evita mandar o mesmo pedido 2x na mesma chamada). NÃO pré-carregamos
   // hashes do banco: todos os pedidos válidos da janela vão para a RPC criar_pedidos_com_itens,

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -888,30 +888,43 @@ async function syncPedidos(
   let reachedEnd = false;            // true SÓ no fim real do Omie (null = "Não existem registros", ou página vazia)
   let lastErrorKind: 'rate_limit' | 'transient' | 'http' | null = null;
 
-  // ── Pre-load document -> user_id mapping from profiles ──
-  const docToUserMap = new Map<string, string>();
-  let cPage = 0;
+  // ── Pre-load document -> user_id mapping from profiles (KEYSET + fail-closed) ──
+  // P1 (Codex xhigh 2026-07-10): doc compartilhado por 2+ profiles (users DISTINTOS) é AMBÍGUO — o
+  // last-write-wins gravava um user ARBITRÁRIO e um pedido no fallback resolveClientUserId (ConsultarCliente
+  // -> doc -> docToUserMap.get) era atribuído ao cliente ERRADO (money-path). Fail-closed via helper puro
+  // espelhado buildDocUserMapFailClosed (análogo VENDAS do fetchProfileDocUserMap P1b): doc ambíguo fica FORA
+  // do mapa. Paginação KEYSET (.order('user_id') + .gt), não offset .range: sem .order o PostgREST não
+  // garante ordem estável entre páginas → um profile podia ser PULADO (some do mapa) sob inserção concorrente.
+  // Erro de query é FAIL-CLOSED (throw): engolir o error deixaria um mapa PARCIAL silencioso → miss no
+  // fallback → skip/atribuição arbitrária. Melhor abortar o run e retomar na próxima janela.
   const pgSize = 1000;
+  const profileDocRegistros: Array<{ doc: string; userId: string }> = [];
+  let lastUserId: string | null = null;
   let hasMore = true;
   while (hasMore) {
-    const { data: batch } = await supabase
+    let query = supabase
       .from('profiles')
       .select('user_id, document')
       .not('document', 'is', null)
-      .range(cPage * pgSize, (cPage + 1) * pgSize - 1);
+      .order('user_id')
+      .limit(pgSize);
+    if (lastUserId !== null) query = query.gt('user_id', lastUserId);
+    const { data: batch, error: profErr } = await query;
+    if (profErr) throw new Error(`pre-load profile doc map (${account}): ${profErr.message}`);
     if (!batch || batch.length === 0) { hasMore = false; }
     else {
       for (const p of batch) {
         if (p.document) {
           const cleanDoc = p.document.replace(/\D/g, '');
-          if (cleanDoc.length >= 11) docToUserMap.set(cleanDoc, p.user_id);
+          if (cleanDoc.length >= 11) profileDocRegistros.push({ doc: cleanDoc, userId: p.user_id });
         }
       }
+      lastUserId = batch[batch.length - 1].user_id;
       if (batch.length < pgSize) hasMore = false;
-      cPage++;
     }
   }
-  console.log(`[sync_pedidos][${account}] Document map: ${docToUserMap.size} profiles`);
+  const docToUserMap = buildDocUserMapFailClosed(profileDocRegistros);
+  console.log(`[sync_pedidos][${account}] Document map: ${docToUserMap.size} profiles (fail-closed)`);
 
   // Dedupe DENTRO da run (evita mandar o mesmo pedido 2x na mesma chamada). NÃO pré-carregamos
   // hashes do banco: todos os pedidos válidos da janela vão para a RPC criar_pedidos_com_itens,
@@ -975,41 +988,36 @@ async function syncPedidos(
   // Helper: resolve codigo_cliente -> user_id (cache-first, API fallback only for unknown)
   async function resolveClientUserId(codigoCliente: number): Promise<string | null> {
     if (clientCache.has(codigoCliente)) return clientCache.get(codigoCliente) || null;
-    // Fallback: call Omie API only for clients NOT in omie_clientes table.
-    // Modo cursor (backfill): throwOnTransient — um rate-limit/transitório aqui NÃO pode
-    // virar "cliente ausente" cacheado (#4 Codex): isso pularia o pedido (skippedNoClient)
-    // e a janela poderia COMPLETAR sem ele → perda permanente. Re-lançamos o transitório
-    // p/ o loop PAUSAR a janela e retomar depois (o cliente genuinamente sem doc segue null).
-    try {
-      const result = (await callOmieVendasApi(
-        "geral/clientes/",
-        "ConsultarCliente",
-        { codigo_cliente_omie: codigoCliente },
-        account,
-        cursor ? { throwOnTransient: true } : undefined,
-      )) as OmieClienteCadastro | null;
-      if (!result) {
-        clientCache.set(codigoCliente, null);
-        return null;
-      }
-      const doc = (result.cnpj_cpf || '').replace(/\D/g, '');
-      // Cache address/phone from ConsultarCliente result
-      const addrParts = [result.endereco, result.endereco_numero, result.complemento, result.bairro, result.cidade, result.estado, result.cep].filter(Boolean);
-      const phone = result.telefone1_ddd && result.telefone1_numero ? `(${result.telefone1_ddd}) ${result.telefone1_numero}` : '';
-      clientAddressCache.set(codigoCliente, { address: addrParts.join(', '), phone });
+    // Fallback: chama a API Omie só p/ clientes fora do cache. throwOnTransient em AMBOS os modos (cursor
+    // E incremental — P2 Codex xhigh 2026-07-10): um rate-limit/transitório do ConsultarCliente NÃO pode
+    // virar "cliente ausente" cacheado. No incremental (sem cursor) isso pulava o pedido (skippedNoClient++)
+    // e a janela COMPLETAVA success:true; se a falha persistisse até o pedido sair da janela de ~5 dias →
+    // PERDA PERMANENTE silenciosa. SEM try/catch: o transitório (e qualquer erro de lookup) PROPAGA — no
+    // cursor o loop PAUSA e retoma; no incremental propaga (500 + fin_sync_log error) e a próxima run
+    // reprocessa a janela (idempotente, a RPC decide skip/reparo). Só o caminho SEM erro cacheia null:
+    // result null ("Não existem registros" no Omie) ou doc<11 (cliente sem CPF/CNPJ usável) = ausência
+    // CONFIRMADA. Ver callOmieVendasApi: "Não existem registros"/HTTP-erro independem de throwOnTransient.
+    const result = (await callOmieVendasApi(
+      "geral/clientes/",
+      "ConsultarCliente",
+      { codigo_cliente_omie: codigoCliente },
+      account,
+      { throwOnTransient: true },
+    )) as OmieClienteCadastro | null;
+    if (!result) {
+      clientCache.set(codigoCliente, null);
+      return null;
+    }
+    const doc = (result.cnpj_cpf || '').replace(/\D/g, '');
+    // Cache address/phone from ConsultarCliente result
+    const addrParts = [result.endereco, result.endereco_numero, result.complemento, result.bairro, result.cidade, result.estado, result.cep].filter(Boolean);
+    const phone = result.telefone1_ddd && result.telefone1_numero ? `(${result.telefone1_ddd}) ${result.telefone1_numero}` : '';
+    clientAddressCache.set(codigoCliente, { address: addrParts.join(', '), phone });
 
-      if (doc.length >= 11) {
-        const userId = docToUserMap.get(doc) || null;
-        clientCache.set(codigoCliente, userId);
-        return userId;
-      }
-    } catch (e) {
-      // Backfill (#A Codex): QUALQUER erro de lookup (transitório, HTTP, rede, fault
-      // não-classificado) re-lança → o loop PAUSA a janela, não cacheia ausência FALSA.
-      // Só o caminho SEM erro cacheia null: `if (!result)` (Omie diz que não existe) e
-      // doc<11 (cliente existe, sem doc usável) — esses são skip LEGÍTIMO, não erro.
-      if (cursor) throw e;
-      console.warn(`[sync_pedidos][${account}] ConsultarCliente ${codigoCliente} falhou:`, (e as Error).message);
+    if (doc.length >= 11) {
+      const userId = docToUserMap.get(doc) || null;
+      clientCache.set(codigoCliente, userId);
+      return userId;
     }
     clientCache.set(codigoCliente, null);
     return null;
@@ -1629,6 +1637,32 @@ function decideAccountIdentity(input: DecideInput): DecideResult {
   if (suppliedCodigo != null && !sameCode(suppliedCodigo, cand.codigo_cliente)) return { ok: false, reason: 'divergence' };
 
   return { ok: true, source: cand.source, codigo_cliente: cand.codigo_cliente, codigo_vendedor: cand.codigo_vendedor, backfill: cand.backfill };
+}
+// MIRROR-END
+
+// MIRROR-START omie doc-user-fail-closed — espelhado verbatim em supabase/functions/omie-vendas-sync/index.ts
+// P1 (fail-closed money-path): no syncPedidos, o docToUserMap (doc normalizado -> user_id de profiles)
+// alimenta o fallback resolveClientUserId (ConsultarCliente devolve o doc -> docToUserMap.get(doc)). Se 2
+// profiles DISTINTOS compartilham o mesmo CPF/CNPJ, o last-write-wins gravava o user do ÚLTIMO da paginação
+// e o pedido money-path era atribuído ao cliente ARBITRÁRIO. Fail-closed: doc com 2+ users distintos fica
+// FORA do mapa (precisão > recall — melhor cair no skip/log que atribuir errado). Análogo VENDAS do lado
+// profile (fetchProfileDocUserMap, P1b). Espelhado no edge (Deno não importa de src/); paridade textual no
+// CI em src/__tests__/edge-money-path-invariants.test.ts.
+function buildDocUserMapFailClosed(
+  registros: ReadonlyArray<{ doc: string; userId: string }>,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  const ambiguos = new Set<string>();
+  for (const r of registros) {
+    if (!r.doc || !r.userId) continue;         // sem doc ou sem user → não vira vínculo
+    if (ambiguos.has(r.doc)) continue;          // já ambíguo → permanece FORA (sticky)
+    const prev = map.get(r.doc);
+    if (prev === undefined) { map.set(r.doc, r.userId); continue; }
+    if (prev === r.userId) continue;            // mesmo user repetido (duplicata de paginação, idempotente)
+    map.delete(r.doc);                          // 2º user DISTINTO → ambíguo, fail-closed
+    ambiguos.add(r.doc);
+  }
+  return map;
 }
 // MIRROR-END
 


### PR DESCRIPTION
## Contexto
Dois furos **PRÉ-EXISTENTES** no resolver de identidade dos pedidos (`syncPedidos`), achados no **Codex challenge xhigh (2026-07-10)** da PR-2 (P0-B-bis). Ambos **money-path estrutural** — hoje **0 casos observáveis** (`docs_com_2mais_users=0` via psql-ro), mas risco real de atribuir pedido ao cliente errado / perder pedido silenciosamente.

Fora do escopo da PR-2 [#1285](https://github.com/LucasSardenbergL/afiacao/pull/1285) (que migra só o cache `codigo->user`).

## P1 — `docToUserMap` last-write-wins (doc→user de profiles)
Doc (CPF/CNPJ) compartilhado por 2+ profiles (users **distintos**) mapeava o user do **último** da paginação. Um pedido no fallback `resolveClientUserId` (`ConsultarCliente` → doc → `docToUserMap.get`) era atribuído ao cliente **arbitrário**.

- **Fail-closed** via helper puro espelhado `buildDocUserMapFailClosed` (análogo VENDAS do `fetchProfileDocUserMap` P1b): doc ambíguo fica **fora** do mapa (precisão > recall).
- Pré-load migrado p/ paginação **KEYSET** (`.order('user_id')` + `.gt`, não offset `.range` instável) + **`if (err) throw`** (não engolir → cache parcial silencioso).

## P2 — `resolveClientUserId` fail-open no incremental
`throwOnTransient` só era passado no **modo cursor**. No **incremental** um transitório do `ConsultarCliente` virava `null` cacheado + `skippedNoClient++` (`success:true`) → **perda PERMANENTE** se persistisse até o pedido sair da janela ~5 dias.

- `throwOnTransient` **incondicional** + remoção do `try/catch`: o transitório (e qualquer erro de lookup) **propaga** — no cursor o loop pausa/retoma; no incremental propaga (500 + `fin_sync_log error`) e a próxima run reprocessa a janela (idempotente).
- Só **ausência CONFIRMADA** (`result` null = "Não existem registros" / doc<11) cacheia `null`.
- ⚠️ Consequência além do transitório estrito: erros **não-transitórios** de `ConsultarCliente` no incremental também deixam de virar skip silencioso (fail-safe, alinha com o backfill). "Cliente inexistente" retorna `null` (não erro) → não trava a janela.

## Gate
- ✅ **vitest do helper puro** (`omie-doc-user-map.test.ts`, 10 casos) — **falsificado**: sabota o fail-closed (last-write-wins) → 5 asserts vermelhos.
- ✅ **guard textual** (`edge-money-path-invariants.test.ts`, +6): paridade MIRROR src×edge + keyset + `throwOnTransient` — **falsificado** P2 (reverte `throwOnTransient` → vermelho).
- ✅ `deno check` (edge) · `typecheck` · `lint` (0 errors) · **suíte 4854 verde**.
- Sem migration (edge TS).
- 🔄 `/codex` challenge xhigh em andamento (gate money-path).

## Coordenação
Achados **ortogonais** à PR-2 [#1285](https://github.com/LucasSardenbergL/afiacao/pull/1285): meus hunks no `index.ts` (docToUserMap ~892 / resolveClientUserId ~988) estão separados do hunk dela (clientCache ~920) por gaps > 3 linhas → auto-merge esperado limpo. Meu `describe` no teste foi posicionado no **meio** do arquivo (junto ao P1b) para não colidir com o **append** da #1285 no fim.

## Deploy (pós-merge)
Edge `omie-vendas-sync` **verbatim** no chat do Lovable (frontend/migration não se aplicam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)