### PR TITLE
feat(carteira): Fatia 0 P0-B-bis — ledger de membership (fundação p/ dropar omie_clientes)

### DIFF
--- a/db/carteira-membership-ledger.sql
+++ b/db/carteira-membership-ledger.sql
@@ -1,0 +1,58 @@
+-- Cópia sincronizada da migration versionada — handoff pronto pro SQL Editor do Lovable.
+-- Fonte canônica (aplicada em prod E pelo harness db/test-carteira-membership-ledger.sh):
+--   supabase/migrations/20260712150000_carteira_membership_ledger_fatia0.sql
+-- Se este arquivo e a migration divergirem, a migration VENCE (é o que roda em prod/no PG17 local).
+-- Prova: db/test-carteira-membership-ledger.sh (PG17, backfill+trigger+idempotência+CHECK+RLS, com
+-- falsificação do CHECK de identity_state).
+--
+-- P0-B-bis Fatia 0: ledger de membership da carteira (acumulador durável) + backfill + trigger.
+-- Aditivo: NADA lê o ledger ainda (Fatia 1). RLS espelha omie_clientes.
+
+CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger (
+  user_id       uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  identity_state text NOT NULL DEFAULT 'verified'
+                 CHECK (identity_state IN ('verified','ambiguous','inactive','conflict')),
+  first_seen_at timestamptz NOT NULL,
+  source        text NOT NULL DEFAULT 'trigger'
+                 CHECK (source IN ('backfill','trigger','rpc')),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cml_identity_state
+  ON public.carteira_membership_ledger (identity_state);
+
+ALTER TABLE public.carteira_membership_ledger ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Staff can manage carteira membership ledger" ON public.carteira_membership_ledger;
+CREATE POLICY "Staff can manage carteira membership ledger"
+  ON public.carteira_membership_ledger FOR ALL
+  USING      (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role))
+  WITH CHECK (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role));
+
+DROP POLICY IF EXISTS "Users can view their own membership" ON public.carteira_membership_ledger;
+CREATE POLICY "Users can view their own membership"
+  ON public.carteira_membership_ledger FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Backfill: 1 linha por user_id do espelho, com a data REAL do vínculo (~março).
+INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+SELECT user_id, created_at, 'backfill'
+FROM public.omie_clientes
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Trigger: enquanto o espelho ainda é escrito (Fatias 0-3), captura todo user_id novo.
+-- ON CONFLICT DO NOTHING → idempotente + coexiste com o backfill.
+CREATE OR REPLACE FUNCTION public.tg_omie_clientes_to_ledger()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+  VALUES (NEW.user_id, COALESCE(NEW.created_at, now()), 'trigger')
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_omie_clientes_to_ledger ON public.omie_clientes;
+CREATE TRIGGER trg_omie_clientes_to_ledger
+  AFTER INSERT ON public.omie_clientes
+  FOR EACH ROW EXECUTE FUNCTION public.tg_omie_clientes_to_ledger();

