### PR TITLE
fix(telemetria): a mensagem do PostgREST podia carregar PII — sai código + categoria [money-path]

### DIFF
--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -59,7 +59,7 @@ export function useFarmerTacticalPlan() {
         .in('farmer_id', ownerIds)
         .order('priority_score', { ascending: false })
         .order('customer_user_id', { ascending: true })
-        .range(de, ate));
+        .range(de, ate), 'farmer_client_scores/plano-tatico');
     if (!scores.length) return;
 
     // [GUARD] LOTES. `.in()` com N ids vira query string: 3.858 UUIDs = ~143 KB de URL, contra um

--- a/src/lib/__tests__/postgrest.test.ts
+++ b/src/lib/__tests__/postgrest.test.ts
@@ -340,7 +340,7 @@ describe('fetchAllPages — instrumentação da página perdida', () => {
 
   beforeEach(() => captureExceptionMock.mockClear());
 
-  it('reporta fonte, índice da página, linhas perdidas e o código do PostgREST', async () => {
+  it('reporta fonte, índice da página, linhas lidas antes da falha e o código do PostgREST', async () => {
     await expect(
       fetchAllPages<{ id: number }>(falhaNaTerceira, 'product_costs/bundle'),
     ).rejects.toThrow();
@@ -349,28 +349,73 @@ describe('fetchAllPages — instrumentação da página perdida', () => {
     const [, ctx] = captureExceptionMock.mock.calls[0] as [unknown, Record<string, unknown>];
     expect(ctx.fonte).toBe('product_costs/bundle');
     expect(ctx.pagina).toBe(2); // 0-based, igual à mensagem do throw
-    expect(ctx.linhas_perdidas).toBe(2 * POSTGREST_PAGE_SIZE);
+    // Renomeado (Codex): é a contagem de linhas LIDAS antes da falha, não das perdidas
+    // (o total da tabela era desconhecido). O nome antigo afirmava um número que não temos.
+    expect(ctx.linhas_lidas_antes_da_falha).toBe(2 * POSTGREST_PAGE_SIZE);
     expect(ctx.codigo).toBe('42501');
-    expect(ctx.mensagem).toBe('permission denied for table product_costs');
   });
 
-  it('NÃO envia as linhas lidas — metadado só, sem payload nem PII', async () => {
+  // O CORAÇÃO DO FIX (Codex, achado a): `error.message` do PostgREST encaminha o MESSAGE do
+  // Postgres, e função/view/RLS num SELECT pode lançar mensagem com valor de linha (RAISE
+  // interpolando ID, erro de cast reproduzindo o valor). O helper é GENÉRICO — a garantia
+  // "message é metadado sem PII" era falsa. A telemetria manda só código + categoria por
+  // allowlist; a mensagem crua NUNCA sai.
+  it('NUNCA envia a mensagem crua do PostgREST (pode conter PII interpolada)', async () => {
+    const comPII = {
+      code: 'P0001',
+      message: 'cliente 123.456.789-00 (João da Silva, joao@exemplo.com) sem permissão',
+    };
+    await expect(
+      fetchAllPages<{ id: number }>(() => Promise.resolve({ data: null, error: comPII }), 'x/y'),
+    ).rejects.toThrow();
+
+    const [errArg, ctx] = captureExceptionMock.mock.calls[0] as [unknown, Record<string, unknown>];
+    const tudo = JSON.stringify(ctx) + String((errArg as Error)?.message ?? '');
+    // Nenhum fragmento da mensagem crua pode aparecer — nem no contexto, nem no Error.
+    expect(tudo).not.toMatch(/123\.456\.789/);
+    expect(tudo).not.toMatch(/João da Silva/);
+    expect(tudo).not.toMatch(/joao@exemplo/);
+    // O que DEVE sair: o código (seguro, é de transporte) e a categoria normalizada.
+    expect(ctx.codigo).toBe('P0001');
+    expect(ctx).not.toHaveProperty('mensagem');
+  });
+
+  it('categoriza o erro por código, sem depender do texto livre', async () => {
+    const casos: Array<[string | undefined, string]> = [
+      ['57014', 'timeout'],       // canceling statement due to statement timeout
+      ['42501', 'rls_ou_permissao'],
+      ['P0001', 'excecao_customizada'],
+      [undefined, 'desconhecido'],
+    ];
+    for (const [code, categoriaEsperada] of casos) {
+      captureExceptionMock.mockClear();
+      await expect(
+        fetchAllPages<{ id: number }>(
+          () => Promise.resolve({ data: null, error: code ? { code, message: 'x' } : { message: 'x' } }),
+          'x/y',
+        ),
+      ).rejects.toThrow();
+      const [, ctx] = captureExceptionMock.mock.calls[0] as [unknown, Record<string, unknown>];
+      expect(ctx.categoria, `code=${code}`).toBe(categoriaEsperada);
+    }
+  });
+
+  it('NÃO envia as linhas lidas — metadado só, sem payload', async () => {
     await expect(fetchAllPages<{ id: number }>(falhaNaTerceira, 'product_costs/bundle')).rejects.toThrow();
 
     const [, ctx] = captureExceptionMock.mock.calls[0] as [unknown, Record<string, unknown>];
-    // `linhas_perdidas` é uma CONTAGEM; as linhas em si nunca entram no contexto.
     expect(JSON.stringify(ctx)).not.toMatch(/"id"/);
     for (const v of Object.values(ctx)) expect(Array.isArray(v)).toBe(false);
   });
 
-  it('data:null sem error também reporta (rotulado, não confundido com timeout)', async () => {
+  it('data:null sem error é categorizado à parte (não confundido com timeout)', async () => {
     await expect(
       fetchAllPages<{ id: number }>(() => Promise.resolve({ data: null, error: null }), 'x/y'),
     ).rejects.toThrow();
 
     const [, ctx] = captureExceptionMock.mock.calls[0] as [unknown, Record<string, unknown>];
     expect(ctx.codigo).toBeNull();
-    expect(ctx.mensagem).toBe('data=null sem error');
+    expect(ctx.categoria).toBe('data_null_sem_error');
   });
 
   it('leitura completa não instrumenta nada (sem ruído na telemetria)', async () => {

--- a/src/lib/__tests__/postgrest.test.ts
+++ b/src/lib/__tests__/postgrest.test.ts
@@ -451,27 +451,27 @@ describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
 
   it('tabela maior que a capa: devolve TUDO, não as primeiras 1.000', async () => {
     const { buscar } = tabelaFalsa(3637); // product_costs real
-    const todas = await fetchAllPages(buscar);
+    const todas = await fetchAllPages(buscar, 'teste/capa');
     expect(todas).toHaveLength(3637);
     expect(todas.at(-1)).toEqual({ id: 3636 }); // a cauda chegou
   });
 
   it('pagina com janelas contíguas e para na primeira página parcial', async () => {
     const { buscar, chamadas } = tabelaFalsa(2500);
-    await fetchAllPages(buscar);
+    await fetchAllPages(buscar, 'teste/capa');
     expect(chamadas).toEqual([[0, 999], [1000, 1999], [2000, 2999]]);
   });
 
   it('múltiplo exato da capa: faz uma página extra vazia e para (sem loop infinito)', async () => {
     const { buscar, chamadas } = tabelaFalsa(2000);
-    const todas = await fetchAllPages(buscar);
+    const todas = await fetchAllPages(buscar, 'teste/capa');
     expect(todas).toHaveLength(2000);
     expect(chamadas).toHaveLength(3);
   });
 
   it('tabela menor que a capa: uma única requisição', async () => {
     const { buscar, chamadas } = tabelaFalsa(42);
-    expect(await fetchAllPages(buscar)).toHaveLength(42);
+    expect(await fetchAllPages(buscar, 'teste/capa')).toHaveLength(42);
     expect(chamadas).toHaveLength(1);
   });
 
@@ -481,7 +481,7 @@ describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
 
   it('tabela vazia → lista vazia, sem estourar', async () => {
     const { buscar, chamadas } = tabelaFalsa(0);
-    expect(await fetchAllPages(buscar)).toEqual([]);
+    expect(await fetchAllPages(buscar, 'teste/capa')).toEqual([]);
     expect(chamadas).toHaveLength(1);
   });
 
@@ -497,7 +497,7 @@ describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
   // com o bug de volta. Cada asserção tem que distinguir QUAL ramo disparou.
   it('erro na PRIMEIRA página → REJEITA (não devolve [] como se a tabela estivesse vazia)', async () => {
     const { buscar } = tabelaFalsa(3637, 0);
-    await expect(fetchAllPages(buscar)).rejects.toThrow(/\(0-999\) falhou/);
+    await expect(fetchAllPages(buscar, 'teste/capa')).rejects.toThrow(/\(0-999\) falhou/);
   });
 
   it('O CORAÇÃO DO FIX: erro numa página do MEIO → REJEITA, nunca devolve o acumulado parcial', async () => {
@@ -505,7 +505,7 @@ describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
     // linhas — numericamente indistinguível de uma carteira que de fato tem 2.000. Nos três
     // callers de `product_costs` a mesma perda vira "SKU sem custo", que INFLA margem.
     const { buscar, chamadas } = tabelaFalsa(3858, 2);
-    await expect(fetchAllPages(buscar)).rejects.toThrow(/\(2000-2999\) falhou/);
+    await expect(fetchAllPages(buscar, 'teste/capa')).rejects.toThrow(/\(2000-2999\) falhou/);
     expect(chamadas).toHaveLength(3); // parou NA página que falhou; não seguiu adiante
   });
 
@@ -513,7 +513,7 @@ describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
     // Sem a janela e a causa, o incidente chega como "deu erro" e não dá pra saber QUAL
     // fatia da tabela sumiu nem se foi timeout, RLS ou 500.
     const { buscar } = tabelaFalsa(3858, 2);
-    const erro = await fetchAllPages(buscar).catch((e: unknown) => e);
+    const erro = await fetchAllPages(buscar, 'teste/capa').catch((e: unknown) => e);
     expect(erro).toBeInstanceOf(Error); // se RESOLVEU, cai aqui mostrando o parcial devolvido
     expect((erro as Error).message).toMatch(/\(2000-2999\) falhou/); // a janela que sumiu
     expect((erro as Error & { cause?: unknown }).cause).toEqual(ERRO_TIMEOUT); // timeout? RLS? 500?
@@ -525,7 +525,7 @@ describe('fetchAllPages — a capa de 1.000 do PostgREST é silenciosa', () => {
     // Casa a mensagem do RAMO (não um throw qualquer): sem o guard, `push(...null)` lançaria
     // TypeError e um `rejects.toThrow()` pelado passaria verde pelo motivo errado.
     await expect(
-      fetchAllPages<{ id: number }>(() => Promise.resolve({ data: null, error: null })),
+      fetchAllPages<{ id: number }>(() => Promise.resolve({ data: null, error: null }), 'teste/capa'),
     ).rejects.toThrow(/data null sem error/);
   });
 });

--- a/src/lib/postgrest.ts
+++ b/src/lib/postgrest.ts
@@ -133,9 +133,11 @@ export const POSTGREST_PAGE_SIZE = 1000;
  * é OBRIGATÓRIO no contrato: sem ele o caller não tem como detectar (era o furo original).
  * Fim legítimo da tabela é `data: []` sem erro — só isso encerra o loop.
  *
- * `fonte` rotula a origem na telemetria (ex.: `'product_costs/bundle'`). Opcional para não
- * quebrar caller existente, mas SEMPRE preencha: sem ela a agregação depende do stack trace,
- * que muda com o bundler. Ela é o que separa "product_costs falha às terças" de "algo falhou".
+ * `fonte` rotula a origem na telemetria (ex.: `'product_costs/bundle'`) e é OBRIGATÓRIA: o
+ * propósito dela é agregação ESTÁVEL, e o compilador é quem garante isso. A alternativa —
+ * cair no stack trace — é instável (a exceção nasce dentro de `relatarPaginaPerdida`; stack
+ * assíncrono, minificação e source-maps mudam entre builds, e o agrupamento junto). Um default
+ * silencioso deixaria justo a lacuna no mecanismo criado para observabilidade. (Codex, #1550.)
  *
  * ```ts
  * const custos = await fetchAllPages<CostRow>(
@@ -149,7 +151,7 @@ export const POSTGREST_PAGE_SIZE = 1000;
  */
 export async function fetchAllPages<T>(
   buscarPagina: (de: number, ate: number) => PromiseLike<{ data: T[] | null; error: unknown }>,
-  fonte = 'nao-informada',
+  fonte: string,
 ): Promise<T[]> {
   const todas: T[] = [];
   for (let pagina = 0; ; pagina++) {
@@ -184,14 +186,36 @@ function comCausa(mensagem: string, causa: unknown): Error {
 }
 
 /**
+ * Categoriza o erro pelo SQLSTATE (allowlist), NUNCA pelo texto livre. O `code` do PostgREST
+ * é seguro — é de transporte, valor fechado do Postgres. A `message`, não: o PostgREST
+ * encaminha o MESSAGE do Postgres, e função/view/RLS avaliada num SELECT pode lançar mensagem
+ * com valor de linha (`RAISE EXCEPTION` interpolando ID/CPF; erro de cast reproduzindo o valor
+ * inválido). Como o helper é GENÉRICO, categorizar por código dá o sinal de observabilidade
+ * — "está falhando por timeout? por RLS?" — sem arriscar PII na telemetria. (Achado do Codex
+ * gpt-5.6-sol na revisão do #1550: a garantia "message é metadado sem PII" era falsa.)
+ */
+function categoriaDoErro(code: string | null, causa: unknown): string {
+  if (causa === null) return 'data_null_sem_error';
+  if (code === null) return 'desconhecido';
+  if (code === '57014') return 'timeout';
+  if (code === '42501') return 'rls_ou_permissao';
+  if (code === 'P0001') return 'excecao_customizada'; // RAISE do plpgsql — o de maior risco de PII
+  if (code.startsWith('08')) return 'conexao';
+  if (code.startsWith('53')) return 'recursos'; // out of memory, too many connections
+  return 'desconhecido';
+}
+
+/**
  * Reporta a página perdida ANTES de lançar. Lançar conserta a mentira do número; sem
  * instrumentar, a falha continua invisível para MEDIÇÃO — e não dá para saber se acontece uma
  * vez por mês ou toda tarde, nem se um caller sofre mais que os outros. Antes do contrato de
  * rejeição isso era impossível por construção: a falha virava lista vazia e ninguém sabia.
  *
- * Só METADADO. As linhas lidas nunca entram no contexto: `linhas_perdidas` é uma CONTAGEM, e
- * o `code`/`message` do PostgREST são de transporte (`57014`, `42501`, "permission denied for
- * table X") — sem payload, sem PII. O caller que quiser tratar o erro ainda recebe a exceção.
+ * Só METADADO SEGURO — nunca a `message` crua (pode carregar PII interpolada; ver
+ * `categoriaDoErro`). Sai o `code` (transporte, valor fechado), a `categoria` normalizada, e
+ * `linhas_lidas_antes_da_falha` (uma CONTAGEM — quantas vieram antes de estourar; o total da
+ * tabela é desconhecido, então NÃO é "linhas perdidas"). Sem payload, sem texto livre. O
+ * caller que quiser diagnosticar a mensagem ainda a tem via `error.cause` na exceção.
  *
  * ⚠️ AO LER A MÉTRICA: um evento por TENTATIVA, não por incidente. Os callers em react-query
  * herdam `retry: 2` (App.tsx), então uma única falha do ponto de vista do usuário emite até
@@ -199,15 +223,14 @@ function comCausa(mensagem: string, causa: unknown): Error {
  * Contar tentativas é o que se pode afirmar aqui dentro: o helper não sabe se está numa
  * retentativa (nem deveria — inferir isso seria estado escondido no lugar errado).
  */
-function relatarPaginaPerdida(fonte: string, pagina: number, acumuladas: number, causa: unknown): void {
-  const pg = causa as { message?: unknown; code?: unknown } | null;
-  const message = typeof pg?.message === 'string' ? pg.message : null;
+function relatarPaginaPerdida(fonte: string, pagina: number, lidasAntes: number, causa: unknown): void {
+  const pg = causa as { code?: unknown } | null;
   const code = typeof pg?.code === 'string' ? pg.code : null;
   captureException(new Error(`fetchAllPages(${fonte}): página ${pagina} perdida`), {
     fonte,
     pagina,
-    linhas_perdidas: acumuladas,
+    linhas_lidas_antes_da_falha: lidasAntes,
     codigo: code,
-    mensagem: message ?? (causa == null ? 'data=null sem error' : null),
+    categoria: categoriaDoErro(code, causa),
   });
 }


### PR DESCRIPTION
Hardening da telemetria de `fetchAllPages`, endereçando o parecer adversarial do Codex (`gpt-5.6-sol` xhigh) sobre o #1550 — a **revisão independente pendente** que ficou registrada lá.

## (a) `error.message` cru podia vazar PII — a garantia que escrevi era falsa

O #1550 mandava `mensagem` crua do PostgREST para o `captureException`, com um comentário afirmando "metadado de transporte, sem PII". **Errado**, e o Codex pegou: o PostgREST encaminha o `MESSAGE` do Postgres, e função/view/RLS avaliada num `SELECT` pode lançar mensagem com valor de linha — `RAISE EXCEPTION` interpolando ID/CPF, erro de cast reproduzindo o valor inválido. Nos 4 queries concretos do #1550 o risco é baixo (filtros constantes, único dinâmico é UUID), **mas o helper é genérico** e a garantia documentada não valia. Confirmei que `captureException` (`src/lib/analytics.ts`) repassa o contexto direto ao PostHog, **sem sanitização central**.

**Correção:** a telemetria passa a mandar só metadado seguro — `code` (transporte, valor fechado do Postgres) e uma **`categoria` normalizada por allowlist de SQLSTATE** (`57014`→timeout, `42501`→rls_ou_permissao, `P0001`→excecao_customizada, `08*`→conexao, `53*`→recursos, resto→desconhecido; `data:null`→data_null_sem_error). A `message` crua **nunca** sai. Quem quiser diagnosticá-la ainda a tem via `error.cause` na exceção que sobe.

O teste-âncora injeta uma mensagem com CPF + nome + email e prova que **nenhum fragmento** aparece na telemetria (nem no contexto, nem no `Error`).

## (b) `fonte` passa a ser obrigatória

Era opcional (`= 'nao-informada'`) para não tocar os 11 callers recém-mergeados do #1545. O Codex apontou que isso justifica uma migração compatível, não a API permanente: o propósito de `fonte` é agregação **estável**, e o fallback (stack trace) é instável — a exceção nasce dentro de `relatarPaginaPerdida`, e stack assíncrono/minificação/source-maps mudam entre builds. Um default silencioso deixaria a lacuna justo no mecanismo de observabilidade. Agora o compilador garante o rótulo; os 15 call-sites já o passam.

## Rename: `linhas_perdidas` → `linhas_lidas_antes_da_falha`

Também do Codex: o valor era `todas.length` — linhas **lidas antes** de estourar, não "perdidas" (o total da tabela é desconhecido). O nome antigo afirmava um número que não temos.

## O que NÃO está aqui (chip próprio)

O Codex achou um bug **pré-existente** que o #1550 não criou nem consertou: o fallback super_admin nos engines (`if (!clientScores.length && !isImpersonating) fetchAllScores()`) decide escopo pela **cardinalidade** do resultado, não por role/capability. Farmer real sem carteira é tratado como possível super_admin. É mudança de lógica de autorização — merece PR isolado com prova própria. Chip aberto: **"Fallback super_admin decide escopo por cardinalidade, não por role"**.

## Prova

- RED sobre o helper mergeado + teste novo (asserts de PII/categoria falham) → GREEN com o helper novo.
- Falsificação: sabotar a allowlist (voltar a mandar `message`) tem de reprovar o teste-âncora de PII.
- Gates do CI verdes.

## Origem

Parecer cru do Codex preservado em anexo à sessão. Este PR fecha a `REVISÃO INDEPENDENTE PENDENTE` do #1550 nos pontos (a) e (b); (c) segue como chip.
