### PR TITLE
fix(farmer): a troca das regras de associação para de poder zerar a tabela [money-path]

### DIFF
--- a/db/test-farmer-association-rules-atomica.sh
+++ b/db/test-farmer-association-rules-atomica.sh
@@ -1,0 +1,550 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — farmer_association_rules_substituir (substituição ATÔMICA)      ║
+# ║      bash db/test-farmer-association-rules-atomica.sh > /tmp/t.log 2>&1        ║
+# ║      echo "exit=$?"     (NÃO pipe pra tail — engole o exit≠0)                  ║
+# ║                                                                                ║
+# ║  O que está sob prova: a tabela é GLOBAL e alimenta 5 consumidores (MixGap,    ║
+# ║  canal Melhorias, edge recommend, cross-sell, o próprio bundle engine). Os     ║
+# ║  dois writers faziam DELETE-tudo + INSERT em chamadas SEPARADAS com o `error`  ║
+# ║  descartado — falha no meio ZERAVA a tabela. Aqui provo que a RPC nova não     ║
+# ║  deixa a tabela vazia em NENHUM caminho de falha.                             ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="assocrules"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK   $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 -- esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup pronto (PG17 :$PORT) ==="
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migração LÊ mas não cria) — fiéis à prod
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TYPE public.app_role AS ENUM ('master', 'employee', 'customer');
+
+CREATE TABLE public.user_roles (
+  id      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL,
+  role    public.app_role NOT NULL
+);
+
+-- verbatim da prod (pg_get_functiondef)
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role app_role)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $function$;
+
+-- verbatim do schema-snapshot.sql (linhas 20202-20214)
+CREATE TABLE public.farmer_association_rules (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    antecedent_product_ids text[] NOT NULL,
+    consequent_product_ids text[] NOT NULL,
+    support numeric DEFAULT 0 NOT NULL,
+    confidence numeric DEFAULT 0 NOT NULL,
+    lift numeric DEFAULT 0 NOT NULL,
+    rule_type text DEFAULT 'association'::text NOT NULL,
+    cluster_segment text,
+    sample_size integer DEFAULT 0,
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT farmer_association_rules_rule_type_check CHECK ((rule_type = ANY (ARRAY['association'::text, 'sequential'::text])))
+);
+ALTER TABLE ONLY public.farmer_association_rules ADD CONSTRAINT farmer_association_rules_pkey PRIMARY KEY (id);
+ALTER TABLE public.farmer_association_rules ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Staff can manage association rules" ON public.farmer_association_rules
+  USING ((public.has_role(auth.uid(), 'master'::public.app_role) OR public.has_role(auth.uid(), 'employee'::public.app_role)))
+  WITH CHECK ((public.has_role(auth.uid(), 'master'::public.app_role) OR public.has_role(auth.uid(), 'employee'::public.app_role)));
+SQL
+echo "pré-requisitos criados"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260729120000_farmer_association_rules_substituicao_atomica.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED (3 personas + o LOTE ANTIGO que precisa sobreviver a toda falha)
+# ══════════════════════════════════════════════════════════════════════════════
+MASTER='11111111-1111-1111-1111-111111111111'
+EMPLOYEE='22222222-2222-2222-2222-222222222222'
+CUSTOMER='33333333-3333-3333-3333-333333333333'
+
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$MASTER'), ('$EMPLOYEE'), ('$CUSTOMER');
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('$MASTER','master'), ('$EMPLOYEE','employee'), ('$CUSTOMER','customer');
+
+-- LOTE ANTIGO: 3 regras "em produção". A pergunta que todo assert negativo faz é
+-- "elas continuam aqui?". Marcadas com sample_size=475 (o valor real da prod hoje).
+INSERT INTO public.farmer_association_rules
+  (antecedent_product_ids, consequent_product_ids, support, confidence, lift, rule_type, sample_size)
+VALUES
+  (ARRAY['ANTIGA-A'], ARRAY['ANTIGA-B'], 0.0105, 0.2000,  6.33, 'association', 475),
+  (ARRAY['ANTIGA-B'], ARRAY['ANTIGA-C'], 0.0211, 1.0000, 47.50, 'association', 475),
+  (ARRAY['ANTIGA-C'], ARRAY['ANTIGA-A'], 0.0150, 0.5000, 12.00, 'sequential',  475);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.farmer_association_rules TO authenticated, anon;
+GRANT SELECT ON public.user_roles TO authenticated, anon;
+SQL
+
+# lote novo, válido, com 2 regras (reproduz o formato que os dois writers montam)
+LOTE_OK='[
+  {"antecedent_product_ids":["NOVA-1"],"consequent_product_ids":["NOVA-2"],"support":0.03,"confidence":0.42,"lift":2.1,"rule_type":"association","sample_size":500},
+  {"antecedent_product_ids":["NOVA-2"],"consequent_product_ids":["NOVA-3"],"support":0.04,"confidence":0.55,"lift":3.7,"rule_type":"sequential","sample_size":500}
+]'
+
+# quantas regras ANTIGAS continuam de pé (a pergunta central deste harness)
+antigas() { Pq -c "SELECT count(*) FROM public.farmer_association_rules WHERE sample_size = 475;"; }
+total()   { Pq -c "SELECT count(*) FROM public.farmer_association_rules;"; }
+
+eq "S0 lote antigo semeado" "$(antigas)" "3"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "-- asserts: caminho feliz --"
+
+# A1 — master substitui: retorno = nº inserido, e o lote ANTIGO some (é substituição, não append)
+R=$(Pq -c "SET test.uid='$MASTER'; SELECT public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);" | tail -1)
+eq "A1 master substitui (retorno)" "$R" "2"
+eq "A1b lote antigo foi substituído" "$(antigas)" "0"
+eq "A1c total = só o lote novo" "$(total)" "2"
+
+# A2 — os VALORES chegaram inteiros (não é só contagem: o consumidor lê confidence/lift)
+V=$(Pq -c "SELECT confidence || '|' || lift || '|' || rule_type || '|' || sample_size FROM public.farmer_association_rules WHERE antecedent_product_ids = ARRAY['NOVA-2'];")
+eq "A2 valores preservados" "$V" "0.55|3.7|sequential|500"
+
+# A3 — service_role (a edge omie-analytics-sync roda com service key, auth.uid() nulo)
+P -q -c "TRUNCATE public.farmer_association_rules;"
+P -q <<SQL
+INSERT INTO public.farmer_association_rules (antecedent_product_ids, consequent_product_ids, support, confidence, lift, rule_type, sample_size)
+VALUES (ARRAY['ANTIGA-A'], ARRAY['ANTIGA-B'], 0.0105, 0.2, 6.33, 'association', 475),
+       (ARRAY['ANTIGA-B'], ARRAY['ANTIGA-C'], 0.0211, 1.0, 47.5, 'association', 475),
+       (ARRAY['ANTIGA-C'], ARRAY['ANTIGA-A'], 0.0150, 0.5, 12.0, 'sequential',  475);
+SQL
+R=$(Pq -c "SET test.role='service_role'; SELECT public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);" | tail -1)
+eq "A3 service_role substitui (a edge)" "$R" "2"
+
+# restaura o lote antigo para os negativos
+restaura_antigas() {
+  P -q <<SQL
+DELETE FROM public.farmer_association_rules;
+INSERT INTO public.farmer_association_rules (antecedent_product_ids, consequent_product_ids, support, confidence, lift, rule_type, sample_size)
+VALUES (ARRAY['ANTIGA-A'], ARRAY['ANTIGA-B'], 0.0105, 0.2, 6.33, 'association', 475),
+       (ARRAY['ANTIGA-B'], ARRAY['ANTIGA-C'], 0.0211, 1.0, 47.5, 'association', 475),
+       (ARRAY['ANTIGA-C'], ARRAY['ANTIGA-A'], 0.0150, 0.5, 12.0, 'sequential',  475);
+SQL
+}
+
+echo "-- asserts: a defesa morde (SQLSTATE esperada + re-raise) --"
+
+# ── A4: customer não substitui (gate 42501) ────────────────────────────────────
+restaura_antigas
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$CUSTOMER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;   -- 42501 = o erro ESPERADO
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A4_ABERTO'; ELSE RAISE NOTICE 'SENTINELA_A4_BARROU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A4_BARROU*) ok  "A4 customer barrado pelo gate" ;;
+  *SENTINELA_A4_ABERTO*) bad "A4 gate ABERTO — customer substituiu as regras" ;;
+  *)                     bad "A4 resultado inesperado: $R" ;;
+esac
+eq "A4b regras antigas intactas após o gate negar" "$(antigas)" "3"
+
+# ── A5: LOTE VAZIO não apaga a tabela (TR001) — o coração do fail-closed ───────
+restaura_antigas
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('[]'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN SQLSTATE 'TR001' THEN NULL;         -- lote vazio recusado = ESPERADO
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A5_ACEITOU'; ELSE RAISE NOTICE 'SENTINELA_A5_RECUSOU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A5_RECUSOU*) ok  "A5 lote vazio recusado (TR001)" ;;
+  *SENTINELA_A5_ACEITOU*) bad "A5 lote vazio ACEITO — a tabela seria zerada" ;;
+  *)                      bad "A5 resultado inesperado: $R" ;;
+esac
+eq "A5b regras antigas intactas após lote vazio" "$(antigas)" "3"
+
+# ── A6: payload inválido não apaga a tabela (TR005) ───────────────────────────
+# confidence 1.4 (>1) e consequent vazio: os dois tipos de lixo que a validação pega
+restaura_antigas
+LOTE_RUIM='[{"antecedent_product_ids":["X"],"consequent_product_ids":[],"support":0.03,"confidence":1.4,"lift":2.1,"rule_type":"association","sample_size":9}]'
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_RUIM'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN SQLSTATE 'TR005' THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A6_ACEITOU'; ELSE RAISE NOTICE 'SENTINELA_A6_RECUSOU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A6_RECUSOU*) ok  "A6 payload inválido recusado (TR005)" ;;
+  *SENTINELA_A6_ACEITOU*) bad "A6 payload inválido ACEITO" ;;
+  *)                      bad "A6 resultado inesperado: $R" ;;
+esac
+eq "A6b regras antigas intactas após payload inválido" "$(antigas)" "3"
+
+# ── A7: ATOMICIDADE — INSERT falha DEPOIS do DELETE e as antigas sobrevivem ────
+# É o defeito original em forma executável: injeto uma falha no meio do INSERT
+# (trigger que estoura na 2ª linha) e exijo que o DELETE tenha sido desfeito.
+restaura_antigas
+P -q <<'SQL'
+CREATE FUNCTION public.__injeta_falha_insert() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.antecedent_product_ids = ARRAY['NOVA-2'] THEN
+    RAISE EXCEPTION 'falha injetada no meio do INSERT' USING ERRCODE = '58030';  -- io_error
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER zz_injeta_falha BEFORE INSERT ON public.farmer_association_rules
+  FOR EACH ROW EXECUTE FUNCTION public.__injeta_falha_insert();
+SQL
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN io_error THEN NULL;                 -- 58030 = a falha que injetei
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A7_NAOFALHOU'; ELSE RAISE NOTICE 'SENTINELA_A7_PROPAGOU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A7_PROPAGOU*)  ok  "A7 falha no INSERT propaga (não é engolida)" ;;
+  *SENTINELA_A7_NAOFALHOU*) bad "A7 a falha injetada não chegou ao caller" ;;
+  *)                        bad "A7 resultado inesperado: $R" ;;
+esac
+# ESTE é o assert que o parecer pediu: INSERT falhou -> as regras antigas continuam lá
+eq "A7b ATOMICIDADE: as 3 antigas sobreviveram ao INSERT falho" "$(antigas)" "3"
+eq "A7c tabela NÃO ficou vazia"                                 "$(total)"   "3"
+P -q -c "DROP TRIGGER zz_injeta_falha ON public.farmer_association_rules; DROP FUNCTION public.__injeta_falha_insert();"
+
+# ── A8: CONCORRÊNCIA — o 2º recálculo simultâneo é recusado (TR004), não intercala ──
+restaura_antigas
+# uma 2ª conexão segura o mesmo advisory lock por alguns segundos
+P -q -c "BEGIN; SELECT pg_advisory_xact_lock(hashtext('farmer_association_rules_substituir')); SELECT pg_sleep(6); COMMIT;" >/dev/null 2>&1 &
+LOCK_BG=$!
+for _ in $(seq 1 60); do
+  N=$(Pq -c "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND granted;")
+  [ "${N:-0}" -ge 1 ] && break
+  sleep 0.2
+done
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN SQLSTATE 'TR004' THEN NULL;         -- concorrente recusado = ESPERADO
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A8_INTERCALOU'; ELSE RAISE NOTICE 'SENTINELA_A8_SERIALIZOU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A8_SERIALIZOU*) ok  "A8 recálculo concorrente recusado (TR004)" ;;
+  *SENTINELA_A8_INTERCALOU*) bad "A8 dois recálculos rodaram juntos — lote pode duplicar" ;;
+  *)                         bad "A8 resultado inesperado: $R" ;;
+esac
+eq "A8b regras antigas intactas sob concorrência" "$(antigas)" "3"
+wait "$LOCK_BG" 2>/dev/null || true
+# o lock é _xact_: some sozinho no commit. Prova que não vazou entre chamadas.
+R=$(Pq -c "SET test.uid='$MASTER'; SELECT public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);" | tail -1)
+eq "A8c lock liberado — a chamada seguinte passa" "$R" "2"
+
+# ── A9: teto defensivo (TR003) ────────────────────────────────────────────────
+restaura_antigas
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false; v_lote jsonb;
+BEGIN
+  SELECT jsonb_agg(jsonb_build_object(
+    'antecedent_product_ids', jsonb_build_array('A' || i),
+    'consequent_product_ids', jsonb_build_array('B' || i),
+    'support', 0.02, 'confidence', 0.5, 'lift', 2.0,
+    'rule_type', 'association', 'sample_size', 10))
+  INTO v_lote FROM generate_series(1, 1001) i;
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir(v_lote);
+    v_passou := true;
+  EXCEPTION
+    WHEN SQLSTATE 'TR003' THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A9_ACEITOU'; ELSE RAISE NOTICE 'SENTINELA_A9_RECUSOU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A9_RECUSOU*) ok  "A9 lote acima do teto recusado (TR003)" ;;
+  *SENTINELA_A9_ACEITOU*) bad "A9 lote de 1001 regras aceito" ;;
+  *)                      bad "A9 resultado inesperado: $R" ;;
+esac
+eq "A9b regras antigas intactas após lote gigante" "$(antigas)" "3"
+
+# ── A10: anon não executa (REVOKE na porta, antes mesmo do gate) ──────────────
+R=$(P -tA 2>&1 <<SQL
+SET ROLE anon;
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;   -- 42501 do REVOKE
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENTINELA_A10_EXECUTOU'; ELSE RAISE NOTICE 'SENTINELA_A10_BARRADO'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_A10_BARRADO*)  ok  "A10 anon não executa a função" ;;
+  *SENTINELA_A10_EXECUTOU*) bad "A10 anon EXECUTOU a função" ;;
+  *)                        bad "A10 resultado inesperado: $R" ;;
+esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3: sabota → exija VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+# Regra: cada invariante crítico ganha UMA sabotagem apontada a ELE. Sabotagem que
+# não deixa o assert vermelho = assert sem dente.
+echo "-- falsificação --"
+
+# roda um assert isolado e devolve VERDE/VERMELHO, sem mexer nos contadores globais
+# $1 = SQLSTATE esperada · $2 = lote · $3 = quantas antigas devem sobreviver
+sonda() {
+  local estado="$1" lote="$2" esperado="$3" out
+  restaura_antigas
+  out=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$lote'::jsonb);
+    v_passou := true;
+  EXCEPTION
+    WHEN SQLSTATE '$estado' THEN NULL;
+    WHEN OTHERS THEN NULL;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SONDA_PASSOU'; ELSE RAISE NOTICE 'SONDA_BARROU'; END IF;
+END \$\$;
+SQL
+)
+  # o invariante sobrevive?  barrou E as antigas continuam de pé
+  case "$out" in
+    *SONDA_BARROU*) [ "$(antigas)" = "$esperado" ] && echo "VERDE" || echo "VERMELHO" ;;
+    *)              echo "VERMELHO" ;;
+  esac
+}
+
+# sabota o arquivo da migration cirurgicamente e reaplica.
+# O `cmp` NÃO é zelo: uma expressão que não casa nada aplicaria a migration VERDADEIRA e
+# a falsificação inteira ficaria verde sem ter sabotado nada — o teatro que a Lei #3 existe
+# pra matar. (Aconteceu aqui: `0,/re/s//../` é sintaxe do GNU sed, o macOS usa BSD.)
+sabota() {
+  local expr="$1" tmp
+  tmp="$(mktemp /tmp/sabota-XXXXXX.sql)"
+  sed -E "$expr" "$MIG" > "$tmp"
+  if cmp -s "$tmp" "$MIG"; then
+    bad "SABOTAGEM INERTE: [$expr] não alterou a migration — falsificação sem valor"
+    rm -f "$tmp"
+    return 0
+  fi
+  P -q -f "$tmp"; rm -f "$tmp"
+}
+restaura_migration() { P -q -f "$MIG"; }
+
+# F1 — sabota o fail-closed do lote vazio → A5 tem que ficar VERMELHO
+sabota "s/IF v_total = 0 THEN/IF false THEN/"
+V=$(sonda "TR001" "[]" "3")
+if [ "$V" = "VERMELHO" ]; then ok "F1 sabotar o fail-closed derruba A5 (assert tem dente)"
+else bad "F1 A5 seguiu VERDE com o fail-closed sabotado — assert sem dente"; fi
+restaura_migration
+
+# F2 — sabota o gate → A4 tem que ficar VERMELHO
+# (o 1º termo vira `true`, então `IF NOT (true OR ...)` nunca levanta o 42501)
+sabota "s/coalesce\\(auth\\.role\\(\\), ''\\) = 'service_role'/true/"
+restaura_antigas
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$CUSTOMER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);
+    v_passou := true;
+  EXCEPTION WHEN OTHERS THEN NULL;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SONDA_PASSOU'; ELSE RAISE NOTICE 'SONDA_BARROU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SONDA_PASSOU*) ok  "F2 sabotar o gate derruba A4 (customer passou a substituir)" ;;
+  *)              bad "F2 A4 seguiu VERDE com o gate sabotado — assert sem dente" ;;
+esac
+restaura_migration
+
+# F3 — sabota a ATOMICIDADE: reproduz o bug ORIGINAL (DELETE de pé + INSERT engolido).
+#      A7b tem que ficar VERMELHO — é a prova de que ele mede a atomicidade, não outra coisa.
+restaura_antigas
+P -q <<'SQL'
+CREATE FUNCTION public.__injeta_falha_insert() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.antecedent_product_ids = ARRAY['NOVA-2'] THEN
+    RAISE EXCEPTION 'falha injetada no meio do INSERT' USING ERRCODE = '58030';
+  END IF;
+  RETURN NEW;
+END $$;
+CREATE TRIGGER zz_injeta_falha BEFORE INSERT ON public.farmer_association_rules
+  FOR EACH ROW EXECUTE FUNCTION public.__injeta_falha_insert();
+
+-- versão FURADA: o bloco EXCEPTION cria um savepoint só em volta do INSERT, então o
+-- DELETE fica de pé e o erro é engolido. É exatamente o defeito de 9892dd88, em SQL.
+CREATE OR REPLACE FUNCTION public.farmer_association_rules_substituir(p_regras jsonb)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp AS $$
+DECLARE v_inseridas integer := 0;
+BEGIN
+  DELETE FROM public.farmer_association_rules;
+  BEGIN
+    INSERT INTO public.farmer_association_rules
+      (antecedent_product_ids, consequent_product_ids, support, confidence, lift, rule_type, sample_size)
+    SELECT r.antecedent_product_ids, r.consequent_product_ids, r.support, r.confidence, r.lift,
+           r.rule_type, coalesce(r.sample_size, 0)
+    FROM jsonb_to_recordset(p_regras) AS r(
+      antecedent_product_ids text[], consequent_product_ids text[], support numeric,
+      confidence numeric, lift numeric, rule_type text, sample_size integer);
+    GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+  EXCEPTION WHEN OTHERS THEN v_inseridas := 0;
+  END;
+  RETURN v_inseridas;
+END $$;
+SQL
+P -q -c "SET test.uid='$MASTER'; SELECT public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);" >/dev/null 2>&1 || true
+SOBRARAM="$(antigas)"
+if [ "$SOBRARAM" != "3" ]; then ok "F3 sabotar a atomicidade derruba A7b (sobraram $SOBRARAM de 3 — tabela zerada, o bug original)"
+else bad "F3 A7b seguiu VERDE com a atomicidade sabotada — assert sem dente"; fi
+P -q -c "DROP TRIGGER zz_injeta_falha ON public.farmer_association_rules; DROP FUNCTION public.__injeta_falha_insert();"
+restaura_migration
+
+# F4 — sabota o advisory lock → A8 tem que ficar VERMELHO
+sabota "s/IF NOT pg_try_advisory_xact_lock\\(hashtext\\('farmer_association_rules_substituir'\\)\\) THEN/IF false THEN/"
+restaura_antigas
+P -q -c "BEGIN; SELECT pg_advisory_xact_lock(hashtext('farmer_association_rules_substituir')); SELECT pg_sleep(5); COMMIT;" >/dev/null 2>&1 &
+LOCK_BG2=$!
+for _ in $(seq 1 60); do
+  N=$(Pq -c "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND granted;")
+  [ "${N:-0}" -ge 1 ] && break
+  sleep 0.2
+done
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$MASTER';
+DO \$\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);
+    v_passou := true;
+  EXCEPTION WHEN OTHERS THEN NULL;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SONDA_PASSOU'; ELSE RAISE NOTICE 'SONDA_BARROU'; END IF;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SONDA_PASSOU*) ok  "F4 sabotar o lock derruba A8 (o concorrente entrou junto)" ;;
+  *)              bad "F4 A8 seguiu VERDE com o lock sabotado — assert sem dente" ;;
+esac
+wait "$LOCK_BG2" 2>/dev/null || true
+restaura_migration
+
+# sanidade final: com a migration VERDADEIRA de volta, o caminho feliz volta a funcionar
+restaura_antigas
+R=$(Pq -c "SET test.uid='$MASTER'; SELECT public.farmer_association_rules_substituir('$LOTE_OK'::jsonb);" | tail -1)
+eq "Z1 migration restaurada, caminho feliz de volta" "$R" "2"
+
+# ── veredito ──
+echo "------------------------------"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "HARNESS VERMELHO"; exit 1; }
+echo "HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,11 +21,11 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **430** custom migrations totais
-- **1497** objetos esperados (criados por estas migrations)
+- **433** custom migrations totais
+- **1499** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 434
-  - `rls_policy`: 380
+  - `function`: 435
+  - `rls_policy`: 381
   - `index`: 224
   - `cron_job`: 157
   - `table`: 147
