### PR TITLE
docs(deploy): deployar edge sobe o arquivo da main, não só seu diff — pré-flight das deps de banco

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -11,6 +11,12 @@
 ## Edge — armadilhas
 
 - **Deploy SÓ depois do merge** — o chat lê a `main`; deployar antes pega o código velho.
+- **Deployar uma edge sobe o ARQUIVO INTEIRO da `main`, não só o seu diff** → o pré-flight é das dependências de banco de TODO o arquivo, inclusive código de PRs de TERCEIROS mergeados desde o último deploy dela. É a irmã da armadilha da migration silenciosa, vista do outro lado: não foi a migration que faltou aplicar — foi o **deploy do código que a exigia** que chegou depois e revelou a falta. Mordido 2026-07-17 (Fatia 2 do épico-drop): deployei `carteira-rebuild` verbatim (a MINHA mudança tinha as deps checadas: `identity_state` existia no schema) — mas o arquivo da main carregava junto o lease do #1333 (`claim_carteira_rebuild`/`finalizar_carteira_rebuild`), mergeado dias antes, cuja migration NUNCA fora aplicada. As duas metades faltando (edge do #1333 nunca deployada + migration nunca aplicada) se cancelavam; meu deploy correto trouxe só a metade-código → **rebuild 500 em produção por ~40min** (`claim: Could not find the function ... in the schema cache`), carteira congelada no snapshot do dia anterior (modo-falha seguro: o `claim` é o 1º passo, morre ANTES de escrever). **Pré-flight barato (roda em segundos, teria pego):** antes de dar o prompt de deploy de uma edge, cruze as RPCs que ela chama com o que existe em prod —
+  ```bash
+  grep -rhoE "\.rpc\('[a-z_]+'" supabase/functions/<edge>/ | sed "s/.*rpc('//;s/'//" | sort -u
+  # cada uma: ~/.config/afiacao/psql-ro -c "select 1 from pg_proc where proname='<rpc>';"  (vazio = bomba armada)
+  ```
+  Varredura do repo inteiro em 2026-07-17: das 16 RPCs chamadas por edges, as 16 existem em prod — o `claim_carteira_rebuild` era o único caso. Vale o mesmo raciocínio p/ tabela/coluna/view nova que o arquivo referencie.
 - **Proibir "melhorias"** — instrua o chat a deployar **verbatim** o arquivo do repo (o Lovable tende a reescrever a função).
 - **Verificar por comportamento/bytes, não pela palavra do Lovable** — `503 LOAD_FUNCTION_ERROR` + zero `running` no log = a edge não BOOTA → fix é **redeploy**, não código (ver `docs/agent/sync.md`).
 - **`config.toml` pode vir com `[functions.<x>]` DUPLICADO** (bug do bot do Lovable) → TOML inválido (`redefine an already defined table`) que **quebra o `supabase` CLI** no parse. Fix: apagar a 2ª entrada (se idêntica = no-op de comportamento) — pode reaparecer num "Changes" do bot. (#974)


### PR DESCRIPTION
## O incidente

Durante a validação da Fatia 2 (#1358), eu deployei a edge `carteira-rebuild` — corretamente, verbatim da main — e ela passou a dar **500 em produção** por ~40 minutos:

```
{"ok":false,"error":"claim: Could not find the function public.claim_carteira_rebuild(p_run_id) in the schema cache"}
```

A carteira congelou no snapshot do dia anterior (o `claim` é o primeiro passo do rebuild → morre antes de escrever, então **modo-falha seguro**, sem corrupção). Mas o cron noturno das 07:30 falharia todo dia até a causa ser resolvida.

## A causa não foi a Fatia 2

O arquivo `carteira-rebuild/index.ts` da main não era só a minha mudança — ele carregava junto o **lease do #1333** (`claim_carteira_rebuild` / `finalizar_carteira_rebuild`), mergeado dias antes. A migration que cria essas funções **nunca foi aplicada** no banco.

Ficou latente porque o edge do #1333 **também nunca tinha sido deployado**: o binário em produção era o antigo, sem lease. As duas metades faltando (migration não-aplicada + edge não-deployada) se cancelavam. Meu deploy correto trouxe só a metade-código, e expôs a falta da outra.

## Por que virou regra

Eu verifiquei as dependências de banco da **minha** mudança (confirmei que `identity_state` existia no schema antes de dar o prompt de deploy). Não verifiquei as do **resto do arquivo**. É a irmã da armadilha nº 1 do CLAUDE.md — migration custom não auto-aplica, falha silenciosa — vista do outro lado: aqui não foi a migration que faltou aplicar, foi o **deploy do código que a exigia** que chegou depois e revelou a falta.

O pré-flight é barato e teria pego (roda em segundos):

```bash
grep -rhoE "\.rpc\('[a-z_]+'" supabase/functions/<edge>/ | sed "s/.*rpc('//;s/'//" | sort -u
# cada uma: psql-ro -c "select 1 from pg_proc where proname='<rpc>';"   (vazio = bomba armada)
```

Varri o repo inteiro: das **16 RPCs** chamadas por edges, as 16 existem em prod. O `claim_carteira_rebuild` era o único caso — já desarmado (migration aplicada, rebuild validado: `6909 upserted`, lease `complete/fim`, distribuição idêntica ao baseline).

## Estado

- ✅ Migration do lease aplicada, rebuild de volta ao ar e validado.
- ✅ Fatia 2 (#1358) no ar e validada contra o baseline — quarantine inerte porque não há doc `ambiguous` hoje (preventivo, como projetado).
- ✅ Nenhuma outra edge na mesma situação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
