### PR TITLE
feat(authz): FU4-H — as 2 tabelas de compras que ficaram fora da matriz [money-path]

### DIFF
--- a/db/test-authz-cap-compras-escrever.sh
+++ b/db/test-authz-cap-compras-escrever.sh
@@ -60,6 +60,7 @@ eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], 
 MASTER="10000000-0000-0000-0000-000000000001"
 GERENCIAL="20000000-0000-0000-0000-000000000002"
 FARMER="40000000-0000-0000-0000-000000000004"
+EMPL_SEM_CR="50000000-0000-0000-0000-000000000005"   # employee SEM linha em commercial_roles (o TRI-STATE)
 
 # ═══════════════════════════════════════════════════════════════════════════════════
 # ZONA 1 — PRÉ-REQUISITOS (stubs espelhando PROD, medido 2026-07-19)
@@ -88,16 +89,39 @@ CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
 
+-- get_commercial_role: cópia verbatim de prod (pg_get_functiondef). É a fonte do TRI-STATE —
+-- sem linha em commercial_roles, a subquery escalar devolve NULL (não false).
+CREATE OR REPLACE FUNCTION public.get_commercial_role(_user_id uuid)
+ RETURNS public.commercial_role LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT commercial_role
+  FROM public.commercial_roles
+  WHERE user_id = _user_id
+  LIMIT 1
+$f$;
+
 -- O gate ANTIGO precisa existir: é o que a migration procura e troca.
 -- Em PROD ele vive nas DUAS formas (impl em private pelo #1427 + wrapper em public); as 3 RPCs
 -- alvo chamam a de `public`, então é essa que o stub precisa ter para o regex casar.
+--
+-- ⚠️ TRI-STATE — `get_commercial_role(...) IN (...)`, VERBATIM de prod, e NÃO um `EXISTS(...)`.
+-- A distinção é a razão de ser deste harness. Para um `employee` SEM linha em commercial_roles:
+--   ·  com get_commercial_role:  false OR (true AND (NULL IN (...)))  =  false OR NULL  =  NULL
+--   ·  com EXISTS (o que estava aqui): false OR (true AND false)      =  false
+-- As 3 RPCs alvo gateiam com `IF NOT gate(...)`, e `NOT NULL` = NULL ⇒ o IF NÃO ENTRA e a
+-- SECURITY DEFINER ESCREVE. Esse era o bypass real que o FU4-E fechou. Com o EXISTS o stub
+-- devolvia `false`, o `NOT false` negava, e o harness ficava CEGO para o bypass que existe
+-- justamente para provar. Trocar de volta reabre o ponto cego (a falsificação F5 exige vermelho).
 CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$
   SELECT public.has_role(_uid,'master'::public.app_role)
       OR (public.has_role(_uid,'employee'::public.app_role)
-          AND EXISTS (SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
-                       AND cr.commercial_role IN ('gerencial','estrategico','super_admin')));
+          AND public.get_commercial_role(_uid) IN (
+            'gerencial'::public.commercial_role,
+            'estrategico'::public.commercial_role,
+            'super_admin'::public.commercial_role
+          ));
 $f$;
 GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated, service_role;
 
@@ -264,11 +288,25 @@ eq "P0b as 3 RPCs seguem com o gate novo após re-aplicar" \
 echo "── ZONA 3: seeds ──"
 P -q <<SQL
 INSERT INTO public.user_roles(user_id,role) VALUES
-  ('$MASTER','master'), ('$GERENCIAL','employee'), ('$FARMER','employee');
+  ('$MASTER','master'), ('$GERENCIAL','employee'), ('$FARMER','employee'), ('$EMPL_SEM_CR','employee');
 INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES
   ('$GERENCIAL','gerencial'), ('$FARMER','farmer');
+-- EMPL_SEM_CR fica SEM linha de propósito: é o que faz o gate ANTIGO devolver NULL.
 SQL
 echo "  seeds inseridos"
+
+# ── sanidade do STUB: ele reproduz mesmo o tri-state de prod? ──
+# Sem isto, uma regressão silenciosa do stub para `EXISTS(...)` (bi-state) deixaria o harness
+# verde e CEGO — foi exatamente o defeito que este arquivo teve até 2026-07-20.
+eq "T1 gate ANTIGO é TRI-STATE: employee sem commercial_role ⇒ NULL (não false)" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$EMPL_SEM_CR') IS NULL;")" "t"
+eq "T1b ...e o mesmo gate devolve false (não NULL) p/ quem tem papel comercial comum" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$FARMER') IS FALSE;")" "t"
+eq "T1c ...e true para gerencial (o tri-state não quebrou o caminho positivo)" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$GERENCIAL') IS TRUE;")" "t"
+# a capability NOVA nunca devolve NULL — é o que torna `IF NOT cap(...)` seguro nas 3 RPCs.
+eq "T2 capability NOVA é BI-STATE p/ o mesmo uid (COALESCE ⇒ false, nunca NULL)" \
+   "$(Pq -c "SELECT private.cap_compras_escrever('$EMPL_SEM_CR') IS FALSE;")" "t"
 
 # helper: roda SQL como `authenticated` com um uid.
 # ⚠️ `SET` e NÃO `SET LOCAL`: cada invocação do psql é sessão nova em autocommit, onde SET LOCAL
@@ -364,6 +402,20 @@ eq "N3 gerencial NÃO reverte run inteiro" \
 echo "── ZONA 4b: farmer (papel comercial comum) também negado ──"
 eq "N4 farmer NÃO despina"        "$(call_rpc "$FARMER" "public.despinar_parametro('oben','9002')")" "DENIED"
 eq "N5 farmer NÃO reverte run"    "$(call_rpc "$FARMER" "public.reverter_run_auto('$RUN_ID')")"      "DENIED"
+
+echo "── ZONA 4b2: o BYPASS TRI-STATE que o FU4-E fechou (employee sem commercial_role) ──"
+# No gate ANTIGO este uid produzia NULL, `NOT NULL` = NULL, o IF não entrava e a escrita PASSAVA.
+# Sob o gate NOVO (COALESCE ⇒ false) ele é negado. A falsificação F5 prova que este par de asserts
+# tem dente: com o corpo antigo restaurado, o mesmo uid volta a ESCREVER.
+seed_cenario
+eq "N7 employee sem commercial_role NÃO despina (tri-state fechado)" \
+   "$(call_rpc "$EMPL_SEM_CR" "public.despinar_parametro('oben','9002')")" "DENIED"
+eq "N7e ...e o pin CONTINUA lá (efeito no dado)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_pin WHERE empresa='oben' AND sku_codigo_omie='9002';")" "1"
+eq "N8 employee sem commercial_role NÃO reverte run" \
+   "$(call_rpc "$EMPL_SEM_CR" "public.reverter_run_auto('$RUN_ID')")" "DENIED"
+eq "N8e ...e o log segue NÃO revertido" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_auto_log WHERE id='$LOG_ID' AND revertido_em IS NULL;")" "1"
 
 echo "── ZONA 4c: anônimo (uid NULO) negado — fail-closed ──"
 eq "N6 uid NULO não despina" \
@@ -495,6 +547,53 @@ if P -q -f "$MIG" >/dev/null 2>&1; then
 else
   ok "F4 guard aborta com 2 ocorrências do gate antigo → não reescreve corpo divergente"
 fi
