### PR TITLE
refactor(analytics-sync): importar pedidos arma o cursor server-side — a aba pode fechar [money-path]

### DIFF
--- a/db/test-vendas_sync_semear_janela.sh
+++ b/db/test-vendas_sync_semear_janela.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — vendas_sync_semear_janela (semeadura staff do backfill)        ║
+# ║  Prova money-path: gate staff fail-closed (uid nulo NUNCA passa), fronteira    ║
+# ║  de EXECUTE (anon barrado por privilégio), validação de janela (22023),        ║
+# ║  idempotência que NÃO clobbera janela em voo/completa, e integração com o      ║
+# ║  cron REAL (janela semeada → http_post do vendas-sync-continuacao-6min).       ║
+# ║  Rodar:  bash db/test-vendas_sync_semear_janela.sh > "$LOG" 2>&1; echo $?      ║
+# ║  Sentinelas: ASCII, caixa fixa, sem -i, sem grep (case builtin) — locale-safe. ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5459}"
+SLUG="vendas_sync_semear_janela"
+TMPROOT="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")"
+DATA="$TMPROOT/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "$TMPROOT/pg.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -q -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FALHOU  $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup pronto (PG17 :$PORT) ==="
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: app_role + user_roles + has_role REAL (verbatim da
+# PROD via pg_get_functiondef, 2026-07-21 — é o GATE, não pode ser stub de mentira),
+# e os stubs cron/net/vault pra migração-fundação (20260617133633) aplicar.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='app_role') THEN
+  CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); END IF; END $$;
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role public.app_role);
+
+-- has_role: espelho verbatim da PROD (SECURITY DEFINER, STABLE, search_path=public).
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $function$;
+
+-- pg_cron: schema+cron.job vêm do stubs; faltam schedule/unschedule GUARDANDO o command.
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $$
+DECLARE v_id bigint;
+BEGIN
+  DELETE FROM cron.job WHERE jobname = p_jobname;
+  v_id := COALESCE((SELECT max(jobid) FROM cron.job), 0) + 1;
+  INSERT INTO cron.job(jobid, jobname, schedule, command, active) VALUES (v_id, p_jobname, p_schedule, p_command, true);
+  RETURN v_id;
+END $$;
+CREATE OR REPLACE FUNCTION cron.unschedule(p_jobname text)
+RETURNS boolean LANGUAGE sql AS $$ DELETE FROM cron.job WHERE jobname=$1; SELECT true; $$;
+
+-- pg_net stub: registra cada chamada (assinatura nomeada idêntica à real).
+CREATE SCHEMA IF NOT EXISTS net;
+CREATE TABLE net._calls (id serial PRIMARY KEY, url text, body jsonb);
+CREATE OR REPLACE FUNCTION net.http_post(
+  url text, body jsonb DEFAULT '{}'::jsonb, params jsonb DEFAULT '{}'::jsonb,
+  headers jsonb DEFAULT '{}'::jsonb, timeout_milliseconds integer DEFAULT 5000)
+RETURNS bigint LANGUAGE sql AS $$
+  INSERT INTO net._calls(url, body) VALUES (url, body);
+  SELECT count(*)::bigint FROM net._calls; $$;
+
+-- vault stub (o cron lê o CRON_SECRET).
+CREATE SCHEMA IF NOT EXISTS vault;
+CREATE TABLE vault.decrypted_secrets (name text, decrypted_secret text);
+INSERT INTO vault.decrypted_secrets VALUES ('CRON_SECRET','test-secret');
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATIONS REAIS (Lei #1): fundação (tabela+RPCs+cron) e a SOB TESTE.
+# ══════════════════════════════════════════════════════════════════════════════
+MIG_BASE="$REPO_ROOT/supabase/migrations/20260617133633_vendas_sync_cursor.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260726130000_vendas_sync_semear_janela.sql"
+P -q -f "$MIG_BASE"
+P -q -f "$MIG"
+echo "migrations aplicadas: $(basename "$MIG_BASE") + $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES
+  ('11111111-1111-1111-1111-111111111111'),   -- staff (employee)
+  ('33333333-3333-3333-3333-333333333333'),   -- staff (master)
+  ('22222222-2222-2222-2222-222222222222')    -- não-staff (customer)
+  ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('11111111-1111-1111-1111-111111111111','employee'),
+  ('33333333-3333-3333-3333-333333333333','master'),
+  ('22222222-2222-2222-2222-222222222222','customer') ON CONFLICT DO NOTHING;
+GRANT SELECT ON public.vendas_sync_cursor, public.user_roles TO authenticated, anon;
+SQL
+
+# guard anti-teatro do SET ROLE (#1434): impersonação TEM de rebaixar o role.
+CU=$(Pq -c "SET ROLE authenticated; SELECT current_user;")
+[ "$CU" = "authenticated" ] || { echo "ABORTA: SET ROLE nao rebaixou (current_user=$CU) — zona de RLS seria teatro"; exit 1; }
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "-- positivos: semeadura pelo CAMINHO REAL (authenticated + JWT staff) --"
+
+# P1: staff (employee) semeia janela nova → semeada=true; nasce livre (sem lease, sem progresso).
+R=$(Pq <<'SQL'
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
+SQL
+)
+eq "P1 staff semeia janela nova (semeada=true)" "$R" "true"
+ROW=$(Pq -c "SELECT (next_page IS NULL)||'/'||(completed_at IS NULL)||'/'||(running_since IS NULL) FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-01-01';")
+eq "P1 janela nasce livre (next_page/completed/lease nulos)" "$ROW" "true/true/true"
+
+# P1b: master também semeia (2ª conta — o clique arma as DUAS contas).
+R=$(Pq <<'SQL'
+SET test.uid='33333333-3333-3333-3333-333333333333';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('colacor', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
+SQL
+)
+eq "P1b master semeia a outra conta" "$R" "true"
+
+# P6: o motor consegue COMEÇAR a janela semeada (lease_acquire retorna pág 1).
+A=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2026-01-01','2026-06-30');")
+eq "P6 lease_acquire da janela semeada retoma da pag 1" "$A" "1"
+P -q -c "SELECT public.vendas_sync_release('oben','2026-01-01','2026-06-30', NULL);" >/dev/null
+
+# P2: re-semear a MESMA janela → semeada=false e linha intocada (updated_at idêntico).
+UA1=$(Pq -c "SELECT updated_at FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2026-01-01';")
+R=$(Pq <<'SQL'
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('colacor', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
+SQL
+)
+UA2=$(Pq -c "SELECT updated_at FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2026-01-01';")
+eq "P2 re-semear no-opa (semeada=false)" "$R" "false"
+eq "P2 re-semear nao toca a linha (updated_at identico)" "$UA2" "$UA1"
+
+# P3: janela EM VOO não é clobberada — nem progresso (next_page) nem lease.
+P -q -c "UPDATE public.vendas_sync_cursor SET running_since=now(), heartbeat_at=now(), next_page=7
+         WHERE account='oben' AND date_from='2026-01-01';" >/dev/null
+R=$(Pq <<'SQL'
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
+SQL
+)
+VOO=$(Pq -c "SELECT next_page||'/'||(running_since IS NOT NULL) FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-01-01';")
+eq "P3 semear sobre janela em voo no-opa"                 "$R"   "false"
+eq "P3 progresso e lease preservados (next_page=7/lease)" "$VOO" "7/true"
+
+# P4: janela COMPLETA não reabre.
+P -q -c "UPDATE public.vendas_sync_cursor SET running_since=NULL, next_page=NULL, completed_at='2026-06-24 08:00:00+00'
+         WHERE account='oben' AND date_from='2026-01-01';" >/dev/null
+R=$(Pq <<'SQL'
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT (public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30'))->>'semeada'
+    || '/' || ((public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30'))->>'completed_at' IS NOT NULL);
+SQL
+)
+CA=$(Pq -c "SELECT completed_at = '2026-06-24 08:00:00+00'::timestamptz FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-01-01';")
+eq "P4 semear sobre completa no-opa e devolve completed_at" "$R"  "false/true"
+eq "P4 completed_at original preservado"                    "$CA" "t"
+
+echo "-- negativos: gate, fronteira e validacao (SQLSTATE esperada + re-raise) --"
+
+# N1: customer (authenticated, COM grant de EXECUTE) → barrado pelo GATE (42501 com a msg do gate).
+R=$(P -q -tA 2>&1 <<'SQL'
+SET test.uid='22222222-2222-2222-2222-222222222222';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+  RAISE EXCEPTION 'SABOTAGEM_GATE_AUSENTE';
+EXCEPTION WHEN insufficient_privilege THEN
+  IF SQLERRM LIKE '%requer perfil staff%' THEN RAISE NOTICE 'N1_GATE_BARROU';
+  ELSE RAISE; END IF;
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *N1_GATE_BARROU*) ok "N1 customer barrado pelo gate (42501 do gate)" ;; *) bad "N1 — veio: $R" ;; esac
+NC=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-02-01';")
+eq "N1 nenhuma janela criada pelo customer" "$NC" "0"
+
+# N2: anon → barrado na FRONTEIRA (REVOKE): 'permission denied for function' do Postgres,
+# que o MEU código nunca emite (sentinela exclusiva do ramo de privilégio).
+R=$(P -q -tA 2>&1 <<'SQL'
+SET ROLE anon;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+SQL
+) || true
+case "$R" in *"permission denied for function"*) ok "N2 anon barrado na fronteira (sem EXECUTE)" ;; *) bad "N2 — veio: $R" ;; esac
+
+# N3: authenticated SEM uid (JWT sem sub) → o gate uid-nulo barra (fail-closed), não a fronteira.
+R=$(P -q -tA 2>&1 <<'SQL'
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+  RAISE EXCEPTION 'SABOTAGEM_UID_NULO_PASSOU';
+EXCEPTION WHEN insufficient_privilege THEN
+  IF SQLERRM LIKE '%requer perfil staff%' THEN RAISE NOTICE 'N3_UID_NULO_BARROU';
+  ELSE RAISE; END IF;
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *N3_UID_NULO_BARROU*) ok "N3 uid nulo barrado pelo gate (fail-closed)" ;; *) bad "N3 — veio: $R" ;; esac
+
+# N4-N7: validação de janela (staff legítimo, 22023 = invalid_parameter_value).
+valida_22023() {  # $1 rotulo  $2 chamada SQL
+  R=$(P -q -tA 2>&1 <<SQL
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  PERFORM $2;
+  RAISE EXCEPTION 'SABOTAGEM_VALIDACAO_PASSOU';
+EXCEPTION WHEN invalid_parameter_value THEN RAISE NOTICE 'VAL_22023_BARROU';
+  WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+  case "$R" in *VAL_22023_BARROU*) ok "$1" ;; *) bad "$1 — veio: $R" ;; esac
+}
+valida_22023 "N4 conta invalida rejeitada (22023)"        "public.vendas_sync_semear_janela('xpto', DATE '2026-02-01', DATE '2026-02-28')"
+valida_22023 "N5 date_from > date_to rejeitado (22023)"   "public.vendas_sync_semear_janela('oben', DATE '2026-03-01', DATE '2026-02-01')"
+valida_22023 "N6 date_to futuro rejeitado (22023)"        "public.vendas_sync_semear_janela('oben', DATE '2026-02-01', current_date + 1)"
+valida_22023 "N7 date_from < 2015 rejeitado (22023)"      "public.vendas_sync_semear_janela('oben', DATE '1920-01-01', DATE '2026-02-28')"
+NV=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from IN ('2026-02-01','2026-03-01','1920-01-01');")
+eq "N4-N7 nenhuma janela invalida persistida" "$NV" "0"
+
+echo "-- integracao: janela semeada pela RPC dispara o cron REAL --"
+P -q <<'SQL'
+TRUNCATE net._calls;
+DELETE FROM public.vendas_sync_cursor;
+SQL
+Pq <<'SQL' >/dev/null
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('oben',    DATE '2026-01-22', DATE '2026-06-30');
+SELECT public.vendas_sync_semear_janela('colacor', DATE '2026-01-22', DATE '2026-06-30');
+SQL
+P -q <<'SQL'
+DO $exec$ DECLARE c text; BEGIN
+  SELECT command INTO c FROM cron.job WHERE jobname='vendas-sync-continuacao-6min';
+  EXECUTE c;
+END $exec$;
+SQL
+NCALLS=$(Pq -c "SELECT count(*) FROM net._calls;")
+BODYOK=$(Pq -c "SELECT count(*) FROM net._calls WHERE body->>'use_cursor'='true' AND body->>'date_from'='22/01/2026' AND body->>'action'='sync_pedidos';")
+CONTAS=$(Pq -c "SELECT string_agg(DISTINCT body->>'account', ',' ORDER BY body->>'account') FROM net._calls;")
+eq "C1 cron dispara 1 http_post por conta semeada"     "$NCALLS" "2"
+eq "C2 payload com use_cursor + data DD/MM/YYYY"       "$BODYOK" "2"
+eq "C3 as duas contas semeadas disparam"               "$CONTAS" "colacor,oben"
+
+# V1: o VALIDADOR pós-apply (o mesmo arquivo que o founder cola) aprova o banco BOM.
+VALIDA="$REPO_ROOT/db/valida-vendas-sync-semear-janela.sql"
+V=$(Pq -f "$VALIDA")
+case "$V" in "✅"*) ok "V1 validador pos-apply aprova o banco bom" ;; *) bad "V1 validador reprovou banco bom: $V" ;; esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota → exige a INVERSÃO do assert alvo → restaura.
+# Baseline verde acima prova que os asserts rodam; aqui cada sabotagem mira UM assert.
+# ══════════════════════════════════════════════════════════════════════════════
+echo "-- falsificacao --"
+
+# F1 (mira N1): remove o gate → customer teria de CONSEGUIR semear.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_account text, p_date_from date, p_date_to date)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO ''
+AS $$
+DECLARE v_semeada boolean := false;
+BEGIN
+  -- SABOTADO: sem gate
+  INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+  VALUES (p_account, p_date_from, p_date_to)
+  ON CONFLICT (account, date_from, date_to) DO NOTHING;
+  v_semeada := FOUND;
+  RETURN jsonb_build_object('semeada', v_semeada);
+END; $$;
+SQL
+R=$(Pq <<'SQL'
+SET test.uid='22222222-2222-2222-2222-222222222222';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28')->>'semeada';
+SQL
+)
+if [ "$R" = "true" ]; then ok "F1 sem gate o customer semeia (N1 tem dente)"; else bad "F1 sabotei o gate e o customer seguiu barrado ($R) → N1 fraco"; fi
+V=$(Pq -f "$VALIDA")
+case "$V" in *"corpo sem o gate staff"*) ok "F1b validador reprova corpo sem gate (validador tem dente)" ;; *) bad "F1b validador aprovou corpo SABOTADO: $V" ;; esac
+P -q -c "DELETE FROM public.vendas_sync_cursor WHERE date_from='2026-02-01';" >/dev/null
+P -q -f "$MIG" >/dev/null   # restaura
+
+# F2 (mira P3): ON CONFLICT que CLOBBERA o progresso → next_page 7 viraria 1.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_account text, p_date_from date, p_date_to date)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO ''
+AS $$
+DECLARE v_uid uuid := auth.uid();
+BEGIN
+  IF v_uid IS NULL
+     OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
+          OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+  INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+  VALUES (p_account, p_date_from, p_date_to)
+  ON CONFLICT (account, date_from, date_to) DO UPDATE SET next_page = 1;  -- SABOTADO: clobber
+  RETURN jsonb_build_object('semeada', true);
+END; $$;
+SQL
+P -q -c "INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page,running_since,heartbeat_at)
+         VALUES ('oben','2026-04-01','2026-04-30',7,now(),now());" >/dev/null
+Pq <<'SQL' >/dev/null
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-04-01', DATE '2026-04-30');
+SQL
+NP=$(Pq -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-04-01';")
+if [ "$NP" = "1" ]; then ok "F2 clobber rebobina next_page 7->1 (P3 tem dente)"; else bad "F2 sabotei o ON CONFLICT e o next_page seguiu $NP → P3 fraco"; fi
+V=$(Pq -f "$VALIDA")
+case "$V" in *"sem o ON CONFLICT DO NOTHING"*) ok "F2b validador reprova o clobber (validador tem dente)" ;; *) bad "F2b validador aprovou corpo com DO UPDATE: $V" ;; esac
+P -q -c "DELETE FROM public.vendas_sync_cursor WHERE date_from='2026-04-01';" >/dev/null
+P -q -f "$MIG" >/dev/null   # restaura
+
+# F3 (mira N2): GRANT a anon → a fronteira some; anon passa a bater no GATE (msg do gate,
+# nao mais 'permission denied for function').
+P -q -c "GRANT EXECUTE ON FUNCTION public.vendas_sync_semear_janela(text,date,date) TO anon;" >/dev/null
+R=$(P -q -tA 2>&1 <<'SQL'
+SET ROLE anon;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+SQL
+) || true
+case "$R" in
+  *"permission denied for function"*) bad "F3 concedi EXECUTE a anon e a fronteira seguiu barrando → N2 fraco" ;;
+  *"requer perfil staff"*)            ok  "F3 com GRANT o anon passa a fronteira e cai no gate (N2 tem dente)" ;;
+  *)                                  bad "F3 — saida inesperada: $R" ;;
+esac
+V=$(Pq -f "$VALIDA")
+case "$V" in *"anon com EXECUTE"*) ok "F3b validador reprova grant a anon (validador tem dente)" ;; *) bad "F3b validador aprovou anon com EXECUTE: $V" ;; esac
+P -q -f "$MIG" >/dev/null   # restaura (re-REVOKE de anon)
+
+# pós-restauração: a versão REAL voltou a valer (staff semeia, customer não).
+R=$(Pq <<'SQL'
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela('oben', DATE '2026-05-01', DATE '2026-05-31')->>'semeada';
+SQL
+)
+eq "POS restauracao: staff volta a semear" "$R" "true"
+
+# ── veredito ──
+echo "------------------------------"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "HARNESS VERMELHO"; exit 1; }
+echo "HARNESS VERDE"

