### PR TITLE
feat(tint): Fase 3 — revalidação de preço no submit, a fronteira que toda via cruza [money-path]

### DIFF
--- a/db/test-tint-gate-revalida.sh
+++ b/db/test-tint-gate-revalida.sh
@@ -1,0 +1,714 @@
+#!/usr/bin/env bash
+# Teste PG17 do GATE DE REVALIDAÇÃO tintométrica no submit (Fase 3).
+# Aplica schema-snapshot + migrations 20260718213000 + 20260718233000 (canônica
+# Fase 2/2b) + 20260722100001_tint_gate_revalida_submit.sql NA ORDEM de prod,
+# semeia fórmulas/pedidos controlados e prova (com falsificação):
+#   G0  pré-condição do seed
+#   G1  item de produto COMUM (não-base-tint) sem cor fica fora do gate
+#   G2  fonte 'calculado' com preço atual (ceil10) passa — sem e com desconto
+#   G3  fonte 'tabela' (CSV legado) passa MESMO menor que o calc (escolha 2b)
+#   G4  fonte 'cliente' com último praticado qualificado passa
+#   G5  item LEGADO (lastro persistido SEM fonte) ≥ min(calc,tab) passa; sobrepreço passa
+#   G6  fórmula DESATIVADA → bloqueia formula_morta (o caso do plano)
+#   G7  cor inexistente → formula_morta
+#   G8  receita MUDOU → preço velho na fonte 'calculado' bloqueia (caso central)
+#   G9  motor NULL (corante quebrado) bloqueia TODAS as fontes (mesmo 'tabela'
+#       com CSV presente — paridade selectTintPrice regra 1)
+#   G10 fonte 'tabela' escolhida mas chave sem CSV → bloqueia
+#   G11 fonte 'cliente' com preço de pedido NÃO-qualificado → bloqueia
+#   G12 legado ABAIXO do piso min(calc,tab) → preco_obsoleto
+#   G13 desconto fora de range → bloqueia; G26 d=100 → bloqueia (0 ≤ d < 100)
+#   G14 tint_formula_id divergente da canônica → warning, NÃO bloqueia
+#   G15 tint_ultimo_preco_cliente: qualificado mais recente vence (ignora
+#       cancelado mais novo, rascunho e >180d); exclude tira o pedido corrente
+#   G16 autorização: authenticated NÃO executa o gate (42501); service_role sim
+#   G17 RLS/INVOKER: customer B não extrai histórico do cliente A
+#   G18 paridade ceil10/round2 float8 SQL × node (Math.ceil/Math.round)
+#   G19 payload misto: só o item ruim bloqueia, com index certo
+#   G20 criação: base tintométrica SEM tint_cor_id → bloqueia (classificação
+#       server-side pelo PRODUTO — omitir o marcador não desliga o gate, Codex P1)
+#   G21 edição: base-sem-cor IDÊNTICA ao baseline (inbound) passa; alterada bloqueia
+#   G22 edição: item tint IDÊNTICO ao baseline passa com warning tint_intocado
+#       (mesmo abaixo do piso atual — o valor já está no Omie)
+#   G23 edição: item tint ALTERADO sem metadados → revalida pelo piso → bloqueia
+#   G24 edição: fonte 'cliente' NÃO se autovalida com o próprio pedido (exclude)
+#   G25 metadados ausentes SEM lastro legado no persistido → bloqueia (o
+#       fallback de piso não é controlável pelo caller, Codex P1)
+#   G27 contexto desconhecido → payload_invalido (fail-closed)
+#   F1  sabotagem: gate always-ok → bloco central cai
+#   F2  sabotagem: formula_morta vira passe → G6 cai
+#   F3  sabotagem: fonte 'tabela' pula o gate do motor → G9 cai
+#   F4  sabotagem: último-preço sem filtros → G15 cai
+#   F5  sabotagem: REVOKE só FROM PUBLIC (default privileges replicados!) → G16 cai
+#   F6  sabotagem: ultimo_preco vira SECURITY DEFINER → G17 cai
+#   F7  sabotagem: sem o exclude anti-autovalidação → G24 cai
+#   F8  sabotagem: item sem cor ignorado sem classificar → G20 cai
+#   R   restauração: migration real de volta ⇒ tudo verde
+# Base estrutural: db/test-tint-canonica.sh. Pré-req: brew install postgresql@17 pgvector.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MIG_F2="$REPO_ROOT/supabase/migrations/20260718213000_tint_formula_canonica.sql"
+MIG_F2B="$REPO_ROOT/supabase/migrations/20260718233000_tint_canonica_preco_csv_legado.sql"
+MIGRATION="$REPO_ROOT/supabase/migrations/20260722100001_tint_gate_revalida_submit.sql"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT=5449
+DATA="$(mktemp -d /tmp/pgtest-tintgate.XXXXXX)/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+for f in "$MIG_F2" "$MIG_F2B" "$MIGRATION"; do
+  [ -f "$f" ] || { echo "migration ausente: $f"; exit 1; }
+done
+
+CELLAR="$(brew --prefix postgresql@${PGVER})"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; rm -f "${RR:-}"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-tintgate.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres gate_verify
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d gate_verify -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+RR="$(mktemp "${TMPDIR:-/tmp}/snap-tintgate.XXXXXX")"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+
+echo "→ stubs + prelude + snapshot…"
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql" || { echo "FALHA no setup: stubs"; exit 1; }
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" || { echo "FALHA no setup: prelude"; exit 1; }
+P --single-transaction -q -f "$RR" >/dev/null || { echo "FALHA no setup: snapshot"; exit 1; }
+rm -f "$RR"
+
+# Default privileges do Supabase: função NOVA nasce com EXECUTE p/ todos.
+# Sem replicar isto, o REVOKE por nome da migration não tem o que morder e a
+# falsificação F5 dá falso-verde (lição database.md — mordida em prod).
+P -q -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;"
+
+echo "→ migrations Fase 2 + 2b + Fase 3 na ordem de prod…"
+P -q -f "$MIG_F2"  >/dev/null || { echo "FALHA: migration Fase 2 não aplicou"; exit 1; }
+P -q -f "$MIG_F2B" >/dev/null || { echo "FALHA: migration Fase 2b não aplicou"; exit 1; }
+P -q -f "$MIGRATION" >/dev/null || { echo "FALHA: migration Fase 3 (gate) não aplicou"; exit 1; }
+
+restore_gate() {
+  P -q -f "$MIGRATION" >/dev/null || { echo "FALHA: restore_gate não re-aplicou a migration"; exit 1; }
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SEEDS — malha da canônica (K1/K9/K16) + pedidos p/ histórico e baselines.
+#   K1 AZUL: SL válida (canônica; calc 100 + 10ml×200/810 = 102.469→ceil10 102.5)
+#            × SAYERLACK csv 150 (⇒ preco_csv_legado 150, ceil10 150)
+#   K9 BRANCO: só SL válida, SEM CSV (fonte tabela indisponível)
+#   K16 TESTEMOTOR: só SAYERLACK, receita c/ corante-zero (motor NULL) + CSV 300
+#   900001 = BASE-OK (is_tintometric base!) · 900010 = produto comum
+# Pedidos do cliente A (3333…):
+#   SO-A  …0a qualificado 10d R$95   ← último-preço legítimo
+#   SO-B  …0b CANCELADO 2d R$50      ← não conta
+#   SO-C  …0c sem omie_pedido_id 1d R$40 ← não conta
+#   SO-D  …0d qualificado 200d R$60  ← fora da janela
+#   SO-E  …0e qualificado 30d R$97   ← 2º mais recente qualificado
+#   SO-NEW …0f rascunho, items COM metadados (fonte calculado 102.5)
+#   SO-LEG …10 rascunho, items SEM metadados (valor 120) — lastro legado
+#   SO-EDIT …11 faturado omie 555, 1d: [tint K1 90 SEM metadados; base s/ cor 88×2]
+#   SO-EMPTY …12 rascunho items=[]
+# ══════════════════════════════════════════════════════════════════════════════
+echo "→ seeds…"
+P -q <<'SQL' || { echo "FALHA no seed"; exit 1; }
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),
+  ('33333333-3333-3333-3333-333333333333'),
+  ('66666666-6666-6666-6666-666666666666') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('11111111-1111-1111-1111-111111111111','master'),
+  ('33333333-3333-3333-3333-333333333333','customer'),
+  ('66666666-6666-6666-6666-666666666666','customer') ON CONFLICT DO NOTHING;
+
+INSERT INTO public.tint_subcolecoes (id, account, id_subcolecao_sayersystem, descricao) VALUES
+  ('5c000000-0000-0000-0000-000000000001','oben','SL','SL'),
+  ('0d000000-0000-0000-0000-000000000001','oben','1','SAYERLACK');
+
+INSERT INTO public.omie_products (id, omie_codigo_produto, codigo, descricao, valor_unitario, ativo, account, is_tintometric, tint_type) VALUES
+  ('0b000000-0000-0000-0000-00000000ba5e', 900001,'BASE-OK','Base OK',      100, true , 'oben', true , 'base'),
+  ('0c000000-0000-0000-0000-0000000c0c01', 900003,'COR-OK','Corante OK',    200, true , 'oben', true , 'corante'),
+  ('0c000000-0000-0000-0000-0000000c0c02', 900004,'COR-Z','Corante zero',     0, true , 'oben', true , 'corante'),
+  ('0e000000-0000-0000-0000-000000000001', 900010,'COMUM','Produto comum',   50, true , 'oben', false, NULL);
+
+INSERT INTO public.tint_corantes (id, account, id_corante_sayersystem, descricao, volume_total_ml, omie_product_id) VALUES
+  ('c0000000-0000-0000-0000-000000000001','oben','WPOK','Corante OK',   810, '0c000000-0000-0000-0000-0000000c0c01'),
+  ('c0000000-0000-0000-0000-000000000002','oben','WPRU','Corante RUIM', 810, '0c000000-0000-0000-0000-0000000c0c02');
+
+INSERT INTO public.tint_produtos  (id, account, cod_produto, descricao) VALUES
+  ('a0000000-0000-0000-0000-000000000001','oben','P1','Produto 1');
+INSERT INTO public.tint_bases     (id, account, id_base_sayersystem, descricao) VALUES
+  ('a0000000-0000-0000-0000-000000000002','oben','B1','Base 1');
+INSERT INTO public.tint_embalagens(id, account, id_embalagem_sayersystem, descricao, volume_ml) VALUES
+  ('a0000000-0000-0000-0000-0000000000e1','oben','E900A','Galao 900A',900);
+
+INSERT INTO public.tint_skus (id, account, produto_id, base_id, embalagem_id, omie_product_id) VALUES
+  ('50000000-0000-0000-0000-00000000000a','oben','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0b000000-0000-0000-0000-00000000ba5e');
+
+INSERT INTO public.tint_formulas (id, account, cor_id, nome_cor, produto_id, base_id, embalagem_id, subcolecao_id, sku_id, preco_final_sayersystem) VALUES
+  ('f1000000-0000-0000-0000-00000000005a','oben','K1','AZUL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f1000000-0000-0000-0000-000000000019','oben','K1','AZUL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',150),
+  ('f9000000-0000-0000-0000-00000000005a','oben','K9','BRANCO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f0160000-0000-0000-0000-000000000019','oben','K16','TESTEMOTOR','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',300);
+
+INSERT INTO public.tint_formula_itens (formula_id, corante_id, ordem, qtd_ml) VALUES
+  ('f1000000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
+  ('f1000000-0000-0000-0000-000000000019','c0000000-0000-0000-0000-000000000001',1,10),
+  ('f9000000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
+  ('f0160000-0000-0000-0000-000000000019','c0000000-0000-0000-0000-000000000002',1, 5);
+
+INSERT INTO public.sales_orders (id, customer_user_id, created_by, account, status, omie_pedido_id, created_at, subtotal, total, items) VALUES
+  ('a5000000-0000-0000-0000-00000000000a','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 111, now() - interval '10 days', 95, 95,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":95,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]'::jsonb),
+  ('a5000000-0000-0000-0000-00000000000b','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','cancelado', 112, now() - interval '2 days', 50, 50,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":50,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]'::jsonb),
+  ('a5000000-0000-0000-0000-00000000000c','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','rascunho', NULL, now() - interval '1 day', 40, 40,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":40,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]'::jsonb),
+  ('a5000000-0000-0000-0000-00000000000d','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 113, now() - interval '200 days', 60, 60,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":60,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]'::jsonb),
+  ('a5000000-0000-0000-0000-00000000000e','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 114, now() - interval '30 days', 97, 97,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":97,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]'::jsonb),
+  ('a5000000-0000-0000-0000-00000000000f','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','rascunho', NULL, now(), 102.5, 102.5,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":102.5,"tint_cor_id":"K1","tint_nome_cor":"AZUL","tint_price_source":"calculado","tint_discount_pct":0,"tint_preco_sem_desconto":102.5}]'::jsonb),
+  ('a5000000-0000-0000-0000-000000000010','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','rascunho', NULL, now(), 120, 120,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":120,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]'::jsonb),
+  ('a5000000-0000-0000-0000-000000000011','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 555, now() - interval '1 day', 266, 266,
+   '[{"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":90,"tint_cor_id":"K1","tint_nome_cor":"AZUL"},
+     {"omie_codigo_produto":900001,"quantidade":2,"valor_unitario":88}]'::jsonb),
+  ('a5000000-0000-0000-0000-000000000012','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','rascunho', NULL, now(), 0, 0, '[]'::jsonb);
+
+-- grants de tabela (o dump não os traz; em prod o Supabase concede e a RLS filtra)
+GRANT SELECT ON public.tint_formulas, public.tint_formula_itens, public.tint_corantes,
+                public.tint_subcolecoes, public.tint_skus, public.omie_products,
+                public.sales_orders
+  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.has_role(uuid, public.app_role) TO authenticated, service_role;
+SQL
+
+gq() { Pq -c "$1" | tail -1; }
+
+echo ""
+echo "════════ G0 — pré-condição do seed ════════"
+eq "G0a fórmulas semeadas" "$(gq 'SELECT count(*) FROM public.tint_formulas;')" "4"
+eq "G0b pedidos semeados"  "$(gq 'SELECT count(*) FROM public.sales_orders;')" "9"
+eq "G0c canônica de K1 é a SL" "$(gq "SELECT id::text FROM public.v_tint_formula_canonica WHERE cor_id='K1';")" "f1000000-0000-0000-0000-00000000005a"
+eq "G0d calc de K1 (ceil10 via float8) = 102.5" "$(gq "SELECT (ceil(((public.get_tint_price('f1000000-0000-0000-0000-00000000005a'))->>'precoFinal')::float8 * 10) / 10)::text;")" "102.5"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Bloco central (service_role, payloads controlados — G1-G14, G19-G27)
+# ══════════════════════════════════════════════════════════════════════════════
+run_central() {
+  P -tA 2>&1 <<'SQL'
+SET ROLE service_role;
+DO $$
+DECLARE r jsonb; b jsonb; w jsonb;
+  cliente  CONSTANT uuid := '33333333-3333-3333-3333-333333333333';
+  so_empty CONSTANT uuid := 'a5000000-0000-0000-0000-000000000012';
+  so_new   CONSTANT uuid := 'a5000000-0000-0000-0000-00000000000f';
+  so_leg   CONSTANT uuid := 'a5000000-0000-0000-0000-000000000010';
+  so_edit  CONSTANT uuid := 'a5000000-0000-0000-0000-000000000011';
+BEGIN
+  -- G1 produto comum sem cor → fora do gate (classificado pelo PRODUTO)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900010,"quantidade":1,"valor_unitario":1.23}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G1 FALHOU: item comum deveria passar sem gate: %', r; END IF;
+
+  -- G2 fonte calculado exata (102.5) passa; com desconto 10% (92.25) passa
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":102.5,"tint_price_source":"calculado","tint_discount_pct":0}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G2a FALHOU: calculado exato deveria passar: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":92.25,"tint_price_source":"calculado","tint_discount_pct":10}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G2b FALHOU: calculado com desconto 10%% deveria passar: %', r; END IF;
+
+  -- G3 fonte tabela (CSV 150) passa MESMO com calc 102.5 ≠ 150 (escolha 2b)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":150,"tint_price_source":"tabela"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G3 FALHOU: fonte tabela legítima deveria passar: %', r; END IF;
+
+  -- G4 fonte cliente: último qualificado = 90 (SO-EDIT, 1d, real no Omie) passa
+  -- na CRIAÇÃO (o exclude só tira o pedido em validação — so_empty)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":90,"tint_price_source":"cliente"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G4 FALHOU: fonte cliente com 90 (SO-EDIT qualificado) deveria passar: %', r; END IF;
+
+  -- G5 legado COM lastro (SO-LEG sem fonte): 120 ≥ min(102.5,150) passa; 999 passa
+  r := public.tint_gate_revalida('oben', cliente, so_leg, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":120}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G5a FALHOU: legado com lastro 120 >= piso deveria passar: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_leg, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":999}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G5b FALHOU: sobrepreço legado deveria passar: %', r; END IF;
+
+  -- G7 cor inexistente → formula_morta (sem fonte: a resolução da célula vem
+  -- antes do switch de fonte — com fonte declarada cairia em payload_invalido
+  -- pela coerência de fórmula, que exige fórmula existente da cor)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K99","valor_unitario":100}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'formula_morta' THEN
+    RAISE EXCEPTION 'G7 FALHOU: cor inexistente deveria dar formula_morta: %', r; END IF;
+
+  -- G8 preço divergente: 90 ≠ 102.5 na fonte calculado → bloqueia
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":90,"tint_price_source":"calculado"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_divergente' THEN
+    RAISE EXCEPTION 'G8 FALHOU: 90 vs calc 102.5 deveria dar preco_divergente: %', r; END IF;
+
+  -- G9 motor NULL (K16) bloqueia MESMO fonte tabela com CSV 300 presente
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K16","tint_formula_id":"f0160000-0000-0000-0000-000000000019","valor_unitario":300,"tint_price_source":"tabela"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'sem_preco_motor' THEN
+    RAISE EXCEPTION 'G9 FALHOU: motor NULL deveria barrar TODAS as fontes: %', r; END IF;
+
+  -- G10 fonte tabela sem CSV (K9) → fonte_tabela_indisponivel
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K9","tint_formula_id":"f9000000-0000-0000-0000-00000000005a","valor_unitario":150,"tint_price_source":"tabela"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'fonte_tabela_indisponivel' THEN
+    RAISE EXCEPTION 'G10 FALHOU: tabela sem CSV deveria bloquear: %', r; END IF;
+
+  -- G11 fonte cliente com valor que SÓ existe em pedidos não-qualificados
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":50,"tint_price_source":"cliente"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_divergente' THEN
+    RAISE EXCEPTION 'G11 FALHOU: preço do pedido CANCELADO não pode validar a fonte cliente: %', r; END IF;
+
+  -- G12 legado abaixo do piso: 80 < min(102.5,150) → preco_obsoleto (lastro SO-LEG)
+  r := public.tint_gate_revalida('oben', cliente, so_leg, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":80}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G12 FALHOU: legado 80 < piso deveria dar preco_obsoleto: %', r; END IF;
+
+  -- G13 desconto inválido (150); G26 d=100 também bloqueia (0 ≤ d < 100)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":10,"tint_price_source":"calculado","tint_discount_pct":150}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'desconto_invalido' THEN
+    RAISE EXCEPTION 'G13 FALHOU: desconto 150 deveria bloquear: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":0.01,"tint_price_source":"calculado","tint_discount_pct":100}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'desconto_invalido' THEN
+    RAISE EXCEPTION 'G26 FALHOU: desconto 100 deveria bloquear (0<=d<100): %', r; END IF;
+
+  -- G14 formula_id divergente (declara a SAYERLACK, canônica é a SL): warning, passa
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-000000000019","valor_unitario":102.5,"tint_price_source":"calculado"}]');
+  w := r->'warnings'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM true OR w->>'aviso' IS DISTINCT FROM 'formula_recanonizada' THEN
+    RAISE EXCEPTION 'G14 FALHOU: formula divergente deveria passar COM warning: %', r; END IF;
+
+  -- G19 payload misto: item bom + item ruim → ok=false, 1 bloqueio, index=1
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":102.5,"tint_price_source":"calculado"},
+      {"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":90,"tint_price_source":"calculado"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM false
+     OR jsonb_array_length(r->'bloqueios') <> 1
+     OR (r->'bloqueios'->0->>'index')::int <> 1 THEN
+    RAISE EXCEPTION 'G19 FALHOU: só o item 1 deveria bloquear: %', r; END IF;
+
+  -- G20 criação: BASE tint sem cor → bloqueia (classificação pelo produto)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"quantidade":1,"valor_unitario":1}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'base_sem_cor' THEN
+    RAISE EXCEPTION 'G20 FALHOU: base tint sem cor na criação deveria bloquear: %', r; END IF;
+
+  -- G21 edição: base-sem-cor IDÊNTICA ao baseline (88×2) passa; alterada bloqueia
+  r := public.tint_gate_revalida('oben', cliente, so_edit, 'edicao',
+    '[{"omie_codigo_produto":900001,"quantidade":2,"valor_unitario":88},
+      {"product_id":"0b000000-0000-0000-0000-00000000ba5e","omie_codigo_produto":900001,"quantidade":1,"valor_unitario":90,"tint_cor_id":"K1","tint_nome_cor":"AZUL"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G21a FALHOU: edição intocada (inbound + tint idêntico) deveria passar: %', r; END IF;
+  -- G22: o tint 90 do payload acima é IDÊNTICO ao baseline → warning tint_intocado
+  IF NOT EXISTS (SELECT 1 FROM jsonb_array_elements(r->'warnings') x
+                 WHERE x.value->>'aviso' = 'tint_intocado') THEN
+    RAISE EXCEPTION 'G22 FALHOU: tint idêntico deveria passar com warning tint_intocado: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_edit, 'edicao',
+    '[{"omie_codigo_produto":900001,"quantidade":2,"valor_unitario":10}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'base_sem_cor_alterada' THEN
+    RAISE EXCEPTION 'G21b FALHOU: base sem cor ALTERADA na edição deveria bloquear: %', r; END IF;
+
+  -- G23 edição: tint ALTERADO (91≠90) sem metadados → piso legado → bloqueia
+  r := public.tint_gate_revalida('oben', cliente, so_edit, 'edicao',
+    '[{"omie_codigo_produto":900001,"quantidade":1,"valor_unitario":91,"tint_cor_id":"K1"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G23 FALHOU: tint alterado 91 < piso deveria dar preco_obsoleto: %', r; END IF;
+
+  -- G24 edição: fonte cliente NÃO se autovalida — exclude tira SO-EDIT (90 é o
+  -- valor do PRÓPRIO pedido; o histórico legítimo é 95 do SO-A) → diverge
+  r := public.tint_gate_revalida('oben', cliente, so_edit, 'edicao',
+    '[{"omie_codigo_produto":900001,"quantidade":1,"valor_unitario":90,"tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","tint_price_source":"cliente"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_divergente'
+     OR (b->>'esperado')::float8 IS DISTINCT FROM 95::float8 THEN
+    RAISE EXCEPTION 'G24 FALHOU: fonte cliente deveria excluir o próprio pedido (esperado 95): %', r; END IF;
+
+  -- G25 metadados ausentes SEM lastro legado → bloqueia (a: pedido sem itens;
+  -- b: pedido cujo item persistido TEM fonte — payload que a omite é suspeito)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":120}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'metadados_ausentes' THEN
+    RAISE EXCEPTION 'G25a FALHOU: sem metadados e sem lastro deveria bloquear: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_new, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":120}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'metadados_ausentes' THEN
+    RAISE EXCEPTION 'G25b FALHOU: payload que OMITE metadados presentes no persistido deveria bloquear: %', r; END IF;
+
+  -- G27 contexto desconhecido → payload_invalido (fail-closed)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'qualquer',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":102.5,"tint_price_source":"calculado"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'payload_invalido' THEN
+    RAISE EXCEPTION 'G27 FALHOU: contexto desconhecido deveria bloquear: %', r; END IF;
+
+  -- G28 código do produto como STRING (o edge trafega os dois — Codex P1):
+  -- (a) com cor + fonte válida → resolve e passa; (b) base sem cor → bloqueia
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":"900001","tint_cor_id":"K1","tint_formula_id":"f1000000-0000-0000-0000-00000000005a","valor_unitario":102.5,"tint_price_source":"calculado"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G28a FALHOU: código string "900001" deveria resolver e passar: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":"900001","quantidade":1,"valor_unitario":1}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'base_sem_cor' THEN
+    RAISE EXCEPTION 'G28b FALHOU: base sem cor com código STRING deveria bloquear (classificação não pode depender do tipo JSON): %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":"90x1","tint_cor_id":"K1","valor_unitario":102.5}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'payload_invalido' THEN
+    RAISE EXCEPTION 'G28c FALHOU: código ilegível deveria ser payload_invalido, nunca "não-tint": %', r; END IF;
+
+  -- G29 fonte 'manual' (edição humana do preço): subir é livre; abaixo do piso bloqueia
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":150,"tint_price_source":"manual"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G29a FALHOU: manual 150 >= piso 102.5 deveria passar: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":80,"tint_price_source":"manual"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G29b FALHOU: manual 80 < piso deveria dar preco_obsoleto: %', r; END IF;
+
+  -- G30 fonte do picker SEM/COM fórmula alheia → payload_invalido (anti-adulteração)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","valor_unitario":102.5,"tint_price_source":"calculado"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'payload_invalido' THEN
+    RAISE EXCEPTION 'G30a FALHOU: fonte declarada SEM tint_formula_id deveria bloquear: %', r; END IF;
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K1","tint_formula_id":"f9000000-0000-0000-0000-00000000005a","valor_unitario":102.5,"tint_price_source":"calculado"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'payload_invalido' THEN
+    RAISE EXCEPTION 'G30b FALHOU: fórmula de OUTRA cor (K9 num item K1) deveria bloquear: %', r; END IF;
+
+  RAISE NOTICE 'CENTRAL_OK';
+END $$;
+RESET ROLE;
+SQL
+}
+
+echo ""
+echo "════════ G1–G27 — bloco central (baseline) ════════"
+OUT="$(run_central)"
+case "$OUT" in
+  *CENTRAL_OK*) ok "G1–G27 baseline verde (fontes, legado-com-lastro, bloqueios, base-sem-cor, intocado, exclude, contexto)" ;;
+  *) bad "baseline central NÃO passou: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-300)" ;;
+esac
+
+CALL_K1_CALC="SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000012','criacao',
+  '[{\"omie_codigo_produto\":900001,\"tint_cor_id\":\"K1\",\"tint_formula_id\":\"f1000000-0000-0000-0000-00000000005a\",\"valor_unitario\":102.5,\"tint_price_source\":\"calculado\"}]'::jsonb))"
+
+echo ""
+echo "════════ G6 — fórmula DESATIVADA bloqueia (o caso do plano) ════════"
+P -q -c "UPDATE public.tint_formulas SET desativada_em = now() WHERE cor_id='K1';"
+OUT="$(gq "SET ROLE service_role; $CALL_K1_CALC->'bloqueios'->0->>'motivo';")"
+eq "G6a fórmula desativada → formula_morta" "$OUT" "formula_morta"
+P -q -c "UPDATE public.tint_formulas SET desativada_em = NULL WHERE cor_id='K1';"
+OUT="$(gq "SET ROLE service_role; $CALL_K1_CALC->>'ok';")"
+eq "G6b reativada → volta a passar" "$OUT" "true"
+
+echo ""
+echo "════════ G8b — receita MUDOU: preço velho barra (caso central do plano) ════════"
+P -q -c "UPDATE public.tint_formula_itens SET qtd_ml = 20 WHERE formula_id='f1000000-0000-0000-0000-00000000005a';"
+OUT="$(gq "SET ROLE service_role; $CALL_K1_CALC->'bloqueios'->0->>'motivo';")"
+eq "G8b receita mudada → preço velho bloqueia (preco_divergente)" "$OUT" "preco_divergente"
+P -q -c "UPDATE public.tint_formula_itens SET qtd_ml = 10 WHERE formula_id='f1000000-0000-0000-0000-00000000005a';"
+OUT="$(gq "SET ROLE service_role; $CALL_K1_CALC->>'ok';")"
+eq "G8c receita restaurada → 102.5 volta a passar" "$OUT" "true"
+
+echo ""
+echo "════════ G15 — tint_ultimo_preco_cliente (filtros endurecidos + exclude) ════════"
+# SO-EDIT (90, 1d, faturado+omie) é QUALIFICADO e o mais recente — sem exclude
+# ele vence legitimamente (pedido real no Omie). Cancelado (50, 2d), rascunho
+# (40, 1d) e o velho (60, 200d) NUNCA vencem — é isso que o filtro prova.
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1'))->>'price';")"
+eq "G15a mais recente QUALIFICADO vence (SO-EDIT 90 — nunca o cancelado 50 nem o rascunho 40)" "$OUT" "90"
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1','a5000000-0000-0000-0000-000000000011'))->>'price';")"
+eq "G15b com exclude do SO-EDIT → 95 (SO-A volta a ser o mais recente)" "$OUT" "95"
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K99')) IS NULL;")"
+eq "G15c cor sem histórico → NULL" "$OUT" "t"
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('66666666-6666-6666-6666-666666666666','0b000000-0000-0000-0000-00000000ba5e','K1')) IS NULL;")"
+eq "G15d cliente sem pedidos → NULL" "$OUT" "t"
+
+echo ""
+echo "════════ G16 — autorização (gate é service_role-only) ════════"
+AUTH_OUT=$(P -tA 2>&1 -c "SET ROLE authenticated; SELECT public.tint_gate_revalida('oben',NULL,NULL,'criacao','[]'::jsonb);" || true)
+case "$AUTH_OUT" in
+  *"permission denied"*) ok "G16a authenticated NÃO executa o gate (permission denied)" ;;
+  *) bad "G16a authenticated deveria tomar permission denied, veio: $(printf '%s' "$AUTH_OUT" | head -1)" ;;
+esac
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben',NULL,'a5000000-0000-0000-0000-000000000012','criacao','[]'::jsonb))->>'ok';")"
+eq "G16b service_role executa (payload vazio ok)" "$OUT" "true"
+OUT="$(gq "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1','a5000000-0000-0000-0000-000000000011'))->>'price';")"
+eq "G16c authenticated (staff) executa tint_ultimo_preco_cliente" "$OUT" "95"
+ANON_OUT=$(P -tA 2>&1 -c "SET ROLE anon; SELECT public.tint_ultimo_preco_cliente(NULL,NULL,NULL,NULL);" || true)
+case "$ANON_OUT" in
+  *"permission denied"*) ok "G16d anon NÃO executa tint_ultimo_preco_cliente" ;;
+  *) bad "G16d anon deveria tomar permission denied, veio: $(printf '%s' "$ANON_OUT" | head -1)" ;;
+esac
+
+echo ""
+echo "════════ G17 — INVOKER: customer B não lê o histórico do cliente A ════════"
+OUT="$(gq "SET test.uid='66666666-6666-6666-6666-666666666666'; SET ROLE authenticated; SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1')) IS NULL;")"
+eq "G17 customer B (RLS) → NULL para pedidos do cliente A" "$OUT" "t"
+
+echo ""
+echo "════════ G31 — multi-SKU: célula ambígua bloqueia; declarada resolve ════════"
+# semeia um 2º SKU do MESMO produto Omie com fórmula K1 válida → 2 canônicas
+P -q <<'SQL'
+INSERT INTO public.tint_produtos  (id, account, cod_produto, descricao) VALUES
+  ('a0000000-0000-0000-0000-000000000009','oben','P2','Produto 2') ON CONFLICT DO NOTHING;
+INSERT INTO public.tint_skus (id, account, produto_id, base_id, embalagem_id, omie_product_id) VALUES
+  ('50000000-0000-0000-0000-00000000000b','oben','a0000000-0000-0000-0000-000000000009','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0b000000-0000-0000-0000-00000000ba5e');
+INSERT INTO public.tint_formulas (id, account, cor_id, nome_cor, produto_id, base_id, embalagem_id, subcolecao_id, sku_id, preco_final_sayersystem) VALUES
+  ('f1b00000-0000-0000-0000-00000000005a','oben','K1','AZUL','a0000000-0000-0000-0000-000000000009','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000b',NULL);
+INSERT INTO public.tint_formula_itens (formula_id, corante_id, ordem, qtd_ml) VALUES
+  ('f1b00000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10);
+SQL
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000012','criacao',
+  '[{\"omie_codigo_produto\":900001,\"quantidade\":1,\"valor_unitario\":120,\"tint_cor_id\":\"K1\",\"tint_price_source\":\"manual\"}]'::jsonb))->'bloqueios'->0->>'motivo';")"
+eq "G31a manual sem fórmula com 2 SKUs candidatos → formula_ambigua (nunca desempatar por UUID)" "$OUT" "formula_ambigua"
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000012','criacao',
+  '[{\"omie_codigo_produto\":900001,\"tint_cor_id\":\"K1\",\"tint_formula_id\":\"f1b00000-0000-0000-0000-00000000005a\",\"valor_unitario\":102.5,\"tint_price_source\":\"calculado\"}]'::jsonb))->>'ok';")"
+eq "G31b fórmula declarada do 2º SKU resolve a célula e passa" "$OUT" "true"
+P -q -c "DELETE FROM public.tint_formula_itens WHERE formula_id='f1b00000-0000-0000-0000-00000000005a';
+DELETE FROM public.tint_formulas WHERE id='f1b00000-0000-0000-0000-00000000005a';
+DELETE FROM public.tint_skus WHERE id='50000000-0000-0000-0000-00000000000b';"
+
+echo ""
+echo "════════ G32 — jsonb malformado no histórico não derruba a RPC ════════"
+P -q -c "INSERT INTO public.sales_orders (id, customer_user_id, created_by, account, status, omie_pedido_id, created_at, subtotal, total, items) VALUES
+  ('a5000000-0000-0000-0000-000000000013','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 556, now() - interval '3 hours', 0, 0, '{\"nao\":\"array\"}'::jsonb);"
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1'))->>'price';")"
+eq "G32 linha com items-objeto no meio do histórico → RPC segue funcionando (90)" "$OUT" "90"
+
+echo ""
+echo "════════ G18 — paridade float8 SQL × JS (ceil10 e round2) ════════"
+SAMPLE="12.3 32.61 9.99 41.7 123.45 7.07 102.46913580246913 0.05 199.999"
+SQL_OUT="$(gq "SELECT string_agg((ceil(v*10)/10)::text || ':' || (floor(v*0.9*100+0.5)/100)::text, ',' ORDER BY o)
+  FROM unnest(ARRAY[${SAMPLE// /,}]::float8[]) WITH ORDINALITY AS t(v,o);")"
+JS_OUT="$(node -e "
+const vs=[${SAMPLE// /,}];
+console.log(vs.map(v=>{
+  const c=Math.ceil(v*10)/10;
+  const r=Math.round(v*0.9*100)/100;
+  return c+':'+r;
+}).join(','));" 2>/dev/null)"
+eq "G18 ceil10+round2(desc.10%) idênticos SQL float8 × node" "$SQL_OUT" "$JS_OUT"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# FALSIFICAÇÕES — sabota, exige o vermelho CERTO, restaura.
+# ══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "════════ F1 — sabotagem: gate always-ok (aceita qualquer coisa) ════════"
+P -q <<'SQL' >/dev/null
+CREATE OR REPLACE FUNCTION public.tint_gate_revalida(p_account text, p_customer_user_id uuid, p_sales_order_id uuid, p_contexto text, p_items jsonb)
+RETURNS jsonb LANGUAGE sql STABLE SET search_path = public, pg_temp AS
+$$ SELECT jsonb_build_object('ok', true, 'bloqueios', '[]'::jsonb, 'warnings', '[]'::jsonb) $$;
+SQL
+OUT="$(run_central)"
+case "$OUT" in
+  *"G7 FALHOU"*|*"G8 FALHOU"*|*"G20 FALHOU"*) ok "F1 pegou a sabotagem: gate always-ok derrubou os asserts de bloqueio" ;;
+  *CENTRAL_OK*) bad "F1 NÃO pegou: bloco central verde com o gate sabotado (asserts sem dente)" ;;
+  *) bad "F1 caiu de forma inesperada: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
+restore_gate
+
+echo ""
+echo "════════ F2 — sabotagem: formula_morta vira passe silencioso ════════"
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f2.XXXXXX.sql")"
+# migration real com o bloqueio de canônica-ausente trocado por CONTINUE
+sed "s/'motivo', 'formula_morta',/'motivo', 'formula_morta_DESLIGADA',/" "$MIGRATION" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+P -q -c "UPDATE public.tint_formulas SET desativada_em = now() WHERE cor_id='K1';"
+OUT="$(gq "SET ROLE service_role; $CALL_K1_CALC->'bloqueios'->0->>'motivo';")"
+if [ "$OUT" = "formula_morta" ]; then
+  bad "F2 NÃO pegou: gate sabotado ainda emitiu formula_morta (sabotagem inócua?)"
+else
+  ok "F2 pegou a sabotagem: motivo mudou (veio ${OUT:-vazio}) — G6a ficaria vermelho"
+fi
+P -q -c "UPDATE public.tint_formulas SET desativada_em = NULL WHERE cor_id='K1';"
+restore_gate
+
+echo ""
+echo "════════ F3 — sabotagem: fonte 'tabela' pula o gate do motor ════════"
+# migration real com o check do motor condicionado a fonte ≠ tabela
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f3.XXXXXX.sql")"
+sed "s/IF v_calc_raw IS NULL THEN/IF v_calc_raw IS NULL AND COALESCE(v_item->>'tint_price_source','') <> 'tabela' THEN/" "$MIGRATION" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000012','criacao',
+  '[{\"omie_codigo_produto\":900001,\"tint_cor_id\":\"K16\",\"tint_formula_id\":\"f0160000-0000-0000-0000-000000000019\",\"valor_unitario\":300,\"tint_price_source\":\"tabela\"}]'::jsonb))->>'ok';")"
+if [ "$OUT" = "true" ]; then
+  ok "F3 pegou a sabotagem: K16 (motor NULL) passou pela fonte tabela (G9 ficaria vermelho)"
+else
+  bad "F3 NÃO provou o dente: gate sabotado ainda bloqueou K16 (veio ok=$OUT)"
+fi
+restore_gate
+
+echo ""
+echo "════════ F4 — sabotagem: último-preço sem filtros (inferência crua) ════════"
+P -q <<'SQL' >/dev/null
+CREATE OR REPLACE FUNCTION public.tint_ultimo_preco_cliente(p_customer_user_id uuid, p_product_id uuid, p_cor_id text, p_exclude_sales_order_id uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE sql STABLE SET search_path = public, pg_temp AS $$
+  SELECT jsonb_build_object('price', (it.item->>'valor_unitario')::float8, 'date', so.created_at)
+  FROM public.sales_orders so
+  CROSS JOIN LATERAL jsonb_array_elements(so.items) AS it(item)
+  WHERE so.customer_user_id = p_customer_user_id
+    AND so.account = 'oben'
+    -- SABOTADO: sem omie_pedido_id / status / janela
+    AND it.item->>'product_id' = p_product_id::text
+    AND it.item->>'tint_cor_id' = p_cor_id
+  ORDER BY so.created_at DESC
+  LIMIT 1
+$$;
+SQL
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1','a5000000-0000-0000-0000-000000000011'))->>'price';")"
+if [ "$OUT" = "95" ]; then
+  bad "F4 NÃO pegou: sem filtros ainda devolveu 95 (G15b sem dente)"
+else
+  ok "F4 pegou a sabotagem: sem filtros o não-qualificado venceu (veio $OUT — G15b ficaria vermelho)"
+fi
+restore_gate
+
+echo ""
+echo "════════ F5 — sabotagem: REVOKE só FROM PUBLIC (grant explícito sobra) ════════"
+P -q -c "GRANT EXECUTE ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) TO authenticated;" >/dev/null
+AUTH_OUT=$(P -tA 2>&1 -c "SET ROLE authenticated; SELECT (public.tint_gate_revalida('oben',NULL,'a5000000-0000-0000-0000-000000000012','criacao','[]'::jsonb))->>'ok';" || true)
+case "$AUTH_OUT" in
+  *"permission denied"*) bad "F5 NÃO provou o dente: authenticated seguiu barrado com o grant re-aberto" ;;
+  *true*) ok "F5 pegou a sabotagem: com grant explícito o authenticated executa (G16a ficaria vermelho)" ;;
+  *) bad "F5 resultado inesperado: $(printf '%s' "$AUTH_OUT" | head -1)" ;;
+esac
+restore_gate
+
+echo ""
+echo "════════ F6 — sabotagem: ultimo_preco vira SECURITY DEFINER (fura a RLS) ════════"
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f6.XXXXXX.sql")"
+sed "s/^STABLE$/STABLE SECURITY DEFINER/" "$MIGRATION" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(gq "SET test.uid='66666666-6666-6666-6666-666666666666'; SET ROLE authenticated; SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1')) IS NULL;")"
+if [ "$OUT" = "t" ]; then
+  bad "F6 NÃO provou o dente: DEFINER ainda devolveu NULL ao customer B (RLS do harness inerte?)"
+else
+  ok "F6 pegou a sabotagem: DEFINER vazou o histórico do cliente A ao customer B (G17 ficaria vermelho)"
+fi
+restore_gate
+
+echo ""
+echo "════════ F7 — sabotagem: sem o exclude anti-autovalidação ════════"
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f7.XXXXXX.sql")"
+sed "s/AND (p_exclude_sales_order_id IS NULL OR so.id <> p_exclude_sales_order_id)/AND true/" "$MIGRATION" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000011','edicao',
+  '[{\"omie_codigo_produto\":900001,\"quantidade\":1,\"valor_unitario\":90,\"tint_cor_id\":\"K1\",\"tint_formula_id\":\"f1000000-0000-0000-0000-00000000005a\",\"tint_price_source\":\"cliente\"}]'::jsonb))->>'ok';")"
+if [ "$OUT" = "true" ]; then
+  ok "F7 pegou a sabotagem: sem exclude o pedido validou-se com o PRÓPRIO preço (G24 ficaria vermelho)"
+else
+  bad "F7 NÃO provou o dente: gate sabotado ainda bloqueou a autovalidação (veio ok=$OUT)"
+fi
+restore_gate
+
+echo ""
+echo "════════ F8 — sabotagem: item sem cor ignorado SEM classificar o produto ════════"
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f8.XXXXXX.sql")"
+sed "s/CONTINUE WHEN NOT v_is_base_tint;/CONTINUE;/" "$MIGRATION" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000012','criacao',
+  '[{\"omie_codigo_produto\":900001,\"quantidade\":1,\"valor_unitario\":1}]'::jsonb))->>'ok';")"
+if [ "$OUT" = "true" ]; then
+  ok "F8 pegou a sabotagem: base sem cor passou sem classificação (G20 ficaria vermelho)"
+else
+  bad "F8 NÃO provou o dente: gate sabotado ainda bloqueou a base sem cor (veio ok=$OUT)"
+fi
+restore_gate
+
+echo ""
+echo "════════ F9 — sabotagem: coerência de fórmula sempre-true (anti-adulteração morre) ════════"
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f9.XXXXXX.sql")"
+sed "s/v_declarada_coerente := false;/v_declarada_coerente := true;/" "$MIGRATION" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(gq "SET ROLE service_role; SELECT (public.tint_gate_revalida('oben','33333333-3333-3333-3333-333333333333','a5000000-0000-0000-0000-000000000012','criacao',
+  '[{\"omie_codigo_produto\":900001,\"tint_cor_id\":\"K1\",\"valor_unitario\":102.5,\"tint_price_source\":\"calculado\"}]'::jsonb))->>'ok';")"
+if [ "$OUT" = "true" ]; then
+  ok "F9 pegou a sabotagem: fonte sem formula_id passou com a coerência desligada (G30a ficaria vermelho)"
+else
+  bad "F9 NÃO provou o dente: gate sabotado ainda bloqueou fonte sem formula_id (veio ok=$OUT)"
+fi
+restore_gate
+
+echo ""
+echo "════════ R — restauração: migration real ⇒ baseline verde de novo ════════"
+OUT="$(run_central)"
+case "$OUT" in
+  *CENTRAL_OK*) ok "R bloco central verde com a migration real re-aplicada" ;;
+  *) bad "R restauração falhou: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-300)" ;;
+esac
+OUT="$(gq "SELECT (public.tint_ultimo_preco_cliente('33333333-3333-3333-3333-333333333333','0b000000-0000-0000-0000-00000000ba5e','K1','a5000000-0000-0000-0000-000000000011'))->>'price';")"
+eq "R2 ultimo_preco restaurado (95 com exclude do SO-EDIT)" "$OUT" "95"
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "RESULTADO: $PASS ✅ · $FAIL ❌"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "test-tint-gate-revalida: OK"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **398** custom migrations totais
-- **1360** objetos esperados (criados por estas migrations)
+- **403** custom migrations totais
+- **1367** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 397
+  - `function`: 401
   - `rls_policy`: 295
