### PR TITLE
fix(farmer): o canário de cobertura para de colapsar NULL com 0 [money-path]

### DIFF
--- a/db/valida-farmer-cobertura-custo.sql
+++ b/db/valida-farmer-cobertura-custo.sql
@@ -46,10 +46,18 @@ FROM checagens ORDER BY ord;
 SELECT
   count(*)                                          AS clientes,
   count(itens_com_custo)                            AS com_cobertura_computada,
+  count(*) FILTER (WHERE itens_com_custo IS NULL)   AS sem_cobertura_ainda_null,
   count(*) FILTER (WHERE itens_com_custo = 0)       AS zero_itens_computaveis,
   count(*) FILTER (WHERE itens_com_custo > 0)       AS com_ao_menos_1_item,
   count(gross_margin_pct)                           AS com_margem_conhecida,
-  -- coerência: margem conhecida DEVE implicar cobertura > 0. Qualquer linha aqui é bug.
-  count(*) FILTER (WHERE gross_margin_pct IS NOT NULL AND COALESCE(itens_com_custo,0) = 0)
-                                                    AS INCOERENTES_margem_sem_item
+  -- Canário de coerência: margem apurada DEVE ter item que a sustente.
+  -- ⚠️ O `itens_com_custo IS NOT NULL` é OBRIGATÓRIO aqui. A 1ª versão desta query usava
+  -- COALESCE(itens_com_custo,0)=0, que COLAPSA "não computado" (NULL) com "computado e deu zero" —
+  -- o mesmo ausente≠zero que esta migration existe para SEPARAR. Resultado: antes do 1º run da edge,
+  -- com a coluna toda NULL, o canário acusou a base inteira de incoerente (falso alarme medido em
+  -- 2026-07-23 na PROD: 1.069 falsos positivos, quando os incoerentes reais eram 0).
+  -- Lição: um canário que aplica COALESCE numa coluna cujo NULL é SIGNIFICATIVO mede outra coisa.
+  count(*) FILTER (WHERE gross_margin_pct IS NOT NULL
+                     AND itens_com_custo IS NOT NULL
+                     AND itens_com_custo = 0)       AS incoerentes_margem_sem_item
 FROM public.farmer_client_scores;


### PR DESCRIPTION
## O falso alarme

A query de validação entregue no #1567 acusou **1.069 clientes "incoerentes"** na PROD. Falso alarme — e do tipo mais constrangedor: **o canário cometia o erro que a própria migration existe para corrigir**.

```sql
-- ANTES (errado)
count(*) FILTER (WHERE gross_margin_pct IS NOT NULL AND COALESCE(itens_com_custo,0) = 0)
```

`COALESCE(itens_com_custo, 0)` colapsa **NULL (não computado)** com **0 (computado e deu zero)** — o mesmo `ausente≠zero` que a migration existe para separar. Como a edge ainda não foi redeployada, a coluna inteira é `NULL`, então todo cliente com margem de runs anteriores caiu no filtro.

## Medição na PROD (read-only, no mesmo instante)

| | antes | depois |
|---|---:|---:|
| `incoerentes_margem_sem_item` | **1.069** ❌ | **0** ✅ |
| `sem_cobertura_ainda_null` | (invisível) | 6.633 |
| `com_margem_conhecida` | 1.069 | 1.069 |

Incoerentes **reais** eram 0 o tempo todo. A migration do #1567 está aplicada e íntegra (validação 5/5 ✅).

## Correção

- exigir `itens_com_custo IS NOT NULL` antes de comparar com `0`;
- expor `sem_cobertura_ainda_null` como coluna própria — "ainda não computado" é informação legítima, não anomalia, e escondê-la foi o que permitiu o falso positivo se disfarçar de bug.

## Lição (registrada no arquivo)

Um canário que aplica `COALESCE` numa coluna cujo `NULL` é **significativo** deixa de medir a asserção pretendida. A migration separou ausente de zero na tabela; a query que a verifica tem de honrar a mesma distinção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)