### PR TITLE
feat(afiacao): recomendações consultivas na Central da Ferramenta (PR3 benchmark #13)

### DIFF
--- a/src/components/CustomerDashboard.tsx
+++ b/src/components/CustomerDashboard.tsx
@@ -14,7 +14,6 @@ import { PriorityCard } from '@/components/customerDashboard/PriorityCard';
 import { GamificationMini } from '@/components/customerDashboard/GamificationMini';
 import { PedidosAndamento } from '@/components/customerDashboard/PedidosAndamento';
 import { FerramentasAtencao } from '@/components/customerDashboard/FerramentasAtencao';
-import { RecomendacoesCliente } from '@/components/customerDashboard/RecomendacoesCliente';
 import { AcoesRapidas } from '@/components/customerDashboard/AcoesRapidas';
 import { CentralEntryCard } from '@/components/customerDashboard/CentralEntryCard';
 import type { Profile, Order, UserTool } from '@/components/customerDashboard/types';
@@ -95,8 +94,8 @@ export function CustomerDashboard({ profile, pendingOrders, userTools, getGreeti
           </motion.section>
         )}
 
-        {/* ─── Recomendações consultivas determinísticas (PR2 · benchmark #13) ─── */}
-        <RecomendacoesCliente userTools={userTools} navigate={navigate} />
+        {/* Recomendações consultivas (benchmark #13) migraram para a Central da
+            Ferramenta (/central) — lar consultivo do ciclo da afiação. */}
 
         {/* ─── SEÇÃO 4: Ações Rápidas ─── */}
         <motion.section variants={fadeUp}>

--- a/src/components/customerDashboard/CentralEntryCard.tsx
+++ b/src/components/customerDashboard/CentralEntryCard.tsx
@@ -24,7 +24,7 @@ export function CentralEntryCard({ navigate }: CentralEntryCardProps) {
           <div className="min-w-0 flex-1">
             <p className="font-semibold text-foreground">Central da Ferramenta</p>
             <p className="text-sm text-muted-foreground">
-              Economia, ferramentas, agendamentos e pedidos num só lugar
+              Recomendações, economia, ferramentas e pedidos num só lugar
             </p>
           </div>
           <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0" />

--- a/src/components/customerDashboard/RecomendacoesCliente.tsx
+++ b/src/components/customerDashboard/RecomendacoesCliente.tsx
@@ -12,12 +12,14 @@ import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDeliveredOrders12m } from '@/queries/useOrders';
 import { track } from '@/lib/analytics';
-import { gerarRecomendacoes, resumirEconomia, type ToolInput, type Recomendacao } from '@/lib/afiacao/recomendacoes';
+import { gerarRecomendacoes, filtrarRecomendacoes, resumirEconomia, type ToolInput, type Recomendacao } from '@/lib/afiacao/recomendacoes';
 import type { UserTool } from './types';
 
 interface RecomendacoesClienteProps {
   userTools: UserTool[];
   navigate: ReturnType<typeof useNavigate>;
+  /** Tipos a NÃO exibir nesta tela. Ex.: a Central oculta 'economia' — já tem o herói. */
+  ocultarTipos?: Recomendacao['tipo'][];
 }
 
 const brl = (v: number) => `R$ ${Math.round(v).toLocaleString('pt-BR')}`;
@@ -28,7 +30,7 @@ function nomesResumidos(ferramentas: { nome: string }[]): string {
   return resto > 0 ? `${nomes.join(', ')} +${resto}` : nomes.join(', ');
 }
 
-export function RecomendacoesCliente({ userTools, navigate }: RecomendacoesClienteProps) {
+export function RecomendacoesCliente({ userTools, navigate, ocultarTipos }: RecomendacoesClienteProps) {
   const { user } = useAuth();
   const { data: orders = [] } = useDeliveredOrders12m(user?.id);
 
@@ -41,8 +43,9 @@ export function RecomendacoesCliente({ userTools, navigate }: RecomendacoesClien
       sharpening_interval_days: t.sharpening_interval_days,
       suggested_interval_days: t.tool_categories?.suggested_interval_days ?? null,
     }));
-    return gerarRecomendacoes({ tools, economia: resumirEconomia(orders) });
-  }, [userTools, orders]);
+    const geradas = gerarRecomendacoes({ tools, economia: resumirEconomia(orders) });
+    return filtrarRecomendacoes(geradas, ocultarTipos ?? []);
+  }, [userTools, orders, ocultarTipos]);
 
   if (recomendacoes.length === 0) return null;
 

--- a/src/lib/afiacao/recomendacoes.test.ts
+++ b/src/lib/afiacao/recomendacoes.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   gerarRecomendacoes,
+  filtrarRecomendacoes,
   resumirEconomia,
   CUSTO_MEDIO_FERRAMENTA_NOVA_BRL,
   type ToolInput,
@@ -238,5 +239,31 @@ describe('resumirEconomia — parse defensivo dos itens (jsonb)', () => {
       { items: undefined as unknown as unknown[], total: 50 },
     ]);
     expect(res).toEqual({ totalAfiacoes: 0, totalGastoReal: 50 });
