### PR TITLE
feat(carteira): lease anti-intercalação no carteira-rebuild (fecha mosaico rebuild × rebuild)

### DIFF
--- a/db/test-carteira-rebuild-lease.sh
+++ b/db/test-carteira-rebuild-lease.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Teste PG17 do LEASE do carteira-rebuild (fecha o mosaico rebuild × rebuild) + hardening do Codex challenge.
+# Migration: supabase/migrations/20260713160000_carteira_rebuild_lease.sql
+#   D1  lease ausente → claim = true (cria 'syncing')
+#   D2/D2b claim enquanto 'syncing' recente/6min → false (serializa 2 writers = o furo fechado)
+#   D3  claim 'syncing' STALE (>15min) → true (auto-libera; prova comparação via now() do BANCO)
+#   D4  claim 'complete' → true (reivindica)
+#   D6  finalize run_id DONO → true + status='complete'
+#   D7  finalize run_id ALHEIO → false + status fica 'syncing' (ownership)
+#   D7b finalize sobre 'complete' posto POR FORA (fase='inicio') → false (não re-finaliza estado alheio)
+#   D8  IDEMPOTÊNCIA (Codex P1): finalize repetido do MESMO run → true, true; alheio sobre complete → false
+#   D9  VALIDAÇÃO (Codex): status ∉ {complete,error} → 22023; run_id vazio → 22004
+#   D5  REVOKE: anon E authenticated NÃO executam; service_role executa (claim + finalize)
+#   RLS (Codex P1): employee NÃO adultera a linha carteira_rebuild (policy RESTRICTIVE); toca outras entity_type
+#   C1  CONCORRÊNCIA REAL robusta: 8 claims simultâneos → 0 workers falham, EXATAMENTE 1 't' e 7 'f'
+#   F1/F2/F3 falsificação: WHERE do claim / ownership do finalize / policy RESTRICTIVE
+# Base: db/test-claim-full-sync.sh. Pré-req: brew install postgresql@17 pgvector.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5459}"
+SLUG="carteira-rebuild-lease"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql" >/dev/null
+# auth.uid() lê o GUC test.uid (impersonação de RLS); service_role BYPASSRLS (espelha o admin do Supabase).
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid', true), '')::uuid $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ── ZONA 1: ambiente Supabase real p/ sync_state — RLS on, policy permissiva "Staff can manage", GRANTs,
+#            app_role/has_role/user_roles (a policy os usa). A migration ADICIONA as policies RESTRICTIVE. ──
+EMP='22222222-2222-2222-2222-222222222222'
+P -q <<SQL
+DO \$\$ BEGIN CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;
+CREATE TABLE public.user_roles (user_id uuid, role public.app_role);
+CREATE FUNCTION public.has_role(uid uuid, r public.app_role) RETURNS boolean LANGUAGE sql STABLE AS \$\$ SELECT EXISTS(SELECT 1 FROM public.user_roles WHERE user_id=uid AND role=r) \$\$;
+INSERT INTO public.user_roles(user_id, role) VALUES ('$EMP','employee');
+
+CREATE TABLE public.sync_state (
+  id uuid DEFAULT gen_random_uuid() NOT NULL,
+  entity_type text NOT NULL,
+  account text DEFAULT 'vendas'::text NOT NULL,
+  last_sync_at timestamptz, last_page integer DEFAULT 0, last_cursor text,
+  total_synced integer DEFAULT 0, status text DEFAULT 'idle'::text, error_message text,
+  metadata jsonb DEFAULT '{}'::jsonb, created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now()
+);
+CREATE UNIQUE INDEX sync_state_entity_account_uq ON public.sync_state (entity_type, account);
+ALTER TABLE public.sync_state ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Staff can manage sync state" ON public.sync_state FOR ALL
+  USING (public.has_role(auth.uid(),'master') OR public.has_role(auth.uid(),'employee'));
+-- concede TRUNCATE (como em prod: authenticated TEM) → a migration REVOGA → o assert D5 TRUNCATE prova o dente
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON public.sync_state TO authenticated, anon, service_role;
+-- a policy permissiva avalia has_role() = SELECT em user_roles com os privilégios do CALLER → conceda tb (assert-patterns.md)
+GRANT SELECT ON public.user_roles TO authenticated, anon, service_role;
+SQL
+
+# ── ZONA 2: aplicar a migration REAL ──
+MIG="$REPO_ROOT/supabase/migrations/20260713160000_carteira_rebuild_lease.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+CLEAR() { P -q -c "DELETE FROM public.sync_state WHERE entity_type='carteira_rebuild';" >/dev/null; }
+STATUS() { Pq -c "SELECT status FROM public.sync_state WHERE entity_type='carteira_rebuild' AND account='global';"; }
+
+echo "── asserts: lease ──"
+CLEAR
+eq "D1 claim livre"            "$(Pq -c "SELECT public.claim_carteira_rebuild('run-A');")" "t"
+eq "D1 status vira syncing (RPC escreve a chave APESAR da policy RESTRICTIVE)" "$(STATUS)" "syncing"
+eq "D2 claim fresco negado"    "$(Pq -c "SELECT public.claim_carteira_rebuild('run-B');")" "f"
+P -q -c "UPDATE public.sync_state SET last_sync_at = now() - interval '6 minutes' WHERE entity_type='carteira_rebuild';" >/dev/null
+eq "D2b claim 6min (<TTL) negado" "$(Pq -c "SELECT public.claim_carteira_rebuild('run-B');")" "f"
+P -q -c "UPDATE public.sync_state SET last_sync_at = now() - interval '16 minutes' WHERE entity_type='carteira_rebuild';" >/dev/null
+eq "D3 claim stale>15min auto-libera" "$(Pq -c "SELECT public.claim_carteira_rebuild('run-C');")" "t"
+P -q -c "UPDATE public.sync_state SET status='complete', last_sync_at=now() WHERE entity_type='carteira_rebuild';" >/dev/null
+eq "D4 claim reivindica complete" "$(Pq -c "SELECT public.claim_carteira_rebuild('run-D');")" "t"
+
+echo "── asserts: finalize (ownership + idempotência + validação) ──"
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('run-E');" >/dev/null
+eq "D6 finalize dono"          "$(Pq -c "SELECT public.finalizar_carteira_rebuild('run-E','complete');")" "t"
+eq "D6 status complete"        "$(STATUS)" "complete"
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('run-F');" >/dev/null
+eq "D7 finalize alheio negado" "$(Pq -c "SELECT public.finalizar_carteira_rebuild('run-ALHEIO','complete');")" "f"
+eq "D7 status fica syncing"    "$(STATUS)" "syncing"
+P -q -c "UPDATE public.sync_state SET status='complete' WHERE entity_type='carteira_rebuild';" >/dev/null   # 'complete' por FORA (fase segue 'inicio')
+eq "D7b finalize sobre complete-alheio negado" "$(Pq -c "SELECT public.finalizar_carteira_rebuild('run-F','complete');")" "f"
+# D8 idempotência
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('idem-1');" >/dev/null
+eq "D8 finalize 1a vez"        "$(Pq -c "SELECT public.finalizar_carteira_rebuild('idem-1','complete');")" "t"
+eq "D8 finalize IDEMPOTENTE (2a vez, mesmo run)" "$(Pq -c "SELECT public.finalizar_carteira_rebuild('idem-1','complete');")" "t"
+eq "D8 status segue complete"  "$(STATUS)" "complete"
+eq "D8 alheio sobre complete → false" "$(Pq -c "SELECT public.finalizar_carteira_rebuild('OUTRO','complete');")" "f"
+# D9 validação (SQLSTATE + re-raise)
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN PERFORM public.finalizar_carteira_rebuild('x','LIXO'); RAISE EXCEPTION 'NAO_VALIDOU';
+EXCEPTION WHEN invalid_parameter_value THEN RAISE NOTICE 'VALIDOU_STATUS'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *VALIDOU_STATUS*) ok "D9 finalize rejeita status invalido (22023)" ;; *) bad "D9 status — veio: $R" ;; esac
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN PERFORM public.claim_carteira_rebuild(''); RAISE EXCEPTION 'NAO_VALIDOU';
+EXCEPTION WHEN null_value_not_allowed THEN RAISE NOTICE 'VALIDOU_RUNID'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *VALIDOU_RUNID*) ok "D9 claim rejeita run_id vazio (22004)" ;; *) bad "D9 runid — veio: $R" ;; esac
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN PERFORM public.finalizar_carteira_rebuild('x', NULL); RAISE EXCEPTION 'NAO_VALIDOU';
+EXCEPTION WHEN invalid_parameter_value THEN RAISE NOTICE 'VALIDOU_NULL'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *VALIDOU_NULL*) ok "D9 finalize rejeita status NULL (22023 — NULL NOT IN e' NULL)" ;; *) bad "D9 NULL — veio: $R" ;; esac
+
+echo "── asserts: REVOKE (anon + authenticated barrados; service_role ok) ──"
+eq "D5 claim anon revogado"          "$(Pq -c "SELECT has_function_privilege('anon','public.claim_carteira_rebuild(text)','EXECUTE');")" "f"
+eq "D5 claim authenticated revogado" "$(Pq -c "SELECT has_function_privilege('authenticated','public.claim_carteira_rebuild(text)','EXECUTE');")" "f"
+eq "D5 claim service_role ok"        "$(Pq -c "SELECT has_function_privilege('service_role','public.claim_carteira_rebuild(text)','EXECUTE');")" "t"
+eq "D5 finalize authenticated revogado" "$(Pq -c "SELECT has_function_privilege('authenticated','public.finalizar_carteira_rebuild(text,text)','EXECUTE');")" "f"
+eq "D5 finalize service_role ok"     "$(Pq -c "SELECT has_function_privilege('service_role','public.finalizar_carteira_rebuild(text,text)','EXECUTE');")" "t"
+eq "D5 TRUNCATE authenticated revogado" "$(Pq -c "SELECT has_table_privilege('authenticated','public.sync_state','TRUNCATE');")" "f"
+eq "D5 TRUNCATE anon revogado"          "$(Pq -c "SELECT has_table_privilege('anon','public.sync_state','TRUNCATE');")" "f"
+
+echo "── asserts: RLS (employee NÃO adultera o lease; policy é cirúrgica) ──"
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('rls-seed');" >/dev/null
+R=$(P -tA 2>&1 -v emp="$EMP" <<'SQL'
+SELECT set_config('test.uid', :'emp', false); SET ROLE authenticated;
+DO $$ DECLARE n int; BEGIN
+  UPDATE public.sync_state SET status='hacked' WHERE entity_type='carteira_rebuild';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n=0 THEN RAISE NOTICE 'RLS_BLOQUEOU'; ELSE RAISE NOTICE 'RLS_FUROU_%', n; END IF;
+END $$;
+SQL
+); case "$R" in *RLS_BLOQUEOU*) ok "RLS: employee NAO adultera lease carteira_rebuild (0 linhas)" ;; *) bad "RLS FUROU — veio: $R" ;; esac
+eq "RLS status intacto após tentativa" "$(STATUS)" "syncing"
+# INSERT direto da chave por employee → WITH CHECK viola (42501 insufficient_privilege)
+R=$(P -tA 2>&1 -v emp="$EMP" <<'SQL'
+SELECT set_config('test.uid', :'emp', false); SET ROLE authenticated;
+DO $$ BEGIN
+  INSERT INTO public.sync_state(entity_type, account, status) VALUES ('carteira_rebuild','g2','syncing');
+  RAISE NOTICE 'INSERT_FUROU';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'INSERT_BLOQUEOU'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+); case "$R" in *INSERT_BLOQUEOU*) ok "RLS: employee NAO faz INSERT da chave (WITH CHECK)" ;; *) bad "RLS INSERT — veio: $R" ;; esac
+# DELETE da linha carteira_rebuild por employee → USING filtra (0 linhas)
+R=$(P -tA 2>&1 -v emp="$EMP" <<'SQL'
+SELECT set_config('test.uid', :'emp', false); SET ROLE authenticated;
+DO $$ DECLARE n int; BEGIN
+  DELETE FROM public.sync_state WHERE entity_type='carteira_rebuild';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n=0 THEN RAISE NOTICE 'DELETE_BLOQUEOU'; ELSE RAISE NOTICE 'DELETE_FUROU_%', n; END IF;
+END $$;
+SQL
+); case "$R" in *DELETE_BLOQUEOU*) ok "RLS: employee NAO faz DELETE da chave (USING)" ;; *) bad "RLS DELETE — veio: $R" ;; esac
+R=$(P -tA 2>&1 -v emp="$EMP" <<'SQL'
+SELECT set_config('test.uid', :'emp', false); SET ROLE authenticated;
+DO $$ DECLARE n int; BEGIN
+  INSERT INTO public.sync_state(entity_type, account, status) VALUES ('outra_entidade','x','idle');
+  UPDATE public.sync_state SET status='ok2' WHERE entity_type='outra_entidade';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n=1 THEN RAISE NOTICE 'RLS_PERMITIU_OUTRA'; ELSE RAISE NOTICE 'RLS_BLOQUEOU_OUTRA_%', n; END IF;
+END $$;
+SQL
+); case "$R" in *RLS_PERMITIU_OUTRA*) ok "RLS: employee toca OUTRAS entity_type (policy cirurgica)" ;; *) bad "RLS bloqueou demais — veio: $R" ;; esac
+
+echo "── asserts: concorrência real robusta (Codex P2) ──"
+CLEAR
+CDIR="$(mktemp -d /tmp/claim-conc.XXXXXX)"; pids=()
+for i in $(seq 1 8); do
+  "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -tA \
+    -c "SELECT public.claim_carteira_rebuild('conc-$i');" > "$CDIR/c$i.out" 2>"$CDIR/c$i.err" &
+  pids+=($!)
+done
+fail_workers=0; for pid in "${pids[@]}"; do wait "$pid" || fail_workers=$((fail_workers+1)); done
+TRUES="$(cat "$CDIR"/c*.out | grep -c '^t$' || true)"
+FALSES="$(cat "$CDIR"/c*.out | grep -c '^f$' || true)"
+eq "C1 nenhum worker falhou"   "$fail_workers" "0"
+eq "C1 exatamente 1 vence"     "$TRUES" "1"
+eq "C1 os outros 7 perdem (f)" "$FALSES" "7"
+rm -rf "$CDIR"
+
+# ── ZONA 5: FALSIFICAÇÃO ──
+echo "── falsificação ──"
+# F1: WHERE do claim removido → 2º claim no lease fresco PASSA (D2 tem dente)
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.claim_carteira_rebuild(p_run_id text)
+RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_temp AS $$
+DECLARE v_claimed boolean := false; BEGIN
+  INSERT INTO public.sync_state (entity_type, account, status, last_sync_at, total_synced, metadata, updated_at)
+  VALUES ('carteira_rebuild','global','syncing',now(),0,jsonb_build_object('run_id',p_run_id,'fase','inicio'),now())
+  ON CONFLICT (entity_type, account) DO UPDATE
+    SET status='syncing', last_sync_at=now(), metadata=jsonb_build_object('run_id',p_run_id,'fase','inicio'), updated_at=now()
+  RETURNING true INTO v_claimed;   -- WHERE REMOVIDO
+  RETURN COALESCE(v_claimed,false); END $$;
+SQL
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('sab-1');" >/dev/null
+case "$(Pq -c "SELECT public.claim_carteira_rebuild('sab-2');")" in
+  t) ok "F1 sem o WHERE o 2º claim fresco PASSOU (D2 tem dente)" ;; *) bad "F1 D2 fraco" ;; esac
+P -q -f "$MIG" >/dev/null
+
+# F2: ownership do finalize removido → finalize alheio PASSA (D7 tem dente)
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.finalizar_carteira_rebuild(p_run_id text, p_status text)
+RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path=public,pg_temp AS $$
+DECLARE v_done boolean := false; BEGIN
+  UPDATE public.sync_state SET status=p_status, last_sync_at=now(), updated_at=now()
+   WHERE entity_type='carteira_rebuild' AND account='global' AND status='syncing'
+  RETURNING true INTO v_done;   -- OWNERSHIP (run_id) REMOVIDO
+  RETURN COALESCE(v_done,false); END $$;
+SQL
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('owner-1');" >/dev/null
+case "$(Pq -c "SELECT public.finalizar_carteira_rebuild('ALHEIO','complete');")" in
+  t) ok "F2 sem ownership o finalize alheio PASSOU (D7 tem dente)" ;; *) bad "F2 D7 fraco" ;; esac
+P -q -f "$MIG" >/dev/null
+
+# F3: policy RESTRICTIVE de UPDATE removida → employee ADULTERA o lease (o assert RLS tem dente)
+P -q -c "DROP POLICY carteira_rebuild_lease_no_update ON public.sync_state;"
+CLEAR; Pq -c "SELECT public.claim_carteira_rebuild('f3');" >/dev/null
+R=$(P -tA 2>&1 -v emp="$EMP" <<'SQL'
+SELECT set_config('test.uid', :'emp', false); SET ROLE authenticated;
+DO $$ DECLARE n int; BEGIN
+  UPDATE public.sync_state SET status='hacked' WHERE entity_type='carteira_rebuild';
+  GET DIAGNOSTICS n = ROW_COUNT;
+  IF n>0 THEN RAISE NOTICE 'SABOTAGEM_FUROU_%', n; ELSE RAISE NOTICE 'AINDA_BLOQUEIA'; END IF;
+END $$;
+SQL
+); case "$R" in *SABOTAGEM_FUROU*) ok "F3 sem a policy o employee adultera o lease (RLS tem dente)" ;; *) bad "F3 RLS assert fraco — veio: $R" ;; esac
+P -q -f "$MIG" >/dev/null
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE ($PASS asserts)"

