### PR TITLE
fix(agente): pr-watch — a janela conta VIGÍLIA, não relógio de parede

### DIFF
--- a/docs/historico/setup-agente.md
+++ b/docs/historico/setup-agente.md
@@ -10,8 +10,20 @@
 - **`exit 6` = NÃO consegui consultar** (estado DESCONHECIDO) vs **`exit 5` = consultei e o PR segue sem desfecho**. JSON ilegível/vazio também cai no 6 — antes caía no ramo de SUCESSO e imprimia estado vazio (`ainda /?`), afirmando ter consultado.
 - **Cartada final com backoff** (`5 15 45`s; env `PR_WATCH_BACKOFFS`, testes usam `0 0 0`) antes de declarar desconhecido — a falha é quase sempre transitória. Desfecho real encontrado aí **vence o timeout**: é o que teria salvado o #1396 (exit 0, não 5).
 - Regra no **CLAUDE.md §Merge**: num 6, confirmar com `gh pr view <nº>` ANTES do PushNotification.
+- **A janela passou a contar VIGÍLIA, não relógio de parede** (`dormir`): no suspend o `sleep` não avança mas o `date` sim, então o tempo dormido é devolvido ao deadline. Sem teto de extensão de propósito — cada wake compra ≥1 poll, e é esse poll que acha o desfecho (o watcher morre com a sessão de qualquer forma). Isso ataca o GATILHO; o exit 6 ataca o DEFEITO. Fora do CLAUDE.md porque não muda o que o agente FAZ (só o exit 6 muda).
 