+
+# ── F5 — O BYPASS TRI-STATE, DEMONSTRADO (a falsificação que dá dente ao N7) ──────────────────
+# Restaura o corpo PRÉ-#1462 (gate ANTIGO + `IF NOT`, verbatim) e exige que o employee sem
+# commercial_role VOLTE A ESCREVER. Se este bloco não conseguir reabrir o bypass, então o stub
+# do gate antigo não é tri-state e o N7 estava passando por acidente — que foi exatamente o
+# defeito deste harness até 2026-07-20 (stub com `EXISTS(...)`, bi-state).
+# ⚠️ Esta é a única falsificação do arquivo que testa o STUB, não a migration: ela prova que o
+# mundo que o harness simula é o mundo que existe em produção.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.despinar_parametro(p_empresa text, p_sku text)
+ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT public.pode_ver_carteira_completa(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  DELETE FROM public.reposicao_param_pin WHERE empresa=p_empresa AND sku_codigo_omie=p_sku;
+  RETURN FOUND;
+END;
+$function$;
+SQL
+seed_cenario
+if [ "$(call_rpc "$EMPL_SEM_CR" "public.despinar_parametro('oben','9002')")" = "OK" ]; then
+  ok "F5 gate ANTIGO reabre o bypass p/ employee sem commercial_role → N7 tem dente"
+else
+  bad "F5 restaurei o gate ANTIGO e o employee sem commercial_role seguiu NEGADO — o stub NÃO é tri-state (regressão para EXISTS?), N7 é cego"
+fi
+eq "F5e ...e o bypass ESCREVEU de fato: o pin sumiu (efeito, não só ausência de exceção)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_param_pin WHERE empresa='oben' AND sku_codigo_omie='9002';")" "0"
+# contraste: no MESMO corpo antigo, o farmer (papel comercial comum ⇒ false, não NULL) segue negado.
+# Prova que o vazamento vem do NULL e não de o gate antigo liberar geral.
+eq "F5c ...mas o farmer segue negado no gate antigo (o furo é o NULL, não o gate inteiro)" \
+   "$(call_rpc "$FARMER" "public.despinar_parametro('oben','9002')")" "DENIED"
+
+# restaura o gate NOVO e exige que o bypass feche de novo
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.despinar_parametro(p_empresa text, p_sku text)
+ RETURNS boolean LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NOT private.cap_compras_escrever(auth.uid()) THEN RAISE EXCEPTION 'sem permissão'; END IF;
+  DELETE FROM public.reposicao_param_pin WHERE empresa=p_empresa AND sku_codigo_omie=p_sku;
+  RETURN FOUND;
+END;
+$function$;
+SQL
+seed_cenario
+eq "F5r restaurado: employee sem commercial_role volta a ser negado" \
+   "$(call_rpc "$EMPL_SEM_CR" "public.despinar_parametro('oben','9002')")" "DENIED"
 
 echo ""
 echo "═══════════════════════════════════════════════════════"

