### PR TITLE
feat(afiacao): recomendações determinísticas no dashboard do cliente (PR2 benchmark #13)

### DIFF
--- a/src/components/CustomerDashboard.tsx
+++ b/src/components/CustomerDashboard.tsx
@@ -14,6 +14,7 @@ import { PriorityCard } from '@/components/customerDashboard/PriorityCard';
 import { GamificationMini } from '@/components/customerDashboard/GamificationMini';
 import { PedidosAndamento } from '@/components/customerDashboard/PedidosAndamento';
 import { FerramentasAtencao } from '@/components/customerDashboard/FerramentasAtencao';
+import { RecomendacoesCliente } from '@/components/customerDashboard/RecomendacoesCliente';
 import { AcoesRapidas } from '@/components/customerDashboard/AcoesRapidas';
 import type { Profile, Order, UserTool } from '@/components/customerDashboard/types';
 
@@ -87,6 +88,9 @@ export function CustomerDashboard({ profile, pendingOrders, userTools, getGreeti
             <FerramentasAtencao urgentTools={urgentTools} navigate={navigate} />
           </motion.section>
         )}
+
+        {/* ─── Recomendações consultivas determinísticas (PR2 · benchmark #13) ─── */}
+        <RecomendacoesCliente userTools={userTools} navigate={navigate} />
 
         {/* ─── SEÇÃO 4: Ações Rápidas ─── */}
         <motion.section variants={fadeUp}>

--- a/src/components/customerDashboard/RecomendacoesCliente.tsx
+++ b/src/components/customerDashboard/RecomendacoesCliente.tsx
@@ -1,0 +1,170 @@
+// Seção "Recomendações para você" do CustomerDashboard (PR2 do benchmark #13).
+// Consultoria em produto via dados: cards DETERMINÍSTICOS derivados de Tools + Savings.
+// Toda a lógica (e a degradação honesta money-path) vive no helper puro testado
+// src/lib/afiacao/recomendacoes.ts — aqui é só apresentação.
+import { useMemo, type ReactNode } from 'react';
+import { motion } from 'framer-motion';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Clock, CalendarClock, PiggyBank, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useAuth } from '@/contexts/AuthContext';
+import { useDeliveredOrders12m } from '@/queries/useOrders';
+import { track } from '@/lib/analytics';
+import { gerarRecomendacoes, resumirEconomia, type ToolInput, type Recomendacao } from '@/lib/afiacao/recomendacoes';
+import type { UserTool } from './types';
+
+interface RecomendacoesClienteProps {
+  userTools: UserTool[];
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+const brl = (v: number) => `R$ ${Math.round(v).toLocaleString('pt-BR')}`;
+
+function nomesResumidos(ferramentas: { nome: string }[]): string {
+  const nomes = ferramentas.slice(0, 3).map((f) => f.nome);
+  const resto = ferramentas.length - nomes.length;
+  return resto > 0 ? `${nomes.join(', ')} +${resto}` : nomes.join(', ');
+}
+
+export function RecomendacoesCliente({ userTools, navigate }: RecomendacoesClienteProps) {
+  const { user } = useAuth();
+  const { data: orders = [] } = useDeliveredOrders12m(user?.id);
+
+  const recomendacoes = useMemo(() => {
+    const tools: ToolInput[] = userTools.map((t) => ({
+      id: t.id,
+      nome: t.tool_categories?.name ?? 'Ferramenta',
+      next_sharpening_due: t.next_sharpening_due,
+      last_sharpened_at: t.last_sharpened_at,
+      sharpening_interval_days: t.sharpening_interval_days,
+      suggested_interval_days: t.tool_categories?.suggested_interval_days ?? null,
+    }));
+    return gerarRecomendacoes({ tools, economia: resumirEconomia(orders) });
+  }, [userTools, orders]);
+
+  if (recomendacoes.length === 0) return null;
+
+  return (
+    <motion.section
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="font-display font-bold text-lg text-foreground">Recomendações para você</h2>
+      </div>
+      <div className="space-y-3">
+        {recomendacoes.map((rec) => (
+          <RecomendacaoCard key={rec.tipo} rec={rec} navigate={navigate} />
+        ))}
+      </div>
+    </motion.section>
+  );
+}
+
+function RecomendacaoCard({
+  rec,
+  navigate,
+}: {
+  rec: Recomendacao;
+  navigate: ReturnType<typeof useNavigate>;
+}) {
+  if (rec.tipo === 'economia') {
+    return (
+      <CardBase
+        icon={<PiggyBank className="w-5 h-5 text-status-success" />}
+        iconBg="bg-status-success-bg"
+        titulo={`Você já economizou ~${brl(rec.economiaComprovada)} afiando em vez de comprar`}
+        descricao={
+          rec.economiaPotencial != null
+            ? `Afiar as ${rec.nAtrasadas} ferramenta(s) atrasada(s), em vez de trocar, pode render mais ~${brl(rec.economiaPotencial)}. Estimativa com base no custo médio de uma ferramenta nova.`
+            : 'Estimativa com base no custo médio de uma ferramenta nova; os valores de afiação são reais dos seus pedidos.'
+        }
+        ctaLabel="Ver economia"
+        onClick={() => {
+          track('recomendacoes.cta', { tipo: rec.tipo });
+          navigate('/savings');
+        }}
+      />
+    );
+  }
+
+  if (rec.tipo === 'possivelmente_atrasada') {
+    const n = rec.ferramentas.length;
+    return (
+      <CardBase
+        icon={<Clock className="w-5 h-5 text-status-warning" />}
+        iconBg="bg-status-warning-bg"
+        titulo={
+          n === 1
+            ? '1 ferramenta pode estar passando do ponto de afiação'
+            : `${n} ferramentas podem estar passando do ponto de afiação`
+        }
+        descricao={`${nomesResumidos(rec.ferramentas)} — pelo intervalo, já passou da data sugerida. Vale conferir o fio.`}
+        ctaLabel="Agendar afiação"
+        onClick={() => {
+          track('recomendacoes.cta', { tipo: rec.tipo });
+          navigate('/new-order');
+        }}
+      />
+    );
+  }
+
+  // sem_programacao
+  const n = rec.ferramentas.length;
+  return (
+    <CardBase
+      icon={<CalendarClock className="w-5 h-5 text-status-info" />}
+      iconBg="bg-status-info-bg"
+      titulo={
+        n === 1
+          ? '1 ferramenta sem programação de afiação'
+          : `${n} ferramentas sem programação de afiação`
+      }
+      descricao={`${nomesResumidos(rec.ferramentas)} — defina um intervalo para receber lembretes no momento certo.`}
+      ctaLabel="Definir programação"
+      onClick={() => {
+        track('recomendacoes.cta', { tipo: rec.tipo });
+        navigate('/tools');
+      }}
+    />
+  );
+}
+
+function CardBase({
+  icon,
+  iconBg,
+  titulo,
+  descricao,
+  ctaLabel,
+  onClick,
+}: {
+  icon: ReactNode;
+  iconBg: string;
+  titulo: string;
+  descricao: string;
+  ctaLabel: string;
+  onClick: () => void;
+}) {
+  return (
+    <Card className="overflow-hidden">
+      <CardContent className="p-4">
+        <div className="flex items-start gap-3">
+          <div className={cn('w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0', iconBg)}>
+            {icon}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-semibold text-foreground text-sm leading-tight">{titulo}</p>
+            <p className="text-xs text-muted-foreground mt-1">{descricao}</p>
+          </div>
+        </div>
+        <Button size="sm" variant="outline" className="w-full mt-3 gap-1" onClick={onClick}>
+          {ctaLabel}
+          <ChevronRight className="w-4 h-4" />
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/customerDashboard/__tests__/FerramentasAtencao.test.tsx
+++ b/src/components/customerDashboard/__tests__/FerramentasAtencao.test.tsx
@@ -9,8 +9,9 @@ function makeTool(o: Partial<UserTool> = {}): UserTool {
     id: "t1",
     tool_category_id: "c1",
     next_sharpening_due: new Date(Date.now() - 5 * 86400000).toISOString(),
+    last_sharpened_at: null,
     sharpening_interval_days: 30,
-    tool_categories: { name: "Faca de corte" },
+    tool_categories: { name: "Faca de corte", suggested_interval_days: null },
     ...o,
   };
 }

--- a/src/components/customerDashboard/__tests__/priority.test.ts
+++ b/src/components/customerDashboard/__tests__/priority.test.ts
@@ -10,8 +10,9 @@ function makeTool(o: Partial<UserTool> = {}): UserTool {
     id: "t1",
     tool_category_id: "c1",
     next_sharpening_due: null,
+    last_sharpened_at: null,
     sharpening_interval_days: 30,
-    tool_categories: { name: "Faca" },
+    tool_categories: { name: "Faca", suggested_interval_days: null },
     ...o,
   };
 }

--- a/src/components/customerDashboard/types.ts
+++ b/src/components/customerDashboard/types.ts
@@ -19,8 +19,9 @@ export interface UserTool {
   id: string;
   tool_category_id: string;
   next_sharpening_due: string | null;
+  last_sharpened_at: string | null;
   sharpening_interval_days: number | null;
-  tool_categories: { name: string };
+  tool_categories: { name: string; suggested_interval_days: number | null };
 }
 
 export interface PriorityAction {

--- a/src/lib/afiacao/recomendacoes.test.ts
+++ b/src/lib/afiacao/recomendacoes.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import {
+  gerarRecomendacoes,
+  resumirEconomia,
+  CUSTO_MEDIO_FERRAMENTA_NOVA_BRL,
+  type ToolInput,
+  type EconomiaInput,
+  type Recomendacao,
+} from './recomendacoes';
+
+// ── Datas de referência (construídas em horário LOCAL para não flakear por fuso) ──
+// O helper parseia as strings com parseISO (local midnight), então comparar com um
+// `hoje` também em local midnight mantém as bordas de dia estáveis em qualquer TZ.
+const HOJE = new Date(2026, 6, 13); // 13 jul 2026
+
+function tool(over: Partial<ToolInput> = {}): ToolInput {
+  return {
+    id: over.id ?? 'tool-1',
+    nome: over.nome ?? 'Serra circular',
+    next_sharpening_due: 'next_sharpening_due' in over ? over.next_sharpening_due! : null,
+    last_sharpened_at: 'last_sharpened_at' in over ? over.last_sharpened_at! : null,
+    sharpening_interval_days: 'sharpening_interval_days' in over ? over.sharpening_interval_days! : null,
+    suggested_interval_days: 'suggested_interval_days' in over ? over.suggested_interval_days! : null,
+  };
+}
+
+function economia(over: Partial<EconomiaInput> = {}): EconomiaInput {
+  return {
+    totalAfiacoes: over.totalAfiacoes ?? 0,
+    totalGastoReal: over.totalGastoReal ?? 0,
+  };
+}
+
+function pick<T extends Recomendacao['tipo']>(recs: Recomendacao[], tipo: T) {
+  return recs.find((r) => r.tipo === tipo) as Extract<Recomendacao, { tipo: T }> | undefined;
+}
+
+describe('gerarRecomendacoes — possivelmente_atrasada (não-agendada)', () => {
+  it('sinaliza ferramenta não-agendada cuja última afiação + intervalo já passou', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ id: 'a', nome: 'Plaina', last_sharpened_at: '2026-06-01', sharpening_interval_days: 30 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'possivelmente_atrasada');
+    expect(r).toBeDefined();
+    expect(r!.ferramentas).toEqual([{ id: 'a', nome: 'Plaina' }]);
+  });
+
+  it('NÃO sinaliza quando a projeção última+intervalo ainda está no futuro', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ last_sharpened_at: '2026-07-10', sharpening_interval_days: 30 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
+  });
+
+  it('NÃO sinaliza sem last_sharpened_at, mesmo com intervalo (ausente ≠ atrasada)', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ last_sharpened_at: null, sharpening_interval_days: 30 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
+    // e também não cai em sem_programacao (tem intervalo → há base de lembrete)
+    expect(pick(recs, 'sem_programacao')).toBeUndefined();
+  });
+
+  it('NÃO sinaliza sem intervalo algum (ferramenta nem categoria)', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ last_sharpened_at: '2026-01-01', sharpening_interval_days: null, suggested_interval_days: null })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
+  });
+
+  it('NÃO duplica o PriorityCard: ferramenta AGENDADA vencida não entra em possivelmente_atrasada', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ next_sharpening_due: '2026-07-01', last_sharpened_at: '2026-06-01', sharpening_interval_days: 30 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
+  });
+
+  it('usa suggested_interval_days da categoria quando a ferramenta não tem intervalo próprio', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ id: 'c', nome: 'Broca', last_sharpened_at: '2026-06-01', sharpening_interval_days: null, suggested_interval_days: 30 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'possivelmente_atrasada');
+    expect(r?.ferramentas).toEqual([{ id: 'c', nome: 'Broca' }]);
+  });
+
+  it('borda: última + intervalo == hoje ainda NÃO é atrasada (só estritamente antes)', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ last_sharpened_at: '2026-06-13', sharpening_interval_days: 30 })], // 2026-07-13 == hoje
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
+  });
+});
+
+describe('gerarRecomendacoes — sem_programacao', () => {
+  it('sinaliza ferramenta sem next_due e sem intervalo algum', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ id: 'x', nome: 'Faca', next_sharpening_due: null, sharpening_interval_days: null, suggested_interval_days: null })],
+      economia: null,
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'sem_programacao');
+    expect(r?.ferramentas).toEqual([{ id: 'x', nome: 'Faca' }]);
+  });
+
+  it('NÃO sinaliza quando há intervalo (existe base para lembrete)', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ next_sharpening_due: null, sharpening_interval_days: 45 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'sem_programacao')).toBeUndefined();
+  });
+
+  it('NÃO sinaliza ferramenta já agendada (tem next_due)', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ next_sharpening_due: '2026-08-01', sharpening_interval_days: null, suggested_interval_days: null })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'sem_programacao')).toBeUndefined();
+  });
+});
+
+describe('gerarRecomendacoes — economia (comprovada + potencial)', () => {
+  it('sem objeto de economia → sem card de economia', () => {
+    const recs = gerarRecomendacoes({ tools: [], economia: null, hoje: HOJE });
+    expect(pick(recs, 'economia')).toBeUndefined();
+  });
+
+  it('degrada (sem card) quando não há afiações — evita 0/0', () => {
+    const recs = gerarRecomendacoes({ tools: [], economia: economia({ totalAfiacoes: 0, totalGastoReal: 0 }), hoje: HOJE });
+    expect(pick(recs, 'economia')).toBeUndefined();
+  });
+
+  it('degrada (sem card) quando o gasto real é 0 (dado suspeito, não infla)', () => {
+    const recs = gerarRecomendacoes({ tools: [], economia: economia({ totalAfiacoes: 5, totalGastoReal: 0 }), hoje: HOJE });
+    expect(pick(recs, 'economia')).toBeUndefined();
+  });
+
+  it('economia comprovada = afiações × custo-nova − gasto real', () => {
+    const recs = gerarRecomendacoes({
+      tools: [],
+      economia: economia({ totalAfiacoes: 10, totalGastoReal: 500 }),
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'economia');
+    expect(r?.economiaComprovada).toBe(10 * CUSTO_MEDIO_FERRAMENTA_NOVA_BRL - 500); // 2000
+    expect(r?.economiaPotencial).toBeNull(); // sem ferramentas atrasadas
+  });
+
+  it('degrada (sem card) quando a economia comprovada seria ≤ 0', () => {
+    const recs = gerarRecomendacoes({
+      tools: [],
+      economia: economia({ totalAfiacoes: 1, totalGastoReal: 250 }), // 1×250−250 = 0
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'economia')).toBeUndefined();
+  });
+
+  it('economia potencial = nAtrasadas × (custo-nova − custo-médio-real)', () => {
+    const recs = gerarRecomendacoes({
+      // 1 agendada-vencida + 1 possivelmente-atrasada = 2 atrasadas
+      tools: [
+        tool({ id: 'v', next_sharpening_due: '2026-07-01' }),
+        tool({ id: 'p', last_sharpened_at: '2026-06-01', sharpening_interval_days: 30 }),
+      ],
+      economia: economia({ totalAfiacoes: 10, totalGastoReal: 500 }), // custo médio = 50
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'economia');
+    // 2 × (250 − 50) = 400
+    expect(r?.economiaComprovada).toBe(2000);
+    expect(r?.economiaPotencial).toBe(2 * (CUSTO_MEDIO_FERRAMENTA_NOVA_BRL - 50));
+    expect(r?.nAtrasadas).toBe(2);
+  });
+
+  it('economia potencial é null quando não há ferramentas atrasadas', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ next_sharpening_due: '2026-08-01' })], // agendada futura, não atrasada
+      economia: economia({ totalAfiacoes: 10, totalGastoReal: 500 }),
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'economia');
+    expect(r?.economiaComprovada).toBe(2000);
+    expect(r?.economiaPotencial).toBeNull();
+  });
+});
+
+describe('gerarRecomendacoes — composição e ordem', () => {
+  it('input vazio → sem recomendações', () => {
+    expect(gerarRecomendacoes({ tools: [], economia: null, hoje: HOJE })).toEqual([]);
+  });
+
+  it('ordena: possivelmente_atrasada → sem_programacao → economia', () => {
+    const recs = gerarRecomendacoes({
+      tools: [
+        tool({ id: 'p', last_sharpened_at: '2026-06-01', sharpening_interval_days: 30 }), // possivelmente atrasada
+        tool({ id: 's', next_sharpening_due: null, sharpening_interval_days: null }), // sem programação
+      ],
+      economia: economia({ totalAfiacoes: 10, totalGastoReal: 500 }),
+      hoje: HOJE,
+    });
+    expect(recs.map((r) => r.tipo)).toEqual(['possivelmente_atrasada', 'sem_programacao', 'economia']);
+  });
+});
+
+describe('resumirEconomia — parse defensivo dos itens (jsonb)', () => {
+  it('soma quantidades dos itens e os totais dos pedidos', () => {
+    const res = resumirEconomia([
+      { items: [{ quantity: 2 }, { quantity: 3 }], total: 300 },
+      { items: [{ quantity: 1 }], total: 100 },
+    ]);
+    expect(res).toEqual({ totalAfiacoes: 6, totalGastoReal: 400 });
+  });
+
+  it('item sem quantity conta como 1 (espelha o SavingsDashboard)', () => {
+    const res = resumirEconomia([{ items: [{}, {}], total: 80 }]);
+    expect(res.totalAfiacoes).toBe(2);
+  });
+
+  it('items ausente/não-array e total nulo não quebram nem fabricam número', () => {
+    const res = resumirEconomia([
+      { items: null, total: null },
+      { items: undefined as unknown as unknown[], total: 50 },
+    ]);
+    expect(res).toEqual({ totalAfiacoes: 0, totalGastoReal: 50 });
+  });
+});

