### PR TITLE
fix(tint): separa o RÓTULO do PISO — preco_piso_legado NULL-preserving [money-path]

### DIFF
--- a/db/test-tint-canonica.sh
+++ b/db/test-tint-canonica.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 # Teste PG17 da FÓRMULA CANÔNICA tintométrica (Fase 2 + 2b + fix semântico +
-# allowlist — v_tint_formula_canonica). Aplica schema-snapshot + as migrations
-# 20260718213000_tint_formula_canonica.sql, 20260718233000_tint_canonica_preco_
-# csv_legado.sql, 20260722100002_tint_canonica_csv_legado_semantico.sql E
-# 20260724130000_tint_canonica_csv_legado_allowlist.sql NA
+# allowlist + piso legado — v_tint_formula_canonica). Aplica schema-snapshot +
+# as migrations 20260718213000_tint_formula_canonica.sql, 20260718233000_tint_
+# canonica_preco_csv_legado.sql, 20260722100002_tint_canonica_csv_legado_
+# semantico.sql, 20260724130000_tint_canonica_csv_legado_allowlist.sql E
+# 20260726160000_tint_canonica_piso_legado.sql NA
 # ORDEM (prova a cadeia de REPLACEs que prod executa),
 # semeia gêmeas SL×SAYERLACK controladas e prova (com falsificação):
 #   C1  preferência: SL válida vence SAYERLACK válida na mesma chave
@@ -54,6 +55,42 @@
 #   F11 falsificação: allowlist sem `s2.account = g2.account` → derruba {C19}
 #   F12 falsificação: `<> 'SL'` no lugar de `= '1'` → derruba {C20}
 #   F13 falsificação: `IN ('1','2')` → derruba {C20}
+#   ── separação RÓTULO × PISO (follow-up do challenge Codex no #1523) ──
+#   A 14ª coluna `preco_piso_legado` existe porque a 13ª servia dois donos com
+#   necessidades OPOSTAS: o RÓTULO do balcão quer PRECISÃO DE PROVENIÊNCIA (só
+#   a geração '1'), o PISO do gate de submit quer CONSERVADORISMO (toda linha
+#   ativa). Encolher o max para dar precisão ao rótulo REDUZIA o piso do gate.
+#   ⚠️ E o spec óbvio ("max de todas as ativas") está ERRADO: como o gate faz
+#   LEAST(v_calc, COALESCE(v_tab, v_calc)), v_tab NULL dá o piso MAIS ALTO, e
+#   trocar NULL por um número AFROUXA. Daí o NULL-preserving. Medido em prod
+#   (2026-07-21): 6,3% das chaves com SL ativa (31.062 de 495.057) não têm
+#   geração '1' — é a população que o spec ingênuo afrouxaria.
+#   C21 K18 o CASO DO CODEX: rótulo=290 (allowlist) mas piso=500 (a
+#       personalizada entra no piso e não no rótulo) — a divergência que motiva
+#       a coluna
+#   C22 K17 2ª linha SL entra no piso (800) e segue fora do rótulo (280)
+#   C23 K19 DESATIVADA fica fora dos DOIS (300/300) — o piso herda o filtro
+#   C24 K21 subcoleções futuras entram no piso (880), fora do rótulo (330)
+#   C25 K20 linha cross-account entra no piso (850) — o piso não filtra
+#       subcoleção, então o guard de conta do rótulo não se aplica aqui
+#   C26 K22 NULL-PRESERVING (o coração): sem geração '1' provada na chave,
+#       csv=NULL ⇒ piso=NULL. Devolver 700 aqui derruba o piso do gate de
+#       v_calc para 700 — AFROUXA. É o assert que separa o spec certo do óbvio
+#   C27 K16 ramo não-SL: piso ≡ csv (a allowlist nem dispara)
+#   C28 INVARIANTE I1 global: (csv IS NULL) ⟺ (piso IS NULL) — guarda de DRIFT
+#       entre as 2 cópias da subquery do csv na migration
+#   C29 INVARIANTE I2 global: piso >= csv (max de um SUPERconjunto)
+#   C30 SHAPE: as 13 colunas na ordem exata + a 14ª só ACRESCENTADA no fim
+#   C31 security_invoker=on sobreviveu ao REPLACE (armadilha #1375)
+#   F14 falsificação: spec INGÊNUO (sem o NULL-preserving) → derruba {C26,C28}
+#   F15 falsificação: piso com a allowlist (vira cópia do rótulo) → derruba
+#       {C21,C22,C24,C25}
+#   F16 falsificação: piso sem `desativada_em` → derruba {C23}
+#   ⚠️ C21-C31 vivem em `run_asserts_piso`, SEPARADO de `run_asserts`: as 10
+#   views sabotadas de F1-F10 são recriadas à mão com 13 colunas, e fazer
+#   `run_asserts` ler a 14ª mataria todas em "column does not exist" —
+#   sabotagem que muda o alvo E o shape não isola o que prova. Em F14-F16 o
+#   inverso é VERIFICADO: C1-C20 têm de seguir verdes (`piso_isolado`).
 #   R   restauração: re-aplica a migration REAL → tudo verde de novo
 #
 # ⚠️ CONTRATO DAS FALSIFICAÇÕES: cada uma declara o CONJUNTO EXATO de asserts que
@@ -73,6 +110,7 @@ MIGRATION="$REPO_ROOT/supabase/migrations/20260718213000_tint_formula_canonica.s
 MIGRATION2="$REPO_ROOT/supabase/migrations/20260718233000_tint_canonica_preco_csv_legado.sql"
 MIGRATION3="$REPO_ROOT/supabase/migrations/20260722100002_tint_canonica_csv_legado_semantico.sql"
 MIGRATION4="$REPO_ROOT/supabase/migrations/20260724130000_tint_canonica_csv_legado_allowlist.sql"
+MIGRATION5="$REPO_ROOT/supabase/migrations/20260726160000_tint_canonica_piso_legado.sql"
 PGVER=17
 PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
 PORT=5447
@@ -84,6 +122,7 @@ export LC_ALL=C LANG=C
 [ -f "$MIGRATION2" ] || { echo "migration ausente: $MIGRATION2"; exit 1; }
 [ -f "$MIGRATION3" ] || { echo "migration ausente: $MIGRATION3"; exit 1; }
 [ -f "$MIGRATION4" ] || { echo "migration ausente: $MIGRATION4"; exit 1; }
+[ -f "$MIGRATION5" ] || { echo "migration ausente: $MIGRATION5"; exit 1; }
 
 CELLAR="$(brew --prefix postgresql@${PGVER})"
 cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
@@ -154,7 +193,7 @@ P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" || { echo "FALHA no 
 P --single-transaction -q -f "$RR" >/dev/null || { echo "FALHA no setup: snapshot"; exit 1; }
 rm -f "$RR"
 
-echo "→ migrations 20260718213000 + 20260718233000 + 20260722100002 + 20260724130000 na ordem de prod (cadeia de REPLACEs)…"
+echo "→ migrations 20260718213000 + 20260718233000 + 20260722100002 + 20260724130000 + 20260726160000 na ordem de prod (cadeia de REPLACEs)…"
 # ⚠️ O snapshot AGORA traz a view pronta (13 colunas) — desde o re-dump do #1509
 # (2026-07-21). Antes disso o snapshot era de junho, anterior à view, e a cadeia
 # aplicava no vazio. Sem este DROP, a Fase 2 (12 colunas) morre em "cannot drop
