### PR TITLE
fix(monthly-report): N+1 de ~5.285 consultas deixava /admin/monthly-reports em spinner — inverte a direção da consulta (3 idas ao banco)

### DIFF
--- a/supabase/functions/_shared/relatorio-mensal.ts
+++ b/supabase/functions/_shared/relatorio-mensal.ts
@@ -1,0 +1,216 @@
+// Núcleo do relatório mensal de ferramentas (edge `monthly-report`).
+//
+// Mora em `_shared/` — e não dentro de `monthly-report/` — porque é aqui que vive a lógica
+// de edge COBERTA POR TESTE no repo (`*_test.ts` ao lado, `bun run test:edges`). O `index.ts`
+// da edge fica só com HTTP, auth, template de e-mail e envio.
+//
+// O banco entra por INJEÇÃO (`BancoPostgrest`), não como `SupabaseClient`: é o que permite
+// contar quantas idas ao banco a função faz — o invariante que esta unidade existe para
+// proteger (ver `relatorio-mensal_test.ts` → "custo de banco não cresce com a base").
+//
+// ⚠️ A DIREÇÃO DA CONSULTA É O DESENHO, não detalhe de implementação. Parte-se de
+// `user_tools` (4 linhas em prod, 2 donos) e daí para os perfis desses donos. Partir de
+// `profiles` (5.276 linhas) custava ~5.280 consultas sequenciais para descobrir que 5.274
+// clientes não têm ferramenta alguma: a página `/admin/monthly-reports` ficava em spinner
+// indefinido e o cron mensal (`0 9 1 * *`, timeout 150s) corria risco de nunca entregar.
+// Medido em prod 2026-07-18. Inverter a direção é o que torna o custo O(ferramentas).
+import { fetchAll } from "./paginate.ts";
+
+export interface ResumoFerramenta {
+  name: string;
+  internal_code: string | null;
+  category: string;
+  last_sharpened_at: string | null;
+  next_sharpening_due: string | null;
+  sharpening_count: number;
+  anomaly_count: number;
+  is_overdue: boolean;
+  is_due_soon: boolean;
+  days_until_due: number | null;
+}
+
+export interface RelatorioCliente {
+  user_id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  tools: ResumoFerramenta[];
+  overdue_count: number;
+  due_soon_count: number;
+  total_tools: number;
+}
+
+// ── Contrato mínimo do PostgREST que este núcleo usa ────────────────────────
+// Estrutural de propósito: o `SupabaseClient` real satisfaz sem adaptador, e o teste
+// satisfaz com um banco de memória que conta chamadas.
+
+export interface RespostaPostgrest<T> {
+  data: T[] | null;
+  count?: number | null;
+  error: { message: string } | null;
+}
+
+export interface QueryPostgrest<T> extends PromiseLike<RespostaPostgrest<T>> {
+  select(colunas: string, opts?: { count?: "exact"; head?: boolean }): QueryPostgrest<T>;
+  eq(coluna: string, valor: unknown): QueryPostgrest<T>;
+  in(coluna: string, valores: readonly unknown[]): QueryPostgrest<T>;
+  order(coluna: string, opts?: { ascending?: boolean }): QueryPostgrest<T>;
+  range(de: number, ate: number): QueryPostgrest<T>;
+}
+
+export interface BancoPostgrest {
+  // deno-lint-ignore no-explicit-any
+  from(tabela: string): QueryPostgrest<any>;
+}
+
+interface LinhaFerramenta {
+  id: string;
+  user_id: string;
+  internal_code: string | null;
+  generated_name: string | null;
+  custom_name: string | null;
+  last_sharpened_at: string | null;
+  next_sharpening_due: string | null;
+  tool_categories: { name?: string } | null;
+}
+
+interface LinhaPerfil {
+  user_id: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+}
+
+// Ordenação de exibição: atrasadas primeiro, depois as que vencem em breve, depois por
+// proximidade do vencimento. Preservada verbatim do comportamento original.
+function ordenarFerramentas(a: ResumoFerramenta, b: ResumoFerramenta): number {
+  if (a.is_overdue && !b.is_overdue) return -1;
+  if (!a.is_overdue && b.is_overdue) return 1;
+  if (a.is_due_soon && !b.is_due_soon) return -1;
+  if (!a.is_due_soon && b.is_due_soon) return 1;
+  return (a.days_until_due ?? 999) - (b.days_until_due ?? 999);
+}
+
+// Quantos ids cabem num `.in(...)` por requisição. O limite real é o TAMANHO DA URL (o
+// PostgREST recebe os ids na query string; o Kong do Supabase corta o request line em ~8 KB):
+// 150 uuids ≈ 5,9 KB, com folga. Não é sobre o Postgres — é sobre o transporte.
+const LOTE_IDS = 150;
+
+function emLotes<T>(itens: readonly T[], tamanho: number): T[][] {
+  const lotes: T[][] = [];
+  for (let i = 0; i < itens.length; i += tamanho) lotes.push(itens.slice(i, i + tamanho));
+  return lotes;
+}
+
+interface LinhaEvento {
+  user_tool_id: string;
+  event_type: string;
+}
+
+export async function montarRelatorios(
+  db: BancoPostgrest,
+  opts: { userIdAlvo?: string | null; agora: Date },
+): Promise<RelatorioCliente[]> {
+  const { userIdAlvo, agora } = opts;
+
+  // (1) Fonte da verdade: as FERRAMENTAS. Quem não tem ferramenta não entra no relatório —
+  // então percorrer a base de clientes para descobrir isso é trabalho jogado fora.
+  // `fetchAll` + `.order('id')` porque o PostgREST capa em 1000 linhas SEM ERRO.
+  const ferramentas = await fetchAll<LinhaFerramenta>((de, ate) => {
+    let q = db.from("user_tools").select("*, tool_categories(name)");
+    if (userIdAlvo) q = q.eq("user_id", userIdAlvo);
+    return q.order("id", { ascending: true }).range(de, ate);
+  }, "user_tools");
+
+  if (ferramentas.length === 0) return [];
+
+  // Ordem de primeira aparição (as ferramentas vêm ordenadas por id) — saída determinística.
+  const idsDonos: string[] = [];
+  const vistos = new Set<string>();
+  for (const f of ferramentas) {
+    if (!vistos.has(f.user_id)) {
+      vistos.add(f.user_id);
+      idsDonos.push(f.user_id);
+    }
+  }
+
+  // (2) Só os perfis desses donos.
+  const perfis = new Map<string, LinhaPerfil>();
+  for (const lote of emLotes(idsDonos, LOTE_IDS)) {
+    const linhas = await fetchAll<LinhaPerfil>((de, ate) =>
+      db.from("profiles").select("user_id, name, email, phone")
+        .in("user_id", lote).order("user_id", { ascending: true }).range(de, ate), "profiles");
+    for (const p of linhas) perfis.set(p.user_id, p);
+  }
+
+  // (3) Uma agregação dos eventos, no lugar de 2 counts POR FERRAMENTA.
+  // Erro de leitura PROPAGA (fetchAll lança): um relatório que reporta "0 afiações" porque a
+  // consulta falhou é pior que um 500 — fabricaria número no lugar de dado ausente.
+  const contagens = new Map<string, { afiacoes: number; anomalias: number }>();
+  for (const lote of emLotes(ferramentas.map((f) => f.id), LOTE_IDS)) {
+    const eventos = await fetchAll<LinhaEvento>((de, ate) =>
+      db.from("tool_events").select("user_tool_id, event_type")
+        .in("user_tool_id", lote).order("id", { ascending: true }).range(de, ate), "tool_events");
+    for (const ev of eventos) {
+      const c = contagens.get(ev.user_tool_id) ?? { afiacoes: 0, anomalias: 0 };
+      if (ev.event_type === "sharpening") c.afiacoes++;
+      else if (ev.event_type === "anomaly") c.anomalias++;
+      contagens.set(ev.user_tool_id, c);
+    }
+  }
+
+  // (4) Montagem em memória.
+  const porDono = new Map<string, ResumoFerramenta[]>();
+  for (const ferramenta of ferramentas) {
+    const vencimento = ferramenta.next_sharpening_due
+      ? new Date(ferramenta.next_sharpening_due)
+      : null;
+    const diasAteVencer = vencimento
+      ? Math.ceil((vencimento.getTime() - agora.getTime()) / (1000 * 60 * 60 * 24))
+      : null;
+    const c = contagens.get(ferramenta.id);
+
+    const resumo: ResumoFerramenta = {
+      name: ferramenta.generated_name || ferramenta.custom_name ||
+        ferramenta.tool_categories?.name || "Ferramenta",
+      internal_code: ferramenta.internal_code,
+      category: ferramenta.tool_categories?.name || "",
+      last_sharpened_at: ferramenta.last_sharpened_at,
+      next_sharpening_due: ferramenta.next_sharpening_due,
+      sharpening_count: c?.afiacoes ?? 0,
+      anomaly_count: c?.anomalias ?? 0,
+      is_overdue: diasAteVencer !== null && diasAteVencer < 0,
+      is_due_soon: diasAteVencer !== null && diasAteVencer >= 0 && diasAteVencer <= 7,
+      days_until_due: diasAteVencer,
+    };
+
+    const lista = porDono.get(ferramenta.user_id);
+    if (lista) lista.push(resumo);
+    else porDono.set(ferramenta.user_id, [resumo]);
+  }
+
+  const relatorios: RelatorioCliente[] = [];
+  for (const userId of idsDonos) {
+    const perfil = perfis.get(userId);
+    if (!perfil) {
+      // Dono de ferramenta sem linha em `profiles`. O código anterior (que partia de
+      // `profiles`) também o omitia, só que sem deixar rastro. Omitir em silêncio é o que
+      // transforma "relatório incompleto" em "relatório aparentemente completo".
+      console.warn(`monthly-report: user_id ${userId} tem ferramenta mas não tem profile — omitido`);
+      continue;
+    }
+    const resumos = (porDono.get(userId) ?? []).sort(ordenarFerramentas);
+    relatorios.push({
+      user_id: perfil.user_id,
+      name: perfil.name,
+      email: perfil.email,
+      phone: perfil.phone,
+      tools: resumos,
+      overdue_count: resumos.filter((f) => f.is_overdue).length,
+      due_soon_count: resumos.filter((f) => f.is_due_soon).length,
+      total_tools: resumos.length,
+    });
+  }
+
+  return relatorios;
+}

