### PR TITLE
fix(omie): snapshot de não-vinculados lê a proof por conta (Fatia 3-edges PR-B) [money-path]

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1241,6 +1241,67 @@ describe('guardrail money-path: omie-sync-sku-items (fila de leadtime)', () => {
   });
 });
 
+// ── Fatia 3-edges PR-B (omie-analytics-sync: o snapshot de não-vinculados lê a proof por conta) ──
+// classifyClienteForSnapshot decide se um cliente Omie entra no relatório omie_clientes_nao_vinculados:
+// código no Set = "linked" (fica de fora). O Set vinha do espelho omie_clientes SEM filtro de conta —
+// mas o espelho é UNIQUE(user_id) (1 linha/user, sobrescrita pelo writer da vez, hoje dominado por oben)
+// e por isso NÃO contém os códigos das outras contas. Medido em prod (2026-07-16), códigos da proof
+// ausentes do espelho: colacor 5.148/5.148 (100%), colacor_sc 3.604/5.275 (68%), oben 0/5.238 (0%).
+// Rodar o snapshot de colacor/colacor_sc reportava clientes VINCULADOS como não-vinculados em massa;
+// só oben roda hoje, o que mascarava o furo. Agora o Set vem da fresca com .eq("account", empresa).
+// Os outros omie_clientes deste edge NÃO migram nesta PR e o motivo é estrutural, não esquecimento:
+//   • :238 fetchOmieClienteUserMap alimenta o upsertByUser CODE-FIRST → é a leitura de suporte do
+//     WRITER do espelho (:515), par indivisível: morre junto com ele na Fatia 4;
+//   • :1669 fetchAlvosSemProfile / :1890 fetchOmieCodigoPorUser operam sobre os CLONES (user sem
+//     profile). Medido: 1.633 alvos pelo espelho, 0 pela proof (clone não tem linha lá), 1.633 pelo
+//     ledger — mas o ledger não tem omie_codigo_cliente, e essas funções precisam do par
+//     (clone → código). Migrá-las p/ a proof zeraria syncBackfillCadastro e mapaConsolidacao em
+//     SILÊNCIO. Bloqueio de design escalado — o DROP (Fatia 5) depende de resolvê-lo.
+const OMIE_ANALYTICS = 'supabase/functions/omie-analytics-sync/index.ts';
+
+describe('guardrail money-path: snapshot de não-vinculados lê a proof por conta (Fatia 3-edges PR-B)', () => {
+  const src = read(OMIE_ANALYTICS);
+
+  it('sentinela: leu o arquivo real (edge)', () => {
+    expect(src).toContain('syncNaoVinculados');
+    expect(src).toContain('classifyClienteForSnapshot');
+  });
+
+  it('o Set de "já vinculados" vem da fresca, filtrado pela conta do run, paginado com .order', () => {
+    expect(
+      src,
+      'REVERSÃO Lovable? o Set de vinculados não lê a fresca com .eq("account", empresa) + .order + .range',
+    ).toMatch(
+      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,120}\.eq\("account", empresa\)[\s\S]{0,240}\.order\("omie_codigo_cliente"\)[\s\S]{0,120}\.range\(/,
+    );
+    // A conta TEM de chegar na função: sem o parâmetro o Set volta a ser global (o bug).
+    expect(
+      src,
+      'REGRESSÃO: fetchAllOmieClienteCodigos perdeu o parâmetro de conta — Set global de novo',
+    ).toMatch(/async function fetchAllOmieClienteCodigos\(db: SupabaseClient, empresa: Empresa\)/);
+    expect(
+      src,
+      'REGRESSÃO: o chamador não passa mais a empresa do run para o Set de vinculados',
+    ).toMatch(/fetchAllOmieClienteCodigos\(db, empresa\)/);
+  });
+
+  it('o Set de vinculados NÃO voltou ao espelho poluído', () => {
+    expect(
+      src,
+      'REGRESSÃO: fetchAllOmieClienteCodigos voltou a ler omie_clientes (Set global → falso não-vinculado)',
+    ).not.toMatch(/fetch omie_clientes codigos/);
+  });
+
+  it('os omie_clientes restantes são o writer + as 2 funções de CLONE (bloqueadas), nunca mais', () => {
+    // Trava o escopo: 4 = :238 (leitura de suporte do writer) + :515 (upsert) + fetchAlvosSemProfile
+    // + fetchOmieCodigoPorUser. Se virar 5, alguém reabriu uma leitura do espelho neste edge.
+    expect(
+      count(src, '.from("omie_clientes")'),
+      'omie_clientes mudou de contagem neste edge — leitura nova do espelho ou migração não registrada aqui',
+    ).toBe(4);
+  });
+});
+
 // ── Fatia 3-edges PR-A (omie-cliente: os 3 LEITORES saem do espelho → proof fresca account-correta) ──
 // Os 3 leitores do edge de cadastro resolviam identidade por um código de conta INDETERMINADA. O espelho
 // omie_clientes é UNIQUE(user_id) — 1 linha por user, sobrescrita pelo writer da vez (oben, colacor_sc…) —

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -629,16 +629,29 @@ function classifyClienteForSnapshot(
 }
 
 // Lê TODOS os omie_codigo_cliente de omie_clientes (paginado p/ furar o cap de 1000 do PostgREST).
