### PR TITLE
fix(omie-analytics-sync): popula vendedor de recomendacoes — carteira 100% Hunter (P0-B-bis)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -708,3 +708,38 @@ describe('guardrail money-path: syncPedidos resolve user pela view fresca accoun
     ).toMatch(/\.from\("omie_clientes"\)\s*\.select\("omie_codigo_cliente, empresa_omie"\)/);
   });
 });
+
+// ── P0-B-bis (incidente carteira): omie-analytics-sync popula o vendedor de recomendacoes ──
+// O vendedor do cliente no Omie mora em recomendacoes.codigo_vendedor (o codigo_vendedor RAIZ vem vazio no
+// ListarClientes). O writer da proof (omie_customer_account_map) e do espelho (omie_clientes) lia só
+// c.codigo_vendedor → gravava NULL → carteira-rebuild via todo cliente como órfão e mandava os 6909 pro
+// Hunter (0 clientes atribuídos aos 18 vendedores). Corrigido p/ ler recomendacoes primeiro (padrão de
+// omie-cliente/omie-sync). A paridade textual aqui pega a reversão do deploy do Lovable.
+const ANALYTICS_VEND = 'supabase/functions/omie-analytics-sync/index.ts';
+
+describe('guardrail money-path: omie-analytics-sync popula vendedor de recomendacoes (incidente carteira)', () => {
+  const src = read(ANALYTICS_VEND);
+
+  it('sentinela: leu o edge real (syncCustomers + proof)', () => {
+    expect(src).toContain('syncCustomers');
+    expect(src).toContain('omie_customer_account_map');
+  });
+
+  it('os writers da PROOF e do ESPELHO leem recomendacoes.codigo_vendedor (não o raiz vazio)', () => {
+    expect(
+      count(src, 'omie_codigo_vendedor: c.recomendacoes?.codigo_vendedor || c.codigo_vendedor || null'),
+      'REVERSÃO Lovable? os 2 writers de vendedor não leem mais recomendacoes (carteira volta 100% pro Hunter)',
+    ).toBe(2);
+  });
+
+  it('anti-reversão: nenhum writer voltou a gravar SÓ c.codigo_vendedor (o campo raiz vazio)', () => {
+    expect(
+      src,
+      'REGRESSÃO: omie_codigo_vendedor voltou a ler só c.codigo_vendedor (raiz vazio) — vendedor NULL de novo',
+    ).not.toMatch(/omie_codigo_vendedor: c\.codigo_vendedor \|\| null/);
+  });
+
+  it('a interface declara recomendacoes.codigo_vendedor (senão o parse dropa o campo silenciosamente)', () => {
+    expect(src).toMatch(/recomendacoes\?: \{ codigo_vendedor\?: number \| null \}/);
+  });
+});

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -59,7 +59,7 @@ function buildNaoVinculadoRow(
     nome_fantasia: c.nome_fantasia?.trim() || null,
     cidade: c.cidade?.trim() || null,
     uf: c.estado?.trim() || null,
-    codigo_vendedor: c.codigo_vendedor ?? null,
+    codigo_vendedor: c.recomendacoes?.codigo_vendedor ?? c.codigo_vendedor ?? null,
     synced_at: syncedAtIso,
   };
 }
@@ -68,6 +68,10 @@ interface OmieClienteCadastro {
   codigo_cliente_omie?: number;
   codigo_cliente_integracao?: string | null;
   codigo_vendedor?: number | null;
+  // O vendedor do cliente no Omie mora em recomendacoes.codigo_vendedor (o codigo_vendedor raiz vem
+  // vazio no ListarClientes) — padrão já usado em omie-cliente/omie-sync. Sem isto a proof/espelho
+  // gravavam vendedor NULL → carteira-rebuild mandava tudo pro Hunter (incidente P0-B-bis).
+  recomendacoes?: { codigo_vendedor?: number | null };
   cnpj_cpf?: string;
   razao_social?: string;
   nome_fantasia?: string;
@@ -358,7 +362,7 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
           user_id: userId,
           omie_codigo_cliente: c.codigo_cliente_omie,
           omie_codigo_cliente_integracao: c.codigo_cliente_integracao || null,
-          omie_codigo_vendedor: c.codigo_vendedor || null,
+          omie_codigo_vendedor: c.recomendacoes?.codigo_vendedor || c.codigo_vendedor || null,
           updated_at: new Date().toISOString(),
         });
         // Captura tags do cadastro Omie para derivar is_fornecedor / excluir_da_carteira depois.
@@ -375,7 +379,7 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
             user_id: userIdByDoc,
             account: empresaMap,
             omie_codigo_cliente: c.codigo_cliente_omie,
-            omie_codigo_vendedor: c.codigo_vendedor || null,
+            omie_codigo_vendedor: c.recomendacoes?.codigo_vendedor || c.codigo_vendedor || null,
             source: "document",
             updated_at: new Date().toISOString(),
           });


### PR DESCRIPTION
## Incidente: carteira de vendedores 100% no Hunter

`carteira_assignments` está **100% no Hunter** — 6909 assignments, todos `source='hunter_orphan'`, os **18 vendedores oben sem nenhum cliente** (psql-ro produção 2026-07-11; rebuild de hoje 07:30).

**Causa raiz:** `syncCustomers` (omie-analytics-sync) grava `omie_codigo_vendedor` lendo só `c.codigo_vendedor` — o campo **raiz** do `ListarClientes`, que vem **vazio** no Omie. O vendedor do cliente mora em `c.recomendacoes.codigo_vendedor` (padrão já usado em `omie-cliente` :214/568/828 e `omie-sync` PR-1). Resultado: `omie_codigo_vendedor` 100% NULL na proof-table (0/15661) e no espelho (0/6909) → `carteira-rebuild` vê todo cliente como órfão → Hunter.

## Conserto

- Interface `OmieClienteCadastro` ganha `recomendacoes?: { codigo_vendedor?: number | null }`.
- Os 3 usos do vendedor (`nao_vinculados` :62, espelho :365, proof :382) leem `recomendacoes.codigo_vendedor` primeiro.
- Canário textual anti-reversão-Lovable + falsificação (reverti os writers → 2 asserts vermelhos).

## Efeito

Desbloqueia a **PR-3** (que dependia do vendedor na view fresca) e corrige a carteira. Auto-correção no próximo ciclo: `sync_customers` (05:00 UTC) popula o vendedor → `carteira-rebuild` (07:30 UTC) atribui.

## Gate

`deno check` · `typecheck` · `lint` · test **64/64** · /codex challenge (xhigh, em andamento — mantido DRAFT até o parecer). Edge TS puro, **sem SQL**.

## ⚠️ Deploy do founder (Lovable — merge ≠ produção)

1. Deploy do edge **`omie-analytics-sync` verbatim** (chat do Lovable).
2. Disparar 1 `sync_customers` na conta **`vendas`** (= oben): `{"action":"sync_customers","account":"vendas"}` — ou aguardar o cron 05:00.
3. Verificação (eu, psql-ro): a proof ganha `omie_codigo_vendedor` não-nulo e a carteira sai do Hunter.

Parte do épico **P0-B-bis**. Ver `docs/superpowers/specs/2026-07-09-omie-leituras-money-path-p0b-bis-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
