### PR TITLE
fix(seguranca): restaura security_invoker em 5 views — customer/anon liam dado interno [money-path]

### DIFF
--- a/db/test-security-invoker-views.sh
+++ b/db/test-security-invoker-views.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA — restaurar security_invoker=on em 5 views (fix de SEGURANÇA)          ║
+# ║  bash db/test-security-invoker-views.sh > /tmp/t.log 2>&1; echo "exit=$?"     ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                      ║
+# ║                                                                               ║
+# ║  Lei de Ferro:                                                                ║
+# ║   1. Aplica a migration REAL (psql -f). Os PRÉ-REQUISITOS (tabela+RLS+views)  ║
+# ║      são stubs fiéis: o snapshot NÃO é restore-ready (124 erros de ordem de   ║
+# ║      dependência; nem chega a criar 2 das 5 views).                           ║
+# ║   2. Assert negativo captura a condição esperada; nada de WHEN OTHERS mudo.   ║
+# ║   3. Falsificação: desfaz o fix → exige VERMELHO → restaura.                  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="secinvoker"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: reproduz o estado de PROD (medido via psql-ro 2026-07-16)
+#   • app_role/has_role: assinatura real -> has_role(_user_id uuid, _role app_role)
+#   • tabela-base com RLS staff-only, idêntica em forma à policy real de
+#     sku_leadtime_history: has_role(uid,'master') OR has_role(uid,'employee')
+#   • as 5 views: owner=postgres, SEM gate próprio no corpo, e SEM security_invoker
+#     (é exatamente o estado regredido da prod)
+#   • grants conforme a relacl real: anon tem SELECT só em v_sku_sla_compliance;
+#     authenticated tem SELECT nas 5.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE app_role AS ENUM ('master','employee','customer');
+
+CREATE TABLE user_roles (user_id uuid NOT NULL, role app_role NOT NULL);
+
+CREATE FUNCTION has_role(_user_id uuid, _role app_role) RETURNS boolean
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $f$
+  SELECT EXISTS (SELECT 1 FROM user_roles ur WHERE ur.user_id = _user_id AND ur.role = _role)
+$f$;
+
+-- tabela-base: dado INTERNO de reposição, protegido por RLS staff-only.
+CREATE TABLE sku_leadtime_history (
+  id bigserial PRIMARY KEY,
+  empresa text,
+  sku_codigo_omie text,
+  fornecedor_nome text,
+  lt_bruto_dias_uteis int
+);
+ALTER TABLE sku_leadtime_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY staff_sku_leadtime_history_all ON sku_leadtime_history
+  FOR ALL TO authenticated
+  USING ( (SELECT has_role((SELECT auth.uid()), 'master') OR has_role((SELECT auth.uid()), 'employee')) );
+CREATE POLICY service_all_sku_leadtime_history ON sku_leadtime_history
+  FOR ALL TO service_role USING (true);
+
+-- As 5 views, como estão HOJE na prod: sem WITH (security_invoker) e sem gate no corpo.
+CREATE VIEW v_sku_sla_compliance AS
+  SELECT empresa, sku_codigo_omie, fornecedor_nome, avg(lt_bruto_dias_uteis) AS lt_medio
+  FROM sku_leadtime_history GROUP BY 1,2,3;
+CREATE VIEW v_sku_candidatos_primeira_compra AS
+  SELECT empresa, sku_codigo_omie, fornecedor_nome FROM sku_leadtime_history;
+CREATE VIEW v_sku_demanda_estatisticas AS
+  SELECT empresa, sku_codigo_omie, count(*) AS n FROM sku_leadtime_history GROUP BY 1,2;
+CREATE VIEW v_sku_demanda_rajada AS
+  SELECT empresa, sku_codigo_omie, max(lt_bruto_dias_uteis) AS pico FROM sku_leadtime_history GROUP BY 1,2;
+CREATE VIEW v_sku_sigma_demanda AS
+  SELECT empresa, sku_codigo_omie, stddev_samp(lt_bruto_dias_uteis) AS sigma FROM sku_leadtime_history GROUP BY 1,2;
+
+-- grants conforme relacl real da prod
+GRANT SELECT ON v_sku_sla_compliance TO anon, authenticated;          -- anon=ar... (tem r)
+GRANT SELECT ON v_sku_candidatos_primeira_compra TO authenticated;    -- anon=aw... (sem r)
+GRANT SELECT ON v_sku_demanda_estatisticas       TO authenticated;
+GRANT SELECT ON v_sku_demanda_rajada             TO authenticated;
+GRANT SELECT ON v_sku_sigma_demanda              TO authenticated;
+-- ⚠️ FIEL À PROD: anon E authenticated TÊM GRANT SELECT na tabela-base (medido via
+-- psql-ro: has_table_privilege('anon','sku_leadtime_history','SELECT') = true). Quem barra
+-- o anon é o RLS — a policy é `TO authenticated`, então o anon não casa nenhuma e leva 0
+-- linhas. Sem este grant o stub daria "permission denied" e o teste provaria uma negação
+-- (falta de grant) que NÃO é a que roda em produção (RLS). É a lição do CLAUDE.md:
+-- "REVOKE FROM PUBLIC não tira anon/authenticated".
+GRANT SELECT ON sku_leadtime_history TO authenticated, anon;
+-- BYPASSRLS não dispensa GRANT: sem isto o seed abaixo dá "permission denied".
+GRANT ALL ON sku_leadtime_history TO service_role;
+GRANT ALL ON SEQUENCE sku_leadtime_history_id_seq TO service_role;
+GRANT SELECT ON user_roles TO authenticated, anon;
+
+INSERT INTO user_roles(user_id, role) VALUES
+  ('11111111-1111-1111-1111-111111111111','customer'),
+  ('22222222-2222-2222-2222-222222222222','employee');
+SQL
+
+# seed do dado sensível (como service_role, que tem BYPASSRLS)
+P -q <<'SQL'
+SET ROLE service_role;
+INSERT INTO sku_leadtime_history(empresa, sku_codigo_omie, fornecedor_nome, lt_bruto_dias_uteis)
+VALUES ('OBEN','SKU-1','FORNECEDOR CONFIDENCIAL',10),
+       ('OBEN','SKU-1','FORNECEDOR CONFIDENCIAL',20);
+RESET ROLE;
+SQL
+
+# Helpers de impersonação.
+# ⚠️ SET LOCAL SÓ vale dentro de transação — fora dela o Postgres emite apenas um WARNING
+# e SEGUE COMO SUPERUSER. Sem o BEGIN/COMMIT o teste inteiro mede a leitura do postgres e
+# pinta verde por acidente (mordeu ao escrever este harness: as falsificações "passaram"
+# comparando a string "SET\nSET\n1" com "1"). Daí o BEGIN + o filtro numérico estrito.
+_conta() {  # $1 = SQL de identidade, $2 = view
+  P -tAq <<SQL 2>/dev/null | grep -E '^[0-9]+$' | tail -1
+BEGIN;
+$1
+SELECT count(*) FROM $2;
+COMMIT;
+SQL
+}
+como_customer() { _conta "SET LOCAL ROLE authenticated; SET LOCAL test.uid = '11111111-1111-1111-1111-111111111111';" "$1"; }
+como_staff()    { _conta "SET LOCAL ROLE authenticated; SET LOCAL test.uid = '22222222-2222-2222-2222-222222222222';" "$1"; }
+como_anon()     { _conta "SET LOCAL ROLE anon;" "$1"; }
+
+echo ""
+echo "═══ 1. O BUG reproduzido (estado atual da PROD: invoker OFF) ═══"
+# Se estes derem 0, o cenário não reproduz o bug e todo o resto é teatro.
+eq "customer LÊ v_sku_sla_compliance (vazamento)"             "$(como_customer v_sku_sla_compliance)"             "1"
+eq "customer LÊ v_sku_candidatos_primeira_compra (vazamento)" "$(como_customer v_sku_candidatos_primeira_compra)" "2"
+eq "customer LÊ v_sku_demanda_estatisticas (vazamento)"       "$(como_customer v_sku_demanda_estatisticas)"       "1"
+eq "customer LÊ v_sku_demanda_rajada (vazamento)"             "$(como_customer v_sku_demanda_rajada)"             "1"
+eq "customer LÊ v_sku_sigma_demanda (vazamento)"              "$(como_customer v_sku_sigma_demanda)"              "1"
+eq "anon LÊ v_sku_sla_compliance SEM LOGIN (vazamento)"       "$(como_anon v_sku_sla_compliance)"                 "1"
+# contraprova de que o RLS existe e morde quando aplicado:
+eq "customer NÃO lê a tabela-base direto (RLS ativo)"         "$(como_customer sku_leadtime_history)"             "0"
+
+echo ""
+echo "═══ 2. Aplicando a migration REAL (Lei #1) ═══"
+P -q -f "$REPO_ROOT/supabase/migrations/20260717015000_restaurar_security_invoker_views.sql"
+echo "  migration aplicada"
+
+echo ""
+echo "═══ 3. O FIX: o vazamento fecha, o staff continua trabalhando ═══"
+eq "customer NÃO lê v_sku_sla_compliance"             "$(como_customer v_sku_sla_compliance)"             "0"
+eq "customer NÃO lê v_sku_candidatos_primeira_compra" "$(como_customer v_sku_candidatos_primeira_compra)" "0"
+eq "customer NÃO lê v_sku_demanda_estatisticas"       "$(como_customer v_sku_demanda_estatisticas)"       "0"
+eq "customer NÃO lê v_sku_demanda_rajada"             "$(como_customer v_sku_demanda_rajada)"             "0"
+eq "customer NÃO lê v_sku_sigma_demanda"              "$(como_customer v_sku_sigma_demanda)"              "0"
+eq "anon NÃO lê v_sku_sla_compliance"                 "$(como_anon v_sku_sla_compliance)"                 "0"
+# o fix não pode quebrar quem TEM direito — senão "seguro" virou "quebrado".
+eq "staff (employee) CONTINUA lendo v_sku_sla_compliance"             "$(como_staff v_sku_sla_compliance)"             "1"
+eq "staff (employee) CONTINUA lendo v_sku_candidatos_primeira_compra" "$(como_staff v_sku_candidatos_primeira_compra)" "2"
+eq "staff (employee) CONTINUA lendo v_sku_sigma_demanda"              "$(como_staff v_sku_sigma_demanda)"              "1"
+eq "as 5 views ficaram com security_invoker=on" \
+   "$(Pq -c "SELECT count(*) FROM pg_class WHERE relname IN ('v_sku_sla_compliance','v_sku_candidatos_primeira_compra','v_sku_demanda_estatisticas','v_sku_demanda_rajada','v_sku_sigma_demanda') AND reloptions::text ILIKE '%security_invoker=on%';")" "5"
+
+echo ""
+echo "═══ 4. Idempotência (o founder pode re-rodar o SQL Editor) ═══"
+P -q -f "$REPO_ROOT/supabase/migrations/20260717015000_restaurar_security_invoker_views.sql"
+eq "re-aplicar a migration mantém o fix"  "$(como_customer v_sku_sla_compliance)"  "0"
+
+echo ""
+echo "═══ 5. FALSIFICAÇÃO (Lei #3) — sabota e EXIGE vermelho ═══"
+# Sabotagem A: desliga o invoker de novo (reproduz a regressão). O assert do fix DEVE falhar.
+P -q -c "ALTER VIEW public.v_sku_sla_compliance RESET (security_invoker);"
+n="$(como_customer v_sku_sla_compliance)"
+if [ "$n" = "0" ]; then
+  bad "FALSIFICAÇÃO A: sabotei (RESET invoker) e o assert seguiu VERDE — assert sem dente"
+else
+  ok "FALSIFICAÇÃO A: com o invoker desligado o customer volta a ler (=$n) — o assert tem dente"
+fi
+P -q -c "ALTER VIEW public.v_sku_sla_compliance SET (security_invoker = on);"
+eq "restaurado após falsificação A" "$(como_customer v_sku_sla_compliance)" "0"
+
+# Sabotagem B: o assert do staff também precisa ter dente. Se a policy sumir, o staff
+# perde acesso — provando que é o RLS (e não um acaso do cenário) que decide a leitura.
+P -q -c "DROP POLICY staff_sku_leadtime_history_all ON sku_leadtime_history;"
+n="$(como_staff v_sku_sla_compliance)"
+if [ "$n" = "1" ]; then
+  bad "FALSIFICAÇÃO B: dropei a policy de staff e ele seguiu lendo — o assert não prova RLS"
+else
+  ok "FALSIFICAÇÃO B: sem a policy o staff para de ler (=$n) — quem autoriza é o RLS"
+fi
+P -q -c "CREATE POLICY staff_sku_leadtime_history_all ON sku_leadtime_history FOR ALL TO authenticated USING ( (SELECT has_role((SELECT auth.uid()), 'master') OR has_role((SELECT auth.uid()), 'employee')) );"
+eq "restaurado após falsificação B" "$(como_staff v_sku_sla_compliance)" "1"
+
+# Sabotagem C: prova que o mecanismo é o CREATE OR REPLACE sem WITH — a causa-raiz.
+# Este é o assert que teria pego o #1354 antes do merge.
+P -q -c "CREATE OR REPLACE VIEW public.v_sku_sla_compliance AS SELECT empresa, sku_codigo_omie, fornecedor_nome, avg(lt_bruto_dias_uteis) AS lt_medio FROM sku_leadtime_history GROUP BY 1,2,3;"
+opt="$(Pq -c "SELECT coalesce(reloptions::text,'NULL') FROM pg_class WHERE relname='v_sku_sla_compliance';")"
+if [ "$opt" = "NULL" ]; then
+  ok "FALSIFICAÇÃO C: CREATE OR REPLACE sem WITH RESETA o invoker (reloptions=NULL) — causa-raiz provada"
+else
+  bad "FALSIFICAÇÃO C: esperava reset silencioso, veio [$opt] — a tese da causa-raiz está errada"
+fi
+n="$(como_customer v_sku_sla_compliance)"
+if [ "$n" = "0" ]; then
+  bad "FALSIFICAÇÃO C: o reset não reabriu o vazamento — cenário não prova o impacto"
+else
+  ok "FALSIFICAÇÃO C: o reset reabre o vazamento (customer lê =$n) — é assim que o #1354 regrediu"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  PASS=$PASS  FAIL=$FAIL"
+echo "═══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/supabase/migrations/20260717015000_restaurar_security_invoker_views.sql
+++ b/supabase/migrations/20260717015000_restaurar_security_invoker_views.sql
@@ -1,0 +1,58 @@
+-- Fix de SEGURANÇA — restaura security_invoker=on em 5 views que o perderam em produção.
+--
+-- ─── O DEFEITO (auditado na prod via psql-ro, 2026-07-16) ─────────────────────────────
+-- Cinco views de public estão hoje SEM `security_invoker`. Todas têm owner=postgres
+-- (superuser) e NENHUMA tem gate próprio no corpo (nem auth.uid(), nem has_role()) — elas
+-- sempre dependeram do RLS das tabelas-base para autorizar. Com o invoker desligado, a
+-- view lê as tabelas com a identidade do OWNER, e o RLS dessas tabelas — que é staff-only
+-- (`has_role(uid,'master') OR has_role(uid,'employee')`) — deixa de ser aplicado.
+-- Resultado: a view devolve tudo para quem tem SELECT nela.
+--
+--   view                              | grant       | consequência
+--   v_sku_sla_compliance              | anon + auth | leitura SEM LOGIN (PostgREST expõe public)
+--   v_sku_candidatos_primeira_compra  | auth        | qualquer customer logado
+--   v_sku_demanda_estatisticas        | auth        | qualquer customer logado
+--   v_sku_demanda_rajada              | auth        | qualquer customer logado
+--   v_sku_sigma_demanda               | auth        | qualquer customer logado
+--
+-- Conteúdo exposto: fornecedor, lead time, SLA, demanda, sigma e candidatos de compra com
+-- preço — dado interno de reposição, para uma base cujo papel dominante é `customer`.
+--
+-- ─── A CAUSA: CREATE OR REPLACE VIEW **sem** o WITH RESETA a opção ────────────────────
+-- Não é "não muda"; é reset silencioso. Provado no PG17 (db/test-security-invoker-views.sh):
+--     CREATE OR REPLACE VIEW vw WITH (security_invoker = on) AS ...  -> {security_invoker=on}
+--     CREATE OR REPLACE VIEW vw AS ...                              -> NULL  (= definer)
+-- O CREATE OR REPLACE não preserva reloptions omitidas. Toda recriação precisa REPETIR o
+-- WITH — e nada no CI pega isso, porque o SQL é válido e a view segue funcionando: só a
+-- autorização muda, e muda para MAIS permissiva (falha aberta, não fechada).
+--
+-- ─── ORIGEM DE CADA UMA (rastreado; o snapshot de 2026-06-27 é a testemunha) ──────────
+-- O snapshot traz as 5 com WITH (security_invoker='on') ⇒ todas JÁ estiveram corretas.
+--   • v_sku_sla_compliance → regressão do #1354 (20260716230000), que recriou a view com
+--     `CREATE OR REPLACE VIEW public.v_sku_sla_compliance AS` (sem o WITH). Rastro no repo.
+--   • as outras 4 → nenhuma migration do repo as recria sem o WITH (as 4 de
+--     v_sku_candidatos_primeira_compra têm o WITH; as 3 de demanda não têm migration
+--     nenhuma — nasceram fora do repo). Logo: apply manual no SQL Editor / chat do Lovable
+--     entre 2026-06-27 e 2026-07-16. Sem rastro versionado — é o gotcha "apply manual
+--     diverge do repo" (docs/agent/database.md) na sua forma cara.
+--
+-- ─── ESCOPO: por que só estas 5 ───────────────────────────────────────────────────────
+-- Há outras views em public sem invoker, e elas foram verificadas uma a uma — NÃO entram:
+-- são definer INTENCIONAL, com gate explícito no corpo. Ex.: selfservice_meus_pedidos
+-- filtra `so.customer_user_id = auth.uid()` — ela precisa ler sales_orders sem dar RLS ao
+-- customer, e se autoriza sozinha ("gate na fronteira"). Ligar o invoker nelas QUEBRARIA o
+-- self-service. O critério aqui é estreito e verificável: (a) o snapshot prova que a view
+-- já teve invoker=on, e (b) o corpo não tem gate próprio ⇒ ela depende de RLS ⇒ restaurar.
+--
+-- ─── ALTER VIEW, não CREATE OR REPLACE ────────────────────────────────────────────────
+-- Muda só a reloption; não toca o corpo. Assim este fix não colide com o #1366 nem com a
+-- repontagem da CTE precos_compra (que mexem em corpo), e não corre o risco de reordenar
+-- coluna. Idempotente: ALTER VIEW ... SET é seguro de re-rodar.
+--
+-- Prova: db/test-security-invoker-views.sh (PG17, RLS sob SET ROLE + GUC, com falsificação).
+
+ALTER VIEW public.v_sku_sla_compliance             SET (security_invoker = on);
+ALTER VIEW public.v_sku_candidatos_primeira_compra SET (security_invoker = on);
+ALTER VIEW public.v_sku_demanda_estatisticas       SET (security_invoker = on);
+ALTER VIEW public.v_sku_demanda_rajada             SET (security_invoker = on);
+ALTER VIEW public.v_sku_sigma_demanda              SET (security_invoker = on);


