### PR TITLE
fix(farmer): idempotência do plano tático passa a usar o dia BRT, não o dia UTC

### DIFF
--- a/supabase/functions/_shared/dia-operacional.ts
+++ b/supabase/functions/_shared/dia-operacional.ts
@@ -1,0 +1,33 @@
+// Dia operacional do negócio (BRT), para janelas de idempotência.
+//
+// Lógica PURA extraída para caber no `--no-remote` do `test:edges`.
+// Testes em dia-operacional_test.ts.
+//
+// POR QUE EXISTE — incidente 2026-07-21/22. A idempotência do generate-tactical-plan
+// perguntava "já gerei hoje?" com `created_at >= 00:00 UTC`. Mas o dia de quem usa o
+// sistema é BRT (UTC-3): duas execuções no MESMO dia 21 para o negócio (19:03 e 22:48
+// BRT) caíram em dias UTC diferentes → a trava não pegou → 30 clientes com 2 planos.
+//
+// A janela UTC erra nos DOIS sentidos, não só um:
+//   - run às 22:48 BRT do dia D    → não pula o que gerou às 19:03 → DUPLICATA
+//   - cron às 05:00 BRT do dia D+1 → pula por causa do run da véspera → DIA SEM PLANO
+//
+// É a mesma classe do #1510 (schedule de pg_cron lido como BRT quando é UTC): o fuso
+// entra em silêncio, o CI não vê, e o erro só aparece como dado estranho semanas depois.
+
+/** BRT = UTC−3. Fixo: o Brasil não observa horário de verão desde 2019 (Decreto 9.772/2019). */
+const OFFSET_BRT_MS = 3 * 60 * 60 * 1000;
+
+/**
+ * Instante UTC correspondente a 00:00 BRT do dia operacional que contém `agora`.
+ *
+ * Serve como limite inferior de janelas "já fiz isso hoje?" — use com `>=`.
+ * `agora` é parâmetro (não Date.now() interno) para o comportamento ser testável
+ * sem depender do relógio da máquina.
+ */
+export function inicioDiaOperacional(agora: Date): string {
+  // Desloca para o "calendário BRT", trunca no dia, e volta para UTC.
+  const emBrt = new Date(agora.getTime() - OFFSET_BRT_MS);
+  const diaBrt = emBrt.toISOString().slice(0, 10); // YYYY-MM-DD no calendário BRT
+  return new Date(new Date(`${diaBrt}T00:00:00Z`).getTime() + OFFSET_BRT_MS).toISOString();
+}

