### PR TITLE
feat(cron): cria `tactical-plans-batch-nightly` + regenera o baseline (75→81)

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **422** custom migrations totais
-- **1480** objetos esperados (criados por estas migrations)
+- **423** custom migrations totais
+- **1487** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 426
   - `rls_policy`: 380
   - `index`: 224
-  - `cron_job`: 150
+  - `cron_job`: 157
   - `table`: 147
   - `trigger`: 79
   - `view`: 70
@@ -952,6 +952,7 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `cron_job` | `cron.afiacao_ciclo_oportunidade_diario` | — |
+| `cron_job` | `cron.afiacao_customer_metrics_refresh_6h` | — |
 | `cron_job` | `cron.afiacao_dispatch_notificacoes_30min` | — |
 | `cron_job` | `cron.afiacao_estados_eventos_diarios` | — |
 | `cron_job` | `cron.afiacao_limpeza_sugestoes_mensal` | — |
@@ -985,8 +986,9 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `cron_job` | `cron.fin-sync-watchdog` | — |
 | `cron_job` | `cron.gerar-pedidos-diario-oben` | — |
 | `cron_job` | `cron.gerar-pedidos-intraday-oben` | — |
-| `cron_job` | `cron.monthly-tool-report` | — |
 | `cron_job` | `cron.nao-vinculados-refresh-diario` | — |
+| `cron_job` | `cron.omie-nfe-recebimento-import-1h` | — |
+| `cron_job` | `cron.omie-nfe-reconcile-1h` | — |
 | `cron_job` | `cron.omie-sync-estoque-diario` | — |
 | `cron_job` | `cron.omie-sync-estoque-intraday-oben` | — |
 | `cron_job` | `cron.omie-sync-metadados-daily` | — |
@@ -1000,14 +1002,18 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `cron_job` | `cron.reposicao-classificar-sayerlack-grupo` | — |
 | `cron_job` | `cron.reposicao-cold-start-parametros` | — |
 | `cron_job` | `cron.reposicao-depara-sayerlack-auto-diario` | — |
+| `cron_job` | `cron.reposicao-embalagem-cadastro-wp-daily` | — |
 | `cron_job` | `cron.reposicao-param-auto-resumo` | — |
 | `cron_job` | `cron.reposicao-param-limbo-watchdog` | — |
 | `cron_job` | `cron.reposicao-preencher-parametros-faltantes` | — |
 | `cron_job` | `cron.reposicao-refresh-descricao-diario` | — |
+| `cron_job` | `cron.sayerlack-captura-precos-mensal` | — |
 | `cron_job` | `cron.sayerlack-portal-watchdog` | — |
 | `cron_job` | `cron.sayerlack-retry-orfaos` | — |
 | `cron_job` | `cron.scoring-recalc-batch-nightly` | — |
 | `cron_job` | `cron.sync-colacor-vendas-products` | — |
+| `cron_job` | `cron.sync-customers-colacor-vendas-daily` | — |
+| `cron_job` | `cron.sync-customers-servicos-daily` | — |
 | `cron_job` | `cron.sync-customers-vendas-daily` | — |
 | `cron_job` | `cron.sync-inventory-colacor-vendas-1h` | — |
 | `cron_job` | `cron.sync-inventory-servicos-1h` | — |
