### PR TITLE
fix(churn): ausência de risco para de virar "sem risco" na fronteira da carteira

### DIFF
--- a/src/components/adminCustomers/Customer360View.tsx
+++ b/src/components/adminCustomers/Customer360View.tsx
@@ -131,12 +131,13 @@ export function Customer360View({
           <MetricCard icon={Activity} label="Score saúde" value={score.health_score.toFixed(0)} />
           {/* churn_risk é PERCENTUAL 0–100, não fração: prod (2026-07-21) tem 6.632/6.632 linhas
               acima de 1 (mín. 33, máx. 100, média 96). O `* 100` que estava aqui exibia "9600%",
-              e o limiar `> 0.5` deixava o realce de perigo permanentemente ligado. */}
+              e o limiar `> 0.5` deixava o realce de perigo permanentemente ligado.
+              null = risco não medido → "—" (nunca "0%", que afirmaria risco nulo apurado). */}
           <MetricCard
             icon={AlertTriangle}
             label="Risco churn"
-            value={`${score.churn_risk.toFixed(0)}%`}
-            danger={score.churn_risk > 50}
+            value={score.churn_risk == null ? '—' : `${score.churn_risk.toFixed(0)}%`}
+            danger={score.churn_risk != null && score.churn_risk > 50}
           />
           <MetricCard icon={Package} label="Categorias" value={String(score.category_count)} />
         </div>

--- a/src/components/adminCustomers/types.ts
+++ b/src/components/adminCustomers/types.ts
@@ -34,7 +34,7 @@ export interface ClientScore {
   customer_user_id: string;
   health_score: number;
   health_class: string;
-  churn_risk: number;
+  churn_risk: number | null;
   expansion_score: number;
   priority_score: number;
   avg_monthly_spend_180d: number;

--- a/src/lib/carteira/escopo-clientes.ts
+++ b/src/lib/carteira/escopo-clientes.ts
@@ -3,6 +3,7 @@
 // Spec: docs/superpowers/specs/2026-06-11-clientes-escopo-carteira-design.md
 import { supabase } from '@/integrations/supabase/client';
 import { margemConhecida } from '@/lib/scoring/margin';
+import { churnConhecido } from '@/lib/scoring/churn';
 import type { Customer, ClientScore } from '@/components/adminCustomers/types';
 
 export interface DisplayFlags {
@@ -179,7 +180,10 @@ export async function fetchScoresPorCustomer(ids: string[]): Promise<Map<string,
       customer_user_id: s.customer_user_id,
       health_score: s.health_score ?? 0,
       health_class: s.health_class ?? 'critico',
-      churn_risk: s.churn_risk ?? 0,
+      // Sem `?? 0`: risco ausente chega como null ao consumidor (mesma razão do gross_margin_pct
+      // abaixo). Coagir para 0 afirmaria "sem risco de churn" — o melhor resultado — sobre quem
+      // não foi medido. churn_risk é 0–100 e 0 é conhecido.
+      churn_risk: churnConhecido(s.churn_risk),
       expansion_score: s.expansion_score ?? 0,
       priority_score: s.priority_score ?? 0,
       avg_monthly_spend_180d: s.avg_monthly_spend_180d ?? 0,

--- a/src/lib/scoring/__tests__/churn.test.ts
+++ b/src/lib/scoring/__tests__/churn.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { churnConhecido } from '../churn';
+
+/**
+ * `churn_risk` está 100% preenchido em prod hoje (6.633/6.633), então estes testes fixam
+ * comportamento que ainda não é exercido por dado real — são a prova de que a DEFESA funciona no
+ * dia em que o produtor mudar, não a prova de um bug corrente. A distinção está no helper.
+ */
+describe('churnConhecido', () => {
+  it('preserva 0 como veredito conhecido, não como ausência', () => {
+    // O ponto central: 0 é "cliente sem risco", o MELHOR resultado. Tratá-lo como ausente foi
+    // exatamente o que `churn_risk || 100` fazia — invertia o melhor cliente no pior.
+    expect(churnConhecido(0)).toBe(0);
+  });
+
+  it('devolve o número quando conhecido', () => {
+    expect(churnConhecido(96)).toBe(96);
+    expect(churnConhecido('33')).toBe(33);
+  });
+
+  it('devolve null para ausente ou não-finito', () => {
+    expect(churnConhecido(null)).toBeNull();
+    expect(churnConhecido(undefined)).toBeNull();
+    expect(churnConhecido(NaN)).toBeNull();
+    expect(churnConhecido(Infinity)).toBeNull();
+  });
+});
+
+describe('o guard relacional que o helper existe para permitir', () => {
+  it('fixa o hazard: `null < 30` é TRUE em JS (null coage a 0)', () => {
+    // Não é curiosidade — é a razão de o helper devolver null em vez de um número. Um consumidor
+    // que faça `if (churn < 30)` direto sobre a coluna classifica o NÃO-MEDIDO como risco baixo.
+    expect((null as unknown as number) < 30).toBe(true);
+  });
+
+  it('com o helper, ausente não passa por risco baixo — a checagem fica explícita', () => {
+    const desconhecido = churnConhecido(null);
+    expect(desconhecido != null && desconhecido < 30).toBe(false);
+
+    const conhecidoBaixo = churnConhecido(10);
+    expect(conhecidoBaixo != null && conhecidoBaixo < 30).toBe(true);
+
+    // E 0 — o melhor cliente — continua contando como risco baixo, não como ausência.
+    const semRisco = churnConhecido(0);
+    expect(semRisco != null && semRisco < 30).toBe(true);
+  });
+});

--- a/src/lib/scoring/churn.ts
+++ b/src/lib/scoring/churn.ts
@@ -1,0 +1,26 @@
+/**
+ * Risco de churn utilizável, ou `null` se desconhecido.
+ *
+ * Irmão de `margemConhecida` (`./margin`), pela mesma razão e com a mesma semântica — mas com uma
+ * diferença que importa: hoje ele é **defesa, não correção de sintoma**.
+ * `farmer_client_scores.churn_risk` medido em prod (2026-07-22) está 100% preenchido
+ * (6.633/6.633 linhas, mín. 33, máx. 100, média 96,0; zero nulos e zero zeros), então nenhuma
+ * coação dispara. O helper existe porque a coluna tem `column_default = 0` e `is_nullable = YES`:
+ * a ausência é estruturalmente possível, e a hora de decidir o que ela significa é antes de ela
+ * acontecer. Foi essa a lição do `gross_margin_pct` — ele também era constante até o dia em que
+ * o produtor mudou e 84% da base virou NULL (#1495/#1498).
+ *
+ * ⚠️ `0` é CONHECIDO: é o veredito "cliente sem risco de churn", o melhor resultado possível.
+ * Confundi-lo com ausência é o erro que este helper impede — e é por isso que `|| ` não serve:
+ * `churn_risk || 100` transformava o cliente de risco ZERO no de risco MÁXIMO (corrigido para
+ * `?? 100` no #1561, que é a leitura certa para um KPI que não quer premiar dado faltante).
+ *
+ * ⚠️ Em comparação relacional o guard é obrigatório: `null < 30` é `true` em JS (null coage a 0),
+ * então `if (churn < 30)` sem checar null classifica como "risco baixo" justamente quem não foi
+ * medido — a mesma armadilha que `margemConhecida` documenta para margem.
+ */
+export function churnConhecido(raw: unknown): number | null {
+  if (raw == null) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}


### PR DESCRIPTION
Complemento do #1561 na fronteira que ele não cobre. Nasceu maior — incluía o fixture e o
`|| 100` do IPF —, mas o #1561 mergeou com essas duas correções enquanto eu verificava, então
**removi tudo que era duplicata** e sobrou só o que ninguém está fazendo. Zero sobreposição com
ele (conferido arquivo a arquivo).

## O que ficou

`farmer_client_scores.churn_risk` chega ao frontend por `fetchScoresPorCustomer`
(`escopo-clientes.ts`), que coagia a ausência na fronteira:

```ts
churn_risk: s.churn_risk ?? 0,          // "sem risco" — o MELHOR resultado possível
gross_margin_pct: margemConhecida(s.gross_margin_pct),   // ← a linha de baixo já fazia certo
```

Duas colunas de score lidas no mesmo `map.set`, com tratamentos opostos da ausência. A de baixo
tem comentário explicando por que NÃO coage ("coagir aqui tornaria inertes os guards de quem lê
este mapa" — a armadilha da correção só-no-consumidor, #1498). A de cima contradizia isso.

Agora churn tem o mesmo tratamento:

- **`src/lib/scoring/churn.ts`** — `churnConhecido(raw)` → `number | null`, irmão de
  `margemConhecida`. `0` é preservado como veredito conhecido ("cliente sem risco"); só
  null/undefined/NaN/Infinity são ausência.
- **`escopo-clientes`** — `?? 0` → `churnConhecido()`, alinhado com a margem ao lado.
- **`ClientScore.churn_risk`** → `number | null`; o único consumidor (`Customer360View`) degrada
  ausente para "—", nunca "0%", que afirmaria risco nulo apurado.

## Escala e prova de que isto é DEFESA

`churn_risk` está 100% preenchido em prod (2026-07-22): 6.633/6.633 linhas em [33, 100], zero
nulos, zero zeros. **Nenhuma tela muda hoje.** O helper existe porque a coluna é `is_nullable=YES`
com `column_default = 0` — a ausência é estruturalmente possível, e a hora de decidir o que ela
significa é antes de acontecer. É literalmente a lição do `gross_margin_pct`: constante até o
produtor mudar, e aí 84% da base virou NULL de um dia para o outro (#1495/#1498).

Verifiquei que `churn_risk` **não** está entre as 6 colunas que a migration do #1561 desarma
(`recover_score`, `expansion_score`, `revenue_potential`, `x_score`, `s_score`, `eff_score`) —
então a defesa segue inerte por ora, e digo isso em vez de sugerir que corrigi um sintoma.

Os testes fixam o hazard que motiva o helper: **`null < 30` é `true` em JS**, então
`if (churn < 30)` sobre a coluna crua classifica o não-medido como risco baixo.

## O que NÃO está aqui

O fixture (`churn_risk: 0.1`) e o `|| 100` do IPF — ambos corrigidos pelo #1561, que mergeou
03:12. Descartei minha versão dos dois para não duplicar nem conflitar.

## Prova

```
TYPECHECK=0
TEST=0        Test Files  627 passed (627)   Tests  5684 passed (5684)
LINT=0        0 errors (72 warnings pré-existentes)
KNIP=1        259 issues, NENHUMA neste diff — dívida pré-existente (#1212)
```

`src/lib/scoring/__tests__/churn.test.ts (5 tests)` ✓.

Custou 4 tentativas: as 3 primeiras **abortaram por timeout de 30 min na fila do `heavy`, sem
executar** — a M2 esteve em crise de RAM (swap 7,2 GB de 8 GB, ~30 sessões, 1 slot). O tell de que
não eram falhas reais foi `TYPECHECK=1` com ZERO `error TS`: o exit vinha da fila, não do tsc.
Registro porque o mesmo log, lido às pressas, passaria por "gate vermelho" ou — pior — por
"rodou". Os 3 vermelhos que a `origin/main` mostrou naquele momento (`manifesto.gate`,
`UploadDialog`, `VisaoGeralTab`) eram da mesma contenção: sumiram na rodada que de fato executou.
