### PR TITLE
feat(carteira): Fatia 2 P0-B-bis — popular E consumir identity_state (ativa o quarantine) [money-path]

### DIFF
--- a/docs/superpowers/specs/2026-07-16-fatia2-identity-state-quarantine-design.md
+++ b/docs/superpowers/specs/2026-07-16-fatia2-identity-state-quarantine-design.md
@@ -1,0 +1,173 @@
+# Fatia 2 (P0-B-bis) — popular E consumir `identity_state`: o quarantine de identidade ambígua — design
+
+> money-path (comissão de vendedor + visibilidade de carteira). Fatia 2 do épico-drop do espelho `omie_clientes`
+> (spec macro: [2026-07-12-carteira-membership-ledger-drop-espelho-design.md](2026-07-12-carteira-membership-ledger-drop-espelho-design.md), opção **D**).
+> Estado verificado por psql-ro (prod) + leitura direta do código em 2026-07-16. **Zero DDL** — a fatia é 2 edges.
+
+## 1. Ponto de partida (verificado, não presumido)
+
+| fato | evidência (2026-07-16) |
+|---|---|
+| Fatias 0/1/3 mergeadas | `865fa7f3` (#1321), `e065cf86` (#1329), `60ba92ba` (#1331), `3f5b4729` (#1333) |
+| ledger populado, quarantine INERTE | psql-ro: **6909 membros / 6909 `verified` / 0 outros** |
+| schema pronto p/ a fatia | `identity_state` NOT NULL DEFAULT `'verified'`, CHECK `('verified','ambiguous','inactive','conflict')`, índice `idx_cml_identity_state`, RLS staff+own |
+| docs ambíguos HOJE | **0** (psql-ro, lado `profiles`) → a fatia é **preventiva** |
+| órfãos Hunter visíveis | **2069** (`carteira_assignments` source=`hunter_orphan` AND eligible) |
+
+### 1.1 O rebuild NÃO consome `identity_state` (o briefing de sessão errou)
+
+Grep de `quarantin` em todo o repo retorna **um único hit**: o comentário
+[carteira-rebuild:281](../../../supabase/functions/carteira-rebuild/index.ts) — *"Sem filtro de identity_state
+(quarantine é da Fatia 2)"*. Não há implementação.
+
+Não é deslize: a **Fatia 1 adiou deliberadamente**, e registrou em
+[§2 do seu design](2026-07-13-fatia1-carteira-rebuild-le-ledger-design.md) — *"Decisão de escopo — quarantine fica
+para a Fatia 2 (diverge da spec macro §5-Fatia1)"*, com a justificativa de que consumir `identity_state` com 100%
+dos membros em `verified` seria dead code não-testável, e de que **"a Fatia 2 popula E consome juntas"**.
+
+**Consequência:** a Fatia 2 tem **duas pontas**. Só marcar (escritor) entregaria uma fatia decorativa — o
+`ambiguous` gravado, ninguém lendo, o quarantine seguindo inerte, com aparência de entrega feita.
+
+## 2. O furo money-path que esta fatia fecha
+
+Hoje, quando um doc vira ambíguo (2+ códigos Omie distintos p/ o mesmo doc na mesma conta):
+
+1. o sync **deleta** o vínculo da proof ([analytics-sync:464](../../../supabase/functions/omie-analytics-sync/index.ts), `source='document'`);
+2. o rebuild lê o membro do ledger (nunca some ✅) mas **não** acha vendedor na proof → `montarClientes` → `omie_codigo_vendedor: null`;
+3. `computeCarteira` cai no ramo órfão ([rebuild-helpers:150-155](../../../src/lib/carteira/rebuild-helpers.ts)) → emite `source='hunter_orphan'`, **`eligible: true`**.
+
+**Resultado:** um cliente cuja identidade nós admitimos não saber entra visível na carteira do Hunter e **gera
+comissão**. E "sem vendedor" (legítimo) é hoje indistinguível de "identidade ambígua" — os 2069 órfãos são um
+balde só.
+
+Alvo (spec macro §3.3/§6): **quarantined** — vendedor sem efeito, `eligible=false`, **membro preservado**, zero comissão.
+
+## 3. Decisões desta fatia
+
+| # | decisão | porquê |
+|---|---|---|
+| D1 | **Popular só `ambiguous`** | único estado com gatilho REAL. `inactive`/`conflict` do `mapaConsolidacao` ficam fora — ver §3.1. Aditivo: o CHECK já aceita os 4. |
+| D2 | **Consumir `identity_state !== 'verified'`** (não `=== 'ambiguous'`) | **fail-closed**: estado desconhecido/futuro/NULL → quarantine. Se alguém popular `inactive` amanhã, a rede já está armada em vez de falhar aberto. |
+| D3 | **Quarantined = `hunter_orphan` + `eligible=false`** | `carteira_assignments.owner_user_id` é **NOT NULL** e o CHECK de `source` só aceita `('omie','hunter_orphan')` → `source='quarantined'` exigiria DDL em tabela quente + auditar todos os leitores. `eligible=false` já entrega o efeito money-path (índice `idx_carteira_owner_eligible`). **Zero DDL.** |
+| D4 | **Reversão `ambiguous→verified` escopada ao que o run PROVOU limpo** | sem ela é catraca de mão única: doc corrigido no Omie deixaria o cliente invisível e sem comissão **para sempre**, e ninguém saberia que precisa de um UPDATE manual. |
+| D5 | **Só o run da conta `vendas`/oben escreve no ledger** | `identity_state` é coluna **global** (1 row/user) mas a ambiguidade é detectada **por conta** → 3 runs escrevendo = um marca, outro desmarca (**flapping**). A carteira é oben-only (rebuild lê proof `account='oben'`), e o código já segue essa regra: só `'vendas'` escreve o espelho ([:488](../../../supabase/functions/omie-analytics-sync/index.ts)) e as tags. |
+
+### 3.1 Por que `inactive`/`conflict` do `mapaConsolidacao` ficam fora
+
+A spec macro §3 diz *"`mapaConsolidacao` alias `inactive`/`conflict` → reflete no ledger do clone"*. Isso **não
+sobrevive ao código real**:
+
+- `mapaConsolidacao` grava **todos** os aliases com `status:"inactive"` hard-coded
+  ([:1887](../../../supabase/functions/omie-analytics-sync/index.ts)); o handler ([:2140](../../../supabase/functions/omie-analytics-sync/index.ts))
+  descreve o estado como *"INERTE até o canário"*. Ou seja **`inactive` = proposta não-ativada, não revogação**.
+  Prod: 1633 aliases, **todos `active`** (ativados depois, manualmente).
+- Um clone canonicalizado tem identidade **perfeitamente conhecida** — ele *é* o gêmeo. Marcá-lo não-`verified`
+  conflaria "mapeamento proposto" com "identidade problemática".
+- Seria um **2º writer** para um efeito que o `aliasMap` já produz (clone → `eligible=false`, [rebuild-helpers:157](../../../src/lib/carteira/rebuild-helpers.ts)).
+  O CLAUDE.md proíbe sinal money-path multi-writer.
+- `'conflict'`: **nenhum caminho** do `mapaConsolidacao` o emite (o tipo em [:1781](../../../supabase/functions/omie-analytics-sync/index.ts)
+  permite; o código sempre grava `inactive`). O `conflict` do `computeCarteira` é outro conceito (código→2 vendedores),
+  calculado no rebuild. Popular seria dead code.
+
+D2 (fail-closed) preserva a opção: se um gatilho real de `inactive` aparecer, basta popular — o consumo já quarantina.
+
+## 4. Arquitetura
+
+### 4.1 Escritor — `omie-analytics-sync` (2 escritas, espelhando as da proof)
+
+Cada escrita no ledger acompanha a escrita correspondente na proof, no mesmo bloco:
+
+| onde | hoje | + Fatia 2 |
+|---|---|---|
+| [:464](../../../supabase/functions/omie-analytics-sync/index.ts) | DELETE dos ambíguos da proof | `UPDATE ledger SET identity_state='ambiguous'` p/ `usersAmbiguosOmie` |
+| [:501](../../../supabase/functions/omie-analytics-sync/index.ts) | UPSERT dos vínculos limpos na proof | `UPDATE ledger SET identity_state='verified'` p/ `accountMapByUser.keys()`, filtrado por `.eq('identity_state','ambiguous')` |
+
+- **Conjuntos disjuntos de graça:** [:447](../../../supabase/functions/omie-analytics-sync/index.ts) já faz
+  `accountMapByUser.delete(uid)` para todo ambíguo → quem entra na reversão nunca é quem entra na marcação.
+- **Ordem fail-closed:** marca ambíguo **antes** de reverter. Se a marcação falhar → `throw` → run falha, nada muda.
+  Se a reversão falhar → sobra gente quarantinada a mais (conservador: esconde em vez de pagar comissão errada),
+  corrigida no próximo run.
+- **`UPDATE` nunca insere:** `.in('user_id', …)` sobre linhas existentes. Membro fora do ledger não é criado aqui
+  (isso é do trigger da Fatia 0) — o ledger continua acumulador.
+- **`.eq('identity_state','ambiguous')` na reversão:** evita reescrever ~5238 linhas por run (write amplification)
+  e impede que a reversão toque estados que esta fatia não populou.
+- **Run parcial é fail-safe:** vê menos registros → detecta menos ambíguos → marca menos; e reverte só o que provou
+  limpo. Mesma propriedade do DELETE cirúrgico já existente.
+
+### 4.2 Leitor — `carteira-rebuild`
+
+- [:291](../../../supabase/functions/carteira-rebuild/index.ts): `.select('user_id')` → `.select('user_id, identity_state')`;
+  monta `quarantinados: Set<string>` via `extrairQuarantinados` (helper puro, D2).
+- [:380](../../../supabase/functions/carteira-rebuild/index.ts): a máscara de elegibilidade passa a incluir o
+  quarantine, reusando o padrão que os `flaggeds` já usam.
+
+**O que NÃO fazer (o erro catastrófico):** filtrar o quarantinado da LISTA. O membro sumiria da entrada → o
+upsert-only ([:403](../../../supabase/functions/carteira-rebuild/index.ts), `onConflict: 'customer_user_id'`, sem
+DELETE) não geraria row → **o assignment antigo persistiria STALE** (vendedor errado, válido, cobrando comissão).
+Esse é exatamente o mecanismo pelo qual o Codex refutou a opção A′. O membro permanece na lista; **só o `eligible` cai**.
+
+Na prática o ambíguo já perde o vendedor sozinho (deletado da proof → `montarClientes` → `null` → órfão), então a
+fatia só precisa **derrubar o `eligible`**: a diferença entre "vai pro Hunter e gera comissão" e "preservado,
+invisível, zero comissão".
+
+### 4.3 Helpers puros (`src/lib/carteira/rebuild-helpers.ts`, dentro do bloco MIRROR)
+
+```ts
+extrairQuarantinados(rows: Array<{ user_id: string; identity_state: string | null }>): Set<string>
+// D2 fail-closed: TUDO que não for exatamente 'verified' entra (inclui null/undefined/estado futuro).
+
+aplicarMascaras(assignments, flaggeds, quarantinados): ComputedAssignment[]
+// eligible := a.eligible && !flaggeds.has(id) && !quarantinados.has(id). Extrai a regra do edge p/ ser testável.
+```
+
+Ambos espelhados **verbatim** no edge (Deno não importa de `src/`) — paridade guardada pela canária textual.
+
+## 5. Invariantes
+
+1. Membro **nunca** sai do ledger nem da lista do rebuild. Quarantine muda `eligible`, **nunca** a presença.
+2. Todo membro do ledger → **uma** row em `carteira_assignments` (reconciliação; nada fica stale).
+3. Quarantinado → `eligible=false` → zero comissão e invisível (todos os leitores usam `WHERE eligible`).
+4. Consumo é fail-closed (`!== 'verified'`); população é conservadora (só `ambiguous`, só conta oben).
+5. Aditivo: com 0 ambíguos (o caso de hoje), o rebuild produz **exatamente** o resultado atual.
+6. O `owner_user_id` do quarantinado permanece na row (NOT NULL), inerte — o quarantine é **máscara reversível**,
+   não destruição de dado. Volta a `verified` → volta a valer.
+
+## 6. Testing
+
+**`prove-sql-money-path` (PG17) NÃO se aplica** — e isso é um desvio consciente do briefing de sessão, que o exigia
+presumindo DDL. D3 eliminou toda a SQL nova: sem migration, o PG17 provaria só que um `UPDATE` não apaga a linha e
+que o CHECK aceita `ambiguous` (já provado na Fatia 0). A própria skill exclui *"edge function sem SQL novo"*.
+O risco desta fatia é **lógica TypeScript** — o teste que pega a saída errada é vitest.
+
+| teste | pega |
+|---|---|
+| `extrairQuarantinados` +/− | `verified`→fora; `ambiguous`→dentro; `null`/estado futuro→dentro (D2) |
+| `aplicarMascaras` +/− | quarantinado tem row com `eligible=false` (**não some**); `verified` intocado; flagged+quarantine compõem |
+| composição `computeCarteira`+máscara | o **erro catastrófico**: membro quarantinado sumir da saída |
+| **falsificação** | sabotar a máscara (`&& !quarantinados.has(...)` removido) → a suíte **tem** que ficar vermelha |
+| canária textual | `select` inclui `identity_state`; edge aplica a máscara; paridade do MIRROR |
+| `heavy bun run test` | suíte completa (não só os alvos) |
+
+A canária atual ([edge-money-path-invariants:805](../../../src/__tests__/edge-money-path-invariants.test.ts)) casa
+`select('user_id')` **exato** → vai quebrar de propósito e precisa ser atualizada. É o teste fazendo seu trabalho.
+
+**Pós-deploy (psql-ro):** distribuição de `identity_state` (esperado: 6909 `verified`, 0 `ambiguous` — hoje não há
+doc ambíguo) e `carteira_assignments` sem perda de membro (`count == 6909`).
+
+## 7. Deploy
+
+**💬 2 edges pelo chat do Lovable, verbatim** (`omie-analytics-sync`, `carteira-rebuild`). **Sem 🟣 SQL Editor**
+(zero DDL) e **sem Publish** (nenhuma mudança de frontend — `rebuild-helpers.ts` é lib compartilhada consumida pelo
+espelhamento no edge, não por página).
+
+## 8. Resíduos conhecidos
+
+- **Override manual + doc ambíguo:** o DELETE da proof preserva `source='manual'` ([:471](../../../supabase/functions/omie-analytics-sync/index.ts)),
+  então um user com override humano pode ficar `ambiguous` **com** vendedor na proof → o quarantine derruba o
+  `eligible` mesmo assim (fail-closed vence). Reversível: doc corrigido → `verified` → override volta a valer.
+- **`orphanCount`** conta o quarantinado como órfão visível (a máscara é aplicada depois do `computeCarteira`).
+  É métrica de observabilidade, não money-path; mesmo comportamento dos `flaggeds` hoje.
+- **`avaliarGuardResultado`** vira rede de segurança de graça: quarantine em massa (bug) derruba `omieElegivelNovo`
+  → `< 80%` do baseline → rebuild **aborta** sem gravar. Com 0 ambíguos hoje, inerte.
+- **`computeCarteira` não emite membro com conflito de mapeamento** ([rebuild-helpers:115](../../../src/lib/carteira/rebuild-helpers.ts))
+  → mesmo padrão stale do A′, pré-existente e fora do escopo desta fatia. Candidato a fatia própria.

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -798,11 +798,39 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
     ).toMatch(/from\(['"]omie_customer_account_map_fresco['"]\)[\s\S]{0,220}\.eq\(['"]account['"],\s*['"]oben['"]\)/);
   });
 
