### PR TITLE
feat(afiacao): recomendação nunca_afiada — empurra a 1ª afiação do cliente novo (PR4 benchmark #13)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-recomendacao-nunca-afiada-design.md
+++ b/docs/superpowers/specs/2026-07-17-recomendacao-nunca-afiada-design.md
@@ -1,0 +1,82 @@
+# Recomendação `nunca_afiada` — 4ª regra determinística (benchmark #13)
+
+**Data:** 2026-07-17 · **Escopo:** 1 PR frontend, sem migration/edge · **Deploy:** Publish no Lovable.
+
+## Problema (verificado em produção, psql-ro)
+
+Toda a base viva do app do cliente são **4 `user_tools` em 2 clientes**, todas categoria
+"Serra Circular de Widea", com `next_sharpening_due`, `last_sharpened_at` e
+`sharpening_interval_days` **NULL** e `suggested_interval_days` (categoria) = 120.
+A tabela `orders` está **vazia** (0 pedidos).
+
+Pelas 3 regras atuais de `src/lib/afiacao/recomendacoes.ts` nenhum card renderiza:
+- `possivelmente_atrasada` exige `last_sharpened_at` (para projetar last+intervalo) → false.
+- `sem_programacao` exige intervalo nulo, mas a categoria dá 120 → false.
+- `economia` exige pedidos entregues → null (e a Central oculta 'economia').
+
+**Buraco conceitual:** ferramenta cadastrada + intervalo conhecido + NUNCA afiada
+(`last` NULL) + sem agendamento (`next_due` NULL) cai num limbo — lida como "tem
+programação" (tem intervalo), mas sem data alguma para calcular. Atinge justamente o
+cliente recém-chegado, onde o empurrão mais importa.
+
+**Agravante descoberto:** a `main` (PR #1372) já tirou a seção de recomendações da home
+— o empurrão do cliente novo passou a depender do `PriorityCard`. Mas `all_good` é o
+último degrau de `priority.ts` e não olha histórico: 1 dos 2 clientes reais (com endereço)
+lê **"Tudo em dia! Suas ferramentas estão bem cuidadas"** sem nunca ter afiado.
+Mesma família de erro que "ausente ≠ zero".
+
+## Solução
+
+Nova regra determinística `nunca_afiada` = `next_sharpening_due IS NULL AND
+last_sharpened_at IS NULL` (independe do intervalo — fato verificável, sem inferência,
+sem fabricar número).
+
+### 1. Helper puro `recomendacoes.ts` (fonte única do predicado)
+
+- Exporta `ehNuncaAfiada(t: { next_sharpening_due; last_sharpened_at })`.
+- Novo tipo `{ tipo: 'nunca_afiada'; ferramentas: FerramentaAfetada[] }`.
+- **Precedência por exclusão mútua** (não por ordem frágil): `ehSemProgramacao` passa a
+  exigir `last_sharpened_at != null`. Cada ferramenta cai em EXATAMENTE um balde:
+
+  | next_due | last | intervalo | regra |
+  |---|---|---|---|
+  | NULL | NULL | qualquer | **nunca_afiada** (as 4 de produção) |
+  | NULL | set | set, projeção vencida | possivelmente_atrasada |
+  | NULL | set | NULL | sem_programacao |
+  | set  | — | — | agendada → PriorityCard (fora das consultivas) |
+
+  `possivelmente_atrasada` (last≠null) e `nunca_afiada` (last=null) já são exclusivas.
+- Ordem de apresentação: `possivelmente_atrasada → nunca_afiada → sem_programacao → economia`.
+
+### 2. Card na Central — `RecomendacoesCliente.tsx`
+
+Card `nunca_afiada`: ícone `CalendarPlus`, título "N ferramenta(s) cadastrada(s), ainda
+sem afiação", descrição com nomes + "agende a primeira afiação para começar", CTA
+"Agendar afiação" → `/new-order`. **Não** entra em `ocultarTipos` (é o alcance-alvo).
+
+### 3. Home — `priority.ts`
+
+Novo degrau `nunca_afiada` **imediatamente antes de `all_good`**, reusando `ehNuncaAfiada`
+(mesmo predicado). `variant: 'default'` (convite, não alarme), CTA → `/new-order`. Só
+substitui a falsa tranquilidade: `quote`/`tools_overdue`/`no_tools`/`no_address` intactos
+(o cliente sem endereço segue vendo "Cadastre um endereço").
+
+## Testes (TDD)
+
+- `recomendacoes.test.ts`: novo `describe` nunca_afiada (dispara; precede sem_programacao;
+  exclusivo de possivelmente_atrasada; com/sem intervalo). Consertar 3 fixtures que mudam
+  de balde (dar `last` SET onde o alvo era sem_programacao).
+- `priority.test.ts`: "tudo em dia" ganha `last` + `next` futuro (all_good legítimo);
+  +teste do degrau nunca_afiada disparando antes de all_good.
+- `CentralFerramenta.test.tsx`: +teste com as 4 ferramentas reais (all-null + categoria 120)
+  provando que o card aparece.
+
+## Verificação
+
+Sem QA visual por impersonação (lente "Ver como" não lista clientes de afiação, só farmers).
+Validar por `bun run typecheck` + `bun run test` + bytes (skill lovable-deploy-verify).
+
+## Fora de escopo (anotado)
+
+Cabeçalho de `recomendacoes.ts` cita `docs/historico/benchmark-concorrentes-marcenaria-2026-07.md`,
+que só existe no PR #1305 (aberto) — referência morta, não é arquivo desta entrega.

--- a/src/components/customerDashboard/RecomendacoesCliente.tsx
+++ b/src/components/customerDashboard/RecomendacoesCliente.tsx
@@ -7,7 +7,7 @@ import { motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Clock, CalendarClock, PiggyBank, ChevronRight } from 'lucide-react';
+import { Clock, CalendarClock, CalendarPlus, PiggyBank, ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useAuth } from '@/contexts/AuthContext';
 import { useDeliveredOrders12m } from '@/queries/useOrders';
@@ -89,6 +89,27 @@ function RecomendacaoCard({
         onClick={() => {
           track('recomendacoes.cta', { tipo: rec.tipo });
           navigate('/savings');
+        }}
+      />
+    );
+  }
+
+  if (rec.tipo === 'nunca_afiada') {
+    const n = rec.ferramentas.length;
+    return (
+      <CardBase
+        icon={<CalendarPlus className="w-5 h-5 text-status-info" />}
+        iconBg="bg-status-info-bg"
+        titulo={
+          n === 1
+            ? '1 ferramenta cadastrada, ainda sem afiação'
+            : `${n} ferramentas cadastradas, ainda sem afiação`
+        }
+        descricao={`${nomesResumidos(rec.ferramentas)} — agende a primeira afiação para começar a acompanhar o fio.`}
+        ctaLabel="Agendar afiação"
+        onClick={() => {
+          track('recomendacoes.cta', { tipo: rec.tipo });
+          navigate('/new-order');
         }}
       />
     );

--- a/src/components/customerDashboard/__tests__/priority.test.ts
+++ b/src/components/customerDashboard/__tests__/priority.test.ts
@@ -37,13 +37,26 @@ describe("computePriority", () => {
     expect(p.type).toBe("no_tools");
   });
 
-  it("sem endereço quando há ferramentas e tudo ok", () => {
+  it("sem endereço tem precedência sobre nunca_afiada (mesmo cadastrada sem afiar)", () => {
+    // makeTool() default é all-null (nunca afiada); sem endereço, o convite de endereço vence
     const p = computePriority([], [], [makeTool()], false);
     expect(p.type).toBe("no_address");
   });
 
-  it("tudo em dia", () => {
+  it("ferramenta cadastrada mas NUNCA afiada → nunca_afiada, não 'tudo em dia'", () => {
+    // com endereço e sem afiação alguma: empurra a 1ª afiação em vez de afirmar "bem cuidadas"
     const p = computePriority([], [], [makeTool()], true);
+    expect(p.type).toBe("nunca_afiada");
+    expect(p.path).toBe("/new-order");
+  });
+
+  it("tudo em dia só quando JÁ afiou e está no prazo", () => {
+    const p = computePriority(
+      [],
+      [],
+      [makeTool({ last_sharpened_at: "2026-01-01", next_sharpening_due: "2999-01-01" })],
+      true,
+    );
     expect(p.type).toBe("all_good");
     expect(p.variant).toBe("success");
   });

--- a/src/components/customerDashboard/priority.ts
+++ b/src/components/customerDashboard/priority.ts
@@ -1,6 +1,7 @@
 // Lógica de ação prioritária do CustomerDashboard.
 // Extraída verbatim de src/components/CustomerDashboard.tsx (god-component split).
-import { AlertTriangle, Wrench, MapPin, CheckCircle2, FileText } from 'lucide-react';
+import { AlertTriangle, Wrench, MapPin, CalendarPlus, CheckCircle2, FileText } from 'lucide-react';
+import { ehNuncaAfiada } from '@/lib/afiacao/recomendacoes';
 import type { Order, UserTool, PriorityAction } from './types';
 
 export function computePriority(
@@ -51,7 +52,20 @@ export function computePriority(
     };
   }
 
-  // 5. All good
+  // 5. Cadastrou mas nunca afiou — empurra a 1ª afiação (não é "tudo em dia": sem
+  //    histórico não há o que estar "bem cuidado"). Mesmo predicado do helper de
+  //    recomendações (fonte única) — ausente ≠ zero.
+  const nuncaAfiadas = userTools.filter(ehNuncaAfiada);
+  if (nuncaAfiadas.length > 0) {
+    return {
+      type: 'nunca_afiada', variant: 'default', icon: CalendarPlus,
+      title: 'Agende a primeira afiação',
+      description: `${nuncaAfiadas.length} ferramenta${nuncaAfiadas.length === 1 ? '' : 's'} cadastrada${nuncaAfiadas.length === 1 ? '' : 's'} ainda sem nenhuma afiação. Agende a primeira para começar.`,
+      buttonLabel: 'Agendar afiação', path: '/new-order',
+    };
+  }
+
+  // 6. All good
   return {
     type: 'all_good', variant: 'success', icon: CheckCircle2,
     title: 'Tudo em dia!',

--- a/src/components/customerDashboard/types.ts
+++ b/src/components/customerDashboard/types.ts
@@ -25,7 +25,7 @@ export interface UserTool {
 }
 
 export interface PriorityAction {
-  type: 'quote' | 'order_issue' | 'tools_overdue' | 'no_tools' | 'no_address' | 'all_good';
+  type: 'quote' | 'order_issue' | 'tools_overdue' | 'no_tools' | 'no_address' | 'nunca_afiada' | 'all_good';
   title: string;
   description: string;
   buttonLabel?: string;

--- a/src/lib/afiacao/recomendacoes.test.ts
+++ b/src/lib/afiacao/recomendacoes.test.ts
@@ -64,8 +64,9 @@ describe('gerarRecomendacoes — possivelmente_atrasada (não-agendada)', () => 
       hoje: HOJE,
     });
     expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
-    // e também não cai em sem_programacao (tem intervalo → há base de lembrete)
+    // sem last não é "atrasada" — mas cadastrada-sem-afiação vira nunca_afiada, não sem_programacao
     expect(pick(recs, 'sem_programacao')).toBeUndefined();
+    expect(pick(recs, 'nunca_afiada')).toBeDefined();
   });
 
   it('NÃO sinaliza sem intervalo algum (ferramenta nem categoria)', () => {
@@ -106,29 +107,95 @@ describe('gerarRecomendacoes — possivelmente_atrasada (não-agendada)', () => 
   });
 });
 
-describe('gerarRecomendacoes — sem_programacao', () => {
-  it('sinaliza ferramenta sem next_due e sem intervalo algum', () => {
+describe('gerarRecomendacoes — nunca_afiada (cadastrada, sem afiação alguma)', () => {
+  it('sinaliza ferramenta sem agendamento E sem última afiação (as 4 de produção)', () => {
     const recs = gerarRecomendacoes({
-      tools: [tool({ id: 'x', nome: 'Faca', next_sharpening_due: null, sharpening_interval_days: null, suggested_interval_days: null })],
+      // caso REAL: next_due NULL, last NULL, sem intervalo próprio, categoria dá 120
+      tools: [tool({ id: 'w', nome: 'Serra Circular de Widea', suggested_interval_days: 120 })],
+      economia: null,
+      hoje: HOJE,
+    });
+    const r = pick(recs, 'nunca_afiada');
+    expect(r?.ferramentas).toEqual([{ id: 'w', nome: 'Serra Circular de Widea' }]);
+  });
+
+  it('dispara MESMO com intervalo definido — o intervalo não substitui a 1ª afiação', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ id: 'i', nome: 'Plaina', sharpening_interval_days: 30 })], // last/next NULL
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'nunca_afiada')?.ferramentas).toEqual([{ id: 'i', nome: 'Plaina' }]);
+    // e NÃO cai em sem_programacao (nunca_afiada tem precedência) nem em possivelmente_atrasada
+    expect(pick(recs, 'sem_programacao')).toBeUndefined();
+    expect(pick(recs, 'possivelmente_atrasada')).toBeUndefined();
+  });
+
+  it('precede sem_programacao: ferramenta all-null é nunca_afiada, nunca sem_programacao', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ next_sharpening_due: null, last_sharpened_at: null, sharpening_interval_days: null, suggested_interval_days: null })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'nunca_afiada')).toBeDefined();
+    expect(pick(recs, 'sem_programacao')).toBeUndefined();
+  });
+
+  it('é exclusiva de possivelmente_atrasada: quem já afiou (last set) não é nunca_afiada', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ last_sharpened_at: '2026-06-01', sharpening_interval_days: 30 })], // vencida
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'nunca_afiada')).toBeUndefined();
+    expect(pick(recs, 'possivelmente_atrasada')).toBeDefined();
+  });
+
+  it('NÃO sinaliza ferramenta já agendada (tem next_due), mesmo sem last', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ next_sharpening_due: '2026-08-01', last_sharpened_at: null })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'nunca_afiada')).toBeUndefined();
+  });
+});
+
+describe('gerarRecomendacoes — sem_programacao (já afiou, mas sem cadência)', () => {
+  it('sinaliza ferramenta que JÁ afiou, sem next_due e sem intervalo algum', () => {
+    const recs = gerarRecomendacoes({
+      // last set (já afiou) isola sem_programacao de nunca_afiada
+      tools: [tool({ id: 'x', nome: 'Faca', last_sharpened_at: '2026-01-01', next_sharpening_due: null, sharpening_interval_days: null, suggested_interval_days: null })],
       economia: null,
       hoje: HOJE,
     });
     const r = pick(recs, 'sem_programacao');
     expect(r?.ferramentas).toEqual([{ id: 'x', nome: 'Faca' }]);
+    expect(pick(recs, 'nunca_afiada')).toBeUndefined();
   });
 
   it('NÃO sinaliza quando há intervalo (existe base para lembrete)', () => {
     const recs = gerarRecomendacoes({
-      tools: [tool({ next_sharpening_due: null, sharpening_interval_days: 45 })],
+      tools: [tool({ last_sharpened_at: '2026-07-10', next_sharpening_due: null, sharpening_interval_days: 45 })],
       economia: null,
       hoje: HOJE,
     });
     expect(pick(recs, 'sem_programacao')).toBeUndefined();
   });
 
+  it('NÃO sinaliza ferramenta nunca afiada (essa é nunca_afiada, não sem_programacao)', () => {
+    const recs = gerarRecomendacoes({
+      tools: [tool({ last_sharpened_at: null, next_sharpening_due: null, sharpening_interval_days: null })],
+      economia: null,
+      hoje: HOJE,
+    });
+    expect(pick(recs, 'sem_programacao')).toBeUndefined();
+    expect(pick(recs, 'nunca_afiada')).toBeDefined();
+  });
+
   it('NÃO sinaliza ferramenta já agendada (tem next_due)', () => {
     const recs = gerarRecomendacoes({
-      tools: [tool({ next_sharpening_due: '2026-08-01', sharpening_interval_days: null, suggested_interval_days: null })],
+      tools: [tool({ last_sharpened_at: '2026-01-01', next_sharpening_due: '2026-08-01', sharpening_interval_days: null, suggested_interval_days: null })],
       economia: null,
       hoje: HOJE,
     });
@@ -206,16 +273,17 @@ describe('gerarRecomendacoes — composição e ordem', () => {
     expect(gerarRecomendacoes({ tools: [], economia: null, hoje: HOJE })).toEqual([]);
   });
 
-  it('ordena: possivelmente_atrasada → sem_programacao → economia', () => {
+  it('ordena: possivelmente_atrasada → nunca_afiada → sem_programacao → economia', () => {
     const recs = gerarRecomendacoes({
       tools: [
         tool({ id: 'p', last_sharpened_at: '2026-06-01', sharpening_interval_days: 30 }), // possivelmente atrasada
-        tool({ id: 's', next_sharpening_due: null, sharpening_interval_days: null }), // sem programação
+        tool({ id: 'n', next_sharpening_due: null, last_sharpened_at: null }), // nunca afiada
+        tool({ id: 's', last_sharpened_at: '2026-01-01', next_sharpening_due: null, sharpening_interval_days: null }), // sem programação (já afiou)
       ],
       economia: economia({ totalAfiacoes: 10, totalGastoReal: 500 }),
       hoje: HOJE,
     });
-    expect(recs.map((r) => r.tipo)).toEqual(['possivelmente_atrasada', 'sem_programacao', 'economia']);
+    expect(recs.map((r) => r.tipo)).toEqual(['possivelmente_atrasada', 'nunca_afiada', 'sem_programacao', 'economia']);
   });
 });
 

--- a/src/lib/afiacao/recomendacoes.ts
+++ b/src/lib/afiacao/recomendacoes.ts
@@ -39,6 +39,7 @@ export interface FerramentaAfetada {
 
 export type Recomendacao =
   | { tipo: 'possivelmente_atrasada'; ferramentas: FerramentaAfetada[] }
+  | { tipo: 'nunca_afiada'; ferramentas: FerramentaAfetada[] }
   | { tipo: 'sem_programacao'; ferramentas: FerramentaAfetada[] }
   | {
       tipo: 'economia';
@@ -85,9 +86,23 @@ function ehPossivelmenteAtrasada(t: ToolInput, hoje: Date): boolean {
   return differenceInCalendarDays(hoje, projetada) > 0;
 }
 
-/** Sem next_due E sem intervalo algum → não há base para lembrete. */
+/**
+ * Cadastrada mas SEM nenhuma afiação: não-agendada E nunca afiada. Independe do
+ * intervalo — ter cadência não substitui a 1ª afiação, e sem `last` não há data
+ * alguma para projetar. Fato verificável (não inferência). Atinge o cliente novo,
+ * onde o empurrão mais importa. Precede `sem_programacao` (que exige já ter afiado).
+ */
+export function ehNuncaAfiada(t: Pick<ToolInput, 'next_sharpening_due' | 'last_sharpened_at'>): boolean {
+  return t.next_sharpening_due == null && t.last_sharpened_at == null;
+}
+
+/**
+ * JÁ afiou antes (last set), mas sem next_due E sem intervalo → sem base para o
+ * próximo lembrete. O recorte `last != null` cede o caso "nunca afiada" à regra
+ * `nunca_afiada` (baldes exclusivos: nenhuma ferramenta gera dois cards).
+ */
 function ehSemProgramacao(t: ToolInput): boolean {
-  return t.next_sharpening_due == null && intervaloEfetivo(t) == null;
+  return t.last_sharpened_at != null && t.next_sharpening_due == null && intervaloEfetivo(t) == null;
 }
 
 /** Atrasada de fato: agendada-vencida OU possivelmente-atrasada (não-agendada projetada). */
@@ -123,7 +138,8 @@ function calcularEconomia(
 
 /**
  * Recomendações consultivas determinísticas, na ordem de prioridade:
- * possivelmente_atrasada → sem_programacao → economia. Só entra o que o dado sustenta.
+ * possivelmente_atrasada → nunca_afiada → sem_programacao → economia.
+ * Só entra o que o dado sustenta.
  */
 export function gerarRecomendacoes(input: GerarRecomendacoesInput): Recomendacao[] {
   const { tools, economia } = input;
@@ -135,6 +151,11 @@ export function gerarRecomendacoes(input: GerarRecomendacoesInput): Recomendacao
   const atrasadas = tools.filter((t) => ehPossivelmenteAtrasada(t, hoje));
   if (atrasadas.length > 0) {
     recs.push({ tipo: 'possivelmente_atrasada', ferramentas: atrasadas.map((t) => ({ id: t.id, nome: t.nome })) });
+  }
+
+  const nuncaAfiadas = tools.filter(ehNuncaAfiada);
+  if (nuncaAfiadas.length > 0) {
+    recs.push({ tipo: 'nunca_afiada', ferramentas: nuncaAfiadas.map((t) => ({ id: t.id, nome: t.nome })) });
   }
 
   const semProgramacao = tools.filter(ehSemProgramacao);

--- a/src/pages/__tests__/CentralFerramenta.test.tsx
+++ b/src/pages/__tests__/CentralFerramenta.test.tsx
@@ -170,6 +170,26 @@ describe('CentralFerramenta', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/savings');
   });
 
+  it('cliente novo (ferramentas all-null, categoria com intervalo, 0 pedidos): empurra a 1ª afiação', () => {
+    // Réplica do estado REAL de produção: cadastrou, categoria dá intervalo (120),
+    // mas next_due/last/intervalo-próprio NULL e nenhum pedido → cai no limbo nunca_afiada.
+    const { container } = setup({
+      summary: { ...EMPTY_SUMMARY, totalTools: 0 }, // sem economia (cliente novo)
+      tools: [
+        { id: 't1', next_sharpening_due: null, last_sharpened_at: null, sharpening_interval_days: null, tool_categories: { name: 'Serra Circular de Widea', suggested_interval_days: 120 } },
+        { id: 't2', next_sharpening_due: null, last_sharpened_at: null, sharpening_interval_days: null, tool_categories: { name: 'Serra Circular de Widea', suggested_interval_days: 120 } },
+      ],
+      deliveredOrders: [], // nenhum pedido entregue
+    });
+    const txt = container.textContent ?? '';
+    expect(txt).toContain('Recomendações para você');
+    expect(txt).toContain('ainda sem afiação'); // card nunca_afiada aparece
+    expect(txt).not.toContain('Você já economizou'); // sem economia fabricada
+    // o CTA leva a criar o primeiro pedido
+    fireEvent.click(screen.getByRole('button', { name: /agendar afiação/i }));
+    expect(mockNavigate).toHaveBeenCalledWith('/new-order');
+  });
+
   it('mostra recomendação consultiva (atraso) mas NUNCA o card de economia — o herói já cobre', () => {
     const { container } = setup({
       summary: { ...EMPTY_SUMMARY, totalTools: 5, totalSpent: 500, totalSavings: 1500, savingsPercent: 75 },


### PR DESCRIPTION
## PR-4 (benchmark #13) — a 4ª regra consultiva que alcança o cliente recém-chegado

Quarto PR do programa. Fecha o **alcance ZERO** das recomendações consultivas, verificado no banco de produção (psql-ro, 2026-07-17).

### O problema (medido, não suposto)
Toda a base viva do app do cliente são **4 `user_tools` em 2 clientes**, todas "Serra Circular de Widea", com `next_sharpening_due` / `last_sharpened_at` / `sharpening_interval_days` **NULL** e `suggested_interval_days` (categoria) = 120. A tabela `orders` está **vazia**. Pelas 3 regras atuais, **nenhum card renderiza para ninguém**:
- `possivelmente_atrasada` exige `last` (para projetar) → false
- `sem_programacao` exige intervalo nulo, mas a categoria dá 120 → false
- `economia` exige pedidos entregues → null

Ferramenta cadastrada + intervalo conhecido + **nunca afiada** (`last` NULL) + sem agendamento (`next_due` NULL) caía num limbo: lida como "tem programação" (tem intervalo), mas sem data alguma para calcular. Atinge justamente o recém-chegado, onde o empurrão mais importa.

### Agravante descoberto nesta sessão
A `main` (PR #1372) já tirou a seção de recomendações da home — o empurrão do cliente novo passou a depender do `PriorityCard`. Mas `all_good` é o último degrau de `priority.ts` e **não olha histórico**: rodando os 2 clientes reais, 1 deles (com endereço) lia **"Tudo em dia! Suas ferramentas estão bem cuidadas"** sem nunca ter afiado. Mesma família de erro que "ausente ≠ zero" — e a própria Central já resolve melhor (`toolsDesc`: "Sem prazo NÃO é 'em dia'"); a home é que ficou para trás. Isso satisfaz a condição exata do follow-up do Codex no #1372 (promover via `PriorityCard` quando `sem_programacao` perder relevância para quem não abre a Central).

### Solução
4ª regra determinística `nunca_afiada` = `next_due IS NULL AND last IS NULL` (independe do intervalo — fato verificável, sem inferência, sem fabricar número).

- **`recomendacoes.ts`**: predicado exportado `ehNuncaAfiada` (fonte única) + novo tipo. **Precedência por exclusão mútua** (não por ordem frágil): `ehSemProgramacao` passa a exigir `last != null` ("já afiou, mas sem cadência"). Cada ferramenta cai em **exatamente um** balde. Ordem: `possivelmente_atrasada → nunca_afiada → sem_programacao → economia`.
- **`RecomendacoesCliente.tsx`**: card `nunca_afiada` (ícone `CalendarPlus`, CTA "Agendar afiação" → `/new-order`). **Não** entra em `ocultarTipos` — é o alcance-alvo.
- **`priority.ts`**: novo degrau `nunca_afiada` **imediatamente antes de `all_good`**, reusando `ehNuncaAfiada`. Só substitui a falsa tranquilidade — `quote`/`tools_overdue`/`no_tools`/`no_address` intactos (o cliente sem endereço segue vendo "Cadastre um endereço").

| next_due | last | intervalo | regra |
|---|---|---|---|
| NULL | NULL | qualquer | **nunca_afiada** ← as 4 de produção |
| NULL | set | set, vencida | possivelmente_atrasada |
| NULL | set | NULL | sem_programacao |
| set | — | — | agendada → PriorityCard |

### Money-path preservado
`nunca_afiada` é **fato** (duas colunas NULL), não estimativa. Nenhum número fabricado; geração das outras 3 regras inalterada.

### Testes (TDD, vermelho antes do verde)
- Helper: novo `describe` nunca_afiada (dispara; precede sem_programacao; exclusivo de possivelmente_atrasada; com/sem intervalo); 3 fixtures ajustadas para a nova semântica de `sem_programacao`.
- `priority.test`: `all_good` agora exige histórico (com `last` + prazo futuro) + teste do degrau novo + teste de precedência de `no_address`.
- `CentralFerramenta.test`: réplica do estado real de produção (all-null + categoria 120 + 0 pedidos) prova que o card aparece e o CTA leva a `/new-order`.
- typecheck limpo · suíte verde (**600 arquivos, 5312 testes**).

### Deploy
Frontend puro — **sem migration, sem edge**. Precisa de 🖱️ **Publish** no Lovable.

### Verificação
Sem QA visual por impersonação (a lente "Ver como" não lista clientes de afiação, só farmers) — validado por teste + typecheck; bytes pós-Publish via `lovable-deploy-verify`.

### Nota (fora de escopo)
O cabeçalho de `recomendacoes.ts` cita `docs/historico/benchmark-concorrentes-marcenaria-2026-07.md`, que só existe no PR #1305 (ainda aberto) — referência morta, não é arquivo desta entrega.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
