### PR TITLE
fix(farmer): tactical-plans-batch para de responder `ok:true` com metade dos alvos quebrada

### DIFF
--- a/supabase/functions/_shared/tactical-batch-resultado.ts
+++ b/supabase/functions/_shared/tactical-batch-resultado.ts
@@ -1,0 +1,78 @@
+// Classificação e agregação do resultado por alvo do tactical-plans-batch.
+//
+// Lógica PURA extraída para caber no `--no-remote` do `test:edges` — o index.ts da edge
+// importa `npm:@supabase/supabase-js` e não entra no grafo de teste (mesmo padrão de
+// tactical-margem.ts). Testes em tactical-batch-resultado_test.ts.
+//
+// POR QUE EXISTE — incidente 2026-07-21, 1ª execução do cron (jobid 165):
+//   {"ok":true,"farmers":3,"alvos":58,"gerados":30,"pulados":0,"erros":28}
+// 48% dos alvos falharam, uma vendedora inteira ficou sem plano, e a edge respondeu
+// `ok: true` com HTTP 200 — o cron marcaria `succeeded`. O laço fazia `else erros++`
+// sem ler `r.status` nem `j.error`, então o MOTIVO se perdia: foi preciso re-executar
+// o batch 3h depois só para descobrir que era transiente (429), não quota (402).
+//
+// Duas invariantes:
+//   1. `ok` é falso quando há erro — resultado parcial não pode ler como sucesso.
+//   2. Todo erro carrega o STATUS HTTP no motivo — é o que separa 429 de 402 de 500,
+//      que exigem correções OPOSTAS (backoff não resolve crédito esgotado).
+
+export type Classificacao =
+  | { tipo: "gerado" }
+  | { tipo: "pulado"; motivo: string }
+  | { tipo: "erro"; motivo: string };
+
+export interface ResumoLote {
+  ok: boolean;
+  gerados: number;
+  pulados: number;
+  erros: number;
+  erros_por_motivo: Record<string, number>;
+  pulados_por_motivo: Record<string, number>;
+}
+
+/**
+ * Classifica a resposta de UM alvo (chamada a generate-tactical-plan).
+ *
+ * `skipped` é caminho ESPERADO, não falha: `ja_gerado_hoje` (idempotência),
+ * `sem_score` e `rpc_error` (race de reatribuição — a edge alvo já o trata).
+ * Tratá-lo como erro apagaria o sinal que distingue "pulei de propósito" de
+ * "quebrei" — foi `pulados: 0` que provou, no incidente, que os 28 erros não
+ * vinham da RPC.
+ *
+ * O motivo do erro é `http_<status>`: chave ESTÁVEL, para agrupar. Mensagem livre
+ * do gateway fragmentaria a contagem e não agrega ao diagnóstico — o status já
+ * separa as classes que pedem conserto diferente.
+ */
+export function classificarAlvo(
+  status: number,
+  corpo: Record<string, unknown>,
+): Classificacao {
+  if (corpo.generated) return { tipo: "gerado" };
+  if (corpo.skipped) return { tipo: "pulado", motivo: String(corpo.skipped) };
+  // Inclui o caso traiçoeiro do HTTP 200 com corpo inesperado: contar como sucesso
+  // fabricaria um plano que não existe (money-path — ausente ≠ zero).
+  return { tipo: "erro", motivo: `http_${status}` };
+}
+
+/** Agrega as classificações do lote. `ok` reflete a VERDADE do lote, não o fato de ter rodado. */
+export function agregar(classificacoes: Classificacao[]): ResumoLote {
+  let gerados = 0;
+  let pulados = 0;
+  let erros = 0;
+  const erros_por_motivo: Record<string, number> = {};
+  const pulados_por_motivo: Record<string, number> = {};
+
+  for (const c of classificacoes) {
+    if (c.tipo === "gerado") {
+      gerados++;
+    } else if (c.tipo === "pulado") {
+      pulados++;
+      pulados_por_motivo[c.motivo] = (pulados_por_motivo[c.motivo] ?? 0) + 1;
+    } else {
+      erros++;
+      erros_por_motivo[c.motivo] = (erros_por_motivo[c.motivo] ?? 0) + 1;
+    }
+  }
+
+  return { ok: erros === 0, gerados, pulados, erros, erros_por_motivo, pulados_por_motivo };
+}

