### PR TITLE
feat(whatsapp): PR-3 funil do canal — elo de atribuição conservadora + RPC + seção na supervisão

### DIFF
--- a/db/test-whatsapp-funil.sh
+++ b/db/test-whatsapp-funil.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# Prova PG17 do PR-3 (migration 20260713030000_whatsapp_funil):
+# - aplica as 3 migrations do programa EM ORDEM (010000 → 020000 → 030000) — a
+#   mesma ordem do deploy manual do founder;
+# - asserts do funil: enviados/entregues/lidos/falhas; "respondeu" só com inbound
+#   ≤24h APÓS o send (resposta anterior NÃO conta; >24h NÃO conta); proposta/pedido
+#   SÓ com elo explícito (pedido de telefone NÃO conta); período respeitado; receita
+#   sum() null-safe;
+# - RLS sob SET ROLE: staff vê números; não-staff vê tudo 0 (fail-closed); anon 42501;
+# - FALSIFICAÇÃO: recria a RPC SEM exigir o elo (o erro de atribuição que o parecer
+#   do Codex alerta) → o assert de pedidos_omie TEM de ficar vermelho.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5445
+DATA="$(mktemp -d /tmp/pgtest-wafunil.XXXXXX)/data"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=en_US.UTF-8 >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l /tmp/pg-wafunil.log -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres wafunil_verify
+P() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d wafunil_verify "$@"; }
+
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-wafunil.XXXXXX")"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -v ON_ERROR_STOP=1 -q -f "$RR"
+rm -f "$RR"
+
+echo "→ grants de prod + auth.uid() fiel…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated, service_role;
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$
+  SELECT coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+  )::uuid
+$f$;
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION auth.uid() TO anon, authenticated, service_role;
+SQL
+
+echo "→ migrations do programa EM ORDEM (010000 HSM → 020000 pendentes → 030000 funil)…"
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260713010000_whatsapp_templates_hsm.sql" >/dev/null
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260713020000_whatsapp_pendentes_rpc.sql" >/dev/null
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260713030000_whatsapp_funil.sql" >/dev/null
+
+echo "→ seed (1 conversa por cenário; sends com created_at explícito)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+INSERT INTO auth.users (id) VALUES
+  ('00000000-0000-0000-0000-0000000aaaa1'),
+  ('00000000-0000-0000-0000-0000000bbbb2'),
+  ('00000000-0000-0000-0000-0000000dddd4')
+ON CONFLICT (id) DO NOTHING;
+INSERT INTO public.user_roles (user_id, role) VALUES
+  ('00000000-0000-0000-0000-0000000aaaa1', 'employee');
+
+INSERT INTO public.whatsapp_conversations (id, phone_key, status) VALUES
+  ('00000000-0000-0000-0000-00000000c001', 'c1', 'aberta'),
+  ('00000000-0000-0000-0000-00000000c002', 'c2', 'aberta'),
+  ('00000000-0000-0000-0000-00000000c003', 'c3', 'aberta'),
+  ('00000000-0000-0000-0000-00000000c004', 'c4', 'aberta');
+
+-- sends (template do seed da 010000):
+--   s1 sent cv1 (sem resposta) · s2 delivered cv2 (in +1h ⇒ respondido)
+--   s3 read cv3 (in +30h ⇒ fora da janela) · s4 failed cv1 · s5 delivered cv4
+--   (in ANTERIOR ao send ⇒ não conta) · s6 queued cv2 (reserva, não é envio)
+INSERT INTO public.whatsapp_template_sends (template_nome, conversation_id, phone_e164, dedupe_key, status, created_at) VALUES
+  ('colacor_proposta_recompra', '00000000-0000-0000-0000-00000000c001', '5537000000001', 'k1', 'sent',      now() - interval '2 days'),
+  ('colacor_proposta_recompra', '00000000-0000-0000-0000-00000000c002', '5537000000002', 'k2', 'delivered', now() - interval '2 days'),
+  ('colacor_proposta_recompra', '00000000-0000-0000-0000-00000000c003', '5537000000003', 'k3', 'read',      now() - interval '3 days'),
+  ('colacor_proposta_recompra', '00000000-0000-0000-0000-00000000c001', '5537000000001', 'k4', 'failed',    now() - interval '2 days'),
+  ('colacor_proposta_recompra', '00000000-0000-0000-0000-00000000c004', '5537000000004', 'k5', 'delivered', now() - interval '1 day'),
+  ('colacor_proposta_recompra', '00000000-0000-0000-0000-00000000c002', '5537000000002', 'k6', 'queued',    now() - interval '1 day');
+
+INSERT INTO public.whatsapp_messages (conversation_id, direction, body, created_at) VALUES
+  ('00000000-0000-0000-0000-00000000c002', 'in', 'quero sim',  now() - interval '2 days' + interval '1 hour'),
+  ('00000000-0000-0000-0000-00000000c003', 'in', 'tarde demais', now() - interval '3 days' + interval '30 hours'),
+  ('00000000-0000-0000-0000-00000000c004', 'in', 'antes do envio', now() - interval '1 day' - interval '1 hour');
+
+-- orders: o1 elo+omie+total(1000) · o2 elo sem omie · o3 SEM elo com omie (telefone!)
+--         o4 elo+omie mas 60d atrás (fora do período de 30d)
+INSERT INTO public.sales_orders (customer_user_id, created_by, total, status, omie_pedido_id, whatsapp_conversation_id, created_at) VALUES
+  ('00000000-0000-0000-0000-0000000dddd4', '00000000-0000-0000-0000-0000000aaaa1', 1000, 'confirmado', 111, '00000000-0000-0000-0000-00000000c002', now() - interval '1 day'),
+  ('00000000-0000-0000-0000-0000000dddd4', '00000000-0000-0000-0000-0000000aaaa1', 500,  'orcamento',  NULL, '00000000-0000-0000-0000-00000000c003', now() - interval '1 day'),
+  ('00000000-0000-0000-0000-0000000dddd4', '00000000-0000-0000-0000-0000000aaaa1', 900,  'confirmado', 222, NULL,                                    now() - interval '1 day'),
+  ('00000000-0000-0000-0000-0000000dddd4', '00000000-0000-0000-0000-0000000aaaa1', 700,  'confirmado', 333, '00000000-0000-0000-0000-00000000c001', now() - interval '60 days');
+SQL
+
+echo "→ asserts do funil sob SET ROLE authenticated (staff)…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+BEGIN;
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-0000000aaaa1","role":"authenticated"}';
+DO $$ DECLARE r record; BEGIN
+  SELECT * INTO r FROM public.get_whatsapp_funil(30);
+  IF r.enviados     <> 4 THEN RAISE EXCEPTION 'FALHA enviados: esperava 4 (s1,s2,s3,s5 — queued fora), veio %', r.enviados; END IF;
+  IF r.entregues    <> 3 THEN RAISE EXCEPTION 'FALHA entregues: esperava 3 (s2,s3,s5), veio %', r.entregues; END IF;
+  IF r.lidos        <> 1 THEN RAISE EXCEPTION 'FALHA lidos: esperava 1 (s3), veio %', r.lidos; END IF;
+  IF r.falhas       <> 1 THEN RAISE EXCEPTION 'FALHA falhas: esperava 1 (s4), veio %', r.falhas; END IF;
+  IF r.respondidos  <> 1 THEN RAISE EXCEPTION 'FALHA respondidos: esperava 1 (só s2 — anterior/30h não contam), veio %', r.respondidos; END IF;
+  IF r.propostas    <> 2 THEN RAISE EXCEPTION 'FALHA propostas: esperava 2 (o1,o2 — sem elo/fora do período não contam), veio %', r.propostas; END IF;
+  IF r.pedidos_omie <> 1 THEN RAISE EXCEPTION 'FALHA pedidos_omie: esperava 1 (o1 — o3 sem elo é TELEFONE), veio %', r.pedidos_omie; END IF;
+  IF r.receita_omie IS DISTINCT FROM 1000 THEN RAISE EXCEPTION 'FALHA receita: esperava 1000 (só o1), veio %', r.receita_omie; END IF;
+END $$;
+ROLLBACK;
+
+-- período curto (p_dias=1... sends de 2-3d ficam fora; s5/s6 de 1d: borda now()-1d NÃO > inicio)
+BEGIN;
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-0000000aaaa1","role":"authenticated"}';
+DO $$ DECLARE r record; BEGIN
+  SELECT * INTO r FROM public.get_whatsapp_funil(2);
+  IF r.enviados <> 1 THEN RAISE EXCEPTION 'FALHA período: p_dias=2 esperava 1 enviado (s5), veio %', r.enviados; END IF;
+END $$;
+ROLLBACK;
+
+-- não-staff: RLS fail-closed → tudo 0 (sends/messages staff-only; sem orders próprios)
+BEGIN;
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-0000000bbbb2","role":"authenticated"}';
+DO $$ DECLARE r record; BEGIN
+  SELECT * INTO r FROM public.get_whatsapp_funil(30);
+  IF r.enviados <> 0 OR r.respondidos <> 0 OR r.propostas <> 0
+    THEN RAISE EXCEPTION 'FALHA RLS: não-staff viu enviados=% respondidos=% propostas=%', r.enviados, r.respondidos, r.propostas; END IF;
+END $$;
+ROLLBACK;
+
+-- anon: EXECUTE revogado por nome → 42501
+BEGIN;
+SET LOCAL ROLE anon;
+DO $$ DECLARE n bigint; BEGIN
+  SELECT enviados INTO n FROM public.get_whatsapp_funil(30);
+  RAISE EXCEPTION 'FALHA: anon EXECUTOU a RPC do funil';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'ok: anon negado 42501'; END $$;
+ROLLBACK;
+SQL
+
+echo "→ FALSIFICAÇÃO: RPC sabotada SEM exigir o elo (atribuição por junk) → assert TEM de ficar vermelho…"
+P -v ON_ERROR_STOP=1 -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.get_whatsapp_funil(p_dias int DEFAULT 30)
+RETURNS TABLE (enviados bigint, entregues bigint, lidos bigint, falhas bigint,
+               respondidos bigint, propostas bigint, pedidos_omie bigint, receita_omie numeric)
+LANGUAGE sql STABLE SECURITY INVOKER SET search_path TO 'public'
+AS $$
+  SELECT 4::bigint, 3::bigint, 1::bigint, 1::bigint, 1::bigint,
+         count(*),
+         count(*) FILTER (WHERE o.omie_pedido_id IS NOT NULL),
+         sum(o.total) FILTER (WHERE o.omie_pedido_id IS NOT NULL)
+    FROM public.sales_orders o
+   WHERE o.created_at >= now() - make_interval(days => p_dias);  -- SABOTADO: sem exigir o elo
+$$;
+SQL
+if P -v ON_ERROR_STOP=1 -q >/dev/null 2>&1 <<'SQL'
+BEGIN;
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-0000000aaaa1","role":"authenticated"}';
+DO $$ DECLARE r record; BEGIN
+  SELECT * INTO r FROM public.get_whatsapp_funil(30);
+  IF r.pedidos_omie <> 1 THEN RAISE EXCEPTION 'sabotagem detectada (pedidos=%)' , r.pedidos_omie; END IF;
+END $$;
+ROLLBACK;
+SQL
+then
+  echo "✗ FALSIFICAÇÃO FALHOU: RPC sem elo passou no assert (pedido de TELEFONE contaria como WhatsApp)"; exit 1
+else
+  echo "ok: sem o elo o assert fica vermelho — a atribuição conservadora morde"
+fi
+P -v ON_ERROR_STOP=1 -q -f "$REPO_ROOT/supabase/migrations/20260713030000_whatsapp_funil.sql" >/dev/null
+
+echo "✅ prova PG17 do PR-3 funil: verde (estágios, janela 24h, elo explícito, período, RLS, falsificação)"

