### PR TITLE
ci(edges): deno check das 93 edges no validate — o gate que faltava

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@
 # - test:edges (deno test --no-remote): blocking — os 119 testes das edge functions. Rodavam em
 #   lugar NENHUM até 2026-07-18: existiam no repo, com script pronto no package.json, e o CI nunca
 #   os chamou. Detalhe (inclusive por que NÃO existe um gate de pin do deno) no próprio step.
+# - edges:typecheck (deno check): blocking — type-check dos 93 `index.ts` de edge. O `test:edges`
+#   acima NÃO cobre isso: `deno test` só type-checa o grafo que os testes alcançam, e nenhum
+#   `index.ts` é importado por teste algum. Até 2026-07-21 erro de tipo em edge passava VERDE em
+#   todos os gates e só quebrava em RUNTIME na produção (#1498). Único step do job que precisa de
+#   REDE; o porquê disso ser inevitável aqui está no próprio step.
 # - build (vite build): blocking — pega Tailwind quebrado + import errors + PWA setup
 # - lint (eslint): blocking em ERRORS — a dívida de `no-explicit-any` foi zerada
 #   (era ~1300 errors, hoje 0; ver CLAUDE.md §10/§13), então o lint virou gate
@@ -111,6 +116,38 @@ jobs:
 
       - name: Tests (edge functions — Deno, offline)
         run: bun run test:edges
+
+      # Type-check das EDGE FUNCTIONS — blocking. Buraco que ficou aberto mesmo depois do
+      # `test:edges` acima: `deno test` só type-checa o grafo que os TESTES alcançam, e por desenho
+      # os testes cobrem lógica PURA extraída (justamente para caber no `--no-remote`), então
+      # NENHUM `index.ts` de edge entra no grafo. Somado a `typecheck` (só src/) e `lint` (não
+      # type-checa Deno), erro de tipo numa edge ficava VERDE em TODOS os gates e só quebrava em
+      # RUNTIME na produção, depois do deploy manual pelo chat do Lovable. Detectado no PR #1498:
+      # `classifyProfile` usado sem estar no import passou por 5.527 testes vitest, 181 testes deno,
+      # typecheck e lint — só apareceu num `deno check` manual.
+      #
+      # ⚠️ Este step PRECISA de rede, ao contrário do `test:edges` — não dá para espelhar o
+      # `--no-remote` aqui: as edges importam `npm:`/`https://` de verdade e o check resolve o grafo
+      # todo (2.245 downloads, ~48s cold / ~2,5s warm). Mitigação do que dá: dos 3 hosts,
+      # `registry.npmjs.org` (2.087 requests) JÁ está no caminho de entrega via `bun install`; os
+      # novos são `esm.sh` (135) e `deno.land` (23), ambos de import legado — 34 edges em
+      # `deno.land/std/http/server.ts` (o `Deno.serve` nativo substitui) e 18 em
+      # `esm.sh/@supabase/supabase-js` (tem equivalente `npm:`). Migrar as duas famílias zera os
+      # hosts novos: é o follow-up 2 do spec.
+      #
+      # Sem `actions/cache` de propósito: o DENO_DIR fica em 681 MB (677 de tarballs npm) e
+      # economizaria ~30s dos 48s consumindo ~7% do budget de 10 GB do repo, mais drift de chave —
+      # e não há `deno.lock` versionado (está no .gitignore) para chavear. Roda DEPOIS de
+      # typecheck+vitest+test:edges pelo mesmo motivo que o `test:edges`: PR quebrado no comum falha
+      # antes de pagar a rede.
+      #
+      # O gate é de PRECISÃO, não de recall: falha só nas 6 classes de "símbolo/módulo não resolve"
+      # (a do #1498), que hoje estão em ZERO nas 93 edges — por isso não precisa de allowlist. As
+      # outras 141 (dívida de tipos gerados do Supabase) são reportadas sem falhar. O porquê da
+      # escolha, os números e os follow-ups estão no cabeçalho do script e no spec:
+      # docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md
+      - name: Type check (edge functions — Deno)
+        run: bun run edges:typecheck
 
       - name: Build
         run: bun run build