--- a/db/test-authz-cap-compras-ler-alertas-fu4h.sh
+++ b/db/test-authz-cap-compras-ler-alertas-fu4h.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — FU4-H: as 2 tabelas de compras fora da matriz                     ║
+# ║   bash db/test-authz-cap-compras-ler-alertas-fu4h.sh > "$S/t.log" 2>&1; echo $?   ║
+# ║                                                                                    ║
+# ║  Aplica a migration REAL 20260720160000 e prova que a policy de SELECT de          ║
+# ║  `reposicao_alerta_pedido_minimo` e `reposicao_auto_aprovacao_log` saiu de         ║
+# ║  "staff (employee OR master)" e entrou em `private.cap_compras_ler` (master-only)  ║
+# ║  SEM quebrar a escrita (SECDEF service-role-only) e SEM tirar o master.            ║
+# ║                                                                                    ║
+# ║  ⚠️ É prova de RLS: TODO assert de leitura roda sob `SET ROLE authenticated`.      ║
+# ║  O psql conecta como superuser, que BYPASSA RLS — asserts rodados como postgres    ║
+# ║  pintariam tudo de verde provando nada. O guard aborta se o SET ROLE não pegar.    ║
+# ║                                                                                    ║
+# ║  Lei #1: a migration REAL é aplicada (não um stub da lógica).                      ║
+# ║  Lei #2: negativo por CONTAGEM sob a role certa + anon por SQLSTATE.               ║
+# ║  Lei #3: ZONA 5 sabota e EXIGE vermelho.                                          ║
+# ╚══════════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5494}"
+SLUG="fu4halertas"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+MIG="$REPO_ROOT/supabase/migrations/20260720160000_authz_cap_compras_ler_alertas_auto_aprovacao_fu4h.sql"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+[ -f "$MIG" ] || { echo "migration nao encontrada: $MIG"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+MASTER="10000000-0000-0000-0000-000000000001"
+FARMER="40000000-0000-0000-0000-000000000004"
+EMPL_SEM_CR="50000000-0000-0000-0000-000000000005"
+CUSTOMER="60000000-0000-0000-0000-000000000006"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (stubs espelhando PROD, medido 2026-07-20)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 1: pré-requisitos ──"
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+GRANT USAGE ON SCHEMA private TO authenticated, anon, service_role;
+GRANT USAGE ON SCHEMA auth    TO authenticated, anon, service_role;
+
+CREATE TYPE public.app_role        AS ENUM ('customer','employee','master','admin');
+CREATE TYPE public.commercial_role AS ENUM ('operacional','gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+
+CREATE TABLE public.user_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE public.commercial_roles (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL UNIQUE,
+  commercial_role public.commercial_role NOT NULL);
+
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+-- ⚠️ `user_roles` PRECISA do GRANT + RLS + policies de prod (medido 2026-07-20).
+-- A policy ANTIGA ("staff") lê `public.user_roles` DIRETO — sem isto, ela falha com
+-- `permission denied for table user_roles` e a falsificação F1 não consegue reabrir a leitura,
+-- fazendo o assert negativo passar por acidente. (Já mordeu: 1ª execução deste harness.)
+-- A policy NOVA não depende disto — `cap_compras_ler` chama `has_role`, que é SECDEF e bypassa
+-- a RLS de user_roles. Por isso só a falsificação quebrava, e os asserts positivos não.
+GRANT SELECT ON public.user_roles TO authenticated, service_role;
+ALTER TABLE public.user_roles ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Admins and employees can view all roles" ON public.user_roles
+  FOR SELECT USING (public.has_role(auth.uid(),'master'::public.app_role)
+                 OR public.has_role(auth.uid(),'employee'::public.app_role));
+CREATE POLICY "Users can view their own roles" ON public.user_roles
+  FOR SELECT USING (auth.uid() = user_id);
+
+-- a capability do #1434 (dependência REAL desta migration — a §0 aborta sem ela)
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false) $f$;
+REVOKE ALL ON FUNCTION private.cap_compras_ler(uuid) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION private.cap_compras_ler(uuid) TO authenticated, service_role;
+
+-- ── as 2 tabelas alvo: colunas VERBATIM de prod (psql-ro 2026-07-20) ──
+CREATE TABLE public.reposicao_alerta_pedido_minimo (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text NOT NULL, fornecedor_nome text, grupo_codigo text, pedido_id bigint,
+  valor_alertado numeric, valor_ultimo numeric,
+  alertado_em timestamptz NOT NULL DEFAULT now(), resolvido_em timestamptz);
+CREATE TABLE public.reposicao_auto_aprovacao_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pedido_id bigint, empresa text NOT NULL, fornecedor_nome text, grupo_codigo text,
+  valor_total numeric, valor_anterior numeric, delta_pct numeric, regua text,
+  criado_em timestamptz NOT NULL DEFAULT now());
+
+-- RLS + a policy "staff" VERBATIM de prod: é o que a migration vai substituir.
+-- Nome com espaço e acento de propósito — é o nome real, e a migration tem de lidar com ele
+-- (%I no format). Um stub com nome "limpo" provaria um mundo que não existe.
+ALTER TABLE public.reposicao_alerta_pedido_minimo ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.reposicao_auto_aprovacao_log   ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Staff lê alertas de pedido mínimo" ON public.reposicao_alerta_pedido_minimo
+  FOR SELECT TO authenticated USING (EXISTS (
+    SELECT 1 FROM public.user_roles ur
+     WHERE ur.user_id = (SELECT auth.uid()) AND ur.role = ANY (ARRAY['employee'::public.app_role,'master'::public.app_role])));
+CREATE POLICY "Staff lê log de auto-aprovação" ON public.reposicao_auto_aprovacao_log
+  FOR SELECT TO authenticated USING (EXISTS (
+    SELECT 1 FROM public.user_roles ur
+     WHERE ur.user_id = (SELECT auth.uid()) AND ur.role = ANY (ARRAY['employee'::public.app_role,'master'::public.app_role])));
+
+-- GRANTs como em prod (o default privilege do Supabase concede a anon também; RLS é quem nega)
+GRANT SELECT, INSERT ON public.reposicao_alerta_pedido_minimo TO authenticated, anon, service_role;
+GRANT SELECT, INSERT ON public.reposicao_auto_aprovacao_log   TO authenticated, anon, service_role;
+
+-- o WRITER real: SECDEF, service-role-only (authenticated NÃO executa). Bypassa RLS.
+CREATE OR REPLACE FUNCTION public.reposicao_alerta_pedido_minimo_tick()
+ RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','pg_temp'
+AS $f$
+DECLARE v int;
+BEGIN
+  INSERT INTO public.reposicao_alerta_pedido_minimo(empresa, fornecedor_nome, pedido_id, valor_alertado, valor_ultimo)
+    VALUES ('OBEN','Sayerlack', 4242, 2800.00, 3100.00);
+  GET DIAGNOSTICS v = ROW_COUNT;
+  RETURN v;
+END $f$;
+REVOKE ALL ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reposicao_alerta_pedido_minimo_tick() TO service_role;
+SQL
+echo "  pré-requisitos criados"
+
+# guard do stub: sem a policy STAFF viva, a migration não teria o que trocar e a prova seria vacuosa.
+eq "S1 stub nasce com a policy STAFF nas 2 tabelas" \
+   "$(Pq -c "SELECT count(*) FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+             WHERE n.nspname='public' AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+               AND p.polcmd='r' AND pg_get_expr(p.polqual,p.polrelid) ~ 'user_roles';")" "2"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS (antes da migration: a precondição de papel gerencial olha isto)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 3: seeds ──"
+P -q <<SQL
+INSERT INTO public.user_roles(user_id,role) VALUES
+  ('$MASTER','master'), ('$FARMER','employee'), ('$EMPL_SEM_CR','employee'), ('$CUSTOMER','customer');
+INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES ('$FARMER','farmer');
+-- linhas com o dado que a matriz protege: valor de compra + fornecedor
+INSERT INTO public.reposicao_alerta_pedido_minimo(empresa, fornecedor_nome, pedido_id, valor_alertado, valor_ultimo)
+  VALUES ('OBEN','Sayerlack', 101, 1500.00, 1800.00);
+INSERT INTO public.reposicao_auto_aprovacao_log(empresa, fornecedor_nome, pedido_id, valor_total, valor_anterior, delta_pct, regua)
+  VALUES ('OBEN','Sayerlack', 101, 9900.00, 9000.00, 10.0, 'r1');
+SQL
+echo "  seeds inseridos"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo "── ZONA 2: aplicar migration real ──"
+P -q -f "$MIG"
+echo "  migration aplicada: $(basename "$MIG")"
+
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  ok "P0a migration é IDEMPOTENTE (2ª aplicação passa)"
+else
+  bad "P0a re-aplicar a migration falhou — não é idempotente"
+fi
+
+# ── o guard de RLS: sem isto TODO assert de leitura seria teatro (superuser bypassa RLS) ──
+as_user() { P -tA -q <<SQL
+SET test.uid = '$1';
+SET ROLE authenticated;
+$2
+SQL
+}
+GUARD=$(as_user "$MASTER" "SELECT current_user;")
+[ "$GUARD" = "authenticated" ] || { echo "❌ HARNESS INVÁLIDO: SET ROLE não pegou (current_user=$GUARD)"; exit 1; }
+echo "  guard: asserts rodam como '$GUARD' (não superuser) ✅"
+
+le_alertas()  { as_user "$1" "SELECT count(*) FROM public.reposicao_alerta_pedido_minimo;"; }
+le_aprov()    { as_user "$1" "SELECT count(*) FROM public.reposicao_auto_aprovacao_log;"; }
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── ZONA 4a: o furo que o FU4-H fecha (farmer perde o valor de compra) ──"
+# RLS não levanta exceção: ela FILTRA. O negativo aqui é contagem 0 sob a role certa.
+eq "N1 farmer NÃO lê alertas de pedido mínimo"      "$(le_alertas "$FARMER")"      "0"
+eq "N2 farmer NÃO lê log de auto-aprovação"         "$(le_aprov   "$FARMER")"      "0"
+eq "N3 employee sem commercial_role NÃO lê alertas" "$(le_alertas "$EMPL_SEM_CR")" "0"
+eq "N4 employee sem commercial_role NÃO lê aprovações" "$(le_aprov "$EMPL_SEM_CR")" "0"
+eq "N5 customer NÃO lê alertas"                     "$(le_alertas "$CUSTOMER")"    "0"
+eq "N6 uid NULO (sem JWT) NÃO lê alertas — fail-closed" \
+   "$(P -tA -q -c "SET ROLE authenticated;" -c "SELECT count(*) FROM public.reposicao_alerta_pedido_minimo;")" "0"
+
+echo "── ZONA 4b: anon negado ──"
+eq "N7 anon NÃO lê alertas" \
+   "$(P -tA -q -c "SET ROLE anon;" -c "SELECT count(*) FROM public.reposicao_alerta_pedido_minimo;")" "0"
+
+echo "── ZONA 4c: master preserva TUDO (ninguém que devia ler perdeu) ──"
+eq "M1 master LÊ os alertas"          "$(le_alertas "$MASTER")" "1"
+eq "M2 master LÊ o log de aprovação"  "$(le_aprov   "$MASTER")" "1"
+eq "M3 e o conteúdo sensível chega íntegro (valor+fornecedor)" \
+   "$(as_user "$MASTER" "SELECT valor_alertado::int||'|'||fornecedor_nome FROM public.reposicao_alerta_pedido_minimo;")" \
+   "1500|Sayerlack"
+eq "M4 idem no log de aprovação (valor_total+delta)" \
+   "$(as_user "$MASTER" "SELECT valor_total::int||'|'||delta_pct::int FROM public.reposicao_auto_aprovacao_log;")" "9900|10"
+
+echo "── ZONA 4d: a ESCRITA não foi tocada (o writer é SECDEF service-role-only) ──"
+# É o risco real de fechar uma policy: matar o alimentador em silêncio. O tick roda como
+# service_role e bypassa RLS — a troca da policy de SELECT não pode afetá-lo.
+eq "W1 o tick (SECDEF, service_role) ESCREVE normalmente após a troca" \
+   "$(P -tA -q -c "SET ROLE service_role;" -c "SELECT public.reposicao_alerta_pedido_minimo_tick();")" "1"
+eq "W1e ...e a linha nova existe de fato (2 agora)" \
+   "$(Pq -c "SELECT count(*) FROM public.reposicao_alerta_pedido_minimo;")" "2"
+eq "W2 authenticated segue SEM EXECUTE no tick (fronteira de GRANT preservada)" \
+   "$(Pq -c "SELECT has_function_privilege('authenticated','public.reposicao_alerta_pedido_minimo_tick()','EXECUTE');")" "f"
+
+echo "── ZONA 4e: catálogo ──"
+eq "K1 as 2 policies de SELECT estão no gate NOVO" \
+   "$(Pq -c "SELECT count(*) FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+             WHERE n.nspname='public' AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+               AND p.polcmd='r' AND pg_get_expr(p.polqual,p.polrelid) ~ 'cap_compras_ler';")" "2"
+eq "K2 NENHUMA sobrou no gate staff (user_roles)" \
+   "$(Pq -c "SELECT count(*) FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+             WHERE n.nspname='public' AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+               AND p.polcmd='r' AND pg_get_expr(p.polqual,p.polrelid) ~ 'user_roles';")" "0"
+eq "K3 o nome MENTIROSO ('Staff lê...') não existe mais no catálogo" \
+   "$(Pq -c "SELECT count(*) FROM pg_policy WHERE polname LIKE 'Staff lê%';")" "0"
+eq "K4 RLS segue LIGADA nas 2 (policy sem RLS seria decorativa)" \
+   "$(Pq -c "SELECT count(*) FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+             WHERE n.nspname='public' AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+               AND c.relrowsecurity;")" "2"
+eq "K5 nenhuma policy de ESCRITA foi criada (a migration não inventa contrato)" \
+   "$(Pq -c "SELECT count(*) FROM pg_policy p JOIN pg_class c ON c.oid=p.polrelid JOIN pg_namespace n ON n.oid=c.relnamespace
+             WHERE n.nspname='public' AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+               AND p.polcmd <> 'r';")" "0"
+
+# ═══════════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota e EXIGE vermelho
+# ═══════════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── ZONA 5: falsificação (sabotar → exigir vermelho) ──"
+
+# F1 — devolve a policy STAFF. O farmer TEM de voltar a ler; se não voltar, N1 é cego
+# (ex.: a tabela estaria vazia, ou o SET ROLE não estaria pegando).
+P -q <<'SQL'
+DROP POLICY reposicao_alerta_pedido_minimo_sel ON public.reposicao_alerta_pedido_minimo;
+CREATE POLICY "Staff lê alertas de pedido mínimo" ON public.reposicao_alerta_pedido_minimo
+  FOR SELECT TO authenticated USING (EXISTS (
+    SELECT 1 FROM public.user_roles ur
+     WHERE ur.user_id = (SELECT auth.uid()) AND ur.role = ANY (ARRAY['employee'::public.app_role,'master'::public.app_role])));
+SQL
+# ⚠️ IGUALDADE EXATA, não `!= "0"`. A 1ª versão deste assert usava `if [ ... != "0" ]` e passou
+# com a query FALHANDO: `permission denied for table user_roles` devolve string VAZIA, e ""!="0"
+# é verdadeiro ⇒ o assert declarava "o farmer voltou a ler" quando ninguém tinha lido nada.
+# Um negativo formulado como "diferente do valor ruim" aceita todo resultado anômalo, inclusive
+# erro; o positivo por igualdade só aceita o número que o cenário produz. São 2 linhas aqui:
+# a do seed (pedido 101) + a que o tick inseriu na W1 (pedido 4242).
+eq "F1 policy staff restaurada → farmer VOLTA a ler as 2 linhas → N1 tem dente" \
+   "$(le_alertas "$FARMER")" "2"
+eq "F1e ...e o vazamento entrega o valor de compra (efeito, não só contagem)" \
+   "$(as_user "$FARMER" "SELECT valor_alertado::int FROM public.reposicao_alerta_pedido_minimo WHERE pedido_id=101;")" "1500"
+
+# restaura o gate novo re-aplicando a migration REAL (é idempotente e reconhece a policy staff)
+P -q -f "$MIG"
+eq "F1r restaurado: farmer volta a NÃO ler" "$(le_alertas "$FARMER")" "0"
+
+# F2 — a precondição de dependência tem dente? Sem cap_compras_ler, DEVE abortar.
+P -q -c "DROP POLICY reposicao_alerta_pedido_minimo_sel ON public.reposicao_alerta_pedido_minimo;"
+P -q -c "CREATE POLICY \"Staff lê alertas de pedido mínimo\" ON public.reposicao_alerta_pedido_minimo FOR SELECT TO authenticated USING (EXISTS (SELECT 1 FROM public.user_roles ur WHERE ur.user_id=(SELECT auth.uid()) AND ur.role=ANY(ARRAY['employee'::public.app_role,'master'::public.app_role])));"
+P -q -c "DROP FUNCTION private.cap_compras_ler(uuid) CASCADE;" >/dev/null 2>&1 || true
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F2 precondição: migration aplicou SEM private.cap_compras_ler (deveria abortar)"
+else
+  ok "F2 precondição aborta sem cap_compras_ler → sem policy órfã"
+fi
+
+# recria a capability e as policies para as falsificações seguintes
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false) $f$;
+GRANT EXECUTE ON FUNCTION private.cap_compras_ler(uuid) TO authenticated, service_role;
+SQL
+P -q -c "DROP POLICY IF EXISTS reposicao_auto_aprovacao_log_sel ON public.reposicao_auto_aprovacao_log;" >/dev/null 2>&1 || true
+P -q -c "CREATE POLICY \"Staff lê log de auto-aprovação\" ON public.reposicao_auto_aprovacao_log FOR SELECT TO authenticated USING (EXISTS (SELECT 1 FROM public.user_roles ur WHERE ur.user_id=(SELECT auth.uid()) AND ur.role=ANY(ARRAY['employee'::public.app_role,'master'::public.app_role])));" >/dev/null 2>&1 || true
+
+# F3 — o guard de "policy divergente" tem dente? Troca o USING por algo que a migration NÃO
+# reconhece e exige aborto (em vez de dropar uma regra que ela não sabe o que é).
+P -q -c "DROP POLICY \"Staff lê alertas de pedido mínimo\" ON public.reposicao_alerta_pedido_minimo;"
+P -q -c "CREATE POLICY politica_estranha ON public.reposicao_alerta_pedido_minimo FOR SELECT TO authenticated USING (true);"
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F3 guard: migration dropou uma policy de SELECT que NÃO era a staff medida"
+else
+  ok "F3 guard aborta com policy de SELECT divergente → não destrói regra desconhecida"
+fi
+eq "F3e ...e a policy estranha continua intacta (a migration não a tocou)" \
+   "$(Pq -c "SELECT count(*) FROM pg_policy WHERE polname='politica_estranha';")" "1"
+
+# F4 — a precondição de "papel gerencial vivo" tem dente?
+P -q -c "DROP POLICY politica_estranha ON public.reposicao_alerta_pedido_minimo;"
+P -q -c "CREATE POLICY \"Staff lê alertas de pedido mínimo\" ON public.reposicao_alerta_pedido_minimo FOR SELECT TO authenticated USING (EXISTS (SELECT 1 FROM public.user_roles ur WHERE ur.user_id=(SELECT auth.uid()) AND ur.role=ANY(ARRAY['employee'::public.app_role,'master'::public.app_role])));"
+P -q -c "INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES ('20000000-0000-0000-0000-000000000002','gerencial');"
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F4 precondição: migration aplicou COM papel gerencial vivo (deveria abortar)"
+else
+  ok "F4 precondição aborta com papel gerencial vivo → o guard tem dente"
+fi
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "  PASS=$PASS  FAIL=$FAIL"
+echo "═══════════════════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/db/test-authz-cap-compras-ler-pos-candidatos.sh
+++ b/db/test-authz-cap-compras-ler-pos-candidatos.sh
@@ -84,17 +84,36 @@ CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
 