--- a/src/lib/afiacao/recomendacoes.ts
+++ b/src/lib/afiacao/recomendacoes.ts
@@ -1,0 +1,172 @@
+// Recomendações consultivas DETERMINÍSTICAS para o cliente (PR2 do benchmark #13).
+// Regra de ouro (money-path): só regras determinísticas sobre dado confiável.
+// Ausente ≠ zero — na dúvida a recomendação NÃO é gerada (degradação honesta),
+// nunca se fabrica um número. Ver docs/historico/benchmark-concorrentes-marcenaria-2026-07.md.
+import { parseISO, addDays, differenceInCalendarDays } from 'date-fns';
+
+/**
+ * Custo médio ESTIMADO de uma ferramenta nova (R$). É uma estimativa de negócio,
+ * não um dado do cliente — espelha o AVG_NEW_TOOL_COST de SavingsDashboard.tsx.
+ * Sempre exibido ao cliente com o rótulo "estimativa".
+ */
+export const CUSTO_MEDIO_FERRAMENTA_NOVA_BRL = 250;
+
+export interface ToolInput {
+  id: string;
+  nome: string;
+  /** Vencimento AGENDADO da próxima afiação (ISO) ou null se não agendada. */
+  next_sharpening_due: string | null;
+  /** Data da última afiação (ISO) ou null. */
+  last_sharpened_at: string | null;
+  /** Intervalo de afiação da própria ferramenta (dias) ou null. */
+  sharpening_interval_days: number | null;
+  /** Intervalo sugerido pela categoria (dias) ou null — fallback do anterior. */
+  suggested_interval_days: number | null;
+}
+
+/** Agregados REAIS derivados dos pedidos entregues (nunca estimados). */
+export interface EconomiaInput {
+  /** Total de afiações realizadas (soma das quantidades dos itens entregues). */
+  totalAfiacoes: number;
+  /** Total efetivamente pago em afiação (R$, soma dos totais dos pedidos). */
+  totalGastoReal: number;
+}
+
+export interface FerramentaAfetada {
+  id: string;
+  nome: string;
+}
+
+export type Recomendacao =
+  | { tipo: 'possivelmente_atrasada'; ferramentas: FerramentaAfetada[] }
+  | { tipo: 'sem_programacao'; ferramentas: FerramentaAfetada[] }
+  | {
+      tipo: 'economia';
+      /** Economia já realizada vs. comprar novas (R$). Sempre > 0 quando presente. */
+      economiaComprovada: number;
+      /** Projeção de afiar (em vez de trocar) as atrasadas (R$), ou null se indeterminável. */
+      economiaPotencial: number | null;
+      /** Nº de ferramentas atualmente atrasadas (agendadas-vencidas + possivelmente-atrasadas). */
+      nAtrasadas: number;
+    };
+
+export interface GerarRecomendacoesInput {
+  tools: ToolInput[];
+  economia: EconomiaInput | null;
+  /** Custo de ferramenta nova (R$). Default: CUSTO_MEDIO_FERRAMENTA_NOVA_BRL. */
+  custoNovaEstimado?: number;
+  /** "Hoje" injetável para testes determinísticos. Default: new Date(). */
+  hoje?: Date;
+}
+
+/** Pedido entregue cru (items é jsonb → unknown; total pode faltar). */
+export interface PedidoEntregueInput {
+  items: unknown;
+  total: number | null;
+}
+
+/** Intervalo de afiação efetivo (dias): o da ferramenta ou, na falta, o da categoria. */
+function intervaloEfetivo(t: ToolInput): number | null {
+  const dias = t.sharpening_interval_days ?? t.suggested_interval_days;
+  return dias != null && dias > 0 ? dias : null;
+}
+
+/**
+ * Ferramenta NÃO-agendada que já passou do ponto pela projeção última-afiação + intervalo.
+ * Exige last_sharpened_at E intervalo — sem qualquer um, degrada (ausente ≠ atrasada).
+ * Ferramenta agendada (com next_due) fica de fora: já é coberta pelo PriorityCard.
+ */
+function ehPossivelmenteAtrasada(t: ToolInput, hoje: Date): boolean {
+  if (t.next_sharpening_due) return false;
+  if (!t.last_sharpened_at) return false;
+  const intervalo = intervaloEfetivo(t);
+  if (intervalo == null) return false;
+  const projetada = addDays(parseISO(t.last_sharpened_at), intervalo);
+  return differenceInCalendarDays(hoje, projetada) > 0;
+}
+
+/** Sem next_due E sem intervalo algum → não há base para lembrete. */
+function ehSemProgramacao(t: ToolInput): boolean {
+  return t.next_sharpening_due == null && intervaloEfetivo(t) == null;
+}
+
+/** Atrasada de fato: agendada-vencida OU possivelmente-atrasada (não-agendada projetada). */
+function estaAtrasada(t: ToolInput, hoje: Date): boolean {
+  if (t.next_sharpening_due) {
+    return differenceInCalendarDays(hoje, parseISO(t.next_sharpening_due)) > 0;
+  }
+  return ehPossivelmenteAtrasada(t, hoje);
+}
+
+function calcularEconomia(
+  tools: ToolInput[],
+  economia: EconomiaInput,
+  custoNova: number,
+  hoje: Date,
+): Extract<Recomendacao, { tipo: 'economia' }> | null {
+  const { totalAfiacoes, totalGastoReal } = economia;
+  // Sem histórico real não há base — nunca dividir 0/0 nem inflar com gasto zero.
+  if (totalAfiacoes <= 0 || totalGastoReal <= 0) return null;
+
+  const economiaComprovada = totalAfiacoes * custoNova - totalGastoReal;
+  if (economiaComprovada <= 0) return null; // não anuncia economia ≤ 0
+
+  const custoMedioAfiacaoReal = totalGastoReal / totalAfiacoes;
+  const nAtrasadas = tools.filter((t) => estaAtrasada(t, hoje)).length;
+  const economiaPotencial =
+    nAtrasadas > 0 && custoNova > custoMedioAfiacaoReal
+      ? nAtrasadas * (custoNova - custoMedioAfiacaoReal)
+      : null;
+
+  return { tipo: 'economia', economiaComprovada, economiaPotencial, nAtrasadas };
+}
+
+/**
+ * Recomendações consultivas determinísticas, na ordem de prioridade:
+ * possivelmente_atrasada → sem_programacao → economia. Só entra o que o dado sustenta.
+ */
+export function gerarRecomendacoes(input: GerarRecomendacoesInput): Recomendacao[] {
+  const { tools, economia } = input;
+  const hoje = input.hoje ?? new Date();
+  const custoNova = input.custoNovaEstimado ?? CUSTO_MEDIO_FERRAMENTA_NOVA_BRL;
+
+  const recs: Recomendacao[] = [];
+
+  const atrasadas = tools.filter((t) => ehPossivelmenteAtrasada(t, hoje));
+  if (atrasadas.length > 0) {
+    recs.push({ tipo: 'possivelmente_atrasada', ferramentas: atrasadas.map((t) => ({ id: t.id, nome: t.nome })) });
+  }
+
+  const semProgramacao = tools.filter(ehSemProgramacao);
+  if (semProgramacao.length > 0) {
+    recs.push({ tipo: 'sem_programacao', ferramentas: semProgramacao.map((t) => ({ id: t.id, nome: t.nome })) });
+  }
+
+  if (economia) {
+    const eco = calcularEconomia(tools, economia, custoNova, hoje);
+    if (eco) recs.push(eco);
+  }
+
+  return recs;
+}
+
+/**
+ * Agrega pedidos entregues em totais REAIS. Parse defensivo do jsonb `items`:
+ * item sem quantidade conta como 1 (espelha o SavingsDashboard); items não-array
+ * e total nulo viram 0 — nunca quebram nem fabricam número.
+ */
+export function resumirEconomia(orders: PedidoEntregueInput[]): EconomiaInput {
+  let totalAfiacoes = 0;
+  let totalGastoReal = 0;
+
+  for (const order of orders) {
+    const items = Array.isArray(order.items) ? order.items : [];
+    for (const item of items) {
+      const q = Number((item as { quantity?: unknown } | null)?.quantity);
+      totalAfiacoes += Number.isFinite(q) && q > 0 ? q : 1;
+    }
+    totalGastoReal += Number(order.total) || 0;
+  }
+
+  return { totalAfiacoes, totalGastoReal };
+}