--- a/db/test-vendas_sync_semear_janela.sh
+++ b/db/test-vendas_sync_semear_janela.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 # ╔══════════════════════════════════════════════════════════════════════════════╗
-# ║  HARNESS PG17 — vendas_sync_semear_janela (semeadura staff do backfill)        ║
+# ║  HARNESS PG17 — vendas_sync_semear_janela v2 (semeadura ATÔMICA do backfill)   ║
 # ║  Prova money-path: gate staff fail-closed (uid nulo NUNCA passa), fronteira    ║
 # ║  de EXECUTE (anon barrado por privilégio), validação de janela (22023),        ║
-# ║  idempotência que NÃO clobbera janela em voo/completa, e integração com o      ║
-# ║  cron REAL (janela semeada → http_post do vendas-sync-continuacao-6min).       ║
+# ║  ATOMICIDADE do par de contas (conta inválida → rollback TOTAL), recusa        ║
+# ║  'ja_pendente_outra' (janela aberta ≠ PK), não-clobber de janela em voo, e a   ║
+# ║  integração com o cron REAL (janela semeada → http_post do continuacao-6min).  ║
+# ║  O VALIDADOR pós-apply (db/valida-vendas-sync-semear-janela.sql) é EXECUTADO   ║
+# ║  contra banco bom e sabotado (lição #1490/#1501: validador sem dente).         ║
 # ║  Rodar:  bash db/test-vendas_sync_semear_janela.sh > "$LOG" 2>&1; echo $?      ║
 # ║  Sentinelas: ASCII, caixa fixa, sem -i, sem grep (case builtin) — locale-safe. ║
 # ╚══════════════════════════════════════════════════════════════════════════════╝
@@ -96,9 +99,11 @@ SQL
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 2 — MIGRATIONS REAIS (Lei #1): fundação (tabela+RPCs+cron) e a SOB TESTE.
+# A v1 (20260726130000) NÃO é aplicada — superseded; a v2 dropa a assinatura dela.
 # ══════════════════════════════════════════════════════════════════════════════
 MIG_BASE="$REPO_ROOT/supabase/migrations/20260617133633_vendas_sync_cursor.sql"
-MIG="$REPO_ROOT/supabase/migrations/20260726130000_vendas_sync_semear_janela.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260726140000_vendas_sync_semear_janela_v2.sql"
+VALIDA="$REPO_ROOT/db/valida-vendas-sync-semear-janela.sql"
 P -q -f "$MIG_BASE"
 P -q -f "$MIG"
 echo "migrations aplicadas: $(basename "$MIG_BASE") + $(basename "$MIG")"
@@ -123,83 +128,82 @@ SQL
 CU=$(Pq -c "SET ROLE authenticated; SELECT current_user;")
 [ "$CU" = "authenticated" ] || { echo "ABORTA: SET ROLE nao rebaixou (current_user=$CU) — zona de RLS seria teatro"; exit 1; }
 
+# helper: par de desfechos (contas em ordem alfabética: [0]=colacor, [1]=oben)
+DESF_PAR() {  # $1 uid  $2 date_from  $3 date_to
+  Pq <<SQL
+SET test.uid='$1';
+SET ROLE authenticated;
+SELECT (r->'contas'->0->>'desfecho') || '/' || (r->'contas'->1->>'desfecho')
+  FROM public.vendas_sync_semear_janela(DATE '$2', DATE '$3') AS r;
+SQL
+}
+STAFF='11111111-1111-1111-1111-111111111111'
+MASTER='33333333-3333-3333-3333-333333333333'
+
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 4 — ASSERTS
 # ══════════════════════════════════════════════════════════════════════════════
-echo "-- positivos: semeadura pelo CAMINHO REAL (authenticated + JWT staff) --"
+echo "-- positivos: semeadura ATÔMICA pelo caminho real (authenticated + JWT staff) --"
 
-# P1: staff (employee) semeia janela nova → semeada=true; nasce livre (sem lease, sem progresso).
-R=$(Pq <<'SQL'
-SET test.uid='11111111-1111-1111-1111-111111111111';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
-SQL
-)
-eq "P1 staff semeia janela nova (semeada=true)" "$R" "true"
-ROW=$(Pq -c "SELECT (next_page IS NULL)||'/'||(completed_at IS NULL)||'/'||(running_since IS NULL) FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-01-01';")
-eq "P1 janela nasce livre (next_page/completed/lease nulos)" "$ROW" "true/true/true"
+# P1: staff (employee) arma o PAR numa chamada; as duas janelas nascem livres.
+R=$(DESF_PAR "$STAFF" 2026-01-01 2026-06-30)
+eq "P1 uma chamada arma as 2 contas (colacor/oben)" "$R" "semeada/semeada"
+NL=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-01-01' AND next_page IS NULL AND completed_at IS NULL AND running_since IS NULL;")
+eq "P1 par completo e livre (2 linhas sem lease/progresso)" "$NL" "2"
 
-# P1b: master também semeia (2ª conta — o clique arma as DUAS contas).
-R=$(Pq <<'SQL'
-SET test.uid='33333333-3333-3333-3333-333333333333';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('colacor', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
-SQL
-)
-eq "P1b master semeia a outra conta" "$R" "true"
-
-# P6: o motor consegue COMEÇAR a janela semeada (lease_acquire retorna pág 1).
-A=$(Pq -c "SELECT public.vendas_sync_lease_acquire('oben','2026-01-01','2026-06-30');")
-eq "P6 lease_acquire da janela semeada retoma da pag 1" "$A" "1"
-P -q -c "SELECT public.vendas_sync_release('oben','2026-01-01','2026-06-30', NULL);" >/dev/null
-
-# P2: re-semear a MESMA janela → semeada=false e linha intocada (updated_at idêntico).
-UA1=$(Pq -c "SELECT updated_at FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2026-01-01';")
-R=$(Pq <<'SQL'
-SET test.uid='11111111-1111-1111-1111-111111111111';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('colacor', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
-SQL
-)
-UA2=$(Pq -c "SELECT updated_at FROM public.vendas_sync_cursor WHERE account='colacor' AND date_from='2026-01-01';")
-eq "P2 re-semear no-opa (semeada=false)" "$R" "false"
-eq "P2 re-semear nao toca a linha (updated_at identico)" "$UA2" "$UA1"
+# P2: re-chamar a MESMA janela → ja_pendente nas duas, linhas intocadas.
+UA1=$(Pq -c "SELECT max(updated_at) FROM public.vendas_sync_cursor WHERE date_from='2026-01-01';")
+R=$(DESF_PAR "$MASTER" 2026-01-01 2026-06-30)
+UA2=$(Pq -c "SELECT max(updated_at) FROM public.vendas_sync_cursor WHERE date_from='2026-01-01';")
+eq "P2 re-semear no-opa (master; ja_pendente no par)" "$R" "ja_pendente/ja_pendente"
+eq "P2 re-semear nao toca as linhas (updated_at identico)" "$UA2" "$UA1"
 
 # P3: janela EM VOO não é clobberada — nem progresso (next_page) nem lease.
 P -q -c "UPDATE public.vendas_sync_cursor SET running_since=now(), heartbeat_at=now(), next_page=7
          WHERE account='oben' AND date_from='2026-01-01';" >/dev/null
-R=$(Pq <<'SQL'
-SET test.uid='11111111-1111-1111-1111-111111111111';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30')->>'semeada';
-SQL
-)
+R=$(DESF_PAR "$STAFF" 2026-01-01 2026-06-30)
 VOO=$(Pq -c "SELECT next_page||'/'||(running_since IS NOT NULL) FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-01-01';")
-eq "P3 semear sobre janela em voo no-opa"                 "$R"   "false"
+eq "P3 semear sobre janela em voo no-opa"                 "$R"   "ja_pendente/ja_pendente"
 eq "P3 progresso e lease preservados (next_page=7/lease)" "$VOO" "7/true"
 
 # P4: janela COMPLETA não reabre.
 P -q -c "UPDATE public.vendas_sync_cursor SET running_since=NULL, next_page=NULL, completed_at='2026-06-24 08:00:00+00'
-         WHERE account='oben' AND date_from='2026-01-01';" >/dev/null
-R=$(Pq <<'SQL'
-SET test.uid='11111111-1111-1111-1111-111111111111';
+         WHERE date_from='2026-01-01';" >/dev/null
+R=$(DESF_PAR "$STAFF" 2026-01-01 2026-06-30)
+CA=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-01-01' AND completed_at='2026-06-24 08:00:00+00'::timestamptz;")
+eq "P4 semear sobre completa no-opa (ja_concluida no par)" "$R"  "ja_concluida/ja_concluida"
+eq "P4 completed_at original preservado (2 linhas)"        "$CA" "2"
+
+# P4b: conta com OUTRA janela aberta → recusa honesta, sem inserir (starvation do cron).
+P -q <<'SQL'
+DELETE FROM public.vendas_sync_cursor;
+INSERT INTO public.vendas_sync_cursor(account, date_from, date_to, next_page) VALUES ('oben','2026-01-01','2026-03-31', 5);
+SQL
+R=$(Pq <<SQL
+SET test.uid='$STAFF';
 SET ROLE authenticated;
-SELECT (public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30'))->>'semeada'
-    || '/' || ((public.vendas_sync_semear_janela('oben', DATE '2026-01-01', DATE '2026-06-30'))->>'completed_at' IS NOT NULL);
+SELECT (r->'contas'->0->>'desfecho') || '/' || (r->'contas'->1->>'desfecho') || '/' || (r->'contas'->1->>'janela_aberta_de')
+  FROM public.vendas_sync_semear_janela(DATE '2026-02-01', DATE '2026-06-30') AS r;
 SQL
 )
-CA=$(Pq -c "SELECT completed_at = '2026-06-24 08:00:00+00'::timestamptz FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-01-01';")
-eq "P4 semear sobre completa no-opa e devolve completed_at" "$R"  "false/true"
-eq "P4 completed_at original preservado"                    "$CA" "t"
+NO=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-02-01';")
+eq "P4b outra janela aberta → ja_pendente_outra + aponta a aberta" "$R"  "semeada/ja_pendente_outra/2026-01-01"
+eq "P4b nada inserido pra conta ocupada"                           "$NO" "0"
 
-echo "-- negativos: gate, fronteira e validacao (SQLSTATE esperada + re-raise) --"
+# P6: o motor consegue COMEÇAR a janela semeada (lease_acquire retorna pág 1).
+A=$(Pq -c "SELECT public.vendas_sync_lease_acquire('colacor','2026-02-01','2026-06-30');")
+eq "P6 lease_acquire da janela semeada retoma da pag 1" "$A" "1"
+P -q -c "SELECT public.vendas_sync_release('colacor','2026-02-01','2026-06-30', NULL);" >/dev/null
+
+echo "-- negativos: gate, fronteira, validacao e ATOMICIDADE (SQLSTATE esperada + re-raise) --"
+P -q -c "DELETE FROM public.vendas_sync_cursor;" >/dev/null
 
 # N1: customer (authenticated, COM grant de EXECUTE) → barrado pelo GATE (42501 com a msg do gate).
 R=$(P -q -tA 2>&1 <<'SQL'
 SET test.uid='22222222-2222-2222-2222-222222222222';
 SET ROLE authenticated;
 DO $$ BEGIN
-  PERFORM public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+  PERFORM public.vendas_sync_semear_janela(DATE '2026-05-01', DATE '2026-05-31');
   RAISE EXCEPTION 'SABOTAGEM_GATE_AUSENTE';
 EXCEPTION WHEN insufficient_privilege THEN
   IF SQLERRM LIKE '%requer perfil staff%' THEN RAISE NOTICE 'N1_GATE_BARROU';
@@ -208,14 +212,14 @@ EXCEPTION WHEN insufficient_privilege THEN
 SQL
 )
 case "$R" in *N1_GATE_BARROU*) ok "N1 customer barrado pelo gate (42501 do gate)" ;; *) bad "N1 — veio: $R" ;; esac
-NC=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-02-01';")
+NC=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-05-01';")
 eq "N1 nenhuma janela criada pelo customer" "$NC" "0"
 
 # N2: anon → barrado na FRONTEIRA (REVOKE): 'permission denied for function' do Postgres,
 # que o MEU código nunca emite (sentinela exclusiva do ramo de privilégio).
 R=$(P -q -tA 2>&1 <<'SQL'
 SET ROLE anon;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+SELECT public.vendas_sync_semear_janela(DATE '2026-05-01', DATE '2026-05-31');
 SQL
 ) || true
 case "$R" in *"permission denied for function"*) ok "N2 anon barrado na fronteira (sem EXECUTE)" ;; *) bad "N2 — veio: $R" ;; esac
@@ -224,7 +228,7 @@ case "$R" in *"permission denied for function"*) ok "N2 anon barrado na fronteir
 R=$(P -q -tA 2>&1 <<'SQL'
 SET ROLE authenticated;
 DO $$ BEGIN
-  PERFORM public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+  PERFORM public.vendas_sync_semear_janela(DATE '2026-05-01', DATE '2026-05-31');
   RAISE EXCEPTION 'SABOTAGEM_UID_NULO_PASSOU';
 EXCEPTION WHEN insufficient_privilege THEN
   IF SQLERRM LIKE '%requer perfil staff%' THEN RAISE NOTICE 'N3_UID_NULO_BARROU';
@@ -234,7 +238,24 @@ SQL
 )
 case "$R" in *N3_UID_NULO_BARROU*) ok "N3 uid nulo barrado pelo gate (fail-closed)" ;; *) bad "N3 — veio: $R" ;; esac
 
