### PR TITLE
fix(farmer): a busca do plano tático não achava NINGUÉM — o `|| 'Cliente'` escondia a falha [money-path]

### DIFF
--- a/src/components/farmer/tacticalPlan/__tests__/carteira-busca-paginacao.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/carteira-busca-paginacao.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * O dropdown "Gerar Plano para QUALQUER Cliente" enxergava 26% da carteira — e chamava o resto
+ * de "Cliente".
+ *
+ * Dois defeitos compostos em `loadCustomers`, medidos em prod (psql-ro, 2026-07-22):
+ *
+ *  1. `farmer_client_scores` era lido single-shot. O PostgREST capa em 1.000 linhas em SILÊNCIO,
+ *     e os três farmers têm 3.858 / 1.528 / 1.246 clientes — todos acima da capa. O cliente na
+ *     posição 1.001 não existia para a busca, num card que promete "qualquer cliente".
+ *
+ *  2. Os nomes vinham de um `.in('user_id', ids)` com TODOS os ids de uma vez: 3.858 UUIDs ≈
+ *     143 KB de query string, contra ~8 KB de teto. A consulta falhava inteira, `data` voltava
+ *     null, o mapa ficava vazio — e o `|| 'Cliente'` convertia a FALHA em mil clientes chamados
+ *     "Cliente". Nenhuma busca por nome real casava, e a tela dizia apenas "Nenhum cliente
+ *     encontrado": o fallback plausível escondeu o erro que ele deveria denunciar.
+ *
+ * O 2º é o que fez o 1º passar despercebido por tanto tempo — com todo mundo chamado "Cliente",
+ * a truncagem era invisível.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const OWNER = '414a9727-ad1d-4998-914e-9c6ccf26cf50';
+const PAGINA = 1000;
+
+const uuid = (n: number) => `${String(n).padStart(8, '0')}-0000-4000-8000-000000000000`;
+
+type Q = { table: string; ranges: Array<[number, number]>; orders: string[]; inIds: string[] };
+let queries: Q[] = [];
+
+/** Carteira maior que uma página: 1.500 clientes ⇒ 2 páginas. */
+const TOTAL = 1500;
+const scoreRow = (n: number) => ({ customer_user_id: uuid(n), health_score: 30, churn_risk: 40 });
+
+/** Simula o 414 (URI Too Long) que o `.in()` gigante provocava. */
+let falhaSeLoteMaiorQue = Infinity;
+
+function result(q: Q): { data: unknown; error: unknown } {
+  if (q.table === 'farmer_client_scores') {
+    const de = q.ranges.at(-1)?.[0] ?? 0;
+    const linhas = [];
+    for (let i = de; i < Math.min(de + PAGINA, TOTAL); i++) linhas.push(scoreRow(i));
+    return { data: linhas, error: null };
+  }
+  if (q.table === 'profiles') {
+    if (q.inIds.length > falhaSeLoteMaiorQue) {
+      return { data: null, error: { message: 'Request-URI Too Large', code: '414' } };
+    }
+    return { data: q.inIds.map((id) => ({ user_id: id, name: `PRIME WOOD ${id.slice(0, 8)}` })), error: null };
+  }
+  return { data: [], error: null };
+}
+
+function chain(table: string): unknown {
+  const q: Q = { table, ranges: [], orders: [], inIds: [] };
+  queries.push(q);
+  const c: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'limit', 'or', 'filter']) c[m] = () => c;
+  c.in = (col: string, ids: string[]) => { if (col === 'user_id') q.inIds = ids; return c; };
+  c.order = (col: string) => { q.orders.push(col); return c; };
+  c.range = (de: number, ate: number) => { q.ranges.push([de, ate]); return c; };
+  c.single = () => c;
+  c.maybeSingle = () => c;
+  c.then = (resolve: (v: unknown) => void) => resolve(result(q));
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => chain(t), rpc: () => Promise.resolve({ data: null, error: null }), functions: { invoke: vi.fn() } },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => ({ isImpersonating: false, effectiveUserId: OWNER }) }));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: OWNER }, isStaff: true }) }));
+vi.mock('@/hooks/useCoverage', () => ({ useMyActiveCoverage: () => ({ data: [] }) }));
+vi.mock('@/hooks/useTacticalPlan', () => ({
+  useTacticalPlan: () => ({
+    plans: [], loading: false, generating: false,
+    loadPlans: vi.fn(), generatePlan: vi.fn(), checkEfficiency: vi.fn(), recordResult: vi.fn(),
+  }),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { useFarmerTacticalPlan } from '../useFarmerTacticalPlan';
+
+describe('carteira do PTPL: paginação + nomes em lote', () => {
+  beforeEach(() => { queries = []; falhaSeLoteMaiorQue = Infinity; });
+
+  it('carrega a carteira INTEIRA, não só a primeira página do PostgREST', async () => {
+    const { result: hook } = renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(hook.current.filteredCustomers.length).toBe(TOTAL));
+    // O tell da versão quebrada: exatamente 1.000 (a capa), não 1.500.
+    expect(hook.current.filteredCustomers.length).not.toBe(PAGINA);
+  });
+
+  it('pagina com ordem TOTAL — priority_score empata em massa e sozinho pula/repete linha', async () => {
+    renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(queries.some((q) => q.table === 'farmer_client_scores' && q.ranges.length)).toBe(true));
+    const scoreQ = queries.filter((q) => q.table === 'farmer_client_scores');
+    expect(scoreQ.every((q) => q.orders.includes('customer_user_id'))).toBe(true);
+  });
+
+  it('busca nomes em LOTES pequenos — nunca um .in() com a carteira toda', async () => {
+    renderHook(() => useFarmerTacticalPlan());
+    await waitFor(() => expect(queries.some((q) => q.table === 'profiles')).toBe(true));
+    const lotes = queries.filter((q) => q.table === 'profiles');
+    expect(lotes.length).toBeGreaterThan(1);
+    for (const l of lotes) expect(l.inIds.length).toBeLessThanOrEqual(200);
+  });
+
+  it('nome REAL chega ao dropdown — o cliente é buscável pelo que o vendedor digita', async () => {
+    const { result: hook } = renderHook(() => useFarmerTacticalPlan());
+    // Espera QUALQUER carga (não `=== TOTAL`): este teste é sobre o NOME, não sobre a paginação.
+    // Amarrá-lo ao total faria a sabotagem da paginação derrubá-lo em cascata, e um vermelho que
+    // não é sobre o que o teste afirma medir não prova nada sobre ele.
+    await waitFor(() => expect(hook.current.filteredCustomers.length).toBeGreaterThan(0));
+    const nomes = hook.current.filteredCustomers.map((c) => c.name);
+    expect(nomes.every((n) => n.startsWith('PRIME WOOD'))).toBe(true);
+    // A regressão exata do bug: todo mundo virando o mesmo rótulo genérico.
+    expect(nomes.filter((n) => n === 'Cliente').length).toBe(0);
+  });
+
+  it('consulta de nomes que FALHA não vira nome fabricado — o rótulo denuncia', async () => {
+    falhaSeLoteMaiorQue = 0; // toda página de profiles falha
+    const { result: hook } = renderHook(() => useFarmerTacticalPlan());
+    // Idem: independente da paginação — o que se mede aqui é o RÓTULO sob falha de consulta.
+    await waitFor(() => expect(hook.current.filteredCustomers.length).toBeGreaterThan(0));
+    const nomes = hook.current.filteredCustomers.map((c) => c.name);
+    // Falha de consulta ≠ ausência de cadastro: o texto separa os dois, e nenhum deles é
+    // um nome plausível que a busca trataria como dado bom.
+    expect(nomes.every((n) => n.startsWith('Nome indisponível'))).toBe(true);
+    expect(nomes.some((n) => n === 'Cliente')).toBe(false);
+  });
+});

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -7,7 +7,12 @@ import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useMyActiveCoverage } from '@/hooks/useCoverage';
 import { useTacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
+import { fetchAllPages } from '@/lib/postgrest';
 import type { FarmerClientScoreRow, ProfileRow, CustomerLite } from './types';
+
+// Lote do `.in()` de profiles. 200 UUIDs ≈ 7,4 KB de query string — abaixo do teto de ~8 KB do
+// PostgREST/proxy, com folga para o resto da URL. Ver o guard em `loadCustomers`.
+const PROFILES_BATCH = 200;
 
 export function useFarmerTacticalPlan() {
   const { user, isStaff } = useAuth();
@@ -40,26 +45,52 @@ export function useFarmerTacticalPlan() {
 
   const loadCustomers = async () => {
     if (!ownerIds.length) return;
-    const { data: scoresData } = await supabase
-      .from('farmer_client_scores')
-      .select('customer_user_id, health_score, churn_risk')
-      .in('farmer_id', ownerIds)
-      .order('priority_score', { ascending: false });
-    const scores = (scoresData ?? []) as FarmerClientScoreRow[];
+    // [GUARD money-path] PAGINADO. A consulta era single-shot e o PostgREST capa em 1.000 linhas
+    // em SILÊNCIO — medido em prod (psql-ro, 2026-07-22): os três farmers têm 3.858, 1.528 e
+    // 1.246 clientes, TODOS acima da capa, então o maior deles só conseguia gerar plano para 26%
+    // da própria carteira. Num card chamado "Gerar Plano para QUALQUER Cliente", o cliente 1.001
+    // simplesmente não existia. Desempate por `customer_user_id` (UNIQUE): `priority_score` tem
+    // empates massivos (centenas de clientes com o mesmo valor) e, sem ordem total, a paginação
+    // pula e repete linha entre páginas.
+    const scores = await fetchAllPages<FarmerClientScoreRow>((de, ate) =>
+      supabase
+        .from('farmer_client_scores')
+        .select('customer_user_id, health_score, churn_risk')
+        .in('farmer_id', ownerIds)
+        .order('priority_score', { ascending: false })
+        .order('customer_user_id', { ascending: true })
+        .range(de, ate));
     if (!scores.length) return;
 
-    const ids = scores.map((s) => s.customer_user_id);
-    const { data: profilesData } = await supabase
-      .from('profiles')
-      .select('user_id, name')
-      .in('user_id', ids);
-    const profiles = (profilesData ?? []) as ProfileRow[];
+    // [GUARD] LOTES. `.in()` com N ids vira query string: 3.858 UUIDs = ~143 KB de URL, contra um
+    // teto de ~8 KB no PostgREST/proxy. A consulta falhava inteira, `data` voltava null, o mapa
+    // ficava vazio — e o `|| 'Cliente'` abaixo transformava a FALHA em 1.000 clientes chamados
+    // "Cliente", indistinguíveis de dado bom. Nenhuma busca por nome real encontrava nada, e o
+    // card parecia apenas "sem resultados". Falha de consulta ≠ ausência de nome (#1524).
+    const profiles: ProfileRow[] = [];
+    let consultaFalhou = false;
+    for (let i = 0; i < scores.length; i += PROFILES_BATCH) {
+      const lote = scores.slice(i, i + PROFILES_BATCH).map((s) => s.customer_user_id);
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('user_id, name')
+        .in('user_id', lote);
+      if (error) consultaFalhou = true;
+      profiles.push(...((data ?? []) as ProfileRow[]));
+    }
 
     const profileMap = new Map(profiles.map((p) => [p.user_id, p.name]));
 
+    // Sem nome, o cliente é INALCANÇÁVEL pela busca (que filtra por `name`), então o rótulo tem
+    // de dizer a verdade em vez de fabricar um nome plausível. Os dois casos são distintos e
+    // ambos reais: perfil legitimamente ausente (aliases fiscais sem `profiles`) × consulta que
+    // falhou. Um sufixo com o id curto mantém a linha identificável e buscável.
+    const semNome = (id: string) =>
+      `${consultaFalhou ? 'Nome indisponível' : 'Cliente sem cadastro'} (${id.slice(0, 8)})`;
+
     setCustomers(scores.map((s) => ({
       id: s.customer_user_id,
-      name: profileMap.get(s.customer_user_id) || 'Cliente',
+      name: profileMap.get(s.customer_user_id) || semNome(s.customer_user_id),
       healthScore: Number(s.health_score || 0),
       churnRisk: Number(s.churn_risk || 0),
     })));


### PR DESCRIPTION
Achado ao tentar provar o deploy do #1498: o founder digitou o nome de um cliente em **"Gerar Plano para QUALQUER Cliente"** e recebeu *"Nenhum cliente encontrado"* — para qualquer nome.

**FRONTEND puro** — sem migration, sem edge. Exige **Publish** no Lovable.

## A causa que explica o sintoma

Os nomes vinham de um `.in('user_id', ids)` com **todos os ids de uma vez**:

| ids | query string | teto PostgREST/proxy |
|---|---|---|
| 1.000 | **~37 KB** | ~8 KB |

A consulta falha inteira, `data` volta `null`, o mapa fica vazio — e o `|| 'Cliente'` convertia a **falha** em mil clientes chamados literalmente `"Cliente"`. Nenhuma busca por nome real casava.

> O fallback plausível escondeu o erro que ele deveria denunciar. Sem o `|| 'Cliente'`, apareceriam nomes vazios e o bug seria óbvio no primeiro uso — em vez disso a tela dizia apenas "sem resultados", que se lê como *"esse cliente não existe"*.

Mesma família do #1524 (*falha de consulta ≠ ausência*), agora no nome em vez da margem.

## O segundo defeito — real, mas de alcance diferente

`farmer_client_scores` era lido single-shot, e o PostgREST capa em 1.000 linhas **em silêncio**. Medido em prod (`psql-ro`, 2026-07-22):

| farmer | carteira | via na busca | invisível |
|---|---|---|---|
| `414a9727` | 3.858 | 1.000 | **2.858 (74%)** |
| `700657a1` | 1.528 | 1.000 | 528 (35%) |
| `33f59dc7` | 1.246 | 1.000 | 246 (20%) |

⚠️ **Sendo preciso sobre o que cada defeito causa:** a capa **não** é o que produziu o sintoma relatado — o cliente testado (PRIME WOOD) está na **posição 507**, dentro da capa, e mesmo assim não era encontrado. Minha hipótese inicial era essa e estava errada; a medição derrubou. A capa é um bug independente que torna 2.858 clientes inalcançáveis para geração de plano.

## Correções

1. **`fetchAllPages` + ordem TOTAL.** `priority_score` empata em massa (centenas no mesmo valor); sem desempate por `customer_user_id` (UNIQUE) a paginação pula e repete linha entre páginas.
2. **Nomes em lotes de 200** (~7,4 KB/URL, com folga sob o teto).
3. **Fallback honesto**, que distingue *perfil legitimamente ausente* (aliases fiscais sem `profiles`) de *consulta falhou*, ambos com id curto para seguirem buscáveis.

## Prova

Baseline verde: **23/23** no módulo. **3 falsificações**, cada uma derrubando só os asserts que mira:

| sabotagem | vermelhos | são os que ela mira? |
|---|---|---|
| volta o `\|\| 'Cliente'` | 1 — *consulta que falha não vira nome fabricado* | ✅ |
| tira os lotes do `.in()` | 1 — *nomes em lotes pequenos* | ✅ |
| tira a paginação | 2 — *carteira inteira* + *ordem total* | ✅ |

**Nota de método:** a 3ª falsificação inicialmente acendeu **4** vermelhos — dois eram cascata, porque dois testes esperavam `length === TOTAL` no `waitFor` e a sabotagem da paginação quebrava justamente isso. Um vermelho que não é sobre o que o teste afirma medir não prova nada sobre ele, então desacoplei os dois (`toBeGreaterThan(0)`) e re-rodei: passou a acender exatamente 2, os corretos.

Gates: `typecheck` 0 · `lint` 0 errors (72 warnings, **idêntico à main**) · `manifesto.gate` 2/2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)