### PR TITLE
fix(tipos): types.ts ganha preco_csv_legado — destrava o validate de todo PR aberto

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -17791,6 +17791,7 @@ export type Database = {
           is_sl: boolean | null
           nome_cor: string | null
           personalizada: boolean | null
+          preco_csv_legado: number | null
           preco_final_sayersystem: number | null
           receita_valida: boolean | null
           sku_id: string | null


### PR DESCRIPTION
**Uma linha.** Destrava o CI de todos os PRs abertos.

## O que aconteceu

O [#1439](https://github.com/LucasSardenbergL/afiacao/pull/1439) (tintométrico Fase 2b) aplicou a migration que adiciona `preco_csv_legado` a `v_tint_formula_canonica`. A coluna **existe em produção** — conferido por psql-ro:

```
preco_csv_legado | numeric | YES
```

Mas o `types.ts` **não foi regenerado**. Sem a coluna no tipo, o `supabase-js` infere `SelectQueryError<"column 'preco_csv_legado' does not exist…">` e o `useTintColorSelect.ts` quebra com **17 erros** TS2339/TS2352.

## Por que isso merece um PR próprio

O efeito **não fica no domínio de quem causou**: o `validate` cai em *todo* PR aberto, apontando um arquivo que o autor não tocou. Foi assim que apareceu — no [#1444](https://github.com/LucasSardenbergL/afiacao/pull/1444), que é de carteira e não encosta em tintométrico.

Corrigir num PR mínimo destrava todos de uma vez, em vez de cada PR carregar o conserto alheio e misturar escopos.

## A armadilha (variante nova)

O ritual do repo cobre bem *"a migration foi aplicada?"* — e aqui **ela foi**. O passo que ficou para trás é o **quarto**: regenerar os tipos. O sintoma é enganoso porque aparece longe da causa e some da vista de quem a produziu.

Talvez valha uma linha no `CLAUDE.md`: *migration que altera view/tabela lida pelo front exige `types.ts` regenerado no mesmo PR*.

## Validação

O tipo corresponde ao medido em produção (`numeric` NULLABLE → `number | null`), na posição alfabética que o gerador do Supabase usa. Deixo o `validate` do CI ser a prova — a máquina local está em swap com 3 sessões pesadas, e o runner valida sem disputar RAM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)