### PR TITLE
fix(margem): custo ausente não vira margem cheia no cross-sell/bundle [money-path]

### DIFF
--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -420,7 +420,11 @@ export const useBundleEngine = () => {
           for (const pid of missingProducts) {
             const product = productMap.get(pid);
             if (!product) continue;
-            const cost = costMap.get(pid) || 0;
+            // Custo desconhecido → SKU fora do bundle (ausente≠zero). Com `|| 0` a margem virava
+            // o preço cheio, e como o único filtro é `margin <= 0` o produto sem custo nunca era
+            // excluído: o LIE do bundle passava a preferir justamente o que falta cadastrar.
+            const cost = costMap.get(pid);
+            if (cost == null) continue;
             const price = Number(product.valor_unitario || 0);
             const margin = price - cost;
             if (margin <= 0) continue;
@@ -436,7 +440,9 @@ export const useBundleEngine = () => {
                 if (purchased.has(relatedPid) || relatedPid === pid) continue;
                 const relatedProduct = productMap.get(relatedPid);
                 if (!relatedProduct) continue;
-                const relatedCost = costMap.get(relatedPid) || 0;
+                // Mesmo motivo do produto principal: sem custo o par sai do bundle.
+                const relatedCost = costMap.get(relatedPid);
+                if (relatedCost == null) continue;
                 const relatedPrice = Number(relatedProduct.valor_unitario || 0);
                 const relatedMargin = relatedPrice - relatedCost;
                 if (relatedMargin <= 0) continue;

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
-import { custoCanonico } from '@/lib/custo/custoCanonico';
+import { custoCanonico, margemUnitaria } from '@/lib/custo/custoCanonico';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface Recommendation {
@@ -260,7 +260,8 @@ export const useCrossSellEngine = () => {
       });
 
       // 7. Build per-customer purchase history
-      const customerProducts = new Map<string, Map<string, { qty: number; price: number; cost: number }>>();
+      // cost: number | null — null = custo DESCONHECIDO (SKU fora do costMap), nunca 0.
+      const customerProducts = new Map<string, Map<string, { qty: number; price: number; cost: number | null }>>();
       const allProductPurchases = new Map<string, number>(); // product_id -> total customers who bought
 
       for (const order of salesOrders || []) {
@@ -277,10 +278,12 @@ export const useCrossSellEngine = () => {
           }
           if (!productId) continue;
 
-          const existing = cp.get(productId) || { qty: 0, price: 0, cost: 0 };
+          const existing = cp.get(productId) || { qty: 0, price: 0, cost: null as number | null };
           existing.qty += Number(item.quantity || item.quantidade || 1);
           existing.price = Number(item.unit_price || item.valor_unitario || 0);
-          existing.cost = costMap.get(productId) || 0;
+          // Custo ausente fica null (ausente≠zero) — com `|| 0` a margem do item virava o preço
+          // cheio e distorcia a comparação de rentabilidade do up-sell logo abaixo.
+          existing.cost = costMap.get(productId) ?? null;
           cp.set(productId, existing);
 
           // Track which products are popular
@@ -329,10 +332,12 @@ export const useCrossSellEngine = () => {
         for (const product of productList) {
           if (purchasedIds.has(product.id)) continue;
 
-          const cost = costMap.get(product.id) || 0;
           const price = Number(product.valor_unitario || 0);
-          const margin = price - cost;
-          if (margin <= 0) continue; // Skip negative margin products
+          // Sem custo conhecido a margem é INDEFINIDA, não cheia: o SKU sai do ranking. Com
+          // `|| 0` ele ganhava margem 100% e, como o único filtro é `margin <= 0`, era o único
+          // que jamais era excluído — o LIE passava a preferir o produto sem custo cadastrado.
+          const margin = margemUnitaria(price, costMap.get(product.id));
+          if (margin == null || margin <= 0) continue; // custo desconhecido, ou margem não-positiva
 
           // Cluster adherence: how many similar customers bought this
           const buyerCount = allProductPurchases.get(product.id) || 0;
@@ -382,8 +387,10 @@ export const useCrossSellEngine = () => {
 
         // ─── UP-SELL: Find premium alternatives for current low-margin products ───
         for (const [purchasedId, purchaseData] of customerPurchased.entries()) {
-          const currentMargin = purchaseData.price - purchaseData.cost;
-          if (currentMargin <= 0 || purchaseData.price <= 0) continue;
+          // Custo do item comprado desconhecido → não dá para afirmar que a margem atual é ruim;
+          // o produto sai do up-sell em vez de ser tratado como margem cheia.
+          const currentMargin = margemUnitaria(purchaseData.price, purchaseData.cost);
+          if (currentMargin == null || currentMargin <= 0 || purchaseData.price <= 0) continue;
           const currentMarginPct = currentMargin / purchaseData.price;
           if (currentMarginPct > 0.35) continue; // Already good margin, skip
 
@@ -392,9 +399,11 @@ export const useCrossSellEngine = () => {
             if (product.id === purchasedId) continue;
             if (purchasedIds.has(product.id)) continue;
 
-            const premiumCost = costMap.get(product.id) || 0;
             const premiumPrice = Number(product.valor_unitario || 0);
-            const premiumMargin = premiumPrice - premiumCost;
+            const premiumMargin = margemUnitaria(premiumPrice, costMap.get(product.id));
+            // Sem custo não há como PROVAR que a alternativa é mais rentável — fora do up-sell
+            // (com `|| 0` ela aparentava a maior margem possível e vencia a comparação abaixo).
+            if (premiumMargin == null) continue;
 
             // Must be genuinely premium: higher price AND higher margin
             if (premiumPrice <= purchaseData.price * 1.1) continue;

--- a/src/lib/custo/__tests__/custoCanonico.test.ts
+++ b/src/lib/custo/__tests__/custoCanonico.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { custoValido, custoCanonico } from '@/lib/custo/custoCanonico';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { custoValido, custoCanonico, margemUnitaria } from '@/lib/custo/custoCanonico';
 
 describe('custoValido — ausente≠zero', () => {
   it('aceita número positivo finito', () => {
@@ -27,5 +29,45 @@ describe('custoCanonico — cost_final preferido, fallback cost_price real', () 
     expect(custoCanonico({ cost_final: null, cost_price: null })).toBeNull();
     expect(custoCanonico({ cost_final: 0, cost_price: 0 })).toBeNull();
     expect(custoCanonico({})).toBeNull();
+  });
+});
+
+describe('margemUnitaria — custo ausente NÃO vira margem cheia', () => {
+  it('calcula preço - custo quando o custo é conhecido', () => {
+    expect(margemUnitaria(100, 60)).toBe(40);
+  });
+
+  it('custo ausente (costMap sem o SKU) → null, e a margem NUNCA é igual ao preço', () => {
+    for (const semCusto of [undefined, null] as const) {
+      const m = margemUnitaria(100, semCusto);
+      expect(m).toBeNull();
+      // O ponto do bug: com `costMap.get(id) || 0` isto daria 100 (margem 100%) e o SKU
+      // sem custo SUBIA no ranking, porque todo engine filtra só `margin <= 0`.
+      expect(m).not.toBe(100);
+    }
+  });
+
+  it('margem negativa é preservada (custo > preço é dado REAL, não ausência)', () => {
+    expect(margemUnitaria(50, 80)).toBe(-30);
+  });
+});
+
+// ── Invariante textual: o CONSUMO do costMap nos engines não pode fabricar custo 0 ──
+// Por que textual: o bug não está no cálculo isolado, está no ponto de LEITURA do map — a
+// montagem já excluía o SKU sem custo (custoCanonico → null), e o consumo reintroduzia o zero
+// com `costMap.get(id) || 0`. O helper acima não impede alguém de escrever `|| 0` de novo no
+// hook; este teste impede. Mesmo idioma de src/__tests__/edge-money-path-invariants.test.ts.
+const REPO = resolve(__dirname, '../../../..');
+const ENGINES = [
+  'src/hooks/useCrossSellEngine.ts',
+  'src/hooks/useBundleEngine.ts',
+  'src/hooks/useFarmerScoring.ts',
+];
+
+describe('invariante: consumo do costMap não fabrica custo zero', () => {
+  it.each(ENGINES)('%s não usa `costMap.get(...) || 0` nem `?? 0`', (rel) => {
+    const src = readFileSync(resolve(REPO, rel), 'utf8');
+    const fabricacoes = src.match(/costMap\.get\([^)]*\)\s*(\|\||\?\?)\s*0/g) ?? [];
+    expect(fabricacoes).toEqual([]);
   });
 });

--- a/src/lib/custo/custoCanonico.ts
+++ b/src/lib/custo/custoCanonico.ts
@@ -19,3 +19,17 @@ export function custoCanonico(row: {
 }): number | null {
   return custoValido(row.cost_final) ?? custoValido(row.cost_price);
 }
+
+/**
+ * Margem unitária honesta: `null` quando o custo é DESCONHECIDO (SKU fora do costMap).
+ *
+ * O chamador DEVE excluir o SKU do ranking ao receber null — nunca tratar como 0. Com o
+ * antigo `costMap.get(id) || 0`, um SKU sem custo virava `margin = price - 0` = preço cheio
+ * (margem 100%); e como todo engine filtra apenas `margin <= 0`, o SKU sem custo era o ÚNICO
+ * que jamais era excluído — o ranking passava a RECOMENDAR justamente os produtos cujo custo
+ * falta, o inverso do desejado. Margem negativa é dado real e é preservada.
+ */
+export function margemUnitaria(price: number, cost: number | null | undefined): number | null {
+  if (cost == null) return null;
+  return price - cost;
+}


### PR DESCRIPTION
## O bug

Os 3 engines montam o `costMap` **excluindo corretamente** o SKU sem custo (`custoCanonico` devolve `null`), com o comentário explícito *"Number(null)===0 inflava a margem (ausente≠zero) — excluir SKU sem custo, não fabricar 0"*. Mas o **consumo** do map reintroduzia exatamente a fabricação que o comentário diz evitar:

```ts
const cost = costMap.get(product.id) || 0;   // ← SKU ausente vira custo 0
const margin = price - cost;                 // ← margem = preço = 100%
if (margin <= 0) continue;                   // ← e este é o ÚNICO filtro
```

O agravante está no guard: como todo engine filtra apenas `margin <= 0`, o SKU sem custo era **o único que jamais era excluído** — sua margem fabricada é a máxima possível. O ranking passava a **recomendar preferencialmente os produtos cujo custo está faltando**, o inverso do desejado. Contaminava `mij` (margem incremental) no cross-sell e `mBundle`/`lieBundle` no bundle.

## Dimensionamento em produção — corrige a hipótese de impacto

Medido via `psql-ro` antes de dimensionar a correção:

| métrica | valor |
|---|---|
| SKUs ativos (`omie_products`) | 3.108 |
| Linhas em `product_costs` | 3.637 |
| Com custo válido | 3.632 |
| **Ativos sem custo** | **53** |
| **Sem custo E com preço > 0** | **0** |

Os 53 SKUs sem custo têm **todos** `valor_unitario = 0`. Logo `margin = 0 - 0 = 0` e o guard `margin <= 0` já os excluía. **A exposição efetiva hoje é zero.**

Isso não torna o bug inócuo — torna-o *latente*: a proteção é **acidental** (depende de o preço também estar ausente), não intencional. Um único sync de preço do Omie sobre qualquer um desses 53 SKUs arma o problema. A correção é da causa, não do sintoma.

## O que mudou

**5 sites** (o relato original listava 3 — os outros 2 apareceram no `grep`):

- `useCrossSellEngine.ts` — histórico do cliente, ranking cross-sell, alternativa premium do up-sell
- `useBundleEngine.ts` — produto principal e produto relacionado do par

Onde o custo é desconhecido, o SKU agora **sai do ranking** em vez de receber margem cheia. Helper `margemUnitaria(price, cost)` em `custoCanonico.ts` — arquivo que os engines **já importavam**, então nenhuma fronteira de módulo nova.

`useFarmerScoring` **não tinha o bug**: já usa `accumulateMarginFromItems`, que exclui com `if (c == null) continue`.

## Teste que falha hoje

Invariante textual (idioma de `edge-money-path-invariants.test.ts`) proibindo `costMap.get(...) || 0` nos 3 engines — ele **detectou sozinho** os 2 sites do bundle:

```
AssertionError: expected [ 'costMap.get(pid) || 0', …(1) ] to deeply equal []
```

Mais unitários de `margemUnitaria` cobrindo o caso pedido: *costMap sem o SKU → a margem NÃO pode ser igual ao preço*.

**Falsificado:** sabotar o helper para `price - (cost ?? 0)` deixa a suíte vermelha (`exit=1`) no teste exato — o teste não é teatro.

## Verificação

| gate | resultado |
|---|---|
| vitest (custo + scoring) | `exit=0` — 215 testes |
| typecheck (strict) | `exit=0` |
| lint | `exit=0` |
| falsificação (helper sabotado) | `exit=1` ✓ vermelho esperado |

## Fora de escopo (achado durante a investigação)

A investigação encontrou um **bug maior e independente** no `useFarmerScoring`, com impacto **ativo hoje** — vai em PR separado, conforme combinado: o hook lê `item.product_id` e `item.unit_price`, mas dos **68.166** itens de pedido em produção apenas **43** têm `product_id` e **zero** têm `unit_price` (o dado real é pt-BR: `omie_codigo_produto` / `valor_unitario`). Efeito: margem (G) e diversidade de categoria (X) são constante zero para todos os clientes → **30% do health score do farmer está morto**. Os outros dois engines têm o fallback para `omie_codigo_produto`; o farmer é o único sem ele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