--- a/supabase/functions/_shared/dia-operacional_test.ts
+++ b/supabase/functions/_shared/dia-operacional_test.ts
@@ -1,0 +1,99 @@
+// Testa o CÓDIGO REAL de dia-operacional.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/dia-operacional_test.ts
+//
+// POR QUE EXISTE — incidente 2026-07-21/22. A idempotência do generate-tactical-plan
+// usava `created_at >= 00:00 UTC`, mas o dia operacional das vendedoras é BRT (UTC-3).
+// Duas execuções do batch no MESMO dia 21 para o negócio (19:03 e 22:48 BRT) caíram em
+// dias UTC diferentes (21 e 22) → a trava não pegou → 30 clientes ficaram com 2 planos.
+//
+// A janela UTC erra nos DOIS sentidos:
+//   - run manual às 22:48 BRT      → NÃO pula (deveria) → duplicata
+//   - cron às 05:00 BRT do dia D+1 → pula (não deveria) → dia sem plano
+//
+// `agora` é injetado: teste de fuso com relógio real é não-determinístico, e
+// Date.now() varia entre a máquina de quem escreve e o CI.
+import { inicioDiaOperacional } from "./dia-operacional.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (a !== b) throw new Error(msg ?? `esperava ${JSON.stringify(b)}, veio ${JSON.stringify(a)}`);
+}
+
+Deno.test("00:00 BRT corresponde a 03:00 UTC do mesmo dia", () => {
+  // meio-dia BRT do dia 21 = 15:00Z do dia 21
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-07-21T15:00:00Z")),
+    "2026-07-21T03:00:00.000Z",
+  );
+});
+
+Deno.test("22:48 BRT do dia 21 (= 01:48Z do dia 22) ainda é o dia operacional 21", () => {
+  // O caso EXATO do incidente: em UTC já virou dia 22, para o negócio ainda é 21.
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-07-22T01:48:00Z")),
+    "2026-07-21T03:00:00.000Z",
+  );
+});
+
+Deno.test("05:00 BRT do dia 22 (= 08:00Z, horário do cron) é o dia operacional 22", () => {
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-07-22T08:00:00Z")),
+    "2026-07-22T03:00:00.000Z",
+  );
+});
+
+Deno.test("exatamente 00:00 BRT é o início do próprio dia (borda inclusiva)", () => {
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-07-21T03:00:00Z")),
+    "2026-07-21T03:00:00.000Z",
+  );
+});
+
+Deno.test("um segundo ANTES de 00:00 BRT ainda pertence ao dia anterior", () => {
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-07-21T02:59:59Z")),
+    "2026-07-20T03:00:00.000Z",
+  );
+});
+
+Deno.test("23:59 BRT continua no mesmo dia operacional", () => {
+  // 23:59 BRT do dia 21 = 02:59Z do dia 22
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-07-22T02:59:00Z")),
+    "2026-07-21T03:00:00.000Z",
+  );
+});
+
+Deno.test("vira o mês corretamente", () => {
+  // 22:00 BRT de 31/07 = 01:00Z de 01/08
+  assertEquals(
+    inicioDiaOperacional(new Date("2026-08-01T01:00:00Z")),
+    "2026-07-31T03:00:00.000Z",
+  );
+});
+
+Deno.test("vira o ANO corretamente", () => {
+  // 22:00 BRT de 31/12/2026 = 01:00Z de 01/01/2027
+  assertEquals(
+    inicioDiaOperacional(new Date("2027-01-01T01:00:00Z")),
+    "2026-12-31T03:00:00.000Z",
+  );
+});
+
+// ── A invariante que o incidente exigiu ──────────────────────────────────────
+
+Deno.test("os DOIS runs do incidente caem no mesmo dia operacional", () => {
+  // Run 1: 2026-07-21T22:03Z = 19:03 BRT · Run 2: 2026-07-22T01:48Z = 22:48 BRT
+  // Sob a janela UTC antiga davam dias diferentes → 30 duplicatas.
+  const run1 = inicioDiaOperacional(new Date("2026-07-21T22:03:00Z"));
+  const run2 = inicioDiaOperacional(new Date("2026-07-22T01:48:00Z"));
+  assertEquals(run1, run2, "runs do mesmo dia BRT precisam compartilhar a janela");
+});
+
+Deno.test("o cron do dia seguinte NÃO herda a janela do dia anterior", () => {
+  // Contrapartida: a janela não pode ser tão larga que o cron de D+1 pule o dia inteiro.
+  const noite21 = inicioDiaOperacional(new Date("2026-07-22T01:48:00Z")); // 22:48 BRT dia 21
+  const cron22 = inicioDiaOperacional(new Date("2026-07-22T08:00:00Z")); // 05:00 BRT dia 22
+  if (noite21 === cron22) {
+    throw new Error("dias operacionais distintos colapsaram — o cron pularia o dia 22");
+  }
+});

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
+import { inicioDiaOperacional } from "../_shared/dia-operacional.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -76,8 +77,11 @@ serve(async (req) => {
       const admin = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!, { auth: { persistSession: false } });
       const { customerId, farmerId } = body;
 
