### PR TITLE
fix(carteira): carteira_visivel_para/minha_carteira filtram eligible — fecha furo RLS de visibilidade [money-path]

### DIFF
--- a/db/test-carteira-visivel-eligible.sh
+++ b/db/test-carteira-visivel-eligible.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — carteira_visivel_para / minha_carteira filtram `eligible`      ║
+# ║  Prova o furo RLS de visibilidade (money-path/auth). Falsificação nas 2 funcs. ║
+# ║  Spec: docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-*  ║
+# ║      bash db/test-carteira-visivel-eligible.sh > /tmp/t.log 2>&1; echo exit=$? ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="carteira-elig"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migração LÊ mas não cria). Corpos reais de prod.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('master','employee','customer');
+CREATE TYPE public.commercial_role AS ENUM ('operacional','gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE public.commercial_roles (user_id uuid NOT NULL, commercial_role public.commercial_role NOT NULL);
+
+CREATE TABLE public.carteira_assignments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id uuid NOT NULL UNIQUE,
+  owner_user_id uuid NOT NULL,
+  source text NOT NULL,
+  eligible boolean NOT NULL DEFAULT true
+);
+CREATE INDEX idx_carteira_owner_eligible ON public.carteira_assignments (owner_user_id) WHERE eligible;
+
+CREATE TABLE public.carteira_coverage (
+  covered_user_id uuid NOT NULL,
+  covering_user_id uuid NOT NULL,
+  active boolean NOT NULL DEFAULT true,
+  valid_until timestamptz
+);
+
+-- artefato de cliente gateado por carteira (uma das 8 policies; SEM braço de autoria → fecha 100%)
+CREATE TABLE public.farmer_client_scores (
+  customer_user_id uuid NOT NULL,
+  farmer_id uuid,
+  priority_score numeric
+);
+
+-- helpers reais (pg_get_functiondef prod, 2026-07-17)
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+CREATE OR REPLACE FUNCTION public.get_commercial_role(_user_id uuid)
+RETURNS public.commercial_role LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $f$ SELECT commercial_role FROM public.commercial_roles WHERE user_id = _user_id LIMIT 1 $f$;
+
+CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $f$
+  SELECT has_role(_uid, 'master'::app_role)
+    OR (has_role(_uid, 'employee'::app_role)
+        AND get_commercial_role(_uid) IN ('gerencial'::commercial_role,'estrategico'::commercial_role,'super_admin'::commercial_role));
+$f$;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1) — cria carteira_visivel_para + minha_carteira
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260717181500_carteira_visivel_para_filtra_eligible.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# RLS real de farmer_client_scores (fcs_select_carteira) — verbatim do pg_policies de prod.
+# DEPOIS da migration: a policy referencia carteira_visivel_para, que a migration acabou de criar.
+P -q <<'SQL'
+ALTER TABLE public.farmer_client_scores ENABLE ROW LEVEL SECURITY;
+CREATE POLICY fcs_select_carteira ON public.farmer_client_scores FOR SELECT
+USING (
+  ( SELECT public.pode_ver_carteira_completa(( SELECT auth.uid() AS uid)) AS pode_ver_carteira_completa)
+  OR public.carteira_visivel_para(customer_user_id, ( SELECT auth.uid() AS uid))
+);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED + GRANTS
+# ══════════════════════════════════════════════════════════════════════════════
+# MASTER=333 (master) · OWNER=111 (employee/farmer, NÃO-gestor, como Regina) ·
+# GESTOR=444 (employee/gerencial) · OTHER=222 (outro dono, coberto por OWNER)
+# C_ELIG=aaa (dono OWNER, eligible) · C_MASK=bbb (dono OWNER, eligible=false) ·
+# C_COVER_MASK=ccc (dono OTHER, eligible=false; OWNER cobre OTHER)
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),
+  ('22222222-2222-2222-2222-222222222222'),
+  ('33333333-3333-3333-3333-333333333333'),
+  ('44444444-4444-4444-4444-444444444444'),
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc') ON CONFLICT DO NOTHING;
+
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('33333333-3333-3333-3333-333333333333','master'),
+  ('11111111-1111-1111-1111-111111111111','employee'),
+  ('44444444-4444-4444-4444-444444444444','employee'),
+  ('22222222-2222-2222-2222-222222222222','employee');
+INSERT INTO public.commercial_roles(user_id, commercial_role) VALUES
+  ('11111111-1111-1111-1111-111111111111','farmer'),
+  ('44444444-4444-4444-4444-444444444444','gerencial'),
+  ('22222222-2222-2222-2222-222222222222','farmer');
+
+INSERT INTO public.carteira_assignments(customer_user_id, owner_user_id, source, eligible) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','11111111-1111-1111-1111-111111111111','omie',          true),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','11111111-1111-1111-1111-111111111111','hunter_orphan', false),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc','22222222-2222-2222-2222-222222222222','hunter_orphan', false);
+
+INSERT INTO public.carteira_coverage(covered_user_id, covering_user_id, active, valid_until) VALUES
+  ('22222222-2222-2222-2222-222222222222','11111111-1111-1111-1111-111111111111', true, NULL);
+
+INSERT INTO public.farmer_client_scores(customer_user_id, farmer_id, priority_score) VALUES
+  ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','11111111-1111-1111-1111-111111111111', 10),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb','11111111-1111-1111-1111-111111111111', 20),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc','22222222-2222-2222-2222-222222222222', 30);
+
+GRANT SELECT ON public.farmer_client_scores TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION public.carteira_visivel_para(uuid,uuid),
+                          public.pode_ver_carteira_completa(uuid),
+                          public.minha_carteira() TO authenticated, anon;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+M='33333333-3333-3333-3333-333333333333'   # master
+O='11111111-1111-1111-1111-111111111111'   # owner não-gestor
+G='44444444-4444-4444-4444-444444444444'   # gestor
+CE='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'   # cliente eligible
+CM='bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'   # cliente mascarado (dono OWNER)
+CC='cccccccc-cccc-cccc-cccc-cccccccccccc'   # cliente mascarado (dono OTHER, via cobertura)
+
+echo "── gate direto (carteira_visivel_para) ──"
+eq "A1 owner vê cliente ELIGIBLE (positivo)"          "$(Pq -c "SELECT public.carteira_visivel_para('$CE','$O');")" "t"
+eq "A2 owner NÃO vê cliente MASCARADO (o fix)"        "$(Pq -c "SELECT public.carteira_visivel_para('$CM','$O');")" "f"
+eq "A3 master VÊ mascarado (braço master intacto)"    "$(Pq -c "SELECT public.carteira_visivel_para('$CM','$M');")" "t"
+eq "A4 _uid NULL → false (totalidade)"                "$(Pq -c "SELECT public.carteira_visivel_para('$CM',NULL);")" "f"
+eq "A5 cobertura c/ mascarado → false (2º braço)"     "$(Pq -c "SELECT public.carteira_visivel_para('$CC','$O');")" "f"
+eq "A6 gate NUNCA retorna NULL (mesmo uid NULL)"      "$(Pq -c "SELECT (public.carteira_visivel_para('$CE',NULL)) IS NOT NULL;")" "t"
+
+echo "── fim-a-fim via RLS real (fcs_select_carteira) ──"
+OWN=$(Pq -c "SET test.uid='$O'; SET ROLE authenticated; SELECT count(*) FROM public.farmer_client_scores;" | tail -1)
+MAS=$(Pq -c "SET test.uid='$M'; SET ROLE authenticated; SELECT count(*) FROM public.farmer_client_scores;" | tail -1)
+GES=$(Pq -c "SET test.uid='$G'; SET ROLE authenticated; SELECT count(*) FROM public.farmer_client_scores;" | tail -1)
+ANO=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.farmer_client_scores;" | tail -1)
+eq "A7 owner vê só 1 score (o eligible; masca + cobertura fecham)" "$OWN" "1"
+eq "A8 master vê os 3 (pode_ver_carteira_completa)"               "$MAS" "3"
+eq "A9 gestor vê os 3 (BYPASS gestor INTACTO — fix não mexe)"     "$GES" "3"
+eq "A10 anon vê 0"                                                "$ANO" "0"
+
+echo "── RPC minha_carteira ──"
+MC_OWN=$(Pq -c "SET test.uid='$O'; SET ROLE authenticated; SELECT count(*) FROM public.minha_carteira();" | tail -1)
+MC_HAS_MASK=$(Pq -c "SET test.uid='$O'; SET ROLE authenticated; SELECT EXISTS(SELECT 1 FROM public.minha_carteira() WHERE customer_user_id='$CM');" | tail -1)
+eq "A11 minha_carteira do owner devolve só o eligible" "$MC_OWN" "1"
+eq "A12 minha_carteira NÃO devolve o mascarado"        "$MC_HAS_MASK" "f"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (sabota cada função → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+# F1: gate SEM o filtro eligible no braço direto → A2 deve virar 't' e A7 deve virar 3
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.carteira_visivel_para(_customer_user_id uuid, _uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT _uid IS NOT NULL AND (
+    COALESCE(public.has_role(_uid,'master'::app_role),false)
+    OR EXISTS (SELECT 1 FROM public.carteira_assignments a
+               WHERE a.customer_user_id=_customer_user_id AND a.owner_user_id=_uid)  -- SABOTADO: sem AND a.eligible
+    OR EXISTS (SELECT 1 FROM public.carteira_assignments a
+               JOIN public.carteira_coverage c ON c.covered_user_id=a.owner_user_id
+               WHERE a.customer_user_id=_customer_user_id AND a.eligible IS TRUE
+                 AND c.covering_user_id=_uid AND c.active AND (c.valid_until IS NULL OR c.valid_until>now())));
+$$;
+SQL
+F_A2=$(Pq -c "SELECT public.carteira_visivel_para('$CM','$O');")
+F_A7=$(Pq -c "SET test.uid='$O'; SET ROLE authenticated; SELECT count(*) FROM public.farmer_client_scores;" | tail -1)
+if [ "$F_A2" = "t" ] && [ "$F_A7" != "1" ]; then ok "F1 gate furado reabre o mascarado (A2→t, A7→$F_A7) — A2/A7 têm dente"; else bad "F1 sabotei o gate e A2/A7 NÃO mudaram (A2=$F_A2 A7=$F_A7) → asserts fracos"; fi
+P -q -f "$MIG"   # restaura o gate real
+
+# F2: minha_carteira SEM o filtro eligible no braço direto → A12 deve reencontrar o mascarado
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.minha_carteira()
+RETURNS TABLE(customer_user_id uuid, owner_user_id uuid, coberto_de uuid)
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public
+AS $$
+  SELECT a.customer_user_id, a.owner_user_id, NULL::uuid FROM public.carteira_assignments a
+    WHERE a.owner_user_id=auth.uid()  -- SABOTADO: sem AND a.eligible
+  UNION
+  SELECT a.customer_user_id, a.owner_user_id, a.owner_user_id FROM public.carteira_assignments a
+    JOIN public.carteira_coverage c ON c.covered_user_id=a.owner_user_id
+    WHERE c.covering_user_id=auth.uid() AND c.active AND (c.valid_until IS NULL OR c.valid_until>now()) AND a.eligible IS TRUE;
+$$;
+GRANT EXECUTE ON FUNCTION public.minha_carteira() TO authenticated, anon;
+SQL
+F_A12=$(Pq -c "SET test.uid='$O'; SET ROLE authenticated; SELECT EXISTS(SELECT 1 FROM public.minha_carteira() WHERE customer_user_id='$CM');" | tail -1)
+if [ "$F_A12" = "t" ]; then ok "F2 minha_carteira furada reencontra o mascarado (A12→t) — A12 tem dente"; else bad "F2 sabotei minha_carteira e A12 NÃO mudou (=$F_A12) → assert fraco"; fi
+P -q -f "$MIG"   # restaura
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/superpowers/specs/2026-07-16-fatia2-identity-state-quarantine-design.md
+++ b/docs/superpowers/specs/2026-07-16-fatia2-identity-state-quarantine-design.md
@@ -126,7 +126,14 @@ Ambos espelhados **verbatim** no edge (Deno não importa de `src/`) — paridade
 
 1. Membro **nunca** sai do ledger nem da lista do rebuild. Quarantine muda `eligible`, **nunca** a presença.
 2. Todo membro do ledger → **uma** row em `carteira_assignments` (reconciliação; nada fica stale).
-3. Quarantinado → `eligible=false` → zero comissão e invisível (todos os leitores usam `WHERE eligible`).
+3. Quarantinado → `eligible=false` → zero comissão (protegido: `_carteira_positivacao_for_owner`) e
+   invisível na carteira operacional (`escopo-clientes.ts`). ⚠️ **CORRIGIDO 2026-07-17:** a afirmação
+   original *"todos os leitores usam `WHERE eligible`"* era **FALSA** — `carteira_visivel_para` e
+   `minha_carteira` ignoravam `eligible` e vazavam artefatos do cliente via RLS (medido em prod:
+   8/14 consumidores). Fechado o gate + RPC em
+   [2026-07-17-carteira-rls-eligible-visibilidade-design.md](2026-07-17-carteira-rls-eligible-visibilidade-design.md);
+   os braços de **autoria** (`farmer_id`), **`pode_ver_carteira_completa`** (gestor) e **edge service_role**
+   seguem eligible-blind por design — para identidade ambígua isso é um gap de reidentificação aberto (FU1 do design acima).
 4. Consumo é fail-closed (`!== 'verified'`); população é conservadora (só `ambiguous`, só conta oben).
 5. Aditivo: com 0 ambíguos (o caso de hoje), o rebuild produz **exatamente** o resultado atual.
 6. O `owner_user_id` do quarantinado permanece na row (NOT NULL), inerte — o quarantine é **máscara reversível**,

--- a/docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md
+++ b/docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md
@@ -1,0 +1,210 @@
+# Furo de visibilidade: `carteira_visivel_para`/`minha_carteira` ignoram `eligible` — design
+
+> money-path (autorização RLS de carteira + visibilidade de artefatos de cliente). Fecha o furo que a
+> **invariante #3 da Fatia 2** ([2026-07-16-fatia2-identity-state-quarantine-design.md](2026-07-16-fatia2-identity-state-quarantine-design.md))
+> declarou fechado e não está. Estado **medido em PROD via psql-ro (role `claude_ro`) em 2026-07-17**;
+> revisão adversária **Codex `gpt-5.6-sol` xhigh** na metodologia (parecer `DONE_WITH_CONCERNS`).
+> **2 funções, zero DDL de tabela.**
+
+## 1. Ponto de partida (verificado, não presumido)
+
+| fato | evidência (2026-07-17, psql-ro) |
+|---|---|
+| `carteira_visivel_para` ignora `eligible` | `pg_get_functiondef`: `EXISTS(... WHERE customer_user_id=… AND owner_user_id=_uid)` **sem** `AND a.eligible`, em ambos os braços (direto + cobertura) |
+| ela gateia **8 policies RLS** | `carteira_assignments` (SELECT), `farmer_client_scores`, `customer_visit_scores`, `farmer_recommendations`, `farmer_bundle_recommendations`, `farmer_calls`, `route_visits` (SELECT), `visitas_agendadas` (**INSERT** WITH CHECK) |
+| `minha_carteira` ignora `eligible` | idem, nos 2 ramos do UNION; `EXECUTE` p/ `authenticated`; **sem caller no app** (só types gerados) mas exposta como RPC PostgREST |
+| `eligible` | `boolean NOT NULL DEFAULT true`, **0 NULLs**; `carteira_assignments` tem `UNIQUE(customer_user_id)` → 1 linha/cliente |
+| linhas `eligible=false` | **2112** (2093 `hunter_orphan` = fornecedores excluídos + master-parked; 19 `omie` = clones B-lite escondidos) |
+| `carteira_coverage` | **0 linhas** → o braço de cobertura é inerte hoje |
+| repo == prod | `20260524120000_carteira_omie_fase1.sql` define ambas idênticas ao `pg_get_functiondef` de prod — **sem deriva** |
+
+### 1.1 O que a invariante #3 da Fatia 2 errou
+
+A Fatia 2 declara: *"Quarantinado → eligible=false → zero comissão E invisível (todos os leitores usam
+`WHERE eligible`)."* A **1ª metade é verdadeira** (comissão/positivação filtra eligible em
+`_carteira_positivacao_for_owner`; a tela filtra em [escopo-clientes.ts:130](../../../src/lib/carteira/escopo-clientes.ts)).
+A **2ª metade é FALSA**: 8 de 14 consumidores SQL de `carteira_assignments` ignoram `eligible`. O furo é de
+**VISIBILIDADE (autorização RLS)**, não de dinheiro.
+
+## 2. Auditoria caso-a-caso dos 8 que ignoram `eligible`
+
+Precisão > recall: filtrar `eligible` **não é** correto em bloco — `eligible` colapsa dois sentidos
+("aparece na carteira operacional" **e** "autoriza acesso RLS"). Veredito por função (corpo lido de PROD):
+
+| # | função | veredito | porquê |
+|---|---|---|---|
+| 1 | **`carteira_visivel_para`** | 🔴 **FILTRAR** | gate de autz das 8 policies. `farmer_client_scores`/`customer_visit_scores` **não têm** braço de autoria → o fix **fecha 100%** delas. |
+| 2 | **`minha_carteira`** | 🔴 **FILTRAR** | RPC SECURITY DEFINER exposta a `authenticated`; devolve mascarados se chamada direto. Sem caller no app → baixo risco. |
+| 3 | `list_impersonation_targets` | 🟢 não tocar | enumera **reps** (`DISTINCT owner_user_id`), não artefatos de cliente; `eligible` é da relação com o cliente. Inerte: 0 owners são 100%-inelegíveis. Lente "Ver como". |
+| 4 | `criar_plano_tatico` | 🟢 não tocar | já chama `carteira_visivel_para` p/ auth (herda o fix); o `SELECT … FOR UPDATE` é lock/atribuição — precisa achar o owner. Ver §3.1 (fail-open **descartado**). |
+| 5 | `cleanup_orphan_score_on_carteira_delete` | 🟢 não tocar | **razão (corrigida pelo Codex):** com `UNIQUE(customer_user_id)` + `AFTER DELETE`, não sobra outra assignment → `NOT EXISTS` é true com ou sem eligible; mudar eligible→false **não dispara** DELETE. GC testa **existência física**, não visibilidade. |
+| 6–8 | `enqueue_score_recalc_from_{call,sinais}` / `enqueue_visit_score_recalc_from_visit` | 🟢 não tocar | recompute é derivação backend, não leak nem comissão; filtrar = score stale sem ganho. **Condicional (Codex):** vale enquanto fila/sinks forem privados e a elegibilidade for reaplicada **no momento da exposição/comissão** — ver §7-FU3. |
+
+## 3. A mudança (this PR)
+
+### 3.1 `carteira_visivel_para` — filtrar + tornar TOTAL (nunca-NULL)
+
+O Codex apontou fail-open teórico no caller `IF NOT carteira_visivel_para(...)` de `criar_plano_tatico`
+(PL/pgSQL só roda `THEN` em TRUE; se a função retornasse NULL, pula). **Verificado e descartado como bug
+vivo:** `has_role` é `SELECT EXISTS(...)` → nunca NULL; os 2 `EXISTS` nunca são NULL; logo a função nunca
+retorna NULL, e `criar_plano_tatico` ainda guarda `_uid IS NULL` antes. Mesmo assim tornamos o gate
+**provavelmente total** na fonte (custo ~0), o que torna o caller seguro **por construção** — por isso
+`criar_plano_tatico` **não é reescrita** aqui (evita transcrever 60 linhas money-path; o `IS NOT TRUE` do
+caller fica como micro-follow-up FU5).
+
+```sql
+CREATE OR REPLACE FUNCTION public.carteira_visivel_para(_customer_user_id uuid, _uid uuid)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT _uid IS NOT NULL
+    AND (
+      COALESCE(public.has_role(_uid, 'master'::app_role), false)
+      OR EXISTS (
+        SELECT 1 FROM public.carteira_assignments a
+        WHERE a.customer_user_id = _customer_user_id
+          AND a.owner_user_id = _uid
+          AND a.eligible IS TRUE
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.carteira_assignments a
+        JOIN public.carteira_coverage c ON c.covered_user_id = a.owner_user_id
+        WHERE a.customer_user_id = _customer_user_id
+          AND a.eligible IS TRUE
+          AND c.covering_user_id = _uid
+          AND c.active
+          AND (c.valid_until IS NULL OR c.valid_until > now())
+      )
+    );
+$function$;
+```
+
+Mudanças vs prod: (a) `AND a.eligible IS TRUE` nos 2 `EXISTS`; (b) wrapper `_uid IS NOT NULL AND (…)` +
+`COALESCE(has_role,…,false)` → totalidade explícita; (c) refs qualificadas (`public.`) — neutraliza
+shadowing de `search_path` para estas funções (Codex §4.5; o `pg_temp`-last repo-wide é FU7).
+**Equivalência provada:** para `_uid` NULL, prod já retornava false (has_role(NULL)=false via EXISTS;
+EXISTS(owner=NULL)=false) → o wrapper não muda comportamento além da máscara `eligible`.
+
+### 3.2 `minha_carteira` — filtrar os 2 ramos
+
+```sql
+CREATE OR REPLACE FUNCTION public.minha_carteira()
+ RETURNS TABLE(customer_user_id uuid, owner_user_id uuid, coberto_de uuid)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT a.customer_user_id, a.owner_user_id, NULL::uuid AS coberto_de
+  FROM public.carteira_assignments a
+  WHERE a.owner_user_id = auth.uid()
+    AND a.eligible IS TRUE
+  UNION
+  SELECT a.customer_user_id, a.owner_user_id, a.owner_user_id AS coberto_de
+  FROM public.carteira_assignments a
+  JOIN public.carteira_coverage c ON c.covered_user_id = a.owner_user_id
+  WHERE c.covering_user_id = auth.uid()
+    AND c.active
+    AND (c.valid_until IS NULL OR c.valid_until > now())
+    AND a.eligible IS TRUE;
+$function$;
+```
+
+### 3.3 Aplicação (Codex §6)
+
+Uma transação; reafirmar `STABLE`/`SECURITY DEFINER`/`SET search_path` (CREATE OR REPLACE preserva owner
+e grants — **verificado: sem `EXECUTE` para PUBLIC**, nada a revogar). Assertion pós-apply por
+`pg_get_functiondef` (a última a recriar vence; serializar deploy).
+
+## 4. Impacto medido (PROD)
+
+Restrição **monotônica**: linhas só somem, **0 ganham** visibilidade.
+
+| owner afetado | papel | `pode_ver_carteira_completa` | `eligible=false` | efeito do fix |
+|---|---|---|---|---|
+| lucascoelhosardenberg | **master** | ✅ | 2093 | **ZERO** (lê tudo pelo braço `master`, intacto, + policy `Master manage`) |
+| REGINA CELIA | farmer/employee | ❌ | 14 | perde visibilidade de 14 clientes mascarados |
+| tatyanamartins2002 | farmer/employee | ❌ | 5 | perde visibilidade de 5 clientes mascarados |
+
+**Dos 2112 pares teóricos, 2093 são do master (imune).** O efeito material vivo é **19 pares / 2
+vendedoras não-gestoras**. Dado real fechado pelo fix: `farmer_client_scores` 1459 + `customer_visit_scores`
+1459 (100%, sem braço de autoria) + 91 de 730 `farmer_recommendations`. Nenhum leitor frontend direto
+quebra: o único ([escopo-clientes.ts:128](../../../src/lib/carteira/escopo-clientes.ts)) já filtra
+`eligible=true`.
+
+**Valor primário** não é o volume de hoje — é (a) fechar a **RPC direta `minha_carteira`** e a SELECT de
+`carteira_assignments` para não-master, e (b) **armar o fail-closed** para quando o quarantine de
+identidade ambígua ficar vivo (hoje 0 ambíguos).
+
+## 5. Invariantes (o mapa HONESTO — substitui a #3 da Fatia 2)
+
+1. O gate `carteira_visivel_para` e a RPC `minha_carteira` passam a **filtrar `eligible IS TRUE`** →
+   fecham `farmer_client_scores`/`customer_visit_scores` (100%), a SELECT de `carteira_assignments`
+   (não-master) e o INSERT de `visitas_agendadas`.
+2. O gate é **total** (`_uid IS NOT NULL AND …`, nunca NULL) → callers `IF NOT gate()` são fail-closed.
+3. **NÃO é verdade** que "todos os leitores usam `WHERE eligible`". Continuam eligible-**blind**, por design:
+   os braços de **autoria** (`farmer_id`/`visited_by = auth.uid()`) em recommendations/calls/visits/bundle;
+   **`pode_ver_carteira_completa`** (gestor/master); e **edge functions com `service_role`** (bypassam RLS).
+4. Para **fornecedor-excluído / clone-escondido**, o resíduo de autoria é aceitável (o vendedor já conhece
+   esses clientes; não é caso de esconder identidade). Para **identidade-ambígua** (futuro) o braço de
+   autoria é um **gap de reidentificação aberto** (Codex §5) → FU1.
+5. Aditivo: com os 3 owners de hoje, master é intocado; o efeito é 19 pares em 2 vendedoras.
+
+## 6. Testing — `prove-sql-money-path` (PG17, falsificável)
+
+RLS de alto risco → PG17 local com `SET ROLE authenticated` + GUC `request.jwt.claims`, e **falsificação**.
+
+| cenário | prova |
+|---|---|
+| owner vê cliente `eligible=true` (direto) | policy retorna a linha |
+| owner **não** vê cliente `eligible=false` (direto) | **fechado** pós-fix (regride pré-fix) |
+| master vê `eligible=false` | braço `master` intacto |
+| gestor (`pode_ver_carteira_completa`) vê scores de `eligible=false` | **inalterado** (bypass documentado, §5.3) — asserção de que o fix NÃO mexe nisso |
+| anon / `_uid` NULL | false (totalidade) |
+| cobertura (`carteira_coverage`) com `eligible=false` | fechado (semear 1 linha, já que prod tem 0) |
+| `minha_carteira()` sob `SET ROLE` do owner | não retorna mascarados |
+| **falsificação** | remover `AND a.eligible IS TRUE` de um braço → o assert negativo **tem** que ficar vermelho; baseline VERDE + contagem/nomes dos vermelhos conferidos (lição #1358) |
+
+Baseline pré-apply (psql-ro): `carteira_visivel_para` retorna true hoje para os 19 pares (Regina/Tatyana);
+pós-apply: false. Master: true nos dois. `farmer_client_scores` legíveis por Regina caem de N→N−(seus mascarados).
+
+## 7. Deploy
+
+**🟣 SQL Editor do Lovable** (founder cola — via `lovable-db-operator`). Sem Publish (nenhuma mudança de
+frontend). Sem edge. Verificação pós-apply por `pg_get_functiondef` (psql-ro) + a distribuição de impacto.
+
+## 8. Follow-ups arquivados (decisão Lucas 2026-07-17: fix estreito + arquivar)
+
+Fechar a invariante por completo exige um **split de motivo/estado** que uma flag booleana não expressa
+(Codex: `eligible=false` colapsa fornecedor-excluído / clone / identidade-ambígua). Arquivados, não
+construídos aqui:
+
+- **FU1 — autoria vs quarantine de identidade:** RESTRICTIVE policy central por-cliente **ou** coluna de
+  motivo, p/ autoria sobreviver no fornecedor-excluído mas **não** na identidade-ambígua. Vale p/ futuras
+  `farmer_calls`/`route_visits`/`farmer_bundle_recommendations` (0 hoje). (Codex §5.)
+- **FU2 — audit edge service_role:** 14 edges leem scores/recs/`carteira_assignments` via `service_role`
+  (bypassa RLS); provar que nenhum devolve dado de cliente mascarado a vendedor (`recommend` já usa
+  client-JWT + admin separados — padrão bom). (Codex §3.)
+- **FU3 — policy broad-staff das filas:** `score_recalc_queue`/`visit_score_recalc_queue` SELECT =
+  `master OR employee` → qualquer funcionário lê pares `(cliente,owner)` mascarados (ids-only, transiente).
+  Estreitar p/ master/service ou carteira-scoped. Reaplicar `eligible` no consumo/comissão, não só no
+  enqueue (Codex §1.4-6).
+- **FU4 — modelo de auditoria do gestor:** decidir se `pode_ver_carteira_completa` deve respeitar a máscara
+  ou se o quarantine precisa de superfície de auditoria dedicada. Default hoje: **master-as-auditor**
+  (vê tudo via `Master manage`). (Codex §2.)
+- **FU5 — `criar_plano_tatico` caller `IS NOT TRUE`:** micro-hardening (redundante dado o gate total; belt
+  contra refactor futuro do gate). (Codex §1.2/§4.2.)
+- **FU6 — `eligible DEFAULT true` é fail-open** p/ um writer futuro de identidade não-resolvida (estado
+  inicial seguro = pending/false). (Codex §4.1.)
+- **FU7 — hardening repo-wide de SECURITY DEFINER:** `search_path` com `pg_temp` por último + mover helpers
+  sensíveis de RLS (`carteira_visivel_para` é oráculo "cliente X é do owner Y?") p/ schema não-exposto.
+  (Codex §3/§4.5.)
+- **FU8 — comentário stale:** [useMyCarteiraScores.ts:31](../../../src/hooks/useMyCarteiraScores.ts)
+  diz "a RLS é ampla (qualquer staff lê tudo)" — **falso** (é carteira-scoped: `pode_ver_carteira_completa OR carteira_visivel_para`).
+
+## 9. Correção da invariante #3 da Fatia 2
+
+Editar [2026-07-16-fatia2-identity-state-quarantine-design.md](2026-07-16-fatia2-identity-state-quarantine-design.md)
+§5 invariante 3: trocar *"todos os leitores usam `WHERE eligible`"* pelo mapa honesto (§5 deste doc) e
+apontar para este design + FU1.

--- a/supabase/migrations/20260717181500_carteira_visivel_para_filtra_eligible.sql
+++ b/supabase/migrations/20260717181500_carteira_visivel_para_filtra_eligible.sql
@@ -1,0 +1,61 @@
+-- money-path (autorização RLS de carteira + visibilidade de artefatos de cliente).
+-- Fecha o furo: carteira_visivel_para e minha_carteira IGNORAVAM `eligible` → o dono de uma
+-- assignment eligible=false (fornecedor excluído / clone escondido / futura identidade ambígua)
+-- continuava lendo, via RLS, os artefatos do cliente (scores/visitas/recomendações) e a própria
+-- linha de atribuição. `carteira_visivel_para` gateia 8 policies; `minha_carteira` é RPC exposta a
+-- `authenticated`. Ver docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md.
+--
+-- Idempotente (CREATE OR REPLACE). Pré-flight pg_get_functiondef prod×repo: idênticos (fase1
+-- 20260524120000), sem deriva. Hardening (Codex xhigh): gate TOTAL (nunca-NULL: `_uid IS NOT NULL`
+-- + COALESCE(has_role,false)); `eligible IS TRUE` explícito; refs qualificadas (`public.`) neutralizam
+-- shadowing de search_path. Equivalência p/ _uid NULL: prod já retornava false → o wrapper não muda
+-- comportamento além da máscara `eligible`.
+
+-- ── 1. O GATE (SECURITY DEFINER; 8 policies dependem dele) ────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.carteira_visivel_para(_customer_user_id uuid, _uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT _uid IS NOT NULL
+    AND (
+      COALESCE(public.has_role(_uid, 'master'::app_role), false)
+      OR EXISTS (
+        SELECT 1 FROM public.carteira_assignments a
+        WHERE a.customer_user_id = _customer_user_id
+          AND a.owner_user_id = _uid
+          AND a.eligible IS TRUE
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.carteira_assignments a
+        JOIN public.carteira_coverage c ON c.covered_user_id = a.owner_user_id
+        WHERE a.customer_user_id = _customer_user_id
+          AND a.eligible IS TRUE
+          AND c.covering_user_id = _uid
+          AND c.active
+          AND (c.valid_until IS NULL OR c.valid_until > now())
+      )
+    );
+$$;
+
+-- ── 2. A RPC "minha carteira" (exposta a authenticated via PostgREST) ─────────────────────────
+CREATE OR REPLACE FUNCTION public.minha_carteira()
+RETURNS TABLE(customer_user_id uuid, owner_user_id uuid, coberto_de uuid)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT a.customer_user_id, a.owner_user_id, NULL::uuid AS coberto_de
+  FROM public.carteira_assignments a
+  WHERE a.owner_user_id = auth.uid()
+    AND a.eligible IS TRUE
+  UNION
+  SELECT a.customer_user_id, a.owner_user_id, a.owner_user_id AS coberto_de
+  FROM public.carteira_assignments a
+  JOIN public.carteira_coverage c ON c.covered_user_id = a.owner_user_id
+  WHERE c.covering_user_id = auth.uid()
+    AND c.active
+    AND (c.valid_until IS NULL OR c.valid_until > now())
+    AND a.eligible IS TRUE;
+$$;


### PR DESCRIPTION
Fecha o furo de VISIBILIDADE que a invariante #3 da Fatia 2 (#1358) declarou fechado e não estava: `carteira_visivel_para` (gate de 8 policies RLS) e `minha_carteira` (RPC exposta a `authenticated`) **ignoravam `eligible`** → o dono de uma assignment `eligible=false` (fornecedor excluído / clone escondido / futura identidade ambígua) lia via RLS os artefatos do cliente e a própria linha de atribuição.

Medido em prod (psql-ro): 8/14 consumidores SQL ignoravam `eligible`. Auditoria caso-a-caso → só 2 são furo real (gate + RPC); os outros 6 estão corretos por design (recompute/GC/impersonação — ver spec §2).

## O fix (2 funções, zero DDL de tabela)
`AND a.eligible IS TRUE` nos 2 braços de cada função + **gate total nunca-NULL** (`_uid IS NOT NULL AND COALESCE(has_role,false)`, hardening do Codex xhigh) + refs qualificadas (`public.`). Drift check: repo == prod (fase1 `20260524120000`), sem deriva.

## Evidência
- **Prova PG17 falsificável** (`db/test-carteira-visivel-eligible.sh`): **14 asserts, 2 sabotagens com dente** (gate e RPC). Master + gestor (`pode_ver_carteira_completa`) intactos por design; anon negado; totalidade nunca-NULL; braço de cobertura filtra.
- **Codex `gpt-5.6-sol` xhigh** na metodologia (`DONE_WITH_CONCERNS`) — reconciliado no spec.
- **Impacto medido:** dos 2112 pares `eligible=false`, **2093 são do master (imune)**; efeito vivo = **19 pares em 2 vendedoras não-gestoras**. Fecha 100% de `farmer_client_scores`/`customer_visit_scores` (sem braço de autoria); 0 ganham visibilidade.
- Spec: `docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md` (+ invariante #3 da Fatia 2 corrigida).

## Resíduo por design (mapeado no spec §8, follow-ups arquivados)
Autoria (`farmer_id`), `pode_ver_carteira_completa` (gestor) e edges service_role seguem `eligible`-blind — para identidade ambígua é gap de reidentificação (FU1). Filas broad-staff (FU3). Audit edges (FU2).

## ⚠️ ATENÇÃO: migration manual necessária
Este PR adiciona `supabase/migrations/20260717181500_carteira_visivel_para_filtra_eligible.sql`. **Lovable NÃO aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar (`🟣 Lovable → SQL Editor → cola → Run`).

Validação pós-apply (read-only):
```sql
SELECT CASE
  WHEN (SELECT pg_get_functiondef(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
        WHERE n.nspname='public' AND p.proname='carteira_visivel_para' AND p.prokind='f') ~* 'eligible'
   AND (SELECT pg_get_functiondef(p.oid) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
        WHERE n.nspname='public' AND p.proname='minha_carteira' AND p.prokind='f') ~* 'eligible'
  THEN '✅ ambas filtram eligible' ELSE '❌ FALTANDO — migration não aplicada' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
