### PR TITLE
fix(omie-analytics-sync): popula vendedor de recomendacoes na proof account-safe (P0-B-bis)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -709,26 +709,22 @@ describe('guardrail money-path: syncPedidos resolve user pela view fresca accoun
   });
 });
 
-// ── P0-B-bis (incidente carteira): vendedor de recomendacoes NA PROOF + carteira lê a proof account-safe ──
+// ── P0-B-bis (incidente carteira, ponta 1/2): o writer popula o vendedor de recomendacoes NA PROOF ──
 // A carteira estava 100% Hunter: o writer gravava omie_codigo_vendedor lendo só c.codigo_vendedor (raiz
-// vazio) → proof/espelho NULL → todo cliente órfão. Corrigido em DUAS pontas (Codex BLOCK do approach que
-// populava o mirror code-first inseguro):
-//  (1) o writer popula o vendedor SÓ na PROOF (document-first, account-safe) via helper extrairCodigoVendedor
-//      (recomendacoes vence, só inteiro positivo — resolve o ??/|| do Codex). O mirror code-first NÃO recebe.
-//  (2) carteira-rebuild passa a ler a PROOF (omie_customer_account_map_fresco, account='oben') em vez do
-//      espelho poluído. A paridade textual aqui pega a reversão do deploy do Lovable.
+// vazio) → proof NULL → todo cliente órfão. O vendedor mora em recomendacoes.codigo_vendedor. O writer
+// popula o vendedor SÓ na PROOF (document-first, account-safe) via helper extrairCodigoVendedor (Codex R2:
+// recomendacoes é autoritativa, só inteiro safe positivo). O mirror code-first NÃO recebe (Codex BLOCKou
+// popular o mirror inseguro). A ponta 2/2 (carteira-rebuild LER a proof) é PR próprio — o rebuild tem
+// consolidação B-lite (herança cross-account) que exige redesign account-safe (Codex R2: 3 P1).
 const ANALYTICS_V = 'supabase/functions/omie-analytics-sync/index.ts';
-const CARTEIRA = 'supabase/functions/carteira-rebuild/index.ts';
 const VEND_HELPER = 'src/lib/omie/codigo-vendedor.ts';
 
-describe('guardrail money-path: vendedor de recomendacoes na PROOF + carteira lê a proof (P0-B-bis)', () => {
+describe('guardrail money-path: writer popula vendedor de recomendacoes na PROOF (P0-B-bis)', () => {
   const analytics = read(ANALYTICS_V);
-  const carteira = read(CARTEIRA);
   const helper = read(VEND_HELPER);
 
   it('sentinela: leu os arquivos reais', () => {
     expect(analytics).toContain('syncCustomers');
-    expect(carteira).toContain('carteira_assignments');
     expect(helper).toContain('extrairCodigoVendedor');
   });
 
@@ -750,16 +746,5 @@ describe('guardrail money-path: vendedor de recomendacoes na PROOF + carteira l�
       mirrorBlockNamed(analytics, 'omie-codigo-vendedor'),
       'edge divergiu do helper de src/ — Lovable reescreveu a extração do vendedor?',
     ).toBe(mirrorBlockNamed(helper, 'omie-codigo-vendedor'));
-  });
-
-  it('carteira-rebuild lê a PROOF account-correta (oben), NÃO o espelho poluído', () => {
-    expect(
-      carteira,
-      'REVERSÃO Lovable? a carteira não lê mais a view fresca com account=oben',
-    ).toMatch(/\.from\('omie_customer_account_map_fresco'\)[\s\S]{0,120}\.eq\('account', 'oben'\)/);
-    expect(
-      carteira,
-      'REGRESSÃO: a carteira voltou a carregar clientes do espelho poluído omie_clientes',
-    ).not.toMatch(/\.from\('omie_clientes'\)/);
   });
 });

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -708,3 +708,58 @@ describe('guardrail money-path: syncPedidos resolve user pela view fresca accoun
     ).toMatch(/\.from\("omie_clientes"\)\s*\.select\("omie_codigo_cliente, empresa_omie"\)/);
   });
 });