### PR DESCRIPTION
## O defeito

Cinco views de `public` estão **sem `security_invoker` em produção**. Todas têm `owner=postgres` (superuser) e **nenhuma tem gate próprio no corpo** (nem `auth.uid()`, nem `has_role()`) — sempre dependeram do RLS staff-only das tabelas-base. Com o invoker desligado, a view lê com a identidade do **owner**, o RLS não se aplica, e ela devolve tudo a quem tiver SELECT nela.

| view | grant | quem lê hoje |
|---|---|---|
| `v_sku_sla_compliance` | `anon` + `authenticated` | **sem login** |
| `v_sku_candidatos_primeira_compra` | `authenticated` | qualquer customer |
| `v_sku_demanda_estatisticas` | `authenticated` | qualquer customer |
| `v_sku_demanda_rajada` | `authenticated` | qualquer customer |
| `v_sku_sigma_demanda` | `authenticated` | qualquer customer |

O RLS dessas tabelas é `has_role(uid,'master') OR has_role(uid,'employee')` — existe justamente para barrar `customer`. Exposto: fornecedor, lead time, SLA, demanda, sigma e candidatos de compra com preço.

## A causa-raiz

`CREATE OR REPLACE VIEW` **sem** o `WITH` não preserva a reloption — ele a **reseta**, silenciosamente:

