### PR TITLE
ci: valida a main 1x/dia — merge de PR não dispara o CI lá

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,39 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Validação PERIÓDICA da main — tapa a única janela que `pull_request`+`push` não cobrem.
+  #
+  # O buraco: merge de PR NÃO dispara o CI na main. Medido em 2026-07-21 (`gh run list --limit 60`):
+  # TODO run com `event=push` é commit DIRETO do bot do Lovable; nenhum merge de PR (#1503/#1505/
+  # #1506/#1507) gerou run de push. Causa: o auto-merge.yml usa `secrets.GITHUB_TOKEN`, e pela
+  # proteção anti-loop do GitHub eventos disparados por esse token não acionam workflows. Ou seja, o
+  # `push:` acima só pega a via do Lovable.
+  #
+  # Por que isso importa: dois PRs verdes ISOLADAMENTE podem quebrar a main JUNTOS (semantic
+  # conflict) e ninguém saber. Ex. concreto com o `edges:typecheck`: PR A remove um export de
+  # `supabase/functions/_shared/`, PR B adiciona um import dele — cada um passa, juntos dão TS2305.
+  # Com ~30 worktrees paralelas e ~8 PRs mergeados por sessão, não é hipotético. Pior: o sintoma
+  # aparece no lugar errado — o PRÓXIMO PR falha por algo que o autor não causou.
+  #
+  # Por que `schedule` e não PAT/merge-queue: evento `schedule` roda SEMPRE no default branch, então
+  # `github.ref` já é `refs/heads/main` e os dois steps de alerta lá embaixo
+  # (`if: failure() && github.ref == 'refs/heads/main'` / `success() && ...`) passam a cobrir esta
+  # via SEM alteração — abrem e fecham a Issue `ci-main-red` sozinhos. Trocar o token do auto-merge
+  # por um PAT/App faria o push disparar o CI, mas custa gerenciar credencial e um run de ~5min por
+  # merge; merge queue resolve melhor (valida a combinação ANTES da main) mas muda o fluxo do repo
+  # inteiro. Diário é o piso útil: pega o conflito no dia seguinte por ~150 min/mês de Actions.
+  #
+  # Horário: 09:17 UTC ≈ 06:17 BRT — o founder começa o dia com o sinal, e o minuto quebrado evita a
+  # fila de crons "redondos" do GitHub (que atrasa muito em :00). ⚠️ O GitHub DESABILITA cron após
+  # 60 dias sem atividade no repo; se o repo hibernar, reativar na aba Actions.
+  schedule:
+    - cron: '17 9 * * *'
+  # Botão "validar a main agora" (aba Actions → CI → Run workflow), sem esperar as 09:17. Serve para
+  # (a) confirmar a main na hora depois de uma leva de merges, e (b) VERIFICAR este próprio desenho:
+  # como `workflow_dispatch` na main também dá `github.ref == 'refs/heads/main'`, ele exercita os
+  # mesmos dois steps de alerta que o `schedule` vai exercitar — sem isso, a primeira prova de que a
+  # Issue abre/fecha só viria no primeiro cron.
+  workflow_dispatch:
 
 jobs:
   validate:
@@ -250,6 +283,12 @@ jobs:
   mutation-check:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # FORA do `schedule` de propósito. O run diário existe para provar que a main passa nos gates
+    # BLOQUEANTES; este job é informativo, não-required, e pode ficar INVÁLIDO por refactor legítimo
+    # (ver o comentário acima). Rodando diário ele falharia sem abrir Issue nenhuma — os dois steps
+    # de alerta vivem no job `validate` —, virando exatamente o sinal vermelho que ninguém lê. Além
+    # de somar ~2m41s por dia sem leitor. Nos eventos de PR/push segue rodando igual.
+    if: github.event_name != 'schedule'
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## O buraco

**Merge de PR não dispara o CI na `main`.** Medido em 2026-07-21 com `gh run list --limit 60`: todo run com `event=push` é commit **direto** do bot do Lovable. Nenhum merge de PR (#1503, #1505, #1506, #1507) gerou run de push.

**Causa:** [auto-merge.yml:31](.github/workflows/auto-merge.yml) usa `secrets.GITHUB_TOKEN`, e pela proteção anti-loop do GitHub eventos disparados por esse token não acionam workflows. O `push: branches: [main]` existente só cobre a via do Lovable — que é exatamente o caso de uso para o qual o alerta de main-vermelha foi desenhado, então **não é bug**; é uma via descoberta.

## Por que importa

Dois PRs verdes **isoladamente** podem quebrar a main **juntos**. Exemplo concreto com o `edges:typecheck` do #1506: PR A remove um export de `supabase/functions/_shared/`, PR B adiciona um import dele — cada um passa, juntos dão `TS2305`. Com ~30 worktrees paralelas e **8 PRs mergeados no intervalo de uma única sessão**, não é hipotético.

Pior: o sintoma aparece no lugar errado. O **próximo** PR roda contra a main já quebrada e falha por algo que o autor não causou.

## Isto fecha risco latente, não apaga incêndio

Medi a main **antes** de mudar qualquer coisa (base `ccaa549b`): `typecheck`, `edges:typecheck`, `test:edges`, `test` (vitest completo) e `lint` — **todos exit 0**. A janela existe mas ainda não produziu quebra.

## Por que `schedule`, e não as alternativas

Evento `schedule` roda **sempre no default branch**, então `github.ref` já é `refs/heads/main` e os **dois steps de alerta que já existem** (linhas 194 e 228, `if: failure() && github.ref == 'refs/heads/main'` / `success() && …`) passam a cobrir esta via **sem nenhuma alteração** — abrem e fecham a Issue `ci-main-red` sozinhos.

| Alternativa | Por que não agora |
|---|---|
| PAT / GitHub App no auto-merge | faz o push disparar o CI, mas custa gerenciar credencial + um run de ~5min por merge |
| Merge queue (`merge_group`) | resolve melhor (valida a combinação **antes** da main), mas muda o fluxo de merge do repo inteiro |
| Aceitar e documentar | defensável, mas 3 linhas fecham a janela |

**Diário** é o piso útil: pega o conflito no dia seguinte por ~150 min/mês de Actions. Horário 09:17 UTC ≈ 06:17 BRT (minuto quebrado evita a fila de crons "redondos" do GitHub, que atrasa muito em `:00`).

## Duas decisões que tomei dentro do escopo

- **`mutation-check` fica fora do schedule** (`if: github.event_name != 'schedule'`). É informativo, não-required, pode ficar inválido por refactor legítimo, e falharia **sem abrir Issue nenhuma** (os alertas vivem no job `validate`) — viraria o sinal vermelho que ninguém lê, mais ~2m41s/dia sem leitor. Em PR e push segue rodando igual.
- **Incluí `workflow_dispatch`** (além do que foi pedido). Motivo: sem ele, a primeira prova de que a Issue abre/fecha só viria no primeiro cron. Dispatch na main dá o mesmo `github.ref` do schedule, logo exercita os mesmos steps — dá para **verificar o desenho hoje**. Serve também de botão "validar a main agora" na aba Actions.

## Validação

YAML parseado com o parser real (não regex): 4 gatilhos, `cron: '17 9 * * *'`, `mutation-check.if` presente, os 15 steps do `validate` intactos incluindo o `edges:typecheck`. `bunpin:check` verde.

39 linhas adicionadas, das quais **3 são efetivas** — o resto é o porquê, para ninguém ter que redescobrir a regra do `GITHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)