### PR TITLE
fix(margem): reconcilia as duas margens — um universo, uma função [money-path]

### DIFF
--- a/db/nota-1530-premissa-envelheceu.md
+++ b/db/nota-1530-premissa-envelheceu.md
@@ -1,0 +1,62 @@
+# Correção de premissa da `20260726160000_margem_reconciliacao_universo_unico.sql`
+
+> A migration é imutável depois de committada (`supabase/migrations/` é fonte de DR e o apply é
+> manual). Esta nota corrige uma afirmação do cabeçalho dela que **envelheceu entre escrever e
+> mergear** — o padrão do repo para isso é arquivo em `db/`, mesmo sendo só texto.
+
+## O que o cabeçalho afirma, e por que deixou de ser verdade
+
+> "Nenhuma das duas chegou a rodar em prod (conferido: 0 em `pg_proc` para ambas antes deste PR;
+> `farmer_client_scores.gross_margin_pct` seguia 0 em 6.632/6.632). Esta migration reconcilia
+> ANTES que qualquer número divergente exista — **não há flip-flop de valor exibido**."
+
+Verdadeiro quando escrito (2026-07-21, início da tarde). **Falso a partir de 2026-07-21 ~22:04**,
+quando o founder aplicou a migration do #1495 e o cron rodou:
+
+| medição | antes (quando a migration foi escrita) | depois (2026-07-21 22:04) |
+|---|---|---|
+| `public.get_customer_margin_summary` em `pg_proc` | 0 | **1** |
+| `private.margem_cliente_agregada` em `pg_proc` | 0 | 0 (o #1519 não foi aplicado) |
+| `gross_margin_pct` ≠ 0 | 0 de 6.632 | **1.058** |
+| `gross_margin_pct` NULL | 0 | 5.574 |
+
+⇒ **A margem está viva em produção**, calculada pelo caminho do #1495: JOIN por `product_id`
+(perde os R$ 247.482,10) com o universo denylist (correto). Logo esta migration **não** é mais
+"reconciliar antes que exista número" — ela **altera número já exibido**.
+
+## O impacto real de aplicar, medido contra o estado VIVO
+
+Comparando o que está em produção hoje (JOIN `product_id` + denylist) com o que esta migration
+produz (JOIN `omie_codigo_produto` + denylist), sobre 1.225 clientes:
+
+| efeito | clientes |
+|---|---|
+| **ganham** margem (eram NULL, passam a ter valor) | **6** |
+| **perdem** margem (tinham valor, virariam NULL) | **0** |
+| número muda (ambos com valor) | 187 |
+| delta máximo | 35,19 pp |
+| delta médio | **0,20 pp** |
+
+**A mudança é estritamente melhoradora: ninguém regride.** Nenhum cliente perde o sinal, 6 passam
+a tê-lo, e os 187 ajustes vêm de custo que o JOIN antigo não alcançava — o número novo é mais
+completo, não diferente por acaso.
+
+O eixo do UNIVERSO (denylist) **já está vivo** e veio do próprio #1495, então esta migration não o
+altera em produção — ela alinha o helper a ele. O que ela muda de fato em prod é o **eixo do
+JOIN** e os **guards de qualidade**.
+
+## O que continua válido no cabeçalho
+
+Tudo o mais: os três eixos e quem venceu cada um, os números do JOIN (1.837 itens com `product_id`
+nulo, 783 com custo alcançável por código, R$ 247.482,10), o universo de status
+(R$ 6.985.425,66 que a allowlist descartava) e a limitação medida do double-count (24 pares,
+3 clientes, 0,61 pp, zero mudanças de faixa).
+
+## Lição
+
+A premissa de uma migration money-path pode envelhecer **entre escrevê-la e mergeá-la** quando o
+founder aplica coisas em paralelo. "Conferido: 0 em `pg_proc`" é um fato **datado**, não uma
+propriedade — e um cabeçalho que promete "não há flip-flop" é exatamente o tipo de afirmação que
+se torna perigosa ao envelhecer, porque quem for aplicar vai lê-la como garantia. **Ao mergear
+migration money-path que ficou aberta por horas, remeça o estado de prod antes** — a mesma
+disciplina do baseline, aplicada ao momento do merge e não só ao da escrita.

--- a/db/test-farmer-margem-server-side.sh
+++ b/db/test-farmer-margem-server-side.sh
@@ -70,6 +70,7 @@ CREATE TABLE public.order_items (
   sales_order_id uuid NOT NULL REFERENCES public.sales_orders(id),
   customer_user_id uuid,
   product_id uuid,
+  omie_codigo_produto bigint,   -- reconciliação: é por aqui que o custo passa a ser encontrado
   unit_price numeric,
   quantity numeric
 );
@@ -77,6 +78,20 @@ CREATE TABLE public.product_costs (
   product_id uuid PRIMARY KEY,
   cost_price numeric,
   cost_final numeric
+);
+-- Acrescentadas na RECONCILIAÇÃO (2026-07-21): get_customer_margin_summary passou a ser projeção
+-- de private.margem_cliente_agregada(), que junta custo por `omie_codigo_produto` em vez de
+-- `product_id` (product_id é NULO em 2,67% dos itens da prod, escondendo R$ 247.482,10 de custo
+-- conhecido). O mapeamento abaixo é 1:1 com os product_id já semeados, então TODOS os valores
+-- esperados deste harness permanecem idênticos — é essa invariância que prova que a delegação
+-- preservou a intenção dos asserts originais.
+CREATE TABLE public.omie_products (
+  id uuid PRIMARY KEY,
+  omie_codigo_produto bigint UNIQUE
+);
+CREATE TABLE public.cliente_classificacao (
+  user_id uuid PRIMARY KEY,
+  excluir_da_carteira boolean
 );
 -- farmer_client_scores: alvo de apply_score_updates. Nulabilidade E DEFAULTS espelham a PROD
 -- (medido 2026-07-20/21: m_score/g_score/gross_margin_pct/health_score todos is_nullable=YES,
@@ -105,6 +120,14 @@ echo "migration aplicada: $(basename "$MIG")"
 MIG2="$REPO_ROOT/supabase/migrations/20260723160000_farmer_margem_correcoes_review.sql"
 P -q -f "$MIG2"
 echo "migration aplicada: $(basename "$MIG2")"
+# 150000/160000 (helper + reconciliação): get_customer_margin_summary deixa de ter cálculo próprio
+# e vira PROJEÇÃO de private.margem_cliente_agregada(). Aplicadas na ordem em que o founder vai
+# colar. ⚠️ Toda restauração de falsificação abaixo tem de reaplicar as TRÊS — restaurar só a $MIG
+# ressuscita o cálculo antigo e os asserts seguintes passariam a medir o objeto errado.
+MIG3="$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+MIG4="$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
+P -q -f "$MIG3"; P -q -f "$MIG4"
+echo "migration aplicada: $(basename "$MIG3") + $(basename "$MIG4")"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 3 — SEED: cenários com margem EXATA, conferível à mão
@@ -156,6 +179,23 @@ INSERT INTO public.order_items(sales_order_id, customer_user_id, product_id, uni
   ('0a000000-0000-0000-0000-000000000002','0c000000-0000-0000-0000-000000000008','0b000000-0000-0000-0000-000000000001',100,1),
   -- C9 pedido com deleted_at → cliente some
   ('0a000000-0000-0000-0000-000000000003','0c000000-0000-0000-0000-000000000009','0b000000-0000-0000-0000-000000000001',100,1);
+
+-- RECONCILIAÇÃO: mapeia cada product_id semeado para um código Omie 1:1 e propaga aos itens.
+-- Feito por UPDATE derivado (e não reescrevendo as 11 linhas acima) de propósito: os dados do
+-- seed original ficam INTOCADOS, então qualquer mudança nos valores esperados seria da lógica
+-- nova, nunca de um seed reescrito à mão.
+INSERT INTO public.omie_products(id, omie_codigo_produto)
+SELECT product_id, (9000 + row_number() OVER (ORDER BY product_id))::bigint
+  FROM public.product_costs;
+-- O SKU sem custo (0bff…ff) também ganha código: ele TEM código e NÃO tem custo — que é
+-- exatamente o caso que o assert da mistura (P2) e o do "sem custo algum" (N1) exercitam.
+INSERT INTO public.omie_products(id, omie_codigo_produto)
+VALUES ('0bff0000-0000-0000-0000-0000000000ff', 9999);
+
+UPDATE public.order_items oi
+   SET omie_codigo_produto = op.omie_codigo_produto
+  FROM public.omie_products op
+ WHERE op.id = oi.product_id;
 SQL
 
 M() { Pq -c "SELECT COALESCE(gross_margin_pct::text,'NULL') FROM public.get_customer_margin_summary() WHERE customer_user_id='0c000000-0000-0000-0000-00000000000$1';"; }
@@ -296,8 +336,7 @@ eq "D3 health_score mantem DEFAULT 0"        "$HS9" "0"
 echo "── assert: idempotencia (aplicar 2x) ──"
 # As DUAS, na mesma ordem — inclui reaplicar o ALTER TABLE ... DROP DEFAULT (que é idempotente por
 # natureza, mas isso tem de ser PROVADO, não presumido: o founder pode colar o bloco duas vezes).
-P -q -f "$MIG"
-P -q -f "$MIG2"
+P -q -f "$MIG"; P -q -f "$MIG2"; P -q -f "$MIG3"; P -q -f "$MIG4"
 eq "I1 margem intacta apos 2o apply"       "$(M 1)" "56.00"
 eq "I3 DROP DEFAULT idempotente"           "$(Pq -c "SELECT COALESCE(column_default,'NULL') FROM information_schema.columns WHERE table_name='farmer_client_scores' AND column_name='gross_margin_pct';")" "NULL"
 SVC2=$(Pq -c "SET ROLE service_role; SELECT count(*) FROM public.get_customer_margin_summary();" | tail -1)
@@ -379,7 +418,7 @@ SQL
 ne "F2 P2 fica vermelho (40.00 viraria 80.00)" "$(M 2)" "40.00"
 
 echo "── falsificacao F3: GRANT p/ authenticated (o REVOKE perde o dente) ──"
-P -q -f "$MIG"                                                  # restaura a versão verdadeira
+P -q -f "$MIG"; P -q -f "$MIG2"; P -q -f "$MIG3"; P -q -f "$MIG4"                                                  # restaura a versão verdadeira
 P -q -c "GRANT EXECUTE ON FUNCTION public.get_customer_margin_summary() TO authenticated;"
 AUTHF=$(P -tA 2>&1 <<'SQL' || true
 SET ROLE authenticated;
@@ -455,8 +494,7 @@ ne "F5 AP4 fica vermelho (56.00 seria NULLado)" "$(GMP 1)" "56.00"
 ne "F5 m_score idem"                            "$(MSC 1)" "56"
 
 echo "── restauro final: migrations verdadeiras + reconferencia ──"
-P -q -f "$MIG"
-P -q -f "$MIG2"
+P -q -f "$MIG"; P -q -f "$MIG2"; P -q -f "$MIG3"; P -q -f "$MIG4"
 P -q -c "REVOKE ALL ON FUNCTION public.get_customer_margin_summary() FROM authenticated;"
 # R6: com a sentinela de volta, o MESMO payload sem as chaves volta a PRESERVAR (fecha o ciclo do F5).
 P -q -c "UPDATE public.farmer_client_scores SET gross_margin_pct=56.00, m_score=56 WHERE id='0d000000-0000-0000-0000-000000000001';"

--- a/db/test-farmer-margem-server-side.sh
+++ b/db/test-farmer-margem-server-side.sh
@@ -82,9 +82,17 @@ CREATE TABLE public.product_costs (
 -- Acrescentadas na RECONCILIAÇÃO (2026-07-21): get_customer_margin_summary passou a ser projeção
 -- de private.margem_cliente_agregada(), que junta custo por `omie_codigo_produto` em vez de
 -- `product_id` (product_id é NULO em 2,67% dos itens da prod, escondendo R$ 247.482,10 de custo
--- conhecido). O mapeamento abaixo é 1:1 com os product_id já semeados, então TODOS os valores
--- esperados deste harness permanecem idênticos — é essa invariância que prova que a delegação
--- preservou a intenção dos asserts originais.
+-- conhecido). O mapeamento abaixo é 1:1 com os product_id já semeados, então todos os valores
+-- esperados deste harness permanecem idênticos.
+--
+-- ⚠️ O QUE ESSA INVARIÂNCIA PROVA — E O QUE NÃO PROVA (auto-challenge, Caminho B):
+-- Com o mapeamento 1:1, os dois caminhos de JOIN são EQUIVALENTES para este seed. Logo este
+-- harness é, por construção, INSENSÍVEL à mudança de JOIN — ele não pode detectá-la, e seria
+-- tautológico citá-lo como prova de que o JOIN novo está certo.
+-- O que ele prova: a delegação não QUEBROU nenhum dos cenários originais (margem exata, mistura,
+-- negativa, precedência, fallback, NULL, ACL, idempotência) — que é exatamente o seu papel aqui.
+-- Quem prova o JOIN é o assert H1 de db/test-margem-cliente-helper-compartilhado.sh, cujo seed
+-- tem um item com product_id NULO e código resolvível: o único caso em que os caminhos DIVERGEM.
 CREATE TABLE public.omie_products (
   id uuid PRIMARY KEY,
   omie_codigo_produto bigint UNIQUE

--- a/db/test-margem-cliente-helper-compartilhado.sh
+++ b/db/test-margem-cliente-helper-compartilhado.sh
@@ -21,7 +21,10 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PGVER=17
 PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
-PORT="${PGPORT_TEST:-5471}"
+# 5472, NÃO 5471: o harness do #1495 (db/test-farmer-margem-server-side.sh) já ocupa a 5471, e
+# esta sessão roda os dois em sequência — mesma porta = colisão quando um servidor sobrevive ao
+# outro. Com ~40 worktrees paralelas, porta de harness é recurso compartilhado.
+PORT="${PGPORT_TEST:-5472}"
 SLUG="margemhelper"
 DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
 export LC_ALL=C LANG=C
@@ -255,10 +258,19 @@ P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_univ
 eq "O1 re-aplicar não muda o resultado"                "$(m aa000000-0000-0000-0000-000000000001)" "40.00"
 eq "O2 re-aplicar preserva o REVOKE de authenticated" \
    "$(Pq -c "SELECT has_function_privilege('authenticated','private.margem_cliente_agregada()','EXECUTE');")" "f"
-# ⚠️ Guarda contra o risco de ORDEM: re-colar SÓ a migration 150000 (a antiga) recria o helper com
-# a ALLOWLIST e reverte o universo em silêncio — "a última a recriar vence" (database.md §2).
-# Este assert exige que, após a sequência completa, o universo amplo tenha prevalecido.
 eq "O3 após re-aplicar as duas EM ORDEM, o universo segue AMPLO" \
+   "$(m ff000000-0000-0000-0000-000000000006)" "40.00"
+
+# ⚠️ O RISCO DE ORDEM, exercitado de verdade — não só afirmado num comentário.
+# O3 acima prova que a sequência COMPLETA converge; ele NÃO prova nada sobre recolar só a antiga.
+# Os dois abaixo separam as coisas: O4 demonstra que o perigo é REAL (a 150000 sozinha reverte o
+# universo, sem erro nenhum), e O5 que a 160000 reconverge. É documentação EXECUTÁVEL do hazard —
+# um comentário dizendo "cuidado com a ordem" não falha quando alguém erra a ordem.
+P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+eq "O4 recolar SÓ a antiga REVERTE o universo (o hazard é real)" \
+   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='ff000000-0000-0000-0000-000000000006';")" "0"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
+eq "O5 re-aplicar a 160000 reconverge para o universo amplo" \
    "$(m ff000000-0000-0000-0000-000000000006)" "40.00"
 
 echo "-- P. get_customer_margin_summary virou PROJEÇÃO do helper --"

--- a/db/test-margem-cliente-helper-compartilhado.sh
+++ b/db/test-margem-cliente-helper-compartilhado.sh
@@ -90,8 +90,11 @@ CREATE TABLE public.cliente_classificacao (
   excluir_da_carteira boolean);
 SQL
 
-# ── aplica a migration REAL (não uma cópia) ──────────────────────────────────
+# ── aplica as migrations REAIS, na ordem (não cópias) ────────────────────────
+# A 2ª reconcilia o universo de status (allowlist → denylist) e faz
+# get_customer_margin_summary virar projeção deste helper.
 P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
 
 # ── seed ─────────────────────────────────────────────────────────────────────
 P -q <<'SQL'
@@ -120,8 +123,11 @@ INSERT INTO public.sales_orders (id, status, deleted_at) VALUES
   ('50000000-0000-0000-0000-00000000000c', 'faturado',  NULL),
   ('50000000-0000-0000-0000-00000000000d', 'faturado',  NULL),
   ('50000000-0000-0000-0000-00000000000e', 'faturado',  NULL),
-  ('50000000-0000-0000-0000-00000000000f', 'importado', NULL),   -- fora do allowlist vivo
-  ('50000000-0000-0000-0000-000000000010', 'cancelado', NULL),   -- 2º negativo de status
+  ('50000000-0000-0000-0000-00000000000f', 'importado', NULL),   -- venda real: ENTRA na denylist
+  ('50000000-0000-0000-0000-000000000015', 'separacao', NULL),   -- em trânsito: ENTRA
+  ('50000000-0000-0000-0000-000000000017', 'enviado',   NULL),   -- em trânsito: ENTRA
+  ('50000000-0000-0000-0000-000000000010', 'cancelado', NULL),   -- não é venda: SAI
+  ('50000000-0000-0000-0000-000000000018', 'orcamento', NULL),   -- 2º negativo: SAI
   ('50000000-0000-0000-0000-000000000011', 'faturado',  NULL),
   ('50000000-0000-0000-0000-000000000012', 'faturado',  NULL),
   ('50000000-0000-0000-0000-000000000013', 'faturado',  NULL),
@@ -142,10 +148,14 @@ INSERT INTO public.order_items (sales_order_id, customer_user_id, omie_codigo_pr
   ('50000000-0000-0000-0000-00000000000d','dd111111-0000-0000-0000-000000000004', 1004, 'dd000000-0000-0000-0000-000000000004', 1, 100),
   -- E: excluído da carteira → some
   ('50000000-0000-0000-0000-00000000000e','ee000000-0000-0000-0000-000000000005', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
-  -- F: status 'importado' → some
+  -- F: status 'importado' → ENTRA (venda real). Mesmo SKU/preço dos demais → margem 40%.
   ('50000000-0000-0000-0000-00000000000f','ff000000-0000-0000-0000-000000000006', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
-  -- F2: status 'cancelado' → some (2º negativo: barra `status <> 'importado'`)
+  -- SEP/ENV: em trânsito, mas vendidos → ENTRAM
+  ('50000000-0000-0000-0000-000000000015','5e000000-0000-0000-0000-000000000015', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
+  ('50000000-0000-0000-0000-000000000017','6e000000-0000-0000-0000-000000000017', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
+  -- F2: 'cancelado' → SAI. ORC: 'orcamento' → SAI (2º negativo: barra `status <> 'cancelado'`)
   ('50000000-0000-0000-0000-000000000010','f2000000-0000-0000-0000-000000000016', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
+  ('50000000-0000-0000-0000-000000000018','7e000000-0000-0000-0000-000000000018', 1001, 'dd000000-0000-0000-0000-000000000001', 1, 100),
   -- I: fallback cost_price (cost_final NULL) → 60%
   ('50000000-0000-0000-0000-000000000011','1a000000-0000-0000-0000-000000000011', 1005, 'dd000000-0000-0000-0000-000000000005', 1, 100),
   -- SD: pedido soft-deleted → some
@@ -198,14 +208,23 @@ eq "J3 multi-item: contadores e somas batem" \
                FROM private.margem_cliente_agregada() WHERE customer_user_id='9a000000-0000-0000-0000-000000000012';")" \
    "2|1|350|180"
 
-echo "-- K. universo --"
+echo "-- K. universo (DENYLIST desde a reconciliação) --"
 eq "K1 cliente excluído da carteira some" \
    "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='ee000000-0000-0000-0000-000000000005';")" "0"
-eq "K2 status 'importado' some" \
-   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='ff000000-0000-0000-0000-000000000006';")" "0"
-eq "K3 status 'cancelado' some (2o negativo — barra 'status <> importado')" \
+# ⚠️ INVERTIDO na reconciliação. A allowlist anterior (`IN ('confirmado','faturado','entregue')`)
+# resolvia para SÓ `faturado` e descartava R$ 6.985.425,66 de vendas reais — 311 clientes (25,6%)
+# perdiam a margem e caíam em `neutro`. `importado` É venda: entra.
+eq "K2 status 'importado' ENTRA (é venda real, R\$ 2,75M)" \
+   "$(m ff000000-0000-0000-0000-000000000006)" "40.00"
+eq "K3 status 'separacao' ENTRA (em trânsito, mas vendido)" \
+   "$(m 5e000000-0000-0000-0000-000000000015)" "40.00"
+eq "K4 status 'enviado' ENTRA" \
+   "$(m 6e000000-0000-0000-0000-000000000017)" "40.00"
+eq "K5 status 'cancelado' SOME (a denylist barra)" \
    "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='f2000000-0000-0000-0000-000000000016';")" "0"
-eq "K4 pedido soft-deleted some" \
+eq "K6 status 'orcamento' SOME (2o negativo — barra 'status <> cancelado')" \
+   "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='7e000000-0000-0000-0000-000000000018';")" "0"
+eq "K7 pedido soft-deleted some" \
    "$(Pq -c "SELECT count(*) FROM private.margem_cliente_agregada() WHERE customer_user_id='5d000000-0000-0000-0000-000000000014';")" "0"
 
 echo "-- L. ACL (o helper não é alcançável do browser) --"
@@ -232,9 +251,32 @@ eq "N3 é STABLE (não VOLATILE)" \
 
 echo "-- O. idempotência --"
 P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
 eq "O1 re-aplicar não muda o resultado"                "$(m aa000000-0000-0000-0000-000000000001)" "40.00"
 eq "O2 re-aplicar preserva o REVOKE de authenticated" \
    "$(Pq -c "SELECT has_function_privilege('authenticated','private.margem_cliente_agregada()','EXECUTE');")" "f"
+# ⚠️ Guarda contra o risco de ORDEM: re-colar SÓ a migration 150000 (a antiga) recria o helper com
+# a ALLOWLIST e reverte o universo em silêncio — "a última a recriar vence" (database.md §2).
+# Este assert exige que, após a sequência completa, o universo amplo tenha prevalecido.
+eq "O3 após re-aplicar as duas EM ORDEM, o universo segue AMPLO" \
+   "$(m ff000000-0000-0000-0000-000000000006)" "40.00"
+
+echo "-- P. get_customer_margin_summary virou PROJEÇÃO do helper --"
+# Os nomes de coluna são preservados (a edge calculate-scores depende deles), mas o número passa
+# a vir do helper — mesma linha, mesmo valor, nos dois objetos.
+eq "P1 a projeção devolve o MESMO valor que o helper" \
+   "$(Pq -c "SELECT gross_margin_pct FROM public.get_customer_margin_summary() WHERE customer_user_id='aa000000-0000-0000-0000-000000000001';")" \
+   "$(m aa000000-0000-0000-0000-000000000001)"
+eq "P2 a projeção herda o universo amplo (importado entra)" \
+   "$(Pq -c "SELECT gross_margin_pct FROM public.get_customer_margin_summary() WHERE customer_user_id='ff000000-0000-0000-0000-000000000006';")" "40.00"
+eq "P3 a projeção herda o JOIN por código (product_id NULO resolve)" \
+   "$(Pq -c "SELECT gross_margin_pct FROM public.get_customer_margin_summary() WHERE customer_user_id='aa000000-0000-0000-0000-000000000001';")" "40.00"
+eq "P4 a projeção NÃO tem cálculo próprio (corpo só lê o helper)" \
+   "$(Pq -c "SELECT pg_get_functiondef(p.oid) ~ 'margem_cliente_agregada' AND pg_get_functiondef(p.oid) !~ 'product_costs'
+               FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+              WHERE n.nspname='public' AND p.proname='get_customer_margin_summary';")" "t"
+eq "P5 a projeção segue fechada a authenticated" \
+   "$(Pq -c "SELECT has_function_privilege('authenticated','public.get_customer_margin_summary()','EXECUTE');")" "f"
 
 echo "========================================"
 echo "  $PASS verde(s), $FAIL vermelho(s)"

--- a/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql
+++ b/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql
@@ -42,6 +42,20 @@
 -- frequência, spend, mix) continuam lendo `sales_orders` com a allowlist local — o chip "Corrigir
 -- filtro de status do scoring do farmer" segue aberto para elas. Este PR fecha o eixo da MARGEM.
 --
+-- ── LIMITAÇÃO CONHECIDA E MEDIDA: pedido Omie duplicado em dois status ───────────────────────
+-- A denylist herda um defeito de DADO que a allowlist mascarava: existem **24 pares
+-- (account, omie_pedido_id)** gravados como DUAS linhas de `sales_orders` com status diferentes
+-- (tipicamente `faturado` + `enviado`), mesmo cliente e mesma conta. A allowlist via só
+-- `faturado` e pegava uma; a denylist enxerga as duas e conta os itens em dobro.
+-- Medido em 2026-07-21 (deduplicando por `(account, omie_pedido_id)`, ficando com o status mais
+-- avançado): **3 clientes** mudam de margem, delta máximo **0,61 pp**, e **ZERO** mudam de faixa.
+-- ⇒ NÃO deduplicado aqui, de propósito. A causa é um bug de SYNC (duas linhas para um pedido) que
+-- afeta igualmente receita, frequência e spend; corrigir só dentro da margem mascararia o
+-- problema upstream e acrescentaria uma window function ao caminho quente por 0,61 pp em 3 de
+-- 1.224 clientes. Follow-up: investigar o writer que duplica no `omie-vendas-sync`.
+-- Se algum dia esses 24 virarem centenas, o efeito deixa de ser imaterial — remeça antes de
+-- assumir que continua.
+--
 -- ⚠️ MIGRATION MANUAL: nome custom não auto-aplica no Lovable. Colar no SQL Editor → Run.
 -- Ordem: esta migration DEPOIS de `20260723150000` e `20260726150000` (recria objetos das duas).
 

--- a/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql
+++ b/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql
@@ -1,0 +1,180 @@
+-- Reconciliação da margem por cliente — uma função de verdade, um universo de pedidos.
+--
+-- CONTEXTO: duas frentes entregaram cálculo de margem por cliente com poucos dias de diferença.
+--   • #1495  `public.get_customer_margin_summary()` — cron/health score. JOIN por `product_id`,
+--            universo por DENYLIST de status.
+--   • #1519  `private.margem_cliente_agregada()` — helper compartilhado. JOIN por
+--            `omie_codigo_produto`, universo por ALLOWLIST (espelhando `useFarmerScoring`).
+-- Nenhuma das duas chegou a rodar em prod (conferido: 0 em `pg_proc` para ambas antes deste PR;
+-- `farmer_client_scores.gross_margin_pct` seguia 0 em 6.632/6.632). Esta migration reconcilia
+-- ANTES que qualquer número divergente exista — não há flip-flop de valor exibido.
+--
+-- ── O QUE VENCEU EM CADA EIXO, POR MEDIÇÃO ───────────────────────────────────────────────────
+--
+-- EIXO 1 — JOIN: vence o #1519 (`omie_codigo_produto`).
+--   `order_items.product_id` é NULO em 1.837 de 68.700 itens (2,67%). Desses, **783 TÊM custo
+--   conhecido** alcançável pelo código, carregando **R$ 247.482,10** de receita que o JOIN por
+--   `product_id` classificava como "sem custo". É "ausente ≠ zero" aplicado à JUNÇÃO: item que não
+--   junta não é item sem custo.
+--
+-- EIXO 2 — UNIVERSO DE STATUS: vence o #1495 (DENYLIST). ⚠️ Aqui o #1519 estava ERRADO, e este é
+--   o achado maior deste PR. A allowlist `IN ('confirmado','faturado','entregue')` foi copiada de
+--   `useFarmerScoring.ts:147` para "preservar o comportamento vivo" — mas `confirmado` e
+--   `entregue` NÃO EXISTEM em `sales_orders` (zero linhas), então ela resolve para **só
+--   `faturado`** e descarta vendas reais:
+--       faturado  20.207 · R$ 20.220.276,84   ← único que a allowlist enxerga
+--       importado  5.271 · R$  2.753.517,63   ┐
+--       separacao  2.759 · R$  2.637.938,56   ├ vendas REAIS que a allowlist descartava:
+--       enviado    2.005 · R$  1.593.969,47   ┘ R$ 6.985.425,66 (26% do faturamento)
+--       cancelado     15 · orcamento 1 · rascunho 1  ← as duas listas excluem, corretamente
+--   Efeito medido de adotar o universo amplo (JOIN mantido constante, 1.216 clientes):
+--     · **311 clientes (25,6%) que a allowlist não conseguia calcular passam a ter margem real**
+--       — com a allowlist eles caíam em `neutro`, ou seja, o sinal sumia da tela;
+--     · 345 clientes (28,4%) mudam de faixa; delta médio 2,97 pp, máximo 112,42 pp.
+--   Preservar um comportamento medidamente errado não é conservador — é congelar o erro numa
+--   "fonte única" e multiplicá-lo pelos dois consumidores.
+--
+-- EIXO 3 — guards de qualidade: vence o #1519 (as três pernas computáveis + finitude).
+--   Mantidos como estão no helper; o #1495 fabricava margem com `COALESCE(unit_price,0)`.
+--
+-- ⚠️ CONSEQUÊNCIA PARA O `useFarmerScoring` (FU4-F fase 3): ao consumir o helper, o hook passa a
+-- enxergar o universo amplo. Isso corrige a margem, mas as OUTRAS métricas do hook (recência,
+-- frequência, spend, mix) continuam lendo `sales_orders` com a allowlist local — o chip "Corrigir
+-- filtro de status do scoring do farmer" segue aberto para elas. Este PR fecha o eixo da MARGEM.
+--
+-- ⚠️ MIGRATION MANUAL: nome custom não auto-aplica no Lovable. Colar no SQL Editor → Run.
+-- Ordem: esta migration DEPOIS de `20260723150000` e `20260726150000` (recria objetos das duas).
+
+BEGIN;
+
+-- ── 1. O helper adota o universo amplo ───────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION private.margem_cliente_agregada()
+RETURNS TABLE (
+  customer_user_id  uuid,
+  itens_computaveis bigint,
+  itens_ignorados   bigint,
+  receita_computada numeric,
+  custo_computado   numeric,
+  margem_pct        numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $fn$
+  WITH custo AS (
+    -- `> 0 AND < 'Infinity'` é o teste de FINITUDE POSITIVA em numeric e cobre os três lixos de
+    -- uma vez: 0/negativo reprovam no `> 0`; Infinity reprova no `< 'Infinity'`; e NaN reprova
+    -- também, porque o Postgres ordena NaN como MAIOR que qualquer numeric, inclusive Infinity.
+    SELECT op.omie_codigo_produto AS cod,
+           COALESCE(
+             CASE WHEN pc.cost_final > 0 AND pc.cost_final < 'Infinity'::numeric THEN pc.cost_final END,
+             CASE WHEN pc.cost_price > 0 AND pc.cost_price < 'Infinity'::numeric THEN pc.cost_price END
+           ) AS custo_unit
+      FROM public.omie_products op
+      JOIN public.product_costs pc ON pc.product_id = op.id
+     WHERE op.omie_codigo_produto IS NOT NULL
+  ),
+  itens AS (
+    SELECT oi.customer_user_id      AS cid,
+           oi.quantity::numeric     AS qtd,
+           oi.unit_price::numeric   AS preco_unit,
+           cu.custo_unit
+      FROM public.order_items oi
+      JOIN public.sales_orders so ON so.id = oi.sales_order_id
+      -- EIXO 1: JOIN set-based por código. `product_costs.product_id` é UNIQUE e
+      -- `omie_products.omie_codigo_produto` é único (7.962/7.962) ⇒ não duplica linha.
+      LEFT JOIN custo cu          ON cu.cod = oi.omie_codigo_produto
+     -- EIXO 2: DENYLIST. Só o que não é venda sai; todo status de venda real entra, inclusive os
+     -- em trânsito (`separacao`, `enviado`) e os importados do Omie.
+     WHERE so.status NOT IN ('cancelado', 'rascunho', 'pendente', 'orcamento')
+       AND so.deleted_at IS NULL
+       AND oi.customer_user_id IS NOT NULL
+       -- NOT EXISTS, não NOT IN: NOT IN é NULL-blind e zeraria o resultado inteiro.
+       AND NOT EXISTS (
+             SELECT 1 FROM public.cliente_classificacao cc
+              WHERE cc.user_id = oi.customer_user_id
+                AND cc.excluir_da_carteira IS TRUE)
+  ),
+  norm AS (
+    -- EIXO 3: um item só conta com as TRÊS pernas utilizáveis. `COALESCE(unit_price,0)` fabricava
+    -- margem: item com custo conhecido e preço ausente entrava com receita 0 e custo real.
+    SELECT i.cid, i.qtd, i.preco_unit, i.custo_unit,
+           ( i.qtd        IS NOT NULL AND i.qtd        >  0 AND i.qtd        < 'Infinity'::numeric
+         AND i.preco_unit IS NOT NULL AND i.preco_unit >= 0 AND i.preco_unit < 'Infinity'::numeric
+         AND i.custo_unit IS NOT NULL ) AS computavel
+      FROM itens i
+  )
+  SELECT
+    n.cid,
+    count(*) FILTER (WHERE n.computavel),
+    count(*) FILTER (WHERE NOT n.computavel),
+    COALESCE(sum(n.preco_unit * n.qtd)  FILTER (WHERE n.computavel), 0),
+    COALESCE(sum(n.custo_unit  * n.qtd) FILTER (WHERE n.computavel), 0),
+    CASE
+      WHEN COALESCE(sum(n.preco_unit * n.qtd) FILTER (WHERE n.computavel), 0) > 0
+      THEN round(
+             ( sum(n.preco_unit * n.qtd)  FILTER (WHERE n.computavel)
+             - sum(n.custo_unit  * n.qtd) FILTER (WHERE n.computavel) )
+             / sum(n.preco_unit * n.qtd)  FILTER (WHERE n.computavel) * 100
+           , 2)
+      ELSE NULL
+    END
+  FROM norm n
+  GROUP BY n.cid;
+$fn$;
+
+COMMENT ON FUNCTION private.margem_cliente_agregada() IS
+  'Fonte UNICA da margem bruta por cliente (order_items x omie_products x product_costs). '
+  'Universo por DENYLIST de status (inclui separacao/enviado/importado: sao vendas reais, '
+  'R$ 6.985.425,66 que a allowlist anterior descartava). JOIN por omie_codigo_produto — '
+  'product_id e nulo em 2,67% dos itens. ausente<>zero nas TRES pernas: sem item computavel '
+  'devolve NULL, nunca 0. Fechada por REVOKE; o schema private fecha a rota do PostgREST mas '
+  'NAO o EXECUTE (authenticated tem USAGE nele).';
+
+-- Reafirmar o fechamento: `CREATE OR REPLACE` preserva a ACL, mas repetir é barato e imuniza
+-- contra a função ter sido recriada à mão sem os REVOKE no intervalo.
+REVOKE ALL ON FUNCTION private.margem_cliente_agregada() FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.margem_cliente_agregada() FROM anon;
+REVOKE ALL ON FUNCTION private.margem_cliente_agregada() FROM authenticated;
+GRANT EXECUTE ON FUNCTION private.margem_cliente_agregada() TO service_role;
+GRANT USAGE ON SCHEMA private TO service_role;
+
+-- ── 2. `get_customer_margin_summary` vira PROJEÇÃO do helper ─────────────────────────────────
+-- Assinatura e nomes de coluna PRESERVADOS: a edge `calculate-scores` consome estes nomes e não
+-- muda. O que muda é de onde o número vem — e, com ele, os três eixos acima.
+CREATE OR REPLACE FUNCTION public.get_customer_margin_summary()
+RETURNS TABLE(
+  customer_user_id  uuid,
+  itens_com_custo   bigint,
+  itens_sem_custo   bigint,
+  receita_com_custo numeric,
+  custo_conhecido   numeric,
+  gross_margin_pct  numeric
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $function$
+  SELECT m.customer_user_id,
+         m.itens_computaveis,
+         m.itens_ignorados,
+         m.receita_computada,
+         m.custo_computado,
+         m.margem_pct
+    FROM private.margem_cliente_agregada() m;
+$function$;
+
+COMMENT ON FUNCTION public.get_customer_margin_summary() IS
+  'Margem bruta por cliente para o componente de margem do health score. Desde a reconciliacao '
+  '(2026-07-21) e uma PROJECAO de private.margem_cliente_agregada() — nao tem calculo proprio. '
+  'Nomes de coluna preservados para a edge calculate-scores. ausente<>zero: cliente sem item '
+  'computavel devolve NULL, nunca 0. SECURITY DEFINER + EXECUTE so para service_role.';
+
+REVOKE ALL ON FUNCTION public.get_customer_margin_summary() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_customer_margin_summary() FROM anon;
+REVOKE ALL ON FUNCTION public.get_customer_margin_summary() FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.get_customer_margin_summary() TO service_role;
+
+COMMIT;


### PR DESCRIPTION
Reconcilia `get_customer_margin_summary` (#1495) e `private.margem_cliente_agregada` (#1519), que entregaram cálculo de margem por cliente com dias de diferença e **discordavam em 28,4% dos clientes na faixa**.

**Nenhuma das duas rodou em prod** — conferido: 0 em `pg_proc` para ambas, `gross_margin_pct` seguia 0 em 6.632/6.632. A reconciliação acontece antes de qualquer número divergente existir, então não há flip-flop de valor exibido.

## O que venceu em cada eixo, por medição

### Eixo 1 — JOIN: vence o #1519

`order_items.product_id` é NULO em 1.837 de 68.700 itens (2,67%). Desses, **783 têm custo conhecido** alcançável por `omie_codigo_produto`, carregando **R$ 247.482,10** de receita que o JOIN por `product_id` classificava como "sem custo". É "ausente ≠ zero" aplicado à junção: item que não junta não é item sem custo.

### Eixo 2 — Universo de status: vence o #1495. ⚠️ Aqui o #1519 estava errado

Este é o achado maior, e é meu erro. A allowlist `IN ('confirmado','faturado','entregue')` foi copiada de `useFarmerScoring.ts:147` para "preservar o comportamento vivo". Mas **`confirmado` e `entregue` não existem em `sales_orders`** (zero linhas), então ela resolve para **só `faturado`** e descarta vendas reais:

| status | pedidos | valor | allowlist | denylist |
|---|---:|---:|:---:|:---:|
| `faturado` | 20.207 | R$ 20.220.276,84 | ✅ | ✅ |
| `importado` | 5.271 | R$ 2.753.517,63 | ❌ | ✅ |
| `separacao` | 2.759 | R$ 2.637.938,56 | ❌ | ✅ |
| `enviado` | 2.005 | R$ 1.593.969,47 | ❌ | ✅ |
| `cancelado`/`orcamento`/`rascunho` | 17 | — | ❌ | ❌ |

**R$ 6.985.425,66 descartados — 26% do faturamento.**

Efeito medido de adotar o universo amplo (JOIN mantido constante, 1.216 clientes):

- **311 clientes (25,6%) que a allowlist não conseguia calcular passam a ter margem real.** Com ela, caíam em `neutro` — o sinal sumia da tela.
- 345 (28,4%) mudam de faixa; delta médio **2,97 pp**, máximo **112,42 pp**.

Preservar um comportamento medidamente errado não é conservador: é congelar o erro numa "fonte única" e multiplicá-lo pelos dois consumidores.

### Eixo 3 — guards de qualidade: vence o #1519

Três pernas computáveis (quantidade, preço, custo) + teste de finitude. O #1495 fabricava margem com `COALESCE(unit_price,0)`.

## O que NÃO muda

`get_customer_margin_summary` mantém **assinatura e nomes de coluna** — a edge `calculate-scores` não muda. O que muda é de onde o número vem.

## Prova

**Harness do helper: 32 asserts** (era 23). Novos:
- `K2`/`K3`/`K4` travam a inclusão de `importado`/`separacao`/`enviado`
- `O3` guarda o **risco de ordem**: recolar só a migration antiga recria o helper com a allowlist e reverteria o universo em silêncio ("a última a recriar vence")
- `P1`-`P5` provam que a projeção herda universo, JOIN e fechamento, e que não tem cálculo próprio

**2 falsificações**, ambas isolando: `G1` (volta a allowlist) → `K2 K3 K4 O3 P2`; `G2` (devolve cálculo próprio) → `P4`.

**Harness do #1495: 48/48, valores esperados INTACTOS** (56.00, 40.00, −60.00, 80.00, 75.00). Ele ganhou só o mapeamento código→produto 1:1, feito por `UPDATE` derivado para não reescrever o seed — se eu tivesse reescrito as 11 linhas à mão, uma mudança de valor poderia vir do seed em vez da lógica. Essa invariância é a prova de que a delegação preservou a intenção dos asserts deles.

## ⚠️ Migration manual — e a ORDEM importa

`20260726160000_margem_reconciliacao_universo_unico.sql` — colar no SQL Editor **depois** de `20260723150000`, `20260723160000` e `20260726150000`. Recolar uma das anteriores **sozinha** depois desta reverte o universo sem erro nenhum.

## Follow-up que continua aberto

O chip "Corrigir filtro de status do scoring do farmer" **não** é fechado por este PR. Ele fecha o eixo da **margem**; as outras métricas do hook (recência, frequência, spend, mix) continuam lendo `sales_orders` com a allowlist local.