--- ⚠️ TRI-STATE, verbatim de prod: para um `employee` SEM linha em commercial_roles o EXISTS dá
--- false, mas `has_role(master)` dá false e o OR devolve false... já para quem NÃO é employee nem
--- master o resultado é false. O NULL aparece quando has_role devolve NULL. Mantido como em prod:
--- é justamente o tri-state que motivou o `IS NOT TRUE` no corpo da RPC.
+-- get_commercial_role: cópia verbatim de prod (pg_get_functiondef). É a FONTE do tri-state —
+-- sem linha em commercial_roles a subquery escalar devolve NULL, não false.
+CREATE OR REPLACE FUNCTION public.get_commercial_role(_user_id uuid)
+ RETURNS public.commercial_role LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $f$
+  SELECT commercial_role
+  FROM public.commercial_roles
+  WHERE user_id = _user_id
+  LIMIT 1
+$f$;
+
+-- ⚠️ TRI-STATE — `get_commercial_role(...) IN (...)`, VERBATIM de prod, e NÃO um `EXISTS(...)`.
+-- Para um `employee` SEM linha em commercial_roles:
+--   ·  com get_commercial_role:  false OR (true AND (NULL IN (...)))  =  false OR NULL  =  NULL
+--   ·  com EXISTS (o que estava aqui): false OR (true AND false)      =  false
+-- Aqui o veredito FINAL não muda — o `IS NOT TRUE` do corpo trata NULL e false igualmente, e é
+-- por isso que esta RPC de LEITURA nunca teve o bypass que as 3 de ESCRITA tinham. O que o EXISTS
+-- escondia era outra coisa: a NECESSIDADE do `IS NOT TRUE`. Com stub bi-state, trocá-lo por
+-- `NOT(...)` seguia verde; com o tri-state real, a falsificação F3 fica VERMELHA. O assert que não
+-- distingue os dois mundos não estava provando a defesa, só acompanhando-a.
 CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
  RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
 AS $f$
   SELECT public.has_role(_uid,'master'::public.app_role)
       OR (public.has_role(_uid,'employee'::public.app_role)
-          AND EXISTS (SELECT 1 FROM public.commercial_roles cr WHERE cr.user_id=_uid
-                       AND cr.commercial_role IN ('gerencial','estrategico','super_admin')));
+          AND public.get_commercial_role(_uid) IN (
+            'gerencial'::public.commercial_role,
+            'estrategico'::public.commercial_role,
+            'super_admin'::public.commercial_role
+          ));
 $f$;
 GRANT EXECUTE ON FUNCTION public.pode_ver_carteira_completa(uuid) TO authenticated, service_role;
 
