### PR TITLE
feat(ux): 'última execução' PR2 — varredura (tintométrico, gestor, reposição) + primeiro nome + refresh instantâneo

### DIFF
--- a/src/components/analyticsSync/useAnalyticsSync.ts
+++ b/src/components/analyticsSync/useAnalyticsSync.ts
@@ -6,6 +6,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/AuthContext";
 import { toast } from "sonner";
 import { useMutationComRegistro } from "@/components/execucoes/useMutationComRegistro";
+import { ULTIMA_EXECUCAO_QUERY_KEY } from "@/components/execucoes/tipos";
 import { OmieAccount, SyncState } from "./types";
 import { ACOES_ANALYTICS_SYNC } from "./acoes";
 
@@ -76,6 +77,8 @@ export function useAnalyticsSync() {
     onError: (error) => {
       toast.error("Erro no sync", { description: String(error) });
     },
+    // Quem grava é a EDGE (sync_completo + motores por dentro do sync_all) — aqui só re-lê a caption.
+    onSettled: () => queryClient.invalidateQueries({ queryKey: [ULTIMA_EXECUCAO_QUERY_KEY] }),
   });
 
   const computeCostsMutation = useMutation({
@@ -94,6 +97,8 @@ export function useAnalyticsSync() {
     onError: (error) => {
       toast.error("Erro ao calcular custos", { description: String(error) });
     },
+    // Quem grava é a EDGE (analytics_sync.recalcular_custos) — aqui só re-lê a caption na hora.
+    onSettled: () => queryClient.invalidateQueries({ queryKey: [ULTIMA_EXECUCAO_QUERY_KEY] }),
   });
 
   const assocRulesMutation = useMutation({
@@ -112,6 +117,8 @@ export function useAnalyticsSync() {
     onError: (error) => {
       toast.error("Erro ao gerar regras", { description: String(error) });
     },
+    // Quem grava é a EDGE (analytics_sync.recalcular_regras) — aqui só re-lê a caption na hora.
+    onSettled: () => queryClient.invalidateQueries({ queryKey: [ULTIMA_EXECUCAO_QUERY_KEY] }),
   });
 
   const updateConfigMutation = useMutation({

--- a/src/components/dashboard/GestorExcecoes.tsx
+++ b/src/components/dashboard/GestorExcecoes.tsx
@@ -10,7 +10,12 @@ import { useExcecoesGestor } from '@/hooks/useExcecoesGestor';
 import { useTarefaMutations } from '@/hooks/useTarefas';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { useMutationComRegistro } from '@/components/execucoes/useMutationComRegistro';
+import { UltimaExecucao } from '@/components/execucoes/UltimaExecucao';
 import type { LinhaExcecao, Severidade } from '@/lib/gestor/excecoes/types';
+
+// Escritor: frontend (ação global; a edge ai-ops-agent não tem cron — sem sobreposição).
+const ACAO_ATUALIZAR_ANALISE = 'dashboard.atualizar_analise_carteira';
 
 const SEV_CLS: Record<Severidade, string> = {
   critico: 'text-status-error', aviso: 'text-status-warning', info: 'text-status-info',
@@ -69,13 +74,20 @@ export function GestorExcecoes() {
     });
   }, [data]);
 
-  const onRodarAgente = async () => {
-    track('gestor.excecoes_run_agent', {});
-    const { error } = await supabase.functions.invoke('ai-ops-agent');
-    if (error) { toast.error('Erro ao atualizar análise'); return; }
-    toast.success('Análise atualizada');
-    refetchAll();
-  };
+  const rodarAgente = useMutationComRegistro({
+    acao: ACAO_ATUALIZAR_ANALISE,
+    mutationFn: async () => {
+      const { error } = await supabase.functions.invoke('ai-ops-agent');
+      if (error) throw new Error((error as { message?: string }).message ?? 'Falha na edge ai-ops-agent');
+    },
+    onMutate: () => track('gestor.excecoes_run_agent', {}),
+    onSuccess: () => {
+      toast.success('Análise atualizada');
+      refetchAll();
+    },
+    onError: () => toast.error('Erro ao atualizar análise'),
+  });
+  const onRodarAgente = () => rodarAgente.mutate();
 
   if (isLoading) {
     return <Card className="p-3 space-y-2"><Skeleton className="h-4 w-40" />{[0, 1].map(i => <Skeleton key={i} className="h-10 w-full" />)}</Card>;
@@ -86,6 +98,7 @@ export function GestorExcecoes() {
       <CardHeader className="pb-2">
         <h2 className="text-base font-medium">Exceções — o que está fora do lugar</h2>
         <p className="text-2xs text-muted-foreground">Só o que precisa de atenção hoje. Cada linha mostra a fonte e o frescor.</p>
+        <UltimaExecucao acao={ACAO_ATUALIZAR_ANALISE} />
       </CardHeader>
       {!data || data.vazio ? (
         <div className="p-6 text-2xs text-muted-foreground">Tudo no lugar hoje 🎯</div>

--- a/src/components/execucoes/__tests__/rotulo.test.ts
+++ b/src/components/execucoes/__tests__/rotulo.test.ts
@@ -67,6 +67,11 @@ describe("rotuloUltimaExecucao", () => {
     expect(r.texto).toBe("Última execução: há cerca de 2 horas · ✓");
   });
 
+  it("nome composto → só o primeiro nome (caption compacta)", () => {
+    const r = rotuloUltimaExecucao(execucao({ executado_por_nome: "Lucas Sardenberg" }), AGORA);
+    expect(r.texto).toBe("Última execução: há cerca de 2 horas · Lucas · ✓");
+  });
+
   it("sucesso sem finalizado_em (legado) → cai no iniciado_em", () => {
     const r = rotuloUltimaExecucao(
       execucao({ finalizado_em: null, iniciado_em: "2026-07-18T13:05:00-03:00" }),

--- a/src/components/execucoes/rotulo.ts
+++ b/src/components/execucoes/rotulo.ts
@@ -25,7 +25,9 @@ export function rotuloUltimaExecucao(execucao: AcaoExecucao | null, agora: Date)
   }
 
   const quando = relativo(execucao.finalizado_em ?? execucao.iniciado_em);
-  const quem = execucao.origem === "automatica" ? "automática" : execucao.executado_por_nome;
+  // Só o primeiro nome — caption compacta (nome completo continua no banco).
+  const primeiroNome = execucao.executado_por_nome?.trim().split(/\s+/)[0] ?? null;
+  const quem = execucao.origem === "automatica" ? "automática" : primeiroNome;
   const marca = execucao.status === "sucesso" ? "✓" : "falhou";
   const partes = [quando, ...(quem ? [quem] : []), marca];
   return {

--- a/src/components/tintImport/SyncCard.tsx
+++ b/src/components/tintImport/SyncCard.tsx
@@ -3,6 +3,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { RefreshCw, Loader2 } from 'lucide-react';
+import { UltimaExecucao } from '@/components/execucoes/UltimaExecucao';
+import { ACOES_TINT_IMPORT } from './acoes';
 
 export function SyncCard({
   syncing, onSync, tintCounts,
@@ -15,6 +17,7 @@ export function SyncCard({
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Sincronizar Produtos Omie</CardTitle>
+        <UltimaExecucao acao={ACOES_TINT_IMPORT.sincronizarProdutos} />
       </CardHeader>
       <CardContent>
         <p className="text-sm text-muted-foreground mb-3">

--- a/src/components/tintImport/__tests__/SyncCard.test.tsx
+++ b/src/components/tintImport/__tests__/SyncCard.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+
+// Caption isolada: o card é componente burro; a UltimaExecucao (query real) tem teste próprio.
+vi.mock('@/components/execucoes/UltimaExecucao', () => ({
+  UltimaExecucao: () => null,
+}));
+
 import { SyncCard } from '../SyncCard';
 
 describe('SyncCard', () => {

--- a/src/components/tintImport/acoes.ts
+++ b/src/components/tintImport/acoes.ts
@@ -1,0 +1,6 @@
+// Slug de acoes_execucoes desta tela. Escritor: frontend (useMutationComRegistro) —
+// o cron tint-marcar-bases-diario roda OUTRA ação (tint_marcar_bases_mixmachine), sem
+// sobreposição com o sync de produtos. Um escritor por slug (CLAUDE.md §Design System).
+export const ACOES_TINT_IMPORT = {
+  sincronizarProdutos: "tint_import.sincronizar_produtos",
+} as const;

--- a/src/pages/AdminReposicaoPedidos.tsx
+++ b/src/pages/AdminReposicaoPedidos.tsx
@@ -22,6 +22,8 @@ import {
 import { AlertTriangle, CheckCircle2, ChevronDown, ChevronRight, Clock, CloudDownload, Eye, Loader2, Zap } from 'lucide-react';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { toast } from 'sonner';
+import { useMutationComRegistro } from '@/components/execucoes/useMutationComRegistro';
+import { UltimaExecucao } from '@/components/execucoes/UltimaExecucao';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { PedidoSugerido } from '@/components/reposicao/pedidos/types';
@@ -357,7 +359,18 @@ export default function AdminReposicaoPedidos() {
   // lista / recalcular) num só, a pedido do founder — a lista tem refetchInterval 30s (atualiza
   // sozinha). Se uma sync falhar, NÃO recalcula (regenerar com saldo/status velho = pedido errado,
   // money-path); o resumoSyncRecalc reporta e o usuário reexecuta. Idempotente. ~1–2 min.
-  const syncRecalcMutation = useMutation({
+  // Escritor do slug: frontend (orquestração client-side de 2 edges + RPC). Os crons diários
+  // rodam as EDGES isoladas (outra ação); o composto "sincronizar E recalcular" só existe aqui.
+  // status='sucesso' registra que a EXECUÇÃO completou; o resultado real (sync parcial/recalc)
+  // vai em detalhes — o tom pro usuário continua no toast (resumoSyncRecalc), sem mudança.
+  const syncRecalcMutation = useMutationComRegistro({
+    acao: 'reposicao.sincronizar_recalcular',
+    detalhes: ({ estoqueOk, statusOk, recalc }) => ({
+      estoque_ok: estoqueOk,
+      status_ok: statusOk,
+      recalculou: recalc?.ok ?? false,
+      pedidos: recalc?.pedidos ?? 0,
+    }),
     mutationFn: async () => {
       const [estoque, status] = await Promise.allSettled([
         supabase.functions.invoke('omie-sync-estoque', { body: { empresa: EMPRESA } }),
@@ -555,6 +568,7 @@ export default function AdminReposicaoPedidos() {
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
+          <UltimaExecucao acao="reposicao.sincronizar_recalcular" />
         </div>
       </div>
 

--- a/src/pages/TintImport.tsx
+++ b/src/pages/TintImport.tsx
@@ -1,38 +1,38 @@
-import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { invokeFunction } from '@/lib/invoke-function';
 import { toast } from 'sonner';
+import { useMutationComRegistro } from '@/components/execucoes/useMutationComRegistro';
 import type { TintSyncResult } from '@/components/tintImport/types';
 import { useTintProductCounts } from '@/components/tintImport/queries';
 import { SyncCard } from '@/components/tintImport/SyncCard';
+import { ACOES_TINT_IMPORT } from '@/components/tintImport/acoes';
 
 // Catálogo tintométrico é AUTOMÁTICO (sync do Sayersystem em tempo real). A importação
 // manual por CSV foi aposentada e removida em 2026-07-13 (Opção A → remoção total; ver
 // docs/runbooks/tint-sync-corte-csv.md). Esta tela mantém só o sync de produtos do Omie.
 export default function TintImport() {
-  const [syncing, setSyncing] = useState(false);
   const queryClient = useQueryClient();
   const { data: tintCounts } = useTintProductCounts();
 
-  const handleSync = async () => {
-    setSyncing(true);
-    try {
-      const res = await invokeFunction<TintSyncResult>('tint-omie-sync', { action: 'sync_tint_products' });
+  const syncMutation = useMutationComRegistro({
+    acao: ACOES_TINT_IMPORT.sincronizarProdutos,
+    detalhes: (res) => ({ sincronizados: res.total_sincronizado ?? res.totalSynced ?? 0 }),
+    mutationFn: () => invokeFunction<TintSyncResult>('tint-omie-sync', { action: 'sync_tint_products' }),
+    onSuccess: (res) => {
       const total = res.total_sincronizado ?? res.totalSynced ?? 0;
       toast.success(`${total} produtos tintométricos sincronizados`);
       queryClient.invalidateQueries({ queryKey: ['tint'] });
       queryClient.invalidateQueries({ queryKey: ['tint-product-counts'] });
-    } catch (err) {
+    },
+    onError: (err) => {
       toast.error(err instanceof Error ? err.message : 'Erro ao sincronizar');
-    } finally {
-      setSyncing(false);
-    }
-  };
+    },
+  });
 
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Tintométrico — Produtos &amp; Sincronização</h1>
-      <SyncCard syncing={syncing} onSync={handleSync} tintCounts={tintCounts} />
+      <SyncCard syncing={syncMutation.isPending} onSync={() => syncMutation.mutate()} tintCounts={tintCounts} />
     </div>
   );
 }


### PR DESCRIPTION
## O quê

PR2 da "última execução" (spec `2026-07-18-ultima-execucao-acoes-design.md`): **varredura** nos botões de ação global fora do analytics-sync + os 2 polimentos notados na entrega do PR1. **Frontend-only** — deploy é só Publish (sem migration, sem edge).

### Adoções (escritor: frontend — sem cron sobreposto na MESMA ação, verificado em `cron.job` de prod)

| Botão | Slug | Nota |
|---|---|---|
| Tintométrico "Sincronizar Produtos Omie" (`/tint-import`) | `tint_import.sincronizar_produtos` | handler cru `useState` convertido pra `useMutationComRegistro`; cron `tint-marcar-bases-diario` roda OUTRA função (sem sobreposição) |
| Dashboard "Atualizar análise da carteira" (GestorExcecoes → `ai-ops-agent`) | `dashboard.atualizar_analise_carteira` | edge sem cron; handler cru convertido; caption no header do card |
| Reposição "Sincronizar e recalcular" (`/admin/reposicao/pedidos`) | `reposicao.sincronizar_recalcular` | orquestração client-side (2 edges + RPC) — o composto só existe no botão; `status`='execução completou', resultado real (estoque_ok/status_ok/recalculou/pedidos) em `detalhes`; **corpo da mutation money-path intocado** |

### Exclusões justificadas (convenção: ação per-registro fica de fora)

- `PrecoEmbalagemDialog` ("Atualizar preços do portal"): entrada manual de preço POR SKU — estado vive nas linhas capturadas.
- `GerarCicloDialog` ("Gerar ciclo de oportunidade"): o cron `afiacao_ciclo_oportunidade_diario` roda a MESMA função SQL diariamente — caption só-manual mentiria. Escritor certo é a própria função SQL (migration + prova PG17) → **PR3**.

### Polimentos

- **Primeiro nome na caption** (`rotulo.ts`): "Lucas Sardenberg" → "Lucas" (compacta; nome completo segue no banco).
- **Invalidação instantânea** nos 3 mutations edge-registrados do analytics-sync (`onSettled` → recarrega a caption no clique; antes levava ~1 min).

## Provas

- vitest: suíte inteira verde (inclui teste novo do primeiro nome + mock da caption no SyncCard.test).
- typecheck strict + lint verdes.
- Crons conferidos em produção via psql-ro (decisão de escritor por slug com evidência).

## Deploy

Só **Publish** (frontend). Nada de SQL Editor nem chat de edge desta vez.

Spec: `docs/superpowers/specs/2026-07-18-ultima-execucao-acoes-design.md` (§Fora de escopo → este PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
