### PR TITLE
fix(financeiro): buscarTodasPaginas rejeita data:null sem error — o `?? []` fechava o laço parcial [money-path]

### DIFF
--- a/src/services/__tests__/getFluxoCaixa.test.ts
+++ b/src/services/__tests__/getFluxoCaixa.test.ts
@@ -31,8 +31,15 @@ const state: {
   db: Record<string, Row[]>;
   /** Falha na N-ésima requisição desta tabela (1-indexed). */
   falharNaRequisicao: Record<string, number | undefined>;
+  /**
+   * Resposta MALFORMADA (`{data:null, error:null}`) na N-ésima requisição (1-indexed).
+   * Não é o mesmo que `falharNaRequisicao`: ali o PostgREST se anuncia (timeout/RLS/500),
+   * aqui ele volta sem linhas E sem erro — o caso que `data ?? []` convertia em "fim da
+   * tabela", encerrando o laço com o acumulado parcial.
+   */
+  dataNullNaRequisicao: Record<string, number | undefined>;
   requisicoes: Record<string, number>;
-} = { db: {}, falharNaRequisicao: {}, requisicoes: {} };
+} = { db: {}, falharNaRequisicao: {}, dataNullNaRequisicao: {}, requisicoes: {} };
 
 /**
  * Ordena como o Postgres: estável pelas chaves de ORDER BY e, dentro de um grupo
@@ -97,6 +104,9 @@ function makeBuilder(tabela: string) {
         const error = { message: `falha simulada na requisição ${n} de ${tabela}` };
         return Promise.resolve({ data: null, error }).then(resolve, reject);
       }
+      if (state.dataNullNaRequisicao[tabela] === n) {
+        return Promise.resolve({ data: null, error: null }).then(resolve, reject);
+      }
       const casadas = (state.db[tabela] ?? []).filter((r) => filtros.every((f) => f(r)));
       const ordenadas = ordenarComoPostgres(casadas, ordem, n);
       // PostgREST real: a capa de 1.000 vale SEMPRE — sem range capa em 1.000, e
@@ -148,6 +158,7 @@ describe('getFluxoCaixa — caixa REALIZADO (fin_movimentacoes)', () => {
   beforeEach(() => {
     state.db = { fin_movimentacoes: [], fin_contas_receber: [], fin_contas_pagar: [] };
     state.falharNaRequisicao = {};
+    state.dataNullNaRequisicao = {};
     state.requisicoes = {};
   });
 
@@ -160,6 +171,35 @@ describe('getFluxoCaixa — caixa REALIZADO (fin_movimentacoes)', () => {
     state.falharNaRequisicao.fin_movimentacoes = 2;
 
     await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('data:null SEM error numa página LANÇA — resposta malformada não é fim da tabela', async () => {
+    // O mesmo defeito do caso acima por uma via que o `if (error)` não cobre: a resposta
+    // volta sem linhas E sem erro, e o `data ?? []` a convertia em página vazia ⇒
+    // `0 < 1000` ⇒ laço encerrado ⇒ ~40% do caixa devolvido como se fosse o caixa inteiro.
+    // Nada distingue esse total de uma empresa que de fato movimentou menos.
+    state.db.fin_movimentacoes = Array.from({ length: 2500 }, (_, i) =>
+      mov(i, `2026-03-${String((i % 28) + 1).padStart(2, '0')}`, 10),
+    );
+    state.dataNullNaRequisicao.fin_movimentacoes = 2;
+
+    // Ancorado em `data=null sem error`, trecho EXCLUSIVO deste ramo: os dois guards
+    // compartilham o prefixo `Falha ao carregar <contexto>`, então casar o prefixo
+    // passaria verde com este ramo sabotado (lição do #1524, money-path §6).
+    await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toThrow(/data=null sem error/);
+  });
+
+  it('múltiplo exato da capa: página vazia (data:[]) é fim LEGÍTIMO, não malformação', async () => {
+    // Contraparte do teste acima — o guard de `null` não pode engolir o EOF de verdade.
+    // Com 2.000 linhas a 3ª requisição volta `data: []`; confundir `[]` com `null` faria
+    // toda leitura de tamanho múltiplo de 1.000 lançar, quebrando a tela no caso são.
+    state.db.fin_movimentacoes = Array.from({ length: 2000 }, (_, i) =>
+      mov(i, `2026-${String(Math.floor(i / 200) + 1).padStart(2, '0')}-${String((i % 25) + 1).padStart(2, '0')}`, 10),
+    );
+
+    const fluxo = await getFluxoCaixa('oben', INICIO, FIM);
+
+    expect(somaRealizadoEntradas(fluxo)).toBe(20000);
   });
 
   it('ordem total: empate em data_movimento não pode pular nem duplicar entre páginas', async () => {
@@ -193,6 +233,7 @@ describe('getFluxoCaixa — caixa PREVISTO (fin_contas_receber / fin_contas_paga
   beforeEach(() => {
     state.db = { fin_movimentacoes: [], fin_contas_receber: [], fin_contas_pagar: [] };
     state.falharNaRequisicao = {};
+    state.dataNullNaRequisicao = {};
     state.requisicoes = {};
   });
 
@@ -210,6 +251,13 @@ describe('getFluxoCaixa — caixa PREVISTO (fin_contas_receber / fin_contas_paga
     state.falharNaRequisicao.fin_contas_pagar = 1;
 
     await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toBeInstanceOf(Error);
+  });
+
+  it('data:null SEM error no CR LANÇA — a projeção não encerra numa página malformada', async () => {
+    state.db.fin_contas_receber = [titulo(0, '2026-03-01', 10)];
+    state.dataNullNaRequisicao.fin_contas_receber = 1;
+
+    await expect(getFluxoCaixa('oben', INICIO, FIM)).rejects.toThrow(/data=null sem error/);
   });
 
   it('CR acima da capa de 1.000 não sai truncado (prod: 4.094 títulos na janela)', async () => {

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -210,7 +210,13 @@ async function buscarTodasPaginas<T>(
   for (let from = 0; ; from += PAGE) {
     const { data, error } = await fetchPage(from, from + PAGE - 1);
     if (error) throw new Error(`Falha ao carregar ${contexto}: ${error.message}`);
-    const rows = data ?? [];
+    // `data == null` sem `error` é resposta MALFORMADA do PostgREST — não é fim da tabela.
+    // O `?? []` de antes a convertia em página vazia → `0 < PAGE` → laço encerrado → o
+    // acumulado PARCIAL voltava como se fosse a tabela inteira (o defeito que o
+    // fetchAllPages de src/lib/postgrest.ts já rejeita; este helper prometia o mesmo no
+    // JSDoc e não cumpria). Fim LEGÍTIMO é `data: []` — array vazio, que segue adiante.
+    if (data == null) throw new Error(`Falha ao carregar ${contexto}: data=null sem error`);
+    const rows = data;
     out.push(...rows);
     if (rows.length < PAGE) break;
   }


### PR DESCRIPTION
**Resíduo P2**, follow-up do #1550 (fix do `fetchAllPages`).

`buscarTodasPaginas` (`src/services/financeiroService.ts`) já tinha o contrato quase certo — recebe `{data, error}`, tem `contexto` para diagnóstico, lança em `error`. O resíduo era a linha seguinte:

```ts
const rows = data ?? [];   // ← data:null SEM error vira página vazia
```

Quando o PostgREST devolve `data: null` **sem** `error` (resposta malformada), o `?? []` a converte em página vazia → satisfaz `rows.length < PAGE` → **encerra o laço como "fim da tabela"** e devolve o acumulado **parcial** em silêncio. É exatamente o caso que o `fetchAllPages` passou a rejeitar — e este helper é o precedente que validou aquele desenho: o JSDoc já prometia *"Erro de qualquer página LANÇA Error real — nunca lista parcial"* e não cumpria nesta via.

## Por que importa (money-path)

Alimenta **caixa realizado e projeção de caixa** (`getFluxoCaixa`), **top inadimplentes** e **CR/CP aberto** do cockpit. Uma leitura truncada não se anuncia como incompleta: some dinheiro e a tela segue firme, numericamente indistinguível de um mês fraco.

## A correção (1 linha)

```ts
if (data == null) throw new Error(`Falha ao carregar ${contexto}: data=null sem error`);
const rows = data;
```

`data == null` cobre `null` **e** `undefined` — o conjunto exato que o `?? []` engolia. Mesma forma do precedente em `src/lib/postgrest.ts:166`. Fim **legítimo** da tabela continua sendo `data: []`, preservado por teste dedicado.

## Prova (TDD + falsificação — `docs/agent/money-path.md`)

| Etapa | Resultado |
|---|---|
| RED | `2 failed \| 7 passed (9)` — as 2 falhas são exatamente os casos `data:null` |
| GREEN | `9 passed (9)` |
| Falsificação | sabotar o throw (`→ break`) deixa **exatamente 2 vermelhos**, os mirados |

- Denominador **(9)** conferido nas duas pontas (o tell de "não rodou nada" em vitest é o total).
- Asserção ancorada em `data=null sem error` — string **exclusiva do ramo** e ASCII; os dois guards compartilham o prefixo `Falha ao carregar <contexto>`, então casar o prefixo passaria verde com o ramo sabotado (lição do #1524).
- O guard de **EOF legítimo** (`data:[]`) permanece verde sob a sabotagem — ele protege contra over-correção, não contra o defeito atual.

### Testes adicionados (`getFluxoCaixa.test.ts`)
- `data:null SEM error numa página LANÇA` (realizado)
- `data:null SEM error no CR LANÇA` (previsto)
- `múltiplo exato da capa: data:[] é fim LEGÍTIMO` (guarda anti-over-correção)

## Gates locais

`typecheck` exit 0 · `test` exit 0 (**626 arquivos, 5677 testes**) · `lint` exit 0 (72 warnings pré-existentes, 0 errors) · `shellcheck` exit 0.

`knip` exit 1 é **baseline pré-existente** e **não roda no CI** (`grep -rn knip .github/workflows/` vazio; o #1212 existe justamente para zerá-lo). A reclamação dele é uma interface não usada em `supabase/functions/sync-reprocess/products-lote.ts` — arquivo que este diff não toca; o diff não adiciona nem remove export.

Não rodei `test:edges`/`edges:typecheck`: cobrem `supabase/functions/` sob Deno, e este diff é `src/`-only — Deno não importa de `src/` (invariante do repo), então são estruturalmente inalcançáveis por ele. O CI roda os dois assim mesmo.

## Achados adjacentes (NÃO neste PR)

1. **Gêmeo exato no mesmo arquivo:** `somarSaldoPorStatus` (exportada, ~L868) tem o **mesmo** `const rows = (data ?? []) as …` no seu laço inline, com o **mesmo** JSDoc prometendo *"nunca soma parcial silenciosa"*. Alimenta `total_a_receber`/`total_a_pagar` do `getResumoFinanceiro`. Fica para um ciclo TDD próprio (função distinta, contrato travado em `somarSaldoAberto.test.ts`).
2. **A edge ainda tem o defeito:** o #1557 corrigiu os 6 laços artesanais nos `index.ts` das edges, mas **não** o `fetchAll` de `supabase/functions/_shared/paginate.ts` — na `main` a L57 segue `const rows = data ?? [];`, com 13 edges consumindo (inclui `fin-cashflow-engine`, `fin-funding`, `cost-compute`).
3. **Convergência:** o contrato tem hoje ~6 implementações (`fetchAllPages` [corrigida], esta [corrigida], `somarSaldoPorStatus`, `_shared/paginate.ts` da edge, e 3 laços em `src/queries`). O prêmio real de convergir as de `src/` não é DRY — é a **instrumentação** (`captureException` com fonte/página/linhas perdidas só existe na canônica).

## Deploy

Só **frontend (Publish)** — arquivo `src/`, sem edge e sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)