### PR TITLE
fix(carteira-rebuild): trava de saída no bootstrap fail-closed (P0-B-bis 2/2 hardening) [money-path]

### DIFF
--- a/db/test-carteira-vendedor-oben-account-safe.sh
+++ b/db/test-carteira-vendedor-oben-account-safe.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — camada SQL do carteira-rebuild account-safe (P0-B-bis ponta 2/2) ║
+# ║  A carteira lê o VENDEDOR da view fresca omie_customer_account_map_fresco       ║
+# ║  (account=oben). Esta prova crava a SEMÂNTICA da view+query em que a correção   ║
+# ║  se apoia — NÃO há migração nova (edge TS puro; a lógica é provada por vitest). ║
+# ║  Recria a tabela base + a view com as DEFINIÇÕES REAIS (pg_get_viewdef +        ║
+# ║  constraints conferidas via psql-ro 2026-07-11) e FALSIFICA cada invariante.    ║
+# ║  A UNIQUE(user_id,account) provada aqui (F3/F4) é o que garante o KEYSET seguro.║
+# ║      bash db/test-carteira-vendedor-oben-account-safe.sh > /tmp/t.log 2>&1; echo "exit=$?"  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"     # porta própria (evita colisão com outros harnesses em paralelo)
+SLUG="carteira-vend-oben"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1+2 — SCHEMA REAL: tabela base (com as UNIQUE reais) + view fresca (def real)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+-- Estrutura REAL de omie_customer_account_map (information_schema + pg_constraint via psql-ro 2026-07-11).
+CREATE TABLE public.omie_customer_account_map (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id              uuid   NOT NULL,
+  account              text   NOT NULL,
+  omie_codigo_cliente  bigint NOT NULL,
+  omie_codigo_vendedor bigint,               -- nullable: o writer só popula quando recomendacoes traz
+  source               text   NOT NULL,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT uq_ocam_codigo_account UNIQUE (omie_codigo_cliente, account),
+  CONSTRAINT uq_ocam_user_account   UNIQUE (user_id, account)
+);
+-- Definição REAL da view (pg_get_viewdef via psql-ro): TTL 7d sobre a base.
+CREATE VIEW public.omie_customer_account_map_fresco AS
+  SELECT id, user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, created_at, updated_at
+    FROM public.omie_customer_account_map
+   WHERE updated_at >= (now() - '7 days'::interval);
+SQL
+echo "schema real recriado (tabela base + view fresca)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED: casos de borda do money-path da carteira
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO public.omie_customer_account_map (user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source, updated_at) VALUES
+ -- user1: MESMO cliente em 2 contas com vendedores DIFERENTES. A carteira (oben) deve pegar 100, nunca 200.
+ ('11111111-1111-1111-1111-111111111111', 'oben',       9001, 100, 'document', now()),
+ ('11111111-1111-1111-1111-111111111111', 'colacor_sc', 9002, 200, 'document', now()),
+ -- user2: linha oben fresca mas vendedor NULL (estado transitório / recomendacoes sem vendedor) → órfão honesto.
+ ('22222222-2222-2222-2222-222222222222', 'oben',       9003, NULL, 'document', now()),
+ -- user3: linha oben com vendedor 300 mas STALE (>7d) → a view fresca deve OCULTAR (senão vendedor podre).
+ ('33333333-3333-3333-3333-333333333333', 'oben',       9004, 300, 'document', now() - interval '8 days'),
+ -- user4: só existe em colacor_sc (é o clone típico) → NÃO deve aparecer na carteira oben (sem herança).
+ ('44444444-4444-4444-4444-444444444444', 'colacor_sc', 9005, 400, 'document', now());
+SQL
+echo "seed aplicado"
+
+U1="11111111-1111-1111-1111-111111111111"
+U2="22222222-2222-2222-2222-222222222222"
+U3="33333333-3333-3333-3333-333333333333"
+U4="44444444-4444-4444-4444-444444444444"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS POSITIVOS: a query REAL do edge é account-safe
+# (a query do edge: FROM omie_customer_account_map_fresco WHERE account='oben')
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts positivos (a query correta que o edge faz) ──"
+
+V=$(Pq -c "SELECT omie_codigo_vendedor FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U1';")
+eq "A1 vendedor da CONTA CERTA (oben=100, nunca o colacor_sc=200)" "$V" "100"
+
+V=$(Pq -c "SELECT coalesce(omie_codigo_vendedor::text,'NULL') FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U2';")
+eq "A2 vendedor ausente preservado como NULL (órfão honesto, vira Hunter no rebuild)" "$V" "NULL"
+
+V=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U3';")
+eq "A3 STALE (>7d) OCULTO pela view fresca (não injeta vendedor podre)" "$V" "0"
+
+V=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE account='oben' AND user_id='$U4';")
+eq "A4 clone só-colacor_sc AUSENTE na carteira oben (sem herança cross-account)" "$V" "0"
+
+# nenhuma linha colacor_sc pode aparecer sob o filtro account='oben'
+V=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE account='oben' AND omie_codigo_vendedor=200;")
+eq "A5 isolamento de conta: o vendedor 200 (colacor_sc) NÃO aparece sob account=oben" "$V" "0"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO: sabota cada proteção da query → exige VERMELHO
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação (sabota o filtro → prova o dente) ──"
+
+# F1 — SABOTA o filtro de CONTA (o bug do espelho poluído, que lia sem account): o mesmo user1 passa a
+#      trazer 2 vendedores (100 oben E 200 colacor_sc). Se a query correta (A1) NÃO tivesse o filtro
+#      account=oben, ela pegaria um vendedor arbitrário/errado. Provamos que SEM o filtro há ambiguidade.
+FURADO=$(Pq -c "SELECT count(DISTINCT omie_codigo_vendedor) FROM omie_customer_account_map_fresco WHERE user_id='$U1';")
+if [ "$FURADO" = "2" ]; then ok "F1 sem o filtro de conta → 2 vendedores p/ o mesmo user (vazamento que o account=oben mata)"; else bad "F1 falsificação fraca — sem filtro deu [$FURADO], esperava 2 (o filtro não estaria protegendo nada)"; fi
+# e o valor arbitrário que vazaria inclui o colacor_sc:
+LEAK=$(Pq -c "SELECT count(*) FROM omie_customer_account_map_fresco WHERE user_id='$U1' AND omie_codigo_vendedor=200;")
+eq "F1b o vendedor colacor_sc (200) É alcançável sem o filtro de conta (por isso o filtro tem dente)" "$LEAK" "1"
+
+# F2 — SABOTA a fonte fresca (ler a BASE em vez da view): o stale user3 (vendedor 300 podre) reaparece.
+#      Prova que é a VIEW (TTL 7d) que protege — ler a base reabriria stale infinito (Codex P1).
+STALE_NA_BASE=$(Pq -c "SELECT count(*) FROM omie_customer_account_map WHERE account='oben' AND user_id='$U3';")
+eq "F2 a BASE traz o stale (300) — a view fresca é o que o oculta; ler a base seria fail-open" "$STALE_NA_BASE" "1"
+
+# F3 — a UNIQUE(user_id, account) é o que garante ≤1 vendedor por (user, oben): tentar 2ª linha oben deve
+#      violar unique_violation (SQLSTATE 23505). É a GARANTIA da unicidade que torna o KEYSET seguro (sem
+#      empate que a fronteira de página pudesse cortar). Falsifica a premissa do invariante-4 na base.
+ERR=$(P -v VERBOSITY=verbose -c "INSERT INTO public.omie_customer_account_map (user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source) VALUES ('$U1','oben', 9999, 999, 'document');" 2>&1 || true)
+if echo "$ERR" | grep -qE "23505|uq_ocam_user_account"; then ok "F3 UNIQUE(user_id,account) impede 2ª linha oben → keyset seguro + ambiguidade impossível NA BASE (23505)"; else bad "F3 esperava unique_violation (23505/uq_ocam_user_account), veio: $ERR"; fi
+
+# F4 — prova que a UNIQUE é REAL (dropa a constraint → o insert duplicado agora PASSA → assert vira vermelho).
+#      Restaura em seguida. Isto garante que F3 tem dente (não passou por acaso).
+P -q -c "ALTER TABLE public.omie_customer_account_map DROP CONSTRAINT uq_ocam_user_account;"
+if P -q -c "INSERT INTO public.omie_customer_account_map (user_id, account, omie_codigo_cliente, omie_codigo_vendedor, source) VALUES ('$U1','oben', 9998, 998, 'document');" >/dev/null 2>&1; then
+  ok "F4 sabotagem confirmada: SEM a UNIQUE o duplicado (user1,oben) entra → keyset poderia cortar empate"
+else
+  bad "F4 falsificação fraca: o insert duplicado falhou mesmo sem a constraint"
+fi
+P -q -c "DELETE FROM public.omie_customer_account_map WHERE omie_codigo_cliente=9998; ALTER TABLE public.omie_customer_account_map ADD CONSTRAINT uq_ocam_user_account UNIQUE (user_id, account);"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -41,16 +41,24 @@ Como provar o que está **SERVIDO** nesse host (hash do index + grep nos chunks)
 
 ## Canárias de deploy (a única prova do que está SERVIDO)
 
