### PR TITLE
fix(authz): o stub do gate antigo era bi-state — a prova do tri-state nunca existiu [money-path]

### DIFF
--- a/db/test-authz-cap-compras-escrever.sh
+++ b/db/test-authz-cap-compras-escrever.sh
@@ -60,6 +60,7 @@ eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], 
 MASTER="10000000-0000-0000-0000-000000000001"
 GERENCIAL="20000000-0000-0000-0000-000000000002"
 FARMER="40000000-0000-0000-0000-000000000004"
+EMPL_SEM_CR="50000000-0000-0000-0000-000000000005"   # employee SEM linha em commercial_roles (o TRI-STATE)
 
 # ═══════════════════════════════════════════════════════════════════════════════════
 # ZONA 1 — PRÉ-REQUISITOS (stubs espelhando PROD, medido 2026-07-19)
@@ -88,16 +89,39 @@ CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
 
+-- get_commercial_role: cópia verbatim de prod (pg_get_functiondef). É a fonte do TRI-STATE —
+-- sem linha em commercial_roles, a subquery escalar devolve NULL (não false).
+CREATE OR REPLACE FUNCTION public.get_commercial_role(_user_id uuid)
+ RETURNS public.commercial_role LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT commercial_role
+  FROM public.commercial_roles
+  WHERE user_id = _user_id
+  LIMIT 1
+$f$;
+
 -- O gate ANTIGO precisa existir: é o que a migration procura e troca.
 -- Em PROD ele vive nas DUAS formas (impl em private pelo #1427 + wrapper em public); as 3 RPCs
 -- alvo chamam a de `public`, então é essa que o stub precisa ter para o regex casar.
+--
+-- ⚠️ TRI-STATE — `get_commercial_role(...) IN (...)`, VERBATIM de prod, e NÃO um `EXISTS(...)`.
+-- A distinção é a razão de ser deste harness. Para um `employee` SEM linha em commercial_roles:
+--   ·  com get_commercial_role:  false OR (true AND (NULL IN (...)))  =  false OR NULL  =  NULL
+--   ·  com EXISTS (o que estava aqui): false OR (true AND false)      =  false
+-- As 3 RPCs alvo gateiam com `IF NOT gate(...)`, e `NOT NULL` = NULL ⇒ o IF NÃO ENTRA e a
+-- SECURITY DEFINER ESCREVE. Esse era o bypass real que o FU4-E fechou. Com o EXISTS o stub
+-- devolvia `false`, o `NOT false` negava, e o harness ficava CEGO para o bypass que existe
+-- justamente para provar. Trocar de volta reabre o ponto cego (a falsificação F5 exige vermelho).
 CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$
   SELECT public.has_role(_uid,'master'::public.app_role)
       OR (public.has_role(_uid,'employee'::public.app_role)
-          AND EXISTS (SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
-                       AND cr.commercial_role IN ('gerencial','estrategico','super_admin')));
+          AND public.get_commercial_role(_uid) IN (
+            'gerencial'::public.commercial_role,
+            'estrategico'::public.commercial_role,
+            'super_admin'::public.commercial_role
+          ));
 $f$;
 GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated, service_role;
 
@@ -264,11 +288,25 @@ eq "P0b as 3 RPCs seguem com o gate novo após re-aplicar" \
 echo "── ZONA 3: seeds ──"
 P -q <<SQL
 INSERT INTO public.user_roles(user_id,role) VALUES
-  ('$MASTER','master'), ('$GERENCIAL','employee'), ('$FARMER','employee');
+  ('$MASTER','master'), ('$GERENCIAL','employee'), ('$FARMER','employee'), ('$EMPL_SEM_CR','employee');
 INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES
   ('$GERENCIAL','gerencial'), ('$FARMER','farmer');
+-- EMPL_SEM_CR fica SEM linha de propósito: é o que faz o gate ANTIGO devolver NULL.
 SQL
 echo "  seeds inseridos"
