### PR TITLE
feat(hooks): pr-collision-guard — re-conferência de colisão multi-sessão no gh pr create

### DIFF
--- a/.claude/hooks/pr-collision-guard.sh
+++ b/.claude/hooks/pr-collision-guard.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# pr-collision-guard.sh — PreToolUse(Bash): AVISA (não nega) na hora do `gh pr create` se há
+# colisão de arquivos com a origin/main FRESCA ou com PR ABERTO de outra branch.
+#
+# Automatiza o ritual manual do worktrees.md §"Colisão de CÓDIGO multi-sessão": a checagem de
+# `gh pr list` feita no minuto 0 de uma sessão longa é foto velha — o #1526 abriu no minuto em
+# que o #1525 mergeou e jogou 26 arquivos fora. A janela de colisão é o tempo da sessão LONGA;
+# este hook re-executa a conferência no único instante que importa: imediatamente antes do create.
+#
+# Interseções por diff de TRÊS pontos (ancora na merge-base — o de dois pontos acusa os próprios
+# commits como colisão, falso positivo do #1551):
+#   meus arquivos  = git diff --name-only origin/main...HEAD
+#   main ganhou    = git diff --name-only HEAD...origin/main
+#   colisão (a)    = interseção dos dois;  colisão (b) = meus × files de PRs abertos (gh).
+#
+# Fail-open TOTAL e GRANULAR: sem jq/git → exit 0; fetch falha → segue com refs locais (stale é
+# melhor que nada); gh falha → checa só a main. AVISA via additionalContext com
+# permissionDecision=allow — NUNCA bloqueia (re-create legítimo sobre domínio quente existe;
+# zero-FP bloqueante é o padrão dos guards deste repo). Testes: scripts/test-pr-collision-guard.sh.
+set -u
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -n "$cmd" ] || exit 0
+
+# É um `gh pr create`? Sanitiza aspas/heredoc antes (menção "gh pr create" ≠ execução).
+# shellcheck disable=SC2016  # \x27/\x22 são literais do regex do perl, não expansão de shell
+if command -v perl >/dev/null 2>&1; then
+  scan="$(printf '%s' "$cmd" | perl -0777 -pe "s/<<-?\s*([\x27\x22]?)(\w+)\1.*?^\2[ \t]*\$//gms; s/\x27[^\x27]*\x27//g; s/\x22[^\x22]*\x22//g" 2>/dev/null)"
+else
+  scan="$(printf '%s' "$cmd" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null)"
+fi
+[ -n "$scan" ] || scan="$cmd"
+printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
+
+# Refs frescas — rede pode falhar/pendurar → timeout curto e segue com o que há localmente.
+if command -v timeout >/dev/null 2>&1; then
+  timeout 8 git fetch origin main --quiet >/dev/null 2>&1 || true
+else
+  git fetch origin main --quiet >/dev/null 2>&1 || true
+fi
+
+# Meus arquivos desde a merge-base (3 pontos, HEAD por último). Sem diff próprio → nada a colidir.
+mine="$(git diff --name-only origin/main...HEAD 2>/dev/null)" || exit 0
+[ -n "$mine" ] || exit 0
+mine_sorted="$(printf '%s\n' "$mine" | sort -u)"
+
+avisos=""
+
+# (a) A main ganhou arquivo que EU também toco?
+ganhou="$(git diff --name-only HEAD...origin/main 2>/dev/null)" || ganhou=""
+if [ -n "$ganhou" ]; then
+  col_main="$(comm -12 <(printf '%s\n' "$mine_sorted") <(printf '%s\n' "$ganhou" | sort -u) 2>/dev/null | head -12)"
+  if [ -n "$col_main" ]; then
+    avisos="A origin/main GANHOU commits nesses arquivos que você também toca (desde a merge-base):
+$col_main
+Confira se o seu diff ainda vale antes de criar o PR — pode já ter sido feito/suplantado (padrão #1525/#1526)."
+  fi
+fi
+
+# (b) PR ABERTO de OUTRA branch tocando arquivo meu? (gh é rede → fail-open granular: pula se falhar)
+if command -v gh >/dev/null 2>&1; then
+  branch="$(git branch --show-current 2>/dev/null)" || branch=""
+  prs="$(gh pr list --state open --json number,title,headRefName,files --limit 30 2>/dev/null)" || prs=""
+  if [ -n "$prs" ]; then
+    col_prs="$(printf '%s' "$prs" | jq -r --arg mine "$mine_sorted" --arg me "$branch" '
+      ($mine | split("\n") | map(select(length > 0))) as $m
+      | .[]
+      | select(.headRefName != $me)
+      | [.files[].path] as $paths
+      | ($paths - ($paths - $m)) as $hit
+      | select(($hit | length) > 0)
+      | "  PR #\(.number) (\(.title)) ja toca: \($hit | join(", "))"' 2>/dev/null | head -8)"
+    if [ -n "$col_prs" ]; then
+      avisos="$avisos${avisos:+
+
+}PR(s) ABERTO(s) de outra sessao tocando arquivo(s) que este PR tambem toca:
+$col_prs"
+    fi
+  fi
+fi
+
+[ -n "$avisos" ] || exit 0
+
+msg="⚠️ Colisão multi-sessão detectada na hora do gh pr create (re-conferência automática — worktrees.md §Colisão de CÓDIGO).
+$avisos
+
+Antes de criar: se o núcleo já mergeou/está em voo, fechar > reconciliar — salve só o SEU diferencial num PR enxuto sobre o vencedor. Para inspecionar: gh pr list --search \"<domínio>\" e git log origin/main -- <arquivo>."
+jq -n --arg m "$msg" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"allow",additionalContext:$m}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-pos-squash-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-collision-guard.sh\""
           }
         ]
       },

