### PR TITLE
docs(carteira): comentários do useTacticalPlan descreviam uma policy que não existe

### DIFF
--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -198,9 +198,13 @@ export const useTacticalPlan = () => {
   // Lente "Ver como" + COBERTURA (#980): as leituras de EXIBIÇÃO (lista de planos, plano ativo do
   // cliente) seguem a VISIBILIDADE de carteira do id efetivo — carteira própria + carteiras
   // cobertas (fetchOwnerScope/ownersAtivosDoAlvo). O id efetivo é o ALVO na lente, o próprio
-  // usuário fora. A RLS de farmer_tactical_plans recorta por CLIENTE (tactical_plans_select_carteira:
-  // pode_ver_carteira_completa OR carteira_visivel_para, que filtra eligible) — eixo DIFERENTE do
-  // farmer_id, então o escopo por DONO segue sendo do app. A GERAÇÃO (checkEfficiency/generatePlan) e o
+  // usuário fora. ⚠️ A RLS de farmer_tactical_plans é BROAD-STAFF (`tactical_plans_select_staff`:
+  // master OR employee) — NÃO recorta por cliente nem por farmer_id, então TODO o escopo de leitura
+  // é responsabilidade do app. O que a fecha hoje é a ESCRITA (#1422: RPC + trigger recusam cliente
+  // mascarado, e a tabela não é escrevível fora das RPCs) ⇒ não existe plano de mascarado para vazar.
+  // Estreitar a policy p/ carteira-scoped ficou como follow-up com desenho próprio: a carteira é
+  // VIVA, então um cliente reatribuído sumiria retroativamente da métrica de performance do dono
+  // anterior. A GERAÇÃO (checkEfficiency/generatePlan) e o
   // registro de resultado seguem user.id (write identity = master real) e são bloqueados na lente
   // pelo write-guard + botões disabled. A POSSE gravada (farmer_id) é o DONO da carteira do cliente
   // (score.farmer_id), nunca o executor. Fora da lente effectiveUserId === user.id.
@@ -268,8 +272,8 @@ export const useTacticalPlan = () => {
 
   // Visibilidade de carteira p/ LEITURA: dono efetivo + carteiras que ele cobre (cobertura ativa e
   // dentro da validade). Reproduz, com a sessão atual, o que carteira_visivel_para daria — preciso
-  // porque a RLS de farmer_tactical_plans recorta por CLIENTE, não por farmer_id: ela barra cliente
-  // fora da carteira (e mascarado), mas não separa os planos POR DONO — este filtro é esse eixo.
+  // porque a RLS de farmer_tactical_plans é BROAD-STAFF (master OR employee): ela não separa por
+  // DONO nem por CLIENTE, então este filtro é a única barreira de escopo na leitura.
   // baseId = effectiveUserId (alvo na lente, próprio fora).
   const fetchOwnerScope = useCallback(async (baseId: string): Promise<string[]> => {
     const { data: cov, error } = (await supabase
@@ -369,7 +373,7 @@ export const useTacticalPlan = () => {
       }
 
       // [GUARD money-path] POSSE do plano = DONO da carteira do cliente (score.farmer_id, Opção A),
-      // NUNCA o executor logado. A RLS de farmer_tactical_plans recorta por CLIENTE (não por
+      // NUNCA o executor logado. A RLS de farmer_tactical_plans é broad-staff (não escopa por
       // farmer_id), então o campo é o ÚNICO mecanismo de posse: gravar user.id poluiria a carteira
       // do gestor sob cobertura (#980) e sumiria da carteira do dono. O bundle (multi por
       // (customer,farmer)) e o cluster também escopam pelo dono. farmer_id null = corrupção →


### PR DESCRIPTION
Resíduo meu do #1422, encontrado no ritual de fecho da própria sessão.

## O que aconteceu

Eu tinha desenhado o estreitamento da policy SELECT de `farmer_tactical_plans` para carteira-scoped e editei os comentários do hook para descrever esse mundo. Depois **recuei do estreitamento** — challenge do Codex xhigh: a carteira é viva, então um cliente reatribuído A→B sumiria **retroativamente** da métrica de performance de A, e a métrica passaria a variar conforme quem a calcula.

A migration saiu certa. Os comentários ficaram descrevendo o desenho abandonado.

## O que eles afirmavam × o que é verdade

Os 3 comentários diziam que a RLS "recorta por CLIENTE (`tactical_plans_select_carteira`: `pode_ver_carteira_completa OR carteira_visivel_para`, que filtra eligible)".

Medido em prod (2026-07-18, reconferido no commit): a única policy é `tactical_plans_select_staff` — `master OR employee`. **Broad-staff, como sempre foi.**

## Por que isso merece um PR próprio

Comentário errado sobre **autorização** é pior que comentário desatualizado: afirma uma garantia que não existe, e quem lê decide que não precisa gatear algo. Não é hipotético — a lacuna que ele mascarava (leitura broad-staff da tabela) é exatamente o que um follow-up ainda vai fechar.

## A correção

Os comentários novos dizem o que é verdade **e nomeiam a lacuna em vez de escondê-la**:

- a RLS é broad-staff → o escopo de leitura é 100% responsabilidade do app
- o que fecha o furo hoje é a **escrita** (#1422: RPC + trigger recusam cliente mascarado, tabela não-escrevível fora das RPCs) ⇒ não existe plano de mascarado para vazar
- o estreitamento da policy é follow-up com desenho próprio, pelo custo da métrica retroativa

Só comentários; zero mudança de comportamento. `typecheck` ✅ `lint` ✅

⚠️ Há uma sessão paralela trabalhando em "estreitar policy de farmer_tactical_plans sem quebrar histórico". Se ela mergear antes, estes comentários precisam ser atualizados de novo — na direção oposta. Descrevem o estado **de hoje**, medido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)