### PR TITLE
feat(reposicao): resumo mostra o VALOR que o fusível barrou no item segurado

### DIFF
--- a/db/test-param-auto.sh
+++ b/db/test-param-auto.sh
@@ -94,6 +94,8 @@ echo "→ migration E (resumo 18h: rótulo = descrição do produto, fallback p/
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260619120000_param_auto_resumo_descricao.sql"
 echo "→ migration F (resumo: altas/reduções separadas + segurado pelo nome)…"
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql"
+echo "→ migration G (log grava valor barrado + tick mostra 'quis subir máx X → Y')…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260712140000_param_auto_log_valor_barrado_fusivel.sql"
 
 echo "→ seed dos cenários (view controlada + sku_parametros + pins + estoque/custo)…"
 P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/seed-param-auto.sql"
@@ -125,6 +127,9 @@ BEGIN
   ASSERT r.status='segurado', format('B FALHOU: status=% (esperado segurado)', r.status);
   SELECT estoque_maximo INTO r FROM public.sku_parametros WHERE sku_codigo_omie=1002;
   ASSERT r.estoque_maximo=100, format('B preservou FALHOU: max=% (esperado 100, não 400)', r.estoque_maximo);
+  -- B: o LOG agora grava o valor SUGERIDO barrado (400), mesmo o parâmetro ficando em 100 (migration G).
+  SELECT estoque_maximo_sugerido INTO r FROM public.reposicao_param_auto_log WHERE sku_codigo_omie='1002';
+  ASSERT r.estoque_maximo_sugerido=400, format('B sugerido FALHOU: %s (esperado 400: o valor que o fusível barrou, gravado no log)', r.estoque_maximo_sugerido);
 
   -- C: GIRO LENTO inalterado → sem_mudanca (NÃO loga). Prova que o gatilho de cobertura morreu:
   --    demanda 1/dia + máx 200 daria 200d de cobertura (>120) → a versão antiga seguraria; agora
@@ -351,10 +356,10 @@ BEGIN
   ASSERT position('Maiores altas:' IN v_msg) < position('Maiores reduções:' IN v_msg),
     'P-ORDEM FALHOU: "Maiores reduções" deveria vir DEPOIS de "Maiores altas"';
 
-  -- P-SEGURADO (o "confira" agora diz o quê): B listado pelo NOME sob "Segurados pelo fusível".
+  -- P-SEGURADO (o "confira" agora diz o quê E quanto): B pelo NOME + o VALOR BARRADO (máx 100→400).
   ASSERT position('Segurados pelo fusível (confira): 1' IN v_msg) > 0, 'P-SEGURADO FALHOU: contador do fusível ausente';
   ASSERT position('SKU-B salto>3x' IN v_msg) > 0,        'P-SEGURADO FALHOU: item segurado (B) não listado pelo nome';
-  ASSERT position('máx atual 100' IN v_msg) > 0,         'P-SEGURADO FALHOU: contexto (máx atual) do segurado ausente';
+  ASSERT position('quis subir máx 100 → 400' IN v_msg) > 0, 'P-BARRADO FALHOU: valor barrado (100→400) ausente no segurado (migration G)';
 
   -- P-SEM-CUSTO: L (aplicado, impacto NULL) NÃO é listado (sem custo), mas conta no "(+1 sem custo)".
   ASSERT position('SKU-L queda do máximo' IN v_msg) = 0, 'P-SEM-CUSTO FALHOU: L (impacto NULL) não deveria ser listado';
@@ -371,11 +376,37 @@ SELECT 'cron' AS k, count(*) AS n FROM cron.job WHERE jobname='reposicao-param-a
 SQL
 
 echo ""
