### PR TITLE
docs(worktrees): checar colisão de arquivo é git diff de TRÊS pontos, não de dois

### DIFF
--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -62,6 +62,23 @@ diff de 26 arquivos para 8 (#1533).
 **Regra:** re-conferir `gh pr list` **imediatamente antes do `gh pr create`**, filtrando pelo
 domínio (`gh pr list --search "margem"`). Custa segundos; teria pego o #1525 seis minutos antes.
 
+⚠️ **Checar colisão de ARQUIVO: `git diff` de TRÊS pontos, não de dois (2026-07-22).** A checagem
+por PR acima tem uma irmã por diff — "a `main` mexeu num arquivo que EU também mexo?" — e o comando
+óbvio **mente depois que você commita**. `git diff --name-only HEAD..origin/main` (DOIS pontos)
+compara as duas árvores, então lista o que a `main` ganhou **mais o inverso dos seus próprios
+commits**: antes de commitar, `HEAD` É a base e ele acerta por acidente; depois de commitar, ele
+acusa os SEUS arquivos como se a `main` os tivesse tocado — falso positivo (me deu um "colisão!"
+fantasma no #1551, um doc-only que a `main` nem havia tocado). Use **TRÊS pontos**, que ancora na
+merge-base: `git diff --name-only HEAD...origin/main` lista só o que a `main` ganhou desde que você
+divergiu (idêntico a `$(git merge-base HEAD origin/main)..origin/main`). Colisão REAL = a interseção
+disso com os SEUS arquivos (`git diff --name-only origin/main...HEAD`, três pontos, HEAD por último).
+Provado num repo descartável nos dois sentidos: o três-pontos remove o falso positivo **e** mantém o
+verdadeiro (arquivo tocado pelos dois lados continua aparecendo — não vira falso-negativo). Regra de
+bolso: **`A...B` para "o que um lado ganhou desde a base"; `A..B` de dois pontos quase nunca é o que
+você quer aqui.** (As skills `fecho`/`lovable-deploy-verify` já usam `origin/main...HEAD` de três
+pontos para classificar o PRÓPRIO diff — correto pelo mesmo motivo; o furo era só a checagem de
+colisão feita à mão.)
+
 ⚠️ **A hipótese "são os chips" foi investigada e NÃO se sustenta** — registrado para não virar
 folclore. Chips criam sessões, mas não escolhem o alvo; o que concentrou quatro sessões no mesmo
 ponto foi o produtor represado. Nada na memória (claude-mem) registra decisão sobre chips×compact.


### PR DESCRIPTION
Corrige uma lacuna no ritual de checagem de colisão multi-sessão (`docs/agent/worktrees.md`), descoberta na própria sessão que registrou o [#1548](https://github.com/LucasSardenbergL/afiacao/pull/1548)/[#1551](https://github.com/LucasSardenbergL/afiacao/pull/1551).

## O furo

A regra "re-conferir colisão **imediatamente antes do `gh pr create`**" só cobria `gh pr list`. A irmã por diff — "a `main` mexeu num arquivo que EU também mexo?" — usa `git diff`, e o comando óbvio **mente depois que você commita**:

- `git diff --name-only HEAD..origin/main` (**DOIS** pontos) compara as duas árvores → lista o que a `main` ganhou **mais o inverso dos seus próprios commits**.
- **Antes** de commitar, `HEAD` é a base e ele acerta por acidente. **Depois** de commitar, acusa os SEUS arquivos como se a `main` os tivesse tocado.
- Aconteceu nesta sessão: um falso "colisão!" no #1551, um doc-only que a `main` sequer havia tocado.

## A correção

**TRÊS** pontos, que ancora na merge-base: `git diff --name-only HEAD...origin/main` lista só o que a `main` ganhou desde que você divergiu. Colisão real = a interseção disso com os seus arquivos (`git diff --name-only origin/main...HEAD`).

## Provado, não afirmado de cabeça

Repo git descartável, dois cenários:

| Cenário | dois pontos | três pontos |
|---|---|---|
| **A** — main tocou OUTRO arquivo | lista o meu arquivo (falso +) + o dela | só o dela ✅ |
| **B** — main e eu tocamos o MESMO | — | o compartilhado presente ✅ (sem falso −) |

O três-pontos remove o falso positivo **e** mantém o verdadeiro — a falsificação (sabotar e exigir que a colisão real ainda apareça) passou.

Nota no PR: as skills `fecho`/`lovable-deploy-verify` já usam `origin/main...HEAD` de três pontos para classificar o próprio diff — corretas pelo mesmo motivo. O furo era só a checagem de colisão feita à mão.

Doc-only: nenhum código tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)