### PR TITLE
fix(monthly-report): torna CONTÁVEL o cliente que fica sem relatório por falta de contato

### DIFF
--- a/supabase/functions/_shared/relatorio-mensal.ts
+++ b/supabase/functions/_shared/relatorio-mensal.ts
@@ -40,6 +40,31 @@ export interface RelatorioCliente {
   total_tools: number;
 }
 
+/**
+ * Por que um cliente COM ferramenta não recebe o relatório por e-mail.
+ *
+ * Existe para tornar o pulo CONTÁVEL. O envio é gateado por `report.email`, e um cliente sem
+ * e-mail simplesmente não recebia nada — sem log, sem contador, sem rastro. O cron
+ * `monthly-tool-report` (`0 9 1 * *`) entregou ZERO e-mails desde sempre e isso só apareceu
+ * quando alguém foi medir o banco à mão, em 2026-07-18 (#1436, que pausou o cron).
+ *
+ * Distingue dois casos porque a AÇÃO é diferente, e a diferença foi medida em prod:
+ *  · `sem_email`        → tem telefone; o `whatsapp_url` que a edge devolve é acionável pelo
+ *                         staff. Degradou de canal, mas o cliente é alcançável.
+ *  · `sem_canal_nenhum` → nem e-mail nem telefone; `whatsapp_url` sai `null` e o cliente é
+ *                         INVISÍVEL por qualquer via. Era o caso dos 2 únicos donos de
+ *                         ferramenta em prod. Um contador único não separaria "mudou de canal"
+ *                         de "não há canal", que é justamente a informação que faltava.
+ */
+export type MotivoSemEnvio = "sem_email" | "sem_canal_nenhum";
+
+export function motivoSemEnvio(
+  cliente: Pick<RelatorioCliente, "email" | "phone">,
+): MotivoSemEnvio | null {
+  if (cliente.email) return null;
+  return cliente.phone ? "sem_email" : "sem_canal_nenhum";
+}
+
 // ── Contrato mínimo do PostgREST que este núcleo usa ────────────────────────
 // Estrutural de propósito: o `SupabaseClient` real satisfaz sem adaptador, e o teste
 // satisfaz com um banco de memória que conta chamadas.

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -8,6 +8,7 @@
 import {
   type BancoPostgrest,
   montarRelatorios,
+  motivoSemEnvio,
   type QueryPostgrest,
   type RespostaPostgrest,
 } from "./relatorio-mensal.ts";
@@ -306,4 +307,32 @@ Deno.test("erro do banco PROPAGA (fail-closed), não vira relatório vazio nem c
     );
   }
   assertEquals(lancou, true, "erro de banco não pode ser engolido — relatório mudo é pior que 500");
+});
+
+// ── CONTATO: por que um cliente com ferramenta fica sem relatório ────────────
+// Estes existem porque o pulo por falta de contato era SILENCIOSO: o envio é gateado por
+// `report.email` e quem não tinha e-mail simplesmente não recebia nada, sem log nem contador.
+// O cron entregou zero e-mails desde sempre e só apareceu ao medir o banco à mão (#1436).
+
+Deno.test("quem tem e-mail não é pulado — independente de ter telefone", () => {
+  assertEquals(motivoSemEnvio({ email: "a@b.com", phone: "11999999999" }), null);
+  assertEquals(motivoSemEnvio({ email: "a@b.com", phone: null }), null);
+});
+
+Deno.test("sem e-mail MAS com telefone → sem_email (alcançável pelo whatsapp_url)", () => {
+  assertEquals(motivoSemEnvio({ email: null, phone: "11999999999" }), "sem_email");
+});
+
+Deno.test("sem e-mail e sem telefone → sem_canal_nenhum (invisível por qualquer via)", () => {
+  // O caso real dos 2 únicos donos de ferramenta em prod (2026-07-18): `whatsapp_url` sai
+  // `null`, então nem o fallback manual do staff existe.
+  assertEquals(motivoSemEnvio({ email: null, phone: null }), "sem_canal_nenhum");
+});
+
+Deno.test("string vazia conta como ausência de canal, não como canal válido", () => {
+  // `''` é falsy em JS, então o gate `&& report.email` do index.ts já o trataria como ausente.
+  // Se a classificação discordasse do gate, o contador mentiria justamente no caso em que o
+  // e-mail existe na coluna mas não serve para enviar.
+  assertEquals(motivoSemEnvio({ email: "", phone: "" }), "sem_canal_nenhum");
+  assertEquals(motivoSemEnvio({ email: "", phone: "11999999999" }), "sem_email");
 });

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -4,6 +4,8 @@ import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import {
   type BancoPostgrest,
   montarRelatorios,
+  type MotivoSemEnvio,
+  motivoSemEnvio,
   type RelatorioCliente,
 } from "../_shared/relatorio-mensal.ts";
 // Resend usado via fetch direto à REST API (https://api.resend.com/emails) para evitar dep npm
