### PR TITLE
fix(farmer): margem ausente para de virar veredito "cliente não-lucrativo" [money-path]

### DIFF
--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -33,6 +33,7 @@ import { MetricCard, ScoreItem } from './cards';
 import { RequiresPoToggle } from './RequiresPoToggle';
 import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
 import type { Customer, ClientScore, ToolCategory, UserTool, SalesOrder } from './types';
+import { formatarMargemPct } from '@/lib/margem';
 
 export function Customer360View({
   customer,
@@ -191,7 +192,10 @@ export function Customer360View({
             </CardHeader>
             <CardContent>
               <div className="grid grid-cols-3 md:grid-cols-5 gap-3">
-                <ScoreItem label="Margem" value={`${(score.gross_margin_pct * 100).toFixed(1)}%`} />
+                {/* `* 100` assumia fração 0-1, mas a coluna guarda PERCENTUAL 0-100 — com a
+                    margem real do #1495, 56% virava "5600.0%". Enquanto a coluna era 0 em
+                    6.632/6.632 linhas o erro exibia "0.0%" e passava por dado legítimo. */}
+                <ScoreItem label="Margem" value={formatarMargemPct(score.gross_margin_pct)} />
                 <ScoreItem label="Expansão" value={score.expansion_score.toFixed(1)} />
                 <ScoreItem label="Prioridade" value={score.priority_score.toFixed(1)} />
                 <ScoreItem label="Dias s/ compra" value={String(score.days_since_last_purchase)} danger={score.days_since_last_purchase > 60} />

--- a/src/components/adminCustomers/__tests__/CustomerListView.test.tsx
+++ b/src/components/adminCustomers/__tests__/CustomerListView.test.tsx
@@ -37,7 +37,7 @@ const score: ClientScore = {
   avg_monthly_spend_180d: 1000,
   days_since_last_purchase: 10,
   category_count: 3,
-  gross_margin_pct: 0.3,
+  gross_margin_pct: 30,
   sales_history_status: 'ativo',
 };
 

--- a/src/components/adminCustomers/types.ts
+++ b/src/components/adminCustomers/types.ts
@@ -40,7 +40,11 @@ export interface ClientScore {
   avg_monthly_spend_180d: number;
   days_since_last_purchase: number;
   category_count: number;
-  gross_margin_pct: number;
+  /** PERCENTUAL 0-100 (56 = 56%), ou `null` quando a margem é desconhecida — cliente sem
+   *  pedido, ou com itens sem custo conhecido (~84% da base pós-#1495). `0` é o veredito
+   *  "não-lucrativo", NUNCA "não sei": use `margemConhecida`/`faixaMargem` de
+   *  `@/lib/margem` em vez de `?? 0`. */
+  gross_margin_pct: number | null;
   avg_repurchase_interval?: number | null;
   sales_history_status: string | null;
 }

--- a/src/components/customer360/CustomerHero.tsx
+++ b/src/components/customer360/CustomerHero.tsx
@@ -11,8 +11,9 @@ import { AgendarVisitaDialog } from '@/components/visitas/AgendarVisitaDialog';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 import { whatsappLink } from '@/lib/phone';
+import { faixaMargem, formatarMargemPct } from '@/lib/margem';
 import {
-  formatPctMaybe, formatDateOrDash, initials, healthTone, churnTone, formatDocument,
+  formatDateOrDash, initials, healthTone, churnTone, formatDocument,
 } from './format';
 import type { Customer, CustomerScore } from './viewTypes';
 
@@ -134,19 +135,24 @@ export function CustomerHero({
                   {churn.label}
                 </span>
               )}
-              {s?.gross_margin_pct != null && (
+              {/* Faixa em PERCENTUAL 0-100. Os thresholds eram `>= 0.3` / `>= 0.15` (fração)
+                  contra uma coluna 0-100: com a margem real do #1495, qualquer cliente acima
+                  de 0,3% cairia no verde — inclusive margem de 5%. Enquanto a coluna era 0 em
+                  6.632/6.632 linhas todo mundo caía no vermelho e o erro não aparecia.
+                  `desconhecida` não renderiza: sem margem medida não há veredito a dar. */}
+              {faixaMargem(s?.gross_margin_pct) !== 'desconhecida' && (
                 <span
                   className={cn(
                     'inline-flex items-center gap-1.5 px-2 py-1 rounded-md border',
-                    s.gross_margin_pct >= 0.3
+                    faixaMargem(s?.gross_margin_pct) === 'alta'
                       ? 'bg-status-success-bg text-status-success-bold border-status-success/20'
-                      : s.gross_margin_pct >= 0.15
+                      : faixaMargem(s?.gross_margin_pct) === 'media'
                         ? 'bg-status-warning-bg text-status-warning-bold border-status-warning/20'
                         : 'bg-status-error-bg text-status-error-bold border-status-error/20',
                   )}
                 >
                   <Activity className="w-3 h-3" />
-                  {formatPctMaybe(s.gross_margin_pct)} margem
+                  {formatarMargemPct(s?.gross_margin_pct)} margem
                 </span>
               )}
             </div>

--- a/src/components/customer360/__tests__/CustomerHero.test.tsx
+++ b/src/components/customer360/__tests__/CustomerHero.test.tsx
@@ -26,7 +26,7 @@ const customer = {
   cnae: null,
 } as unknown as Customer;
 
-const score = { health_class: 'saudavel', churn_risk: 10, gross_margin_pct: 0.35 } as unknown as CustomerScore;
+const score = { health_class: 'saudavel', churn_risk: 10, gross_margin_pct: 35 } as unknown as CustomerScore;
 
 function renderHero(ui: React.ReactElement) {
   return render(<MemoryRouter><TooltipProvider>{ui}</TooltipProvider></MemoryRouter>);
@@ -46,5 +46,59 @@ describe('CustomerHero', () => {
   it('PF (isPj=false) → badge PF', () => {
     renderHero(<CustomerHero customer={{ ...customer, document: '12345678901' }} score={null} isPj={false} onBack={() => {}} />);
     expect(screen.getByText('PF')).toBeTruthy();
+  });
+});
+
+// ── Margem no hero: unidade e ausência (money-path) ────────────────────────────
+// Estes casos provam o guard NO CONSUMIDOR. Testar só o helper não prova que o
+// componente parou de coagir — a coação a montante é que decide (money-path §2).
+describe('CustomerHero — badge de margem', () => {
+  const comMargem = (m: number | null) =>
+    ({ health_class: 'saudavel', churn_risk: 10, gross_margin_pct: m }) as unknown as CustomerScore;
+
+  it('margem desconhecida NÃO renderiza o badge (nem como 0%)', () => {
+    renderHero(<CustomerHero customer={customer} score={comMargem(null)} isPj onBack={vi.fn()} />);
+    expect(screen.queryByText(/margem/)).toBeNull();
+  });
+
+  it('exibe percentual sem reescalar — 56 é "56%", não "5600%"', () => {
+    renderHero(<CustomerHero customer={customer} score={comMargem(56)} isPj onBack={vi.fn()} />);
+    expect(screen.getByText(/56% margem/)).toBeTruthy();
+  });
+
+  it('margem negativa não vira -6000% (a heurística antiga multiplicava por 100)', () => {
+    renderHero(<CustomerHero customer={customer} score={comMargem(-60)} isPj onBack={vi.fn()} />);
+    expect(screen.getByText(/-60% margem/)).toBeTruthy();
+  });
+
+  it('margem de 5% é pintada como BAIXA, não como alta por passar de 0.3', () => {
+    const { container } = renderHero(
+      <CustomerHero customer={customer} score={comMargem(5)} isPj onBack={vi.fn()} />,
+    );
+    const badge = Array.from(container.querySelectorAll('span')).find((e) =>
+      e.textContent?.includes('margem'),
+    );
+    expect(badge?.className).toContain('status-error');
+    expect(badge?.className).not.toContain('status-success');
+  });
+
+  it('margem de 56% é pintada como ALTA', () => {
+    const { container } = renderHero(
+      <CustomerHero customer={customer} score={comMargem(56)} isPj onBack={vi.fn()} />,
+    );
+    const badge = Array.from(container.querySelectorAll('span')).find((e) =>
+      e.textContent?.includes('margem'),
+    );
+    expect(badge?.className).toContain('status-success');
+  });
+
+  it('margem de 20% cai na faixa intermediária', () => {
+    const { container } = renderHero(
+      <CustomerHero customer={customer} score={comMargem(20)} isPj onBack={vi.fn()} />,
+    );
+    const badge = Array.from(container.querySelectorAll('span')).find((e) =>
+      e.textContent?.includes('margem'),
+    );
+    expect(badge?.className).toContain('status-warning');
   });
 });

--- a/src/components/farmer/bundles/CustomerBundleCard.tsx
+++ b/src/components/farmer/bundles/CustomerBundleCard.tsx
@@ -4,7 +4,8 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { ChevronDown, ChevronUp, Layers, Zap } from 'lucide-react';
 import type { BundleRecommendation, CustomerBundles } from '@/hooks/useBundleEngine';
-import { classifyCustomerProfile, profileLabels, type CustomerProfile, type BundleArgument } from '@/hooks/useBundleArguments';
+import { profileLabels, type CustomerProfile, type BundleArgument } from '@/hooks/useBundleArguments';
+import { classificarPerfilCliente } from '@/lib/scoring/perfilCliente';
 import type { useDiagnosticQuestions } from '@/hooks/useDiagnosticQuestions';
 import { fmt } from './format';
 import type { CustomerCtx } from './types';
@@ -26,7 +27,10 @@ export const CustomerBundleCard = ({ data, expanded, onToggle, bundleArgs, argGe
   const individualLIE = data.bestIndividual?.lie || 0;
   const bundleWins = bestBundleLIE > individualLIE;
 
-  const profile = classifyCustomerProfile(data.healthScore, data.avgMonthlySpend || 0, data.grossMarginPct || 0, data.categoryCount || 0);
+  // `data.grossMarginPct || 0` era o SEGUNDO ponto de coação da cadeia (o primeiro é
+  // useBundleEngine): convertia o null antes do guard, então blindar só o classificador
+  // não mudaria nada. A margem chega crua e quem decide não decidir é o classificador.
+  const profile = classificarPerfilCliente(data.healthScore, data.avgMonthlySpend || 0, data.grossMarginPct, data.categoryCount || 0);
   const profileInfo = profileLabels[profile];
 
   const customerCtx = {

--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -13,6 +13,7 @@ import { Minus } from 'lucide-react';
 import { directionConfig, suggestionTypeIcons, fallbackSuggestionIcon } from './config';
 import type { InputMode } from './types';
 import type { MotorVozScribeProps } from './MotorVozScribe';
+import { margemConhecida } from '@/lib/margem';
 
 export function useFarmerCopilot() {
   const navigate = useNavigate();
@@ -108,7 +109,12 @@ export function useFarmerCopilot() {
         customerType: profile?.customer_type,
         healthScore: score?.health_score,
         avgMonthlySpend: score?.avg_monthly_spend_180d,
-        grossMarginPct: score?.gross_margin_pct,
+        // Vai para o prompt da IA. `margemConhecida` garante null EXPLÍCITO (em vez de
+        // undefined, que some do JSON, ou de uma string numérica) — o modelo precisa
+        // distinguir "margem 0%" de "margem não apurada" para não sugerir desconto ou
+        // discurso de rentabilidade em cima de um número que ninguém mediu.
+        // Unidade: PERCENTUAL 0-100.
+        grossMarginPct: margemConhecida(score?.gross_margin_pct),
         categoryCount: score?.category_count,
         daysSinceLastPurchase: score?.days_since_last_purchase,
         churnRisk: score?.churn_risk,

--- a/src/components/farmer/tacticalPlan/EfficiencyAlertDialog.tsx
+++ b/src/components/farmer/tacticalPlan/EfficiencyAlertDialog.tsx
@@ -7,27 +7,41 @@ import type { PlanType } from '@/hooks/useTacticalPlan';
 import { fmt } from './config';
 
 interface EfficiencyAlertDialogProps {
-  alert: { customerId: string; profitPerHour: number; planType: PlanType } | null;
+  /** `profitPerHour` null = margem desconhecida (gate indecidível), NÃO R$0/h. */
+  alert: { customerId: string; profitPerHour: number | null; planType: PlanType } | null;
   onClose: () => void;
   onConfirm: () => void;
 }
 
 export function EfficiencyAlertDialog({ alert, onClose, onConfirm }: EfficiencyAlertDialogProps) {
+  // Dois motivos distintos caem neste diálogo, e confundi-los mente sobre o cliente:
+  // gate REPROVADO (R$/h medido e baixo) vs. gate INDECIDÍVEL (margem nunca apurada).
+  // Com `|| 0` o segundo virava "Potencial Baixo: R$ 0,00/h" — um veredito comercial
+  // fabricado a partir de ausência de custo (money-path: ausente ≠ zero).
+  const semMargem = alert != null && alert.profitPerHour == null;
   return (
     <Dialog open={!!alert} onOpenChange={onClose}>
       <DialogContent className="max-w-xs">
         <DialogHeader>
           <DialogTitle className="text-sm flex items-center gap-2">
             <AlertCircle className="w-4 h-4 text-status-warning" />
-            Potencial Baixo
+            {semMargem ? 'Sem margem apurada' : 'Potencial Baixo'}
           </DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
-          <p className="text-xs text-muted-foreground">
-            O lucro estimado por hora para este cliente é de{' '}
-            <strong className="text-foreground">{fmt(alert?.profitPerHour || 0)}/h</strong>,
-            abaixo do limiar recomendado de <strong className="text-foreground">{fmt(50)}/h</strong>.
-          </p>
+          {semMargem ? (
+            <p className="text-xs text-muted-foreground">
+              Não foi possível estimar o lucro por hora deste cliente: os itens comprados
+              não têm custo conhecido. Isso <strong className="text-foreground">não</strong>{' '}
+              significa potencial baixo — significa que não há dado para julgar.
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              O lucro estimado por hora para este cliente é de{' '}
+              <strong className="text-foreground">{fmt(alert?.profitPerHour ?? 0)}/h</strong>,
+              abaixo do limiar recomendado de <strong className="text-foreground">{fmt(50)}/h</strong>.
+            </p>
+          )}
           <p className="text-xs text-muted-foreground">Deseja continuar mesmo assim?</p>
           <div className="flex gap-2">
             <Button variant="outline" size="sm" className="flex-1 text-xs" onClick={onClose}>

--- a/src/components/farmer/tacticalPlan/PlanCard.tsx
+++ b/src/components/farmer/tacticalPlan/PlanCard.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { getObjectiveLabel, type TacticalPlan } from '@/hooks/useTacticalPlan';
 import { fmt, objectiveColors, profileLabels } from './config';
+import { formatarMargemPct } from '@/lib/margem';
 import { Section, MetricRow, CopyButton } from './PlanSection';
 import { RecordResultDialog } from './RecordResultDialog';
 import type { RecordResultPayload } from './types';
@@ -63,7 +64,9 @@ export const PlanCard = ({
         </div>
 
         {/* Efficiency indicator */}
-        {plan.estimatedProfitPerHour > 0 && (
+        {/* null = margem desconhecida → o R$/h não é estimável. Some o indicador em vez de
+            mostrar R$0/h, que se leria como "cliente não compensa" (money-path: ausente ≠ zero). */}
+        {plan.estimatedProfitPerHour != null && plan.estimatedProfitPerHour > 0 && (
           <div className={`mt-1.5 flex items-center gap-1 text-[9px] ${
             plan.estimatedProfitPerHour >= 50 ? 'text-status-success' : 'text-status-warning'
           }`}>
@@ -77,7 +80,7 @@ export const PlanCard = ({
           <div className="mt-3 space-y-3">
             {/* Diagnosis */}
             <Section title="Diagnóstico Resumido" icon={Heart}>
-              <MetricRow label="Margem atual" value={`${plan.currentMarginPct.toFixed(1)}%`} />
+              <MetricRow label="Margem atual" value={formatarMargemPct(plan.currentMarginPct)} />
               <MetricRow label="Média cluster" value={plan.clusterAvgMarginPct == null ? '—' : `${plan.clusterAvgMarginPct.toFixed(1)}%`} />
               <MetricRow label="Potencial expansão" value={`${plan.expansionPotential.toFixed(0)}%`} />
               <MetricRow label="Perfil" value={profileLabels[plan.customerProfile] || plan.customerProfile} />

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -26,7 +26,7 @@ export function useFarmerTacticalPlan() {
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
   const [copiedText, setCopiedText] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
-  const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number; planType: PlanType } | null>(null);
+  const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number | null; planType: PlanType } | null>(null);
 
   useEffect(() => {
     if (user?.id && isStaff) {
@@ -69,6 +69,8 @@ export function useFarmerTacticalPlan() {
     const check = await checkEfficiency(customerId);
     if (!check.isAboveThreshold) {
       setEfficiencyAlert({ customerId, profitPerHour: check.estimatedProfitPerHour, planType });
+      // ⚠️ profitPerHour null = margem desconhecida, NÃO R$0/h — o diálogo tem de dizer
+      // "não foi possível estimar", não afirmar que o cliente não compensa.
       return;
     }
     generatePlan(customerId, planType);

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -6,16 +6,39 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Users, AlertTriangle, Layers } from 'lucide-react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer } from 'recharts';
+import { mediaMargemConhecida, legendaCobertura, formatarMargemPct } from '@/lib/margem';
+import { fetchAllPages } from '@/lib/postgrest';
+
 import { KpiCard } from './KpiCard';
+
+interface ScoreLinha {
+  customer_user_id: string;
+  farmer_id: string;
+  health_score: number | null;
+  health_class: string | null;
+  /** PERCENTUAL 0-100, ou null quando desconhecida. Ver @/lib/margem. */
+  gross_margin_pct: number | null;
+  category_count: number | null;
+  sales_history_status: string | null;
+}
+
 
 function IntelligenceManagerialTabImpl() {
   const { data: allScores, isLoading } = useQuery({
     queryKey: ['intel-all-scores'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('farmer_client_scores').select('*').order('priority_score', { ascending: false }).limit(500);
-      if (error) throw error;
-      return data || [];
-    },
+    // Base COMPLETA, paginada. Era `.limit(500)` sobre `priority_score` desc — 500 de 6.632, e
+    // logo os de MAIOR prioridade: uma amostra enviesada apresentada como comparativo entre
+    // vendedores. Não dava pra declarar a cobertura da margem em cima disso sem mentir sobre
+    // o denominador. Ordem por `customer_user_id` (UNIQUE) porque paginação sem ordem estável
+    // pula e repete linha entre páginas.
+    queryFn: () =>
+      fetchAllPages<ScoreLinha>((de, ate) =>
+        supabase
+          .from('farmer_client_scores')
+          .select('customer_user_id, farmer_id, health_score, health_class, gross_margin_pct, category_count, sales_history_status')
+          .order('customer_user_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ScoreLinha[] | null }>,
+      ),
   });
 
   const { data: allPerformance } = useQuery({
@@ -67,11 +90,14 @@ function IntelligenceManagerialTabImpl() {
   const farmerMetrics = Object.entries(farmerGroups).map(([farmerId, clients]) => {
     const avgHealth = clients.reduce((a, c) => a + Number(c.health_score || 0), 0) / clients.length;
     const atRisk = clients.filter(c => (c.health_class === 'critico' || c.health_class === 'atencao') && c.sales_history_status !== 'sem_historico').length;
-    const avgMargin = clients.reduce((a, c) => a + Number(c.gross_margin_pct || 0), 0) / clients.length;
+    // Só margens CONHECIDAS. Com `|| 0`, o vendedor cuja carteira ainda não tem custo
+    // apurado apareceria com margem pior do que o colega medido — comparação entre
+    // vendedores fabricada a partir de ausência de dado (money-path §2).
+    const margem = mediaMargemConhecida(clients.map((c) => c.gross_margin_pct));
     const avgCategories = clients.reduce((a, c) => a + Number(c.category_count || 0), 0) / clients.length;
     const adoption = recoAdoption[farmerId];
     const adoptionPct = adoption && adoption.total > 0 ? (adoption.accepted / adoption.total * 100) : 0;
-    return { farmerId, clientCount: clients.length, avgHealth, atRisk, avgMargin, avgCategories, adoptionPct };
+    return { farmerId, clientCount: clients.length, avgHealth, atRisk, margem, avgCategories, adoptionPct };
   });
 
   const globalAvgCategories = allScores?.length
@@ -120,7 +146,9 @@ function IntelligenceManagerialTabImpl() {
                       <Badge variant={fm.avgHealth > 60 ? 'default' : 'destructive'} className="text-2xs">{fm.avgHealth.toFixed(0)}</Badge>
                     </td>
                     <td className="text-center py-2">{fm.atRisk}</td>
-                    <td className="text-center py-2">{fm.avgMargin.toFixed(1)}%</td>
+                    <td className="text-center py-2" title={legendaCobertura(fm.margem.comMargem, fm.margem.total)}>
+                      {formatarMargemPct(fm.margem.media)}
+                    </td>
                     <td className="text-center py-2">{fm.avgCategories.toFixed(1)}</td>
                     <td className="text-center py-2">
                       <span className={fm.avgCategories < globalAvgCategories ? 'text-destructive' : 'text-status-success'}>

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -9,6 +9,17 @@ import {
   BarChart3, PieChart, ShieldCheck, RefreshCw
 } from 'lucide-react';
 import { toast } from 'sonner';
+import { mediaMargemConhecida, legendaCobertura, formatarMargemPct } from '@/lib/margem';
+import { fetchAllPages } from '@/lib/postgrest';
+
+interface ScoreLinha {
+  customer_user_id: string;
+  /** PERCENTUAL 0-100, ou null quando desconhecida. Ver @/lib/margem. */
+  gross_margin_pct: number | null;
+  avg_monthly_spend_180d: number | null;
+  avg_repurchase_interval: number | null;
+  revenue_potential: number | null;
+}
 import { KpiCard } from './KpiCard';
 
 export function IntelligenceStrategicTab() {
@@ -23,11 +34,18 @@ export function IntelligenceStrategicTab() {
 
   const { data: allScores } = useQuery({
     queryKey: ['intel-strategic-scores'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('farmer_client_scores').select('*').limit(500);
-      if (error) throw error;
-      return data || [];
-    },
+    // Base COMPLETA, paginada. Era `.limit(500)` de 6.632 e SEM `.order()` — o Postgres não
+    // garante ordem sem ORDER BY, então as 500 linhas eram um recorte não determinístico:
+    // dois carregamentos podiam produzir KPIs diferentes da mesma base. Ordem por
+    // `customer_user_id` (UNIQUE) para a paginação não pular nem repetir linha.
+    queryFn: () =>
+      fetchAllPages<ScoreLinha>((de, ate) =>
+        supabase
+          .from('farmer_client_scores')
+          .select('customer_user_id, gross_margin_pct, avg_monthly_spend_180d, avg_repurchase_interval, revenue_potential')
+          .order('customer_user_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ScoreLinha[] | null }>,
+      ),
   });
 
   const { data: salesOrders } = useQuery({
@@ -104,9 +122,10 @@ export function IntelligenceStrategicTab() {
   const estimatedMarket = Math.max(uniqueCustomers * 3, 100);
   const marketSharePct = (uniqueCustomers / estimatedMarket * 100);
 
-  const avgGrossMargin = allScores?.length
-    ? allScores.reduce((a, c) => a + Number(c.gross_margin_pct || 0), 0) / allScores.length
-    : 0;
+  // Só margens CONHECIDAS entram na média. Com `|| 0`, os ~84% de clientes sem custo
+  // conhecido (pós-#1495) entrariam como "margem zero" e puxariam o KPI para baixo na
+  // proporção exata da ignorância — um número que ninguém reconheceria como errado.
+  const margemMedia = mediaMargemConhecida((allScores ?? []).map((c) => c.gross_margin_pct));
 
   const [runningAlgoA, setRunningAlgoA] = useState(false);
   const runAlgoA = async () => {
@@ -153,7 +172,12 @@ export function IntelligenceStrategicTab() {
         <KpiCard title="LTV Projetado (3a)" value={`R$ ${ltvEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={BarChart3} subtitle="Estimativa média" />
         <KpiCard title="CAC Estimado" value={`R$ ${cacEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle="Custo aquisição cliente" />
         <KpiCard title="Concentração Top 20%" value={`${concentrationPct.toFixed(1)}%`} icon={PieChart} subtitle="da receita total" />
-        <KpiCard title="Margem Bruta Média" value={`${avgGrossMargin.toFixed(1)}%`} icon={Percent} />
+        <KpiCard
+          title="Margem Bruta Média"
+          value={formatarMargemPct(margemMedia.media)}
+          icon={Percent}
+          subtitle={legendaCobertura(margemMedia.comMargem, margemMedia.total)}
+        />
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/hooks/useBundleArguments.ts
+++ b/src/hooks/useBundleArguments.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
+import type { PerfilCliente } from '@/lib/scoring/perfilCliente';
 
 export interface BundleArgument {
   diagnostico: string;
@@ -13,22 +14,11 @@ export interface BundleArgument {
   versao_tecnica: string;
 }
 
-export type CustomerProfile = 'sensivel_preco' | 'orientado_qualidade' | 'orientado_produtividade' | 'misto';
-
-export const classifyCustomerProfile = (
-  healthScore: number,
-  avgMonthlySpend: number,
-  grossMarginPct: number,
-  categoryCount: number
-): CustomerProfile => {
-  // Price-sensitive: low spend, low margin tolerance
-  if (avgMonthlySpend < 500 && grossMarginPct < 20) return 'sensivel_preco';
-  // Quality-oriented: high margin, fewer categories (focused buyer)
-  if (grossMarginPct > 35 && categoryCount <= 3) return 'orientado_qualidade';
-  // Productivity-oriented: high spend, many categories, high health
-  if (avgMonthlySpend > 2000 && categoryCount >= 4 && healthScore > 60) return 'orientado_produtividade';
-  return 'misto';
-};
+// O classificador migrou para @/lib/scoring/perfilCliente (classificarPerfilCliente): esta
+// cópia e a de useTacticalPlan eram a MESMA regra escrita duas vezes, e ambas comparavam a
+// margem sem guard — `null < 20` é true em JS, então quem só não teve custo apurado saía
+// rotulado "sensível a preço". Blindar uma só deixaria a outra fabricando o rótulo.
+export type CustomerProfile = PerfilCliente;
 
 export const profileLabels: Record<CustomerProfile, { label: string; emoji: string; color: string }> = {
   sensivel_preco: { label: 'Sensível a Preço', emoji: '💰', color: 'text-amber-700' },

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -5,6 +5,7 @@ import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
 import { fetchAllPages } from '@/lib/postgrest';
+import { margemConhecida } from '@/lib/margem';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AssociationRule {
@@ -47,7 +48,8 @@ export interface CustomerBundles {
   bundles: BundleRecommendation[];
   bestIndividual: IndividualComparison | null;
   avgMonthlySpend: number;
-  grossMarginPct: number;
+  /** PERCENTUAL 0-100, ou null quando desconhecida. Ver @/lib/margem. */
+  grossMarginPct: number | null;
   categoryCount: number;
   daysSinceLastPurchase: number;
   cnae: string;
@@ -528,7 +530,9 @@ export const useBundleEngine = () => {
             bundles: topBundles,
             bestIndividual,
             avgMonthlySpend: Number(score.avg_monthly_spend_180d || 0),
-            grossMarginPct: Number(score.gross_margin_pct || 0),
+            // `|| 0` matava o null ANTES do guard de classificarPerfilCliente, tornando a
+            // blindagem do classificador inerte — a coação a montante é que decide.
+            grossMarginPct: margemConhecida(score.gross_margin_pct),
             categoryCount: Number(score.category_count || 0),
             daysSinceLastPurchase: Number(score.days_since_last_purchase || 0),
             cnae: profile.cnae || '',

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -5,6 +5,7 @@ import type { Tables } from '@/integrations/supabase/types';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
 import { fetchAllPages } from '@/lib/postgrest';
 import { accumulateMarginFromItems, resolveProductIdsFromItems } from '@/lib/scoring/margin';
+import { calcularHealthScore } from '@/lib/scoring/healthScore';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
 type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price' | 'cost_final'>;
@@ -45,7 +46,9 @@ export interface ClientScore {
   customer_name: string;
   customer_phone: string | null;
   // Health
-  rf: number; m: number; g: number; x: number; s: number;
+  rf: number; m: number; x: number; s: number;
+  /** Componente de margem 0-1, ou null quando nenhum item do cliente tem custo conhecido. */
+  g: number | null;
   healthScore: number;
   healthClass: 'saudavel' | 'estavel' | 'atencao' | 'critico';
   // Priority
@@ -56,7 +59,8 @@ export interface ClientScore {
   daysSinceLastPurchase: number;
   avgRepurchaseInterval: number;
   avgMonthlySpend180d: number;
-  grossMarginPct: number;
+  /** PERCENTUAL 0-100, ou null quando nenhum item do cliente tem custo conhecido. */
+  grossMarginPct: number | null;
   categoryCount: number;
   answerRate60d: number;
   whatsappReplyRate60d: number;
@@ -347,8 +351,12 @@ export const useFarmerScoring = (farmerId?: string) => {
         const m = clamp(Math.log(1 + avgMonthly) / Math.log(1 + p95MonthlySpend), 0, 1);
 
         // G = clamp((GrossMarginClient - P10Margin) / (P90Margin - P10Margin), 0, 1)
-        const clientMargin = cd.totalRevenue > 0 ? (cd.totalRevenue - cd.totalCost) / cd.totalRevenue : 0;
-        const g = clamp((clientMargin - p10Margin) / marginRange, 0, 1);
+        // Receita 0 = NENHUM item do cliente tem custo conhecido (accumulateMarginFromItems
+        // já exclui SKU sem custo) → margem DESCONHECIDA, não zero. O `: 0` anterior era
+        // incoerente com a própria régua: a linha ~308 exclui esses clientes de `allMargins`
+        // ao montar os percentis, ou seja, o código já reconhecia que receita 0 não é margem 0.
+        const clientMargin = cd.totalRevenue > 0 ? (cd.totalRevenue - cd.totalCost) / cd.totalRevenue : null;
+        const g = clientMargin == null ? null : clamp((clientMargin - p10Margin) / marginRange, 0, 1);
 
         // X = clamp(CatCount / CatTarget, 0, 1)
         const x = clamp(cd.categories.size / config.cat_target, 0, 1);
@@ -358,13 +366,16 @@ export const useFarmerScoring = (farmerId?: string) => {
         const whatsappRate = cd.whatsappCalls60d > 0 ? cd.whatsappReplied60d / cd.whatsappCalls60d : 0;
         const s = 0.7 * answerRate + 0.3 * whatsappRate;
 
-        // Health = 100 * (0.35*RF + 0.20*M + 0.15*G + 0.15*X + 0.15*S)
-        const healthScore = 100 * (
-          config.health_w_rf * rf +
-          config.health_w_m * m +
-          config.health_w_g * g +
-          config.health_w_x * x +
-          config.health_w_s * s
+        // Health = média ponderada das dimensões CONHECIDAS (0.35*RF + 0.20*M + 0.15*G +
+        // 0.15*X + 0.15*S). Margem desconhecida sai da conta e seu peso é redistribuído —
+        // entrar como 0 custaria até 15 pontos ao cliente por ausência de dado. Oráculo
+        // testado em src/lib/scoring/healthScore.ts; espelha o #1495 no calculate-scores.
+        const healthScore = calcularHealthScore(
+          { rf, m, g, x, s },
+          {
+            rf: config.health_w_rf, m: config.health_w_m, g: config.health_w_g,
+            x: config.health_w_x, s: config.health_w_s,
+          },
         );
 
         // ChurnRisk = 100 * (1 - exp(-k1 * max((D/max(I,1)) - 1, 0)))
@@ -407,7 +418,8 @@ export const useFarmerScoring = (farmerId?: string) => {
           daysSinceLastPurchase: D,
           avgRepurchaseInterval: Math.round(I * 10) / 10,
           avgMonthlySpend180d: Math.round(avgMonthly * 100) / 100,
-          grossMarginPct: Math.round(clientMargin * 1000) / 10,
+          // null preservado até a UI: Math.round(null) é 0 e fabricaria "0,0% de margem".
+          grossMarginPct: clientMargin == null ? null : Math.round(clientMargin * 1000) / 10,
           categoryCount: cd.categories.size,
           answerRate60d: Math.round(answerRate * 1000) / 10,
           whatsappReplyRate60d: Math.round(whatsappRate * 1000) / 10,

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,6 +1,10 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
+import { margemConhecida, mediaMargemConhecida } from '@/lib/margem';
+import { classificarPerfilCliente } from '@/lib/scoring/perfilCliente';
+import { profitPerHora } from '@/lib/tactical/pregeracao';
+import { fetchAllPages } from '@/lib/postgrest';
 import { ownersAtivosDoAlvo } from '@/lib/carteira/escopo-clientes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
@@ -23,7 +27,8 @@ export interface TacticalPlan {
   healthScore: number;
   churnRisk: number;
   mixGap: number;
-  currentMarginPct: number;
+  /** PERCENTUAL 0-100, ou null quando a margem era desconhecida na geração do plano. */
+  currentMarginPct: number | null;
   clusterAvgMarginPct: number | null;
   expansionPotential: number;
 
@@ -53,7 +58,8 @@ export interface TacticalPlan {
   operationalRisks: string[];
 
   // Efficiency
-  estimatedProfitPerHour: number;
+  /** R$/h estimado, ou null quando a margem é desconhecida (gate não decidível). */
+  estimatedProfitPerHour: number | null;
 
   // Tracking
   status: string;
@@ -168,7 +174,8 @@ interface DiagnosticData {
 }
 
 export interface EfficiencyCheck {
-  estimatedProfitPerHour: number;
+  /** R$/h estimado, ou null quando a margem do cliente é desconhecida — "não sei", não R$0/h. */
+  estimatedProfitPerHour: number | null;
   threshold: number;
   isAboveThreshold: boolean;
 }
@@ -184,12 +191,9 @@ const objectiveLabels: Record<string, string> = {
 
 export const getObjectiveLabel = (obj: string) => objectiveLabels[obj] || obj;
 
-const classifyProfile = (healthScore: number, avgSpend: number, marginPct: number, categoryCount: number): string => {
-  if (avgSpend < 500 && marginPct < 20) return 'sensivel_preco';
-  if (marginPct > 35 && categoryCount <= 3) return 'orientado_qualidade';
-  if (avgSpend > 2000 && categoryCount >= 4 && healthScore > 60) return 'orientado_produtividade';
-  return 'misto';
-};
+// classifyProfile migrou para @/lib/scoring/perfilCliente (classificarPerfilCliente), que
+// unifica esta cópia com a de useBundleArguments e guarda os ramos de margem contra null —
+// `null < 20` é true em JS e rotularia como "sensível a preço" quem só não teve custo apurado.
 
 const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h configurable threshold
 
@@ -230,7 +234,9 @@ export const useTacticalPlan = () => {
       healthScore: Number(d.health_score || 0),
       churnRisk: Number(d.churn_risk || 0),
       mixGap: Number(d.mix_gap || 0),
-      currentMarginPct: Number(d.current_margin_pct || 0),
+      // O plano persistido grava a margem do cliente no momento da geração; pós-#1495 ela
+      // pode ser null e `Number(null || 0)` a exibiria como "0%" — margem nula CONHECIDA.
+      currentMarginPct: margemConhecida(d.current_margin_pct),
       clusterAvgMarginPct: d.cluster_avg_margin_pct == null ? null : Number(d.cluster_avg_margin_pct),
       expansionPotential: Number(d.expansion_potential || 0),
       strategicObjective: d.strategic_objective,
@@ -323,7 +329,8 @@ export const useTacticalPlan = () => {
 
   // Check efficiency before generating
   const checkEfficiency = useCallback(async (customerId: string): Promise<EfficiencyCheck> => {
-    if (!user?.id) return { estimatedProfitPerHour: 0, threshold: PROFIT_PER_HOUR_THRESHOLD, isAboveThreshold: false };
+    // Sem sessão não há o que estimar: `null` = "não sei", não R$0/h.
+    if (!user?.id) return { estimatedProfitPerHour: null, threshold: PROFIT_PER_HOUR_THRESHOLD, isAboveThreshold: false };
 
     const { data: score } = (await supabase
       .from('farmer_client_scores')
@@ -333,17 +340,20 @@ export const useTacticalPlan = () => {
       .eq('customer_user_id', customerId)
       .single()) as unknown as { data: Pick<ClientScoreFull, 'revenue_potential' | 'avg_monthly_spend_180d' | 'gross_margin_pct'> | null };
 
-    const revPotential = Number(score?.revenue_potential || 0);
-    const avgSpend = Number(score?.avg_monthly_spend_180d || 0);
-    const marginPct = Number(score?.gross_margin_pct || 0);
-    const estimatedMarginPerCall = (revPotential > 0 ? revPotential : avgSpend) * (marginPct / 100) * 0.1;
-    const avgCallMinutes = 15;
-    const estimatedProfitPerHour = estimatedMarginPerCall / (avgCallMinutes / 60);
+    // Delega ao oráculo testado (src/lib/tactical/pregeracao.ts) em vez de repetir a fórmula:
+    // ele já devolve `null` quando a margem é desconhecida. Sem margem o gate de R$/h NÃO é
+    // decidível — `|| 0` dava R$0/h, indistinguível de "cliente comprovadamente ruim", e o
+    // alerta dizia à vendedora que não valia a ligação com base em dado que ninguém mediu.
+    const estimatedProfitPerHour = profitPerHora({
+      revenuePotential: Number(score?.revenue_potential || 0),
+      avgSpend: Number(score?.avg_monthly_spend_180d || 0),
+      marginPct: margemConhecida(score?.gross_margin_pct),
+    });
 
     return {
       estimatedProfitPerHour,
       threshold: PROFIT_PER_HOUR_THRESHOLD,
-      isAboveThreshold: estimatedProfitPerHour >= PROFIT_PER_HOUR_THRESHOLD,
+      isAboveThreshold: estimatedProfitPerHour != null && estimatedProfitPerHour >= PROFIT_PER_HOUR_THRESHOLD,
     };
   }, [user]);
 
@@ -387,7 +397,10 @@ export const useTacticalPlan = () => {
       const healthScore = Number(score.health_score || 0);
       const churnRisk = Number(score.churn_risk || 0);
       const avgSpend = Number(score.avg_monthly_spend_180d || 0);
-      const marginPct = Number(score.gross_margin_pct || 0);
+      // `|| 0` afirmaria "margem zero" (cliente não-lucrativo) sobre quem não teve custo
+      // apurado. O null atravessa até classificarPerfilCliente e selectObjective, que sabem
+      // não decidir sem margem.
+      const marginPct = margemConhecida(score.gross_margin_pct);
       const categoryCount = Number(score.category_count || 0);
       const daysSince = Number(score.days_since_last_purchase || 0);
       const expansionPotential = Number(score.expansion_score || 0);
@@ -401,20 +414,25 @@ export const useTacticalPlan = () => {
       // carteira do coberto (carteira_visivel_para via carteira_coverage). Exclui o próprio cliente
       // (peer benchmark) e exige ≥1 par com margem finita; sem par → null (selectObjective trata;
       // nada de 25).
+      // [GUARD money-path] PAGINADO. A consulta era single-shot e o PostgREST capa em 1.000
+      // linhas em SILÊNCIO — medido em prod (2026-07-21) os três farmers têm 3.858, 1.528 e
+      // 1.246 clientes, ou seja TODOS truncavam. O cluster é a RÉGUA contra a qual a margem do
+      // cliente é julgada (`margem < cluster * 0.8` → consolidacao_margem): calculá-lo sobre
+      // 26% dos pares produz um veredito plausível e errado. Hoje é inerte (a coluna é 0 em
+      // 6.632/6.632), o #1495 ativa. Ordem por `customer_user_id` (UNIQUE) — sem ordem estável
+      // a paginação pula e repete linha.
       let clusterMargin: number | null = null;
       {
-        const { data: peers } = (await supabase
-          .from('farmer_client_scores')
-          .select('gross_margin_pct')
-          .eq('farmer_id', ownerId)
-          .neq('customer_user_id', customerId)) as unknown as { data: Pick<ClientScoreFull, 'gross_margin_pct'>[] | null };
-        const peerMargins = (peers ?? [])
-          .filter((r) => r.gross_margin_pct != null)
-          .map((r) => Number(r.gross_margin_pct))
-          .filter((m) => Number.isFinite(m));
-        if (peerMargins.length >= 1) {
-          clusterMargin = peerMargins.reduce((s, m) => s + m, 0) / peerMargins.length;
-        }
+        const peers = await fetchAllPages<Pick<ClientScoreFull, 'gross_margin_pct'>>((de, ate) =>
+          supabase
+            .from('farmer_client_scores')
+            .select('gross_margin_pct')
+            .eq('farmer_id', ownerId)
+            .neq('customer_user_id', customerId)
+            .order('customer_user_id', { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: Pick<ClientScoreFull, 'gross_margin_pct'>[] | null }>,
+        );
+        clusterMargin = mediaMargemConhecida(peers.map((r) => r.gross_margin_pct)).media;
       }
 
       // Bundle pendente do cliente sob a carteira do DONO (ownerId), não do viewer. A tabela é
@@ -431,7 +449,7 @@ export const useTacticalPlan = () => {
         .limit(2)) as unknown as { data: BundleRow[] | null };
 
       const mixGap = Math.max(0, 8 - categoryCount);
-      const customerProfile = classifyProfile(healthScore, avgSpend, marginPct, categoryCount);
+      const customerProfile = classificarPerfilCliente(healthScore, avgSpend, marginPct, categoryCount);
       const recencyCapDays = clampRecencyCapDays(recencyCapRow?.value);
       const strategicObjective = selectObjective(churnRisk, mixGap, marginPct, clusterMargin, daysSince, recencyCapDays, salesHistoryStatus);
 

--- a/src/lib/carteira/escopo-clientes.ts
+++ b/src/lib/carteira/escopo-clientes.ts
@@ -3,6 +3,7 @@
 // Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
 import { supabase } from '@/integrations/supabase/client';
 import type { Customer, ClientScore } from '@/components/adminCustomers/types';
+import { margemConhecida } from '@/lib/margem';
 
 export interface DisplayFlags {
   displayIsMaster: boolean;
@@ -184,7 +185,9 @@ export async function fetchScoresPorCustomer(ids: string[]): Promise<Map<string,
       avg_monthly_spend_180d: s.avg_monthly_spend_180d ?? 0,
       days_since_last_purchase: s.days_since_last_purchase ?? 0,
       category_count: s.category_count ?? 0,
-      gross_margin_pct: s.gross_margin_pct ?? 0,
+      // `?? 0` afirmaria "margem zero" (cliente não-lucrativo) sobre quem não tem custo
+      // conhecido. Degrada para null e deixa o consumidor decidir — money-path §2.
+      gross_margin_pct: margemConhecida(s.gross_margin_pct),
       sales_history_status: s.sales_history_status ?? null,
     });
   }

--- a/src/lib/margem/index.ts
+++ b/src/lib/margem/index.ts
@@ -1,0 +1,108 @@
+// Consumo honesto de `farmer_client_scores.gross_margin_pct` no front.
+//
+// ESPELHO SEMÂNTICO de `supabase/functions/_shared/tactical-margem.ts` (Deno não importa de
+// `src/`) — mudou a semântica de ausência aqui, mude lá.
+//
+// PRINCÍPIO (money-path, "ausente ≠ zero"): margem desconhecida degrada para `null` e o
+// consumidor EXCLUI o cliente do cálculo. Nunca 0 — `0` é o VEREDITO de negócio "cliente
+// não-lucrativo", e afirmá-lo sobre quem não tem custo conhecido é fabricar diagnóstico.
+//
+// ESCALA: PERCENTUAL 0-100 (56 = 56%). Não é fração. O produtor (#1495) grava assim — o
+// harness PG17 dele afirma `gross_margin_pct = "56.00"` para margem de 56%, e preserva
+// negativo ("-60.00") quando o cliente foi vendido no prejuízo. Havia consumidor comparando
+// contra `0.3`/`0.15` e multiplicando por 100; enquanto a coluna era `0` em 6.632/6.632
+// linhas o erro era invisível, e o #1495 o ativaria.
+
+/** Fronteira "margem alta" em pontos percentuais. Era `>= 0.3` em CustomerHero (fração). */
+export const MARGEM_ALTA_PCT = 30;
+/** Fronteira "margem média" em pontos percentuais. Era `>= 0.15` em CustomerHero (fração). */
+export const MARGEM_MEDIA_PCT = 15;
+
+export type FaixaMargem = 'alta' | 'media' | 'baixa' | 'desconhecida';
+
+/** Margem utilizável, ou `null` se desconhecida.
+ *
+ *  ⚠️ `0` é CONHECIDO (margem nula real); só ausência/não-finito/não-numérico viram null.
+ *
+ *  Mais estrito que o espelho do edge de propósito: `Number('')`, `Number(' ')`,
+ *  `Number(false)` e `Number([])` são todos `0`, então um `Number(raw)` solto fabricaria
+ *  exatamente o veredito que este módulo existe para impedir. `numeric` do Postgres não
+ *  produz esses valores — é defesa em profundidade, não bug medido —, mas o tipo declarado
+ *  nos hooks é `number | string | null` e barrar custa uma linha. */
+export function margemConhecida(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string') {
+    const texto = raw.trim();
+    if (texto === '') return null;
+    const n = Number(texto);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Média das margens CONHECIDAS, com a cobertura que a produziu.
+ *
+ *  O desconhecido sai do numerador E do denominador. Trocar ausente por 0 antes de dividir
+ *  não "aproxima" a média — puxa-a para baixo na proporção exata da ignorância, e o número
+ *  resultante é indistinguível de um KPI legítimo.
+ *
+ *  `comMargem`/`total` NÃO são decorativos: pós-#1495, ~84% da base fica sem margem, então
+ *  a média representa uma fatia pequena e o chamador DEVE dizer isso na tela (money-path:
+ *  no silent caps). Nenhuma margem conhecida → `media: null`, jamais 0 nem NaN de 0/0. */
+export function mediaMargemConhecida(valores: readonly unknown[]): {
+  media: number | null;
+  comMargem: number;
+  total: number;
+} {
+  const conhecidas: number[] = [];
+  for (const valor of valores) {
+    const m = margemConhecida(valor);
+    if (m != null) conhecidas.push(m);
+  }
+  const total = valores.length;
+  if (conhecidas.length === 0) return { media: null, comMargem: 0, total };
+  return {
+    media: conhecidas.reduce((soma, m) => soma + m, 0) / conhecidas.length,
+    comMargem: conhecidas.length,
+    total,
+  };
+}
+
+/** Legenda de cobertura para acompanhar uma média de margem na tela.
+ *
+ *  Uma média que representa 16% da base e uma que representa 100% são números diferentes
+ *  disfarçados do mesmo jeito. Enquanto a fatia coberta não estiver escrita ao lado do KPI,
+ *  quem lê assume "todos os clientes" — que é a leitura errada pós-#1495. */
+export function legendaCobertura(comMargem: number, total: number): string {
+  if (total === 0) return 'sem clientes';
+  if (comMargem === 0) return 'nenhum cliente c/ margem conhecida';
+  const cobertos = comMargem.toLocaleString('pt-BR');
+  if (comMargem === total) return `${cobertos} clientes c/ margem`;
+  return `parcial — ${cobertos} de ${total.toLocaleString('pt-BR')} clientes c/ margem`;
+}
+
+/** Faixa semântica da margem, em PERCENTUAL 0-100.
+ *
+ *  Ausência tem faixa PRÓPRIA (`desconhecida`) em vez de cair na mais baixa: pintar de
+ *  vermelho quem não foi medido afirma "margem ruim" com a mesma confiança de quem foi. */
+export function faixaMargem(raw: unknown): FaixaMargem {
+  const m = margemConhecida(raw);
+  if (m == null) return 'desconhecida';
+  if (m >= MARGEM_ALTA_PCT) return 'alta';
+  if (m >= MARGEM_MEDIA_PCT) return 'media';
+  return 'baixa';
+}
+
+/** Margem para exibição: `"56%"` / `"0,5%"` / `"—"` quando desconhecida.
+ *
+ *  Sem heurística de escala. `formatPctMaybe` (customer360/format.ts) adivinha a unidade com
+ *  `v > 1 ? v : v * 100`, o que quebra nos dois extremos que o #1495 torna alcançáveis:
+ *  0,5% viraria "50%" e -60% viraria "-6000%". Aqui a unidade é contrato, não palpite. */
+export function formatarMargemPct(raw: unknown): string {
+  const m = margemConhecida(raw);
+  if (m == null) return '—';
+  const arredondado = Math.round(m);
+  if (Math.abs(m - arredondado) < 0.05) return `${arredondado}%`;
+  return `${m.toFixed(1).replace('.', ',')}%`;
+}

--- a/src/lib/margem/margem.test.ts
+++ b/src/lib/margem/margem.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest';
+import {
+  margemConhecida,
+  mediaMargemConhecida,
+  legendaCobertura,
+  faixaMargem,
+  formatarMargemPct,
+  MARGEM_ALTA_PCT,
+  MARGEM_MEDIA_PCT,
+} from './index';
+
+// Oráculo do consumo de `farmer_client_scores.gross_margin_pct` no front.
+//
+// Contexto medido em prod (2026-07-21): a coluna é `0` LITERAL em 6.632/6.632 linhas
+// (`column_default = 0`). O PR produtor (#1495) passa a gravar NULL em 5.579 (84,1%) e
+// PERCENTUAL 0-100 no resto. Os dois fatos abaixo é que este oráculo trava:
+//
+//   1. ausente ≠ zero — `0` é o VEREDITO "cliente não-lucrativo", não "não sei";
+//   2. a escala é PERCENTUAL 0-100 (o PG17 do #1495 afirma "56.00" p/ 56%), e havia
+//      consumidor comparando contra 0.3/0.15 (fração) e multiplicando por 100.
+
+describe('margemConhecida', () => {
+  it('trata 0 como CONHECIDO — margem nula real é um fato, não ausência', () => {
+    expect(margemConhecida(0)).toBe(0);
+  });
+
+  it('preserva margem negativa (cliente vendido no prejuízo é dado real)', () => {
+    expect(margemConhecida(-60)).toBe(-60);
+  });
+
+  it('preserva percentual positivo sem reescalar', () => {
+    expect(margemConhecida(56)).toBe(56);
+    expect(margemConhecida(0.5)).toBe(0.5); // 0,5% — NÃO é "50%"
+  });
+
+  it('degrada ausência para null, nunca para 0', () => {
+    expect(margemConhecida(null)).toBeNull();
+    expect(margemConhecida(undefined)).toBeNull();
+  });
+
+  it('degrada não-finito para null (NaN/Infinity não são margem)', () => {
+    expect(margemConhecida(NaN)).toBeNull();
+    expect(margemConhecida(Infinity)).toBeNull();
+    expect(margemConhecida(-Infinity)).toBeNull();
+  });
+
+  it('aceita numeric serializado como string (PostgREST)', () => {
+    expect(margemConhecida('56.00')).toBe(56);
+    expect(margemConhecida('-60')).toBe(-60);
+  });
+
+  // Defesa em profundidade, NÃO bug medido: `numeric` do Postgres não produz "" nem " ".
+  // Mas o tipo declarado nos hooks é `number | string | null`, e `Number('')` é 0 — a
+  // fabricação exata que este módulo existe para impedir. Custa uma linha barrar.
+  it('não deixa string vazia/branca virar 0 (Number("") === 0)', () => {
+    expect(margemConhecida('')).toBeNull();
+    expect(margemConhecida('   ')).toBeNull();
+  });
+
+  it('não deixa tipo não-numérico virar 0 (Number(false)/Number([]) === 0)', () => {
+    expect(margemConhecida('abc')).toBeNull();
+    expect(margemConhecida(false)).toBeNull();
+    expect(margemConhecida([])).toBeNull();
+    expect(margemConhecida({})).toBeNull();
+  });
+});
+
+describe('mediaMargemConhecida', () => {
+  it('exclui o desconhecido do numerador E do denominador', () => {
+    // Com `|| 0`: (40 + 60 + 0 + 0) / 4 = 25 — um KPI que ninguém reconheceria como errado.
+    // Correto: (40 + 60) / 2 = 50.
+    const r = mediaMargemConhecida([40, 60, null, undefined]);
+    expect(r.media).toBe(50);
+    expect(r.comMargem).toBe(2);
+    expect(r.total).toBe(4);
+  });
+
+  it('conta o 0 legítimo no denominador (é margem conhecida)', () => {
+    const r = mediaMargemConhecida([60, 0]);
+    expect(r.media).toBe(30);
+    expect(r.comMargem).toBe(2);
+  });
+
+  it('nenhuma margem conhecida → media null, jamais 0', () => {
+    const r = mediaMargemConhecida([null, null, undefined]);
+    expect(r.media).toBeNull();
+    expect(r.comMargem).toBe(0);
+    expect(r.total).toBe(3);
+  });
+
+  it('lista vazia → media null (não NaN de 0/0)', () => {
+    const r = mediaMargemConhecida([]);
+    expect(r.media).toBeNull();
+    expect(r.total).toBe(0);
+  });
+
+  it('reporta a cobertura no cenário real pós-#1495 (84% ausente)', () => {
+    // 1.053 conhecidas de 6.632: a média representa 16% da base e a UI precisa dizer isso.
+    const valores = [
+      ...Array.from({ length: 1053 }, () => 50),
+      ...Array.from({ length: 5579 }, () => null),
+    ];
+    const r = mediaMargemConhecida(valores);
+    expect(r.media).toBe(50);
+    expect(r.comMargem).toBe(1053);
+    expect(r.total).toBe(6632);
+  });
+});
+
+describe('legendaCobertura', () => {
+  it('declara que a média é parcial quando falta margem', () => {
+    expect(legendaCobertura(1053, 6632)).toBe('parcial — 1.053 de 6.632 clientes c/ margem');
+  });
+
+  it('não diz "parcial" quando todos os clientes têm margem', () => {
+    expect(legendaCobertura(10, 10)).toBe('10 clientes c/ margem');
+  });
+
+  it('nenhum cliente com margem → diz isso em vez de mostrar cobertura 0', () => {
+    expect(legendaCobertura(0, 6632)).toBe('nenhum cliente c/ margem conhecida');
+  });
+
+  it('base vazia não vira "0 de 0"', () => {
+    expect(legendaCobertura(0, 0)).toBe('sem clientes');
+  });
+});
+
+describe('faixaMargem', () => {
+  it('classifica em PERCENTUAL 0-100, não em fração', () => {
+    expect(faixaMargem(56)).toBe('alta');
+    expect(faixaMargem(20)).toBe('media');
+    expect(faixaMargem(5)).toBe('baixa');
+  });
+
+  // Regressão do bug de unidade: CustomerHero comparava `>= 0.3` contra uma coluna 0-100.
+  // Pós-#1495 isso pintaria de VERDE qualquer cliente com margem acima de 0,3%.
+  it('margem de 5% é BAIXA — não "alta" por passar de 0.3', () => {
+    expect(faixaMargem(5)).not.toBe('alta');
+  });
+
+  it('margem de 0,5% é baixa (a fração 0.5 não vale 50%)', () => {
+    expect(faixaMargem(0.5)).toBe('baixa');
+  });
+
+  it('respeita as fronteiras declaradas', () => {
+    expect(faixaMargem(MARGEM_ALTA_PCT)).toBe('alta');
+    expect(faixaMargem(MARGEM_ALTA_PCT - 0.01)).toBe('media');
+    expect(faixaMargem(MARGEM_MEDIA_PCT)).toBe('media');
+    expect(faixaMargem(MARGEM_MEDIA_PCT - 0.01)).toBe('baixa');
+  });
+
+  it('margem negativa é baixa, não desconhecida', () => {
+    expect(faixaMargem(-60)).toBe('baixa');
+  });
+
+  it('ausente é "desconhecida" — não cai na faixa mais baixa', () => {
+    expect(faixaMargem(null)).toBe('desconhecida');
+    expect(faixaMargem(undefined)).toBe('desconhecida');
+    expect(faixaMargem(NaN)).toBe('desconhecida');
+  });
+
+  it('0 conhecido é baixa (veredito real), não desconhecida', () => {
+    expect(faixaMargem(0)).toBe('baixa');
+  });
+});
+
+describe('formatarMargemPct', () => {
+  it('mostra "—" para margem desconhecida, nunca um número', () => {
+    expect(formatarMargemPct(null)).toBe('—');
+    expect(formatarMargemPct(undefined)).toBe('—');
+    expect(formatarMargemPct(NaN)).toBe('—');
+  });
+
+  it('não reescala: 56 é 56%, não 5600%', () => {
+    expect(formatarMargemPct(56)).toBe('56%');
+  });
+
+  // Regressão da heurística `v > 1 ? v : v * 100` de formatPctMaybe: com margem negativa
+  // (que o #1495 preserva) o ramo `false` multiplicava por 100 → "-6000%".
+  it('margem negativa não é multiplicada por 100', () => {
+    expect(formatarMargemPct(-60)).toBe('-60%');
+  });
+
+  it('margem abaixo de 1% não vira dezenas (0,5% ≠ 50%)', () => {
+    expect(formatarMargemPct(0.5)).toBe('0,5%');
+  });
+
+  it('0 conhecido é exibido como 0%, não como "—"', () => {
+    expect(formatarMargemPct(0)).toBe('0%');
+  });
+
+  it('usa vírgula decimal (pt-BR) e omite decimal quando inteiro', () => {
+    expect(formatarMargemPct(56.4)).toBe('56,4%');
+    expect(formatarMargemPct(56.04)).toBe('56%');
+  });
+});

--- a/src/lib/margem/sem-coacao.test.ts
+++ b/src/lib/margem/sem-coacao.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Guard de REGRESSÃO textual sobre os consumidores de margem que não têm teste unitário
+// próprio (hooks com query no meio do caminho, componentes de KPI).
+//
+// Por que textual: o tipo `number | null` NÃO protege contra `|| 0` e `?? 0` — a coerção
+// produz `number`, perfeitamente tipada, e o typecheck passa verde. Foi exatamente assim
+// que a coação sobreviveu até aqui. E a lição da cadeia dos bundles é que basta UM `|| 0`
+// a montante para tornar inerte o guard que está a jusante (useBundleEngine matava o null
+// antes de classificarPerfilCliente poder decidir não decidir).
+//
+// Escopo deliberadamente estreito: só a coação da COLUNA de margem, nos arquivos listados.
+// Não é um linter de estilo — é a trava do invariante "ausente ≠ zero" no money-path.
+
+const RAIZ = resolve(__dirname, '../../..');
+
+/** Arquivos que leem a margem do score e já foram migrados para o helper. */
+const CONSUMIDORES = [
+  'src/hooks/useBundleEngine.ts',
+  'src/hooks/useTacticalPlan.ts',
+  'src/hooks/useFarmerScoring.ts',
+  'src/lib/carteira/escopo-clientes.ts',
+  'src/components/adminCustomers/Customer360View.tsx',
+  'src/components/customer360/CustomerHero.tsx',
+  'src/components/intelligence/IntelligenceManagerialTab.tsx',
+  'src/components/intelligence/IntelligenceStrategicTab.tsx',
+  'src/components/farmer/bundles/CustomerBundleCard.tsx',
+  'src/components/farmer/copilot/useFarmerCopilot.ts',
+];
+
+/** Remove comentários antes de casar: um `|| 0` citado em comentário explicando o bug
+ *  produziria falso-vermelho, e o inverso (código escondido em comentário) não existe.
+ *  Mesma lição do #1488 — assert sobre texto mede prosa se não normalizar antes. */
+function semComentarios(fonte: string): string {
+  return fonte
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/** Casa coação aplicada à margem PERCENTUAL do cliente — e SÓ a ela.
+ *
+ *  ⚠️ Escopado a nomes exatos de propósito. A primeira versão casava `[mM]argin` solto e
+ *  acusou `actual_margin || 0` e `bundle_incremental_margin || 0`, que são valores em R$ —
+ *  para os quais `|| 0` é legítimo (somatório de dinheiro). Predicado que varre a vizinhança
+ *  reprova código correto e ensina a ignorar o vermelho (money-path §"o VALIDADOR mente",
+ *  #1490). Se um campo percentual novo aparecer, acrescente-o aqui explicitamente. */
+const CAMPOS = [
+  'gross_margin_pct',
+  'grossMarginPct',
+  'current_margin_pct',
+  'currentMarginPct',
+  'marginPct',
+  'clusterMargin',
+];
+const COACAO = new RegExp(`(?:${CAMPOS.join('|')})\\s*(?:\\|\\||\\?\\?)\\s*0`);
+
+describe('consumidores de margem não coagem ausência para zero', () => {
+  it.each(CONSUMIDORES)('%s não contém `margem || 0` nem `margem ?? 0`', (relativo) => {
+    const fonte = semComentarios(readFileSync(resolve(RAIZ, relativo), 'utf8'));
+    const linhas = fonte.split('\n');
+    const ofensoras = linhas
+      .map((linha, i) => ({ linha: linha.trim(), n: i + 1 }))
+      .filter(({ linha }) => COACAO.test(linha));
+
+    expect(
+      ofensoras,
+      `Coação de margem reintroduzida em ${relativo}:\n` +
+        ofensoras.map((o) => `  linha ${o.n}: ${o.linha}`).join('\n') +
+        '\n\nUse margemConhecida() de @/lib/margem. `0` é o veredito ' +
+        '"cliente não-lucrativo"; ausência é null.',
+    ).toEqual([]);
+  });
+});
+
+describe('o guard textual tem dente', () => {
+  // Falsificação embutida: se o regex parasse de casar (typo, refactor do padrão), a suíte
+  // acima ficaria verde para sempre e ninguém notaria. Estes casos fixam o que ele detecta.
+  it('detecta as formas de coação que já existiram no código', () => {
+    expect(COACAO.test('Number(score.gross_margin_pct || 0)')).toBe(true);
+    expect(COACAO.test('s.gross_margin_pct ?? 0')).toBe(true);
+    expect(COACAO.test('data.grossMarginPct || 0')).toBe(true);
+    expect(COACAO.test('const marginPct = Number(score?.gross_margin_pct || 0);')).toBe(true);
+  });
+
+  it('não acusa uso legítimo', () => {
+    expect(COACAO.test('margemConhecida(score.gross_margin_pct)')).toBe(false);
+    expect(COACAO.test('const categoryCount = Number(score.category_count || 0);')).toBe(false);
+    expect(COACAO.test('formatarMargemPct(plan.currentMarginPct)')).toBe(false);
+  });
+
+  it('ignora coação citada em comentário (senão o próprio aviso vira vermelho)', () => {
+    const fonte = semComentarios('// evite gross_margin_pct || 0 aqui\nconst x = 1;');
+    expect(COACAO.test(fonte)).toBe(false);
+  });
+});

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -609,6 +609,7 @@ export const MODULOS: ModuloApp[] = [
       "src/components/VoiceServiceInput.tsx",
       "src/lib/impersonation/**",
       "src/lib/mcp/**",
+      "src/lib/margem/**",
       "src/lib/nav/**",
       "src/lib/omie/**",
       "src/lib/posthog-error/**",

--- a/src/lib/scoring/__tests__/healthScore.test.ts
+++ b/src/lib/scoring/__tests__/healthScore.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { calcularHealthScore, type PesosHealth } from '../healthScore';
+
+// Oráculo da composição do health score do motor client-side (useFarmerScoring).
+//
+// O ponto: margem DESCONHECIDA não pode entrar como 0 numa média ponderada. Entrar como 0
+// não é neutro — é a pior nota possível naquele eixo, então o cliente sem custo apurado
+// levaria uma penalidade de até 15 pontos por um dado que ninguém mediu.
+//
+// ESPELHO da renormalização que o #1495 aplicou em supabase/functions/calculate-scores.
+
+const PESOS: PesosHealth = { rf: 0.35, m: 0.2, g: 0.15, x: 0.15, s: 0.15 };
+
+describe('calcularHealthScore — margem conhecida', () => {
+  it('compõe a média ponderada normalmente', () => {
+    // 100*(0.35*1 + 0.20*1 + 0.15*1 + 0.15*1 + 0.15*1) = 100
+    expect(calcularHealthScore({ rf: 1, m: 1, g: 1, x: 1, s: 1 }, PESOS)).toBe(100);
+  });
+
+  it('g = 0 CONHECIDO penaliza de verdade (margem nula real é veredito)', () => {
+    // 100*(0.35 + 0.20 + 0 + 0.15 + 0.15) = 85. toBeCloseTo porque a soma de floats
+    // devolve 85.00000000000001 — a fórmula está certa, a igualdade exata é que não cabe.
+    expect(calcularHealthScore({ rf: 1, m: 1, g: 0, x: 1, s: 1 }, PESOS)).toBeCloseTo(85, 6);
+  });
+});
+
+describe('calcularHealthScore — margem desconhecida renormaliza', () => {
+  it('g null NÃO penaliza: o peso é redistribuído entre as dimensões conhecidas', () => {
+    // Sem renormalizar seriam 85 (o mesmo que margem zero conhecida) — indistinguível de
+    // "cliente ruim". Renormalizado: 100*(0.85/0.85) = 100.
+    expect(calcularHealthScore({ rf: 1, m: 1, g: null, x: 1, s: 1 }, PESOS)).toBe(100);
+  });
+
+  it('g null preserva a proporção entre as demais dimensões', () => {
+    // rf=1, m=0, x=1, s=0 → (0.35 + 0.15) / 0.85 = 0.5882... → 58.82
+    const r = calcularHealthScore({ rf: 1, m: 0, g: null, x: 1, s: 0 }, PESOS);
+    expect(r).toBeCloseTo(58.82, 1);
+  });
+
+  it('cliente sem margem não fica ABAIXO do idêntico com margem zero conhecida', () => {
+    const semMargem = calcularHealthScore({ rf: 0.5, m: 0.5, g: null, x: 0.5, s: 0.5 }, PESOS);
+    const margemZero = calcularHealthScore({ rf: 0.5, m: 0.5, g: 0, x: 0.5, s: 0.5 }, PESOS);
+    expect(semMargem).toBeGreaterThan(margemZero);
+  });
+});
+
+describe('calcularHealthScore — bordas', () => {
+  it('todos os pesos zerados → 0, sem NaN de 0/0', () => {
+    const r = calcularHealthScore(
+      { rf: 1, m: 1, g: 1, x: 1, s: 1 },
+      { rf: 0, m: 0, g: 0, x: 0, s: 0 },
+    );
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+
+  it('só a margem tem peso e ela é desconhecida → 0, não NaN', () => {
+    const r = calcularHealthScore(
+      { rf: 1, m: 1, g: null, x: 1, s: 1 },
+      { rf: 0, m: 0, g: 1, x: 0, s: 0 },
+    );
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+
+  it('pesos que não somam 1 ainda produzem escala 0-100 (a divisão normaliza)', () => {
+    const r = calcularHealthScore(
+      { rf: 1, m: 1, g: 1, x: 1, s: 1 },
+      { rf: 0.5, m: 0.5, g: 0.5, x: 0.5, s: 0.5 },
+    );
+    expect(r).toBe(100);
+  });
+});

--- a/src/lib/scoring/__tests__/objective.test.ts
+++ b/src/lib/scoring/__tests__/objective.test.ts
@@ -85,4 +85,17 @@ describe('selectObjective — cluster AUSENTE (null) degrada honesto (money-path
   it('cluster presente baixo ainda dispara consolidacao quando margem < cluster*0.8', () => {
     expect(selectObjective(0, 0, 10, 25, 0, cap)).toBe('consolidacao_margem'); // 10 < 20
   });
+
+  it('margem do CLIENTE null NÃO dispara consolidacao_margem (null < 24 é true em JS)', () => {
+    // Simétrico ao cluster ausente, e a via que o #1495 abre: pós-produtor, ~84% dos clientes
+    // ficam sem margem. Sem o guard, `null < cluster*0.8` coage null a 0 e TODO cliente sem
+    // custo apurado receberia o objetivo "consolidar margem" — uma tese sobre a margem dele
+    // afirmada justamente por não conhecê-la.
+    expect(selectObjective(50, 2, null, 30, 10, cap)).toBe('upsell_premium');
+    expect(selectObjective(0, 0, null, 25, 0, cap)).toBe('upsell_premium');
+  });
+
+  it('margem 0 CONHECIDA continua disparando consolidacao (0 é veredito, não ausência)', () => {
+    expect(selectObjective(0, 0, 0, 25, 0, cap)).toBe('consolidacao_margem'); // 0 < 20
+  });
 });

--- a/src/lib/scoring/__tests__/perfilCliente.test.ts
+++ b/src/lib/scoring/__tests__/perfilCliente.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { classificarPerfilCliente } from '../perfilCliente';
+
+// Oráculo do perfil comercial do cliente. O rótulo entra no prompt da IA que gera a
+// abordagem (`generate-bundle-argument`, `generate-tactical-plan`), então um perfil
+// fabricado vira a conversa que a vendedora leva para a rua.
+//
+// ESPELHO de supabase/functions/_shared/tactical-margem.ts:classifyProfile (já blindado
+// pelo #1498). Este módulo unifica as DUAS cópias que existiam no front —
+// useTacticalPlan.classifyProfile e useBundleArguments.classifyCustomerProfile.
+
+describe('classificarPerfilCliente — margem desconhecida não decide', () => {
+  it('gasto baixo + margem DESCONHECIDA não vira "sensivel_preco"', () => {
+    // `null < 20` é true em JS (null coage a 0). Sem o guard, todo cliente de gasto baixo
+    // sem custo apurado seria rotulado sensível a preço — e a vendedora entraria com
+    // desconto na mão por causa de um dado que ninguém mediu.
+    expect(classificarPerfilCliente(50, 400, null, 5)).toBe('misto');
+    expect(classificarPerfilCliente(50, 400, undefined as unknown as null, 5)).toBe('misto');
+  });
+
+  it('margem DESCONHECIDA não vira "orientado_qualidade"', () => {
+    // `null > 35` é false, então este ramo não dispara por coação — mas o guard explícito
+    // impede que uma futura inversão do comparador o reintroduza em silêncio.
+    expect(classificarPerfilCliente(50, 400, null, 2)).toBe('misto');
+  });
+
+  it('NaN e não-finito são desconhecidos, não margem zero', () => {
+    expect(classificarPerfilCliente(50, 400, NaN, 5)).toBe('misto');
+    expect(classificarPerfilCliente(50, 400, Infinity, 2)).toBe('misto');
+  });
+});
+
+describe('classificarPerfilCliente — margem conhecida decide como antes', () => {
+  it('gasto baixo + margem baixa CONHECIDA é sensivel_preco', () => {
+    expect(classificarPerfilCliente(50, 400, 10, 5)).toBe('sensivel_preco');
+  });
+
+  it('margem 0 CONHECIDA é veredito e dispara sensivel_preco', () => {
+    expect(classificarPerfilCliente(50, 400, 0, 5)).toBe('sensivel_preco');
+  });
+
+  it('margem alta + poucas categorias é orientado_qualidade', () => {
+    expect(classificarPerfilCliente(50, 400, 40, 2)).toBe('orientado_qualidade');
+  });
+
+  it('margem no limite não dispara (fronteiras são estritas: <20 e >35)', () => {
+    expect(classificarPerfilCliente(50, 400, 20, 5)).toBe('misto');
+    expect(classificarPerfilCliente(50, 400, 35, 2)).toBe('misto');
+  });
+
+  it('gasto alto vence a fronteira de gasto baixo', () => {
+    expect(classificarPerfilCliente(50, 600, 10, 5)).toBe('misto');
+  });
+});
+
+describe('classificarPerfilCliente — ramo que não depende de margem', () => {
+  it('orientado_produtividade dispara mesmo com margem desconhecida', () => {
+    // Este ramo só olha gasto/categorias/health — não há razão para a ausência de margem
+    // suprimir um perfil que não a usa.
+    expect(classificarPerfilCliente(70, 3000, null, 5)).toBe('orientado_produtividade');
+  });
+
+  it('sem nenhuma regra satisfeita cai em misto', () => {
+    expect(classificarPerfilCliente(50, 1000, 25, 5)).toBe('misto');
+  });
+});
+
+describe('classificarPerfilCliente — precedência das regras', () => {
+  it('sensivel_preco vence orientado_produtividade quando ambos casariam', () => {
+    // avgSpend 400 (<500, margem 10 <20) e o terceiro ramo exige >2000: não colidem de fato,
+    // mas a ordem é contratual — o primeiro ramo que casa vence.
+    expect(classificarPerfilCliente(70, 400, 10, 5)).toBe('sensivel_preco');
+  });
+
+  it('orientado_qualidade vence orientado_produtividade quando ambos casariam', () => {
+    // margem 40 (>35) e cat 3 (<=3) casam o 2º; o 3º exige cat>=4, então o 2º vence por ordem.
+    expect(classificarPerfilCliente(70, 3000, 40, 3)).toBe('orientado_qualidade');
+  });
+});

--- a/src/lib/scoring/healthScore.ts
+++ b/src/lib/scoring/healthScore.ts
@@ -1,0 +1,53 @@
+// Composição do health score do motor client-side (useFarmerScoring).
+//
+// Extraído para cá porque a regra que importa — o que fazer quando uma dimensão é
+// DESCONHECIDA — não era testável dentro do hook (query + agregação no meio do caminho).
+//
+// ESPELHO da renormalização aplicada em `supabase/functions/calculate-scores` pelo #1495.
+// Os dois motores calculam o mesmo score; se só um renormalizar, o mesmo cliente recebe
+// notas diferentes conforme a tela que o carregou.
+
+/** Dimensões do health score, em escala 0-1. `g` (margem) é `null` quando desconhecida. */
+export interface DimensoesHealth {
+  /** Recência/frequência. */
+  rf: number;
+  /** Monetário. */
+  m: number;
+  /** Margem bruta — `null` quando nenhum item do cliente tem custo conhecido. */
+  g: number | null;
+  /** Diversidade de mix. */
+  x: number;
+  /** Engajamento. */
+  s: number;
+}
+
+export interface PesosHealth {
+  rf: number;
+  m: number;
+  g: number;
+  x: number;
+  s: number;
+}
+
+/** Health score 0-100 pela média ponderada das dimensões CONHECIDAS.
+ *
+ *  ⚠️ Margem desconhecida sai da conta e seu peso é redistribuído — não entra como 0.
+ *  Zero não é neutro numa média ponderada: é a pior nota do eixo, então o cliente cujos
+ *  itens não têm custo apurado levaria até 15 pontos de penalidade por ausência de dado,
+ *  ficando indistinguível de um cliente medido e genuinamente ruim (money-path: ausente ≠
+ *  zero). `g = 0` CONHECIDO continua penalizando: aí é veredito, não ignorância.
+ *
+ *  A divisão por `pesoTotal` normaliza a escala, então pesos que não somam 1 continuam
+ *  produzindo 0-100. Todos os pesos zerados → 0 (nunca NaN de 0/0). */
+export function calcularHealthScore(dim: DimensoesHealth, pesos: PesosHealth): number {
+  const pesoG = dim.g == null ? 0 : pesos.g;
+  const pesoTotal = pesos.rf + pesos.m + pesoG + pesos.x + pesos.s;
+  if (pesoTotal <= 0) return 0;
+  const soma =
+    pesos.rf * dim.rf +
+    pesos.m * dim.m +
+    pesoG * (dim.g ?? 0) +
+    pesos.x * dim.x +
+    pesos.s * dim.s;
+  return 100 * (soma / pesoTotal);
+}

--- a/src/lib/scoring/objective.ts
+++ b/src/lib/scoring/objective.ts
@@ -23,10 +23,13 @@
  * e LER o teto do config (não hardcode), pra a fronteira ACOMPANHAR o modelo se o operador
  * retunar T. Ver docs/historico/bugs-resolvidos.md.
  */
+import { margemConhecida } from '@/lib/margem';
+
 export function selectObjective(
   churnRisk: number,
   mixGap: number,
-  marginPct: number,
+  /** PERCENTUAL 0-100, ou null quando a margem do cliente é desconhecida. */
+  marginPct: number | null,
   clusterMargin: number | null,
   daysSince: number,
   recencyCapDays: number,
@@ -41,7 +44,12 @@ export function selectObjective(
   // consolidacao a esmo. (O espelho no edge generate-tactical-plan sempre passa número —
   // benchmarka pela carteira-dono no batch — então a divergência só aparece no caminho client,
   // onde o cluster pode faltar.)
-  if (clusterMargin != null && Number.isFinite(clusterMargin) && marginPct < clusterMargin * 0.8) return 'consolidacao_margem';
+  // Margem do CLIENTE ausente também não decide: `null < cluster*0.8` coage null a 0 e seria
+  // true, afirmando "margem baixa vs. pares" sobre quem não teve a margem apurada. Pós-#1495
+  // isso valeria para ~84% da base. `0` conhecido segue disparando — é veredito, não ausência.
+  const margem = margemConhecida(marginPct);
+  const cluster = margemConhecida(clusterMargin);
+  if (cluster != null && margem != null && margem < cluster * 0.8) return 'consolidacao_margem';
   return 'upsell_premium';
 }
 

--- a/src/lib/scoring/perfilCliente.ts
+++ b/src/lib/scoring/perfilCliente.ts
@@ -1,0 +1,40 @@
+// Perfil comercial do cliente — rótulo categórico que entra no prompt da IA
+// (`generate-bundle-argument`, `generate-tactical-plan`) e molda a abordagem que a
+// vendedora leva para a rua. Perfil fabricado = conversa fabricada.
+//
+// ESPELHO de `supabase/functions/_shared/tactical-margem.ts:classifyProfile` (Deno não
+// importa de `src/`) — mudou a regra aqui, mude lá.
+//
+// Este módulo UNIFICA as duas cópias que viviam no front:
+//   · useTacticalPlan.ts:187  (classifyProfile, privado do hook)
+//   · useBundleArguments.ts:18 (classifyCustomerProfile, exportado)
+// Eram a mesma regra escrita duas vezes; blindar só uma deixaria a outra fabricando.
+
+import { margemConhecida } from '@/lib/margem';
+
+export type PerfilCliente =
+  | 'sensivel_preco'
+  | 'orientado_qualidade'
+  | 'orientado_produtividade'
+  | 'misto';
+
+/** Perfil comercial a partir dos sinais do score. Regras em ORDEM: a primeira que casa vence.
+ *
+ *  ⚠️ Os dois primeiros ramos dependem da margem e só disparam com margem CONHECIDA. Sem o
+ *  guard, `null < 20` é `true` (null coage a 0) e todo cliente de gasto baixo com margem não
+ *  apurada — ~84% da base pós-#1495 — sairia rotulado "sensível a preço", empurrando a
+ *  vendedora para uma abordagem de desconto por causa de um dado que ninguém mediu.
+ *
+ *  `marginPct` em PERCENTUAL 0-100. `0` é margem nula CONHECIDA e decide normalmente. */
+export function classificarPerfilCliente(
+  healthScore: number,
+  avgSpend: number,
+  marginPct: number | null,
+  categoryCount: number,
+): PerfilCliente {
+  const margem = margemConhecida(marginPct);
+  if (margem != null && avgSpend < 500 && margem < 20) return 'sensivel_preco';
+  if (margem != null && margem > 35 && categoryCount <= 3) return 'orientado_qualidade';
+  if (avgSpend > 2000 && categoryCount >= 4 && healthScore > 60) return 'orientado_produtividade';
+  return 'misto';
+}

--- a/src/pages/FarmerDashboard.tsx
+++ b/src/pages/FarmerDashboard.tsx
@@ -18,6 +18,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { CallButton } from '@/components/call/CallButton';
 import { SlaVencidoCard } from '@/components/farmer/SlaVencidoCard';
+import { formatarMargemPct } from '@/lib/margem';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 const healthColors: Record<string, { bg: string; text: string; border: string }> = {
@@ -410,12 +411,19 @@ const ClientDetail = ({ client, onBack }: { client: ClientScore; onBack: () => v
               { label: 'X', value: client.x },
               { label: 'S', value: client.s },
             ].map(({ label, value }) => (
+              // G (margem) é null quando nenhum item do cliente tem custo conhecido. Barra
+              // vazia + "—" em vez de "0%": zero aqui é a PIOR nota do componente, e exibi-la
+              // por ausência de custo acusa o cliente de algo que ninguém mediu.
               <div key={label} className="text-center">
                 <div className="w-full bg-muted rounded-full h-1.5 mb-1">
-                  <div className="bg-primary h-1.5 rounded-full" style={{ width: `${value * 100}%` }} />
+                  {value != null && (
+                    <div className="bg-primary h-1.5 rounded-full" style={{ width: `${value * 100}%` }} />
+                  )}
                 </div>
                 <p className="text-[9px] text-muted-foreground">{label}</p>
-                <p className="text-[10px] font-semibold">{(value * 100).toFixed(0)}%</p>
+                <p className="text-[10px] font-semibold">
+                  {value == null ? '—' : `${(value * 100).toFixed(0)}%`}
+                </p>
               </div>
             ))}
           </div>
@@ -439,7 +447,7 @@ const ClientDetail = ({ client, onBack }: { client: ClientScore; onBack: () => v
           <MetricRow label="Dias sem compra" value={String(client.daysSinceLastPurchase)} />
           <MetricRow label="Intervalo médio recompra" value={`${client.avgRepurchaseInterval.toFixed(0)} dias`} />
           <MetricRow label="Gasto mensal (180d)" value={fmt(client.avgMonthlySpend180d)} />
-          <MetricRow label="Margem bruta" value={`${client.grossMarginPct.toFixed(1)}%`} />
+          <MetricRow label="Margem bruta" value={formatarMargemPct(client.grossMarginPct)} />
           <MetricRow label="Categorias compradas" value={String(client.categoryCount)} />
           <MetricRow label="Taxa resposta (60d)" value={`${client.answerRate60d.toFixed(1)}%`} />
           <MetricRow label="WhatsApp reply (60d)" value={`${client.whatsappReplyRate60d.toFixed(1)}%`} />


### PR DESCRIPTION
**Pré-requisito de merge do #1495** (margem do health score calculada no servidor), que está em draft esperando isto. Este PR entra **antes**.

## Por quê

Medido em prod (`psql-ro`, 2026-07-21): `farmer_client_scores.gross_margin_pct` é `0` **LITERAL** em 6.632/6.632 linhas, `column_default = 0`, zero nulos. Depois do #1495, **5.579 (84,1%)** ficam `NULL`.

Os consumidores tratavam ausência como `0`. Como `0` é um **veredito** de negócio ("cliente não-lucrativo") e não "não sei", passariam a afirmar isso sobre 84% da base — em KPI de gestão, no perfil comercial que entra no prompt da IA que a vendedora leva para a rua, e no gate que decide se vale ligar para o cliente.

## Bug de unidade — preexistente, ativado pelo mesmo PR

O produtor grava **percentual 0–100** (o PG17 do #1495 afirma `gross_margin_pct = "56.00"` para 56%), mas:

| Arquivo | Código | Com margem real |
|---|---|---|
| `CustomerHero` | `>= 0.3` / `>= 0.15` (fração) | margem de **5% pintada de verde** |
| `Customer360View` | `(x * 100).toFixed(1)` | 56% exibido como **"5600,0%"** |

Enquanto a coluna era `0` em todas as linhas o primeiro pintava todo mundo de vermelho e o segundo exibia "0.0%" — ambos plausíveis. Por isso corrigido **junto** com o guard de null: entregar só o guard deixaria a tela pior do que hoje.

## Helper compartilhado

`src/lib/margem/` — **plataforma**, não `scoring/`: o contrato da coluna é consumido por farmer *e* admin-crm, e o gate de fronteiras recusou o vazamento (`admin-crm → farmer-inteligencia`).

`margemConhecida` · `mediaMargemConhecida` · `legendaCobertura` · `faixaMargem` · `formatarMargemPct`

Espelho semântico de `_shared/tactical-margem.ts`, **mais estrito** num ponto: barra `''`/`' '`/`false`/`[]`, que `Number()` converte para `0`. Defesa em profundidade, não bug medido.

## Pontos corrigidos

**Coação `|| 0` / `?? 0`** — os 5 da lista original (Intelligence ×2, `useBundleEngine`, `escopo-clientes`, `useTacticalPlan` 338/390) + `currentMarginPct`.

**Comparação sem guard** — as **três** cópias do classificador de perfil unificadas em `classificarPerfilCliente`. A cadeia tinha 3 pontos de coação (`useBundleEngine` → `CustomerBundleCard` → `classifyCustomerProfile`): blindar só o comparador seria **inerte**, porque o `|| 0` a montante já matava o null.

**Fora da lista original** (mesma classe, achados por grep + Codex):
- `selectObjective` — `null < cluster*0.8` é `true` em JS: todo cliente sem margem receberia o objetivo *"consolidar margem"*, uma tese sobre a margem dele afirmada por não conhecê-la
- `checkEfficiency` / `EfficiencyAlertDialog` — R$0/h virava "Potencial Baixo"; agora distingue gate **reprovado** de gate **indecidível**
- `useFarmerScoring` — `totalRevenue > 0 ? … : 0` fabricava margem 0. **Incoerência interna**: a linha ~308 já excluía receita 0 do cálculo dos percentis. O health score agora renormaliza os pesos (espelha o #1495 no `calculate-scores`)
- `FarmerDashboard` — componente G exibia "0%" por ausência de custo
- `useFarmerCopilot` — null explícito no contexto que vai para o prompt

## Caps silenciosos (achado do Codex, P0)

As duas telas de Intelligence calculavam sobre `.limit(500)` de 6.632 — no gerencial os **500 de maior prioridade** (amostra enviesada), no estratégico **sem `.order()`** (recorte não determinístico entre carregamentos). Declarar cobertura em cima disso seria mentir sobre o denominador.

O cluster de pares do plano tático era single-shot contra o cap de **1.000** do PostgREST. Medido em prod: os três farmers têm **3.858 / 1.528 / 1.246** clientes — **todos truncavam**, e o cluster é a régua que julga a margem do cliente (`margem < cluster * 0.8`). Hoje inerte (tudo é 0); o #1495 ativa.

Os três agora paginam com `fetchAllPages` + ordem estável por `customer_user_id`.

## Prova

**62 testes novos.** Falsificação em duas camadas, com baseline verde explícito, contagem de vermelhos conferida e âncoras ASCII (money-path §31 — *"exit code não distingue 'pegou o bug' de 'não rodou nada'"*):

- **helper** — 4 sabotagens (`Number()` solto · ausente→0 · faixas em fração · heurística de escala) → **2/6/3/2** falhas, todas nos asserts mirados
- **consumidores** — 6 sabotagens nos arquivos **reais** (Hero · objective · perfilCliente · healthScore · useTacticalPlan · escopo-clientes) → **2/1/3/3/1/1** falhas

Restauração verificada contra backup, arquivo a arquivo (não via `git diff`, que compararia com o HEAD e esconderia a sabotagem no meio das mudanças legítimas).

**Guard textual de regressão** (`src/lib/margem/sem-coacao.test.ts`) sobre os 10 consumidores: o tipo `number | null` **não** protege contra `|| 0` — a coerção produz `number` e o typecheck passa verde. Foi exatamente assim que a coação sobreviveu até aqui. O regex é escopado a nomes exatos de campo: a primeira versão varria `[mM]argin` solto e acusou `actual_margin || 0` (valor em **R$**, onde `|| 0` é legítimo) — validador que reprova código correto ensina a ignorar o vermelho (§*"o VALIDADOR mente"*, #1490).

## Gates

`typecheck` 0 erros · `test` **5602/5602** · `lint` 0 errors · `build` ok.
`knip` segue vermelho — dívida preexistente do #1212; **nenhum export novo entrou na lista**.

## Fora de escopo (follow-up)

`formatPctMaybe` (`customer360/format.ts`) adivinha unidade com `v > 1 ? v : v * 100`. Removi o uso na margem, mas a heurística segue viva em 5 call-sites de outro domínio (taxa de conversão, KPIs de visita). O Codex auditou e achou ali um bug independente: **o KPI de equipe pode legitimamente exceder 1**, então `2` vira `"2%"` quando deveria ser `"200%"`. Não é ativado pelo #1495 e arrastaria 5 telas para um PR de margem — merece PR próprio com prova própria.

## 2ª opinião (Codex `gpt-5.6-sol`, reasoning `xhigh`)

Veredito dele: **DONE_WITH_CONCERNS** — *"junte A+B+C no mesmo PR e bloqueie o merge do #1495 até esse contrato estar consistente"*. Os P0 dele sobre caps (500/1.000) e sobre `useFarmerScoring` foram **verificados contra prod e incorporados**. Um P0 dele (`calculate-scores`) já estava resolvido no próprio #1495, que ele não tinha em contexto. A calibração de escopo (incluir `useFarmerScoring`, adiar `formatPctMaybe`) é **minha**, não dele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)