+
+# ── sanidade do STUB: ele reproduz mesmo o tri-state de prod? ──
+# Sem isto, uma regressão silenciosa do stub para `EXISTS(...)` (bi-state) deixaria o harness
+# verde e CEGO — foi exatamente o defeito que este arquivo teve até 2026-07-20.
+eq "T1 gate ANTIGO é TRI-STATE: employee sem commercial_role ⇒ NULL (não false)" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$EMPL_SEM_CR') IS NULL;")" "t"
+eq "T1b ...e o mesmo gate devolve false (não NULL) p/ quem tem papel comercial comum" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$FARMER') IS FALSE;")" "t"
+eq "T1c ...e true para gerencial (o tri-state não quebrou o caminho positivo)" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$GERENCIAL') IS TRUE;")" "t"
+# a capability NOVA nunca devolve NULL — é o que torna `IF NOT cap(...)` seguro nas 3 RPCs.
+eq "T2 capability NOVA é BI-STATE p/ o mesmo uid (COALESCE ⇒ false, nunca NULL)" \
+   "$(Pq -c "SELECT private.cap_compras_escrever('$EMPL_SEM_CR') IS FALSE;")" "t"
 
 # helper: roda SQL como `authenticated` com um uid.
 # ⚠️ `SET` e NÃO `SET LOCAL`: cada invocação do psql é sessão nova em autocommit, onde SET LOCAL
@@ -364,6 +402,20 @@ eq "N3 gerencial NÃO reverte run inteiro" \
 echo "── ZONA 4b: farmer (papel comercial comum) também negado ──"
 eq "N4 farmer NÃO despina"        "$(call_rpc "$FARMER" "public.despinar_parametro('oben','9002')")" "DENIED"
 eq "N5 farmer NÃO reverte run"    "$(call_rpc "$FARMER" "public.reverter_run_auto('$RUN_ID')")"      "DENIED"
+
+echo "── ZONA 4b2: o BYPASS TRI-STATE que o FU4-E fechou (employee sem commercial_role) ──"
+# No gate ANTIGO este uid produzia NULL, `NOT NULL` = NULL, o IF não entrava e a escrita PASSAVA.
+# Sob o gate NOVO (COALESCE ⇒ false) ele é negado. A falsificação F5 prova que este par de asserts
+# tem dente: com o corpo antigo restaurado, o mesmo uid volta a ESCREVER.
+seed_cenario
+eq "N7 employee sem commercial_role NÃO despina (tri-state fechado)" \
+   "$(call_rpc "$EMPL_SEM_CR" "public.despinar_parametro('oben','9002')")" "DENIED"
+eq "N7e ...e o pin CONTINUA lá (efeito no dado)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_pin WHERE empresa='oben' AND sku_codigo_omie='9002';")" "1"
+eq "N8 employee sem commercial_role NÃO reverte run" \
+   "$(call_rpc "$EMPL_SEM_CR" "public.reverter_run_auto('$RUN_ID')")" "DENIED"
+eq "N8e ...e o log segue NÃO revertido" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_auto_log WHERE id='$LOG_ID' AND revertido_em IS NULL;")" "1"
 
 echo "── ZONA 4c: anônimo (uid NULO) negado — fail-closed ──"
 eq "N6 uid NULO não despina" \
@@ -495,6 +547,53 @@ if P -q -f "$MIG" >/dev/null 2>&1; then
 else
   ok "F4 guard aborta com 2 ocorrências do gate antigo → não reescreve corpo divergente"
 fi