+  });
+});
+
+describe('filtrarRecomendacoes — corte de apresentação por tela', () => {
+  const atrasada: Recomendacao = { tipo: 'possivelmente_atrasada', ferramentas: [{ id: 'a', nome: 'Serra' }] };
+  const semProg: Recomendacao = { tipo: 'sem_programacao', ferramentas: [{ id: 'b', nome: 'Faca' }] };
+  const eco: Recomendacao = { tipo: 'economia', economiaComprovada: 500, economiaPotencial: 100, nAtrasadas: 2 };
+  const todas: Recomendacao[] = [atrasada, semProg, eco];
+
+  it('sem tipos a ocultar → devolve tudo na mesma ordem', () => {
+    expect(filtrarRecomendacoes(todas, [])).toEqual(todas);
+  });
+
+  it("oculta 'economia' (a Central já tem o herói) preservando as consultivas", () => {
+    const r = filtrarRecomendacoes(todas, ['economia']);
+    expect(r.map((x) => x.tipo)).toEqual(['possivelmente_atrasada', 'sem_programacao']);
+  });
+
+  it('ocultar todos os tipos presentes → lista vazia (dispara o null no componente)', () => {
+    expect(filtrarRecomendacoes(todas, ['possivelmente_atrasada', 'sem_programacao', 'economia'])).toEqual([]);
+  });
+
+  it('é puro: não muta o array de entrada', () => {
+    const entrada = [...todas];
+    filtrarRecomendacoes(entrada, ['economia']);
+    expect(entrada).toEqual(todas);
   });
 });