@@ -3629,11 +3629,27 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `view` | `public.v_tint_formula_canonica` | — |
 
+### `20260727130000_farmer_scores_colunas_orfas_null.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260727140000_authz_preco_fecha_omie_products.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `rls_policy` | `public.omie_products_select_staff` | `omie_products` |
+
 ### `20260728120000_farmer_persiste_cobertura_custo.sql`
 
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.apply_score_updates` | — |
+
+### `20260729120000_farmer_association_rules_substituicao_atomica.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.farmer_association_rules_substituir` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 430
+-- Total de custom migrations: 433
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -471,7 +471,10 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260726160000', 'margem_reconciliacao_universo_unico', '20260726160000_margem_reconciliacao_universo_unico.sql'),
   ('20260726160000', 'tint_canonica_piso_legado', '20260726160000_tint_canonica_piso_legado.sql'),
   ('20260727120000', 'tint_fase5_desativa_geracao_legada', '20260727120000_tint_fase5_desativa_geracao_legada.sql'),
-  ('20260728120000', 'farmer_persiste_cobertura_custo', '20260728120000_farmer_persiste_cobertura_custo.sql')
+  ('20260727130000', 'farmer_scores_colunas_orfas_null', '20260727130000_farmer_scores_colunas_orfas_null.sql'),
+  ('20260727140000', 'authz_preco_fecha_omie_products', '20260727140000_authz_preco_fecha_omie_products.sql'),
+  ('20260728120000', 'farmer_persiste_cobertura_custo', '20260728120000_farmer_persiste_cobertura_custo.sql'),
+  ('20260729120000', 'farmer_association_rules_substituicao_atomica', '20260729120000_farmer_association_rules_substituicao_atomica.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1957,7 +1960,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
-  ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', '')
+  ('authz_preco_fecha_omie_products', 'rls_policy', 'public', 'omie_products_select_staff', 'omie_products'),
+  ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', ''),
+  ('farmer_association_rules_substituicao_atomica', 'function', 'public', 'farmer_association_rules_substituir', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3491,7 +3496,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tint_canonica_piso_legado', 'function', 'public', 'tint_gate_revalida', ''),
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
-  ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', '')
+  ('authz_preco_fecha_omie_products', 'rls_policy', 'public', 'omie_products_select_staff', 'omie_products'),
+  ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', ''),
+  ('farmer_association_rules_substituicao_atomica', 'function', 'public', 'farmer_association_rules_substituir', '')
 )
 SELECT
   e.migration,

--- a/src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx
+++ b/src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Guard money-path — a substituição das regras de associação não pode ZERAR a tabela.
+ *
+ * `farmer_association_rules` é GLOBAL (não tem farmer_id) e o engine a substituía assim:
+ *
+ *   await supabase.from('farmer_association_rules').delete().neq('id', '000…');  // apaga TUDO
+ *   if (discoveredRules.length > 0) await supabase.from(…).insert(rulesToInsert);
+ *
+ * Três defeitos num bloco de cinco linhas: (1) DELETE e INSERT são chamadas PostgREST
+ * separadas — logo transações separadas — e uma falha entre elas deixa a tabela VAZIA;
+ * (2) o `error` das duas era descartado e o toast de sucesso saía do mesmo jeito, então o
+ * operador via "N regras gravadas" com a tabela zerada; (3) sem lote (0 regras) o DELETE
+ * rodava sozinho.
+ *
+ * O estrago não fica no bundle engine — cinco consumidores leem essa tabela e nenhum
+ * distingue "sem regra" de "zerada": `get_meu_mixgap` (card MixGap em FarmerCalls),
+ * `melhoria_produtos_relacionados` (canal Melhorias, em prod), a edge `recommend`
+ * (assoc_score, peso w_assoc), o `useCrossSellEngine` e o próprio bundle engine.
+ *
+ * DISCRIMINADOR: nenhum `delete()` sobre `farmer_association_rules` pode partir do cliente.
+ * A troca inteira vai por `farmer_association_rules_substituir`, que faz DELETE+INSERT numa
+ * transação (provada em db/test-farmer-association-rules-atomica.sh).
+ *
+ * Irmão de `bundle-escopo-sob-falha.test.tsx` (mesmo hook, outro defeito).
+ */
+const FARMER = 'farmer-real';
+const CLIENTE = 'cliente-1';
+
+type Q = { table: string; metodos: string[] };
+type ChamadaRpc = { nome: string; args: Record<string, unknown> };
+
+let queries: Q[] = [];
+let rpcs: ChamadaRpc[] = [];
+let rpcFalha = false;
+let semPedidos = false;
+let naLente = false;
+
+const ERRO_RPC = { code: '08006', message: 'connection failure', details: '', hint: '' };
+
+/**
+ * Quatro cestas desenhadas para o Apriori achar UMA regra acima dos pisos
+ * (minSupport 0.01, minLift 1.05): P1 e P2 só aparecem juntos, P3 sozinho.
+ * lift(P1→P2) = conf/support(P2) = 1 / (2/4) = 2.
+ */
+const PEDIDOS = [
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }], total: 100, created_at: '2026-07-01T00:00:00Z' },
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }], total: 100, created_at: '2026-07-02T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P3' }], total: 50, created_at: '2026-07-03T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P3' }], total: 50, created_at: '2026-07-04T00:00:00Z' },
+];
+
+const PRODUTOS = ['P1', 'P2', 'P3'].map((id) => ({
+  id, codigo: id, descricao: `Produto ${id}`, valor_unitario: 100,
+  metadata: null, ativo: true, omie_codigo_produto: null,
+}));
+
+function dadosDa(tabela: string): unknown[] {
+  switch (tabela) {
+    case 'farmer_client_scores':
+      return [{ customer_user_id: CLIENTE, health_score: 80, answer_rate_60d: 50,
+                whatsapp_reply_rate_60d: 50, avg_monthly_spend_180d: 1000,
+                gross_margin_pct: 30, category_count: 2, days_since_last_purchase: 10 }];
+    case 'omie_products': return PRODUTOS;
+    case 'profiles': return [{ user_id: CLIENTE, name: 'Cliente 1', customer_type: 'moveleiro', cnae: '3101' }];
+    case 'sales_orders': return semPedidos ? [] : PEDIDOS;
+    default: return [];
+  }
+}
+
+function chain(table: string): unknown {
+  const q: Q = { table, metodos: [] };
+  queries.push(q);
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'eq', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) c[m] = () => { q.metodos.push(m); return c; };
+  c.then = (resolve: (v: unknown) => void) => resolve({ data: dadosDa(table), error: null, count: 0 });
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (t: string) => chain(t),
+    rpc: (nome: string, args: Record<string, unknown>) => {
+      rpcs.push({ nome, args });
+      return Promise.resolve(rpcFalha ? { data: null, error: ERRO_RPC } : { data: 2, error: null });
+    },
+  },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: naLente, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: FARMER }, isStaff: true }) }));
+
+const toastMock = { error: vi.fn(), success: vi.fn(), warning: vi.fn() };
+vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastMock.error(...a),
+                                    success: (...a: unknown[]) => toastMock.success(...a),
+                                    warning: (...a: unknown[]) => toastMock.warning(...a) } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import { useBundleEngine } from '../useBundleEngine';
+
+beforeEach(() => {
+  queries = []; rpcs = [];
+  rpcFalha = false; semPedidos = false; naLente = false;
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+/** DELETE partindo do cliente sobre a tabela global = o defeito de volta. */
+const deletesNaTabelaDeRegras = () =>
+  queries.filter((q) => q.table === 'farmer_association_rules' && q.metodos.includes('delete'));
+
+const substituicoes = () => rpcs.filter((r) => r.nome === 'farmer_association_rules_substituir');
+
+async function calcular() {
+  const { result } = renderHook(() => useBundleEngine());
+  await act(async () => { await result.current.calculateBundles(); });
+  return result;
+}
+
+describe('useBundleEngine — troca de regras é atômica ou não acontece', () => {
+  it('substitui via RPC e nunca apaga a tabela pelo cliente', async () => {
+    await calcular();
+
+    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
+    expect(substituicoes()).toHaveLength(1);
+
+    const lote = substituicoes()[0].args.p_regras as Array<Record<string, unknown>>;
+    expect(lote.length).toBeGreaterThan(0);
+    expect(lote[0]).toMatchObject({ rule_type: expect.stringMatching(/^(association|sequential)$/) });
+  });
+
+  it('RPC falhando NÃO emite toast de sucesso — e nada foi apagado', async () => {
+    rpcFalha = true;
+    await calcular();
+
+    // O ponto do parecer: falhou, então a tela não pode dizer que gravou.
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(toastMock.warning).toHaveBeenCalledTimes(1);
+    expect(String(toastMock.warning.mock.calls[0][0])).toContain('anteriores seguem valendo');
+
+    // E as regras que já estavam lá sobrevivem, porque nenhum DELETE partiu daqui.
+    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
+  });
+
+  it('caminho feliz mantém o toast de sucesso', async () => {
+    await calcular();
+
+    expect(toastMock.success).toHaveBeenCalledTimes(1);
+    expect(toastMock.warning).not.toHaveBeenCalled();
+  });
+
+  it('zero regras descobertas preserva as vigentes — não chama a RPC nem apaga', async () => {
+    semPedidos = true;
+    await calcular();
+
+    expect(substituicoes()).toHaveLength(0);
+    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(String(toastMock.warning.mock.calls[0][0])).toContain('preservadas');
+  });
+
+  it('na lente "Ver como" não escreve nada (o master inspeciona, não regrava)', async () => {
+    naLente = true;
+    await calcular();
+
+    expect(substituicoes()).toHaveLength(0);
+    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
+  });
+});

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -376,22 +376,45 @@ export const useBundleEngine = () => {
       discoveredRules.sort((a, b) => b.lift - a.lift);
       setRules(discoveredRules.slice(0, 50)); // Keep top 50
 
-      // Persist top rules — PULADO na lente "Ver como" (a tabela é GLOBAL: o delete
-      // apaga as regras de toda a base; o master inspeciona os bundles do alvo sem
+      // Persist top rules — PULADO na lente "Ver como" (a tabela é GLOBAL: a troca
+      // substitui as regras de toda a base; o master inspeciona os bundles do alvo sem
       // recalcular regras/recomendações da carteira dele).
+      //
+      // Vai por RPC porque `delete()` + `insert()` são DUAS chamadas PostgREST, logo duas
+      // transações: falha entre elas deixava a tabela VAZIA — e ela alimenta o MixGap
+      // (`get_meu_mixgap`), o canal Melhorias (`melhoria_produtos_relacionados`), a edge
+      // `recommend` (assoc_score) e o `useCrossSellEngine`. A RPC faz DELETE+INSERT numa
+      // transação só: INSERT falho devolve as regras antigas. Provada em db/test-farmer-
+      // association-rules-atomica.sh (26 asserts + 4 falsificações).
+      let desfechoRegras: 'gravadas' | 'lente' | 'sem_regras' | 'falhou' = 'lente';
       if (!isImpersonating) {
-        await supabase.from('farmer_association_rules').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-        if (discoveredRules.length > 0) {
-          const rulesToInsert = discoveredRules.slice(0, 50).map(r => ({
-            antecedent_product_ids: r.antecedent,
-            consequent_product_ids: r.consequent,
-            support: Math.round(r.support * 10000) / 10000,
-            confidence: Math.round(r.confidence * 10000) / 10000,
-            lift: Math.round(r.lift * 100) / 100,
-            rule_type: r.type,
-            sample_size: totalBaskets,
-          }));
-          await supabase.from('farmer_association_rules').insert(rulesToInsert);
+        const regrasParaGravar = discoveredRules.slice(0, 50).map(r => ({
+          antecedent_product_ids: r.antecedent,
+          consequent_product_ids: r.consequent,
+          support: Math.round(r.support * 10000) / 10000,
+          confidence: Math.round(r.confidence * 10000) / 10000,
+          lift: Math.round(r.lift * 100) / 100,
+          rule_type: r.type,
+          sample_size: totalBaskets,
+        }));
+
+        if (regrasParaGravar.length === 0) {
+          // Zero regra descoberta quase sempre é dado faltando a montante, não "a base não
+          // tem padrão" — e apagar por isso derruba quatro features. Preserva o que está lá.
+          // (A RPC recusaria o lote vazio de qualquer jeito; não chamamos só pra tomar erro.)
+          desfechoRegras = 'sem_regras';
+        } else {
+          const { error: erroRegras } = await supabase.rpc('farmer_association_rules_substituir', {
+            p_regras: regrasParaGravar as unknown as Json,
+          });
+          // Sem `throw`: os bundles abaixo saem das regras em MEMÓRIA e continuam válidos.
+          // Mas o toast final não pode dizer que deu tudo certo.
+          if (erroRegras) {
+            console.error('Falha ao substituir farmer_association_rules:', erroRegras);
+            desfechoRegras = 'falhou';
+          } else {
+            desfechoRegras = 'gravadas';
+          }
         }
       }
 
@@ -574,7 +597,20 @@ export const useBundleEngine = () => {
         }
       }
 
-      toast.success(`${discoveredRules.length} regras e ${allCustomerBundles.reduce((s, c) => s + c.bundles.length, 0)} bundles gerados`);
+      // O toast reflete o que REALMENTE aconteceu. Antes ele era `success` incondicional —
+      // com a persistência falhando calada, o operador via "regras gravadas" e ia embora.
+      const totalBundles = allCustomerBundles.reduce((s, c) => s + c.bundles.length, 0);
+      if (desfechoRegras === 'falhou') {
+        toast.warning(
+          `${totalBundles} bundles gerados, mas as regras NÃO foram salvas — as anteriores seguem valendo`,
+        );
+      } else if (desfechoRegras === 'sem_regras') {
+        toast.warning(
+          `Nenhuma regra atingiu os pisos — as regras anteriores foram preservadas (${totalBundles} bundles)`,
+        );
+      } else {
+        toast.success(`${discoveredRules.length} regras e ${totalBundles} bundles gerados`);
+      }
     } catch (error) {
       console.error('Error calculating bundles:', error);
       toast.error('Erro ao calcular bundles');

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -18438,6 +18438,10 @@ export type Database = {
             Args: { p_item_id: number; p_threshold_similaridade?: number }
             Returns: Json
           }
+      farmer_association_rules_substituir: {
+        Args: { p_regras: Json }
+        Returns: number
+      }
       fin_analise_cp_dimensoes_rpc: {
         Args: { p_ano?: number; p_company?: string; p_mes?: number }
         Returns: {

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -280,6 +280,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx",
       "src/hooks/__tests__/bundle-escopo-sob-falha.test.tsx",
+      "src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx",
       "src/hooks/__tests__/cluster-margin-cobertura.test.tsx",
       "src/hooks/__tests__/cluster-margin-paginacao.test.tsx",
       "src/hooks/__tests__/efficiency-margem-indisponivel.test.tsx",

--- a/supabase/functions/_shared/assoc-rules-substituicao_test.ts
+++ b/supabase/functions/_shared/assoc-rules-substituicao_test.ts
@@ -1,0 +1,75 @@
+/**
+ * Gate estrutural — nenhuma edge pode apagar `farmer_association_rules` por conta própria.
+ *
+ * A tabela é GLOBAL (sem farmer_id) e alimenta cinco consumidores que não distinguem
+ * "sem regra" de "tabela zerada": `get_meu_mixgap` (card MixGap), `melhoria_produtos_
+ * relacionados` (canal Melhorias), a edge `recommend` (assoc_score), o `useCrossSellEngine`
+ * e o bundle engine. O writer daqui fazia `delete()` de tudo e depois um INSERT POR REGRA,
+ * com o `error` só decrementando um contador — falha no meio deixava a tabela vazia ou pela
+ * metade, e o retorno seguia dizendo "N regras geradas".
+ *
+ * A troca inteira passou a ir por `farmer_association_rules_substituir`, que faz DELETE+INSERT
+ * numa transação (migration 20260729120000, provada em db/test-farmer-association-rules-
+ * atomica.sh). Este teste trava a regressão: um `delete()` direto aqui volta a ser possível
+ * de digitar, mas não de mergear.
+ *
+ * Estrutural em vez de comportamental porque a lógica que mudou é I/O puro: `index.ts` importa
+ * `serve` de URL remota e `test:edges` roda com `--no-remote`, então importá-lo derrubaria a
+ * entrega de todo PR. A garantia de comportamento vive no harness PG17 (26 asserts).
+ */
+
+// Asserts locais: `test:edges` roda com `--no-remote`, então um `import "jsr:…"` aqui poria
+// o jsr.io no caminho de entrega de TODO PR. Mesmo padrão de paginate_test.ts.
+function assert(cond: boolean, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+function assertListaVazia(itens: string[], msg: string): void {
+  if (itens.length > 0) throw new Error(`${msg}\n  - ${itens.join("\n  - ")}`);
+}
+
+const RAIZ = "supabase/functions";
+
+async function* arquivosTs(dir: string): AsyncGenerator<string> {
+  for await (const entrada of Deno.readDir(dir)) {
+    const caminho = `${dir}/${entrada.name}`;
+    if (entrada.isDirectory) yield* arquivosTs(caminho);
+    else if (entrada.name.endsWith(".ts")) yield caminho;
+  }
+}
+
+/** Colapsa espaços/quebras pra pegar a cadeia mesmo formatada em várias linhas. */
+const normalizar = (s: string) => s.replace(/\s+/g, "");
+
+const PROIBIDOS = [
+  `from("farmer_association_rules").delete(`,
+  `from('farmer_association_rules').delete(`,
+];
+
+Deno.test("nenhuma edge apaga farmer_association_rules direto", async () => {
+  const infratores: string[] = [];
+
+  for await (const caminho of arquivosTs(RAIZ)) {
+    if (caminho.endsWith("assoc-rules-substituicao_test.ts")) continue; // as strings-alvo vivem aqui
+    const codigo = normalizar(await Deno.readTextFile(caminho));
+    if (PROIBIDOS.some((p) => codigo.includes(normalizar(p)))) infratores.push(caminho);
+  }
+
+  assertListaVazia(
+    infratores,
+    "troque via RPC farmer_association_rules_substituir (DELETE+INSERT numa transação), não com .delete():",
+  );
+});
+
+Deno.test("o writer de omie-analytics-sync usa a RPC de substituição", async () => {
+  const codigo = await Deno.readTextFile(`${RAIZ}/omie-analytics-sync/index.ts`);
+
+  assert(
+    normalizar(codigo).includes(normalizar(`rpc("farmer_association_rules_substituir"`)),
+    "computeAssociationRules deve trocar o lote pela RPC atômica",
+  );
+  // O erro tem que subir: engoli-lo era o que fazia a falha virar "sucesso com 0 regras".
+  assert(
+    /erroSubstituir[\s\S]{0,200}throw/.test(codigo),
+    "o erro da RPC precisa ser propagado, não logado e esquecido",
+  );
+});

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1808,12 +1808,20 @@ async function computeAssociationRules(db: SupabaseClient) {
   rules.sort((a, b) => (b.lift * b.confidence) - (a.lift * a.confidence));
   const topRules = rules.slice(0, maxRules);
 
-  // Clear old rules and insert new ones
-  await db.from("farmer_association_rules").delete().neq("id", "00000000-0000-0000-0000-000000000000");
+  // Troca ATÔMICA do lote. Antes: `delete()` de tudo seguido de um INSERT POR REGRA —
+  // qualquer falha no meio deixava a tabela vazia ou PELA METADE, e o `error` só decrementava
+  // um contador que ninguém lia (o retorno dizia "N regras geradas" e seguia em frente).
+  // A tabela é global e alimenta MixGap, canal Melhorias, a edge `recommend` e o cross-sell.
+  // A RPC faz DELETE+INSERT numa transação: falhou, as regras antigas continuam de pé.
+  if (topRules.length === 0) {
+    // Zero regra é sintoma de dado faltando a montante, não motivo pra apagar o que vale.
+    // (A RPC recusaria com TR001; não chamamos só pra tomar o erro.)
+    console.warn(`[AssocRules] 0 regras de ${totalTx} transações — regras vigentes preservadas`);
+    return { rules_generated: 0, total_transactions: totalTx, frequent_items: frequentItems.size, preservadas: true };
+  }
 
-  let inserted = 0;
-  for (const rule of topRules) {
-    const { error } = await db.from("farmer_association_rules").insert({
+  const { data: inserted, error: erroSubstituir } = await db.rpc("farmer_association_rules_substituir", {
+    p_regras: topRules.map((rule) => ({
       antecedent_product_ids: rule.antecedent,
       consequent_product_ids: rule.consequent,
       support: rule.support,
@@ -1821,8 +1829,14 @@ async function computeAssociationRules(db: SupabaseClient) {
       lift: rule.lift,
       rule_type: "association",
       sample_size: totalTx,
-    });
-    if (!error) inserted++;
+    })),
+  });
+
+  // `throw`, não log: quem chama (`compute_association_rules` / `sync_all`) precisa ver o
+  // erro. Engolir aqui era o que fazia a falha virar "sucesso com 0 regras".
+  if (erroSubstituir) {
+    console.error(`[AssocRules] falha ao substituir as regras:`, erroSubstituir);
+    throw new Error(`farmer_association_rules_substituir: ${erroSubstituir.message}`);
   }
 
   console.log(`[AssocRules] Generated ${inserted} rules from ${totalTx} transactions`);

--- a/supabase/migrations/20260729120000_farmer_association_rules_substituicao_atomica.sql
+++ b/supabase/migrations/20260729120000_farmer_association_rules_substituicao_atomica.sql
@@ -1,0 +1,142 @@
+-- ============================================================
+-- farmer_association_rules_substituir — troca ATÔMICA do lote global de regras
+--
+-- PROBLEMA (pré-existente, commit 9892dd88): os DOIS writers da tabela faziam
+-- `DELETE` de tudo e depois `INSERT`, em chamadas PostgREST SEPARADAS e com o
+-- `error` descartado:
+--   · src/hooks/useBundleEngine.ts            (browser, staff clica "calcular bundles")
+--   · supabase/functions/omie-analytics-sync  (edge, action compute_association_rules)
+-- Falha de rede/permissão entre as duas chamadas deixa a tabela VAZIA — e ela é
+-- GLOBAL (sem farmer_id), então o estrago é de toda a base. Cinco consumidores
+-- dependem dela e nenhum sabe distinguir "sem regra" de "tabela zerada":
+--   1. _carteira_mixgap_for_owner → get_meu_mixgap  → card MixGap em FarmerCalls
+--   2. melhoria_produtos_relacionados               → canal Melhorias (em prod)
+--   3. supabase/functions/recommend                 → assoc_score (peso w_assoc, 0.25)
+--   4. src/hooks/useCrossSellEngine                 → cross-sell do farmer
+--   5. o próprio bundle engine, na execução seguinte
+--
+-- CONSERTO: um único statement — DELETE + INSERT dentro da MESMA transação.
+-- Qualquer falha faz rollback e as regras ANTIGAS sobrevivem. Três garantias a mais:
+--   · payload validado ANTES do DELETE (mensagem útil em vez de rollback opaco);
+--   · lote vazio é RECUSADO (fail-closed) — "não achei regra" quase sempre é dado
+--     faltando a montante, e zerar a tabela derruba 4 features de uma vez;
+--   · advisory lock transacional serializa dois recálculos concorrentes, que hoje
+--     conseguem intercalar DELETE/INSERT e DUPLICAR o lote inteiro.
+--
+-- SECURITY DEFINER: espelha a policy "Staff can manage association rules" e soma
+-- o service_role (a edge roda com service key, `auth.uid()` nulo). A semântica é
+-- "substitua TUDO", que precisa enxergar a tabela inteira independentemente de RLS.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.farmer_association_rules_substituir(p_regras jsonb)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_total     integer;
+  v_invalidas integer;
+  v_inseridas integer;
+BEGIN
+  -- 1) GATE (a função bypassa RLS: a autorização é AQUI, na fronteira)
+  --    `coalesce(auth.role(), '')`, não `auth.role() = ...`: sem JWT a função devolve
+  --    NULL, `NULL = 'service_role'` é NULL, `NOT (NULL OR false OR false)` é NULL — e
+  --    `IF NULL THEN` NÃO entra no ramo. O gate falharia ABERTO, deixando customer
+  --    substituir as regras. Pego pelo assert A4 do harness PG17.
+  IF NOT (
+    coalesce(auth.role(), '') = 'service_role'
+    OR public.has_role(auth.uid(), 'master'::public.app_role)
+    OR public.has_role(auth.uid(), 'employee'::public.app_role)
+  ) THEN
+    RAISE EXCEPTION 'Acesso negado: requer perfil staff' USING ERRCODE = '42501';
+  END IF;
+
+  -- 2) FORMATO
+  IF p_regras IS NULL OR jsonb_typeof(p_regras) <> 'array' THEN
+    RAISE EXCEPTION 'p_regras deve ser um array jsonb (recebido: %)',
+      coalesce(jsonb_typeof(p_regras), 'null') USING ERRCODE = 'TR002';
+  END IF;
+
+  v_total := jsonb_array_length(p_regras);
+
+  -- 3) LOTE VAZIO = RECUSA, não "apaga tudo". Substituir por nada é destruição
+  --    disfarçada de resultado; quem quiser mesmo esvaziar faz DELETE explícito.
+  IF v_total = 0 THEN
+    RAISE EXCEPTION 'lote vazio: as % regra(s) atuais foram preservadas',
+      (SELECT count(*) FROM public.farmer_association_rules) USING ERRCODE = 'TR001';
+  END IF;
+
+  -- Teto defensivo: acima do maior lote que os callers produzem
+  -- (browser 50; edge `max_association_rules`, default 500).
+  IF v_total > 1000 THEN
+    RAISE EXCEPTION 'lote de % regras excede o teto de 1000', v_total USING ERRCODE = 'TR003';
+  END IF;
+
+  -- 4) SERIALIZAÇÃO. `try` em vez de esperar na fila: dois recálculos simultâneos
+  --    calculam o MESMO lote, então enfileirar só gasta o timeout do PostgREST.
+  --    O lock é _xact_: sai sozinho no commit/rollback.
+  IF NOT pg_try_advisory_xact_lock(hashtext('farmer_association_rules_substituir')) THEN
+    RAISE EXCEPTION 'outra substituição de regras está em andamento — nada foi alterado'
+      USING ERRCODE = 'TR004';
+  END IF;
+
+  -- 5) VALIDAÇÃO ANTES DE DESTRUIR. O rollback já protegeria a tabela, mas um
+  --    payload torto tem que virar mensagem legível, não erro de cast.
+  SELECT count(*) INTO v_invalidas
+  FROM jsonb_to_recordset(p_regras) AS r(
+    antecedent_product_ids text[],
+    consequent_product_ids text[],
+    support                numeric,
+    confidence             numeric,
+    lift                   numeric,
+    rule_type              text,
+    sample_size            integer
+  )
+  WHERE r.antecedent_product_ids IS NULL OR cardinality(r.antecedent_product_ids) = 0
+     OR r.consequent_product_ids IS NULL OR cardinality(r.consequent_product_ids) = 0
+     OR r.support    IS NULL OR r.support    < 0 OR r.support    > 1
+     OR r.confidence IS NULL OR r.confidence < 0 OR r.confidence > 1
+     OR r.lift       IS NULL OR r.lift       < 0
+     OR r.rule_type  IS NULL OR r.rule_type NOT IN ('association', 'sequential');
+
+  IF v_invalidas > 0 THEN
+    RAISE EXCEPTION '% de % regra(s) inválidas — nada foi apagado', v_invalidas, v_total
+      USING ERRCODE = 'TR005';
+  END IF;
+
+  -- 6) A TROCA. Os dois statements na MESMA transação: o INSERT falhando desfaz
+  --    o DELETE, que é a garantia inteira desta função.
+  DELETE FROM public.farmer_association_rules;
+
+  INSERT INTO public.farmer_association_rules (
+    antecedent_product_ids, consequent_product_ids,
+    support, confidence, lift, rule_type, sample_size
+  )
+  SELECT
+    r.antecedent_product_ids, r.consequent_product_ids,
+    r.support, r.confidence, r.lift, r.rule_type, coalesce(r.sample_size, 0)
+  FROM jsonb_to_recordset(p_regras) AS r(
+    antecedent_product_ids text[],
+    consequent_product_ids text[],
+    support                numeric,
+    confidence             numeric,
+    lift                   numeric,
+    rule_type              text,
+    sample_size            integer
+  );
+
+  GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+  RETURN v_inseridas;
+END;
+$$;
+
+COMMENT ON FUNCTION public.farmer_association_rules_substituir(jsonb) IS
+  'Substitui ATOMICAMENTE o lote global de farmer_association_rules (DELETE+INSERT numa transação). '
+  'Recusa lote vazio (TR001) e payload inválido (TR005) sem apagar nada; serializa concorrentes (TR004). '
+  'Único caminho de escrita destrutiva: useBundleEngine e omie-analytics-sync.';
+
+-- Grants: a função é DEFINER, então a porta é o EXECUTE. `anon` fica de fora.
+REVOKE ALL ON FUNCTION public.farmer_association_rules_substituir(jsonb) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.farmer_association_rules_substituir(jsonb) FROM anon;
+GRANT EXECUTE ON FUNCTION public.farmer_association_rules_substituir(jsonb) TO authenticated, service_role;


### PR DESCRIPTION
Achado **[P1]** do parecer Codex (challenge retroativo do #1550). **Pré-existente** (9892dd88) — não introduzido lá.

## O defeito

`farmer_association_rules` é **global** (não tem `farmer_id`) e os **dois** writers a substituíam com `delete()` de tudo seguido de `insert()` — chamadas PostgREST separadas, logo **transações separadas**, com o `error` das duas descartado:

| Writer | Como era |
|---|---|
| [useBundleEngine.ts](src/hooks/useBundleEngine.ts) | staff clica "calcular bundles" → DELETE-tudo + INSERT em lote |
| [omie-analytics-sync](supabase/functions/omie-analytics-sync/index.ts) | action `compute_association_rules` → DELETE-tudo + **um INSERT por regra** |

Falha de rede entre as duas chamadas deixa a tabela **vazia** — ou **pela metade**, no caso da edge — e o toast de sucesso saía do mesmo jeito.

## Blast radius — maior que o relatado

O parecer via 2 consumidores e 1 writer. São **5 consumidores** e **2 writers**, e nenhum consumidor distingue "sem regra" de "tabela zerada":

1. `_carteira_mixgap_for_owner` → `get_meu_mixgap` → card **MixGap** em `FarmerCalls`
2. `melhoria_produtos_relacionados` → **canal Melhorias** (em produção)
3. [`supabase/functions/recommend`](supabase/functions/recommend/index.ts) → `assoc_score`, peso `w_assoc` **0.25** do score
4. [`useCrossSellEngine`](src/hooks/useCrossSellEngine.ts) → cross-sell do farmer
5. o próprio bundle engine, na execução seguinte

Um clique com falha de rede no meio derrubava quatro features, sem sinal na tela.

## O conserto

A troca passa a ir por `farmer_association_rules_substituir(jsonb)` — **DELETE+INSERT na mesma transação**, então INSERT falho devolve as regras antigas. Segue o padrão que o repo já usa em `fin_divida_replace_parcelas`, com três garantias a mais que a natureza global da tabela exige:

- **valida o payload ANTES de destruir** (mensagem legível em vez de rollback opaco);
- **recusa lote vazio** (`TR001`) — zero regra quase sempre é dado faltando a montante, não motivo pra apagar o que vale;
- **serializa concorrentes** com advisory lock transacional (`TR004`) — hoje dois recálculos simultâneos conseguem intercalar DELETE/INSERT e **duplicar** o lote.

O toast deixa de mentir: falha na persistência vira `toast.warning` dizendo que as regras anteriores seguem valendo. A edge **propaga** o erro em vez de logá-lo.

## Prova — PG17 local

[`db/test-farmer-association-rules-atomica.sh`](db/test-farmer-association-rules-atomica.sh): **26 asserts**, verde sob `LC_ALL=C` **e** `pt_BR.UTF-8`. O assert central é o A7: injeta falha no meio do INSERT (trigger que estoura na 2ª linha) e exige que as 3 regras antigas continuem lá.

**O harness pegou um bug de autorização na primeira versão da própria migration.** `auth.role() = 'service_role'` devolve `NULL` sem JWT; `NOT (NULL OR false OR false)` é `NULL`; e `IF NULL THEN` **não entra no ramo** — o gate falhava **aberto** e o customer substituía as regras de toda a base (assert A4 vermelho). Corrigido com `coalesce(auth.role(), '')`.

**4 falsificações**, cada uma apontada a um invariante, todas exigindo vermelho:

| Sabotagem | Assert que tem de cair |
|---|---|
| fail-closed do lote vazio | A5 (tabela zeraria) |
| gate de staff | A4 (customer passa) |
| atomicidade (reproduz 9892dd88) | A7b — sobraram **0** de 3 regras |
| advisory lock | A8 (concorrente entra junto) |

O helper de sabotagem confere com `cmp` que a expressão **realmente alterou** a migration: `0,/re/s//../` é sintaxe do GNU sed e o macOS usa BSD — uma sabotagem inerte teria deixado a falsificação inteira verde sem ter sabotado nada.

Os testes de front e de edge também foram falsificados: `toast.success` incondicional derruba 1; o `.delete()` de volta derruba 2 (front) e 1 (edge); erro engolido derruba 1 (edge).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260729120000_farmer_association_rules_substituicao_atomica.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

**Ordem de deploy importa**: a migration precisa ir **antes** do Publish do frontend e do deploy da edge. Sem a RPC no banco, os dois writers falham no `rpc()` — o que preserva as regras (degradação correta), mas nenhum recálculo grava.

<details><summary>SQL pra aplicar (🟣 SQL Editor)</summary>

Ver o arquivo completo em `supabase/migrations/20260729120000_farmer_association_rules_substituicao_atomica.sql` — cole byte-a-byte.
</details>

Validação pós-apply (eu rodo via psql-ro):

```sql
SELECT CASE WHEN EXISTS (
  SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
  WHERE n.nspname = 'public' AND p.proname = 'farmer_association_rules_substituir'
) THEN 'OK funcao existe' ELSE 'FALTANDO -- migration nao aplicada' END AS status;
```

Além da migration: **Publish** (frontend) e **deploy da edge `omie-analytics-sync`** pelo chat do Lovable.

## Coordenação

O #1520 (draft) reescreve outras regiões de `useBundleEngine.ts` — seus hunks param em ~234 e retomam em ~428; o bloco de persistência (382-396) fica no meio, com folga de contexto. Sem sobreposição.

## Fora de escopo (deliberado)

O `insert` de `farmer_bundle_recommendations` logo abaixo (linhas ~560-575) tem o mesmo erro silencioso — mas **não é destrutivo** (INSERT puro, sem DELETE) e é exatamente o bloco que o #1520 reescreve. Mexer ali criaria conflito com um PR em voo, para consertar algo de severidade menor. Fica registrado como follow-up.

## Gates

`test` 5698/5698 · `typecheck` 0 · `lint` 0 erros · `test:edges` 240/240 · `edges:typecheck` 0 crash · `shellcheck` 0 · harness PG17 26/26 (C e pt_BR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
