### PR TITLE
feat(authz): FU4-F fase 3 — o scoring do farmer para de baixar o catálogo de custo [money-path]

### DIFF
--- a/db/test-fu4f-fase3-carteira-margem-faixa.sh
+++ b/db/test-fu4f-fase3-carteira-margem-faixa.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  Prova PG17 de `public.get_carteira_margem_faixa()` (FU4-F fase 3)            ║
+# ║    bash db/test-fu4f-fase3-carteira-margem-faixa.sh > log 2>&1; echo $?       ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                        ║
+# ║                                                                               ║
+# ║  O que prova:                                                                 ║
+# ║   · escopo espelha fcs_select_carteira (carteira própria; gestor vê tudo)      ║
+# ║   · gate de PROJEÇÃO: margem_pct só sob cap_custo_ler; a FAIXA sempre sai      ║
+# ║   · `g` usa a régua de percentis da POPULAÇÃO — mesmo valor para qualquer      ║
+# ║     caller (o assert que sustenta a decisão de desenho de 2026-07-22)          ║
+# ║   · `g` é NULL (não 0) quando a margem não é apurável — 0 é veredito           ║
+# ║   · fail-closed sem auth.uid()                                                 ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+# 5473: 5471 é do harness do #1495, 5472 do helper compartilhado.
+PORT="${PGPORT_TEST:-5473}"
+SLUG="fu4f3faixa"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  XX  $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+# ── stubs espelhando a PROD ──────────────────────────────────────────────────
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$
+  SELECT nullif(current_setting('test.uid', true), '')::uuid $f$;
+
+CREATE SCHEMA IF NOT EXISTS private;
+-- Default privilege do Supabase em AMBOS os schemas: sem isto o teste de ACL nasce fechado
+-- por acidente e dá falso-verde.
+ALTER DEFAULT PRIVILEGES IN SCHEMA private GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+GRANT USAGE ON SCHEMA private TO authenticated, anon, service_role;
+
+-- ⚠️ TABELAS ANTES DAS FUNÇÕES: `LANGUAGE sql` é validada no CREATE quando
+-- `check_function_bodies=on` (o default) — referenciar tabela inexistente RECUSA o CREATE,
+-- diferente de plpgsql, que aceita e só quebra ao executar. Criar `carteira_visivel_para` antes
+-- de `carteira_teste` derruba o harness inteiro com "relation does not exist".
+CREATE TABLE public.carteira_teste (cid uuid, dono uuid);
+CREATE TABLE public.farmer_algorithm_config (key text PRIMARY KEY, value text NOT NULL);
+CREATE TABLE public.omie_products (id uuid PRIMARY KEY, omie_codigo_produto bigint UNIQUE);
+CREATE TABLE public.product_costs (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                                   product_id uuid UNIQUE, cost_final numeric, cost_price numeric);
+CREATE TABLE public.sales_orders (id uuid PRIMARY KEY, status text, deleted_at timestamptz);
+CREATE TABLE public.order_items (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                                 sales_order_id uuid, customer_user_id uuid,
+                                 omie_codigo_produto bigint, product_id uuid,
+                                 quantity numeric, unit_price numeric);
+CREATE TABLE public.cliente_classificacao (user_id uuid PRIMARY KEY, excluir_da_carteira boolean);
+
+-- Capabilities controláveis por GUC (a prod resolve por has_role/carteira). Depois das tabelas.
+CREATE OR REPLACE FUNCTION private.cap_custo_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT coalesce(nullif(current_setting('test.cap_custo',true),'')::boolean,false) $f$;
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT coalesce(nullif(current_setting('test.cap_carteira',true),'')::boolean,false) $f$;
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_customer_user_id uuid, _uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT EXISTS (SELECT 1 FROM public.carteira_teste c
+                                             WHERE c.cid=_customer_user_id AND c.dono=_uid) $f$;
+SQL
+
+# ── migrations REAIS, na ordem ───────────────────────────────────────────────
+P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+
+# ── seed: 5 clientes com margens espalhadas, em 2 carteiras ──────────────────
+P -q <<'SQL'
+INSERT INTO public.farmer_algorithm_config(key,value) VALUES
+  ('margem_faixa_piso_pct','30'), ('margem_faixa_meta_pct','50')
+ON CONFLICT (key) DO NOTHING;
+
+-- SKUs: custo 90 / 70 / 50 / 10 / sem custo
+INSERT INTO public.omie_products(id, omie_codigo_produto) VALUES
+  ('d0000000-0000-0000-0000-000000000001', 2001),
+  ('d0000000-0000-0000-0000-000000000002', 2002),
+  ('d0000000-0000-0000-0000-000000000003', 2003),
+  ('d0000000-0000-0000-0000-000000000004', 2004),
+  ('d0000000-0000-0000-0000-000000000009', 2009);
+INSERT INTO public.product_costs(product_id, cost_final) VALUES
+  ('d0000000-0000-0000-0000-000000000001', 110),  -- preço 100 → -10%  (vermelho)
+  ('d0000000-0000-0000-0000-000000000002',  80),  -- preço 100 →  20%  (amarelo)
+  ('d0000000-0000-0000-0000-000000000003',  60),  -- preço 100 →  40%  (verde/abaixo_da_meta)
+  ('d0000000-0000-0000-0000-000000000004',  10);  -- preço 100 →  90%  (verde/saudavel)
+-- 2009 fica SEM linha de custo → cliente que só o compra é `neutro`
+
+INSERT INTO public.sales_orders(id,status,deleted_at) VALUES
+  ('50000000-0000-0000-0000-000000000001','faturado',NULL),
+  ('50000000-0000-0000-0000-000000000002','faturado',NULL),
+  ('50000000-0000-0000-0000-000000000003','faturado',NULL),
+  ('50000000-0000-0000-0000-000000000004','faturado',NULL),
+  ('50000000-0000-0000-0000-000000000005','faturado',NULL);
+
+-- carteira do vendedor A: clientes 1 e 2 | vendedor B: clientes 3, 4 e 5
+INSERT INTO public.carteira_teste(cid,dono) VALUES
+  ('c1000000-0000-0000-0000-000000000001','aa000000-0000-0000-0000-00000000000a'),
+  ('c2000000-0000-0000-0000-000000000002','aa000000-0000-0000-0000-00000000000a'),
+  ('c3000000-0000-0000-0000-000000000003','bb000000-0000-0000-0000-00000000000b'),
+  ('c4000000-0000-0000-0000-000000000004','bb000000-0000-0000-0000-00000000000b'),
+  ('c5000000-0000-0000-0000-000000000005','bb000000-0000-0000-0000-00000000000b');
+
+INSERT INTO public.order_items(sales_order_id,customer_user_id,omie_codigo_produto,quantity,unit_price) VALUES
+  ('50000000-0000-0000-0000-000000000001','c1000000-0000-0000-0000-000000000001',2001,1,100), -- -10%
+  ('50000000-0000-0000-0000-000000000002','c2000000-0000-0000-0000-000000000002',2002,1,100), --  20%
+  ('50000000-0000-0000-0000-000000000003','c3000000-0000-0000-0000-000000000003',2003,1,100), --  40%
+  ('50000000-0000-0000-0000-000000000004','c4000000-0000-0000-0000-000000000004',2004,1,100), --  90%
+  ('50000000-0000-0000-0000-000000000005','c5000000-0000-0000-0000-000000000005',2009,1,100); -- sem custo
+SQL
+
+# helper: roda como um caller específico
+como() { P -tA -q -c "SET test.uid='$1'; SET test.cap_custo='$2'; SET test.cap_carteira='$3'; $4"; }
+A=aa000000-0000-0000-0000-00000000000a
+B=bb000000-0000-0000-0000-00000000000b
+
+echo "-- E. escopo (espelha fcs_select_carteira) --"
+eq "E1 vendedor A vê só os 2 da carteira dele" \
+   "$(como $A false false "SELECT count(*) FROM public.get_carteira_margem_faixa();")" "2"
+eq "E2 vendedor B vê só os 3 dele" \
+   "$(como $B false false "SELECT count(*) FROM public.get_carteira_margem_faixa();")" "3"
+eq "E3 A NÃO alcança cliente de B" \
+   "$(como $A false false "SELECT count(*) FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c3000000-0000-0000-0000-000000000003';")" "0"
+eq "E4 gestor (cap_carteira_ler) vê os 5" \
+   "$(como $A false true "SELECT count(*) FROM public.get_carteira_margem_faixa();")" "5"
+eq "E5 fail-closed: sem auth.uid() → zero linhas" \
+   "$(P -tA -q -c "SET test.uid=''; SELECT count(*) FROM public.get_carteira_margem_faixa();")" "0"
+
+echo "-- F. gate de PROJEÇÃO do número --"
+eq "F1 com cap_custo_ler, margem_pct é o valor EXATO" \
+   "$(como $A true false "SELECT margem_pct FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "20.00"
+eq "F2 SEM cap_custo_ler, margem_pct é NULL" \
+   "$(como $A false false "SELECT coalesce(margem_pct::text,'') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" ""
+eq "F3 a FAIXA sai mesmo sem cap_custo_ler (o sinal fica)" \
+   "$(como $A false false "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "amarelo"
+eq "F4 o MOTIVO sai mesmo sem cap_custo_ler" \
+   "$(como $A false false "SELECT motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "abaixo_do_piso"
+eq "F5 o campo g sai mesmo sem cap_custo_ler (é ele que preserva o score)" \
+   "$(como $A false false "SELECT (g IS NOT NULL)::text FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "true"
+
+echo "-- G. classificação --"
+eq "G1 margem negativa → vermelho/abaixo_do_custo" \
+   "$(como $A false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c1000000-0000-0000-0000-000000000001';")" "vermelho|abaixo_do_custo"
+eq "G2 40% → verde/abaixo_da_meta" \
+   "$(como $B false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c3000000-0000-0000-0000-000000000003';")" "verde|abaixo_da_meta"
+eq "G3 90% → verde/saudavel" \
+   "$(como $B false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c4000000-0000-0000-0000-000000000004';")" "verde|saudavel"
+eq "G4 sem custo → neutro/sem_custo" \
+   "$(como $B false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c5000000-0000-0000-0000-000000000005';")" "neutro|sem_custo"
+
+echo "-- H. o campo g (a decisao de desenho de 2026-07-22) --"
+# ⚠️ ASSERT DECISIVO: a régua é da POPULAÇÃO, não da carteira. O mesmo cliente tem de receber o
+# MESMO `g` seja quem for que pergunta. Se a régua fosse calculada depois do filtro de escopo, o
+# vendedor A (2 clientes) e o gestor (5 clientes) veriam percentis diferentes para o mesmo cliente
+# — e o health score passaria a depender de QUEM calcula.
+G_VENDEDOR="$(como $A false false "SELECT g FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")"
+G_GESTOR="$(como $A false true  "SELECT g FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")"
+eq "H1 o g e o MESMO para vendedor e gestor (régua populacional)" "$G_VENDEDOR" "$G_GESTOR"
+
+# Régua sobre a população: margens -0,10 / 0,20 / 0,40 / 0,90 (o `neutro` não entra).
+# p10 = -0,010 ; p90 = 0,750 ; range = 0,760.
+#   cliente 2 (0,20): (0,20 - (-0,010)) / 0,760 = 0,2763…
+eq "H2 o g bate a regua de percentis calculada à mão" \
+   "$(como $A false false "SELECT round(g,4) FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "0.2763"
+eq "H3 o melhor da população satura em 1" \
+   "$(como $B false false "SELECT round(g,2) FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c4000000-0000-0000-0000-000000000004';")" "1.00"
+eq "H4 o pior satura em 0" \
+   "$(como $A false false "SELECT round(g,2) FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c1000000-0000-0000-0000-000000000001';")" "0.00"
+# ⚠️ 0 é VEREDITO ("pior margem da população"), NULL é "não sei". Confundi-los reintroduz a
+# fabricação que o #1533 removeu — o calcularHealthScore renormaliza o peso quando g é NULL.
+eq "H5 sem custo -> g e NULL, NÃO 0" \
+   "$(como $B false false "SELECT coalesce(g::text,'NULO') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c5000000-0000-0000-0000-000000000005';")" "NULO"
+
+echo "-- I. ACL --"
+eq "I1 anon NÃO executa" \
+   "$(Pq -q -c "SELECT has_function_privilege('anon','public.get_carteira_margem_faixa()','EXECUTE');")" "f"
+eq "I2 authenticated EXECUTA (é o vendedor; o gate está no corpo)" \
+   "$(Pq -q -c "SELECT has_function_privilege('authenticated','public.get_carteira_margem_faixa()','EXECUTE');")" "t"
+eq "I3 PUBLIC NÃO executa" \
+   "$(Pq -q -c "SELECT has_function_privilege('public','public.get_carteira_margem_faixa()','EXECUTE');")" "f"
+eq "I4 é SECURITY DEFINER" \
+   "$(Pq -q -c "SELECT prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")" "t"
+
+echo "-- J. idempotência --"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+eq "J1 re-aplicar não muda a faixa" \
+   "$(como $A false false "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "amarelo"
+eq "J2 re-aplicar preserva o REVOKE de anon" \
+   "$(Pq -q -c "SELECT has_function_privilege('anon','public.get_carteira_margem_faixa()','EXECUTE');")" "f"
+
+echo "========================================"
+echo "  $PASS verde(s), $FAIL vermelho(s)"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "  TODOS OS ASSERTS PASSARAM"