--- a/docs/historico/ci-testes-edge-deno.md
+++ b/docs/historico/ci-testes-edge-deno.md
@@ -94,3 +94,70 @@ em edge costuma ser guard que alguém achou que estava rodando e não está.
 > no-explicit-any` deixou o `deno lint` limpo e o CI vermelho com 4 erros. **Cada linter só enxerga o
 > seu próprio comentário de supressão**, então nenhum dos dois, sozinho, prova o outro. Regra prática
 > em `docs/agent/deploy.md` → "Edge — armadilhas".
+
+---
+
+# Sequela (2026-07-21): o `test:edges` rodava — e mesmo assim nenhuma edge era type-checada
+
+Plugar os testes no CI **não** fechou o buraco de tipos. `deno test` só type-checa o grafo que os
+testes **alcançam**, e por desenho os 15 arquivos de teste cobrem **lógica pura extraída** —
+justamente para caber no `--no-remote`. Nenhum `index.ts` de edge é importado por teste algum, então
+nenhum entrava no grafo. Com `typecheck` cobrindo só `src/` e o ESLint não type-checando Deno, **erro
+de tipo em edge ficava verde nos quatro gates** e só quebrava em runtime na produção, depois do
+deploy manual pelo Lovable.
+
+Detectado no PR #1498: `classifyProfile` usado sem estar no import em `generate-tactical-plan`
+sobreviveu a 5.527 testes vitest, 181 testes deno, typecheck e lint. Só apareceu num `deno check`
+manual. Fechado pelo step `edges:typecheck` (`scripts/edges-typecheck-gate.ts`).
+
+**A tensão com o `--no-remote` é real e não teve como evitar.** `deno check` precisa resolver o grafo
+de verdade — 2.245 downloads, ~48s cold / ~2,5s warm. O que dá para dizer com número: dos 3 hosts,
+`registry.npmjs.org` (2.087 requests) **já** está no caminho de entrega via `bun install`; os novos
+são `esm.sh` (135) e `deno.land` (23), ambos vindos de import legado. Migrar as duas famílias
+(follow-up) zera os hosts novos.
+
+**Diff-only foi medido e descartado:** checar *uma* edge custa 14–16s e ~2.000 requests — quase o
+mesmo que checar as 93. Quase toda edge importa `@supabase/supabase-js`, que sozinho arrasta ~2.000
+`.d.ts`; as outras 92 custam ~245 requests marginais. O diff economizaria tempo e **zero** do SPOF.
+
+## Quatro armadilhas medidas (deno 2.9.2)
+
+- **`deno check` cru não roda neste repo.** O `package.json` da raiz põe o Deno em modo node_modules
+  e ele **aborta na resolução**, antes de type-checar. Exige `--node-modules-dir=none` — que por
+  sinal é mais fiel ao Edge Runtime do Supabase. O `--no-remote` do `test:edges` corta antes e por
+  isso nunca esbarrou nisso.
+- **Com 1 erro só, o Deno OMITE a linha `Found N errors.`** Usá-la como marcador de "rodou" deixa o
+  gate cego exatamente no caso de 1 erro — a forma típica de símbolo faltando no import. O marcador
+  confiável é `error: Type checking failed.`
+- **Com o cache de check quente, a saída é vazia e exit 0.** "Saída vazia" é o caso de **sucesso**
+  normal, não anomalia — a decisão tem que pender do exit code, nunca do volume de saída.
+- **Glob de edge expandido pelo shell diverge entre shells:** zsh aborta com "no matches found",
+  bash passa o glob literal. Um glob que não casa nada viraria verde silencioso — a mesma família do
+  "glob de teste que não casa nada" logo acima. O gate enumera em TypeScript e trata 0 edges como
+  **falha**.
+
+## Por que o gate é de precisão, não de recall
+
+Medido na main de 2026-07-21: **141 erros de tipo em 25 das 93 edges** (68 limpas). Quase todos são
+ruído dos tipos gerados do Supabase — `does not exist on type 'never'`, `@ts-expect-error` obsoleto,
+e 17 `SupabaseClient not assignable` causados por `@supabase/supabase-js` aparecer em **6 versões
+distintas** nas edges. Código que roda.
+
+Já a classe que **quebra em runtime** — símbolo/módulo/membro que não resolve (`TS2304` `TS2552`
+`TS2307` `TS2305` `TS2724` `TS2503`) — está em **zero nas 93**. Gatear só nela dá um gate verde hoje
+**sem allowlist nenhuma**, cobrindo inclusive as 25 sujas e as de money-path.
+
+A alternativa (check completo + denylist das 25) excluiria justamente `fin-cashflow-engine`,
+`enviar-pedido-portal-sayerlack`, `omie-financeiro` e `recommend` — **o gate protegendo onde o risco
+é menor** — além de criar um arquivo-lista que vira ímã de conflito entre as worktrees paralelas.
+Apertar para check completo é o destino natural, depois que a dívida encolher.
+
+## Follow-ups (medidos)
+
+1. Consolidar `@supabase/supabase-js` numa versão só (hoje 6) — corta download e resolve 17 dos 141.
+2. Migrar `deno.land/std/http/server.ts` → `Deno.serve` (34 edges) e `esm.sh/@supabase/supabase-js` →
+   `npm:` (18 edges). Deixa `registry.npmjs.org` como host único.
+3. Zerar as 25 edges sujas e apertar o gate para check completo.
+4. Versionar `deno.lock` (hoje no `.gitignore`) — reprodutibilidade + chave de cache estável.
+
+Spec: `docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md`

--- a/docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md
+++ b/docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md
@@ -1,0 +1,114 @@
+# Gate de type-check das edge functions no CI — design
+
+**Data:** 2026-07-21 · **Motivador:** PR #1498 · **Escopo:** `.github/workflows/ci.yml` (job `validate`), `scripts/`, `package.json`
+
+## O buraco
+
+Nenhum gate do repo type-checa as edge functions:
+
+| Gate | Cobre | Por que não pega edge |
+|---|---|---|
+| `bun run typecheck` | `src/` + testes | `tsconfig.app.json` não inclui `supabase/functions/` |
+| `bun run test` (vitest) | `src/`, `scripts/` | `include` do `vitest.config.ts` |
+| `bun run test:edges` (deno) | edges **importadas por teste** | nenhuma `*/index.ts` é importada por teste algum |
+| `bun lint` (eslint) | `src/` | não type-checa; não roda em Deno |
+
+`deno test` só type-checa o grafo que os testes alcançam. Como os 15 arquivos de teste testam **lógica pura extraída** (por desenho — ver `docs/historico/ci-testes-edge-deno.md`), nenhum `index.ts` entra no grafo. Resultado: erro de tipo numa edge passa verde em todos os gates e só quebra em **runtime na produção**, depois do deploy manual pelo chat do Lovable.
+
+Detectado no PR #1498: `classifyProfile` usado sem estar no import em `generate-tactical-plan/index.ts` passou por 5.527 testes vitest, 181 testes deno, typecheck e lint. Só apareceu num `deno check` manual.
+
+## Medição (Deno 2.9.2 — mesmo pin do CI; feita em 2026-07-21)
+
+| Métrica | Valor |
+|---|---|
+| Edges (`supabase/functions/*/index.ts`) | 93 |
+| `deno check` **cold** (DENO_DIR virgem) | **48s** · 2.245 downloads · 681 MB |
+| `deno check` **warm** | **2,5s** |
+| Custo de **uma** edge cold | 14–16s · ~2.000 downloads · 617 MB |
+| Erros de tipo hoje | **141**, em **25 das 93** edges (68 limpas = 73%) |
+| Erros da classe "não resolve" (TS2304/2552/2307/2305/2724/2503) | **0** |
+| Hosts | `registry.npmjs.org` 2.087 · `esm.sh` 135 · `deno.land` 23 |
+
+### Três descobertas que fixaram a forma
+
+**1. `deno check` não roda cru neste repo.** Aborta na *resolução*, antes de type-checar: o `package.json` da raiz põe o Deno em modo node_modules e `npm:@simplewebauthn/server@10.0.1` (usado por `biometric-auth`) não está lá. Exige `--node-modules-dir=none` — que por sinal é mais fiel ao Edge Runtime real do Supabase, que resolve `npm:` do próprio registry sem node_modules. O `test:edges` nunca esbarrou nisso porque `--no-remote` corta antes.
+
+**2. Diff-only não compensa.** Checar *uma* edge custa 14–16s e ~2.000 requests — quase o mesmo que checar as 93 (48s, 2.245). Quase toda edge importa `@supabase/supabase-js`, que sozinho arrasta ~2.000 `.d.ts` transitivos; as outras 92 custam ~245 requests marginais. O diff economizaria ~2/3 do tempo e **zero** do SPOF de rede, ao custo de lógica de diff frágil (base ausente no push da main; mudança em `_shared/` afeta muitas edges). Descartado.
+
+**3. Dos 3 hosts, só 2 são novos no caminho de entrega.** `registry.npmjs.org` (2.087 dos 2.245 requests) já é usado pelo `bun install --frozen-lockfile`. Novos: `esm.sh` (135) e `deno.land` (23), ambos vindos de import legado — 34 edges em `https://deno.land/std@*/http/server.ts` (o `Deno.serve` nativo do Deno 2 substitui) e 18 em `https://esm.sh/@supabase/supabase-js@*` (tem equivalente `npm:`). Migrar zeraria os hosts novos → **follow-up**, não este PR (mexeria em ~50 edges que só deployam manualmente).
+
+### Dívida pré-existente: existe, mas não é a classe perigosa
+
+Os 141 erros são quase todos ruído dos tipos gerados do Supabase — `Property 'x' does not exist on type 'never'`, `@ts-expect-error` obsoleto (13), e `SupabaseClient not assignable` (17). Este último tem causa identificada: `@supabase/supabase-js` aparece em **6 versões distintas** nas edges (`npm:@2`, `@2.45.0`, `@^2`, `@^2.95.3`, `esm.sh@2`, `esm.sh@2.39.0`), então versões diferentes do tipo do client fluem para os helpers compartilhados. Código que **roda bem**.
+
+A classe que de fato crasha em runtime — símbolo ou módulo que não resolve, a do #1498 — está em **zero nas 93 edges**. É isso que permite um gate sem allowlist nenhuma.
+
+## Desenho
+
+### Componente 1 — `scripts/edges-typecheck-gate.ts`
+
+Casa o idioma de `authz-gate-check.ts` / `bun-pin-gate-check.ts`: `#!/usr/bin/env bun`, só builtins, cabeçalho explicando o porquê.
+
+**Enumera o glob em TypeScript** (`readdirSync`), não no shell. Motivo: zsh aborta com "no matches found" e bash passa o glob literal — comportamentos diferentes, e um glob que não casa nada viraria verde silencioso. Se a enumeração der 0 arquivos, o gate falha.
+
+**Classes bloqueantes** (6): `TS2304` `TS2552` `TS2307` `TS2305` `TS2724` `TS2503` — "cannot find name/module/namespace" e "has no exported member". Todas significam que o runtime quebra ao executar aquele caminho.
+
+**Classes toleradas:** as demais. Reportadas na saída como dívida conhecida, sem falhar.
+
+**Decisão fail-closed** (a parte que mais importa):
+
+| `deno check` | Saída contém `error: Type checking failed.` | Veredito |
+|---|---|---|
+| exit 0 | — | **passa** (com cache quente a saída é *vazia*; isso é sucesso normal, não anomalia) |
+| exit ≠ 0 | sim | parseável → classifica; bloqueia só se houver classe-crash |
+| exit ≠ 0 | não | **bloqueia** — infra/rede/resolução. Não conseguir checar ≠ estar limpo. |
+
+O marcador é `error: Type checking failed.`, **não** `Found N errors.`: com exatamente 1 erro o Deno omite a linha de contagem (verificado empiricamente). Usar a contagem como marcador deixaria o gate cego justamente no caso de 1 erro — que é a forma típica do #1498.
+
+Parse em TypeScript, não em `grep`: imune ao shim `ugrep` e à dobra de acento por locale que produziu o falso-verde do #1483.
+
+### Componente 2 — `scripts/edges-typecheck-gate.test.ts`
+
+A função de classificação é **pura** (recebe `stdout` + `exitCode`, devolve veredito) e testada offline no vitest, que já inclui `scripts/**/*.test.ts`. Fixtures são saída **real** capturada em 2026-07-21:
+
+1. **baseline** — 141 erros, 0 classe-crash → espera `passa`
+2. **sabotado** — `TS2304 Cannot find name` numa edge limpa, sem linha `Found N` → espera `bloqueia`
+3. **sabotado em edge suja** — classe-crash isolada no meio de 11 erros tolerados → espera `bloqueia`
+4. **resolução** — `Could not find a matching package` do `biometric-auth`, sem `Type checking failed` → espera `bloqueia` (infra)
+5. **vazio + exit 0** — cache quente → espera `passa`
+6. **vazio + exit ≠ 0** — rede caiu sem mensagem → espera `bloqueia`
+
+É a lição do `ci-testes-edge-deno.md` aplicada: o teste não pode ter dep remota, então extrai-se a lógica pura e testa-se ela.
+
+### Componente 3 — `ci.yml` + `package.json`
+
+Step novo logo após `Tests (edge functions — Deno, offline)`: o Deno já está instalado (setup zero) e PR quebrado no comum falha antes de pagar os ~48s de rede — mesma lógica que o `test:edges` já documenta.
+
+`package.json`: `edges:typecheck` novo. O `typecheck:edges` atual (cobre 2 edges, não roda em lugar nenhum) é **substituído** por ele.
+
+**Sem `actions/cache`:** o DENO_DIR é 681 MB (677 são tarballs npm). Economizaria ~30s dos 48s consumindo ~7% do budget de 10 GB do repo, mais drift de chave — e não há `deno.lock` versionado (está no `.gitignore`) para chavear. `--no-lock` evita que o check escreva um lock de 297 KB na raiz.
+
+### Componente 4 — doc
+
+Lição em `docs/historico/ci-testes-edge-deno.md` (o doc que já conta a história do `--no-remote`), com os números medidos e os follow-ups.
+
+## O que este gate NÃO cobre (explícito)
+
+Erros de tipo reais das outras classes — um `TS2345` novo numa edge limpa passa. É recall trocado por precisão e por não ter allowlist: a alternativa (check completo com denylist das 25 sujas) excluiria justamente `fin-cashflow-engine`, `enviar-pedido-portal-sayerlack`, `omie-financeiro` e `recommend` — money-path — deixando o gate protegendo onde o risco é menor, além de criar um arquivo-lista que vira ímã de conflito entre as ~30 worktrees paralelas.
+
+Apertar para check completo é o destino natural, depois que a dívida encolher.
+
+## Follow-ups (medidos, não especulativos)
+
+1. **Consolidar `@supabase/supabase-js` numa versão** — hoje 6. Corta download e resolve 17 dos 141 erros de uma vez.
+2. **Migrar `deno.land/std/http/server.ts` → `Deno.serve`** (34 edges) e **`esm.sh/@supabase/supabase-js` → `npm:`** (18 edges). Deixa `registry.npmjs.org` como host único; o gate passa a não adicionar SPOF novo.
+3. **Zerar as 25 edges sujas** e então apertar o gate para check completo.
+4. **Versionar `deno.lock`** — reprodutibilidade + habilita chave de cache estável, caso o custo de rede vire problema.
+
+## Validação de aceite
+
+- [ ] Gate verde na `main` atual (0 classe-crash em 93/93) — evidência: exit 0
+- [ ] Falsificação ponta-a-ponta: sabotar edge real → vermelho; restaurar → verde
+- [ ] Falsificação da falha de infra: simular saída não-parseável → vermelho
+- [ ] Teste do parser passa no vitest, offline
+- [ ] `bun run typecheck`, `bun lint`, `bun run test` verdes

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:edges": "deno test --no-remote --allow-read=supabase/functions supabase/functions/",
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
-    "typecheck:edges": "deno check supabase/functions/sync-reprocess/index.ts supabase/functions/omie-analytics-sync/index.ts",
+    "edges:typecheck": "bun scripts/edges-typecheck-gate.ts",
     "audit:migrations": "bun scripts/audit-custom-migrations.ts",
     "authz:check": "bun scripts/authz-gate-check.ts",
     "bunpin:check": "bun scripts/bun-pin-gate-check.ts",

