### PR TITLE
fix(farmer): 6 colunas de score sem produtor param de fabricar — DEFAULT 0 → null [money-path]

### DIFF
--- a/db/test-farmer-scores-colunas-orfas.sh
+++ b/db/test-farmer-scores-colunas-orfas.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260727130000_farmer_scores_colunas_orfas_null.sql              ║
+# ║  DROP DEFAULT + backfill NULL nas 6 colunas órfãs, enfileirando SÓ os fósseis. ║
+# ║  Rode: bash db/test-farmer-scores-colunas-orfas.sh > /tmp/t.log 2>&1; echo $?  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="farmer-orfas"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup PG17 :$PORT ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — SCHEMA (reproduz prod ANTES: DEFAULT 0 nas 6) + trigger real + fila + SEED
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TABLE public.farmer_client_scores (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  customer_user_id  uuid NOT NULL,
+  farmer_id         uuid NOT NULL,
+  priority_score    numeric,
+  churn_risk        numeric,
+  signal_modifiers  jsonb,
+  recover_score     numeric DEFAULT 0,
+  expansion_score   numeric DEFAULT 0,
+  revenue_potential numeric DEFAULT 0,
+  x_score           numeric DEFAULT 0,
+  s_score           numeric DEFAULT 0,
+  eff_score         numeric DEFAULT 0
+);
+
+CREATE TABLE public.visit_score_recalc_queue (
+  id               bigserial PRIMARY KEY,
+  customer_user_id uuid NOT NULL,
+  farmer_id        uuid NOT NULL,
+  reason           text,
+  processed_at     timestamptz,
+  created_at       timestamptz DEFAULT now()
+);
+CREATE UNIQUE INDEX visit_score_recalc_queue_pending_uk
+  ON public.visit_score_recalc_queue (customer_user_id) WHERE processed_at IS NULL;
+
+-- trigger REAL de prod (corpo verbatim de pg_get_functiondef, 2026-07-22): observa expansion_score.
+CREATE OR REPLACE FUNCTION public.enqueue_visit_score_recalc_from_client_score()
+ RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+BEGIN
+  IF (NEW.priority_score    IS DISTINCT FROM OLD.priority_score
+      OR NEW.churn_risk      IS DISTINCT FROM OLD.churn_risk
+      OR NEW.expansion_score IS DISTINCT FROM OLD.expansion_score
+      OR NEW.signal_modifiers IS DISTINCT FROM OLD.signal_modifiers)
+     AND NEW.customer_user_id IS NOT NULL
+     AND NEW.farmer_id IS NOT NULL THEN
+    INSERT INTO public.visit_score_recalc_queue
+      (customer_user_id, farmer_id, reason)
+    VALUES
+      (NEW.customer_user_id, NEW.farmer_id, 'score_changed')
+    ON CONFLICT (customer_user_id) WHERE processed_at IS NULL DO NOTHING;
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+CREATE TRIGGER trg_farmer_client_scores_enqueue_visit_recalc
+  AFTER UPDATE ON public.farmer_client_scores
+  FOR EACH ROW EXECUTE FUNCTION public.enqueue_visit_score_recalc_from_client_score();
+
+-- SEED: 1 FÓSSIL (expansion=60, muda de missão) + 2 no DEFAULT 0 (expansion=0, missão não muda).
+INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id, priority_score, churn_risk, expansion_score)
+VALUES ('a0000000-0000-0000-0000-000000000001','f0000000-0000-0000-0000-000000000009', 30, 96, 60);
+INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id, priority_score, churn_risk)
+VALUES ('a0000000-0000-0000-0000-000000000002','f0000000-0000-0000-0000-000000000009', 30, 96);
+INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id, priority_score, churn_risk)
+VALUES ('a0000000-0000-0000-0000-000000000003','f0000000-0000-0000-0000-000000000009', 30, 96);
+SQL
+
+SEED_FILA=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue;")
+eq "SETUP fila vazia após seed" "$SEED_FILA" "0"
+FOSSIL=$(Pq -c "SELECT count(*) FROM public.farmer_client_scores WHERE expansion_score = 60;")
+eq "SETUP 1 linha fóssil expansion=60" "$FOSSIL" "1"
+ZEROS=$(Pq -c "SELECT count(*) FROM public.farmer_client_scores WHERE recover_score = 0 AND x_score = 0 AND s_score = 0 AND eff_score = 0 AND revenue_potential = 0;")
+eq "SETUP 3 linhas com as órfãs no DEFAULT 0" "$ZEROS" "3"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260727130000_farmer_scores_colunas_orfas_null.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts ──"
+
+# P2 — backfill: TODAS as 6 colunas viram NULL em TODAS as linhas (0 e o fóssil 60).
+NAONULOS=$(Pq -c "SELECT count(*) FROM public.farmer_client_scores
+  WHERE recover_score IS NOT NULL OR expansion_score IS NOT NULL OR revenue_potential IS NOT NULL
+     OR x_score IS NOT NULL OR s_score IS NOT NULL OR eff_score IS NOT NULL;")
+eq "P2 backfill: 0 linhas com qualquer órfã não-nula" "$NAONULOS" "0"
+
+# P1 — DROP DEFAULT: linha NOVA que OMITE as 6 nasce NULL, não 0.
+P -q -c "INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id, priority_score, churn_risk)
+         VALUES ('a0000000-0000-0000-0000-0000000000ff','f0000000-0000-0000-0000-000000000009', 30, 96);"
+NOVA=$(Pq -c "SELECT count(*) FROM public.farmer_client_scores
+  WHERE customer_user_id='a0000000-0000-0000-0000-0000000000ff'
+    AND recover_score IS NULL AND expansion_score IS NULL AND revenue_potential IS NULL
+    AND x_score IS NULL AND s_score IS NULL AND eff_score IS NULL;")
+eq "P1 DROP DEFAULT: INSERT omitindo as 6 → NULL (não 0)" "$NOVA" "1"
+
+# P3 — propagação CIRÚRGICA: a fila tem SÓ o fóssil (1), NÃO as 3 linhas existentes.
+#      (a linha nova P1 é INSERT com o trigger ativo, mas expansion NULL IS NOT DISTINCT de NULL →
+#       o trigger não dispara; de todo modo INSERT não é UPDATE. Por isso a fila = 1, não 2.)
+FILA=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue;")
+eq "P3 fila tem SÓ o fóssil (não a base inteira)" "$FILA" "1"
+FILA_FOSSIL=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue
+  WHERE customer_user_id='a0000000-0000-0000-0000-000000000001' AND reason='expansion_orfa_backfill';")
+eq "P3b o fóssil está na fila com o reason certo" "$FILA_FOSSIL" "1"
+# P3c — os 2 não-fósseis (expansion era 0) NÃO foram enfileirados (supressão via session_replication_role)
+NAO_FOSSEIS=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue
+  WHERE customer_user_id IN ('a0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-000000000003');")
+eq "P3c não-fósseis (expansion=0) NÃO enfileirados" "$NAO_FOSSEIS" "0"
+
+# P3d — session_replication_role foi RESTAURADO (SET LOCAL reverte no COMMIT; não vazou 'replica')
+SRR=$(Pq -c "SHOW session_replication_role;")
+eq "P3d session_replication_role restaurado a 'origin'" "$SRR" "origin"
+
+# P4 — idempotência: re-aplicar a migration INTEIRA não muda a fila nem re-nula (WHERE guard).
+P -q -f "$MIG"
+FILA2=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue;")
+eq "P4 idempotência: 2ª aplicação da migration não re-enfileira" "$FILA2" "1"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (sabota → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+FALSIF_OK=0; FALSIF_BAD=0
+fok()  { FALSIF_OK=$((FALSIF_OK+1));  echo "  ✅ falsif: $1"; }
+fbad() { FALSIF_BAD=$((FALSIF_BAD+1)); echo "  ❌ falsif INÓCUA: $1"; }
+
+# F1 — DROP DEFAULT tem dente? Re-arma o DEFAULT 0 e insere omitindo → nasce 0 (P1 mordeu).
+P -q -c "ALTER TABLE public.farmer_client_scores ALTER COLUMN expansion_score SET DEFAULT 0;"
+P -q -c "INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id, priority_score, churn_risk)
+         VALUES ('b0000000-0000-0000-0000-0000000000f1','f0000000-0000-0000-0000-000000000009', 30, 96);"
+SAB1=$(Pq -c "SELECT expansion_score FROM public.farmer_client_scores WHERE customer_user_id='b0000000-0000-0000-0000-0000000000f1';")
+if [ "$SAB1" = "0" ]; then fok "F1 sem DROP DEFAULT, INSERT omitindo → 0 (P1 mordeu)"; else fbad "F1 esperava 0, veio [$SAB1]"; fi
+P -q -c "ALTER TABLE public.farmer_client_scores ALTER COLUMN expansion_score DROP DEFAULT;"
+P -q -c "DELETE FROM public.farmer_client_scores WHERE customer_user_id='b0000000-0000-0000-0000-0000000000f1';"
+
+# F2 — P2 tem dente? Injeta fóssil remanescente → count não-null passa de 0 → 1.
+P -q -c "INSERT INTO public.farmer_client_scores (customer_user_id, farmer_id, priority_score, churn_risk, expansion_score)
+         VALUES ('b0000000-0000-0000-0000-0000000000f2','f0000000-0000-0000-0000-000000000009', 30, 96, 60);"
+SAB2=$(Pq -c "SELECT count(*) FROM public.farmer_client_scores WHERE expansion_score IS NOT NULL;")
+if [ "$SAB2" = "1" ]; then fok "F2 fóssil remanescente detectado por P2 (=1)"; else fbad "F2 esperava 1, veio [$SAB2]"; fi
+P -q -c "DELETE FROM public.farmer_client_scores WHERE customer_user_id='b0000000-0000-0000-0000-0000000000f2';"
+
+# F3 — a SUPRESSÃO (session_replication_role) tem dente? Prova que SEM ela o trigger enfileira o
+#      não-fóssil também. Com replica → UPDATE de expansion NÃO enfileira; com origin → enfileira.
+#      Se P3c fosse tautológico, este contraste não apareceria.
+P -q -c "DELETE FROM public.visit_score_recalc_queue;"
+# (a) sob replica: UPDATE de expansion no cliente 002 NÃO deve enfileirar
+P -q -c "BEGIN; SET LOCAL session_replication_role = replica;
+         UPDATE public.farmer_client_scores SET expansion_score = 5 WHERE customer_user_id='a0000000-0000-0000-0000-000000000002'; COMMIT;"
+SAB3A=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue;")
+# (b) sob origin (default): UPDATE de expansion no cliente 003 DEVE enfileirar (trigger ativo)
+P -q -c "UPDATE public.farmer_client_scores SET expansion_score = 5 WHERE customer_user_id='a0000000-0000-0000-0000-000000000003';"
+SAB3B=$(Pq -c "SELECT count(*) FROM public.visit_score_recalc_queue;")
+if [ "$SAB3A" = "0" ] && [ "$SAB3B" = "1" ]; then
+  fok "F3 supressão tem dente: replica não enfileira (=$SAB3A), origin enfileira (=$SAB3B)"
+else
+  fbad "F3 esperava replica=0 e origin=1, veio replica=$SAB3A origin=$SAB3B"
+fi
+
+echo "── falsificação: $FALSIF_OK com dente / $FALSIF_BAD inócuas ──"
+[ "$FALSIF_BAD" = "0" ] || FAIL=$((FAIL+1))
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/valida-farmer-scores-orfas.sql
+++ b/db/valida-farmer-scores-orfas.sql
@@ -1,0 +1,44 @@
+-- Validação PÓS-APPLY de 20260727130000_farmer_scores_colunas_orfas_null.sql
+-- Roda de QUALQUER role (psql-ro OU SQL Editor): LÊ CATÁLOGO/dados, NUNCA invoca função (lição
+-- #1462 — validação que chama objeto mente nos dois sentidos). Cole no SQL Editor após o Run, ou
+-- eu rodo via psql-ro.
+
+\echo '=== (1) DEFAULT removido das 6 colunas (column_default deve ser vazio) ==='
+SELECT column_name, column_default
+FROM information_schema.columns
+WHERE table_name = 'farmer_client_scores'
+  AND column_name IN ('recover_score','expansion_score','revenue_potential','x_score','s_score','eff_score')
+ORDER BY column_name;
+-- ESPERADO: column_default vazio (NULL) nas 6 linhas.
+
+\echo ''
+\echo '=== (2) Backfill: as 6 colunas 100% NULL (0 não-nulos cada) ==='
+SELECT
+  count(*)                                              AS total,
+  count(*) FILTER (WHERE recover_score     IS NOT NULL) AS recover_nn,
+  count(*) FILTER (WHERE expansion_score   IS NOT NULL) AS expansion_nn,
+  count(*) FILTER (WHERE revenue_potential IS NOT NULL) AS revenue_nn,
+  count(*) FILTER (WHERE x_score           IS NOT NULL) AS x_nn,
+  count(*) FILTER (WHERE s_score           IS NOT NULL) AS s_nn,
+  count(*) FILTER (WHERE eff_score         IS NOT NULL) AS eff_nn
+FROM farmer_client_scores;
+-- ESPERADO: *_nn = 0 em todas (o fóssil expansion=60 e o 0 fabricado viraram NULL).
+
+\echo ''
+\echo '=== (3) Propagação CIRÚRGICA: só os fósseis (expansion era 60) foram enfileirados ==='
+SELECT count(*) FILTER (WHERE reason = 'expansion_orfa_backfill' AND processed_at IS NULL) AS fosseis_enfileirados,
+       count(*) FILTER (WHERE processed_at IS NULL)                                        AS total_pendentes
+FROM visit_score_recalc_queue;
+-- ESPERADO: fosseis_enfileirados ~= 303 (o baseline dos expansion=60), NÃO 6633. A supressão via
+-- session_replication_role impede a inundação da fila; só os 303 que mudam de missão entram.
+-- Drena em 1 noite (303 < max_drain 500 do visit-score-recalc-batch).
+
+\echo ''
+\echo '=== (4) DIFERIDA — rode APÓS o dreno da fila (próximo batch): missão EXPANSÃO fóssil sumiu ==='
+SELECT primary_mission, count(*) AS n, round(avg(visit_score), 2) AS media
+FROM customer_visit_scores
+GROUP BY primary_mission
+ORDER BY n DESC;
+-- ESPERADO: 'expansao' cai de 169 (todos com visit_score=36,00) para ~0 — nenhum cliente pode
+-- receber a missão EXPANSÃO enquanto expansion_score não tiver produtor. Os 169 migram para
+-- recuperacao/prospeccao conforme os demais sinais.

--- a/src/components/adminCustomers/__tests__/CustomerListView.test.tsx
+++ b/src/components/adminCustomers/__tests__/CustomerListView.test.tsx
@@ -31,7 +31,7 @@ const score: ClientScore = {
   customer_user_id: "c1",
   health_score: 80,
   health_class: "saudavel",
-  churn_risk: 0.1,
+  churn_risk: 20, // escala 0–100 (= 100 - health_score), NÃO fração 0–1
   expansion_score: 5,
   priority_score: 5.2,
   avg_monthly_spend_180d: 1000,

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -106,6 +106,11 @@ export function IntelligenceStrategicTab() {
   const top20Revenue = sortedByRevenue.slice(0, top20Count).reduce((a, c) => a + Number(c.revenue_potential || 0), 0);
   const totalRevenue = sortedByRevenue.reduce((a, c) => a + Number(c.revenue_potential || 0), 0);
   const concentrationPct = totalRevenue > 0 ? (top20Revenue / totalRevenue * 100) : 0;
+  // revenue_potential não tem produtor server-side (coluna órfã, 0/null para toda a base). Sem
+  // potencial medido a concentração é 0/0 — mostrar "0,0%" fabricaria "carteira nada concentrada".
+  // "—", como a Margem Bruta faz quando avgGrossMargin é null. (≠ scoresIndisponivel, que é erro
+  // de leitura; aqui a leitura foi OK e o dado é que não existe.)
+  const concentracaoIndisponivel = totalRevenue === 0;
 
   const discountedItems = orderItems?.filter(i => Number(i.discount || 0) > 0) || [];
   const avgDiscountQty = discountedItems.length > 0
@@ -194,7 +199,7 @@ export function IntelligenceStrategicTab() {
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
         <KpiCard title="LTV Projetado (3a)" value={ou(`R$ ${ltvEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`)} icon={BarChart3} subtitle="Estimativa média" />
         <KpiCard title="CAC Estimado" value={ou(`R$ ${cacEstimate.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`)} icon={DollarSign} subtitle="Custo aquisição cliente" />
-        <KpiCard title="Concentração Top 20%" value={ou(`${concentrationPct.toFixed(1)}%`)} icon={PieChart} subtitle="da receita total" />
+        <KpiCard title="Concentração Top 20%" value={scoresIndisponivel || concentracaoIndisponivel ? '—' : `${concentrationPct.toFixed(1)}%`} icon={PieChart} subtitle={scoresIndisponivel ? 'base indisponível' : concentracaoIndisponivel ? 'potencial não medido' : 'da receita total'} />
         <KpiCard
           title="Margem Bruta Média"
           value={scoresIndisponivel || avgGrossMargin == null ? '—' : `${avgGrossMargin.toFixed(1)}%`}

--- a/src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx
+++ b/src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx
@@ -20,12 +20,22 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 type Resposta = { data: unknown; error: unknown };
 let falharScores = false;
+let scoresRevenueAusente = false;
 
 const ERRO_PG = { message: 'canceling statement due to statement timeout', code: '57014' };
 
+// Leitura OK, mas revenue_potential ausente (a coluna órfã real de prod: sem produtor server-side).
+// A Concentração não tem potencial pra concentrar → "—" (potencial não medido), nunca 0,0%.
+const SCORES_SEM_REVENUE = [
+  { customer_user_id: 'c1', gross_margin_pct: null, avg_monthly_spend_180d: 1000, avg_repurchase_interval: 5, revenue_potential: null },
+  { customer_user_id: 'c2', gross_margin_pct: null, avg_monthly_spend_180d: 2000, avg_repurchase_interval: 8, revenue_potential: null },
+];
+
 function resposta(table: string): Resposta {
   if (table === 'farmer_client_scores') {
-    return falharScores ? { data: null, error: ERRO_PG } : { data: [], error: null };
+    if (falharScores) return { data: null, error: ERRO_PG };
+    if (scoresRevenueAusente) return { data: SCORES_SEM_REVENUE, error: null };
+    return { data: [], error: null };
   }
   return { data: [], error: null };
 }
@@ -58,7 +68,7 @@ const renderWithClient = (ui: ReactElement) => {
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 };
 
-beforeEach(() => { falharScores = true; vi.clearAllMocks(); });
+beforeEach(() => { falharScores = true; scoresRevenueAusente = false; vi.clearAllMocks(); });
 
 describe('IntelligenceManagerialTab — falha de carga não vira "0 clientes"', () => {
   it('anuncia indisponibilidade em vez de renderizar os KPIs zerados', async () => {
@@ -109,5 +119,29 @@ describe('IntelligenceStrategicTab — falha de carga não vira LTV/CAC/Concentr
       const card = el!.closest('div')?.parentElement;
       expect(card?.textContent, `KPI "${titulo}" exibiu zero fabricado`).toMatch(/—/);
     }
+  });
+});
+
+/**
+ * Guard money-path — coluna ÓRFÃ (leitura OK, dado inexistente) ≠ erro de transporte.
+ *
+ * revenue_potential não tem produtor server-side: em prod é 0/null para toda a base. A leitura
+ * SUCEDE (nenhum alerta de indisponibilidade), mas o KPI de Concentração calcularia 0/0. Exibir
+ * "0,0%" afirmaria "carteira nada concentrada" — um número fabricado de um dado que não existe.
+ * Contrato: nesse caso o KPI diz "—" com o motivo "potencial não medido" (distinto de "base
+ * indisponível", que é o caso de erro acima).
+ */
+describe('IntelligenceStrategicTab — Concentração sob revenue_potential órfão', () => {
+  beforeEach(() => { falharScores = false; scoresRevenueAusente = true; });
+
+  it('mostra "—" (potencial não medido), não 0,0%, quando a leitura foi OK mas o potencial é ausente', async () => {
+    renderWithClient(<IntelligenceStrategicTab />);
+
+    const el = await screen.findByText('Concentração Top 20%');
+    const card = el.closest('div')?.parentElement;
+    // "—" com o motivo do órfão — e SEM alerta de "indisponível" (a base foi lida com sucesso).
+    expect(card?.textContent, 'Concentração exibiu 0,0% fabricado').toMatch(/—/);
+    expect(card?.textContent, 'faltou o motivo "potencial não medido"').toMatch(/não medido/);
+    expect(screen.queryByRole('alert'), 'não devia anunciar indisponibilidade: a leitura sucedeu').toBeNull();
   });
 });

--- a/src/hooks/useFarmerPerformance.ts
+++ b/src/hooks/useFarmerPerformance.ts
@@ -298,7 +298,9 @@ export const useFarmerPerformance = () => {
       const ipfLtvEvolution = Math.round(Math.min(100, (avgSpend / 2000) * 100));
 
       // 5. Churn reduction: % of clients with low churn risk (<30%)
-      const lowChurnClients = clientArr.filter((c) => Number(c.churn_risk || 100) < 30).length;
+      // `?? 100` (não `|| 100`): churn ausente conta como pior caso (não é "baixo churn"), mas
+      // churn REAL = 0 (cliente perfeitamente saudável) tem de contar — `|| 100` o tratava como 100.
+      const lowChurnClients = clientArr.filter((c) => Number(c.churn_risk ?? 100) < 30).length;
       const ipfChurnReduction = clientArr.length > 0
         ? Math.round((lowChurnClients / clientArr.length) * 100)
         : 0;

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -245,7 +245,7 @@ export const useTacticalPlan = () => {
       customerName: profileMap.get(d.customer_user_id) || 'Cliente',
       planType: d.plan_type || 'essencial',
       healthScore: Number(d.health_score || 0),
-      churnRisk: Number(d.churn_risk || 0),
+      churnRisk: Number(d.churn_risk ?? 0), // ?? (não ||): churn=0 é valor real (cliente saudável), não ausência
       mixGap: Number(d.mix_gap || 0),
       // O plano persistido grava a margem do cliente no INSTANTE da geração; pós-#1495 ela
       // pode ser null, e `Number(null || 0)` a exibiria como "0,0%" — margem nula apurada.
@@ -424,7 +424,7 @@ export const useTacticalPlan = () => {
       }
 
       const healthScore = Number(score.health_score || 0);
-      const churnRisk = Number(score.churn_risk || 0);
+      const churnRisk = Number(score.churn_risk ?? 0); // ?? (não ||): churn=0 é valor real, não ausência
       const avgSpend = Number(score.avg_monthly_spend_180d || 0);
       const marginPct = margemConhecida(score.gross_margin_pct);
       const categoryCount = Number(score.category_count || 0);

--- a/supabase/functions/calculate-scores/index.ts
+++ b/supabase/functions/calculate-scores/index.ts
@@ -57,15 +57,18 @@ interface FarmerClientScoreSeed {
   // zero que criava o loop fechado. m_score idem (é o score derivado desta margem).
   gross_margin_pct: number | null;
   avg_repurchase_interval: number;
-  expansion_score: number;
-  recover_score: number;
-  revenue_potential: number;
+  // As 6 colunas SEM produtor (nenhum writer as calcula; só este seed as tocava, com 0). null =
+  // "não medido", nunca 0 — mesma razão do gross_margin_pct acima. O DEFAULT 0 foi removido na
+  // migration 20260727130000; enviar null EXPLÍCITO independe da ordem de deploy migration×edge.
+  expansion_score: number | null;
+  recover_score: number | null;
+  revenue_potential: number | null;
   rf_score: number;
   m_score: number | null;
   g_score: number;
-  s_score: number;
-  x_score: number;
-  eff_score: number;
+  s_score: number | null;
+  x_score: number | null;
+  eff_score: number | null;
   sales_history_status: 'sem_historico' | 'stale' | 'ativo';
 }
 
@@ -459,15 +462,18 @@ Deno.serve(async (req) => {
               // sobrevivia a qualquer run em que a RPC de margem falhasse.
               gross_margin_pct: null,
               avg_repurchase_interval: 0,
-              expansion_score: 0,
-              recover_score: 0,
-              revenue_potential: 0,
+              // As 6 colunas SEM produtor → null ("não medido"), nunca 0. O 0 aqui era a arma
+              // carregada: um valor de decisão fabricado numa coluna que ninguém calcula (missão de
+              // recuperação/expansão, componentes de health/priority). Ver migration 20260727130000.
+              expansion_score: null,
+              recover_score: null,
+              revenue_potential: null,
               rf_score: 0,
               m_score: null,
               g_score: 0,
-              s_score: 0,
-              x_score: 0,
-              eff_score: 0,
+              s_score: null,
+              x_score: null,
+              eff_score: null,
               sales_history_status: deriveSalesHistoryStatus(salesMap.get(client.user_id), salesActiveDays),
             });
           }

--- a/supabase/migrations/20260727130000_farmer_scores_colunas_orfas_null.sql
+++ b/supabase/migrations/20260727130000_farmer_scores_colunas_orfas_null.sql
@@ -1,0 +1,103 @@
+-- Farmer scoring — desarmar o DEFAULT 0 das 6 colunas de score SEM produtor ("colunas órfãs")
+--
+-- PROBLEMA (medido em prod 2026-07-22 via psql-ro): seis colunas de farmer_client_scores estão
+-- 0 para toda a base porque NENHUM writer as calcula. O compute persiste por apply_score_updates,
+-- cuja lista de colunas é FIXA e não as inclui; o único ponto que as escreve é o SEED
+-- (calculate-scores/index.ts), com 0 literal. Distribuição (6.633 linhas):
+--     recover_score      6633 zeros / 0 positivos      DEFAULT 0
+--     revenue_potential  6633 zeros / 0 positivos      DEFAULT 0
+--     x_score            6633 zeros / 0 positivos      DEFAULT 0
+--     s_score            6633 zeros / 0 positivos      DEFAULT 0
+--     eff_score          6633 zeros / 0 positivos      DEFAULT 0
+--     expansion_score    6330 zeros / 303 = 60         DEFAULT 0   (os 303 são FÓSSEIS de mai/2026,
+--                            de um writer despromovido em 20260520010000_scoring_visit_p1_fixes.sql:
+--                            "o scoring-recalc passou a gravar SÓ signal_modifiers")
+-- É a assinatura EXATA do gross_margin_pct antes do #1495 (rótulo com DEFAULT constante que nenhum
+-- writer setou — money-path.md §2). O DEFAULT 0 é uma arma carregada: no dia em que um consumidor
+-- ler a coluna sem coagir, o 0 fabrica um número no caminho que dirige a agenda do vendedor.
+--
+-- EFEITO ATIVO desta migration (fabricação que HOJE chega a uma decisão):
+--   • expansion_score: as 303 linhas fósseis (=60) fazem scoreExpansao = 60*0,6 = 36 e vencem a
+--     missão de 169 clientes em customer_visit_scores (visit_score = 36,00, sem variância). Nulá-las
+--     + enfileirar SÓ esses 303 no visit_score_recalc_queue re-scora e derruba a missão fóssil.
+--   • revenue_potential: customer360 (nova) mostra "R$ 0,00" fabricado → "—" (já trata null); o KPI
+--     "Concentração Top 20%" deixa de exibir 0% enganoso.
+--
+-- EFEITO PREPARATÓRIO (inerte HOJE, pré-requisito estrutural do produtor futuro):
+--   recover_score, x_score, s_score, eff_score — os consumidores já coagem `|| 0`, então 0→null
+--   não muda comportamento agora. Mas SEM o null o produtor futuro não consegue distinguir "não
+--   medido" de "medido zero" (a lição do gross_margin_pct/#1495). Desarmar o DEFAULT agora é a
+--   metade "consumidor" do par consumidor+produtor (mesma ordem segura do #1498 → #1495).
+--
+-- O QUE ESTA MIGRATION NÃO RESOLVE (produtor server-side + displays que coagem null→0, follow-up):
+--   o dano SISTÊMICO de valor-ausente (health_score deprimido, 35% do priority_score morto,
+--   recoverBoost nulo) e os displays que ainda mostram 0 fabricado (plano tático→LLM, Customer360
+--   administrativa via escopo-clientes `?? 0`). Nullar NÃO conserta isso; só um produtor conserta.
+--
+-- ⚠️ ORDEM DE DEPLOY — deploye a EDGE calculate-scores ANTES desta migration (achado Codex xhigh):
+--   • Edge primeiro: o seed novo grava null; linhas novas nascem null (DEFAULT 0 NÃO sobrescreve
+--     null explícito). Depois a migration remove o DEFAULT e backfilla as existentes. Sem janela.
+--   • Migration primeiro (NÃO recomendado): entre o apply e o deploy da edge, o cron diário roda o
+--     seed ANTIGO, que grava 0 explícito em novos faltantes — e como apply_score_updates não toca
+--     essas colunas, esse 0 fica PERMANENTE. Salvaguarda: re-rode o backfill (é idempotente) DEPOIS
+--     de deployar a edge nova.
+--
+-- BASELINE medido em prod ANTES do apply (reconstruível: as colunas sobrevivem ao apply como null):
+--   recover/revenue_potential/x/s/eff = 0 em 6633/6633 · expansion = 60 em 303, 0 em 6330 · 0 nulos.
+--   customer_visit_scores: 169 com primary_mission='expansao', visit_score=36,00 (min=max=36).
+-- Pós-apply: as 6 colunas → 6633 NULLs, 0 positivos; visit_score_recalc_queue ganha ~303 pendências
+--   (NÃO 6633 — ver nota do backfill); após o dreno, os 169 'expansao' migram para outra missão.
+
+BEGIN;
+
+-- (1) Desarmar o DEFAULT constante. DROP DEFAULT é idempotente (no-op se já não há default).
+ALTER TABLE public.farmer_client_scores ALTER COLUMN recover_score     DROP DEFAULT;
+ALTER TABLE public.farmer_client_scores ALTER COLUMN expansion_score   DROP DEFAULT;
+ALTER TABLE public.farmer_client_scores ALTER COLUMN revenue_potential DROP DEFAULT;
+ALTER TABLE public.farmer_client_scores ALTER COLUMN x_score           DROP DEFAULT;
+ALTER TABLE public.farmer_client_scores ALTER COLUMN s_score           DROP DEFAULT;
+ALTER TABLE public.farmer_client_scores ALTER COLUMN eff_score         DROP DEFAULT;
+
+-- (2) Capturar os FÓSSEIS (expansion_score não-nulo e <> 0 → os 303 com 60) ANTES de nular. São os
+--     únicos cujo visit_score MUDA (60→null vira scoreExpansao 0, deixando a missão EXPANSÃO cair).
+--     Os 6330 com expansion=0 já dão scoreExpansao 0 e não precisam de recálculo.
+CREATE TEMP TABLE _fcs_fosseis_expansion ON COMMIT DROP AS
+  SELECT customer_user_id, farmer_id
+  FROM public.farmer_client_scores
+  WHERE expansion_score IS NOT NULL AND expansion_score <> 0
+    AND customer_user_id IS NOT NULL AND farmer_id IS NOT NULL;
+
+-- (3) Backfill: trocar o 0 fabricado (e o fóssil expansion=60) por NULL honesto.
+--     session_replication_role=replica SUPRIME o trigger de enqueue durante o UPDATE em massa. Sem
+--     isso, nular expansion_score enfileira as 6.633 linhas (0→null e 60→null são ambos DISTINCT de
+--     null) — e a fila drena só 500/noite (visit-score-recalc-batch max_drain:500) = ~14 noites,
+--     enterrando os 303 que importam atrás de 6.330 recálculos inúteis; pior, recalcOne marca
+--     processed_at MESMO em erro, sem retry, então um fóssil pode se perder (achado Codex xhigh).
+--     O WHERE mantém o UPDATE idempotente (2ª execução afeta 0 linhas).
+SET LOCAL session_replication_role = replica;
+
+UPDATE public.farmer_client_scores
+SET recover_score     = NULL,
+    expansion_score   = NULL,
+    revenue_potential = NULL,
+    x_score           = NULL,
+    s_score           = NULL,
+    eff_score         = NULL
+WHERE recover_score     IS NOT NULL
+   OR expansion_score   IS NOT NULL
+   OR revenue_potential IS NOT NULL
+   OR x_score           IS NOT NULL
+   OR s_score           IS NOT NULL
+   OR eff_score         IS NOT NULL;
+
+SET LOCAL session_replication_role = origin;
+
+-- (4) Enfileirar SÓ os fósseis capturados (os que mudam de missão), imitando o trigger real
+--     (mesmo índice único parcial do ON CONFLICT). Drena em 1 noite (303 < 500), sem atrasar
+--     eventos normais nem re-recalcular 6.330 clientes cujo visit_score não muda.
+INSERT INTO public.visit_score_recalc_queue (customer_user_id, farmer_id, reason)
+SELECT customer_user_id, farmer_id, 'expansion_orfa_backfill'
+FROM _fcs_fosseis_expansion
+ON CONFLICT (customer_user_id) WHERE processed_at IS NULL DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## O que

Seis colunas de `farmer_client_scores` estão **sem produtor server-side** — nenhum writer as calcula, o único ponto que as tocava é o seed da edge (com `0` literal), e o DDL tem `DEFAULT 0`. Medido em prod (psql-ro, 2026-07-22) sobre 6.633 linhas:

| coluna | zeros | positivos | `column_default` |
|---|---|---|---|
| `recover_score` | 6633 | 0 | `0` |
| `revenue_potential` | 6633 | 0 | `0` |
| `x_score` | 6633 | 0 | `0` |
| `s_score` | 6633 | 0 | `0` |
| `eff_score` | 6633 | 0 | `0` |
| `expansion_score` | 6330 | 303 (*todos = 60*) | `0` |

É a assinatura exata do `gross_margin_pct` antes do #1495 (rótulo com `DEFAULT` constante que nenhum writer setou — `money-path.md` §2). Este PR **para a fabricação**: remove o `DEFAULT 0` e faz backfill `NULL`. **Não** cria produtor (isso é follow-up).

## Por que importa (efeito medido no consumidor, não na tabela)

- **`expansion_score`** — as 303 linhas fósseis (=60, mai/2026, de um writer despromovido em `20260520010000`) fazem `scoreExpansao = 60·0,6 = 36` e vencem a missão de **169 clientes** em `customer_visit_scores` (`visit_score = 36,00`, sem variância, todos vindos das 303). Ser elegível à missão EXPANSÃO hoje depende só de ter sido tocado por um writer morto. Backfill→`NULL` + enfileirar **só esses 303** re-scora e derruba a missão fóssil.
- **`revenue_potential`** — `customer360` (nova) mostra "R$ 0,00" fabricado → "—"; KPI "Concentração Top 20%" mostra 0% enganoso → "—".

## Ativo vs preparatório (honestidade — isto NÃO conserta o farmer scoring)

- **Ativo** (fabricação que hoje chega a uma decisão): `expansion_score`, `revenue_potential`.
- **Preparatório** (inerte hoje — consumidores já coagem `|| 0`; mas o `null` é pré-requisito estrutural do produtor futuro distinguir "não medido" de "medido 0", a lição do `gross_margin_pct`): `recover_score`, `x_score`, `s_score`, `eff_score`.
- **NÃO resolve** (fica para o produtor server-side + displays que coagem null→0): o dano sistêmico de valor-ausente — `health_score` deprimido (`x_score`/`s_score`=0 comem ~20% do teto: média 4,00, **zero** clientes saudáveis, churn médio 96), 35% do `priority_score` morto, `recoverBoost` de 0,3 nulo. Nullar não recupera capacidade; só um produtor que **calcule** os valores recupera.

## Mudanças

- **Migration** `20260727130000_farmer_scores_colunas_orfas_null.sql` (⚠️ **manual** — cole no SQL Editor): `DROP DEFAULT` + backfill `NULL` nas 6, enfileirando **só os 303 fósseis** (via `session_replication_role` para suprimir o trigger no backfill em massa). Provada em PG17 (`db/test-farmer-scores-colunas-orfas.sh`, 10 asserts + 3 falsificações com dente). Validação pós-apply em `db/valida-farmer-scores-orfas.sql` (lê catálogo, não invoca — lição #1462).
- **Edge** `calculate-scores`: seed grava `null` nas 6 (+ type `number | null`). Compute robusto a null (todos os usos coagem `|| 0`).
- **Consumidor** `IntelligenceStrategicTab`: KPI Concentração mostra "—" quando `revenue_potential` órfão (+ teste de regressão em `tabs-erro-honesto.test.tsx`).
- **Resíduos** (varredura do PR #1547): fixture `churn_risk 0.1`→escala 0-100; `useTacticalPlan:248,427` `||`→`??`; `useFarmerPerformance:301` `|| 100`→`?? 100` (corrige bug ativo: cliente `churn=0` era contado como churn 100).

## ⚠️ Ordem de deploy — EDGE ANTES da migration

Deploye a **edge `calculate-scores` primeiro**, depois cole a migration. Se a migration for antes, o cron diário roda o seed **antigo** (grava `0` explícito em novos faltantes) na janela, e como `apply_score_updates` não toca essas colunas, esse `0` fica permanente. Salvaguarda se inverter: re-rode o backfill (idempotente) após a edge.

## Revisão adversarial (Codex `gpt-5.6-sol`, `xhigh`)

O Codex encontrou 2 bloqueadores reais, ambos **corrigidos** neste PR: (1) a ordem migration→edge (acima); (2) enfileirar 6.633 na fila que drena 500/noite (~14 noites) com `recalcOne` marcando `processed_at` mesmo em erro sem retry → agora enfileira **só os 303**. Confirmou o resto do diff robusto a null. Rebaixados a follow-up (inertes hoje, dependem do produtor): plano tático manda `0` ao LLM; KPI não trata cobertura parcial; Customer360 administrativa exibe "0.0" via `escopo-clientes ?? 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
