### PR TITLE
fix(sync): sku_items — 1 chamada Omie por recebimento e item no tracking do SEU pedido [money-path]

### DIFF
--- a/src/lib/reposicao/__tests__/sku-items-fila-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/sku-items-fila-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   skuItemsBackoffMs,
   skuItemsElegivel,
   skuItemsCompararFila,
+  skuItemsDedupPorRecebimento,
   type SkuItemsFilaControle,
 } from '../sku-items-fila-helpers';
 
@@ -93,5 +94,67 @@ describe('skuItemsCompararFila — nunca-tentadas primeiro, poison pro fim', () 
       'tentada-1x',
       'poison',
     ]);
+  });
+});
+
+describe('skuItemsDedupPorRecebimento', () => {
+  it('N linhas com o MESMO nIdReceb viram 1 (a NFe que fatura N pedidos)', () => {
+    // A forma do passivo medido em prod: 1 NFe fatura N pedidos → N linhas em
+    // purchase_orders_tracking com a mesma chave, e o backfill do sync de NFes grava o
+    // MESMO recebimento no raw_data de todas. Sem dedup, cada uma consultava o mesmo
+    // recebimento e regravava os mesmos itens sob o seu tracking_id: peso N×.
+    const out = skuItemsDedupPorRecebimento([
+      { id: 'pedido-a', nIdReceb: '555' },
+      { id: 'pedido-b', nIdReceb: '555' },
+      { id: 'pedido-c', nIdReceb: '555' },
+    ]);
+    expect(out.map((o) => o.id)).toEqual(['pedido-a']);
+  });
+
+  it('recebimentos DISTINTOS passam todos (não colapsa o legítimo)', () => {
+    const out = skuItemsDedupPorRecebimento([
+      { id: 'a', nIdReceb: '1' },
+      { id: 'b', nIdReceb: '2' },
+      { id: 'c', nIdReceb: '3' },
+    ]);
+    expect(out.map((o) => o.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('linha sem nIdReceb passa direto e NÃO deduplica contra outra sem nIdReceb', () => {
+    // Sem nIdReceb não há o que consultar: são o gap de cobertura, contadas à parte pelo
+    // chamador. Colapsá-las entre si (todas com chave `null`) esconderia o gap.
+    const out = skuItemsDedupPorRecebimento([
+      { id: 'sem-1', nIdReceb: null },
+      { id: 'sem-2', nIdReceb: null },
+      { id: 'com', nIdReceb: '9' },
+    ]);
+    expect(out.map((o) => o.id)).toEqual(['sem-1', 'sem-2', 'com']);
+  });
+
+  it('a eleita é a PRIMEIRA da ordem da fila — dedup preserva a prioridade, não a atropela', () => {
+    // A fila chega ordenada earliest-deadline-first. Se o dedup elegesse outra que não a
+    // primeira, a NFe prestes a expirar perderia a vez pra uma folgada.
+    const fila = [
+      { id: 'poison', tentativas: 5, t2: '2026-07-14T00:00:00+00:00', nIdReceb: '777' },
+      { id: 'virgem', tentativas: 0, t2: '2026-06-15T00:00:00+00:00', nIdReceb: '777' },
+    ].sort(skuItemsCompararFila);
+    const out = skuItemsDedupPorRecebimento(fila);
+    expect(out.map((o) => o.id)).toEqual(['virgem']);
+  });
+
+  it('eleição é DETERMINÍSTICA entre runs quando as irmãs empatam', () => {
+    // Irmãs da mesma NFe têm t2 DIFERENTE em prod (o sync de NFes preserva o t2
+    // pré-existente de cada pedido via `??`), mas quando empatam o id desempata. Sem
+    // ordem total, dois runs elegeriam linhas diferentes e o item sem pedido casado
+    // pousaria ora numa, ora noutra — criando a duplicata que o dedup veio matar.
+    const mesmoT2 = '2026-07-01T00:00:00+00:00';
+    const eleger = (ordemDeChegada: Array<{ id: string; tentativas: number; t2: string; nIdReceb: string }>) =>
+      skuItemsDedupPorRecebimento([...ordemDeChegada].sort(skuItemsCompararFila))[0].id;
+
+    const x = { id: 'bbb', tentativas: 0, t2: mesmoT2, nIdReceb: '42' };
+    const y = { id: 'aaa', tentativas: 0, t2: mesmoT2, nIdReceb: '42' };
+    // a MESMA fila chegando em ordens opostas tem de eleger a MESMA linha
+    expect(eleger([x, y])).toBe('aaa');
+    expect(eleger([y, x])).toBe('aaa');
   });
 });

--- a/src/lib/reposicao/sku-items-fila-helpers.ts
+++ b/src/lib/reposicao/sku-items-fila-helpers.ts
@@ -43,12 +43,55 @@ export function skuItemsElegivel(
  *  O empate é earliest-deadline-first, não "mais recente primeiro": a NFe só é
  *  visível enquanto está dentro da janela de `dias` do run, então a mais antiga é
  *  a de menor folga — se o guard de 50s corta o run, quem fica de fora deve ser
- *  quem volta amanhã (folga grande), não quem expira sem nunca virar leadtime. */
+ *  quem volta amanhã (folga grande), não quem expira sem nunca virar leadtime.
+ *
+ *  O 3º critério (id) NÃO é cosmético: ele dá ordem TOTAL à fila, e a eleição de
+ *  skuItemsDedupPorRecebimento depende disso pra ser determinística entre runs. Sem
+ *  ele, duas linhas irmãs empatadas elegeriam vencedores diferentes a cada execução e
+ *  o item sem pedido casado pousaria ora numa, ora noutra. (t2 NÃO desempata as irmãs:
+ *  linhas que dividem a mesma NFe têm t2 DIFERENTE — o sync de NFes preserva o valor
+ *  pré-existente de cada pedido via `??`. Auditado em prod 2026-07-16.) */
 export function skuItemsCompararFila(
-  a: { tentativas: number; t2: string },
-  b: { tentativas: number; t2: string },
+  a: { tentativas: number; t2: string; id?: string },
+  b: { tentativas: number; t2: string; id?: string },
 ): number {
   if (a.tentativas !== b.tentativas) return a.tentativas - b.tentativas;
-  return a.t2 === b.t2 ? 0 : a.t2 < b.t2 ? -1 : 1;
+  if (a.t2 !== b.t2) return a.t2 < b.t2 ? -1 : 1;
+  const ai = a.id ?? "";
+  const bi = b.id ?? "";
+  return ai === bi ? 0 : ai < bi ? -1 : 1;
+}
+
+/** Elege UMA linha por (empresa, nIdReceb), preservando a ordem da fila.
+ *
+ *  Por que existe: uma NFe que fatura N pedidos deixa N linhas em
+ *  purchase_orders_tracking com a MESMA nfe_chave_acesso — e o backfillRawData do sync
+ *  de NFes grava o MESMO recebimento (logo o MESMO nIdReceb) no raw_data de todas. Sem
+ *  deduplicar, cada uma consulta o MESMO recebimento e regrava os MESMOS itens sob o
+ *  seu próprio tracking_id: peso N× pra mesma nota na estatística de leadtime, e N
+ *  chamadas Omie onde 1 basta (a pressão de rate-limit que causou o poison de 07-14).
+ *
+ *  ⚠️ A eleita NÃO vira dona do dado: cada item é gravado sob o tracking do SEU pedido
+ *  (nNumPedCompra → numero_contrato_fornecedor). A eleita decide só QUEM chama a Omie,
+ *  e serve de pouso pros itens que não casaram com pedido nenhum. Como o recebimento
+ *  traz os itens dos N pedidos, as N linhas ganham suas linhas de leadtime na MESMA
+ *  chamada e saem da fila juntas — por isso deduplicar aqui não cria poison.
+ *
+ *  Linha sem nIdReceb passa direto (é contada como gap de cobertura pelo chamador). */
+export function skuItemsDedupPorRecebimento<T extends { id: string; nIdReceb: string | null }>(
+  fila: readonly T[],
+): T[] {
+  const vistos = new Set<string>();
+  const out: T[] = [];
+  for (const linha of fila) {
+    if (!linha.nIdReceb) {
+      out.push(linha);
+      continue;
+    }
+    if (vistos.has(linha.nIdReceb)) continue;
+    vistos.add(linha.nIdReceb);
+    out.push(linha);
+  }
+  return out;
 }
 // MIRROR-END

--- a/supabase/functions/omie-sync-sku-items/index.ts
+++ b/supabase/functions/omie-sync-sku-items/index.ts
@@ -93,6 +93,9 @@ interface EmpresaSummary {
   empresa: Empresa;
   fila_pendente: number;
   fila_em_backoff: number;
+  /** Linhas tiradas da fila por dividirem o nIdReceb com uma já eleita (NFe que fatura
+   *  N pedidos). = chamadas Omie economizadas E duplicatas de leadtime não criadas. */
+  recebimentos_deduplicados: number;
   nfes_processadas: number;
   nfes_sem_nidreceb: number;
   nfes_sem_nidreceb_dias_max: number;
@@ -145,13 +148,56 @@ function skuItemsElegivel(
  *  O empate é earliest-deadline-first, não "mais recente primeiro": a NFe só é
  *  visível enquanto está dentro da janela de `dias` do run, então a mais antiga é
  *  a de menor folga — se o guard de 50s corta o run, quem fica de fora deve ser
- *  quem volta amanhã (folga grande), não quem expira sem nunca virar leadtime. */
+ *  quem volta amanhã (folga grande), não quem expira sem nunca virar leadtime.
+ *
+ *  O 3º critério (id) NÃO é cosmético: ele dá ordem TOTAL à fila, e a eleição de
+ *  skuItemsDedupPorRecebimento depende disso pra ser determinística entre runs. Sem
+ *  ele, duas linhas irmãs empatadas elegeriam vencedores diferentes a cada execução e
+ *  o item sem pedido casado pousaria ora numa, ora noutra. (t2 NÃO desempata as irmãs:
+ *  linhas que dividem a mesma NFe têm t2 DIFERENTE — o sync de NFes preserva o valor
+ *  pré-existente de cada pedido via `??`. Auditado em prod 2026-07-16.) */
 function skuItemsCompararFila(
-  a: { tentativas: number; t2: string },
-  b: { tentativas: number; t2: string },
+  a: { tentativas: number; t2: string; id?: string },
+  b: { tentativas: number; t2: string; id?: string },
 ): number {
   if (a.tentativas !== b.tentativas) return a.tentativas - b.tentativas;
-  return a.t2 === b.t2 ? 0 : a.t2 < b.t2 ? -1 : 1;
+  if (a.t2 !== b.t2) return a.t2 < b.t2 ? -1 : 1;
+  const ai = a.id ?? "";
+  const bi = b.id ?? "";
+  return ai === bi ? 0 : ai < bi ? -1 : 1;
+}
+
+/** Elege UMA linha por (empresa, nIdReceb), preservando a ordem da fila.
+ *
+ *  Por que existe: uma NFe que fatura N pedidos deixa N linhas em
+ *  purchase_orders_tracking com a MESMA nfe_chave_acesso — e o backfillRawData do sync
+ *  de NFes grava o MESMO recebimento (logo o MESMO nIdReceb) no raw_data de todas. Sem
+ *  deduplicar, cada uma consulta o MESMO recebimento e regrava os MESMOS itens sob o
+ *  seu próprio tracking_id: peso N× pra mesma nota na estatística de leadtime, e N
+ *  chamadas Omie onde 1 basta (a pressão de rate-limit que causou o poison de 07-14).
+ *
+ *  ⚠️ A eleita NÃO vira dona do dado: cada item é gravado sob o tracking do SEU pedido
+ *  (nNumPedCompra → numero_contrato_fornecedor). A eleita decide só QUEM chama a Omie,
+ *  e serve de pouso pros itens que não casaram com pedido nenhum. Como o recebimento
+ *  traz os itens dos N pedidos, as N linhas ganham suas linhas de leadtime na MESMA
+ *  chamada e saem da fila juntas — por isso deduplicar aqui não cria poison.
+ *
+ *  Linha sem nIdReceb passa direto (é contada como gap de cobertura pelo chamador). */
+function skuItemsDedupPorRecebimento<T extends { id: string; nIdReceb: string | null }>(
+  fila: readonly T[],
+): T[] {
+  const vistos = new Set<string>();
+  const out: T[] = [];
+  for (const linha of fila) {
+    if (!linha.nIdReceb) {
+      out.push(linha);
+      continue;
+    }
+    if (vistos.has(linha.nIdReceb)) continue;
+    vistos.add(linha.nIdReceb);
+    out.push(linha);
+  }
+  return out;
 }
 // MIRROR-END
 
@@ -258,6 +304,12 @@ interface NFeRow {
   fornecedor_nome: string | null;
   raw_data: NFeRawData | null;
 }
+
+/** NFeRow com o nIdReceb já extraído do raw_data — a fila dedup-a por ele, e o
+ *  raw_data é jsonb MULTI-WRITER (o sync de pedidos o sobrescreve com o payload do
+ *  pedido e apaga o nIdReceb), então lê-lo UMA vez por run evita depender de um campo
+ *  que pode mudar debaixo do loop. */
+type NFeFilaRow = NFeRow & { nIdReceb: string | null };
 
 async function authorizeCronOrStaff(req: Request): Promise<boolean> {
   const SUPA_URL = Deno.env.get("SUPABASE_URL")!;
@@ -476,19 +528,32 @@ Deno.serve(async (req) => {
 
     const agoraMs = Date.now();
     const pendentes = ((nfes ?? []) as NFeRow[]).filter((n) => !existingTrackingIds.has(n.id));
-    const fila = pendentes
+    const filaOrdenada: NFeFilaRow[] = pendentes
+      .map((n) => ({
+        ...n,
+        nIdReceb: n.raw_data?.cabec?.nIdReceb != null
+          ? String(n.raw_data.cabec.nIdReceb)
+          : null,
+      }))
       .filter((n) => skuItemsElegivel(controleMap.get(n.id), agoraMs))
       .sort((a, b) =>
         skuItemsCompararFila(
-          { tentativas: controleMap.get(a.id)?.tentativas ?? 0, t2: a.t2_data_faturamento },
-          { tentativas: controleMap.get(b.id)?.tentativas ?? 0, t2: b.t2_data_faturamento },
+          { tentativas: controleMap.get(a.id)?.tentativas ?? 0, t2: a.t2_data_faturamento, id: a.id },
+          { tentativas: controleMap.get(b.id)?.tentativas ?? 0, t2: b.t2_data_faturamento, id: b.id },
         )
       );
+    // Uma NFe que fatura N pedidos deixa N linhas com o MESMO nIdReceb (o backfill do
+    // sync de NFes o grava em todas). Sem isto, cada uma consulta o MESMO recebimento e
+    // regrava os MESMOS itens sob o seu tracking_id — peso N× na estatística de leadtime.
+    // A eleita só faz a CHAMADA; o destino de cada item é o pedido dele (ver upsert).
+    const fila = skuItemsDedupPorRecebimento(filaOrdenada);
+    const recebimentosDeduplicados = filaOrdenada.length - fila.length;
 
     const summary: EmpresaSummary = {
       empresa,
       fila_pendente: pendentes.length,
-      fila_em_backoff: pendentes.length - fila.length,
+      fila_em_backoff: pendentes.length - filaOrdenada.length,
+      recebimentos_deduplicados: recebimentosDeduplicados,
       nfes_processadas: 0,
       nfes_sem_nidreceb: 0,
       nfes_sem_nidreceb_dias_max: 0,
@@ -519,7 +584,7 @@ Deno.serve(async (req) => {
       summary.nfes_processadas++;
       const tentativasPrevias = controleMap.get(nfeRaw.id)?.tentativas ?? 0;
 
-      const nIdReceb = nfeRaw.raw_data?.cabec?.nIdReceb;
+      const nIdReceb = nfeRaw.nIdReceb;
       if (!nIdReceb) {
         // Sem nIdReceb não há o que consultar. NÃO marca tentativa (re-checar não custa
         // chamada Omie), mas também NÃO se auto-resolve: a linha com pedido casado quase
@@ -605,8 +670,18 @@ Deno.serve(async (req) => {
         const t3 = nfeRaw.t3_data_cte;
         const t4 = nfeRaw.t4_data_recebimento;
 
+        // O item vai pro tracking do SEU pedido, não pro da linha que estava iterando.
+        // Era ESTE o defeito: gravar sob `nfeRaw.id` fazia cada uma das N linhas da NFe
+        // regravar a NFe inteira. Com o dedup da fila (1 linha por nIdReceb) + este
+        // destino, as N linhas ganham só os SEUS itens, da MESMA chamada Omie.
+        //
+        // ⚠️ Sem pedido casado o item cai na linha eleita (fallback). NÃO é o dono
+        // correto — é um pouso determinístico (a eleição é estável: a fila tem ordem
+        // total, com id de desempate). O destino honesto seria tracking_id=NULL +
+        // match_status, mas a coluna é NOT NULL: o modelo atual não sabe dizer "não sei"
+        // (por isso o receipt-first ledger é a fase seguinte, não este patch).
         const upsertRow = {
-          tracking_id: nfeRaw.id,
+          tracking_id: pedidoMatch?.id ?? nfeRaw.id,
           empresa,
           sku_codigo_omie: skuCodigoOmie,
           sku_codigo: toStr(cab?.cCodigoProduto),


### PR DESCRIPTION
fix(sync): sku_items — 1 chamada Omie por recebimento e item no tracking do SEU pedido [money-path]

Fase 1 de 4: STOP-BLEEDING do writer. NÃO é a correção do modelo — ver "O que
isto NÃO faz".

## O que muda

- skuItemsDedupPorRecebimento (helper novo, espelhado): elege UMA linha por
  nIdReceb. Uma NFe que fatura N pedidos deixa N linhas em
  purchase_orders_tracking com a mesma chave, e o backfillRawData do sync de
  NFes grava o MESMO recebimento (logo o mesmo nIdReceb) no raw_data de todas —
  então a fila tinha N entradas para 1 recebimento. Vira 1: N-1 chamadas Omie
  economizadas por NFe multipedido (alivia a pressão de rate-limit que causou o
  poison de 07-14) e N-1 duplicatas de leadtime não criadas.

- upsert grava sob `pedidoMatch?.id ?? nfeRaw.id`, não mais sob `nfeRaw.id`.
  Era ESTE o defeito: cada uma das N linhas regravava a NFe inteira sob o seu
  próprio tracking_id. O código já sabia a qual pedido o item pertencia
  (nNumPedCompra → numero_contrato_fornecedor) e ignorava. Como o recebimento
  traz os itens dos N pedidos, as N linhas ganham seus itens da MESMA chamada e
  saem da fila juntas — por isso deduplicar não cria poison.

- skuItemsCompararFila ganha `id` como 3º critério: dá ordem TOTAL à fila, sem a
  qual a eleição não é determinística entre runs (duas irmãs empatadas elegeriam
  vencedores diferentes e o item sem pedido pousaria ora numa, ora noutra).

- fila_em_backoff passa a medir contra a fila PRÉ-dedup: senão as linhas tiradas
  pelo dedup seriam contadas como "em backoff" — métrica mentindo.

- results ganha recebimentos_deduplicados (chamadas Omie economizadas = duplicatas
  evitadas; observabilidade do efeito).

## O que isto NÃO faz (deliberado — parecer Codex xhigh)

O Codex derrubou a alegação de que isto torna a escrita CONVERGENTE, e com razão:
- a linha eleita ainda fornece fornecedor_codigo_omie e t2/t3/t4, e linhas que
  dividem a NFe têm t2/t4 DIFERENTES (o sync de NFes preserva o valor
  pré-existente de cada pedido via `??`) — convergência de CHAVE, não de ESTADO;
- pedidoMatch usa .limit(1) sem .order() e há contratos ambíguos; ORDER BY só
  tornaria o erro repetível, não correto — match com 2+ candidatos deveria virar
  `ambiguous`, não "casado";
- item sem pedido casado cai na linha eleita: pouso determinístico, NÃO dono
  correto. O destino honesto seria tracking_id=NULL + match_status, mas a coluna
  é NOT NULL — o modelo atual não sabe dizer "não sei".

Idem a fabricação de zero: `t1 = pedidoMatch?.t1_data_pedido ?? t2` faz
lt_faturamento=0 quando não casa (ausente != zero). Degradar para NULL exige
`ALTER COLUMN t1_data_pedido DROP NOT NULL` + auditoria de consumidores — fora
deste patch.

Tudo isso é a Fase 2 (ledger receipt-first, identidade (empresa,nIdReceb,
nSequencia), vínculo nullable, claim atômico). Esta fase corta o multiplicador N×
e a pressão de rate-limit; não conserta o modelo.

## Prova

- src/lib/reposicao/__tests__/sku-items-fila-helpers.test.ts: 5 casos novos —
  N irmãs viram 1; recebimentos distintos passam; sem-nIdReceb não colapsa entre
  si (esconderia o gap de cobertura); a eleita é a 1ª da ordem (dedup preserva o
  earliest-deadline-first, não o atropela); eleição determinística sob empate (a
  mesma fila em ordens opostas elege a mesma linha — falharia sem o desempate).
- Paridade MIRROR src × edge verde (gate de CI).
- typecheck + 103 testes verdes.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
