### PR TITLE
docs(multi-sessão): como RESOLVER a colisão, e o MERGE_HEAD que mente em worktree

### DIFF
--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -38,7 +38,7 @@ juntas. Cronologia medida (PRs de margem, mesmo dia):
 ```
 #1495  criado 00:30 → merge 17:58   produtor (draft por 17h)
 #1519  criado 17:01 → merge 21:40   helper SQL
-#1524  criado 17:39 → aberto        leitura fechada no frontend
+#1524  criado 17:39 → merge 22:32   leitura fechada no frontend (resolvido, ver abaixo)
 #1525  criado 17:41 → merge 17:47   consumidores  ← viveu 6 minutos
 #1526  criado 17:47 → FECHADO       duplicata do #1525, 26 arquivos jogados fora
 ```
@@ -71,6 +71,25 @@ ponto foi o produtor represado. Nada na memória (claude-mem) registra decisão 
 uma sessão só não colide consigo mesma. Ela nasceu de dor medida (sessão-épico com 14 compacts:
 regressão de idioma, releituras, estado perdido). Trocar split por compact reduz colisão e traz a
 degradação de volta; a saída barata é a re-checagem acima, que ataca a colisão sem desfazer a regra.
+
+**Se for RESOLVER em vez de refazer** (#1524, mergeado 22:32 — o founder pediu para resolver o PR
+já aberto): `git merge origin/main` e **a `main` vence por padrão** (`git checkout --theirs` em
+todos os conflitos). Ela passou pelo CI e está em produção; sobrescrevê-la reverte trabalho
+mergeado — mesma classe de falha do sync bidirecional do Lovable (`deploy.md`). Preserve só
+**adição genuína não coberta**: dos 4 achados do Codex no #1524 sobraram 2, ausentes da `main`
+justamente porque as sessões irmãs não rodaram segunda opinião — o diferencial de uma sessão lenta
+tende a ser o que o rigor extra produziu, não o núcleo. Módulo duplicado **apaga-se**, não se
+reconcilia (`lib/margem.ts` contra o `lib/format.ts` que já existia; as duas sessões chegaram a
+criar `legendaCobertura`, mesmo nome, em arquivos diferentes). Spec que descreve plano já executado
+por outras mãos sai junto — documento afirmando trabalho não realizado engana quem ler depois.
+Resultado: 15 arquivos conflitantes → 9, e o PR passou a valer pelo que só ele tinha.
+
+⚠️ **`MERGE_HEAD` em worktree NÃO fica em `.git/MERGE_HEAD`** — ali `.git` é *arquivo*, não
+diretório. `test -f .git/MERGE_HEAD` dá falso-negativo e faz um merge íntegro parecer perdido
+(custou uma tentativa de refazer do zero); use `$(git rev-parse --git-dir)/MERGE_HEAD`. E **não
+rode `git stash` com merge em curso** — mexe no estado do merge; para salvar, copie os arquivos
+para fora da árvore. O guard de `git reset --hard` pagou-se aqui: barrou o reset que teria
+destruído o merge por causa desse diagnóstico errado.
 
 ## Higiene de RAM/Node (M2 8GB satura; **swap em uso = RAM cheia**)
 


### PR DESCRIPTION
Complemento do #1537, que documentou a **prevenção** (re-conferir antes do `gh pr create`) e concluiu *"refazer o delta > resolver conflitos"*. Faltavam duas coisas: o caso em que **resolver é o pedido**, e uma armadilha de ferramenta independente.

## Como isto foi achado

Aplicando a própria regra do #1537. Ao reconferir `origin/main` antes de commitar, descobri que a lição que eu ia escrever **já estava na main** — escrita por outra sessão, inclusive numa seção de mesmo título. Colisão no assunto "não colidir".

Descartei tudo que duplicava (a mudança no `CLAUDE.md` inteira) e sobrou só o delta. **`CLAUDE.md` fica intocado**: a regra já está lá, e o orçamento tem 36 palavras de folga — isto é lição de domínio ⇒ `docs/agent/`, conforme a política do próprio arquivo.

## O que entra

**1. Resolver, quando refazer não é opção.** A `main` vence por padrão (`--theirs`): passou pelo CI e está em produção, e sobrescrevê-la reverte trabalho mergeado — mesma classe de falha do sync bidirecional do Lovable. Preserva-se só adição genuína não coberta.

No #1524 isso foram **2 dos 4 achados do Codex**, ausentes da main porque as sessões irmãs não rodaram segunda opinião. Daí a generalização que vale registrar: *o diferencial de uma sessão lenta tende a ser o que o rigor extra produziu, não o núcleo* — o núcleo é justamente o que a sessão rápida também alcança.

Dois detalhes operacionais: módulo duplicado **apaga-se** em vez de reconciliar (as duas sessões criaram `legendaCobertura`, mesmo nome, em arquivos diferentes), e spec que descreve plano já executado por outras mãos sai junto — documento afirmando trabalho não realizado engana quem ler depois. 15 arquivos conflitantes → 9.

**2. `MERGE_HEAD` mente em worktree.** Ali `.git` é *arquivo*, não diretório, então `test -f .git/MERGE_HEAD` dá falso-negativo e faz um merge íntegro parecer perdido. Diagnostiquei errado e comecei a refazer do zero um merge que estava perfeito — e o guard de `git reset --hard` barrou o comando que teria destruído de verdade o que eu supunha já destruído. Use `$(git rev-parse --git-dir)/MERGE_HEAD`. Também: não rodar `git stash` com merge em curso.

## Higiene

Branch **nova a partir da `main`** — o hook `branch-pos-squash-guard` avisou que a branch original já tinha PR squash-mergeado, e o padrão é não recommitar ali. Diff efetivo: 1 arquivo, +20/−1.

Docs puro ⇒ **sem Publish, sem migration, sem edge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)