--- a/docs/superpowers/specs/2026-07-13-carteira-rebuild-lease-design.md
+++ b/docs/superpowers/specs/2026-07-13-carteira-rebuild-lease-design.md
@@ -1,0 +1,142 @@
+# carteira-rebuild — lease anti-intercalação (fecha o mosaico de dois writers)
+
+> Data: 2026-07-13 · money-path (carteira/positivação) · segue `docs/agent/money-path.md`
+> Status: **IMPLEMENTADO, PROVADO e ENDURECIDO** (PG17 **31/31** verde: lease + RLS + idempotência +
+> concorrência robusta + 3 falsificações; `deno check`/`eslint`/`shellcheck` OK). Codex consult (metodologia,
+> "A com condições") + challenge (código, **2 P1 + P2 achados e CORRIGIDOS** — ver §Hardening); re-challenge
+> em curso. Deploy pendente (handoff drenado).
+>
+> Artefatos: `supabase/migrations/20260713160000_carteira_rebuild_lease.sql` ·
+> `supabase/functions/carteira-rebuild/index.ts` · `db/test-carteira-rebuild-lease.sh`.
+
+## Problema
+
+`supabase/functions/carteira-rebuild/index.ts` reconstrói `carteira_assignments` (6.909 linhas, 1:1 com
+o espelho `omie_clientes`) lendo 3 snapshots, computando em TS (helper account-safe, 4 invariantes já em
+prod) e fazendo **upsert por chunks de 500 via PostgREST** (`index.ts:357-362`), SEM lease e SEM
+transação de conjunto.
+
+**Furo (P2, classificado por gpt-5.6-sol em 2026-07-13, adiado; este é o follow-up):** dois runs
+concorrentes (cron `carteira-rebuild-nightly` 30 7 × disparo manual staff, ou 2 manuais) podem
+intercalar chunks de **snapshots diferentes** → carteira em "mosaico". Só um próximo run limpo conserta.
+Os 4 guards barram carteira degenerada/100%-Hunter, mas NÃO a intercalação. (O outro cron de carteira,
+`carteira-positivacao-snapshot-mensal`, escreve `carteira_positivacao_snapshot`, não `carteira_assignments`.)
+
+## Descoberta técnica (reorienta a "opção a" literal da tarefa)
+
+`pg_try_advisory_lock` **de sessão** no handler é inseguro aqui: **toda escrita da edge é via PostgREST**,
+que não dá afinidade de conexão — o lock de sessão pode ser liberado por outra conexão do pool ou ficar
+preso numa conexão reciclada e vazar. O repo usa lease row-based via `sync_state`
+(`claim_estoque_full_sync`/`finalizar_estoque_full_sync`) — é esse padrão que espelhamos.
+
+## Restrições
+
+1. **Triggers em `carteira_assignments`:** `trg_carteira_reconcile_score_owner` (AFTER INSERT/UPDATE OF
+   owner) e `trg_carteira_cleanup_orphan_score` (AFTER DELETE) ⇒ swap `DELETE+INSERT` dispara cleanup em
+   massa. Qualquer B tem de ser **upsert-em-massa** (sem DELETE). O design atual nunca deleta.
+2. **Fencing por plataforma:** edge morto pelo wall-clock (150s Free / 400s pago, não-configurável;
+   `waitUntil` não amplia). TTL do lease **15min (900s) > 400s** ⇒ nenhum run **vivo** tem o lease
+   roubado. ⚠️ `service_role` (a edge) **não tem `statement_timeout`** (confirmado via psql-ro) — o teto
+   efetivo é o wall-clock do edge, não o timeout de 60s do PostgREST. Rebuild dura ~segundos (~14 chunks).
+3. **Consumidores toleram a janela parcial p/ ESTE ticket, mas ela NÃO é estritamente benigna** (Codex #4):
+   RLS `carteira_visivel_para` muda acesso por-chunk; `get_minha_positivacao()` pode ver prefixo-novo +
+   sufixo-antigo; paginação frontend multi-request pode montar lista mista; `carteira_positivacao_snapshot`
+   pode **materializar** donos mistos se rodar durante o rebuild. `farmer_client_scores` e
+   `criar_plano_tatico` são consistentes por-cliente (trigger na mesma tx / `FOR UPDATE`). ⇒ **atomicidade
+   observável de leitura é um requisito SEPARADO** (versionamento por geração / leitura em RPC única);
+   B não a resolve para leitores paginados. Fora do escopo deste ticket.
+
+## Decisão: **A** (lease via `sync_state`) — selada pelo Codex
+
+O furo classificado é a intercalação **rebuild × rebuild**; A elimina isso enquanto o lease é válido,
+custo mínimo, padrão confiado, robusto ao pooler. Formulação honesta (correção do Codex #1): **A elimina
+100% da intercalação entre invocações lease-aware enquanto o lease é válido** — não é fencing formal
+contra writers antigos/não-cooperativos. B/C não se justificam para este P2.
+
+## Design da opção A (com as condições do Codex)
+
+### Migration `supabase/migrations/<ts>_carteira_rebuild_lease.sql` — 2 RPCs
+- `claim_carteira_rebuild(p_run_id text) RETURNS boolean` — chave **`carteira_rebuild`/`global` e TTL 15min
+  HARDCODED na RPC** (Codex #6/#1: sem parâmetro `account`; nada de outra conta abrir outro lease na mesma
+  tabela). Usa **`now()` do Postgres** para gravar e comparar idade (Codex #1: relógio do banco, não
+  `p_at` da edge — imune a clock skew). `INSERT … ON CONFLICT (entity_type,account) DO UPDATE … WHERE
+  status IS DISTINCT FROM 'syncing' OR last_sync_at IS NULL OR last_sync_at < now()-interval '15 minutes'
+  RETURNING true`.
+- `finalizar_carteira_rebuild(p_run_id text, p_status text) RETURNS boolean` — `UPDATE … WHERE … status=
+  'syncing' AND metadata->>'run_id'=p_run_id RETURNING true` (ownership).
+- Ambas `SECURITY DEFINER`, `search_path=public,pg_temp`, `REVOKE … FROM PUBLIC, anon, authenticated`,
+  `GRANT EXECUTE … TO service_role`. Validação pós-apply read-only.
+
+### Edge (`carteira-rebuild/index.ts`)
+1. `run_id = crypto.randomUUID()` (Codex #1: **não** `Date.now()` — evita colisão de run_id).
+2. **Claim OBRIGATORIAMENTE após `authorizeCronOrStaff`, ANTES de qualquer snapshot/baseline** (Codex #5:
+   a opção "só antes do upsert" tem TOCTOU semântico — dois runs leriam baselines diferentes e o mais
+   lento sobrescreveria o mais novo, burlando a catraca do baseline). `claim=false` → **409 fail-closed**,
+   sem ler nem escrever.
+3. **Finalize honesto** (Codex #3 — NÃO best-effort silencioso como o baseline):
+   - `await` sempre; finalize **imediato** em todo caminho de saída pós-claim (inclusive aborts de guard).
+   - retorno `true` = ok; retorno **`false` = perda de ownership = incidente** (`console.error`, não warn).
+   - **erro de transporte** no finalize após o upsert ter commitado → resposta honesta **503** com
+     `{writes_committed:true, finalize:'unknown'}` + `console.error`; retry curto (idempotente p/ o mesmo
+     run_id) antes de desistir. O lease auto-expira em 15min (fail-closed; **sem** force-release, **sem**
+     reduzir TTL).
+
+### Rollout com quiescência (Codex #7 — migration-antes-da-edge NÃO basta)
+O cutover tem janela onde a edge velha (sem lease) e a nova (com lease) coexistem. Handoff:
+1. desabilitar `carteira-rebuild-nightly` temporariamente + não disparar manual;
+2. aplicar a migration (SQL Editor) e testar as RPCs;
+3. **drenar** edge velha + cauda PostgREST (~8min dá margem sobre 400s+60s);
+4. publicar a edge nova (chat Lovable, verbatim);
+5. testar claim concorrente (2 disparos → um 409);
+6. reativar o cron.
+Rollback p/ código sem lease exige a MESMA drenagem.
+
+### Gate de deploy (Codex — verificações que ele não pôde rodar; EU confirmei)
+- Registros: **6.909** (psql-ro ✓). Timeout PostgREST: `service_role` sem statement_timeout, wall-clock do
+  edge é o teto (✓, ver Restrição 2). Reconfirmar no dia do deploy se algo mudou.
+
+## Prova (money-path) — reforçada pelo Codex
+
+`db/test-carteira-rebuild-lease.sh` (PG17), além do espelho de `db/test-claim-full-sync.sh` (claim livre;
+'syncing' fresco→false; stale >15min→true; finalize dono→true; alheio→false; não-'syncing'→false; REVOKE
+anon/GRANT service_role), acrescenta (Codex #8 — o teste sequencial não basta):
+- **concorrência real:** dois claims em sessões psql simultâneas → **exatamente um** `true`;
+- **clock skew:** idade calculada com `now()` do banco resiste a `p_*` divergente da edge;
+- **finalize idempotente** p/ o mesmo run_id;
+- **Falsificação:** sabotar o `WHERE` do claim → o assert "claim fresco = false" fica VERMELHO.
+
+Edge: `deno check` + revisão (a edge orquestra `supabase.rpc`; a lógica vive nas RPCs provadas no PG17).
+
+## Hardening pós-challenge do Codex (2 P1 + P2 corrigidos)
+
+- **[P1] Adulteração direta do lease.** `sync_state` dá DML a `authenticated`/`anon` (grant) + policy
+  permissiva `"Staff can manage sync state"` sem filtro por `entity_type` → um employee faria `UPDATE
+  sync_state SET status='complete'` e furaria a exclusão. **Fix:** 3 policies **RESTRICTIVE**
+  (`no_insert`/`no_update`/`no_delete`, `entity_type <> 'carteira_rebuild'`). `service_role` é BYPASSRLS
+  (confirmado, `rolbypassrls=t`) e as RPCs são SECURITY DEFINER (owner bypassa) → escrevem normal; staff
+  fica barrado da linha do lease. Furo do padrão `sync_state` em outras chaves (estoque) = **dívida separada**.
+- **[P1] Finalize não-idempotente.** Retry após resposta HTTP perdida acusava falso ownership-lost. **Fix:**
+  `finalizar` aceita re-finalize do mesmo run (`status=p_status AND fase='fim'`), mantendo ownership por
+  `run_id`. `complete` posto por fora (`fase='inicio'`) não re-finaliza.
+- **P2:** validação (`p_run_id` vazio→22004, `p_status ∉ {complete,error}`→22023); edge — `leaseReleased`
+  marca só no sucesso; `'ownership'` no fim → **500** `integrity:'unknown'` (fencing quebrado, não
+  retentável) distinto de `'transport'` → **503**; upsert parcial → `{writes_committed, partial, upserted}`.
+### Re-challenge (GATE FAIL → corrigido)
+- **[P1] Regressão de branch stale:** a edge revertia a fonte de membership `omie_clientes`→`carteira_membership_ledger` já corrigida na `main` (PR #1329). **Fix:** rebase sobre `origin/main`, preservando o ledger + o lease.
+- **[P2] `p_status=NULL` escapava** (`NULL NOT IN` = NULL) → `IF p_status IS NULL OR p_status NOT IN (...)`.
+- **[P2] Caminho de upsert parcial** não propagava `releaseLease` → agora distingue ownership(500)/transport(503); **retry idempotente do chunk** (mitiga mosaico por erro transitório).
+- **Hardening:** `REVOKE TRUNCATE` (não passa por RLS). Viabilidade confirmada via psql-ro: owner das RPCs = `postgres` BYPASSRLS, `sync_state` FORCE RLS off → a RPC bypassa a própria policy.
+
+- **Prova:** PG17 **34/34** — RLS (employee barrado de U/I/D / cirúrgico), idempotência (D8), validação (status inválido + **NULL**), concorrência robusta (0 workers falham, 1t/7f), REVOKE de `authenticated`, e **3 falsificações**.
+
+## Rollback
+Reverter o deploy da edge (com a drenagem do rollout). RPCs/policies podem ficar inertes. Sem migration de dados.
+
+## Finding SEPARADO obrigatório (Codex #8) — NÃO fecha neste ticket
+Writers de `carteira_assignments.eligible` fora do lease: `aplicar_exclusao_fornecedores()` (roda no cron
+nightly, `UPDATE … eligible=false`) e `reverter_exclusao_fornecedor()` (master, `UPDATE … eligible`).
+Cenário: rebuild lê `flaggeds` → RPC muda `eligible` → rebuild grava depois com snapshot antigo →
+sobrescreve a decisão. **A fecha rebuild × rebuild; NÃO declarar "carteira tem writer único" até coordenar
+essas RPCs** (ambas derivam de `cliente_classificacao.excluir_da_carteira`, então convergem no fim — o
+risco é a janela transitória). Recomendação de escopo (Claude): **dívida v2 separada**, não expande este
+ticket (é pré-existente; A não o piora). Decisão de inclusão = do founder.

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -199,6 +199,41 @@ Deno.serve(async (req) => {
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
   );
 
+  // LEASE anti-intercalação (fecha o mosaico rebuild × rebuild — spec 2026-07-13, Codex xhigh). run_id via
+  // crypto.randomUUID() (não Date.now(): sem colisão). Claim ANTES de qualquer leitura/baseline (Codex #5:
+  // travar tarde deixaria dois runs lerem baselines diferentes e o mais lento sobrescrever o mais novo,
+  // burlando a catraca). Lease ocupado → 409 fail-closed, sem ler nem escrever. Advisory de SESSÃO via
+  // PostgREST NÃO serve (o pool não dá afinidade de conexão) → lease row-based (claim_carteira_rebuild).
+  const runId = crypto.randomUUID();
+  const claimRes = await supabase.rpc('claim_carteira_rebuild', { p_run_id: runId });
+  if (claimRes.error) { console.error('[carteira-rebuild] claim erro:', claimRes.error.message); return fail(`claim: ${claimRes.error.message}`); }
+  if (claimRes.data !== true) {
+    console.warn('[carteira-rebuild] lease ocupado — outro rebuild em andamento; abortando 409 (fail-closed)');
+    return fail('rebuild em andamento (lease ocupado)', 409);
+  }
+
+  // Libera o lease com OWNERSHIP (a RPC só fecha se ESTE run ainda é dono). Idempotente (flag). await sempre
+  // (Codex #3: NÃO best-effort silencioso). retorno 'ownership'/'transport' = incidente (console.error). Os
+  // aborts de guard liberam via failLease; uma exceção não-capturada (rara) conta com o auto-expiry de 15min
+  // (mesmo backstop de crash — Codex #3: lease preso ≤15min é aceitável, fail-closed).
+  let leaseReleased = false;
+  const releaseLease = async (status: 'complete' | 'error'): Promise<'ok' | 'ownership' | 'transport'> => {
+    if (leaseReleased) return 'ok';   // já liberado COM SUCESSO — a flag marca só no 'ok' (Codex: "iniciado" ≠ "liberado")
+    for (let attempt = 1; attempt <= 2; attempt++) {   // retry curto; a RPC é IDEMPOTENTE p/ o mesmo run_id (finalize repetido → true)
+      const { data, error } = await supabase.rpc('finalizar_carteira_rebuild', { p_run_id: runId, p_status: status });
+      if (error) { console.error(`[carteira-rebuild] finalize transporte (tent ${attempt}):`, error.message); continue; }
+      if (data !== true) { console.error('[carteira-rebuild] finalize SEM ownership (fencing quebrado/lease adulterado?):', runId); return 'ownership'; }
+      leaseReleased = true;
+      return 'ok';
+    }
+    return 'transport';
+  };
+  // Abort pós-claim: libera o lease ('error') ANTES de responder o fail (senão fica preso até o TTL).
+  const failLease = async (msg: string, status = 500): Promise<Response> => {
+    await releaseLease('error');
+    return fail(msg, status);
+  };
+
   // 1. Carregar mapa + hunter (tabelas pequenas). FAIL-CLOSED: erro de leitura estrutural aborta ANTES
   // de qualquer upsert — senão vendedorMap=[] mandaria a carteira inteira pro Hunter (P1.4 Codex).
   const [mapRes, hunterRes, baselineRes] = await Promise.all([
@@ -206,16 +241,16 @@ Deno.serve(async (req) => {
     supabase.from('company_config').select('value').eq('key', 'carteira_hunter_user_id').maybeSingle(),
     supabase.from('company_config').select('value').eq('key', 'carteira_omie_baseline').maybeSingle(),
   ]);
-  if (mapRes.error) { console.error('[carteira-rebuild] load vendedor_map error:', mapRes.error.message); return fail(`vendedor_map: ${mapRes.error.message}`); }
-  if (hunterRes.error) { console.error('[carteira-rebuild] load hunter error:', hunterRes.error.message); return fail(`hunter: ${hunterRes.error.message}`); }
-  if (baselineRes.error) { console.error('[carteira-rebuild] load baseline error:', baselineRes.error.message); return fail(`baseline: ${baselineRes.error.message}`); }
+  if (mapRes.error) { console.error('[carteira-rebuild] load vendedor_map error:', mapRes.error.message); return await failLease(`vendedor_map: ${mapRes.error.message}`); }
+  if (hunterRes.error) { console.error('[carteira-rebuild] load hunter error:', hunterRes.error.message); return await failLease(`hunter: ${hunterRes.error.message}`); }
+  if (baselineRes.error) { console.error('[carteira-rebuild] load baseline error:', baselineRes.error.message); return await failLease(`baseline: ${baselineRes.error.message}`); }
   // Baseline saudável persistido (omie elegível do último rebuild bom). Ausente → 0 (bootstrap). Valor CORROMPIDO
   // (não-decimal / > 2^53) → ABORTA (Codex R3 P2: não deixar "4797lixo"→4797, "1e9"→1, gigante→Infinity/congelar).
   const baselinePersistido = parseBaselineSaudavel((baselineRes.data?.value as string | null | undefined) ?? '0');
-  if (baselinePersistido === null) { console.error('[carteira-rebuild] baseline corrompido:', baselineRes.data?.value); return fail(`baseline corrompido: ${baselineRes.data?.value}`); }
+  if (baselinePersistido === null) { console.error('[carteira-rebuild] baseline corrompido:', baselineRes.data?.value); return await failLease(`baseline corrompido: ${baselineRes.data?.value}`); }
   const vendedorMap = (mapRes.data ?? []) as VendedorMapRow[];
   // vendedor_map vazio é anômalo (sempre há vendedores) e mandaria todos pro Hunter → aborta.
-  if (vendedorMap.length === 0) { console.error('[carteira-rebuild] vendedor_map vazio — abortando'); return fail('vendedor_map vazio (anômalo)'); }
+  if (vendedorMap.length === 0) { console.error('[carteira-rebuild] vendedor_map vazio — abortando'); return await failLease('vendedor_map vazio (anômalo)'); }
   // value pode vir como uuid puro ou JSON-quoted ("uuid") — normaliza removendo aspas.
   const rawHunter = (hunterRes.data?.value as string | null | undefined) ?? null;
   const hunterUserId = rawHunter ? (rawHunter.replace(/^"|"$/g, '').trim() || null) : null;
@@ -233,7 +268,7 @@ Deno.serve(async (req) => {
         .eq('status', 'active')
         .order('alias_user_id', { ascending: true })
         .range(from, from + PAGE - 1);
-      if (error) { console.error('[carteira-rebuild] load aliases error:', error.message); return fail(`aliases: ${error.message}`); }
+      if (error) { console.error('[carteira-rebuild] load aliases error:', error.message); return await failLease(`aliases: ${error.message}`); }
       const page = (data ?? []) as Array<{ alias_user_id: string; canonical_user_id: string }>;
       for (const r of page) if (r.alias_user_id && r.canonical_user_id) aliasMap.set(r.alias_user_id, r.canonical_user_id);
       if (page.length < PAGE) break;
@@ -256,12 +291,12 @@ Deno.serve(async (req) => {
       .select('user_id')
       .order('user_id', { ascending: true })
       .range(from, from + PAGE - 1);
-    if (error) { console.error('[carteira-rebuild] load ledger error:', error.message); return fail(error.message); }
+    if (error) { console.error('[carteira-rebuild] load ledger error:', error.message); return await failLease(error.message); }
     const page = (data ?? []) as Array<{ user_id: string }>;
     for (const r of page) membroIds.push(r.user_id);
     if (page.length === 0) break;
     from += page.length;
-    if (from > MAX_ROWS) { console.error('[carteira-rebuild] ledger excedeu MAX_ROWS'); return fail('paginacao ledger excedeu limite'); }
+    if (from > MAX_ROWS) { console.error('[carteira-rebuild] ledger excedeu MAX_ROWS'); return await failLease('paginacao ledger excedeu limite'); }
   }
 
   // VENDEDOR account-correto = view FRESCA omie_customer_account_map_fresco (account='oben') → Map por
@@ -277,7 +312,7 @@ Deno.serve(async (req) => {
       .not('user_id', 'is', null)
       .order('user_id', { ascending: true })
       .range(from, from + PAGE - 1);
-    if (error) { console.error('[carteira-rebuild] load proof oben error:', error.message); return fail(`proof oben: ${error.message}`); }
+    if (error) { console.error('[carteira-rebuild] load proof oben error:', error.message); return await failLease(`proof oben: ${error.message}`); }
     const page = (data ?? []) as Array<{ user_id: string; omie_codigo_vendedor: number | string | null }>;
     for (const r of page) {
       const cod = coerceCodigoVendedor(r.omie_codigo_vendedor);
@@ -286,7 +321,7 @@ Deno.serve(async (req) => {
     }
     if (page.length === 0) break;
     from += page.length;
-    if (from > MAX_ROWS) { console.error('[carteira-rebuild] proof oben excedeu MAX_ROWS'); return fail('paginacao proof oben excedeu limite'); }
+    if (from > MAX_ROWS) { console.error('[carteira-rebuild] proof oben excedeu MAX_ROWS'); return await failLease('paginacao proof oben excedeu limite'); }
   }
 
   // Denominador do guard de frescor = proof oben CRUA (sem TTL), não o espelho misto (#4 Codex): isola a
@@ -294,13 +329,13 @@ Deno.serve(async (req) => {
   // persistido — senão baseline=0 && atual>0, após uma persistência falha, reabriria a catraca).
   const { count: proofCruaRaw, error: cruaErr } = await supabase
     .from('omie_customer_account_map').select('*', { count: 'exact', head: true }).eq('account', 'oben').not('user_id', 'is', null);
-  if (cruaErr) { console.error('[carteira-rebuild] count proof crua error:', cruaErr.message); return fail(`proof crua: ${cruaErr.message}`); }
+  if (cruaErr) { console.error('[carteira-rebuild] count proof crua error:', cruaErr.message); return await failLease(`proof crua: ${cruaErr.message}`); }
   const proofCrua = proofCruaRaw ?? 0;
 
   // Guard PRÉ-compute fail-closed: proof oben anômala → aborta ANTES de qualquer upsert (senão a carteira
   // zeraria p/ Hunter silenciosamente). Análogo ao guard de vendedor_map vazio (:155).
   const guardPre = avaliarGuardProof({ proofCrua, proofFresca: proofOben.size, comVendedor });
-  if (guardPre.abortar) { console.error('[carteira-rebuild] guard proof oben:', guardPre.motivo); return fail(`guard proof oben: ${guardPre.motivo}`); }
+  if (guardPre.abortar) { console.error('[carteira-rebuild] guard proof oben:', guardPre.motivo); return await failLease(`guard proof oben: ${guardPre.motivo}`); }
 
   // Merge: LISTA (ledger) × VENDEDOR (proof oben). Clone ausente da proof → null → herda do gêmeo no grupo.
   const clientes = montarClientes(membroIds, proofOben);
@@ -318,7 +353,7 @@ Deno.serve(async (req) => {
         .eq('excluir_da_carteira', true)
         .order('user_id', { ascending: true })
         .range(from, from + FPAGE - 1);
-      if (error) { console.error('[carteira-rebuild] load flaggeds error:', error.message); return fail(`flaggeds: ${error.message}`); }
+      if (error) { console.error('[carteira-rebuild] load flaggeds error:', error.message); return await failLease(`flaggeds: ${error.message}`); }
       const page = (data ?? []) as Array<{ user_id: string }>;
       for (const r of page) flaggeds.add(r.user_id);
       if (page.length < FPAGE) break;
@@ -331,7 +366,7 @@ Deno.serve(async (req) => {
   // 2b. Cadeia de alias (A→B→C) detectada → ABORTA sem escrever (P2.7 Codex). Aliases devem ser 1 nível.
   if (chainViolations.length) {
     console.error('[carteira-rebuild] cadeia de alias detectada — abortando:', JSON.stringify(chainViolations.slice(0, 20)));
-    return fail(`cadeia de alias (${chainViolations.length}) — corrija customer_canonical_alias`);
+    return await failLease(`cadeia de alias (${chainViolations.length}) — corrija customer_canonical_alias`);
   }
 
   // 2c. Rows finais — eligible EXPLÍCITO pós-flaggeds (clone a.eligible E não-fornecedor: é o que esconde
@@ -352,15 +387,47 @@ Deno.serve(async (req) => {
   // (fator 0.8, monotônico → sem catraca). Nunca grava carteira integralmente órfã.
   const omieElegivelNovo = rows.filter((r) => r.source === 'omie' && r.eligible).length;
   const guardPos = avaliarGuardResultado({ omieElegivelNovo, baselinePersistido, autorizado });
-  if (guardPos.abortar) { console.error('[carteira-rebuild] guard resultado:', guardPos.motivo); return fail(`guard resultado: ${guardPos.motivo}`); }
+  if (guardPos.abortar) { console.error('[carteira-rebuild] guard resultado:', guardPos.motivo); return await failLease(`guard resultado: ${guardPos.motivo}`); }
 
   // 3. Upsert idempotente.
 
   let upserted = 0;
   for (let i = 0; i < rows.length; i += 500) {
     const chunk = rows.slice(i, i + 500);
-    const { error } = await supabase.from('carteira_assignments').upsert(chunk, { onConflict: 'customer_user_id' });
-    if (error) { console.error('[carteira-rebuild] upsert error:', error.message); return fail(error.message); }
+    // Retry idempotente do chunk (Codex re-challenge): o upsert é idempotente por customer_user_id → re-tentar
+    // reduz o mosaico por erro TRANSITÓRIO. Erro persistente ainda deixa parcial (reportado honesto abaixo); o
+    // reparo total (staging + swap atômico = opção B) é dívida v2.
+    let chunkErr: { message: string } | null = null;
+    let chunkStatus = 0;
+    for (let tent = 1; tent <= 3; tent++) {
+      const { error, status } = await supabase.from('carteira_assignments').upsert(chunk, { onConflict: 'customer_user_id' });
+      if (!error) { chunkErr = null; break; }
+      chunkErr = error; chunkStatus = status ?? 0;
+      console.warn(`[carteira-rebuild] upsert chunk ${i} falhou (tent ${tent}, http ${chunkStatus}):`, error.message);
+    }
+    if (chunkErr) {
+      // Upsert parcial (chunks anteriores JÁ commitaram — PostgREST = 1 tx/chunk). Codex re-challenge #4: NÃO
+      // declarar writes_committed:false sob RESPOSTA PERDIDA. `status:0` do SDK = falha de fetch → o chunk PODE
+      // ter commitado (commit DESCONHECIDO); `status>=400` = o banco recusou (chunk NÃO commitou). Reporte:
+      // upserted_confirmed (só chunks que retornaram ok) + current_chunk_commit. Propaga ownership/transport do
+      // finalize. Reparo total (staging + swap atômico = opção B) é dívida v2.
+      const commitDesconhecido = chunkStatus === 0;
+      console.error(`[carteira-rebuild] upsert parcial (chunk ${i}, http ${chunkStatus}, commit ${commitDesconhecido ? 'DESCONHECIDO' : 'nao'}):`, chunkErr.message);
+      const rel = await releaseLease('error');
+      const base = {
+        ok: false, error: chunkErr.message, runId,
+        upserted_confirmed: upserted,                                  // só os chunks que retornaram sucesso
+        current_chunk_commit: commitDesconhecido ? 'unknown' : 'no',
+        writes_committed: upserted > 0 || commitDesconhecido,          // honesto: transporte pode ter escrito
+        partial: upserted > 0 || commitDesconhecido,
+      };
+      const body = rel === 'ownership' ? { ...base, ownership_lost: true, integrity: 'unknown' }
+                 : rel === 'transport' ? { ...base, finalize: 'unknown' }
+                 : base;
+      // 503 se o commit do chunk é incerto (transporte) OU o finalize teve transporte; 500 no erro real de banco.
+      const httpStatus = (commitDesconhecido || rel === 'transport') ? 503 : 500;
+      return new Response(JSON.stringify(body), { status: httpStatus, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+    }
     upserted += chunk.length;
   }
 
@@ -374,9 +441,31 @@ Deno.serve(async (req) => {
     if (bErr) console.warn('[carteira-rebuild] falha ao persistir baseline (nao-fatal):', bErr.message);
   }
 
+  // Finalize honesto do lease. 'ownership' e 'transport' são DISTINTOS (Codex #3):
+  const finalize = await releaseLease('complete');
+  if (finalize === 'ownership') {
+    // perdeu o lease no FIM = fencing quebrado ou lease adulterado → integridade DESCONHECIDA. NÃO é
+    // transitório nem retentável (500, distinto do 503 de transporte). A escrita saiu, mas outro run pode
+    // ter concorrido: alerta forte.
+    console.error('[carteira-rebuild] OWNERSHIP perdido no finalize (integridade desconhecida):', runId);
+    return new Response(JSON.stringify({
+      ok: false, error: 'ownership perdido no finalize', ownership_lost: true, integrity: 'unknown',
+      writes_committed: true, upserted, omieElegivelNovo, novoBaseline: guardPos.novoBaseline, runId,
+    }), { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+  if (finalize === 'transport') {
+    // transporte falhou APÓS o upsert commitado → 503 honesto (writes_committed:true, finalize:'unknown').
+    // A escrita ESTÁ boa; só o selo do lease ficou incerto. O lease auto-expira em 15min (fail-closed; sem
+    // force-release, sem reduzir TTL).
+    return new Response(JSON.stringify({
+      ok: false, error: 'finalize falhou (transporte)', writes_committed: true, finalize: 'unknown',
+      upserted, omieElegivelNovo, novoBaseline: guardPos.novoBaseline, runId,
+    }), { status: 503, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+  }
+
   return new Response(JSON.stringify({
     ok: true, upserted, orphanCount, omieElegivelNovo, comVendedor,
     proofFresca: proofOben.size, proofCrua, baselinePersistido, novoBaseline: guardPos.novoBaseline,
-    autorizado, via: auth.via, conflicts, hunterUserId, aliasesAtivos: aliasMap.size,
+    autorizado, via: auth.via, conflicts, hunterUserId, aliasesAtivos: aliasMap.size, runId,
   }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 });

--- a/supabase/migrations/20260713160000_carteira_rebuild_lease.sql
+++ b/supabase/migrations/20260713160000_carteira_rebuild_lease.sql
@@ -1,0 +1,127 @@
+-- ============================================================================================
+-- carteira-rebuild — LEASE anti-intercalação (fecha o mosaico rebuild × rebuild)
+-- ============================================================================================
+-- Furo (P2, classificado por gpt-5.6-sol 2026-07-13, adiado; este é o follow-up): a edge
+-- carteira-rebuild faz upsert por chunks de 500 via PostgREST, SEM lease. Dois runs concorrentes
+-- (cron carteira-rebuild-nightly 30 7 × disparo manual, ou 2 manuais) podem intercalar chunks de
+-- SNAPSHOTS DIFERENTES → carteira em "mosaico" (parte do snapshot A + parte do B); só um próximo run
+-- limpo conserta. Advisory lock de SESSÃO via PostgREST NÃO serve (o pool não dá afinidade de conexão:
+-- o lock vaza/solta em conexão reciclada). Solução idiomática do repo: LEASE row-based via sync_state,
+-- espelhando claim_estoque_full_sync/finalizar_estoque_full_sync (migration 20260611220000).
+--
+-- Selado por Codex gpt-5.6-sol (xhigh): consult (metodologia, "A com condições") + challenge (código,
+-- 2 P1). Condições/correções incorporadas AQUI:
+--   • chave (entity_type/account) e TTL 15min HARDCODED na RPC — sem parâmetro account (a carteira é uma
+--     tabela ÚNICA e customer_user_id é globalmente único; account parametrizável deixaria outra conta
+--     abrir 2º lease e escrever na MESMA tabela).
+--   • idade e timestamps via now() DO BANCO, não p_at da edge (imune a clock skew da edge).
+--   • run_id é TEXT (a edge passa crypto.randomUUID(): evita colisão de Date.now()).
+--   • [P1 challenge] finalize IDEMPOTENTE (retry após resposta HTTP perdida não acusa falso ownership-lost).
+--   • [P1 challenge] policy RESTRICTIVE reserva a chave do lease ao service_role — sem isto, employee/staff
+--     (a policy "Staff can manage sync state" dá FOR ALL) faria UPDATE direto e furaria a exclusão.
+--
+-- Fencing por PLATAFORMA (o run vivo NUNCA perde o lease): o edge do Supabase é morto pelo wall-clock
+-- (150s Free / 400s pago, não-configurável; waitUntil não amplia). TTL 15min (900s) > 400s ⇒ o run
+-- antigo já morreu pela plataforma antes de o TTL expirar. (service_role não tem statement_timeout — o
+-- teto efetivo é o wall-clock do edge, não o timeout do PostgREST.) O rebuild real dura ~segundos
+-- (6.909 linhas / ~14 chunks). Defesa extra: finalizar_carteira_rebuild só grava se o run AINDA é dono.
+-- ⚠️ MONEY-PATH — provado em PG17 (db/test-carteira-rebuild-lease.sh) com concorrência real + RLS + falsificação.
+
+-- claim: reivindica o lease 'syncing' SE livre (não-'syncing', ou 'syncing' velho >15min = run morto).
+-- INSERT ... ON CONFLICT DO UPDATE ... WHERE ... RETURNING é UMA instrução com lock de linha → só UM
+-- concorrente reivindica; o outro vê o WHERE falso → RETURNING vazio → false (e a edge aborta 409).
+CREATE OR REPLACE FUNCTION public.claim_carteira_rebuild(p_run_id text)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_claimed boolean := false;
+BEGIN
+  IF p_run_id IS NULL OR p_run_id = '' THEN RAISE EXCEPTION 'p_run_id vazio' USING ERRCODE = '22004'; END IF;
+  INSERT INTO public.sync_state (entity_type, account, status, last_sync_at, total_synced, metadata, updated_at)
+  VALUES ('carteira_rebuild', 'global', 'syncing', now(), 0,
+          jsonb_build_object('run_id', p_run_id, 'fase', 'inicio'), now())
+  ON CONFLICT (entity_type, account) DO UPDATE
+    SET status = 'syncing', last_sync_at = now(), total_synced = 0,
+        metadata = jsonb_build_object('run_id', p_run_id, 'fase', 'inicio'), updated_at = now()
+    WHERE sync_state.status IS DISTINCT FROM 'syncing'
+       OR sync_state.last_sync_at IS NULL
+       OR sync_state.last_sync_at < now() - interval '15 minutes'  -- TTL > teto de wall-clock do edge
+  RETURNING true INTO v_claimed;
+  RETURN COALESCE(v_claimed, false);
+END $$;
+
+REVOKE ALL ON FUNCTION public.claim_carteira_rebuild(text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_carteira_rebuild(text) TO service_role;
+
+-- finalize com OWNERSHIP + IDEMPOTÊNCIA (Codex P1). Grava 'complete'/'error' se ESTE run é dono
+-- (metadata->>'run_id' == p_run_id) E (status ainda 'syncing' — finalização normal — OU já finalizado
+-- ANTES por este mesmo run: status == p_status E fase == 'fim' — retry após resposta HTTP perdida). Run
+-- alheio nunca casa (ownership). fase='fim' distingue "EU finalizei" de "alguém pôs 'complete' por fora"
+-- (esse não re-finaliza → false). Retorno: true = finalizado/já-finalizado-por-mim; false = não sou dono.
+CREATE OR REPLACE FUNCTION public.finalizar_carteira_rebuild(p_run_id text, p_status text)
+RETURNS boolean
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_done boolean := false;
+BEGIN
+  IF p_run_id IS NULL OR p_run_id = '' THEN RAISE EXCEPTION 'p_run_id vazio' USING ERRCODE = '22004'; END IF;
+  -- [Codex re-challenge] p_status IS NULL explicito: `NULL NOT IN (...)` = NULL (nao TRUE) → sem o IS NULL o
+  -- RAISE nao rodaria e o finalize gravaria status=NULL retornando true.
+  IF p_status IS NULL OR p_status NOT IN ('complete', 'error') THEN
+    RAISE EXCEPTION 'p_status invalido: %', p_status USING ERRCODE = '22023';
+  END IF;
+  UPDATE public.sync_state
+     SET status = p_status, last_sync_at = now(),
+         metadata = jsonb_build_object('run_id', p_run_id, 'fase', 'fim'),
+         updated_at = now()
+   WHERE entity_type = 'carteira_rebuild'
+     AND account = 'global'
+     AND (metadata->>'run_id') = p_run_id
+     AND (
+       status = 'syncing'                                       -- finalização normal
+       OR (status = p_status AND (metadata->>'fase') = 'fim')   -- retry idempotente do MESMO run
+     )
+  RETURNING true INTO v_done;
+  RETURN COALESCE(v_done, false);
+END $$;
+
+REVOKE ALL ON FUNCTION public.finalizar_carteira_rebuild(text, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.finalizar_carteira_rebuild(text, text) TO service_role;
+
+-- [Codex P1] BLOQUEIO de adulteração direta do lease. A policy "Staff can manage sync state" dá FOR ALL
+-- em sync_state a employee/master, e o GRANT de tabela dá DML a authenticated/anon → um staff (ou insider
+-- comprometido) faria UPDATE sync_state SET status='complete' na chave do lease e furaria a exclusão (o
+-- claim seguinte reivindicaria). Policies RESTRICTIVE reservam a ESCRITA da chave 'carteira_rebuild' ao
+-- service_role (BYPASSRLS → edge/cron não afetados; postgres do cron idem). SELECT fica livre (leitura da
+-- linha de lease é inócua). Fecha ESTE lease; o furo geral do padrão sync_state (outras chaves de lease,
+-- ex. reposicao_estoque_full) é dívida SEPARADA (mesmo vetor insider, fora deste ticket).
+DROP POLICY IF EXISTS carteira_rebuild_lease_no_insert ON public.sync_state;
+DROP POLICY IF EXISTS carteira_rebuild_lease_no_update ON public.sync_state;
+DROP POLICY IF EXISTS carteira_rebuild_lease_no_delete ON public.sync_state;
+CREATE POLICY carteira_rebuild_lease_no_insert ON public.sync_state
+  AS RESTRICTIVE FOR INSERT TO public WITH CHECK (entity_type <> 'carteira_rebuild');
+CREATE POLICY carteira_rebuild_lease_no_update ON public.sync_state
+  AS RESTRICTIVE FOR UPDATE TO public
+  USING (entity_type <> 'carteira_rebuild') WITH CHECK (entity_type <> 'carteira_rebuild');
+CREATE POLICY carteira_rebuild_lease_no_delete ON public.sync_state
+  AS RESTRICTIVE FOR DELETE TO public USING (entity_type <> 'carteira_rebuild');
+
+-- [Codex re-challenge] TRUNCATE NÃO passa por RLS (bypassa as policies acima). Não há via Data API/RPC que
+-- exponha TRUNCATE a staff (não é P1 explorável), mas revoga-se como defesa em profundidade — só o
+-- service_role/superuser (que já bypassam) truncam sync_state.
+REVOKE TRUNCATE ON public.sync_state FROM PUBLIC, anon, authenticated;
+
+-- Validação pós-apply (read-only): as 2 funções existem, revogadas de anon/authenticated, e as 3 policies.
+SELECT 'MIGRATION carteira_rebuild_lease OK' AS status,
+  (SELECT count(*) FROM pg_proc WHERE proname IN ('claim_carteira_rebuild','finalizar_carteira_rebuild'))::int AS funcs_existem,
+  has_function_privilege('service_role', 'public.claim_carteira_rebuild(text)', 'EXECUTE') AS claim_service_role,
+  has_function_privilege('anon', 'public.claim_carteira_rebuild(text)', 'EXECUTE') AS claim_anon,
+  has_function_privilege('authenticated', 'public.finalizar_carteira_rebuild(text, text)', 'EXECUTE') AS finalizar_authenticated,
+  (SELECT count(*) FROM pg_policy WHERE polrelid = 'public.sync_state'::regclass
+     AND polname LIKE 'carteira_rebuild_lease_%')::int AS policies_lease;


### PR DESCRIPTION
> **DRAFT** — 3 rodadas de Codex (consult + challenge + re-challenge) concluídas; **rebaseado sobre `origin/main`** (o re-challenge pegou uma regressão de branch stale — ver Hardening). Ainda draft para sua revisão. **Deploy é MANUAL** (migration + edge no Lovable) — não vai a produção por merge.

## Problema

`carteira-rebuild` faz upsert por chunks de 500 via PostgREST, **sem lease**. Dois runs concorrentes (cron `carteira-rebuild-nightly` 30 7 × disparo manual, ou 2 manuais) podiam intercalar chunks de **snapshots diferentes** → `carteira_assignments` em "mosaico". P2 classificado por Codex gpt-5.6-sol (adiado); este é o follow-up de lease.

## Solução — lease row-based (opção A, selada pelo Codex)

Advisory lock de **sessão** via PostgREST vaza no pooler (sem afinidade de conexão). Solução idiomática do repo: **lease via `sync_state`**, espelhando `claim_estoque_full_sync`/`finalizar_estoque_full_sync`.

- **Migration `20260713160000`** — `claim_carteira_rebuild(text)` + `finalizar_carteira_rebuild(text,text)`, `SECURITY DEFINER`, `REVOKE` anon/authenticated, `GRANT` service_role. Chave `carteira_rebuild`/`global` + TTL 15min **hardcoded**; `run_id` text; idade via `now()` do banco (imune a clock skew).
- **Edge** — `run_id = crypto.randomUUID()`; **claim após auth, antes das leituras** (serializa o baseline → evita catraca burlada por baseline stale); lease ocupado → **409 fail-closed**; **finalize honesto** (`await`, retry idempotente, ownership por run_id, **503** `writes_committed:true` se o transporte falhar após o upsert). Lógica account-safe intocada (só `fail`→`failLease` nos aborts).

## Fencing (por que 15min basta)

Edge morto pelo wall-clock (150-400s, não-configurável) ≪ TTL 900s ⇒ nenhum run **vivo** perde o lease. `service_role` não tem `statement_timeout`, mas o teto é o wall-clock do edge.

## Hardening — Codex challenge do código pegou 2 P1 (corrigidos)

- **[P1] Staff adulterava o lease direto na tabela** (`sync_state` dá DML a authenticated + policy permissiva sem filtro por `entity_type`). Fix: 3 policies **RESTRICTIVE** reservando `entity_type='carteira_rebuild'` ao service_role (BYPASSRLS).
- **[P1] Finalize não era idempotente** (retry após resposta HTTP perdida acusava falso ownership-lost). Fix: `finalizar` aceita re-finalize do mesmo run (`status=p_status AND fase='fim'`), ownership por `run_id`.
- **P2:** validação `p_status`/`p_run_id`; `leaseReleased` só no sucesso; `ownership` no fim → 500 `integrity:'unknown'` ≠ `transport` → 503; upsert parcial → `{writes_committed, partial, upserted}`.

### Re-challenge (GATE FAIL → corrigido)

- **[P1] Regressão de branch stale:** a edge revertia a fonte de membership `omie_clientes`→`carteira_membership_ledger` já corrigida na `main` (#1329). **Fix: rebase sobre `origin/main`, ledger preservado.**
- **[P2] `p_status=NULL` escapava** (`NULL NOT IN` = NULL) → `p_status IS NULL OR …`.
- **[P2] Caminho parcial não propagava** ownership/transport → agora 500/503 distintos; **retry idempotente do chunk** (mitiga mosaico transitório). **Hardening:** `REVOKE TRUNCATE`.

## Prova (money-path)

`db/test-carteira-rebuild-lease.sh` (PG17): **34 asserts verde** — lease, auto-recuperação (stale>15min), ownership + **idempotência**, **validação** (status inválido + **NULL**), REVOKE (anon+authenticated), **RLS** (employee barrado de U/I/D / cirúrgico), **concorrência robusta** (8 claims → 0 falham, 1t/7f), **3 falsificações**. `deno check` / `eslint` / `shellcheck` / `typecheck` / `test` OK. Viabilidade da policy confirmada via psql-ro (owner BYPASSRLS, FORCE RLS off).

## Codex (2ª opinião adversária) — 3 rodadas, gpt-5.6-sol xhigh

Consult (metodologia, A com 8 condições) + challenge (2 P1) + re-challenge (P1 regressão de branch stale + 2 P2) — todos corrigidos.

## Deploy (manual, Lovable) — rollout DRENADO

1. Desabilitar `carteira-rebuild-nightly` + não disparar manual;
2. aplicar a migration (SQL Editor) e testar as RPCs;
3. drenar edge velha + cauda PostgREST (~8min);
4. publicar a edge `carteira-rebuild` (verbatim);
5. testar claim concorrente (2 disparos → um 409);
6. reativar o cron.

Spec: `docs/superpowers/specs/2026-07-13-carteira-rebuild-lease-design.md`.

## Fora do escopo (dívida registrada)

`aplicar_exclusao_fornecedores()`/`reverter_exclusao_fornecedor()` escrevem `carteira_assignments.eligible` fora do lease (achado do Codex). A fecha rebuild × rebuild; este eixo é v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
