### PR TITLE
feat(authz): FU4-E — capability de ESCRITA em compras, master-only [money-path]

### DIFF
--- a/db/test-authz-cap-compras-escrever.sh
+++ b/db/test-authz-cap-compras-escrever.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — FU4-E: capability de ESCRITA em compras                           ║
+# ║   bash db/test-authz-cap-compras-escrever.sh > "$SCRATCH/t.log" 2>&1; echo $?     ║
+# ║                                                                                    ║
+# ║  Aplica a migration REAL 20260719120000_authz_cap_compras_escrever_fu4e.sql e     ║
+# ║  prova que as 3 RPCs de escrita em compras passaram do gate `gerencial` para      ║
+# ║  `private.cap_compras_escrever` (master-only) SEM mudar comportamento algum.      ║
+# ║                                                                                    ║
+# ║  Lei #1: plpgsql é late-bound — as RPCs são CHAMADAS de verdade e o EFEITO no     ║
+# ║  dado é conferido. "Criou sem erro" não prova nada.                               ║
+# ║  Lei #2: assert negativo captura a SQLSTATE esperada (P0001) e RE-LANÇA o resto.  ║
+# ║  Lei #3: ZONA 5 sabota de propósito e EXIGE vermelho.                             ║
+# ║                                                                                    ║
+# ║  Os stubs ESPELHAM PROD (medido via psql-ro 2026-07-19), não o design:            ║
+# ║  `sku_parametros.sku_codigo_omie` é bigint enquanto o log é text (daí o ::text    ║
+# ║  do código); `param_pin` tem PK COMPOSTA (empresa, sku) — é ela que serve o       ║
+# ║  ON CONFLICT; `param_auto_log.run_id` é NOT NULL com FK para param_auto_run.      ║
+# ╚══════════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5487}"
+SLUG="capcompras"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+MIG="$REPO_ROOT/supabase/migrations/20260719120000_authz_cap_compras_escrever_fu4e.sql"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+[ -f "$MIG" ] || { echo "migration nao encontrada: $MIG"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+MASTER="10000000-0000-0000-0000-000000000001"
+GERENCIAL="20000000-0000-0000-0000-000000000002"
+FARMER="40000000-0000-0000-0000-000000000004"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (stubs espelhando PROD, medido 2026-07-19)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 1: pré-requisitos ──"
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+GRANT USAGE ON SCHEMA private TO authenticated, anon, service_role;
+GRANT USAGE ON SCHEMA auth    TO authenticated, anon, service_role;
+
+CREATE TYPE public.app_role        AS ENUM ('customer','employee','master','admin');
+CREATE TYPE public.commercial_role AS ENUM ('operacional','gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+
+CREATE TABLE public.user_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL, role public.app_role NOT NULL
+);
+CREATE TABLE public.commercial_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL UNIQUE,
+  commercial_role public.commercial_role NOT NULL
+);
+
+-- has_role: cópia verbatim de prod (pg_get_functiondef)
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+-- O gate ANTIGO precisa existir: é o que a migration procura e troca.
+-- Em PROD ele vive nas DUAS formas (impl em private pelo #1427 + wrapper em public); as 3 RPCs
+-- alvo chamam a de `public`, então é essa que o stub precisa ter para o regex casar.
+CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT public.has_role(_uid,'master'::public.app_role)
+      OR (public.has_role(_uid,'employee'::public.app_role)
+          AND EXISTS (SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
+                       AND cr.commercial_role IN ('gerencial','estrategico','super_admin')));
+$f$;
+GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated, service_role;
+
+-- ── tabelas de compras (colunas/constraints ESPELHANDO prod) ──
+CREATE TABLE public.reposicao_param_auto_run (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text NOT NULL,
+  data_negocio_brt date NOT NULL,
+  status text NOT NULL DEFAULT 'rodando',
+  criado_em timestamptz NOT NULL DEFAULT now()
+);
+
+-- ⚠️ sku_codigo_omie é TEXT aqui e BIGINT em sku_parametros (medido) — a assimetria é real e é
+-- por isso que o código faz `sp.sku_codigo_omie::text = r.sku_codigo_omie`. Igualar os tipos no
+-- stub deixaria o harness verde provando um mundo que não existe.
+CREATE TABLE public.reposicao_param_auto_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid NOT NULL REFERENCES public.reposicao_param_auto_run(id),
+  empresa text NOT NULL,
+  sku_codigo_omie text NOT NULL,
+  status text NOT NULL CHECK (status = ANY (ARRAY['aplicado','segurado','pinado','bloqueado_validacao'])),
+  ponto_pedido_antes numeric,       ponto_pedido_depois numeric,
+  estoque_minimo_antes numeric,     estoque_minimo_depois numeric,
+  estoque_maximo_antes numeric,     estoque_maximo_depois numeric,
+  estoque_seguranca_antes numeric,  estoque_seguranca_depois numeric,
+  cobertura_antes numeric,          cobertura_depois numeric,
+  revertido_em timestamptz, revertido_por uuid,
+  criado_em timestamptz NOT NULL DEFAULT now()
+);
+
+-- PK COMPOSTA (não UNIQUE avulso) — é ela que serve o ON CONFLICT (empresa, sku_codigo_omie).
+CREATE TABLE public.reposicao_param_pin (
+  empresa text NOT NULL,
+  sku_codigo_omie text NOT NULL,
+  ponto_pedido_rejeitado numeric NOT NULL,
+  estoque_maximo_rejeitado numeric NOT NULL,
+  pinado_em timestamptz NOT NULL DEFAULT now(),
+  pinado_por uuid,
+  PRIMARY KEY (empresa, sku_codigo_omie)
+);
+
+CREATE TABLE public.sku_parametros (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text NOT NULL,
+  sku_codigo_omie bigint NOT NULL,
+  ponto_pedido numeric, estoque_minimo numeric, estoque_maximo numeric,
+  estoque_seguranca numeric, cobertura_alvo_dias integer,
+  ultima_atualizacao_calculo timestamptz,
+  UNIQUE (empresa, sku_codigo_omie)
+);
+
+-- ── as 3 RPCs alvo: corpo VERBATIM de prod (pg_get_functiondef, psql-ro 2026-07-19) ──
+-- É o corpo real que a migration vai reescrever. Um stub "equivalente mas reescrito" provaria
+-- que o regex casa no texto que EU escrevi, não no que existe em produção.
+CREATE OR REPLACE FUNCTION public.despinar_parametro(p_empresa text, p_sku text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT public.pode_ver_carteira_completa(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  DELETE FROM public.reposicao_param_pin WHERE empresa=p_empresa AND sku_codigo_omie=p_sku;
+  RETURN FOUND;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.reverter_parametro_auto(p_log_id uuid)
+ RETURNS text
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE r record; v_uid uuid := auth.uid();
+BEGIN
+  IF NOT public.pode_ver_carteira_completa(v_uid) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  SELECT * INTO r FROM public.reposicao_param_auto_log
+    WHERE id=p_log_id AND status='aplicado' AND revertido_em IS NULL;
+  IF NOT FOUND THEN RETURN 'nao_encontrado'; END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.sku_parametros sp
+    WHERE sp.empresa=r.empresa AND sp.sku_codigo_omie::text=r.sku_codigo_omie
+      AND round(COALESCE(sp.ponto_pedido,-1))      = round(COALESCE(r.ponto_pedido_depois,-1))
+      AND round(COALESCE(sp.estoque_maximo,-1))    = round(COALESCE(r.estoque_maximo_depois,-1))
+      AND round(COALESCE(sp.estoque_minimo,-1))    = round(COALESCE(r.estoque_minimo_depois,-1))
+      AND round(COALESCE(sp.estoque_seguranca,-1)) = round(COALESCE(r.estoque_seguranca_depois,-1))
+      AND round(COALESCE(sp.cobertura_alvo_dias,-1))= round(COALESCE(r.cobertura_depois,-1))
+  ) THEN RETURN 'conflito'; END IF;
+  UPDATE public.sku_parametros sp SET
+    ponto_pedido=r.ponto_pedido_antes, estoque_minimo=r.estoque_minimo_antes,
+    estoque_maximo=r.estoque_maximo_antes, estoque_seguranca=r.estoque_seguranca_antes,
+    cobertura_alvo_dias=r.cobertura_antes, ultima_atualizacao_calculo=now()
+  WHERE sp.empresa=r.empresa AND sp.sku_codigo_omie::text=r.sku_codigo_omie;
+  INSERT INTO public.reposicao_param_pin (empresa, sku_codigo_omie, ponto_pedido_rejeitado, estoque_maximo_rejeitado, pinado_por)
+    VALUES (r.empresa, r.sku_codigo_omie, round(r.ponto_pedido_depois), round(r.estoque_maximo_depois), v_uid)
+    ON CONFLICT (empresa, sku_codigo_omie) DO UPDATE
+      SET ponto_pedido_rejeitado=excluded.ponto_pedido_rejeitado,
+          estoque_maximo_rejeitado=excluded.estoque_maximo_rejeitado, pinado_em=now(), pinado_por=v_uid;
+  UPDATE public.reposicao_param_auto_log SET revertido_em=now(), revertido_por=v_uid WHERE id=p_log_id;
+  RETURN 'revertido';
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.reverter_run_auto(p_run_id uuid)
+ RETURNS TABLE(revertidos integer, conflitos integer)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE r record; v_rev int := 0; v_conf int := 0; res text;
+BEGIN
+  IF NOT public.pode_ver_carteira_completa(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  FOR r IN SELECT id FROM public.reposicao_param_auto_log
+           WHERE run_id=p_run_id AND status='aplicado' AND revertido_em IS NULL LOOP
+    res := public.reverter_parametro_auto(r.id);
+    IF res='revertido' THEN v_rev := v_rev+1; ELSIF res='conflito' THEN v_conf := v_conf+1; END IF;
+  END LOOP;
+  revertidos := v_rev; conflitos := v_conf; RETURN NEXT;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.despinar_parametro(text,text)  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.reverter_parametro_auto(uuid)  TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.reverter_run_auto(uuid)        TO authenticated, service_role;
+SQL
+echo "  pré-requisitos criados"
+
+# guard do próprio stub: o corpo tem de conter o gate ANTIGO, senão a migration não teria o que
+# trocar e TODA a prova seria vacuosa (verde por ausência de trabalho).
+eq "S1 stub das 3 RPCs nasce com o gate ANTIGO" \
+   "$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+             WHERE n.nspname='public' AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+               AND pg_get_functiondef(p.oid) ~ 'public\.pode_ver_carteira_completa\s*\(';")" "3"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 2: aplicar migration real ──"
+
+# AUTONOMIA (a propriedade que sustenta a decisão de estrutura do spec §3): a migration tem de
+# aplicar SEM `private.cap_compras_ler` existir. Se um dia alguém a fizer depender do #1434,
+# este assert fica vermelho.
+eq "A0 cap_compras_ler NÃO existe neste banco (prova a autonomia)" \
+   "$(Pq -c "SELECT to_regprocedure('private.cap_compras_ler(uuid)') IS NULL;")" "t"
+
+P -q -f "$MIG"
+echo "  migration aplicada: $(basename "$MIG")"
+
+# IDEMPOTÊNCIA: o dono cola à mão; uma queda de rede no meio não pode travar a 2ª tentativa.
+# Na 2ª passada o padrão de busca já não existe — o bloco tem de seguir pelo CONTINUE, não abortar.
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  ok "P0a migration é IDEMPOTENTE (2ª aplicação passa)"
+else
+  bad "P0a re-aplicar a migration falhou — não é idempotente"
+fi
+eq "P0b as 3 RPCs seguem com o gate novo após re-aplicar" \
+   "$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+             WHERE n.nspname='public' AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+               AND pg_get_functiondef(p.oid) ~ 'private\.cap_compras_escrever\s*\(';")" "3"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 3: seeds ──"
+P -q <<SQL
+INSERT INTO public.user_roles(user_id,role) VALUES
+  ('$MASTER','master'), ('$GERENCIAL','employee'), ('$FARMER','employee');
+INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES
+  ('$GERENCIAL','gerencial'), ('$FARMER','farmer');
+SQL
+echo "  seeds inseridos"
+
+# helper: roda SQL como `authenticated` com um uid.
+# ⚠️ `SET` e NÃO `SET LOCAL`: cada invocação do psql é sessão nova em autocommit, onde SET LOCAL
+# não pega — e sem o SET ROLE o assert rodaria como `postgres`, que bypassa RLS e pinta tudo de
+# verde falsamente.
+as_user() { # $1=uid  $2=sql
+  P -tA -q <<SQL
+SET test.uid = '$1';
+SET ROLE authenticated;
+$2
+SQL
+}
+# sanidade do próprio harness: se o SET ROLE não pegar, TODO assert é teatro.
+GUARD=$(as_user "$MASTER" "SELECT current_user;")
+[ "$GUARD" = "authenticated" ] || { echo "❌ HARNESS INVÁLIDO: SET ROLE não pegou (current_user=$GUARD)"; exit 1; }
+echo "  guard: asserts rodam como '$GUARD' (não superuser) ✅"
+
+# re-semeia o cenário de reversão (chamado antes de cada teste que consome estado)
+seed_cenario() {
+  P -q <<SQL
+DELETE FROM public.reposicao_param_auto_log;
+DELETE FROM public.reposicao_param_auto_run;
+DELETE FROM public.reposicao_param_pin;
+DELETE FROM public.sku_parametros;
+
+INSERT INTO public.reposicao_param_auto_run(id, empresa, data_negocio_brt)
+  VALUES ('99999999-0000-0000-0000-00000000aaaa','oben', CURRENT_DATE);
+-- sku_parametros com os valores "DEPOIS" (é o que o código exige para não retornar 'conflito')
+INSERT INTO public.sku_parametros(empresa, sku_codigo_omie, ponto_pedido, estoque_minimo,
+                                  estoque_maximo, estoque_seguranca, cobertura_alvo_dias)
+  VALUES ('oben', 7001, 200, 60, 500, 30, 21);
+INSERT INTO public.reposicao_param_auto_log(id, run_id, empresa, sku_codigo_omie, status,
+    ponto_pedido_antes, ponto_pedido_depois, estoque_minimo_antes, estoque_minimo_depois,
+    estoque_maximo_antes, estoque_maximo_depois, estoque_seguranca_antes, estoque_seguranca_depois,
+    cobertura_antes, cobertura_depois)
+  VALUES ('99999999-0000-0000-0000-00000000bbbb','99999999-0000-0000-0000-00000000aaaa',
+          'oben','7001','aplicado', 100, 200, 50, 60, 400, 500, 25, 30, 14, 21);
+-- pin independente, alvo do despinar_parametro
+INSERT INTO public.reposicao_param_pin(empresa, sku_codigo_omie, ponto_pedido_rejeitado, estoque_maximo_rejeitado)
+  VALUES ('oben','9002', 111, 222);
+SQL
+}
+LOG_ID="99999999-0000-0000-0000-00000000bbbb"
+RUN_ID="99999999-0000-0000-0000-00000000aaaa"
+
+# helper: chama uma RPC e ecoa OK/DENIED/ERRO. O negativo é classificado pela SQLSTATE (P0001,
+# o RAISE EXCEPTION sem errcode das 3), NUNCA pelo texto da mensagem — casar 'sem permissão'
+# seria teatro de ILIKE: a sentinela do teste não pode conter o texto que o código emite.
+call_rpc() { # $1=uid $2=sql
+  local out
+  if out=$(P -tA -q <<SQL 2>&1
+SET test.uid = '$1';
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  PERFORM $2;
+EXCEPTION
+  WHEN raise_exception THEN RAISE NOTICE 'SENTINELA_NEGOU_P0001';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+  ); then
+    case "$out" in
+      *SENTINELA_NEGOU_P0001*) echo "DENIED" ;;
+      *) echo "OK" ;;
+    esac
+  else
+    echo "ERRO_INESPERADO: $out"
+  fi
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── ZONA 4a: o furo que o FU4-E fecha (gerencial PERDE a escrita) ──"
+
+seed_cenario
+eq "N1 gerencial NÃO despina parâmetro" \
+   "$(call_rpc "$GERENCIAL" "public.despinar_parametro('oben','9002')")" "DENIED"
+eq "N1e ...e o pin CONTINUA lá (efeito no dado, não só a exceção)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_pin WHERE empresa='oben' AND sku_codigo_omie='9002';")" "1"
+
+eq "N2 gerencial NÃO reverte parâmetro" \
+   "$(call_rpc "$GERENCIAL" "public.reverter_parametro_auto('$LOG_ID')")" "DENIED"
+eq "N2e ...e o log segue NÃO revertido" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_auto_log WHERE id='$LOG_ID' AND revertido_em IS NULL;")" "1"
+eq "N2p ...e sku_parametros segue no valor DEPOIS (nada foi revertido)" \
+   "$(Pq -c "SELECT ponto_pedido::int FROM public.sku_parametros WHERE empresa='oben' AND sku_codigo_omie=7001;")" "200"
+
+eq "N3 gerencial NÃO reverte run inteiro" \
+   "$(call_rpc "$GERENCIAL" "public.reverter_run_auto('$RUN_ID')")" "DENIED"
+
+echo "── ZONA 4b: farmer (papel comercial comum) também negado ──"
+eq "N4 farmer NÃO despina"        "$(call_rpc "$FARMER" "public.despinar_parametro('oben','9002')")" "DENIED"
+eq "N5 farmer NÃO reverte run"    "$(call_rpc "$FARMER" "public.reverter_run_auto('$RUN_ID')")"      "DENIED"
+
+echo "── ZONA 4c: anônimo (uid NULO) negado — fail-closed ──"
+eq "N6 uid NULO não despina" \
+   "$(P -tA -q <<'SQL' 2>&1 | grep -c SENTINELA_NEGOU || true
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.despinar_parametro('oben','9002');
+EXCEPTION WHEN raise_exception THEN RAISE NOTICE 'SENTINELA_NEGOU';
+          WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+)" "1"
+eq "N6b cap_compras_escrever(NULL) é FALSE (não NULL)" \
+   "$(Pq -c "SELECT private.cap_compras_escrever(NULL) IS FALSE;")" "t"
+
+echo "── ZONA 4d: master preserva TUDO (ninguém perdeu acesso) ──"
+seed_cenario
+eq "M1 master despina (retorna true)" \
+   "$(as_user "$MASTER" "SELECT public.despinar_parametro('oben','9002');")" "t"
+eq "M1e ...e o pin SUMIU (efeito real)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_pin WHERE empresa='oben' AND sku_codigo_omie='9002';")" "0"
+
+seed_cenario
+eq "M2 master reverte parâmetro (retorna 'revertido')" \
+   "$(as_user "$MASTER" "SELECT public.reverter_parametro_auto('$LOG_ID');")" "revertido"
+eq "M2e ...e sku_parametros voltou ao valor ANTES" \
+   "$(Pq -c "SELECT ponto_pedido::int FROM public.sku_parametros WHERE empresa='oben' AND sku_codigo_omie=7001;")" "100"
+eq "M2l ...e o log ficou marcado como revertido pelo master" \
+   "$(Pq -c "SELECT revertido_por::text FROM public.reposicao_param_auto_log WHERE id='$LOG_ID';")" "$MASTER"
+
+seed_cenario
+eq "M3 master reverte run inteiro (1 revertido, 0 conflitos)" \
+   "$(as_user "$MASTER" "SELECT revertidos||'/'||conflitos FROM public.reverter_run_auto('$RUN_ID');")" "1/0"
+
+echo "── ZONA 4e: a troca NÃO mudou comportamento algum ──"
+seed_cenario
+eq "C1 despinar de sku inexistente segue retornando false" \
+   "$(as_user "$MASTER" "SELECT public.despinar_parametro('oben','NAO-EXISTE');")" "f"
+eq "C2 reverter log inexistente segue 'nao_encontrado'" \
+   "$(as_user "$MASTER" "SELECT public.reverter_parametro_auto('00000000-0000-0000-0000-0000000000ff');")" "nao_encontrado"
+P -q -c "UPDATE public.sku_parametros SET ponto_pedido=999 WHERE empresa='oben' AND sku_codigo_omie=7001;"
+eq "C3 divergência de parâmetro segue devolvendo 'conflito'" \
+   "$(as_user "$MASTER" "SELECT public.reverter_parametro_auto('$LOG_ID');")" "conflito"
+
+echo "── ZONA 4f: catálogo — a reescrita preservou os atributos ──"
+eq "K1 as 3 seguem SECURITY DEFINER" \
+   "$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+             WHERE n.nspname='public' AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+               AND p.prosecdef;")" "3"
+eq "K2 as 3 seguem com search_path pinado" \
+   "$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+             WHERE n.nspname='public' AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+               AND array_to_string(p.proconfig,',') LIKE '%search_path%';")" "3"
+eq "K3 nenhuma das 3 referencia o gate ANTIGO" \
+   "$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+             WHERE n.nspname='public' AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+               AND pg_get_functiondef(p.oid) ~ '(public\.|private\.)?pode_ver_carteira_completa\s*\(';")" "0"
+eq "K4 authenticated segue com EXECUTE nas 3 (ACL preservado)" \
+   "$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+             WHERE n.nspname='public' AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+               AND has_function_privilege('authenticated', p.oid, 'EXECUTE');")" "3"
+eq "K5 o ARGUMENTO foi preservado (reverter_parametro_auto segue passando v_uid)" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reverter_parametro_auto(uuid)'::regprocedure) ~ 'cap_compras_escrever\(v_uid\)';")" "t"
+eq "K6 anon NÃO executa a capability" \
+   "$(Pq -c "SELECT has_function_privilege('anon','private.cap_compras_escrever(uuid)','EXECUTE');")" "f"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota e EXIGE vermelho
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── ZONA 5: falsificação (sabotar → exigir vermelho) ──"
+seed_cenario
+
+# F1 — a capability passa a aceitar o gate antigo. N1/N2/N3 devem QUEBRAR.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION private.cap_compras_escrever(_uid uuid) RETURNS boolean
+ LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(public.pode_ver_carteira_completa(_uid), false) $f$;  -- SABOTADO
+SQL
+if [ "$(call_rpc "$GERENCIAL" "public.despinar_parametro('oben','9002')")" = "OK" ]; then
+  ok "F1 sabotagem REABRIU o furo no despinar → N1 tem dente"
+else
+  bad "F1 sabotei a capability e N1 seguiu negando — assert FRACO"
+fi
+if [ "$(call_rpc "$GERENCIAL" "public.reverter_run_auto('$RUN_ID')")" = "OK" ]; then
+  ok "F2 sabotagem REABRIU o furo no reverter_run → N3 tem dente"
+else
+  bad "F2 sabotei a capability e N3 seguiu negando — assert FRACO"
+fi
+# o efeito de escrita também tem de vazar (não basta a exceção sumir)
+eq "F2e sabotado, o gerencial REVERTEU de fato (efeito vazou)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_auto_log WHERE id='$LOG_ID' AND revertido_por='$GERENCIAL';")" "1"
+
+# Restaura CIRURGICAMENTE (só a função sabotada). Re-aplicar a migration inteira aqui NÃO
+# funcionaria: a precondição dela aborta de propósito porque já semeamos um papel gerencial.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION private.cap_compras_escrever(_uid uuid) RETURNS boolean
+ LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid, 'master'::public.app_role), false) $f$;
+SQL
+seed_cenario
+eq "F1r restaurado: gerencial volta a ser negado" \
+   "$(call_rpc "$GERENCIAL" "public.despinar_parametro('oben','9002')")" "DENIED"
+
+# F3 — a precondição de "papel gerencial vivo" tem dente? Já há um gerencial semeado (ZONA 3),
+# então re-aplicar a migration DEVE abortar.
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F3 precondição: migration aplicou COM papel gerencial vivo (deveria abortar)"
+else
+  ok "F3 precondição aborta com papel gerencial vivo → o guard tem dente"
+fi
+
+# F4 — o guard de "1 ocorrência do gate antigo" tem dente? Injeta uma 2ª chamada e exige aborto.
+P -q -c "DELETE FROM public.commercial_roles WHERE commercial_role IN ('gerencial','estrategico','super_admin');"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.despinar_parametro(p_empresa text, p_sku text)
+ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT public.pode_ver_carteira_completa(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  IF NOT public.pode_ver_carteira_completa(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  DELETE FROM public.reposicao_param_pin WHERE empresa=p_empresa AND sku_codigo_omie=p_sku;
+  RETURN FOUND;
+END;
+$function$;
+SQL
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F4 guard de contagem: migration aceitou 2 ocorrências do gate antigo (deveria abortar)"
+else
+  ok "F4 guard aborta com 2 ocorrências do gate antigo → não reescreve corpo divergente"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "  PASS=$PASS  FAIL=$FAIL"
+echo "═══════════════════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/docs/superpowers/specs/2026-07-19-authz-fu4e-cap-compras-escrever-design.md
+++ b/docs/superpowers/specs/2026-07-19-authz-fu4e-cap-compras-escrever-design.md
@@ -1,0 +1,156 @@
+# FU4-E — capability de ESCRITA em compras (`private.cap_compras_escrever`)
+
+> Fecha a incoerência deixada consciente pelo E2/FU4 (#1434): o papel `gerencial` deixaria de
+> **ler** a telemetria do motor de compras, mas seguiria podendo **alterá-la**.
+> Money-path / autorização. Migration MANUAL (SQL Editor).
+
+## 1. O problema
+
+O #1434 substituiu o gate único `pode_ver_carteira_completa` por uma matriz de capability por
+recurso × ação. As 9 tabelas `reposicao_*` de LEITURA passaram a exigir `private.cap_compras_ler`
+(master-only), desacoplando compras do papel comercial.
+
+Três RPCs de ESCRITA em compras ficaram no gate antigo — registrado como **FU4-E** no cabeçalho da
+migration `20260718190000`:
+
+| RPC | Efeito de escrita |
+|---|---|
+| `public.despinar_parametro(p_empresa text, p_sku text)` | `DELETE` em `reposicao_param_pin` |
+| `public.reverter_parametro_auto(p_log_id uuid)` | reverte parâmetro aplicado; `UPDATE sku_parametros` + `INSERT reposicao_param_pin` + `UPDATE reposicao_param_auto_log` |
+| `public.reverter_run_auto(p_run_id uuid)` | reverte um run inteiro (chama a anterior em loop) |
+
+Todas `SECURITY DEFINER`, todas gateadas por
+`IF NOT public.pode_ver_carteira_completa(<uid>) THEN RAISE EXCEPTION 'sem permissão'`.
+
+Não é vazamento de custo/preço/crédito — é coerência interna de compras: quem não lê o estado do
+motor não deveria poder mutá-lo.
+
+## 2. Estado medido de PROD (psql-ro, 2026-07-19)
+
+Medição que **corrige a premissa** com que a tarefa foi escrita:
+
+- **#1434 está em DRAFT e a migration dele NUNCA foi aplicada.** O schema `private` tem apenas
+  `carteira_visivel_para`, `is_super_admin`, `pode_ver_carteira_completa` — **zero** `cap_*`.
+  Logo `private.cap_compras_ler` **não existe**.
+- **#1427 (`20260718180000`) FOI aplicado** — ao contrário do que o cabeçalho do #1434 afirma
+  (ele foi escrito em 18/07, quando ainda não estava). `private.pode_ver_carteira_completa`
+  existe, e as 9 policies `reposicao_*` já apontam para ela.
+- As 3 RPCs alvo usam **`public.pode_ver_carteira_completa`**, exatamente **1 ocorrência cada**.
+  `reverter_parametro_auto` passa a variável `v_uid`; as outras duas passam `auth.uid()`.
+- Owner `postgres`, ACL `{postgres=X, authenticated=X, service_role=X, sandbox_exec*=X}` nas três.
+- `public.has_role(_user_id uuid, _role app_role)` — SECDEF, STABLE.
+- `commercial_roles`: **2 farmer + 1 master**. Zero `gerencial`/`estrategico`/`super_admin`
+  ⇒ a troca não retira acesso de ninguém vivo.
+
+## 3. Decisão de estrutura: PR próprio, migration AUTÔNOMA
+
+Aprovado pelo founder em 2026-07-19. `cap_compras_escrever` lê `has_role` **direto**, sem
+referenciar `cap_compras_ler` nem o gate antigo — logo esta migration aplica-se **antes, depois ou
+sem** o #1434, em qualquer ordem.
+
+É o mesmo princípio que o próprio #1434 adotou ("robusta à ordem de aplicação") depois da falha do
+#1423 (caller órfão). O founder aplica migrations à mão, uma de cada vez; uma esquecida falha em
+SILÊNCIO. Ordem-independência é o que remove essa classe de falha.
+
+Matriz de estados — **nenhum pior que hoje**:
+
+| Aplicado | Resultado |
+|---|---|
+| ambas | estado-alvo: compras desacoplado do papel comercial nos dois lados |
+| só esta | gerencial LÊ telemetria mas não MUTA — **mais restritivo** que hoje |
+| só #1434 | a incoerência FU4-E original, já documentada |
+| nenhuma | status quo |
+
+Alternativas descartadas: **dobrar no #1434** (mexe em PR com CI verde e prova pronta, reabrindo
+revisão de uma transação já grande) e **migration dependente** (cria ordem obrigatória entre dois
+blocos manuais — o risco que o cabeçalho do #1434 argumenta ser inseguro).
+
+## 4. Desenho
+
+### 4.1 `private.cap_compras_escrever(uuid)`
+
+```sql
+LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false)
+```
+
+Master-only, fail-closed em `_uid` nulo. Forma idêntica à `cap_compras_ler`, mas **função
+separada** — exigência do spec §4.2 do #1434: é o que permite apertar um lado depois sem reabrir o
+outro, mexendo em 1 função em vez das policies/RPCs.
+
+`REVOKE ALL FROM PUBLIC, anon` + `GRANT EXECUTE TO authenticated, service_role`: obrigatório porque
+o default privilege do Supabase concede `EXECUTE` em toda função nova (`database.md` §62 — o objeto
+nasce aberto).
+
+### 4.2 Troca do gate nas 3 RPCs — substituição programática guardada
+
+Padrão da §3 do #1434: reescrever a partir do corpo VIVO (`pg_get_functiondef`), não colar corpo
+verbatim (o repo diverge de prod em `CREATE OR REPLACE`; a última a recriar vence).
+
+**Divergência obrigatória em relação ao #1434:** lá o replace fixava `auth.uid()` no padrão. Aqui
+não pode — `reverter_parametro_auto` passa `v_uid`. Então troca-se apenas **nome + abre-parêntese**,
+preservando o argumento verbatim:
+
+```sql
+regexp_replace(v_def, '(public\.|private\.)?pode_ver_carteira_completa\s*\(',
+                      'private.cap_compras_escrever(', 'g')
+```
+
+O alternador aceita `private.` porque prod tem as duas formas do gate antigo (wrapper em `public` +
+implementação em `private`); casar só `public.` deixaria passar uma reescrita futura.
+
+Guards por função — qualquer divergência **aborta**, nunca aplica no-op silencioso:
+
+1. função existe (por **assinatura**, `to_regprocedure` — não por `proname`, que escolheria um
+   overload arbitrariamente);
+2. **idempotência**: já migrada (tem gate novo, não tem antigo) ⇒ segue;
+3. exatamente **1** ocorrência do gate antigo (medido);
+4. replace **não** foi no-op;
+5. gate antigo **sumiu** do texto novo;
+6. gate novo **presente** no texto novo;
+7. **pós-check no catálogo** após o `EXECUTE` (o guard textual valida a string que vai executar;
+   isto valida o que o catálogo realmente guardou).
+
+### 4.3 Precondições (abortam a transação)
+
+- schema `private` ausente;
+- qualquer das 3 funções ausente;
+- `public.has_role(uuid, app_role)` ausente;
+- **papel `gerencial`/`estrategico`/`super_admin` vivo** — replicando o guard do #1434: se alguém
+  foi promovido entre a escrita e a aplicação, a troca tiraria acesso de uma pessoa viva sem aviso.
+  Melhor abortar e revisar do que descobrir pelo suporte.
+
+### 4.4 O que NÃO muda (deliberado)
+
+Mensagem `'sem permissão'`, ausência de ERRCODE explícito (⇒ SQLSTATE `P0001`), `SECURITY DEFINER`,
+`SET search_path`, assinatura, corpo, e o ACL (`CREATE OR REPLACE` preserva privilégios de função
+existente — ao contrário de `DROP`+`CREATE`, que reaplicaria o default privilege do Supabase).
+Trocar **só** o gate é precisamente o que a substituição programática garante.
+
+## 5. Prova (PG17, `db/test-authz-cap-compras-escrever.sh`)
+
+Molde: `db/test-authz-capability-matrix.sh`.
+
+- **Lei #1 — executar, não só criar.** plpgsql é late-bound: `CREATE` passa com SQL inválido e só
+  falha em runtime. As 3 RPCs são **chamadas de verdade**, com efeito de escrita verificado no dado.
+- **Lei #2 — assert negativo com SQLSTATE + re-raise.** Captura `P0001` (o `RAISE EXCEPTION`
+  sem errcode das 3) e re-lança o resto. Sem casar o **texto** da mensagem (anti-teatro de ILIKE);
+  a sentinela do teste nunca contém o texto que o código emite.
+- **RLS real:** tudo sob `SET ROLE authenticated` + GUC de uid, com guard de sanidade do harness
+  (se o `SET ROLE` não pegar, todo assert seria falso-verde — psql roda como superuser).
+- **Lei #3 — falsificação.** Sabotar `cap_compras_escrever` para aceitar o gate antigo deve deixar
+  os asserts negativos **vermelhos**; restauração cirúrgica; e conferir **contagem e nomes** dos
+  vermelhos (exit code não distingue "pegou o bug" de "não rodou nada").
+- **Idempotência:** 2ª aplicação da migration com banco limpo passa (o founder cola à mão; queda de
+  rede não pode travar a retentativa), e não desfaz o gate novo.
+- **Autonomia:** um assert prova que a migration aplica **sem** `private.cap_compras_ler` existir —
+  é a propriedade que sustenta a decisão da §3.
+
+## 6. Entregáveis
+
+1. `supabase/migrations/20260719120000_authz_cap_compras_escrever_fu4e.sql`
+2. `db/test-authz-cap-compras-escrever.sh` (harness PG17 com falsificação)
+3. Bloco pronto para colar no SQL Editor do Lovable + query de validação pós-apply
+4. PR com a nota de deploy manual
+
+Sem mudança de frontend: as 3 RPCs mantêm assinatura, retorno e mensagem de erro.

--- a/supabase/migrations/20260719120000_authz_cap_compras_escrever_fu4e.sql
+++ b/supabase/migrations/20260719120000_authz_cap_compras_escrever_fu4e.sql
@@ -1,0 +1,217 @@
+-- ╔══════════════════════════════════════════════════════════════════════════════════════════╗
+-- ║  FU4-E — capability de ESCRITA em compras  [money-path / autorização]                     ║
+-- ╚══════════════════════════════════════════════════════════════════════════════════════════╝
+-- Spec:  docs/superpowers/specs/2026-07-19-authz-fu4e-cap-compras-escrever-design.md
+-- Prova: db/test-authz-cap-compras-escrever.sh (PG17, SET ROLE authenticated, com falsificação)
+-- Fecha o FU4-E registrado no cabeçalho da 20260718190000 (E2/FU4, PR #1434).
+--
+-- ── A INCOERÊNCIA QUE ISTO FECHA ───────────────────────────────────────────────────────────
+-- O #1434 tira do papel `gerencial` a LEITURA da telemetria do motor de compras (9 tabelas
+-- `reposicao_*` → `private.cap_compras_ler`, master-only), mas deixa 3 RPCs de ESCRITA no gate
+-- antigo `pode_ver_carteira_completa`. Resultado: quem não lê o estado do motor ainda pode
+-- MUTÁ-LO. Não é vazamento de custo/preço/crédito — é coerência interna de compras.
+--   · public.despinar_parametro(text,text)   → DELETE em reposicao_param_pin
+--   · public.reverter_parametro_auto(uuid)   → reverte parâmetro aplicado (UPDATE sku_parametros
+--                                              + INSERT param_pin + UPDATE param_auto_log)
+--   · public.reverter_run_auto(uuid)         → reverte um run inteiro (chama a anterior em loop)
+--
+-- ── POR QUE ESCRITA ≠ LEITURA (spec §4.2 do #1434) ─────────────────────────────────────────
+-- `cap_compras_escrever` NÃO reusa `cap_compras_ler`, mesmo concedendo hoje ao mesmo conjunto
+-- (master). Funções separadas são o que permite apertar/afrouxar um lado depois sem reabrir o
+-- outro, mexendo em 1 função em vez de caçar policies e RPCs.
+--
+-- ── ROBUSTA À ORDEM DE APLICAÇÃO (medido: o #1434 NÃO está aplicado) ───────────────────────
+-- Medido em prod via psql-ro 2026-07-19: o schema `private` tem só `carteira_visivel_para`,
+-- `is_super_admin` e `pode_ver_carteira_completa` — ZERO `cap_*`. O #1434 segue em DRAFT e a
+-- migration dele nunca foi colada. (Já o #1427/20260718180000 FOI aplicado, ao contrário do que
+-- o cabeçalho do #1434 afirma: `private.pode_ver_carteira_completa` existe e as 9 policies
+-- `reposicao_*` apontam para ela.)
+-- Por isso esta migration NÃO referencia `private.cap_compras_ler` em lugar nenhum: a capability
+-- nova lê `has_role` direto. Aplica-se ANTES, DEPOIS ou SEM o #1434, em qualquer ordem — mesma
+-- propriedade que o #1434 adotou depois da falha do #1423 (caller órfão). Nenhum estado
+-- intermediário fica pior que hoje: se só ESTA for aplicada, o gerencial passa a ler a
+-- telemetria mas não a mutar (mais restritivo que o status quo).
+--
+-- ── O QUE NÃO MUDA, DE PROPÓSITO ───────────────────────────────────────────────────────────
+-- Mensagem 'sem permissão', ausência de ERRCODE explícito (⇒ SQLSTATE P0001), SECURITY DEFINER,
+-- SET search_path, assinatura, corpo e ACL. `CREATE OR REPLACE` preserva os privilégios de uma
+-- função existente (≠ DROP+CREATE, que reaplicaria o default privilege do Supabase). Trocar SÓ o
+-- gate é exatamente o que a substituição programática da §2 garante.
+--
+-- ⚠️ Migration MANUAL (Lovable não aplica nome custom) — colar no SQL Editor.
+
+BEGIN;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 0) PRECONDIÇÕES — aborta se o banco vivo divergir do medido
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+DO $$
+DECLARE
+  v_alvos      text[] := ARRAY['public.despinar_parametro(text,text)',
+                               'public.reverter_parametro_auto(uuid)',
+                               'public.reverter_run_auto(uuid)'];
+  v_a          text;
+  v_gerenciais int;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_namespace WHERE nspname = 'private') THEN
+    RAISE EXCEPTION 'FU4-E: schema private ausente — aplique o #1421 (20260718150000) antes'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  IF to_regprocedure('public.has_role(uuid, public.app_role)') IS NULL THEN
+    RAISE EXCEPTION 'FU4-E: public.has_role(uuid,app_role) ausente — banco divergente, abortando'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- por ASSINATURA, não por proname: um overload futuro seria escolhido arbitrariamente.
+  FOREACH v_a IN ARRAY v_alvos LOOP
+    IF to_regprocedure(v_a) IS NULL THEN
+      RAISE EXCEPTION 'FU4-E: funcao % nao encontrada — banco divergente do medido', v_a
+        USING ERRCODE = 'raise_exception';
+    END IF;
+  END LOOP;
+
+  -- A troca é segura HOJE porque ninguém vive sob papel gerencial (medido 2026-07-19: 2 farmer
+  -- + 1 master, zero gerencial/estrategico/super_admin). Se alguém foi promovido entre a escrita
+  -- e a aplicação, a troca TIRARIA acesso de uma pessoa viva sem aviso — melhor abortar.
+  IF to_regclass('public.commercial_roles') IS NULL THEN
+    RAISE EXCEPTION 'FU4-E: tabela commercial_roles ausente — banco divergente, abortando'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  SELECT count(*) INTO v_gerenciais FROM public.commercial_roles
+   WHERE commercial_role IN ('gerencial','estrategico','super_admin');
+  IF v_gerenciais > 0 THEN
+    RAISE EXCEPTION 'FU4-E: % papel(is) gerencial(is) vivo(s) — a troca muda o acesso deles. Revise antes de aplicar.', v_gerenciais
+      USING ERRCODE = 'raise_exception';
+  END IF;
+END $$;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 1) A CAPABILITY — ESCREVER na telemetria do motor de compras
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- Master-only, igual à de leitura: o enum `commercial_role` não tem papel de compras, e inventar
+-- um aqui seria fabricar contrato. Ninguém perde acesso hoje (só o master passava no gate antigo).
+-- Fail-closed: `_uid` nulo ⇒ false, sem depender de NULL propagar como falso.
+CREATE OR REPLACE FUNCTION private.cap_compras_escrever(_uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid, 'master'::public.app_role), false);
+$function$;
+
+COMMENT ON FUNCTION private.cap_compras_escrever(uuid) IS
+  'FU4-E — ESCREVER na telemetria do motor de compras (despinar_parametro, reverter_parametro_auto, '
+  'reverter_run_auto). MASTER-ONLY. Separada de cap_compras_ler de propósito (spec §4.2): mesmo '
+  'concedendo hoje ao mesmo conjunto, é o que permite apertar um lado sem reabrir o outro.';
+
+-- O objeto NASCE ABERTO: o default privilege do Supabase concede EXECUTE em toda função nova
+-- (database.md §62). GRANT só acrescenta — o REVOKE tem de vir antes, e por NOME (revogar de
+-- PUBLIC não tira anon/authenticated).
+REVOKE ALL ON FUNCTION private.cap_compras_escrever(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION private.cap_compras_escrever(uuid) TO authenticated, service_role;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 2) AS 3 RPCs — troca do gate por substituição programática GUARDADA
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- POR QUE PROGRAMÁTICO E NÃO VERBATIM: o repo diverge de prod em `CREATE OR REPLACE` (apply
+-- manual), e a última a recriar VENCE. Colar o corpo daqui arriscaria sobrescrever prod com uma
+-- versão velha do repo. Reescrevemos a partir do corpo VIVO (`pg_get_functiondef`), trocando só
+-- o gate. O guard é o que torna isto seguro: se o padrão não casar — função já migrada, ou corpo
+-- diferente do medido — a migration ABORTA em vez de aplicar no-op silencioso.
+--
+-- ⚠️ DIFERENÇA em relação à §3 do #1434: lá o replace fixava `auth.uid()` no padrão. Aqui NÃO
+-- pode — `reverter_parametro_auto` chama o gate com a variável `v_uid`, não com `auth.uid()`
+-- (medido). Trocamos apenas NOME + abre-parêntese, preservando o argumento verbatim; assim o
+-- mesmo bloco serve às três sem hardcodar o que cada uma passa.
+DO $$
+DECLARE
+  v_alvos text[] := ARRAY['public.despinar_parametro(text,text)',
+                          'public.reverter_parametro_auto(uuid)',
+                          'public.reverter_run_auto(uuid)'];
+  v_a     text;
+  v_oid   regprocedure;
+  v_def   text;
+  v_novo  text;
+  v_ocorr int;
+  -- Chamada do gate antigo, tolerante a qualificação e espaçamento. O alternador aceita
+  -- `private.` porque a PROD tem as DUAS formas (wrapper em public + implementação em private,
+  -- pelo #1427): casar só `public.` deixaria passar uma reescrita futura, e o guard mentiria.
+  c_re_antigo constant text := '(public\.|private\.)?pode_ver_carteira_completa\s*\(';
+  c_re_novo   constant text := 'private\.cap_compras_escrever\s*\(';
+BEGIN
+  FOREACH v_a IN ARRAY v_alvos LOOP
+    v_oid := to_regprocedure(v_a);   -- existência já garantida na §0
+    v_def := pg_get_functiondef(v_oid);
+
+    -- IDEMPOTENTE: já migrada ⇒ segue. Migration custom deste repo tem de poder ser re-aplicada
+    -- (o dono cola à mão; um erro de rede no meio não pode travar a 2ª tentativa).
+    IF v_def ~ c_re_novo AND v_def !~ c_re_antigo THEN
+      CONTINUE;
+    END IF;
+
+    -- exatamente 1 chamada do gate antigo — medido em prod 2026-07-19. Mais de uma significa
+    -- corpo diferente do que esta migration foi escrita para tratar.
+    SELECT count(*) INTO v_ocorr FROM regexp_matches(v_def, c_re_antigo, 'g');
+    IF v_ocorr <> 1 THEN
+      RAISE EXCEPTION 'FU4-E: esperava 1 chamada do gate antigo em %, encontrei % — inspecione pg_get_functiondef antes de prosseguir', v_a, v_ocorr
+        USING ERRCODE = 'raise_exception';
+    END IF;
+
+    -- troca NOME + abre-parêntese; o argumento (auth.uid() ou v_uid) fica intacto.
+    v_novo := regexp_replace(v_def, c_re_antigo, 'private.cap_compras_escrever(', 'g');
+
+    IF v_novo = v_def THEN
+      RAISE EXCEPTION 'FU4-E: padrao do gate nao casou em % — nao aplicar no-op silencioso', v_a
+        USING ERRCODE = 'raise_exception';
+    END IF;
+    IF v_novo ~ c_re_antigo THEN
+      RAISE EXCEPTION 'FU4-E: sobrou chamada ao gate antigo em % apos a troca', v_a
+        USING ERRCODE = 'raise_exception';
+    END IF;
+    IF v_novo !~ c_re_novo THEN
+      RAISE EXCEPTION 'FU4-E: o gate NOVO nao aparece em % apos a troca', v_a
+        USING ERRCODE = 'raise_exception';
+    END IF;
+
+    EXECUTE v_novo;
+
+    -- pós-check POSITIVO no objeto final: o guard textual acima valida a string que vamos
+    -- executar; isto valida o que o catálogo realmente guardou.
+    IF pg_get_functiondef(to_regprocedure(v_a)) !~ c_re_novo THEN
+      RAISE EXCEPTION 'FU4-E: pos-check falhou — % nao ficou com o gate novo', v_a
+        USING ERRCODE = 'raise_exception';
+    END IF;
+    IF pg_get_functiondef(to_regprocedure(v_a)) ~ c_re_antigo THEN
+      RAISE EXCEPTION 'FU4-E: pos-check falhou — % ainda referencia o gate antigo', v_a
+        USING ERRCODE = 'raise_exception';
+    END IF;
+  END LOOP;
+END $$;
+
+COMMIT;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY (rodar DEPOIS do COMMIT; 4 linhas, todas devem vir `t`)
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- SELECT 'cap existe + master-only' AS check,
+--        private.cap_compras_escrever(NULL) IS FALSE
+--        AND to_regprocedure('private.cap_compras_escrever(uuid)') IS NOT NULL AS ok
+-- UNION ALL
+-- SELECT 'as 3 RPCs com o gate NOVO',
+--        count(*) = 3 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--         WHERE n.nspname='public'
+--           AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+--           AND pg_get_functiondef(p.oid) ~ 'private\.cap_compras_escrever\s*\('
+-- UNION ALL
+-- SELECT 'nenhuma das 3 no gate ANTIGO',
+--        count(*) = 0 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+--         WHERE n.nspname='public'
+--           AND p.proname IN ('despinar_parametro','reverter_parametro_auto','reverter_run_auto')
+--           AND pg_get_functiondef(p.oid) ~ '(public\.|private\.)?pode_ver_carteira_completa\s*\('
+-- UNION ALL
+-- SELECT 'ACL: authenticated executa, anon não',
+--        has_function_privilege('authenticated','private.cap_compras_escrever(uuid)','EXECUTE')
+--        AND NOT has_function_privilege('anon','private.cap_compras_escrever(uuid)','EXECUTE');


### PR DESCRIPTION
Fecha o **FU4-E** registrado no cabeçalho da `20260718190000` (E2/FU4, #1434): o papel `gerencial` deixaria de **ler** a telemetria do motor de compras, mas seguiria podendo **alterá-la**.

As 3 RPCs `SECURITY DEFINER` que ficaram no gate antigo (medidas em prod via `psql-ro`, 1 ocorrência cada):

| RPC | Efeito de escrita |
|---|---|
| `despinar_parametro(text,text)` | `DELETE` em `reposicao_param_pin` |
| `reverter_parametro_auto(uuid)` | `UPDATE sku_parametros` + `INSERT param_pin` + `UPDATE param_auto_log` |
| `reverter_run_auto(uuid)` | reverte um run inteiro (chama a anterior em loop) |

## Achado que mudou a premissa

O PR #1434 **segue em draft e a migration dele nunca foi aplicada** — medido 2026-07-19: o schema `private` tem só `carteira_visivel_para`, `is_super_admin` e `pode_ver_carteira_completa`, **zero `cap_*`**. (Já o #1427 **foi** aplicado, ao contrário do que o cabeçalho do #1434 afirma.)

Por isso esta migration é **ordem-independente**: `cap_compras_escrever` lê `has_role` direto, sem referenciar `cap_compras_ler`. Aplica antes, depois ou sem o #1434 — mesma propriedade que o #1434 adotou após a falha do #1423.

| Aplicado | Resultado |
|---|---|
| ambas | estado-alvo |
| **só esta** | gerencial lê telemetria mas não muta — **mais restritivo que hoje** |
| só #1434 | a incoerência FU4-E original |
| nenhuma | status quo |

## Desenho

- **Escrita ≠ leitura** (spec §4.2): função separada mesmo concedendo hoje ao mesmo conjunto — permite apertar um lado sem reabrir o outro, mexendo em 1 função.
- **Substituição programática guardada** a partir do corpo VIVO (`pg_get_functiondef`), não corpo colado: o repo diverge de prod em `CREATE OR REPLACE` e a última a recriar vence. **Diferente da §3 do #1434**, o replace preserva o **argumento** (`reverter_parametro_auto` passa `v_uid`, não `auth.uid()`) — troca só nome + abre-parêntese.
- 7 guards por função + precondição que aborta com papel gerencial vivo. Qualquer divergência **aborta**; nunca no-op silencioso.
- `REVOKE`/`GRANT` explícitos: o default privilege do Supabase faz a função **nascer aberta**.

## Prova

`db/test-authz-cap-compras-escrever.sh` — PG17, **35 asserts**, `SET ROLE authenticated` + GUC. Negativos por **SQLSTATE `P0001`**, sem casar o texto da mensagem. As RPCs são **chamadas de verdade** e o efeito no dado é conferido (plpgsql é late-bound).

Stubs espelham prod, não o design: `sku_codigo_omie` é `bigint` em `sku_parametros` e `text` no log (daí o `::text` do código), `param_pin` tem **PK composta**, `param_auto_log.run_id` é NOT NULL com FK.

**Falsificação em 2 eixos**, com baseline verde explícito antes:

| Sabotagem | Vermelhos | Total |
|---|---|---|
| baseline | 0 | 35 |
| capability aceita o gate antigo | **6** (N1, N1e, N2, N2e, N2p, N3) | 35 |
| troca do gate removida | **11** (+ P0b, K3, K5, F1r, F4) | 35 |

Total preservado em ambas ⇒ o harness rodou inteiro, não morreu cedo.

## ⚠️ Deploy

**Migration MANUAL** — colar no SQL Editor do Lovable (Lovable não aplica nome custom; falha silenciosa). A query de validação pós-apply (4 linhas, todas `t`) está comentada no rodapé do arquivo.

Sem mudança de frontend: assinatura, retorno e mensagem de erro das 3 RPCs ficam idênticos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)