--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -31,7 +31,7 @@ Limite conhecido (fase 1): não pega a *race fria* (duas sessões, nenhum arquiv
 
 ## Colisão de CÓDIGO multi-sessão: re-conferir ANTES do `gh pr create` (2026-07-21)
 
-Irmã da colisão de migration acima, sem ferramenta equivalente — e o custo aqui não é sobrescrita
+Irmã da colisão de migration acima — e o custo aqui não é sobrescrita
 silenciosa, é **retrabalho** e o risco de duas correções divergentes do mesmo invariante entrarem
 juntas. Cronologia medida (PRs de margem, mesmo dia):
 
@@ -77,6 +77,15 @@ havia escrito, que provei vazar PII interpolada sem delimitador (`cliente 123.45
 Silva, joao@exemplo.com) sem permissão` passava inteiro — sem aspas e abaixo do teto de caracteres).
 Implementação descartada por inteiro. **A re-checagem pré-`gh pr create` evita o PR duplicado; só a
 pré-implementação evita a hora perdida.**
+
+**Rede automática (2026-07-23):** hook `.claude/hooks/pr-collision-guard.sh` (PreToolUse Bash)
+re-executa a conferência POR ARQUIVO na hora do `gh pr create` — fetch fresco + interseção de TRÊS
+pontos com a `origin/main` + `gh pr list --json files` dos PRs abertos de outras branches — e
+**AVISA** via `additionalContext` (nunca nega; fail-open granular: gh fora → checa só a main).
+Testes: `scripts/test-pr-collision-guard.sh` (stub git+gh + falsificação por sabotagem do veredito).
+Limites: cobre a re-checagem por ARQUIVO no create; a varredura por TEMA/título e a checagem
+**pré-implementação** (bloco acima) seguem manuais — e a race fria (duas sessões, nenhum PR aberto)
+continua fora do alcance.
 
 ⚠️ **Checar colisão de ARQUIVO: `git diff` de TRÊS pontos, não de dois (2026-07-22).** A checagem
 por PR acima tem uma irmã por diff — "a `main` mexeu num arquivo que EU também mexo?" — e o comando

--- a/scripts/test-pr-collision-guard.sh
+++ b/scripts/test-pr-collision-guard.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# test-pr-collision-guard.sh — TDD do hook pr-collision-guard.sh (git+gh STUBADOS, sem rede).
+#
+# Regra: `gh pr create` com colisão de arquivos — (a) a origin/main ganhou arquivo que EU
+#        também toco desde a merge-base (diff de TRÊS pontos), ou (b) um PR ABERTO de outra
+#        branch toca arquivo meu — → AVISA via additionalContext (permissionDecision=allow),
+#        SEM bloquear. Sem colisão, comando ≠ `gh pr create`, ou erro de infra → stdout mudo.
+#        Fail-open GRANULAR: gh fora → ainda checa a main (git é local).
+#
+# Uso: bash scripts/test-pr-collision-guard.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$here/../.claude/hooks/pr-collision-guard.sh"
+
+stub="$(mktemp -d)"
+trap 'rm -rf "$stub"' EXIT
+
+# stub de git: fetch é no-op; os DOIS diffs de 3 pontos vêm de arquivos controlados por env
+# (origin/main...HEAD = meus arquivos; HEAD...origin/main = o que a main ganhou).
+cat >"$stub/git" <<'STUB'
+#!/bin/sh
+case "$1" in
+  fetch)  [ -n "${GIT_STUB_FETCH_FAIL:-}" ] && exit 128; exit 0 ;;
+  branch) printf '%s\n' "${GIT_STUB_BRANCH-minha-branch}" ;;
+  diff)
+    case "$*" in
+      *"origin/main...HEAD"*) [ -n "${GIT_STUB_DIFF_FAIL:-}" ] && exit 128; cat "${GIT_STUB_MINE_FILE:-/dev/null}" ;;
+      *"HEAD...origin/main"*) cat "${GIT_STUB_GAINED_FILE:-/dev/null}" ;;
+      *) exit 0 ;;
+    esac ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$stub/git"
+
+# stub de gh: JSON de PRs abertos (GH_STUB_FILE) ou falha de rede (GH_STUB_EXIT)
+cat >"$stub/gh" <<'STUB'
+#!/bin/sh
+[ -n "${GH_STUB_EXIT:-}" ] && exit "$GH_STUB_EXIT"
+cat "${GH_STUB_FILE:-/dev/null}"
+STUB
+chmod +x "$stub/gh"
+
+export PATH="$stub:$PATH"
+
+printf 'src/lib/quente.ts\nsrc/outro.ts\n'  > "$stub/mine.txt"
+printf 'src/lib/quente.ts\ndocs/alheio.md\n' > "$stub/gained_hit.txt"
+printf 'docs/alheio.md\n'                    > "$stub/gained_miss.txt"
+printf '%s' '[{"number":42,"title":"toca o helper quente","headRefName":"outra-branch","files":[{"path":"src/lib/quente.ts"},{"path":"src/so-dele.ts"}]}]' > "$stub/prs_hit.json"
+printf '%s' '[{"number":43,"title":"nada a ver","headRefName":"outra-branch","files":[{"path":"src/so-dele.ts"}]}]' > "$stub/prs_miss.json"
+printf '%s' '[{"number":44,"title":"o MEU proprio PR","headRefName":"minha-branch","files":[{"path":"src/lib/quente.ts"}]}]' > "$stub/prs_own.json"
+
+fail=0
+
+# _hook "<envs de stub>" "<cmd>" → stdout do hook
+_hook() {
+  local envs="$1" cmd="$2" json
+  json="$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
+  # shellcheck disable=SC2086  # envs é lista KEY=VAL controlada (valores sem espaço) — split intencional
+  printf '%s' "$json" | env $envs bash "$HOOK" 2>/dev/null
+}
+
+# expect_warn <nome> <envs> <cmd> <token1> [token2] — allow + additionalContext com os tokens (ASCII, caixa fixa)
+expect_warn() {
+  local nome="$1" envs="$2" cmd="$3" t1="$4" t2="${5:-}" out ctx
+  out="$(_hook "$envs" "$cmd")"
+  ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)"
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "allow"' >/dev/null 2>&1 \
+     && printf '%s' "$ctx" | grep -qF "$t1" \
+     && { [ -z "$t2" ] || printf '%s' "$ctx" | grep -qF "$t2"; }; then
+    echo "  ok    warn  | $nome"
+  else
+    echo "  FAIL  want warn ($t1 ${t2:+e $t2}) | $nome | out='$out'"; fail=1
+  fi
+}
+
+expect_quiet() {  # não interfere: stdout vazio
+  local nome="$1" out
+  out="$(_hook "$2" "$3")"
+  if [ -z "$out" ]; then echo "  ok    quiet | $nome"
+  else echo "  FAIL  want quiet | $nome | out='$out'"; fail=1; fi
+}
+
+M="GIT_STUB_MINE_FILE=$stub/mine.txt"
+
+echo "── caso-alvo (a): a main ganhou arquivo que EU toco → AVISA ──"
+expect_warn "colisao com origin/main" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_miss.json" \
+  'gh pr create --title "x" --body "y"' 'origin/main' 'src/lib/quente.ts'
+
+echo "── caso-alvo (b): PR ABERTO de outra branch toca arquivo meu → AVISA ──"
+expect_warn "colisao com PR aberto" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_miss.txt GH_STUB_FILE=$stub/prs_hit.json" \
+  'gh pr create --fill' '#42' 'src/lib/quente.ts'
+expect_warn "gh com flag antes do pr create" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_miss.txt GH_STUB_FILE=$stub/prs_hit.json" \
+  'gh --repo x/y pr create --fill' '#42'
+
+echo "── NÃO dispara (sem falso-positivo) ──"
+expect_quiet "sem colisao nenhuma" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_miss.txt GH_STUB_FILE=$stub/prs_miss.json" \
+  'gh pr create --fill'
+expect_quiet "PR aberto e o MEU (mesma branch)" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_miss.txt GH_STUB_FILE=$stub/prs_own.json GIT_STUB_BRANCH=minha-branch" \
+  'gh pr create --fill'
+expect_quiet "comando nao e pr create" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_hit.json" \
+  'gh pr list --state open'
+expect_quiet "mencao entre aspas nao e execucao" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_hit.json" \
+  'echo "gh pr create --fill"'
+expect_quiet "sem diff proprio (mine vazio)" \
+  "GIT_STUB_MINE_FILE=/dev/null GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_hit.json" \
+  'gh pr create --fill'
+
+echo "── fail-open de infra (granular: nunca trava, nunca chuta) ──"
+expect_warn "gh fora MAS main colide → ainda avisa da main" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_EXIT=1" \
+  'gh pr create --fill' 'origin/main' 'src/lib/quente.ts'
+expect_quiet "gh fora + main sem colisao" \
+  "$M GIT_STUB_GAINED_FILE=$stub/gained_miss.txt GH_STUB_EXIT=1" \
+  'gh pr create --fill'
+expect_warn "fetch falha (offline) → segue com refs locais" \
+  "$M GIT_STUB_FETCH_FAIL=1 GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_miss.json" \
+  'gh pr create --fill' 'src/lib/quente.ts'
+expect_quiet "git diff falha" \
+  "GIT_STUB_DIFF_FAIL=1 GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_hit.json" \
+  'gh pr create --fill'
+
+echo
+if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi
+exit "$fail"


