### PR TITLE
feat(tint): watchdog do corante impagável — a Fase 5 tirou o fallback, e um corante caindo agora é visto em 5min [money-path]

### DIFF
--- a/db/test-tint-watchdog-corante.sh
+++ b/db/test-tint-watchdog-corante.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — tint_watchdog_corante_check() (Fase 5b#2, PR 1)                  ║
+# ║  bash db/test-tint-watchdog-corante.sh > /tmp/t.log 2>&1; echo "exit=$?"       ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                        ║
+# ║                                                                                ║
+# ║  O QUE PROVA (a migration 20260727150000):                                     ║
+# ║   A1 corante impagável EM USO  -> alerta criado (fin_alertas + e-mail)         ║
+# ║   A2 corante impagável FORA de uso -> NÃO alerta      (precisão > recall)      ║
+# ║   A3 impagável só em fórmula DESATIVADA -> NÃO alerta (precisão > recall)      ║
+# ║   A4 marcador sync_state avança em sucesso COMPLETO   (Codex: "verde por       ║
+# ║      construção" — sem last_success_at, ausência de alerta não é saúde)        ║
+# ║   A5 volta a zero -> dismiss                                                   ║
+# ║   A6 AGRAVAMENTO: 2o corante cai com alerta aberto -> atualiza + re-emite      ║
+# ║      (Codex [P1]: ON CONFLICT DO NOTHING deixaria o 2o MUDO)                   ║
+# ║   A7 severidade escala com o nº de fórmulas atingidas (Codex [P2])             ║
+# ║   A8 dead-man cruzado NÃO alarma quando a Camada B ainda não existe            ║
+# ║   A9 marcador da Camada B stale (>13h) -> alerta watchdog parado               ║
+# ║  FALSIFICAÇÕES (cada uma declara o CONJUNTO EXATO que derruba):                ║
+# ║   F1 remove o filtro de USO            -> {A2,A3}                              ║
+# ║   F2 remove `ativo` do predicado       -> {A1}                                 ║
+# ║   F3 remove o bloco de agravamento     -> {A6}                                 ║
+# ║   F4 remove o marcador de sucesso      -> {A4}                                 ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5457}"
+SLUG="tintwd"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0; FALHAS=()
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); FALHAS+=("$1"); echo "  XX  $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup PG17 :$PORT ==="
+
+# ══ ZONA 1 — pré-requisitos (o que a migration LÊ mas não cria) ══
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS cron;
+-- a migration chama cron.schedule; no PG17 local não há pg_cron. Stub que REGISTRA
+-- a chamada, para o assert provar que o cron foi armado com o schedule certo.
+CREATE TABLE IF NOT EXISTS cron.job (jobid bigserial, jobname text, schedule text, command text, active boolean DEFAULT true);
+CREATE OR REPLACE FUNCTION cron.schedule(p_name text, p_sched text, p_cmd text)
+RETURNS bigint LANGUAGE plpgsql AS $f$
+DECLARE v bigint; BEGIN
+  DELETE FROM cron.job WHERE jobname = p_name;
+  INSERT INTO cron.job (jobname, schedule, command) VALUES (p_name, p_sched, p_cmd) RETURNING jobid INTO v;
+  RETURN v;
+END $f$;
+
+CREATE TABLE public.omie_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  valor_unitario numeric, ativo boolean, descricao text, codigo text);
+CREATE TABLE public.tint_corantes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  omie_product_id uuid, volume_total_ml numeric, ativo boolean DEFAULT true);
+CREATE TABLE public.tint_formulas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account text NOT NULL DEFAULT 'oben', sku_id uuid, cor_id uuid,
+  desativada_em timestamptz, desativada_motivo text);
+CREATE TABLE public.tint_formula_itens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  formula_id uuid, corante_id uuid, qtd_ml numeric);
+CREATE TABLE public.fin_alertas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company text NOT NULL, tipo text NOT NULL, severidade text NOT NULL, mensagem text NOT NULL,
+  contexto jsonb, criado_em timestamptz NOT NULL DEFAULT now(),
+  dismissed_at timestamptz, email_enfileirado_em timestamptz);
+-- o UNIQUE PARCIAL real de prod: é ele que faz o ON CONFLICT DO NOTHING ser anti-spam
+CREATE UNIQUE INDEX fin_alertas_unique_ativo ON public.fin_alertas (company, tipo) WHERE dismissed_at IS NULL;
+CREATE TABLE public.fornecedor_alerta (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text, tipo text, severidade text, titulo text, mensagem text, status text,
+  criado_em timestamptz DEFAULT now());
+CREATE TABLE public.sync_state (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type text NOT NULL, account text NOT NULL DEFAULT 'vendas',
+  last_sync_at timestamptz, status text DEFAULT 'idle', error_message text,
+  metadata jsonb DEFAULT '{}'::jsonb, created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now());
+CREATE UNIQUE INDEX sync_state_entity_account_uq ON public.sync_state (entity_type, account);
+SQL
+
+# ══ ZONA 2 — a migration REAL (Lei #1: nunca um stub da lógica) ══
+MIG="$REPO_ROOT/supabase/migrations/20260727150000_tint_watchdog_corante_impagavel.sql"
+[ -f "$MIG" ] || { echo "migration nao encontrada: $MIG"; exit 1; }
+P -q -f "$MIG"
+echo "=== migration aplicada ==="
+
+# guarda o corpo verdadeiro, para restaurar depois de cada sabotagem
+P -q -c "CREATE TABLE _bkp AS SELECT pg_get_functiondef('public.tint_watchdog_corante_check()'::regprocedure) AS def;"
+restaura() { Pq -c "SELECT def FROM _bkp;" > /tmp/_wd_real.sql; P -q -f /tmp/_wd_real.sql; }
+
+# ══ ZONA 3 — seeds ══
+# C_OK: corante saudável (nunca deve alarmar).  C_INAT: omie INATIVO (impagável).
+# C_SEMCUSTO: valor_unitario 0.  C_ORFAO: impagável mas FORA de uso.
+# C_MORTA: impagável, usado só por fórmula DESATIVADA.
+P -q <<'SQL'
+INSERT INTO public.omie_products (id, valor_unitario, ativo, descricao) VALUES
+ ('a0000000-0000-0000-0000-000000000001', 600, true,  'CONCENTRADO OK'),
+ ('a0000000-0000-0000-0000-000000000002', 600, false, 'CONCENTRADO INATIVO'),
+ ('a0000000-0000-0000-0000-000000000003', 0,    true, 'CONCENTRADO SEM CUSTO'),
+ ('a0000000-0000-0000-0000-000000000004', 0,    true, 'CONCENTRADO ORFAO'),
+ ('a0000000-0000-0000-0000-000000000005', 0,    true, 'CONCENTRADO SO EM MORTA');
+INSERT INTO public.tint_corantes (id, omie_product_id, volume_total_ml) VALUES
+ ('c0000000-0000-0000-0000-000000000001','a0000000-0000-0000-0000-000000000001', 810),
+ ('c0000000-0000-0000-0000-000000000002','a0000000-0000-0000-0000-000000000002', 810),
+ ('c0000000-0000-0000-0000-000000000003','a0000000-0000-0000-0000-000000000003', 810),
+ ('c0000000-0000-0000-0000-000000000004','a0000000-0000-0000-0000-000000000004', 810),
+ ('c0000000-0000-0000-0000-000000000005','a0000000-0000-0000-0000-000000000005', 810);
+-- F_ATIVA usa C_OK e C_INAT; F_MORTA (desativada) usa C_MORTA; C_ORFAO não é usado por ninguém.
+INSERT INTO public.tint_formulas (id, account, sku_id, cor_id, desativada_em, desativada_motivo) VALUES
+ ('f0000000-0000-0000-0000-000000000001','oben','5c000000-0000-0000-0000-000000000001'::uuid,'c0100000-0000-0000-0000-000000000001'::uuid, NULL, NULL),
+ ('f0000000-0000-0000-0000-000000000002','oben','5c000000-0000-0000-0000-000000000001'::uuid,'c0100000-0000-0000-0000-000000000002'::uuid, now(), 'fase5_geracao_legada');
+INSERT INTO public.tint_formula_itens (formula_id, corante_id, qtd_ml) VALUES
+ ('f0000000-0000-0000-0000-000000000001','c0000000-0000-0000-0000-000000000001', 10),
+ ('f0000000-0000-0000-0000-000000000002','c0000000-0000-0000-0000-000000000005', 10);
+SQL
+
+reset_estado() {
+  P -q -c "DELETE FROM public.fin_alertas; DELETE FROM public.fornecedor_alerta; DELETE FROM public.sync_state;"
+}
+# liga/desliga um corante impagável DENTRO de uma fórmula ATIVA
+usa_na_ativa() { P -q -c "INSERT INTO public.tint_formula_itens (formula_id, corante_id, qtd_ml) VALUES ('f0000000-0000-0000-0000-000000000001','$1', 5);"; }
+tira_da_ativa() { P -q -c "DELETE FROM public.tint_formula_itens WHERE formula_id='f0000000-0000-0000-0000-000000000001' AND corante_id='$1';"; }
+
+alertas_ativos() { Pq -c "SELECT count(*) FROM public.fin_alertas WHERE tipo='$1' AND dismissed_at IS NULL;"; }
+emails()         { Pq -c "SELECT count(*) FROM public.fornecedor_alerta WHERE titulo LIKE '%$1%';"; }
+
+# ══ ZONA 4 — a suíte (roda inteira; usada também sob sabotagem) ══
+roda_suite() {
+  PASS=0; FAIL=0; FALHAS=()
+
+  # A2/A3 primeiro: estado SAUDÁVEL (só C_OK em uso). C_ORFAO e C_MORTA são impagáveis
+  # mas não estão em fórmula ativa -> o watchdog tem de ficar MUDO.
+  reset_estado
+  P -q -c "SELECT public.tint_watchdog_corante_check();"
+  eq "A2 impagavel FORA de uso nao alarma" "$(alertas_ativos tint_corante_impagavel)" "0"
+  eq "A3 impagavel so em formula DESATIVADA nao alarma" "$(emails 'corante sem custo')" "0"
+  eq "A4 marcador avanca em sucesso" "$(Pq -c "SELECT COALESCE(status,'AUSENTE') FROM public.sync_state WHERE entity_type='tint_watchdog_corante';")" "complete"
+  eq "A8 dead-man nao alarma sem a Camada B" "$(alertas_ativos tint_watchdog_fase5_parado)" "0"
+
+  # A1: o corante INATIVO entra numa fórmula ativa -> tem de alarmar
+  usa_na_ativa 'c0000000-0000-0000-0000-000000000002'
+  P -q -c "SELECT public.tint_watchdog_corante_check();"
+  eq "A1 impagavel EM USO alarma" "$(alertas_ativos tint_corante_impagavel)" "1"
+  eq "A1b e-mail enfileirado" "$(emails 'corante sem custo')" "1"
+  eq "A7 severidade aviso com poucas formulas" "$(Pq -c "SELECT severidade FROM public.fin_alertas WHERE tipo='tint_corante_impagavel' AND dismissed_at IS NULL;")" "aviso"
+
+  # A6: um SEGUNDO corante cai com o alerta ABERTO -> tem de atualizar e re-emitir
+  usa_na_ativa 'c0000000-0000-0000-0000-000000000003'
+  P -q -c "SELECT public.tint_watchdog_corante_check();"
+  eq "A6 agravamento atualiza o contexto" "$(Pq -c "SELECT contexto->>'corantes' FROM public.fin_alertas WHERE tipo='tint_corante_impagavel' AND dismissed_at IS NULL;")" "2"
+  eq "A6b agravamento re-emite e-mail" "$(emails 'AGRAVOU')" "1"
+
+  # A5: tudo volta ao normal -> dismiss
+  tira_da_ativa 'c0000000-0000-0000-0000-000000000002'
+  tira_da_ativa 'c0000000-0000-0000-0000-000000000003'
+  P -q -c "SELECT public.tint_watchdog_corante_check();"
+  eq "A5 dismiss quando volta a zero" "$(alertas_ativos tint_corante_impagavel)" "0"
+
+  # A9: marcador da Camada B velho -> dead-man cruzado dispara
+  P -q -c "INSERT INTO public.sync_state (entity_type, account, last_sync_at, status) VALUES ('tint_watchdog_fase5','oben', now() - interval '20 hours','complete');"
+  P -q -c "SELECT public.tint_watchdog_corante_check();"
+  eq "A9 dead-man cruzado dispara com B parada" "$(alertas_ativos tint_watchdog_fase5_parado)" "1"
+}
+
+echo "=== BASELINE (migration real) ==="
+roda_suite
+BASE_PASS=$PASS; BASE_FAIL=$FAIL
+echo "--- baseline: $BASE_PASS ok / $BASE_FAIL falhas ---"
+if [ "$BASE_FAIL" -ne 0 ]; then
+  echo "BASELINE VERMELHO — a migration real nao passa. Falhas: ${FALHAS[*]}"
+  exit 1
+fi
+echo "TOTAL_ASSERTS=$BASE_PASS"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# FALSIFICAÇÃO (Lei #3) — sabota a migration em UM ponto e exige o conjunto
+# EXATO de asserts vermelhos. "Falsificação prova que o assert tem dente; só
+# instrumentar o RESULTADO prova que ele é ESPECÍFICO" (lição #1505).
+# Cada sabotagem nasce por substituição sobre a migration REAL (diferença de
+# exatamente 1 ponto), e PROVA QUE APLICOU antes de medir — senão "não casou
+# nada" se leria como "o assert não tem dente".
+# ══════════════════════════════════════════════════════════════════════════════
+FALSIF_ERR=0
+
+sabota_e_mede() {   # $1=rotulo  $2=busca  $3=troca  $4..=asserts esperados
+  local rot="$1" busca="$2" troca="$3"; shift 3
+  local esperado="$*"
+  local sab="/tmp/_wd_sab_${rot}.sql"
+
+  python3 - "$MIG" "$sab" "$busca" "$troca" <<'PY'
+import sys
+src, dst, busca, troca = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+s = open(src).read()
+n = s.count(busca)
+if n != 1:
+    sys.stderr.write("ANCORA NAO UNICA (%d ocorrencias)\n" % n); sys.exit(3)
+open(dst, "w").write(s.replace(busca, troca))
+PY
+  if [ $? -ne 0 ]; then
+    echo "  FALSIF XX  $rot: a sabotagem NAO aplicou (ancora nao casou) — INVALIDA, nao leia como 'sem dente'"
+    FALSIF_ERR=$((FALSIF_ERR+1)); return
+  fi
+  # prova que aplicou de fato
+  if ! command grep -q -- "$troca" "$sab"; then
+    echo "  FALSIF XX  $rot: texto sabotado ausente no arquivo — INVALIDA"
+    FALSIF_ERR=$((FALSIF_ERR+1)); return
+  fi
+
+  P -q -f "$sab" >/dev/null 2>&1
+  roda_suite > /tmp/_wd_suite.log 2>&1
+
+  local caidos=""
+  if [ "${#FALHAS[@]}" -gt 0 ]; then
+    for f in "${FALHAS[@]}"; do caidos="$caidos $(printf '%s' "$f" | awk '{print $1}')"; done
+  fi
+  caidos="$(printf '%s' "$caidos" | tr ' ' '\n' | command grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+  local esp="$(printf '%s' "$esperado" | tr ' ' '\n' | command grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+  if [ "$caidos" = "$esp" ]; then
+    echo "  FALSIF OK  $rot derrubou EXATAMENTE [$caidos]"
+  else
+    echo "  FALSIF XX  $rot: esperado [$esp], veio [$caidos]"
+    FALSIF_ERR=$((FALSIF_ERR+1))
+  fi
+  restaura   # volta a versão verdadeira antes da próxima
+}
+
+echo "=== FALSIFICACOES ==="
+
+# F1 — remove o filtro de USO: corante impagável que ninguém dosa passaria a alarmar.
+#      Prova que A2/A3 (precisão > recall) têm dente.
+#      ⚠️ O conjunto é MAIOR que {A2,A3}, e isso é CASCATA LÓGICA de uma sabotagem
+#      só — não de duas. Sem o filtro, os impagáveis órfãos (C_ORFAO/C_MORTA)
+#      contam SEMPRE: a chave nunca volta a zero (derruba o dismiss A5) e a
+#      contagem nunca sobe de 1->2 (derruba o agravamento A6/A6b). Declarado como
+#      medido: prever {A2,A3} e "consertar" o harness para casar seria repintar
+#      de verde uma sabotagem que de fato morde mais fundo.
+sabota_e_mede "F1" \
+  "AND EXISTS (SELECT 1 FROM tint_formula_itens fi
+                     JOIN tint_formulas f ON f.id = fi.formula_id
+                    WHERE fi.corante_id = c.id
+                      AND f.desativada_em IS NULL AND f.sku_id IS NOT NULL)" \
+  "AND true" \
+  A2 A3 A5 A6 A6b
+
+# F2 — remove o 'ativo' do predicado: o corante INATIVO deixa de ser impagável.
+#      Prova que a detecção cobre inatividade no Omie, não só custo zero.
+sabota_e_mede "F2" \
+  "AND COALESCE(op.ativo, false)" \
+  "AND true" \
+  A1 A1b A7 A6 A6b
+
+# F3 — mata o ramo de agravamento: o 2o corante caindo com alerta aberto fica MUDO.
+#      Prova que o fix do achado [P1] do Codex tem dente.
+sabota_e_mede "F3" \
+  "IF v_ruins > COALESCE(v_ant_n, 0) THEN" \
+  "IF false THEN" \
+  A6 A6b
+
+# F4 — grava o marcador sob outro nome: o dead-man perde o last_success_at.
+#      Prova que A4 mede mesmo o avanço do marcador.
+sabota_e_mede "F4" \
+  "'tint_watchdog_corante', v_conta" \
+  "'tint_watchdog_NOME_ERRADO', v_conta" \
+  A4
+
+# ══ fecho: re-roda a suíte na versão REAL e exige verde ══
+echo "=== VERIFICACAO FINAL (migration real restaurada) ==="
+roda_suite
+echo "--- final: $PASS ok / $FAIL falhas | falsificacoes invalidas/erradas: $FALSIF_ERR ---"
+if [ "$FAIL" -ne 0 ] || [ "$FALSIF_ERR" -ne 0 ]; then
+  echo "RESULTADO: VERMELHO"
+  exit 1
+fi
+echo "RESULTADO: VERDE — $PASS asserts + 4 falsificacoes com conjunto exato"

