### PR TITLE
fix(intelligence): 3 caminhos onde falha ainda virava zero na tela + cross-sell expõe stale [money-path]

### DIFF
--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -21,6 +21,21 @@ interface ScoreLinha {
   sales_history_status: string | null;
 }
 
+interface RecoLinha {
+  farmer_id: string;
+  status: string | null;
+}
+
+/**
+ * Único rótulo de aceitação que `farmer_recommendations.status` permite — o CHECK da tabela é
+ * ('pendente','ofertado','aceito','rejeitado','expirado'). O código comparava com `'aceita'`,
+ * valor que o banco REJEITA: o predicado nunca casava e a taxa era estruturalmente 0%, medisse
+ * o que medisse. Hoje as 3.659 linhas de prod são 100% `pendente` (nenhum writer registra
+ * desfecho desde que `markAsAccepted` saiu), então a correção é DEFESA DO FUTURO — mas é
+ * exatamente no dia em que o loop de feedback existir que a coluna passaria a mentir em silêncio.
+ */
+const STATUS_ACEITO = 'aceito';
+
 function IntelligenceManagerialTabImpl() {
   const { data: allScores, isLoading, isError } = useQuery({
     queryKey: ['intel-all-scores'],
@@ -63,13 +78,21 @@ function IntelligenceManagerialTabImpl() {
     return acc;
   }, {} as Record<string, string>);
 
-  const { data: recommendations } = useQuery({
+  const { data: recommendations, isError: recoErro } = useQuery({
     queryKey: ['intel-reco-adoption'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('farmer_recommendations').select('farmer_id, status').limit(500);
-      if (error) throw error;
-      return data || [];
-    },
+    // Base COMPLETA, paginada. Era `.limit(500)` de 3.659 linhas e SEM `.order()`: sem ORDER BY
+    // o Postgres não garante ordem, então a fatia de 13,7% mudava entre carregamentos — dois
+    // pedidos idênticos podiam render taxas de adoção diferentes, sem nada na tela indicando
+    // que o denominador era amostral. `id` é a PK: ordem estável para paginar.
+    queryFn: () =>
+      fetchAllPages<RecoLinha>((de, ate) =>
+        supabase
+          .from('farmer_recommendations')
+          .select('farmer_id, status')
+          .order('id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: RecoLinha[] | null; error: unknown }>,
+        'farmer_recommendations/intel-adocao',
+      ),
   });
 
   const farmerGroups = allScores?.reduce((acc, score) => {
@@ -82,9 +105,15 @@ function IntelligenceManagerialTabImpl() {
   const recoAdoption = recommendations?.reduce((acc, r) => {
     if (!acc[r.farmer_id]) acc[r.farmer_id] = { total: 0, accepted: 0 };
     acc[r.farmer_id].total++;
-    if (r.status === 'aceita') acc[r.farmer_id].accepted++;
+    if (r.status === STATUS_ACEITO) acc[r.farmer_id].accepted++;
     return acc;
   }, {} as Record<string, { total: number; accepted: number }>) || {};
+
+  // A falha desta query virava `recommendations === undefined` → adoção 0% para TODO vendedor.
+  // Num comparativo ENTRE vendedores, "não seguiu nenhuma recomendação" é uma acusação — e era
+  // fabricada por uma falha de transporte nossa.
+  const adocaoIndisponivel = recoErro && !recommendations;
+  const adocaoDesatualizada = recoErro && !!recommendations;
 
   const farmerMetrics = Object.entries(farmerGroups).map(([farmerId, clients]) => {
     const avgHealth = clients.reduce((a, c) => a + Number(c.health_score || 0), 0) / clients.length;
@@ -97,7 +126,20 @@ function IntelligenceManagerialTabImpl() {
     const cobertura = coberturaMargem(clients.map(c => c.gross_margin_pct));
     const avgCategories = clients.reduce((a, c) => a + Number(c.category_count || 0), 0) / clients.length;
     const adoption = recoAdoption[farmerId];
-    const adoptionPct = adoption && adoption.total > 0 ? (adoption.accepted / adoption.total * 100) : 0;
+    // `null` = taxa NÃO APURÁVEL → a coluna mostra "—". `!adoption` cobre as duas origens de
+    // ausência, ambas "ausente ≠ zero":
+    // (a) a leitura falhou — `recommendations` vira `undefined`, `recoAdoption` sai vazio e
+    //     TODO vendedor cai aqui; 0% afirmaria que ninguém seguiu sugestão alguma;
+    // (b) o vendedor não tem recomendação — sem denominador não existe taxa, e "0%" o puniria
+    //     no comparativo por um dado que não existe.
+    // Nada de `|| adoption.total === 0` nem de `adocaoIndisponivel ||` aqui: o primeiro é
+    // INALCANÇÁVEL (o objeto só nasce no `acc[...] = {total:0}` imediatamente seguido do
+    // `total++`, então existir implica `total >= 1`) e o segundo é uma segunda camada para o
+    // caso (a). Guard que não pode disparar não protege — só faz a falsificação passar verde e
+    // dar a impressão de cobertura que não existe (foi o que a sabotagem S4 revelou).
+    const adoptionPct = !adoption
+      ? null
+      : (adoption.accepted / adoption.total) * 100;
     return { farmerId, clientCount: clients.length, avgHealth, atRisk, avgMargin, cobertura, avgCategories, adoptionPct };
   });
 
@@ -134,6 +176,18 @@ function IntelligenceManagerialTabImpl() {
         <div role="alert" className="rounded-lg border border-status-warning/30 bg-status-warning/5 p-3 text-xs text-status-warning">
           Exibindo a última leitura bem-sucedida — a atualização mais recente falhou. Os números
           podem estar desatualizados.
+        </div>
+      )}
+      {adocaoIndisponivel && (
+        <div role="alert" className="rounded-lg border border-status-error/30 bg-status-error/5 p-3 text-xs text-status-error">
+          Adoção de recomendações indisponível — a base de recomendações não pôde ser lida. A
+          coluna fica em “—”; 0% seria afirmar que os vendedores não seguiram nenhuma sugestão.
+        </div>
+      )}
+      {adocaoDesatualizada && (
+        <div role="alert" className="rounded-lg border border-status-warning/30 bg-status-warning/5 p-3 text-xs text-status-warning">
+          Exibindo a última leitura bem-sucedida da adoção de recomendações — a atualização mais
+          recente falhou. A coluna “Adoção Reco” pode estar desatualizada.
         </div>
       )}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
@@ -186,7 +240,11 @@ function IntelligenceManagerialTabImpl() {
                         {(fm.avgCategories - globalAvgCategories).toFixed(1)}
                       </span>
                     </td>
-                    <td className="text-center py-2">{fm.adoptionPct.toFixed(0)}%</td>
+                    <td className="text-center py-2">
+                      {fm.adoptionPct == null
+                        ? <span className="text-muted-foreground">—</span>
+                        : `${fm.adoptionPct.toFixed(0)}%`}
+                    </td>
                   </tr>
                 ))}
                 {farmerMetrics.length === 0 && (

--- a/src/components/intelligence/IntelligenceStrategicTab.tsx
+++ b/src/components/intelligence/IntelligenceStrategicTab.tsx
@@ -23,16 +23,20 @@ interface ScoreLinha {
 }
 
 export function IntelligenceStrategicTab() {
-  const { data: marginAudit, isLoading } = useQuery({
+  const { data: marginAudit, isLoading: auditCarregando, isError: auditErro } = useQuery({
     queryKey: ['intel-margin-audit'],
+    // A falha era convertida em `[]` EXPLICITAMENTE (`console.error` + `return []`), e os quatro
+    // KPIs monetários abaixo somam sobre esse array: uma leitura que falhou virava "Margem Real
+    // R$ 0 · Gap R$ 0 · 0/0 clientes c/ custo". Zero de vazamento de preço é a leitura mais
+    // tranquilizadora possível — e era fabricada por uma falha de transporte nossa.
     queryFn: async () => {
       const { data, error } = await supabase.from('margin_audit_log').select('*').order('calculated_at', { ascending: false }).limit(100);
-      if (error) { console.error(error); return []; }
-      return data || [];
+      if (error) throw error;
+      return data ?? [];
     },
   });
 
-  const { data: allScores, isError: scoresErro } = useQuery({
+  const { data: allScores, isError: scoresErro, isLoading: scoresCarregando } = useQuery({
     queryKey: ['intel-strategic-scores'],
     // Base COMPLETA, paginada. Era `.limit(500)` de 6.632 e SEM `.order()` — o Postgres não
     // garante ordem sem ORDER BY, então as 500 eram um recorte não determinístico: dois
@@ -147,19 +151,34 @@ export function IntelligenceStrategicTab() {
     }
   };
 
-  if (isLoading) {
+  // O gate espera TODA fonte que a tela apresenta como número. Antes ele olhava só
+  // `margin_audit_log`: bastava a AUDITORIA resolver — com os scores ainda em voo — para a tela
+  // renderizar inteira, e LTV/CAC/Market Share saíam em zero. Um zero de "ainda não chegou" é
+  // indistinguível, na tela, de um zero medido. E "—" não serve nesta janela: "—" é o estado
+  // FINAL de indisponibilidade, e carregar não é indisponível — o honesto é seguir carregando.
+  if (auditCarregando || scoresCarregando) {
     return <div className="grid grid-cols-2 gap-3">{Array.from({ length: 6 }).map((_, i) => <Skeleton key={i} className="h-24" />)}</div>;
   }
 
-  // ⚠️ O `isLoading` acima é da query de `margin_audit_log` — OUTRA query. Os KPIs derivados de
-  // `allScores` (LTV, CAC, Concentração, Market Share, Margem Bruta) não olhavam o próprio
-  // estado de erro, então a tela renderizava INTEIRA como se estivesse tudo certo, com esses
-  // números em zero produzidos por uma falha de transporte. O #1545 fazer `fetchAllPages`
-  // lançar não bastou: a exceção vira `allScores === undefined` e os `|| 0` fabricam de novo.
-  // Nunca zero: "—" e o motivo. `retry` é global (App.tsx: 2 + backoff); aqui só o estado final.
+  // Os KPIs derivados de `allScores` (LTV, CAC, Concentração, Market Share, Margem Bruta) não
+  // olhavam o próprio estado de erro, então a tela renderizava INTEIRA como se estivesse tudo
+  // certo, com esses números em zero produzidos por uma falha de transporte. O #1545 fazer
+  // `fetchAllPages` lançar não bastou: a exceção vira `allScores === undefined` e os `|| 0`
+  // fabricam de novo. Nunca zero: "—" e o motivo. `retry` é global (App.tsx: 2 + backoff);
+  // aqui só o estado final.
   const scoresIndisponivel = scoresErro && !allScores;
   const scoresDesatualizados = scoresErro && !!allScores;
   const ou = (v: string) => (scoresIndisponivel ? '—' : v);
+
+  // Mesmo par para a auditoria de margem — as duas queries falham de forma independente, e a
+  // tela precisa dizer QUAL bloco não pôde ser lido (os KPIs de carteira e os de margem vêm de
+  // fontes distintas). Com cache: último dado bom + aviso de stale; sem cache: "—" e o motivo.
+  const auditoriaIndisponivel = auditErro && !marginAudit;
+  const auditoriaDesatualizada = auditErro && !!marginAudit;
+  const ouAudit = (v: string) => (auditoriaIndisponivel ? '—' : v);
+  const legendaAudit = auditoriaIndisponivel
+    ? 'auditoria indisponível'
+    : `parcial — ${auditComCusto}/${auditTotal} clientes c/ custo`;
 
   return (
     <div className="space-y-4">
@@ -175,6 +194,18 @@ export function IntelligenceStrategicTab() {
           falhou. Os indicadores de carteira podem estar desatualizados.
         </div>
       )}
+      {auditoriaIndisponivel && (
+        <div role="alert" className="rounded-lg border border-status-error/30 bg-status-error/5 p-3 text-xs text-status-error">
+          Auditoria de margem indisponível — o log do Algoritmo A não pôde ser lido. Margem Real,
+          Potencial, Gap e Margem Global ficam em “—”; nenhum valor foi somado.
+        </div>
+      )}
+      {auditoriaDesatualizada && (
+        <div role="alert" className="rounded-lg border border-status-warning/30 bg-status-warning/5 p-3 text-xs text-status-warning">
+          Exibindo a última leitura bem-sucedida da auditoria de margem — a atualização mais
+          recente falhou. Os valores do Algoritmo A podem estar desatualizados.
+        </div>
+      )}
       {/* Algoritmo A – Margin Gap */}
       <div className="rounded-lg border border-status-warning/30 bg-status-warning/5 p-3">
         <div className="flex items-center justify-between mb-3">
@@ -188,10 +219,12 @@ export function IntelligenceStrategicTab() {
           </Button>
         </div>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-          <KpiCard title="Margem Real" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle={`parcial — ${auditComCusto}/${auditTotal} clientes c/ custo`} />
-          <KpiCard title="Margem Potencial" value={`R$ ${totalMarginPotential.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingUp} subtitle={`parcial — ${auditComCusto}/${auditTotal} clientes c/ custo`} />
-          <KpiCard title="Gap de Margem" value={`R$ ${totalGap.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={TrendingDown} subtitle="vazamento de preço (todas as linhas)" />
-          <KpiCard title="Registros" value={String(marginAudit?.length || 0)} icon={Eye} />
+          <KpiCard title="Margem Real" value={ouAudit(`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`)} icon={DollarSign} subtitle={legendaAudit} />
+          <KpiCard title="Margem Potencial" value={ouAudit(`R$ ${totalMarginPotential.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`)} icon={TrendingUp} subtitle={legendaAudit} />
+          <KpiCard title="Gap de Margem" value={ouAudit(`R$ ${totalGap.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`)} icon={TrendingDown} subtitle={auditoriaIndisponivel ? 'auditoria indisponível' : 'vazamento de preço (todas as linhas)'} />
+          {/* "Registros: 0" afirmaria que a auditoria rodou e não achou nada — a mesma troca de
+              "não consegui ler" por "não existe" que os KPIs monetários ao lado fazem em R$. */}
+          <KpiCard title="Registros" value={ouAudit(String(marginAudit?.length ?? 0))} icon={Eye} />
         </div>
       </div>
 
@@ -212,7 +245,7 @@ export function IntelligenceStrategicTab() {
         <KpiCard title="Elasticidade de Preço" value={`${priceElasticity.toFixed(1)}%`} icon={TrendingUp} subtitle="Δ qty c/ desconto" />
         <KpiCard title="Sensibilidade a Desconto" value={`${discountSensitivity.toFixed(1)}%`} icon={Percent} subtitle={`${ordersWithDiscount} de ${salesOrders?.length || 0} pedidos`} />
         <KpiCard title="Market Share Est." value={ou(`${marketSharePct.toFixed(1)}%`)} icon={Target} subtitle={scoresIndisponivel ? 'base indisponível' : `${uniqueCustomers} de ~${estimatedMarket} clientes`} />
-        <KpiCard title="Margem Global" value={`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`} icon={DollarSign} subtitle={`parcial — ${auditComCusto}/${auditTotal} c/ custo`} />
+        <KpiCard title="Margem Global" value={ouAudit(`R$ ${totalMarginReal.toLocaleString('pt-BR', { minimumFractionDigits: 0 })}`)} icon={DollarSign} subtitle={auditoriaIndisponivel ? 'auditoria indisponível' : `parcial — ${auditComCusto}/${auditTotal} c/ custo`} />
       </div>
 
       {/* Margin Audit Table */}

--- a/src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx
+++ b/src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx
@@ -21,6 +21,16 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 type Resposta = { data: unknown; error: unknown };
 let falharScores = false;
 let scoresRevenueAusente = false;
+/** Scores em VOO (a promessa nunca resolve) — o estado que o gate do skeleton ignorava. */
+let scoresPendentes = false;
+let scoresGerencial = false;
+let falharAudit = false;
+let falharReco = false;
+let recoComDesfecho = false;
+
+/** Métodos do query-builder por chamada — discrimina `.limit(500)` solto de paginação ordenada. */
+type Chamada = { table: string; metodos: string[] };
+let chamadas: Chamada[] = [];
 
 const ERRO_PG = { message: 'canceling statement due to statement timeout', code: '57014' };
 
@@ -31,22 +41,49 @@ const SCORES_SEM_REVENUE = [
   { customer_user_id: 'c2', gross_margin_pct: null, avg_monthly_spend_180d: 2000, avg_repurchase_interval: 8, revenue_potential: null },
 ];
 
+// Dois clientes do MESMO vendedor: a tabela do gerencial precisa de ao menos uma linha para
+// que a coluna "Adoção Reco" exista e possa ser inspecionada.
+const SCORES_GERENCIAL = [
+  { customer_user_id: 'c1', farmer_id: 'f1', health_score: 70, health_class: 'estavel', gross_margin_pct: null, category_count: 3, sales_history_status: 'ok' },
+  { customer_user_id: 'c2', farmer_id: 'f1', health_score: 40, health_class: 'critico', gross_margin_pct: null, category_count: 1, sales_history_status: 'ok' },
+];
+
+// `aceito` é o único rótulo de aceitação que a tabela permite — o CHECK de
+// `farmer_recommendations.status` é ('pendente','ofertado','aceito','rejeitado','expirado').
+const RECO_COM_DESFECHO = [
+  { farmer_id: 'f1', status: 'aceito' },
+  { farmer_id: 'f1', status: 'pendente' },
+];
+
 function resposta(table: string): Resposta {
   if (table === 'farmer_client_scores') {
     if (falharScores) return { data: null, error: ERRO_PG };
     if (scoresRevenueAusente) return { data: SCORES_SEM_REVENUE, error: null };
+    if (scoresGerencial) return { data: SCORES_GERENCIAL, error: null };
     return { data: [], error: null };
+  }
+  if (table === 'margin_audit_log' && falharAudit) return { data: null, error: ERRO_PG };
+  if (table === 'farmer_recommendations') {
+    if (falharReco) return { data: null, error: ERRO_PG };
+    if (recoComDesfecho) return { data: RECO_COM_DESFECHO, error: null };
   }
   return { data: [], error: null };
 }
 
 function chain(table: string): unknown {
+  const registro: Chamada = { table, metodos: [] };
+  chamadas.push(registro);
   const c: Record<string, unknown> = {};
   for (const m of [
     'select', 'eq', 'neq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order',
     'limit', 'range', 'or', 'filter', 'contains', 'single', 'maybeSingle',
-  ]) c[m] = () => c;
-  c.then = (resolve: (v: unknown) => void) => resolve(resposta(table));
+  ]) c[m] = () => { registro.metodos.push(m); return c; };
+  c.then = (resolve: (v: unknown) => void) => {
+    // Promessa PENDENTE: nem resolve nem rejeita. É o estado "ainda em voo", distinto de
+    // erro — e o que o gate do skeleton do StrategicTab não enxergava.
+    if (table === 'farmer_client_scores' && scoresPendentes) return undefined;
+    return resolve(resposta(table));
+  };
   return c;
 }
 
@@ -57,6 +94,7 @@ vi.mock('@/integrations/supabase/client', () => ({
   },
 }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
 
 import { IntelligenceManagerialTab } from '../IntelligenceManagerialTab';
 import { IntelligenceStrategicTab } from '../IntelligenceStrategicTab';
@@ -65,10 +103,35 @@ import { IntelligenceStrategicTab } from '../IntelligenceStrategicTab';
 // interessa o ESTADO FINAL de erro, não a política de tentativa.
 const renderWithClient = (ui: ReactElement) => {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+  return { qc, ...render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>) };
 };
 
-beforeEach(() => { falharScores = true; scoresRevenueAusente = false; vi.clearAllMocks(); });
+/** Texto do card do KPI (o título e o valor são irmãos dentro do mesmo bloco). */
+const cardDo = (titulo: string): string => {
+  const el = screen.getByText(titulo);
+  return el.closest('div')?.parentElement?.textContent ?? '';
+};
+
+/**
+ * Skeletons na tela. A classe é `animate-shimmer` (o `<Skeleton>` do projeto usa shimmer
+ * gradient, não o pulse genérico do shadcn) — o assert original media `animate-pulse`, que
+ * NUNCA existe: passava sempre, inclusive sob skeleton eterno. Um detector que não enxerga o
+ * objeto vivo não distingue "não tem" de "está quebrado", então há um teste-DETECTOR abaixo
+ * provando que este seletor casa um skeleton de verdade.
+ */
+const skeletons = (c: HTMLElement) => c.querySelectorAll('[class*="animate-shimmer"]');
+
+beforeEach(() => {
+  falharScores = true;
+  scoresRevenueAusente = false;
+  scoresPendentes = false;
+  scoresGerencial = false;
+  falharAudit = false;
+  falharReco = false;
+  recoComDesfecho = false;
+  chamadas = [];
+  vi.clearAllMocks();
+});
 
 describe('IntelligenceManagerialTab — falha de carga não vira "0 clientes"', () => {
   it('anuncia indisponibilidade em vez de renderizar os KPIs zerados', async () => {
@@ -95,8 +158,19 @@ describe('IntelligenceManagerialTab — falha de carga não vira "0 clientes"', 
     await screen.findByRole('alert');
 
     await waitFor(() => {
-      expect(container.querySelectorAll('[class*="animate-pulse"]').length).toBe(0);
+      expect(skeletons(container).length).toBe(0);
     });
+  });
+
+  it('DETECTOR: o seletor de skeleton casa um skeleton vivo', async () => {
+    // Sem este par, o assert acima ("0 skeletons") passa mesmo com a tela travada em
+    // carregamento — foi o que aconteceu enquanto ele media `animate-pulse`, classe que o
+    // `<Skeleton>` deste projeto não usa.
+    scoresPendentes = true;
+
+    const { container } = renderWithClient(<IntelligenceManagerialTab />);
+
+    await waitFor(() => { expect(skeletons(container).length).toBeGreaterThan(0); });
   });
 });
 
@@ -143,5 +217,182 @@ describe('IntelligenceStrategicTab — Concentração sob revenue_potential órf
     expect(card?.textContent, 'Concentração exibiu 0,0% fabricado').toMatch(/—/);
     expect(card?.textContent, 'faltou o motivo "potencial não medido"').toMatch(/não medido/);
     expect(screen.queryByRole('alert'), 'não devia anunciar indisponibilidade: a leitura sucedeu').toBeNull();
+  });
+});
+
+/**
+ * Guard money-path — o gate do skeleton pertencia à query ERRADA (residual do #1550).
+ *
+ * O #1550 cobriu o estado de ERRO dos scores. Sobrou a JANELA anterior a ele: `isLoading` vinha
+ * de `margin_audit_log`, então bastava a auditoria resolver — os scores ainda em voo — para a
+ * tela renderizar INTEIRA, com LTV/CAC/Market Share em zero. É a mesma fabricação do caso de
+ * erro, num estado que nem erro é: "ainda não chegou" apresentado como "medi e deu zero".
+ *
+ * E "—" não serve aqui: "—" é o estado FINAL de indisponibilidade. Carregar não é indisponível,
+ * então o honesto é continuar carregando — o skeleton tem de esperar TODA fonte que a tela
+ * apresenta como número.
+ */
+describe('IntelligenceStrategicTab — base de scores em voo não vira KPI zerado', () => {
+  beforeEach(() => { falharScores = false; scoresPendentes = true; });
+
+  it('não renderiza os KPIs de carteira antes da base chegar', async () => {
+    const { qc, container } = renderWithClient(<IntelligenceStrategicTab />);
+
+    // Ponto de decisão: a auditoria RESOLVE (os scores não). É exatamente aqui que o
+    // `isLoading` da query errada virava false e a tela renderizava com os zeros.
+    await waitFor(() => {
+      expect(qc.getQueryState(['intel-margin-audit'])?.status, 'a auditoria nem resolveu').toBe('success');
+    });
+
+    expect(screen.queryByText('LTV Projetado (3a)'), 'KPI de carteira renderizou sem a base').toBeNull();
+    expect(screen.queryByText('Market Share Est.'), 'KPI de carteira renderizou sem a base').toBeNull();
+    expect(
+      skeletons(container).length,
+      'sem skeleton e sem KPI: a tela não está dizendo nada',
+    ).toBeGreaterThan(0);
+  });
+
+  it('DETECTOR: com a base resolvida os KPIs de carteira aparecem', async () => {
+    // Prova que o seletor do assert acima ENXERGA o objeto vivo — sem isto, "não renderizou o
+    // KPI" e "o seletor está quebrado" seriam indistinguíveis.
+    scoresPendentes = false;
+
+    renderWithClient(<IntelligenceStrategicTab />);
+
+    expect(await screen.findByText('LTV Projetado (3a)')).toBeTruthy();
+    expect(await screen.findByText('Market Share Est.')).toBeTruthy();
+  });
+});
+
+/**
+ * Guard money-path — a falha da auditoria de margem virava `[]` EXPLICITAMENTE.
+ *
+ * A queryFn fazia `if (error) { console.error(error); return []; }` — falha convertida em "não
+ * há registro". Os quatro KPIs monetários do bloco do Algoritmo A somam sobre esse array, então
+ * uma leitura que falhou era apresentada como "Margem Real R$ 0 · Gap R$ 0 · 0/0 clientes com
+ * custo". Zero de vazamento de preço é a leitura mais tranquilizadora possível — e era fabricada.
+ *
+ * Mesmo tratamento que o #1550 deu aos scores: falha → último dado bom + aviso de stale; sem
+ * cache → "—" com o motivo.
+ */
+describe('IntelligenceStrategicTab — falha da auditoria de margem não vira R$ 0', () => {
+  beforeEach(() => { falharScores = false; falharAudit = true; });
+
+  it('anuncia a indisponibilidade da auditoria', async () => {
+    renderWithClient(<IntelligenceStrategicTab />);
+
+    const avisos = await screen.findAllByRole('alert');
+    expect(
+      avisos.some((a) => /auditoria/i.test(a.textContent ?? '')),
+      'nenhum alerta menciona a auditoria de margem',
+    ).toBe(true);
+  });
+
+  it('Margem Real, Potencial, Gap e Margem Global mostram "—", não R$ 0', async () => {
+    renderWithClient(<IntelligenceStrategicTab />);
+    await screen.findAllByRole('alert');
+
+    for (const titulo of ['Margem Real', 'Margem Potencial', 'Gap de Margem', 'Margem Global']) {
+      const texto = cardDo(titulo);
+      expect(texto, `KPI "${titulo}" exibiu R$ 0 fabricado`).not.toMatch(/R\$\s*0\b/);
+      expect(texto, `KPI "${titulo}" devia mostrar "—"`).toMatch(/—/);
+    }
+  });
+
+  it('o contador de Registros não afirma "0" sob falha', async () => {
+    renderWithClient(<IntelligenceStrategicTab />);
+    await screen.findAllByRole('alert');
+
+    // "Registros: 0" afirma que a auditoria rodou e não achou nada.
+    expect(cardDo('Registros'), 'Registros exibiu 0 fabricado').toMatch(/—/);
+  });
+
+  it('DETECTOR: com a auditoria lida os KPIs monetários aparecem sem alerta', async () => {
+    falharAudit = false;
+
+    renderWithClient(<IntelligenceStrategicTab />);
+
+    await screen.findByText('Margem Real');
+    expect(
+      screen.queryAllByRole('alert').some((a) => /auditoria/i.test(a.textContent ?? '')),
+      'alertou auditoria indisponível com a leitura OK',
+    ).toBe(false);
+  });
+});
+
+/**
+ * Guard money-path — adoção de recomendações: falha virava 0%, e o recorte era não-determinístico.
+ *
+ * Dois defeitos na mesma query:
+ *  (a) a falha caía em `recommendations === undefined` → `adoptionPct = 0` → a coluna "Adoção
+ *      Reco" afirmava que o vendedor não seguiu NENHUMA recomendação. Num comparativo ENTRE
+ *      vendedores, isso é uma acusação fabricada por uma falha de transporte nossa.
+ *  (b) `.limit(500)` SEM `.order()` sobre 3.659 linhas: o Postgres não garante ordem sem ORDER
+ *      BY, então a fatia de 13,7% mudava entre carregamentos — dois pedidos idênticos podiam
+ *      render taxas diferentes, sem nada na tela indicando que o denominador era amostral.
+ */
+describe('IntelligenceManagerialTab — adoção de recomendações honesta', () => {
+  beforeEach(() => { falharScores = false; scoresGerencial = true; });
+
+  it('lê farmer_recommendations paginado e com ordem estável, sem recorte de 500', async () => {
+    renderWithClient(<IntelligenceManagerialTab />);
+    await screen.findByText('Comparativo por Vendedor');
+
+    const reco = chamadas.filter((c) => c.table === 'farmer_recommendations');
+    expect(reco.length, 'a query de recomendações nem foi disparada').toBeGreaterThan(0);
+    for (const c of reco) {
+      expect(c.metodos, 'sem .order() a paginação repete e pula linha entre páginas').toContain('order');
+      expect(c.metodos, 'sem .range() a leitura para na capa de 1.000 do PostgREST').toContain('range');
+      expect(c.metodos, '.limit() recorta a base — eram 500 de 3.659 linhas').not.toContain('limit');
+    }
+  });
+
+  it('a coluna "Adoção Reco" mostra "—", não 0%, quando a leitura falha', async () => {
+    falharReco = true;
+
+    renderWithClient(<IntelligenceManagerialTab />);
+    await screen.findByText('Comparativo por Vendedor');
+
+    const linha = screen.getByText(/^f1/).closest('tr');
+    expect(linha, 'a linha do vendedor sumiu da tabela').toBeTruthy();
+    expect(linha!.textContent, 'adoção exibiu 0% fabricado sob falha de leitura').not.toMatch(/0%/);
+    expect(linha!.textContent, 'adoção devia mostrar "—"').toMatch(/—/);
+  });
+
+  it('anuncia a indisponibilidade da adoção', async () => {
+    falharReco = true;
+
+    renderWithClient(<IntelligenceManagerialTab />);
+
+    const avisos = await screen.findAllByRole('alert');
+    expect(
+      avisos.some((a) => /ado(ç|c)(ã|a)o/i.test(a.textContent ?? '')),
+      'nenhum alerta menciona a adoção de recomendações',
+    ).toBe(true);
+  });
+
+  it('sem NENHUMA recomendação o vendedor mostra "—", não 0% (0/0 não é taxa)', async () => {
+    // Leitura OK e vazia: não há o que adotar. "0%" afirmaria "ignorou tudo que sugerimos".
+    renderWithClient(<IntelligenceManagerialTab />);
+    await screen.findByText('Comparativo por Vendedor');
+
+    const linha = screen.getByText(/^f1/).closest('tr');
+    expect(linha!.textContent, 'denominador zero virou taxa 0%').not.toMatch(/0%/);
+    expect(linha!.textContent, 'adoção devia mostrar "—"').toMatch(/—/);
+  });
+
+  it('conta o desfecho "aceito" — o único rótulo que o CHECK da tabela permite', async () => {
+    // O código comparava `status === 'aceita'`, valor que o CHECK de farmer_recommendations
+    // REJEITA ('pendente','ofertado','aceito','rejeitado','expirado'). O predicado nunca casava:
+    // a taxa era estruturalmente 0%, medisse o que medisse. Hoje as 3.659 linhas de prod são
+    // 100% `pendente` (nenhum writer registra desfecho), então a defesa é do FUTURO — mas é o
+    // dia em que o loop de feedback existir que a coluna passaria a mentir em silêncio.
+    recoComDesfecho = true;
+
+    renderWithClient(<IntelligenceManagerialTab />);
+    await screen.findByText('Comparativo por Vendedor');
+
+    const linha = screen.getByText(/^f1/).closest('tr');
+    expect(linha!.textContent, '1 aceito de 2 recomendações = 50%').toMatch(/50%/);
   });
 });

--- a/src/hooks/__tests__/cross-sell-escopo-sob-falha.test.tsx
+++ b/src/hooks/__tests__/cross-sell-escopo-sob-falha.test.tsx
@@ -32,8 +32,49 @@ const FARMER = 'farmer-real';
 type Q = { table: string; eq: Array<[string, unknown]> };
 let queries: Q[] = [];
 let falharScores = false;
+/** Semeia o caminho FELIZ inteiro — só assim dá para provar o estado "resultado anterior". */
+let semeado = false;
 
 const ERRO_TIMEOUT = { code: '57014', message: 'canceling statement due to statement timeout' };
+
+// Seed mínimo que produz UMA recomendação de cross-sell (p2, puxado pela regra de associação
+// p1→p2). p1 foi comprado e tem margem 40% — acima do corte de up-sell (0,35), então o cenário
+// exercita só o ramo de cross-sell, que é o que interessa aqui.
+const SCORES = [{
+  customer_user_id: 'c1', farmer_id: FARMER,
+  health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50,
+}];
+const PRODUTOS = [
+  { id: 'p1', codigo: 'P1', descricao: 'Produto Um', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 10 },
+  { id: 'p2', codigo: 'P2', descricao: 'Produto Dois', valor_unitario: 200, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 5 },
+];
+const CUSTOS = [
+  { product_id: 'p1', cost_final: 60, cost_price: null },
+  { product_id: 'p2', cost_final: 100, cost_price: null },
+];
+const PEDIDOS = [{
+  customer_user_id: 'c1', total: 200, created_at: '2026-07-01T00:00:00Z',
+  items: [{ product_id: 'p1', quantity: 2, unit_price: 100 }],
+}];
+const REGRAS = [{
+  antecedent_product_ids: ['p1'], consequent_product_ids: ['p2'],
+  confidence: 0.5, lift: 2, support: 0.1,
+}];
+const PERFIS = [{ user_id: 'c1', name: 'Cliente Um', customer_type: 'pj', cnae: null }];
+
+function resposta(table: string): unknown {
+  if (table === 'farmer_client_scores') {
+    if (falharScores) return { data: null, error: ERRO_TIMEOUT };
+    return { data: semeado ? SCORES : [], error: null, count: 0 };
+  }
+  if (!semeado) return { data: [], error: null, count: 0 };
+  if (table === 'omie_products') return { data: PRODUTOS, error: null };
+  if (table === 'product_costs') return { data: CUSTOS, error: null };
+  if (table === 'sales_orders') return { data: PEDIDOS, error: null };
+  if (table === 'farmer_association_rules') return { data: REGRAS, error: null };
+  if (table === 'profiles') return { data: PERFIS, error: null };
+  return { data: [], error: null, count: 0 };
+}
 
 function chain(table: string): unknown {
   const q: Q = { table, eq: [] };
@@ -45,12 +86,7 @@ function chain(table: string): unknown {
     'upsert', 'insert', 'update', 'delete',
   ]) c[m] = () => c;
   c.eq = (col: string, val: unknown) => { q.eq.push([col, val]); return c; };
-  c.then = (resolve: (v: unknown) => void) => {
-    if (q.table === 'farmer_client_scores' && falharScores) {
-      return resolve({ data: null, error: ERRO_TIMEOUT });
-    }
-    return resolve({ data: [], error: null, count: 0 });
-  };
+  c.then = (resolve: (v: unknown) => void) => resolve(resposta(q.table));
   return c;
 }
 
@@ -64,7 +100,7 @@ vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() })
 
 import { useCrossSellEngine } from '../useCrossSellEngine';
 
-beforeEach(() => { queries = []; falharScores = true; vi.clearAllMocks(); });
+beforeEach(() => { queries = []; falharScores = true; semeado = false; vi.clearAllMocks(); });
 
 /** Queries a farmer_client_scores que NÃO filtram por farmer_id = leitura da base inteira. */
 const scoresSemFiltroDeFarmer = () =>
@@ -87,5 +123,79 @@ describe('useCrossSellEngine — página que falha não vira "sem carteira, deve
       (q) => q.table === 'farmer_client_scores' && q.eq.some(([c, v]) => c === 'farmer_id' && v === FARMER),
     );
     expect(comFiltro.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Guard money-path — a falha era ENGOLIDA no `catch`: só `console.error`, nada no contrato.
+ *
+ * Residual do #1545/#1550. O `fetchAllPages` passou a lançar, mas o engine captura a exceção e
+ * segue: `recommendations` mantém o resultado do ÚLTIMO cálculo bem-sucedido, `loading` e
+ * `calculating` voltam a false, e a tela fica idêntica a um recálculo que deu certo. O vendedor
+ * clica "Recalcular", vê a lista se acomodar, e continua olhando números velhos achando que são
+ * novos — enquanto o motivo (uma página perdida) só existe no console do navegador.
+ *
+ * Contrato: o hook EXPÕE a falha (`erro`) e diz se o que está na mão veio de uma execução
+ * ANTERIOR (`desatualizado`). Sem isso a tela não tem como ser honesta — e a correção do
+ * money-path só termina na tela.
+ */
+describe('useCrossSellEngine — a falha do cálculo aparece no contrato do hook', () => {
+  it('DETECTOR: o caminho feliz produz recomendação (senão os asserts abaixo medem o vazio)', async () => {
+    falharScores = false;
+    semeado = true;
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    expect(result.current.recommendations.length, 'o seed parou de gerar recomendação').toBe(1);
+    expect(result.current.recommendations[0].crossSell.length).toBeGreaterThan(0);
+  });
+
+  it('expõe o erro quando a leitura falha, em vez de só escrever no console', async () => {
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    expect(result.current.erro, 'a falha não chegou ao contrato do hook').toBeTruthy();
+    expect(result.current.calculating, 'ficou preso em "calculando"').toBe(false);
+  });
+
+  it('marca DESATUALIZADO quando mantém o resultado de um cálculo anterior', async () => {
+    falharScores = false;
+    semeado = true;
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+    expect(result.current.recommendations).toHaveLength(1);
+
+    // Recálculo que perde uma página: o resultado ANTERIOR continua na tela.
+    falharScores = true;
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    expect(result.current.recommendations, 'o último dado bom foi descartado').toHaveLength(1);
+    expect(result.current.erro, 'a falha não chegou ao contrato').toBeTruthy();
+    expect(result.current.desatualizado, 'não sinalizou que a lista é de um cálculo anterior').toBe(true);
+  });
+
+  it('sem resultado anterior a falha NÃO é "desatualizado" — é indisponível', async () => {
+    // Discriminador: "velho" e "inexistente" pedem textos diferentes na tela. Marcar
+    // desatualizado sem nada na mão faria a tela prometer um dado que não existe.
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    expect(result.current.recommendations).toHaveLength(0);
+    expect(result.current.erro).toBeTruthy();
+    expect(result.current.desatualizado).toBe(false);
+  });
+
+  it('o recálculo bem-sucedido limpa erro e desatualizado', async () => {
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+    expect(result.current.erro).toBeTruthy();
+
+    falharScores = false;
+    semeado = true;
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    expect(result.current.erro, 'o erro anterior ficou grudado após o sucesso').toBeNull();
+    expect(result.current.desatualizado).toBe(false);
+    expect(result.current.recommendations).toHaveLength(1);
   });
 });

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { custoCanonico, margemUnitaria } from '@/lib/custo/custoCanonico';
@@ -119,11 +119,32 @@ export const useCrossSellEngine = () => {
   const [recommendations, setRecommendations] = useState<CustomerRecommendations[]>([]);
   const [loading, setLoading] = useState(false);
   const [calculating, setCalculating] = useState(false);
+  // A falha era ENGOLIDA: o `catch` só fazia `console.error` e o estado voltava a "pronto", com
+  // `recommendations` mantendo o resultado do ÚLTIMO cálculo bem-sucedido. A tela ficava
+  // idêntica a um recálculo que deu certo — o vendedor clicava "Recalcular", via a lista se
+  // acomodar, e seguia decidindo sobre números velhos. Sem isto no contrato, nenhum consumidor
+  // *podia* ser honesto: a correção do money-path só termina na tela.
+  const [erro, setErro] = useState<Error | null>(null);
+  const [desatualizado, setDesatualizado] = useState(false);
+  // Espelha `recommendations` para o `catch` ler o valor ATUAL. Ler o state aqui devolveria o
+  // do render em que o callback foi criado (`recommendations` não está nas deps do useCallback).
+  const recomendacoesRef = useRef<CustomerRecommendations[]>([]);
+
+  const aplicarRecomendacoes = useCallback((recs: CustomerRecommendations[]) => {
+    recomendacoesRef.current = recs;
+    setRecommendations(recs);
+  }, []);
 
   const calculateRecommendations = useCallback(async () => {
     if (!effectiveUserId) return;
     setCalculating(true);
     setLoading(true);
+    setErro(null);
+    setDesatualizado(false);
+    // Discrimina "a falha veio ANTES de produzir resultado" (a tela segue com o cálculo
+    // anterior = desatualizada) de "veio DEPOIS" (falha ao persistir: os números na tela são
+    // desta execução, e chamá-los de desatualizados mentiria na direção oposta).
+    let resultadoDestaExecucao = false;
 
     try {
       // 1. Load client scores with pagination. Era um loop MANUAL com o mesmo defeito que o
@@ -155,7 +176,8 @@ export const useCrossSellEngine = () => {
       }
 
       if (!clientScores?.length) {
-        setRecommendations([]);
+        aplicarRecomendacoes([]);
+        resultadoDestaExecucao = true;
         return;
       }
 
@@ -214,7 +236,8 @@ export const useCrossSellEngine = () => {
       const customerIds = activeClientScores.map((c) => c.customer_user_id);
 
       if (!customerIds.length) {
-        setRecommendations([]);
+        aplicarRecomendacoes([]);
+        resultadoDestaExecucao = true;
         return;
       }
 
@@ -468,7 +491,8 @@ export const useCrossSellEngine = () => {
         return totalB - totalA;
       });
 
-      setRecommendations(allRecs);
+      aplicarRecomendacoes(allRecs);
+      resultadoDestaExecucao = true;
 
       // Persist recommendations (batch upsert único — antes era N×M serial)
       const recRows = allRecs.flatMap((cr) =>
@@ -494,11 +518,16 @@ export const useCrossSellEngine = () => {
       }
     } catch (error) {
       console.error('Error calculating recommendations:', error);
+      setErro(error instanceof Error ? error : new Error(String(error)));
+      // Só é "desatualizado" se a tela está exibindo o resultado de uma execução ANTERIOR.
+      // Sem nada na mão o estado é indisponível — textos diferentes, e prometer um dado que
+      // não existe seria trocar uma mentira por outra.
+      setDesatualizado(!resultadoDestaExecucao && recomendacoesRef.current.length > 0);
     } finally {
       setCalculating(false);
       setLoading(false);
     }
-  }, [effectiveUserId, isImpersonating]);
+  }, [effectiveUserId, isImpersonating, aplicarRecomendacoes]);
 
   // ─── Actions ─────────────────────────────────────────────────────────
   // `markAsOffered` / `markAsAccepted` / `markAsRejected` e o `updateConversionStats`
@@ -514,5 +543,9 @@ export const useCrossSellEngine = () => {
     loading,
     calculating,
     calculateRecommendations,
+    /** Falha da ÚLTIMA execução (`null` = correu bem). O consumidor decide o que exibir. */
+    erro,
+    /** `true` = o que está em `recommendations` veio de uma execução ANTERIOR à que falhou. */
+    desatualizado,
   };
 };

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -292,6 +292,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/tactical-plan-posse-dono.test.tsx",
       "src/hooks/__tests__/useLastVisit.test.tsx",
       "src/hooks/__tests__/useDashboardCompany.test.ts",
+      "src/pages/__tests__/FarmerRecommendations.erro-honesto.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },

--- a/src/pages/FarmerRecommendations.tsx
+++ b/src/pages/FarmerRecommendations.tsx
@@ -29,7 +29,7 @@ const FarmerRecommendations = () => {
   const navigate = useNavigate();
   const { isStaff, loading: authLoading } = useAuth();
   const {
-    recommendations, loading, calculating, calculateRecommendations,
+    recommendations, loading, calculating, calculateRecommendations, erro, desatualizado,
   } = useCrossSellEngine();
   const [expandedClient, setExpandedClient] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -50,6 +50,12 @@ const FarmerRecommendations = () => {
     s + [...cr.crossSell, ...cr.upSell].reduce((s2, r) => s2 + r.lie, 0), 0);
   const totalCrossSell = recommendations.reduce((s, cr) => s + cr.crossSell.length, 0);
   const totalUpSell = recommendations.reduce((s, cr) => s + cr.upSell.length, 0);
+
+  // O cálculo falhou e não sobrou nada de uma execução anterior: os três KPIs somariam sobre a
+  // lista vazia e diriam "EIP Total R$ 0,00 · 0 Cross-sell · 0 Up-sell" — a falha de transporte
+  // apresentada como "não há oportunidade nenhuma na carteira". Nunca zero: "—" e o motivo.
+  const semDado = !!erro && recommendations.length === 0;
+  const ou = (v: string) => (semDado ? '—' : v);
 
   const filtered = recommendations.filter(cr => {
     if (searchQuery) {
@@ -76,21 +82,38 @@ const FarmerRecommendations = () => {
         </Button>
       </div>
 
+      {/* A falha do engine chega aqui: sem isto a tela fica idêntica a um recálculo que deu
+          certo — o vendedor vê a lista se acomodar e segue decidindo sobre números velhos. */}
+      {erro && (
+        <div
+          role="alert"
+          className={`rounded-lg border p-3 text-xs ${desatualizado
+            ? 'border-status-warning/30 bg-status-warning/5 text-status-warning'
+            : 'border-status-error/30 bg-status-error/5 text-status-error'}`}
+        >
+          {desatualizado
+            ? 'Exibindo o último cálculo bem-sucedido — a atualização mais recente falhou. As recomendações podem estar desatualizadas.'
+            : recommendations.length > 0
+              ? 'As recomendações foram calculadas, mas não puderam ser salvas. Os números abaixo são desta execução.'
+              : 'Não foi possível calcular as recomendações — a leitura da base falhou. Nenhum número abaixo foi estimado.'}
+        </div>
+      )}
+
       {/* Summary KPIs */}
       <div className="grid grid-cols-3 gap-3">
         <Card><CardContent className="p-3 text-center">
           <DollarSign className="w-4 h-4 mx-auto mb-1 text-primary" />
-          <p className="text-lg font-bold text-primary">{fmt(totalLIE)}</p>
+          <p className="text-lg font-bold text-primary">{ou(fmt(totalLIE))}</p>
           <p className="text-[10px] text-muted-foreground">EIP Total (estimativa)</p>
         </CardContent></Card>
         <Card><CardContent className="p-3 text-center">
           <ShoppingCart className="w-4 h-4 mx-auto mb-1 text-status-info" />
-          <p className="text-lg font-bold">{totalCrossSell}</p>
+          <p className="text-lg font-bold">{ou(String(totalCrossSell))}</p>
           <p className="text-[10px] text-muted-foreground">Cross-sell</p>
         </CardContent></Card>
         <Card><CardContent className="p-3 text-center">
           <ArrowUpRight className="w-4 h-4 mx-auto mb-1 text-status-purple" />
-          <p className="text-lg font-bold">{totalUpSell}</p>
+          <p className="text-lg font-bold">{ou(String(totalUpSell))}</p>
           <p className="text-[10px] text-muted-foreground">Up-sell</p>
         </CardContent></Card>
       </div>
@@ -130,7 +153,11 @@ const FarmerRecommendations = () => {
         <Card><CardContent className="py-12 text-center">
           <Target className="w-8 h-8 mx-auto mb-3 text-muted-foreground/40" />
           <p className="text-sm text-muted-foreground">
-            Nenhuma recomendação disponível. Calcule os scores dos clientes primeiro.
+            {/* Sob falha, "nenhuma recomendação disponível" afirma "não existe" onde a verdade
+                é "não consegui ler" — e ainda manda recalcular um cálculo que acabou de falhar. */}
+            {semDado
+              ? 'Não foi possível carregar as recomendações. Tente recalcular em instantes.'
+              : 'Nenhuma recomendação disponível. Calcule os scores dos clientes primeiro.'}
           </p>
         </CardContent></Card>
       ) : (

--- a/src/pages/__tests__/FarmerRecommendations.erro-honesto.test.tsx
+++ b/src/pages/__tests__/FarmerRecommendations.erro-honesto.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Guard money-path — a falha do engine tem de CHEGAR À TELA.
+ *
+ * O `useCrossSellEngine` passou a expor `erro`/`desatualizado` (antes a exceção morria num
+ * `console.error`). Isso é metade: consertar o hook não conserta a tela. Esta página tem dois
+ * lugares onde uma falha vira afirmação sobre o negócio:
+ *
+ *  - os três KPIs do topo somam sobre `recommendations` → "EIP Total R$ 0,00", "0 Cross-sell";
+ *  - o empty state diz "Nenhuma recomendação disponível. Calcule os scores primeiro" — que
+ *    manda o vendedor recalcular um cálculo que JÁ rodou e falhou, e afirma "não existe" onde
+ *    a verdade é "não consegui ler".
+ *
+ * E o caso mais silencioso: com resultado de um cálculo ANTERIOR na mão, a tela fica idêntica a
+ * um recálculo bem-sucedido. Contrato: sob falha a tela diz o que aconteceu — e distingue
+ * "indisponível" (nada na mão) de "desatualizado" (o que está aí é de antes).
+ *
+ * Aqui o hook roda de VERDADE (só o supabase é mockado): é a cadeia leitura→engine→tela que
+ * precisa ser honesta, e mockar o hook provaria apenas que a página sabe renderizar um estado
+ * que eu mesmo montei.
+ */
+const FARMER = 'farmer-real';
+
+let falharScores = false;
+
+const ERRO_TIMEOUT = { code: '57014', message: 'canceling statement due to statement timeout' };
+
+// Mesmo seed mínimo de `cross-sell-escopo-sob-falha.test.tsx`: produz UMA recomendação de
+// cross-sell (p2, puxada pela regra de associação p1→p2).
+const SCORES = [{
+  customer_user_id: 'c1', farmer_id: FARMER,
+  health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50,
+}];
+const PRODUTOS = [
+  { id: 'p1', codigo: 'P1', descricao: 'Produto Um', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 10 },
+  { id: 'p2', codigo: 'P2', descricao: 'Produto Dois', valor_unitario: 200, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 5 },
+];
+const CUSTOS = [
+  { product_id: 'p1', cost_final: 60, cost_price: null },
+  { product_id: 'p2', cost_final: 100, cost_price: null },
+];
+const PEDIDOS = [{
+  customer_user_id: 'c1', total: 200, created_at: '2026-07-01T00:00:00Z',
+  items: [{ product_id: 'p1', quantity: 2, unit_price: 100 }],
+}];
+const REGRAS = [{
+  antecedent_product_ids: ['p1'], consequent_product_ids: ['p2'],
+  confidence: 0.5, lift: 2, support: 0.1,
+}];
+const PERFIS = [{ user_id: 'c1', name: 'Cliente Um', customer_type: 'pj', cnae: null }];
+
+function resposta(table: string): unknown {
+  if (table === 'farmer_client_scores') {
+    if (falharScores) return { data: null, error: ERRO_TIMEOUT };
+    return { data: SCORES, error: null };
+  }
+  if (table === 'omie_products') return { data: PRODUTOS, error: null };
+  if (table === 'product_costs') return { data: CUSTOS, error: null };
+  if (table === 'sales_orders') return { data: PEDIDOS, error: null };
+  if (table === 'farmer_association_rules') return { data: REGRAS, error: null };
+  if (table === 'profiles') return { data: PERFIS, error: null };
+  return { data: [], error: null, count: 0 };
+}
+
+function chain(table: string): unknown {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'eq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) c[m] = () => c;
+  c.then = (resolve: (v: unknown) => void) => resolve(resposta(table));
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: { from: (t: string) => chain(t) } }));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: FARMER }, isStaff: true, loading: false }),
+}));
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import FarmerRecommendations from '../FarmerRecommendations';
+
+beforeEach(() => { falharScores = false; vi.clearAllMocks(); });
+
+/** Texto do card do KPI de topo (o rótulo e o valor são irmãos no mesmo bloco). */
+const cardDo = (rotulo: string): string =>
+  screen.getByText(rotulo).closest('div')?.parentElement?.textContent ?? '';
+
+describe('FarmerRecommendations — falha do engine não vira "nenhuma recomendação"', () => {
+  it('DETECTOR: o caminho feliz renderiza a recomendação e nenhum alerta', async () => {
+    // Sem isto, "não achei o alerta" e "a tela nem chegou a montar" seriam indistinguíveis.
+    render(<FarmerRecommendations />);
+
+    expect(await screen.findByText('Cliente Um')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('anuncia que NÃO CONSEGUIU calcular, em vez de "nenhuma recomendação disponível"', async () => {
+    falharScores = true;
+
+    render(<FarmerRecommendations />);
+
+    const aviso = await screen.findByRole('alert');
+    expect(aviso.textContent, 'o alerta não diz que a leitura falhou').toMatch(/não foi possível|indispon/i);
+    // O empty state de sucesso manda "calcular os scores primeiro" — sob falha isso é um
+    // conselho errado sobre um estado que não é o real.
+    expect(
+      screen.queryByText(/Nenhuma recomendação disponível/i),
+      'afirmou "não existe" onde a verdade é "não consegui ler"',
+    ).toBeNull();
+  });
+
+  it('os KPIs do topo mostram "—", não R$ 0,00 / 0, quando o cálculo falhou sem dado', async () => {
+    falharScores = true;
+
+    render(<FarmerRecommendations />);
+    await screen.findByRole('alert');
+
+    for (const rotulo of ['EIP Total (estimativa)', 'Cross-sell', 'Up-sell']) {
+      const texto = cardDo(rotulo);
+      expect(texto, `KPI "${rotulo}" exibiu zero fabricado`).not.toMatch(/R\$\s*0,00|\b0\b/);
+      expect(texto, `KPI "${rotulo}" devia mostrar "—"`).toMatch(/—/);
+    }
+  });
+
+  it('avisa que a lista é de um cálculo ANTERIOR quando o recálculo falha', async () => {
+    render(<FarmerRecommendations />);
+    await screen.findByText('Cliente Um');
+
+    // Recálculo que perde uma página: hoje a lista se acomoda igualzinho a um sucesso.
+    falharScores = true;
+    fireEvent.click(screen.getByRole('button', { name: /Recalcular/i }));
+
+    const aviso = await screen.findByRole('alert');
+    expect(aviso.textContent, 'nada avisa que os números são de antes').toMatch(/desatualiz|anterior/i);
+    // O último dado bom continua na tela — descartá-lo trocaria uma mentira por outra.
+    await waitFor(() => { expect(screen.getByText('Cliente Um')).toBeTruthy(); });
+  });
+});


### PR DESCRIPTION
Residuais achados pelo **Codex (gpt-5.6-sol, xhigh)** na revisão do #1550. Aquele PR corrigiu o estado de **erro** das queries de scores nos dois tabs; sobraram três caminhos onde uma falha de transporte continuava virando número na tela, mais um engine que engolia a exceção. Todos violam *"ausente ≠ zero"* (`docs/agent/money-path.md` §2/§7).

## Os quatro consertos

**1. `IntelligenceStrategicTab` — o gate do skeleton pertencia à query ERRADA.** `isLoading` vinha de `margin_audit_log`: bastava a **auditoria** resolver, com os scores ainda em voo, para a tela renderizar inteira com LTV/CAC/Market Share em zero. Um zero de *"ainda não chegou"* é indistinguível, na tela, de um zero medido. `"—"` não serve nessa janela — é o estado **final** de indisponibilidade, e carregar não é indisponível —, então o gate passou a esperar as **duas** fontes.

**2. `IntelligenceStrategicTab` — a falha da auditoria virava `[]` explicitamente.** A queryFn fazia `console.error(error); return []`, e os quatro KPIs monetários somam sobre esse array: *"Margem Real R$ 0 · Gap R$ 0 · 0/0 clientes c/ custo"*. Zero de vazamento de preço é a leitura mais tranquilizadora possível — e era fabricada. Agora lança, com o mesmo par que o #1550 deu aos scores: último dado bom + aviso de stale; sem cache → `"—"` e o motivo.

**3. `IntelligenceManagerialTab` — adoção de recomendações.** A falha virava **0% para todo vendedor**; num comparativo *entre* vendedores isso é uma acusação fabricada por transporte nosso. E o `.limit(500)` **sem `.order()`** sobre 3.659 linhas tornava a fatia de 13,7% não-determinística — dois carregamentos podiam render taxas diferentes, sem nada na tela indicando que o denominador era amostral. Agora `fetchAllPages` com `.order('id')` (PK) e taxa `null` → `"—"`.

**4. `useCrossSellEngine` — o `catch` só fazia `console.error`.** Depois de um cálculo bom, um recálculo que perde página mantinha as recomendações **antigas** e a tela ficava idêntica a um sucesso. O hook passa a expor `erro` e `desatualizado`, e a `FarmerRecommendations` os apresenta — distinguindo *indisponível* (nada na mão), *desatualizado* (o que está aí é de antes) e *calculado mas não salvo*. A correção do money-path só termina na tela (§7).

## Dois achados de medição — ambos "o predicado nunca casa"

- **`status === 'aceita'`** era comparado contra um valor que o **CHECK da tabela rejeita** (`'pendente','ofertado','aceito','rejeitado','expirado'`): a taxa de adoção era **estruturalmente 0%**, medisse o que medisse. Corrigido para `'aceito'`. Prod hoje é 100% `pendente` (3.659/3.659, conferido via `psql-ro`), então é **defesa do futuro** — declarada como tal, conforme §2.
- **O assert "não fica em skeleton eterno" herdado do #1550 é inerte**: media `animate-pulse`, classe que o `<Skeleton>` deste projeto não usa (é `animate-shimmer`). Passava sempre, inclusive sob skeleton eterno. Corrigido, com teste-**DETECTOR** provando que o seletor enxerga um skeleton vivo.

## Método (`money-path.md`)

| Etapa | Evidência |
|---|---|
| Baseline | árvore **provada limpa** no instante da execução — 5.679 testes, `exit 0` |
| RED | **16 vermelhos**, conferidos por **contagem e nomes**; 4 testes-DETECTOR verdes |
| GREEN | 34/34 focado; suíte completa 5.719, `exit 0` |
| Falsificação | **12 sabotagens**, denominador **fixo em 29** nas 13 rodadas, **12/12** com vermelho no alvo certo |

Cada sabotagem **prova que aplicou** (exatamente 1 ocorrência trocada + `grep` do texto sabotado) *antes* de rodar, e o alvo é ancorado em trecho **ASCII** do nome do teste — `grep -F` é literal e os nomes têm acento. Os quatro DETECTORES existem porque *"não achei"* e *"o seletor está quebrado"* são indistinguíveis sem eles (foi exatamente o que deixou o assert do #1550 inerte por um PR inteiro).

**A sabotagem S4 voltou VERDE na 1ª rodada e revelou um guard MORTO:** `adoption.total === 0` é inalcançável por construção — o objeto só nasce no `{total:0}` seguido *imediatamente* do `total++`, então existir implica `total >= 1`. Removido: guard que não pode disparar não protege, só simula cobertura. Mesma razão para não empilhar `adocaoIndisponivel ||` ali — `!adoption` já cobre o caso da falha, e duas camadas fazendo o mesmo escondem qual vale (§6).

## Gates

`typecheck` 0 · `lint` 0 errors · `test` **5.719 / 629 arquivos, exit 0** (suíte **completa** — o `fronteiras.gate` só acusa vazamento de módulo assim). `knip` acusa só dívida pré-existente em `supabase/functions/`, e não é gate do CI.

Sem mudança de banco, edge ou dependência → **só Publish do frontend** para ir ao ar.

### Follow-ups (não neste PR)
- O teste da página nasceu mockando `useCrossSellEngine` e o `fronteiras.gate` acusou aresta nova `farmer-inteligencia→vendas`. Em vez de gravar dívida na baseline, foi reescrito como **integração real** (supabase mockado → hook real → tela) — prova mais forte e zero dívida.
- Esta é a 4ª instância da mesma classe (`|| 0` sobre leitura que falhou) e a 2ª de "paginação sem `.order()`". **Não existe gate estrutural** para nenhuma das duas: o `mutcheck` cobre só helpers financeiros nomeados e o `no-restricted-syntax` do ESLint só o `.or()`. Candidato natural à skill `matar-classe` (#1576).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ Colisão multi-sessão com o #1520 (draft) — ler antes de rebasear

O #1520 (*"custo sai do browser sem virar oráculo"*, **draft**, último push 22/07) reescreve profundamente os mesmos dois arquivos: troca `lie`/`mij` por `affinityScore`, tira `product_costs` do browser em favor da RPC `get_skus_margem_positiva()`, e substitui os KPIs desta página. Este PR é **independente** (trata estado de falha, não fórmula de score), mas os dois se cruzam em três pontos. Quem rebasear por último precisa preservar:

**1. `useCrossSellEngine` — o early-return fail-closed do #1520 é um caminho de FALHA sem sinal.** O #1520 adiciona:

```ts
if (erroVendaveis || !skusVendaveis) {
  console.error('get_skus_margem_positiva falhou — sem recomendação (fail-closed):', erroVendaveis);
  setRecommendations([]);   // ← some sem setErro: a tela dirá "nenhuma recomendação"
  return;
}
```

Fail-closed no *cálculo* está certo (produto de prejuízo no topo é o pior desfecho). Mas `setRecommendations([])` sem `setErro` reintroduz exatamente a classe que este PR fecha, **num caminho novo**: a RPC falhou e a tela afirma *"não há oportunidade"*. Após o merge deve virar `setErro(...)` + `aplicarRecomendacoes([])`, para cair no alerta *"Não foi possível calcular"* em vez do empty state.

**2. `FarmerRecommendations` — conflito textual no bloco dos KPIs.** O #1520 remove `fmt`/`totalLIE` e troca o primeiro card por *"Clientes com oferta"*. Este PR envolveu os três valores em `ou()` e inseriu o `role="alert"` logo acima. Ao resolver: os rótulos são do #1520, o `ou()` e o alerta são deste. `semDado` continua valendo qualquer que seja o KPI — o que ele protege é *"exibir número quando o cálculo falhou"*, não o número em si.

**3. `manifesto.ts` — conflito trivial.** Ambos acrescentam entradas em `testes`; a resolução é manter as três linhas.

Não estou marcando este PR como draft: ele está verde e é independente, e o #1520 já está segurado de propósito. Se a ordem preferida for a inversa, basta convertê-lo em draft.
