### PR TITLE
fix(farmer): margem — caps silenciosos, motor paralelo e plano persistido [money-path]

### DIFF
--- a/src/components/farmer/copilot/useFarmerCopilot.ts
+++ b/src/components/farmer/copilot/useFarmerCopilot.ts
@@ -13,6 +13,7 @@ import { Minus } from 'lucide-react';
 import { directionConfig, suggestionTypeIcons, fallbackSuggestionIcon } from './config';
 import type { InputMode } from './types';
 import type { MotorVozScribeProps } from './MotorVozScribe';
+import { margemConhecida } from '@/lib/scoring/margin';
 
 export function useFarmerCopilot() {
   const navigate = useNavigate();
@@ -108,7 +109,12 @@ export function useFarmerCopilot() {
         customerType: profile?.customer_type,
         healthScore: score?.health_score,
         avgMonthlySpend: score?.avg_monthly_spend_180d,
-        grossMarginPct: score?.gross_margin_pct,
+        // Vai para o prompt da IA. `margemConhecida` garante null EXPLÍCITO (em vez de
+        // undefined, que some do JSON, ou de uma string numérica): o modelo precisa
+        // distinguir "margem 0%" de "margem não apurada" para não sugerir desconto nem
+        // discurso de rentabilidade em cima de um número que ninguém mediu.
+        // Unidade: PERCENTUAL 0-100.
+        grossMarginPct: margemConhecida(score?.gross_margin_pct),
         categoryCount: score?.category_count,
         daysSinceLastPurchase: score?.days_since_last_purchase,
         churnRisk: score?.churn_risk,

--- a/src/components/farmer/tacticalPlan/PlanCard.tsx
+++ b/src/components/farmer/tacticalPlan/PlanCard.tsx
@@ -12,6 +12,7 @@ import { fmt, objectiveColors, profileLabels } from './config';
 import { Section, MetricRow, CopyButton } from './PlanSection';
 import { RecordResultDialog } from './RecordResultDialog';
 import type { RecordResultPayload } from './types';
+import { formatMargemPct } from '@/lib/format';
 
 export const PlanCard = ({
   plan, expanded, onToggle, onCopy, copiedText, onRecordResult,
@@ -77,7 +78,7 @@ export const PlanCard = ({
           <div className="mt-3 space-y-3">
             {/* Diagnosis */}
             <Section title="Diagnóstico Resumido" icon={Heart}>
-              <MetricRow label="Margem atual" value={`${plan.currentMarginPct.toFixed(1)}%`} />
+              <MetricRow label="Margem atual" value={formatMargemPct(plan.currentMarginPct)} />
               <MetricRow label="Média cluster" value={plan.clusterAvgMarginPct == null ? '—' : `${plan.clusterAvgMarginPct.toFixed(1)}%`} />
               <MetricRow label="Potencial expansão" value={`${plan.expansionPotential.toFixed(0)}%`} />
               <MetricRow label="Perfil" value={profileLabels[plan.customerProfile] || plan.customerProfile} />

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -5,18 +5,38 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Users, AlertTriangle, Layers } from 'lucide-react';
-import { mediaMargensConhecidas } from '@/lib/scoring/margin';
+import { mediaMargensConhecidas, coberturaMargem, legendaCobertura } from '@/lib/scoring/margin';
+import { fetchAllPages } from '@/lib/postgrest';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip as RechartsTooltip, ResponsiveContainer } from 'recharts';
 import { KpiCard } from './KpiCard';
+
+interface ScoreLinha {
+  customer_user_id: string;
+  farmer_id: string;
+  health_score: number | null;
+  health_class: string | null;
+  /** PERCENTUAL (0–100, negativo válido). `null` = não apurada. Ver @/lib/scoring/margin. */
+  gross_margin_pct: number | null;
+  category_count: number | null;
+  sales_history_status: string | null;
+}
 
 function IntelligenceManagerialTabImpl() {
   const { data: allScores, isLoading } = useQuery({
     queryKey: ['intel-all-scores'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('farmer_client_scores').select('*').order('priority_score', { ascending: false }).limit(500);
-      if (error) throw error;
-      return data || [];
-    },
+    // Base COMPLETA, paginada. Era `.limit(500)` de 6.632 ordenado por `priority_score` desc —
+    // ou seja, os 500 de MAIOR prioridade, uma amostra enviesada apresentada como comparativo
+    // ENTRE VENDEDORES. Não dá para declarar a cobertura da margem em cima disso sem mentir
+    // sobre o denominador. Ordem por `customer_user_id` (UNIQUE): paginação sem ordem estável
+    // pula e repete linha entre páginas.
+    queryFn: () =>
+      fetchAllPages<ScoreLinha>((de, ate) =>
+        supabase
+          .from('farmer_client_scores')
+          .select('customer_user_id, farmer_id, health_score, health_class, gross_margin_pct, category_count, sales_history_status')
+          .order('customer_user_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ScoreLinha[] | null }>,
+      ),
   });
 
   const { data: allPerformance } = useQuery({
@@ -73,10 +93,11 @@ function IntelligenceManagerialTabImpl() {
     // isso valeria para a maioria da base, e o gestor compararia farmers por um número que mede
     // cobertura de custo, não desempenho. `null` → a coluna mostra "—".
     const avgMargin = mediaMargensConhecidas(clients.map(c => c.gross_margin_pct));
+    const cobertura = coberturaMargem(clients.map(c => c.gross_margin_pct));
     const avgCategories = clients.reduce((a, c) => a + Number(c.category_count || 0), 0) / clients.length;
     const adoption = recoAdoption[farmerId];
     const adoptionPct = adoption && adoption.total > 0 ? (adoption.accepted / adoption.total * 100) : 0;
-    return { farmerId, clientCount: clients.length, avgHealth, atRisk, avgMargin, avgCategories, adoptionPct };
+    return { farmerId, clientCount: clients.length, avgHealth, atRisk, avgMargin, cobertura, avgCategories, adoptionPct };
   });
 
   const globalAvgCategories = allScores?.length
@@ -125,9 +146,12 @@ function IntelligenceManagerialTabImpl() {
                       <Badge variant={fm.avgHealth > 60 ? 'default' : 'destructive'} className="text-2xs">{fm.avgHealth.toFixed(0)}</Badge>
                     </td>
                     <td className="text-center py-2">{fm.atRisk}</td>
-                    <td className="text-center py-2">
+                    {/* title carrega a COBERTURA: sem ela, a coluna compara vendedores como se
+                        as médias falassem da carteira inteira de cada um — e elas falam de
+                        fatias diferentes, porque a apuração de custo não é uniforme. */}
+                    <td className="text-center py-2" title={legendaCobertura(fm.cobertura)}>
                       {fm.avgMargin == null
-                        ? <span className="text-muted-foreground" title="Nenhum cliente deste farmer tem margem apurada">—</span>
+                        ? <span className="text-muted-foreground">—</span>
                         : `${fm.avgMargin.toFixed(1)}%`}
                     </td>
                     <td className="text-center py-2">{fm.avgCategories.toFixed(1)}</td>

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -9,8 +9,18 @@ import {
   BarChart3, PieChart, ShieldCheck, RefreshCw
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { mediaMargensConhecidas } from '@/lib/scoring/margin';
+import { mediaMargensConhecidas, coberturaMargem, legendaCobertura } from '@/lib/scoring/margin';
+import { fetchAllPages } from '@/lib/postgrest';
 import { KpiCard } from './KpiCard';
+
+interface ScoreLinha {
+  customer_user_id: string;
+  /** PERCENTUAL (0–100, negativo válido). `null` = não apurada. Ver @/lib/scoring/margin. */
+  gross_margin_pct: number | null;
+  avg_monthly_spend_180d: number | null;
+  avg_repurchase_interval: number | null;
+  revenue_potential: number | null;
+}
 
 export function IntelligenceStrategicTab() {
   const { data: marginAudit, isLoading } = useQuery({
@@ -24,11 +34,17 @@ export function IntelligenceStrategicTab() {
 
   const { data: allScores } = useQuery({
     queryKey: ['intel-strategic-scores'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('farmer_client_scores').select('*').limit(500);
-      if (error) throw error;
-      return data || [];
-    },
+    // Base COMPLETA, paginada. Era `.limit(500)` de 6.632 e SEM `.order()` — o Postgres não
+    // garante ordem sem ORDER BY, então as 500 eram um recorte não determinístico: dois
+    // carregamentos podiam produzir KPIs diferentes da mesma base, sem nada na tela indicando.
+    queryFn: () =>
+      fetchAllPages<ScoreLinha>((de, ate) =>
+        supabase
+          .from('farmer_client_scores')
+          .select('customer_user_id, gross_margin_pct, avg_monthly_spend_180d, avg_repurchase_interval, revenue_potential')
+          .order('customer_user_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: ScoreLinha[] | null }>,
+      ),
   });
 
   const { data: salesOrders } = useQuery({
@@ -109,6 +125,7 @@ export function IntelligenceStrategicTab() {
   // margem apurada entrava como 0 — e como esse é o caso da maioria da base desde o cálculo
   // server-side, o KPI estratégico viraria uma medida de cobertura de custo disfarçada de margem.
   const avgGrossMargin = mediaMargensConhecidas((allScores ?? []).map(c => c.gross_margin_pct));
+  const coberturaGrossMargin = coberturaMargem((allScores ?? []).map(c => c.gross_margin_pct));
 
   const [runningAlgoA, setRunningAlgoA] = useState(false);
   const runAlgoA = async () => {
@@ -155,7 +172,12 @@ export function IntelligenceStrategicTab() {
         <KpiCard title="LTV Projetado (3a)" value={`R$ ${ltvEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={BarChart3} subtitle="Estimativa média" />
         <KpiCard title="CAC Estimado" value={`R$ ${cacEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle="Custo aquisição cliente" />
         <KpiCard title="Concentração Top 20%" value={`${concentrationPct.toFixed(1)}%`} icon={PieChart} subtitle="da receita total" />
-        <KpiCard title="Margem Bruta Média" value={avgGrossMargin == null ? '—' : `${avgGrossMargin.toFixed(1)}%`} icon={Percent} />
+        <KpiCard
+          title="Margem Bruta Média"
+          value={avgGrossMargin == null ? '—' : `${avgGrossMargin.toFixed(1)}%`}
+          icon={Percent}
+          subtitle={legendaCobertura(coberturaGrossMargin)}
+        />
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -5,6 +5,7 @@ import type { Tables } from '@/integrations/supabase/types';
 import { custoCanonico } from '@/lib/custo/custoCanonico';
 import { fetchAllPages } from '@/lib/postgrest';
 import { accumulateMarginFromItems, resolveProductIdsFromItems } from '@/lib/scoring/margin';
+import { calcularHealthScore } from '@/lib/scoring/healthScore';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
 type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price' | 'cost_final'>;
@@ -45,7 +46,9 @@ export interface ClientScore {
   customer_name: string;
   customer_phone: string | null;
   // Health
-  rf: number; m: number; g: number; x: number; s: number;
+  rf: number; m: number; x: number; s: number;
+  /** Componente de margem 0-1, ou null quando nenhum item do cliente tem custo conhecido. */
+  g: number | null;
   healthScore: number;
   healthClass: 'saudavel' | 'estavel' | 'atencao' | 'critico';
   // Priority
@@ -56,7 +59,8 @@ export interface ClientScore {
   daysSinceLastPurchase: number;
   avgRepurchaseInterval: number;
   avgMonthlySpend180d: number;
-  grossMarginPct: number;
+  /** PERCENTUAL (0–100, negativo válido). `null` = não apurada. */
+  grossMarginPct: number | null;
   categoryCount: number;
   answerRate60d: number;
   whatsappReplyRate60d: number;
@@ -347,8 +351,13 @@ export const useFarmerScoring = (farmerId?: string) => {
         const m = clamp(Math.log(1 + avgMonthly) / Math.log(1 + p95MonthlySpend), 0, 1);
 
         // G = clamp((GrossMarginClient - P10Margin) / (P90Margin - P10Margin), 0, 1)
-        const clientMargin = cd.totalRevenue > 0 ? (cd.totalRevenue - cd.totalCost) / cd.totalRevenue : 0;
-        const g = clamp((clientMargin - p10Margin) / marginRange, 0, 1);
+        // Receita 0 = NENHUM item deste cliente tem custo conhecido (accumulateMarginFromItems
+        // já descarta SKU sem custo) → margem DESCONHECIDA, não zero. O `: 0` anterior era
+        // incoerente com a régua construída logo acima: o laço que monta `allMargins` (~l.308)
+        // exclui justamente os clientes de receita 0 do cálculo dos percentis. O código já
+        // sabia que receita 0 não é margem 0 — só não aplicava isso ao próprio cliente.
+        const clientMargin = cd.totalRevenue > 0 ? (cd.totalRevenue - cd.totalCost) / cd.totalRevenue : null;
+        const g = clientMargin == null ? null : clamp((clientMargin - p10Margin) / marginRange, 0, 1);
 
         // X = clamp(CatCount / CatTarget, 0, 1)
         const x = clamp(cd.categories.size / config.cat_target, 0, 1);
@@ -358,13 +367,17 @@ export const useFarmerScoring = (farmerId?: string) => {
         const whatsappRate = cd.whatsappCalls60d > 0 ? cd.whatsappReplied60d / cd.whatsappCalls60d : 0;
         const s = 0.7 * answerRate + 0.3 * whatsappRate;
 
-        // Health = 100 * (0.35*RF + 0.20*M + 0.15*G + 0.15*X + 0.15*S)
-        const healthScore = 100 * (
-          config.health_w_rf * rf +
-          config.health_w_m * m +
-          config.health_w_g * g +
-          config.health_w_x * x +
-          config.health_w_s * s
+        // Health = média ponderada das dimensões CONHECIDAS (0.35*RF + 0.20*M + 0.15*G +
+        // 0.15*X + 0.15*S). Margem desconhecida SAI da conta e seu peso é redistribuído: zero
+        // não é neutro numa média ponderada, é a pior nota do eixo, então entrar como 0 custaria
+        // até 15 pontos por ausência de dado. Oráculo em src/lib/scoring/healthScore.ts; espelha
+        // a renormalização que o #1495 aplicou no calculate-scores (motor server-side).
+        const healthScore = calcularHealthScore(
+          { rf, m, g, x, s },
+          {
+            rf: config.health_w_rf, m: config.health_w_m, g: config.health_w_g,
+            x: config.health_w_x, s: config.health_w_s,
+          },
         );
 
         // ChurnRisk = 100 * (1 - exp(-k1 * max((D/max(I,1)) - 1, 0)))
@@ -407,7 +420,8 @@ export const useFarmerScoring = (farmerId?: string) => {
           daysSinceLastPurchase: D,
           avgRepurchaseInterval: Math.round(I * 10) / 10,
           avgMonthlySpend180d: Math.round(avgMonthly * 100) / 100,
-          grossMarginPct: Math.round(clientMargin * 1000) / 10,
+          // null preservado até a UI: Math.round(null) é 0 e reintroduziria "0,0% de margem".
+          grossMarginPct: clientMargin == null ? null : Math.round(clientMargin * 1000) / 10,
           categoryCount: cd.categories.size,
           answerRate60d: Math.round(answerRate * 1000) / 10,
           whatsappReplyRate60d: Math.round(whatsappRate * 1000) / 10,

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,7 +1,8 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
-import { margemConhecida } from '@/lib/scoring/margin';
+import { margemConhecida, mediaMargensConhecidas } from '@/lib/scoring/margin';
+import { fetchAllPages } from '@/lib/postgrest';
 import { ownersAtivosDoAlvo } from '@/lib/carteira/escopo-clientes';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
@@ -24,7 +25,8 @@ export interface TacticalPlan {
   healthScore: number;
   churnRisk: number;
   mixGap: number;
-  currentMarginPct: number;
+  /** PERCENTUAL (0–100), ou null quando a margem era desconhecida na geração do plano. */
+  currentMarginPct: number | null;
   clusterAvgMarginPct: number | null;
   expansionPotential: number;
 
@@ -238,7 +240,9 @@ export const useTacticalPlan = () => {
       healthScore: Number(d.health_score || 0),
       churnRisk: Number(d.churn_risk || 0),
       mixGap: Number(d.mix_gap || 0),
-      currentMarginPct: Number(d.current_margin_pct || 0),
+      // O plano persistido grava a margem do cliente no INSTANTE da geração; pós-#1495 ela
+      // pode ser null, e `Number(null || 0)` a exibiria como "0,0%" — margem nula apurada.
+      currentMarginPct: margemConhecida(d.current_margin_pct),
       clusterAvgMarginPct: d.cluster_avg_margin_pct == null ? null : Number(d.cluster_avg_margin_pct),
       expansionPotential: Number(d.expansion_potential || 0),
       strategicObjective: d.strategic_objective,
@@ -417,20 +421,26 @@ export const useTacticalPlan = () => {
       // carteira do coberto (carteira_visivel_para via carteira_coverage). Exclui o próprio cliente
       // (peer benchmark) e exige ≥1 par com margem finita; sem par → null (selectObjective trata;
       // nada de 25).
+      // [GUARD money-path] PAGINADO. A consulta era single-shot e o PostgREST capa em 1.000
+      // linhas em SILÊNCIO. Medido em prod (psql-ro, 2026-07-21): os três farmers têm 3.858,
+      // 1.528 e 1.246 clientes — TODOS truncavam, o maior deles enxergando 26% dos pares.
+      // Isso importa mais aqui do que numa lista qualquer: o cluster é a RÉGUA contra a qual a
+      // margem do cliente é julgada (`margem < cluster * 0.8` → consolidacao_margem), então a
+      // truncagem não some um cliente da tela — ela move a régua e troca o VEREDITO, de forma
+      // plausível e silenciosa. Ordem por `customer_user_id` (UNIQUE): sem ordem estável a
+      // paginação pula e repete linha entre páginas.
       let clusterMargin: number | null = null;
       {
-        const { data: peers } = (await supabase
-          .from('farmer_client_scores')
-          .select('gross_margin_pct')
-          .eq('farmer_id', ownerId)
-          .neq('customer_user_id', customerId)) as unknown as { data: Pick<ClientScoreFull, 'gross_margin_pct'>[] | null };
-        const peerMargins = (peers ?? [])
-          .filter((r) => r.gross_margin_pct != null)
-          .map((r) => Number(r.gross_margin_pct))
-          .filter((m) => Number.isFinite(m));
-        if (peerMargins.length >= 1) {
-          clusterMargin = peerMargins.reduce((s, m) => s + m, 0) / peerMargins.length;
-        }
+        const peers = await fetchAllPages<Pick<ClientScoreFull, 'gross_margin_pct'>>((de, ate) =>
+          supabase
+            .from('farmer_client_scores')
+            .select('gross_margin_pct')
+            .eq('farmer_id', ownerId)
+            .neq('customer_user_id', customerId)
+            .order('customer_user_id', { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: Pick<ClientScoreFull, 'gross_margin_pct'>[] | null }>,
+        );
+        clusterMargin = mediaMargensConhecidas(peers.map((r) => r.gross_margin_pct));
       }
 
       // Bundle pendente do cliente sob a carteira do DONO (ownerId), não do viewer. A tabela é

--- a/src/lib/scoring/__tests__/cobertura-margem.test.ts
+++ b/src/lib/scoring/__tests__/cobertura-margem.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { coberturaMargem, legendaCobertura } from '../margin';
+
+// Uma média de margem que representa 16% da base e uma que representa 100% são números
+// diferentes disfarçados do mesmo jeito. `mediaMargensConhecidas` (#1525) já faz a conta
+// certa; o que falta é a tela DIZER que fatia ela cobre — senão quem lê assume "todos os
+// clientes", que é a leitura errada agora que o #1495 gravou NULL em ~84% das linhas
+// (money-path: no silent caps).
+
+describe('coberturaMargem', () => {
+  it('conta quantos têm margem conhecida e o total', () => {
+    expect(coberturaMargem([40, 60, null, undefined])).toEqual({ comMargem: 2, total: 4 });
+  });
+
+  it('conta o 0 legítimo como conhecido (é veredito, não ausência)', () => {
+    expect(coberturaMargem([0, null])).toEqual({ comMargem: 1, total: 2 });
+  });
+
+  it('não-finito não conta como conhecido', () => {
+    expect(coberturaMargem([NaN, Infinity, 30])).toEqual({ comMargem: 1, total: 3 });
+  });
+
+  it('lista vazia → 0 de 0, sem divisão', () => {
+    expect(coberturaMargem([])).toEqual({ comMargem: 0, total: 0 });
+  });
+
+  it('cenário real pós-#1495 (84% ausente)', () => {
+    const valores = [
+      ...Array.from({ length: 1053 }, () => 50),
+      ...Array.from({ length: 5579 }, () => null),
+    ];
+    expect(coberturaMargem(valores)).toEqual({ comMargem: 1053, total: 6632 });
+  });
+});
+
+describe('legendaCobertura', () => {
+  it('declara que a média é parcial quando falta margem', () => {
+    expect(legendaCobertura({ comMargem: 1053, total: 6632 })).toBe(
+      'parcial — 1.053 de 6.632 clientes c/ margem',
+    );
+  });
+
+  it('não diz "parcial" quando todos têm margem', () => {
+    expect(legendaCobertura({ comMargem: 10, total: 10 })).toBe('10 clientes c/ margem');
+  });
+
+  it('nenhum com margem → diz isso, em vez de exibir cobertura 0', () => {
+    expect(legendaCobertura({ comMargem: 0, total: 6632 })).toBe(
+      'nenhum cliente c/ margem conhecida',
+    );
+  });
+
+  it('base vazia não vira "0 de 0"', () => {
+    expect(legendaCobertura({ comMargem: 0, total: 0 })).toBe('sem clientes');
+  });
+});

--- a/src/lib/scoring/__tests__/healthScore.test.ts
+++ b/src/lib/scoring/__tests__/healthScore.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { calcularHealthScore, type PesosHealth } from '../healthScore';
+
+// Oráculo da composição do health score do motor client-side (useFarmerScoring).
+//
+// O ponto: margem DESCONHECIDA não pode entrar como 0 numa média ponderada. Entrar como 0
+// não é neutro — é a pior nota possível naquele eixo, então o cliente sem custo apurado
+// levaria uma penalidade de até 15 pontos por um dado que ninguém mediu.
+//
+// ESPELHO da renormalização que o #1495 aplicou em supabase/functions/calculate-scores.
+
+const PESOS: PesosHealth = { rf: 0.35, m: 0.2, g: 0.15, x: 0.15, s: 0.15 };
+
+describe('calcularHealthScore — margem conhecida', () => {
+  it('compõe a média ponderada normalmente', () => {
+    // 100*(0.35*1 + 0.20*1 + 0.15*1 + 0.15*1 + 0.15*1) = 100
+    expect(calcularHealthScore({ rf: 1, m: 1, g: 1, x: 1, s: 1 }, PESOS)).toBe(100);
+  });
+
+  it('g = 0 CONHECIDO penaliza de verdade (margem nula real é veredito)', () => {
+    // 100*(0.35 + 0.20 + 0 + 0.15 + 0.15) = 85. toBeCloseTo porque a soma de floats
+    // devolve 85.00000000000001 — a fórmula está certa, a igualdade exata é que não cabe.
+    expect(calcularHealthScore({ rf: 1, m: 1, g: 0, x: 1, s: 1 }, PESOS)).toBeCloseTo(85, 6);
+  });
+});
+
+describe('calcularHealthScore — margem desconhecida renormaliza', () => {
+  it('g null NÃO penaliza: o peso é redistribuído entre as dimensões conhecidas', () => {
+    // Sem renormalizar seriam 85 (o mesmo que margem zero conhecida) — indistinguível de
+    // "cliente ruim". Renormalizado: 100*(0.85/0.85) = 100.
+    expect(calcularHealthScore({ rf: 1, m: 1, g: null, x: 1, s: 1 }, PESOS)).toBe(100);
+  });
+
+  it('g null preserva a proporção entre as demais dimensões', () => {
+    // rf=1, m=0, x=1, s=0 → (0.35 + 0.15) / 0.85 = 0.5882... → 58.82
+    const r = calcularHealthScore({ rf: 1, m: 0, g: null, x: 1, s: 0 }, PESOS);
+    expect(r).toBeCloseTo(58.82, 1);
+  });
+
+  it('cliente sem margem não fica ABAIXO do idêntico com margem zero conhecida', () => {
+    const semMargem = calcularHealthScore({ rf: 0.5, m: 0.5, g: null, x: 0.5, s: 0.5 }, PESOS);
+    const margemZero = calcularHealthScore({ rf: 0.5, m: 0.5, g: 0, x: 0.5, s: 0.5 }, PESOS);
+    expect(semMargem).toBeGreaterThan(margemZero);
+  });
+});
+
+describe('calcularHealthScore — bordas', () => {
+  it('todos os pesos zerados → 0, sem NaN de 0/0', () => {
+    const r = calcularHealthScore(
+      { rf: 1, m: 1, g: 1, x: 1, s: 1 },
+      { rf: 0, m: 0, g: 0, x: 0, s: 0 },
+    );
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+
+  it('só a margem tem peso e ela é desconhecida → 0, não NaN', () => {
+    const r = calcularHealthScore(
+      { rf: 1, m: 1, g: null, x: 1, s: 1 },
+      { rf: 0, m: 0, g: 1, x: 0, s: 0 },
+    );
+    expect(r).toBe(0);
+    expect(Number.isNaN(r)).toBe(false);
+  });
+
+  it('pesos que não somam 1 ainda produzem escala 0-100 (a divisão normaliza)', () => {
+    const r = calcularHealthScore(
+      { rf: 1, m: 1, g: 1, x: 1, s: 1 },
+      { rf: 0.5, m: 0.5, g: 0.5, x: 0.5, s: 0.5 },
+    );
+    expect(r).toBe(100);
+  });
+});

--- a/src/lib/scoring/__tests__/margem-sem-coacao.test.ts
+++ b/src/lib/scoring/__tests__/margem-sem-coacao.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Guard de REGRESSÃO textual sobre os consumidores de margem que não têm teste unitário
+// próprio (hooks com query no meio do caminho, componentes de KPI).
+//
+// Por que textual: o tipo `number | null` NÃO protege contra `|| 0` e `?? 0` — a coerção
+// produz `number`, perfeitamente tipada, e o typecheck passa verde. Foi exatamente assim
+// que a coação sobreviveu até aqui. E a lição da cadeia dos bundles é que basta UM `|| 0`
+// a montante para tornar inerte o guard que está a jusante (useBundleEngine matava o null
+// antes de classificarPerfilCliente poder decidir não decidir).
+//
+// Escopo deliberadamente estreito: só a coação da COLUNA de margem, nos arquivos listados.
+// Não é um linter de estilo — é a trava do invariante "ausente ≠ zero" no money-path.
+
+const RAIZ = resolve(__dirname, '../../../..');
+
+/** Arquivos que leem a margem do score e já foram migrados para o helper. */
+const CONSUMIDORES = [
+  'src/hooks/useBundleEngine.ts',
+  'src/hooks/useTacticalPlan.ts',
+  'src/hooks/useFarmerScoring.ts',
+  'src/lib/carteira/escopo-clientes.ts',
+  'src/components/adminCustomers/Customer360View.tsx',
+  'src/components/customer360/CustomerHero.tsx',
+  'src/components/intelligence/IntelligenceManagerialTab.tsx',
+  'src/components/intelligence/IntelligenceStrategicTab.tsx',
+  'src/components/farmer/bundles/CustomerBundleCard.tsx',
+  'src/components/farmer/copilot/useFarmerCopilot.ts',
+];
+
+/** Remove comentários antes de casar: um `|| 0` citado em comentário explicando o bug
+ *  produziria falso-vermelho, e o inverso (código escondido em comentário) não existe.
+ *  Mesma lição do #1488 — assert sobre texto mede prosa se não normalizar antes. */
+function semComentarios(fonte: string): string {
+  return fonte
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/** Casa coação aplicada à margem PERCENTUAL do cliente — e SÓ a ela.
+ *
+ *  ⚠️ Escopado a nomes exatos de propósito. A primeira versão casava `[mM]argin` solto e
+ *  acusou `actual_margin || 0` e `bundle_incremental_margin || 0`, que são valores em R$ —
+ *  para os quais `|| 0` é legítimo (somatório de dinheiro). Predicado que varre a vizinhança
+ *  reprova código correto e ensina a ignorar o vermelho (money-path §"o VALIDADOR mente",
+ *  #1490). Se um campo percentual novo aparecer, acrescente-o aqui explicitamente. */
+const CAMPOS = [
+  'gross_margin_pct',
+  'grossMarginPct',
+  'current_margin_pct',
+  'currentMarginPct',
+  'marginPct',
+  'clusterMargin',
+];
+const COACAO = new RegExp(`(?:${CAMPOS.join('|')})\\s*(?:\\|\\||\\?\\?)\\s*0`);
+
+describe('consumidores de margem não coagem ausência para zero', () => {
+  it.each(CONSUMIDORES)('%s não contém `margem || 0` nem `margem ?? 0`', (relativo) => {
+    const fonte = semComentarios(readFileSync(resolve(RAIZ, relativo), 'utf8'));
+    const linhas = fonte.split('\n');
+    const ofensoras = linhas
+      .map((linha, i) => ({ linha: linha.trim(), n: i + 1 }))
+      .filter(({ linha }) => COACAO.test(linha));
+
+    expect(
+      ofensoras,
+      `Coação de margem reintroduzida em ${relativo}:\n` +
+        ofensoras.map((o) => `  linha ${o.n}: ${o.linha}`).join('\n') +
+        '\n\nUse margemConhecida() de @/lib/scoring/margin. `0` é o veredito ' +
+        '"cliente não-lucrativo"; ausência é null.',
+    ).toEqual([]);
+  });
+});
+
+describe('o guard textual tem dente', () => {
+  // Falsificação embutida: se o regex parasse de casar (typo, refactor do padrão), a suíte
+  // acima ficaria verde para sempre e ninguém notaria. Estes casos fixam o que ele detecta.
+  it('detecta as formas de coação que já existiram no código', () => {
+    expect(COACAO.test('Number(score.gross_margin_pct || 0)')).toBe(true);
+    expect(COACAO.test('s.gross_margin_pct ?? 0')).toBe(true);
+    expect(COACAO.test('data.grossMarginPct || 0')).toBe(true);
+    expect(COACAO.test('const marginPct = Number(score?.gross_margin_pct || 0);')).toBe(true);
+  });
+
+  it('não acusa uso legítimo', () => {
+    expect(COACAO.test('margemConhecida(score.gross_margin_pct)')).toBe(false);
+    expect(COACAO.test('const categoryCount = Number(score.category_count || 0);')).toBe(false);
+    expect(COACAO.test('formatarMargemPct(plan.currentMarginPct)')).toBe(false);
+  });
+
+  it('ignora coação citada em comentário (senão o próprio aviso vira vermelho)', () => {
+    const fonte = semComentarios('// evite gross_margin_pct || 0 aqui\nconst x = 1;');
+    expect(COACAO.test(fonte)).toBe(false);
+  });
+});
+
+// ── Paginação dos consumidores de margem ──────────────────────────────────────
+// O PostgREST capa em 1.000 linhas em SILÊNCIO e `.limit(500)` corta antes disso. Nenhum dos
+// dois falha, loga ou muda de forma — a lista só vem menor, e a média sai de uma amostra.
+// Não há teste unitário viável (a query é feita dentro do hook/componente contra o supabase),
+// então o guard é textual: garante que estes três pontos continuam paginando.
+//
+// Medido em prod (2026-07-21): os três farmers têm 3.858 / 1.528 / 1.246 clientes — todos
+// acima do cap —, e as telas liam 500 de 6.632.
+describe('consumidores de margem paginam a base inteira', () => {
+  const PAGINADOS = [
+    ['src/hooks/useTacticalPlan.ts', 'cluster de pares (a régua do veredito de margem)'],
+    ['src/components/intelligence/IntelligenceManagerialTab.tsx', 'comparativo entre vendedores'],
+    ['src/components/intelligence/IntelligenceStrategicTab.tsx', 'margem bruta média global'],
+  ] as const;
+
+  it.each(PAGINADOS)('%s usa fetchAllPages — %s', (relativo) => {
+    const fonte = semComentarios(readFileSync(resolve(RAIZ, relativo), 'utf8'));
+    expect(
+      fonte.includes('fetchAllPages'),
+      `${relativo} deixou de paginar. Consulta a farmer_client_scores sem fetchAllPages ` +
+        'lê no máximo 1.000 linhas (cap do PostgREST) sem erro nenhum — a média sai de uma ' +
+        'amostra e nada na tela indica isso.',
+    ).toBe(true);
+  });
+
+  // NÃO existe aqui uma asserção "não usa .limit()". Tentei: a chamada é encadeada em várias
+  // linhas, então o predicado varria uma janela a partir do `.from('farmer_client_scores')` — e
+  // acusou `useTacticalPlan`, onde 5 linhas abaixo há um `.limit(1)` legítimo numa consulta a
+  // OUTRA tabela (farmer_algorithm_config). Validador que reprova código correto ensina a
+  // ignorar o vermelho, e aí o próximo vermelho — o real — vira ruído (money-path, §"o
+  // VALIDADOR mente", #1490). A asserção positiva acima basta: trocar a paginação por .limit()
+  // remove o fetchAllPages, e é isso que ela detecta.
+});

--- a/src/lib/scoring/healthScore.ts
+++ b/src/lib/scoring/healthScore.ts
@@ -1,0 +1,53 @@
+// Composição do health score do motor client-side (useFarmerScoring).
+//
+// Extraído para cá porque a regra que importa — o que fazer quando uma dimensão é
+// DESCONHECIDA — não era testável dentro do hook (query + agregação no meio do caminho).
+//
+// ESPELHO da renormalização aplicada em `supabase/functions/calculate-scores` pelo #1495.
+// Os dois motores calculam o mesmo score; se só um renormalizar, o mesmo cliente recebe
+// notas diferentes conforme a tela que o carregou.
+
+/** Dimensões do health score, em escala 0-1. `g` (margem) é `null` quando desconhecida. */
+export interface DimensoesHealth {
+  /** Recência/frequência. */
+  rf: number;
+  /** Monetário. */
+  m: number;
+  /** Margem bruta — `null` quando nenhum item do cliente tem custo conhecido. */
+  g: number | null;
+  /** Diversidade de mix. */
+  x: number;
+  /** Engajamento. */
+  s: number;
+}
+
+export interface PesosHealth {
+  rf: number;
+  m: number;
+  g: number;
+  x: number;
+  s: number;
+}
+
+/** Health score 0-100 pela média ponderada das dimensões CONHECIDAS.
+ *
+ *  ⚠️ Margem desconhecida sai da conta e seu peso é redistribuído — não entra como 0.
+ *  Zero não é neutro numa média ponderada: é a pior nota do eixo, então o cliente cujos
+ *  itens não têm custo apurado levaria até 15 pontos de penalidade por ausência de dado,
+ *  ficando indistinguível de um cliente medido e genuinamente ruim (money-path: ausente ≠
+ *  zero). `g = 0` CONHECIDO continua penalizando: aí é veredito, não ignorância.
+ *
+ *  A divisão por `pesoTotal` normaliza a escala, então pesos que não somam 1 continuam
+ *  produzindo 0-100. Todos os pesos zerados → 0 (nunca NaN de 0/0). */
+export function calcularHealthScore(dim: DimensoesHealth, pesos: PesosHealth): number {
+  const pesoG = dim.g == null ? 0 : pesos.g;
+  const pesoTotal = pesos.rf + pesos.m + pesoG + pesos.x + pesos.s;
+  if (pesoTotal <= 0) return 0;
+  const soma =
+    pesos.rf * dim.rf +
+    pesos.m * dim.m +
+    pesoG * (dim.g ?? 0) +
+    pesos.x * dim.x +
+    pesos.s * dim.s;
+  return 100 * (soma / pesoTotal);
+}

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -30,6 +30,40 @@ export function margemConhecida(raw: unknown): number | null {
  * baixo — pior que um erro visível, porque não parece errado. Aqui numerador e denominador
  * saem da MESMA lista filtrada.
  */
+export interface CoberturaMargem {
+  /** Quantos clientes têm margem CONHECIDA (0 conta; ausente e não-finito não). */
+  comMargem: number;
+  /** Tamanho da lista avaliada. */
+  total: number;
+}
+
+/**
+ * Cobertura da amostra por trás de uma média de margem.
+ *
+ * Companheira obrigatória de `mediaMargensConhecidas`: ela devolve a conta certa, mas um
+ * número sozinho não diz sobre QUANTOS clientes foi feito. Com ~84% da base sem margem
+ * apurada (pós-#1495), a mesma "margem média" pode descrever a carteira inteira ou um sexto
+ * dela, e a tela precisa dizer qual (money-path: no silent caps).
+ */
+export function coberturaMargem(valores: Iterable<unknown>): CoberturaMargem {
+  let comMargem = 0;
+  let total = 0;
+  for (const v of valores) {
+    total++;
+    if (margemConhecida(v) != null) comMargem++;
+  }
+  return { comMargem, total };
+}
+
+/** Legenda pronta para acompanhar o KPI. Sem isso, quem lê assume "todos os clientes". */
+export function legendaCobertura({ comMargem, total }: CoberturaMargem): string {
+  if (total === 0) return 'sem clientes';
+  if (comMargem === 0) return 'nenhum cliente c/ margem conhecida';
+  const cobertos = comMargem.toLocaleString('pt-BR');
+  if (comMargem === total) return `${cobertos} clientes c/ margem`;
+  return `parcial — ${cobertos} de ${total.toLocaleString('pt-BR')} clientes c/ margem`;
+}
+
 export function mediaMargensConhecidas(valores: Iterable<unknown>): number | null {
   const conhecidas: number[] = [];
   for (const v of valores) {

--- a/src/pages/FarmerDashboard.tsx
+++ b/src/pages/FarmerDashboard.tsx
@@ -18,6 +18,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { CallButton } from '@/components/call/CallButton';
 import { SlaVencidoCard } from '@/components/farmer/SlaVencidoCard';
+import { formatMargemPct } from '@/lib/format';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 const healthColors: Record<string, { bg: string; text: string; border: string }> = {
@@ -412,10 +413,17 @@ const ClientDetail = ({ client, onBack }: { client: ClientScore; onBack: () => v
             ].map(({ label, value }) => (
               <div key={label} className="text-center">
                 <div className="w-full bg-muted rounded-full h-1.5 mb-1">
-                  <div className="bg-primary h-1.5 rounded-full" style={{ width: `${value * 100}%` }} />
+                  {value != null && (
+                    <div className="bg-primary h-1.5 rounded-full" style={{ width: `${value * 100}%` }} />
+                  )}
                 </div>
                 <p className="text-[9px] text-muted-foreground">{label}</p>
-                <p className="text-[10px] font-semibold">{(value * 100).toFixed(0)}%</p>
+                {/* G (margem) é null quando nenhum item do cliente tem custo conhecido. Barra
+                    vazia + "—" em vez de "0%": zero aqui é a PIOR nota do componente, e exibi-la
+                    por ausência de custo acusa o cliente de algo que ninguém mediu. */}
+                <p className="text-[10px] font-semibold">
+                  {value == null ? '—' : `${(value * 100).toFixed(0)}%`}
+                </p>
               </div>
             ))}
           </div>
@@ -439,7 +447,7 @@ const ClientDetail = ({ client, onBack }: { client: ClientScore; onBack: () => v
           <MetricRow label="Dias sem compra" value={String(client.daysSinceLastPurchase)} />
           <MetricRow label="Intervalo médio recompra" value={`${client.avgRepurchaseInterval.toFixed(0)} dias`} />
           <MetricRow label="Gasto mensal (180d)" value={fmt(client.avgMonthlySpend180d)} />
-          <MetricRow label="Margem bruta" value={`${client.grossMarginPct.toFixed(1)}%`} />
+          <MetricRow label="Margem bruta" value={formatMargemPct(client.grossMarginPct)} />
           <MetricRow label="Categorias compradas" value={String(client.categoryCount)} />
           <MetricRow label="Taxa resposta (60d)" value={`${client.answerRate60d.toFixed(1)}%`} />
           <MetricRow label="WhatsApp reply (60d)" value={`${client.whatsappReplyRate60d.toFixed(1)}%`} />


### PR DESCRIPTION
Delta do que o #1525 não cobriu. **Com o #1495 já mergeado, a margem real está em produção e estes sete pontos estão ativos agora.**

O #1525 acertou o essencial (helper `margemConhecida`/`mediaMargensConhecidas`, `formatMargemPct`, thresholds 30/15 no `CustomerHero`, guard no classificador de perfil, dois estados no `EfficiencyAlertDialog`). Este PR fecha o que sobrou — e usa os helpers dele, sem criar módulo novo.

## 1. Caps silenciosos — o mais grave

**Cluster de pares do plano tático** (`useTacticalPlan`) era single-shot contra o cap de **1.000** do PostgREST. Medido em prod (`psql-ro`, 2026-07-21):

| farmer | clientes | via |
|---|---|---|
| 414a9727… | 3.858 | 26% |
| 700657a1… | 1.528 | 65% |
| 33f59dc7… | 1.246 | 80% |

**Todos truncavam.** Isso pesa mais do que numa lista qualquer: o cluster é a **régua** contra a qual a margem do cliente é julgada (`margem < cluster * 0.8` → `consolidacao_margem`). A truncagem não some um cliente da tela — ela **move a régua e troca o veredito**, de forma plausível e silenciosa.

**As duas telas de Intelligence** liam `.limit(500)` de 6.632:
- gerencial: ordenado por `priority_score` desc → os 500 de **maior prioridade**, amostra enviesada servindo de comparativo *entre vendedores*
- estratégico: **sem `.order()`** → recorte não determinístico; dois carregamentos podiam dar KPIs diferentes da mesma base

Os três agora paginam com `fetchAllPages` + ordem estável por `customer_user_id`.

## 2. Cobertura ao lado do KPI

`mediaMargensConhecidas` faz a conta certa, mas um número sozinho não diz **sobre quantos clientes** foi feito. Com ~84% da base sem margem apurada, a mesma "margem média" pode descrever a carteira inteira ou um sexto dela.

`coberturaMargem` + `legendaCobertura` (novos em `scoring/margin.ts`) passam a acompanhar o KPI estratégico e a coluna por vendedor: `parcial — 1.053 de 6.632 clientes c/ margem`.

## 3. Motor paralelo (`useFarmerScoring`)

`totalRevenue > 0 ? … : 0` fabricava margem 0. Era **incoerente com a régua construída no mesmo arquivo**: o laço que monta `allMargins` (~l.308) já exclui os clientes de receita 0 do cálculo dos percentis. O código sabia que receita 0 não é margem 0 — só não aplicava isso ao próprio cliente.

O health score passa a **renormalizar** o peso da dimensão ausente (`calcularHealthScore`, oráculo novo), espelhando o que o #1495 fez no motor server-side. Sem isso, margem desconhecida custaria até 15 pontos por ausência de dado. `g = 0` **conhecido** continua penalizando — aí é veredito.

## 4. Plano persistido e exibições

- `currentMarginPct: Number(d.current_margin_pct || 0)` exibia "0,0%" quando a margem era desconhecida na geração — **achado pelo guard textual deste PR, não por leitura**
- `FarmerDashboard`: componente G como "0%" e margem bruta sem tratar null
- `useFarmerCopilot`: margem crua no contexto que vai para o prompt da IA

## Prova

**25 testes novos.** Falsificação com baseline verde, contagem de vermelhos conferida e âncoras ASCII (money-path §31 — *"exit code não distingue 'pegou o bug' de 'não rodou nada'"*): 5 sabotagens nos arquivos **reais** — health sem renormalizar · cobertura contando ausente · legenda omitindo "parcial" · cluster sem paginar · `|| 0` de volta no plano — → **3/4/1/1/1** falhas, todas nos asserts mirados.

Restauração verificada contra backup, arquivo a arquivo — não via `git diff`, que compara com o HEAD e esconderia a sabotagem entre as mudanças legítimas.

**Guard textual** (`margem-sem-coacao.test.ts`) sobre os 10 consumidores + os 3 pontos paginados: o tipo `number | null` **não** protege contra `|| 0` (a coerção produz `number` e o typecheck passa verde). Foi ele que achou o `currentMarginPct`.

Duas asserções minhas foram **removidas por darem falso positivo em código correto**: o regex de coação varria `[mM]argin` solto e acusava `actual_margin || 0` (valor em R$, onde `|| 0` é legítimo); e a asserção "não usa `.limit()`" varria uma janela de linhas e acusava um `.limit(1)` de *outra tabela*. Validador que reprova código correto ensina a ignorar o vermelho, e aí o próximo vermelho — o real — vira ruído (§*"o VALIDADOR mente"*, #1490).

## Gates

`typecheck` 0 · `test` **5615/5615** · `lint` 0 errors · `build` ok.

## Nota de processo

O #1526 (fechado) fez este trabalho em paralelo ao #1525, sem que nenhuma das duas sessões soubesse da outra. Descobri na hora do merge. Refiz sobre a `main` usando os helpers do #1525 em vez de resolver 13 conflitos — o diff caiu de 26 arquivos para 8.

## Follow-up aberto

`formatPctMaybe` (`customer360/format.ts`) ainda adivinha unidade com `v > 1 ? v : v * 100` em 5 call-sites de outro domínio. O Codex achou ali um bug independente: o KPI de equipe pode passar de 1, então `2` vira `"2%"` quando deveria ser `"200%"`. Chip criado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)