-  - `index`: 223
+  - `index`: 224
   - `cron_job`: 150
-  - `table`: 146
+  - `table`: 147
   - `trigger`: 79
   - `view`: 67
   - `enum_value`: 4
@@ -3329,6 +3329,18 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `view` | `public.v_tint_formula_canonica` | — |
 
+### `20260718220000_data_health_vendas_cadastros_proof.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+
+### `20260718220100_seed_targets_faltantes_ledger.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.seed_targets_faltantes` | — |
+
 ### `20260718233000_tint_canonica_preco_csv_legado.sql`
 
 | Tipo | Objeto | Parent |
@@ -3346,6 +3358,20 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260721190001_pausa_cron_relatorio_mensal_ferramentas.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260722100000_acoes_execucoes_ultima_execucao.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `table` | `public.acoes_execucoes` | — |
+| `index` | `public.acoes_execucoes_acao_idx` | `acoes_execucoes` |
+
+### `20260722100001_tint_gate_revalida_submit.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tint_ultimo_preco_cliente` | — |
+| `function` | `public.tint_gate_revalida` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 398
+-- Total de custom migrations: 403
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -438,9 +438,13 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260718180000', 'fu7b_pode_ver_carteira_completa_privado', '20260718180000_fu7b_pode_ver_carteira_completa_privado.sql'),
   ('20260718200000', 'register_carteira_member_source_rpc', '20260718200000_register_carteira_member_source_rpc.sql'),
   ('20260718213000', 'tint_formula_canonica', '20260718213000_tint_formula_canonica.sql'),
