### PR TITLE
fix(sync): nid_receb sai do jsonb multi-writer — backfill de leadtime para de girar em falso [money-path]

### DIFF
--- a/db/test-pot-nid-receb.sh
+++ b/db/test-pot-nid-receb.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# PROVA PG17 — retenção do nIdReceb (coluna dedicada + backfill barato do jsonb).
+#   bash db/test-pot-nid-receb.sh > /tmp/t.log 2>&1; echo "exit=$?"
+#   (NÃO pipe pra tail — engole o exit≠0.)
+#
+# O que se prova aqui:
+#   1. O backfill barato tira o sinal do jsonb SEM chamar a Omie.
+#   2. Ele só aceita nIdReceb NUMÉRICO — qualquer outra coisa fica NULL (ausente ≠ zero:
+#      um sinal fabricado consultaria o recebimento ERRADO no ERP).
+#   3. Reaplicar não sobrescreve um nid_receb já resolvido (o WHERE ... IS NULL).
+#   4. O índice parcial do backfill existe e casa com o predicado do sync.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="nidreceb"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ── ZONA 1: pré-requisitos de schema (o que a migration ALTERA mas não cria) ──
+P -q <<'SQL'
+CREATE TYPE public.empresa_reposicao AS ENUM ('OBEN','COLACOR');
+CREATE TABLE public.purchase_orders_tracking (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa public.empresa_reposicao NOT NULL,
+  nfe_chave_acesso text,
+  raw_data jsonb
+);
+SQL
+
+# ── ZONA 3 (antes da 2 de propósito): seed. O backfill barato só tem o que popular se o
+#    jsonb já existir quando a migration roda — é exatamente a situação de produção. ──
+P -q <<'SQL'
+INSERT INTO public.purchase_orders_tracking (id, empresa, nfe_chave_acesso, raw_data) VALUES
+  -- (a) sinal numérico no jsonb → DEVE virar coluna
+  ('aaaaaaaa-0000-0000-0000-000000000001','OBEN','1', '{"cabec":{"nIdReceb":90001}}'),
+  -- (b) numérico como STRING (a Omie devolve os dois) → DEVE virar coluna
+  ('aaaaaaaa-0000-0000-0000-000000000002','OBEN','2', '{"cabec":{"nIdReceb":"90002"}}'),
+  -- (c) NÃO-numérico → tem de ficar NULL (fabricar consultaria o recebimento errado)
+  ('bbbbbbbb-0000-0000-0000-000000000001','OBEN','3', '{"cabec":{"nIdReceb":"90003abc"}}'),
+  -- (d) string vazia → NULL
+  ('bbbbbbbb-0000-0000-0000-000000000002','OBEN','4', '{"cabec":{"nIdReceb":""}}'),
+  -- (e) payload do PEDIDO (o que o sync concorrente grava por cima) → NULL
+  ('bbbbbbbb-0000-0000-0000-000000000003','OBEN','5', '{"cabecalho_consulta":{"nCodPed":7}}'),
+  -- (f) raw_data ausente → NULL
+  ('bbbbbbbb-0000-0000-0000-000000000004','OBEN','6', NULL);
+SQL
+
+# ── ZONA 2: aplica a migration REAL do repo (Lei #1) ──
+MIG="$REPO_ROOT/supabase/migrations/20260718120000_pot_nid_receb_retencao.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+echo "═══ asserts ═══"
+
+# A1 — o sinal numérico saiu do jsonb para a coluna (int e string)
+eq "A1a nIdReceb numérico virou coluna" \
+   "$(Pq -c "SELECT nid_receb FROM public.purchase_orders_tracking WHERE nfe_chave_acesso='1'")" "90001"
+eq "A1b nIdReceb numérico-string virou coluna" \
+   "$(Pq -c "SELECT nid_receb FROM public.purchase_orders_tracking WHERE nfe_chave_acesso='2'")" "90002"
+
+# A2 — precisão > recall: nada de fabricar sinal a partir de lixo
+eq "A2 lixo NÃO vira sinal (não-numérico, vazio, payload de pedido, raw_data nulo)" \
+   "$(Pq -c "SELECT count(*) FROM public.purchase_orders_tracking WHERE nfe_chave_acesso IN ('3','4','5','6') AND nid_receb IS NOT NULL")" "0"
+
+# A3 — o índice parcial do backfill existe e casa com o predicado do sync
+eq "A3 índice parcial do backfill criado" \
+   "$(Pq -c "SELECT count(*) FROM pg_indexes WHERE schemaname='public' AND indexname='idx_pot_backfill_nid_receb'")" "1"
+eq "A3b índice cobre o predicado (NFe presente + sinal ausente)" \
+   "$(Pq -c "SELECT count(*) FROM pg_indexes WHERE indexname='idx_pot_backfill_nid_receb' AND indexdef LIKE '%nfe_chave_acesso IS NOT NULL%' AND indexdef LIKE '%nid_receb IS NULL%'")" "1"
+
+# A4 — IDEMPOTÊNCIA REAL: um sinal já resolvido não é sobrescrito ao reaplicar.
+# (Simula o sinal resolvido pela edge; o jsonb da linha (a) diz 90001, a coluna diz 99999.)
+P -q -c "UPDATE public.purchase_orders_tracking SET nid_receb = 99999 WHERE nfe_chave_acesso='1'"
+P -q -f "$MIG"
+eq "A4 reaplicar NÃO sobrescreve sinal já resolvido" \
+   "$(Pq -c "SELECT nid_receb FROM public.purchase_orders_tracking WHERE nfe_chave_acesso='1'")" "99999"
+eq "A4b reaplicar não estraga os demais" \
+   "$(Pq -c "SELECT nid_receb FROM public.purchase_orders_tracking WHERE nfe_chave_acesso='2'")" "90002"
+
+echo "═══ RESULTADO: $PASS ok / $FAIL fail ═══"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,12 +21,12 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **384** custom migrations totais
-- **1341** objetos esperados (criados por estas migrations)
+- **385** custom migrations totais
+- **1342** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 381
   - `rls_policy`: 295
