### PR TITLE
refactor(monthly-report): uma cópia só do gate de envio + invariante de conservação sob teste

### DIFF
--- a/supabase/functions/_shared/relatorio-mensal.ts
+++ b/supabase/functions/_shared/relatorio-mensal.ts
@@ -65,6 +65,68 @@ export function motivoSemEnvio(
   return cliente.phone ? "sem_email" : "sem_canal_nenhum";
 }
 
+/**
+ * Por que um relatório MONTADO não gera tentativa de envio. Estende `MotivoSemEnvio` (que é
+ * sobre o CADASTRO) com os dois motivos que são sobre a INVOCAÇÃO/AMBIENTE.
+ */
+export type MotivoPulo = MotivoSemEnvio | "sem_chave_resend" | "envio_desarmado";
+
+export interface PlanoEnvio {
+  /** Recebem tentativa de envio. */
+  destinatarios: RelatorioCliente[];
+  /** Não recebem, com o porquê. Puro: quem loga é o call-site. */
+  pulados: Array<{ report: RelatorioCliente; motivo: MotivoPulo }>;
+}
+
+/**
+ * Parte os relatórios montados em "vai tentar enviar" × "não vai, e por quê".
+ *
+ * ⚠️ ESTA É A ÚNICA CÓPIA DO GATE DE ENVIO — é isso que a função existe para garantir.
+ * Antes, a classificação (`motivoSemEnvio`) e o gate real (`if (... && resendApiKey)`) eram
+ * duas expressões separadas, e elas DIVERGIRAM: com a chave da Resend ausente, um cliente
+ * com e-mail não era pulado por contato (a classificação devolvia `null`) nem tentado (o
+ * gate barrava) — não aparecia em contador nenhum e os totais fechavam em zero como se
+ * estivesse tudo certo. A mesma entrega-zero silenciosa que a instrumentação foi criada
+ * para acabar, entrando por outra porta (#1438 → #1440).
+ *
+ * A INVARIANTE que fecha essa classe inteira de buraco: `destinatarios + pulados` cobre
+ * `reports` EXATAMENTE, sem sobra nem repetição — nenhum relatório evapora. Vale por
+ * construção (cada item faz exatamente um `push`) e está sob teste de conservação em
+ * `relatorio-mensal_test.ts`. Ao acrescentar uma condição de pulo, ela entra AQUI, com
+ * motivo próprio; um `continue` novo no call-site reabre o buraco sem o teste perceber.
+ */
+export function planejarEnvios(
+  reports: readonly RelatorioCliente[],
+  opts: { envioArmado: boolean; temChaveResend: boolean },
+): PlanoEnvio {
+  const destinatarios: RelatorioCliente[] = [];
+  const pulados: Array<{ report: RelatorioCliente; motivo: MotivoPulo }> = [];
+
+  for (const report of reports) {
+    // Contato é avaliado PRIMEIRO e SEMPRE, inclusive em preview: "quantos clientes estão
+    // inalcançáveis" é fato sobre o cadastro, não sobre o modo desta invocação.
+    const semContato = motivoSemEnvio(report);
+    if (semContato) {
+      pulados.push({ report, motivo: semContato });
+      continue;
+    }
+    // Alcançável, mas esta invocação não é de envio (preview / `send_email:false`).
+    if (!opts.envioArmado) {
+      pulados.push({ report, motivo: "envio_desarmado" });
+      continue;
+    }
+    // Alcançável e o envio foi PEDIDO, mas o ambiente não tem a chave: é falha de
+    // configuração, não do cadastro — e é o caso que sumia dos totais.
+    if (!opts.temChaveResend) {
+      pulados.push({ report, motivo: "sem_chave_resend" });
+      continue;
+    }
+    destinatarios.push(report);
+  }
+
+  return { destinatarios, pulados };
+}
+
 // ── Contrato mínimo do PostgREST que este núcleo usa ────────────────────────
 // Estrutural de propósito: o `SupabaseClient` real satisfaz sem adaptador, e o teste
 // satisfaz com um banco de memória que conta chamadas.

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -9,6 +9,7 @@ import {
   type BancoPostgrest,
   montarRelatorios,
   motivoSemEnvio,
+  planejarEnvios,
   type QueryPostgrest,
   type RespostaPostgrest,
 } from "./relatorio-mensal.ts";