### PR DESCRIPTION
## O que faz

Automatiza o ritual do `worktrees.md` §Colisão de CÓDIGO multi-sessão — a re-conferência que hoje depende de disciplina manual e já falhou caro (#1525/#1526: PR duplicado aberto no minuto do merge do gêmeo, 26 arquivos refeitos; 4 PRs do mesmo domínio em 46min).

Hook novo `.claude/hooks/pr-collision-guard.sh` (PreToolUse Bash): quando o comando é `gh pr create`, faz `git fetch` fresco e **AVISA** (nunca nega) via `additionalContext` se:

- **(a)** a `origin/main` ganhou commits em arquivo que o PR também toca — interseção por **diff de TRÊS pontos** (ancora na merge-base; o de dois pontos gera falso positivo pós-commit, caso #1551);
- **(b)** um **PR ABERTO** de outra branch toca arquivo do diff (`gh pr list --json files`, exclui a própria branch).

## Desenho

- **Warn-only** (`permissionDecision: allow`) — re-create legítimo sobre domínio quente existe; zero-FP bloqueante é o padrão dos guards do repo.
- **Fail-open granular**: sem `jq`/`git` → no-op; `fetch` falha → segue com refs locais; `gh` fora → checa só a main.
- Sanitização de aspas/heredoc antes do match (menção `"gh pr create"` em string ≠ execução) — mesmo padrão do `branch-pos-squash-guard`.
- Custo zero fora do alvo: fetch/gh só rodam quando o comando É um `gh pr create`.

## Prova

- `scripts/test-pr-collision-guard.sh`: 13 casos com git+gh **stubados** (sem rede) — 2 casos-alvo de warn, flag antes do subcomando, 5 anti-falso-positivo (menção em aspas, PR da própria branch, sem diff próprio), fail-open granular (gh fora ainda avisa da main; diff quebrado silencia).
- **Falsificação executada**: sabotagem do veredito (`comm -12` → `-23`) deixou a suíte VERMELHA sob `LC_ALL=C` **e** `pt_BR.UTF-8`; restaurado → verde nos dois. Asserts com tokens ASCII, caixa fixa, sem `-i` (lição #1483).
- `shellcheck` limpo (hook + teste).

## Limites (documentados no worktrees.md)

Cobre a re-checagem POR ARQUIVO no instante do create. A varredura por TEMA/título e a checagem pré-implementação (bloco do #1568) seguem manuais; race fria (nenhum PR aberto ainda) fora do alcance.

Nasce do relatório de otimização de retrabalho desta sessão (padrão 13 do catálogo: colisão multi-sessão — contramedida era textual, vira estrutural).

🤖 Generated with [Claude Code](https://claude.com/claude-code)