-echo "→ FALSIFICAÇÃO (reverte à migration E: lista única DESC LIMIT 10 → prova o dente de reduções/segurado)…"
+echo "→ FALSIFICAÇÃO 1 (reverte o TICK à migration F: 'máx atual' em vez de 'quis subir') → dente do valor barrado…"
+# A F (#1302) lista o segurado pelo nome mas SEM o valor barrado ("máx atual N"). Reverter só o tick
+# deixa o CORE G gravando o sugerido no log (400), mas o tick F o IGNORA → "quis subir" some, o nome
+# permanece. Sentinela de dente = 'quis subir máx', string que SÓ a migration G emite.
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+DELETE FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
+UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=NULL
+  WHERE status='completo' AND data_negocio_brt=(now() AT TIME ZONE 'America/Sao_Paulo')::date;
+DO $$
+DECLARE v_msg text;
+BEGIN
+  PERFORM public.reposicao_param_auto_resumo_tick();
+  SELECT mensagem INTO v_msg FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
+  ASSERT position('quis subir máx' IN v_msg) = 0,
+    'FALSIFICAÇÃO FRACA: "quis subir" apareceria sem a migration G → P-BARRADO sem dente';
+  -- confirma que a reversão rodou: a F ainda lista o segurado pelo nome, mas no formato "máx atual".
+  ASSERT position('SKU-B salto>3x' IN v_msg) > 0 AND position('máx atual 100' IN v_msg) > 0,
+    'FALSIFICAÇÃO INCONCLUSIVA: a F deveria listar o segurado pelo nome com "máx atual 100"';
+  RAISE NOTICE 'OK falsificação 1: sem a migration G o segurado volta a "máx atual" (o valor barrado SOME → P-BARRADO VERMELHO)';
+END $$;
+SQL
+echo "→ restaura a migration G (tick com valor barrado)…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260712140000_param_auto_log_valor_barrado_fusivel.sql"
+
+echo ""
+echo "→ FALSIFICAÇÃO 2 (reverte à migration E: lista única DESC LIMIT 10 → prova o dente de reduções/segurado)…"
 # Sabotagem = voltar à versão ANTERIOR (E), que tem UMA lista "Maiores mudanças" sem seção de reduções
 # nem segurado-por-nome. Com só 4 aplicados (<10), a E até mostraria M na lista única — por isso a
 # sentinela de dente NÃO é 'SKU-M' (apareceria nas duas), e sim a SEÇÃO "Maiores reduções:" e o NOME
-# do segurado 'SKU-B', strings que SÓ a migration F emite.
+# do segurado 'SKU-B', strings que SÓ as migrations F/G emitem.
 P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260619120000_param_auto_resumo_descricao.sql"
 P -v ON_ERROR_STOP=1 -q <<'SQL'
 DELETE FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
@@ -396,12 +427,12 @@ BEGIN
   -- Confirma que a reversão REALMENTE rodou (a E emite a lista única "Maiores mudanças"):
   ASSERT position('Maiores mudanças:' IN v_msg) > 0,
     'FALSIFICAÇÃO INCONCLUSIVA: nem "Maiores mudanças" (rótulo da versão E) apareceu — a reversão não rodou';
-  RAISE NOTICE 'OK falsificação: sem a migration F o e-mail volta à lista única (reduções e segurado-por-nome SOMEM → P-REDUCOES/P-SEGURADO VERMELHOS)';
+  RAISE NOTICE 'OK falsificação 2: sem F/G o e-mail volta à lista única (reduções e segurado-por-nome SOMEM → P-REDUCOES/P-SEGURADO VERMELHOS)';
 END $$;
 SQL
 
-echo "→ restaura a migration F verdadeira…"
-P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260711193000_param_auto_resumo_altas_reducoes_segurado.sql"
+echo "→ restaura a migration G verdadeira…"
+P -v ON_ERROR_STOP=1 -f "$REPO_ROOT/supabase/migrations/20260712140000_param_auto_log_valor_barrado_fusivel.sql"
 
 echo ""
 echo "→ FALLBACK (descrição NULL/só-espaços → cai no código nas 3 superfícies, nunca rótulo vazio)…"
@@ -421,11 +452,33 @@ BEGIN
   ASSERT position('1001: PP' IN v_msg) > 0,          'FALLBACK FALHOU: descrição NULL (A) não caiu no código nas altas';
   ASSERT position('SKU-A normal' IN v_msg) = 0,      'FALLBACK FALHOU: A ainda mostra a descrição apagada';
   ASSERT position('1013: PP' IN v_msg) > 0,          'FALLBACK FALHOU: descrição só-espaços (M) não caiu no código nas reduções (nullif/btrim)';
-  ASSERT position('1002 (máx atual' IN v_msg) > 0,   'FALLBACK FALHOU: segurado B com descrição NULL não caiu no código';
+  ASSERT position('• 1002' IN v_msg) > 0,            'FALLBACK FALHOU: segurado B com descrição NULL não caiu no código';
+  ASSERT position('quis subir máx 100 → 400' IN v_msg) > 0, 'FALLBACK FALHOU: B (segurado) deveria manter o valor barrado junto do código';
   ASSERT position('SKU-F pin diferente' IN v_msg) > 0,'FALLBACK FALHOU: F (com descrição) deveria manter o texto';
   ASSERT position('• : PP' IN v_msg) = 0,            'FALLBACK FALHOU: rótulo vazio nas listas (money-path: ausente≠vazio)';
-  ASSERT position('•  (máx atual' IN v_msg) = 0,     'FALLBACK FALHOU: rótulo vazio no segurado';
+  ASSERT position(E'• \n' IN v_msg) = 0,             'FALLBACK FALHOU: rótulo vazio no segurado (bullet+espaço+newline)';
   RAISE NOTICE 'OK fallback: NULL/só-espaços caem no código (altas, reduções e segurado); com descrição mantém; sem rótulo vazio';
