### PR TITLE
fix(ai-ops): farmer_id da carteira canônica, não do espelho circular (P0-B-bis 3/3)

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -869,16 +869,26 @@ describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opç
     expect(helper).toMatch(/export function resolveOwner/);
   });
 
-  it('o edge LÊ a carteira canônica (carteira_assignments) com .order estável na paginação', () => {
+  it('o edge LÊ a carteira canônica (carteira_assignments) por KEYSET, e monta o mapa dos dados REAIS', () => {
     expect(
       src,
       'REVERSÃO Lovable? o ai-ops não lê mais carteira_assignments — o farmer voltou ao espelho circular?',
     ).toMatch(/from\(["']carteira_assignments["']\)/);
-    // .order estável na chave única (footgun PostgREST §5): sem isso a cauda >1000 pula/duplica linhas.
+    // Keyset (.gt + .limit), não offset: carteira_assignments é dinâmica (rebuild concorrente 07:30) e o
+    // offset pularia linha por churn → farmer_id null (Codex ponta 3 #3). Sem paginação a cauda >1000 sumiria.
     expect(
       src,
-      'a leitura da carteira precisa de .order estável (customer_user_id) na paginação',
-    ).toMatch(/from\(["']carteira_assignments["']\)[\s\S]{0,220}\.order\(["']customer_user_id["']/);
+      'a leitura da carteira precisa ser KEYSET: .gt(customer_user_id) + .order + .limit',
+    ).toMatch(/from\(["']carteira_assignments["']\)[\s\S]{0,260}\.gt\(["']customer_user_id["'][\s\S]{0,140}\.limit\(/);
+    expect(
+      src,
+      'REGRESSÃO (Codex #2): a paginação keyset perdeu o avanço do cursor — truncaria em 1 página',
+    ).toMatch(/lastCustomerId\s*=\s*rows\[rows\.length - 1\]/);
+    // Falso-verde que o Codex #2 pegou: buildOwnerMap([]) passaria os asserts frouxos. Trava o argumento REAL.
+    expect(
+      src,
+      'REGRESSÃO (Codex #2): o ownerMap não é montado dos assignments reais (virou buildOwnerMap([])?)',
+    ).toMatch(/buildOwnerMap\(assignmentsRaw\)/);
   });
 
   it('ANTI-CIRCULAR (BUG-1): farmer_id NÃO é mais o user_id do próprio cliente — vem de resolveOwner', () => {
@@ -886,10 +896,12 @@ describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opç
       src,
       'REGRESSÃO BUG-1: farmer_id voltou a ser assignment.user_id (o próprio cliente) — referência circular',
     ).not.toMatch(/farmer_id:\s*assignment\?\.user_id/);
+    // Args EXATOS (Codex #2): fallback null e chave = customer_user_id. `farmer_id: m.customer_user_id`
+    // (o bug circular) NÃO casaria isto — fecha o falso-verde do resolveOwner-sem-args.
     expect(
       src,
-      'farmer_id deveria vir de resolveOwner(ownerMap, ...) — o dono account-safe da carteira',
-    ).toMatch(/farmer_id:\s*resolveOwner\(/);
+      'farmer_id deveria vir de resolveOwner(ownerMap, m.customer_user_id, null) — dono account-safe da carteira',
+    ).toMatch(/farmer_id:\s*resolveOwner\(ownerMap,\s*m\.customer_user_id,\s*null\)/);
   });
 
   it('ANTI-REVERSÃO (BUG-2): o farmer NÃO vem mais do espelho poluído nem do dead code de employees', () => {
@@ -901,6 +913,19 @@ describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opç
       src,
       'sumiu a limpeza do dead code — o edge ainda busca profiles is_employee sem usar (mapeamento fantasma)?',
     ).not.toContain('is_employee');
+  });
+
+  it('PURGE completo (Codex #1): apaga TODAS as pending, sem filtro de data — limpa o farmer_id circular antigo', () => {
+    // O delete antigo filtrava created_at de HOJE → as 228 linhas circulares antigas (BUG-1) sobreviviam e
+    // reapareciam no Console de Exceções quando a run gerava < 200 decisões. Purge sem data limpa o legado.
+    expect(
+      src,
+      'REGRESSÃO (Codex #1): o purge de pending voltou a filtrar por created_at — o circular antigo sobrevive',
+    ).not.toMatch(/\.eq\("status",\s*"pending"\)[\s\S]{0,140}created_at/);
+    expect(
+      src,
+      'o purge de pending deveria ser fail-closed (erro do delete aborta antes de inserir → sem duplicata)',
+    ).toMatch(/if \(purgeError\) throw/);
   });
 
   it('o edge USA o helper espelhado (define buildOwnerMap E chama), ≥2 menções', () => {

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -841,3 +841,82 @@ describe('guardrail: fin-valor-cockpit lê o código do cliente pela view fresca
     ).not.toMatch(/from\("omie_clientes"\)/);
   });
 });
+
+// ── P0-B-bis ponta 3 (ai-ops-agent: farmer_id vem da carteira canônica, não do espelho circular) ──
+// DOIS bugs (investigados 2026-07-12, psql-ro + leitura): BUG-1 (circular, PRÉ-EXISTENTE) — o edge fazia
+// `farmer_id: assignment?.user_id` com assignment.user_id === m.customer_user_id → o "dono" era o PRÓPRIO
+// cliente (useExcecoesGestor.ts:112 `donoNome: nome(d.farmer_id)` mostra o nome do cliente como dono no
+// Console de Exceções do gestor). BUG-2 (regressão da ponta 1 #1293) — omie_clientes.omie_codigo_vendedor
+// virou 100% NULL (o vendedor mudou-se p/ a proof). Fix (Opção A, decisão do founder 2026-07-12): resolve o
+// farmer da fonte CANÔNICA carteira_assignments.owner_user_id via owner-map (buildOwnerMap/resolveOwner),
+// herdando os guards fail-closed + Hunter/B-lite/eligible da ponta 2 (carteira-rebuild). Edge TS puro, sem SQL.
+// Este canário textual pega a reversão do deploy do Lovable (mesma armadilha do #1272). Ver
+// docs/agent/money-path.md e o design da ponta 2 (2026-07-11-carteira-rebuild-vendedor-proof-ponta2-design.md).
+const AIOPS = 'supabase/functions/ai-ops-agent/index.ts';
+const OWNER_MAP = 'src/lib/carteira/owner-map.ts';
+
+describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opção A, anti-circular)', () => {
+  const src = read(AIOPS);
+  const helper = read(OWNER_MAP);
+
+  it('sentinela: leu os arquivos reais (edge + helper)', () => {
+    expect(src).toContain('farmer_id');
+    expect(helper).toContain('buildOwnerMap');
+  });
+
+  it('o helper puro existe e exporta buildOwnerMap + resolveOwner', () => {
+    expect(helper).toMatch(/export function buildOwnerMap/);
+    expect(helper).toMatch(/export function resolveOwner/);
+  });
+
+  it('o edge LÊ a carteira canônica (carteira_assignments) com .order estável na paginação', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? o ai-ops não lê mais carteira_assignments — o farmer voltou ao espelho circular?',
+    ).toMatch(/from\(["']carteira_assignments["']\)/);
+    // .order estável na chave única (footgun PostgREST §5): sem isso a cauda >1000 pula/duplica linhas.
+    expect(
+      src,
+      'a leitura da carteira precisa de .order estável (customer_user_id) na paginação',
+    ).toMatch(/from\(["']carteira_assignments["']\)[\s\S]{0,220}\.order\(["']customer_user_id["']/);
+  });
+
+  it('ANTI-CIRCULAR (BUG-1): farmer_id NÃO é mais o user_id do próprio cliente — vem de resolveOwner', () => {
+    expect(
+      src,
+      'REGRESSÃO BUG-1: farmer_id voltou a ser assignment.user_id (o próprio cliente) — referência circular',
+    ).not.toMatch(/farmer_id:\s*assignment\?\.user_id/);
+    expect(
+      src,
+      'farmer_id deveria vir de resolveOwner(ownerMap, ...) — o dono account-safe da carteira',
+    ).toMatch(/farmer_id:\s*resolveOwner\(/);
+  });
+
+  it('ANTI-REVERSÃO (BUG-2): o farmer NÃO vem mais do espelho poluído nem do dead code de employees', () => {
+    expect(
+      src,
+      'REGRESSÃO BUG-2: o ai-ops voltou a ler omie_clientes p/ o vendedor (espelho 100% NULL)',
+    ).not.toMatch(/from\(["']omie_clientes["']\)/);
+    expect(
+      src,
+      'sumiu a limpeza do dead code — o edge ainda busca profiles is_employee sem usar (mapeamento fantasma)?',
+    ).not.toContain('is_employee');
+  });
+
+  it('o edge USA o helper espelhado (define buildOwnerMap E chama), ≥2 menções', () => {
+    expect(src, 'edge não define mais o helper espelhado owner-map').toMatch(/function buildOwnerMap/);
+    expect(src, 'edge não chama mais buildOwnerMap — voltou à lógica inline?').toMatch(/buildOwnerMap\(/);
+    expect(src, 'edge não chama mais resolveOwner').toMatch(/resolveOwner\(/);
+    expect(
+      count(src, 'buildOwnerMap'),
+      'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao owner-map de src/ (pega reversão do Lovable)', () => {
+    expect(
+      mirrorBlockNamed(src, 'owner-map'),
+      'edge divergiu de owner-map.ts — o Lovable reescreveu o mapeamento no deploy?',
+    ).toBe(mirrorBlockNamed(helper, 'owner-map'));
+  });
+});

--- a/src/lib/carteira/__tests__/owner-map.test.ts
+++ b/src/lib/carteira/__tests__/owner-map.test.ts
@@ -16,4 +16,12 @@ describe('owner-map (anti-drift: score vem da carteira, não de atividade)', () 
     expect(resolveOwner(m, 'c1', 'hunter')).toBe('regina');
     expect(resolveOwner(m, 'desconhecido', 'hunter')).toBe('hunter');
   });
+  // ai-ops-agent (P0-B-bis ponta 3): resolve farmer_id da carteira com fallback NULL. Trava a semântica
+  // anti-circular do BUG-1 (o edge antigo fazia farmer_id = customer_user_id → cliente era dono de si).
+  it('ai-ops: o dono é o VENDEDOR (não o cliente); fora da carteira → null, nunca o próprio id', () => {
+    const m = buildOwnerMap([{ customer_user_id: 'cliente-x', owner_user_id: 'vendedora-ana' }]);
+    expect(resolveOwner(m, 'cliente-x', null)).toBe('vendedora-ana');
+    expect(resolveOwner(m, 'cliente-x', null)).not.toBe('cliente-x');
+    expect(resolveOwner(m, 'cliente-orfao', null)).toBeNull();
+  });
 });

--- a/src/lib/carteira/owner-map.ts
+++ b/src/lib/carteira/owner-map.ts
@@ -1,14 +1,16 @@
 // src/lib/carteira/owner-map.ts
+// MIRROR-START owner-map — espelhado verbatim no edge ai-ops-agent (P0-B-bis ponta 3). Manter idêntico.
 export interface AssignmentRow { customer_user_id: string; owner_user_id: string; }
 
-/** customer_user_id → owner_user_id (dono da carteira). Fonte de verdade do score (Opção A). */
+// customer_user_id -> owner_user_id (dono da carteira). Fonte de verdade do farmer/score (Opcao A).
 export function buildOwnerMap(assignments: AssignmentRow[]): Map<string, string> {
   const m = new Map<string, string>();
   for (const a of assignments) m.set(a.customer_user_id, a.owner_user_id);
   return m;
 }
 
-/** Resolve o dono de um cliente; fallback (ex.: Hunter) só se o cliente não estiver na carteira. */
+// Resolve o dono de um cliente; fallback (ex.: Hunter/null) so se o cliente nao estiver na carteira.
 export function resolveOwner(map: Map<string, string>, customerUserId: string, fallback: string | null): string | null {
   return map.get(customerUserId) ?? fallback;
 }
+// MIRROR-END

--- a/supabase/functions/ai-ops-agent/index.ts
+++ b/supabase/functions/ai-ops-agent/index.ts
@@ -29,10 +29,21 @@ interface Evidence {
   type: 'warning' | 'info' | 'critical';
 }
 
-interface ClientAssignment {
-  user_id: string;
-  omie_codigo_vendedor: string | null;
+// MIRROR-START owner-map — espelhado verbatim de src/lib/carteira/owner-map.ts (P0-B-bis ponta 3). Manter idêntico.
+interface AssignmentRow { customer_user_id: string; owner_user_id: string; }
+
+// customer_user_id -> owner_user_id (dono da carteira). Fonte de verdade do farmer/score (Opcao A).
+function buildOwnerMap(assignments: AssignmentRow[]): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const a of assignments) m.set(a.customer_user_id, a.owner_user_id);
+  return m;
 }
+
+// Resolve o dono de um cliente; fallback (ex.: Hunter/null) so se o cliente nao estiver na carteira.
+function resolveOwner(map: Map<string, string>, customerUserId: string, fallback: string | null): string | null {
+  return map.get(customerUserId) ?? fallback;
+}
+// MIRROR-END
 
 interface AiDecision {
   decision_type: string;
@@ -245,17 +256,29 @@ serve(async (req) => {
 
     console.log(`[ai-ops-agent] Total customers fetched: ${allMetrics.length}`);
 
-    // 3. Get farmer (vendedor) assignments from omie_clientes
-    const { data: clientAssignmentsRaw } = await supabase
-      .from("omie_clientes")
-      .select("user_id, omie_codigo_vendedor");
-    const clientAssignments = (clientAssignmentsRaw ?? []) as unknown as ClientAssignment[];
-
-    // Get employee profiles to map vendedor codes to farmer_ids
-    const { data: employees } = await supabase
-      .from("profiles")
-      .select("user_id, name")
-      .eq("is_employee", true);
+    // 3. Resolve o farmer (owner da carteira) da fonte canônica carteira_assignments (Opção A, P0-B-bis
+    //    ponta 3). owner_user_id já é o vendedor account-safe (oben) OU Hunter (órfão), resolvido pela
+    //    ponta 2 (carteira-rebuild) com guards fail-closed + consolidação B-lite. NÃO lê o espelho poluído
+    //    omie_clientes (vendedor 100% NULL) nem repete o mapeamento circular antigo (farmer_id = o cliente).
+    //    Sem filtro eligible: UNIQUE(customer_user_id) dá 1 linha/cliente e queremos o dono de QUALQUER
+    //    cliente com métrica (clone→Hunter, gêmeo→vendedor). Paginação com .order estável (footgun §5).
+    const assignmentsRaw: AssignmentRow[] = [];
+    let carteiraOffset = 0;
+    let carteiraHasMore = true;
+    while (carteiraHasMore) {
+      const { data: aPage, error: aError } = await supabase
+        .from("carteira_assignments")
+        .select("customer_user_id, owner_user_id")
+        .order("customer_user_id", { ascending: true })
+        .range(carteiraOffset, carteiraOffset + PAGE_SIZE - 1);
+      if (aError) throw new Error(`Failed to get carteira page ${carteiraOffset}: ${aError.message}`);
+      const rows = (aPage ?? []) as unknown as AssignmentRow[];
+      assignmentsRaw.push(...rows);
+      carteiraOffset += PAGE_SIZE;
+      carteiraHasMore = rows.length === PAGE_SIZE;
+    }
+    const ownerMap = buildOwnerMap(assignmentsRaw);
+    console.log(`[ai-ops-agent] Carteira assignments carregados: ${assignmentsRaw.length}`);
 
     // 4. Calculate scores and generate decisions
     const decisions: AiDecision[] = [];
@@ -272,13 +295,10 @@ serve(async (req) => {
       // Only create decisions for customers with score > 10
       if (result.score < 10) continue;
 
-      // Try to find farmer assignment
-      const assignment = clientAssignments.find((a) => a.user_id === m.customer_user_id);
-
       decisions.push({
         decision_type: "RECOMMEND_CONTACT",
         customer_user_id: m.customer_user_id,
-        farmer_id: assignment?.user_id || null, // Will be null if no assignment
+        farmer_id: resolveOwner(ownerMap, m.customer_user_id, null), // owner da carteira; null se fora dela
         score_final: result.score,
         confidence: result.confidence,
         confidence_value: result.confidenceValue,
@@ -352,7 +372,7 @@ serve(async (req) => {
   } catch (error) {
     console.error("[ai-ops-agent] Error:", error);
     return new Response(
-      JSON.stringify({ error: error.message }),
+      JSON.stringify({ error: error instanceof Error ? error.message : String(error) }),
       { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
   }

--- a/supabase/functions/ai-ops-agent/index.ts
+++ b/supabase/functions/ai-ops-agent/index.ts
@@ -261,21 +261,23 @@ serve(async (req) => {
     //    ponta 2 (carteira-rebuild) com guards fail-closed + consolidação B-lite. NÃO lê o espelho poluído
     //    omie_clientes (vendedor 100% NULL) nem repete o mapeamento circular antigo (farmer_id = o cliente).
     //    Sem filtro eligible: UNIQUE(customer_user_id) dá 1 linha/cliente e queremos o dono de QUALQUER
-    //    cliente com métrica (clone→Hunter, gêmeo→vendedor). Paginação com .order estável (footgun §5).
+    //    cliente com métrica (clone→Hunter, gêmeo→vendedor). Paginação por KEYSET em customer_user_id (não
+    //    offset): carteira_assignments é dinâmica (cron carteira-rebuild 07:30) — .range/offset pularia uma
+    //    linha se o rebuild inserisse/removesse uma chave entre páginas → farmer_id null (Codex ponta 3).
     const assignmentsRaw: AssignmentRow[] = [];
-    let carteiraOffset = 0;
-    let carteiraHasMore = true;
-    while (carteiraHasMore) {
+    let lastCustomerId = "";
+    for (;;) {
       const { data: aPage, error: aError } = await supabase
         .from("carteira_assignments")
         .select("customer_user_id, owner_user_id")
+        .gt("customer_user_id", lastCustomerId)
         .order("customer_user_id", { ascending: true })
-        .range(carteiraOffset, carteiraOffset + PAGE_SIZE - 1);
-      if (aError) throw new Error(`Failed to get carteira page ${carteiraOffset}: ${aError.message}`);
+        .limit(PAGE_SIZE);
+      if (aError) throw new Error(`Failed to get carteira page after ${lastCustomerId}: ${aError.message}`);
       const rows = (aPage ?? []) as unknown as AssignmentRow[];
       assignmentsRaw.push(...rows);
-      carteiraOffset += PAGE_SIZE;
-      carteiraHasMore = rows.length === PAGE_SIZE;
+      if (rows.length < PAGE_SIZE) break;
+      lastCustomerId = rows[rows.length - 1].customer_user_id;
     }
     const ownerMap = buildOwnerMap(assignmentsRaw);
     console.log(`[ai-ops-agent] Carteira assignments carregados: ${assignmentsRaw.length}`);
@@ -323,13 +325,15 @@ serve(async (req) => {
     // Sort by score descending
     decisions.sort((a, b) => b.score_final - a.score_final);
 
-    // 5. Clear old pending decisions from today and insert new ones
-    await supabase
+    // 5. Recompute completo: purga TODAS as recomendações pending (não só as de hoje) antes de regenerar.
+    //    Senão pending antigas — inclusive as com farmer_id circular do BUG-1 (P0-B-bis ponta 3) — sobrevivem
+    //    no banco e reaparecem no Console de Exceções quando a run gera < 200 decisões (Codex). accepted/
+    //    dismissed são preservadas (só status='pending' é purgado); a run seguinte reprioriza do zero.
+    const { error: purgeError } = await supabase
       .from("ai_decisions")
       .delete()
-      .eq("status", "pending")
-      .gte("created_at", `${today}T00:00:00`)
-      .lte("created_at", `${today}T23:59:59`);
+      .eq("status", "pending");
+    if (purgeError) throw new Error(`Failed to purge pending decisions: ${purgeError.message}`);
 
     // Insert in batches of 50
     let inserted = 0;


### PR DESCRIPTION
> **DRAFT — segurando o auto-merge de propósito.** O CI `validate` vai ficar **vermelho por 1 teste NÃO-relacionado**: a time-bomb `src/test/csv-aposentadoria.deadline.test.ts` venceu em 2026-07-13 (chip `task_fd0e07f1`). Este fix está 100% verde localmente. Converter para **ready** quando o `main` voltar ao verde (após remover o break-glass do CSV).

## O quê

`ai-ops-agent` passa a resolver o `farmer_id` (dono/vendedor do cliente) da fonte **canônica** `carteira_assignments.owner_user_id` (via helper `owner-map`), em vez do espelho `omie_clientes`. Fecha o P0-B-bis (ponta 3/3). Edge TS puro, **sem SQL**.

## Por quê — DOIS bugs (psql-ro + leitura)

- **BUG-1 (circular, pré-existente):** o edge fazia `farmer_id: assignment?.user_id` onde `assignment` era a linha do **próprio cliente** no espelho (`a.user_id === m.customer_user_id`) → `farmer_id === customer_user_id` sempre. Produção: **228/228** `ai_decisions` não-nulos têm `farmer_id == customer_user_id`. O `omie_codigo_vendedor` lido nunca era usado; a query `profiles is_employee` era dead code. Isso alimenta `useExcecoesGestor.ts:112` (`donoNome: nome(d.farmer_id)`) → o **Console de Exceções do gestor mostrava o nome do próprio cliente como "dono"**.
- **BUG-2 (regressão da ponta 1, #1293):** o writer moveu o vendedor para a proof; `omie_clientes.omie_codigo_vendedor` virou **100% NULL** (produção: 0 de 6909).

## A escolha (Opção A, decidida com o founder)

Ler `carteira_assignments.owner_user_id` em vez de espelhar a ponta 2 (proof + `omie_vendedor_map`): **herda** os guards fail-closed da ponta 2 (proof TTL/bootstrap/catraca — 4 rodadas de Codex) + Hunter/B-lite/eligible; é o **padrão canônico** do repo (`owner-map.ts`, `escopo-clientes.ts`); **anti-drift** (o dono no Console = o dono na carteira). Produção: ponta 2 já ativa (**2747** `source='omie'`), cobertura métrica∩carteira **100%** (5273/5273).

## Mudanças

- `supabase/functions/ai-ops-agent/index.ts` — lê `carteira_assignments` por **keyset** (`.gt(customer_user_id)` + `.limit`, robusto a churn concorrente) → `buildOwnerMap`; `farmer_id: resolveOwner(ownerMap, customer_user_id, null)`; **purga TODAS as pending** antes de regenerar (limpa o circular legado); remove o dead code (`omie_clientes` + `profiles is_employee`); catch type-safe (deno check verde).
- `src/lib/carteira/owner-map.ts` — marcadores MIRROR (paridade textual normaliza só código).
- `src/lib/carteira/__tests__/owner-map.test.ts` — caso anti-circular (dono = vendedor, não o cliente; fora → null).
- `src/__tests__/edge-money-path-invariants.test.ts` — 8º guardrail: lê carteira por keyset, anti-circular (args exatos), anti-reversão, purge sem filtro de data, paridade MIRROR.

## Codex challenge (gpt-5.6-sol, xhigh) — 3 furos, todos corrigidos + falsificados

1. **[ALTO]** purge só apagava pending de hoje → circular antigo sobrevivia → **purga todas** (fail-closed).
2. **[MÉDIO]** canário com falso-verde (`buildOwnerMap([])`/fallback errado/paginação truncada passavam) → travados **args reais** + avanço do cursor.
3. **[MÉDIO]** offset pularia linha sob rebuild concorrente → **keyset**.

## Verificação

- `bun run test` (suíte): **4952/4953** — o único vermelho é a time-bomb do CSV (não-relacionada).
- Canário + owner-map: **84/84** · `typecheck` EXIT=0 · `deno check` EXIT=0 · `lint` 0 errors.
- **Falsificação:** sabotar a fonte (`carteira_assignments`→`omie_clientes`), `buildOwnerMap([])` e reintroduzir o filtro de data deixam os asserts certos **vermelhos**.

## Passos manuais pós-merge (Lovable ≠ produção)

1. **Deploy do edge `ai-ops-agent`** verbatim pelo chat do Lovable.
2. **Rodar o agente** (botão "Rodar análise" no AI Ops, ou invocar a edge) para regenerar as decisões.
3. **Verificação psql-ro:** `select count(*) filter (where farmer_id = customer_user_id) from ai_decisions where status='pending'` → deve virar **0**; os não-nulos passam a existir em `carteira_assignments` como `owner_user_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