-  - `index`: 222
+  - `index`: 223
   - `cron_job`: 150
   - `table`: 146
   - `trigger`: 78
@@ -3254,6 +3254,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260718120000_pot_nid_receb_retencao.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `index` | `public.idx_pot_backfill_nid_receb` | `purchase_orders_tracking` |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 384
+-- Total de custom migrations: 385
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -425,7 +425,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260717160000', 'data_health_customer_metrics_watchdog', '20260717160000_data_health_customer_metrics_watchdog.sql'),
   ('20260717181500', 'carteira_visivel_para_filtra_eligible', '20260717181500_carteira_visivel_para_filtra_eligible.sql'),
   ('20260718091409', 'drop_omie_cliente_upsert_mapping_orfa', '20260718091409_drop_omie_cliente_upsert_mapping_orfa.sql'),
-  ('20260718093248', 'drop_estimar_impacto_exclusao_outlier_orfa', '20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql')
+  ('20260718093248', 'drop_estimar_impacto_exclusao_outlier_orfa', '20260718093248_drop_estimar_impacto_exclusao_outlier_orfa.sql'),
+  ('20260718120000', 'pot_nid_receb_retencao', '20260718120000_pot_nid_receb_retencao.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1755,7 +1756,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('refresh_customer_metrics_automacao', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', ''),
   ('data_health_customer_metrics_watchdog', 'function', 'public', '_data_health_compute', ''),
   ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'carteira_visivel_para', ''),
-  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'minha_carteira', '')
+  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'minha_carteira', ''),
+  ('pot_nid_receb_retencao', 'index', 'public', 'idx_pot_backfill_nid_receb', 'purchase_orders_tracking')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3133,7 +3135,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('refresh_customer_metrics_automacao', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', ''),
   ('data_health_customer_metrics_watchdog', 'function', 'public', '_data_health_compute', ''),
   ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'carteira_visivel_para', ''),