```sql
CREATE OR REPLACE VIEW vw WITH (security_invoker = on) AS ...  -- {security_invoker=on}
CREATE OR REPLACE VIEW vw AS ...                               -- NULL  (= definer)
```

O SQL segue válido e a view segue retornando linhas: **só a autorização muda, e muda para mais permissiva**. É falha *aberta* — nenhum teste de "a view funciona" pega, e o CI não tem como ver.

## Origem

O snapshot de 2026-06-27 traz as 5 com `WITH (security_invoker='on')` — todas já estiveram corretas.

- **`v_sku_sla_compliance`** → regressão do #1354 (`20260716230000`), que recriou a view sem o `WITH`. Rastro no repo.
- **as outras 4** → nenhuma migration do repo as recria sem o `WITH` (as 4 de `candidatos_primeira_compra` têm; as 3 de demanda não têm migration nenhuma). Logo: **apply manual** no SQL Editor / chat do Lovable, entre 27/06 e hoje. Sem rastro versionado — o gotcha "apply manual diverge do repo" na forma cara.

## Escopo — por que só estas 5

Outras views de `public` sem invoker foram verificadas uma a uma e **não entram**: são definer **intencional**, com gate explícito no corpo. Ex.: `selfservice_meus_pedidos` filtra `customer_user_id = auth.uid()` — precisa ler `sales_orders` sem dar RLS ao customer e se autoriza sozinha. **Ligar o invoker nelas quebraria o self-service.**