--- a/scripts/edges-typecheck-gate.test.ts
+++ b/scripts/edges-typecheck-gate.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CLASSES_BLOQUEANTES,
+  classificar,
+  enumerarEdges,
+  extrairOcorrencias,
+  semAnsi,
+} from './edges-typecheck-gate';
+
+/**
+ * Fixtures são saída REAL do `deno check` capturada em 2026-07-21 (deno 2.9.2, o pin do CI) contra
+ * este repo. Nada sintético: o valor do gate está em acertar o formato do Deno, e formato inventado
+ * testaria o parser contra a minha suposição em vez de contra a ferramenta.
+ *
+ * O teste é OFFLINE por desenho (só strings) — teste de edge não pode ter dep remota, senão o
+ * jsr.io/npm entra no caminho de entrega de todo PR. Ver docs/historico/ci-testes-edge-deno.md.
+ */
+
+const RAIZ = '/Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/dazzling-pare-167cec';
+
+/** Cache de check quente: saída vazia + exit 0. É o caso de SUCESSO normal (armadilha 3). */
+const VAZIO = '\n';
+
+/** 1 erro apenas → o Deno OMITE a linha `Found N errors.` (armadilha 2). Forma típica do #1498. */
+const SABOTADO_UM_ERRO = `Check supabase/functions/calculate-scores/index.ts
+TS2304 [ERROR]: Cannot find name 'simboloQueNaoExiste'.
+const _sab = simboloQueNaoExiste(1);
+             ~~~~~~~~~~~~~~~~~~~
+    at file://${RAIZ}/supabase/functions/calculate-scores/index.ts:658:14
+
+error: Type checking failed.
+`;
+
+/** Classe-crash ISOLADA no meio da dívida tolerada, na mesma edge (money-path, suja). */
+const MISTO = `Check supabase/functions/omie-financeiro/index.ts
+TS2345 [ERROR]: Argument of type '{ parameter: string; value: "omie_sync" | "edge_fn" | "cron"; is_local: boolean; }' is not assignable to parameter of type 'undefined'.
+  await supabase.rpc('set_config', {
+                                   ^
+    at file://${RAIZ}/supabase/functions/omie-financeiro/index.ts:332:36
+
+TS2345 [ERROR]: Argument of type 'SupabaseClient<any, "public", "public", any, any>' is not assignable to parameter of type 'SupabaseClient<unknown, { PostgrestVersion: string; }, never, never, { PostgrestVersion: string; }>'.
+  Types of property 'rest' are incompatible.
+    Type 'PostgrestClient<any, any, "public", any>' is not assignable to type 'PostgrestClient<unknown, { PostgrestVersion: string; }, never, never>'.
+      Type '"public"' is not assignable to type 'never'.
+    await setAuditOrigem(supabase, 'omie_sync');
+                         ~~~~~~~~
+    at file://${RAIZ}/supabase/functions/omie-financeiro/index.ts:2092:26
+
+TS2571 [ERROR]: Object is of type 'unknown'.
+      const total = resp.total_de_registros;
+                    ~~~~
+    at file://${RAIZ}/supabase/functions/omie-financeiro/index.ts:701:21
+
+TS2304 [ERROR]: Cannot find name 'helperInexistente'.
+const _sab = helperInexistente(1);
+             ~~~~~~~~~~~~~~~~~
+    at file://${RAIZ}/supabase/functions/omie-financeiro/index.ts:2431:14
+
+Found 11 errors.
+
+error: Type checking failed.
+`;
+
+/** Dívida pré-existente pura: nenhuma classe-crash. É o baseline verde de hoje (141 erros). */
+const SO_DIVIDA = `Check supabase/functions/omie-financeiro/index.ts
+TS2571 [ERROR]: Object is of type 'unknown'.
+      const total = resp.total_de_registros;
+                    ~~~~
+    at file://${RAIZ}/supabase/functions/omie-financeiro/index.ts:701:21
+
+TS2578 [ERROR]: Unused '@ts-expect-error' directive.
+      // @ts-expect-error - fin_contas_receber may not be in generated supabase types yet
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    at file://${RAIZ}/supabase/functions/fin-cashflow-engine/index.ts:214:7
+
+TS2339 [ERROR]: Property 'product_id' does not exist on type 'never'.
+    at file://${RAIZ}/supabase/functions/recommend/index.ts:88:31
+
+Found 141 errors.
+
+error: Type checking failed.
+`;
+
+/**
+ * Falha de RESOLUÇÃO — o que acontece sem `--node-modules-dir=none` (armadilha 1). Repare que NÃO
+ * há `error: Type checking failed.`: o Deno abortou antes de type-checar coisa alguma.
+ */
+const RESOLUCAO = `error: Could not find a matching package for 'npm:@simplewebauthn/server@10.0.1' in the node_modules directory. Ensure you have all your JSR and npm dependencies listed in your deno.json or package.json, then run \`deno install\`. Alternatively, turn on auto-install by specifying \`"nodeModulesDir": "auto"\` in your deno.json file.
+    at file://${RAIZ}/supabase/functions/biometric-auth/index.ts:3:46
+`;
+
+describe('classificar — o caminho feliz', () => {
+  it('exit 0 com saída vazia (cache de check quente) passa', () => {
+    // Armadilha 3: saída vazia é SUCESSO normal, não anomalia. Se isto virar "bloqueia", todo PR
+    // com cache quente fica vermelho; se a regra pendesse do volume de saída, seria falso-verde.
+    expect(classificar(VAZIO, 0).tipo).toBe('passa');
+  });
+
+  it('dívida pré-existente sem classe-crash passa, e reporta as toleradas', () => {
+    const v = classificar(SO_DIVIDA, 1, RAIZ);
+    expect(v.tipo).toBe('passa');
+    if (v.tipo !== 'passa') throw new Error('inalcançável');
+    expect(v.toleradas.map((o) => o.codigo)).toEqual(['TS2571', 'TS2578', 'TS2339']);
+  });
+});
+
+describe('classificar — a classe que quebra em runtime (#1498)', () => {
+  it('bloqueia com UM erro só, quando o Deno omite a linha `Found N errors.`', () => {
+    // Armadilha 2: se o gate exigisse `Found N errors.` como marcador, ficaria cego exatamente
+    // aqui — e 1 erro é a forma típica do símbolo faltando no import.
+    expect(SABOTADO_UM_ERRO).not.toContain('Found ');
+    const v = classificar(SABOTADO_UM_ERRO, 1, RAIZ);
+    expect(v.tipo).toBe('bloqueia');
+    if (v.tipo !== 'bloqueia' || v.motivo !== 'classe-crash') throw new Error('esperava classe-crash');
+    expect(v.bloqueantes).toHaveLength(1);
+    expect(v.bloqueantes[0].codigo).toBe('TS2304');
+    expect(v.bloqueantes[0].arquivo).toBe('supabase/functions/calculate-scores/index.ts');
+    expect(v.bloqueantes[0].linha).toBe(658);
+  });
+
+  it('isola a classe-crash no meio da dívida tolerada da mesma edge', () => {
+    // É o que permite gatear as 25 edges sujas sem allowlist: o veredito não é "o arquivo está
+    // vermelho", é "apareceu um erro DESTA classe".
+    const v = classificar(MISTO, 1, RAIZ);
+    expect(v.tipo).toBe('bloqueia');
+    if (v.tipo !== 'bloqueia' || v.motivo !== 'classe-crash') throw new Error('esperava classe-crash');
+    expect(v.bloqueantes.map((o) => o.codigo)).toEqual(['TS2304']);
+    expect(v.toleradas.map((o) => o.codigo)).toEqual(['TS2345', 'TS2345', 'TS2571']);
+  });
+});
+
+describe('classificar — fail-closed ("ausência de sinal NÃO é aprovação")', () => {
+  it('bloqueia quando o deno aborta na RESOLUÇÃO, sem chegar a type-checar', () => {
+    // Armadilha 1. Sem `--node-modules-dir=none` é literalmente isto que acontece neste repo.
+    const v = classificar(RESOLUCAO, 1, RAIZ);
+    expect(v.tipo).toBe('bloqueia');
+    if (v.tipo !== 'bloqueia' || v.motivo !== 'infra') throw new Error('esperava infra');
+    expect(v.detalhe).toContain('Could not find a matching package');
+  });
+
+  it('bloqueia em exit≠0 sem saída nenhuma (rede caiu, binário sumiu)', () => {
+    const v = classificar('', 1);
+    expect(v.tipo).toBe('bloqueia');
+    if (v.tipo !== 'bloqueia' || v.motivo !== 'infra') throw new Error('esperava infra');
+  });
+
+  it('bloqueia se disser que type-check falhou mas nada for parseável (formato mudou)', () => {
+    // Guarda contra bump do Deno: um parser cego que devolve "0 bloqueantes" é falso-verde.
+    const v = classificar('error: Type checking failed.\n', 1);
+    expect(v.tipo).toBe('bloqueia');
+    if (v.tipo !== 'bloqueia' || v.motivo !== 'infra') throw new Error('esperava infra');
+    expect(v.detalhe).toContain('formato de saída mudou');
+  });
+});
+
+describe('extrairOcorrencias', () => {
+  it('não rouba a âncora do erro seguinte quando um erro vem sem âncora', () => {
+    const s = `TS2304 [ERROR]: Cannot find name 'a'.
+TS2339 [ERROR]: Property 'b' does not exist.
+    at file:///r/supabase/functions/x/index.ts:10:1
+`;
+    const ocs = extrairOcorrencias(s, '/r');
+    expect(ocs).toHaveLength(2);
+    expect(ocs[0].arquivo).toBeNull();
+    expect(ocs[1].arquivo).toBe('supabase/functions/x/index.ts');
+  });
+
+  it('sobrevive a códigos ANSI (saída de TTY)', () => {
+    const comAnsi = `\x1b[1m\x1b[31mTS2304\x1b[0m [ERROR]: Cannot find name 'x'.`;
+    expect(extrairOcorrencias(semAnsi(comAnsi))).toHaveLength(1);
+  });
+});
+
+describe('invariantes do gate', () => {
+  it('as 6 classes bloqueantes são as de "não resolve" — nenhuma de incompatibilidade', () => {
+    // Trava a decisão precisão>recall do desenho: TS2345/2322/2339/2571/2578 são a dívida de 141
+    // que o gate TOLERA de propósito. Incluir uma delas aqui deixaria o gate vermelho na main.
+    expect([...CLASSES_BLOQUEANTES].sort()).toEqual([
+      'TS2304',
+      'TS2305',
+      'TS2307',
+      'TS2503',
+      'TS2552',
+      'TS2724',
+    ]);
+    for (const divida of ['TS2345', 'TS2322', 'TS2339', 'TS2571', 'TS2578', 'TS2769']) {
+      expect(CLASSES_BLOQUEANTES.has(divida)).toBe(false);
+    }
+  });
+
+  it('enumera as edges do repo de verdade (glob vazio seria falso-verde)', () => {
+    // O gate expande o glob no TS e não no shell: zsh aborta com "no matches found", bash passa o
+    // glob literal. 0 edges tem que ser FALHA, não "nada a checar".
+    // `process.cwd()` e não `import.meta.url`: sob Vite/vitest o segundo vira o caminho VIRTUAL
+    // `/@fs/…`, que não existe no disco — o teste passaria a medir 0 edges por acidente de bundler.
+    const edges = enumerarEdges(process.cwd());
+    expect(edges.length).toBeGreaterThan(80);
+    expect(edges.every((e) => e.endsWith('/index.ts'))).toBe(true);
+  });
+});

