### PR TITLE
fix(ci): fixa bun-version em 1.3.14 — tira api.github.com do caminho de entrega

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # ⚠️ bun-version tem que ser semver ESTRITO (x.y.z) — NÃO `latest`, `1.3`,
+      # `^1.3.14` nem `1.3.x` (o exemplo da doc do input!). Só o estrito casa o
+      # `validateStrict()` da action (src/download-url.ts) e pula a chamada a
+      # api.github.com/repos/oven-sh/bun/git/refs/tags; qualquer outro formato cai
+      # nela e reintroduz a dependência de rede no caminho de entrega. Com
+      # `latest` a action também desliga o cache de propósito (isCacheEnabled).
+      # Lição de 2026-07-16: incidente "Degraded REST API Availability" do GitHub
+      # (~35% das chamadas REST falhando) derrubou TODO PR do repo em ~6s no setup
+      # do bun — inclusive PRs de 1 linha de markdown. Bump: conferir `bun --version`
+      # local e alinhar aqui (as duas ocorrências) + no job mutation-check.
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install deps
         run: bun install --frozen-lockfile
@@ -160,10 +170,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # Semver estrito, mesmo motivo do job `validate` acima (manter as duas em sincronia).
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install deps
         run: bun install --frozen-lockfile


### PR DESCRIPTION
Tira o **ponto único de falha externo** do caminho de entrega: hoje todo job do CI faz uma chamada a `api.github.com` no setup do bun, a cada run, para descobrir uma versão que quase nunca muda. Quando a REST API do GitHub tosse, **todo PR do repo trava** — e como o auto-merge espera o verde, nada mergeia até alguém re-rodar à mão.

## O que quebrou (2026-07-16 ~23:20 UTC)

Todo job com `bun-version: latest` falhava em ~6s:

```
Error: Failed to fetch url https://api.github.com/repos/oven-sh/bun/git/refs/tags. (status code: 503)
```

Derrubou `validate` e `mutation-check` do #1351 — um PR de **uma linha de markdown**, zero código. 3 reruns consecutivos.

## Causa raiz

Incidente do GitHub **`Degraded REST API Availability`** (impacto **major**, componente *API Requests*), aberto às **22:51 UTC**. Update oficial das 23:29:

> "approximately 35% of REST API requests to fail. […] requests are not consistently reaching the application layer"

A janela bate com a falha do CI. Os 3 reruns seguidos não são anomalia: a 35% de falha por chamada, com 2 jobs por run, cada run tem ~42% de chance de passar inteiro — 3 falhas seguidas ≈ 20%, perfeitamente esperado.

Duas hipóteses iniciais foram **testadas e refutadas**:

| Hipótese | Refutação |
|---|---|
| É throttling do IP compartilhado do runner Azure | O input `token` da action já tem default `${{ github.token }}` — a chamada **já era autenticada**, fora do limite anônimo por IP |
| O IP do dev não vê o 503 | `gh run list` **deu 503 do IP do dev** durante o incidente. A degradação é global e intermitente, não específica do runner |

Ou seja: a conclusão ("é o endpoint, não o repo") estava certa, mas a causa era um incidente global — não uma característica do runner.

## Por que fixar resolve (provado, não inferido)

Do source da action (`oven-sh/setup-bun@v2`, `src/download-url.ts`):

```ts
if (validateStrict(version)) { tag = `bun-v${version}`; }               // ← pula
if (!tag) { await request("https://api.github.com/.../git/refs/tags") } // ← a API inteira
```

Com semver estrito, `validateStrict()` passa e o bloco da API é **pulado inteiro**. A URL final vira:

`github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip` → 302 → `release-assets.githubusercontent.com` → **200**

Verificado: esse host **não é** `api.github.com`, ou seja, fica fora do componente que está em incidente.

**Bônus:** `isCacheEnabled()` retorna `false` de propósito para `latest` e `true` para versão fixa. Fixar também **liga o cache** do runner — setup mais rápido e menos dependente de rede.

## ⚠️ A armadilha (por isso o comentário no arquivo)

Só semver **estrito `x.y.z`** funciona. Testado empiricamente contra a lib real:

| formato | `validateStrict` | consequência |
|---|---|---|
| `1.3.14` | ✅ true | pula a API |
| `1.3` | ❌ false | **cai na API** |
| `^1.3.14` | ❌ false | **cai na API** |
| `v1.3.14` | ❌ false | **cai na API** |
| `1.3.x` | ❌ false | **cai na API** |

`1.3.x` é justamente o exemplo na doc do input — segui-lo reintroduziria o bug silenciosamente.

E há uma **segunda armadilha independente**: o YAML converte `1.3` em float `1.3`, e `1.30` também vira `1.3` (perde o zero). Duas razões distintas apontam para `x.y.z`.

## Risco: essencialmente zero

`bun --version` local = **1.3.14**. `latest` do bun = **bun-v1.3.14**. **É a mesma versão que o CI já resolve hoje** — o que roda não muda; só some a chamada de rede que descobre isso.

## Validação

Suíte completa rodada local com bun 1.3.14 (a mesma versão fixada): typecheck · test · build · lint · `claude:size` · `authz:check` · `mutcheck:selftest` · `mutcheck`.

> **Nota sobre o CI deste PR:** enquanto o incidente estiver ativo, verde/vermelho aqui é ruído — outros steps (`actions/github-script@v7`, o próprio auto-merge) também usam a REST API. A prova do fix é o code-reading + a resolução da URL acima, não o check. O auto-merge apenas espera o verde; normalizando o GitHub, mergeia sozinho.

## Trade-off aceito

Bump manual periódico (conferir `bun --version` e alinhar as **duas** ocorrências). Automatizar via Renovate/Dependabot fica como follow-up — deliberadamente fora deste PR para manter o diff mínimo em infra compartilhada.

## Coordenação

Nenhum PR aberto toca `.github/workflows/ci.yml`; branch em sincronia exata com `origin/main`. Escopo: 2 linhas + comentário.

---

Destrava o #1351 (que só precisa de `gh run rerun` quando o incidente normalizar — o conteúdo dele não tem problema algum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