-**Prova:** `scripts/test-pr-watch.sh` (11 casos, `gh` stubado, sem rede) — testes escritos ANTES do fix e vistos vermelhos; o harness ganhou stub com contador (`GH_STUB_FALHAS=N` falha as N primeiras chamadas e depois volta, reproduzindo o #1396) e asserção de SAÍDA, sem a qual um exit 5 "não consultei" se disfarça de 5 "consultei". **Falsificado:** desfazer o exit 6 derruba só os 2 casos de "não consegui consultar"; remover a cartada final derruba só os 2 de "a rede volta".
+**Prova:** `scripts/test-pr-watch.sh` (12 casos, `gh` stubado, sem rede) — testes escritos ANTES do fix e vistos vermelhos; o harness ganhou stub com contador (`GH_STUB_FALHAS=N` falha as N primeiras chamadas e depois volta, reproduzindo o #1396), asserção de SAÍDA (sem ela um exit 5 "não consultei" se disfarça de 5 "consultei") e RELÓGIO VIRTUAL (`date`/`sleep` stubados; `SLEEP_SALTO` simula suspend — determinístico e instantâneo, sem esperar 40min de verdade). No caso do relógio o exit code NÃO discrimina (5 nos dois mundos): o observável é a **contagem de polls** (2 sem o fix, 6 com).
+
+**Falsificado** — cada sabotagem derruba só o que ela guarda:
+
+| sabotagem | vermelho |
+|---|---|
+| desfaz o `exit 6` | só os 2 casos de "não consegui consultar" |
+| remove a cartada final | só os 2 casos de "a rede volta" |
+| não estende o deadline | só o caso do relógio (volta aos 2 polls) |
+| credita o elapsed inteiro em vez do EXCESSO | deadline recua tanto quanto avança = loop infinito → `exit 143` pelo watchdog do teste (FAIL, não trava) |
+
+**Ponta-a-ponta com `gh`/`date`/`sleep` REAIS:** `#1396 → 0 (MERGEADO)` (era 5) · PR aberto `→ 5` com o estado na mensagem · PR inexistente `→ 6` após 3 tentativas · watcher congelado por `SIGSTOP` 40s com poll de 10s → salto de **33s detectado**, janela estendida, rodou 101s de relógio para uma janela nominal de 60s. `SIGSTOP` é o análogo fiel do suspend **desde que o congelamento seja MAIOR que o poll**: a 1ª tentativa (congelar 25s com poll de 30s) não acusou nada — coube dentro do `sleep` do processo filho, que seguiu correndo, e não somou elapsed nenhum.
 
 ## 2026-07-06 — Anti-fricção do setup Claude Code (candidatos 1–9 do diagnóstico)
 

--- a/scripts/pr-watch.sh
+++ b/scripts/pr-watch.sh
@@ -13,6 +13,11 @@
 # relógio saltou o deadline, e o script desistiu após 2 tentativas reais em vez
 # de 45min de rede fora — por isso a cartada final abaixo, com backoff.
 #
+# A JANELA CONTA VIGÍLIA, não relógio de parede (ver `dormir`): no suspend o
+# `sleep` não avança mas o `date` sim, então o tempo dormido é devolvido ao
+# deadline. Um watcher pode viver bem mais que os N min nominais — intencional:
+# cada wake compra um poll, e é esse poll que encontra o desfecho.
+#
 # Por quê (diagnóstico 2026-07): o founder virou o poller do auto-merge ("por
 # que o #868 não mergeou?", PR órfão descoberto dias depois). Rode via Bash com
 # run_in_background:true logo após criar/atualizar o PR: quando este processo
@@ -32,6 +37,10 @@ command -v jq >/dev/null 2>&1 || { echo "ERRO: jq ausente" >&2; exit 64; }
 # transitória (Wi-Fi reassociando depois do sono, rate limit passando).
 # Sobrescrevível por env — os testes usam "0 0 0" pra não esperar de verdade.
 read -ra backoffs <<< "${PR_WATCH_BACKOFFS:-5 15 45}"
+
+# Tolerância do detector de salto: `sleep N` estoura o esperado por 0–1s
+# (quantização do `date +%s` + scheduler); suspend estoura por MINUTOS.
+tolerancia_salto="${PR_WATCH_TOLERANCIA_SALTO:-5}"
 
 ultimo_estado=""   # preenchido só por consulta BEM-SUCEDIDA; "" = nunca soube
 ultimo_url=""
@@ -97,6 +106,24 @@ cartada_final() {
   exit 6
 }
 
+# Dorme o intervalo e DEVOLVE ao deadline o tempo em que a máquina esteve
+# suspensa. A janela conta tempo VIGIANDO, não relógio de parede: durante o
+# suspend o `sleep` não avança mas o `date` sim, então sem isso um laptop
+# fechado queima os 45min tendo consultado 2× (o gatilho do #1396).
+# Sem teto de extensão de propósito: cada wake compra ao menos 1 poll, e esse
+# poll quase sempre já resolve o PR — além de o watcher morrer com a sessão.
+dormir() {
+  local antes depois excesso
+  antes="$(date +%s)"
+  sleep "$intervalo"
+  depois="$(date +%s)"
+  excesso=$(( depois - antes - intervalo ))
+  if [ "$excesso" -gt "$tolerancia_salto" ]; then
+    deadline=$(( deadline + excesso ))
+    echo "AVISO: o relógio saltou ${excesso}s neste poll (máquina dormiu?) — a janela conta vigília, então foi estendida" >&2
+  fi
+}
+
 deadline=$(( $(date +%s) + timeout_min * 60 ))
 echo "vigiando PR #$pr (timeout ${timeout_min}min, poll ${intervalo}s)…"
 
@@ -107,5 +134,5 @@ while :; do
     [ "$(date +%s)" -ge "$deadline" ] && cartada_final
     echo "AVISO: gh pr view falhou (rede/rate-limit?); nova tentativa em ${intervalo}s" >&2
   fi
-  sleep "$intervalo"
+  dormir
 done

--- a/scripts/test-pr-watch.sh
+++ b/scripts/test-pr-watch.sh
@@ -11,6 +11,10 @@
 # founder. Se algum dia "não consegui consultar" voltar a sair 5, este teste
 # fica vermelho.
 #
+# O último caso cobre o GATILHO do mesmo incidente: a janela conta VIGÍLIA, não
+# relógio de parede. Ali o exit code não discrimina (5 nos dois mundos) — o
+# observável é quantas vezes o script chegou a consultar.
+#
 # Uso: bash scripts/test-pr-watch.sh   (exit 0 = tudo verde)
 set -u
 
@@ -18,7 +22,24 @@ here="$(cd "$(dirname "$0")" && pwd)"
 WATCH="$here/pr-watch.sh"
 
 stub="$(mktemp -d)"
-trap 'rm -rf "$stub"' EXIT
+tempo="$(mktemp -d)"
+trap 'rm -rf "$stub" "$tempo"' EXIT
+
+# Stubs de TEMPO — usados SÓ pelo teste de salto de relógio (entram no PATH
+# apenas naquele caso, pros demais seguirem exercitando date/sleep de verdade).
+# Relógio VIRTUAL num arquivo: `sleep N` não dorme, só adianta o relógio em
+# N + SLEEP_SALTO. Assim dá pra simular a máquina suspendendo — de forma
+# determinística e instantânea, sem esperar 40min de verdade.
+cat >"$tempo/date" <<'STUB'
+#!/bin/sh
+cat "$PR_WATCH_RELOGIO"
+STUB
+cat >"$tempo/sleep" <<'STUB'
+#!/bin/sh
+agora="$(cat "$PR_WATCH_RELOGIO")"
+echo $(( agora + $1 + ${SLEEP_SALTO:-0} )) > "$PR_WATCH_RELOGIO"
+STUB
+chmod +x "$tempo/date" "$tempo/sleep"
 
 # stub de gh:
 #   GH_STUB_EXIT=N   → falha SEMPRE com N (rede fora o tempo todo)
@@ -89,6 +110,34 @@ echo "── cartada final: a rede volta antes de desistir ──"
 # precisa vencer o timeout, senão o watcher mente sobre um PR que fechou.
 caso "falha 2×, a rede volta e acha MERGED → 0" 0 '{"state":"MERGED","mergeStateStatus":"CLEAN","statusCheckRollup":[],"title":"t","url":"u"}' 2 MERGEADO
 caso "falha 1×, a rede volta e o PR segue OPEN → 5" 5 '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"name":"validate","conclusion":null}],"title":"t","url":"u"}' 1 'ainda OPEN'
+
+echo "── relógio saltando (máquina suspendendo) ──"
+# A janela quer dizer "N min VIGIANDO", não N min de relógio de parede. Se o
+# laptop dorme, `sleep` não avança mas o relógio salta — e o watcher queimava a
+# janela inteira tendo consultado 2× (foi o GATILHO do #1396).
+#
+# O exit code NÃO discrimina aqui (com ou sem o fix dá 5): o observável é
+# QUANTAS vezes ele realmente consultou. Janela de 5min com poll de 60s = ~6
+# consultas; sem o fix, o 1º sono de 40min encerra tudo na 2ª.
+echo 1000000000 > "$tempo/relogio"
+rm -f "$GH_STUB_CONTADOR"
+printf '%s' '{"state":"OPEN","mergeStateStatus":"BLOCKED","statusCheckRollup":[],"title":"t","url":"u"}' > "$stub/cenario.json"
+# Watchdog: com `sleep` stubado (instantâneo), errar a aritmética do salto —
+# creditar o elapsed inteiro em vez do EXCESSO — faria o deadline recuar tanto
+# quanto avança, e o teste TRAVARIA em vez de falhar. Aqui vira exit 143 = FAIL.
+PATH="$tempo:$PATH" PR_WATCH_RELOGIO="$tempo/relogio" SLEEP_SALTO=2400 \
+  GH_STUB_FILE="$stub/cenario.json" bash "$WATCH" 999 5 60 >"$tempo/saida" 2>/dev/null &
+alvo=$!
+( sleep 20 && kill "$alvo" 2>/dev/null ) >/dev/null 2>&1 &
+cao=$!
+wait "$alvo"; rc=$?
+kill "$cao" 2>/dev/null
+polls="$(cat "$GH_STUB_CONTADOR" 2>/dev/null || echo 0)"
+if [ "$rc" -eq 5 ] && [ "$polls" -ge 5 ]; then
+  echo "  ok    exit 5 após $polls polls | 40min de sono por poll não queimam a janela de 5min"
+else
+  echo "  FAIL  want exit 5 com ≥5 polls, got exit $rc com $polls poll(s) | a janela foi queimada pelo relógio, não pela vigília"; fail=1
+fi
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi


### PR DESCRIPTION
Follow-up do #1407. Aquele atacou o **defeito** do #1396 (exit 5 ambíguo); este ataca o **gatilho**.

## Problema

`deadline` era relógio de parede. Durante o suspend o `sleep` não avança, mas o `date` sim — então um laptop fechado **queima a janela inteira tendo consultado 2×**. É exatamente a assinatura do #1396: 2 AVISOs antes do TIMEOUT, quando 45min de rede fora dariam ~45.

## Fix

`dormir` mede o elapsed em volta do poll e devolve ao deadline o **excesso** sobre o intervalo:

```
excesso = depois - antes - intervalo     # tolerância 5s (env PR_WATCH_TOLERANCIA_SALTO)
```

`sleep N` estoura o esperado por 0–1s (quantização do `date +%s` + scheduler); suspend estoura por minutos — separação limpa.

**Sem teto de extensão, de propósito:** cada wake compra ≥1 poll, e é esse poll que encontra o desfecho. O watcher morre com a sessão de qualquer forma.

## Por que o teste não olha o exit code

Aqui o exit code **não discrimina** — dá 5 com ou sem o fix. O observável é **quantas vezes o script chegou a consultar**. O harness ganhou **relógio virtual** (`date`/`sleep` stubados; `SLEEP_SALTO` simula o suspend, determinístico e instantâneo):

| | polls numa janela de 5min com 40min de sono por poll |
|---|---|
| sem o fix | **2** |
| com o fix | **6** |

O caso roda sob **watchdog de 20s**: com `sleep` stubado, errar a aritmética (creditar o elapsed inteiro em vez do excesso) faz o deadline recuar tanto quanto avança = loop infinito, e sem o watchdog o teste **travaria em vez de falhar**.

## Falsificação

| sabotagem | vermelho |
|---|---|
| não estende o deadline | só o caso do relógio (volta aos 2 polls) |
| credita o elapsed inteiro | loop infinito → `exit 143` pelo watchdog |

## Ponta-a-ponta com `date`/`sleep` reais

Watcher congelado por `SIGSTOP` 40s com poll de 10s → **salto de 33s detectado**, janela estendida, rodou **101s de relógio para uma janela nominal de 60s**, e ainda saiu com a mensagem honesta do estado observado.

Nota metodológica (está no `docs/historico/`): `SIGSTOP` só é análogo fiel do suspend se o congelamento for **maior que o poll**. A 1ª tentativa (25s com poll de 30s) não acusou nada — coube dentro do `sleep` do processo filho, que seguiu correndo.

## Escopo

Script de dev + docs. Sem impacto em produto/banco/money-path. CLAUDE.md **não** mudou: o contrato de exit codes é o mesmo do #1407, e isto não muda o que o agente faz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)