-async function fetchAllOmieClienteCodigos(db: SupabaseClient): Promise<Set<number>> {
+// Códigos JÁ vinculados NA CONTA do run, pela proof fresca account-correta. Alimenta o
+// classifyClienteForSnapshot: um código presente aqui é "linked" e NÃO entra no relatório de
+// não-vinculados. Antes vinha do espelho omie_clientes SEM filtro de conta — e o espelho é
+// UNIQUE(user_id) (1 linha/user, sobrescrita pelo writer da vez, hoje dominado por oben), então
+// ele NÃO contém os códigos das outras contas: medido em prod, dos códigos da proof faltavam no
+// espelho 5.148/5.148 (colacor, 100%) e 3.604/5.275 (colacor_sc, 68%) contra 0/5.238 (oben).
+// Consequência: rodar o snapshot de colacor/colacor_sc classificaria clientes VINCULADOS como
+// não-vinculados em massa (o relatório de oben, o único que roda hoje, mascarava o furo).
+// A fresca é UNIQUE(omie_codigo_cliente, account) → o Set é exatamente a conta do run.
+async function fetchAllOmieClienteCodigos(db: SupabaseClient, empresa: Empresa): Promise<Set<number>> {
   const set = new Set<number>();
   const pageSize = 1000;
   let from = 0;
   while (true) {
     const { data, error } = await db
-      .from("omie_clientes")
+      .from("omie_customer_account_map_fresco")
       .select("omie_codigo_cliente")
+      .eq("account", empresa)
+      // .order estável: sem ele o .range pagina sobre ordem indefinida (armadilha PostgREST) e
+      // uma linha pode repetir ou sumir entre páginas — num Set de dedup, sumir vira falso "unlinked".
+      .order("omie_codigo_cliente")
       .range(from, from + pageSize - 1);
-    if (error) throw new Error(`fetch omie_clientes codigos: ${error.message}`);
+    if (error) throw new Error(`fetch codigos vinculados (${empresa}): ${error.message}`);
     const rows = (data ?? []) as { omie_codigo_cliente: number | null }[];
     for (const r of rows) if (r.omie_codigo_cliente != null) set.add(Number(r.omie_codigo_cliente));
     if (rows.length < pageSize) break;
@@ -680,7 +693,9 @@ async function syncNaoVinculados(db: SupabaseClient, account: OmieAccount) {
 
   try {
     // 2 leituras em massa (sets) — substitui ~2 queries POR cliente do laço de linking.
-    const codigosVinculados = await fetchAllOmieClienteCodigos(db);
+    // `empresa` (=accountToEmpresa(account)) escopa os códigos à conta DESTE run — ver a nota em
+    // fetchAllOmieClienteCodigos: o Set global do espelho classificava errado fora de oben.
+    const codigosVinculados = await fetchAllOmieClienteCodigos(db, empresa);
     const docsComProfile = await fetchAllProfileDocs(db);
 
     const naoVinculados: NaoVinculadoRow[] = [];


### PR DESCRIPTION
Fatia 3-edges **PR-B**. Migra o leitor do snapshot de não-vinculados no `omie-analytics-sync` para a proof account-correta. Escopo menor que o planejado — o porquê está abaixo, com medição.

## O bug que isto conserta

`classifyClienteForSnapshot` decide se um cliente Omie entra no relatório `omie_clientes_nao_vinculados`: código no Set = `"linked"` → fica de fora. O Set vinha do espelho `omie_clientes` **sem filtro de conta**. Mas o espelho é `UNIQUE(user_id)` — 1 linha por user, sobrescrita pelo writer da vez — e hoje está **dominado pela Oben**.

Códigos da proof **ausentes do espelho** (psql-ro, prod, 2026-07-16):

| conta | códigos | ausentes do espelho |
|---|---|---|
| `colacor` | 5.148 | **5.148 (100%)** |
| `colacor_sc` | 5.275 | **3.604 (68%)** |
| `oben` | 5.238 | 0 (0%) |

Rodar o snapshot de `colacor`/`colacor_sc` classificaria clientes **vinculados** como não-vinculados **em massa**. O relatório hoje só tem linhas de `oben` (a única conta que roda) — foi isso que mascarou o furo.

Agora o Set vem de `omie_customer_account_map_fresco` com `.eq("account", empresa)` + `.order` estável no `.range` (sem `.order`, o range pagina sobre ordem indefinida e uma linha sumida entre páginas vira falso `"unlinked"`).

## Por que só 1 dos 4 leitores

O handoff previa migrar 4. A leitura do código mostrou que os outros 3 não são leitores independentes:

- **`fetchOmieClienteUserMap` (~:238)** alimenta o `upsertByUser` **CODE-FIRST**, que é o **writer do espelho** (~:515). É a leitura de suporte do writer — par indivisível, igual ao `AdminApprovals` do handoff §4. Migra junto na **Fatia 4**. (A proof, `accountMapByUser`, já usa `userByDoc` document-first.)
- **`fetchAlvosSemProfile` (~:1669)** e **`fetchOmieCodigoPorUser` (~:1890)** operam sobre os **clones** (user sem profile):

| fonte | alvos do backfill/consolidação |
|---|---|
| espelho (hoje) | **1.633** |
| **proof** | **0** ← zeraria os dois fluxos, em silêncio |
| **ledger** | **1.633** ✅ |

O ledger tem os alvos, mas suas colunas são `user_id, identity_state, first_seen_at, source, updated_at` — **sem `omie_codigo_cliente`**, e essas funções precisam do par (clone → código). O handoff §3 apostava no ledger por causa do `created_at`; o `created_at` ele resolve (`first_seen_at` idêntico em **6.909/6.909**, verificado), o código não.

**Bloqueio de design escalado em chip** — o DROP (Fatia 5) depende de resolvê-lo.

## Provas

- 4 canárias novas. A última **trava a contagem** de `omie_clientes` do edge em 4 (writer + leitura de suporte + as 2 funções de clone), então uma leitura nova do espelho não passa despercebida.
- `deno check` verde · suíte do arquivo 115/115.
- Sem SQL novo → sem prove-sql.

⚠️ **Deploy:** edge pelo chat do Lovable (verbatim), **após o merge**. Sem migration, sem Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)