### PR TITLE
feat(reposicao): religa a demanda de insumos de produção + fix #10 (PR-2)

### DIFF
--- a/db/perf-reposicao-religamento.sql
+++ b/db/perf-reposicao-religamento.sql
@@ -1,0 +1,65 @@
+-- db/perf-reposicao-religamento.sql — PR-2, prova de PERFORMANCE (furo #14).
+-- READ-ONLY. Medido em PROD (PG 17.6) via ~/.config/afiacao/psql-ro em 2026-07-11.
+-- ============================================================================
+-- VEREDITO: ✅ SEGUE PARA APPLY (sem materializar). O pior consumidor do fan-out
+-- (v_sku_parametros_sugeridos) fica ~3.1s pós-religamento — abaixo do alvo 4s e
+-- MUITO abaixo do statement_timeout=8s do role authenticated (PostgREST).
+-- ============================================================================
+--
+-- ⚠️ CAVEAT DE MÉTODO (honesto): `SET ROLE authenticated` é NEGADO ao claude_ro
+--    ("permission denied to set role"), então NÃO medi sob authenticated. Medi o
+--    custo ESTRUTURAL (o fan-out — o que o furo #14 teme) com claude_ro (BYPASSRLS).
+--    Isso é REPRESENTATIVO porque a RLS da folha venda_items_history é InitPlan-wrapped:
+--      staff_venda_items_history_select USING
+--        ( SELECT (has_role((SELECT auth.uid()),'master') OR has_role((SELECT auth.uid()),'employee')) )
+--    → avaliada 1× por scan (InitPlan), custo desprezível vs. o fan-out. A camada RLS
+--    NÃO é o gargalo aqui (≠ casos SECDEF-por-linha do database.md §4). Ainda assim, o
+--    GOLD STANDARD é medir pós-apply real sob authenticated no SQL Editor (bloco no fim).
+--
+-- ⚠️ O religamento NÃO está aplicado em prod (apply é do founder). As 4 views ainda leem
+--    v_venda_items_history_efetivo. Por isso o custo PÓS-religamento das views base foi
+--    medido com a def real + FROM trocado inline (pg_get_viewdef | sed), e o dos
+--    CONSUMIDORES (sugeridos/candidatos) foi DERIVADO do plano (as views base são
+--    computadas 1× dentro deles — Subquery Scan, não re-scan por referência textual).
+
+-- ── MEDIÇÕES (claude_ro, PG 17.6, empresa='OBEN', EXPLAIN ANALYZE BUFFERS) ──
+--
+-- FONTE (o que o religamento troca):
+--   v_venda_items_history_efetivo  (atual) ......  7.6 ms
+--   v_sku_demanda_efetiva          (nova)  .... 256.8 ms   (~34× a atual, mas 0.26s absoluto)
+--   → overhead por scan da folha = ~249 ms
+--
+-- VIEWS BASE — atual vs RELIGADA (def real, FROM→v_sku_demanda_efetiva, standalone):
+--   v_sku_demanda_estatisticas ....  11.8 ms → 264.4 ms   (+252 ms)
+--   v_sku_sigma_demanda ...........  297.4 ms → 553.2 ms  (+256 ms)
+--   v_sku_demanda_rajada (2 scans) . 241.7 ms → 809.2 ms  (+567 ms ≈ 2×)
+--   → TODAS < 1s religadas (folga 5-15× vs 4s).
+--
+-- CONSUMIDORES do fan-out (ATUAL / pré-religamento):
+--   v_sku_parametros_sugeridos ....... 2073.8 ms   (lê estatisticas+sigma+rajada, 1× cada via Subquery Scan)
+--   v_sku_candidatos_primeira_compra .. 759.4 ms   (lê sugeridos filtrado + CTE recorrencia_180d)
+--
+-- ── ESTIMATIVA PÓS-RELIGAMENTO (2 métodos convergentes) ──
+--   sugeridos: v_venda_items_history_efetivo é escaneada 4× na cadeia (est 1 + sigma 1 + rajada 2).
+--     • por-view (aditivo, 1× cada): 2073 + 252 + 256 + 567 ≈ 3148 ms
+--     • por-scan-da-folha:           2073 + 4 × 249         ≈ 3069 ms
+--     → ~3.1s. Sob authenticated: + InitPlans de RLS (desprezível). << 8s timeout.
+--   candidatos: 759 ms atual + 1 scan religado da recorrencia_180d (~+249 ms) ≈ ~1.0-1.5s (predicate pushdown reduz).
+--
+-- CONCLUSÃO: p95 << 4s. Materialização (fato privado grão empresa×sku×data×NF) NÃO é
+-- necessária no PR-2. Se o cockpit crescer muito, é candidata a PR-3 (design próprio) —
+-- sinalizado, não silenciado.
+
+-- ── GOLD STANDARD (opcional): medir pós-apply REAL sob authenticated, no SQL Editor do
+--    Lovable, DEPOIS de aplicar o religamento (o SQL Editor tem permissão de SET ROLE):
+BEGIN;
+SET LOCAL statement_timeout = '8s';
+SET LOCAL ROLE authenticated;
+SELECT set_config('request.jwt.claims', json_build_object(
+  'sub', (SELECT user_id::text FROM public.user_roles WHERE role IN ('employee','master') LIMIT 1),
+  'role','authenticated')::text, true);
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM v_sku_parametros_sugeridos WHERE empresa='OBEN';
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM v_sku_candidatos_primeira_compra WHERE empresa='OBEN';
+RESET ROLE;
+ROLLBACK;   -- read-only: nada é gravado
+-- Esperado: Execution Time < 4s em ambas, sem 'canceling statement due to statement timeout'.

--- a/db/perf-reposicao-religamento.sql
+++ b/db/perf-reposicao-religamento.sql
@@ -46,9 +46,13 @@
 --     → ~3.1s. Sob authenticated: + InitPlans de RLS (desprezível). << 8s timeout.
 --   candidatos: 759 ms atual + 1 scan religado da recorrencia_180d (~+249 ms) ≈ ~1.0-1.5s (predicate pushdown reduz).
 --
--- CONCLUSÃO: p95 << 4s. Materialização (fato privado grão empresa×sku×data×NF) NÃO é
--- necessária no PR-2. Se o cockpit crescer muito, é candidata a PR-3 (design próprio) —
--- sinalizado, não silenciado.
+-- CONCLUSÃO: custo estrutural estimado ~3.1s (pior consumidor), folga ~2.6× vs o timeout 8s.
+-- ⚠️ NÃO é um p95 sob authenticated+concorrência (Codex P2.2): os 2 métodos acima partem do
+-- MESMO incremento por scan (~249 ms) — corroboram, não são independentes; cache frio ou
+-- consultas concorrentes do cockpit podem elevar a cauda. O custo estrutural NÃO pede
+-- materialização, mas a CONFIRMAÇÃO p95 real é o bloco gold-standard abaixo (founder,
+-- pós-apply). Se lá estourar 4s, materializar (grão empresa×sku×data×NF) vira PR-3.
+-- Sinalizado, não silenciado.
 
 -- ── GOLD STANDARD (opcional): medir pós-apply REAL sob authenticated, no SQL Editor do
 --    Lovable, DEPOIS de aplicar o religamento (o SQL Editor tem permissão de SET ROLE):

--- a/db/preflight-reposicao-religamento.sql
+++ b/db/preflight-reposicao-religamento.sql
@@ -1,0 +1,35 @@
+-- db/preflight-reposicao-religamento.sql — READ-ONLY, rodar via psql-ro.
+-- PR-2 (money-path): congela o estado REAL da prod ANTES do religamento, para a
+-- Task 2 partir da def prod EXATA (não do repo — o #1292 tocou estas views com
+-- security_invoker; pode haver drift). Ver docs/superpowers/plans/2026-07-11-reposicao-pr2-religamento.md Task 0.
+
+-- P1: as 4 views leem v_venda_items_history_efetivo hoje? (o FROM a trocar) + reloptions (security_invoker).
+SELECT 'P1_'||c.relname AS chk,
+       (SELECT count(*) FROM regexp_matches(pg_get_viewdef(c.oid,true),'v_venda_items_history_efetivo','g'))::text AS from_hits,
+       c.reloptions::text AS reloptions   -- esperado: {security_invoker=true}
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public' AND c.relname IN
+  ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+ORDER BY c.relname;
+
+-- P2: md5 da def prod das 4 (p/ detectar drift entre capturas / comparar com o repo).
+SELECT 'P2_'||c.relname AS chk, md5(pg_get_viewdef(c.oid,true)) AS md5_prod
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public' AND c.relname IN
+  ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+ORDER BY c.relname;
+
+-- P3: v_sku_demanda_efetiva existe (PR-1 aplicado em prod)? (handoff dizia 0; msg do founder/plano diz aplicado)
+SELECT 'P3_demanda_efetiva' AS chk, count(*)::text AS existe FROM pg_views WHERE viewname='v_sku_demanda_efetiva';  -- esperado 1
+
+-- P4: v_sku_parametros_sugeridos lê as 4 (herança) — confirmar que NÃO referencia v_sku_demanda_efetiva ainda (herda pelo religamento das 4).
+SELECT 'P4_sugeridos_ja_le_efetiva' AS chk,
+       (SELECT count(*) FROM regexp_matches(pg_get_viewdef('v_sku_parametros_sugeridos',true),'v_sku_demanda_efetiva','g'))::text AS hits;  -- esperado 0
+
+-- P5: shape — nº e ordem de colunas de cada view (o CREATE OR REPLACE tem de preservar a ORDEM exata).
+SELECT 'P5_'||table_name AS chk, count(*)::text AS n_colunas,
+       string_agg(column_name, ',' ORDER BY ordinal_position) AS colunas_em_ordem
+FROM information_schema.columns
+WHERE table_schema='public' AND table_name IN
+  ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+GROUP BY table_name ORDER BY table_name;

--- a/db/reposicao-consolidacao-demanda.sql
+++ b/db/reposicao-consolidacao-demanda.sql
@@ -56,6 +56,13 @@ LEFT JOIN sku_substituicao s
 --    ÚNICA leitura direta que ela tem é a CTE precos_venda, que é PREÇO — e o
 --    custo/preço deve ser do SKU REAL, não misturar os antigos (money-path:
 --    ausente≠fabricar). Idem funções outlier/simulação: fora do de-para.
+--
+-- ⚠️ RELIGADO NO PR-2 (2026-07-11) — db/reposicao-religamento-insumos.sql troca a fonte
+--    destas 4 views de v_venda_items_history_efetivo → v_sku_demanda_efetiva (venda ⊕
+--    consumo de insumo). "A última recriação vence": se você REAPLICAR este arquivo isolado
+--    (manutenção/restauração), as 4 views VOLTAM à fonte antiga e os INSUMOS SOMEM do
+--    cockpit SILENCIOSAMENTE. → SEMPRE reaplique db/reposicao-religamento-insumos.sql DEPOIS
+--    (a versão canônica destas 4 views vive lá). Codex challenge P2.1.
 -- ─────────────────────────────────────────────────────────────────────────────
 
 -- 2.1 — v_sku_demanda_estatisticas (90d) · CTE vendas_por_ordem

--- a/db/reposicao-demanda-insumos-bom.sql
+++ b/db/reposicao-demanda-insumos-bom.sql
@@ -199,7 +199,8 @@ FROM v_venda_items_history_efetivo v
 JOIN v_pcp_malha_oben mo   ON mo.pai_oben = v.sku_codigo_omie
 JOIN omie_products ins     ON ins.omie_codigo_produto = mo.comp_oben
                           AND ins.account = 'oben'
-WHERE v.empresa = 'OBEN';    -- guard: nunca cruzar empresa
+WHERE v.empresa = 'OBEN'    -- guard: nunca cruzar empresa
+  AND v.quantidade > 0;   -- [Codex #10] devolução de tingidor não recompõe componente
 
 COMMENT ON VIEW v_sku_demanda_efetiva IS
   'Demanda = venda direta ⊕ consumo de insumo derivado da ficha técnica. A linha de consumo herda a NF do pai (num_ordens) e usa a unidade do insumo; valor de venda é NULL (insumo não gera receita). PR-2 aponta as 4 views estatísticas para cá.';

--- a/db/reposicao-religamento-insumos.sql
+++ b/db/reposicao-religamento-insumos.sql
@@ -1,0 +1,282 @@
+-- db/reposicao-religamento-insumos.sql — PR-2 (money-path).
+-- Religa as 4 views estatísticas na v_sku_demanda_efetiva (venda ⊕ consumo de insumo explodido).
+-- Único delta vs db/reposicao-consolidacao-demanda.sql (§2.1-2.4): o FROM de cada view passa a
+-- ler a fonte explodida v_sku_demanda_efetiva (no lugar da view de história efetiva "crua");
+-- alias (venda_items_history / vih) preservado → referências qualificadas seguem válidas; ZERO
+-- mudança de agregação/GROUP BY/colunas. security_invoker=true OBRIGATÓRIO em cada CREATE OR
+-- REPLACE (senão o replace ZERA reloptions e reabre o P0 de RLS que o #1292 fechou). É a versão
+-- CANÔNICA destas 4 views: aplicar DEPOIS da consolidação (a última recriação vence).
+-- NÃO vai em supabase/migrations/. Colar no SQL Editor do Lovable → Run.
+--
+-- Gerado por transformação determinística das defs §2.1-2.4 de reposicao-consolidacao-demanda.sql,
+-- confirmadas SEM DRIFT vs a def prod no pré-flight (db/preflight-reposicao-religamento.sql, 2026-07-11).
+-- ============================================================================
+
+-- 2.1 — v_sku_demanda_estatisticas (90d) · CTE vendas_por_ordem
+CREATE OR REPLACE VIEW v_sku_demanda_estatisticas WITH (security_invoker = true) AS
+ WITH vendas_por_ordem AS (
+         SELECT venda_items_history.empresa,
+            venda_items_history.sku_codigo_omie,
+            max(venda_items_history.sku_descricao) AS sku_descricao,
+            max(venda_items_history.sku_unidade) AS sku_unidade,
+            venda_items_history.nfe_chave_acesso,
+            venda_items_history.data_emissao,
+            sum(venda_items_history.quantidade) AS qtde_ordem,
+            sum(venda_items_history.valor_total) AS valor_ordem
+           FROM v_sku_demanda_efetiva venda_items_history
+          WHERE venda_items_history.data_emissao >= (CURRENT_DATE - '90 days'::interval)
+          GROUP BY venda_items_history.empresa, venda_items_history.sku_codigo_omie, venda_items_history.nfe_chave_acesso, venda_items_history.data_emissao
+        ), stats AS (
+         SELECT vendas_por_ordem.empresa,
+            vendas_por_ordem.sku_codigo_omie,
+            max(vendas_por_ordem.sku_descricao) AS sku_descricao,
+            max(vendas_por_ordem.sku_unidade) AS sku_unidade,
+            count(DISTINCT vendas_por_ordem.nfe_chave_acesso) AS num_ordens,
+            sum(vendas_por_ordem.qtde_ordem) AS demanda_total_90d,
+            sum(vendas_por_ordem.valor_ordem) AS valor_total_90d,
+            round(avg(vendas_por_ordem.qtde_ordem), 4) AS qtde_media_por_ordem,
+            round(stddev(vendas_por_ordem.qtde_ordem), 4) AS qtde_desvio_por_ordem,
+            max(vendas_por_ordem.data_emissao) AS ultima_venda_data,
+            round(sum(vendas_por_ordem.qtde_ordem) / 90.0, 4) AS demanda_media_diaria,
+                CASE
+                    WHEN avg(vendas_por_ordem.qtde_ordem) > 0::numeric AND count(*) >= 2 THEN round(stddev(vendas_por_ordem.qtde_ordem) / avg(vendas_por_ordem.qtde_ordem), 4)
+                    ELSE NULL::numeric
+                END AS coef_variacao_ordem
+           FROM vendas_por_ordem
+          GROUP BY vendas_por_ordem.empresa, vendas_por_ordem.sku_codigo_omie
+        )
+ SELECT empresa, sku_codigo_omie, sku_descricao, sku_unidade, num_ordens,
+    demanda_total_90d, valor_total_90d, qtde_media_por_ordem, qtde_desvio_por_ordem,
+    demanda_media_diaria, coef_variacao_ordem, ultima_venda_data
+   FROM stats;
+
+-- 2.2 — v_sku_sigma_demanda (180d) · CTE vendas_diarias
+CREATE OR REPLACE VIEW v_sku_sigma_demanda WITH (security_invoker = true) AS
+ WITH datas AS (
+         SELECT generate_series(CURRENT_DATE - '180 days'::interval, CURRENT_DATE - '1 day'::interval, '1 day'::interval)::date AS dt
+        ), vendas_diarias AS (
+         SELECT venda_items_history.empresa,
+            venda_items_history.sku_codigo_omie::text AS sku_codigo_omie,
+            venda_items_history.data_emissao AS dt,
+            sum(venda_items_history.quantidade) AS qtde
+           FROM v_sku_demanda_efetiva venda_items_history
+          WHERE venda_items_history.data_emissao >= (CURRENT_DATE - '180 days'::interval)
+          GROUP BY venda_items_history.empresa, (venda_items_history.sku_codigo_omie::text), venda_items_history.data_emissao
+        ), serie AS (
+         SELECT v.empresa,
+            v.sku_codigo_omie,
+            d.dt,
+            COALESCE(sum(vd.qtde), 0::numeric) AS qtde
+           FROM ( SELECT DISTINCT vendas_diarias.empresa,
+                    vendas_diarias.sku_codigo_omie
+                   FROM vendas_diarias) v
+             CROSS JOIN datas d
+             LEFT JOIN vendas_diarias vd ON vd.empresa = v.empresa AND vd.sku_codigo_omie = v.sku_codigo_omie AND vd.dt = d.dt
+          GROUP BY v.empresa, v.sku_codigo_omie, d.dt
+        )
+ SELECT empresa, sku_codigo_omie,
+    round(stddev_samp(qtde), 4) AS sigma_demanda_diaria,
+    round(avg(qtde), 4) AS media_demanda_diaria
+   FROM serie
+  GROUP BY empresa, sku_codigo_omie;
+
+-- 2.3 — v_sku_demanda_rajada (180d) · CTEs skus_ativos + vendas_diarias
+CREATE OR REPLACE VIEW v_sku_demanda_rajada WITH (security_invoker = true) AS
+ WITH datas_serie AS (
+         SELECT generate_series(CURRENT_DATE - '179 days'::interval, CURRENT_DATE::timestamp without time zone, '1 day'::interval)::date AS dt
+        ), skus_ativos AS (
+         SELECT DISTINCT venda_items_history.empresa,
+            venda_items_history.sku_codigo_omie,
+            max(venda_items_history.sku_descricao) AS sku_descricao,
+            max(venda_items_history.sku_unidade) AS sku_unidade
+           FROM v_sku_demanda_efetiva venda_items_history
+          WHERE venda_items_history.data_emissao >= (CURRENT_DATE - '180 days'::interval)
+          GROUP BY venda_items_history.empresa, venda_items_history.sku_codigo_omie
+        ), vendas_diarias AS (
+         SELECT venda_items_history.empresa,
+            venda_items_history.sku_codigo_omie,
+            venda_items_history.data_emissao AS dt,
+            sum(venda_items_history.quantidade) AS qtde_dia,
+            sum(venda_items_history.valor_total) AS valor_dia
+           FROM v_sku_demanda_efetiva venda_items_history
+          WHERE venda_items_history.data_emissao >= (CURRENT_DATE - '180 days'::interval)
+          GROUP BY venda_items_history.empresa, venda_items_history.sku_codigo_omie, venda_items_history.data_emissao
+        ), serie_completa AS (
+         SELECT s.empresa,
+            s.sku_codigo_omie,
+            s.sku_descricao,
+            s.sku_unidade,
+            d.dt,
+            COALESCE(v.qtde_dia, 0::numeric) AS qtde_dia,
+            COALESCE(v.valor_dia, 0::numeric) AS valor_dia
+           FROM skus_ativos s
+             CROSS JOIN datas_serie d
+             LEFT JOIN vendas_diarias v ON s.empresa = v.empresa AND s.sku_codigo_omie = v.sku_codigo_omie AND d.dt = v.dt
+        )
+ SELECT empresa,
+    sku_codigo_omie,
+    max(sku_descricao) AS sku_descricao,
+    max(sku_unidade) AS sku_unidade,
+    round(avg(qtde_dia), 4) AS demanda_media_diaria,
+    round(stddev(qtde_dia), 4) AS demanda_desvio_diario,
+    round(percentile_cont(0.90::double precision) WITHIN GROUP (ORDER BY (qtde_dia::double precision))::numeric, 2) AS p90_diario,
+    round(percentile_cont(0.95::double precision) WITHIN GROUP (ORDER BY (qtde_dia::double precision))::numeric, 2) AS p95_diario,
+    round(percentile_cont(0.99::double precision) WITHIN GROUP (ORDER BY (qtde_dia::double precision))::numeric, 2) AS p99_diario,
+    round(percentile_cont(0.90::double precision) WITHIN GROUP (ORDER BY (qtde_dia::double precision)) FILTER (WHERE qtde_dia > 0::numeric)::numeric, 2) AS p90_quando_vende,
+    round(percentile_cont(0.95::double precision) WITHIN GROUP (ORDER BY (qtde_dia::double precision)) FILTER (WHERE qtde_dia > 0::numeric)::numeric, 2) AS p95_quando_vende,
+    max(qtde_dia) AS pico_maximo_dia,
+    count(*) FILTER (WHERE qtde_dia > 0::numeric) AS dias_com_movimento,
+    sum(qtde_dia) AS qtde_total_180d,
+    round(sum(valor_dia), 2) AS valor_total_180d
+   FROM serie_completa
+  GROUP BY empresa, sku_codigo_omie;
+
+-- 2.4 — v_sku_candidatos_primeira_compra (180d) · CTE recorrencia_180d (alias vih)
+CREATE OR REPLACE VIEW v_sku_candidatos_primeira_compra WITH (security_invoker = true) AS
+ WITH recorrencia_180d AS (
+         SELECT vih.empresa,
+            vih.sku_codigo_omie,
+            count(DISTINCT vih.nfe_chave_acesso) AS nfs_180d,
+            count(DISTINCT to_char(vih.data_emissao::timestamp with time zone, 'YYYY-MM'::text)) AS meses_180d,
+            count(DISTINCT vih.cliente_cnpj_cpf) AS clientes_180d,
+            CURRENT_DATE - max(vih.data_emissao) AS dias_desde_ultima
+           FROM v_sku_demanda_efetiva vih
+          WHERE vih.data_emissao >= (CURRENT_DATE - '180 days'::interval) AND vih.quantidade > 0::numeric
+          GROUP BY vih.empresa, vih.sku_codigo_omie
+        ), elegiveis AS (
+         SELECT v.empresa,
+            v.sku_codigo_omie,
+            v.sku_descricao,
+            v.fornecedor_nome,
+            v.fornecedor_habilitado,
+            sp.habilitado_reposicao_automatica AS ja_habilitado,
+            v.classe_abc_proposta,
+            v.classe_xyz_proposta,
+            v.classe_consolidada,
+            v.demanda_media_diaria AS d,
+            v.lead_time_medio AS lt,
+            v.lt_total_teorico_dias_uteis,
+            v.demanda_sigma_diario,
+            v.coef_variacao_ordem,
+            v.dias_com_movimento,
+            v.lead_time_desvio,
+            v.lt_p95_dias,
+            v.fonte_leadtime,
+            v.z_aplicado,
+            v.preco_item_eoq,
+            v.preco_compra_real,
+            v.preco_venda_medio,
+            v.fonte_preco,
+            v.custo_pedido_aplicado,
+            v.custo_capital_efetivo_perc,
+            v.valor_total_90d,
+            v.valor_total_180d,
+            v.calculado_em,
+            r.nfs_180d,
+            r.meses_180d,
+            r.clientes_180d,
+            r.dias_desde_ultima,
+                CASE v.classe_abc_proposta
+                    WHEN 'A'::text THEN 30
+                    WHEN 'B'::text THEN 21
+                    ELSE 14
+                END AS cap_dias,
+                CASE
+                    WHEN v.preco_item_eoq > 0::numeric AND v.custo_capital_efetivo_perc > 0::numeric AND v.demanda_media_diaria > 0::numeric THEN ceil(sqrt(2.0 * (v.demanda_media_diaria * 252::numeric) * v.custo_pedido_aplicado / (v.custo_capital_efetivo_perc / 100.0 * v.preco_item_eoq)))
+                    ELSE 1::numeric
+                END AS qc_eoq
+           FROM v_sku_parametros_sugeridos v
+             JOIN recorrencia_180d r ON r.empresa = v.empresa AND r.sku_codigo_omie = v.sku_codigo_omie
+             JOIN sku_parametros sp ON sp.empresa = v.empresa AND sp.sku_codigo_omie = v.sku_codigo_omie
+             LEFT JOIN omie_products op ON op.omie_codigo_produto::text = v.sku_codigo_omie::text AND op.account = lower(v.empresa)
+          WHERE v.status_sugestao = 'AGUARDANDO_SEGUNDA_ORDEM'::text AND v.demanda_media_diaria > 0::numeric AND v.lead_time_medio IS NOT NULL AND v.fornecedor_nome IS NOT NULL AND v.fornecedor_habilitado IS TRUE AND v.preco_item_eoq > 0::numeric AND v.classe_abc_proposta IS NOT NULL AND (v.grupo_codigo IS NOT NULL OR v.fornecedor_nome <> 'RENNER SAYERLACK S/A'::text) AND r.meses_180d >= 2 AND r.nfs_180d >= 2 AND r.dias_desde_ultima <= 60 AND sp.ponto_pedido IS NULL AND sp.estoque_maximo IS NULL AND COALESCE(op.tipo_produto, op.metadata ->> 'tipo_produto'::text, ''::text) <> '04'::text
+        ), calc AS (
+         SELECT elegiveis.empresa,
+            elegiveis.sku_codigo_omie,
+            elegiveis.sku_descricao,
+            elegiveis.fornecedor_nome,
+            elegiveis.fornecedor_habilitado,
+            elegiveis.ja_habilitado,
+            elegiveis.classe_abc_proposta,
+            elegiveis.classe_xyz_proposta,
+            elegiveis.classe_consolidada,
+            elegiveis.d,
+            elegiveis.lt,
+            elegiveis.lt_total_teorico_dias_uteis,
+            elegiveis.demanda_sigma_diario,
+            elegiveis.coef_variacao_ordem,
+            elegiveis.dias_com_movimento,
+            elegiveis.lead_time_desvio,
+            elegiveis.lt_p95_dias,
+            elegiveis.fonte_leadtime,
+            elegiveis.z_aplicado,
+            elegiveis.preco_item_eoq,
+            elegiveis.preco_compra_real,
+            elegiveis.preco_venda_medio,
+            elegiveis.fonte_preco,
+            elegiveis.custo_pedido_aplicado,
+            elegiveis.custo_capital_efetivo_perc,
+            elegiveis.valor_total_90d,
+            elegiveis.valor_total_180d,
+            elegiveis.calculado_em,
+            elegiveis.nfs_180d,
+            elegiveis.meses_180d,
+            elegiveis.clientes_180d,
+            elegiveis.dias_desde_ultima,
+            elegiveis.cap_dias,
+            elegiveis.qc_eoq,
+            ceil(elegiveis.d * elegiveis.cap_dias::numeric) AS cap_cobertura,
+            ceil(elegiveis.d * elegiveis.lt) AS dem_lt
+           FROM elegiveis
+        )
+ SELECT empresa,
+    sku_codigo_omie,
+    sku_descricao,
+    fornecedor_nome,
+    fornecedor_habilitado,
+    classe_abc_proposta,
+    classe_xyz_proposta,
+    classe_consolidada,
+    d AS demanda_media_diaria,
+    lt AS lead_time_medio,
+    lt_total_teorico_dias_uteis,
+    demanda_sigma_diario,
+    coef_variacao_ordem,
+    dias_com_movimento,
+    lead_time_desvio,
+    lt_p95_dias,
+    fonte_leadtime,
+    z_aplicado,
+    preco_item_eoq,
+    preco_compra_real,
+    preco_venda_medio,
+    fonte_preco,
+    valor_total_90d,
+    valor_total_180d,
+    calculado_em,
+    'CANDIDATO_PRIMEIRA_COMPRA'::text AS status_sugestao,
+    nfs_180d AS recorrencia_nfs_180d,
+    meses_180d AS recorrencia_meses_180d,
+    clientes_180d AS recorrencia_clientes_180d,
+    dias_desde_ultima AS dias_desde_ultima_venda,
+    cap_dias AS primeira_compra_cap_dias,
+    GREATEST(1::numeric, LEAST(GREATEST(qc_eoq, 1::numeric), cap_cobertura)) AS primeira_compra_qtde,
+    GREATEST(1::numeric, LEAST(dem_lt, cap_cobertura)) AS primeira_compra_ponto_pedido,
+    GREATEST(1::numeric, LEAST(dem_lt, cap_cobertura)) + GREATEST(1::numeric, LEAST(GREATEST(qc_eoq, 1::numeric), cap_cobertura)) AS primeira_compra_estoque_maximo,
+    ja_habilitado
+   FROM calc;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- SEGURANÇA das 4 views religadas (P0 RLS — docs/agent/database.md §4; espelha
+-- db/reposicao-consolidacao-demanda.sql §2.5). O CREATE OR REPLACE acima repete
+-- WITH (security_invoker) obrigatório: sem ele o replace RESETA reloptions e a view volta a
+-- rodar como owner postgres (bypassa a RLS staff-only das tabelas-base → vaza
+-- venda/custo/margem a qualquer authenticated, INCLUI customer). REVOKE SELECT fecha a
+-- anon-key pública; authenticated MANTÉM (staff é authenticated; customer é filtrado pela
+-- RLS via invoker=on). Só as 4 religadas — a folha de história efetiva e a
+-- v_sku_demanda_efetiva têm a segurança nos seus próprios arquivos. Idempotente.
+-- ─────────────────────────────────────────────────────────────────────────────
+REVOKE SELECT ON public.v_sku_demanda_estatisticas, public.v_sku_sigma_demanda,
+                 public.v_sku_demanda_rajada, public.v_sku_candidatos_primeira_compra FROM anon, PUBLIC;
+GRANT  SELECT ON public.v_sku_demanda_estatisticas, public.v_sku_sigma_demanda,
+                 public.v_sku_demanda_rajada, public.v_sku_candidatos_primeira_compra TO authenticated;

--- a/db/test-reposicao-religamento.sh
+++ b/db/test-reposicao-religamento.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# Harness PG17 do RELIGAMENTO (PR-2) — prova EXECUTANDO que, ao trocar o FROM das 4
+# views estatísticas de v_venda_items_history_efetivo → v_sku_demanda_efetiva:
+#   A. RELIGAMENTO   — o INSUMO ganha demanda_total_90d > 0 (antes era ausente);
+#   B. NÃO-REGRESSÃO — SKU não-insumo (300) IDÊNTICO antes/depois nas 4 views (EXCEPT ALL);
+#   C. FIX #10       — devolução do pai (qtde<0) NÃO vira consumo negativo do insumo;
+#   D. GRADUAÇÃO     — o insumo herda 2 NFs distintas dos pais → num_ordens=2 (sai de AGUARDANDO);
+#   E. RLS           — security_invoker preservado nas 4 views recriadas.
+# + FALSIFICAÇÃO (um assert só vale se QUEBRA quando o guard some):
+#   SAB1 — v_sku_demanda_efetiva SEM o guard #10 → a devolução VAZA como consumo negativo (C1 quebraria);
+#   SAB2 — remover security_invoker de 1 view religada → E1 cai de 4 p/ 3.
+#
+# MONEY-PATH (muda comportamento de compra). SQL sob teste, aplicado NESTA ORDEM:
+#   db/reposicao-demanda-insumos-bom.sql (com fix #10)  →  db/reposicao-religamento-insumos.sql
+# Bootstrap: db/test-reposicao-demanda-insumos-bom.sh (mesmo initdb/snapshot/deps).
+# PORT=5444 (≠ 5442 consolidação · ≠ 5443 bom — roda em paralelo). Pré-req: brew install postgresql@17.
+#
+# ⚠️ security_invoker: o PG17 LOCAL grava reloptions como `security_invoker=true`; a PROD (Supabase)
+#    grava `=on`. O assert E aceita AMBOS (a validação pós-apply na prod casa `=on`).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5444
+DATA="$(mktemp -d /tmp/pgtest-relig.XXXXXX)/data"
+WORK="$(mktemp -d /tmp/relig-work.XXXXXX)"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")" "$WORK"; rm -f "${RR:-}"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=en_US.UTF-8 >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-relig.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres relig_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d relig_verify "$@"; }
+
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-relig.XXXXXX")"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ dependências (PCP + consolidação — vieram DEPOIS do dump)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/pcp-f1a-m1-staging.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/pcp-f1a-m2-nucleo.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/reposicao-consolidacao-demanda.sql"   # as 4 views v1: FROM v_venda_items_history_efetivo
+
+echo "→ PR-1 (com fix #10): v_pcp_malha_oben* + v_sku_demanda_efetiva…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/reposicao-demanda-insumos-bom.sql"
+
+# ── Helpers ──
+PASS=0
+Pq() { P -tA -q "$@"; }
+assert_eq() { if [ "$2" = "$3" ]; then PASS=$((PASS+1)); echo "  ✓ $1"; else echo "  ✗ $1: esperado='$2' obtido='$3'"; exit 1; fi; }
+# conta quantas das 4 views religadas têm security_invoker (aceita 'true' do PG17 e 'on' da prod).
+inv4() { Pq -c "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='public'
+    AND c.relname IN ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+    AND (c.reloptions @> ARRAY['security_invoker=true'] OR c.reloptions @> ARRAY['security_invoker=on']);"; }
+
+set_malha() {
+  P -v ON_ERROR_STOP=1 -q -c "
+    INSERT INTO pcp_malha_staging (omie_codigo_produto, empresa, payload, sync_run_id, synced_at)
+    VALUES ($1, 'colacor',
+            jsonb_build_object('ident', jsonb_build_object('idProduto', $1), 'itens', '$2'::jsonb),
+            1, now())
+    ON CONFLICT (omie_codigo_produto) DO UPDATE SET payload = EXCLUDED.payload;"
+}
+
+# ══════════════════════════════════════════════════════════════════════════
+# Fixtures (mesmos do PR-1 Step 1/5 + a DEVOLUÇÃO do pai p/ o fix #10)
+# ══════════════════════════════════════════════════════════════════════════
+echo "→ seed: pcp_run_logs (FK do sync_run_id=1 de set_malha)…"
+P -v ON_ERROR_STOP=1 -q -c "INSERT INTO pcp_run_logs (empresa, funcao, status) VALUES ('colacor','test-harness-relig','ok');"
+
+echo "→ catálogo colacor↔oben (pai 100/200 · insumo BASE 101/201 · sem-ficha 300)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+INSERT INTO omie_products (id, omie_codigo_produto, codigo, descricao, account, ativo, unidade)
+VALUES (gen_random_uuid(), 100, 'PRD_PAI',      'TINGIDOR X',        'colacor', true, 'UN'),
+       (gen_random_uuid(), 200, 'PRD_PAI',      'TINGIDOR X',        'oben',    true, 'UN'),
+       (gen_random_uuid(), 101, 'PRD_BASE',     'BASE',              'colacor', true, 'L'),
+       (gen_random_uuid(), 201, 'PRD_BASE',     'BASE',              'oben',    true, 'L'),
+       (gen_random_uuid(), 300, 'PRD_SEMFICHA', 'PRODUTO SEM FICHA', 'oben',    true, 'UN');
+SQL
+
+echo "→ ficha: pai 100 leva 0.9 L do insumo 101 (→ oben: pai 200 leva 0.9 L do 201)"
+set_malha 100 '[{"idProdMalha":101,"quantProdMalha":0.9,"unidProdMalha":"L","percPerdaProdMalha":0}]'
+
+echo "→ vendas: NFE-1 (pai 200 q1) · NFE-2 (pai 200 q2) · NFE-3 (300 q7) · NFE-DEV (pai 200 q-1 DEVOLUÇÃO)"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+INSERT INTO venda_items_history
+  (id, empresa, nfe_chave_acesso, data_emissao, sku_codigo_omie, sku_descricao,
+   sku_unidade, quantidade, valor_unitario, valor_total, created_at)
+VALUES
+  (gen_random_uuid(),'OBEN','NFE-1',   CURRENT_DATE - 10, 200, 'TINGIDOR X','UN',  1, 100,  100, now()),
+  (gen_random_uuid(),'OBEN','NFE-2',   CURRENT_DATE - 5,  200, 'TINGIDOR X','UN',  2, 100,  200, now()),
+  (gen_random_uuid(),'OBEN','NFE-3',   CURRENT_DATE - 3,  300, 'SEM FICHA', 'UN',  7,  10,   70, now()),
+  (gen_random_uuid(),'OBEN','NFE-DEV', CURRENT_DATE - 2,  200, 'TINGIDOR X','UN', -1, 100, -100, now());
+SQL
+
+echo "→ sanidade: a malha real enxerga o par 200→201"
+assert_eq "setup: par 200->201 elegivel" "1" "$(Pq -c "SELECT count(*) FROM v_pcp_malha_oben WHERE pai_oben=200 AND comp_oben=201;")"
+
+# ══════════════════════════════════════════════════════════════════════════
+# BASELINE das 4 views ANTES do religamento (ainda leem v_venda_items_history_efetivo),
+# JÁ COM os fixtures → o EXCEPT ALL do SKU não-insumo compara mesmos-dados/só-a-fonte-muda.
+# ══════════════════════════════════════════════════════════════════════════
+echo "→ baseline pré-religamento das 4 views (com fixtures)…"
+for v in v_sku_demanda_estatisticas v_sku_sigma_demanda v_sku_demanda_rajada v_sku_candidatos_primeira_compra; do
+  P -v ON_ERROR_STOP=1 -q -c "CREATE TABLE base_${v} AS SELECT * FROM ${v};"
+done
+
+echo "→ PRE: o insumo 201 AINDA não aparece (as 4 views leem só a venda direta)"
+assert_eq "PRE1 insumo 201 ausente antes do religamento" "0" \
+  "$(Pq -c "SELECT count(*) FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=201 AND empresa='OBEN';")"
+
+# ══════════════════════════════════════════════════════════════════════════
+# APLICAR O RELIGAMENTO (as 4 views passam a ler v_sku_demanda_efetiva)
+# ══════════════════════════════════════════════════════════════════════════
+echo "→ RELIGAMENTO…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/reposicao-religamento-insumos.sql"
+
+# ── A. RELIGAMENTO ──
+echo "→ A. o insumo 201 ganha demanda após religar"
+assert_eq "A1 insumo com demanda>0" "t" \
+  "$(Pq -c "SELECT COALESCE(demanda_total_90d,0)>0 FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=201 AND empresa='OBEN';")"
+# 0.9 (NFE-1) + 1.8 (NFE-2) = 2.7; a devolução NFE-DEV é filtrada pelo fix #10 (comparação NUMÉRICA, robusta a formatação)
+assert_eq "A2 demanda_total_90d = 2.7 (devolucao NAO conta)" "t" \
+  "$(Pq -c "SELECT demanda_total_90d = 2.7 FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=201 AND empresa='OBEN';")"
+
+# ── B. NÃO-REGRESSÃO (EXCEPT ALL bidirecional do SKU não-insumo 300, nas 4 views) ──
+echo "→ B. SKU não-insumo (300) idêntico antes/depois nas 4 views"
+for v in v_sku_demanda_estatisticas v_sku_sigma_demanda v_sku_demanda_rajada v_sku_candidatos_primeira_compra; do
+  got=$(Pq -c "SELECT count(*) FROM (
+                 (SELECT * FROM ${v} WHERE sku_codigo_omie::text='300' EXCEPT ALL SELECT * FROM base_${v} WHERE sku_codigo_omie::text='300')
+                 UNION ALL
+                 (SELECT * FROM base_${v} WHERE sku_codigo_omie::text='300' EXCEPT ALL SELECT * FROM ${v} WHERE sku_codigo_omie::text='300')) d;")
+  assert_eq "B:${v} nao-insumo (300) intacto" "0" "$got"
+done
+
+# ── C. FIX #10 ──
+echo "→ C. devolução do pai NÃO gera consumo negativo do insumo"
+assert_eq "C1 sem consumo negativo do insumo 201" "0" \
+  "$(Pq -c "SELECT count(*) FROM v_sku_demanda_efetiva WHERE sku_codigo_omie=201 AND quantidade<0;")"
+
+# ── D. GRADUAÇÃO ──
+echo "→ D. o insumo herda 2 NFs distintas (NFE-1, NFE-2) → num_ordens=2"
+assert_eq "D1 num_ordens=2 (devolucao NAO conta como ordem)" "2" \
+  "$(Pq -c "SELECT num_ordens FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=201 AND empresa='OBEN';")"
+
+# ── E. RLS ──
+echo "→ E. security_invoker preservado nas 4 views religadas"
+assert_eq "E1 as 4 views security_invoker" "4" "$(inv4)"
+
+# ══════════════════════════════════════════════════════════════════════════
+# FALSIFICAÇÃO — sabotar → exigir vermelho
+# ══════════════════════════════════════════════════════════════════════════
+echo "→ SAB1: v_sku_demanda_efetiva SEM o guard #10 → a devolução vaza como consumo negativo (C1 quebraria)"
+P -q -c "CREATE OR REPLACE VIEW v_sku_demanda_efetiva WITH (security_invoker = true) AS
+  SELECT id, empresa, nfe_chave_acesso, nfe_numero, nfe_serie, data_emissao,
+         cliente_codigo_omie, cliente_razao_social, cliente_cnpj_cpf, cliente_uf, cliente_cidade,
+         sku_codigo_omie, sku_codigo, sku_descricao, sku_ncm, sku_unidade,
+         quantidade, valor_unitario, valor_total, cfop, raw_data, created_at
+  FROM v_venda_items_history_efetivo
+  UNION ALL
+  SELECT md5(v.id::text || ':' || mo.comp_oben::text)::uuid, v.empresa,
+         v.nfe_chave_acesso, v.nfe_numero, v.nfe_serie, v.data_emissao,
+         v.cliente_codigo_omie, v.cliente_razao_social, v.cliente_cnpj_cpf, v.cliente_uf, v.cliente_cidade,
+         mo.comp_oben, ins.codigo, ins.descricao, ins.ncm, ins.unidade,
+         v.quantidade * mo.quantidade, NULL::numeric, NULL::numeric,
+         v.cfop, v.raw_data, v.created_at
+  FROM v_venda_items_history_efetivo v
+  JOIN v_pcp_malha_oben mo ON mo.pai_oben = v.sku_codigo_omie
+  JOIN omie_products ins ON ins.omie_codigo_produto = mo.comp_oben AND ins.account='oben'
+  WHERE v.empresa='OBEN';"   -- SEM 'AND v.quantidade > 0'
+neg=$(Pq -c "SELECT count(*) FROM v_sku_demanda_efetiva WHERE sku_codigo_omie=201 AND quantidade<0;")
+if [ "$neg" = "0" ]; then echo "  ✗ SAB1 INÚTIL: C1 não detecta a remoção do guard #10"; exit 1; fi
+echo "  ✓ S1 ok (sem o guard #10 a devolução vira consumo -0.9 → C1 protege de verdade; vazou $neg linha(s))"
+PASS=$((PASS+1))
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/reposicao-demanda-insumos-bom.sql"   # restaura a versão real (com guard)
+
+echo "→ SAB2: remover security_invoker de 1 view religada → E1 cai p/ 3"
+P -q -c "ALTER VIEW v_sku_demanda_estatisticas RESET (security_invoker);"   # equivale a um CREATE OR REPLACE sem o WITH
+got=$(inv4)
+if [ "$got" != "3" ]; then echo "  ✗ SAB2 INÚTIL: E1 não detectou a view sem security_invoker (obtido=$got, esperava 3)"; exit 1; fi
+echo "  ✓ S2 ok (view sem security_invoker → E1 cai p/ 3; logo E1 protege a RLS)"
+PASS=$((PASS+1))
+P -q -c "ALTER VIEW v_sku_demanda_estatisticas SET (security_invoker = true);"   # restaura
+
+# ── prova de que a sabotagem foi DESFEITA (não mascarada) ──
+echo "→ RESTORE: C1 volta a 0 e E1 volta a 4"
+assert_eq "R-C1 consumo negativo zerado de novo" "0" \
+  "$(Pq -c "SELECT count(*) FROM v_sku_demanda_efetiva WHERE sku_codigo_omie=201 AND quantidade<0;")"
+assert_eq "R-E1 as 4 views security_invoker de novo" "4" "$(inv4)"
+
+echo ""
+echo "PASS=$PASS"
+echo "✅ religamento (PR-2): demanda do insumo + não-regressão + fix#10 + graduação + RLS — provado com falsificação"

--- a/docs/handoff/2026-07-11-pr2-apply.md
+++ b/docs/handoff/2026-07-11-pr2-apply.md
@@ -55,7 +55,14 @@ O religamento (este PR) faz os **23 insumos ganharem DEMANDA**. Mas só aparecem
 - **PG17** `db/test-reposicao-religamento.sh` — PASS=15, exit 0 (asserts A-E + falsificação SAB1/SAB2 + restauração).
 - **Performance** `db/perf-reposicao-religamento.sql` — views base religadas < 1s; pior consumidor `v_sku_parametros_sugeridos` ~3.1s (<< 8s timeout). Sem materializar.
 - **Pré-flight** `db/preflight-reposicao-religamento.sql` — sem drift vs prod; validação reversa diff=0.
-- **Codex xhigh** — [integrar parecer].
+- **Codex xhigh** — **0 P1**; lógica central de religamento e fix #10 confirmados corretos (dupla contagem, não-regressão de demanda, shape, RLS, ausente≠zero, empresa). P2.1 (regressão por reaplicar consolidação) e P2.2 (perf não-p95) **mitigados neste PR**; demais verificados em prod (0 casos) → seção Vigilância.
+
+## Vigilância (Codex challenge — verificado em prod 2026-07-11: 0 casos hoje, guard de futuro)
+- **BOM multinível** (P2.3→P3): **0** insumos elegíveis são também pai. A explosão de 1 nível basta hoje. Se um insumo virar semiacabado (ganhar ficha), a demanda do 2º nível não seria gerada → subcompra. Vigiar ao cadastrar fichas.
+- **NF nula no pai** (#11/P3.3): **0** vendas positivas de pai sem NF. Se surgir, o insumo herda 0 ordens → preso em `AGUARDANDO_SEGUNDA_ORDEM`. Vigiar.
+- **Unidade SKU-ambos** (#13/P3.4): **5** SKUs são vendidos E insumos; **0** com unidade venda≠estoque. Se surgir divergência, a soma mistura unidades. Vigiar.
+- **2 pais consolidados** (P3.2): consolidação N→1 + BOM pode fundir receitas de fichas diferentes (supercompra). Não demonstrado nos dados atuais; limitação estrutural do PR-1/consolidação.
+- **Classe ABC** (P3.1): a ABC é por **faturamento acumulado** (Pareto — a def usa `OVER`+acumulado, sem `ntile`/`percent_rank`) → adicionar insumos com receita NULL/0 **não altera o total nem os acumulados dos SKUs vendidos** → classe dos vendidos preservada por construção (≠ o deslocamento que `ntile` causaria). A classe do próprio insumo (cauda/C) é calibração downstream, coberta pela curadoria (`minimo_forcado_manual`).
 
 ## Rollback
 Reverter é re-aplicar `db/reposicao-consolidacao-demanda.sql` (as 4 views voltam a `FROM v_venda_items_history_efetivo`) — a última recriação vence. Nada destrutivo (só troca de fonte das views; zero DDL de tabela/dado).

--- a/docs/handoff/2026-07-11-pr2-apply.md
+++ b/docs/handoff/2026-07-11-pr2-apply.md
@@ -1,0 +1,61 @@
+# Handoff de APPLY — PR-2: religamento da demanda de insumos + fix #10
+
+> Money-path PLENO (muda comportamento de compra). Provado: PG17 (PASS=15, falsificação) + performance (< 4s) + Codex xhigh. **Apply é MANUAL no SQL Editor do Lovable** (não vai em `supabase/migrations/`). Frontend NÃO muda (views backend puro; o motor herda) → **sem Publish, sem deploy de edge**.
+
+## TL;DR do que aplicar
+1. **SQL Editor → cole `db/reposicao-demanda-insumos-bom.sql` → Run** (re-aplica `v_sku_demanda_efetiva` COM o fix #10; idempotente).
+2. **SQL Editor → cole `db/reposicao-religamento-insumos.sql` → Run** (as 4 views passam a ler `v_sku_demanda_efetiva`).
+3. **SQL Editor → cole o bloco de validação abaixo → Run** (confirma o efeito, read-only).
+
+**Ordem OBRIGATÓRIA:** o `bom.sql` (fix #10) ANTES do religamento — senão as 4 views leriam a fonte com o furo #10 aberto por uma janela.
+
+## Pré-requisito (já satisfeito)
+- ✅ **PR-1 aplicado** em prod (`v_sku_demanda_efetiva` existe — confirmado via psql-ro 2026-07-11). O passo 1 acima é um `CREATE OR REPLACE` que só ACRESCENTA o guard `AND v.quantidade > 0` — não recria estrutura nova.
+
+## Validação pós-apply (READ-ONLY — cole no SQL Editor)
+```sql
+-- V1. security_invoker preservado nas 4 views (prod grava 'on', NÃO 'true' — não estranhe)
+SELECT 'V1_security_invoker' AS chk, count(*)::text AS obtido, '4' AS esperado
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public'
+  AND c.relname IN ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+  AND c.reloptions @> ARRAY['security_invoker=on']
+UNION ALL
+-- V2. o BASE PARA TINGIMIX (8689961993) GANHOU demanda (antes do religamento = ausente)
+SELECT 'V2_base_demanda_media_diaria', COALESCE(round(demanda_media_diaria,3)::text,'(ausente)'), '> 0'
+FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=8689961993 AND empresa='OBEN'
+UNION ALL
+-- V3. fix #10: nenhuma linha de CONSUMO com quantidade negativa (devolução não recompõe insumo)
+SELECT 'V3_consumo_negativo', count(*)::text, '0'
+FROM v_sku_demanda_efetiva WHERE quantidade < 0 AND valor_total IS NULL
+UNION ALL
+-- V4. NÃO-REGRESSÃO: distribuição de classes dos SKUs vendidos inalterada
+--     (baseline pré-apply 2026-07-11: A=68, B=90, C=164; os insumos NOVOS entram além disso)
+SELECT 'V4_classe_'||classe_abc_proposta, count(*)::text,
+       CASE classe_abc_proposta WHEN 'A' THEN '>=68' WHEN 'B' THEN '>=90' ELSE '>=164' END
+FROM v_sku_classificacao_abc_xyz WHERE empresa='OBEN' GROUP BY classe_abc_proposta
+UNION ALL
+-- V5. quantos dos 23 insumos ganharam demanda E estão SUGERÍVEIS (têm lead time → viram ponto_pedido)
+SELECT 'V5_insumos_sugeriveis', (
+  SELECT count(DISTINCT s.sku_codigo_omie)::text FROM v_sku_parametros_sugeridos s
+  JOIN (SELECT DISTINCT comp_oben FROM v_pcp_malha_oben) i ON i.comp_oben = s.sku_codigo_omie
+  WHERE s.empresa='OBEN'), '~4 hoje (ver nota)'
+ORDER BY 1;
+```
+
+**Esperado:** V1=4 · V2 demanda > 0 · V3=0 · V4 classes ≥ baseline (vendidos intactos) · V5 = os insumos com lead time.
+
+## ⚠️ Expectativa honesta — "ganhar demanda" ≠ "aparecer no cockpit já"
+O religamento (este PR) faz os **23 insumos ganharem DEMANDA**. Mas só aparecem no cockpit os que forem **COMPRÁVEIS** (têm lead time = linha em `sku_grupo_producao` + fornecedor). Medido em prod (2026-07-11): **dos 23, só ~4 têm lead time hoje**; os outros ~19 ganham demanda mas ficam `SEM_LEADTIME_DEFINIDO` → o motor não os dimensiona (lição `docs/agent/reposicao.md`: *consolidar/religar demanda não basta — o destino precisa estar comprável*).
+- **Fluxo até o cockpit:** religamento (feito) → insumo com lead time entra em `v_sku_parametros_sugeridos` → cold-start (cron 08:15) / função de aplicação popula `sku_parametros.ponto_pedido` → motor `gerar_pedidos_sugeridos_ciclo` (cron 2h) inclui quando estoque ≤ ponto. **Não é instantâneo** — depende dos crons rodarem (ou recálculo manual na tela de Reposição).
+- **Setup dos 19 sem lead time = curadoria/próximo PR** (fornecedor + grupo), fora do escopo do religamento.
+- **Curadoria dos ~5 insumos caros:** aplicar `minimo_forcado_manual` (o motor honra o piso de quantidade; visibilidade + decisão humana protege — spec §3).
+
+## Provas (anexas ao PR)
+- **PG17** `db/test-reposicao-religamento.sh` — PASS=15, exit 0 (asserts A-E + falsificação SAB1/SAB2 + restauração).
+- **Performance** `db/perf-reposicao-religamento.sql` — views base religadas < 1s; pior consumidor `v_sku_parametros_sugeridos` ~3.1s (<< 8s timeout). Sem materializar.
+- **Pré-flight** `db/preflight-reposicao-religamento.sql` — sem drift vs prod; validação reversa diff=0.
+- **Codex xhigh** — [integrar parecer].
+
+## Rollback
+Reverter é re-aplicar `db/reposicao-consolidacao-demanda.sql` (as 4 views voltam a `FROM v_venda_items_history_efetivo`) — a última recriação vence. Nada destrutivo (só troca de fonte das views; zero DDL de tabela/dado).

--- a/docs/handoff/2026-07-11-pr2-religamento-handoff.md
+++ b/docs/handoff/2026-07-11-pr2-religamento-handoff.md
@@ -1,0 +1,54 @@
+# Handoff — PR-2: religamento da demanda de insumos + fix #10
+
+> Briefing determinístico para uma SESSÃO NOVA. Confira cada bloco por comando (não confie de memória). Contexto completo no spec — leia-o primeiro.
+
+## 1. Objetivo desta sessão (UMA entrega)
+
+**Executar o plano `docs/superpowers/plans/2026-07-11-reposicao-pr2-religamento.md`** (subagent-driven) e entregar o **PR-2 mergeado e provado**: religar as 4 views estatísticas na `v_sku_demanda_efetiva` (PR-1) + corrigir o furo #10. Resultado verificável: `BASE PARA TINGIMIX` (e os 23 insumos) passam a ser incluídos por `gerar_pedidos_sugeridos_ciclo('OBEN')` quando o estoque cai ao ponto. Design e plano JÁ FEITOS — não refazer. **Escopo além disso (V3, PR-3) = outra sessão.**
+
+## 2. Estado na main (verificado 2026-07-11)
+
+- `origin/main`: **e5bb5fb7**. PRs mergeados relevantes:
+  - **#1291** — PR-1: fonte de demanda via BOM (`db/reposicao-demanda-insumos-bom.sql`: as 4 views `v_pcp_malha_oben*` + `v_sku_demanda_efetiva`). **INERTE** (não religou nada).
+  - **#1292** — `security_invoker` nas 5 views de consolidação-demanda (P0 RLS). ⚠️ **Isto tocou as views que o PR-2 vai recriar** — parta do `pg_get_viewdef` ATUAL da prod, não do repo.
+- ⚠️ **PR-1 NÃO foi aplicado no banco ainda** — `SELECT count(*) FROM pg_views WHERE viewname='v_sku_demanda_efetiva'` = 0 em prod. **Pré-requisito do apply do PR-2.** O apply é do founder (SQL Editor) via `docs/handoff/2026-07-09-pr1-bom-insumos-apply.md`. O PG17 aplica PR-1+PR-2 localmente, então dá para DESENVOLVER e PROVAR o PR-2 sem o apply — só o apply em prod é ordenado (PR-1 antes).
+
+## 3. Arquivos/funções-chave (caminhos exatos)
+
+- **LER 1º:** `docs/superpowers/specs/2026-07-11-reposicao-pr2-religamento-criticidade-design.md` (o design).
+- **O PLANO JÁ ESTÁ ESCRITO:** `docs/superpowers/plans/2026-07-11-reposicao-pr2-religamento.md` — 5 tasks (pré-flight → fix #10 → religar 4 views → harness PG17 → performance → Codex+handoff). A sessão nova **executa** este plano (subagent-driven-development), NÃO refaz o brainstorming nem o writing-plans.
+- `db/reposicao-demanda-insumos-bom.sql` (PR-1) — contém `v_sku_demanda_efetiva`. **Fix #10 aqui:** no ramo de consumo (2ª metade do UNION ALL) adicionar `AND v.quantidade > 0` (devolução de tingidor não recompõe componente).
+- As **4 views a religar** (trocar só `FROM v_venda_items_history_efetivo` → `FROM v_sku_demanda_efetiva`): `v_sku_demanda_estatisticas`, `v_sku_sigma_demanda`, `v_sku_demanda_rajada`, `v_sku_candidatos_primeira_compra`. Pré-flight `pg_get_viewdef` de cada (preservar ordem de colunas + `security_invoker=true` que o #1292 aplicou).
+- **Padrão de religamento:** `db/reposicao-consolidacao-demanda.sql` (a consolidação fez exatamente isto — trocar o FROM, alias remapeado).
+- Docs a ler: `docs/agent/database.md` §4 (security_invoker/RLS), `docs/agent/money-path.md`, `docs/agent/reposicao.md`.
+
+## 4. Decisões já tomadas (NÃO re-litigar)
+
+- **V3 automático ABANDONADO** — Codex challenge do design achou 14 furos (Pareto quebra em população pequena, `valor_consumo` mistura venda+consumo, SKU-ambos insolúvel, C invertido, cardinalidade 112×, cross-company, proxy temporal). Reverter = reabrir os 14 furos. Detalhe no spec §7.
+- **Criticidade dos ~5 insumos caros = curadoria humana** (`minimo_forcado_manual`, que o motor já honra) + visibilidade. Não há código de criticidade no PR-2.
+- **Abordagem A** (explodir a ficha) — PR-1 mergeado.
+- A `v_sku_classificacao_abc_xyz`, `v_sku_parametros_sugeridos`, a função de aplicação e o motor ficam **INTOCADOS** (insumo cai em classe C, aceito).
+
+## 5. Validações a rodar (a prova da entrega — money-path)
+
+- **`prove-sql-money-path`** (PG17 aplicando PR-1 + PR-2, com falsificação):
+  - religamento: insumo (BASE) ganha `demanda_total_90d`/`demanda_media_diaria` > 0;
+  - **graduação → cockpit** (teste-fim): estoque do BASE < ponto → `gerar_pedidos_sugeridos_ciclo('OBEN')` inclui o BASE; acima, não;
+  - **fix #10 (falsificar):** venda de pai com `quantidade<0` não gera consumo negativo; remover o guard → vermelho;
+  - **não-regressão:** `v_sku_classificacao_abc_xyz` idêntica antes/depois (`EXCEPT ALL` old×new);
+  - ordem de colunas + `security_invoker=true` preservados nas 4 views.
+- **Performance (obrigatório, furo #14):** `EXPLAIN (ANALYZE, BUFFERS)` sob `SET ROLE authenticated` + GUC do JWT + `statement_timeout='8s'` nas 4 views + `v_sku_parametros_sugeridos` + candidatos. Exigir folga (p95 < 4s). Se estourar → **materializar antes do fan-out** (fato privado grão `empresa×sku×data×NF`, `qtde_direta`/`qtde_consumo`/`valor` separados). `psql-ro` tem BYPASSRLS e NÃO prova o timeout — usar `SET ROLE authenticated`.
+- **Codex challenge do SQL** (`scripts/codex-async.sh` em background).
+- **Pós-apply (psql-ro):** BASE com `ponto_pedido` preenchido; TINGIMIX aparece com estoque ≤ ponto; classe dos produtos idêntica.
+
+## 6. Pendências do founder
+
+- 🟣 **SQL Editor:** aplicar o **PR-1** (`db/reposicao-demanda-insumos-bom.sql`) ANTES de aplicar o PR-2 — handoff `docs/handoff/2026-07-09-pr1-bom-insumos-apply.md`.
+- 🖱️ Chip aberto (não urgente): "Limpar cadastro duplicado PRD03688 no Omie" (`task_0399980e`) — dívida de cadastro Omie; impacto de demanda zero.
+- ✅ Dívida do `security_invoker` em `v_venda_items_history_efetivo`: **FECHADA** pelo #1292 (não precisa mais).
+
+## 7. Abertura da sessão nova
+
+- `bun run wt reposicao-pr2` (worktree NOVO a partir da main atual `e5bb5fb7` — NÃO reusar o worktree `tingimix-item-visibility-28df07`, que é a sessão que gerou este handoff).
+- O spec está na branch `claude/reposicao-pr2-criticidade-insumos` no origin — `git cherry-pick d623eb6f` para a branch nova, ou copiar o arquivo do spec.
+- 1ª mensagem: colar este briefing + "executar o plano `docs/superpowers/plans/2026-07-11-reposicao-pr2-religamento.md` com subagent-driven-development (o design e o plano já estão prontos; comece pela Task 0)".

--- a/docs/superpowers/plans/2026-07-11-reposicao-pr2-religamento.md
+++ b/docs/superpowers/plans/2026-07-11-reposicao-pr2-religamento.md
@@ -1,0 +1,277 @@
+# PR-2 — Religamento da demanda de insumos — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development para implementar task-por-task. Steps usam checkbox (`- [ ]`).
+
+**Goal:** Religar as 4 views estatísticas de demanda na `v_sku_demanda_efetiva` (PR-1) + corrigir o furo #10 (devolução), fazendo os 23 insumos elegíveis aparecerem no cockpit quando o estoque cai ao ponto — sem mudar a classe de nenhum produto vendido.
+
+**Architecture:** Trocar `FROM v_venda_items_history_efetivo venda_items_history` → `FROM v_sku_demanda_efetiva venda_items_history` nas 4 views (alias preservado → referências qualificadas seguem válidas; zero mudança de agregação/colunas). Como `v_sku_demanda_efetiva = v_venda_items_history_efetivo ⊕ consumo`, o produto vendido enxerga a MESMA demanda (só venda); o insumo ganha o consumo. `v_sku_classificacao_abc_xyz`, `v_sku_parametros_sugeridos` e o motor **herdam sem tocar**.
+
+**Tech Stack:** PostgreSQL (Supabase prod). Views SQL. Harness PG17 (`db/test-*.sh`). Apply manual no SQL Editor do Lovable.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-reposicao-pr2-religamento-criticidade-design.md`
+
+## Global Constraints
+
+- **MONEY-PATH PLENO.** Muda comportamento de compra. Nada em prod sem: PG17 com falsificação + Codex challenge do SQL + **prova de performance sob `SET ROLE authenticated`** + verificação pós-apply.
+- **Pré-requisito de apply:** PR-1 já aplicado em prod (verificado: `v_sku_demanda_efetiva` existe, 297 pares, 0 duplicatas).
+- **NUNCA** editar `supabase/migrations/`. SQL vive em `db/`, colado no SQL Editor.
+- `CREATE OR REPLACE VIEW` **DEVE** repetir `WITH (security_invoker = true)` — sem ele o replace **ZERA** o reloptions e a view volta a rodar como owner (bypassa RLS → vaza dado; regressão do P0/#1292). Ver `db/reposicao-consolidacao-demanda.sql:16`.
+- **Ordem exata de colunas** preservada em cada view (senão `cannot change name of view column`).
+- **A última recriação vence:** as 4 views hoje vêm de `db/reposicao-consolidacao-demanda.sql`. O arquivo do religamento passa a ser a versão canônica dessas 4 — aplicá-lo DEPOIS.
+- Idioma pt-BR em código/commits.
+
+## Premissas medidas em prod (2026-07-11 — Task 0 revalida)
+
+| Fato | Valor |
+|---|---|
+| `v_sku_demanda_efetiva` (PR-1) | aplicada; 23 insumos, 297 pares, 0 duplicatas |
+| 4 views a religar leem `FROM v_venda_items_history_efetivo venda_items_history` | linhas 72/108/138/147/189 de `db/reposicao-consolidacao-demanda.sql` |
+| `security_invoker=true` nelas (P0/#1292) | a confirmar no pré-flight (reloptions) |
+| BASE: demanda explodida | consumo 0,61/dia + venda direta 0,15/dia = 0,76/dia total |
+
+## File Structure
+
+- **Create:** `db/reposicao-religamento-insumos.sql` — recria as 4 views com `FROM v_sku_demanda_efetiva` (fonte viva). Uma responsabilidade: apontar a demanda para a fonte explodida.
+- **Modify:** `db/reposicao-demanda-insumos-bom.sql` — fix #10 na `v_sku_demanda_efetiva` (1 linha).
+- **Create:** `db/test-reposicao-religamento.sh` — harness PG17 (PR-1 + fix#10 + religamento).
+- **Create:** `db/preflight-reposicao-religamento.sql` — capturas read-only (Task 0).
+- **Modify:** nenhuma view existente além das 4 religadas + v_sku_demanda_efetiva.
+
+---
+
+### Task 0: Pré-flight — congelar o estado real da prod
+
+**Files:** Create `db/preflight-reposicao-religamento.sql`
+
+**Interfaces:** Produces os fatos que Task 2/3 assumem. Divergiu → parar e reavaliar.
+
+- [ ] **Step 1: Escrever o pré-flight**
+
+```sql
+-- db/preflight-reposicao-religamento.sql — READ-ONLY, rodar via psql-ro.
+-- P1: as 4 views leem v_venda_items_history_efetivo hoje? (o FROM a trocar)
+SELECT 'P1_'||c.relname AS chk,
+       (SELECT count(*) FROM regexp_matches(pg_get_viewdef(c.oid,true),'v_venda_items_history_efetivo','g'))::text AS from_hits,
+       c.reloptions::text AS reloptions   -- esperado: {security_invoker=true}
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public' AND c.relname IN
+  ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+ORDER BY c.relname;
+
+-- P2: a def prod das 4 bate com db/reposicao-consolidacao-demanda.sql? (md5 p/ detectar drift)
+SELECT 'P2_'||c.relname AS chk, md5(pg_get_viewdef(c.oid,true)) AS md5_prod
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public' AND c.relname IN
+  ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+ORDER BY c.relname;
+
+-- P3: v_sku_demanda_efetiva existe (PR-1 aplicado)?
+SELECT 'P3_demanda_efetiva' AS chk, count(*)::text FROM pg_views WHERE viewname='v_sku_demanda_efetiva';  -- esperado 1
+
+-- P4: v_sku_parametros_sugeridos lê as 4 (herança) — confirmar que NÃO referencia v_sku_demanda_efetiva ainda
+SELECT 'P4_sugeridos_ja_le_efetiva' AS chk,
+       (SELECT count(*) FROM regexp_matches(pg_get_viewdef('v_sku_parametros_sugeridos',true),'v_sku_demanda_efetiva','g'))::text;  -- esperado 0
+```
+
+- [ ] **Step 2: Rodar contra prod**
+
+```bash
+~/.config/afiacao/psql-ro -f db/preflight-reposicao-religamento.sql
+```
+Esperado: P1 `from_hits≥1` + `{security_invoker=true}` nas 4; P3=1; P4=0. **Guardar os 4 md5 (P2)** — a Task 2 deve partir da def prod EXATA (se um md5 divergir do repo, capturar a def prod via `pg_get_viewdef` e usar ELA como base, não o arquivo).
+
+- [ ] **Step 3: Confirmar a branch tem o #1292 e commit**
+
+```bash
+git merge-base --is-ancestor 64fe7b9b HEAD && echo "ok #1292" || git rebase origin/main
+git add db/preflight-reposicao-religamento.sql
+git commit -m "chore(reposicao): pre-flight do religamento (PR-2)"
+```
+
+---
+
+### Task 1: Fix #10 — devolução não vira consumo negativo
+
+**Files:** Modify `db/reposicao-demanda-insumos-bom.sql` (a view `v_sku_demanda_efetiva`)
+
+**Interfaces:** Consumes `v_pcp_malha_oben`. Produces `v_sku_demanda_efetiva` com o ramo de consumo filtrado a `quantidade>0`.
+
+- [ ] **Step 1: Aplicar o guard** — no ramo de consumo (2ª metade do `UNION ALL`), o `WHERE v.empresa = 'OBEN'` vira:
+
+```sql
+WHERE v.empresa = 'OBEN'
+  AND v.quantidade > 0;   -- [Codex #10] devolução de tingidor não recompõe componente
+```
+A 1ª metade (venda direta) permanece intacta (devolução é demanda de venda legítima).
+
+- [ ] **Step 2: `grep` de sanidade**
+
+```bash
+grep -c "AND v.quantidade > 0" db/reposicao-demanda-insumos-bom.sql   # esperado 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/reposicao-demanda-insumos-bom.sql
+git commit -m "fix(reposicao): devolucao nao vira consumo negativo do insumo (#10)"
+```
+
+---
+
+### Task 2: Religar as 4 views (`FROM v_sku_demanda_efetiva`)
+
+**Files:** Create `db/reposicao-religamento-insumos.sql`
+
+**Interfaces:** Consumes as defs prod das 4 views (Task 0) + `v_sku_demanda_efetiva`. Produces as 4 views lendo a fonte explodida, shape idêntico.
+
+- [ ] **Step 1: Gerar o arquivo por transformação determinística**
+
+Para cada uma das 4 views, partir da def **prod** (Task 0; se o md5 bate com `db/reposicao-consolidacao-demanda.sql`, usar o arquivo), aplicar EXATAMENTE uma substituição e **nada mais**:
+
+```
+FROM v_venda_items_history_efetivo venda_items_history  →  FROM v_sku_demanda_efetiva venda_items_history
+FROM v_venda_items_history_efetivo vih                  →  FROM v_sku_demanda_efetiva vih
+```
+(o alias `venda_items_history`/`vih` é preservado → todas as referências qualificadas seguem válidas). Cada view mantém `WITH (security_invoker = true)` e a ordem de colunas. Cabeçalho do arquivo:
+
+```sql
+-- db/reposicao-religamento-insumos.sql — PR-2 (money-path).
+-- Religa as 4 views estatísticas na v_sku_demanda_efetiva (venda ⊕ consumo de insumo).
+-- Único delta vs db/reposicao-consolidacao-demanda.sql: FROM v_venda_items_history_efetivo
+-- → FROM v_sku_demanda_efetiva. security_invoker=true OBRIGATÓRIO em cada CREATE OR REPLACE.
+-- É a versão CANÔNICA destas 4 views (aplicar DEPOIS da consolidação). NÃO vai em supabase/migrations/.
+```
+
+- [ ] **Step 2: Sanidade estrutural**
+
+```bash
+grep -c "CREATE OR REPLACE VIEW" db/reposicao-religamento-insumos.sql          # 4
+grep -c "security_invoker = true" db/reposicao-religamento-insumos.sql          # 4
+grep -c "FROM v_sku_demanda_efetiva" db/reposicao-religamento-insumos.sql       # ≥4
+grep -c "v_venda_items_history_efetivo" db/reposicao-religamento-insumos.sql    # 0 (todas trocadas)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add db/reposicao-religamento-insumos.sql
+git commit -m "feat(reposicao): religa as 4 views de demanda na v_sku_demanda_efetiva (PR-2)"
+```
+
+---
+
+### Task 3: Harness PG17 — prova (PR-1 + fix#10 + religamento)
+
+**Files:** Create `db/test-reposicao-religamento.sh`
+
+**Interfaces:** exit 0 = verde. Aplica, na ordem: snapshot → 3 deps do PCP → `db/reposicao-demanda-insumos-bom.sql` (com fix #10) → `db/reposicao-religamento-insumos.sql`.
+
+**Base:** bootstrap de `db/test-reposicao-demanda-insumos-bom.sh` (initdb, snapshot, deps, `set_malha`). **PORT=5444** (paralelo). Capturar `base_<view>` das 4 views ANTES do religamento (para o EXCEPT ALL de não-regressão).
+
+- [ ] **Step 1: Asserts (money-path)**
+
+```bash
+# fixtures: pai 200 vende (ficha 0.9L do insumo 201); produto 300 vende, SEM ficha (não-insumo)
+echo "→ A. RELIGAMENTO: o insumo ganha demanda_total_90d > 0"
+got=$(Pq -c "SELECT COALESCE(demanda_total_90d,0)>0 FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=201 AND empresa='OBEN';")
+assert_eq "A1 insumo tem demanda apos religar" "t" "$got"
+
+echo "→ B. NÃO-REGRESSÃO: SKU não-insumo (300) idêntico antes/depois nas 4 views"
+for v in v_sku_demanda_estatisticas v_sku_sigma_demanda v_sku_demanda_rajada v_sku_candidatos_primeira_compra; do
+  got=$(Pq -c "SELECT count(*) FROM (
+                 (SELECT * FROM ${v} WHERE sku_codigo_omie::text='300' EXCEPT ALL SELECT * FROM base_${v} WHERE sku_codigo_omie::text='300')
+                 UNION ALL
+                 (SELECT * FROM base_${v} WHERE sku_codigo_omie::text='300' EXCEPT ALL SELECT * FROM ${v} WHERE sku_codigo_omie::text='300')) d;")
+  assert_eq "B:${v} nao-insumo intacto" "0" "$got"
+done
+
+echo "→ C. FIX #10: devolução do pai (qtde<0) NÃO gera consumo negativo"
+# semear venda do pai 200 com quantidade=-5 (devolução)
+got=$(Pq -c "SELECT count(*) FROM v_sku_demanda_efetiva WHERE sku_codigo_omie=201 AND quantidade<0;")
+assert_eq "C1 sem consumo negativo" "0" "$got"
+
+echo "→ D. GRADUAÇÃO: o insumo sai de AGUARDANDO_SEGUNDA_ORDEM (o problema original era num_ordens=1)"
+# fixture: pai 200 vende em DUAS NFs distintas ('NFE-1','NFE-2') → o consumo do insumo 201
+# herda as 2 NFs (PR-1) → num_ordens=2. Sem o religamento, o insumo tinha num_ordens=0.
+got=$(Pq -c "SELECT num_ordens FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=201 AND empresa='OBEN';")
+assert_eq "D1 insumo graduou: num_ordens=2 (herdou 2 NFs dos pais)" "2" "$got"
+# e o gate do motor (ponto_pedido IS NOT NULL) já foi provado no PR-1; a inclusão no cockpit
+# é verificada end-to-end na PROD pós-apply (Task 5), com o motor real e os dados reais.
+
+echo "→ E. security_invoker + shape das 4 views preservados"
+got=$(Pq -c "SELECT count(*) FROM pg_class WHERE relname IN
+      ('v_sku_demanda_estatisticas','v_sku_sigma_demanda','v_sku_demanda_rajada','v_sku_candidatos_primeira_compra')
+      AND reloptions @> ARRAY['security_invoker=true'];")
+assert_eq "E1 4 views security_invoker" "4" "$got"
+```
+
+- [ ] **Step 2: FALSIFICAÇÃO**
+
+```bash
+echo "→ SAB1: religar SEM o guard #10 → consumo negativo VAZA (C1 quebraria)"
+# recriar v_sku_demanda_efetiva sem 'AND v.quantidade>0' → assertar que aparece consumo<0 → prova que C1 protege
+echo "→ SAB2: recriar uma view religada SEM security_invoker → E1 cai p/ 3 (prova que E1 protege a RLS)"
+```
+
+- [ ] **Step 3: Rodar verde + commit**
+
+```bash
+heavy bash db/test-reposicao-religamento.sh > /tmp/relig.log 2>&1; echo $?
+git add db/test-reposicao-religamento.sh
+git commit -m "test(reposicao): PG17 prova religamento (demanda+graduacao+nao-regressao+fix10+RLS)"
+```
+
+---
+
+### Task 4: Prova de performance (o furo #14 — obrigatória)
+
+**Files:** Create `db/perf-reposicao-religamento.sql` (EXPLAIN sob authenticated)
+
+**Interfaces:** decide se o religamento vai a prod direto ou precisa materializar.
+
+- [ ] **Step 1: Medir sob o role real**
+
+```sql
+-- rodar via psql-ro MAS com SET ROLE authenticated + GUC do JWT + statement_timeout='8s'.
+-- psql-ro tem BYPASSRLS → NÃO reproduz o custo real; por isso o SET ROLE.
+SET statement_timeout='8s';
+SET ROLE authenticated;  -- + set_config dos claims do JWT (empresa/uid) como o PostgREST faz
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM v_sku_parametros_sugeridos WHERE empresa='OBEN';
+EXPLAIN (ANALYZE, BUFFERS) SELECT * FROM v_sku_candidatos_primeira_compra WHERE empresa='OBEN';
+RESET ROLE;
+```
+
+- [ ] **Step 2: Veredito**
+  - p95 < 4s e sem `statement timeout` → ✅ segue para apply.
+  - estourou → **materializar antes do fan-out**: fato privado `empresa×sku×data×NF` com `qtde_direta`/`qtde_consumo` separadas + índice `(empresa,sku,data)`; religar as 4 na materialização. **Escalar ao controlador** — isso vira uma sub-fase de design (não improvisar no plano).
+
+- [ ] **Step 3: Registrar o EXPLAIN** em `db/perf-reposicao-religamento.sql` + commit.
+
+---
+
+### Task 5: Codex do SQL + handoff de apply
+
+**Files:** Create `docs/handoff/2026-07-11-pr2-apply.md`
+
+- [ ] **Step 1: Codex challenge (money-path)** — `cat db/reposicao-religamento-insumos.sql db/reposicao-demanda-insumos-bom.sql | scripts/codex-async.sh -r xhigh -` (background). Pedir: dupla contagem venda+consumo, não-regressão real, ordem das colunas, RLS, performance.
+
+- [ ] **Step 2: Handoff de apply** — bloco pro SQL Editor (ordem: `reposicao-demanda-insumos-bom.sql` re-aplicado com fix#10, DEPOIS `reposicao-religamento-insumos.sql`) + validação pós-apply:
+
+```sql
+-- esperado: insumo com demanda; TINGIMIX sugerível; produto com classe idêntica
+SELECT 'base_demanda' AS chk, round(demanda_media_diaria,2)::text FROM v_sku_demanda_estatisticas WHERE sku_codigo_omie=8689961993 AND empresa='OBEN'
+UNION ALL SELECT 'base_ponto_pedido', ponto_pedido::text FROM sku_parametros WHERE sku_codigo_omie::bigint=8689961993 AND empresa='OBEN';
+```
+
+- [ ] **Step 3: Verificação pós-apply (psql-ro)** + PR draft (NÃO criar sem ok do founder — CLAUDE.md).
+
+## Self-Review
+
+**Spec coverage:** §4.1 religamento → Task 2. §4.2 fix#10 → Task 1. §5 não-regressão → Task 3 B. §5 performance #14 → Task 4. §6 provas → Task 3. §7 furos: #10 corrigido (Task 1/3C); #9/#11/#13 são limitações declaradas no spec (não código); demais furos eliminados por não haver V3.
+
+**Placeholders:** asserts A–E têm bash executável. SAB1/SAB2 (falsificação) descrevem a sabotagem em 1 linha — o implementador recria a view sem o guard seguindo o padrão de sabotagem do PR-1 (`db/test-reposicao-demanda-insumos-bom.sh` S1–S3). O teste-fim do motor (insumo sugerido) foi **movido para a verificação pós-apply na PROD** (Task 5) — no harness prova-se a graduação (`num_ordens=2`), e o gate do motor já foi provado no PR-1; reproduzir o motor inteiro no harness seria duplicar `db/test-embalagem-motor.sh` sem ganho.
+
+**Type consistency:** as 4 views mantêm shape (o religamento não muda colunas). `v_sku_demanda_efetiva` shape idêntico a `v_venda_items_history_efetivo` (garantido pelo PR-1, assert R1). Alias `venda_items_history`/`vih` preservado.
+
+**Gap conhecido:** Task 4 pode escalar para materialização (design próprio) se o EXPLAIN estourar — sinalizado, não silenciado.

--- a/docs/superpowers/specs/2026-07-11-reposicao-pr2-religamento-criticidade-design.md
+++ b/docs/superpowers/specs/2026-07-11-reposicao-pr2-religamento-criticidade-design.md
@@ -1,0 +1,103 @@
+# PR-2 — religamento da demanda de insumos (money-path)
+
+> **Status:** design (brainstorming). **Money-path PLENO** — este PR muda comportamento de compra (o PR-1 era inerte). NÃO implementar sem: prova PG17 com falsificação + Codex challenge do SQL + pré-flight `pg_get_viewdef` da PROD + **prova de performance sob `authenticated`** + verificação read-only pós-apply.
+> **Pré-requisito de APPLY:** o PR-1 (`db/reposicao-demanda-insumos-bom.sql`, PR #1291 mergeado) precisa estar **aplicado no banco** antes deste. PG17 aplica ambos localmente.
+> **Decisão de rumo (2026-07-11):** o **V3 automático foi ABANDONADO** após o Codex challenge do design achar bloqueadores fundamentais (§7). A criticidade dos poucos insumos caros passa a ser **curadoria humana** via `minimo_forcado_manual` (já existente). Isso enxuga o PR-2 ao **religamento** e elimina 8 dos 14 furos do Codex por construção (a classificação não muda).
+
+## 1. Problema
+
+O PR-1 criou `v_sku_demanda_efetiva` (venda ⊕ consumo explodido) mas não religou nada. Este PR faz as 4 views estatísticas lerem a nova fonte → o insumo ganha demanda → o motor calcula `ponto_pedido`/`estoque_maximo` → **aparece no cockpit** quando o estoque cai.
+
+## 2. Por que NÃO o V3 automático (registro da decisão)
+
+O objetivo do V3 era dar ao insumo caro um estoque de segurança à altura (a classe ABC por venda joga insumo em C). O Codex challenge (§7) mostrou que a "curva de Pareto particionada" tem bloqueadores fundamentais (Pareto quebra em população de 9 itens; `valor_consumo` mistura venda+consumo; SKU-ambos insolúvel com uma classe; C é a MENOS protetiva, não a mais; joins duplicam o SKU 112×) **e** uma limitação de fundo: a venda-explodida **suaviza** o consumo real (produção em lote → série sintética 1/dia → segurança subdimensionada). Construir isso robusto é caro e o resultado seguiria frágil.
+
+**Fato que decide:** os insumos caros são **pouquíssimos** — as 4 soluções XT.1803 (cmc R$200–392/L) + a BASE dominam. Curá-los à mão (`minimo_forcado_manual`) é trivial e robusto. Alinhado com a lição da auto-aprovação N3: *no money-path, a ferramenta sugere; a decisão fina é humana.*
+
+## 3. Decisão
+
+1. **Religar** as 4 views estatísticas: `FROM v_venda_items_history_efetivo` → `FROM v_sku_demanda_efetiva`.
+2. **Corrigir o furo #10** (devolução vira consumo negativo) na `v_sku_demanda_efetiva`: só explodir venda com `quantidade > 0`.
+3. **`v_sku_classificacao_abc_xyz`, `v_sku_parametros_sugeridos`, a função de aplicação e o motor: INTOCADOS.** O insumo cai em classe C (aceito) — o `minimo_forcado_manual` protege os caros.
+4. **Criticidade = curadoria** (operacional, **sem código novo**). O motor honra `minimo_forcado_manual` (piso de **quantidade** do pedido) — útil, mas note: ele **não** move o ponto de pedido (o *timing*), que segue classe C. O que realmente protege é a **visibilidade + decisão humana**: o religamento faz o insumo caro **aparecer** no cockpit, o founder o vê e compra antes se preciso (o que ele já faz hoje às cegas — agora com o item na tela). O `minimo_forcado_manual` é a ferramenta para garantir volume nos poucos caros.
+
+## 4. Arquitetura
+
+```
+[PR-1] v_sku_demanda_efetiva  (venda ⊕ consumo explodido)  ← fix #10: consumo só de venda qtde>0
+   │
+   ▼ RELIGAMENTO (mecânico — disciplina da consolidação)
+4 views estatísticas trocam FROM → v_sku_demanda_efetiva
+   │   (v_sku_demanda_estatisticas · _sigma_demanda · _demanda_rajada · _candidatos_primeira_compra)
+   ▼ (herdam SEM tocar — nenhuma lógica nova)
+v_sku_classificacao_abc_xyz → v_sku_parametros_sugeridos → função de aplicação → sku_parametros
+   ▼
+gerar_pedidos_sugeridos_ciclo [intocado] → 🎯 COCKPIT (insumo aparece com estoque ≤ ponto)
+   +
+[operacional] founder aplica minimo_forcado_manual nos ~5 insumos caros
+```
+
+### 4.1 Religamento (4 views)
+`CREATE OR REPLACE VIEW` de cada uma, trocando **só** o `FROM` (alias remapeado; zero mudança de agregação/GROUP BY/colunas — padrão de `db/reposicao-consolidacao-demanda.sql`). Pré-flight `pg_get_viewdef` da PROD + **ordem exata de colunas** + **`security_invoker=true`** preservado (o PR-1/§4 do database.md exige — não regredir ao recriar).
+
+### 4.2 Fix #10 — devolução (na `v_sku_demanda_efetiva`)
+No ramo de consumo (2ª metade do UNION ALL), adicionar `AND v.quantidade > 0`: uma devolução de tingidor acabado **não** recompõe os componentes já consumidos, então não deve gerar consumo negativo do insumo. A venda direta (1ª metade) mantém as devoluções (são demanda de venda legítima). 0 casos hoje; guard latente. Isto edita `db/reposicao-demanda-insumos-bom.sql` (ainda não aplicado em prod → o handoff do PR-1 passa a usar a versão corrigida; se o PR-1 já tiver sido aplicado, vira um `CREATE OR REPLACE` no PR-2).
+
+## 5. Money-path — invariantes, correções e limitações declaradas
+
+- **Não-regressão TRIVIAL:** `v_sku_classificacao_abc_xyz` e o cálculo **não mudam** → produto vendido mantém classe idêntica por construção (não há partição, não há mistura). Ainda assim, provar com `EXCEPT ALL` old×new da classificação (barato, fecha a dúvida).
+- **Fix #10** (devolução) — provado com fixture de venda negativa.
+- **Furos do V3 ELIMINADOS** por não construí-lo: #1 (Pareto pequeno), #2 (NULL 3VL), #3 (mistura venda/consumo no valor), #5 (SKU-ambos), #6 (C invertido), #7 (cardinalidade do join de malha/cmc), #8 (cross-company), #12 (cmc instável). Nenhum existe sem a partição.
+- **Limitações declaradas (não bloqueiam; o founder está no loop + curadoria):**
+  - **#9 proxy temporal:** a demanda explodida suaviza o consumo real (produção em lote). Subdimensiona a variabilidade → estoque de segurança pode ficar abaixo do pico real. Mitigação: curadoria dos caros + PR-3 observa os primeiros ciclos. Fonte robusta (apontamento de consumo real) seria a Abordagem C, fora de escopo.
+  - **#11 NF nula → não gradua:** herdado (num_ordens conta NF). 0 vendas de pais sem NF hoje. Query de vigilância (spec PR-1 §12).
+  - **#13 unidade do SKU-ambos:** se um insumo também vende numa embalagem de unidade diferente, `demanda_total_90d` soma unidades distintas. Afeta só os 5 SKU-ambos; a curadoria os cobre. Provar a unidade dos 5 no plano; se divergir, tratar caso a caso.
+- **Performance (#14):** as 4 views + `v_sku_parametros_sugeridos` (que lê 3 delas) + candidatos passam a expandir `v_sku_demanda_efetiva` (UNION ALL da história + JOIN da explosão) sobre 90/180d — potencialmente 4 scans numa requisição. **Prova obrigatória:** `EXPLAIN (ANALYZE, BUFFERS)` sob `SET ROLE authenticated` + GUC do JWT + `statement_timeout='8s'`, exigindo folga (p95 < 4s). Se estourar, **materializar antes do fan-out** (fato privado no grão `empresa×sku×data×NF`, com `qtde_direta`/`qtde_consumo`/`valor` separados) — decisão do plano guiada pelo EXPLAIN, não deste design.
+- `security_invoker=true` em toda view recriada. Não tocar `supabase/migrations/`.
+
+## 6. Provas (obrigatórias)
+
+**PG17 (`prove-sql-money-path`), aplicando PR-1 + PR-2, com falsificação:**
+- Religamento: insumo (BASE) ganha `demanda_total_90d`/`demanda_media_diaria` > 0; venda direta segue contando.
+- **Graduação → cockpit (o teste-fim):** com estoque do BASE abaixo do ponto, `gerar_pedidos_sugeridos_ciclo('OBEN')` passa a incluí-lo; acima, não.
+- **Fix #10 (falsificar):** venda de pai com `quantidade<0` (devolução) NÃO gera consumo negativo do insumo; remover o guard → exigir vermelho.
+- **Não-regressão:** `v_sku_classificacao_abc_xyz` retorna idêntica antes/depois (só o religamento muda a fonte; a lógica de classe não). `EXCEPT ALL` old×new sobre o baseline de todos os SKUs.
+- `minimo_forcado_manual` num insumo caro força a quantidade-piso no pedido (o instrumento da curadoria funciona).
+- Ordem de colunas + `security_invoker=true` preservados nas 4 views recriadas.
+
+**Codex challenge (xhigh)** sobre o SQL. **Pré-flight** `pg_get_viewdef`. **Prova de performance** (§5). **Verificação pós-apply (psql-ro):** BASE com `ponto_pedido` preenchido; produtos com classe idêntica; TINGIMIX aparece quando estoque ≤ ponto; EXPLAIN dentro do timeout.
+
+## 7. Codex challenge do design (xhigh, 2026-07-11) — 14 furos e status
+
+Veredito original: *"não aplicar o V3 como está — bloqueadores lógicos independentes de performance."* Levou ao abandono do V3.
+
+| # | Furo | Status |
+|---|---|---|
+| 1 | Pareto quebra em curva pequena (9 itens) | ✅ eliminado (sem curva de insumos) |
+| 2 | cmc ausente → `eh_insumo=NULL` cria 3ª partição | ✅ eliminado |
+| 3 | `valor_consumo` mistura venda + consumo | ✅ eliminado |
+| 4 | não-regressão não é "por construção" | ✅ agora É trivial (classificação intocada) |
+| 5 | SKU-ambos insolúvel com uma classe | ✅ eliminado (curadoria) |
+| 6 | "C conservadora" invertido; gate não salva | ✅ eliminado (sem depender de classe do insumo) |
+| 7 | cardinalidade: join de malha duplica SKU 112× | ✅ eliminado (sem join de malha na classificação) |
+| 8 | malha sem `empresa` → cross-company | ✅ eliminado |
+| 12 | eleição de cmc instável (empate/stale/NaN) | ✅ eliminado (sem cmc na classificação) |
+| 10 | devolução → consumo negativo | ✅ **corrigido** (guard `quantidade>0`, §4.2) |
+| 9 | explosão suaviza demanda temporal | 🔍 **declarado** (limitação do proxy; curadoria + PR-3) |
+| 11 | NF nula → não gradua | 🔍 **vigiado** (0 hoje) |
+| 13 | unidade do SKU-ambos | 🔍 **provado no plano** p/ os 5; caso a caso |
+| 14 | fan-out 4× → timeout | ⚠️ **prova obrigatória** de performance (§5); materializar se preciso |
+
+## 8. Faseamento
+
+- **PR-2 (este):** religamento + fix #10. Money-path pleno.
+- **Curadoria (operacional, contínua):** founder aplica `minimo_forcado_manual` nos insumos caros conforme aparecem.
+- **PR-3:** observar os primeiros ciclos; se o proxy temporal (#9) causar ruptura/excesso, avaliar apontamento de consumo real (Abordagem C) ou um dimensionamento dedicado. Decisão com dados reais.
+
+## 9. Critério de sucesso
+
+Aplicados PR-1 + PR-2, o `BASE PARA TINGIMIX` e os demais insumos elegíveis **aparecem no cockpit quando o estoque cai ao ponto de pedido**, sem pedido manual às cegas — e **nenhum produto vendido muda de classe**. Os insumos caros ficam protegidos por `minimo_forcado_manual` (curadoria), até termos dados para decidir se um dimensionamento automático se justifica.
+
+## 10. Fora de escopo
+
+V3 automático (abandonado); materialização (só se o EXPLAIN exigir); apontamento de consumo real (Abordagem C); conversão de unidade (quarentena do PR-1); auto-aprovação N3.


### PR DESCRIPTION
## PR-2 — Religa a demanda de insumos de produção (money-path)

Segundo PR do épico de reposição de insumos. O PR-1 (#1291) criou `v_sku_demanda_efetiva` (venda ⊕ consumo de insumo explodido da ficha técnica) mas era **inerte**. Este PR **religa** a demanda: as 4 views estatísticas passam a ler a fonte explodida → o insumo ganha demanda → o motor `gerar_pedidos_sugeridos_ciclo` passa a incluí-lo no cockpit quando o estoque cai ao ponto.

### O que muda (2 arquivos de código)
- **`db/reposicao-demanda-insumos-bom.sql`** (+3/−1): **fix #10** — `AND v.quantidade > 0` no ramo de consumo. Uma devolução do produto acabado não recompõe o insumo (não gera consumo negativo).
- **`db/reposicao-religamento-insumos.sql`** (novo): recria as 4 views (`v_sku_demanda_estatisticas`, `v_sku_sigma_demanda`, `v_sku_demanda_rajada`, `v_sku_candidatos_primeira_compra`) trocando **só** o `FROM v_venda_items_history_efetivo` → `FROM v_sku_demanda_efetiva`. `security_invoker=true` + REVOKE/GRANT preservados. `v_sku_classificacao_abc_xyz`, `v_sku_parametros_sugeridos` e o motor ficam **intocados** (herdam).

### Provas (money-path)
- **Pré-flight** (`db/preflight-...sql`): sem drift vs prod (validação reversa diff=0); PR-1 aplicado; PG17.6.
- **PG17** (`db/test-reposicao-religamento.sh`): **PASS=15, exit 0** — religamento (insumo ganha demanda) · não-regressão (SKU não-insumo idêntico, EXCEPT ALL) · fix#10 · graduação (num_ordens=2) · security_invoker — **+ falsificação** SAB1/SAB2 (com dente).
- **Performance** (`db/perf-...sql`): views base religadas < 1s; pior consumidor `v_sku_parametros_sugeridos` ~3.1s **<< 8s timeout**. Materialização não necessária.
- **Codex xhigh**: **0 P1**; lógica central de religamento e fix#10 confirmados. **P2.1** (reaplicar a consolidação regride silenciosamente) e **P2.2** (perf era estimativa, não p95) mitigados neste PR. P3 verificados em prod = **0 casos** (multinível, NF nula, unidade SKU-ambos); **P3.1 fechado por prova** (ABC é faturamento acumulado + `sum()` ignora NULL → SKUs vendidos não regridem, insumo→classe C). Vigilância no handoff.

### ⚠️ Apply é MANUAL (não vai por merge)
Ver `docs/handoff/2026-07-11-pr2-apply.md`. Ordem: `bom.sql` (fix#10) → religamento no SQL Editor. **Sem Publish, sem edge** (views backend puro). Dos 23 insumos elegíveis, ~4 têm lead time hoje (compráveis); o resto ganha demanda mas precisa de fornecedor/grupo (curadoria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
