### PR TITLE
fix(kpi): a unidade vira contrato — fração e percentual param de se adivinhar [money-path]

### DIFF
--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -129,11 +129,14 @@ export function Customer360View({
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           <MetricCard icon={DollarSign} label="Gasto mensal" value={fmt(score.avg_monthly_spend_180d)} />
           <MetricCard icon={Activity} label="Score saúde" value={score.health_score.toFixed(0)} />
+          {/* churn_risk é PERCENTUAL 0–100, não fração: prod (2026-07-21) tem 6.632/6.632 linhas
+              acima de 1 (mín. 33, máx. 100, média 96). O `* 100` que estava aqui exibia "9600%",
+              e o limiar `> 0.5` deixava o realce de perigo permanentemente ligado. */}
           <MetricCard
             icon={AlertTriangle}
             label="Risco churn"
-            value={`${(score.churn_risk * 100).toFixed(0)}%`}
-            danger={score.churn_risk > 0.5}
+            value={`${score.churn_risk.toFixed(0)}%`}
+            danger={score.churn_risk > 50}
           />
           <MetricCard icon={Package} label="Categorias" value={String(score.category_count)} />
         </div>

--- a/src/components/customer/CustomerVisitsTab.tsx
+++ b/src/components/customer/CustomerVisitsTab.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from 'lucide-react';
 import { useCustomerVisits } from '@/hooks/useCustomerVisits';
 import { visitResultLabel, resumoVisitas } from '@/lib/visitas/visit-result';
-import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+import { formatBRL, formatarFracaoPct } from '@/components/customer360/format';
 
 const toneClass: Record<string, string> = {
   success: 'text-status-success',
@@ -36,7 +36,7 @@ export function CustomerVisitsTab({ customerId }: { customerId: string }) {
     <div className="space-y-3">
       <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground border-b pb-2">
         <span><strong className="text-foreground">{resumo.total}</strong> visita{resumo.total > 1 ? 's' : ''}</span>
-        <span>Conversão: <strong className="text-foreground">{formatPctMaybe(resumo.taxaConversao)}</strong></span>
+        <span>Conversão: <strong className="text-foreground">{formatarFracaoPct(resumo.taxaConversao)}</strong></span>
         <span>Receita: <strong className="text-foreground">{formatBRL(resumo.receitaTotal)}</strong></span>
       </div>
 

--- a/src/components/customer360/__tests__/format.test.ts
+++ b/src/components/customer360/__tests__/format.test.ts
@@ -1,40 +1,68 @@
 import { describe, it, expect } from 'vitest';
-import { formatPctMaybe } from '../format';
+import { formatarFracaoPct, churnTone } from '../format';
 
 /**
- * `formatPctMaybe` adivinha a unidade (`v > 1 ? v : v * 100`) porque atende chamadores cuja
- * origem é FRAÇÃO — ex.: `MinhasVisitasResultadoCard`, que usa o mesmo `pct` para a largura da
- * barra (`pct * 100`).
+ * Estes dois formatadores nasceram de UMA função que adivinhava a unidade do valor
+ * (`formatPctMaybe`, com `v > 1 ? v : v * 100`). A adivinhação erra sempre que o valor legítimo
+ * cai do outro lado da fronteira — e as duas entradas reais caem em lados OPOSTOS: taxa de
+ * conversão e variação MoM são FRAÇÃO; `farmer_client_scores.churn_risk` é PERCENTUAL.
  *
- * Estes testes fixam onde a heurística ACERTA e onde ela ERRA. O erro não é bug a corrigir aqui:
- * é a razão de margem ter formatador próprio (`formatMargemPct`, em `@/lib/format`). Mudar a
- * heurística para consertar o caso da margem quebraria os chamadores de fração.
+ * Por isso são duas funções com contrato no nome, e não uma com heurística: no call-site,
+ * `formatarFracaoPct(x)` diz qual unidade `x` tem — `formatPctMaybe(x)` não dizia.
  */
-describe('formatPctMaybe', () => {
-  it('trata valor ≤ 1 como fração', () => {
-    expect(formatPctMaybe(0.3)).toBe('30%');
-    expect(formatPctMaybe(0.155)).toBe('15.5%');
+describe('formatarFracaoPct — entrada é FRAÇÃO, sempre × 100', () => {
+  it('converte fração em percentual', () => {
+    expect(formatarFracaoPct(0.3)).toBe('30%');
+    expect(formatarFracaoPct(0.155)).toBe('15.5%');
+    expect(formatarFracaoPct(0)).toBe('0%');
   });
 
-  it('trata valor > 1 como percentual já pronto', () => {
-    expect(formatPctMaybe(53.47)).toBe('53.5%');
+  it('não trunca fração MAIOR que 1 — o bug que motivou o contrato', () => {
+    // `variacaoPct` (lib/dashboard/team-kpis) é (atual−anterior)/anterior: não tem teto.
+    // Sob a heurística antiga tudo acima de 1 caía no ramo "já é percentual" e saía com DUAS
+    // ordens de grandeza a menos.
+    expect(formatarFracaoPct(1)).toBe('100%');
+    expect(formatarFracaoPct(2)).toBe('200%');
+    // Pior caso REAL medido em prod (2026-07-21): colacor no dia 01/07/2026 cresceu 11.553%
+    // sobre o mesmo período de junho, e o tile exibia "115.5%".
+    expect(formatarFracaoPct(115.53)).toBe('11553%');
+  });
+
+  it('preserva o sinal de fração negativa', () => {
+    expect(formatarFracaoPct(-0.25)).toBe('-25%');
+  });
+
+  it('devolve travessão para ausente — nunca 0%', () => {
+    expect(formatarFracaoPct(null)).toBe('—');
+    expect(formatarFracaoPct(undefined)).toBe('—');
+    expect(formatarFracaoPct(NaN)).toBe('—');
+  });
+});
+
+describe('churnTone — entrada é PERCENTUAL 0–100', () => {
+  it('usa o valor como percentual, sem multiplicar', () => {
+    // Faixa real da coluna em prod (2026-07-21): mín. 33, máx. 100, média 96,03.
+    expect(churnTone(96)).toEqual({ label: '96% risco churn', className: 'text-status-error-bold' });
+    expect(churnTone(33)).toEqual({ label: '33% risco churn', className: 'text-status-success-bold' });
+  });
+
+  it('não inverte risco BAIXO em máximo — defesa hoje inerte', () => {
+    // Sob a heurística antiga, 1 não passava no `> 1` e virava "100% risco churn" em VERMELHO:
+    // o menor risco possível exibido como o maior, com o tom de alarme junto. Nenhuma linha em
+    // prod está hoje na faixa 0–1 (0 de 6.632), então isto é defesa do futuro, não correção de
+    // sintoma observado — o produtor pode passar a emitir a faixa baixa sem avisar o consumidor.
+    expect(churnTone(1)).toEqual({ label: '1% risco churn', className: 'text-status-success-bold' });
+    expect(churnTone(0)).toEqual({ label: '0% risco churn', className: 'text-status-success-bold' });
+  });
+
+  it('classifica pelas faixas de atenção', () => {
+    expect(churnTone(70).className).toBe('text-status-error-bold');
+    expect(churnTone(40).className).toBe('text-status-warning-bold');
+    expect(churnTone(39).className).toBe('text-status-success-bold');
   });
 
   it('devolve travessão para ausente', () => {
-    expect(formatPctMaybe(null)).toBe('—');
-    expect(formatPctMaybe(undefined)).toBe('—');
-    expect(formatPctMaybe(NaN)).toBe('—');
-  });
-
-  it('ERRA com percentual NEGATIVO — por isso margem não usa este formatador', () => {
-    // −143,22% é o mínimo real medido em farmer_client_scores. Como não passa no `> 1`, a
-    // heurística o multiplica por 100. Fixado como comportamento CONHECIDO, não como desejado:
-    // quem formata margem deve usar formatMargemPct (@/lib/format), que não adivinha.
-    expect(formatPctMaybe(-143.22)).toBe('-14322%');
-  });
-
-  it('ERRA com percentual menor que 1 — mesma raiz', () => {
-    // Margem real de 0,5% vira "50%".
-    expect(formatPctMaybe(0.5)).toBe('50%');
+    expect(churnTone(null).label).toBe('—');
+    expect(churnTone(NaN).label).toBe('—');
   });
 });

--- a/src/components/customer360/format.ts
+++ b/src/components/customer360/format.ts
@@ -9,16 +9,26 @@ export function formatBRL(v: number | null | undefined): string {
 }
 
 /**
- * Percentual a partir de valor cuja unidade é AMBÍGUA (fração 0–1 ou percentual 0–100), decidida
- * pela heurística `v > 1`. Usado onde a origem é fração — ex.: `MinhasVisitasResultadoCard`.
+ * Percentual a partir de FRAÇÃO (0–1 nominal, SEM teto — 2 é "200%"). Multiplica por 100 sempre.
  *
- * ⚠️ NÃO use para margem: veja `formatMargemPct` em `@/lib/format`. A heurística erra em dois casos que a margem
- * produz de verdade — margem menor que 1% (0,5 vira "50%") e margem NEGATIVA (−143,22, o mínimo
- * medido em prod, não passa no `> 1` e vira "−14322%").
+ * O contrato está no nome porque a unidade não está no tipo: `number` serve tanto a 0,56 quanto a
+ * 56, e só o call-site sabe qual. Substituiu `formatPctMaybe`, que adivinhava pela heurística
+ * `v > 1 ? v : v * 100` — inferência, não contrato, que errava sempre que o valor legítimo caía do
+ * outro lado da fronteira.
+ *
+ * O caso que a heurística quebrava: `variacaoPct` (`@/lib/dashboard/team-kpis`) é
+ * (atual−anterior)/anterior e não tem teto, então toda variação acima de +100% caía no ramo "já é
+ * percentual" e saía com DUAS ordens de grandeza a menos. Medido em prod (2026-07-21) sobre
+ * `sales_orders`, reproduzindo a janela MTD do consumidor: 39 de 971 combinações
+ * mês × dia-do-mês × empresa dos últimos 12 meses excedem 1 — concentradas nos primeiros dias do
+ * mês, quando a base ainda é pequena. Pior caso real: colacor em 01/07/2026 cresceu 11.553% e o
+ * tile exibia "115.5%".
+ *
+ * ⚠️ Para valor JÁ percentual (0–100), use `formatMargemPct` em `@/lib/format`.
  */
-export function formatPctMaybe(v: number | null | undefined): string {
+export function formatarFracaoPct(v: number | null | undefined): string {
   if (v === null || v === undefined || Number.isNaN(v)) return '—';
-  const pct = v > 1 ? v : v * 100;
+  const pct = v * 100;
   // Zero sem decimal ("0%" em vez de "0.0%"); outros valores com 1 decimal só se houver fração.
   if (pct === 0) return '0%';
   const rounded = Math.round(pct);
@@ -124,12 +134,28 @@ export function healthTone(healthClass: string | null, salesHistoryStatus?: stri
   }
 }
 
+/**
+ * Tom + rótulo do risco de churn. `risk` é PERCENTUAL 0–100 — não fração.
+ *
+ * É o que a coluna produz: `farmer_client_scores.churn_risk` medido em prod (2026-07-21) tem
+ * 6.632/6.632 linhas acima de 1 (mín. 33, máx. 100, média 96,03), zero nulos e zero zeros.
+ *
+ * Não adivinha unidade. A heurística anterior (`risk > 1 ? risk : risk * 100`) acertava só porque
+ * o mínimo em prod é 33: um risco de 1% cairia no ramo da fração e viraria "100% risco churn" em
+ * VERMELHO — o menor risco possível exibido como o maior, com o tom de alarme junto. Como nenhuma
+ * linha está hoje na faixa 0–1, isto é DEFESA (o produtor pode passar a emitir a faixa baixa sem
+ * avisar o consumidor), não correção de sintoma observado.
+ *
+ * `NaN` → "—", junto com null/undefined: antes vazava "NaN% risco churn" para a tela.
+ */
 export function churnTone(risk: number | null): { label: string; className: string } {
-  if (risk === null || risk === undefined) return { label: '—', className: 'text-muted-foreground' };
-  const pct = risk > 1 ? risk : risk * 100;
-  if (pct >= 70) return { label: `${pct.toFixed(0)}% risco churn`, className: 'text-status-error-bold' };
-  if (pct >= 40) return { label: `${pct.toFixed(0)}% risco churn`, className: 'text-status-warning-bold' };
-  return { label: `${pct.toFixed(0)}% risco churn`, className: 'text-status-success-bold' };
+  if (risk === null || risk === undefined || Number.isNaN(risk)) {
+    return { label: '—', className: 'text-muted-foreground' };
+  }
+  const label = `${risk.toFixed(0)}% risco churn`;
+  if (risk >= 70) return { label, className: 'text-status-error-bold' };
+  if (risk >= 40) return { label, className: 'text-status-warning-bold' };
+  return { label, className: 'text-status-success-bold' };
 }
 
 export function formatDocument(doc: string): string {

--- a/src/components/dashboard/MinhasVisitasResultadoCard.tsx
+++ b/src/components/dashboard/MinhasVisitasResultadoCard.tsx
@@ -3,7 +3,7 @@ import { Card } from '@/components/ui/card';
 import { useMinhasVisitasResultado } from '@/hooks/useMinhasVisitasResultado';
 import { agruparVisitasPorResultado } from '@/lib/visitas/conversao';
 import { visitResultLabel } from '@/lib/visitas/visit-result';
-import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+import { formatBRL, formatarFracaoPct } from '@/components/customer360/format';
 
 const JANELA_DIAS = 90;
 
@@ -62,7 +62,7 @@ export function MinhasVisitasResultadoCard() {
               <div className="flex items-center justify-between text-xs">
                 <span className={`font-medium ${toneText[r.tone]}`}>{r.emoji} {r.label}</span>
                 <span className="text-muted-foreground">
-                  {b.count} ({formatPctMaybe(b.pct)})
+                  {b.count} ({formatarFracaoPct(b.pct)})
                   {b.revenue > 0 && <span className="text-status-success"> · {formatBRL(b.revenue)}</span>}
                 </span>
               </div>

--- a/src/components/dashboard/TeamKpiTiles.tsx
+++ b/src/components/dashboard/TeamKpiTiles.tsx
@@ -10,7 +10,7 @@ import { Card } from '@/components/ui/card';
 import { Users, Briefcase, CalendarRange, type LucideIcon } from 'lucide-react';
 import { useTeamKpis } from '@/hooks/useTeamKpis';
 import { useCompany } from '@/contexts/CompanyContext';
-import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+import { formatBRL, formatarFracaoPct } from '@/components/customer360/format';
 
 function Tile({ icon: Icon, label, value, sub }: { icon: LucideIcon; label: string; value: string; sub?: ReactNode }) {
   return (
@@ -27,7 +27,7 @@ function Tile({ icon: Icon, label, value, sub }: { icon: LucideIcon; label: stri
 function trendMoM(v: number | null | undefined): ReactNode {
   if (v == null) return null;
   if (v === 0) return <div>= vs mês passado</div>;
-  const pct = formatPctMaybe(Math.abs(v));
+  const pct = formatarFracaoPct(Math.abs(v));
   const seta = v > 0 ? '▲' : '▼';
   const cor = v > 0 ? 'text-status-success' : 'text-status-error';
   return <div className={`${cor} font-medium`}>{seta} {pct} vs mês passado</div>;

--- a/src/components/dashboard/VisitasKpiTiles.tsx
+++ b/src/components/dashboard/VisitasKpiTiles.tsx
@@ -12,7 +12,7 @@ import { useKpisVisita } from '@/hooks/useKpisVisita';
 import { useVisitasAgendadas } from '@/hooks/useVisitasAgendadas';
 import { diasDesde } from '@/lib/visitas/recencia';
 import { hojeISO } from '@/lib/visitas/today';
-import { formatBRL, formatPctMaybe } from '@/components/customer360/format';
+import { formatBRL, formatarFracaoPct } from '@/components/customer360/format';
 
 function Tile({ icon: Icon, label, value, sub }: { icon: LucideIcon; label: string; value: string; sub?: string }) {
   return (
@@ -44,7 +44,7 @@ export function VisitasKpiTiles() {
   const lista = proximas.data ?? [];
   const prox = rotuloProxima(lista[0]?.scheduled_date, hojeISO());
 
-  const conversao = carregando || !kpis ? dash : formatPctMaybe(kpis.taxaConversao);
+  const conversao = carregando || !kpis ? dash : formatarFracaoPct(kpis.taxaConversao);
   const conversaoSub = kpis && kpis.semResultado > 0
     ? `fechados ÷ c/ resultado · ${kpis.semResultado} sem resultado`
     : 'fechados ÷ c/ resultado';

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -59,9 +59,12 @@ export function decodeHtmlEntities(text: string | null | undefined): string {
  * própria `get_customer_margin_summary` (`round(… * 100, 2)`). Enquanto a coluna valia 0 em 100%
  * das linhas, nenhuma divergência de unidade aparecia; com a margem calculada no servidor, aparece.
  *
- * ⚠️ NÃO use `formatPctMaybe` (de components/customer360/format) para margem: a heurística
- * `v > 1 ? v : v * 100` de lá erra em dois casos que a margem produz de verdade — margem abaixo de
- * 1% (0,5 vira "50%") e margem NEGATIVA (−143,22, o mínimo medido em prod, vira "−14322%").
+ * ⚠️ Esta função é a metade PERCENTUAL de um par. A outra é `formatarFracaoPct` (em
+ * components/customer360/format), que recebe FRAÇÃO 0–1 e multiplica por 100. Escolha pela
+ * unidade da origem — as duas juntas substituíram um único formatador que adivinhava
+ * (`formatPctMaybe`, com `v > 1 ? v : v * 100`) e por isso errava nos extremos de ambos os lados:
+ * margem abaixo de 1% virava "50%", margem negativa virava "−14322%", e fração acima de 1 saía
+ * com duas ordens de grandeza a menos.
  *
  * `null` → "—" (não medida), nunca "0%", que afirmaria margem nula apurada.
  */

--- a/src/lib/scoring/__tests__/churn-unidade.test.ts
+++ b/src/lib/scoring/__tests__/churn-unidade.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Guard de REGRESSÃO textual sobre a UNIDADE de `farmer_client_scores.churn_risk`.
+//
+// A coluna é PERCENTUAL 0–100. Medido em prod (2026-07-21): 6.632/6.632 linhas acima de 1,
+// mínimo 33, máximo 100, média 96,03 — zero nulos, zero zeros. Mesmo assim dois consumidores a
+// liam como FRAÇÃO e multiplicavam por 100: `Customer360View` exibia "9600%" e mantinha o realce
+// de perigo (`churn_risk > 0.5`) permanentemente ligado.
+//
+// Por que textual: a unidade não está no tipo. `churn_risk` é `number` de um lado e do outro, e
+// `number * 100` é `number` — o typecheck fica verde em ambas as leituras. Foi assim que as duas
+// convenções opostas conviveram no mesmo código lendo a mesma coluna. Mesma razão do irmão
+// `margem-sem-coacao.test.ts` (também sobre farmer_client_scores).
+//
+// Escopo deliberadamente estreito: só a MULTIPLICAÇÃO da coluna de churn, nos arquivos listados.
+// Quem tem teste unitário próprio (`churnTone`, em customer360/format) não entra aqui — lá o
+// contrato é verificado por comportamento, que é mais forte que texto.
+
+const RAIZ = resolve(__dirname, '../../../..');
+
+/** Consumidores de `churn_risk` sem teste unitário próprio (componente/hook com query no meio). */
+const CONSUMIDORES = [
+  'src/components/adminCustomers/Customer360View.tsx',
+  'src/components/farmer/ClientesAPositivarCard.tsx',
+  'src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts',
+  'src/hooks/useFarmerPerformance.ts',
+];
+
+/** Remove comentários antes de casar: um `* 100` citado em comentário que explica o bug
+ *  produziria falso-vermelho. Mesma lição do #1488 — assert sobre texto mede prosa se não
+ *  normalizar antes. */
+function semComentarios(fonte: string): string {
+  return fonte
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+/** Casa a coluna de churn multiplicada por 100 — a conversão fração→percentual de um valor que
+ *  JÁ é percentual.
+ *
+ *  ⚠️ Ancorado no NOME do campo, não num `* 100` solto: multiplicar por 100 é legítimo em toda
+ *  parte do app, e um predicado que varre a vizinhança reprova código correto e ensina a ignorar
+ *  o vermelho — aí o próximo vermelho, o real, vira ruído (money-path, §"o VALIDADOR mente",
+ *  #1490). Tolera o `?? 0` no meio (`(c.churn_risk ?? 0) * 100`), que é a forma que apareceria
+ *  num refactor. */
+const MULTIPLICACAO = /(?:churn_risk|churnRisk)\s*(?:\?\?\s*[\d.]+\s*)?\)?\s*\*\s*100/;
+
+describe('consumidores de churn_risk não tratam a coluna como fração', () => {
+  it.each(CONSUMIDORES)('%s não multiplica churn_risk por 100', (relativo) => {
+    const fonte = semComentarios(readFileSync(resolve(RAIZ, relativo), 'utf8'));
+    const ofensoras = fonte
+      .split('\n')
+      .map((linha, i) => ({ linha: linha.trim(), n: i + 1 }))
+      .filter(({ linha }) => MULTIPLICACAO.test(linha));
+
+    expect(
+      ofensoras,
+      `churn_risk tratado como fração em ${relativo}:\n` +
+        ofensoras.map((o) => `  linha ${o.n}: ${o.linha}`).join('\n') +
+        '\n\nA coluna é PERCENTUAL 0–100 (prod: mín. 33, máx. 100, média 96). ' +
+        'Multiplicar por 100 exibe "9600%". Para formatar, use churnTone ' +
+        '(@/components/customer360/format), que declara a unidade no contrato.',
+    ).toEqual([]);
+  });
+});
+
+describe('o guard textual tem dente', () => {
+  // Falsificação embutida: se o regex parasse de casar (typo, refactor do padrão), a suíte acima
+  // ficaria verde para sempre e ninguém notaria. Estes casos fixam o que ele detecta.
+  it('detecta as formas que já existiram no código', () => {
+    // A forma exata que estava em Customer360View.tsx:135 antes desta correção.
+    expect(MULTIPLICACAO.test('value={`${(score.churn_risk * 100).toFixed(0)}%`}')).toBe(true);
+    expect(MULTIPLICACAO.test('const pct = s.churn_risk * 100;')).toBe(true);
+    expect(MULTIPLICACAO.test('(c.churn_risk ?? 0) * 100')).toBe(true);
+    expect(MULTIPLICACAO.test('Math.round(churnRisk * 100)')).toBe(true);
+  });
+
+  it('não acusa uso legítimo', () => {
+    expect(MULTIPLICACAO.test('churnTone(s?.churn_risk ?? null)')).toBe(false);
+    expect(MULTIPLICACAO.test('(c.churn_risk ?? 0) >= 60')).toBe(false);
+    expect(MULTIPLICACAO.test('Number(c.churn_risk || 100) < 30')).toBe(false);
+    // Outra coluna multiplicada por 100 é legítima — o guard é da coluna de churn, não do `* 100`.
+    expect(MULTIPLICACAO.test('const share = ratio * 100;')).toBe(false);
+    expect(MULTIPLICACAO.test('score.health_score * 100')).toBe(false);
+  });
+
+  it('ignora multiplicação citada em comentário (senão o próprio aviso vira vermelho)', () => {
+    const fonte = semComentarios('// nunca faça churn_risk * 100 aqui\nconst x = 1;');
+    expect(MULTIPLICACAO.test(fonte)).toBe(false);
+  });
+});

--- a/src/lib/scoring/__tests__/margemAusente.test.ts
+++ b/src/lib/scoring/__tests__/margemAusente.test.ts
@@ -123,8 +123,10 @@ describe('formatMargemPct', () => {
   });
 
   it('formata margem negativa corretamente', () => {
-    // O mínimo real medido em prod. O contraste com formatPctMaybe (que erra aqui, e é por isso
-    // que margem tem formatador próprio) está fixado em components/customer360/__tests__/format.test.ts.
+    // O mínimo real medido em prod. Este caso é a razão de margem ter formatador próprio: o
+    // formatador que adivinhava a unidade (`formatPctMaybe`) exibia "−14322%" aqui. Ele não
+    // existe mais — virou o par explícito formatMargemPct (percentual) / formatarFracaoPct
+    // (fração), cujo contraste está em components/customer360/__tests__/format.test.ts.
     expect(formatMargemPct(-143.22)).toBe('-143.2%');
   });
 });


### PR DESCRIPTION
Follow-up dos #1525/#1533, deixado fora deles por ser outro domínio. Achado inicial do Codex
(gpt-5.6-sol, xhigh); a premissa foi verificada e **medida** aqui antes de agir — e a medição
mudou parte do diagnóstico.

## O problema

`formatPctMaybe` decidia a unidade do valor por heurística:

```ts
const pct = v > 1 ? v : v * 100;   // "se passa de 1, já é percentual"
```

Isso é inferência, não contrato. Erra sempre que o valor legítimo cai do outro lado da fronteira —
e no call-site ninguém sabia qual unidade estava passando, que é exatamente a dúvida que o nome
tinha de eliminar.

## O que a medição em prod mostrou

**1. O bug do KPI de equipe é ATIVO, não teórico.** `variacaoPct` é `(atual−anterior)/anterior` e
não tem teto. Reproduzindo a janela MTD do consumidor sobre `sales_orders` (12 meses × cada
dia-do-mês × escopo de empresa): **39 de 971 combinações excedem 1**, concentradas nos primeiros
dias do mês, quando a base ainda é pequena.

| Mês | Dia | Escopo | Real | Exibido |
|---|---|---|---|---|
| 2026-07 | 1 | colacor | **11.553%** | "115.5%" |
| 2026-06 | 4 | colacor | 10.200% | "102.0%" |
| 2026-06 | 4 | all | 694% | "6.9%" |

O pior caso é deste mês. Erro de duas ordens de grandeza num KPI de gestão.

**2. `churnTone` era o caso INVERSO do suposto.** O Codex sugeriu avaliá-lo como irmão do
problema de fração; `farmer_client_scores.churn_risk` é **percentual 0–100**:

```
linhas 6632 | nulos 0 | zeros 0 | entre_0_e_1 0 | acima_de_1 6632 | mín 33 | máx 100 | média 96,03
```

A heurística acertava só porque o mínimo é 33. Um risco de 1% cairia no ramo da fração e viraria
**"100% risco churn" em vermelho** — o menor risco exibido como o maior, com o alarme junto.
Nenhuma linha está hoje em 0–1, então isto é **defesa, não correção de sintoma** (dito
explicitamente no código, para não passar a impressão falsa de bug eliminado).

**3. Achado fora do escopo original, incluído com aprovação:** `Customer360View.tsx:135` lia a
**mesma coluna** como fração — `(score.churn_risk * 100)` — exibindo **"9600%"** com a média de 96,
e `danger={churn_risk > 0.5}` deixava o realce de perigo permanentemente ligado. Bug ativo em
6.632/6.632 linhas.

**4. Bug não previsto, achado pelo próprio teste:** `churnTone(NaN)` devolvia `"NaN% risco churn"`
cru para a tela.

## O que mudou

- `formatPctMaybe` → **`formatarFracaoPct`** (fração 0–1, sem teto, `× 100` sempre). Renomeada em
  vez de ter a semântica trocada em silêncio: o nome novo declara a unidade no call-site.
- **`churnTone`** deixa de adivinhar: trata percentual 0–100 e degrada `NaN` para "—".
- **`Customer360View`**: unidade corrigida (`* 100` removido, limiar `0.5` → `50`).
- Par de formatadores agora explícito e documentado nos dois lados: `formatarFracaoPct` (fração) /
  `formatMargemPct` (percentual, de #1525).

Os 4 call-sites foram verificados **contra o produtor**, não pela leitura do consumidor:

| Call-site | Produtor | Unidade | Antes |
|---|---|---|---|
| `TeamKpiTiles:30` | `variacaoPct` — sem teto | fração | 🔴 errado acima de +100% |
| `VisitasKpiTiles:47` | `montarKpisVisita` — `fechados/comResultado` | fração, teto 1 | ✅ certo |
| `CustomerVisitsTab:39` | `resumoVisitas` — idem | fração, teto 1 | ✅ certo |
| `MinhasVisitasResultadoCard:65` | `agruparVisitasPorResultado` — `count/total` | fração, teto 1 | ✅ certo |

## Prova

Baseline verde antes de tocar em nada (`Tests 5 passed`, árvore provadamente limpa no instante da
execução — `heavy` é fila, não prefixo síncrono).

**Falsificação com previsão registrada ANTES** (money-path §31: exit code não distingue "pegou o
bug" de "não rodou nada"). Sabotadas as 3 correções de volta ao comportamento antigo, com cada
sabotagem **verificada no arquivo** antes de rodar:

```
Tests  4 failed | 11 passed (15)
```

Os 4 vermelhos, nome a nome, são exatamente os previstos — nenhum a mais, nenhum a menos:
`não trunca fração MAIOR que 1` · `não inverte risco BAIXO em máximo` ·
`devolve travessão para ausente` · `Customer360View.tsx não multiplica churn_risk por 100`.

Guard textual novo (`churn-unidade.test.ts`) cobre os consumidores de `churn_risk` sem teste
unitário — a unidade não está no tipo, então o typecheck fica verde nas duas leituras. Segue o
padrão do irmão `margem-sem-coacao.test.ts`, com falsificação embutida e predicado ancorado no
nome do campo (não num `* 100` solto, que é legítimo em toda parte).

## O que este PR NÃO faz

- **Não capa a exibição de variações extremas.** O tile passará a mostrar "▲ 11553% vs mês
  passado" — honesto, mas largo para um tile pequeno. Tratamento visual é decisão de produto e
  merece PR próprio.
- **Não unifica os limiares de churn** entre `CustomerHero` (40/70) e `Customer360View` (50).
  Preservei o comportamento de cada tela; só a unidade mudou.

Gates: typecheck ✅ · test ✅ (5.647) · lint ✅ 0 errors. `knip` segue em 1 — dívida pré-existente
(259 issues, nenhuma no diff; é o que o #1212 endereça).
