### PR TITLE
docs(carteira): RLS de farmer_client_scores é carteira-scoped, não staff-wide (FU8)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md
+++ b/docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md
@@ -200,8 +200,11 @@ construídos aqui:
 - **FU7 — hardening repo-wide de SECURITY DEFINER:** `search_path` com `pg_temp` por último + mover helpers
   sensíveis de RLS (`carteira_visivel_para` é oráculo "cliente X é do owner Y?") p/ schema não-exposto.
   (Codex §3/§4.5.)
-- **FU8 — comentário stale:** [useMyCarteiraScores.ts:31](../../../src/hooks/useMyCarteiraScores.ts)
-  diz "a RLS é ampla (qualquer staff lê tudo)" — **falso** (é carteira-scoped: `pode_ver_carteira_completa OR carteira_visivel_para`).
+- **FU8 — comentário stale: ✅ FEITO (2026-07-18).** [useMyCarteiraScores.ts](../../../src/hooks/useMyCarteiraScores.ts)
+  dizia "a RLS é ampla (qualquer staff lê tudo)" — **falso**. Reescrito contra `pg_policies` medida em prod:
+  `fcs_select_carteira` = `pode_ver_carteira_completa OR carteira_visivel_para` (carteira-scoped, **sem** braço
+  de autoria no SELECT — `farmer_id` só aparece em INSERT/UPDATE/DELETE). Nuance registrada no comentário:
+  p/ gestor o filtro segue display-only; p/ vendedor comum a RLS é a fronteira e recorta por CLIENTE.
 
 ## 9. Correção da invariante #3 da Fatia 2
 