+
+# ── F5 — O BYPASS TRI-STATE, DEMONSTRADO (a falsificação que dá dente ao N7) ──────────────────
+# Restaura o corpo PRÉ-#1462 (gate ANTIGO + `IF NOT`, verbatim) e exige que o employee sem
+# commercial_role VOLTE A ESCREVER. Se este bloco não conseguir reabrir o bypass, então o stub
+# do gate antigo não é tri-state e o N7 estava passando por acidente — que foi exatamente o
+# defeito deste harness até 2026-07-20 (stub com `EXISTS(...)`, bi-state).
+# ⚠️ Esta é a única falsificação do arquivo que testa o STUB, não a migration: ela prova que o
+# mundo que o harness simula é o mundo que existe em produção.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.despinar_parametro(p_empresa text, p_sku text)
+ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT public.pode_ver_carteira_completa(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  DELETE FROM public.reposicao_param_pin WHERE empresa=p_empresa AND sku_codigo_omie=p_sku;
+  RETURN FOUND;
+END;
+$function$;
+SQL
+seed_cenario
+if [ "$(call_rpc "$EMPL_SEM_CR" "public.despinar_parametro('oben','9002')")" = "OK" ]; then
+  ok "F5 gate ANTIGO reabre o bypass p/ employee sem commercial_role → N7 tem dente"
+else
+  bad "F5 restaurei o gate ANTIGO e o employee sem commercial_role seguiu NEGADO — o stub NÃO é tri-state (regressão para EXISTS?), N7 é cego"
+fi
+eq "F5e ...e o bypass ESCREVEU de fato: o pin sumiu (efeito, não só ausência de exceção)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_pin WHERE empresa='oben' AND sku_codigo_omie='9002';")" "0"
+# contraste: no MESMO corpo antigo, o farmer (papel comercial comum ⇒ false, não NULL) segue negado.
+# Prova que o vazamento vem do NULL e não de o gate antigo liberar geral.
+eq "F5c ...mas o farmer segue negado no gate antigo (o furo é o NULL, não o gate inteiro)" \
+   "$(call_rpc "$FARMER" "public.despinar_parametro('oben','9002')")" "DENIED"
+
+# restaura o gate NOVO e exige que o bypass feche de novo
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.despinar_parametro(p_empresa text, p_sku text)
+ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT private.cap_compras_escrever(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  DELETE FROM public.reposicao_param_pin WHERE empresa=p_empresa AND sku_codigo_omie=p_sku;
+  RETURN FOUND;
+END;
+$function$;
+SQL
+seed_cenario
+eq "F5r restaurado: employee sem commercial_role volta a ser negado" \
+   "$(call_rpc "$EMPL_SEM_CR" "public.despinar_parametro('oben','9002')")" "DENIED"
 
 echo ""
 echo "═══════════════════════════════════════════════════════"

--- a/db/test-authz-cap-compras-ler-pos-candidatos.sh
+++ b/db/test-authz-cap-compras-ler-pos-candidatos.sh
@@ -84,17 +84,36 @@ CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
 
--- ⚠️ TRI-STATE, verbatim de prod: para um `employee` SEM linha em commercial_roles o EXISTS dá
--- false, mas `has_role(master)` dá false e o OR devolve false... já para quem NÃO é employee nem
--- master o resultado é false. O NULL aparece quando has_role devolve NULL. Mantido como em prod:
--- é justamente o tri-state que motivou o `IS NOT TRUE` no corpo da RPC.
+-- get_commercial_role: cópia verbatim de prod (pg_get_functiondef). É a FONTE do tri-state —
+-- sem linha em commercial_roles a subquery escalar devolve NULL, não false.
+CREATE OR REPLACE FUNCTION public.get_commercial_role(_user_id uuid)
+ RETURNS public.commercial_role LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT commercial_role
+  FROM public.commercial_roles
+  WHERE user_id = _user_id
+  LIMIT 1
+$f$;
+
+-- ⚠️ TRI-STATE — `get_commercial_role(...) IN (...)`, VERBATIM de prod, e NÃO um `EXISTS(...)`.
+-- Para um `employee` SEM linha em commercial_roles:
+--   ·  com get_commercial_role:  false OR (true AND (NULL IN (...)))  =  false OR NULL  =  NULL
+--   ·  com EXISTS (o que estava aqui): false OR (true AND false)      =  false
+-- Aqui o veredito FINAL não muda — o `IS NOT TRUE` do corpo trata NULL e false igualmente, e é
+-- por isso que esta RPC de LEITURA nunca teve o bypass que as 3 de ESCRITA tinham. O que o EXISTS
+-- escondia era outra coisa: a NECESSIDADE do `IS NOT TRUE`. Com stub bi-state, trocá-lo por
+-- `NOT(...)` seguia verde; com o tri-state real, a falsificação F3 fica VERMELHA. O assert que não
+-- distingue os dois mundos não estava provando a defesa, só acompanhando-a.
 CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$
   SELECT public.has_role(_uid,'master'::public.app_role)
       OR (public.has_role(_uid,'employee'::public.app_role)
-          AND EXISTS (SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
-                       AND cr.commercial_role IN ('gerencial','estrategico','super_admin')));
+          AND public.get_commercial_role(_uid) IN (
+            'gerencial'::public.commercial_role,
+            'estrategico'::public.commercial_role,
+            'super_admin'::public.commercial_role
+          ));
 $f$;
 GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated, service_role;
 
