### PR TITLE
fix(types): restaura preco_csv_legado que o bot do Lovable removeu — main vermelha, 11 PRs parados

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -17791,6 +17791,7 @@ export type Database = {
           is_sl: boolean | null
           nome_cor: string | null
           personalizada: boolean | null
+          preco_csv_legado: number | null
           preco_final_sayersystem: number | null
           receita_valida: boolean | null
           sku_id: string | null


### PR DESCRIPTION
## 🔴 A `main` está vermelha e todo PR do repo está parado

Fecha (ou ao menos destrava) a Issue #1442.

O commit **`2e6b1614 Changes`** (`gpt-engineer-app[bot]`, 21:41) apagou **uma linha** de `src/integrations/supabase/types.ts`:

```diff
-          preco_csv_legado: number | null      # Row de v_tint_formula_canonica
```

É exatamente a linha que o [#1439](https://github.com/LucasSardenbergL/afiacao/pull/1439) (Fase 2b do tintométrico, **money-path**) acrescentou 66 minutos antes.

## Linha do tempo

| horário | evento |
|---|---|
| 20:35 | #1439 mergeia e **adiciona** `preco_csv_legado` ao `types.ts` |
| 21:41 | `2e6b1614` (bot, direto na `main`, **sem CI**) **remove** a linha |
| 21:41:42 | `validate` da `main` → ❌ (run 29662069067) |
| desde então | auto-merge espera o verde → **11 PRs abertos parados** |

## Por que derruba o CI

`src/components/tintColorSelect/useTintColorSelect.ts` cita `preco_csv_legado` em 3 `.select()` e em 2 leituras de campo. Essas strings são verificadas contra o `types.ts`, então remover o tipo derruba o `tsc --noEmit -p tsconfig.app.json` — **passo 5** do `validate`, que aborta os 9 seguintes.

## O código não está errado — o tipo é que divergiu do banco

Este é o ponto que decide o conserto. Conferido em produção via `psql-ro` **antes** de restaurar:

```
v_tint_formula_canonica → 13 colunas; a 13ª é preco_csv_legado (numeric, nullable)
```

A coluna **existe**. Não é caso de remover o uso no código: é a regeneração de tipos do bot que ficou fora de sincronia com o schema real.

## Dano isolado

Rodei `git show <sha> -- src/integrations/supabase/types.ts` nos **3** commits do bot desta janela (`5a498ea8`, `2e6b1614`, `98752992`): só o `2e6b1614` alterou linha, e só essa. Os outros dois mexeram em `mcp/` e `.lovable/`.

Restaurada na posição alfabética (entre `personalizada` e `preco_final_sayersystem`), que é onde o gerador a emite — o diff é **+1 linha**, nada mais.

## Procedência

Armadilha já documentada em `docs/agent/deploy.md` §"Quando o Lovable reverte um fix — detectar e restaurar": o bot commita direto na `main` sem CI e às vezes desfaz um PR; o jogo é **MTTR** — restaurar por PR, **nunca** direto na `main`, que vira guerra de commits.

Encontrado de lado: meu PR #1443, que só mexe em 2 arquivos `.md`, falhou no typecheck — o que só era possível se a base estivesse quebrada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