+
+// ── P0-B-bis (incidente carteira): vendedor de recomendacoes NA PROOF + carteira lê a proof account-safe ──
+// A carteira estava 100% Hunter: o writer gravava omie_codigo_vendedor lendo só c.codigo_vendedor (raiz
+// vazio) → proof/espelho NULL → todo cliente órfão. Corrigido em DUAS pontas (Codex BLOCK do approach que
+// populava o mirror code-first inseguro):
+//  (1) o writer popula o vendedor SÓ na PROOF (document-first, account-safe) via helper extrairCodigoVendedor
+//      (recomendacoes vence, só inteiro positivo — resolve o ??/|| do Codex). O mirror code-first NÃO recebe.
+//  (2) carteira-rebuild passa a ler a PROOF (omie_customer_account_map_fresco, account='oben') em vez do
+//      espelho poluído. A paridade textual aqui pega a reversão do deploy do Lovable.
+const ANALYTICS_V = 'supabase/functions/omie-analytics-sync/index.ts';
+const CARTEIRA = 'supabase/functions/carteira-rebuild/index.ts';
+const VEND_HELPER = 'src/lib/omie/codigo-vendedor.ts';
+
+describe('guardrail money-path: vendedor de recomendacoes na PROOF + carteira lê a proof (P0-B-bis)', () => {
+  const analytics = read(ANALYTICS_V);
+  const carteira = read(CARTEIRA);
+  const helper = read(VEND_HELPER);
+
+  it('sentinela: leu os arquivos reais', () => {
+    expect(analytics).toContain('syncCustomers');
+    expect(carteira).toContain('carteira_assignments');
+    expect(helper).toContain('extrairCodigoVendedor');
+  });
+
+  it('o helper puro existe e exporta extrairCodigoVendedor', () => {
+    expect(helper).toMatch(/export function extrairCodigoVendedor/);
+  });
+
+  it('o writer USA o helper espelhado na PROOF (define + chama), NÃO o campo raiz cru', () => {
+    expect(analytics, 'sumiu a definição espelhada do helper').toMatch(/function extrairCodigoVendedor/);
+    expect(
+      analytics,
+      'REVERSÃO Lovable? a proof não usa mais extrairCodigoVendedor (vendedor volta a NULL → carteira Hunter)',
+    ).toMatch(/omie_codigo_vendedor: extrairCodigoVendedor\(c\),\s*\n\s*source: "document"/);
+    expect(count(analytics, 'extrairCodigoVendedor'), 'helper deve ser DEFINIDO e CHAMADO (≥2)').toBeGreaterThanOrEqual(2);
+  });
+
+  it('PARIDADE: o bloco espelhado do helper é IDÊNTICO ao src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlockNamed(analytics, 'omie-codigo-vendedor'),
+      'edge divergiu do helper de src/ — Lovable reescreveu a extração do vendedor?',
+    ).toBe(mirrorBlockNamed(helper, 'omie-codigo-vendedor'));
+  });
+
+  it('carteira-rebuild lê a PROOF account-correta (oben), NÃO o espelho poluído', () => {
+    expect(
+      carteira,
+      'REVERSÃO Lovable? a carteira não lê mais a view fresca com account=oben',
+    ).toMatch(/\.from\('omie_customer_account_map_fresco'\)[\s\S]{0,120}\.eq\('account', 'oben'\)/);
+    expect(
+      carteira,
+      'REGRESSÃO: a carteira voltou a carregar clientes do espelho poluído omie_clientes',
+    ).not.toMatch(/\.from\('omie_clientes'\)/);
+  });
+});

--- a/src/lib/omie/codigo-vendedor.test.ts
+++ b/src/lib/omie/codigo-vendedor.test.ts
@@ -2,49 +2,49 @@ import { describe, it, expect } from 'vitest';
 import { extrairCodigoVendedor } from './codigo-vendedor';
 
 // P0-B-bis (incidente carteira) — extração do vendedor do cadastro Omie (ListarClientes). O vendedor mora
