### PR TITLE
feat(carteira): Fatia 1 P0-B-bis — carteira-rebuild lê a LISTA de membros do ledger

### DIFF
--- a/docs/superpowers/plans/2026-07-13-fatia1-carteira-rebuild-le-ledger.md
+++ b/docs/superpowers/plans/2026-07-13-fatia1-carteira-rebuild-le-ledger.md
@@ -1,0 +1,208 @@
+# Fatia 1 P0-B-bis — carteira-rebuild lê a LISTA do ledger — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Trocar a FONTE da LISTA de membros do `carteira-rebuild` de `omie_clientes` para `carteira_membership_ledger`, preservando cobertura (6909) e comportamento (paridade exata), sem tocar vendedor/guards/lógica pura.
+
+**Architecture:** Mudança cirúrgica num único bloco de LOAD do edge (o handler `Deno.serve`, fora do bloco MIRROR). A lista passa a vir do ledger (acumulador append-only, população idêntica ao espelho hoje — diff simétrico 0/0). O guard textual (canário money-path) é atualizado test-first para exigir a nova fonte e barrar o retorno ao espelho. Helper puro e paridade MIRROR intactos.
+
+**Tech Stack:** Supabase Edge (Deno, `@supabase/supabase-js`), vitest (canário textual em `src/__tests__`), TypeScript strict.
+
+## Global Constraints
+
+- **Idioma:** rotas/código/commits/PRs em pt-BR.
+- **Money-path:** ausente ≠ zero; nunca fabricar número; guards fail-closed preservados.
+- **Edge NÃO auto-deploya** no Lovable — merge na main ≠ produção; deploy manual no chat Lovable (verbatim do repo).
+- **Sem SQL novo** nesta fatia → sem prove-sql PG17 (o ledger foi provado na Fatia 0).
+- **Paridade edge↔helper:** o bloco `// MIRROR-START carteira-load` do edge deve permanecer textualmente idêntico ao de `src/lib/carteira/rebuild-helpers.ts` (comentários são normalizados fora na comparação — podem divergir).
+- **/codex challenge** obrigatório antes do PR (money-path + este edge bloqueou 2×).
+- **Épico QUENTE:** conferir `origin/main` + PRs antes de tocar `carteira-rebuild`/`rebuild-helpers` (feito: nenhum PR aberto toca esses arquivos).
+
+---
+
+## File Structure
+
+- **Modify:** `supabase/functions/carteira-rebuild/index.ts` — bloco de LOAD da lista (:242-262), a chamada `montarClientes` (:303), o cabeçalho (:1-4). Troca a tabela; renomeia `espelhoIds`→`membroIds`; atualiza comentários.
+- **Modify:** `src/__tests__/edge-money-path-invariants.test.ts` — no `describe` "carteira-rebuild lê o vendedor da PROOF oben (P0-B-bis ponta 2/2)": assert positivo (lista vem do ledger) + anti-reversão (não lê mais `omie_clientes`).
+- **Modify (cosmético):** `src/lib/carteira/rebuild-helpers.ts` — comentário-header (:168) para refletir a nova fonte. Sem mudança de lógica.
+- **Não toca:** vendedor (proof oben), `computeCarteira`, bloco MIRROR, guards, `rebuild-helpers.test.ts`.
+
+---
+
+### Task 1: carteira-rebuild lê a LISTA do ledger (canário test-first + edge)
+
+**Files:**
+- Modify: `src/__tests__/edge-money-path-invariants.test.ts` (describe da linha ~760)
+- Modify: `supabase/functions/carteira-rebuild/index.ts:242-262, :303, :1-4`
+- Modify: `src/lib/carteira/rebuild-helpers.ts:168` (comentário)
+
+**Interfaces:**
+- Consumes: tabela `public.carteira_membership_ledger(user_id uuid PK, ...)` (Fatia 0, já aplicada). PostgREST `.from('carteira_membership_ledger').select('user_id')`.
+- Produces: nada novo para outras tasks (é a última desta fatia). O edge segue produzindo `carteira_assignments` idêntico.
+
+- [ ] **Step 1: Atualizar o pré-requisito de contexto — atualizar o branch para origin/main**
+
+O branch precisa conter o hotfix do canário (#1322, +10 linhas na região ai-ops) e os docs da Fatia 0 antes de editar. Fast-forward puro (0 commits próprios):
+
+Run: `git merge --ff-only origin/main`
+Expected: fast-forward até o topo de origin/main (inclui #1321/#1322). `git status` limpo.
+
+- [ ] **Step 2: Escrever os asserts do canário (test-first)**
+
+No arquivo `src/__tests__/edge-money-path-invariants.test.ts`, dentro do `describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P0-B-bis ponta 2/2)' ...)`, SUBSTITUIR o `it('anti-reversão: o load de omie_clientes NÃO tira mais o vendedor ...')` por estes dois testes:
+
+```typescript
+  it('A LISTA de membros vem do carteira_membership_ledger (Fatia 1 — não mais do espelho)', () => {
+    expect(
+      rebuild,
+      'REVERSÃO Lovable? a LISTA de membros não vem mais do ledger — voltou ao espelho omie_clientes?',
+    ).toMatch(/from\(['"]carteira_membership_ledger['"]\)[\s\S]{0,80}select\(['"]user_id['"]\)/);
+  });
+
+  it('anti-reversão: o carteira-rebuild NÃO lê mais omie_clientes em lugar nenhum (nem lista, nem vendedor)', () => {
+    expect(
+      rebuild,
+      'REGRESSÃO: o carteira-rebuild voltou a ler o espelho poluído omie_clientes (lista ou vendedor)',
+    ).not.toMatch(/from\(['"]omie_clientes['"]\)/);
+  });
+```
+
+- [ ] **Step 3: Rodar o canário e verificar que FALHA**
+
+Run: `heavy bun run test src/__tests__/edge-money-path-invariants.test.ts`
+Expected: FALHA — o novo `it('A LISTA de membros vem do carteira_membership_ledger ...')` falha (o edge ainda lê `omie_clientes`), e o anti-reversão também falha (`omie_clientes` ainda presente). Prova que os asserts têm dente.
+
+- [ ] **Step 4: Trocar a fonte da lista no edge**
+
+Em `supabase/functions/carteira-rebuild/index.ts`, no bloco de LOAD (:242-262), substituir o comentário (:242-245) e o loop. Comentário novo:
+
+```typescript
+  // LISTA de membros = carteira_membership_ledger (P0-B-bis Fatia 1). Acumulador durável (append-only:
+  // backfill + trigger AFTER INSERT no espelho; CASCADE só em delete de auth.users) → cobertura monotônica,
+  // nunca encolhe → sem stale. Preserva a herança B-lite (gêmeo + clones) E a cobertura. O VENDEDOR vem da
+  // proof oben (abaixo), não daqui. Paginação robusta a max_rows (#7 Codex): avança pela quantidade REAL
+  // retornada e para na página VAZIA. Guard anti-loop MAX_ROWS. Sem filtro de identity_state (Fatia 2).
+```
+
+E o loop (o `user_id` do ledger é PK NOT NULL → o `.not('user_id','is',null)` do espelho vira morto e é removido):
+
+```typescript
+  const PAGE = 1000;
+  const MAX_ROWS = 500_000;
+  const membroIds: string[] = [];
+  for (let from = 0; ;) {
+    const { data, error } = await supabase
+      .from('carteira_membership_ledger')
+      .select('user_id')
+      .order('user_id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) { console.error('[carteira-rebuild] load ledger error:', error.message); return fail(error.message); }
+    const page = (data ?? []) as Array<{ user_id: string }>;
+    for (const r of page) membroIds.push(r.user_id);
+    if (page.length === 0) break;
+    from += page.length;
+    if (from > MAX_ROWS) { console.error('[carteira-rebuild] ledger excedeu MAX_ROWS'); return fail('paginacao ledger excedeu limite'); }
+  }
+```
+
+- [ ] **Step 5: Atualizar a chamada montarClientes e o cabeçalho do arquivo**
+
+Na linha ~303, a variável renomeada: `const clientes = montarClientes(membroIds, proofOben);` (era `espelhoIds`). Atualizar o comentário :302 se mencionar espelho.
+
+No cabeçalho (:2), trocar `LISTA de membros (omie_clientes)` por `LISTA de membros (carteira_membership_ledger)`. Atualizar as linhas :2-4 que descrevem o fluxo se citarem o espelho como fonte da lista.
+
+Verificar que NÃO restou nenhuma outra referência a `omie_clientes` nem a `espelhoIds` no arquivo:
+
+Run: `rg "omie_clientes|espelhoIds" supabase/functions/carteira-rebuild/index.ts`
+Expected: nenhuma saída (zero ocorrências).
+
+- [ ] **Step 6: Atualizar o comentário-header do helper (cosmético, não afeta paridade)**
+
+Em `src/lib/carteira/rebuild-helpers.ts:168`, a linha que diz "A LISTA de membros continua vindo do espelho (preserva a herança B-lite...)" passa a: "A LISTA de membros vem do carteira_membership_ledger (Fatia 1; acumulador durável — preserva a herança B-lite: gêmeo + clones no mesmo grupo);". Comentário é normalizado fora na comparação de paridade → não quebra o MIRROR.
+
+- [ ] **Step 7: Rodar o canário e verificar que PASSA**
+
+Run: `heavy bun run test src/__tests__/edge-money-path-invariants.test.ts`
+Expected: PASS — inclusive o `it('PARIDADE: as funções de load espelhadas são IDÊNTICAS ao src/ ...')` (o MIRROR não foi tocado) e os dois novos asserts.
+
+- [ ] **Step 8: Rodar a suíte de carteira + gates estáticos**
+
+Run: `heavy bun run test src/lib/carteira/`
+Expected: PASS (rebuild-helpers inalterado — a lógica pura não mudou).
+
+Run: `heavy bun run typecheck`
+Expected: PASS (0 erros).
+
+Run: `bun lint`
+Expected: PASS.
+
+- [ ] **Step 9: `deno check` do edge (o Deno não passa pelo tsc do src)**
+
+Run: `deno check supabase/functions/carteira-rebuild/index.ts`
+Expected: PASS. (Se `deno` não estiver instalado no ambiente, registrar e confiar no canário de paridade + typecheck do helper; anotar no PR.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add supabase/functions/carteira-rebuild/index.ts src/lib/carteira/rebuild-helpers.ts src/__tests__/edge-money-path-invariants.test.ts docs/superpowers/specs/2026-07-13-fatia1-carteira-rebuild-le-ledger-design.md docs/superpowers/plans/2026-07-13-fatia1-carteira-rebuild-le-ledger.md
+git commit -m "feat(carteira): Fatia 1 P0-B-bis — carteira-rebuild lê a LISTA do ledger
+
+A LISTA de membros vem de carteira_membership_ledger (acumulador append-only)
+em vez do espelho poluído omie_clientes. Vendedor/guards/lógica pura intactos;
+paridade MIRROR preservada. População idêntica (diff 0/0) → paridade exata.
+Quarantine (identity_state) fica para a Fatia 2.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: /codex challenge do diff + abrir o PR
+
+**Files:** nenhum (revisão + PR).
+
+- [ ] **Step 1: Rodar o /codex challenge em background**
+
+Money-path + este edge bloqueou 2× → revisão independente do diff antes do PR. Conduzir via wrapper assíncrono (nunca `codex exec` cru em foreground):
+
+Run: `bash scripts/codex-async.sh -r xhigh` (com o diff da Task 1 como alvo — seguir a skill `/codex`)
+Expected: parecer do Codex. Tratar cada P1/P2 (corrigir ou registrar como aceito com justificativa). O diff é pequeno (troca de fonte), mas o rótulo money-path exige o passo.
+
+- [ ] **Step 2: Abrir o PR (não-draft → auto-merge no CI verde)**
+
+```bash
+git push -u origin claude/wizardly-varahamihira-90a6c6
+gh pr create --title "feat(carteira): Fatia 1 P0-B-bis — carteira-rebuild lê a LISTA do ledger" --body "<corpo: contexto, decisão de escopo (quarantine→Fatia 2), validação, pendência de deploy do edge>"
+```
+
+- [ ] **Step 3: Armar o pr-watch em background**
+
+Run: `bash scripts/pr-watch.sh <nº>` (run_in_background) → avisar no desfecho (mergeado/conflito/CI vermelho) via PushNotification.
+
+---
+
+## Deploy (pós-merge — pendências do founder)
+
+- 💬 **chat Lovable:** deploy do edge `carteira-rebuild` (ler do repo, verbatim) — edge NÃO auto-deploya.
+- ✅ **Migration:** nenhuma (Fatia 0 já aplicada).
+- **Pós-deploy (Claude, psql-ro):** confirmar `source='omie'` ~2747 total / ~2728 elegíveis, cobertura 6909, `carteira_omie_baseline` = 2728. Reincidência do incidente 100% Hunter se congelar.
+
+---
+
+## Self-Review (plano × spec)
+
+**1. Cobertura da spec:**
+- §3.1 (troca da fonte no edge) → Task 1 Steps 4-5. ✅
+- §3.2 (helper sem lógica, só comentário) → Task 1 Step 6. ✅
+- §3.3 (canário: positivo + anti-reversão) → Task 1 Steps 2-3, 7. ✅
+- §2 (sem filtro de identity_state) → comentário do Step 4 explicita "Sem filtro (Fatia 2)". ✅
+- §5 (validação: vitest + typecheck + lint + deno check + codex + gate psql-ro) → Task 1 Steps 7-9, Task 2 Step 1, Deploy. ✅
+- §4 (cobertura/guards preservados) → validado pelo gate psql-ro pós-deploy + guard baseline inalterado. ✅
+
+**2. Placeholders:** o corpo do PR (Task 2 Step 2) é o único `<...>` — é conteúdo redacional a compor no momento, não código. Os asserts e o diff do edge estão completos e literais.
+
+**3. Type consistency:** `membroIds: string[]` (renomeado de `espelhoIds`) usado no loop e em `montarClientes(membroIds, proofOben)`. `montarClientes(espelhoIds: string[], ...)` no helper mantém o nome do parâmetro (posicional na chamada — sem impacto). `page` tipado `Array<{ user_id: string }>` consistente com `.select('user_id')`.
+
+## Execution Handoff
+
+Escolha de execução após aprovação do plano (a Task 1 é única e coesa — inline com um checkpoint é o mais direto; subagent-driven alinha com o ritual da Fatia 0).

--- a/docs/superpowers/specs/2026-07-13-fatia1-carteira-rebuild-le-ledger-design.md
+++ b/docs/superpowers/specs/2026-07-13-fatia1-carteira-rebuild-le-ledger-design.md
@@ -1,0 +1,82 @@
+# Fatia 1 P0-B-bis — `carteira-rebuild` lê a LISTA de membros do ledger — design
+
+**Data:** 2026-07-13 · **Money-path** (lista de membros → carteira → comissão) · **Edge que já bloqueou 2× no Codex**
+**Referências:** spec do épico `2026-07-12-carteira-membership-ledger-drop-espelho-design.md` (§3, §5), plano da Fatia 0 `2026-07-12-fatia0-carteira-membership-ledger.md`, design da ponta 2 `2026-07-11-carteira-rebuild-vendedor-proof-ponta2-design.md`.
+
+## 1. Contexto
+
+O épico P0-B-bis aposenta o espelho poluído `omie_clientes`. A **Fatia 0** (#1321, `865fa7f3`) criou o `carteira_membership_ledger` (acumulador durável) + backfill dos 6909 membros de hoje (`first_seen_at = omie_clientes.created_at`) + trigger `AFTER INSERT ON omie_clientes` (`ON CONFLICT DO NOTHING`, `source='trigger'`). **Aplicado e verificado** (psql-ro, 2026-07-13): `ledger == espelho == 6909`, população **idêntica** (diferença simétrica `0/0`), 100% `identity_state='verified'`/`source='backfill'`.
+
+A **última dependência dura** do espelho no `carteira-rebuild` é a **LISTA de membros**: [carteira-rebuild/index.ts:251](../../../supabase/functions/carteira-rebuild/index.ts) faz `.from('omie_clientes').select('user_id')` — só o CONJUNTO de user_ids. O VENDEDOR (proof oben, #1310), o ALIAS (`customer_canonical_alias`) e os FLAGGEDS (`cliente_classificacao`) já vêm de fontes account-corretas.
+
+Esta **Fatia 1** troca a FONTE DA LISTA: `omie_clientes` → `carteira_membership_ledger`. Escopo mínimo, aditivo, paridade exata com o comportamento de hoje.
+
+## 2. Decisão de escopo — quarantine fica para a Fatia 2 (diverge da spec macro §5-Fatia1)
+
+A spec macro (§5-Fatia1) previa que a Fatia 1 já lesse `identity_state` e marcasse `ambiguous`/`conflict` como `eligible=false` (quarantined). **Decisão desta sessão (handoff): o quarantine vai para a Fatia 2.**
+
+**Justificativa:**
+- **Dead-code hoje:** 100% dos membros são `verified` (nada popula os outros estados até a Fatia 2). Consumir `identity_state` agora não muda nada e não é testável com dados reais.
+- **Risco money-path:** este edge bloqueou 2× no Codex — o menor diff possível é o mais seguro (precisão > recall).
+- **Upsert-only:** o rebuild não deleta ([:359](../../../supabase/functions/carteira-rebuild/index.ts), `onConflict: 'customer_user_id'`). Filtrar um estado da lista SEM deletar deixaria o assignment antigo **stale** — pior que não filtrar.
+- **Coesão:** a Fatia 2 popula E consome `identity_state` juntas (aditivo, fail-safe, com asserts +/− sobre dados reais).
+
+**Resultado:** a Fatia 1 lê **todos** os `user_id` do ledger, **sem filtro de `identity_state`** → comportamento idêntico ao de hoje. Paridade garantida pela população idêntica (`0/0`).
+
+## 3. Mudança de código
+
+### 3.1 `supabase/functions/carteira-rebuild/index.ts` — só o LOAD da lista (:242-262)
+
+```
+-  .from('omie_clientes')
+-  .select('user_id')
+-  .not('user_id', 'is', null)
+-  .order('user_id', { ascending: true })
+-  .range(from, from + PAGE - 1)
++  .from('carteira_membership_ledger')
++  .select('user_id')
++  .order('user_id', { ascending: true })
++  .range(from, from + PAGE - 1)
+```
+
+- Remove `.not('user_id','is',null)` — no ledger `user_id` é **PK NOT NULL** (filtro morto).
+- Paginação robusta a `max_rows` preservada: avança por `page.length` real, para na página vazia, guard `MAX_ROWS`.
+- Renomeia a variável local `espelhoIds` → `membroIds` (a var local do handler está FORA do bloco MIRROR); atualiza os comentários (:242-245) para a fonte real (ledger, acumulador).
+- **NÃO toca:** o VENDEDOR (proof `omie_customer_account_map_fresco` account='oben'), `computeCarteira`, o bloco `// MIRROR-START carteira-load`, nenhum guard.
+
+### 3.2 `src/lib/carteira/rebuild-helpers.ts` — sem mudança de lógica
+
+O helper é PURO (recebe uma *lista de ids* via `montarClientes(espelhoIds, proofOben)`; a origem é irrelevante). **A paridade edge↔helper se mantém sem tocar o corpo do MIRROR** — o LOAD vive no handler. Único toque admissível: atualizar o comentário-header (P0-B-bis ponta 2/2) que afirma "A LISTA de membros continua vindo do espelho" para refletir o ledger. O nome do parâmetro `espelhoIds` permanece (renomeá-lo exigiria mexer nos dois lados do MIRROR sem ganho de comportamento).
+
+### 3.3 `src/__tests__/edge-money-path-invariants.test.ts` — canário do carteira-rebuild
+
+- **Assert POSITIVO novo:** a LISTA vem de `carteira_membership_ledger` (`.from('carteira_membership_ledger')` + `.select('user_id')`).
+- **Anti-reversão atualizada:** o rebuild NÃO lê mais `omie_clientes` em lugar nenhum (nem lista, nem vendedor) — `not.toMatch(/from\(['"]omie_clientes['"]\)/)`. Substitui o assert antigo que só barrava `omie_clientes` + `user_id, omie_codigo_vendedor`.
+- **Mantém intactos:** VENDEDOR da proof oben (4ª leitura money-path), guards usados (pré/pós), baseline/bootstrap gated, paridade MIRROR.
+
+## 4. Invariantes / riscos
+
+- **Cobertura 6909 preservada.** Ledger é **append-only** (backfill + trigger INSERT; CASCADE só em delete de `auth.users`) → cobertura **monotônica, nunca encolhe** → dissolve o risco "carteira encolhe" (incidente 100% Hunter) melhor ainda que o espelho.
+- **Guards fail-closed inalterados.** `carteira_omie_baseline = 2728` (≠ 0) → o guard comparativo está ATIVO no 1º run pós-deploy (não é bootstrap; sem `?bootstrap=1`). Como a população é idêntica, `omieElegivelNovo ≈ 2728 ≥ 0.8×2728` → passa.
+- **Transição via trigger.** Enquanto o espelho é escrito (Fatias 0-3), o trigger mantém o ledger em dia. A Fatia 4 desacopla os writers; a Fatia 5 dropa o espelho. Risco aceito: um delete direto no espelho (raro/inexistente — é mirror de sync upsert-only) não encolhe o ledger — comportamento SEGURO.
+
+## 5. Validação (a prova da entrega)
+
+- `heavy bun run test src/lib/carteira/` (rebuild-helpers — inalterado, paridade) + canário `edge-money-path-invariants` atualizado.
+- `deno check` do edge · `bun run typecheck` · `bun lint`.
+- **Sem prove-sql PG17** — não há SQL novo (o ledger já foi provado na Fatia 0).
+- **/codex challenge** (`scripts/codex-async.sh -r xhigh`) do diff antes do PR (money-path + histórico de 2 bloqueios), conduzido pelo Claude em background.
+- **Pós-deploy (psql-ro):** `source='omie'` ~2747 total / ~2728 elegíveis, cobertura total 6909, `carteira_omie_baseline` permanece 2728.
+
+## 6. Deploy
+
+- PR não-draft → auto-merge (squash) no CI `validate` verde.
+- **Edge NÃO auto-deploya** → deploy manual do founder no chat Lovable (ler `carteira-rebuild` do repo, verbatim) após o merge.
+- **Migration: nenhuma** (Fatia 0 já aplicada e verificada).
+
+## 7. Fora de escopo (fatias futuras — planos próprios)
+
+- **Fatia 2:** popular + consumir `identity_state` (quarantine de ambiguous/conflict: vendedor removido, eligible=false, membro preservado, zero comissão).
+- **Fatia 3:** migrar os leitores de código/vendedor restantes → proof.
+- **Fatia 4:** migrar os 6 writers → RPC `register_carteira_member`.
+- **Fatia 5:** `DROP TABLE omie_clientes` + regenerar `types.ts`.

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -773,11 +773,18 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
     ).toMatch(/from\(['"]omie_customer_account_map_fresco['"]\)[\s\S]{0,220}\.eq\(['"]account['"],\s*['"]oben['"]\)/);
   });
 
-  it('anti-reversão: o load de omie_clientes NÃO tira mais o vendedor (só a LISTA de user_id)', () => {
+  it('A LISTA de membros vem do carteira_membership_ledger (Fatia 1 — não mais do espelho)', () => {
     expect(
       rebuild,
-      'REGRESSÃO: o rebuild voltou a ler omie_codigo_vendedor do espelho poluído (mix de contas)',
-    ).not.toMatch(/from\(['"]omie_clientes['"]\)[\s\S]{0,80}select\(['"]user_id,\s*omie_codigo_vendedor['"]\)/);
+      'REVERSÃO Lovable? a LISTA de membros não vem mais do ledger — voltou ao espelho omie_clientes?',
+    ).toMatch(/from\(['"]carteira_membership_ledger['"]\)[\s\S]{0,80}select\(['"]user_id['"]\)/);
+  });
+
+  it('anti-reversão: o carteira-rebuild NÃO lê mais omie_clientes em lugar nenhum (nem lista, nem vendedor)', () => {
+    expect(
+      rebuild,
+      'REGRESSÃO: o carteira-rebuild voltou a ler o espelho poluído omie_clientes (lista ou vendedor)',
+    ).not.toMatch(/from\(['"]omie_clientes['"]\)/);
   });
 
   it('guards presentes E USADOS — não ignorados (wiring, P2 Codex)', () => {

--- a/src/lib/carteira/rebuild-helpers.ts
+++ b/src/lib/carteira/rebuild-helpers.ts
@@ -164,9 +164,9 @@ export function computeCarteira(
   return { assignments, conflicts, orphanCount, chainViolations };
 }
 
-// ── P0-B-bis ponta 2/2: o load do carteira-rebuild lê o vendedor da PROOF oben (não do espelho poluído).
-// A LISTA de membros continua vindo do espelho (preserva a herança B-lite: gêmeo + clones no mesmo grupo);
-// só a FONTE do vendedor muda, via lookup em omie_customer_account_map_fresco(account='oben'). As 4 funções
+// ── P0-B-bis: o carteira-rebuild lê a LISTA de membros do carteira_membership_ledger (Fatia 1, acumulador)
+// e o VENDEDOR da PROOF oben omie_customer_account_map_fresco(account='oben') — nem lista nem vendedor vêm
+// mais do espelho poluído omie_clientes. A lista preserva a herança B-lite (gêmeo + clones). As 4 funções
 // são ESPELHADAS verbatim no edge (Deno não importa de src/) — paridade textual no canário edge-money-path.
 // Guards fail-closed endurecidos após o Codex challenge (8 P1):
 //   • coerceCodigoVendedor: SÓ decimal canônico (regex ^[0-9]+$ + BigInt) antes de virar number — rejeita

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -1,7 +1,8 @@
 // supabase/functions/carteira-rebuild/index.ts
-// Reconstrói carteira_assignments: LISTA de membros (omie_clientes) × VENDEDOR account-correto da proof
-// oben (omie_customer_account_map_fresco, P0-B-bis) × omie_vendedor_map. O vendedor NÃO vem mais do
-// espelho poluído — só a lista (preserva a herança B-lite + a cobertura). Órfão → Hunter. Idempotente.
+// Reconstrói carteira_assignments: LISTA de membros (carteira_membership_ledger) × VENDEDOR account-correto
+// da proof oben (omie_customer_account_map_fresco, P0-B-bis) × omie_vendedor_map. Nem a lista nem o vendedor
+// vêm mais do espelho poluído omie_clientes (Fatia 1). A lista (acumulador) preserva a herança B-lite + a
+// cobertura. Órfão → Hunter. Idempotente.
 //
 // Consolidação B-lite (spec 2026-06-13): consulta customer_canonical_alias (clones ATIVOS) e
 // canonicaliza clone→gêmeo — o gêmeo (cadastro Oben, com nome) herda o vendedor do clone e fica
@@ -239,26 +240,28 @@ Deno.serve(async (req) => {
     }
   }
 
-  // LISTA de membros = espelho omie_clientes (só user_id). Preserva a herança B-lite (gêmeo + clones no
-  // mesmo grupo) E a cobertura (não encolhe → sem stale). O VENDEDOR não vem mais daqui (poluído/NULL).
+  // LISTA de membros = carteira_membership_ledger (P0-B-bis Fatia 1). Acumulador durável (append-only:
+  // backfill + trigger AFTER INSERT no espelho; CASCADE só em delete de auth.users) → cobertura monotônica,
+  // nunca encolhe → sem stale. Preserva a herança B-lite (gêmeo + clones no mesmo grupo) E a cobertura. O
+  // VENDEDOR vem da proof oben (abaixo), não daqui. Sem filtro de identity_state (quarantine é da Fatia 2).
   // Paginação robusta a max_rows (#7 Codex): avança pela quantidade REAL retornada e para na página VAZIA
   // — não presume PAGE=1000 (se o servidor capar em 500, `< PAGE` truncaria na 1ª página). Guard anti-loop.
+  // user_id é PK NOT NULL no ledger → sem o `.not(is null)` do espelho.
   const PAGE = 1000;
   const MAX_ROWS = 500_000;
-  const espelhoIds: string[] = [];
+  const membroIds: string[] = [];
   for (let from = 0; ;) {
     const { data, error } = await supabase
-      .from('omie_clientes')
+      .from('carteira_membership_ledger')
       .select('user_id')
-      .not('user_id', 'is', null)
       .order('user_id', { ascending: true })
       .range(from, from + PAGE - 1);
-    if (error) { console.error('[carteira-rebuild] load omie_clientes error:', error.message); return fail(error.message); }
+    if (error) { console.error('[carteira-rebuild] load ledger error:', error.message); return fail(error.message); }
     const page = (data ?? []) as Array<{ user_id: string }>;
-    for (const r of page) espelhoIds.push(r.user_id);
+    for (const r of page) membroIds.push(r.user_id);
     if (page.length === 0) break;
     from += page.length;
-    if (from > MAX_ROWS) { console.error('[carteira-rebuild] omie_clientes excedeu MAX_ROWS'); return fail('paginacao omie_clientes excedeu limite'); }
+    if (from > MAX_ROWS) { console.error('[carteira-rebuild] ledger excedeu MAX_ROWS'); return fail('paginacao ledger excedeu limite'); }
   }
 
   // VENDEDOR account-correto = view FRESCA omie_customer_account_map_fresco (account='oben') → Map por
@@ -299,8 +302,8 @@ Deno.serve(async (req) => {
   const guardPre = avaliarGuardProof({ proofCrua, proofFresca: proofOben.size, comVendedor });
   if (guardPre.abortar) { console.error('[carteira-rebuild] guard proof oben:', guardPre.motivo); return fail(`guard proof oben: ${guardPre.motivo}`); }
 
-  // Merge: LISTA (espelho) × VENDEDOR (proof oben). Clone ausente da proof → null → herda do gêmeo no grupo.
-  const clientes = montarClientes(espelhoIds, proofOben);
+  // Merge: LISTA (ledger) × VENDEDOR (proof oben). Clone ausente da proof → null → herda do gêmeo no grupo.
+  const clientes = montarClientes(membroIds, proofOben);
 
   // Fornecedores fora da carteira (cliente_classificacao.excluir_da_carteira): entram com
   // eligible=false (combinado com o eligible-de-clone abaixo). FAIL-CLOSED: erro de leitura aborta


### PR DESCRIPTION
## P0-B-bis Fatia 1 — carteira-rebuild lê a LISTA de membros do ledger

Última dependência dura do espelho poluído `omie_clientes` no `carteira-rebuild`: a **LISTA de membros** (`.from('omie_clientes').select('user_id')`). Esta fatia troca a fonte para `carteira_membership_ledger` (acumulador da Fatia 0 #1321). Vendedor (proof oben), guards fail-closed e a lógica pura (`computeCarteira`) **não mudam**.

### Por que é seguro (paridade exata hoje)
- **População idêntica** (psql-ro, prod): `ledger == omie_clientes == 6909`, diferença simétrica **0/0** (mesmos user_id, não só a contagem).
- **Append-only**: o ledger só cresce (backfill + trigger `AFTER INSERT`; `CASCADE` só em delete de `auth.users`) → cobertura **monotônica, nunca encolhe** → dissolve o risco "carteira encolhe" (incidente 100% Hunter) melhor que o espelho.
- **Guards inalterados**: `carteira_omie_baseline = 2728` (≠ 0) → o guard comparativo pós-compute fica **ATIVO** no 1º run pós-deploy (aborta com < 2183 elegíveis; 100% Hunter → `omieElegivelNovo=0` aborta inclusive com `?bootstrap=1`).

### Decisão de escopo
Lê **todos** os `user_id` do ledger, **sem filtrar `identity_state`** (100% `verified` hoje). O quarantine de `ambiguous`/`conflict` (popular + consumir `identity_state`) é a **Fatia 2** — o rebuild é upsert-only, então filtrar sem deletar deixaria assignment stale.

### Mudança
- `supabase/functions/carteira-rebuild/index.ts`: `.from('carteira_membership_ledger').select('user_id')` (removido o `.not(is null)` morto — `user_id` é PK NOT NULL); `espelhoIds`→`membroIds`; comentários. Paginação robusta a max_rows preservada.
- `src/__tests__/edge-money-path-invariants.test.ts`: canário — assert positivo (lista vem do ledger) + anti-reversão (não lê mais `omie_clientes`).
- `src/lib/carteira/rebuild-helpers.ts`: só comentário-header (paridade MIRROR intacta).

### Validação
- vitest: canário **82/82**, `rebuild-helpers` **39/39**, suíte carteira **153/153**. TDD red→green.
- typecheck strict **0 erros** · lint (0 errors) · `deno check` do edge.
- Sem prove-sql PG17 (sem SQL novo — o ledger foi provado na Fatia 0).
- **/codex challenge xhigh: SEM FURO MONEY-PATH** (P1 nenhum, P2 nenhum). Confirmou: sem rota de DELETE/TRUNCATE do espelho no repo; `.not(null)` era morto; paginação sem furo novo (ordem total pela PK); guard do 1º run protege a falha catastrófica.

### 🔭 Nota do Codex para a Fatia 2
O produtor de estados não-verificados (`ambiguous`/`conflict`) **não deve entrar antes do consumidor**: o rebuild precisa, na mesma fatia, passar a emitir assignment **preservado** com vendedor removido e `eligible=false` para o membro em quarentena. Ordem popular↔consumir importa (senão vira stale ou perda).

### ⚠️ Pendência de deploy (founder)
- 💬 **chat Lovable:** deploy do edge `carteira-rebuild` (verbatim do repo) — edge NÃO auto-deploya.
- Sem migration (Fatia 0 já aplicada).
- Pós-deploy (psql-ro): confirmar `source='omie'` ~2747/2728 elegíveis, cobertura 6909, baseline 2728.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