@@ -335,4 +336,72 @@ Deno.test("string vazia conta como ausência de canal, não como canal válido",
   // e-mail existe na coluna mas não serve para enviar.
   assertEquals(motivoSemEnvio({ email: "", phone: "" }), "sem_canal_nenhum");
   assertEquals(motivoSemEnvio({ email: "", phone: "11999999999" }), "sem_email");
+});
+
+// ── CONSERVAÇÃO: nenhum relatório pode evaporar ─────────────────────────────
+// Este bloco é a razão de `planejarEnvios` existir. Em #1438 a classificação de contato e o
+// gate real de envio eram expressões SEPARADAS, e divergiram: com a chave da Resend ausente,
+// um cliente com e-mail não era pulado por contato nem tentado — sumia de todos os totais e a
+// execução parecia bem-sucedida. Testar só a classificação (os testes acima) NÃO pega isso;
+// o que pega é exigir que a partição cubra a entrada inteira.
+
+function clientes(n: number, molde: (i: number) => { email: string | null; phone: string | null }) {
+  return Array.from({ length: n }, (_, i) => ({
+    user_id: `u${i}`,
+    name: `Cliente ${i}`,
+    ...molde(i),
+    tools: [],
+    overdue_count: 0,
+    due_soon_count: 0,
+    total_tools: 1,
+  }));
+}
+
+// Mistura os quatro casos de propósito: com contato, só telefone, sem canal, e de novo.
+const AMOSTRA = clientes(12, (i) => {
+  if (i % 4 === 0) return { email: `c${i}@x.com`, phone: "11999999999" };
+  if (i % 4 === 1) return { email: null, phone: "11999999999" };
+  if (i % 4 === 2) return { email: null, phone: null };
+  return { email: `c${i}@x.com`, phone: null };
+});
+
+for (
+  const cenario of [
+    { nome: "envio armado, com chave", envioArmado: true, temChaveResend: true },
+    { nome: "envio armado, SEM chave (o buraco do #1438)", envioArmado: true, temChaveResend: false },
+    { nome: "preview (envio desarmado), com chave", envioArmado: false, temChaveResend: true },
+    { nome: "preview, sem chave", envioArmado: false, temChaveResend: false },
+  ]
+) {
+  Deno.test(`conservação: nenhum relatório evapora — ${cenario.nome}`, () => {
+    const plano = planejarEnvios(AMOSTRA, cenario);
+    assertEquals(
+      plano.destinatarios.length + plano.pulados.length,
+      AMOSTRA.length,
+      `partição não cobre a entrada: ${plano.destinatarios.length} + ${plano.pulados.length} ≠ ${AMOSTRA.length}`,
+    );
+    // Cobrir por contagem não basta: o mesmo item duas vezes compensaria uma ausência.
+    const ids = [...plano.destinatarios, ...plano.pulados.map((p) => p.report)].map((r) => r.user_id);
+    assertEquals(new Set(ids).size, AMOSTRA.length, "algum relatório foi contado duas vezes");
+  });
+}
+
+Deno.test("conservação vale para a lista vazia", () => {
+  const plano = planejarEnvios([], { envioArmado: true, temChaveResend: true });
+  assertEquals(plano.destinatarios.length + plano.pulados.length, 0);
+});
+
+Deno.test("SEM chave da Resend: alcançável não vira destinatário — vira pulo CONTADO", () => {
+  // O caso exato que sumia. Cliente com e-mail, envio pedido, ambiente sem chave.
+  const so1 = clientes(1, () => ({ email: "a@b.com", phone: "11999999999" }));
+  const plano = planejarEnvios(so1, { envioArmado: true, temChaveResend: false });
+  assertEquals(plano.destinatarios.length, 0, "não pode tentar enviar sem chave");
+  assertEquals(plano.pulados.length, 1, "e não pode sumir: tem que aparecer como pulo");
+  assertEquals(plano.pulados[0].motivo, "sem_chave_resend");
+});
+
+Deno.test("falta de contato tem precedência sobre falta de chave (o cadastro é o fato mais forte)", () => {
+  const semCanal = clientes(1, () => ({ email: null, phone: null }));
+  const plano = planejarEnvios(semCanal, { envioArmado: true, temChaveResend: false });
+  assertEquals(plano.pulados[0].motivo, "sem_canal_nenhum");
 });

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -5,7 +5,7 @@ import {
   type BancoPostgrest,
   montarRelatorios,
   type MotivoSemEnvio,
-  motivoSemEnvio,
+  planejarEnvios,
   type RelatorioCliente,
 } from "../_shared/relatorio-mensal.ts";
 // Resend usado via fetch direto à REST API (https://api.resend.com/emails) para evitar dep npm
