### PR TITLE
fix(recebimento): reconcile v3.3 — pagina janelas cheias (últimas 7 fora_da_listagem)

### DIFF
--- a/supabase/functions/omie-nfe-reconcile/index.ts
+++ b/supabase/functions/omie-nfe-reconcile/index.ts
@@ -321,6 +321,9 @@ const LIMITE_DEFAULT = 25;
 const LIMITE_MAX = 25;
 const REGISTROS_POR_PAGINA = 50;
 const TREGUA_LISTAGEM_MS = 1500;
+// Guard global de chamadas de listagem por rodada (janelas × páginas). 7-8 chamadas/rodada
+// provadas sem trava em prod; 12 dá folga pra paginação sem virar rajada (~18s de tréguas).
+const MAX_CHAMADAS_LISTAGEM = 12;
 
 Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
@@ -393,6 +396,7 @@ Deno.serve(async (req) => {
     let puladasCredencial = 0;
     let listagemTruncada = false;
     let janelasConsultadas = 0;
+    let chamadasListagem = 0;
     const errosListagem: string[] = [];
     const amostraCrua: Array<Record<string, unknown>> = [];
     const amostraNaoRecebidas: Array<Record<string, unknown>> = [];
@@ -416,29 +420,42 @@ Deno.serve(async (req) => {
       for (const [j, janela] of janelas.entries()) {
         if (j > 0) await new Promise((r) => setTimeout(r, TREGUA_LISTAGEM_MS));
         janelasConsultadas++;
-        const lst = await omieCall(RECEB_URL, {
-          call: "ListarRecebimentos",
-          app_key: creds.appKey,
-          app_secret: creds.appSecret,
-          // cExibirDetalhes:'S' — SEM ele a listagem NÃO retorna infoCadastro (provado em
-          // prod 2026-07-17 via diagnostico_listagem: keys_registro sem infoCadastro,
-          // cRecebido null, com as NFs em cEtapa=80). Com o flag, cRecebido=S volta a vir
-          // e o cruzamento forte reconcilia. Parse permanece fail-closed se faltar.
-          param: [{ nPagina: 1, nRegistrosPorPagina: REGISTROS_POR_PAGINA, dtEmissaoDe: formatarDataOmie(janela.de), dtEmissaoAte: formatarDataOmie(janela.ate), cExibirDetalhes: "S" }],
-        });
-        const cls = classificarRespostaOmie({ httpOk: !lst.error, status: lst.error ? lst.status : 200, body: lst.data });
-        if (!cls.sucesso) {
-          const msg = `${whCode} janela ${formatarDataOmie(janela.de)}–${formatarDataOmie(janela.ate)}: ${cls.erro ?? "erro"}`;
-          if (errosListagem.length < 3) errosListagem.push(msg);
-          console.warn(`[omie-nfe-reconcile] listagem falhou — ${msg}`);
-          continue; // as demais janelas ainda podem cobrir outras pendentes
-        }
-        const recsPagina = asRecord(lst.data).recebimentos;
-        const cheia = Array.isArray(recsPagina) && recsPagina.length >= REGISTROS_POR_PAGINA;
-        if (cheia) listagemTruncada = true; // honestidade: há mais registros além da página 1 desta janela
-        paginas.push(lst.data);
-        if (diagnosticoListagem && amostraCrua.length < 4 && Array.isArray(recsPagina)) {
-          for (const r of recsPagina.slice(0, 2)) amostraCrua.push({ conta: whCode, registro: r });
+        // v3.3: PAGINA janelas cheias (7 fora_da_listagem estagnaram em prod com janelas
+        // OBEN >50 registros truncadas na página 1). Padrão da casa p/ Omie: paginar até
+        // página VAZIA/incompleta + guard — nTotalPaginas NÃO é confiável (CLAUDE.md §Omie).
+        let nPagina = 1;
+        while (true) {
+          if (chamadasListagem >= MAX_CHAMADAS_LISTAGEM) {
+            listagemTruncada = true; // cap global cortou — cobertura parcial honesta
+            break;
+          }
+          if (nPagina > 1) await new Promise((r) => setTimeout(r, TREGUA_LISTAGEM_MS));
+          chamadasListagem++;
+          const lst = await omieCall(RECEB_URL, {
+            call: "ListarRecebimentos",
+            app_key: creds.appKey,
+            app_secret: creds.appSecret,
+            // cExibirDetalhes:'S' — SEM ele a listagem NÃO retorna infoCadastro (provado em
+            // prod 2026-07-17 via diagnostico_listagem: keys_registro sem infoCadastro,
+            // cRecebido null, com as NFs em cEtapa=80). Com o flag, cRecebido=S volta a vir
+            // e o cruzamento forte reconcilia. Parse permanece fail-closed se faltar.
+            param: [{ nPagina, nRegistrosPorPagina: REGISTROS_POR_PAGINA, dtEmissaoDe: formatarDataOmie(janela.de), dtEmissaoAte: formatarDataOmie(janela.ate), cExibirDetalhes: "S" }],
+          });
+          const cls = classificarRespostaOmie({ httpOk: !lst.error, status: lst.error ? lst.status : 200, body: lst.data });
+          if (!cls.sucesso) {
+            const msg = `${whCode} janela ${formatarDataOmie(janela.de)}–${formatarDataOmie(janela.ate)} p${nPagina}: ${cls.erro ?? "erro"}`;
+            if (errosListagem.length < 3) errosListagem.push(msg);
+            console.warn(`[omie-nfe-reconcile] listagem falhou — ${msg}`);
+            break; // desiste DESTA janela; as demais ainda podem cobrir outras pendentes
+          }
+          const recsPagina = asRecord(lst.data).recebimentos;
+          paginas.push(lst.data);
+          if (diagnosticoListagem && amostraCrua.length < 4 && Array.isArray(recsPagina)) {
+            for (const r of recsPagina.slice(0, 2)) amostraCrua.push({ conta: whCode, registro: r });
+          }
+          // Página incompleta/vazia = última desta janela (critério que não depende de nTotalPaginas).
+          if (!Array.isArray(recsPagina) || recsPagina.length < REGISTROS_POR_PAGINA) break;
+          nPagina++;
         }
       }
       if (janelas.length > 0 && janelas[janelas.length - 1].ate.getTime() < Date.now()) {
@@ -492,10 +509,11 @@ Deno.serve(async (req) => {
     if (diagnosticoListagem) {
       return jsonRes({
         success: true,
-        versao: "v3.2-exibir-detalhes",
+        versao: "v3.3-paginacao-janelas",
         modo: "diagnostico_listagem",
         pendentes_avaliadas: rows.length,
         janelas_consultadas: janelasConsultadas,
+        chamadas_listagem: chamadasListagem,
         amostra_erros_listagem: errosListagem,
         amostra_nao_recebidas: amostraNaoRecebidas,
         amostra_crua: amostraCrua,
@@ -557,12 +575,13 @@ Deno.serve(async (req) => {
 
     return jsonRes({
       success: true,
-      versao: "v3.2-exibir-detalhes",
+      versao: "v3.3-paginacao-janelas",
       pendentes_avaliadas: rows.length,
       candidatas: candidatas.length,
       reconciliadas: reconciliadasNfe.length,
       listagem: {
         janelas_consultadas: janelasConsultadas,
+        chamadas_listagem: chamadasListagem,
         nao_recebidas: naoRecebidas,
         canceladas: canceladasListagem,
         identidade_fraca: identidadeFraca,


### PR DESCRIPTION
## O que este PR faz

A v3.2 destravou o `cRecebido` e **reconciliou 15 NFs em 3 rodadas (painel 24→9)** — mas estagnou: **7 pendentes seguem `fora_da_listagem` com `truncada: true`** (janelas OBEN com >50 registros truncam na página 1; não havia paginação).

**v3.3**: pagina cada janela até **página vazia/incompleta** (padrão da casa para Omie — `nTotalPaginas` não é confiável, CLAUDE.md §Omie), com guard duplo: trégua 1.5s entre TODAS as chamadas + **cap global `MAX_CHAMADAS_LISTAGEM=12`/rodada** (7-8 chamadas/rodada provadas sem trava em prod; corte pelo cap seta `truncada=true` — cobertura parcial honesta, nunca silenciosa). Contador `chamadas_listagem` na resposta. `versao` → `v3.3-paginacao-janelas`.

`deno check` limpo · helpers/testes intocados.

## 🚀 Deploy

💬 chat do Lovable: redeploy **verbatim** de `omie-nfe-reconcile`. Sem migration, sem cron, sem Publish.

## 🧭 GOAL ([PR #1335](https://github.com/LucasSardenbergL/afiacao/pull/1335))

F4: 15/24 baixadas ✅. Das 9 restantes: 1 legitimamente aguardando no Omie (cEtapa=40, cRecebido=N — painel CERTO), 1 **cancelada no Omie** (follow-up de produto: dar status próprio no app pra sair do funil), 7 destravam com este PR. Expectativa pós-deploy: painel estabiliza em ~2 NFs, ambas refletindo a realidade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)