### PR TITLE
docs(cron): scoring/visit-score-recalc — comentário passa a descrever o cron que existe

### DIFF
--- a/supabase/functions/scoring-recalc-batch/index.ts
+++ b/supabase/functions/scoring-recalc-batch/index.ts
@@ -7,13 +7,29 @@
 // Invoca scoring-recalc-client internamente via fetch.
 // Auth cron via header x-cron-secret (CRON_SECRET env var).
 //
-// Setup pg_cron (manual depois do merge):
+// pg_cron: `scoring-recalc-batch-nightly` JÁ ESTÁ ATIVO em produção (`'0 6 * * *'`, conferido em
+// `cron.job` 2026-07-21). O bloco abaixo é o comando REAL que está rodando — serve para DR ou para
+// recriar (`cron.schedule` faz upsert por nome → idempotente), NÃO é um setup pendente:
 //   SELECT cron.schedule('scoring-recalc-batch-nightly', '0 6 * * *',
 //     $$ SELECT net.http_post(
-//       url := 'https://<PROJECT_REF>.supabase.co/functions/v1/scoring-recalc-batch',
-//       headers := jsonb_build_object('x-cron-secret', current_setting('app.cron_shared_key', true))
+//       url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/scoring-recalc-batch',
+//       headers := jsonb_build_object('Content-Type', 'application/json',
+//         'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)),
+//       timeout_milliseconds := 55000
 //     ); $$
 //   );
+//
+// Este bloco documentava `current_setting('app.cron_shared_key', true)` — GUC que não existe no
+// projeto. O `true` (missing_ok) devolve NULL calado, o header sai nulo e a edge responde 401, com
+// `cron.job_run_details` marcando `succeeded` mesmo assim (só registra o ENQUEUE do net.http_post;
+// a verdade HTTP está em `net._http_response`). Quem criou o cron não seguiu o comentário — ele
+// descrevia um setup que nunca existiu. Nenhum dos crons vivos usa a GUC.
+//
+// `timeout_milliseconds` também faltava, e é obrigatório: o default do pg_net é 5s e mataria o
+// batch em silêncio. 55000 é o valor em prod; o teto padrão da casa é 150000 (docs/agent/sync.md)
+// — alinhar os dois é follow-up, não deste PR.
+//
+// Schedule é UTC (`cron.timezone` vazio, #1510): '0 6' = 03:00 BRT, como diz o cabeçalho acima.
 
 import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';

--- a/supabase/functions/visit-score-recalc-batch/index.ts
+++ b/supabase/functions/visit-score-recalc-batch/index.ts
@@ -9,13 +9,29 @@
 //    (qualquer farmer_calls OU route_visits — sales_orders pulado por falta
 //     de farmer_id direto)
 //
-// Setup pg_cron (manual pós-merge):
+// pg_cron: `visit-score-recalc-batch-nightly` JÁ ESTÁ ATIVO em produção (`'0 7 * * *'`, conferido
+// em `cron.job` 2026-07-21). O bloco abaixo é o comando REAL que está rodando — serve para DR ou
+// para recriar (`cron.schedule` faz upsert por nome → idempotente), NÃO é um setup pendente:
 //   SELECT cron.schedule('visit-score-recalc-batch-nightly', '0 7 * * *',
 //     $$ SELECT net.http_post(
-//       url := 'https://<PROJECT_REF>.supabase.co/functions/v1/visit-score-recalc-batch',
-//       headers := jsonb_build_object('x-cron-secret', current_setting('app.cron_shared_key', true))
+//       url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/visit-score-recalc-batch',
+//       headers := jsonb_build_object('Content-Type', 'application/json',
+//         'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)),
+//       timeout_milliseconds := 55000
 //     ); $$
 //   );