@@ -295,6 +314,16 @@ GUARD=$(as_user "$MASTER" "SELECT current_user;")
 [ "$GUARD" = "authenticated" ] || { echo "❌ HARNESS INVÁLIDO: SET ROLE não pegou (current_user=$GUARD)"; exit 1; }
 echo "  guard: asserts rodam como '$GUARD' (não superuser) ✅"
 
+# ── sanidade do STUB: ele reproduz mesmo o tri-state de prod? ──
+# Uma regressão do stub para `EXISTS(...)` (bi-state) deixaria a falsificação F3 impossível de
+# ficar vermelha — foi o defeito deste arquivo até 2026-07-20.
+eq "T1 gate ANTIGO é TRI-STATE: employee sem commercial_role ⇒ NULL (não false)" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$EMPL_SEM_CR') IS NULL;")" "t"
+eq "T1b ...e devolve false (não NULL) p/ papel comercial comum" \
+   "$(Pq -c "SELECT public.pode_ver_carteira_completa('$FARMER') IS FALSE;")" "t"
+eq "T2 capability NOVA é BI-STATE p/ o mesmo uid (COALESCE ⇒ false, nunca NULL)" \
+   "$(Pq -c "SELECT private.cap_compras_ler('$EMPL_SEM_CR') IS FALSE;")" "t"
+
 # nega classificando pela SQLSTATE 42501 — nunca pelo texto da mensagem (anti-teatro de ILIKE).
 call_rpc() { # $1=uid ('' = cron/uid NULL)
   local out setuid=""
@@ -395,6 +424,57 @@ CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid) RETURNS boolean
 AS $f$ SELECT COALESCE(_uid IS NOT NULL AND public.has_role(_uid,'master'::public.app_role), false) $f$;
 SQL
 eq "F1r restaurado: gerencial volta a ser negado" "$(call_rpc "$GERENCIAL")" "DENIED"
+
+# ── F3 — O `IS NOT TRUE` É NECESSÁRIO? (a falsificação que o stub bi-state tornava impossível) ──
+# Volta o corpo ao gate ANTIGO **e** troca `IS NOT TRUE` por `NOT (...)`. Com o gate antigo sendo
+# TRI-STATE, o employee sem commercial_role produz `NOT NULL` = NULL ⇒ o IF não entra ⇒ a SECDEF
+# ENTREGA TUDO. É o bypass que o `IS NOT TRUE` existe para fechar.
+# Enquanto o stub era `EXISTS(...)` (bi-state) esta sabotagem NÃO conseguia vazar — o assert que
+# fiscaliza o `IS NOT TRUE` acompanhava a defesa sem nunca prová-la.
+# ⚠️ A sabotagem tem GUARD próprio: se o regex não casar, `EXECUTE` recriaria a função IDÊNTICA e
+# o "não vazou" seria falso verde — exatamente o teatro que esta zona existe para matar.
+P -q <<'SQL'
+DO $$
+DECLARE v_def text; v_sab text;
+BEGIN
+  v_def := pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure);
+  v_sab := regexp_replace(v_def,
+    'AND \(SELECT private\.cap_compras_ler\(\(SELECT auth\.uid\(\)\)\)\)\s+IS NOT TRUE THEN',
+    'AND NOT (SELECT public.pode_ver_carteira_completa((SELECT auth.uid()))) THEN');
+  IF v_sab = v_def THEN
+    RAISE EXCEPTION 'F3 INVÁLIDA: a sabotagem não casou — o teste seria vacuoso';
+  END IF;
+  EXECUTE v_sab;
+END $$;
+SQL
+if [ "$(call_rpc "$EMPL_SEM_CR")" = "OK" ]; then
+  ok "F3 gate antigo + NOT(...) VAZA p/ employee sem commercial_role → o IS NOT TRUE tem função"
+else
+  bad "F3 sabotei o IS NOT TRUE e nada vazou — o stub NÃO é tri-state (regressão para EXISTS?), o K4 é cego"
+fi
+eq "F3e ...e o vazamento entrega o conteúdo sensível (efeito, não só ausência de erro)" \
+   "$(as_user "$EMPL_SEM_CR" "SELECT portal_protocolo FROM public.reposicao_pos_candidatos('OBEN') WHERE portal_protocolo IS NOT NULL;")" "PROTO-9"
+# contraste: o farmer (papel comercial comum ⇒ false, não NULL) segue negado no MESMO corpo
+# sabotado. Prova que o vazamento vem do NULL, e não de o gate antigo liberar geral.
+eq "F3c ...mas o farmer segue negado no mesmo corpo (o furo é o NULL, não o gate inteiro)" \
+   "$(call_rpc "$FARMER")" "DENIED"
+
+# restaura o corpo verdadeiro (gate novo + IS NOT TRUE) e exige que o furo feche
+P -q -f "$MIG" >/dev/null 2>&1 || true
+P -q <<'SQL'
+DO $$
+DECLARE v_def text; v_ok text;
+BEGIN
+  v_def := pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure);
+  v_ok := regexp_replace(v_def,
+    'AND NOT \(SELECT public\.pode_ver_carteira_completa\(\(SELECT auth\.uid\(\)\)\)\) THEN',
+    'AND (SELECT private.cap_compras_ler((SELECT auth.uid()))) IS NOT TRUE THEN');
+  IF v_ok <> v_def THEN EXECUTE v_ok; END IF;
+END $$;
+SQL
+eq "F3r restaurado: employee sem commercial_role volta a ser negado" "$(call_rpc "$EMPL_SEM_CR")" "DENIED"
+eq "F3rk ...e o IS NOT TRUE está de volta na CHAMADA" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure) ~ 'cap_compras_ler\(\(SELECT auth\.uid\(\)\)\)\)\s+IS NOT TRUE';")" "t"
 
 # F2 — a precondição de dependência tem dente? Sem cap_compras_ler, a migration DEVE abortar.
 # (é a diferença de desenho em relação ao FU4-E, que era autônomo de propósito)