--- a/src/hooks/useWhatsappFunil.ts
+++ b/src/hooks/useWhatsappFunil.ts
@@ -1,0 +1,18 @@
+// Funil do Canal WhatsApp (PR-3): RPC get_whatsapp_funil (INVOKER — RLS staff
+// aplica; não-staff lê zeros). Atribuição por elo explícito, decidida no SQL.
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { mapFunilRow, type WaFunil } from '@/lib/whatsapp/funil';
+
+export function useWhatsappFunil(dias = 30) {
+  return useQuery({
+    queryKey: ['whatsapp', 'funil', dias],
+    queryFn: async (): Promise<WaFunil | null> => {
+      // RPC nova ainda fora do types.ts gerado — mesmo padrão de useDataHealth.ts
+      const { data, error } = await supabase.rpc('get_whatsapp_funil' as never, { p_dias: dias } as never);
+      if (error) throw new Error(error.message);
+      const row = Array.isArray(data) ? (data as unknown[])[0] : data;
+      return mapFunilRow(row ?? null);
+    },
+  });
+}

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -535,6 +535,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/useCustomerCalls.ts",
       "src/hooks/useSendWhatsapp.ts",
       "src/hooks/useWhatsappPendentes.ts",
+      "src/hooks/useWhatsappFunil.ts",
       "src/hooks/useRoutePlanner.ts",
       "src/hooks/useMunicaoLigacao.ts",
       "src/hooks/useCatalisadorLink.ts",