@@ -265,10 +265,6 @@ serve(async (req) => {
     let falhasEnvio = 0;
     let naoEnviadosSemChave = 0;
 
-    // O envio foi PEDIDO mas o ambiente não tem a chave: o cliente com e-mail não é pulado
-    // por contato (`motivoSemEnvio` devolve null) e também nunca é tentado — sem este ramo ele
-    // não aparece em contador nenhum, e os totais fecham em zero como se estivesse tudo certo.
-    // É a mesma entrega-zero silenciosa de sempre, entrando por outra porta.
     const envioArmado = sendEmail && !previewOnly;
     if (envioArmado && !resendApiKey) {
       console.error(
@@ -276,52 +272,56 @@ serve(async (req) => {
       );
     }
 
-    for (const report of reports) {
-      // Classificado SEMPRE, inclusive em preview/`send_email:false` — "quantos clientes estão
-      // inalcançáveis" é um fato sobre o cadastro, não sobre o modo desta invocação.
-      const motivo = motivoSemEnvio(report);
-      if (motivo) {
-        semContato[motivo]++;
-        console.warn(
-          `monthly-report: user_id ${report.user_id} PULADO (${motivo}) — ` +
-          `${report.total_tools} ferramenta(s), ${report.overdue_count} atrasada(s)`,
-        );
-        continue;
-      }
+    // Quem recebe × quem não recebe sai de UMA função pura, testada — inclusive pela
+    // invariante de conservação (nenhum relatório evapora). O gate de envio mora lá e só
+    // lá: replicá-lo aqui como um `continue` extra é exatamente como o caso da chave
+    // ausente escapou dos contadores em #1438.
+    const plano = planejarEnvios(reports, { envioArmado, temChaveResend: !!resendApiKey });
 
-      if (envioArmado && !resendApiKey) {
+    // Contadores derivados da partição, não recontados por outro caminho.
+    for (const { report, motivo } of plano.pulados) {
+      if (motivo === 'sem_chave_resend') {
         naoEnviadosSemChave++;
         continue;
       }
+      // `envio_desarmado` (preview / `send_email:false`) é o modo pedido, não anomalia:
+      // não polui os contadores nem o log.
+      if (motivo === 'envio_desarmado') continue;
 
-      if (envioArmado) {
-        const html = generateEmailHtml(report);
+      semContato[motivo]++;
+      console.warn(
+        `monthly-report: user_id ${report.user_id} PULADO (${motivo}) — ` +
+        `${report.total_tools} ferramenta(s), ${report.overdue_count} atrasada(s)`,
+      );
+    }
 
-        try {
-          const resp = await fetch("https://api.resend.com/emails", {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${resendApiKey}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify({
-              from: 'Colacor <noreply@colacor.com.br>',
-              to: [report.email],
-              subject: `🔧 Relatório Mensal de Ferramentas - ${report.overdue_count > 0 ? `${report.overdue_count} ferramenta(s) atrasada(s)` : 'Tudo em dia!'}`,
-              html,
-            }),
-          });
-          if (!resp.ok) {
-            falhasEnvio++;
-            console.error(`monthly-report: envio FALHOU p/ user_id ${report.user_id}: HTTP ${resp.status}`);
-          } else {
-            enviados++;
-            console.log(`monthly-report: enviado p/ user_id ${report.user_id}`);
-          }
-        } catch (emailErr) {
+    for (const report of plano.destinatarios) {
+      const html = generateEmailHtml(report);
+
+      try {
+        const resp = await fetch("https://api.resend.com/emails", {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${resendApiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            from: 'Colacor <noreply@colacor.com.br>',
+            to: [report.email],
+            subject: `🔧 Relatório Mensal de Ferramentas - ${report.overdue_count > 0 ? `${report.overdue_count} ferramenta(s) atrasada(s)` : 'Tudo em dia!'}`,
+            html,
+          }),
+        });
+        if (!resp.ok) {
           falhasEnvio++;
-          console.error(`monthly-report: envio FALHOU p/ user_id ${report.user_id}:`, emailErr);
+          console.error(`monthly-report: envio FALHOU p/ user_id ${report.user_id}: HTTP ${resp.status}`);
+        } else {
+          enviados++;
+          console.log(`monthly-report: enviado p/ user_id ${report.user_id}`);
         }
+      } catch (emailErr) {
+        falhasEnvio++;
+        console.error(`monthly-report: envio FALHOU p/ user_id ${report.user_id}:`, emailErr);
       }
     }
 


### PR DESCRIPTION
Fecha o débito deixado por [#1438](https://github.com/LucasSardenbergL/afiacao/pull/1438) → [#1440](https://github.com/LucasSardenbergL/afiacao/pull/1440).

## A causa que continuava de pé

Os dois PRs consertaram **sintomas** da mesma causa estrutural: a classificação de contato e o gate real de envio eram expressões **separadas**, livres para divergir.

Foi assim que o buraco do #1440 nasceu — com `RESEND_API_KEY` ausente, um cliente com e-mail não era pulado por contato (a classificação devolvia `null`) nem tentado (o gate barrava). Não entrava em contador nenhum e os totais fechavam em zero **como se estivesse tudo certo**: a mesma entrega-zero silenciosa que a instrumentação foi criada para acabar, entrando por outra porta.

O #1440 fechou aquela porta. Nada impedia uma quarta.

## O que muda

`planejarEnvios()` no `_shared` — função pura que parte os relatórios em `destinatarios` × `pulados[{report, motivo}]`. **O gate mora lá e só lá.** O `index.ts` deriva os contadores da partição, em vez de recontá-los por um segundo caminho.

A invariante que fecha a classe inteira de buraco:

> `destinatarios + pulados` cobre `reports` **exatamente** — sem sobra nem repetição.

Vale por construção (cada item faz um `push` só) e agora está **sob teste** — o que o loop dentro do `index.ts` não permitia, por não ser testável.

Essa era a peça que faltava: os testes do #1438 cobriam a classificação isolada e passavam **verdes com o buraco aberto do lado**. Cobertura de unidade não pega vazamento *entre* unidades; conservação pega.

## Prova — falsificada

21 testes verdes (eram 14). Verde não prova dente, então sabotei três vezes:

| Sabotagem | Resultado |
|---|---|
| **Reintroduzir o bug histórico do #1438** — sem chave, o alcançável some da partição | 🔴 **2 testes vermelhos** |
| Contar o mesmo relatório duas vezes | 🔴 vermelho |
| Inverter a precedência contato × chave | 🔴 vermelho |
| Restaurar | 🟢 verde |

A primeira é a prova de ouro: **o teste teria pegado o bug real**, não é teatro.

A segunda explica por que existe a checagem de unicidade além da contagem — cobrir só por contagem deixaria uma duplicata compensar uma ausência, e a soma fecharia mentindo.

## Sem mudança de comportamento

Contrato do retorno preservado: `reports_count`, `emails_enviados`, `falhas_envio`, `pulados_sem_contato`, `pulados_detalhe`, `nao_enviados_sem_chave`. O frontend do #1440 consome cinco desses e **não muda**.

Mesma precedência (contato > modo > chave), mesmos logs por `user_id`, mesmos números. Só a estrutura muda.

`deno check` e lint verdes (0 errors).

## 💬 Deploy

Toca `supabase/functions/` — precisa de deploy da edge `monthly-report` após o merge. **Não** toca `src/`, então não precisa de Publish por conta deste PR.

Sem urgência: o cron segue pausado (#1436), a edge só roda por invocação manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)