--- a/db/valida-fu4h-alertas-compras.sql
+++ b/db/valida-fu4h-alertas-compras.sql
@@ -1,0 +1,65 @@
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY — FU4-H (20260720160000)
+-- Cole no SQL Editor DEPOIS de aplicar a migration. As 6 linhas devem vir `t`.
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- ⚠️ Só CATÁLOGO, de propósito. Uma query que SELECIONA das 2 tabelas mentiria de duas formas:
+--    · o SQL Editor roda como superuser, que BYPASSA RLS ⇒ "eu vejo tudo" não prova nada;
+--    · 0 linhas pode ser tabela vazia, não policy funcionando.
+--    Quem prova comportamento é db/test-authz-cap-compras-ler-alertas-fu4h.sh (PG17, SET ROLE
+--    authenticated, com falsificação). Aqui só confirmamos que o objeto ficou como o desenho diz.
+
+SELECT 'as 2 policies de SELECT estão no gate NOVO' AS check,
+       count(*) = 2 AS ok
+  FROM pg_policy p
+  JOIN pg_class c ON c.oid = p.polrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE n.nspname = 'public'
+   AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+   AND p.polcmd = 'r'
+   AND pg_get_expr(p.polqual, p.polrelid) ~ 'cap_compras_ler'
+
+UNION ALL
+SELECT 'NENHUMA sobrou no gate staff (user_roles)',
+       count(*) = 0
+  FROM pg_policy p
+  JOIN pg_class c ON c.oid = p.polrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE n.nspname = 'public'
+   AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+   AND p.polcmd = 'r'
+   AND pg_get_expr(p.polqual, p.polrelid) ~ 'user_roles'
+
+UNION ALL
+-- o nome antigo afirmava "Staff lê…", o que ficaria FALSO depois da troca.
+SELECT 'o nome mentiroso (Staff lê…) não existe mais',
+       count(*) = 0
+  FROM pg_policy WHERE polname LIKE 'Staff lê%'
+
+UNION ALL
+SELECT 'RLS segue LIGADA nas 2 (policy sem RLS é decorativa)',
+       count(*) = 2
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE n.nspname = 'public'
+   AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+   AND c.relrowsecurity
+
+UNION ALL
+-- a migration não cria contrato de escrita: as 2 tabelas seguem sem policy de INSERT/UPDATE/DELETE
+-- (quem escreve é o tick, SECDEF service-role-only, que bypassa RLS).
+SELECT 'nenhuma policy de ESCRITA foi criada',
+       count(*) = 0
+  FROM pg_policy p
+  JOIN pg_class c ON c.oid = p.polrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+ WHERE n.nspname = 'public'
+   AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+   AND p.polcmd <> 'r'
+
+UNION ALL
+-- o alimentador tem de seguir intocado: SECDEF e SEM execute para authenticated.
+SELECT 'o writer (tick) segue SECDEF e service-role-only',
+       (SELECT p.prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public' AND p.proname = 'reposicao_alerta_pedido_minimo_tick')
+       AND NOT has_function_privilege('authenticated',
+             'public.reposicao_alerta_pedido_minimo_tick()', 'EXECUTE');

--- a/supabase/migrations/20260720160000_authz_cap_compras_ler_alertas_auto_aprovacao_fu4h.sql
+++ b/supabase/migrations/20260720160000_authz_cap_compras_ler_alertas_auto_aprovacao_fu4h.sql
@@ -1,0 +1,191 @@
+-- ╔══════════════════════════════════════════════════════════════════════════════════════════╗
+-- ║  FU4-H — as 2 tabelas de compras que ficaram FORA da matriz  [money-path / autorização]    ║
+-- ╚══════════════════════════════════════════════════════════════════════════════════════════╝
+-- Prova: db/test-authz-cap-compras-ler-alertas-fu4h.sh (PG17, SET ROLE authenticated, com falsificação)
+-- Continuação do E2/FU4 (#1434), FU4-E (#1462) e FU4-G (#1472) — todos aplicados.
+-- Achado da revisão adversária retroativa via Codex (2026-07-20), confirmado em prod via psql-ro.
+--
+-- ── O FURO (medido em prod, 2026-07-20) ────────────────────────────────────────────────────
+-- O #1434 fechou NOVE tabelas `reposicao_*` em `private.cap_compras_ler` (master-only). Existem
+-- TREZE. Duas das quatro restantes carregam exatamente a classe de dado que a matriz protege:
+--   · reposicao_alerta_pedido_minimo → fornecedor_nome, valor_alertado, valor_ultimo, pedido_id
+--   · reposicao_auto_aprovacao_log   → fornecedor_nome, valor_total, valor_anterior, delta_pct
+-- Ambas com policy de SELECT para `employee OR master`. O #1472 fechou `reposicao_pos_candidatos`
+-- JUSTAMENTE porque ela projetava `valor_total` e `fornecedor_nome` — os mesmos campos, a mesma
+-- decisão, outra porta. Fechar 9 tabelas e deixar o mesmo dado legível em 2 vizinhas não é uma
+-- matriz de autorização, é uma matriz com exceção não declarada.
+--
+-- ── EXPOSIÇÃO REAL, NÃO LATENTE (≠ FU4-E/FU4-G) ────────────────────────────────────────────
+-- Medido 2026-07-20: `reposicao_alerta_pedido_minimo` tem 24 LINHAS VIVAS (última 2026-07-08);
+-- `reposicao_auto_aprovacao_log` está vazia (exposição latente). E há POPULAÇÃO: os 2 usuários
+-- `farmer` têm app_role `employee` (medido) e ZERO deles passa em `cap_compras_ler`. São
+-- precisamente as pessoas que a matriz barra nas 9 tabelas, lendo o mesmo dado nesta.
+-- Diferente do FU4-E/FU4-G (onde a troca não retirava acesso de ninguém vivo), esta RETIRA — e é
+-- exatamente o que se decidiu: farmer não vê valor de compra (decisão do founder, 2026-07-20).
+--
+-- ── POR QUE ISTO NÃO QUEBRA NADA (verificado, não presumido) ────────────────────────────────
+-- · LEITURA: `grep` em `src/` e `supabase/functions/` — NENHUM consumidor lê as duas tabelas.
+--   Não há tela, hook ou edge que as consulte. Fechar o SELECT não derruba UX alguma.
+-- · ESCRITA: as duas são escritas SÓ por `public.reposicao_alerta_pedido_minimo_tick()` —
+--   SECURITY DEFINER, `has_function_privilege(authenticated)=false` (service-role-only), chamada
+--   pela edge `gerar-pedidos-diario`. SECDEF bypassa RLS ⇒ trocar a policy de SELECT não a toca.
+-- · Esta migration mexe em UMA policy por tabela, de comando SELECT (`polcmd='r'`). Não há policy
+--   de INSERT/UPDATE/DELETE nas duas (medido) — nada de escrita é criado nem alterado aqui.
+--
+-- ── POR QUE RENOMEAR A POLICY (e não só trocar o USING) ────────────────────────────────────
+-- Os nomes atuais são "Staff lê alertas de pedido mínimo" e "Staff lê log de auto-aprovação".
+-- Depois da troca elas NÃO são mais staff-readable — são master-only. Manter o nome deixaria no
+-- catálogo uma afirmação FALSA sobre quem lê, que é a mesma dívida que o #1472 pagou ao corrigir
+-- um comentário em vez de deixá-lo mentir. Os nomes novos seguem o padrão das 9 (`<tabela>_sel`).
+--
+-- ⚠️ Migration MANUAL (Lovable não aplica nome custom) — colar no SQL Editor.
+
+BEGIN;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 0) PRECONDIÇÕES — aborta se o banco vivo divergir do medido
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+DO $$
+DECLARE v_gerenciais int;
+BEGIN
+  IF to_regclass('public.reposicao_alerta_pedido_minimo') IS NULL
+     OR to_regclass('public.reposicao_auto_aprovacao_log') IS NULL THEN
+    RAISE EXCEPTION 'FU4-H: tabela(s) alvo ausente(s) — banco divergente, abortando'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- DEPENDÊNCIA REAL: o gate de destino é a capability do #1434. Sem ela, a policy nasceria
+  -- referenciando função inexistente e TODA leitura das duas tabelas quebraria em runtime
+  -- (inclusive para o master). Precondição explícita em vez de caller órfão (a falha do #1423).
+  IF to_regprocedure('private.cap_compras_ler(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'FU4-H: private.cap_compras_ler(uuid) ausente — aplique o #1434 (20260718190000) antes'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  IF to_regclass('public.commercial_roles') IS NULL THEN
+    RAISE EXCEPTION 'FU4-H: tabela commercial_roles ausente — banco divergente, abortando'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- Coerência com FU4-E/FU4-G: um papel gerencial vivo mudaria o acesso dele sem aviso.
+  SELECT count(*) INTO v_gerenciais FROM public.commercial_roles
+   WHERE commercial_role IN ('gerencial','estrategico','super_admin');
+  IF v_gerenciais > 0 THEN
+    RAISE EXCEPTION 'FU4-H: % papel(is) gerencial(is) vivo(s) — revise antes de aplicar', v_gerenciais
+      USING ERRCODE = 'raise_exception';
+  END IF;
+END $$;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 1) A TROCA — policy de SELECT sai de "staff" e entra em cap_compras_ler
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- Guardada: só dropa o que RECONHECE. Se a policy de SELECT viva não for a medida (outra
+-- migration a reescreveu), aborta em vez de destruir uma regra que não conhece.
+DO $$
+DECLARE
+  r          record;
+  v_qual     text;
+  v_n_sel    int;
+BEGIN
+  FOR r IN
+    SELECT * FROM (VALUES
+      ('reposicao_alerta_pedido_minimo', 'reposicao_alerta_pedido_minimo_sel'),
+      ('reposicao_auto_aprovacao_log',   'reposicao_auto_aprovacao_log_sel')
+    ) AS t(tabela, pol_nova)
+  LOOP
+    -- IDEMPOTENTE: já migrada ⇒ segue. O dono cola à mão; queda de rede não pode travar a 2ª vez.
+    IF EXISTS (SELECT 1 FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+                JOIN pg_namespace n ON n.oid = c.relnamespace
+               WHERE n.nspname = 'public' AND c.relname = r.tabela AND p.polname = r.pol_nova) THEN
+      RAISE NOTICE 'FU4-H: %.% já migrada — nada a fazer', r.tabela, r.pol_nova;
+      CONTINUE;
+    END IF;
+
+    -- exatamente UMA policy de SELECT (polcmd='r') — mais de uma significa desenho diferente do
+    -- medido, e dropar "a primeira" seria arbitrário.
+    SELECT count(*) INTO v_n_sel
+      FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public' AND c.relname = r.tabela AND p.polcmd = 'r';
+    IF v_n_sel <> 1 THEN
+      RAISE EXCEPTION 'FU4-H: esperava 1 policy de SELECT em %, encontrei % — inspecione pg_policy antes de prosseguir', r.tabela, v_n_sel
+        USING ERRCODE = 'raise_exception';
+    END IF;
+
+    -- e ela tem de ser a policy "staff" MEDIDA (lê user_roles e concede a employee). Se o USING
+    -- for outro, esta migration não sabe o que está substituindo.
+    SELECT pg_get_expr(p.polqual, p.polrelid) INTO v_qual
+      FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public' AND c.relname = r.tabela AND p.polcmd = 'r';
+    IF v_qual !~ 'user_roles' OR v_qual !~ 'employee' THEN
+      RAISE EXCEPTION 'FU4-H: a policy de SELECT de % não é a staff medida (USING=%) — abortando', r.tabela, v_qual
+        USING ERRCODE = 'raise_exception';
+    END IF;
+
+    -- dropa a antiga PELO NOME REAL lido do catálogo (os nomes têm espaço e acento; nunca
+    -- hardcodar string literal aqui — %I cita corretamente o que o catálogo devolveu).
+    EXECUTE (
+      SELECT format('DROP POLICY %I ON public.%I', p.polname, r.tabela)
+        FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public' AND c.relname = r.tabela AND p.polcmd = 'r'
+    );
+
+    -- `(SELECT ...)` envolvendo a chamada: initplan, avaliado UMA vez por query em vez de por
+    -- linha — é o padrão das 9 policies do #1434.
+    EXECUTE format(
+      'CREATE POLICY %I ON public.%I FOR SELECT TO authenticated USING ((SELECT private.cap_compras_ler((SELECT auth.uid()))))',
+      r.pol_nova, r.tabela);
+  END LOOP;
+END $$;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- 2) PÓS-CHECK POSITIVO no catálogo (dentro da transação — falha ⇒ ROLLBACK)
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+DO $$
+DECLARE v_ok int; v_velha int;
+BEGIN
+  SELECT count(*) INTO v_ok
+    FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+     AND p.polcmd = 'r'
+     AND pg_get_expr(p.polqual, p.polrelid) ~ 'cap_compras_ler';
+  IF v_ok <> 2 THEN
+    RAISE EXCEPTION 'FU4-H: pos-check falhou — % de 2 policies no gate novo', v_ok
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- e NENHUMA das duas pode ter sobrado no gate staff
+  SELECT count(*) INTO v_velha
+    FROM pg_policy p JOIN pg_class c ON c.oid = p.polrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+     AND p.polcmd = 'r'
+     AND pg_get_expr(p.polqual, p.polrelid) ~ 'user_roles';
+  IF v_velha <> 0 THEN
+    RAISE EXCEPTION 'FU4-H: pos-check falhou — % policy(s) ainda no gate staff', v_velha
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  -- RLS tem de seguir ligada nas duas: policy nova com RLS desligada seria decorativa.
+  IF EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE n.nspname = 'public'
+                AND c.relname IN ('reposicao_alerta_pedido_minimo','reposicao_auto_aprovacao_log')
+                AND NOT c.relrowsecurity) THEN
+    RAISE EXCEPTION 'FU4-H: pos-check falhou — RLS desligada em alguma das 2 tabelas'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+END $$;
+
+COMMIT;
+
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY → db/valida-fu4h-alertas-compras.sql (só catálogo; roda de qualquer role).
+-- Não repetida aqui: uma query que SELECIONA das tabelas mentiria de duas formas (o superuser do
+-- SQL Editor bypassa RLS ⇒ "vejo tudo" não prova nada; e 0 linhas pode ser tabela vazia, não
+-- policy funcionando). database.md, §validação pós-apply.
+-- ════════════════════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Fecha o **[P1]** da revisão adversária retroativa via Codex (`gpt-5.6-sol`, xhigh) dos #1462/#1467/#1472. O outro achado daquele parecer virou o #1480 (já mergeado).