--- a/src/lib/whatsapp/__tests__/funil.test.ts
+++ b/src/lib/whatsapp/__tests__/funil.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { mapFunilRow } from '../funil';
+
+describe('mapFunilRow (row da RPC get_whatsapp_funil → WaFunil)', () => {
+  const row = (over: Record<string, unknown> = {}) => ({
+    enviados: 4,
+    entregues: 3,
+    lidos: 1,
+    falhas: 1,
+    respondidos: 1,
+    propostas: 2,
+    pedidos_omie: 1,
+    receita_omie: '1000.50', // numeric do PostgREST chega como string
+    ...over,
+  });
+
+  it('converte counts e receita (string numérica → number)', () => {
+    const f = mapFunilRow(row());
+    expect(f).toEqual({
+      enviados: 4, entregues: 3, lidos: 1, falhas: 1,
+      respondidos: 1, propostas: 2, pedidosOmie: 1, receitaOmie: 1000.5,
+    });
+  });
+
+  it('receita null PERMANECE null (ausente ≠ zero — nunca fabricar R$ 0)', () => {
+    const f = mapFunilRow(row({ receita_omie: null }));
+    expect(f?.receitaOmie).toBeNull();
+  });
+
+  it('shape inválido vira null, não crash nem números fabricados', () => {
+    expect(mapFunilRow(null)).toBeNull();
+    expect(mapFunilRow('erro')).toBeNull();
+    expect(mapFunilRow(row({ enviados: 'não-é-número' }))).toBeNull();
+  });
+});

