### PR TITLE
fix(agente): pr-watch — exit 6 separa "não consegui consultar" de "sem desfecho"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Diário de PR/entregas: `docs/historico/` (`bugs-resolvidos.md`, `programas-vend
 
 ## Merge (auto)
 
-Todo PR não-draft **auto-mergeia (squash) quando o CI `validate` passa** (`.github/workflows/auto-merge.yml`, zero clique do founder). Para **segurar** um PR, deixe-o **DRAFT**. Nunca `gh pr merge --admin` de rotina (o auto-merge espera o verde — não bypassa o CI). **Ao criar/atualizar PR: arme `scripts/pr-watch.sh <nº>` em background** (Bash `run_in_background:true`) e, no desfecho, avise via PushNotification (mergeado/conflito/CI vermelho) — o founder não fica de poller.
+Todo PR não-draft **auto-mergeia (squash) quando o CI `validate` passa** (`.github/workflows/auto-merge.yml`, zero clique do founder). Para **segurar** um PR, deixe-o **DRAFT**. Nunca `gh pr merge --admin` de rotina (o auto-merge espera o verde — não bypassa o CI). **Ao criar/atualizar PR: arme `scripts/pr-watch.sh <nº>` em background** (Bash `run_in_background:true`) e, no desfecho, avise via PushNotification (mergeado/conflito/CI vermelho) — o founder não fica de poller. **Exit 6 ≠ 5:** 5 = consultei e o PR segue sem desfecho; **6 = NÃO consegui consultar** (rede/rate-limit/máquina dormindo) → estado DESCONHECIDO, confirme com `gh pr view <nº>` **antes** de avisar — reportar "não mergeou" num 6 é falso negativo (o #1396 tinha mergeado).
 
 ## Produto
 

--- a/docs/historico/setup-agente.md
+++ b/docs/historico/setup-agente.md
@@ -1,5 +1,18 @@
 # Setup do agente — diário de entregas
 
+## 2026-07-18 — `pr-watch.sh`: exit 6 separa "não consegui consultar" de "sem desfecho"
+
+**Falso negativo real (#1396, 2026-07-17):** o watcher saiu **5 (TIMEOUT)** num PR que tinha **MERGEADO** normalmente (auto-merge squash, `validate` verde em 5m16s). Causa: `exit 5` era emitido por DOIS caminhos — a consulta bem-sucedida sem desfecho *e* a consulta que falhou (ramo de erro do `gh pr view`) —, indistinguíveis pelo exit code. Um agente que confiasse no código reportaria "não mergeou" ao founder: exatamente o furo de rastreio que o script existe pra fechar ("PR órfão descoberto dias depois", C5 abaixo).
+
+**Pista que o log dava:** só **2 AVISOs** antes do TIMEOUT — com janela 45min/poll 60s, rede fora daria ~45. Não foi outage: a máquina dormiu e o relógio saltou o deadline, então o script desistiu após 2 tentativas reais, com a rede provavelmente já de volta.
+
+**Fix:**
+- **`exit 6` = NÃO consegui consultar** (estado DESCONHECIDO) vs **`exit 5` = consultei e o PR segue sem desfecho**. JSON ilegível/vazio também cai no 6 — antes caía no ramo de SUCESSO e imprimia estado vazio (`ainda /?`), afirmando ter consultado.
+- **Cartada final com backoff** (`5 15 45`s; env `PR_WATCH_BACKOFFS`, testes usam `0 0 0`) antes de declarar desconhecido — a falha é quase sempre transitória. Desfecho real encontrado aí **vence o timeout**: é o que teria salvado o #1396 (exit 0, não 5).
+- Regra no **CLAUDE.md §Merge**: num 6, confirmar com `gh pr view <nº>` ANTES do PushNotification.
+
+**Prova:** `scripts/test-pr-watch.sh` (11 casos, `gh` stubado, sem rede) — testes escritos ANTES do fix e vistos vermelhos; o harness ganhou stub com contador (`GH_STUB_FALHAS=N` falha as N primeiras chamadas e depois volta, reproduzindo o #1396) e asserção de SAÍDA, sem a qual um exit 5 "não consultei" se disfarça de 5 "consultei". **Falsificado:** desfazer o exit 6 derruba só os 2 casos de "não consegui consultar"; remover a cartada final derruba só os 2 de "a rede volta".
+
 ## 2026-07-06 — Anti-fricção do setup Claude Code (candidatos 1–9 do diagnóstico)
 
 Origem: [melhorias-code-2026-07.md](melhorias-code-2026-07.md) — diagnóstico sobre 240 sessões/880MB de transcrições (65% dos erros de ferramenta = classificador de permissões; ~450 mensagens "Retome"; claude-mem com 0 observações em 331 sessões).

--- a/scripts/pr-watch.sh
+++ b/scripts/pr-watch.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 # pr-watch.sh — vigia o DESFECHO de um PR sob auto-merge e sai quando decidir:
 #   exit 0 = MERGEADO · 2 = fechado sem merge · 3 = CONFLITO (precisa rebase)
-#   exit 4 = CI VERMELHO · 5 = timeout sem desfecho · 64 = uso/deps errados
+#   exit 4 = CI VERMELHO · 5 = CONSULTEI e o PR segue sem desfecho (timeout)
+#   exit 6 = NÃO CONSEGUI CONSULTAR — estado DESCONHECIDO: confirme com
+#            `gh pr view <nº>` ANTES de reportar qualquer coisa ao founder
+#   exit 64 = uso/deps errados
+#
+# 5 e 6 eram o MESMO código até o #1396 (2026-07-17): o watcher não conseguiu
+# consultar, saiu 5, e o PR tinha MERGEADO normalmente — o falso negativo
+# exatamente do tipo que este script existe pra evitar. Pista de que era 6 e
+# não 5: pouquíssimos AVISOs antes do fim (2, não ~45). A máquina dormiu, o
+# relógio saltou o deadline, e o script desistiu após 2 tentativas reais em vez
+# de 45min de rede fora — por isso a cartada final abaixo, com backoff.
 #
 # Por quê (diagnóstico 2026-07): o founder virou o poller do auto-merge ("por
 # que o #868 não mergeou?", PR órfão descoberto dias depois). Rode via Bash com
@@ -18,21 +28,30 @@ intervalo="${3:-60}"
 command -v gh >/dev/null 2>&1 || { echo "ERRO: gh CLI ausente" >&2; exit 64; }
 command -v jq >/dev/null 2>&1 || { echo "ERRO: jq ausente" >&2; exit 64; }
 
-deadline=$(( $(date +%s) + timeout_min * 60 ))
-echo "vigiando PR #$pr (timeout ${timeout_min}min, poll ${intervalo}s)…"
+# Cartada final antes de declarar DESCONHECIDO: a falha de consulta costuma ser
+# transitória (Wi-Fi reassociando depois do sono, rate limit passando).
+# Sobrescrevível por env — os testes usam "0 0 0" pra não esperar de verdade.
+read -ra backoffs <<< "${PR_WATCH_BACKOFFS:-5 15 45}"
 
-while :; do
-  if ! info="$(gh pr view "$pr" --json state,mergeStateStatus,statusCheckRollup,title,url 2>/dev/null)"; then
-    echo "AVISO: gh pr view falhou (rede?); nova tentativa em ${intervalo}s" >&2
-    [ "$(date +%s)" -ge "$deadline" ] && { echo "⏳ TIMEOUT: sem conseguir consultar o PR #$pr"; exit 5; }
-    sleep "$intervalo"
-    continue
-  fi
+ultimo_estado=""   # preenchido só por consulta BEM-SUCEDIDA; "" = nunca soube
+ultimo_url=""
 
-  state="$(jq -r '.state' <<<"$info")"
+consultar() {
+  gh pr view "$pr" --json state,mergeStateStatus,statusCheckRollup,title,url 2>/dev/null
+}
+
+# Recebe o JSON de uma consulta. SAI do script se houver desfecho (0/2/3/4).
+# Retorna 0 = consultei e não há desfecho ainda · 1 = JSON ilegível/vazio, que
+# é "não consultei" disfarçado (gh vivo devolvendo lixo) e NÃO pode virar 5.
+decidir() {
+  local info="$1" state msstat titulo url falhas
+  # NB: `local x="$(cmd)"` mascara o rc do cmd — por isso declarar e atribuir
+  # em linhas separadas.
+  state="$(jq -r '.state // empty' <<<"$info" 2>/dev/null)" || return 1
+  [ -n "$state" ] || return 1
   msstat="$(jq -r '.mergeStateStatus // ""' <<<"$info")"
-  titulo="$(jq -r '.title' <<<"$info")"
-  url="$(jq -r '.url' <<<"$info")"
+  titulo="$(jq -r '.title // "?"' <<<"$info")"
+  url="$(jq -r '.url // "?"' <<<"$info")"
 
   case "$state" in
     MERGED) echo "✅ MERGEADO: PR #$pr — $titulo — $url"; exit 0 ;;
@@ -50,9 +69,43 @@ while :; do
     exit 4
   fi
 
-  if [ "$(date +%s)" -ge "$deadline" ]; then
-    echo "⏳ TIMEOUT: PR #$pr ainda ${state}/${msstat:-?} após ${timeout_min}min — $url"
-    exit 5
+  ultimo_estado="${state}/${msstat:-?}"
+  ultimo_url="$url"
+  return 0
+}
+
+# Só quem CONSULTOU pode sair 5.
+timeout_consultado() {
+  echo "⏳ TIMEOUT: PR #$pr ainda ${ultimo_estado} após ${timeout_min}min — $ultimo_url"
+  exit 5
+}
+
+# Deadline bateu sem consulta boa: insiste mais algumas vezes antes de desistir,
+# porque a falha costuma ser transitória — e um desfecho real encontrado aqui
+# vence o timeout (foi o que faltou no #1396).
+cartada_final() {
+  local backoff tentativas=0
+  echo "AVISO: consulta falhando no fim da janela; última cartada (backoff ${backoffs[*]}s)…" >&2
+  for backoff in "${backoffs[@]}"; do
+    tentativas=$((tentativas + 1))
+    [ "$backoff" -gt 0 ] && sleep "$backoff"
+    if info="$(consultar)" && decidir "$info"; then
+      timeout_consultado   # consegui consultar: o PR realmente segue sem desfecho
+    fi
+  done
+  echo "❓ DESCONHECIDO: não consegui consultar o PR #$pr (rede/rate-limit/máquina dormindo) — $tentativas tentativa(s) extras, última leitura: ${ultimo_estado:-nenhuma}. O desfecho NÃO foi observado e o PR PODE ter mergeado: confirme com \`gh pr view $pr\` antes de reportar."
+  exit 6
+}
+
+deadline=$(( $(date +%s) + timeout_min * 60 ))
+echo "vigiando PR #$pr (timeout ${timeout_min}min, poll ${intervalo}s)…"
+
+while :; do
+  if info="$(consultar)" && decidir "$info"; then
+    [ "$(date +%s)" -ge "$deadline" ] && timeout_consultado
+  else
+    [ "$(date +%s)" -ge "$deadline" ] && cartada_final
+    echo "AVISO: gh pr view falhou (rede/rate-limit?); nova tentativa em ${intervalo}s" >&2
   fi
   sleep "$intervalo"
 done

--- a/scripts/test-pr-watch.sh
+++ b/scripts/test-pr-watch.sh
@@ -2,7 +2,14 @@
 # test-pr-watch.sh — TDD do scripts/pr-watch.sh com `gh` STUBADO (sem rede).
 #
 # Contrato testado (exit codes): 0=MERGED · 2=CLOSED · 3=DIRTY(conflito) ·
-# 4=CI vermelho · 5=timeout sem desfecho (inclusive gh falhando sempre).
+# 4=CI vermelho · 5=CONSULTEI e o PR segue sem desfecho · 6=NÃO CONSEGUI
+# CONSULTAR (estado DESCONHECIDO — confirmar à mão antes de reportar).
+#
+# 5 vs 6 é o coração deste teste. Até o #1396 os dois saíam 5: o watcher não
+# conseguiu consultar (2 falhas + relógio saltando o deadline com a máquina
+# dormindo), saiu 5, e o PR tinha MERGEADO — falso negativo reportado ao
+# founder. Se algum dia "não consegui consultar" voltar a sair 5, este teste
+# fica vermelho.
 #
 # Uso: bash scripts/test-pr-watch.sh   (exit 0 = tudo verde)
 set -u
@@ -13,27 +20,44 @@ WATCH="$here/pr-watch.sh"
 stub="$(mktemp -d)"
 trap 'rm -rf "$stub"' EXIT
 
-# stub de gh: devolve o JSON do cenário (GH_STUB_FILE) ou falha (GH_STUB_EXIT)
+# stub de gh:
+#   GH_STUB_EXIT=N   → falha SEMPRE com N (rede fora o tempo todo)
+#   GH_STUB_FALHAS=N → falha as N PRIMEIRAS chamadas e depois devolve o JSON
+#                      (a rede volta — cenário real do #1396)
+#   senão            → devolve o JSON do cenário (GH_STUB_FILE)
 cat >"$stub/gh" <<'STUB'
 #!/bin/sh
+n=0
+[ -f "$GH_STUB_CONTADOR" ] && n="$(cat "$GH_STUB_CONTADOR")"
+n=$((n + 1)); printf '%s' "$n" > "$GH_STUB_CONTADOR"
 [ -n "${GH_STUB_EXIT:-}" ] && exit "$GH_STUB_EXIT"
+[ "$n" -le "${GH_STUB_FALHAS:-0}" ] && exit 1
 cat "$GH_STUB_FILE"
 STUB
 chmod +x "$stub/gh"
 export PATH="$stub:$PATH"
+export GH_STUB_CONTADOR="$stub/contador"
+# backoff da cartada final zerado: o teste prova a SEQUÊNCIA, não a espera
+export PR_WATCH_BACKOFFS="0 0 0"
 
 fail=0
 
 # roda o watcher com timeout curtíssimo (0 min) e poll de 1s
+# $4 = quantas consultas falham antes de a rede voltar (default 0)
+# $5 = trecho que a saída PRECISA conter (default: não checa) — sem isso um
+#      exit 5 "não consegui consultar" se disfarça de exit 5 "consultei"
 caso() {
-  local nome="$1" want_exit="$2" json="$3" out rc
+  local nome="$1" want_exit="$2" json="$3" falhas="${4:-0}" want_saida="${5:-}" out rc
   printf '%s' "$json" > "$stub/cenario.json"
-  out="$(GH_STUB_FILE="$stub/cenario.json" bash "$WATCH" 999 0 1 2>/dev/null)"; rc=$?
-  if [ "$rc" -eq "$want_exit" ]; then
-    echo "  ok    exit $rc | $nome"
-  else
-    echo "  FAIL  want exit $want_exit, got $rc | $nome | $out"; fail=1
+  rm -f "$GH_STUB_CONTADOR"
+  out="$(GH_STUB_FILE="$stub/cenario.json" GH_STUB_FALHAS="$falhas" bash "$WATCH" 999 0 1 2>/dev/null)"; rc=$?
+  if [ "$rc" -ne "$want_exit" ]; then
+    echo "  FAIL  want exit $want_exit, got $rc | $nome | $out"; fail=1; return
   fi
+  if [ -n "$want_saida" ] && ! grep -q "$want_saida" <<<"$out"; then
+    echo "  FAIL  exit $rc ok, mas a saída não diz \"$want_saida\" | $nome | $out"; fail=1; return
+  fi
+  echo "  ok    exit $rc | $nome"
 }
 
 echo "── desfechos terminais ──"
@@ -43,16 +67,28 @@ caso "conflito (DIRTY) → 3" 3 '{"state":"OPEN","mergeStateStatus":"DIRTY","sta
 caso "CI vermelho (conclusion FAILURE) → 4" 4 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","conclusion":"FAILURE"}],"title":"t","url":"u"}'
 caso "CI vermelho (state ERROR, sem conclusion) → 4" 4 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"context":"ci","state":"error"}],"title":"t","url":"u"}'
 
-echo "── sem desfecho ──"
+echo "── consultei e o PR segue sem desfecho (→ 5) ──"
 caso "OPEN limpo até o deadline → 5" 5 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","conclusion":null}],"title":"t","url":"u"}'
-
-# gh falhando sempre (rede fora) → timeout 5, nunca trava
-out="$(GH_STUB_EXIT=1 GH_STUB_FILE=/dev/null bash "$WATCH" 999 0 1 2>/dev/null)"; rc=$?
-if [ "$rc" -eq 5 ]; then echo "  ok    exit 5 | gh falhando sempre (rede)"
-else echo "  FAIL  want exit 5, got $rc | gh falhando sempre"; fail=1; fi
 
 # check pendente NÃO pode contar como vermelho (falso-positivo)
 caso "check pendente ≠ vermelho → 5" 5 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","state":"PENDING"}],"title":"t","url":"u"}'
+
+echo "── NÃO consegui consultar (→ 6, nunca 5) ──"
+# Regressão do #1396: "não sei o estado" não pode se disfarçar de "sem desfecho".
+rm -f "$GH_STUB_CONTADOR"
+out="$(GH_STUB_EXIT=1 GH_STUB_FILE=/dev/null bash "$WATCH" 999 0 1 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 6 ]; then echo "  ok    exit 6 | gh falhando sempre (rede/rate-limit) → DESCONHECIDO"
+else echo "  FAIL  want exit 6, got $rc | gh falhando sempre → DESCONHECIDO"; fail=1; fi
+
+# gh vivo mas devolvendo lixo (JSON ilegível) também é "não sei", não "sem desfecho"
+caso "JSON ilegível → 6" 6 'nao-e-json'
+
+echo "── cartada final: a rede volta antes de desistir ──"
+# O caso REAL do #1396: máquina dormiu, o relógio saltou o deadline e as
+# primeiras consultas falharam — mas o PR já tinha MERGEADO. O desfecho real
+# precisa vencer o timeout, senão o watcher mente sobre um PR que fechou.
+caso "falha 2×, a rede volta e acha MERGED → 0" 0 '{"state":"MERGED","mergeStateStatus":"CLEAN","statusCheckRollup":[],"title":"t","url":"u"}' 2 MERGEADO
+caso "falha 1×, a rede volta e o PR segue OPEN → 5" 5 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","conclusion":null}],"title":"t","url":"u"}' 1 'ainda OPEN'
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi


### PR DESCRIPTION
## Problema (falso negativo REAL — #1396, 2026-07-17)

O watcher saiu **5 (TIMEOUT)** num PR que tinha **MERGEADO** normalmente (auto-merge squash, `validate` verde em 5m16s):

```
vigiando PR #1396 (timeout 45min, poll 60s)…
AVISO: gh pr view falhou (rede?); nova tentativa em 60s
AVISO: gh pr view falhou (rede?); nova tentativa em 60s
⏳ TIMEOUT: sem conseguir consultar o PR #1396
```

`exit 5` era emitido por **dois** caminhos indistinguíveis — a consulta bem-sucedida sem desfecho (linha 55) **e** a consulta que falhou (linha 27). Um agente que confiasse no exit code reportaria "não mergeou" ao founder: exatamente o furo de rastreio que o script existe pra fechar.

**Pista que o log dava:** só **2 AVISOs** antes do TIMEOUT — com janela 45min/poll 60s, rede fora daria ~45. Não foi outage: a máquina dormiu, o relógio saltou o deadline, e o script desistiu após 2 tentativas reais **com a rede provavelmente já de volta**.

## Fix

| exit | significado |
|---|---|
| 5 | **consultei** e o PR segue sem desfecho |
| 6 | **não consegui consultar** — estado DESCONHECIDO, confirmar à mão |

- **`exit 6`** para "não sei". JSON ilegível/vazio também cai no 6 — antes caía no ramo de **sucesso** e imprimia estado vazio (`ainda /?`), afirmando ter consultado.
- **Cartada final com backoff** (`5 15 45`s; env `PR_WATCH_BACKOFFS`) antes de desistir. Desfecho real encontrado aí **vence o timeout** — é o que teria salvado o #1396 (exit 0, não 5).
- **CLAUDE.md §Merge**: num 6, confirmar com `gh pr view <nº>` **antes** do PushNotification.

## Evidência

`scripts/test-pr-watch.sh` — 11 casos, `gh` stubado, sem rede. Testes escritos **antes** do fix e vistos vermelhos (o caso "falha 2×, a rede volta e acha MERGED" reproduziu a saída literal do #1396). O harness ganhou stub com contador (`GH_STUB_FALHAS=N`) e asserção de **saída**, sem a qual um exit 5 "não consultei" se disfarça de 5 "consultei".

**Falsificado** — cada sabotagem derruba só o que ela guarda:

| sabotagem | vermelho |
|---|---|
| desfaz o `exit 6` | só os 2 casos de "não consegui consultar" |
| remove a cartada final | só os 2 casos de "a rede volta" |

**Ponta-a-ponta com `gh` real:** `#1396 → 0 (MERGEADO)` · PR aberto `→ 5` com o estado na mensagem · PR inexistente `→ 6` após 3 tentativas.

`shellcheck` limpo (health stack inteiro) · CLAUDE.md dentro do orçamento (15.6KB/20.5KB).

Sem impacto em produto/banco/money-path: script de dev + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)