### PR TITLE
fix(omie): omie-cliente resolve identidade pela proof account-correta (Fatia 3-edges PR-A) [money-path]

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1168,3 +1168,160 @@ describe('guardrail money-path: omie-sync-sku-items (fila de leadtime)', () => {
     ).toMatch(/throw new Error\(\s*\n?\s*`sku_items_sync_controle ilegível/);
   });
 });
+
+// ── Fatia 3-edges PR-A (omie-cliente: os 3 LEITORES saem do espelho → proof fresca account-correta) ──
+// Os 3 leitores do edge de cadastro resolviam identidade por um código de conta INDETERMINADA. O espelho
+// omie_clientes é UNIQUE(user_id) — 1 linha por user, sobrescrita pelo writer da vez (oben, colacor_sc…) —
+// e empresa_omie está 'colacor' em 6.909/6.909 linhas (o DEFAULT, nunca populado): o rótulo de conta é
+// mentiroso. Migrados p/ omie_customer_account_map_fresco, que é UNIQUE(user_id, account) e
+// UNIQUE(omie_codigo_cliente, account) → .maybeSingle() seguro. A conta de CADA leitor saiu do CHAMADOR,
+// não de presunção (as credenciais do edge enganam: callOmieApi é colacor_sc, mas não é ela que decide):
+//   • criar_perfil_local → 'oben'  — useUnifiedOrder.handleStaffAddTool passa selectedCustomer.codigo_cliente
+//     (código OBEN) e resolve o MESMO código com .eq('account','oben') logo antes de invocar (#1331);
+//   • sync_all_clients   → conta do account_index (useAnalyticsSync itera "Conta N/3", 0→2);
+//   • sync_addresses     → multi-conta por natureza: usa o account de CADA linha da proof (não filtra uma).
+// Restam 3 omie_clientes, todos WRITERS (inserts → migram na Fatia 4 p/ register_carteira_member).
+// A paridade textual pega a reversão do deploy do Lovable (armadilha do #1272). Ver design §4/§5.
+const OMIE_CLIENTE = 'supabase/functions/omie-cliente/index.ts';
+const UNIFIED_ORDER = 'src/hooks/useUnifiedOrder.ts';
+
+// Recorta o corpo de um `case "<nome>": {` do edge (até o próximo case na mesma indentação). Necessário
+// porque o omie-cliente tem 9 handlers e vários compartilham vocabulário: `for (const account of accounts)`
+// é REGRESSÃO no sync_addresses (chutar o código nas 3 contas) e LEGÍTIMO no buscar_logos_empresas, que
+// varre as contas de propósito. Um assert no arquivo inteiro confundiria os dois.
+function blocoCaseCliente(s: string, nome: string): string {
+  const i = s.indexOf(`case "${nome}": {`);
+  if (i < 0) throw new Error(`case "${nome}" não encontrado no omie-cliente`);
+  const resto = s.slice(i);
+  const fim = resto.search(/\n {6}case "/);
+  return fim < 0 ? resto : resto.slice(0, fim);
+}
+
+// Recorta handleStaffAddTool (o único chamador de criar_perfil_local) para amarrar edge × chamador
+// dentro do MESMO fluxo, sem depender de contar caracteres entre as duas âncoras.
+function blocoHandleStaffAddTool(s: string): string {
+  const i = s.indexOf('const handleStaffAddTool = async () => {');
+  if (i < 0) throw new Error('handleStaffAddTool não encontrada em useUnifiedOrder');
+  const resto = s.slice(i);
+  const fim = resto.search(/\n {2}\};\n/);
+  return fim < 0 ? resto : resto.slice(0, fim);
+}
+
+describe('guardrail money-path: omie-cliente lê a proof fresca account-correta (Fatia 3-edges PR-A)', () => {
+  const src = read(OMIE_CLIENTE);
+
+  it('sentinela: leu o arquivo real (edge) e os 3 handlers migrados', () => {
+    expect(src).toContain('criar_perfil_local');
+    expect(src).toContain('sync_all_clients');
+    expect(src).toContain('sync_addresses');
+  });
+
+  it('os 3 LEITORES vêm da view fresca; omie_clientes só resta como WRITER', () => {
+    expect(
+      count(src, '.from("omie_customer_account_map_fresco")'),
+      'REVERSÃO Lovable? sumiu leitura da view fresca (esperado 3: criar_perfil_local, sync_all_clients, sync_addresses)',
+    ).toBe(3);
+    expect(
+      count(src, '.from("omie_clientes")'),
+      'REGRESSÃO: omie_clientes voltou como LEITOR (deveria restar só os 3 writers INSERT → Fatia 4)',
+    ).toBe(3);
+    // Os 3 restantes TÊM de ser inserts: contar == 3 sozinho não impede trocar um insert por um select.
+    expect(
+      (src.match(/\.from\("omie_clientes"\)\s*\.insert\(/g) ?? []).length,
+      'REGRESSÃO: algum dos 3 omie_clientes restantes deixou de ser o writer INSERT',
+    ).toBe(3);
+    expect(
+      src,
+      'REVERSÃO Lovable? voltou a .select() do espelho poluído omie_clientes (código de conta indeterminada)',
+    ).not.toMatch(/\.from\("omie_clientes"\)\s*\.select/);
+  });
+
+  it('a credencial Omie carrega o slug canônico da conta (não o índice instável nem o nome de UI)', () => {
+    // getOmieAccounts monta a lista CONDICIONALMENTE (só com as env vars presentes): faltar
+    // OMIE_OBEN_APP_KEY faria o índice 1 virar Colacor e o filtro de conta mentir em silêncio.
+    expect(src, 'sumiu o slug canônico do OmieAccountConfig — o filtro de conta volta a depender do índice')
+      .toMatch(/account:\s*OmieAccountSlug/);
+    expect(
+      count(src, 'account: "colacor_sc"') + count(src, 'account: "oben"') + count(src, 'account: "colacor"'),
+      'as 3 contas devem declarar seu slug canônico (domínio do CHECK chk_ocam_account)',
+    ).toBe(3);
+  });
+
+  it('criar_perfil_local resolve codigo->user na fresca account=oben (a conta do chamador)', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? criar_perfil_local não resolve mais o código pela fresca com account=oben',
+    ).toMatch(
+      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,200}\.eq\("omie_codigo_cliente", cliente\.codigo_cliente\)[\s\S]{0,120}\.eq\("account", "oben"\)/,
+    );
+    // Miss (ausente/stale >7d) NÃO pode virar código chutado: o ramo cai no fallback por documento.
+    expect(
+      src,
+      'REGRESSÃO: sumiu o guard de miss (existingMapping?.user_id) — user_id null da view viraria hit falso',
+    ).toMatch(/if \(existingMapping\?\.user_id\)/);
+  });
+
+  it('COERÊNCIA cross-file: o edge usa a MESMA conta que o chamador — senão resolvem users diferentes', () => {
+    // O frontend resolve o código pela fresca account=oben e SÓ ENTÃO invoca criar_perfil_local com ele.
+    // Se um dos dois mudar de conta, o edge acha um user diferente do que o chamador acabou de achar e
+    // a ferramenta é anexada ao cliente ERRADO (Codex P2). Este assert amarra os dois lados no MESMO fluxo.
+    const fluxo = blocoHandleStaffAddTool(read(UNIFIED_ORDER));
+    expect(
+      fluxo,
+      'sentinela: handleStaffAddTool deixou de ser o chamador de criar_perfil_local',
+    ).toMatch(/action: 'criar_perfil_local'/);
+    expect(
+      fluxo,
+      'o chamador de criar_perfil_local não resolve mais o código pela fresca account=oben — o edge divergiu dele?',
+    ).toMatch(/omie_customer_account_map_fresco[\s\S]{0,260}\.eq\('account', 'oben'\)/);
+  });
+
+  it('sync_all_clients dedupa pela conta DO LOTE, paginado e fail-closed em erro de query', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? o dedup do sync_all_clients não lê a fresca filtrando a conta do account_index',
+    ).toMatch(
+      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,120}\.eq\("account", account\.account\)[\s\S]{0,120}\.order\("omie_codigo_cliente"\)[\s\S]{0,120}\.range\(/,
+    );
+    // Sem .range o PostgREST capa em 1.000 linhas SILENCIOSO (eram 1.000 de 6.909 → o dedup enxergava 1/7).
+    expect(
+      src,
+      'REGRESSÃO: o pré-load do dedup perdeu a paginação — volta a capar em 1.000 e reprocessar o resto',
+    ).toMatch(/codePage\.length < codePageSize/);
+    // Codex P2 do PR-2: engolir o erro deixa o Set vazio e o loop tenta RECRIAR milhares de clientes.
+    expect(
+      src,
+      'REGRESSÃO: o pré-load do dedup engole o erro da query — Set vazio → reimportação em massa',
+    ).toMatch(/if \(codeErr\) throw new Error/);
+  });
+
+  it('sync_addresses lê (user, conta, código) da proof e consulta a conta CERTA de cada código', () => {
+    // Ancorado no bloco do handler: `for (const account of accounts)` é regressão AQUI e legítimo no
+    // buscar_logos_empresas (que varre as contas de propósito) — no arquivo inteiro os dois se confundem.
+    const bloco = blocoCaseCliente(src, 'sync_addresses');
+    expect(
+      bloco,
+      'REVERSÃO Lovable? sync_addresses não lê mais (user_id, account, omie_codigo_cliente) da fresca paginada',
+    ).toMatch(
+      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,120}\.select\("user_id, account, omie_codigo_cliente"\)[\s\S]{0,160}\.range\(/,
+    );
+    // O código agora vem PAREADO com a conta dele: nada de chutar o mesmo código nas 3 contas.
+    expect(
+      bloco,
+      'REGRESSÃO: sync_addresses voltou a varrer as 3 contas com o mesmo código indeterminado',
+    ).not.toMatch(/for \(const account of accounts\)/);
+    expect(
+      bloco,
+      'sentinela: a consulta usa a credencial da conta DA LINHA da proof',
+    ).toMatch(/accountBySlug\.get\(entry\.account\)/);
+    // A proof tem até 1 linha por (user, conta) — sem agrupar, batch_size=30 viraria ~10 users.
+    expect(
+      bloco,
+      'REGRESSÃO: sumiu o agrupamento por user — o lote passa a contar LINHAS da proof, não clientes',
+    ).toMatch(/codesByUser/);
+    expect(
+      bloco,
+      'REGRESSÃO: o pré-load dos mapeamentos engole o erro — vira "No client mappings found" (no-op mudo)',
+    ).toMatch(/if \(pageErr\) throw new Error/);
+  });
+});

--- a/supabase/functions/omie-cliente/index.ts
+++ b/supabase/functions/omie-cliente/index.ts
@@ -125,8 +125,16 @@ async function callOmieApi(
   return callOmieApiWithCredentials(endpoint, call, params, OMIE_APP_KEY, OMIE_APP_SECRET);
 }
 
+// Slug canônico da conta, igual ao domínio de omie_customer_account_map.account
+// (CHECK chk_ocam_account: 'oben' | 'colacor' | 'colacor_sc'). É a chave que amarra a credencial
+// Omie usada na chamada à linha correspondente da proof — o `name` é rótulo de UI e não serve
+// (buscar_logos_empresas já erra ao casar por nome), e o ÍNDICE em getOmieAccounts() é instável:
+// a lista é montada condicionalmente, então faltar OMIE_OBEN_APP_KEY faz o índice 1 virar Colacor.
+type OmieAccountSlug = "colacor_sc" | "oben" | "colacor";
+
 interface OmieAccountConfig {
   name: string;
+  account: OmieAccountSlug;
   appKey: string;
   appSecret: string;
 }
@@ -137,19 +145,19 @@ function getOmieAccounts(): OmieAccountConfig[] {
   const colacorScKey = Deno.env.get("OMIE_COLACOR_SC_APP_KEY");
   const colacorScSecret = Deno.env.get("OMIE_COLACOR_SC_APP_SECRET");
   if (colacorScKey && colacorScSecret) {
-    accounts.push({ name: "Colacor SC (Afiação)", appKey: colacorScKey, appSecret: colacorScSecret });
+    accounts.push({ name: "Colacor SC (Afiação)", account: "colacor_sc", appKey: colacorScKey, appSecret: colacorScSecret });
   }
 
   const obenKey = Deno.env.get("OMIE_OBEN_APP_KEY");
   const obenSecret = Deno.env.get("OMIE_OBEN_APP_SECRET");
   if (obenKey && obenSecret) {
-    accounts.push({ name: "Oben", appKey: obenKey, appSecret: obenSecret });
+    accounts.push({ name: "Oben", account: "oben", appKey: obenKey, appSecret: obenSecret });
   }
 
   const colacorKey = Deno.env.get("OMIE_COLACOR_APP_KEY");
   const colacorSecret = Deno.env.get("OMIE_COLACOR_APP_SECRET");
   if (colacorKey && colacorSecret) {
-    accounts.push({ name: "Colacor", appKey: colacorKey, appSecret: colacorSecret });
+    accounts.push({ name: "Colacor", account: "colacor", appKey: colacorKey, appSecret: colacorSecret });
   }
 
   return accounts;
@@ -622,14 +630,23 @@ serve(async (req) => {
         const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
         const adminClient = createClient(supabaseUrl, supabaseServiceKey);
 
-        // Check if mapping already exists by omie_codigo_cliente
+        // Resolve codigo->user_id pela proof fresca account-correta (account='oben').
+        // O ÚNICO chamador é o fluxo de vendas OBEN (useUnifiedOrder.handleStaffAddTool), que passa
+        // selectedCustomer.codigo_cliente — código da conta OBEN — e JÁ resolve esse mesmo código pela
+        // fresca com .eq('account','oben') antes de invocar (#1331). Buscá-lo no espelho omie_clientes
+        // SEM conta lia um código de conta INDETERMINADA: o espelho é UNIQUE(user_id) (1 linha/user,
+        // sobrescrita pelo writer da vez) e empresa_omie é 'colacor' em 100% das linhas — rótulo
+        // mentiroso. Divergir da conta do chamador aqui anexaria a ferramenta ao cliente ERRADO.
+        // Miss (ausente ou stale >7d) cai no fallback por documento abaixo — fail-closed.
         const { data: existingMapping } = await adminClient
-          .from("omie_clientes")
+          .from("omie_customer_account_map_fresco")
           .select("user_id")
           .eq("omie_codigo_cliente", cliente.codigo_cliente)
+          .eq("account", "oben")
           .maybeSingle();
 
-        if (existingMapping) {
+        // user_id da view é nulável (view sem NOT NULL) → null = miss, cai no fallback por documento.
+        if (existingMapping?.user_id) {
           result = { user_id: existingMapping.user_id };
           break;
         }
@@ -745,11 +762,31 @@ serve(async (req) => {
         let accErrors = 0;
         let pagesProcessed = 0;
 
-        // Pre-load all existing omie_clientes mappings for fast lookup
-        const { data: allMappings } = await adminClient
-          .from("omie_clientes")
-          .select("omie_codigo_cliente");
-        const existingCodes = new Set((allMappings || []).map(m => m.omie_codigo_cliente));
+        // Códigos JÁ mapeados NESTA conta, pela proof fresca account-correta. Antes vinha de
+        // .select("omie_codigo_cliente") do espelho omie_clientes: (a) SEM filtro de conta — e o
+        // espelho é UNIQUE(user_id), 1 linha/user sobrescrita pelo writer da vez, com empresa_omie
+        // 'colacor' em 100% das linhas → o Set misturava códigos de contas diferentes; (b) SEM
+        // .range() → capado em 1.000 linhas silencioso (armadilha PostgREST) de 6.909 → o dedup
+        // enxergava 1/7 dos códigos e o loop reprocessava o resto. A fresca dá os códigos DESTA
+        // conta, paginados com .order estável.
+        const existingCodes = new Set<number>();
+        let codeOffset = 0;
+        const codePageSize = 1000;
+        while (true) {
+          const { data: codePage, error: codeErr } = await adminClient
+            .from("omie_customer_account_map_fresco")
+            .select("omie_codigo_cliente")
+            .eq("account", account.account)
+            .order("omie_codigo_cliente")
+            .range(codeOffset, codeOffset + codePageSize - 1);
+          // Fail-closed: engolir o erro deixaria o Set vazio/parcial e o loop tentaria RECRIAR
+          // milhares de clientes já existentes (Codex P2 do PR-2, mesma armadilha).
+          if (codeErr) throw new Error(`Falha ao carregar códigos já mapeados (${account.account}): ${codeErr.message}`);
+          if (!codePage || codePage.length === 0) break;
+          for (const row of codePage) existingCodes.add(row.omie_codigo_cliente as number);
+          if (codePage.length < codePageSize) break;
+          codeOffset += codePageSize;
+        }
 
         // Pre-load all profiles with documents for dedup
         const { data: allProfiles } = await adminClient
@@ -900,47 +937,76 @@ serve(async (req) => {
         }
         const usersWithAddress = new Set(allAddressUserIds);
 
-        // Get ALL omie_clientes mappings (paginate to bypass 1000 row limit)
-        let allMappings: Array<{ user_id: string; omie_codigo_cliente: number }> = [];
+        // Mapeamentos (user, conta, código) pela proof fresca account-correta, paginado com .order
+        // estável. Antes vinha de .select("user_id, omie_codigo_cliente") do espelho omie_clientes,
+        // que é UNIQUE(user_id): 1 linha por user com o código da ÚLTIMA conta que escreveu (e
+        // empresa_omie 'colacor' em 100% das linhas, rótulo mentiroso) — o loop abaixo então chutava
+        // esse código indeterminado nas 3 contas até uma responder. A proof tem 1 linha por
+        // (user, conta), então sabemos a conta CERTA de cada código.
+        let allMappings: Array<{ user_id: string; account: string; omie_codigo_cliente: number }> = [];
         let fetchOffset = 0;
         const fetchPageSize = 1000;
         while (true) {
-          const { data: page } = await adminClient
-            .from("omie_clientes")
-            .select("user_id, omie_codigo_cliente")
+          const { data: page, error: pageErr } = await adminClient
+            .from("omie_customer_account_map_fresco")
+            .select("user_id, account, omie_codigo_cliente")
+            .order("user_id")
+            .order("account")
             .range(fetchOffset, fetchOffset + fetchPageSize - 1);
+          // Fail-closed: engolir o erro daria "No client mappings found" — um NO-OP mudo que parece sucesso.
+          if (pageErr) throw new Error(`Falha ao carregar mapeamentos da proof: ${pageErr.message}`);
           if (!page || page.length === 0) break;
-          allMappings = allMappings.concat(page);
+          allMappings = allMappings.concat(page as typeof allMappings);
           if (page.length < fetchPageSize) break;
           fetchOffset += fetchPageSize;
         }
-        const totalCount = allMappings.length;
 
-        if (allMappings.length === 0) {
+        // Agrupa por user: a proof tem até 1 linha por (user, conta) e o batch conta USERS (o espelho
+        // tinha 1 linha/user, então sem agrupar um batch_size=30 viraria ~10 users e o lote encolheria).
+        const codesByUser = new Map<string, Array<{ account: string; codigo: number }>>();
+        for (const m of allMappings) {
+          const list = codesByUser.get(m.user_id) ?? [];
+          list.push({ account: m.account, codigo: m.omie_codigo_cliente });
+          codesByUser.set(m.user_id, list);
+        }
+        const totalCount = codesByUser.size;
+
+        if (totalCount === 0) {
           result = { synced: 0, skipped: 0, errors: 0, hasMore: false, message: "No client mappings found" };
           break;
         }
 
         // Filter to those without addresses
-        const clientsNeedingAddress = allMappings.filter((m) => !usersWithAddress.has(m.user_id));
+        const clientsNeedingAddress = [...codesByUser.keys()].filter((userId) => !usersWithAddress.has(userId));
         const totalNeeding = clientsNeedingAddress.length;
 
         // Always take from the beginning since the list shrinks as addresses are created
         const batch = clientsNeedingAddress.slice(0, batchSize);
         console.log(`[sync_addresses] Processing batch size=${batch.length}, totalNeeding=${totalNeeding}`);
 
-        for (const mapping of batch) {
+        // Chave `string` de propósito: o account vem da proof (dado externo). Slug desconhecido ou
+        // sem credencial nesta edge → .get() undefined → o guard abaixo pula (fail-closed).
+        const accountBySlug = new Map<string, OmieAccountConfig>(accounts.map((a) => [a.account, a]));
+
+        for (const userId of batch) {
           try {
             let clienteData: OmieCliente | null = null;
-            
-            for (const account of accounts) {
+
+            // Só as contas onde o user REALMENTE tem cadastro, cada uma com o código DAQUELA conta
+            // (a proof garante o par). Antes: o mesmo código indeterminado era chutado nas 3 contas
+            // até uma responder — até 3x chamadas Omie e, sob colisão de código entre contas, o
+            // endereço de OUTRO cliente. Mantém "tenta até achar endereço" entre as contas do user.
+            for (const entry of codesByUser.get(userId) ?? []) {
+              const conta = accountBySlug.get(entry.account);
+              // Conta sem credencial nesta edge → pula (fail-closed: não tenta o código em outra conta).
+              if (!conta) continue;
               try {
                 const detailResult = await callOmieApiWithCredentials(
                   "geral/clientes/",
                   "ConsultarCliente",
-                  { codigo_cliente_omie: mapping.omie_codigo_cliente },
-                  account.appKey,
-                  account.appSecret
+                  { codigo_cliente_omie: entry.codigo },
+                  conta.appKey,
+                  conta.appSecret
                 ) as unknown as OmieCliente;
 
                 if (detailResult && detailResult.endereco && detailResult.cidade) {
@@ -948,7 +1014,7 @@ serve(async (req) => {
                   break;
                 }
               } catch {
-                // Client not in this account, try next
+                // Sem cadastro/endereço nesta conta do user → tenta a próxima conta DELE
               }
             }
 
@@ -957,14 +1023,14 @@ serve(async (req) => {
               continue;
             }
 
-            const inserted = await upsertAddressFromOmie(adminClient, mapping.user_id, clienteData);
+            const inserted = await upsertAddressFromOmie(adminClient, userId, clienteData);
             if (inserted) {
               totalSynced++;
             } else {
               totalSkipped++;
             }
           } catch (err) {
-            console.error(`[sync_addresses] Error for user ${mapping.user_id}:`, err);
+            console.error(`[sync_addresses] Error for user ${userId}:`, err);
             totalErrors++;
           }
         }
@@ -976,7 +1042,7 @@ serve(async (req) => {
           skipped: totalSkipped,
           errors: totalErrors,
           totalNeeding,
-          totalClients: totalCount || allMappings.length,
+          totalClients: totalCount,
           processed: batch.length,
           hasMore,
         };


### PR DESCRIPTION
Fatia 3-edges **PR-A** do épico-drop do espelho. Migra os **3 LEITORES** de `omie_clientes` do edge de cadastro para a proof fresca account-correta. **Writers intocados** (Fatia 4).

## O que o espelho realmente é (medido, não presumido)

Via psql-ro em prod:

| fonte | linhas | por quê |
|---|---|---|
| `omie_clientes` | 6.909 | `UNIQUE(user_id)` → **1 linha por user** |
| `omie_customer_account_map` | 15.661 | `UNIQUE(user_id, account)` → até 3 por user |

E o achado que fecha o caso: **`empresa_omie` está `'colacor'` em 6.909 de 6.909 linhas** — o *default*, nunca populado por nenhum writer. O espelho guarda o código da **primeira/última conta que escreveu**, sob um rótulo de conta mentiroso. Quem lê `omie_codigo_cliente` de lá recebe um código de conta **indeterminada**. É a mesma "poluição" que o PR-1 já documentava; aqui ela está quantificada.

## A conta de cada leitor veio do CHAMADOR, não de presunção

As credenciais do edge enganam — `callOmieApi` usa Colacor SC, mas não é ela que decide:

| leitor | handler | conta | prova |
|---|---|---|---|
| `:628` | `criar_perfil_local` | **`oben`** | Único chamador (`useUnifiedOrder.handleStaffAddTool`) passa `selectedCustomer.codigo_cliente` — código OBEN — e resolve o MESMO código com `.eq('account','oben')` logo antes de invocar (#1331) |
| `:751` | `sync_all_clients` | **do `account_index`** | `useAnalyticsSync` itera "Conta N/3", 0→2 |
| `:910` | `sync_addresses` | **multi-conta** | Usa o `account` de cada linha da proof |

Divergir da conta do chamador no `criar_perfil_local` anexaria a ferramenta ao **cliente errado** (Codex P2). Há uma canária cross-file que amarra os dois lados.

## Bugs corrigidos pela própria troca de fonte

1. **Cap de 1.000 silencioso** — o dedup do `sync_all_clients` fazia `.select()` **sem `.range()`**: via 1.000 de 6.909 códigos (1/7) e reprocessava o resto. Agora pagina com `.order` estável e filtra a conta do lote.
2. **Fail-open nos pré-loads** — ambos engoliam o erro da query. Set vazio faria o loop **recriar milhares de clientes**; mapeamentos vazios virariam `"No client mappings found"` — um no-op mudo que parece sucesso. Agora fail-closed (Codex P2 do PR-2).
3. **Chute nas 3 contas** — `sync_addresses` testava o mesmo código indeterminado nas 3 contas até uma responder (até 3x chamadas Omie). Agora consulta só as contas onde o user tem cadastro, cada uma com o código daquela conta.

`OmieAccountConfig` ganhou **slug canônico**: o `name` é rótulo de UI (`buscar_logos_empresas` já erra ao casar por nome) e o índice de `getOmieAccounts()` é **instável** — a lista é montada condicionalmente, então faltar `OMIE_OBEN_APP_KEY` faria o índice 1 virar Colacor e o filtro de conta mentir em silêncio.

## Provas

- **7 canárias textuais** novas — pegam a reversão do deploy do Lovable (armadilha do #1272).
- **Falsificadas**: 5 sabotagens independentes (voltar ao espelho · tirar o filtro de conta · tirar a paginação · engolir o erro · o chamador trocar de conta) → **todas produziram vermelho**. O guardrail morde.
- `deno check` verde · suíte **5217/5217** · typecheck · lint (0 erros).
- Sem SQL novo → sem prove-sql.
- Grant confirmado: a view tem `service_role=arwdDxtm` (`security_invoker=true` + service role → lê tudo); precedente do `omie-sync` já em prod.

## Estado do épico

`omie_clientes` no edge cai a **3 ocorrências, todas writers** (`.insert`). Depois desta PR, restam como leitores só os 4 do `omie-analytics-sync` (**PR-B — bloqueado até a Fatia 2 mergear**, mesmo arquivo).

⚠️ **Deploy:** edge pelo chat do Lovable (verbatim). Sem migration, sem Publish (não toca runtime de `src/` — só o teste).

🤖 Generated with [Claude Code](https://claude.com/claude-code)