@@ -295,6 +314,16 @@ GUARD=$(as_user "$MASTER" "SELECT current_user;")
 [ "$GUARD" = "authenticated" ] || { echo "❌ HARNESS INVÁLIDO: SET ROLE não pegou (current_user=$GUARD)"; exit 1; }
 echo "  guard: asserts rodam como '$GUARD' (não superuser) ✅"
 
+# ── sanidade do STUB: ele reproduz mesmo o tri-state de prod? ──
+# Uma regressão do stub para `EXISTS(...)` (bi-state) deixaria a falsificação F3 impossível de
+# ficar vermelha — foi o defeito deste arquivo até 2026-07-20.
+eq "T1 gate ANTIGO é TRI-STATE: employee sem commercial_role ⇒ NULL (não false)" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$EMPL_SEM_CR') IS NULL;")" "t"
+eq "T1b ...e devolve false (não NULL) p/ papel comercial comum" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$FARMER') IS FALSE;")" "t"
+eq "T2 capability NOVA é BI-STATE p/ o mesmo uid (COALESCE ⇒ false, nunca NULL)" \
+   "$(Pq -c "SELECT private.cap_compras_ler('$EMPL_SEM_CR') IS FALSE;")" "t"
+
 # nega classificando pela SQLSTATE 42501 — nunca pelo texto da mensagem (anti-teatro de ILIKE).
 call_rpc() { # $1=uid ('' = cron/uid NULL)
   local out setuid=""
@@ -395,6 +424,57 @@ CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid) RETURNS boolean
 AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false) $f$;
 SQL
 eq "F1r restaurado: gerencial volta a ser negado" "$(call_rpc "$GERENCIAL")" "DENIED"