@@ -253,8 +255,29 @@ serve(async (req) => {
       { userIdAlvo: targetUserId, agora: new Date() },
     );
 
+    // Contadores de entrega: é o que distingue "rodou e não havia para quem enviar" de
+    // "rodou e entregou". Sem eles, uma execução que entrega ZERO é indistinguível de uma
+    // bem-sucedida — foi assim que o cron entregou zero e-mails por meses sem ninguém notar.
+    // Os logs identificam por `user_id`, NUNCA por e-mail/telefone: log de edge não é lugar
+    // de dado pessoal de cliente.
+    const semContato: Record<MotivoSemEnvio, number> = { sem_email: 0, sem_canal_nenhum: 0 };
+    let enviados = 0;
+    let falhasEnvio = 0;
+
     for (const report of reports) {
-      if (sendEmail && !previewOnly && resendApiKey && report.email) {
+      // Classificado SEMPRE, inclusive em preview/`send_email:false` — "quantos clientes estão
+      // inalcançáveis" é um fato sobre o cadastro, não sobre o modo desta invocação.
+      const motivo = motivoSemEnvio(report);
+      if (motivo) {
+        semContato[motivo]++;
+        console.warn(
+          `monthly-report: user_id ${report.user_id} PULADO (${motivo}) — ` +
+          `${report.total_tools} ferramenta(s), ${report.overdue_count} atrasada(s)`,
+        );
+        continue;
+      }
+
+      if (sendEmail && !previewOnly && resendApiKey) {
         const html = generateEmailHtml(report);
 
         try {
@@ -272,14 +295,26 @@ serve(async (req) => {
             }),
           });
           if (!resp.ok) {
-            console.error(`Failed to send email to ${report.email}: HTTP ${resp.status}`);
+            falhasEnvio++;
+            console.error(`monthly-report: envio FALHOU p/ user_id ${report.user_id}: HTTP ${resp.status}`);
           } else {
-            console.log(`Email sent to ${report.email}`);
+            enviados++;
+            console.log(`monthly-report: enviado p/ user_id ${report.user_id}`);
           }
         } catch (emailErr) {
-          console.error(`Failed to send email to ${report.email}:`, emailErr);
+          falhasEnvio++;
+          console.error(`monthly-report: envio FALHOU p/ user_id ${report.user_id}:`, emailErr);
         }
       }
+    }
+
+    const puladosTotal = semContato.sem_email + semContato.sem_canal_nenhum;
+    if (puladosTotal > 0) {
+      console.warn(
+        `monthly-report: ${puladosTotal} de ${reports.length} cliente(s) com ferramenta ficaram ` +
+        `SEM relatório por falta de contato (${semContato.sem_email} sem e-mail mas com telefone, ` +
+        `${semContato.sem_canal_nenhum} sem canal nenhum).`,
+      );
     }
 
     const reportsWithWhatsApp = reports.map(report => ({
@@ -291,9 +326,15 @@ serve(async (req) => {
       email_html: previewOnly ? generateEmailHtml(report) : undefined,
     }));
 
-    return new Response(JSON.stringify({ 
-      success: true, 
+    return new Response(JSON.stringify({
+      success: true,
       reports_count: reportsWithWhatsApp.length,
+      // `success: true` + `reports_count: 0` sempre foi ambíguo entre "ninguém tem ferramenta"
+      // e "todo mundo ficou sem contato". Estes campos desambiguam sem precisar ir ao banco.
+      emails_enviados: enviados,
+      falhas_envio: falhasEnvio,
+      pulados_sem_contato: puladosTotal,
+      pulados_detalhe: semContato,
       reports: reportsWithWhatsApp,
     }), {
       status: 200,


### PR DESCRIPTION
Implementa a decisão **(c)** de 2026-07-18: a edge deve **logar o pulo e contar no retorno**, em vez do silêncio atual.

## O problema

O envio é gateado por `report.email`. Quem não tem e-mail simplesmente não recebia nada — sem log, sem contador, sem rastro. E `success: true` + `reports_count: 0` era ambíguo entre *"ninguém tem ferramenta"* e *"todo mundo ficou sem contato"*.

Foi exatamente assim que o cron `monthly-tool-report` entregou **zero e-mails por meses** sem ninguém notar. Só apareceu quando alguém foi medir o banco à mão ([#1436](https://github.com/LucasSardenbergL/afiacao/pull/1436), que pausou o cron).

## Dois motivos, não um

A classificação distingue dois casos porque **a ação é diferente**, e a diferença foi medida em prod:

| Motivo | Situação | Consequência |
|---|---|---|
| `sem_email` | tem telefone | o `whatsapp_url` que a edge já devolve é acionável pelo staff — degradou de canal, mas o cliente é **alcançável** |
| `sem_canal_nenhum` | nem e-mail nem telefone | `whatsapp_url` sai `null` — o cliente é **invisível por qualquer via** |

Os 2 únicos donos de ferramenta em prod caem no segundo caso. Um contador único não separaria "mudou de canal" de "não há canal" — que é justamente a informação que faltava.

A classificação roda **sempre**, inclusive em preview e `send_email:false`: "quantos clientes estão inalcançáveis" é fato sobre o cadastro, não sobre o modo da invocação.

## Retorno

Ganha `emails_enviados`, `falhas_envio`, `pulados_sem_contato` e `pulados_detalhe`. Antes não havia como distinguir entrega de silêncio sem ir ao banco.

## LGPD

Os logs deste bloco passam a identificar por `user_id`, **nunca** por e-mail/telefone. Isso corrige de passagem os `Email sent to ${report.email}` que já existiam nas linhas reescritas aqui — log de edge não é lugar de dado pessoal de cliente.

## Prova — falsificada, não só verde

4 testes novos (14 no total, todos verdes). Mas verde não prova dente, então **sabotei a classificação de 3 formas e exigi vermelho**:

| Sabotagem | Resultado |
|---|---|
| sempre retornar `null` (o bug original — silêncio total) | 🔴 vermelho |
| inverter `sem_email` ↔ `sem_canal_nenhum` | 🔴 vermelho |
| tratar `''` como canal válido (`!== null` em vez de falsy) | 🔴 vermelho |
| restaurar | 🟢 verde |

A terceira importa porque o gate real do `index.ts` é falsy (`&& report.email`): se a classificação discordasse dele, o contador mentiria exatamente no caso em que o e-mail existe na coluna mas não serve para enviar.

`deno check` da edge e `bun lint` verdes (0 errors).

## ⚠️ Correção factual sobre o #1436

O [#1436](https://github.com/LucasSardenbergL/afiacao/pull/1436) descreve os 2 donos de ferramenta como **"aliases fiscais do import Omie"**. **Isso está errado** e eu propaguei sem verificar. Medido agora:

- **LOHAN MOVEIS LTDA tem 52 pedidos reais** nas contas `colacor` e `oben` — é cliente ativo, não alias.
- Pela própria heurística do CLAUDE.md, alias fiscal é `@placeholder.local` **sem** `profiles`; ambos **têm** `profiles`.
- `@placeholder.local` não discrimina nada: **5.665 dos 7.302** users com esse domínio têm profile.

O veredito do #1436 não muda (seguem sem e-mail e sem telefone, e `tool_events` segue sem writer), mas a caracterização estava incorreta e fica corrigida aqui.

Isso também **reforça a decisão (b)**: se LOHAN compra 52 vezes, o Omie certamente tem o contato dele. E o escopo é pequeno — de 1.181 clientes com pedidos, só **21 estão sem e-mail** e apenas **2 sem canal nenhum**.

## Não reativa o cron

O relatório segue pausado (#1436). Esta instrumentação protege o dia em que for religado.

## 💬 Deploy de edge necessário

Mergear não deploya. Depois do merge, peça no chat do Lovable o deploy **verbatim** de `monthly-report` lendo do repo. Sem urgência — o cron está pausado, então a edge só roda por invocação manual em `/admin/monthly-reports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)