-Grep na `main` prova a **fonte**; a canária prova o **deploy**. Chame com `?canary=1` (staff-gated) e leia `ok`:
+Grep na `main` prova a **fonte**; a canária prova o **deploy**. Chame com `?canary=1` (staff-gated). Nas canárias **VERSIONADAS** (as que têm `contrato` na tabela abaixo) exija os **TRÊS** campos — nunca só o `ok`:
 
-| edge | rota | o que a fixture discrimina |
-|---|---|---|
-| `analyze-unified-order` | Governança → Auditoria (card "Canária de preço") | praticado 123 vence Omie 999 |
-| `omie-vendas-sync` | `identidade_probe` | identidade derivada por documento |
-| `omie-analytics-sync` | `doc_ambiguo_probe` | doc ambíguo não vira vínculo |
-| `carteira-rebuild` | `?canary=1` | conflito de mapeamento **permanece** com `eligible=false` (código velho: some) |
+```text
+canary === true   E   contrato === '<marcador da fatia>'   E   ok === true
+```
 
-⚠️ **Só é canária se a resposta tiver `"canary":true`.** Um deploy anterior à canária ignora o param e roda o **fluxo real** — no `carteira-rebuild` isso é um rebuild completo (lease + 6909 upserts; idempotente e guardado, mas é escrita). Resposta sem `canary:true` = a canária não rodou **e** o deploy é velho: isso já é o veredito.
+Nas canárias ainda **não-versionadas** (`contrato` = `—`) só há `canary` + `ok`, o que **não** protege contra deploy integralmente velho (ver ⚠️ abaixo) — versioná-las é dívida aberta.
+
+| edge | rota | `contrato` esperado | o que a fixture discrimina |
+|---|---|---|---|
+| `analyze-unified-order` | Governança → Auditoria (card "Canária de preço") | — | praticado 123 vence Omie 999 |
+| `omie-vendas-sync` | `identidade_probe` | — | identidade derivada por documento |
+| `omie-analytics-sync` | `doc_ambiguo_probe` | — | doc ambíguo não vira vínculo |
+| `carteira-rebuild` | `?canary=1` | `trava-saida-v1` | conflito permanece com `eligible=false` (velho: some) **+** trava de saída do bootstrap (velho: grava ~Hunter) |
+
+⚠️ **Só é canária se a resposta tiver `"canary":true` E o `contrato` esperado.** Duas falhas distintas:
+1. Deploy ANTERIOR à canária ignora o param e roda o **fluxo real** — no `carteira-rebuild` isso é um rebuild completo (lease + upserts; idempotente e guardado, mas é escrita). Resposta sem `canary:true` = canária não rodou **e** o deploy é velho: já é o veredito.
+2. Deploy **integralmente velho** (com a canária de uma fatia anterior) carrega o `expected` VELHO junto e compara velho×velho → responde `canary:true, ok:true` e **mente verde** (Codex 2026-07-20). Por isso o **`contrato` (version marker) é obrigatório na verificação**: `ok` sozinho não discrimina reversão de fatia. Faça **bump do marcador** a cada fatia que mude o contrato da canária — senão a próxima reversão volta a passar despercebida.
 
 ⚠️ **Canária que não discrimina é teatro verde.** Se a mudança for no-op nos dados de hoje (caso do #1397: 0 conflitos em prod), a resposta do fluxo REAL é byte-idêntica com código velho ou novo — não prova deploy nenhum. A fixture tem de exercitar **o comportamento que mudou**, e o teste tem de provar que sob o comportamento ANTIGO a canária ficaria vermelha (ver `rebuild-helpers.test.ts` → "a fixture DISCRIMINA"). Sem esse assert, a canária só prova que a função responde.
 

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -841,7 +841,9 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
       'cobertura não aborta o run — membro sem row entraria como assignment antigo STALE',
     ).toMatch(/if\s*\(!cobertura\.ok\)[\s\S]{0,160}failLease\(/);
     const iCobertura = rebuild.indexOf('verificarCobertura(membroIds, rows)');
-    const iUpsert = rebuild.indexOf(".from('carteira_assignments')");
+    // ancora no UPSERT (não em qualquer acesso à tabela): a trava de saída do bootstrap também lê
+    // carteira_assignments (count omie elegível) ANTES daqui, e um indexOf genérico casaria com ela.
+    const iUpsert = rebuild.indexOf(".from('carteira_assignments').upsert(");
     expect(iCobertura, 'âncora: não achei a chamada de verificarCobertura').toBeGreaterThan(-1);
     expect(iUpsert, 'âncora: não achei o upsert de carteira_assignments').toBeGreaterThan(-1);
     expect(iCobertura, 'a cobertura é verificada DEPOIS do upsert — inútil: o stale já foi gravado').toBeLessThan(iUpsert);
@@ -897,6 +899,58 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
     expect(rebuild, 'guard pós não filtra por eligible — conta inelegíveis (#3)').toMatch(/r\.source === 'omie' && r\.eligible/);
     expect(rebuild, 'sumiu a leitura de count (proof crua + carteira atual)').toContain("count: 'exact'");
   });