+
+# ── F3 — O `IS NOT TRUE` É NECESSÁRIO? (a falsificação que o stub bi-state tornava impossível) ──
+# Volta o corpo ao gate ANTIGO **e** troca `IS NOT TRUE` por `NOT (...)`. Com o gate antigo sendo
+# TRI-STATE, o employee sem commercial_role produz `NOT NULL` = NULL ⇒ o IF não entra ⇒ a SECDEF
+# ENTREGA TUDO. É o bypass que o `IS NOT TRUE` existe para fechar.
+# Enquanto o stub era `EXISTS(...)` (bi-state) esta sabotagem NÃO conseguia vazar — o assert que
+# fiscaliza o `IS NOT TRUE` acompanhava a defesa sem nunca prová-la.
+# ⚠️ A sabotagem tem GUARD próprio: se o regex não casar, `EXECUTE` recriaria a função IDÊNTICA e
+# o "não vazou" seria falso verde — exatamente o teatro que esta zona existe para matar.
+P -q <<'SQL'
+DO $$
+DECLARE v_def text; v_sab text;
+BEGIN
+  v_def := pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure);
+  v_sab := regexp_replace(v_def,
+    'AND \(SELECT private\.cap_compras_ler\(\(SELECT auth\.uid\(\)\)\)\)\s+IS NOT TRUE THEN',
+    'AND NOT (SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))) THEN');
+  IF v_sab = v_def THEN
+    RAISE EXCEPTION 'F3 INVÁLIDA: a sabotagem não casou — o teste seria vacuoso';
+  END IF;
+  EXECUTE v_sab;
+END $$;
+SQL
+if [ "$(call_rpc "$EMPL_SEM_CR")" = "OK" ]; then
+  ok "F3 gate antigo + NOT(...) VAZA p/ employee sem commercial_role → o IS NOT TRUE tem função"
+else
+  bad "F3 sabotei o IS NOT TRUE e nada vazou — o stub NÃO é tri-state (regressão para EXISTS?), o K4 é cego"
+fi
+eq "F3e ...e o vazamento entrega o conteúdo sensível (efeito, não só ausência de erro)" \
+   "$(as_user "$EMPL_SEM_CR" "SELECT portal_protocolo FROM public.reposicao_pos_candidatos('OBEN') WHERE portal_protocolo IS NOT NULL;")" "PROTO-9"
+# contraste: o farmer (papel comercial comum ⇒ false, não NULL) segue negado no MESMO corpo
+# sabotado. Prova que o vazamento vem do NULL, e não de o gate antigo liberar geral.
+eq "F3c ...mas o farmer segue negado no mesmo corpo (o furo é o NULL, não o gate inteiro)" \
+   "$(call_rpc "$FARMER")" "DENIED"
+
+# restaura o corpo verdadeiro (gate novo + IS NOT TRUE) e exige que o furo feche
+P -q -f "$MIG" >/dev/null 2>&1 || true
+P -q <<'SQL'
+DO $$
+DECLARE v_def text; v_ok text;
+BEGIN
+  v_def := pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure);
+  v_ok := regexp_replace(v_def,
+    'AND NOT \(SELECT public\.pode_ver_carteira_completa\(\(SELECT auth\.uid\(\)\)\)\) THEN',
+    'AND (SELECT private.cap_compras_ler((SELECT auth.uid()))) IS NOT TRUE THEN');
+  IF v_ok <> v_def THEN EXECUTE v_ok; END IF;
+END $$;
+SQL
+eq "F3r restaurado: employee sem commercial_role volta a ser negado" "$(call_rpc "$EMPL_SEM_CR")" "DENIED"
+eq "F3rk ...e o IS NOT TRUE está de volta na CHAMADA" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'cap_compras_ler\(\(SELECT auth\.uid\(\)\)\)\)\s+IS NOT TRUE';")" "t"
 
 # F2 — a precondição de dependência tem dente? Sem cap_compras_ler, a migration DEVE abortar.
 # (é a diferença de desenho em relação ao FU4-E, que era autônomo de propósito)


### PR DESCRIPTION
Primeiro achado acionado da **revisão adversária retroativa via Codex** (`gpt-5.6-sol`, xhigh) dos PRs #1462 / #1467 / #1472 — os três já mergeados e aplicados em produção, provados na época só pelo Caminho B (auto-prova), sem segundo olho.

## O defeito

Os dois harnesses declaravam, em comentário, reproduzir "verbatim de prod" o gate antigo `pode_ver_carteira_completa`. Não reproduziam:

```
PROD (get_commercial_role(_uid) IN (...)):  false OR (true AND NULL)  => NULL    (tri-state)
STUB (EXISTS (SELECT 1 FROM ...)):          false OR (true AND false) => false   (bi-state)
```

`EXISTS` nunca devolve NULL. E o comentário que justificava o stub — *"o NULL aparece quando has_role devolve NULL"* — era factualmente falso: `has_role` também usa `EXISTS`.

## Por que isso importa

Os harnesses não conseguiam provar a defesa que existem para fiscalizar.

**FU4-E:** as 3 RPCs de escrita gateiam com `IF NOT gate(...)`. Com o tri-state real, `NOT NULL` = NULL, o `IF` não entra e a `SECURITY DEFINER` **escreve**. Um `employee` sem linha em `commercial_roles` mutava o motor de compras. O #1462 fechou isso ao trocar para uma capability com `COALESCE` — mas o harness era cego para o bypass que existia para provar, e o cabeçalho daquele PR descrevia a mudança como "coerência interna", subestimando o que ela fez.