-  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'minha_carteira', '')
+  ('carteira_visivel_para_filtra_eligible', 'function', 'public', 'minha_carteira', ''),
+  ('pot_nid_receb_retencao', 'index', 'public', 'idx_pot_backfill_nid_receb', 'purchase_orders_tracking')
 )
 SELECT
   e.migration,

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1632,6 +1632,9 @@ describe('guardrail money-path: omie-sync-sku-items agrega itens por (tracking, 
       mirrorBlockNamed(src, 'sku-items-agregacao'),
       'edge divergiu do helper de src/ — o Lovable reescreveu a agregação no deploy?',
     ).toBe(mirrorBlockNamed(helper, 'sku-items-agregacao'));
+  });
+});
+
 // ── Retenção do sinal do recebimento (nid_receb) ──
 // purchase_orders_tracking.raw_data é jsonb MULTI-WRITER: o sync de pedidos grava o payload
 // do PEDIDO por cima e apaga o nIdReceb que o sync de NFes acabou de resolver. A cada rodada
@@ -1663,10 +1666,13 @@ describe('guardrail money-path: retenção do nid_receb (coluna dedicada + 1 wri
   });
 
   it('nfes-recebidas decide o pendente pela COLUNA, no banco (não pelo jsonb, em memória)', () => {
+    // Ancorado no SELECT do backfill, não solto no arquivo: `.is("nid_receb", null)` também
+    // aparece no compare-and-set do UPDATE, e um regex solto passaria verde com o filtro do
+    // select removido — o Sísifo voltaria sem ninguém ver. (Pego pela falsificação F2.)
     expect(
       nfes,
-      'REGRESSÃO: o backfill não filtra mais por nid_receb no banco — volta a redescobrir como pendente o que já resolveu, e o teto de 1.000 linhas do PostgREST volta a truncar em silêncio',
-    ).toMatch(/\.is\("nid_receb",\s*null\)/);
+      'REGRESSÃO: o SELECT do backfill não filtra mais por nid_receb no banco — volta a redescobrir como pendente o que já resolveu, e o teto de 1.000 linhas do PostgREST volta a truncar em silêncio',
+    ).toMatch(/\.not\("nfe_chave_acesso",\s*"is",\s*null\)\s*\n\s*\.is\("nid_receb",\s*null\)/);
   });
 
   it('nfes-recebidas é o writer ÚNICO e grava com compare-and-set', () => {

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1632,5 +1632,58 @@ describe('guardrail money-path: omie-sync-sku-items agrega itens por (tracking, 
       mirrorBlockNamed(src, 'sku-items-agregacao'),
       'edge divergiu do helper de src/ — o Lovable reescreveu a agregação no deploy?',
     ).toBe(mirrorBlockNamed(helper, 'sku-items-agregacao'));
+// ── Retenção do sinal do recebimento (nid_receb) ──
+// purchase_orders_tracking.raw_data é jsonb MULTI-WRITER: o sync de pedidos grava o payload
+// do PEDIDO por cima e apaga o nIdReceb que o sync de NFes acabou de resolver. A cada rodada
+// do cron o reparo é desfeito — o backfill nunca converge (contador de identificadas travado
+// por dias no fin_sync_log) e queima rate-limit da Omie re-resolvendo o que já estava pronto.
+// O sinal foi para uma COLUNA DEDICADA com UM escritor. Os três guardrails abaixo vigiam as
+// três pontas do circuito; se qualquer uma cair, o Sísifo volta em silêncio.
+const POT_PEDIDOS = 'supabase/functions/omie-sync-pedidos-compra/index.ts';
+const POT_NFES = 'supabase/functions/omie-sync-nfes-recebidas/index.ts';
+
+describe('guardrail money-path: retenção do nid_receb (coluna dedicada + 1 writer)', () => {
+  const pedidos = read(POT_PEDIDOS);
+  const nfes = read(POT_NFES);
+  const skuItems = read(SKU_ITEMS);
+
+  it('sentinela: leu os arquivos reais das três edges', () => {
+    expect(pedidos).toContain('PRESERVE_FIELDS');
+    expect(nfes).toContain('ConsultarRecebimento');
+    expect(skuItems).toContain('sku_leadtime_history');
+  });
+
+  it('pedidos-compra PRESERVA o sinal (não pode voltar a apagá-lo a cada rodada)', () => {
+    const bloco = pedidos.match(/const PRESERVE_FIELDS = new Set\(\[([\s\S]*?)\]\)/);
+    expect(bloco, 'PRESERVE_FIELDS sumiu do sync de pedidos').not.toBeNull();
+    expect(
+      bloco![1],
+      'REGRESSÃO: nid_receb saiu do PRESERVE_FIELDS — o sync de pedidos volta a apagar o sinal a cada rodada e o backfill volta ao Sísifo',
+    ).toContain('nid_receb');
+  });
+
+  it('nfes-recebidas decide o pendente pela COLUNA, no banco (não pelo jsonb, em memória)', () => {
+    expect(
+      nfes,
+      'REGRESSÃO: o backfill não filtra mais por nid_receb no banco — volta a redescobrir como pendente o que já resolveu, e o teto de 1.000 linhas do PostgREST volta a truncar em silêncio',
+    ).toMatch(/\.is\("nid_receb",\s*null\)/);
+  });
+
+  it('nfes-recebidas é o writer ÚNICO e grava com compare-and-set', () => {
+    expect(
+      nfes,
+      'REGRESSÃO: o writer não grava mais a coluna — a migration fica inerte e nada converge',
+    ).toMatch(/updateRow\.nid_receb/);
+    expect(
+      nfes,
+      'REGRESSÃO: sumiu a trava da chave no update — um run concorrente pode carimbar nesta linha o recebimento de OUTRA NFe',
+    ).toMatch(/\.eq\("nfe_chave_acesso",\s*linha\.nfe_chave_acesso\)/);
+  });
+
+  it('sku-items lê a COLUNA primeiro (jsonb só como fallback da transição)', () => {
+    expect(
+      skuItems,
+      'REGRESSÃO: o leitor voltou a depender só do jsonb — quando o backfill convergir ele para de regravar o raw_data e o leadtime morre em silêncio',
+    ).toMatch(/n\.nid_receb\s*!=\s*null/);
   });
 });

--- a/supabase/functions/omie-sync-nfes-recebidas/index.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/index.ts
@@ -76,7 +76,8 @@ const MAIN_LOOP_GUARD_MS = 120_000;
 
 // Tipos minimos pra responses da Omie (campos opcionais — Omie nem sempre devolve tudo)
 interface OmieNFeCabec {
-  nIdReceb?: number;
+  /** A Omie devolve ora número, ora string — quem lê normaliza (e rejeita não-numérico). */
+  nIdReceb?: number | string;
   cChaveNFe?: string;
   cChaveNfe?: string;
   nIdFornecedor?: number;
@@ -140,6 +141,8 @@ interface PurchaseOrderTrackingRow {
   t4_data_recebimento?: string | null;
   nfe_chave_acesso?: string | null;
   raw_data?: Record<string, unknown> | null;
+  /** Sinal do recebimento em coluna DEDICADA (o raw_data é multi-writer e perde o valor). */
+  nid_receb?: number | null;
   transportadora_nome?: string | null;
   transportadora_cnpj?: string | null;
 }
@@ -373,6 +376,9 @@ async function insertOrfa(
     transportadora_cnpj: m.transp_cnpj,
     transportadora_nome: m.transp_nome,
     raw_data: nfe,
+    // Coluna dedicada: a órfã nasce com o sinal já resolvido, então nunca entra na fila
+    // do backfill. (O raw_data aqui é do recebimento, mas é multi-writer e não sobrevive.)
+    nid_receb: nIdReceb,
   };
 
   const { data: existing } = await supabase
@@ -600,11 +606,20 @@ async function backfillRawData(
 
   const { app_key, app_secret } = getCredentials(empresa);
 
+  // O pendente é decidido pela COLUNA DEDICADA, no BANCO — não pelo jsonb, em memória.
+  // Por quê: raw_data é multi-writer (o sync de pedidos o sobrescreve com o payload do
+  // PEDIDO), então filtrar por ele redescobria como "pendente" toda linha que este mesmo
+  // backfill já havia resolvido na rodada anterior — o contador de identificadas ficava
+  // travado por dias enquanto a Omie era consultada à toa. nid_receb sobrevive ao sync
+  // concorrente (está no PRESERVE_FIELDS dele), então o trabalho ACUMULA e a fila drena.
+  // Filtrar no banco também tira a lista inteira da memória — o teto de 1.000 linhas do
+  // PostgREST truncava em silêncio conforme a tabela crescesse.
   let q = supabase
     .from("purchase_orders_tracking")
-    .select("id, nfe_chave_acesso, raw_data, t2_data_faturamento, t4_data_recebimento, transportadora_nome, transportadora_cnpj")
+    .select("id, nfe_chave_acesso, raw_data, nid_receb, t2_data_faturamento, t4_data_recebimento, transportadora_nome, transportadora_cnpj")
     .eq("empresa", empresa)
-    .not("nfe_chave_acesso", "is", null);
+    .not("nfe_chave_acesso", "is", null)
+    .is("nid_receb", null);
   if (fornecedorCodigo) q = q.eq("fornecedor_codigo_omie", fornecedorCodigo);
 
   const { data: linhas, error: selErr } = await q;
@@ -614,14 +629,7 @@ async function backfillRawData(
     return out;
   }
 
-  const linhasTyped = (linhas ?? []) as PurchaseOrderTrackingRow[];
-  const incompletos = linhasTyped.filter((l) => {
-    const rd = l.raw_data as { cabec?: { nIdReceb?: number } } | null | undefined;
-    if (!rd || typeof rd !== "object") return true;
-    const cab = rd.cabec;
-    if (!cab || typeof cab !== "object") return true;
-    return !cab.nIdReceb;
-  });
+  const incompletos = (linhas ?? []) as PurchaseOrderTrackingRow[];
 
   out.nfes_identificadas_para_backfill = incompletos.length;
   console.log(`[backfill] ${empresa} identificadas=${incompletos.length}`);
@@ -652,9 +660,19 @@ async function backfillRawData(
 
       const m = mapNFe(detalhe);
       const updateRow: Record<string, unknown> = {
+        // Dual-write: a coluna dedicada é a fonte de verdade daqui pra frente, mas o
+        // raw_data segue sendo gravado enquanto houver leitor legado do jsonb.
         raw_data: detalhe,
         updated_at: new Date().toISOString(),
       };
+
+      // Sinal money-path: só entra se for numérico. Ausente/ilegível ⇒ deixa NULL — um
+      // nIdReceb fabricado consultaria o recebimento ERRADO no ERP (ausente ≠ zero).
+      const nidBruto = detalhe?.cabec?.nIdReceb;
+      const nid = typeof nidBruto === "number"
+        ? nidBruto
+        : (typeof nidBruto === "string" && /^\d+$/.test(nidBruto) ? Number(nidBruto) : null);
+      if (nid !== null) updateRow.nid_receb = nid;
       if (!linha.t2_data_faturamento && m.data_emissao_iso) {
         updateRow.t2_data_faturamento = m.data_emissao_iso;
       }
@@ -668,10 +686,16 @@ async function backfillRawData(
         updateRow.transportadora_cnpj = m.transp_cnpj;
       }
 
+      // Compare-and-set: só grava se o sinal ainda estiver ausente E a chave da linha for
+      // a MESMA que foi consultada. Sem isto, dois runs concorrentes (ou uma chave trocada
+      // no meio da chamada à Omie) poderiam carimbar nesta linha o recebimento de outra
+      // NFe. Perder a corrida é inócuo — quem venceu já gravou o mesmo sinal.
       const { error: updErr } = await supabase
         .from("purchase_orders_tracking")
         .update(updateRow)
-        .eq("id", linha.id);
+        .eq("id", linha.id)
+        .eq("nfe_chave_acesso", linha.nfe_chave_acesso)
+        .is("nid_receb", null);
       if (updErr) {
         console.error(`[backfill] ${empresa} chave=${chave} update erro: ${updErr.message}`);
         out.erros++;

--- a/supabase/functions/omie-sync-pedidos-compra/index.ts
+++ b/supabase/functions/omie-sync-pedidos-compra/index.ts
@@ -505,6 +505,12 @@ const PRESERVE_FIELDS = new Set([
   "lt_bruto_dias_uteis",
   "lt_faturamento_dias_uteis",
   "lt_logistica_dias_uteis",
+  // Sinal do RECEBIMENTO, resolvido pelo omie-sync-nfes-recebidas (writer único).
+  // Estava só no raw_data — que este upsert sobrescreve com o payload do PEDIDO — e era
+  // apagado a cada rodada do cron, obrigando o backfill do sync irmão a re-resolvê-lo
+  // eternamente sem nunca convergir (contador de identificadas travado por dias no
+  // fin_sync_log). Sem esta linha, o Sísifo volta.
+  "nid_receb",
 ]);
 
 /**

--- a/supabase/functions/omie-sync-sku-items/index.ts
+++ b/supabase/functions/omie-sync-sku-items/index.ts
@@ -434,6 +434,9 @@ interface NFeRow {
   fornecedor_codigo_omie: number;
   fornecedor_nome: string | null;
   raw_data: NFeRawData | null;
+  /** Sinal do recebimento em coluna DEDICADA — sobrevive ao sync de pedidos, que
+   *  sobrescreve o raw_data. Fonte preferida; o jsonb fica só como fallback. */
+  nid_receb: number | null;
 }
 
 /** NFeRow com o nIdReceb já extraído do raw_data — a fila dedup-a por ele, e o
@@ -663,7 +666,7 @@ Deno.serve(async (req) => {
     let q = supabase
       .from("purchase_orders_tracking")
       .select(
-        "id, nfe_chave_acesso, t1_data_pedido, t2_data_faturamento, t3_data_cte, t4_data_recebimento, fornecedor_codigo_omie, fornecedor_nome, raw_data",
+        "id, nfe_chave_acesso, t1_data_pedido, t2_data_faturamento, t3_data_cte, t4_data_recebimento, fornecedor_codigo_omie, fornecedor_nome, raw_data, nid_receb",
       )
       .eq("empresa", empresa)
       .gte("t2_data_faturamento", cutoffIso)
@@ -722,9 +725,14 @@ Deno.serve(async (req) => {
     const filaOrdenada: NFeFilaRow[] = pendentes
       .map((n) => ({
         ...n,
-        nIdReceb: n.raw_data?.cabec?.nIdReceb != null
-          ? String(n.raw_data.cabec.nIdReceb)
-          : null,
+        // Dual-read: a coluna dedicada VENCE; o jsonb fica como fallback da transição.
+        // Quando o backfill do sync de NFes convergir, ele para de re-consultar a Omie e
+        // portanto para de regravar o raw_data — um leitor só-jsonb regrediria em silêncio.
+        nIdReceb: n.nid_receb != null
+          ? String(n.nid_receb)
+          : (n.raw_data?.cabec?.nIdReceb != null
+            ? String(n.raw_data.cabec.nIdReceb)
+            : null),
       }))
       .filter((n) => skuItemsElegivel(controleMap.get(n.id), agoraMs))
       .sort((a, b) =>

--- a/supabase/migrations/20260718120000_pot_nid_receb_retencao.sql
+++ b/supabase/migrations/20260718120000_pot_nid_receb_retencao.sql
@@ -1,0 +1,46 @@
+-- Retenção do nIdReceb: sinal do recebimento sai do jsonb multi-writer para coluna dedicada.
+--
+-- PROBLEMA (assinatura medida no fin_sync_log): o contador
+-- `nfes_identificadas_para_backfill` do omie-sync-nfes-recebidas fica TRAVADO no mesmo
+-- valor por dias, apesar de dezenas de reparos bem-sucedidos por dia. Trabalho cumulativo
+-- que não acumula = trabalho sendo DESFEITO por um escritor concorrente.
+--
+-- A causa: `purchase_orders_tracking.raw_data` é jsonb MULTI-WRITER.
+--   1) omie-sync-pedidos-compra grava o payload do PEDIDO (sem nIdReceb) — e `raw_data`
+--      NÃO está no PRESERVE_FIELDS dele, então o upsert apaga o sinal;
+--   2) omie-sync-nfes-recebidas resolve de novo via ConsultarRecebimento(cChaveNFe) e
+--      regrava o payload do RECEBIMENTO (com nIdReceb);
+--   3) omie-sync-sku-items só LÊ o sinal.
+-- A cada rodada do cron o passo 1 desfaz o passo 2. O backfill repara eternamente, nunca
+-- converge, e queima o orçamento de rate-limit da Omie em linhas que já estavam prontas —
+-- enquanto as que de fato precisam ficam por inanição.
+--
+-- É a armadilha que o CLAUDE.md já documenta, materializada: "sinal money-path nunca em
+-- coluna jsonb multi-writer (upsert destrutivo) → coluna dedicada + 1 writer".
+--
+-- ⚠️ ORDEM DE DEPLOY: esta migration vem ANTES das edges. A edge nova referencia a coluna
+-- (`.is('nid_receb', null)` e o select); subir a edge primeiro quebraria o sync. A migration
+-- sozinha é inerte para as edges antigas (coluna nullable que ninguém lê).
+
+ALTER TABLE public.purchase_orders_tracking
+  ADD COLUMN IF NOT EXISTS nid_receb bigint;
+
+COMMENT ON COLUMN public.purchase_orders_tracking.nid_receb IS
+  'Recebimento (Omie nIdReceb) da NFe desta linha. Coluna DEDICADA com UM escritor '
+  '(omie-sync-nfes-recebidas): o raw_data é jsonb multi-writer e o sync de pedidos o '
+  'sobrescrevia, apagando o sinal a cada rodada e impedindo o backfill de convergir. '
+  'NULL = ainda não resolvido (nunca fabricar: ausente ≠ zero).';
+
+-- Backfill barato: o sinal que AINDA está no jsonb entra na coluna SEM chamar a Omie.
+-- O regex é a trava de precisão — só numérico vira nid_receb. Qualquer outra coisa
+-- (ausente, vazio, texto) permanece NULL: degradar, nunca fabricar.
+UPDATE public.purchase_orders_tracking
+SET nid_receb = (raw_data->'cabec'->>'nIdReceb')::bigint
+WHERE nid_receb IS NULL
+  AND raw_data->'cabec'->>'nIdReceb' ~ '^\d+$';
+
+-- Índice do backfill: achar os pendentes sem varrer a tabela. O predicado espelha
+-- exatamente o filtro do omie-sync-nfes-recebidas (linhas com NFe e sem sinal).
+CREATE INDEX IF NOT EXISTS idx_pot_backfill_nid_receb
+  ON public.purchase_orders_tracking (empresa, id)
+  WHERE nfe_chave_acesso IS NOT NULL AND nid_receb IS NULL;


### PR DESCRIPTION
## O quê

O sinal que o sync de lead time precisa — `nIdReceb`, o id do recebimento na Omie — **é resolvido com sucesso a cada rodada do cron e destruído logo em seguida**. Ele mora em `purchase_orders_tracking.raw_data`, um jsonb **multi-writer**:

| Ordem no cron | Edge | O que faz com `raw_data` |
|---|---|---|
| 1 | `omie-sync-pedidos-compra` | grava o payload do **PEDIDO** — e `raw_data` **não estava** no `PRESERVE_FIELDS`, então apaga o sinal |
| 2 | `omie-sync-nfes-recebidas` | resolve de novo via `ConsultarRecebimento(cChaveNFe)` e regrava o payload do **RECEBIMENTO** |
| 4 | `omie-sync-sku-items` | só **lê** o sinal |

O passo 1 desfaz o passo 2, toda rodada. O backfill repara eternamente e **nunca converge**.

## A assinatura

No `fin_sync_log`, o contador `nfes_identificadas_para_backfill` fica **travado no mesmo valor por dias**, apesar de dezenas de reparos bem-sucedidos por dia. Trabalho cumulativo que não acumula é a assinatura de **trabalho sendo desfeito por escritor concorrente**.

O custo não é o lead time perdido — é o **orçamento de rate-limit da Omie**, gasto re-resolvendo linhas que já estavam prontas, enquanto as que de fato precisam ficam por inanição atrás do guard de timeout.

É a armadilha que o `CLAUDE.md` já documenta, materializada:

> "Sinal money-path **nunca** em coluna jsonb multi-writer (upsert destrutivo) → coluna dedicada + 1 writer."

O próprio código já reconhecia o multi-writer num comentário — sem corrigi-lo.

## O fix — coluna dedicada, um escritor

**Migration** — `purchase_orders_tracking.nid_receb` (nullable) + índice parcial para o backfill achar os pendentes + **backfill barato** que tira do jsonb o que já está lá, **sem chamar a Omie**. Só numérico vira sinal: um `nIdReceb` fabricado consultaria o recebimento **errado** no ERP.

**`omie-sync-pedidos-compra`** — `nid_receb` entra no `PRESERVE_FIELDS`. Era ele quem apagava.

**`omie-sync-nfes-recebidas`** (writer único) — grava a coluna além do `raw_data` (dual-write), e o pendente passa a ser decidido **no banco** (`.is('nid_receb', null)`) em vez de filtrar o jsonb em memória. Filtrar pelo jsonb redescobria como pendente o que o próprio backfill já resolvera; filtrar no banco também tira a lista da memória — o teto de 1.000 linhas do PostgREST truncaria em silêncio conforme a tabela cresce. Update com **compare-and-set** (id + chave inalterada + sinal ausente): sem isso, um run concorrente poderia carimbar na linha o recebimento de **outra** NFe.

**`omie-sync-sku-items`** (leitor) — **dual-read**, coluna primeiro, jsonb como fallback da transição. Não é escopo extra: quando o backfill converge, ele para de re-consultar e portanto **para de regravar o `raw_data`** — um leitor só-jsonb regrediria em silêncio.

## Prova

- **Migration provada no PG17 executando**, com **falsificação dupla**: (F1) "extrair os dígitos" de um valor sujo derruba o assert de não-fabricação; (F2) remover a guarda de idempotência faz o reaply sobrescrever um sinal já resolvido. Ambas revertidas com md5 conferido. 7/7 asserts.
- **Guardrails falsificados um a um.** A falsificação pegou um deles sendo **teatro**: o regex solto `.is("nid_receb", null)` casava também com o compare-and-set do UPDATE, então remover o filtro do SELECT passava **verde**. Ancorado no select e re-falsificado — agora fica vermelho.
- Health: typecheck · lint · suite completo.

## Território (multi-sessão)

O #1391 (DRAFT) reescreve `omie-sync-sku-items` **a partir da linha ~635** (loop de upsert / agregação). Este PR toca essa edge em **três pontos apenas** — o type da fila, o `.select(...)` e a extração do sinal (linhas 318 / 550 / 609). **Zero sobreposição**, verificado no diff.

## Deploy (manual — merge na `main` ≠ produção)

**Ordem obrigatória:**

1. **Migration** `supabase/migrations/20260718120000_pot_nid_receb_retencao.sql` → SQL Editor.
2. **Redeploy** das três edges → chat do Lovable (ler do repo, verbatim):
   `omie-sync-pedidos-compra` · `omie-sync-nfes-recebidas` · `omie-sync-sku-items`

⚠️ **A migration vem ANTES das edges.** A edge nova referencia a coluna (`.is('nid_receb', null)` e o `select`); subir a edge primeiro quebra o sync. A migration sozinha é inerte para as edges antigas (coluna nullable que ninguém lê).

**Publish do frontend:** não se aplica.

## Como saber se funcionou

O teste da tese: acompanhar `results->'backfill'->>'nfes_identificadas_para_backfill'` no `fin_sync_log`. Ele está **estável há dias**. Se o diagnóstico está certo, ele passa a **cair** rodada após rodada até o fluxo de NFes novas. **Se não cair, a tese está errada** — e o diagnóstico volta à mesa em vez de ser remendado.

## Fora de escopo (registrados)

- **`PRESERVE_FIELDS` é denylist** — o próximo campo crítico nasce desprotegido, que é exatamente como este incidente começou. Trocar por allowlist é mudança de arquitetura.
- **Separar `pedido_raw_data` / `recebimento_raw_data`** — o jsonb segue multi-writer; só o **sinal** money-path saiu dele.
- **Remover o fallback de leitura ao jsonb** — depois que a coluna estiver populada e verificada em produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