-// em recomendacoes.codigo_vendedor (o codigo_vendedor RAIZ vem vazio); padrão de omie-cliente/omie-sync.
-// Regra centralizada p/ resolver a inconsistência ??/|| apontada pelo Codex: recomendacoes VENCE, e só
-// inteiro POSITIVO conta (0/negativo/não-inteiro = não-atribuído). Alimenta a carteira → comissão.
+// em recomendacoes.codigo_vendedor (o codigo_vendedor RAIZ vem vazio). Regra (Codex R2): recomendacoes é
+// AUTORITATIVA — se presente (mesmo 0), decide; só cai no raiz se AUSENTE. Só inteiro POSITIVO safe conta.
 describe('extrairCodigoVendedor (money-path: vendedor do cliente → carteira)', () => {
-  it('recomendacoes tem código positivo → vence o raiz (fonte primária)', () => {
+  it('recomendacoes tem código positivo → usa (fonte autoritativa)', () => {
     expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
-    expect(extrairCodigoVendedor({ codigo_vendedor: 99, recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
+    expect(extrairCodigoVendedor({ recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
   });
 
-  it('recomendacoes ausente/vazia, raiz positivo → usa o raiz (fallback)', () => {
+  it('recomendacoes AUSENTE (undefined/null), raiz positivo → cai no raiz (fallback)', () => {
     expect(extrairCodigoVendedor({ codigo_vendedor: 41 })).toBe(41);
     expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: {} })).toBe(41);
     expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: null } })).toBe(41);
   });
 
-  it('ambos ausentes/null → null (sem vendedor)', () => {
+  it('recomendacoes PRESENTE mas 0 → null, NÃO cai no raiz (0 = "sem vendedor" autoritativo — Codex P2)', () => {
+    // `??`/`||` ingênuos cairiam no raiz (41). A regra: recomendacoes presente decide → 0 vira sem-vendedor.
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 0 } })).toBeNull();
+  });
+
+  it('ambos ausentes/null → null', () => {
     expect(extrairCodigoVendedor({})).toBeNull();
     expect(extrairCodigoVendedor({ codigo_vendedor: null })).toBeNull();
-    expect(extrairCodigoVendedor({ codigo_vendedor: null, recomendacoes: { codigo_vendedor: null } })).toBeNull();
   });
 
-  it('0 NÃO é vendedor (Omie usa 0/vazio p/ não-atribuído): recomendacoes=0, raiz=41 → 41', () => {
-    // O caso exato do Codex P2: `??` guardaria 0 (errado), `||` guardaria 41. A regra: 0 não conta → raiz.
-    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 0 } })).toBe(41);
-  });
-
-  it('0/negativo em ambos → null', () => {
+  it('raiz 0/negativo (recomendacoes ausente) → null', () => {
     expect(extrairCodigoVendedor({ codigo_vendedor: 0 })).toBeNull();
-    expect(extrairCodigoVendedor({ codigo_vendedor: -5, recomendacoes: { codigo_vendedor: 0 } })).toBeNull();
-  });
-
-  it('raiz×nested concordam (mesmo código) → esse código', () => {
-    expect(extrairCodigoVendedor({ codigo_vendedor: 7, recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
+    expect(extrairCodigoVendedor({ codigo_vendedor: -5 })).toBeNull();
   });
 
   it('não-inteiro (float) não conta como vendedor', () => {
     expect(extrairCodigoVendedor({ codigo_vendedor: 1.5 })).toBeNull();
-    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 1.5 } })).toBe(41);
+    expect(extrairCodigoVendedor({ recomendacoes: { codigo_vendedor: 1.5 } })).toBeNull();
+  });
+
+  it('código acima de 2^53 (não SafeInteger) → null (Codex P3: perderia precisão)', () => {
+    expect(extrairCodigoVendedor({ recomendacoes: { codigo_vendedor: Number.MAX_SAFE_INTEGER + 1 } })).toBeNull();
+    expect(extrairCodigoVendedor({ codigo_vendedor: Number.MAX_SAFE_INTEGER + 2 })).toBeNull();
   });
 
   it('FALSIFICAÇÃO: um extrator `recomendacoes ?? raiz` daria 0 no caso recomendacoes=0 (o guard tem dente)', () => {
     const r = extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 0 } });
     expect(r).not.toBe(0);
-    expect(r).toBe(41);
+    expect(r).not.toBe(41); // não ressuscita o raiz — recomendacoes=0 é autoritativo
+    expect(r).toBeNull();
   });
 });

