### PR TITLE
fix(farmer): margem ausente para de virar 0 nos consumidores de gross_margin_pct [money-path]

### DIFF
--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -18,7 +18,7 @@ import {
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { cn } from '@/lib/utils';
-import { decodeHtmlEntities } from '@/lib/format';
+import { decodeHtmlEntities, formatMargemPct } from '@/lib/format';
 import { formatBrPhone, whatsappLink } from '@/lib/phone';
 import { CallButton } from '@/components/call/CallButton';
 import { RecommendationsPanel } from '@/components/RecommendationsPanel';
@@ -191,7 +191,9 @@ export function Customer360View({
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-3 md:grid-cols-5 gap-3">
-                <ScoreItem label="Margem" value={`${(score.gross_margin_pct * 100).toFixed(1)}%`} />
+                {/* Sem `* 100`: a coluna já é percentual. Com a margem calculada no servidor,
+                    53,47 viraria "5347.0%" — e `null` virava "0.0%", afirmando margem nula. */}
+                <ScoreItem label="Margem" value={formatMargemPct(score.gross_margin_pct)} />
                 <ScoreItem label="Expansão" value={score.expansion_score.toFixed(1)} />
                 <ScoreItem label="Prioridade" value={score.priority_score.toFixed(1)} />
                 <ScoreItem label="Dias s/ compra" value={String(score.days_since_last_purchase)} danger={score.days_since_last_purchase > 60} />

--- a/src/components/adminCustomers/types.ts
+++ b/src/components/adminCustomers/types.ts
@@ -40,7 +40,8 @@ export interface ClientScore {
   avg_monthly_spend_180d: number;
   days_since_last_purchase: number;
   category_count: number;
-  gross_margin_pct: number;
+  /** PERCENTUAL (0–100, negativo válido). `null` = não apurada — jamais tratar como 0. */
+  gross_margin_pct: number | null;
   avg_repurchase_interval?: number | null;
   sales_history_status: string | null;
 }

--- a/src/components/customer360/CustomerHero.tsx
+++ b/src/components/customer360/CustomerHero.tsx
@@ -10,9 +10,10 @@ import { CallButton } from '@/components/call/CallButton';
 import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { formatMargemPct } from '@/lib/format';
 import { whatsappLink } from '@/lib/phone';
 import {
-  formatPctMaybe, formatDateOrDash, initials, healthTone, churnTone, formatDocument,
+  formatDateOrDash, initials, healthTone, churnTone, formatDocument,
 } from './format';
 import type { Customer, CustomerScore } from './viewTypes';
 
@@ -138,15 +139,19 @@ export function CustomerHero({
                 <span
                   className={cn(
                     'inline-flex items-center gap-1.5 px-2 py-1 rounded-md border',
-                    s.gross_margin_pct >= 0.3
+                    // Limiares em PERCENTUAL (30 / 15), não em fração (0.3 / 0.15): a coluna é
+                    // percentual, como useTacticalPlan e useBundleArguments já assumem. Com 0.3 a
+                    // faixa nunca discriminava — qualquer margem real (ex.: 53,47) passa de 0.3 e
+                    // tudo ficava verde. Enquanto a coluna era 0 em toda a base isso não aparecia.
+                    s.gross_margin_pct >= 30
                       ? 'bg-status-success-bg text-status-success-bold border-status-success/20'
-                      : s.gross_margin_pct >= 0.15
+                      : s.gross_margin_pct >= 15
                         ? 'bg-status-warning-bg text-status-warning-bold border-status-warning/20'
                         : 'bg-status-error-bg text-status-error-bold border-status-error/20',
                   )}
                 >
                   <Activity className="w-3 h-3" />
-                  {formatPctMaybe(s.gross_margin_pct)} margem
+                  {formatMargemPct(s.gross_margin_pct)} margem
                 </span>
               )}
             </div>

--- a/src/components/customer360/__tests__/format.test.ts
+++ b/src/components/customer360/__tests__/format.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { formatPctMaybe } from '../format';
+
+/**
+ * `formatPctMaybe` adivinha a unidade (`v > 1 ? v : v * 100`) porque atende chamadores cuja
+ * origem é FRAÇÃO — ex.: `MinhasVisitasResultadoCard`, que usa o mesmo `pct` para a largura da
+ * barra (`pct * 100`).
+ *
+ * Estes testes fixam onde a heurística ACERTA e onde ela ERRA. O erro não é bug a corrigir aqui:
+ * é a razão de margem ter formatador próprio (`formatMargemPct`, em `@/lib/format`). Mudar a
+ * heurística para consertar o caso da margem quebraria os chamadores de fração.
+ */
+describe('formatPctMaybe', () => {
+  it('trata valor ≤ 1 como fração', () => {
+    expect(formatPctMaybe(0.3)).toBe('30%');
+    expect(formatPctMaybe(0.155)).toBe('15.5%');
+  });
+
+  it('trata valor > 1 como percentual já pronto', () => {
+    expect(formatPctMaybe(53.47)).toBe('53.5%');
+  });
+
+  it('devolve travessão para ausente', () => {
+    expect(formatPctMaybe(null)).toBe('—');
+    expect(formatPctMaybe(undefined)).toBe('—');
+    expect(formatPctMaybe(NaN)).toBe('—');
+  });
+
+  it('ERRA com percentual NEGATIVO — por isso margem não usa este formatador', () => {
+    // −143,22% é o mínimo real medido em farmer_client_scores. Como não passa no `> 1`, a
+    // heurística o multiplica por 100. Fixado como comportamento CONHECIDO, não como desejado:
+    // quem formata margem deve usar formatMargemPct (@/lib/format), que não adivinha.
+    expect(formatPctMaybe(-143.22)).toBe('-14322%');
+  });
+
+  it('ERRA com percentual menor que 1 — mesma raiz', () => {
+    // Margem real de 0,5% vira "50%".
+    expect(formatPctMaybe(0.5)).toBe('50%');
+  });
+});

--- a/src/components/customer360/format.ts
+++ b/src/components/customer360/format.ts
@@ -8,15 +8,23 @@ export function formatBRL(v: number | null | undefined): string {
   return BRL.format(v);
 }
 
+/**
+ * Percentual a partir de valor cuja unidade é AMBÍGUA (fração 0–1 ou percentual 0–100), decidida
+ * pela heurística `v > 1`. Usado onde a origem é fração — ex.: `MinhasVisitasResultadoCard`.
+ *
+ * ⚠️ NÃO use para margem: veja `formatMargemPct` em `@/lib/format`. A heurística erra em dois casos que a margem
+ * produz de verdade — margem menor que 1% (0,5 vira "50%") e margem NEGATIVA (−143,22, o mínimo
+ * medido em prod, não passa no `> 1` e vira "−14322%").
+ */
 export function formatPctMaybe(v: number | null | undefined): string {
   if (v === null || v === undefined || Number.isNaN(v)) return '—';
-  // Schema: gross_margin_pct vem como número (ex: 0.32 ou 32 — normalizamos)
   const pct = v > 1 ? v : v * 100;
   // Zero sem decimal ("0%" em vez de "0.0%"); outros valores com 1 decimal só se houver fração.
   if (pct === 0) return '0%';
   const rounded = Math.round(pct);
   return Math.abs(pct - rounded) < 0.05 ? `${rounded}%` : `${pct.toFixed(1)}%`;
 }
+
 
 /**
  * Profiles tem campo `email` text livre. Sincronização do Omie costuma concatenar

--- a/src/components/farmer/bundles/CustomerBundleCard.tsx
+++ b/src/components/farmer/bundles/CustomerBundleCard.tsx
@@ -26,7 +26,9 @@ export const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGe
   const individualLIE = data.bestIndividual?.lie || 0;
   const bundleWins = bestBundleLIE > individualLIE;
 
-  const profile = classifyCustomerProfile(data.healthScore, data.avgMonthlySpend || 0, data.grossMarginPct || 0, data.categoryCount || 0);
+  // grossMarginPct passa SEM `|| 0`: o guard dentro de classifyCustomerProfile só funciona se o
+  // null chegar até lá. Coagir aqui tornaria a correção inerte (a armadilha do #1508).
+  const profile = classifyCustomerProfile(data.healthScore, data.avgMonthlySpend || 0, data.grossMarginPct, data.categoryCount || 0);
   const profileInfo = profileLabels[profile];
 
   const customerCtx = {

--- a/src/components/farmer/tacticalPlan/EfficiencyAlertDialog.tsx
+++ b/src/components/farmer/tacticalPlan/EfficiencyAlertDialog.tsx
@@ -7,27 +7,41 @@ import type { PlanType } from '@/hooks/useTacticalPlan';
 import { fmt } from './config';
 
 interface EfficiencyAlertDialogProps {
-  alert: { customerId: string; profitPerHour: number; planType: PlanType } | null;
+  /** `profitPerHour: null` = margem não apurada → o R$/h é INDECIDÍVEL, não baixo. */
+  alert: { customerId: string; profitPerHour: number | null; planType: PlanType } | null;
   onClose: () => void;
   onConfirm: () => void;
 }
 
 export function EfficiencyAlertDialog({ alert, onClose, onConfirm }: EfficiencyAlertDialogProps) {
+  // Dois motivos distintos para o alerta e a vendedora precisa saber qual é: "este cliente rende
+  // pouco" é um veredito acionável; "não consegui calcular" é ausência de dado. Antes o `|| 0`
+  // exibia "R$ 0,00/h abaixo do limiar" nos dois casos — uma afirmação falsa no segundo.
+  const indecidivel = alert != null && alert.profitPerHour == null;
   return (
     <Dialog open={!!alert} onOpenChange={onClose}>
       <DialogContent className="max-w-xs">
         <DialogHeader>
           <DialogTitle className="text-sm flex items-center gap-2">
             <AlertCircle className="w-4 h-4 text-status-warning" />
-            Potencial Baixo
+            {indecidivel ? 'Potencial não estimado' : 'Potencial Baixo'}
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
-          <p className="text-xs text-muted-foreground">
-            O lucro estimado por hora para este cliente é de{' '}
-            <strong className="text-foreground">{fmt(alert?.profitPerHour || 0)}/h</strong>,
-            abaixo do limiar recomendado de <strong className="text-foreground">{fmt(50)}/h</strong>.
-          </p>
+          {indecidivel ? (
+            <p className="text-xs text-muted-foreground">
+              Não foi possível estimar o lucro por hora deste cliente: a{' '}
+              <strong className="text-foreground">margem ainda não foi apurada</strong> (nenhum item
+              comprado tem custo conhecido). O limiar de referência é{' '}
+              <strong className="text-foreground">{fmt(50)}/h</strong>.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              O lucro estimado por hora para este cliente é de{' '}
+              <strong className="text-foreground">{fmt(alert?.profitPerHour ?? 0)}/h</strong>,
+              abaixo do limiar recomendado de <strong className="text-foreground">{fmt(50)}/h</strong>.
+            </p>
+          )}
           <p className="text-xs text-muted-foreground">Deseja continuar mesmo assim?</p>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" className="flex-1 text-xs" onClick={onClose}>

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -26,7 +26,7 @@ export function useFarmerTacticalPlan() {
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
   const [copiedText, setCopiedText] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
-  const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number; planType: PlanType } | null>(null);
+  const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number | null; planType: PlanType } | null>(null);
 
   useEffect(() => {
     if (user?.id && isStaff) {
@@ -67,7 +67,9 @@ export function useFarmerTacticalPlan() {
 
   const handleGenerateWithCheck = async (customerId: string, planType: PlanType) => {
     const check = await checkEfficiency(customerId);
-    if (!check.isAboveThreshold) {
+    // `isAboveThreshold` é tri-estado: false (reprovou) e null (indecidível) ambos abrem o dialog,
+    // que distingue os dois na mensagem. Só `true` gera direto.
+    if (check.isAboveThreshold !== true) {
       setEfficiencyAlert({ customerId, profitPerHour: check.estimatedProfitPerHour, planType });
       return;
     }

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Users, AlertTriangle, Layers } from 'lucide-react';
+import { mediaMargensConhecidas } from '@/lib/scoring/margin';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer } from 'recharts';
 import { KpiCard } from './KpiCard';
 
@@ -67,7 +68,11 @@ function IntelligenceManagerialTabImpl() {
   const farmerMetrics = Object.entries(farmerGroups).map(([farmerId, clients]) => {
     const avgHealth = clients.reduce((a, c) => a + Number(c.health_score || 0), 0) / clients.length;
     const atRisk = clients.filter(c => (c.health_class === 'critico' || c.health_class === 'atencao') && c.sales_history_status !== 'sem_historico').length;
-    const avgMargin = clients.reduce((a, c) => a + Number(c.gross_margin_pct || 0), 0) / clients.length;
+    // Só quem TEM margem entra — numerador e denominador. Com `|| 0` cada cliente sem margem
+    // medida entrava como 0 e puxava a média do farmer para baixo; desde o cálculo server-side
+    // isso valeria para a maioria da base, e o gestor compararia farmers por um número que mede
+    // cobertura de custo, não desempenho. `null` → a coluna mostra "—".
+    const avgMargin = mediaMargensConhecidas(clients.map(c => c.gross_margin_pct));
     const avgCategories = clients.reduce((a, c) => a + Number(c.category_count || 0), 0) / clients.length;
     const adoption = recoAdoption[farmerId];
     const adoptionPct = adoption && adoption.total > 0 ? (adoption.accepted / adoption.total * 100) : 0;
@@ -120,7 +125,11 @@ function IntelligenceManagerialTabImpl() {
                       <Badge variant={fm.avgHealth > 60 ? 'default' : 'destructive'} className="text-2xs">{fm.avgHealth.toFixed(0)}</Badge>
                     </td>
                     <td className="text-center py-2">{fm.atRisk}</td>
-                    <td className="text-center py-2">{fm.avgMargin.toFixed(1)}%</td>
+                    <td className="text-center py-2">
+                      {fm.avgMargin == null
+                        ? <span className="text-muted-foreground" title="Nenhum cliente deste farmer tem margem apurada">—</span>
+                        : `${fm.avgMargin.toFixed(1)}%`}
+                    </td>
                     <td className="text-center py-2">{fm.avgCategories.toFixed(1)}</td>
                     <td className="text-center py-2">
                       <span className={fm.avgCategories < globalAvgCategories ? 'text-destructive' : 'text-status-success'}>

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3, PieChart, ShieldCheck, RefreshCw
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { mediaMargensConhecidas } from '@/lib/scoring/margin';
 import { KpiCard } from './KpiCard';
 
 export function IntelligenceStrategicTab() {
@@ -104,9 +105,10 @@ export function IntelligenceStrategicTab() {
   const estimatedMarket = Math.max(uniqueCustomers * 3, 100);
   const marketSharePct = (uniqueCustomers / estimatedMarket * 100);
 
-  const avgGrossMargin = allScores?.length
-    ? allScores.reduce((a, c) => a + Number(c.gross_margin_pct || 0), 0) / allScores.length
-    : 0;
+  // Só as margens conhecidas entram na média (numerador E denominador). Com `|| 0`, cliente sem
+  // margem apurada entrava como 0 — e como esse é o caso da maioria da base desde o cálculo
+  // server-side, o KPI estratégico viraria uma medida de cobertura de custo disfarçada de margem.
+  const avgGrossMargin = mediaMargensConhecidas((allScores ?? []).map(c => c.gross_margin_pct));
 
   const [runningAlgoA, setRunningAlgoA] = useState(false);
   const runAlgoA = async () => {
@@ -153,7 +155,7 @@ export function IntelligenceStrategicTab() {
         <KpiCard title="LTV Projetado (3a)" value={`R$ ${ltvEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={BarChart3} subtitle="Estimativa média" />
         <KpiCard title="CAC Estimado" value={`R$ ${cacEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle="Custo aquisição cliente" />
         <KpiCard title="Concentração Top 20%" value={`${concentrationPct.toFixed(1)}%`} icon={PieChart} subtitle="da receita total" />
-        <KpiCard title="Margem Bruta Média" value={`${avgGrossMargin.toFixed(1)}%`} icon={Percent} />
+        <KpiCard title="Margem Bruta Média" value={avgGrossMargin == null ? '—' : `${avgGrossMargin.toFixed(1)}%`} icon={Percent} />
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/hooks/useBundleArguments.ts
+++ b/src/hooks/useBundleArguments.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import { margemConhecida } from '@/lib/scoring/margin';
 
 export interface BundleArgument {
   diagnostico: string;
@@ -15,16 +16,27 @@ export interface BundleArgument {
 
 export type CustomerProfile = 'sensivel_preco' | 'orientado_qualidade' | 'orientado_produtividade' | 'misto';
 
+/**
+ * Perfil comercial do cliente. Espelho de `classifyProfile` em
+ * `supabase/functions/_shared/tactical-margem.ts` — mudou aqui, mude lá.
+ *
+ * ⚠️ `grossMarginPct` aceita `null` ("não medida") e os dois primeiros ramos SÓ disparam com
+ * margem conhecida. Sem esse guard o JS fabrica o diagnóstico: `null < 20` é `true` (null coage
+ * a 0), então todo cliente de gasto baixo e margem desconhecida seria rotulado "sensível a
+ * preço" — e o rótulo muda a abordagem que a vendedora leva para a rua. Não é hipótese: desde o
+ * cálculo server-side da margem, 84% das linhas ficam com margem nula.
+ */
 export const classifyCustomerProfile = (
   healthScore: number,
   avgMonthlySpend: number,
-  grossMarginPct: number,
+  grossMarginPct: number | null,
   categoryCount: number
 ): CustomerProfile => {
+  const margem = margemConhecida(grossMarginPct);
   // Price-sensitive: low spend, low margin tolerance
-  if (avgMonthlySpend < 500 && grossMarginPct < 20) return 'sensivel_preco';
+  if (margem != null && avgMonthlySpend < 500 && margem < 20) return 'sensivel_preco';
   // Quality-oriented: high margin, fewer categories (focused buyer)
-  if (grossMarginPct > 35 && categoryCount <= 3) return 'orientado_qualidade';
+  if (margem != null && margem > 35 && categoryCount <= 3) return 'orientado_qualidade';
   // Productivity-oriented: high spend, many categories, high health
   if (avgMonthlySpend > 2000 && categoryCount >= 4 && healthScore > 60) return 'orientado_produtividade';
   return 'misto';

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -4,6 +4,7 @@ import type { Json } from '@/integrations/supabase/types';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
+import { margemConhecida } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -47,7 +48,9 @@ export interface CustomerBundles {
   bundles: BundleRecommendation[];
   bestIndividual: IndividualComparison | null;
   avgMonthlySpend: number;
-  grossMarginPct: number;
+  /** `null` = margem não apurada. NÃO trocar por 0: 0 classifica o cliente como "sensível a
+   *  preço" via `classifyCustomerProfile`, um veredito que a ausência de dado não sustenta. */
+  grossMarginPct: number | null;
   categoryCount: number;
   daysSinceLastPurchase: number;
   cnae: string;
@@ -528,7 +531,7 @@ export const useBundleEngine = () => {
             bundles: topBundles,
             bestIndividual,
             avgMonthlySpend: Number(score.avg_monthly_spend_180d || 0),
-            grossMarginPct: Number(score.gross_margin_pct || 0),
+            grossMarginPct: margemConhecida(score.gross_margin_pct),
             categoryCount: Number(score.category_count || 0),
             daysSinceLastPurchase: Number(score.days_since_last_purchase || 0),
             cnae: profile.cnae || '',

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
+import { margemConhecida } from '@/lib/scoring/margin';
 import { ownersAtivosDoAlvo } from '@/lib/carteira/escopo-clientes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
@@ -168,9 +169,11 @@ interface DiagnosticData {
 }
 
 export interface EfficiencyCheck {
-  estimatedProfitPerHour: number;
+  /** `null` = margem do cliente não apurada → R$/h indecidível (não é zero). */
+  estimatedProfitPerHour: number | null;
   threshold: number;
-  isAboveThreshold: boolean;
+  /** `null` = indecidível. Não afirma que passou NEM que reprovou no gate. */
+  isAboveThreshold: boolean | null;
 }
 
 const objectiveLabels: Record<string, string> = {
@@ -184,9 +187,14 @@ const objectiveLabels: Record<string, string> = {
 
 export const getObjectiveLabel = (obj: string) => objectiveLabels[obj] || obj;
 
-const classifyProfile = (healthScore: number, avgSpend: number, marginPct: number, categoryCount: number): string => {
-  if (avgSpend < 500 && marginPct < 20) return 'sensivel_preco';
-  if (marginPct > 35 && categoryCount <= 3) return 'orientado_qualidade';
+// Espelho de classifyProfile em supabase/functions/_shared/tactical-margem.ts (e de
+// classifyCustomerProfile em useBundleArguments.ts). ⚠️ Os dois primeiros ramos exigem margem
+// CONHECIDA: `null < 20` é `true` em JS, então sem o guard todo cliente de gasto baixo e margem
+// não apurada sairia como "sensível a preço" — e esse rótulo entra no prompt da IA.
+const classifyProfile = (healthScore: number, avgSpend: number, marginPct: number | null, categoryCount: number): string => {
+  const m = margemConhecida(marginPct);
+  if (m != null && avgSpend < 500 && m < 20) return 'sensivel_preco';
+  if (m != null && m > 35 && categoryCount <= 3) return 'orientado_qualidade';
   if (avgSpend > 2000 && categoryCount >= 4 && healthScore > 60) return 'orientado_produtividade';
   return 'misto';
 };
@@ -323,7 +331,8 @@ export const useTacticalPlan = () => {
 
   // Check efficiency before generating
   const checkEfficiency = useCallback(async (customerId: string): Promise<EfficiencyCheck> => {
-    if (!user?.id) return { estimatedProfitPerHour: 0, threshold: PROFIT_PER_HOUR_THRESHOLD, isAboveThreshold: false };
+    // Sem sessão também é "não avaliei", não "reprovou" — mesmo tri-estado do resto.
+    if (!user?.id) return { estimatedProfitPerHour: null, threshold: PROFIT_PER_HOUR_THRESHOLD, isAboveThreshold: null };
 
     const { data: score } = (await supabase
       .from('farmer_client_scores')
@@ -335,15 +344,22 @@ export const useTacticalPlan = () => {
 
     const revPotential = Number(score?.revenue_potential || 0);
     const avgSpend = Number(score?.avg_monthly_spend_180d || 0);
-    const marginPct = Number(score?.gross_margin_pct || 0);
-    const estimatedMarginPerCall = (revPotential > 0 ? revPotential : avgSpend) * (marginPct / 100) * 0.1;
+    // Margem desconhecida → R$/h INDECIDÍVEL, não zero. Com `|| 0` o gate reprovava o cliente por
+    // omissão, e "não sei" ficava indistinguível de "não vale a ligação" na tela da vendedora.
+    // Espelha profitPerHora de supabase/functions/_shared/tactical-margem.ts.
+    const marginPct = margemConhecida(score?.gross_margin_pct);
     const avgCallMinutes = 15;
-    const estimatedProfitPerHour = estimatedMarginPerCall / (avgCallMinutes / 60);
+    const estimatedProfitPerHour = marginPct == null
+      ? null
+      : ((revPotential > 0 ? revPotential : avgSpend) * (marginPct / 100) * 0.1) / (avgCallMinutes / 60);
 
     return {
       estimatedProfitPerHour,
       threshold: PROFIT_PER_HOUR_THRESHOLD,
-      isAboveThreshold: estimatedProfitPerHour >= PROFIT_PER_HOUR_THRESHOLD,
+      // null → não afirma que passou NEM que reprovou; quem exibe decide como mostrar "sem dado".
+      isAboveThreshold: estimatedProfitPerHour == null
+        ? null
+        : estimatedProfitPerHour >= PROFIT_PER_HOUR_THRESHOLD,
     };
   }, [user]);
 
@@ -387,7 +403,7 @@ export const useTacticalPlan = () => {
       const healthScore = Number(score.health_score || 0);
       const churnRisk = Number(score.churn_risk || 0);
       const avgSpend = Number(score.avg_monthly_spend_180d || 0);
-      const marginPct = Number(score.gross_margin_pct || 0);
+      const marginPct = margemConhecida(score.gross_margin_pct);
       const categoryCount = Number(score.category_count || 0);
       const daysSince = Number(score.days_since_last_purchase || 0);
       const expansionPotential = Number(score.expansion_score || 0);

--- a/src/lib/carteira/escopo-clientes.ts
+++ b/src/lib/carteira/escopo-clientes.ts
@@ -2,6 +2,7 @@
 // PUROS + HOFs testáveis aqui; a glue Supabase é anexada na 2ª metade (Task 2).
 // Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
 import { supabase } from '@/integrations/supabase/client';
+import { margemConhecida } from '@/lib/scoring/margin';
 import type { Customer, ClientScore } from '@/components/adminCustomers/types';
 
 export interface DisplayFlags {
@@ -184,7 +185,9 @@ export async function fetchScoresPorCustomer(ids: string[]): Promise<Map<string,
       avg_monthly_spend_180d: s.avg_monthly_spend_180d ?? 0,
       days_since_last_purchase: s.days_since_last_purchase ?? 0,
       category_count: s.category_count ?? 0,
-      gross_margin_pct: s.gross_margin_pct ?? 0,
+      // Sem `?? 0`: margem ausente tem de chegar como null ao consumidor. Coagir aqui tornaria
+      // inertes os guards de quem lê este mapa (a armadilha da "correção só no consumidor").
+      gross_margin_pct: margemConhecida(s.gross_margin_pct),
       sales_history_status: s.sales_history_status ?? null,
     });
   }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -50,3 +50,23 @@ export function decodeHtmlEntities(text: string | null | undefined): string {
   el.innerHTML = text;
   return el.value;
 }
+
+/**
+ * Margem bruta em PERCENTUAL (0–100, negativos válidos), sem adivinhar unidade.
+ *
+ * `farmer_client_scores.gross_margin_pct` é percentual — é a convenção de `useTacticalPlan`
+ * (`marginPct / 100`), `useBundleArguments` (compara com 20 e 35), das abas de Intelligence e da
+ * própria `get_customer_margin_summary` (`round(… * 100, 2)`). Enquanto a coluna valia 0 em 100%
+ * das linhas, nenhuma divergência de unidade aparecia; com a margem calculada no servidor, aparece.
+ *
+ * ⚠️ NÃO use `formatPctMaybe` (de components/customer360/format) para margem: a heurística
+ * `v > 1 ? v : v * 100` de lá erra em dois casos que a margem produz de verdade — margem abaixo de
+ * 1% (0,5 vira "50%") e margem NEGATIVA (−143,22, o mínimo medido em prod, vira "−14322%").
+ *
+ * `null` → "—" (não medida), nunca "0%", que afirmaria margem nula apurada.
+ */
+export function formatMargemPct(v: number | null | undefined): string {
+  if (v === null || v === undefined || Number.isNaN(v)) return '—';
+  const rounded = Math.round(v);
+  return Math.abs(v - rounded) < 0.05 ? `${rounded}%` : `${v.toFixed(1)}%`;
+}

--- a/src/lib/scoring/__tests__/margemAusente.test.ts
+++ b/src/lib/scoring/__tests__/margemAusente.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { margemConhecida, mediaMargensConhecidas } from '../margin';
+import { selectObjective } from '../objective';
+import { classifyCustomerProfile } from '@/hooks/useBundleArguments';
+import { formatMargemPct } from '@/lib/format';
+
+/**
+ * Guards contra a fabricação que aparece quando `gross_margin_pct` passa a ser NULL.
+ *
+ * Contexto: a coluna era `0` literal em 6.632/6.632 linhas (com `column_default = 0`), então
+ * todo `|| 0` era inerte e nada disso dava sinal. Com a margem calculada no servidor (#1495),
+ * 5.579 de 6.632 linhas (84,1%) viram NULL de uma vez.
+ *
+ * O erro que estes testes existem para impedir não é "esqueci de tratar null" — é a COERÇÃO
+ * SILENCIOSA do JS: `null < 20` é `true`, `null * 100` é `0`, `Number(null)` é `0`. Cada um
+ * produz um resultado plausível, e plausível é o que passa despercebido.
+ */
+
+describe('margemConhecida', () => {
+  it('distingue margem ZERO (veredito) de margem AUSENTE (sem dado)', () => {
+    // A distinção que dá nome a tudo isto: 0 é uma medição ("cliente não-lucrativo").
+    expect(margemConhecida(0)).toBe(0);
+    expect(margemConhecida(null)).toBeNull();
+    expect(margemConhecida(undefined)).toBeNull();
+  });
+
+  it('preserva margem negativa — o mínimo em prod é −143,22%', () => {
+    expect(margemConhecida(-143.22)).toBe(-143.22);
+  });
+
+  it('trata não-finito como ausente', () => {
+    expect(margemConhecida(NaN)).toBeNull();
+    expect(margemConhecida(Infinity)).toBeNull();
+    expect(margemConhecida('não é número')).toBeNull();
+  });
+
+  it('aceita numeric vindo do Postgres como string', () => {
+    expect(margemConhecida('53.47')).toBe(53.47);
+  });
+});
+
+describe('mediaMargensConhecidas', () => {
+  it('exclui ausentes do numerador E do denominador', () => {
+    // Com `|| 0` a média seria (50+30+0+0)/4 = 20. O erro é sedutor porque 20 é plausível.
+    expect(mediaMargensConhecidas([50, 30, null, undefined])).toBe(40);
+  });
+
+  it('devolve null quando nenhuma margem é conhecida — não 0', () => {
+    expect(mediaMargensConhecidas([null, undefined, NaN])).toBeNull();
+    expect(mediaMargensConhecidas([])).toBeNull();
+  });
+
+  it('conta o zero conhecido, que é medição de verdade', () => {
+    expect(mediaMargensConhecidas([0, 100])).toBe(50);
+  });
+});
+
+describe('classifyCustomerProfile — margem ausente não vira diagnóstico', () => {
+  it('NÃO rotula sensivel_preco quando a margem é desconhecida', () => {
+    // `null < 20` é `true` em JS. Sem o guard, todo cliente de gasto baixo e margem não apurada
+    // sairia como "sensível a preço" — rótulo que molda a abordagem levada ao cliente.
+    expect(classifyCustomerProfile(50, 300, null, 5)).not.toBe('sensivel_preco');
+  });
+
+  it('AINDA rotula sensivel_preco quando a margem é de fato baixa', () => {
+    expect(classifyCustomerProfile(50, 300, 10, 5)).toBe('sensivel_preco');
+  });
+
+  it('margem 0 CONHECIDA continua sendo margem baixa', () => {
+    expect(classifyCustomerProfile(50, 300, 0, 5)).toBe('sensivel_preco');
+  });
+
+  it('NÃO rotula orientado_qualidade sem margem, mas rotula com margem alta', () => {
+    expect(classifyCustomerProfile(50, 1000, null, 2)).not.toBe('orientado_qualidade');
+    expect(classifyCustomerProfile(50, 1000, 40, 2)).toBe('orientado_qualidade');
+  });
+
+  it('ramos que não dependem de margem seguem funcionando sem ela', () => {
+    expect(classifyCustomerProfile(70, 3000, null, 5)).toBe('orientado_produtividade');
+    expect(classifyCustomerProfile(50, 1000, null, 5)).toBe('misto');
+  });
+});
+
+describe('selectObjective — consolidacao_margem exige margem conhecida', () => {
+  const cap = 180;
+
+  it('NÃO escolhe consolidacao_margem sem a margem do cliente', () => {
+    // Sem guard: `null < 40 * 0.8` é `true` → consolidação a esmo para 84% da base.
+    expect(selectObjective(10, 0, null, 40, 5, cap)).not.toBe('consolidacao_margem');
+  });
+
+  it('escolhe consolidacao_margem quando ambas são conhecidas e a do cliente é baixa', () => {
+    expect(selectObjective(10, 0, 20, 40, 5, cap)).toBe('consolidacao_margem');
+  });
+
+  it('segue exigindo o cluster (comportamento preexistente preservado)', () => {
+    expect(selectObjective(10, 0, 20, null, 5, cap)).not.toBe('consolidacao_margem');
+  });
+
+  it('regras anteriores à margem não são afetadas pela ausência dela', () => {
+    expect(selectObjective(10, 0, null, 40, 999, cap)).toBe('reativacao');
+    expect(selectObjective(80, 0, null, 40, 5, cap)).toBe('recuperacao');
+    expect(selectObjective(10, 5, null, 40, 5, cap)).toBe('expansao_mix');
+    expect(selectObjective(10, 0, null, 40, 5, cap, 'sem_historico')).toBe('ativacao');
+  });
+});
+
+describe('formatMargemPct', () => {
+  it('mostra travessão para margem ausente, nunca "0%"', () => {
+    expect(formatMargemPct(null)).toBe('—');
+    expect(formatMargemPct(undefined)).toBe('—');
+    expect(formatMargemPct(NaN)).toBe('—');
+  });
+
+  it('mostra "0%" só quando a margem zero foi realmente apurada', () => {
+    expect(formatMargemPct(0)).toBe('0%');
+  });
+
+  it('trata o valor como PERCENTUAL, sem multiplicar por 100', () => {
+    // O bug que isto previne: `(53.47 * 100).toFixed(1)` exibia "5347.0%".
+    expect(formatMargemPct(53.47)).toBe('53.5%');
+    expect(formatMargemPct(30)).toBe('30%');
+  });
+
+  it('formata margem negativa corretamente', () => {
+    // O mínimo real medido em prod. O contraste com formatPctMaybe (que erra aqui, e é por isso
+    // que margem tem formatador próprio) está fixado em components/customer360/__tests__/format.test.ts.
+    expect(formatMargemPct(-143.22)).toBe('-143.2%');
+  });
+});

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -1,3 +1,45 @@
+/**
+ * Margem utilizável, ou `null` se desconhecida.
+ *
+ * `farmer_client_scores.gross_margin_pct` era `0` LITERAL em 6.632/6.632 linhas (com
+ * `column_default = 0`), então `?? 0` e `|| 0` nunca disparavam e o problema ficava invisível.
+ * Com a margem calculada no servidor (#1495), **5.579 de 6.632 linhas (84,1%) passam a ser
+ * `NULL`** — e aí cada `|| 0` vira uma afirmação de negócio sobre a maioria da base.
+ *
+ * ⚠️ `0` é CONHECIDO (margem nula apurada, um veredito: "cliente não-lucrativo"). Só
+ * null/undefined/NaN/Infinity são ausência. Confundir os dois é o erro que este helper existe
+ * para impedir.
+ *
+ * ⚠️ Em comparação relacional o guard é obrigatório: `null < 20` é `true` em JS (null coage a
+ * 0), então `if (margem < 20)` sem checar null classifica como "margem baixa" justamente quem
+ * não foi medido.
+ *
+ * Espelhado em `supabase/functions/_shared/tactical-margem.ts` (Deno não importa de `src/`).
+ */
+export function margemConhecida(raw: unknown): number | null {
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Média das margens conhecidas, ou `null` se nenhuma for conhecida.
+ *
+ * Existe como função própria porque a forma errada é sedutora: filtrar o numerador e esquecer
+ * o denominador (`soma(conhecidas) / total`) devolve um número plausível e sistematicamente
+ * baixo — pior que um erro visível, porque não parece errado. Aqui numerador e denominador
+ * saem da MESMA lista filtrada.
+ */
+export function mediaMargensConhecidas(valores: Iterable<unknown>): number | null {
+  const conhecidas: number[] = [];
+  for (const v of valores) {
+    const m = margemConhecida(v);
+    if (m != null) conhecidas.push(m);
+  }
+  if (conhecidas.length === 0) return null;
+  return conhecidas.reduce((s, m) => s + m, 0) / conhecidas.length;
+}
+
 interface MarginItem {
   product_id?: string;
   omie_codigo_produto?: number | string;

--- a/src/lib/scoring/objective.ts
+++ b/src/lib/scoring/objective.ts
@@ -1,3 +1,5 @@
+import { margemConhecida } from '@/lib/scoring/margin';
+
 /**
  * Objetivo estratégico do plano tático do farmer — rótulo categórico que entra no
  * prompt da IA (`generate-tactical-plan`) e molda o plano de abordagem.
@@ -26,7 +28,8 @@
 export function selectObjective(
   churnRisk: number,
   mixGap: number,
-  marginPct: number,
+  /** `null` = margem do cliente não apurada → consolidacao_margem fica INDECIDÍVEL (ver abaixo). */
+  marginPct: number | null,
   clusterMargin: number | null,
   daysSince: number,
   recencyCapDays: number,
@@ -41,7 +44,11 @@ export function selectObjective(
   // consolidacao a esmo. (O espelho no edge generate-tactical-plan sempre passa número —
   // benchmarka pela carteira-dono no batch — então a divergência só aparece no caminho client,
   // onde o cluster pode faltar.)
-  if (clusterMargin != null && Number.isFinite(clusterMargin) && marginPct < clusterMargin * 0.8) return 'consolidacao_margem';
+  // A margem do CLIENTE também precisa ser conhecida — simétrico ao cluster. Não se afirma
+  // "margem baixa vs. pares" sem saber a margem, e `null < X` é `true` em JS (null coage a 0),
+  // então sem este guard todo cliente sem margem apurada cairia em consolidacao_margem.
+  const m = margemConhecida(marginPct);
+  if (m != null && clusterMargin != null && Number.isFinite(clusterMargin) && m < clusterMargin * 0.8) return 'consolidacao_margem';
   return 'upsell_premium';
 }
 

--- a/src/lib/tactical/pregeracao.ts
+++ b/src/lib/tactical/pregeracao.ts
@@ -2,6 +2,8 @@
  *  Oráculo puro — a edge tactical-plans-batch (Deno) replica esta lógica via
  *  supabase/functions/_shared/tactical-margem.ts (front e edge não compartilham módulo;
  *  este helper é a fonte da verdade testada). */
+import { margemConhecida } from '@/lib/scoring/margin';
+
 export const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h — espelha useTacticalPlan.ts:198
 const AVG_CALL_MINUTES = 15;
 
@@ -14,12 +16,8 @@ export interface ScoreParaSelecao {
   marginPct: number | null;
 }
 
-/** Margem utilizável, ou null se desconhecida/não-finita (money-path: ausente ≠ zero). */
-function margemConhecida(raw: number | null | undefined): number | null {
-  if (raw == null) return null;
-  const n = Number(raw);
-  return Number.isFinite(n) ? n : null;
-}
+// margemConhecida vem de @/lib/scoring/margin (era uma cópia privada aqui). A cópia que RESTA é a
+// de supabase/functions/_shared/tactical-margem.ts, e essa é inevitável: Deno não importa de src/.
 
 /** R$/h estimado por ligação. Espelha useTacticalPlan.checkEfficiency (linhas 313-318).
  *  Margem desconhecida → `null` ("não sei"), NUNCA 0 (que significaria "cliente não-lucrativo"). */


### PR DESCRIPTION
## O que este PR faz

Blinda os consumidores de `farmer_client_scores.gross_margin_pct` contra `NULL`. É a metade **consumidor** do par que o princípio 2 do `money-path.md` descreve; o [#1498](https://github.com/LucasSardenbergL/afiacao/pull/1498) cobriu o caminho **tático**, este cobre o resto.

**Entra sozinho com segurança e é pré-requisito do [#1495](https://github.com/LucasSardenbergL/afiacao/pull/1495)** (a margem calculada no servidor), que está em draft esperando isto.

## Por que agora

Hoje a coluna é `0` literal em **6.632/6.632** linhas, com `column_default = 0` — então todo `|| 0` é inerte e o problema é invisível. Com o #1495, medido em prod 2026-07-21:

| | linhas |
|---|---|
| total em `farmer_client_scores` | 6.632 |
| que teriam margem apurada | 1.053 |
| que passam a ser **`NULL`** | **5.579 (84,1%)** |

`0` é um **veredito** de negócio ("cliente não-lucrativo"). Sem estes guards, o app passaria a afirmar isso sobre 84% da base — em KPI de gestor, em rótulo que entra no prompt da IA, e na tela do cliente.

## Os oito pontos

**Coação `|| 0` / `?? 0`:**
1. `IntelligenceManagerialTab.tsx` — média por farmer. Trocado por `mediaMargensConhecidas`, que filtra numerador **e** denominador; a UI mostra "—" quando nenhum cliente do farmer tem margem.
2. `IntelligenceStrategicTab.tsx` — KPI "Margem Bruta Média", mesmo tratamento.
3. `useBundleEngine.ts` — o campo vira `number | null` no tipo, e o valor passa por `margemConhecida`.
4. `escopo-clientes.ts` — o mapa de carteira para de coagir na fronteira.
5. `useTacticalPlan.ts` — o R$/h por ligação vira **tri-estado**: margem desconhecida → `null`, não zero. Com `|| 0` o gate reprovava o cliente por omissão, e "não sei" ficava indistinguível de "não vale a ligação".

**Comparação sem guard (`null < 20` é `true` — null coage a 0):**

6. `useBundleArguments.ts` — `classifyCustomerProfile` só classifica `sensivel_preco`/`orientado_qualidade` com margem conhecida.
7. `CustomerHero.tsx` — faixa de cor do badge.

**Exibição:**

8. `Customer360View.tsx` — mostrava `0.0%` para margem ausente.

## Três achados além do mapeado

**1. A correção seria inerte em dois dos pontos.** `useBundleEngine:551` coagia com `Number(… || 0)` e `CustomerBundleCard:29` coagia de novo com `|| 0`, **antes** de chamar `classifyCustomerProfile`. Blindar só a função de classificação não mudaria nada — o `null` nunca chegaria lá. Mesma armadilha que o #1508 registrou hoje ("só o consumidor é inerte"), aqui numa cadeia de três camadas. Os três níveis foram corrigidos.

**2. Havia um terceiro espelho do `classifyProfile`.** A mesma regra existe em `_shared/tactical-margem.ts` (blindada pelo #1498), `useBundleArguments.ts` e `useTacticalPlan.ts:187`. Só a primeira tinha o guard. Os três estão alinhados agora, e a cópia privada de `margemConhecida` em `pregeracao.ts` foi consolidada no helper compartilhado — resta apenas a cópia do edge, inevitável (Deno não importa de `src/`).

**3. Um bug de unidade que o zero universal escondia.** A coluna é **percentual (0–100)** — é o que `useTacticalPlan` (`marginPct / 100`), `useBundleArguments` (compara com 20 e 35), as abas de Intelligence e a própria `get_customer_margin_summary` (`round(… * 100, 2)`) já assumem. Mas dois lugares tratavam como fração:

- `Customer360View.tsx` multiplicava por 100 → com margem real de 53,47 exibiria **"5347.0%"**
- `CustomerHero.tsx` comparava com `0.3` / `0.15` → **qualquer** margem real passa de 0,3, então tudo ficaria verde

Enquanto a coluna valia 0 em toda a base, nenhum dos dois aparecia. O `formatPctMaybe` genérico também erra aqui: a heurística `v > 1 ? v : v * 100` não reconhece **margem negativa** (o mínimo medido em prod é **−143,22%**, que viraria "−14322%"). Como outra tela usa esse formatador legitimamente com fração, criei `formatMargemPct` explícito em vez de mudar o compartilhado.

## Prova

`src/lib/scoring/__tests__/margemAusente.test.ts` — **20 testes**, cobrindo as três formas de coerção silenciosa do JS (`null < 20`, `null * 100`, `Number(null)`), a distinção entre margem **zero apurada** e **ausente**, e a preservação de margem negativa.

**4 falsificações**, cada uma acendendo exatamente os testes que mira:

| sabotagem | vermelhos |
|---|---|
| guard de `classifyCustomerProfile` removido | 1 |
| guard de `selectObjective` removido | 1 (nomeado) |
| `mediaMargensConhecidas` dividindo pelo total | 1 (nomeado) |
| `formatMargemPct` voltando a multiplicar por 100 | 2 (nomeados) |

O teste do denominador merece nota: a forma errada — filtrar o numerador e esquecer o denominador — devolve um número plausível e sistematicamente baixo, que é pior que um erro visível porque não parece errado.

## Efeito hoje

**Nenhum visível.** Como a coluna é `0` em 100% das linhas, todos os guards são no-op até o #1495 entrar. Isto é defesa preparada, e está sendo dito explicitamente porque o #1508 registrou que "só o consumidor é inerte — legítimo como defesa do futuro, mas **diga** que é defesa, senão fica a impressão falsa de que o bug foi eliminado".

As duas exceções, que **corrigem comportamento hoje**, são os bugs de unidade do achado 3: `Customer360View` e `CustomerHero` já estão errados para qualquer margem não-zero — só não aparece porque não existe margem não-zero.

## Deploy

Só **frontend** (Publish no Lovable). Sem migration, sem edge.