--- a/src/queries/useUserTools.ts
+++ b/src/queries/useUserTools.ts
@@ -47,15 +47,16 @@ export function useUserToolsSummary(userId: string | undefined, enabled = true) 
     queryFn: async () => {
       const { data, error } = await supabase
         .from('user_tools')
-        .select(`id, tool_category_id, next_sharpening_due, sharpening_interval_days, tool_categories (name)`)
+        .select(`id, tool_category_id, next_sharpening_due, last_sharpened_at, sharpening_interval_days, tool_categories (name, suggested_interval_days)`)
         .eq('user_id', userId!);
       if (error) throw error;
       return (data ?? []) as unknown as {
         id: string;
         tool_category_id: string;
         next_sharpening_due: string | null;
+        last_sharpened_at: string | null;
         sharpening_interval_days: number | null;
-        tool_categories: { name: string };
+        tool_categories: { name: string; suggested_interval_days: number | null };
       }[];
     },
     enabled: !!userId && enabled,


### PR DESCRIPTION
## PR2 — Recomendações determinísticas (Onda 1 · benchmark marcenaria #13)

"Consultoria em produto via dados": cards **determinísticos** no dashboard do cliente, derivados de `Tools` (status/histórico de ferramentas) e `SavingsDashboard` (ROI da afiação). É o que as redes associativas oferecem como consultoria humana — aqui, escalável a partir dos nossos próprios dados.

