### PR TITLE
fix(recebimento): reconcile v3.2 — cExibirDetalhes:'S' na listagem (destrava o cRecebido)

### DIFF
--- a/supabase/functions/omie-nfe-reconcile/index.ts
+++ b/supabase/functions/omie-nfe-reconcile/index.ts
@@ -420,7 +420,11 @@ Deno.serve(async (req) => {
           call: "ListarRecebimentos",
           app_key: creds.appKey,
           app_secret: creds.appSecret,
-          param: [{ nPagina: 1, nRegistrosPorPagina: REGISTROS_POR_PAGINA, dtEmissaoDe: formatarDataOmie(janela.de), dtEmissaoAte: formatarDataOmie(janela.ate) }],
+          // cExibirDetalhes:'S' — SEM ele a listagem NÃO retorna infoCadastro (provado em
+          // prod 2026-07-17 via diagnostico_listagem: keys_registro sem infoCadastro,
+          // cRecebido null, com as NFs em cEtapa=80). Com o flag, cRecebido=S volta a vir
+          // e o cruzamento forte reconcilia. Parse permanece fail-closed se faltar.
+          param: [{ nPagina: 1, nRegistrosPorPagina: REGISTROS_POR_PAGINA, dtEmissaoDe: formatarDataOmie(janela.de), dtEmissaoAte: formatarDataOmie(janela.ate), cExibirDetalhes: "S" }],
         });
         const cls = classificarRespostaOmie({ httpOk: !lst.error, status: lst.error ? lst.status : 200, body: lst.data });
         if (!cls.sucesso) {
@@ -488,7 +492,7 @@ Deno.serve(async (req) => {
     if (diagnosticoListagem) {
       return jsonRes({
         success: true,
-        versao: "v3.1-janelas-consecutivas",
+        versao: "v3.2-exibir-detalhes",
         modo: "diagnostico_listagem",
         pendentes_avaliadas: rows.length,
         janelas_consultadas: janelasConsultadas,
@@ -553,7 +557,7 @@ Deno.serve(async (req) => {
 
     return jsonRes({
       success: true,
-      versao: "v3.1-janelas-consecutivas",
+      versao: "v3.2-exibir-detalhes",
       pendentes_avaliadas: rows.length,
       candidatas: candidatas.length,
       reconciliadas: reconciliadasNfe.length,


### PR DESCRIPTION
## O que este PR faz

**Diagnóstico fechado em prod** (modo `diagnostico_listagem`, 2026-07-17): o `ListarRecebimentos` **sem** `cExibirDetalhes` não retorna o bloco `infoCadastro` — as 3 amostras vieram com `keys_registro: [cabec, infoAdicionais, parcelas, totais, transporte]`, `cRecebido_cru: null`, e as NFs em **`cEtapa: 80` (concluídas no Omie)**. Ou seja: as pendentes do app ESTÃO recebidas no Omie; o fail-closed (correto) só não reconciliava porque a prova contratual não vinha. A doc oficial descreve `infoCadastro` no retorno da listagem, mas a API só o entrega com o flag.

**Fix: 1 parâmetro** — `cExibirDetalhes: "S"` na chamada da listagem (único flag de visibilidade do `rcbtoListarRequest`). Estritamente não-piorante: o parse já é defensivo — com `infoCadastro` presente, o cruzamento forte (nIdReceb + chave 44 + cRecebido=S + não-cancelada + 1:1) reconcilia; sem ele, segue fail-closed como hoje. `versao` → `v3.2-exibir-detalhes`.

`deno check` limpo · helpers/testes intocados.

## 🚀 Deploy

💬 chat do Lovable: redeploy **verbatim** de `omie-nfe-reconcile`. Sem migration, sem cron, sem Publish. A rodada horária seguinte (hh:10) deve começar a reconciliar de verdade — expectativa: até 25 das pendentes concluídas no Omie baixam na primeira rodada.

## 🧭 GOAL ([PR #1335](https://github.com/LucasSardenbergL/afiacao/pull/1335))

F4 (acúmulo zerado): este PR remove o último bloqueio técnico conhecido. Validação pós-deploy: `reconciliadas > 0` na resposta + `select status, count(*) from nfe_recebimentos group by status` mostrando pendentes caindo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)