### PR TITLE
feat(farmer): a cobertura de custo para de ser calculada e jogada fora [money-path]

### DIFF
--- a/db/test-farmer-cobertura-custo.sh
+++ b/db/test-farmer-cobertura-custo.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# ════════════════════════════════════════════════════════════════════════════════
+# PROVA — persistir cobertura de custo (itens_com_custo/itens_sem_custo) em farmer_client_scores
+# Migration: supabase/migrations/20260728120000_farmer_persiste_cobertura_custo.sql
+# Roda:  bash db/test-farmer-cobertura-custo.sh > /tmp/t.log 2>&1; echo "exit=$?"
+#
+# Invariantes (só o DELTA desta migration; anti-ressurreição/recência/grants seguem em
+# db/test-apply-score-updates.sh — aqui provo o que EU acrescentei sem regredir o guard):
+#   PA  número no payload → itens_com_custo/itens_sem_custo PERSISTEM e sobrescrevem o valor velho.
+#   PB  itens_com_custo=0 grava 0 (NÃO NULL): "tem itens, nenhum com custo" ≠ "não computado" (ausente≠zero).
+#   PC  chave presente com null grava NULL (sobrescreve o valor velho: cliente parou de ter item computável).
+#   PD  chave AUSENTE preserva o valor atual (retrocompat: edge ANTIGA não zera a base — as duas
+#       ordens de deploy do Lovable ficam seguras). É o coração da migration.
+#   PE  colunas são bigint, is_nullable=YES, column_default IS NULL (sem DEFAULT de propósito).
+#   G1  guard das 12 chaves CORE PRESERVADO: payload sem health_score → check_violation, linha intocada.
+#   Falsificação:
+#   F1  RPC que OMITE itens_com_custo do SET → PA fica VERMELHO (a coluna não persiste). Restaura.
+#   F2  RPC que troca o CASE jsonb_exists por sobrescrita direta → PD fica VERMELHO (chave ausente
+#       vira NULL, apagando o valor velho). Prova que o jsonb_exists é o que segura a retrocompat.
+#
+# Nota: interpolação de uuid é feita pelo SHELL ('$VAR'); heredocs sem ids ficam <<'SQL' (aspados).
+# ════════════════════════════════════════════════════════════════════════════════
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5478}"
+SLUG="farmer-cobertura-custo"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+B_ID="bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+B_CUST="b0000000-0000-4000-8000-000000000002"
+FARMER="f0000000-0000-4000-8000-000000000003"
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITO: farmer_client_scores (schema real de PROD, SEM as colunas novas)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TABLE public.farmer_client_scores (
+  id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+  customer_user_id uuid NOT NULL,
+  farmer_id uuid NOT NULL,
+  rf_score numeric DEFAULT 0,
+  m_score numeric,
+  g_score numeric DEFAULT 0,
+  x_score numeric DEFAULT 0,
+  s_score numeric DEFAULT 0,
+  health_score numeric DEFAULT 0,
+  health_class text DEFAULT 'critico',
+  churn_risk numeric DEFAULT 0,
+  recover_score numeric DEFAULT 0,
+  expansion_score numeric DEFAULT 0,
+  eff_score numeric DEFAULT 0,
+  priority_score numeric DEFAULT 0,
+  days_since_last_purchase integer DEFAULT 0,
+  avg_repurchase_interval numeric DEFAULT 0,
+  avg_monthly_spend_180d numeric DEFAULT 0,
+  gross_margin_pct numeric,
+  category_count integer DEFAULT 0,
+  answer_rate_60d numeric DEFAULT 0,
+  whatsapp_reply_rate_60d numeric DEFAULT 0,
+  revenue_potential numeric DEFAULT 0,
+  calculated_at timestamptz DEFAULT now(),
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  signal_modifiers jsonb DEFAULT '{}'::jsonb,
+  last_signal_recalc_at timestamptz,
+  sales_history_status text,
+  CONSTRAINT farmer_client_scores_customer_unique UNIQUE (customer_user_id)
+);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260728120000_farmer_persiste_cobertura_custo.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+# Payload CORE (12 chaves obrigatórias) reusável — a cada caso concatenamos as chaves de cobertura.
+# Mantido numa função SQL p/ não repetir as 12 chaves em cada assert (e não errar uma).
+P -q <<SQL
+CREATE FUNCTION public.core_payload() RETURNS jsonb LANGUAGE sql AS \$f\$
+  SELECT jsonb_build_object(
+    'id','$B_ID','health_score',88,'health_class','saudavel','churn_risk',12,'priority_score',77,
+    'rf_score',90,'g_score',70,'days_since_last_purchase',7,'avg_monthly_spend_180d',2500,
+    'category_count',4,'calculated_at','2026-07-28T12:00:00Z','updated_at','2026-07-28T12:00:00Z')
+\$f\$;
+GRANT SELECT, UPDATE ON public.farmer_client_scores TO service_role;
+SQL
+
+# reseed: sempre volta B ao estado VELHO distinguível (itens_com_custo=77, itens_sem_custo=88, gm=99)
+reseed() {
+  P -q -c "DELETE FROM public.farmer_client_scores WHERE id='$B_ID';
+           INSERT INTO public.farmer_client_scores
+             (id, customer_user_id, farmer_id, health_score, days_since_last_purchase,
+              avg_monthly_spend_180d, category_count, gross_margin_pct, itens_com_custo, itens_sem_custo)
+           VALUES ('$B_ID','$B_CUST','$FARMER', 10, 42, 111, 9, 99, 77, 88);"
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── PA: número persiste e sobrescreve o velho ──"
+reseed
+R=$(Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('itens_com_custo', 3, 'itens_sem_custo', 37)));")
+eq "PA0 retorno = 1 (B atualizado)" "$R" "1"
+eq "PA1 itens_com_custo = 3"  "$(Pq -c "SELECT itens_com_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "3"
+eq "PA2 itens_sem_custo = 37" "$(Pq -c "SELECT itens_sem_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "37"
+eq "PA3 health_score core tambem aplicou (UPDATE inteiro OK)" "$(Pq -c "SELECT health_score FROM public.farmer_client_scores WHERE id='$B_ID';")" "88"
+
+echo "── PB: itens_com_custo=0 grava 0, NÃO NULL (ausente≠zero) ──"
+reseed
+Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('itens_com_custo', 0, 'itens_sem_custo', 40)));" >/dev/null
+eq "PB1 itens_com_custo = 0 (nao NULL)" "$(Pq -c "SELECT itens_com_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "0"
+eq "PB2 itens_com_custo NÃO é NULL"     "$(Pq -c "SELECT itens_com_custo IS NULL FROM public.farmer_client_scores WHERE id='$B_ID';")" "f"
+eq "PB3 itens_sem_custo = 40"           "$(Pq -c "SELECT itens_sem_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "40"
+
+echo "── PC: chave presente com null grava NULL (sobrescreve o velho) ──"
+reseed
+Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('itens_com_custo', null, 'itens_sem_custo', null)));" >/dev/null
+eq "PC1 itens_com_custo virou NULL (era 77)" "$(Pq -c "SELECT itens_com_custo IS NULL FROM public.farmer_client_scores WHERE id='$B_ID';")" "t"
+eq "PC2 itens_sem_custo virou NULL (era 88)" "$(Pq -c "SELECT itens_sem_custo IS NULL FROM public.farmer_client_scores WHERE id='$B_ID';")" "t"
+
+echo "── PD: chave AUSENTE preserva o valor atual (retrocompat / edge antiga) ──"
+reseed
+# payload = core + gross_margin_pct, SEM as chaves itens_* → a edge antiga (que não as conhece)
+Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('gross_margin_pct', 55)));" >/dev/null
+eq "PD1 itens_com_custo PRESERVADO em 77 (nao zerou)" "$(Pq -c "SELECT itens_com_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "77"
+eq "PD2 itens_sem_custo PRESERVADO em 88"             "$(Pq -c "SELECT itens_sem_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "88"
+eq "PD3 gross_margin_pct aplicou (chave presente)"    "$(Pq -c "SELECT gross_margin_pct FROM public.farmer_client_scores WHERE id='$B_ID';")" "55"
+
+echo "── PE: schema das colunas (bigint, nullable, SEM default) ──"
+eq "PE1 itens_com_custo é bigint"        "$(Pq -c "SELECT data_type FROM information_schema.columns WHERE table_name='farmer_client_scores' AND column_name='itens_com_custo';")" "bigint"
+eq "PE2 itens_com_custo is_nullable=YES" "$(Pq -c "SELECT is_nullable FROM information_schema.columns WHERE table_name='farmer_client_scores' AND column_name='itens_com_custo';")" "YES"
+eq "PE3 itens_com_custo SEM default"     "$(Pq -c "SELECT column_default IS NULL FROM information_schema.columns WHERE table_name='farmer_client_scores' AND column_name='itens_com_custo';")" "t"
+eq "PE4 itens_sem_custo SEM default"     "$(Pq -c "SELECT column_default IS NULL FROM information_schema.columns WHERE table_name='farmer_client_scores' AND column_name='itens_sem_custo';")" "t"
+
+echo "── G1: guard das 12 chaves CORE PRESERVADO (não regredi ao recriar a RPC) ──"
+reseed
+# core SEM health_score (jsonb - remove a chave) → deve dar check_violation ANTES do UPDATE
+R=$(P -tA 2>&1 <<SQL
+SET ROLE service_role;
+DO \$\$
+BEGIN
+  PERFORM public.apply_score_updates(jsonb_build_array(
+    (public.core_payload() - 'health_score') || jsonb_build_object('itens_com_custo', 5, 'itens_sem_custo', 5)));
+  RAISE NOTICE 'GUARD_NAO_BARROU';
+EXCEPTION
+  WHEN check_violation THEN RAISE NOTICE 'GUARD_BARROU';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+) || true
+case "$R" in *GUARD_BARROU*) ok "G1a payload sem health_score REJEITADO (check_violation)";; *) bad "G1a — esperava check_violation, veio: $R";; esac
+eq "G1b linha INTOCADA: itens_com_custo continua 77 (UPDATE nao rodou)" "$(Pq -c "SELECT itens_com_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" "77"
+
+echo "── N1: ANTI-RESSURREIÇÃO (#971) preservada — recriei a função INTEIRA, tenho de reprovar ──"
+# A RPC é UPDATE-only por id de propósito: se aplicar_exclusao_fornecedores() DELETAR a linha
+# mid-run, o id stale não casa e a função NÃO pode re-inserir (ressuscitaria um fornecedor excluído).
+reseed
+P -q -c "DELETE FROM public.farmer_client_scores WHERE id='$B_ID';"
+R=$(Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('itens_com_custo', 3, 'itens_sem_custo', 37)));")
+eq "N1a id deletado mid-run: retorno 0 (nada atualizado)" "$R" "0"
+eq "N1b NAO ressuscitou a linha (UPDATE-only, jamais INSERT)" "$(Pq -c "SELECT count(*) FROM public.farmer_client_scores WHERE id='$B_ID';")" "0"
+
+echo "── N3: grants preservados (REVOKE anon/authenticated + GRANT service_role, no fim da migration) ──"
+# Falha ABERTA seria invisível ao CI: a função nasce com EXECUTE p/ PUBLIC se o REVOKE sumir.
+for ROLE in anon authenticated; do
+  R=$(P -tA 2>&1 <<SQL
+SET ROLE $ROLE;
+DO \$\$
+BEGIN
+  PERFORM public.apply_score_updates('[]'::jsonb);
+  RAISE NOTICE 'EXEC_NAO_BARROU';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'EXEC_BARRADO';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+  ) || true
+  case "$R" in
+    *EXEC_BARRADO*) ok "N3 $ROLE BARRADO (insufficient_privilege)";;
+    *) bad "N3 $ROLE — esperava barrado, veio: $R";;
+  esac
+done
+# -q suprime a tag de comando do SET (sem ele a saida vem "SET\n0" e o assert falha por ruido, nao por regressao)
+R=$(P -tAq -c "SET ROLE service_role; SELECT public.apply_score_updates('[]'::jsonb);" 2>&1) || true
+eq "N3 service_role EXECUTA (lista vazia → 0)" "$R" "0"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3: sabota → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+
+# F1 — dente do PA: RPC que OMITE itens_com_custo do SET. EXIGE que a coluna NÃO persista (fica velha).
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.apply_score_updates(p_updates jsonb)
+RETURNS integer LANGUAGE plpgsql SET search_path TO 'public' AS $fn$
+DECLARE v_count int;
+BEGIN
+  UPDATE public.farmer_client_scores f SET
+    health_score    = u.health_score,
+    itens_sem_custo = CASE WHEN u.tem_itens_sem_custo THEN u.itens_sem_custo ELSE f.itens_sem_custo END
+    -- itens_com_custo OMITIDO (sabotagem)
+  FROM (
+    SELECT (e.elem->>'id')::uuid AS id, (e.elem->>'health_score')::numeric AS health_score,
+           (e.elem->>'itens_sem_custo')::bigint AS itens_sem_custo,
+           jsonb_exists(e.elem,'itens_sem_custo') AS tem_itens_sem_custo
+    FROM jsonb_array_elements(p_updates) AS e(elem)
+  ) u WHERE f.id = u.id;
+  GET DIAGNOSTICS v_count = ROW_COUNT; RETURN v_count;
+END $fn$;
+SQL
+reseed
+Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('itens_com_custo', 3, 'itens_sem_custo', 37)));" >/dev/null
+case "$(Pq -c "SELECT itens_com_custo FROM public.farmer_client_scores WHERE id='$B_ID';")" in
+  3) bad "F1 sabotei (removi itens_com_custo do SET) e PA seguiu verde → PA é fraco";;
+  *) ok  "F1 RPC sem itens_com_custo no SET NÃO persiste (=$( Pq -c "SELECT itens_com_custo FROM public.farmer_client_scores WHERE id='$B_ID';")) → PA tem dente";;
+esac
+P -q -f "$MIG" >/dev/null   # restaura a RPC verdadeira
+
+# F2 — dente do PD (retrocompat): RPC que sobrescreve itens_com_custo SEM o CASE jsonb_exists (direto
+# u.itens_com_custo). EXIGE que a chave AUSENTE apague o valor velho (vira NULL) → prova que o
+# jsonb_exists é o que segura a retrocompat, e não o teste. Sentinela: o EFEITO (vira NULL), não o texto.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.apply_score_updates(p_updates jsonb)
+RETURNS integer LANGUAGE plpgsql SET search_path TO 'public' AS $fn$
+DECLARE v_count int;
+BEGIN
+  UPDATE public.farmer_client_scores f SET
+    health_score    = u.health_score,
+    itens_com_custo = u.itens_com_custo,   -- SEM CASE jsonb_exists (sabotagem: ausente vira NULL)
+    itens_sem_custo = u.itens_sem_custo
+  FROM (
+    SELECT (e.elem->>'id')::uuid AS id, (e.elem->>'health_score')::numeric AS health_score,
+           (e.elem->>'itens_com_custo')::bigint AS itens_com_custo,
+           (e.elem->>'itens_sem_custo')::bigint AS itens_sem_custo
+    FROM jsonb_array_elements(p_updates) AS e(elem)
+  ) u WHERE f.id = u.id;
+  GET DIAGNOSTICS v_count = ROW_COUNT; RETURN v_count;
+END $fn$;
+SQL
+reseed
+# payload SEM as chaves itens_* (edge antiga) — com a sabotagem, deve zerar o 77 para NULL
+Pq -c "SELECT public.apply_score_updates(jsonb_build_array(
+  public.core_payload() || jsonb_build_object('gross_margin_pct', 55)));" >/dev/null
+case "$(Pq -c "SELECT itens_com_custo IS NULL FROM public.farmer_client_scores WHERE id='$B_ID';")" in
+  t) ok  "F2 RPC sem CASE jsonb_exists APAGA o valor na chave ausente → PD tem dente (jsonb_exists segura a retrocompat)";;
+  *) bad "F2 removi o CASE jsonb_exists e a chave ausente NÃO apagou → PD é teatro/fraco";;
+esac
+P -q -f "$MIG" >/dev/null   # restaura a RPC verdadeira
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/valida-farmer-cobertura-custo.sql
+++ b/db/valida-farmer-cobertura-custo.sql
@@ -1,0 +1,55 @@
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- VALIDAÇÃO PÓS-APPLY — 20260728120000_farmer_persiste_cobertura_custo
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- Cole no SQL Editor do Lovable DEPOIS de aplicar a migration. Espera-se ✅ em TODAS as linhas.
+--
+-- ⚠️ O docs/migrations-audit.md NÃO é evidência para esta migration: ele a detecta pela função
+-- `apply_score_updates`, que JÁ existia desde junho (5 migrations anteriores a recriam). O audit
+-- diria "aplicado" mesmo que ninguém tivesse rodado nada. Esta query checa só o que passa a existir
+-- DEPOIS desta migration: as 2 colunas e os marcadores novos no corpo da função.
+
+WITH checagens AS (
+  SELECT 1 AS ord,
+         'colunas itens_com_custo/itens_sem_custo (bigint, nullable, SEM default)' AS checagem,
+         (SELECT count(*) FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'farmer_client_scores'
+             AND column_name IN ('itens_com_custo','itens_sem_custo')
+             AND data_type = 'bigint' AND is_nullable = 'YES' AND column_default IS NULL) = 2 AS ok
+  UNION ALL
+  SELECT 2, 'apply_score_updates TRANSPORTA as 2 contagens (padrao jsonb_exists)',
+         (SELECT pg_get_functiondef(p.oid) LIKE '%tem_itens_com_custo%'
+             AND pg_get_functiondef(p.oid) LIKE '%tem_itens_sem_custo%'
+            FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+           WHERE n.nspname = 'public' AND p.proname = 'apply_score_updates')
+  UNION ALL
+  SELECT 3, 'guard das 12 chaves CORE PRESERVADO (nao regrediu ao recriar a funcao)',
+         (SELECT pg_get_functiondef(p.oid) LIKE '%contrato full-update violado%'
+            FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+           WHERE n.nspname = 'public' AND p.proname = 'apply_score_updates')
+  UNION ALL
+  SELECT 4, 'anon e authenticated SEM EXECUTE (a falha ABERTA nao entrou)',
+         NOT has_function_privilege('anon','public.apply_score_updates(jsonb)','EXECUTE')
+     AND NOT has_function_privilege('authenticated','public.apply_score_updates(jsonb)','EXECUTE')
+  UNION ALL
+  SELECT 5, 'service_role COM EXECUTE (a edge consegue gravar)',
+         has_function_privilege('service_role','public.apply_score_updates(jsonb)','EXECUTE')
+)
+SELECT ord, CASE WHEN ok THEN '✅ OK' ELSE '❌ FALHOU' END AS status, checagem
+FROM checagens ORDER BY ord;
+
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- SEGUNDA PARTE — rode só DEPOIS de publicar a edge nova E o cron de scores rodar
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- Antes do 1º run pós-deploy: com_cobertura_computada = 0 (todas NULL). Isso é o ESPERADO, não
+-- falha: a migration só abre a coluna; quem a preenche é a edge. Depois do run, o total coberto
+-- deve bater com o nº de clientes que get_customer_margin_summary() retorna.
+SELECT
+  count(*)                                          AS clientes,
+  count(itens_com_custo)                            AS com_cobertura_computada,
+  count(*) FILTER (WHERE itens_com_custo = 0)       AS zero_itens_computaveis,
+  count(*) FILTER (WHERE itens_com_custo > 0)       AS com_ao_menos_1_item,
+  count(gross_margin_pct)                           AS com_margem_conhecida,
+  -- coerência: margem conhecida DEVE implicar cobertura > 0. Qualquer linha aqui é bug.
+  count(*) FILTER (WHERE gross_margin_pct IS NOT NULL AND COALESCE(itens_com_custo,0) = 0)
+                                                    AS INCOERENTES_margem_sem_item
+FROM public.farmer_client_scores;

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **429** custom migrations totais
-- **1496** objetos esperados (criados por estas migrations)
+- **430** custom migrations totais
+- **1497** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 433
+  - `function`: 434
   - `rls_policy`: 380
   - `index`: 224
   - `cron_job`: 157
