### PR TITLE
fix(seg): conserta 4 callers órfãos do FU7 — RPCs quebradas em prod por função movida de schema [money-path]

### DIFF
--- a/db/test-fu7-callers-orfaos.sh
+++ b/db/test-fu7-callers-orfaos.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║ PROVA PG17 — hotfix dos 4 callers órfãos do FU7 (#1421)                       ║
+# ║ Migration: 20260718170000_fu7_conserta_callers_orfaos.sql                     ║
+# ║   bash db/test-fu7-callers-orfaos.sh > /tmp/t.log 2>&1; echo $?                ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+# O QUE ESTA PROVA TRAVA: o #1421 moveu `carteira_visivel_para`/`is_super_admin` de
+# `public` p/ `private` e não atualizou os 4 callers PL/pgSQL, que qualificam com
+# `public.` EXPLÍCITO. `CREATE OR REPLACE`/`SET SCHEMA` NÃO validam o corpo ⇒ as 4
+# funções só quebram ao EXECUTAR, com 42883 undefined_function.
+#
+# ⇒ Todo assert aqui EXECUTA a função. Um teste que só confira o TEXTO da definição
+#   (grep por 'private.') passaria verde com a função quebrada — é exatamente o
+#   falso-verde que o late-bound produz.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5472}"
+SLUG="fu7-callers"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+MASTER='10000000-0000-0000-0000-000000000001'
+VEND_A='30000000-0000-0000-0000-000000000003'
+CLI_OK='a0000000-0000-0000-0000-0000000000aa'
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — o estado PÓS-#1421: helpers em `private`, AUSENTES em `public`
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+DO $$ BEGIN CREATE TYPE public.commercial_role AS ENUM ('vendedor','gerencial','estrategico','super_admin'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.user_roles (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE IF NOT EXISTS public.commercial_roles (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.commercial_role NOT NULL);
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id=_user_id AND role=_role) $f$;
+CREATE OR REPLACE FUNCTION public.get_commercial_role(_uid uuid)
+RETURNS public.commercial_role LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT role FROM public.commercial_roles WHERE user_id=_uid LIMIT 1 $f$;
+CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT has_role(_uid,'master'::app_role) OR (has_role(_uid,'employee'::app_role)
+   AND get_commercial_role(_uid) IN ('gerencial'::commercial_role,'estrategico'::commercial_role,'super_admin'::commercial_role)) $f$;
+
+CREATE TABLE IF NOT EXISTS public.carteira_assignments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), customer_user_id uuid NOT NULL UNIQUE, owner_user_id uuid NOT NULL,
+  source text NOT NULL DEFAULT 'omie', eligible boolean NOT NULL DEFAULT true,
+  valid_from timestamptz NOT NULL DEFAULT now(), updated_at timestamptz NOT NULL DEFAULT now());
+CREATE TABLE IF NOT EXISTS public.carteira_coverage (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), covering_user_id uuid NOT NULL, covered_user_id uuid NOT NULL,
+  valid_from timestamptz NOT NULL DEFAULT now(), valid_until timestamptz, active boolean NOT NULL DEFAULT true,
+  created_by uuid NOT NULL DEFAULT gen_random_uuid(), created_at timestamptz NOT NULL DEFAULT now());
+
+-- ⚠️ O ESTADO QUE O #1421 DEIXOU: helper existe SÓ em `private`. Nenhum wrapper em `public`.
+--    Sem isto o harness "prova" um mundo onde public.carteira_visivel_para ainda existe,
+--    e o hotfix passaria verde mesmo estando errado.
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_customer_user_id uuid, _uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT _uid IS NOT NULL AND (
+    COALESCE(public.has_role(_uid,'master'::app_role),false)
+    OR EXISTS (SELECT 1 FROM public.carteira_assignments a
+               WHERE a.customer_user_id=_customer_user_id AND a.owner_user_id=_uid AND a.eligible IS TRUE)
+    OR EXISTS (SELECT 1 FROM public.carteira_assignments a
+               JOIN public.carteira_coverage c ON c.covered_user_id=a.owner_user_id
+               WHERE a.customer_user_id=_customer_user_id AND a.eligible IS TRUE
+                 AND c.covering_user_id=_uid AND c.active AND (c.valid_until IS NULL OR c.valid_until>now())));
+$f$;
+CREATE OR REPLACE FUNCTION private.is_super_admin(_uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(public.get_commercial_role(_uid) = 'super_admin'::public.commercial_role, false) $f$;
+
+CREATE TABLE IF NOT EXISTS public.farmer_tactical_plans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), farmer_id uuid NOT NULL, customer_user_id uuid NOT NULL,
+  bundle_recommendation_id uuid, health_score numeric, churn_risk numeric, mix_gap integer,
+  current_margin_pct numeric, cluster_avg_margin_pct numeric, expansion_potential numeric,
+  strategic_objective text NOT NULL DEFAULT 'expansao_mix', customer_profile text,
+  top_bundle jsonb, bundle_lie numeric, bundle_probability numeric, bundle_incremental_margin numeric,
+  best_individual_lie numeric, diagnostic_questions jsonb, implication_question text, offer_transition text,
+  probable_objections jsonb, approach_strategy text, plan_followed boolean, call_result text,
+  actual_margin numeric, call_duration_seconds integer, objection_type text, notes text, effectiveness_score numeric,
+  status text DEFAULT 'gerado', generated_at timestamptz DEFAULT now(), used_at timestamptz, completed_at timestamptz,
+  created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now(), plan_type text,
+  approach_strategy_b text, second_bundle jsonb, ltv_projection jsonb, expected_result jsonb, operational_risks jsonb);
+
+CREATE TABLE IF NOT EXISTS public.route_contact_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), data_rota date NOT NULL, customer_user_id uuid NOT NULL,
+  farmer_id uuid NOT NULL, canal text NOT NULL, valor_da_ligacao numeric, bucket text, status text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now());
+
+CREATE TABLE IF NOT EXISTS public.company_config (key text PRIMARY KEY, value text);
+SQL
+
+# o trigger de máscara do #1422 também vive nesta tabela — aplicar a migration anterior
+# mantém o harness fiel à prod (as duas convivem).
+P -q -f "$REPO_ROOT/supabase/migrations/20260718160000_tactical_plans_eligible_fail_closed.sql" >/dev/null 2>&1 || true
+echo "pré-req: estado pós-#1421 (helpers só em private) + trigger do #1422"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — a migration REAL sob teste
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260718170000_fu7_conserta_callers_orfaos.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — seeds
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$MASTER'),('$VEND_A'),('$CLI_OK') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES ('$MASTER','master'),('$VEND_A','employee');
+INSERT INTO public.commercial_roles(user_id, role) VALUES ('$VEND_A','vendedor');
+INSERT INTO public.carteira_assignments(customer_user_id, owner_user_id, eligible) VALUES ('$CLI_OK','$VEND_A', true);
+INSERT INTO public.company_config(key, value) VALUES ('master_cpf','00000000000');
+CREATE TRIGGER protect_master_config_trigger BEFORE INSERT OR UPDATE OR DELETE ON public.company_config
+  FOR EACH ROW EXECUTE FUNCTION public.protect_master_config();
+SQL
+echo "seeds ok"
+
+# Executa um comando e classifica em sentinelas MINHAS. O que importa é distinguir
+# "42883 undefined_function" (o bug do FU7) de qualquer outro desfecho.
+exec_sql() { # $1=uid $2=role $3=SQL
+  P -tA 2>&1 <<SQL
+SET test.uid='$1';
+SET test.role='$2';
+DO \$\$
+DECLARE v_out text := 'OK';
+BEGIN
+  BEGIN
+    $3
+  EXCEPTION
+    WHEN undefined_function THEN v_out := 'ORFA_42883';   -- o bug que este hotfix conserta
+    WHEN insufficient_privilege THEN v_out := 'GATE_42501';
+    WHEN raise_exception THEN v_out := 'GATE_P0001';
+    WHEN OTHERS THEN v_out := 'OUTRO_'||SQLSTATE;
+  END;
+  RAISE NOTICE 'RES=%', v_out;
+END \$\$;
+SQL
+}
+espera() { case "$2" in *"RES=$3"*) ok "$1 ($3)" ;; *) bad "$1 — esperado RES=$3, veio: $(echo "$2" | tr '\n' ' ' | tail -c 110)" ;; esac; }
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS: cada função é EXECUTADA (late-bound só aparece rodando)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── A. as 4 funções resolvem o helper e EXECUTAM ──"
+espera "A1 criar_plano_tatico (owner legítimo) executa" \
+  "$(exec_sql "$VEND_A" 'authenticated' "PERFORM public.criar_plano_tatico('$CLI_OK'::uuid, '$VEND_A'::uuid, '{}'::jsonb);")" 'OK'
+PID=$(Pq -c "SELECT id FROM public.farmer_tactical_plans LIMIT 1;")
+espera "A2 registrar_resultado_plano (owner legítimo) executa" \
+  "$(exec_sql "$VEND_A" 'authenticated' "PERFORM public.registrar_resultado_plano('$PID'::uuid, true, 'ganhou', 40, 600, NULL, NULL);")" 'OK'
+espera "A3 registrar_contato_rota (owner legítimo) executa" \
+  "$(exec_sql "$VEND_A" 'authenticated' "PERFORM public.registrar_contato_rota('$CLI_OK'::uuid, 'respondido', CURRENT_DATE, NULL, NULL);")" 'OK'
+espera "A4 protect_master_config: super_admin ausente ⇒ bloqueia pelo GATE (não por 42883)" \
+  "$(exec_sql "$VEND_A" 'authenticated' "UPDATE public.company_config SET value='11111111111' WHERE key='master_cpf';")" 'GATE_P0001'
+
+echo "── B. EFEITO no dado (a função não só 'não deu erro' — ela fez o trabalho) ──"
+eq "B1 o plano foi criado"                 "$(Pq -c "SELECT count(*) FROM public.farmer_tactical_plans;")" "1"
+eq "B2 o resultado foi registrado"         "$(Pq -c "SELECT status FROM public.farmer_tactical_plans LIMIT 1;")" "concluido"
+eq "B3 o contato de rota foi gravado"      "$(Pq -c "SELECT count(*) FROM public.route_contact_log;")" "1"
+eq "B4 master_cpf ficou INTACTO (gate barrou)" "$(Pq -c "SELECT value FROM public.company_config WHERE key='master_cpf';")" "00000000000"
+
+echo "── C. os gates de autorização continuam mordendo (o hotfix não afrouxou nada) ──"
+OUTRO='90000000-0000-0000-0000-000000000009'
+P -q -c "INSERT INTO auth.users(id) VALUES ('$OUTRO') ON CONFLICT DO NOTHING; INSERT INTO public.user_roles(user_id,role) VALUES ('$OUTRO','employee');"
+espera "C1 employee fora da carteira: criar_plano_tatico nega" \
+  "$(exec_sql "$OUTRO" 'authenticated' "PERFORM public.criar_plano_tatico('$CLI_OK'::uuid, '$VEND_A'::uuid, '{}'::jsonb);")" 'GATE_42501'
+espera "C2 employee fora da carteira: registrar_contato_rota nega" \
+  "$(exec_sql "$OUTRO" 'authenticated' "PERFORM public.registrar_contato_rota('$CLI_OK'::uuid, 'respondido', CURRENT_DATE, NULL, NULL);")" 'GATE_P0001'
+espera "C3 super_admin PODE alterar master_cpf (o gate não virou bloqueio total)" \
+  "$(P -tA 2>&1 <<SQL
+INSERT INTO public.commercial_roles(user_id, role) VALUES ('$MASTER','super_admin');
+SET test.uid='$MASTER'; SET test.role='authenticated';
+DO \$\$
+DECLARE v_out text := 'OK';
+BEGIN
+  BEGIN UPDATE public.company_config SET value='22222222222' WHERE key='master_cpf';
+  EXCEPTION WHEN undefined_function THEN v_out := 'ORFA_42883';
+           WHEN OTHERS THEN v_out := 'OUTRO_'||SQLSTATE; END;
+  RAISE NOTICE 'RES=%', v_out;
+END \$\$;
+SQL
+)" 'OK'
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO: restaura o `public.` (o estado quebrado) → exige 42883
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── FALSIFICAÇÃO (reproduz o bug do FU7 em cada caller) ──"
+P -q -c "CREATE OR REPLACE FUNCTION public.registrar_contato_rota(p_customer_user_id uuid,p_status text,p_data_rota date,p_bucket text DEFAULT NULL,p_valor numeric DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS \$f\$
+DECLARE v_uid uuid := auth.uid(); v_id uuid;
+BEGIN
+  IF NOT (COALESCE(public.pode_ver_carteira_completa(v_uid),false) OR public.carteira_visivel_para(p_customer_user_id, v_uid)) THEN
+    RAISE EXCEPTION 'forbidden: customer not visible'; END IF;
+  INSERT INTO public.route_contact_log (data_rota,customer_user_id,farmer_id,canal,status)
+  VALUES (p_data_rota,p_customer_user_id,v_uid,'ligacao',p_status) RETURNING id INTO v_id;
+  RETURN jsonb_build_object('id', v_id);
+END \$f\$;"
+espera "F1 com 'public.' de volta, registrar_contato_rota QUEBRA (42883) → A3 tem dente" \
+  "$(exec_sql "$VEND_A" 'authenticated' "PERFORM public.registrar_contato_rota('$CLI_OK'::uuid, 'respondido', CURRENT_DATE, NULL, NULL);")" 'ORFA_42883'
+
+P -q -c "CREATE OR REPLACE FUNCTION public.protect_master_config() RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS \$f\$
+BEGIN
+  IF (TG_OP IN ('UPDATE','DELETE')) AND (OLD.key IN ('master_cpf','master_cnpj')) AND NOT public.is_super_admin(auth.uid()) THEN
+    RAISE EXCEPTION 'Somente super admin pode alterar master_cpf ou master_cnpj'; END IF;
+  RETURN COALESCE(NEW, OLD);
+END \$f\$;"
+espera "F2 com 'public.' de volta, protect_master_config QUEBRA (42883) → A4 tem dente" \
+  "$(exec_sql "$VEND_A" 'authenticated' "UPDATE public.company_config SET value='33333333333' WHERE key='master_cpf';")" 'ORFA_42883'
+
+# ⚠️ o assert que um teste ingênuo escreveria — e por que ele MENTE:
+P -q -f "$MIG"
+GREP_OK=$(Pq -c "SELECT (pg_get_functiondef('public.registrar_contato_rota'::regproc) LIKE '%private.carteira_visivel_para%')::text;")
+eq "F3 (meta) o grep por 'private.' passa — mas SÓ os asserts que EXECUTAM provam algo" "$GREP_OK" "true"
+espera "F3' e a execução confirma de verdade" \
+  "$(exec_sql "$VEND_A" 'authenticated' "PERFORM public.registrar_contato_rota('$CLI_OK'::uuid, 'sem_resposta', CURRENT_DATE, NULL, NULL);")" 'OK'
+
+echo ""
+echo "═══ RESULTADO: $PASS ok, $FAIL falhas ═══"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **389** custom migrations totais
-- **1348** objetos esperados (criados por estas migrations)
+- **391** custom migrations totais
+- **1352** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 386
+  - `function`: 390
   - `rls_policy`: 295
   - `index`: 223
   - `cron_job`: 150
