### PR TITLE
feat(authz): FU4-G — fecha o bypass SECDEF da matriz de leitura de compras [money-path]

### DIFF
--- a/db/test-authz-cap-compras-ler-pos-candidatos.sh
+++ b/db/test-authz-cap-compras-ler-pos-candidatos.sh
@@ -1,0 +1,413 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — FU4-G: o bypass SECDEF da matriz de LEITURA de compras            ║
+# ║   bash db/test-authz-cap-compras-ler-pos-candidatos.sh > "$S/t.log" 2>&1; echo $? ║
+# ║                                                                                    ║
+# ║  Aplica a migration REAL 20260720120000 e prova que `reposicao_pos_candidatos`     ║
+# ║  passou do gate `pode_ver_carteira_completa` para `private.cap_compras_ler`        ║
+# ║  SEM matar o cron e SEM mudar o que a RPC devolve.                                ║
+# ║                                                                                    ║
+# ║  ⚠️ O ASSERT QUE MAIS IMPORTA é o do CRON (uid NULL): o gate é cron-or-staff       ║
+# ║  NULL-aware, e uma troca desatenta o mataria em SILÊNCIO — a fila de atenção       ║
+# ║  pararia de ser alimentada sem erro visível (reposicao.md: mordido 2×).            ║
+# ║                                                                                    ║
+# ║  Lei #1: plpgsql é late-bound — a RPC é CHAMADA e as LINHAS são conferidas.        ║
+# ║  Lei #2: negativo por SQLSTATE (42501) + re-raise, sem casar o texto.              ║
+# ║  Lei #3: ZONA 5 sabota e EXIGE vermelho.                                          ║
+# ╚══════════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5493}"
+SLUG="poscandidatos"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+MIG="$REPO_ROOT/supabase/migrations/20260720120000_authz_cap_compras_ler_pos_candidatos_fu4g.sql"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+[ -f "$MIG" ] || { echo "migration nao encontrada: $MIG"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+MASTER="10000000-0000-0000-0000-000000000001"
+GERENCIAL="20000000-0000-0000-0000-000000000002"
+FARMER="40000000-0000-0000-0000-000000000004"
+EMPL_SEM_CR="50000000-0000-0000-0000-000000000005"   # employee SEM linha em commercial_roles (o tri-state)
+RUN_ID="99999999-0000-0000-0000-00000000aaaa"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (stubs espelhando PROD, medido 2026-07-20)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 1: pré-requisitos ──"
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+GRANT USAGE ON SCHEMA private TO authenticated, anon, service_role;
+GRANT USAGE ON SCHEMA auth    TO authenticated, anon, service_role;
+
+CREATE TYPE public.app_role           AS ENUM ('customer','employee','master','admin');
+CREATE TYPE public.commercial_role    AS ENUM ('operacional','gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+CREATE TYPE public.empresa_reposicao  AS ENUM ('OBEN','COLACOR');
+
+CREATE TABLE public.user_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE public.commercial_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL UNIQUE,
+  commercial_role public.commercial_role NOT NULL);
+
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+-- ⚠️ TRI-STATE, verbatim de prod: para um `employee` SEM linha em commercial_roles o EXISTS dá
+-- false, mas `has_role(master)` dá false e o OR devolve false... já para quem NÃO é employee nem
+-- master o resultado é false. O NULL aparece quando has_role devolve NULL. Mantido como em prod:
+-- é justamente o tri-state que motivou o `IS NOT TRUE` no corpo da RPC.
+CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT public.has_role(_uid,'master'::public.app_role)
+      OR (public.has_role(_uid,'employee'::public.app_role)
+          AND EXISTS (SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
+                       AND cr.commercial_role IN ('gerencial','estrategico','super_admin')));
+$f$;
+GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated, service_role;
+
+-- a capability do #1434 (dependência REAL desta migration — a §0 aborta sem ela)
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false) $f$;
+REVOKE ALL ON FUNCTION private.cap_compras_ler(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION private.cap_compras_ler(uuid) TO authenticated, service_role;
+
+-- ── tabelas de compras (tipos ESPELHANDO prod) ──
+-- ⚠️ `pedido_compra_sugerido.empresa` é TEXT enquanto as outras usam o ENUM. A assimetria é REAL
+-- e é o que o corpo da RPC compara com `v_empresa::text`. Igualar no stub esconderia o bug de
+-- tipo que o comentário da própria função documenta (late-bound: quebra ao EXECUTAR).
+CREATE TABLE public.reposicao_pedidos_compra_run (
+  run_id uuid NOT NULL, seq bigint GENERATED ALWAYS AS IDENTITY,
+  empresa public.empresa_reposicao NOT NULL, status text NOT NULL, volume_ok boolean);
+CREATE TABLE public.pedido_compra_sugerido (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  empresa text NOT NULL, status text NOT NULL, omie_pedido_compra_id text,
+  data_ciclo date, fornecedor_nome text, canal_usado text, portal_protocolo text,
+  status_envio_portal text, resposta_canal jsonb);
+CREATE TABLE public.pedido_compra_item (pedido_id bigint NOT NULL, valor_linha numeric);
+CREATE TABLE public.purchase_orders_tracking (
+  empresa public.empresa_reposicao NOT NULL, omie_codigo_pedido bigint NOT NULL);
+CREATE TABLE public.reposicao_po_last_seen (
+  empresa public.empresa_reposicao NOT NULL, omie_codigo_pedido bigint NOT NULL, run_id uuid);
+
+-- funções auxiliares: corpo VERBATIM de prod
+CREATE OR REPLACE FUNCTION public.reposicao__po_id(p text)
+ RETURNS bigint LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE
+AS $function$
+DECLARE t text; b text := '[[:space:]   -​    　﻿]';
+BEGIN
+  IF p IS NULL THEN RETURN NULL; END IF;
+  t := regexp_replace(regexp_replace(p, '^' || b || '+', ''), b || '+$', '');
+  IF t !~ '^[0-9]+$' THEN RETURN NULL; END IF;
+  t := ltrim(t, '0');
+  IF t = '' THEN RETURN 0; END IF;
+  IF length(t) > 19 OR (length(t) = 19 AND t > '9223372036854775807') THEN RETURN NULL; END IF;
+  RETURN t::bigint;
+END $function$;
+
+CREATE OR REPLACE FUNCTION public.reposicao__trim(p text)
+ RETURNS text LANGUAGE sql IMMUTABLE PARALLEL SAFE
+AS $function$ SELECT COALESCE(regexp_replace(regexp_replace(p,
+       '^[[:space:]   -​    　﻿]+', ''),
+       '[[:space:]   -​    　﻿]+$', ''), '') $function$;
+SQL
+
+# ── a RPC alvo: corpo VERBATIM de prod (pg_get_functiondef, psql-ro 2026-07-20) ──
+# É o corpo real que a migration vai reescrever — inclusive o COMENTÁRIO que menciona o gate
+# antigo, que é o que distingue este caso do FU4-E.
+P -q -f /dev/stdin <<'SQL'
+CREATE OR REPLACE FUNCTION public.reposicao_pos_candidatos(p_empresa text)
+ RETURNS TABLE(pedido_id bigint, omie_codigo_pedido text, data_ciclo date, idade_dias integer, na_janela_7d boolean, valor_total numeric, itens_sem_valor integer, visto_status text, po_no_espelho boolean, fornecedor_nome text, canal_usado text, portal_protocolo text, status_envio_portal text, resposta_canal jsonb, tem_protocolo boolean, tem_status_portal boolean, tem_resposta_canal boolean, tem_canal boolean, algum_sinal_de_canal boolean, marcador_run_id uuid, marcador_seq bigint)
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_empresa public.empresa_reposicao := upper(btrim(p_empresa))::public.empresa_reposicao;
+BEGIN
+  -- Gate cron-or-staff NULL-aware: uid presente exige staff; uid NULL (service_role/cron SQL-local) passa.
+  -- ⚠️ NUNCA gatear por auth.role()='service_role' — o pg_cron roda como postgres SEM JWT (auth.role()=NULL)
+  -- e o gate mataria o cron em SILÊNCIO (reposicao.md: mordido 2x, migrations 20260627130000/20260627200000).
+  IF (SELECT auth.uid()) IS NOT NULL
+     -- ⚠️ IS NOT TRUE, não NOT(...): pode_ver_carteira_completa() é TRI-STATE. Para um `employee` SEM linha
+     -- em commercial_roles ela retorna NULL, e `NOT NULL` = NULL — o IF não entrava e a SECURITY DEFINER
+     -- ENTREGAVA TUDO (protocolo, fornecedor, JSON cru). Bypass real (Codex v11), e viola o fail-closed do
+     -- CLAUDE.md ("query de role falha → role null, approval false"). IS NOT TRUE trata NULL como negado e
+     -- preserva o uid NULL do cron, que é barrado antes pelo primeiro AND.
+     AND (SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))) IS NOT TRUE THEN
+    RAISE EXCEPTION 'reposicao_pos_candidatos: acesso negado' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH marcador AS (
+    SELECT r.run_id, r.seq
+    FROM public.reposicao_pedidos_compra_run r
+    WHERE r.empresa = v_empresa AND r.status = 'ok' AND r.volume_ok IS TRUE
+    ORDER BY r.seq DESC
+    LIMIT 1
+  ),
+  base AS (
+    SELECT
+      p.id AS pedido_id,
+      p.omie_pedido_compra_id AS omie_codigo_pedido,
+      p.data_ciclo::date AS data_ciclo,
+      (now()::date - p.data_ciclo::date)::integer AS idade_dias,
+      p.fornecedor_nome,
+      p.canal_usado,
+      p.portal_protocolo,
+      p.status_envio_portal,
+      p.resposta_canal,
+      m.run_id AS marcador_run_id,
+      m.seq AS marcador_seq,
+      ls.run_id AS visto_run_id,
+      (SELECT CASE WHEN count(*) FILTER (WHERE i.valor_linha IS NULL) = 0
+                   THEN sum(i.valor_linha) END
+         FROM public.pedido_compra_item i WHERE i.pedido_id = p.id) AS valor_total,
+      (SELECT count(*) FILTER (WHERE i.valor_linha IS NULL)
+         FROM public.pedido_compra_item i WHERE i.pedido_id = p.id)::integer AS itens_sem_valor,
+      CASE WHEN public.reposicao__po_id(p.omie_pedido_compra_id) IS NULL THEN NULL ELSE EXISTS (
+        SELECT 1 FROM public.purchase_orders_tracking t
+        WHERE t.empresa = v_empresa
+          AND t.omie_codigo_pedido = public.reposicao__po_id(p.omie_pedido_compra_id)
+      ) END AS po_no_espelho
+    FROM public.pedido_compra_sugerido p
+    CROSS JOIN marcador m
+    LEFT JOIN public.reposicao_po_last_seen ls
+           ON ls.empresa = v_empresa
+          AND ls.omie_codigo_pedido = public.reposicao__po_id(p.omie_pedido_compra_id)
+    WHERE upper(btrim(p.empresa)) = v_empresa::text
+      AND p.status IN ('disparado', 'aprovado_aguardando_disparo')
+      AND p.omie_pedido_compra_id IS NOT NULL
+      AND btrim(p.omie_pedido_compra_id) <> ''
+      AND (ls.run_id IS NULL OR ls.run_id <> m.run_id)
+  )
+  SELECT
+    b.pedido_id, b.omie_codigo_pedido, b.data_ciclo, b.idade_dias,
+    (b.idade_dias BETWEEN 0 AND 7) AS na_janela_7d,
+    b.valor_total, b.itens_sem_valor,
+    CASE
+      WHEN public.reposicao__po_id(b.omie_codigo_pedido) IS NULL THEN 'identidade_nao_interpretavel'
+      WHEN b.visto_run_id IS NULL                                THEN 'sem_registro_last_seen'
+      ELSE 'visto_em_outro_run'
+    END AS visto_status,
+    b.po_no_espelho, b.fornecedor_nome, b.canal_usado,
+    b.portal_protocolo, b.status_envio_portal, b.resposta_canal,
+    (public.reposicao__trim(b.portal_protocolo) <> '')    AS tem_protocolo,
+    (public.reposicao__trim(b.status_envio_portal) <> '') AS tem_status_portal,
+    (b.resposta_canal IS NOT NULL AND jsonb_typeof(b.resposta_canal) <> 'null') AS tem_resposta_canal,
+    (public.reposicao__trim(b.canal_usado) <> '')         AS tem_canal,
+    (public.reposicao__trim(b.portal_protocolo) <> ''
+      OR public.reposicao__trim(b.status_envio_portal) <> ''
+      OR (b.resposta_canal IS NOT NULL AND jsonb_typeof(b.resposta_canal) <> 'null')
+      OR public.reposicao__trim(b.canal_usado) <> '')     AS algum_sinal_de_canal,
+    b.marcador_run_id, b.marcador_seq
+  FROM base b
+  ORDER BY (b.idade_dias BETWEEN 0 AND 7) DESC, b.valor_total DESC NULLS LAST, b.pedido_id;
+END;
+$function$;
+GRANT EXECUTE ON FUNCTION public.reposicao_pos_candidatos(text) TO authenticated, service_role;
+SQL
+echo "  pré-requisitos criados"
+
+# guard do stub: sem o gate antigo NO CÓDIGO **e** no COMENTÁRIO, a prova seria vacuosa.
+eq "S1 stub nasce com a CHAMADA do gate antigo" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'public\.pode_ver_carteira_completa\s*\(\s*\(\s*SELECT';")" "t"
+eq "S2 stub nasce com a MENÇÃO no comentário (o caso que o FU4-E não tinha)" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'pode_ver_carteira_completa\(\) é TRI-STATE';")" "t"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 2: aplicar migration real ──"
+P -q -f "$MIG"
+echo "  migration aplicada: $(basename "$MIG")"
+
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  ok "P0a migration é IDEMPOTENTE (2ª aplicação passa)"
+else
+  bad "P0a re-aplicar a migration falhou — não é idempotente"
+fi
+eq "P0b segue com o gate novo após re-aplicar" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'private\.cap_compras_ler\s*\(\s*\(\s*SELECT';")" "t"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 3: seeds ──"
+P -q <<SQL
+INSERT INTO public.user_roles(user_id,role) VALUES
+  ('$MASTER','master'), ('$GERENCIAL','employee'), ('$FARMER','employee'), ('$EMPL_SEM_CR','employee');
+INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES
+  ('$GERENCIAL','gerencial'), ('$FARMER','farmer');
+-- EMPL_SEM_CR fica SEM linha: é o caso tri-state que motivou o IS NOT TRUE.
+
+INSERT INTO public.reposicao_pedidos_compra_run(run_id, empresa, status, volume_ok)
+  VALUES ('$RUN_ID','OBEN','ok', true);
+INSERT INTO public.pedido_compra_sugerido(empresa, status, omie_pedido_compra_id, data_ciclo,
+                                          fornecedor_nome, canal_usado, portal_protocolo,
+                                          status_envio_portal, resposta_canal)
+  VALUES ('OBEN','disparado','00101', now()::date - 2, 'Sayerlack', 'portal', 'PROTO-9', 'enviado', '{"ok":true}'::jsonb);
+INSERT INTO public.pedido_compra_item(pedido_id, valor_linha)
+  SELECT id, 1500.00 FROM public.pedido_compra_sugerido;
+SQL
+echo "  seeds inseridos"
+
+as_user() { P -tA -q <<SQL
+SET test.uid = '$1';
+SET ROLE authenticated;
+$2
+SQL
+}
+GUARD=$(as_user "$MASTER" "SELECT current_user;")
+[ "$GUARD" = "authenticated" ] || { echo "❌ HARNESS INVÁLIDO: SET ROLE não pegou (current_user=$GUARD)"; exit 1; }
+echo "  guard: asserts rodam como '$GUARD' (não superuser) ✅"
+
+# nega classificando pela SQLSTATE 42501 — nunca pelo texto da mensagem (anti-teatro de ILIKE).
+call_rpc() { # $1=uid ('' = cron/uid NULL)
+  local out setuid=""
+  [ -n "$1" ] && setuid="SET test.uid = '$1';"
+  if out=$(P -tA -q <<SQL 2>&1
+$setuid
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  PERFORM * FROM public.reposicao_pos_candidatos('OBEN');
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'SENTINELA_NEGOU_42501';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+  ); then
+    case "$out" in *SENTINELA_NEGOU_42501*) echo "DENIED" ;; *) echo "OK" ;; esac
+  else echo "ERRO_INESPERADO: $out"; fi
+}
+linhas() { as_user "$1" "SELECT count(*) FROM public.reposicao_pos_candidatos('OBEN');"; }
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── ZONA 4a: o CRON não pode morrer (o risco #1 desta troca) ──"
+# uid NULL = pg_cron/service_role SQL-local. O 1º AND do gate deixa passar ANTES de consultar a
+# capability. Se esta troca matasse o cron, a fila de atenção pararia em SILÊNCIO.
+eq "X1 cron (uid NULL) NÃO é negado" "$(call_rpc "")" "OK"
+eq "X2 cron (uid NULL) LÊ as linhas (não só 'não deu erro')" \
+   "$(P -tA -q -c "SET ROLE authenticated;" -c "SELECT count(*) FROM public.reposicao_pos_candidatos('OBEN');")" "1"
+
+echo "── ZONA 4b: o furo que o FU4-G fecha ──"
+eq "N1 gerencial é NEGADO (era o bypass da matriz)" "$(call_rpc "$GERENCIAL")" "DENIED"
+eq "N2 farmer é negado"                              "$(call_rpc "$FARMER")"    "DENIED"
+eq "N3 employee SEM commercial_role é negado (tri-state)" "$(call_rpc "$EMPL_SEM_CR")" "DENIED"
+
+echo "── ZONA 4c: master preserva TUDO (ninguém perdeu acesso) ──"
+eq "M1 master não é negado"        "$(call_rpc "$MASTER")" "OK"
+eq "M2 master LÊ a linha candidata" "$(linhas "$MASTER")"   "1"
+eq "M3 e o conteúdo sensível chega íntegro (valor+protocolo)" \
+   "$(as_user "$MASTER" "SELECT valor_total::int||'|'||portal_protocolo||'|'||visto_status FROM public.reposicao_pos_candidatos('OBEN');")" \
+   "1500|PROTO-9|sem_registro_last_seen"
+
+echo "── ZONA 4d: a troca não mexeu na semântica da RPC ──"
+eq "C1 empresa sem run marcador devolve VAZIO (fail-closed preservado)" \
+   "$(as_user "$MASTER" "SELECT count(*) FROM public.reposicao_pos_candidatos('COLACOR');")" "0"
+eq "C2 identidade ilegível segue classificada, não omitida" \
+   "$(P -tA -q -c "INSERT INTO public.pedido_compra_sugerido(empresa,status,omie_pedido_compra_id,data_ciclo) VALUES ('OBEN','disparado','1 0 1', now()::date);" \
+       -c "SET test.uid='$MASTER';" -c "SET ROLE authenticated;" \
+       -c "SELECT count(*) FROM public.reposicao_pos_candidatos('OBEN') WHERE visto_status='identidade_nao_interpretavel';")" "1"
+
+echo "── ZONA 4e: catálogo — a reescrita preservou atributos e corrigiu o comentário ──"
+eq "K1 segue SECURITY DEFINER e STABLE" \
+   "$(Pq -c "SELECT (prosecdef AND provolatile='s') FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='reposicao_pos_candidatos';")" "t"
+eq "K2 segue com search_path pinado" \
+   "$(Pq -c "SELECT array_to_string(proconfig,',') LIKE '%search_path%' FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='reposicao_pos_candidatos';")" "t"
+eq "K3 NÃO sobrou CHAMADA ao gate antigo" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ '(public\.|private\.)?pode_ver_carteira_completa\s*\(\s*\(\s*SELECT';")" "f"
+# ⚠️ ANCORADO NA CHAMADA, não em `cap_compras_ler.*IS NOT TRUE`. A 1ª versão usava esse regex
+# solto e era TEATRO: o comentário que a própria migration escreve contém
+# "private.cap_compras_ler faz COALESCE … IS NOT TRUE fica como defesa em profundidade", então o
+# `.*` casava DENTRO do comentário e o assert ficava verde mesmo com o `IS NOT TRUE` removido do
+# CÓDIGO. Apanhado pela falsificação C (sabotar → seguia verde). É a armadilha "a sentinela contém
+# o texto que o código emite", aqui na forma "a migration satisfaz o assert que a fiscaliza".
+eq "K4 o IS NOT TRUE foi PRESERVADO na CHAMADA (defesa em profundidade)" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'cap_compras_ler\(\(SELECT auth\.uid\(\)\)\)\)\s+IS NOT TRUE';")" "t"
+# o comentário tinha de mudar: afirmar 'é TRI-STATE' sobre cap_compras_ler seria FALSO.
+eq "K5 o comentário FALSO foi corrigido" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'era TRI-STATE';")" "t"
+eq "K6 ...e a história do porquê foi preservada (menção ao gate antigo continua)" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'pode_ver_carteira_completa';")" "t"
+eq "K7 authenticated mantém EXECUTE (ACL preservado)" \
+   "$(Pq -c "SELECT has_function_privilege('authenticated','public.reposicao_pos_candidatos(text)','EXECUTE');")" "t"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── ZONA 5: falsificação (sabotar → exigir vermelho) ──"
+
+# F1 — a capability passa a aceitar o gate antigo. N1 deve QUEBRAR.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid) RETURNS boolean
+ LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(public.pode_ver_carteira_completa(_uid), false) $f$;  -- SABOTADO
+SQL
+if [ "$(call_rpc "$GERENCIAL")" = "OK" ]; then
+  ok "F1 sabotagem REABRIU o bypass p/ gerencial → N1 tem dente"
+else
+  bad "F1 sabotei a capability e N1 seguiu negando — assert FRACO"
+fi
+eq "F1e sabotado, o gerencial LÊ o conteúdo sensível (efeito, não só ausência de erro)" \
+   "$(as_user "$GERENCIAL" "SELECT portal_protocolo FROM public.reposicao_pos_candidatos('OBEN') WHERE portal_protocolo IS NOT NULL;")" "PROTO-9"
+
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid) RETURNS boolean
+ LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false) $f$;
+SQL
+eq "F1r restaurado: gerencial volta a ser negado" "$(call_rpc "$GERENCIAL")" "DENIED"
+
+# F2 — a precondição de dependência tem dente? Sem cap_compras_ler, a migration DEVE abortar.
+# (é a diferença de desenho em relação ao FU4-E, que era autônomo de propósito)
+P -q -c "DROP FUNCTION private.cap_compras_ler(uuid);"
+P -q -c "CREATE OR REPLACE FUNCTION public.reposicao_pos_candidatos(p_empresa text) RETURNS boolean LANGUAGE sql AS \$f\$ SELECT true \$f\$;" >/dev/null 2>&1 || true
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F2 precondição: migration aplicou SEM private.cap_compras_ler (deveria abortar)"
+else
+  ok "F2 precondição aborta sem cap_compras_ler → sem caller órfão"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "  PASS=$PASS  FAIL=$FAIL"
+echo "═══════════════════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/db/valida-fu4g-pos-candidatos.sql
+++ b/db/valida-fu4g-pos-candidatos.sql
@@ -1,0 +1,41 @@
+-- Validação pós-apply do FU4-G (migration 20260720120000_authz_cap_compras_ler_pos_candidatos_fu4g.sql).
+--   ~/.config/afiacao/psql-ro -X -f db/valida-fu4g-pos-candidatos.sql
+-- 6 linhas, todas devem vir `t`.
+--
+-- ⚠️ SÓ CATÁLOGO — roda de QUALQUER role, inclusive read-only sem EXECUTE (lição do FU4-E:
+-- validação que INVOCA o objeto mente por resolução de tipo e por ACL, e o falso NEGATIVO
+-- empurra a re-aplicar algo que está são). Ver docs/agent/database.md.
+--
+-- ⚠️ Os regex de CHAMADA são ancorados em `((SELECT` de propósito: o corpo desta função MENCIONA
+-- os dois gates em COMENTÁRIO (a história do `IS NOT TRUE` é preservada). Um regex solto pelo
+-- NOME classificaria a menção como chamada e daria falso-positivo nos dois sentidos.
+
+SELECT 'gate NOVO presente como CHAMADA' AS check,
+       pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure)
+         ~ 'private\.cap_compras_ler\s*\(\s*\(\s*SELECT' AS ok
+UNION ALL
+SELECT 'gate ANTIGO ausente como CHAMADA (menção em comentário é OK)',
+       pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure)
+         !~ '(public\.|private\.)?pode_ver_carteira_completa\s*\(\s*\(\s*SELECT'
+UNION ALL
+-- ancorado na CHAMADA: o comentário escrito pela própria migration contém
+-- "cap_compras_ler … IS NOT TRUE", e um regex solto casaria ali (teatro apanhado na falsificação C).
+SELECT 'IS NOT TRUE preservado NA CHAMADA (defesa em profundidade)',
+       pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure)
+         ~ 'cap_compras_ler\(\(SELECT auth\.uid\(\)\)\)\)\s+IS NOT TRUE'
+UNION ALL
+-- o gate é cron-or-staff: o 1º AND deixa o uid NULL do pg_cron passar ANTES da capability.
+-- Se este sumir, o cron morre em silêncio e a fila de atenção para de ser alimentada.
+SELECT 'guarda do CRON preservada (uid NULL passa)',
+       pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure)
+         ~ 'IF \(SELECT auth\.uid\(\)\) IS NOT NULL'
+UNION ALL
+SELECT 'atributos preservados (SECDEF + STABLE + search_path)',
+       (SELECT p.prosecdef AND p.provolatile = 's'
+               AND array_to_string(p.proconfig, ',') LIKE '%search_path%'
+          FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public' AND p.proname = 'reposicao_pos_candidatos')
+UNION ALL
+SELECT 'ACL preservado: authenticated executa, anon não',
+       has_function_privilege('authenticated','public.reposicao_pos_candidatos(text)','EXECUTE')
+       AND NOT has_function_privilege('anon','public.reposicao_pos_candidatos(text)','EXECUTE');

--- a/supabase/migrations/20260720120000_authz_cap_compras_ler_pos_candidatos_fu4g.sql
+++ b/supabase/migrations/20260720120000_authz_cap_compras_ler_pos_candidatos_fu4g.sql
@@ -1,0 +1,185 @@
+-- ╔══════════════════════════════════════════════════════════════════════════════════════════╗
+-- ║  FU4-G — o bypass SECDEF da matriz de LEITURA de compras  [money-path / autorização]      ║
+-- ╚══════════════════════════════════════════════════════════════════════════════════════════╝
+-- Prova: db/test-authz-cap-compras-ler-pos-candidatos.sh (PG17, SET ROLE authenticated, com falsificação)
+-- Continuação do E2/FU4 (#1434, aplicado) e do FU4-E (#1462, aplicado).
+--
+-- ── O FURO (medido em prod via psql-ro, 2026-07-20) ────────────────────────────────────────
+-- O #1434 fechou as 9 tabelas `reposicao_*` em `private.cap_compras_ler` (master-only) via RLS.
+-- Mas `public.reposicao_pos_candidatos(text)` é **SECURITY DEFINER** — ela BYPASSA essa RLS e
+-- faz o próprio gate no corpo, que ficou no gate ANTIGO `pode_ver_carteira_completa`.
+-- Ela lê `reposicao_pedidos_compra_run` e `reposicao_po_last_seen` (2 das 9) e PROJETA
+-- `valor_total`, `fornecedor_nome`, `portal_protocolo`, `status_envio_portal` e `resposta_canal`
+-- (JSON cru do canal). Tem `EXECUTE` para `authenticated`.
+-- ⇒ um `gerencial` não lê as tabelas direto (RLS nega), mas lê o CONTEÚDO delas pela RPC.
+-- É o mesmo padrão que o #1434 tratou nas 4 RPCs SECDEF de CUSTO, e que o FU4-E tratou nas 3 de
+-- ESCRITA de compras — aqui na LEITURA de compras.
+--
+-- POR QUE ESCAPOU: a função nasceu no #1453 (migration 20260721190000), DEPOIS da matriz. O
+-- #1434 não tinha como tratá-la. Não é regressão de nenhum dos dois — é superfície nova que
+-- nasceu com o gate velho, e é assim que uma matriz de autorização se erode.
+--
+-- INERTE HOJE, LATENTE AMANHÃ: medido 2026-07-20 — 2 farmer + 1 master, ZERO gerencial. Como o
+-- gate antigo é `master OR gestor comercial` e não há gestor vivo, só o master passa hoje nos
+-- DOIS gates ⇒ a troca não retira acesso de ninguém. O furo abre no dia da primeira promoção.
+--
+-- ── VARREDURA DAS IRMÃS (o gate parcial é vazamento latente — database.md §66) ──────────────
+-- 6 funções SECDEF tocam as 9 tabelas fora da matriz. As outras 5
+-- (`aplicar_parametros_automatico_diario`, `reposicao_aplicar_depara_sayerlack_auto`,
+-- `reposicao_cold_start_parametros`, `reposicao_param_auto_resumo_tick`,
+-- `reposicao_publicar_run_completo`) NÃO são furo: não têm gate JWT, mas medi
+-- `has_function_privilege(authenticated|anon, …)` = FALSE nas cinco — são service-role-only pela
+-- fronteira de GRANT, o padrão correto para engine de cron (database.md §61). `pos_candidatos` é
+-- a ÚNICA com EXECUTE para `authenticated`.
+--
+-- ── POR QUE `cap_compras_ler` E NÃO `cap_compras_escrever` ─────────────────────────────────
+-- A função é `STABLE` e `RETURNS TABLE` — leitura pura, não muta nada. Ler telemetria de compras
+-- é exatamente o que `cap_compras_ler` governa nas 9 tabelas; usar a de escrita seria mais
+-- restritivo que a policy equivalente e incoerente com a matriz.
+--
+-- ── O `IS NOT TRUE` FICA (e o comentário dele precisa mudar) ────────────────────────────────
+-- O corpo usa `IS NOT TRUE` porque `pode_ver_carteira_completa` é TRI-STATE: para um `employee`
+-- sem linha em `commercial_roles` ela devolve NULL, e `NOT NULL` = NULL ⇒ o IF não entrava e a
+-- SECDEF entregava tudo (bypass real, Codex v11). `private.cap_compras_ler` faz
+-- `COALESCE(…,false)` e NUNCA devolve NULL, então hoje `IS NOT TRUE` ≡ `NOT (…)`. Mantemos por
+-- defesa em profundidade — mas o COMENTÁRIO que afirma "é TRI-STATE" passaria a ser FALSO sobre
+-- a função nova, então ele é corrigido junto (§1, replace 2). Comentário errado num gate de
+-- autorização é dívida que o próximo leitor paga.
+--
+-- ⚠️ Migration MANUAL (Lovable não aplica nome custom) — colar no SQL Editor.
+
+BEGIN;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 0) PRECONDIÇÕES — aborta se o banco vivo divergir do medido
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+DO $$
+DECLARE v_gerenciais int;
+BEGIN
+  IF to_regprocedure('public.reposicao_pos_candidatos(text)') IS NULL THEN
+    RAISE EXCEPTION 'FU4-G: reposicao_pos_candidatos(text) ausente — banco divergente, abortando'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- DEPENDÊNCIA REAL (≠ FU4-E, que era autônoma de propósito): aqui o gate de destino é a
+  -- capability criada pelo #1434. Sem ela, o CREATE OR REPLACE passaria (plpgsql é late-bound) e
+  -- a função só quebraria ao ser CHAMADA — deixando a fila de atenção morta em runtime, para o
+  -- master inclusive. Precondição explícita em vez de caller órfão (a falha do #1423).
+  IF to_regprocedure('private.cap_compras_ler(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'FU4-G: private.cap_compras_ler(uuid) ausente — aplique o #1434 (20260718190000) antes'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  IF to_regclass('public.commercial_roles') IS NULL THEN
+    RAISE EXCEPTION 'FU4-G: tabela commercial_roles ausente — banco divergente, abortando'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  SELECT count(*) INTO v_gerenciais FROM public.commercial_roles
+   WHERE commercial_role IN ('gerencial','estrategico','super_admin');
+  IF v_gerenciais > 0 THEN
+    RAISE EXCEPTION 'FU4-G: % papel(is) gerencial(is) vivo(s) — a troca muda o acesso deles. Revise antes de aplicar.', v_gerenciais
+      USING ERRCODE = 'raise_exception';
+  END IF;
+END $$;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 1) A TROCA — substituição programática guardada, a partir do corpo VIVO
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- ⚠️ DIFERENÇA CRÍTICA em relação ao FU4-E: aqui o corpo MENCIONA `pode_ver_carteira_completa`
+-- DUAS vezes — uma na chamada (código) e outra num COMENTÁRIO que explica o `IS NOT TRUE`.
+-- O padrão do FU4-E (contar ocorrências do nome e exigir exatamente 1) ABORTARIA aqui, e um
+-- `regexp_replace` global reescreveria o comentário para uma afirmação FALSA
+-- ("private.cap_compras_ler() é TRI-STATE" — ela não é, faz COALESCE).
+-- Solução: os dois casos são textualmente DISTINGUÍVEIS e tratados por regex separados —
+--   · chamada:    `pode_ver_carteira_completa((SELECT …`  → parênteses COM argumento
+--   · comentário: `pode_ver_carteira_completa()`          → parênteses VAZIOS
+-- Cada um com contagem própria; qualquer divergência aborta.
+DO $$
+DECLARE
+  v_alvo  constant text := 'public.reposicao_pos_candidatos(text)';
+  v_oid   regprocedure;
+  v_def   text;
+  v_novo  text;
+  v_ocorr int;
+  -- a CHAMADA: nome qualificado + `(` + `(SELECT`. Tolerante a espaçamento; o alternador aceita
+  -- `private.` porque a prod tem as duas formas do gate antigo (impl private + wrapper public).
+  c_re_chamada  constant text := '(public\.|private\.)?pode_ver_carteira_completa\s*\(\s*\(\s*SELECT';
+  -- o COMENTÁRIO: a afirmação que fica falsa depois da troca.
+  c_re_coment   constant text := 'pode_ver_carteira_completa\(\) é TRI-STATE';
+  -- o gate NOVO, na forma de chamada (não de menção textual).
+  c_re_novo     constant text := 'private\.cap_compras_ler\s*\(\s*\(\s*SELECT';
+BEGIN
+  v_oid := to_regprocedure(v_alvo);   -- existência já garantida na §0
+  v_def := pg_get_functiondef(v_oid);
+
+  -- IDEMPOTENTE: já migrada ⇒ segue. O dono cola à mão; uma queda de rede no meio não pode
+  -- travar a 2ª tentativa.
+  IF v_def ~ c_re_novo AND v_def !~ c_re_chamada THEN
+    RAISE NOTICE 'FU4-G: % já está no gate novo — nada a fazer', v_alvo;
+    RETURN;
+  END IF;
+
+  -- exatamente 1 CHAMADA do gate antigo — medido em prod 2026-07-20.
+  SELECT count(*) INTO v_ocorr FROM regexp_matches(v_def, c_re_chamada, 'g');
+  IF v_ocorr <> 1 THEN
+    RAISE EXCEPTION 'FU4-G: esperava 1 CHAMADA do gate antigo em %, encontrei % — inspecione pg_get_functiondef antes de prosseguir', v_alvo, v_ocorr
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- exatamente 1 menção no COMENTÁRIO. Zero significaria corpo diferente do medido (o comentário
+  -- foi reescrito por outra migration) — abortar é melhor que deixar comentário incoerente.
+  SELECT count(*) INTO v_ocorr FROM regexp_matches(v_def, c_re_coment, 'g');
+  IF v_ocorr <> 1 THEN
+    RAISE EXCEPTION 'FU4-G: esperava 1 mencao do gate antigo no comentario de %, encontrei % — corpo divergente do medido', v_alvo, v_ocorr
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- replace 1 — a CHAMADA. Troca nome + abre-parêntese; o argumento `((SELECT auth.uid()))` e o
+  -- `IS NOT TRUE` ficam intactos.
+  v_novo := regexp_replace(v_def, c_re_chamada, 'private.cap_compras_ler((SELECT', 'g');
+
+  -- replace 2 — o COMENTÁRIO que ficaria falso. Preserva a história (por que o IS NOT TRUE
+  -- existe) e diz a verdade sobre a função nova.
+  v_novo := regexp_replace(
+    v_novo, c_re_coment,
+    'pode_ver_carteira_completa() era TRI-STATE (o gate ANTERIOR; private.cap_compras_ler faz COALESCE e nunca devolve NULL, entao IS NOT TRUE fica como defesa em profundidade)',
+    'g');
+
+  IF v_novo = v_def THEN
+    RAISE EXCEPTION 'FU4-G: nenhum padrao casou em % — nao aplicar no-op silencioso', v_alvo
+      USING ERRCODE = 'raise_exception';
+  END IF;
+  IF v_novo ~ c_re_chamada THEN
+    RAISE EXCEPTION 'FU4-G: sobrou CHAMADA ao gate antigo em % apos a troca', v_alvo
+      USING ERRCODE = 'raise_exception';
+  END IF;
+  IF v_novo !~ c_re_novo THEN
+    RAISE EXCEPTION 'FU4-G: o gate NOVO nao aparece como chamada em % apos a troca', v_alvo
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  EXECUTE v_novo;
+
+  -- pós-check POSITIVO no catálogo. ⚠️ Checa a CHAMADA, não a MENÇÃO: exigir ausência total da
+  -- string `pode_ver_carteira_completa` falharia de propósito — o comentário histórico a mantém,
+  -- e é assim que tem de ser.
+  v_def := pg_get_functiondef(to_regprocedure(v_alvo));
+  IF v_def !~ c_re_novo THEN
+    RAISE EXCEPTION 'FU4-G: pos-check falhou — % nao ficou com o gate novo', v_alvo
+      USING ERRCODE = 'raise_exception';
+  END IF;
+  IF v_def ~ c_re_chamada THEN
+    RAISE EXCEPTION 'FU4-G: pos-check falhou — % ainda CHAMA o gate antigo', v_alvo
+      USING ERRCODE = 'raise_exception';
+  END IF;
+END $$;
+
+COMMIT;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY → db/valida-fu4g-pos-candidatos.sql (só catálogo; roda de qualquer role).
+-- Não repetida aqui de propósito: o rodapé da 20260719120000 trazia uma query que INVOCAVA a
+-- função e mentia de duas formas (NULL sem cast ⇒ "does not exist"; falta de EXECUTE ⇒
+-- "permission denied" — que era o REVOKE funcionando). database.md, §validação pós-apply.
+-- ════════════════════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Terceiro e último furo da mesma família. O #1434 fechou as 9 tabelas `reposicao_*` em `private.cap_compras_ler` (master-only) **via RLS** — mas `public.reposicao_pos_candidatos(text)` é `SECURITY DEFINER`: ela **bypassa essa RLS** e faz o próprio gate no corpo, que ficou no gate antigo.

| | Superfície | Fechado por |
|---|---|---|
| Custo | 4 RPCs SECDEF | #1434 |
| Compras — escrita | 3 RPCs SECDEF | #1462 (FU4-E) |
| **Compras — leitura** | **1 RPC SECDEF** | **este PR** |

Ela lê `reposicao_pedidos_compra_run` e `reposicao_po_last_seen` (2 das 9) e projeta `valor_total`, `fornecedor_nome`, `portal_protocolo`, `status_envio_portal` e `resposta_canal` (JSON cru), com `EXECUTE` para `authenticated`. Um `gerencial` não lê as tabelas direto, mas lê o **conteúdo** delas pela RPC.

**Por que escapou:** a função nasceu no #1453, *depois* da matriz. Não é regressão de ninguém — é superfície nova nascida com o gate velho. É assim que uma matriz de autorização se erode.

**Varredura das irmãs:** 6 funções SECDEF tocam as 9 tabelas fora da matriz. As outras 5 **não são furo** — medi `has_function_privilege(authenticated|anon)` = FALSE nas cinco: são service-role-only pela fronteira de GRANT, o padrão correto de engine de cron. `pos_candidatos` é a única alcançável por `authenticated`.

**Inerte hoje, latente amanhã:** 2 farmer + 1 master, zero gerencial. Como o gate antigo é `master OR gestor` e não há gestor vivo, só o master passa nos dois gates — ninguém perde acesso. O furo abriria na primeira promoção.

## Duas diferenças de desenho

**1. Dependência real** (≠ FU4-E, que era autônomo de propósito): o gate de destino é a capability do #1434. Precondição explícita que **aborta** — sem ela o `CREATE OR REPLACE` passaria (plpgsql é late-bound) e a função só quebraria ao ser **chamada**, deixando a fila de atenção morta em runtime, para o master inclusive.

**2. O corpo menciona o gate antigo duas vezes** — na chamada e num **comentário**. O padrão do FU4-E (contar o nome, exigir 1) abortaria aqui, e um replace global reescreveria o comentário para uma afirmação **falsa** (`cap_compras_ler` não é tri-state, faz `COALESCE`). Os dois casos são textualmente distinguíveis — `((SELECT` vs `()` — e tratados por regex separados, com contagem própria. O comentário é corrigido junto, preservando a história do *porquê* do `IS NOT TRUE`.

## Prova

25 asserts em PG17, `SET ROLE authenticated` + GUC, negativo por SQLSTATE `42501`. **O assert que mais importa é o do CRON** (`uid` NULL): o gate é cron-or-staff NULL-aware, e uma troca desatenta o mataria em silêncio — a fila de atenção pararia de ser alimentada sem erro visível (`reposicao.md`: mordido 2×).

Falsificação em 3 eixos:

| Sabotagem | Efeito |
|---|---|
| A — replace vira no-op | a **migration aborta** (o guard tem dente) |
| B — sem o replace do comentário | 1 vermelho (K5) |
| C — descarta o `IS NOT TRUE` | 1 vermelho (K4) |

**A (C) revelou um assert sem dente.** O K4 original usava `cap_compras_ler.*IS NOT TRUE` e casava dentro do comentário que a **própria migration escreve** — a migration satisfazia o assert que deveria fiscalizá-la, e a sabotagem passava verde. É a armadilha "a sentinela contém o texto que o código emite", numa variante nova. Corrigido para ancorar na chamada; só então (C) ficou vermelha. O comentário do harness registra o caso.

## ⚠️ Deploy

**Migration MANUAL** — colar no SQL Editor. Validação: `db/valida-fu4g-pos-candidatos.sql`, só catálogo (lição do #1467), e **provado que discrimina**: rodado contra prod antes do apply, 3 checks vêm `f` e 3 vêm `t`.

Sem mudança de frontend: assinatura, retorno e semântica idênticos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)