+  it('hardening: BOOTSTRAP trava a SAÍDA vs a carteira atual — presente, alimentada e com escape (Codex R4)', () => {
+    // O furo R4: o >0 sozinho gravava carteira ~Hunter no bootstrap (perda de vendedor grande / flaggeds em massa
+    // / corrupção de 1 código). Agora o guard recebe omieAtual (count omie elegível da carteira) + forcado; o ramo
+    // bootstrap aborta se a carteira omie elegível encolher < 80% da atual, salvo &force=1.
+    expect(
+      rebuild,
+      'REGRESSÃO: o guard pós não recebe mais omieAtual+forcado — bootstrap voltaria a gravar só com >0 (furo R4)',
+    ).toMatch(/avaliarGuardResultado\(\{[\s\S]{0,160}omieAtual,\s*forcado\s*\}\)/);
+    expect(
+      rebuild,
+      'REGRESSÃO: sumiu a leitura da carteira atual (count omie elegível) — denominador da trava fica vazio',
+    ).toMatch(/from\('carteira_assignments'\)[\s\S]{0,120}\.eq\('source', 'omie'\)[\s\S]{0,60}\.eq\('eligible', true\)/);
+    expect(
+      rebuild,
+      'REGRESSÃO: a leitura da carteira atual não é mais condicional a autorizado — I/O inerte + fail-closed espúrio no cron (Codex R4b P2-6a)',
+    ).toMatch(/if \(autorizado\) \{[\s\S]{0,240}from\('carteira_assignments'\)/);
+    expect(
+      rebuild,
+      'REGRESSÃO: o flag &force=1 não é lido/gated — reset legítimo perderia o escape (ou staff comum forçaria)',
+    ).toMatch(/forcado = params\.get\('force'\) === '1' && via/);
+    // o guard de cobertura da FONTE foi REMOVIDO (media a coisa errada — Codex R4 rejeitou): não pode reaparecer.
+    expect(rebuild, 'avaliarGuardCobertura voltou ao edge — mede a fonte, não a saída (Codex R4)').not.toContain('avaliarGuardCobertura');
+    expect(rebuildHelper, 'avaliarGuardCobertura voltou ao helper de src/').not.toContain('avaliarGuardCobertura');
+  });
+  it('HIGH-WATER: o baseline é persistido ANTES do upsert e de forma FATAL (Codex R6 P1 — erosão por persistência falha)', () => {
+    // A ordem antiga (carteira → baseline não-fatal) perdia o high-water quando a gravação falhava: o run
+    // seguinte lia a carteira DEGRADADA como omieAtual e deixava cair mais 20% sem force (2747→2198→1759).
+    const iBaseline = rebuild.indexOf("key: 'carteira_omie_baseline'");
+    const iUpsert = rebuild.indexOf(".from('carteira_assignments').upsert(");
+    expect(iBaseline, 'âncora: não achei a persistência do baseline').toBeGreaterThan(-1);
+    expect(iUpsert, 'âncora: não achei o upsert da carteira').toBeGreaterThan(-1);
+    expect(iBaseline, 'REGRESSÃO: o baseline voltou a ser persistido DEPOIS do upsert — erosão por falha de persistência reabre').toBeLessThan(iUpsert);
+    expect(
+      rebuild,
+      'REGRESSÃO: a falha ao persistir o baseline voltou a ser não-fatal (console.warn) — sem high-water, o próximo run eroderia',
+    ).not.toMatch(/falha ao persistir baseline \(nao-fatal\)/);
+    expect(
+      rebuild,
+      'a falha de persistência do baseline não aborta via failLease',
+    ).toMatch(/persistir baseline: \$\{bErr\.message\}/);
+    // Guardrail (Codex R8 P3): com o high-water gravado ANTES do upsert, um run que falha JÁ moveu a
+    // referência — a resposta de erro precisa dizer isso, senão o operador não sabe que o baseline subiu.
+    expect(
+      rebuild,
+      'a resposta de erro do upsert parcial não reporta baseline_persisted — run falho move a referência em silêncio',
+    ).toMatch(/baseline_persisted: guardPos\.novoBaseline/);
+    expect(
+      rebuild,
+      'a resposta de erro não reporta baseline_anterior — sem o par, não dá p/ ver que a referência mudou',
+    ).toMatch(/baseline_anterior: baselinePersistido/);
+  });
+
   it('guard comparativo vem ANTES do upsert da carteira (não movido p/ depois — P2 Codex)', () => {
     const iGuard = rebuild.indexOf('avaliarGuardResultado({');
     const iUpsert = rebuild.indexOf("from('carteira_assignments').upsert(");
@@ -906,14 +960,24 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
   });
   it('baseline persistido + bootstrap flag presentes E USADOS (Codex R2-R3)', () => {
     expect(rebuild, 'sumiu a leitura do baseline persistido').toContain("'carteira_omie_baseline'");
-    expect(rebuild, 'guard não recebe baselinePersistido + autorizado').toMatch(/avaliarGuardResultado\(\{[\s\S]{0,120}baselinePersistido,\s*autorizado\s*\}/);
-    expect(rebuild, 'flag de bootstrap não vem do query param').toMatch(/searchParams\.get\('bootstrap'\)/);
+    expect(rebuild, 'guard não recebe baselinePersistido + autorizado').toMatch(/avaliarGuardResultado\(\{[\s\S]{0,140}baselinePersistido,\s*autorizado,\s*omieAtual/);
+    expect(rebuild, 'params não vem do query string da request').toMatch(/params = new URL\(req\.url\)\.searchParams/);
+    expect(rebuild, 'flag de bootstrap não é lida do query param').toMatch(/params\.get\('bootstrap'\) === '1'/);
     expect(rebuild, 'baseline não é PERSISTIDO após o upsert (catraca volta)').toMatch(/upsert\(\{\s*key: 'carteira_omie_baseline'/);
     // R3 #2: a flag é gated em service_role/cron (não staff comum — employee comprometido não força bootstrap)
     expect(rebuild, 'flag de bootstrap não é gated por auth.via').toMatch(/auth\.via === 'service_role'/);
     // R3 P2: o baseline lido é VALIDADO (corrompido → aborta, não vira valor inseguro)
     expect(rebuild, 'baseline lido não é validado (parseBaselineSaudavel)').toContain('parseBaselineSaudavel(');
     expect(rebuild, 'baseline corrompido não aborta').toMatch(/baselinePersistido === null/);
+  });
+
+  it('hardening: owner account-safe — omie_vendedor_map filtrado por omie_account=oben', () => {
+    // omie_vendedor_map É por-conta (o MESMO vendedor tem código distinto em oben/colacor/colacor_sc).
+    // Como o código do cliente vem da proof oben, o mapa código→owner tem de ser oben também.
+    expect(
+      rebuild,
+      'REGRESSÃO: o mapa código→owner voltou a ler TODAS as contas — código colidente mapearia owner não-oben',
+    ).toMatch(/from\(['"]omie_vendedor_map['"]\)[\s\S]{0,120}\.eq\(['"]omie_account['"],\s*['"]oben['"]\)/);
   });
 
   it('PARIDADE: as funções de load espelhadas são IDÊNTICAS ao src/ (pega reversão do Lovable)', () => {
@@ -931,9 +995,15 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
       expect(bloco, 'sumiu a canária ?canary=1 — sem ela não há prova do DEPLOY, só da fonte').not.toBe('');
     });
 
-    it('roda o helper REAL (computeCarteira + verificarCobertura), não uma reimplementação', () => {
+    it('roda o helper REAL (computeCarteira + verificarCobertura + avaliarGuardResultado), não uma reimplementação', () => {
       expect(bloco, 'canária não chama computeCarteira — não provaria o helper deployado').toContain('computeCarteira(');
       expect(bloco, 'canária não chama verificarCobertura').toContain('verificarCobertura(');
+      // Codex R5 P2: sem exercitar o guard, um deploy VELHO (sem omieAtual/forcado) roda computeCarteira e
+      // verificarCobertura igual → canária verde apesar da trava de saída ter sumido no deploy.
+      expect(
+        bloco,
+        'canária não exercita avaliarGuardResultado — não discrimina um deploy sem a trava de saída do bootstrap',
+      ).toContain('avaliarGuardResultado(');
     });
 
     it('o `expected` casa a verdade-base provada em rebuild-helpers.test.ts (senão a canária mente verde)', () => {
@@ -942,6 +1012,29 @@ describe('guardrail money-path: carteira-rebuild lê o vendedor da PROOF oben (P
       expect(bloco).toMatch(/conflitadoEligible: false/);
       expect(bloco).toMatch(/conflitadoCodigo: 222/);
       expect(bloco).toMatch(/coberturaOk: true/);
+      // trava de saída do bootstrap: aborta sem force, passa com force, e o baseline herda o MAIOR dos três.
+      expect(bloco, 'expected não cobre o abort sem force').toMatch(/guardSemForceAborta: true/);
+      expect(bloco, 'expected não cobre o escape com &force=1').toMatch(/guardComForcePassa: true/);
+      expect(bloco, 'expected não cobre o baseline herdando o atual (erosão acumulada)').toMatch(/guardBaselineHerdaAtual: 2747/);
+    });
+
+    it('a canária expõe o VERSION MARKER `contrato` E o guia manda o verificador exigir esse VALOR (Codex R6/R7 P2)', () => {
+      expect(
+        bloco,
+        'sumiu o marcador `contrato` — um deploy integralmente velho responderia ok:true e a canária não discriminaria',
+      ).toMatch(/contrato: 'trava-saida-v1'/);
+      // O marcador só fecha o furo se o CONSUMIDOR exigir o valor. Sem isto, o produtor emite e o
+      // procedimento documentado segue aceitando `ok` sozinho — foi exatamente o que o Codex R7 bloqueou.
+      // Matchers ANCORADOS (Codex R8 P3): um `toContain` solto aceitaria o valor em qualquer trecho do doc.
+      const deployDoc = read('docs/agent/deploy.md');
+      expect(
+        deployDoc,
+        'o guia não instrui a exigir o PREDICADO COMPLETO (canary === true E contrato === ... E ok === true)',
+      ).toMatch(/canary === true\s+E\s+contrato === '<marcador da fatia>'\s+E\s+ok === true/);
+      expect(
+        deployDoc,
+        'a LINHA da tabela do carteira-rebuild não fixa o contrato trava-saida-v1 — o verificador não sabe o valor esperado',
+      ).toMatch(/\|\s*`carteira-rebuild`\s*\|[^|]*\|\s*`trava-saida-v1`\s*\|/);
     });
 
     it('a fixture tem o CONFLITO (código 222 → 2 vendedores) — é o que discrimina velho×novo', () => {

--- a/src/lib/carteira/__tests__/rebuild-helpers.test.ts
+++ b/src/lib/carteira/__tests__/rebuild-helpers.test.ts
@@ -282,46 +282,100 @@ describe('avaliarGuardProof (fail-closed pré-compute: proof oben anômala → a
   });
 });
 
-describe('avaliarGuardResultado (guard vs BASELINE PERSISTIDO — Codex R3: fecha baseline=0 && atual>0)', () => {
+describe('avaliarGuardResultado — CRON vs baseline persistido (R3) + BOOTSTRAP trava de saída vs carteira atual (R4)', () => {
+  // CRON = não-autorizado. omieAtual/forcado são inertes no ramo cron (não são lidos), mas o tipo os exige.
+  const cron = (omieElegivelNovo: number, baselinePersistido: number) =>
+    avaliarGuardResultado({ omieElegivelNovo, baselinePersistido, autorizado: false, omieAtual: 0, forcado: false });
+
   it('0 omie ELEGÍVEL → aborta sempre (carteira 100% Hunter nunca é gravada)', () => {
-    const r = avaliarGuardResultado({ omieElegivelNovo: 0, baselinePersistido: 5000, autorizado: false });
+    const r = cron(0, 5000);
     expect(r.abortar).toBe(true);
     expect(r.motivo).toMatch(/hunter|elegiv/i);
   });
-  it('BOOTSTRAP (baseline persistido=0) SEM autorização → aborta INDEPENDENTE da carteira atual (#1 R3)', () => {
-    // o buraco fechado: persistência do baseline falhou (=0) mas a carteira atual tem N>0 → NÃO reabre catraca.
-    const r = avaliarGuardResultado({ omieElegivelNovo: 100, baselinePersistido: 0, autorizado: false });
+  it('CRON: bootstrap (baseline persistido=0) sem autorização → aborta INDEPENDENTE da carteira (#1 R3)', () => {
+    const r = cron(100, 0);
     expect(r.abortar).toBe(true);
     expect(r.motivo).toMatch(/bootstrap|autoriza/i);
   });
-  it('BOOTSTRAP autorizado (flag explícito) → grava e define o baseline pelo novo', () => {
-    const r = avaliarGuardResultado({ omieElegivelNovo: 4200, baselinePersistido: 0, autorizado: true });
-    expect(r.abortar).toBe(false);
-    expect(r.novoBaseline).toBe(4200);
-  });
-  it('catraca BLOQUEADA: compara com o baseline persistido (não a carteira atual) — 2399 < 80% de 4797 aborta', () => {
-    const r = avaliarGuardResultado({ omieElegivelNovo: 2399, baselinePersistido: 4797, autorizado: false });
+  it('CRON: catraca vs baseline persistido — 2399 < 80% de 4797 aborta (não a carteira atual)', () => {
+    const r = cron(2399, 4797);
     expect(r.abortar).toBe(true);
     expect(r.motivo).toMatch(/regress|baseline|80%/i);
   });
-  it('catraca 2º passo: o baseline persistido segue 4797 → 1200 também aborta (sem degradação em série)', () => {
-    expect(avaliarGuardResultado({ omieElegivelNovo: 1200, baselinePersistido: 4797, autorizado: false }).abortar).toBe(true);
+  it('CRON: baseline persistido segue 4797 → 1200 também aborta (sem degradação em série)', () => {
+    expect(cron(1200, 4797).abortar).toBe(true);
   });
-  it('regime normal saudável (novo ≥ 80% do baseline) → não aborta; baseline sobe (recorde)', () => {
-    const r = avaliarGuardResultado({ omieElegivelNovo: 5000, baselinePersistido: 4797, autorizado: false });
+  it('CRON: regime saudável (≥80% do baseline) → não aborta; baseline sobe (recorde)', () => {
+    const r = cron(5000, 4797);
     expect(r.abortar).toBe(false);
     expect(r.novoBaseline).toBe(5000);
   });
-  it('flutuação dentro de 20% → não aborta; baseline NÃO desce (max — evita catraca)', () => {
-    const r = avaliarGuardResultado({ omieElegivelNovo: 4600, baselinePersistido: 4797, autorizado: false });
+  it('CRON: flutuação dentro de 20% → não aborta; baseline NÃO desce (max — evita catraca)', () => {
+    const r = cron(4600, 4797);
     expect(r.abortar).toBe(false);
     expect(r.novoBaseline).toBe(4797);
   });
-  it('queda legítima grande → só passa com autorização explícita (reset do baseline)', () => {
-    expect(avaliarGuardResultado({ omieElegivelNovo: 3000, baselinePersistido: 4797, autorizado: false }).abortar).toBe(true);
-    const comAuth = avaliarGuardResultado({ omieElegivelNovo: 3000, baselinePersistido: 4797, autorizado: true });
-    expect(comAuth.abortar).toBe(false);
-    expect(comAuth.novoBaseline).toBe(3000);
+
+  // ── BOOTSTRAP (autorizado) — trava de SAÍDA vs a carteira ATUAL (Codex R4) ──
+  it('BOOTSTRAP primeira população (omieAtual=0) → grava; baseline = novo (não há saída a preservar)', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 4200, baselinePersistido: 0, autorizado: true, omieAtual: 0, forcado: false });
+    expect(r.abortar).toBe(false);
+    expect(r.novoBaseline).toBe(4200);
+  });
+  it('BOOTSTRAP saudável (não encolhe vs a carteira atual) → grava', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 2750, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: false });
+    expect(r.abortar).toBe(false);
+    expect(r.novoBaseline).toBe(2750);
+  });
+  it('BOOTSTRAP que ENCOLHERIA a carteira omie < 80% da atual → ABORTA sem force (cenário 1226: 1521 < 0,8×2747)', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 1521, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: false });
+    expect(r.abortar).toBe(true);
+    expect(r.motivo).toMatch(/encolheria|force|80%/i);
+  });
+  it('BOOTSTRAP corrupção/flaggeds (omieElegivelNovo=1) vs carteira atual cheia → ABORTA (o >0 sozinho não basta mais — furo Codex R4)', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 1, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: false });
+    expect(r.abortar).toBe(true);
+  });
+  it('BOOTSTRAP com &force=1 → grava mesmo encolhendo (reset legítimo: vendedor desligado); baseline = novo', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 1521, baselinePersistido: 4797, autorizado: true, omieAtual: 2747, forcado: true });
+    expect(r.abortar).toBe(false);
+    expect(r.novoBaseline).toBe(1521);
+  });
+  it('BOOTSTRAP com force NÃO fura o "0 omie elegível" (100% Hunter nunca grava, nem forçado)', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 0, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: true });
+    expect(r.abortar).toBe(true);
+  });
+  it('BOOTSTRAP fronteira: exatamente 80% da atual NÃO aborta; logo abaixo aborta', () => {
+    expect(avaliarGuardResultado({ omieElegivelNovo: 800, baselinePersistido: 0, autorizado: true, omieAtual: 1000, forcado: false }).abortar).toBe(false);
+    expect(avaliarGuardResultado({ omieElegivelNovo: 799, baselinePersistido: 0, autorizado: true, omieAtual: 1000, forcado: false }).abortar).toBe(true);
+  });
+  it('BOOTSTRAP não eroda o baseline (R4b): ref = max(atual, baseline) — atual 2198 < baseline 2747 → 1759 aborta', () => {
+    // sem o max, 1759 < 0,8×2198=1758,4 seria FALSE (passava e erodia o baseline p/ 1759). Com ref=max=2747: 1759 < 2197,6 → aborta.
+    const r = avaliarGuardResultado({ omieElegivelNovo: 1759, baselinePersistido: 2747, autorizado: true, omieAtual: 2198, forcado: false });
+    expect(r.abortar).toBe(true);
+  });
+  it('BOOTSTRAP primeira população TRUNCADA (omieAtual=0) mas com baseline histórico 2747 → 1 aborta (protegida pelo max)', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 1, baselinePersistido: 2747, autorizado: true, omieAtual: 0, forcado: false });
+    expect(r.abortar).toBe(true);
+  });
+  it('BOOTSTRAP &force=1 fura a ref-max (reset legítimo assume, mesmo vs baseline histórico); baseline = novo', () => {
+    const r = avaliarGuardResultado({ omieElegivelNovo: 1759, baselinePersistido: 2747, autorizado: true, omieAtual: 2198, forcado: true });
+    expect(r.abortar).toBe(false);
+    expect(r.novoBaseline).toBe(1759);
+  });
+  it('BOOTSTRAP sem force é MONOTÔNICO: novo 2198 ≥ 80% de 2747 passa MAS o baseline NÃO desce (Codex R4c)', () => {
+    // O furo: sem baseline monotônico, gravar 2198 baixava o baseline p/ 2198, e o próximo bootstrap desceria
+    // p/ 1759 (erosão em etapas de 20% sem force). Com o max no novoBaseline, força é o ÚNICO jeito de baixar.
+    const r = avaliarGuardResultado({ omieElegivelNovo: 2198, baselinePersistido: 2747, autorizado: true, omieAtual: 2747, forcado: false });
+    expect(r.abortar).toBe(false);       // 2198 ≥ 0,8×2747=2197,6 → passa
+    expect(r.novoBaseline).toBe(2747);   // monotônico: NÃO desce sem force
+  });
+  it('BOOTSTRAP com baseline DESATUALIZADO (0) e carteira real 2747 → persiste 2747, não 2198 (Codex R5)', () => {
+    // O furo R5: max(baseline=0, novo=2198) persistia 2198 e ESQUECIA os 2747 da carteira real; o run seguinte
+    // compararia com 2198 e deixaria cair p/ 1759 — erosão acumulada de 36% SEM force. O omieAtual no max mata.
+    const r = avaliarGuardResultado({ omieElegivelNovo: 2198, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: false });
+    expect(r.abortar).toBe(false);       // 2198 ≥ 0,8×max(2747,0)=2197,6 → passa
+    expect(r.novoBaseline).toBe(2747);   // persiste o MAIOR dos três (o atual), não o novo
   });
 });
 

--- a/src/lib/carteira/rebuild-helpers.ts
+++ b/src/lib/carteira/rebuild-helpers.ts
@@ -188,10 +188,13 @@ export function computeCarteira(
 //   • montarClientes: merge LISTA×VENDEDOR preservando a ordem do espelho (clone ausente da proof → null).
 //   • avaliarGuardProof (PRÉ-compute): aborta se proof oben fresca vazia / < 50% da proof CRUA (denominador
 //     é a própria proof, não o espelho misto — corrige o falso-positivo #4) / 0 vendedores não-null.
-//   • avaliarGuardResultado (PÓS-compute): aborta se 0 omie ELEGÍVEL (#3); BLOQUEIA o bootstrap quando o
-//     BASELINE PERSISTIDO é 0 sem flag — INDEPENDENTE da carteira atual (Codex R3: se a persistência falha,
-//     o baseline segue 0 → o cron fica fail-closed); compara SÓ com o baseline persistido (fator 0.8, monotônico
-//     → sem catraca). Retorna o novoBaseline a gravar.
+//   • avaliarGuardResultado (PÓS-compute): aborta se 0 omie ELEGÍVEL. CRON (não-autorizado): compara
+//     omieElegivelNovo SÓ com o BASELINE PERSISTIDO (fator 0.8, monotônico → sem catraca; a carteira atual fica
+//     FORA — Codex R3: se a persistência do baseline falha (0), o cron fica fail-closed). BOOTSTRAP (autorizado):
+//     mede a SAÍDA vs max(carteira ATUAL omie elegível, baseline persistido) — encolher < 80% exige &force=1
+//     (R4b: o max impede erodir o baseline em etapas quando atual<baseline). Fecha o furo Codex R4 (o >0 sozinho
+//     gravava ~Hunter na perda de vendedor grande / flaggeds-consolidação em massa / corrupção de 1 código). A
+//     carteira atual entra SÓ no ramo autorizado → não reabre a catraca do cron. Retorna o novoBaseline.
 //   • parseBaselineSaudavel: valida o baseline lido do company_config (decimal canônico ≤ 2^53); inválido → null
 //     (o edge ABORTA em vez de virar valor inseguro — "4797lixo"→null, "1e9"→null, gigante→null).
 // MIRROR-START carteira-load — espelhado verbatim em supabase/functions/carteira-rebuild/index.ts
@@ -278,12 +281,29 @@ export function avaliarGuardProof(m: { proofCrua: number; proofFresca: number; c
   }
   return { abortar: false, motivo: null };
 }
-export function avaliarGuardResultado(m: { omieElegivelNovo: number; baselinePersistido: number; autorizado: boolean }): { abortar: boolean; motivo: string | null; novoBaseline: number } {
+export function avaliarGuardResultado(m: { omieElegivelNovo: number; baselinePersistido: number; autorizado: boolean; omieAtual: number; forcado: boolean }): { abortar: boolean; motivo: string | null; novoBaseline: number } {
   if (m.omieElegivelNovo === 0) {
     return { abortar: true, motivo: '0 assignments omie elegiveis (carteira 100% Hunter) — abortado p/ preservar', novoBaseline: m.baselinePersistido };
   }
   if (m.autorizado) {
-    return { abortar: false, motivo: null, novoBaseline: m.omieElegivelNovo };
+    // BOOTSTRAP mede a SAIDA (omieElegivelNovo POS consolidacao/conflitos/flaggeds), nao a fonte (Codex R4 P1.1-3):
+    // o >0 sozinho gravaria carteira ~Hunter se o vendedor_map dessincronizasse (perda de um vendedor grande),
+    // flaggeds/consolidacao em massa destruissem a saida, OU corrupcao deixasse so 1 codigo valido. Trava vs a
+    // REFERENCIA = max(carteira ATUAL omie elegivel, baseline persistido): o MAIOR sinal saudavel (Codex R4b P2:
+    // usar so a atual permitia erodir o baseline em etapas quando atual<baseline; com o max, &force=1 vira o UNICO
+    // jeito de baixar o baseline, e a primeira populacao TRUNCADA com baseline>0 fica protegida). Encolher < 80%
+    // da ref exige &force=1. A ref entra SO neste ramo autorizado -> NAO reabre a catraca do cron (so-baseline, R3).
+    // Primeira populacao SEM historico (ref=0): so o >0 protege (carteira nascendo; operador confere os contadores).
+    const ref = Math.max(m.omieAtual, m.baselinePersistido);
+    if (!m.forcado && ref > 0 && m.omieElegivelNovo < 0.8 * ref) {
+      return { abortar: true, motivo: `bootstrap encolheria omie elegivel p/ ${m.omieElegivelNovo} (< 80% de ${ref} = max[atual ${m.omieAtual}, baseline ${m.baselinePersistido}]) — investigue vendedor_map/proof ou &force=1 se a queda e legitima`, novoBaseline: m.baselinePersistido };
+    }
+    // Sem force o baseline persiste MONOTONICO sobre as TRES grandezas (atual, baseline, novo) — nunca desce.
+    // O omieAtual PRECISA entrar no max (Codex R5 P1): com baseline DESATUALIZADO (0) e carteira real 2747, um
+    // max(baseline, novo) persistiria 2198 e ESQUECERIA os 2747 — o run seguinte compararia com 2198 e deixaria
+    // cair p/ 1759 (erosao acumulada de 36% sem force). Incluindo o atual, o baseline vira 2747 e o 2º passo
+    // aborta. COM force o reset legitimo assume a queda e grava o novo valor (o UNICO jeito de baixar).
+    return { abortar: false, motivo: null, novoBaseline: m.forcado ? m.omieElegivelNovo : Math.max(m.omieAtual, m.baselinePersistido, m.omieElegivelNovo) };
   }
   if (m.baselinePersistido === 0) {
     return { abortar: true, motivo: 'bootstrap (baseline persistido=0) exige autorizacao explicita — cron nao faz bootstrap', novoBaseline: 0 };

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -237,12 +237,29 @@ function avaliarGuardProof(m: { proofCrua: number; proofFresca: number; comVende
   }
   return { abortar: false, motivo: null };
 }
-function avaliarGuardResultado(m: { omieElegivelNovo: number; baselinePersistido: number; autorizado: boolean }): { abortar: boolean; motivo: string | null; novoBaseline: number } {
+function avaliarGuardResultado(m: { omieElegivelNovo: number; baselinePersistido: number; autorizado: boolean; omieAtual: number; forcado: boolean }): { abortar: boolean; motivo: string | null; novoBaseline: number } {
   if (m.omieElegivelNovo === 0) {
     return { abortar: true, motivo: '0 assignments omie elegiveis (carteira 100% Hunter) — abortado p/ preservar', novoBaseline: m.baselinePersistido };
   }
   if (m.autorizado) {
-    return { abortar: false, motivo: null, novoBaseline: m.omieElegivelNovo };
+    // BOOTSTRAP mede a SAIDA (omieElegivelNovo POS consolidacao/conflitos/flaggeds), nao a fonte (Codex R4 P1.1-3):
+    // o >0 sozinho gravaria carteira ~Hunter se o vendedor_map dessincronizasse (perda de um vendedor grande),
+    // flaggeds/consolidacao em massa destruissem a saida, OU corrupcao deixasse so 1 codigo valido. Trava vs a
+    // REFERENCIA = max(carteira ATUAL omie elegivel, baseline persistido): o MAIOR sinal saudavel (Codex R4b P2:
+    // usar so a atual permitia erodir o baseline em etapas quando atual<baseline; com o max, &force=1 vira o UNICO
+    // jeito de baixar o baseline, e a primeira populacao TRUNCADA com baseline>0 fica protegida). Encolher < 80%
+    // da ref exige &force=1. A ref entra SO neste ramo autorizado -> NAO reabre a catraca do cron (so-baseline, R3).
+    // Primeira populacao SEM historico (ref=0): so o >0 protege (carteira nascendo; operador confere os contadores).
+    const ref = Math.max(m.omieAtual, m.baselinePersistido);
+    if (!m.forcado && ref > 0 && m.omieElegivelNovo < 0.8 * ref) {
+      return { abortar: true, motivo: `bootstrap encolheria omie elegivel p/ ${m.omieElegivelNovo} (< 80% de ${ref} = max[atual ${m.omieAtual}, baseline ${m.baselinePersistido}]) — investigue vendedor_map/proof ou &force=1 se a queda e legitima`, novoBaseline: m.baselinePersistido };
+    }
+    // Sem force o baseline persiste MONOTONICO sobre as TRES grandezas (atual, baseline, novo) — nunca desce.
+    // O omieAtual PRECISA entrar no max (Codex R5 P1): com baseline DESATUALIZADO (0) e carteira real 2747, um
+    // max(baseline, novo) persistiria 2198 e ESQUECERIA os 2747 — o run seguinte compararia com 2198 e deixaria
+    // cair p/ 1759 (erosao acumulada de 36% sem force). Incluindo o atual, o baseline vira 2747 e o 2º passo
+    // aborta. COM force o reset legitimo assume a queda e grava o novo valor (o UNICO jeito de baixar).
+    return { abortar: false, motivo: null, novoBaseline: m.forcado ? m.omieElegivelNovo : Math.max(m.omieAtual, m.baselinePersistido, m.omieElegivelNovo) };
   }
   if (m.baselinePersistido === 0) {
     return { abortar: true, motivo: 'bootstrap (baseline persistido=0) exige autorizacao explicita — cron nao faz bootstrap', novoBaseline: 0 };
@@ -301,6 +318,14 @@ Deno.serve(async (req) => {
     const out = computeCarteira(clientesFix, mapFix, HUNTER_FIX);
     const conflitado = out.assignments.find((a) => a.customer_user_id === membrosFix[1]) ?? null;
     const cobertura = verificarCobertura(membrosFix, out.assignments);
+    // Fixture da TRAVA DE SAÍDA do bootstrap (Codex R5 P2): sem isto a canária NÃO discrimina esta fatia —
+    // um deploy velho roda computeCarteira/verificarCobertura igual e passa verde. Em runtime o código velho
+    // ignora os campos extras (omieAtual/forcado) e cai no `return {novoBaseline: omieElegivelNovo}` — o que
+    // faz as 3 asserções abaixo divergirem. (a) bootstrap encolhendo < 80% da ref ABORTA sem force; (b) com
+    // &force=1 passa (reset legítimo); (c) o baseline herda o MAIOR dos três — fecha a erosão acumulada.
+    const gSemForce = avaliarGuardResultado({ omieElegivelNovo: 1521, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: false });
+    const gComForce = avaliarGuardResultado({ omieElegivelNovo: 1521, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: true });
+    const gBaseline = avaliarGuardResultado({ omieElegivelNovo: 2198, baselinePersistido: 0, autorizado: true, omieAtual: 2747, forcado: false });
     const resolved = {
       membroConflitadoPresente: conflitado !== null,
       conflitadoSource: conflitado?.source ?? null,
@@ -308,6 +333,9 @@ Deno.serve(async (req) => {
       conflitadoCodigo: conflitado?.omie_codigo_vendedor ?? null,
       conflictsRegistrados: out.conflicts.length,
       coberturaOk: cobertura.ok,
+      guardSemForceAborta: gSemForce.abortar,
+      guardComForcePassa: !gComForce.abortar,
+      guardBaselineHerdaAtual: gBaseline.novoBaseline,
     };
     const expected = {
       membroConflitadoPresente: true,
@@ -316,13 +344,20 @@ Deno.serve(async (req) => {
       conflitadoCodigo: 222,
       conflictsRegistrados: 1,
       coberturaOk: true,
+      guardSemForceAborta: true,
+      guardComForcePassa: true,
+      guardBaselineHerdaAtual: 2747,
     };
     const ok = (Object.keys(expected) as Array<keyof typeof expected>)
       .every((k) => resolved[k] === expected[k]);
     if (!ok) {
       console.error('[carteira-rebuild] CANÁRIA VERMELHA — deploy servido diverge do repo:', JSON.stringify({ resolved, expected }));
     }
-    return new Response(JSON.stringify({ canary: true, ok, resolved, expected }), {
+    // `contrato` é o VERSION MARKER (Codex R6 P2): sem ele, um deploy INTEGRALMENTE velho compara o `expected`
+    // velho com o `resolved` velho e responde ok:true — a canária mente verde e não discrimina nada. Ler só o
+    // `ok` é insuficiente: o verificador tem de exigir TAMBÉM `contrato === 'trava-saida-v1'`. Bump obrigatório
+    // a cada fatia que mude o contrato da canária (senão a próxima reversão volta a passar despercebida).
+    return new Response(JSON.stringify({ canary: true, contrato: 'trava-saida-v1', ok, resolved, expected }), {
       status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }
@@ -330,8 +365,13 @@ Deno.serve(async (req) => {
   // Flag de bootstrap: ?bootstrap=1 autoriza gravar quando não há baseline saudável (ou resetá-lo numa queda
   // legítima grande). Gated em service_role/cron-secret — NÃO staff comum (Codex R3 #2: employee comprometido
   // não força bootstrap destrutivo). O cron ROTINEIRO chama sem o param → nunca faz bootstrap nem destrava a catraca.
-  const autorizado = new URL(req.url).searchParams.get('bootstrap') === '1'
-    && (auth.via === 'service_role' || auth.via === 'cron');
+  const params = new URL(req.url).searchParams;
+  const via = auth.via === 'service_role' || auth.via === 'cron';
+  const autorizado = params.get('bootstrap') === '1' && via;
+  // &force=1 (mesmo gate service_role/cron): assume uma QUEDA LEGÍTIMA grande no bootstrap (ex.: vendedor
+  // desligado) — pula a trava de saída vs max(carteira atual, baseline) e é o ÚNICO jeito de BAIXAR o baseline
+  // (Codex R4/R4b/R4c). Sem force, o bootstrap aborta se a carteira omie elegível fosse encolher < 80% da ref.
+  const forcado = params.get('force') === '1' && via;
 
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
@@ -486,12 +526,23 @@ Deno.serve(async (req) => {
   }
 
   // Denominador do guard de frescor = proof oben CRUA (sem TTL), não o espelho misto (#4 Codex): isola a
-  // degradação por TTL/sync. A carteira ATUAL NÃO entra no guard (Codex R3 #1: o comparativo é SÓ vs o baseline
-  // persistido — senão baseline=0 && atual>0, após uma persistência falha, reabriria a catraca).
+  // degradação por TTL/sync. No CRON a carteira ATUAL fica FORA do guard (Codex R3 #1: o comparativo é SÓ vs o
+  // baseline persistido — senão baseline=0 && atual>0, após uma persistência falha, reabriria a catraca).
   const { count: proofCruaRaw, error: cruaErr } = await supabase
     .from('omie_customer_account_map').select('*', { count: 'exact', head: true }).eq('account', 'oben').not('user_id', 'is', null);
   if (cruaErr) { console.error('[carteira-rebuild] count proof crua error:', cruaErr.message); return await failLease(`proof crua: ${cruaErr.message}`); }
   const proofCrua = proofCruaRaw ?? 0;
+
+  // Carteira ATUAL (omie elegível) lida SÓ no BOOTSTRAP: a trava de saída (Codex R4) só a usa no ramo
+  // autorizado; no cron seria I/O inerte + um motivo fail-closed espúrio (R4b P2-6a). Não-bootstrap →
+  // omieAtual=0 e a ref da trava cai p/ o baseline persistido, coerente com o cron (que já é só-baseline).
+  let omieAtual = 0;
+  if (autorizado) {
+    const { count: omieAtualRaw, error: atualErr } = await supabase
+      .from('carteira_assignments').select('*', { count: 'exact', head: true }).eq('source', 'omie').eq('eligible', true);
+    if (atualErr) { console.error('[carteira-rebuild] count carteira atual error:', atualErr.message); return await failLease(`carteira atual: ${atualErr.message}`); }
+    omieAtual = omieAtualRaw ?? 0;
+  }
 
   // Guard PRÉ-compute fail-closed: proof oben anômala → aborta ANTES de qualquer upsert (senão a carteira
   // zeraria p/ Hunter silenciosamente). Análogo ao guard de vendedor_map vazio (:155).
@@ -558,8 +609,24 @@ Deno.serve(async (req) => {
   // PERSISTIDO é 0 sem ?bootstrap=1 — INDEPENDENTE da carteira atual (R3 #1); compara SÓ com o baseline persistido
   // (fator 0.8, monotônico → sem catraca). Nunca grava carteira integralmente órfã.
   const omieElegivelNovo = rows.filter((r) => r.source === 'omie' && r.eligible).length;
-  const guardPos = avaliarGuardResultado({ omieElegivelNovo, baselinePersistido, autorizado });
+  const guardPos = avaliarGuardResultado({ omieElegivelNovo, baselinePersistido, autorizado, omieAtual, forcado });
   if (guardPos.abortar) { console.error('[carteira-rebuild] guard resultado:', guardPos.motivo); return await failLease(`guard resultado: ${guardPos.motivo}`); }
+
+  // 2e. HIGH-WATER MARK persistido ANTES do upsert e FATAL se falhar (Codex R6 P1). A ordem é invertida de
+  // propósito: gravar a carteira primeiro e o baseline depois (não-fatal, como era) PERDIA o conhecimento do
+  // maior valor quando a persistência falhava — o run seguinte já lia a carteira DEGRADADA como omieAtual e
+  // deixava cair mais 20% sem force (erosão acumulada 2747→2198→1759, −36%). Persistir antes é seguro mesmo se
+  // o upsert falhar depois: o high-water é sobre o que JÁ foi observado (omieAtual) + o que vai ser gravado
+  // (novo), então um upsert falho deixa a carteira no estado ANTERIOR, que a referência já cobre — e o run
+  // seguinte compara com ela (fail-closed). Sem force o baseline nunca desce; com force, o reset é deliberado.
+  if (guardPos.novoBaseline !== baselinePersistido) {
+    const { error: bErr } = await supabase.from('company_config')
+      .upsert({ key: 'carteira_omie_baseline', value: String(guardPos.novoBaseline) }, { onConflict: 'key' });
+    if (bErr) {
+      console.error('[carteira-rebuild] persistir baseline FALHOU — abortando ANTES do upsert (sem high-water, o próximo run erodiria):', bErr.message);
+      return await failLease(`persistir baseline: ${bErr.message}`);
+    }
+  }
 
   // 3. Upsert idempotente.
 
@@ -590,6 +657,10 @@ Deno.serve(async (req) => {
         ok: false, error: chunkErr.message, runId,
         upserted_confirmed: upserted,                                  // só os chunks que retornaram sucesso
         current_chunk_commit: commitDesconhecido ? 'unknown' : 'no',
+        // O run falho JÁ moveu a referência (2e persiste o high-water ANTES do upsert). Reportar explícito,
+        // senão o operador não sabe que o baseline subiu num run que não completou (Codex R7, observabilidade).
+        baseline_persisted: guardPos.novoBaseline,
+        baseline_anterior: baselinePersistido,
         writes_committed: upserted > 0 || commitDesconhecido,          // honesto: transporte pode ter escrito
         partial: upserted > 0 || commitDesconhecido,
       };
@@ -605,13 +676,7 @@ Deno.serve(async (req) => {
 
   if (conflicts.length) console.warn('[carteira-rebuild] conflitos de mapeamento:', JSON.stringify(conflicts));
 
-  // Persiste o baseline saudável (sobe com recorde; reset só via ?bootstrap=1). Protege os próximos rebuilds
-  // do cron contra catraca. Falha aqui é NÃO-fatal (a carteira já foi gravada) e mantém o cron fail-closed.
-  if (guardPos.novoBaseline !== baselinePersistido) {
-    const { error: bErr } = await supabase.from('company_config')
-      .upsert({ key: 'carteira_omie_baseline', value: String(guardPos.novoBaseline) }, { onConflict: 'key' });
-    if (bErr) console.warn('[carteira-rebuild] falha ao persistir baseline (nao-fatal):', bErr.message);
-  }
+  // (o baseline saudável já foi persistido em 2e, ANTES do upsert e de forma FATAL — Codex R6 P1)
 
   // Finalize honesto do lease. 'ownership' e 'transport' são DISTINTOS (Codex #3):
   const finalize = await releaseLease('complete');
@@ -636,8 +701,8 @@ Deno.serve(async (req) => {
   }
 
   return new Response(JSON.stringify({
-    ok: true, upserted, orphanCount, omieElegivelNovo, comVendedor,
+    ok: true, upserted, orphanCount, omieElegivelNovo, comVendedor, omieAtual,
     proofFresca: proofOben.size, proofCrua, baselinePersistido, novoBaseline: guardPos.novoBaseline,
-    autorizado, via: auth.via, conflicts, hunterUserId, aliasesAtivos: aliasMap.size, runId,
+    autorizado, forcado, via: auth.via, conflicts, hunterUserId, aliasesAtivos: aliasMap.size, runId,
   }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
 });


### PR DESCRIPTION
## O que muda

No **bootstrap** (`?bootstrap=1`), o guard pós-compute do `carteira-rebuild` só exigia `omieElegivelNovo > 0`
— uma carteira ~100% Hunter podia ser gravada (comissão errada e silenciosa) se o `omie_vendedor_map`
dessincronizasse da proof, se quarantine/flaggeds destruíssem a saída, ou se a corrupção deixasse 1 código
válido. Agora o bootstrap mede a **saída** (pós-consolidação/conflitos/flaggeds) contra
`max(carteira atual omie elegível, baseline persistido)` e aborta se encolher < 80%, salvo `&force=1`
(mesmo gate `service_role`/cron). O high-water passa a ser persistido **antes** do upsert e de forma **fatal**.

## Por quê — 10 rodadas de Codex, 6 furos reais

| # | Furo | Correção |
|---|---|---|
| R4 | A 1ª tentativa media a **cobertura da fonte** (proof × map, pré-consolidação). Ângulo errado: perder um vendedor grande reduz numerador E denominador juntos (1226 clientes → cobertura 55%, passa qualquer piso) | passou a medir a **saída** |
| R4b | `max` na trava mas `novoBaseline` gravava o menor | baseline monotônico |
| R4c | erosão em etapas de 20% | confirmada morta por execução do helper |
| R5 | `max` do `novoBaseline` esquecia `omieAtual`: baseline desatualizado (0) + carteira real 2747 persistia 2198 → **−36% acumulado sem force** | `max` das **três** grandezas |
| R5 | canária retornava **antes** do guard → deploy revertido pelo Lovable passava verde | fixture exercita o guard |
| R6 | carteira gravava **antes** do baseline, com falha **não-fatal** → high-water se perdia e o run seguinte erodia | persistir **antes** do upsert, **fatal** |
| R7 | `contrato` existia no produtor mas o **consumidor** não exigia | `deploy.md` exige os 3 campos |

## Design final

- **CRON** (não-autorizado): inalterado — vs baseline PERSISTIDO (0.8, sem catraca; carteira atual FORA, R3).
  A leitura da carteira atual nem roda no cron (condicional a `autorizado`).
- **BOOTSTRAP** (autorizado): saída vs `max(omieAtual, baselinePersistido)`; < 80% aborta salvo `&force=1`,
  que é o **único** jeito de baixar a referência. A ref entra SÓ no ramo autorizado → não reabre a catraca do cron.
- `omieElegivelNovo === 0` aborta antes de tudo (nem `force` grava carteira 100% Hunter).
- **High-water antes do upsert, fatal**: se o upsert falhar depois, a carteira fica no estado anterior — que a
  referência já cobre (fail-closed). A resposta de erro reporta `baseline_persisted`/`baseline_anterior`.

## Canária versionada

`?canary=1` agora devolve `contrato: 'trava-saida-v1'` e exercita o guard (aborta sem force · passa com force ·
baseline herda o atual). Sem o marcador, um deploy **integralmente velho** compara `expected` velho com
`resolved` velho e responde `ok:true` — mentindo verde. `docs/agent/deploy.md` passou a exigir os três campos.

## Provas

- Harness PG17 `db/test-carteira-vendedor-oben-account-safe.sh`: **10/10** (account-safe + keyset, com falsificação)
- `bunx vitest run`: **228/228** · `bunx tsc --noEmit -p tsconfig.app.json`: **exit 0** · `bun lint`: **0 errors**
- Codex (gpt-5.6-sol, 10 rodadas): **LIBERADO**, com os 3 P3 finais aplicados
- P1 condicional (keyset da proof) fechado por evidência psql-ro: `user_id` único sob `account=oben`
  (5238/5238, 0 duplicado, `UNIQUE(user_id,account)`)

## Deploy (edge — MANUAL, Lovable)

Após o merge, deploy pelo chat do Lovable **verbatim**. Sem migration, sem Publish.

**Pré-flight** (lição do #1443 — deploy sobe o arquivo INTEIRO da main, não só este diff):
```bash
grep -rhoE "\.rpc\('[a-z_]+'" supabase/functions/carteira-rebuild/ | sed "s/.*rpc('//;s/'//" | sort -u
# cada uma: ~/.config/afiacao/psql-ro -c "select 1 from pg_proc where proname='<rpc>';"
```

**Verificação pós-deploy** — exigir os **três**, não só o `ok`:
```
GET .../carteira-rebuild?canary=1  →  canary:true  E  contrato:'trava-saida-v1'  E  ok:true
```

## Observação registrada (fora deste PR)

A leitura da proof usa offset `.range` sob view com TTL 7d: se uma linha expirar entre páginas, o offset
desloca e pula um cliente (→ Hunter). Risco baixo, mas real — merece ciclo próprio (keyset + prova + Codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