### O que entra (3 tipos de card)
- **Possivelmente atrasada** — ferramenta **não-agendada** cuja `última afiação + intervalo` (da ferramenta ou, no fallback, da categoria) já passou. Complementa o `PriorityCard` (que já cobre agendadas-vencidas) **sem duplicar**. O "possivelmente" é a degradação honesta: é projeção do intervalo, não medição do fio.
- **Sem programação** — ferramentas sem `next_due` **e** sem intervalo (hoje invisíveis no dashboard). "Defina um intervalo para receber lembretes."
- **Economia** — comprovada (retrospectiva, dado real dos pedidos entregues) + potencial (projeção de afiar em vez de trocar as atrasadas), **rotulada como estimativa**.

### Rigor money-path (Codex + CLAUDE.md)
Só regras determinísticas sobre dado confiável. **Ausente ≠ zero** (`Number(null)===0` é fabricação):
- sem histórico de pedidos → **sem** card de economia (nunca `0/0`, nunca infla com gasto zero);
- economia comprovada ≤ 0 → oculta;
- ferramenta sem `last_sharpened_at` ou sem intervalo → **não conta** como atrasada;
- custo de ferramenta nova é **estimativa rotulada** (espelha o `AVG_NEW_TOOL_COST` do `SavingsDashboard`).

### Como foi feito
- Helper **puro** `src/lib/afiacao/recomendacoes.ts` via **TDD** — RED `10 fail / 12 pass` → GREEN `22/22`. Bordas de dia estáveis (`parseISO`/`differenceInCalendarDays`), `hoje` injetável.
- Seção `RecomendacoesCliente.tsx` (só apresentação) montada no `CustomerDashboard`.
- `useUserToolsSummary` + `last_sharpened_at` + `suggested_interval_days` (só query; **sem migration**).
- `bun run typecheck` ✅ · `bun run lint` ✅ (0 erros).

### Coordenação / notas
- **PR1 "Central da Ferramenta"** existe em paralelo (`03cdc7cc`) e toca o mesmo `CustomerDashboard.tsx` → possível conflito de merge; **o helper puro é reutilizável** pela Central quando ela entrar.
- O CI pode estar vermelho por uma **time-bomb alheia** (`src/test/csv-aposentadoria.deadline.test.ts`, vencida em 2026-07-13) — **não é deste PR**.

### 🖱️ Deploy
Só frontend → **Publish** no Lovable. Sem edge function, sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
