### PR TITLE
fix(analytics-sync): importação manual de pedidos cabe no timeout da edge (max_pages 10→2)

### DIFF
--- a/src/components/analyticsSync/useAnalyticsSync.ts
+++ b/src/components/analyticsSync/useAnalyticsSync.ts
@@ -263,7 +263,12 @@ export function useAnalyticsSync() {
             action: "sync_pedidos",
             account: acc.account,
             start_page: startPage,
-            max_pages: 10,
+            // 2 págs/invocação ≈ 75–110s diurno (medido no cron: 35–50s/pág) — cabe no
+            // request timeout (~150s) da edge. Com 10, janela de 180d (~70 págs oben)
+            // estourava o limite na 1ª invocação e o loop abortava (incidente 20/07/2026:
+            // não-2xx no browser + órfã running fechada pelo watchdog). O loop já retoma
+            // via nextPage, então só muda o tamanho do lote, não a cobertura.
+            max_pages: 2,
             ...(dateFrom && { date_from: dateFrom }),
             ...(dateTo && { date_to: dateTo }),
           },


### PR DESCRIPTION
## Incidente

2026-07-20 18:38 (SP): o founder clicou **"Importar Recentes (180d)"** em `/admin/analytics-sync` e a execução falhou com `Oben: Edge Function returned a non-2xx status code` (`acoes_execucoes`, acao `analytics_sync.importar_pedidos_recentes`). Diagnóstico completo via `diagnose-supabase-sync` (psql-ro, 100% read-only).

## Causa raiz (CONFIRMADA)

`runOrdersSync` invoca `omie-vendas-sync` (`sync_pedidos`, modo incremental) com **`max_pages: 10` por invocação**. Numa janela de 180 dias na Oben (~70 páginas), 10 páginas custam **~350–500s** (35–50s/página em horário comercial — medido nas runs do cron: 2 págs = 73–109s), mas o request de Edge Function é cortado em **~150s**:

- 18:38:37 clique → 18:38:41 `fin_sync_log` `running` ({oben}, triggered_by = user) → **18:41:10 (153s)** não-2xx no browser → loop aborta (Colacor nem rodou).
- O isolate morreu **sem passar pelo catch** (nenhum 500 de aplicação): a órfã `running` foi fechada pelo `fin_sync_watchdog` às 19:30:00 em ponto (`orphaned_running_timeout`).
- Contraprova: a mesma edge/action/conta completou via cron às 19:05 e 21:05 (pós-incidente); `net._http_response` 18:25–18:55 é 100% 200; **0 `order_items`** gravados na janela (sem dado sujo; idempotente por `hash_payload`).
- Histórico: essa importação de 180d **nunca completou** (única run manual anterior, 31/05: 78s, 1 página — coube no limite).

Não é transiente: reexecutar em horário comercial reproduz o erro por aritmética.

## Fix

`max_pages: 10 → 2` no `runOrdersSync` (`useAnalyticsSync.ts`): cada invocação ≈ 75–110s diurno, cabe no timeout com folga. O loop client-side **já retoma via `nextPage`** — muda o tamanho do lote, não a cobertura nem a semântica. Beneficia também o "Importar Pedidos (todos)" (mesmo `runOrdersSync`). Custo: mais invocações encadeadas (~50 para 180d, ~40–60 min de tela aberta).

Ressalva registrada em comentário: página patologicamente lenta (rate-limit Omie com retries) ainda pode estourar 150s sozinha — para backfill histórico de verdade, o caminho robusto segue sendo o modo cursor (`use_cursor` + motor cron serializado, validado no backfill Oben de jun/2026). O botão fica para reconciliação leve.

## Pós-merge (manual — Lovable)

- [ ] **Publish do frontend** no editor do Lovable (merge ≠ produção; sem edge/migration neste PR).
- [ ] Revalidação após novo clique: série de `complete` com `lastPage ≤ 2` em `fin_sync_log` (`triggered_by <> 'cron'`), sem órfãs, e `acoes_execucoes` com status ok.

## Validação

- `heavy bun run typecheck` — exit 0
- `bunx eslint src/components/analyticsSync/useAnalyticsSync.ts` — exit 0
- `heavy bunx vitest run src/components/analyticsSync` — exit 0 (testes do módulo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
