### PR TITLE
fix(recebimento): varredura reconcile expõe motivo das consultas falhas (observabilidade)

### DIFF
--- a/supabase/functions/omie-nfe-reconcile/index.ts
+++ b/supabase/functions/omie-nfe-reconcile/index.ts
@@ -306,6 +306,7 @@ Deno.serve(async (req) => {
     let puladasCredencial = 0;
     let estadoMudou = 0;
     let errosUpdate = 0;
+    const errosConsulta: string[] = []; // amostra (até 3 distintos) do motivo de consulta_falhou
 
     for (let i = 0; i < rows.length; i++) {
       if (i > 0) await new Promise((r) => setTimeout(r, TREGUA_MS));
@@ -373,6 +374,13 @@ Deno.serve(async (req) => {
           const erroIdent = validarIdentidade(extrairEstadoConsulta(consulta.data), esperado).erro ?? "identidade não confere";
           await registrarTentativa(supabase, { nfe_recebimento_id: nfe.id, tentativa: nfe.efetivacao_tentativas ?? 0, operacao: "reconcile_identidade", sucesso: false, erro: erroIdent, omie_status: null });
           console.warn(`[omie-nfe-reconcile] NF ${nfe.numero_nfe}: ${erroIdent} — pulada.`);
+        } else if (efeito.motivo === "consulta_falhou") {
+          // Observabilidade (lição 2026-07-16: 15/15 consultas falharam e o MOTIVO não era
+          // visível de fora — só contadores). Amostra na resposta → fica em net._http_response,
+          // legível via psql-ro sem depender de clique/log; warn por NF cobre o resto.
+          const erroConsulta = `${cls.erro ?? "erro desconhecido"}${cls.omieStatus ? ` (omie_status ${cls.omieStatus})` : ""}`;
+          if (errosConsulta.length < 3 && !errosConsulta.includes(erroConsulta)) errosConsulta.push(erroConsulta);
+          console.warn(`[omie-nfe-reconcile] NF ${nfe.numero_nfe}: consulta falhou — ${erroConsulta}`);
         }
       } finally {
         // libera o lock só se ainda é o MEU (compare-and-clear pelo timestamp gravado)
@@ -399,6 +407,7 @@ Deno.serve(async (req) => {
       puladas_credencial: puladasCredencial,
       estado_mudou: estadoMudou,
       erros_update: errosUpdate,
+      amostra_erros_consulta: errosConsulta,
       reconciliadas_nfe: reconciliadasNfe,
       restantes_pendentes: restantes ?? null,
     });


### PR DESCRIPTION
## O que este PR faz

1ª rodada do cron `omie-nfe-reconcile-1h` em prod (2026-07-16 17:10 UTC): `consulta_falhou: 15/15`, 0 reconciliadas — e o **motivo não era observável de fora** (resposta só com contadores; caminho `consulta_falhou` sem log). Este PR fecha a lacuna mínima:

- `amostra_erros_consulta` (até 3 erros distintos, com `omie_status`) na resposta da edge → fica gravado em `net._http_response`, legível via psql-ro sem clique nem acesso a logs;
- `console.warn` por NF com o erro da consulta.

Follow-up de observabilidade do design review (Codex) do [PR #1335](https://github.com/LucasSardenbergL/afiacao/pull/1335) — versão mínima antes do run-ledger completo.

## 🚀 Deploy

💬 chat do Lovable: **redeploy verbatim** de `omie-nfe-reconcile` (`supabase/functions/omie-nfe-reconcile/index.ts`). Sem migration, sem Publish.

## 🧭 GOAL: Recebimento NF-e closed-loop — atualização

F3 ✅ (edges deployadas + migration aplicada + crons disparando; import trouxe NF nova na 1ª rodada). F4 🔄 **bloqueada por consultas ao Omie falhando na varredura (15/15, ambas as contas)** — causa em investigação; este PR instrumenta o motivo. Política fail-safe confirmada em prod: nenhuma NF pintada de falha pela varredura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)