@@ -167,15 +206,17 @@ P -q -f "$MIGRATION" >/dev/null  || { echo "FALHA: migration Fase 2 não aplicou
 P -q -f "$MIGRATION2" >/dev/null || { echo "FALHA: migration Fase 2b não aplicou"; exit 1; }
 P -q -f "$MIGRATION3" >/dev/null || { echo "FALHA: migration fix semântico não aplicou"; exit 1; }
 P -q -f "$MIGRATION4" >/dev/null || { echo "FALHA: migration allowlist não aplicou"; exit 1; }
+P -q -f "$MIGRATION5" >/dev/null || { echo "FALHA: migration piso legado não aplicou"; exit 1; }
 
-# Restaura a view REAL (4 migrations na ordem). DROP antes: as views sabotadas
+# Restaura a view REAL (5 migrations na ordem). DROP antes: as views sabotadas
 # das falsificações têm shape divergente e REPLACE não remove/reordena coluna.
 restore_view() {
   if ! P -q -c "DROP VIEW IF EXISTS public.v_tint_formula_canonica;" >/dev/null \
      || ! P -q -f "$MIGRATION" >/dev/null \
      || ! P -q -f "$MIGRATION2" >/dev/null \
      || ! P -q -f "$MIGRATION3" >/dev/null \
-     || ! P -q -f "$MIGRATION4" >/dev/null; then
+     || ! P -q -f "$MIGRATION4" >/dev/null \
+     || ! P -q -f "$MIGRATION5" >/dev/null; then
     echo "FALHA: restore_view não re-aplicou as migrations"; exit 1
   fi
 }
@@ -341,7 +382,18 @@ INSERT INTO public.tint_formulas (id, account, cor_id, nome_cor, produto_id, bas
   ('f0210000-0000-0000-0000-000000000019','oben','K21','FUTURAS','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',330),
   ('f0210000-0000-0000-0000-000000000002','oben','K21','FUTURAS','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','02000000-0000-0000-0000-000000000002','50000000-0000-0000-0000-00000000000a',860),
   ('f0210000-0000-0000-0000-000000000010','oben','K21','FUTURAS','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','10000000-0000-0000-0000-000000000010','50000000-0000-0000-0000-00000000000a',870),
-  ('f0210000-0000-0000-0000-00000000000e','oben','K21','FUTURAS','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0e000000-0000-0000-0000-00000000000e','50000000-0000-0000-0000-00000000000a',880);
+  ('f0210000-0000-0000-0000-00000000000e','oben','K21','FUTURAS','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0e000000-0000-0000-0000-00000000000e','50000000-0000-0000-0000-00000000000a',880),
+  -- K22 SEMGEN1 @SKU_OK (correção do spec do piso — medição psql-ro 2026-07-21):
+  -- SL canônica válida × personalizada com CSV 700 × NENHUMA linha da geração
+  -- '1' na chave. preco_csv_legado = NULL (a allowlist não acha a '1') ⇒
+  -- preco_piso_legado TAMBÉM NULL (NULL-preserving).
+  -- É o seed que separa o spec CERTO do spec INGÊNUO: "max de TODAS as ativas"
+  -- devolveria 700 aqui, e como o gate faz LEAST(v_calc, COALESCE(v_tab,
+  -- v_calc)), trocar NULL por 700 DERRUBA o piso de v_calc para 700 — afrouxa
+  -- em vez de apertar. Em prod isso é a população de 31.062 chaves (6,3% das
+  -- 495.057 com SL ativa) que não têm geração '1' ativa.
+  ('f0220000-0000-0000-0000-00000000005a','oben','K22','SEMGEN1','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f0220000-0000-0000-0000-0000000000e0','oben','K22','SEMGEN1','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e2',NULL,'50000000-0000-0000-0000-00000000000a',700);
 UPDATE public.tint_formulas SET desativada_em = now()
  WHERE id IN ('fb000000-0000-0000-0000-00000000005a','f0190000-0000-0000-0000-00000000001a');
 
@@ -380,7 +432,10 @@ INSERT INTO public.tint_formula_itens (formula_id, corante_id, ordem, qtd_ml) VA
   -- corante_id → omie), então serve à fórmula de colacor sem alterar o que K20
   -- prova (o guard de account da SUBCOLEÇÃO, não do corante).
   ('f0200000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
-  ('f0210000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10);
+  ('f0210000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
+  -- K22: só a SL canônica tem receita válida (rank 0) — a personalizada fica
+  -- rank 3, então a canônica é a SL e o ramo da allowlist dispara.
+  ('f0220000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10);
 
 -- O dump do snapshot NÃO traz os GRANTs de tabela; em prod o Supabase concede a
 -- authenticated/anon (RLS filtra). security_invoker exige privilégio do CALLER
@@ -412,10 +467,12 @@ BEGIN
   -- passarem em NULL (teatro — foi exatamente o modo de falha do run 1).
   -- Segue ABORTANDO na hora (≠ demais asserts): seed errado torna todo o
   -- resto ruído, não sinal.
+  -- 47/31 desde o seed K22 (piso NULL-preserving, 2026-07-21): +2 fórmulas
+  -- (SL canônica + personalizada com CSV, sem geração '1' na chave) e +1 item.
   SELECT count(*) INTO nf FROM public.tint_formulas;
   SELECT count(*) INTO ni FROM public.tint_formula_itens;
-  IF nf <> 45 OR ni <> 30 THEN
-    RAISE EXCEPTION 'C0 FALHOU: seed incompleto (formulas=% esperado 45, itens=% esperado 30)', nf, ni; END IF;
+  IF nf <> 47 OR ni <> 31 THEN
+    RAISE EXCEPTION 'C0 FALHOU: seed incompleto (formulas=% esperado 47, itens=% esperado 31)', nf, ni; END IF;
 
   -- C8 não-desaparecimento GLOBAL primeiro (cardinalidade pega duplicata E omissão
   -- antes de qualquer SELECT por-cor devolver linha a mais/menos)
@@ -623,12 +680,157 @@ END $$;
 SQL
 }
 
+# ══════════════════════════════════════════════════════════════════════════════
+# ASSERTS DO PISO (C21-C31) — bloco SEPARADO de propósito.
+#
+# Por que separado: as 10 views sabotadas de F1-F10 são recriadas À MÃO com 13
+# colunas. Se `run_asserts` passasse a ler `preco_piso_legado`, TODAS elas
+# morreriam em "column does not exist" — sabotagem que muda DUAS coisas (o alvo
+# + o shape) não isola o que prova (é a lição já registrada no comentário da F1).
+# Mantendo os asserts do piso aqui, F1-F13 seguem provando o RÓTULO/rank contra
+# a cadeia de 4 migrations, sem tocar nada, e o piso ganha as falsificações
+# próprias (F14-F16, por mutação sed da MIGRATION5).
+# O baseline continua cobrindo o risco real: C1-C20 rodam contra a view FINAL
+# (5 migrations), então um erro da MIGRATION5 na coluna 13 aparece lá.
+# ══════════════════════════════════════════════════════════════════════════════
+run_asserts_piso() {
+  P -tA 2>&1 <<'SQL'
+DO $$
+DECLARE
+  r record;
+  falhas text[] := '{}';
+  n int;
+  v_cols text;
+  b boolean;
+BEGIN
+  -- ── C21 O CASO DO CODEX (a razão de a coluna existir) ──────────────────────
+  -- K18: canônica SL, personalizada com CSV 500 e geração '1' com CSV 290.
+  -- O RÓTULO fica em 290 (allowlist = proveniência provada); o PISO sobe para
+  -- 500 (conservador = toda linha ativa). Com uma coluna só, dar precisão ao
+  -- rótulo derrubava o piso de 500 para 290 e liberava preço manual mais baixo.
+  SELECT c.is_sl, c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.cor_id='K18';
+  IF r.is_sl IS DISTINCT FROM true THEN
+    falhas := falhas || format('C21 FALHOU (pre-condicao): canonica de K18 nao e SL (is_sl=%s)', r.is_sl);
+  ELSIF r.csv IS DISTINCT FROM '290' OR r.piso IS DISTINCT FROM '500' THEN
+    falhas := falhas || format('C21 FALHOU: K18 csv=%s piso=%s — esperado csv=290 (rotulo/allowlist) e piso=500 (conservador: a personalizada entra no piso, nao no rotulo)', r.csv, r.piso);
+  END IF;
+
+  -- ── C22 2ª linha SL entra no PISO (mas segue fora do rótulo) ───────────────
+  SELECT c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.cor_id='K17';
+  IF r.csv IS DISTINCT FROM '280' OR r.piso IS DISTINCT FROM '800' THEN
+    falhas := falhas || format('C22 FALHOU: K17 csv=%s piso=%s — esperado csv=280 e piso=800 (a 2a SL alimenta o piso)', r.csv, r.piso);
+  END IF;
+
+  -- ── C23 DESATIVADA fica fora dos DOIS (o piso herda o filtro) ──────────────
+  -- Sem o `desativada_em IS NULL` no ramo do piso, o CSV 900 da linha morta
+  -- entraria e o piso viraria 900 — dado de fórmula desativada não é evidência.
+  SELECT c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.cor_id='K19';
+  IF r.csv IS DISTINCT FROM '300' OR r.piso IS DISTINCT FROM '300' THEN
+    falhas := falhas || format('C23 FALHOU: K19 csv=%s piso=%s — esperado 300/300 (a desativada com CSV 900 fica fora do piso tambem)', r.csv, r.piso);
+  END IF;
+
+  -- ── C24 subcoleções FUTURAS entram no piso (e seguem fora do rótulo) ───────
+  SELECT c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.cor_id='K21';
+  IF r.csv IS DISTINCT FROM '330' OR r.piso IS DISTINCT FROM '880' THEN
+    falhas := falhas || format('C24 FALHOU: K21 csv=%s piso=%s — esperado csv=330 (so a geracao 1) e piso=880 (2/10/rotulo-NULL entram no piso)', r.csv, r.piso);
+  END IF;
+
+  -- ── C25 linha cross-account entra no PISO (conservador) ────────────────────
+  -- O guard `s2.account = g2.account` protege o RÓTULO (C19). O piso não junta
+  -- subcoleção nenhuma: é linha ATIVA da chave (account, sku, cor), logo o 850
+  -- entra. Direção segura — piso mais alto.
+  SELECT c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.account='colacor' AND c.cor_id='K20';
+  IF r.csv IS DISTINCT FROM '320' OR r.piso IS DISTINCT FROM '850' THEN
+    falhas := falhas || format('C25 FALHOU: K20 csv=%s piso=%s — esperado csv=320 (guard de conta no rotulo) e piso=850 (o piso nao filtra subcolecao)', r.csv, r.piso);
+  END IF;
+
+  -- ── C26 NULL-PRESERVING (o coração da correção do spec) ────────────────────
+  -- K22: canônica SL, personalizada com CSV 700, NENHUMA geração '1' na chave.
+  -- csv = NULL ⇒ piso TEM de ser NULL. Se virasse 700, o gate trocaria
+  -- v_floor = v_calc por v_floor = 700 e AFROUXARIA — em prod são 31.062 chaves.
+  SELECT c.is_sl, c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.cor_id='K22';
+  IF r.is_sl IS DISTINCT FROM true THEN
+    falhas := falhas || format('C26 FALHOU (pre-condicao): canonica de K22 nao e SL (is_sl=%s)', r.is_sl);
+  ELSIF r.csv IS NOT NULL OR r.piso IS NOT NULL THEN
+    falhas := falhas || format('C26 FALHOU: K22 csv=%s piso=%s — esperado NULL/NULL (sem geracao 1 provada o piso NAO desce; devolver 700 aqui AFROUXA o gate)', COALESCE(r.csv,'NULL'), COALESCE(r.piso,'NULL'));
+  END IF;
+
+  -- ── C27 ramo NÃO-SL: piso ≡ csv (a allowlist nem dispara) ──────────────────
+  SELECT c.is_sl, c.preco_csv_legado::text AS csv, c.preco_piso_legado::text AS piso
+    INTO r FROM public.v_tint_formula_canonica c WHERE c.cor_id='K16';
+  IF r.is_sl IS DISTINCT FROM false THEN
+    falhas := falhas || format('C27 FALHOU (pre-condicao): canonica de K16 deveria ser nao-SL (is_sl=%s)', r.is_sl);
+  ELSIF r.csv IS DISTINCT FROM '400' OR r.piso IS DISTINCT FROM '400' THEN
+    falhas := falhas || format('C27 FALHOU: K16 csv=%s piso=%s — esperado 400/400 (canonica nao-SL: os dois ja sao o max de todas)', r.csv, r.piso);
+  END IF;
+
+  -- ── C28 INVARIANTE I1, GLOBAL: (csv IS NULL) ⟺ (piso IS NULL) ─────────────
+  -- Guarda de DRIFT: a subquery do csv aparece 2× na migration (coluna 13 e o
+  -- teste de NULL da 14ª). Se as cópias divergirem, I1 quebra aqui na hora.
+  SELECT count(*) INTO n FROM public.v_tint_formula_canonica
+   WHERE (preco_csv_legado IS NULL) <> (preco_piso_legado IS NULL);
+  IF n <> 0 THEN
+    falhas := falhas || format('C28 FALHOU: %s linha(s) violam I1 (csv IS NULL) <=> (piso IS NULL) — as 2 copias da subquery do csv driftaram', n);
+  END IF;
+
+  -- ── C29 INVARIANTE I2, GLOBAL: piso >= csv ────────────────────────────────
+  -- O piso é o max de um SUPERconjunto do max do rótulo. Se alguma linha tiver
+  -- piso < csv, o piso deixou de ser conservador e a mudança pode afrouxar.
+  SELECT count(*) INTO n FROM public.v_tint_formula_canonica
+   WHERE preco_csv_legado IS NOT NULL AND preco_piso_legado IS NOT NULL
+     AND preco_piso_legado < preco_csv_legado;
+  IF n <> 0 THEN
+    falhas := falhas || format('C29 FALHOU: %s linha(s) com piso < csv — o piso tem de ser o max de um SUPERconjunto (senao o gate afrouxa)', n);
+  END IF;
+
+  -- ── C30 SHAPE: a 14ª só ACRESCENTA; as 13 anteriores na ordem EXATA ───────
+  -- Regra do repo para REPLACE de view (CLAUDE.md): preservar a ordem e só
+  -- acrescentar no fim. Um consumidor posicional quebra silenciosamente se não.
+  SELECT string_agg(a.attname, ',' ORDER BY a.attnum) INTO v_cols
+    FROM pg_attribute a
+   WHERE a.attrelid = 'public.v_tint_formula_canonica'::regclass
+     AND a.attnum > 0 AND NOT a.attisdropped;
+  IF v_cols IS DISTINCT FROM 'id,account,sku_id,cor_id,nome_cor,preco_final_sayersystem,subcolecao_id,personalizada,updated_at,is_sl,tem_receita,receita_valida,preco_csv_legado,preco_piso_legado' THEN
+    falhas := falhas || format('C30 FALHOU: ordem/nomes das colunas mudou — veio [%s]', v_cols);
+  END IF;
+
+  -- ── C31 security_invoker=on sobreviveu ao REPLACE (armadilha #1375) ───────
+  -- Omitir o WITH no replace RESETA a opção: a view passa a ler como OWNER e
+  -- bypassa RLS. Falha ABERTA, muda autorização e não comportamento — nenhum
+  -- assert de VALOR pegaria.
+  SELECT EXISTS (SELECT 1 FROM pg_class c
+                  WHERE c.oid = 'public.v_tint_formula_canonica'::regclass
+                    AND c.reloptions @> ARRAY['security_invoker=on']) INTO b;
+  IF NOT b THEN
+    falhas := falhas || 'C31 FALHOU: a view perdeu security_invoker=on — passa a ler como OWNER e bypassa a RLS (armadilha #1375)';
+  END IF;
+
+  IF array_length(falhas, 1) IS NULL THEN
+    RAISE NOTICE 'TODOS_OK';
+  ELSE
+    RAISE EXCEPTION 'FALHAS[%]: %', array_length(falhas, 1), array_to_string(falhas, ' | ');
+  END IF;
+END $$;
+SQL
+}
+
 echo ""
 echo "════════ BASELINE (migration real) ════════"
 OUT="$(run_asserts)"
 case "$OUT" in
   *TODOS_OK*) ok "C1–C20 baseline verde (preferência, fallback, 12, personalizada, csv legado allowlist, guard de conta, exclusividade da '1', determinismo, paridade RPC)" ;;
   *) bad "baseline NÃO passou: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-300)" ;;
+esac
+OUT_PISO="$(run_asserts_piso)"
+case "$OUT_PISO" in
+  *TODOS_OK*) ok "C21–C31 baseline verde (piso conservador, NULL-preserving, invariantes I1/I2, shape das 14 colunas, security_invoker)" ;;
+  *) bad "baseline do PISO NÃO passou: $(printf '%s' "$OUT_PISO" | tr '\n' ' ' | cut -c1-300)" ;;
 esac
 
 echo ""
@@ -637,7 +839,7 @@ echo "════════ C11 — RLS/security_invoker (staff vê · custom
 vcnt() { Pq -c "$1 SELECT count(*) FROM public.v_tint_formula_canonica;" 2>&1 | tail -1; }
 is_num() { case "$1" in ''|*[!0-9]*) return 1;; *) return 0;; esac; }
 N_STAFF=$(vcnt "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated;")
-if is_num "$N_STAFF" && [ "$N_STAFF" -eq 21 ]; then ok "C11a staff (master) vê a view ($N_STAFF chaves)"; else bad "C11a staff: esperado 21, veio [$N_STAFF]"; fi
+if is_num "$N_STAFF" && [ "$N_STAFF" -eq 22 ]; then ok "C11a staff (master) vê a view ($N_STAFF chaves)"; else bad "C11a staff: esperado 22, veio [$N_STAFF]"; fi
 N_CUST=$(vcnt "SET test.uid='33333333-3333-3333-3333-333333333333'; SET ROLE authenticated;")
 eq "C11b customer autenticado NÃO vê (RLS herdada)" "$N_CUST" "0"
 N_NOROLE=$(vcnt "SET test.uid='44444444-4444-4444-4444-444444444444'; SET ROLE authenticated;")
@@ -650,7 +852,7 @@ esac
 ANON_PRIV=$(Pq -c "SELECT has_table_privilege('anon','public.v_tint_formula_canonica','SELECT');" | tail -1)
 eq "C11d2 anon SEM privilégio direto na VIEW (has_table_privilege=f)" "$ANON_PRIV" "f"
 N_SRV=$(vcnt "SET ROLE service_role;")
-if is_num "$N_SRV" && [ "$N_SRV" -eq 21 ]; then ok "C11e service_role vê ($N_SRV chaves)"; else bad "C11e service_role: esperado 21, veio [$N_SRV]"; fi
+if is_num "$N_SRV" && [ "$N_SRV" -eq 22 ]; then ok "C11e service_role vê ($N_SRV chaves)"; else bad "C11e service_role: esperado 22, veio [$N_SRV]"; fi
 Pq -c "RESET ROLE;" >/dev/null
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -1272,6 +1474,61 @@ sabota_migration "s/AND s2\.id_subcolecao_sayersystem = '1'/AND s2.id_subcolecao
 OUT="$(run_asserts)"
 confere_falsificacao "F13" "$OUT" 1 "C20" -- "IN ('1','2'): a geracao '2' entrou no max"
 
+# ══════════════════════════════════════════════════════════════════════════════
+# F14-F16 — falsificações do PISO (coluna 14), por MUTAÇÃO sed da MIGRATION5.
+# Cada uma ataca UMA propriedade do piso e é conferida contra `run_asserts_piso`.
+# Em cada uma, `run_asserts` (C1-C20) TEM de seguir verde: o piso é coluna nova
+# e a sabotagem não pode vazar para o rótulo/rank. Isso é VERIFICADO, não
+# assumido — é o que prova que a sabotagem isola o que diz isolar.
+# ══════════════════════════════════════════════════════════════════════════════
+sabota_migration5() { # <expressao sed>
+  # A MIGRATION5 é REPLACE puro e as mutações abaixo preservam as 14 colunas na
+  # mesma ordem — então dá para re-aplicar por cima sem DROP.
+  restore_view
+  sed "$1" "$MIGRATION5" | P -q -f - >/dev/null || return 1
+}
+
+# Confere que a sabotagem do piso NÃO vazou para os asserts do rótulo/rank.
+piso_isolado() { # <rotulo>
+  local o; o="$(run_asserts)"
+  case "$o" in
+    *TODOS_OK*) ok "$1 isolada: C1–C20 (rótulo/rank) seguem verdes sob a sabotagem do piso" ;;
+    *) bad "$1 VAZOU para C1–C20: $(printf '%s' "$o" | tr '\n' ' ' | cut -c1-220)" ;;
+  esac
+}
+
+echo ""
+echo "════════ F14 — sabotagem: o SPEC INGÊNUO (piso sem o NULL-preserving) ════════"
+# `AND false` no WHEN da CASE ⇒ o ramo ELSE sempre vale ⇒ piso = max de TODAS as
+# ativas INCONDICIONALMENTE. É exatamente o spec que o follow-up pedia ao pé da
+# letra, e que a medição em prod mostrou estar errado: onde não há geração '1'
+# provada (K22 / 31.062 chaves reais), o piso deixa de ser v_calc e vira o CSV
+# de qualquer linha ativa — AFROUXANDO o gate em vez de apertá-lo.
+sabota_migration5 's/))) IS NULL/))) IS NULL AND false/' || bad "F14 não aplicou a sabotagem"
+OUT_PISO="$(run_asserts_piso)"
+confere_falsificacao "F14" "$OUT_PISO" 2 "C26" "C28" -- "spec ingenuo: sem geracao 1 provada o piso virou 700 (afrouxa) e quebrou o invariante I1"
+piso_isolado "F14"
+
+echo ""
+echo "════════ F15 — sabotagem: piso com a ALLOWLIST (piso ≡ rótulo) ════════"
+# O piso passa a filtrar pela geração '1' igual ao rótulo — ou seja, a coluna
+# nova vira uma cópia da 13ª e a separação some. É o estado ANTERIOR a esta
+# migration: o cenário do Codex volta a ficar desprotegido.
+sabota_migration5 "s/AND g3\.desativada_em IS NULL)/AND g3.desativada_em IS NULL AND (NOT rf.is_sl OR EXISTS (SELECT 1 FROM public.tint_subcolecoes s3 WHERE s3.id = g3.subcolecao_id AND s3.account = g3.account AND s3.id_subcolecao_sayersystem = '1')))/" || bad "F15 não aplicou a sabotagem"
+OUT_PISO="$(run_asserts_piso)"
+confere_falsificacao "F15" "$OUT_PISO" 4 "C21" "C22" "C24" "C25" -- "piso com allowlist: virou copia do rotulo e o caso do Codex (K18) ficou desprotegido"
+piso_isolado "F15"
+
+echo ""
+echo "════════ F16 — sabotagem: piso sem o filtro desativada_em ════════"
+# Fórmula DESATIVADA voltaria a ser evidência de preço: o CSV 900 da linha morta
+# de K19 entraria no piso. Direção "conservadora" na aparência, errada no mérito
+# — piso alto demais barra venda legítima, e o dado nem é vivo.
+sabota_migration5 's/AND g3\.desativada_em IS NULL)/)/' || bad "F16 não aplicou a sabotagem"
+OUT_PISO="$(run_asserts_piso)"
+confere_falsificacao "F16" "$OUT_PISO" 1 "C23" -- "piso sem desativada_em: o CSV 900 da formula morta virou piso"
+piso_isolado "F16"
+
 echo ""
 echo "════════ R — restauração: migrations reais de volta ⇒ tudo verde ════════"
 restore_view
