### PR TITLE
fix(financeiro): fluxo de caixa para de encolher em silêncio — erro lança, ordem total, previsto pagina [money-path]

### DIFF
--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -133,6 +133,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useUtiContas.test.ts",
       "src/hooks/__tests__/ponto-equilibrio-folha-ambigua.test.ts",
       "src/services/__tests__/getCapitalDeGiro.test.ts",
+      "src/services/__tests__/getFluxoCaixa.test.ts",
       "src/services/__tests__/getResumoFinanceiro.test.ts",
       "src/services/__tests__/getTopInadimplentes.test.ts",
       "src/services/__tests__/somarSaldoAberto.test.ts",

--- a/src/services/__tests__/getFluxoCaixa.test.ts
+++ b/src/services/__tests__/getFluxoCaixa.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Contrato do getFluxoCaixa (aba "Fluxo de Caixa" de /financeiro) — money-path.
+ * A tela exibe caixa REALIZADO (o que entrou/saiu, de fin_movimentacoes) e
+ * PREVISTO (a vencer, de fin_contas_receber/pagar) como número firme, sem
+ * qualquer marca de incompletude. Três defeitos o tornavam menor em silêncio
+ * (achado do Codex gpt-5.6-sol xhigh, 2026-07-21):
+ *
+ * 1. REALIZADO — o laço de paginação descartava o `error` (`const { data: page }`)
+ *    e tratava página perdida (timeout/RLS/500) como fim da tabela. Um caixa
+ *    menor não se anuncia como incompleto: some dinheiro e a tela segue firme.
+ * 2. REALIZADO — `.order('data_movimento')` NÃO é ordem total. Medido em prod
+ *    (psql-ro, 2026-07-21) na janela real da tela (6 meses atrás → 3 à frente):
+ *    14.104 linhas, **100,0% delas em dias com empate** (maior dia = 305 linhas,
+ *    média ~90). Com página de 1.000, toda fronteira de página cai DENTRO de um
+ *    dia empatado ⇒ offset sem desempate estável pula e duplica linhas — e este
+ *    erra sem erro nenhum, em todo load.
+ * 3. PREVISTO — as queries de CR/CP descartavam o `error` E não paginavam:
+ *    4.094 títulos de CR na janela (oben sozinha 2.897) contra a capa de 1.000
+ *    ⇒ ~76% das entradas previstas sumiam na visão "todas".
+ *
+ * O mock reproduz o PostgREST real: capa de 1.000 linhas por request, e — o
+ * ponto do caso 2 — ordem NÃO-determinística entre requests quando as chaves de
+ * `.order()` empatam, que é precisamente o que o Postgres não promete.
+ */
+
+type Row = Record<string, unknown>;
+
+const state: {
+  db: Record<string, Row[]>;
+  /** Falha na N-ésima requisição desta tabela (1-indexed). */
+  falharNaRequisicao: Record<string, number | undefined>;
+  requisicoes: Record<string, number>;
+} = { db: {}, falharNaRequisicao: {}, requisicoes: {} };
+
+/**
+ * Ordena como o Postgres: estável pelas chaves de ORDER BY e, dentro de um grupo
+ * que EMPATA em todas elas, sem promessa de ordem entre requests. Rotacionar o
+ * grupo por número de requisição é a forma determinística de reproduzir isso —
+ * com desempate único (id) todo grupo tem 1 linha e a rotação vira no-op.
+ */
+function ordenarComoPostgres(linhas: Row[], chaves: string[], requisicao: number): Row[] {
+  const chaveDe = (r: Row) => chaves.map((c) => String(r[c])).join('\u0000');
+  const grupos = new Map<string, Row[]>();
+  for (const r of linhas) {
+    const k = chaveDe(r);
+    const g = grupos.get(k) ?? [];
+    g.push(r);
+    grupos.set(k, g);
+  }
+  const saida: Row[] = [];
+  for (const k of [...grupos.keys()].sort()) {
+    const g = grupos.get(k)!;
+    const desloc = g.length > 1 ? requisicao % g.length : 0;
+    saida.push(...g.slice(desloc), ...g.slice(0, desloc));
+  }
+  return saida;
+}
+
+function makeBuilder(tabela: string) {
+  const filtros: Array<(r: Row) => boolean> = [];
+  const ordem: string[] = [];
+  let janela: { from: number; to: number } | null = null;
+  const builder = {
+    select: (_cols: string) => builder,
+    eq: (col: string, val: unknown) => {
+      filtros.push((r) => r[col] === val);
+      return builder;
+    },
+    in: (col: string, vals: unknown[]) => {
+      filtros.push((r) => vals.includes(r[col]));
+      return builder;
+    },
+    gte: (col: string, val: string) => {
+      filtros.push((r) => String(r[col]) >= val);
+      return builder;
+    },
+    lte: (col: string, val: string) => {
+      filtros.push((r) => String(r[col]) <= val);
+      return builder;
+    },
+    order: (col: string, _opts?: unknown) => {
+      ordem.push(col);
+      return builder;
+    },
+    range: (from: number, to: number) => {
+      janela = { from, to };
+      return builder;
+    },
+    then: (
+      resolve: (v: { data: Row[] | null; error: { message: string } | null }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => {
+      const n = (state.requisicoes[tabela] = (state.requisicoes[tabela] ?? 0) + 1);
+      if (state.falharNaRequisicao[tabela] === n) {
+        const error = { message: `falha simulada na requisição ${n} de ${tabela}` };
+        return Promise.resolve({ data: null, error }).then(resolve, reject);
+      }
+      const casadas = (state.db[tabela] ?? []).filter((r) => filtros.every((f) => f(r)));
+      const ordenadas = ordenarComoPostgres(casadas, ordem, n);
+      // PostgREST real: a capa de 1.000 vale SEMPRE — sem range capa em 1.000, e
+      // com range a janela nunca passa de 1.000 linhas.
+      const rows = janela
+        ? ordenadas.slice(janela.from, Math.min(janela.to + 1, janela.from + 1000))
+        : ordenadas.slice(0, 1000);
+      return Promise.resolve({ data: rows, error: null }).then(resolve, reject);
+    },
+  };
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (tabela: string) => makeBuilder(tabela) },
+}));
+
+import { getFluxoCaixa } from '@/services/financeiroService';
+
+const INICIO = '2026-01-01';
+const FIM = '2026-12-31';
+
+/** Movimento de caixa realizado. `valor` distinto por linha: pular ou duplicar altera a soma. */
+const mov = (i: number, dia: string, valor: number, tipo = 'E'): Row => ({
+  id: `mov-${String(i).padStart(6, '0')}`,
+  company: 'oben',
+  data_movimento: dia,
+  tipo,
+  valor,
+  omie_codigo_lancamento: 1000 + i,
+});
+
+const titulo = (i: number, dia: string, valor: number): Row => ({
+  id: `cr-${String(i).padStart(6, '0')}`,
+  company: 'oben',
+  data_vencimento: dia,
+  data_recebimento: null,
+  valor_documento: valor,
+  valor_recebido: 0,
+  status_titulo: 'A VENCER',
+});
+
+const somaRealizadoEntradas = (fluxo: { entradas_realizadas: number }[]) =>
+  fluxo.reduce((s, d) => s + d.entradas_realizadas, 0);
+const somaPrevistoEntradas = (fluxo: { entradas_previstas: number }[]) =>
+  fluxo.reduce((s, d) => s + d.entradas_previstas, 0);
+
+describe('getFluxoCaixa — caixa REALIZADO (fin_movimentacoes)', () => {
+  beforeEach(() => {
+    state.db = { fin_movimentacoes: [], fin_contas_receber: [], fin_contas_pagar: [] };
+    state.falharNaRequisicao = {};
+    state.requisicoes = {};
+  });
+
+  it('erro numa página LANÇA — página perdida não vira fim da tabela', async () => {
+    // 2.500 movimentos = 3 páginas. A 2ª falha (timeout/RLS/500): sem guard o laço
+    // encerra e devolve ~40% do caixa como se fosse o caixa inteiro.
+    state.db.fin_movimentacoes = Array.from({ length: 2500 }, (_, i) =>
+      mov(i, `2026-03-${String((i % 28) + 1).padStart(2, '0')}`, 10),
+    );
+    state.falharNaRequisicao.fin_movimentacoes = 2;
+
+    await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('ordem total: empate em data_movimento não pode pular nem duplicar entre páginas', async () => {
+    // 3 dias × 900 movimentos: as fronteiras de página (1.000 e 2.000) caem DENTRO
+    // de um dia — o cenário medido em prod, onde 100% das linhas empatam em data.
+    // Valor distinto por linha: qualquer pulo/duplicata desloca a soma.
+    const dias = ['2026-03-01', '2026-03-02', '2026-03-03'];
+    state.db.fin_movimentacoes = Array.from({ length: 2700 }, (_, i) =>
+      mov(i, dias[Math.floor(i / 900)], i + 1),
+    );
+    const esperado = (2700 * 2701) / 2;
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+
+    expect(somaRealizadoEntradas(fluxo)).toBe(esperado);
+  });
+
+  it('soma TODAS as páginas acima da capa de 1.000 do PostgREST', async () => {
+    // Dias distintos isolam a paginação do desempate: aqui não há empate nenhum.
+    state.db.fin_movimentacoes = Array.from({ length: 2500 }, (_, i) =>
+      mov(i, `2026-${String(Math.floor(i / 250) + 1).padStart(2, '0')}-${String((i % 25) + 1).padStart(2, '0')}`, 10),
+    );
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+
+    expect(somaRealizadoEntradas(fluxo)).toBe(25000);
+  });
+});
+
+describe('getFluxoCaixa — caixa PREVISTO (fin_contas_receber / fin_contas_pagar)', () => {
+  beforeEach(() => {
+    state.db = { fin_movimentacoes: [], fin_contas_receber: [], fin_contas_pagar: [] };
+    state.falharNaRequisicao = {};
+    state.requisicoes = {};
+  });
+
+  it('erro no CR LANÇA — projeção parcial engana tanto quanto realizado parcial', async () => {
+    state.db.fin_contas_receber = [titulo(0, '2026-03-01', 10)];
+    state.falharNaRequisicao.fin_contas_receber = 1;
+
+    await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('erro no CP LANÇA', async () => {
+    state.db.fin_contas_pagar = [
+      { ...titulo(0, '2026-03-01', 10), data_pagamento: null, valor_pago: 0 },
+    ];
+    state.falharNaRequisicao.fin_contas_pagar = 1;
+
+    await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('CR acima da capa de 1.000 não sai truncado (prod: 4.094 títulos na janela)', async () => {
+    // 2.500 títulos A VENCER de R$10: sem paginação o PostgREST devolve 1.000 e a
+    // projeção exibe R$10k onde há R$25k.
+    state.db.fin_contas_receber = Array.from({ length: 2500 }, (_, i) =>
+      titulo(i, `2026-03-${String((i % 28) + 1).padStart(2, '0')}`, 10),
+    );
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+
+    expect(somaPrevistoEntradas(fluxo)).toBe(25000);
+  });
+});

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -360,25 +360,31 @@ export async function getFluxoCaixa(
   dataInicio: string,
   dataFim: string
 ): Promise<FluxoCaixaDiario[]> {
-  // Buscar CR e CP para projetar fluxo
-  let crQuery = supabase
-    .from("fin_contas_receber")
-    .select("data_vencimento, data_recebimento, valor_documento, valor_recebido, status_titulo")
-    .gte("data_vencimento", dataInicio)
-    .lte("data_vencimento", dataFim);
-
-  let cpQuery = supabase
-    .from("fin_contas_pagar")
-    .select("data_vencimento, data_pagamento, valor_documento, valor_pago, status_titulo")
-    .gte("data_vencimento", dataInicio)
-    .lte("data_vencimento", dataFim);
-
-  if (company !== 'all') {
-    crQuery = crQuery.eq("company", company);
-    cpQuery = cpQuery.eq("company", company);
-  }
-
-  const [{ data: crData }, { data: cpData }] = await Promise.all([crQuery, cpQuery]);
+  // Previsto: títulos a vencer na janela. Paginado + erro LANÇA. Sem `.range()` o
+  // PostgREST capa em 1000 silenciosamente — prod 2026-07-21: 4.094 títulos de CR
+  // na janela desta tela (oben sozinha 2.897), então ~76% das entradas previstas
+  // sumiam na visão "todas". E o `error` descartado fazia falha de consulta virar
+  // "nada a vencer": uma projeção menor não se anuncia como incompleta.
+  const [crData, cpData] = await Promise.all([
+    buscarTodasPaginas(`CR do fluxo de caixa (${company})`, (from, to) => {
+      let q = supabase
+        .from("fin_contas_receber")
+        .select("data_vencimento, data_recebimento, valor_documento, valor_recebido, status_titulo")
+        .gte("data_vencimento", dataInicio)
+        .lte("data_vencimento", dataFim);
+      if (company !== 'all') q = q.eq("company", company);
+      return q.order("id").range(from, to);
+    }),
+    buscarTodasPaginas(`CP do fluxo de caixa (${company})`, (from, to) => {
+      let q = supabase
+        .from("fin_contas_pagar")
+        .select("data_vencimento, data_pagamento, valor_documento, valor_pago, status_titulo")
+        .gte("data_vencimento", dataInicio)
+        .lte("data_vencimento", dataFim);
+      if (company !== 'all') q = q.eq("company", company);
+      return q.order("id").range(from, to);
+    }),
+  ]);
 
   // Agrupar por dia
   const fluxoMap = new Map<string, FluxoCaixaDiario>();
@@ -398,7 +404,7 @@ export async function getFluxoCaixa(
     return fluxoMap.get(d)!;
   };
 
-  for (const cr of crData || []) {
+  for (const cr of crData) {
     if (cr.data_vencimento) {
       const day = ensureDay(cr.data_vencimento);
       if (cr.status_titulo && ['A VENCER', 'ATRASADO', 'VENCE HOJE'].includes(cr.status_titulo)) {
@@ -407,7 +413,7 @@ export async function getFluxoCaixa(
     }
   }
 
-  for (const cp of cpData || []) {
+  for (const cp of cpData) {
     if (cp.data_vencimento) {
       const day = ensureDay(cp.data_vencimento);
       if (cp.status_titulo && ['A VENCER', 'ATRASADO', 'VENCE HOJE'].includes(cp.status_titulo)) {
@@ -418,24 +424,26 @@ export async function getFluxoCaixa(
 
   // Realizado: caixa que de fato entrou/saiu por dia (fin_movimentacoes).
   // A baixa-do-título (data_recebimento/data_pagamento) está sempre NULL — o
-  // Omie não manda no endpoint LIST. Paginação manual: PostgREST capa em 1000
-  // linhas e a janela pode passar disso.
-  const movimentos: Array<{ data_movimento: string; tipo: string | null; valor: number; omie_codigo_lancamento: number | null }> = [];
-  const PAGE = 1000;
-  for (let from = 0; ; from += PAGE) {
-    let movQuery = supabase
-      .from('fin_movimentacoes')
-      .select('data_movimento, tipo, valor, omie_codigo_lancamento')
-      .gte('data_movimento', dataInicio)
-      .lte('data_movimento', dataFim)
-      .order('data_movimento', { ascending: true })
-      .range(from, from + PAGE - 1);
-    if (company !== 'all') movQuery = movQuery.eq('company', company);
-    const { data: page } = await movQuery;
-    if (!page || page.length === 0) break;
-    movimentos.push(...page);
-    if (page.length < PAGE) break;
-  }
+  // Omie não manda no endpoint LIST.
+  // Paginado + erro LANÇA: a janela passa de 1000 (prod 2026-07-21: 14.104 linhas
+  // = 15 páginas na visão "todas") e uma página perdida encerrando o laço
+  // subnotificava o caixa — exibido como número firme, sem sinal de incompletude.
+  // Ordem TOTAL (data_movimento, id): `data_movimento` sozinho NÃO desempata —
+  // 100,0% das linhas da janela dividem o dia com outra (maior dia = 305, média
+  // ~90), então toda fronteira de página cai dentro de um empate e o offset pula
+  // e duplica linhas, sem erro nenhum. O `id` (PK) fecha a ordem.
+  const movimentos = await buscarTodasPaginas(
+    `movimentações do fluxo de caixa (${company})`,
+    (from, to) => {
+      let q = supabase
+        .from('fin_movimentacoes')
+        .select('data_movimento, tipo, valor, omie_codigo_lancamento')
+        .gte('data_movimento', dataInicio)
+        .lte('data_movimento', dataFim);
+      if (company !== 'all') q = q.eq('company', company);
+      return q.order('data_movimento', { ascending: true }).order('id').range(from, to);
+    },
+  );
 
   const realizadoPorDia = agregarRealizadoPorDia(movimentos);
   for (const [dia, r] of realizadoPorDia) {


### PR DESCRIPTION
A aba "Fluxo de Caixa" de `/financeiro` exibia caixa **realizado** e **previsto** como
número firme, sem marca de incompletude — e três caminhos independentes o deixavam
menor em silêncio. Achado do Codex (gpt-5.6-sol, xhigh) numa auditoria de paginação;
o terceiro defeito apareceu ao medir a exposição dos dois primeiros.

## Os três defeitos

**1. Realizado: página perdida virava fim da tabela.** O laço de `fin_movimentacoes`
descartava o `error` (`const { data: page } = await movQuery`), então timeout/RLS/500
numa página encerrava a paginação e o caixa saía subnotificado — apresentado como fato.

**2. Realizado: `.order('data_movimento')` não é ordem total.** Várias movimentações
dividem a mesma data, e paginação por offset com ordem ambígua pula e duplica linhas
entre páginas. Este erra **sem erro nenhum**, em todo load.

**3. Previsto: CR/CP descartavam o `error` E não paginavam.** `const [{ data: crData }]
= await Promise.all(...)` sem `.range()` — a capa de 1.000 do PostgREST truncava a
projeção silenciosamente, e falha de consulta virava "nada a vencer".

## Exposição medida (via psql-ro, janela real da tela: 6 meses atrás → 3 à frente)

A medição atravessa as mesmas camadas que o consumidor — não é contagem de tabela
(`docs/agent/money-path.md`, §"dimensionar impacto pela TABELA superestima a segurança").

| Consulta | Linhas na janela | Páginas | Situação |
|---|---:|---:|---|
| `fin_movimentacoes` (todas) | 14.104 | 15 | pagina — exposta a #1 e #2 |
| `fin_movimentacoes` (oben) | 9.231 | 10 | idem |
| `fin_movimentacoes` (colacor_sc) | 1.505 | 2 | idem — **até a menor empresa pagina** |
| `fin_contas_receber` (todas) | 4.094 | — | **truncada em 1.000 hoje: ~76% do previsto sumia** |
| `fin_contas_receber` (oben) | 2.897 | — | **truncada: ~65% sumia** |
| `fin_contas_pagar` (todas) | 1.624 | — | **truncada: ~38% sumia** |

Sobre o defeito #2, o número que decide: **100,0% das linhas da janela (14.097/14.104)
estão em dias com empate**, maior dia = 305 linhas, média ~90/dia. Com página de 1.000,
**toda fronteira de página cai dentro de um dia empatado** — não é risco latente, é o
caso típico, em cada um dos 14 cortes.

Isto é, a exposição não é "baixa hoje e cresce": o defeito #3 estava **ativo e visível**
na tela — a projeção de entradas mostrava ~R$1 de cada R$4 na visão "todas".

## A correção

Migrei para `buscarTodasPaginas` — o helper **local** deste arquivo, que já lança em
erro (linha 212) e já é usado por `getTopInadimplentes`/`getCapitalDeGiro`. Deliberadamente
**não** usei o `fetchAllPages` de `@/lib/postgrest`: ele hoje tem exatamente o defeito #1
(`data ?? []` trata erro como EOF) e está sendo corrigido no chip irmão. Quando aquele
contrato fechar, unificar os dois helpers é um follow-up natural — não um pré-requisito.

Ordem total: `.order('data_movimento').order('id')`. O `id` (uuid, PK, NOT NULL) desempata.

## Prova

TDD: 6 testes escritos **antes** da correção. RED com contagem e nomes conferidos —
5 vermelhos (os 3 defeitos) e 1 verde (paginação sem empate, que já funcionava e isola
a causa do teste de ordem). Motivos conferidos um a um, não só o exit code:
`promise resolved instead of rejecting` nos guards, `expected 3646050 to be 3646350`
na ordem (300 linhas deslocadas), `expected 10000 to be 25000` no truncamento do previsto.

Falsificação por guard, com **contagem e nomes** dos vermelhos conferidos (§31 do
money-path: exit code não distingue "pegou o bug" de "não rodou nada"). O baseline
roda dentro do mesmo slot do `heavy`, imediatamente antes das sabotagens — baseline
que executa antes da edição não é baseline ("o relógio mente"):

| Rodada | Vermelhos | Quais caíram |
|---|---:|---|
| Baseline (árvore final) | 0 | `Tests 6 passed` |
| S1 — helper engole o erro (`throw` → `return out`) | 3 | os 3 testes de erro (realizado, CR, CP) |
| S2 — remove o desempate `.order('id')` | 1 | só o de ordem total |
| S3 — CR volta a ler só a 1ª página | 1 | só o de truncamento do previsto |

Cada sabotagem derrubou exatamente os testes que mira, sem colateral, e a árvore foi
conferida idêntica ao original ao fim (o script sabota `src/` in-place — mesma classe
de risco do `mutcheck`, que pode fazer um `git add -A` commitar sabotagem).

O mock reproduz o PostgREST real: capa de 1.000 por request e — o ponto do defeito #2 —
ordem não-determinística entre requests quando as chaves de `.order()` empatam.

## O que este PR NÃO muda

O consumidor (`useFinanceiro.loadFluxoCaixa`) já tem `try/catch` que alimenta o banner
de erro de `FinanceiroDashboard` (linha 160), então a falha agora **aparece** em vez de
virar número menor. Mas `setFluxoCaixa` não é limpo no catch: num re-load que falhe, a
tela mantém o dado anterior com o banner por cima. Isso é o padrão de todos os ~10
`setError` do hook, não algo específico do fluxo de caixa — mexer nisso seria um refactor
do hook inteiro, fora do escopo deste fix. A garantia essencial está fechada: **nunca
mais um caixa parcial apresentado como completo.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
