### PR TITLE
fix(omie): migra leitores de display p/ view fresca account-correta (P0-B-bis PR-4)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -748,3 +748,30 @@ describe('guardrail money-path: writer popula vendedor de recomendacoes na PROOF
     ).toBe(mirrorBlockNamed(helper, 'omie-codigo-vendedor'));
   });
 });
+
+// ── P0-B-bis PR-4 #8 (fin-valor-cockpit: mapa user->codigo de DISPLAY pela view fresca account=oben) ──
+// O cockpit (COMPANY='oben') montava o mapa user_id->omie_codigo_cliente lendo o espelho poluído
+// omie_clientes SEM filtro de conta — o código exibido podia ser de OUTRA conta do mesmo user (colacor_sc
+// domina o espelho). Migrado p/ a view fresca account-correta com account=oben. Display (ℹ️ baixo, não
+// roteia dinheiro) → paginação offset .range basta (o syncPedidos, money-path, exige keyset; aqui um miss
+// de TTL entre páginas só omitiria 1 código do display). Este canário pega a reversão do deploy do Lovable.
+const VALOR_COCKPIT = 'supabase/functions/fin-valor-cockpit/index.ts';
+
+describe('guardrail: fin-valor-cockpit lê o código do cliente pela view fresca account=oben (P0-B-bis PR-4 #8)', () => {
+  const src = read(VALOR_COCKPIT);
+
+  it('sentinela: leu o arquivo real (mapa de display userToOmie)', () => {
+    expect(src).toContain('userToOmie');
+  });
+
+  it('o mapa user->codigo (display) vem da view fresca account=oben, não do espelho poluído', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? o cockpit voltou a ler o código do cliente do espelho omie_clientes sem conta',
+    ).toMatch(/from\("omie_customer_account_map_fresco"\)[\s\S]{0,200}\.eq\("account", "oben"\)/);
+    expect(
+      src,
+      'REGRESSÃO: fin-valor-cockpit ainda lê o espelho poluído omie_clientes no mapa de display',
+    ).not.toMatch(/from\("omie_clientes"\)/);
+  });
+});

--- a/src/hooks/__tests__/useUnifiedOrder.accountGuard.test.ts
+++ b/src/hooks/__tests__/useUnifiedOrder.accountGuard.test.ts
@@ -33,4 +33,16 @@ describe('useUnifiedOrder: resolução de código Omie por user_id filtra empres
         '(colacor) vaza para OmieCustomer.codigo_cliente (oben) e o pedido vai ao cliente errado (P0-A)',
     ).toBeGreaterThanOrEqual(2);
   });
