### PR TITLE
fix(reposicao): resumo diário mostra reduções e nomeia o item segurado pelo fusível

### DIFF
--- a/db/seed-param-auto.sql
+++ b/db/seed-param-auto.sql
@@ -49,6 +49,8 @@ CREATE VIEW public.v_sku_parametros_sugeridos AS SELECT * FROM public._param_sug
 -- D máx<pp→bloqueia · E pin igual→pina · F pin diferente→aplica+limpa pin · G igual ao atual→sem_mudanca
 -- H fusível>pin→segura · I desabilitado→aplica sem logar · J prod_acabado→aplica sem logar
 -- K base NULL→bloqueia (cold-start) · L queda do máximo→aplica (assimétrico)
+-- M redução do máximo COM estoque abaixo do ponto → aplicado com impacto NEGATIVO (prova a seção
+--   "Maiores reduções" do resumo: o parâmetro cai e LIBERA capital — o análogo de um caso real de prod)
 INSERT INTO public.sku_parametros
   (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome,
    ponto_pedido, estoque_minimo, estoque_maximo, estoque_seguranca, cobertura_alvo_dias,
@@ -65,7 +67,8 @@ VALUES
   ('OBEN', 1009, 'SKU-I desabilitado',   'FORN-I', 50, 20, 120, 15, 30, false,'automatica', true),
   ('OBEN', 1010, 'SKU-J prod_acabado',   'FORN-J', 50, 20, 120, 15, 30, true, 'produto_acabado', true),
   ('OBEN', 1011, 'SKU-K base NULL',      'FORN-K', NULL, NULL, NULL, NULL, NULL, true, 'automatica', true),
-  ('OBEN', 1012, 'SKU-L queda do máximo','FORN-L', 50, 20, 120, 15, 30, true, 'automatica', true);
+  ('OBEN', 1012, 'SKU-L queda do máximo','FORN-L', 50, 20, 120, 15, 30, true, 'automatica', true),
+  ('OBEN', 1013, 'SKU-M reducao capital','FORN-M', 50, 20, 120, 15, 30, true, 'automatica', true);
 
 -- ── Sugestões da view controlada (status já implícito: todos OK = não-NULL) ──
 INSERT INTO public._param_sug_test
@@ -98,7 +101,10 @@ VALUES
   -- K: base NULL (primeira parametrização). Sugestão coerente → BLOQUEADO_VALIDACAO (cold-start manual).
   ('OBEN',1011,'SKU-K base NULL','FORN-K',       20, 60, 140, 15, 35, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
   -- L: QUEDA do máximo 120→4 (pp 50→2). Fusível é upward-only → não segura → APLICADO (assimétrico).
-  ('OBEN',1012,'SKU-L queda do máximo','FORN-L',  1,  2,   4,  1, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX');
+  ('OBEN',1012,'SKU-L queda do máximo','FORN-L',  1,  2,   4,  1, 30, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX'),
+  -- M: REDUÇÃO do máximo 120→90 (pp 50→45), estoque 30 abaixo do ponto em ambos → aplicado (queda não
+  --    segura) com impacto NEGATIVO: qtde_antes=120-30=90, qtde_depois=90-30=60, Δ-30×cmc10 = -300.
+  ('OBEN',1013,'SKU-M reducao capital','FORN-M', 18, 45,  90, 12, 28, 4, 1.0, 0.25, 12, 5000, 7, 2, 9, 'historico', 1.64, 'AX');
 
 -- ── Pins para E (igual), F (diferente) e H (bate, mas pin agora vence o fusível) ──
 INSERT INTO public.reposicao_param_pin (empresa, sku_codigo_omie, ponto_pedido_rejeitado, estoque_maximo_rejeitado)
@@ -113,9 +119,11 @@ INSERT INTO public.sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, 
 VALUES
   ('OBEN','1001', 30, 0),
   ('OBEN','1002', 30, 0),
-  ('OBEN','1006', 30, 0);
+  ('OBEN','1006', 30, 0),
+  ('OBEN','1013', 30, 0);   -- M: pos 30 (abaixo do ponto 50/45) → redução do máximo vira impacto negativo
 INSERT INTO public.inventory_position (omie_codigo_produto, account, cmc, preco_medio)
 VALUES
   (1001,'oben', 10, 8),   -- A: cmc=10 → impacto 200
   (1002,'oben', 10, 8),   -- B segurado: Δ0 → impacto 0
-  (1006,'oben', 10, 8);   -- F: custo presente
+  (1006,'oben', 10, 8),   -- F: custo presente
+  (1013,'oben', 10, 8);   -- M: cmc=10 → impacto Δ-30 × 10 = -300

--- a/db/test-param-auto.sh
+++ b/db/test-param-auto.sh
@@ -92,6 +92,8 @@ echo "→ migration D (recalibra fusível: dropa cobertura, no-op antes do fusí
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260605150000_param_auto_fusivel_calibracao.sql"
 echo "→ migration E (resumo 18h: rótulo = descrição do produto, fallback p/ código)…"
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260619120000_param_auto_resumo_descricao.sql"
+echo "→ migration F (resumo: altas/reduções separadas + segurado pelo nome)…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql"
 
 echo "→ seed dos cenários (view controlada + sku_parametros + pins + estoque/custo)…"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/seed-param-auto.sql"
@@ -206,19 +208,25 @@ BEGIN
   SELECT impacto_rs INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1012';
   ASSERT r.impacto_rs IS NULL, format('L impacto FALHOU: % (esperado NULL — custo ausente = desconhecido)', r.impacto_rs);
 
+  -- M: REDUÇÃO do máximo (120→90) com estoque 30 abaixo do ponto → aplicado com impacto NEGATIVO
+  --    (qtde_antes 120-30=90, qtde_depois 90-30=60, Δ-30 × cmc10 = -300). É o caso do resumo "reduções".
+  SELECT status, impacto_rs INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1013';
+  ASSERT r.status='aplicado', format('M FALHOU: status=% (esperado aplicado: queda do máximo não é segurada)', r.status);
+  ASSERT r.impacto_rs=-300, format('M impacto FALHOU: % (esperado -300: Δ-30 × cmc10 — capital LIBERADO)', r.impacto_rs);
+
   -- Totais do run: log escopado ao motor (I/J aplicam config mas NÃO contam aqui).
   SELECT total_aplicados, total_segurados, total_pinados, impacto_total_rs, impacto_desconhecido_n
     INTO r FROM public.reposicao_param_auto_run WHERE id=v_run;
-  ASSERT r.total_aplicados=3, format('total_aplicados FALHOU: % (esperado 3: A,F,L — I/J aplicam mas não logam)', r.total_aplicados);
+  ASSERT r.total_aplicados=4, format('total_aplicados FALHOU: % (esperado 4: A,F,L,M — I/J aplicam mas não logam)', r.total_aplicados);
   ASSERT r.total_segurados=1, format('total_segurados FALHOU: % (esperado 1: B — cobertura removida, C virou no-op)', r.total_segurados);
   ASSERT r.total_pinados=2, format('total_pinados FALHOU: % (esperado 2: E,H — pin vence o fusível)', r.total_pinados);
-  -- impacto_total_rs = soma dos impactos conhecidos: A=200, F=? (pos 30<=70→qtde_depois 150-30=120;
-  --   antes pp 40, máx 100 → 30<=40→qtde_antes 100-30=70; Δ50×cmc10=500) → 200+500=700; B=0(segurado);
-  --   L=NULL (não soma).
-  ASSERT r.impacto_total_rs=700, format('impacto_total_rs FALHOU: % (esperado 700: A 200 + F 500)', r.impacto_total_rs);
+  -- impacto_total_rs = soma dos impactos conhecidos: A=200, F=500 (pos 30<=70→qtde_depois 150-30=120;
+  --   antes pp 40, máx 100 → 30<=40→qtde_antes 100-30=70; Δ50×cmc10=500); M=-300 (redução); B=0(segurado);
+  --   L=NULL (não soma). → 200+500-300 = 400 (o total JÁ é líquido: inclui a redução de M).
+  ASSERT r.impacto_total_rs=400, format('impacto_total_rs FALHOU: % (esperado 400 líquido: A 200 + F 500 - M 300)', r.impacto_total_rs);
   ASSERT COALESCE(r.impacto_desconhecido_n,0)=1, format('impacto_desconhecido_n FALHOU: % (esperado 1: L aplica sem custo)', r.impacto_desconhecido_n);
 
-  RAISE NOTICE 'OK status/impacto/totais (A/F/L aplicam · B segura (3×) · C giro-lento no-op · D bloqueia · E/H pinam · G sem_mudanca · I/J aplicam sem logar · K bloqueia cold-start · L queda aplica)';
+  RAISE NOTICE 'OK status/impacto/totais (A/F/L/M aplicam · B segura (3×) · C giro-lento no-op · D bloqueia · E/H pinam · G sem_mudanca · I/J aplicam sem logar · K bloqueia cold-start · L queda aplica · M reduz -300)';
 END $$;
 SQL
 
@@ -324,17 +332,38 @@ BEGIN
   SELECT count(*) INTO n FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
   ASSERT n=1, format('RESUMO idempotência FALHOU: % alertas (esperado 1)', n);
 
-  -- ── P1/P2 (migration E): cada item é rotulado pela DESCRIÇÃO, não pelo código cru ──
+  -- ── Corpo do e-mail: altas / reduções / segurado-pelo-nome (migration F) ──
   SELECT mensagem INTO v_msg FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
-  -- P1 (positivo): as descrições dos 3 aplicados (A/F/L) aparecem no corpo
-  ASSERT position('SKU-A normal' IN v_msg) > 0,         'P1 FALHOU: descrição de A ausente no e-mail';
-  ASSERT position('SKU-F pin diferente' IN v_msg) > 0,  'P1 FALHOU: descrição de F ausente no e-mail';
-  ASSERT position('SKU-L queda do máximo' IN v_msg) > 0,'P1 FALHOU: descrição de L ausente no e-mail';
-  -- P2 (positivo): o código deixou de ser o RÓTULO do item ("<código>: PP")
-  ASSERT position('1001: PP' IN v_msg) = 0, 'P2 FALHOU: A ainda rotulado pelo código (1001) em vez da descrição';
-  ASSERT position('1006: PP' IN v_msg) = 0, 'P2 FALHOU: F ainda rotulado pelo código (1006)';
-  ASSERT position('1012: PP' IN v_msg) = 0, 'P2 FALHOU: L ainda rotulado pelo código (1012)';
-  RAISE NOTICE 'OK resumo: 1 alerta (info/pendente) + idempotente + rótulo=descrição (P1) + código não é rótulo (P2)';
+  RAISE NOTICE E'\n──── CORPO DO E-MAIL ────\n%\n─────────────────────────', v_msg;
+
+  -- P-ALTAS (positivo): seção "Maiores altas" com A (+200) e F (+500), pela DESCRIÇÃO e com sinal +.
+  ASSERT position('Maiores altas:' IN v_msg) > 0,        'P-ALTAS FALHOU: seção "Maiores altas" ausente';
+  ASSERT position('SKU-A normal' IN v_msg) > 0,          'P-ALTAS FALHOU: A (alta +200) ausente';
+  ASSERT position('SKU-F pin diferente' IN v_msg) > 0,   'P-ALTAS FALHOU: F (alta +500) ausente';
+  ASSERT position('(R$ +500)' IN v_msg) > 0,             'P-ALTAS FALHOU: sinal/valor "+500" de F ausente';
+  ASSERT position('(R$ +200)' IN v_msg) > 0,             'P-ALTAS FALHOU: sinal/valor "+200" de A ausente';
+
+  -- P-REDUÇÕES (o bug do founder): seção PRÓPRIA "Maiores reduções" com M (-300) — nunca cortada.
+  ASSERT position('Maiores reduções:' IN v_msg) > 0,     'P-REDUCOES FALHOU: seção "Maiores reduções" ausente (o bug: só mostrava alta)';
+  ASSERT position('SKU-M reducao capital' IN v_msg) > 0, 'P-REDUCOES FALHOU: M (redução -300) ausente';
+  ASSERT position('(R$ -300)' IN v_msg) > 0,             'P-REDUCOES FALHOU: valor "-300" de M ausente';
+  -- ordem: altas ANTES de reduções (a seção de alta precede a de baixa no corpo)
+  ASSERT position('Maiores altas:' IN v_msg) < position('Maiores reduções:' IN v_msg),
+    'P-ORDEM FALHOU: "Maiores reduções" deveria vir DEPOIS de "Maiores altas"';
+
+  -- P-SEGURADO (o "confira" agora diz o quê): B listado pelo NOME sob "Segurados pelo fusível".
+  ASSERT position('Segurados pelo fusível (confira): 1' IN v_msg) > 0, 'P-SEGURADO FALHOU: contador do fusível ausente';
+  ASSERT position('SKU-B salto>3x' IN v_msg) > 0,        'P-SEGURADO FALHOU: item segurado (B) não listado pelo nome';
+  ASSERT position('máx atual 100' IN v_msg) > 0,         'P-SEGURADO FALHOU: contexto (máx atual) do segurado ausente';
+
+  -- P-SEM-CUSTO: L (aplicado, impacto NULL) NÃO é listado (sem custo), mas conta no "(+1 sem custo)".
+  ASSERT position('SKU-L queda do máximo' IN v_msg) = 0, 'P-SEM-CUSTO FALHOU: L (impacto NULL) não deveria ser listado';
+  ASSERT position('(+1 sem custo)' IN v_msg) > 0,        'P-SEM-CUSTO FALHOU: rótulo "(+1 sem custo)" do L ausente no cabeçalho';
+
+  -- P-CÓDIGO-NÃO-É-RÓTULO: com descrição presente, o código cru não vira rótulo ("<código>: PP").
+  ASSERT position('1001: PP' IN v_msg) = 0, 'P-RÓTULO FALHOU: A ainda rotulado pelo código (1001)';
+  ASSERT position('1006: PP' IN v_msg) = 0, 'P-RÓTULO FALHOU: F ainda rotulado pelo código (1006)';
+  RAISE NOTICE 'OK resumo: altas só-positivas (A/F) · reduções em seção própria (M -300) · segurado pelo nome (B) · L sem custo não-listado · idempotente';
 END $$;
 
 -- cron registrado
@@ -342,39 +371,13 @@ SELECT 'cron' AS k, count(*) AS n FROM cron.job WHERE jobname='reposicao-param-a
 SQL
 
 echo ""
-echo "→ FALSIFICAÇÃO (sabota a migration E → o e-mail volta ao código; prova o dente de P1)…"
+echo "→ FALSIFICAÇÃO (reverte à migration E: lista única DESC LIMIT 10 → prova o dente de reduções/segurado)…"
+# Sabotagem = voltar à versão ANTERIOR (E), que tem UMA lista "Maiores mudanças" sem seção de reduções
+# nem segurado-por-nome. Com só 4 aplicados (<10), a E até mostraria M na lista única — por isso a
+# sentinela de dente NÃO é 'SKU-M' (apareceria nas duas), e sim a SEÇÃO "Maiores reduções:" e o NOME
+# do segurado 'SKU-B', strings que SÓ a migration F emite.
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260619120000_param_auto_resumo_descricao.sql"
 P -v ON_ERROR_STOP=1 -q <<'SQL'
--- Versão FURADA: rótulo = sku_codigo_omie cru (como era ANTES da migration E).
-CREATE OR REPLACE FUNCTION public.reposicao_param_auto_resumo_tick()
-  RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','pg_temp'
-  AS $fur$
-DECLARE r record; v_hoje date := (now() AT TIME ZONE 'America/Sao_Paulo')::date; v_corpo text; v_top text;
-BEGIN
-  PERFORM pg_advisory_xact_lock(hashtext('param_auto_resumo'));
-  SELECT * INTO r FROM public.reposicao_param_auto_run
-    WHERE data_negocio_brt=v_hoje AND status='completo' AND resumo_enviado_em IS NULL
-    ORDER BY concluido_em DESC LIMIT 1;
-  IF NOT FOUND THEN RETURN; END IF;
-  IF COALESCE(r.total_aplicados,0)=0 AND COALESCE(r.total_segurados,0)=0 THEN
-    UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=now() WHERE id=r.id; RETURN;
-  END IF;
-  SELECT string_agg(format('• %s: PP %s→%s, máx %s→%s%s', sku_codigo_omie,
-            coalesce(ponto_pedido_antes::text,'—'), coalesce(ponto_pedido_depois::text,'—'),
-            coalesce(estoque_maximo_antes::text,'—'), coalesce(estoque_maximo_depois::text,'—'),
-            CASE WHEN impacto_rs IS NULL THEN ' (R$ ?)' ELSE ' (R$ '||round(impacto_rs)::text||')' END), E'\n')
-    INTO v_top FROM (
-      SELECT * FROM public.reposicao_param_auto_log WHERE run_id=r.id AND status='aplicado'
-      ORDER BY impacto_rs DESC NULLS LAST LIMIT 10) t;
-  v_corpo := format(E'%s parâmetros mudaram hoje (OBEN).\nImpacto estimado total: R$ %s%s\n\nMaiores mudanças:\n%s\n\nSegurados pelo fusível (confira): %s\n\nVeja e reverta em: /admin/reposicao/mudancas-automaticas',
-    r.total_aplicados, round(COALESCE(r.impacto_total_rs,0)),
-    CASE WHEN COALESCE(r.impacto_desconhecido_n,0)>0 THEN ' (+'||r.impacto_desconhecido_n||' sem custo)' ELSE '' END,
-    COALESCE(v_top,'—'), COALESCE(r.total_segurados,0));
-  INSERT INTO public.fornecedor_alerta (tipo, titulo, mensagem, empresa, severidade, status)
-    VALUES ('param_auto_resumo', 'Parâmetros de reposição — resumo do dia', v_corpo, r.empresa, 'info', 'pendente_notificacao');
-  UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=now() WHERE id=r.id;
-END;
-$fur$;
-
 DELETE FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
 UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=NULL
   WHERE status='completo' AND data_negocio_brt=(now() AT TIME ZONE 'America/Sao_Paulo')::date;
@@ -384,24 +387,28 @@ DECLARE v_msg text;
 BEGIN
   PERFORM public.reposicao_param_auto_resumo_tick();
   SELECT mensagem INTO v_msg FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
-  -- Sentinela ASCII que SÓ a versão verdadeira emite (a descrição). Com a furada deve SUMIR:
-  ASSERT position('SKU-A normal' IN v_msg) = 0,
-    'FALSIFICAÇÃO FRACA: P1 ficaria verde mesmo sem a migration E (rótulo=código) → assert sem dente';
-  -- e o código volta a ser o rótulo (confirma que a sabotagem rodou de fato):
-  ASSERT position('1001: PP' IN v_msg) > 0,
-    'FALSIFICAÇÃO INCONCLUSIVA: nem o código apareceu — a versão furada não rodou como esperado';
-  RAISE NOTICE 'OK falsificação: sem a migration E o e-mail volta ao código cru (P1 ficaria VERMELHO)';
+  -- Dente de P-REDUCOES: a SEÇÃO própria some sem a F (a redução voltaria a competir/ser cortada pelo LIMIT).
+  ASSERT position('Maiores reduções:' IN v_msg) = 0,
+    'FALSIFICAÇÃO FRACA: "Maiores reduções" apareceria sem a migration F → P-REDUCOES sem dente';
+  -- Dente de P-SEGURADO: o segurado deixa de ser listado pelo nome (E só mostra o contador).
+  ASSERT position('SKU-B salto>3x' IN v_msg) = 0,
+    'FALSIFICAÇÃO FRACA: o segurado (B) seria listado pelo nome sem a migration F → P-SEGURADO sem dente';
+  -- Confirma que a reversão REALMENTE rodou (a E emite a lista única "Maiores mudanças"):
+  ASSERT position('Maiores mudanças:' IN v_msg) > 0,
+    'FALSIFICAÇÃO INCONCLUSIVA: nem "Maiores mudanças" (rótulo da versão E) apareceu — a reversão não rodou';
+  RAISE NOTICE 'OK falsificação: sem a migration F o e-mail volta à lista única (reduções e segurado-por-nome SOMEM → P-REDUCOES/P-SEGURADO VERMELHOS)';
 END $$;
 SQL
 
-echo "→ restaura a migration E verdadeira…"
-P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260619120000_param_auto_resumo_descricao.sql"
+echo "→ restaura a migration F verdadeira…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql"
 
 echo ""
-echo "→ P3 FALLBACK (descrição NULL/só-espaços → cai no código, nunca rótulo vazio)…"
+echo "→ FALLBACK (descrição NULL/só-espaços → cai no código nas 3 superfícies, nunca rótulo vazio)…"
 P -v ON_ERROR_STOP=1 -q <<'SQL'
-UPDATE public.reposicao_param_auto_log SET sku_descricao=NULL  WHERE sku_codigo_omie='1001';  -- A: NULL
-UPDATE public.reposicao_param_auto_log SET sku_descricao='   ' WHERE sku_codigo_omie='1012';  -- L: só-espaços
+UPDATE public.reposicao_param_auto_log SET sku_descricao=NULL  WHERE sku_codigo_omie='1001';  -- A (alta): NULL
+UPDATE public.reposicao_param_auto_log SET sku_descricao='   ' WHERE sku_codigo_omie='1013';  -- M (redução): só-espaços
+UPDATE public.reposicao_param_auto_log SET sku_descricao=NULL  WHERE sku_codigo_omie='1002';  -- B (segurado): NULL
 DELETE FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
 UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=NULL
   WHERE status='completo' AND data_negocio_brt=(now() AT TIME ZONE 'America/Sao_Paulo')::date;
@@ -411,12 +418,14 @@ DECLARE v_msg text;
 BEGIN
   PERFORM public.reposicao_param_auto_resumo_tick();
   SELECT mensagem INTO v_msg FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
-  ASSERT position('1001: PP' IN v_msg) > 0,          'P3 FALHOU: descrição NULL (A) não caiu no código';
-  ASSERT position('SKU-A normal' IN v_msg) = 0,      'P3 FALHOU: A ainda mostra a descrição apagada';
-  ASSERT position('1012: PP' IN v_msg) > 0,          'P3 FALHOU: descrição só-espaços (L) não caiu no código (nullif/btrim)';
-  ASSERT position('SKU-F pin diferente' IN v_msg) > 0,'P3 FALHOU: F (com descrição) deveria manter o texto';
-  ASSERT position('• : PP' IN v_msg) = 0,            'P3 FALHOU: rótulo vazio no e-mail (money-path: ausente≠vazio)';
-  RAISE NOTICE 'OK fallback: NULL e só-espaços caem no código; com descrição mantém; sem rótulo vazio';
+  ASSERT position('1001: PP' IN v_msg) > 0,          'FALLBACK FALHOU: descrição NULL (A) não caiu no código nas altas';
+  ASSERT position('SKU-A normal' IN v_msg) = 0,      'FALLBACK FALHOU: A ainda mostra a descrição apagada';
+  ASSERT position('1013: PP' IN v_msg) > 0,          'FALLBACK FALHOU: descrição só-espaços (M) não caiu no código nas reduções (nullif/btrim)';
+  ASSERT position('1002 (máx atual' IN v_msg) > 0,   'FALLBACK FALHOU: segurado B com descrição NULL não caiu no código';
+  ASSERT position('SKU-F pin diferente' IN v_msg) > 0,'FALLBACK FALHOU: F (com descrição) deveria manter o texto';
+  ASSERT position('• : PP' IN v_msg) = 0,            'FALLBACK FALHOU: rótulo vazio nas listas (money-path: ausente≠vazio)';
+  ASSERT position('•  (máx atual' IN v_msg) = 0,     'FALLBACK FALHOU: rótulo vazio no segurado';
+  RAISE NOTICE 'OK fallback: NULL/só-espaços caem no código (altas, reduções e segurado); com descrição mantém; sem rótulo vazio';
 END $$;
 SQL
 

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **356** custom migrations totais
-- **1277** objetos esperados (criados por estas migrations)
+- **357** custom migrations totais
+- **1278** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 357
+  - `function`: 358
   - `rls_policy`: 285
   - `index`: 211
   - `cron_job`: 146
@@ -3055,6 +3055,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `view` | `public.v_grupo_contatos` | — |
+
+### `20260711193000_param_auto_resumo_altas_reducoes_segurado.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.reposicao_param_auto_resumo_tick` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 356
+-- Total de custom migrations: 357
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -395,7 +395,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260709163500', 'selfservice_pr00bis_b_revoke_omie_payload', '20260709163500_selfservice_pr00bis_b_revoke_omie_payload.sql'),
   ('20260710012337', 'carteira_saude_eligible_e_efeito_mensal', '20260710012337_carteira_saude_eligible_e_efeito_mensal.sql'),
   ('20260711090000', 'prime_fundacao', '20260711090000_prime_fundacao.sql'),
-  ('20260711145000', 'v_grupo_contatos_fresca', '20260711145000_v_grupo_contatos_fresca.sql')
+  ('20260711145000', 'v_grupo_contatos_fresca', '20260711145000_v_grupo_contatos_fresca.sql'),
+  ('20260711193000', 'param_auto_resumo_altas_reducoes_segurado', '20260711193000_param_auto_resumo_altas_reducoes_segurado.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1663,7 +1664,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_staff_insert', 'prime_beneficio_uso'),
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_staff_update', 'prime_beneficio_uso'),
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_cliente_read', 'prime_beneficio_uso'),
-  ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', '')
+  ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', ''),
+  ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2979,7 +2981,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_staff_insert', 'prime_beneficio_uso'),
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_staff_update', 'prime_beneficio_uso'),
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_cliente_read', 'prime_beneficio_uso'),
-  ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', '')
+  ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', ''),
+  ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql
+++ b/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql
@@ -1,0 +1,118 @@
+-- Reposição — resumo diário: mostrar REDUÇÕES e LISTAR o item segurado pelo nome
+-- ============================================================================
+-- O e-mail "Parâmetros de reposição — resumo do dia" tinha DOIS pontos cegos (feedback do founder):
+--
+--   (1) SÓ mostrava acréscimo de capital, nunca redução. A lista única ordenava por
+--       `impacto_rs DESC LIMIT 10` → os itens de impacto NEGATIVO (parâmetro que caiu e LIBEROU
+--       capital) ficavam no fim e eram cortados quando havia mais de 10 aplicados no dia. O total do
+--       run já é líquido (soma os negativos), então "não fechava" com a lista visível — e o founder
+--       perdia de vista justamente a economia de capital.
+--
+--   (2) O rodapé "Segurados pelo fusível (confira): N" dizia "confira" mas NÃO dizia O QUÊ. Para
+--       saber qual item o fusível travou, só na tela /admin/reposicao/mudancas-automaticas.
+--
+-- CORREÇÃO (só apresentação — o cálculo do impacto/segurado e o total do run NÃO mudam):
+--   • Duas listas separadas: "Maiores altas" (impacto>0, DESC) e "Maiores reduções" (impacto<0, ASC) —
+--     as reduções nunca competem com as altas pelo LIMIT, então SEMPRE aparecem quando existem.
+--   • Cada seção só é renderizada quando tem item (sem "Maiores reduções:\n—" órfão).
+--   • Sob "Segurados pelo fusível" agora vêm os itens pelo NOME (máx atual + giro), top 5.
+--   • Aplicados de impacto exatamente 0 (parâmetro mudou mas não muda a compra de hoje) saem das
+--     listas e viram um contador discreto — o cabeçalho já rotula os de custo ausente ("+N sem custo").
+--
+-- Fallback (money-path: ausente ≠ vazio) PRESERVADO: descrição NULL/só-espaços → cai no código
+-- (coalesce + nullif(btrim(...))); demanda/máx ausentes → '?'/'—', nunca rótulo vazio.
+--
+-- CREATE OR REPLACE: pré-flight pg_get_functiondef da prod em 2026-07-11 — corpo vivo IDÊNTICO à
+-- 20260619120000 (sem drift). "A última a recriar vence" → aplicar ESTA por último no SQL Editor.
+-- Provado em PostgreSQL 17 local (db/test-param-auto.sh): altas só-positivas · reduções aparecem
+-- (cenário M −300) · segurado pelo nome · fallback NULL/espaços · seção vazia omitida · falsificação
+-- (voltar ao DESC-LIMIT-10 → a redução some = P-reduções VERMELHO; voltar a só-contador → segurado
+-- VERMELHO).
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.reposicao_param_auto_resumo_tick()
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public', 'pg_temp'
+  AS $$
+DECLARE
+  r record;
+  v_hoje date := (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+  v_corpo text;
+  v_altas text;       -- aplicados com impacto > 0 (capital que SUBIU), top 5 DESC
+  v_reducoes text;    -- aplicados com impacto < 0 (capital LIBERADO), top 5 ASC
+  v_segurados text;   -- itens travados pelo fusível, pelo NOME, top 5
+  v_sem_efeito int;   -- aplicados com impacto EXATAMENTE 0 (mudou o parâmetro, não a compra de hoje)
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('param_auto_resumo'));  -- serializa ticks concorrentes (anti-duplo-email)
+  -- v1 OBEN-only: processa 1 run por tick e o corpo do e-mail rotula "(OBEN)". Se um dia houver multi-empresa, trocar por um loop por empresa (senão a 2ª empresa do dia não recebe digest).
+  SELECT * INTO r FROM public.reposicao_param_auto_run
+    WHERE data_negocio_brt=v_hoje AND status='completo' AND resumo_enviado_em IS NULL
+    ORDER BY concluido_em DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN; END IF;
+  IF COALESCE(r.total_aplicados,0)=0 AND COALESCE(r.total_segurados,0)=0 THEN
+    UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=now() WHERE id=r.id;  -- nada relevante
+    RETURN;
+  END IF;
+
+  -- ── Maiores ALTAS (impacto > 0): capital que subiu. Rótulo = descrição; cai no código se faltar. ──
+  SELECT string_agg(format('• %s: PP %s→%s, máx %s→%s (R$ +%s)',
+            coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+            coalesce(ponto_pedido_antes::text,'—'), coalesce(ponto_pedido_depois::text,'—'),
+            coalesce(estoque_maximo_antes::text,'—'), coalesce(estoque_maximo_depois::text,'—'),
+            round(impacto_rs)::text), E'\n' ORDER BY impacto_rs DESC)
+    INTO v_altas FROM (
+      SELECT * FROM public.reposicao_param_auto_log
+      WHERE run_id=r.id AND status='aplicado' AND impacto_rs > 0
+      ORDER BY impacto_rs DESC LIMIT 5) t;
+
+  -- ── Maiores REDUÇÕES (impacto < 0): capital liberado. Lista PRÓPRIA → nunca cortada pelas altas. ──
+  -- round(impacto_rs) já traz o sinal '-' (ex.: -300 → "R$ -300").
+  SELECT string_agg(format('• %s: PP %s→%s, máx %s→%s (R$ %s)',
+            coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+            coalesce(ponto_pedido_antes::text,'—'), coalesce(ponto_pedido_depois::text,'—'),
+            coalesce(estoque_maximo_antes::text,'—'), coalesce(estoque_maximo_depois::text,'—'),
+            round(impacto_rs)::text), E'\n' ORDER BY impacto_rs ASC)
+    INTO v_reducoes FROM (
+      SELECT * FROM public.reposicao_param_auto_log
+      WHERE run_id=r.id AND status='aplicado' AND impacto_rs < 0
+      ORDER BY impacto_rs ASC LIMIT 5) t;
+
+  -- ── SEGURADOS pelo fusível, pelo NOME (o "confira" agora diz o quê). Contexto: máx atual + giro. ──
+  SELECT string_agg(format('• %s (máx atual %s, giro %s/dia)',
+            coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+            coalesce(estoque_maximo_antes::text,'—'),
+            coalesce(round(demanda_media_diaria, 2)::text,'?')), E'\n' ORDER BY estoque_maximo_antes DESC NULLS LAST)
+    INTO v_segurados FROM (
+      SELECT * FROM public.reposicao_param_auto_log
+      WHERE run_id=r.id AND status='segurado'
+      ORDER BY estoque_maximo_antes DESC NULLS LAST LIMIT 5) t;
+
+  -- Aplicados de impacto EXATAMENTE 0 (parâmetro mudou, compra de hoje não). NULL já conta em impacto_desconhecido_n.
+  SELECT count(*) INTO v_sem_efeito FROM public.reposicao_param_auto_log
+    WHERE run_id=r.id AND status='aplicado' AND impacto_rs = 0;
+
+  -- ── Montagem (seções vazias omitidas graciosamente) ──
+  v_corpo :=
+       format('%s parâmetros mudaram hoje (OBEN).', r.total_aplicados)
+    || format(E'\nImpacto estimado total: R$ %s%s', round(COALESCE(r.impacto_total_rs,0)),
+         CASE WHEN COALESCE(r.impacto_desconhecido_n,0)>0 THEN ' (+'||r.impacto_desconhecido_n||' sem custo)' ELSE '' END)
+    || CASE WHEN v_altas    IS NOT NULL THEN E'\n\nMaiores altas:\n'    || v_altas    ELSE '' END
+    || CASE WHEN v_reducoes IS NOT NULL THEN E'\n\nMaiores reduções:\n' || v_reducoes ELSE '' END
+    || format(E'\n\nSegurados pelo fusível (confira): %s', COALESCE(r.total_segurados,0))
+    || CASE WHEN v_segurados IS NOT NULL THEN E'\n' || v_segurados ELSE '' END
+    || CASE WHEN COALESCE(v_sem_efeito,0) > 0
+            THEN format(E'\n\n+%s ajuste(s) sem efeito na compra de hoje.', v_sem_efeito) ELSE '' END
+    || E'\n\nVeja e reverta em: /admin/reposicao/mudancas-automaticas';
+
+  INSERT INTO public.fornecedor_alerta (tipo, titulo, mensagem, empresa, severidade, status)
+    VALUES ('param_auto_resumo', 'Parâmetros de reposição — resumo do dia', v_corpo, r.empresa, 'info', 'pendente_notificacao');
+  UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=now() WHERE id=r.id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.reposicao_param_auto_resumo_tick() FROM anon, authenticated, public;
+
+COMMIT;
+
+SELECT 'param_auto_resumo_altas_reducoes_segurado OK' AS status;


### PR DESCRIPTION
## Problema (resumo diário de parâmetros de reposição)

O e-mail **"Parâmetros de reposição — resumo do dia"** tinha dois pontos cegos:

1. **Só mostrava acréscimo de capital, nunca redução.** A lista única ordenava por `impacto_rs DESC LIMIT 10` → os itens de impacto **negativo** (parâmetro que caiu e **liberou** capital) ficavam no fim e eram cortados quando havia mais de 10 aplicados no dia. O total do run já é líquido (soma os negativos), então "não fechava" com a lista visível, e perdia-se de vista justamente a economia de capital.
2. **O rodapé "Segurados pelo fusível: N" dizia "confira" mas não dizia o quê.** Para saber qual item o fusível travou, só na tela `/admin/reposicao/mudancas-automaticas`.

## Correção (só apresentação — cálculo de impacto/segurado e total do run **não** mudam)

- Duas listas separadas: **"Maiores altas"** (impacto > 0, DESC) e **"Maiores reduções"** (impacto < 0, ASC). As reduções têm seção própria → **nunca competem com as altas pelo LIMIT**, sempre aparecem quando existem.
- Cada seção só é renderizada quando tem item (sem `Maiores reduções:\n—` órfão).
- Sob **"Segurados pelo fusível"** agora vêm os itens **pelo nome** (máx atual + giro), top 5.
- Aplicados de impacto exatamente 0 (parâmetro mudou mas não muda a compra de hoje) saem das listas e viram um contador discreto; o cabeçalho já rotula os de custo ausente (`+N sem custo`).

Fallback preservado (money-path: ausente ≠ vazio): descrição NULL/só-espaços → cai no código; demanda/máx ausentes → `?`/`—`, nunca rótulo vazio.

### Formato do corpo (exemplo do harness de teste, dados fictícios)

```
4 parâmetros mudaram hoje (OBEN).
Impacto estimado total: R$ 400 (+1 sem custo)

Maiores altas:
• SKU-F pin diferente: PP 40→70, máx 100→150 (R$ +500)
• SKU-A normal: PP 50→60, máx 120→140 (R$ +200)

Maiores reduções:
• SKU-M reducao capital: PP 50→45, máx 120→90 (R$ -300)

Segurados pelo fusível (confira): 1
• SKU-B salto>3x (máx atual 100, giro 4.00/dia)
```

## Prova (PG17 local, `db/test-param-auto.sh`)

- ✅ Verde com a migration real: altas só-positivas · **reduções em seção própria** · segurado pelo nome · aplicado de impacto NULL não-listado mas contado · fallback NULL/espaços nas 3 superfícies · idempotência.
- ✅ **Falsificação** (revert → migration anterior, lista única): `Maiores reduções:` e o nome do segurado **somem** → prova o dente dos asserts.
- ✅ **Sabotagem direta** (`CASE WHEN false` na seção de reduções): assert de reduções falha, exit=3.
- Novo cenário **M** no seed (`db/seed-param-auto.sql`): redução do máximo com estoque abaixo do ponto → impacto negativo.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar.

É `CREATE OR REPLACE FUNCTION reposicao_param_auto_resumo_tick()`. Pré-flight `pg_get_functiondef` da prod (11/07): corpo vivo **idêntico** à `20260619120000` (sem drift); esta migration tem o maior timestamp → **a última a recriar vence**. Só muda o corpo do e-mail; não altera cálculo, gate nem total do run.

<details><summary>Validação pós-apply (read-only)</summary>

```sql
SELECT CASE
  WHEN pg_get_functiondef('public.reposicao_param_auto_resumo_tick()'::regprocedure) LIKE '%Maiores reduções%'
  THEN '✅ resumo com reduções/segurado aplicado'
  ELSE '❌ FALTANDO — ainda é a versão antiga (lista única)'
END AS status;
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