--- a/docs/superpowers/specs/2026-07-22-tint-fase5-watchdog-design.md
+++ b/docs/superpowers/specs/2026-07-22-tint-fase5-watchdog-design.md
@@ -1,0 +1,222 @@
+# Watchdog "tombstone Fase 5 sem SL válida" — design (follow-up 5b#2)
+
+> Follow-up do PR #1549 (Fase 5 tintométrica, migration `20260727120000`, aplicada em prod
+> 2026-07-22). Fecha o **P1-7** do challenge Codex, calibrado à época como 5b.
+> Money-path: `docs/agent/money-path.md` · domínio: `docs/agent/tintometrico.md`.
+
+## 1. O problema
+
+A Fase 5 desativou **463.995** fórmulas da geração `'1'` (carimbo
+`desativada_motivo='fase5_geracao_legada'`) porque cada chave `(account, sku_id, cor_id)`
+tinha uma **gêmea SL ativa e válida** para servir no lugar. Os guards G2/G3 da migration
+provaram essa propriedade no instante do apply.
+
+**A propriedade não é durável.** Depois do apply, se a gêmea SL invalidar — um corante
+perder custo Omie, ficar inativo, ou a receita ser corrompida por um sync — a chave fica
+**sem fórmula precificável**: a RPC devolve `precoFinal=NULL` (fail-closed), o balcão não
+vende aquela cor, e **ninguém é avisado**. Antes da Fase 5 a `'1'` era o fallback; agora
+não é (o filtro de candidata a canônica é ativo-only e **não** foi relaxado).
+
+Modo de falha irmão (**P1-2**): a FONTE retirar a chave depois da Fase 5. O writer
+`tint_apply_keys_snapshot(uuid)` faz `UPDATE ... SET desativada_em=now()` apenas em linhas
+**ativas** e **não seta `desativada_motivo`** — então ele desativa a SL e a `'1'` permanece
+carimbada, com o CSV dela ainda alimentando rótulo e piso via a coluna 13/14 da view.
+
+### "SL válida" — o predicado canônico
+
+Espelha `receita_valida` da view e `corantes_completos` da RPC de preço:
+
+```sql
+g.desativada_em IS NULL AND g.sku_id IS NOT NULL
+AND EXISTS (SELECT 1 FROM tint_formula_itens fi WHERE fi.formula_id = g.id)   -- tem receita
+AND NOT EXISTS (                                                              -- todo corante precificável
+      SELECT 1 FROM tint_formula_itens fi
+      LEFT JOIN tint_corantes c   ON c.id = fi.corante_id
+      LEFT JOIN omie_products op  ON op.id = c.omie_product_id
+       WHERE fi.formula_id = g.id
+         AND NOT (COALESCE(op.valor_unitario,0) > 0 AND COALESCE(op.ativo,false)
+                  AND c.volume_total_ml IS NOT NULL AND c.volume_total_ml > 0))
+```
+
+## 2. Dimensionamento em PROD (psql-ro, 2026-07-23 ~01:50 UTC, pós-apply)
+
+| Medição | Valor | Custo |
+|---|---|---|
+| Linhas carimbadas `fase5_geracao_legada` | **463.995** (= 463.995 chaves distintas) | 3,7s |
+| Carimbadas que estão ATIVAS (estado impossível) | **0** (o CHECK segura) | — |
+| **P1-7**: carimbada sem gêmea SL ativa e válida | **0** | 20,5s |
+| **Efeito**: carimbada sem canônica `receita_valida` (via a view) | **0** | 26,2s |
+| **P1-2**: carimbada sem SL ativa, com SL desativada | **0** | 9,5s |
+| Fórmulas ATIVAS totais | 496.296 — **496.292 precificáveis**, 4 sem receita, **0 com corante impagável** | 17,4s |
+| Desativadas por OUTRO motivo (fonte retirou) | **16.989** (era 16.958 em 21/07) | — |
+
+**Dois oráculos independentes concordam em 0.** O watchdog nasce medindo zero: ele é
+**preventivo**, e o número que ele vigia é o que deve continuar zero.
+
+### A descoberta que define o desenho: o dano é em AVALANCHE
+
+Existem **14 corantes no total**, todos precificáveis hoje. Fórmulas ativas por corante:
+
+| Corante | `valor_unitario` | Fórmulas ativas que o usam |
+|---|---|---|
+| WP87.3900QT CONCENTRADO OCRE | 632,65 | **296.931** |
+| WP69.3900QT CONCENTRADO VERMELHO S | 633,20 | 256.739 |
+| WP01.3900QT CONCENTRADO PRETO INTE | 498,40 | 227.015 |
+| WP02.3900QT CONCENTRADO BRANCO | 606,30 | 190.810 |
+| WP12.3900QT CONCENTRADO PRETO | 500,70 | 154.066 |
+| … (mais 9, de 137.221 a 7.213) | | |
+
+Um único corante perdendo `valor_unitario` ou ficando inativo no Omie invalida **centenas de
+milhares de fórmulas de uma vez**. Como a Fase 5 removeu o fallback de 463.995 chaves, isso
+derrubaria a venda de boa parte do catálogo simultaneamente. **O modo de falha dominante não
+é uma chave degradar — é um corante derrubar um bloco inteiro.**
+
+Consequência: a causa-raiz do cenário dominante é observável em **14 linhas**, não em 464k.
+
+## 3. Arquitetura — duas camadas
+
+| Camada | Vigia | Custo medido | Cobre |
+|---|---|---|---|
+| **A — corante** | corante impagável **em uso** por fórmula ativa | **214ms** | a avalanche, com detecção rápida; vale também para chaves que nunca tiveram a `'1'` |
+| **B — chave** | carimbada Fase 5 sem canônica `receita_valida` | 26,2s | receita corrompida numa fórmula isolada, fonte retirando a chave, e caminhos não previstos — com fidelidade ao que o balcão lê |
+
+São complementares: **A** é barata, rápida e ampla sobre a **causa**; **B** é completa e fiel
+sobre o **efeito** no escopo que a Fase 5 criou. Nenhuma substitui a outra:
+
+- A sem B: não vê receita corrompida nem chave retirada pela fonte.
+- B sem A: só detecta a avalanche na varredura seguinte, e ignora o dano fora do tombstone.
+
+### Restrição dura: a Camada B NÃO pode viver no `_data_health_compute`
+
+Não é preferência, é timeout medido. `statement_timeout` por role em prod:
+
+| Role | `statement_timeout` |
+|---|---|
+| `anon` | 3s |
+| `authenticated` | **8s** |
+| `supabase_admin` (o cron) | **0 = sem limite** |
+| `claude_ro` (diagnóstico) | 30s (explica os estouros em 45s) |
+
+O dashboard `/health` chama `get_data_health()` (SECURITY DEFINER, `EXECUTE` para
+`authenticated`) que chama `_data_health_compute()`, via `useDataHealth.ts:21` — e o
+`DataHealthBadge` a repete periodicamente. **SECURITY DEFINER troca privilégio, não
+`statement_timeout`**: a sessão continua sendo a do `authenticated`, com 8s de orçamento
+total. Um check de 26s ali derrubaria o dashboard inteiro por timeout, para todo mundo.
+
+⇒ A Camada B fica **obrigatoriamente** num cron dedicado (roda como `supabase_admin`,
+timeout 0). A Camada A (214ms) caberia no Sentinela; o que pesa contra é só o risco de
+cascata do arquivo quente (45.362 chars, 5 reversões históricas, ~58 sessões vivas).
+
+### Oráculo da Camada B: a própria view
+
+A detecção B usa `v_tint_formula_canonica` ("chave carimbada sem canônica `receita_valida`")
+em vez de reimplementar o predicado, porque: (i) é o que o balcão lê, então mede o dano real
+em vez de um proxy; (ii) precisão > recall — não alarma se a chave tiver outro fallback
+válido; (iii) evita criar uma **terceira** cópia do predicado de validade (ele já vive na
+view e na migration da Fase 5), que é exatamente o acoplamento da lição §9 do money-path.
+
+### Canal de alerta
+
+Catálogo tint é 100% da conta **`oben`** (496.296 ativas). O canal reusa a infra existente:
+`fin_alertas` (UNIQUE parcial `(company,tipo) WHERE dismissed_at IS NULL` ⇒ anti-spam, emite
+só na transição ok→degradado) + `fornecedor_alerta` → edge `dispatch-notifications`, com
+dismiss ao voltar a zero. **Tipos dedicados por classe** (lição `sync.md` §Sentinela: duas
+classes no mesmo tipo ficam silenciadas pelo `ON CONFLICT DO NOTHING`).
+
+## 4. Escopo da v1
+
+**Só detecção + alerta.** Sem recuperação automática: não reativar a `'1'`, porque ela é a
+geração **congelada de março** e pode ter preço tão obsoleto quanto a SL que caiu — reativar
+às cegas restaura a venda com preço potencialmente errado, que é pior que fail-closed.
+Recuperação vira decisão de produto posterior, informada pela frequência real observada.
+
+O P1-2 entra de graça na detecção (a chave retirada vira "não vende" e o alerta pega); a
+**ação** de recarimbar/limpar o motivo toca o writer do snapshot e fica no 5b separado.
+
+## 5. Prova
+
+Harness PG17 próprio (`db/test-tint-fase5-watchdog.sh`), aplicando a migration REAL:
+
+- semeia o estado degradado — a gêmea SL invalidando **depois** do carimbo. O cenário **K10**
+  de `db/test-tint-fase5-desativacao.sh` já o constrói (foi o seed que a falsificação F1
+  daquele harness precisou criar, e é literalmente este P1-7);
+- asserta detecção (degradado ⇒ alerta), não-detecção (saudável ⇒ silêncio), e **dismiss**
+  ao voltar a zero;
+- falsifica cada assert declarando o **conjunto exato** que a sabotagem derruba
+  (`confere_falsificacao`, lição #1505 — falsificação prova dente, só instrumentação prova
+  especificidade);
+- baseline verde explícito antes de cada sabotagem (o exit code não distingue "pegou o bug"
+  de "não rodou nada").
+
+## 6. Riscos e lacunas conhecidas
+
+- **Ancoragem no carimbo.** A Camada B só enxerga chaves com tombstone Fase 5. Se o carimbo
+  for limpo (follow-up 5b#1) ou a linha deletada, a chave sai do escopo — a Camada A cobre
+  parcialmente esse vão por não depender do tombstone.
+- **Quem vigia o vigia.** `cron.job_run_details` reporta `succeeded` mesmo quando nada rodou;
+  um cron morto deixa o watchdog verde-silencioso. Precisa de decisão explícita sobre
+  heartbeat próprio.
+- **Nasce em zero.** Um detector que nunca disparou não prova que dispara — daí a exigência
+  de falsificação e de um cenário semeado que force o alerta.
+
+## 7. Challenge Codex — REPROVADO, e o que mudou
+
+Consulta em 2026-07-22 (`gpt-5.6-sol`, reasoning `high`; a 1ª tentativa em `xhigh` morreu no
+hard-stop de 20min sem produzir uma linha). Parecer cru preservado no scratchpad da sessão.
+Veredito: **REPROVADO** — 1 P0, 6 P1, 2 P2.
+
+### Achados aceitos (o desenho muda)
+
+| # | Achado | Efeito no desenho |
+|---|---|---|
+| P0 | B diária deixa a avalanche invisível por 24h | **A a cada 5min · B a cada 6h** |
+| P1 | "P1-2 entra de graça" está **errado**: classes com remediações distintas no mesmo `tipo` são silenciadas pelo `ON CONFLICT DO NOTHING`, e com ~30 retiradas/dia o alerta nunca volta a zero | **tipos de alerta separados por classe** |
+| P1 | A e B no mesmo job = dependência de falha | funções, crons e alertas **separados** |
+| P1 | Sem estado operacional, ausência de alerta não é saúde | **dead-man com `last_success_at`**; timeout ≠ sucesso; timeout nunca dismissa |
+| P1 | Carimbo não é fundamento durável (delete/limpeza fazem o universo sumir ⇒ zero ⇒ "verde") | **vigia de cardinalidade** do universo carimbado (v1); ledger completo → v2 |
+| P2 | Os dois oráculos não são independentes — compartilham a definição de validade | registrado como limite conhecido da evidência |
+
+**O P1-2 era erro meu**: o spec citava a lição do `sync.md` sobre `ON CONFLICT` silenciar a
+segunda classe e a violava no desenho seguinte.
+
+### Achado aceito cuja conclusão a medição refina
+
+**"A view não é o consumidor completo"** — procede: `get_tint_price` faz
+`v_preco_final := CASE WHEN v_base_disponivel AND v_corantes_completos THEN … ELSE NULL END`,
+e a view só expõe o segundo termo. **Mas `base_disponivel` não discrimina gêmeas**: medido
+**0 chaves** com divergência de `base_ok` entre a '1' e a SL (o `sku_id` é o mesmo), logo a
+Fase 5 não causou nem piorou essa condição.
+
+Consequência quantificada: das 463.995 carimbadas, **296.536 (64%) já tinham base
+indisponível** — não vendiam antes da Fase 5. **A exposição real do P1-7 são as 167.459
+chaves com base disponível.** Incluir `base_disponivel` no *gatilho* produziria 296.536
+alertas no dia 1 sobre condição pré-existente (o watchdog nasceria como ruído, contra
+precisão>recall) ⇒ fica **fora do gatilho, dentro do relatório**.
+
+### Achado calibrado
+
+**"26s contra timeout de 45s é pouca margem"** — o Codex usou o número do meu prompt. Medido
+depois: o cron roda como `supabase_admin` (`statement_timeout=0`); os 30s/45s eram do role de
+diagnóstico. A margem não é o risco; o risco *derivado* (erro engolido virando falso verde)
+permanece e é coberto pelo dead-man.
+
+### Fora da v1 (decisão minha, registrada)
+
+Ledger `tint_fase5_coverage_keys` completo · modo degradado explícito com
+`price_source='legacy_csv'` · telemetria de tentativas reais de precificação sem preço ·
+detecção de custo **aberrante** (valor positivo porém errado/obsoleto). Todos procedem; nenhum
+é pré-requisito da detecção, e cada um é uma decisão de produto própria.
+
+## 8. Desenho final da v1
+
+Quatro sinais, tipos distintos, funções e crons separados:
+
+| Sinal | `tipo` do alerta | Frequência | Custo |
+|---|---|---|---|
+| corante impagável em uso | `tint_corante_impagavel_em_uso` | `*/5` | 214ms |
+| chave carimbada sem preço | `tint_fase5_chave_sem_preco` | 6h | 26s |
+| fonte retirou a chave com legado exposto | `tint_fase5_fonte_retirada` | 6h | junto de B |
+| o próprio watchdog parou | `tint_fase5_watchdog_stale` | dead-man | — |
+
+Severidade escala com a contagem (1 chave ≠ 300 mil). Nenhum reativa fórmula: a
+recuperação segue humana, e a `'1'` congelada de março nunca volta a canônica sozinha.

--- a/supabase/migrations/20260727150000_tint_watchdog_corante_impagavel.sql
+++ b/supabase/migrations/20260727150000_tint_watchdog_corante_impagavel.sql
@@ -1,0 +1,231 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Tintométrico — WATCHDOG da causa-raiz: corante impagável EM USO
+-- (Fase 5b#2, PR 1 de 2 — spec docs/superpowers/specs/2026-07-22-tint-fase5-watchdog-design.md)
+--
+-- POR QUE EXISTE. A Fase 5 (20260727120000) desativou 463.995 fórmulas da geração
+-- '1' porque cada chave tinha gêmea SL ATIVA E VÁLIDA. Os guards provaram isso NO
+-- INSTANTE DO APPLY — mas a propriedade NÃO É DURÁVEL: se a SL invalidar depois, a
+-- '1' que a respaldava já está desativada, a chave fica sem fórmula precificável
+-- (RPC devolve precoFinal=NULL, fail-closed), o balcão não vende, e ninguém é
+-- avisado. É o P1-7 do challenge Codex da Fase 5, calibrado à época como 5b.
+--
+-- O QUE ESTA MIGRATION VIGIA (e por que este recorte). Medido em prod 2026-07-23:
+-- existem só 14 CORANTES, e o mais usado está em 296.931 fórmulas ativas.
+-- => o modo de falha dominante NAO é uma chave degradar: é UM corante perder custo
+-- Omie (ou ficar inativo) e invalidar centenas de milhares de fórmulas DE UMA VEZ.
+-- Como a Fase 5 removeu o fallback, isso derruba a venda de boa parte do catálogo
+-- simultaneamente. A causa-raiz é observável em 14 linhas: 214ms, contra 26s da
+-- varredura por chave — daí a cadência */5 (a Camada B, por chave, é o PR 2).
+--
+-- NAO vive no _data_health_compute, e não é só preferência: authenticated tem
+-- statement_timeout=8s e o dashboard /health chama get_data_health() -> o compute
+-- (useDataHealth.ts:21, repetido pelo DataHealthBadge). SECURITY DEFINER troca
+-- privilégio, NAO o statement_timeout. Um check pesado ali derruba o dashboard
+-- inteiro. Este cron roda como supabase_admin (statement_timeout=0). Bônus: não
+-- toca o arquivo mais quente do repo (45k chars, 5 reversões por cascata).
+--
+-- ESTE WATCHDOG NAO DEPENDE DO CARIMBO da Fase 5 — de propósito. O tombstone
+-- não é fundamento durável (linha deletada / motivo limpo => o universo some =>
+-- o resultado vira zero => "verde"). Ancorar na FONTE do dano (o corante) é imune
+-- a isso, e ainda cobre chaves que nunca tiveram a geração '1'.
+--
+-- ── Achados do challenge Codex (gpt-5.6-sol, 2026-07-22) endereçados aqui ──
+--  [P0] "diária deixa a avalanche invisível por 24h"  -> */5 (214ms permite).
+--  [P1] "A e B no mesmo job = dependência de falha"    -> função e cron PRÓPRIOS.
+--  [P1] "sem last_success_at, ausência de alerta não é saúde; verde por
+--       construção"                                    -> marcador em sync_state,
+--       que só avança em avaliação COMPLETA. Erro NAO avança e NAO dismissa.
+--  [P1] "ON CONFLICT DO NOTHING esconde um 2o corante que caia durante um
+--       incidente aberto"                              -> quando o conjunto PIORA,
+--       o alerta ativo é ATUALIZADO e o e-mail RE-ENFILEIRADO (não fica mudo).
+--  [P2] "falta política de agravamento"                -> severidade escala pelo
+--       no. de fórmulas ativas atingidas.
+--
+-- Prova: db/test-tint-watchdog-corante.sh (PG17, migration REAL, falsificação).
+-- ═══════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.tint_watchdog_corante_check()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  -- tint_watchdog_corante guard v1 — MARCADOR do guard anti-rollback. Uma versão
+  -- SUCESSORA que recrie esta função DEVE trocar este marcador (v2, v3...), para que
+  -- re-aplicar ESTA por cima dela ABORTE em vez de revertê-la em silêncio.
+  v_conta        text := 'oben';   -- 100% do catálogo tint é oben (medido)
+  v_ruins        int;
+  v_formulas     bigint;
+  v_lista        text;
+  v_msg          text;
+  v_sev_fin      text;
+  v_sev_forn     text;
+  v_ant_n        int;
+  v_b_atraso     interval;
+BEGIN
+  -- ── DETECÇÃO ────────────────────────────────────────────────────────────
+  -- Corante cujo custo Omie não precifica, E que está EM USO por fórmula ativa.
+  -- O predicado espelha corantes_completos da RPC get_tint_price / receita_valida
+  -- da v_tint_formula_canonica: valor_unitario>0 E omie ativo E volume_total_ml>0.
+  -- O filtro de USO evita alarmar por corante recém-cadastrado que ninguém dosa.
+  SELECT count(*),
+         COALESCE(sum(x.formulas), 0),
+         string_agg(x.rotulo, '; ' ORDER BY x.formulas DESC)
+    INTO v_ruins, v_formulas, v_lista
+  FROM (
+    SELECT c.id,
+           (SELECT count(*) FROM tint_formula_itens fi
+              JOIN tint_formulas f ON f.id = fi.formula_id
+             WHERE fi.corante_id = c.id
+               AND f.desativada_em IS NULL AND f.sku_id IS NOT NULL) AS formulas,
+           COALESCE(NULLIF(btrim(op.descricao), ''), op.codigo, c.id::text)
+             || ' (' || CASE
+                  WHEN c.omie_product_id IS NULL              THEN 'sem vinculo Omie'
+                  WHEN op.id IS NULL                          THEN 'produto Omie inexistente'
+                  WHEN NOT COALESCE(op.ativo, false)          THEN 'inativo no Omie'
+                  WHEN COALESCE(op.valor_unitario, 0) <= 0    THEN 'sem custo'
+                  ELSE 'volume_total_ml invalido' END || ')' AS rotulo
+      FROM tint_corantes c
+      LEFT JOIN omie_products op ON op.id = c.omie_product_id
+     WHERE NOT (COALESCE(op.valor_unitario, 0) > 0
+                AND COALESCE(op.ativo, false)
+                AND c.volume_total_ml IS NOT NULL
+                AND c.volume_total_ml > 0)
+       AND EXISTS (SELECT 1 FROM tint_formula_itens fi
+                     JOIN tint_formulas f ON f.id = fi.formula_id
+                    WHERE fi.corante_id = c.id
+                      AND f.desativada_em IS NULL AND f.sku_id IS NOT NULL)
+  ) x;
+
+  IF v_ruins > 0 THEN
+    -- Agravamento (Codex [P2]): 1 corante numa fórmula != 1 corante em 300 mil.
+    v_sev_fin  := CASE WHEN v_formulas >= 1000 THEN 'critico'  ELSE 'aviso'   END;
+    v_sev_forn := CASE WHEN v_formulas >= 1000 THEN 'urgente'  ELSE 'atencao' END;
+    v_msg := 'Tintometrico: ' || v_ruins || ' corante(s) sem custo utilizavel atingindo '
+             || v_formulas || ' formula(s) ativa(s) - essas formulas deixam de ter preco '
+             || '(precoFinal NULL, fail-closed) e o balcao nao vende. Apos a Fase 5 a '
+             || 'geracao 1 nao e mais fallback. Corante(s): ' || COALESCE(v_lista, '?');
+
+    INSERT INTO fin_alertas (company, tipo, severidade, mensagem, contexto)
+    VALUES (v_conta, 'tint_corante_impagavel', v_sev_fin, v_msg,
+            jsonb_build_object('corantes', v_ruins, 'formulas_ativas', v_formulas,
+                               'detalhe', v_lista, 'avaliado_em', now()))
+    ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+
+    IF FOUND THEN
+      INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+      VALUES (v_conta, 'outro', v_sev_forn,
+              '[Tintometrico] corante sem custo - formulas sem preco', v_msg, 'pendente_notificacao');
+    ELSE
+      -- Codex [P1]: com ON CONFLICT DO NOTHING, um SEGUNDO corante caindo durante um
+      -- incidente aberto ficaria MUDO. Se o conjunto PIOROU, atualiza e re-emite.
+      SELECT COALESCE((contexto->>'corantes')::int, 0) INTO v_ant_n
+        FROM fin_alertas
+       WHERE company = v_conta AND tipo = 'tint_corante_impagavel' AND dismissed_at IS NULL;
+
+      IF v_ruins > COALESCE(v_ant_n, 0) THEN
+        UPDATE fin_alertas
+           SET severidade = v_sev_fin, mensagem = v_msg,
+               contexto = jsonb_build_object('corantes', v_ruins, 'formulas_ativas', v_formulas,
+                                             'detalhe', v_lista, 'avaliado_em', now(),
+                                             'agravou_de', v_ant_n)
+         WHERE company = v_conta AND tipo = 'tint_corante_impagavel' AND dismissed_at IS NULL;
+
+        INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+        VALUES (v_conta, 'outro', v_sev_forn,
+                '[Tintometrico] AGRAVOU: ' || v_ruins || ' corantes sem custo',
+                v_msg || E'\n\n(agravamento: eram ' || v_ant_n || ')', 'pendente_notificacao');
+      END IF;
+    END IF;
+  ELSE
+    UPDATE fin_alertas SET dismissed_at = now()
+     WHERE company = v_conta AND tipo = 'tint_corante_impagavel' AND dismissed_at IS NULL;
+  END IF;
+
+  -- ── MARCADOR DE SUCESSO (Codex [P1]: "verde por construção") ────────────
+  -- last_sync_at = último sucesso COMPLETO. Só chega aqui quem avaliou e transicionou
+  -- o alerta; qualquer exceção acima aborta a função e NAO avança o marcador - então
+  -- "sem alerta" deixa de ser indistinguível de "nunca rodou".
+  INSERT INTO sync_state (entity_type, account, last_sync_at, status, error_message, metadata)
+  VALUES ('tint_watchdog_corante', v_conta, now(), 'complete', NULL,
+          jsonb_build_object('corantes_ruins', v_ruins, 'formulas_atingidas', v_formulas))
+  ON CONFLICT (entity_type, account) DO UPDATE
+    SET last_sync_at  = now(),
+        status        = 'complete',
+        error_message = NULL,
+        updated_at    = now(),
+        metadata      = jsonb_build_object('corantes_ruins', v_ruins,
+                                           'formulas_atingidas', v_formulas);
+
+  -- ── VIGILÂNCIA CRUZADA (dead-man da Camada B, quando ela existir) ───────
+  -- Um cron não vigia a si mesmo: cron.job_run_details diz "succeeded" só por ter
+  -- ENFILEIRADO. Como esta camada roda */5 e é barata, ela vigia o marcador da
+  -- camada lenta (6h). O caso "pg_cron inteiro morreu" já é coberto pelo
+  -- dead-man-switch global existente (fin_sync_heartbeat para de enviar).
+  -- Só age se o marcador da B JA existir (ela é o PR 2), senão esta função
+  -- alarmaria por ausência de algo que ainda não foi entregue.
+  SELECT now() - ss.last_sync_at INTO v_b_atraso
+    FROM sync_state ss
+   WHERE ss.entity_type = 'tint_watchdog_fase5' AND ss.account = v_conta;
+
+  IF v_b_atraso IS NOT NULL AND v_b_atraso > interval '13 hours' THEN
+    -- 13h = 2 ciclos de 6h + folga (Codex: "dead-man da B dispara após 2 ciclos perdidos")
+    INSERT INTO fin_alertas (company, tipo, severidade, mensagem, contexto)
+    VALUES (v_conta, 'tint_watchdog_fase5_parado', 'aviso',
+            'Watchdog da Fase 5 (chave sem preco) sem sucesso ha ' ||
+            date_trunc('minute', v_b_atraso) || ' - a rede de deteccao por chave esta CEGA.',
+            jsonb_build_object('atraso', v_b_atraso::text))
+    ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+    IF FOUND THEN
+      INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+      VALUES (v_conta, 'outro', 'atencao', '[Tintometrico] watchdog da Fase 5 parado',
+              'O watchdog por chave nao conclui ha ' || date_trunc('minute', v_b_atraso) ||
+              '. Cheque o cron tint-watchdog-fase5-6h.', 'pendente_notificacao');
+    END IF;
+  ELSIF v_b_atraso IS NOT NULL THEN
+    UPDATE fin_alertas SET dismissed_at = now()
+     WHERE company = v_conta AND tipo = 'tint_watchdog_fase5_parado' AND dismissed_at IS NULL;
+  END IF;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.tint_watchdog_corante_check() IS
+  'Fase 5b#2 (PR 1): vigia a CAUSA-RAIZ do P1-7 - corante sem custo Omie utilizavel '
+  'que esta EM USO por formula ativa. Com 14 corantes e o maior deles em ~297k '
+  'formulas, um corante caindo tira o preco de centenas de milhares de chaves de uma '
+  'vez, e a Fase 5 removeu o fallback da geracao 1. Roda */5 (214ms). NAO depende '
+  'do carimbo fase5_geracao_legada (tombstone nao e fundamento duravel). Grava '
+  'marcador sync_state tint_watchdog_corante que so avanca em sucesso COMPLETO. '
+  'NAO pode migrar para _data_health_compute: authenticated tem statement_timeout=8s '
+  'e o dashboard /health chama aquele caminho.';
+
+-- Cron SQL-local (roda no Postgres como supabase_admin => statement_timeout=0).
+-- NAO usa net.http_post, então não precisa de timeout_milliseconds; e o
+-- job_run_details aqui carrega o erro plpgsql REAL (cron SQL-local é fonte
+-- primária confiável - docs/agent/sync.md).
+-- cron.schedule faz upsert por nome => idempotente.
+SELECT cron.schedule(
+  'tint-watchdog-corante-5min',
+  '*/5 * * * *',
+  $cron$SELECT public.tint_watchdog_corante_check();$cron$
+);
+
+COMMIT;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- VALIDAÇÃO PÓS-APPLY (read-only; o founder cola, ou eu rodo via psql-ro)
+--   1) a função existe e o cron está armado:
+--      SELECT to_regprocedure('public.tint_watchdog_corante_check()') IS NOT NULL AS fn_ok,
+--             (SELECT active FROM cron.job WHERE jobname='tint-watchdog-corante-5min') AS cron_ativo;
+--   2) primeira execução manual + marcador (esperado: corantes_ruins=0 em 2026-07-23):
+--      SELECT public.tint_watchdog_corante_check();
+--      SELECT status, last_sync_at, metadata FROM public.sync_state
+--       WHERE entity_type='tint_watchdog_corante' AND account='oben';
+--   3) nasce VERDE (nenhum alerta aberto por ele):
+--      SELECT count(*) FROM public.fin_alertas
+--       WHERE tipo IN ('tint_corante_impagavel','tint_watchdog_fase5_parado')
+--         AND dismissed_at IS NULL;   -- esperado 0
+-- ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up **5b#2** da Fase 5 tintométrica (#1549). Fecha o **P1-7** do challenge Codex daquela entrega.