@@ -3628,6 +3628,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `view` | `public.v_tint_formula_canonica` | — |
+
+### `20260728120000_farmer_persiste_cobertura_custo.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.apply_score_updates` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 429
+-- Total de custom migrations: 430
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -470,7 +470,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260726150000', 'margem_cliente_helper_compartilhado', '20260726150000_margem_cliente_helper_compartilhado.sql'),
   ('20260726160000', 'margem_reconciliacao_universo_unico', '20260726160000_margem_reconciliacao_universo_unico.sql'),
   ('20260726160000', 'tint_canonica_piso_legado', '20260726160000_tint_canonica_piso_legado.sql'),
-  ('20260727120000', 'tint_fase5_desativa_geracao_legada', '20260727120000_tint_fase5_desativa_geracao_legada.sql')
+  ('20260727120000', 'tint_fase5_desativa_geracao_legada', '20260727120000_tint_fase5_desativa_geracao_legada.sql'),
+  ('20260728120000', 'farmer_persiste_cobertura_custo', '20260728120000_farmer_persiste_cobertura_custo.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1955,7 +1956,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('margem_reconciliacao_universo_unico', 'function', 'public', 'get_customer_margin_summary', ''),
   ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
-  ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', '')
+  ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
+  ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3488,7 +3490,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('margem_reconciliacao_universo_unico', 'function', 'public', 'get_customer_margin_summary', ''),
   ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
-  ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', '')
+  ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
+  ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', '')
 )
 SELECT
   e.migration,

