### PR TITLE
docs(skills): rotear frontend-design no roteamento canônico — e marcar a colisão com o DS v3

### DIFF
--- a/docs/agent/skills.md
+++ b/docs/agent/skills.md
@@ -29,6 +29,7 @@
 | Perf React | `vercel-react-best-practices` | |
 | Refatorar god-component | `vercel-composition-patterns` | |
 | UI/acessibilidade WCAG | `vercel-web-design-guidelines` | |
+| Superfície NOVA fora do app (landing, protótipo, artefato visual, peça de marketing) | `frontend-design` (oficial) — direção estética autoral: tipografia/paleta/motion/layout próprios | ⚠️ **NÃO** usar em tela do app: a skill manda escolher fonte e paleta próprias, layout assimétrico e "grid-breaking" — e o DS v3 é FIXO (tokens `src/index.css`, Geist/Newsreader, radius 6px, `--status-*`, densidade alta). Dentro do app → `vercel-web-design-guidelines` + `docs/visual-direction/` |
 | Optimistic UI / React Query | `tanstack-query` | receitas `onMutate`/rollback |
 | RBAC / personas→roles | `access-control-rbac` | |
 | QA da app rodando | `/qa` (report+fix) / `/qa-only` (report) — gstack | |


### PR DESCRIPTION
## O que

Uma linha na tabela de roteamento de `docs/agent/skills.md`, roteando a skill `frontend-design`.

## Por quê

O founder pediu "instale Context 7, superpowers e frontend design". Verificação do estado real:

| Item | Estado | Evidência |
|---|---|---|
| Context7 | ✅ instalado, ativo, **funcionando** | plugin `context7@claude-plugins-official` habilitado; smoke test `resolve-library-id` "TanStack Query" retornou 5 libs |
| superpowers | ✅ instalado v6.1.1 | 14 skills no cache do plugin |
| frontend-design | ✅ instalada, ❌ **não roteada** | `~/.claude/skills/frontend-design/SKILL.md` (manual, 13/mai) — ausente da tabela |

Os três já estavam instalados: **não havia nada a instalar**. A lacuna era de roteamento — e o topo do próprio doc manda "atualizar esta tabela ao instalar/remover skill".

## A nota de fronteira é o ponto

`frontend-design` não é uma skill neutra pra este repo. Ela instrui explicitamente:

- "Choose fonts that are beautiful, unique... **Avoid generic fonts like Arial and Inter**"
- "**Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements**"
- "commit to a **BOLD** aesthetic direction"

Isso é o oposto do DS v3 do repo, cujos tokens em `src/index.css` são fixos (paleta quase-neutra low-fatigue, Geist/Newsreader, radius 6px, `--status-*`, `density-compact`). Aplicá-la numa tela do app quebraria o sistema em vez de melhorá-lo.

Roteada, então, para **superfície NOVA fora do app** (landing, protótipo, artefato visual). Dentro do app segue `vercel-web-design-guidelines` + `docs/visual-direction/`.

## Risco

Nenhum — doc only, 1 linha adicionada. Sem colisão: último toque em `skills.md` na main é o #1582 (já mergeado), nenhum PR aberto mexe no arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)