### PR TITLE
fix(engines): mapas de custo/produto/perfil chegavam truncados em 1.000 [money-path]

### DIFF
--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -4,6 +4,7 @@ import type { Json } from '@/integrations/supabase/types';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
+import { fetchAllPages } from '@/lib/postgrest';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AssociationRule {
@@ -183,17 +184,37 @@ export const useBundleEngine = () => {
       let clientScores = await fetchAllScores(effectiveUserId);
       if (!clientScores.length && !isImpersonating) clientScores = await fetchAllScores();
 
-      const [
-        { data: products },
-        { data: productCosts },
-        { data: profiles },
-        { data: conversionData },
-      ] = await Promise.all([
-        supabase.from('omie_products').select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto').eq('ativo', true) as unknown as Promise<{ data: ProductRow[] | null }>,
-        supabase.from('product_costs').select('product_id, cost_final, cost_price') as unknown as Promise<{ data: ProductCostRow[] | null }>,
-        supabase.from('profiles').select('user_id, name, customer_type, cnae') as unknown as Promise<{ data: ProfileRow[] | null }>,
+      // As três primeiras estouram a capa de 1.000 do PostgREST (3.108 SKUs ativos, 3.637
+      // linhas de custo, 5.668 perfis) e vinham truncadas em silêncio: o costMap lia a maior
+      // parte do catálogo como "sem custo" e o profileMap deixava a maioria dos clientes sem
+      // perfil — e sem perfil o cliente é pulado (`if (!profile) continue`), ou seja, nunca
+      // recebia bundle. farmer_category_conversion não pagina: a tabela está vazia hoje.
+      const [products, productCosts, profiles, conversionResult] = await Promise.all([
+        fetchAllPages<ProductRow>((de, ate) =>
+          supabase
+            .from('omie_products')
+            .select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto')
+            .eq('ativo', true)
+            .order('id', { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: ProductRow[] | null }>,
+        ),
+        fetchAllPages<ProductCostRow>((de, ate) =>
+          supabase
+            .from('product_costs')
+            .select('product_id, cost_final, cost_price')
+            .order('product_id', { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: ProductCostRow[] | null }>,
+        ),
+        fetchAllPages<ProfileRow>((de, ate) =>
+          supabase
+            .from('profiles')
+            .select('user_id, name, customer_type, cnae')
+            .order('user_id', { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: ProfileRow[] | null }>,
+        ),
         supabase.from('farmer_category_conversion').select('*') as unknown as Promise<{ data: ConversionRow[] | null }>,
       ]);
+      const conversionData = conversionResult.data;
 
       if (!clientScores?.length) { setCustomerBundles([]); return; }
 

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { custoCanonico, margemUnitaria } from '@/lib/custo/custoCanonico';
+import { fetchAllPages } from '@/lib/postgrest';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface Recommendation {
@@ -153,20 +154,30 @@ export const useCrossSellEngine = () => {
         return;
       }
 
-      // 2. Load all products with costs
-      const { data: products } = (await supabase
-        .from('omie_products')
-        .select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto, estoque')
-        .eq('ativo', true)) as unknown as { data: ProductRow[] | null };
+      // 2. Load all products with costs. AMBAS paginadas: 3.108 SKUs ativos e 3.637 linhas de
+      // custo, contra a capa de 1.000 do PostgREST. Truncado, o costMap lia 72% do catálogo
+      // como "sem custo" e o productList nunca chegava a recomendar 2/3 dos SKUs.
+      const products = await fetchAllPages<ProductRow>((de, ate) =>
+        supabase
+          .from('omie_products')
+          .select('id, codigo, descricao, valor_unitario, metadata, ativo, omie_codigo_produto, estoque')
+          .eq('ativo', true)
+          .order('id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ProductRow[] | null }>,
+      );
 
-      const { data: productCosts } = (await supabase
-        .from('product_costs')
-        .select('product_id, cost_final, cost_price')) as unknown as { data: ProductCostRow[] | null };
+      const productCosts = await fetchAllPages<ProductCostRow>((de, ate) =>
+        supabase
+          .from('product_costs')
+          .select('product_id, cost_final, cost_price')
+          .order('product_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ProductCostRow[] | null }>,
+      );
 
       const costMap = new Map<string, number>();
       // Custo canônico = cost_final (proxy-aware); cost_price agora é nullable (só custo real).
       // Number(null)===0 inflava a margem (ausente≠zero) — excluir SKU sem custo, não fabricar 0.
-      (productCosts || []).forEach((pc) => {
+      productCosts.forEach((pc) => {
         const c = custoCanonico(pc);
         if (c != null) costMap.set(pc.product_id, c);
       });

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { Tables } from '@/integrations/supabase/types';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
+import { fetchAllPages } from '@/lib/postgrest';
 import { accumulateMarginFromItems, resolveProductIdsFromItems } from '@/lib/scoring/margin';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
@@ -100,24 +101,6 @@ function percentile(arr: number[], p: number): number {
   return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
 }
 
-// PostgREST corta a resposta em 1.000 linhas — capa SILENCIOSA (sem erro, sem aviso).
-// product_costs tem 3.637 linhas e omie_products 3.108: sem paginar, a cauda do catálogo
-// some do costMap e do mapa omie→uuid, e cada SKU da cauda é lido como "sem custo".
-// Mesmo padrão do fetchAllPaginated dos edges (algorithm-a-audit, fin-valor-cockpit).
-// `.order` estável é obrigatório: sem ordenação definida a paginação pode repetir/pular linhas.
-async function fetchAllPages<T>(
-  buscarPagina: (de: number, ate: number) => PromiseLike<{ data: T[] | null }>,
-): Promise<T[]> {
-  const tamanho = 1000;
-  const todas: T[] = [];
-  for (let pagina = 0; ; pagina++) {
-    const { data } = await buscarPagina(pagina * tamanho, (pagina + 1) * tamanho - 1);
-    const linhas = data ?? [];
-    todas.push(...linhas);
-    if (linhas.length < tamanho) return todas;
-  }
-}
-
 // ─── Main Hook ───────────────────────────────────────────────────────
 export const useFarmerScoring = (farmerId?: string) => {
   // Lente "Ver como": id efetivo = ALVO na lente (lê/exibe a agenda dele), próprio usuário fora.
@@ -153,12 +136,17 @@ export const useFarmerScoring = (farmerId?: string) => {
     setCalculating(true);
 
     try {
-      // 1. Load all customers with sales orders
-      const { data: salesOrdersData } = await supabase
-        .from('sales_orders')
-        .select('id, customer_user_id, items, total, created_at, order_date_kpi, status')
-        .in('status', ['confirmado', 'faturado', 'entregue']);
-      const salesOrders = (salesOrdersData ?? []) as SalesOrderRow[];
+      // 1. Load all customers with sales orders (paginado: 19.978 pedidos nos 3 status).
+      // Sem paginar, TODO o scoring — recência, frequência, spend, margem, mix — enxergava
+      // só as primeiras 1.000 linhas, ~5% do histórico. Cross-sell e bundle já paginavam.
+      const salesOrders = await fetchAllPages<SalesOrderRow>((de, ate) =>
+        supabase
+          .from('sales_orders')
+          .select('id, customer_user_id, items, total, created_at, order_date_kpi, status')
+          .in('status', ['confirmado', 'faturado', 'entregue'])
+          .order('id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: SalesOrderRow[] | null }>,
+      );
 
       if (salesOrders.length === 0) {
         setClientScores([]);

--- a/src/lib/__tests__/postgrest.test.ts
+++ b/src/lib/__tests__/postgrest.test.ts
@@ -9,6 +9,8 @@ import {
   eqInt,
   eqText,
   orFilter,
+  fetchAllPages,
+  POSTGREST_PAGE_SIZE,
 } from '../postgrest';
 
 // Os metacaracteres que o parser do .or() interpreta — nenhum pode sobreviver à sanitização.
@@ -307,5 +309,61 @@ describe('orFilter', () => {
 
   it('zero cláusulas → string vazia', () => {
     expect(orFilter()).toBe('');
+  });
+});
+
+describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
+  // Simula o PostgREST: devolve no máximo POSTGREST_PAGE_SIZE linhas por request,
+  // truncando sem erro — exatamente o comportamento que engana quem não pagina.
+  const tabelaFalsa = (total: number) => {
+    const linhas = Array.from({ length: total }, (_, i) => ({ id: i }));
+    const chamadas: [number, number][] = [];
+    const buscar = (de: number, ate: number) => {
+      chamadas.push([de, ate]);
+      const fatia = linhas.slice(de, Math.min(ate + 1, de + POSTGREST_PAGE_SIZE));
+      return Promise.resolve({ data: fatia });
+    };
+    return { buscar, chamadas };
+  };
+
+  it('tabela maior que a capa: devolve TUDO, não as primeiras 1.000', async () => {
+    const { buscar } = tabelaFalsa(3637); // product_costs real
+    const todas = await fetchAllPages(buscar);
+    expect(todas).toHaveLength(3637);
+    expect(todas.at(-1)).toEqual({ id: 3636 }); // a cauda chegou
+  });
+
+  it('pagina com janelas contíguas e para na primeira página parcial', async () => {
+    const { buscar, chamadas } = tabelaFalsa(2500);
+    await fetchAllPages(buscar);
+    expect(chamadas).toEqual([[0, 999], [1000, 1999], [2000, 2999]]);
+  });
+
+  it('múltiplo exato da capa: faz uma página extra vazia e para (sem loop infinito)', async () => {
+    const { buscar, chamadas } = tabelaFalsa(2000);
+    const todas = await fetchAllPages(buscar);
+    expect(todas).toHaveLength(2000);
+    expect(chamadas).toHaveLength(3);
+  });
+
+  it('tabela menor que a capa: uma única requisição', async () => {
+    const { buscar, chamadas } = tabelaFalsa(42);
+    expect(await fetchAllPages(buscar)).toHaveLength(42);
+    expect(chamadas).toHaveLength(1);
+  });
+
+  it('tabela vazia → lista vazia, sem estourar', async () => {
+    const { buscar } = tabelaFalsa(0);
+    expect(await fetchAllPages(buscar)).toEqual([]);
+  });
+
+  it('data null (erro/RLS) encerra em vez de repetir a página para sempre', async () => {
+    let n = 0;
+    const todas = await fetchAllPages<{ id: number }>(() => {
+      n++;
+      return Promise.resolve({ data: null });
+    });
+    expect(todas).toEqual([]);
+    expect(n).toBe(1);
   });
 });

--- a/src/lib/postgrest.ts
+++ b/src/lib/postgrest.ts
@@ -103,3 +103,43 @@ export function eqText(column: string, value: string): string {
 export function orFilter(...clauses: string[]): string {
   return clauses.join(',');
 }
+
+/** Tamanho da página do PostgREST — é também a capa por request (CLAUDE.md §9b). */
+export const POSTGREST_PAGE_SIZE = 1000;
+
+/**
+ * Lê uma tabela INTEIRA respeitando a capa de 1.000 linhas por request do PostgREST.
+ *
+ * A capa é SILENCIOSA: a resposta vem truncada, sem erro e sem aviso. Quem carrega um
+ * catálogo inteiro para montar um Map (custo, produto, perfil) e não pagina fica com um
+ * mapa parcial — e a cauda vira "não encontrado", que no money-path é lido como "sem
+ * custo"/"produto inexistente". Já mordeu este repo em `product_costs` (ver o teste
+ * "O CORAÇÃO DO FIX" em costCompute) e os edges já paginam por isso
+ * (`algorithm-a-audit`, `fin-valor-cockpit`).
+ *
+ * `buscarPagina` DEVE aplicar um `.order()` estável junto do `.range(de, ate)`: sem
+ * ordenação definida o Postgres não garante a mesma sequência entre requests, e a
+ * paginação pode repetir ou pular linhas.
+ *
+ * ```ts
+ * const custos = await fetchAllPages<CostRow>((de, ate) =>
+ *   supabase.from('product_costs').select('product_id, cost_final')
+ *     .order('product_id', { ascending: true }).range(de, ate) as unknown as
+ *       PromiseLike<{ data: CostRow[] | null }>,
+ * );
+ * ```
+ */
+export async function fetchAllPages<T>(
+  buscarPagina: (de: number, ate: number) => PromiseLike<{ data: T[] | null }>,
+): Promise<T[]> {
+  const todas: T[] = [];
+  for (let pagina = 0; ; pagina++) {
+    const { data } = await buscarPagina(
+      pagina * POSTGREST_PAGE_SIZE,
+      (pagina + 1) * POSTGREST_PAGE_SIZE - 1,
+    );
+    const linhas = data ?? [];
+    todas.push(...linhas);
+    if (linhas.length < POSTGREST_PAGE_SIZE) return todas;
+  }
+}


### PR DESCRIPTION
## O bug

Os três engines carregam catálogos inteiros para montar `Map`s (custo, produto, perfil) com `.select()` sem `.range()`. O PostgREST corta a resposta em **1.000 linhas** — e o corte é **silencioso**: sem erro, sem aviso, sem sinal no cliente. O `Map` nasce parcial, e a cauda vira "não encontrado", que no money-path é lido como **"sem custo"** ou **"produto inexistente"**.

Não é novidade no repo: a regra está no CLAUDE.md, os edges `algorithm-a-audit` e `fin-valor-cockpit` já paginam `product_costs`, e um teste de `costCompute` documenta a mordida anterior **nesta mesma tabela** — *"um produto que ANTES sumia do costMap truncado (cauda > 1000 linhas de product_costs)"*, marcado como "O CORAÇÃO DO FIX". O padrão existia só nos edges; os hooks do frontend nunca receberam.

## O que estava truncado (medido, não estimado)

| tabela | linhas | onde | o engine via | efeito |
|---|---|---|---|---|
| `sales_orders` (3 status) | **19.978** | farmer | ~1.000 (**5%**) | recência, frequência, spend, margem e mix calculados sobre 5% do histórico |
| `profiles` | **5.668** | bundle | ~1.000 (18%) | sem perfil o cliente é pulado (`if (!profile) continue`) → 82% nunca recebia bundle |
| `product_costs` | **3.637** | cross-sell, bundle | ~1.000 (27%) | 72% dos SKUs lidos como "sem custo" |
| `omie_products` (ativos) | **3.108** | os 3 | ~1.000 (32%) | 2/3 do catálogo nunca era recomendado |

O `sales_orders` do farmer é o mais grave: o scoring inteiro operava sobre 5% dos pedidos. Cross-sell e bundle já paginavam essa tabela — o farmer era o único sem.

Isto também explica por que o #1466 parecia inofensivo quando medi a exposição direto no banco: eu perguntei *o que o banco tem* (53 SKUs sem custo, todos com preço 0 → guard já excluía), quando o que importa é *o que o engine carrega*. Com o `costMap` truncado, ~2.632 SKUs **que têm custo** eram lidos como sem custo — e, com o antigo `|| 0`, viravam margem 100% e subiam ao topo do ranking. A exposição não era zero; era a maior parte do catálogo. Corrijo aqui o registro daquele PR.

## O que NÃO foi paginado

Medi todas as candidatas e paginei só as que passam de 1.000. Ficam como estão: `farmer_association_rules` (22 linhas com os filtros aplicados), `cliente_classificacao` (669, e já paginava), `farmer_calls` (**0**), `farmer_category_conversion` (**0** — é por isso que todo `conversion_rate` cai no default de 15%/10%; fora de escopo, mas vale saber). `farmer_client_scores` (6.632) já tinha paginação própria nos dois engines.

## O helper

`fetchAllPages` em `src/lib/postgrest.ts` (módulo *plataforma*, isento da regra de fronteira — `fronteiras.ts:66`, "plataforma é base de todos"). Substitui a cópia local que entrou no #1468 e os loops inline duplicados. Exige `.order()` estável junto do `.range()`: sem ordenação definida o Postgres não garante a mesma sequência entre requests, e a paginação pode repetir ou pular linhas.

6 testes cobrindo o comportamento de fronteira, com um PostgREST falso que trunca do mesmo jeito: tabela maior que a capa (usa 3.637, o tamanho real de `product_costs`), janelas contíguas, múltiplo exato da capa (a página extra vazia que evita loop infinito), tabela menor, tabela vazia, e `data: null` (erro/RLS) encerrando em vez de repetir a página para sempre.

## Ressalva honesta

**Não confirmei a capa de 1.000 por execução.** Pelo PostgREST como `anon` bate na RLS (`permission denied for function has_role`); no banco, `pgrst.db_max_rows` está vazia e nenhuma role tem override — o limite vive na config do painel do Supabase, fora do meu alcance de leitura. O que sustenta a mudança é a regra do CLAUDE.md, os dois edges que já paginam, e o teste que documenta a mordida anterior nesta tabela.

Vale notar que **a correção é segura mesmo se a capa fosse outra**: paginar quando não é necessário custa uma requisição extra que volta vazia. O inverso — não paginar quando é necessário — é o truncamento silencioso. Se quiser fechar a dúvida, dá para conferir em Settings → API → Max rows no painel.

## Verificação

| gate | resultado |
|---|---|
| vitest (suíte completa) | `exit=0` — 5.503 testes, 609 arquivos |
| typecheck (strict) | `exit=0` |
| lint | `exit=0` |

## Série

Fecha a trinca aberta pela investigação do custo ausente: #1466 (consumo do costMap fabricava custo 0) · #1468 (farmer lia item em inglês num jsonb pt-BR) · este (os mapas chegavam truncados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
