### PR TITLE
fix(email): CTA do relatório mensal caía em domínio morto (404) — APP_URL + guard no CI

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -12,7 +12,7 @@
 const APP_URL = Deno.env.get("APP_URL") ?? "https://steu.lovable.app";
 ```
 
-Padrão em `gerar-pedidos-diario`/`disparar-pedidos-aprovados`. O guard `src/__tests__/edge-app-url.test.ts` quebra o CI se alguma edge voltar a citar host nu ou o domínio morto (#1409: o CTA "Agendar Afiação" do `monthly-report` apontava para o 404 — e só era renderizado para o cliente COM ferramenta atrasada, o de maior intenção).
+Padrão em `gerar-pedidos-diario`/`disparar-pedidos-aprovados`. O guard `src/__tests__/edge-app-url.test.ts` quebra o CI se alguma edge voltar a citar host nu ou o domínio morto (#1413: o CTA "Agendar Afiação" do `monthly-report` apontava para o 404 — e só era renderizado para o cliente COM ferramenta atrasada, o de maior intenção).
 
 Como provar o que está **SERVIDO** nesse host (hash do index + grep nos chunks): skill `lovable-deploy-verify` — o método vive lá, não é duplicado aqui.
 

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -2,6 +2,20 @@
 
 > O que NÃO acontece sozinho no merge. Lição durável carregada sob demanda. Runbook passo-a-passo completo: `docs/runbooks/lovable-supabase.md`. Banco/migration: `docs/agent/database.md`. Verificação: skill `lovable-deploy-verify`.
 
+## Domínio canônico — `https://steu.lovable.app`
+
+É **a** URL de produção: o que verificar depois de um Publish, o host do QA visual, e o destino de todo link que uma edge mande para o cliente. **`afiacao.lovable.app` está MORTO** — HTTP 404 `Project not found` (conferido 2026-07-18), assim como `preview--afiacao.lovable.app` e as variações por project-id. O nome do projeto no Lovable não é o nome do repo; não dá para adivinhar a URL a partir de "afiacao".
+
+**Edge que linka o app não hardcoda host** — lê a env, com o canônico só como fallback:
+
+```ts
+const APP_URL = Deno.env.get("APP_URL") ?? "https://steu.lovable.app";
+```
+
+Padrão em `gerar-pedidos-diario`/`disparar-pedidos-aprovados`. O guard `src/__tests__/edge-app-url.test.ts` quebra o CI se alguma edge voltar a citar host nu ou o domínio morto (#1409: o CTA "Agendar Afiação" do `monthly-report` apontava para o 404 — e só era renderizado para o cliente COM ferramenta atrasada, o de maior intenção).
+
+Como provar o que está **SERVIDO** nesse host (hash do index + grep nos chunks): skill `lovable-deploy-verify` — o método vive lá, não é duplicado aqui.
+
 ## Merge na `main` ≠ produção — 3 deploys MANUAIS e independentes
 
 1. **Migration** → colar o SQL no **SQL Editor do Lovable** → Run → validar com query de contagem. O Lovable **NÃO** aplica migration de nome custom sozinho (falha SILENCIOSA: a feature compila e quebra em runtime). Detalhe + ritual + skill `lovable-db-operator`: `docs/agent/database.md`.

--- a/src/__tests__/edge-app-url.test.ts
+++ b/src/__tests__/edge-app-url.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+// repo root: src/__tests__ → src → repo (2 níveis).
+const CWD = resolve(__dirname, '../..');
+const DIR_EDGES = resolve(CWD, 'supabase/functions');
+
+// ── Guard: edge NÃO hardcoda o host do app — o host vem da env APP_URL ──
+// Por que existe: o CTA "Agendar Afiação" do relatório mensal apontava para
+// `https://afiacao.lovable.app/new-order` — domínio MORTO (HTTP 404 "Project not found",
+// verificado 2026-07-18; o canônico é steu.lovable.app). Pior: esse botão só é renderizado
+// quando `overdue_count > 0`, ou seja, ia exatamente para o cliente de MAIOR intenção — que
+// clicava e caía num 404. O padrão certo já existia nas edges de reposição desde sempre; nada
+// no CI apontava que a monthly-report divergia, e o link não quebra build nem teste.
+// Textual (lê o arquivo, não importa) pelo mesmo motivo do edge-money-path-invariants.test.ts:
+// edge é Deno, roda no Lovable Cloud, fora do typecheck/vitest do src/.
+const DOMINIO_MORTO = 'afiacao.lovable.app';
+
+// Única citação permitida de um host do app: o fallback da env. Tolerante a aspas/espaçamento,
+// rígida quanto à FORMA (tem de vir de `Deno.env.get('APP_URL')`) — o que se proíbe é o literal nu.
+const FALLBACK_APP_URL =
+  /Deno\.env\.get\(\s*['"]APP_URL['"]\s*\)\s*\?\?\s*['"]https:\/\/steu\.lovable\.app['"]/;
+
+function arquivosTs(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entrada) => {
+    const caminho = join(dir, entrada.name);
+    if (entrada.isDirectory()) return arquivosTs(caminho);
+    return entrada.isFile() && caminho.endsWith('.ts') ? [caminho] : [];
+  });
+}
+
+// Toda linha, em qualquer edge, que cite um host *.lovable.app.
+const citacoes = arquivosTs(DIR_EDGES).flatMap((abs) =>
+  readFileSync(abs, 'utf8')
+    .split('\n')
+    .map((texto, i) => ({ arquivo: relative(CWD, abs), linha: i + 1, texto }))
+    .filter((l) => l.texto.includes('lovable.app')),
+);
+
+describe('edges: host do app vem da env APP_URL', () => {
+  it('nenhuma edge cita o domínio morto afiacao.lovable.app', () => {
+    const mortas = citacoes.filter((c) => c.texto.includes(DOMINIO_MORTO));
+    expect(mortas.map((c) => `${c.arquivo}:${c.linha}`)).toEqual([]);
+  });
+
+  it('toda citação de host *.lovable.app é o fallback de Deno.env.get("APP_URL")', () => {
+    const nuas = citacoes.filter((c) => !FALLBACK_APP_URL.test(c.texto));
+    expect(nuas.map((c) => `${c.arquivo}:${c.linha} → ${c.texto.trim()}`)).toEqual([]);
+  });
+
+  it('o guard enxerga as edges (senão passa vazio e não prova nada)', () => {
+    // Anti-falso-verde: se a varredura quebrar (path errado, glob vazio), os dois asserts acima
+    // ficam verdes por vacuidade. As edges de reposição são a linha de base conhecida.
+    expect(citacoes.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -676,6 +676,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/__tests__/app-route-dedupe.test.ts",
       "src/__tests__/auth.test.ts",
+      "src/__tests__/edge-app-url.test.ts",
       "src/__tests__/index-html.test.ts",
       "src/lib/escape-html.test.ts",
       "src/lib/__tests__/**",

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -8,6 +8,10 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-cron-secret, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
 };
 
+// Host do app para os links do e-mail. Mesmo padrão das edges de reposição
+// (gerar-pedidos-diario / disparar-pedidos-aprovados) — nunca hardcodar o domínio.
+const APP_URL = Deno.env.get('APP_URL') ?? 'https://steu.lovable.app';
+
 interface ToolSummary {
   name: string;
   internal_code: string | null;
@@ -138,7 +142,7 @@ function generateEmailHtml(report: CustomerReport): string {
       <p style="font-size: 14px; color: #666; margin-bottom: 12px;">
         Você tem ferramentas que precisam de afiação!
       </p>
-      <a href="https://afiacao.lovable.app/new-order" 
+      <a href="${APP_URL}/new-order"
          style="display: inline-block; background: linear-gradient(135deg, #dc2626, #991b1b); color: #fff; 
                 padding: 14px 32px; border-radius: 8px; text-decoration: none; font-weight: 600; font-size: 15px;">
         Agendar Afiação


### PR DESCRIPTION
## O bug (outward-facing, chega ao cliente)

O CTA **"Agendar Afiação"** do e-mail de relatório mensal apontava para `https://afiacao.lovable.app/new-order` — hardcoded, e o domínio está **morto**: HTTP `404 Project not found` (conferido nesta sessão, junto com `preview--afiacao.lovable.app`). O canônico vivo é `https://steu.lovable.app` (HTTP 200).

O agravante é **quem** recebia o link: o botão só é renderizado quando `report.overdue_count > 0`, ou seja, ia exatamente para o cliente que TEM ferramenta atrasada — o de maior intenção de compra. Ele clicava e caía num 404.

## A correção

Adota o padrão que as edges de reposição já usavam (`gerar-pedidos-diario:17`, `disparar-pedidos-aprovados:15`) — host pela env, canônico só como fallback:

```ts
const APP_URL = Deno.env.get('APP_URL') ?? 'https://steu.lovable.app';
```

A `monthly-report` não lia `APP_URL` (só `SUPABASE_URL`/`ANON_KEY`/`SERVICE_ROLE_KEY`/`CRON_SECRET`), então a env é nova para esta edge — o fallback cobre o caso de ela não estar setada, e o comportamento fica idêntico ao das outras duas.

**Varredura do repo inteiro** (sem `head`): `afiacao.lovable.app` restava **só** nesse ponto. Migrations, snapshot e docs já usavam `steu.lovable.app`.

## Verificação

- **TDD** — `src/__tests__/edge-app-url.test.ts` escrito ANTES do fix, visto **vermelho** apontando `supabase/functions/monthly-report/index.ts:141`, e verde depois. Varre as 94 edges e falha se alguma citar host `*.lovable.app` nu ou o domínio morto; tem assert anti-falso-verde (se a varredura quebrar, os outros dois passariam por vacuidade).
- **Comportamento** — a função de render real foi extraída e executada com um report sintético: href sai `https://steu.lovable.app/new-order`, sem literal `${APP_URL}` não-interpolado (o modo-falha pior que o bug original, se a interpolação caísse fora do template), e com `overdue_count = 0` o CTA some — confirmando o gate.
- typecheck 0 · lint 0 · `manifesto.gate` verde (teste novo registrado em `plataforma`).

## Descoberta — por que ninguém achava a URL

O relato original era que o domínio canônico estava **apenas** na skill `lovable-deploy-verify`. Na verdade ele **está** em `docs/agent/deploy.md`, na linha 8 — mas como sujeito de uma frase sobre *outra* coisa ("`steu.lovable.app` serve o build velho até o Publish"). O doc nunca **declarava** a URL de produção, e um `grep` por "URL"/"domínio" não devolvia nada. Achável só por acidente.

Este PR acrescenta uma seção `## Domínio canônico` declarativa e procurável, com o negativo (o domínio morto, que é o que evita repetir o erro) e o snippet do `APP_URL`. O **método** de verificação por bytes do bundle continua só na skill — aqui vai apenas o ponteiro, sem duplicar.

## Deploy — `monthly-report` é edge function

Merge na `main` **não** deploya. Prompt para o chat do Lovable, após o merge:

> Deploy the edge function `monthly-report` from `main`, verbatim from `supabase/functions/monthly-report/index.ts`. Do NOT reconcile from your internal copy and do NOT "improve" the code. If your copy differs from `main`, abort and report the difference.

Sem migration e sem Publish de frontend nesta entrega (o `src/` mudou só em teste e manifesto).

Opcional: setar o secret `APP_URL` no Supabase para desacoplar de vez o host do código — sem ele, o fallback já entrega o comportamento correto.
