### PR TITLE
feat(carteira): rebuild lê o vendedor da proof account=oben (P0-B-bis ponta 2/2)

### DIFF
--- a/db/test-carteira-vendedor-oben-account-safe.sh
+++ b/db/test-carteira-vendedor-oben-account-safe.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — camada SQL da ponta 2/2 do incidente carteira-Hunter (P0-B-bis)  ║
+# ║  A carteira lê o VENDEDOR da view fresca omie_customer_account_map_fresco       ║
+# ║  (account=oben). Esta prova crava a SEMÂNTICA da view+query em que a correção   ║
+# ║  se apoia — NÃO há migração nova (edge TS puro; a lógica é provada por vitest). ║
+# ║  Recria a tabela base + a view com as DEFINIÇÕES REAIS (pg_get_viewdef +        ║
+# ║  constraints conferidas via psql-ro 2026-07-11) e FALSIFICA cada invariante.    ║
+# ║      bash db/test-carteira-vendedor-oben-account-safe.sh > /tmp/t.log 2>&1; echo "exit=$?"  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"     # porta própria (evita colisão com outros harnesses em paralelo)
+SLUG="carteira-vend-oben"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1+2 — SCHEMA REAL: tabela base (com as UNIQUE reais) + view fresca (def real)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+-- Estrutura REAL de omie_customer_account_map (information_schema + pg_constraint via psql-ro 2026-07-11).
+CREATE TABLE public.omie_customer_account_map (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id              uuid   NOT NULL,
+  account              text   NOT NULL,
+  omie_codigo_cliente  bigint NOT NULL,
+  omie_codigo_vendedor bigint,               -- nullable: o writer só popula quando recomendacoes traz
+  source               text   NOT NULL,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_ocam_codigo_account UNIQUE (omie_codigo_cliente, account),
+  CONSTRAINT uq_ocam_user_account   UNIQUE (user_id, account)
+);
+-- Definição REAL da view (pg_get_viewdef via psql-ro): TTL 7d sobre a base.
+CREATE VIEW public.omie_customer_account_map_fresco AS
+  SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
+    FROM public.omie_customer_account_map
+   WHERE updated_at >= (now() - '7 days'::interval);
+SQL
+echo "schema real recriado (tabela base + view fresca)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED: casos de borda do money-path da carteira
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO public.omie_customer_account_map (user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, updated_at) VALUES
+ -- user1: MESMO cliente em 2 contas com vendedores DIFERENTES. A carteira (oben) deve pegar 100, nunca 200.
+ ('11111111-1111-1111-1111-111111111111', 'oben',       9001, 100, 'document', now()),
+ ('11111111-1111-1111-1111-111111111111', 'colacor_sc', 9002, 200, 'document', now()),
+ -- user2: linha oben fresca mas vendedor NULL (estado transitório / recomendacoes sem vendedor) → órfão honesto.
+ ('22222222-2222-2222-2222-222222222222', 'oben',       9003, NULL, 'document', now()),
+ -- user3: linha oben com vendedor 300 mas STALE (>7d) → a view fresca deve OCULTAR (senão vendedor podre).
+ ('33333333-3333-3333-3333-333333333333', 'oben',       9004, 300, 'document', now() - interval '8 days'),
+ -- user4: só existe em colacor_sc (é o clone típico) → NÃO deve aparecer na carteira oben (sem herança).
+ ('44444444-4444-4444-4444-444444444444', 'colacor_sc', 9005, 400, 'document', now());
+SQL
+echo "seed aplicado"
+
+U1="11111111-1111-1111-1111-111111111111"
+U2="22222222-2222-2222-2222-222222222222"
+U3="33333333-3333-3333-3333-333333333333"
+U4="44444444-4444-4444-4444-444444444444"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS POSITIVOS: a query REAL do edge é account-safe
+# (a query do edge: FROM omie_customer_account_map_fresco WHERE account='oben')
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts positivos (a query correta que o edge faz) ──"
+
+V=$(Pq -c "SELECT omie_codigo_vendedor FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U1';")
+eq "A1 vendedor da CONTA CERTA (oben=100, nunca o colacor_sc=200)" "$V" "100"
+
+V=$(Pq -c "SELECT coalesce(omie_codigo_vendedor::text,'NULL') FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U2';")
+eq "A2 vendedor ausente preservado como NULL (órfão honesto, vira Hunter no rebuild)" "$V" "NULL"
+
+V=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U3';")
+eq "A3 STALE (>7d) OCULTO pela view fresca (não injeta vendedor podre)" "$V" "0"
+
+V=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U4';")
+eq "A4 clone só-colacor_sc AUSENTE na carteira oben (sem herança cross-account)" "$V" "0"
+
+# nenhuma linha colacor_sc pode aparecer sob o filtro account='oben'
+V=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE account='oben' AND omie_codigo_vendedor=200;")
+eq "A5 isolamento de conta: o vendedor 200 (colacor_sc) NÃO aparece sob account=oben" "$V" "0"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO: sabota cada proteção da query → exige VERMELHO
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação (sabota o filtro → prova o dente) ──"
+
+# F1 — SABOTA o filtro de CONTA (o bug do espelho poluído, que lia sem account): o mesmo user1 passa a
+#      trazer 2 vendedores (100 oben E 200 colacor_sc). Se a query correta (A1) NÃO tivesse o filtro
+#      account=oben, ela pegaria um vendedor arbitrário/errado. Provamos que SEM o filtro há ambiguidade.
+FURADO=$(Pq -c "SELECT count(DISTINCT omie_codigo_vendedor) FROM omie_customer_account_map_fresco WHERE user_id='$U1';")
+if [ "$FURADO" = "2" ]; then ok "F1 sem o filtro de conta → 2 vendedores p/ o mesmo user (vazamento que o account=oben mata)"; else bad "F1 falsificação fraca — sem filtro deu [$FURADO], esperava 2 (o filtro não estaria protegendo nada)"; fi
+# e o valor arbitrário que vazaria inclui o colacor_sc:
+LEAK=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE user_id='$U1' AND omie_codigo_vendedor=200;")
+eq "F1b o vendedor colacor_sc (200) É alcançável sem o filtro de conta (por isso o filtro tem dente)" "$LEAK" "1"
+
+# F2 — SABOTA a fonte fresca (ler a BASE em vez da view): o stale user3 (vendedor 300 podre) reaparece.
+#      Prova que é a VIEW (TTL 7d) que protege — ler a base reabriria stale infinito (Codex P1).
+STALE_NA_BASE=$(Pq -c "SELECT count(*) FROM omie_customer_account_map WHERE account='oben' AND user_id='$U3';")
+eq "F2 a BASE traz o stale (300) — a view fresca é o que o oculta; ler a base seria fail-open" "$STALE_NA_BASE" "1"
+
+# F3 — a UNIQUE(user_id, account) é o que garante ≤1 vendedor por (user, oben): tentar 2ª linha oben deve
+#      violar unique_violation (SQLSTATE 23505). Falsifica a premissa do invariante-4 "ambíguo" na base.
+ERR=$(P -v VERBOSITY=verbose -c "INSERT INTO public.omie_customer_account_map (user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source) VALUES ('$U1','oben', 9999, 999, 'document');" 2>&1 || true)
+if echo "$ERR" | grep -qE "23505|uq_ocam_user_account"; then ok "F3 UNIQUE(user_id,account) impede 2ª linha oben → ambiguidade impossível NA BASE (SQLSTATE 23505)"; else bad "F3 esperava unique_violation (23505/uq_ocam_user_account), veio: $ERR"; fi
+
+# F4 — prova que a UNIQUE é REAL (dropa a constraint → o insert duplicado agora PASSA → assert vira vermelho).
+#      Restaura em seguida. Isto garante que F3 tem dente (não passou por acaso).
+P -q -c "ALTER TABLE public.omie_customer_account_map DROP CONSTRAINT uq_ocam_user_account;"
+if P -q -c "INSERT INTO public.omie_customer_account_map (user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source) VALUES ('$U1','oben', 9998, 998, 'document');" >/dev/null 2>&1; then
+  ok "F4 sabotagem confirmada: SEM a UNIQUE o duplicado (user1,oben) entra → 2 vendedores oben (o cenário que o invariante-4 fail-closa)"
+else
+  bad "F4 falsificação fraca: o insert duplicado falhou mesmo sem a constraint"
+fi
+P -q -c "DELETE FROM public.omie_customer_account_map WHERE omie_codigo_cliente=9998; ALTER TABLE public.omie_customer_account_map ADD CONSTRAINT uq_ocam_user_account UNIQUE (user_id, account);"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -775,3 +775,108 @@ describe('guardrail: fin-valor-cockpit lê o código do cliente pela view fresca
     ).not.toMatch(/from\("omie_clientes"\)/);
   });
 });