--- a/src/lib/whatsapp/funil.ts
+++ b/src/lib/whatsapp/funil.ts
@@ -1,0 +1,38 @@
+// Funil do Canal WhatsApp (PR-3): parse da row de get_whatsapp_funil.
+// Atribuição conservadora decidida no SQL (elo explícito); aqui só o shape.
+
+export interface WaFunil {
+  enviados: number;
+  entregues: number;
+  lidos: number;
+  falhas: number;
+  respondidos: number;
+  propostas: number;
+  pedidosOmie: number;
+  /** null = sem pedidos com total conhecido — NUNCA exibir como R$ 0 (ausente ≠ zero) */
+  receitaOmie: number | null;
+}
+
+const COUNTS = ['enviados', 'entregues', 'lidos', 'falhas', 'respondidos', 'propostas', 'pedidos_omie'] as const;
+
+/** Row da RPC → WaFunil. Counts inválidos invalidam a row inteira (null, não números fabricados). */
+export function mapFunilRow(raw: unknown): WaFunil | null {
+  if (raw === null || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+
+  const counts: number[] = [];
+  for (const key of COUNTS) {
+    const n = typeof r[key] === 'number' ? (r[key] as number) : Number(r[key]);
+    if (!Number.isFinite(n)) return null;
+    counts.push(n);
+  }
+
+  // numeric do PostgREST vem como string; null preservado (sum() sem linhas)
+  const receitaRaw = r['receita_omie'];
+  const receitaOmie =
+    receitaRaw === null || receitaRaw === undefined ? null : Number(receitaRaw);
+  if (receitaOmie !== null && !Number.isFinite(receitaOmie)) return null;
+
+  const [enviados, entregues, lidos, falhas, respondidos, propostas, pedidosOmie] = counts;
+  return { enviados, entregues, lidos, falhas, respondidos, propostas, pedidosOmie, receitaOmie };
+}

--- a/src/pages/WhatsappSlaSupervisao.tsx
+++ b/src/pages/WhatsappSlaSupervisao.tsx
@@ -2,12 +2,64 @@ import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useWhatsappSla, type WaSlaRow } from '@/queries/useWhatsappSla';
+import { useWhatsappFunil } from '@/hooks/useWhatsappFunil';
 import { formatSlaWait } from '@/lib/whatsapp/sla-format';
 