-# N4-N7: validação de janela (staff legítimo, 22023 = invalid_parameter_value).
+# N4: conta inválida NO MEIO do par → 22023 e ROLLBACK TOTAL (a válida NÃO persiste).
+# 'colacor' < 'xpto': o loop insere colacor ANTES de rejeitar xpto — o assert de count
+# prova que a exceção desfez o insert já feito (atomicidade real, não ordem de sorte).
+R=$(P -q -tA 2>&1 <<'SQL'
+SET test.uid='11111111-1111-1111-1111-111111111111';
+SET ROLE authenticated;
+DO $$ BEGIN
+  PERFORM public.vendas_sync_semear_janela(DATE '2026-05-01', DATE '2026-05-31', ARRAY['colacor','xpto']);
+  RAISE EXCEPTION 'SABOTAGEM_VALIDACAO_PASSOU';
+EXCEPTION WHEN invalid_parameter_value THEN RAISE NOTICE 'N4_CONTA_BARROU';
+  WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in *N4_CONTA_BARROU*) ok "N4 conta invalida no par rejeitada (22023)" ;; *) bad "N4 — veio: $R" ;; esac
+NA=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-05-01';")
+eq "N4 ATOMICIDADE: a conta valida do par tambem NAO persistiu (rollback)" "$NA" "0"
+
+# N5-N8: validação de janela (staff legítimo, 22023 = invalid_parameter_value).
 valida_22023() {  # $1 rotulo  $2 chamada SQL
   R=$(P -q -tA 2>&1 <<SQL
 SET test.uid='11111111-1111-1111-1111-111111111111';
@@ -248,23 +269,19 @@ SQL
 )
   case "$R" in *VAL_22023_BARROU*) ok "$1" ;; *) bad "$1 — veio: $R" ;; esac
 }
-valida_22023 "N4 conta invalida rejeitada (22023)"        "public.vendas_sync_semear_janela('xpto', DATE '2026-02-01', DATE '2026-02-28')"
-valida_22023 "N5 date_from > date_to rejeitado (22023)"   "public.vendas_sync_semear_janela('oben', DATE '2026-03-01', DATE '2026-02-01')"
-valida_22023 "N6 date_to futuro rejeitado (22023)"        "public.vendas_sync_semear_janela('oben', DATE '2026-02-01', current_date + 1)"
-valida_22023 "N7 date_from < 2015 rejeitado (22023)"      "public.vendas_sync_semear_janela('oben', DATE '1920-01-01', DATE '2026-02-28')"
-NV=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from IN ('2026-02-01','2026-03-01','1920-01-01');")
-eq "N4-N7 nenhuma janela invalida persistida" "$NV" "0"
+valida_22023 "N5 date_from > date_to rejeitado (22023)"   "public.vendas_sync_semear_janela(DATE '2026-03-01', DATE '2026-02-01')"
+valida_22023 "N6 date_to futuro rejeitado (22023)"        "public.vendas_sync_semear_janela(DATE '2026-02-01', current_date + 1)"
+valida_22023 "N7 date_from < 2015 rejeitado (22023)"      "public.vendas_sync_semear_janela(DATE '2014-12-31', DATE '2026-02-28')"
+valida_22023 "N8 p_accounts vazio rejeitado (22023)"      "public.vendas_sync_semear_janela(DATE '2026-02-01', DATE '2026-02-28', ARRAY[]::text[])"
+NV=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor;")
+eq "N5-N8 nada persistido pelos rejeitados" "$NV" "0"
 
 echo "-- integracao: janela semeada pela RPC dispara o cron REAL --"
-P -q <<'SQL'
-TRUNCATE net._calls;
-DELETE FROM public.vendas_sync_cursor;
-SQL
-Pq <<'SQL' >/dev/null
-SET test.uid='11111111-1111-1111-1111-111111111111';
+P -q -c "TRUNCATE net._calls;" >/dev/null
+Pq <<SQL >/dev/null
+SET test.uid='$STAFF';
 SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('oben',    DATE '2026-01-22', DATE '2026-06-30');
-SELECT public.vendas_sync_semear_janela('colacor', DATE '2026-01-22', DATE '2026-06-30');
+SELECT public.vendas_sync_semear_janela(DATE '2026-01-22', DATE '2026-06-30');
 SQL
 P -q <<'SQL'
 DO $exec$ DECLARE c text; BEGIN
@@ -279,69 +296,65 @@ eq "C1 cron dispara 1 http_post por conta semeada"     "$NCALLS" "2"
 eq "C2 payload com use_cursor + data DD/MM/YYYY"       "$BODYOK" "2"
 eq "C3 as duas contas semeadas disparam"               "$CONTAS" "colacor,oben"
 
-# V1: o VALIDADOR pós-apply (o mesmo arquivo que o founder cola) aprova o banco BOM.
-VALIDA="$REPO_ROOT/db/valida-vendas-sync-semear-janela.sql"
+# V0/V1: v1 dropada + o VALIDADOR pós-apply (o mesmo arquivo que o founder cola) aprova o banco bom.
+V0=$(Pq -c "SELECT to_regprocedure('public.vendas_sync_semear_janela(text,date,date)') IS NULL;")
+eq "V0 assinatura v1 (por conta) nao existe (DROP da v2 pegou)" "$V0" "t"
 V=$(Pq -f "$VALIDA")
 case "$V" in "✅"*) ok "V1 validador pos-apply aprova o banco bom" ;; *) bad "V1 validador reprovou banco bom: $V" ;; esac
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota → exige a INVERSÃO do assert alvo → restaura.
-# Baseline verde acima prova que os asserts rodam; aqui cada sabotagem mira UM assert.
+# Baseline verde acima prova que os asserts rodam; cada sabotagem mira UM assert.
 # ══════════════════════════════════════════════════════════════════════════════
 echo "-- falsificacao --"
 
 # F1 (mira N1): remove o gate → customer teria de CONSEGUIR semear.
 P -q <<'SQL'
-CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_account text, p_date_from date, p_date_to date)
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_date_from date, p_date_to date, p_accounts text[] DEFAULT ARRAY['oben','colacor'])
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO ''
 AS $$
-DECLARE v_semeada boolean := false;
+DECLARE v_account text; v_contas jsonb := '[]'::jsonb;
 BEGIN
   -- SABOTADO: sem gate
-  INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
-  VALUES (p_account, p_date_from, p_date_to)
-  ON CONFLICT (account, date_from, date_to) DO NOTHING;
-  v_semeada := FOUND;
-  RETURN jsonb_build_object('semeada', v_semeada);
+  FOR v_account IN SELECT DISTINCT a FROM unnest(p_accounts) AS a ORDER BY a LOOP
+    INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+    VALUES (v_account, p_date_from, p_date_to)
+    ON CONFLICT (account, date_from, date_to) DO NOTHING;
+    v_contas := v_contas || jsonb_build_object('account', v_account, 'desfecho', 'semeada');
+  END LOOP;
+  RETURN jsonb_build_object('contas', v_contas);
 END; $$;
 SQL
-R=$(Pq <<'SQL'
-SET test.uid='22222222-2222-2222-2222-222222222222';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28')->>'semeada';
-SQL
-)
-if [ "$R" = "true" ]; then ok "F1 sem gate o customer semeia (N1 tem dente)"; else bad "F1 sabotei o gate e o customer seguiu barrado ($R) → N1 fraco"; fi
+R=$(DESF_PAR '22222222-2222-2222-2222-222222222222' 2026-05-01 2026-05-31)
+if [ "$R" = "semeada/semeada" ]; then ok "F1 sem gate o customer semeia (N1 tem dente)"; else bad "F1 sabotei o gate e o customer seguiu barrado ($R) → N1 fraco"; fi
 V=$(Pq -f "$VALIDA")
 case "$V" in *"corpo sem o gate staff"*) ok "F1b validador reprova corpo sem gate (validador tem dente)" ;; *) bad "F1b validador aprovou corpo SABOTADO: $V" ;; esac
-P -q -c "DELETE FROM public.vendas_sync_cursor WHERE date_from='2026-02-01';" >/dev/null
+P -q -c "DELETE FROM public.vendas_sync_cursor WHERE date_from='2026-05-01';" >/dev/null
 P -q -f "$MIG" >/dev/null   # restaura
 
 # F2 (mira P3): ON CONFLICT que CLOBBERA o progresso → next_page 7 viraria 1.
 P -q <<'SQL'
-CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_account text, p_date_from date, p_date_to date)
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_date_from date, p_date_to date, p_accounts text[] DEFAULT ARRAY['oben','colacor'])
 RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO ''
 AS $$
-DECLARE v_uid uuid := auth.uid();
+DECLARE v_uid uuid := auth.uid(); v_account text;
 BEGIN
   IF v_uid IS NULL
      OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
           OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
     RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
   END IF;
-  INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
-  VALUES (p_account, p_date_from, p_date_to)
-  ON CONFLICT (account, date_from, date_to) DO UPDATE SET next_page = 1;  -- SABOTADO: clobber
-  RETURN jsonb_build_object('semeada', true);
+  FOR v_account IN SELECT DISTINCT a FROM unnest(p_accounts) AS a ORDER BY a LOOP
+    INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+    VALUES (v_account, p_date_from, p_date_to)
+    ON CONFLICT (account, date_from, date_to) DO UPDATE SET next_page = 1;  -- SABOTADO: clobber
+  END LOOP;
+  RETURN '{}'::jsonb;
 END; $$;
 SQL
 P -q -c "INSERT INTO public.vendas_sync_cursor(account,date_from,date_to,next_page,running_since,heartbeat_at)
          VALUES ('oben','2026-04-01','2026-04-30',7,now(),now());" >/dev/null
-Pq <<'SQL' >/dev/null
-SET test.uid='11111111-1111-1111-1111-111111111111';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-04-01', DATE '2026-04-30');
-SQL
+DESF_PAR "$STAFF" 2026-04-01 2026-04-30 >/dev/null
 NP=$(Pq -c "SELECT next_page FROM public.vendas_sync_cursor WHERE account='oben' AND date_from='2026-04-01';")
 if [ "$NP" = "1" ]; then ok "F2 clobber rebobina next_page 7->1 (P3 tem dente)"; else bad "F2 sabotei o ON CONFLICT e o next_page seguiu $NP → P3 fraco"; fi
 V=$(Pq -f "$VALIDA")
@@ -351,10 +364,10 @@ P -q -f "$MIG" >/dev/null   # restaura
 
 # F3 (mira N2): GRANT a anon → a fronteira some; anon passa a bater no GATE (msg do gate,
 # nao mais 'permission denied for function').
-P -q -c "GRANT EXECUTE ON FUNCTION public.vendas_sync_semear_janela(text,date,date) TO anon;" >/dev/null
+P -q -c "GRANT EXECUTE ON FUNCTION public.vendas_sync_semear_janela(date,date,text[]) TO anon;" >/dev/null
 R=$(P -q -tA 2>&1 <<'SQL'
 SET ROLE anon;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-02-01', DATE '2026-02-28');
+SELECT public.vendas_sync_semear_janela(DATE '2026-05-01', DATE '2026-05-31');
 SQL
 ) || true
 case "$R" in
@@ -366,14 +379,72 @@ V=$(Pq -f "$VALIDA")
 case "$V" in *"anon com EXECUTE"*) ok "F3b validador reprova grant a anon (validador tem dente)" ;; *) bad "F3b validador aprovou anon com EXECUTE: $V" ;; esac
 P -q -f "$MIG" >/dev/null   # restaura (re-REVOKE de anon)
 
-# pós-restauração: a versão REAL voltou a valer (staff semeia, customer não).
-R=$(Pq <<'SQL'
-SET test.uid='11111111-1111-1111-1111-111111111111';
-SET ROLE authenticated;
-SELECT public.vendas_sync_semear_janela('oben', DATE '2026-05-01', DATE '2026-05-31')->>'semeada';
+# F4 (mira o VALIDADOR): corpo com gate + DO NOTHING mas SEM o advisory lock por conta.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_date_from date, p_date_to date, p_accounts text[] DEFAULT ARRAY['oben','colacor'])
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO ''
+AS $$
+DECLARE v_uid uuid := auth.uid(); v_account text;
+BEGIN
+  IF v_uid IS NULL
+     OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
+          OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+  FOR v_account IN SELECT DISTINCT a FROM unnest(p_accounts) AS a ORDER BY a LOOP
+    -- SABOTADO: sem pg_advisory_xact_lock
+    INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+    VALUES (v_account, p_date_from, p_date_to)
+    ON CONFLICT (account, date_from, date_to) DO NOTHING;
+  END LOOP;
+  RETURN '{}'::jsonb;
+END; $$;
 SQL
-)
-eq "POS restauracao: staff volta a semear" "$R" "true"
+V=$(Pq -f "$VALIDA")
+case "$V" in *"sem o advisory lock"*) ok "F4 validador reprova corpo sem o lock por conta (dente)" ;; *) bad "F4 validador aprovou corpo sem lock: $V" ;; esac
+P -q -f "$MIG" >/dev/null   # restaura
+
+# F5 (mira N4): engolir exceção por conta quebra a atomicidade → a válida persistiria.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(p_date_from date, p_date_to date, p_accounts text[] DEFAULT ARRAY['oben','colacor'])
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO ''
+AS $$
+DECLARE v_uid uuid := auth.uid(); v_account text;
+BEGIN
+  IF v_uid IS NULL
+     OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
+          OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+  FOR v_account IN SELECT DISTINCT a FROM unnest(p_accounts) AS a ORDER BY a LOOP
+    BEGIN
+      IF v_account NOT IN ('oben','colacor') THEN
+        RAISE EXCEPTION 'conta invalida' USING ERRCODE = '22023';
+      END IF;
+      INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+      VALUES (v_account, p_date_from, p_date_to)
+      ON CONFLICT (account, date_from, date_to) DO NOTHING;
+    EXCEPTION WHEN OTHERS THEN NULL;  -- SABOTADO: engole e segue (mata a atomicidade)
+    END;
+  END LOOP;
+  RETURN '{}'::jsonb;
+END; $$;
+SQL
+Pq <<SQL >/dev/null
+SET test.uid='$STAFF';
+SET ROLE authenticated;
+SELECT public.vendas_sync_semear_janela(DATE '2026-05-01', DATE '2026-05-31', ARRAY['colacor','xpto']);
+SQL
+NS=$(Pq -c "SELECT count(*) FROM public.vendas_sync_cursor WHERE date_from='2026-05-01';")
+if [ "$NS" = "1" ]; then ok "F5 engolir excecao persiste a valida do par (N4-atomicidade tem dente)"; else bad "F5 sabotei a atomicidade e nada persistiu ($NS) → N4 fraco"; fi
+P -q -c "DELETE FROM public.vendas_sync_cursor WHERE date_from='2026-05-01';" >/dev/null
+P -q -f "$MIG" >/dev/null   # restaura
+
+# pós-restauração: a versão REAL voltou a valer (staff arma o par).
+# (limpa as janelas abertas da seção C — senão o guard 'ja_pendente_outra', correto, recusa.)
+P -q -c "DELETE FROM public.vendas_sync_cursor;" >/dev/null
+R=$(DESF_PAR "$STAFF" 2026-03-01 2026-03-31)
+eq "POS restauracao: staff volta a armar o par" "$R" "semeada/semeada"
 
 # ── veredito ──
 echo "------------------------------"

