### PR TITLE
chore(banco): DROP da RPC órfã estimar_impacto_exclusao_outlier — condição do #1402 cumprida (Publish provado nos bytes)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **380** custom migrations totais
-- **1338** objetos esperados (criados por estas migrations)
+- **384** custom migrations totais
+- **1341** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 378
+  - `function`: 381
   - `rls_policy`: 295
   - `index`: 222
   - `cron_job`: 150
@@ -3210,6 +3210,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `view` | `public.v_sku_parametros_sugeridos` | — |
 
+### `20260717020000_reposicao_exclusao_outlier_remover.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.resolver_outlier` | — |
+
 ### `20260717120000_seg_customer_metrics_gate_staff.sql`
 
 | Tipo | Objeto | Parent |
@@ -3233,6 +3239,21 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public._data_health_compute` | — |
+
+### `20260717181500_carteira_visivel_para_filtra_eligible.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.carteira_visivel_para` | — |
+| `function` | `public.minha_carteira` | — |
+
+### `20260718091409_drop_omie_cliente_upsert_mapping_orfa.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 380
+-- Total de custom migrations: 384
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -14,7 +14,7 @@
 -- Read-only — não altera nada no banco.
 -- ========================================================================
 
--- 11 objeto(s) OBSOLETO(s) excluído(s) do inventário (criados por uma migration,
+-- 13 objeto(s) OBSOLETO(s) excluído(s) do inventário (criados por uma migration,
 -- removidos/renomeados por outra — NÃO são bug; ver OBSOLETE em scripts/audit-custom-migrations.ts):
 --   • rls_policy public.kb_product_specs_insert_staff (kb_specs_and_competitors) — substituída → kb_product_specs_insert_master (hardening)
 --   • trigger public.trg_audit (fin_a1_audit_lock_attach) — drop — 20260523210000_drop_audit_trigger_fin_config_cashflow
@@ -27,6 +27,8 @@
 --   • view public.v_sayerlack_mapeamento_gap (data_health_check_sayerlack_mapeamento_gap) — view abandonada (zero uso no app/SQL)
 --   • cron_job cron.sync-inventory-full-vendas-daily (cron_sync_inventory_full) — reorganizado → sync-inventory-vendas-30m / -servicos-1h / -colacor-vendas-1h
 --   • rls_policy public.cmc_ledger_select_staff (cmc_ledger) — substituída → cmc_ledger_select_gestor (hardening staff→gestor)
+--   • function public.omie_cliente_upsert_mapping (omie_identidade_por_conta) — drop — 20260718091409_drop_omie_cliente_upsert_mapping_orfa (PR #1409)
+--   • function public.estimar_impacto_exclusao_outlier (outliers_leadtime_stack_efetivo) — drop — 20260718093248_drop_estimar_impacto_exclusao_outlier_orfa
 
 -- =====================================================
 -- SECTION 1: Status reconciliado por migration
@@ -416,10 +418,14 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260717010000', 'preco_medio_leadtime_efetivo', '20260717010000_preco_medio_leadtime_efetivo.sql'),
   ('20260717015000', 'restaurar_security_invoker_views', '20260717015000_restaurar_security_invoker_views.sql'),
   ('20260717020000', 'precos_compra_leadtime_efetivo', '20260717020000_precos_compra_leadtime_efetivo.sql'),
+  ('20260717020000', 'reposicao_exclusao_outlier_remover', '20260717020000_reposicao_exclusao_outlier_remover.sql'),
   ('20260717120000', 'seg_customer_metrics_gate_staff', '20260717120000_seg_customer_metrics_gate_staff.sql'),
   ('20260717130000', 'seg_customer_metrics_acl_least_privilege', '20260717130000_seg_customer_metrics_acl_least_privilege.sql'),
   ('20260717154500', 'refresh_customer_metrics_automacao', '20260717154500_refresh_customer_metrics_automacao.sql'),
-  ('20260717160000', 'data_health_customer_metrics_watchdog', '20260717160000_data_health_customer_metrics_watchdog.sql')
+  ('20260717160000', 'data_health_customer_metrics_watchdog', '20260717160000_data_health_customer_metrics_watchdog.sql'),
+  ('20260717181500', 'carteira_visivel_para_filtra_eligible', '20260717181500_carteira_visivel_para_filtra_eligible.sql'),
+  ('20260718091409', 'drop_omie_cliente_upsert_mapping_orfa', '20260718091409_drop_omie_cliente_upsert_mapping_orfa.sql'),
+  ('20260718093248', 'drop_estimar_impacto_exclusao_outlier_orfa', '20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1622,7 +1628,6 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_select_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_write_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo'),
-  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', ''),
   ('fin_antecipacoes', 'function', 'public', 'fin_antecipacoes_set_autor', ''),
   ('fin_antecipacoes', 'table', 'public', 'fin_antecipacoes', ''),
   ('fin_antecipacoes', 'index', 'public', 'fin_antecipacoes_ref_uq', 'fin_antecipacoes'),
@@ -1740,15 +1745,17 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('reposicao_recompute_leadtime_derivado', 'function', 'public', 'recomputar_leadtime_derivado', ''),
   ('sla_compliance_le_leadtime_efetivo', 'view', 'public', 'v_sku_sla_compliance', ''),
   ('outliers_leadtime_stack_efetivo', 'function', 'public', 'detectar_outliers_empresa', ''),
-  ('outliers_leadtime_stack_efetivo', 'function', 'public', 'estimar_impacto_exclusao_outlier', ''),
   ('outliers_leadtime_stack_efetivo', 'function', 'public', 'resolver_outlier', ''),
   ('preco_medio_leadtime_efetivo', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
   ('precos_compra_leadtime_efetivo', 'view', 'public', 'v_sku_parametros_sugeridos', ''),
+  ('reposicao_exclusao_outlier_remover', 'function', 'public', 'resolver_outlier', ''),
   ('seg_customer_metrics_gate_staff', 'view', 'public', 'customer_metrics_mv', ''),
   ('refresh_customer_metrics_automacao', 'function', 'public', 'refresh_customer_metrics', ''),
   ('refresh_customer_metrics_automacao', 'function', 'public', 'request_customer_metrics_refresh', ''),
   ('refresh_customer_metrics_automacao', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', ''),
-  ('data_health_customer_metrics_watchdog', 'function', 'public', '_data_health_compute', '')
+  ('data_health_customer_metrics_watchdog', 'function', 'public', '_data_health_compute', ''),
+  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'carteira_visivel_para', ''),
+  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'minha_carteira', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -2999,7 +3006,6 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_select_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_write_master', 'fin_dre_custo_tipo'),
   ('fin_dre_custo_tipo', 'rls_policy', 'public', 'fin_dre_custo_tipo_service_all', 'fin_dre_custo_tipo'),
-  ('omie_identidade_por_conta', 'function', 'public', 'omie_cliente_upsert_mapping', ''),
   ('fin_antecipacoes', 'function', 'public', 'fin_antecipacoes_set_autor', ''),
   ('fin_antecipacoes', 'table', 'public', 'fin_antecipacoes', ''),
   ('fin_antecipacoes', 'index', 'public', 'fin_antecipacoes_ref_uq', 'fin_antecipacoes'),
@@ -3117,15 +3123,17 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_recompute_leadtime_derivado', 'function', 'public', 'recomputar_leadtime_derivado', ''),
   ('sla_compliance_le_leadtime_efetivo', 'view', 'public', 'v_sku_sla_compliance', ''),
   ('outliers_leadtime_stack_efetivo', 'function', 'public', 'detectar_outliers_empresa', ''),
-  ('outliers_leadtime_stack_efetivo', 'function', 'public', 'estimar_impacto_exclusao_outlier', ''),
   ('outliers_leadtime_stack_efetivo', 'function', 'public', 'resolver_outlier', ''),
   ('preco_medio_leadtime_efetivo', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', ''),
   ('precos_compra_leadtime_efetivo', 'view', 'public', 'v_sku_parametros_sugeridos', ''),
+  ('reposicao_exclusao_outlier_remover', 'function', 'public', 'resolver_outlier', ''),
   ('seg_customer_metrics_gate_staff', 'view', 'public', 'customer_metrics_mv', ''),
   ('refresh_customer_metrics_automacao', 'function', 'public', 'refresh_customer_metrics', ''),
   ('refresh_customer_metrics_automacao', 'function', 'public', 'request_customer_metrics_refresh', ''),
   ('refresh_customer_metrics_automacao', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', ''),
-  ('data_health_customer_metrics_watchdog', 'function', 'public', '_data_health_compute', '')
+  ('data_health_customer_metrics_watchdog', 'function', 'public', '_data_health_compute', ''),
+  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'carteira_visivel_para', ''),
+  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'minha_carteira', '')
 )
 SELECT
   e.migration,

--- a/scripts/audit-custom-migrations.ts
+++ b/scripts/audit-custom-migrations.ts
@@ -50,6 +50,9 @@ const OBSOLETE: Record<string, string> = {
   'cmc_ledger::cmc_ledger_select_staff': 'substituída → cmc_ledger_select_gestor (hardening staff→gestor)',
   'kb_specs_and_competitors::kb_product_specs_insert_staff': 'substituída → kb_product_specs_insert_master (hardening)',
   'data_health_check_sayerlack_mapeamento_gap::v_sayerlack_mapeamento_gap': 'view abandonada (zero uso no app/SQL)',
+  // Faxina de RPCs órfãs (2026-07-18) — orfandade provada via psql-ro + grep no repo antes do DROP.
+  'outliers_leadtime_stack_efetivo::estimar_impacto_exclusao_outlier': 'drop — 20260718093248_drop_estimar_impacto_exclusao_outlier_orfa',
+  'omie_identidade_por_conta::omie_cliente_upsert_mapping': 'drop — 20260718091409_drop_omie_cliente_upsert_mapping_orfa (PR #1409)',
 };
 
 interface MigrationAudit {

--- a/supabase/migrations/20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql
+++ b/supabase/migrations/20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql
@@ -1,0 +1,166 @@
+-- ============================================================
+-- DROP da RPC ÓRFÃ estimar_impacto_exclusao_outlier(bigint)
+--
+-- CONTEXTO: resíduo do PR #1402 (exclusão de outlier RETIRADA, 2026-07-16). A ação prometia
+-- "one-off, remove da estatística" mas `observacoes_excluidas` NUNCA entrou na cadeia do motor
+-- de reposição — a exclusão não movia a compra. Esta RPC alimentava o card "Impacto se excluir"
+-- (σ atual → sem outlier), que saiu da tela junto com a ação.
+--
+-- POR QUE NÃO FOI DROPADA NA HORA: migration e Publish do Lovable são passos MANUAIS e
+-- INDEPENDENTES — um DROP aplicado antes do Publish quebraria o card ainda servido em produção.
+-- A função ficou com COMMENT de deprecada e "DROP pendente de faxina após o Publish confirmado".
+--
+-- A CONDIÇÃO FOI CUMPRIDA (verificado 2026-07-18, pelos BYTES do bundle servido em
+-- https://steu.lovable.app/assets/ — não pela main nem por relato):
+--   • chunk AdminReposicaoAlertas-DUwQaNyd.js CONTÉM "Marcar como revisado" e "4. Revisão"
+--     (estado pós-#1402) e NÃO contém "Impacto se excluir" / "remove da estatística" / "5. Decisão";
+--   • varredura dos 305 chunks referenciados (5,8 MB): ZERO ocorrências do nome da RPC.
+--
+-- ORFANDADE PROVADA (psql-ro na PROD + grep no repo, 2026-07-18) — com FALSIFICAÇÃO do método:
+--   • banco: pg_depend ZERO dependentes; zero rotinas (todo prokind) citando no prosrc; zero
+--     views/matviews, RLS policies, cron.job, defaults/generated, CHECK constraints e triggers;
+--   • assinatura ÚNICA — não há overload (o guard abaixo torna isso verificável no apply);
+--   • código vivo (src + supabase/functions, fora o types.ts gerado): ZERO invocações — os 2
+--     únicos hits são COMENTÁRIOS explicativos que sobrevivem ao DROP de propósito (explicam por
+--     que a média do gráfico passou a ser derivada do mesmo histórico que desenha os pontos);
+--   • invocação DINÂMICA (`.rpc(var)`): só 2 sítios, ambos de domínio FECHADO por literal
+--     (pcp-apontamento.ts → callRpc NÃO exportada, só 3 literais fn_pcp_*; melhoria-triagem →
+--     mapa RPC_POR_TOOL de 2 literais) — nenhum a alcança;
+--   • FALSIFICAÇÃO: o MESMO método rodado contra `resolver_outlier` (RPC viva da MESMA tela)
+--     ENCONTRA os chamadores — no repo (AdminReposicaoAlertas.tsx:212 e :241) E no bundle de
+--     produção. O método discrimina: "não achou" é significativo, não é o grep estando cego.
+--     ⚠️ pg_stat_statements NÃO existe nesta instância e pg_stat_user_functions não serve
+--     (track_functions='none') — nenhum dos dois foi usado como evidência.
+--
+-- POR QUE DROPAR EM VEZ DE "DEIXAR QUIETA": a função carrega 3 bugs (documentados no próprio
+-- COMMENT) que a tornam uma armadilha para quem a encontrar no catálogo e a supuser utilizável:
+--   (a) fórmula DIVERGE da do motor (z fixo 1,65 × z por classe; σ por-venda × σ diário; 180d × 90d);
+--   (b) COALESCE(sigma,0) FABRICA zero quando o desvio é desconhecido — viola "ausente != zero"
+--       do money-path (o número sairia plausível e errado, que é o pior modo de falha);
+--   (c) nenhum ramo para sku_inativado_omie/sku_reativado_omie — caía no ramo de leadtime e
+--       devolvia `error`, que a tela exibia como "Calculando…" para sempre.
+-- É superfície de LEITURA (SECURITY DEFINER, GRANT p/ authenticated), não de escrita: o DROP não
+-- toca dado algum. Nenhuma tabela é referenciada por este arquivo.
+--
+-- REVERSÍVEL: o corpo íntegro está no bloco de rollback ao fim (comentado), capturado verbatim de
+-- pg_get_functiondef na PROD em 2026-07-18.
+--
+-- Spec: docs/superpowers/specs/2026-07-16-reposicao-exclusao-outlier-escopo-design.md
+-- Lição: docs/agent/reposicao.md §Outras frentes (entrada de 2026-07-16)
+-- Migration que retirou o fluxo: 20260717020000_reposicao_exclusao_outlier_remover.sql
+-- ============================================================
+
+DROP FUNCTION IF EXISTS public.estimar_impacto_exclusao_outlier(bigint);
+
+-- Guard: falha ALTO se sobrou algum overload do mesmo nome (o DROP acima é por assinatura).
+-- Idempotente: re-colar este bloco após o DROP bem-sucedido conta 0 e passa.
+DO $$
+DECLARE v_sobrou int;
+BEGIN
+  SELECT count(*) INTO v_sobrou
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'estimar_impacto_exclusao_outlier';
+
+  IF v_sobrou > 0 THEN
+    RAISE EXCEPTION 'estimar_impacto_exclusao_outlier ainda tem % overload(s) — DROP incompleto', v_sobrou;
+  END IF;
+END $$;
+
+-- ============================================================
+-- ROLLBACK (se precisar ressuscitar — corpo verbatim de pg_get_functiondef, prod 2026-07-18).
+-- ⚠️ Ressuscitar reintroduz os 3 bugs acima: não use como fonte de número sem corrigi-los.
+--
+-- CREATE OR REPLACE FUNCTION public.estimar_impacto_exclusao_outlier(p_evento_id bigint)
+--  RETURNS jsonb
+--  LANGUAGE plpgsql
+--  SECURITY DEFINER
+--  SET search_path TO 'public'
+-- AS $function$
+-- DECLARE
+--   v_evento RECORD;
+--   v_sigma_atual numeric;
+--   v_media_atual numeric;
+--   v_sigma_sem numeric;
+--   v_media_sem numeric;
+--   v_d numeric;
+--   v_lt numeric;
+--   v_z numeric := 1.65;
+--   v_em_atual numeric;
+--   v_em_sem numeric;
+--   v_dedup_key text;
+-- BEGIN
+--   IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role)) THEN
+--     RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+--   END IF;
+--   SELECT * INTO v_evento FROM eventos_outlier WHERE id = p_evento_id;
+--   IF NOT FOUND THEN
+--     RETURN jsonb_build_object('error', 'Evento não encontrado');
+--   END IF;
+--
+--   IF v_evento.tipo = 'venda_atipica' THEN
+--     SELECT AVG(quantidade), STDDEV_SAMP(quantidade) INTO v_media_atual, v_sigma_atual
+--     FROM venda_items_history
+--     WHERE empresa::text = v_evento.empresa AND sku_codigo_omie::text = v_evento.sku_codigo_omie
+--       AND data_emissao >= CURRENT_DATE - INTERVAL '180 days' AND quantidade > 0;
+--     SELECT AVG(quantidade), STDDEV_SAMP(quantidade) INTO v_media_sem, v_sigma_sem
+--     FROM venda_items_history
+--     WHERE empresa::text = v_evento.empresa AND sku_codigo_omie::text = v_evento.sku_codigo_omie
+--       AND data_emissao >= CURRENT_DATE - INTERVAL '180 days' AND quantidade > 0
+--       AND NOT (data_emissao::date = v_evento.data_evento AND nfe_chave_acesso::text = COALESCE(v_evento.detalhes->>'nfe', ''));
+--     SELECT demanda_media_diaria, lt_medio_dias_uteis INTO v_d, v_lt
+--     FROM sku_parametros WHERE empresa = v_evento.empresa AND sku_codigo_omie::text = v_evento.sku_codigo_omie LIMIT 1;
+--     v_d := COALESCE(v_d, v_media_atual);
+--     v_lt := COALESCE(v_lt, 10);
+--     v_em_atual := CEIL(v_z * COALESCE(v_sigma_atual, 0) * SQRT(v_lt));
+--     v_em_sem := CEIL(v_z * COALESCE(v_sigma_sem, 0) * SQRT(v_lt));
+--     RETURN jsonb_build_object(
+--       'tipo', 'venda_atipica',
+--       'sigma_atual', ROUND(COALESCE(v_sigma_atual, 0), 2),
+--       'sigma_sem', ROUND(COALESCE(v_sigma_sem, 0), 2),
+--       'media_atual', ROUND(COALESCE(v_media_atual, 0), 2),
+--       'media_sem', ROUND(COALESCE(v_media_sem, 0), 2),
+--       'em_atual', v_em_atual, 'em_sem', v_em_sem,
+--       'delta_em', v_em_sem - v_em_atual, 'd', v_d, 'lt', v_lt
+--     );
+--   ELSE
+--     -- A identidade da observação é o dedup_key. Evento antigo sem dedup_key (não
+--     -- alcançado pelo backfill da seção 4) não é estimável: devolver 0 de impacto seria
+--     -- fabricar "excluir não muda nada". A tela já degrada em `error` (ImpactoData.error).
+--     v_dedup_key := v_evento.detalhes->>'dedup_key';
+--     IF v_dedup_key IS NULL THEN
+--       RETURN jsonb_build_object(
+--         'tipo', 'lt_atipico',
+--         'error', 'Evento sem identidade de observação (dedup_key) — impacto não estimável'
+--       );
+--     END IF;
+--
+--     -- Fonte efetiva: 1 observação por NFe. Antes lia sku_leadtime_history cru — média e
+--     -- sigma saíam ponderados pela multiplicidade da NFe.
+--     SELECT AVG(lt_bruto_dias_uteis), STDDEV_SAMP(lt_bruto_dias_uteis) INTO v_media_atual, v_sigma_atual
+--     FROM v_sku_leadtime_efetivo
+--     WHERE empresa::text = v_evento.empresa AND sku_codigo_omie::text = v_evento.sku_codigo_omie
+--       AND lt_bruto_dias_uteis IS NOT NULL;
+--
+--     -- Era `NOT (data_pedido::date = v_evento.data_evento)`: `data_pedido` NUNCA existiu
+--     -- nesta tabela (é `t1_data_pedido`) ⇒ 42703 em runtime, sempre.
+--     SELECT AVG(lt_bruto_dias_uteis), STDDEV_SAMP(lt_bruto_dias_uteis) INTO v_media_sem, v_sigma_sem
+--     FROM v_sku_leadtime_efetivo
+--     WHERE empresa::text = v_evento.empresa AND sku_codigo_omie::text = v_evento.sku_codigo_omie
+--       AND lt_bruto_dias_uteis IS NOT NULL
+--       AND dedup_key <> v_dedup_key;
+--
+--     RETURN jsonb_build_object(
+--       'tipo', 'lt_atipico',
+--       'sigma_atual', ROUND(COALESCE(v_sigma_atual, 0), 2),
+--       'sigma_sem', ROUND(COALESCE(v_sigma_sem, 0), 2),
+--       'media_atual', ROUND(COALESCE(v_media_atual, 0), 2),
+--       'media_sem', ROUND(COALESCE(v_media_sem, 0), 2)
+--     );
+--   END IF;
+-- END;
+-- $function$
+--
+--
+-- REVOKE ALL ON FUNCTION public.estimar_impacto_exclusao_outlier(bigint) FROM PUBLIC, anon;
+-- GRANT EXECUTE ON FUNCTION public.estimar_impacto_exclusao_outlier(bigint) TO authenticated;
+-- ============================================================


### PR DESCRIPTION
Faxina do resíduo do #1402: a RPC `estimar_impacto_exclusao_outlier(bigint)` ficou órfã em produção **de propósito** e agora a condição que segurava o DROP foi cumprida.

## Por que ela ainda estava lá

O #1402 retirou a ação "excluir outlier" e o card **"Impacto se excluir"** que esta RPC alimentava. O DROP não foi junto porque **migration e Publish do Lovable são passos manuais independentes** — dropar antes do Publish quebraria o card ainda servido em produção. O `COMMENT` na função dizia literalmente *"DROP pendente de faxina após o Publish confirmado"*.

## A condição foi cumprida — provada nos BYTES, não na main

Verificado em 2026-07-18 contra o bundle **servido** em `https://steu.lovable.app/assets/`:

| Verificação | Resultado |
|---|---|
| `AdminReposicaoAlertas-DUwQaNyd.js` contém "Marcar como revisado" / "4. Revisão" (estado pós-#1402) | ✅ presente |
| mesmo chunk contém "Impacto se excluir" / "remove da estatística" / "5. Decisão" | ✅ ausente |
| nome da RPC em **qualquer** dos 305 chunks referenciados (5,8 MB baixados) | ✅ zero |

## Orfandade provada — com falsificação do método

Pré-flight via `psql-ro` na PROD + grep no repo:

- **Banco:** `pg_depend` zero dependentes; zero rotinas (todo `prokind`) citando no `prosrc`; zero views/matviews, RLS policies, `cron.job`, defaults/generated, CHECK constraints e triggers.
- **Assinatura única** — sem overload (e a migration traz um guard que falha alto se sobrar algum).
- **Código vivo** (`src` + `supabase/functions`, fora o `types.ts` gerado): zero invocações. Os 2 únicos hits são **comentários explicativos**, mantidos de propósito (ver abaixo).
- **Invocação dinâmica** (`.rpc(var)`): só 2 sítios, ambos de domínio **fechado por literal** — `pcp-apontamento.ts` (`callRpc` não exportada, 3 literais `fn_pcp_*`) e `melhoria-triagem` (mapa `RPC_POR_TOOL` de 2 literais). Nenhum a alcança.
- **🔍 Falsificação:** o **mesmo método** rodado contra `resolver_outlier` (RPC viva da **mesma tela**) **encontra** os chamadores — no repo (`AdminReposicaoAlertas.tsx:212` e `:241`) **e** no bundle de produção. O método discrimina: "não achou" é significativo, não é o grep estando cego. `pg_stat_statements` não existe nesta instância e `pg_stat_user_functions` não serve (`track_functions='none'`) — nenhum dos dois foi usado como evidência.

## Por que dropar em vez de deixar quieta

A função carrega **3 bugs** documentados no próprio `COMMENT`, que a tornam uma armadilha para quem a achar no catálogo e a supuser utilizável:

1. **fórmula diverge da do motor** — `z` fixo 1,65 × `z` por classe; σ por-venda × σ diário; 180d × 90d;
2. **`COALESCE(sigma,0)` fabrica zero** quando o desvio é desconhecido — viola *"ausente != zero"* do money-path (número plausível e errado, o pior modo de falha);
3. **nenhum ramo** para `sku_inativado_omie`/`sku_reativado_omie` — caía no ramo de leadtime e devolvia `error`, que a tela exibia como "Calculando…" para sempre.

É superfície de **leitura** (`SECURITY DEFINER`, GRANT p/ `authenticated`): o DROP não toca dado algum, nenhuma tabela é referenciada.

## Decisões de escopo

- **`types.ts` não foi tocado** (mesma escolha do #1409). Ele descreve o **banco**, que só muda quando o SQL for colado — removê-lo agora mentiria sobre o estado atual. A entrada é inerte (sem chamador) e o Lovable regenera.
- **Os 2 comentários foram MANTIDOS.** Eles respondem *"por que a média do gráfico é derivada localmente?"* — pergunta que **sobrevive ao DROP** e cuja resposta previne a regressão de alguém recriar uma RPC para isso. Removê-los deixaria o `useMemo` sem justificativa.
- **⚠️ Fora do pedido, sinalizado:** o mapa `OBSOLETE` do gerador de audit ganhou 2 entradas. Sem elas, o audit acusaria `❌ objeto faltando` **para sempre** — a migration que *criou* a função continua listando-a como esperada. Uma é minha; **a outra é do #1409** (mergeado hoje, mesma classe, 1 linha) — que sem isso passaria a gerar falso positivo. Se preferir separar, é só remover a linha do `omie_cliente_upsert_mapping`.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

**🟣 Lovable → SQL Editor → cola → Run:**

```sql
-- DROP da RPC órfã estimar_impacto_exclusao_outlier(bigint) — resíduo do PR #1402.
-- Orfandade provada (psql-ro + grep + bundle de produção); Publish confirmado nos bytes.
-- Cabeçalho completo e bloco de ROLLBACK no arquivo da migration.

DROP FUNCTION IF EXISTS public.estimar_impacto_exclusao_outlier(bigint);

-- Guard: falha ALTO se sobrou algum overload do mesmo nome (o DROP acima é por assinatura).
DO $$
DECLARE v_sobrou int;
BEGIN
  SELECT count(*) INTO v_sobrou
  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
  WHERE n.nspname = 'public' AND p.proname = 'estimar_impacto_exclusao_outlier';

  IF v_sobrou > 0 THEN
    RAISE EXCEPTION 'estimar_impacto_exclusao_outlier ainda tem % overload(s) — DROP incompleto', v_sobrou;
  END IF;
END $$;
```

**Validação pós-apply** (read-only):

```sql
SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
 WHERE n.nspname = 'public' AND p.proname = 'estimar_impacto_exclusao_outlier';  -- esperado: 0
```

> Pode colar de novo sem medo: é idempotente (`IF EXISTS` + guard que conta 0 e passa).

## Verificação

Sem prova PG17 formal (`prove-sql-money-path`) — é um DROP sem chamador, não emite número de decisão. Mas rodei um **smoke test** em PG17 efêmero, porque o modo de falha real é *o SQL quebrar na mão do founder*:

```
✅ pré-condição: função existe antes da migration (=1)
✅ migration aplicou sem erro
✅ a função órfã sumiu (=0)
✅ re-apply não quebra (idempotência)
✅ guard PEGOU o overload e falhou alto  ← falsificação: com overload presente a migration TEM de falhar
═══ 5 ✅   0 ❌ ═══
```

`wt:preflight --full` 🟢 sem colisão (59.381 objetos concorrentes). `typecheck` 0 erros · `lint` 0 erros.

Spec: `docs/superpowers/specs/2026-07-16-reposicao-exclusao-outlier-escopo-design.md` · Lição: `docs/agent/reposicao.md` §Outras frentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
