### PR TITLE
feat(margem): helper compartilhado de margem por cliente — uma só verdade [money-path]

### DIFF
--- a/db/test-margem-cliente-helper-compartilhado.sh
+++ b/db/test-margem-cliente-helper-compartilhado.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  Prova PG17 do helper compartilhado `private.margem_cliente_agregada()`       ║
+# ║    bash db/test-margem-cliente-helper-compartilhado.sh > log 2>&1; echo $?    ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                       ║
+# ║                                                                               ║
+# ║  Revisão adversária Codex (gpt-5.6-sol xhigh, 2026-07-21) derrubou a v1.      ║
+# ║  Corrigido aqui:                                                              ║
+# ║   · o ALTER DEFAULT PRIVILEGES era no schema `public` e a função nasce em     ║
+# ║     `private` ⇒ anon/authenticated nunca recebiam os grants que a PROD tem,   ║
+# ║     e L1/L2 ficavam VERDES mesmo sem os REVOKE por nome (falso-verde);        ║
+# ║   · faltava o assert financeiro central: cliente MULTI-ITEM com custo         ║
+# ║     conhecido + desconhecido e quantidade ≠ 1;                                ║
+# ║   · faltava o contraexemplo do preço ausente fabricando margem 0.00;          ║
+# ║   · nada checava prosecdef/proconfig — sabotar o SECURITY DEFINER passava;    ║
+# ║   · "service_role executa" lia o ACL da função sem USAGE no schema;           ║
+# ║   · só havia UM negativo de status; `status <> 'importado'` passaria.         ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="margemhelper"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  XX  $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+# ── espelhando a PROD (tipos, chaves e ACL reais, conferidos por psql-ro) ─────
+P -q <<'SQL'
+-- ⚠️ O schema `private` é criado ANTES da migration e recebe o default privilege AQUI.
+-- Sem isto, anon/authenticated nasceriam sem o EXECUTE que a PROD concede por default, e os
+-- asserts de REVOKE passariam pela razão errada — o falso-verde que o Codex xhigh pegou.
+CREATE SCHEMA IF NOT EXISTS private;
+ALTER DEFAULT PRIVILEGES IN SCHEMA private GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+
+-- USAGE em `private` para anon/authenticated ESPELHA A PROD, não é folga do harness:
+-- medido 2026-07-21, `private.nspacl` = {…,authenticated=U/postgres,anon=U/postgres,…}.
+-- Sem replicar, o assert de ACL mediria a ausência de USAGE em vez do REVOKE.
+GRANT USAGE ON SCHEMA private TO authenticated, anon;
+
+CREATE TABLE public.omie_products (
+  id uuid PRIMARY KEY,
+  omie_codigo_produto bigint UNIQUE);
+-- Espelha a PROD: `id` é a PK e `product_id` é UNIQUE em separado
+-- (product_costs_pkey em id + product_costs_product_id_key em product_id).
+CREATE TABLE public.product_costs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  product_id uuid UNIQUE,
+  cost_final numeric,
+  cost_price numeric);
+CREATE TABLE public.sales_orders (
+  id uuid PRIMARY KEY,
+  status text,
+  deleted_at timestamptz);       -- 100% NULO na prod, mas a coluna EXISTE
+CREATE TABLE public.order_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sales_order_id uuid,
+  customer_user_id uuid,
+  omie_codigo_produto bigint,
+  product_id uuid,               -- NULO em 2,67% dos itens da prod — é o ponto do H1
+  quantity numeric,
+  unit_price numeric);
+CREATE TABLE public.cliente_classificacao (
+  user_id uuid PRIMARY KEY,
+  excluir_da_carteira boolean);
+SQL
+
+# ── aplica a migration REAL (não uma cópia) ──────────────────────────────────
+P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+
+# ── seed ─────────────────────────────────────────────────────────────────────
+P -q <<'SQL'
+INSERT INTO public.omie_products (id, omie_codigo_produto) VALUES
+  ('dd000000-0000-0000-0000-000000000001', 1001),   -- custo 60
+  ('dd000000-0000-0000-0000-000000000002', 1002),   -- SEM linha em product_costs
+  ('dd000000-0000-0000-0000-000000000003', 1003),   -- custo 150
+  ('dd000000-0000-0000-0000-000000000004', 1004),   -- cost_final = 0  → "não sei"
+  ('dd000000-0000-0000-0000-000000000005', 1005),   -- cost_final NULL, cost_price 40
+  ('dd000000-0000-0000-0000-000000000006', 1006),   -- custo 20
+  ('dd000000-0000-0000-0000-000000000007', 1007),   -- cost_final = Infinity → "não sei"
+  ('dd000000-0000-0000-0000-000000000008', 1008);   -- cost_final = NaN      → "não sei"
+
+INSERT INTO public.product_costs (product_id, cost_final, cost_price) VALUES
+  ('dd000000-0000-0000-0000-000000000001',        60, NULL),
+  ('dd000000-0000-0000-0000-000000000003',       150, NULL),
+  ('dd000000-0000-0000-0000-000000000004',         0, NULL),
+  ('dd000000-0000-0000-0000-000000000005',      NULL,   40),
+  ('dd000000-0000-0000-0000-000000000006',        20, NULL),
+  ('dd000000-0000-0000-0000-000000000007', 'Infinity'::numeric, NULL),
+  ('dd000000-0000-0000-0000-000000000008', 'NaN'::numeric,      NULL);
+
+INSERT INTO public.sales_orders (id, status, deleted_at) VALUES
+  ('50000000-0000-0000-0000-00000000000a', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-00000000000b', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-00000000000c', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-00000000000d', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-00000000000e', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-00000000000f', 'importado', NULL),   -- fora do allowlist vivo
+  ('50000000-0000-0000-0000-000000000010', 'cancelado', NULL),   -- 2º negativo de status
+  ('50000000-0000-0000-0000-000000000011', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-000000000012', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-000000000013', 'faturado',  NULL),
+  ('50000000-0000-0000-0000-000000000014', 'faturado',  now());  -- soft-deleted
+
+-- ⚠️ SÓ o item de A tem `product_id` NULO. Os outros vêm preenchidos DE PROPÓSITO: assim a
+-- falsificação F1 (trocar o JOIN para product_id) fica vermelha em H1 e nos asserts que
+-- REPETEM aquele mesmo valor, e não no harness inteiro — sabotagem que derruba tudo não prova
+-- nada de específico.
+INSERT INTO public.order_items (sales_order_id, customer_user_id, omie_codigo_produto, product_id, quantity, unit_price) VALUES
+  -- A: product_id NULO, código resolve p/ SKU COM custo → 40%. Classe dos 783 itens / R$ 247.482,10.
+  ('50000000-0000-0000-0000-00000000000a','aa000000-0000-0000-0000-000000000001', 1001, NULL, 1, 100),
+  -- B: só SKU sem linha de custo → NULL
+  ('50000000-0000-0000-0000-00000000000b','bb000000-0000-0000-0000-000000000002', 1002, 'dd000000-0000-0000-0000-000000000002', 1, 100),
+  -- C: custo 150 sobre receita 100 → margem NEGATIVA, preservada
+  ('50000000-0000-0000-0000-00000000000c','cc000000-0000-0000-0000-000000000003', 1003, 'dd000000-0000-0000-0000-000000000003', 1, 100),
+  -- D: cost_final = 0 → "não sei" → NULL
+  ('50000000-0000-0000-0000-00000000000d','dd111111-0000-0000-0000-000000000004', 1004, 'dd000000-0000-0000-0000-000000000004', 1, 100),
+  -- E: excluído da carteira → some
+  ('50000000-0000-0000-0000-00000000000e','ee000000-0000-0000-0000-000000000005', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
+  -- F: status 'importado' → some
+  ('50000000-0000-0000-0000-00000000000f','ff000000-0000-0000-0000-000000000006', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
+  -- F2: status 'cancelado' → some (2º negativo: barra `status <> 'importado'`)
+  ('50000000-0000-0000-0000-000000000010','f2000000-0000-0000-0000-000000000016', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
+  -- I: fallback cost_price (cost_final NULL) → 60%
+  ('50000000-0000-0000-0000-000000000011','1a000000-0000-0000-0000-000000000011', 1005, 'dd000000-0000-0000-0000-000000000005', 1, 100),
+  -- SD: pedido soft-deleted → some
+  ('50000000-0000-0000-0000-000000000014','5d000000-0000-0000-0000-000000000014', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100);
+
+INSERT INTO public.cliente_classificacao (user_id, excluir_da_carteira) VALUES
+  ('ee000000-0000-0000-0000-000000000005', true);
+
+-- G: MULTI-ITEM com quantidade ≠ 1 e custo conhecido + desconhecido (o assert financeiro central).
+--   (2×100, custo 60) → receita 200, custo 120
+--   (3× 50, custo 20) → receita 150, custo  60
+--   (1×999, SEM custo) → IGNORADO
+--   receita 350, custo 180 → (350-180)/350 = 48,571… → 48.57
+INSERT INTO public.order_items (sales_order_id, customer_user_id, omie_codigo_produto, product_id, quantity, unit_price) VALUES
+  ('50000000-0000-0000-0000-000000000012','9a000000-0000-0000-0000-000000000012', 1001, 'dd000000-0000-0000-0000-000000000001', 2, 100),
+  ('50000000-0000-0000-0000-000000000012','9a000000-0000-0000-0000-000000000012', 1006, 'dd000000-0000-0000-0000-000000000006', 3,  50),
+  ('50000000-0000-0000-0000-000000000012','9a000000-0000-0000-0000-000000000012', 1002, 'dd000000-0000-0000-0000-000000000002', 1, 999);
+
+-- H: o CONTRAEXEMPLO do Codex — preço ausente com custo conhecido, misturado a um item válido.
+--   Sem o guard: receita 100, custo 60+40=100 → margem 0.00 FABRICADA.
+--   Com o guard: o item de preço NULO é ignorado → receita 100, custo 60 → 40.00.
+INSERT INTO public.order_items (sales_order_id, customer_user_id, omie_codigo_produto, product_id, quantity, unit_price) VALUES
+  ('50000000-0000-0000-0000-000000000013','8a000000-0000-0000-0000-000000000013', 1001, 'dd000000-0000-0000-0000-000000000001', 1,  100),
+  ('50000000-0000-0000-0000-000000000013','8a000000-0000-0000-0000-000000000013', 1005, 'dd000000-0000-0000-0000-000000000005', 1, NULL);
+SQL
+
+m() { Pq -c "SELECT COALESCE(margem_pct::text,'NULL') FROM private.margem_cliente_agregada() WHERE customer_user_id='$1';"; }
+
+echo "-- H. o JOIN por omie_codigo_produto (o ponto do PR) --"
+eq "H1 item com product_id NULO mas código com custo → margem REAL" \
+   "$(m aa000000-0000-0000-0000-000000000001)" "40.00"
+
+echo "-- I. ausente != zero, nas TRES pernas --"
+eq "I1 SKU sem linha de custo → NULL, jamais 0"        "$(m bb000000-0000-0000-0000-000000000002)" "NULL"
+eq "I2 cost_final = 0 é 'não sei', não custo zero"     "$(m dd111111-0000-0000-0000-000000000004)" "NULL"
+eq "I3 fallback cost_price quando cost_final é NULL"   "$(m 1a000000-0000-0000-0000-000000000011)" "60.00"
+eq "I4 itens_ignorados contabiliza o desconhecido" \
+   "$(Pq -c "SELECT itens_ignorados FROM private.margem_cliente_agregada() WHERE customer_user_id='bb000000-0000-0000-0000-000000000002';")" "1"
+# O contraexemplo do Codex: sem o guard de preço isto devolveria 0.00 (margem fabricada).
+eq "I5 preço ausente NÃO fabrica margem 0 (item é ignorado)" \
+   "$(m 8a000000-0000-0000-0000-000000000013)" "40.00"
+
+echo "-- J. dado real preservado + agregação multi-item --"
+eq "J1 margem NEGATIVA é dado real, não é zerada" "$(m cc000000-0000-0000-0000-000000000003)" "-50.00"
+# O assert financeiro central: quantidade != 1, 2 SKUs com custo + 1 sem, tudo junto.
+eq "J2 multi-item, qtd!=1, custo misto → margem correta" \
+   "$(m 9a000000-0000-0000-0000-000000000012)" "48.57"
+eq "J3 multi-item: contadores e somas batem" \
+   "$(Pq -c "SELECT itens_computaveis||'|'||itens_ignorados||'|'||receita_computada||'|'||custo_computado
+               FROM private.margem_cliente_agregada() WHERE customer_user_id='9a000000-0000-0000-0000-000000000012';")" \
+   "2|1|350|180"
+
+echo "-- K. universo --"
+eq "K1 cliente excluído da carteira some" \
+   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='ee000000-0000-0000-0000-000000000005';")" "0"
+eq "K2 status 'importado' some" \
+   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='ff000000-0000-0000-0000-000000000006';")" "0"
+eq "K3 status 'cancelado' some (2o negativo — barra 'status <> importado')" \
+   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='f2000000-0000-0000-0000-000000000016';")" "0"
+eq "K4 pedido soft-deleted some" \
+   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='5d000000-0000-0000-0000-000000000014';")" "0"
+
+echo "-- L. ACL (o helper não é alcançável do browser) --"
+eq "L1 anon NAO executa"          "$(Pq -c "SELECT has_function_privilege('anon','private.margem_cliente_agregada()','EXECUTE');")"          "f"
+eq "L2 authenticated NAO executa" "$(Pq -c "SELECT has_function_privilege('authenticated','private.margem_cliente_agregada()','EXECUTE');")" "f"
+eq "L3 PUBLIC NAO executa"        "$(Pq -c "SELECT has_function_privilege('public','private.margem_cliente_agregada()','EXECUTE');")"        "f"
+# `has_function_privilege` lê só o ACL da função. A chamada REAL sob SET ROLE é que prova que
+# service_role alcança a função de fato (precisa de USAGE no schema também).
+# `-q` é obrigatório: sem ele a tag "SET" do `SET ROLE` entra na saída capturada por `-tA`
+# e o assert compara "SET\nt" com "t" (armadilha registrada em money-path.md).
+eq "L4 service_role CHAMA de verdade (SET ROLE, não só ACL)" \
+   "$(P -tA -q -c "SET ROLE service_role; SELECT count(*) > 0 FROM private.margem_cliente_agregada();")" "t"
+eq "L5 vive em private, fora do schema exposto" \
+   "$(Pq -c "SELECT n.nspname FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE p.proname='margem_cliente_agregada';")" "private"
+
+echo "-- N. propriedades do objeto (sabotar isto passava antes) --"
+eq "N1 é SECURITY DEFINER" \
+   "$(Pq -c "SELECT prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND p.proname='margem_cliente_agregada';")" "t"
+eq "N2 search_path fixado (não herda o do caller)" \
+   "$(Pq -c "SELECT array_to_string(proconfig,',') FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND p.proname='margem_cliente_agregada';")" \
+   "search_path=pg_catalog, pg_temp"
+eq "N3 é STABLE (não VOLATILE)" \
+   "$(Pq -c "SELECT provolatile FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND p.proname='margem_cliente_agregada';")" "s"
+
+echo "-- O. idempotência --"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+eq "O1 re-aplicar não muda o resultado"                "$(m aa000000-0000-0000-0000-000000000001)" "40.00"
+eq "O2 re-aplicar preserva o REVOKE de authenticated" \
+   "$(Pq -c "SELECT has_function_privilege('authenticated','private.margem_cliente_agregada()','EXECUTE');")" "f"
+
+echo "========================================"
+echo "  $PASS verde(s), $FAIL vermelho(s)"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "  TODOS OS ASSERTS PASSARAM"

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -123,6 +123,23 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // atravessa; o custo unitário não sai do banco. Mesmo perfil da irmã get_customer_sales_summary
   // (confirmado psql-ro: auth_exec=f, anon_exec=f, svc_exec=t). Reconfirmar após o apply em prod.
   'public.get_customer_margin_summary',
+
+  // 2026-07-21 — helper COMPARTILHADO de margem por cliente (PR #1519). Fecha por PRIVILÉGIO,
+  // não por gate no corpo, e é por isso que entra aqui e não no AUTHZ_MANIFEST:
+  //   · o REVOKE é o que fecha: de PUBLIC + anon + authenticated (função nova nasce com
+  //     proacl NULL = EXECUTE implícito a PUBLIC, e o default privilege do Supabase concede às
+  //     roles nomeadas — revogar dos dois jeitos), GRANT só a service_role;
+  //   · `private` fecha a rota HTTP (o PostgREST só publica os schemas configurados), mas
+  //     ⚠️ NÃO é barreira de EXECUTE: medido em prod, `private` concede USAGE a authenticated E
+  //     anon (`nspacl = {…,authenticated=U/postgres,anon=U/postgres,…}`). Quem depender do schema
+  //     como se fosse trava está enganado — é o REVOKE, e só ele;
+  //   · os consumidores é que carregam o gate: `get_carteira_margem_faixa` (FU4-F fase 3) aplica
+  //     cap_custo_ler na PROJEÇÃO do número e cap_carteira_ler/carteira_visivel_para no ESCOPO;
+  //     `get_customer_margin_summary` (#1495, acima) passa a DERIVAR deste helper em vez de ter
+  //     cálculo próprio — as duas discordavam em 28,5% dos clientes na faixa.
+  // Provado em db/test-margem-cliente-helper-compartilhado.sh (L1-L5): anon/authenticated/PUBLIC
+  // com has_function_privilege=f, service_role=t, e a função residindo em `private`.
+  'private.margem_cliente_agregada',
 ]);
 
 /** chave de lookup a partir de schema+name (case-insensitive, sem assinatura) */

--- a/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql
+++ b/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql
@@ -1,0 +1,159 @@
+-- Helper COMPARTILHADO de margem por cliente — uma só verdade para os dois consumidores.
+--
+-- POR QUE ELE EXISTE (medido em prod 2026-07-21): duas frentes simultâneas construíram, cada uma,
+-- o "cálculo server-side da margem por cliente":
+--   • PR #1495  — `get_customer_margin_summary()`, service_role, alimenta o cron que popula
+--                 `farmer_client_scores.gross_margin_pct` (hoje 0 para 6.632/6.632 linhas);
+--   • FU4-F f3  — `get_carteira_margem_faixa()`, authenticated, devolve a FAIXA ao browser para
+--                 `useFarmerScoring` parar de baixar `product_costs` (3.637 linhas) ao cliente.
+-- Rodando as duas lógicas lado a lado sobre a prod: 1.215 clientes, 461 com margem numérica
+-- diferente, 310 divergindo em *ser calculável*, delta máximo de 112,57 pontos percentuais e
+-- **346 clientes (28,5%) caindo em FAIXA diferente**. Duas autoridades money-path discordando no
+-- sinal que o vendedor vê. Este helper é a resposta: ambos passam a derivar daqui.
+--
+-- ⚠️ MIGRATION MANUAL: nome custom não auto-aplica no Lovable. Colar no SQL Editor → Run.
+--
+-- ── DECISÃO 1: o JOIN é por `omie_codigo_produto`, não por `order_items.product_id` ───────────
+-- `product_id` é NULO em 1.837 de 68.700 itens (2,67%). Desses, **783 TÊM custo conhecido**
+-- alcançável por `omie_codigo_produto`, carregando **R$ 247.482,10** de receita — que um JOIN por
+-- `product_id` classifica como "sem custo". É a lição "ausente ≠ zero" aplicada à JUNÇÃO: item que
+-- não junta não é item sem custo.
+-- O JOIN é SET-BASED: `product_costs.product_id` é UNIQUE (`product_costs_product_id_key`) e
+-- `omie_products.omie_codigo_produto` é único (7.962/7.962) ⇒ não duplica linha.
+--
+-- ── DECISÃO 2: o filtro de status PRESERVA o comportamento do HOOK, de propósito ──────────────
+-- ⚠️ ELE ESTÁ ERRADO E ISSO É DELIBERADO. O universo real de `sales_orders.status` é
+-- `faturado` 20.182 · `importado` 5.269 · `separacao` 2.760 · `enviado` 2.005 · e 17 entre
+-- `cancelado`/`orcamento`/`rascunho`. **`confirmado` e `entregue` não existem (zero linhas).**
+-- O allowlist abaixo é o de `useFarmerScoring.ts:147`, logo o scoring vivo enxerga só `faturado`:
+-- 20.182 de 30.216 pedidos reais — **faltam 33% da base**, e não só para a margem (recência,
+-- frequência, spend e mix saem do mesmo universo).
+--
+-- ⚠️ PRECISÃO: o que se preserva é o comportamento do HOOK (`useFarmerScoring`), que é o que o
+-- vendedor vê hoje. NÃO se preserva o do #1495, que usa denylist e nunca rodou em prod (a coluna
+-- que ele alimenta está 0 para todos). Ao absorver este helper, o #1495 MUDA de universo — é
+-- mudança consciente, não regressão: alinha o cron ao que a tela mostra.
+--
+-- ⚠️ E o custo de cristalizar: enquanto o follow-up não entrar, este objeto é a "fonte única" que
+-- exclui 33% da base. A mitigação é ele ser UM lugar — o chip "Corrigir filtro de status do
+-- scoring do farmer" (PR próprio, com baseline medido) muda esta lista e vale para os dois
+-- consumidores de uma vez. Sem esse follow-up, a dívida fica; com ele, some de uma vez só.
+--
+-- ── DECISÃO 3: ausente ≠ zero, nas TRÊS pernas ───────────────────────────────────────────────
+-- Um item só é COMPUTÁVEL quando quantidade, preço E custo são utilizáveis. Cliente sem nenhum
+-- item computável devolve `margem_pct = NULL`, jamais 0 — margem 0 é veredito legítimo
+-- ("cliente ruim") e confundi-lo com "não sei" fabrica número. Margem NEGATIVA é dado real e é
+-- preservada. Espelha `src/lib/custo/custoCanonico.ts` e `src/lib/scoring/margin.ts`.
+--
+-- ── Superfície ───────────────────────────────────────────────────────────────────────────────
+-- Fechado por PRIVILÉGIO: `REVOKE` de PUBLIC + anon + authenticated, `GRANT` só a service_role.
+-- ⚠️ Viver em `private` fecha a rota HTTP (o PostgREST só publica os schemas configurados) mas
+-- NÃO é barreira de EXECUTE: medido, `private` concede USAGE a authenticated E anon
+-- (`nspacl = {…,authenticated=U/postgres,anon=U/postgres,…}`). Quem tratar o schema como trava
+-- está enganado — é o REVOKE, e só ele. Os consumidores é que carregam o gate.
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE OR REPLACE FUNCTION private.margem_cliente_agregada()
+RETURNS TABLE (
+  customer_user_id  uuid,
+  itens_computaveis bigint,
+  itens_ignorados   bigint,
+  receita_computada numeric,
+  custo_computado   numeric,
+  margem_pct        numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $fn$
+  WITH custo AS (
+    -- Custo canônico: cost_final (saída do motor, proxy-aware) → fallback cost_price.
+    -- `> 0 AND < 'Infinity'` é o teste de FINITUDE POSITIVA em numeric e cobre os três lixos de
+    -- uma vez: 0/negativo reprovam no `> 0`; Infinity reprova no `< 'Infinity'`; e NaN reprova
+    -- também, porque o Postgres ordena NaN como MAIOR que qualquer numeric, inclusive Infinity.
+    -- (Um `NULLIF(x,'NaN')` sozinho deixaria Infinity passar — achado Codex xhigh, 2026-07-21.)
+    SELECT op.omie_codigo_produto AS cod,
+           COALESCE(
+             CASE WHEN pc.cost_final > 0 AND pc.cost_final < 'Infinity'::numeric THEN pc.cost_final END,
+             CASE WHEN pc.cost_price > 0 AND pc.cost_price < 'Infinity'::numeric THEN pc.cost_price END
+           ) AS custo_unit
+      FROM public.omie_products op
+      JOIN public.product_costs pc ON pc.product_id = op.id
+     WHERE op.omie_codigo_produto IS NOT NULL
+  ),
+  itens AS (
+    SELECT oi.customer_user_id      AS cid,
+           oi.quantity::numeric     AS qtd,
+           oi.unit_price::numeric   AS preco_unit,
+           cu.custo_unit
+      FROM public.order_items oi
+      JOIN public.sales_orders so ON so.id = oi.sales_order_id
+      LEFT JOIN custo cu          ON cu.cod = oi.omie_codigo_produto
+     -- ⚠️ DECISÃO 2 acima: esta lista é o comportamento VIVO, conhecidamente incompleto.
+     -- É o ÚNICO lugar a mudar quando o PR do filtro de status entrar.
+     WHERE so.status IN ('confirmado', 'faturado', 'entregue')
+       -- 100% NULO hoje; sem isto o 1º pedido soft-deleted entraria no cálculo em silêncio.
+       AND so.deleted_at IS NULL
+       AND oi.customer_user_id IS NOT NULL
+       -- NOT EXISTS, não NOT IN: NOT IN é NULL-blind e zeraria o resultado inteiro.
+       AND NOT EXISTS (
+             SELECT 1 FROM public.cliente_classificacao cc
+              WHERE cc.user_id = oi.customer_user_id
+                AND cc.excluir_da_carteira IS TRUE)
+  ),
+  norm AS (
+    -- ⚠️ A versão anterior fazia `COALESCE(quantity,0→1)` e `COALESCE(unit_price,0)`, o que
+    -- FABRICAVA margem: item com custo conhecido e preço ausente entrava com receita 0 e custo
+    -- real, e um cliente com (100,60) + (preço ausente, custo 40) fechava em 0.00% — veredito
+    -- inventado (achado Codex xhigh). A prod tem 0 desses em 68.720 itens, então o guard não
+    -- muda número nenhum hoje; ele impede que o primeiro apareça em silêncio.
+    SELECT i.cid, i.qtd, i.preco_unit, i.custo_unit,
+           ( i.qtd        IS NOT NULL AND i.qtd        >  0 AND i.qtd        < 'Infinity'::numeric
+         AND i.preco_unit IS NOT NULL AND i.preco_unit >= 0 AND i.preco_unit < 'Infinity'::numeric
+         AND i.custo_unit IS NOT NULL ) AS computavel
+      FROM itens i
+  )
+  SELECT
+    n.cid,
+    count(*) FILTER (WHERE n.computavel),
+    count(*) FILTER (WHERE NOT n.computavel),
+    COALESCE(sum(n.preco_unit * n.qtd)  FILTER (WHERE n.computavel), 0),
+    COALESCE(sum(n.custo_unit  * n.qtd) FILTER (WHERE n.computavel), 0),
+    -- Denominador > 0 é a ÚNICA condição que produz número. Sem item computável (ou receita 0
+    -- sobre eles) → NULL. NUNCA 0.
+    CASE
+      WHEN COALESCE(sum(n.preco_unit * n.qtd) FILTER (WHERE n.computavel), 0) > 0
+      THEN round(
+             ( sum(n.preco_unit * n.qtd)  FILTER (WHERE n.computavel)
+             - sum(n.custo_unit  * n.qtd) FILTER (WHERE n.computavel) )
+             / sum(n.preco_unit * n.qtd)  FILTER (WHERE n.computavel) * 100
+           , 2)
+      ELSE NULL
+    END
+  FROM norm n
+  GROUP BY n.cid;
+$fn$;
+
+COMMENT ON FUNCTION private.margem_cliente_agregada() IS
+  'Fonte UNICA da margem bruta por cliente (order_items x omie_products x product_costs). '
+  'Consumida por get_customer_margin_summary (cron/service_role) e get_carteira_margem_faixa '
+  '(browser, via faixa). ausente<>zero nas TRES pernas: sem item computavel devolve NULL, nunca 0. '
+  'JOIN por omie_codigo_produto — product_id e nulo em 2,67% dos itens. Fechada por REVOKE; '
+  'o schema private fecha a rota do PostgREST mas NAO o EXECUTE (authenticated tem USAGE nele).';
+
+-- Fechamento por privilégio. Função nova nasce com `proacl = NULL` = EXECUTE implícito a PUBLIC,
+-- e o default privilege do Supabase concede às roles nomeadas — revogar dos DOIS jeitos.
+REVOKE ALL ON FUNCTION private.margem_cliente_agregada() FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.margem_cliente_agregada() FROM anon;
+REVOKE ALL ON FUNCTION private.margem_cliente_agregada() FROM authenticated;
+GRANT EXECUTE ON FUNCTION private.margem_cliente_agregada() TO service_role;
+-- Sem USAGE no schema, o GRANT de EXECUTE é decorativo num banco novo: `has_function_privilege`
+-- olha só o ACL da função e devolveria `t` para uma role que na prática não alcança a função
+-- (achado Codex xhigh). Em prod o USAGE já existe; aqui é para o objeto ser autossuficiente.
+GRANT USAGE ON SCHEMA private TO service_role;
+
+COMMIT;


### PR DESCRIPTION
## Por que este PR existe

Duas sessões paralelas construíram, cada uma, **o cálculo server-side da margem por cliente**:

- **#1495** — `get_customer_margin_summary()`, `service_role`, alimenta o cron que popula `farmer_client_scores.gross_margin_pct` (hoje 0 para 6.632/6.632 linhas).
- **FU4-F fase 3** (`feat/authz-fu4f-fase3-farmer-scoring-custo`) — `get_carteira_margem_faixa()`, devolve a **faixa** ao browser para o `useFarmerScoring` parar de baixar `product_costs` (3.637 linhas) ao cliente.

Rodei as duas lógicas lado a lado sobre a produção:

| | |
|---|---|
| clientes | 1.215 |
| margem numérica diverge | 461 |
| divergem em *ser calculável* (NULL × número) | 310 |
| **caem em FAIXA diferente** | **346 (28,5%)** |
| maior delta | **112,57 pontos percentuais** |

Duas autoridades money-path discordando no sinal que o vendedor vê. Este PR é a fonte única de que ambas passam a derivar.

## Decisão 1 — o JOIN é por `omie_codigo_produto`

`order_items.product_id` é **NULO em 1.837 de 68.700 itens (2,67%)**. Desses, **783 TÊM custo conhecido** alcançável por `omie_codigo_produto`, carregando **R$ 247.482,10** de receita — que um JOIN por `product_id` classifica como "sem custo".

`omie_codigo_produto` é 100% preenchido e único em `omie_products` (7.962/7.962, 1 account por código), então não duplica linha. É a lição *ausente ≠ zero* aplicada à **junção**: item que não junta não é item sem custo.

⚠️ **Para o #1495:** é a única mudança de comportamento ao absorver este helper. O comentário de lá diz *"order_items (tabela normalizada, com product_id real)"* — a medição não sustenta o "real".

## Decisão 2 — o filtro de status preserva o comportamento vivo, de propósito

⚠️ **Ele está errado, e isso é deliberado.** O universo real de `sales_orders.status`:

| status | pedidos | o scoring vê? |
|---|---|---|
| `faturado` | 20.182 | ✅ |
| `importado` | 5.269 | ❌ |
| `separacao` | 2.760 | ❌ |
| `enviado` | 2.005 | ❌ |
| `cancelado`/`orcamento`/`rascunho` | 17 | corretamente fora |

**`confirmado` e `entregue` não existem — zero linhas.** O allowlist de `useFarmerScoring.ts:147` faz o scoring vivo enxergar só `faturado`: **20.182 de 30.216 pedidos reais, faltando 33% da base** — e não só para a margem (recência, frequência, spend e mix saem do mesmo universo).

Corrigir muda o score de **todo** cliente, então é **PR próprio com baseline medido** (decisão do dono, 2026-07-21). Concentrar o filtro aqui faz aquela correção ser **uma** mudança visível e reversível, em **um** lugar, valendo para os dois consumidores de uma vez.

## Superfície

Vive em `private` — helper `SECURITY DEFINER` em schema exposto é **oráculo** consultável por qualquer autenticado (lição do FU7). Fechado também por privilégio: `REVOKE` de `PUBLIC`, `anon` e `authenticated` (função nova nasce com `proacl = NULL` = EXECUTE implícito a PUBLIC), `GRANT` só a `service_role`. Os consumidores são SECDEF com owner `postgres` e o alcançam sem grant.

## Prova

`db/test-margem-cliente-helper-compartilhado.sh` — **15 asserts, 3 falsificações**, baseline verde antes de cada uma e migration restaurada byte a byte depois:

| falsificação | vermelhos esperados | resultado |
|---|---|---|
| F1 — trocar o JOIN para `product_id` (a lógica do #1495) | só o `H1` | `H1` + `M1` (que re-mede o mesmo valor) |
| F2 — `ELSE NULL` vira `ELSE 0` (fabricar zero) | `I1` + `I2` | `I1` + `I2` |
| F3 — remover o guard `custo > 0` | só o `I2` | `I2` |

O seed dá `product_id` preenchido a todos os itens **exceto** o do caso H1 — sem isso a F1 derrubaria o harness inteiro e não provaria nada de específico.

## ⚠️ Migration manual

`20260726150000_margem_cliente_helper_compartilhado.sql` — nome custom **não** auto-aplica no Lovable. Colar no SQL Editor → Run.

Aplicar este helper sozinho é **inerte**: ele não tem consumidor até o #1495 (ou o FU4-F fase 3) passar a chamá-lo. Pode entrar antes dos dois sem efeito em produção.

## Ordem sugerida

1. Este PR (helper, inerte)
2. #1495 passa a derivar dele — perde o JOIN por `product_id`, ganha os R$ 247k
3. FU4-F fase 3 consome o mesmo helper para a faixa
4. Chip "Corrigir filtro de status do scoring do farmer" — muda o allowlist num lugar só