### PR TITLE
fix(authz): FU4-F fase 3 PR-A — a edge `recommend` para de devolver custo ao browser [money-path]

### DIFF
--- a/db/test-authz-custo-fu4f-fase3-recommend.sh
+++ b/db/test-authz-custo-fu4f-fase3-recommend.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # os comandos passados a `falsifica` sao strings avaliadas DEPOIS da
+#                              sabotagem: a expansao TEM de ser adiada, entao aspas simples e o
+#                              desenho, nao um descuido.
+# shellcheck disable=SC2329  # `cleanup` e invocada indiretamente, pelo `trap` (o shellcheck nao ve).
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  FU4-F fase 3 (PR-A) — prova PG17 de public.pode_ler_custo() + recommendation_log ║
+# ║   bash db/test-authz-custo-fu4f-fase3-recommend.sh > log 2>&1; echo "exit=$?"  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                       ║
+# ║                                                                               ║
+# ║  DISCIPLINA APLICADA (lições caras do repo):                                  ║
+# ║   · BASELINE PRÉ-MIGRATION do detector: provo que o farmer LÊ o log ANTES.    ║
+# ║     Sem isso, "lê 0 linhas" depois é indistinguível de "a query quebrou".     ║
+# ║   · CONTROLE POSITIVO em todo assert de negação: se ninguém lê nada, "negado" ║
+# ║     passaria como sucesso. Por isso o master TEM de ler N.                    ║
+# ║   · SET ROLE (não SET LOCAL — em autocommit vira WARNING e roda como superuser,║
+# ║     que BYPASSA RLS e deixa a zona inteira falso-verde), + guard de current_user.║
+# ║   · assert de existência por to_regprocedure, nunca comparando identity_args   ║
+# ║     com string literal (#1488: o detector que nunca dispara).                  ║
+# ║   · migration aplicada com -f, NUNCA -c com heredoc (o psql descarta o stdin   ║
+# ║     em silêncio e a falsificação passa a medir o objeto original).             ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5463}"
+SLUG="fu4f3rec"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+MIG="$REPO_ROOT/supabase/migrations/20260724130000_authz_custo_fu4f_fase3_recommend.sql"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+[ -f "$MIG" ] || { echo "migration ausente: $MIG"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -q -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK   $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 -- esperado [$3], veio [$2]"; fi; }
+
+M='11111111-1111-1111-1111-111111111111'   # master
+F='22222222-2222-2222-2222-222222222222'   # farmer      (employee + commercial_role=farmer)
+E='33333333-3333-3333-3333-333333333333'   # estrategico (employee + commercial_role=estrategico)
+
+# guard: se o SET ROLE nao pegar, TODA a zona de RLS roda como superuser (bypassa) e fica
+# falso-verde. Aborta em vez de "passar".
+as_user() {
+  local got
+  got="$(Pq -c "SET test.uid='$1'; SET ROLE authenticated; SELECT current_user;" | tail -1)"
+  [ "$got" = "authenticated" ] || { echo "ABORT: SET ROLE nao pegou (current_user=$got)"; exit 9; }
+  Pq -c "SET test.uid='$1'; SET ROLE authenticated; $2" | tail -1
+}
+
+echo "=== setup pronto (PG17 :$PORT) ==="
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — STUBS ESPELHANDO A PROD (money-path.md: "espelhe a PROD, nao o design")
+# cap_custo_ler copiada VERBATIM de pg_get_functiondef em prod (2026-07-20).
+# recommendation_log com a policy ANTIGA (cmd=ALL, master OR employee), tambem verbatim.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('customer','employee','master');
+CREATE TYPE public.commercial_role AS ENUM ('gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE public.commercial_roles (user_id uuid PRIMARY KEY, commercial_role public.commercial_role NOT NULL);
+
+CREATE FUNCTION public.has_role(_uid uuid, _role public.app_role) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public' AS $f$
+  SELECT EXISTS (SELECT 1 FROM public.user_roles ur WHERE ur.user_id=_uid AND ur.role=_role);
+$f$;
+
+CREATE FUNCTION private.cap_custo_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public' AS $f$
+  SELECT COALESCE(
+    _uid IS NOT NULL AND (
+      public.has_role(_uid,'master'::public.app_role)
+      OR (public.has_role(_uid,'employee'::public.app_role)
+          AND EXISTS (SELECT 1 FROM public.commercial_roles cr
+                       WHERE cr.user_id=_uid AND cr.commercial_role IN ('estrategico','super_admin')))
+    ), false);
+$f$;
+
+-- colunas espelhando a prod (a tabela guarda a superficie de inversao INTEIRA:
+-- unit_cost, margin, eip, score_*, weights)
+CREATE TABLE public.recommendation_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  product_id uuid,
+  recommendation_type text NOT NULL,
+  score_final numeric, score_assoc numeric, score_eip numeric, score_sim numeric, score_ctx numeric,
+  explanation_text text, explanation_key text,
+  unit_cost numeric, cost_source text, margin numeric, probability numeric, eip numeric,
+  event_type text, weights jsonb,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+ALTER TABLE public.recommendation_log ENABLE ROW LEVEL SECURITY;
+-- GRANTs espelhando a PROD, medidos com has_table_privilege (2026-07-20): anon, authenticated E
+-- service_role tem SELECT/INSERT. Stub menos permissivo que a prod inventa seguranca que nao existe
+-- (money-path.md) -- foi exatamente o que derrubou A14 na 1a rodada deste harness.
+--
+-- ⚠️ E os GRANTs FICAM como estao de proposito. Revogar INSERT de `authenticated` faria A13 passar
+-- por falta de PRIVILEGIO em vez de falta de POLICY -- e ele seguiria verde mesmo se uma policy
+-- permissiva de INSERT reaparecesse. Endurecer o gate transformaria o fiscal em tautologia (#1488).
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.recommendation_log TO anon, authenticated, service_role;
+
+-- policy ANTIGA, verbatim da prod
+CREATE POLICY "Staff can manage recommendation log" ON public.recommendation_log
+  FOR ALL USING (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('11111111-1111-1111-1111-111111111111','master'),
+  ('22222222-2222-2222-2222-222222222222','employee'),
+  ('33333333-3333-3333-3333-333333333333','employee');
+INSERT INTO public.commercial_roles(user_id, commercial_role) VALUES
+  ('22222222-2222-2222-2222-222222222222','farmer'),
+  ('33333333-3333-3333-3333-333333333333','estrategico');
+
+-- 3 linhas com custo, como o que a edge grava
+INSERT INTO public.recommendation_log(farmer_id, customer_user_id, product_id, recommendation_type, unit_cost, margin, eip, event_type)
+SELECT '22222222-2222-2222-2222-222222222222','44444444-4444-4444-4444-444444444444',
+       gen_random_uuid(),'cross_sell', 7.77, 92.23, 46.115, 'impression'
+FROM generate_series(1,3);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — BASELINE PRE-MIGRATION
+# Prova que o DETECTOR enxerga o mundo VIVO. Sem isto, "farmer le 0" depois seria
+# indistinguivel de "a query esta quebrada" (licao #1488).
+# ══════════════════════════════════════════════════════════════════════════════
+echo "=== ZONA 2: baseline PRE-migration ==="
+eq "B1 farmer LE o log hoje (o vazamento existe)"        "$(as_user "$F" "SELECT count(*) FROM public.recommendation_log;")" "3"
+eq "B2 master LE o log hoje"                             "$(as_user "$M" "SELECT count(*) FROM public.recommendation_log;")" "3"
+eq "B3 pode_ler_custo() ainda NAO existe"                "$(Pq -c "SELECT to_regprocedure('public.pode_ler_custo()') IS NULL;")" "t"
+eq "B4 farmer ESCREVE no log hoje (a policy ALL concedia)" \
+   "$(as_user "$F" "INSERT INTO public.recommendation_log(farmer_id,customer_user_id,recommendation_type) VALUES ('$F','$F','x') RETURNING 1;")" "1"
+Pq -c "DELETE FROM public.recommendation_log WHERE recommendation_type='x';" >/dev/null
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — APLICA A MIGRATION REAL (-f, nunca -c)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "=== ZONA 3: aplicando a migration real ==="
+P -q -f "$MIG" >/dev/null
+echo "  migration aplicada"
+
+# idempotencia: reaplicar tem de ser no-op, nao erro.
+# if-then-else e nao `A && B || C`: naquele padrao o C roda tambem quando B falha (SC2015).
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  ok "A0 migration e IDEMPOTENTE (2a aplicacao passa)"
+else
+  bad "A0 2a aplicacao falhou"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — public.pode_ler_custo()
+# ══════════════════════════════════════════════════════════════════════════════
+echo "=== ZONA 4: pode_ler_custo() ==="
+eq "A1 existe com assinatura EXATA (0 args, via to_regprocedure)" \
+   "$(Pq -c "SELECT to_regprocedure('public.pode_ler_custo()') IS NOT NULL;")" "t"
+eq "A2 sem parametro (o desenho anti-oraculo depende disso)" \
+   "$(Pq -c "SELECT pg_get_function_identity_arguments(to_regprocedure('public.pode_ler_custo()'));")" ""
+eq "A3 master TEM a capability"                "$(as_user "$M" "SELECT public.pode_ler_custo();")" "t"
+eq "A4 farmer NAO tem (o vazamento fecha aqui)" "$(as_user "$F" "SELECT public.pode_ler_custo();")" "f"
+eq "A5 estrategico TEM (controle positivo: nao e 'negado para todos')" \
+   "$(as_user "$E" "SELECT public.pode_ler_custo();")" "t"
+# fail-closed com auth.uid() NULL. ⚠️ ROTULO CORRIGIDO (achado do Codex): isto testa `authenticated`
+# com uid nulo, NAO literalmente o service_role. Prova a PROPRIEDADE de que a funcao depende
+# (uid ausente => false), que e a mesma que protege a chamada por service_role -- mas o rotulo
+# anterior ("e o que acontece com service_role") era mais forte que a evidencia.
+eq "A6 uid NULO -> false (fail-closed; mesma propriedade que cobre o service_role)" \
+   "$(Pq -c "SET test.uid=''; SET ROLE authenticated; SELECT public.pode_ler_custo();" | tail -1)" "f"
+
+# privilegio: anon NAO executa; authenticated executa (controle positivo)
+eq "A7 anon NAO executa"          "$(Pq -c "SELECT has_function_privilege('anon', to_regprocedure('public.pode_ler_custo()'), 'EXECUTE');")" "f"
+eq "A8 authenticated EXECUTA (sem isso a edge quebra com o assert verde)" \
+   "$(Pq -c "SELECT has_function_privilege('authenticated', to_regprocedure('public.pode_ler_custo()'), 'EXECUTE');")" "t"
+# comportamental, nao so catalogo: anon chamando levanta 42501
+eq "A9 anon chamando levanta 42501" \
+   "$(Pq -c "SET ROLE anon; DO \$\$ BEGIN PERFORM public.pode_ler_custo(); RAISE EXCEPTION 'NAO_BARROU'; EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'ok'; END \$\$; SELECT '42501';" 2>/dev/null | tail -1)" "42501"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — recommendation_log
+# ══════════════════════════════════════════════════════════════════════════════
+echo "=== ZONA 5: recommendation_log ==="
+eq "A10 farmer le 0 linhas (era 3 no baseline B1)" "$(as_user "$F" "SELECT count(*) FROM public.recommendation_log;")" "0"
+eq "A11 master SEGUE lendo 3 (controle positivo: nao quebrei a tabela)" \
+   "$(as_user "$M" "SELECT count(*) FROM public.recommendation_log;")" "3"
+eq "A12 estrategico le 3"                          "$(as_user "$E" "SELECT count(*) FROM public.recommendation_log;")" "3"
+# escrita por authenticated sumiu (a policy ALL antiga concedia -- B4 provou)
+eq "A13 farmer NAO escreve mais (42501)" \
+   "$(as_user "$F" "DO \$\$ BEGIN INSERT INTO public.recommendation_log(farmer_id,customer_user_id,recommendation_type) VALUES ('$F','$F','x'); RAISE EXCEPTION 'NAO_BARROU'; EXCEPTION WHEN insufficient_privilege THEN NULL; END \$\$; SELECT '42501';")" "42501"
+eq "A14 service_role SEGUE gravando (e o writer real da edge)" \
+   "$(Pq -c "SET ROLE service_role; INSERT INTO public.recommendation_log(farmer_id,customer_user_id,recommendation_type) VALUES ('$F','$F','svc') RETURNING 1;" | tail -1)" "1"
+Pq -c "SET ROLE service_role; DELETE FROM public.recommendation_log WHERE recommendation_type='svc';" >/dev/null
+# anon TEM grant de tabela na prod (medido) e mesmo assim le 0: quem barra e a RLS, porque nenhuma
+# policy alcanca o role. Assert com SIGNIFICADO justamente por o grant continuar presente.
+eq "A15 anon le 0 (com GRANT presente -- quem nega e a RLS, nao o privilegio)" \
+   "$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.recommendation_log;" | tail -1)" "0"
+
+echo
+echo "=== BASELINE: ${PASS} OK / ${FAIL} FAIL ==="
+[ "$FAIL" -eq 0 ] || { echo "BASELINE VERMELHO -- nao faz sentido falsificar"; exit 1; }
+BASE_PASS=$PASS
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 6 — FALSIFICACAO
+# Cada sabotagem exige o vermelho DO ASSERT QUE ELA MIRA, com contagem conferida.
+# "exit != 0" nao distingue "pegou o bug" de "o comando quebrou" -- por isso conto.
+# ══════════════════════════════════════════════════════════════════════════════
+echo
+echo "=== ZONA 6: falsificacao ==="
+falsifica() { # $1=nome  $2=sql da sabotagem  $3=assert  $4=esperado_sabotado
+  local got
+  P -q -c "$2" >/dev/null 2>&1 || { echo "  FAIL [$1] a sabotagem nem aplicou"; FAIL=$((FAIL+1)); return; }
+  got="$(eval "$3")"
+  if [ "$got" = "$4" ]; then echo "  OK   [$1] o assert FICOU VERMELHO (veio [$got], o correto seria diferente)"
+  else echo "  FAIL [$1] o assert NAO reagiu -- veio [$got], esperava a sabotagem produzir [$4]"; FAIL=$((FAIL+1)); fi
+}
+
+# S1: pode_ler_custo() sempre true -> A4 (farmer nao tem) deveria virar 't'
+falsifica "S1 pode_ler_custo := true" \
+  "CREATE OR REPLACE FUNCTION public.pode_ler_custo() RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public', pg_temp AS \$f\$ SELECT true \$f\$;" \
+  'as_user "$F" "SELECT public.pode_ler_custo();"' "t"
+P -q -f "$MIG" >/dev/null   # restaura
+
+# S2: GRANT a anon -> A7 deveria virar 't'
+falsifica "S2 GRANT EXECUTE TO anon" \
+  "GRANT EXECUTE ON FUNCTION public.pode_ler_custo() TO anon;" \
+  'Pq -c "SELECT has_function_privilege('"'"'anon'"'"', to_regprocedure('"'"'public.pode_ler_custo()'"'"'), '"'"'EXECUTE'"'"');"' "t"
+P -q -c "REVOKE ALL ON FUNCTION public.pode_ler_custo() FROM anon;" >/dev/null
+
+# S3: policy antiga de volta -> A10 (farmer le 0) deveria virar 3
+falsifica "S3 policy antiga (master OR employee) de volta" \
+  "DROP POLICY recommendation_log_select_custo ON public.recommendation_log; CREATE POLICY recommendation_log_select_custo ON public.recommendation_log FOR SELECT TO authenticated USING (has_role(auth.uid(),'master'::app_role) OR has_role(auth.uid(),'employee'::app_role));" \
+  'as_user "$F" "SELECT count(*) FROM public.recommendation_log;"' "3"
+P -q -f "$MIG" >/dev/null
+
+# S4: CONTROLE POSITIVO do assert de negacao -- sem policy nenhuma, TODOS leem 0.
+#     A10 continuaria verde por acidente; quem tem de gritar e A11 (master le 3).
+#     Sem esta falsificacao, "negado para todos" passaria como sucesso.
+falsifica "S4 sem policy: A11 (master le 3) tem de cair" \
+  "DROP POLICY recommendation_log_select_custo ON public.recommendation_log;" \
+  'as_user "$M" "SELECT count(*) FROM public.recommendation_log;"' "0"
+P -q -f "$MIG" >/dev/null
+
+# S5: quem falsifica A13 (escrita). Achado do Codex: S4 cobre o falso-verde da LEITURA, mas nenhuma
+#     sabotagem exercia o assert de ESCRITA -- ele podia estar passando por motivo errado sem aviso.
+#     Com uma policy permissiva de INSERT o farmer volta a inserir (=1), provando que A13 mede
+#     POLICY e nao PRIVILEGIO (o grant de INSERT continua presente, ver ZONA 1).
+falsifica "S5 policy permissiva de INSERT: A13 (farmer nao escreve) tem de cair" \
+  "CREATE POLICY tmp_insert_livre ON public.recommendation_log FOR INSERT TO authenticated WITH CHECK (true);" \
+  'as_user "$F" "INSERT INTO public.recommendation_log(farmer_id,customer_user_id,recommendation_type) VALUES ('"'"'$F'"'"','"'"'$F'"'"','"'"'s5'"'"') RETURNING 1;"' "1"
+P -q -c "DROP POLICY IF EXISTS tmp_insert_livre ON public.recommendation_log; DELETE FROM public.recommendation_log WHERE recommendation_type='s5';" >/dev/null
+
+# S6: falsifica os asserts DENTRO da migration (A2b/A2c). Eles rodam no apply e passaram -- mas
+#     "passou" e "dispara quando deve" sao crencas diferentes (licao #1488: o detector que nunca
+#     dispara). Aqui a sabotagem cria a precondicao do ataque de owner e exige que a migration ABORTE.
+FALS=5
+echo "  --- S6: A2c (CREATE em public) tem de ABORTAR a migration ---"
+P -q -c "GRANT CREATE ON SCHEMA public TO anon;" >/dev/null
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  echo "  FAIL [S6] a migration APLICOU com anon tendo CREATE em public — A2c nao dispara"
+  FAIL=$((FAIL+1))
+else
+  echo "  OK   [S6] a migration ABORTOU (A2c tem dente)"
+  FALS=$((FALS+1))
+fi
+P -q -c "REVOKE CREATE ON SCHEMA public FROM anon;" >/dev/null
+P -q -f "$MIG" >/dev/null   # restaura estado bom
+
+# S7: falsifica o A2b, que S6 NAO cobre. Achado MEU, ao reler a licao do #1488 contra o meu proprio
+#     assert: no harness `pode_ler_custo` e `cap_custo_ler` sao criadas pelo MESMO papel, entao os
+#     owners sao iguais POR CONSTRUCAO e o A2b nunca e visto disparando -- tautologico, exatamente o
+#     detector-que-nunca-dispara que o #1488 custou caro. Aqui monto o ATAQUE de fato: um papel
+#     hostil pre-cria a assinatura, `CREATE OR REPLACE` PRESERVA o owner dele, e a migration tem de
+#     recusar. E a unica prova de que o achado #3 do Codex esta realmente fechado.
+echo "  --- S7: A2b (owner hostil pre-criado) tem de ABORTAR a migration ---"
+P -q -c "DROP FUNCTION IF EXISTS public.pode_ler_custo();
+         DROP ROLE IF EXISTS atacante; CREATE ROLE atacante;
+         GRANT CREATE ON SCHEMA public TO atacante;
+         SET ROLE atacante;
+         CREATE FUNCTION public.pode_ler_custo() RETURNS boolean LANGUAGE sql AS \$\$ SELECT true \$\$;
+         RESET ROLE;
+         REVOKE CREATE ON SCHEMA public FROM atacante;" >/dev/null 2>&1
+OWNER_HOSTIL=$(P -q -tA -c "SELECT pg_get_userbyid(proowner) FROM pg_proc WHERE oid=to_regprocedure('public.pode_ler_custo()');" | tail -1)
+if [ "$OWNER_HOSTIL" != "atacante" ]; then
+  echo "  FAIL [S7] a montagem falhou: owner e '$OWNER_HOSTIL', esperava 'atacante' — sabotagem nao rodou"
+  FAIL=$((FAIL+1))
+elif P -q -f "$MIG" >/dev/null 2>&1; then
+  echo "  FAIL [S7] a migration APLICOU sobre funcao de owner hostil — A2b nao dispara"
+  FAIL=$((FAIL+1))
+else
+  echo "  OK   [S7] a migration ABORTOU (A2b tem dente; CREATE OR REPLACE preservou o owner 'atacante')"
+  FALS=$((FALS+1))
+fi
+P -q -c "DROP FUNCTION IF EXISTS public.pode_ler_custo(); DROP ROLE IF EXISTS atacante;" >/dev/null 2>&1
+P -q -f "$MIG" >/dev/null   # restaura estado bom
+
+echo
+echo "=== TOTAL: ${PASS} asserts de baseline, ${FAIL} falhas ==="
+if [ "$FAIL" -eq 0 ]; then
+  echo "VERDE (baseline ${BASE_PASS} asserts + ${FALS} falsificacoes com dente)"
+else
+  echo "VERMELHO"
+fi
+exit "$FAIL"

--- a/docs/superpowers/specs/2026-07-20-fechamento-custo-recommend-engines-design.md
+++ b/docs/superpowers/specs/2026-07-20-fechamento-custo-recommend-engines-design.md
@@ -1,0 +1,320 @@
+# FU4-F fase 3 — as vias de recomendação param de entregar custo ao browser
+
+> Spec de desenho. Irmão de [`2026-07-20-fechamento-custo-farmer-scoring-design.md`](2026-07-20-fechamento-custo-farmer-scoring-design.md),
+> que fecha `useFarmerScoring`. Aqui: as **três** vias restantes da §9 daquele spec.
+>
+> Decisão de produto (dono, 2026-07-20): **ordem + faixa ficam, o R$ derivado de custo fecha.**
+> Escopo (dono, 2026-07-20): **PR-A antes de PR-B** — a edge `recommend` vaza AGORA; os hooks estão dormentes.
+
+## 1. A população inteira do problema são 2 pessoas
+
+Medido em prod (`psql-ro`, 2026-07-20). Isto dimensiona tudo o que vem abaixo:
+
+| | |
+|---|---|
+| staff total | **3** — 1 `master`, 2 `employee` |
+| os 2 `employee` | ambos `commercial_role='farmer'` |
+| quem tem `private.cap_custo_ler` | **só o master** (exige `master` ou `employee`+`estrategico`/`super_admin`) |
+| quem lê `product_costs` hoje | policy `master OR employee` ⇒ **os 3** |
+| usuários `gerencial`/`estrategico` | **0** |
+
+⇒ **Os 2 farmers são a superfície inteira do FU4-F fase 3.** E a assimetria `cap_carteira_ler` ⊃ `cap_custo_ler`
+(que permitiria a um `gerencial` ler carteira sem poder ler custo) tem **zero usuários hoje** — é dívida
+latente, não caminho vivo. Dizer o contrário seria inflar a ameaça.
+
+## 2. As quatro vias, medidas — e três não são o que o enunciado supunha
+
+| via | vaza o quê | estado medido | veredito |
+|---|---|---|---|
+| edge `recommend` | `cost_final` + `margin` + `eip` exatos | **VIVO e corrente** | **PR-A** |
+| `useCrossSellEngine` | `product_costs` inteira (3.637) + `m_ij` persistido | dormente desde **2026-05-12** | PR-B |
+| `useBundleEngine` | `product_costs` inteira + `"cost"` literal no jsonb | dormente desde **2026-03-02** | PR-B |
+| `useBaixoGiro` | — | **já gatado** | **não é lacuna** (§6) |
+
+### 2.1 `useBaixoGiro` — o brief mandou verificar antes de concluir, e a verificação nega a lacuna
+
+`inventory_position` **já tem `private.cap_custo_ler` nas duas policies** (`Staff can manage inventory`
+e `staff_inventory_position_select`). Não há o que fechar: está fechado pela régua mais estrita do repo.
+
+O efeito colateral é o **inverso** de um vazamento: um comprador não-master abre
+`/admin/reposicao/baixo-giro` e recebe `saldo`/`cmc`/`capital_parado` = `null` **em silêncio**
+([`useBaixoGiro.ts:33`](../../../src/components/reposicao/baixoGiro/useBaixoGiro.ts)) — a tela mostra
+"—" sem dizer que é falta de permissão. É degradação silenciosa (questão de produto: `cap_compras_ler`
+também é master-only, então nenhum comprador não-master enxerga capital parado), **não** autorização.
+Registrado na §7; fora do escopo de segurança.
+
+## 3. PR-A — a edge `recommend`
+
+### 3.1 O vazamento: o strip é no browser, depois de receber
+
+A edge tem gate `employee OR master` ([`index.ts:401`](../../../supabase/functions/recommend/index.ts))
+e monta `_admin.cost_final` **incondicionalmente** ([`:319-321`](../../../supabase/functions/recommend/index.ts)).
+Quem apaga é o cliente:
+
+```ts
+// useRecommendationEngine.ts:69-75
+if (!isAdmin) {
+  res.recommendations = res.recommendations.map(r => { const { _admin, ...rest } = r; return rest; });
+}
+```
+
+**A resposta de rede já entregou o custo.** É a fachada exata que o spec irmão nomeia (§8, "mascarar a
+saída mantendo o `fetch`"). Os 2 farmers veem o `cost_final` de cada candidato no DevTools.
+
+E há um caminho mais curto que nem precisa do `_admin`: `margin` é **top-level**, renderizado em
+[`RecommendationCard.tsx:81`](../../../src/components/RecommendationCard.tsx) **fora** do
+`showAdminBreakdown`, ao lado de `price` na linha 62 ⇒ `custo = preço − margem`, aritmética de duas
+células da mesma tela. O `Custo:` da linha 120 que o enunciado apontou é o sintoma menor.
+
+### 3.2 A superfície de inversão é maior que `cost_final` — inventário completo
+
+Nulificar o campo óbvio não fecha. Enumerado a partir do código, não por analogia:
+
+| campo | por que inverte |
+|---|---|
+| `margin` | `custo = price − margin`, direto |
+| `eip` | `eip = probability × margemRank`, e `probability` **é devolvido** ⇒ `margemRank = eip/probability` |
+| `_admin.eiltv` | idem, via `kappa` e `recurrence` |
+| `_admin.cost_final` · `_admin.estimated_cost_for_ranking` | literais |
+| `score_final` **+** `meta.weights` **+** sub-scores do `_admin` | `score_final = wA·assocN + wP·eipN + wS·simN + wC·ctxN − pen` ([`:271`](../../../supabase/functions/recommend/index.ts)). Com pesos e sub-scores conhecidos, isola-se `eipN`; `minMaxNorm` é invertível a menos de afim sobre o conjunto ⇒ margens recuperáveis a menos de afim, e **duas âncoras conhecidas fixam a afim** |
+| `explanation_text` | ⚠️ [`:241`](../../../supabase/functions/recommend/index.ts) embute o número na **prosa**: `` `… alto potencial de margem (R$ ${margemExibida.toFixed(2)})` `` — nenhum nulificar-campo pega isto |
+
+O `explanation_text` é o achado que justifica enumerar em vez de tapar o buraco visível.
+
+### 3.3 O desenho
+
+**(a) Migration — `public.pode_ler_custo() → boolean`, SEM PARÂMETRO**
+
+`private.cap_custo_ler` não é alcançável por PostgREST (só `public` é exposto). Replicar a regra em TS
+**derivaria em fail-OPEN** (a edge acharia que pode quando o banco diz que não) — é a armadilha do
+helper espelhado sem prova de paridade.
+
+⇒ wrapper fino, `SECURITY DEFINER`, `STABLE`, `SET search_path TO 'public', pg_temp` (`pg_temp` por
+último), corpo = `SELECT COALESCE(private.cap_custo_ler((SELECT auth.uid())), false)`.
+
+⚠️ **O desenho sem parâmetro não é detalhe.** Uma `pode_ler_custo(_uid uuid)` seria um **oráculo de
+capability**: qualquer caller sondaria a permissão de qualquer usuário. Sem argumento, a função
+responde só sobre o **caller** — informação que ele já obtém olhando a própria tela. Zero informação
+nova ⇒ pode ser `GRANT`ada a `authenticated`, que é como a edge (chamando com o JWT do usuário) obtém
+a resposta. `REVOKE` de `PUBLIC` e `anon` **por nome** (revogar de `PUBLIC` não remove grant nomeado).
+
+⚠️ **Propriedade defensiva de brinde:** chamada com `service_role`, `auth.uid()` é `NULL` e o retorno
+é `false`. Ligar a edge no client errado falha **FECHADO** (nega custo), nunca aberto. Por isso a edge
+chama com `supabaseAuth`, não com `supabaseAdmin` — e o harness prova esse caso (A6).
+
+**(b) Edge — gate de projeção, espelhando `get_preco_cockpit`**
+
+```
+v_pode := pode_ler_custo(user.id)     -- erro na RPC ⇒ false (fail-closed)
+```
+
+| campo | sem `cap_custo_ler` |
+|---|---|
+| `margin`, `eip` | `null` (chave presente) |
+| `_admin` | **ausente por inteiro** — não nulificado campo a campo |
+| `meta.weights` | ausente |
+| `score_final` | **migra para dentro do `_admin`** (já é conteúdo admin-only: [`RecommendationCard:124`](../../../src/components/RecommendationCard.tsx)) |
+| `explanation_text`, ramo `margin` | mesma frase **sem o R$** |
+| nº de itens | `top_n_vendedor` (5) em vez de `top_n_admin` (20) — reduz 4× a superfície de ordenação |
+
+O que **fica**: `price`, `probability`, `estoque`, `explanation_text`, `recommendation_type` e a
+**ordem** do array. É o ranqueamento — o produto da feature.
+
+**(c) `recommendation_log`** — `unit_cost` é gravado pela edge ([`:295`](../../../supabase/functions/recommend/index.ts))
+e a RLS é `master OR employee` ⇒ os farmers leem. Medido: 683 linhas, 3 com `unit_cost`, 154 SKUs,
+último 2026-06-14. **Nenhum leitor no frontend** (`grep` em `src/`: só `types.ts` e um doc).
+⇒ apertar o SELECT para `cap_custo_ler`, mantendo a escrita por `service_role` (que bypassa RLS).
+Impacto de UX: zero.
+
+⚠️ Ao apertar este gate, **reler os asserts que dependiam do gate antigo** — o aperto transforma
+fiscal em tautologia e nada no exit code avisa (corolário medido 3× no #1488).
+
+**(d) Frontend** — `fmt()` já devolve `—` para `null` ([`RecommendationCard:10`](../../../src/components/RecommendationCard.tsx)),
+então a degradação já é honesta. `score_final` sai do tipo top-level e passa a ser lido de `_admin`.
+
+**O strip client-side de `useRecommendationEngine:69-75` SAI** — decisão revista durante a
+implementação. Manter "como defense-in-depth" seria errado: `isAdmin` é `role === 'master'`,
+**estritamente mais restrito** que `cap_custo_ler` (que também concede a `employee` `estrategico`/
+`super_admin`). Duas autoridades discordando não é profundidade, é uma tela que **esconde de quem o
+servidor autorizou**. A presença de `_admin` na resposta **é** a resposta do servidor. O toggle
+`showAdminBreakdown` segue como controle de **exibição** e já exige `item._admin` — fail-closed por
+construção se o servidor não mandar o bloco.
+
+### 3.4 O que PR-A NÃO fecha — declarar no corpo do PR
+
+Precisão>recall exige nomear o resíduo em vez de anunciar "custo fechado":
+
+1. **Ordem + pertencimento ao top-N + distribuição sob chamadas repetidas** — declaração ampliada
+   após o Codex. Eu tinha escrito só "a ordem"; é mais que isso:
+   - `score_final` embute `eipN`, que embute margem ⇒ a ordenação devolve desigualdades.
+   - **Entrar ou não no top-N é sinal por si só.** Custo desconhecido não é excluído (recebe
+     `margemRank = 0`, [`:201`](../../../supabase/functions/recommend/index.ts)), mas cai no ranking
+     — a **identidade do SKU omitido** é o canal. A *quantidade* devolvida, isolada, não é.
+   - **Repetição amplifica.** Com `epsilon_exploration = 0,10` somando até `0,3` ao `score_final`
+     ([`:276`](../../../supabase/functions/recommend/index.ts)), a *frequência* com que um par troca
+     de posição em chamadas repetidas estima a diferença de `score_final` entre eles. O ruído que eu
+     citei como defesa é, sob repetição, um **canal de medição**.
+2. **1 bit por SKU — pela FRASE, não pela chave.** Correção do Codex, verificada por mim no código:
+   `explanationKey` é **inicializado** como `"margin"` ([`:252`](../../../supabase/functions/recommend/index.ts))
+   e o `else` final não o troca ⇒ `explanation_key === 'margin'` também vale para o fallback e
+   **não prova nada**. Quem prova `margem > 50` é a frase *"tem alto potencial de margem"*, emitida
+   só no ramo real. O resíduo existe, é 1 desigualdade por SKU (limiar **fixo**, não busca binária),
+   e é **menor** do que eu havia declarado. Mantido de propósito: suprimir a frase degradaria a
+   explicação para "boa adição ao mix", destruindo conteúdo legítimo para fechar 1 bit.
+3. ⚠️ **Esconder `meta.weights` é defense-in-depth, não barreira** — achado da própria revisão
+   adversarial desta sessão, contra a versão anterior deste spec. `recommendation_config` tem policy
+   `master OR employee`: o mesmo usuário de quem escondemos os pesos na resposta lê
+   `w_assoc/w_eip/w_sim/w_ctx` com um `select`. `farmer_association_rules` (idem) reconstrói
+   `assoc_score`. **O que encarece de verdade a inversão é `score_final` ter saído da resposta** —
+   sobram desigualdades (a ordem), não valores. Fechar a config é follow-up (§6.4), não gratuito:
+   `useAnalyticsSync` lê **e escreve** a tabela numa tela de tuning.
+4. `product_costs` **continua** com policy `master OR employee`. PR-A não toca a tabela.
+
+### 3.5 Como se prova
+
+- **PG17 (`prove-sql-money-path`)** para a migration: `pode_ler_custo` com `SET ROLE authenticated`
+  + GUC (nunca `SET LOCAL` — em autocommit vira `WARNING` e o assert fica falso-verde), guard que
+  **aborta** se `current_user ≠ authenticated`, e negativo por `SQLSTATE` + re-raise.
+- **Assert de existência via `to_regprocedure('public.pode_ler_custo(uuid)')`**, nunca comparando
+  `pg_get_function_identity_arguments` com string literal — ela inclui os NOMES dos parâmetros e
+  **nunca casa** (o detector que não dispara, #1488).
+- **Asserts sobre corpo de função rodam com comentários removidos**
+  (`regexp_replace(pg_get_functiondef(oid), '--[^\n]*', '', 'g')`) — a própria migration é fonte do
+  texto que o assert lê de volta (#1472/#1488).
+- **Suíte Deno** (`test:edges`, `--no-remote` ⇒ **sem import remoto**): a projeção sai como **função
+  pura** (`projetarRecomendacoes(candidatos, podeCusto)`) justamente para ser testável sem dep.
+- **Falsificações EXECUTADAS**, cada uma com baseline VERDE antes e conferência de **contagem e
+  nomes** dos vermelhos (contagem sozinha não prova que o vermelho é o certo):
+
+  | # | sabotagem | vermelho observado |
+  |---|---|---|
+  | S1 | `pode_ler_custo()` → `SELECT true` | A4 (farmer não tem capability) virou `t` |
+  | S2 | `GRANT EXECUTE TO anon` | A7 (anon não executa) virou `t` |
+  | S3 | policy antiga (`master OR employee`) de volta | A10 (farmer lê 0) virou `3` |
+  | S4 | **sem policy nenhuma** | A11 (master lê 3) virou `0` |
+  | D1 | gate de projeção desligado (`if (false)`) | 3 testes Deno, nomeados e conferidos |
+  | D2 | R$ de volta na prosa | 1 teste Deno, nomeado |
+
+  **S4 é o controle positivo e o mais importante:** sem ele, "ninguém lê nada" passaria como
+  sucesso — o assert de negação (A10) ficaria verde com a tabela quebrada. É o assert POSITIVO que
+  tem de gritar quando a policy some.
+
+  Resultado: **20 asserts de baseline + 4 falsificações no PG17 (exit 0)**, **10 testes Deno + 2
+  falsificações**. O baseline B1–B4 roda **antes** da migration e prova o detector vendo o mundo
+  vivo (farmer lendo as 3 linhas, e escrevendo) — sem isso, "lê 0 depois" não se distingue de
+  "a query quebrou".
+
+- **Codex adversarial** (`gpt-5.6-sol`, `xhigh`) antes de tirar do draft.
+
+### 3.6 Entrega (3 camadas manuais do Lovable)
+
+1. Migration custom no SQL Editor — **não auto-aplica**, falha silenciosa
+2. **Deploy da edge `recommend` pelo chat do Lovable**, verbatim da `main`. ⚠️ Após o merge, conferir
+   `git log -S pode_ler_custo` do arquivo **antes** de pedir o deploy — o sync bidirecional já
+   reverteu wiring de edge 4h depois do merge (#1445→#1478)
+3. Publish do frontend
+4. `types.ts`: a RPC nova não regenera tipos sozinha — parte da entrega, senão a `main` fica vermelha
+   e trava o auto-merge de todos os PRs abertos
+
+**Ordem: edge → migration → verificar as duas → Publish.** Revista após o Codex — eu tinha
+`migration → edge`, e ele mostrou que é a ordem *menos* fail-closed das duas:
+
+| janela | com `migration → edge` (antes) | com `edge → migration` (adotada) |
+|---|---|---|
+| intermediária | a edge VELHA segue devolvendo custo ⇒ **o vazamento continua aberto** | a RPC ainda não existe ⇒ `podeLerCusto` recebe erro e devolve `false` ⇒ resposta **já redigida** |
+| custo | nenhum | o master perde o breakdown até a migration entrar (degradação, não vazamento) |
+
+Para um PR cujo objetivo é confidencialidade, fechar antes vale mais que evitar uma degradação
+temporária e honesta. O `Publish` continua por último, **depois de confirmar que a edge nova está
+servindo** — publicar o front antes de confirmar a edge é o único risco real que sobra aqui.
+
+## 4. PR-B — os dois hooks (desenho, execução em sessão própria)
+
+### 4.1 O achado que muda o desenho: a persistência re-arma o oráculo
+
+Não estava no enunciado. Os dois engines **gravam** o resultado, e o que gravam inverte:
+
+- `farmer_recommendations` guarda `m_ij` **e** `cluster_volume_estimate` na **mesma linha**. Como
+  `m_ij = margem × volume` ([`useCrossSellEngine.ts:373`](../../../src/hooks/useCrossSellEngine.ts)),
+  uma divisão dá a margem unitária exata. Verificado em prod: `134,26 / 2 = 67,13`.
+- `farmer_bundle_recommendations.bundle_products` tem `"cost"` **literal** por SKU
+  ([`useBundleEngine.ts:496`](../../../src/hooks/useBundleEngine.ts)). 12 linhas, 12 com custo. Sem
+  inversão nenhuma.
+
+RLS de ambas: `farmer_id = uid` ⇒ os 2 farmers leem as próprias linhas.
+
+⚠️ **Calibragem honesta:** as linhas estão velhas (2026-05-12 e 2026-03-02) e **0 de 2.617** batem com
+o custo atual — hoje é oráculo de margem **histórica** sobre 19 SKUs, não de custo corrente.
+**O ponto é que o conserto re-arma:** mover o ranqueamento para o servidor faz a tabela voltar a ser
+fresca, e aí o oráculo passa a ser corrente sobre o conjunto recomendado inteiro. Um PR que mova o
+cálculo sem mexer na persistência **piora** a exposição.
+
+### 4.2 RPC, não edge — e o corte que torna isto tratável
+
+**A mineração de regras não toca custo.** `support`/`confidence`/`lift` saem de co-ocorrência de cesta
+([`useBundleEngine.ts:289-365`](../../../src/hooks/useBundleEngine.ts)); `pij` sai de health score,
+engajamento, aderência de cluster e taxa histórica. **Custo entra só no scoring** (`margin`, `mij`,
+`lieBundle`).
+
+⇒ Não é preciso reescrever os engines em SQL. A RPC recebe os candidatos **já pontuados na parte que
+não toca custo** e devolve a ordem. Isso é `JOIN` + `ROW_NUMBER() OVER (PARTITION BY cliente ORDER BY
+lie DESC)` — nativo em SQL, cabe no padrão `get_preco_cockpit`, ganha o harness `prove-sql-money-path`,
+e a superfície de paridade TS×SQL encolhe para a fórmula da margem.
+
+**Edge foi descartada** porque: (a) some o harness PG17 falsificável; (b) acrescenta um 2º deploy
+manual e a exposição ao sync bidirecional; (c) a parte que sobra é set-based, exatamente o que o
+Postgres faz melhor que um laço JS de ~3,8M iterações.
+
+⚠️ **O peso é conhecido pelo cliente** — se a RPC devolvesse `lie`, então `margem = lie / peso` seria
+inversão imediata. Só a **ordem** e a **faixa** saem sem `cap_custo_ler`.
+
+### 4.3 Contrato da RPC (esboço)
+
+`get_ranking_margem(p_itens jsonb)` — uma linha por candidato:
+
+| campo | regra |
+|---|---|
+| `product_id` | — |
+| `ordem` | posição no ranking — **sempre presente** |
+| `faixa` | `verde\|amarelo\|vermelho\|neutro` — `neutro` obrigatório: SKU sem custo **não** é empurrado para cor |
+| `mij`, `lie` | **só** com `cap_custo_ler`; senão `null` com a chave presente |
+
+Persistência: `m_ij`/`cluster_volume_estimate` e `bundle_products.cost` **param de ser gravados juntos**
+(ou a gravação passa a ser server-side com a leitura gatada) — senão o §4.1 volta.
+
+### 4.4 Paridade — o risco principal
+
+Mesma lista do spec irmão §4, valendo aqui: universo de pedidos (`confirmado|faturado|entregue`),
+custo canônico (`cost_final` → `cost_price`, finito **e** > 0), ⚠️ `'NaN'::numeric` é valor legítimo em
+Postgres e `Number.isFinite` o rejeita em TS — o SQL precisa excluir explicitamente, senão a paridade
+quebra onde ninguém olha.
+
+## 5. Alternativas descartadas
+
+| alternativa | por que não |
+|---|---|
+| Fechar `product_costs` direto (`cap_custo_ler`) e deixar degradar | Os engines já excluem SKU sem custo (pós-#1471) ⇒ a lista dos 2 farmers fica **vazia**. Apaga a feature em vez de protegê-la — exatamente o que o spec irmão barrou. |
+| Nulificar só `_admin.cost_final` na edge | Deixa `margin` top-level, `eip`, `score_final`+pesos e o R$ na prosa (§3.2). |
+| Manter o strip client-side como proteção | O `fetch` já entregou. Fachada. |
+| Agregado por cliente em R$ (mantendo o total da carteira) | `Σ kᵢ·margemᵢ` com `kᵢ` conhecido ⇒ sistema linear resolvível para SKUs recorrentes. Estreita, não fecha. Descartado pelo dono em favor de ordem+faixa. |
+| Replicar `cap_custo_ler` em TS na edge | Deriva em **fail-open**: a edge acha que pode quando o banco diz que não. |
+| Reescrever os engines inteiros em SQL | A mineração não toca custo — reescrevê-la é trabalho sem ganho de segurança e paridade cara (§4.2). |
+
+## 6. Fora de escopo — follow-ups com evidência
+
+1. **`/admin/reposicao/baixo-giro` degrada em silêncio** (§2.1): não-master vê `cmc`/`capital_parado`
+   como "—" sem saber que é permissão. `cap_compras_ler` é master-only ⇒ nenhum comprador enxerga
+   capital parado. Decisão de produto, não de segurança.
+2. **A dívida latente `cap_carteira_ler` ⊃ `cap_custo_ler`**: hoje 0 usuários. No dia em que existir um
+   `gerencial`, ele lerá `farmer_recommendations` da base inteira — e o §4.1 vale para ele sem o
+   filtro `farmer_id = uid`.
+3. **`derivarMargensCandidato` é helper espelhado** (`src/lib/custos/cost-source.ts:67` ×
+   `supabase/functions/recommend/index.ts:59`) sem guard textual `MIRROR-START/END` nem canária. O
+   `money-path.md` exige um dos dois para lógica replicada.
+4. **`recommendation_config` legível por `employee`** (medido: policy `master OR employee`; contém
+   `w_assoc=0.25`, `w_eip=0.35`, `w_sim=0.20`, `w_ctx=0.20`, `epsilon_exploration`, e ainda
+   `margem_default_global/minima/maxima`). Enfraquece o gate de `meta.weights` do PR-A (§3.4.3) e
+   entrega os parâmetros de política de margem. **Não é trivial de fechar:**
+   `src/components/analyticsSync/useAnalyticsSync.ts:55,127` **lê e escreve** a tabela numa tela de
+   tuning sob `GestaoAdmin` — fechar exige decidir se tunar peso de recomendação é ato de `master`,
+   de `cap_custo_ler`, ou se a escrita vira RPC. Decisão de produto antes do diff.

--- a/src/components/RecommendationCard.tsx
+++ b/src/components/RecommendationCard.tsx
@@ -121,7 +121,7 @@ export const RecommendationCard = React.memo(function RecommendationCard({
                   <p>Família: {item._admin.familia || 'N/A'}</p>
                 </TooltipContent>
               </Tooltip>
-              <span>Score: {item.score_final.toFixed(4)}</span>
+              <span>Score: {item._admin.score_final.toFixed(4)}</span>
               <span>EILTV: {fmt(item._admin.eiltv)}</span>
             </div>
           </div>

--- a/src/hooks/useRecommendationEngine.ts
+++ b/src/hooks/useRecommendationEngine.ts
@@ -7,15 +7,20 @@ export interface RecommendationItem {
   codigo: string;
   descricao: string;
   price: number;
+  // FU4-F/3: `null` quando o servidor não concedeu custo (private.cap_custo_ler). Chave PRESENTE
+  // com null — degradação honesta: "não posso mostrar", não "vale zero". `fmt()` já rende "—".
   margin: number | null;
   probability: number;
   eip: number | null;
-  score_final: number;
   recommendation_type: string;
   explanation_text: string;
   explanation_key: string;
   estoque: number;
+  // Bloco inteiro AUSENTE sem cap_custo_ler — a decisão é do servidor, não do browser.
+  // `score_final` mora aqui porque é insumo da inversão: com os pesos e os sub-scores dá para
+  // isolar o termo de EIP e recuperar a margem a menos de uma transformação afim.
   _admin?: {
+    score_final: number;
     cost_final: number | null;
     estimated_cost_for_ranking: number | null;
     cost_source: string;
@@ -34,13 +39,14 @@ export interface RecommendationResult {
   meta: {
     total_candidates: number;
     mode: 'profit' | 'ltv';
-    weights: { wA: number; wP: number; wS: number; wC: number };
+    // Ausente sem cap_custo_ler: os pesos são insumo da inversão de `score_final`.
+    weights?: { wA: number; wP: number; wS: number; wC: number };
     top_n: number;
   };
 }
 
 export function useRecommendationEngine() {
-  const { user, isAdmin } = useAuth();
+  const { user } = useAuth();
   const [result, setResult] = useState<RecommendationResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -67,14 +73,16 @@ export function useRecommendationEngine() {
 
       const res = data.data as RecommendationResult;
 
-      // Strip admin fields for non-admin users
-      if (!isAdmin) {
-        res.recommendations = res.recommendations.map(r => {
-          const { _admin, ...rest } = r;
-          return rest;
-        });
-      }
-
+      // FU4-F/3: o strip client-side de `_admin` SAIU daqui.
+      //
+      // Ele nunca foi proteção — rodava DEPOIS de a resposta de rede chegar, então o custo já
+      // estava no DevTools. Agora quem decide é a edge, por `private.cap_custo_ler`.
+      //
+      // E mantê-lo seria pior que inútil: `isAdmin` é `role === 'master'`, ESTRITAMENTE mais
+      // restrito que cap_custo_ler (que também concede a employee `estrategico`/`super_admin`).
+      // Duas autoridades discordando ⇒ a tela esconderia de quem o servidor autorizou.
+      // A presença de `_admin` na resposta É a resposta do servidor; renderizar é o certo.
+      // (O toggle `showAdminBreakdown` segue como controle de EXIBIÇÃO, e já exige `item._admin`.)
       setResult(res);
       return res;
     } catch (err) {
@@ -85,7 +93,7 @@ export function useRecommendationEngine() {
     } finally {
       setLoading(false);
     }
-  }, [user?.id, isAdmin]);
+  }, [user?.id]);
 
   const logAccept = useCallback(async (
     customerId: string,

--- a/supabase/functions/_shared/recommend-projecao.ts
+++ b/supabase/functions/_shared/recommend-projecao.ts
@@ -1,0 +1,187 @@
+// ════════════════════════════════════════════════════════════════════════════════════════════
+// FU4-F fase 3 (PR-A) — projeção fail-closed da resposta da edge `recommend`
+// ════════════════════════════════════════════════════════════════════════════════════════════
+//
+// POR QUE ISTO É UMA FUNÇÃO PURA E SEPARADA: a suíte de edge roda com `--no-remote`, então um teste
+// não pode importar `index.ts` (que faz `Deno.serve` no topo e puxa o SDK remoto). Lógica pura em
+// `_shared/` + teste ao lado é o padrão do repo (paginate.ts, omie-paginacao.ts).
+//
+// O QUE ESTA CAMADA PROTEGE. Antes, a edge devolvia `_admin.cost_final` a TODO staff e o browser
+// apagava o campo DEPOIS de receber (useRecommendationEngine.ts:69-75) — a resposta de rede já
+// tinha entregue o custo. A decisão de quem vê número acontece aqui, no servidor.
+//
+// A SUPERFÍCIE DE INVERSÃO É MAIOR QUE `cost_final` — enumerada do código, não por analogia:
+//   · margin                      → custo = price − margin
+//   · eip = probability × margem  → e `probability` é devolvido ⇒ divisão dá a margem
+//   · eiltv                       → idem, via kappa/recorrência
+//   · cost_final, cost_ranking    → literais
+//   · score_final + weights + sub-scores → score_final = wA·assocN + wP·eipN + wS·simN + wC·ctxN − pen;
+//     com pesos e sub-scores conhecidos isola-se eipN, e minMaxNorm é invertível a menos de afim
+//     sobre o conjunto ⇒ duas âncoras conhecidas fixam a afim e recuperam as margens
+//   · explanation_text            → o R$ ia EMBUTIDO NA PROSA (nenhum nulificar-campo pega isso)
+//
+// Por isso `_admin` some INTEIRO (não nulificado campo a campo), `score_final` migra para dentro
+// dele, `weights` sai do meta, e o texto perde o número.
+//
+// ⚠️ O QUE NÃO FECHA, de propósito: a ORDEM do array. Ela embute margem via score_final. É o
+// produto da feature (o ranqueamento) e foi mantida por decisão do dono — declarado no PR.
+// ════════════════════════════════════════════════════════════════════════════════════════════
+
+export interface CandidatoProjetavel {
+  product_id: string;
+  codigo: string;
+  descricao: string;
+  price: number;
+  margin: number | null;
+  probability: number;
+  eip: number;
+  eiltv: number;
+  score_final: number;
+  recommendation_type: string;
+  explanation_text: string;
+  explanation_key: string;
+  estoque: number;
+  cost_final: number | null;
+  cost_source: string;
+  cost_confidence: number;
+  cost_ranking: number | null;
+  assoc_score: number;
+  sim_score: number;
+  ctx_score: number;
+  penalties: number;
+  familia: string | null;
+}
+
+export interface Pesos {
+  wA: number;
+  wP: number;
+  wS: number;
+  wC: number;
+}
+
+/**
+ * Texto do ramo "margem" da explicação.
+ *
+ * O ramo em si FICA mesmo sem a capability: ele é conteúdo legítimo de venda ("este item tem alto
+ * potencial de margem"). Some só o R$.
+ *
+ * ⚠️ Resíduo aceito e declarado: o ramo dispara com `margemExibida > 50`, então vê-lo prova
+ * `margem > 50` ⇒ `custo < preço − 50`. Limiar FIXO ⇒ 1 desigualdade por SKU, não busca binária.
+ * Suprimir o ramo degradaria a explicação para "boa adição ao mix" — conteúdo real destruído para
+ * fechar 1 bit.
+ */
+export function textoExplicacaoMargem(
+  descricao: string,
+  margemExibida: number,
+  podeCusto: boolean,
+): string {
+  return podeCusto
+    ? `${descricao} tem alto potencial de margem (R$ ${margemExibida.toFixed(2)})`
+    : `${descricao} tem alto potencial de margem`;
+}
+
+/**
+ * Quantos candidatos devolver.
+ *
+ * O `recommendation_config` já distinguia `top_n_vendedor` (5) de `top_n_admin` (20), mas o código
+ * devolvia `top_n_admin` para TODO MUNDO — a intenção da config estava escrita e não aplicada.
+ * Aplicar reduz 4× a superfície do canal de ordenação e implementa o que a config já dizia.
+ */
+export function limiteCandidatos(topN: number, topNAdmin: number, podeCusto: boolean): number {
+  return podeCusto ? topNAdmin : topN;
+}
+
+/**
+ * Remove valores em reais de texto livre.
+ *
+ * ⚠️ POR QUE EXISTE (achado do Codex, gpt-5.6-sol xhigh, 2026-07-20): a lista branca de campos
+ * protege contra campo NOVO, mas `explanation_text` JÁ está nela e carrega texto arbitrário. Um
+ * ramo futuro que escrevesse `"Custo interno R$ 7,77"` vazaria pela projeção que se declara
+ * fail-closed. O limite de segurança estava no PRODUTOR, não aqui.
+ *
+ * ⚠️ LIMITE HONESTO: isto pega a forma marcada com `R$`, que é a regressão realista (foi
+ * exatamente o que existia). NÃO pega `"custo unitario: 7.77"` sem marcador. Texto livre segue
+ * sendo responsabilidade do produtor — a defesa aqui é profundidade, e o gate primário continua
+ * sendo `textoExplicacaoMargem(..., podeCusto)` no caller.
+ */
+export function removerValores(texto: string): string {
+  // R$ seguido de numero com separadores pt-BR ou en-US (1.234,56 / 1,234.56 / 7.77 / 7,77)
+  return texto.replace(/R\$\s*-?\d[\d.,]*/g, "R$ —");
+}
+
+/**
+ * Projeta um candidato para a resposta.
+ *
+ * Fail-closed por CONSTRUÇÃO: o objeto do caso negativo é montado do zero com a lista branca de
+ * campos, em vez de copiar o candidato e deletar os sensíveis. Campo novo no Candidate não vaza
+ * sozinho — precisa ser adicionado aqui de propósito. E o único campo de texto livre da lista
+ * branca passa por `removerValores` (ver o limite declarado acima).
+ */
+export function projetarCandidato(c: CandidatoProjetavel, podeCusto: boolean): Record<string, unknown> {
+  const base = {
+    product_id: c.product_id,
+    codigo: c.codigo,
+    descricao: c.descricao,
+    price: c.price,
+    probability: c.probability,
+    estoque: c.estoque,
+    recommendation_type: c.recommendation_type,
+    explanation_text: c.explanation_text,
+    explanation_key: c.explanation_key,
+  };
+
+  if (!podeCusto) {
+    // Chaves PRESENTES com valor null: o contrato do cliente não muda de forma, e `fmt()` já
+    // renderiza "—" para null. Degradação honesta — "não posso mostrar", não "vale zero".
+    return {
+      ...base,
+      explanation_text: removerValores(c.explanation_text),
+      margin: null,
+      eip: null,
+    };
+  }
+
+  return {
+    ...base,
+    margin: c.margin,
+    // EIP é money (R$ de lucro esperado): null quando o custo não é confiável (margin null).
+    eip: c.margin != null ? c.eip : null,
+    _admin: {
+      score_final: c.score_final,
+      cost_final: c.cost_final,
+      cost_source: c.cost_source,
+      cost_confidence: c.cost_confidence,
+      estimated_cost_for_ranking: c.cost_ranking,
+      assoc_score: c.assoc_score,
+      sim_score: c.sim_score,
+      ctx_score: c.ctx_score,
+      penalties: c.penalties,
+      familia: c.familia,
+      eiltv: c.margin != null ? c.eiltv : null,
+    },
+  };
+}
+
+/**
+ * Meta da resposta. `weights` é insumo da inversão de `score_final` ⇒ só com a capability.
+ *
+ * ⚠️ MAS ISTO É DEFENSE-IN-DEPTH, NÃO BARREIRA — e dizer o contrário seria mentir. A tabela
+ * `recommendation_config` (de onde os pesos saem) tem policy `master OR employee`: o mesmo usuário
+ * de quem escondemos `weights` aqui lê `w_assoc/w_eip/w_sim/w_ctx` com um `select`. Idem
+ * `farmer_association_rules`, que reconstrói `assoc_score`.
+ *
+ * O que realmente encarece a inversão é `score_final` ter saído da resposta (ele mora em `_admin`
+ * agora): sobra só a ORDEM, que dá desigualdades, não valores. Fechar `recommendation_config` é
+ * follow-up com dependência real de frontend (`useAnalyticsSync` lê E escreve a tabela numa tela
+ * de tuning), então não entrou aqui.
+ */
+export function projetarMeta(
+  totalCandidates: number,
+  modo: "profit" | "ltv",
+  pesos: Pesos,
+  topN: number,
+  podeCusto: boolean,
+): Record<string, unknown> {
+  const base = { total_candidates: totalCandidates, mode: modo, top_n: topN };
+  return podeCusto ? { ...base, weights: pesos } : base;
+}

--- a/supabase/functions/_shared/recommend-projecao_test.ts
+++ b/supabase/functions/_shared/recommend-projecao_test.ts
@@ -1,0 +1,162 @@
+// Testa o CÓDIGO REAL da projeção da edge `recommend` (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/recommend-projecao_test.ts
+import {
+  type CandidatoProjetavel,
+  limiteCandidatos,
+  projetarCandidato,
+  projetarMeta,
+  textoExplicacaoMargem,
+} from "./recommend-projecao.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+// ── Sentinelas ──────────────────────────────────────────────────────────────────────────────
+// Valores ESCOLHIDOS para serem improváveis e mutuamente distintos, de modo que procurá-los na
+// serialização não dê falso-positivo nem falso-negativo por coincidência aritmética.
+const CUSTO = 7.77;
+const PRECO = 100;
+const MARGEM = PRECO - CUSTO; // 92.23
+const PROB = 0.5;
+const EIP = PROB * MARGEM; //  46.115
+const EILTV = 61.4321;
+const CUSTO_RANKING = 8.88;
+const SCORE = 0.4242;
+
+function candidato(over: Partial<CandidatoProjetavel> = {}): CandidatoProjetavel {
+  return {
+    product_id: "p-1",
+    codigo: "SKU-1",
+    descricao: "Lixa 220",
+    price: PRECO,
+    margin: MARGEM,
+    probability: PROB,
+    eip: EIP,
+    eiltv: EILTV,
+    score_final: SCORE,
+    recommendation_type: "cross_sell",
+    explanation_text: "Lixa 220 tem alto potencial de margem",
+    explanation_key: "margin",
+    estoque: 12,
+    cost_final: CUSTO,
+    cost_source: "PRODUCT_COST",
+    cost_confidence: 0.9,
+    cost_ranking: CUSTO_RANKING,
+    assoc_score: 0.31,
+    sim_score: 0.22,
+    ctx_score: 0.13,
+    penalties: 0.05,
+    familia: "abrasivos",
+    ...over,
+  };
+}
+
+// ── O assert que pega o campo que eu esqueci ────────────────────────────────────────────────
+// Um teste campo-a-campo só prova o que eu lembrei de listar. Este serializa a projeção inteira e
+// exige que NENHUM número derivado de custo apareça em lugar nenhum — pega chave nova, campo
+// renomeado, valor embutido em string e objeto aninhado, sem eu precisar prever o formato.
+//
+// ⚠️ A fixture usa `explanation_text` SUJO de propósito (achado do Codex contra a 1a versão deste
+// teste): com o texto já sanitizado, o assert passava sem nunca exercer a alegação de que captura
+// número embutido em string — provava o mundo que eu queria ter.
+Deno.test("sem capability: nenhum número derivado de custo sobrevive à serialização", () => {
+  const sujo = candidato({ explanation_text: `Custo interno R$ ${CUSTO} e margem R$ ${MARGEM}` });
+  const json = JSON.stringify(projetarCandidato(sujo, false));
+  for (const proibido of [CUSTO, MARGEM, EIP, EILTV, CUSTO_RANKING, SCORE]) {
+    assert(
+      !json.includes(String(proibido)),
+      `vazou ${proibido} na resposta sem cap_custo_ler: ${json}`,
+    );
+  }
+});
+
+Deno.test("sem capability: R$ em texto LIVRE do produtor tambem e removido", () => {
+  const sujo = candidato({ explanation_text: "Custo interno R$ 7.77" });
+  const out = projetarCandidato(sujo, false) as Record<string, string>;
+  assert(!out.explanation_text.includes("7.77"), `vazou: ${out.explanation_text}`);
+  assert(out.explanation_text.includes("Custo interno"), "sanitizou demais — perdeu o texto");
+});
+
+Deno.test("COM capability: o texto do produtor passa intacto", () => {
+  const sujo = candidato({ explanation_text: "Custo interno R$ 7.77" });
+  const out = projetarCandidato(sujo, true) as Record<string, string>;
+  assertEquals(out.explanation_text, "Custo interno R$ 7.77");
+});
+
+Deno.test("sem capability: _admin some INTEIRO (não nulificado campo a campo)", () => {
+  const out = projetarCandidato(candidato(), false);
+  assert(!("_admin" in out), "_admin presente sem cap_custo_ler");
+  assert(!("score_final" in out), "score_final top-level sem cap_custo_ler — insumo da inversão");
+});
+
+Deno.test("sem capability: margin/eip PRESENTES e null (degradação honesta, não ausência de chave)", () => {
+  const out = projetarCandidato(candidato(), false);
+  assert("margin" in out && out.margin === null, "margin deveria estar presente e null");
+  assert("eip" in out && out.eip === null, "eip deveria estar presente e null");
+});
+
+Deno.test("sem capability: o conteúdo de venda SOBREVIVE (não é apagar a tela)", () => {
+  const out = projetarCandidato(candidato(), false);
+  assertEquals(out.price, PRECO, "price é legítimo e conhecido pelo cliente");
+  assertEquals(out.probability, PROB);
+  assertEquals(out.estoque, 12);
+  assertEquals(out.descricao, "Lixa 220");
+  assertEquals(out.explanation_key, "margin");
+  assertEquals(out.recommendation_type, "cross_sell");
+});
+
+Deno.test("COM capability: _admin volta e score_final mora DENTRO dele", () => {
+  const out = projetarCandidato(candidato(), true) as Record<string, Record<string, unknown>>;
+  assert(!("score_final" in out), "score_final deveria ter migrado para dentro de _admin");
+  assertEquals(out._admin.score_final, SCORE);
+  assertEquals(out._admin.cost_final, CUSTO);
+  assertEquals(out._admin.estimated_cost_for_ranking, CUSTO_RANKING);
+  assertEquals(out.margin, MARGEM);
+  assertEquals(out.eip, EIP);
+});
+
+Deno.test("COM capability e custo não confiável: eip/eiltv viram null (money não se fabrica)", () => {
+  const out = projetarCandidato(candidato({ margin: null }), true) as Record<
+    string,
+    Record<string, unknown>
+  >;
+  assertEquals(out.margin, null);
+  assertEquals(out.eip, null, "EIP é R$ — sem margem confiável não há lucro a afirmar");
+  assertEquals(out._admin.eiltv, null);
+});
+
+// ── Explicação: o R$ que ia embutido na PROSA ───────────────────────────────────────────────
+Deno.test("explicação sem capability: mantém o sinal, perde o número", () => {
+  const txt = textoExplicacaoMargem("Lixa 220", MARGEM, false);
+  assert(!txt.includes("R$"), `o R$ sobreviveu na prosa: ${txt}`);
+  assert(!txt.includes("92"), `o valor sobreviveu na prosa: ${txt}`);
+  assert(txt.includes("alto potencial de margem"), "o sinal de venda foi destruído junto");
+});
+
+Deno.test("explicação com capability: o número volta", () => {
+  const txt = textoExplicacaoMargem("Lixa 220", MARGEM, true);
+  assert(txt.includes("R$ 92.23"), `esperava o valor formatado, veio: ${txt}`);
+});
+
+// ── Meta ────────────────────────────────────────────────────────────────────────────────────
+Deno.test("meta: weights só com capability (é insumo da inversão de score_final)", () => {
+  const pesos = { wA: 0.25, wP: 0.35, wS: 0.2, wC: 0.2 };
+  const sem = projetarMeta(50, "profit", pesos, 5, false);
+  assert(!("weights" in sem), "weights vazou sem cap_custo_ler");
+  assertEquals(sem.total_candidates, 50, "o resto do meta continua");
+
+  const com = projetarMeta(50, "profit", pesos, 20, true);
+  assertEquals(com.weights, pesos);
+});
+
+// ── Limite de candidatos ────────────────────────────────────────────────────────────────────
+Deno.test("limite: vendedora recebe top_n_vendedor, admin recebe top_n_admin", () => {
+  assertEquals(limiteCandidatos(5, 20, false), 5, "config já dizia 5 e o código devolvia 20");
+  assertEquals(limiteCandidatos(5, 20, true), 20);
+});

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -1,4 +1,10 @@
 import { createClient } from "npm:@supabase/supabase-js@2";
+import {
+  limiteCandidatos,
+  projetarCandidato,
+  projetarMeta,
+  textoExplicacaoMargem,
+} from "../_shared/recommend-projecao.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -96,11 +102,27 @@ interface Candidate {
   penalties: number;
 }
 
+/**
+ * FU4-F/3: a capability de CUSTO do usuário chamador.
+ *
+ * ⚠️ Recebe o client do JWT DO USUÁRIO (supabaseAuth), nunca o service_role: `public.pode_ler_custo()`
+ * é sem parâmetro e resolve por `auth.uid()`. Com service_role o uid é NULL e a resposta é `false` —
+ * ligar no client errado falha FECHADO (nega custo), nunca aberto.
+ *
+ * Fail-closed também no erro: RPC indisponível ⇒ `false`. "Não consegui verificar" não é permissão.
+ */
+async function podeLerCusto(dbUsuario: ReturnType<typeof createClient>): Promise<boolean> {
+  const { data, error } = await dbUsuario.rpc("pode_ler_custo");
+  if (error) return false;
+  return data === true;
+}
+
 async function recommend(
   db: ReturnType<typeof createClient>,
   customerId: string,
   basketProductIds: string[],
-  farmerId: string
+  farmerId: string,
+  podeCusto: boolean
 ) {
   // 1. Load config + customer orders + products + costs + rules + client score in PARALLEL
   const [
@@ -237,7 +259,8 @@ async function recommend(
       explanationText = `${Math.round(sim * 100)}% dos clientes similares compram ${p.descricao}`;
     } else if (margemExibida != null && margemExibida > 50) {
       explanationKey = "margin";
-      explanationText = `${p.descricao} tem alto potencial de margem (R$ ${margemExibida.toFixed(2)})`;
+      // O R$ ia EMBUTIDO NA PROSA — nenhum gate de campo pegaria isto. O sinal fica, o número sai.
+      explanationText = textoExplicacaoMargem(p.descricao, margemExibida, podeCusto);
     } else if (ctx > 0.2) {
       explanationKey = "context";
       explanationText = `Baseado no histórico de compras, ${p.descricao} complementa bem o mix`;
@@ -259,7 +282,12 @@ async function recommend(
     basketFamilies[familia] = (basketFamilies[familia] || 0) + 1;
   }
 
-  if (candidates.length === 0) return { recommendations: [], meta: { total_candidates: 0, mode: "profit", weights: { wA, wP, wS, wC }, top_n: topN } };
+  // ⚠️ o retorno vazio TAMBÉM passa pela projeção: `weights` é insumo da inversão de score_final e
+  // vazava por aqui. (O `mode` fixo em "profit" desta linha é inconsistência PRÉ-EXISTENTE com o
+  // retorno principal — preservada verbatim para manter o diff restrito a autorização.)
+  if (candidates.length === 0) {
+    return { recommendations: [], meta: projetarMeta(0, "profit", { wA, wP, wS, wC }, topN, podeCusto) };
+  }
 
   // Normalize and score
   const assocNormed = minMaxNorm(candidates.map((c) => c.assoc_score));
@@ -277,7 +305,9 @@ async function recommend(
   }
 
   candidates.sort((a, b) => b.score_final - a.score_final);
-  const topCandidates = candidates.slice(0, topNAdmin);
+  // Sem a capability, `top_n_vendedor` (5) em vez de `top_n_admin` (20): a config já distinguia os
+  // dois e o código devolvia 20 para todos. Menos itens = menos superfície do canal de ordenação.
+  const topCandidates = candidates.slice(0, limiteCandidatos(topN, topNAdmin, podeCusto));
 
   // BATCH log impressions (single insert instead of N inserts)
   const logRows = topCandidates.slice(0, topN).map((c) => ({
@@ -308,28 +338,18 @@ async function recommend(
     await db.from("recommendation_log").insert(logRows);
   }
 
+  // FU4-F/3: a decisão de quem vê número acontece AQUI, no servidor. Antes, `_admin.cost_final` ia
+  // para todo staff e o browser apagava depois de receber (useRecommendationEngine.ts) — a resposta
+  // de rede já tinha entregue o custo.
   return {
-    recommendations: topCandidates.map((c) => ({
-      product_id: c.product_id, codigo: c.codigo, descricao: c.descricao,
-      price: c.price, margin: c.margin, probability: c.probability,
-      eip: c.margin != null ? c.eip : null, score_final: c.score_final,
-      recommendation_type: c.recommendation_type,
-      explanation_text: c.explanation_text, explanation_key: c.explanation_key,
-      estoque: c.estoque,
-      _admin: {
-        cost_final: c.cost_final, cost_source: c.cost_source,
-        cost_confidence: c.cost_confidence, estimated_cost_for_ranking: c.cost_ranking,
-        assoc_score: c.assoc_score,
-        sim_score: c.sim_score, ctx_score: c.ctx_score,
-        penalties: c.penalties, familia: c.familia, eiltv: c.margin != null ? c.eiltv : null,
-      },
-    })),
-    meta: {
-      total_candidates: candidates.length,
-      mode: mode === 0 ? "profit" : "ltv",
-      weights: { wA, wP, wS, wC },
-      top_n: topN,
-    },
+    recommendations: topCandidates.map((c) => projetarCandidato(c, podeCusto)),
+    meta: projetarMeta(
+      candidates.length,
+      mode === 0 ? "profit" : "ltv",
+      { wA, wP, wS, wC },
+      topN,
+      podeCusto,
+    ),
   };
 }
 
@@ -411,7 +431,10 @@ Deno.serve(async (req) => {
       case "recommend": {
         const { customer_id, basket_product_ids = [] } = params;
         if (!customer_id) throw new Error("customer_id obrigatório");
-        result = await recommend(supabaseAdmin, customer_id, basket_product_ids, user.id);
+        // ⚠️ supabaseAuth (JWT do usuário), NÃO supabaseAdmin: pode_ler_custo() resolve por
+        // auth.uid(). Com service_role o uid é NULL e a resposta seria `false` — fail-closed.
+        const podeCusto = await podeLerCusto(supabaseAuth);
+        result = await recommend(supabaseAdmin, customer_id, basket_product_ids, user.id, podeCusto);
         break;
       }
       case "log_accept": {

--- a/supabase/migrations/20260724130000_authz_custo_fu4f_fase3_recommend.sql
+++ b/supabase/migrations/20260724130000_authz_custo_fu4f_fase3_recommend.sql
@@ -1,0 +1,255 @@
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+-- FU4-F fase 3 (PR-A) — a edge `recommend` para de devolver custo ao browser
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+--
+-- CONTEXTO. A fase 1 (20260723140000) deixou explícito o que sobrava: as vias que baixam custo
+-- para o browser. Esta é a PRIMEIRA delas, e a única VIVA — medido em prod 2026-07-20:
+--
+--   · a edge `recommend` tem gate `employee OR master` e monta `_admin.cost_final` INCONDICIONAL;
+--     quem apaga é o cliente (useRecommendationEngine.ts:69-75), DEPOIS de receber. A resposta de
+--     rede já entregou o custo — fachada, não proteção.
+--   · `margin` é top-level e renderizado FORA do showAdminBreakdown (RecommendationCard.tsx:81),
+--     ao lado de `price` (:62) ⇒ custo = preço − margem, aritmética de duas células da mesma tela.
+--
+-- POPULAÇÃO REAL: 3 staff — 1 master, 2 employee (ambos commercial_role='farmer'). Só o master tem
+-- private.cap_custo_ler. Os 2 farmers são a superfície inteira desta frente. Não é hipotético e
+-- não é grande: dimensionar honesto é parte da entrega.
+--
+-- ESCOPO DESTA MIGRATION — só o que o banco precisa dar à edge:
+--   1) public.pode_ler_custo()  — a edge não alcança `private` (PostgREST só expõe `public`)
+--   2) recommendation_log       — a edge grava unit_cost e a RLS deixava os farmers lerem
+--
+-- A projeção em si (nulificar margin/eip/_admin/weights) é do CÓDIGO da edge, no mesmo PR.
+--
+-- ⚠️ LIMITE HONESTO (mesma disciplina do #1434/fase 1): fechar o NÚMERO não fecha o SINAL.
+-- A ORDEM do ranking embute margem via score_final, e o ramo `margin` do explanation_text prova
+-- `margem > 50` (limiar FIXO ⇒ 1 desigualdade por SKU, não busca binária). Declarado no corpo do
+-- PR em vez de anunciar "custo fechado". Barreira de conveniência, como a fase 1.
+--
+-- Aplicada À MÃO pelo dono no SQL Editor do Lovable.
+-- Prova: db/test-authz-custo-fu4f-fase3-recommend.sh (PG17, baseline + falsificação ancorada).
+-- ════════════════════════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+-- 0) PRECONDIÇÕES — aborta em vez de aplicar num banco divergente do medido
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  -- Dependência dura: esta migration ENVOLVE cap_custo_ler. Sem ela, o wrapper referenciaria
+  -- função inexistente e falharia só em RUNTIME (plpgsql é late-bound) — atrás de um try/catch da
+  -- edge isso vira "ninguém lê custo" ou, pior, um erro engolido lido como `false`.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'private' AND p.proname = 'cap_custo_ler'
+  ) THEN
+    RAISE EXCEPTION 'FU4-F/3: private.cap_custo_ler ausente — aplique o #1434 (20260718190000) ANTES'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename='recommendation_log') THEN
+    RAISE EXCEPTION 'FU4-F/3: public.recommendation_log ausente — banco divergente do medido'
+      USING ERRCODE = 'raise_exception';
+  END IF;
+END $$;
+
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+-- 1) public.pode_ler_custo() — a ponte mínima entre a edge e a capability
+--
+--    POR QUE EXISTE: `private` não é exposto pelo PostgREST, então a edge não chama
+--    private.cap_custo_ler diretamente. A alternativa — replicar a regra em TypeScript — derivaria
+--    em FAIL-OPEN (a edge acharia que pode quando o banco diz que não) na primeira vez que a
+--    capability mudasse. Wrapper fino mantém UMA definição.
+--
+--    ⚠️ SEM PARÂMETRO, DE PROPÓSITO. Uma `pode_ler_custo(_uid uuid)` seria um ORÁCULO DE
+--    CAPABILITY: qualquer caller sondaria a permissão de QUALQUER usuário. Sem argumento, a função
+--    responde só sobre o CALLER — informação que ele já obtém observando a própria tela. Zero
+--    informação nova.
+--
+--    ⚠️ CONSEQUÊNCIA DESEJADA: chamada com a chave service_role, auth.uid() é NULL e a função
+--    devolve FALSE. Se alguém ligar a edge no client errado, ela falha FECHADA (nega custo), nunca
+--    aberta. A edge tem de chamar com o JWT do usuário (supabaseAuth), não com supabaseAdmin.
+--
+--    STABLE (não IMMUTABLE): lê tabelas. SECURITY DEFINER para alcançar `private`.
+--    pg_temp por ÚLTIMO no search_path (regra FU7 — pg_temp na frente é vetor de shadowing).
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.pode_ler_custo()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', pg_temp
+AS $function$
+  SELECT COALESCE(private.cap_custo_ler((SELECT auth.uid())), false);
+$function$;
+
+COMMENT ON FUNCTION public.pode_ler_custo() IS
+  'FU4-F/3: espelha private.cap_custo_ler para o CALLER (sem parâmetro — não é oráculo de '
+  'capability de terceiros). Consumida pela edge `recommend` com o JWT do usuário. Com '
+  'service_role auth.uid() é NULL e o retorno é false (fail-closed).';
+
+-- Supabase concede EXECUTE por DEFAULT a PUBLIC/anon/authenticated/service_role em função nova de
+-- `public`. Revogar de PUBLIC NÃO remove grant nomeado (database.md) ⇒ revogar por NOME.
+REVOKE ALL ON FUNCTION public.pode_ler_custo() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.pode_ler_custo() FROM anon;
+GRANT EXECUTE ON FUNCTION public.pode_ler_custo() TO authenticated;
+
+-- ↑ `authenticated` é INTENCIONAL e é o ponto do desenho sem-parâmetro: o usuário só descobre a
+--   PRÓPRIA capability. É assim que a edge (que chama com o JWT dele) obtém a resposta.
+--   `anon` fica de fora: sem sessão não há custo a decidir.
+
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+-- 2) recommendation_log — a edge grava unit_cost; os farmers liam
+--
+--    Medido em prod 2026-07-20: 683 linhas, 3 com unit_cost, 154 SKUs, último 2026-06-14.
+--    Policy única `Staff can manage recommendation log`, cmd=ALL, USING master OR employee.
+--    ZERO leitores no frontend (grep em src/: só types.ts gerado e um doc).
+--
+--    Writers: SÓ a edge `recommend`, com SUPABASE_SERVICE_ROLE_KEY (index.ts:374) — service_role
+--    BYPASSA RLS, então trocar ALL por SELECT-only não afeta a gravação. Verificado enumerando os
+--    writers (grep em supabase/functions/): index.ts:308 e :346, ambos sobre o client admin.
+--
+--    ⚠️ Ao APERTAR este gate, todo assert que dependia do gate antigo vira suspeito (corolário
+--    medido 3× no #1488): não há asserts pré-existentes sobre esta tabela — conferido, e é por
+--    isso que o harness novo traz os dele.
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+DROP POLICY IF EXISTS "Staff can manage recommendation log" ON public.recommendation_log;
+DROP POLICY IF EXISTS recommendation_log_select_custo ON public.recommendation_log;
+
+CREATE POLICY recommendation_log_select_custo ON public.recommendation_log
+  FOR SELECT TO authenticated
+  USING ((SELECT private.cap_custo_ler((SELECT auth.uid()))));
+
+-- Sem policy de INSERT/UPDATE/DELETE para `authenticated`: a escrita é exclusiva do service_role.
+-- Isto ESTREITA de propósito (a policy ALL antiga concedia escrita a qualquer employee).
+
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+-- 3) ASSERTIONS — estruturais, sobre o CATÁLOGO, com o corpo SEM COMENTÁRIOS
+--
+--    Duas lições caras aplicadas aqui:
+--    · #1488: assert de existência por to_regprocedure, NUNCA comparando
+--      pg_get_function_identity_arguments com string literal — ela inclui os NOMES dos parâmetros
+--      e o `=` nunca casa, deixando o detector eternamente cego.
+--    · #1472/#1488: assert sobre corpo de função roda sobre a definição com os comentários
+--      REMOVIDOS — a própria migration é fonte do texto que o assert lê de volta, e `.` casa
+--      newline no regex do Postgres.
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+DO $$
+DECLARE v_n int; v_qual text; v_code text; v_oid oid;
+BEGIN
+  -- A1: a função existe COM A ASSINATURA EXATA (zero argumentos). to_regprocedure devolve NULL se
+  --     ausente em vez de levantar erro, e resolve tipo de verdade em vez de comparar texto.
+  v_oid := to_regprocedure('public.pode_ler_custo()');
+  IF v_oid IS NULL THEN
+    RAISE EXCEPTION 'FU4-F/3 A1: public.pode_ler_custo() ausente apos a migration'
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A2: assinatura de segurança — SECURITY DEFINER + STABLE + search_path fixo com pg_temp no FIM.
+  SELECT count(*) INTO v_n FROM pg_proc p
+   WHERE p.oid = v_oid AND p.prosecdef AND p.provolatile = 's'
+     AND array_to_string(p.proconfig, ',') = 'search_path=public, pg_temp';
+  IF v_n <> 1 THEN
+    RAISE EXCEPTION 'FU4-F/3 A2: pode_ler_custo() sem SECURITY DEFINER/STABLE/search_path esperado'
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A2b: OWNER confiável. ⚠️ Achado do Codex (gpt-5.6-sol xhigh, 2026-07-20): `CREATE OR REPLACE`
+  --      PRESERVA o owner de uma função pré-existente. Se a assinatura já existisse com owner não
+  --      confiável, esse owner poderia redefinir a RPC para `SELECT true` — e a edge, com
+  --      service_role, materializaria o custo.
+  --      Medido em prod 2026-07-20: `CREATE` em `public` é FALSE para anon/authenticated/
+  --      service_role/authenticator/PUBLIC, então a precondição do ataque NÃO vale hoje (por isso
+  --      P2, não P1). Este assert PRENDE a propriedade em vez de deixá-la verdadeira por acidente.
+  --      Âncora = o owner da própria capability que a função delega (ambas `postgres` em prod).
+  IF (SELECT proowner FROM pg_proc WHERE oid = v_oid)
+     <> (SELECT p.proowner FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+          WHERE n.nspname='private' AND p.proname='cap_custo_ler') THEN
+    RAISE EXCEPTION 'FU4-F/3 A2b: pode_ler_custo() tem owner % , diferente do de private.cap_custo_ler (%) — SECDEF com dono nao confiavel',
+      (SELECT pg_get_userbyid(proowner) FROM pg_proc WHERE oid = v_oid),
+      (SELECT pg_get_userbyid(p.proowner) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+        WHERE n.nspname='private' AND p.proname='cap_custo_ler')
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A2c: e nenhum papel exposto pode CRIAR em `public` — a precondição do ataque acima.
+  SELECT count(*) INTO v_n FROM unnest(ARRAY['anon','authenticated','service_role']) AS r
+   WHERE has_schema_privilege(r, 'public', 'CREATE');
+  IF v_n <> 0 THEN
+    RAISE EXCEPTION 'FU4-F/3 A2c: % papel(is) exposto(s) com CREATE em public — podem pre-criar/roubar SECDEF', v_n
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A3: o corpo delega a cap_custo_ler, ancorado na CHAMADA COM ARGUMENTO (não no nome solto), e
+  --     sobre o código SEM COMENTÁRIOS. Sem o strip, o COMMENT acima — que cita o nome da função —
+  --     satisfaria o assert e ele ficaria verde com o corpo vazio.
+  v_code := regexp_replace(pg_get_functiondef(v_oid), '--[^\n]*', '', 'g');
+  IF v_code !~ 'private\.cap_custo_ler\s*\(' THEN
+    RAISE EXCEPTION 'FU4-F/3 A3: pode_ler_custo() nao delega a private.cap_custo_ler'
+      USING ERRCODE='raise_exception';
+  END IF;
+  -- e NÃO aceita parâmetro (o desenho anti-oráculo depende disso)
+  IF pg_get_function_identity_arguments(v_oid) <> '' THEN
+    RAISE EXCEPTION 'FU4-F/3 A3: pode_ler_custo() ganhou parametro — vira oraculo de capability (args=%)',
+      pg_get_function_identity_arguments(v_oid) USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A4: `anon` NÃO executa. has_function_privilege cobre o efetivo (grant direto ou via PUBLIC),
+  --     que é o que importa — revogar de PUBLIC sem revogar de anon deixaria isto verdadeiro.
+  IF has_function_privilege('anon', v_oid, 'EXECUTE') THEN
+    RAISE EXCEPTION 'FU4-F/3 A4: anon executa pode_ler_custo()' USING ERRCODE='raise_exception';
+  END IF;
+  -- e `authenticated` EXECUTA (controle POSITIVO: sem ele, "negado para todos" passaria como sucesso
+  -- e a edge quebraria em prod com o assert verde)
+  IF NOT has_function_privilege('authenticated', v_oid, 'EXECUTE') THEN
+    RAISE EXCEPTION 'FU4-F/3 A4: authenticated NAO executa pode_ler_custo() — a edge quebra'
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A5: recommendation_log — RLS ligada. Policy em tabela com RLS off não protege nada.
+  IF NOT EXISTS (SELECT 1 FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+                  WHERE n.nspname='public' AND c.relname='recommendation_log' AND c.relrowsecurity) THEN
+    RAISE EXCEPTION 'FU4-F/3 A5: RLS desabilitada em recommendation_log' USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A6: inventário EXATO das permissivas de leitura. Permissivas combinam com OR ⇒ uma segunda,
+  --     ainda que "inofensiva", reabriria a tabela.
+  SELECT count(*) INTO v_n FROM pg_policies
+   WHERE schemaname='public' AND tablename='recommendation_log'
+     AND cmd IN ('SELECT','ALL') AND permissive='PERMISSIVE';
+  IF v_n <> 1 THEN
+    RAISE EXCEPTION 'FU4-F/3 A6: esperava 1 policy permissiva de leitura em recommendation_log, ha %', v_n
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A7: e ela é a nossa, no comando/roles certos, gateada por cap_custo_ler e SEM disjunção
+  --     (`USING (cap_custo_ler(...) OR true)` passaria num assert que só procurasse o nome).
+  SELECT qual INTO v_qual FROM pg_policies
+   WHERE schemaname='public' AND tablename='recommendation_log'
+     AND policyname='recommendation_log_select_custo'
+     AND cmd='SELECT' AND permissive='PERMISSIVE' AND roles::text = '{authenticated}';
+  IF v_qual IS NULL THEN
+    RAISE EXCEPTION 'FU4-F/3 A7: policy ausente ou com cmd/permissividade/roles fora do esperado'
+      USING ERRCODE='raise_exception';
+  END IF;
+  IF v_qual !~ 'cap_custo_ler' THEN
+    RAISE EXCEPTION 'FU4-F/3 A7: policy nao gateia por cap_custo_ler (qual=%)', v_qual
+      USING ERRCODE='raise_exception';
+  END IF;
+  IF v_qual ~* '\mor\M' THEN
+    RAISE EXCEPTION 'FU4-F/3 A7: expressao da policy contem disjuncao — gate ampliado (qual=%)', v_qual
+      USING ERRCODE='raise_exception';
+  END IF;
+
+  -- A8: nenhuma policy de ESCRITA sobrou para `authenticated` (a ALL antiga concedia).
+  SELECT count(*) INTO v_n FROM pg_policies
+   WHERE schemaname='public' AND tablename='recommendation_log'
+     AND cmd IN ('INSERT','UPDATE','DELETE','ALL');
+  IF v_n <> 0 THEN
+    RAISE EXCEPTION 'FU4-F/3 A8: sobrou policy de escrita em recommendation_log (%)', v_n
+      USING ERRCODE='raise_exception';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## O vazamento: o strip é no browser, DEPOIS de receber

A edge `recommend` tem gate `employee OR master` e monta `_admin.cost_final` **incondicionalmente**. Quem apaga é o cliente:

```ts
// useRecommendationEngine.ts:69-75  (removido neste PR)
if (!isAdmin) { res.recommendations = res.recommendations.map(r => { const { _admin, ...rest } = r; return rest; }); }
```

A resposta de rede já entregou o custo. É a fachada que o spec irmão nomeia — "mascarar a saída mantendo o `fetch`".

E há um caminho mais curto que nem precisa do `_admin`: **`margin` é top-level**, renderizado em `RecommendationCard.tsx:81` **fora** do `showAdminBreakdown`, ao lado de `price` na linha 62 ⇒ `custo = preço − margem`. Duas células da mesma tela.

## Quem é afetado — medido, não estimado

| | |
|---|---|
| staff em prod | **3** — 1 `master`, 2 `employee` |
| os 2 `employee` | ambos `commercial_role='farmer'` |
| quem tem `cap_custo_ler` | **só o master** |
| usuários `gerencial`/`estrategico` | **0** |

**Os 2 farmers são a superfície inteira.** Não é hipotético e não é grande — dimensionar honesto é parte da entrega.

## A superfície de inversão é maior que `cost_final`

Enumerada do código, não por analogia. Nulificar o campo óbvio não fecharia:

| campo | por que inverte |
|---|---|
| `margin` | `custo = price − margin`, direto |
| `eip` | `eip = probability × margem`, e `probability` **é devolvido** ⇒ divisão |
| `_admin.eiltv` | idem |
| `cost_final`, `estimated_cost_for_ranking` | literais |
| `score_final` + `meta.weights` + sub-scores | `score_final = wA·assocN + wP·eipN + …`; com pesos e sub-scores isola-se `eipN`, e `minMaxNorm` é invertível a menos de afim ⇒ 2 âncoras fixam a afim |
| `explanation_text` | ⚠️ o R$ ia **embutido na PROSA** (`"…margem (R$ 92.23)"`) — nenhum gate de campo pega isso |

## O que muda

**1. `public.pode_ler_custo()` — SEM PARÂMETRO.** `private` não é alcançável por PostgREST. Replicar a regra em TS derivaria em **fail-open**. Uma versão `(_uid uuid)` seria **oráculo de capability de terceiros**; sem argumento responde só sobre o caller — informação que ele já tem olhando a própria tela.

⚠️ **Propriedade defensiva:** com `service_role`, `auth.uid()` é `NULL` ⇒ `false`. Ligar a edge no client errado falha **FECHADO**. Por isso ela chama com `supabaseAuth`, e o harness prova esse caso (A6).

**2. Projeção fail-closed**, em `_shared/recommend-projecao.ts` como **função pura** — a suíte de edge roda `--no-remote` e não pode importar `index.ts`. Sem a capability: `_admin` some **inteiro** (não nulificado campo a campo), `score_final` migra para dentro dele, `weights` sai do meta, o R$ sai da prosa, e o retorno cai de `top_n_admin` (20) para `top_n_vendedor` (5) — a config já distinguia os dois e o código devolvia 20 para todos.

O objeto do caso negativo é montado do zero por lista branca: **campo novo no `Candidate` não vaza sozinho.**

**3. `recommendation_log`** — persiste `unit_cost`, `margin`, `eip`, `score_*` e `weights`; RLS era `master OR employee`. SELECT passa a exigir `cap_custo_ler`. Writer real é a edge com `service_role` (bypassa RLS) — verificado enumerando os writers. Zero leitores no frontend ⇒ impacto de UX nulo.

**4. O strip client-side SAI.** Manter "como defense-in-depth" seria errado: `isAdmin` é `role === 'master'`, **estritamente mais restrito** que `cap_custo_ler`. Duas autoridades discordando não é profundidade — é uma tela que esconde de quem o servidor autorizou.

## Prova

`db/test-authz-custo-fu4f-fase3-recommend.sh` — **20 asserts + 7 falsificações, exit 0**
(eram 4; S5/S6/S7 entraram na rodada do Codex — ver a seção no fim).

**Baseline B1–B4 roda ANTES da migration**: prova o detector vendo o mundo vivo (farmer lendo as 3 linhas e escrevendo). Sem isso, "lê 0 depois" não se distingue de "a query quebrou".

| # | sabotagem | vermelho observado |
|---|---|---|
| S1 | `pode_ler_custo()` → `true` | A4 (farmer não tem) virou `t` |
| S2 | `GRANT EXECUTE TO anon` | A7 virou `t` |
| S3 | policy antiga de volta | A10 (farmer lê 0) virou `3` |
| S4 | **sem policy nenhuma** | A11 (master lê 3) virou `0` |
| D1 | gate de projeção desligado | 3 testes Deno, nomeados |
| D2 | R$ de volta na prosa | 1 teste Deno, nomeado |

**S4 é o controle positivo e o mais importante:** sem ele, "ninguém lê nada" passaria como sucesso — A10 ficaria verde com a tabela quebrada.

⚠️ **Um assert caiu na 1ª rodada e o achado foi do stub, não do código:** A14 (`service_role` grava) falhou porque meu stub concedia só a `authenticated`. A prod concede a `anon`, `authenticated` **e** `service_role` (medido com `has_table_privilege`). Stub menos permissivo que a prod inventa segurança que não existe. Corrigido — e os GRANTs **ficam como estão de propósito**: revogar `INSERT` de `authenticated` faria A13 passar por falta de *privilégio* em vez de falta de *policy*, e ele seguiria verde se uma policy permissiva de INSERT reaparecesse.

Gates: `typecheck` · `test` (5514) · `test:edges` (164, inclui os 10 novos) · `lint` (0 errors) · `authz:check` · `build` · `claude:size` — todos exit 0.

## ⚠️ O que este PR NÃO fecha — e é preciso dizer

1. **Ordem + pertencimento ao top-N + distribuição sob chamadas repetidas.** ⚠️ *Ampliado após o
   Codex — eu tinha declarado só "a ordem".* `score_final` embute margem via `eipN`, então a
   ordenação devolve desigualdades; **entrar ou não no top-N é sinal por si só** (custo desconhecido
   recebe `margemRank=0` e cai no ranking — a identidade do SKU omitido é o canal); e sob **chamadas
   repetidas** a frequência de inversões estima diferenças de `score_final`. O `epsilon_exploration`
   (0,10) que eu citei como defesa é, sob repetição, um **canal de medição**.
2. **1 bit por SKU — pela FRASE, não pela chave.** ⚠️ *Correção do Codex, que eu verifiquei no
   código: o que eu tinha escrito aqui estava errado.* `explanationKey` é **inicializado** como
   `"margin"` e o `else` final não o troca ⇒ `explanation_key === 'margin'` vale também para o
   fallback e **não prova nada**. Quem prova `margem > 50` é a frase *"alto potencial de margem"*.
   O resíduo existe (1 desigualdade por SKU, limiar fixo, não busca binária) e é **menor** do que eu
   havia declarado. Mantido de propósito: suprimir a frase degradaria a explicação a "boa adição ao
   mix", destruindo conteúdo real para fechar 1 bit.
3. ⚠️ **Esconder `meta.weights` é defense-in-depth, não barreira** — achado da minha própria passada adversarial, contra o que eu tinha escrito acima. `recommendation_config` tem policy `master OR employee` e contém `w_assoc=0.25`, `w_eip=0.35`, `w_sim=0.20`, `w_ctx=0.20`: o mesmo usuário de quem escondo os pesos na resposta os lê da tabela com um `select`. `farmer_association_rules` (idem) reconstrói `assoc_score`. **O que encarece a inversão de verdade é `score_final` ter saído da resposta** — sobram desigualdades (a ordem), não valores. Fechar a config não é de graça: `useAnalyticsSync` lê **e escreve** a tabela numa tela de tuning ⇒ follow-up com evidência (§6.4 da spec), não escopo deste PR.
4. `product_costs` **continua** com policy `master OR employee` — PR-A não toca a tabela. É o PR-B.

## ⚠️ Entrega — 3 camadas manuais

1. **Migration** `20260724130000_authz_custo_fu4f_fase3_recommend.sql` no SQL Editor — **não auto-aplica**, falha silenciosa
2. **Deploy da edge `recommend`** pelo chat do Lovable, verbatim da `main`. ⚠️ Conferir `git log -S pode_ler_custo -- supabase/functions/recommend/index.ts` **antes** de pedir — o sync bidirecional já reverteu wiring de edge 4h depois do merge (#1445→#1478)
3. **Publish** do frontend

**Ordem: `edge` → `migration` → verificar as duas → `Publish`.** ⚠️ *Invertida após o Codex — eu
tinha `migration → edge`, que é a ordem menos fail-closed das duas:* com a migration aplicada e a
edge velha no ar, **o vazamento continua aberto**; com a edge nova e o banco velho, a RPC ausente
vira erro → `false` → resposta **já redigida**. O custo da ordem adotada é o master perder o
breakdown até a migration entrar — degradação honesta, não vazamento.

O front velho tolera `_admin` ausente (já é opcional no tipo). `types.ts` **não** precisa regenerar:
`pode_ler_custo` é chamada só de dentro da edge (Deno), não do cliente tipado.

Validação pós-apply (eu rodo por `psql-ro`, sem invocar a função — invocar exige EXECUTE e dá falso-negativo sob `claude_ro`):

```sql
SELECT to_regprocedure('public.pode_ler_custo()') IS NOT NULL AS existe,
       has_function_privilege('anon', to_regprocedure('public.pode_ler_custo()'), 'EXECUTE') AS anon_exec,
       (SELECT count(*) FROM pg_policies WHERE tablename='recommendation_log') AS policies_log;
-- esperado: t | f | 1
```

## Contexto

Spec: `docs/superpowers/specs/2026-07-20-fechamento-custo-recommend-engines-design.md`. Irmão do PR #1495 (fecha `useFarmerScoring`).

**PR-B (sessão própria)** — os 2 hooks + RPC de ranqueamento. Achado que muda o desenho dele e não estava no enunciado: `farmer_recommendations` guarda `m_ij` **e** `cluster_volume_estimate` na mesma linha ⇒ uma divisão dá a margem unitária exata (verificado: `134,26 / 2 = 67,13`), e `farmer_bundle_recommendations.bundle_products` tem `"cost"` literal no jsonb. Hoje as linhas são de mai/mar e **0 de 2.617** batem com o custo atual — mas **mover o cálculo para o servidor sem mexer na persistência re-arma o oráculo**, agora corrente.

**`useBaixoGiro` — verificado, não é lacuna:** `inventory_position` já tem `cap_custo_ler` nas duas policies. O efeito colateral é o inverso (comprador não-master vê `cmc` como "—" sem saber que é permissão) — questão de produto, registrada na §6 da spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 Revisão adversarial — Codex `gpt-5.6-sol`, reasoning `xhigh`

Veredito dele: **DONE_WITH_CONCERNS** — "nenhum P1 direto demonstrado sob os fatos fornecidos, mas eu manteria o draft por três P2 de hardening e um P2 de rollout."

### O que o Codex escreveu (parecer CRU, resumido sem edição de mérito)

| # | Achado dele | Onde |
|---|---|---|
| 1 | **P2** — a projeção não é totalmente fail-closed; `explanation_text` atravessa como conteúdo confiável. "Reproduzi e recebi `"explanation_text":"Custo interno R$ 7.77"`." E: *"O teste de serialização passa porque a própria fixture já contém texto sanitizado; portanto não prova a alegação de que captura número embutido em string."* | `recommend-projecao.ts:102` |
| 2 | **P2** — existe um **terceiro canal**: pertencimento ao top-N, amplificado pela distribuição de rankings em chamadas repetidas sob o ruído epsilon. *"O resíduo deveria ser declarado como 'ordem + pertencimento ao top-N + distribuição sob chamadas repetidas', não apenas ordem."* | `index.ts:223,292,302,307` |
| 3 | **P2** — `CREATE OR REPLACE` **preserva o owner** de uma função pré-existente e a migration não o fixa nem verifica. *"Torna-se P1 se `anon`/`authenticated` ou outro papel compartilhado tiver `CREATE` em `public`."* | `migration.sql:77,149` |
| 4 | **P2** — a ordem `migration → edge` mantém a exposição da edge velha na janela intermediária; `edge → migration` é mais fail-closed. | `migration.sql:117`, `index.ts:114,434` |
| P3 | **A afirmação de que `explanation_key='margin'` prova `margem > 50` está incorreta** — a linha 252 inicia a chave como `margin` e o fallback não a troca. *"Isso reduz, não aumenta, o vazamento declarado."* | `index.ts:252,268` |
| P3 | S4 não falsifica A13; A6 testa `authenticated` com UID nulo, não literalmente `service_role` — *"o rótulo está mais forte que a evidência."* | harness |

**Concessões que ele fez explicitamente:** `probability`/`recommendation_type`/`estoque`/`total_candidates` não dependem de custo; resposta vazia passa por `projetarMeta`; `weights` não vaza; erros não serializam candidatos; a capability usa o client do JWT e erro→`false`; A13 **não** é tautológico (o grant continua presente, a negação vem da policy); e remover o strip client-side é correto.

Parecer cru completo preservado pelo `codex-async.sh`.

### Minha calibragem (decisão minha, não dele)

Verifiquei os dois achados factuais antes de aceitar — Codex erra tanto quanto eu:

- **P3 `explanation_key`: ele está certo, eu estava errado.** `let explanationKey = "margin"` é o inicializador e o `else` final não o troca. Meu resíduo declarado estava **mal atribuído**: quem prova `margem > 50` é a *frase* "alto potencial de margem", não a chave. Corrigido na spec — e o resíduo é **menor** do que eu havia escrito.
- **#3 owner: rebaixado a P2 por medição.** `has_schema_privilege(..., 'public', 'CREATE')` em prod é **`f`** para `anon`, `authenticated`, `service_role`, `authenticator` e `PUBLIC` — a precondição do ataque não vale hoje. Mas "verdadeiro por acidente" não é invariante: virou assert.

Todos os quatro P2 foram atacados nesta revisão:

| Achado | O que mudou |
|---|---|
| #1 `explanation_text` | `removerValores()` na **própria projeção** + fixture do teste agora **suja** de propósito. Falsificação **D3**: sanitizador vira no-op → os 2 asserts que o miram ficam vermelhos, nomeados. **Limite declarado no código:** pega a forma marcada com `R$`, não `"custo: 7.77"` — texto livre segue sendo responsabilidade do produtor, e isto é profundidade. |
| #2 top-N | Resíduo §3.4 reescrito: ordem **+ pertencimento ao top-N + distribuição sob repetição**. Registrei que o epsilon que eu citei como defesa é, sob chamadas repetidas, um **canal de medição**. |
| #3 owner | Asserts **A2b** (owner ≡ owner de `private.cap_custo_ler`) e **A2c** (nenhum papel exposto com `CREATE` em `public`) dentro da migration, com **duas** falsificações — ver abaixo. |
| #4 ordem | Adotada: **edge → migration → verificar as duas → Publish**, com a tabela do trade-off na spec. Fecho o vazamento antes, ao custo de o master perder o breakdown até a migration entrar — degradação honesta, não vazamento. |
| P3 harness | **S5** nova (policy permissiva de `INSERT` → A13 tem de cair); rótulo do **A6** corrigido para "uid NULO", que é o que ele mede de fato. |

### Um buraco que o Codex NÃO apontou e eu achei relendo meu próprio assert

O A2b que criei para fechar o achado #3 **era tautológico no harness**: ali `pode_ler_custo` e
`cap_custo_ler` são criadas pelo mesmo papel, então os owners são iguais **por construção** e o
assert nunca seria visto disparando. É exatamente o *detector-que-nunca-dispara* que custou o #1488
— e eu tinha acabado de reintroduzi-lo enquanto corrigia outro achado.

Fechado com a falsificação **S7**, que monta o ataque de verdade: um papel `atacante` pré-cria a
assinatura, a migration roda, e o `CREATE OR REPLACE` **preserva o owner hostil** — confirmando no
PG17 que a premissa do Codex é real — e então o A2b **aborta**. Sem S7, o achado #3 estaria
"corrigido" por um assert que não protege nada.

**Onde eu NÃO segui:** ele sugeriu manter o draft até fechar tudo — fechei os quatro, então proponho
tirar do draft. E mantive a frase "alto potencial de margem" (1 desigualdade por SKU, limiar fixo):
suprimi-la destruiria conteúdo legítimo para fechar 1 bit, e a spec declara isso como resíduo aceito.

**Prova depois das correções:** PG17 `20 asserts / 0 falhas` + **7 falsificações com dente** (era 4).
Deno `12 passed` no helper, `166 passed` na suíte de edges.