--- a/src/hooks/useMyCarteiraScores.ts
+++ b/src/hooks/useMyCarteiraScores.ts
@@ -27,11 +27,17 @@ export interface CarteiraScoreRow {
  * Busca farmer_client_scores da MINHA carteira (Opção A: farmer_id = dono).
  * Expande pra cobertura ativa: farmer_id IN [eu, ...donos que eu cubro agora].
  *
- * ⚠️ SEGURANÇA: o filtro por farmer_id aqui é display-only, NÃO é fronteira de
- * segurança — a RLS de farmer_client_scores é ampla (qualquer staff lê tudo).
- * A impersonação (effectiveUserId ≠ eu) é master-only (gate no ImpersonationContext)
- * e o master já lê tudo, então isto não abre vazamento novo. Endurecer a RLS dessa
- * tabela (master OR farmer_id=auth.uid() OR cobertura) é follow-up de segurança.
+ * 🔐 RLS de LEITURA (medida em prod 2026-07-18 — `fcs_select_carteira`):
+ * `pode_ver_carteira_completa(uid) OR carteira_visivel_para(customer_user_id, uid)`
+ * — carteira-scoped, NÃO staff-wide. O SELECT não tem braço de autoria; quem tem é
+ * INSERT/UPDATE/DELETE (`... OR farmer_id = uid`) — não confundir os dois.
+ * Consequência: para GESTOR (`pode_ver_carteira_completa` = master, ou employee com
+ * commercial_role gerencial/estrategico/super_admin) o filtro daqui é display-only,
+ * porque ele lê tudo mesmo. Para vendedor NÃO-gestor a RLS é a fronteira real, e ela
+ * recorta pelo CLIENTE (`carteira_assignments` com `eligible IS TRUE` desde #1398, +
+ * cobertura ativa) — eixo distinto do `farmer_id` filtrado aqui, que segue sendo só o
+ * recorte de exibição. Impersonação é master-only (gate no ImpersonationContext) e o
+ * master passa nos dois braços, então não abre vazamento.
  */
 export function useMyCarteiraScores() {
   const { user } = useAuth();


### PR DESCRIPTION
Follow-up **FU8** do fix de RLS/eligible ([spec §8](docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md), PR #1398 mergeado e aplicado em prod).

## O problema

O bloco de comentário de [`useMyCarteiraScores.ts`](src/hooks/useMyCarteiraScores.ts) afirmava:

> ⚠️ SEGURANÇA: (…) a RLS de farmer_client_scores é ampla (**qualquer staff lê tudo**). (…) Endurecer a RLS dessa tabela (…) é **follow-up de segurança**.

**As duas afirmações eram falsas.** Um comentário de segurança errado é pior que nenhum: ele convida a decisões erradas nos dois sentidos — "a RLS não protege, então preciso defender no cliente" e "isso ainda está por fazer, deixa eu re-consertar".

## A realidade (medida em prod via psql-ro, `pg_policies` + `pg_get_functiondef`, 2026-07-18)

| Afirmação antiga | Medido |
|---|---|
| "qualquer staff lê tudo" | **Falso.** `fcs_select_carteira` = `pode_ver_carteira_completa(uid) OR carteira_visivel_para(customer_user_id, uid)`. Não existe policy de leitura staff-wide. |
| "endurecer a RLS é follow-up" | **Já aconteceu.** E o #1398 endureceu mais: `carteira_visivel_para` exige `a.eligible IS TRUE` nos dois `EXISTS` → cliente mascarado sai. |
| (implícito) o SELECT gateia por `farmer_id` | **Não gateia.** O braço de autoria `… OR farmer_id = uid` só existe em INSERT/UPDATE/DELETE. |

As 4 policies de `farmer_client_scores` em prod:

| policy | cmd | tem braço de autoria (`farmer_id`)? |
|---|---|---|
| `fcs_select_carteira` | SELECT | **não** — `pode_ver_carteira_completa OR carteira_visivel_para` |
| `fcs_insert_own_or_gestor` | INSERT | sim |
| `fcs_update_own_or_gestor` | UPDATE | sim |
| `fcs_delete_own_or_gestor` | DELETE | sim |

A confusão entre o SELECT (carteira-scoped) e o INSERT/UPDATE/DELETE (autoria) é provavelmente a origem do erro original — por isso a reescrita separa os dois explicitamente.

## Nuances preservadas

- **Gestor** (`pode_ver_carteira_completa` = master, ou employee com `commercial_role` gerencial/estrategico/super_admin): o filtro por `farmer_id` no hook **segue sendo display-only** — ele lê tudo mesmo.
- **Vendedor não-gestor:** a RLS **é** a fronteira real, e recorta pelo **CLIENTE** (`carteira_assignments` + cobertura ativa) — eixo distinto do `farmer_id` filtrado no hook. Registrei isso explicitamente porque é o que impede a conclusão errada de "então o filtro é redundante, posso tirar".
- **Impersonação:** segue master-only (`lensActive = isMaster && !!target`, [ImpersonationContext.tsx:29](src/contexts/ImpersonationContext.tsx:29)) e o master passa nos **dois** braços da policy → não abre vazamento. Afirmação verificada e mantida.

O comentário novo **nomeia a policy e data a medição** — o anterior apodreceu justamente por afirmar sobre RLS sem âncora verificável.

## Escopo / deploy

Mudança **só de comentário** + marcação do FU8 no spec como feito.

- ❌ Sem migration · ❌ sem edge · ❌ **sem Publish** — comentário não sobrevive ao build (minificador descarta), o bundle servido fica byte-idêntico.
- ✅ `bun run tsc --noEmit` verde (exit 0) — um bloco JSDoc mal fechado é o único jeito de um comentário quebrar o build; era o teste mais barato que pegaria a saída errada.

## Coordenação

Nenhum dos PRs abertos toca `useMyCarteiraScores.ts`. O #1403 é trabalho adjacente sobre a mesma realidade, mas toca só `docs/agent/database.md` — sem colisão.

## Fora de escopo (de propósito)

O **FU4** do spec ("decidir se `pode_ver_carteira_completa` deve respeitar a máscara") segue em aberto — hoje o gestor vê cliente mascarado. Não puxei para o comentário: comentário de código deve dizer o que **é**, não catalogar o que se debate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
