### PR TITLE
fix(farmer): margem ausente para de virar 0/25 no plano tático [money-path]

### DIFF
--- a/src/lib/tactical/__tests__/pregeracao.test.ts
+++ b/src/lib/tactical/__tests__/pregeracao.test.ts
@@ -10,10 +10,24 @@ describe('profitPerHora', () => {
     // (500 * 20% * 0.1) / 0.25 = 10 / 0.25 = 40
     expect(profitPerHora({ revenuePotential: 0, avgSpend: 500, marginPct: 20 })).toBeCloseTo(40);
   });
+
+  // ── ausente ≠ zero (money-path princípio 2) ────────────────────────────────
+  it('margem DESCONHECIDA (null) → null, não 0', () => {
+    // Number(null) === 0 fabricaria "R$ 0/h", que é um veredito de negócio
+    // (cliente não-lucrativo) e não "não sei calcular".
+    expect(profitPerHora({ revenuePotential: 1000, avgSpend: 50, marginPct: null })).toBeNull();
+  });
+  it('margem não-finita (NaN/Infinity) → null', () => {
+    expect(profitPerHora({ revenuePotential: 1000, avgSpend: 50, marginPct: NaN })).toBeNull();
+    expect(profitPerHora({ revenuePotential: 1000, avgSpend: 50, marginPct: Infinity })).toBeNull();
+  });
+  it('margem 0 CONHECIDA continua sendo 0 (é um fato, não uma ausência)', () => {
+    expect(profitPerHora({ revenuePotential: 1000, avgSpend: 50, marginPct: 0 })).toBe(0);
+  });
 });
 
 describe('selecionarParaPregeracao', () => {
-  const base = (id: string, priority: number, rev: number, m: number) =>
+  const base = (id: string, priority: number, rev: number, m: number | null) =>
     ({ customerUserId: id, priorityScore: priority, revenuePotential: rev, avgSpend: 0, marginPct: m });
 
   it('ordena por priority desc, filtra pelo gate, corta no topN', () => {
@@ -23,13 +37,13 @@ describe('selecionarParaPregeracao', () => {
       base('c', 70, 2000, 25), // pph (2000*25%*0.1)/0.25 = 200 ✓
       base('d', 95, 5000, 40), // pph 800 ✓
     ];
-    const sel = selecionarParaPregeracao(scores, 2);
-    expect(sel.map((s) => s.customerUserId)).toEqual(['d', 'a']); // top-2 por priority, ambos passam o gate
+    const { selecionados } = selecionarParaPregeracao(scores, 2);
+    expect(selecionados.map((s) => s.customerUserId)).toEqual(['d', 'a']); // top-2 por priority, ambos passam o gate
   });
 
   it('pula quem está abaixo do gate mesmo com priority alta', () => {
-    const sel = selecionarParaPregeracao([base('b', 99, 100, 10)], 25);
-    expect(sel).toEqual([]);
+    const { selecionados } = selecionarParaPregeracao([base('b', 99, 100, 10)], 25);
+    expect(selecionados).toEqual([]);
   });
 
   it('filtra o gate ANTES de cortar topN: mantém menor-priority elegível quando o de maior priority falha o gate', () => {
@@ -40,8 +54,8 @@ describe('selecionarParaPregeracao', () => {
       base('b', 80, 2000, 25), // pph 200 ✓
       base('c', 70, 1000, 30), // pph 120 ✓
     ];
-    const sel = selecionarParaPregeracao(scores, 2);
-    expect(sel.map((s) => s.customerUserId)).toEqual(['b', 'c']);
+    const { selecionados } = selecionarParaPregeracao(scores, 2);
+    expect(selecionados.map((s) => s.customerUserId)).toEqual(['b', 'c']);
   });
 
   it('não muta o array de entrada', () => {
@@ -53,5 +67,28 @@ describe('selecionarParaPregeracao', () => {
 
   it('threshold exposto é 50 R$/h', () => {
     expect(PROFIT_PER_HOUR_THRESHOLD).toBe(50);
+  });
+
+  // ── ausente ≠ zero: o indecidível é SEPARADO do reprovado ──────────────────
+  it('margem desconhecida NÃO entra em selecionados — o gate não é decidível', () => {
+    const { selecionados } = selecionarParaPregeracao([base('x', 99, 100000, null)], 25);
+    expect(selecionados).toEqual([]);
+  });
+
+  it('margem desconhecida é CONTABILIZADA em semMargem, não silenciada', () => {
+    // "no silent caps" (money-path): quem sai do ranking por falta de dado tem de ser
+    // contável, senão o batch reporta "cobri todo mundo" sem ter coberto.
+    const scores = [base('conhecido', 90, 1000, 30), base('ausente', 95, 1000, null)];
+    const { selecionados, semMargem } = selecionarParaPregeracao(scores, 25);
+    expect(selecionados.map((s) => s.customerUserId)).toEqual(['conhecido']);
+    expect(semMargem.map((s) => s.customerUserId)).toEqual(['ausente']);
+  });
+
+  it('distingue reprovado-no-gate de indecidível: margem 0 conhecida NÃO é semMargem', () => {
+    // O ponto da correção: hoje ambos os casos viram "0" e são indistinguíveis.
+    const scores = [base('margem-zero-real', 90, 1000, 0), base('margem-ausente', 80, 1000, null)];
+    const { selecionados, semMargem } = selecionarParaPregeracao(scores, 25);
+    expect(selecionados).toEqual([]); // nenhum dos dois gera plano...
+    expect(semMargem.map((s) => s.customerUserId)).toEqual(['margem-ausente']); // ...mas por motivos DIFERENTES
   });
 });

--- a/src/lib/tactical/pregeracao.ts
+++ b/src/lib/tactical/pregeracao.ts
@@ -1,6 +1,7 @@
 /** Pré-geração noturna do plano tático: gate de eficiência + seleção dos prioritários.
- *  Oráculo puro — a edge tactical-plans-batch (Deno) replica esta lógica inline
- *  (front e edge não compartilham módulo; este helper é a fonte da verdade testada). */
+ *  Oráculo puro — a edge tactical-plans-batch (Deno) replica esta lógica via
+ *  supabase/functions/_shared/tactical-margem.ts (front e edge não compartilham módulo;
+ *  este helper é a fonte da verdade testada). */
 export const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h — espelha useTacticalPlan.ts:198
 const AVG_CALL_MINUTES = 15;
 
@@ -9,26 +10,47 @@ export interface ScoreParaSelecao {
   priorityScore: number;
   revenuePotential: number;
   avgSpend: number;
-  marginPct: number;
+  /** null = margem DESCONHECIDA. Não confundir com 0, que é margem nula CONHECIDA. */
+  marginPct: number | null;
 }
 
-/** R$/h estimado por ligação. Espelha useTacticalPlan.checkEfficiency (linhas 313-318). */
+/** Margem utilizável, ou null se desconhecida/não-finita (money-path: ausente ≠ zero). */
+function margemConhecida(raw: number | null | undefined): number | null {
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** R$/h estimado por ligação. Espelha useTacticalPlan.checkEfficiency (linhas 313-318).
+ *  Margem desconhecida → `null` ("não sei"), NUNCA 0 (que significaria "cliente não-lucrativo"). */
 export function profitPerHora(
   s: Pick<ScoreParaSelecao, 'revenuePotential' | 'avgSpend' | 'marginPct'>,
-): number {
+): number | null {
+  const margem = margemConhecida(s.marginPct);
+  if (margem == null) return null;
   const base = s.revenuePotential > 0 ? s.revenuePotential : s.avgSpend;
-  const marginPerCall = base * (s.marginPct / 100) * 0.1;
+  const marginPerCall = base * (margem / 100) * 0.1;
   return marginPerCall / (AVG_CALL_MINUTES / 60);
 }
 
 /** Top-N por priorityScore desc, filtrando quem passa no gate de R$/h.
- *  Filtra ANTES de cortar: retorna os N de maior priority DENTRE OS ELEGÍVEIS. */
+ *  Filtra ANTES de cortar: retorna os N de maior priority DENTRE OS ELEGÍVEIS.
+ *
+ *  Quem tem margem desconhecida sai em `semMargem`, NÃO em `selecionados`: o gate não é
+ *  decidível sem margem, e tratá-lo como reprovado o confundiria com um cliente de margem
+ *  genuinamente ruim. `semMargem` existe para o chamador CONTABILIZAR o descarte — corte
+ *  silencioso leria como "cobri todo mundo" sem ter coberto (money-path: no silent caps). */
 export function selecionarParaPregeracao(
   scores: ScoreParaSelecao[],
   topN: number,
-): ScoreParaSelecao[] {
-  return [...scores]
-    .sort((a, b) => b.priorityScore - a.priorityScore)
-    .filter((s) => profitPerHora(s) >= PROFIT_PER_HOUR_THRESHOLD)
+): { selecionados: ScoreParaSelecao[]; semMargem: ScoreParaSelecao[] } {
+  const ordenados = [...scores].sort((a, b) => b.priorityScore - a.priorityScore);
+  const semMargem = ordenados.filter((s) => margemConhecida(s.marginPct) == null);
+  const selecionados = ordenados
+    .filter((s) => {
+      const pph = profitPerHora(s);
+      return pph != null && pph >= PROFIT_PER_HOUR_THRESHOLD;
+    })
     .slice(0, topN);
+  return { selecionados, semMargem };
 }

--- a/supabase/functions/_shared/tactical-margem.ts
+++ b/supabase/functions/_shared/tactical-margem.ts
@@ -1,0 +1,119 @@
+// Margem no plano tático: gate de R$/h, cluster de comparação e objetivo estratégico.
+//
+// ESPELHO dos oráculos vitest do front (Deno não importa de src/) — mudou aqui, mude lá:
+//   src/lib/tactical/pregeracao.ts        → profitPerHora · selecionarParaPregeracao
+//   src/lib/scoring/objective.ts          → selectObjective
+//   src/hooks/useTacticalPlan.ts:404-418  → calcularClusterMargin
+//
+// PRINCÍPIO (money-path, "ausente ≠ zero"): margem desconhecida degrada para `null` e o
+// consumidor EXCLUI o cliente do cálculo. Nunca 0 (que significa "cliente não-lucrativo",
+// um veredito de negócio) nem um número médio fabricado (que vira régua invisível).
+// Mesma semântica que src/lib/scoring/margin.ts aplica a SKU sem custo (#1466/#1468).
+
+export const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h — espelha src/lib/tactical/pregeracao.ts
+const AVG_CALL_MINUTES = 15;
+
+/** Margem utilizável, ou null se desconhecida/não-finita.
+ *  ⚠️ `0` é CONHECIDO (margem nula real); só null/undefined/NaN/Infinity são ausência. */
+export function margemConhecida(raw: unknown): number | null {
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** R$/h estimado por ligação. Margem desconhecida → `null` ("não sei"), nunca 0. */
+export function profitPerHora(rev: number, avg: number, marginPct: unknown): number | null {
+  const margem = margemConhecida(marginPct);
+  if (margem == null) return null;
+  const baseRev = rev > 0 ? rev : avg;
+  // 10% do GMV como proxy de margem operacional; visita ~15 min → 4 visitas/h.
+  return (baseRev * (margem / 100) * 0.1) / (AVG_CALL_MINUTES / 60);
+}
+
+export interface LinhaSelecao {
+  customer: string;
+  priority: number;
+  rev: number;
+  avg: number;
+  marginPct: number | null;
+}
+
+/** Top-N por priority desc DENTRE os que passam no gate de R$/h (filtra ANTES de cortar).
+ *
+ *  Margem desconhecida sai em `semMargem`, não em `selecionados`: sem margem o gate não é
+ *  decidível, e reprovar por omissão confundiria "não sei" com "cliente ruim". O chamador
+ *  DEVE reportar `semMargem` — corte silencioso leria como "cobri todo mundo" sem ter
+ *  coberto (money-path: no silent caps). */
+export function selecionarParaPregeracao(
+  scores: LinhaSelecao[],
+  topN: number,
+): { selecionados: LinhaSelecao[]; semMargem: LinhaSelecao[] } {
+  const ordenados = [...scores].sort((a, b) => b.priority - a.priority);
+  const semMargem = ordenados.filter((s) => margemConhecida(s.marginPct) == null);
+  const selecionados = ordenados
+    .filter((s) => {
+      const pph = profitPerHora(s.rev, s.avg, s.marginPct);
+      return pph != null && pph >= PROFIT_PER_HOUR_THRESHOLD;
+    })
+    .slice(0, topN);
+  return { selecionados, semMargem };
+}
+
+/** Margem média dos PARES da carteira, contando SÓ quem tem margem conhecida.
+ *  Nenhum par com margem → `null`. NUNCA um default fabricado: este número é a RÉGUA
+ *  contra a qual a margem do cliente é julgada (`marginPct < cluster * 0.8`), então um
+ *  cluster inventado produz um veredito inventado — e plausível o bastante para passar. */
+export function calcularClusterMargin(
+  peers: Array<{ gross_margin_pct?: unknown }> | null | undefined,
+): number | null {
+  const margens = (peers ?? [])
+    .map((p) => margemConhecida(p.gross_margin_pct))
+    .filter((m): m is number => m != null);
+  if (margens.length === 0) return null;
+  return margens.reduce((s, m) => s + m, 0) / margens.length;
+}
+
+/** Perfil comercial do cliente — espelho de useTacticalPlan.ts:187 (classifyProfile).
+ *
+ *  Os dois primeiros ramos dependem da margem e só disparam com margem CONHECIDA.
+ *  ⚠️ Sem esse guard a coerção do JS fabricaria diagnóstico: `null < 20` é `true`
+ *  (null coage a 0), então todo cliente de gasto baixo e margem desconhecida seria
+ *  rotulado "sensível a preço" — e esse rótulo entra no prompt da IA e molda a
+ *  abordagem que a vendedora leva para a rua. */
+export function classifyProfile(
+  healthScore: number,
+  avgSpend: number,
+  marginPct: number | null,
+  categoryCount: number,
+): string {
+  const m = margemConhecida(marginPct);
+  if (m != null && avgSpend < 500 && m < 20) return 'sensivel_preco';
+  if (m != null && m > 35 && categoryCount <= 3) return 'orientado_qualidade';
+  if (avgSpend > 2000 && categoryCount >= 4 && healthScore > 60) return 'orientado_produtividade';
+  return 'misto';
+}
+
+/** Objetivo estratégico — espelho de src/lib/scoring/objective.ts.
+ *  Regras em ORDEM (a primeira que casa vence); ver o oráculo para o porquê de cada fronteira.
+ *
+ *  Divergência DELIBERADA do oráculo: aqui `marginPct` também aceita null (o front recebe o
+ *  valor já numerizado). Sem a margem do cliente a regra de consolidação é indecidível —
+ *  não se afirma "margem baixa vs. pares" sem saber a margem. */
+export function selectObjective(
+  churnRisk: number,
+  mixGap: number,
+  marginPct: number | null,
+  clusterMargin: number | null,
+  daysSince: number,
+  recencyCapDays: number,
+  salesHistoryStatus: string | null = null,
+): string {
+  if (salesHistoryStatus === 'sem_historico') return 'ativacao';
+  if (daysSince >= recencyCapDays) return 'reativacao';
+  if (churnRisk > 60) return 'recuperacao';
+  if (mixGap > 3) return 'expansao_mix';
+  const m = margemConhecida(marginPct);
+  const c = margemConhecida(clusterMargin);
+  if (m != null && c != null && m < c * 0.8) return 'consolidacao_margem';
+  return 'upsell_premium';
+}

--- a/supabase/functions/_shared/tactical-margem_test.ts
+++ b/supabase/functions/_shared/tactical-margem_test.ts
@@ -1,0 +1,185 @@
+// Testa o CÓDIGO REAL de tactical-margem.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/tactical-margem_test.ts
+//
+// Espelha os oráculos vitest do front:
+//   src/lib/tactical/pregeracao.ts        (gate de R$/h + seleção top-N)
+//   src/lib/scoring/objective.ts          (selectObjective)
+//   src/hooks/useTacticalPlan.ts:404-418  (cluster = média dos PARES com margem conhecida)
+import {
+  calcularClusterMargin,
+  classifyProfile,
+  margemConhecida,
+  profitPerHora,
+  PROFIT_PER_HOUR_THRESHOLD,
+  selecionarParaPregeracao,
+  selectObjective,
+} from "./tactical-margem.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+function assertClose(a: number | null, b: number, msg?: string) {
+  if (a == null || Math.abs(a - b) > 1e-9) {
+    throw new Error(msg ?? `assertClose falhou: ${a} !== ${b}`);
+  }
+}
+
+// ── margemConhecida: a fronteira ausente/conhecido ────────────────────────────
+Deno.test("margemConhecida: null/undefined → null", () => {
+  assertEquals(margemConhecida(null), null);
+  assertEquals(margemConhecida(undefined), null);
+});
+
+Deno.test("margemConhecida: 0 é CONHECIDO (fato), não ausente", () => {
+  assertEquals(margemConhecida(0), 0);
+});
+
+Deno.test("margemConhecida: NaN/Infinity → null (não-finito não é fato)", () => {
+  assertEquals(margemConhecida(NaN), null);
+  assertEquals(margemConhecida(Infinity), null);
+});
+
+// ── profitPerHora: o gate de R$/h ────────────────────────────────────────────
+Deno.test("profitPerHora: paridade numérica com o oráculo vitest", () => {
+  // (1000 * 30% * 0.1) / (15/60) = 120
+  assertClose(profitPerHora(1000, 50, 30), 120);
+  // revenue 0 → cai pra avgSpend: (500 * 20% * 0.1) / 0.25 = 40
+  assertClose(profitPerHora(0, 500, 20), 40);
+});
+
+Deno.test("profitPerHora: margem DESCONHECIDA → null, não 0", () => {
+  // Number(null) === 0 fabricaria "R$ 0/h" — veredito de negócio, não "não sei".
+  assertEquals(profitPerHora(1000, 50, null), null);
+});
+
+Deno.test("profitPerHora: margem 0 conhecida → 0 (reprova o gate por MÉRITO)", () => {
+  assertEquals(profitPerHora(1000, 50, 0), 0);
+});
+
+// ── selecionarParaPregeracao: indecidível ≠ reprovado ────────────────────────
+const linha = (id: string, priority: number, rev: number, m: number | null) => ({
+  customer: id,
+  priority,
+  rev,
+  avg: 0,
+  marginPct: m,
+});
+
+Deno.test("selecao: ordena por priority desc, filtra o gate ANTES de cortar topN", () => {
+  const scores = [
+    linha("a", 90, 100, 10), // pph 4 ✗
+    linha("b", 80, 2000, 25), // pph 200 ✓
+    linha("c", 70, 1000, 30), // pph 120 ✓
+  ];
+  const { selecionados } = selecionarParaPregeracao(scores, 2);
+  assertEquals(selecionados.map((s) => s.customer), ["b", "c"]);
+});
+
+Deno.test("selecao: margem desconhecida NÃO entra em selecionados", () => {
+  const { selecionados } = selecionarParaPregeracao([linha("x", 99, 100000, null)], 25);
+  assertEquals(selecionados.length, 0);
+});
+
+Deno.test("selecao: margem desconhecida é CONTABILIZADA em semMargem (no silent caps)", () => {
+  const scores = [linha("conhecido", 90, 1000, 30), linha("ausente", 95, 1000, null)];
+  const { selecionados, semMargem } = selecionarParaPregeracao(scores, 25);
+  assertEquals(selecionados.map((s) => s.customer), ["conhecido"]);
+  assertEquals(semMargem.map((s) => s.customer), ["ausente"]);
+});
+
+Deno.test("selecao: margem 0 conhecida reprova o gate mas NÃO é semMargem", () => {
+  // O ponto da correção: hoje ambos viram "0" e ficam indistinguíveis.
+  const scores = [linha("zero-real", 90, 1000, 0), linha("ausente", 80, 1000, null)];
+  const { selecionados, semMargem } = selecionarParaPregeracao(scores, 25);
+  assertEquals(selecionados.length, 0);
+  assertEquals(semMargem.map((s) => s.customer), ["ausente"]);
+});
+
+Deno.test("selecao: threshold é 50 R$/h (paridade com o front)", () => {
+  assertEquals(PROFIT_PER_HOUR_THRESHOLD, 50);
+});
+
+// ── calcularClusterMargin: o baseline de comparação ──────────────────────────
+Deno.test("cluster: média SÓ dos pares com margem conhecida", () => {
+  const peers = [{ gross_margin_pct: 20 }, { gross_margin_pct: 40 }];
+  assertClose(calcularClusterMargin(peers), 30);
+});
+
+Deno.test("cluster: pares SEM margem são EXCLUÍDOS, não contados como 0", () => {
+  // Com 20, 40 e um ausente: média dos conhecidos = 30. Contar o ausente como 0
+  // daria 20 e rebaixaria o baseline — margem fabricada virando régua.
+  const peers = [{ gross_margin_pct: 20 }, { gross_margin_pct: 40 }, { gross_margin_pct: null }];
+  assertClose(calcularClusterMargin(peers), 30);
+});
+
+Deno.test("cluster: NENHUM par com margem → null (NUNCA o 25 mágico)", () => {
+  assertEquals(calcularClusterMargin([{ gross_margin_pct: null }]), null);
+});
+
+Deno.test("cluster: carteira vazia → null", () => {
+  assertEquals(calcularClusterMargin([]), null);
+  assertEquals(calcularClusterMargin(null), null);
+});
+
+Deno.test("cluster: pares com margem 0 CONHECIDA contam (média 0, e é um fato)", () => {
+  assertClose(calcularClusterMargin([{ gross_margin_pct: 0 }, { gross_margin_pct: 0 }]), 0);
+});
+
+// ── selectObjective: espelho do oráculo, com o guard de ausência ─────────────
+Deno.test("objective: sem_historico PRECEDE tudo", () => {
+  assertEquals(selectObjective(99, 9, 5, 50, 999, 180, "sem_historico"), "ativacao");
+});
+
+Deno.test("objective: dormência >= teto → reativacao", () => {
+  assertEquals(selectObjective(10, 0, 30, 40, 180, 180, null), "reativacao");
+});
+
+Deno.test("objective: churn > 60 → recuperacao", () => {
+  assertEquals(selectObjective(61, 0, 30, 40, 10, 180, null), "recuperacao");
+});
+
+Deno.test("objective: mixGap > 3 → expansao_mix", () => {
+  assertEquals(selectObjective(10, 4, 30, 40, 10, 180, null), "expansao_mix");
+});
+
+Deno.test("objective: margem abaixo de 80% do cluster → consolidacao_margem", () => {
+  // 30 < 40*0.8 = 32 ✓
+  assertEquals(selectObjective(10, 0, 30, 40, 10, 180, null), "consolidacao_margem");
+});
+
+Deno.test("objective: cluster AUSENTE → NÃO dispara consolidacao_margem", () => {
+  // Era aqui que o 25 mágico agia: com cluster=25, margem 15 < 20 empurrava
+  // consolidacao_margem a esmo, sem nenhum par real para comparar.
+  assertEquals(selectObjective(10, 0, 15, null, 10, 180, null), "upsell_premium");
+});
+
+Deno.test("objective: margem do CLIENTE ausente → NÃO dispara consolidacao_margem", () => {
+  // Não se afirma "margem baixa vs. pares" sem saber a margem do cliente.
+  assertEquals(selectObjective(10, 0, null, 40, 10, 180, null), "upsell_premium");
+});
+
+// ── classifyProfile: os dois ramos que dependem de margem ───────────────────
+Deno.test("profile: paridade com o oráculo quando a margem é CONHECIDA", () => {
+  assertEquals(classifyProfile(50, 400, 10, 5), "sensivel_preco");
+  assertEquals(classifyProfile(50, 1000, 40, 3), "orientado_qualidade");
+  assertEquals(classifyProfile(70, 3000, 25, 5), "orientado_produtividade");
+  assertEquals(classifyProfile(50, 1000, 25, 5), "misto");
+});
+
+Deno.test("profile: margem AUSENTE não vira 'sensivel_preco' (null < 20 é true em JS!)", () => {
+  // A armadilha: `null < 20` coage a `0 < 20` → true. Sem guard, todo cliente de gasto
+  // baixo e margem desconhecida seria rotulado "sensível a preço" — um diagnóstico
+  // comercial fabricado a partir de ausência de dado.
+  assertEquals(classifyProfile(50, 400, null, 5), "misto");
+});
+
+Deno.test("profile: margem AUSENTE não vira 'orientado_qualidade'", () => {
+  assertEquals(classifyProfile(50, 1000, null, 3), "misto");
+});
+
+Deno.test("profile: margem ausente ainda permite o ramo que NÃO usa margem", () => {
+  // orientado_produtividade não depende de margem — segue decidível.
+  assertEquals(classifyProfile(70, 3000, null, 5), "orientado_produtividade");
+});

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -1,6 +1,8 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { fetchAll } from "../_shared/paginate.ts";
+import { calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -83,14 +85,35 @@ serve(async (req) => {
         return new Response(JSON.stringify({ id: existente[0].id, skipped: 'ja_gerado_hoje' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
       }
 
-      const [{ data: score }, { data: profile }, { data: bundles }, { data: allScores }, { data: objEvents }, { data: recencyCapRow }] = await Promise.all([
+      // Pares da carteira do dono para o cluster de margem. TRÊS correções vs. a versão
+      // anterior (`select('gross_margin_pct').eq('farmer_id', farmerId)`), espelhando
+      // useTacticalPlan.ts:404-418:
+      //  1. PAGINA (fetchAll): sem .range() o PostgREST capa em 1.000 SILENCIOSO e os 3
+      //     farmers em prod têm até 3.858 clientes — a régua saía de uma amostra arbitrária
+      //     de ~26% da carteira, sem sequer um .order() que a tornasse estável (#1471).
+      //  2. EXCLUI o próprio cliente (peer benchmark): comparar a margem do cliente com um
+      //     cluster que o contém puxa a régua na direção do próprio valor.
+      //  3. Falha de leitura → [] → cluster null (degradação honesta: o plano sai sem a
+      //     régua de margem, em vez de sair com uma régua truncada).
+      const peersClusterPromise = fetchAll<{ gross_margin_pct: number | null }>(
+        (from, to) => admin
+          .from('farmer_client_scores')
+          .select('gross_margin_pct')
+          .eq('farmer_id', farmerId)
+          .neq('customer_user_id', customerId)
+          .order('customer_user_id', { ascending: true }) // UNIQUE ⇒ estável entre páginas
+          .range(from, to),
+        'pares da carteira p/ cluster de margem',
+      ).catch(() => [] as Array<{ gross_margin_pct: number | null }>);
+
+      const [{ data: score }, { data: profile }, { data: bundles }, peersCluster, { data: objEvents }, { data: recencyCapRow }] = await Promise.all([
         // Opção A: 1 linha por cliente (customer_user_id único). NÃO filtrar por farmer_id —
         // score stale pós-reatribuição (dono ≠ farmerId) virava "sem_score" falso e PULAVA o
         // plano do cliente reatribuído. Espelha useTacticalPlan.checkEfficiency (admin = service role).
         admin.from('farmer_client_scores').select('*').eq('customer_user_id', customerId).maybeSingle(),
         admin.from('profiles').select('name, customer_type, cnae').eq('user_id', customerId).maybeSingle(),
         admin.from('farmer_bundle_recommendations').select('*').eq('customer_user_id', customerId).eq('farmer_id', farmerId).eq('status', 'pendente').order('lie_bundle', { ascending: false }).limit(2),
-        admin.from('farmer_client_scores').select('gross_margin_pct').eq('farmer_id', farmerId),
+        peersClusterPromise, // paginada acima; entra no mesmo Promise.all p/ não serializar
         admin.from('farmer_copilot_events').select('event_data').eq('event_type', 'suggestion').limit(20),
         // Teto de recência (hs_recency_cap_days): a fronteira reativacao/recuperacao ACOMPANHA o teto
         // do modelo, não o 90 hardcode. Ausente → clampRecencyCapDays default 180. limit(1) p/ maybeSingle
@@ -103,24 +126,32 @@ serve(async (req) => {
 
       const num = (v: unknown) => Number(v ?? 0);
       const healthScore = num(score.health_score), churnRisk = num(score.churn_risk), avgSpend = num(score.avg_monthly_spend_180d);
-      const marginPct = num(score.gross_margin_pct), categoryCount = num(score.category_count), daysSince = num(score.days_since_last_purchase);
+      const categoryCount = num(score.category_count), daysSince = num(score.days_since_last_purchase);
+      // money-path "ausente ≠ zero": margem desconhecida fica `null` e é EXCLUÍDA dos
+      // cálculos — nunca 0 (que afirmaria "cliente sem margem") nem a média fabricada.
+      const marginPct = margemConhecida(score.gross_margin_pct);
       const salesHistoryStatus = (score.sales_history_status ?? null) as string | null;
-      const clusterMargin = allScores?.length ? allScores.reduce((s: number, r: { gross_margin_pct: unknown }) => s + num(r.gross_margin_pct), 0) / allScores.length : 25;
+      // Sem par com margem conhecida → null. Era `: 25` — um número inventado que virava
+      // a régua de `marginPct < cluster * 0.8` e empurrava consolidacao_margem a esmo,
+      // plausível o bastante para não levantar suspeita. Mesma correção que o front já
+      // aplicou em objective.ts; o edge era o lado que faltava.
+      const clusterMargin = calcularClusterMargin(peersCluster);
       const mixGap = Math.max(0, 8 - categoryCount);
 
-      // classifyProfile/selectObjective — espelham useTacticalPlan.ts (classifyProfile + selectObjective, validado).
-      const customerProfile = avgSpend < 500 && marginPct < 20 ? 'sensivel_preco'
-        : marginPct > 35 && categoryCount <= 3 ? 'orientado_qualidade'
-        : avgSpend > 2000 && categoryCount >= 4 && healthScore > 60 ? 'orientado_produtividade' : 'misto';
+      // classifyProfile/selectObjective — _shared/tactical-margem.ts, espelho TESTADO de
+      // useTacticalPlan.ts + objective.ts (antes eram encadeamentos inline não-testados).
       // Fronteira reativacao/recuperacao = daysSince >= teto de recência (ponto onde o sinal de
       // recência satura em 0), NÃO o 90 mágico — espelha selectObjective (objective.ts) pós-#982.
-      // Aqui clusterMargin é SEMPRE número (fallback 25 acima), então a regra de margem dispensa o
-      // guard null que o front tem. recencyCapDays vem do config (acompanha o retuning do operador).
+      // recencyCapDays vem do config (acompanha o retuning do operador).
       // sem_historico → ativacao PRECEDE tudo (#1026): sem venda válida, nada p/ recuperar/reativar.
+      // Margem (do cliente ou do cluster) ausente → a regra de consolidacao_margem NÃO dispara:
+      // o guard null que o front já tinha e que este lado não tinha, porque o fallback 25
+      // garantia um número — fabricado.
+      const customerProfile = classifyProfile(healthScore, avgSpend, marginPct, categoryCount);
       const recencyCapDays = clampRecencyCapDays(recencyCapRow?.value);
-      const strategicObjective = salesHistoryStatus === 'sem_historico' ? 'ativacao'
-        : daysSince >= recencyCapDays ? 'reativacao' : churnRisk > 60 ? 'recuperacao'
-        : mixGap > 3 ? 'expansao_mix' : marginPct < clusterMargin * 0.8 ? 'consolidacao_margem' : 'upsell_premium';
+      const strategicObjective = selectObjective(
+        churnRisk, mixGap, marginPct, clusterMargin, daysSince, recencyCapDays, salesHistoryStatus,
+      );
 
       topBundleRow = bundles?.[0] ?? null;
       secondBundleRow = bundles?.[1] ?? null;
@@ -167,7 +198,12 @@ Retorne um JSON com:
    - "economic_response": Resposta econômica
    - "probability": 0-100
 
-IMPORTANTE: Retorne APENAS o JSON, sem markdown. Personalize com dados reais.`;
+IMPORTANTE: Retorne APENAS o JSON, sem markdown. Personalize com dados reais.
+
+DADO AUSENTE: campo com valor null (ex.: "grossMarginPct": null, "clusterAvgMargin": null) significa
+NÃO MEDIDO — não é zero nem valor baixo. NUNCA estime, preencha ou infira um número para ele, e não
+construa argumento sobre margem a partir dele. Se a margem for necessária ao ponto, diga explicitamente
+que o dado não está disponível.`;
 
     const strategicPrompt = `Você é um estrategista comercial sênior especializado em afiação de ferramentas industriais.
 
@@ -208,7 +244,13 @@ Retorne um JSON com:
 
 10. "operational_risks": Array de strings com riscos operacionais
 
-IMPORTANTE: Retorne APENAS o JSON, sem markdown. Use dados reais do cliente.`;
+IMPORTANTE: Retorne APENAS o JSON, sem markdown. Use dados reais do cliente.
+
+DADO AUSENTE: campo com valor null (ex.: "grossMarginPct": null, "clusterAvgMargin": null) significa
+NÃO MEDIDO — não é zero nem valor baixo. NUNCA estime, preencha ou infira um número para ele. Se a
+margem atual do cliente for null, retorne "expected_result" com null nos três cenários e diga em
+"approach_strategy" que a margem não está medida — projetar margem a partir de dado ausente entrega
+à vendedora um número que parece medido e não é.`;
 
     const systemPrompt = mode === 'estrategico' ? strategicPrompt : essentialPrompt;
 
@@ -295,7 +337,10 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
     // race em vez de gravar dono stale (precisão>recall). farmer_id/customer/status são do servidor.
     if (selfContained) {
       const admin = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!, { auth: { persistSession: false } });
-      const d = (body as { _derived: Record<string, number | string> })._derived;
+      // marginPct/clusterMargin podem ser null (margem desconhecida). As colunas
+      // current_margin_pct/cluster_avg_margin_pct são nullable — o plano grava "não sei"
+      // em vez de um número, e a UI mostra "—" em vez de uma margem inventada.
+      const d = (body as { _derived: Record<string, number | string | null> })._derived;
       const { data: newId, error: rpcErr } = await admin.rpc('criar_plano_tatico', {
         _customer_user_id: body.customerId,
         _expected_owner: body.farmerId,

--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -5,12 +5,17 @@
 // a pré-geração do plano tático chamando generate-tactical-plan no modo
 // self-contained. Idempotência fica na edge alvo (skipped: 'ja_gerado_hoje').
 //
-// Gate de R$/h: espelha src/lib/tactical/pregeracao.ts (oráculo testado por vitest).
+// Gate de R$/h: _shared/tactical-margem.ts (espelho testado de src/lib/tactical/pregeracao.ts).
 //   profitPerHora = ((rev > 0 ? rev : avg) * (margin / 100) * 0.1) / (15 / 60)
 //   Threshold: R$ 50/h.
 //
 // Semântica top-N: filtra o gate ANTES de cortar no TOP_25 — pega os 25 de
 // maior priority DENTRE os que passam (não os 25 de maior priority e filtra depois).
+//
+// Margem AUSENTE não é margem zero (money-path princípio 2): sem margem o gate de R$/h
+// não é decidível, então o cliente sai do ranking e é CONTADO em `sem_margem_indecidivel`.
+// Antes, `Number(null ?? 0)` fabricava R$ 0/h — indistinguível de um cliente de margem
+// genuinamente ruim, e reprovado em silêncio.
 //
 // Setup pg_cron (manual depois do merge):
 //   SELECT cron.schedule('tactical-plans-batch-nightly', '0 5 * * *',
@@ -24,15 +29,11 @@
 import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCron, corsHeaders } from '../_shared/auth.ts';
 import { fetchAll } from '../_shared/paginate.ts';
-
-// ── Gate de R$/h (espelha src/lib/tactical/pregeracao.ts) ────────────────────
-const PROFIT_PER_HOUR_THRESHOLD = 50;
-
-function profitPerHora(rev: number, avg: number, marginPct: number): number {
-  const baseRev = rev > 0 ? rev : avg;
-  // 10% do GMV como proxy de margem operacional; visita ~15 min → 4 visitas/h.
-  return (baseRev * (marginPct / 100) * 0.1) / (15 / 60);
-}
+import {
+  type LinhaSelecao,
+  margemConhecida,
+  selecionarParaPregeracao,
+} from '../_shared/tactical-margem.ts';
 
 const TOP_N = 25;
 const CONCURRENCY = 5; // cada chamada faz 1 LLM (~3-5s); 5 em paralelo ~5s/chunk
@@ -89,13 +90,7 @@ Deno.serve(async (req) => {
   // 1. Pagina farmer_client_scores e agrupa por farmer_id.
   //    A carteira já está limpa de fornecedor pela Fase 1 (classificacao).
   let mascaradosIgnorados = 0;
-  const porFarmer = new Map<string, Array<{
-    customer: string;
-    priority: number;
-    rev: number;
-    avg: number;
-    m: number;
-  }>>();
+  const porFarmer = new Map<string, LinhaSelecao[]>();
 
   for (let from = 0; ; from += 1000) {
     const { data, error } = await supabase
@@ -132,7 +127,8 @@ Deno.serve(async (req) => {
         priority: Number(r.priority_score ?? 0),
         rev: Number(r.revenue_potential ?? 0),
         avg: Number(r.avg_monthly_spend_180d ?? 0),
-        m: Number(r.gross_margin_pct ?? 0),
+        // ausente ≠ zero: `null` mantém "não sei" distinguível de "margem 0".
+        marginPct: margemConhecida(r.gross_margin_pct),
       });
       porFarmer.set(r.farmer_id, arr);
     }
@@ -143,16 +139,12 @@ Deno.serve(async (req) => {
   // 2. Por farmer: ordena por priority desc, filtra gate R$/h, corta em TOP_N.
   //    Semântica: pega os 25 de maior priority DENTRE os que passam no gate.
   const alvos: Array<{ farmer: string; customer: string }> = [];
+  let semMargemIndecidivel = 0;
 
   for (const [farmer, scores] of porFarmer) {
-    scores.sort((a, b) => b.priority - a.priority);
-    let n = 0;
-    for (const s of scores) {
-      if (n >= TOP_N) break;
-      if (profitPerHora(s.rev, s.avg, s.m) < PROFIT_PER_HOUR_THRESHOLD) continue;
-      alvos.push({ farmer, customer: s.customer });
-      n++;
-    }
+    const { selecionados, semMargem } = selecionarParaPregeracao(scores, TOP_N);
+    semMargemIndecidivel += semMargem.length;
+    for (const s of selecionados) alvos.push({ farmer, customer: s.customer });
   }
 
   // 3. Fan-out concorrente em chunks de 5. Idempotência é na edge alvo.
@@ -199,6 +191,10 @@ Deno.serve(async (req) => {
       // transparência do que foi DESCARTADO pela máscara: um corte silencioso leria como
       // "cobri todo mundo" sem ter coberto (money-path — no silent caps).
       mascarados_ignorados: mascaradosIgnorados,
+      // clientes que saíram do ranking por FALTA DE MARGEM (gate indecidível), não por
+      // reprovação no gate. Enquanto nenhum writer calcular gross_margin_pct, este número
+      // tende ao total da carteira — e é o sinal de que o batch está cego, não ocioso.
+      sem_margem_indecidivel: semMargemIndecidivel,
     }),
     { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
   );


### PR DESCRIPTION
> **DRAFT de propósito.** A medição em produção derrubou a premissa do achado original — leia o §1 antes de tirar do draft.

## 1. O que a medição mudou

O achado pedia trocar `?? 0` por `?? null`. **Isso sozinho seria inerte:**

```
farmer_client_scores.gross_margin_pct  (6.632 linhas)
  nulos: 0  |  zero_literal: 6.632  |  positivos: 0
  column_default: 0
```

Não há um único NULL na tabela — o `??` nunca dispara. A coluna tem `DEFAULT 0` e nenhum writer a calcula, então **os 6.632 zeros são o default do DDL, não um fato de negócio** (mesmo padrão do P0-A revogado em #1490: "rótulo com DEFAULT constante não é fato").

O que torna esta entrega útil é o **#1495**, que passa a gravar `NULL` para margem desconhecida (os asserts dele provam: `"N1 sem custo algum → NULL (nao 0)"`). Os dois PRs encaixam:

| | produtor | consumidores |
|---|---|---|
| **#1495** | grava NULL p/ desconhecido | — |
| **este** | — | trata NULL honestamente |

⚠️ **Sem este PR, o #1495 ATIVA o bug pela primeira vez**: hoje o `?? 0` e o `: 25` nunca disparam porque não há NULL; depois do #1495 passam a disparar de verdade.

## 2. Exposição corrente: zero (e por quê)

`farmer_tactical_plans` tem **0 linhas** — nenhum plano jamais foi gerado. O cron `tactical-plans-batch-nightly` **não está registrado** (o comentário no topo do arquivo pede setup manual que nunca aconteceu), e com margem 0 em tudo o gate de R$50/h reprova 100% da carteira.

Não é uma coincidência protetora: são duas camadas verificadas diretamente. Mas é o perfil "arma carregada" do money-path.md — no dia em que o cron for agendado **e** o #1495 landar, tudo dispara junto.

## 3. Correções

1. **`?? 0` → `margemConhecida()`** no batch. Margem ausente ⇒ gate indecidível ⇒ cliente sai do ranking e é **contado** em `sem_margem_indecidivel` (no silent caps).
2. **Fallback `: 25` removido.** Sem par com margem conhecida ⇒ `null` ⇒ `consolidacao_margem` não dispara. O front já fazia isso (`objective.ts:39` documenta a remoção do "25 mágico" e racionaliza que o edge "sempre passa número" — passa: o 25).

**Achados adicionais na mesma função, corrigidos junto** (fora do escopo pedido; sinalizo para revisão):

3. **Capa de 1.000 do PostgREST** no cluster — sem `.range()` **nem `.order()`**. Os 3 farmers em prod têm **até 3.858 clientes**, então a régua saía de ~26% da carteira em ordem indefinida (#1471, a armadilha canônica).
4. **O cluster incluía o próprio cliente** — comparar a margem com um cluster que a contém puxa a régua na direção do valor julgado. O front já excluía.
5. **`classifyProfile` com margem null** cairia em `sensivel_preco` por coerção (`null < 20` é **true** em JS). Esse rótulo entra no prompt da IA e molda a abordagem que a vendedora leva para a rua — mudar `marginPct` para nullable **sem** este guard teria introduzido um bug novo.

## 4. Prova

Helper novo `_shared/tactical-margem.ts` — espelho testado dos oráculos do front, sem import remoto (`--no-remote`).

**Falsificação** (baseline verde: `27 passed | 0 failed`):

| sabotagem | vermelhos | são os que ela mira? |
|---|---|---|
| volta o `25` mágico | 2 (`25 !== null`) | ✅ só os de cluster ausente |
| margem ausente → `0` | 8, nas 5 funções | ✅ toda a fronteira ausente/zero |
| tira guard do profile | 1 | ✅ exatamente o `null < 20` |

Gates: `test:edges` 181/181 · `test` 5527/5527 · `typecheck` 0 · `lint` 0 errors · `shellcheck` 0.

## 5. Achado sobre o CI (independente desta entrega)

`deno check` pegou um erro meu (`classifyProfile` faltando no import) que **todos os gates do CI deixariam passar**: `test:edges` só type-checa arquivos **importados por testes**, e nenhuma `index.ts` de edge é importada por teste. Teria quebrado em runtime, em produção, depois do deploy manual.

Vale considerar um `deno check supabase/functions/*/index.ts` no `validate`.

## 6. Deploy

Edge-only ⇒ **sem Publish, sem migration**. As 2 edges precisam de deploy manual pelo chat do Lovable (verbatim da main) — e o `docs/agent/deploy.md` alerta: conferir com `git log -S` se um "Changes" do Lovable não atropelou o arquivo antes de pedir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)