--- a/src/lib/omie/codigo-vendedor.test.ts
+++ b/src/lib/omie/codigo-vendedor.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { extrairCodigoVendedor } from './codigo-vendedor';
+
+// P0-B-bis (incidente carteira) — extração do vendedor do cadastro Omie (ListarClientes). O vendedor mora
+// em recomendacoes.codigo_vendedor (o codigo_vendedor RAIZ vem vazio); padrão de omie-cliente/omie-sync.
+// Regra centralizada p/ resolver a inconsistência ??/|| apontada pelo Codex: recomendacoes VENCE, e só
+// inteiro POSITIVO conta (0/negativo/não-inteiro = não-atribuído). Alimenta a carteira → comissão.
+describe('extrairCodigoVendedor (money-path: vendedor do cliente → carteira)', () => {
+  it('recomendacoes tem código positivo → vence o raiz (fonte primária)', () => {
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
+    expect(extrairCodigoVendedor({ codigo_vendedor: 99, recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
+  });
+
+  it('recomendacoes ausente/vazia, raiz positivo → usa o raiz (fallback)', () => {
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41 })).toBe(41);
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: {} })).toBe(41);
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: null } })).toBe(41);
+  });
+
+  it('ambos ausentes/null → null (sem vendedor)', () => {
+    expect(extrairCodigoVendedor({})).toBeNull();
+    expect(extrairCodigoVendedor({ codigo_vendedor: null })).toBeNull();
+    expect(extrairCodigoVendedor({ codigo_vendedor: null, recomendacoes: { codigo_vendedor: null } })).toBeNull();
+  });
+
+  it('0 NÃO é vendedor (Omie usa 0/vazio p/ não-atribuído): recomendacoes=0, raiz=41 → 41', () => {
+    // O caso exato do Codex P2: `??` guardaria 0 (errado), `||` guardaria 41. A regra: 0 não conta → raiz.
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 0 } })).toBe(41);
+  });
+
+  it('0/negativo em ambos → null', () => {
+    expect(extrairCodigoVendedor({ codigo_vendedor: 0 })).toBeNull();
+    expect(extrairCodigoVendedor({ codigo_vendedor: -5, recomendacoes: { codigo_vendedor: 0 } })).toBeNull();
+  });
+
+  it('raiz×nested concordam (mesmo código) → esse código', () => {
+    expect(extrairCodigoVendedor({ codigo_vendedor: 7, recomendacoes: { codigo_vendedor: 7 } })).toBe(7);
+  });
+
+  it('não-inteiro (float) não conta como vendedor', () => {
+    expect(extrairCodigoVendedor({ codigo_vendedor: 1.5 })).toBeNull();
+    expect(extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 1.5 } })).toBe(41);
+  });
+
+  it('FALSIFICAÇÃO: um extrator `recomendacoes ?? raiz` daria 0 no caso recomendacoes=0 (o guard tem dente)', () => {
+    const r = extrairCodigoVendedor({ codigo_vendedor: 41, recomendacoes: { codigo_vendedor: 0 } });
+    expect(r).not.toBe(0);
+    expect(r).toBe(41);
+  });
+});

--- a/src/lib/omie/codigo-vendedor.ts
+++ b/src/lib/omie/codigo-vendedor.ts
@@ -8,8 +8,12 @@ export function extrairCodigoVendedor(c: {
   codigo_vendedor?: number | null;
   recomendacoes?: { codigo_vendedor?: number | null } | null;
 }): number | null {
+  // bigint-safe (Codex P3): código > 2^53 perderia precisão e casaria com outro vendedor.
   const positivo = (v: number | null | undefined): number | null =>
-    typeof v === 'number' && Number.isInteger(v) && v > 0 ? v : null;
-  return positivo(c.recomendacoes?.codigo_vendedor) ?? positivo(c.codigo_vendedor);
+    typeof v === 'number' && Number.isSafeInteger(v) && v > 0 ? v : null;
+  // recomendacoes é a fonte AUTORITATIVA: se PRESENTE (mesmo 0/inválido) ela decide — 0 = "sem vendedor"
+  // explícito, não cai no raiz (Codex P2: fallback só quando o primário está AUSENTE, não presente-inválido).
+  const nested = c.recomendacoes?.codigo_vendedor;
+  return nested != null ? positivo(nested) : positivo(c.codigo_vendedor);
 }
 // MIRROR-END