--- a/supabase/functions/_shared/tactical-batch-resultado_test.ts
+++ b/supabase/functions/_shared/tactical-batch-resultado_test.ts
@@ -1,0 +1,146 @@
+// Testa o CÓDIGO REAL de tactical-batch-resultado.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/tactical-batch-resultado_test.ts
+//
+// POR QUE ESTE MÓDULO EXISTE — incidente 2026-07-21, 1ª execução real do
+// tactical-plans-batch-nightly (jobid 165). A resposta foi:
+//   {"ok":true,"farmers":3,"alvos":58,"gerados":30,"pulados":0,"erros":28}
+// 28 de 58 alvos falharam (48%), UMA VENDEDORA INTEIRA ficou sem plano, e o batch
+// devolveu `ok: true` com HTTP 200. O cron marcaria `succeeded`, e o motivo dos 28
+// erros foi PERDIDO — o laço fazia `else erros++` sem ler `r.status` nem `j.error`.
+// Sem o motivo, foi impossível distinguir 429 (transiente) de 402 (quota) sem
+// re-executar o batch inteiro 3h depois.
+//
+// As duas invariantes que este módulo garante:
+//   1. `ok` é FALSO quando há erro — resultado parcial não pode ler como sucesso.
+//   2. Todo erro carrega motivo com o STATUS HTTP — é o que separa 429 de 402 de 500.
+import { agregar, classificarAlvo } from "./tactical-batch-resultado.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+function assertInclui(hay: string, needle: string, msg?: string) {
+  if (!hay.includes(needle)) {
+    throw new Error(msg ?? `esperava "${needle}" dentro de "${hay}"`);
+  }
+}
+
+// ── classificarAlvo ──────────────────────────────────────────────────────────
+
+Deno.test("classificarAlvo: generated:true → gerado", () => {
+  assertEquals(classificarAlvo(200, { id: "uuid-1", generated: true }), { tipo: "gerado" });
+});
+
+Deno.test("classificarAlvo: skipped preserva o motivo do skip", () => {
+  assertEquals(
+    classificarAlvo(200, { id: "uuid-1", skipped: "ja_gerado_hoje" }),
+    { tipo: "pulado", motivo: "ja_gerado_hoje" },
+  );
+});
+
+Deno.test("classificarAlvo: rpc_error é PULADO (não erro) — a edge alvo já o trata", () => {
+  // Regressão do diagnóstico: `pulados: 0` foi o que provou que os 28 erros NÃO
+  // vinham da RPC criar_plano_tatico. Se rpc_error virasse `erro`, essa dedução
+  // teria sido impossível.
+  assertEquals(
+    classificarAlvo(200, { skipped: "rpc_error", detail: "owner mismatch" }),
+    { tipo: "pulado", motivo: "rpc_error" },
+  );
+});
+
+Deno.test("classificarAlvo: 429 vira erro com o STATUS no motivo", () => {
+  const c = classificarAlvo(429, { error: "Limite de requisições excedido." });
+  assertEquals(c.tipo, "erro");
+  assertInclui((c as { motivo: string }).motivo, "429");
+});
+
+Deno.test("classificarAlvo: 402 vira erro com o STATUS no motivo", () => {
+  // 402 (quota) e 429 (rate limit) exigem correções OPOSTAS — backoff não resolve
+  // quota esgotada. O motivo tem de os separar.
+  const c = classificarAlvo(402, { error: "Créditos de IA esgotados." });
+  assertEquals(c.tipo, "erro");
+  assertInclui((c as { motivo: string }).motivo, "402");
+});
+
+Deno.test("classificarAlvo: 429 e 402 produzem motivos DIFERENTES", () => {
+  const a = classificarAlvo(429, { error: "Limite de requisições excedido." });
+  const b = classificarAlvo(402, { error: "Créditos de IA esgotados." });
+  if ((a as { motivo: string }).motivo === (b as { motivo: string }).motivo) {
+    throw new Error("429 e 402 colapsaram no mesmo motivo — indistinguíveis no log");
+  }
+});
+
+Deno.test("classificarAlvo: corpo vazio (JSON ilegível) não vira erro SILENCIOSO", () => {
+  // `r.json().catch(() => ({}))` no batch produz {} quando a resposta não é JSON.
+  // Ausência de motivo é ausência de dado, não 'sem causa' — precisa ser nomeada.
+  const c = classificarAlvo(500, {});
+  assertEquals(c.tipo, "erro");
+  assertInclui((c as { motivo: string }).motivo, "500");
+});
+
+Deno.test("classificarAlvo: status 0 = fetch não respondeu (rede/timeout)", () => {
+  // Convenção usada pelo catch do index.ts: em vez de um ramo de erro NÃO TESTADO
+  // no laço, o catch chama classificarAlvo(0, {}) e cai nesta função. `http_0` é
+  // distinguível de qualquer status real — falha de rede não se confunde com 500.
+  const c = classificarAlvo(0, {});
+  assertEquals(c.tipo, "erro");
+  assertEquals((c as { motivo: string }).motivo, "http_0");
+});
+
+Deno.test("classificarAlvo: 200 sem generated nem skipped ainda é erro", () => {
+  // Caso traiçoeiro: HTTP ok, corpo inesperado. Contar como sucesso fabricaria plano.
+  const c = classificarAlvo(200, { foo: "bar" });
+  assertEquals(c.tipo, "erro");
+});
+
+// ── agregar ──────────────────────────────────────────────────────────────────
+
+Deno.test("agregar: ok é FALSO quando há erro — o bug de 2026-07-21", () => {
+  const r = agregar([
+    { tipo: "gerado" },
+    { tipo: "gerado" },
+    { tipo: "erro", motivo: "http_429" },
+  ]);
+  assertEquals(r.ok, false, "resultado parcial NÃO pode reportar ok:true");
+  assertEquals(r.gerados, 2);
+  assertEquals(r.erros, 1);
+});
+
+Deno.test("agregar: ok é verdadeiro só com zero erros", () => {
+  const r = agregar([
+    { tipo: "gerado" },
+    { tipo: "pulado", motivo: "ja_gerado_hoje" },
+  ]);
+  assertEquals(r.ok, true);
+  assertEquals(r.erros, 0);
+});
+
+Deno.test("agregar: lote vazio é ok (nada a fazer ≠ falha)", () => {
+  const r = agregar([]);
+  assertEquals(r.ok, true);
+  assertEquals(r.gerados, 0);
+});
+
+Deno.test("agregar: agrupa motivos com contagem", () => {
+  const r = agregar([
+    { tipo: "erro", motivo: "http_429" },
+    { tipo: "erro", motivo: "http_429" },
+    { tipo: "erro", motivo: "http_402" },
+    { tipo: "pulado", motivo: "ja_gerado_hoje" },
+  ]);
+  assertEquals(r.erros_por_motivo, { http_429: 2, http_402: 1 });
+  assertEquals(r.pulados_por_motivo, { ja_gerado_hoje: 1 });
+});
+
+Deno.test("agregar: reproduz o incidente real (30 gerados / 28 erros)", () => {
+  const cs = [
+    ...Array.from({ length: 30 }, () => ({ tipo: "gerado" as const })),
+    ...Array.from({ length: 28 }, () => ({ tipo: "erro" as const, motivo: "http_429" })),
+  ];
+  const r = agregar(cs);
+  assertEquals(r.ok, false, "48% de falha reportado como ok:true foi o incidente");
+  assertEquals(r.gerados, 30);
+  assertEquals(r.erros, 28);
+  assertEquals(r.erros_por_motivo, { http_429: 28 });
+});

