### PR TITLE
docs(cron): setup do `tactical-plans-batch` ensinava o padrão que falha em silêncio

### DIFF
--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -17,14 +17,40 @@
 // Antes, `Number(null ?? 0)` fabricava R$ 0/h — indistinguível de um cliente de margem
 // genuinamente ruim, e reprovado em silêncio.
 //
-// Setup pg_cron (manual depois do merge):
-//   SELECT cron.schedule('tactical-plans-batch-nightly', '0 5 * * *',
+// Setup pg_cron (manual depois do merge) — padrão copiado do `daily-calculate-scores` EM PRODUÇÃO:
+//   SELECT cron.schedule('tactical-plans-batch-nightly', '0 8 * * *',
 //     $$ SELECT net.http_post(
-//       url := 'https://<PROJECT_REF>.supabase.co/functions/v1/tactical-plans-batch',
-//       headers := jsonb_build_object('x-cron-secret', current_setting('app.cron_shared_key', true)),
-//       timeout_milliseconds := 55000
+//       url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/tactical-plans-batch',
+//       headers := jsonb_build_object('Content-Type','application/json',
+//         'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+//       body := '{"triggered_by":"cron"}'::jsonb,
+//       timeout_milliseconds := 150000
 //     ); $$
 //   );
+//
+// O secret vem do VAULT, não de `current_setting('app.cron_shared_key', true)`: essa GUC não
+// existe no projeto, o `true` (missing_ok) devolve NULL em silêncio, e o header sai nulo →
+// `authorizeCron` responde 401. E `cron.job_run_details` marca `succeeded` mesmo assim, porque
+// só registra o ENQUEUE do net.http_post — a verdade HTTP está em `net._http_response`.
+// Falha silenciosa clássica (docs/agent/sync.md). Nenhum dos crons vivos usa a GUC.
+//
+// `timeout_milliseconds` explícito é obrigatório: o default do pg_net é 5s e mataria o batch no
+// meio, em silêncio. 150000 é o teto padrão da casa (docs/agent/sync.md).
+//
+// ⚠️ SCHEDULE É UTC, não BRT — `cron.timezone` está vazio no banco (#1510). `'0 8 * * *'` dispara
+// às 05:00 BRT. Ao mexer, converta explícito: BRT = UTC−3.
+//
+// 08:00 UTC é o primeiro slot DEPOIS de todas as dependências do batch — não mexer sem refazer
+// esta conta (o `'0 5 * * *'` que este bloco sugeria antes é 02:00 BRT, ANTES de todas elas: leria
+// a margem e a carteira do dia anterior):
+//   06:00 UTC `daily-calculate-scores`           → grava os scores que o gate de R$/h consome
+//   06:00 UTC `scoring-recalc-batch-nightly`     → recalcula priority_score
+//   07:00 UTC `visit-score-recalc-batch-nightly` → recalcula o score de visita
+//   07:30 UTC `carteira-rebuild-nightly`         → reconstrói `carteira_assignments`, a allowlist
+//                                                  de elegíveis lida no passo 0 abaixo
+//
+// Depois de criar: versione o cron numa migration — cron que vive só no banco some sem rastro
+// (docs/agent/sync.md; o de vendas ficou 8 dias morto por isso).
 
 import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCron, corsHeaders } from '../_shared/auth.ts';


### PR DESCRIPTION
## O problema

O comentário de cabeçalho da edge documentava, no bloco **"Setup pg_cron (manual depois do merge)"**, um padrão que **não funciona**:

```sql
headers := jsonb_build_object('x-cron-secret', current_setting('app.cron_shared_key', true))
```

Essa GUC não existe no projeto. O `true` (`missing_ok`) faz o `current_setting` devolver **NULL calado** em vez de erro, o header sai nulo, e o [`authorizeCron`](supabase/functions/_shared/auth.ts:30) — que exige `provided === expected` — responde **401**.

E o cron continua parecendo saudável: `cron.job_run_details` marca `succeeded` porque só registra o **enqueue** do `net.http_post`. A verdade HTTP está em `net._http_response`. Falha silenciosa exatamente do tipo que [sync.md](docs/agent/sync.md) descreve.

## Evidência

Verificado em 2026-07-21 via `psql-ro` contra `cron.job`:

- **Nenhum** dos 46 crons ativos usa `current_setting('app.cron_shared_key', ...)` — todos leem do vault.
- `tactical-plans-batch-nightly` **ainda não existe** em produção → ninguém aplicou o bloco errado, a correção é preventiva.

O bloco novo é copiado verbatim do `daily-calculate-scores` em prod.

## Horário: `0 5` → `0 8`

O batch depende de 4 crons a montante, e `0 5` é anterior a **todos**:

| Cron | Schedule | BRT | Por que o batch depende |
|---|---|---|---|
| `daily-calculate-scores` | `0 6` UTC | 03:00 | grava os scores que o gate de R$/h consome |
| `scoring-recalc-batch-nightly` | `0 6` UTC | 03:00 | recalcula `priority_score` |
| `visit-score-recalc-batch-nightly` | `0 7` UTC | 04:00 | recalcula o score de visita |
| `carteira-rebuild-nightly` | `30 7` UTC | 04:30 | reconstrói `carteira_assignments`, a allowlist do passo 0 |
| **`tactical-plans-batch-nightly`** | **`0 8` UTC** | **05:00** | — |

Às `0 5` (02:00 BRT) o batch leria a margem **e a carteira** do dia anterior.

Os horários vêm rotulados **UTC** no comentário por causa do #1510 (`cron.timezone` vazio → todo schedule é UTC), mergeado hoje.

Também: `timeout_milliseconds` de 55000 para **150000**, o teto padrão da casa.

## Risco

**Mudança só de comentário** — zero efeito em runtime. O diff não toca uma linha de código executável.

## Gates

| Gate | Exit | Resultado |
|---|---|---|
| `test:edges` | **0** | 193 passed, 0 failed |
| `edges:typecheck` | **0** | 93 edges, 0 erros de classe-crash |

## Follow-up (fora do escopo deste PR)

O mesmo bloco errado está em mais duas edges — em ambas o cron **já roda em produção com o padrão correto (vault)**, ou seja, o comentário está mentindo sobre o que existe:

- [`visit-score-recalc-batch/index.ts:16`](supabase/functions/visit-score-recalc-batch/index.ts:16)
- [`scoring-recalc-batch/index.ts:14`](supabase/functions/scoring-recalc-batch/index.ts:14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