@@ -1279,6 +1536,11 @@ OUT="$(run_asserts)"
 case "$OUT" in
   *TODOS_OK*) ok "R restauração: C1–C20 verdes com a migration real re-aplicada" ;;
   *) bad "R restauração falhou: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-300)" ;;
+esac
+OUT_PISO="$(run_asserts_piso)"
+case "$OUT_PISO" in
+  *TODOS_OK*) ok "R restauração: C21–C31 (piso) verdes com a migration real re-aplicada" ;;
+  *) bad "R restauração do PISO falhou: $(printf '%s' "$OUT_PISO" | tr '\n' ' ' | cut -c1-300)" ;;
 esac
 
 echo ""

--- a/db/test-tint-gate-revalida.sh
+++ b/db/test-tint-gate-revalida.sh
@@ -43,14 +43,43 @@
 #   F6  sabotagem: ultimo_preco vira SECURITY DEFINER → G17 cai
 #   F7  sabotagem: sem o exclude anti-autovalidação → G24 cai
 #   F8  sabotagem: item sem cor ignorado sem classificar → G20 cai
+#   ── separação RÓTULO × PISO (20260726160000, follow-up do Codex no #1523) ──
+#   O gate lia UMA coluna (preco_csv_legado) para dois propósitos opostos: o
+#   RÓTULO da fonte 'tabela' (precisão de proveniência) e o PISO das fontes
+#   'manual'/legado (conservadorismo). Dar precisão ao rótulo ENCOLHIA o max e
+#   com ele o piso — ampliando a aceitação de preço baixo na fronteira do submit.
+#   G32 K30 (rótulo 60 × piso 90 × calc 102.5): manual 75 fica acima do rótulo e
+#       abaixo do piso ⇒ preco_obsoleto com esperado_minimo=90; manual 95 passa;
+#       e a fonte 'tabela' a 60 SEGUE passando (o piso não governa a escolha da
+#       vendedora — isso é o que separa as duas colunas)
+#   G33 K31 (sem geração '1'): rótulo NULL ⇒ piso NULL ⇒ v_floor = v_calc
+#       (102.5). Manual 80 bloqueia. Se o piso viesse 70, o NULL-preserving caiu
+#       e o gate AFROUXOU — em prod são 31.062 chaves (6,3% das com SL ativa)
+#   F10 sabotagem: v_floor volta a usar v_tab (reverte a separação) → G32 cai
+#   F11 sabotagem: piso sem o NULL-preserving (o spec ingênuo) → G33 cai
 #   R   restauração: migration real de volta ⇒ tudo verde
+#
+# ⚠️ 2026-07-21: este arquivo estava QUEBRADO na main — morria em "cannot drop
+# columns from view" ANTES do primeiro assert, desde o re-dump do snapshot no
+# #1509 (que passou a trazer a view pronta). A canônica levou o conserto no
+# #1523; aqui passou batido, e como db/test-*.sh não roda no CI nada acusou:
+# a prova do gate do submit ficou morta e silenciosa. Corrigido com o mesmo
+# DROP VIEW antes da cadeia. A cadeia da VIEW também passou a ser aplicada
+# INTEIRA (faltavam o fix semântico e a allowlist) — o gate lê a view, então
+# testá-lo contra uma versão antiga dela provava menos do que dizia.
 # Base estrutural: db/test-tint-canonica.sh. Pré-req: brew install postgresql@17 pgvector.
 set -uo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MIG_F2="$REPO_ROOT/supabase/migrations/20260718213000_tint_formula_canonica.sql"
 MIG_F2B="$REPO_ROOT/supabase/migrations/20260718233000_tint_canonica_preco_csv_legado.sql"
+# A cadeia da VIEW tem de vir INTEIRA: o gate lê v_tint_formula_canonica, e
+# desde a 20260726160000 lê a 14ª coluna (preco_piso_legado). plpgsql é
+# late-bound — sem a coluna, o gate CRIA normalmente e só explode ao EXECUTAR.
+MIG_F2C="$REPO_ROOT/supabase/migrations/20260722100002_tint_canonica_csv_legado_semantico.sql"
+MIG_F2D="$REPO_ROOT/supabase/migrations/20260724130000_tint_canonica_csv_legado_allowlist.sql"
 MIGRATION="$REPO_ROOT/supabase/migrations/20260722100001_tint_gate_revalida_submit.sql"
+MIG_PISO="$REPO_ROOT/supabase/migrations/20260726160000_tint_canonica_piso_legado.sql"
 PGVER=17
 PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
 PORT=5449
