### PR TITLE
feat(authz): FU4-F 2b — pedido_compra_item, a 10ª tabela de compras esquecida pelo #1434 [money-path]

### DIFF
--- a/db/test-authz-pedido-compra-item.sh
+++ b/db/test-authz-pedido-compra-item.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# ╔════════════════════════════════════════════════════════════════════════════════╗
+# ║  FU4-F 2b — prova PG17: pedido_compra_item fecha em cap_compras_ler (4 policies)║
+# ╚════════════════════════════════════════════════════════════════════════════════╝
+#
+# O QUE PROVA. A tabela é OPERACIONAL (≠ as 9 irmãs, que são log só-SELECT): o frontend lê E apaga.
+# Por isso a falsificação decisiva aqui é a F2 — sabota SÓ o DELETE de volta para `has_role` e exige
+# que o farmer volte a APAGAR. Ela pega o meio-fix "fechei a leitura, o resto tanto faz", que
+# deixaria um employee sem poder ver o preço mas ainda podendo destruir o item do pedido.
+#
+# Pré-requisitos: brew install postgresql@17 pgvector
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5462}"
+SLUG="pci-2b"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — estado de prod ANTES desta migration
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('employee','customer','master');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role public.app_role);
+
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+-- private.cap_compras_ler REAL (verbatim do #1434): MASTER-ONLY, desacoplado do papel comercial.
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid, 'master'::public.app_role), false); $f$;
+REVOKE ALL     ON FUNCTION private.cap_compras_ler(uuid) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION private.cap_compras_ler(uuid) TO authenticated, service_role;
+GRANT  USAGE   ON SCHEMA private TO authenticated, anon, service_role;
+
+CREATE TABLE IF NOT EXISTS public.pedido_compra_item (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pedido_id uuid,
+  omie_codigo_produto bigint,
+  quantidade numeric,
+  preco_unitario numeric,
+  preco_sem_desconto numeric
+);
+ALTER TABLE public.pedido_compra_item ENABLE ROW LEVEL SECURITY;
+GRANT ALL ON public.pedido_compra_item TO anon, authenticated, service_role;
+
+-- As 4 policies no estado PRÉ-migration (staff amplo, has_role CRU — sem wrap InitPlan, como em prod)
+CREATE POLICY staff_pedido_compra_item_select ON public.pedido_compra_item FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role));
+CREATE POLICY staff_pedido_compra_item_insert ON public.pedido_compra_item FOR INSERT TO authenticated
+  WITH CHECK (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role));
+CREATE POLICY staff_pedido_compra_item_update ON public.pedido_compra_item FOR UPDATE TO authenticated
+  USING      (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role))
+  WITH CHECK (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role));
+CREATE POLICY staff_pedido_compra_item_delete ON public.pedido_compra_item FOR DELETE TO authenticated
+  USING (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role));
+SQL
+
+# GUARD ANTI-FALSO-VERDE: psql conecta como superuser, que BYPASSA RLS.
+GUARD=$(Pq -c "SET ROLE authenticated; SELECT current_user;" | tail -1)
+[ "$GUARD" = "authenticated" ] || { echo "❌ ABORT: SET ROLE não pegou (current_user=$GUARD)"; exit 1; }
+echo "  🔒 guard SET ROLE ok"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATION REAL
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260723140000_authz_pedido_compra_item_cap_compras.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED
+# ══════════════════════════════════════════════════════════════════════════════
+M_UID='11111111-1111-1111-1111-111111111111'   # master → cap_compras_ler = TRUE
+F_UID='22222222-2222-2222-2222-222222222222'   # employee/farmer → FALSE
+
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$M_UID'),('$F_UID') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('$M_UID','master'::public.app_role), ('$F_UID','employee'::public.app_role);
+INSERT INTO public.pedido_compra_item(id, omie_codigo_produto, quantidade, preco_unitario, preco_sem_desconto) VALUES
+  ('aaaaaaaa-0000-0000-0000-000000000001', 5001, 10, 47.30, 52.00),
+  ('aaaaaaaa-0000-0000-0000-000000000002', 5002,  4, 118.90, 118.90);
+GRANT SELECT ON public.user_roles TO authenticated, anon;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts ──"
+
+# M1: AS QUATRO policies migraram; nenhuma antiga; nenhuma 5ª; todas wrapped.
+CAP=$(Pq -c "SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item' AND coalesce(qual,with_check) ILIKE '%cap_compras_ler%';")
+eq "M1a as 4 policies exigem cap_compras_ler" "$CAP" "4"
+OLD=$(Pq -c "SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item' AND coalesce(qual,with_check) ILIKE '%has_role%';")
+eq "M1b nenhuma policy antiga sobrou" "$OLD" "0"
+TOT=$(Pq -c "SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item';")
+eq "M1c exatamente 4 policies (nenhuma 5ª permissiva)" "$TOT" "4"
+WRAP=$(Pq -c "SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item' AND coalesce(qual,with_check) ILIKE '%( select%';")
+eq "M1d wrap InitPlan nas 4 (era has_role CRU antes)" "$WRAP" "4"
+
+# M2: o UPDATE tem as DUAS cláusulas fechadas (USING governa quais linhas; WITH CHECK, o resultado)
+UPD=$(Pq -c "SELECT (qual ILIKE '%cap_compras_ler%' AND with_check ILIKE '%cap_compras_ler%') FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item' AND cmd='UPDATE';")
+eq "M2 UPDATE fechado no USING e no WITH CHECK" "$UPD" "t"
+
+# P1: master opera normalmente (lê e apaga)
+MST=$(Pq -c "SET test.uid='$M_UID'; SET ROLE authenticated; SELECT count(*) FROM public.pedido_compra_item;" | tail -1)
+eq "P1 master lê os itens" "$MST" "2"
+MST_P=$(Pq -c "SET test.uid='$M_UID'; SET ROLE authenticated; SELECT preco_unitario FROM public.pedido_compra_item WHERE omie_codigo_produto=5001;" | tail -1)
+eq "P1b master vê o preço do fornecedor" "$MST_P" "47.30"
+
+# P2: service_role (edges/cron) preservado
+SVC=$(Pq -c "SET ROLE service_role; SELECT count(*) FROM public.pedido_compra_item;" | tail -1)
+eq "P2 service_role preservado (BYPASSRLS)" "$SVC" "2"
+
+# N1: farmer não LÊ
+FRM=$(Pq -c "SET test.uid='$F_UID'; SET ROLE authenticated; SELECT count(*) FROM public.pedido_compra_item;" | tail -1)
+eq "N1 farmer NÃO lê preço de fornecedor" "$FRM" "0"
+
+# N2/N3/N4: farmer não ESCREVE. ROW_COUNT (não FOUND — FOUND carrega estado de comando anterior).
+for OP in "UPDATE public.pedido_compra_item SET preco_unitario = 1|N2 UPDATE" \
+          "DELETE FROM public.pedido_compra_item|N3 DELETE"; do
+  SQL_CMD="${OP%%|*}"; LABEL="${OP##*|}"
+  R=$(P -tA 2>&1 <<SQL
+DO \$\$
+DECLARE v_rows integer;
+BEGIN
+  PERFORM set_config('test.uid','$F_UID',true);
+  EXECUTE 'SET LOCAL ROLE authenticated';
+  EXECUTE '$SQL_CMD';
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  IF v_rows = 0 THEN RAISE NOTICE 'ZZ_SENTINELA_OK';
+  ELSE RAISE NOTICE 'ZZ_FALHOU_ESCREVEU_%_LINHAS', v_rows; END IF;
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'ZZ_SENTINELA_OK';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$R" in *ZZ_SENTINELA_OK*) ok "$LABEL negado ao farmer";; *) bad "$LABEL PASSOU — [$R]";; esac
+done
+
+# N4: INSERT negado (WITH CHECK)
+R=$(P -tA 2>&1 <<SQL
+DO \$\$ BEGIN
+  PERFORM set_config('test.uid','$F_UID',true);
+  EXECUTE 'SET LOCAL ROLE authenticated';
+  EXECUTE 'INSERT INTO public.pedido_compra_item(omie_codigo_produto, preco_unitario) VALUES (9999, 1)';
+  RAISE NOTICE 'ZZ_FALHOU_FARMER_INSERIU';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'ZZ_SENTINELA_N4_OK';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+case "$R" in *ZZ_SENTINELA_N4_OK*) ok "N4 INSERT negado ao farmer (WITH CHECK)";; *) bad "N4 farmer INSERIU — [$R]";; esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+
+# F1 — sabota o SELECT de volta: N1 tem de ficar vermelho.
+P -q <<'SQL'
+DROP POLICY IF EXISTS staff_pedido_compra_item_select ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_select ON public.pedido_compra_item FOR SELECT TO authenticated
+  USING (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role));
+SQL
+F1=$(Pq -c "SET test.uid='$F_UID'; SET ROLE authenticated; SELECT count(*) FROM public.pedido_compra_item;" | tail -1)
+eq "F1 sabotagem detectada: farmer volta a LER" "$F1" "2"
+
+# F2 — A DECISIVA para esta tabela. Restaura o SELECT (fechado) e sabota SÓ o DELETE.
+# Se o teste seguisse verde, o meio-fix "fecho a leitura e deixo a escrita" passaria batido —
+# um employee sem poder VER o preço, mas ainda podendo APAGAR o item do pedido.
+P -q <<'SQL'
+DROP POLICY IF EXISTS staff_pedido_compra_item_select ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_select ON public.pedido_compra_item FOR SELECT TO authenticated
+  USING ((SELECT private.cap_compras_ler((SELECT auth.uid()))));
+DROP POLICY IF EXISTS staff_pedido_compra_item_delete ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_delete ON public.pedido_compra_item FOR DELETE TO authenticated
+  USING (public.has_role(auth.uid(),'master'::public.app_role) OR public.has_role(auth.uid(),'employee'::public.app_role));
+SQL
+R=$(P -tA 2>&1 <<SQL
+DO \$\$
+DECLARE v_rows integer;
+BEGIN
+  PERFORM set_config('test.uid','$F_UID',true);
+  EXECUTE 'SET LOCAL ROLE authenticated';
+  EXECUTE 'DELETE FROM public.pedido_compra_item';
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RAISE NOTICE 'ZZ_APAGOU_%_LINHAS', v_rows;
+EXCEPTION WHEN OTHERS THEN RAISE NOTICE 'ZZ_BARRADO';
+END \$\$;
+SQL
+)
+case "$R" in
+  *ZZ_APAGOU_2_LINHAS*) ok "F2 sabotagem detectada: com o DELETE aberto o farmer APAGA sem poder ler (meio-fix pego)";;
+  *) bad "F2 SEM DENTE: sabotei o DELETE e o farmer não apagou — [$R]";;
+esac
+
+# restaura tudo reaplicando a migration (prova idempotência de brinde)
+P -q -f "$MIG"
+F2R=$(Pq -c "SELECT count(*) FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item' AND coalesce(qual,with_check) ILIKE '%cap_compras_ler%';")
+eq "F2r reaplicar restaura as 4 (idempotente)" "$F2R" "4"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,11 +21,11 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **411** custom migrations totais
-- **1449** objetos esperados (criados por estas migrations)
+- **412** custom migrations totais
+- **1453** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 412
-  - `rls_policy`: 364
+  - `rls_policy`: 368
   - `index`: 224
   - `cron_job`: 150
   - `table`: 147