+END $$;
+SQL
+
+echo ""
+echo "→ DEGRADAÇÃO GRACIOSA (run gravado pelo core ANTIGO: sugerido NULL → 'máx atual', nunca '→ ?')…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+-- Simula um run gravado ANTES da migration G (sem o valor sugerido) — ex.: o run de hoje na prod.
+UPDATE public.reposicao_param_auto_log SET estoque_maximo_sugerido=NULL WHERE sku_codigo_omie='1002';
+DELETE FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
+UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=NULL
+  WHERE status='completo' AND data_negocio_brt=(now() AT TIME ZONE 'America/Sao_Paulo')::date;
+DO $$
+DECLARE v_msg text;
+BEGIN
+  PERFORM public.reposicao_param_auto_resumo_tick();
+  SELECT mensagem INTO v_msg FROM public.fornecedor_alerta WHERE tipo='param_auto_resumo';
+  ASSERT position('quis subir' IN v_msg) = 0,    'DEGRADAÇÃO FALHOU: sem sugerido não deveria dizer "quis subir"';
+  ASSERT position('máx atual 100' IN v_msg) > 0, 'DEGRADAÇÃO FALHOU: sem sugerido deveria cair em "máx atual 100" (só-nome)';
+  ASSERT position('→ ?' IN v_msg) = 0,           'DEGRADAÇÃO FALHOU: nunca mostrar "→ ?" (sugerido ausente = formato só-nome)';
+  ASSERT position('Segurados pelo fusível (confira): 1' IN v_msg) > 0, 'DEGRADAÇÃO FALHOU: o segurado ainda deve ser contado';
+  RAISE NOTICE 'OK degradação graciosa: run sem sugerido → "máx atual", sem "→ ?" feio';
 END $$;
 SQL
 

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **357** custom migrations totais
-- **1278** objetos esperados (criados por estas migrations)
+- **358** custom migrations totais
+- **1280** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 358
+  - `function`: 360
   - `rls_policy`: 285
   - `index`: 211
   - `cron_job`: 146
@@ -3060,6 +3060,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
+| `function` | `public.reposicao_param_auto_resumo_tick` | — |
+
+### `20260712140000_param_auto_log_valor_barrado_fusivel.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.atualizar_parametros_numericos_skus` | — |
 | `function` | `public.reposicao_param_auto_resumo_tick` | — |
 
 ## Próximos passos por status

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 357
+-- Total de custom migrations: 358
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -396,7 +396,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260710012337', 'carteira_saude_eligible_e_efeito_mensal', '20260710012337_carteira_saude_eligible_e_efeito_mensal.sql'),
   ('20260711090000', 'prime_fundacao', '20260711090000_prime_fundacao.sql'),
   ('20260711145000', 'v_grupo_contatos_fresca', '20260711145000_v_grupo_contatos_fresca.sql'),
-  ('20260711193000', 'param_auto_resumo_altas_reducoes_segurado', '20260711193000_param_auto_resumo_altas_reducoes_segurado.sql')
+  ('20260711193000', 'param_auto_resumo_altas_reducoes_segurado', '20260711193000_param_auto_resumo_altas_reducoes_segurado.sql'),
+  ('20260712140000', 'param_auto_log_valor_barrado_fusivel', '20260712140000_param_auto_log_valor_barrado_fusivel.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1665,7 +1666,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_staff_update', 'prime_beneficio_uso'),
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_cliente_read', 'prime_beneficio_uso'),
   ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', ''),
-  ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
+  ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', ''),
+  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'atualizar_parametros_numericos_skus', ''),
+  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2982,7 +2985,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_staff_update', 'prime_beneficio_uso'),
   ('prime_fundacao', 'rls_policy', 'public', 'prime_uso_cliente_read', 'prime_beneficio_uso'),
   ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', ''),