@@ -58,7 +87,7 @@ DATA="$(mktemp -d /tmp/pgtest-tintgate.XXXXXX)/data"
 export LC_ALL=C LANG=C
 
 [ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
-for f in "$MIG_F2" "$MIG_F2B" "$MIGRATION"; do
+for f in "$MIG_F2" "$MIG_F2B" "$MIG_F2C" "$MIG_F2D" "$MIGRATION" "$MIG_PISO"; do
   [ -f "$f" ] || { echo "migration ausente: $f"; exit 1; }
 done
 
@@ -101,13 +130,28 @@ rm -f "$RR"
 # falsificação F5 dá falso-verde (lição database.md — mordida em prod).
 P -q -c "ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;"
 
-echo "→ migrations Fase 2 + 2b + Fase 3 na ordem de prod…"
+echo "→ migrations Fase 2 + 2b + semântico + allowlist + Fase 3 + piso na ordem de prod…"
+# ⚠️ O snapshot JÁ TRAZ a view pronta desde o re-dump do #1509 (2026-07-21).
+# Sem este DROP, a Fase 2 (12 colunas) morre em "cannot drop columns from view"
+# e o harness inteiro para ANTES do primeiro assert — que é EXATAMENTE o estado
+# em que este arquivo estava na main até 2026-07-21: quebrado e silencioso,
+# porque db/test-*.sh não roda no CI. A canônica levou esse mesmo conserto no
+# #1523; aqui ele passou batido. O objetivo é provar a CADEIA desde o zero, não
+# o snapshot.
+P -q -c "DROP VIEW IF EXISTS public.v_tint_formula_canonica;" >/dev/null \
+  || { echo "FALHA: não removeu a view do snapshot antes da cadeia"; exit 1; }
 P -q -f "$MIG_F2"  >/dev/null || { echo "FALHA: migration Fase 2 não aplicou"; exit 1; }
 P -q -f "$MIG_F2B" >/dev/null || { echo "FALHA: migration Fase 2b não aplicou"; exit 1; }
+P -q -f "$MIG_F2C" >/dev/null || { echo "FALHA: migration fix semântico não aplicou"; exit 1; }
+P -q -f "$MIG_F2D" >/dev/null || { echo "FALHA: migration allowlist não aplicou"; exit 1; }
 P -q -f "$MIGRATION" >/dev/null || { echo "FALHA: migration Fase 3 (gate) não aplicou"; exit 1; }
+P -q -f "$MIG_PISO" >/dev/null || { echo "FALHA: migration piso legado não aplicou"; exit 1; }
 
+# A migration do piso recria a VIEW (14 colunas) E o gate — restaurar as duas na
+# ordem de prod, senão o gate volta lendo uma view que não tem mais a coluna.
 restore_gate() {
   P -q -f "$MIGRATION" >/dev/null || { echo "FALHA: restore_gate não re-aplicou a migration"; exit 1; }
+  P -q -f "$MIG_PISO"  >/dev/null || { echo "FALHA: restore_gate não re-aplicou o piso"; exit 1; }
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -167,13 +211,45 @@ INSERT INTO public.tint_formulas (id, account, cor_id, nome_cor, produto_id, bas
   ('f1000000-0000-0000-0000-00000000005a','oben','K1','AZUL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
   ('f1000000-0000-0000-0000-000000000019','oben','K1','AZUL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',150),
   ('f9000000-0000-0000-0000-00000000005a','oben','K9','BRANCO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
-  ('f0160000-0000-0000-0000-000000000019','oben','K16','TESTEMOTOR','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',300);
+  ('f0160000-0000-0000-0000-000000000019','oben','K16','TESTEMOTOR','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',300),
+  -- K30 PISOCODEX (separação rótulo×piso — o cenário do challenge Codex):
+  --   SL canônica válida × geração '1' CSV 60 × personalizada CSV 90.
+  --   RÓTULO (preco_csv_legado, allowlist) = 60 · PISO (preco_piso_legado) = 90.
+  --   calc = 102.5 ⇒ v_floor ANTES = LEAST(102.5,60) = 60; AGORA = 90.
+  --   Um manual de 75 fica ACIMA do rótulo e ABAIXO do piso: era aceito, agora não.
+  ('f0300000-0000-0000-0000-00000000005a','oben','K30','PISOCODEX','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f0300000-0000-0000-0000-000000000019','oben','K30','PISOCODEX','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',60),
+  ('f0300000-0000-0000-0000-0000000000e0','oben','K30','PISOCODEX','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1',NULL,'50000000-0000-0000-0000-00000000000a',90),
+  -- K31 PISONULL (o NULL-preserving na fronteira do submit):
+  --   SL canônica válida × personalizada CSV 70 × SEM geração '1' na chave.
+  --   RÓTULO = NULL ⇒ PISO = NULL ⇒ v_floor = v_calc = 102.5 (o mais alto).
+  --   O spec ingênuo ("max de todas") daria piso 70 e deixaria passar um manual
+  --   de 80 — afrouxando. Em prod essa é a população de 31.062 chaves.
+  ('f0310000-0000-0000-0000-00000000005a','oben','K31','PISONULL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f0310000-0000-0000-0000-0000000000e0','oben','K31','PISONULL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1',NULL,'50000000-0000-0000-0000-00000000000a',70),
+  -- K32 PISOZERO (achado P1 do challenge Codex xhigh 2026-07-21 — o furo que os
+  -- invariantes da VIEW não pegavam): SL canônica × geração '1' com CSV ZERO ×
+  -- personalizada CSV 90.
+  --   rótulo (preco_csv_legado) = 0  → NÃO é NULL, então I1 e I2 passam!
+  --   piso  (preco_piso_legado) = 90 → também não é NULL.
+  -- Mas no GATE o guard `> 0` reprova o rótulo: v_tab = NULL. Se v_piso fosse
+  -- montado sozinho, viraria 90 e o piso efetivo CAIRIA de 102.5 para 90 —
+  -- um manual de 95 passaria a ser aceito onde hoje bloqueia. Por isso a
+  -- elegibilidade de v_piso é ACOPLADA a v_tab.
+  ('f0320000-0000-0000-0000-00000000005a','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f0320000-0000-0000-0000-000000000019','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',0),
+  ('f0320000-0000-0000-0000-0000000000e0','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1',NULL,'50000000-0000-0000-0000-00000000000a',90);
 
 INSERT INTO public.tint_formula_itens (formula_id, corante_id, ordem, qtd_ml) VALUES
   ('f1000000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
   ('f1000000-0000-0000-0000-000000000019','c0000000-0000-0000-0000-000000000001',1,10),
   ('f9000000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
-  ('f0160000-0000-0000-0000-000000000019','c0000000-0000-0000-0000-000000000002',1, 5);
+  ('f0160000-0000-0000-0000-000000000019','c0000000-0000-0000-0000-000000000002',1, 5),
+  -- K30/K31: só a SL leva receita válida (rank 0) — a geração '1' e a
+  -- personalizada ficam rank 3, então a canônica é a SL e a allowlist dispara.
+  ('f0300000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
+  ('f0310000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
+  ('f0320000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10);
 
 INSERT INTO public.sales_orders (id, customer_user_id, created_by, account, status, omie_pedido_id, created_at, subtotal, total, items) VALUES
   ('a5000000-0000-0000-0000-00000000000a','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 111, now() - interval '10 days', 95, 95,
@@ -207,7 +283,10 @@ gq() { Pq -c "$1" | tail -1; }
 
 echo ""
 echo "════════ G0 — pré-condição do seed ════════"
-eq "G0a fórmulas semeadas" "$(gq 'SELECT count(*) FROM public.tint_formulas;')" "4"
+# 12 desde os seeds K30/K31/K32 (separação rótulo×piso, 2026-07-21): +3 de K30
+# (SL + geração '1' + personalizada), +2 de K31 (SL + personalizada) e +3 de K32
+# (SL + geração '1' com CSV ZERO + personalizada — o achado P1 do Codex).
+eq "G0a fórmulas semeadas" "$(gq 'SELECT count(*) FROM public.tint_formulas;')" "12"
 eq "G0b pedidos semeados"  "$(gq 'SELECT count(*) FROM public.sales_orders;')" "9"
 eq "G0c canônica de K1 é a SL" "$(gq "SELECT id::text FROM public.v_tint_formula_canonica WHERE cor_id='K1';")" "f1000000-0000-0000-0000-00000000005a"
 eq "G0d calc de K1 (ceil10 via float8) = 102.5" "$(gq "SELECT (ceil(((public.get_tint_price('f1000000-0000-0000-0000-00000000005a'))->>'precoFinal')::float8 * 10) / 10)::text;")" "102.5"
@@ -435,6 +514,71 @@ BEGIN
   b := r->'bloqueios'->0;
   IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'payload_invalido' THEN
     RAISE EXCEPTION 'G30b FALHOU: fórmula de OUTRA cor (K9 num item K1) deveria bloquear: %', r; END IF;
+
+  -- ══════════════════════════════════════════════════════════════════════════
+  -- G32/G33 — SEPARAÇÃO RÓTULO × PISO (migration 20260726160000).
+  -- Até aqui o gate lia UMA coluna para dois propósitos opostos. Estes asserts
+  -- exercitam a divergência na fronteira REAL do submit, não só na view.
+  -- ══════════════════════════════════════════════════════════════════════════
+
+  -- G32 o CASO DO CODEX: K30 tem rótulo 60 (allowlist) e piso 90 (conservador).
+  -- Um manual de 75 está ACIMA do rótulo e ABAIXO do piso — com a coluna única
+  -- ele PASSAVA, e dar precisão de proveniência ao rótulo tinha AMPLIADO a
+  -- aceitação de preço baixo.
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K30","valor_unitario":75,"tint_price_source":"manual"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G32a FALHOU: manual 75 (acima do rotulo 60, ABAIXO do piso 90) deveria dar preco_obsoleto: %', r; END IF;
+  IF (b->>'esperado_minimo')::float8 IS DISTINCT FROM 90::float8 THEN
+    RAISE EXCEPTION 'G32b FALHOU: o piso reportado deveria ser 90 (conservador, inclui a personalizada), veio % — se veio 60, o gate ainda le o ROTULO', b->>'esperado_minimo'; END IF;
+  -- e o que é legítimo segue passando (a mudança não pode virar fricção cega)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K30","valor_unitario":95,"tint_price_source":"manual"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G32c FALHOU: manual 95 >= piso 90 deveria passar: %', r; END IF;
+  -- a fonte 'tabela' segue validando contra o RÓTULO (60) — a escolha da
+  -- vendedora é sobre PROVENIÊNCIA; validá-la contra o piso barraria o legítimo
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K30","tint_formula_id":"f0300000-0000-0000-0000-00000000005a","valor_unitario":60,"tint_price_source":"tabela"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G32d FALHOU: fonte "tabela" a 60 (o rotulo) deveria passar — o piso conservador NAO governa a escolha da vendedora: %', r; END IF;
+
+  -- G33 NULL-PRESERVING na fronteira: K31 não tem geração '1', logo rótulo=NULL
+  -- ⇒ piso=NULL ⇒ v_floor = v_calc (102.5), o piso MAIS ALTO possível.
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K31","valor_unitario":80,"tint_price_source":"manual"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G33a FALHOU: sem geracao 1 provada o piso e o CALCULADO — manual 80 deveria bloquear: %', r; END IF;
+  IF (b->>'esperado_minimo')::float8 IS DISTINCT FROM 102.5::float8 THEN
+    RAISE EXCEPTION 'G33b FALHOU: piso deveria ser 102.5 (v_calc), veio % — se veio 70, o NULL-preserving caiu e o gate AFROUXOU em 31.062 chaves de prod', b->>'esperado_minimo'; END IF;
+
+  -- G34 (achado P1 do challenge Codex xhigh 2026-07-21) — O FURO QUE OS
+  -- INVARIANTES DA VIEW NÃO PEGAVAM. K32: rótulo = 0 (não é NULL!) e piso = 90.
+  -- I1 passa (nenhum NULL) e I2 passa (90 >= 0) — os dois invariantes provados
+  -- ficam VERDES. Mas o guard `> 0` do gate reprova o rótulo (v_tab = NULL), e
+  -- se v_piso fosse montado sozinho ele viraria 90: o piso efetivo cairia de
+  -- 102.5 para 90 e o manual 95 seria ACEITO. Este assert exige o contrário.
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K32","valor_unitario":95,"tint_price_source":"manual"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G34a FALHOU: com rotulo=0 (reprovado pelo guard >0) o piso e o CALCULADO — manual 95 deveria bloquear: %', r; END IF;
+  IF (b->>'esperado_minimo')::float8 IS DISTINCT FROM 102.5::float8 THEN
+    RAISE EXCEPTION 'G34b FALHOU: piso deveria ser 102.5 (v_calc), veio % — se veio 90, a elegibilidade de v_piso NAO esta acoplada a v_tab e o gate AFROUXOU por um caminho que I1/I2 nao veem', b->>'esperado_minimo'; END IF;
+
+  -- G35 (Codex, achado 6a) AMBOS os ramos leem o piso. A falsificação F10
+  -- substitui as DUAS ocorrências de uma vez, então uma regressão em SÓ UM ramo
+  -- (o legado voltar a v_tab, por exemplo) passaria verde. Este assert
+  -- estrutural discrimina — é o que dá dente contra a mutação de um ramo só.
+  IF (SELECT (length(pg_get_functiondef(p.oid))
+              - length(replace(pg_get_functiondef(p.oid), 'COALESCE(v_piso, v_calc)', '')))
+             / length('COALESCE(v_piso, v_calc)')
+        FROM pg_proc p JOIN pg_namespace nsp ON nsp.oid = p.pronamespace
+       WHERE nsp.nspname = 'public' AND p.proname = 'tint_gate_revalida') <> 2 THEN
+    RAISE EXCEPTION 'G35 FALHOU: v_floor nao usa o piso nos 2 ramos (manual + legado) — um deles regrediu para v_tab';
+  END IF;
 
   RAISE NOTICE 'CENTRAL_OK';
 END $$;
@@ -695,6 +839,94 @@ if [ "$OUT" = "true" ]; then
 else
   bad "F9 NÃO provou o dente: gate sabotado ainda bloqueou fonte sem formula_id (veio ok=$OUT)"
 fi
+restore_gate
+
+echo ""
+echo "════════ F10 — sabotagem: o PISO volta a ler o RÓTULO (reverte a separação) ════════"
+# A regressão EXATA que esta migration existe para impedir: as duas linhas do
+# v_floor voltam a usar v_tab (preco_csv_legado, allowlist) em vez de v_piso.
+# É o estado da main antes de 2026-07-21 — e o que o challenge do Codex apontou:
+# encolher o max para dar precisão de proveniência ao rótulo AFROUXAVA o piso.
+# Se G32/G33 seguissem verdes aqui, eles não teriam dente nenhum.
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f10.XXXXXX.sql")"
+sed 's/COALESCE(v_piso, v_calc)/COALESCE(v_tab, v_calc)/' "$MIG_PISO" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(run_central)"
+case "$OUT" in
+  *"G32 FALHOU"*|*"G32a FALHOU"*|*"G32b FALHOU"*)
+    ok "F10 pegou a sabotagem: com o piso lendo o rótulo, o manual 75 (abaixo do piso 90) voltou a passar" ;;
+  *CENTRAL_OK*)
+    bad "F10 NÃO pegou: bloco central VERDE com o piso revertido ao rótulo — G32/G33 estão sem dente" ;;
+  *) bad "F10 caiu de forma inesperada: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
+restore_gate
+
+echo ""
+echo "════════ F11 — DEFESA EM PROFUNDIDADE: view sabotada, gate segue correto ════════"
+# ⚠️ Esta NÃO é uma falsificação — é o oposto, e a distinção importa.
+# Escrita primeiro como falsificação ("sem o NULL-preserving da view, G33 cai"),
+# ela FALHOU em pegar depois da correção P1 do Codex — e a razão é boa: ao
+# acoplar a elegibilidade de v_piso a v_tab, o GATE passou a se defender sozinho.
+# Com a CASE da view sabotada (piso = max de todas, incondicional), K31 ganha
+# piso 70; mas v_tab é NULL ali, logo v_piso continua NULL e o piso efetivo
+# segue sendo v_calc. O comportamento do gate NÃO muda.
+# Repintar isso de verde chamando de falsificação seria mover a trave. A
+# falsificação do spec ingênuo continua existindo e VERMELHA, no harness certo:
+# db/test-tint-canonica.sh, F14 → derruba {C26,C28}. Aqui a afirmação é outra,
+# e verdadeira: as duas camadas são independentes, e uma cobre a queda da outra.
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f11.XXXXXX.sql")"
+sed 's/))) IS NULL/))) IS NULL AND false/' "$MIG_PISO" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(run_central)"
+case "$OUT" in
+  *CENTRAL_OK*)
+    ok "F11 defesa em profundidade: com o NULL-preserving da view QUEBRADO, o gate segue correto (o acoplamento v_piso→v_tab sustenta sozinho)" ;;
+  *) bad "F11 o gate NÃO se sustentou sozinho com a view sabotada — a segunda camada não existe: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-220)" ;;
+esac
+restore_gate
+
+echo ""
+echo "════════ F12 — sabotagem: v_piso SEM o acoplamento a v_tab (achado P1 do Codex) ════════"
+# Remove só o `v_tab IS NOT NULL AND` da elegibilidade do piso. É a versão que
+# eu tinha escrito ANTES do challenge: os invariantes I1/I2 da view continuam
+# VERDES (K32 tem csv=0, que não é NULL), mas o guard `> 0` do gate derruba
+# v_tab e deixa v_piso=90 de pé — o piso efetivo cai de 102.5 para 90 e o
+# manual 95 passa. Falha ABERTA por um caminho que os invariantes não enxergam.
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f12.XXXXXX.sql")"
+sed 's/CASE WHEN v_tab IS NOT NULL AND v_can_piso IS NOT NULL/CASE WHEN v_can_piso IS NOT NULL/' "$MIG_PISO" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(run_central)"
+case "$OUT" in
+  *"G34 FALHOU"*|*"G34a FALHOU"*|*"G34b FALHOU"*)
+    ok "F12 pegou a sabotagem: com csv=0 o piso caiu de 102.5 para 90 e o manual 95 passou" ;;
+  *CENTRAL_OK*)
+    bad "F12 NÃO pegou: bloco central VERDE sem o acoplamento — G34 está sem dente" ;;
+  *) bad "F12 caiu de forma inesperada: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
+restore_gate
+
+echo ""
+echo "════════ F13 — sabotagem: SÓ o ramo LEGADO volta a v_tab (mutação de um ramo) ════════"
+# A F10 troca as DUAS ocorrências de uma vez, então não discrimina os ramos.
+# Aqui o sed encontra o comentário do ramo legado e substitui só a linha
+# SEGUINTE (`n;s///`) — o ramo 'manual' fica intacto. Sem o G35 estrutural,
+# esta sabotagem passaria VERDE (nenhum assert comportamental cobre o legado
+# com piso divergente hoje).
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f13.XXXXXX.sql")"
+sed '/mesmo piso conservador da fonte/{n;s/COALESCE(v_piso, v_calc)/COALESCE(v_tab, v_calc)/;}' "$MIG_PISO" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(run_central)"
+case "$OUT" in
+  *"G35 FALHOU"*)
+    ok "F13 pegou a sabotagem: o ramo legado regrediu sozinho e o assert estrutural discriminou" ;;
+  *CENTRAL_OK*)
+    bad "F13 NÃO pegou: mutar SÓ o ramo legado ficou verde — G35 está sem dente" ;;
+  *) bad "F13 caiu de forma inesperada: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
 restore_gate
 
 echo ""