+// formatador local (padrão do repo: cada módulo tem o seu — evita aresta cross-módulo)
+const BRL = new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' });
+
 interface Grupo { ownerId: string | null; total: number; vermelhos: number; amarelos: number; pior: number; }
+
+/** Funil do canal (PR-3): estágios agregados dos últimos 30 dias, atribuição por elo explícito. */
+function FunilDoCanal() {
+  const { data: funil, isLoading, isError } = useWhatsappFunil(30);
+
+  if (isLoading) return <Card className="p-3"><Skeleton className="h-10 w-full" /></Card>;
+  if (isError || !funil) {
+    return (
+      <Card className="p-3 text-xs text-muted-foreground">
+        Funil do canal indisponível agora — não significa que não houve envios.
+      </Card>
+    );
+  }
+
+  const estagios: Array<{ label: string; valor: string; destaque?: string }> = [
+    { label: 'Enviadas', valor: String(funil.enviados) },
+    { label: 'Entregues', valor: String(funil.entregues) },
+    { label: 'Lidas', valor: String(funil.lidos) },
+    { label: 'Responderam', valor: String(funil.respondidos), destaque: 'text-status-success' },
+    { label: 'Falhas', valor: String(funil.falhas), destaque: funil.falhas > 0 ? 'text-status-error' : undefined },
+    { label: 'Propostas', valor: String(funil.propostas) },
+    { label: 'Pedidos Omie', valor: String(funil.pedidosOmie), destaque: 'text-status-info' },
+    // ausente ≠ zero: sem pedido com total conhecido mostra "—", nunca R$ 0
+    { label: 'Receita', valor: funil.receitaOmie === null ? '—' : BRL.format(funil.receitaOmie) },
+  ];
+
+  return (
+    <Card className="p-3 space-y-2">
+      <div className="flex items-baseline justify-between">
+        <div className="text-sm font-medium">Funil do canal — últimos 30 dias</div>
+        <div className="text-[11px] text-muted-foreground">templates HSM</div>
+      </div>
+      <div className="grid grid-cols-4 sm:grid-cols-8 gap-2">
+        {estagios.map((e) => (
+          <div key={e.label}>
+            <div className={`text-lg font-semibold tabular-nums ${e.destaque ?? ''}`}>{e.valor}</div>
+            <div className="text-[11px] text-muted-foreground">{e.label}</div>
+          </div>
+        ))}
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        Atribuição conservadora: proposta/pedido contam só com elo explícito à conversa
+        (nasce no envio de proposta pela conversa — PR-4). Pedido por telefone não entra.
+      </p>
+    </Card>
+  );
+}
 
 function agrupar(rows: WaSlaRow[]): Grupo[] {
   const map = new Map<string, Grupo>();
@@ -57,6 +109,7 @@ export default function WhatsappSlaSupervisao() {
         <h1 className="text-xl font-semibold">SLA do WhatsApp — supervisão</h1>
         <p className="text-xs text-muted-foreground">Clientes sem resposta, por vendedora. Atualiza ao vivo.</p>
       </div>
+      <FunilDoCanal />
       {grupos.length === 0 ? (
         <Card className="p-4 text-sm text-muted-foreground">Nenhum cliente esperando agora. 👌</Card>
       ) : grupos.map((g) => (

--- a/supabase/migrations/20260713030000_whatsapp_funil.sql
+++ b/supabase/migrations/20260713030000_whatsapp_funil.sql
@@ -1,0 +1,75 @@
+-- PR-3 do Canal WhatsApp: funil enviado→entregue→respondeu→proposta→pedido Omie.
+-- Atribuição CONSERVADORA (precisão>recall, parecer Codex): pedido só conta no
+-- canal com elo EXPLÍCITO sales_orders.whatsapp_conversation_id — nunca heurística
+-- por telefone/janela temporal (atribuiria ao WhatsApp pedido fechado por telefone).
+
+-- 1) Elo de atribuição (mesmo desenho do atendimento_id existente). Writer chega
+--    no PR-4 (proposta 1-toque envia a cesta a partir da conversa); até lá os
+--    estágios proposta/pedido leem 0 — honesto, não fabricado.
+ALTER TABLE public.sales_orders
+  ADD COLUMN IF NOT EXISTS whatsapp_conversation_id uuid REFERENCES public.whatsapp_conversations(id);
+
+CREATE INDEX IF NOT EXISTS idx_so_whatsapp_conv
+  ON public.sales_orders(whatsapp_conversation_id)
+  WHERE whatsapp_conversation_id IS NOT NULL;
+
+-- 2) RPC do funil: SECURITY INVOKER — RLS aplica nas 3 tabelas base (sends e
+--    messages são staff-only ⇒ não-staff lê funil zerado, fail-closed).
+--    "Respondeu" = mensagem 'in' na MESMA conversa em até 24h após o send
+--    (janela padrão do canal; resposta ANTERIOR ao envio não conta).
+--    "Enviado" exclui 'queued' (reserva de dedupe que pode nunca ter postado).
+--    Receita: sum() ignora NULL — pedido sem total não vira zero fabricado.
+CREATE OR REPLACE FUNCTION public.get_whatsapp_funil(p_dias int DEFAULT 30)
+RETURNS TABLE (
+  enviados bigint,
+  entregues bigint,
+  lidos bigint,
+  falhas bigint,
+  respondidos bigint,
+  propostas bigint,
+  pedidos_omie bigint,
+  receita_omie numeric
+) LANGUAGE sql STABLE SECURITY INVOKER SET search_path TO 'public'
+AS $$
+  WITH periodo AS (
+    SELECT now() - make_interval(days => least(greatest(p_dias, 1), 365)) AS inicio
+  ),
+  sends AS (
+    SELECT s.id, s.conversation_id, s.status, s.created_at
+      FROM public.whatsapp_template_sends s, periodo
+     WHERE s.created_at >= periodo.inicio
+  ),
+  respondidos AS (
+    SELECT count(DISTINCT s.id) AS n
+      FROM sends s
+     WHERE s.status IN ('sent','delivered','read')
+       AND EXISTS (
+         SELECT 1 FROM public.whatsapp_messages m
+          WHERE m.conversation_id = s.conversation_id
+            AND m.direction = 'in'
+            AND m.created_at > s.created_at
+            AND m.created_at <= s.created_at + interval '24 hours'
+       )
+  ),
+  pedidos AS (
+    SELECT count(*) FILTER (WHERE true)                            AS propostas,
+           count(*) FILTER (WHERE o.omie_pedido_id IS NOT NULL)    AS pedidos_omie,
+           sum(o.total) FILTER (WHERE o.omie_pedido_id IS NOT NULL) AS receita_omie
+      FROM public.sales_orders o, periodo
+     WHERE o.whatsapp_conversation_id IS NOT NULL
+       AND o.created_at >= periodo.inicio
+  )
+  SELECT
+    (SELECT count(*) FROM sends WHERE status IN ('sent','delivered','read')) AS enviados,
+    (SELECT count(*) FROM sends WHERE status IN ('delivered','read'))        AS entregues,
+    (SELECT count(*) FROM sends WHERE status = 'read')                       AS lidos,
+    (SELECT count(*) FROM sends WHERE status = 'failed')                     AS falhas,
+    (SELECT n FROM respondidos)                                              AS respondidos,
+    (SELECT propostas FROM pedidos)                                          AS propostas,
+    (SELECT pedidos_omie FROM pedidos)                                       AS pedidos_omie,
+    (SELECT receita_omie FROM pedidos)                                       AS receita_omie;
+$$;
+
+-- Função nova nasce com EXECUTE pra PUBLIC — revogar por nome (CLAUDE.md)
+REVOKE ALL ON FUNCTION public.get_whatsapp_funil(int) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_whatsapp_funil(int) TO authenticated, service_role;


### PR DESCRIPTION
## O que é

**PR-3 do Programa Canal WhatsApp** ([programa](docs/historico/programa-canal-whatsapp.md); PR-1 #1316 · PR-2 #1318): o **funil do canal** — `enviado → entregue → lido → respondeu → proposta → pedido Omie → receita` — embutido na página de supervisão que já existe (`/whatsapp/sla`), não um "projeto de dashboard" (parecer do Codex: métricas são critério de aceite, não feature futura).

## Atribuição conservadora (o coração do PR)

Risco apontado pelo Codex: *atribuir ao WhatsApp pedido fechado por telefone/vendedor externo*. Resposta: **precisão>recall** —
- `sales_orders.whatsapp_conversation_id` (novo, FK, mesmo desenho do `atendimento_id`): pedido/proposta só contam no funil com **elo explícito** à conversa. **Nenhuma heurística** por telefone/janela temporal.
- O **writer do elo chega no PR-4** (proposta 1-toque nasce da conversa). Até lá, proposta/pedido/receita leem **0/—, honesto** — a UI explica isso em rodapé.
- "Respondeu" = mensagem `in` na MESMA conversa **≤24h após** o send (janela padrão do canal); resposta ANTERIOR ao envio não conta.
- "Enviado" exclui `queued` (reserva de dedupe que pode nunca ter postado).
- Receita: `sum()` ignora NULL — pedido sem total **não vira R$ 0 fabricado**; UI mostra "—" (ausente ≠ zero).

## O que muda

**Banco — migration `20260713030000_whatsapp_funil.sql`** 🟣
- Coluna `whatsapp_conversation_id` em `sales_orders` + índice parcial.
- RPC `get_whatsapp_funil(p_dias default 30)` **SECURITY INVOKER** (RLS staff das 3 tabelas base aplica; não-staff lê zeros, fail-closed; `EXECUTE` revogado de `anon`/`PUBLIC` por nome; `p_dias` com clamp 1..365).

**Frontend** 🖱️
- `mapFunilRow` por TDD (3/3): numeric do PostgREST como string; **receita null preservada** (nunca 0); shape inválido → null.
- `useWhatsappFunil` + seção **"Funil do canal — últimos 30 dias"** na `WhatsappSlaSupervisao` (gate master/gestor existente), 8 estágios densos + rodapé de honestidade.
- Formatador BRL local (padrão do repo — evita aresta cross-módulo); hook registrado no manifesto de módulos.

## Prova

- **PG17 real (`db/test-whatsapp-funil.sh`) → ✅ verde**: aplica as **3 migrations do programa em ordem** (mesma ordem do deploy manual); asserts exatos por estágio (queued fora; resposta anterior/30h fora; pedido sem elo fora; período respeitado; receita 1000 exata); RLS com staff/não-staff/anon(42501); **FALSIFICAÇÃO no risco de negócio**: RPC sabotada SEM exigir o elo → `pedidos_omie` contaria o pedido de telefone → assert fica vermelho (a atribuição conservadora morde).
- `typecheck` 0 · `lint` 0 · suite completa verde (gates de fronteiras e manifesto inclusos).

## Handoff do founder (merge ≠ produção)

1. 🟣 **Migration no SQL Editor**: `supabase/migrations/20260713030000_whatsapp_funil.sql` (após as do PR-1/PR-2, se ainda pendentes). Validação:
   `SELECT proname FROM pg_proc WHERE proname='get_whatsapp_funil';` → 1 linha.
2. 🖱️ **Publish no Lovable** (seção nova em `/whatsapp/sla`).
3. 💬 Edges: **nenhuma** neste PR.

## Próximo (programa)

**PR-4 — Proposta 1-toque** (🟥 prove-sql + Codex adversarial): envia a cesta de `/rota/propostas` pela conversa via template com recotação Omie; é ele que **escreve o elo** e faz proposta/pedido/receita do funil saírem do 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