--- a/src/lib/omie/codigo-vendedor.ts
+++ b/src/lib/omie/codigo-vendedor.ts
@@ -1,0 +1,15 @@
+// MIRROR-START omie-codigo-vendedor — espelhado verbatim em supabase/functions/omie-analytics-sync/index.ts
+// Extrai o vendedor do cadastro Omie (ListarClientes) — money-path P0-B-bis (vendedor → carteira → comissão).
+// O vendedor mora em recomendacoes.codigo_vendedor (o codigo_vendedor RAIZ vem vazio no ListarClientes);
+// recomendacoes é a fonte PRIMÁRIA (padrão de omie-cliente/omie-sync), o raiz é fallback. Só inteiro
+// POSITIVO conta como vendedor — 0/negativo/não-inteiro = não-atribuído (resolve o ??/|| ambíguo, Codex P2).
+// PURA: sem I/O. Espelhado no edge (Deno não importa de src/); paridade textual no CI.
+export function extrairCodigoVendedor(c: {
+  codigo_vendedor?: number | null;
+  recomendacoes?: { codigo_vendedor?: number | null } | null;
+}): number | null {
+  const positivo = (v: number | null | undefined): number | null =>
+    typeof v === 'number' && Number.isInteger(v) && v > 0 ? v : null;
+  return positivo(c.recomendacoes?.codigo_vendedor) ?? positivo(c.codigo_vendedor);
+}
+// MIRROR-END

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -1,5 +1,5 @@
 // supabase/functions/carteira-rebuild/index.ts
-// Reconstrói carteira_assignments a partir de omie_clientes × omie_vendedor_map.
+// Reconstrói carteira_assignments a partir de omie_customer_account_map_fresco (oben) × omie_vendedor_map.
 // Órfão (sem vendedor mapeado) → Hunter. Idempotente (upsert por customer_user_id).
 //
 // Consolidação B-lite (spec 2026-06-13): consulta customer_canonical_alias (clones ATIVOS) e
@@ -177,18 +177,22 @@ Deno.serve(async (req) => {
     }
   }
 
-  // omie_clientes pode ter milhares de linhas e o PostgREST limita o SELECT a ~1000 por página →
-  // paginar com range() até esgotar. .order p/ estabilidade (P1.5 Codex).
+  // P0-B-bis: a carteira (oben) lê a VIEW FRESCA account-correta omie_customer_account_map_fresco
+  // (account='oben') em vez do espelho poluído omie_clientes (mix de contas, sem filtro). A proof é
+  // document-first + fail-closed doc-ambíguo (account-safe, Codex) e o omie_codigo_vendedor vem populado
+  // de recomendacoes (fix do writer no mesmo PR). Só clientes OBEN entram (era o espelho inteiro, incl.
+  // não-oben indevidos). PostgREST capa em ~1000/página → paginar com range() + .order estável (P1.5 Codex).
   const clientes: OmieClienteRow[] = [];
   const PAGE = 1000;
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
-      .from('omie_clientes')
+      .from('omie_customer_account_map_fresco')
       .select('user_id, omie_codigo_vendedor')
+      .eq('account', 'oben')
       .not('user_id', 'is', null)
       .order('user_id', { ascending: true })
       .range(from, from + PAGE - 1);
-    if (error) { console.error('[carteira-rebuild] load omie_clientes error:', error.message); return fail(error.message); }
+    if (error) { console.error('[carteira-rebuild] load omie_customer_account_map_fresco error:', error.message); return fail(error.message); }
     const page = (data ?? []) as Array<{ user_id: string; omie_codigo_vendedor: number | null }>;
     for (const r of page) clientes.push({ customer_user_id: r.user_id, omie_codigo_vendedor: r.omie_codigo_vendedor });
     if (page.length < PAGE) break;

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -1,5 +1,5 @@
 // supabase/functions/carteira-rebuild/index.ts
-// Reconstrói carteira_assignments a partir de omie_customer_account_map_fresco (oben) × omie_vendedor_map.
+// Reconstrói carteira_assignments a partir de omie_clientes × omie_vendedor_map.
 // Órfão (sem vendedor mapeado) → Hunter. Idempotente (upsert por customer_user_id).
 //
 // Consolidação B-lite (spec 2026-06-13): consulta customer_canonical_alias (clones ATIVOS) e
@@ -177,22 +177,18 @@ Deno.serve(async (req) => {
     }
   }
 
