### PR TITLE
fix(farmer): score lê o item pt-BR — G e X deixam de ser zero para todo cliente [money-path]

### DIFF
--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { Tables } from '@/integrations/supabase/types';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
-import { accumulateMarginFromItems } from '@/lib/scoring/margin';
+import { accumulateMarginFromItems, resolveProductIdsFromItems } from '@/lib/scoring/margin';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
 type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price' | 'cost_final'>;
@@ -17,10 +17,15 @@ type SalesOrderRow = Pick<
   'id' | 'customer_user_id' | 'items' | 'total' | 'created_at' | 'order_date_kpi' | 'status'
 >;
 
+// O jsonb real de sales_orders.items é pt-BR (omie_codigo_produto/quantidade/valor_unitario);
+// as chaves em inglês existiam no tipo mas nunca no dado — mantidas por compatibilidade.
 interface SalesOrderItem {
   product_id?: string;
+  omie_codigo_produto?: number | string;
   quantity?: number | string;
+  quantidade?: number | string;
   unit_price?: number | string;
+  valor_unitario?: number | string;
 }
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -95,6 +100,24 @@ function percentile(arr: number[], p: number): number {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
 }
 
+// PostgREST corta a resposta em 1.000 linhas — capa SILENCIOSA (sem erro, sem aviso).
+// product_costs tem 3.637 linhas e omie_products 3.108: sem paginar, a cauda do catálogo
+// some do costMap e do mapa omie→uuid, e cada SKU da cauda é lido como "sem custo".
+// Mesmo padrão do fetchAllPaginated dos edges (algorithm-a-audit, fin-valor-cockpit).
+// `.order` estável é obrigatório: sem ordenação definida a paginação pode repetir/pular linhas.
+async function fetchAllPages<T>(
+  buscarPagina: (de: number, ate: number) => PromiseLike<{ data: T[] | null }>,
+): Promise<T[]> {
+  const tamanho = 1000;
+  const todas: T[] = [];
+  for (let pagina = 0; ; pagina++) {
+    const { data } = await buscarPagina(pagina * tamanho, (pagina + 1) * tamanho - 1);
+    const linhas = data ?? [];
+    todas.push(...linhas);
+    if (linhas.length < tamanho) return todas;
+  }
+}
+
 // ─── Main Hook ───────────────────────────────────────────────────────
 export const useFarmerScoring = (farmerId?: string) => {
   // Lente "Ver como": id efetivo = ALVO na lente (lê/exibe a agenda dele), próprio usuário fora.
@@ -166,17 +189,36 @@ export const useFarmerScoring = (farmerId?: string) => {
         if (fPage.length < 1000) break;
       }
 
-      // 2. Load product costs for margin calculation
-      const { data: productCostsData } = await supabase
-        .from('product_costs')
-        .select('product_id, cost_final, cost_price');
-      const productCosts = (productCostsData ?? []) as ProductCostRow[];
+      // 2. Load product costs for margin calculation (paginado: 3.637 linhas > capa de 1.000)
+      const productCosts = await fetchAllPages<ProductCostRow>((de, ate) =>
+        supabase
+          .from('product_costs')
+          .select('product_id, cost_final, cost_price')
+          .order('product_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ProductCostRow[] | null }>,
+      );
       const costMap = new Map<string, number>();
       // Custo canônico = cost_final (proxy-aware); cost_price agora é nullable (só custo real).
       // Number(null)===0 inflava a margem (ausente≠zero) — excluir SKU sem custo, não fabricar 0.
       productCosts.forEach((pc) => {
         const c = custoCanonico(pc);
         if (c != null) costMap.set(pc.product_id, c);
+      });
+
+      // 2b. Mapa omie_codigo_produto → UUID. Os itens de pedido em produção são pt-BR e trazem
+      // `omie_codigo_produto`, não `product_id` — sem este mapa, TODO item era descartado e os
+      // componentes de margem (G) e de mix (X) do health score ficavam zerados para todo cliente.
+      type ProdutoOmieRow = { id: string; omie_codigo_produto: number | string | null };
+      const produtos = await fetchAllPages<ProdutoOmieRow>((de, ate) =>
+        supabase
+          .from('omie_products')
+          .select('id, omie_codigo_produto')
+          .order('id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ProdutoOmieRow[] | null }>,
+      );
+      const omieToProductId = new Map<number, string>();
+      produtos.forEach((p) => {
+        if (p.omie_codigo_produto != null) omieToProductId.set(Number(p.omie_codigo_produto), p.id);
       });
 
       // 3. Load farmer calls for contact rates
@@ -241,12 +283,12 @@ export const useFarmerScoring = (farmerId?: string) => {
         const items: SalesOrderItem[] = Array.isArray(order.items)
           ? (order.items as unknown as SalesOrderItem[])
           : [];
-        for (const item of items) {
-          if (item.product_id) cd.categories.add(item.product_id);
+        for (const pid of resolveProductIdsFromItems(items, omieToProductId)) {
+          cd.categories.add(pid);
         }
         // Margem só sobre SKU com custo CONHECIDO (custo ausente não vira 0 — inflaria a
         // margem; ausente ≠ zero). Alinhado ao filtro do costMap acima (~linha 176).
-        const { revenue, cost } = accumulateMarginFromItems(items, costMap);
+        const { revenue, cost } = accumulateMarginFromItems(items, costMap, omieToProductId);
         cd.totalRevenue += revenue;
         cd.totalCost += cost;
       }

--- a/src/lib/scoring/__tests__/margin.test.ts
+++ b/src/lib/scoring/__tests__/margin.test.ts
@@ -48,3 +48,63 @@ describe('accumulateMarginFromItems', () => {
     expect(cost).toBe(10);
   });
 });
+
+// ── Forma REAL do jsonb de sales_orders.items em produção ───────────────────────────
+// Medido em 2026-07-20 (psql-ro), status confirmado/faturado/entregue: 46.396 itens, dos
+// quais 46.396 têm `omie_codigo_produto`/`valor_unitario`/`quantidade` (pt-BR) e ZERO têm
+// `product_id`/`unit_price`/`quantity` (inglês). Os fixtures em inglês acima descrevem um
+// contrato que o banco nunca produziu — por isso o helper ficava 100% verde enquanto a
+// margem do farmer era zero para todo cliente.
+describe('accumulateMarginFromItems — item pt-BR (a forma que produção realmente tem)', () => {
+  const omieToProductId = new Map<number, string>([[555, 'A']]);
+
+  it('resolve o SKU por omie_codigo_produto quando product_id está ausente', () => {
+    const { revenue, cost } = accumulateMarginFromItems(
+      [{ omie_codigo_produto: 555, quantidade: 2, valor_unitario: 30 }],
+      new Map([['A', 10]]),
+      omieToProductId,
+    );
+    expect(revenue).toBe(60);
+    expect(cost).toBe(20);
+  });
+
+  it('aceita omie_codigo_produto como string (jsonb) e quantidade/valor_unitario string', () => {
+    const { revenue, cost } = accumulateMarginFromItems(
+      [{ omie_codigo_produto: '555', quantidade: '3', valor_unitario: '10' }],
+      new Map([['A', 4]]),
+      omieToProductId,
+    );
+    expect(revenue).toBe(30);
+    expect(cost).toBe(12);
+  });
+
+  it('a receita do item pt-BR NÃO pode ser zero — era o bug: 30% do health score morto', () => {
+    const { revenue } = accumulateMarginFromItems(
+      [{ omie_codigo_produto: 555, quantidade: 4, valor_unitario: 25 }],
+      new Map([['A', 10]]),
+      omieToProductId,
+    );
+    expect(revenue).toBeGreaterThan(0);
+    expect(revenue).toBe(100);
+  });
+
+  it('SKU que o mapa omie→uuid não conhece é ignorado (não vira receita órfã)', () => {
+    const { revenue, cost } = accumulateMarginFromItems(
+      [{ omie_codigo_produto: 999, quantidade: 1, valor_unitario: 50 }],
+      new Map([['A', 10]]),
+      omieToProductId,
+    );
+    expect(revenue).toBe(0);
+    expect(cost).toBe(0);
+  });
+
+  it('product_id explícito continua tendo precedência sobre omie_codigo_produto', () => {
+    const { revenue, cost } = accumulateMarginFromItems(
+      [{ product_id: 'B', omie_codigo_produto: 555, quantidade: 1, valor_unitario: 10 }],
+      new Map([['B', 3]]),
+      omieToProductId,
+    );
+    expect(revenue).toBe(10);
+    expect(cost).toBe(3);
+  });
+});

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -1,7 +1,27 @@
 interface MarginItem {
   product_id?: string;
+  omie_codigo_produto?: number | string;
   quantity?: number | string;
+  quantidade?: number | string;
   unit_price?: number | string;
+  valor_unitario?: number | string;
+}
+
+/**
+ * Resolve o UUID do produto a partir do item de pedido.
+ *
+ * O jsonb de `sales_orders.items` em produção é pt-BR e traz `omie_codigo_produto`, NÃO
+ * `product_id` (medido 2026-07-20: 46.396 de 46.396 itens com omie_codigo, ZERO com
+ * product_id). Ler só `product_id` descartava todos os itens em silêncio. Mesmo fallback
+ * que useCrossSellEngine e useBundleEngine já aplicam.
+ */
+function resolveProductId(
+  item: MarginItem,
+  omieToProductId?: Map<number, string>,
+): string | undefined {
+  if (item.product_id) return item.product_id;
+  if (item.omie_codigo_produto == null || !omieToProductId) return undefined;
+  return omieToProductId.get(Number(item.omie_codigo_produto));
 }
 
 /**
@@ -11,21 +31,42 @@ interface MarginItem {
  * SKU sem custo é EXCLUÍDO (receita e custo) em vez de virar custo 0 — senão a margem
  * bruta infla silenciosamente (ausente ≠ zero, money-path). O cliente que só compra SKU
  * sem custo fica com receita/custo 0 → margem indefinida (não 100%).
+ *
+ * `omieToProductId` mapeia omie_codigo_produto → UUID; sem ele, itens que só têm o código
+ * Omie (a maioria absoluta em produção) são descartados.
  */
 export function accumulateMarginFromItems(
   items: MarginItem[],
   costMap: Map<string, number>,
+  omieToProductId?: Map<number, string>,
 ): { revenue: number; cost: number } {
   let revenue = 0;
   let cost = 0;
   for (const item of items) {
-    if (!item.product_id) continue;
-    const c = costMap.get(item.product_id);
+    const productId = resolveProductId(item, omieToProductId);
+    if (!productId) continue;
+    const c = costMap.get(productId);
     if (c == null) continue;
-    const qty = Number(item.quantity || 1);
-    const price = Number(item.unit_price || 0);
+    const qty = Number(item.quantity || item.quantidade || 1);
+    const price = Number(item.unit_price || item.valor_unitario || 0);
     revenue += price * qty;
     cost += c * qty;
   }
   return { revenue, cost };
+}
+
+/**
+ * SKUs distintos de um pedido, para a diversidade de mix (componente X do health score).
+ * Mesma resolução pt-BR do cálculo de margem — ler só `product_id` zerava o X de todo cliente.
+ */
+export function resolveProductIdsFromItems(
+  items: MarginItem[],
+  omieToProductId?: Map<number, string>,
+): string[] {
+  const ids: string[] = [];
+  for (const item of items) {
+    const productId = resolveProductId(item, omieToProductId);
+    if (productId) ids.push(productId);
+  }
+  return ids;
 }


### PR DESCRIPTION
## O bug

`useFarmerScoring` lê cada item de pedido por `item.product_id` e `item.unit_price`. **Esses campos não existem no dado real.** O jsonb de `sales_orders.items` em produção é pt-BR.

Medido via `psql-ro` em 2026-07-20, status `confirmado`/`faturado`/`entregue`:

| chave | itens que a possuem |
|---|---|
| `omie_codigo_produto` | **46.396** (100%) |
| `valor_unitario` | **46.396** (100%) |
| `quantidade` | **46.396** (100%) |
| `product_id` | **0** |
| `unit_price` | **0** |
| `quantity` | **0** |

(Considerando todos os status: 68.166 itens, dos quais **43** têm `product_id`.)

Consequência — o hook descartava **todo** item, em silêncio, em dois pontos:

1. `accumulateMarginFromItems` → `if (!item.product_id) continue` → `totalRevenue = 0` para todo cliente → `allMargins` vazio → `percentile([], p)` devolve `0` → `p10 = p90 = 0` → **G (margem) = 0 para todos**.
2. `cd.categories.add(item.product_id)` → conjunto sempre vazio → **X (diversidade de mix) = 0 para todos**.

`Health = 100 × (0.35·RF + 0.20·M + 0.15·G + 0.15·X + 0.15·S)` — com G e X constantes em zero, **30% do health score não discriminava nada**. Não era um viés no ranking: era um componente morto.

`useCrossSellEngine` e `useBundleEngine` já tinham o fallback para `omie_codigo_produto`; o farmer era o único engine sem ele.

## Por que o teste não pegava

`margin.test.ts` usava fixtures em inglês (`product_id`, `unit_price`) — um contrato que o banco **nunca produziu**. A suíte ficava 100% verde enquanto a margem era zero em produção. Os novos casos usam a forma pt-BR real e falham no código antigo:

```
AssertionError: expected +0 to be 60
```

## Efeito da correção (simulado no banco antes de entregar)

Refazendo o cálculo do hook em SQL sobre os dados reais:

| métrica | antes | depois |
|---|---|---|
| clientes com margem calculável | **0** | **744** |
| p10 da margem | 0% | **24,9%** |
| mediana | 0% | **53,0%** |
| p90 | 0% | **73,5%** |
| faixa (`marginRange`) | 0,01 (piso artificial) | **48,6 pontos** |

O mínimo é −123,9% (cliente com prejuízo real — dado legítimo, absorvido pelo `clamp(0,1)` do G). O componente volta a discriminar.

⚠️ **Isto muda o health score de todo cliente em produção** — é o objetivo da correção, mas vale saber antes de olhar a agenda do farmer.

## Paginação (obrigatória, não oportunista)

A correção exige um mapa `omie_codigo_produto → UUID`, e o PostgREST corta respostas em **1.000 linhas** — capa silenciosa, sem erro (regra registrada no CLAUDE.md; os edges `algorithm-a-audit` e `fin-valor-cockpit` já paginam `product_costs` por isso, e um teste de `costCompute` documenta a mordida anterior: *"um produto que ANTES sumia do costMap truncado (cauda > 1000 linhas de product_costs)"*).

`omie_products` tem 3.108 linhas e `product_costs` 3.637. Sem paginar, o mapa novo nasceria truncado em 1.000 e ~2/3 dos itens continuariam descartados — a correção reintroduziria o próprio bug que remove. Ambas as queries agora paginam com `.order()` estável.

Isso também significa que **o `costMap` do farmer estava truncado desde sempre**, independente deste bug.

## Verificação

| gate | resultado |
|---|---|
| vitest (suíte completa) | `exit=0` — 5.497 testes, 609 arquivos |
| vitest (scoring + custo) | `exit=0` — 220 testes (+5 novos) |
| typecheck (strict) | `exit=0` |
| lint | `exit=0` |
| teste novo no código ANTIGO | `exit=1` ✓ (`expected +0 to be 60`) |

## Segue em PR separado

`useCrossSellEngine` e `useBundleEngine` carregam `product_costs` sem paginação pelo mesmo motivo — o `costMap` deles também está truncado em 1.000 de 3.637. Vai num PR próprio, focado em transporte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