--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -60,6 +60,11 @@ import {
   margemConhecida,
   selecionarParaPregeracao,
 } from '../_shared/tactical-margem.ts';
+import {
+  agregar,
+  type Classificacao,
+  classificarAlvo,
+} from '../_shared/tactical-batch-resultado.ts';
 
 const TOP_N = 25;
 const CONCURRENCY = 5; // cada chamada faz 1 LLM (~3-5s); 5 em paralelo ~5s/chunk
@@ -174,14 +179,15 @@ Deno.serve(async (req) => {
   }
 
   // 3. Fan-out concorrente em chunks de 5. Idempotência é na edge alvo.
-  let gerados = 0;
-  let pulados = 0;
-  let erros = 0;
+  //    A classificação/agregação vive em _shared/tactical-batch-resultado.ts (testada):
+  //    aqui só coletamos. Antes, três contadores soltos com `else erros++` perdiam o
+  //    MOTIVO — ver o incidente no cabeçalho daquele módulo.
+  const classificacoes: Classificacao[] = [];
 
   for (let i = 0; i < alvos.length; i += CONCURRENCY) {
     const chunk = alvos.slice(i, i + CONCURRENCY);
-    await Promise.all(
-      chunk.map(async (a) => {
+    classificacoes.push(...await Promise.all(
+      chunk.map(async (a): Promise<Classificacao> => {
         try {
           const r = await fetch(selfUrl, {
             method: 'POST',
@@ -196,24 +202,26 @@ Deno.serve(async (req) => {
             }),
           });
           const j = await r.json().catch(() => ({})) as Record<string, unknown>;
-          if (j.generated) gerados++;
-          else if (j.skipped) pulados++;
-          else erros++;
+          return classificarAlvo(r.status, j);
         } catch {
-          erros++;
+          // fetch nem chegou a responder (rede/timeout). Reusa a MESMA função testada
+          // com status 0 em vez de um ramo de erro solto e não coberto aqui.
+          return classificarAlvo(0, {});
         }
       }),
-    );
+    ));
   }
+
+  const resumo = agregar(classificacoes);
 
   return new Response(
     JSON.stringify({
-      ok: true,
+      // `ok` vem do AGREGADO: falso se qualquer alvo falhou. Antes era `true` fixo —
+      // em 2026-07-21 devolveu ok:true com 28 de 58 alvos quebrados e uma vendedora
+      // inteira sem plano, e o cron marcou `succeeded`.
+      ...resumo,
       farmers: porFarmer.size,
       alvos: alvos.length,
-      gerados,
-      pulados,
-      erros,
       // transparência do que foi DESCARTADO pela máscara: um corte silencioso leria como
       // "cobri todo mundo" sem ter coberto (money-path — no silent caps).
       mascarados_ignorados: mascaradosIgnorados,


### PR DESCRIPTION
Achado na **1ª execução real** do cron criado em #1522 (jobid 165, 2026-07-21):

```json
{"ok":true,"farmers":3,"alvos":58,"gerados":30,"pulados":0,"erros":28}
```

28 de 58 alvos falharam (**48%**), **uma vendedora inteira ficou sem plano**, e a edge devolveu `ok: true` com HTTP 200. O cron marcaria `succeeded` e ninguém saberia.

## Dois defeitos no mesmo laço

**1. `ok: true` era literal**, não derivado do resultado.

**2. `else erros++` descartava `r.status` e `j.error`.** A edge sabia *que* falhou, nunca *por quê*. Sem o motivo foi impossível separar **429** (transiente, pede backoff) de **402** (quota, pede outra coisa) — precisei **re-executar o batch 3h depois** para descobrir que era transiente. A 2ª rodada deu 58/58, zero erros.

Ou seja: o bug de observabilidade custou uma execução inteira de diagnóstico.

## O fix

A classificação vira função **pura** em `_shared/tactical-batch-resultado.ts`, testável sob o `--no-remote` do `test:edges` (o `index.ts` importa `npm:` e não entra no grafo — mesmo padrão de `tactical-margem.ts`).

Duas invariantes:

- **`ok` vem do agregado** — falso se qualquer alvo falhou.
- **Todo erro carrega o status no motivo** (`http_429` / `http_402` / `http_500`) — chave estável que agrupa e separa as classes que pedem conserto oposto.

Novos campos: `erros_por_motivo` e `pulados_por_motivo`. Ficam gravados em `net._http_response.content`, que é de onde li o diagnóstico.

### Decisões que preservam sinal

**`skipped` continua sendo caminho esperado, não erro.** Foi justamente `pulados: 0` que provou que os 28 erros **não** vinham da RPC `criar_plano_tatico` — a edge alvo devolve `{skipped:'rpc_error'}` nesse caso. Colapsar as duas classes teria apagado a dedução que resolveu o diagnóstico. Tem teste de regressão para isso.

**O `catch` do fetch reusa `classificarAlvo(0, {})`** → `http_0`, em vez de um ramo de erro solto que o teste não alcança.

## TDD

14 testes escritos **antes**, vistos vermelhos (módulo inexistente), depois verdes.

Falsificados com 6 mutações — todas vermelhas:

| Mutação | Resultado |
|---|---|
| `ok: true` fixo (o bug de 21/07) | 🔴 |
| motivo sem o status HTTP | 🔴 |
| `skipped` virando erro | 🔴 |
| HTTP 200 virando `gerado` | 🔴 |
| contagem fixa em 1 | 🔴 |
| `http_0` colapsado | 🔴 |

## Gates

| Gate | Exit | Resultado |
|---|---|---|
| `test:edges` | **0** | **207 passed** (era 193) |
| `edges:typecheck` | **0** | 93 edges · 0 crash-class · 142 tolerados (baseline inalterado) |

## Risco

**Só observabilidade.** Não muda quais planos são gerados, nem a seleção top-N, nem o gate de R$/h. O `mascarados_ignorados` e o `sem_margem_indecidivel` seguem idênticos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