--- a/db/test-fu4f-fase3-carteira-margem-faixa.sh
+++ b/db/test-fu4f-fase3-carteira-margem-faixa.sh
@@ -148,6 +148,12 @@ eq "E4 gestor (cap_carteira_ler) vê os 5" \
    "$(como $A false true "SELECT count(*) FROM public.get_carteira_margem_faixa();")" "5"
 eq "E5 fail-closed: sem auth.uid() → zero linhas" \
    "$(P -tA -q -c "SET test.uid=''; SELECT count(*) FROM public.get_carteira_margem_faixa();")" "0"
+# ⚠️ E5 sozinho NÃO isola o fail-closed: sem uid, `carteira_visivel_para(cid, NULL)` já devolve
+# false e o escopo zeraria o resultado de qualquer jeito. O `IF v_uid IS NULL THEN RETURN` só é
+# a ÚNICA defesa quando a capability resolve permissiva — é esse o caso que E5b fixa, e é ele
+# que a falsificação K1 sabota. Sem E5b, K1 não teria assert para deixar vermelho.
+eq "E5b fail-closed morde mesmo com cap_carteira_ler permissiva" \
+   "$(P -tA -q -c "SET test.uid=''; SET test.cap_carteira='true'; SELECT count(*) FROM public.get_carteira_margem_faixa();")" "0"
 
 echo "-- F. gate de PROJEÇÃO do número --"
 eq "F1 com cap_custo_ler, margem_pct é o valor EXATO" \
@@ -210,6 +216,92 @@ eq "J1 re-aplicar não muda a faixa" \
    "$(como $A false false "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "amarelo"
 eq "J2 re-aplicar preserva o REVOKE de anon" \
    "$(Pq -q -c "SELECT has_function_privilege('anon','public.get_carteira_margem_faixa()','EXECUTE');")" "f"
