### PR TITLE
docs(skills): rotear as 4 skills órfãs (farmer-industrial, reposicao-caixa, goal, triagem-3-modelos)

### DIFF
--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -8,6 +8,7 @@
 |---|---|---|
 | Revisar diff antes de mergear | **`/review`** (gstack) — SQL safety, trust boundary LLM, side effects condicionais | redundantes: `engineering:code-review`, superpowers review |
 | Revisão de segurança | **`/security-review`** (oficial) | complementa `/review` — rode os dois em PR sensível |
+| 3 vozes independentes sobre decisão de RISCO (PR crítico money-path/authz, tradeoff de arquitetura não-óbvio) | `triagem-3-modelos` (proprietária, global) — Claude (produto) + Codex (engenharia) + Gemini (triagem ampla) preenchem contrato JSON; decisão sai de REGRAS determinísticas, não de voto | degrau ACIMA do ritual `/codex`; NÃO p/ review simples (use `/review` ou `/codex`) |
 | SAST profundo | `semgrep` (JS/TS rápido) / `codeql` (interprocedural) + `sarif-parsing` | análise estática real (≠ heurístico) |
 | Auditar supply chain | `supply-chain-risk-auditor` (Trail of Bits) | |
 | Debugar bug/falha | **`/investigate`** (gstack) — root-cause, 4 fases | `engineering:debug`/`systematic-debugging` (escolha 1) |
@@ -19,6 +20,8 @@
 | Mudança de banco sob Lovable | **`lovable-db-operator`** — migration + bloco SQL Editor + validação + audit | design com `supabase`, entrega com este |
 | BI executivo / número de negócio via Lovable (brief da semana, vendas/estoque/inadimplência/margem) | **`bi-colacor`** (proprietária) — SQL read-only versionado p/ colar no Lovable→SQL Editor → interpreta → decisão; conhece as 4 grafias de empresa + confiabilidade do dado | leitura (≠ `lovable-db-operator`, que escreve); não `data:*`/`finance:*` (text-to-SQL sem nosso schema). Fechamento profundo (NCG/DRE-regime/tributário/contador) → `cfo-colacor` |
 | Ritual de fechamento financeiro mensal / controladoria (NCG, DRE caixa-vs-competência, carga tributária por regime, projeção 13 semanas, perguntas pro contador) | **`cfo-colacor`** (proprietária) — SQL read-only p/ Lovable, ritual de 9 levas + relatório mensal + perguntas pro contador; **NÃO** apura imposto nem substitui contador | sobrepõe `bi-colacor` em inadimplência/caixa: número rápido/brief semanal → `bi-colacor`; fechamento profundo → esta. **Schema financeiro canônico mora na `bi-colacor`** (esta referencia, não duplica) |
+| Plano de ação SEMANAL da carteira de um vendedor televendas (rota/cidade/dia, clientes em queda, mix ausente, cross-sell por ramo) | `farmer-industrial` (proprietária) — plano acionável do vendedor a partir da carteira existente | ≠ `bi-colacor` (número pontual/brief); esta produz o PLANO do Farmer |
+| Decidir SE/QUANTO/QUANDO comprar de fornecedor ponderando o CAIXA da Oben (comprar agora × segurar × parcelar × antecipar × priorizar A/B/C) | `reposicao-caixa` (proprietária) — memorando de decisão de compra | ≠ motor de reposição do app (quantidade técnica); ≠ `cfo-colacor` (fechamento) — esta decide a COMPRA à luz do capital de giro |
 | Otimizar query/schema PG | `supabase-postgres-best-practices` | |
 | Provar SQL money-path | **`prove-sql-money-path`** (PG17 falsificável) | |
 | Diagnosticar sync/cron | **`diagnose-supabase-sync`** (8 passos + queries `psql-ro`) | |
@@ -34,6 +37,7 @@
 | Corrigiu bug que é INSTÂNCIA de padrão repetível ("Nº laço", fix quase idêntico a anterior, série no git log) | **`matar-classe`** (proprietária) — passo 0 do PR de bugfix (instância ou classe?); assinatura grepável → varredura do repo INTEIRO → erradicação → gate estrutural falsificado → registro | nasce do catálogo de retrabalho 2026-07 (paginação: ~20 PRs da MESMA classe). Fix pontual pode sair 1º; varredura+gate na MESMA sessão ou chip com dono |
 | Fechar sessão ("posso excluir?") | **`/fecho`** (proprietária) — PRs×CI, migrations×psql-ro, edges/Publish, chips, wt:status | veredito por EVIDÊNCIA, não memória |
 | Continuar em sessão nova / split no 2º compact | **`/handoff-sessao`** (proprietária) — briefing determinístico, 1 entrega = 1 sessão | não usar `/context-restore` (pode pegar save de OUTRA sessão) |
+| Objetivo multi-sessão ("continua o goal", "retoma o épico", entrega que atravessa várias sessões/PRs) | `goal` (proprietária) | complementa `/handoff-sessao` (contexto) e `/fecho` (encerramento); entrega de sessão única → roadmap no chat, sem goal |
 | Ingerir CSV de base pública BR (RAIS/CNO/Receita/CNPJ) com DuckDB | receituário **`docs/agent/csv-governo-br.md`** | encoding CP1252/latin-1 + `delim=';'` + `quote=''` + `parallel=false` + `all_varchar` |
 
 - ⚠️ **Colisão de nome:** `/review` (gstack, **canônico**) vs `review` (oficial code-review) — invocar via gstack.


### PR DESCRIPTION
## O quê

P1-1 do relatório de otimização de retrabalho (2026-07-23): o inventário achou 4 skills fora do roteamento canônico — existiam e disparavam só pela própria description, sem rota deliberada nem diferenciação das vizinhas.

Entram na tabela do `skills.md`, nos encaixes temáticos:

- **`triagem-3-modelos`** — junto do bloco de review; nota explícita: degrau ACIMA do `/codex`, NÃO para review simples (sobreposição não-gerida apontada no inventário).
- **`farmer-industrial`** — junto de `bi-colacor`, diferenciada (plano semanal do vendedor ≠ número pontual).
- **`reposicao-caixa`** — diferenciada do motor de reposição do app (quantidade técnica) e do `cfo-colacor` (fechamento): esta decide a COMPRA à luz do caixa.
- **`goal`** — junto de `/fecho`/`/handoff-sessao`, com a fronteira (entrega de sessão única → roadmap no chat).

**Rotear ≠ aposentar**: a eventual aposentadoria de `farmer-industrial`/`reposicao-caixa` é decisão de produto do founder — este PR só tira as 4 do limbo.

Doc-only, sem código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)