### PR TITLE
fix(omie-cliente): fecha a fábrica de clones — dedup paginado, guard de proof e erros de escrita audíveis [money-path]

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1528,18 +1528,24 @@ describe('guardrail money-path: omie-cliente lê a proof fresca account-correta 
     ).toMatch(/omie_customer_account_map_fresco[\s\S]{0,260}\.eq\('account', 'oben'\)/);
   });
 
-  it('sync_all_clients dedupa pela conta DO LOTE, paginado e fail-closed em erro de query', () => {
+  it('sync_all_clients dedupa pela conta DO LOTE, paginado por keyset e fail-closed em erro de query', () => {
     expect(
       src,
       'REVERSÃO Lovable? o dedup do sync_all_clients não lê a fresca filtrando a conta do account_index',
     ).toMatch(
-      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,120}\.eq\("account", account\.account\)[\s\S]{0,120}\.order\("omie_codigo_cliente"\)[\s\S]{0,120}\.range\(/,
+      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,140}\.eq\("account", account\.account\)[\s\S]{0,140}\.order\("omie_codigo_cliente"\)[\s\S]{0,140}\.limit\(codePageSize\)/,
     );
-    // Sem .range o PostgREST capa em 1.000 linhas SILENCIOSO (eram 1.000 de 6.909 → o dedup enxergava 1/7).
+    // Sem paginar, o PostgREST capa em 1.000 linhas SILENCIOSO (eram 1.000 de 6.909 → o dedup enxergava 1/7).
     expect(
       src,
       'REGRESSÃO: o pré-load do dedup perdeu a paginação — volta a capar em 1.000 e reprocessar o resto',
     ).toMatch(/codePage\.length < codePageSize/);
+    // Keyset e não offset: a fresca é uma view DESLIZANTE (TTL 7d) — linha que expira entre páginas
+    // desloca as seguintes, o dedup PULA códigos, e código pulado vira cliente RECRIADO.
+    expect(
+      src,
+      'REGRESSÃO: o dedup trocou keyset por offset — numa view deslizante isso pula códigos → clientes recriados',
+    ).toMatch(/codeQuery\.gt\("omie_codigo_cliente", codeCursor\)/);
     // Codex P2 do PR-2: engolir o erro deixa o Set vazio e o loop tenta RECRIAR milhares de clientes.
     expect(
       src,
@@ -1555,8 +1561,14 @@ describe('guardrail money-path: omie-cliente lê a proof fresca account-correta 
       bloco,
       'REVERSÃO Lovable? sync_addresses não lê mais (user_id, account, omie_codigo_cliente) da fresca paginada',
     ).toMatch(
-      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,120}\.select\("user_id, account, omie_codigo_cliente"\)[\s\S]{0,160}\.range\(/,
+      /\.from\("omie_customer_account_map_fresco"\)[\s\S]{0,140}\.select\("user_id, account, omie_codigo_cliente"\)[\s\S]{0,200}\.limit\(fetchPageSize\)/,
     );
+    // Keyset com `.gte` (não `.gt`): a fronteira da página parte um user multi-conta ao meio e `.gt`
+    // descartaria as contas restantes dele — o Set de pares desduplica a sobra reprocessada.
+    expect(
+      bloco,
+      'REGRESSÃO: a paginação dos mapeamentos trocou keyset por offset — view deslizante pula users',
+    ).toMatch(/query\.gte\("user_id", userCursor\)/);
     // O código agora vem PAREADO com a conta dele: nada de chutar o mesmo código nas 3 contas.
     expect(
       bloco,
@@ -1575,6 +1587,141 @@ describe('guardrail money-path: omie-cliente lê a proof fresca account-correta 
       bloco,
       'REGRESSÃO: o pré-load dos mapeamentos engole o erro — vira "No client mappings found" (no-op mudo)',
     ).toMatch(/if \(pageErr\) throw new Error/);
+  });
+});
+
+// ── Hardening P1 do omie-cliente (parecer Codex sobre a Fatia 3-edges PR-A) — 2026-07-18 ──
+// Migrar os 3 leitores para a proof trocou a FONTE do dedup e deixou de pé a porta que fabricou os
+// clones já existentes. Medido em prod (psql-ro 2026-07-18): profiles=5.276 · users na proof=5.276 ·
+// espelho=6.909 → 1.633 linhas do espelho SEM profile. O `profileByDoc` do sync_all_clients lia
+// `profiles` sem paginar — 1.000 de 5.276 (19%) — e para os outros 81% o dedup por documento
+// devolvia undefined: o handler criava um usuário Auth NOVO para quem já tinha cadastro. Como o
+// supabase-js devolve `{ error }` em vez de lançar, os inserts falhos passavam mudos e o contador
+// ainda somava "importado". A fresca é a base filtrada por `updated_at >= now() - 7 dias`: se o
+// omie-analytics-sync parar uma semana ela ESVAZIA, e consulta OK com zero linhas não acusa erro
+// nenhum — dedup cego reimporta tudo. Estas canárias travam as PORTAS; a fonte já foi migrada.
+describe('guardrail money-path: omie-cliente não fabrica identidade (hardening P1 do Codex)', () => {
+  const src = read(OMIE_CLIENTE);
+
+  it('a varredura de profiles passa por uma helper paginada por keyset (teto de 1.000 é silencioso)', () => {
+    expect(src, 'sumiu a helper de paginação de profiles').toMatch(
+      /async function\* paginarProfilesComDocumento/,
+    );
+    // Keyset e não offset: o sync_all_clients INSERE profiles enquanto varre — com `.range()` cada
+    // inserção desloca as páginas seguintes e pula linhas.
+    expect(src, 'REGRESSÃO: a paginação de profiles deixou de ser keyset').toMatch(
+      /query\.gt\("user_id", cursor\)/,
+    );
+    // Os DOIS deduplicadores por documento (criar_perfil_local e sync_all_clients) passam por ela.
+    expect(
+      count(src, 'for await (const pagina of paginarProfilesComDocumento(adminClient))'),
+      'REGRESSÃO: algum dedup por documento voltou a varrer profiles fora da helper paginada',
+    ).toBe(2);
+    // A varredura crua que fabricou os clones não pode voltar em handler nenhum.
+    expect(
+      src,
+      'REGRESSÃO: voltou o SELECT cru de profiles — 1.000 de 5.276 lidas como se fossem todas',
+    ).not.toMatch(/\.from\("profiles"\)\s*\.select\("user_id, document"\)\s*\.not\("document", "is", null\);/);
+  });
+
+  it('proof degradada barra a importação ANTES de criar identidade (zero linhas não é erro SQL)', () => {
+    expect(src, 'sumiu o guard de cobertura da proof').toMatch(/async function assertProofFrescaSaudavel/);
+    const bloco = blocoCaseCliente(src, 'sync_all_clients');
+    const posGuard = bloco.indexOf('await assertProofFrescaSaudavel(');
+    const posCreate = bloco.indexOf('auth.admin.createUser(');
+    expect(posGuard, 'REGRESSÃO: sumiu a chamada do guard de cobertura no sync_all_clients').toBeGreaterThan(-1);
+    expect(posCreate, 'sentinela: sync_all_clients deixou de criar usuários?').toBeGreaterThan(-1);
+    expect(
+      posGuard,
+      'REGRESSÃO: o guard de cobertura passou a rodar DEPOIS da criação de usuários — não barra nada',
+    ).toBeLessThan(posCreate);
+    // A base entra só como DENOMINADOR (count/head). Ler vínculo dela é o stale infinito que o
+    // épico-drop existe para fechar — nem "para consertar a cobertura".
+    expect(
+      src,
+      'REGRESSÃO: o guard passou a LER vínculo da tabela base — reabre o stale infinito',
+    ).not.toMatch(/\.from\("omie_customer_account_map"\)\s*\.select\("user_id/);
+  });
+
+  it('erro de escrita conta como erro — o supabase-js devolve {error}, não lança', () => {
+    const bloco = blocoCaseCliente(src, 'sync_all_clients');
+    expect(
+      bloco,
+      'REGRESSÃO: o insert de profiles voltou a ser disparado sem checar o retorno — Auth órfão contado como importado',
+    ).toMatch(/const \{ error: profileError \} = await adminClient\.from\("profiles"\)\.insert\(/);
+    expect(
+      bloco,
+      'REGRESSÃO: falha no insert de profiles deixou de abortar o cliente (segue para vínculo e endereço)',
+    ).toMatch(/if \(profileError\)[\s\S]{0,240}accErrors\+\+;[\s\S]{0,60}continue;/);
+    expect(
+      bloco,
+      'REGRESSÃO: o insert do vínculo voltou a ignorar o retorno — "importado" sem vínculo é recriado na próxima execução',
+    ).toMatch(/const \{ error: mappingError \} = await adminClient\.from\("omie_clientes"\)\.insert\(/);
+    expect(bloco, 'REGRESSÃO: falha no vínculo deixou de contar erro').toMatch(
+      /if \(mappingError\)[\s\S]{0,240}accErrors\+\+;/,
+    );
+  });
+
+  it('upsertAddressFromOmie devolve false quando a escrita falha (senão o synced mente)', () => {
+    expect(
+      src,
+      'REGRESSÃO: o update de endereço voltou a ignorar o retorno — synced conta endereço que não gravou',
+    ).toMatch(/const \{ error: updateError \} = await adminClient[\s\S]{0,160}\.update\(addressData\)/);
+    expect(src, 'REGRESSÃO: falha no update deixou de devolver false').toMatch(
+      /if \(updateError\)[\s\S]{0,200}return false;/,
+    );
+    expect(src, 'REGRESSÃO: o insert de endereço voltou a ignorar o retorno').toMatch(
+      /const \{ error: insertError \} = await adminClient\.from\("addresses"\)\.insert\(addressData\)/,
+    );
+    expect(src, 'REGRESSÃO: falha no insert deixou de devolver false').toMatch(
+      /if \(insertError\)[\s\S]{0,200}return false;/,
+    );
+  });
+
+  it('sync_addresses drena: lote que não progride não repete para sempre', () => {
+    const bloco = blocoCaseCliente(src, 'sync_addresses');
+    // Bastam batchSize "poison users" (sem credencial da conta, sem endereço na Omie) para o
+    // slice(0, n) devolver sempre os mesmos e o `while (hasMore)` do useAnalyticsSync girar sem fim.
+    expect(
+      bloco,
+      'REGRESSÃO: o lote voltou a sair sempre do início — poison users travam o caller em loop',
+    ).toMatch(/clientsNeedingAddress\.slice\(offset, offset \+ batchSize\)/);
+    expect(bloco, 'REGRESSÃO: sumiu o avanço do offset pelos não-drenados').toMatch(
+      /naoDrenados = batch\.length - totalSynced/,
+    );
+    expect(
+      bloco,
+      'REGRESSÃO: hasMore voltou a ignorar se ALGO drenou — o caller legado (sem offset) gira para sempre',
+    ).toMatch(/totalSynced > 0 && nextOffset < totalNeeding/);
+  });
+
+  it('a conta que dá o endereço é escolha explícita, não ordem alfabética', () => {
+    const bloco = blocoCaseCliente(src, 'sync_addresses');
+    // Sem rank, a ordem caía do `.order("account")` da consulta: colacor < colacor_sc < oben — ou
+    // seja, collation virando regra de negócio (a ordem declarada em getOmieAccounts é outra).
+    expect(
+      bloco,
+      'REGRESSÃO: a prioridade de conta voltou a cair da ordenação alfabética da consulta',
+    ).toMatch(/accountRank/);
+    expect(bloco, 'REGRESSÃO: as contas do user deixaram de ser ordenadas pela prioridade declarada').toMatch(
+      /entradasDoUser[\s\S]{0,240}\.sort\(/,
+    );
+  });
+
+  it('proof fresca vazia é erro, não "concluído"', () => {
+    const bloco = blocoCaseCliente(src, 'sync_addresses');
+    expect(
+      bloco,
+      'REGRESSÃO: proof vazia voltou a responder 200/zeros — a UI pinta "concluído" com a base inteira por fazer',
+    ).toMatch(/Proof fresca vazia com \$\{baseCount\}/);
+  });
+
+  it('criar_perfil_local não confunde erro de consulta com miss', () => {
+    const bloco = blocoCaseCliente(src, 'criar_perfil_local');
+    expect(
+      bloco,
+      'REGRESSÃO: erro da view voltou a ser indistinguível de miss — falha transitória vira clone permanente',
+    ).toMatch(/if \(mappingLookupError\)[\s\S]{0,240}throw new Error/);
   });
 });
 

--- a/supabase/functions/omie-cliente/index.ts
+++ b/supabase/functions/omie-cliente/index.ts
@@ -275,12 +275,19 @@ async function upsertAddressFromOmie(
     if (!cliente.endereco || !cliente.cidade) return false;
 
     // Check if user already has an Omie address
-    const { data: existing } = await adminClient
+    const { data: existing, error: lookupError } = await adminClient
       .from("addresses")
       .select("id")
       .eq("user_id", userId)
       .eq("is_from_omie", true)
       .maybeSingle();
+
+    // Erro de consulta ≠ "não tem endereço": seguir com `existing` undefined tentaria um INSERT
+    // por cima de uma linha que pode existir.
+    if (lookupError) {
+      console.error(`[upsertAddressFromOmie] Lookup failed for user ${userId}:`, lookupError);
+      return false;
+    }
 
     const addressData = {
       user_id: userId,
@@ -296,15 +303,106 @@ async function upsertAddressFromOmie(
       is_from_omie: true,
     };
 
+    // O supabase-js NÃO lança em falha de escrita: devolve { error }. Ignorá-lo fazia esta função
+    // retornar `true` sem ter gravado nada — e o `synced` do sync_addresses contava esse endereço
+    // como criado. Progresso fabricado: o relatório fechava "concluído" com o trabalho por fazer.
     if (existing) {
-      await adminClient.from("addresses").update(addressData).eq("id", existing.id);
+      const { error: updateError } = await adminClient
+        .from("addresses")
+        .update(addressData)
+        .eq("id", existing.id);
+      if (updateError) {
+        console.error(`[upsertAddressFromOmie] Update failed for user ${userId}:`, updateError);
+        return false;
+      }
     } else {
-      await adminClient.from("addresses").insert(addressData);
+      const { error: insertError } = await adminClient.from("addresses").insert(addressData);
+      if (insertError) {
+        console.error(`[upsertAddressFromOmie] Insert failed for user ${userId}:`, insertError);
+        return false;
+      }
     }
     return true;
   } catch (err) {
     console.error(`[upsertAddressFromOmie] Error for user ${userId}:`, err);
     return false;
+  }
+}
+
+/**
+ * Páginas de `profiles` com documento, por KEYSET em user_id.
+ *
+ * O PostgREST capa a resposta em 1.000 linhas SILENCIOSAMENTE — sem erro, sem sinal. Uma leitura
+ * crua de `profiles` (5.276 hoje) devolve 1.000 (19%), e os 4.276 restantes ficam indistinguíveis
+ * de "não existe": quem dedupa por documento cria um usuário Auth NOVO para cliente que já tem
+ * cadastro. É a morfologia dos 1.633 placeholders sem profile que já estão no banco.
+ *
+ * Keyset (`.gt("user_id", cursor)`) e não `.range()`: com offset, uma inserção concorrente desloca
+ * as páginas seguintes e pula linhas — e o sync_all_clients INSERE profiles enquanto varre.
+ */
+async function* paginarProfilesComDocumento(
+  adminClient: SupabaseClient,
+): AsyncGenerator<Array<{ user_id: string; document: string }>> {
+  const pageSize = 1000;
+  let cursor: string | null = null;
+
+  while (true) {
+    let query = adminClient
+      .from("profiles")
+      .select("user_id, document")
+      .not("document", "is", null)
+      .order("user_id")
+      .limit(pageSize);
+    if (cursor) query = query.gt("user_id", cursor);
+
+    const { data, error } = await query;
+    // Fail-closed: erro engolido vira página vazia, que vira "cliente não existe" → clone.
+    if (error) throw new Error(`Falha ao paginar profiles: ${error.message}`);
+    if (!data || data.length === 0) return;
+
+    const rows = data as Array<{ user_id: string; document: string | null }>;
+    yield rows.filter((r): r is { user_id: string; document: string } => !!r.document);
+
+    cursor = rows[rows.length - 1].user_id;
+    if (rows.length < pageSize) return;
+  }
+}
+
+/** Abaixo disto a proof fresca não serve como dedup: importar criaria duplicatas em massa. */
+const COBERTURA_MINIMA_PROOF = 0.5;
+
+/**
+ * Barra a importação em massa quando a proof fresca está degradada.
+ *
+ * `omie_customer_account_map_fresco` é a base filtrada por `updated_at >= now() - 7 dias`. Se o
+ * omie-analytics-sync ficar uma semana parado (já aconteceu neste repo), a view ESVAZIA — e uma
+ * consulta bem-sucedida com zero linhas não acusa erro nenhum. O dedup então enxerga "nenhum
+ * código mapeado" e o handler recria do zero milhares de clientes que já existem, cada um com
+ * user_id novo. Zero linhas não é "nada a fazer": é cegueira.
+ *
+ * A base entra aqui só como DENOMINADOR (count) — nunca como fonte de vínculo. Ler vínculo da
+ * base é o que reabre o stale infinito que o épico-drop existe para fechar.
+ */
+async function assertProofFrescaSaudavel(
+  adminClient: SupabaseClient,
+  account: string,
+  codigosFrescos: number,
+): Promise<void> {
+  const { count, error } = await adminClient
+    .from("omie_customer_account_map")
+    .select("*", { count: "exact", head: true })
+    .eq("account", account);
+
+  if (error) throw new Error(`Falha ao medir cobertura da proof (${account}): ${error.message}`);
+  if (!count) return; // conta sem histórico na base: não há baseline com que comparar
+
+  const cobertura = codigosFrescos / count;
+  if (cobertura < COBERTURA_MINIMA_PROOF) {
+    throw new Error(
+      `Proof fresca degradada em ${account}: ${codigosFrescos}/${count} códigos ` +
+        `(${(cobertura * 100).toFixed(1)}% < ${COBERTURA_MINIMA_PROOF * 100}%). ` +
+        `Rode o omie-analytics-sync antes — importar agora criaria clientes duplicados.`,
+    );
   }
 }
 
@@ -638,12 +736,19 @@ serve(async (req) => {
         // sobrescrita pelo writer da vez) e empresa_omie é 'colacor' em 100% das linhas — rótulo
         // mentiroso. Divergir da conta do chamador aqui anexaria a ferramenta ao cliente ERRADO.
         // Miss (ausente ou stale >7d) cai no fallback por documento abaixo — fail-closed.
-        const { data: existingMapping } = await adminClient
+        const { data: existingMapping, error: mappingLookupError } = await adminClient
           .from("omie_customer_account_map_fresco")
           .select("user_id")
           .eq("omie_codigo_cliente", cliente.codigo_cliente)
           .eq("account", "oben")
           .maybeSingle();
+
+        // Erro de consulta NÃO é miss. Tratar os dois igual seguiria para a criação de um usuário
+        // Auth novo por indisponibilidade momentânea do banco — clone permanente por falha
+        // transitória. Fail-closed: aborta e o chamador reporta (ele tem o próprio fallback).
+        if (mappingLookupError) {
+          throw new Error(`Falha ao consultar vínculo na proof fresca: ${mappingLookupError.message}`);
+        }
 
         // user_id da view é nulável (view sem NOT NULL) → null = miss, cai no fallback por documento.
         if (existingMapping?.user_id) {
@@ -655,29 +760,51 @@ serve(async (req) => {
         if (cliente.cnpj_cpf) {
           const docLimpo = cliente.cnpj_cpf.replace(/\D/g, "");
           if (docLimpo.length >= 11) {
-            const { data: existingProfiles } = await adminClient
+            // Caminho rápido: o documento é gravado já normalizado por este edge e pelo
+            // sync_all_clients, então o match direto resolve o caso comum sem varrer a tabela.
+            // `.order("created_at")` não é cosmético: documento duplicado EXISTE (é o rastro dos
+            // clones). Sem ordem, o PostgREST devolve uma linha arbitrária e o mesmo cliente podia
+            // cair ora no perfil real, ora no clone. O mais ANTIGO é o canônico — o clone veio depois.
+            const { data: docHit, error: docHitError } = await adminClient
               .from("profiles")
-              .select("user_id, document")
-              .not("document", "is", null);
+              .select("user_id")
+              .eq("document", docLimpo)
+              .order("created_at")
+              .limit(1);
+            if (docHitError) {
+              throw new Error(`Falha ao buscar perfil por documento: ${docHitError.message}`);
+            }
 
-            const matchedProfile = existingProfiles?.find(p => 
-              p.document?.replace(/\D/g, "") === docLimpo
-            );
+            let matchedUserId = (docHit?.[0] as { user_id: string } | undefined)?.user_id;
 
-            if (matchedProfile) {
+            // Legado formatado ("12.345.678/0001-90") só casa normalizando os dois lados — varredura
+            // PAGINADA. Antes era um SELECT cru da tabela inteira, capado em 1.000 linhas pelo
+            // PostgREST: perfil fora dessa janela lia como inexistente e o fluxo criava um usuário
+            // novo para quem já tinha cadastro.
+            if (!matchedUserId) {
+              for await (const pagina of paginarProfilesComDocumento(adminClient)) {
+                const hit = pagina.find((p) => p.document.replace(/\D/g, "") === docLimpo);
+                if (hit) {
+                  matchedUserId = hit.user_id;
+                  break;
+                }
+              }
+            }
+
+            if (matchedUserId) {
               // Profile exists — just create the omie_clientes mapping
-              console.log(`[criar_perfil_local] Found existing profile by document ${docLimpo}, linking to user ${matchedProfile.user_id}`);
+              console.log(`[criar_perfil_local] Found existing profile by document ${docLimpo}, linking to user ${matchedUserId}`);
               const { error: mappingError } = await adminClient
                 .from("omie_clientes")
                 .insert({
-                  user_id: matchedProfile.user_id,
+                  user_id: matchedUserId,
                   omie_codigo_cliente: cliente.codigo_cliente,
                   omie_codigo_vendedor: cliente.codigo_vendedor || null,
                 });
               if (mappingError) {
                 console.error("[criar_perfil_local] Mapping error:", mappingError);
               }
-              result = { user_id: matchedProfile.user_id };
+              result = { user_id: matchedUserId };
               break;
             }
           }
@@ -770,34 +897,41 @@ serve(async (req) => {
         // enxergava 1/7 dos códigos e o loop reprocessava o resto. A fresca dá os códigos DESTA
         // conta, paginados com .order estável.
         const existingCodes = new Set<number>();
-        let codeOffset = 0;
+        let codeCursor: number | null = null;
         const codePageSize = 1000;
         while (true) {
-          const { data: codePage, error: codeErr } = await adminClient
+          // Keyset, não `.range()`: a fresca é uma view DESLIZANTE (TTL de 7 dias). Com offset, uma
+          // linha que expira entre duas páginas desloca todas as seguintes e o dedup PULA códigos —
+          // e código pulado aqui vira cliente RECRIADO no laço de importação abaixo.
+          let codeQuery = adminClient
             .from("omie_customer_account_map_fresco")
             .select("omie_codigo_cliente")
             .eq("account", account.account)
             .order("omie_codigo_cliente")
-            .range(codeOffset, codeOffset + codePageSize - 1);
+            .limit(codePageSize);
+          if (codeCursor !== null) codeQuery = codeQuery.gt("omie_codigo_cliente", codeCursor);
+
+          const { data: codePage, error: codeErr } = await codeQuery;
           // Fail-closed: engolir o erro deixaria o Set vazio/parcial e o loop tentaria RECRIAR
           // milhares de clientes já existentes (Codex P2 do PR-2, mesma armadilha).
           if (codeErr) throw new Error(`Falha ao carregar códigos já mapeados (${account.account}): ${codeErr.message}`);
           if (!codePage || codePage.length === 0) break;
           for (const row of codePage) existingCodes.add(row.omie_codigo_cliente as number);
+          codeCursor = codePage[codePage.length - 1].omie_codigo_cliente as number;
           if (codePage.length < codePageSize) break;
-          codeOffset += codePageSize;
         }
 
-        // Pre-load all profiles with documents for dedup
-        const { data: allProfiles } = await adminClient
-          .from("profiles")
-          .select("user_id, document")
-          .not("document", "is", null);
+        // O `codeErr` acima só pega erro SQL. Uma consulta BEM-SUCEDIDA com zero linhas (view
+        // expirada porque o omie-analytics-sync parou) passa limpo e é o cenário mais destrutivo:
+        // dedup cego reimporta a conta inteira. Barra ANTES de qualquer criação de identidade.
+        await assertProofFrescaSaudavel(adminClient, account.account, existingCodes.size);
+
+        // Dedup por documento — paginado. Era um SELECT cru de `profiles` capado em 1.000 de 5.276
+        // (19%): para os outros 81%, `profileByDoc.get()` devolvia undefined e o laço abaixo criava
+        // um usuário Auth NOVO para cliente que já tinha cadastro. Esta é a fábrica dos clones.
         const profileByDoc = new Map<string, string>();
-        for (const p of allProfiles || []) {
-          if (p.document) {
-            profileByDoc.set(p.document.replace(/\D/g, ""), p.user_id);
-          }
+        for await (const pagina of paginarProfilesComDocumento(adminClient)) {
+          for (const p of pagina) profileByDoc.set(p.document.replace(/\D/g, ""), p.user_id);
         }
 
         console.log(`[sync_all_clients] Starting ${account.name} from page ${startPage}...`);
@@ -852,23 +986,38 @@ serve(async (req) => {
                   }
 
                   userId = authData.user.id;
-                  await adminClient.from("profiles").insert({
+                  // O supabase-js NÃO lança em falha de escrita: devolve { error }. Ignorá-lo
+                  // deixava o usuário Auth recém-criado SEM profile — órfão — e o laço seguia
+                  // contando "importado". Nenhum UNIQUE segura: o user_id acabou de nascer.
+                  const { error: profileError } = await adminClient.from("profiles").insert({
                     user_id: userId,
                     name: cliente.nome_fantasia || cliente.razao_social || "Cliente",
                     email: cliente.email || null,
                     phone: cliente.telefone1_numero || null,
                     document: cnpjCpf,
                   });
+                  if (profileError) {
+                    console.error(`[sync_all_clients] profile insert falhou (user ${userId}, código ${codigoCliente}):`, profileError);
+                    accErrors++;
+                    continue;
+                  }
                   profileByDoc.set(cnpjCpf, userId);
                 }
 
                 const codigoVendedor = cliente.recomendacoes?.codigo_vendedor || cliente.codigo_vendedor || null;
-                await adminClient.from("omie_clientes").insert({
+                const { error: mappingError } = await adminClient.from("omie_clientes").insert({
                   user_id: userId,
                   omie_codigo_cliente: codigoCliente,
                   omie_codigo_vendedor: codigoVendedor,
                   omie_codigo_cliente_integracao: cliente.codigo_cliente_integracao || null,
                 });
+                // Sem o vínculo o cliente NÃO foi importado: fica invisível ao dedup da próxima
+                // execução e seria recriado. Conta erro em vez de sucesso silencioso.
+                if (mappingError) {
+                  console.error(`[sync_all_clients] mapping insert falhou (user ${userId}, código ${codigoCliente}):`, mappingError);
+                  accErrors++;
+                  continue;
+                }
 
                 existingCodes.add(codigoCliente);
                 
@@ -943,22 +1092,43 @@ serve(async (req) => {
         // empresa_omie 'colacor' em 100% das linhas, rótulo mentiroso) — o loop abaixo então chutava
         // esse código indeterminado nas 3 contas até uma responder. A proof tem 1 linha por
         // (user, conta), então sabemos a conta CERTA de cada código.
-        let allMappings: Array<{ user_id: string; account: string; omie_codigo_cliente: number }> = [];
-        let fetchOffset = 0;
+        const allMappings: Array<{ user_id: string; account: string; omie_codigo_cliente: number }> = [];
+        const paresVistos = new Set<string>();
+        let userCursor: string | null = null;
         const fetchPageSize = 1000;
         while (true) {
-          const { data: page, error: pageErr } = await adminClient
+          // Keyset, não `.range()`: a fresca é uma view DESLIZANTE (TTL de 7 dias) e, com offset,
+          // uma linha que expira entre duas páginas desloca as seguintes e PULA users — que ficam
+          // sem endereço sem ninguém notar. `.gte` e não `.gt` para não perder as contas restantes
+          // do user partido na fronteira da página; o Set desduplica a sobra reprocessada.
+          let query = adminClient
             .from("omie_customer_account_map_fresco")
             .select("user_id, account, omie_codigo_cliente")
             .order("user_id")
             .order("account")
-            .range(fetchOffset, fetchOffset + fetchPageSize - 1);
+            .limit(fetchPageSize);
+          if (userCursor) query = query.gte("user_id", userCursor);
+
+          const { data: page, error: pageErr } = await query;
           // Fail-closed: engolir o erro daria "No client mappings found" — um NO-OP mudo que parece sucesso.
           if (pageErr) throw new Error(`Falha ao carregar mapeamentos da proof: ${pageErr.message}`);
           if (!page || page.length === 0) break;
-          allMappings = allMappings.concat(page as typeof allMappings);
-          if (page.length < fetchPageSize) break;
-          fetchOffset += fetchPageSize;
+
+          const rows = page as typeof allMappings;
+          let novos = 0;
+          for (const m of rows) {
+            const chave = `${m.user_id}|${m.account}`;
+            if (paresVistos.has(chave)) continue;
+            paresVistos.add(chave);
+            allMappings.push(m);
+            novos++;
+          }
+
+          const ultimoUser = rows[rows.length - 1].user_id;
+          // Guard de não-avanço: só ocorreria com um user ocupando a página inteira (>1.000 contas),
+          // mas sem ele um cursor parado é laço infinito.
+          if (rows.length < fetchPageSize || (novos === 0 && ultimoUser === userCursor)) break;
+          userCursor = ultimoUser;
         }
 
         // Agrupa por user: a proof tem até 1 linha por (user, conta) e o batch conta USERS (o espelho
@@ -972,6 +1142,18 @@ serve(async (req) => {
         const totalCount = codesByUser.size;
 
         if (totalCount === 0) {
+          // Proof fresca vazia NÃO é "nada a fazer": a fresca é a base filtrada por TTL de 7 dias,
+          // então zero linhas com a base cheia significa sync parado há uma semana. Responder
+          // 200/zeros pinta "concluído" na UI e esconde a base inteira por processar (fail-open).
+          const { count: baseCount } = await adminClient
+            .from("omie_customer_account_map")
+            .select("*", { count: "exact", head: true });
+          if (baseCount && baseCount > 0) {
+            throw new Error(
+              `Proof fresca vazia com ${baseCount} vínculos na base: o omie-analytics-sync está ` +
+                `parado (TTL de 7 dias). Rode-o antes de sincronizar endereços.`,
+            );
+          }
           result = { synced: 0, skipped: 0, errors: 0, hasMore: false, message: "No client mappings found" };
           break;
         }
@@ -980,13 +1162,26 @@ serve(async (req) => {
         const clientsNeedingAddress = [...codesByUser.keys()].filter((userId) => !usersWithAddress.has(userId));
         const totalNeeding = clientsNeedingAddress.length;
 
-        // Always take from the beginning since the list shrinks as addresses are created
-        const batch = clientsNeedingAddress.slice(0, batchSize);
-        console.log(`[sync_addresses] Processing batch size=${batch.length}, totalNeeding=${totalNeeding}`);
+        // A lista encolhe sozinha a cada endereço criado (quem sincroniza sai do filtro acima), então
+        // o offset só precisa saltar quem NÃO drena: user sem credencial da conta, sem endereço na
+        // Omie, ou com erro. Sem esse salto, `slice(0, batchSize)` devolve eternamente os mesmos 30
+        // "poison users" e o caller (useAnalyticsSync: `while (hasMore)`) nunca termina — Codex P1.
+        const batch = clientsNeedingAddress.slice(offset, offset + batchSize);
+        console.log(`[sync_addresses] Processing batch size=${batch.length}, offset=${offset}, totalNeeding=${totalNeeding}`);
 
         // Chave `string` de propósito: o account vem da proof (dado externo). Slug desconhecido ou
         // sem credencial nesta edge → .get() undefined → o guard abaixo pula (fail-closed).
         const accountBySlug = new Map<string, OmieAccountConfig>(accounts.map((a) => [a.account, a]));
+
+        // Prioridade EXPLÍCITA de qual conta dá o endereço de um user multi-conta: a ordem em que
+        // esta edge declara as contas (getOmieAccounts → colacor_sc, oben, colacor), a mesma que o
+        // account_index do sync_all_clients já usa. Antes a ordem saía do `.order("account")` da
+        // consulta — alfabética (colacor < colacor_sc < oben): collation virando regra de negócio,
+        // com o endereço default vindo de uma conta que ninguém escolheu (Codex).
+        // Chave `string` pelo mesmo motivo do accountBySlug: o account vem da proof (dado externo).
+        // Slug fora da lista → rank MAX_SAFE_INTEGER → tentado por último, nunca antes de uma conta
+        // conhecida (fail-closed).
+        const accountRank = new Map<string, number>(accounts.map((a, i) => [a.account, i]));
 
         for (const userId of batch) {
           try {
@@ -996,7 +1191,13 @@ serve(async (req) => {
             // (a proof garante o par). Antes: o mesmo código indeterminado era chutado nas 3 contas
             // até uma responder — até 3x chamadas Omie e, sob colisão de código entre contas, o
             // endereço de OUTRO cliente. Mantém "tenta até achar endereço" entre as contas do user.
-            for (const entry of codesByUser.get(userId) ?? []) {
+            const entradasDoUser = [...(codesByUser.get(userId) ?? [])].sort(
+              (a, b) =>
+                (accountRank.get(a.account) ?? Number.MAX_SAFE_INTEGER) -
+                (accountRank.get(b.account) ?? Number.MAX_SAFE_INTEGER),
+            );
+
+            for (const entry of entradasDoUser) {
               const conta = accountBySlug.get(entry.account);
               // Conta sem credencial nesta edge → pula (fail-closed: não tenta o código em outra conta).
               if (!conta) continue;
@@ -1035,7 +1236,18 @@ serve(async (req) => {
           }
         }
 
-        const hasMore = totalNeeding > batch.length;
+        // Quem sincronizou sai da lista sozinho; quem foi pulado/errou continua nela e precisa ser
+        // SALTADO no próximo lote.
+        const naoDrenados = batch.length - totalSynced;
+        const nextOffset = offset + naoDrenados;
+
+        // Caller que pagina (passa `offset`) drena até o fim, inclusive a cauda de poison users.
+        // O caller legado recomeça do zero a cada chamada — então só continua se ALGO drenou aqui;
+        // senão o próximo lote seria idêntico a este, e o `while (hasMore)` dele giraria para sempre.
+        const chamadorPagina = body.offset !== undefined;
+        const hasMore = chamadorPagina
+          ? nextOffset < totalNeeding
+          : totalSynced > 0 && nextOffset < totalNeeding;
 
         result = {
           synced: totalSynced,
@@ -1045,6 +1257,9 @@ serve(async (req) => {
           totalClients: totalCount,
           processed: batch.length,
           hasMore,
+          next: { offset: nextOffset },
+          // Lote inteiro sem drenar: o que resta só é alcançável passando `offset`.
+          stalled: batch.length > 0 && totalSynced === 0,
         };
         break;
       }


### PR DESCRIPTION
## O que

Fecha os P1 que o Codex apontou no parecer sobre a Fatia 3-edges PR-A (#1364). Aquele PR trocou a
**fonte** do dedup dos 3 leitores do `omie-cliente` (espelho → proof fresca account-correta) e
deixou de pé a **porta** que fabricou os clones que já estão no banco. Este PR fecha a porta.

**#1364 não deve ser deployado sem isto.**

## A aritmética (psql-ro, prod, 2026-07-18)

```
profiles reais:        5.276   ← o profileByDoc lia SEM paginar → via 1.000 (19%)
users na proof:        5.276
espelho total:         6.909
clones sem profile:    1.633   ← 6.909 − 5.276
```

Para os 81% de perfis fora da janela de 1.000, o dedup por documento devolvia `undefined` e o
handler criava um **usuário Auth novo** para quem já tinha cadastro. Como o supabase-js devolve
`{ error }` em vez de lançar, os inserts falhos passavam mudos e o contador ainda somava
"importado". Nas palavras do Codex: *"É exatamente a morfologia dos 1.633 placeholders."*

Conferido hoje: `profiles_criados_ult_72h = 0` — ninguém deployou nem rodou o sync desde o merge
do #1364, então nada piorou desde o baseline.

## Os 8 fixes

| # | Fix | O que quebrava sem ele |
|---|---|---|
| 1 | `profileByDoc` paginado por keyset (helper `paginarProfilesComDocumento`) | **a fábrica de clones**: 1.000 de 5.276 lidas como se fossem todas |
| 2 | Mesmo fallback paginado em `criar_perfil_local` | idem, no fluxo interativo de vendas |
| 3 | `assertProofFrescaSaudavel` antes de qualquer criação | proof vazia (sync parado 7d) → dedup cego reimporta ~15k clientes |
| 4 | Erros de insert (`profiles`, `omie_clientes`) contam como erro | Auth órfão e cliente sem vínculo contados como "importado" |
| 5 | `upsertAddressFromOmie` devolve `false` em falha de escrita | `synced` contava endereço que não gravou |
| 6 | `sync_addresses` drena (offset avança pelos não-drenados) | 30 poison users → `while (hasMore)` do caller gira para sempre |
| 7 | Prioridade de conta explícita (`accountRank`) | collation (`colacor < colacor_sc < oben`) virando regra de negócio |
| 8 | Proof vazia vira erro, não `200`/zeros | UI pintava "concluído" com a base inteira por fazer |

Bônus dos mesmos guards: erro de consulta deixa de ser indistinguível de miss (falha transitória
virava clone permanente), e a paginação das views deslizantes passou de offset para **keyset** —
com TTL de 7 dias, uma linha que expira entre páginas desloca as seguintes e pula registros.

## Por que a base aparece no diff

`assertProofFrescaSaudavel` consulta `omie_customer_account_map` **só como denominador**
(`count`/`head: true`), nunca como fonte de vínculo — ler vínculo da base é o stale infinito que o
épico-drop existe para fechar. Há canária negativa travando isso:
`not.toMatch(/\.from\("omie_customer_account_map"\)\s*\.select\("user_id/)`.

## Prova

- `deno check supabase/functions/omie-cliente/index.ts` → exit 0
- `typecheck` → exit 0
- Suíte completa: **5381/5382**. A única falha é `SalesQuotes.accountGuard` (*"Unable to find role=button
  name /Enviar Pedido/i"*), que **não tem acoplamento com este diff**: o teste importa `SalesQuotes`,
  `AuthContext` e `sonner`, sem uma menção a `omie-cliente`, `omie_customer_account_map` ou `profiles`;
  e o diff toca código Deno em `supabase/functions/` (que o vitest nem resolve no bundle React) e um
  arquivo de teste que só faz `readFileSync`. Rodou sob load average ~20 numa M2 de 8GB, esperando um
  botão que depende de estado assíncrono. Como os PRs recentes mergearam com CI verde e o auto-merge
  exige verde, o teste passa na main no runner do CI — **o CI deste PR é o juiz**: se ficar verde,
  confirma flaky local; se acusar o mesmo teste, eu trato antes de qualquer merge.
- **8 canárias novas** + 2 existentes atualizadas (o keyset invalidou o assert de `.range()`)
- **Falsificação**: 14 sabotagens, uma por guard, cada uma exigindo vermelho — com detecção de
  sabotagem-que-não-aplicou, senão um regex furado do script viraria falso "teatro"

Sem SQL novo → sem prove-sql. Sem migration, sem Publish (o único arquivo `src/` é o de canárias,
não importado pelo runtime).

## O que este PR NÃO fecha (consciente)

**Cadastro real sem linha na proof fica sem endereço.** O Codex apontou (P2 [4]) que o código não
tem fallback quando o user existe numa conta ausente da proof. Das duas saídas que ele aceita
("fallback por documento/account" ou "exigir proof saudável"), este PR faz a **segunda** — o guard
de cobertura. A alternativa que *não* serve é voltar ao probe por código: reabre a atribuição
errada que o épico fechou. Perder um endereço é reversível; anexar o endereço de outro cliente não.

**`sync_all_clients` não tem read-your-writes.** Ele dedupa na proof mas escreve no espelho, então
até o próximo `omie-analytics-sync` os imports da execução anterior seguem invisíveis ao dedup. O
efeito grave disso era criar clones — e esse caminho está fechado pelo fix 1: numa segunda
execução o `profileByDoc` paginado *acha* o perfil pelo documento, então o pior desfecho vira
insert de vínculo duplicado, que o UNIQUE rejeita e o fix 4 agora contabiliza como erro em vez de
engolir. Fecha de vez na Fatia 4, quando os writers migrarem.

## Deploy

Só a edge, pelo chat do Lovable, **verbatim**, depois do merge:

> Edit the existing edge function `omie-cliente` and replace its code with the current contents of
> `supabase/functions/omie-cliente/index.ts` from the `main` branch. Deploy it **verbatim** — do NOT
> modify, reinterpret, "improve", or reformat the code. After deploying, confirm it shows **Active**.

Pós-deploy, validar por psql-ro contra o baseline: `espelho 6909 · users_na_proof 5276 ·
profiles 5276 · clones 1633`. O sinal de sucesso é **clones não crescerem** na primeira execução
do `sync_all_clients`.