-  // P0-B-bis: a carteira (oben) lê a VIEW FRESCA account-correta omie_customer_account_map_fresco
-  // (account='oben') em vez do espelho poluído omie_clientes (mix de contas, sem filtro). A proof é
-  // document-first + fail-closed doc-ambíguo (account-safe, Codex) e o omie_codigo_vendedor vem populado
-  // de recomendacoes (fix do writer no mesmo PR). Só clientes OBEN entram (era o espelho inteiro, incl.
-  // não-oben indevidos). PostgREST capa em ~1000/página → paginar com range() + .order estável (P1.5 Codex).
+  // omie_clientes pode ter milhares de linhas e o PostgREST limita o SELECT a ~1000 por página →
+  // paginar com range() até esgotar. .order p/ estabilidade (P1.5 Codex).
   const clientes: OmieClienteRow[] = [];
   const PAGE = 1000;
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await supabase
-      .from('omie_customer_account_map_fresco')
+      .from('omie_clientes')
       .select('user_id, omie_codigo_vendedor')
-      .eq('account', 'oben')
       .not('user_id', 'is', null)
       .order('user_id', { ascending: true })
       .range(from, from + PAGE - 1);
-    if (error) { console.error('[carteira-rebuild] load omie_customer_account_map_fresco error:', error.message); return fail(error.message); }
+    if (error) { console.error('[carteira-rebuild] load omie_clientes error:', error.message); return fail(error.message); }
     const page = (data ?? []) as Array<{ user_id: string; omie_codigo_vendedor: number | null }>;
     for (const r of page) clientes.push({ customer_user_id: r.user_id, omie_codigo_vendedor: r.omie_codigo_vendedor });
     if (page.length < PAGE) break;

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -68,6 +68,8 @@ interface OmieClienteCadastro {
   codigo_cliente_omie?: number;
   codigo_cliente_integracao?: string | null;
   codigo_vendedor?: number | null;
+  // O vendedor do cliente mora em recomendacoes.codigo_vendedor (o raiz vem vazio no ListarClientes).
+  recomendacoes?: { codigo_vendedor?: number | null };
   cnpj_cpf?: string;
   razao_social?: string;
   nome_fantasia?: string;
@@ -301,6 +303,22 @@ function docsComCodigoAmbiguoNoOmie(
 }
 // MIRROR-END
 
+// MIRROR-START omie-codigo-vendedor — espelhado verbatim de src/lib/omie/codigo-vendedor.ts
+// Extrai o vendedor do cadastro Omie (ListarClientes) — money-path P0-B-bis (vendedor → carteira → comissão).
+// O vendedor mora em recomendacoes.codigo_vendedor (o codigo_vendedor RAIZ vem vazio no ListarClientes);
+// recomendacoes é a fonte PRIMÁRIA (padrão de omie-cliente/omie-sync), o raiz é fallback. Só inteiro
+// POSITIVO conta como vendedor — 0/negativo/não-inteiro = não-atribuído (resolve o ??/|| ambíguo, Codex P2).
+// PURA: sem I/O. Espelhado no edge (Deno não importa de src/); paridade textual no CI.
+function extrairCodigoVendedor(c: {
+  codigo_vendedor?: number | null;
+  recomendacoes?: { codigo_vendedor?: number | null } | null;
+}): number | null {
+  const positivo = (v: number | null | undefined): number | null =>
+    typeof v === 'number' && Number.isInteger(v) && v > 0 ? v : null;
+  return positivo(c.recomendacoes?.codigo_vendedor) ?? positivo(c.codigo_vendedor);
+}
+// MIRROR-END
+
 async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
   await updateSyncState(db, "customers", account, { status: "running", error_message: null });
 
@@ -375,7 +393,10 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
             user_id: userIdByDoc,
             account: empresaMap,
             omie_codigo_cliente: c.codigo_cliente_omie,
-            omie_codigo_vendedor: c.codigo_vendedor || null,
+            // P0-B-bis: vendedor da PROOF (document-first, account-safe) via helper — recomendacoes vence.
+            // O mirror upsertByUser (code-first) NÃO recebe vendedor (Codex: resolução insegura); a carteira
+            // migra p/ ler a proof (carteira-rebuild). Só a proof alimenta a carteira daqui pra frente.
+            omie_codigo_vendedor: extrairCodigoVendedor(c),
             source: "document",
             updated_at: new Date().toISOString(),
           });

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -313,9 +313,13 @@ function extrairCodigoVendedor(c: {
   codigo_vendedor?: number | null;
   recomendacoes?: { codigo_vendedor?: number | null } | null;
 }): number | null {
+  // bigint-safe (Codex P3): código > 2^53 perderia precisão e casaria com outro vendedor.
   const positivo = (v: number | null | undefined): number | null =>
-    typeof v === 'number' && Number.isInteger(v) && v > 0 ? v : null;
-  return positivo(c.recomendacoes?.codigo_vendedor) ?? positivo(c.codigo_vendedor);
+    typeof v === 'number' && Number.isSafeInteger(v) && v > 0 ? v : null;
+  // recomendacoes é a fonte AUTORITATIVA: se PRESENTE (mesmo 0/inválido) ela decide — 0 = "sem vendedor"
+  // explícito, não cai no raiz (Codex P2: fallback só quando o primário está AUSENTE, não presente-inválido).
+  const nested = c.recomendacoes?.codigo_vendedor;
+  return nested != null ? positivo(nested) : positivo(c.codigo_vendedor);
 }
 // MIRROR-END
 