+
+// ── P0-B-bis ponta 2/2 (carteira-rebuild lê o VENDEDOR da proof account=oben, não do espelho) ──
+// Incidente: carteira 100% Hunter. Ponta 1 (#1293): o writer popula omie_codigo_vendedor na proof. Ponta 2
+// (esta): o rebuild passa a LER o vendedor da proof fresca omie_customer_account_map_fresco (account=oben)
+// via helper resolverVendedorObenPorUser (fail-closed em ambiguidade) — o espelho poluído omie_clientes
+// resta só como UNIVERSO (user_id, não-poluído), nunca mais como fonte de vendedor. A herança cross-account
+// do B-lite fica eliminada por construção (clone colacor_sc resolve AUSENTE na proof oben). Dois guards
+// fail-closed (Codex R2): proof vazia aborta; encolhimento >30% dos vendedores aborta. A paridade textual
+// aqui pega a reversão do deploy do Lovable (mesma armadilha do #1272). Ver handoff Fatia 4 P0.
+const CARTEIRA_REBUILD = 'supabase/functions/carteira-rebuild/index.ts';
+const VEND_OBEN_HELPER = 'src/lib/carteira/vendedor-oben.ts';
+
+describe('guardrail money-path: carteira-rebuild lê o vendedor da proof account=oben (P0-B-bis ponta 2/2)', () => {
+  const src = read(CARTEIRA_REBUILD);
+  const helper = read(VEND_OBEN_HELPER);
+
+  it('sentinela: leu os arquivos reais (edge + helper)', () => {
+    expect(src).toContain('computeCarteira');
+    expect(helper).toContain('resolverVendedorObenPorUser');
+  });
+
+  it('o helper puro existe e exporta resolverVendedorObenPorUser', () => {
+    expect(helper).toMatch(/export function resolverVendedorObenPorUser/);
+  });
+
+  it('o edge USA o helper espelhado (define MIRROR + chama), ≥2 menções', () => {
+    expect(src, 'edge não define mais o helper espelhado de vendedor oben').toMatch(/function resolverVendedorObenPorUser/);
+    expect(
+      src,
+      'REVERSÃO Lovable? o rebuild não chama mais resolverVendedorObenPorUser — vendedor voltou ao espelho?',
+    ).toMatch(/resolverVendedorObenPorUser\(/);
+    expect(count(src, 'resolverVendedorObenPorUser'), 'helper deve ser DEFINIDO e CHAMADO (≥2)').toBeGreaterThanOrEqual(2);
+  });
+
+  it('LÊ o vendedor da view fresca account=oben — NÃO o espelho poluído', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? o rebuild não lê mais o vendedor da proof fresca account=oben',
+    ).toMatch(/from\(['"]omie_customer_account_map_fresco['"]\)[\s\S]{0,220}\.eq\(['"]account['"],\s*['"]oben['"]\)/);
+    // O espelho só pode restar como UNIVERSO (user_id), NUNCA carregando o omie_codigo_vendedor poluído.
+    expect(
+      src,
+      'REGRESSÃO: o rebuild voltou a ler omie_codigo_vendedor do espelho poluído omie_clientes',
+    ).not.toMatch(/from\(['"]omie_clientes['"]\)\s*\.select\(['"]user_id,\s*omie_codigo_vendedor['"]\)/);
+    expect(
+      src,
+      'REGRESSÃO: a leitura de omie_clientes deixou de ser só o universo (user_id)',
+    ).toMatch(/from\(['"]omie_clientes['"]\)\s*\.select\(['"]user_id['"]\)/);
+  });
+
+  it('Guard A fail-closed: proof oben VAZIA aborta antes de escrever (não zera a carteira em silêncio)', () => {
+    expect(
+      src,
+      'REGRESSÃO: sumiu o Guard A — proof oben vazia (view sumiu/sync parado) zeraria a carteira pro Hunter em silêncio',
+    ).toMatch(/proofObenRows\.length === 0[\s\S]{0,220}return fail\(/);
+  });
+
+  it('Guard B fail-closed: encolhimento >30% dos vendedores atribuídos aborta (Codex R2 P1 fail-open)', () => {
+    expect(
+      src,
+      'REGRESSÃO: sumiu o Guard B anti-encolhimento — a view fresca encolhendo degradaria a carteira em silêncio',
+    ).toMatch(/novoOmieVisivel < base \* 0\.7[\s\S]{0,260}return fail\(/);
+  });
+
+  it('Guard A2 fail-closed: proof COM linhas mas ZERO vendedor resolvido aborta (Codex ponta-2 P1 bootstrap)', () => {
+    expect(
+      src,
+      'REGRESSÃO: sumiu o Guard A2 — no bootstrap (base=0) a proof sem vendedor manteria tudo Hunter em silêncio',
+    ).toMatch(/vendedorPorUser\.size === 0[\s\S]{0,260}return fail\(/);
+  });
+
+  it('owner account-safe: omie_vendedor_map filtrado por omie_account=oben (Codex ponta-2 P2)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o mapa código→owner voltou a ler TODAS as contas — um código colidente mapearia owner não-oben',
+    ).toMatch(/from\(['"]omie_vendedor_map['"]\)[\s\S]{0,120}\.eq\(['"]omie_account['"],\s*['"]oben['"]\)/);
+  });
+
+  it('paginação KEYSET (.gt + .limit), não offset .range: a proof fresca muda entre páginas (Codex ponta-2 P1)', () => {
+    // a leitura da proof oben tem de paginar por keyset (user_id > last) — offset .range pularia linhas
+    // quando o TTL expira/insere no meio da paginação.
+    expect(
+      src,
+      'REVERSÃO: a leitura da proof oben voltou a offset .range — keyset (.gt user_id + .limit) sumiu',
+    ).toMatch(/omie_customer_account_map_fresco['"]\)[\s\S]{0,260}\.gt\(['"]user_id['"][\s\S]{0,120}\.limit\(/);
+    expect(
+      src,
+      'REGRESSÃO: a leitura da proof oben ainda usa .range (offset) — não-determinístico sob TTL',
+    ).not.toMatch(/omie_customer_account_map_fresco['"]\)[\s\S]{0,260}\.range\(/);
+  });
+
+  it('universo é UNIÃO (espelho ∪ proof oben): cliente na proof sem linha no espelho não some (Codex ponta-2 P2)', () => {
+    expect(
+      src,
+      'REGRESSÃO: sumiu a união do universo com a proof oben — cliente oben fora do espelho sumiria da carteira',
+    ).toMatch(/for \(const r of proofObenRows\)[\s\S]{0,80}universoSet\.add/);
+  });
+
+  it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlockNamed(src, 'carteira-vendedor-oben'),
+      'edge divergiu do helper de src/ — o Lovable reescreveu a resolução de vendedor no deploy?',
+    ).toBe(mirrorBlockNamed(helper, 'carteira-vendedor-oben'));
+  });
+});

--- a/src/lib/carteira/__tests__/vendedor-oben.test.ts
+++ b/src/lib/carteira/__tests__/vendedor-oben.test.ts
@@ -1,0 +1,154 @@
+// src/lib/carteira/__tests__/vendedor-oben.test.ts
+import { describe, it, expect } from 'vitest';
+import { resolverVendedorObenPorUser } from '../vendedor-oben';
+import { computeCarteira } from '../rebuild-helpers';
+
+describe('resolverVendedorObenPorUser (money-path P0-B-bis — vendedor da carteira vem da proof oben)', () => {
+  it('user com 1 vendedor oben → resolve', () => {
+    const r = resolverVendedorObenPorUser([{ user_id: 'u1', omie_codigo_vendedor: 42 }]);
+    expect(r.vendedorPorUser.get('u1')).toBe(42);
+    expect(r.ambiguos).toEqual([]);
+  });
+
+  it('user com vendedor NULL na proof → órfão (não entra no mapa, sem vendedor herdado)', () => {
+    const r = resolverVendedorObenPorUser([{ user_id: 'u2', omie_codigo_vendedor: null }]);
+    expect(r.vendedorPorUser.has('u2')).toBe(false);
+    expect(r.ambiguos).toEqual([]);
+  });
+
+  it('AMBIGUIDADE (invariante 4): 2 vendedores oben DISTINTOS p/ o mesmo user → NÃO atribui (fail-closed) + registra', () => {
+    const r = resolverVendedorObenPorUser([
+      { user_id: 'u3', omie_codigo_vendedor: 42 },
+      { user_id: 'u3', omie_codigo_vendedor: 99 },
+    ]);
+    // precisão>recall: ambíguo não vira assignment (cai pro Hunter no rebuild), nunca chuta o 1º
+    expect(r.vendedorPorUser.has('u3')).toBe(false);
+    expect(r.ambiguos).toEqual(['u3']);
+  });
+
+  it('mesmo vendedor repetido (duplicata de linha, NÃO ambiguidade) → resolve normal', () => {
+    const r = resolverVendedorObenPorUser([
+      { user_id: 'u4', omie_codigo_vendedor: 42 },
+      { user_id: 'u4', omie_codigo_vendedor: 42 },
+    ]);
+    expect(r.vendedorPorUser.get('u4')).toBe(42);
+    expect(r.ambiguos).toEqual([]);
+  });
+
+  it('código inválido (0, negativo, não-inteiro-seguro) → ignorado (órfão), nunca casa vendedor errado', () => {
+    const r = resolverVendedorObenPorUser([
+      { user_id: 'zero', omie_codigo_vendedor: 0 },
+      { user_id: 'neg', omie_codigo_vendedor: -5 },
+      { user_id: 'unsafe', omie_codigo_vendedor: 2 ** 53 }, // > MAX_SAFE_INTEGER → perde precisão
+    ]);
+    expect(r.vendedorPorUser.size).toBe(0);
+    expect(r.ambiguos).toEqual([]);
+  });
+
+  it('código inválido + código válido no MESMO user → resolve pelo válido (o inválido não conta nem como ambiguidade)', () => {
+    const r = resolverVendedorObenPorUser([
+      { user_id: 'u5', omie_codigo_vendedor: 0 },
+      { user_id: 'u5', omie_codigo_vendedor: 42 },
+    ]);
+    expect(r.vendedorPorUser.get('u5')).toBe(42);
+    expect(r.ambiguos).toEqual([]);
+  });
+
+  it('múltiplos users independentes → resolvidos separadamente', () => {
+    const r = resolverVendedorObenPorUser([
+      { user_id: 'a', omie_codigo_vendedor: 1 },
+      { user_id: 'b', omie_codigo_vendedor: 2 },
+      { user_id: 'c', omie_codigo_vendedor: null },
+      { user_id: 'd', omie_codigo_vendedor: 7 },
+      { user_id: 'd', omie_codigo_vendedor: 8 }, // ambíguo
+    ]);
+    expect(r.vendedorPorUser.get('a')).toBe(1);
+    expect(r.vendedorPorUser.get('b')).toBe(2);
+    expect(r.vendedorPorUser.has('c')).toBe(false);
+    expect(r.vendedorPorUser.has('d')).toBe(false);
+    expect(r.ambiguos).toEqual(['d']);
+  });
+
+  it('user_id vazio/inválido → ignorado (não vira chave)', () => {
+    const r = resolverVendedorObenPorUser([
+      { user_id: '', omie_codigo_vendedor: 42 },
+    ]);
+    expect(r.vendedorPorUser.size).toBe(0);
+    expect(r.ambiguos).toEqual([]);
+  });
+
+  it('entrada vazia → mapa vazio (não quebra)', () => {
+    const r = resolverVendedorObenPorUser([]);
+    expect(r.vendedorPorUser.size).toBe(0);
+    expect(r.ambiguos).toEqual([]);
+  });
+});
+
+// Integração resolverVendedorObenPorUser × computeCarteira — prova o INVARIANTE 2 (herança cross-account
+// eliminada). Reproduz a montagem do edge: clientes[] = universo × vendedorPorUser(proof oben).
+describe('invariante 2: herança cross-account ELIMINADA (clone colacor_sc não injeta vendedor no gêmeo oben)', () => {
+  const HUNTER = 'hunter';
+  const montar = (universo: string[], proofOben: { user_id: string; omie_codigo_vendedor: number | null }[]) => {
+    const { vendedorPorUser } = resolverVendedorObenPorUser(proofOben);
+    return universo.map((u) => ({ customer_user_id: u, omie_codigo_vendedor: vendedorPorUser.get(u) ?? null }));
+  };
+
+  it('clone só-colacor_sc (AUSENTE na proof oben) + gêmeo oben órfão → gêmeo NÃO herda, vai pro Hunter', () => {
+    // Proof oben traz só o gêmeo, sem vendedor; o clone colacor_sc não tem linha oben (prod: 0/1633).
+    const clientes = montar(['clone_sc', 'gemeo_oben'], [{ user_id: 'gemeo_oben', omie_codigo_vendedor: null }]);
+    const r = computeCarteira(
+      clientes,
+      [{ omie_codigo_vendedor: 10, user_id: 'vendedora_sc' }], // a vendedora colacor_sc existe no map…
+      HUNTER,
+      new Map([['clone_sc', 'gemeo_oben']]),
+    );
+    const gemeo = r.assignments.find((a) => a.customer_user_id === 'gemeo_oben');
+    // …mas o clone resolve AUSENTE → não injeta o código 10 → fail-closed: Hunter, não a vendedora_sc.
+    expect(gemeo?.owner_user_id).toBe(HUNTER);
+    expect(gemeo?.source).toBe('hunter_orphan');
+  });
+
+  it('CONTRASTE (o bug que existia × o novo): o modelo espelho herdava cross-account; o modelo proof NÃO', () => {
+    // Modelo ANTIGO (espelho poluído): o clone trazia vendedor 10 (colacor_sc) → o gêmeo herdava (BUG).
+    const rAntigo = computeCarteira(
+      [{ customer_user_id: 'clone_sc', omie_codigo_vendedor: 10 }, { customer_user_id: 'gemeo_oben', omie_codigo_vendedor: null }],
+      [{ omie_codigo_vendedor: 10, user_id: 'vendedora_sc' }],
+      HUNTER,
+      new Map([['clone_sc', 'gemeo_oben']]),
+    );
+    expect(rAntigo.assignments.find((a) => a.customer_user_id === 'gemeo_oben')?.owner_user_id).toBe('vendedora_sc'); // herança cross-account
+
+    // Modelo NOVO (proof oben): o clone resolve ausente → o gêmeo NÃO herda o vendedor colacor_sc.
+    const rNovo = computeCarteira(
+      montar(['clone_sc', 'gemeo_oben'], [{ user_id: 'gemeo_oben', omie_codigo_vendedor: null }]),
+      [{ omie_codigo_vendedor: 10, user_id: 'vendedora_sc' }],
+      HUNTER,
+      new Map([['clone_sc', 'gemeo_oben']]),
+    );
+    expect(rNovo.assignments.find((a) => a.customer_user_id === 'gemeo_oben')?.owner_user_id).toBe(HUNTER); // corrigido
+  });
+
+  it('caminho feliz preservado: gêmeo COM vendedor oben real → herda o vendedor OBEN, eligible=true', () => {
+    const r = computeCarteira(
+      montar(['clone_sc', 'gemeo_oben'], [{ user_id: 'gemeo_oben', omie_codigo_vendedor: 20 }]),
+      [{ omie_codigo_vendedor: 20, user_id: 'vendedor_oben' }],
+      HUNTER,
+      new Map([['clone_sc', 'gemeo_oben']]),
+    );
+    const gemeo = r.assignments.find((a) => a.customer_user_id === 'gemeo_oben');
+    expect(gemeo?.owner_user_id).toBe('vendedor_oben');
+    expect(gemeo?.eligible).toBe(true);
+  });
+
+  it('user ambíguo na proof oben (2 vendedores) → não atribui → Hunter (precisão>recall)', () => {
+    const r = computeCarteira(
+      montar(['u_amb'], [
+        { user_id: 'u_amb', omie_codigo_vendedor: 30 },
+        { user_id: 'u_amb', omie_codigo_vendedor: 31 },
+      ]),
+      [{ omie_codigo_vendedor: 30, user_id: 'vA' }, { omie_codigo_vendedor: 31, user_id: 'vB' }],
+      HUNTER,
+    );
+    expect(r.assignments.find((a) => a.customer_user_id === 'u_amb')?.owner_user_id).toBe(HUNTER);
+  });
+});

--- a/src/lib/carteira/vendedor-oben.ts
+++ b/src/lib/carteira/vendedor-oben.ts
@@ -1,0 +1,45 @@
+// src/lib/carteira/vendedor-oben.ts
+// Money-path P0-B-bis (ponta 2/2): o vendedor da carteira vem da PROOF account-correta
+// (omie_customer_account_map_fresco, account=oben), NÃO do espelho poluído omie_clientes.
+//
+// Esta função resolve, por user_id, o omie_codigo_vendedor OBEN a partir das linhas frescas da proof.
+// Invariantes (Codex R2 / handoff):
+//  - Conta explícita: só recebe linhas já filtradas por account=oben (o caller filtra na query).
+//  - Fail-closed na ambiguidade (precisão>recall): user com 2+ vendedores oben DISTINTOS → NÃO atribui
+//    (cai pro Hunter no rebuild) e é registrado em `ambiguos`. Nunca chuta o primeiro.
+//  - Herança cross-account eliminada por construção: como o mapa só carrega vendedores OBEN, um clone
+//    colacor_sc (que não tem linha oben) resolve para AUSENTE — nunca injeta seu vendedor no gêmeo oben.
+//  - Só inteiro seguro positivo conta como vendedor (0/negativo/≥2^53 = não-atribuído), espelhando
+//    extrairCodigoVendedor do writer (defesa em profundidade na leitura).
+export interface OmieVendedorObenRow {
+  user_id: string;
+  omie_codigo_vendedor: number | null;
+}
+
+export interface VendedorObenResolvido {
+  /** user_id → código do vendedor oben, apenas para users com EXATAMENTE 1 vendedor distinto. */
+  vendedorPorUser: Map<string, number>;
+  /** users com 2+ vendedores oben distintos — fail-closed: não atribuídos (Hunter), registrados p/ auditoria. */
+  ambiguos: string[];
+}
+
+// MIRROR-START carteira-vendedor-oben — espelhado verbatim em supabase/functions/carteira-rebuild/index.ts
+export function resolverVendedorObenPorUser(rows: OmieVendedorObenRow[]): VendedorObenResolvido {
+  const codigoValido = (v: number | null): v is number =>
+    typeof v === 'number' && Number.isSafeInteger(v) && v > 0;
+  const porUser = new Map<string, Set<number>>();
+  for (const r of rows) {
+    if (!r.user_id) continue;
+    let s = porUser.get(r.user_id);
+    if (!s) { s = new Set<number>(); porUser.set(r.user_id, s); }
+    if (codigoValido(r.omie_codigo_vendedor)) s.add(r.omie_codigo_vendedor);
+  }
+  const vendedorPorUser = new Map<string, number>();
+  const ambiguos: string[] = [];
+  for (const [user, vends] of porUser) {
+    if (vends.size === 1) vendedorPorUser.set(user, [...vends][0]);
+    else if (vends.size > 1) ambiguos.push(user); // size 0 → órfão (fora do mapa, sem vendedor)
+  }
+  return { vendedorPorUser, ambiguos };
+}
+// MIRROR-END

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -1,11 +1,14 @@
 // supabase/functions/carteira-rebuild/index.ts
-// Reconstrói carteira_assignments a partir de omie_clientes × omie_vendedor_map.
-// Órfão (sem vendedor mapeado) → Hunter. Idempotente (upsert por customer_user_id).
+// Reconstrói carteira_assignments. UNIVERSO = user_ids de omie_clientes; VENDEDOR = proof account-correta
+// omie_customer_account_map_fresco (account=oben) — NÃO o espelho poluído (era 100% NULL → carteira 100%
+// Hunter, incidente P0-B-bis ponta 2/2). Órfão (sem vendedor oben) → Hunter. Idempotente (upsert/customer).
 //
-// Consolidação B-lite (spec 2026-06-13): consulta customer_canonical_alias (clones ATIVOS) e
-// canonicaliza clone→gêmeo — o gêmeo (cadastro Oben, com nome) herda o vendedor do clone e fica
-// eligible=true; o clone (cadastro Colacor SC, sem nome) fica eligible=false (escondido da tela,
-// preservado no banco). aliasMap vazio = comportamento legado + eligible explícito.
+// Consolidação B-lite (spec 2026-06-13): consulta customer_canonical_alias (clones ATIVOS) e canonicaliza
+// clone→gêmeo — o gêmeo (cadastro Oben) herda o vendedor do grupo e fica eligible=true; o clone (cadastro
+// Colacor SC) fica eligible=false (escondido, preservado). Como o vendedor agora vem SÓ da proof OBEN, o
+// clone colacor_sc resolve AUSENTE (não tem linha oben) → herança cross-account ELIMINADA por construção
+// (Codex R2 P1: filtro oben quebraria o B-lite — resolvido lendo o vendedor por-user, não trocando o
+// universo). aliasMap vazio = comportamento legado + eligible explícito.
 //
 // Setup pg_cron (manual pós-merge), roda após o sync do Omie:
 //   SELECT cron.schedule('carteira-rebuild-nightly', '30 7 * * *',
@@ -129,6 +132,31 @@ function computeCarteira(
   return { assignments, conflicts, orphanCount, chainViolations };
 }
 
+// Resolve o vendedor OBEN por user a partir da proof account-correta (ponta 2/2 do incidente carteira-Hunter).
+// Espelhado de src/lib/carteira/vendedor-oben.ts — paridade textual no CI (edge-money-path-invariants).
+interface OmieVendedorObenRow { user_id: string; omie_codigo_vendedor: number | null; }
+interface VendedorObenResolvido { vendedorPorUser: Map<string, number>; ambiguos: string[]; }
+// MIRROR-START carteira-vendedor-oben — espelhado verbatim de src/lib/carteira/vendedor-oben.ts
+function resolverVendedorObenPorUser(rows: OmieVendedorObenRow[]): VendedorObenResolvido {
+  const codigoValido = (v: number | null): v is number =>
+    typeof v === 'number' && Number.isSafeInteger(v) && v > 0;
+  const porUser = new Map<string, Set<number>>();
+  for (const r of rows) {
+    if (!r.user_id) continue;
+    let s = porUser.get(r.user_id);
+    if (!s) { s = new Set<number>(); porUser.set(r.user_id, s); }
+    if (codigoValido(r.omie_codigo_vendedor)) s.add(r.omie_codigo_vendedor);
+  }
+  const vendedorPorUser = new Map<string, number>();
+  const ambiguos: string[] = [];
+  for (const [user, vends] of porUser) {
+    if (vends.size === 1) vendedorPorUser.set(user, [...vends][0]);
+    else if (vends.size > 1) ambiguos.push(user); // size 0 → órfão (fora do mapa, sem vendedor)
+  }
+  return { vendedorPorUser, ambiguos };
+}
+// MIRROR-END
+
 const fail = (msg: string, status = 500) =>
   new Response(JSON.stringify({ ok: false, error: msg }), { status, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 
@@ -144,15 +172,19 @@ Deno.serve(async (req) => {
 
   // 1. Carregar mapa + hunter (tabelas pequenas). FAIL-CLOSED: erro de leitura estrutural aborta ANTES
   // de qualquer upsert — senão vendedorMap=[] mandaria a carteira inteira pro Hunter (P1.4 Codex).
+  // ACCOUNT-SAFE (Codex ponta-2 P2): omie_vendedor_map É por-conta (coluna omie_account; o MESMO vendedor
+  // tem código diferente em oben/colacor/colacor_sc). Como o código do cliente vem da proof OBEN, o mapa
+  // código→owner também tem de ser filtrado por oben — senão um código que colidisse entre contas mapearia
+  // um owner de outra conta. Fecha o contrato "owner é oben" que o código-account-safe sozinho não prova.
   const [mapRes, hunterRes] = await Promise.all([
-    supabase.from('omie_vendedor_map').select('omie_codigo_vendedor, user_id'),
+    supabase.from('omie_vendedor_map').select('omie_codigo_vendedor, user_id').eq('omie_account', 'oben'),
     supabase.from('company_config').select('value').eq('key', 'carteira_hunter_user_id').maybeSingle(),
   ]);
   if (mapRes.error) { console.error('[carteira-rebuild] load vendedor_map error:', mapRes.error.message); return fail(`vendedor_map: ${mapRes.error.message}`); }
   if (hunterRes.error) { console.error('[carteira-rebuild] load hunter error:', hunterRes.error.message); return fail(`hunter: ${hunterRes.error.message}`); }
   const vendedorMap = (mapRes.data ?? []) as VendedorMapRow[];
-  // vendedor_map vazio é anômalo (sempre há vendedores) e mandaria todos pro Hunter → aborta.
-  if (vendedorMap.length === 0) { console.error('[carteira-rebuild] vendedor_map vazio — abortando'); return fail('vendedor_map vazio (anômalo)'); }
+  // vendedor_map oben vazio é anômalo (sempre há vendedores oben) e mandaria todos pro Hunter → aborta.
+  if (vendedorMap.length === 0) { console.error('[carteira-rebuild] vendedor_map oben vazio — abortando'); return fail('vendedor_map oben vazio (anômalo)'); }
   // value pode vir como uuid puro ou JSON-quoted ("uuid") — normaliza removendo aspas.
   const rawHunter = (hunterRes.data?.value as string | null | undefined) ?? null;
   const hunterUserId = rawHunter ? (rawHunter.replace(/^"|"$/g, '').trim() || null) : null;
@@ -177,22 +209,86 @@ Deno.serve(async (req) => {
     }
   }
 
-  // omie_clientes pode ter milhares de linhas e o PostgREST limita o SELECT a ~1000 por página →
-  // paginar com range() até esgotar. .order p/ estabilidade (P1.5 Codex).
-  const clientes: OmieClienteRow[] = [];
+  // UNIVERSO da carteira = user_ids de omie_clientes UNIÃO os users da proof oben. O user_id NÃO é o dado
+  // poluído (só empresa_omie/omie_codigo_vendedor eram); o VENDEDOR não vem mais daqui (era 100% NULL →
+  // incidente carteira-Hunter) e sim da proof abaixo. A UNIÃO garante que um cliente presente na proof oben
+  // mas AUSENTE do espelho (cliente novo / atraso do espelho) não suma da carteira (Codex ponta-2 P2).
+  // Trocar o universo SÓ p/ a proof (redução 6909→5238 + reconciliação do upsert-only) é a Fatia 4 / DROP.
+  // Paginação KEYSET (.gt + .order + .limit), NÃO offset .range: a proof fresca muda entre páginas (TTL 7d
+  // expira no limite, sync concorrente insere) e offset deslocaria/pularia linhas (Codex ponta-2 P1).
   const PAGE = 1000;
-  for (let from = 0; ; from += PAGE) {
-    const { data, error } = await supabase
-      .from('omie_clientes')
-      .select('user_id, omie_codigo_vendedor')
-      .not('user_id', 'is', null)
-      .order('user_id', { ascending: true })
-      .range(from, from + PAGE - 1);
-    if (error) { console.error('[carteira-rebuild] load omie_clientes error:', error.message); return fail(error.message); }
-    const page = (data ?? []) as Array<{ user_id: string; omie_codigo_vendedor: number | null }>;
-    for (const r of page) clientes.push({ customer_user_id: r.user_id, omie_codigo_vendedor: r.omie_codigo_vendedor });
-    if (page.length < PAGE) break;
+  const ZERO_UUID = '00000000-0000-0000-0000-000000000000';
+  const universoSet = new Set<string>();
+  {
+    let last = ZERO_UUID;
+    for (;;) {
+      const { data, error } = await supabase
+        .from('omie_clientes')
+        .select('user_id')
+        .not('user_id', 'is', null)
+        .gt('user_id', last)
+        .order('user_id', { ascending: true })
+        .limit(PAGE);
+      if (error) { console.error('[carteira-rebuild] load universo (omie_clientes) error:', error.message); return fail(error.message); }
+      const page = (data ?? []) as Array<{ user_id: string }>;
+      for (const r of page) if (r.user_id) universoSet.add(r.user_id);
+      if (page.length < PAGE) break;
+      last = page[page.length - 1].user_id;
+    }
   }
+
+  // VENDEDOR account-correto: proof FRESCA omie_customer_account_map_fresco, account=oben (a carteira é do
+  // cadastro Oben canônico — design §4 #6). NUNCA o espelho poluído; NUNCA a base (a view filtra
+  // updated_at >= now()-7d — a base reabriria stale infinito). Keyset por user_id (único por conta na proof).
+  const proofObenRows: OmieVendedorObenRow[] = [];
+  {
+    let last = ZERO_UUID;
+    for (;;) {
+      const { data, error } = await supabase
+        .from('omie_customer_account_map_fresco')
+        .select('user_id, omie_codigo_vendedor')
+        .eq('account', 'oben')
+        .not('user_id', 'is', null)
+        .gt('user_id', last)
+        .order('user_id', { ascending: true })
+        .limit(PAGE);
+      if (error) { console.error('[carteira-rebuild] load proof oben error:', error.message); return fail(`proof oben: ${error.message}`); }
+      const page = (data ?? []) as OmieVendedorObenRow[];
+      for (const r of page) proofObenRows.push(r);
+      if (page.length < PAGE) break;
+      last = page[page.length - 1].user_id;
+    }
+  }
+  // Guard A (fail-closed anti-zeramento): proof oben SEM NENHUMA linha fresca é anômalo (sync da proof
+  // parou >7d, ou a view sumiu) → ABORTA antes de escrever, senão zerar-em-silêncio mandaria tudo pro Hunter.
+  if (proofObenRows.length === 0) {
+    console.error('[carteira-rebuild] proof oben (omie_customer_account_map_fresco) VAZIA — abortando (anômalo)');
+    return fail('proof oben vazia (omie_customer_account_map_fresco) — sync da proof parado?');
+  }
+  // União: adiciona os users da proof oben ao universo (cliente oben sem linha no espelho não some).
+  for (const r of proofObenRows) if (r.user_id) universoSet.add(r.user_id);
+
+  const { vendedorPorUser, ambiguos } = resolverVendedorObenPorUser(proofObenRows);
+  if (ambiguos.length) {
+    console.warn(`[carteira-rebuild] ${ambiguos.length} users com vendedor oben AMBÍGUO (fail-closed, não atribuídos):`, JSON.stringify(ambiguos.slice(0, 50)));
+  }
+  // Guard A2 (fail-closed anti-bootstrap-fail-open — Codex ponta-2 P1): proof COM linhas mas ZERO vendedor
+  // resolvido é o estado EXATO do incidente (writer #1293 não deployado/não rodou → vendedor 100% NULL na
+  // proof). O Guard B (relativo à saída) fica desativado no bootstrap (base=0), então SEM isto o rebuild
+  // retornaria ok e manteria tudo Hunter EM SILÊNCIO. O modo de falha é binário (o writer popula ~todos os
+  // clientes-com-vendedor ou nenhum) → size===0 é o sinal certo e força a ordem de deploy (ponta 1 antes).
+  if (vendedorPorUser.size === 0) {
+    console.error('[carteira-rebuild] proof oben SEM nenhum vendedor resolvido — writer omie-analytics-sync (#1293) deployado/rodou?');
+    return fail('proof oben sem vendedor resolvido — o writer omie-analytics-sync (#1293) foi deployado e rodou?');
+  }
+
+  // clientes[] = universo × vendedor-da-proof-oben. Ausência na proof → vendedor null → órfão/Hunter
+  // (degradação honesta). Clone colacor_sc (sem linha oben) resolve null → NÃO injeta seu vendedor no
+  // gêmeo oben na consolidação B-lite: a herança cross-account fica ELIMINADA por construção (invariante 2).
+  const clientes: OmieClienteRow[] = [...universoSet].map((user_id) => ({
+    customer_user_id: user_id,
+    omie_codigo_vendedor: vendedorPorUser.get(user_id) ?? null,
+  }));
 
   // Fornecedores fora da carteira (cliente_classificacao.excluir_da_carteira): entram com
   // eligible=false (combinado com o eligible-de-clone abaixo). FAIL-CLOSED: erro de leitura aborta
@@ -237,6 +333,26 @@ Deno.serve(async (req) => {
     last_synced_at: now,
   }));
 
+  // Guard B (fail-closed anti-encolhimento — Codex R2 P1: fail-open se a view fresca encolher): se a proof
+  // oben ENCOLHER (staleness parcial da view 7d), o nº de assignments com vendedor real (source=omie
+  // visível) despencaria e a carteira degradaria em silêncio. Compara o novo total com o ATUAL na tabela;
+  // queda >30% ABORTA sem escrever. Bootstrap-safe: hoje a carteira é 100% Hunter (base=0) → o 1º run
+  // pós-#1293 só CRESCE (não dispara). Ausência total (proof vazia) já foi barrada no Guard A.
+  const novoOmieVisivel = rows.filter((r) => r.source === 'omie' && r.eligible).length;
+  {
+    const { count: atual, error: cntErr } = await supabase
+      .from('carteira_assignments')
+      .select('*', { count: 'exact', head: true })
+      .eq('source', 'omie')
+      .eq('eligible', true);
+    if (cntErr) { console.error('[carteira-rebuild] count atual source=omie error:', cntErr.message); return fail(`count atual source=omie: ${cntErr.message}`); }
+    const base = atual ?? 0;
+    if (base > 0 && novoOmieVisivel < base * 0.7) {
+      console.error(`[carteira-rebuild] encolhimento suspeito de vendedores atribuídos: atual=${base} novo=${novoOmieVisivel} (<70%) — abortando sem escrever`);
+      return fail(`encolhimento suspeito da proof oben (vendedores visíveis ${base}→${novoOmieVisivel}) — não vou zerar a carteira`);
+    }
+  }
+
   let upserted = 0;
   for (let i = 0; i < rows.length; i += 500) {
     const chunk = rows.slice(i, i + 500);
@@ -249,5 +365,8 @@ Deno.serve(async (req) => {
 
   return new Response(JSON.stringify({
     ok: true, upserted, orphanCount, conflicts, hunterUserId, aliasesAtivos: aliasMap.size,
+    // observabilidade da fonte account-safe: quantos users tinham vendedor oben resolvido, quantos ambíguos
+    // (fail-closed), e o tamanho da proof lida — para provar que a carteira saiu do 100%-Hunter pós-#1293.
+    proofObenLinhas: proofObenRows.length, vendedoresObenResolvidos: vendedorPorUser.size, ambiguosCount: ambiguos.length,
   }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 });


### PR DESCRIPTION
## Ponta 2/2 do incidente carteira-Hunter: `carteira-rebuild` lê o vendedor da proof account=oben

**Money-path** (carteira → positivação → comissão). Fecha a 2ª ponta do incidente que o [#1293](../../pull/1293) abriu: a carteira estava 100% Hunter porque o vendedor (`recomendacoes.codigo_vendedor` do Omie) não era populado em lugar nenhum. O #1293 (ponta 1) fez o writer `omie-analytics-sync` popular `omie_codigo_vendedor` na **proof** `omie_customer_account_map`. Este PR (ponta 2) faz o `carteira-rebuild` **LER** o vendedor da proof account-correta em vez do espelho poluído — o "PR próprio" que o Codex R2 exigiu ao bloquear a inclusão no #1293.

### O que muda
`carteira-rebuild` passa a montar `clientes[]` com o vendedor vindo da view fresca `omie_customer_account_map_fresco` (`account='oben'`), resolvido por-user. O **universo** (a lista de clientes) continua vindo de `omie_clientes` (só os `user_id`, dado não-poluído); o `computeCarteira` (consolidação B-lite) fica **inalterado**.

### Como resolve os 3 P1 do Codex R2 (abordagem "manter universo, trocar só o vendedor")
- **P1-a (B-lite / herança cross-account)** → ELIMINADA por construção: o vendedor de cada user vem SÓ da conta oben. Um clone colacor_sc resolve AUSENTE na proof oben (fato psql-ro: dos 1633 aliases ativos, `clone_tem_linha_oben=0`, `canonico_tem_linha_oben=1633`) → não injeta seu vendedor no gêmeo. Teste de contraste prova bug-antigo-herda × novo-vai-pro-Hunter.
- **P1-b (redução 6909→5238 não reconciliada)** → EVITADA: mantenho o universo (6909), não troco para a proof, logo não há nada a reconciliar no upsert-only. A troca de universo + DROP do espelho é a Fatia 4 (fora daqui).
- **P1-c (fail-open se a view encolher)** → 2 guards fail-closed: **Guard A** (proof oben com 0 linhas frescas → aborta) e **Guard B** (vendedores atribuídos caem >30% vs a tabela atual → aborta). Bootstrap-safe (carteira hoje 100% Hunter → base=0 → 1º run só cresce).
- **Ambiguidade (precisão>recall)**: helper `resolverVendedorObenPorUser` — user com 2+ vendedores oben distintos → NÃO atribui (Hunter) + registra em `ambiguos`.

### Provas
- **vitest 96 verde**: helper (ambiguidade/órfão/código inválido/multi-user), integração invariante-2 (contraste), 7 canários textuais anti-reversão-Lovable (`edge-money-path-invariants.test.ts`).
- **PG17 10 asserts + falsificação** (`db/test-carteira-vendedor-oben-account-safe.sh`): a query `account=oben` isola conta E TTL; sem o filtro o vendedor colacor_sc vaza; UNIQUE(user_id,account) impede ambiguidade na base (F4 dropa a constraint e confirma o dente).
- **/codex challenge (gpt-5.6-sol, xhigh)** — bloqueou com 3 P1; 4 endereçados neste diff:
  - **[P1] bootstrap fail-open** (base=0 + vendedor NULL passava silencioso) → **Guard A2**: `vendedorPorUser.size===0` aborta e força a ordem de deploy.
  - **[P1] paginação offset** (view TTL muda entre páginas) → **keyset** (`.gt('user_id')+.order+.limit`) na proof e no universo.
  - **[P2] owner sem dimensão de conta** (`omie_vendedor_map` É por-conta) → filtro **`.eq('omie_account','oben')`**.
  - **[P2] cliente na proof some do espelho** → universo = **UNIÃO** (espelho ∪ proof oben).
  - **[P1 concorrência]** (2 runs intercalam upserts): **pré-existente** (o rebuild sempre foi cron-único sem lease; não é regressão deste PR; auto-corrige no próximo run). Fix adequado = lease/RPC transacional (migration) → **follow-up**.
  - **[P2]** Guard B mede efeito não saúde da proof (Guard A2 mitiga o bootstrap; baseline persistente = follow-up); upsert-only stale = Fatia 4.

### ⚠️ Deploy — ORDEM IMPORTA (edge, manual, Lovable)
Este edge só conserta a carteira se a proof já tiver vendedor. Sequência:
1. Deploy da **ponta 1** (`omie-analytics-sync`, #1293) pelo chat do Lovable — hoje ela ainda **não está no ar** (proof oben com vendedor 100% NULL, psql-ro 2026-07-11).
2. 1 run do cron da proof (05:00 UTC) → `fresco_oben_com_vendedor > 0`.
3. **Só então** deploy desta edge (`carteira-rebuild`) verbatim pelo chat do Lovable.
4. Rebuild roda (07:30 UTC) → carteira sai do 100%-Hunter.

Sem migration. Canário textual (`edge-money-path-invariants.test.ts`) trava a reversão do Lovable no CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