--- a/src/lib/scoring/__tests__/margin.test.ts
+++ b/src/lib/scoring/__tests__/margin.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { accumulateMarginFromItems } from '../margin';
+import { accumulateMarginFromItems, coberturaCustoCliente } from '../margin';
 
 describe('accumulateMarginFromItems', () => {
   it('soma receita e custo dos itens com custo conhecido', () => {
@@ -106,5 +106,54 @@ describe('accumulateMarginFromItems — item pt-BR (a forma que produção realm
     );
     expect(revenue).toBe(10);
     expect(cost).toBe(3);
+  });
+});
+
+describe('coberturaCustoCliente — ausente≠zero (a distinção que a persistência protege)', () => {
+  it('cliente FORA do marginMap (undefined/null) → {null, null}, jamais {0, 0}', () => {
+    expect(coberturaCustoCliente(undefined)).toEqual({ itensComCusto: null, itensSemCusto: null });
+    expect(coberturaCustoCliente(null)).toEqual({ itensComCusto: null, itensSemCusto: null });
+  });
+
+  it('linha da RPC com contagens → transporta os números', () => {
+    expect(coberturaCustoCliente({ itens_com_custo: 3, itens_sem_custo: 37 }))
+      .toEqual({ itensComCusto: 3, itensSemCusto: 37 });
+  });
+
+  it('itens_com_custo=0 é PRESERVADO como 0 (tem itens, nenhum com custo — não é "não computado")', () => {
+    const cob = coberturaCustoCliente({ itens_com_custo: 0, itens_sem_custo: 40 });
+    expect(cob.itensComCusto).toBe(0);
+    expect(cob.itensComCusto).not.toBeNull();
+    expect(cob.itensSemCusto).toBe(40);
+  });
+
+  it('bigint via PostgREST pode vir string → Number', () => {
+    expect(coberturaCustoCliente({ itens_com_custo: '5', itens_sem_custo: '9' }))
+      .toEqual({ itensComCusto: 5, itensSemCusto: 9 });
+  });
+
+  it('valor não-finito (NaN/Infinity/campo ausente) degrada para null, não fabrica contagem', () => {
+    expect(coberturaCustoCliente({ itens_com_custo: NaN, itens_sem_custo: Infinity }))
+      .toEqual({ itensComCusto: null, itensSemCusto: null });
+    expect(coberturaCustoCliente({ itens_com_custo: 7 }))
+      .toEqual({ itensComCusto: 7, itensSemCusto: null });
+  });
+
+  // Regressões do challenge adversarial /codex (2026-07-22): com `Number.isFinite` puro, TODOS os
+  // valores abaixo viravam 0 — isto é, lixo produzia o veredito "medi e deu zero" na coluna que
+  // existe justamente para distinguir medido-zero de não-medido.
+  it('fail-closed: lixo coercível a 0 NÃO vira contagem zero', () => {
+    for (const lixo of ['', '   ', false, true, [], {}]) {
+      expect(coberturaCustoCliente({ itens_com_custo: lixo, itens_sem_custo: lixo }))
+        .toEqual({ itensComCusto: null, itensSemCusto: null });
+    }
+  });
+
+  it('fail-closed: fração/negativo/acima de 2^53 violam o contrato de count(*) → null', () => {
+    // 3.5 também derrubaria o batch inteiro no `::bigint` da RPC (22P02) se chegasse ao SQL.
+    expect(coberturaCustoCliente({ itens_com_custo: 3.5, itens_sem_custo: -1 }))
+      .toEqual({ itensComCusto: null, itensSemCusto: null });
+    expect(coberturaCustoCliente({ itens_com_custo: Number.MAX_SAFE_INTEGER + 1, itens_sem_custo: 2 }))
+      .toEqual({ itensComCusto: null, itensSemCusto: 2 });
   });
 });

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -64,6 +64,53 @@ export function legendaCobertura({ comMargem, total }: CoberturaMargem): string 
   return `parcial — ${cobertos} de ${total.toLocaleString('pt-BR')} clientes c/ margem`;
 }
 