## O buraco que isto tapa

A Fase 5 desativou **463.995** fórmulas da geração `'1'` porque cada chave tinha gêmea SL **ativa e válida**. Os guards G2/G3 provaram isso **no instante do apply** — mas a propriedade **não é durável**. Se a SL invalidar depois (corante perde custo Omie, fica inativo, receita corrompida), a `'1'` que a respaldava já está desativada: a chave fica sem fórmula precificável, a RPC devolve `precoFinal=NULL` (fail-closed), **o balcão não vende aquela cor e ninguém é avisado**. Antes da Fase 5 a `'1'` era o fallback; agora não é.

## Dimensionamento em prod (psql-ro, read-only)

| Medição | Hoje |
|---|---|
| Carimbadas `fase5_geracao_legada` | 463.995 (= 463.995 chaves) |
| **P1-7** (sem gêmea SL válida) — predicado espelhado, 20,5s | **0** |
| **Efeito** (sem canônica `receita_valida`) — via a view, 26,2s | **0** |
| **P1-2** (fonte retirou a chave) — 9,5s | **0** |

Dois oráculos independentes concordam em zero. **O watchdog nasce medindo zero — é preventivo**, e o número que ele vigia é o que deve continuar zero.

## A descoberta que definiu o desenho: o dano é em AVALANCHE

