### PR TITLE
docs(db-operator): validar CREATE OR REPLACE por EXECUÇÃO, não por grep no corpo

### DIFF
--- a/.claude/skills/lovable-db-operator/references/validation-queries.md
+++ b/.claude/skills/lovable-db-operator/references/validation-queries.md
@@ -76,6 +76,32 @@ FROM information_schema.role_routine_grants
 WHERE routine_schema = 'public' AND routine_name = '<funcao>';
 ```
 
+### `CREATE OR REPLACE` de função: "existe" não é validação
+
+Com `CREATE OR REPLACE`, a função **já existia** — o `EXISTS` acima passa mesmo que nada tenha sido aplicado. Valide o **corpo**, e ancore na **presença do código NOVO**, nunca na **ausência do texto antigo**:
+
+```sql
+-- ✅ ancora no que o fix INTRODUZIU
+SELECT CASE WHEN (
+  SELECT pg_get_functiondef(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = '<funcao>'
+) ILIKE '%<identificador que só o corpo novo tem>%'
+THEN '✅ corpo novo aplicado' ELSE '❌ ainda o corpo antigo' END AS status;
+```
+
+⚠️ **A armadilha (mordeu no #1357):** validar por `... NOT ILIKE '%<coluna_do_bug_antigo>%'` **mente**. `pg_get_functiondef` devolve o corpo **com os comentários**, e um fix bem documentado quase sempre explica o bug antigo citando o nome errado — então o grep casa a **própria explicação** e acusa `❌` numa função correta. É a regra anti-teatro da skill `prove-sql-money-path` aplicada à validação: *a sentinela nunca pode conter o texto que o próprio código emite*. Cuidado extra com substring: `t1_data_pedido` **contém** `data_pedido`, então mesmo sem comentário o `NOT ILIKE` daria falso-negativo.
+
+Lá o erro caiu pro lado seguro (`❌` falso). No sentido inverso — grep que casa por acidente e diz `✅` — você declara aplicado algo que nunca rodou, que é exatamente a falha silenciosa que esta skill existe pra prevenir.
+
+**A validação forte de função é por EXECUÇÃO, não por grep.** Rode via `psql-ro` a query que o corpo novo executa (ou a própria função, se o gate permitir) contra dado REAL e confira que (a) não estoura e (b) o número faz sentido:
+
+```sql
+-- prova que o caminho corrigido roda limpo e devolve valor plausível
+SELECT <a expressão/agregação exata do corpo novo> FROM <fonte nova> WHERE <filtro do corpo novo>;
+```
+
+Se a função tem gate de staff (`SECURITY DEFINER` + `has_role`), o `claude_ro` não a executa — sem JWT, `auth.uid()` é NULL e ela levanta `42501` antes de chegar na lógica. Nesse caso execute **a query interna**, que é onde mora o `42703`/`42P01` que você quer descartar.
+
 ## Trigger
 
 ```sql


### PR DESCRIPTION
A query de validação que entreguei no #1357 acusou **❌ numa função correta**. Ela provava que o bug tinha morrido com `pg_get_functiondef(...) NOT ILIKE '%data_pedido%'` — mas `pg_get_functiondef` devolve o corpo **com os comentários**, e o comentário do próprio fix explicava o bug antigo citando `data_pedido`. O grep casou a própria explicação.

É a regra anti-teatro da skill `prove-sql-money-path` — *a sentinela nunca pode conter o texto que o próprio código emite* — aplicada à validação pós-apply. O harness do #1357 **não** caiu nela porque prova **executando** (a falsificação `F3` exige o 42703 rodando a função de verdade); a query de validação provava por **grep no fonte**, método mais fraco.

Dessa vez falhou pro lado seguro (`❌` falso numa função boa, custando uma rodada de investigação). No sentido inverso — grep que casa por acidente e diz `✅` — declara-se aplicado algo que nunca rodou, que é exatamente a falha silenciosa que a skill `lovable-db-operator` existe pra prevenir.

Há ainda a armadilha de substring, independente de comentário: `t1_data_pedido` **contém** `data_pedido`, então `NOT ILIKE '%data_pedido%'` daria falso-negativo mesmo num corpo sem comentário nenhum.

## O que fica registrado em `references/validation-queries.md`

- `EXISTS` não valida `CREATE OR REPLACE` — a função **já existia**; o teste passa com zero aplicado.
- Ancore na **presença do código novo**, nunca na **ausência do texto antigo**.
- A validação forte de função é **por execução** via `psql-ro`, contra dado real: (a) não estoura e (b) o número faz sentido. Com gate de staff (`SECURITY DEFINER` + `has_role`), o `claude_ro` não executa a função — sem JWT o `auth.uid()` é NULL e ela levanta 42501 antes da lógica; nesse caso execute a **query interna**, que é onde mora o 42703/42P01.

Foi assim que o #1357 acabou validado de verdade: rodando a agregação exata do corpo novo num evento pendente real, que devolveu σ atual 4,52 → σ sem o outlier 2,49 — o painel que a tela prometia e nunca conseguiu mostrar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)