+/**
+ * Cobertura de custo POR CLIENTE — quantos itens de pedido dele têm custo conhecido, e quantos não.
+ * É a CONFIANÇA por trás do `gross_margin_pct` do cliente: "53% sobre 3 de 40 itens" e "53% sobre
+ * 40 de 40" são vereditos opostos. A RPC `get_customer_margin_summary` já retorna as duas contagens
+ * (`itens_com_custo`/`itens_sem_custo`), mas o writer `calculate-scores` as descartava.
+ *
+ * ⚠️ ausente≠zero: cliente FORA do resultado da RPC (sem item de pedido elegível — 97% dos sem-margem,
+ * ver docs/historico/farmer-margem-cobertura-custo.md) → `{ null, null }`, NUNCA `{ 0, 0 }`. O 0 é o
+ * veredito "tem itens, nenhum com custo" (categoria D do doc), que é dado; "não computado" é ausência.
+ * `Number(...)` não-finito degrada para null — jamais fabrica contagem.
+ *
+ * Espelhado inline em `supabase/functions/calculate-scores/index.ts` (Deno não importa de `src/`).
+ */
+export interface CoberturaCustoCliente {
+  /** Itens com custo conhecido (base do gross_margin_pct). null = cobertura não computada. */
+  itensComCusto: number | null;
+  /** Itens sem custo conhecido (excluídos do gross_margin_pct). null = cobertura não computada. */
+  itensSemCusto: number | null;
+}
+
+export function coberturaCustoCliente(
+  row: { itens_com_custo?: unknown; itens_sem_custo?: unknown } | null | undefined,
+): CoberturaCustoCliente {
+  if (row == null) return { itensComCusto: null, itensSemCusto: null };
+  return {
+    itensComCusto: contagemFinita(row.itens_com_custo),
+    itensSemCusto: contagemFinita(row.itens_sem_custo),
+  };
+}
+
+/**
+ * Contagem utilizável (inteiro ≥ 0) ou null. bigint via PostgREST pode vir string → `Number`.
+ *
+ * Fail-closed de propósito, e NÃO `Number.isFinite` puro: `Number('')`, `Number('  ')`,
+ * `Number(false)` e `Number([])` são todos **0** — lixo viraria o veredito "medi e deu zero",
+ * exatamente a fabricação que este módulo existe para impedir. Fração/negativo/acima de 2^53 são
+ * violação do contrato de `count(*)` → null, e assim nunca alcançam o `::bigint` da RPC (onde um
+ * `3.5` derrubaria o batch inteiro com 22P02). [endurecido após challenge adversarial /codex]
+ */
+function contagemFinita(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw !== 'number' && typeof raw !== 'string') return null;
+  if (typeof raw === 'string' && raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+
 export function mediaMargensConhecidas(valores: Iterable<unknown>): number | null {
   const conhecidas: number[] = [];
   for (const v of valores) {

--- a/supabase/functions/calculate-scores/index.ts
+++ b/supabase/functions/calculate-scores/index.ts
@@ -21,6 +21,9 @@ interface FarmerClientScoreRow {
   avg_monthly_spend_180d: number | null;
   category_count: number | null;
   gross_margin_pct: number | null;
+  // COBERTURA DE CUSTO: lidas do banco (select *) p/ preservar no caso marginRefreshFatal (overlay pulado).
+  itens_com_custo: number | null;
+  itens_sem_custo: number | null;
   avg_repurchase_interval: number | null;
   expansion_score: number | null;
   recover_score: number | null;
@@ -93,6 +96,11 @@ interface ScoreUpdate {
   // MARGEM-VIVA: idem — null é "não medido", e a RPC grava direto (sem COALESCE) para que o
   // desconhecido sobrescreva um valor velho que já não se sustenta.
   gross_margin_pct: number | null;
+  // COBERTURA DE CUSTO (aditivo): itens com/sem custo por cliente, hoje calculados por
+  // get_customer_margin_summary e descartados. Nuláveis (jsonb_exists na RPC, como gross_margin_pct):
+  // null = não computado (cliente ausente do marginMap), jamais 0. Chave presente → sobrescreve.
+  itens_com_custo: number | null;
+  itens_sem_custo: number | null;
   // RECÊNCIA-VIVA: o compute agora REESCREVE a base de vendas (antes só lia → congelava no seed).
   days_since_last_purchase: number;
   avg_monthly_spend_180d: number;
@@ -143,6 +151,26 @@ function margemConhecida(pct: number | null | undefined): number | null {
   if (pct == null) return null;
   const n = Number(pct);
   return Number.isFinite(n) ? n : null;
+}
+
+// Cobertura de custo por cliente — espelho inline de src/lib/scoring/margin.ts:coberturaCustoCliente
+// (vitest; Deno não importa de src/). ausente≠zero: cliente fora do marginMap → {null,null}, jamais
+// {0,0} (0 = "tem itens, nenhum com custo"). Paridade: mudou aqui → mude lá.
+// contagemFinita é FAIL-CLOSED de propósito: `Number('')`, `Number(false)` e `Number([])` são 0 e
+// fabricariam "medi e deu zero"; fração/negativo/>2^53 violam o contrato de count(*) e o `3.5`
+// chegaria ao `::bigint` da RPC derrubando o batch inteiro (22P02).
+function contagemFinita(raw: unknown): number | null {
+  if (raw == null) return null;
+  if (typeof raw !== 'number' && typeof raw !== 'string') return null;
+  if (typeof raw === 'string' && raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isSafeInteger(n) && n >= 0 ? n : null;
+}
+function coberturaCustoCliente(
+  row: { itens_com_custo?: unknown; itens_sem_custo?: unknown } | null | undefined,
+): { itensComCusto: number | null; itensSemCusto: number | null } {
+  if (row == null) return { itensComCusto: null, itensSemCusto: null };
+  return { itensComCusto: contagemFinita(row.itens_com_custo), itensSemCusto: contagemFinita(row.itens_sem_custo) };
 }
 
 // RPC set-returning SEM paginação é truncada em 1.000 linhas pelo PostgREST — SILENCIOSAMENTE, sem
@@ -575,7 +603,13 @@ Deno.serve(async (req) => {
     // Cliente ausente do marginMap (sem pedido, ou só com item sem custo) → NULL, jamais 0.
     if (!marginRefreshFatal) {
       for (const c of clients) {
-        c.gross_margin_pct = margemConhecida(marginMap.get(c.customer_user_id)?.gross_margin_pct);
+        const m = marginMap.get(c.customer_user_id);
+        c.gross_margin_pct = margemConhecida(m?.gross_margin_pct);
+        // COBERTURA DE CUSTO: a confiança por trás da margem ("53% sobre 3 de 40 itens"). Mesma
+        // regra do valor acima — cliente AUSENTE do marginMap (sem item elegível) → NULL, jamais 0.
+        const cob = coberturaCustoCliente(m);
+        c.itens_com_custo = cob.itensComCusto;
+        c.itens_sem_custo = cob.itensSemCusto;
       }
     }
 
@@ -692,6 +726,22 @@ Deno.serve(async (req) => {
         // MARGEM-VIVA: persiste a margem calculada no servidor (pós-overlay). Sem esta linha o
         // cálculo novo morreria em memória e a coluna seguiria no 0 do seed.
         gross_margin_pct: margemPct,
+        // COBERTURA DE CUSTO: persiste as contagens sobrepostas (pós-overlay) — sem isto a RPC de
+        // margem seguiria calculando e o writer jogando fora. Três caminhos, todos honestos:
+        //   cliente no marginMap        → a contagem medida (0 inclusive: "tem itens, nenhum com custo")
+        //   cliente FORA do marginMap   → null (sem item elegível) — a RPC grava NULL, jamais 0
+        //   marginRefreshFatal          → overlay pulado → valor LIDO DO BANCO → o UPDATE regrava o
+        //                                 mesmo valor. Nunca zera por RPC ausente.
+        // ⚠️ Esse último caso só é no-op se NÃO houver run concorrente: o payload carrega o snapshot
+        // lido no INÍCIO do run, então um run com a RPC de margem falha que termine DEPOIS de um run
+        // saudável restaura o valor velho (last-writer-wins). NÃO é próprio desta coluna — hoje vale
+        // igual para gross_margin_pct, m_score e a base de vendas, que usam o mesmo padrão; fechar
+        // isso exige serializar os runs (lock/lease) e é escopo próprio. Achado do challenge /codex.
+        // Na ordem de deploy INVERTIDA (edge nova publicada antes da migration) a coluna não existe,
+        // o select('*') não a traz e isto vale `undefined` → JSON.stringify OMITE a chave → a RPC cai
+        // no ramo "chave ausente = preserva". Por isso as duas publicações são seguras em qualquer ordem.
+        itens_com_custo: client.itens_com_custo,
+        itens_sem_custo: client.itens_sem_custo,
         // RECÊNCIA-VIVA: persiste a base de vendas FRESCA (pós-overlay) — antes congelava no seed.
         days_since_last_purchase: client.days_since_last_purchase ?? 999,
         avg_monthly_spend_180d: client.avg_monthly_spend_180d ?? 0,

--- a/supabase/migrations/20260728120000_farmer_persiste_cobertura_custo.sql
+++ b/supabase/migrations/20260728120000_farmer_persiste_cobertura_custo.sql
@@ -1,0 +1,171 @@
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- Farmer — PERSISTIR a cobertura de custo por cliente (itens_com_custo / itens_sem_custo)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- Motivação (análise 2026-07-22, docs/historico/farmer-margem-cobertura-custo.md): a margem de
+-- `farmer_client_scores.gross_margin_pct` é NULL em 84% da base, e mesmo onde é conhecida cobre só
+-- 58% da receita do cliente. Um número de margem SOZINHO não diz sobre QUANTOS itens ele foi apurado
+-- — "53% sobre 3 de 40 itens" e "53% sobre 40 de 40" são confianças opostas. A RPC de margem
+-- `get_customer_margin_summary()` JÁ retorna `itens_com_custo` e `itens_sem_custo` por cliente, mas o
+-- writer `calculate-scores` os DESCARTA: extrai só `gross_margin_pct` do map e o UPDATE (via
+-- apply_score_updates) nunca grava as duas contagens. Esta migration para de jogar fora o dado.
+--
+-- Escopo: 2 colunas nuláveis + estender apply_score_updates para transportá-las. NÃO recomputa
+-- margem, NÃO cadastra custo, NÃO aplica janela temporal (decisão de produto — ver o doc). Aditivo.
+--
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- 1) Colunas de cobertura — nuláveis, SEM DEFAULT (de propósito)
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- bigint porque a origem é `count(*)` (bigint) de private.margem_cliente_agregada(). NULL = a
+-- cobertura AINDA NÃO foi computada para este cliente (recém-semeado, ou cliente sem NENHUM item de
+-- pedido elegível → ausente do resultado da RPC de margem). É distinto de 0, que é o veredito
+-- "tem itens, nenhum com custo conhecido" (os 156 clientes da categoria D do doc). ausente≠zero: a
+-- mesma regra money-path de gross_margin_pct/m_score. SEM DEFAULT para que OMITIR a coluna num
+-- INSERT não fabrique 0 (foi o DEFAULT 0 de gross_margin_pct que criou o loop fechado do #1495).
+ALTER TABLE public.farmer_client_scores
+  ADD COLUMN IF NOT EXISTS itens_com_custo bigint,
+  ADD COLUMN IF NOT EXISTS itens_sem_custo bigint;
+
+COMMENT ON COLUMN public.farmer_client_scores.itens_com_custo IS
+  'Qtd de LINHAS de item do cliente COMPUTAVEIS na margem (private.margem_cliente_agregada.itens_computaveis): '
+  'custo conhecido E quantidade/preco validos. E a base sobre a qual gross_margin_pct foi apurado. '
+  'NULL = cobertura nao computada (cliente sem item elegivel, ou RPC de margem falhou no run). '
+  '0 = tem itens elegiveis, nenhum computavel. ausente<>zero. Sem DEFAULT de proposito.';
+
+COMMENT ON COLUMN public.farmer_client_scores.itens_sem_custo IS
+  'Qtd de LINHAS de item NAO computaveis (private.margem_cliente_agregada.itens_ignorados): sem custo conhecido '
+  'OU com quantidade/preco invalidos — nao e estritamente "sem custo", o nome vem da RPC publica. '
+  'itens_com_custo + itens_sem_custo = total de linhas elegiveis. ATENCAO ao ler na tela: e contagem de LINHAS, '
+  'nao de unidades nem de receita, e a margem e ponderada por RECEITA — 3 de 40 linhas pode cobrir 99% do '
+  'faturamento do cliente, e 39 de 40 pode omitir justamente a linha grande. NULL = nao computado. Sem DEFAULT.';
+
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- 2) apply_score_updates — transportar itens_com_custo / itens_sem_custo até a coluna
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- Recriada a partir da versão em prod (20260723160000, conferida por pg_get_functiondef em
+-- 2026-07-22 — idêntica ao repo, sem drift). ÚNICA mudança: as duas contagens entram no UPDATE com
+-- EXATAMENTE o mesmo padrão jsonb_exists de gross_margin_pct/m_score. NÃO entram no guard das 12
+-- chaves CORE (são nuláveis por semântica, como gross_margin_pct/m_score).
+--
+-- Semântica idêntica à de gross_margin_pct, nos três casos:
+--   chave presente com número → grava o número (inclusive 0 = "tem itens, nenhum com custo")
+--   chave presente com null   → grava NULL ("cliente sem item elegível neste run"; TEM de
+--                               sobrescrever, senão a contagem velha sobrevive a um cliente que
+--                               parou de ter pedido computável)
+--   chave AUSENTE             → preserva o valor atual (no-op)
+--
+-- O terceiro caso é o que mantém seguras as DUAS ORDENS de deploy do Lovable (migration e edge são
+-- publicações manuais independentes): a edge ANTIGA, que não envia estas chaves, vira no-op nestas
+-- colunas em vez de zerá-las enquanto o founder não publica a edge nova. Espelha a lição do
+-- 20260723160000 (um guard exigindo a chave transformaria a janela entre deploys em cron quebrado).
+CREATE OR REPLACE FUNCTION public.apply_score_updates(p_updates jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_count int;
+  v_total int;
+  v_valid int;
+BEGIN
+  -- GUARD DE CONTRATO (full-update only): as 12 chaves CORE são obrigatórias em TODA linha.
+  -- Aqui jsonb_to_recordset basta: ausente e null são AMBOS inválidos, então colapsá-los é correto.
+  -- sales_history_status, gross_margin_pct, m_score, itens_com_custo e itens_sem_custo NÃO entram
+  -- (nuláveis por semântica).
+  v_total := jsonb_array_length(p_updates);
+
+  SELECT count(*) INTO v_valid
+  FROM jsonb_to_recordset(p_updates) AS u(
+    id                       uuid,
+    health_score             numeric,
+    health_class             text,
+    churn_risk               numeric,
+    priority_score           numeric,
+    rf_score                 numeric,
+    g_score                  numeric,
+    days_since_last_purchase integer,
+    avg_monthly_spend_180d   numeric,
+    category_count           integer,
+    calculated_at            timestamptz,
+    updated_at               timestamptz
+  )
+  WHERE id                       IS NOT NULL
+    AND health_score             IS NOT NULL
+    AND health_class             IS NOT NULL
+    AND churn_risk               IS NOT NULL
+    AND priority_score           IS NOT NULL
+    AND rf_score                 IS NOT NULL
+    AND g_score                  IS NOT NULL
+    AND days_since_last_purchase IS NOT NULL
+    AND avg_monthly_spend_180d   IS NOT NULL
+    AND category_count           IS NOT NULL
+    AND calculated_at            IS NOT NULL
+    AND updated_at               IS NOT NULL;
+
+  IF v_valid <> v_total THEN
+    RAISE EXCEPTION
+      'apply_score_updates: contrato full-update violado — % de % elemento(s) com campo obrigatorio nulo/ausente (as 12 chaves CORE sao obrigatorias; jsonb_to_recordset nao faz COALESCE)',
+      (v_total - v_valid), v_total
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  -- UPDATE-only por id (anti-ressurreição #971), base de vendas (#987) + sales_history_status (COALESCE)
+  -- + cobertura de custo (itens_com_custo/itens_sem_custo, jsonb_exists como gross_margin_pct).
+  UPDATE public.farmer_client_scores f SET
+    health_score             = u.health_score,
+    health_class             = u.health_class,
+    churn_risk               = u.churn_risk,
+    priority_score           = u.priority_score,
+    rf_score                 = u.rf_score,
+    m_score                  = CASE WHEN u.tem_m_score          THEN u.m_score          ELSE f.m_score          END,
+    g_score                  = u.g_score,
+    gross_margin_pct         = CASE WHEN u.tem_gross_margin_pct THEN u.gross_margin_pct ELSE f.gross_margin_pct END,
+    itens_com_custo          = CASE WHEN u.tem_itens_com_custo  THEN u.itens_com_custo  ELSE f.itens_com_custo  END,
+    itens_sem_custo          = CASE WHEN u.tem_itens_sem_custo  THEN u.itens_sem_custo  ELSE f.itens_sem_custo  END,
+    days_since_last_purchase = u.days_since_last_purchase,
+    avg_monthly_spend_180d   = u.avg_monthly_spend_180d,
+    category_count           = u.category_count,
+    sales_history_status     = COALESCE(u.sales_history_status, f.sales_history_status),
+    calculated_at            = u.calculated_at,
+    updated_at               = u.updated_at
+  FROM (
+    SELECT
+      (e.elem->>'id')::uuid                          AS id,
+      (e.elem->>'health_score')::numeric             AS health_score,
+      (e.elem->>'health_class')                      AS health_class,
+      (e.elem->>'churn_risk')::numeric               AS churn_risk,
+      (e.elem->>'priority_score')::numeric           AS priority_score,
+      (e.elem->>'rf_score')::numeric                 AS rf_score,
+      (e.elem->>'m_score')::numeric                  AS m_score,
+      (e.elem->>'g_score')::numeric                  AS g_score,
+      (e.elem->>'gross_margin_pct')::numeric         AS gross_margin_pct,
+      (e.elem->>'itens_com_custo')::bigint           AS itens_com_custo,
+      (e.elem->>'itens_sem_custo')::bigint           AS itens_sem_custo,
+      (e.elem->>'days_since_last_purchase')::integer AS days_since_last_purchase,
+      (e.elem->>'avg_monthly_spend_180d')::numeric   AS avg_monthly_spend_180d,
+      (e.elem->>'category_count')::integer           AS category_count,
+      (e.elem->>'sales_history_status')              AS sales_history_status,
+      (e.elem->>'calculated_at')::timestamptz        AS calculated_at,
+      (e.elem->>'updated_at')::timestamptz           AS updated_at,
+      -- jsonb_exists(), e não o operador ?, para não depender de como o parser trata ? em plpgsql.
+      jsonb_exists(e.elem, 'm_score')                AS tem_m_score,
+      jsonb_exists(e.elem, 'gross_margin_pct')       AS tem_gross_margin_pct,
+      jsonb_exists(e.elem, 'itens_com_custo')        AS tem_itens_com_custo,
+      jsonb_exists(e.elem, 'itens_sem_custo')        AS tem_itens_sem_custo
+    FROM jsonb_array_elements(p_updates) AS e(elem)
+  ) u
+  WHERE f.id = u.id;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count;
+END $function$;
+
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- 3) SEGURANÇA — repetida em TODO replace (padrão das 5 migrations anteriores desta função)
+-- ───────────────────────────────────────────────────────────────────────────────────────────────
+-- CREATE OR REPLACE PRESERVA os grants num banco que JÁ tem a função (é o caso da PROD: proacl hoje
+-- = postgres + service_role, conferido por psql-ro em 2026-07-22). Mas num restore/DR a função nasce
+-- DESTE arquivo, e o default do Postgres é EXECUTE para PUBLIC — omitir isto seria falha ABERTA
+-- silenciosa, a mesma classe do `WITH (security_invoker=on)` que o CLAUDE.md manda repetir sempre.
+-- REVOKE por NOME: `FROM PUBLIC` não remove grant explícito de anon/authenticated.
+-- SECURITY INVOKER (default, menor privilégio) mantido — a função é chamada só pelo edge/service_role.
+REVOKE ALL    ON FUNCTION public.apply_score_updates(jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.apply_score_updates(jsonb) TO service_role;


### PR DESCRIPTION
## O que muda

A RPC `get_customer_margin_summary()` **já calculava** `itens_com_custo`/`itens_sem_custo` por
cliente — e o writer `calculate-scores` **jogava fora** as duas contagens a cada run, transportando
só `gross_margin_pct`. Este PR para de descartá-las.

Por que importa: com margem `NULL` em 84% da base e, onde conhecida, cobrindo só 58% da receita, o
número de margem sozinho não diz sobre **quantos** itens foi apurado. "53% sobre 3 de 40 linhas" e
"53% sobre 40 de 40" são confianças opostas e hoje chegam **idênticas** à tela. Persistir a cobertura
deixa a UI ordenar/filtrar por confiança — alternativa **aditiva** a impor janela temporal (que
subiria precisão mas cortaria pela metade a cobertura de clientes).

**Não** recomputa margem, **não** cadastra custo (decisão de negócio, vai pelo ERP/Omie), **não**
impõe janela temporal.

## Banco

- 2 colunas `bigint` **nuláveis, SEM default**. `ausente≠zero`: `NULL` = não computado; `0` = tem
  itens elegíveis e **nenhum** computável. Os dois estados são reais e distintos.
- `apply_score_updates` recriada a partir do `pg_get_functiondef` da **PROD** (conferido, sem drift),
  transportando as contagens pelo **mesmo padrão `jsonb_exists`** de `gross_margin_pct`:
  | payload | efeito |
  |---|---|
  | chave presente com número | grava o número (inclusive `0`) |
  | chave presente com `null` | grava `NULL` (sobrescreve valor velho) |
  | chave **ausente** | **preserva** o valor atual |
  O 3º caso é o que mantém seguras as **duas ordens de deploy** — migration e edge são publicações
  manuais independentes, e a edge antiga vira no-op nas colunas novas em vez de zerá-las.
- `REVOKE`/`GRANT` **repetidos no replace** (padrão das 5 migrations anteriores desta função):
  `CREATE OR REPLACE` preserva grants num banco que já tem a função, mas num **restore/DR** ela
  nasceria com `EXECUTE` para `PUBLIC` — falha **ABERTA** silenciosa, mesma classe do
  `security_invoker` que o CLAUDE.md cobra.

## Prova

`db/test-farmer-cobertura-custo.sh` — PG17 descartável, **25 asserts, verde**, com falsificação:

- persistência, `0`≠`NULL`, `null` sobrescreve, chave ausente preserva, schema das colunas;
- **guard das 12 chaves CORE**, **anti-ressurreição (#971)** e **grants** — invariantes que a função
  já carregava e que recriá-la inteira poderia ter quebrado;
- falsificação: sem a linha do `SET` não persiste; sem o `CASE jsonb_exists` a chave ausente **apaga**.

Gates (exits capturados): `harness=0` · `shellcheck=0` · `test:edges=0` (220) · `edges:typecheck=0`
· `vitest=0` (16) · `typecheck=0`.

## Challenge adversarial `/codex` (xhigh)

Pegou que o worktree estava **3 commits atrás** e que o **#1561** (`0`→`null` em 6 colunas órfãs)
tocara **este mesmo arquivo** — publicar a edge verbatim teria **revertido money-path recém-mergeado**.
Integrado e verificado. Dele também vieram:

- o **fail-closed** do helper (`Number('')`/`Number(false)`/`Number([])` são `0` e fabricariam o
  veredito "medi e deu zero"; fração/negativo/>2^53 violam o contrato de `count(*)`, e um `3.5`
  derrubaria o batch inteiro no `::bigint`);
- a **semântica dos COMMENTs**: `itens_ignorados` inclui qtd/preço inválidos (não é estritamente
  "sem custo"), e são **linhas** de item, não receita — 3 de 40 linhas pode cobrir 99% do faturamento;
- o `REVOKE`/`GRANT` acima.

## Limitação conhecida (herdada, não introduzida)

Sob runs **concorrentes**, um run com a RPC de margem falha que termine depois de um saudável
restaura o snapshot velho (last-writer-wins). Vale **hoje igual** para `gross_margin_pct`, `m_score`
e a base de vendas — fechar exige serializar os runs (lock/lease), escopo próprio. Documentado no código.

## ⚠️ Deploy — merge na main ≠ produção

1. **Migration** no SQL Editor do Lovable (custom → **não** auto-aplica).
2. **Redeploy da edge `calculate-scores`** pelo chat do Lovable, verbatim da main.
3. Validar com `db/valida-farmer-cobertura-custo.sql`.

`docs/migrations-audit.md` **não é evidência** aqui: detecta pela função `apply_score_updates`, que
já existia desde junho — diria "aplicado" sem nada ter rodado. A evidência é a query de validação,
que **hoje reprova em prod** (checagens 1 e 2 ❌) e deve aprovar após o apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