**FU4-G:** a RPC usa `IS NOT TRUE`, que trata NULL e `false` igualmente, então o veredito final nunca mudou. O que o stub escondia era a **necessidade** dessa defesa: trocar `IS NOT TRUE` por `NOT(...)` passava verde.

Nenhum dos dois é furo em produção — o gate lá está correto desde o #1462/#1472. O que estava quebrado era a capacidade de detectar uma regressão futura.

## O que muda

- stub passa a `get_commercial_role(...) IN (...)` verbatim de prod, nos dois arquivos;
- `public.get_commercial_role` (a fonte do NULL) passa a existir no harness;
- FU4-E ganha o uid `EMPL_SEM_CR`, que não existia no arquivo;
- **T1/T1b/T1c/T2** — sanidade do próprio stub: o gate antigo devolve NULL, a capability nova devolve `false`. Pegam a regressão do stub direto, sem depender de nenhuma RPC;
- **FU4-E N7/N7e/N8/N8e** — o bypass de escrita está fechado, verificado no dado;
- **FU4-E F5** — restaura o corpo pré-#1462 e **exige** que o bypass reabra (o pin some de verdade);
- **FU4-G F3** — gate antigo + `NOT(...)` e **exige** o vazamento do `portal_protocolo`;
- **F5c/F3c** — no mesmo corpo sabotado o `farmer` segue negado, provando que o furo é o NULL e não o gate antigo sendo permissivo em geral;
- **F3 tem guard próprio**: se o regex da sabotagem não casar, levanta exceção em vez de recriar a função idêntica e reportar "não vazou". Uma sabotagem que silenciosamente não aplica é o mesmo teatro que este PR conserta.

## Evidência

PG17 local, asserts sob `SET ROLE authenticated`, com **meta-falsificação** (rodei os harnesses com o stub antigo restaurado e exigi vermelho):

| | stub corrigido | stub antigo (`EXISTS`) |
|---|---|---|
| FU4-E | 47 asserts, FAIL=0, **exit 0** | **FAIL=3, exit 1** — T1, F5, F5e |
| FU4-G | 33 asserts, FAIL=0, **exit 0** | **FAIL=3, exit 1** — T1, F3, F3e |

Falham exatamente os asserts que dependem do tri-state, e a mensagem diagnostica sozinha quem reintroduzir o defeito: *"o stub NÃO é tri-state (regressão para EXISTS?)"*.

O `F5e` transformou em evidência executada o que era dedução: com o corpo pré-#1462, o `employee` sem `commercial_role` **apagou o pin**.

## Escopo

Zero mudança de banco, zero migration, zero código de `src/`. Só `db/*.sh`.

| gate | resultado |
|---|---|
| `shellcheck` (os 2 arquivos) | `exit 0` |
| `bun run authz:check` | `exit 0` (1 aviso pré-existente, sobre outra migration) |

Nenhum step do `ci.yml` executa `db/*.sh` (exigem `postgresql@17` local) — a prova acima é a evidência.

## Achados restantes do mesmo parecer

Não entram aqui. Em ordem de prioridade, para PR próprio:

1. **[P1]** `reposicao_alerta_pedido_minimo` (24 linhas vivas) e `reposicao_auto_aprovacao_log` expõem `valor_*` + `fornecedor_nome` a qualquer `employee` — e os 2 farmers são employees que a matriz barra nas 9 tabelas. Tem decisão de produto embutida: os farmers **devem** ver valor de compra?
2. **[P2]** `IS NOT TRUE` nas 3 RPCs de escrita (defesa em profundidade, sem mudança de comportamento hoje).
3. **[P2]** `supabase/migrations/20260721190000_reposicao_pos_candidatos.sql:112` ainda chama o gate antigo — colá-la reverte o #1472 em silêncio.
4. **[P2]** o validador do #1467 casa `has_role(...)` e `_uid IS NOT NULL` como regex independentes: uma capability com `OR` no lugar do `AND` passaria, autorizando qualquer uid não-nulo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
