### PR TITLE
test(farmer): canária comportamental do #1498 — a prova de DEPLOY que faltava [money-path]

### DIFF
--- a/supabase/functions/_shared/tactical-margem.ts
+++ b/supabase/functions/_shared/tactical-margem.ts
@@ -117,3 +117,36 @@ export function selectObjective(
   if (m != null && c != null && m < c * 0.8) return 'consolidacao_margem';
   return 'upsell_premium';
 }
+
+export interface CanariaResultado {
+  nome: string;
+  got: unknown;
+  expected: unknown;
+  ok: boolean;
+}
+
+/** CANÁRIA COMPORTAMENTAL do #1498 — prova de DEPLOY, não de fonte.
+ *
+ *  Roda as decisões deste módulo sobre fixtures fixos e confere contra o esperado. Cada caso é
+ *  uma das fabricações que o #1498 removeu, e o `expected` difere do que o código ANTIGO daria —
+ *  um fixture que os dois códigos resolvem igual não prova deploy. A edge `generate-tactical-plan`
+ *  expõe isto via `{ canary: true }` (staff/cron-gated). Por que ela é necessária: o dado de prod
+ *  NÃO discrimina os dois códigos (o gate de R$/h filtra estruturalmente quem não tem margem, o
+ *  único caso onde eles divergem), então só um probe do COMPORTAMENTO deployado responde "está no
+ *  ar?". Ver o comentário na edge para o histórico completo. */
+export function avaliarCanariaMargem(): { ok: boolean; resultados: CanariaResultado[] } {
+  const casos: Array<Omit<CanariaResultado, 'ok'>> = [
+    // `?? 0`: margem ausente virava R$ 0/h e o cliente sumia do ranking como se fosse ruim.
+    { nome: 'margem_ausente_nao_vira_zero', got: margemConhecida(null), expected: null },
+    // Margem 0 é veredito REAL ("cliente não-lucrativo") e tem de sobreviver ao guard.
+    { nome: 'zero_e_conhecido', got: margemConhecida(0), expected: 0 },
+    // `: 25` mágico: sem par com margem, o cluster virava régua inventada.
+    { nome: 'cluster_sem_pares_e_null', got: calcularClusterMargin([]), expected: null },
+    // `null < 20` é true em JS: sem guard, gasto baixo + margem ausente = "sensivel_preco".
+    { nome: 'perfil_nao_fabrica_sensivel_preco', got: classifyProfile(50, 400, null, 5), expected: 'misto' },
+    // A régua de consolidação não decide sem os dois lados conhecidos.
+    { nome: 'objetivo_sem_margem_nao_consolida', got: selectObjective(10, 1, null, 50, 5, 180), expected: 'upsell_premium' },
+  ];
+  const resultados = casos.map((c) => ({ ...c, ok: c.got === c.expected }));
+  return { ok: resultados.every((r) => r.ok), resultados };
+}