+  ('20260718220000', 'data_health_vendas_cadastros_proof', '20260718220000_data_health_vendas_cadastros_proof.sql'),
+  ('20260718220100', 'seed_targets_faltantes_ledger', '20260718220100_seed_targets_faltantes_ledger.sql'),
   ('20260718233000', 'tint_canonica_preco_csv_legado', '20260718233000_tint_canonica_preco_csv_legado.sql'),
   ('20260721190000', 'reposicao_pos_candidatos', '20260721190000_reposicao_pos_candidatos.sql'),
-  ('20260721190001', 'pausa_cron_relatorio_mensal_ferramentas', '20260721190001_pausa_cron_relatorio_mensal_ferramentas.sql')
+  ('20260721190001', 'pausa_cron_relatorio_mensal_ferramentas', '20260721190001_pausa_cron_relatorio_mensal_ferramentas.sql'),
+  ('20260722100000', 'acoes_execucoes_ultima_execucao', '20260722100000_acoes_execucoes_ultima_execucao.sql'),
+  ('20260722100001', 'tint_gate_revalida_submit', '20260722100001_tint_gate_revalida_submit.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1787,10 +1791,16 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('fu7b_pode_ver_carteira_completa_privado', 'function', 'public', 'pode_ver_carteira_completa', ''),
   ('register_carteira_member_source_rpc', 'function', 'public', 'register_carteira_member', ''),
   ('tint_formula_canonica', 'view', 'public', 'v_tint_formula_canonica', ''),
+  ('data_health_vendas_cadastros_proof', 'function', 'public', '_data_health_compute', ''),
+  ('seed_targets_faltantes_ledger', 'function', 'public', 'seed_targets_faltantes', ''),
   ('tint_canonica_preco_csv_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('reposicao_pos_candidatos', 'function', 'public', 'reposicao__trim', ''),
   ('reposicao_pos_candidatos', 'function', 'public', 'reposicao__po_id', ''),
-  ('reposicao_pos_candidatos', 'function', 'public', 'reposicao_pos_candidatos', '')
+  ('reposicao_pos_candidatos', 'function', 'public', 'reposicao_pos_candidatos', ''),
+  ('acoes_execucoes_ultima_execucao', 'table', 'public', 'acoes_execucoes', ''),
+  ('acoes_execucoes_ultima_execucao', 'index', 'public', 'acoes_execucoes_acao_idx', 'acoes_execucoes'),
+  ('tint_gate_revalida_submit', 'function', 'public', 'tint_ultimo_preco_cliente', ''),
+  ('tint_gate_revalida_submit', 'function', 'public', 'tint_gate_revalida', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3185,10 +3195,16 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('fu7b_pode_ver_carteira_completa_privado', 'function', 'public', 'pode_ver_carteira_completa', ''),
   ('register_carteira_member_source_rpc', 'function', 'public', 'register_carteira_member', ''),
   ('tint_formula_canonica', 'view', 'public', 'v_tint_formula_canonica', ''),
+  ('data_health_vendas_cadastros_proof', 'function', 'public', '_data_health_compute', ''),
+  ('seed_targets_faltantes_ledger', 'function', 'public', 'seed_targets_faltantes', ''),
   ('tint_canonica_preco_csv_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('reposicao_pos_candidatos', 'function', 'public', 'reposicao__trim', ''),
   ('reposicao_pos_candidatos', 'function', 'public', 'reposicao__po_id', ''),
-  ('reposicao_pos_candidatos', 'function', 'public', 'reposicao_pos_candidatos', '')
+  ('reposicao_pos_candidatos', 'function', 'public', 'reposicao_pos_candidatos', ''),
+  ('acoes_execucoes_ultima_execucao', 'table', 'public', 'acoes_execucoes', ''),
+  ('acoes_execucoes_ultima_execucao', 'index', 'public', 'acoes_execucoes_acao_idx', 'acoes_execucoes'),
+  ('tint_gate_revalida_submit', 'function', 'public', 'tint_ultimo_preco_cliente', ''),
+  ('tint_gate_revalida_submit', 'function', 'public', 'tint_gate_revalida', '')
 )
 SELECT
   e.migration,

--- a/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.priceGuard.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.priceGuard.test.tsx
@@ -144,13 +144,38 @@ describe('useSalesOrderEdit — guard de preço ao salvar', () => {
     const { result } = await renderLoaded();
     mockedInvoke.mockClear();
     updateSpy.mockClear();
+    // Fase 3: o edge é AGUARDADO e persiste no write-back — o front não faz
+    // update local pré-invoke (o jsonb persistido é o BASELINE do gate tint).
+    mockedInvoke.mockResolvedValue({ data: { success: true }, error: null } as never);
 
     await act(async () => {
       await result.current.handleSave();
     });
 
-    expect(updateSpy).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      'omie-vendas-sync',
+      expect.objectContaining({ body: expect.objectContaining({ action: 'alterar_pedido' }) }),
+    );
+    expect(updateSpy).not.toHaveBeenCalled();
     await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('/sales'));
     expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('Fase 3: bloqueio tint_preco do edge → NÃO persiste local, NÃO navega, avisa', async () => {
+    const { result } = await renderLoaded();
+    mockedInvoke.mockClear();
+    updateSpy.mockClear();
+    mockedInvoke.mockResolvedValue({
+      data: { success: false, blocked: 'tint_preco', bloqueios: [{ cor_id: 'K1', motivo: 'preco_divergente' }] },
+      error: null,
+    } as never);
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(navigateSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/components/salesOrderEdit/types.ts
+++ b/src/components/salesOrderEdit/types.ts
@@ -13,6 +13,12 @@ export interface OrderItem {
   tint_cor_id?: string;
   tint_nome_cor?: string;
   tint_formula_id?: string;
+  // Fase 3: metadados de precificação (fonte escolhida + desconto declarado).
+  // Editar o valor_unitario de um item tint MANUALMENTE os limpa (o item vira
+  // "legado" e o gate da fronteira valida pelo piso min(fontes atuais)).
+  tint_price_source?: string;
+  tint_discount_pct?: number;
+  tint_preco_sem_desconto?: number;
 }
 
 export interface OmiePayload {

--- a/src/components/salesOrderEdit/useSalesOrderEdit.ts
+++ b/src/components/salesOrderEdit/useSalesOrderEdit.ts
@@ -136,6 +136,15 @@ export function useSalesOrderEdit() {
     setItems(prev => prev.map((item, i) => {
       if (i !== index) return item;
       const updated = { ...item, [field]: value };
+      // Fase 3: editar o PREÇO de um item tint na mão invalida a prova da fonte
+      // do picker — o item vira fonte 'manual' EXPLÍCITA (não "sem metadados",
+      // que é reservado ao legado pré-Fase-3). O gate valida 'manual' pelo piso
+      // min(calc, tabela): subir é livre; baixar além do piso atual bloqueia.
+      if (field === 'valor_unitario' && item.tint_cor_id) {
+        updated.tint_price_source = 'manual';
+        delete updated.tint_discount_pct;
+        delete updated.tint_preco_sem_desconto;
+      }
       updated.valor_total = updated.quantidade * updated.valor_unitario;
       return updated;
     }));
@@ -178,7 +187,15 @@ export function useSalesOrderEdit() {
     toast.success(`"${product.descricao}" adicionado`);
   };
 
-  const handleTintConfirm = (formulaId: string, corId: string, nomeCor: string, precoFinal: number, _custoCorantes: number, alternativeProduct?: Product) => {
+  const handleTintConfirm = (
+    formulaId: string,
+    corId: string,
+    nomeCor: string,
+    precoFinal: number,
+    _custoCorantes: number,
+    pricingMeta?: { source: string | null; discountPct: number; precoSemDesconto: number | null },
+    alternativeProduct?: Product,
+  ) => {
     const product = alternativeProduct
       ? catalogProducts.find(p => p.id === alternativeProduct.id) || tintPendingProduct!
       : tintPendingProduct!;
@@ -195,6 +212,12 @@ export function useSalesOrderEdit() {
       tint_nome_cor: nomeCor,
       // espelha o balcão (submitOrder.ts): grava a fórmula p/ auditoria e re-precificação.
       tint_formula_id: formulaId,
+      // Fase 3: fonte/desconto declarados — o gate do submit revalida esta decisão.
+      ...(pricingMeta?.source ? {
+        tint_price_source: pricingMeta.source,
+        tint_discount_pct: pricingMeta.discountPct,
+        ...(pricingMeta.precoSemDesconto != null ? { tint_preco_sem_desconto: pricingMeta.precoSemDesconto } : {}),
+      } : {}),
     };
     setItems(prev => [...prev, newItem]);
     setTintPendingProduct(null);
@@ -249,32 +272,14 @@ export function useSalesOrderEdit() {
       const account = order.account === 'colacor' ? 'colacor' : 'oben';
 
       if (order.omie_pedido_id) {
-        // Save locally first
-        const updatedPayload = {
-          ...(order.omie_payload || {}),
-          cabecalho: {
-            ...(order.omie_payload?.cabecalho || {}),
-            ...(selectedParcela ? { codigo_parcela: selectedParcela } : {}),
-          },
-        };
-        const { error: localErr } = await supabase
-          .from('sales_orders')
-          .update({
-            items: items as unknown as Json,
-            subtotal,
-            total: subtotal,
-            notes: notes || null,
-            omie_payload: updatedPayload as unknown as Json,
-          })
-          .eq('id', order.id);
-        if (localErr) throw localErr;
-
-        // Navigate immediately and sync in background
-        toast.info('Pedido salvo! Sincronizando com o Omie em segundo plano...');
-        navigate('/sales');
-
-        // Fire-and-forget sync
-        supabase.functions.invoke('omie-vendas-sync', {
+        // ── Fase 3 (refactor exigido pelo gate — achado Codex P1): o edge vem
+        // PRIMEIRO, aguardado. O jsonb persistido fica INTACTO até o sucesso —
+        // ele é o BASELINE que o gate tint usa p/ distinguir item intocado de
+        // alterado e p/ impedir o preço-cliente de se autovalidar. No sucesso o
+        // EDGE persiste items/notes/payload (write-back do alterar_pedido);
+        // bloqueio/erro → permanecer na tela, local intacto, nada de "salvo!".
+        toast.info('Validando e sincronizando com o Omie...');
+        const { data, error } = await supabase.functions.invoke('omie-vendas-sync', {
           body: {
             action: 'alterar_pedido',
             account,
@@ -287,30 +292,61 @@ export function useSalesOrderEdit() {
               unidade: i.unidade,
               quantidade: i.quantidade,
               valor_unitario: i.valor_unitario,
-              ...(i.tint_cor_id ? { tint_cor_id: i.tint_cor_id, tint_nome_cor: i.tint_nome_cor } : {}),
+              ...(i.tint_cor_id ? {
+                tint_cor_id: i.tint_cor_id,
+                tint_nome_cor: i.tint_nome_cor,
+                // Fase 3: o gate do edge revalida a fonte declarada (ou o piso, se legado)
+                ...(i.tint_formula_id ? { tint_formula_id: i.tint_formula_id } : {}),
+                ...(i.tint_price_source ? {
+                  tint_price_source: i.tint_price_source,
+                  tint_discount_pct: i.tint_discount_pct ?? 0,
+                  ...(i.tint_preco_sem_desconto != null ? { tint_preco_sem_desconto: i.tint_preco_sem_desconto } : {}),
+                } : {}),
+              } : {}),
             })),
             observacao: notes,
             codigo_parcela: selectedParcela || undefined,
           },
-        }).then(({ data, error }) => {
-          if (error) {
-            toast.error('Erro ao sincronizar com Omie: ' + (error.message || 'Erro desconhecido'));
-          } else if ((data as { blocked?: string } | null)?.blocked === 'credito') {
-            // Trava Fase 2 (edge devolve 200 estruturado): o gate barrou o AUMENTO —
-            // o Omie NÃO foi atualizado e o pedido local ficou à frente. Nunca
-            // "sincronizado com sucesso" aqui.
-            toast.error('Edição bloqueada por crédito — o Omie NÃO foi atualizado', {
-              description:
-                'Aumento de valor para cliente com vencido 60+ exige exceção de gestor ' +
-                '(Pedidos → abrir o pedido → botão Crédito). Após aprovar, salve o pedido de novo.',
-              duration: 12000,
-            });
-          } else {
-            toast.success('Pedido sincronizado com o Omie com sucesso!');
-          }
-        }).catch((err) => {
-          toast.error('Erro ao sincronizar com Omie: ' + (err.message || 'Erro desconhecido'));
         });
+        if (error) {
+          toast.error('Erro ao sincronizar com Omie: ' + (error.message || 'Erro desconhecido'));
+          setSaving(false);
+          return;
+        }
+        if ((data as { blocked?: string } | null)?.blocked === 'credito') {
+          // Trava Fase 2 (edge devolve 200 estruturado): o gate barrou o AUMENTO —
+          // o Omie NÃO foi atualizado e o pedido local seguiu intacto.
+          toast.error('Edição bloqueada por crédito — o Omie NÃO foi atualizado', {
+            description:
+              'Aumento de valor para cliente com vencido 60+ exige exceção de gestor ' +
+              '(Pedidos → abrir o pedido → botão Crédito). Após aprovar, salve o pedido de novo.',
+            duration: 12000,
+          });
+          setSaving(false);
+          return;
+        }
+        if ((data as { blocked?: string } | null)?.blocked === 'tint_preco') {
+          // Gate tint Fase 3: item de tinta com preço obsoleto/fórmula morta —
+          // o Omie NÃO foi atualizado e o pedido local seguiu intacto.
+          const bloqueios = (data as { bloqueios?: Array<{ cor_id?: string }> }).bloqueios;
+          const cores = [...new Set((bloqueios ?? []).map(b => b.cor_id).filter(Boolean))].join(', ');
+          toast.error('Edição bloqueada: preço de tinta desatualizado — o Omie NÃO foi atualizado', {
+            description:
+              `${cores ? `Cor ${cores}: ` : ''}o preço/fórmula mudou desde a criação do pedido. ` +
+              'Remova o item de tinta e adicione de novo pela tela (o preço recalcula), então salve.',
+            duration: 12000,
+          });
+          setSaving(false);
+          return;
+        }
+        if (!(data as { success?: boolean } | null)?.success) {
+          toast.error('O Omie não confirmou a alteração — o pedido local seguiu intacto. Tente novamente.');
+          setSaving(false);
+          return;
+        }
+        // Sucesso: o edge já persistiu items/subtotal/notes/omie_payload.
+        toast.success('Pedido atualizado e sincronizado com o Omie!');
+        navigate('/sales');
       } else {
         const updatedPayloadLocal = {
           ...(order.omie_payload || {}),

--- a/src/components/tintColorSelect/GlobalColorMatches.tsx
+++ b/src/components/tintColorSelect/GlobalColorMatches.tsx
@@ -6,7 +6,7 @@ import type { Product } from '@/hooks/useUnifiedOrder';
 import { fmt } from '@/hooks/useUnifiedOrder';
 import { selectAltPrice, type AltPriceSource, type TintPriceBreakdownLite } from '@/lib/tint/select-price';
 import { AltPriceSourcePicker } from './AltPriceSourcePicker';
-import type { AlternativePackaging } from './types';
+import type { AlternativePackaging, TintPricingMeta } from './types';
 
 interface GlobalColorMatchesProps {
   product: Product;
@@ -20,7 +20,7 @@ interface GlobalColorMatchesProps {
   /** Override de fonte POR alternativa (Fase 2b-fix) — validado em selectAltPrice. */
   altPriceSourceOverrides: Record<string, AltPriceSource>;
   setAltPriceSourceOverride: (formulaId: string, source: AltPriceSource) => void;
-  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
+  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, pricingMeta: TintPricingMeta, alternativeProduct?: Product) => void;
 }
 
 export function GlobalColorMatches({ product, matches, colorExists, precoMap, precoLoading, altPriceSourceOverrides, setAltPriceSourceOverride, onConfirm }: GlobalColorMatchesProps) {
@@ -81,6 +81,9 @@ export function GlobalColorMatches({ product, matches, colorExists, precoMap, pr
                     alt.nomeCor || '',
                     altSel.preco as number,
                     altSel.custoCorantes,
+                    // Fase 3: o item carrega a fonte EFETIVA (altSel já aplicou o
+                    // override da vendedora — 2b-fix); busca global não tem desconto
+                    { source: altSel.fonte, discountPct: 0, precoSemDesconto: altSel.preco },
                     alt.product,
                   )}
                   className={`w-full flex items-center justify-between gap-2 p-2.5 ${altDisponivel ? 'hover:bg-primary/5' : 'opacity-60 cursor-not-allowed'}`}

--- a/src/components/tintColorSelect/SelectedFormulaCard.tsx
+++ b/src/components/tintColorSelect/SelectedFormulaCard.tsx
@@ -11,7 +11,7 @@ import type { Product } from '@/hooks/useUnifiedOrder';
 import { fmt } from '@/hooks/useUnifiedOrder';
 import { selectAltPrice, type TintPriceSource, type AltPriceSource, type SemPrecoMotivo, type TintPriceBreakdownLite } from '@/lib/tint/select-price';
 import { AltPriceSourcePicker } from './AltPriceSourcePicker';
-import type { FormulaResult, AlternativePackaging } from './types';
+import type { FormulaResult, AlternativePackaging, TintPricingMeta } from './types';
 
 const LABEL_FONTE: Record<TintPriceSource, string> = {
   cliente: 'Preço cliente',
@@ -59,7 +59,7 @@ interface SelectedFormulaCardProps {
   altDiscounts: Record<string, number>;
   setAltDiscounts: React.Dispatch<React.SetStateAction<Record<string, number>>>;
   custoCorantes: number;
-  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
+  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, pricingMeta: TintPricingMeta, alternativeProduct?: Product) => void;
 }
 
 export function SelectedFormulaCard({
@@ -187,10 +187,10 @@ export function SelectedFormulaCard({
                 <Input
                   type="number"
                   min={0}
-                  max={100}
+                  max={99.99}
                   step={1}
                   value={discountPct || ''}
-                  onChange={(e) => setDiscountPct(Math.min(100, Math.max(0, Number(e.target.value) || 0)))}
+                  onChange={(e) => setDiscountPct(Math.min(99.99, Math.max(0, Number(e.target.value) || 0)))}
                   className="h-7 w-20 text-xs text-right"
                   placeholder="0"
                 />
@@ -221,6 +221,9 @@ export function SelectedFormulaCard({
                 selectedFormula.nome_cor,
                 precoFinal ?? 0,
                 custoCorantes,
+                // Fase 3: o item carrega a fonte escolhida + desconto — o gate
+                // do submit revalida exatamente ESTA decisão contra o estado atual.
+                { source: priceSource, discountPct, precoSemDesconto },
               )}
             >
               <Palette className="w-3.5 h-3.5 mr-1.5" />
@@ -279,6 +282,9 @@ export function SelectedFormulaCard({
                         selectedFormula.nome_cor,
                         altPrice,
                         altSel.custoCorantes,
+                        // Fase 3: fonte EFETIVA da alternativa (altSel já aplicou o
+                        // override 2b-fix) + desconto próprio da embalagem
+                        { source: altSel.fonte, discountPct: altDisc, precoSemDesconto: altSel.preco },
                         alt.product,
                       )}
                       className={`w-full flex items-center justify-between gap-2 p-2 ${altDisponivel ? 'hover:bg-primary/5' : 'opacity-60 cursor-not-allowed'}`}
@@ -322,10 +328,10 @@ export function SelectedFormulaCard({
                           <Input
                             type="number"
                             min={0}
-                            max={100}
+                            max={99.99}
                             step={1}
                             value={altDisc || ''}
-                            onChange={(e) => setAltDiscounts(prev => ({ ...prev, [alt.formulaId]: Math.min(100, Math.max(0, Number(e.target.value) || 0)) }))}
+                            onChange={(e) => setAltDiscounts(prev => ({ ...prev, [alt.formulaId]: Math.min(99.99, Math.max(0, Number(e.target.value) || 0)) }))}
                             className="h-6 w-16 text-[10px] text-right"
                             placeholder="0"
                           />

--- a/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
+++ b/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
@@ -65,7 +65,11 @@ describe('GlobalColorMatches', () => {
     const precoMap = { f1: { custoBase: 152.1, baseDisponivel: true, custoCorantes: 18.06, corantesCompletos: true, precoFinal: 170.16 } };
     render(<GlobalColorMatches product={product} altPriceSourceOverrides={{}} setAltPriceSourceOverride={() => {}} matches={[alt({ precoFinalCsv: 13.7 })]} precoMap={precoMap} onConfirm={onConfirm} />);
     fireEvent.click(screen.getByText('Base Branca 3.6L'));
-    expect(onConfirm).toHaveBeenCalledWith('f1', 'RAL9010', 'Branco', 170.2, 18.06, expect.objectContaining({ id: 'op1' }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      'f1', 'RAL9010', 'Branco', 170.2, 18.06,
+      { source: 'calculado', discountPct: 0, precoSemDesconto: 170.2 },
+      expect.objectContaining({ id: 'op1' }),
+    );
   });
 
   it('sem CSV e sem cálculo → "sem preço", não confirma (não vende a valor_unitario nu)', () => {
@@ -99,7 +103,12 @@ describe('GlobalColorMatches', () => {
     const onConfirm = vi.fn();
     render(<GlobalColorMatches product={product} altPriceSourceOverrides={{ f1: 'tabela' }} setAltPriceSourceOverride={() => {}} matches={[alt({ precoFinalCsv: 13.7 })]} precoMap={precoMapAmbos} onConfirm={onConfirm} />);
     fireEvent.click(screen.getByText('Base Branca 3.6L'));
-    expect(onConfirm).toHaveBeenCalledWith('f1', 'RAL9010', 'Branco', 13.7, 18.06, expect.objectContaining({ id: 'op1' }));
+    // Fase 3: o meta carrega a fonte EFETIVA do override (tabela) — é isto que o gate revalida
+    expect(onConfirm).toHaveBeenCalledWith(
+      'f1', 'RAL9010', 'Branco', 13.7, 18.06,
+      { source: 'tabela', discountPct: 0, precoSemDesconto: 13.7 },
+      expect.objectContaining({ id: 'op1' }),
+    );
   });
 
   it('só uma fonte com valor (sem CSV) → não oferece seletor', () => {

--- a/src/components/tintColorSelect/__tests__/SelectedFormulaCard.test.tsx
+++ b/src/components/tintColorSelect/__tests__/SelectedFormulaCard.test.tsx
@@ -50,17 +50,20 @@ describe('SelectedFormulaCard', () => {
     expect(screen.getByText('Azul Sinal')).toBeTruthy();
   });
 
-  it('confirma com os dados da fórmula e preço final', () => {
-    const props = setup({ precoFinal: 50, custoCorantes: 5 });
+  it('confirma com os dados da fórmula, preço final e o meta de precificação (Fase 3)', () => {
+    const props = setup({ precoFinal: 50, custoCorantes: 5, priceSource: 'calculado', discountPct: 0, precoSemDesconto: 50 });
     fireEvent.click(screen.getByRole('button', { name: /Adicionar ao Pedido/ }));
-    expect(props.onConfirm).toHaveBeenCalledWith('f1', 'RAL5005', 'Azul Sinal', 50, 5);
+    expect(props.onConfirm).toHaveBeenCalledWith(
+      'f1', 'RAL5005', 'Azul Sinal', 50, 5,
+      { source: 'calculado', discountPct: 0, precoSemDesconto: 50 },
+    );
   });
 
-  it('clampa o desconto entre 0 e 100', () => {
+  it('clampa o desconto entre 0 e 99.99 (d=100 zeraria o preço — contrato do gate é d<100)', () => {
     const props = setup();
     const input = screen.getByPlaceholderText('0') as HTMLInputElement;
     fireEvent.change(input, { target: { value: '150' } });
-    expect(props.setDiscountPct).toHaveBeenCalledWith(100);
+    expect(props.setDiscountPct).toHaveBeenCalledWith(99.99);
   });
 
   it('mostra seletor de preço quando há último preço cliente e tabela; dispara override', () => {
@@ -83,7 +86,11 @@ describe('SelectedFormulaCard', () => {
     expect(screen.getByText('Mesma cor em outras embalagens')).toBeTruthy();
     fireEvent.click(screen.getByText('Base 3.6L'));
     // calc 200 ≈ CSV 200 → calculado; custoCorantes 120 DA própria alternativa
-    expect(props.onConfirm).toHaveBeenCalledWith('fa', 'RAL5005', 'Azul Sinal', 200, 120, altProduct);
+    expect(props.onConfirm).toHaveBeenCalledWith(
+      'fa', 'RAL5005', 'Azul Sinal', 200, 120,
+      { source: 'calculado', discountPct: 0, precoSemDesconto: 200 },
+      altProduct,
+    );
   });
 
   it('alternativa sem breakdown no mapa (batch não respondeu) → "sem preço", não confirma (fail-closed)', () => {
@@ -106,7 +113,11 @@ describe('SelectedFormulaCard', () => {
     };
     const props = setup({ alternatives, altPriceMap });
     fireEvent.click(screen.getByText('Base 3.6L'));
-    expect(props.onConfirm).toHaveBeenCalledWith('fa', 'RAL5005', 'Azul Sinal', 170.2, 18.06, altProduct);
+    expect(props.onConfirm).toHaveBeenCalledWith(
+      'fa', 'RAL5005', 'Azul Sinal', 170.2, 18.06,
+      { source: 'calculado', discountPct: 0, precoSemDesconto: 170.2 },
+      altProduct,
+    );
   });
 
   it('alternativa sem preço (base ausente no mapa): mostra "sem preço" e não confirma', () => {
@@ -193,7 +204,11 @@ describe('SelectedFormulaCard', () => {
     const { altProduct, alternatives, altPriceMap } = altComAmbasFontes();
     const props = setup({ alternatives, altPriceMap, altPriceSourceOverrides: { fa: 'tabela' } });
     fireEvent.click(screen.getByText('Base 3.6L'));
-    expect(props.onConfirm).toHaveBeenCalledWith('fa', 'RAL5005', 'Azul Sinal', 13.7, 18.06, altProduct);
+    expect(props.onConfirm).toHaveBeenCalledWith(
+      'fa', 'RAL5005', 'Azul Sinal', 13.7, 18.06, // Fase 3: fonte efetiva do override viaja no meta
+      { source: 'tabela', discountPct: 0, precoSemDesconto: 13.7 },
+      altProduct,
+    );
   });
 
   it('alternativa com só uma fonte (sem breakdown) → não oferece seletor', () => {

--- a/src/components/tintColorSelect/types.ts
+++ b/src/components/tintColorSelect/types.ts
@@ -1,12 +1,25 @@
 // Tipos do diálogo de seleção de cor tintométrica.
 // Extraídos verbatim de src/components/TintColorSelectDialog.tsx (god-component split).
 import type { Product } from '@/hooks/useUnifiedOrder';
+import type { TintPriceSource } from '@/lib/tint/select-price';
+
+/** Fase 3: metadados de precificação que o item CARREGA até a fronteira —
+ *  a fonte escolhida pela vendedora + o desconto declarado + o preço-base.
+ *  O gate do submit (tint_gate_revalida) recomputa a fonte AGORA e confere. */
+export interface TintPricingMeta {
+  /** Fonte efetivamente usada no preço confirmado (null = indisponível). */
+  source: TintPriceSource | null;
+  /** Desconto % aplicado por cima do preço da fonte (0–100). */
+  discountPct: number;
+  /** Preço da fonte ANTES do desconto (o que o gate recomputa). */
+  precoSemDesconto: number | null;
+}
 
 export interface TintColorSelectDialogProps {
   product: Product;
   open: boolean;
   onClose: () => void;
-  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, alternativeProduct?: Product) => void;
+  onConfirm: (formulaId: string, corId: string, nomeCor: string, precoFinal: number, custoCorantes: number, pricingMeta: TintPricingMeta, alternativeProduct?: Product) => void;
   customerUserId?: string | null;
   /** Pré-preenche a busca de cor ao abrir (re-pedido via "Cores do cliente"). */
   initialSearch?: string | null;

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -31,6 +31,13 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
       setSelectedFormula(null);
       setPriceSourceOverride(null);
       setAltPriceSourceOverrides({});
+      // Fase 3 (achado Codex P1): desconto NÃO sobrevive entre aberturas do
+      // diálogo — senão um 99% digitado numa cor reapareceria silencioso na
+      // próxima, e o gate o consideraria "coerente" (desconto declarado é
+      // escolha POR ITEM, não estado ambiente).
+      setDiscountPct(0);
+      setAltDiscounts({});
+      setSyncDiscount(false);
     }
   }, [open]);
 
@@ -226,40 +233,33 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
   // Pricing breakdown for selected formula (motor honesto get_tint_price)
   const { data: pricing, isLoading: pricingLoading, isError: pricingError } = useTintPricing(selectedFormula?.id || null);
 
-  // Last practiced price for this color+base for the customer
+  // Último preço PRATICADO do cliente — Fase 3: a inferência crua (50 pedidos
+  // sem filtro de status) virou a RPC tint_ultimo_preco_cliente, ENDURECIDA
+  // server-side: só pedido real no Omie (omie_pedido_id), não-cancelado, janela
+  // de 180 dias. A MESMA função valida a fonte 'cliente' no gate do submit
+  // (tint_gate_revalida) — paridade estrutural picker×fronteira, zero espelho.
+  // (`as never`: RPC nova ainda fora do types.ts gerado pelo Lovable — padrão
+  // do repo, ver staff_get_sales_order_payload em useSalesOrderEdit.)
   const { data: lastPracticedPrice, isLoading: loadingLastPrice } = useQuery({
     queryKey: ['tint-last-price', customerUserId, product.id, selectedFormula?.cor_id],
     staleTime: 30 * 1000,
     enabled: !!customerUserId && !!selectedFormula?.cor_id && !!product.id,
     queryFn: async () => {
       if (!customerUserId || !selectedFormula?.cor_id || !product.id) return null;
-
-      const { data: orders } = await supabase
-        .from('sales_orders')
-        .select('items, created_at')
-        .eq('customer_user_id', customerUserId)
-        .eq('account', 'oben')
-        .order('created_at', { ascending: false })
-        .limit(50);
-
-      if (!orders) return null;
-
-      for (const order of orders) {
-        const items = order.items as Array<{ product_id?: string; tint_cor_id?: string; valor_unitario?: number }>;
-        if (!Array.isArray(items)) continue;
-        for (const item of items) {
-          if (
-            item.product_id === product.id &&
-            item.tint_cor_id === selectedFormula.cor_id
-          ) {
-            return {
-              price: item.valor_unitario as number,
-              date: order.created_at as string,
-            };
-          }
-        }
-      }
-      return null;
+      const { data, error } = await supabase.rpc(
+        'tint_ultimo_preco_cliente' as never,
+        {
+          p_customer_user_id: customerUserId,
+          p_product_id: product.id,
+          p_cor_id: selectedFormula.cor_id,
+        } as never,
+      );
+      // Erro (RPC ausente/permissão) → sem histórico, NUNCA preço fabricado;
+      // a fonte 'cliente' simplesmente não aparece no seletor.
+      if (error) return null;
+      const row = data as unknown as { price?: number; date?: string } | null;
+      if (!row || typeof row.price !== 'number' || row.price <= 0) return null;
+      return { price: row.price, date: row.date ?? '' };
     },
   });
 
@@ -373,12 +373,15 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
   useEffect(() => {
     setPriceSourceOverride(null);
     setAltPriceSourceOverrides({});
+    // Fase 3: o DESCONTO também reseta por cor (escolha por item, nunca herdada).
+    setDiscountPct(0);
   }, [selectedFormula?.id]);
 
-  // Enquanto a RPC de preço (ou o último preço do cliente) carrega, NÃO decidir o preço: o motor
-  // honesto ainda não respondeu e cair no CSV/cliente aqui venderia o preço legado (subfaturado)
-  // antes de saber. A UI mostra "calculando" e segura o "Adicionar".
-  const precoCarregando = !!selectedFormula && (pricingLoading || loadingLastPrice);
+  // Enquanto a RPC do MOTOR carrega, NÃO decidir o preço (a UI mostra
+  // "calculando" e segura o "Adicionar"). Fase 3: o último-preço do cliente
+  // NÃO trava mais o preço seguro — deixou de ser default (é chip opt-in);
+  // lentidão/falha da RPC de histórico não pode impedir calc/tabela (Codex P2).
+  const precoCarregando = !!selectedFormula && pricingLoading;
 
   // A RPC de preço pode FALHAR (erro/permissão/runtime) e o hook devolve pricing null igual a
   // "carregando". Sem distinguir, a seleção cairia no CSV legado/preço-cliente e venderia base/

--- a/src/hooks/unifiedOrder/types.ts
+++ b/src/hooks/unifiedOrder/types.ts
@@ -99,6 +99,13 @@ export interface ProductCartItem {
   tint_nome_cor?: string;
   tint_custo_corantes?: number;
   tint_formula_id?: string;
+  // Fase 3: metadados de precificação do picker — a fonte que a vendedora
+  // escolheu + o desconto declarado + o preço-base. Viajam no jsonb e no
+  // payload do edge; o gate do submit (tint_gate_revalida) recomputa a fonte
+  // AGORA e confere. Ausentes = item legado (o gate usa o piso min(fontes)).
+  tint_price_source?: string;
+  tint_discount_pct?: number;
+  tint_preco_sem_desconto?: number;
 }
 
 export interface UserTool {

--- a/src/hooks/unifiedOrder/useCart.ts
+++ b/src/hooks/unifiedOrder/useCart.ts
@@ -123,6 +123,8 @@ export function useCart({ getProductPrice, getServicePrice, servicos }: UseCartA
       nomeCor: string,
       precoFinal: number,
       custoCorantes: number,
+      // Fase 3: fonte escolhida + desconto declarado (o gate do submit revalida)
+      pricingMeta?: { source: string | null; discountPct: number; precoSemDesconto: number | null },
     ) => {
       const account = (product.account || 'oben') as ProductAccount;
       setCart(prev => {
@@ -148,6 +150,15 @@ export function useCart({ getProductPrice, getServicePrice, servicos }: UseCartA
             tint_nome_cor: nomeCor,
             tint_custo_corantes: custoCorantes,
             tint_formula_id: formulaId,
+            ...(pricingMeta?.source
+              ? {
+                  tint_price_source: pricingMeta.source,
+                  tint_discount_pct: pricingMeta.discountPct,
+                  ...(pricingMeta.precoSemDesconto != null
+                    ? { tint_preco_sem_desconto: pricingMeta.precoSemDesconto }
+                    : {}),
+                }
+              : {}),
           } as ProductCartItem,
         ];
       });

--- a/src/lib/tint/__tests__/select-price.test.ts
+++ b/src/lib/tint/__tests__/select-price.test.ts
@@ -26,15 +26,30 @@ describe('selectTintPrice — seleção honesta da fonte de preço (Passo 2, mon
     expect(r.motivoSemPreco).toBe('base');
   });
 
-  it('preço do cliente (negociado) vence quando existe e a base tem preço', () => {
+  it('Fase 3: o "último preço do cliente" NÃO vence mais por default — é opt-in no seletor', () => {
+    // Regra 2 removida (2026-07-19): a inferência silenciosa BAIXAVA o preço
+    // (contra a filosofia da 2b — baixar é escolha ATIVA). Com cliente 200,
+    // calc 190 e CSV 180, o default é o maior entre calc/CSV (regra 3), e o
+    // chip "Cliente" fica disponível no card para escolha explícita.
     const r = selectTintPrice({
       lastPracticedPrice: 200,
       precoCsv: 180,
       pricing: pricing({ precoFinal: 190 }),
     });
-    expect(r.source).toBe('cliente');
-    expect(r.precoSemDesconto).toBe(200);
-    expect(r.recalculado).toBe(false);
+    expect(r.source).toBe('calculado');
+    expect(r.precoSemDesconto).toBe(190);
+    expect(r.recalculado).toBe(true); // calc 190 > CSV 180 → Grupo B avisa, como sem cliente
+    expect(r.precoImportadoAnterior).toBe(180);
+  });
+
+  it('Fase 3: cliente MENOR que calc/CSV também não vence por default (não baixa silencioso)', () => {
+    const r = selectTintPrice({
+      lastPracticedPrice: 90,
+      precoCsv: 180,
+      pricing: pricing({ precoFinal: 190 }),
+    });
+    expect(r.source).toBe('calculado');
+    expect(r.precoSemDesconto).toBe(190);
   });
 
   it('Grupo B (calc > CSV): usa o calc e marca recalculado, guardando o importado anterior', () => {

--- a/src/lib/tint/select-price.ts
+++ b/src/lib/tint/select-price.ts
@@ -16,7 +16,12 @@
 //     base/corante inativo ou zerado). Diferente de "carregando" (aí o consumidor segura a venda).
 //  1. Base ausente/zero num produto vendável → SEM PREÇO, mesmo havendo CSV/cliente
 //     (o CSV também subfatura aqui; ex.: PRD03657). Corrigir no Omie.
-//  2. Preço do cliente (último praticado) vence — é acordo comercial explícito.
+//  2. [REMOVIDA — Fase 3, 2026-07-19] O "último preço do cliente" NÃO vence mais
+//     por default: era inferência silenciosa que BAIXAVA o preço (contra a
+//     filosofia da 2b — baixar é escolha ATIVA). A fonte 'cliente' segue no
+//     seletor do card como OPT-IN explícito da vendedora, agora endurecida
+//     server-side (RPC tint_ultimo_preco_cliente: só pedido real no Omie,
+//     não-cancelado, janela 180d) e revalidada no submit (tint_gate_revalida).
 //  3. Calc e CSV ambos: usa o MAIOR. calc > CSV (Grupo B) → recalcula e avisa o
 //     balcão ("a base não estava no importado"); calc ≈ CSV → usa o calc sem aviso;
 //     calc < CSV → mantém o CSV (não baixa na transição).
@@ -72,6 +77,8 @@ const comPreco = (
 ): TintPriceSelection => ({ source, precoSemDesconto, recalculado, precoImportadoAnterior, motivoSemPreco: null });
 
 export function selectTintPrice(input: {
+  /** Mantido na assinatura para o card montar o chip "Cliente" (opt-in) — a
+   *  SELEÇÃO default não o usa mais (regra 2 removida na Fase 3). */
   lastPracticedPrice: number | null;
   /** CSV bruto (>0) ou null/0; arredondado internamente. */
   precoCsv: number | null;
@@ -83,7 +90,7 @@ export function selectTintPrice(input: {
    *  produto desativado. ≠ `pricing == null` por loading (nesse caso o consumidor segura a venda). */
   motorFalhou?: boolean;
 }): TintPriceSelection {
-  const { lastPracticedPrice, pricing } = input;
+  const { pricing } = input;
 
   // 0. Motor falhou (≠ carregando) → SEM PREÇO, mesmo havendo CSV/cliente. A RPC não confirmou o
   //    preço honesto; cair no importado aqui venderia justamente o que a RPC poderia estar barrando.
@@ -101,8 +108,7 @@ export function selectTintPrice(input: {
     return semPreco('receita');
   }
 
-  // 2. Preço do cliente (negociado) vence.
-  if (lastPracticedPrice != null && lastPracticedPrice > 0) return comPreco('cliente', lastPracticedPrice);
+  // 2. (removida — Fase 3) 'cliente' é opt-in no seletor do card, nunca default.
 
   // 3. Calc e CSV coexistem → o MAIOR; avisa quando o calc sobe (Grupo B).
   if (calc != null && csv != null) {

--- a/src/pages/SalesQuotes.tsx
+++ b/src/pages/SalesQuotes.tsx
@@ -30,6 +30,12 @@ interface QuoteItem {
   descricao: string;
   tint_cor_id?: string;
   tint_nome_cor?: string;
+  // Fase 3: metadados de precificação persistidos no orçamento (podem estar
+  // ausentes em orçamento legado — o gate usa o piso min(fontes) nesse caso)
+  tint_formula_id?: string;
+  tint_price_source?: string;
+  tint_discount_pct?: number;
+  tint_preco_sem_desconto?: number;
 }
 
 const SalesQuotes = () => {
@@ -115,7 +121,17 @@ const SalesQuotes = () => {
         quantidade: i.quantidade,
         valor_unitario: i.valor_unitario,
         descricao: i.descricao,
-        ...(i.tint_cor_id ? { tint_cor_id: i.tint_cor_id, tint_nome_cor: i.tint_nome_cor } : {}),
+        ...(i.tint_cor_id ? {
+          tint_cor_id: i.tint_cor_id,
+          tint_nome_cor: i.tint_nome_cor,
+          // Fase 3: o gate da fronteira revalida a fonte declarada no orçamento
+          ...(i.tint_formula_id ? { tint_formula_id: i.tint_formula_id } : {}),
+          ...(i.tint_price_source ? {
+            tint_price_source: i.tint_price_source,
+            tint_discount_pct: i.tint_discount_pct ?? 0,
+            ...(i.tint_preco_sem_desconto != null ? { tint_preco_sem_desconto: i.tint_preco_sem_desconto } : {}),
+          } : {}),
+        } : {}),
       }));
 
       toast.info('Enviando pedido para o Omie...');
@@ -130,6 +146,20 @@ const SalesQuotes = () => {
       if ((omieData as { blocked?: string } | null)?.blocked === 'credito') {
         toast.warning('Conversão bloqueada por crédito', {
           description: 'Um gestor pode aprovar uma exceção para este pedido; depois é só reconverter.',
+        });
+        return;
+      }
+      if ((omieData as { blocked?: string } | null)?.blocked === 'tint_preco') {
+        // Gate tint Fase 3: o preço da tinta no orçamento ficou obsoleto (ou a
+        // fórmula mudou/morreu) desde que ele foi salvo. Orçamento intacto.
+        const bloqueios = (omieData as { bloqueios?: Array<{ cor_id?: string; detalhe?: string }> }).bloqueios;
+        const cores = [...new Set((bloqueios ?? []).map(b => b.cor_id).filter(Boolean))].join(', ');
+        setInvalidQuoteId(quote.id);
+        toast.error('Conversão bloqueada: preço de tinta desatualizado', {
+          description:
+            `${cores ? `Cor ${cores}: ` : ''}o preço/fórmula mudou desde que o orçamento foi salvo. ` +
+            'Refaça o item de tinta num pedido novo (o balcão recalcula) ou atualize o orçamento.',
+          duration: 12000,
         });
         return;
       }

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -552,8 +552,8 @@ const UnifiedOrder = () => {
           onClose={() => { h.setTintPendingProduct(null); setTintInitialSearch(null); }}
           customerUserId={h.customerUserId}
           initialSearch={tintInitialSearch}
-          onConfirm={(formulaId, corId, nomeCor, precoFinal, custoCorantes, alternativeProduct) => {
-            h.addTintProductToCart(alternativeProduct || h.tintPendingProduct!, formulaId, corId, nomeCor, precoFinal, custoCorantes);
+          onConfirm={(formulaId, corId, nomeCor, precoFinal, custoCorantes, pricingMeta, alternativeProduct) => {
+            h.addTintProductToCart(alternativeProduct || h.tintPendingProduct!, formulaId, corId, nomeCor, precoFinal, custoCorantes, pricingMeta);
             setTintInitialSearch(null);
           }}
         />

--- a/src/services/orderSubmission/submitOrder.ts
+++ b/src/services/orderSubmission/submitOrder.ts
@@ -21,10 +21,25 @@ import { ensureSalesOrderRow } from './idempotency';
 import { validarVendabilidade, bloqueioVendabilidade } from './vendabilidade';
 import { findInvalidPricedProductItems, invalidPriceMessage } from './priceGuard';
 
-/** Resposta estruturada do gate de crédito do edge (trava Fase 2 — não cria o PV). */
+/** Resposta estruturada dos gates do edge (crédito Fase 2 / tint Fase 3 — não cria o PV). */
 interface GateCreditoPayload {
   blocked?: string;
   gate?: { vencido?: number | null; titulos?: number | null } | null;
+  /** Fase 3: bloqueios do gate tintométrico (preço obsoleto/fórmula morta). */
+  bloqueios?: Array<{ cor_id?: string; motivo?: string; detalhe?: string }>;
+}
+
+/** Mensagem acionável do bloqueio tintométrico (gate da fronteira, Fase 3). */
+function mensagemBloqueioTint(
+  conta: string,
+  bloqueios?: Array<{ cor_id?: string; motivo?: string; detalhe?: string }>,
+): string {
+  const cores = [...new Set((bloqueios ?? []).map(b => b.cor_id).filter(Boolean))].join(', ');
+  const detalhe = bloqueios?.[0]?.detalhe ? ` ${bloqueios[0].detalhe}.` : '';
+  return (
+    `Pedido ${conta} BLOQUEADO: o preço da tinta${cores ? ` (cor ${cores})` : ''} está desatualizado ou a fórmula mudou.${detalhe} ` +
+    `Reprecifique o item pela tela de tinta (remova e adicione de novo) e reenvie.`
+  );
 }
 
 export function mensagemBloqueioCredito(
@@ -159,6 +174,12 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
         tint_cor_id: c.tint_cor_id,
         tint_nome_cor: c.tint_nome_cor,
         tint_formula_id: c.tint_formula_id,
+        // Fase 3: fonte/desconto declarados — auditoria no jsonb + insumo do gate
+        ...(c.tint_price_source ? {
+          tint_price_source: c.tint_price_source,
+          tint_discount_pct: c.tint_discount_pct ?? 0,
+          ...(c.tint_preco_sem_desconto != null ? { tint_preco_sem_desconto: c.tint_preco_sem_desconto } : {}),
+        } : {}),
       } : {}),
     }));
 
@@ -218,7 +239,17 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
               quantidade: c.quantity,
               valor_unitario: c.unit_price,
               descricao: c.product.descricao,
-              ...(c.tint_cor_id ? { tint_cor_id: c.tint_cor_id, tint_nome_cor: c.tint_nome_cor } : {}),
+              ...(c.tint_cor_id ? {
+                tint_cor_id: c.tint_cor_id,
+                tint_nome_cor: c.tint_nome_cor,
+                // Fase 3: o gate da fronteira revalida a fonte declarada
+                ...(c.tint_formula_id ? { tint_formula_id: c.tint_formula_id } : {}),
+                ...(c.tint_price_source ? {
+                  tint_price_source: c.tint_price_source,
+                  tint_discount_pct: c.tint_discount_pct ?? 0,
+                  ...(c.tint_preco_sem_desconto != null ? { tint_preco_sem_desconto: c.tint_preco_sem_desconto } : {}),
+                } : {}),
+              } : {}),
             })),
             observacao: meta.notes,
             codigo_parcela: payment.parcelaOben,
@@ -240,6 +271,11 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
               vencido: typeof gatePayload.gate?.vencido === 'number' ? gatePayload.gate.vencido : null,
               titulos: typeof gatePayload.gate?.titulos === 'number' ? gatePayload.gate.titulos : null,
             });
+          } else if (gatePayload?.blocked === 'tint_preco') {
+            // Gate tint Fase 3: preço obsoleto/fórmula morta — o edge NÃO criou o PV.
+            // O pedido local fica salvo; reprecificar no balcão e reenviar.
+            results.push('PV Oben (bloqueado: preço tinta)');
+            errors.push({ step: 'bloqueio_tint_oben', message: mensagemBloqueioTint('Oben', gatePayload.bloqueios) });
           } else {
             results.push(`PV Oben ${omieResult?.omie_numero_pedido || ''}`);
           }
@@ -567,7 +603,8 @@ export async function submitOrder(params: SubmitOrderParams): Promise<SubmitOrde
     errors,
     allConfirmed: !errors.some(e =>
       e.step === 'sync_oben_omie' || e.step === 'sync_colacor_omie' || e.step === 'sync_os_omie' ||
-      e.step === 'bloqueio_credito_oben' || e.step === 'bloqueio_credito_colacor'),
+      e.step === 'bloqueio_credito_oben' || e.step === 'bloqueio_credito_colacor' ||
+      e.step === 'bloqueio_tint_oben'),
     bloqueiosCredito,
   };
 }

--- a/src/services/orderSubmission/submitQuote.ts
+++ b/src/services/orderSubmission/submitQuote.ts
@@ -52,6 +52,13 @@ export async function submitQuote(params: SubmitQuoteParams): Promise<SubmitQuot
           tint_cor_id: c.tint_cor_id,
           tint_nome_cor: c.tint_nome_cor,
           tint_formula_id: c.tint_formula_id,
+          // Fase 3: fonte/desconto viajam no orçamento — a CONVERSÃO repassa ao
+          // edge e o gate revalida a fonte declarada contra o estado do dia.
+          ...(c.tint_price_source ? {
+            tint_price_source: c.tint_price_source,
+            tint_discount_pct: c.tint_discount_pct ?? 0,
+            ...(c.tint_preco_sem_desconto != null ? { tint_preco_sem_desconto: c.tint_preco_sem_desconto } : {}),
+          } : {}),
         } : {}),
       }));
       const { error } = await supabase.from('sales_orders').insert({

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -134,6 +134,12 @@ interface OrderItemPayload {
   desconto?: number;
   tint_cor_id?: string;
   tint_nome_cor?: string;
+  // Fase 3 tint: metadados de precificação do picker — insumo do gate de
+  // revalidação (tint_gate_revalida) na fronteira. Ausentes = item legado.
+  tint_formula_id?: string;
+  tint_price_source?: string;
+  tint_discount_pct?: number;
+  tint_preco_sem_desconto?: number;
 }
 
 // (OrderBatchRow/OrderItemBatchRow/PriceHistoryBatchRow removidos: o sync agora monta o payload
@@ -149,6 +155,11 @@ interface EditItemInput {
   valor_unitario: number;
   tint_cor_id?: string;
   tint_nome_cor?: string;
+  // Fase 3 tint: metadados de precificação (ver OrderItemPayload)
+  tint_formula_id?: string;
+  tint_price_source?: string;
+  tint_discount_pct?: number;
+  tint_preco_sem_desconto?: number;
 }
 
 interface OpItemInput {
@@ -2028,6 +2039,89 @@ async function gateCredito(
   return { permitido: false, gate };
 }
 
+// ── Gate tintométrico Fase 3 — revalidação de preço na fronteira comum ──
+// TODA via de pedido (submit, conversão de orçamento, edição, retry) cruza
+// criar_pedido/alterar_pedido; o guard do preço tint mora AQUI, não na UI
+// (money-path §5). A RPC tint_gate_revalida (provada em db/test-tint-gate-
+// revalida.sh) revalida cada item COM tint_cor_id contra o estado ATUAL:
+// canônica viva + preço recomputado + fonte declarada pela vendedora.
+// ⚠️ FAIL-CLOSED na indisponibilidade — deliberadamente ≠ gateCredito (que é
+// fail-open com log durável): (a) o blast radius é só pedido COM item tint
+// (o caminho comum nem chama a RPC); (b) o risco real aqui é a migration
+// custom NÃO aplicada no Lovable (falha silenciosa clássica) — fail-open
+// criaria um gate fantasma invisível; fail-closed grita na primeira venda.
+interface GateTintResultado {
+  ok: boolean;
+  bloqueios: Array<Record<string, unknown>>;
+  warnings?: Array<Record<string, unknown>>;
+}
+
+async function gateTintPreco(
+  supabase: SupabaseClient,
+  account: Account,
+  customerUserId: string | null,
+  salesOrderId: string,
+  contexto: "criacao" | "edicao",
+  items: Array<{ tint_cor_id?: string; omie_codigo_produto?: number | string }>,
+): Promise<{ permitido: true } | { permitido: false; bloqueios: Array<Record<string, unknown>> }> {
+  if (items.length === 0) return { permitido: true };
+
+  // Classificação em BATCH antes da RPC (Codex P1 do diff): a RPC só roda
+  // quando há marcador tint, produto classificado como BASE tintométrica ou
+  // código ilegível (que a RPC bloqueia como payload_invalido). Assim uma
+  // migration ausente/RPC indisponível NÃO derruba venda comum — o blast
+  // radius do fail-closed fica restrito a pedido com cara de tint. A
+  // classificação lê omie_products (tabela pré-existente — funciona mesmo
+  // sem a migration da Fase 3).
+  const temMarcador = items.some((i) => typeof i.tint_cor_id === "string" && i.tint_cor_id.length > 0);
+  const codigos = [...new Set(items.map((i) => Number(i.omie_codigo_produto)).filter((n) => Number.isFinite(n) && n > 0))];
+  const temCodigoIlegivel = items.some((i) => !Number.isFinite(Number(i.omie_codigo_produto)) || Number(i.omie_codigo_produto) <= 0);
+  let temBaseTint = false;
+  if (!temMarcador && !temCodigoIlegivel && codigos.length > 0) {
+    const { data: prods, error: clsErr } = await supabase
+      .from("omie_products")
+      .select("omie_codigo_produto, is_tintometric, tint_type")
+      .eq("account", account)
+      .in("omie_codigo_produto", codigos);
+    if (clsErr) {
+      // classificação indisponível = não sei se há base tint ⇒ fail-closed
+      // (mesma infra da RPC; se isto falhou, nada do pedido funcionaria)
+      throw new Error(`Classificação tintométrica indisponível (${clsErr.message}) — pedido não enviado (fail-closed).`);
+    }
+    temBaseTint = (prods ?? []).some(
+      (p) => (p as { is_tintometric?: boolean; tint_type?: string | null }).is_tintometric === true &&
+        (p as { tint_type?: string | null }).tint_type === "base",
+    );
+  }
+  if (!temMarcador && !temBaseTint && !temCodigoIlegivel) return { permitido: true };
+
+  const { data, error } = await supabase.rpc("tint_gate_revalida", {
+    p_account: account,
+    p_customer_user_id: customerUserId,
+    p_sales_order_id: salesOrderId,
+    p_contexto: contexto,
+    p_items: items,
+  });
+  if (error) {
+    throw new Error(
+      `Gate tintométrico indisponível (${error.message}) — pedido com item de tinta NÃO enviado (fail-closed). ` +
+        `Confira se a migration 20260722100001_tint_gate_revalida_submit foi aplicada.`,
+    );
+  }
+  const r = data as GateTintResultado | null;
+  if (!r || typeof r.ok !== "boolean") {
+    throw new Error("Gate tintométrico devolveu resposta inválida — pedido NÃO enviado (fail-closed).");
+  }
+  if (!r.ok) {
+    console.warn(`[gate-tint][${account}] pedido bloqueado:`, JSON.stringify(r.bloqueios));
+    return { permitido: false, bloqueios: r.bloqueios };
+  }
+  if (r.warnings && r.warnings.length > 0) {
+    console.log(`[gate-tint][${account}] warnings:`, JSON.stringify(r.warnings));
+  }
+  return { permitido: true };
+}
+
 // Só as actions de SYNC logam (não as interativas de PV). Com action LIKE 'sync_%'
 // + companies=[account], a varredura de órfãs (>30min) e o sinal sync_error do
 // watchdog (#330) passam a cobrir vendas SEM mudar o watchdog. BEST-EFFORT: uma
@@ -2412,6 +2506,22 @@ serve(async (req) => {
           result = { success: false, blocked: "credito", gate: credito.gate };
           break;
         }
+        // Gate tintométrico Fase 3: revalida preço/fórmula dos itens tint contra
+        // o estado ATUAL, IMEDIATAMENTE antes da mutação Omie (janela TOCTOU
+        // mínima — veredito Codex). Bloqueio = 200 estruturado, pedido local
+        // intacto p/ retry após reprecificar no balcão.
+        const gateTint = await gateTintPreco(
+          supabaseAdmin,
+          account,
+          soRow?.customer_user_id ?? null,
+          sales_order_id,
+          "criacao",
+          items as Array<{ tint_cor_id?: string }>,
+        );
+        if (!gateTint.permitido) {
+          result = { success: false, blocked: "tint_preco", bloqueios: gateTint.bloqueios };
+          break;
+        }
         const pedido = await criarPedidoVenda(
           supabaseAdmin,
           sales_order_id,
@@ -2487,6 +2597,24 @@ serve(async (req) => {
         // revalidar — é onde um produto desativado depois da criação do PV passaria batido.
         await assertOmieItemsAtivos(supabaseAdmin, editItems, editAccount);
 
+        // Gate tintométrico Fase 3: a edição re-envia TODOS os itens ao Omie.
+        // Revalida ANTES do delete+add destrutivo, contra o BASELINE persistido
+        // (o front só persiste APÓS o sucesso — o baseline é o estado pré-
+        // edição): item tint IDÊNTICO passa com warning (já está no Omie);
+        // novo/alterado revalida; base-sem-cor só passa intocada (inbound).
+        const gateTintEdit = await gateTintPreco(
+          supabaseAdmin,
+          editAccount,
+          (existingOrder as { customer_user_id?: string | null }).customer_user_id ?? null,
+          editSoId,
+          "edicao",
+          editItems as Array<{ tint_cor_id?: string }>,
+        );
+        if (!gateTintEdit.permitido) {
+          result = { success: false, blocked: "tint_preco", contexto: "edicao", bloqueios: gateTintEdit.bloqueios };
+          break;
+        }
+
         // Build updated items payload for local DB
         const editItemsTyped: EditItemInput[] = editItems;
         const updatedItemsPayload = editItemsTyped.map((item) => ({
@@ -2498,7 +2626,19 @@ serve(async (req) => {
           quantidade: item.quantidade,
           valor_unitario: item.valor_unitario,
           valor_total: item.quantidade * item.valor_unitario,
-          ...(item.tint_cor_id ? { tint_cor_id: item.tint_cor_id, tint_nome_cor: item.tint_nome_cor } : {}),
+          ...(item.tint_cor_id
+            ? {
+                tint_cor_id: item.tint_cor_id,
+                tint_nome_cor: item.tint_nome_cor,
+                // Fase 3: preservar auditoria de precificação no jsonb local
+                ...(item.tint_formula_id ? { tint_formula_id: item.tint_formula_id } : {}),
+                ...(item.tint_price_source ? { tint_price_source: item.tint_price_source } : {}),
+                ...(typeof item.tint_discount_pct === "number" ? { tint_discount_pct: item.tint_discount_pct } : {}),
+                ...(typeof item.tint_preco_sem_desconto === "number"
+                  ? { tint_preco_sem_desconto: item.tint_preco_sem_desconto }
+                  : {}),
+              }
+            : {}),
         }));
         const updatedSubtotal = updatedItemsPayload.reduce((s: number, i) => s + i.valor_total, 0);
 
@@ -2807,8 +2947,12 @@ serve(async (req) => {
           validated_items: finalOmieItems.length,
         };
 
-        // Update local DB
-        await supabaseAdmin
+        // Write-back local CHECADO (Codex P1 do diff): o front agora depende
+        // EXCLUSIVAMENTE deste update (não persiste antes do gate — o baseline
+        // é sagrado). Erro/0-linhas aqui com o Omie JÁ mutado = estado
+        // divergente → devolver ERRO explícito (nunca success), para o caller
+        // avisar e ninguém re-salvar por cima sem recarregar.
+        const { data: editWb, error: editWbErr } = await supabaseAdmin
           .from("sales_orders")
           .update({
             items: updatedItemsPayload,
@@ -2819,7 +2963,15 @@ serve(async (req) => {
             omie_response: editResult,
             updated_at: new Date().toISOString(),
           })
-          .eq("id", editSoId);
+          .eq("id", editSoId)
+          .select("id");
+        if (editWbErr || !editWb || editWb.length !== 1) {
+          throw new Error(
+            `Omie ATUALIZADO (${editItems.length} itens) mas o registro local falhou ` +
+              `(${editWbErr?.message ?? `${editWb?.length ?? 0} linhas`}) — NÃO re-salve sem recarregar o pedido; ` +
+              `o Omie está com a versão nova e o app com a antiga.`,
+          );
+        }
 
         result = { success: true, omie_response: editResult };
         break;

--- a/supabase/migrations/20260722100001_tint_gate_revalida_submit.sql
+++ b/supabase/migrations/20260722100001_tint_gate_revalida_submit.sql
@@ -1,0 +1,560 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Tintométrico Fase 3 — revalidação no SUBMIT (a fronteira que TODA via cruza)
+--
+-- Problema (plano 2026-07-17 §Fase 3): a proteção de preço tint vive só na UI
+-- do picker (selectTintPrice). O cache de preço dura 5min; a conversão de
+-- orçamento (SalesQuotes.convertToOrder), a edição (useSalesOrderEdit) e o
+-- retry idempotente re-enviam `valor_unitario` persistido/velho DIRETO ao edge
+-- omie-vendas-sync → preço obsoleto/fórmula morta vira PV real no Omie sem
+-- barreira (subfaturamento silencioso — o mesmo mal das 240 receitas parciais).
+--
+-- Fecho: o edge (criar_pedido/alterar_pedido — fronteira final comum) chama
+-- `tint_gate_revalida` ANTES de tocar o Omie. Regras (endurecidas por DOIS
+-- challenges Codex xhigh 2026-07-19 — design e diff):
+--   1. A identificação de item tint NÃO depende só do marcador `tint_cor_id`
+--      do payload (removível pelo caller): item SEM cor cujo PRODUTO é base
+--      tintométrica (omie_products.is_tintometric AND tint_type='base') é
+--      bloqueado na criação (o push nunca produziu base sem cor — 0 na
+--      história) e, na edição, só passa se IDÊNTICO ao baseline persistido
+--      (linha inbound do balcão físico preservada — 5.167 no histórico).
+--      `omie_codigo_produto` aceita number OU string numérica (o edge trafega
+--      os dois) — código não-numérico é payload_invalido, nunca "não-tint".
+--   2. Fórmula canônica ATUAL resolvida por (produto→sku→v_tint_formula_
+--      canonica); desativada/inexistente ⇒ bloqueia (formula_morta). Fonte
+--      DECLARADA exige `tint_formula_id` válido e pertencente a (conta, cor)
+--      — sem isso, payload_invalido (anti-adulteração). Produto com MAIS de
+--      um SKU candidato para a cor e sem fórmula declarada que desambigue ⇒
+--      bloqueia (formula_ambigua) — nunca desempatar célula por UUID.
+--   3. Preço recomputado AGORA (get_tint_price + preco_csv_legado); motor sem
+--      preço ⇒ bloqueia TODAS as fontes (paridade com selectTintPrice regra 1).
+--   4. Valida contra a FONTE DECLARADA (tint_price_source + tint_discount_pct,
+--      0 ≤ d < 100) — preserva a ESCOLHA da vendedora (2b: "tabela versão
+--      anterior" é legítima; o que barra é preço OBSOLETO, não a escolha).
+--      Fonte 'manual' = preço digitado na edição: passa se ≥ piso atual
+--      min(calc, tabela) — subir é livre, baixar além do piso não.
+--   5. Item sem metadados só cai no piso legado min(fontes) com PROVA de
+--      proveniência server-side: o item correspondente no jsonb PERSISTIDO
+--      (sales_orders.items) também não tem metadados. Payload que OMITE
+--      metadados que o persistido tem ⇒ bloqueia (metadados_ausentes).
+--   6. Edição: item tint IDÊNTICO ao baseline (produto+cor+qtd+valor+fonte+
+--      desconto, com CONTAGEM por assinatura) passa com warning — o valor já
+--      está no Omie; barrar impediria editar parcela/observação. Item novo/
+--      alterado revalida. ⚠️ Pré-requisito: o caller NÃO persiste items antes
+--      do gate (o front da edição aguarda o edge — Codex P1 do design).
+--   7. Fonte 'cliente' validada por tint_ultimo_preco_cliente EXCLUINDO o
+--      próprio pedido (p_exclude_sales_order_id) — anti-autovalidação.
+--
+-- `tint_ultimo_preco_cliente` substitui a inferência crua do picker
+-- (useTintColorSelect ~:229 — 50 pedidos SEM filtro de status): só pedido REAL
+-- no Omie (omie_pedido_id NOT NULL), não-cancelado, janela de 180 dias — e o
+-- MESMO helper valida a fonte no gate (paridade estrutural, zero espelho).
+--
+-- Paridade numérica com o cliente JS (por construção, não por tolerância):
+-- toda a aritmética roda em FLOAT8 (IEEE754 = Number do JS), a partir do MESMO
+-- texto decimal que o PostgREST serializa ao front:
+--   ceil10:  ceil(v*10)/10           ≡ Math.ceil(v*10)/10        (select-price)
+--   round2:  floor(v*100 + 0.5)/100  ≡ Math.round(v*100)/100     (desconto)
+-- (round(dp) do Postgres é half-to-even ≠ Math.round — por isso floor+0.5.)
+-- Comparação final com tolerância 0.005 (igualdade de centavos).
+--
+-- Autorização: tint_gate_revalida é service_role-only (só o edge chama;
+-- REVOKE por nome — FROM PUBLIC não tira anon/authenticated no Supabase).
+-- tint_ultimo_preco_cliente é INVOKER com grant a authenticated: sob o picker
+-- ela respeita a RLS de sales_orders EXATAMENTE como a query crua que
+-- substitui (não dá acesso novo); sob o edge (service_role) bypassa como hoje.
+--
+-- Prova: db/test-tint-gate-revalida.sh (PG17, snapshot + migrations reais,
+-- falsificação por invariante). Plano: docs/superpowers/plans/
+-- 2026-07-17-tint-receita-perdida-remediacao.md §Fase 3.
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1. Último preço PRATICADO do cliente para (produto, cor) — endurecido.
+--    Fonte única da inferência 'cliente': o picker (authenticated, sob RLS)
+--    e o gate (service_role) chamam a MESMA função. p_exclude_sales_order_id
+--    tira o pedido CORRENTE da inferência (anti-autovalidação na edição).
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.tint_ultimo_preco_cliente(
+  p_customer_user_id uuid,
+  p_product_id uuid,
+  p_cor_id text,
+  p_exclude_sales_order_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT jsonb_build_object(
+    'price', (it.item->>'valor_unitario')::float8,
+    'date',  so.created_at,
+    'sales_order_id', so.id
+  )
+  FROM public.sales_orders so
+  -- CASE defensivo: linha histórica com items não-array NÃO pode derrubar a
+  -- RPC (a ordem de avaliação WHERE×LATERAL não é garantida pelo planner —
+  -- um typeof no WHERE não protegeria o jsonb_array_elements).
+  CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN jsonb_typeof(so.items) = 'array' THEN so.items ELSE '[]'::jsonb END
+  ) AS it(item)
+  WHERE so.customer_user_id = p_customer_user_id
+    AND so.account = 'oben'
+    -- acordo comercial só conta se virou pedido REAL no Omie…
+    AND so.omie_pedido_id IS NOT NULL
+    -- …não-cancelado…
+    AND so.status IS DISTINCT FROM 'cancelado'
+    -- …recente (validade da inferência; fora da janela = renegociar)…
+    AND so.created_at >= now() - interval '180 days'
+    -- …e NUNCA o pedido que está sendo validado (anti-autovalidação)
+    AND (p_exclude_sales_order_id IS NULL OR so.id <> p_exclude_sales_order_id)
+    AND it.item->>'product_id' = p_product_id::text
+    AND it.item->>'tint_cor_id' = p_cor_id
+    AND jsonb_typeof(it.item->'valor_unitario') = 'number'
+    AND (it.item->>'valor_unitario')::float8 > 0
+  ORDER BY so.created_at DESC
+  LIMIT 1
+$$;
+
+COMMENT ON FUNCTION public.tint_ultimo_preco_cliente(uuid, uuid, text, uuid) IS
+  'Fase 3 tint: último preço praticado do cliente para (produto omie, cor) — '
+  'só pedido real no Omie, não-cancelado, janela 180d, excluindo o pedido '
+  'corrente (anti-autovalidação). Fonte ÚNICA da fonte "cliente": o picker '
+  '(INVOKER, sob RLS) e o gate do submit usam a mesma função. NULL = sem '
+  'acordo comprovado na janela.';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2. O gate da fronteira: revalida cada item tint do payload contra o estado
+--    ATUAL (canônica + motor + fonte declarada), usando o jsonb PERSISTIDO
+--    como baseline de proveniência (legado × novo) e de intocabilidade.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.tint_gate_revalida(
+  p_account text,
+  p_customer_user_id uuid,
+  p_sales_order_id uuid,
+  p_contexto text,
+  p_items jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_bloqueios jsonb := '[]'::jsonb;
+  v_warnings  jsonb := '[]'::jsonb;
+  v_baseline  jsonb;
+  v_base_sigs jsonb;              -- {assinatura: count} do baseline
+  v_usados    jsonb := '{}'::jsonb; -- {assinatura: count} já consumidos do payload
+  v_item      jsonb;
+  v_idx       int;
+  v_cor       text;
+  v_cod_txt   text;
+  v_sig       text;
+  v_base_n    int;
+  v_uso_n     int;
+  v_declarada uuid;
+  v_declarada_coerente boolean;
+  v_prod_id   uuid;
+  v_is_base_tint boolean;
+  v_n_skus    int;
+  v_can_id    uuid;
+  v_can_csv   numeric;
+  v_price     jsonb;
+  v_calc_raw  float8;
+  v_calc      float8;
+  v_tab       float8;
+  v_vu        float8;
+  v_fonte     text;
+  v_desc      float8;
+  v_esperado  float8;
+  v_floor     float8;
+  v_ult       jsonb;
+  v_motivo    text;
+  v_legado_ok boolean;
+
+  -- espelhos JS (float8 de ponta a ponta — ver cabeçalho):
+  --   ceil10(v) ≡ Math.ceil(v*10)/10 · round2(v) ≡ floor(v*100+0.5)/100
+BEGIN
+  IF p_contexto NOT IN ('criacao', 'edicao') THEN
+    RETURN jsonb_build_object('ok', false, 'bloqueios', jsonb_build_array(
+      jsonb_build_object('index', -1, 'motivo', 'payload_invalido',
+                         'detalhe', 'contexto desconhecido: ' || COALESCE(p_contexto, 'NULL'))),
+      'warnings', v_warnings);
+  END IF;
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' THEN
+    RETURN jsonb_build_object('ok', false, 'bloqueios', jsonb_build_array(
+      jsonb_build_object('index', -1, 'motivo', 'payload_invalido',
+                         'detalhe', 'items ausente ou não é array')),
+      'warnings', v_warnings);
+  END IF;
+
+  -- Baseline PERSISTIDO (fonte de proveniência/intocabilidade — o caller não
+  -- controla; a edição só persiste APÓS o gate). Linha ausente ⇒ '[]'.
+  SELECT CASE WHEN jsonb_typeof(so.items) = 'array' THEN so.items ELSE '[]'::jsonb END
+    INTO v_baseline
+  FROM public.sales_orders so WHERE so.id = p_sales_order_id;
+  v_baseline := COALESCE(v_baseline, '[]'::jsonb);
+
+  -- Assinaturas do baseline (com contagem): T|produto|cor|qtd|valor|fonte|desc
+  -- para item tint; B|produto|qtd|valor para base-sem-cor. Números
+  -- canonicalizados via float8::text; campo malformado vira '?' (nunca erro).
+  SELECT COALESCE(jsonb_object_agg(sig, n), '{}'::jsonb) INTO v_base_sigs
+  FROM (
+    SELECT
+      CASE WHEN bi.item->>'tint_cor_id' IS NOT NULL AND bi.item->>'tint_cor_id' <> '' THEN
+        'T|' || COALESCE(bi.item->>'omie_codigo_produto', '?') || '|' || (bi.item->>'tint_cor_id') || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'quantidade') = 'number'
+                     THEN ((bi.item->>'quantidade')::float8)::text ELSE '?' END || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'valor_unitario') = 'number'
+                     THEN ((bi.item->>'valor_unitario')::float8)::text ELSE '?' END || '|'
+             || COALESCE(bi.item->>'tint_price_source', '-') || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'tint_discount_pct') = 'number'
+                     THEN ((bi.item->>'tint_discount_pct')::float8)::text ELSE '0' END
+      ELSE
+        'B|' || COALESCE(bi.item->>'omie_codigo_produto', '?') || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'quantidade') = 'number'
+                     THEN ((bi.item->>'quantidade')::float8)::text ELSE '?' END || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'valor_unitario') = 'number'
+                     THEN ((bi.item->>'valor_unitario')::float8)::text ELSE '?' END
+      END AS sig,
+      count(*) AS n
+    FROM jsonb_array_elements(v_baseline) AS bi(item)
+    GROUP BY 1
+  ) s;
+
+  FOR v_idx, v_item IN
+    SELECT (ord - 1)::int, val
+    FROM jsonb_array_elements(p_items) WITH ORDINALITY AS t(val, ord)
+  LOOP
+    v_cor := NULLIF(v_item->>'tint_cor_id', '');
+
+    -- valor_unitario numérico (o edge já barrou ≤0/NaN antes; defesa em profundidade)
+    IF jsonb_typeof(v_item->'valor_unitario') <> 'number' THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'payload_invalido',
+        'detalhe', 'valor_unitario não numérico');
+      CONTINUE;
+    END IF;
+    v_vu := (v_item->>'valor_unitario')::float8;
+
+    -- Código do produto: number OU string numérica (o edge trafega os dois —
+    -- Codex P1 do diff: "900001" string escapava da classificação). Código
+    -- ilegível NUNCA vira "não-tint": é payload_invalido (fail-closed).
+    v_cod_txt := v_item->>'omie_codigo_produto';
+    IF v_cod_txt IS NULL OR v_cod_txt !~ '^[0-9]{1,15}$' THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'payload_invalido',
+        'detalhe', 'omie_codigo_produto ausente/não numérico: ' || COALESCE(v_cod_txt, 'NULL'));
+      CONTINUE;
+    END IF;
+
+    v_prod_id := NULL; v_is_base_tint := false;
+    SELECT op.id, COALESCE(op.is_tintometric, false) AND op.tint_type = 'base'
+      INTO v_prod_id, v_is_base_tint
+    FROM public.omie_products op
+    WHERE op.omie_codigo_produto = v_cod_txt::bigint
+      AND op.account = p_account;
+
+    IF v_cor IS NULL THEN
+      -- Item SEM marcador tint: só interessa se o PRODUTO é base tintométrica
+      -- (classificação server-side — a ausência do marcador NÃO decide sozinha;
+      -- Codex P1: omitir tint_cor_id não pode desligar o gate).
+      CONTINUE WHEN NOT v_is_base_tint;
+      IF p_contexto = 'criacao' THEN
+        -- Push nunca produziu base sem cor (0 na história) — omissão = bloqueio.
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'motivo', 'base_sem_cor',
+          'detalhe', 'base tintométrica sem cor não é vendável pelo app — escolha a cor no balcão de tinta');
+        CONTINUE;
+      END IF;
+      -- Edição: linha inbound (balcão físico, importada do Omie) é legítima —
+      -- mas SÓ intocada (mesma assinatura B| com contagem no baseline).
+      v_sig := 'B|' || v_cod_txt || '|'
+            || CASE WHEN jsonb_typeof(v_item->'quantidade') = 'number'
+                    THEN ((v_item->>'quantidade')::float8)::text ELSE '?' END || '|'
+            || (v_vu)::text;
+      v_base_n := COALESCE((v_base_sigs->>v_sig)::int, 0);
+      v_uso_n  := COALESCE((v_usados->>v_sig)::int, 0);
+      IF v_uso_n < v_base_n THEN
+        v_usados := jsonb_set(v_usados, ARRAY[v_sig], to_jsonb(v_uso_n + 1));
+        CONTINUE; -- inbound preservada
+      END IF;
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'motivo', 'base_sem_cor_alterada',
+        'detalhe', 'base tintométrica sem cor alterada/nova na edição — reprecifique pela tela de tinta');
+      CONTINUE;
+    END IF;
+
+    -- ── item COM tint_cor_id ──
+    IF v_prod_id IS NULL THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'produto_nao_encontrado',
+        'detalhe', 'produto do item tint não existe na conta ' || p_account);
+      CONTINUE;
+    END IF;
+
+    -- Edição: item IDÊNTICO ao baseline (assinatura completa, com contagem)
+    -- passa com warning — o valor já está no Omie; barrar impediria editar
+    -- parcela/observação. Item novo/alterado segue para a validação.
+    IF p_contexto = 'edicao' THEN
+      v_sig := 'T|' || v_cod_txt || '|' || v_cor || '|'
+            || CASE WHEN jsonb_typeof(v_item->'quantidade') = 'number'
+                    THEN ((v_item->>'quantidade')::float8)::text ELSE '?' END || '|'
+            || (v_vu)::text || '|'
+            || COALESCE(v_item->>'tint_price_source', '-') || '|'
+            || CASE WHEN jsonb_typeof(v_item->'tint_discount_pct') = 'number'
+                    THEN ((v_item->>'tint_discount_pct')::float8)::text ELSE '0' END;
+      v_base_n := COALESCE((v_base_sigs->>v_sig)::int, 0);
+      v_uso_n  := COALESCE((v_usados->>v_sig)::int, 0);
+      IF v_uso_n < v_base_n THEN
+        v_usados := jsonb_set(v_usados, ARRAY[v_sig], to_jsonb(v_uso_n + 1));
+        v_warnings := v_warnings || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'aviso', 'tint_intocado',
+          'detalhe', 'item tint idêntico ao pedido persistido — preço não revalidado (já está no Omie)');
+        CONTINUE;
+      END IF;
+    END IF;
+
+    -- fórmula declarada (cast defensivo — uuid inválido vira NULL)
+    v_declarada := NULL;
+    IF (v_item->>'tint_formula_id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+      v_declarada := (v_item->>'tint_formula_id')::uuid;
+    END IF;
+    -- fórmula declarada COERENTE = existe em tint_formulas para (conta, cor) —
+    -- qualquer geração (a declarada pode ser a gêmea re-canonizada). Fórmula
+    -- ALHEIA (outra conta/cor) ou inexistente NÃO desambigua nem audita nada.
+    v_declarada_coerente := false;
+    IF v_declarada IS NOT NULL THEN
+      SELECT EXISTS (
+        SELECT 1 FROM public.tint_formulas tf
+        WHERE tf.id = v_declarada AND tf.account = p_account AND tf.cor_id = v_cor
+      ) INTO v_declarada_coerente;
+    END IF;
+
+    v_fonte := v_item->>'tint_price_source';
+
+    -- Fonte declarada pelo PICKER exige a fórmula que o picker viu (anti-
+    -- adulteração — Codex P1 do diff). 'manual' (edição humana) e legado não
+    -- têm picker por trás, então não exigem.
+    IF v_fonte IN ('calculado', 'tabela', 'cliente') AND NOT v_declarada_coerente THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'payload_invalido',
+        'detalhe', 'fonte declarada sem tint_formula_id válido de (conta, cor) — reprecifique no balcão de tinta');
+      CONTINUE;
+    END IF;
+
+    -- Canônicas candidatas da célula: produto pode ter MAIS de um SKU com a
+    -- cor. Sem fórmula declarada que desambigue, célula ambígua BLOQUEIA
+    -- (nunca desempatar preço por UUID — Codex P1 do diff).
+    SELECT count(*) INTO v_n_skus
+    FROM public.tint_skus s
+    JOIN public.v_tint_formula_canonica c
+      ON c.account = p_account AND c.sku_id = s.id AND c.cor_id = v_cor
+    WHERE s.omie_product_id = v_prod_id
+      AND s.account = p_account;
+
+    IF v_n_skus = 0 THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'formula_morta',
+        'detalhe', 'não há fórmula ativa/canônica desta cor para o produto — reprecifique no balcão de tinta');
+      CONTINUE;
+    END IF;
+
+    v_can_id := NULL; v_can_csv := NULL;
+    IF v_n_skus > 1 THEN
+      -- só a fórmula declarada (do picker) desambigua a célula
+      SELECT c.id, c.preco_csv_legado INTO v_can_id, v_can_csv
+      FROM public.tint_skus s
+      JOIN public.v_tint_formula_canonica c
+        ON c.account = p_account AND c.sku_id = s.id AND c.cor_id = v_cor
+      WHERE s.omie_product_id = v_prod_id
+        AND s.account = p_account
+        AND c.id = v_declarada;
+      IF v_can_id IS NULL THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'formula_ambigua',
+          'detalhe', 'o produto tem mais de um SKU com esta cor e a fórmula declarada não resolve — reprecifique no balcão de tinta');
+        CONTINUE;
+      END IF;
+    ELSE
+      SELECT c.id, c.preco_csv_legado INTO v_can_id, v_can_csv
+      FROM public.tint_skus s
+      JOIN public.v_tint_formula_canonica c
+        ON c.account = p_account AND c.sku_id = s.id AND c.cor_id = v_cor
+      WHERE s.omie_product_id = v_prod_id
+        AND s.account = p_account;
+    END IF;
+
+    IF v_declarada_coerente AND v_declarada <> v_can_id THEN
+      -- geração trocou (ex.: Fase 5 desativar a SAYERLACK) — informa, não barra;
+      -- o PREÇO é validado contra a canônica atual de qualquer forma.
+      v_warnings := v_warnings || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'aviso', 'formula_recanonizada',
+        'declarada', v_declarada, 'canonica', v_can_id);
+    END IF;
+
+    -- motor de preço AGORA (get_tint_price REAL — sem cache de 5min)
+    v_price := public.get_tint_price(v_can_id);
+    v_calc_raw := (v_price->>'precoFinal')::float8;
+    IF v_calc_raw IS NULL THEN
+      -- paridade com selectTintPrice regra 1: motor sem preço bloqueia TODAS
+      -- as fontes (inclusive tabela/cliente) — nunca vender o que a RPC barra.
+      v_motivo := CASE
+        WHEN NOT COALESCE((v_price->>'baseDisponivel')::boolean, false) THEN 'base'
+        WHEN NOT COALESCE((v_price->>'corantesCompletos')::boolean, false) THEN 'corante'
+        ELSE 'receita' END;
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'sem_preco_motor',
+        'detalhe', 'motor honesto sem preço (' || v_motivo || ') — corrija no Omie/tintométrico antes de vender');
+      CONTINUE;
+    END IF;
+
+    v_calc := ceil(v_calc_raw * 10) / 10;                       -- ceil10 (≡ JS)
+    v_tab  := CASE WHEN v_can_csv IS NOT NULL AND v_can_csv > 0
+                   THEN ceil((v_can_csv)::float8 * 10) / 10 ELSE NULL END;
+
+    -- desconto declarado (0 ≤ d < 100; ausente = 0). d=100 é incompatível com
+    -- o guard global preço>0 do edge — contrato alinhado (Codex).
+    v_desc := 0;
+    IF v_item ? 'tint_discount_pct' THEN
+      IF jsonb_typeof(v_item->'tint_discount_pct') <> 'number' THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'desconto_invalido',
+          'detalhe', 'tint_discount_pct não numérico');
+        CONTINUE;
+      END IF;
+      v_desc := (v_item->>'tint_discount_pct')::float8;
+      IF v_desc < 0 OR v_desc >= 100 THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'desconto_invalido',
+          'detalhe', 'tint_discount_pct fora de 0–99.99: ' || v_desc);
+        CONTINUE;
+      END IF;
+    END IF;
+
+    IF v_fonte = 'calculado' THEN
+      v_esperado := floor(v_calc * (1 - v_desc/100) * 100 + 0.5) / 100;
+
+    ELSIF v_fonte = 'tabela' THEN
+      IF v_tab IS NULL THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'fonte_tabela_indisponivel',
+          'detalhe', 'a fonte "tabela" foi escolhida mas a chave não tem mais CSV — reprecifique no balcão');
+        CONTINUE;
+      END IF;
+      v_esperado := floor(v_tab * (1 - v_desc/100) * 100 + 0.5) / 100;
+
+    ELSIF v_fonte = 'cliente' THEN
+      v_ult := public.tint_ultimo_preco_cliente(
+        p_customer_user_id, v_prod_id, v_cor, p_sales_order_id);
+      IF v_ult IS NULL OR jsonb_typeof(v_ult->'price') <> 'number' THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_cliente_sem_historico',
+          'detalhe', 'a fonte "cliente" exige pedido real no Omie (não-cancelado, últimos 180 dias) — não encontrado');
+        CONTINUE;
+      END IF;
+      v_esperado := floor((v_ult->>'price')::float8 * (1 - v_desc/100) * 100 + 0.5) / 100;
+
+    ELSIF v_fonte = 'manual' THEN
+      -- Preço digitado pelo humano na EDIÇÃO (o front seta 'manual' ao editar
+      -- valor de item tint): subir é livre; baixar além do piso atual das
+      -- fontes legítimas bloqueia. Nada abaixo do que 'tabela'/'calculado'
+      -- sem desconto já permitiriam (Codex P1 do diff: sem esta fonte, todo
+      -- aumento manual legítimo caía em metadados_ausentes).
+      v_floor := LEAST(v_calc, COALESCE(v_tab, v_calc));
+      IF v_vu < v_floor - 0.005 THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_obsoleto',
+          'detalhe', 'preço manual abaixo do piso atual das fontes (calc/tabela) — reprecifique no balcão de tinta',
+          'esperado_minimo', v_floor, 'recebido', v_vu);
+      END IF;
+      CONTINUE;
+
+    ELSIF v_fonte IS NULL THEN
+      -- SEM metadados: o fallback legado (piso) EXIGE prova de proveniência —
+      -- existe no baseline persistido um item da MESMA célula TAMBÉM sem fonte
+      -- (orçamento/pedido pré-Fase-3). Sem essa prova, item novo que omite
+      -- metadados é bloqueado (o fallback não é controlável pelo caller).
+      SELECT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(v_baseline) AS bi(item)
+        WHERE bi.item->>'omie_codigo_produto' = v_cod_txt
+          AND bi.item->>'tint_cor_id' = v_cor
+          AND bi.item->>'tint_price_source' IS NULL
+      ) INTO v_legado_ok;
+      IF NOT v_legado_ok THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'metadados_ausentes',
+          'detalhe', 'item tint sem fonte de preço declarada e sem lastro legado no pedido — reprecifique no balcão de tinta');
+        CONTINUE;
+      END IF;
+      v_floor := LEAST(v_calc, COALESCE(v_tab, v_calc));
+      IF v_vu < v_floor - 0.005 THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_obsoleto',
+          'detalhe', 'preço abaixo do piso atual das fontes (calc/tabela) — reprecifique no balcão de tinta',
+          'esperado_minimo', v_floor, 'recebido', v_vu);
+      END IF;
+      CONTINUE;
+
+    ELSE
+      -- fonte desconhecida (typo/adulteração) — nunca cair no fallback
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'fonte_invalida',
+        'detalhe', 'tint_price_source desconhecida: ' || v_fonte);
+      CONTINUE;
+    END IF;
+
+    -- Auditoria: preco_sem_desconto declarado divergente da fonte recomputada
+    -- vira WARNING (o preço COBRADO já é validado acima — bloquear aqui só
+    -- criaria falso positivo sem proteção extra).
+    IF jsonb_typeof(v_item->'tint_preco_sem_desconto') = 'number' THEN
+      IF abs((v_item->>'tint_preco_sem_desconto')::float8 -
+             CASE v_fonte
+               WHEN 'calculado' THEN v_calc
+               WHEN 'tabela'    THEN v_tab
+               ELSE (v_ult->>'price')::float8
+             END) > 0.005 THEN
+        v_warnings := v_warnings || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'aviso', 'preco_sem_desconto_divergente',
+          'declarado', (v_item->>'tint_preco_sem_desconto')::float8);
+      END IF;
+    END IF;
+
+    IF abs(v_vu - v_esperado) > 0.005 THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_divergente',
+        'detalhe', 'o preço da fonte "' || v_fonte || '" mudou desde a montagem do pedido — reprecifique no balcão de tinta',
+        'fonte', v_fonte, 'esperado', v_esperado, 'recebido', v_vu);
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ok', jsonb_array_length(v_bloqueios) = 0,
+    'bloqueios', v_bloqueios,
+    'warnings', v_warnings);
+END;
+$$;
+
+COMMENT ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) IS
+  'Fase 3 tint: gate da fronteira omie-vendas-sync (criar_pedido/alterar_'
+  'pedido). Revalida item tint contra o estado ATUAL (canônica viva + preço '
+  'recomputado + fonte declarada, aritmética float8 ≡ JS). Baseline persistido '
+  'decide proveniência (legado=piso) e intocabilidade (edição). Fontes: '
+  'calculado/tabela/cliente (exigem tint_formula_id coerente) · manual (piso) '
+  '· ausente (legado com lastro). Base tint sem cor: bloqueia na criação; na '
+  'edição só intocada (inbound). Multi-SKU sem fórmula que desambigue: '
+  'bloqueia. service_role-only. Bloqueio ⇒ {ok:false,bloqueios:[…]} — o edge '
+  'NÃO toca o Omie.';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 3. Autorização (default privileges do Supabase dão EXECUTE a todos — revogar
+--    POR NOME; FROM PUBLIC sozinho não tira anon/authenticated).
+-- ───────────────────────────────────────────────────────────────────────────
+REVOKE ALL ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) TO service_role;
+
+REVOKE ALL ON FUNCTION public.tint_ultimo_preco_cliente(uuid, uuid, text, uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.tint_ultimo_preco_cliente(uuid, uuid, text, uuid) TO authenticated, service_role;
+
+-- RPC nova consumida pelo frontend (picker) via PostgREST
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Tintométrico Fase 3 — revalidação no submit (a fronteira que TODA via cruza) [money-path]

**Plano:** `docs/superpowers/plans/2026-07-17-tint-receita-perdida-remediacao.md` §Fase 3 · Fases 2+2b em prod desde 2026-07-18.

### O problema

A proteção de preço tint vivia só na UI do picker (`selectTintPrice`). O cache de preço dura 5min; a **conversão de orçamento**, a **edição** e o **retry** re-enviavam `valor_unitario` persistido/velho direto ao edge → preço obsoleto/fórmula morta virava PV real no Omie sem barreira (subfaturamento silencioso).

### O fecho

`tint_gate_revalida` roda no edge `omie-vendas-sync` (`criar_pedido` **e** `alterar_pedido` — a fronteira final comum), imediatamente antes da mutação Omie:

1. **Classificação server-side**: item sem `tint_cor_id` cujo produto é base tintométrica é bloqueado na criação (o push nunca produziu base sem cor — 0 na história; os 5.167 do PULL ficam livres) e, na edição, só passa intocado (linha inbound preservada). Omitir o marcador **não** desliga o gate.
2. **Canônica atual**: fórmula desativada/cor inexistente ⇒ `formula_morta`.
3. **Preço recomputado agora** (`get_tint_price` + `preco_csv_legado`); motor sem preço ⇒ bloqueia TODAS as fontes (paridade com a regra 1 do balcão).
4. **Fonte declarada**: o item carrega `tint_price_source`/`tint_discount_pct`/`tint_preco_sem_desconto` (gravados pelo picker); o gate valida `valor_unitario ≈ fonte_atual × (1−d)` em float8 espelho do JS. **A escolha "tabela (versão anterior)" da vendedora sobrevive** — o que barra é preço obsoleto, não a escolha de fonte (decisão da 2b preservada).
5. **Legado com prova**: item sem metadados só cai no piso `min(calc, tabela)` se o jsonb PERSISTIDO também não os tem (proveniência server-side); item novo sem metadados bloqueia.
6. **Edição**: item tint IDÊNTICO ao baseline passa com warning (editar parcela/observação não trava); alterado/novo revalida. O `handleSave` agora **aguarda o edge** e só persiste no sucesso — o baseline fica íntegro (e o preço-cliente não se autovalida: `p_exclude_sales_order_id`).

**Fonte 'cliente' deixou de ser default** no balcão (era inferência dos 50 últimos pedidos SEM filtro de status, e vencia baixando preço silenciosamente). Virou **opt-in** no seletor, endurecida pela RPC `tint_ultimo_preco_cliente` (só pedido real no Omie, não-cancelado, janela 180d) — a MESMA função que o gate usa (paridade estrutural, zero espelho).

### Vias enumeradas (money-path §5)

| Via | Cobertura |
|---|---|
| `submitOrder` → `criar_pedido` | gate na fronteira |
| Conversão de orçamento (`SalesQuotes`) → `criar_pedido` | gate + metadados repassados do jsonb |
| Edição (`useSalesOrderEdit`) → `alterar_pedido` | gate + baseline íntegro (aguarda o edge) |
| Retry idempotente | re-passa pelo gate com dado atual |
| Repetir pedido (`replicar-pedido`) | já seguro por design (fila do picker) |
| `submitQuote` | não vai ao Omie — a conversão revalida |

### 2ª opinião (Codex xhigh — DOIS challenges, pareceres crus nos comentários do PR)

- **Challenge do DESIGN** (pré-código): 6 P1 + 3 P2 — todos implementados (bypass por omissão de cor, autovalidação do cliente na edição, persistência antes do gate, desconto vazando entre cores, fallback legado controlável, item intocado).
- **Challenge do DIFF**: 6 P1 + 3 P2. **Implementados**: código string bypassava a classificação (agora number|string; ilegível = `payload_invalido`); aumento manual legítimo caía em `metadados_ausentes` (nova fonte `manual` ≥ piso); write-back da edição não checado (agora `.select('id')` + erro explícito — nunca `success` com local divergente); RPC rodava para TODO pedido (classificação batch no edge — migration ausente só afeta pedido com cara de tint); fórmula ausente desempatava célula por UUID (fonte declarada exige `tint_formula_id` coerente; multi-SKU ambíguo bloqueia); jsonb malformado derrubava a RPC; UI permitia d=100. **Calibrados como follow-up** (rotulado como decisão MINHA de escopo, não do Codex): drift local×Omie revertido pela edição — comportamento PRÉ-existente de toda a edição (o `alterar_pedido` sempre re-enviou o local para qualquer item, tint ou não; a correção é reconciliação estrutural da edição, fase própria); janela TOCTOU residual de ~1-2s entre o gate e a mutação (era 5min+ de cache; eliminar exige re-arquitetar `criarPedidoVenda`).

### Prova (PG17 com falsificação)

`db/test-tint-gate-revalida.sh` — **33 asserts · 9 falsificações (F1–F9) · restauração verde**. Destaques: G6 fórmula desativada barra; G8b receita mudada barra o preço velho; G3 escolha 'tabela' sobrevive; G9 motor NULL barra até a fonte tabela; G24+F7 anti-autovalidação; G20/G28+F8 anti-bypass por omissão/tipo; G29 fonte manual; G30+F9 anti-adulteração de fórmula; G31 multi-SKU; G32 jsonb malformado; G18 paridade numérica SQL float8 × node; F5 REVOKE por nome com default privileges replicados.

Gates: typecheck ✅ · vitest 5.451 ✅ · lint 0 errors ✅ · test:edges 137 ✅ · shellcheck ✅ · deno check ✅.

## ⚠️ ATENÇÃO: deploy em 3 camadas manuais (merge ≠ produção)

1. **Migration** `supabase/migrations/20260722100001_tint_gate_revalida_submit.sql` — colar no SQL Editor do Lovable (Lovable NÃO aplica nome custom). **Ordem: migration ANTES do deploy da edge** (a edge chama a RPC; sem ela, todo pedido com item tint é bloqueado fail-closed com mensagem apontando a migration).
2. **Edge** `omie-vendas-sync` — deploy pelo chat do Lovable (ler do repo, verbatim), SÓ depois do merge.
3. **Publish** do frontend no editor do Lovable.

Validação pós-apply (read-only):

```sql
SELECT
  CASE WHEN EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
    WHERE n.nspname='public' AND p.proname='tint_gate_revalida')
  THEN '✅ tint_gate_revalida existe' ELSE '❌ FALTANDO' END AS gate,
  CASE WHEN EXISTS (SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
    WHERE n.nspname='public' AND p.proname='tint_ultimo_preco_cliente')
  THEN '✅ tint_ultimo_preco_cliente existe' ELSE '❌ FALTANDO' END AS ultimo_preco,
  CASE WHEN NOT has_function_privilege('authenticated','public.tint_gate_revalida(text,uuid,uuid,text,jsonb)','EXECUTE')
  THEN '✅ gate fechado a authenticated' ELSE '❌ authenticated executa o gate' END AS acl;
```

### Follow-ups registrados (fora do escopo desta fase)

- Carimbo de validação server-side no jsonb pós-gate (`validated_at`/`canonical_formula_id`) — auditoria enriquecida (Codex P2, corte v1).
- Cap de desconto comercial (hoje 0–99,99% livre, comportamento pré-existente da UI) — decisão de produto.
- Botão "reprecificar item" na tela de edição (hoje: remover e re-adicionar pelo picker).
- Fase 4 (TintPricing usa a RPC) e Fase 5 (soft-deactivation SAYERLACK) do plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