--- a/db/test-carteira-membership-ledger.sh
+++ b/db/test-carteira-membership-ledger.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260712150000_carteira_membership_ledger_fatia0                 ║
+# ║  P0-B-bis Fatia 0: tabela carteira_membership_ledger (backfill + trigger AFTER ║
+# ║  INSERT em omie_clientes + RLS espelhando omie_clientes). Aditivo: NINGUÉM lê   ║
+# ║  o ledger ainda — o risco desta fatia é só "a fundação está certa".            ║
+# ║                                                                                ║
+# ║  Espelha db/test-recencia-fonte-trigger-backfill.sh (trigger+backfill+        ║
+# ║  created_at) pro arranque PG17; o padrão de RLS (SET ROLE authenticated + GUC  ║
+# ║  request.jwt.claim.sub + has_role/user_roles reais) vem de                     ║
+# ║  db/test-profiles-prevent-self-approval.sh / .claude/skills/prove-sql-money-   ║
+# ║  path/references/assert-patterns.md.                                          ║
+# ║                                                                                ║
+# ║  Rode:  heavy bash db/test-carteira-membership-ledger.sh > /tmp/cml.log 2>&1;  ║
+# ║         echo $?           (NÃO pipe pra tail — engole o exit≠0; §2 CLAUDE.md)  ║
+# ║                                                                                ║
+# ║  FALSIFICAÇÃO (Lei #3) — feita por FORA deste script, editando o texto da      ║
+# ║  migration (não embutida numa ZONA 5 inline): remova o `CHECK (identity_state  ║
+# ║  IN (...))` de supabase/migrations/20260712150000_..._fatia0.sql e re-rode     ║
+# ║  este harness do zero → o assert A8 (CHECK identity_state) deve FALHAR/abortar ║
+# ║  o script com SQLSTATE ausente (exit≠0 = vermelho). Reverta a sabotagem e      ║
+# ║  re-rode → volta a verde. Motivo de não sabotar inline: o assert negativo usa  ║
+# ║  um bloco DO/EXCEPTION (Lei #2) — se a defesa realmente cair, o RAISE de       ║
+# ║  re-lançamento propaga como erro real do psql (-v ON_ERROR_STOP=1) e, sob      ║
+# ║  `set -e`, aborta o script ali mesmo; restaurar o CHECK depois exigiria        ║
+# ║  recriar a constraint com ALTER TABLE (CREATE TABLE IF NOT EXISTS não          ║
+# ║  reaplica), o que é mais frágil que re-rodar o harness do zero duas vezes.     ║
+# ║                                                                                ║
+# ║  Lei de Ferro: 1) migration REAL  2) negativo com SQLSTATE + re-raise          ║
+# ║                3) FALSIFICAÇÃO (sabota → exige vermelho → restaura)            ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5482}"
+SLUG="carteira-membership-ledger"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+# roles base do Supabase (anon/authenticated/service_role) + schema auth/auth.users
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+
+# auth.uid() lê o GUC request.jwt.claim.sub — igual ao Supabase real em runtime (não test.uid).
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS
+  $f$ SELECT nullif(current_setting('request.jwt.claim.sub', true), '')::uuid $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (app_role/user_roles/has_role — assinatura real, confirmada
+# via psql-ro em prod: pg_get_functiondef('public.has_role(uuid, app_role)')) +
+# omie_clientes (só as colunas que a migration lê) + SEED SUJO do espelho (u1, u2)
+# ANTES da migration → o backfill embutido nela precisa capturá-los.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('master','employee','customer');
+
+CREATE TABLE public.user_roles (
+  id      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  role    public.app_role NOT NULL
+);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+-- espelho Omie (prod: unique_user_omie UNIQUE(user_id) — 1 linha por user_id; created_at NOT NULL DEFAULT now())
+CREATE TABLE public.omie_clientes (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             uuid NOT NULL UNIQUE,
+  omie_codigo_cliente bigint NOT NULL,
+  created_at          timestamptz NOT NULL DEFAULT now()
+);
+
+-- atores: u1/u2 já no espelho (backfill), u3 chega DEPOIS da migration (trigger), staff = employee
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),  -- u1 (backfill, data-alvo do assert de first_seen_at)
+  ('22222222-2222-2222-2222-222222222222'),  -- u2 (backfill, RLS own-scope)
+  ('33333333-3333-3333-3333-333333333333'),  -- u3 (trigger, inserido pós-migration)
+  ('44444444-4444-4444-4444-444444444444'),  -- u4 (não entra no espelho — alvo do INSERT rejeitado por CHECK)
+  ('99999999-9999-9999-9999-999999999999')   -- staff (employee, RLS all-scope)
+  ON CONFLICT DO NOTHING;
+
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('99999999-9999-9999-9999-999999999999','employee');
+
+INSERT INTO public.omie_clientes(user_id, omie_codigo_cliente, created_at) VALUES
+  ('11111111-1111-1111-1111-111111111111', 9001, '2026-03-01T09:00:00Z'),
+  ('22222222-2222-2222-2222-222222222222', 9002, '2026-03-02T09:00:00Z');
+SQL
+echo "seed sujo aplicado (pré-migration): u1@2026-03-01, u2@2026-03-02 no espelho"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1) — cria tabela+RLS, roda o backfill
+# embutido sobre o seed acima, cria a trigger.
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260712150000_carteira_membership_ledger_fatia0.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# migration --no-privileges (Supabase concede em runtime) → conceda pros asserts de RLS lerem/escreverem;
+# a RLS filtra por cima. has_role() é SECURITY DEFINER: não precisa de GRANT em user_roles pro caller.
+P -q -c "GRANT SELECT, INSERT, UPDATE, DELETE ON public.carteira_membership_ledger TO authenticated;
+         GRANT SELECT ON public.carteira_membership_ledger TO anon;"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── A0: anti-drift (db/carteira-membership-ledger.sql == corpo da migration) ──"
+DIFF=$(diff \
+  <(sed -n '/^CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger/,$p' "$MIG") \
+  <(sed -n '/^CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger/,$p' "$REPO_ROOT/db/carteira-membership-ledger.sql") || true)
+if [ -z "$DIFF" ]; then ok "A0 db/carteira-membership-ledger.sql idêntico ao corpo da migration"; else bad "A0 DIVERGÊNCIA — corrija o handoff: $DIFF"; fi
+
+echo "── asserts: BACKFILL (efeito do apply) ──"
+V=$(Pq -c "SELECT count(*) FROM public.carteira_membership_ledger;")
+eq "A1 backfill: 2 linhas (u1+u2 já estavam no espelho)" "$V" "2"
+
+V=$(Pq -c "SELECT to_char(first_seen_at AT TIME ZONE 'UTC','YYYY-MM-DD') FROM public.carteira_membership_ledger WHERE user_id='11111111-1111-1111-1111-111111111111';")
+eq "A2 backfill preserva first_seen_at = created_at do espelho (NÃO now())" "$V" "2026-03-01"
+
+V=$(Pq -c "SELECT source FROM public.carteira_membership_ledger WHERE user_id='11111111-1111-1111-1111-111111111111';")
+eq "A3 backfill grava source='backfill'" "$V" "backfill"
+
+V=$(Pq -c "SELECT identity_state FROM public.carteira_membership_ledger WHERE user_id='11111111-1111-1111-1111-111111111111';")
+eq "A3b default identity_state='verified'" "$V" "verified"
+
+echo "── assert: TRIGGER (insert pós-migration) ──"
+P -q -c "INSERT INTO public.omie_clientes(user_id, omie_codigo_cliente, created_at) VALUES ('33333333-3333-3333-3333-333333333333', 9003, '2026-07-10T14:00:00Z');"
+V=$(Pq -c "SELECT to_char(first_seen_at AT TIME ZONE 'UTC','YYYY-MM-DD')||'|'||source FROM public.carteira_membership_ledger WHERE user_id='33333333-3333-3333-3333-333333333333';")
+eq "A4 trigger captura user_id novo (first_seen_at=2026-07-10, source=trigger)" "$V" "2026-07-10|trigger"
+
+V=$(Pq -c "SELECT count(*) FROM public.carteira_membership_ledger;")
+eq "A5 ledger tem 3 linhas após o trigger (u1,u2,u3)" "$V" "3"
+
+echo "── assert: IDEMPOTÊNCIA (re-rodar o INSERT..SELECT..ON CONFLICT do backfill) ──"
+P -q -c "INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+         SELECT user_id, created_at, 'backfill' FROM public.omie_clientes
+         ON CONFLICT (user_id) DO NOTHING;"
+
+V=$(Pq -c "SELECT count(*) FROM public.carteira_membership_ledger;")
+eq "A6 backfill re-rodado NÃO duplica (segue 3, mesmo com u3 agora no espelho)" "$V" "3"
+
+V=$(Pq -c "SELECT source FROM public.carteira_membership_ledger WHERE user_id='33333333-3333-3333-3333-333333333333';")
+eq "A7 backfill re-rodado NÃO sobrescreve source='trigger' de u3 (ON CONFLICT DO NOTHING)" "$V" "trigger"
+
+V=$(Pq -c "SELECT to_char(first_seen_at AT TIME ZONE 'UTC','YYYY-MM-DD') FROM public.carteira_membership_ledger WHERE user_id='33333333-3333-3333-3333-333333333333';")
+eq "A7b backfill re-rodado NÃO sobrescreve first_seen_at de u3" "$V" "2026-07-10"
+
+echo "── assert NEGATIVO: CHECK identity_state (23514) ──"
+R=$(P -tA 2>&1 <<'SQL'
+DO $$
+BEGIN
+  UPDATE public.carteira_membership_ledger SET identity_state='xpto' WHERE user_id='11111111-1111-1111-1111-111111111111';
+  RAISE EXCEPTION 'CHECK_IDENTITY_NAO_BARROU';   -- chegou aqui = o CHECK não rejeitou = BUG
+EXCEPTION
+  WHEN check_violation THEN RAISE NOTICE 'CHECK_IDENTITY_OK';  -- 23514 = o erro ESPERADO
+  WHEN OTHERS THEN RAISE;                         -- qualquer outro erro: RELANÇA (não engole)
+END $$;
+SQL
+)
+case "$R" in *CHECK_IDENTITY_OK*) ok "A8 CHECK identity_state rejeita valor fora do enum (23514)" ;; *) bad "A8 — veio: $R" ;; esac
+V=$(Pq -c "SELECT identity_state FROM public.carteira_membership_ledger WHERE user_id='11111111-1111-1111-1111-111111111111';")
+eq "A8b UPDATE rejeitado não alterou identity_state (segue verified)" "$V" "verified"
+
+echo "── assert NEGATIVO: CHECK source (23514) ──"
+R=$(P -tA 2>&1 <<'SQL'
+DO $$
+BEGIN
+  INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+  VALUES ('44444444-4444-4444-4444-444444444444', now(), 'foo');
+  RAISE EXCEPTION 'CHECK_SOURCE_NAO_BARROU';
+EXCEPTION
+  WHEN check_violation THEN RAISE NOTICE 'CHECK_SOURCE_OK';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *CHECK_SOURCE_OK*) ok "A9 CHECK source rejeita valor fora do enum (23514)" ;; *) bad "A9 — veio: $R" ;; esac
+V=$(Pq -c "SELECT count(*) FROM public.carteira_membership_ledger WHERE user_id='44444444-4444-4444-4444-444444444444';")
+eq "A9b INSERT rejeitado não deixou linha órfã" "$V" "0"
+
+echo "── assert RLS (SET ROLE authenticated + GUC request.jwt.claim.sub — psql é superuser e BYPASSA RLS sem isso) ──"
+OWN=$(Pq -c "SET request.jwt.claim.sub='22222222-2222-2222-2222-222222222222'; SET ROLE authenticated; SELECT count(*) FROM public.carteira_membership_ledger;" | tail -1)
+eq "A10 não-staff (u2) enxerga SÓ a própria linha" "$OWN" "1"
+
+STAFF=$(Pq -c "SET request.jwt.claim.sub='99999999-9999-9999-9999-999999999999'; SET ROLE authenticated; SELECT count(*) FROM public.carteira_membership_ledger;" | tail -1)
+eq "A11 staff (employee via has_role) enxerga TODAS as linhas" "$STAFF" "3"
+
+ANON=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.carteira_membership_ledger;" | tail -1)
+eq "A12 anon (sem request.jwt.claim.sub) não enxerga nenhuma linha" "$ANON" "0"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **358** custom migrations totais
-- **1280** objetos esperados (criados por estas migrations)
+- **359** custom migrations totais
+- **1284** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 360
+  - `function`: 361
   - `rls_policy`: 285