> **Decisão de produto do founder (2026-07-20): farmer não deve ver valor de compra.** Este PR implementa isso. Se a decisão fosse a inversa, o certo seria documentar a desclassificação das colunas, não fechar a porta.

## O furo

O #1434 fechou **nove** tabelas `reposicao_*` em `private.cap_compras_ler` (master-only). Existem **treze**. Duas das quatro restantes carregam exatamente a classe de dado que a matriz protege:

| tabela | colunas | policy até agora |
|---|---|---|
| `reposicao_alerta_pedido_minimo` | `fornecedor_nome`, `valor_alertado`, `valor_ultimo`, `pedido_id` | staff (`employee OR master`) |
| `reposicao_auto_aprovacao_log` | `fornecedor_nome`, `valor_total`, `valor_anterior`, `delta_pct` | staff (`employee OR master`) |

O #1472 fechou `reposicao_pos_candidatos` **justamente porque ela projetava `valor_total` e `fornecedor_nome`** — os mesmos campos, a mesma decisão, outra porta. Fechar 9 tabelas e deixar o mesmo dado legível em 2 vizinhas não é uma matriz de autorização, é uma matriz com exceção não declarada.

## Exposição real, não latente

Diferente do #1462 e do #1472 (calibrados como "ninguém perde acesso hoje"), **este retira acesso de gente viva** — deliberadamente:

