### PR TITLE
fix(omie): Fatia 3 — leitores OBEN resolvem identidade pela proof fresca (épico-drop do espelho)

### DIFF
--- a/src/hooks/__tests__/leitoresObenProof.fatia3.test.ts
+++ b/src/hooks/__tests__/leitoresObenProof.fatia3.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// ── Guard (P0-B-bis épico-drop do espelho, Fatia 3): leitores OBEN resolvem código->user pela PROOF ──
+// Os 6 sítios resolviam omie_codigo_cliente (o slot OBEN vindo da busca) -> user_id no espelho poluído
+// omie_clientes filtrando .eq('empresa_omie','oben'). Como o espelho é 100% 'colacor' (rótulo fabricado),
+// esse filtro era VAZIO → sempre caía no fallback por documento. A proof fresca
+// (omie_customer_account_map_fresco, UNIQUE(omie_codigo_cliente,account), document-first, TTL 7d) tem o
+// vínculo OBEN real → resolve certo E recupera cobertura, mantendo o fail-closed (miss → fallback por doc).
+// Teste TEXTUAL (anti-regressão de fonte). Ver design 2026-07-12-carteira-membership-ledger-drop-espelho §4.
+const CWD = resolve(__dirname, '../../..');
+const read = (rel: string) => readFileSync(resolve(CWD, rel), 'utf8');
+const count = (hay: string, needle: string) => hay.split(needle).length - 1;
+
+const ARQUIVOS = [
+  { rel: 'src/hooks/useBuscaClienteOmie.ts', sitios: 2 },
+  { rel: 'src/hooks/unifiedOrder/useCustomerSelection.ts', sitios: 2 },
+  { rel: 'src/pages/FarmerCalls.tsx', sitios: 2 },
+];
+
+describe('Fatia 3: leitores OBEN resolvem pela proof fresca, não pelo espelho omie_clientes', () => {
+  for (const { rel, sitios } of ARQUIVOS) {
+    const src = read(rel);
+
+    it(`${rel}: não lê mais o espelho omie_clientes`, () => {
+      expect(
+        src,
+        `REGRESSÃO: ${rel} voltou a resolver código->user pelo espelho poluído omie_clientes`,
+      ).not.toMatch(/from\(['"]omie_clientes['"]\)/);
+    });
+
+    it(`${rel}: resolve os ${sitios} sítios pela view fresca account=oben`, () => {
+      expect(
+        count(src, "from('omie_customer_account_map_fresco')"),
+        `${rel} deve resolver os ${sitios} sítios OBEN pela proof fresca`,
+      ).toBe(sitios);
+      expect(
+        count(src, "eq('account', 'oben')"),
+        `cada sítio OBEN deve filtrar account=oben (fail-closed por-conta)`,
+      ).toBeGreaterThanOrEqual(sitios);
+    });
+  }
+});

--- a/src/hooks/unifiedOrder/useCustomerSelection.ts
+++ b/src/hooks/unifiedOrder/useCustomerSelection.ts
@@ -206,11 +206,11 @@ export function useCustomerSelection({
           if (clientes.length > 0) {
             const codigos = clientes.map(c => c.codigo_cliente);
             const { data: mappings } = await supabase
-              .from('omie_clientes')
+              .from('omie_customer_account_map_fresco')
               .select('user_id, omie_codigo_cliente')
-              // P0-B: a busca é na conta OBEN; sem empresa_omie o código colidiria com colacor e
-              // anexaria o customer_user_id ERRADO (item 2). Fail-safe: 0 linhas oben hoje → sem mapa.
-              .eq('empresa_omie', 'oben')
+              // Fatia 3 (épico-drop): resolve o código OBEN -> user_id pela proof fresca account-correta.
+              // UNIQUE(código,account) → sem colisão cross-conta. Miss → sem mapa → match por documento.
+              .eq('account', 'oben')
               .in('omie_codigo_cliente', codigos);
             if (mappings) {
               for (const c of clientes) {
@@ -244,12 +244,12 @@ export function useCustomerSelection({
     let localUserId = cust.local_user_id || null;
     if (!localUserId) {
       const { data: mapping } = await supabase
-        .from('omie_clientes')
+        .from('omie_customer_account_map_fresco')
         .select('user_id')
         .eq('omie_codigo_cliente', cust.codigo_cliente)
-        // P0-B: filtra a conta OBEN (cust.codigo_cliente é o slot oben) — sem isso um código colacor
-        // colidente mapearia o user errado (item 2). Fail-safe: 0 oben → cai no match por documento abaixo.
-        .eq('empresa_omie', 'oben')
+        // Fatia 3 (épico-drop): resolve o slot OBEN (cust.codigo_cliente) -> user_id pela proof fresca
+        // account-correta. UNIQUE(código,account) → sem colisão. Miss → cai no match por documento abaixo.
+        .eq('account', 'oben')
         .maybeSingle();
       if (mapping?.user_id) localUserId = mapping.user_id;
     }

--- a/src/hooks/useBuscaClienteOmie.ts
+++ b/src/hooks/useBuscaClienteOmie.ts
@@ -29,14 +29,14 @@ export function useBuscaClienteOmie() {
       let empresaByCode: Record<number, string> = {};
       if (omieClientes.length > 0) {
         const codigos = omieClientes.map((c) => c.codigo_cliente);
-        // P0-B follow-up: a busca `listar_clientes` roda na conta OBEN (default do edge). Sem
-        // empresa_omie o código OBEN colidiria com um código colacor do espelho e anexaria o
-        // customer_user_id ERRADO. Fail-safe: 0 linhas oben hoje → sem mapa → cai no match por doc.
-        const { data: mappings } = await supabase.from('omie_clientes')
-          .select('user_id, omie_codigo_cliente, empresa_omie')
-          .eq('empresa_omie', 'oben').in('omie_codigo_cliente', codigos);
+        // Fatia 3 (épico-drop): resolve o código OBEN -> user_id pela proof fresca account-correta
+        // (account='oben'), não pelo espelho poluído. O código vem da busca OBEN; UNIQUE(código,account)
+        // → sem colisão cross-conta. Miss (sem vínculo fresco) → sem mapa → cai no match por documento.
+        const { data: mappings } = await supabase.from('omie_customer_account_map_fresco')
+          .select('user_id, omie_codigo_cliente, account')
+          .eq('account', 'oben').in('omie_codigo_cliente', codigos);
         mappingByCode = Object.fromEntries((mappings || []).map((m) => [m.omie_codigo_cliente, m.user_id]));
-        empresaByCode = Object.fromEntries((mappings || []).map((m) => [m.omie_codigo_cliente, m.empresa_omie]));
+        empresaByCode = Object.fromEntries((mappings || []).map((m) => [m.omie_codigo_cliente, m.account]));
       }
       const omieMapped: ClienteBusca[] = omieClientes.map((c) => ({
         user_id: mappingByCode[c.codigo_cliente] || '',
@@ -73,10 +73,10 @@ export function useBuscaClienteOmie() {
       if (profile?.user_id) return profile.user_id;
     }
     if (c.omie_codigo_cliente) {
-      // P0-B follow-up: c.omie_codigo_cliente veio da busca OBEN — resolve só contra a conta OBEN
-      // (código colidente de colacor mapearia o user errado). 0 oben hoje → null → sem vínculo.
-      const { data: mapping } = await supabase.from('omie_clientes').select('user_id')
-        .eq('omie_codigo_cliente', c.omie_codigo_cliente).eq('empresa_omie', 'oben').maybeSingle();
+      // Fatia 3 (épico-drop): c.omie_codigo_cliente veio da busca OBEN — resolve pela proof fresca
+      // account-correta (account='oben'). UNIQUE(código,account) → sem colisão. Miss → null → sem vínculo.
+      const { data: mapping } = await supabase.from('omie_customer_account_map_fresco').select('user_id')
+        .eq('omie_codigo_cliente', c.omie_codigo_cliente).eq('account', 'oben').maybeSingle();
       if (mapping?.user_id) return mapping.user_id;
     }
     return null;

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -189,6 +189,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useReguaPreco.test.tsx",
       "src/hooks/__tests__/useReguaPreco360.test.tsx",
       "src/hooks/__tests__/useUnifiedOrder.accountGuard.test.ts",
+      "src/hooks/__tests__/leitoresObenProof.fatia3.test.ts",
       "src/pages/__tests__/SalesQuotes.accountGuard.test.tsx",
       "src/pages/__tests__/SalesQuotes.priceGuard.test.tsx",
       "src/pages/__tests__/displayReaders.viewFresca.test.ts",

--- a/src/pages/FarmerCalls.tsx
+++ b/src/pages/FarmerCalls.tsx
@@ -206,13 +206,13 @@ const FarmerCalls = () => {
       let mappingByCode: Record<number, string> = {};
       if (omieClientes.length > 0) {
         const codigos = omieClientes.map(c => c.codigo_cliente);
-        // P0-B follow-up: a busca `listar_clientes` roda na conta OBEN (default do edge). Sem
-        // empresa_omie o código OBEN colidiria com um código colacor do espelho e anexaria o
-        // customer_user_id ERRADO. Fail-safe: 0 linhas oben hoje → sem mapa → cai no match por doc.
+        // Fatia 3 (épico-drop): resolve o código OBEN -> user_id pela proof fresca account-correta
+        // (account='oben'), não pelo espelho poluído. UNIQUE(código,account) → sem colisão cross-conta.
+        // Miss (sem vínculo fresco) → sem mapa → resolve on save via documento.
         const { data: mappings } = await supabase
-          .from('omie_clientes')
+          .from('omie_customer_account_map_fresco')
           .select('user_id, omie_codigo_cliente')
-          .eq('empresa_omie', 'oben')
+          .eq('account', 'oben')
           .in('omie_codigo_cliente', codigos);
         mappingByCode = Object.fromEntries((mappings || []).map(m => [m.omie_codigo_cliente, m.user_id]));
       }
@@ -306,13 +306,13 @@ const FarmerCalls = () => {
         if (profile?.user_id) customerUserId = profile.user_id;
       }
       if (!customerUserId && selectedCustomer.omie_codigo_cliente) {
-        // P0-B follow-up: o código veio da busca OBEN — resolve só contra a conta OBEN (código
-        // colidente de colacor mapearia o user errado). 0 oben hoje → null → cai no aviso abaixo.
+        // Fatia 3 (épico-drop): o código veio da busca OBEN — resolve pela proof fresca account-correta
+        // (account='oben'). UNIQUE(código,account) → sem colisão. Miss → null → cai no aviso abaixo.
         const { data: mapping } = await supabase
-          .from('omie_clientes')
+          .from('omie_customer_account_map_fresco')
           .select('user_id')
           .eq('omie_codigo_cliente', selectedCustomer.omie_codigo_cliente)
-          .eq('empresa_omie', 'oben')
+          .eq('account', 'oben')
           .maybeSingle();
         if (mapping?.user_id) customerUserId = mapping.user_id;
       }


### PR DESCRIPTION
## O quê
Fatia 3 do épico "aposentar o espelho `omie_clientes`" (design `2026-07-12-carteira-membership-ledger-drop-espelho`). Migra os **6 leitores OBEN frontend** que resolviam `omie_codigo_cliente` (slot OBEN da busca) → `user_id`, do espelho poluído para a **proof fresca account-correta** `omie_customer_account_map_fresco`.

## Por quê
O espelho é 100% `empresa_omie='colacor'` (rótulo fabricado). O filtro `.eq('empresa_omie','oben')` era **vazio** → os 6 sítios sempre caíam no fallback por documento. A proof fresca (`UNIQUE(omie_codigo_cliente, account)`, document-first, TTL 7d) tem o vínculo OBEN real → resolve certo, recupera cobertura e mantém o fail-closed (miss → fallback por doc). `UNIQUE(codigo,account)` fecha a colisão cross-conta que o espelho abria.

## Sítios (6 — troca mecânica `omie_clientes`→`_fresco`, `empresa_omie`→`account`)
- `useBuscaClienteOmie.ts` — `buscar` + `resolver`
- `unifiedOrder/useCustomerSelection.ts` — customer search + `resolveLocalUserId`
- `FarmerCalls.tsx` — `searchCustomers` + `handleSaveCall`

## Gate
- ✅ guard textual novo `leitoresObenProof.fatia3` (anti-regressão de fonte, 6/6)
- ✅ typecheck · lint (0 errors) · vizinhos (`accountGuard`, `no-write-leak`) sem regressão

## Deploy
Frontend puro → **Publish** no Lovable (sem edge/migration).

## Escopo
Edges da Fatia 3 (`omie-cliente`, `omie-analytics-sync`, `ai-ops-agent`) ficam **fora** — quentes/coordenados com #1298 e a task carteira-rebuild (Fatia 1). Ordem do design: leitores antes dos writers; DROP é a Fatia 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
