### PR TITLE
fix(types): re-adiciona preco_csv_legado apagado pela regeneração do Lovable — conserta main vermelha

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -17791,6 +17791,7 @@ export type Database = {
           is_sl: boolean | null
           nome_cor: string | null
           personalizada: boolean | null
+          preco_csv_legado: number | null
           preco_final_sayersystem: number | null
           receita_valida: boolean | null
           sku_id: string | null


### PR DESCRIPTION
## O que é

**Hotfix da main vermelha (issue #1442).** O commit `2e6b1614` ("Changes" — regeneração do Lovable, push direto na main) reescreveu `src/integrations/supabase/types.ts` a partir de schema **anterior** ao apply da migration `20260718233000` (Fase 2b, #1439) e **apagou a coluna `preco_csv_legado`** da view `v_tint_formula_canonica`. O typecheck da main quebrou (o hook do picker seleciona a coluna) e todo PR novo herda o vermelho (primeiro a sentir: #1446).

**O banco e o app estão certos** — a coluna existe em prod (validada via psql-ro; picker publicado funcionando). Só o tipo sumiu. Fix: 1 linha re-adicionada na posição alfabética, preservando o shape novo do gerador.

## Lição (registrada no commit)

Regeneração do Lovable entre o merge do PR e o apply manual da migration reverte adição manual de tipo. Sintoma: main vermelha com `SelectQueryError<"column X does not exist">`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)