@@ -3565,6 +3571,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.tint_promote_sync_run` | — |
+
+### `20260726120001_cron_tactical_plans_batch_nightly.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.tactical-plans-batch-nightly` | — |
 
 ### `20260726130000_vendas_sync_semear_janela.sql`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 422
+-- Total de custom migrations: 423
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -462,6 +462,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260724130000', 'authz_custo_fu4f_fase3_recommend', '20260724130000_authz_custo_fu4f_fase3_recommend.sql'),
   ('20260724130000', 'tint_canonica_csv_legado_allowlist', '20260724130000_tint_canonica_csv_legado_allowlist.sql'),
   ('20260726120000', 'tint_promote_error_details_completo', '20260726120000_tint_promote_error_details_completo.sql'),
+  ('20260726120001', 'cron_tactical_plans_batch_nightly', '20260726120001_cron_tactical_plans_batch_nightly.sql'),
   ('20260726130000', 'vendas_sync_semear_janela', '20260726130000_vendas_sync_semear_janela.sql'),
   ('20260726140000', 'vendas_sync_semear_janela_v2', '20260726140000_vendas_sync_semear_janela_v2.sql')
 ),
@@ -912,6 +913,7 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('data_health_watchdog', 'function', 'public', 'fin_sync_heartbeat', ''),
   ('data_health_watchdog', 'cron_job', 'cron', 'data-health-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_ciclo_oportunidade_diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_dispatch_notificacoes_30min', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_estados_eventos_diarios', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_limpeza_sugestoes_mensal', ''),
@@ -945,8 +947,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('cron_baseline', 'cron_job', 'cron', 'fin-sync-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'gerar-pedidos-diario-oben', ''),
   ('cron_baseline', 'cron_job', 'cron', 'gerar-pedidos-intraday-oben', ''),
-  ('cron_baseline', 'cron_job', 'cron', 'monthly-tool-report', ''),
   ('cron_baseline', 'cron_job', 'cron', 'nao-vinculados-refresh-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-nfe-recebimento-import-1h', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-nfe-reconcile-1h', ''),
   ('cron_baseline', 'cron_job', 'cron', 'omie-sync-estoque-diario', ''),
   ('cron_baseline', 'cron_job', 'cron', 'omie-sync-estoque-intraday-oben', ''),
   ('cron_baseline', 'cron_job', 'cron', 'omie-sync-metadados-daily', ''),
@@ -960,14 +963,18 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-classificar-sayerlack-grupo', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-cold-start-parametros', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-depara-sayerlack-auto-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'reposicao-embalagem-cadastro-wp-daily', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-param-auto-resumo', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-param-limbo-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-preencher-parametros-faltantes', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-refresh-descricao-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sayerlack-captura-precos-mensal', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sayerlack-portal-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sayerlack-retry-orfaos', ''),
   ('cron_baseline', 'cron_job', 'cron', 'scoring-recalc-batch-nightly', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-colacor-vendas-products', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-customers-colacor-vendas-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-customers-servicos-daily', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-customers-vendas-daily', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-inventory-colacor-vendas-1h', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-inventory-servicos-1h', ''),
@@ -1931,6 +1938,7 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('authz_custo_fu4f_fase3_recommend', 'rls_policy', 'public', 'recommendation_log_select_custo', 'recommendation_log'),
   ('tint_canonica_csv_legado_allowlist', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
+  ('cron_tactical_plans_batch_nightly', 'cron_job', 'cron', 'tactical-plans-batch-nightly', ''),
   ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', ''),
   ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', '')
 ),
@@ -2429,6 +2437,7 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('data_health_watchdog', 'function', 'public', 'fin_sync_heartbeat', ''),
   ('data_health_watchdog', 'cron_job', 'cron', 'data-health-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_ciclo_oportunidade_diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'afiacao_customer_metrics_refresh_6h', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_dispatch_notificacoes_30min', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_estados_eventos_diarios', ''),
   ('cron_baseline', 'cron_job', 'cron', 'afiacao_limpeza_sugestoes_mensal', ''),
@@ -2462,8 +2471,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('cron_baseline', 'cron_job', 'cron', 'fin-sync-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'gerar-pedidos-diario-oben', ''),
   ('cron_baseline', 'cron_job', 'cron', 'gerar-pedidos-intraday-oben', ''),
-  ('cron_baseline', 'cron_job', 'cron', 'monthly-tool-report', ''),
   ('cron_baseline', 'cron_job', 'cron', 'nao-vinculados-refresh-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-nfe-recebimento-import-1h', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'omie-nfe-reconcile-1h', ''),
   ('cron_baseline', 'cron_job', 'cron', 'omie-sync-estoque-diario', ''),
   ('cron_baseline', 'cron_job', 'cron', 'omie-sync-estoque-intraday-oben', ''),
   ('cron_baseline', 'cron_job', 'cron', 'omie-sync-metadados-daily', ''),
@@ -2477,14 +2487,18 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-classificar-sayerlack-grupo', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-cold-start-parametros', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-depara-sayerlack-auto-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'reposicao-embalagem-cadastro-wp-daily', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-param-auto-resumo', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-param-limbo-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-preencher-parametros-faltantes', ''),
   ('cron_baseline', 'cron_job', 'cron', 'reposicao-refresh-descricao-diario', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sayerlack-captura-precos-mensal', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sayerlack-portal-watchdog', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sayerlack-retry-orfaos', ''),
   ('cron_baseline', 'cron_job', 'cron', 'scoring-recalc-batch-nightly', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-colacor-vendas-products', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-customers-colacor-vendas-daily', ''),
+  ('cron_baseline', 'cron_job', 'cron', 'sync-customers-servicos-daily', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-customers-vendas-daily', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-inventory-colacor-vendas-1h', ''),
   ('cron_baseline', 'cron_job', 'cron', 'sync-inventory-servicos-1h', ''),
@@ -3448,6 +3462,7 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('authz_custo_fu4f_fase3_recommend', 'rls_policy', 'public', 'recommendation_log_select_custo', 'recommendation_log'),
   ('tint_canonica_csv_legado_allowlist', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
+  ('cron_tactical_plans_batch_nightly', 'cron_job', 'cron', 'tactical-plans-batch-nightly', ''),
   ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', ''),
   ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', '')
 )

--- a/supabase/migrations/20260527230000_cron_baseline.sql
+++ b/supabase/migrations/20260527230000_cron_baseline.sql
@@ -1,9 +1,9 @@
 -- ============================================================
--- BASELINE DE CRONS — snapshot da topologia de pg_cron (regenerado 2026-07-04)
+-- BASELINE DE CRONS — snapshot da topologia de pg_cron (regenerado 2026-07-21)
 -- ============================================================
 -- LIÇÃO DO INCIDENTE 2026-05-27: o cron de vendas (omie-vendas-sync sync_pedidos) se perdeu
 -- porque vivia SÓ no banco, nunca versionado → sumiu sem rastro e vendas ficou morto 8 dias.
--- Esta migration versiona TODOS os 75 crons ativos como safety net: se um sumir, re-rodar o
+-- Esta migration versiona TODOS os 81 crons ativos como safety net: se um sumir, re-rodar o
 -- statement correspondente restaura. cron.schedule faz upsert por nome (idempotente).
 --
 -- GERADO automaticamente a partir de cron.job (active=true) via:
@@ -11,7 +11,7 @@
 --          regexp_replace(command,'\s+',' ','g')), E'\n\n' ORDER BY jobname) FROM cron.job WHERE active;
 -- ⚠️ O regexp_replace ACHATA o whitespace do command (1 statement/linha) → o arquivo é LOSSY nesse
 --    aspecto: um command com whitespace SIGNIFICATIVO (texto de e-mail, markdown, regex, JSON com
---    espaços intencionais) seria reescrito. Hoje os 75 são whitespace-insensíveis (SQL/DO/URL/JSON
+--    espaços intencionais) seria reescrito. Hoje os 81 são whitespace-insensíveis (SQL/DO/URL/JSON
 --    compacto) — reavaliar se um cron futuro carregar texto sensível a espaço.
 -- NÃO editar à mão. REGENERAR quando a topologia mudar (rodar o generator de novo e substituir).
 -- NÃO precisa ser aplicada agora (os crons já existem em prod) — é artefato de recuperação.
@@ -19,7 +19,10 @@
 -- (reseta o histórico em job_run_details) — por isso só aplicar sob demanda, não de rotina.
 -- ============================================================
 
+
 SELECT cron.schedule('afiacao_ciclo_oportunidade_diario', '5 11 * * *', 'SELECT public.ciclo_oportunidade_do_dia(''OBEN'');');
+
+SELECT cron.schedule('afiacao_customer_metrics_refresh_6h', '15 */6 * * *', 'SELECT public.refresh_customer_metrics()');
 
 SELECT cron.schedule('afiacao_dispatch_notificacoes_30min', '*/30 * * * *', ' select net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/dispatch-notifications'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'') ), body := ''{}''::jsonb, timeout_milliseconds := 60000 ); ');
 
@@ -87,9 +90,11 @@ SELECT cron.schedule('gerar-pedidos-diario-oben', '15 9 * * *', ' SELECT net.htt
 
 SELECT cron.schedule('gerar-pedidos-intraday-oben', '15 10,12,14,16,18,20 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/gerar-pedidos-diario'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"empresa":"OBEN","intraday":true}''::jsonb, timeout_milliseconds := 150000 ) AS request_id; ');
 
-SELECT cron.schedule('monthly-tool-report', '0 9 1 * *', ' SELECT net.http_post(url:=''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/monthly-report'', headers:=jsonb_build_object(''Content-Type'',''application/json'',''x-cron-secret'',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'')), body:=''{"send_email": true}''::jsonb,timeout_milliseconds:=150000);');
-
 SELECT cron.schedule('nao-vinculados-refresh-diario', '30 8 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = ''CRON_SECRET'' LIMIT 1) ), body := jsonb_build_object(''action'', ''start_nao_vinculados'', ''account'', ''vendas''), timeout_milliseconds := 60000 ); ');
+
+SELECT cron.schedule('omie-nfe-recebimento-import-1h', '50 10-22 * * 1-6', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-nfe-recebimento-sync'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{}''::jsonb, timeout_milliseconds := 150000 ); ');
+
+SELECT cron.schedule('omie-nfe-reconcile-1h', '10 11-23 * * 1-6', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-nfe-reconcile'', headers := jsonb_build_object(''Content-Type'',''application/json'',''x-cron-secret'',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1)), body := ''{}''::jsonb, timeout_milliseconds := 150000); ');
 
 SELECT cron.schedule('omie-sync-estoque-diario', '0 9 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-sync-estoque'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"empresa": "OBEN"}''::jsonb, timeout_milliseconds := 90000 ) AS request_id; ');
 
@@ -117,6 +122,8 @@ SELECT cron.schedule('reposicao-cold-start-parametros', '15 8 * * *', ' SELECT p
 
 SELECT cron.schedule('reposicao-depara-sayerlack-auto-diario', '0 4 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/reposicao-depara-sayerlack-auto'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), timeout_milliseconds := 120000 ); ');
 
+SELECT cron.schedule('reposicao-embalagem-cadastro-wp-daily', '0 9 * * *', 'SELECT public.reposicao_sincronizar_embalagem_wp(''oben'')');
+
 SELECT cron.schedule('reposicao-param-auto-resumo', '0 21 * * *', ' SELECT public.reposicao_param_auto_resumo_tick(); ');
 
 SELECT cron.schedule('reposicao-param-limbo-watchdog', '30 11 * * *', ' SELECT public.reposicao_param_limbo_watchdog(); ');
@@ -125,6 +132,8 @@ SELECT cron.schedule('reposicao-preencher-parametros-faltantes', '0 8 * * *', ' 
 
 SELECT cron.schedule('reposicao-refresh-descricao-diario', '45 8 * * *', ' SELECT public.atualizar_descricao_sku_parametros(''OBEN''); ');
 
+SELECT cron.schedule('sayerlack-captura-precos-mensal', '0 9 10-12 * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/sayerlack-captura-precos'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"modo":"full","empresa":"oben"}''::jsonb, timeout_milliseconds := 395000 ); ');
+
 SELECT cron.schedule('sayerlack-portal-watchdog', '*/5 * * * *', ' SELECT net.http_post(url:=''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/enviar-pedido-portal-sayerlack'', headers:=jsonb_build_object(''Content-Type'',''application/json'',''x-cron-secret'',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1)), body:=jsonb_build_object(''watchdog'',true,''minutos'',5),timeout_milliseconds:=150000);');
 
 SELECT cron.schedule('sayerlack-retry-orfaos', '*/15 * * * *', ' SELECT public.sayerlack_retry_orfaos(); ');
@@ -132,6 +141,10 @@ SELECT cron.schedule('sayerlack-retry-orfaos', '*/15 * * * *', ' SELECT public.s
 SELECT cron.schedule('scoring-recalc-batch-nightly', '0 6 * * *', 'SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/scoring-recalc-batch'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = ''CRON_SECRET'' LIMIT 1) ), timeout_milliseconds := 55000 );');
 
 SELECT cron.schedule('sync-colacor-vendas-products', '15 6 * * *', ' SELECT net.http_post(url:=''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync'', headers:=jsonb_build_object(''Content-Type'',''application/json'',''x-cron-secret'',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'')), body:=''{"action": "sync_products", "account": "colacor_vendas", "max_pages": 50}''::jsonb,timeout_milliseconds:=150000);');
+
+SELECT cron.schedule('sync-customers-colacor-vendas-daily', '20 5 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"action":"sync_customers","account":"colacor_vendas"}''::jsonb, timeout_milliseconds := 60000 ); ');
+
+SELECT cron.schedule('sync-customers-servicos-daily', '40 5 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"action":"sync_customers","account":"servicos"}''::jsonb, timeout_milliseconds := 60000 ); ');
 
 SELECT cron.schedule('sync-customers-vendas-daily', '0 5 * * *', ' SELECT net.http_post( url := ''https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-analytics-sync'', headers := jsonb_build_object( ''Content-Type'', ''application/json'', ''x-cron-secret'', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name=''CRON_SECRET'' LIMIT 1) ), body := ''{"action":"sync_customers","account":"vendas"}''::jsonb, timeout_milliseconds := 60000 ); ');
 

--- a/supabase/migrations/20260726120001_cron_tactical_plans_batch_nightly.sql
+++ b/supabase/migrations/20260726120001_cron_tactical_plans_batch_nightly.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- cron `tactical-plans-batch-nightly` — pré-geração noturna dos planos táticos
+--
+-- Cria o agendamento que faltava para a edge `tactical-plans-batch`. A edge está deployada e
+-- respondendo em produção desde #1422/#1498 (confirmado 2026-07-21: POST sem secret → 401, o
+-- gate `authorizeCron` funcionando), mas nunca teve cron — rodava só sob invocação manual.
+--
+-- ⚠️ SCHEDULE É UTC, não BRT — `cron.timezone` está vazio no projeto (#1510). '0 8 * * *'
+-- dispara às 05:00 BRT. É o primeiro slot DEPOIS de todas as dependências do batch:
+--   06:00 UTC `daily-calculate-scores`           → grava os scores que o gate de R$/h consome
+--   06:00 UTC `scoring-recalc-batch-nightly`     → recalcula priority_score
+--   07:00 UTC `visit-score-recalc-batch-nightly` → recalcula o score de visita
+--   07:30 UTC `carteira-rebuild-nightly`         → reconstrói carteira_assignments, a allowlist
+--                                                  de elegíveis que o batch lê no passo 0
+-- Antecipar o horário faz o batch ler a margem e a carteira do dia anterior.
+--
+-- Secret vem do VAULT. NUNCA `current_setting('app.cron_shared_key', true)`: essa GUC não existe
+-- no projeto, o `true` (missing_ok) devolve NULL calado, o header sai nulo e a edge responde 401
+-- — com `cron.job_run_details` marcando `succeeded`, porque só registra o ENQUEUE do
+-- net.http_post (a verdade HTTP está em `net._http_response`). Ver #1513/#1516.
+--
+-- `timeout_milliseconds := 150000` (teto padrão da casa, docs/agent/sync.md): 3 vendedoras ×
+-- top-25 = ≤75 chamadas LLM com CONCURRENCY 5 → ~15 chunks de ~5s. O default do pg_net é 5s e
+-- mataria o batch em silêncio.
+--
+-- `cron.schedule` faz upsert por nome → idempotente, pode rerodar sem duplicar.
+-- ============================================================
+
+SELECT cron.schedule(
+  'tactical-plans-batch-nightly',
+  '0 8 * * *',
+  $$SELECT net.http_post(
+      url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/tactical-plans-batch',
+      headers := jsonb_build_object(
+        'Content-Type', 'application/json',
+        'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
+      ),
+      body := '{"triggered_by":"cron"}'::jsonb,
+      timeout_milliseconds := 150000
+  );$$
+);


### PR DESCRIPTION
Fecha o versionamento dos crons. O pedido era "versionar os 3", mas a apuração mostrou que só **um** deles tinha o que fazer:

| Cron | Situação | Ação |
|---|---|---|
| `scoring-recalc-batch-nightly` | já versionado 2× ([migration dedicada](supabase/migrations/20260524095612_crons_scoring_visit_lendo_cron_secret_do_vault.sql) + baseline) | nenhuma |
| `visit-score-recalc-batch-nightly` | idem | nenhuma |
| `tactical-plans-batch-nightly` | **não existia em produção** | **criar o cron** |

## 1. Cron novo

A edge `tactical-plans-batch` está deployada e respondendo desde #1422/#1498 — confirmado com `POST` sem secret → **401**, ou seja, o `authorizeCron` funcionando. Mas nunca teve agendamento: rodava só sob invocação manual.

`'0 8 * * *'` **é UTC** (`cron.timezone` vazio, #1510) = **05:00 BRT** — o primeiro slot depois das 4 dependências a montante (`calculate-scores` 06:00, `scoring` 06:00, `visit-score` 07:00, `carteira-rebuild` 07:30, todos UTC). Antecipar faz o batch ler margem e carteira do dia anterior.

Secret do vault; `timeout 150000` (3 vendedoras × top-25 = ≤75 chamadas LLM, `CONCURRENCY 5` → ~15 chunks de ~5s; o default do `pg_net` é 5s).

O corpo do `net.http_post` é **idêntico ao comentário mergeado em #1513** — comparação normalizada, comparador falsificado em 4 sabotagens.

> A 1ª versão do comparador dava **VERDE com o timeout sabotado** (truncava no primeiro parêntese). A falsificação pegou; sem ela eu teria afirmado equivalência com um teste cego a metade do conteúdo.

## 2. Baseline regenerado (75 → 81)

Estava stale ~2 semanas. **7 crons ativos fora dele**: `afiacao_customer_metrics_refresh_6h`, `omie-nfe-recebimento-import-1h`, `omie-nfe-reconcile-1h`, `reposicao-embalagem-cadastro-wp-daily`, `sayerlack-captura-precos-mensal`, `sync-customers-colacor-vendas-daily`, `sync-customers-servicos-daily`. E `monthly-tool-report` dentro dele apesar de pausado hoje (`active=false` → sai; o baseline versiona só `WHERE active`).

Gerado pelo generator do próprio header contra prod, header preservado com as contagens atualizadas — deixar "75" no texto seria mais um comentário mentindo. Os 7 novos passaram pela checagem de **whitespace significativo** que o header pede antes de confiar no `regexp_replace`: todos SQL/URL/JSON compacto.

## Pré-voos e gates

| Check | Resultado |
|---|---|
| `wt:preflight --full` | 🟢 sem colisão (97.367 objetos concorrentes) |
| PROD (`psql-ro`): vault `CRON_SECRET` | ✅ existe |
| PROD: `pg_cron` / `pg_net` | ✅ ativas |
| PROD: cron já existe? | ✅ não |
| PROD: respostas HTTP 24h | ✅ 204, **todas 2xx** |
| `authz:check` | exit **0** |
| `claude:size` | exit **0** |
| `audit:migrations` | exit **0** (423 migrations) |

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260726120001_cron_tactical_plans_batch_nightly.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor e rodar.

O baseline (`20260527230000`) **não** precisa ser aplicado: é artefato de recuperação.

<details><summary>SQL pra aplicar</summary>

```sql
-- ============================================================
-- cron `tactical-plans-batch-nightly` — pré-geração noturna dos planos táticos
--
-- Cria o agendamento que faltava para a edge `tactical-plans-batch`. A edge está deployada e
-- respondendo em produção desde #1422/#1498 (confirmado 2026-07-21: POST sem secret → 401, o
-- gate `authorizeCron` funcionando), mas nunca teve cron — rodava só sob invocação manual.
--
-- ⚠️ SCHEDULE É UTC, não BRT — `cron.timezone` está vazio no projeto (#1510). '0 8 * * *'
-- dispara às 05:00 BRT. É o primeiro slot DEPOIS de todas as dependências do batch:
--   06:00 UTC `daily-calculate-scores`           → grava os scores que o gate de R$/h consome
--   06:00 UTC `scoring-recalc-batch-nightly`     → recalcula priority_score
--   07:00 UTC `visit-score-recalc-batch-nightly` → recalcula o score de visita
--   07:30 UTC `carteira-rebuild-nightly`         → reconstrói carteira_assignments, a allowlist
--                                                  de elegíveis que o batch lê no passo 0
-- Antecipar o horário faz o batch ler a margem e a carteira do dia anterior.
--
-- Secret vem do VAULT. NUNCA `current_setting('app.cron_shared_key', true)`: essa GUC não existe
-- no projeto, o `true` (missing_ok) devolve NULL calado, o header sai nulo e a edge responde 401
-- — com `cron.job_run_details` marcando `succeeded`, porque só registra o ENQUEUE do
-- net.http_post (a verdade HTTP está em `net._http_response`). Ver #1513/#1516.
--
-- `timeout_milliseconds := 150000` (teto padrão da casa, docs/agent/sync.md): 3 vendedoras ×
-- top-25 = ≤75 chamadas LLM com CONCURRENCY 5 → ~15 chunks de ~5s. O default do pg_net é 5s e
-- mataria o batch em silêncio.
--
-- `cron.schedule` faz upsert por nome → idempotente, pode rerodar sem duplicar.
-- ============================================================

SELECT cron.schedule(
  'tactical-plans-batch-nightly',
  '0 8 * * *',
  $$SELECT net.http_post(
      url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/tactical-plans-batch',
      headers := jsonb_build_object(
        'Content-Type', 'application/json',
        'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'CRON_SECRET' LIMIT 1)
      ),
      body := '{"triggered_by":"cron"}'::jsonb,
      timeout_milliseconds := 150000
  );$$
);
```
</details>

Validação pós-apply:

```sql
SELECT CASE WHEN count(*) = 1
  THEN '✅ tactical-plans-batch-nightly criado — ' || max(schedule) || ' UTC'
  ELSE '❌ FALTANDO — migration não aplicada' END AS status
FROM cron.job WHERE jobname = 'tactical-plans-batch-nightly' AND active;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