--- a/scripts/edges-typecheck-gate.ts
+++ b/scripts/edges-typecheck-gate.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env bun
+/**
+ * edges-typecheck-gate.ts — gate de CI que type-checa as EDGE FUNCTIONS (Deno).
+ * ============================================================================================
+ *
+ * O BURACO QUE ELE TAPA. Nenhum gate do repo type-checava `supabase/functions/`:
+ *   - `bun run typecheck` (tsc) → `tsconfig.app.json` cobre só `src/` + testes;
+ *   - `bun run test` (vitest) → `include` é `src/**` + `scripts/**`;
+ *   - `bun lint` (eslint)    → não type-checa, e não roda em Deno;
+ *   - `bun run test:edges`   → `deno test` só type-checa o grafo que os TESTES alcançam, e por
+ *     desenho os 15 arquivos de teste testam lógica PURA extraída (ver
+ *     docs/historico/ci-testes-edge-deno.md) — nenhum `index.ts` de edge entra no grafo.
+ * Resultado: erro de tipo numa edge ficava VERDE em todos os gates e só quebrava em RUNTIME na
+ * produção, depois do deploy manual pelo chat do Lovable. Detectado no PR #1498: `classifyProfile`
+ * usado sem estar no import em generate-tactical-plan/index.ts passou por 5.527 testes vitest, 181
+ * testes deno, typecheck e lint — só apareceu num `deno check` manual.
+ *
+ * PRECISÃO > RECALL: por que só 6 classes. Hoje as 93 edges têm 141 erros de tipo em 25 delas,
+ * quase todos ruído dos tipos gerados do Supabase (`... does not exist on type 'never'`,
+ * `@ts-expect-error` obsoleto, e 17 `SupabaseClient not assignable` causados por @supabase/
+ * supabase-js aparecer em 6 versões distintas). Código que RODA BEM. Já a classe "símbolo ou módulo
+ * não resolve" — a do #1498 — está em ZERO nas 93. Gatear só nela dá um gate VERDE HOJE sem
+ * allowlist nenhuma, cobrindo inclusive as 25 sujas e as de money-path. A alternativa (check
+ * completo + denylist das 25) excluiria justamente fin-cashflow-engine,
+ * enviar-pedido-portal-sayerlack, omie-financeiro e recommend — o gate protegendo onde o risco é
+ * MENOR — e criaria um arquivo-lista que vira ímã de conflito entre as ~30 worktrees paralelas.
+ * Apertar para check completo é o destino natural, depois que a dívida encolher.
+ *
+ * TRÊS ARMADILHAS VALIDADAS EMPIRICAMENTE (2026-07-21, deno 2.9.2 — o pin do CI):
+ *
+ *  1. `--node-modules-dir=none` é OBRIGATÓRIO. Sem ele o `deno check` ABORTA na RESOLUÇÃO, antes
+ *     de type-checar qualquer coisa: o package.json da raiz põe o Deno em modo node_modules e o
+ *     `npm:@simplewebauthn/server@10.0.1` de biometric-auth não está lá. Bônus: esse modo é mais
+ *     fiel ao Edge Runtime real do Supabase, que resolve `npm:` do próprio registry sem
+ *     node_modules. O `test:edges` nunca esbarrou nisso porque o `--no-remote` corta antes.
+ *
+ *  2. O marcador de "rodou e type-checou" é `error: Type checking failed.`, NÃO `Found N errors.`:
+ *     com EXATAMENTE 1 erro o Deno omite a linha de contagem. Usar a contagem como marcador
+ *     deixaria o gate cego justo no caso de 1 erro — que é a forma típica do #1498.
+ *
+ *  3. Com o cache de check quente a saída é COMPLETAMENTE VAZIA e exit 0. Ou seja, "saída vazia"
+ *     é o caso de SUCESSO normal — não pode ser lido como anomalia. A decisão pende do exit code
+ *     + do marcador acima, nunca do volume de saída.
+ *
+ * FAIL-CLOSED (CLAUDE.md: "ausência de sinal NÃO é aprovação"):
+ *   exit 0                              → passa
+ *   exit≠0 + marcador de type-check     → parseia e classifica; bloqueia só se houver classe-crash
+ *   exit≠0 SEM o marcador               → BLOQUEIA (rede caiu, resolução quebrou, formato mudou).
+ *                                         Não conseguir checar ≠ estar limpo.
+ * O glob é expandido AQUI (readdirSync), não no shell: o zsh aborta com "no matches found" e o
+ * bash passa o glob literal — e um glob que não casa nada viraria verde silencioso. 0 edges = falha.
+ * Parse em TypeScript e não em `grep`: imune ao shim `ugrep` e à dobra de acento por locale que
+ * produziu o falso-verde do #1483.
+ *
+ * Uso:  bun run edges:typecheck            # roda no CI (ci.yml, job validate) e local
+ *       bun scripts/edges-typecheck-gate.ts --json
+ * Custo: ~48s cold (DENO_DIR virgem, 2.245 downloads), ~2,5s warm. Sem actions/cache de propósito:
+ * o DENO_DIR é 681 MB (677 de tarballs npm) e economizaria ~30s consumindo ~7% do budget do repo.
+ * Spec: docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Classes que significam "isto QUEBRA ao executar": o símbolo, módulo ou membro não existe.
+ * Deliberadamente NÃO inclui as classes de incompatibilidade de tipo (TS2345/2322/2339/...), que
+ * hoje somam a dívida de 141 e descrevem código que roda. Ver o cabeçalho.
+ */
+export const CLASSES_BLOQUEANTES: ReadonlySet<string> = new Set([
+  'TS2304', // Cannot find name 'X'            ← a forma exata do #1498
+  'TS2552', // Cannot find name 'X'. Did you mean 'Y'?
+  'TS2307', // Cannot find module 'X'
+  'TS2305', // Module 'X' has no exported member 'Y'
+  'TS2724', // 'X' has no exported member named 'Y'. Did you mean 'Z'?
+  'TS2503', // Cannot find namespace 'X'
+]);
+
+/** Marcador de que o Deno chegou a type-checar (ver armadilha 2 no cabeçalho). */
+const MARCADOR_TYPECHECK = 'error: Type checking failed.';
+
+export interface Ocorrencia {
+  codigo: string;
+  mensagem: string;
+  /** Caminho relativo à raiz do repo, ou null se a âncora `at file://` não veio. */
+  arquivo: string | null;
+  linha: number | null;
+}
+
+export type Veredito =
+  | { tipo: 'passa'; toleradas: Ocorrencia[] }
+  | { tipo: 'bloqueia'; motivo: 'classe-crash'; bloqueantes: Ocorrencia[]; toleradas: Ocorrencia[] }
+  | { tipo: 'bloqueia'; motivo: 'infra'; detalhe: string };
+
+// O ESC vai como `\x1b` escapado, não como o byte cru: o byte literal dispara `no-control-regex` no
+// ESLint (e fica invisível em diff/review). O deno só emite ANSI quando a saída é TTY — no CI, via
+// spawnSync, não emite; o strip existe para a execução local.
+// eslint-disable-next-line no-control-regex
+const RE_ANSI = /\x1b\[[0-9;]*m/g;
+const RE_ERRO = /^(TS\d+) \[ERROR\]: (.*)$/;
+const RE_ANCORA = /^\s+at file:\/\/(\S+?):(\d+):(\d+)\s*$/;
+
+export function semAnsi(s: string): string {
+  return s.replace(RE_ANSI, '');
+}
+
+/** Extrai (código, mensagem, arquivo, linha) de cada `TS#### [ERROR]:` da saída do `deno check`. */
+export function extrairOcorrencias(saidaLimpa: string, raiz = ''): Ocorrencia[] {
+  const linhas = saidaLimpa.split('\n');
+  const out: Ocorrencia[] = [];
+  for (let i = 0; i < linhas.length; i++) {
+    const m = RE_ERRO.exec(linhas[i]);
+    if (!m) continue;
+    // A âncora `at file://…` vem depois da mensagem e do trecho de código. Para no próximo erro
+    // para não roubar a âncora dele quando este vier sem âncora nenhuma.
+    let arquivo: string | null = null;
+    let linha: number | null = null;
+    for (let j = i + 1; j < linhas.length; j++) {
+      if (RE_ERRO.test(linhas[j])) break;
+      const a = RE_ANCORA.exec(linhas[j]);
+      if (a) {
+        arquivo = raiz && a[1].startsWith(raiz) ? a[1].slice(raiz.length).replace(/^\//, '') : a[1];
+        linha = Number(a[2]);
+        break;
+      }
+    }
+    out.push({ codigo: m[1], mensagem: m[2], arquivo, linha });
+  }
+  return out;
+}
+
+/**
+ * O coração do gate — PURO, para ser testável offline (o teste não pode ter dep remota; ver
+ * docs/historico/ci-testes-edge-deno.md). Recebe a saída combinada do `deno check` e o exit code.
+ */
+export function classificar(saida: string, exitCode: number, raiz = ''): Veredito {
+  const limpa = semAnsi(saida);
+
+  // Armadilha 3: com cache quente a saída é vazia e exit 0. Sucesso normal.
+  if (exitCode === 0) return { tipo: 'passa', toleradas: [] };
+
+  // Armadilha 2 + fail-closed: sem o marcador, o Deno não chegou a type-checar. Rede, resolução
+  // (`Could not find a matching package`), permissão, binário ausente… Não sabemos ≠ está limpo.
+  if (!limpa.includes(MARCADOR_TYPECHECK)) {
+    const primeiraLinhaErro = limpa
+      .split('\n')
+      .find((l) => l.startsWith('error:') || l.startsWith('Error:'));
+    return {
+      tipo: 'bloqueia',
+      motivo: 'infra',
+      detalhe: primeiraLinhaErro?.trim() || '(deno check falhou sem mensagem reconhecível)',
+    };
+  }
+
+  const ocorrencias = extrairOcorrencias(limpa, raiz);
+
+  // Disse que type-check falhou mas não conseguimos parsear NENHUM erro → o formato da saída mudou
+  // (bump do Deno?). Fail-closed: um parser cego que devolve "0 bloqueantes" é falso-verde.
+  if (ocorrencias.length === 0) {
+    return {
+      tipo: 'bloqueia',
+      motivo: 'infra',
+      detalhe:
+        'deno check reportou falha de type-check mas nenhum `TS#### [ERROR]:` foi parseado — ' +
+        'formato de saída mudou? (conferir após bump do Deno)',
+    };
+  }
+
+  const bloqueantes = ocorrencias.filter((o) => CLASSES_BLOQUEANTES.has(o.codigo));
+  const toleradas = ocorrencias.filter((o) => !CLASSES_BLOQUEANTES.has(o.codigo));
+
+  return bloqueantes.length > 0
+    ? { tipo: 'bloqueia', motivo: 'classe-crash', bloqueantes, toleradas }
+    : { tipo: 'passa', toleradas };
+}
+
+/** Enumera os `index.ts` de cada pasta sob `supabase/functions/` — no TS, não no shell (ver cabeçalho). */
+export function enumerarEdges(raiz: string): string[] {
+  const base = join(raiz, 'supabase', 'functions');
+  if (!existsSync(base)) return [];
+  return readdirSync(base, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => join('supabase', 'functions', d.name, 'index.ts'))
+    .filter((rel) => existsSync(join(raiz, rel)))
+    .sort();
+}
+
+/** Agrupa por código, para reportar a dívida tolerada de forma compacta. */
+function resumirPorCodigo(ocs: Ocorrencia[]): string {
+  const porCodigo = new Map<string, number>();
+  for (const o of ocs) porCodigo.set(o.codigo, (porCodigo.get(o.codigo) ?? 0) + 1);
+  return [...porCodigo.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([c, n]) => `${c}:${n}`)
+    .join(' ');
+}
+
+function formatar(o: Ocorrencia): string {
+  const local = o.arquivo ? `${o.arquivo}${o.linha ? `:${o.linha}` : ''}` : '(local desconhecido)';
+  return `   ${o.codigo}  ${local}\n           ${o.mensagem}`;
+}
+
+function main(): number {
+  const json = process.argv.includes('--json');
+  const raiz = join(import.meta.dir, '..');
+  const edges = enumerarEdges(raiz);
+
+  if (edges.length === 0) {
+    console.error(
+      '❌ edges-typecheck-gate: nenhuma edge encontrada em supabase/functions/*/index.ts.\n' +
+        '   Isso não é "nada a checar" — é o gate sem alvo. Conferir o layout do repo.',
+    );
+    return 1;
+  }
+
+  const args = ['check', '--no-lock', '--node-modules-dir=none', ...edges];
+  const proc = spawnSync('deno', args, { cwd: raiz, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+
+  if (proc.error) {
+    console.error(`❌ edges-typecheck-gate: não consegui executar o deno — ${proc.error.message}`);
+    return 1;
+  }
+
+  const saida = `${proc.stdout ?? ''}\n${proc.stderr ?? ''}`;
+  const veredito = classificar(saida, proc.status ?? 1, raiz);
+
+  if (json) {
+    console.log(JSON.stringify({ edges: edges.length, veredito }, null, 2));
+    return veredito.tipo === 'passa' ? 0 : 1;
+  }
+
+  console.log(`🔎 edges-typecheck-gate — ${edges.length} edges · deno check ${args.slice(1, 3).join(' ')}`);
+
+  if (veredito.tipo === 'bloqueia' && veredito.motivo === 'infra') {
+    console.error(
+      `\n❌ NÃO FOI POSSÍVEL TYPE-CHECAR as edges (exit ${proc.status}).\n` +
+        `   ${veredito.detalhe}\n\n` +
+        '   Bloqueando de propósito: não conseguir checar não é o mesmo que estar limpo\n' +
+        '   (CLAUDE.md — "ausência de sinal NÃO é aprovação").',
+    );
+    return 1;
+  }
+
+  if (veredito.tipo === 'bloqueia') {
+    console.error(
+      `\n❌ ${veredito.bloqueantes.length} erro(s) de classe que QUEBRA EM RUNTIME ` +
+        '(símbolo/módulo/membro não resolve):\n',
+    );
+    for (const o of veredito.bloqueantes) console.error(formatar(o));
+    if (veredito.toleradas.length > 0) {
+      console.error(
+        `\n   (${veredito.toleradas.length} erro(s) de outras classes ignorados — dívida conhecida: ` +
+          `${resumirPorCodigo(veredito.toleradas)})`,
+      );
+    }
+    console.error(
+      '\n   Essa é a classe do PR #1498: passa por typecheck, vitest, deno test e lint,\n' +
+        '   e só quebra em RUNTIME na produção depois do deploy manual pelo Lovable.',
+    );
+    return 1;
+  }
+
+  if (veredito.toleradas.length > 0) {
+    console.log(
+      `✅ 0 erros de classe-crash.\n` +
+        `   ${veredito.toleradas.length} erro(s) de outras classes tolerados (dívida conhecida): ` +
+        `${resumirPorCodigo(veredito.toleradas)}\n` +
+        '   Ver os follow-ups no spec: docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md',
+    );
+  } else {
+    console.log('✅ 0 erros de classe-crash (e nenhum outro erro de tipo).');
+  }
+  return 0;
+}
+
+if (import.meta.main) process.exit(main());


### PR DESCRIPTION
## O buraco

`deno test` só type-checa o grafo que os **testes alcançam** — e por desenho os 15 arquivos de teste cobrem lógica **pura extraída**, justamente para caber no `--no-remote`. Nenhum `index.ts` de edge entra nesse grafo.

| Gate | Cobre | Por que não pega edge |
|---|---|---|
| `typecheck` (tsc) | `src/` + testes | `tsconfig.app.json` não inclui `supabase/functions/` |
| `test` (vitest) | `src/`, `scripts/` | `include` do `vitest.config.ts` |
| `test:edges` (deno) | edges **importadas por teste** | nenhuma `index.ts` é importada por teste algum |
| `lint` (eslint) | `src/` + functions | não type-checa |

Resultado: erro de tipo em edge ficava **verde nos 4 gates** e só quebrava em **runtime na produção**, depois do deploy manual pelo Lovable. No #1498, `classifyProfile` usado sem estar no import sobreviveu a 5.527 testes vitest, 181 testes deno, typecheck e lint — só apareceu num `deno check` manual.

## Precisão > recall, e por isso sem allowlist

Medido na `main` de hoje: **141 erros de tipo em 25 das 93 edges**. Quase todos são ruído dos tipos gerados do Supabase (`does not exist on type 'never'`, `@ts-expect-error` obsoleto, e 17 `SupabaseClient not assignable` porque `@supabase/supabase-js` aparece em **6 versões distintas**). Código que roda.

Já a classe que **quebra em runtime** — `TS2304` `TS2552` `TS2307` `TS2305` `TS2724` `TS2503` — está em **zero nas 93**. Gatear só nela dá um gate verde hoje **sem lista nenhuma**, cobrindo inclusive as 25 sujas e as de money-path.

A alternativa (check completo + denylist das 25) excluiria justamente `fin-cashflow-engine`, `enviar-pedido-portal-sayerlack`, `omie-financeiro` e `recommend` — **o gate protegendo onde o risco é menor** — e criaria um arquivo-lista que vira ímã de conflito entre as worktrees paralelas.

## Quatro armadilhas medidas (deno 2.9.2)

- **`deno check` cru não roda neste repo:** o `package.json` da raiz põe o Deno em modo node_modules e ele **aborta na resolução**, antes de type-checar. Exige `--node-modules-dir=none` — que por sinal é mais fiel ao Edge Runtime real do Supabase.
- **Com 1 erro só, o Deno OMITE `Found N errors.`** → o marcador confiável é `error: Type checking failed.`. Usar a contagem cegaria o gate exatamente na forma do #1498.
- **Com cache de check quente a saída é VAZIA e exit 0** — sucesso normal, não anomalia. A decisão pende do exit code, nunca do volume de saída.
- **Glob de edge diverge entre shells** (zsh aborta com "no matches found", bash passa literal) → enumerado em TypeScript, e **0 edges é falha**, não "nada a checar".

**Fail-closed:** `exit≠0` sem o marcador de type-check (rede caiu, resolução quebrou, formato mudou) **bloqueia**. Não conseguir checar ≠ estar limpo.

## Custo (e o trade-off com o `--no-remote`)

| | |
|---|---|
| Cold (DENO_DIR virgem) | **48s** · 2.245 downloads · 681 MB |
| Warm | **2,5s** |

Este é o único step do `validate` que precisa de **rede** — não dá para espelhar o `--no-remote` do `test:edges`, porque o check tem que resolver o grafo de verdade. O que dá para dizer com número: dos 3 hosts, **`registry.npmjs.org` (2.087 requests) já está no caminho de entrega** via `bun install`; os novos são `esm.sh` (135) e `deno.land` (23), ambos de import legado — 34 edges em `deno.land/std/http/server.ts` (o `Deno.serve` nativo substitui) e 18 em `esm.sh/@supabase/supabase-js`. Migrar zera os hosts novos (follow-up).

**Diff-only foi medido e descartado:** checar *uma* edge custa 14–16s e ~2.000 requests — quase o mesmo que as 93, porque o `@supabase/supabase-js` sozinho arrasta ~2.000 `.d.ts`. Economizaria tempo e **zero** do SPOF.

**Sem `actions/cache`:** o DENO_DIR é 681 MB (677 de tarballs npm); economizaria ~30s dos 48s consumindo ~7% do budget de 10 GB do repo, e não há `deno.lock` versionado para chavear.

## Falsificação (rodada, não alegada)

| Cenário | Esperado | Obtido |
|---|---|---|
| `main` limpa (locales `C` e `pt_BR.UTF-8`) | verde | exit 0 |
| Símbolo inexistente em edge **limpa** | vermelho | exit 1 · `TS2304 Cannot find name 'classifyProfile'` |
| Símbolo inexistente em edge **suja de money-path** | vermelho | exit 1 · crash isolada no meio dos 11 tolerados |
| `deno` ausente do `PATH` | vermelho | exit 1 · `Executable not found` |
| Import `npm:` inexistente (falha de resolução) | vermelho/infra | exit 1 · `npm package … does not exist` |
| Restaurado | verde | exit 0 |

Os **11 testes do parser rodam offline** no vitest, com fixtures da saída **real** capturada hoje — nada sintético. A lógica é pura justamente para não arrastar dep remota para o teste.

## Gates

`typecheck` 0 · `test` (vitest completo) 0 · `test:edges` 0 · **`edges:typecheck` 0** · `build` 0 · `lint` 0 errors · `claude:size` 0 · `authz:check` 0 · `bunpin:check` 0

`knip` acusa dívida pré-existente de tipos não usados (nada deste PR; não é step do CI).

## Follow-ups (medidos, no spec)

1. Consolidar `@supabase/supabase-js` numa versão (hoje 6) — corta download e resolve 17 dos 141 erros.
2. Migrar `deno.land/std` → `Deno.serve` (34 edges) e `esm.sh` → `npm:` (18) — deixa um host só.
3. Zerar as 25 edges sujas e apertar para check completo.
4. Versionar `deno.lock` (hoje no `.gitignore`).

Substitui `typecheck:edges`, que cobria 2 edges e não rodava em lugar nenhum.
Spec: `docs/superpowers/specs/2026-07-21-edges-typecheck-gate-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)