Existem só **14 corantes**, e o maior está em **296.931 fórmulas ativas**:

| Corante | Fórmulas ativas |
|---|---|
| WP87 OCRE | **296.931** |
| WP69 VERMELHO S | 256.739 |
| WP01 PRETO INTE | 227.015 |
| … (mais 11) | 190.810 → 7.213 |

Um único corante perdendo `valor_unitario` invalida centenas de milhares de fórmulas **de uma vez** — e a Fase 5 removeu o fallback. A causa-raiz é observável em 14 linhas: **214ms**, contra 26s da varredura por chave. Daí o `*/5`.

## Challenge Codex — REPROVOU o desenho inicial

`gpt-5.6-sol` (a 1ª tentativa em `xhigh` morreu no hard-stop de 20min; refeita em `high`). O que mudou:

- **[P0]** cadência diária deixaria a avalanche invisível por 24h → **`*/5`**.
- **[P1]** *"o P1-2 entra de graça" era **erro meu*** — classes com remediações distintas no mesmo `tipo` são silenciadas pelo `ON CONFLICT DO NOTHING`. Agora há **tipos separados**, e um 2º corante caindo com incidente aberto **atualiza o alerta e re-emite** o e-mail.
- **[P1]** sem `last_success_at`, ausência de alerta não é saúde ("verde por construção") → marcador em `sync_state` que **só avança em sucesso completo** + dead-man cruzado.
- **[P1]** o carimbo não é fundamento durável (delete/limpeza fariam o universo sumir ⇒ zero ⇒ "verde") → **este watchdog não depende dele**, e por isso cobre também chaves que nunca tiveram a `'1'`.
- **[P2]** política de agravamento → severidade escala com as fórmulas atingidas.

