### PR TITLE
fix(ai-ops): keyset com sentinela nil UUID — hotfix do 1º deploy

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -884,6 +884,16 @@ describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opç
       src,
       'REGRESSÃO (Codex #2): a paginação keyset perdeu o avanço do cursor — truncaria em 1 página',
     ).toMatch(/lastCustomerId\s*=\s*rows\[rows\.length - 1\]/);
+    // REGRESSÃO real (o 1º deploy ABORTOU em runtime): o cursor keyset em coluna UUID não pode iniciar em
+    // "" — "" não casta para uuid no Postgres (invalid input syntax for type uuid ""). Sentinela = nil UUID.
+    expect(
+      src,
+      'REGRESSÃO: cursor keyset inicia em "" — inválido em coluna UUID; derrubou o 1º deploy do ai-ops-agent',
+    ).not.toMatch(/lastCustomerId\s*=\s*""/);
+    expect(
+      src,
+      'o cursor keyset precisa de sentinela nil UUID válida (00000000-...-000000000000)',
+    ).toMatch(/0{8}-0{4}-0{4}-0{4}-0{12}/);
     // Falso-verde que o Codex #2 pegou: buildOwnerMap([]) passaria os asserts frouxos. Trava o argumento REAL.
     expect(
       src,

--- a/supabase/functions/ai-ops-agent/index.ts
+++ b/supabase/functions/ai-ops-agent/index.ts
@@ -264,8 +264,11 @@ serve(async (req) => {
     //    cliente com métrica (clone→Hunter, gêmeo→vendedor). Paginação por KEYSET em customer_user_id (não
     //    offset): carteira_assignments é dinâmica (cron carteira-rebuild 07:30) — .range/offset pularia uma
     //    linha se o rebuild inserisse/removesse uma chave entre páginas → farmer_id null (Codex ponta 3).
+    // Sentinela do keyset = nil UUID (menor que todo UUID real). "" NÃO casta para uuid no Postgres
+    // (ERROR: invalid input syntax for type uuid "") — o footgun que abortou o 1º deploy desta função.
+    const NIL_UUID = "00000000-0000-0000-0000-000000000000";
     const assignmentsRaw: AssignmentRow[] = [];
-    let lastCustomerId = "";
+    let lastCustomerId = NIL_UUID;
     for (;;) {
       const { data: aPage, error: aError } = await supabase
         .from("carteira_assignments")


### PR DESCRIPTION
Hotfix do #1317. O keyset da carteira (introduzido no Codex #3) iniciava o cursor em `""` e fazia `.gt("customer_user_id", "")` — mas `customer_user_id` é **UUID** e `""` não casta → `invalid input syntax for type uuid ""`. O `ai-ops-agent` abortava no load da carteira **toda vez** (a 1ª página sempre roda `.gt("", …)`), com ou sem auth.

## Por que passou pelos gates

Todos textuais (o canário confere que o keyset **existe**, não o **executa**). É o footgun *"teste EXECUTANDO"* do CLAUDE.md, agora numa query PostgREST em vez de PL/pgSQL. Detectado no **1º deploy real** (a invocação retornou o erro).

## Provas (psql-ro, read-only)

- `.gt(nil_uuid)` → retorna linhas (owner ≠ cliente). ✅
- `.gt('')` → reproduz **exatamente** `ERROR: invalid input syntax for type uuid ""`. ✅
- **Sem dano:** as decisões pending/circulares ficaram **intactas** — o load aborta **antes** do purge (etapa 5), nada foi deletado.

## Correção

Sentinela do keyset = **nil UUID** (`00000000-…-000000000000`), menor que todo UUID real. O canário ganhou assert anti-regressão (`not /lastCustomerId = ""/` + exige nil UUID), **falsificado** (sabotar → vermelho). `deno check` + canário verdes.

## Pós-merge (Lovable ≠ produção)

1. **Re-deploy do edge `ai-ops-agent`** verbatim pelo chat do Lovable.
2. **Rodar o agente** no AI Ops.
3. **psql-ro:** conferir que os `pending` com `farmer_id = customer_user_id` caem a **0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