### PR DESCRIPTION
## Incidente: carteira de vendedores 100% no Hunter

`carteira_assignments` está **100% no Hunter** — 6909 assignments `hunter_orphan`, os **18 vendedores oben sem nenhum cliente** (psql-ro 2026-07-11). Causa: `syncCustomers` gravava `omie_codigo_vendedor` de `c.codigo_vendedor` (campo **raiz**, vazio no `ListarClientes`); o vendedor mora em `c.recomendacoes.codigo_vendedor` → proof **100% NULL** → `carteira-rebuild` via todo cliente como órfão.

## Este PR = ponta 1/2 (o writer)

- **Helper puro `extrairCodigoVendedor`** (src/lib/omie + espelhado no edge): `recomendacoes` é **autoritativa** (se presente, mesmo `0`, decide — `0`=sem-vendedor, não cai no raiz), só **inteiro safe positivo** conta. TDD 8/8 + falsificação. *(incorpora Codex R2 P2/P3)*
- **Writer popula o vendedor SÓ na PROOF** (`accountMapByUser`, document-first + fail-closed doc-ambíguo = account-safe). O **mirror code-first NÃO recebe** — *o Codex R1 bloqueou popular o mirror inseguro (colisão cross-conta → vendedor no user errado)*.
- Canário textual anti-reversão + falsificação.

## Fora deste PR (ponta 2/2 — PR próprio)

Fazer o **`carteira-rebuild` LER a proof**. O Codex R2 bloqueou o approach ingênuo (filtro `account='oben'`) com **3 P1**:
1. **Consolidação B-lite** (header do rebuild `:5-8`): o gêmeo oben **herda o vendedor do clone Colacor SC** — filtrar oben tira o clone da lista e quebra a herança.
2. Redução 6909→5238 **não reconciliada** (rebuild é upsert-only → não limpa os excluídos).
3. **Fail-open** se a view fresca (7d) encolher numa janela de sync → carteira zerada silenciosa.

Exige redesign account-safe (lista preservando a herança + vendedor da proof + guard). **Não force-fitado aqui** — money-path de comissão.

## Efeito deste PR

Popula a **fonte** (proof) com o vendedor account-safe — base necessária para a ponta 2. **Sozinho não tira a carteira do Hunter** (a carteira ainda lê o mirror); isso acontece quando a ponta 2 mergear.

## Gate

Helper TDD 8/8 + falsificação · canário + falsificação · deno×2 · typecheck · lint · test **72/72** · **Codex 2 rodadas xhigh** (pareceres crus arquivados; R1 e R2 incorporados). Edge TS puro, **sem SQL**.

## ⚠️ Deploy do founder (Lovable)

Deploy **`omie-analytics-sync` verbatim** + 1 `sync_customers` (conta `vendas`/oben). Verificação (eu, psql-ro): a proof oben passa a ter `omie_codigo_vendedor` não-nulo. *(A carteira só sai do Hunter com a ponta 2.)*

Épico **P0-B-bis**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
