### PR TITLE
fix(customer-metrics): cron de refresh + autz por identidade positiva [money-path]

### DIFF
--- a/db/test-refresh-customer-metrics-automacao.sh
+++ b/db/test-refresh-customer-metrics-automacao.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — refresh_customer_metrics: automação + autz por identidade positiva ║
+# ║  Migration: 20260717154500_refresh_customer_metrics_automacao.sql              ║
+# ║  Rode: bash db/test-refresh-customer-metrics-automacao.sh > /tmp/t.log 2>&1; echo "exit=$?" ║
+# ║                                                                                ║
+# ║  Invariantes (money-path: autz):                                               ║
+# ║   P1 service_role executa o PRIMITIVE → MV refresha (automação por identidade positiva) ║
+# ║   P2 staff via WRAPPER refresha (UX do frontend preservada)                     ║
+# ║   N1 authenticated NÃO alcança o primitive (fronteira de GRANT — ponto do Codex)║
+# ║   N2 customer no wrapper → 42501 (gate staff)                                    ║
+# ║   N3 uid NULO no wrapper → 42501 (rejeita ausência de identidade — o anti-C)     ║
+# ║   N4 anon barrado em ambas                                                       ║
+# ║   F2 sabota p/ o gate-C (aceita uid nulo) → N3 fica VERMELHO (nosso é melhor)    ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="refresh-custmetrics"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migração LÊ mas não cria)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+-- schema auth: USAGE + EXECUTE (a PROD concede; db/stubs-supabase.sql NÃO — mordeu o #1380).
+-- Sem isto, um caller authenticated que resolva auth.uid() daria 42501 falso e mascararia o teste.
+GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role;
+GRANT EXECUTE ON FUNCTION auth.uid(), auth.role() TO anon, authenticated, service_role;
+
+-- app_role + user_roles + has_role (fiel à prod: SQL STABLE SECDEF search_path=public)
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('employee','master','customer'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role public.app_role);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+  AS $fn$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $fn$;
+
+-- schema private + a MV customer_metrics_mv (stub topológico: índice ÚNICO p/ REFRESH CONCURRENTLY
+-- + coluna calculated_at). A fonte é uma tabela simples cujo count muda p/ provar o efeito do refresh.
+CREATE SCHEMA IF NOT EXISTS private;
+CREATE TABLE public._src_metrics (customer_user_id uuid PRIMARY KEY, calculated_at timestamptz DEFAULT now());
+INSERT INTO public._src_metrics(customer_user_id) VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+CREATE MATERIALIZED VIEW private.customer_metrics_mv AS
+  SELECT customer_user_id, calculated_at FROM public._src_metrics;
+CREATE UNIQUE INDEX customer_metrics_mv_pk ON private.customer_metrics_mv(customer_user_id);
+REVOKE ALL ON private.customer_metrics_mv FROM anon, authenticated;
+
+-- stub das FUNÇÕES do pg_cron (o schema cron + cron.job já vêm de db/stubs-supabase.sql, onde
+-- jobid é bigint sem default → a função gera o jobid). Prova que a migração AGENDA (idempotência
+-- unschedule+schedule), não o pg_cron real.
+CREATE OR REPLACE FUNCTION cron.schedule(job_name text, schedule text, command text) RETURNS bigint
+  LANGUAGE sql AS $fn$
+    INSERT INTO cron.job(jobid, jobname, schedule, command, active)
+    VALUES ((SELECT COALESCE(max(jobid),0)+1 FROM cron.job), job_name, schedule, command, true)
+    RETURNING jobid
+  $fn$;
+CREATE OR REPLACE FUNCTION cron.unschedule(job_name text) RETURNS boolean
+  LANGUAGE sql AS $fn$ DELETE FROM cron.job WHERE jobname=job_name; SELECT true; $fn$;
+
+-- roles/personas
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('33333333-3333-3333-3333-333333333333','master'),
+  ('44444444-4444-4444-4444-444444444444','customer');
+GRANT SELECT ON public.user_roles TO authenticated, anon;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260717154500_refresh_customer_metrics_automacao.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── grants (fronteira de autz) ──"
+eq "G1 authenticated NÃO tem o primitive"      "$(Pq -c "SELECT has_function_privilege('authenticated','public.refresh_customer_metrics()','EXECUTE');")" "f"
+eq "G2 service_role TEM o primitive"           "$(Pq -c "SELECT has_function_privilege('service_role','public.refresh_customer_metrics()','EXECUTE');")" "t"
+eq "G3 anon NÃO tem o primitive"               "$(Pq -c "SELECT has_function_privilege('anon','public.refresh_customer_metrics()','EXECUTE');")" "f"
+eq "G4 authenticated TEM o wrapper"            "$(Pq -c "SELECT has_function_privilege('authenticated','public.request_customer_metrics_refresh()','EXECUTE');")" "t"
+eq "G5 anon NÃO tem o wrapper"                 "$(Pq -c "SELECT has_function_privilege('anon','public.request_customer_metrics_refresh()','EXECUTE');")" "f"
+
+echo "── hardening search_path (Codex) ──"
+SP1=$(Pq -c "SELECT coalesce(array_to_string(proconfig,'|'),'<none>') FROM pg_proc WHERE proname='refresh_customer_metrics';")
+SP2=$(Pq -c "SELECT coalesce(array_to_string(proconfig,'|'),'<none>') FROM pg_proc WHERE proname='request_customer_metrics_refresh';")
+case "$SP1" in *search_path=*) case "$SP1" in *public*) bad "H1 primitive search_path contém public: $SP1" ;; *) ok "H1 primitive fixa search_path vazio ([$SP1])" ;; esac ;; *) bad "H1 primitive sem search_path fixo: $SP1" ;; esac
+case "$SP2" in *search_path=*) case "$SP2" in *public*) bad "H2 wrapper search_path contém public: $SP2" ;; *) ok "H2 wrapper fixa search_path vazio ([$SP2])" ;; esac ;; *) bad "H2 wrapper sem search_path fixo: $SP2" ;; esac
+
+echo "── cron ──"
+eq "C1 cron agendado"          "$(Pq -c "SELECT count(*) FROM cron.job WHERE jobname='afiacao_customer_metrics_refresh_6h';")" "1"
+eq "C2 cron chama o primitive" "$(Pq -c "SELECT command FROM cron.job WHERE jobname='afiacao_customer_metrics_refresh_6h';")" "SELECT public.refresh_customer_metrics()"
+eq "C3 cadência 6h"            "$(Pq -c "SELECT schedule FROM cron.job WHERE jobname='afiacao_customer_metrics_refresh_6h';")" "15 */6 * * *"
+
+echo "── positivos (a função REAL executa — pega late-bound) ──"
+# P1: service_role executa o primitive e o efeito propaga (MV passa de 1 → 2 linhas)
+P -q -c "INSERT INTO public._src_metrics(customer_user_id) VALUES ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');"
+P -q <<'SQL'
+SET ROLE service_role;
+SELECT public.refresh_customer_metrics();
+RESET ROLE;
+SQL
+eq "P1 service_role refresha o primitive (efeito propaga)" "$(Pq -c "SELECT count(*) FROM private.customer_metrics_mv;")" "2"
+
+# P2: staff via wrapper refresha (MV passa de 2 → 3). Prova a UX preservada + PERFORM do primitive.
+P -q -c "INSERT INTO public._src_metrics(customer_user_id) VALUES ('cccccccc-cccc-cccc-cccc-cccccccccccc');"
+P -q <<'SQL'
+SET test.uid='33333333-3333-3333-3333-333333333333';
+SET ROLE authenticated;
+SELECT public.request_customer_metrics_refresh();
+RESET ROLE;
+SQL
+eq "P2 staff via wrapper refresha (UX do frontend)" "$(Pq -c "SELECT count(*) FROM private.customer_metrics_mv;")" "3"
+
+echo "── negativos (a defesa morde — SQLSTATE + re-raise) ──"
+# N1: authenticated (mesmo master) NÃO alcança o primitive direto → 42501 ANTES de qualquer refresh
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='33333333-3333-3333-3333-333333333333';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.refresh_customer_metrics();
+  RAISE EXCEPTION 'PRIMITIVE_NAO_BARROU';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'PRIMITIVE_NEGADO';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *PRIMITIVE_NEGADO*) ok "N1 authenticated/staff não alcança o primitive (fronteira de GRANT)" ;; *) bad "N1 — veio: $R" ;; esac
+
+# N2: customer (uid≠null, não-staff) no wrapper → gate 42501
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='44444444-4444-4444-4444-444444444444';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.request_customer_metrics_refresh();
+  RAISE EXCEPTION 'WRAPPER_NAO_BARROU_CUSTOMER';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'WRAPPER_NEGOU_CUSTOMER';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *WRAPPER_NEGOU_CUSTOMER*) ok "N2 wrapper nega customer (gate staff 42501)" ;; *) bad "N2 — veio: $R" ;; esac
+
+# N3: uid NULO no wrapper → 42501 (rejeita ausência de identidade — o invariante do Codex)
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.request_customer_metrics_refresh();
+  RAISE EXCEPTION 'WRAPPER_ACEITOU_UID_NULO';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'WRAPPER_REJEITOU_UID_NULO';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in *WRAPPER_REJEITOU_UID_NULO*) ok "N3 wrapper REJEITA uid nulo (anti fail-open)" ;; *) bad "N3 — veio: $R" ;; esac
+
+# N4: anon barrado em ambas
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE anon;
+DO $$ BEGIN PERFORM public.refresh_customer_metrics(); RAISE EXCEPTION 'X';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'ANON_NEG_PRIM'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *ANON_NEG_PRIM*) ok "N4a anon negado no primitive" ;; *) bad "N4a — veio: $R" ;; esac
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE anon;
+DO $$ BEGIN PERFORM public.request_customer_metrics_refresh(); RAISE EXCEPTION 'X';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'ANON_NEG_WRAP'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *ANON_NEG_WRAP*) ok "N4b anon negado no wrapper" ;; *) bad "N4b — veio: $R" ;; esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3: sabota → exija VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+
+# F1 — sabota a fronteira: re-GRANT authenticated no primitive → N1 deve deixar de ver 42501
+P -q -c "GRANT EXECUTE ON FUNCTION public.refresh_customer_metrics() TO authenticated;"
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='33333333-3333-3333-3333-333333333333';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.refresh_customer_metrics();
+  RAISE NOTICE 'FRONTEIRA_FURADA_PASSOU';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'PRIMITIVE_NEGADO';
+  WHEN OTHERS THEN RAISE NOTICE 'OUTRO_ERRO_MAS_NAO_42501';
+END $$;
+SQL
+)
+case "$R" in
+  *PRIMITIVE_NEGADO*) bad "F1 sabotei o grant e N1 ainda vê 42501 → N1 é fraco" ;;
+  *) ok "F1 re-grant fura a fronteira (N1/G1 tinham dente)" ;;
+esac
+P -q -c "REVOKE EXECUTE ON FUNCTION public.refresh_customer_metrics() FROM authenticated;"
+
+# F2 — a DECISIVA: troca o gate do wrapper pela versão-C (aceita uid nulo = fail-open) → N3 fica VERMELHO
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.request_customer_metrics_refresh()
+  RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $fn$
+DECLARE v_uid uuid := auth.uid();
+BEGIN
+  -- GATE SABOTADO (Opção C): só barra authenticated NÃO-staff; ACEITA uid nulo (fail-open que o Codex condenou)
+  IF v_uid IS NOT NULL AND NOT (COALESCE(public.has_role(v_uid,'employee'::public.app_role),false)
+                             OR COALESCE(public.has_role(v_uid,'master'::public.app_role),false)) THEN
+    RAISE EXCEPTION 'Acesso negado' USING ERRCODE='42501';
+  END IF;
+  PERFORM public.refresh_customer_metrics();
+END $fn$;
+SQL
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.request_customer_metrics_refresh();
+  RAISE NOTICE 'GATE_C_ACEITOU_UID_NULO';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'WRAPPER_REJEITOU_UID_NULO';
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)
+case "$R" in
+  *GATE_C_ACEITOU_UID_NULO*) ok "F2 gate-C aceita uid nulo → N3 tinha dente; nosso desenho barra o fail-open" ;;
+  *WRAPPER_REJEITOU_UID_NULO*) bad "F2 gate-C ainda rejeitou uid nulo → N3 não distingue os desenhos" ;;
+  *) bad "F2 — veio: $R" ;;
+esac
+P -q -f "$MIG"   # restaura a versão verdadeira
+
+# F3 — sabota o gate staff (remove) → N2 (customer) deve deixar de ser barrado
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.request_customer_metrics_refresh()
+  RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = ''
+AS $fn$ BEGIN PERFORM public.refresh_customer_metrics(); END $fn$;
+SQL
+R=$(P -tA 2>&1 <<'SQL'
+SET test.uid='44444444-4444-4444-4444-444444444444';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.request_customer_metrics_refresh();
+  RAISE NOTICE 'GATE_REMOVIDO_CUSTOMER_PASSOU';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'WRAPPER_NEGOU_CUSTOMER'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in
+  *GATE_REMOVIDO_CUSTOMER_PASSOU*) ok "F3 sem gate, customer passa (N2 tinha dente)" ;;
+  *) bad "F3 — veio: $R" ;;
+esac
+P -q -f "$MIG"
+
+# F4 — sabota a automação: REVOKE service_role do primitive → P1/G2 (automação) quebram
+P -q -c "REVOKE EXECUTE ON FUNCTION public.refresh_customer_metrics() FROM service_role;"
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE service_role;
+DO $$ BEGIN
+  PERFORM public.refresh_customer_metrics();
+  RAISE NOTICE 'SERVICE_AINDA_EXECUTA';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'SERVICE_PERDEU_ACESSO'; WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in
+  *SERVICE_PERDEU_ACESSO*) ok "F4 sem grant service_role a automação quebra (P1/G2 tinham dente)" ;;
+  *) bad "F4 — veio: $R" ;;
+esac
+P -q -f "$MIG"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **378** custom migrations totais
-- **1334** objetos esperados (criados por estas migrations)
+- **379** custom migrations totais
+- **1337** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 375
+  - `function`: 377
   - `rls_policy`: 295
   - `index`: 222