--- a/src/lib/afiacao/recomendacoes.ts
+++ b/src/lib/afiacao/recomendacoes.ts
@@ -151,6 +151,20 @@ export function gerarRecomendacoes(input: GerarRecomendacoesInput): Recomendacao
 }
 
 /**
+ * Corte de APRESENTAÇÃO por tela: remove os tipos em `ocultarTipos`, preservando
+ * a ordem dos demais. Ex.: a Central da Ferramenta já exibe um herói de economia,
+ * então oculta ali o card 'economia' (não duplicar). Puro — não muta a entrada;
+ * se o resultado ficar vazio, o consumidor não renderiza a seção (sem header órfão).
+ */
+export function filtrarRecomendacoes(
+  recs: Recomendacao[],
+  ocultarTipos: Recomendacao['tipo'][],
+): Recomendacao[] {
+  if (ocultarTipos.length === 0) return recs;
+  return recs.filter((r) => !ocultarTipos.includes(r.tipo));
+}
+
+/**
  * Agrega pedidos entregues em totais REAIS. Parse defensivo do jsonb `items`:
  * item sem quantidade conta como 1 (espelha o SavingsDashboard); items não-array
  * e total nulo viram 0 — nunca quebram nem fabricam número.

--- a/src/pages/CentralFerramenta.tsx
+++ b/src/pages/CentralFerramenta.tsx
@@ -15,6 +15,12 @@ import { useSavingsSummary } from '@/queries/useSavings';
 import { useUserToolsSummary } from '@/queries/useUserTools';
 import { useActiveRecurringSchedules } from '@/queries/useRecurringSchedules';
 import { useCustomerPendingOrders } from '@/queries/useOrders';
+import { RecomendacoesCliente } from '@/components/customerDashboard/RecomendacoesCliente';
+import type { Recomendacao } from '@/lib/afiacao/recomendacoes';
+
+// A Central já traz o herói de economia no topo — aqui as recomendações omitem o
+// card 'economia' (não duplicar) e mostram só as consultivas (atraso / sem programação).
+const RECOMENDACOES_OCULTAR_NA_CENTRAL: Recomendacao['tipo'][] = ['economia'];
 
 /** R$ com separador de milhar (mesmo formato do painel de economia). */
 function formatBRL(v: number): string {
@@ -183,6 +189,14 @@ const CentralFerramenta = () => {
           </CardContent>
         </Card>
       </button>
+
+      {/* Recomendações consultivas determinísticas (benchmark #13). 'economia' fica
+          de fora — o herói acima já cobre; aqui só atraso / sem programação. */}
+      <RecomendacoesCliente
+        userTools={tools}
+        navigate={navigate}
+        ocultarTipos={RECOMENDACOES_OCULTAR_NA_CENTRAL}
+      />
 
       <HubCard
         icon={Wrench}

--- a/src/pages/__tests__/CentralFerramenta.test.tsx
+++ b/src/pages/__tests__/CentralFerramenta.test.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useSavingsSummary } from '@/queries/useSavings';
 import { useUserToolsSummary } from '@/queries/useUserTools';
 import { useActiveRecurringSchedules } from '@/queries/useRecurringSchedules';
-import { useCustomerPendingOrders } from '@/queries/useOrders';
+import { useCustomerPendingOrders, useDeliveredOrders12m } from '@/queries/useOrders';
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (io) => ({
@@ -23,7 +23,14 @@ const EMPTY_SUMMARY = { monthlyData: [], totalTools: 0, totalSpent: 0, totalSavi
 
 interface Overrides {
   summary?: typeof EMPTY_SUMMARY;
-  tools?: Array<{ id: string; next_sharpening_due: string | null }>;
+  tools?: Array<{
+    id: string;
+    next_sharpening_due: string | null;
+    last_sharpened_at?: string | null;
+    sharpening_interval_days?: number | null;
+    tool_categories?: { name: string; suggested_interval_days: number | null };
+  }>;
+  deliveredOrders?: Array<{ items: unknown; total: number | null }>;
   schedules?: Array<{ id: string; next_order_date: string }>;
   orders?: Array<{ id: string; status: string }>;
   savingsLoading?: boolean;
@@ -59,6 +66,10 @@ function setup(over: Overrides = {}) {
     isLoading: over.ordersLoading ?? false,
     isError: over.ordersError ?? false,
   } as unknown as ReturnType<typeof useCustomerPendingOrders>);
+  // RecomendacoesCliente (embutido na Central) busca os entregues p/ a economia.
+  vi.mocked(useDeliveredOrders12m).mockReturnValue({
+    data: over.deliveredOrders ?? [],
+  } as unknown as ReturnType<typeof useDeliveredOrders12m>);
   return render(
     <MemoryRouter>
       <CentralFerramenta />
@@ -157,5 +168,26 @@ describe('CentralFerramenta', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /economia/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/savings');
+  });
+
+  it('mostra recomendação consultiva (atraso) mas NUNCA o card de economia — o herói já cobre', () => {
+    const { container } = setup({
+      summary: { ...EMPTY_SUMMARY, totalTools: 5, totalSpent: 500, totalSavings: 1500, savingsPercent: 75 },
+      tools: [
+        {
+          id: 't1',
+          next_sharpening_due: null, // não-agendada
+          last_sharpened_at: '2020-01-01', // muito no passado → sempre atrasada (teste estável)
+          sharpening_interval_days: 30,
+          tool_categories: { name: 'Plaina', suggested_interval_days: null },
+        },
+      ],
+      // Economia REAL existiria (10 afiações a R$500 vs. R$250/nova) — mas o card fica OCULTO na Central.
+      deliveredOrders: [{ items: [{ quantity: 10 }], total: 500 }],
+    });
+    const txt = container.textContent ?? '';
+    expect(txt).toContain('Recomendações para você');
+    expect(txt).toContain('passando do ponto de afiação'); // possivelmente_atrasada aparece
+    expect(txt).not.toContain('Você já economizou'); // card 'economia' suprimido (herói cobre)
   });
 });


### PR DESCRIPTION
## PR-3 (Onda 1, benchmark #13) — recomendações consultivas na Central

Terceiro PR do programa de benchmark competitivo. Com a **Central da Ferramenta** (PR1, #1323) em produção, as recomendações consultivas determinísticas do **PR2** (#1327) migram do dashboard do cliente para a Central — o *lar* do ciclo da afiação.

### Por quê
O objetivo original do #13 pedia "encaixar na Central se ela existir, senão no dashboard". Quando o PR2 foi feito a Central ainda não estava disponível → caiu no dashboard (plano B). Agora que existe, as recomendações voltam ao lar preferido. Bônus: enxuga a home, que já sinaliza urgência de ferramenta via `PriorityCard` + `FerramentasAtencao`.

### Decisão (Claude + Codex)
Ritual de 2ª opinião (Codex) convergiu com a análise: **mover puro** — não espelhar (redundância no mesmo fluxo), não badge-com-fetch (acoplaria o card de entrada). 4ª via do Codex adotada: ajustar a **copy estática** do `CentralEntryCard` p/ citar "Recomendações" — sinaliza o valor na home sem fetch nem contador.

### Mudanças
- `filtrarRecomendacoes(recs, ocultarTipos)` — corte de apresentação **puro** (não muta; vazio→`null` no consumidor). TDD.
- `RecomendacoesCliente` ganha prop opcional `ocultarTipos`; a Central passa `['economia']` (o herói de economia dela já cobre — não duplicar).
- Remove a seção do `CustomerDashboard`; `CentralFerramenta` renderiza o bloco abaixo do herói (narrativa economia → ação → navegação).
- Teste da Central: prova que a recomendação de atraso aparece e o card `economia` fica oculto **mesmo havendo economia real**.

### Money-path preservado
Geração inalterada: só regra determinística sobre dado confiável; ausente ≠ zero; na dúvida a recomendação não é gerada. O filtro é **só apresentação**.

### Deploy
Frontend puro — **sem migration, sem edge**. Precisa de 🖱️ **Publish** no Lovable.

### Follow-up (risco apontado pelo Codex)
Se `sem_programacao` perder relevância p/ quem nunca abre a Central, promover a recomendação mais importante via `PriorityCard` — em vez de devolver a seção inteira à home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