Critério estreito e verificável: (a) o snapshot prova que a view já teve `invoker=on` **e** (b) o corpo não tem gate próprio ⇒ depende de RLS ⇒ restaurar.

## Por que `ALTER VIEW` e não `CREATE OR REPLACE`

Muda só a reloption, não toca o corpo. Assim não colide com o #1366 nem com a repontagem da CTE `precos_compra` (que mexem em corpo), e não corre risco de reordenar coluna. Idempotente.

## Prova

`db/test-security-invoker-views.sh` — PG17, **24 asserts, 0 falhas**.

Reproduz o vazamento **antes** do fix (customer e anon leem), aplica a **migration real**, e prova que customer/anon param de ler **e que o staff continua lendo** (seguro ≠ quebrado). Stub fiel à prod: `anon` tem GRANT na tabela-base — quem o barra é o RLS, não a falta de grant.

3 falsificações confirmam o dente:
- **A** — desligar o invoker reabre o vazamento
- **B** — dropar a policy tira o staff (prova que quem autoriza é o RLS)
- **C** — `CREATE OR REPLACE` sem `WITH` reseta a opção → é assim que o #1354 regrediu

> Escrever este harness rendeu a própria lição: a primeira versão usava `SET LOCAL` fora de transação, que só emite WARNING e **segue como superuser** — o teste media a leitura do `postgres` e pintava verde. Foi a falsificação que expôs.

## ⚠️ Aplicação

Migration custom **não** auto-aplica no Lovable — precisa colar no SQL Editor. Handoff no comentário abaixo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)