### PR TITLE
docs(telemetria): o divisor da métrica de página perdida depende do caller — não é 3 sempre [money-path]

### DIFF
--- a/src/lib/postgrest.ts
+++ b/src/lib/postgrest.ts
@@ -217,11 +217,20 @@ function categoriaDoErro(code: string | null, causa: unknown): string {
  * tabela é desconhecido, então NÃO é "linhas perdidas"). Sem payload, sem texto livre. O
  * caller que quiser diagnosticar a mensagem ainda a tem via `error.cause` na exceção.
  *
- * ⚠️ AO LER A MÉTRICA: um evento por TENTATIVA, não por incidente. Os callers em react-query
- * herdam `retry: 2` (App.tsx), então uma única falha do ponto de vista do usuário emite até
- * 3 eventos. Para "quantas vezes alguém viu a tela quebrar", divida — ou agregue por sessão.
+ * ⚠️ AO LER A MÉTRICA: um evento por TENTATIVA, não por incidente — e quantas tentativas cabem
+ * num incidente DEPENDE DO CALLER. Dentro do `queryFn` de um `useQuery` a chamada herda o
+ * `retry: 2` global (App.tsx), então uma falha única do ponto de vista do usuário emite até 3
+ * eventos: é o caso das abas de Intelligence (`IntelligenceManagerialTab`/`StrategicTab`).
+ * Numa chamada imperativa FORA do react-query não há retentativa nenhuma e 1 evento = 1
+ * incidente: é o caso de `useCrossSellEngine`, `useBundleEngine`, `useFarmerScoring`,
+ * `useTacticalPlan` e `useFarmerTacticalPlan` — hoje a MAIORIA dos sítios de chamada.
+ * Dividir a contagem por 3 uniformemente subestima a frequência real justamente nesses
+ * caminhos money-path (product_costs, farmer_client_scores, sales_orders). Confira o caller
+ * antes de aplicar qualquer divisor — ou agregue por sessão, que independe disso.
  * Contar tentativas é o que se pode afirmar aqui dentro: o helper não sabe se está numa
  * retentativa (nem deveria — inferir isso seria estado escondido no lugar errado).
+ * (A generalização anterior, "os callers em react-query herdam `retry: 2`", era falsa para a
+ * maioria deles. Achado do challenge gpt-5.6-sol sobre o #1550, comentado no #1560 tarde demais.)
  */
 function relatarPaginaPerdida(fonte: string, pagina: number, lidasAntes: number, causa: unknown): void {
   const pg = causa as { code?: unknown } | null;


### PR DESCRIPTION
## Por quê

A nota `⚠️ AO LER A MÉTRICA` acima de `relatarPaginaPerdida` ([src/lib/postgrest.ts](src/lib/postgrest.ts)) afirmava:

> Os callers em react-query herdam `retry: 2` (App.tsx), então uma única falha do ponto de vista do usuário emite até 3 eventos. Para "quantas vezes alguém viu a tela quebrar", **divida**.

A generalização é **falsa para a maioria dos callers**. Quem seguir a instrução e dividir por 3 uniformemente vai **subestimar** a frequência real de página perdida — justamente nos caminhos money-path.

## Levantamento (7 sítios de chamada de `fetchAllPages`)

| Caller | Contexto | Herda `retry: 2`? |
|---|---|---|
| `IntelligenceManagerialTab.tsx:33` | `queryFn` de `useQuery` (:25) | ✅ até 3 eventos/incidente |
| `IntelligenceStrategicTab.tsx:41` | `queryFn` de `useQuery` (:35) | ✅ até 3 eventos/incidente |
| `useCrossSellEngine.ts:139,165,175,197` | `useCallback` `calculateRecommendations` (:123) | ❌ 1 evento = 1 incidente |
| `useBundleEngine.ts:164,186,195,203,219` | `useCallback` `calculateBundles` (:149) | ❌ 1 evento = 1 incidente |
| `useFarmerScoring.ts:146,186,206` | `useCallback` `calculateScores` (:134) | ❌ 1 evento = 1 incidente |
| `useTacticalPlan.ts:459` | `useCallback` `generatePlan` (:390) | ❌ 1 evento = 1 incidente |
| `useFarmerTacticalPlan.ts:55` | `async` solta, via `useEffect` (:36) | ❌ 1 evento = 1 incidente |

**5 dos 7 não herdam** — e os 4 paginadores convertidos no #1550 são justamente os dos engines (`product_costs`, `farmer_client_scores`, `sales_orders`).

O último caller nem usa `useCallback` (é `async` solta chamada por `useEffect`), então a nota nova fala em **"chamada imperativa FORA do react-query"** e não em `useCallback` — para não trocar uma generalização por outra.

## O que muda

Só o bloco de comentário. **Nenhuma linha de código alterada** — `git diff` são 12 inserções/3 remoções, todas dentro do `/** */`.

## Gates (evidência positiva, exit code capturado)

| Gate | Exit | Evidência |
|---|---|---|
| `bun run lint` | `0` | `72 problems (0 errors, 72 warnings)` — warnings de baseline (`exhaustive-deps`/`react-refresh`), nenhuma no arquivo tocado |
| `heavy heavy bun run typecheck` | `0` | `tsc --noEmit -p tsconfig.app.json` sem saída |
| `heavy heavy bun run test` | `0` | **627 arquivos, 5693 testes, todos passando** |

## Deploy

Frontend-only, **sem migration**. Como é comentário puro, **não precisa de Publish** para efeito funcional — entra no próximo build por carona.

## Coordenação

Aplicada a regra do #1568 (mergeou durante os meus gates): varredura por **tema/título** além de por arquivo — `retry`, `telemetria`, `métrica`, `tentativa`, `paginação`, `fetchAllPages` em `--state all`. Todos os PRs do tema estão MERGED; nenhum em voo no mesmo item. Colisão de arquivo conferida com **três pontos** (`HEAD...origin/main`): a main ganhou só `docs/agent/worktrees.md` e `types.ts`, sem interseção.

## Proveniência

Achado do challenge Codex (gpt-5.6-sol) sobre o #1550, confirmado no código e comentado em #1560 — que mergeou antes de incorporar, deixando a imprecisão na `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)