- `reposicao_alerta_pedido_minimo`: **24 linhas vivas** (última 2026-07-08). `reposicao_auto_aprovacao_log`: vazia (latente).
- os **2 usuários `farmer` têm `app_role = employee`** (medido), e **zero** deles passa em `cap_compras_ler`.

São precisamente as pessoas que a matriz barra nas 9 tabelas, lendo o mesmo dado nesta.

## Por que não quebra nada (verificado, não presumido)

- **Leitura:** `grep` em `src/` e `supabase/functions/` — **nenhum** consumidor lê as duas tabelas. Não há tela, hook ou edge que as consulte.
- **Escrita:** ambas são escritas só por `public.reposicao_alerta_pedido_minimo_tick()` — SECDEF, `has_function_privilege(authenticated) = false`, chamada pela edge `gerar-pedidos-diario`. **SECDEF bypassa RLS**, então trocar a policy de SELECT não a toca. Isso virou assert (`W1`/`W1e`/`W2`) porque "fechei a leitura e matei o alimentador em silêncio" é o modo de falha caro aqui.
- A migration mexe em **uma policy por tabela, de comando SELECT**. Não há policy de INSERT/UPDATE/DELETE nas duas (medido), e nenhuma é criada (`K5`).

## Por que renomear a policy

Os nomes eram `Staff lê alertas de pedido mínimo` e `Staff lê log de auto-aprovação`. Depois da troca elas **não são mais staff-readable**. Manter o nome deixaria no catálogo uma afirmação falsa sobre quem lê — a mesma dívida que o #1472 pagou ao corrigir um comentário em vez de deixá-lo mentir. Viram `<tabela>_sel`, o padrão das 9. O assert `K3` exige que o nome mentiroso suma.

## Evidência

`db/test-authz-cap-compras-ler-alertas-fu4h.sh` — PG17 descartável, migration **real** aplicada, asserts de leitura sob `SET ROLE authenticated` (o psql conecta como superuser, que bypassa RLS; há guard que aborta se o `SET ROLE` não pegar).

**28 asserts, FAIL=0, exit 0.** Falsificações:

| | prova |
|---|---|
| `F1` | devolve a policy staff → farmer **volta a ler as 2 linhas** (`=2`) |
| `F1e` | e o vazamento **entrega o valor** (`=1500`), não só contagem |
| `F2` | sem `cap_compras_ler` a migration **aborta** → sem policy órfã |
| `F3` | com policy de SELECT divergente **aborta** → não destrói regra que não reconhece |
| `F3e` | e a policy estranha fica **intacta** |
| `F4` | com papel gerencial vivo **aborta** |

### Uma reprovação no caminho, que vale registrar

A 1ª rodada deu `FAIL=1`. Duas causas, ambas minhas:

1. **o stub não reproduzia prod** — a policy staff lê `public.user_roles` direto e eu não tinha dado GRANT/RLS nessa tabela, então ela falhava com `permission denied` e a falsificação não conseguia reabrir a leitura. É o mesmo defeito que o Codex apontou nos outros harnesses (#1480), repetido enquanto eu o consertava. Só a falsificação quebrou porque os asserts positivos passam por `cap_compras_ler` → `has_role`, que é SECDEF e bypassa a RLS de `user_roles`;
2. **o assert `F1` era `if [ ... != "0" ]`** — e query que falha devolve string vazia, com `"" != "0"` verdadeiro. O assert declarou "o farmer voltou a ler" quando ninguém leu nada. Trocado por **igualdade exata** (`= "2"`). Negativo escrito como "diferente do valor ruim" aceita qualquer resultado anômalo, inclusive erro.

Quem pegou foi o `F1e`, o assert de **efeito no dado**. Sem ele eu teria entregue um harness que passa com o banco quebrado.

## Gates

| gate | resultado |
|---|---|
| prova PG17 + falsificação | `exit 0` — 28 asserts |
| `heavy bun run typecheck` | `exit 0` |
| `heavy bun run test` | `exit 0` |
| `shellcheck` | `exit 0` |
| `bun run authz:check` | `exit 0` (1 aviso pré-existente, outra migration) |

## ⚠️ Handoff — a migration NÃO se aplica sozinha

Merge na `main` **não** aplica migration de nome custom no Lovable. Depois do merge:

1. colar `supabase/migrations/20260720160000_authz_cap_compras_ler_alertas_auto_aprovacao_fu4h.sql` no **SQL Editor**;
2. rodar `db/valida-fu4h-alertas-compras.sql` — **6 linhas, todas `t`**.

A validação é só catálogo de propósito: no SQL Editor você é superuser e bypassa RLS, então "eu vejo as linhas" não provaria nada, e "vejo zero" poderia ser tabela vazia. Quem prova comportamento é o harness.

Sem Publish e sem deploy de edge — o PR não toca `src/` nem `supabase/functions/`.

## Achados ainda abertos do mesmo parecer

- **[P2]** `IS NOT TRUE` nas 3 RPCs de escrita (defesa em profundidade, sem mudança de comportamento hoje).
- **[P2]** `supabase/migrations/20260721190000_reposicao_pos_candidatos.sql:112` ainda chama o gate antigo — colá-la reverte o #1472 em silêncio.
- **[P2]** o validador do #1467 casa `has_role(...)` e `_uid IS NOT NULL` como regex independentes: uma capability com `OR` no lugar do `AND` passaria, autorizando qualquer uid não-nulo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