-  - `index`: 211
+  - `index`: 212
   - `cron_job`: 146
-  - `table`: 138
-  - `trigger`: 76
+  - `table`: 139
+  - `trigger`: 77
   - `view`: 60
   - `enum_value`: 4
 
@@ -3068,6 +3068,15 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.atualizar_parametros_numericos_skus` | — |
 | `function` | `public.reposicao_param_auto_resumo_tick` | — |
+
+### `20260712150000_carteira_membership_ledger_fatia0.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tg_omie_clientes_to_ledger` | — |
+| `table` | `public.carteira_membership_ledger` | — |
+| `index` | `public.idx_cml_identity_state` | `carteira_membership_ledger` |
+| `trigger` | `public.trg_omie_clientes_to_ledger` | `omie_clientes` |
 
 ## Próximos passos por status
 

--- a/docs/superpowers/plans/2026-07-12-fatia0-carteira-membership-ledger.md
+++ b/docs/superpowers/plans/2026-07-12-fatia0-carteira-membership-ledger.md
@@ -1,0 +1,152 @@
+# Fatia 0 — `carteira_membership_ledger` (fundação) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Criar a tabela-ledger de membership da carteira (acumulador durável), fazê-la nascer com os 6909 membros de hoje (backfill preservando a data real do vínculo) e mantê-la em dia via trigger no espelho — SEM ainda ninguém lê-la (aditivo, zero mudança de comportamento).
+
+**Architecture:** Migration aditiva única. `carteira_membership_ledger(user_id PK, identity_state, first_seen_at, source)`. Backfill copia `omie_clientes(user_id, created_at)`. Trigger `AFTER INSERT` em `omie_clientes` espelha todo `user_id` novo para o ledger com `ON CONFLICT DO NOTHING` — cobre os 6 writers durante a transição, sem tocá-los. Prova em PostgreSQL 17 local (prove-sql-money-path) antes de entregar; deploy via lovable-db-operator (SQL Editor).
+
+**Tech Stack:** PostgreSQL 17 (Supabase). Migration SQL pura. Teste: harness PG17 descartável (`db/test-*.sh`). Deploy: SQL Editor do Lovable (migration custom NÃO auto-aplica).
+
+## Global Constraints (verbatim da spec + CLAUDE.md)
+
+- money-path/DDL → **prove-sql PG17 obrigatório** (asserts +/- com SQLSTATE + falsificação) ANTES de entregar.
+- Migration custom NÃO auto-aplica no Lovable (falha SILENCIOSA) → handoff via **lovable-db-operator** (bloco SQL Editor + validação pós-apply por psql-ro).
+- Tabela nova **sempre** com RLS. SECURITY DEFINER **sempre** com `SET search_path`.
+- Aditivo: ledger vazio/parcial → consumidores (Fatia 1+) degradam como hoje. Esta fatia não tem consumidor → risco de comportamento = zero.
+- **Invariante:** ledger é acumulador — `user_id` uma vez dentro NUNCA sai; transições mudam `identity_state`, não a presença.
+- Épico QUENTE: conferir timestamp da migration vs `origin/main` + worktrees `omie-identidade`/`carteira-vendedor-oben-hardening` antes de criar (colisão de timestamp = aviso).
+
+---
+
+## File Structure
+
+- **Create:** `supabase/migrations/<TS>_carteira_membership_ledger_fatia0.sql` — a migration (tabela + índice + RLS + backfill + trigger). `<TS>` = timestamp `YYYYMMDDHHMMSS` posterior ao topo de `origin/main` (hoje `20260712140000` é o mais novo → usar `20260712150000` se livre; reconferir no momento).
+- **Create:** `db/test-carteira-membership-ledger.sh` + `db/carteira-membership-ledger.sql` — harness prove-sql PG17 (espelhar `db/test-recencia-fonte-trigger-backfill.sh`, que já cobre trigger+backfill+created_at).
+- **Não toca:** nenhum código de app. Nenhum leitor do ledger existe até a Fatia 1.
+
+---
+
+### Task 1: Migration + prova PG17 + handoff de deploy
+
+**Files:**
+- Create: `supabase/migrations/<TS>_carteira_membership_ledger_fatia0.sql`
+- Create: `db/test-carteira-membership-ledger.sh`, `db/carteira-membership-ledger.sql`
+
+**Interfaces:**
+- Produces (a Fatia 1 consome): tabela `public.carteira_membership_ledger` com colunas `user_id uuid PK`, `identity_state text ∈ {verified,ambiguous,inactive,conflict}`, `first_seen_at timestamptz`, `source text ∈ {backfill,trigger,rpc}`, `updated_at timestamptz`. Contém 1 linha por `user_id` distinto de `omie_clientes`.
+
+- [ ] **Step 1: Escrever a migration (código real — sem placeholder)**
+
+```sql
+-- <TS>_carteira_membership_ledger_fatia0.sql
+-- P0-B-bis Fatia 0: ledger de membership da carteira (acumulador durável) + backfill + trigger.
+-- Aditivo: NADA lê o ledger ainda (Fatia 1). RLS espelha omie_clientes.
+
+CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger (
+  user_id       uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  identity_state text NOT NULL DEFAULT 'verified'
+                 CHECK (identity_state IN ('verified','ambiguous','inactive','conflict')),
+  first_seen_at timestamptz NOT NULL,
+  source        text NOT NULL DEFAULT 'trigger'
+                 CHECK (source IN ('backfill','trigger','rpc')),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cml_identity_state
+  ON public.carteira_membership_ledger (identity_state);
+
+ALTER TABLE public.carteira_membership_ledger ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Staff can manage carteira membership ledger"
+  ON public.carteira_membership_ledger FOR ALL
+  USING      (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role))
+  WITH CHECK (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role));
+
+CREATE POLICY "Users can view their own membership"
+  ON public.carteira_membership_ledger FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Backfill: 1 linha por user_id do espelho, com a data REAL do vínculo (~março).
+INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+SELECT user_id, created_at, 'backfill'
+FROM public.omie_clientes
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Trigger: enquanto o espelho ainda é escrito (Fatias 0-3), captura todo user_id novo.
+-- ON CONFLICT DO NOTHING → idempotente + coexiste com o backfill.
+CREATE OR REPLACE FUNCTION public.tg_omie_clientes_to_ledger()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+  VALUES (NEW.user_id, COALESCE(NEW.created_at, now()), 'trigger')
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_omie_clientes_to_ledger ON public.omie_clientes;
+CREATE TRIGGER trg_omie_clientes_to_ledger
+  AFTER INSERT ON public.omie_clientes
+  FOR EACH ROW EXECUTE FUNCTION public.tg_omie_clientes_to_ledger();
+```
+
+- [ ] **Step 2: Escrever o harness prove-sql PG17 (asserts + e −)**
+
+Invocar a skill **prove-sql-money-path** apontando `db/test-recencia-fonte-trigger-backfill.sh` como template (trigger+backfill+created_at). O harness aplica a migration REAL e prova, no mínimo:
+
+```sql
+-- Seed mínimo: auth.users(u1,u2), omie_clientes(u1 @ '2026-03-01', u2 @ '2026-03-02'), has_role stub.
+-- ASSERT + (backfill): 2 linhas no ledger; first_seen_at de u1 = '2026-03-01' (data preservada, NÃO now()).
+-- ASSERT + (trigger): INSERT omie_clientes(u3 @ '2026-07-10') → ledger passa a ter u3 com first_seen_at='2026-07-10', source='trigger'.
+-- ASSERT + (idempotência): re-rodar o backfill (INSERT..SELECT..ON CONFLICT) NÃO duplica nem sobrescreve source='backfill'.
+-- ASSERT − (CHECK identity_state): UPDATE ledger SET identity_state='xpto' → SQLSTATE 23514 (re-raise se ≠).
+-- ASSERT − (CHECK source): INSERT source='foo' → SQLSTATE 23514.
+-- ASSERT RLS: SET ROLE authenticated + GUC request.jwt.claim.sub=u2 (não-staff) → SELECT vê SÓ a própria linha (1);
+--             com GUC=staff (has_role stub true) → vê todas (3).
+```
+
+- [ ] **Step 3: Rodar o teste → verde; depois FALSIFICAR → vermelho**
+
+Run: `heavy bash db/test-carteira-membership-ledger.sh > /tmp/cml.log 2>&1; echo $?`
+Expected: exit `0`, todos os asserts PASS.
+Falsificação (exigir vermelho): remover o `CHECK (identity_state IN ...)` da migration e re-rodar → o assert − deve FALHAR (prova que o teste tem dente). Reverter a sabotagem.
+
+- [ ] **Step 4: Handoff de deploy (lovable-db-operator)**
+
+Invocar **lovable-db-operator** para empacotar: (a) o bloco pronto pro SQL Editor (a migration acima), (b) a query de validação pós-apply por psql-ro:
+
+```sql
+-- Pós-apply (psql-ro): cobertura idêntica ao espelho + 0 fora do CHECK.
+SELECT
+  (SELECT count(*) FROM omie_clientes)                          AS espelho,
+  (SELECT count(*) FROM carteira_membership_ledger)             AS ledger,
+  (SELECT count(*) FROM carteira_membership_ledger
+     WHERE identity_state NOT IN ('verified','ambiguous','inactive','conflict')) AS fora_check;
+-- Esperado: espelho == ledger (6909 == 6909), fora_check == 0.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/*_carteira_membership_ledger_fatia0.sql db/test-carteira-membership-ledger.sh db/carteira-membership-ledger.sql
+git commit -m "feat(carteira): ledger de membership (Fatia 0 P0-B-bis) — backfill + trigger, aditivo, provado PG17
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review (plano × spec)
+
+**1. Cobertura da spec (§3, §5-Fatia0, §7):** ✅ tabela com os 4 campos (user_id/identity_state/first_seen_at/source) — §3. ✅ backfill preserva `first_seen_at` (o `created_at` que `analytics-sync:1566` precisa) — §3/§9. ✅ trigger cobre os 6 writers sem tocá-los — §5. ✅ RLS espelha omie_clientes — §3. ✅ prove-sql com +/− + falsificação + RLS sob SET ROLE — §7. ✅ handoff lovable-db-operator — §8.
+- `eligible` e `vendedor` NÃO entram nesta fatia (vivem em carteira_assignments / proof) — correto, §3.
+- `identity_state` só existe como coluna com default 'verified'; a POPULAÇÃO das transições é Fatia 2 — correto, o plano não a implementa aqui.
+
+**2. Placeholders:** `<TS>` é o único — é um timestamp que depende de coordenação multi-sessão no momento da criação (documentado no File Structure). Não é placeholder de conteúdo.
+
+**3. Consistência de tipos:** `user_id uuid`, `first_seen_at timestamptz`, `identity_state`/`source` com os mesmos enums na tabela, no backfill, no trigger e nos asserts. `has_role(auth.uid(),'master'::app_role)` = assinatura real confirmada por psql-ro.
+
+## Próximas fatias (planos próprios, após esta aplicada e provada)
+- **Fatia 1** — `carteira-rebuild` lê o ledger (edge; paridade `src/lib/carteira/rebuild-helpers.ts`; quarantined por identity_state). Deploy de edge.
+- Fatias 2-5 — identity_state → leitores→proof → writers→RPC → DROP.

--- a/docs/superpowers/specs/2026-07-12-carteira-membership-ledger-drop-espelho-design.md
+++ b/docs/superpowers/specs/2026-07-12-carteira-membership-ledger-drop-espelho-design.md
@@ -1,0 +1,109 @@
+# Carteira membership ledger — aposentar o espelho `omie_clientes` (P0-B-bis, fatia final) — design
+
+> money-path (identidade de cliente + carteira de vendedor). Conduzido por Claude + `/codex consult` (gpt-5.6-sol, high) que **refutou** a 1ª recomendação (A′) — refutação verificada por leitura direta. Decisão registrada: `06f5d418`. Levantamento por psql-ro (prod) + 2 subagentes de classificação. Deploy PENDENTE do founder. `prove-sql PG17 + REVISÃO INDEPENDENTE DO DIFF (Codex) PENDENTES por fatia`.
+
+## 1. Problema
+
+`omie_clientes` é o espelho `user_id → omie_codigo_cliente`. `empresa_omie` é 100% o default mentiroso `'colacor'` (nenhum dos 6 writers a seta) — código físico é um MIX de contas Omie (oben bulk + colacor_sc manual). Épico P0-B-bis já migrou: syncPedidos (#1285), leitores de display (#1296), writer vendedor→proof (#1293), carteira-rebuild VENDEDOR (#1303). Falta aposentar o espelho de vez.
+
+**A última dependência dura** é a **LISTA de membros** da carteira: `carteira-rebuild` faz `.from('omie_clientes').select('user_id')` ([carteira-rebuild:251](../../../supabase/functions/carteira-rebuild/index.ts)) — só o CONJUNTO de user_ids. Vendedor, alias e flaggeds já vêm de fontes account-corretas. A "proof" account-correta (`omie_customer_account_map`, opção C de uma rodada anterior) é **document-first**, e ~1633 "clones" (user_ids Omie sem `profiles.document`) nunca entram nela.
+
+### Fatos medidos (psql-ro, produção, 2026-07-12)
+- `omie_clientes`: **6909** user_ids distintos.
+- `omie_customer_account_map` (proof): **5276** distintos (todos com document).
+- `proof ∪ customer_canonical_alias(active)` = **6909** = 100% do espelho. Órfãos (só no espelho) = **0**. Aritmética: 5276 + 1633 clones (no alias) = 6909.
+- Docs ambíguos (mesmo doc, 2+ users) HOJE = **0**. Aliases: 1633, todos `active`.
+
+## 2. A decisão — opção D (não A′)
+
+Três candidatos ao problema "de onde vem a lista": **A′** (view de união `proof∪alias` + guard de não-encolhimento), **B** (tabela dedicada acumuladora), **C** (popular clones na proof).
+
+**A′ foi REFUTADA pelo Codex e a refutação foi VERIFICADA.** O mecanismo:
+- O `carteira-rebuild` faz **upsert-only sem reconciliar ausentes** ([:357](../../../supabase/functions/carteira-rebuild/index.ts), `onConflict: 'customer_user_id'`, sem DELETE). A propriedade que o espelho garante não é "cardinalidade estável" — é **"todo membro já visto continua na entrada para ser reprocessado"**.
+- Se um user some da entrada (ex.: doc vira ambíguo → sync o deleta da proof em [omie-analytics-sync:444](../../../supabase/functions/omie-analytics-sync/index.ts) → some da view A′), o rebuild não gera row para ele → **o assignment antigo `U→V` persiste STALE** (vendedor errado continua válido). Isso é o pior resultado money-path — pior que "encolher".
+- O guard de cardinalidade não distingue quebra × ambiguidade × consolidação × substituição (mesma contagem, conjunto diferente). Bomba concreta e executável hoje: `mapaConsolidacao` re-executado não-dry-run rebaixa os 1633 aliases `active→inactive` de uma vez ([:1868](../../../supabase/functions/omie-analytics-sync/index.ts), dry_run default false).
+
+**C** é pior (mistura semântica document-first, colide com `UNIQUE(codigo,account)`, delete-de-ambíguos persiste). **B** é conceitualmente correta (membership é fato durável; proof/alias são projeções revogáveis) mas o risco real é o big-bang de 6 writers.
+
+**Opção D = B feita direito.** Ordem de preferência do Codex: **D > B > manter `omie_clientes` > A′ > C**.
+
+## 3. Arquitetura
+
+Separar 4 conceitos que hoje estão colapsados no espelho:
+
+| conceito | natureza | onde vive |
+|---|---|---|
+| **membership** | fato histórico, **acumulador** (nunca encolhe) | `carteira_membership_ledger` (NOVO) |
+| **identity_state** | mutável: `verified`/`ambiguous`/`inactive`/`conflict` | coluna no ledger |
+| **eligible** | projeção operacional | `carteira_assignments` (já existe; setado no rebuild) |
+| **vendedor** | account-correto | `omie_customer_account_map(_fresco)` (proof, já usada) |
+
+### `carteira_membership_ledger` (tabela nova, aditiva)
+- `user_id uuid PK → auth.users ON DELETE CASCADE`
+- `identity_state text NOT NULL DEFAULT 'verified' CHECK (identity_state IN ('verified','ambiguous','inactive','conflict'))`
+- `first_seen_at timestamptz NOT NULL` — a data REAL do vínculo (backfill copia `omie_clientes.created_at`, ~março; preserva o que `analytics-sync:1566` precisa e a proof não tem)
+- `source text CHECK (source IN ('backfill','trigger','rpc'))`
+- `updated_at timestamptz DEFAULT now()`
+- RLS espelhando `omie_clientes`: Staff ALL (`has_role master|employee`), user SELECT próprio. Índice `(identity_state)`.
+
+**Invariante central:** um user_id, uma vez no ledger, **nunca é removido** — transições de identidade mudam `identity_state`, nunca a presença. "Ausente da entrada" **nunca** é interpretado como revogação.
+
+### Fluxo do rebuild (novo)
+1. Lê **todos** os membros do ledger (acumulador → cobertura estável, sem depender do frescor de sync).
+2. Para cada membro: vendedor via proof oben; alias via `customer_canonical_alias`; flaggeds via `cliente_classificacao`.
+3. `identity_state ∈ {ambiguous,conflict}` → **quarantined**: vendedor removido, `eligible=false`, membro preservado, **zero comissão** (transição correta do Codex para doc-ambíguo).
+4. Reconcilia: todo membro do ledger → uma row em `carteira_assignments`.
+
+### Quem seta `identity_state`
+- backfill/trigger → `verified` (default).
+- sync que deleta da proof por ambiguidade ([analytics-sync:444](../../../supabase/functions/omie-analytics-sync/index.ts)) → `ambiguous` no ledger (em vez de o user sumir).
+- `mapaConsolidacao` alias `inactive`/`conflict` → reflete no ledger do clone.
+
+## 4. Levantamento — 17 sítios (classificados; ruído de tipos/comentários/UI excluído)
+
+### 🔴 ESCRITORES — 6 pontuais (migram p/ RPC `register_carteira_member` na Fatia 4) + 1 bulk (§9)
+| sítio | fluxo | nota |
+|---|---|---|
+| `Auth.tsx:133` | signup (frontend direto) | grava `omie_codigo_cliente_integracao` (proof não tem) |
+| `AdminApprovals.tsx:113` | aprovação (frontend direto) | gate-leitor `:92` (`already_linked`) é par indivisível |
+| `omie-cliente:654` | `criar_perfil_local` (match doc) | fluxo de pedido |
+| `omie-cliente:705` | `criar_perfil_local` (placeholder novo) | |
+| `omie-cliente:829` | `sync_all_clients` (import massa) | único que grava `..._integracao` |
+| `omie-sync:371` | write-back self-service | já anotado `TODO Fatia 4` |
+| *(bulk)* `analytics-sync:468` | bulk oben (`account='vendas'`) | o principal; já popula a proof em `:482` |
+
+### ⭐ Leitor da LISTA (o coração) → migra p/ ledger
+- `carteira-rebuild:251`
+
+### 🟡 Leitores de código/vendedor → migram p/ proof
+- **6 OBEN (troca mecânica `.eq('account','oben')`, baixo risco):** `useBuscaClienteOmie:35/78`, `useCustomerSelection:209/247`, `FarmerCalls:213/312`
+- **money-path pedido (JÁ neutralizados — filtram `empresa_omie` que nunca é real → retornam `[]` → fallback API):** `omie-vendas-sync:1751/2441`, `useUnifiedOrder:516/562`
+- **edges:** `omie-cliente:627/750/909`, `ai-ops-agent:250` (vendedor), `analytics-sync:238/550/1566` (auto-consumo; `:1566` precisa de `created_at` → coberto pelo ledger)
+- **JÁ migrado (não bloqueia):** `SalesPrintDashboard:215` (via view fresca)
+
+## 5. Fatiamento (multi-PR, aditivo → cada passo fail-safe)
+
+- **Fatia 0 — fundação (migration):** cria `carteira_membership_ledger` + backfill dos 6909 (com `first_seen_at`=`omie_clientes.created_at`) + trigger `AFTER INSERT` em `omie_clientes` (`ON CONFLICT DO NOTHING`, `source='trigger'`). O trigger cobre os 6 writers **sem tocá-los** durante a transição. **prove-sql PG17** (CREATE + RLS sob `SET ROLE` + trigger + falsificação).
+- **Fatia 1 — rebuild lê o ledger:** `carteira-rebuild:251` → ledger; reconcilia `identity_state`→eligible/quarantined; vendedor da proof. **prove-sql** (paridade do helper `rebuild-helpers` + guard). Fecha a decisão-chave.
+- **Fatia 2 — popular `identity_state`:** sync marca `ambiguous` no ledger ao deletar da proof (`:444`); `mapaConsolidacao` reflete `inactive`/`conflict`. Torna o `quarantined` real. **Independente da Fatia 1:** até rodar, todos ficam `verified` (default) → rebuild = comportamento de hoje; a Fatia 2 só ATIVA o quarantine (aditivo, fail-safe).
+- **Fatia 3 — migrar leitores de código → proof:** 6 OBEN + edges. Baixo risco (já degradados). Frontend Publish + edges.
+- **Fatia 4 — migrar 6 writers → RPC `register_carteira_member`:** escreve ledger (membership) + proof (`source='manual'` p/ o código account-correto) e **para** de escrever o espelho. Ordem: leitores antes dos writers; gate `AdminApprovals:92` casa com seu writer `:113`.
+- **Fatia 5 — DROP:** removido o último leitor/escritor e o trigger ocioso → `DROP TABLE omie_clientes` + regenerar `types.ts`. **prove-sql PG17 + lovable-db-operator**.
+
+## 6. Invariantes / error handling
+- Ledger **nunca** perde membro (acumulador). "Ausente" ≠ revogação.
+- Doc ambíguo → `quarantined` (vendedor null, eligible=false, membro vivo, zero comissão) — **não** remove da lista, **não** deixa vendedor stale.
+- Todo passo é aditivo: ledger/coluna vazios → consumidores degradam como hoje (fail-safe).
+- Trigger + backfill cobrem 100% durante a transição; só a Fatia 4 desacopla os writers; só a Fatia 5 dropa.
+
+## 7. Testing (prove-sql PG17, por fatia money-path/DDL)
+- Fatia 0: CREATE real + RLS sob `SET ROLE authenticated` + GUC; backfill preserva `first_seen_at`; trigger idempotente (`ON CONFLICT`); falsificação (sabotar CHECK/trigger → exigir vermelho).
+- Fatia 1: paridade `computeCarteira` edge×`src/lib/carteira/rebuild-helpers.ts`; asserts +/- do quarantined; guard de baseline preservado.
+- Fatia 4/5: RPC prova positiva+negativa; DROP só após grep zero de leitor/escritor.
+
+## 8. Deploy (ordem, por fatia)
+Migration (SQL Editor) → edge (chat Lovable, verbatim) → rodar/backfill → validar (psql-ro: cobertura, 0 ambiguidade) → Publish frontend. Cada fatia é PR próprio (auto-merge no CI verde). Épico QUENTE: coordenar com `omie-identidade` (A1 #1298 / A2) e `carteira-vendedor-oben-hardening` antes de tocar `omie-analytics-sync` / `carteira-rebuild`.
+
+## 9. Resíduos conhecidos
+- `omie_codigo_cliente_integracao` (writers `Auth`/`AdminApprovals`/`omie-cliente:829`): decidir na Fatia 4 se a proof ganha a coluna ou se é descartada (nenhum leitor a consome — candidata a descarte).
+- `analytics-sync:468` (bulk oben) é o único writer que também alimenta a proof; pode ser o último a largar o espelho ou parar quando ledger+proof estabilizarem.

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 358
+-- Total de custom migrations: 359
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -397,7 +397,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260711090000', 'prime_fundacao', '20260711090000_prime_fundacao.sql'),
   ('20260711145000', 'v_grupo_contatos_fresca', '20260711145000_v_grupo_contatos_fresca.sql'),
   ('20260711193000', 'param_auto_resumo_altas_reducoes_segurado', '20260711193000_param_auto_resumo_altas_reducoes_segurado.sql'),
-  ('20260712140000', 'param_auto_log_valor_barrado_fusivel', '20260712140000_param_auto_log_valor_barrado_fusivel.sql')
+  ('20260712140000', 'param_auto_log_valor_barrado_fusivel', '20260712140000_param_auto_log_valor_barrado_fusivel.sql'),
+  ('20260712150000', 'carteira_membership_ledger_fatia0', '20260712150000_carteira_membership_ledger_fatia0.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1668,7 +1669,11 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', ''),
   ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', ''),
   ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'atualizar_parametros_numericos_skus', ''),
-  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
+  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'reposicao_param_auto_resumo_tick', ''),
+  ('carteira_membership_ledger_fatia0', 'function', 'public', 'tg_omie_clientes_to_ledger', ''),
+  ('carteira_membership_ledger_fatia0', 'table', 'public', 'carteira_membership_ledger', ''),
+  ('carteira_membership_ledger_fatia0', 'index', 'public', 'idx_cml_identity_state', 'carteira_membership_ledger'),
+  ('carteira_membership_ledger_fatia0', 'trigger', 'public', 'trg_omie_clientes_to_ledger', 'omie_clientes')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2987,7 +2992,11 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('v_grupo_contatos_fresca', 'view', 'public', 'v_grupo_contatos', ''),
   ('param_auto_resumo_altas_reducoes_segurado', 'function', 'public', 'reposicao_param_auto_resumo_tick', ''),
   ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'atualizar_parametros_numericos_skus', ''),
-  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'reposicao_param_auto_resumo_tick', '')
+  ('param_auto_log_valor_barrado_fusivel', 'function', 'public', 'reposicao_param_auto_resumo_tick', ''),
+  ('carteira_membership_ledger_fatia0', 'function', 'public', 'tg_omie_clientes_to_ledger', ''),
+  ('carteira_membership_ledger_fatia0', 'table', 'public', 'carteira_membership_ledger', ''),
+  ('carteira_membership_ledger_fatia0', 'index', 'public', 'idx_cml_identity_state', 'carteira_membership_ledger'),
+  ('carteira_membership_ledger_fatia0', 'trigger', 'public', 'trg_omie_clientes_to_ledger', 'omie_clientes')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260712150000_carteira_membership_ledger_fatia0.sql
+++ b/supabase/migrations/20260712150000_carteira_membership_ledger_fatia0.sql
@@ -1,0 +1,52 @@
+-- 20260712150000_carteira_membership_ledger_fatia0.sql
+-- P0-B-bis Fatia 0: ledger de membership da carteira (acumulador durável) + backfill + trigger.
+-- Aditivo: NADA lê o ledger ainda (Fatia 1). RLS espelha omie_clientes.
+
+CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger (
+  user_id       uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  identity_state text NOT NULL DEFAULT 'verified'
+                 CHECK (identity_state IN ('verified','ambiguous','inactive','conflict')),
+  first_seen_at timestamptz NOT NULL,
+  source        text NOT NULL DEFAULT 'trigger'
+                 CHECK (source IN ('backfill','trigger','rpc')),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cml_identity_state
+  ON public.carteira_membership_ledger (identity_state);
+
+ALTER TABLE public.carteira_membership_ledger ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Staff can manage carteira membership ledger" ON public.carteira_membership_ledger;
+CREATE POLICY "Staff can manage carteira membership ledger"
+  ON public.carteira_membership_ledger FOR ALL
+  USING      (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role))
+  WITH CHECK (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role));
+
+DROP POLICY IF EXISTS "Users can view their own membership" ON public.carteira_membership_ledger;
+CREATE POLICY "Users can view their own membership"
+  ON public.carteira_membership_ledger FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Backfill: 1 linha por user_id do espelho, com a data REAL do vínculo (~março).
+INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+SELECT user_id, created_at, 'backfill'
+FROM public.omie_clientes
+ON CONFLICT (user_id) DO NOTHING;
+
+-- Trigger: enquanto o espelho ainda é escrito (Fatias 0-3), captura todo user_id novo.
+-- ON CONFLICT DO NOTHING → idempotente + coexiste com o backfill.
+CREATE OR REPLACE FUNCTION public.tg_omie_clientes_to_ledger()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+BEGIN
+  INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
+  VALUES (NEW.user_id, COALESCE(NEW.created_at, now()), 'trigger')
+  ON CONFLICT (user_id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_omie_clientes_to_ledger ON public.omie_clientes;
+CREATE TRIGGER trg_omie_clientes_to_ledger
+  AFTER INSERT ON public.omie_clientes
+  FOR EACH ROW EXECUTE FUNCTION public.tg_omie_clientes_to_ledger();


### PR DESCRIPTION
## P0-B-bis Fatia 0 — fundação do ledger de membership

Primeira fatia do épico que remove o espelho poluído `omie_clientes`. **Aditiva**: cria `carteira_membership_ledger` (acumulador durável) + backfill (preserva `first_seen_at` = o `created_at` real do vínculo) + trigger `AFTER INSERT` no espelho. **Ninguém lê o ledger ainda** → risco de comportamento = zero.

**Por quê:** o `carteira-rebuild` lê a LISTA de membros do espelho — incluindo **1633 clones B-lite que não estão na proof** (cadastro sem document). O ledger, backfillado do espelho, preserva essa lista (clones inclusos) pra que as próximas fatias migrem os leitores e, só na fatia FINAL, dropem o espelho — sem congelar a carteira (evita reincidência do incidente 100% Hunter). Arquitetura (Opção D — ledger dedicado) escolhida com o Codex (que refutou a view-de-união A′) e validada pela sessão irmã #1303.

**Provado (money-path):** `db/test-carteira-membership-ledger.sh` (PG17) — **17/17 verde**: backfill preserva `created_at` (não `now()`), trigger executado de verdade, idempotência do `ON CONFLICT DO NOTHING`, CHECKs negativos com SQLSTATE 23514 + re-raise, RLS sob `SET ROLE authenticated` + GUC (own-scope / staff-all / anon-zero). **Falsificação**: sabotar o CHECK → vermelho (exit 3) → restaurar → verde. Task-review (independente): **Approved, 0 Critical/Important**.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260712150000_carteira_membership_ledger_fatia0.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar. Pré-voo PROD 🟢 (referências existem, tabela ainda não, espelho=6909).

<details><summary>SQL pra aplicar</summary>

```sql
CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger (
  user_id       uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
  identity_state text NOT NULL DEFAULT 'verified'
                 CHECK (identity_state IN ('verified','ambiguous','inactive','conflict')),
  first_seen_at timestamptz NOT NULL,
  source        text NOT NULL DEFAULT 'trigger'
                 CHECK (source IN ('backfill','trigger','rpc')),
  updated_at    timestamptz NOT NULL DEFAULT now()
);
CREATE INDEX IF NOT EXISTS idx_cml_identity_state ON public.carteira_membership_ledger (identity_state);
ALTER TABLE public.carteira_membership_ledger ENABLE ROW LEVEL SECURITY;
DROP POLICY IF EXISTS "Staff can manage carteira membership ledger" ON public.carteira_membership_ledger;
CREATE POLICY "Staff can manage carteira membership ledger" ON public.carteira_membership_ledger FOR ALL
  USING      (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role))
  WITH CHECK (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role));
DROP POLICY IF EXISTS "Users can view their own membership" ON public.carteira_membership_ledger;
CREATE POLICY "Users can view their own membership" ON public.carteira_membership_ledger FOR SELECT
  USING (auth.uid() = user_id);
INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
SELECT user_id, created_at, 'backfill' FROM public.omie_clientes ON CONFLICT (user_id) DO NOTHING;
CREATE OR REPLACE FUNCTION public.tg_omie_clientes_to_ledger()
RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
BEGIN
  INSERT INTO public.carteira_membership_ledger (user_id, first_seen_at, source)
  VALUES (NEW.user_id, COALESCE(NEW.created_at, now()), 'trigger') ON CONFLICT (user_id) DO NOTHING;
  RETURN NEW;
END; $$;
DROP TRIGGER IF EXISTS trg_omie_clientes_to_ledger ON public.omie_clientes;
CREATE TRIGGER trg_omie_clientes_to_ledger AFTER INSERT ON public.omie_clientes
  FOR EACH ROW EXECUTE FUNCTION public.tg_omie_clientes_to_ledger();
```
</details>

Validação pós-apply (o autor roda via psql-ro): tabela existe · `espelho == ledger` (~6909) · `fora_check = 0` · trigger ativo.

## Trava de ordem — NÃO dropar o espelho ainda
Esta é a Fatia 0 (fundação). O `DROP TABLE omie_clientes` é a fatia **FINAL**, só depois de: Fatia 1 (rebuild lê o ledger) + migrar os leitores restantes + cruzar `ai-ops-agent`. Spec: `docs/superpowers/specs/2026-07-12-espelho-omie-rotulo-por-conta-design.md`. Plano: `docs/superpowers/plans/2026-07-12-fatia0-carteira-membership-ledger.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