-  it('A LISTA de membros vem do carteira_membership_ledger (Fatia 1 — não mais do espelho)', () => {
+  it('A LISTA de membros vem do carteira_membership_ledger, COM identity_state (Fatia 1 + 2)', () => {
     expect(
       rebuild,
       'REVERSÃO Lovable? a LISTA de membros não vem mais do ledger — voltou ao espelho omie_clientes?',
-    ).toMatch(/from\(['"]carteira_membership_ledger['"]\)[\s\S]{0,80}select\(['"]user_id['"]\)/);
+    ).toMatch(/from\(['"]carteira_membership_ledger['"]\)[\s\S]{0,80}select\(['"]user_id,\s*identity_state['"]\)/);
+  });
+
+  // ── P0-B-bis Fatia 2 (quarantine). O erro CATASTRÓFICO seria filtrar o quarantinado no BANCO: o membro
+  // sumiria da entrada e o upsert-only (sem DELETE) preservaria o assignment antigo STALE — vendedor errado,
+  // válido, cobrando comissão. É o mecanismo exato pelo qual o Codex refutou a opção A′ deste épico.
+  it('o rebuild NÃO filtra identity_state no banco — o membro quarantinado TEM que vir na lista', () => {
+    const selectLedger = /from\(['"]carteira_membership_ledger['"]\)[\s\S]{0,200}?\.range\(/;
+    const bloco = rebuild.match(selectLedger)?.[0] ?? '';
+    expect(bloco, 'sentinela: não achei o bloco de leitura do ledger').toContain('carteira_membership_ledger');
+    expect(
+      bloco,
+      'REGRESSÃO GRAVE: o rebuild passou a filtrar identity_state no banco → o membro quarantinado SOME da entrada → o upsert-only deixa o assignment antigo STALE (vendedor errado cobrando comissão). Filtre em memória (extrairQuarantinados), nunca na query.',
+    ).not.toMatch(/\.(eq|neq|in|not|filter)\(\s*['"]identity_state['"]/);
+  });
+
+  it('o quarantine é aplicado às rows finais (máscara ligada — não é dead code)', () => {
+    expect(rebuild, 'sumiu a extração dos quarantinados do ledger').toContain('extrairQuarantinados(ledgerRows)');
+    expect(
+      rebuild,
+      'REVERSÃO: as rows finais não passam mais por aplicarMascaras(flaggeds, quarantinados) → quarantine inerte, ambíguo volta a gerar comissão',
+    ).toMatch(/aplicarMascaras\(assignments,\s*flaggeds,\s*quarantinados\)/);
+  });
+
+  it('o consumo de identity_state é FAIL-CLOSED (!== verified), não === ambiguous', () => {
+    expect(
+      rebuildHelper,
+      'FAIL-OPEN: extrairQuarantinados passou a testar um estado específico — estado futuro/NULL deixaria de quarantinar',
+    ).toMatch(/identity_state\s*!==\s*['"]verified['"]/);
   });
 
   it('anti-reversão: o carteira-rebuild NÃO lê mais omie_clientes em lugar nenhum (nem lista, nem vendedor)', () => {
@@ -844,6 +872,50 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
       mirrorBlockNamed(rebuild, 'carteira-load'),
       'edge divergiu de rebuild-helpers.ts — Lovable reescreveu o load/guard?',
     ).toBe(mirrorBlockNamed(rebuildHelper, 'carteira-load'));
+  });
+});
+
+// ── P0-B-bis Fatia 2 — ESCRITOR do identity_state (omie-analytics-sync). Par do DELETE da proof: o vínculo
+// sai da proof, mas o MEMBRO fica no ledger marcado `ambiguous` → o rebuild o quarantina. Sem a marcação o
+// ambíguo perde o vendedor, vira órfão e cai no Hunter com eligible=TRUE (comissão sobre identidade que não
+// conhecemos). Sem a REVERSÃO vira catraca de mão única (doc corrigido → cliente invisível para sempre).
+describe('guardrail money-path: omie-analytics-sync popula identity_state no ledger (P0-B-bis Fatia 2)', () => {
+  const src = read(ANALYTICS);
+
+  it('sentinela: leu o arquivo real', () => {
+    expect(src).toContain('docsComCodigoAmbiguoNoOmie');
+  });
+
+  it('marca `ambiguous` no ledger — o par do DELETE da proof', () => {
+    expect(
+      src,
+      'REVERSÃO: sumiu a marcação de ambiguous no ledger → o doc ambíguo volta a cair no Hunter ELEGÍVEL (comissão indevida)',
+    ).toMatch(/from\(["']carteira_membership_ledger["']\)[\s\S]{0,160}identity_state:\s*["']ambiguous["']/);
+  });
+
+  it('reverte `ambiguous`→`verified` p/ quem o run PROVOU limpo (senão: catraca de mão única)', () => {
+    expect(
+      src,
+      'REGRESSÃO: sumiu a reversão → doc corrigido no Omie deixaria o cliente quarantinado (invisível, sem comissão) PARA SEMPRE',
+    ).toMatch(/identity_state:\s*["']verified["']/);
+    expect(
+      src,
+      'a reversão não está escopada ao que o run provou limpo (accountMapByUser) → risco de reverter ambíguo real',
+    ).toMatch(/accountMapByUser\.has\(/);
+  });
+
+  it('SÓ o run oben (account===vendas) escreve o ledger — identity_state é global, ambiguidade é por conta', () => {
+    // D5: os 3 runs escrevendo se sobrescreveriam (flapping — um marca, o outro desmarca).
+    const marcacao = src.match(/if \(account === "vendas" && usersAmbiguosOmie\.size > 0\)/);
+    expect(marcacao, 'a marcação de ambiguous não está gateada em account==="vendas" → flapping entre contas').not.toBeNull();
+  });
+
+  it('o ledger NUNCA recebe INSERT/upsert aqui — quem popula é o trigger da Fatia 0 (acumulador)', () => {
+    const blocos = src.match(/from\(["']carteira_membership_ledger["']\)\s*\.\w+/g) ?? [];
+    expect(blocos.length, 'sentinela: não achei acesso ao ledger no sync').toBeGreaterThan(0);
+    for (const b of blocos) {
+      expect(b, `o sync está escrevendo no ledger com algo que não é update/select ("${b}") — o ledger é acumulador; inserir aqui fura o trigger da Fatia 0`).toMatch(/\.(update|select)$/);
+    }
   });
 });
 

--- a/src/lib/carteira/__tests__/rebuild-helpers.test.ts
+++ b/src/lib/carteira/__tests__/rebuild-helpers.test.ts
@@ -1,6 +1,6 @@
 // src/lib/carteira/__tests__/rebuild-helpers.test.ts
 import { describe, it, expect } from 'vitest';
-import { computeCarteira, coerceCodigoVendedor, montarClientes, avaliarGuardProof, avaliarGuardResultado, parseBaselineSaudavel } from '../rebuild-helpers';
+import { computeCarteira, coerceCodigoVendedor, montarClientes, avaliarGuardProof, avaliarGuardResultado, parseBaselineSaudavel, extrairQuarantinados, aplicarMascaras } from '../rebuild-helpers';
 
 const HUNTER = 'hunter-uid';
 
@@ -347,5 +347,147 @@ describe('herança B-lite via proof (integração — P1 #1): clone AUSENTE da p
       customer_user_id: 'clone', owner_user_id: HUNTER, source: 'hunter_orphan', omie_codigo_vendedor: null, eligible: false,
     });
     expect(r.orphanCount).toBe(0); // o gêmeo não é órfão; o clone escondido não infla a métrica
+  });
+});
+
+// ── P0-B-bis Fatia 2 — quarantine de identidade ambígua.
+// Hoje um doc ambíguo é deletado da proof pelo sync → o rebuild vê vendedor null → o cliente cai no Hunter
+// com eligible=TRUE → comissão sobre um cliente cuja identidade NÃO sabemos. O quarantine derruba o eligible
+// preservando o membro. O que NÃO se pode fazer é tirá-lo da LISTA: o upsert-only não reconcilia ausentes
+// (onConflict customer_user_id, sem DELETE) → o assignment antigo persistiria STALE (vendedor errado, válido).
+describe('extrairQuarantinados (Fatia 2 — consumo FAIL-CLOSED de identity_state)', () => {
+  it('verified → NÃO quarantina (o caso de 100% da produção hoje: 6909/6909)', () => {
+    expect(extrairQuarantinados([{ user_id: 'u1', identity_state: 'verified' }])).toEqual(new Set());
+  });
+
+  it('ambiguous → quarantina (o único estado que a Fatia 2 popula)', () => {
+    expect(extrairQuarantinados([{ user_id: 'u1', identity_state: 'ambiguous' }])).toEqual(new Set(['u1']));
+  });
+
+  it('FAIL-CLOSED: estados que a Fatia 2 não popula (inactive/conflict) já quarantinam', () => {
+    // D2: consumimos `!== verified`, não `=== ambiguous`. Se um gatilho real de inactive/conflict aparecer,
+    // a rede já está armada — em vez de falhar ABERTO (cliente de identidade dúbia pagando comissão).
+    const r = extrairQuarantinados([
+      { user_id: 'a', identity_state: 'inactive' },
+      { user_id: 'b', identity_state: 'conflict' },
+    ]);
+    expect(r).toEqual(new Set(['a', 'b']));
+  });
+
+  it('FAIL-CLOSED: null/undefined/estado desconhecido quarantinam (nunca vira verified por omissão)', () => {
+    const r = extrairQuarantinados([
+      { user_id: 'a', identity_state: null },
+      { user_id: 'b', identity_state: undefined as unknown as string },
+      { user_id: 'c', identity_state: 'estado_futuro_qualquer' },
+      { user_id: 'd', identity_state: 'Verified' }, // case-sensitive de propósito: só o literal exato passa
+      { user_id: 'e', identity_state: ' verified' }, // idem — espaço não é verified
+    ]);
+    expect(r).toEqual(new Set(['a', 'b', 'c', 'd', 'e']));
+  });
+
+  it('lista mista → só os não-verified entram', () => {
+    const r = extrairQuarantinados([
+      { user_id: 'ok1', identity_state: 'verified' },
+      { user_id: 'amb', identity_state: 'ambiguous' },
+      { user_id: 'ok2', identity_state: 'verified' },
+    ]);
+    expect(r).toEqual(new Set(['amb']));
+  });
+
+  it('lista vazia → set vazio (ledger vazio degrada p/ comportamento de hoje, aditivo)', () => {
+    expect(extrairQuarantinados([])).toEqual(new Set());
+  });
+});
+
+describe('aplicarMascaras (Fatia 2 — quarantine + flaggeds derrubam eligible, NUNCA a presença)', () => {
+  const base = [
+    { customer_user_id: 'c1', owner_user_id: 'regina', source: 'omie' as const, omie_codigo_vendedor: 10, eligible: true },
+    { customer_user_id: 'c2', owner_user_id: HUNTER, source: 'hunter_orphan' as const, omie_codigo_vendedor: null, eligible: true },
+  ];
+
+  it('sem máscara nenhuma → passa idêntico (aditivo: 0 ambíguos = comportamento de hoje)', () => {
+    expect(aplicarMascaras(base, new Set(), new Set())).toEqual(base);
+  });
+
+  it('O INVARIANTE: quarantinado PERMANECE na saída, só com eligible=false', () => {
+    const r = aplicarMascaras(base, new Set(), new Set(['c1']));
+    // Presença preservada — se sumisse, o upsert-only deixaria o assignment antigo STALE (o furo do A′).
+    expect(r).toHaveLength(2);
+    expect(r.find((a) => a.customer_user_id === 'c1')).toEqual({
+      customer_user_id: 'c1', owner_user_id: 'regina', source: 'omie', omie_codigo_vendedor: 10, eligible: false,
+    });
+    // e o não-quarantinado fica intocado
+    expect(r.find((a) => a.customer_user_id === 'c2')?.eligible).toBe(true);
+  });
+
+  it('flagged (fornecedor fora da carteira) continua derrubando eligible — regressão do padrão existente', () => {
+    const r = aplicarMascaras(base, new Set(['c2']), new Set());
+    expect(r.find((a) => a.customer_user_id === 'c2')?.eligible).toBe(false);
+    expect(r.find((a) => a.customer_user_id === 'c1')?.eligible).toBe(true);
+  });
+
+  it('flagged E quarantinado compõem (nenhum "ressuscita" o outro)', () => {
+    const r = aplicarMascaras(base, new Set(['c1']), new Set(['c1']));
+    expect(r.find((a) => a.customer_user_id === 'c1')?.eligible).toBe(false);
+  });
+
+  it('eligible=false de origem (clone B-lite) NUNCA é promovido a true pela máscara', () => {
+    const clone = [{ customer_user_id: 'clone', owner_user_id: HUNTER, source: 'hunter_orphan' as const, omie_codigo_vendedor: null, eligible: false }];
+    expect(aplicarMascaras(clone, new Set(), new Set())[0].eligible).toBe(false);
+  });
+
+  it('não muta a entrada (o caller reusa assignments p/ métricas)', () => {
+    const entrada = structuredClone(base);
+    aplicarMascaras(entrada, new Set(['c1']), new Set(['c1']));
+    expect(entrada).toEqual(base);
+  });
+});
+
+describe('quarantine (integração Fatia 2): doc ambíguo → membro vivo, invisível, ZERO comissão', () => {
+  it('o ambíguo (deletado da proof pelo sync) fica no ledger, tem row e NÃO gera comissão', () => {
+    // Cenário de produção: `amb` teve o doc ambíguo → o sync o deletou da proof e marcou o ledger.
+    // `ok` é saudável. AMBOS continuam na LISTA do ledger (acumulador — nunca encolhe).
+    const membroIds = ['amb', 'ok'];
+    const proofOben = new Map<string, number | null>([['ok', 10]]); // `amb` foi deletado da proof
+    const ledger = [
+      { user_id: 'amb', identity_state: 'ambiguous' },
+      { user_id: 'ok', identity_state: 'verified' },
+    ];
+
+    const clientes = montarClientes(membroIds, proofOben);
+    const { assignments } = computeCarteira(clientes, [{ omie_codigo_vendedor: 10, user_id: 'regina' }], HUNTER);
+    const rows = aplicarMascaras(assignments, new Set(), extrairQuarantinados(ledger));
+
+    const amb = rows.find((a) => a.customer_user_id === 'amb');
+    // 1. o membro NÃO some (senão: assignment antigo STALE = vendedor errado cobrando comissão)
+    expect(amb).toBeDefined();
+    // 2. zero comissão + invisível: todos os leitores filtram por `WHERE eligible`
+    expect(amb?.eligible).toBe(false);
+    // 3. sem vendedor (já perdido na proof) — o Hunter recebe a row morta, mas ela é inerte
+    expect(amb?.omie_codigo_vendedor).toBeNull();
+
+    // 4. o saudável segue intocado com seu vendedor
+    expect(rows.find((a) => a.customer_user_id === 'ok')).toEqual({
+      customer_user_id: 'ok', owner_user_id: 'regina', source: 'omie', omie_codigo_vendedor: 10, eligible: true,
+    });
+  });
+
+  it('CONTRASTE (o que a Fatia 2 conserta): sem o quarantine, o ambíguo iria pro Hunter ELEGÍVEL', () => {
+    // Este é o comportamento de HOJE — o teste existe p/ deixar o delta explícito e pegar uma reversão.
+    const clientes = montarClientes(['amb'], new Map());
+    const { assignments } = computeCarteira(clientes, [{ omie_codigo_vendedor: 10, user_id: 'regina' }], HUNTER);
+    expect(assignments[0]).toEqual({
+      customer_user_id: 'amb', owner_user_id: HUNTER, source: 'hunter_orphan', omie_codigo_vendedor: null, eligible: true,
+    });
+    // com o ledger marcando `ambiguous`, o MESMO input vira eligible=false:
+    const rows = aplicarMascaras(assignments, new Set(), extrairQuarantinados([{ user_id: 'amb', identity_state: 'ambiguous' }]));
+    expect(rows[0].eligible).toBe(false);
+  });
+
+  it('ledger 100% verified (a produção de hoje) → saída IDÊNTICA à sem quarantine (aditivo/fail-safe)', () => {
+    const clientes = montarClientes(['a', 'b'], new Map<string, number | null>([['a', 10], ['b', 10]]));
+    const { assignments } = computeCarteira(clientes, [{ omie_codigo_vendedor: 10, user_id: 'regina' }], HUNTER);
+    const ledger = [{ user_id: 'a', identity_state: 'verified' }, { user_id: 'b', identity_state: 'verified' }];
+    expect(aplicarMascaras(assignments, new Set(), extrairQuarantinados(ledger))).toEqual(assignments);
   });
 });

--- a/src/lib/carteira/rebuild-helpers.ts
+++ b/src/lib/carteira/rebuild-helpers.ts
@@ -195,6 +195,29 @@ export function montarClientes(espelhoIds: string[], proofOben: Map<string, numb
     omie_codigo_vendedor: proofOben.get(customer_user_id) ?? null,
   }));
 }
+export function extrairQuarantinados(rows: Array<{ user_id: string; identity_state: string | null }>): Set<string> {
+  // FAIL-CLOSED (Fatia 2 D2): quarantina tudo que não for EXATAMENTE 'verified' — inclui null, estado
+  // futuro e qualquer valor que o CHECK venha a aceitar. A Fatia 2 só POPULA 'ambiguous', mas testar
+  // `=== 'ambiguous'` falharia ABERTO (cliente de identidade dúbia pagando comissão) no dia em que outro
+  // estado ganhasse gatilho. Ledger vazio → set vazio → rebuild degrada p/ o comportamento de hoje.
+  const quarantinados = new Set<string>();
+  for (const r of rows) if (r.identity_state !== 'verified') quarantinados.add(r.user_id);
+  return quarantinados;
+}
+export function aplicarMascaras(
+  assignments: ComputedAssignment[],
+  flaggeds: Set<string>,
+  quarantinados: Set<string>,
+): ComputedAssignment[] {
+  // As 2 máscaras derrubam ELEGIBILIDADE, nunca PRESENÇA. Tirar o membro da saída faria o upsert-only
+  // (onConflict customer_user_id, sem DELETE) preservar o assignment ANTIGO — vendedor errado, válido,
+  // cobrando comissão (o furo que refutou o A′). eligible=false já entrega zero comissão + invisível
+  // (todo leitor filtra `WHERE eligible`), e é REVERSÍVEL: volta a 'verified' → volta a valer.
+  return assignments.map((a) => ({
+    ...a,
+    eligible: a.eligible && !flaggeds.has(a.customer_user_id) && !quarantinados.has(a.customer_user_id),
+  }));
+}
 export function avaliarGuardProof(m: { proofCrua: number; proofFresca: number; comVendedor: number }): { abortar: boolean; motivo: string | null } {
   if (m.proofFresca === 0) {
     return { abortar: true, motivo: 'proof oben fresca vazia (sync parado / TTL 7d expirado)' };

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -146,6 +146,29 @@ function montarClientes(espelhoIds: string[], proofOben: Map<string, number | nu
     omie_codigo_vendedor: proofOben.get(customer_user_id) ?? null,
   }));
 }
+function extrairQuarantinados(rows: Array<{ user_id: string; identity_state: string | null }>): Set<string> {
+  // FAIL-CLOSED (Fatia 2 D2): quarantina tudo que não for EXATAMENTE 'verified' — inclui null, estado
+  // futuro e qualquer valor que o CHECK venha a aceitar. A Fatia 2 só POPULA 'ambiguous', mas testar
+  // `=== 'ambiguous'` falharia ABERTO (cliente de identidade dúbia pagando comissão) no dia em que outro
+  // estado ganhasse gatilho. Ledger vazio → set vazio → rebuild degrada p/ o comportamento de hoje.
+  const quarantinados = new Set<string>();
+  for (const r of rows) if (r.identity_state !== 'verified') quarantinados.add(r.user_id);
+  return quarantinados;
+}
+function aplicarMascaras(
+  assignments: ComputedAssignment[],
+  flaggeds: Set<string>,
+  quarantinados: Set<string>,
+): ComputedAssignment[] {
+  // As 2 máscaras derrubam ELEGIBILIDADE, nunca PRESENÇA. Tirar o membro da saída faria o upsert-only
+  // (onConflict customer_user_id, sem DELETE) preservar o assignment ANTIGO — vendedor errado, válido,
+  // cobrando comissão (o furo que refutou o A′). eligible=false já entrega zero comissão + invisível
+  // (todo leitor filtra `WHERE eligible`), e é REVERSÍVEL: volta a 'verified' → volta a valer.
+  return assignments.map((a) => ({
+    ...a,
+    eligible: a.eligible && !flaggeds.has(a.customer_user_id) && !quarantinados.has(a.customer_user_id),
+  }));
+}
 function avaliarGuardProof(m: { proofCrua: number; proofFresca: number; comVendedor: number }): { abortar: boolean; motivo: string | null } {
   if (m.proofFresca === 0) {
     return { abortar: true, motivo: 'proof oben fresca vazia (sync parado / TTL 7d expirado)' };
@@ -278,25 +301,32 @@ Deno.serve(async (req) => {
   // LISTA de membros = carteira_membership_ledger (P0-B-bis Fatia 1). Acumulador durável (append-only:
   // backfill + trigger AFTER INSERT no espelho; CASCADE só em delete de auth.users) → cobertura monotônica,
   // nunca encolhe → sem stale. Preserva a herança B-lite (gêmeo + clones no mesmo grupo) E a cobertura. O
-  // VENDEDOR vem da proof oben (abaixo), não daqui. Sem filtro de identity_state (quarantine é da Fatia 2).
+  // VENDEDOR vem da proof oben (abaixo), não daqui. identity_state vem JUNTO (Fatia 2): o não-'verified'
+  // é QUARANTINADO — sai da elegibilidade, NUNCA da lista (tirá-lo daqui faria o upsert-only preservar o
+  // assignment antigo STALE — o furo que refutou o A′). Populado pelo omie-analytics-sync no run oben.
   // Paginação robusta a max_rows (#7 Codex): avança pela quantidade REAL retornada e para na página VAZIA
   // — não presume PAGE=1000 (se o servidor capar em 500, `< PAGE` truncaria na 1ª página). Guard anti-loop.
   // user_id é PK NOT NULL no ledger → sem o `.not(is null)` do espelho.
   const PAGE = 1000;
   const MAX_ROWS = 500_000;
   const membroIds: string[] = [];
+  const ledgerRows: Array<{ user_id: string; identity_state: string | null }> = [];
   for (let from = 0; ;) {
     const { data, error } = await supabase
       .from('carteira_membership_ledger')
-      .select('user_id')
+      .select('user_id, identity_state')
       .order('user_id', { ascending: true })
       .range(from, from + PAGE - 1);
     if (error) { console.error('[carteira-rebuild] load ledger error:', error.message); return await failLease(error.message); }
-    const page = (data ?? []) as Array<{ user_id: string }>;
-    for (const r of page) membroIds.push(r.user_id);
+    const page = (data ?? []) as Array<{ user_id: string; identity_state: string | null }>;
+    for (const r of page) { membroIds.push(r.user_id); ledgerRows.push(r); }
     if (page.length === 0) break;
     from += page.length;
     if (from > MAX_ROWS) { console.error('[carteira-rebuild] ledger excedeu MAX_ROWS'); return await failLease('paginacao ledger excedeu limite'); }
+  }
+  const quarantinados = extrairQuarantinados(ledgerRows);
+  if (quarantinados.size > 0) {
+    console.warn(`[carteira-rebuild] Fatia 2: ${quarantinados.size} membro(s) QUARANTINADO(s) (identity_state != verified) — preservados, eligible=false, zero comissão`);
   }
 
   // VENDEDOR account-correto = view FRESCA omie_customer_account_map_fresco (account='oben') → Map por
@@ -369,15 +399,17 @@ Deno.serve(async (req) => {
     return await failLease(`cadeia de alias (${chainViolations.length}) — corrija customer_canonical_alias`);
   }
 
-  // 2c. Rows finais — eligible EXPLÍCITO pós-flaggeds (clone a.eligible E não-fornecedor: é o que esconde
-  // os clones / reativa no rollback / retira fornecedor). Conserta o bug do upsert que omitia eligible.
+  // 2c. Rows finais — eligible EXPLÍCITO pós-máscaras (clone a.eligible E não-fornecedor E não-quarantinado:
+  // é o que esconde os clones / reativa no rollback / retira fornecedor / neutraliza identidade ambígua).
+  // Conserta o bug do upsert que omitia eligible. Máscara = elegibilidade, nunca presença (todo membro do
+  // ledger sai com row → reconciliado, nada stale).
   const now = new Date().toISOString();
-  const rows = assignments.map((a) => ({
+  const rows = aplicarMascaras(assignments, flaggeds, quarantinados).map((a) => ({
     customer_user_id: a.customer_user_id,
     owner_user_id: a.owner_user_id,
     source: a.source,
     omie_codigo_vendedor: a.omie_codigo_vendedor,
-    eligible: a.eligible && !flaggeds.has(a.customer_user_id),
+    eligible: a.eligible,
     updated_at: now,
     last_synced_at: now,
   }));

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -475,6 +475,30 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       console.log(`[Sync ${account}] P1b: ${ambiguosList.length} user(s) ambíguo(s) — vínculo document removido da proof-table`);
     }
 
+    // ── P0-B-bis Fatia 2: marca `ambiguous` no carteira_membership_ledger. O par do DELETE acima: o vínculo
+    // sai da proof, mas o MEMBRO permanece no ledger (acumulador) e o carteira-rebuild o QUARANTINA
+    // (eligible=false, zero comissão, row preservada). Sem isto, o ambíguo perde o vendedor, vira órfão e cai
+    // no Hunter com eligible=TRUE — comissão sobre um cliente cuja identidade não sabemos.
+    // SÓ o run oben escreve (D5): identity_state é coluna GLOBAL (1 row/user) e a ambiguidade é detectada POR
+    // CONTA → os 3 runs escrevendo se sobrescreveriam (flapping: um marca, o outro desmarca). A carteira lê a
+    // proof account='oben' — é a conta que decide. Mesma regra do espelho (:488) e das tags.
+    // FAIL-CLOSED: marca ANTES da reversão (abaixo). UPDATE .in() nunca INSERE — quem popula o ledger é o
+    // trigger da Fatia 0; membro fora do ledger simplesmente não é tocado.
+    if (account === "vendas" && usersAmbiguosOmie.size > 0) {
+      const ambiguosList = Array.from(usersAmbiguosOmie);
+      const nowIso = new Date().toISOString();
+      for (let i = 0; i < ambiguosList.length; i += 200) {
+        const { error: ledErr } = await db
+          .from("carteira_membership_ledger")
+          .update({ identity_state: "ambiguous", updated_at: nowIso })
+          .in("user_id", ambiguosList.slice(i, i + 200));
+        if (ledErr) throw new Error(`marca ambiguous carteira_membership_ledger: ${ledErr.message}`);
+      }
+      console.warn(
+        `[Sync ${account}] Fatia 2: ${ambiguosList.length} membro(s) → identity_state='ambiguous' no ledger; serão QUARANTINADOS no próximo carteira-rebuild (preservados, eligible=false, zero comissão)`,
+      );
+    }
+
     // Bulk upsert em chunks (onConflict user_id = unique_user_omie). empresa_omie NÃO é setado
     // (preserva o default 'colacor' do comportamento anterior).
     // Fatia 4 (money-path, Codex): SÓ 'vendas'(oben) mantém o espelho legado omie_clientes. Este
@@ -507,6 +531,47 @@ async function syncCustomers(db: SupabaseClient, account: OmieAccount) {
       if (mapErr) throw new Error(`upsert omie_customer_account_map: ${mapErr.message}`);
     }
     console.log(`[Sync ${account}] proof-table omie_customer_account_map: ${mapRows.length} vínculos por documento`);
+
+    // ── P0-B-bis Fatia 2: reversão `ambiguous` → `verified`, SIMÉTRICA ao delete/marcação acima. Quem ESTE run
+    // PROVOU limpo volta a valer: `accountMapByUser` é exatamente o conjunto casado por DOCUMENTO, e os
+    // ambíguos já foram retirados dele (:447) → os dois conjuntos são disjuntos de graça.
+    // Sem isto o quarantine seria CATRACA DE MÃO ÚNICA: doc corrigido no Omie deixaria o cliente invisível e
+    // sem comissão PARA SEMPRE, dependendo de um UPDATE manual que ninguém saberia que precisa fazer.
+    // Barato no caso normal: 1 SELECT indexado (idx_cml_identity_state) que hoje volta VAZIO → nada a fazer.
+    // Paginado (a capa de 1000 do PostgREST é silenciosa). Run parcial reverte só o que viu (fail-safe).
+    if (account === "vendas") {
+      const ambNoLedger: string[] = [];
+      for (let from = 0; ;) {
+        const { data, error: ambErr } = await db
+          .from("carteira_membership_ledger")
+          .select("user_id")
+          .eq("identity_state", "ambiguous")
+          .order("user_id", { ascending: true })
+          .range(from, from + 999);
+        if (ambErr) throw new Error(`lê ambiguous do carteira_membership_ledger: ${ambErr.message}`);
+        const page = (data ?? []) as Array<{ user_id: string }>;
+        for (const r of page) ambNoLedger.push(r.user_id);
+        if (page.length === 0) break;
+        from += page.length;
+        if (from > 500_000) throw new Error("paginacao ambiguous do ledger excedeu limite");
+      }
+      // só os que ESTE run provou limpos (casados por documento, não-ambíguos)
+      const reverter = ambNoLedger.filter((uid) => accountMapByUser.has(uid));
+      if (reverter.length > 0) {
+        const nowIso = new Date().toISOString();
+        for (let i = 0; i < reverter.length; i += 200) {
+          const { error: revErr } = await db
+            .from("carteira_membership_ledger")
+            .update({ identity_state: "verified", updated_at: nowIso })
+            .eq("identity_state", "ambiguous") // restringe ao que a Fatia 2 populou (não toca outros estados)
+            .in("user_id", reverter.slice(i, i + 200));
+          if (revErr) throw new Error(`reverte verified carteira_membership_ledger: ${revErr.message}`);
+        }
+        console.log(
+          `[Sync ${account}] Fatia 2: ${reverter.length} membro(s) ambiguous→verified (documento voltou a ser inequívoco) — saem do quarantine no próximo carteira-rebuild`,
+        );
+      }
+    }
 
     // Fatia 4: para contas não-oben o espelho não é tocado; o "sincronizado" reportado é a proof-table.
     if (account !== "vendas") totalSynced = mapRows.length;


### PR DESCRIPTION
## O furo que esta fatia fecha

Quando um documento vira ambíguo (2+ códigos Omie distintos para o mesmo doc na mesma conta), o sync **deleta** o vínculo da proof (`omie-analytics-sync:464`). O `carteira-rebuild` então vê `omie_codigo_vendedor: null`, cai no ramo órfão (`rebuild-helpers:150-155`) e emite `hunter_orphan` com **`eligible: true`**.

Ou seja: **um cliente cuja identidade nós admitimos não saber entra visível na carteira do Hunter e gera comissão.** E hoje "sem vendedor" (legítimo) é indistinguível de "identidade ambígua" — os 2069 órfãos visíveis são um balde só.

Alvo (spec macro §3.3/§6): **quarantined** — vendedor sem efeito, `eligible=false`, **membro preservado**, zero comissão.

## O escopo real é maior que o do handoff

O briefing desta sessão afirmava que o `carteira-rebuild` **já** consumia `identity_state`, restando só a marcação. **Não consumia.** Um `grep -rni quarantin` no repo inteiro retornava **um único hit**: o comentário `carteira-rebuild:281` — *"Sem filtro de identity_state (quarantine é da Fatia 2)"*.

Não foi deslize: a Fatia 1 adiou **deliberadamente** e registrou em §2 do design dela — *"a Fatia 2 popula E consome juntas"*, já que consumir com 100% dos membros em `verified` seria dead code não-testável.

**Consequência:** esta fatia tem **duas pontas**. Só marcar entregaria `ambiguous` gravado, ninguém lendo, quarantine seguindo inerte — com aparência de entrega feita.

## Decisões

| # | decisão | porquê |
|---|---|---|
| D1 | popular **só `ambiguous`** | único estado com gatilho real. `mapaConsolidacao` grava **todos** os aliases como `'inactive'` hard-coded (`:1887`) — é **proposta não-ativada, não revogação** (prod: 1633 aliases, todos `active`); e **nunca** emite `'conflict'`. Refletir conflaria "mapeamento proposto" com "identidade problemática" e criaria 2o writer para o que o `aliasMap` já faz. |
| D2 | consumir **`!== 'verified'`** | **fail-closed**: `null`/estado futuro quarantinam em vez de falhar aberto. |
| D3 | quarantined = **`hunter_orphan` + `eligible=false`** | `owner_user_id` é NOT NULL e o CHECK de `source` só aceita `omie`/`hunter_orphan` → `'quarantined'` exigiria DDL em tabela quente. `eligible=false` já entrega o efeito (todo leitor filtra `WHERE eligible`) e é **reversível**. **→ ZERO DDL.** |
| D4 | **reversão** escopada ao que o run provou limpo | sem ela é catraca de mão única: doc corrigido no Omie deixaria o cliente invisível **para sempre**, dependendo de um UPDATE manual que ninguém saberia fazer. |
| D5 | **só o run oben escreve** | `identity_state` é coluna **global**, a ambiguidade é detectada **por conta** → 3 runs escrevendo = **flapping**. Mesma regra que o código já aplica ao espelho (`:488`) e às tags. |

## O que NÃO fazer (e uma canária que barra)

Filtrar o quarantinado **na query** faria o membro sumir da entrada → o upsert-only (`onConflict: 'customer_user_id'`, sem DELETE) preservaria o **assignment antigo STALE** — vendedor errado, válido, cobrando comissão. É o mecanismo exato pelo qual o Codex **refutou a opção A′** deste épico. O membro permanece na lista; **só o `eligible` cai**. Há canária textual dedicada a barrar isso.

## Validação

`prove-sql-money-path` (PG17) **não se aplica** — desvio consciente do briefing, que o exigia **presumindo DDL**. D3 eliminou toda a SQL nova; sem migration o PG17 provaria só que um `UPDATE` não apaga a linha e que o CHECK aceita `ambiguous` (já provado na Fatia 0). A skill exclui *"edge function sem SQL novo"*. O risco aqui é **lógica TypeScript**.

- **54 testes** nos helpers puros (+/−, fail-closed, não-mutação, integração).
- **5 canárias textuais** novas (incluindo a anti-filtro-no-banco e a de paridade do MIRROR).
- **Suíte completa: 598 arquivos / 5233 testes verdes.** typecheck + lint: 0 erros.

### Falsificação (4 sabotagens → vermelho real)

| sabotagem | resultado |
|---|---|
| S1 — remover o quarantine da máscara | **3 vermelhos**: `O INVARIANTE: quarantinado PERMANECE na saída`, `o ambíguo ... NÃO gera comissão`, `CONTRASTE` |
| S2 — fail-closed → fail-open (`=== 'ambiguous'`) | **2 vermelhos**: exatamente os dois testes `FAIL-CLOSED` |
| S3 — filtrar `identity_state` no banco (o erro catastrófico) | canária anti-stale pega |
| S4 — sync parar de marcar `ambiguous` | canária do escritor pega |

> Honestidade sobre o ritual: a 1a rodada de S1/S2 foi **inválida** — passei os 2 paths numa variável e o vitest recebeu `"a b"` como filtro único → `No test files found` → `exit=1` **sem rodar nada**. Um exit code sozinho não distingue "pegou o bug" de "não rodou". Refeito com baseline explícito (54 passed) e conferindo os **nomes** dos testes vermelhos.

## Baseline PRÉ-deploy (psql-ro, 2026-07-16) e a predição

Seguindo a lição de #1356 (baselinar antes do apply; medir o que muda **e** o que deve ficar intacto):

| métrica | valor |
|---|---|
| `ledger_total` / `ledger_verified` | **6909 / 6909** (0 ambíguos → quarantine inerte) |
| `assign_total` | **6909** |
| `membro_SEM_assignment` / `assignment_SEM_membro` | **0 / 0** (reconciliação 1:1 perfeita) |
| `hunter_orphan` eligible **true/false** | 2069 / 2093 |
| `omie` eligible **true/false** | 2728 / 19 |
| `baseline_persistido` | **2728** (= `omie eligible=true` → guard calibrado) |

**Predição falsificável:** como há **0 docs ambíguos hoje** (confirmado pelo lado `profiles`), esta fatia é **preventiva** — arma a rede antes de alguém cair. Pós-deploy, **todas** as métricas acima devem ficar **idênticas**. Qualquer mudança refuta a alegação de que a fatia é aditiva.

Rede de segurança de graça: se um bug quarantinasse em massa, `omie eligible=true` cairia abaixo de 80% de 2728 → `avaliarGuardResultado` **aborta o rebuild sem gravar**.

## Deploy

**2 edges pelo chat do Lovable, verbatim:** `omie-analytics-sync`, `carteira-rebuild`.
**Sem SQL Editor** (zero DDL) e **sem Publish** (nenhuma mudança de frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)