--- a/supabase/functions/_shared/relatorio-mensal.ts
+++ b/supabase/functions/_shared/relatorio-mensal.ts
@@ -59,8 +59,9 @@ export interface QueryPostgrest<T> extends PromiseLike<RespostaPostgrest<T>> {
 }
 
 export interface BancoPostgrest {
-  // deno-lint-ignore no-explicit-any
-  from(tabela: string): QueryPostgrest<any>;
+  // Genérico (e não `QueryPostgrest<unknown>`) para o call-site declarar a forma da linha
+  // que espera de cada tabela — é o que mantém `fetchAll<T>` tipado ponta a ponta.
+  from<T>(tabela: string): QueryPostgrest<T>;
 }
 
 interface LinhaFerramenta {
@@ -117,7 +118,7 @@ export async function montarRelatorios(
   // então percorrer a base de clientes para descobrir isso é trabalho jogado fora.
   // `fetchAll` + `.order('id')` porque o PostgREST capa em 1000 linhas SEM ERRO.
   const ferramentas = await fetchAll<LinhaFerramenta>((de, ate) => {
-    let q = db.from("user_tools").select("*, tool_categories(name)");
+    let q = db.from<LinhaFerramenta>("user_tools").select("*, tool_categories(name)");
     if (userIdAlvo) q = q.eq("user_id", userIdAlvo);
     return q.order("id", { ascending: true }).range(de, ate);
   }, "user_tools");
@@ -138,7 +139,7 @@ export async function montarRelatorios(
   const perfis = new Map<string, LinhaPerfil>();
   for (const lote of emLotes(idsDonos, LOTE_IDS)) {
     const linhas = await fetchAll<LinhaPerfil>((de, ate) =>
-      db.from("profiles").select("user_id, name, email, phone")
+      db.from<LinhaPerfil>("profiles").select("user_id, name, email, phone")
         .in("user_id", lote).order("user_id", { ascending: true }).range(de, ate), "profiles");
     for (const p of linhas) perfis.set(p.user_id, p);
   }
@@ -149,7 +150,7 @@ export async function montarRelatorios(
   const contagens = new Map<string, { afiacoes: number; anomalias: number }>();
   for (const lote of emLotes(ferramentas.map((f) => f.id), LOTE_IDS)) {
     const eventos = await fetchAll<LinhaEvento>((de, ate) =>
-      db.from("tool_events").select("user_tool_id, event_type")
+      db.from<LinhaEvento>("tool_events").select("user_tool_id, event_type")
         .in("user_tool_id", lote).order("id", { ascending: true }).range(de, ate), "tool_events");
     for (const ev of eventos) {
       const c = contagens.get(ev.user_tool_id) ?? { afiacoes: 0, anomalias: 0 };

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -1,0 +1,311 @@
+// Testa o CÓDIGO REAL de `montarRelatorios` (não uma cópia) no runtime real (Deno).
+// Roda com: deno test supabase/functions/_shared/relatorio-mensal_test.ts
+//
+// Os dois testes do bloco "INVARIANTES DE CUSTO" são a razão deste arquivo existir: eles
+// ficam VERMELHOS na implementação N+1 que vivia na edge (uma consulta a `user_tools` por
+// perfil + 2 counts por ferramenta ⇒ ~5.280 idas ao banco em prod, página em spinner
+// indefinido e cron mensal ameaçado pelo timeout de 150s).
+import {
+  type BancoPostgrest,
+  montarRelatorios,
+  type QueryPostgrest,
+  type RespostaPostgrest,
+} from "./relatorio-mensal.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+// deno-lint-ignore no-explicit-any
+type Linha = Record<string, any>;
+
+// Banco de memória fiel aos dois comportamentos do PostgREST que importam aqui:
+//  (1) conta cada ida ao banco (round-trip), para o invariante de custo;
+//  (2) CAPA em 1000 linhas, em silêncio, quando o call-site não usa `.range()`
+//      (docs/agent/database.md; o mesmo footgun que `_shared/paginate.ts` previne).
+function bancoFake(tabelas: Record<string, Linha[]>) {
+  const idas: string[] = [];
+
+  function query(tabela: string): QueryPostgrest<Linha> {
+    let linhas = [...(tabelas[tabela] ?? [])];
+    let contarSemCorpo = false;
+    let usouRange = false;
+
+    const q: QueryPostgrest<Linha> = {
+      select(_colunas, opts) {
+        if (opts?.head) contarSemCorpo = true;
+        return q;
+      },
+      eq(coluna, valor) {
+        linhas = linhas.filter((l) => l[coluna] === valor);
+        return q;
+      },
+      in(coluna, valores) {
+        const alvo = new Set(valores);
+        linhas = linhas.filter((l) => alvo.has(l[coluna]));
+        return q;
+      },
+      order(coluna, opts) {
+        const asc = opts?.ascending !== false;
+        linhas.sort((a, b) =>
+          a[coluna] < b[coluna] ? (asc ? -1 : 1) : a[coluna] > b[coluna] ? (asc ? 1 : -1) : 0
+        );
+        return q;
+      },
+      range(de, ate) {
+        usouRange = true;
+        linhas = linhas.slice(de, ate + 1);
+        return q;
+      },
+      then(aoResolver) {
+        idas.push(tabela);
+        // O cap silencioso: sem `.range()` explícito, a cauda além de 1000 some sem erro.
+        const corpo = usouRange ? linhas : linhas.slice(0, 1000);
+        const resposta: RespostaPostgrest<Linha> = contarSemCorpo
+          ? { data: null, count: corpo.length, error: null }
+          : { data: corpo, error: null };
+        return Promise.resolve(resposta).then(aoResolver);
+      },
+    };
+    return q;
+  }
+
+  return {
+    banco: { from: (tabela: string) => query(tabela) } as BancoPostgrest,
+    idas: () => idas,
+    idasA: (tabela: string) => idas.filter((t) => t === tabela).length,
+  };
+}
+
+const AGORA = new Date("2026-07-18T12:00:00Z");
+
+function perfil(user_id: string, extra: Linha = {}): Linha {
+  return { user_id, name: `Cliente ${user_id}`, email: null, phone: null, ...extra };
+}
+
+function ferramenta(id: string, user_id: string, extra: Linha = {}): Linha {
+  return {
+    id,
+    user_id,
+    internal_code: null,
+    generated_name: `Ferramenta ${id}`,
+    custom_name: null,
+    last_sharpened_at: null,
+    next_sharpening_due: null,
+    tool_categories: null,
+    ...extra,
+  };
+}
+
+// ── CONTRATO: o que o relatório entrega ─────────────────────────────────────
+
+Deno.test("só entra no relatório quem TEM ferramenta", async () => {
+  const f = bancoFake({
+    profiles: [perfil("u1"), perfil("u2"), perfil("u3")],
+    user_tools: [ferramenta("t1", "u2")],
+    tool_events: [],
+  });
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(rel.map((r) => r.user_id), ["u2"]);
+  assertEquals(rel[0].total_tools, 1);
+});
+
+Deno.test("conta afiações e anomalias por ferramenta, ignorando outros tipos de evento", async () => {
+  const f = bancoFake({
+    profiles: [perfil("u1")],
+    user_tools: [ferramenta("t1", "u1"), ferramenta("t2", "u1")],
+    tool_events: [
+      { id: "e1", user_tool_id: "t1", event_type: "sharpening" },
+      { id: "e2", user_tool_id: "t1", event_type: "sharpening" },
+      { id: "e3", user_tool_id: "t1", event_type: "anomaly" },
+      { id: "e4", user_tool_id: "t2", event_type: "sharpening" },
+      { id: "e5", user_tool_id: "t1", event_type: "inspection" }, // tipo alheio: não conta
+    ],
+  });
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  const porNome = Object.fromEntries(rel[0].tools.map((t) => [t.name, t]));
+  assertEquals(porNome["Ferramenta t1"].sharpening_count, 2);
+  assertEquals(porNome["Ferramenta t1"].anomaly_count, 1);
+  assertEquals(porNome["Ferramenta t2"].sharpening_count, 1);
+  assertEquals(porNome["Ferramenta t2"].anomaly_count, 0);
+});
+
+Deno.test("ferramenta sem evento nenhum conta zero (ausência real, não fabricação)", async () => {
+  const f = bancoFake({
+    profiles: [perfil("u1")],
+    user_tools: [ferramenta("t1", "u1")],
+    tool_events: [],
+  });
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(rel[0].tools[0].sharpening_count, 0);
+  assertEquals(rel[0].tools[0].anomaly_count, 0);
+});
+
+Deno.test("classifica atrasada / em breve / em dia e ordena nessa prioridade", async () => {
+  const f = bancoFake({
+    profiles: [perfil("u1")],
+    user_tools: [
+      ferramenta("t_ok", "u1", { next_sharpening_due: "2026-09-01T12:00:00Z" }),
+      ferramenta("t_breve", "u1", { next_sharpening_due: "2026-07-22T12:00:00Z" }),
+      ferramenta("t_atrasada", "u1", { next_sharpening_due: "2026-07-10T12:00:00Z" }),
+      ferramenta("t_sem_data", "u1", { next_sharpening_due: null }),
+    ],
+    tool_events: [],
+  });
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(rel[0].tools.map((t) => t.name), [
+    "Ferramenta t_atrasada",
+    "Ferramenta t_breve",
+    "Ferramenta t_ok",
+    "Ferramenta t_sem_data",
+  ]);
+  assertEquals(rel[0].overdue_count, 1);
+  assertEquals(rel[0].due_soon_count, 1);
+  assertEquals(rel[0].tools[0].days_until_due, -8);
+  // Sem data de vencimento não é atrasada nem "em breve" — degrada para null, não para zero.
+  const semData = rel[0].tools[3];
+  assertEquals(semData.days_until_due, null);
+  assertEquals([semData.is_overdue, semData.is_due_soon], [false, false]);
+});
+
+Deno.test("userIdAlvo restringe o relatório a um cliente", async () => {
+  const f = bancoFake({
+    profiles: [perfil("u1"), perfil("u2")],
+    user_tools: [ferramenta("t1", "u1"), ferramenta("t2", "u2")],
+    tool_events: [],
+  });
+  const rel = await montarRelatorios(f.banco, { agora: AGORA, userIdAlvo: "u2" });
+  assertEquals(rel.map((r) => r.user_id), ["u2"]);
+  assertEquals(rel[0].tools.map((t) => t.name), ["Ferramenta t2"]);
+});
+
+Deno.test("nome da ferramenta: generated_name → custom_name → categoria → fallback", async () => {
+  const f = bancoFake({
+    profiles: [perfil("u1")],
+    user_tools: [
+      ferramenta("t1", "u1", { generated_name: "Gerado" }),
+      ferramenta("t2", "u1", { generated_name: null, custom_name: "Customizado" }),
+      ferramenta("t3", "u1", {
+        generated_name: null,
+        custom_name: null,
+        tool_categories: { name: "Serra" },
+      }),
+      ferramenta("t4", "u1", { generated_name: null, custom_name: null }),
+    ],
+    tool_events: [],
+  });
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(rel[0].tools.map((t) => t.name).sort(), [
+    "Customizado",
+    "Ferramenta",
+    "Gerado",
+    "Serra",
+  ]);
+});
+
+// ── INVARIANTES DE CUSTO: o que esta unidade existe para proteger ───────────
+
+Deno.test("custo de banco NÃO cresce com o tamanho da base de clientes", async () => {
+  // Proporção real medida em prod (2026-07-18): 5.276 perfis, 4 ferramentas, 2 donos.
+  const perfis = Array.from({ length: 5276 }, (_, i) => perfil(`u${i}`));
+  const f = bancoFake({
+    profiles: perfis,
+    user_tools: [
+      ferramenta("t1", "u2495"),
+      ferramenta("t2", "u2495"),
+      ferramenta("t3", "u4700"),
+      ferramenta("t4", "u4700"),
+    ],
+    tool_events: [],
+  });
+
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(rel.length, 2, "os 2 donos de ferramenta têm de aparecer");
+
+  // Um teto folgado: o certo são ~3 consultas (+ páginas). O N+1 fazia ~5.280 e estourava aqui.
+  const total = f.idas().length;
+  assert(
+    total <= 10,
+    `custo de banco deveria ser O(1) na base de clientes, mas foram ${total} idas ao banco ` +
+      `(user_tools=${f.idasA("user_tools")}, tool_events=${f.idasA("tool_events")}, ` +
+      `profiles=${f.idasA("profiles")})`,
+  );
+});
+
+Deno.test("custo de banco NÃO cresce com o número de ferramentas (sem 2 counts por ferramenta)", async () => {
+  const ferramentas = Array.from({ length: 300 }, (_, i) => ferramenta(`t${i}`, "u1"));
+  const f = bancoFake({
+    profiles: [perfil("u1")],
+    user_tools: ferramentas,
+    tool_events: ferramentas.flatMap((t, i) => [
+      { id: `e${i}a`, user_tool_id: t.id, event_type: "sharpening" },
+      { id: `e${i}b`, user_tool_id: t.id, event_type: "anomaly" },
+    ]),
+  });
+
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(rel[0].total_tools, 300);
+  assertEquals(rel[0].tools.every((t) => t.sharpening_count === 1 && t.anomaly_count === 1), true);
+
+  const emEventos = f.idasA("tool_events");
+  assert(
+    emEventos <= 3,
+    `contagem de eventos deveria ser agregada, mas foram ${emEventos} consultas a tool_events ` +
+      `(o N+1 fazia 2 por ferramenta = 600)`,
+  );
+});
+
+Deno.test("dono de ferramenta além da linha 1000 NÃO some (cap silencioso do PostgREST)", async () => {
+  // A leitura de `profiles` sem `.range()` devolve só as 1000 primeiras, sem erro. Se o
+  // relatório partir dos perfis, o cliente na posição 4000 desaparece em silêncio.
+  const perfis = Array.from({ length: 5000 }, (_, i) => perfil(`u${String(i).padStart(4, "0")}`));
+  const f = bancoFake({
+    profiles: perfis,
+    user_tools: [ferramenta("t1", "u4000")],
+    tool_events: [],
+  });
+
+  const rel = await montarRelatorios(f.banco, { agora: AGORA });
+  assertEquals(
+    rel.map((r) => r.user_id),
+    ["u4000"],
+    "o dono na posição 4000 sumiu — a leitura foi truncada pelo cap de 1000",
+  );
+});
+
+Deno.test("erro do banco PROPAGA (fail-closed), não vira relatório vazio nem contagem zero", async () => {
+  const bancoQuebrado: BancoPostgrest = {
+    from: () => {
+      const q = {
+        select: () => q,
+        eq: () => q,
+        in: () => q,
+        order: () => q,
+        range: () => q,
+        // deno-lint-ignore no-explicit-any
+        then: (aoResolver: any) =>
+          Promise.resolve({ data: null, error: { message: "boom" } }).then(aoResolver),
+        // deno-lint-ignore no-explicit-any
+      } as any;
+      return q;
+    },
+  };
+
+  let lancou = false;
+  try {
+    await montarRelatorios(bancoQuebrado, { agora: AGORA });
+  } catch (e) {
+    lancou = true;
+    assert(
+      (e as Error).message.includes("boom"),
+      `erro deveria carregar a causa original, veio: ${(e as Error).message}`,
+    );
+  }
+  assertEquals(lancou, true, "erro de banco não pode ser engolido — relatório mudo é pior que 500");
+});

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -22,14 +22,14 @@ function assert(cond: boolean, msg: string) {
   if (!cond) throw new Error(msg);
 }
 
-// deno-lint-ignore no-explicit-any
-type Linha = Record<string, any>;
+type Linha = Record<string, unknown>;
 
 // Banco de memória fiel aos dois comportamentos do PostgREST que importam aqui:
 //  (1) conta cada ida ao banco (round-trip), para o invariante de custo;
 //  (2) CAPA em 1000 linhas, em silêncio, quando o call-site não usa `.range()`
 //      (docs/agent/database.md; o mesmo footgun que `_shared/paginate.ts` previne).
-function bancoFake(tabelas: Record<string, Linha[]>) {
+// `erroDoBanco` faz toda consulta falhar — para provar que o erro PROPAGA em vez de virar zero.
+function bancoFake(tabelas: Record<string, Linha[]>, erroDoBanco?: string) {
   const idas: string[] = [];
 
   function query(tabela: string): QueryPostgrest<Linha> {
@@ -52,10 +52,13 @@ function bancoFake(tabelas: Record<string, Linha[]>) {
         return q;
       },
       order(coluna, opts) {
+        // Textual: as colunas de ordenação aqui são ids, e `unknown` não compara com `<`.
         const asc = opts?.ascending !== false;
-        linhas.sort((a, b) =>
-          a[coluna] < b[coluna] ? (asc ? -1 : 1) : a[coluna] > b[coluna] ? (asc ? 1 : -1) : 0
-        );
+        linhas.sort((a, b) => {
+          const x = String(a[coluna] ?? "");
+          const y = String(b[coluna] ?? "");
+          return x < y ? (asc ? -1 : 1) : x > y ? (asc ? 1 : -1) : 0;
+        });
         return q;
       },
       range(de, ate) {
@@ -67,7 +70,9 @@ function bancoFake(tabelas: Record<string, Linha[]>) {
         idas.push(tabela);
         // O cap silencioso: sem `.range()` explícito, a cauda além de 1000 some sem erro.
         const corpo = usouRange ? linhas : linhas.slice(0, 1000);
-        const resposta: RespostaPostgrest<Linha> = contarSemCorpo
+        const resposta: RespostaPostgrest<Linha> = erroDoBanco
+          ? { data: null, error: { message: erroDoBanco } }
+          : contarSemCorpo
           ? { data: null, count: corpo.length, error: null }
           : { data: corpo, error: null };
         return Promise.resolve(resposta).then(aoResolver);
@@ -77,7 +82,11 @@ function bancoFake(tabelas: Record<string, Linha[]>) {
   }
 
   return {
-    banco: { from: (tabela: string) => query(tabela) } as BancoPostgrest,
+    banco: {
+      // Duplo cast do TEST DOUBLE: `query` devolve sempre `QueryPostgrest<Linha>`, que não
+      // satisfaz sozinho o `from<T>` genérico da interface real.
+      from: <T>(tabela: string) => query(tabela) as unknown as QueryPostgrest<T>,
+    } as BancoPostgrest,
     idas: () => idas,
     idasA: (tabela: string) => idas.filter((t) => t === tabela).length,
   };
@@ -280,26 +289,15 @@ Deno.test("dono de ferramenta além da linha 1000 NÃO some (cap silencioso do P
 });
 
 Deno.test("erro do banco PROPAGA (fail-closed), não vira relatório vazio nem contagem zero", async () => {
-  const bancoQuebrado: BancoPostgrest = {
-    from: () => {
-      const q = {
-        select: () => q,
-        eq: () => q,
-        in: () => q,
-        order: () => q,
-        range: () => q,
-        // deno-lint-ignore no-explicit-any
-        then: (aoResolver: any) =>
-          Promise.resolve({ data: null, error: { message: "boom" } }).then(aoResolver),
-        // deno-lint-ignore no-explicit-any
-      } as any;
-      return q;
-    },
-  };
+  const f = bancoFake({
+    profiles: [perfil("u1")],
+    user_tools: [ferramenta("t1", "u1")],
+    tool_events: [],
+  }, "boom");
 
   let lancou = false;
   try {
-    await montarRelatorios(bancoQuebrado, { agora: AGORA });
+    await montarRelatorios(f.banco, { agora: AGORA });
   } catch (e) {
     lancou = true;
     assert(

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -1,6 +1,11 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import {
+  type BancoPostgrest,
+  montarRelatorios,
+  type RelatorioCliente,
+} from "../_shared/relatorio-mensal.ts";
 // Resend usado via fetch direto à REST API (https://api.resend.com/emails) para evitar dep npm
 
 const corsHeaders = {
@@ -12,29 +17,9 @@ const corsHeaders = {
 // (gerar-pedidos-diario / disparar-pedidos-aprovados) — nunca hardcodar o domínio.
 const APP_URL = Deno.env.get('APP_URL') ?? 'https://steu.lovable.app';
 
-interface ToolSummary {
-  name: string;
-  internal_code: string | null;
-  category: string;
-  last_sharpened_at: string | null;
-  next_sharpening_due: string | null;
-  sharpening_count: number;
-  anomaly_count: number;
-  is_overdue: boolean;
-  is_due_soon: boolean;
-  days_until_due: number | null;
-}
-
-interface CustomerReport {
-  user_id: string;
-  name: string;
-  email: string | null;
-  phone: string | null;
-  tools: ToolSummary[];
-  overdue_count: number;
-  due_soon_count: number;
-  total_tools: number;
-}
+// A montagem do relatório (e o custo de banco dela) vive em `_shared/relatorio-mensal.ts`,
+// coberta por teste. Aqui ficam só HTTP, auth, template e envio.
+type CustomerReport = RelatorioCliente;
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return 'N/A';
@@ -260,84 +245,16 @@ serve(async (req) => {
     const sendEmail = body.send_email !== false;
     const previewOnly = body.preview_only === true;
 
-    let profilesQuery = supabase
-      .from('profiles')
-      .select('user_id, name, email, phone');
-    
-    if (targetUserId) {
-      profilesQuery = profilesQuery.eq('user_id', targetUserId);
-    }
+    // 3 consultas, independentemente do tamanho da base de clientes (medido: 5.276 perfis →
+    // 3 idas ao banco; a versão anterior fazia ~5.285 e não terminava). O invariante de custo
+    // é testado em `_shared/relatorio-mensal_test.ts`, não aqui.
+    const reports: CustomerReport[] = await montarRelatorios(
+      supabase as unknown as BancoPostgrest,
+      { userIdAlvo: targetUserId, agora: new Date() },
+    );
 
-    const { data: profiles, error: profilesError } = await profilesQuery;
-    if (profilesError) throw profilesError;
-
-    const reports: CustomerReport[] = [];
-
-    for (const profile of (profiles || [])) {
-      const { data: tools } = await supabase
-        .from('user_tools')
-        .select('*, tool_categories(name)')
-        .eq('user_id', profile.user_id);
-
-      if (!tools || tools.length === 0) continue;
-
-      const now = new Date();
-      const toolSummaries: ToolSummary[] = [];
-
-      for (const tool of tools) {
-        const { count: sharpeningCount } = await supabase
-          .from('tool_events')
-          .select('*', { count: 'exact', head: true })
-          .eq('user_tool_id', tool.id)
-          .eq('event_type', 'sharpening');
-
-        const { count: anomalyCount } = await supabase
-          .from('tool_events')
-          .select('*', { count: 'exact', head: true })
-          .eq('user_tool_id', tool.id)
-          .eq('event_type', 'anomaly');
-
-        const nextDue = tool.next_sharpening_due ? new Date(tool.next_sharpening_due) : null;
-        const daysUntilDue = nextDue 
-          ? Math.ceil((nextDue.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-          : null;
-
-        toolSummaries.push({
-          name: tool.generated_name || tool.custom_name || (tool.tool_categories as { name?: string } | null)?.name || 'Ferramenta',
-          internal_code: tool.internal_code,
-          category: (tool.tool_categories as { name?: string } | null)?.name || '',
-          last_sharpened_at: tool.last_sharpened_at,
-          next_sharpening_due: tool.next_sharpening_due,
-          sharpening_count: sharpeningCount || 0,
-          anomaly_count: anomalyCount || 0,
-          is_overdue: daysUntilDue !== null && daysUntilDue < 0,
-          is_due_soon: daysUntilDue !== null && daysUntilDue >= 0 && daysUntilDue <= 7,
-          days_until_due: daysUntilDue,
-        });
-      }
-
-      toolSummaries.sort((a, b) => {
-        if (a.is_overdue && !b.is_overdue) return -1;
-        if (!a.is_overdue && b.is_overdue) return 1;
-        if (a.is_due_soon && !b.is_due_soon) return -1;
-        if (!a.is_due_soon && b.is_due_soon) return 1;
-        return (a.days_until_due ?? 999) - (b.days_until_due ?? 999);
-      });
-
-      const report: CustomerReport = {
-        user_id: profile.user_id,
-        name: profile.name,
-        email: profile.email,
-        phone: profile.phone,
-        tools: toolSummaries,
-        overdue_count: toolSummaries.filter(t => t.is_overdue).length,
-        due_soon_count: toolSummaries.filter(t => t.is_due_soon).length,
-        total_tools: toolSummaries.length,
-      };
-
-      reports.push(report);
-
-      if (sendEmail && !previewOnly && resendApiKey && profile.email) {
+    for (const report of reports) {
+      if (sendEmail && !previewOnly && resendApiKey && report.email) {
         const html = generateEmailHtml(report);
 
         try {
@@ -349,18 +266,18 @@ serve(async (req) => {
             },
             body: JSON.stringify({
               from: 'Colacor <noreply@colacor.com.br>',
-              to: [profile.email],
+              to: [report.email],
               subject: `🔧 Relatório Mensal de Ferramentas - ${report.overdue_count > 0 ? `${report.overdue_count} ferramenta(s) atrasada(s)` : 'Tudo em dia!'}`,
               html,
             }),
           });
           if (!resp.ok) {
-            console.error(`Failed to send email to ${profile.email}: HTTP ${resp.status}`);
+            console.error(`Failed to send email to ${report.email}: HTTP ${resp.status}`);
           } else {
-            console.log(`Email sent to ${profile.email}`);
+            console.log(`Email sent to ${report.email}`);
           }
         } catch (emailErr) {
-          console.error(`Failed to send email to ${profile.email}:`, emailErr);
+          console.error(`Failed to send email to ${report.email}:`, emailErr);
         }
       }
     }


### PR DESCRIPTION
## O problema

O handler partia de `profiles` (**5.276 linhas** em prod) e, para CADA perfil, consultava `user_tools` — mais 2 counts em `tool_events` por ferramenta. **~5.285 consultas SEQUENCIAIS** para descobrir que 5.274 clientes não têm ferramenta alguma.

Sintoma confirmado pelo founder: `/admin/monthly-reports` → "Pré-visualizar Relatórios" ficava em spinner indefinido. Invocar a edge com `user_id` no body (que filtra 1 perfil) respondia normal — isolando o N+1.

Medido em prod via `psql-ro` em 2026-07-18: `profiles`=5.276 · `user_tools`=**4** (2 donos) · `tool_events`=**0**.

## A correção

Inverte a direção: parte de `user_tools` (4 linhas), busca os perfis desses donos, e troca os 2 counts por ferramenta por **uma** agregação de `tool_events` em memória.

**Medido na forma real de prod: 5.285 → 3 idas ao banco**, constantes na base de clientes.

```
relatórios gerados : 2
IDAS AO BANCO      : 3  →  user_tools, profiles, tool_events
(N+1 anterior      : 1 + 5.276 + 8 = 5.285)
```

## Por que a lógica saiu do `index.ts`

A montagem foi para `_shared/relatorio-mensal.ts` com o **banco injetado**. Não é gosto por camadas: é o que permite testar o invariante que importa aqui — **quantas vezes a função vai ao banco**. Edge é Deno e fica fora do vitest do `src/`; `_shared/*_test.ts` é onde o repo já testa lógica de edge.

O núcleo foi primeiro portado **verbatim** (N+1 e tudo) e só então testado:

| | porte N+1 | após a correção |
|---|---|---|
| 7 testes de contrato | ✅ verde | ✅ verde |
| 3 testes de custo/cap | ❌ **vermelho** | ✅ verde |

Os contratos verdes nas duas colunas provam que o comportamento foi preservado; os 3 vermelhos provam que o teste **detecta** o N+1 em vez de decorar o resultado.

## Dois defeitos latentes que a mesma inversão corrige

- **Cap silencioso de 1.000 linhas do PostgREST.** A leitura de `profiles` não tinha `.order()`/`.range()`, então **4.276 dos 5.276 perfis eram descartados sem erro**. Hoje não mordia *por sorte* — os 2 donos estão nas posições 3 e 119 do heap — mas posição de heap muda a cada `UPDATE`: um cliente editado podia sumir do relatório em silêncio. (Na simulação do teste, com os donos em 2495/4700, o relatório sai **vazio**.)
- **Erro de leitura virava zero.** `count || 0` transformava falha de consulta em "0 afiações" — fabricação de número. Agora o erro **propaga**.

Dono de ferramenta sem `profiles` continua fora do relatório (como antes), mas agora com `console.warn` em vez de omissão muda.

## O cron: a pergunta em aberto tem resposta — e não é timeout

`cron.job_run_details` está vazio para o jobid 37 por **retenção**, não por falha:

| tabela | janela real medida | cadência do job |
|---|---|---|
| `cron.job_run_details` | 7 dias (mais antigo: 2026-07-11) | `0 9 1 * *` |
| `net._http_response` | `pg_net.ttl = 6 horas` | mensal |

**Um cron mensal nunca pode ser observado post-hoc por essas duas tabelas** — a execução de 1º de julho já tinha sido purgada dias antes de alguém olhar. O vazio não é evidência de falha; é ausência de evidência. (Observabilidade de cron mensal é um problema estrutural em aberto, não resolvido aqui.)

## ⚠️ Achado independente: o cron entrega ZERO e-mails hoje

Os 2 únicos donos de ferramenta têm `profiles.email IS NULL` (são aliases fiscais `@placeholder.local` do import do Omie). O envio é gateado por `report.email` → o `fetch` para a Resend nunca acontece. **Isso não é causado pelo N+1 e não é resolvido por este PR.** Chip aberto em separado.

## Verificação

- `deno check` na edge, com o `SupabaseClient` real — o cast compila ✅
- **129** testes de edge (119 pré-existentes + 10 novos) ✅
- **5.356** testes do vitest, 600 arquivos ✅
- Colunas lidas conferidas em prod (`user_tools`, `tool_events`, `profiles`, `tool_categories`) ✅
- Pré-flight do `deploy.md`: a edge não chama RPC nenhuma ✅
- `deno lint`: **zero problema novo** (os 3 no arquivo são pré-existentes — 2 `no-import-prefix` nas linhas de import não tocadas, padrão obrigatório de edge Supabase; 1 `no-unused-vars` em `authenticateRequest`, código morto anterior)

## 🚨 Deploy — merge NÃO é produção

Esta edge é **deploy MANUAL pelo chat do Lovable** (`docs/agent/deploy.md`). Atenção: o PR adiciona um **arquivo NOVO** (`_shared/relatorio-mensal.ts`) que o deploy precisa levar junto — não é só o `index.ts`.

Descoberto durante o #1413 (CTA para domínio morto), separado de propósito para não misturar escopos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)