### PR TITLE
feat(authz): trava do contrato gerencial — o papel concede preço+crédito hoje [money-path] (E1/FU4)

### DIFF
--- a/docs/superpowers/specs/2026-07-18-authz-gerencial-capability-matrix-design.md
+++ b/docs/superpowers/specs/2026-07-18-authz-gerencial-capability-matrix-design.md
@@ -1,0 +1,165 @@
+# Autorização gerencial: `pode_ver_carteira_completa` é capability universal, não gate de carteira — design
+
+> money-path + autorização. Nasceu como **FU4** do [design de 2026-07-17](2026-07-17-carteira-rls-eligible-visibilidade-design.md)
+> ("gestor deve respeitar a máscara `eligible`?") e cresceu ao medir o alcance real do gate.
+> Estado **medido em PROD via psql-ro em 2026-07-18**. Revisão adversária **Codex `gpt-5.6-sol` xhigh**,
+> 2 rodadas — o parecer derrubou a proposta inicial e corrigiu 6 afirmações.
+> **E1 entregue (só código, zero migration). E2 especificada, não construída.**
+
+## 1. A descoberta que redefine o problema
+
+O FU4 perguntava se o gestor deve ver clientes mascarados (`eligible=false`). Ao medir o alcance de
+`pode_ver_carteira_completa` — a função que os papéis gerenciais acionam — o problema mudou de tamanho.
+
+**Ela gateia 64 policies em 34 tabelas.** Não é o gate da carteira; é a capability universal de gestão.
+
+> **Frescor (re-medido 2026-07-18, após 3 PRs do domínio mergearem durante esta sessão):** eram 68 policies
+> na primeira medição; o [#1416](https://github.com/LucasSardenbergL/afiacao/pull/1416) tornou
+> `score_recalc_queue`/`visit_score_recalc_queue` master-only e tirou 4 do gate. O
+> [#1421](https://github.com/LucasSardenbergL/afiacao/pull/1421) moveu `carteira_visivel_para` para o schema
+> `private` (as policies agora chamam `private.carteira_visivel_para`); `pode_ver_carteira_completa` segue em
+> `public`. **A tese não muda:** preço, crédito, custo e markup continuam no gate — reconfirmado.
+
+| recurso | ação concedida | policy |
+|---|---|---|
+| **`cliente_tier_preco`** | **INSERT + UPDATE** | `cliente_tier_preco_insert_gestor` / `_update_gestor` |
+| **`venda_excecao_credito`** | **INSERT** | `venda_excecao_insert_gestor` |
+| **`cmc_ledger`** | SELECT | `cmc_ledger_select_gestor` |
+| `markup_policy` | SELECT | `markup_policy_select_carteira` |
+| `tarefas` + 3 tabelas de tarefa | INSERT/SELECT/UPDATE | |
+| 10 tabelas `reposicao_*` | SELECT | motor de compras |
+| 4 tabelas `radar_*` | SELECT | prospecção |
+| 7 tabelas de carteira | ALL | inclui os mascarados |
+
+Consequência: **atribuir `commercial_role='gerencial'` hoje concede escrita em preço e crédito, e leitura
+de custo.** O FU4 original (máscara de carteira) é uma fração pequena disso.
+
+Gatilho medido: o papel é atribuído por um `upsert` num dropdown
+([GovernanceUsers.tsx](../../../src/pages/GovernanceUsers.tsx)) — não por migration. Nenhum CI roda quando
+alguém usa essa tela. O dono do produto declarou (2026-07-18) que terá **pessoal gerencial em futuro próximo**,
+o que tira isto de "risco latente".
+
+## 2. Estado medido (prod, 2026-07-18)
+
+| fato | valor |
+|---|---|
+| `commercial_roles` existentes | 2 `farmer` (employees) + 1 `master` — **zero** `gerencial`/`estrategico`/`super_admin` |
+| enum `commercial_role` | gerencial, estrategico, super_admin, farmer, hunter, closer, master |
+| RLS de `commercial_roles` | escrita **só master ou super_admin**; leitura só do próprio (`auth.uid()=user_id`) |
+| writers de `commercial_roles` | o dropdown + o trigger `trg_auto_commercial_super_admin` (nenhum outro) |
+| `carteira_assignments` | 4.797 `eligible=true` · 2.112 `eligible=false` |
+| artefatos de clientes mascarados | 1.459 `farmer_client_scores` · 1.459 `customer_visit_scores` · 730 `farmer_recommendations` |
+| distribuição da contaminação | **100% sob o master** (1.459 de 3.534 = 41,3%); os 2 vendedores reais têm **zero** |
+| natureza dos 2.112 mascarados | todos clones/aliases fiscais; **zero** conflitos de mapeamento represados |
+| `carteira_coverage` | 0 linhas (braço de cobertura inerte) |
+
+O último fato importa: **nenhum número de vendedor está errado hoje.** A exposição é futura e dispara com o
+primeiro gestor.
+
+## 3. E1 — trava do contrato gerencial (ENTREGUE, só código)
+
+Escolhida sobre a alternativa "trigger no banco" porque a pré-condição se verifica (zero papéis gerenciais
+hoje) e cada migration é aplicada **manualmente** pelo dono no SQL Editor, com falha silenciosa se esquecida.
+Gastar uma aplicação manual num interlock que a E2 removeria é desperdício com risco.
+
+1. [`useCommercialRole.ts`](../../../src/hooks/useCommercialRole.ts): `CONTRATO_GERENCIAL_ATIVO = false` gateia
+   `canViewManagerial`/`canViewStrategic`. O papel no banco é preservado; a capability não é concedida.
+2. [`GovernanceUsers.tsx`](../../../src/pages/GovernanceUsers.tsx): opções desabilitadas no dropdown (não
+   omitidas — sumir leria como bug) + guarda na `mutationFn` que barra qualquer outro caller.
+
+**Limite honesto:** é trava de INTENÇÃO, não de segurança. A RLS já garante que só master escreve, então o
+único caminho real é este dropdown — mas quem tem token de master pode chamar a API direto. O gate de banco
+vem na E2. O risco tratado aqui não é ataque: é promover alguém sem lembrar que vai preço e crédito junto.
+
+Prova: [`useCommercialRole.test.tsx`](../../../src/hooks/__tests__/useCommercialRole.test.tsx) — assere que
+`gerencial`/`estrategico`/`super_admin` **no banco** não concedem capability. Red verificado antes do green
+(3 falhas por `expected true to be false`).
+
+Verificado que não quebra ninguém: as telas usam `(canViewStrategic || isAdmin)`, e o master entra por `isAdmin`.
+
+## 4. E2 — matriz de capability (ESPECIFICADA, não construída)
+
+### 4.1 Ordem obrigatória (uma transação)
+
+O dono aplica migrations à mão, uma de cada vez, e uma esquecida falha em silêncio. Por isso a E2 **não pode**
+ser uma sequência de migrations: precisa ser código dual-compatible + **uma única transação**.
+
+1. Código dual-compatible, com gate de versão fail-closed (já entregue como E1).
+2. `BEGIN` + precondições com `RAISE EXCEPTION` se o banco vivo divergir do esperado.
+3. Enum/coluna `ineligibility_reason` + backfill + invariantes.
+4. Compatibilidade: `eligible=false` sem razão vira `legacy_unknown` — **nunca** falha silenciosa.
+5. Separação permanente das policies de **escrita** (ver §4.2).
+6. Policies/views/RPCs de leitura: master total; gestor apenas coorte `eligible=true`.
+7. RPC de quarentena read-only, inicialmente master-only.
+8. RPC de KPIs estratégicos sobre a coorte completa (ver §4.3).
+9. Criar `authz_contract_version=2`, rodar assertions, ativar por último.
+10. `COMMIT`.
+
+Se qualquer passo falhar, tudo volta. Se a migration não for aplicada, a versão não existe e o frontend mantém
+o gestor bloqueado. Elimina o estado "aplicou a segunda, esqueceu a terceira".
+
+### 4.2 Escrita é mais grave que leitura
+
+`pode_ver_carteira_completa` é reusado em policies **mutantes** — o gestor não é auditor read-only, ele pode
+alterar e apagar scores e recomendações de qualquer vendedor. Corrigir `INSERT`, `UPDATE` **e** `DELETE`.
+Não reutilizar a mesma função em policies de leitura e de escrita.
+
+A matriz precisa ser por **recurso × ação** para os 34 recursos. Trocar só os de carteira deixa preço, crédito,
+custo e reposição acoplados ao papel.
+
+### 4.3 Bug independente: KPIs estratégicos são inválidos hoje
+
+[`IntelligenceStrategicTab.tsx`](../../../src/components/intelligence/IntelligenceStrategicTab.tsx) cruza 500
+scores + 500 pedidos + 1.000 itens **arbitrários** (`.limit()` sem `.order` — a armadilha de paginação do
+PostgREST), sem coorte comum, e calcula LTV/CAC/concentração. **Filtrar `eligible` não conserta isto**: os
+números já são matematicamente inválidos, com ou sem máscara. Precisa de agregação server-side.
+
+Fica no escopo da E2 porque é a tela que o papel `estrategico` desbloqueia.
+
+### 4.4 Backfill não pode fabricar certeza
+
+`source + omie_codigo_vendedor` distingue os casos atuais (2.093 sem código = aliases; 19 com código = clones
+com vendedor conhecido), mas não é contrato de domínio. O enum precisa de `legacy_unknown`/`ambiguous_backfill`
+— inventar motivo onde não há é a mesma falha de "ausente ≠ zero" do money-path.
+
+### 4.5 Prova
+
+RLS prova-se sob `SET ROLE authenticated` + JWT falsificado. **Testar pelo SQL Editor passa falsamente**: o
+owner ignora RLS. O trigger `SECURITY DEFINER` roda com privilégios do owner, que pode ter `BYPASSRLS` — provar
+consultando `proowner`, `relowner`, `rolbypassrls`.
+
+Se algum interlock de banco for adicionado depois: substituir as policies existentes, **não** acrescentar outra
+permissiva (policies permissivas combinam com `OR`, e uma nova não restringe nada).
+
+## 5. Riscos conhecidos
+
+| risco | mitigação |
+|---|---|
+| Dono promove alguém antes da E2 | E1 bloqueia o dropdown; a guarda barra outros callers |
+| E1 vira falso senso de segurança | §3 declara o limite: trava de intenção, não de segurança |
+| E2 aplicada pela metade | transação única + `authz_contract_version` ativada por último |
+| `trg_auto_commercial_super_admin` quebrado por interlock futuro | reconhecer o alvo por profile + `master_cpf`, **nunca** pela ordem de `user_roles` |
+| Trocar só as policies de carteira | matriz por recurso × ação cobre os 34 |
+
+## 6. O que o Codex corrigiu (registro honesto)
+
+A proposta inicial era "documentar a regra + teste de CI, sem tocar no banco". Foi derrubada:
+
+1. **"Gestor é auditor" era falso** — o gate concede INSERT/UPDATE/DELETE global.
+2. **"0,7% de divergência" usava o denominador errado** — existem 1.459 scores sob clientes mascarados.
+3. **O teste de CI proposto era teatro** — o papel nasce de um `upsert` numa tela; CI não roda em mudança de dado.
+4. **Filtrar `eligible` não conserta os KPIs estratégicos** (§4.3).
+5. **Backfill inferido fabricaria certeza** (§4.4).
+6. **O gate é capability universal**, usado em dezenas de policies incluindo preço e estoque (§1).
+
+Em contrapartida, duas afirmações do parecer foram refutadas por medição: o dano **não** é imediato (a
+contaminação está 100% sob o master; vendedores reais têm zero), e o interlock proposto **quebraria produção**
+como especificado (o `trg_auto_commercial_super_admin` insere `super_admin` pelo CPF do master).
+
+## 7. Follow-ups
+
+- **FU4-A:** matriz de capability por recurso × ação para os 34 recursos — é a E2 inteira, merece sessão própria.
+- **FU4-B:** agregação server-side dos KPIs estratégicos (§4.3), independente da máscara.
+- **FU4-C:** o TS `CommercialRole` tem 4 valores; o enum do Postgres tem 7 (falta `farmer`, `hunter`, `closer`,
+  `master`). `useCommercialRole` classifica `master` como nenhum dos 4 — hoje inerte porque o master passa por
+  `isAdmin`, mas é divergência de contrato.

--- a/src/hooks/__tests__/useCommercialRole.test.tsx
+++ b/src/hooks/__tests__/useCommercialRole.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useCommercialRole } from '@/hooks/useCommercialRole';
+
+const authMock = vi.fn();
+const maybeSingleMock = vi.fn();
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => authMock() }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ maybeSingle: () => maybeSingleMock() }) }) }) },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authMock.mockReturnValue({ user: { id: 'u-1' } });
+  maybeSingleMock.mockResolvedValue({ data: null, error: null });
+});
+
+/**
+ * Trava do contrato de autorização gerencial (E1 do FU4).
+ *
+ * `pode_ver_carteira_completa` — a função SQL que os papéis gerenciais acionam — gateia
+ * 68 policies em 34 tabelas (medido em prod 2026-07-18), incluindo ESCRITA em
+ * `cliente_tier_preco` (tier de preço) e `venda_excecao_credito`, e leitura de `cmc_ledger`
+ * (custo). Enquanto a matriz de capability por recurso×ação não existir, conceder um papel
+ * gerencial entrega preço + crédito + custo junto — então o app trata esses papéis como
+ * NÃO concedidos, mesmo que a linha exista no banco.
+ */
+describe('useCommercialRole — trava do contrato gerencial (E1/FU4)', () => {
+  it('gerencial no banco NÃO concede canViewManagerial enquanto o contrato v2 não existir', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'gerencial' }, error: null });
+    const { result } = renderHook(() => useCommercialRole());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.commercialRole).toBe('gerencial'); // o dado real é preservado
+    expect(result.current.canViewManagerial).toBe(false); // mas a capability não é concedida
+    expect(result.current.canViewStrategic).toBe(false);
+  });
+
+  it('estrategico no banco NÃO concede canViewStrategic', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'estrategico' }, error: null });
+    const { result } = renderHook(() => useCommercialRole());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.canViewStrategic).toBe(false);
+    expect(result.current.canViewManagerial).toBe(false);
+  });
+
+  it('super_admin no banco NÃO concede as capabilities gerenciais', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'super_admin' }, error: null });
+    const { result } = renderHook(() => useCommercialRole());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.canViewStrategic).toBe(false);
+    expect(result.current.canViewManagerial).toBe(false);
+  });
+
+  it('erro na consulta do papel → fail-closed (role null, capabilities false)', async () => {
+    maybeSingleMock.mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const { result } = renderHook(() => useCommercialRole());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.commercialRole).toBeNull();
+    expect(result.current.canViewManagerial).toBe(false);
+  });
+
+  it('operacional segue sem capability gerencial (comportamento inalterado)', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'operacional' }, error: null });
+    const { result } = renderHook(() => useCommercialRole());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.isOperacional).toBe(true);
+    expect(result.current.canViewManagerial).toBe(false);
+  });
+});