@@ -3492,6 +3492,15 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `rls_policy` | `public.cmc_snapshot_select_staff` | `cmc_snapshot` |
+
+### `20260723140000_authz_pedido_compra_item_cap_compras.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `rls_policy` | `public.staff_pedido_compra_item_select` | `pedido_compra_item` |
+| `rls_policy` | `public.staff_pedido_compra_item_insert` | `pedido_compra_item` |
+| `rls_policy` | `public.staff_pedido_compra_item_update` | `pedido_compra_item` |
+| `rls_policy` | `public.staff_pedido_compra_item_delete` | `pedido_compra_item` |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 411
+-- Total de custom migrations: 412
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -452,7 +452,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260722110000', 'quarentena_omie_clientes_espelho', '20260722110000_quarentena_omie_clientes_espelho.sql'),
   ('20260722113000', 'tint_fase1d_is_base_pura', '20260722113000_tint_fase1d_is_base_pura.sql'),
   ('20260723130000', 'authz_custo_fu4f_fase2_inventory', '20260723130000_authz_custo_fu4f_fase2_inventory.sql'),
-  ('20260723140000', 'authz_custo_fu4f_fase1', '20260723140000_authz_custo_fu4f_fase1.sql')
+  ('20260723140000', 'authz_custo_fu4f_fase1', '20260723140000_authz_custo_fu4f_fase1.sql'),
+  ('20260723140000', 'authz_pedido_compra_item_cap_compras', '20260723140000_authz_pedido_compra_item_cap_compras.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1890,7 +1891,11 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('tint_fase1d_is_base_pura', 'function', 'public', 'tint_promote_sync_run', ''),
   ('authz_custo_fu4f_fase2_inventory', 'view', 'public', 'inventory_position_operacional', ''),
   ('authz_custo_fu4f_fase2_inventory', 'rls_policy', 'public', 'staff_inventory_position_select', 'inventory_position'),
-  ('authz_custo_fu4f_fase1', 'rls_policy', 'public', 'cmc_snapshot_select_staff', 'cmc_snapshot')
+  ('authz_custo_fu4f_fase1', 'rls_policy', 'public', 'cmc_snapshot_select_staff', 'cmc_snapshot'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_select', 'pedido_compra_item'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_insert', 'pedido_compra_item'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_update', 'pedido_compra_item'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_delete', 'pedido_compra_item')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3376,7 +3381,11 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tint_fase1d_is_base_pura', 'function', 'public', 'tint_promote_sync_run', ''),
   ('authz_custo_fu4f_fase2_inventory', 'view', 'public', 'inventory_position_operacional', ''),
   ('authz_custo_fu4f_fase2_inventory', 'rls_policy', 'public', 'staff_inventory_position_select', 'inventory_position'),
-  ('authz_custo_fu4f_fase1', 'rls_policy', 'public', 'cmc_snapshot_select_staff', 'cmc_snapshot')
+  ('authz_custo_fu4f_fase1', 'rls_policy', 'public', 'cmc_snapshot_select_staff', 'cmc_snapshot'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_select', 'pedido_compra_item'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_insert', 'pedido_compra_item'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_update', 'pedido_compra_item'),
+  ('authz_pedido_compra_item_cap_compras', 'rls_policy', 'public', 'staff_pedido_compra_item_delete', 'pedido_compra_item')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260723140000_authz_pedido_compra_item_cap_compras.sql
+++ b/supabase/migrations/20260723140000_authz_pedido_compra_item_cap_compras.sql
@@ -1,0 +1,106 @@
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- FU4-F fase 2b — pedido_compra_item: a 10ª tabela de compras, esquecida pelo #1434
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+--
+-- CONTEXTO. Achado da revisão adversária do Codex (xhigh) sobre o #1473: ele listou
+-- `pedido_compra_item.preco_unitario` como campo de custo persistido cujas "policies reais ainda
+-- precisam ser verificadas". Verifiquei em prod (psql-ro, 2026-07-20) e a porta estava aberta.
+--
+-- O #1434 (E2/FU4) fechou **9 tabelas** do domínio de compras em `private.cap_compras_ler`
+-- (master-only). Todas as 9 são tabelas de LOG (`reposicao_*_log`) — telemetria, só SELECT.
+-- `pedido_compra_item` é do MESMO domínio, guarda `preco_unitario` e `preco_sem_desconto` (o que o
+-- grupo paga ao fornecedor) e ficou com as 4 policies em `has_role(master) OR has_role(employee)`.
+-- Não é uma decisão registrada em lugar nenhum: é a 10ª irmã que passou batido porque não casa com
+-- o padrão de nome `reposicao_*_log` pelo qual as outras foram varridas.
+--
+-- POR QUE `cap_compras_ler` E NÃO `cap_custo_ler`. Preço de fornecedor é telemetria de COMPRAS, não
+-- custo de carteira comercial — o #1434 já separou as duas capabilities de propósito
+-- ("compras não é carteira"). Usar a irmã errada aqui fragmentaria o contrato: quando existir papel
+-- de compras no enum, é `cap_compras_ler` que muda, e esta tabela tem de acompanhar as outras 9.
+--
+-- ⚠️ DIFERENÇA ESTRUTURAL EM RELAÇÃO ÀS 9 IRMÃS — e por que as 4 policies fecham, não só a leitura.
+-- As irmãs são log (SELECT apenas). Esta é OPERACIONAL: o frontend escreve nela
+-- (`useDetalhesModal.ts` faz DELETE de item e de lote; `useSkuMapeamento.ts` lê). Deixar
+-- INSERT/UPDATE/DELETE em `has_role` enquanto o SELECT fecha produziria o pior dos dois mundos —
+-- um employee que não pode LER o preço mas ainda pode APAGAR o item de pedido. Least privilege
+-- exige as quatro.
+--
+-- QUEM PERDE, DE VERDADE. Os 2 employees em prod (ambos `commercial_role='farmer'`).
+-- `cap_compras_ler` é master-only, então eles perdem leitura E escrita de itens de pedido de compra.
+-- É consistente com a decisão do dono de 2026-07-20 — reposição/compras é trabalho do master — e
+-- com o fechamento de `inventory_position` no #1473, que já tirou dessas mesmas telas.
+-- O master não perde nada: passa em `cap_compras_ler` por ser master.
+--
+-- IMUNES: edges e cron usam `service_role` (BYPASSRLS); funções SECURITY DEFINER com owner
+-- `postgres` seguem escrevendo. O wrap InitPlan `(SELECT ...)` é acrescentado — as policies atuais
+-- chamam `has_role(auth.uid(), ...)` CRU, que reavalia por linha (database.md §4).
+--
+-- Aplicada À MÃO pelo dono no SQL Editor do Lovable. Idempotente: pode reaplicar.
+-- Prova: db/test-authz-pedido-compra-item.sh (PG17 + falsificação).
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'private' AND p.proname = 'cap_compras_ler'
+  ) THEN
+    RAISE EXCEPTION 'FU4-F 2b: private.cap_compras_ler ausente — aplique o #1434 (20260718190000) ANTES';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class WHERE oid = 'public.pedido_compra_item'::regclass AND relrowsecurity
+  ) THEN
+    RAISE EXCEPTION 'FU4-F 2b: pedido_compra_item sem RLS ligada — abortando (fechar policy sem RLS é no-op)';
+  END IF;
+END $$;
+
+-- As QUATRO policies. Nomes preservados (o repo já os referencia); só a expressão muda.
+-- Permissivas combinam com OR: fechar um subconjunto não fecha nada — foi o achado central do #1473.
+
+DROP POLICY IF EXISTS staff_pedido_compra_item_select ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_select
+  ON public.pedido_compra_item
+  FOR SELECT
+  TO authenticated
+  USING ((SELECT private.cap_compras_ler((SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS staff_pedido_compra_item_insert ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_insert
+  ON public.pedido_compra_item
+  FOR INSERT
+  TO authenticated
+  WITH CHECK ((SELECT private.cap_compras_ler((SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS staff_pedido_compra_item_update ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_update
+  ON public.pedido_compra_item
+  FOR UPDATE
+  TO authenticated
+  USING      ((SELECT private.cap_compras_ler((SELECT auth.uid()))))
+  WITH CHECK ((SELECT private.cap_compras_ler((SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS staff_pedido_compra_item_delete ON public.pedido_compra_item;
+CREATE POLICY staff_pedido_compra_item_delete
+  ON public.pedido_compra_item
+  FOR DELETE
+  TO authenticated
+  USING ((SELECT private.cap_compras_ler((SELECT auth.uid()))));
+
+COMMIT;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY (read-only)
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- SELECT
+--   count(*) FILTER (WHERE coalesce(qual,with_check) ILIKE '%cap_compras_ler%') AS fechadas,   -- 4
+--   count(*) FILTER (WHERE coalesce(qual,with_check) ILIKE '%has_role%')        AS antigas,    -- 0
+--   count(*)                                                                    AS total,      -- 4
+--   count(*) FILTER (WHERE coalesce(qual,with_check) ILIKE '%( select%')         AS wrapped     -- 4
+-- FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item';
+--
+-- Conjunto de compras completo (as 9 irmãs + esta):
+-- SELECT count(DISTINCT tablename) FROM pg_policies
+--  WHERE schemaname='public' AND coalesce(qual,with_check) ILIKE '%cap_compras_ler%';  -- 10


### PR DESCRIPTION
## Contexto

Achado da revisão adversária do **Codex (xhigh)** sobre o [#1473](https://github.com/LucasSardenbergL/afiacao/pull/1473). Ele listou `pedido_compra_item.preco_unitario` entre os campos de custo persistido cujas "policies reais ainda precisam ser verificadas". Verifiquei em prod por `psql-ro` — **a porta estava aberta**.

O [#1434](https://github.com/LucasSardenbergL/afiacao/pull/1434) fechou **9 tabelas** de compras em `private.cap_compras_ler` (master-only). Todas as 9 são `reposicao_*_log`. `pedido_compra_item` é do **mesmo domínio**, guarda `preco_unitario` e `preco_sem_desconto` — o que o grupo paga ao fornecedor — e ficou com as 4 policies em `has_role(master) OR has_role(employee)`.

Não é uma decisão registrada: é a 10ª irmã que passou batido porque **não casa com o padrão de nome** pelo qual as outras foram varridas.

## Por que `cap_compras_ler` e não `cap_custo_ler`

Preço de fornecedor é telemetria de **compras**, não custo de carteira comercial — o #1434 separou as duas capabilities de propósito ("compras não é carteira"). Usar a irmã errada fragmentaria o contrato: quando existir papel de compras no enum, é `cap_compras_ler` que muda, e esta tabela precisa acompanhar as outras 9.

## As QUATRO policies fecham, não só a leitura

Diferença estrutural em relação às 9 irmãs: elas são **log** (só SELECT). Esta é **operacional** — o frontend escreve nela (`useDetalhesModal.ts` apaga item e lote; `useSkuMapeamento.ts` lê).

Fechar só o SELECT produziria o pior dos dois mundos: um employee que **não pode ver** o preço mas **ainda pode apagar** o item do pedido. A falsificação **F2 prova isso executando** — com o DELETE aberto, o farmer apaga 2 linhas sem conseguir lê-las.

Também acrescentei o **wrap InitPlan**: as policies chamavam `has_role(auth.uid(), …)` cru, que reavalia por linha (database.md §4).

## Quem perde

Os 2 employees em prod (ambos `commercial_role='farmer'`). `cap_compras_ler` é master-only, então perdem leitura **e** escrita de itens de pedido de compra. Consistente com a decisão do dono (2026-07-20) — reposição/compras é trabalho do master — e com o #1473, que já os tirou dessas mesmas telas.

**Você não perde nada:** passa em `cap_compras_ler` por ser master. Edges e cron usam `service_role` (BYPASSRLS).

## Prova

`db/test-authz-pedido-compra-item.sh` — **15 asserts, exit 0**, PG17 com a migration real e o guard que aborta se o `SET ROLE` não pegar.

- **M1a–d:** as 4 policies em `cap_compras_ler`, 0 antigas, nenhuma 5ª, wrap InitPlan nas 4
- **M2:** o UPDATE fechado no `USING` **e** no `WITH CHECK`
- **N1–N4:** farmer não lê, não insere, não atualiza, não apaga (`ROW_COUNT`, não `FOUND`)
- **F1:** sabota o SELECT → farmer volta a ler
- **F2:** sabota só o DELETE → **farmer apaga sem poder ler** (pega o meio-fix)
- **F2r:** reaplicar restaura as 4 (idempotência)

## ⚠️ ATENÇÃO: migration manual necessária

`supabase/migrations/20260723140000_authz_pedido_compra_item_cap_compras.sql`. **Lovable não aplica automaticamente.** Depende do #1434, já aplicado ✅ (a migration aborta com mensagem clara se não estivesse). Só banco — **não precisa de Publish**.

```sql
SELECT
  count(*) FILTER (WHERE coalesce(qual,with_check) ILIKE '%cap_compras_ler%') AS fechadas,  -- 4
  count(*) FILTER (WHERE coalesce(qual,with_check) ILIKE '%has_role%')        AS antigas,   -- 0
  count(*)                                                                    AS total      -- 4
FROM pg_policies WHERE schemaname='public' AND tablename='pedido_compra_item';
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