-  ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
+  ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', ''),
+  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'atualizar_parametros_numericos_skus', ''),
+  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260712140000_param_auto_log_valor_barrado_fusivel.sql
+++ b/supabase/migrations/20260712140000_param_auto_log_valor_barrado_fusivel.sql
@@ -1,0 +1,277 @@
+-- Reposição — resumo diário: mostrar O VALOR que o fusível barrou (não só o nome do item segurado)
+-- ============================================================================
+-- Pedido do founder: no e-mail, o item segurado deve dizer O QUE o fusível impediu — ex.:
+--   "SAYERMASSA JATOBA — quis subir máx 2 → 7 (barrado)" — pra o "confira" ser acionável.
+--
+-- PROBLEMA: o log (reposicao_param_auto_log) grava, para um SEGURADO, depois=antes e DESCARTA o
+--   valor sugerido que foi barrado (o core só persiste o sugerido implicitamente em 'aplicado', via
+--   depois=sug). Então o e-mail não tinha de onde ler "o que o fusível queria fazer".
+--
+-- CORREÇÃO (3 partes, money-path — toca o CORE que decide aplicar/segurar):
+--   (1) ALTER: 2 colunas novas no log — ponto_pedido_sugerido / estoque_maximo_sugerido (o que o
+--       cálculo SUGERIU, independente do status). Para segurado = o valor barrado. Nullable (linhas
+--       antigas ficam NULL — degradam honesto).
+--   (2) CORE atualizar_parametros_numericos_skus: grava d.pp_sug / d.max_sug no INSERT do log. Resto
+--       VERBATIM da versão viva em prod (pg_get_functiondef 2026-07-12, == BLOCO D 20260605150000,
+--       regra do fusível = só multiplicador; zero drift). Mudança ADITIVA: só acrescenta 2 colunas ao
+--       INSERT — não altera decisão, UPDATE de config, impacto nem gating.
+--   (3) TICK reposicao_param_auto_resumo_tick: na seção "Segurados pelo fusível", mostra
+--       "quis subir máx <antes> → <sugerido> (barrado; giro <d>/dia)". DEGRADAÇÃO GRACIOSA: se o
+--       sugerido faltar (run gravado pelo core ANTIGO, ex.: o de hoje), cai no formato só-nome
+--       "(máx atual <antes>, giro <d>/dia)" — nunca "→ ?" feio. Resto = o corpo do #1302
+--       (altas/reduções/fallback), INCLUÍDO aqui verbatim ("a última a recriar vence").
+--
+-- Ordem no bloco: ALTER antes do CORE (senão o INSERT referencia coluna inexistente em runtime).
+-- Provado em PostgreSQL 17 local (db/test-param-auto.sh): core grava sugerido (B→400) · tick mostra
+-- "quis subir máx 100 → 400" · degradação graciosa (sugerido NULL → só-nome) · falsificação (core não
+-- grava → valor barrado some; tick formato-#1302 → "quis subir" some).
+BEGIN;
+
+-- ── (1) Colunas do sugerido no log (o que o cálculo propôs; p/ segurado = o barrado) ──
+ALTER TABLE public.reposicao_param_auto_log
+  ADD COLUMN IF NOT EXISTS ponto_pedido_sugerido numeric,
+  ADD COLUMN IF NOT EXISTS estoque_maximo_sugerido numeric;
+
+-- ── (2) CORE: grava o sugerido no log (VERBATIM da prod EXCETO 2 colunas no INSERT) ──
+CREATE OR REPLACE FUNCTION public.atualizar_parametros_numericos_skus(p_empresa text, p_run_id uuid DEFAULT NULL)
+  RETURNS integer
+  LANGUAGE plpgsql
+  SET search_path TO 'public', 'pg_temp'
+  AS $$
+DECLARE
+  atualizados int := 0;
+  v_mult numeric := COALESCE((SELECT value::numeric FROM public.company_config WHERE key='param_auto_fusivel_mult'), 3);
+BEGIN
+  PERFORM set_config('app.param_auto', CASE WHEN p_run_id IS NULL THEN 'manual' ELSE 'auto' END, true);
+
+  DROP TABLE IF EXISTS tmp_param_decidido;
+  CREATE TEMP TABLE tmp_param_decidido ON COMMIT DROP AS
+  WITH base AS (
+    SELECT sp.id, sp.empresa, sp.sku_codigo_omie,
+           sp.ponto_pedido AS pp_antes, sp.estoque_minimo AS min_antes, sp.estoque_maximo AS max_antes,
+           sp.estoque_seguranca AS ss_antes, sp.cobertura_alvo_dias AS cob_antes,
+           sp.habilitado_reposicao_automatica AS habilitado,
+           COALESCE(sp.tipo_reposicao,'automatica') AS tipo,
+           v.sku_descricao, v.fornecedor_nome,
+           v.estoque_minimo_sugerido AS min_sug, v.ponto_pedido_sugerido AS pp_sug,
+           v.estoque_maximo_sugerido AS max_sug, v.estoque_seguranca_sugerido AS ss_sug,
+           v.cobertura_alvo_dias AS cob_sug,
+           v.demanda_media_diaria, v.demanda_sigma_diario, v.coef_variacao_ordem, v.num_ordens,
+           v.valor_total_90d, v.lead_time_medio, v.lead_time_desvio, v.lt_p95_dias, v.fonte_leadtime,
+           v.z_aplicado, v.classe_consolidada,
+           pin.ponto_pedido_rejeitado, pin.estoque_maximo_rejeitado
+    FROM public.sku_parametros sp
+    JOIN public.v_sku_parametros_sugeridos v
+      ON v.empresa = sp.empresa AND v.sku_codigo_omie = sp.sku_codigo_omie
+    LEFT JOIN public.reposicao_param_pin pin
+      ON pin.empresa = sp.empresa AND pin.sku_codigo_omie = sp.sku_codigo_omie::text
+    WHERE sp.empresa = p_empresa
+  )
+  SELECT b.*,
+    CASE
+      WHEN b.pp_sug IS NULL OR b.max_sug IS NULL OR b.min_sug IS NULL
+           OR b.ss_sug IS NULL OR b.cob_sug IS NULL THEN 'sem_mudanca'
+      WHEN b.pp_sug = 'NaN'::numeric OR b.max_sug = 'NaN'::numeric OR b.min_sug = 'NaN'::numeric
+           OR b.ss_sug = 'NaN'::numeric OR b.cob_sug = 'NaN'::numeric
+           OR b.min_sug < 0 OR b.pp_sug < 0 OR b.max_sug < 0 OR b.ss_sug < 0
+           OR b.max_sug < b.pp_sug OR b.pp_sug < b.min_sug OR b.cob_sug <= 0 THEN 'bloqueado_validacao'
+      WHEN b.max_antes IS NULL OR b.max_antes <= 0 THEN 'bloqueado_validacao'
+      WHEN b.ponto_pedido_rejeitado IS NOT NULL
+           AND round(b.pp_sug) = round(b.ponto_pedido_rejeitado)
+           AND round(b.max_sug) = round(b.estoque_maximo_rejeitado) THEN 'pinado'
+      WHEN round(b.pp_sug) = round(b.pp_antes) AND round(b.max_sug) = round(b.max_antes) THEN 'sem_mudanca'
+      WHEN b.max_antes > 0 AND round(b.max_sug) > v_mult * round(b.max_antes) THEN 'segurado'
+      ELSE 'aplicado'
+    END AS status
+  FROM base b;
+
+  UPDATE public.sku_parametros sp SET
+    sku_descricao = COALESCE(d.sku_descricao, sp.sku_descricao),
+    fornecedor_nome = COALESCE(d.fornecedor_nome, sp.fornecedor_nome),
+    demanda_media_diaria = d.demanda_media_diaria,
+    demanda_desvio_padrao = d.demanda_sigma_diario,
+    demanda_coef_variacao = d.coef_variacao_ordem,
+    demanda_dias_com_movimento = d.num_ordens,
+    valor_vendido_90d = d.valor_total_90d,
+    lt_medio_dias_uteis = d.lead_time_medio,
+    lt_desvio_padrao_dias = d.lead_time_desvio,
+    lt_p95_dias = d.lt_p95_dias,
+    fonte_leadtime = d.fonte_leadtime,
+    z_score = d.z_aplicado,
+    estoque_seguranca   = CASE WHEN d.status='aplicado' THEN d.ss_sug  ELSE sp.estoque_seguranca END,
+    ponto_pedido        = CASE WHEN d.status='aplicado' THEN d.pp_sug  ELSE sp.ponto_pedido END,
+    estoque_minimo      = CASE WHEN d.status='aplicado' THEN d.min_sug ELSE sp.estoque_minimo END,
+    cobertura_alvo_dias = CASE WHEN d.status='aplicado' THEN d.cob_sug ELSE sp.cobertura_alvo_dias END,
+    estoque_maximo      = CASE WHEN d.status='aplicado' THEN d.max_sug ELSE sp.estoque_maximo END,
+    ultima_atualizacao_calculo = NOW()
+  FROM tmp_param_decidido d WHERE sp.id = d.id;
+
+  SELECT count(*) FILTER (WHERE status='aplicado') INTO atualizados FROM tmp_param_decidido;
+
+  DELETE FROM public.reposicao_param_pin p
+  USING tmp_param_decidido d
+  WHERE p.empresa = d.empresa AND p.sku_codigo_omie = d.sku_codigo_omie::text
+    AND d.status = 'aplicado' AND d.ponto_pedido_rejeitado IS NOT NULL;
+
+  IF p_run_id IS NOT NULL THEN
+    INSERT INTO public.reposicao_param_auto_log (
+      run_id, empresa, sku_codigo_omie, sku_descricao, status,
+      ponto_pedido_antes, ponto_pedido_depois, estoque_minimo_antes, estoque_minimo_depois,
+      estoque_maximo_antes, estoque_maximo_depois, estoque_seguranca_antes, estoque_seguranca_depois,
+      cobertura_antes, cobertura_depois,
+      ponto_pedido_sugerido, estoque_maximo_sugerido,   -- NOVO: o que o cálculo propôs (p/ segurado = o barrado)
+      demanda_media_diaria, lt_medio_dias_uteis, classe_consolidada, z_score
+    )
+    SELECT p_run_id, d.empresa, d.sku_codigo_omie::text, d.sku_descricao, d.status,
+      d.pp_antes,  CASE WHEN d.status='aplicado' THEN d.pp_sug  ELSE d.pp_antes END,
+      d.min_antes, CASE WHEN d.status='aplicado' THEN d.min_sug ELSE d.min_antes END,
+      d.max_antes, CASE WHEN d.status='aplicado' THEN d.max_sug ELSE d.max_antes END,
+      d.ss_antes,  CASE WHEN d.status='aplicado' THEN d.ss_sug  ELSE d.ss_antes END,
+      d.cob_antes, CASE WHEN d.status='aplicado' THEN d.cob_sug ELSE d.cob_antes END,
+      d.pp_sug, d.max_sug,   -- NOVO: sugerido cru (independe do status; p/ segurado NÃO é depois=antes)
+      d.demanda_media_diaria, d.lead_time_medio, d.classe_consolidada, d.z_aplicado
+    FROM tmp_param_decidido d
+    WHERE d.status IN ('aplicado','segurado','pinado','bloqueado_validacao')
+      AND d.habilitado = true AND d.tipo = 'automatica';
+
+    WITH em_transito AS (
+      SELECT pcs2.empresa, pci.sku_codigo_omie::text AS sku_codigo_omie, SUM(pci.qtde_final) AS qtde
+      FROM public.pedido_compra_item pci
+      JOIN public.pedido_compra_sugerido pcs2 ON pcs2.id = pci.pedido_id
+      WHERE pcs2.empresa = p_empresa
+        AND pcs2.status IN ('aprovado_aguardando_disparo','disparado','concluido_recebido')
+        AND pcs2.data_ciclo >= (CURRENT_DATE - INTERVAL '7 days')
+      GROUP BY pcs2.empresa, pci.sku_codigo_omie
+    ),
+    posicao AS (
+      SELECT l.id AS log_id,
+             (COALESCE(sea.estoque_fisico,0) + COALESCE(sea.estoque_pendente_entrada,0)
+                + COALESCE(et.qtde,0)) AS pos,
+             ip.custo, ip.custo_fonte
+      FROM public.reposicao_param_auto_log l
+      LEFT JOIN public.sku_estoque_atual sea
+        ON sea.empresa = l.empresa AND sea.sku_codigo_omie = l.sku_codigo_omie
+      LEFT JOIN em_transito et
+        ON et.empresa = l.empresa AND et.sku_codigo_omie = l.sku_codigo_omie
+      LEFT JOIN LATERAL (
+        SELECT CASE WHEN ip0.cmc > 0 THEN ip0.cmc
+                    WHEN ip0.preco_medio > 0 THEN ip0.preco_medio
+                    ELSE NULL END AS custo,
+               CASE WHEN ip0.cmc > 0 THEN 'cmc'
+                    WHEN ip0.preco_medio > 0 THEN 'preco_medio'
+                    ELSE NULL END AS custo_fonte
+        FROM public.inventory_position ip0
+        WHERE ip0.omie_codigo_produto::text = l.sku_codigo_omie
+          AND ip0.account = lower(p_empresa)
+        LIMIT 1
+      ) ip ON true
+      WHERE l.run_id = p_run_id
+        AND l.status IN ('aplicado','segurado')
+    )
+    UPDATE public.reposicao_param_auto_log l SET
+      custo_unitario   = p.custo,
+      custo_fonte      = p.custo_fonte,
+      qtde_compra_antes  = CASE WHEN p.pos <= l.ponto_pedido_antes  THEN GREATEST(0, l.estoque_maximo_antes  - p.pos) ELSE 0 END,
+      qtde_compra_depois = CASE WHEN p.pos <= l.ponto_pedido_depois THEN GREATEST(0, l.estoque_maximo_depois - p.pos) ELSE 0 END,
+      impacto_rs = CASE WHEN p.custo IS NULL THEN NULL ELSE
+        ( (CASE WHEN p.pos <= l.ponto_pedido_depois THEN GREATEST(0, l.estoque_maximo_depois - p.pos) ELSE 0 END)
+        - (CASE WHEN p.pos <= l.ponto_pedido_antes  THEN GREATEST(0, l.estoque_maximo_antes  - p.pos) ELSE 0 END)
+        ) * p.custo END
+    FROM posicao p
+    WHERE l.id = p.log_id;
+  END IF;
+
+  RETURN atualizados;
+END;
+$$;
+
+-- ── (3) TICK: seção "Segurados" mostra o valor barrado (degradação graciosa se sugerido faltar) ──
+CREATE OR REPLACE FUNCTION public.reposicao_param_auto_resumo_tick()
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public', 'pg_temp'
+  AS $$
+DECLARE
+  r record;
+  v_hoje date := (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+  v_corpo text;
+  v_altas text;
+  v_reducoes text;
+  v_segurados text;
+  v_sem_efeito int;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext('param_auto_resumo'));
+  SELECT * INTO r FROM public.reposicao_param_auto_run
+    WHERE data_negocio_brt=v_hoje AND status='completo' AND resumo_enviado_em IS NULL
+    ORDER BY concluido_em DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN; END IF;
+  IF COALESCE(r.total_aplicados,0)=0 AND COALESCE(r.total_segurados,0)=0 THEN
+    UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=now() WHERE id=r.id;
+    RETURN;
+  END IF;
+
+  SELECT string_agg(format('• %s: PP %s→%s, máx %s→%s (R$ +%s)',
+            coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+            coalesce(ponto_pedido_antes::text,'—'), coalesce(ponto_pedido_depois::text,'—'),
+            coalesce(estoque_maximo_antes::text,'—'), coalesce(estoque_maximo_depois::text,'—'),
+            round(impacto_rs)::text), E'\n' ORDER BY impacto_rs DESC)
+    INTO v_altas FROM (
+      SELECT * FROM public.reposicao_param_auto_log
+      WHERE run_id=r.id AND status='aplicado' AND impacto_rs > 0
+      ORDER BY impacto_rs DESC LIMIT 5) t;
+
+  SELECT string_agg(format('• %s: PP %s→%s, máx %s→%s (R$ %s)',
+            coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+            coalesce(ponto_pedido_antes::text,'—'), coalesce(ponto_pedido_depois::text,'—'),
+            coalesce(estoque_maximo_antes::text,'—'), coalesce(estoque_maximo_depois::text,'—'),
+            round(impacto_rs)::text), E'\n' ORDER BY impacto_rs ASC)
+    INTO v_reducoes FROM (
+      SELECT * FROM public.reposicao_param_auto_log
+      WHERE run_id=r.id AND status='aplicado' AND impacto_rs < 0
+      ORDER BY impacto_rs ASC LIMIT 5) t;
+
+  -- Segurados: mostra O QUE o fusível barrou (máx atual → sugerido). Se o sugerido faltar (run gravado
+  -- pelo core antigo), cai no formato só-nome — nunca "→ ?".
+  SELECT string_agg(
+           CASE WHEN estoque_maximo_sugerido IS NOT NULL THEN
+             format(E'• %s\n  quis subir máx %s → %s (barrado; giro %s/dia)',
+               coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+               coalesce(estoque_maximo_antes::text,'—'), estoque_maximo_sugerido::text,
+               coalesce(round(demanda_media_diaria, 2)::text,'?'))
+           ELSE
+             format('• %s (máx atual %s, giro %s/dia)',
+               coalesce(nullif(btrim(sku_descricao), ''), sku_codigo_omie),
+               coalesce(estoque_maximo_antes::text,'—'),
+               coalesce(round(demanda_media_diaria, 2)::text,'?'))
+           END, E'\n' ORDER BY estoque_maximo_sugerido DESC NULLS LAST, estoque_maximo_antes DESC NULLS LAST)
+    INTO v_segurados FROM (
+      SELECT * FROM public.reposicao_param_auto_log
+      WHERE run_id=r.id AND status='segurado'
+      ORDER BY estoque_maximo_sugerido DESC NULLS LAST, estoque_maximo_antes DESC NULLS LAST LIMIT 5) t;
+
+  SELECT count(*) INTO v_sem_efeito FROM public.reposicao_param_auto_log
+    WHERE run_id=r.id AND status='aplicado' AND impacto_rs = 0;
+
+  v_corpo :=
+       format('%s parâmetros mudaram hoje (OBEN).', r.total_aplicados)
+    || format(E'\nImpacto estimado total: R$ %s%s', round(COALESCE(r.impacto_total_rs,0)),
+         CASE WHEN COALESCE(r.impacto_desconhecido_n,0)>0 THEN ' (+'||r.impacto_desconhecido_n||' sem custo)' ELSE '' END)
+    || CASE WHEN v_altas    IS NOT NULL THEN E'\n\nMaiores altas:\n'    || v_altas    ELSE '' END
+    || CASE WHEN v_reducoes IS NOT NULL THEN E'\n\nMaiores reduções:\n' || v_reducoes ELSE '' END
+    || format(E'\n\nSegurados pelo fusível (confira): %s', COALESCE(r.total_segurados,0))
+    || CASE WHEN v_segurados IS NOT NULL THEN E'\n' || v_segurados ELSE '' END
+    || CASE WHEN COALESCE(v_sem_efeito,0) > 0
+            THEN format(E'\n\n+%s ajuste(s) sem efeito na compra de hoje.', v_sem_efeito) ELSE '' END
+    || E'\n\nVeja e reverta em: /admin/reposicao/mudancas-automaticas';
+
+  INSERT INTO public.fornecedor_alerta (tipo, titulo, mensagem, empresa, severidade, status)
+    VALUES ('param_auto_resumo', 'Parâmetros de reposição — resumo do dia', v_corpo, r.empresa, 'info', 'pendente_notificacao');
+  UPDATE public.reposicao_param_auto_run SET resumo_enviado_em=now() WHERE id=r.id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.reposicao_param_auto_resumo_tick() FROM anon, authenticated, public;
+
+COMMIT;
+
+SELECT 'param_auto_log_valor_barrado_fusivel OK' AS status;


### PR DESCRIPTION
## Pedido do founder

No resumo diário, o item segurado pelo fusível deve dizer **o que o fusível impediu** — o valor que o cálculo quis aplicar e foi barrado (ex.: "quis subir máx 2 → 7") — não só o nome. É o que torna o "confira" acionável. (Follow-up do #1302, que passou a listar o segurado pelo nome.)

## Problema

O log (`reposicao_param_auto_log`) grava, para um **segurado**, `depois = antes` e **descarta o valor sugerido barrado** — o core só persistia o sugerido implicitamente em `aplicado` (via `depois = sug`). O e-mail não tinha de onde ler "o que o fusível queria fazer".

## Correção (3 partes — money-path, toca o core que decide aplicar/segurar)

1. **ALTER**: 2 colunas no log — `ponto_pedido_sugerido` / `estoque_maximo_sugerido` (o que o cálculo propôs, independente do status; para segurado = o valor barrado). Nullable → linhas antigas ficam NULL e degradam honesto.
2. **CORE** `atualizar_parametros_numericos_skus`: grava `pp_sug`/`max_sug` no INSERT do log. Resto **VERBATIM** da versão viva em prod (`pg_get_functiondef` 2026-07-12 == BLOCO D `20260605150000`, regra do fusível = só multiplicador; **zero drift**). Mudança **aditiva** — só acrescenta 2 colunas ao INSERT; não altera decisão, UPDATE de config, impacto nem gating.
3. **TICK**: na seção "Segurados pelo fusível", mostra `quis subir máx <antes> → <sugerido> (barrado; giro <d>/dia)`. **Degradação graciosa**: se o sugerido faltar (run gravado pelo core antigo — ex.: os runs de hoje pra trás), cai no formato só-nome `(máx atual <antes>, giro <d>/dia)` — nunca `→ ?` feio.

**Self-contained**: o tick aqui já inclui o corpo do #1302 (altas/reduções/fallback) — "a última a recriar vence". Aplicar **só esta** migration entrega tudo.

### Como fica (exemplo do harness de teste, dados fictícios)

```
Segurados pelo fusível (confira): 1
• SKU-B salto>3x
  quis subir máx 100 → 400 (barrado; giro 4.00/dia)
```

## Prova (PG17 local, `db/test-param-auto.sh`)

- ✅ Core grava o sugerido barrado no log (cenário B → 400).
- ✅ Tick mostra `quis subir máx 100 → 400`.
- ✅ **Degradação graciosa**: sugerido NULL → "máx atual", nunca "→ ?".
- ✅ **Falsificação 1** (reverte o tick à #1302): "quis subir" some, nome permanece → dente do valor barrado.
- ✅ **Falsificação 2** (reverte à lista única): reduções + segurado-por-nome somem.
- ✅ **Sabotagem direta do core** (não grava o sugerido → `NULL`): assert `B sugerido` falha, exit=3.

## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260712140000_param_auto_log_valor_barrado_fusivel.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Colar no SQL Editor e rodar.

Ordem: ALTER antes do core (senão o INSERT referencia coluna inexistente em runtime — já garantido dentro do mesmo `BEGIN`). Se o #1302 ainda não foi aplicado, **esta migration já inclui tudo dele** — não precisa aplicar os dois.

<details><summary>Validação pós-apply (read-only)</summary>

```sql
SELECT CASE
  WHEN EXISTS (SELECT 1 FROM information_schema.columns
               WHERE table_schema='public' AND table_name='reposicao_param_auto_log'
                 AND column_name='estoque_maximo_sugerido')
   AND pg_get_functiondef('public.reposicao_param_auto_resumo_tick()'::regprocedure) LIKE '%quis subir máx%'
  THEN '✅ coluna + tick com valor barrado aplicados'
  ELSE '❌ FALTANDO — migration não aplicada'
END AS status;
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