-  - `cron_job`: 149
+  - `cron_job`: 150
   - `table`: 146
   - `trigger`: 78
   - `view`: 65
@@ -3219,6 +3219,14 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260717130000_seg_customer_metrics_acl_least_privilege.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260717154500_refresh_customer_metrics_automacao.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.refresh_customer_metrics` | — |
+| `function` | `public.request_customer_metrics_refresh` | — |
+| `cron_job` | `cron.afiacao_customer_metrics_refresh_6h` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 378
+-- Total de custom migrations: 379
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -417,7 +417,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260717015000', 'restaurar_security_invoker_views', '20260717015000_restaurar_security_invoker_views.sql'),
   ('20260717020000', 'precos_compra_leadtime_efetivo', '20260717020000_precos_compra_leadtime_efetivo.sql'),
   ('20260717120000', 'seg_customer_metrics_gate_staff', '20260717120000_seg_customer_metrics_gate_staff.sql'),
-  ('20260717130000', 'seg_customer_metrics_acl_least_privilege', '20260717130000_seg_customer_metrics_acl_least_privilege.sql')
+  ('20260717130000', 'seg_customer_metrics_acl_least_privilege', '20260717130000_seg_customer_metrics_acl_least_privilege.sql'),
+  ('20260717154500', 'refresh_customer_metrics_automacao', '20260717154500_refresh_customer_metrics_automacao.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1742,7 +1743,10 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('outliers_leadtime_stack_efetivo', 'function', 'public', 'resolver_outlier', ''),
   ('preco_medio_leadtime_efetivo', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
   ('precos_compra_leadtime_efetivo', 'view', 'public', 'v_sku_parametros_sugeridos', ''),
-  ('seg_customer_metrics_gate_staff', 'view', 'public', 'customer_metrics_mv', '')
+  ('seg_customer_metrics_gate_staff', 'view', 'public', 'customer_metrics_mv', ''),
+  ('refresh_customer_metrics_automacao', 'function', 'public', 'refresh_customer_metrics', ''),
+  ('refresh_customer_metrics_automacao', 'function', 'public', 'request_customer_metrics_refresh', ''),
+  ('refresh_customer_metrics_automacao', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3115,7 +3119,10 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('outliers_leadtime_stack_efetivo', 'function', 'public', 'resolver_outlier', ''),
   ('preco_medio_leadtime_efetivo', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
   ('precos_compra_leadtime_efetivo', 'view', 'public', 'v_sku_parametros_sugeridos', ''),
-  ('seg_customer_metrics_gate_staff', 'view', 'public', 'customer_metrics_mv', '')
+  ('seg_customer_metrics_gate_staff', 'view', 'public', 'customer_metrics_mv', ''),
+  ('refresh_customer_metrics_automacao', 'function', 'public', 'refresh_customer_metrics', ''),
+  ('refresh_customer_metrics_automacao', 'function', 'public', 'request_customer_metrics_refresh', ''),
+  ('refresh_customer_metrics_automacao', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', '')
 )
 SELECT
   e.migration,

--- a/src/components/analyticsSync/useAnalyticsSync.ts
+++ b/src/components/analyticsSync/useAnalyticsSync.ts
@@ -273,9 +273,12 @@ export function useAnalyticsSync() {
       }
     }
 
-    // Refresh materialized view after import
+    // Refresh materialized view after import. Via o WRAPPER staff request_customer_metrics_refresh:
+    // o primitive refresh_customer_metrics passou a ser service-only (cron/edge). supabase-js NÃO
+    // lança → checar o erro (antes era engolido). O cron a cada 6h cobre o frescor de base.
     setOrdersSyncProgress("Atualizando métricas de clientes...");
-    await supabase.rpc("refresh_customer_metrics");
+    const { error: refreshError } = await supabase.rpc("request_customer_metrics_refresh");
+    if (refreshError) throw new Error(`Falha ao atualizar métricas de clientes: ${refreshError.message}`);
 
     setOrdersSyncProgress(null);
     return { grandTotalSynced, grandTotalItems, grandTotalSkipped };

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -18983,6 +18983,7 @@ export type Database = {
         }[]
       }
       refresh_customer_metrics: { Args: never; Returns: undefined }
+      request_customer_metrics_refresh: { Args: never; Returns: undefined }
       refresh_oportunidade_badge: { Args: never; Returns: undefined }
       refresh_sku_ranking_negociacao: {
         Args: never

--- a/supabase/functions/ai-ops-agent/index.ts
+++ b/supabase/functions/ai-ops-agent/index.ts
@@ -230,9 +230,13 @@ serve(async (req) => {
     const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, serviceKey);
 
-    // 1. Refresh materialized view
+    // 1. Refresh materialized view. supabase-js devolve {error}, NÃO lança → checar explicitamente
+    //    (sem isto a falha do refresh era engolida e as métricas serviam stale — achado 2026-07-17).
     console.log("[ai-ops-agent] Refreshing customer metrics...");
-    await supabase.rpc("refresh_customer_metrics");
+    const { error: refreshError } = await supabase.rpc("refresh_customer_metrics");
+    if (refreshError) {
+      throw new Error(`[ai-ops-agent] refresh_customer_metrics falhou: ${refreshError.message}`);
+    }
 
     // 2. Get all customer metrics with pagination (bypass 1000-row limit)
     let allMetrics: CustomerMetric[] = [];

--- a/supabase/migrations/20260717154500_refresh_customer_metrics_automacao.sql
+++ b/supabase/migrations/20260717154500_refresh_customer_metrics_automacao.sql
@@ -1,0 +1,109 @@
+-- ============================================================
+-- 20260717154500_refresh_customer_metrics_automacao.sql
+-- Frescor de customer_metrics_mv: automação por cron + autz por IDENTIDADE POSITIVA.
+-- [money-path: autz + automação]
+--
+-- PROBLEMA (medido via psql-ro 2026-07-17): private.customer_metrics_mv estava STALE há 22
+-- dias (último refresh 2026-06-24). NÃO existia cron. A função public.refresh_customer_metrics()
+-- tinha no corpo `IF auth.uid() IS NULL OR NOT staff THEN RAISE 42501` — sob service_role/pg_cron
+-- o JWT não tem `sub` ⇒ auth.uid() IS NULL ⇒ RAISE ⇒ o refresh NUNCA rodava por automação (só
+-- quando um staff disparava a tela AdminAnalyticsSync). Alimenta Customer360/FilaDoDia/rota de
+-- contatos — decisão comercial com dado velho de semanas.
+--
+-- DESENHO (veredito Codex xhigh — IDENTIDADES SEPARADAS, não gate condicional):
+--   `auth.uid() IS NULL` NÃO significa "é o cron" — significa "sem `sub` utilizável". Autorizar
+--   automação pela AUSÊNCIA de identidade é fail-open (um token `authenticated` sem `sub` passaria).
+--   Padrão do repo (refresh_oportunidade_badge, consagrado em docs/agent/database.md): refresh SEM
+--   gate `auth.uid()` interno, protegido por REVOKE/GRANT service_role. A UX do staff (refresh
+--   síncrono pós-import) é preservada por um WRAPPER separado que REJEITA uid nulo (gate correto
+--   p/ endpoint EXCLUSIVAMENTE humano) — nunca afrouxando o primitive.
+--
+--   • refresh_customer_metrics()          PRIMITIVE service-only (cron + edge ai-ops-agent).
+--                                         Sem gate JWT; advisory xact-lock; REVOKE authenticated;
+--                                         GRANT service_role. Automação por identidade positiva.
+--   • request_customer_metrics_refresh()  WRAPPER staff (frontend useAnalyticsSync). Gate rejeita
+--                                         uid nulo E não-staff; GRANT authenticated. Chama o primitive.
+--   • cron SQL-direto a cada 6h (não net.http_post → sem o footgun do timeout 5s do pg_net).
+--
+-- Hardening (Codex): SECURITY DEFINER com `SET search_path = ''` + qualificação total de TODO
+-- objeto (defesa contra sequestro por search_path numa função owned-by-postgres).
+-- Provado PG17 + falsificação: db/test-refresh-customer-metrics-automacao.sh
+-- Coordenação: #1380 (mergeado) recria a VIEW pública + ACL; NÃO toca esta função/MV/cron
+-- (objetos disjuntos — sem corrida "última a rodar vence").
+-- ⚠️ APLICAÇÃO MANUAL: colar no SQL Editor do Lovable (migration custom NÃO auto-aplica).
+-- Idempotente. Transacional (a migration só CRIA os objetos; o REFRESH CONCURRENTLY roda em
+-- runtime pelo cron/wrapper, fora desta transação).
+-- ============================================================
+BEGIN;
+
+-- 1) PRIMITIVE service-only. Sem gate JWT (o cron/postgres não tem `sub`). Advisory xact-lock
+--    evita pile-up (auto-libera em commit/rollback/statement_timeout — ≠ lock de sessão).
+CREATE OR REPLACE FUNCTION public.refresh_customer_metrics()
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $function$
+BEGIN
+  IF NOT pg_catalog.pg_try_advisory_xact_lock(pg_catalog.hashtext('refresh_customer_metrics')) THEN
+    RAISE NOTICE 'refresh_customer_metrics: refresh já em curso, pulando';
+    RETURN;
+  END IF;
+  REFRESH MATERIALIZED VIEW CONCURRENTLY private.customer_metrics_mv;
+END;
+$function$;
+
+-- autz na FRONTEIRA (não no corpo): PostgreSQL rejeita authenticated ANTES de executar qualquer
+-- instrução como postgres. A superfície privilegiada nem é alcançada por um customer.
+REVOKE EXECUTE ON FUNCTION public.refresh_customer_metrics() FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION public.refresh_customer_metrics() TO service_role;
+
+-- 2) WRAPPER staff: preserva o refresh síncrono do frontend (AdminAnalyticsSync → useAnalyticsSync,
+--    tela viva). Endpoint EXCLUSIVAMENTE humano → REJEITA uid nulo (≠ do primitive: aqui a
+--    ausência de identidade é NEGAÇÃO, não privilégio — é o que separa este desenho do gate
+--    condicional fail-open). COALESCE null-hardened contra negação NULL-blind de has_role.
+CREATE OR REPLACE FUNCTION public.request_customer_metrics_refresh()
+  RETURNS void
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL
+     OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
+          OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+  -- roda como postgres (owner) → alcança o primitive service-only independentemente do GRANT.
+  PERFORM public.refresh_customer_metrics();
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.request_customer_metrics_refresh() FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.request_customer_metrics_refresh() TO authenticated, service_role;
+
+-- 3) Cron SQL-direto a cada 6h (escalonado aos :15). Chama o PRIMITIVE service-only (roda no
+--    Postgres como o job-owner/postgres, sem JWT — passa pela fronteira de GRANT via service_role
+--    do pg_cron). Idempotente.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'afiacao_customer_metrics_refresh_6h') THEN
+    PERFORM cron.unschedule('afiacao_customer_metrics_refresh_6h');
+  END IF;
+END $$;
+SELECT cron.schedule('afiacao_customer_metrics_refresh_6h', '15 */6 * * *',
+                     'SELECT public.refresh_customer_metrics()');
+
+COMMIT;
+
+-- ── Validação pós-apply (rodar após o Run no SQL Editor) ──────────────────────
+-- SELECT
+--   (SELECT count(*) FROM private.customer_metrics_mv) > 0                         AS mv_populada,
+--   to_regprocedure('public.refresh_customer_metrics()')          IS NOT NULL      AS primitive_existe,
+--   to_regprocedure('public.request_customer_metrics_refresh()')  IS NOT NULL      AS wrapper_existe,
+--   has_function_privilege('authenticated','public.refresh_customer_metrics()','EXECUTE')   AS auth_NAO_deve_ter_primitive,  -- deve vir false
+--   has_function_privilege('service_role','public.refresh_customer_metrics()','EXECUTE')    AS service_tem_primitive,        -- deve vir true
+--   has_function_privilege('authenticated','public.request_customer_metrics_refresh()','EXECUTE') AS auth_tem_wrapper,       -- deve vir true
+--   (SELECT count(*) FROM cron.job WHERE jobname='afiacao_customer_metrics_refresh_6h') AS cron_agendado;   -- deve vir 1


### PR DESCRIPTION
## Problema

`private.customer_metrics_mv` estava **stale** (Customer360 / MeuDia-FilaDoDia / rota de contatos servindo dado velho de semanas — decisão comercial com número defasado).

**Causa (provada por execução, não deduzida):** `refresh_customer_metrics()` tinha um gate `auth.uid()` interno. Sob `service_role`/`pg_cron` o JWT não tem `sub` ⇒ `auth.uid() IS NULL` ⇒ `RAISE 42501` ⇒ o refresh **nunca rodava por automação**. E não existia cron para a MV. O único disparo era um staff abrir a tela `AdminAnalyticsSync` — que ninguém fez por semanas. O `ai-ops-agent` chamava o rpc mas **não checava o erro** (supabase-js devolve `{error}`, não lança) → falha silenciosa.

## Desenho (veredito Codex xhigh — identidades separadas)

O Codex refutou a alternativa "gate condicional" (Opção C): `auth.uid() IS NULL` **não** significa "é o cron", significa "sem `sub` utilizável" — autorizar automação pela *ausência* de identidade é **fail-open**. Padrão do repo (`refresh_oportunidade_badge`, `database.md`): refresh sem gate JWT, protegido por `REVOKE`/`GRANT service_role`.

| Objeto | Autz | Chamado por |
|---|---|---|
| `refresh_customer_metrics()` (primitive) | sem gate JWT · advisory xact-lock · `REVOKE authenticated` + `GRANT service_role` · `search_path=''` | cron + `ai-ops-agent` |
| `request_customer_metrics_refresh()` (wrapper, novo) | gate staff que **rejeita uid nulo** (endpoint humano) · `GRANT authenticated` | frontend `useAnalyticsSync` |

Automação por **identidade positiva** (`GRANT`), staff por **identidade de app** (gate humano). Nunca se misturam. Cron **SQL-direto** a cada 6h (não `net.http_post` → sem o footgun do timeout 5s). `ai-ops-agent` passa a **checar o erro** do rpc.

## Prova (PG17 + falsificação — 21 asserts)

`db/test-refresh-customer-metrics-automacao.sh` — verde. Destaques:
- **P1/P2** a função REAL executa (pega late-bound); service_role e staff-via-wrapper refrescam.
- **N1** `authenticated` (mesmo staff) não alcança o primitive — fronteira de GRANT.
- **N3** wrapper rejeita uid nulo.
- **F2 (decisiva)** sabota para o gate-C (aceita uid nulo) e exige **N3 vermelho** → prova que o desenho barra o fail-open que o Codex condenou.

## ⚠️ ATENÇÃO: migration manual necessária + ordem de deploy

Este PR adiciona `supabase/migrations/20260717154500_refresh_customer_metrics_automacao.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Ordem obrigatória:

1. **SQL Editor** → colar e rodar a migration (cria as 2 funções + o cron). *Antes* do Publish.
2. **Publish** do frontend (o rpc `request_customer_metrics_refresh` só existe após o passo 1).
3. **Chat do Lovable** → redeploy da edge `ai-ops-agent` (verbatim do repo — passa a checar o erro do refresh).

Validação pós-apply (read-only):

```sql
SELECT
  (SELECT count(*) FROM private.customer_metrics_mv) > 0                                        AS mv_populada,
  has_function_privilege('authenticated','public.refresh_customer_metrics()','EXECUTE')        AS auth_NAO_deve_ter_primitive,
  has_function_privilege('service_role','public.refresh_customer_metrics()','EXECUTE')          AS service_tem_primitive,
  has_function_privilege('authenticated','public.request_customer_metrics_refresh()','EXECUTE') AS auth_tem_wrapper,
  (SELECT count(*) FROM cron.job WHERE jobname='afiacao_customer_metrics_refresh_6h')           AS cron_agendado;
```
Esperado: `mv_populada=t`, `auth_NAO_deve_ter_primitive=f`, `service_tem_primitive=t`, `auth_tem_wrapper=t`, `cron_agendado=1`.

## Follow-up (separado)

Watchdog de frescor no `_data_health_compute` (a MV **não** é coberta hoje pelo Sentinela) — em PR próprio (recria função quente de 546 linhas, merece foco + prova dedicada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