@@ -3277,6 +3277,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.tint_promote_sync_run` | — |
 
+### `20260718150000_fu7_helpers_rls_schema_privado.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
 ### `20260718160000_tactical_plans_eligible_fail_closed.sql`
 
 | Tipo | Objeto | Parent |
@@ -3285,6 +3289,15 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.registrar_resultado_plano` | — |
 | `function` | `public.tactical_plan_recusa_cliente_mascarado` | — |
 | `trigger` | `public.trg_tactical_plan_recusa_mascarado` | `farmer_tactical_plans` |
+
+### `20260718170000_fu7_conserta_callers_orfaos.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.criar_plano_tatico` | — |
+| `function` | `public.registrar_resultado_plano` | — |
+| `function` | `public.registrar_contato_rota` | — |
+| `function` | `public.protect_master_config` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 389
+-- Total de custom migrations: 391
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -430,7 +430,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260718100000', 'filas_recalc_rls_master_only', '20260718100000_filas_recalc_rls_master_only.sql'),
   ('20260718120000', 'pot_nid_receb_retencao', '20260718120000_pot_nid_receb_retencao.sql'),
   ('20260718140000', 'tint_promote_guard4_v3', '20260718140000_tint_promote_guard4_v3.sql'),
-  ('20260718160000', 'tactical_plans_eligible_fail_closed', '20260718160000_tactical_plans_eligible_fail_closed.sql')
+  ('20260718150000', 'fu7_helpers_rls_schema_privado', '20260718150000_fu7_helpers_rls_schema_privado.sql'),
+  ('20260718160000', 'tactical_plans_eligible_fail_closed', '20260718160000_tactical_plans_eligible_fail_closed.sql'),
+  ('20260718170000', 'fu7_conserta_callers_orfaos', '20260718170000_fu7_conserta_callers_orfaos.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1767,7 +1769,11 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('tactical_plans_eligible_fail_closed', 'function', 'public', 'criar_plano_tatico', ''),
   ('tactical_plans_eligible_fail_closed', 'function', 'public', 'registrar_resultado_plano', ''),
   ('tactical_plans_eligible_fail_closed', 'function', 'public', 'tactical_plan_recusa_cliente_mascarado', ''),
-  ('tactical_plans_eligible_fail_closed', 'trigger', 'public', 'trg_tactical_plan_recusa_mascarado', 'farmer_tactical_plans')
+  ('tactical_plans_eligible_fail_closed', 'trigger', 'public', 'trg_tactical_plan_recusa_mascarado', 'farmer_tactical_plans'),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'criar_plano_tatico', ''),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'registrar_resultado_plano', ''),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'registrar_contato_rota', ''),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'protect_master_config', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3152,7 +3158,11 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tactical_plans_eligible_fail_closed', 'function', 'public', 'criar_plano_tatico', ''),
   ('tactical_plans_eligible_fail_closed', 'function', 'public', 'registrar_resultado_plano', ''),
   ('tactical_plans_eligible_fail_closed', 'function', 'public', 'tactical_plan_recusa_cliente_mascarado', ''),
-  ('tactical_plans_eligible_fail_closed', 'trigger', 'public', 'trg_tactical_plan_recusa_mascarado', 'farmer_tactical_plans')
+  ('tactical_plans_eligible_fail_closed', 'trigger', 'public', 'trg_tactical_plan_recusa_mascarado', 'farmer_tactical_plans'),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'criar_plano_tatico', ''),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'registrar_resultado_plano', ''),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'registrar_contato_rota', ''),
+  ('fu7_conserta_callers_orfaos', 'function', 'public', 'protect_master_config', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260718170000_fu7_conserta_callers_orfaos.sql
+++ b/supabase/migrations/20260718170000_fu7_conserta_callers_orfaos.sql
@@ -1,0 +1,281 @@
+-- ╔════════════════════════════════════════════════════════════════════════════╗
+-- ║ HOTFIX — 4 callers órfãos do FU7 (#1421): public.<helper> → private.<helper> ║
+-- ║ [money-path / autorização] — quebra VIVA em produção                        ║
+-- ╚════════════════════════════════════════════════════════════════════════════╝
+-- O #1421 (`20260718150000_fu7_helpers_rls_schema_privado.sql`, mergeado 2026-07-18
+-- 16:57 UTC) moveu `carteira_visivel_para` e `is_super_admin` de `public` p/ `private`
+-- (FU7 — fechar o oráculo de RLS exposto via PostgREST). Ele atualizou **as 8 policies**
+-- que dependem do helper, mas **não os callers PL/pgSQL**, que chamam com prefixo
+-- `public.` EXPLÍCITO — e não existe wrapper de compatibilidade em `public`.
+--
+-- É a armadilha late-bound canônica do repo (CLAUDE.md): `CREATE OR REPLACE`/`SET SCHEMA`
+-- passam sem validar o corpo das funções que referenciam o objeto movido; elas só quebram
+-- ao EXECUTAR, com `42883 undefined_function`. Nem o CI nem o harness do #1421 veem
+-- (aquele testa o helper movido, não quem o chama).
+--
+-- ── Inventário MEDIDO em prod (2026-07-18, varredura pg_proc + pg_policies + pg_views
+--    + cron.job por regex `public\.(carteira_visivel_para|is_super_admin)`) ────────────
+--   1. public.criar_plano_tatico          → gate de carteira do caller autenticado
+--   2. public.registrar_resultado_plano   → idem
+--   3. public.registrar_contato_rota      → gate de carteira p/ registrar ligação em rota
+--   4. public.protect_master_config       → trigger que protege master_cpf/master_cnpj
+--   (zero policies, zero views, zero crons — as 8 policies já foram corrigidas pelo #1421.)
+--
+-- ── Severidade por função ───────────────────────────────────────────────────────────
+--   1–3 falham ABERTO-EM-USABILIDADE, fechado-em-segurança: a exceção 42883 aborta a
+--       operação ⇒ nada é gravado indevidamente, mas o fluxo do vendedor QUEBRA
+--       (gerar plano tático, registrar resultado pós-call, registrar contato de rota).
+--   4   falha FECHADA: só alcança o `is_super_admin` quando a key é master_cpf/master_cnpj,
+--       então bloqueia a alteração — inclusive a do super_admin legítimo. Sem risco de
+--       escalação (a proteção do achado de privilege-escalation, database.md §4, segue de pé).
+--
+-- ⚠️ NÃO criar wrapper `public.carteira_visivel_para` — reexporia o oráculo ao PostgREST
+--    e desfaria exatamente o que o #1421 fechou. A correção é no CALLER, uma por uma.
+--
+-- Corpos preservados VERBATIM do `pg_get_functiondef` de prod (pré-flight 2026-07-18),
+-- com a ÚNICA alteração sendo o schema do helper. Sem mudança de lógica, gate ou grant.
+--
+-- ⚠️ Provada em PG17 local com falsificação: db/test-fu7-callers-orfaos.sh
+-- ⚠️ Migration MANUAL (Lovable não aplica nome custom) — colar no SQL Editor.
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 1. criar_plano_tatico — v3 do #1422, só o schema do helper muda
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.criar_plano_tatico(
+  _customer_user_id uuid,
+  _expected_owner   uuid,
+  _payload          jsonb
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  _uid        uuid    := auth.uid();
+  _is_service boolean := COALESCE(auth.role() = 'service_role', false);
+  _owner      uuid;
+  _eligible   boolean;
+  _rec        public.farmer_tactical_plans;
+  _new_id     uuid;
+BEGIN
+  IF NOT _is_service THEN
+    IF _uid IS NULL THEN
+      RAISE EXCEPTION 'Não autenticado' USING ERRCODE = '42501';
+    END IF;
+    IF NOT private.carteira_visivel_para(_customer_user_id, _uid) THEN
+      RAISE EXCEPTION 'Cliente fora da sua carteira' USING ERRCODE = '42501';
+    END IF;
+    -- [Codex #4] chamador autenticado NÃO pode pular o race-check passando NULL.
+    IF _expected_owner IS NULL THEN
+      RAISE EXCEPTION 'expected_owner é obrigatório para chamador autenticado (race-check da posse)';
+    END IF;
+  END IF;
+
+  -- [Codex #3] FOR UPDATE: trava a linha de carteira_assignments deste cliente até o commit.
+  -- [#1422] `eligible` sai do MESMO SELECT travado — ler a máscara fora do lock reabriria o
+  -- race pelo outro lado (mascarar concorrente entre a checagem e o INSERT).
+  SELECT a.owner_user_id, a.eligible INTO _owner, _eligible
+  FROM public.carteira_assignments a
+  WHERE a.customer_user_id = _customer_user_id
+  FOR UPDATE;
+
+  IF _owner IS NULL THEN
+    RAISE EXCEPTION 'Cliente % sem dono de carteira', _customer_user_id;
+  END IF;
+
+  -- [#1422 — máscara eligible] Fail-closed p/ TODO caller, inclusive service_role e master.
+  IF _eligible IS NOT TRUE THEN
+    RAISE EXCEPTION 'Cliente % está mascarado na carteira (eligible) — plano tático não é materializado', _customer_user_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF _expected_owner IS NOT NULL AND _owner <> _expected_owner THEN
+    RAISE EXCEPTION 'Carteira do cliente % foi reatribuída durante a geração (dono atual diverge do esperado)', _customer_user_id;
+  END IF;
+
+  _rec := jsonb_populate_record(NULL::public.farmer_tactical_plans, _payload);
+
+  INSERT INTO public.farmer_tactical_plans (
+    farmer_id, customer_user_id, status,
+    bundle_recommendation_id, health_score, churn_risk, mix_gap,
+    current_margin_pct, cluster_avg_margin_pct, expansion_potential,
+    strategic_objective, customer_profile, plan_type,
+    top_bundle, second_bundle, bundle_lie, bundle_probability, bundle_incremental_margin,
+    best_individual_lie, diagnostic_questions, implication_question, offer_transition,
+    probable_objections, approach_strategy, approach_strategy_b,
+    ltv_projection, expected_result, operational_risks
+  ) VALUES (
+    _owner, _customer_user_id, 'gerado',
+    _rec.bundle_recommendation_id, _rec.health_score, _rec.churn_risk, _rec.mix_gap,
+    _rec.current_margin_pct, _rec.cluster_avg_margin_pct, _rec.expansion_potential,
+    COALESCE(_rec.strategic_objective, 'expansao_mix'),
+    COALESCE(_rec.customer_profile, 'misto'),
+    COALESCE(_rec.plan_type, 'essencial'),
+    COALESCE(_rec.top_bundle, '{}'::jsonb), COALESCE(_rec.second_bundle, '{}'::jsonb),
+    _rec.bundle_lie, _rec.bundle_probability, _rec.bundle_incremental_margin,
+    _rec.best_individual_lie,
+    COALESCE(_rec.diagnostic_questions, '[]'::jsonb), _rec.implication_question, _rec.offer_transition,
+    COALESCE(_rec.probable_objections, '[]'::jsonb), _rec.approach_strategy, _rec.approach_strategy_b,
+    _rec.ltv_projection, _rec.expected_result, COALESCE(_rec.operational_risks, '[]'::jsonb)
+  )
+  RETURNING id INTO _new_id;
+
+  RETURN _new_id;
+END;
+$function$;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 2. registrar_resultado_plano — v3 do #1422, só o schema do helper muda
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.registrar_resultado_plano(
+  _plan_id               uuid,
+  _plan_followed         boolean,
+  _call_result           text,
+  _actual_margin         numeric,
+  _call_duration_seconds integer,
+  _objection_type        text DEFAULT NULL,
+  _notes                 text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  _uid        uuid    := auth.uid();
+  _is_service boolean := COALESCE(auth.role() = 'service_role', false);
+  _customer   uuid;
+  _status     text;
+  _eligible   boolean;
+BEGIN
+  SELECT p.customer_user_id, p.status INTO _customer, _status
+  FROM public.farmer_tactical_plans p
+  WHERE p.id = _plan_id;
+
+  IF _customer IS NULL THEN
+    RAISE EXCEPTION 'Plano % inexistente', _plan_id;
+  END IF;
+
+  IF NOT _is_service THEN
+    IF _uid IS NULL THEN
+      RAISE EXCEPTION 'Não autenticado' USING ERRCODE = '42501';
+    END IF;
+    IF NOT private.carteira_visivel_para(_customer, _uid) THEN
+      RAISE EXCEPTION 'Plano fora da sua carteira' USING ERRCODE = '42501';
+    END IF;
+  END IF;
+
+  -- [#1422 — máscara eligible] plano criado elegível e mascarado DEPOIS não recebe resultado.
+  SELECT a.eligible INTO _eligible
+  FROM public.carteira_assignments a
+  WHERE a.customer_user_id = _customer;
+
+  IF _eligible IS NOT TRUE THEN
+    RAISE EXCEPTION 'Cliente do plano % está mascarado na carteira (eligible) — resultado não é registrado', _plan_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- [Codex #5] resultado de plano JÁ concluído não é reescrito.
+  IF _status = 'concluido' THEN
+    RAISE EXCEPTION 'Plano % já concluído — resultado não pode ser reescrito', _plan_id;
+  END IF;
+
+  UPDATE public.farmer_tactical_plans
+  SET plan_followed         = _plan_followed,
+      call_result           = _call_result,
+      actual_margin         = _actual_margin,
+      call_duration_seconds = _call_duration_seconds,
+      objection_type        = _objection_type,
+      notes                 = _notes,
+      status                = 'concluido',
+      completed_at          = now(),
+      updated_at            = now()
+  WHERE id = _plan_id;
+END;
+$function$;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 3. registrar_contato_rota — corpo verbatim de prod, só o schema do helper muda
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.registrar_contato_rota(
+  p_customer_user_id uuid,
+  p_status           text,
+  p_data_rota        date,
+  p_bucket           text DEFAULT NULL::text,
+  p_valor            numeric DEFAULT NULL::numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE v_uid uuid := auth.uid(); v_existing uuid; v_id uuid;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.user_roles ur WHERE ur.user_id = v_uid AND ur.role IN ('employee','master')) THEN
+    RAISE EXCEPTION 'forbidden: staff only';
+  END IF;
+  IF p_customer_user_id IS NULL THEN RAISE EXCEPTION 'customer_user_id required'; END IF;
+  IF p_data_rota IS NULL THEN RAISE EXCEPTION 'data_rota required'; END IF;
+  IF p_status NOT IN ('convertido','respondido','sem_resposta','opt_out') THEN
+    RAISE EXCEPTION 'invalid status: %', p_status;
+  END IF;
+  -- staff responde "é staff?", não "pode afetar ESTE cliente?" — exige visibilidade de carteira.
+  IF NOT (COALESCE(public.pode_ver_carteira_completa(v_uid), false)
+          OR private.carteira_visivel_para(p_customer_user_id, v_uid)) THEN
+    RAISE EXCEPTION 'forbidden: customer not visible';
+  END IF;
+  -- serializa o dedupe por chave lógica (evita race do SELECT→INSERT em double-click concorrente).
+  PERFORM pg_advisory_xact_lock(hashtextextended(
+    v_uid::text||':'||p_customer_user_id::text||':'||p_data_rota::text||':'||p_status||':ligacao', 0));
+  -- dedupe idempotente: mesmo vendedor+cliente+rota+status nos últimos 2 min → devolve o existente.
+  SELECT id INTO v_existing FROM public.route_contact_log
+   WHERE farmer_id = v_uid AND customer_user_id = p_customer_user_id
+     AND data_rota = p_data_rota AND status = p_status AND canal = 'ligacao'
+     AND created_at > now() - interval '2 minutes'
+   ORDER BY created_at DESC LIMIT 1;
+  IF v_existing IS NOT NULL THEN
+    RETURN jsonb_build_object('id', v_existing, 'deduped', true);
+  END IF;
+  INSERT INTO public.route_contact_log (data_rota, customer_user_id, farmer_id, canal, valor_da_ligacao, bucket, status)
+  VALUES (p_data_rota, p_customer_user_id, v_uid, 'ligacao', p_valor, p_bucket, p_status)
+  RETURNING id INTO v_id;
+  RETURN jsonb_build_object('id', v_id, 'deduped', false);
+END $function$;
+
+-- ────────────────────────────────────────────────────────────────────────────
+-- 4. protect_master_config — corpo verbatim de prod, só o schema do helper muda
+-- ────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.protect_master_config()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Se a key sendo alterada é sensível (master_cpf/master_cnpj),
+  -- exigir que quem está alterando seja super_admin.
+  IF (TG_OP IN ('UPDATE', 'DELETE'))
+     AND (OLD.key IN ('master_cpf', 'master_cnpj'))
+     AND NOT private.is_super_admin(auth.uid())
+  THEN
+    RAISE EXCEPTION 'Somente super admin pode alterar master_cpf ou master_cnpj';
+  END IF;
+
+  -- Também bloqueia INSERT de uma key 'master_cpf' ou 'master_cnpj' se ela
+  -- já existe (evita contornar com DELETE + INSERT separados).
+  IF TG_OP = 'INSERT'
+     AND NEW.key IN ('master_cpf', 'master_cnpj')
+     AND EXISTS (SELECT 1 FROM public.company_config WHERE key = NEW.key)
+     AND NOT private.is_super_admin(auth.uid())
+  THEN
+    RAISE EXCEPTION 'Somente super admin pode redefinir master_cpf ou master_cnpj';
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$function$;
+
+COMMIT;


### PR DESCRIPTION
> **Quebra viva em produção.** Descoberta na validação pós-apply do #1422. Precisa de apply manual com prioridade.

## O que aconteceu

O #1421 (`20260718150000_fu7_helpers_rls_schema_privado.sql`, mergeado 16:57 UTC) moveu `carteira_visivel_para` e `is_super_admin` de `public` para `private` — o FU7, fechar o oráculo de RLS exposto via PostgREST. **Objetivo correto e bem executado na parte que ele viu:** as 8 policies que dependem do helper foram atualizadas.

O que ficou de fora: os **callers PL/pgSQL**, que chamam com prefixo `public.` explícito. Não existe wrapper de compatibilidade em `public`.

É a armadilha **late-bound** canônica do repo: `ALTER FUNCTION … SET SCHEMA` e `CREATE OR REPLACE` não validam o corpo de quem referencia o objeto movido. As funções só quebram ao **EXECUTAR**, com `42883 undefined_function`. Nem o CI nem o harness do #1421 pegam — aquele testa o helper movido, não quem o chama.

## Inventário (medido, varredura `pg_proc` + `pg_policies` + `pg_views` + `cron.job`)

| função | efeito no usuário | severidade |
|---|---|---|
| `criar_plano_tatico` | vendedor não gera plano tático | quebra de fluxo |
| `registrar_resultado_plano` | não registra resultado pós-call | quebra de fluxo |
| `registrar_contato_rota` | não registra ligação em rota | quebra de fluxo |
| `protect_master_config` | trigger de `master_cpf`/`master_cnpj` falha **fechada** | bloqueia até o super_admin legítimo; **sem** risco de escalação |

Zero policies, views ou crons afetados.

## O fix

No **caller**, um a um. Corpos preservados **verbatim** do `pg_get_functiondef` de prod; a única alteração é o schema do helper.

⚠️ **Deliberadamente NÃO** criei um wrapper `public.carteira_visivel_para` → `private.…`: seria de uma linha, mas **reexporia o oráculo ao PostgREST** e desfaria exatamente o que o #1421 fechou.

## Prova

`db/test-fu7-callers-orfaos.sh` — PG17, **15 asserts**. O harness reproduz o estado pós-#1421 (helper **só** em `private`, ausente em `public`) e **executa** cada uma das 4 funções; a falsificação restaura o `public.` e exige o `42883` de volta.

O assert `F3` é deliberadamente **meta**: mostra que um `grep` por `private.` na definição passa **verde com a função quebrada**. Só os asserts que executam provam alguma coisa — que é a lição inteira deste incidente.

## Lição para a próxima movida de schema

Mover função usada por RLS exige varrer **os dois lados**: `pg_policies` (o #1421 fez) **e** `pg_proc` por quem a chama qualificada (ficou de fora). O `db/preflight-dependencia-tabela.sql` já faz esse tipo de varredura para *tabela* — falta o equivalente para *função*.

## ⚠️ Migration manual

`supabase/migrations/20260718170000_fu7_conserta_callers_orfaos.sql`. Validação pós-apply:

```sql
SELECT CASE WHEN NOT EXISTS (
  SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
  WHERE n.nspname NOT IN ('pg_catalog','information_schema') AND p.prokind='f'
    AND p.oid NOT IN (SELECT aggfnoid FROM pg_aggregate)
    AND pg_get_functiondef(p.oid) ~ 'public\.(carteira_visivel_para|is_super_admin)')
  THEN '✅ nenhum caller órfão restante' ELSE '❌ ainda há caller apontando p/ public.' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)