--- a/supabase/functions/_shared/tactical-margem_test.ts
+++ b/supabase/functions/_shared/tactical-margem_test.ts
@@ -6,6 +6,7 @@
 //   src/lib/scoring/objective.ts          (selectObjective)
 //   src/hooks/useTacticalPlan.ts:404-418  (cluster = média dos PARES com margem conhecida)
 import {
+  avaliarCanariaMargem,
   calcularClusterMargin,
   classifyProfile,
   margemConhecida,
@@ -182,4 +183,37 @@ Deno.test("profile: margem AUSENTE não vira 'orientado_qualidade'", () => {
 Deno.test("profile: margem ausente ainda permite o ramo que NÃO usa margem", () => {
   // orientado_produtividade não depende de margem — segue decidível.
   assertEquals(classifyProfile(70, 3000, null, 5), "orientado_produtividade");
+});
+
+// ── Canária comportamental (#1498): a prova de DEPLOY que a edge expõe via {canary:true} ─────
+Deno.test("canária: todos os casos passam sobre o helper CORRETO (baseline verde)", () => {
+  const { ok, resultados } = avaliarCanariaMargem();
+  assertEquals(ok, true);
+  assertEquals(resultados.length, 5);
+  assertEquals(resultados.every((r) => r.ok), true);
+});
+
+Deno.test("canária: cada caso mira uma fabricação distinta do #1498", () => {
+  // Os nomes são o contrato lido pelo verificador pós-deploy — se um sumir, a cobertura mudou.
+  const nomes = avaliarCanariaMargem().resultados.map((r) => r.nome).sort();
+  assertEquals(nomes, [
+    "cluster_sem_pares_e_null",
+    "margem_ausente_nao_vira_zero",
+    "objetivo_sem_margem_nao_consolida",
+    "perfil_nao_fabrica_sensivel_preco",
+    "zero_e_conhecido",
+  ]);
+});
+
+Deno.test("canária: o `expected` de cada caso DIFERE do que o código antigo daria", () => {
+  // Uma canária cujo esperado casa com o código velho não prova deploy nenhum. Estes são
+  // exatamente os valores que o #1498 mudou — o que o código ANTIGO produziria está ao lado.
+  const r = avaliarCanariaMargem().resultados;
+  const by = (n: string) => r.find((x) => x.nome === n)!;
+  assertEquals(by("margem_ausente_nao_vira_zero").expected, null);        // antigo: 0
+  assertEquals(by("cluster_sem_pares_e_null").expected, null);            // antigo: 25
+  assertEquals(by("perfil_nao_fabrica_sensivel_preco").expected, "misto"); // antigo: "sensivel_preco"
+  assertEquals(by("objetivo_sem_margem_nao_consolida").expected, "upsell_premium"); // antigo: consolidacao_margem (se cluster contava)
+  // zero_e_conhecido guarda o outro lado: margem 0 REAL não pode ser confundida com ausência.
+  assertEquals(by("zero_e_conhecido").got, 0);
 });

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -2,7 +2,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { fetchAll } from "../_shared/paginate.ts";
-import { calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
+import { avaliarCanariaMargem, calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
 import { inicioDiaOperacional } from "../_shared/dia-operacional.ts";
 
 const corsHeaders = {
@@ -33,6 +33,32 @@ serve(async (req) => {
 
   try {
     const body = await req.json();
+
+    // CANÁRIA COMPORTAMENTAL do helper de margem (#1498) — NÃO escreve, NÃO chama LLM, NÃO toca o
+    // DB. Roda as decisões PURAS de `_shared/tactical-margem.ts` DEPLOYADAS (não as da `main`)
+    // sobre fixtures fixos e compara com o esperado.
+    //
+    // POR QUE ELA EXISTE: em 2026-07-22 gastamos uma sessão inteira tentando provar que o #1498
+    // estava no ar e NÃO conseguimos. O dado de produção não discrimina os dois códigos: o gate de
+    // R$/h ≥ 50 filtra estruturalmente quem não tem margem (velho: NULL→`?? 0`→R$0/h→reprovado;
+    // novo: indecidível→excluído), então o batch produz o MESMO conjunto nos dois. O cron das 08:00
+    // gerou 2 planos de 3.858 clientes, todos limpos — consistente com a correção estar no ar E com
+    // ela não estar. Sem probe, a única via era o founder gerar um plano à mão para um cliente sem
+    // margem. Isto substitui esse clique.
+    //
+    // Prova duas coisas que o commit de deploy NÃO prova: (1) esta action RESPONDE ⇒ o helper subiu
+    // no MESMO build (senão o body cai no fluxo normal e falta `customerContext`); (2) a lógica
+    // certa está no ar — margem ausente degrada em vez de fabricar. NÃO prova que o real-path usa o
+    // helper (isso é o guard textual + paridade), prova que a DECISÃO deployada está correta. Os
+    // fixtures vivem no helper (`avaliarCanariaMargem`), testados em tactical-margem_test.ts.
+    if (body.canary === true) {
+      const { ok, resultados } = avaliarCanariaMargem();
+      return new Response(JSON.stringify({ canary: true, ok, resultados }), {
+        status: ok ? 200 : 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
     // Modo self-contained (cron): body traz { customerId, farmerId } e a edge monta o
     // contexto + grava o plano. Modo front (legado): body traz customerContext já montado
     // e o front é quem grava (useTacticalPlan.generatePlan).


### PR DESCRIPTION
Fecha o loop que ficou aberto a sessão inteira: **não conseguíamos provar que o #1498 estava no ar.**

**EDGE** (`generate-tactical-plan` + `_shared/tactical-margem.ts`) — exige **deploy pelo chat do Lovable**. Sem migration, sem frontend.

## O problema que ela resolve

O dado de produção **não discrimina** os dois códigos do #1498. O gate de R$/h ≥ 50 filtra estruturalmente quem não tem margem — exatamente o único caso onde velho e novo divergem:

```
margem NULL --[velho: ?? 0]--> R$ 0/h --> REPROVADO
margem NULL --[novo: indecidível]--> EXCLUÍDO
==> mesmo conjunto de saída
```

O cron das 08:00 gerou 2 planos de 3.858 clientes, todos limpos — **consistente com a correção estar no ar E com ela não estar.** A única via de prova era o founder gerar um plano à mão para um cliente sem margem e ler o `customer_profile`. Isto substitui esse clique, para sempre.

## O que é

Endpoint `{canary: true}` que roda as 5 decisões de margem **deployadas** sobre fixtures fixos e responde `{ok, resultados}`. Segue o padrão `identidade_probe` do `omie-vendas-sync` (money-path.md, "Helper espelhado"): prova **(1)** que a action responde ⇒ o helper subiu no mesmo build, e **(2)** que a lógica certa está no ar.

Cada fixture tem `expected` que **difere do que o código antigo daria** — um caso que os dois resolvem igual não provaria deploy nenhum:

| fixture | novo (expected) | o que o antigo daria |
|---|---|---|
| margem ausente | `null` | `0` |
| cluster sem pares | `null` | `25` |
| perfil margem-ausente | `misto` | `sensivel_preco` (`null < 20`) |
| objetivo sem margem | `upsell_premium` | `consolidacao_margem` |
| margem 0 | `0` | (o outro lado: 0 REAL ≠ ausência) |

A lógica vive no helper (`avaliarCanariaMargem`), não embutida no handler — por isso é testável sob `--no-remote`. Gated por `authorizeCronOrStaff`.

## Prova

- `deno test --no-remote` **30/30** no helper
- `test:edges` **220/220** (suíte completa, pós-rebase na main atual)
- `edges:typecheck` **0 erros de classe-crash**
- `deno check` dos 2 arquivos exit 0
- **Falsificada:** remover o guard `raw == null` de `margemConhecida` acende a canária baseline (+8 asserts) — ela morde
- Mudança **puramente aditiva** no helper (novo export) ⇒ não quebra o outro importador (`tactical-plans-batch`)

## Depois do deploy

```bash
# staff/cron-gated; substitui o teste manual para sempre
curl -sS -X POST "$SUPABASE_URL/functions/v1/generate-tactical-plan" \
  -H "x-cron-secret: <secret>" -H 'content-type: application/json' \
  -d '{"canary":true}' | jq
# { "canary": true, "ok": true, "resultados": [...] }
```

`ok: true` ⇒ o #1498 está no ar. `ok: false` ⇒ o deploy não pegou o helper novo, com o `resultado` que falhou apontando qual decisão regrediu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)