--- a/src/hooks/useCommercialRole.ts
+++ b/src/hooks/useCommercialRole.ts
@@ -4,6 +4,24 @@ import { supabase } from '@/integrations/supabase/client';
 
 export type CommercialRole = 'operacional' | 'gerencial' | 'estrategico' | 'super_admin';
 
+/**
+ * 🔐 Trava do contrato de autorização gerencial (E1 do FU4 — ver spec de 2026-07-18).
+ *
+ * Os papéis gerenciais acionam `pode_ver_carteira_completa` no banco, que NÃO é o gate da
+ * carteira: medido em prod 2026-07-18, ele gateia **64 policies em 34 tabelas** — incluindo
+ * ESCRITA em `cliente_tier_preco` (tier de preço do cliente) e `venda_excecao_credito`
+ * (aprovação de crédito), e LEITURA de `cmc_ledger` (custo médio) e `markup_policy`.
+ * Conceder um papel gerencial hoje entrega preço + crédito + custo junto, de uma vez.
+ *
+ * Enquanto a matriz de capability por recurso×ação (E2) não existir no BANCO, o app trata
+ * esses papéis como NÃO concedidos, mesmo que a linha exista em `commercial_roles` — o dado
+ * é preservado, a capability não. Fail-closed por construção.
+ *
+ * A E2 vira isto para `true` na MESMA migration que habilita o papel no banco. Não vire
+ * antes: sem a migration aplicada, isto reabre o furo silenciosamente.
+ */
+const CONTRATO_GERENCIAL_ATIVO: boolean = false;
+
 interface UseCommercialRoleReturn {
   commercialRole: CommercialRole | null;
   isSuperAdmin: boolean;
@@ -66,8 +84,9 @@ export function useCommercialRole(): UseCommercialRoleReturn {
     isEstrategico,
     isGerencial,
     isOperacional,
-    canViewStrategic: isSuperAdmin || isEstrategico,
-    canViewManagerial: isSuperAdmin || isEstrategico || isGerencial,
+    // Gateados pela trava acima: o papel no banco não basta enquanto a E2 não existir.
+    canViewStrategic: CONTRATO_GERENCIAL_ATIVO && (isSuperAdmin || isEstrategico),
+    canViewManagerial: CONTRATO_GERENCIAL_ATIVO && (isSuperAdmin || isEstrategico || isGerencial),
     loading,
     refetch: fetchRole,
   };

--- a/src/hooks/useMyCarteiraScores.ts
+++ b/src/hooks/useMyCarteiraScores.ts
@@ -28,7 +28,8 @@ export interface CarteiraScoreRow {
  * Expande pra cobertura ativa: farmer_id IN [eu, ...donos que eu cubro agora].
  *
  * 🔐 RLS de LEITURA (medida em prod 2026-07-18 — `fcs_select_carteira`):
- * `pode_ver_carteira_completa(uid) OR carteira_visivel_para(customer_user_id, uid)`
+ * `pode_ver_carteira_completa(uid) OR private.carteira_visivel_para(customer_user_id, uid)`
+ * (a 2ª migrou p/ o schema `private` no #1421 — `pode_ver_carteira_completa` segue em `public`)
  * — carteira-scoped, NÃO staff-wide. O SELECT não tem braço de autoria; quem tem é
  * INSERT/UPDATE/DELETE (`... OR farmer_id = uid`) — não confundir os dois.
  * Consequência: para GESTOR (`pode_ver_carteira_completa` = master, ou employee com

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -692,6 +692,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useInfiniteScroll.test.ts",
       "src/hooks/__tests__/useDisplayAccess.test.tsx",
       "src/hooks/__tests__/useImpersonationTargets.test.tsx",
+      "src/hooks/__tests__/useCommercialRole.test.tsx",
       "src/hooks/__tests__/useMyCommercialRole.test.tsx",
       "src/hooks/__tests__/useUserDepartment.test.tsx",
     ],

--- a/src/pages/GovernanceUsers.tsx
+++ b/src/pages/GovernanceUsers.tsx
@@ -23,6 +23,21 @@ const ROLE_COLORS: Record<string, string> = {
   super_admin: 'bg-red-500/10 text-red-700 border-red-500/30',
 };
 
+/**
+ * 🔐 Papéis cuja ATRIBUIÇÃO está travada pela E1 do FU4 (spec 2026-07-18).
+ *
+ * Estes papéis acionam `pode_ver_carteira_completa` no banco, que gateia 64 policies em
+ * 34 tabelas (medido em prod): ESCRITA em `cliente_tier_preco` (tier de preço) e
+ * `venda_excecao_credito` (aprova crédito), LEITURA de `cmc_ledger` (custo médio).
+ * Conceder qualquer um deles hoje entrega preço + crédito + custo de uma vez, porque a
+ * matriz de capability por recurso×ação ainda não existe.
+ *
+ * A trava é de INTENÇÃO, não de segurança: a RLS de `commercial_roles` só deixa master
+ * escrever, então o único caminho real é este dropdown — mas quem tem o token de master
+ * pode chamar a API direto. O gate de banco vem na E2.
+ */
+const PAPEIS_GERENCIAIS_BLOQUEADOS: readonly CommercialRole[] = ['gerencial', 'estrategico', 'super_admin'];
+
 export default function GovernanceUsers() {
   const { user, isAdmin } = useAuth();
   const { isSuperAdmin } = useCommercialRole();
@@ -73,6 +88,15 @@ export default function GovernanceUsers() {
   // Mutation to set commercial role
   const setRoleMutation = useMutation({
     mutationFn: async ({ userId, role }: { userId: string; role: CommercialRole }) => {
+      // Trava da E1/FU4 (ver PAPEIS_GERENCIAIS_BLOQUEADOS): o `disabled` do SelectItem é só
+      // a UI — esta guarda é o que barra qualquer outro caller até a E2 existir.
+      if (PAPEIS_GERENCIAIS_BLOQUEADOS.includes(role)) {
+        throw new Error(
+          `Atribuir "${ROLE_LABELS[role] ?? role}" está bloqueado: este papel concede escrita em preço e crédito ` +
+          `(64 policies em 34 tabelas) enquanto a matriz de capability não existe. Ver FU4/E2.`,
+        );
+      }
+
       // Upsert commercial role
       const { error } = await supabase
         .from('commercial_roles')
@@ -172,9 +196,11 @@ export default function GovernanceUsers() {
                         </SelectTrigger>
                         <SelectContent>
                           <SelectItem value="operacional">Operacional</SelectItem>
-                          <SelectItem value="gerencial">Gerencial</SelectItem>
-                          <SelectItem value="estrategico">Estratégico</SelectItem>
-                          {isSuperAdmin && <SelectItem value="super_admin">Super Admin</SelectItem>}
+                          {/* Bloqueados pela E1 do FU4 — ver PAPEIS_GERENCIAIS_BLOQUEADOS acima.
+                              Desabilitados em vez de omitidos: sumir com eles leria como bug. */}
+                          <SelectItem value="gerencial" disabled>Gerencial — bloqueado</SelectItem>
+                          <SelectItem value="estrategico" disabled>Estratégico — bloqueado</SelectItem>
+                          {isSuperAdmin && <SelectItem value="super_admin" disabled>Super Admin — bloqueado</SelectItem>}
                         </SelectContent>
                       </Select>
                     </td>


### PR DESCRIPTION
Nasceu como **FU4** do [design de 2026-07-17](docs/superpowers/specs/2026-07-17-carteira-rls-eligible-visibilidade-design.md) ("o gestor deve respeitar a máscara `eligible`?") e cresceu ao medir o alcance real do gate.

## A descoberta

`pode_ver_carteira_completa` — a função que os papéis gerenciais acionam — **não é o gate da carteira**. Medido em prod (psql-ro, 2026-07-18): ela gateia **64 policies em 34 tabelas**. É a capability universal de gestão.

| recurso | ação concedida |
|---|---|
| **`cliente_tier_preco`** | **INSERT + UPDATE** — tier de preço do cliente |
| **`venda_excecao_credito`** | **INSERT** — aprova exceção de crédito |
| **`cmc_ledger`** | SELECT — custo médio de compra |
| `markup_policy` | SELECT |
| `tarefas` + 3 tabelas | INSERT/SELECT/UPDATE |
| 10× `reposicao_*`, 4× `radar_*` | SELECT |
| 7 tabelas de carteira | ALL (inclui os mascarados) |

**Atribuir `commercial_role='gerencial'` hoje concede escrita em preço e crédito, e leitura de custo.**

E o papel é atribuído por um `upsert` num dropdown ([GovernanceUsers](src/pages/GovernanceUsers.tsx)) — não por migration, então nenhum CI roda. O founder declarou que terá pessoal gerencial em futuro próximo, o que tira isto de risco latente.

## O que este PR faz (E1 — só código, zero migration)

1. [`useCommercialRole`](src/hooks/useCommercialRole.ts): `CONTRATO_GERENCIAL_ATIVO = false` gateia `canViewManagerial`/`canViewStrategic`. O papel no banco é **preservado**; a capability não é concedida.
2. [`GovernanceUsers`](src/pages/GovernanceUsers.tsx): opções desabilitadas no dropdown (não omitidas — sumir leria como bug) **+ guarda na `mutationFn`**, que é o que barra callers fora do dropdown.

Escolhida sobre "interlock no banco" porque a pré-condição se verifica (**zero** `gerencial`/`estrategico`/`super_admin` em prod hoje) e cada migration é aplicada **manualmente** pelo founder, com falha silenciosa se esquecida. Gastar uma aplicação manual num interlock que a E2 removeria é desperdício com risco.

### Limite honesto

É trava de **intenção**, não de segurança. A RLS de `commercial_roles` já só deixa `master` escrever, então o único caminho real é este dropdown — mas quem tem token de master chama a API direto. O gate de banco vem na E2. O risco tratado aqui não é ataque: é promover alguém sem lembrar que vai preço e crédito junto.

## Verificação

- **TDD:** red verificado antes do green — 3 falhas por `expected true to be false` (os papéis concediam). Green 5/5.
- **Não quebra ninguém:** as telas usam `(canViewStrategic || isAdmin)`, e o master entra por `isAdmin`. Confirmado que hoje não existe nenhum papel gerencial.
- ⚠️ **`typecheck`/`lint`/suíte completa não rodaram localmente** — semáforo `heavy` esgotado (swap 7,3/8 GB, duas outras sessões na fila). O CI é o gate.

## Frescor: re-medido após 3 PRs do domínio mergearem durante a sessão

Três PRs do mesmo domínio entraram enquanto isto era escrito, então re-medi antes de abrir:

- **68 → 64 policies**: o #1416 tornou as filas de recompute master-only e tirou 4 do gate.
- **`carteira_visivel_para` migrou para o schema `private`** (#1421). Isso envelheceu o comentário que o #1406 acabou de mergear — corrigido aqui em [`useMyCarteiraScores`](src/hooks/useMyCarteiraScores.ts) (1 linha).
- **A tese não muda**: preço, crédito, custo e markup seguem no gate, reconfirmados.

## Spec da E2

[2026-07-18-authz-gerencial-capability-matrix-design.md](docs/superpowers/specs/2026-07-18-authz-gerencial-capability-matrix-design.md) — matriz de capability por recurso × ação, `ineligibility_reason` tipado, separação leitura/escrita.

Ponto central (§4.1): a E2 **não pode** ser uma sequência de migrations. O founder aplica uma por vez, à mão, e uma esquecida falha em silêncio — então tem que ser **transação única** com `authz_contract_version` ativada por último. Se não for aplicada, a versão não existe e o frontend mantém o bloqueio.

O §6 registra os **6 pontos em que o Codex (`gpt-5.6-sol` xhigh, 2 rodadas) derrubou a proposta inicial**, e as 2 afirmações dele refutadas por medição — incluindo que o interlock que ele propôs quebraria produção (`trg_auto_commercial_super_admin` insere `super_admin` pelo CPF do master).

## Deploy

Frontend puro → **precisa de Publish no Lovable**. Sem migration, sem edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Próxima fatia — E2 (handoff)

# Handoff — E2/FU4: matriz de capability por recurso × ação

## 1. Objetivo desta sessão (UMA entrega)

Entregar a **matriz de capability** que substitui `pode_ver_carteira_completa` como gate único:
gestor operacional deixa de herdar escrita em preço/crédito e leitura de custo. Mergeada + migration
aplicada + `CONTRATO_GERENCIAL_ATIVO` virado para `true` no mesmo passo.

Fora de escopo (outra sessão): FU4-B (agregação server-side dos KPIs estratégicos) e FU4-C
(divergência do enum `CommercialRole` TS × Postgres). Ver §7 do spec.

## 2. Estado na main (verificado 2026-07-18)

- `origin/main`: **3cdd834a** — `feat(authz): trava do contrato gerencial (E1/FU4) (#1424)`
- PRs do domínio que mergearam durante a sessão anterior (**leia antes de medir**):
  - **#1423** — consertou 4 callers órfãos do FU7: RPCs quebradas em prod por função movida de schema
  - **#1422** — plano tático fail-closed p/ cliente mascarado (fecha batch/service_role)
  - **#1421** — fechou oráculos de RLS: `REVOKE` onde não há policy, schema `private` onde há.
    **`carteira_visivel_para` agora é `private.carteira_visivel_para`**; `pode_ver_carteira_completa`
    segue em `public`.
  - **#1416** — filas de recompute viraram master-only (tirou 4 policies do gate)

Medição fresca do gate (2026-07-18, psql-ro): **64 policies em 34 tabelas**. Preço, crédito, custo e
markup reconfirmados no gate:
```
cliente_tier_preco [INSERT] · cliente_tier_preco [UPDATE] · cmc_ledger [SELECT]
markup_policy [SELECT] · venda_excecao_credito [INSERT]
```

**Re-meça antes de abrir PR.** Com ~30 worktrees paralelas, o número mudou 2× durante a sessão anterior.

## 3. Arquivos/funções-chave

- `docs/superpowers/specs/2026-07-18-authz-gerencial-capability-matrix-design.md` — **o spec. Leia inteiro.**
  §4.1 (ordem obrigatória em transação única) e §4.2 (escrita > leitura) são o núcleo.
- `src/hooks/useCommercialRole.ts` — `CONTRATO_GERENCIAL_ATIVO = false`. Virar para `true` **só** na
  mesma entrega que aplica a migration; virar antes reabre o furo em silêncio.
- `src/pages/GovernanceUsers.tsx` — `PAPEIS_GERENCIAIS_BLOQUEADOS` + guarda na `mutationFn`.
- `src/hooks/__tests__/useCommercialRole.test.tsx` — a prova da E1; estender, não substituir.
- Docs a ler ANTES: `docs/agent/database.md` §RLS · `docs/agent/money-path.md` (prove-sql, Codex).

## 4. Decisões já tomadas (NÃO re-litigar)

- **E1 é trava de intenção, não de segurança.** Deliberado: a RLS de `commercial_roles` já limita
  escrita a master, então o dropdown é o único caminho real. Gate de banco é escopo da E2.
- **Interlock por trigger foi DESCARTADO** em favor da trava em código (Codex rodada 2): a
  pré-condição se verifica (zero papéis gerenciais em prod) e cada migration custa aplicação manual
  do founder, com falha silenciosa. Reverter exige dizer explicitamente que reverte.
- **A E2 é uma transação única**, não uma sequência de migrations (§4.1 do spec). Motivo: o founder
  aplica uma por vez à mão; "aplicou a 2ª, esqueceu a 3ª" deixaria estado intermediário inseguro.
- **`legacy_unknown` é obrigatório** no enum `ineligibility_reason` — backfill inferido não pode
  fabricar certeza (§4.4).
- Parecer Codex `gpt-5.6-sol` xhigh, 2 rodadas, registrado em §6 do spec (inclusive as 2 afirmações
  dele refutadas por medição).

## 5. Validações a rodar (a prova da entrega)

- `heavy bun run test` (a suíte é o que o CI roda) · `heavy bun run typecheck` · `heavy bun run lint`
- **prove-sql-money-path obrigatório** (é autorização + money-path): PG17 local, migration REAL
  aplicada, asserts positivos E negativos com SQLSTATE, e **falsificação** (sabotar → exigir vermelho).
- **RLS prova-se sob `SET ROLE authenticated` + JWT falsificado.** Testar pelo SQL Editor passa
  falsamente: o owner ignora RLS. Provar `proowner`/`relowner`/`rolbypassrls` para o SECURITY DEFINER.
- Ritual `/codex` antes de aplicar (money-path) — transporte `scripts/codex-async.sh` em background.

## 6. Pendências do founder

- 🖱️ **Publish do Lovable pendente para o #1424** (E1 é frontend puro; sem Publish a trava não está
  em produção e o dropdown segue concedendo `gerencial`). Confirmar antes de assumir que E1 vale.
- 🟣 SQL Editor: nenhuma migration pendente desta sessão (E1 foi zero-migration).

## 7. Abertura da sessão nova

```
cd /Users/lucassardenberg/Projetos/afiacao && bun run wt claude/authz-capability-matrix-e2
```
Primeira mensagem: colar este briefing inteiro.

**Não reusar** o worktree `distracted-hofstadter-c01e9a` (sessão anterior).