+//
+// Este bloco documentava `current_setting('app.cron_shared_key', true)` — GUC que não existe no
+// projeto. O `true` (missing_ok) devolve NULL calado, o header sai nulo e a edge responde 401, com
+// `cron.job_run_details` marcando `succeeded` mesmo assim (só registra o ENQUEUE do net.http_post;
+// a verdade HTTP está em `net._http_response`). Quem criou o cron não seguiu o comentário — ele
+// descrevia um setup que nunca existiu. Nenhum dos crons vivos usa a GUC.
+//
+// `timeout_milliseconds` também faltava, e é obrigatório: o default do pg_net é 5s e mataria o
+// batch em silêncio. 55000 é o valor em prod; o teto padrão da casa é 150000 (docs/agent/sync.md)
+// — alinhar os dois é follow-up, não deste PR.
+//
+// Schedule é UTC (`cron.timezone` vazio, #1510): '0 7' = 04:00 BRT, como diz o cabeçalho acima.
 
 import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';


### PR DESCRIPTION
Gêmeo do #1513, para as outras duas edges que carregavam o mesmo bloco errado.

## O defeito aqui é de natureza diferente

No `tactical-plans-batch` (#1513) o cron **não existia** — o comentário errado ainda ia causar dano em quem fosse criá-lo.

Aqui os dois crons **já rodam em produção com o padrão correto (vault)**. Ou seja: quem os criou não seguiu o comentário. O bloco descrevia um setup que **nunca existiu**, e continuava ali como isca para o próximo que copiasse.

## Duas armadilhas no mesmo bloco

**1. O header.** `current_setting('app.cron_shared_key', true)` — GUC inexistente no projeto. O `true` (`missing_ok`) faz o `current_setting` devolver **NULL calado** em vez de erro, o header sai nulo e a edge responde **401**. E `cron.job_run_details` marca `succeeded` mesmo assim, porque só registra o **enqueue** do `net.http_post` — a verdade HTTP está em `net._http_response`.

**2. `timeout_milliseconds` ausente por completo.** O default do `pg_net` é **5s** e mataria o batch em silêncio. Prod tem 55000.

## Verificação

O bloco passa a ser a **transcrição literal** do `command` em `cron.job`. Provado por comparação normalizada (whitespace removido) contra produção em 2026-07-21:

```
✅ scoring-recalc-batch      — idêntico ao comando de prod (291 chars)
✅ visit-score-recalc-batch  — idêntico ao comando de prod (295 chars)
```

E o comparador foi **falsificado** com 3 sabotagens, todas vermelhas:

| Sabotagem | Resultado |
|---|---|
| controle (arquivo real) | VERDE |
| `timeout` 55000 → 5000 | VERMELHO |
| vault → GUC antiga (o defeito original) | VERMELHO |
| url de outra edge | VERMELHO |

## Enquadramento

"Setup pg_cron (manual depois do merge)" sugeria um setup **pendente** para um cron ativo há meses. O bloco agora diz que já roda e que serve para DR ou recriação (`cron.schedule` é upsert por nome → idempotente).

## Horários: não mexi

Os cabeçalhos das duas edges **já convertiam UTC→BRT corretamente** (`03:00 BRT = 06:00 UTC` e `04:00 BRT = 07:00 UTC`), antes mesmo do #1510 documentar a regra. Só rotulei a base dentro do bloco.

## Divergência conhecida deixada de fora

Prod usa `timeout_milliseconds := 55000`; o teto padrão da casa é **150000** ([sync.md](docs/agent/sync.md)). Documentei o valor **real** para o comentário não voltar a divergir da produção — que é justamente o pecado que este PR corrige. Alinhar os dois exige mudança no banco, não de comentário: fica como follow-up.

## Risco

**Mudança só de comentário** — zero efeito em runtime. O diff não toca uma linha executável.

## Gates

| Gate | Exit | Resultado |
|---|---|---|
| `test:edges` | **0** | 193 passed, 0 failed |
| `edges:typecheck` | **0** | 93 edges, 0 erros de classe-crash |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
