### PR TITLE
fix(types): restaura RPC farmer_association_rules_substituir removida pelo bot — destrava o Publish

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -18438,6 +18438,10 @@ export type Database = {
             Args: { p_item_id: number; p_threshold_similaridade?: number }
             Returns: Json
           }
+      farmer_association_rules_substituir: {
+        Args: { p_regras: Json }
+        Returns: number
+      }
       fin_analise_cp_dimensoes_rpc: {
         Args: { p_ano?: number; p_company?: string; p_mes?: number }
         Returns: {


### PR DESCRIPTION
**Instância única ou classe?** → instância da classe JÁ documentada "sync bidirecional do Lovable reverte a main" (CLAUDE.md; #1445→#1478) — o gate dela é o lovable-watch (#1573) + esta restauração por PR.

O bot regenerou o types.ts a partir do banco SEM a RPC `farmer_association_rules_substituir` (a migration do #1574 ainda não foi aplicada — `to_regprocedure` = AUSENTE via psql-ro), e o `useBundleEngine` que a chama parou de compilar → **Build unsuccessful** no Publish.

Restauração verbatim das 4 linhas do diff de b49be4c5. A migration pendente é handoff separado ao founder (pré-condição de RUNTIME, não deste compile fix).

Typecheck local na fila do heavy (6 worktrees de chips ativas); gate autoritativo = CI `validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)