### Achado calibrado com medição própria

O Codex apontou que `receita_valida` não prova `precoFinal` (falta `base_disponivel`) — **procede**, confirmei na RPC. Mas medi **0 chaves com divergência de base entre as gêmeas** (compartilham o `sku_id`), logo a Fase 5 **não causou nem piorou** isso. Efeito colateral da medição: das 463.995 carimbadas, **296.536 (64%) já tinham base indisponível** e não vendiam antes da Fase 5 — **a exposição real do P1-7 são 167.459 chaves**. Incluir base no *gatilho* geraria 296.536 alertas no dia 1 sobre condição pré-existente.

## Por que fora do `_data_health_compute`

Restrição **dura**, não preferência: `authenticated` tem `statement_timeout=8s` e o dashboard `/health` chama `get_data_health()` → o compute (`useDataHealth.ts:21`). SECURITY DEFINER troca privilégio, **não** o timeout. Bônus: não toca o arquivo mais quente do repo (45k chars, 5 reversões por cascata).

## Prova

`db/test-tint-watchdog-corante.sh` — PG17, **migration REAL**, `exit=0`:

```
baseline: 11 ok / 0 falhas
FALSIF OK  F1 derrubou EXATAMENTE [A2 A3 A5 A6 A6b]
FALSIF OK  F2 derrubou EXATAMENTE [A1 A1b A6 A6b A7]
FALSIF OK  F3 derrubou EXATAMENTE [A6 A6b]
FALSIF OK  F4 derrubou EXATAMENTE [A4]
```

Cada falsificação **prova que aplicou** antes de medir (senão "não casou nada" se leria como "o assert não tem dente") e declara o **conjunto exato**. A F1 derrubou mais do que eu previra — a previsão é que estava errada (cascata lógica de uma sabotagem só), e ficou declarada como medida em vez de repintada de verde.

## ⚠️ Handoff — o que falta você fazer

Merge na `main` **não** aplica migration. Cole no **SQL Editor do Lovable**:

`supabase/migrations/20260727150000_tint_watchdog_corante_impagavel.sql`

Depois eu rodo a validação via `psql-ro` (está no rodapé do arquivo): função criada, cron `tint-watchdog-corante-5min` ativo, marcador gravado e **nascendo verde** (`corantes_ruins=0`).

## Fora deste PR (registrado no spec)

**PR 2** — Camada B (`tint_fase5_chave_sem_preco` + `tint_fase5_fonte_retirada` + vigia de cardinalidade, 6h). E, como decisão de produto: ledger de cobertura, modo degradado explícito, telemetria de tentativas de precificação sem preço, detecção de custo *aberrante* (valor positivo porém errado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