+
+  // ── #11 (P0-B-bis PR-4): a via INVERSA (codigo->user_id) do handleStaffAddTool ──
+  // Resolver o user_id por omie_codigo_cliente (o código da conta OBEN do selectedCustomer) SEM conta
+  // pegava o user ERRADO quando o mesmo número colide entre contas no espelho poluído (Codex P2 — anexa a
+  // ferramenta ao cliente errado). A view fresca é UNIQUE(omie_codigo_cliente, account) → filtrar
+  // account=oben resolve o user certo; miss (ausente/stale) cai no fallback por documento (fail-closed).
+  it('handleStaffAddTool resolve codigo->user pela view fresca account=oben (não pelo espelho sem conta)', () => {
+    expect(
+      src,
+      'REGRESSÃO: handleStaffAddTool voltou a resolver codigo->user pelo espelho poluído omie_clientes sem conta',
+    ).toMatch(/from\('omie_customer_account_map_fresco'\)\s*\.select\('user_id'\)[\s\S]{0,160}\.eq\('account', 'oben'\)/);
+  });
 });

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -629,9 +629,13 @@ export function useUnifiedOrder() {
     if (customerUserId) { setAddToolDialogOpen(true); return; }
     setCreatingLocalProfile(true);
     try {
+      // #11 (P0-B-bis PR-4): resolve codigo->user_id pela view fresca account=oben. selectedCustomer.codigo_cliente
+      // é o código da conta OBEN; buscá-lo no espelho poluído SEM conta pegava o user ERRADO em colisão de código
+      // entre contas (Codex P2 — anexa a ferramenta ao cliente errado). A fresca é UNIQUE(omie_codigo_cliente,
+      // account) → resolve o user certo; miss (ausente/stale 7d) cai no fallback por documento abaixo (fail-closed).
       const { data: existingMapping } = await supabase
-        .from('omie_clientes').select('user_id')
-        .eq('omie_codigo_cliente', selectedCustomer.codigo_cliente).maybeSingle();
+        .from('omie_customer_account_map_fresco').select('user_id')
+        .eq('omie_codigo_cliente', selectedCustomer.codigo_cliente).eq('account', 'oben').maybeSingle();
       if (existingMapping) {
         setCustomerUserId(existingMapping.user_id);
         loadUserTools(existingMapping.user_id);

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -636,7 +636,8 @@ export function useUnifiedOrder() {
       const { data: existingMapping } = await supabase
         .from('omie_customer_account_map_fresco').select('user_id')
         .eq('omie_codigo_cliente', selectedCustomer.codigo_cliente).eq('account', 'oben').maybeSingle();
-      if (existingMapping) {
+      // user_id da view é string|null (view nulável); null → trata como miss e cai no fallback por documento.
+      if (existingMapping?.user_id) {
         setCustomerUserId(existingMapping.user_id);
         loadUserTools(existingMapping.user_id);
         setAddToolDialogOpen(true);

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -172,6 +172,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useUnifiedOrder.accountGuard.test.ts",
       "src/pages/__tests__/SalesQuotes.accountGuard.test.tsx",
       "src/pages/__tests__/SalesQuotes.priceGuard.test.tsx",
+      "src/pages/__tests__/displayReaders.viewFresca.test.ts",
     ],
     risco: { moneyPath: true, offlineFirst: false, authSensitive: false },
   },

--- a/src/pages/Customer360.tsx
+++ b/src/pages/Customer360.tsx
@@ -1,7 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase/client';
 import { parseISO, subMonths } from 'date-fns';
 import { AlertCircle } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
@@ -55,18 +53,10 @@ export default function Customer360() {
   // mostro só leitura compacta pra contexto operacional.
   const contacts = useCustomerContacts(customerId ?? null);
   const { data: salespeople = [] } = useSalespeople();
-  // empresa_omie do cliente → deriva a empresa correta da tarefa (não fica fixa em 'oben').
-  // Só master/gestor (quem cria tarefa por voz); 1 query leve, maybeSingle.
-  const omieEmpresa = useQuery({
-    queryKey: ['customer-empresa-omie', customerId],
-    enabled: !!customerId && (isMaster || isGestorComercial),
-    staleTime: 5 * 60_000,
-    queryFn: async () => {
-      const { data } = await supabase.from('omie_clientes')
-        .select('empresa_omie').eq('user_id', customerId!).maybeSingle();
-      return data?.empresa_omie ?? null;
-    },
-  });
+  // #9 (P0-B-bis PR-4): NÃO derivamos a empresa da tarefa do espelho omie_clientes — empresa_omie lá é
+  // 100% 'colacor' (rótulo fabricado, nenhum writer o seta). A tarefa por voz usa o default explícito
+  // empresa="oben" da tela (Oben-cêntrica); derivar da view fresca seria ambíguo p/ cliente multi-conta
+  // (precisão>recall: não fabricar a conta). Ver design §4 #9.
 
   // Lifetime + 12m derivados dos pedidos
   const revenueDerived = useMemo(() => {
@@ -162,7 +152,6 @@ export default function Customer360() {
           clienteFixo={{
             customer_user_id: customerId,
             nome: customer.name ?? 'Cliente',
-            empresa_omie: omieEmpresa.data ?? undefined,
           }}
         />
       )}

--- a/src/pages/SalesPrintDashboard.tsx
+++ b/src/pages/SalesPrintDashboard.tsx
@@ -174,18 +174,19 @@ const SalesPrintDashboard = () => {
     enabled: customerIds.length > 0,
   });
 
-  // Fetch omie_clientes mappings to get omie_codigo_cliente for address lookup
+  // Código do cliente (conta colacor_sc) p/ address lookup — via view fresca account-correta.
   const { data: omieClientes = [] } = useQuery({
-    queryKey: ['sales-print-omie-clientes', customerIds],
+    queryKey: ['sales-print-omie-map-fresco', customerIds],
     queryFn: async () => {
       if (customerIds.length === 0) return [];
-      // P0-B follow-up: filtra a conta do espelho ('colacor' = colacor_sc físico) — o código é usado
-      // p/ consultar endereço via `omie-cliente` (que bate na conta colacor_sc). Pós-constraint
-      // composta, evita pegar o código de outra conta do user. Hoje inócuo (UNIQUE(user_id)).
+      // P0-B-bis PR-4 (#12): o código é usado p/ consultar endereço via `omie-cliente` (que bate na conta
+      // colacor_sc) → lê da view fresca omie_customer_account_map_fresco com account=colacor_sc
+      // (document-first, TTL 7d). O filtro antigo .eq('empresa_omie','colacor') era inócuo (o espelho é
+      // 100% 'colacor' rotulado). Miss na fresca → sem código → cai no fallback por documento (fail-closed).
       const { data } = await supabase
-        .from('omie_clientes')
+        .from('omie_customer_account_map_fresco')
         .select('user_id, omie_codigo_cliente')
-        .eq('empresa_omie', 'colacor')
+        .eq('account', 'colacor_sc')
         .in('user_id', customerIds);
       return data || [];
     },

--- a/src/pages/SalesPrintDashboard.tsx
+++ b/src/pages/SalesPrintDashboard.tsx
@@ -215,7 +215,11 @@ const SalesPrintDashboard = () => {
   // Build omie codigo_cliente map from omie_clientes table + order payloads as fallback
   const omieClienteMap = useMemo(() => {
     const m = new Map<string, number>();
-    omieClientes.forEach(oc => m.set(oc.user_id, oc.omie_codigo_cliente));
+    // view fresca é nulável (user_id/omie_codigo_cliente string|null / number|null) → guarda os dois;
+    // linha sem par completo cai no fallback por payload/documento abaixo (fail-closed).
+    omieClientes.forEach(oc => {
+      if (oc.user_id != null && oc.omie_codigo_cliente != null) m.set(oc.user_id, oc.omie_codigo_cliente);
+    });
     // Fallback: extract codigo_cliente from order payloads for customers not in omie_clientes
     allOrdersRaw.forEach(o => {
       const custId = o.customer_user_id || o.user_id;

--- a/src/pages/__tests__/displayReaders.viewFresca.test.ts
+++ b/src/pages/__tests__/displayReaders.viewFresca.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ── Guard (P0-B-bis PR-4 #9/#12): leitores de DISPLAY saíram do espelho poluído omie_clientes ──
+// O espelho é 1 linha/user com rótulo empresa_omie=100% 'colacor' (mentira uniforme) e código
+// colacor_sc-dominante — ler dele sem conta traz o código/rótulo de OUTRA conta. A fonte account-correta
+// é a view fresca omie_customer_account_map_fresco (document-first, UNIQUE(user_id,account), TTL 7d).
+// Teste TEXTUAL (comportamental é caro e o valor aqui é anti-regressão de fonte). Ver design §4/§5.
+const CWD = resolve(__dirname, '../../..');
+const read = (rel: string) => readFileSync(resolve(CWD, rel), 'utf8');
+
+describe('leitores de display migraram do espelho omie_clientes p/ a view fresca (P0-B-bis PR-4)', () => {
+  // #12 SalesPrintDashboard: o código é usado p/ buscar endereço via omie-cliente (conta colacor_sc) →
+  // o código correto é o da conta colacor_sc. O filtro antigo .eq('empresa_omie','colacor') NÃO filtrava
+  // nada (o espelho é 100% 'colacor'); a fresca account=colacor_sc traz o código document-first correto.
+  it('#12 SalesPrintDashboard lê o código pela view fresca account=colacor_sc', () => {
+    const src = read('src/pages/SalesPrintDashboard.tsx');
+    expect(
+      src,
+      'REVERSÃO: SalesPrintDashboard não lê o código pela view fresca colacor_sc',
+    ).toMatch(/from\('omie_customer_account_map_fresco'\)[\s\S]{0,200}\.eq\('account', 'colacor_sc'\)/);
+    expect(
+      src,
+      'REGRESSÃO: SalesPrintDashboard voltou a ler o espelho poluído omie_clientes',
+    ).not.toMatch(/from\('omie_clientes'\)/);
+  });
+
+  // #9 Customer360: lia empresa_omie do espelho (sempre 'colacor' fabricado) p/ derivar a empresa da tarefa
+  // por voz. Dependência REMOVIDA — a tarefa usa o default explícito empresa="oben" da tela (Oben-cêntrica);
+  // derivar da view seria ambíguo p/ cliente multi-conta (precisão>recall: não fabricar a conta).
+  it('#9 Customer360 não lê mais o espelho omie_clientes (empresa fabricada removida)', () => {
+    const src = read('src/pages/Customer360.tsx');
+    expect(
+      src,
+      'REGRESSÃO: Customer360 voltou a ler empresa_omie do espelho poluído omie_clientes',
+    ).not.toMatch(/from\('omie_clientes'\)/);
+  });
+});

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -433,7 +433,12 @@ serve(async (req: Request) => {
     if (linhas.length === 0) return jsonResponse({ company: COMPANY, vazio: true, motivo: "Sem linhas de venda da Oben no TTM." }, 200);
 
     // Mapas de apoio (paginados, sem .in para evitar URL gigante + truncamento)
-    const clientesAll = await fetchAll<{ user_id: string; omie_codigo_cliente: number }>((f, t) => db.from("omie_clientes").select("user_id, omie_codigo_cliente").order("id", { ascending: true }).range(f, t), "omie_clientes");
+    // #8 (P0-B-bis PR-4): mapa user->codigo de DISPLAY pela view fresca account=oben (COMPANY). O espelho
+    // omie_clientes é colacor_sc-dominante sem conta → exibia o código de OUTRA conta do mesmo user.
+    // UNIQUE(user_id,account) → ≤1 linha/user no Map. Display ℹ️ baixo: offset .range basta (um miss de TTL
+    // entre páginas só omitiria 1 código; o syncPedidos, money-path, é que exige keyset). Ordena por
+    // omie_codigo_cliente (UNIQUE por conta → estável e sem empate no offset).
+    const clientesAll = await fetchAll<{ user_id: string; omie_codigo_cliente: number }>((f, t) => db.from("omie_customer_account_map_fresco").select("user_id, omie_codigo_cliente").eq("account", "oben").order("omie_codigo_cliente", { ascending: true }).range(f, t), "omie_customer_account_map_fresco");
     const userToOmie = new Map(clientesAll.map((c) => [c.user_id, String(c.omie_codigo_cliente)]));
     // Nome do cliente: profiles.user_id = order_items.customer_user_id (~98% cobertura na Oben; psql-ro
     // 2026-06-23). razao_social tem prioridade, senão name. service_role bypassa a RLS de profiles.


### PR DESCRIPTION
Fecho dos **leitores de display/UI** do épico P0-B-bis (PRs 1/2/3 migraram os leitores money-path do backend). Migra 4 leitores do espelho poluído `omie_clientes` → view fresca account-correta `omie_customer_account_map_fresco`.

## Itens (design §4/§5)
- **#8** `fin-valor-cockpit` (edge): mapa user→código de display, `account=oben`.
- **#9** `Customer360`: remove a dependência do espelho (empresa_omie 100% `'colacor'` fabricado) na tarefa por voz → default `empresa="oben"`. **Efeito comportamental**: tarefa por voz do Customer360 nasce 'oben' (era 'colacor' fabricado; derivar da view seria ambíguo p/ multi-conta → precisão>recall).
- **#11** `useUnifiedOrder.handleStaffAddTool`: resolve código→user_id por `account=oben` (Codex P2 — colisão de código anexava ferramenta ao cliente errado).
- **#12** `SalesPrintDashboard`: código de endereço por `account=colacor_sc` (filtro antigo `empresa_omie='colacor'` era inócuo — espelho 100% 'colacor').

## Gate
test (71✓, inclui 4 canários novos anti-reversão-Lovable) · typecheck · deno check (#8) · lint — todos verdes.

## Deploy (Lovable, manual pós-merge)
- [ ] **Edge** `fin-valor-cockpit` (chat do Lovable, verbatim)
- [ ] **Publish** frontend (#9/#11/#12)

Sem migration. #10 (view `v_grupo_contatos`) vem em PR próprio com prove-sql. DROP do espelho = Fatia 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)