-      // Idempotência: pula se já há plano 'gerado' criado hoje (>= 00:00 UTC).
-      const hojeIso = new Date(new Date().toISOString().slice(0, 10) + 'T00:00:00Z').toISOString();
+      // Idempotência: pula se já há plano 'gerado' no DIA OPERACIONAL (BRT), não no dia UTC.
+      // Era `>= 00:00 UTC` e errava nos DOIS sentidos (incidente 2026-07-21/22, 30 duplicatas):
+      // run às 22:48 BRT não via o das 19:03 do mesmo dia; e o cron das 05:00 BRT do dia
+      // seguinte via o da véspera e pulava o dia inteiro. Ver _shared/dia-operacional.ts.
+      const hojeIso = inicioDiaOperacional(new Date());
       const { data: existente } = await admin.from('farmer_tactical_plans')
         .select('id').eq('farmer_id', farmerId).eq('customer_user_id', customerId)
         .eq('status', 'gerado').gte('created_at', hojeIso).limit(1);


### PR DESCRIPTION
Incidente 2026-07-21/22: **30 clientes ficaram com dois planos do mesmo dia.**

A trava de idempotência perguntava *"já gerei hoje?"* com `created_at >= 00:00 UTC`, mas o dia de quem usa o sistema é **BRT**. Duas execuções do batch no mesmo dia 21 para o negócio (19:03 e 22:48 BRT) caíram em dias **UTC** diferentes — 21 e 22 — e a trava não pegou.

## A janela UTC erra nos dois sentidos

| Cenário | Janela UTC (antes) | Janela BRT (agora) |
|---|---|---|
| Run às 22:48 BRT, mesmo dia | ❌ não vê o das 19:03 → **duplicata** | ✅ pula |
| Cron às 05:00 BRT do dia D+1 | ❌ vê o da véspera → **pula o dia inteiro** | ✅ gera |

O segundo caso ainda não tinha acontecido — mas aconteceria **hoje**: os 58 planos gerados às 01:48Z (22:48 BRT do dia 21) fariam o cron das 08:00Z pular tudo.

É a mesma classe do #1510 (schedule de `pg_cron` lido como BRT quando é UTC): o fuso entra em silêncio, nenhum gate enxerga, e o erro só aparece como dado estranho semanas depois.

## O fix

`inicioDiaOperacional(agora)` vira função **pura** em `_shared/dia-operacional.ts`, testada sob o `--no-remote`.

`agora` é **parâmetro**, não `Date.now()` interno — teste de fuso com relógio real é não-determinístico entre a máquina de quem escreve e o CI.

Offset fixo em **UTC−3**: o Brasil não observa horário de verão desde o Decreto 9.772/2019. Se voltar, a constante é o ponto único de conserto.

## TDD

10 testes escritos **antes**, vistos vermelhos (módulo inexistente), depois verdes.

Cobrem as duas bordas (00:00 BRT exato e um segundo antes), virada de mês e de ano, e as **duas invariantes** que o incidente exigiu:

- os dois runs do incidente precisam **compartilhar** a janela;
- o cron do dia seguinte **não** pode herdá-la (senão troca duplicata por dia vazio).

Falsificados com 4 mutações, todas vermelhas:

| Mutação | Resultado |
|---|---|
| volta ao dia UTC (o bug) | 🔴 |
| offset UTC−2 | 🔴 |
| sinal invertido | 🔴 |
| sem retorno a UTC | 🔴 |

## Gates

| Gate | Exit | Resultado |
|---|---|---|
| `test:edges` | **0** | **217 passed** (era 207) |
| `edges:typecheck` | **0** | 93 edges · 0 crash-class · 142 tolerados (baseline inalterado) |

## ⚠️ Muda comportamento — precisa de deploy manual

Diferente do #1540 (só observabilidade), este PR **altera quando um plano é gerado**. Mergear não deploya: a edge `generate-tactical-plan` precisa ser deployada pelo chat do Lovable, lendo do repo.

As 30 duplicatas já criadas não são removidas por este PR — elas inflam `totalPlans` em `useFarmerPerformance` apenas no período de hoje, e somem sozinhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
