### PR TITLE
fix(paginação): 7º laço — sync_addresses (omie-cliente) para de tratar página que falha como "acabou" [money-path]

### DIFF
--- a/supabase/functions/omie-cliente/index.ts
+++ b/supabase/functions/omie-cliente/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { fetchAll } from "../_shared/paginate.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -1106,21 +1107,23 @@ serve(async (req) => {
         let totalSkipped = 0;
         let totalErrors = 0;
 
-        // Get ALL user_ids that already have addresses (paginate to bypass 1000 row limit)
-        let allAddressUserIds: string[] = [];
-        let addrOffset = 0;
-        while (true) {
-          const { data: addrPage } = await adminClient
-            .from("addresses")
-            .select("user_id")
-            .range(addrOffset, addrOffset + 999);
-          if (!addrPage || addrPage.length === 0) break;
-          const addrRows = addrPage as unknown as Array<{ user_id: string }>;
-          allAddressUserIds = allAddressUserIds.concat(addrRows.map((a) => a.user_id));
-          if (addrPage.length < 1000) break;
-          addrOffset += 1000;
-        }
-        const usersWithAddress = new Set(allAddressUserIds);
+        // Get ALL user_ids that already have addresses, paginado via fetchAll.
+        // fetchAll LANÇA em página com erro (money-path §6): o laço manual anterior
+        // desestruturava só `data`, então um timeout 57014/RLS/500 virava `data:null` →
+        // break → EOF falso, e o Set saía PARCIAL — os users cujo endereço não foi lido
+        // caíam no filtro `!usersWithAddress.has` abaixo e eram reprocessados/reescritos
+        // à toa no Omie. `.order("id")` (PK uuid única) dá sequência estável entre
+        // páginas — sem ela o `.range()` pode pular/duplicar linhas (§7).
+        const addressRows = await fetchAll<{ user_id: string }>(
+          (from, to) =>
+            adminClient
+              .from("addresses")
+              .select("user_id")
+              .order("id", { ascending: true })
+              .range(from, to),
+          "sync_addresses: user_ids com endereço",
+        );
+        const usersWithAddress = new Set(addressRows.map((a) => a.user_id));
 
         // Mapeamentos (user, conta, código) pela proof fresca account-correta, paginado com .order
         // estável. Antes vinha de .select("user_id, omie_codigo_cliente") do espelho omie_clientes,


### PR DESCRIPTION
Follow-up do #1557 (6 laços artesanais → loaders de `mapas-paginados.ts` + `fetchAll`). Ficou de fora o **7º sítio do MESMO defeito**, em `supabase/functions/omie-cliente/index.ts` (`sync_addresses`).

## O defeito (money-path §6/§7)

```ts
while (true) {
  const { data: addrPage } = await adminClient   // <- descarta `error`
    .from("addresses").select("user_id")
    .range(addrOffset, addrOffset + 999);        // <- sem `.order()`
  if (!addrPage || addrPage.length === 0) break;
  ...
}
```

1. **Descartava `error`** — página que falha (timeout 57014 / RLS / 500) vira `data:null` → `break` → "acabou". O Set `usersWithAddress` sai **PARCIAL**.
2. **Sem `.order()` estável no `.range()`** — o Postgres não garante a mesma sequência entre páginas (pula/duplica linhas).

**Efeito money-path:** o Set alimenta `clientsNeedingAddress = [...].filter(u => !usersWithAddress.has(u))` (linha 1198). Set parcial ⇒ users que **já têm** endereço escapam do filtro e são **reprocessados/reescritos à toa no Omie** — e, sem `.order()`, o retrabalho muda a cada execução.

## A correção

`fetchAll` de `_shared/paginate.ts` (que **LANÇA** em página com erro, em vez de tratá-la como fim) + `.order("id", { ascending: true })`.

`id` é a PK de `addresses` — **conferido em PROD** via psql-ro (`addresses_pkey`, `indisunique=t`, tipo `uuid`), não presumido do design.

## Varredura do arquivo inteiro

§7 avisa que *"paginação MANUAL não aparece no grep do helper"* — então varri o **PADRÃO**, não o nome do helper:

- **`.range()`**: 5 ocorrências, **4 são comentário** (docs sobre keyset); só esta era código real.
- **`while (true)`**: 4 laços; os outros 3 **já são fail-closed** (keyset + `.order()` estável + `throw`), endurecidos nos #1425/#1428/#1444:

| Laço | Linha | `.order()` estável | trata `error` |
|---|---|---|---|
| `paginarProfilesComDocumento` | 350 | OK | OK `throw` (361) |
| `existingCodes` | 932 | OK | OK `throw` (947) |
| `allMappings` | 1138 | OK | OK `throw` (1150) |

**`sync_addresses` era o único sítio remanescente. Nenhum outro descartava `error`.**

## Sem teste novo (deliberado)

O call-site não tem lógica própria além de `fetchAll` + montar o `Set`, e o contrato que conserta o bug **já é coberto** pelo teste do helper — `paginate_test.ts` → *"erro: lança com o label prefixado"*. Cobrir o call-site exigiria mockar o `SupabaseClient` dentro do `serve()`: custo alto, sinal nulo. Nenhum import remoto introduzido (o `--no-remote` da suíte segue válido).

## Evidência (exit capturado, pós-rebase na main com #1557 + #1562)

| Gate | Exit | Tell de "rodou de verdade" |
|---|---|---|
| type-check do arquivo tocado (flags exatas do gate de edges) | 0 | zero erros de qualquer classe |
| teste do helper (`paginate_test.ts`) | 0 | 6 passed / 0 failed |
| suíte de edges (`test:edges`) | 0 | **238 passed / 0 failed** (21 arquivos) |
| gate de typecheck das edges (`edges:typecheck`) | 0 | 93 edges, `"tipo":"passa"`, **0 classe-crash** |

A dívida tolerada marcou **142** (vs. 141 no cabeçalho do gate); o `--json` atribui **0 ocorrências a `omie-cliente`** ⇒ o +1 não vem desta mudança (é de outro PR mergeado desde 2026-07-21).

## Deploy

É **EDGE** — não auto-deploya no merge. Precisa do **deploy pelo chat do Lovable** (verbatim da main) para valer em produção.
