### PR TITLE
feat(tint): restaura rótulo condicional "Tabela (versão anterior)" no balcão [money-path]

### DIFF
--- a/src/components/tintColorSelect/AltPriceSourcePicker.tsx
+++ b/src/components/tintColorSelect/AltPriceSourcePicker.tsx
@@ -12,15 +12,18 @@ const fmt = (v: number) => v.toLocaleString('pt-BR', { style: 'currency', curren
 interface AltPriceSourcePickerProps {
   formulaId: string;
   altSel: AltPriceDisplay;
+  /** Canônica da alternativa é SL → rótulo "Tabela (versão anterior)" (a view
+   *  garante a proveniência desde a 20260722100002); ausente/false → "Tabela". */
+  isSl?: boolean | null;
   setOverride: (formulaId: string, source: AltPriceSource) => void;
   className?: string;
 }
 
-export function AltPriceSourcePicker({ formulaId, altSel, setOverride, className }: AltPriceSourcePickerProps) {
+export function AltPriceSourcePicker({ formulaId, altSel, isSl, setOverride, className }: AltPriceSourcePickerProps) {
   if (altSel.precoCalc == null || altSel.precoTabela == null) return null;
   const fontes: { key: AltPriceSource; label: string; preco: number }[] = [
     { key: 'calculado', label: 'Calculado', preco: altSel.precoCalc },
-    { key: 'tabela', label: 'Tabela importada', preco: altSel.precoTabela },
+    { key: 'tabela', label: isSl ? 'Tabela (versão anterior)' : 'Tabela', preco: altSel.precoTabela },
   ];
   return (
     <div className={`flex flex-wrap items-center gap-1.5 ${className ?? ''}`}>

--- a/src/components/tintColorSelect/GlobalColorMatches.tsx
+++ b/src/components/tintColorSelect/GlobalColorMatches.tsx
@@ -122,6 +122,7 @@ export function GlobalColorMatches({ product, matches, colorExists, precoMap, pr
                 <AltPriceSourcePicker
                   formulaId={alt.formulaId}
                   altSel={altSel}
+                  isSl={alt.isSl}
                   setOverride={setAltPriceSourceOverride}
                   className="px-2.5 pb-2"
                 />

--- a/src/components/tintColorSelect/SelectedFormulaCard.tsx
+++ b/src/components/tintColorSelect/SelectedFormulaCard.tsx
@@ -94,13 +94,14 @@ export function SelectedFormulaCard({
   onConfirm,
 }: SelectedFormulaCardProps) {
   // Fontes de preço disponíveis (com valor), para a vendedora escolher manualmente.
-  // Rótulo NEUTRO de propósito (Fase 2b-fix): o CSV da chave é o max das linhas
-  // ativas — na prática hoje, a versão anterior da tinta quando a canônica é SL —
-  // mas a view não prova a proveniência por-linha, então o rótulo não a afirma.
+  // Rótulo CONDICIONAL restaurado (decisão do founder 2026-07-20): a migration
+  // 20260722100002 garante na VIEW que, quando a canônica é SL, o CSV vem só de
+  // linhas não-SL — "versão anterior" voltou a ser proveniência provada. is_sl
+  // ausente/false → rótulo genérico "Tabela" (nunca afirma sem prova).
   const fontes: { key: TintPriceSource; label: string; preco: number }[] = [];
   if (precoCliente != null) fontes.push({ key: 'cliente', label: 'Cliente', preco: precoCliente });
   if (precoCalc != null) fontes.push({ key: 'calculado', label: 'Calculado', preco: precoCalc });
-  if (precoCsv > 0) fontes.push({ key: 'tabela', label: 'Tabela importada', preco: precoCsv });
+  if (precoCsv > 0) fontes.push({ key: 'tabela', label: selectedFormula.is_sl ? 'Tabela (versão anterior)' : 'Tabela', preco: precoCsv });
 
   return (
     <Card className="border-primary/30">
@@ -321,6 +322,7 @@ export function SelectedFormulaCard({
                         <AltPriceSourcePicker
                           formulaId={alt.formulaId}
                           altSel={altSel}
+                          isSl={alt.isSl}
                           setOverride={setAltPriceSourceOverride}
                         />
                         <div className="flex items-center gap-2">

--- a/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
+++ b/src/components/tintColorSelect/__tests__/GlobalColorMatches.test.tsx
@@ -95,8 +95,13 @@ describe('GlobalColorMatches', () => {
   it('calc e CSV presentes → oferece o seletor de fonte; clique registra o override da fórmula', () => {
     const setOverride = vi.fn();
     render(<GlobalColorMatches product={product} altPriceSourceOverrides={{}} setAltPriceSourceOverride={setOverride} matches={[alt({ precoFinalCsv: 13.7 })]} precoMap={precoMapAmbos} onConfirm={() => {}} />);
-    fireEvent.click(screen.getByRole('button', { name: /Tabela importada/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Tabela/ }));
     expect(setOverride).toHaveBeenCalledWith('f1', 'tabela');
+  });
+
+  it('match SL → o picker rotula a fonte CSV como "Tabela (versão anterior)" (repasse do isSl)', () => {
+    render(<GlobalColorMatches product={product} altPriceSourceOverrides={{}} setAltPriceSourceOverride={() => {}} matches={[alt({ precoFinalCsv: 13.7, isSl: true })]} precoMap={precoMapAmbos} onConfirm={() => {}} />);
+    expect(screen.getByRole('button', { name: /Tabela \(versão anterior\)/ })).toBeTruthy();
   });
 
   it('override "tabela" aplicado → confirma com o preço do CSV, não o calculado', () => {
@@ -113,6 +118,6 @@ describe('GlobalColorMatches', () => {
 
   it('só uma fonte com valor (sem CSV) → não oferece seletor', () => {
     render(<GlobalColorMatches product={product} altPriceSourceOverrides={{}} setAltPriceSourceOverride={() => {}} matches={[alt({ precoFinalCsv: null })]} precoMap={precoMapAmbos} onConfirm={() => {}} />);
-    expect(screen.queryByRole('button', { name: /Tabela importada/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Tabela/ })).toBeNull();
   });
 });

--- a/src/components/tintColorSelect/__tests__/SelectedFormulaCard.test.tsx
+++ b/src/components/tintColorSelect/__tests__/SelectedFormulaCard.test.tsx
@@ -174,9 +174,17 @@ describe('SelectedFormulaCard', () => {
     expect(props.setPriceSourceOverride).toHaveBeenCalledWith('calculado');
   });
 
-  it('rótulo da fonte CSV é neutro: "Tabela importada", nunca "versão anterior" (Fase 2b-fix)', () => {
+  it('rótulo condicional da fonte CSV: canônica SL → "Tabela (versão anterior)" (proveniência garantida pela view desde a 20260722100002)', () => {
+    setup({
+      selectedFormula: { ...selectedFormula, is_sl: true },
+      lastPracticedPrice: { price: 40, date: '2026-05-01T00:00:00Z' }, precoCliente: 40, precoCsv: 50, priceSource: 'cliente',
+    });
+    expect(screen.getByRole('button', { name: /Tabela \(versão anterior\)/ })).toBeTruthy();
+  });
+
+  it('rótulo da fonte CSV sem is_sl (ausente/false) → "Tabela" genérico, nunca afirma "versão anterior" sem prova', () => {
     setup({ lastPracticedPrice: { price: 40, date: '2026-05-01T00:00:00Z' }, precoCliente: 40, precoCsv: 50, priceSource: 'cliente' });
-    expect(screen.getByRole('button', { name: /Tabela importada/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Tabela/ })).toBeTruthy();
     expect(screen.queryByText(/versão anterior/i)).toBeNull();
   });
 
@@ -196,8 +204,14 @@ describe('SelectedFormulaCard', () => {
   it('alternativa com calc e CSV → oferece o seletor de fonte; clique registra o override da fórmula', () => {
     const { alternatives, altPriceMap } = altComAmbasFontes();
     const props = setup({ alternatives, altPriceMap });
-    fireEvent.click(screen.getByRole('button', { name: /Tabela importada/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Tabela/ }));
     expect(props.setAltPriceSourceOverride).toHaveBeenCalledWith('fa', 'tabela');
+  });
+
+  it('alternativa SL → o picker rotula a fonte CSV como "Tabela (versão anterior)"', () => {
+    const { alternatives, altPriceMap } = altComAmbasFontes();
+    setup({ alternatives: [{ ...alternatives[0], isSl: true }], altPriceMap });
+    expect(screen.getByRole('button', { name: /Tabela \(versão anterior\)/ })).toBeTruthy();
   });
 
   it('alternativa com override "tabela" → confirma com o preço do CSV, não o calculado', () => {
@@ -214,6 +228,6 @@ describe('SelectedFormulaCard', () => {
   it('alternativa com só uma fonte (sem breakdown) → não oferece seletor', () => {
     const { alternatives } = altComAmbasFontes();
     setup({ alternatives }); // altPriceMap {} → fail-closed, nenhuma fonte
-    expect(screen.queryByRole('button', { name: /Tabela importada/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Tabela/ })).toBeNull();
   });
 });

--- a/src/components/tintColorSelect/types.ts
+++ b/src/components/tintColorSelect/types.ts
@@ -30,10 +30,13 @@ export interface FormulaResult {
   cor_id: string;
   nome_cor: string;
   preco_final_sayersystem: number | null;
-  /** Fase 2b: CSV da chave (max das linhas ativas — na prática hoje, o preço da
-   *  versão anterior da tinta quando a canônica é a geração SL viva) — alimenta
-   *  a fonte "Tabela importada" do seletor. */
+  /** Fase 2b: CSV da chave — desde a migration 20260722100002 a view GARANTE
+   *  que, quando a canônica é SL, o max lê só linhas não-SL (a versão anterior
+   *  da tinta). Alimenta a fonte "Tabela" do seletor. */
   preco_csv_legado?: number | null;
+  /** Canônica é a geração SL viva — decide o rótulo condicional da fonte CSV
+   *  ("Tabela (versão anterior)"). Ausente/false → rótulo genérico "Tabela". */
+  is_sl?: boolean | null;
 }
 
 export interface AlternativePackaging {
@@ -47,4 +50,6 @@ export interface AlternativePackaging {
   sameAcabamento: boolean;
   corId?: string;
   nomeCor?: string;
+  /** Canônica da alternativa é SL — rótulo condicional do picker de fonte. */
+  isSl?: boolean | null;
 }

--- a/src/components/tintColorSelect/useTintColorSelect.ts
+++ b/src/components/tintColorSelect/useTintColorSelect.ts
@@ -109,7 +109,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
       // lista vazia e a UI mente "cor não encontrada" (achado Codex no diff).
       const { data, error } = await supabase
         .from('v_tint_formula_canonica')
-        .select('id, cor_id, nome_cor, preco_final_sayersystem, preco_csv_legado')
+        .select('id, cor_id, nome_cor, preco_final_sayersystem, preco_csv_legado, is_sl')
         .eq('account', 'oben')
         .eq('sku_id', skuId!)
         .or(ilikeOr(['cor_id', 'nome_cor'], debouncedSearch))
@@ -137,7 +137,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
       // com sku e resolve a gêmea SL×SAYERLACK por chave)
       const { data: globalRaw, error: globalErr } = await supabase
         .from('v_tint_formula_canonica')
-        .select('id, cor_id, nome_cor, sku_id, preco_final_sayersystem, preco_csv_legado')
+        .select('id, cor_id, nome_cor, sku_id, preco_final_sayersystem, preco_csv_legado, is_sl')
         .eq('account', 'oben')
         .or(ilikeOr(['cor_id', 'nome_cor'], debouncedSearch))
         .order('cor_id', { ascending: true })
@@ -219,6 +219,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
           sameAcabamento: false,
           corId: gf.cor_id,
           nomeCor: gf.nome_cor,
+          isSl: gf.is_sl,
         });
       }
 
@@ -275,7 +276,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
       // (1 por SKU; sem a gêmea SAYERLACK duplicando cada embalagem)
       const { data: altFormulas, error: altErr } = await supabase
         .from('v_tint_formula_canonica')
-        .select('id, sku_id, preco_csv_legado')
+        .select('id, sku_id, preco_csv_legado, is_sl')
         .eq('account', 'oben')
         .eq('cor_id', selectedFormula.cor_id)
         .neq('sku_id', skuId)
@@ -326,6 +327,7 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
           precoFinalCsv: af.preco_csv_legado ? Math.ceil(af.preco_csv_legado * 10) / 10 : af.preco_csv_legado,
           product: prod as Product,
           sameAcabamento: sku.produto_id === currentProdutoId && sku.base_id === currentBaseId,
+          isSl: af.is_sl,
         });
       }
 
@@ -352,9 +354,9 @@ export function useTintColorSelect({ product, open, customerUserId, initialSearc
   // Preço honesto da cor selecionada: motor get_tint_price (base + corantes, NULL quando
   // a base/corante falta) + CSV legado + último preço do cliente. Quando o motor não tem
   // preço, vira "sem preço" — nunca um número fabricado. Regras em src/lib/tint/select-price.ts.
-  // Fase 2b: o CSV considerado é o da CHAVE (preco_csv_legado) — quando a canônica
-  // é a SL viva (CSV próprio NULL), vem o preço da VERSÃO ANTERIOR da tinta; a
-  // fonte "Tabela" volta ao seletor e a vendedora escolhe entre novo × anterior.
+  // Fase 2b: o CSV considerado é o da CHAVE (preco_csv_legado) — desde a migration
+  // 20260722100002 a view GARANTE que, na canônica SL, ele vem só de linhas não-SL
+  // (a VERSÃO ANTERIOR da tinta); a vendedora escolhe entre novo × anterior.
   const rawCsv = selectedFormula?.preco_csv_legado ?? null;
   const custoCorantes = pricing?.custoCorantes || 0;
 


### PR DESCRIPTION
## O quê

Restaura o rótulo **condicional** da fonte CSV no balcão tintométrico — decisão do founder (2026-07-20) após o fix semântico da view no #1469:

- canônica **SL** → **"Tabela (versão anterior)"** (o par exato do #1439)
- `is_sl` ausente/false → **"Tabela"** genérico (nunca afirma proveniência sem prova)

Vale no card principal (`SelectedFormulaCard`) **e** no mini-seletor das alternativas/busca global (`AltPriceSourcePicker`, que no 2b-fix nasceu com o neutro).

## Por quê agora é honesto

O #1458 neutralizou o rótulo porque o max de `preco_csv_legado` incluía a própria linha — "versão anterior" seria proveniência não provada (P1 B do parecer Codex xhigh). A migration `20260722100002` (#1469, **aplicada e validada em prod**) garante na VIEW que, com canônica SL, o max lê só linhas não-SL. A objeção morreu na origem; o rótulo informativo volta.

## Como

- `useTintColorSelect`: `is_sl` nos 3 selects da canônica (por-SKU, global, alternativas) + mapeado para `AlternativePackaging.isSl`
- `FormulaResult.is_sl` / `AlternativePackaging.isSl` (tipos)
- `AltPriceSourcePicker`: prop `isSl` + rótulo condicional; callers repassam
- Motor `select-price` **intocado** — mudança é só rótulo de UI

## Prova

- Typecheck strict: exit=0 · Vitest: **5.506/5.506** (609 arquivos) · ESLint: **0 errors**
- Testes novos/ajustados: rótulo nos dois ramos do card; repasse do `isSl` no picker das "outras embalagens" e da busca global; fail-closed do seletor intacto

Sem migration neste PR (a de banco foi o #1469). **Após o merge: precisa de Publish do frontend no Lovable** (merge ≠ produção).

🤖 Generated with [Claude Code](https://claude.com/claude-code)