+
+echo "-- K. FALSIFICAÇÃO (o passo que separa prova de teatro) --"
+# Cada bloco SABOTA a migration e exige VERMELHO no assert que a sabotagem mira. Sem isto os
+# asserts acima seriam decorativos: um `WHERE` que não filtra e um `CASE` que não esconde
+# produzem exatamente o mesmo verde que a versão correta, se o assert não tiver dente.
+#
+# A sabotagem é um `sed` CIRÚRGICO sobre o arquivo REAL — nunca um corpo reescrito à mão, que
+# testaria a minha cópia em vez da migration que o founder vai colar no SQL Editor.
+MIG="$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+SABOTADA="/tmp/sabota-${SLUG}.sql"
+
+sabota() { # $1 = expressão sed
+  sed "$1" "$MIG" > "$SABOTADA"
+  # ANTI-TEATRO (lição do #1483): `sed` que não casa nada devolve a migration ORIGINAL, o assert
+  # segue verde e eu leria isso como "sabotei e nada mudou" — falsificando por acidente de
+  # digitação, não por desenho. Arquivo idêntico = harness quebrado, não sabotagem branda.
+  if cmp -s "$SABOTADA" "$MIG"; then
+    bad "SABOTAGEM NÃO APLICADA — o sed não casou nada: $1"
+    return 1
+  fi
+  P -q -f "$SABOTADA"
+}
+restaura() { P -q -f "$MIG"; }
+# Passa quando o valor MUDOU sob sabotagem — ou seja, o assert original teria ficado vermelho.
+ne() {
+  if [ "$2" != "$3" ]; then ok "$1 (sob sabotagem virou [$2], íntegro era [$3])"
+  else bad "$1 — ASSERT SEM DENTE: seguiu [$3] mesmo com a migration sabotada"; fi
+}
+
+sabota 's/IF v_uid IS NULL THEN/IF false THEN/' && {
+  ne "K1 remover o fail-closed → E5b fica vermelho" \
+     "$(P -tA -q -c "SET test.uid=''; SET test.cap_carteira='true'; SELECT count(*) FROM public.get_carteira_margem_faixa();")" "0"
+  restaura; }
+
+sabota 's/CASE WHEN v_pode_num THEN b.pct END/b.pct/' && {
+  ne "K2 remover o CASE de projeção → F2 fica vermelho" \
+     "$(como $A false false "SELECT coalesce(margem_pct::text,'') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" ""
+  restaura; }
+
+# A régua ANTES do filtro é a decisão de desenho de 2026-07-22 (g comparável entre vendedores).
+# Sabotar = calcular os percentis sobre a carteira do caller, e não sobre a população.
+sabota 's|FROM private.margem_cliente_agregada() m|FROM private.margem_cliente_agregada() m WHERE v_cap_todo OR COALESCE(private.carteira_visivel_para(m.customer_user_id, v_uid), false)|' && {
+  ne "K3 régua por CARTEIRA em vez de população → H1 fica vermelho" \
+     "$(como $A false false "SELECT g FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" \
+     "$(como $A false true  "SELECT g FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")"
+  restaura; }
+
+sabota 's/  WHERE v_cap_todo/  WHERE true OR v_cap_todo/' && {
+  ne "K4 remover o WHERE de escopo → E1 fica vermelho" \
+     "$(como $A false false "SELECT count(*) FROM public.get_carteira_margem_faixa();")" "2"
+  restaura; }
+
+# `g = 0` é VEREDITO ("pior margem da população"); NULL é "não sei". Trocar um pelo outro
+# reintroduz a fabricação que o #1533 removeu, e o health score deixa de renormalizar.
+sabota 's/CASE WHEN b.pct IS NULL THEN NULL/CASE WHEN b.pct IS NULL THEN 0::numeric/' && {
+  ne "K5 g NULL virando 0 → H5 fica vermelho" \
+     "$(como $B false false "SELECT coalesce(g::text,'NULO') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c5000000-0000-0000-0000-000000000005';")" "NULO"
+  restaura; }
+
+# A restauração precisa ser PROVADA: sem isto, um `restaura` que falhasse deixaria o harness
+# verde com a função sabotada em pé, e as 5 falsificações acima viravam ficção.
+eq "K6 canário: a migration íntegra voltou depois das sabotagens" \
+   "$(como $A false false "SELECT faixa||'|'||coalesce(margem_pct::text,'sem-numero') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" \
+   "amarelo|sem-numero"
+
+echo "-- L. impressão digital (amarra o harness à validação pós-apply) --"
+# A validação que o founder roda depois do SQL Editor prova que o objeto EXISTE e que os gates
+# estão lá. O que ela não provaria sozinha: que o corpo colado é o MESMO que este harness
+# testou. O md5 do `prosrc` normalizado fecha isso — e o assert abaixo garante que o número
+# gravado em db/valida-*.sql nunca envelhece em silêncio: mexeu na migration sem regravar a
+# impressão digital, o harness fica VERMELHO aqui, não na mão do founder.
+MD5_APLICADO="$(Pq -q -c "SELECT md5(regexp_replace(prosrc, '[[:space:]]+', ' ', 'g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")"
+# `|| true`: sob `set -o pipefail`, `sed` num arquivo ausente derruba o harness INTEIRO em
+# silêncio — o que já custou uma rodada de diagnóstico aqui. Ausência vira string vazia, que o
+# assert reporta como vermelho legível em vez de morte súbita.
+MD5_DOC="$(sed -n 's/.*IMPRESSAO_DIGITAL=\([0-9a-f]\{32\}\).*/\1/p' "$REPO_ROOT/db/valida-fu4f-fase3-carteira-margem-faixa.sql" 2>/dev/null | head -1 || true)"
+echo "  (md5 do corpo aplicado: $MD5_APLICADO)"
+eq "L1 a impressão digital em db/valida-*.sql casa o corpo realmente aplicado" "$MD5_DOC" "$MD5_APLICADO"
+
+# E roda a PRÓPRIA validação pós-apply contra a migration real. Sem isto, um check meu com
+# formato errado (o `proconfig` que o Postgres normaliza, um nome de role) devolveria `f` num
+# banco CORRETO — e o founder pararia o deploy por um falso alarme meu, do outro lado da tela,
+# sem terminal para investigar. Todos os campos têm de ser `t`.
+VALIDA_OUT="$(Pq -q -f "$REPO_ROOT/db/valida-fu4f-fase3-carteira-margem-faixa.sql")"
+eq "L2 a validação pós-apply dá 't' em TODOS os 11 checks contra a migration real" \
+   "$(printf '%s' "$VALIDA_OUT" | tr '|' '\n' | sort -u | tr -d '\n')" "t"
 
 echo "========================================"
 echo "  $PASS verde(s), $FAIL vermelho(s)"

--- a/db/valida-fu4f-fase3-carteira-margem-faixa.sql
+++ b/db/valida-fu4f-fase3-carteira-margem-faixa.sql
@@ -1,0 +1,57 @@
+-- Validacao pos-apply de 20260726170000_fu4f_fase3_carteira_margem_faixa.sql (FU4-F fase 3)
+-- Cola no SQL Editor do Lovable, ou roda via ~/.config/afiacao/psql-ro -f db/valida-fu4f-fase3-carteira-margem-faixa.sql
+--
+-- LE CATALOGO, nunca INVOCA a funcao (licao do #1462): invocar exige EXECUTE e daria
+-- falso-negativo sob a role read-only, que nao o tem. Todos os checks tem de vir `t`.
+-- Qualquer `f` = a migration nao aplicou como desenhada -> NAO faca o Publish do frontend.
+--
+-- IMPRESSAO_DIGITAL=075209b91d13be52c58220f6ddc88521
+--   md5 do corpo (prosrc) com whitespace colapsado. E o que amarra "o que foi COLADO" a "o que
+--   foi TESTADO": db/test-fu4f-fase3-carteira-margem-faixa.sh (assert L1) recalcula esta digital
+--   contra a migration real num PG17 e falha se as duas divergirem. Mexeu na migration sem
+--   regravar aqui -> vermelho no harness, nao na producao.
+
+SELECT
+  -- ── existencia e forma ──────────────────────────────────────────────────────
+  (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa') = 1   AS c1_existe,
+  (SELECT p.prosecdef FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')       AS c2_security_definer,
+  (SELECT p.provolatile = 's' FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')       AS c3_stable,
+  -- pg_temp POR ULTIMO (regra do FU7): antes de 'public' ele deixaria um objeto temporario
+  -- do atacante sombrear a resolucao de nome dentro de uma funcao SECURITY DEFINER.
+  (SELECT p.proconfig @> ARRAY['search_path=pg_catalog, public, pg_temp']
+     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')       AS c4_search_path,
+
+  -- ── ACL: `authenticated` MANTEM execute de proposito (o gate esta no CORPO) ──
+  -- REVOKE de PUBLIC nao tira das roles nomeadas (grant explicito do Supabase) — por isso
+  -- anon e checado em separado, e nao inferido do PUBLIC.
+  has_function_privilege('anon', 'public.get_carteira_margem_faixa()', 'EXECUTE')
+    = false                                                                        AS c5_anon_negado,
+  has_function_privilege('public', 'public.get_carteira_margem_faixa()', 'EXECUTE')
+    = false                                                                        AS c6_public_negado,
+  has_function_privilege('authenticated', 'public.get_carteira_margem_faixa()', 'EXECUTE')
+    = true                                                                         AS c7_authenticated_ok,
+
+  -- ── os dois gates, por ESTRUTURA (nao por substring solta) ───────────────────
+  -- O md5 do corpo inteiro e o assert forte: "OR true" enxertado num dos gates mudaria a
+  -- digital. Os dois checks seguintes existem para DIAGNOSTICO — quando c10 falha, eles dizem
+  -- QUAL gate sumiu, em vez de so "o corpo difere".
+  (SELECT p.prosrc LIKE '%CASE WHEN v_pode_num THEN b.pct END%'
+     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')       AS c8_gate_projecao,
+  (SELECT p.prosrc LIKE '%carteira_visivel_para(b.cid, v_uid)%'
+     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')       AS c9_gate_escopo,
+  (SELECT md5(regexp_replace(p.prosrc, '[[:space:]]+', ' ', 'g'))
+     FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')
+    = '075209b91d13be52c58220f6ddc88521'                                           AS c10_corpo_identico_ao_testado,
+
+  -- ── a dependencia que faz o custo NAO sair do servidor ───────────────────────
+  -- Sem o helper aplicado (#1519), a funcao criaria bem e so quebraria em RUNTIME (plpgsql e
+  -- late-bound) — silenciosamente, atras do hook.
+  (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'private' AND p.proname = 'margem_cliente_agregada') = 1    AS c11_helper_existe;

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **456** custom migrations totais
-- **1571** objetos esperados (criados por estas migrations)
+- **457** custom migrations totais
+- **1572** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 467
+  - `function`: 468
   - `rls_policy`: 392
   - `index`: 238
   - `cron_job`: 164
@@ -3635,6 +3635,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public.tint_gate_revalida` | — |
 | `view` | `public.v_tint_formula_canonica` | — |
+
+### `20260726170000_fu4f_fase3_carteira_margem_faixa.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_carteira_margem_faixa` | — |
 
 ### `20260727120000_tint_fase5_desativa_geracao_legada.sql`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 456
+-- Total de custom migrations: 457
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -472,6 +472,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260726150000', 'margem_cliente_helper_compartilhado', '20260726150000_margem_cliente_helper_compartilhado.sql'),
   ('20260726160000', 'margem_reconciliacao_universo_unico', '20260726160000_margem_reconciliacao_universo_unico.sql'),
   ('20260726160000', 'tint_canonica_piso_legado', '20260726160000_tint_canonica_piso_legado.sql'),
+  ('20260726170000', 'fu4f_fase3_carteira_margem_faixa', '20260726170000_fu4f_fase3_carteira_margem_faixa.sql'),
   ('20260727120000', 'tint_fase5_desativa_geracao_legada', '20260727120000_tint_fase5_desativa_geracao_legada.sql'),
   ('20260727130000', 'farmer_scores_colunas_orfas_null', '20260727130000_farmer_scores_colunas_orfas_null.sql'),
   ('20260727140000', 'authz_preco_fecha_omie_products', '20260727140000_authz_preco_fecha_omie_products.sql'),
@@ -1985,6 +1986,7 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('margem_reconciliacao_universo_unico', 'function', 'public', 'get_customer_margin_summary', ''),
   ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
+  ('fu4f_fase3_carteira_margem_faixa', 'function', 'public', 'get_carteira_margem_faixa', ''),
   ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('authz_preco_fecha_omie_products', 'rls_policy', 'public', 'omie_products_select_staff', 'omie_products'),
   ('tint_watchdog_corante_impagavel', 'function', 'public', 'tint_watchdog_corante_check', ''),
@@ -3593,6 +3595,7 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('margem_reconciliacao_universo_unico', 'function', 'public', 'get_customer_margin_summary', ''),
   ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
+  ('fu4f_fase3_carteira_margem_faixa', 'function', 'public', 'get_carteira_margem_faixa', ''),
   ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('authz_preco_fecha_omie_products', 'rls_policy', 'public', 'omie_products_select_staff', 'omie_products'),
   ('tint_watchdog_corante_impagavel', 'function', 'public', 'tint_watchdog_corante_check', ''),

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -189,9 +189,14 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   //     policy `fcs_select_carteira` de farmer_client_scores; sem carteira ⇒ zero linhas;
   //   · PROJEÇÃO (qual campo): `CASE WHEN v_pode_num THEN b.pct END` — sem `cap_custo_ler` o
   //     NÚMERO vem NULL, mas a FAIXA e o `g` saem sempre ("o número fecha, o sinal fica").
-  // Ambos provados em db/test-fu4f-fase3-carteira-margem-faixa.sh: E1-E5 (escopo), F1-F5
-  // (projeção), com as falsificações K4 (remove o WHERE → E1/E2/E3 vermelhos) e K2 (remove o
-  // CASE → F2 vermelho). Fail-closed sem `auth.uid()` provado em E5.
+  // Ambos provados em db/test-fu4f-fase3-carteira-margem-faixa.sh (32 asserts): E1-E5b
+  // (escopo), F1-F5 (projeção), G1-G4 (classificação), H1-H5 (a régua populacional e o `g`
+  // NULL≠0), I1-I4 (ACL). Fail-closed sem `auth.uid()` em E5/E5b.
+  // As falsificações K1-K5 sabotam a migration por `sed` cirúrgico e exigem o VERMELHO do
+  // assert que cada uma mira — K1 o fail-closed (E5b), K2 o CASE de projeção (F2), K3 a régua
+  // populacional (H1), K4 o WHERE de escopo (E1), K5 o `g` NULL virando 0 (H5); K6 é o canário
+  // que prova que a migration íntegra voltou. `sed` que não casa nada FALHA o harness, em vez
+  // de deixá-lo verde com uma sabotagem que nunca aconteceu.
   'public.get_carteira_margem_faixa',
 ]);
 

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -178,6 +178,21 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // Provado em db/test-margem-cliente-helper-compartilhado.sh (L1-L5): anon/authenticated/PUBLIC
   // com has_function_privilege=f, service_role=t, e a função residindo em `private`.
   'private.margem_cliente_agregada',
+
+  // 2026-07-22 — FU4-F fase 3. TERCEIRA CATEGORIA (gate de FILTRO/PROJEÇÃO; ver cabeçalho).
+  // ⚠️ O parser não a flagou sozinha: o corpo não cita `product_costs`/`cost_price`, porque ela
+  // deriva de `private.margem_cliente_agregada()`. É um PONTO CEGO do detector — função
+  // cost-derived VIA HELPER passa despercebida —, então está aqui por registro manual, não por
+  // varredura. Ela É sensível (margem por cliente ⇒ custo agregado) e É executável por
+  // `authenticated` (o vendedor no browser). O gate é duplo e nenhum dos dois é RAISE:
+  //   · ESCOPO (quais linhas): `WHERE v_cap_todo OR carteira_visivel_para(cid, uid)` — espelha a
+  //     policy `fcs_select_carteira` de farmer_client_scores; sem carteira ⇒ zero linhas;
+  //   · PROJEÇÃO (qual campo): `CASE WHEN v_pode_num THEN b.pct END` — sem `cap_custo_ler` o
+  //     NÚMERO vem NULL, mas a FAIXA e o `g` saem sempre ("o número fecha, o sinal fica").
+  // Ambos provados em db/test-fu4f-fase3-carteira-margem-faixa.sh: E1-E5 (escopo), F1-F5
+  // (projeção), com as falsificações K4 (remove o WHERE → E1/E2/E3 vermelhos) e K2 (remove o
+  // CASE → F2 vermelho). Fail-closed sem `auth.uid()` provado em E5.
+  'public.get_carteira_margem_faixa',
 ]);
 
 /** chave de lookup a partir de schema+name (case-insensitive, sem assinatura) */

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -196,7 +196,22 @@ export const useFarmerScoring = (farmerId?: string) => {
       // `g` vem PRONTO do servidor, com a mesma régua de percentis (p10/p90 sobre a POPULAÇÃO)
       // que este arquivo usava. Não é preciosismo: derivar `g` da faixa (verde/amarelo/vermelho
       // → 1/0,5/0) mudaria o health score de 68% dos clientes com margem — 5,73 pontos em média,
-      // 14,42 no pior caso (medido em prod, 2026-07-22). O score fica idêntico.
+      // 14,42 no pior caso (medido em prod, 2026-07-22).
+      //
+      // ⚠️ A RÉGUA é a mesma, mas O SCORE MUDA — e o cabeçalho da migration ainda diz que não
+      // (ficou otimista; o arquivo é imutável depois de commitado). Medido em prod 2026-08-13,
+      // são DOIS deltas conhecidos, ambos consequência de a margem passar a vir da autoridade
+      // única do #1519 em vez de ser recalculada aqui:
+      //   1. UNIVERSO DE PEDIDOS. Este hook filtra por allowlist de status (e duas das três —
+      //      `confirmado`, `entregue` — têm ZERO linhas em prod); o helper filtra por denylist.
+      //      30.833 pedidos contra 20.597: ~50% a mais alimentando a margem.
+      //   2. ESCOPO. `sales_orders` é company-wide para staff (policy `sales_orders_select_staff`),
+      //      mas a RPC devolve só a carteira do caller. Para um VENDEDOR, cliente fora da carteira
+      //      cai no `?? null` abaixo e perde o componente G — o `calcularHealthScore` renormaliza,
+      //      então o score dele muda (não penaliza, mas muda) e a ordem da agenda pode mudar
+      //      junto. Para gestor/master (`cap_carteira_ler`) não há delta: a RPC devolve tudo.
+      // O baseline de paridade TS×SQL da §5.1 do spec — que mediria exatamente estes dois — não
+      // foi feito. Está declarado no corpo do PR em vez de anunciado como equivalência.
       //
       // `margem_pct` só vem preenchido para quem tem `cap_custo_ler`; para os demais é null e a
       // UI mostra a FAIXA no lugar do número. O gate é de PROJEÇÃO, no corpo da RPC.

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -2,14 +2,13 @@ import { useState, useEffect, useMemo, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { Tables } from '@/integrations/supabase/types';
-import { custoCanonico } from '@/lib/custo/custoCanonico';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 import { fetchAllPages } from '@/lib/postgrest';
-import { accumulateMarginFromItems, resolveProductIdsFromItems } from '@/lib/scoring/margin';
+import { resolveProductIdsFromItems } from '@/lib/scoring/margin';
 import { calcularHealthScore } from '@/lib/scoring/healthScore';
+import type { FaixaMargem } from '@/lib/scoring/faixaMargem';
 
 type AlgorithmConfigRow = Pick<Tables<'farmer_algorithm_config'>, 'key' | 'value'>;
-type ProductCostRow = Pick<Tables<'product_costs'>, 'product_id' | 'cost_price' | 'cost_final'>;
 type FarmerCallRow = Pick<
   Tables<'farmer_calls'>,
   'customer_user_id' | 'call_result' | 'is_whatsapp' | 'whatsapp_replied' | 'created_at'
@@ -60,8 +59,10 @@ export interface ClientScore {
   daysSinceLastPurchase: number;
   avgRepurchaseInterval: number;
   avgMonthlySpend180d: number;
-  /** PERCENTUAL (0–100, negativo válido). `null` = não apurada. */
+  /** PERCENTUAL (0–100, negativo válido). `null` = não apurada OU sem `cap_custo_ler`. */
   grossMarginPct: number | null;
+  /** O SINAL, sempre presente — substitui o número para quem não pode ver custo. */
+  margemFaixa: FaixaMargem;
   categoryCount: number;
   answerRate60d: number;
   whatsappReplyRate60d: number;
@@ -185,22 +186,46 @@ export const useFarmerScoring = (farmerId?: string) => {
       );
       const flaggeds = new Set<string>(flaggedRows.map((r) => r.user_id));
 
-      // 2. Load product costs for margin calculation (paginado: 3.637 linhas > capa de 1.000)
-      const productCosts = await fetchAllPages<ProductCostRow>((de, ate) =>
-        supabase
-          .from('product_costs')
-          .select('product_id, cost_final, cost_price')
-          .order('product_id', { ascending: true })
-          .range(de, ate) as unknown as PromiseLike<{ data: ProductCostRow[] | null; error: unknown }>,
-        'product_costs/scoring',
-      );
-      const costMap = new Map<string, number>();
-      // Custo canônico = cost_final (proxy-aware); cost_price agora é nullable (só custo real).
-      // Number(null)===0 inflava a margem (ausente≠zero) — excluir SKU sem custo, não fabricar 0.
-      productCosts.forEach((pc) => {
-        const c = custoCanonico(pc);
-        if (c != null) costMap.set(pc.product_id, c);
-      });
+      // 2. Faixa de margem + componente G, vindos do SERVIDOR (FU4-F fase 3).
+      //
+      // Antes, este bloco baixava `product_costs` INTEIRA para o browser — 3.637 linhas de
+      // cost_final/cost_price, paginadas de propósito para furar a capa de 1.000 do PostgREST —
+      // e a margem por cliente era calculada aqui em memória. Era a maior via browser→custo
+      // aberta do app. Agora a RPC lê o custo no servidor e devolve só o SINAL.
+      //
+      // `g` vem PRONTO do servidor, com a mesma régua de percentis (p10/p90 sobre a POPULAÇÃO)
+      // que este arquivo usava. Não é preciosismo: derivar `g` da faixa (verde/amarelo/vermelho
+      // → 1/0,5/0) mudaria o health score de 68% dos clientes com margem — 5,73 pontos em média,
+      // 14,42 no pior caso (medido em prod, 2026-07-22). O score fica idêntico.
+      //
+      // `margem_pct` só vem preenchido para quem tem `cap_custo_ler`; para os demais é null e a
+      // UI mostra a FAIXA no lugar do número. O gate é de PROJEÇÃO, no corpo da RPC.
+      const { data: faixasData, error: faixasErr } = await supabase.rpc('get_carteira_margem_faixa');
+      // FAIL-CLOSED (money-path): sem a faixa, ABORTA. Seguir com o mapa vazio pontuaria toda a
+      // carteira como "sem margem conhecida" — um veredito inventado que o vendedor leria como
+      // dado. Ausente ≠ zero vale também para a falha de transporte.
+      //
+      // O `throw` cai no catch, que DECLARA a falha (`setErro`/`mensagemDeErro`) e preserva o
+      // último estado bom — os setters de sucesso não rodam. Um `return` silencioso aqui seria a
+      // regressão do #1550/#1697: a falha vira tela sem aviso, e `console.error` não é canal de
+      // usuário. `mensagemDeErro` existe exatamente para este erro: o do `supabase.rpc()` sem
+      // `.throwOnError()` é objeto PLANO, que o idiom `instanceof Error` transformaria em
+      // "[object Object]".
+      if (faixasErr) throw faixasErr;
+      // `data: null` sem `error` é resposta MALFORMADA, não carteira vazia (classe do #1581).
+      // O `?? []` que estava aqui mudava a faixa de TODO cliente para `neutro` em silêncio — o
+      // veredito fabricado que este bloco existe para impedir, entrando pela porta dos fundos.
+      if (faixasData == null) {
+        throw new Error('get_carteira_margem_faixa devolveu data null sem error');
+      }
+      const margemPorCliente = new Map<string, { faixa: FaixaMargem; g: number | null; pct: number | null }>();
+      for (const linha of faixasData) {
+        margemPorCliente.set(linha.customer_user_id, {
+          faixa: linha.faixa as FaixaMargem,
+          g: linha.g == null ? null : Number(linha.g),
+          pct: linha.margem_pct == null ? null : Number(linha.margem_pct),
+        });
+      }
 
       // 2b. Mapa omie_codigo_produto → UUID. Os itens de pedido em produção são pt-BR e trazem
       // `omie_codigo_produto`, não `product_id` — sem este mapa, TODO item era descartado e os
@@ -245,8 +270,6 @@ export const useFarmerScoring = (farmerId?: string) => {
         orderDates: number[];
         totalSpend: number;
         spend180d: number;
-        totalRevenue: number;
-        totalCost: number;
         categories: Set<string>;
         calls60d: number;
         contactSuccess60d: number;
@@ -263,7 +286,7 @@ export const useFarmerScoring = (farmerId?: string) => {
         if (!customerMap.has(cid)) {
           customerMap.set(cid, {
             orderDates: [], totalSpend: 0, spend180d: 0,
-            totalRevenue: 0, totalCost: 0, categories: new Set(),
+            categories: new Set(),
             calls60d: 0, contactSuccess60d: 0,
             whatsappCalls60d: 0, whatsappReplied60d: 0,
             lastContactDate: 0,
@@ -284,11 +307,9 @@ export const useFarmerScoring = (farmerId?: string) => {
         for (const pid of resolveProductIdsFromItems(items, omieToProductId)) {
           cd.categories.add(pid);
         }
-        // Margem só sobre SKU com custo CONHECIDO (custo ausente não vira 0 — inflaria a
-        // margem; ausente ≠ zero). Alinhado ao filtro do costMap acima (~linha 176).
-        const { revenue, cost } = accumulateMarginFromItems(items, costMap, omieToProductId);
-        cd.totalRevenue += revenue;
-        cd.totalCost += cost;
+        // A margem NÃO é mais acumulada aqui — vem pronta da RPC (fase 3). O laço acima
+        // continua porque `categories` alimenta o componente X (diversidade de mix), que não
+        // depende de custo.
       }
 
       // Aggregate call data
@@ -311,20 +332,15 @@ export const useFarmerScoring = (farmerId?: string) => {
 
       // 6. Compute population-level stats for normalization
       const allMonthlySpends: number[] = [];
-      const allMargins: number[] = [];
 
       customerMap.forEach(cd => {
         const months = Math.max(1, 6); // 180d
         allMonthlySpends.push(cd.spend180d / months);
-        if (cd.totalRevenue > 0) {
-          allMargins.push((cd.totalRevenue - cd.totalCost) / cd.totalRevenue);
-        }
       });
 
       const p95MonthlySpend = percentile(allMonthlySpends, 95) || 1;
-      const p10Margin = percentile(allMargins, 10);
-      const p90Margin = percentile(allMargins, 90);
-      const marginRange = Math.max(p90Margin - p10Margin, 0.01);
+      // A régua de percentis da MARGEM (p10/p90) mudou-se para o servidor junto com o custo —
+      // `get_carteira_margem_faixa` a calcula sobre a população inteira e devolve `g` pronto.
 
       // 7. Calculate scores per client
       const scores: ClientScore[] = [];
@@ -356,14 +372,11 @@ export const useFarmerScoring = (farmerId?: string) => {
         const avgMonthly = cd.spend180d / 6;
         const m = clamp(Math.log(1 + avgMonthly) / Math.log(1 + p95MonthlySpend), 0, 1);
 
-        // G = clamp((GrossMarginClient - P10Margin) / (P90Margin - P10Margin), 0, 1)
-        // Receita 0 = NENHUM item deste cliente tem custo conhecido (accumulateMarginFromItems
-        // já descarta SKU sem custo) → margem DESCONHECIDA, não zero. O `: 0` anterior era
-        // incoerente com a régua construída logo acima: o laço que monta `allMargins` (~l.308)
-        // exclui justamente os clientes de receita 0 do cálculo dos percentis. O código já
-        // sabia que receita 0 não é margem 0 — só não aplicava isso ao próprio cliente.
-        const clientMargin = cd.totalRevenue > 0 ? (cd.totalRevenue - cd.totalCost) / cd.totalRevenue : null;
-        const g = clientMargin == null ? null : clamp((clientMargin - p10Margin) / marginRange, 0, 1);
+        // G e margem vêm do servidor (fase 3). `neutro`/sem linha ⇒ g e pct null: o
+        // calcularHealthScore RENORMALIZA os pesos, então margem desconhecida não penaliza.
+        // Cliente ausente do mapa = fora do escopo da RPC ou sem custo apurável — mesmo efeito.
+        const mf = margemPorCliente.get(cid);
+        const g = mf?.g ?? null;
 
         // X = clamp(CatCount / CatTarget, 0, 1)
         const x = clamp(cd.categories.size / config.cat_target, 0, 1);
@@ -427,7 +440,9 @@ export const useFarmerScoring = (farmerId?: string) => {
           avgRepurchaseInterval: Math.round(I * 10) / 10,
           avgMonthlySpend180d: Math.round(avgMonthly * 100) / 100,
           // null preservado até a UI: Math.round(null) é 0 e reintroduziria "0,0% de margem".
-          grossMarginPct: clientMargin == null ? null : Math.round(clientMargin * 1000) / 10,
+          // Sem cap_custo_ler a RPC devolve null aqui de propósito — o número fecha, o sinal fica.
+          grossMarginPct: mf?.pct ?? null,
+          margemFaixa: mf?.faixa ?? 'neutro',
           categoryCount: cd.categories.size,
           answerRate60d: Math.round(answerRate * 1000) / 10,
           whatsappReplyRate60d: Math.round(whatsappRate * 1000) / 10,

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -19121,6 +19121,16 @@ export type Database = {
           valor_total_ciclo: number
         }[]
       }
+      get_carteira_margem_faixa: {
+        Args: never
+        Returns: {
+          customer_user_id: string
+          faixa: string
+          g: number | null
+          margem_pct: number | null
+          motivo: string
+        }[]
+      }
       get_carteira_saude: { Args: never; Returns: Json }
       get_commercial_role: {
         Args: { _user_id: string }

--- a/src/lib/modulos/fronteiras-baseline.ts
+++ b/src/lib/modulos/fronteiras-baseline.ts
@@ -144,7 +144,6 @@ export const FRONTEIRAS_BASELINE: Aresta[] = [
   { de: "src/hooks/useCustomerProcess.ts", para: "src/hooks/useReindexRag.ts", deModulo: "admin-crm", paraModulo: "knowledge-base", kind: "runtime" },
   { de: "src/hooks/useDefasagemCliente.ts", para: "src/hooks/usePrecoCockpit.ts", deModulo: "farmer-inteligencia", paraModulo: "vendas", kind: "runtime" },
   { de: "src/hooks/useDefasagemCliente.ts", para: "src/lib/preco/defasagem.ts", deModulo: "farmer-inteligencia", paraModulo: "vendas", kind: "type" },
-  { de: "src/hooks/useFarmerScoring.ts", para: "src/lib/custo/custoCanonico.ts", deModulo: "farmer-inteligencia", paraModulo: "reposicao", kind: "runtime" },
   { de: "src/hooks/useFilaAcoes.ts", para: "src/hooks/useTarefas.ts", deModulo: "farmer-inteligencia", paraModulo: "tarefas", kind: "runtime" },
   { de: "src/hooks/useFilaAcoes.ts", para: "src/hooks/useWhatsappPendentes.ts", deModulo: "farmer-inteligencia", paraModulo: "telefonia-whatsapp-rota", kind: "runtime" },
   { de: "src/hooks/useFilaAcoes.ts", para: "src/queries/useRouteContactList.ts", deModulo: "farmer-inteligencia", paraModulo: "telefonia-whatsapp-rota", kind: "runtime" },

--- a/src/lib/scoring/faixaMargem.ts
+++ b/src/lib/scoring/faixaMargem.ts
@@ -1,0 +1,38 @@
+/**
+ * Faixa de margem do cliente — vocabulário herdado de `get_preco_cockpit` (FU4-F).
+ *
+ * É o SUBSTITUTO do número para quem não tem `cap_custo_ler`: a vendedora deixa de ver
+ * "margem 23,4%" e passa a ver "abaixo do piso". Decisão de produto (dono, 2026-07-20):
+ * o NÚMERO de custo fecha, o SINAL fica.
+ *
+ * Produzido por `public.get_carteira_margem_faixa()`; o front só classifica a cor.
+ *
+ * ⚠️ NÃO existe um `gDaFaixa()` aqui, e a ausência é deliberada. A versão inicial do plano
+ * mapeava faixa → componente G (verde/amarelo/vermelho → 1/0,5/0). Medido sobre a prod, isso
+ * descartaria a régua de percentis e mudaria o health score de 68% dos clientes com margem
+ * (5,73 pontos em média, 14,42 no pior caso) — uma mudança de PRODUTO embutida numa entrega de
+ * AUTORIZAÇÃO. O `g` passou a vir calculado do servidor, com a mesma régua de sempre.
+ */
+export type FaixaMargem = 'verde' | 'amarelo' | 'vermelho' | 'neutro';
+
+/**
+ * Rótulo exibível de cada faixa.
+ *
+ * `neutro` NÃO é uma cor pálida: é a degradação honesta de "não sei". Empurrá-lo para uma cor
+ * fabricaria veredito — margem 0 é um julgamento legítimo ("cliente não-lucrativo") e é
+ * diferente de "nenhum item deste cliente tem custo conhecido".
+ */
+export const FAIXA_LABEL: Record<FaixaMargem, string> = {
+  verde: 'Margem saudável',
+  amarelo: 'Margem abaixo do piso',
+  vermelho: 'Abaixo do custo',
+  neutro: 'Sem custo conhecido',
+};
+
+/** Classe de cor do design system por faixa. `neutro` é neutro de propósito — não é alerta. */
+export const FAIXA_TOM: Record<FaixaMargem, string> = {
+  verde: 'text-status-success',
+  amarelo: 'text-status-warning',
+  vermelho: 'text-status-error',
+  neutro: 'text-muted-foreground',
+};

--- a/src/lib/scoring/faixaMargem.ts
+++ b/src/lib/scoring/faixaMargem.ts
@@ -29,10 +29,10 @@ export const FAIXA_LABEL: Record<FaixaMargem, string> = {
   neutro: 'Sem custo conhecido',
 };
 
-/** Classe de cor do design system por faixa. `neutro` é neutro de propósito — não é alerta. */
-export const FAIXA_TOM: Record<FaixaMargem, string> = {
-  verde: 'text-status-success',
-  amarelo: 'text-status-warning',
-  vermelho: 'text-status-error',
-  neutro: 'text-muted-foreground',
-};
+// NÃO existe um `FAIXA_TOM` (classe de cor por faixa) aqui, e a ausência é deliberada. Ele
+// existiu na primeira versão desta entrega e saiu no rebase: o único consumidor seria o
+// `MetricRow` do FarmerDashboard, que aceita `value: string` — colori-lo exigiria alargar um
+// componente compartilhado, ou seja, mudança de UI embutida numa entrega de AUTORIZAÇÃO (o
+// mesmo erro que o `gDaFaixa` evitou acima). Export sem consumidor também é dead code, e o
+// `knip` é gate do `validate`. Quando a faixa ganhar tratamento visual próprio, a paleta
+// volta junto do componente que a usa.

--- a/src/pages/FarmerDashboard.tsx
+++ b/src/pages/FarmerDashboard.tsx
@@ -19,6 +19,7 @@ import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { CallButton } from '@/components/call/CallButton';
 import { SlaVencidoCard } from '@/components/farmer/SlaVencidoCard';
+import { FAIXA_LABEL } from '@/lib/scoring/faixaMargem';
 import { formatMargemPct } from '@/lib/format';
 
 // ─── Helpers ─────────────────────────────────────────────────────────
@@ -476,7 +477,17 @@ const ClientDetail = ({ client, onBack }: { client: ClientScore; onBack: () => v
           <MetricRow label="Dias sem compra" value={String(client.daysSinceLastPurchase)} />
           <MetricRow label="Intervalo médio recompra" value={`${client.avgRepurchaseInterval.toFixed(0)} dias`} />
           <MetricRow label="Gasto mensal (180d)" value={fmt(client.avgMonthlySpend180d)} />
-          <MetricRow label="Margem bruta" value={formatMargemPct(client.grossMarginPct)} />
+          {/* Quem tem cap_custo_ler vê o número; os demais veem a FAIXA — o sinal fica, o número
+              fecha (FU4-F fase 3). `—` puro só sobraria para quem não pode ver custo, e escondia
+              informação que o vendedor pode e deve ter. */}
+          <MetricRow
+            label="Margem bruta"
+            value={
+              client.grossMarginPct != null
+                ? formatMargemPct(client.grossMarginPct)
+                : FAIXA_LABEL[client.margemFaixa]
+            }
+          />
           <MetricRow label="Categorias compradas" value={String(client.categoryCount)} />
           <MetricRow label="Taxa resposta (60d)" value={`${client.answerRate60d.toFixed(1)}%`} />
           <MetricRow label="WhatsApp reply (60d)" value={`${client.whatsappReplyRate60d.toFixed(1)}%`} />

--- a/src/pages/__tests__/FarmerDashboard.erro-honesto.test.tsx
+++ b/src/pages/__tests__/FarmerDashboard.erro-honesto.test.tsx
@@ -25,6 +25,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 const FARMER_A = 'farmer-a';
 
 let falharScores = false;
+let falharFaixas = false;
 let farmerAtual = FARMER_A;
 
 const ERRO_TIMEOUT = { code: '57014', message: 'canceling statement due to statement timeout' };
@@ -37,6 +38,11 @@ const PEDIDOS = [{
 }];
 const PERFIS = [{ user_id: 'c1', name: 'Cliente Um', phone: null }];
 
+// A margem vem da RPC `get_carteira_margem_faixa` (FU4-F fase 3): o hook não baixa mais
+// `product_costs`. `margem_pct: null` com `faixa` presente é o caller SEM `cap_custo_ler` —
+// o número fecha, o sinal fica.
+const FAIXAS = [{ customer_user_id: 'c1', faixa: 'verde', motivo: 'saudavel', g: 0.8, margem_pct: null }];
+
 function resposta(table: string): unknown {
   if (table === 'sales_orders') {
     if (falharScores) return { data: null, error: ERRO_TIMEOUT };
@@ -44,6 +50,14 @@ function resposta(table: string): unknown {
   }
   if (table === 'profiles') return { data: PERFIS, error: null };
   return { data: [], error: null, count: 0 };
+}
+
+function respostaRpc(fn: string): unknown {
+  if (fn === 'get_carteira_margem_faixa') {
+    if (falharScores || falharFaixas) return { data: null, error: ERRO_TIMEOUT };
+    return { data: FAIXAS, error: null };
+  }
+  return { data: [], error: null };
 }
 
 function chain(table: string): unknown {
@@ -57,7 +71,9 @@ function chain(table: string): unknown {
   return c;
 }
 
-vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: (t: string) => chain(t) } }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => chain(t), rpc: (fn: string) => Promise.resolve(respostaRpc(fn)) },
+}));
 vi.mock('@/contexts/ImpersonationContext', () => ({
   useImpersonation: () => ({ isImpersonating: false, effectiveUserId: farmerAtual }),
 }));
@@ -88,6 +104,7 @@ const renderDashboard = () => {
 
 beforeEach(() => {
   falharScores = false;
+  falharFaixas = false;
   farmerAtual = FARMER_A;
   vi.clearAllMocks();
 });
@@ -121,6 +138,23 @@ describe('FarmerDashboard — falha do scoring não vira "carteira vazia"', () =
       screen.getByRole('button', { name: /Tentar novamente/i }),
       'sem retry o farmer fica preso no estado de erro',
     ).toBeTruthy();
+  });
+
+  it('falha SÓ da margem (RPC) também é erro honesto, não carteira sem margem em silêncio', async () => {
+    // Os pedidos LEEM BEM e só `get_carteira_margem_faixa` cai: o caminho que o rebase do
+    // #1543 quase perdeu. A versão original do PR fazia `console.error` + `return`, e o
+    // `?? []` sobre a resposta pontuava TODA a carteira como "sem custo conhecido" — um
+    // veredito fabricado, indistinguível de medição real, sem nada na tela avisando.
+    falharFaixas = true;
+
+    renderDashboard();
+
+    const aviso = await screen.findByRole('alert');
+    expect(aviso.textContent, 'a falha da margem morreu no console').toMatch(/indispon/i);
+    expect(
+      screen.queryByText(/Nenhum cliente na agenda/i),
+      'afirmou carteira vazia onde a verdade é falha ao ler a margem',
+    ).toBeNull();
   });
 
   it('o retry recarrega de verdade: backend recuperado → agenda aparece', async () => {

--- a/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql
+++ b/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql
@@ -1,0 +1,142 @@
+-- FU4-F fase 3 — o scoring do farmer para de baixar o catálogo de custo.
+--
+-- PROBLEMA: `src/hooks/useFarmerScoring.ts` baixa `product_costs` INTEIRA para o browser —
+-- 3.637 linhas de `cost_final`/`cost_price`, paginadas de propósito para furar a capa de 1.000
+-- do PostgREST — e calcula a margem por cliente em memória. É a maior via browser→custo aberta.
+--
+-- DECISÃO DE PRODUTO (dono, 2026-07-20): o NÚMERO de custo fecha, o SINAL fica.
+--
+-- ── POR QUE ESTA RPC DEVOLVE `g`, E NÃO SÓ A FAIXA (decisão medida, 2026-07-22) ──────────────
+-- O desenho original era devolver só a faixa e o hook mapear verde/amarelo/vermelho → 1/0,5/0.
+-- Medido sobre a prod, isso DESCARTARIA a régua de percentis (p10/p90 da população) que o hook
+-- usa hoje e mudaria o health score de quase todo mundo:
+--     1.069 clientes com margem · peso do G = 0,150
+--     729 deles (68%) teriam `g` alterado em mais de 0,2 (escala 0–1)
+--     delta médio no health score: 5,73 pontos · máximo: 14,42 pontos
+-- Seria uma mudança de PRODUTO embutida numa entrega de AUTORIZAÇÃO. Por isso a RPC calcula `g`
+-- no SERVIDOR com a mesma régua, e o hook passa a consumi-lo em vez de derivá-lo da faixa:
+-- o score fica idêntico e `product_costs` para de ir ao browser.
+--
+-- ⚠️ `g` NÃO é exposição nova: ele já é renderizado hoje na barra "G" do FarmerDashboard
+-- (`:406-429`). O que sai de cena é o CATÁLOGO DE CUSTO UNITÁRIO, que é o alvo da fase.
+--
+-- ── O QUE CADA CAMPO CARREGA ─────────────────────────────────────────────────────────────────
+--   `faixa`/`motivo` — o SINAL, sempre. Vocabulário herdado de `get_preco_cockpit`.
+--   `g`              — o componente de margem normalizado (0..1), sempre. `NULL` quando a margem
+--                      não é apurável — o `calcularHealthScore` (#1533) RENORMALIZA os pesos
+--                      nesse caso, então null não penaliza o cliente. Nunca devolver 0 aqui:
+--                      `g = 0` é veredito ("pior margem da população"), ≠ "não sei".
+--   `margem_pct`     — o NÚMERO, só sob `private.cap_custo_ler`. Gate de PROJEÇÃO: o cálculo
+--                      interno usa o valor real, a SAÍDA esconde. A chave fica presente com
+--                      NULL para o front tolerar.
+--
+-- ── ESCOPO ───────────────────────────────────────────────────────────────────────────────────
+-- Espelha a RLS de `farmer_client_scores` (policy `fcs_select_carteira`):
+--   `cap_carteira_ler(uid)` (gestor/master vê tudo) OR `carteira_visivel_para(cliente, uid)`.
+-- ⚠️ A RÉGUA DE PERCENTIS É CALCULADA SOBRE A POPULAÇÃO INTEIRA, ANTES do filtro de escopo —
+-- de propósito. É o que o hook faz hoje (ele carrega todos os clientes para achar p10/p90) e é o
+-- que mantém `g` COMPARÁVEL entre vendedores: uma régua por carteira faria o mesmo cliente ter
+-- `g` diferente conforme quem pergunta, e o health score deixaria de ser uma medida da BASE.
+-- Isso não vaza: percentil é estatística agregada da população, não dado de cliente alheio.
+--
+-- ⚠️ MIGRATION MANUAL: nome custom não auto-aplica no Lovable. Colar no SQL Editor → Run.
+-- Ordem: DEPOIS de `20260726160000` (consome `private.margem_cliente_agregada`).
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_carteira_margem_faixa()
+RETURNS TABLE (
+  customer_user_id uuid,
+  faixa            text,
+  motivo           text,
+  g                numeric,
+  margem_pct       numeric
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  v_uid      uuid;
+  v_pode_num boolean;
+  v_cap_todo boolean;
+  v_piso     numeric;
+  v_meta     numeric;
+BEGIN
+  -- Atribuição no CORPO, nunca no DECLARE: erro na inicialização de DECLARE não é capturável
+  -- pelo EXCEPTION do próprio bloco e derrubaria a função inteira.
+  v_uid := (SELECT auth.uid());
+
+  -- Fail-closed: sem identidade, zero linhas.
+  IF v_uid IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_pode_num := COALESCE(private.cap_custo_ler(v_uid), false);
+  v_cap_todo := COALESCE(private.cap_carteira_ler(v_uid), false);
+
+  -- Limiares em CONFIG, não em código: mudar a faixa é UPDATE, não deploy.
+  SELECT COALESCE(max(c.value::numeric) FILTER (WHERE c.key = 'margem_faixa_piso_pct'), 30),
+         COALESCE(max(c.value::numeric) FILTER (WHERE c.key = 'margem_faixa_meta_pct'), 50)
+    INTO v_piso, v_meta
+    FROM public.farmer_algorithm_config c
+   WHERE c.key IN ('margem_faixa_piso_pct', 'margem_faixa_meta_pct');
+
+  RETURN QUERY
+  WITH base AS (
+    SELECT m.customer_user_id AS cid, m.margem_pct AS pct
+      FROM private.margem_cliente_agregada() m
+  ),
+  regua AS (
+    -- p10/p90 sobre a POPULAÇÃO INTEIRA (ver nota de escopo acima). `margem_pct` vem em pontos
+    -- percentuais (0–100); o hook trabalha em fração (0–1). Dividir por 100 mantém a régua
+    -- idêntica à dele: a normalização é invariante a escala, mas manter a mesma unidade evita
+    -- que uma futura mudança de limiar leia errado.
+    SELECT percentile_cont(0.10) WITHIN GROUP (ORDER BY b.pct / 100.0)::numeric AS p10,
+           percentile_cont(0.90) WITHIN GROUP (ORDER BY b.pct / 100.0)::numeric AS p90
+      FROM base b
+     WHERE b.pct IS NOT NULL
+  )
+  SELECT
+    b.cid,
+    CASE WHEN b.pct IS NULL   THEN 'neutro'
+         WHEN b.pct < 0       THEN 'vermelho'
+         WHEN b.pct < v_piso  THEN 'amarelo'
+         ELSE                      'verde'   END,
+    CASE WHEN b.pct IS NULL   THEN 'sem_custo'
+         WHEN b.pct < 0       THEN 'abaixo_do_custo'
+         WHEN b.pct < v_piso  THEN 'abaixo_do_piso'
+         WHEN b.pct < v_meta  THEN 'abaixo_da_meta'
+         ELSE                      'saudavel' END,
+    -- `g` com a MESMA régua do hook: clamp((margem - p10) / max(p90 - p10, 0.01), 0, 1).
+    -- NULL quando a margem não é apurável — o calcularHealthScore renormaliza os pesos.
+    CASE WHEN b.pct IS NULL THEN NULL
+         ELSE greatest(0::numeric,
+                least(1::numeric,
+                  (b.pct / 100.0 - r.p10) / greatest(r.p90 - r.p10, 0.01::numeric)))
+    END,
+    -- Gate de PROJEÇÃO: esconde na SAÍDA, não no cálculo.
+    CASE WHEN v_pode_num THEN b.pct END
+  FROM base b CROSS JOIN regua r
+  -- Escopo espelhando fcs_select_carteira. O filtro vem DEPOIS da régua, de propósito.
+  WHERE v_cap_todo
+     OR COALESCE(private.carteira_visivel_para(b.cid, v_uid), false);
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.get_carteira_margem_faixa() IS
+  'FU4-F fase 3: faixa de margem + componente g por cliente da carteira. O custo e lido no '
+  'SERVIDOR (via private.margem_cliente_agregada) e nunca sai; margem_pct so e projetada sob '
+  'private.cap_custo_ler. `g` usa a regua de percentis da POPULACAO, preservando o health score '
+  'do hook byte a byte. Escopo espelha a RLS de farmer_client_scores.';
+
+-- Fechamento por privilégio. Função nova nasce com proacl NULL = EXECUTE implícito a PUBLIC, e o
+-- default privilege do Supabase concede às roles nomeadas — revogar dos DOIS jeitos.
+-- ⚠️ `authenticated` MANTÉM o EXECUTE: é o role do vendedor no browser, e o gate está no CORPO
+-- (escopo por carteira + projeção do número). Revogar aqui quebraria o consumidor legítimo.
+REVOKE ALL ON FUNCTION public.get_carteira_margem_faixa() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_carteira_margem_faixa() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_carteira_margem_faixa() TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
**FU4-F fase 3.** `useFarmerScoring` baixava `product_costs` INTEIRA para o browser — 3.637 linhas
de custo unitário, paginadas de propósito para furar a capa de 1.000 do PostgREST — e calculava a
margem por cliente em memória. Era a maior via browser→custo aberta do app. Agora o custo é lido no
SERVIDOR e só o SINAL sai. Decisão de produto (dono, 2026-07-20): **o número de custo fecha, o
sinal fica.**

Desenho em [`specs/2026-07-20-fechamento-custo-farmer-scoring-design.md`](docs/superpowers/specs/2026-07-20-fechamento-custo-farmer-scoring-design.md)
(#1711), com errata. Consome `private.margem_cliente_agregada` (#1519, já em prod).

---

## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql`. **Lovable não
aplica automaticamente** — mergear NÃO toca o banco. Tem de ser colada no SQL Editor e rodada.

**Ordem acoplada:** migration **antes** do Publish (o front novo depende da RPC). Como este PR não
revoga nada em `product_costs`, não há janela de quebra — o front velho segue funcionando até lá.

Validação pós-apply: [`db/valida-fu4f-fase3-carteira-margem-faixa.sql`](db/valida-fu4f-fase3-carteira-margem-faixa.sql)
— 11 checks que **leem catálogo e nunca invocam** a função (invocar exige EXECUTE e daria
falso-negativo sob a role read-only, lição do #1462).

## O que este PR NÃO fecha — três achados medidos

Levantados por revisão adversarial (Codex `gpt-5.6-sol`, `xhigh`) e **confirmados em prod** via
`psql-ro`. Nenhum é regressão — todos existem hoje em forma pior —, mas precisão>recall exige
declará-los em vez de anunciar o custo "fechado".

**1. O limiar configurável é um oráculo de binary search.** `farmer_algorithm_config` tem policy
`ALL` para `master OR employee` **e** GRANT de UPDATE para `authenticated`. Um employee sem
`cap_custo_ler` pode mover `margem_faixa_piso_pct`, reler a faixa e recuperar a margem exata em
~13 iterações — e daí o custo, já que ele vê a receita. Isso **derrota o gate de projeção**. Hoje o
mesmo employee baixa o catálogo inteiro num request, então o PR ainda reduz muito a exposição; mas
a via continua aberta e o conserto (fechar a escrita da config para não-master) é outra entrega,
com risco próprio de quebrar quem ajusta os pesos do algoritmo.

**2. O score MUDA — a régua é a mesma, o universo não.** O cabeçalho da migration diz que o score
fica idêntico "byte a byte". É falso, e o arquivo é imutável depois de commitado, então a correção
está no comentário do hook. Dois deltas, ambos por a margem passar a vir da autoridade única
do #1519:

| | hook (antes) | helper (agora) |
|---|---|---|
| filtro de status | allowlist `confirmado`/`faturado`/`entregue` | denylist (tudo menos `cancelado`/`rascunho`/`pendente`/`orcamento`) |
| pedidos alcançados | **20.597** | **30.833** (+50%) |

`confirmado` e `entregue` têm **zero** linhas em prod — a allowlist do hook citava status que não
existem. O outro delta é de escopo: `sales_orders` é company-wide para staff, mas a RPC devolve só
a carteira do caller, então para um **vendedor** cliente fora da carteira perde o componente G (o
`calcularHealthScore` renormaliza — não penaliza, mas muda o número e pode mudar a ordem da
agenda). Para gestor/master não há delta.

⚠️ **O harness de paridade TS×SQL da §5.1 do spec não foi feito** — é ele que mediria estes dois
deltas cliente a cliente. Está declarado, não medido.

**3. A lente "Ver como" não impersona a RPC.** `auth.uid()` é sempre o usuário REAL (regra do
repo), então "ver como vendedor" consulta com as capabilities do master. Não é escalada — o master
já é autorizado —, mas a tela apresentada como do vendedor pode mostrar `margem_pct` e a carteira
inteira.

Descartado por medição: sobrecarga maliciosa de `percentile_cont` via `search_path` —
`has_schema_privilege('authenticated','public','CREATE')` é **false**.

## Rebase (193 commits de defasagem)

O commit original é de antes de #1545/#1550/#1581/#1697 — os quatro commits money-path que
endureceram `useFarmerScoring.ts` **na mesma região** que este PR reescreve. Resolver "pegando o
lado do PR" reverteria o fail-closed, que é a classe de acidente que o #1697 já consertou uma vez.
O que mudou em relação ao commit original está no corpo do commit de rebase; em resumo:

- a falha da RPC vira `throw` (→ `catch` → `setErro`/`mensagemDeErro`, que **declara** a falha e
  preserva o último estado bom) no lugar de `console.error` + `return` silencioso;
- `data: null` sem `error` deixa de virar `?? []` — era resposta malformada tratada como carteira
  vazia, e mudava a faixa de **todo** cliente para `neutro` sem aviso (classe do #1581);
- `types.ts` reconstruído sobre a main (15 commits) + só a assinatura da RPC. Regenerar contra a
  prod não a traria: a função ainda não existe lá;
- sai o `FAIXA_TOM`, sem consumidor (knip é gate do `validate`).

## Prova

`db/test-fu4f-fase3-carteira-margem-faixa.sh` — PG17 descartável, aplica as migrations **reais**:

```
34 verde(s), 0 vermelho(s) — exit 0
```

Escopo (E1-E5b) · projeção (F1-F5) · classificação (G1-G4) · régua populacional e `g` NULL≠0
(H1-H5) · ACL (I1-I4) · idempotência (J1-J2). **Falsificações K1-K5**: sabotam a migration por
`sed` cirúrgico e exigem o vermelho do assert que cada uma mira — e um `sed` que não casa nada
falha o harness, em vez de deixá-lo verde com uma sabotagem que nunca aconteceu. K6 é o canário de
restauração; L1/L2 amarram a validação pós-apply ao corpo realmente testado (md5 do `prosrc`) e
provam que os 11 checks dão `t` contra a migration real.

O 5º caso de `FarmerDashboard.erro-honesto.test.tsx` foi **falsificado**: com o `console.error +
return` original ele fica vermelho e os outros quatro seguem verdes.

Gates locais, todos com evidência positiva (`> log 2>&1; echo $?`): `typecheck` 0 · `test` 0 ·
`lint` 0 · `knip` 0 · `shellcheck` 0.