--- a/db/test-tint-gate-revalida.sh
+++ b/db/test-tint-gate-revalida.sh
@@ -238,7 +238,16 @@ INSERT INTO public.tint_formulas (id, account, cor_id, nome_cor, produto_id, bas
   -- elegibilidade de v_piso é ACOPLADA a v_tab.
   ('f0320000-0000-0000-0000-00000000005a','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
   ('f0320000-0000-0000-0000-000000000019','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',0),
-  ('f0320000-0000-0000-0000-0000000000e0','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1',NULL,'50000000-0000-0000-0000-00000000000a',90);
+  ('f0320000-0000-0000-0000-0000000000e0','oben','K32','PISOZERO','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1',NULL,'50000000-0000-0000-0000-00000000000a',90),
+  -- K33 PISOCEIL (Codex, achado 4): piso com CENTAVO, não inteiro. Todos os
+  -- outros seeds usam inteiros, então o ceil10 do piso nunca era exercitado —
+  -- um piso que ignorasse o arredondamento passaria verde em tudo.
+  --   rótulo = 60 → v_tab = 60 · piso bruto = 90.01 → v_piso = ceil(900.1)/10 = 90.1
+  -- O piso EFETIVO é 90.1, não 90.01: arredondar um piso para CIMA é a direção
+  -- conservadora, e a diferença de R$0,09 é exatamente o que o assert fixa.
+  ('f0330000-0000-0000-0000-00000000005a','oben','K33','PISOCEIL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','5c000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',NULL),
+  ('f0330000-0000-0000-0000-000000000019','oben','K33','PISOCEIL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1','0d000000-0000-0000-0000-000000000001','50000000-0000-0000-0000-00000000000a',60),
+  ('f0330000-0000-0000-0000-0000000000e0','oben','K33','PISOCEIL','a0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-0000000000e1',NULL,'50000000-0000-0000-0000-00000000000a',90.01);
 
 INSERT INTO public.tint_formula_itens (formula_id, corante_id, ordem, qtd_ml) VALUES
   ('f1000000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
@@ -249,7 +258,8 @@ INSERT INTO public.tint_formula_itens (formula_id, corante_id, ordem, qtd_ml) VA
   -- personalizada ficam rank 3, então a canônica é a SL e a allowlist dispara.
   ('f0300000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
   ('f0310000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
-  ('f0320000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10);
+  ('f0320000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10),
+  ('f0330000-0000-0000-0000-00000000005a','c0000000-0000-0000-0000-000000000001',1,10);
 
 INSERT INTO public.sales_orders (id, customer_user_id, created_by, account, status, omie_pedido_id, created_at, subtotal, total, items) VALUES
   ('a5000000-0000-0000-0000-00000000000a','33333333-3333-3333-3333-333333333333','11111111-1111-1111-1111-111111111111','oben','faturado', 111, now() - interval '10 days', 95, 95,
@@ -283,10 +293,11 @@ gq() { Pq -c "$1" | tail -1; }
 
 echo ""
 echo "════════ G0 — pré-condição do seed ════════"
-# 12 desde os seeds K30/K31/K32 (separação rótulo×piso, 2026-07-21): +3 de K30
-# (SL + geração '1' + personalizada), +2 de K31 (SL + personalizada) e +3 de K32
-# (SL + geração '1' com CSV ZERO + personalizada — o achado P1 do Codex).
-eq "G0a fórmulas semeadas" "$(gq 'SELECT count(*) FROM public.tint_formulas;')" "12"
+# 15 desde os seeds K30-K33 (separação rótulo×piso, 2026-07-21): +3 de K30
+# (SL + geração '1' + personalizada), +2 de K31 (SL + personalizada), +3 de K32
+# (SL + geração '1' com CSV ZERO + personalizada — achado P1 do Codex) e +3 de
+# K33 (piso com centavo, exercita o ceil10 — achado 4 do Codex).
+eq "G0a fórmulas semeadas" "$(gq 'SELECT count(*) FROM public.tint_formulas;')" "15"
 eq "G0b pedidos semeados"  "$(gq 'SELECT count(*) FROM public.sales_orders;')" "9"
 eq "G0c canônica de K1 é a SL" "$(gq "SELECT id::text FROM public.v_tint_formula_canonica WHERE cor_id='K1';")" "f1000000-0000-0000-0000-00000000005a"
 eq "G0d calc de K1 (ceil10 via float8) = 102.5" "$(gq "SELECT (ceil(((public.get_tint_price('f1000000-0000-0000-0000-00000000005a'))->>'precoFinal')::float8 * 10) / 10)::text;")" "102.5"
@@ -579,6 +590,23 @@ BEGIN
        WHERE nsp.nspname = 'public' AND p.proname = 'tint_gate_revalida') <> 2 THEN
     RAISE EXCEPTION 'G35 FALHOU: v_floor nao usa o piso nos 2 ramos (manual + legado) — um deles regrediu para v_tab';
   END IF;
+
+  -- G36 (Codex, achado 4) ceil10 SOBRE O PISO, com centavo. K33 tem piso bruto
+  -- 90.01; o piso EFETIVO é ceil(90.01*10)/10 = 90.1. Todos os outros seeds usam
+  -- inteiros, então este é o único que distingue "aplicou o ceil10 no piso" de
+  -- "usou o valor bruto" — sem ele, um piso sem arredondamento passava verde.
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K33","valor_unitario":90.05,"tint_price_source":"manual"}]');
+  b := r->'bloqueios'->0;
+  IF (r->>'ok')::boolean IS DISTINCT FROM false OR b->>'motivo' IS DISTINCT FROM 'preco_obsoleto' THEN
+    RAISE EXCEPTION 'G36a FALHOU: manual 90.05 < piso 90.1 (ceil10 de 90.01) deveria bloquear: %', r; END IF;
+  IF (b->>'esperado_minimo')::float8 IS DISTINCT FROM 90.1::float8 THEN
+    RAISE EXCEPTION 'G36b FALHOU: piso deveria ser 90.1 (ceil10), veio % — se veio 90.01, o arredondamento NAO foi aplicado no caminho do piso', b->>'esperado_minimo'; END IF;
+  -- e exatamente no piso passa (a tolerância de centavo não vira fricção)
+  r := public.tint_gate_revalida('oben', cliente, so_empty, 'criacao',
+    '[{"omie_codigo_produto":900001,"tint_cor_id":"K33","valor_unitario":90.1,"tint_price_source":"manual"}]');
+  IF (r->>'ok')::boolean IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'G36c FALHOU: manual 90.1 (exatamente o piso) deveria passar: %', r; END IF;
 
   RAISE NOTICE 'CENTRAL_OK';
 END $$;
@@ -926,6 +954,25 @@ case "$OUT" in
   *CENTRAL_OK*)
     bad "F13 NÃO pegou: mutar SÓ o ramo legado ficou verde — G35 está sem dente" ;;
   *) bad "F13 caiu de forma inesperada: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
+restore_gate
+
+echo ""
+echo "════════ F14 — sabotagem: piso SEM o ceil10 (usa o valor bruto) ════════"
+# O contador de ✅ é do nível bash e o G36 vive DENTRO do run_central — então o
+# número não prova que ele rodou. Esta sabotagem prova. Só K33 (piso 90.01)
+# distingue: para pisos inteiros ceil10(x)=x e nada muda.
+TMP_SAB="$(mktemp "${TMPDIR:-/tmp}/sab-f14.XXXXXX.sql")"
+sed 's|ceil((v_can_piso)::float8 \* 10) / 10|(v_can_piso)::float8|' "$MIG_PISO" > "$TMP_SAB"
+P -q -f "$TMP_SAB" >/dev/null
+rm -f "$TMP_SAB"
+OUT="$(run_central)"
+case "$OUT" in
+  *"G36 FALHOU"*|*"G36a FALHOU"*|*"G36b FALHOU"*)
+    ok "F14 pegou a sabotagem: sem o ceil10 o piso ficou 90.01 e o manual 90.05 passou" ;;
+  *CENTRAL_OK*)
+    bad "F14 NÃO pegou: bloco central VERDE sem o ceil10 do piso — G36 está sem dente (ou nem roda)" ;;
+  *) bad "F14 caiu de forma inesperada: $(printf '%s' "$OUT" | tr '\n' ' ' | cut -c1-200)" ;;
 esac
 restore_gate
 

--- a/db/valida-tint-piso-legado.sql
+++ b/db/valida-tint-piso-legado.sql
@@ -1,0 +1,73 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY da 20260726160000_tint_canonica_piso_legado.sql
+-- Read-only. Cole no SQL Editor do Lovable DEPOIS de rodar a migration.
+-- (O Claude também roda isto sozinho via psql-ro — este arquivo é pra você
+--  conferir por conta própria quando quiser.)
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ── 1. ESTRUTURA: a migration pegou? ───────────────────────────────────────
+WITH estrutura AS (
+  SELECT
+    (SELECT string_agg(a.attname, ',' ORDER BY a.attnum)
+       FROM pg_attribute a
+      WHERE a.attrelid = 'public.v_tint_formula_canonica'::regclass
+        AND a.attnum > 0 AND NOT a.attisdropped)                       AS cols,
+    (SELECT c.reloptions @> ARRAY['security_invoker=on']
+       FROM pg_class c
+      WHERE c.oid = 'public.v_tint_formula_canonica'::regclass)        AS invoker,
+    (SELECT (length(pg_get_functiondef(p.oid))
+             - length(replace(pg_get_functiondef(p.oid), 'COALESCE(v_piso, v_calc)', '')))
+            / length('COALESCE(v_piso, v_calc)')
+       FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+      WHERE n.nspname = 'public' AND p.proname = 'tint_gate_revalida') AS n_pisos
+)
+SELECT
+  CASE WHEN cols = 'id,account,sku_id,cor_id,nome_cor,preco_final_sayersystem,'
+                || 'subcolecao_id,personalizada,updated_at,is_sl,tem_receita,'
+                || 'receita_valida,preco_csv_legado,preco_piso_legado'
+       THEN '✅ 14 colunas na ordem certa (a nova só ACRESCENTOU no fim)'
+       ELSE '❌ ordem/nomes ERRADOS: ' || COALESCE(cols, '(view ausente)')
+  END AS c1_shape,
+  CASE WHEN invoker
+       THEN '✅ security_invoker=on preservado'
+       ELSE '❌ PERDEU security_invoker — a view passou a ler como OWNER e bypassa RLS. NÃO deixe assim'
+  END AS c2_rls,
+  CASE WHEN n_pisos = 2
+       THEN '✅ o gate lê o piso nas 2 fontes (manual + legado)'
+       ELSE '❌ gate não usa preco_piso_legado (ocorrências=' || COALESCE(n_pisos::text, '?') || ', esperado 2)'
+  END AS c3_gate
+FROM estrutura;
+
+-- ── 2. INVARIANTES + DELTA no dado real ────────────────────────────────────
+-- Restrito às ÚNICAS chaves onde a mudança poderia ter efeito hoje (as 756
+-- personalizadas ativas com CSV). A view inteira custa caro (960k fórmulas) e
+-- estoura o statement_timeout; este recorte roda em ~2s.
+WITH chaves AS (
+  SELECT DISTINCT f.account, f.sku_id, f.cor_id
+    FROM public.tint_formulas f
+   WHERE f.desativada_em IS NULL
+     AND f.subcolecao_id IS NULL
+     AND f.preco_final_sayersystem IS NOT NULL
+), v AS (
+  SELECT c.preco_csv_legado AS csv, c.preco_piso_legado AS piso
+    FROM chaves k
+    JOIN public.v_tint_formula_canonica c
+      ON c.account = k.account AND c.sku_id = k.sku_id AND c.cor_id = k.cor_id
+)
+SELECT
+  count(*) AS chaves_conferidas,
+  CASE WHEN count(*) FILTER (WHERE (csv IS NULL) <> (piso IS NULL)) = 0
+       THEN '✅ I1 ok: (csv NULL) ⟺ (piso NULL)'
+       ELSE '❌ I1 QUEBRADO em ' || count(*) FILTER (WHERE (csv IS NULL) <> (piso IS NULL))
+            || ' linha(s) — as 2 cópias da subquery do csv driftaram'
+  END AS i1,
+  CASE WHEN count(*) FILTER (WHERE csv IS NOT NULL AND piso IS NOT NULL AND piso < csv) = 0
+       THEN '✅ I2 ok: piso >= csv'
+       ELSE '❌ I2 QUEBRADO — o piso deixou de ser conservador'
+  END AS i2,
+  CASE WHEN count(*) FILTER (WHERE csv IS DISTINCT FROM piso) = 0
+       THEN '✅ delta 0: nenhuma chave mudou de comportamento (é o esperado hoje)'
+       ELSE '⚠️ ' || count(*) FILTER (WHERE csv IS DISTINCT FROM piso)
+            || ' chave(s) com piso ≠ rótulo — passou a existir caso real, me avise'
+  END AS delta
+FROM v;

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,16 +21,16 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **423** custom migrations totais
-- **1487** objetos esperados (criados por estas migrations)
+- **427** custom migrations totais
+- **1493** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 426
+  - `function`: 431
   - `rls_policy`: 380
   - `index`: 224
   - `cron_job`: 157
   - `table`: 147
   - `trigger`: 79
-  - `view`: 70
+  - `view`: 71
   - `enum_value`: 4
 
 ## Inventário por migration
@@ -3534,9 +3534,22 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.registrar_aplicacao_regua` | — |
 | `rls_policy` | `public.regua_preco_log_select_custo` | `regua_preco_log` |
 
+### `20260723150000_farmer_margem_server_side.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_customer_margin_summary` | — |
+| `function` | `public.apply_score_updates` | — |
+
 ### `20260723160000_authz_fu4e_is_not_true_escritas.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260723160000_farmer_margem_correcoes_review.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.apply_score_updates` | — |
 
 ### `20260724120000_authz_sales_orders_split_escrita_fu4.sql`
 
@@ -3589,6 +3602,19 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.vendas_sync_semear_janela` | — |
+
+### `20260726150000_margem_cliente_helper_compartilhado.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `private.margem_cliente_agregada` | — |
+
+### `20260726160000_tint_canonica_piso_legado.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tint_gate_revalida` | — |
+| `view` | `public.v_tint_formula_canonica` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 423
+-- Total de custom migrations: 427
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -457,14 +457,18 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260723140000', 'authz_custo_fu4f_fase1', '20260723140000_authz_custo_fu4f_fase1.sql'),
   ('20260723140000', 'authz_pedido_compra_item_cap_compras', '20260723140000_authz_pedido_compra_item_cap_compras.sql'),
   ('20260723150000', 'authz_custo_fu4f_fase2_regua', '20260723150000_authz_custo_fu4f_fase2_regua.sql'),
+  ('20260723150000', 'farmer_margem_server_side', '20260723150000_farmer_margem_server_side.sql'),
   ('20260723160000', 'authz_fu4e_is_not_true_escritas', '20260723160000_authz_fu4e_is_not_true_escritas.sql'),
+  ('20260723160000', 'farmer_margem_correcoes_review', '20260723160000_farmer_margem_correcoes_review.sql'),
   ('20260724120000', 'authz_sales_orders_split_escrita_fu4', '20260724120000_authz_sales_orders_split_escrita_fu4.sql'),
   ('20260724130000', 'authz_custo_fu4f_fase3_recommend', '20260724130000_authz_custo_fu4f_fase3_recommend.sql'),
   ('20260724130000', 'tint_canonica_csv_legado_allowlist', '20260724130000_tint_canonica_csv_legado_allowlist.sql'),
   ('20260726120000', 'tint_promote_error_details_completo', '20260726120000_tint_promote_error_details_completo.sql'),
   ('20260726120001', 'cron_tactical_plans_batch_nightly', '20260726120001_cron_tactical_plans_batch_nightly.sql'),
   ('20260726130000', 'vendas_sync_semear_janela', '20260726130000_vendas_sync_semear_janela.sql'),
-  ('20260726140000', 'vendas_sync_semear_janela_v2', '20260726140000_vendas_sync_semear_janela_v2.sql')
+  ('20260726140000', 'vendas_sync_semear_janela_v2', '20260726140000_vendas_sync_semear_janela_v2.sql'),
+  ('20260726150000', 'margem_cliente_helper_compartilhado', '20260726150000_margem_cliente_helper_compartilhado.sql'),
+  ('20260726160000', 'tint_canonica_piso_legado', '20260726160000_tint_canonica_piso_legado.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1924,6 +1928,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('authz_custo_fu4f_fase2_regua', 'function', 'public', 'registrar_exibicao_regua', ''),
   ('authz_custo_fu4f_fase2_regua', 'function', 'public', 'registrar_aplicacao_regua', ''),
   ('authz_custo_fu4f_fase2_regua', 'rls_policy', 'public', 'regua_preco_log_select_custo', 'regua_preco_log'),
+  ('farmer_margem_server_side', 'function', 'public', 'get_customer_margin_summary', ''),
+  ('farmer_margem_server_side', 'function', 'public', 'apply_score_updates', ''),
+  ('farmer_margem_correcoes_review', 'function', 'public', 'apply_score_updates', ''),
   ('authz_sales_orders_split_escrita_fu4', 'function', 'private', 'cap_pedido_escrever', ''),
   ('authz_sales_orders_split_escrita_fu4', 'rls_policy', 'public', 'sales_orders_select_staff', 'sales_orders'),
   ('authz_sales_orders_split_escrita_fu4', 'rls_policy', 'public', 'sales_orders_select_customer', 'sales_orders'),
@@ -1940,7 +1947,10 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
   ('cron_tactical_plans_batch_nightly', 'cron_job', 'cron', 'tactical-plans-batch-nightly', ''),
   ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', ''),
-  ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', '')
+  ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', ''),
+  ('margem_cliente_helper_compartilhado', 'function', 'private', 'margem_cliente_agregada', ''),
+  ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
+  ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3448,6 +3458,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('authz_custo_fu4f_fase2_regua', 'function', 'public', 'registrar_exibicao_regua', ''),
   ('authz_custo_fu4f_fase2_regua', 'function', 'public', 'registrar_aplicacao_regua', ''),
   ('authz_custo_fu4f_fase2_regua', 'rls_policy', 'public', 'regua_preco_log_select_custo', 'regua_preco_log'),
+  ('farmer_margem_server_side', 'function', 'public', 'get_customer_margin_summary', ''),
+  ('farmer_margem_server_side', 'function', 'public', 'apply_score_updates', ''),
+  ('farmer_margem_correcoes_review', 'function', 'public', 'apply_score_updates', ''),
   ('authz_sales_orders_split_escrita_fu4', 'function', 'private', 'cap_pedido_escrever', ''),
   ('authz_sales_orders_split_escrita_fu4', 'rls_policy', 'public', 'sales_orders_select_staff', 'sales_orders'),
   ('authz_sales_orders_split_escrita_fu4', 'rls_policy', 'public', 'sales_orders_select_customer', 'sales_orders'),
@@ -3464,7 +3477,10 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tint_promote_error_details_completo', 'function', 'public', 'tint_promote_sync_run', ''),
   ('cron_tactical_plans_batch_nightly', 'cron_job', 'cron', 'tactical-plans-batch-nightly', ''),
   ('vendas_sync_semear_janela', 'function', 'public', 'vendas_sync_semear_janela', ''),
-  ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', '')
+  ('vendas_sync_semear_janela_v2', 'function', 'public', 'vendas_sync_semear_janela', ''),
+  ('margem_cliente_helper_compartilhado', 'function', 'private', 'margem_cliente_agregada', ''),
+  ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
+  ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260726160000_tint_canonica_piso_legado.sql
+++ b/supabase/migrations/20260726160000_tint_canonica_piso_legado.sql
@@ -1,0 +1,705 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Tintométrico — SEPARA o RÓTULO do PISO: `preco_piso_legado` (14ª coluna)
+-- (follow-up do challenge Codex xhigh no #1523, achado "(c)/(d) NULL e gate";
+-- decisão do founder 2026-07-21, com o spec CORRIGIDO pela medição abaixo).
+--
+-- O PROBLEMA: `preco_csv_legado` servia DOIS consumidores com necessidades
+-- OPOSTAS.
+--   1. O RÓTULO do balcão ("Tabela (versão anterior)") quer PRECISÃO DE
+--      PROVENIÊNCIA — só a geração congelada '1' pode alimentá-lo. Foi por isso
+--      que o #1505 trocou blocklist por allowlist.
+--   2. O PISO do gate de submit (`tint_gate_revalida`, 20260722100001) quer
+--      CONSERVADORISMO: `v_floor := LEAST(v_calc, COALESCE(v_tab, v_calc))`.
+--      Encolher o conjunto do max() REDUZ v_tab, o que REDUZ o piso — a
+--      allowlist podia AMPLIAR a aceitação de preço baixo, o oposto do que se
+--      quer numa fronteira de submit.
+--   Cenário do Codex: calc 500, geração '1' = 300, personalizada = 400.
+--     blocklist → v_tab=400, piso=400 ⇒ manual 350 BLOQUEADO.
+--     allowlist → v_tab=300, piso=300 ⇒ manual 350 PASSA.
+--
+-- ⚠️ O SPEC INGÊNUO ("max de TODAS as ativas, sem allowlist") ESTÁ ERRADO —
+-- ele inverte a direção numa sub-população REAL. Como o piso é
+-- `LEAST(v_calc, COALESCE(v_tab, v_calc))`, **v_tab NULL produz o piso MAIS
+-- ALTO possível** (= v_calc): qualquer número abaixo de calc só faz o piso
+-- CAIR. Então trocar NULL por "max de todas" AFROUXA nas chaves onde a
+-- allowlist não acha geração '1'.
+--   Medido em prod (psql-ro 2026-07-21): das 495.057 chaves com SL ativa,
+--   **31.062 (6,3%) NÃO têm geração '1' ativa** — nelas `preco_csv_legado` é
+--   NULL hoje e o piso é v_calc. O spec ingênuo derrubaria o piso dessas 31.062
+--   para o CSV de qualquer linha ativa. As outras 463.995 (93,7%) são o caso do
+--   Codex, onde o spec ingênuo de fato APERTA. Ou seja: certo em 94%, fail-OPEN
+--   em 6% — e o fail-open é exatamente a direção que este exercício existe para
+--   impedir.
+--
+-- REGRA (NULL-preserving — duas perguntas INDEPENDENTES):
+--   (a) PODE descer abaixo de calc?  → decidido pela PROVENIÊNCIA:
+--       só se `preco_csv_legado` existir (há "versão anterior" provada).
+--   (b) Até ONDE pode descer?        → decidido pelo CONSERVADORISMO:
+--       até o max de TODAS as linhas ATIVAS da chave (nunca menos).
+--   ⇒ preco_piso_legado = NULL quando preco_csv_legado é NULL;
+--     senão, max(preco_final_sayersystem) de TODAS as ativas da chave.
+--
+-- INVARIANTES DA VIEW (sobre os valores CRUS; provados no harness e
+-- re-conferíveis em prod):
+--   I1. (preco_csv_legado IS NULL) ⟺ (preco_piso_legado IS NULL)
+--   I2. preco_piso_legado >= preco_csv_legado  (o max de um SUPERconjunto)
+--
+-- ⚠️ I1+I2 **NÃO BASTAM** para garantir "o piso novo é sempre >= o de hoje" —
+-- e afirmar isso foi o erro que o challenge Codex xhigh derrubou (2026-07-21).
+-- O gate normaliza com um guard `> 0` DEPOIS de ler as colunas, criando uma
+-- SEGUNDA forma de "ausente" que a view não conhece:
+--     csv = 0 (≠ NULL) · piso = 90 · calc = 102.5
+--     ⇒ I1 passa (nenhum é NULL) e I2 passa (90 >= 0) — os dois VERDES —
+--       mas v_tab vira NULL e v_piso vira 90, e o piso EFETIVO cai de 102.5
+--       para 90: um manual de 95 passa a ser aceito onde hoje bloqueia.
+-- Por isso a elegibilidade de v_piso no gate é ACOPLADA à de v_tab (ver §2).
+-- O invariante que de fato sustenta a alegação é o EFETIVO, no gate:
+--   E1. v_tab IS NULL ⇒ v_piso IS NULL
+--   E2. ambos presentes ⇒ v_piso >= v_tab
+--   ⇒ v_floor novo >= v_floor de hoje, SEMPRE.
+-- Provados por G34 (comportamento) e G35 (os 2 ramos) em
+-- db/test-tint-gate-revalida.sh, com F12/F13 falsificando cada um.
+--
+-- DELTA CONTRA A PROD HOJE: **0 linhas** (psql-ro 2026-07-21). Nenhuma linha SL
+-- ativa carrega CSV (0 de 495.057) e as 756 personalizadas ativas com CSV vivem
+-- em 756 chaves que não têm NEM SL NEM geração '1' ativa — logo a canônica
+-- delas não é SL, a allowlist não dispara, e csv já é igual ao piso. É
+-- blindagem semântica pura: muda o que ACONTECERIA, não o que acontece.
+--
+-- O RÓTULO NÃO MUDA: `preco_csv_legado` segue com a allowlist e continua sendo
+-- o que a fonte 'tabela' valida — a escolha da vendedora é sobre PROVENIÊNCIA.
+-- Só o PISO (fontes 'manual' e legado/ausente) passa a usar a coluna nova.
+--
+-- REPLACE: ordem das 13 colunas PRESERVADA (a 14ª só ACRESCENTA no fim) e
+-- WITH (security_invoker = on) REPETIDO — omitir RESETA a opção e a view passa
+-- a ler como OWNER, bypassando RLS (armadilha #1375: falha ABERTA, muda
+-- autorização e não comportamento, e o CI não vê).
+-- Prova: db/test-tint-canonica.sh (piso) + db/test-tint-gate-revalida.sh (gate).
+-- ═══════════════════════════════════════════════════════════════════════════
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 1. A view: 13 colunas verbatim da 20260724130000 + a 14ª (piso).
+--    ⚠️ A subquery do `preco_csv_legado` aparece DUAS vezes (como coluna 13 e
+--    como teste de NULL da 14ª). É duplicação deliberada: manter a coluna 13
+--    intocada byte a byte é o que torna este REPLACE auditável contra a
+--    migration anterior. O risco de drift entre as duas cópias é coberto pelo
+--    invariante I1, provado no harness E re-conferível em prod pela query de
+--    validação pós-apply (uma cópia divergente quebra I1 imediatamente).
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE VIEW public.v_tint_formula_canonica
+WITH (security_invoker = on)
+AS
+SELECT
+  f.id,
+  f.account,
+  f.sku_id,
+  f.cor_id,
+  f.nome_cor,
+  f.preco_final_sayersystem,
+  f.subcolecao_id,
+  f.personalizada,
+  f.updated_at,
+  rf.is_sl,
+  rf.tem_receita,
+  rf.receita_valida,
+  -- 13ª — RÓTULO ("Tabela (versão anterior)"): allowlist, VERBATIM da
+  -- 20260724130000. Precisão de proveniência: canônica SL → só a geração
+  -- congelada '1'; canônica não-SL → max de todas as ativas.
+  (SELECT max(g2.preco_final_sayersystem)
+     FROM public.tint_formulas g2
+    WHERE g2.account = f.account
+      AND g2.sku_id  = f.sku_id
+      AND g2.cor_id  = f.cor_id
+      AND g2.desativada_em IS NULL
+      AND (NOT rf.is_sl
+           OR EXISTS (SELECT 1 FROM public.tint_subcolecoes s2
+                      WHERE s2.id = g2.subcolecao_id
+                        AND s2.account = g2.account
+                        AND s2.id_subcolecao_sayersystem = '1'))) AS preco_csv_legado,
+  -- 14ª — PISO do gate de submit: conservadorismo, NÃO proveniência.
+  -- NULL-preserving: sem "versão anterior" provada (coluna 13 NULL), o piso
+  -- NÃO desce abaixo do calculado — devolver um número aqui AFROUXARIA o gate
+  -- (ver o bloco do spec ingênuo no cabeçalho). Com ela provada, desce só até
+  -- o max de TODAS as ativas da chave (superconjunto do max da allowlist ⇒
+  -- I2: piso >= csv, sempre).
+  CASE
+    WHEN (SELECT max(g2.preco_final_sayersystem)
+            FROM public.tint_formulas g2
+           WHERE g2.account = f.account
+             AND g2.sku_id  = f.sku_id
+             AND g2.cor_id  = f.cor_id
+             AND g2.desativada_em IS NULL
+             AND (NOT rf.is_sl
+                  OR EXISTS (SELECT 1 FROM public.tint_subcolecoes s2
+                             WHERE s2.id = g2.subcolecao_id
+                               AND s2.account = g2.account
+                               AND s2.id_subcolecao_sayersystem = '1'))) IS NULL
+      THEN NULL
+    ELSE (SELECT max(g3.preco_final_sayersystem)
+            FROM public.tint_formulas g3
+           WHERE g3.account = f.account
+             AND g3.sku_id  = f.sku_id
+             AND g3.cor_id  = f.cor_id
+             AND g3.desativada_em IS NULL)
+  END AS preco_piso_legado
+FROM public.tint_formulas f
+CROSS JOIN LATERAL (
+  -- rank de preferência da PRÓPRIA linha (bloco gêmeo do rank da gêmea, abaixo)
+  SELECT v.is_sl,
+         v.tem_receita,
+         (v.tem_receita AND v.corantes_ok) AS receita_valida,
+         CASE WHEN v.is_sl AND v.tem_receita AND v.corantes_ok THEN 0
+              WHEN v.tem_receita AND v.corantes_ok             THEN 1
+              WHEN v.is_sl                                     THEN 2
+              ELSE 3 END AS rank_pref
+  FROM (
+    SELECT
+      EXISTS (SELECT 1 FROM public.tint_subcolecoes s
+              WHERE s.id = f.subcolecao_id
+                AND s.account = f.account
+                AND s.id_subcolecao_sayersystem = 'SL') AS is_sl,
+      EXISTS (SELECT 1 FROM public.tint_formula_itens fi
+              WHERE fi.formula_id = f.id) AS tem_receita,
+      -- [MIRROR get_tint_prices.corantes_completos] todo item precisa de corante
+      -- com omie valor>0 + ativo + volume>0; item órfão de corante conta como ruim.
+      NOT EXISTS (
+        SELECT 1
+        FROM public.tint_formula_itens fi
+        LEFT JOIN public.tint_corantes c  ON c.id = fi.corante_id
+        LEFT JOIN public.omie_products op ON op.id = c.omie_product_id
+        WHERE fi.formula_id = f.id
+          AND NOT (COALESCE(op.valor_unitario, 0) > 0
+                   AND COALESCE(op.ativo, false)
+                   AND c.volume_total_ml IS NOT NULL
+                   AND c.volume_total_ml > 0)
+      ) AS corantes_ok
+  ) v
+) rf
+WHERE f.desativada_em IS NULL
+  AND f.sku_id IS NOT NULL
+  AND NOT EXISTS (
+    -- existe gêmea MELHOR na mesma chave? (rank menor; empate → menor id vence)
+    SELECT 1
+    FROM public.tint_formulas g
+    CROSS JOIN LATERAL (
+      -- rank de preferência da GÊMEA — bloco gêmeo verbatim do rank acima
+      SELECT CASE WHEN w.is_sl AND w.tem_receita AND w.corantes_ok THEN 0
+                  WHEN w.tem_receita AND w.corantes_ok             THEN 1
+                  WHEN w.is_sl                                     THEN 2
+                  ELSE 3 END AS rank_pref
+      FROM (
+        SELECT
+          EXISTS (SELECT 1 FROM public.tint_subcolecoes s
+                  WHERE s.id = g.subcolecao_id
+                    AND s.account = g.account
+                    AND s.id_subcolecao_sayersystem = 'SL') AS is_sl,
+          EXISTS (SELECT 1 FROM public.tint_formula_itens fi
+                  WHERE fi.formula_id = g.id) AS tem_receita,
+          NOT EXISTS (
+            SELECT 1
+            FROM public.tint_formula_itens fi
+            LEFT JOIN public.tint_corantes c  ON c.id = fi.corante_id
+            LEFT JOIN public.omie_products op ON op.id = c.omie_product_id
+            WHERE fi.formula_id = g.id
+              AND NOT (COALESCE(op.valor_unitario, 0) > 0
+                       AND COALESCE(op.ativo, false)
+                       AND c.volume_total_ml IS NOT NULL
+                       AND c.volume_total_ml > 0)
+          ) AS corantes_ok
+      ) w
+    ) rg
+    WHERE g.account = f.account
+      AND g.sku_id  = f.sku_id
+      AND g.cor_id  = f.cor_id
+      AND g.desativada_em IS NULL
+      AND g.id <> f.id
+      AND (rg.rank_pref < rf.rank_pref
+           OR (rg.rank_pref = rf.rank_pref AND g.id < f.id))
+  );
+
+COMMENT ON VIEW public.v_tint_formula_canonica IS
+  'Fase 2 tintométrico: 1 fórmula canônica por (account, sku_id, cor_id) — '
+  'preferência SL válida, fallback SAYERLACK/personalizada; não desativa nada. '
+  'receita_valida espelha corantes_completos da RPC get_tint_prices (validade '
+  'POR FÓRMULA; base_disponivel fica fora — gêmeas compartilham o SKU). '
+  'preco_csv_legado = RÓTULO "Tabela (versão anterior)" (allowlist da geração '
+  '''1'' quando a canônica é SL — precisão de PROVENIÊNCIA). '
+  'preco_piso_legado = PISO do gate de submit (max de TODAS as ativas da chave '
+  '— CONSERVADORISMO), NULL-preserving: NULL exatamente quando '
+  'preco_csv_legado é NULL, senão o piso desceria onde hoje ele é o calculado. '
+  'Invariantes: (csv IS NULL) ⟺ (piso IS NULL) e piso >= csv. '
+  'security_invoker=on: repetir o WITH em todo replace (#1375).';
+
+-- Grants inalterados (REPLACE preserva ACL); re-afirmados por idempotência do bloco.
+REVOKE ALL ON public.v_tint_formula_canonica FROM PUBLIC;
+REVOKE ALL ON public.v_tint_formula_canonica FROM anon;
+GRANT SELECT ON public.v_tint_formula_canonica TO authenticated;
+GRANT SELECT ON public.v_tint_formula_canonica TO service_role;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- 2. O gate: o PISO passa a ler a coluna nova; o RÓTULO ('tabela') não muda.
+--    Corpo verbatim da 20260722100001 (md5 do pg_get_functiondef em PROD
+--    conferido 2026-07-21: 0af971f5d05b29f58b35643fd4364cf9) exceto:
+--      • DECLARE ganha v_can_piso / v_piso
+--      • os 2 SELECT da canônica trazem também c.preco_piso_legado
+--      • v_piso computado ao lado de v_tab (mesmo ceil10 — arredondar p/ CIMA
+--        num piso é conservador)
+--      • fontes 'manual' e ausente(legado): v_floor usa v_piso, não v_tab
+--    A fonte 'tabela' segue validando contra v_tab (preco_csv_legado).
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.tint_gate_revalida(
+  p_account text,
+  p_customer_user_id uuid,
+  p_sales_order_id uuid,
+  p_contexto text,
+  p_items jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_bloqueios jsonb := '[]'::jsonb;
+  v_warnings  jsonb := '[]'::jsonb;
+  v_baseline  jsonb;
+  v_base_sigs jsonb;              -- {assinatura: count} do baseline
+  v_usados    jsonb := '{}'::jsonb; -- {assinatura: count} já consumidos do payload
+  v_item      jsonb;
+  v_idx       int;
+  v_cor       text;
+  v_cod_txt   text;
+  v_sig       text;
+  v_base_n    int;
+  v_uso_n     int;
+  v_declarada uuid;
+  v_declarada_coerente boolean;
+  v_prod_id   uuid;
+  v_is_base_tint boolean;
+  v_n_skus    int;
+  v_can_id    uuid;
+  v_can_csv   numeric;
+  v_can_piso  numeric;            -- 14ª coluna: piso conservador (NULL-preserving)
+  v_price     jsonb;
+  v_calc_raw  float8;
+  v_calc      float8;
+  v_tab       float8;
+  v_piso      float8;             -- ceil10 do v_can_piso (espelha v_tab)
+  v_vu        float8;
+  v_fonte     text;
+  v_desc      float8;
+  v_esperado  float8;
+  v_floor     float8;
+  v_ult       jsonb;
+  v_motivo    text;
+  v_legado_ok boolean;
+
+  -- espelhos JS (float8 de ponta a ponta — ver cabeçalho da 20260722100001):
+  --   ceil10(v) ≡ Math.ceil(v*10)/10 · round2(v) ≡ floor(v*100+0.5)/100
+BEGIN
+  IF p_contexto NOT IN ('criacao', 'edicao') THEN
+    RETURN jsonb_build_object('ok', false, 'bloqueios', jsonb_build_array(
+      jsonb_build_object('index', -1, 'motivo', 'payload_invalido',
+                         'detalhe', 'contexto desconhecido: ' || COALESCE(p_contexto, 'NULL'))),
+      'warnings', v_warnings);
+  END IF;
+  IF p_items IS NULL OR jsonb_typeof(p_items) <> 'array' THEN
+    RETURN jsonb_build_object('ok', false, 'bloqueios', jsonb_build_array(
+      jsonb_build_object('index', -1, 'motivo', 'payload_invalido',
+                         'detalhe', 'items ausente ou não é array')),
+      'warnings', v_warnings);
+  END IF;
+
+  -- Baseline PERSISTIDO (fonte de proveniência/intocabilidade — o caller não
+  -- controla; a edição só persiste APÓS o gate). Linha ausente ⇒ '[]'.
+  SELECT CASE WHEN jsonb_typeof(so.items) = 'array' THEN so.items ELSE '[]'::jsonb END
+    INTO v_baseline
+  FROM public.sales_orders so WHERE so.id = p_sales_order_id;
+  v_baseline := COALESCE(v_baseline, '[]'::jsonb);
+
+  -- Assinaturas do baseline (com contagem): T|produto|cor|qtd|valor|fonte|desc
+  -- para item tint; B|produto|qtd|valor para base-sem-cor. Números
+  -- canonicalizados via float8::text; campo malformado vira '?' (nunca erro).
+  SELECT COALESCE(jsonb_object_agg(sig, n), '{}'::jsonb) INTO v_base_sigs
+  FROM (
+    SELECT
+      CASE WHEN bi.item->>'tint_cor_id' IS NOT NULL AND bi.item->>'tint_cor_id' <> '' THEN
+        'T|' || COALESCE(bi.item->>'omie_codigo_produto', '?') || '|' || (bi.item->>'tint_cor_id') || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'quantidade') = 'number'
+                     THEN ((bi.item->>'quantidade')::float8)::text ELSE '?' END || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'valor_unitario') = 'number'
+                     THEN ((bi.item->>'valor_unitario')::float8)::text ELSE '?' END || '|'
+             || COALESCE(bi.item->>'tint_price_source', '-') || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'tint_discount_pct') = 'number'
+                     THEN ((bi.item->>'tint_discount_pct')::float8)::text ELSE '0' END
+      ELSE
+        'B|' || COALESCE(bi.item->>'omie_codigo_produto', '?') || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'quantidade') = 'number'
+                     THEN ((bi.item->>'quantidade')::float8)::text ELSE '?' END || '|'
+             || CASE WHEN jsonb_typeof(bi.item->'valor_unitario') = 'number'
+                     THEN ((bi.item->>'valor_unitario')::float8)::text ELSE '?' END
+      END AS sig,
+      count(*) AS n
+    FROM jsonb_array_elements(v_baseline) AS bi(item)
+    GROUP BY 1
+  ) s;
+
+  FOR v_idx, v_item IN
+    SELECT (ord - 1)::int, val
+    FROM jsonb_array_elements(p_items) WITH ORDINALITY AS t(val, ord)
+  LOOP
+    v_cor := NULLIF(v_item->>'tint_cor_id', '');
+
+    -- valor_unitario numérico (o edge já barrou ≤0/NaN antes; defesa em profundidade)
+    IF jsonb_typeof(v_item->'valor_unitario') <> 'number' THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'payload_invalido',
+        'detalhe', 'valor_unitario não numérico');
+      CONTINUE;
+    END IF;
+    v_vu := (v_item->>'valor_unitario')::float8;
+
+    -- Código do produto: number OU string numérica (o edge trafega os dois —
+    -- Codex P1 do diff: "900001" string escapava da classificação). Código
+    -- ilegível NUNCA vira "não-tint": é payload_invalido (fail-closed).
+    v_cod_txt := v_item->>'omie_codigo_produto';
+    IF v_cod_txt IS NULL OR v_cod_txt !~ '^[0-9]{1,15}$' THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'payload_invalido',
+        'detalhe', 'omie_codigo_produto ausente/não numérico: ' || COALESCE(v_cod_txt, 'NULL'));
+      CONTINUE;
+    END IF;
+
+    v_prod_id := NULL; v_is_base_tint := false;
+    SELECT op.id, COALESCE(op.is_tintometric, false) AND op.tint_type = 'base'
+      INTO v_prod_id, v_is_base_tint
+    FROM public.omie_products op
+    WHERE op.omie_codigo_produto = v_cod_txt::bigint
+      AND op.account = p_account;
+
+    IF v_cor IS NULL THEN
+      -- Item SEM marcador tint: só interessa se o PRODUTO é base tintométrica
+      -- (classificação server-side — a ausência do marcador NÃO decide sozinha;
+      -- Codex P1: omitir tint_cor_id não pode desligar o gate).
+      CONTINUE WHEN NOT v_is_base_tint;
+      IF p_contexto = 'criacao' THEN
+        -- Push nunca produziu base sem cor (0 na história) — omissão = bloqueio.
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'motivo', 'base_sem_cor',
+          'detalhe', 'base tintométrica sem cor não é vendável pelo app — escolha a cor no balcão de tinta');
+        CONTINUE;
+      END IF;
+      -- Edição: linha inbound (balcão físico, importada do Omie) é legítima —
+      -- mas SÓ intocada (mesma assinatura B| com contagem no baseline).
+      v_sig := 'B|' || v_cod_txt || '|'
+            || CASE WHEN jsonb_typeof(v_item->'quantidade') = 'number'
+                    THEN ((v_item->>'quantidade')::float8)::text ELSE '?' END || '|'
+            || (v_vu)::text;
+      v_base_n := COALESCE((v_base_sigs->>v_sig)::int, 0);
+      v_uso_n  := COALESCE((v_usados->>v_sig)::int, 0);
+      IF v_uso_n < v_base_n THEN
+        v_usados := jsonb_set(v_usados, ARRAY[v_sig], to_jsonb(v_uso_n + 1));
+        CONTINUE; -- inbound preservada
+      END IF;
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'motivo', 'base_sem_cor_alterada',
+        'detalhe', 'base tintométrica sem cor alterada/nova na edição — reprecifique pela tela de tinta');
+      CONTINUE;
+    END IF;
+
+    -- ── item COM tint_cor_id ──
+    IF v_prod_id IS NULL THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'produto_nao_encontrado',
+        'detalhe', 'produto do item tint não existe na conta ' || p_account);
+      CONTINUE;
+    END IF;
+
+    -- Edição: item IDÊNTICO ao baseline (assinatura completa, com contagem)
+    -- passa com warning — o valor já está no Omie; barrar impediria editar
+    -- parcela/observação. Item novo/alterado segue para a validação.
+    IF p_contexto = 'edicao' THEN
+      v_sig := 'T|' || v_cod_txt || '|' || v_cor || '|'
+            || CASE WHEN jsonb_typeof(v_item->'quantidade') = 'number'
+                    THEN ((v_item->>'quantidade')::float8)::text ELSE '?' END || '|'
+            || (v_vu)::text || '|'
+            || COALESCE(v_item->>'tint_price_source', '-') || '|'
+            || CASE WHEN jsonb_typeof(v_item->'tint_discount_pct') = 'number'
+                    THEN ((v_item->>'tint_discount_pct')::float8)::text ELSE '0' END;
+      v_base_n := COALESCE((v_base_sigs->>v_sig)::int, 0);
+      v_uso_n  := COALESCE((v_usados->>v_sig)::int, 0);
+      IF v_uso_n < v_base_n THEN
+        v_usados := jsonb_set(v_usados, ARRAY[v_sig], to_jsonb(v_uso_n + 1));
+        v_warnings := v_warnings || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'aviso', 'tint_intocado',
+          'detalhe', 'item tint idêntico ao pedido persistido — preço não revalidado (já está no Omie)');
+        CONTINUE;
+      END IF;
+    END IF;
+
+    -- fórmula declarada (cast defensivo — uuid inválido vira NULL)
+    v_declarada := NULL;
+    IF (v_item->>'tint_formula_id') ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' THEN
+      v_declarada := (v_item->>'tint_formula_id')::uuid;
+    END IF;
+    -- fórmula declarada COERENTE = existe em tint_formulas para (conta, cor) —
+    -- qualquer geração (a declarada pode ser a gêmea re-canonizada). Fórmula
+    -- ALHEIA (outra conta/cor) ou inexistente NÃO desambigua nem audita nada.
+    v_declarada_coerente := false;
+    IF v_declarada IS NOT NULL THEN
+      SELECT EXISTS (
+        SELECT 1 FROM public.tint_formulas tf
+        WHERE tf.id = v_declarada AND tf.account = p_account AND tf.cor_id = v_cor
+      ) INTO v_declarada_coerente;
+    END IF;
+
+    v_fonte := v_item->>'tint_price_source';
+
+    -- Fonte declarada pelo PICKER exige a fórmula que o picker viu (anti-
+    -- adulteração — Codex P1 do diff). 'manual' (edição humana) e legado não
+    -- têm picker por trás, então não exigem.
+    IF v_fonte IN ('calculado', 'tabela', 'cliente') AND NOT v_declarada_coerente THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'payload_invalido',
+        'detalhe', 'fonte declarada sem tint_formula_id válido de (conta, cor) — reprecifique no balcão de tinta');
+      CONTINUE;
+    END IF;
+
+    -- Canônicas candidatas da célula: produto pode ter MAIS de um SKU com a
+    -- cor. Sem fórmula declarada que desambigue, célula ambígua BLOQUEIA
+    -- (nunca desempatar preço por UUID — Codex P1 do diff).
+    SELECT count(*) INTO v_n_skus
+    FROM public.tint_skus s
+    JOIN public.v_tint_formula_canonica c
+      ON c.account = p_account AND c.sku_id = s.id AND c.cor_id = v_cor
+    WHERE s.omie_product_id = v_prod_id
+      AND s.account = p_account;
+
+    IF v_n_skus = 0 THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'formula_morta',
+        'detalhe', 'não há fórmula ativa/canônica desta cor para o produto — reprecifique no balcão de tinta');
+      CONTINUE;
+    END IF;
+
+    v_can_id := NULL; v_can_csv := NULL; v_can_piso := NULL;
+    IF v_n_skus > 1 THEN
+      -- só a fórmula declarada (do picker) desambigua a célula
+      SELECT c.id, c.preco_csv_legado, c.preco_piso_legado
+        INTO v_can_id, v_can_csv, v_can_piso
+      FROM public.tint_skus s
+      JOIN public.v_tint_formula_canonica c
+        ON c.account = p_account AND c.sku_id = s.id AND c.cor_id = v_cor
+      WHERE s.omie_product_id = v_prod_id
+        AND s.account = p_account
+        AND c.id = v_declarada;
+      IF v_can_id IS NULL THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'formula_ambigua',
+          'detalhe', 'o produto tem mais de um SKU com esta cor e a fórmula declarada não resolve — reprecifique no balcão de tinta');
+        CONTINUE;
+      END IF;
+    ELSE
+      SELECT c.id, c.preco_csv_legado, c.preco_piso_legado
+        INTO v_can_id, v_can_csv, v_can_piso
+      FROM public.tint_skus s
+      JOIN public.v_tint_formula_canonica c
+        ON c.account = p_account AND c.sku_id = s.id AND c.cor_id = v_cor
+      WHERE s.omie_product_id = v_prod_id
+        AND s.account = p_account;
+    END IF;
+
+    IF v_declarada_coerente AND v_declarada <> v_can_id THEN
+      -- geração trocou (ex.: Fase 5 desativar a SAYERLACK) — informa, não barra;
+      -- o PREÇO é validado contra a canônica atual de qualquer forma.
+      v_warnings := v_warnings || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'aviso', 'formula_recanonizada',
+        'declarada', v_declarada, 'canonica', v_can_id);
+    END IF;
+
+    -- motor de preço AGORA (get_tint_price REAL — sem cache de 5min)
+    v_price := public.get_tint_price(v_can_id);
+    v_calc_raw := (v_price->>'precoFinal')::float8;
+    IF v_calc_raw IS NULL THEN
+      -- paridade com selectTintPrice regra 1: motor sem preço bloqueia TODAS
+      -- as fontes (inclusive tabela/cliente) — nunca vender o que a RPC barra.
+      v_motivo := CASE
+        WHEN NOT COALESCE((v_price->>'baseDisponivel')::boolean, false) THEN 'base'
+        WHEN NOT COALESCE((v_price->>'corantesCompletos')::boolean, false) THEN 'corante'
+        ELSE 'receita' END;
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'sem_preco_motor',
+        'detalhe', 'motor honesto sem preço (' || v_motivo || ') — corrija no Omie/tintométrico antes de vender');
+      CONTINUE;
+    END IF;
+
+    v_calc := ceil(v_calc_raw * 10) / 10;                       -- ceil10 (≡ JS)
+    -- RÓTULO (fonte 'tabela'): allowlist, proveniência provada.
+    v_tab  := CASE WHEN v_can_csv IS NOT NULL AND v_can_csv > 0
+                   THEN ceil((v_can_csv)::float8 * 10) / 10 ELSE NULL END;
+    -- PISO (fontes 'manual' e legado): conservador.
+    -- ⚠️ ELEGIBILIDADE ACOPLADA a v_tab (achado P1 do challenge Codex xhigh,
+    -- 2026-07-21). O NULL-preserving da view garante os invariantes sobre os
+    -- valores CRUS — mas o guard `> 0` aqui cria uma SEGUNDA forma de "ausente"
+    -- que a view não conhece, e por ela a monotonicidade vazava:
+    --   csv = 0 (≠ NULL) e piso = 90, calc = 102.5
+    --   ⇒ I1 passa (nenhum é NULL) e I2 passa (90 >= 0) — os dois invariantes
+    --     provados ficam VERDES — mas v_tab vira NULL e v_piso vira 90, então
+    --     o piso EFETIVO cai de 102.5 para 90 e um manual de 95 passa a ser
+    --     aceito onde hoje bloqueia. Afrouxamento pela porta dos fundos.
+    -- Gatear v_piso em v_tab restaura a monotonicidade no nível EFETIVO:
+    --   v_tab IS NULL ⇒ v_piso IS NULL   ·   ambos presentes ⇒ v_piso >= v_tab
+    --   ⇒ v_floor novo >= v_floor de hoje SEMPRE. Sem isto a alegação é falsa.
+    -- (Classe medida em prod 2026-07-21: 0 chaves — latente, como o resto.)
+    v_piso := CASE WHEN v_tab IS NOT NULL AND v_can_piso IS NOT NULL AND v_can_piso > 0
+                   THEN ceil((v_can_piso)::float8 * 10) / 10 ELSE NULL END;
+
+    -- desconto declarado (0 ≤ d < 100; ausente = 0). d=100 é incompatível com
+    -- o guard global preço>0 do edge — contrato alinhado (Codex).
+    v_desc := 0;
+    IF v_item ? 'tint_discount_pct' THEN
+      IF jsonb_typeof(v_item->'tint_discount_pct') <> 'number' THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'desconto_invalido',
+          'detalhe', 'tint_discount_pct não numérico');
+        CONTINUE;
+      END IF;
+      v_desc := (v_item->>'tint_discount_pct')::float8;
+      IF v_desc < 0 OR v_desc >= 100 THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'desconto_invalido',
+          'detalhe', 'tint_discount_pct fora de 0–99.99: ' || v_desc);
+        CONTINUE;
+      END IF;
+    END IF;
+
+    IF v_fonte = 'calculado' THEN
+      v_esperado := floor(v_calc * (1 - v_desc/100) * 100 + 0.5) / 100;
+
+    ELSIF v_fonte = 'tabela' THEN
+      -- ⚠️ a fonte 'tabela' valida contra o RÓTULO (v_tab), NÃO contra o piso:
+      -- a escolha da vendedora é sobre PROVENIÊNCIA ("versão anterior"), e
+      -- validar contra o piso conservador barraria a escolha legítima.
+      IF v_tab IS NULL THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'fonte_tabela_indisponivel',
+          'detalhe', 'a fonte "tabela" foi escolhida mas a chave não tem mais CSV — reprecifique no balcão');
+        CONTINUE;
+      END IF;
+      v_esperado := floor(v_tab * (1 - v_desc/100) * 100 + 0.5) / 100;
+
+    ELSIF v_fonte = 'cliente' THEN
+      v_ult := public.tint_ultimo_preco_cliente(
+        p_customer_user_id, v_prod_id, v_cor, p_sales_order_id);
+      IF v_ult IS NULL OR jsonb_typeof(v_ult->'price') <> 'number' THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_cliente_sem_historico',
+          'detalhe', 'a fonte "cliente" exige pedido real no Omie (não-cancelado, últimos 180 dias) — não encontrado');
+        CONTINUE;
+      END IF;
+      v_esperado := floor((v_ult->>'price')::float8 * (1 - v_desc/100) * 100 + 0.5) / 100;
+
+    ELSIF v_fonte = 'manual' THEN
+      -- Preço digitado pelo humano na EDIÇÃO (o front seta 'manual' ao editar
+      -- valor de item tint): subir é livre; baixar além do piso atual das
+      -- fontes legítimas bloqueia. Nada abaixo do que 'tabela'/'calculado'
+      -- sem desconto já permitiriam (Codex P1 do diff: sem esta fonte, todo
+      -- aumento manual legítimo caía em metadados_ausentes).
+      -- ⚠️ v_piso (conservador), NÃO v_tab (allowlist): encolher o conjunto do
+      -- max para dar precisão AO RÓTULO não pode afrouxar o PISO.
+      v_floor := LEAST(v_calc, COALESCE(v_piso, v_calc));
+      IF v_vu < v_floor - 0.005 THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_obsoleto',
+          'detalhe', 'preço manual abaixo do piso atual das fontes (calc/tabela) — reprecifique no balcão de tinta',
+          'esperado_minimo', v_floor, 'recebido', v_vu);
+      END IF;
+      CONTINUE;
+
+    ELSIF v_fonte IS NULL THEN
+      -- SEM metadados: o fallback legado (piso) EXIGE prova de proveniência —
+      -- existe no baseline persistido um item da MESMA célula TAMBÉM sem fonte
+      -- (orçamento/pedido pré-Fase-3). Sem essa prova, item novo que omite
+      -- metadados é bloqueado (o fallback não é controlável pelo caller).
+      SELECT EXISTS (
+        SELECT 1 FROM jsonb_array_elements(v_baseline) AS bi(item)
+        WHERE bi.item->>'omie_codigo_produto' = v_cod_txt
+          AND bi.item->>'tint_cor_id' = v_cor
+          AND bi.item->>'tint_price_source' IS NULL
+      ) INTO v_legado_ok;
+      IF NOT v_legado_ok THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'metadados_ausentes',
+          'detalhe', 'item tint sem fonte de preço declarada e sem lastro legado no pedido — reprecifique no balcão de tinta');
+        CONTINUE;
+      END IF;
+      -- mesmo piso conservador da fonte 'manual' (ver nota acima)
+      v_floor := LEAST(v_calc, COALESCE(v_piso, v_calc));
+      IF v_vu < v_floor - 0.005 THEN
+        v_bloqueios := v_bloqueios || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_obsoleto',
+          'detalhe', 'preço abaixo do piso atual das fontes (calc/tabela) — reprecifique no balcão de tinta',
+          'esperado_minimo', v_floor, 'recebido', v_vu);
+      END IF;
+      CONTINUE;
+
+    ELSE
+      -- fonte desconhecida (typo/adulteração) — nunca cair no fallback
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'fonte_invalida',
+        'detalhe', 'tint_price_source desconhecida: ' || v_fonte);
+      CONTINUE;
+    END IF;
+
+    -- Auditoria: preco_sem_desconto declarado divergente da fonte recomputada
+    -- vira WARNING (o preço COBRADO já é validado acima — bloquear aqui só
+    -- criaria falso positivo sem proteção extra).
+    IF jsonb_typeof(v_item->'tint_preco_sem_desconto') = 'number' THEN
+      IF abs((v_item->>'tint_preco_sem_desconto')::float8 -
+             CASE v_fonte
+               WHEN 'calculado' THEN v_calc
+               WHEN 'tabela'    THEN v_tab
+               ELSE (v_ult->>'price')::float8
+             END) > 0.005 THEN
+        v_warnings := v_warnings || jsonb_build_object(
+          'index', v_idx, 'cor_id', v_cor, 'aviso', 'preco_sem_desconto_divergente',
+          'declarado', (v_item->>'tint_preco_sem_desconto')::float8);
+      END IF;
+    END IF;
+
+    IF abs(v_vu - v_esperado) > 0.005 THEN
+      v_bloqueios := v_bloqueios || jsonb_build_object(
+        'index', v_idx, 'cor_id', v_cor, 'motivo', 'preco_divergente',
+        'detalhe', 'o preço da fonte "' || v_fonte || '" mudou desde a montagem do pedido — reprecifique no balcão de tinta',
+        'fonte', v_fonte, 'esperado', v_esperado, 'recebido', v_vu);
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ok', jsonb_array_length(v_bloqueios) = 0,
+    'bloqueios', v_bloqueios,
+    'warnings', v_warnings);
+END;
+$$;
+
+COMMENT ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) IS
+  'Fase 3 tint: gate da fronteira omie-vendas-sync (criar_pedido/alterar_'
+  'pedido). Revalida item tint contra o estado ATUAL (canônica viva + preço '
+  'recomputado + fonte declarada, aritmética float8 ≡ JS). Baseline persistido '
+  'decide proveniência (legado=piso) e intocabilidade (edição). Fontes: '
+  'calculado/tabela/cliente (exigem tint_formula_id coerente) · manual (piso) '
+  '· ausente (legado com lastro). Base tint sem cor: bloqueia na criação; na '
+  'edição só intocada (inbound). Multi-SKU sem fórmula que desambigue: '
+  'bloqueia. service_role-only. Bloqueio ⇒ {ok:false,bloqueios:[…]} — o edge '
+  'NÃO toca o Omie. '
+  '2026-07-21: o PISO ("manual"/legado) passou a ler preco_piso_legado (max '
+  'CONSERVADOR de todas as ativas da chave); a fonte "tabela" segue lendo '
+  'preco_csv_legado (RÓTULO, allowlist). Separar os dois impede que dar '
+  'precisão de proveniência ao rótulo afrouxe o piso do submit.';
+
+-- Autorização inalterada (REPLACE preserva ACL); re-afirmada por idempotência.
+REVOKE ALL ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.tint_gate_revalida(text, uuid, uuid, text, jsonb) TO service_role;
+
+-- Coluna nova exposta via PostgREST
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Follow-up do challenge Codex xhigh no #1523 (seção "(c)/(d) NULL e gate"). Separa em duas colunas o que era uma só servindo dois consumidores com necessidades **opostas**.

## O problema

`v_tint_formula_canonica.preco_csv_legado` alimentava:

1. **O RÓTULO** do balcão ("Tabela (versão anterior)") — quer **precisão de proveniência**: só a geração congelada `'1'`. Foi o que o #1505 fixou trocando blocklist por allowlist.
2. **O PISO** do gate de submit `tint_gate_revalida` — quer **conservadorismo**: `v_floor := LEAST(v_calc, COALESCE(v_tab, v_calc))`.

Encolher o conjunto do `max()` para dar precisão ao rótulo **reduzia o piso** — ou seja, a allowlist podia *ampliar* a aceitação de preço baixo na fronteira do submit. O oposto do pretendido.

## Duas correções ao spec, ambas achadas por medição/challenge

**1. O spec óbvio estava errado.** "Max de TODAS as ativas, sem a allowlist" inverte a direção numa sub-população real: como `v_tab` NULL produz o piso **mais alto** (`= v_calc`), trocar NULL por um número **afrouxa**. Medido em prod (psql-ro): das 495.057 chaves com SL ativa, **31.062 (6,3%)** não têm geração `'1'` — o spec ingênuo derrubaria o piso delas. Certo em 94%, fail-**open** em 6%.

Daí o **NULL-preserving**, que separa duas perguntas independentes:
- *Pode* descer abaixo do calculado? → **proveniência** (só se o rótulo existir)
- Até *onde*? → **conservadorismo** (max de todas as ativas)

**2. [P1 do Codex] Os invariantes da view não bastam.** O gate normaliza com um guard `> 0` **depois** de ler as colunas, criando uma segunda forma de "ausente" que a view não conhece:

| | csv | piso | I1 | I2 | `v_tab` | `v_piso` | piso efetivo |
|---|---|---|---|---|---|---|---|
| antes | 0 | 90 | ✅ | ✅ | NULL | 90 | **90** (era 102,5) |
| agora | 0 | 90 | ✅ | ✅ | NULL | NULL | 102,5 |

Com `csv = 0` (que não é NULL), I1 e I2 passam **verdes** e mesmo assim o piso caía de 102,5 para 90 — um manual de 95 passaria. A elegibilidade de `v_piso` passou a ser **acoplada** à de `v_tab`, restaurando a monotonicidade no nível **efetivo**: `v_tab IS NULL ⇒ v_piso IS NULL`, e ambos presentes ⇒ `v_piso >= v_tab`.

## Delta contra a prod: 0 linhas

Provado pelo **predicado exato** da allowlist (não pelo proxy `subcolecao_id IS NULL`), que cobre subcoleção NULL, geração ≠ `'1'` e subcoleção `'1'` de outra conta:

```
chaves com SL ativa .................. 495.057
LIMITE SUPERIOR do delta real ........       0
linhas cross-account com CSV .........       0
linhas em geração ≠ '1' com CSV ......       0
```

"Ter linha SL ativa" é condição **necessária** para a allowlist disparar — 0 no limite superior fecha o delta real em 0. É blindagem semântica: muda o que *aconteceria*.

O rótulo **não muda**: a fonte `'tabela'` segue validando contra `preco_csv_legado` — a escolha da vendedora é sobre proveniência. Só o piso (`'manual'` e legado) lê a coluna nova.

## Prova (PG17, falsificada)

| harness | resultado | falsificações |
|---|---|---|
| `db/test-tint-canonica.sh` | **29 ✅ 0 ❌** | F14/F15/F16 derrubam exatamente `{C26,C28}` / `{C21,C22,C24,C25}` / `{C23}` |
| `db/test-tint-gate-revalida.sh` | **38 ✅ 0 ❌** | F10 (piso lendo rótulo) · F12 (furo do `csv=0`) · F13 (regressão de um ramo só) · F14 (sem `ceil10`) |

Os conjuntos de F1–F13 da canônica ficaram **idênticos** aos contratos originais — a coluna nova não perturbou a prova existente.

F11 virou asserção de **defesa em profundidade**: depois do acoplamento, o gate segue correto mesmo com o NULL-preserving da view quebrado. Não foi repintada de verde — a falsificação do spec ingênuo continua vermelha no harness da canônica (F14→C26).

## Conserta uma quebra silenciosa

`db/test-tint-gate-revalida.sh` estava **quebrado na main** desde o re-dump do snapshot no #1509: morria em `cannot drop columns from view` **antes do primeiro assert**. Confirmado rodando a versão do HEAD sem estas mudanças. Como `db/test-*.sh` não roda no CI, nada acusou — a prova do gate do submit esteve morta e silenciosa. Mesmo `DROP VIEW` que a canônica levou no #1523, mais a cadeia da view aplicada **inteira** (faltavam o fix semântico e a allowlist, então o gate era testado contra uma view desatualizada).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260726160000_tint_canonica_piso_legado.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor e rodar.

Validação pós-apply: `db/valida-tint-piso-legado.sql` (read-only, ~2s — confere as 14 colunas na ordem, `security_invoker=on`, os 2 ramos do gate, I1/I2 e delta 0).

Sem mudança de frontend nem de edge — o piso é consumido só server-side. `types.ts` pega a coluna na próxima regeneração; nada em `src/` precisa dela hoje.

## Aberto do parecer do Codex

Achado #2: trocar a subquery duplicada (coluna 13 + teste de NULL da 14ª) por um `LATERAL` único. Trade-off deliberado — a duplicação mantém a coluna 13 intocada byte a byte e auditável no REPLACE; o `LATERAL` elimina o drift estruturalmente. O guard atual contra drift é o invariante I1 (assert global C28 + query de validação em prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