--- a/db/valida-vendas-sync-semear-janela.sql
+++ b/db/valida-vendas-sync-semear-janela.sql
@@ -1,21 +1,26 @@
--- Validação pós-apply de 20260726130000_vendas_sync_semear_janela.sql (read-only).
+-- Validação pós-apply de 20260726140000_vendas_sync_semear_janela_v2.sql (read-only).
 -- Lê CATÁLOGO, nunca invoca (FU4-E: invocar mente nos dois sentidos — NULL sem cast
 -- não resolve assinatura e o REVOKE vira 'permission denied' que parece falha).
 -- Corpo avaliado com comentários REMOVIDOS (lição #1472/#1488: assert sobre corpo
 -- cru casa prosa de comentário). Executada contra banco bom E sabotado no harness
 -- db/test-vendas_sync_semear_janela.sh (lição #1490/#1501: validador sem dente).
 SELECT CASE
-  WHEN to_regprocedure('public.vendas_sync_semear_janela(text,date,date)') IS NULL
-    THEN '❌ FALTANDO — migration nao aplicada'
-  WHEN NOT has_function_privilege('authenticated', 'public.vendas_sync_semear_janela(text,date,date)', 'EXECUTE')
+  WHEN to_regprocedure('public.vendas_sync_semear_janela(date,date,text[])') IS NULL
+    THEN '❌ FALTANDO — migration v2 nao aplicada'
+  WHEN to_regprocedure('public.vendas_sync_semear_janela(text,date,date)') IS NOT NULL
+    THEN '❌ assinatura v1 ainda presente (o DROP da v2 nao rodou)'
+  WHEN NOT has_function_privilege('authenticated', 'public.vendas_sync_semear_janela(date,date,text[])', 'EXECUTE')
     THEN '❌ authenticated sem EXECUTE (GRANT nao pegou)'
-  WHEN has_function_privilege('anon', 'public.vendas_sync_semear_janela(text,date,date)', 'EXECUTE')
+  WHEN has_function_privilege('anon', 'public.vendas_sync_semear_janela(date,date,text[])', 'EXECUTE')
     THEN '❌ anon com EXECUTE (REVOKE nao pegou)'
-  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(text,date,date)')), '--[^\n]*', '', 'g')
+  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(date,date,text[])')), '--[^\n]*', '', 'g')
        !~ 'IF v_uid IS NULL\s+OR NOT \(COALESCE\(public\.has_role\(v_uid, ''employee''::public\.app_role\), false\)'
     THEN '❌ corpo sem o gate staff fail-closed'
-  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(text,date,date)')), '--[^\n]*', '', 'g')
+  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(date,date,text[])')), '--[^\n]*', '', 'g')
        !~ 'ON CONFLICT \(account, date_from, date_to\) DO NOTHING'
     THEN '❌ corpo sem o ON CONFLICT DO NOTHING (risco de clobber)'
-  ELSE '✅ vendas_sync_semear_janela aplicada (gate staff + grants + DO NOTHING ok)'
+  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(date,date,text[])')), '--[^\n]*', '', 'g')
+       !~ 'pg_advisory_xact_lock\(hashtext\(''vendas_sync_semear_'' \|\| v_account\)\)'
+    THEN '❌ corpo sem o advisory lock por conta'
+  ELSE '✅ vendas_sync_semear_janela v2 aplicada (atomica + gate staff + grants + DO NOTHING + lock ok)'
 END AS status;

--- a/db/valida-vendas-sync-semear-janela.sql
+++ b/db/valida-vendas-sync-semear-janela.sql
@@ -1,0 +1,21 @@
+-- Validação pós-apply de 20260726130000_vendas_sync_semear_janela.sql (read-only).
+-- Lê CATÁLOGO, nunca invoca (FU4-E: invocar mente nos dois sentidos — NULL sem cast
+-- não resolve assinatura e o REVOKE vira 'permission denied' que parece falha).
+-- Corpo avaliado com comentários REMOVIDOS (lição #1472/#1488: assert sobre corpo
+-- cru casa prosa de comentário). Executada contra banco bom E sabotado no harness
+-- db/test-vendas_sync_semear_janela.sh (lição #1490/#1501: validador sem dente).
+SELECT CASE
+  WHEN to_regprocedure('public.vendas_sync_semear_janela(text,date,date)') IS NULL
+    THEN '❌ FALTANDO — migration nao aplicada'
+  WHEN NOT has_function_privilege('authenticated', 'public.vendas_sync_semear_janela(text,date,date)', 'EXECUTE')
+    THEN '❌ authenticated sem EXECUTE (GRANT nao pegou)'
+  WHEN has_function_privilege('anon', 'public.vendas_sync_semear_janela(text,date,date)', 'EXECUTE')
+    THEN '❌ anon com EXECUTE (REVOKE nao pegou)'
+  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(text,date,date)')), '--[^\n]*', '', 'g')
+       !~ 'IF v_uid IS NULL\s+OR NOT \(COALESCE\(public\.has_role\(v_uid, ''employee''::public\.app_role\), false\)'
+    THEN '❌ corpo sem o gate staff fail-closed'
+  WHEN regexp_replace(pg_get_functiondef(to_regprocedure('public.vendas_sync_semear_janela(text,date,date)')), '--[^\n]*', '', 'g')
+       !~ 'ON CONFLICT \(account, date_from, date_to\) DO NOTHING'
+    THEN '❌ corpo sem o ON CONFLICT DO NOTHING (risco de clobber)'
+  ELSE '✅ vendas_sync_semear_janela aplicada (gate staff + grants + DO NOTHING ok)'
+END AS status;

--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -282,3 +282,29 @@ remove (1a4272c7 "Changes"). Fix: restaurar o arquivo de bbd2c155 por PR (#1478)
 Lição (armadilha nova no CLAUDE.md): após merge que toca `supabase/functions/`, conferir
 `git log -S` do símbolo novo ANTES de pedir deploy — "verbatim da main" só vale se a main ainda
 for a sua.
+
+## Importar Pedidos vira semeadura server-side — a aba pode fechar (2026-07-21, [PR #1518](https://github.com/LucasSardenbergL/afiacao/pull/1518), migration `20260726130000` ⚠️ apply manual)
+
+Follow-up do incidente 2026-07-20/21 (pós #1500/#1502): o "Importar Recentes (180d)" de
+/admin/analytics-sync era um loop client-side de 40–60 min (~26–35 invocações da edge por
+conta) — o Chrome matou o JS ~12 min após o clique em 3 tentativas (aba em background/Memory
+Saver), deixando órfãos `executando` em `acoes_execucoes`; a importação só fechou semeando
+`vendas_sync_cursor` na mão. **Fix:** RPC `vendas_sync_semear_janela` (SECDEF, gate staff
+fail-closed espelhado de `request_customer_metrics_refresh`, validação 22023, `INSERT … ON
+CONFLICT DO NOTHING` — nunca toca janela existente) + hook trocando o loop por semeadura
+(mutação ~1s, registro fecha na hora → sem novos órfãos) + polling de leitura do cursor
+(estado por conta, "pode fechar a aba", botões travados com janela aberta) + copy honesta
+(o "~2 min" era mentira histórica). "Importar Todos" idem: 1 janela `2020-01-01→hoje` por
+conta (min real: colacor 2020-04-08, oben 2023-09-25; período vazio não custa páginas no
+Omie). Edge e cron INTOCADOS — o motor (lease/heartbeat/retomada, jobid 140) já existia
+desde `20260617133633`; faltava o caminho de escrita gateado pro staff armar a janela.
+**Prova:** `db/test-vendas_sync_semear_janela.sh` PG17 30/30 (caminho real `SET ROLE
+authenticated`+GUC; anon barrado na fronteira com sentinela do Postgres que meu código não
+emite; integração com o comando REAL do cron; F1 gate/F2 clobber/F3 grant — dentes
+confirmados) e — lição #1490/#1501 aplicada — o validador pós-apply
+(`db/valida-vendas-sync-semear-janela.sql`, lê catálogo, nunca invoca, comenta-strip)
+EXECUTADO contra banco bom (✅) e sabotado ×3 (❌). vitest 5546/5546, typecheck/lint/
+shellcheck 0, authz:check ok, wt:preflight 🟢. **LIÇÃO:** trabalho >10 min que depende de
+aba viva de browser é bug de arquitetura, não de timeout — se o motor server-side já existe
+(cursor+cron), o botão deve SEMEAR e a UI LER; o clique que "executa" vira o clique que
+"arma", e o registro de execução acompanha a semântica (cobre a semeadura, não o run).

--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -283,28 +283,44 @@ Lição (armadilha nova no CLAUDE.md): após merge que toca `supabase/functions/
 `git log -S` do símbolo novo ANTES de pedir deploy — "verbatim da main" só vale se a main ainda
 for a sua.
 
-## Importar Pedidos vira semeadura server-side — a aba pode fechar (2026-07-21, [PR #1518](https://github.com/LucasSardenbergL/afiacao/pull/1518), migration `20260726130000` ⚠️ apply manual)
+## Importar Pedidos vira semeadura server-side — a aba pode fechar (2026-07-21, [PR #1518](https://github.com/LucasSardenbergL/afiacao/pull/1518), migration `20260726140000` (v2) ⚠️ apply manual — a `20260726130000` (v1 por conta) foi superseded ANTES de qualquer apply e não deve ser colada)
 
 Follow-up do incidente 2026-07-20/21 (pós #1500/#1502): o "Importar Recentes (180d)" de
 /admin/analytics-sync era um loop client-side de 40–60 min (~26–35 invocações da edge por
 conta) — o Chrome matou o JS ~12 min após o clique em 3 tentativas (aba em background/Memory
 Saver), deixando órfãos `executando` em `acoes_execucoes`; a importação só fechou semeando
-`vendas_sync_cursor` na mão. **Fix:** RPC `vendas_sync_semear_janela` (SECDEF, gate staff
-fail-closed espelhado de `request_customer_metrics_refresh`, validação 22023, `INSERT … ON
-CONFLICT DO NOTHING` — nunca toca janela existente) + hook trocando o loop por semeadura
-(mutação ~1s, registro fecha na hora → sem novos órfãos) + polling de leitura do cursor
-(estado por conta, "pode fechar a aba", botões travados com janela aberta) + copy honesta
-(o "~2 min" era mentira histórica). "Importar Todos" idem: 1 janela `2020-01-01→hoje` por
-conta (min real: colacor 2020-04-08, oben 2023-09-25; período vazio não custa páginas no
-Omie). Edge e cron INTOCADOS — o motor (lease/heartbeat/retomada, jobid 140) já existia
-desde `20260617133633`; faltava o caminho de escrita gateado pro staff armar a janela.
-**Prova:** `db/test-vendas_sync_semear_janela.sh` PG17 30/30 (caminho real `SET ROLE
-authenticated`+GUC; anon barrado na fronteira com sentinela do Postgres que meu código não
-emite; integração com o comando REAL do cron; F1 gate/F2 clobber/F3 grant — dentes
-confirmados) e — lição #1490/#1501 aplicada — o validador pós-apply
-(`db/valida-vendas-sync-semear-janela.sql`, lê catálogo, nunca invoca, comenta-strip)
-EXECUTADO contra banco bom (✅) e sabotado ×3 (❌). vitest 5546/5546, typecheck/lint/
-shellcheck 0, authz:check ok, wt:preflight 🟢. **LIÇÃO:** trabalho >10 min que depende de
-aba viva de browser é bug de arquitetura, não de timeout — se o motor server-side já existe
-(cursor+cron), o botão deve SEMEAR e a UI LER; o clique que "executa" vira o clique que
-"arma", e o registro de execução acompanha a semântica (cobre a semeadura, não o run).
+`vendas_sync_cursor` na mão. **Fix (v2, endurecida pelo challenge Codex xhigh):** RPC
+`vendas_sync_semear_janela(p_date_from, p_date_to, p_accounts default {oben,colacor})` —
+SECDEF, gate staff fail-closed espelhado de `request_customer_metrics_refresh`, validação
+22023, **UMA chamada arma as DUAS contas na MESMA transação** (P1 do Codex: duas RPCs
+sequenciais deixavam janela parcial se a aba morresse entre elas — e com o botão travado
+pela janela aberta, a 2ª conta ficava inalcançável por 40+ min), `pg_advisory_xact_lock`
+por conta em ordem determinística (2 abas não intercalam), recusa honesta
+`ja_pendente_outra` quando a conta já tem OUTRA janela aberta (o cron trabalha a mais
+antiga primeiro — semear por cima só enfileira atrás), e `INSERT … ON CONFLICT DO NOTHING`
+— nunca toca janela existente. Hook troca o loop por semeadura (mutação ~1s, registro
+fecha na hora → sem novos órfãos) + polling de leitura do cursor com estado **falhando**
+quando `last_error_kind` está aberto (achado Codex: não fingir "aguardando" em falha
+persistente) + "pode fechar a aba" + copy honesta (o "~2 min" era mentira histórica).
+"Importar Todos": 1 janela `2015-01-01→hoje` por conta — 2015 é o próprio piso da RPC; o
+min de `sales_orders` (colacor 2020-04-08, oben 2023-09-25) não prova o min do OMIE (prova
+circular, achado Codex) e período vazio não custa páginas. Edge e cron INTOCADOS — o motor
+(lease/heartbeat/retomada, jobid 140) já existia desde `20260617133633`; faltava o caminho
+de escrita gateado. **Prova:** `db/test-vendas_sync_semear_janela.sh` PG17 **36/36**
+(caminho real `SET ROLE authenticated`+GUC; anon barrado na fronteira com sentinela do
+Postgres que meu código não emite; **atomicidade real** — conta inválida no par faz
+rollback do insert já feito; integração com o comando REAL do cron; falsificações F1
+gate/F2 clobber/F3 grant/F4 lock/F5 engolir-exceção, todas com dente) e — lição
+#1490/#1501 — o validador pós-apply (`db/valida-vendas-sync-semear-janela.sql`, lê
+catálogo, nunca invoca, comment-strip, checa a v1 dropada) EXECUTADO contra banco bom (✅)
+e sabotado ×4 (❌). vitest full verde, typecheck/lint/shellcheck 0, authz:check ok,
+wt:preflight 🟢. Do challenge ficaram 2 follow-ups de FUNDAÇÃO (fora deste PR; chips):
+lease sem fencing/owner token (worker vencido pode corromper o lease do sucessor) e
+`completed_at` fechando janela com `failed[]`>0 / falha permanente sem estado terminal.
+**LIÇÃO:** (a) trabalho >10 min que depende de aba viva de browser é bug de arquitetura,
+não de timeout — se o motor server-side já existe (cursor+cron), o botão deve SEMEAR e a
+UI LER; o clique que "executa" vira o clique que "arma" e o registro acompanha a
+semântica; (b) semeadura multi-conta tem de ser UMA transação — parcial + botão travado =
+conta presa; (c) migration committada é imutável MESMO nunca aplicada (hook bloqueia) —
+correção de desenho pré-apply vira migration v2 com DROP da assinatura antiga, e a v1
+morta fica documentada como "não colar".

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **421** custom migrations totais
-- **1479** objetos esperados (criados por estas migrations)
+- **422** custom migrations totais
+- **1480** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 425
+  - `function`: 426
   - `rls_policy`: 380
   - `index`: 224
   - `cron_job`: 150
@@ -3567,6 +3567,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.tint_promote_sync_run` | — |
 
 ### `20260726130000_vendas_sync_semear_janela.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.vendas_sync_semear_janela` | — |
+
+### `20260726140000_vendas_sync_semear_janela_v2.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **420** custom migrations totais
-- **1478** objetos esperados (criados por estas migrations)
+- **421** custom migrations totais
+- **1479** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 424
+  - `function`: 425
   - `rls_policy`: 380
   - `index`: 224
   - `cron_job`: 150
@@ -3565,6 +3565,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.tint_promote_sync_run` | — |
+
+### `20260726130000_vendas_sync_semear_janela.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.vendas_sync_semear_janela` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 420
+-- Total de custom migrations: 421
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -461,7 +461,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260724120000', 'authz_sales_orders_split_escrita_fu4', '20260724120000_authz_sales_orders_split_escrita_fu4.sql'),
   ('20260724130000', 'authz_custo_fu4f_fase3_recommend', '20260724130000_authz_custo_fu4f_fase3_recommend.sql'),
   ('20260724130000', 'tint_canonica_csv_legado_allowlist', '20260724130000_tint_canonica_csv_legado_allowlist.sql'),
-  ('20260726120000', 'tint_promote_error_details_completo', '20260726120000_tint_promote_error_details_completo.sql')
+  ('20260726120000', 'tint_promote_error_details_completo', '20260726120000_tint_promote_error_details_completo.sql'),
+  ('20260726130000', 'vendas_sync_semear_janela', '20260726130000_vendas_sync_semear_janela.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1928,7 +1929,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('authz_custo_fu4f_fase3_recommend', 'function', 'public', 'pode_ler_custo', ''),
   ('authz_custo_fu4f_fase3_recommend', 'rls_policy', 'public', 'recommendation_log_select_custo', 'recommendation_log'),
   ('tint_canonica_csv_legado_allowlist', 'view', 'public', 'v_tint_formula_canonica', ''),
-  ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', '')
+  ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
+  ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3443,7 +3445,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('authz_custo_fu4f_fase3_recommend', 'function', 'public', 'pode_ler_custo', ''),
   ('authz_custo_fu4f_fase3_recommend', 'rls_policy', 'public', 'recommendation_log_select_custo', 'recommendation_log'),
   ('tint_canonica_csv_legado_allowlist', 'view', 'public', 'v_tint_formula_canonica', ''),
-  ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', '')
+  ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
+  ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', '')
 )
 SELECT
   e.migration,

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 421
+-- Total de custom migrations: 422
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -462,7 +462,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260724130000', 'authz_custo_fu4f_fase3_recommend', '20260724130000_authz_custo_fu4f_fase3_recommend.sql'),
   ('20260724130000', 'tint_canonica_csv_legado_allowlist', '20260724130000_tint_canonica_csv_legado_allowlist.sql'),
   ('20260726120000', 'tint_promote_error_details_completo', '20260726120000_tint_promote_error_details_completo.sql'),
-  ('20260726130000', 'vendas_sync_semear_janela', '20260726130000_vendas_sync_semear_janela.sql')
+  ('20260726130000', 'vendas_sync_semear_janela', '20260726130000_vendas_sync_semear_janela.sql'),
+  ('20260726140000', 'vendas_sync_semear_janela_v2', '20260726140000_vendas_sync_semear_janela_v2.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1930,7 +1931,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('authz_custo_fu4f_fase3_recommend', 'rls_policy', 'public', 'recommendation_log_select_custo', 'recommendation_log'),
   ('tint_canonica_csv_legado_allowlist', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
-  ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', '')
+  ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', ''),
+  ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3446,7 +3448,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('authz_custo_fu4f_fase3_recommend', 'rls_policy', 'public', 'recommendation_log_select_custo', 'recommendation_log'),
   ('tint_canonica_csv_legado_allowlist', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
-  ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', '')
+  ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', ''),
+  ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', '')
 )
 SELECT
   e.migration,

--- a/src/components/analyticsSync/ImportCards.tsx
+++ b/src/components/analyticsSync/ImportCards.tsx
@@ -2,9 +2,10 @@
 // Extraídos verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, Loader2, Sparkles, ShoppingCart, Users, MapPin } from "lucide-react";
+import { RefreshCw, Loader2, Sparkles, ShoppingCart, Users, MapPin, CheckCircle2, Clock } from "lucide-react";
 import { UltimaExecucao } from "@/components/execucoes/UltimaExecucao";
 import { ACOES_ANALYTICS_SYNC } from "./acoes";
+import type { StatusJanelaConta } from "./janelas";
 
 export function ImportClientesCard({
   isRunning,
@@ -101,21 +102,31 @@ export function ImportEnderecosCard({
   );
 }
 
+const JANELA_ICON = {
+  rodando: <Loader2 className="h-3 w-3 animate-spin text-primary" />,
+  aguardando: <Clock className="h-3 w-3 text-muted-foreground" />,
+  concluida: <CheckCircle2 className="h-3 w-3 text-status-success" />,
+} as const;
+
 export function ImportPedidosCard({
   isRunning,
   recentPending,
   bulkPending,
-  progress,
+  importandoEmAndamento,
+  janelas,
   onImportRecent,
   onImportAll,
 }: {
   isRunning: boolean;
   recentPending: boolean;
   bulkPending: boolean;
-  progress: string | null;
+  /** Há janela aberta no vendas_sync_cursor — o servidor ainda está importando. */
+  importandoEmAndamento: boolean;
+  janelas: StatusJanelaConta[];
   onImportRecent: () => void;
   onImportAll: () => void;
 }) {
+  const desabilitado = isRunning || importandoEmAndamento;
   return (
     <Card>
       <CardHeader>
@@ -125,7 +136,7 @@ export function ImportPedidosCard({
             <CardTitle className="text-base">Importar Pedidos (Oben + Colacor)</CardTitle>
           </div>
           <div className="flex gap-2">
-            <Button variant="default" size="sm" disabled={isRunning} onClick={onImportRecent}>
+            <Button variant="default" size="sm" disabled={desabilitado} onClick={onImportRecent}>
               {recentPending ? (
                 <Loader2 className="h-3 w-3 mr-2 animate-spin" />
               ) : (
@@ -133,7 +144,7 @@ export function ImportPedidosCard({
               )}
               Importar Recentes (180d)
             </Button>
-            <Button variant="outline" size="sm" disabled={isRunning} onClick={onImportAll}>
+            <Button variant="outline" size="sm" disabled={desabilitado} onClick={onImportAll}>
               {bulkPending ? (
                 <Loader2 className="h-3 w-3 mr-2 animate-spin" />
               ) : (
@@ -149,14 +160,29 @@ export function ImportPedidosCard({
       </CardHeader>
       <CardContent>
         <p className="text-xs text-muted-foreground">
-          <strong>Importar Recentes:</strong> busca apenas pedidos dos últimos 180 dias (rápido, ~2 min).
+          O clique <strong>arma a janela</strong> no servidor (cursor + cron a cada 6 min) e a importação roda em
+          segundo plano — <strong>pode fechar a aba</strong> e acompanhar o progresso aqui.
           <br />
-          <strong>Importar Todos:</strong> varre todo o histórico (~425 páginas, pode levar 30+ min).
+          <strong>Importar Recentes:</strong> últimos 180 dias (~40–60 min no servidor).
+          <br />
+          <strong>Importar Todos:</strong> histórico completo desde 2020 (algumas horas no servidor).
         </p>
-        {progress && (
-          <div className="mt-3 flex items-center gap-2 text-xs text-primary font-medium">
-            <Loader2 className="h-3 w-3 animate-spin" />
-            {progress}
+        {janelas.length > 0 && (
+          <div className="mt-3 space-y-1.5">
+            {importandoEmAndamento && (
+              <div className="flex items-center gap-2 text-xs text-primary font-medium">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Importando no servidor — pode fechar esta aba.
+              </div>
+            )}
+            {janelas.map((j) => (
+              <div key={`${j.account}-${j.janela}`} className="flex items-center gap-2 text-xs text-muted-foreground">
+                {JANELA_ICON[j.estado]}
+                <span className="font-medium text-foreground">{j.account}</span>
+                <span>{j.janela}</span>
+                <span>— {j.descricao}</span>
+              </div>
+            ))}
           </div>
         )}
       </CardContent>

--- a/src/components/analyticsSync/ImportCards.tsx
+++ b/src/components/analyticsSync/ImportCards.tsx
@@ -2,7 +2,7 @@
 // Extraídos verbatim de src/pages/AdminAnalyticsSync.tsx (god-component split).
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, Loader2, Sparkles, ShoppingCart, Users, MapPin, CheckCircle2, Clock } from "lucide-react";
+import { RefreshCw, Loader2, Sparkles, ShoppingCart, Users, MapPin, CheckCircle2, Clock, AlertTriangle } from "lucide-react";
 import { UltimaExecucao } from "@/components/execucoes/UltimaExecucao";
 import { ACOES_ANALYTICS_SYNC } from "./acoes";
 import type { StatusJanelaConta } from "./janelas";
@@ -105,6 +105,7 @@ export function ImportEnderecosCard({
 const JANELA_ICON = {
   rodando: <Loader2 className="h-3 w-3 animate-spin text-primary" />,
   aguardando: <Clock className="h-3 w-3 text-muted-foreground" />,
+  falhando: <AlertTriangle className="h-3 w-3 text-status-warning" />,
   concluida: <CheckCircle2 className="h-3 w-3 text-status-success" />,
 } as const;
 
@@ -165,7 +166,7 @@ export function ImportPedidosCard({
           <br />
           <strong>Importar Recentes:</strong> últimos 180 dias (~40–60 min no servidor).
           <br />
-          <strong>Importar Todos:</strong> histórico completo desde 2020 (algumas horas no servidor).
+          <strong>Importar Todos:</strong> histórico completo desde 2015 (algumas horas no servidor).
         </p>
         {janelas.length > 0 && (
           <div className="mt-3 space-y-1.5">

--- a/src/components/analyticsSync/__tests__/ImportCards.test.tsx
+++ b/src/components/analyticsSync/__tests__/ImportCards.test.tsx
@@ -34,19 +34,20 @@ describe("ImportEnderecosCard", () => {
 });
 
 describe("ImportPedidosCard", () => {
+  const base = {
+    isRunning: false,
+    recentPending: false,
+    bulkPending: false,
+    importandoEmAndamento: false,
+    janelas: [],
+    onImportRecent: () => {},
+    onImportAll: () => {},
+  };
+
   it("dispara onImportRecent e onImportAll separadamente", () => {
     const onImportRecent = vi.fn();
     const onImportAll = vi.fn();
-    render(
-      <ImportPedidosCard
-        isRunning={false}
-        recentPending={false}
-        bulkPending={false}
-        progress={null}
-        onImportRecent={onImportRecent}
-        onImportAll={onImportAll}
-      />,
-    );
+    render(<ImportPedidosCard {...base} onImportRecent={onImportRecent} onImportAll={onImportAll} />);
     fireEvent.click(screen.getByRole("button", { name: /Importar Recentes/ }));
     fireEvent.click(screen.getByRole("button", { name: /Importar Todos/ }));
     expect(onImportRecent).toHaveBeenCalledTimes(1);
@@ -54,17 +55,38 @@ describe("ImportPedidosCard", () => {
   });
 
   it("desabilita os botões quando isRunning", () => {
-    render(
-      <ImportPedidosCard
-        isRunning
-        recentPending={false}
-        bulkPending={false}
-        progress={null}
-        onImportRecent={() => {}}
-        onImportAll={() => {}}
-      />,
-    );
+    render(<ImportPedidosCard {...base} isRunning />);
     expect(screen.getByRole("button", { name: /Importar Recentes/ })).toHaveProperty("disabled", true);
     expect(screen.getByRole("button", { name: /Importar Todos/ })).toHaveProperty("disabled", true);
+  });
+
+  it("desabilita os botões enquanto o servidor importa (janela aberta)", () => {
+    render(<ImportPedidosCard {...base} importandoEmAndamento />);
+    expect(screen.getByRole("button", { name: /Importar Recentes/ })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: /Importar Todos/ })).toHaveProperty("disabled", true);
+  });
+
+  it("copy honesta: descreve o segundo plano no servidor, sem o '~2 min' histórico", () => {
+    render(<ImportPedidosCard {...base} />);
+    expect(screen.getByText(/pode fechar a aba/)).toBeTruthy();
+    expect(screen.getByText(/~40–60 min no servidor/)).toBeTruthy();
+    expect(screen.queryByText(/~2 min/)).toBeNull();
+  });
+
+  it("mostra as janelas do cursor e o aviso de importação em segundo plano", () => {
+    render(
+      <ImportPedidosCard
+        {...base}
+        importandoEmAndamento
+        janelas={[
+          { account: "oben", janela: "22/01/2026 → 21/07/2026", estado: "rodando", descricao: "importando — página 12" },
+          { account: "colacor", janela: "22/01/2026 → 21/07/2026", estado: "concluida", descricao: "concluída 21/07/2026 14:32" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Importando no servidor — pode fechar esta aba.")).toBeTruthy();
+    expect(screen.getByText("oben")).toBeTruthy();
+    expect(screen.getByText(/importando — página 12/)).toBeTruthy();
+    expect(screen.getByText(/concluída 21\/07\/2026 14:32/)).toBeTruthy();
   });
 });

--- a/src/components/analyticsSync/__tests__/janelas.test.ts
+++ b/src/components/analyticsSync/__tests__/janelas.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import {
+  EPOCA_IMPORTAR_TODOS,
+  haJanelaAberta,
+  isoDataLocal,
+  janelaRecentes,
+  janelaTodos,
+  janelasRelevantes,
+  rotuloSemeadura,
+  statusJanelas,
+  type JanelaCursorRow,
+} from "../janelas";
+
+const linha = (extra: Partial<JanelaCursorRow>): JanelaCursorRow => ({
+  account: "oben",
+  date_from: "2026-01-22",
+  date_to: "2026-07-21",
+  next_page: null,
+  completed_at: null,
+  running_since: null,
+  heartbeat_at: null,
+  updated_at: "2026-07-21T12:00:00Z",
+  ...extra,
+});
+
+describe("isoDataLocal", () => {
+  it("formata a data LOCAL como YYYY-MM-DD com padding", () => {
+    expect(isoDataLocal(new Date(2026, 6, 21))).toBe("2026-07-21");
+    expect(isoDataLocal(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+
+  it("usa os componentes locais mesmo à noite (não o dia UTC seguinte)", () => {
+    // 23:30 local: toISOString() viraria o dia seguinte em qualquer fuso a oeste de UTC.
+    expect(isoDataLocal(new Date(2026, 6, 21, 23, 30))).toBe("2026-07-21");
+  });
+});
+
+describe("janelaRecentes", () => {
+  it("cobre exatamente os últimos 180 dias", () => {
+    expect(janelaRecentes(new Date(2026, 6, 21))).toEqual({ de: "2026-01-22", ate: "2026-07-21" });
+  });
+
+  it("atravessa a virada de ano", () => {
+    expect(janelaRecentes(new Date(2026, 1, 1))).toEqual({ de: "2025-08-05", ate: "2026-02-01" });
+  });
+});
+
+describe("janelaTodos", () => {
+  it("parte da época fixa (min real: colacor 2020-04-08, oben 2023-09-25) até hoje", () => {
+    expect(janelaTodos(new Date(2026, 6, 21))).toEqual({ de: EPOCA_IMPORTAR_TODOS, ate: "2026-07-21" });
+    expect(EPOCA_IMPORTAR_TODOS < "2020-04-08").toBe(true);
+  });
+});
+
+describe("statusJanelas", () => {
+  const agora = new Date("2026-07-21T12:00:00Z");
+
+  it("janela com lease e heartbeat fresco (<3 min) está rodando, com a página em curso", () => {
+    const [s] = statusJanelas(
+      [linha({ running_since: "2026-07-21T11:50:00Z", heartbeat_at: "2026-07-21T11:59:00Z", next_page: 12 })],
+      agora,
+    );
+    expect(s.estado).toBe("rodando");
+    expect(s.descricao).toContain("página 12");
+  });
+
+  it("janela sem lease vivo aguarda o próximo ciclo do motor", () => {
+    const [s] = statusJanelas(
+      [linha({ running_since: "2026-07-21T11:00:00Z", heartbeat_at: "2026-07-21T11:05:00Z", next_page: 4 })],
+      agora,
+    );
+    expect(s.estado).toBe("aguardando");
+    expect(s.descricao).toContain("página 4");
+  });
+
+  it("janela recém-semeada (tudo nulo) aguarda na página 1", () => {
+    const [s] = statusJanelas([linha({})], agora);
+    expect(s.estado).toBe("aguardando");
+    expect(s.descricao).toContain("página 1");
+  });
+
+  it("janela completa reporta concluída e a janela em pt-BR", () => {
+    const [s] = statusJanelas([linha({ completed_at: "2026-07-21T11:30:00Z" })], agora);
+    expect(s.estado).toBe("concluida");
+    expect(s.janela).toBe("22/01/2026 → 21/07/2026");
+  });
+});
+
+describe("janelasRelevantes + haJanelaAberta", () => {
+  const agora = new Date("2026-07-21T12:00:00Z");
+
+  it("mantém abertas e concluídas há pouco; descarta concluídas antigas", () => {
+    const aberta = linha({});
+    const recemConcluida = linha({ account: "colacor", completed_at: "2026-07-21T11:50:00Z" });
+    const antiga = linha({ account: "colacor", date_from: "2020-01-01", completed_at: "2026-06-24T08:00:00Z" });
+    expect(janelasRelevantes([aberta, recemConcluida, antiga], agora)).toEqual([aberta, recemConcluida]);
+  });
+
+  it("haJanelaAberta detecta pendência (e vazio = false)", () => {
+    expect(haJanelaAberta([linha({})])).toBe(true);
+    expect(haJanelaAberta([linha({ completed_at: "2026-07-21T11:50:00Z" })])).toBe(false);
+    expect(haJanelaAberta([])).toBe(false);
+  });
+});
+
+describe("rotuloSemeadura", () => {
+  it("traduz o desfecho da RPC pra toast", () => {
+    expect(rotuloSemeadura("semeada")).toBe("armada");
+    expect(rotuloSemeadura("ja_pendente")).toBe("já estava armada");
+    expect(rotuloSemeadura("ja_concluida")).toBe("já concluída nesta janela");
+    expect(rotuloSemeadura(undefined)).toBe("—");
+  });
+});

--- a/src/components/analyticsSync/__tests__/janelas.test.ts
+++ b/src/components/analyticsSync/__tests__/janelas.test.ts
@@ -17,6 +17,7 @@ const linha = (extra: Partial<JanelaCursorRow>): JanelaCursorRow => ({
   date_to: "2026-07-21",
   next_page: null,
   completed_at: null,
+  last_error_kind: null,
   running_since: null,
   heartbeat_at: null,
   updated_at: "2026-07-21T12:00:00Z",
@@ -84,6 +85,24 @@ describe("statusJanelas", () => {
     expect(s.estado).toBe("concluida");
     expect(s.janela).toBe("22/01/2026 → 21/07/2026");
   });
+
+  it("janela aberta com last_error_kind expõe a falha (não finge 'aguardando')", () => {
+    const [s] = statusJanelas(
+      [linha({ last_error_kind: "http", next_page: 9, heartbeat_at: "2026-07-21T11:00:00Z" })],
+      agora,
+    );
+    expect(s.estado).toBe("falhando");
+    expect(s.descricao).toContain("falhou (http)");
+    expect(s.descricao).toContain("página 9");
+  });
+
+  it("lease vivo tem precedência sobre falha anterior (está re-tentando agora)", () => {
+    const [s] = statusJanelas(
+      [linha({ last_error_kind: "rate_limit", running_since: "2026-07-21T11:58:00Z", heartbeat_at: "2026-07-21T11:59:30Z", next_page: 9 })],
+      agora,
+    );
+    expect(s.estado).toBe("rodando");
+  });
 });
 
 describe("janelasRelevantes + haJanelaAberta", () => {
@@ -108,6 +127,7 @@ describe("rotuloSemeadura", () => {
     expect(rotuloSemeadura("semeada")).toBe("armada");
     expect(rotuloSemeadura("ja_pendente")).toBe("já estava armada");
     expect(rotuloSemeadura("ja_concluida")).toBe("já concluída nesta janela");
+    expect(rotuloSemeadura("ja_pendente_outra")).toBe("outra importação em andamento");
     expect(rotuloSemeadura(undefined)).toBe("—");
   });
 });

--- a/src/components/analyticsSync/acoes.ts
+++ b/src/components/analyticsSync/acoes.ts
@@ -1,6 +1,9 @@
 // Slugs de acoes_execucoes desta página. Os de motor/sync_completo são GRAVADOS pela edge
-// omie-analytics-sync (manual+cron) — o frontend só LÊ; os de importação (loops client-side)
-// são gravados pelo useMutationComRegistro. Um escritor por slug (CLAUDE.md §Design System).
+// omie-analytics-sync (manual+cron) — o frontend só LÊ; os de importação são gravados pelo
+// useMutationComRegistro. Um escritor por slug (CLAUDE.md §Design System).
+// importar_pedidos_*: desde o refactor pós-incidente 2026-07-21, o registro cobre só a
+// SEMEADURA da janela (mutação curta) — a importação em si roda no servidor
+// (vendas_sync_cursor + cron) e o progresso é lido do cursor, não daqui.
 export const ACOES_ANALYTICS_SYNC = {
   importarClientes: "analytics_sync.importar_clientes",
   sincronizarEnderecos: "analytics_sync.sincronizar_enderecos",

--- a/src/components/analyticsSync/janelas.ts
+++ b/src/components/analyticsSync/janelas.ts
@@ -7,8 +7,14 @@
 export const CONTAS_PEDIDOS = ["oben", "colacor"] as const;
 export type ContaPedidos = (typeof CONTAS_PEDIDOS)[number];
 
-/** Época do "Importar Todos" — cobre o histórico real (min em prod: colacor 2020-04-08, oben 2023-09-25). */
-export const EPOCA_IMPORTAR_TODOS = "2020-01-01";
+/**
+ * Época do "Importar Todos" = o próprio piso da RPC (p_date_from >= 2015-01-01).
+ * O min de sales_orders (colacor 2020-04-08, oben 2023-09-25) não prova o min do OMIE
+ * (a tabela nasceu de backfills — prova circular, apontado pelo Codex); 2015 dá margem
+ * e período vazio não custa páginas (o filtro de data só inclui). Pedido anterior a
+ * 2015 no Omie exigiria mudar o piso da RPC junto.
+ */
+export const EPOCA_IMPORTAR_TODOS = "2015-01-01";
 
 /** Data LOCAL como YYYY-MM-DD. Não usar toISOString(): à noite no BRT ela vira o dia UTC seguinte. */
 export function isoDataLocal(d: Date): string {
@@ -40,6 +46,7 @@ export interface JanelaCursorRow {
   date_to: string;
   next_page: number | null;
   completed_at: string | null;
+  last_error_kind: string | null;
   running_since: string | null;
   heartbeat_at: string | null;
   updated_at: string;
@@ -48,7 +55,7 @@ export interface JanelaCursorRow {
 export interface StatusJanelaConta {
   account: string;
   janela: string;
-  estado: "rodando" | "aguardando" | "concluida";
+  estado: "rodando" | "aguardando" | "falhando" | "concluida";
   descricao: string;
 }
 
@@ -76,6 +83,16 @@ export function statusJanelas(rows: JanelaCursorRow[], agora: Date = new Date())
     if (r.running_since && heartbeatVivo) {
       return { account: r.account, janela, estado: "rodando" as const, descricao: `importando — página ${pagina}` };
     }
+    // Honestidade sobre falha persistente (achado Codex): last_error_kind aberto não é
+    // "aguardando" normal — o motor re-tenta a cada 6 min, mas o usuário precisa VER a falha.
+    if (r.last_error_kind) {
+      return {
+        account: r.account,
+        janela,
+        estado: "falhando" as const,
+        descricao: `página ${pagina} — última tentativa falhou (${r.last_error_kind}); o motor re-tenta a cada 6 min`,
+      };
+    }
     return {
       account: r.account,
       janela,
@@ -97,7 +114,7 @@ export function haJanelaAberta(rows: JanelaCursorRow[]): boolean {
 }
 
 /** Desfecho por conta da RPC de semeadura (ver semearJanelaNasContas no useAnalyticsSync). */
-export type DesfechoSemeadura = "semeada" | "ja_pendente" | "ja_concluida";
+export type DesfechoSemeadura = "semeada" | "ja_pendente" | "ja_concluida" | "ja_pendente_outra";
 
 export function rotuloSemeadura(desfecho: DesfechoSemeadura | undefined): string {
   switch (desfecho) {
@@ -107,6 +124,8 @@ export function rotuloSemeadura(desfecho: DesfechoSemeadura | undefined): string
       return "já estava armada";
     case "ja_concluida":
       return "já concluída nesta janela";
+    case "ja_pendente_outra":
+      return "outra importação em andamento";
     default:
       return "—";
   }

--- a/src/components/analyticsSync/janelas.ts
+++ b/src/components/analyticsSync/janelas.ts
@@ -1,0 +1,113 @@
+// Helpers PUROS da importação de pedidos via cursor server-side (vendas_sync_cursor).
+// O clique arma a janela pela RPC vendas_sync_semear_janela; o cron
+// vendas-sync-continuacao-6min + edge omie-vendas-sync importam no servidor
+// (lease + heartbeat + retomada) — a aba pode fechar. Provado em
+// db/test-vendas_sync_semear_janela.sh (PG17 + falsificação).
+
+export const CONTAS_PEDIDOS = ["oben", "colacor"] as const;
+export type ContaPedidos = (typeof CONTAS_PEDIDOS)[number];
+
+/** Época do "Importar Todos" — cobre o histórico real (min em prod: colacor 2020-04-08, oben 2023-09-25). */
+export const EPOCA_IMPORTAR_TODOS = "2020-01-01";
+
+/** Data LOCAL como YYYY-MM-DD. Não usar toISOString(): à noite no BRT ela vira o dia UTC seguinte. */
+export function isoDataLocal(d: Date): string {
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export interface JanelaImportacao {
+  de: string;
+  ate: string;
+}
+
+export function janelaRecentes(hoje: Date = new Date()): JanelaImportacao {
+  const de = new Date(hoje);
+  de.setDate(de.getDate() - 180);
+  return { de: isoDataLocal(de), ate: isoDataLocal(hoje) };
+}
+
+export function janelaTodos(hoje: Date = new Date()): JanelaImportacao {
+  return { de: EPOCA_IMPORTAR_TODOS, ate: isoDataLocal(hoje) };
+}
+
+/** Linha de vendas_sync_cursor que o polling lê (staff tem SELECT via RLS). */
+export interface JanelaCursorRow {
+  account: string;
+  date_from: string;
+  date_to: string;
+  next_page: number | null;
+  completed_at: string | null;
+  running_since: string | null;
+  heartbeat_at: string | null;
+  updated_at: string;
+}
+
+export interface StatusJanelaConta {
+  account: string;
+  janela: string;
+  estado: "rodando" | "aguardando" | "concluida";
+  descricao: string;
+}
+
+/** Mesmo limiar de lease-morto do vendas_sync_lease_acquire (heartbeat > 3 min = livre). */
+const LEASE_MORTO_MS = 3 * 60_000;
+
+/** Concluída há mais que isto sai do card (feedback de fim sem ressuscitar o histórico). */
+const CONCLUIDA_VISIVEL_MS = 30 * 60_000;
+
+function fmtDataBR(iso: string): string {
+  const [y, m, d] = iso.split("-");
+  return `${d}/${m}/${y}`;
+}
+
+export function statusJanelas(rows: JanelaCursorRow[], agora: Date = new Date()): StatusJanelaConta[] {
+  return rows.map((r) => {
+    const janela = `${fmtDataBR(r.date_from)} → ${fmtDataBR(r.date_to)}`;
+    if (r.completed_at) {
+      const quando = new Date(r.completed_at).toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+      return { account: r.account, janela, estado: "concluida" as const, descricao: `concluída ${quando}` };
+    }
+    const heartbeatVivo =
+      r.heartbeat_at !== null && agora.getTime() - new Date(r.heartbeat_at).getTime() < LEASE_MORTO_MS;
+    const pagina = r.next_page ?? 1;
+    if (r.running_since && heartbeatVivo) {
+      return { account: r.account, janela, estado: "rodando" as const, descricao: `importando — página ${pagina}` };
+    }
+    return {
+      account: r.account,
+      janela,
+      estado: "aguardando" as const,
+      descricao: `página ${pagina} — aguardando o motor (ciclo a cada 6 min)`,
+    };
+  });
+}
+
+/** Janelas que o card mostra: todas as ABERTAS + concluídas há menos de 30 min. */
+export function janelasRelevantes(rows: JanelaCursorRow[], agora: Date = new Date()): JanelaCursorRow[] {
+  return rows.filter(
+    (r) => r.completed_at === null || agora.getTime() - new Date(r.completed_at).getTime() < CONCLUIDA_VISIVEL_MS,
+  );
+}
+
+export function haJanelaAberta(rows: JanelaCursorRow[]): boolean {
+  return rows.some((r) => r.completed_at === null);
+}
+
+/** Desfecho por conta da RPC de semeadura (ver semearJanelaNasContas no useAnalyticsSync). */
+export type DesfechoSemeadura = "semeada" | "ja_pendente" | "ja_concluida";
+
+export function rotuloSemeadura(desfecho: DesfechoSemeadura | undefined): string {
+  switch (desfecho) {
+    case "semeada":
+      return "armada";
+    case "ja_pendente":
+      return "já estava armada";
+    case "ja_concluida":
+      return "já concluída nesta janela";
+    default:
+      return "—";
+  }
+}

--- a/src/components/analyticsSync/useAnalyticsSync.ts
+++ b/src/components/analyticsSync/useAnalyticsSync.ts
@@ -9,6 +9,21 @@ import { useMutationComRegistro } from "@/components/execucoes/useMutationComReg
 import { ULTIMA_EXECUCAO_QUERY_KEY } from "@/components/execucoes/tipos";
 import { OmieAccount, SyncState } from "./types";
 import { ACOES_ANALYTICS_SYNC } from "./acoes";
+import {
+  CONTAS_PEDIDOS,
+  haJanelaAberta,
+  janelaRecentes,
+  janelaTodos,
+  janelasRelevantes,
+  rotuloSemeadura,
+  statusJanelas,
+  type ContaPedidos,
+  type DesfechoSemeadura,
+  type JanelaCursorRow,
+  type JanelaImportacao,
+} from "./janelas";
+
+const JANELAS_CURSOR_QUERY_KEY = "vendas-sync-cursor-janelas";
 
 export type RecConfigs = ReturnType<typeof useAnalyticsSync>["recConfigs"];
 
@@ -233,111 +248,81 @@ export function useAnalyticsSync() {
 
   const [editingConfig, setEditingConfig] = useState<Record<string, string>>({});
   const [addressSyncProgress, setAddressSyncProgress] = useState<string | null>(null);
-  const [ordersSyncProgress, setOrdersSyncProgress] = useState<string | null>(null);
 
-  // Helper to format date as DD/MM/YYYY
-  const formatOmieDate = (date: Date) => {
-    const dd = String(date.getDate()).padStart(2, '0');
-    const mm = String(date.getMonth() + 1).padStart(2, '0');
-    const yyyy = date.getFullYear();
-    return `${dd}/${mm}/${yyyy}`;
-  };
-
-  const runOrdersSync = async (dateFrom?: string, dateTo?: string) => {
-    const accounts: Array<{ name: string; account: string }> = [
-      { name: "Oben", account: "oben" },
-      { name: "Colacor", account: "colacor" },
-    ];
-    let grandTotalSynced = 0;
-    let grandTotalItems = 0;
-    let grandTotalSkipped = 0;
-
-    for (const acc of accounts) {
-      let startPage = 1;
-      let complete = false;
-
-      while (!complete) {
-        setOrdersSyncProgress(`${acc.name}: página ${startPage}...`);
-        const { data, error } = await supabase.functions.invoke("omie-vendas-sync", {
-          body: {
-            action: "sync_pedidos",
-            account: acc.account,
-            start_page: startPage,
-            // 2 págs/invocação ≈ 75–110s diurno (medido no cron: 35–50s/pág) — cabe no
-            // request timeout (~150s) da edge. Com 10, janela de 180d (~70 págs oben)
-            // estourava o limite na 1ª invocação e o loop abortava (incidente 20/07/2026:
-            // não-2xx no browser + órfã running fechada pelo watchdog). O loop já retoma
-            // via nextPage, então só muda o tamanho do lote, não a cobertura.
-            max_pages: 2,
-            ...(dateFrom && { date_from: dateFrom }),
-            ...(dateTo && { date_to: dateTo }),
-          },
-        });
-        if (error) throw new Error(`${acc.name}: ${error.message}`);
-
-        grandTotalSynced += data?.totalSynced || 0;
-        grandTotalItems += data?.totalItems || 0;
-        grandTotalSkipped += data?.skippedNoClient || 0;
-
-        const lastPage = data?.lastPage || startPage;
-        const totalPages = data?.totalPaginas || 1;
-        setOrdersSyncProgress(`${acc.name}: pág ${lastPage}/${totalPages} — ${grandTotalSynced} pedidos importados`);
-
-        if (data?.complete || !data?.nextPage) {
-          complete = true;
-        } else {
-          startPage = data.nextPage;
-        }
-      }
+  // Importação de pedidos = SEMEADURA server-side (refactor do incidente 2026-07-20/21):
+  // o loop client-side de 40-60 min morria quando o Chrome suspendia a aba (Memory Saver),
+  // deixando órfãos 'executando'. Agora o clique só ARMA a janela no vendas_sync_cursor
+  // (RPC staff-gated, ON CONFLICT DO NOTHING — provada em db/test-vendas_sync_semear_janela.sh)
+  // e o cron vendas-sync-continuacao-6min + edge omie-vendas-sync importam no servidor
+  // (lease + heartbeat por página + retomada). A aba pode fechar; o progresso é LEITURA.
+  const semearJanelaNasContas = async (janela: JanelaImportacao) => {
+    const resultado = {} as Record<ContaPedidos, DesfechoSemeadura>;
+    for (const account of CONTAS_PEDIDOS) {
+      const { data, error } = await supabase.rpc("vendas_sync_semear_janela", {
+        p_account: account,
+        p_date_from: janela.de,
+        p_date_to: janela.ate,
+      });
+      if (error) throw new Error(`${account}: ${error.message}`);
+      const r = data as { semeada?: boolean; completed_at?: string | null } | null;
+      resultado[account] = r?.semeada ? "semeada" : r?.completed_at ? "ja_concluida" : "ja_pendente";
     }
-
-    // Refresh materialized view after import. Via o WRAPPER staff request_customer_metrics_refresh:
-    // o primitive refresh_customer_metrics passou a ser service-only (cron/edge). supabase-js NÃO
-    // lança → checar o erro (antes era engolido). O cron a cada 6h cobre o frescor de base.
-    setOrdersSyncProgress("Atualizando métricas de clientes...");
-    const { error: refreshError } = await supabase.rpc("request_customer_metrics_refresh");
-    if (refreshError) throw new Error(`Falha ao atualizar métricas de clientes: ${refreshError.message}`);
-
-    setOrdersSyncProgress(null);
-    return { grandTotalSynced, grandTotalItems, grandTotalSkipped };
+    return { janela, resultado };
   };
+
+  // Progresso da importação em segundo plano: polling do cursor enquanto houver janela aberta.
+  // A MV customer_metrics NÃO é atualizada aqui (a aba pode nem existir no fim) — o cron de
+  // refresh a cada 6h cobre, como já cobre as importações dos crons de 2h.
+  const { data: janelasCursor } = useQuery({
+    queryKey: [JANELAS_CURSOR_QUERY_KEY],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("vendas_sync_cursor")
+        .select("*")
+        .order("updated_at", { ascending: false })
+        .limit(12);
+      if (error) throw error;
+      return data as JanelaCursorRow[];
+    },
+    refetchInterval: (query) => (haJanelaAberta(query.state.data ?? []) ? 8000 : false),
+  });
+
+  const janelasImportacao = statusJanelas(janelasRelevantes(janelasCursor ?? []));
+  const importacaoEmAndamento = haJanelaAberta(janelasCursor ?? []);
+
+  const descricaoSemeadura = (resultado: Record<ContaPedidos, DesfechoSemeadura>) =>
+    `oben: ${rotuloSemeadura(resultado.oben)} · colacor: ${rotuloSemeadura(resultado.colacor)}. ` +
+    `Roda no servidor — pode fechar a aba e acompanhar aqui.`;
 
   const bulkOrdersSyncMutation = useMutationComRegistro({
     acao: ACOES_ANALYTICS_SYNC.importarPedidosTodos,
-    detalhes: (d) => ({ pedidos: d.grandTotalSynced, itens: d.grandTotalItems, sem_cliente: d.grandTotalSkipped }),
-    mutationFn: () => runOrdersSync(),
-    onSuccess: (data) => {
-      toast.success("Importação de pedidos concluída", {
-        description: `${data.grandTotalSynced} pedidos, ${data.grandTotalItems} itens, ${data.grandTotalSkipped} sem cliente`,
+    detalhes: (d) => ({ modo: "semeadura_cursor", janela_de: d.janela.de, janela_ate: d.janela.ate, ...d.resultado }),
+    mutationFn: () => semearJanelaNasContas(janelaTodos()),
+    onSuccess: (d) => {
+      toast.success("Histórico completo armado no servidor", {
+        description: descricaoSemeadura(d.resultado),
         duration: 10000,
       });
-      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
+      queryClient.invalidateQueries({ queryKey: [JANELAS_CURSOR_QUERY_KEY] });
     },
     onError: (error) => {
-      setOrdersSyncProgress(null);
-      toast.error("Erro na importação de pedidos", { description: String(error) });
+      toast.error("Erro ao armar a importação de pedidos", { description: String(error) });
     },
   });
 
   const recentOrdersSyncMutation = useMutationComRegistro({
     acao: ACOES_ANALYTICS_SYNC.importarPedidosRecentes,
-    detalhes: (d) => ({ pedidos: d.grandTotalSynced, itens: d.grandTotalItems }),
-    mutationFn: () => {
-      const now = new Date();
-      const from = new Date(now);
-      from.setDate(from.getDate() - 180);
-      return runOrdersSync(formatOmieDate(from), formatOmieDate(now));
-    },
-    onSuccess: (data) => {
-      toast.success("Importação recente concluída", {
-        description: `${data.grandTotalSynced} pedidos, ${data.grandTotalItems} itens`,
+    detalhes: (d) => ({ modo: "semeadura_cursor", janela_de: d.janela.de, janela_ate: d.janela.ate, ...d.resultado }),
+    mutationFn: () => semearJanelaNasContas(janelaRecentes()),
+    onSuccess: (d) => {
+      toast.success("Janela de 180 dias armada no servidor", {
+        description: descricaoSemeadura(d.resultado),
         duration: 10000,
       });
-      queryClient.invalidateQueries({ queryKey: ["sync-state"] });
+      queryClient.invalidateQueries({ queryKey: [JANELAS_CURSOR_QUERY_KEY] });
     },
     onError: (error) => {
-      setOrdersSyncProgress(null);
-      toast.error("Erro na importação recente", { description: String(error) });
+      toast.error("Erro ao armar a importação recente", { description: String(error) });
     },
   });
 
@@ -375,7 +360,8 @@ export function useAnalyticsSync() {
     recentOrdersSyncMutation,
     clientSyncProgress,
     addressSyncProgress,
-    ordersSyncProgress,
+    janelasImportacao,
+    importacaoEmAndamento,
     editingConfig,
     setEditingConfig,
     getStateFor,

--- a/src/components/analyticsSync/useAnalyticsSync.ts
+++ b/src/components/analyticsSync/useAnalyticsSync.ts
@@ -251,21 +251,21 @@ export function useAnalyticsSync() {
 
   // Importação de pedidos = SEMEADURA server-side (refactor do incidente 2026-07-20/21):
   // o loop client-side de 40-60 min morria quando o Chrome suspendia a aba (Memory Saver),
-  // deixando órfãos 'executando'. Agora o clique só ARMA a janela no vendas_sync_cursor
-  // (RPC staff-gated, ON CONFLICT DO NOTHING — provada em db/test-vendas_sync_semear_janela.sh)
+  // deixando órfãos 'executando'. Agora o clique ARMA as DUAS contas numa ÚNICA chamada
+  // ATÔMICA (RPC staff-gated, ON CONFLICT DO NOTHING, advisory lock por conta — provada em
+  // db/test-vendas_sync_semear_janela.sh; uma chamada = sem janela parcial se a aba morrer)
   // e o cron vendas-sync-continuacao-6min + edge omie-vendas-sync importam no servidor
   // (lease + heartbeat por página + retomada). A aba pode fechar; o progresso é LEITURA.
   const semearJanelaNasContas = async (janela: JanelaImportacao) => {
-    const resultado = {} as Record<ContaPedidos, DesfechoSemeadura>;
-    for (const account of CONTAS_PEDIDOS) {
-      const { data, error } = await supabase.rpc("vendas_sync_semear_janela", {
-        p_account: account,
-        p_date_from: janela.de,
-        p_date_to: janela.ate,
-      });
-      if (error) throw new Error(`${account}: ${error.message}`);
-      const r = data as { semeada?: boolean; completed_at?: string | null } | null;
-      resultado[account] = r?.semeada ? "semeada" : r?.completed_at ? "ja_concluida" : "ja_pendente";
+    const { data, error } = await supabase.rpc("vendas_sync_semear_janela", {
+      p_date_from: janela.de,
+      p_date_to: janela.ate,
+    });
+    if (error) throw new Error(error.message);
+    const r = data as { contas?: Array<{ account?: string; desfecho?: string }> } | null;
+    const resultado = {} as Record<ContaPedidos, DesfechoSemeadura | undefined>;
+    for (const conta of CONTAS_PEDIDOS) {
+      resultado[conta] = r?.contas?.find((c) => c.account === conta)?.desfecho as DesfechoSemeadura | undefined;
     }
     return { janela, resultado };
   };
@@ -290,7 +290,7 @@ export function useAnalyticsSync() {
   const janelasImportacao = statusJanelas(janelasRelevantes(janelasCursor ?? []));
   const importacaoEmAndamento = haJanelaAberta(janelasCursor ?? []);
 
-  const descricaoSemeadura = (resultado: Record<ContaPedidos, DesfechoSemeadura>) =>
+  const descricaoSemeadura = (resultado: Record<ContaPedidos, DesfechoSemeadura | undefined>) =>
     `oben: ${rotuloSemeadura(resultado.oben)} · colacor: ${rotuloSemeadura(resultado.colacor)}. ` +
     `Roda no servidor — pode fechar a aba e acompanhar aqui.`;
 
@@ -303,11 +303,12 @@ export function useAnalyticsSync() {
         description: descricaoSemeadura(d.resultado),
         duration: 10000,
       });
-      queryClient.invalidateQueries({ queryKey: [JANELAS_CURSOR_QUERY_KEY] });
     },
     onError: (error) => {
       toast.error("Erro ao armar a importação de pedidos", { description: String(error) });
     },
+    // onSettled (não onSuccess): erro também re-lê o cursor — o estado REAL vem do banco.
+    onSettled: () => queryClient.invalidateQueries({ queryKey: [JANELAS_CURSOR_QUERY_KEY] }),
   });
 
   const recentOrdersSyncMutation = useMutationComRegistro({
@@ -319,11 +320,11 @@ export function useAnalyticsSync() {
         description: descricaoSemeadura(d.resultado),
         duration: 10000,
       });
-      queryClient.invalidateQueries({ queryKey: [JANELAS_CURSOR_QUERY_KEY] });
     },
     onError: (error) => {
       toast.error("Erro ao armar a importação recente", { description: String(error) });
     },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: [JANELAS_CURSOR_QUERY_KEY] }),
   });
 
   const getStateFor = (entity: string, account: string) =>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -19525,6 +19525,10 @@ export type Database = {
         }
         Returns: undefined
       }
+      vendas_sync_semear_janela: {
+        Args: { p_account: string; p_date_from: string; p_date_to: string }
+        Returns: Json
+      }
       wa_is_stop_keyword: { Args: { p_body: string }; Returns: boolean }
       wa_owner_efetivo: { Args: { p_customer: string }; Returns: string }
       whatsapp_minutos_uteis: {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -19526,7 +19526,7 @@ export type Database = {
         Returns: undefined
       }
       vendas_sync_semear_janela: {
-        Args: { p_account: string; p_date_from: string; p_date_to: string }
+        Args: { p_accounts?: string[]; p_date_from: string; p_date_to: string }
         Returns: Json
       }
       wa_is_stop_keyword: { Args: { p_body: string }; Returns: boolean }

--- a/src/pages/AdminAnalyticsSync.tsx
+++ b/src/pages/AdminAnalyticsSync.tsx
@@ -26,7 +26,8 @@ export default function AdminAnalyticsSync() {
     recentOrdersSyncMutation,
     clientSyncProgress,
     addressSyncProgress,
-    ordersSyncProgress,
+    janelasImportacao,
+    importacaoEmAndamento,
     editingConfig,
     setEditingConfig,
     getStateFor,
@@ -99,7 +100,8 @@ export default function AdminAnalyticsSync() {
         isRunning={isRunning}
         recentPending={recentOrdersSyncMutation.isPending}
         bulkPending={bulkOrdersSyncMutation.isPending}
-        progress={ordersSyncProgress}
+        importandoEmAndamento={importacaoEmAndamento}
+        janelas={janelasImportacao}
         onImportRecent={() => recentOrdersSyncMutation.mutate()}
         onImportAll={() => bulkOrdersSyncMutation.mutate()}
       />

--- a/supabase/migrations/20260726130000_vendas_sync_semear_janela.sql
+++ b/supabase/migrations/20260726130000_vendas_sync_semear_janela.sql
@@ -1,0 +1,94 @@
+-- ============================================================
+-- vendas_sync_semear_janela — caminho de ESCRITA gateado (staff) pra armar o
+-- backfill de pedidos no motor server-side (vendas_sync_cursor + cron */6).
+--
+-- Contexto (incidente 2026-07-20/21, follow-up dos PRs #1500/#1502): o botão
+-- "Importar Recentes (180d)" rodava um loop client-side de 40-60 min invocando
+-- omie-vendas-sync ~26-35x por conta — o Chrome matava o JS ~12 min depois do
+-- clique (aba em background/Memory Saver) e deixava órfãos 'executando' em
+-- acoes_execucoes. O motor server-side JÁ EXISTE (20260617133633: cursor + lease
+-- + cron vendas-sync-continuacao-6min); faltava um caminho de escrita pro staff
+-- SEMEAR a janela sem colar INSERT no SQL Editor. Esta RPC é esse caminho:
+--   • SECURITY DEFINER (a escrita na tabela é service_role-only via RLS);
+--   • gate staff/master na FRONTEIRA, fail-closed (espelho verbatim do gate de
+--     request_customer_metrics_refresh — forma bloqueante do authz-gate-check);
+--   • INSERT ... ON CONFLICT DO NOTHING: NUNCA toca janela existente — não
+--     rebobina next_page, não rouba lease, não reabre janela completa;
+--   • o clique vira mutação curta; o progresso é LEITURA (staff tem SELECT na
+--     tabela via RLS) e a importação roda no servidor — pode fechar a aba.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(
+  p_account   text,
+  p_date_from date,
+  p_date_to   date
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_uid          uuid := auth.uid();
+  v_semeada      boolean := false;
+  v_next_page    integer;
+  v_completed_at timestamptz;
+BEGIN
+  -- Gate staff/master na fronteira (fail-closed: uid nulo NUNCA passa) —
+  -- mesmo gate de public.request_customer_metrics_refresh.
+  IF v_uid IS NULL
+     OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
+          OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+
+  -- Validação de janela (money-path: melhor recusar do que semear lixo).
+  IF p_account IS NULL OR p_account NOT IN ('oben', 'colacor') THEN
+    RAISE EXCEPTION 'conta invalida: % (esperado oben|colacor)', COALESCE(p_account, 'NULL')
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_date_from IS NULL OR p_date_to IS NULL OR p_date_from > p_date_to THEN
+    RAISE EXCEPTION 'janela invalida: date_from (%) deve ser <= date_to (%)', p_date_from, p_date_to
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_date_to > current_date THEN
+    RAISE EXCEPTION 'janela invalida: date_to (%) no futuro', p_date_to
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_date_from < DATE '2015-01-01' THEN
+    RAISE EXCEPTION 'janela invalida: date_from (%) anterior a 2015-01-01', p_date_from
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Semeadura idempotente: janela nova nasce livre (next_page NULL → lease_acquire
+  -- retoma da pág 1); janela EXISTENTE (pendente, em voo ou completa) fica intocada.
+  INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+  VALUES (p_account, p_date_from, p_date_to)
+  ON CONFLICT (account, date_from, date_to) DO NOTHING;
+  v_semeada := FOUND;
+
+  SELECT c.next_page, c.completed_at
+    INTO v_next_page, v_completed_at
+    FROM public.vendas_sync_cursor c
+   WHERE c.account = p_account AND c.date_from = p_date_from AND c.date_to = p_date_to;
+
+  RETURN jsonb_build_object(
+    'semeada',      v_semeada,
+    'account',      p_account,
+    'date_from',    p_date_from,
+    'date_to',      p_date_to,
+    'next_page',    v_next_page,
+    'completed_at', v_completed_at
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.vendas_sync_semear_janela(text, date, date) IS
+  'Arma uma janela de backfill de pedidos no vendas_sync_cursor (staff/master; fail-closed). '
+  'ON CONFLICT DO NOTHING: nunca toca janela existente. O cron vendas-sync-continuacao-6min '
+  'pega a janela pendente mais antiga por conta e o edge omie-vendas-sync importa com lease+heartbeat.';
+
+-- Fronteira de EXECUTE: caller humano via PostgREST (o gate interno barra não-staff).
+-- REVOKE nominal (default privilege do Supabase concede EXECUTE a anon/authenticated
+-- em toda função nova; REVOKE FROM PUBLIC não tira o grant explícito — CLAUDE.md).
+REVOKE ALL ON FUNCTION public.vendas_sync_semear_janela(text, date, date) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.vendas_sync_semear_janela(text, date, date) TO authenticated;

--- a/supabase/migrations/20260726140000_vendas_sync_semear_janela_v2.sql
+++ b/supabase/migrations/20260726140000_vendas_sync_semear_janela_v2.sql
@@ -1,0 +1,150 @@
+-- ============================================================
+-- vendas_sync_semear_janela v2 (ATÔMICA) — supersede a 20260726130000 (v1,
+-- por conta, NUNCA aplicada em prod — não colar a v1; este arquivo é
+-- auto-suficiente e dropa a assinatura antiga por segurança).
+--
+-- Por que v2 (challenge Codex xhigh, achado P1): na v1 o cliente fazia DUAS
+-- chamadas sequenciais (oben, colacor). Se a 2ª falhasse — ou o Chrome matasse
+-- o JS entre elas, exatamente o modo de morte do incidente 2026-07-20/21 —
+-- ficava janela PARCIAL (só oben) com o botão travado pela janela aberta:
+-- colacor inalcançável até a oben terminar. A v2 arma TODAS as contas em UMA
+-- transação: ou o par inteiro, ou nada.
+--
+-- Contexto (incidente 2026-07-20/21, follow-up dos PRs #1500/#1502): o botão
+-- "Importar Recentes (180d)" rodava um loop client-side de 40-60 min invocando
+-- omie-vendas-sync ~26-35x por conta — o Chrome matava o JS ~12 min depois do
+-- clique (aba em background/Memory Saver) e deixava órfãos 'executando' em
+-- acoes_execucoes. O motor server-side JÁ EXISTE (20260617133633: cursor + lease
+-- + cron vendas-sync-continuacao-6min); faltava um caminho de escrita pro staff
+-- SEMEAR a janela sem colar INSERT no SQL Editor. Esta RPC é esse caminho:
+--   • SECURITY DEFINER (a escrita na tabela é service_role-only via RLS);
+--   • gate staff/master na FRONTEIRA, fail-closed (espelho verbatim do gate de
+--     request_customer_metrics_refresh — forma bloqueante do authz-gate-check);
+--   • UMA chamada, MESMA transação, todas as contas (atômico);
+--   • pg_advisory_xact_lock por conta em ordem determinística (2 abas semeando
+--     junto não intercalam; sem risco de deadlock);
+--   • recusa honesta 'ja_pendente_outra' quando a conta já tem OUTRA janela
+--     aberta (o cron trabalha a mais antiga primeiro — semear por cima só
+--     enfileiraria atrás dela; Codex P2);
+--   • INSERT ... ON CONFLICT DO NOTHING: NUNCA toca janela existente — não
+--     rebobina next_page, não rouba lease, não reabre janela completa;
+--   • o clique vira mutação curta; o progresso é LEITURA (staff tem SELECT na
+--     tabela via RLS) e a importação roda no servidor — pode fechar a aba.
+-- ============================================================
+
+-- Assinatura v1 (por conta) — nunca aplicada; DROP cobre qualquer apply manual acidental.
+DROP FUNCTION IF EXISTS public.vendas_sync_semear_janela(text, date, date);
+
+CREATE OR REPLACE FUNCTION public.vendas_sync_semear_janela(
+  p_date_from date,
+  p_date_to   date,
+  p_accounts  text[] DEFAULT ARRAY['oben', 'colacor']
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_uid         uuid := auth.uid();
+  v_account     text;
+  v_contas      jsonb := '[]'::jsonb;
+  v_desfecho    text;
+  v_next        integer;
+  v_done        timestamptz;
+  v_aberta_from date;
+  v_aberta_to   date;
+BEGIN
+  -- Gate staff/master na fronteira (fail-closed: uid nulo NUNCA passa) —
+  -- mesmo gate de public.request_customer_metrics_refresh.
+  IF v_uid IS NULL
+     OR NOT (COALESCE(public.has_role(v_uid, 'employee'::public.app_role), false)
+          OR COALESCE(public.has_role(v_uid, 'master'::public.app_role),   false)) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+
+  -- Validação de janela (money-path: melhor recusar do que semear lixo).
+  IF p_accounts IS NULL OR array_length(p_accounts, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_accounts vazio' USING ERRCODE = '22023';
+  END IF;
+  IF p_date_from IS NULL OR p_date_to IS NULL OR p_date_from > p_date_to THEN
+    RAISE EXCEPTION 'janela invalida: date_from (%) deve ser <= date_to (%)', p_date_from, p_date_to
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_date_to > current_date THEN
+    RAISE EXCEPTION 'janela invalida: date_to (%) no futuro', p_date_to
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_date_from < DATE '2015-01-01' THEN
+    RAISE EXCEPTION 'janela invalida: date_from (%) anterior a 2015-01-01', p_date_from
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Contas em ordem determinística → advisory locks sempre na mesma ordem (anti-deadlock).
+  FOR v_account IN SELECT DISTINCT a FROM unnest(p_accounts) AS a ORDER BY a
+  LOOP
+    IF v_account IS NULL OR v_account NOT IN ('oben', 'colacor') THEN
+      RAISE EXCEPTION 'conta invalida: % (esperado oben|colacor)', COALESCE(v_account, 'NULL')
+        USING ERRCODE = '22023';
+    END IF;
+
+    -- Serializa semeadores concorrentes da MESMA conta (xact-lock: solta sozinho no fim/abort).
+    PERFORM pg_advisory_xact_lock(hashtext('vendas_sync_semear_' || v_account));
+
+    SELECT c.date_from, c.date_to
+      INTO v_aberta_from, v_aberta_to
+      FROM public.vendas_sync_cursor c
+     WHERE c.account = v_account
+       AND c.completed_at IS NULL
+       AND NOT (c.date_from = p_date_from AND c.date_to = p_date_to)
+     ORDER BY c.date_from
+     LIMIT 1;
+
+    IF FOUND THEN
+      v_desfecho := 'ja_pendente_outra';
+      v_next := NULL;
+      v_done := NULL;
+    ELSE
+      INSERT INTO public.vendas_sync_cursor (account, date_from, date_to)
+      VALUES (v_account, p_date_from, p_date_to)
+      ON CONFLICT (account, date_from, date_to) DO NOTHING;
+      IF FOUND THEN
+        v_desfecho := 'semeada';
+      END IF;
+      SELECT c.next_page, c.completed_at
+        INTO v_next, v_done
+        FROM public.vendas_sync_cursor c
+       WHERE c.account = v_account AND c.date_from = p_date_from AND c.date_to = p_date_to;
+      IF v_desfecho IS NULL THEN
+        v_desfecho := CASE WHEN v_done IS NOT NULL THEN 'ja_concluida' ELSE 'ja_pendente' END;
+      END IF;
+    END IF;
+
+    v_contas := v_contas || jsonb_build_object(
+      'account',           v_account,
+      'desfecho',          v_desfecho,
+      'next_page',         v_next,
+      'completed_at',      v_done,
+      'janela_aberta_de',  v_aberta_from,
+      'janela_aberta_ate', v_aberta_to
+    );
+
+    v_desfecho := NULL; v_next := NULL; v_done := NULL;
+    v_aberta_from := NULL; v_aberta_to := NULL;
+  END LOOP;
+
+  RETURN jsonb_build_object('date_from', p_date_from, 'date_to', p_date_to, 'contas', v_contas);
+END;
+$$;
+
+COMMENT ON FUNCTION public.vendas_sync_semear_janela(date, date, text[]) IS
+  'Arma janelas de backfill de pedidos no vendas_sync_cursor (staff/master; fail-closed), '
+  'TODAS as contas na mesma transação (atômico) com advisory lock por conta. ON CONFLICT DO '
+  'NOTHING: nunca toca janela existente; conta com OUTRA janela aberta recebe ja_pendente_outra. '
+  'O cron vendas-sync-continuacao-6min pega a pendente mais antiga por conta e o edge '
+  'omie-vendas-sync importa com lease+heartbeat.';
+
+-- Fronteira de EXECUTE: caller humano via PostgREST (o gate interno barra não-staff).
+-- REVOKE nominal (default privilege do Supabase concede EXECUTE a anon/authenticated
+-- em toda função nova; REVOKE FROM PUBLIC não tira o grant explícito — CLAUDE.md).
+REVOKE ALL ON FUNCTION public.vendas_sync_semear_janela(date, date, text[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.vendas_sync_semear_janela(date, date, text[]) TO authenticated;


### PR DESCRIPTION
## O que muda

**Incidente 2026-07-20/21:** o botão "Importar Recentes (180d)" rodava um loop client-side de 40–60 min (`runOrdersSync`, ~26–35 invocações da edge por conta). O Chrome matava o JS ~12 min após o clique (aba em background/Memory Saver) → 3 tentativas falhas + órfãos `executando` em `acoes_execucoes`.

**Refactor:** o clique agora **arma a janela** via RPC nova `vendas_sync_semear_janela` — **uma chamada atômica que arma as DUAS contas (oben+colacor) na mesma transação** — e o motor server-side **que já existe** (cron `vendas-sync-continuacao-6min` jobid 140 + edge `omie-vendas-sync` com lease + heartbeat por página + retomada) importa em segundo plano. A UI vira **polling de leitura** do cursor (staff tem SELECT via RLS): estado por conta (rodando / aguardando / **falhando** quando `last_error_kind` está aberto / concluída, com a página em curso), aviso "pode fechar esta aba", botões desabilitados enquanto houver janela aberta.

- **"Importar Recentes (180d)"** → janela `hoje-180d → hoje`.
- **"Importar Todos"** → janela `2015-01-01 → hoje` (2015 = piso da própria RPC; o min de `sales_orders` não prova o min do Omie — período vazio não custa páginas).
- **Copy do card corrigida** — o "rápido, ~2 min" era mentira histórica.
- **Registro**: `useMutationComRegistro` cobre só a semeadura (~1s) → sem novos órfãos. A MV `customer_metrics` não é mais atualizada no clique — o cron de refresh de 6h cobre.
- **Edge INTOCADA, cron INTOCADO** — só migration + frontend.

## A RPC v2 (SECURITY DEFINER, atômica, gate staff na fronteira)

Gate espelhado verbatim de `request_customer_metrics_refresh` (uid nulo NUNCA passa; forma bloqueante do `authz:check`), validação de janela (from ≤ to ≤ hoje, from ≥ 2015) com `22023`, `pg_advisory_xact_lock` por conta em ordem determinística (2 abas semeando junto não intercalam), recusa honesta `ja_pendente_outra` quando a conta já tem OUTRA janela aberta (o cron trabalha a mais antiga primeiro — semear por cima só enfileiraria atrás), e `INSERT … ON CONFLICT DO NOTHING` — **nunca** toca janela existente. `REVOKE FROM PUBLIC, anon` + `GRANT authenticated`.

## Segunda opinião (Codex xhigh, challenge money-path) — integrada

O parecer cru está na sessão; calibração: **aceitos e corrigidos aqui** → P1 semeadura não-atômica (virou 1 chamada/1 transação), P2 sobreposição/starvation (lock + `ja_pendente_outra`), UI cega a `last_error_kind` (estado "falhando"), época 2020 circular (→ 2015). **Aceitos como follow-up de FUNDAÇÃO** (edge/cron de junho, intocados por desenho; chips abertos): lease sem fencing/owner token; `completed_at` fechando janela com `failed[]`>0 e falha permanente sem estado terminal. **Refutações que falharam** (Codex confirmou): gate fail-closed, RLS/SECDEF sem via de escrita pra não-staff, `search_path=''` são, datas BRT×UTC sem furo, idempotência sem clobber.

## Prova (PG17 + falsificação — `db/test-vendas_sync_semear_janela.sh`, 36 asserts verdes)

- Caminho REAL (`SET ROLE authenticated` + GUC JWT): 1 chamada arma o par; janelas nascem livres; `lease_acquire` retoma da pág 1; re-semear no-opa byte-a-byte; janela em voo preserva `next_page`/lease; completa não reabre; conta ocupada recebe `ja_pendente_outra` **sem inserir**.
- Negativos com SQLSTATE + re-raise: customer barrado pelo GATE; anon barrado na FRONTEIRA (`permission denied for function`, sentinela que meu código nunca emite); uid-nulo barrado; **atomicidade real** (conta inválida no par → rollback do insert já feito); 4 validações `22023`.
- Integração: janelas semeadas pela RPC disparam o comando REAL do cron (2 `http_post` com `use_cursor` + DD/MM/YYYY).
- **5 falsificações com dente**: F1 sem gate → customer semeia; F2 `DO UPDATE` → clobber; F3 grant anon → fronteira cai; F4 corpo sem lock → validador reprova; F5 engolir exceção → atomicidade morre.
- **Validador pós-apply com dente** (lição #1490/#1501): `db/valida-vendas-sync-semear-janela.sql` lê CATÁLOGO (nunca invoca — FU4-E), corpo comment-strip (#1472/#1488), checa a v1 dropada, e o harness o EXECUTA contra banco bom (✅) e sabotado ×4 (❌).

Gates: vitest **5548/5548** · typecheck 0 · lint 0 · shellcheck 0 · `authz:check` ok · `wt:preflight --full` 🟢.

## ⚠️ ATENÇÃO: migration manual necessária — colar SÓ a v2

Este PR adiciona DUAS migrations; **aplicar SOMENTE** `supabase/migrations/20260726140000_vendas_sync_semear_janela_v2.sql`. A `20260726130000` (v1 por conta) foi **superseded antes de qualquer apply** (imutável pós-commit por política do repo — o hook bloqueia edição) e **não deve ser colada**; a v2 é auto-suficiente e dropa a assinatura v1 por segurança. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Colar no SQL Editor **ANTES do Publish do frontend** (sem ela, o clique erra com `function vendas_sync_semear_janela does not exist`).

Validação pós-apply (read-only, `db/valida-vendas-sync-semear-janela.sql`): esperado `✅ vendas_sync_semear_janela v2 aplicada (atomica + gate staff + grants + DO NOTHING + lock ok)`.

## Critério de aceite (do founder)

Clicar em "Importar Recentes (180d)", **fechar a aba**, e a janela 180d fechar sozinha (`completed_at` preenchido nas 2 contas) — verificável via psql-ro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)