### PR TITLE
feat(reposicao): extração de promoção sai do gateway Lovable para a Anthropic direto [money-path]

### DIFF
--- a/src/components/reposicao/aumentos/UploadDialog.tsx
+++ b/src/components/reposicao/aumentos/UploadDialog.tsx
@@ -1,4 +1,4 @@
-// Modal de upload/extração de anúncio de aumento (PDF/imagem → Gemini Vision).
+// Modal de upload/extração de anúncio de aumento (PDF/imagem → extração por IA).
 // Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split).
 import { Loader2, FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";

--- a/src/components/reposicao/aumentos/useAumentos.ts
+++ b/src/components/reposicao/aumentos/useAumentos.ts
@@ -1,7 +1,7 @@
 // Hook de dados/estado dos aumentos anunciados.
 // Extraído verbatim de src/pages/AdminReposicaoAumentos.tsx (god-component split):
 // 2 queries (fornecedores + aumentos com agregação de itens), memos de agrupamento
-// por mês e handlers do upload/extração via Gemini Vision.
+// por mês e handlers do upload/extração via IA (vision).
 import { useState, useRef, useMemo, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
@@ -147,7 +147,7 @@ export function useAumentos() {
       const arquivo_tipo =
         arquivo.type === "application/pdf" ? "pdf" : arquivo.type;
 
-      toast.info("Extraindo dados via Gemini Vision…");
+      toast.info("Extraindo dados do documento…");
 
       const { data, error } = await supabase.functions.invoke(
         "promocao-extrair-via-vision",

--- a/src/components/reposicao/promocoes/UploadDialog.tsx
+++ b/src/components/reposicao/promocoes/UploadDialog.tsx
@@ -106,7 +106,7 @@ export function UploadDialog({
                         </TooltipTrigger>
                         <TooltipContent>
                           {it.confianca !== null && it.confianca !== undefined
-                            ? `Confiança Gemini: ${Math.round(it.confianca * 100)}%`
+                            ? `Confiança da extração: ${Math.round(it.confianca * 100)}%`
                             : "Confiança não informada"}
                         </TooltipContent>
                       </Tooltip>

--- a/supabase/functions/promocao-extrair-via-vision/index.ts
+++ b/supabase/functions/promocao-extrair-via-vision/index.ts
@@ -1,24 +1,42 @@
 // Edge Function: promocao-extrair-via-vision
 // Recebe PDF ou imagem de promoção de fornecedor OU de aviso de aumento de preços,
-// extrai estrutura via Lovable AI Gateway (Gemini Pro Vision),
+// extrai estrutura via Anthropic (claude-sonnet-4-6, vision + forced tool-use),
 // grava campanha (promoção) ou registra aumento (RPC) conforme tipo_documento.
+//
+// Migrada do gateway Lovable/Gemini (LOVABLE_API_KEY) para a Anthropic direto:
+// o gateway tem teto próprio de créditos ("AI features usage limit") que derruba
+// a extração de promoção quando estoura. Contrato de request/response inalterado.
 //
 // Body:
 // {
 //   empresa: string,
 //   fornecedor_nome: string,
 //   arquivo_base64: string,
-//   arquivo_tipo: 'pdf'|'image/jpeg'|'image/png',
+//   arquivo_tipo: 'pdf'|'image/jpeg'|'image/png'|'image/webp'|'image/gif',
 //   tipo_documento?: 'campanha_sayerlack' | 'aumento',  // default 'campanha_sayerlack'
 //   origem_email?: { remetente?: string, assunto?: string, data?: string },
 //   criado_por?: string
 // }
 //
-// Modo: best-effort. Sempre grava algo, mesmo quando incerto.
-// Campos com baixa confiança são flagados em extracao_observacoes.
+// Modo: best-effort. Sempre grava algo, mesmo quando incerto — campos de baixa
+// confiança são flagados em extracao_observacoes para revisão humana.
+// EXCEÇÃO money-path: resposta truncada (stop_reason=max_tokens) NÃO grava —
+// lista parcial de descontos gravada como completa é pior que não gravar.
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+// ⚠️ usar npm: (igual a kb-extract-specs/tarefa-extrair-voz/etc.). O esm.sh/@supabase/supabase-js
+// falhava em resolver no boot do edge runtime → RUNTIME_ERROR sem linha/stack.
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@^2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import {
+  anotarRejeicoes,
+  type BlocoAnexo,
+  dataValida,
+  montarBlocoAnexo,
+  normalizarCategoriasAumento,
+  normalizarConfianca,
+  normalizarItensPromo,
+} from "./vision-helpers.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -26,40 +44,74 @@ const corsHeaders = {
     "authorization, x-client-info, apikey, content-type",
 };
 
-const LOVABLE_AI_URL = "https://ai.gateway.lovable.dev/v1/chat/completions";
-const VISION_MODEL = "google/gemini-2.5-pro";
+const MODELO = "claude-sonnet-4-6";
+const MAX_TOKENS = 8000;
 
-// Prompt de extração — calibrado para promoções Sayerlack no padrão DES
-const EXTRACTION_PROMPT = `Você está analisando uma imagem ou PDF de promoção de produtos do fornecedor Sayerlack (programa DES - Distribuidores Exclusivos).
+// ============= PROMOÇÃO =============
+const SYSTEM_PROMOCAO =
+  `Você analisa imagens e PDFs de promoções de produtos do fornecedor Sayerlack (programa DES — Distribuidores Exclusivos) e extrai a estrutura da campanha.
 
-Extraia as informações estruturadas da promoção e retorne APENAS JSON válido, sem markdown, sem explicação, sem wrapper de código. O JSON deve seguir exatamente este schema:
+REGRAS
+1. "1ª quinzena" → data_inicio = dia 1, data_fim = dia 15 do mês de referência.
+2. "2ª quinzena" → data_inicio = dia 16, data_fim = último dia do mês.
+3. "mês de X" → dia 1 ao último dia desse mês.
+4. Códigos de produto seguem padrões como DR.XXXX, FL.XXXX.XX, YL.XXXX.NTR, YLO4.XXXX.XX — copie EXATAMENTE como aparecem (caixa, pontos, números). Não normalize, não corrija.
+5. Ano não explícito → use o ano corrente.
+6. Campo que você não conseguir ler: omita o item ou use null, e explique em observacoes. NUNCA chute um percentual de desconto — desconto errado vira preço errado.
+7. confianca < 0.7 quando houver ambiguidade relevante.
 
-{
-  "nome": "string - nome descritivo da campanha (ex: 'DES Promo Abril 2ª Quinzena 2026')",
-  "data_inicio": "YYYY-MM-DD",
-  "data_fim": "YYYY-MM-DD",
-  "fornecedor_nome": "string - nome do fornecedor se identificável",
-  "items": [
-    {
-      "codigo_fornecedor": "string - código do produto (ex: 'DR.4403', 'FL.6269.02')",
-      "descricao": "string ou null - descrição se visível",
-      "desconto_perc": "number - percentual de desconto (ex: 20 para 20%)",
-      "volume_minimo": "number ou null - quantidade mínima se houver condição de volume, senão null"
-    }
-  ],
-  "confianca": "number entre 0 e 1 - seu nível de confiança geral na extração",
-  "observacoes": "string - qualquer observação relevante, ambiguidade, texto não identificado, etc."
-}
+Use SEMPRE a tool registrar_promocao. Não responda em texto fora dela.`;
 
-REGRAS IMPORTANTES:
-1. Se a promoção menciona "1ª quinzena", data_inicio = dia 1 e data_fim = dia 15 do mês referência
-2. Se "2ª quinzena", data_inicio = dia 16 e data_fim = último dia do mês
-3. Se mencionar apenas "mês de X", considerar dia 1 ao último dia desse mês
-4. Códigos de produto seguem padrões como DR.XXXX, FL.XXXX.XX, YL.XXXX.NTR, YLO4.XXXX.XX — mantenha EXATAMENTE como aparecem (case, pontos, números)
-5. Se o ano não estiver claro, use o ano atual
-6. Se não conseguir identificar algum campo obrigatório, use null e anote em observacoes
-7. Ajuste confianca para baixo (< 0.7) se houver ambiguidade significativa
-8. Retorne APENAS o JSON, nada mais`;
+const TOOL_PROMOCAO = {
+  name: "registrar_promocao",
+  description:
+    "Registra a campanha promocional extraída do documento do fornecedor.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      nome: {
+        type: "string",
+        description:
+          "Nome descritivo da campanha (ex: 'DES Promo Abril 2ª Quinzena 2026')",
+      },
+      data_inicio: { type: "string", description: "YYYY-MM-DD" },
+      data_fim: { type: "string", description: "YYYY-MM-DD" },
+      fornecedor_nome: {
+        type: ["string", "null"],
+        description: "Nome do fornecedor como aparece no documento",
+      },
+      items: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            codigo_fornecedor: {
+              type: "string",
+              description: "Código do produto, verbatim (ex: 'DR.4403')",
+            },
+            descricao: { type: ["string", "null"] },
+            desconto_perc: {
+              type: "number",
+              description:
+                "Percentual de desconto (20 para 20%). Omita o item inteiro se não conseguir ler com certeza.",
+            },
+            volume_minimo: {
+              type: ["number", "null"],
+              description: "Quantidade mínima, se houver condição de volume",
+            },
+          },
+          required: ["codigo_fornecedor", "desconto_perc"],
+        },
+      },
+      confianca: { type: "number", minimum: 0, maximum: 1 },
+      observacoes: {
+        type: "string",
+        description: "Ambiguidades, texto ilegível, itens omitidos e por quê",
+      },
+    },
+    required: ["nome", "data_inicio", "data_fim", "items", "confianca", "observacoes"],
+  },
+};
 
 interface ExtractedPromo {
   nome: string;
@@ -77,26 +129,50 @@ interface ExtractedPromo {
 }
 
 // ============= AUMENTO =============
-const AUMENTO_PROMPT = `Este documento anuncia reajustes de preços do fornecedor Renner Sayerlack. Extraia:
-- Nome do anúncio / assunto
-- Data em que o novo preço começa a valer (data_vigencia, formato YYYY-MM-DD)
-- Data em que o anúncio foi feito (data_anuncio, se houver)
-- Lista de categorias afetadas, com nome exato como no documento e percentual de aumento
-- Se alguma categoria tem data de vigência específica diferente do geral, registre-a
-- Confiança na extração (0-1)
-- Observações sobre ambiguidades ou dados faltantes
+const SYSTEM_AUMENTO =
+  `Você analisa documentos que anunciam reajustes de preço do fornecedor Renner Sayerlack e extrai a estrutura do aumento.
 
-Retorne APENAS JSON no formato exato:
-{
-  "nome": "...",
-  "data_vigencia": "YYYY-MM-DD",
-  "data_anuncio": "YYYY-MM-DD ou null",
-  "categorias": [
-    { "categoria_fornecedor": "...", "aumento_perc": 5.0, "data_vigencia_especifica": null }
-  ],
-  "confianca": 0.95,
-  "observacoes": "..."
-}`;
+REGRAS
+1. data_vigencia é quando o NOVO preço passa a valer; data_anuncio é quando o comunicado foi emitido.
+2. Nome da categoria: copie EXATAMENTE como aparece no documento.
+3. Categoria com vigência própria diferente da geral → preencha data_vigencia_especifica.
+4. Percentual que você não conseguir ler com certeza: omita a categoria e explique em observacoes. NUNCA chute — aumento errado vira preço errado.
+5. confianca < 0.7 quando houver ambiguidade relevante.
+
+Use SEMPRE a tool registrar_aumento. Não responda em texto fora dela.`;
+
+const TOOL_AUMENTO = {
+  name: "registrar_aumento",
+  description:
+    "Registra o reajuste de preços extraído do comunicado do fornecedor.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      nome: { type: "string", description: "Nome/assunto do comunicado" },
+      data_vigencia: { type: "string", description: "YYYY-MM-DD" },
+      data_anuncio: { type: ["string", "null"], description: "YYYY-MM-DD ou null" },
+      categorias: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            categoria_fornecedor: { type: "string" },
+            aumento_perc: {
+              type: "number",
+              description:
+                "Percentual de aumento (5 para 5%). Omita a categoria se não conseguir ler com certeza.",
+            },
+            data_vigencia_especifica: { type: ["string", "null"] },
+          },
+          required: ["categoria_fornecedor", "aumento_perc"],
+        },
+      },
+      confianca: { type: "number", minimum: 0, maximum: 1 },
+      observacoes: { type: "string" },
+    },
+    required: ["nome", "data_vigencia", "categorias", "confianca", "observacoes"],
+  },
+};
 
 interface ExtractedAumento {
   nome: string;
@@ -116,7 +192,7 @@ interface ExtractedAumento {
 // para o nome canônico (razão social) usado no resto do sistema.
 // Fallback hardcoded para Sayerlack/Renner caso a tabela esteja indisponível.
 async function normalizarFornecedor(
-  supabase: ReturnType<typeof createClient>,
+  supabase: SupabaseClient,
   extraido: string | null | undefined,
   _tipoDocumento: string,
 ): Promise<string> {
@@ -125,19 +201,22 @@ async function normalizarFornecedor(
 
   // 1) tenta match exato (case-insensitive) na tabela
   try {
-    const { data: exact } = await supabase
+    // `fornecedor_mapeamento_extracao` não está nos tipos gerados do Supabase;
+    // sem a anotação o supabase-js infere `never` e o acesso ao campo não checa.
+    const { data: exact } = (await supabase
       .from("fornecedor_mapeamento_extracao")
       .select("nome_canonico")
       .eq("ativo", true)
       .ilike("alias_extraido", normalizado)
-      .maybeSingle();
+      .maybeSingle()) as { data: { nome_canonico: string } | null };
     if (exact?.nome_canonico) return exact.nome_canonico;
 
     // 2) tenta match por substring — pega o alias mais longo que esteja contido no extraído
     const { data: aliases } = await supabase
       .from("fornecedor_mapeamento_extracao")
       .select("alias_extraido, nome_canonico")
-      .eq("ativo", true);
+      .eq("ativo", true)
+      .returns<Array<{ alias_extraido: string | null; nome_canonico: string }>>();
 
     if (Array.isArray(aliases) && aliases.length > 0) {
       const ordenados = [...aliases].sort(
@@ -167,7 +246,7 @@ async function normalizarFornecedor(
   return extraido?.trim() || "DESCONHECIDO";
 }
 
-function fallbackExtraction(reason: string, rawText = ""): ExtractedPromo {
+function fallbackExtraction(reason: string): ExtractedPromo {
   const today = new Date().toISOString().slice(0, 10);
   return {
     nome: `Promoção não identificada — ${today}`,
@@ -176,13 +255,11 @@ function fallbackExtraction(reason: string, rawText = ""): ExtractedPromo {
     fornecedor_nome: "DESCONHECIDO",
     items: [],
     confianca: 0,
-    observacoes:
-      `${reason}` +
-      (rawText ? ` Resposta bruta: ${rawText.slice(0, 500)}` : ""),
+    observacoes: reason,
   };
 }
 
-function fallbackAumento(reason: string, rawText = ""): ExtractedAumento {
+function fallbackAumento(reason: string): ExtractedAumento {
   const today = new Date().toISOString().slice(0, 10);
   return {
     nome: `Aumento não identificado — ${today}`,
@@ -190,115 +267,144 @@ function fallbackAumento(reason: string, rawText = ""): ExtractedAumento {
     data_anuncio: null,
     categorias: [],
     confianca: 0,
-    observacoes:
-      `${reason}` +
-      (rawText ? ` Resposta bruta: ${rawText.slice(0, 500)}` : ""),
+    observacoes: reason,
   };
 }
 
-async function callVisionRaw(
-  fileBase64: string,
-  fileType: string,
-  prompt: string,
-): Promise<string> {
-  const apiKey = Deno.env.get("LOVABLE_API_KEY");
-  if (!apiKey) throw new Error("LOVABLE_API_KEY não configurada");
+/** Erro de truncamento — a extração veio parcial e NÃO pode ser gravada. */
+class ExtracaoTruncada extends Error {}
 
-  // Normaliza media_type: pdf, image/jpeg, image/png, image/webp
-  const normalizedType = fileType === "pdf" || fileType === "application/pdf"
-    ? "application/pdf"
-    : fileType;
-
-  const dataUri = `data:${normalizedType};base64,${fileBase64}`;
-
-  const response = await fetch(LOVABLE_AI_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: VISION_MODEL,
-      messages: [
-        {
-          role: "user",
-          content: [
-            { type: "image_url", image_url: { url: dataUri } },
-            { type: "text", text: prompt },
-          ],
-        },
-      ],
-    }),
+/**
+ * Chamada única à Anthropic com forced tool-use. Devolve o `input` da tool.
+ * O system prompt leva `cache_control` — junto das tools ele é o prefixo estável
+ * entre uploads (a mensagem do usuário, que carrega o anexo, vem depois).
+ */
+async function extrairViaTool(
+  client: Anthropic,
+  system: string,
+  tool: typeof TOOL_PROMOCAO | typeof TOOL_AUMENTO,
+  anexo: BlocoAnexo,
+  instrucao: string,
+): Promise<{ input: unknown; usage: Record<string, number> }> {
+  const response = await client.messages.create({
+    model: MODELO,
+    max_tokens: MAX_TOKENS,
+    system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+    tools: [tool],
+    tool_choice: { type: "tool", name: tool.name },
+    messages: [
+      {
+        role: "user",
+        content: [
+          anexo,
+          { type: "text", text: instrucao },
+        ],
+      },
+    ],
   });
 
-  if (!response.ok) {
-    const errText = await response.text();
-    if (response.status === 429) {
-      throw new Error(
-        `Lovable AI rate limit atingido (429). Tente novamente em alguns segundos.`,
-      );
-    }
-    if (response.status === 402) {
-      throw new Error(
-        `Lovable AI sem créditos (402). Adicione créditos em Settings > Workspace > Usage.`,
-      );
-    }
+  // §8 money-path: teto que trunca fabrica completude. Uma lista de descontos
+  // cortada ao meio é indistinguível de uma promoção curta para quem lê depois.
+  if (response.stop_reason === "max_tokens") {
+    throw new ExtracaoTruncada(
+      `resposta truncada em ${MAX_TOKENS} tokens — extração parcial não é gravada. Envie o documento em partes menores.`,
+    );
+  }
+
+  const toolUse = response.content.find((b) => b.type === "tool_use");
+  if (!toolUse || toolUse.type !== "tool_use") {
+    const texto = response.content
+      .filter((b) => b.type === "text")
+      .map((b) => (b.type === "text" ? b.text : ""))
+      .join(" ")
+      .slice(0, 300);
     throw new Error(
-      `Lovable AI erro ${response.status}: ${errText.slice(0, 300)}`,
+      `modelo não usou a tool ${tool.name} (stop_reason=${response.stop_reason}) ${texto}`,
     );
   }
 
-  const data = await response.json();
-  return data.choices?.[0]?.message?.content ?? "";
+  return {
+    input: toolUse.input,
+    usage: {
+      input_tokens: response.usage.input_tokens,
+      output_tokens: response.usage.output_tokens,
+      cache_creation_input_tokens: response.usage.cache_creation_input_tokens ?? 0,
+      cache_read_input_tokens: response.usage.cache_read_input_tokens ?? 0,
+    },
+  };
 }
 
-function stripJsonFences(textResponse: string): string {
-  let cleaned = textResponse.trim();
-  if (cleaned.startsWith("```json")) cleaned = cleaned.slice(7);
-  if (cleaned.startsWith("```")) cleaned = cleaned.slice(3);
-  if (cleaned.endsWith("```")) cleaned = cleaned.slice(0, -3);
-  return cleaned.trim();
-}
+function montarPromo(bruto: unknown): ExtractedPromo {
+  const cru = (bruto ?? {}) as Record<string, unknown>;
+  const { itens, rejeitados } = normalizarItensPromo(cru.items);
 
-async function callVisionGateway(
-  fileBase64: string,
-  fileType: string,
-): Promise<ExtractedPromo> {
-  const textResponse = await callVisionRaw(fileBase64, fileType, EXTRACTION_PROMPT);
-  const cleaned = stripJsonFences(textResponse);
-  try {
-    const parsed = JSON.parse(cleaned) as ExtractedPromo;
-    if (!Array.isArray(parsed.items)) parsed.items = [];
-    if (typeof parsed.confianca !== "number") parsed.confianca = 0;
-    if (!parsed.observacoes) parsed.observacoes = "";
-    return parsed;
-  } catch (err) {
-    return fallbackExtraction(
-      `ERRO PARSING: ${String(err).slice(0, 200)}.`,
-      textResponse,
+  const inicio = dataValida(cru.data_inicio);
+  const fim = dataValida(cru.data_fim);
+  const observacoesBase = typeof cru.observacoes === "string" ? cru.observacoes : "";
+
+  if (!inicio || !fim) {
+    // Sem período válido a campanha não pode ser aplicada. Grava rascunho com o
+    // período sinalizado (nunca em silêncio) mas PRESERVA os itens já extraídos —
+    // o revisor corrige a data em vez de pagar uma nova extração. O gate humano
+    // segue intacto: estado 'rascunho' + confirmado=false por item.
+    const base = fallbackExtraction(
+      `PERÍODO NÃO IDENTIFICADO — datas abaixo são placeholder, corrija antes de ativar (data_inicio=${
+        JSON.stringify(cru.data_inicio)
+      }, data_fim=${JSON.stringify(cru.data_fim)}). ${observacoesBase}`.trim(),
     );
+    return {
+      ...base,
+      items: itens,
+      observacoes: anotarRejeicoes(base.observacoes, rejeitados),
+    };
   }
+
+  return {
+    nome: typeof cru.nome === "string" && cru.nome.trim()
+      ? cru.nome.trim()
+      : `Promoção ${inicio}`,
+    data_inicio: inicio,
+    data_fim: fim,
+    fornecedor_nome: typeof cru.fornecedor_nome === "string"
+      ? cru.fornecedor_nome
+      : "",
+    items: itens,
+    confianca: normalizarConfianca(cru.confianca),
+    observacoes: anotarRejeicoes(observacoesBase, rejeitados),
+  };
 }
 
-async function callVisionGatewayAumento(
-  fileBase64: string,
-  fileType: string,
-): Promise<ExtractedAumento> {
-  const textResponse = await callVisionRaw(fileBase64, fileType, AUMENTO_PROMPT);
-  const cleaned = stripJsonFences(textResponse);
-  try {
-    const parsed = JSON.parse(cleaned) as ExtractedAumento;
-    if (!Array.isArray(parsed.categorias)) parsed.categorias = [];
-    if (typeof parsed.confianca !== "number") parsed.confianca = 0;
-    if (!parsed.observacoes) parsed.observacoes = "";
-    if (!parsed.data_anuncio) parsed.data_anuncio = null;
-    return parsed;
-  } catch (err) {
-    return fallbackAumento(
-      `ERRO PARSING: ${String(err).slice(0, 200)}.`,
-      textResponse,
+function montarAumento(bruto: unknown): ExtractedAumento {
+  const cru = (bruto ?? {}) as Record<string, unknown>;
+  const { categorias, rejeitadas } = normalizarCategoriasAumento(cru.categorias);
+
+  const vigencia = dataValida(cru.data_vigencia);
+  const observacoesBase = typeof cru.observacoes === "string" ? cru.observacoes : "";
+
+  if (!vigencia) {
+    // Idem promoção: sinaliza a vigência como placeholder e preserva as categorias.
+    const base = fallbackAumento(
+      `VIGÊNCIA NÃO IDENTIFICADA — data abaixo é placeholder, corrija antes de ativar (data_vigencia=${
+        JSON.stringify(cru.data_vigencia)
+      }). ${observacoesBase}`.trim(),
     );
+    return {
+      ...base,
+      categorias,
+      observacoes: anotarRejeicoes(base.observacoes, rejeitadas),
+    };
   }
+
+  return {
+    nome: typeof cru.nome === "string" && cru.nome.trim()
+      ? cru.nome.trim()
+      : `Aumento ${vigencia}`,
+    data_vigencia: vigencia,
+    data_anuncio: dataValida(cru.data_anuncio),
+    categorias,
+    confianca: normalizarConfianca(cru.confianca),
+    observacoes: anotarRejeicoes(observacoesBase, rejeitadas),
+  };
 }
 
 Deno.serve(async (req: Request) => {
@@ -307,6 +413,17 @@ Deno.serve(async (req: Request) => {
   }
   const __auth = await authorizeCronOrStaff(req);
   if (!__auth.ok) return __auth.response;
+
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) {
+    return new Response(
+      JSON.stringify({ error: "ANTHROPIC_API_KEY não configurada" }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
+  }
 
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
@@ -321,6 +438,28 @@ Deno.serve(async (req: Request) => {
       status: 400,
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
+  }
+
+  // CANÁRIA DE VERSÃO (docs/agent/deploy.md): no Lovable Cloud não há PAT, então o
+  // deploy de edge não tem prova de VERSÃO — só "foi servida". Este probe é a prova:
+  // `{ probe: true }` responde qual motor está no ar sem chamar o modelo (custo zero).
+  //   curl -s -X POST <url> -H "Authorization: Bearer <jwt staff>" \
+  //        -H 'content-type: application/json' -d '{"probe":true}'
+  //   → {"ok":true,"motor":"anthropic",...}  = versão nova no ar
+  //   → 400 "arquivo_base64 obrigatório"     = ainda a versão velha (gateway Lovable)
+  if (body.probe === true) {
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        motor: "anthropic",
+        modelo: MODELO,
+        tools: [TOOL_PROMOCAO.name, TOOL_AUMENTO.name],
+      }),
+      {
+        status: 200,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      },
+    );
   }
 
   const empresa = (body.empresa as string) ?? "OBEN";
@@ -346,29 +485,29 @@ Deno.serve(async (req: Request) => {
     );
   }
 
+  // Valida o anexo ANTES do upload: tipo não suportado ou arquivo grande demais
+  // falha aqui, sem deixar lixo no bucket nem gastar chamada de modelo.
+  const anexo = montarBlocoAnexo(arquivoTipo, arquivoBase64);
+  if (!anexo.ok) {
+    return new Response(JSON.stringify({ error: anexo.erro }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
   console.log(
-    `[promocao-extrair-via-vision] start empresa=${empresa} tipo_doc=${tipoDocumento} tipo_arq=${arquivoTipo} bytes_b64=${arquivoBase64.length}`,
+    `[promocao-extrair-via-vision] start empresa=${empresa} tipo_doc=${tipoDocumento} media=${anexo.mediaType} bytes_b64=${arquivoBase64.length}`,
   );
 
   // ===== Upload do arquivo no Storage (compartilhado entre fluxos) =====
-  const ext = arquivoTipo === "pdf" || arquivoTipo === "application/pdf"
-    ? "pdf"
-    : arquivoTipo === "image/png"
-    ? "png"
-    : arquivoTipo === "image/webp"
-    ? "webp"
-    : "jpg";
   const fileName = `${empresa}/${Date.now()}_${
     Math.random().toString(36).slice(2, 8)
-  }.${ext}`;
+  }.${anexo.extensao}`;
   const fileBytes = Uint8Array.from(atob(arquivoBase64), (c) => c.charCodeAt(0));
-  const contentType = arquivoTipo === "pdf" || arquivoTipo === "application/pdf"
-    ? "application/pdf"
-    : arquivoTipo;
 
   const { error: uploadErr } = await supabase.storage
     .from("promocoes")
-    .upload(fileName, fileBytes, { contentType });
+    .upload(fileName, fileBytes, { contentType: anexo.mediaType });
   if (uploadErr) {
     console.error(
       `[promocao-extrair-via-vision] upload falhou: ${uploadErr.message}`,
@@ -376,18 +515,31 @@ Deno.serve(async (req: Request) => {
   }
   const arquivoUrl = uploadErr ? null : fileName;
 
+  const client = new Anthropic({ apiKey });
+
   // ===== FLUXO AUMENTO =====
   if (tipoDocumento === "aumento") {
     let extractedAum: ExtractedAumento;
+    let usageAum: Record<string, number>;
     try {
-      extractedAum = await callVisionGatewayAumento(arquivoBase64, arquivoTipo);
+      const { input, usage } = await extrairViaTool(
+        client,
+        SYSTEM_AUMENTO,
+        TOOL_AUMENTO,
+        anexo.bloco,
+        "Extraia o reajuste de preços deste comunicado usando a tool registrar_aumento.",
+      );
+      extractedAum = montarAumento(input);
+      usageAum = usage;
     } catch (err) {
-      const msg = String(err).slice(0, 300);
-      console.error(`[promocao-extrair-via-vision] vision aumento falhou: ${msg}`);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(
+        `[promocao-extrair-via-vision] vision aumento falhou: ${msg.slice(0, 300)}`,
+      );
       return new Response(
-        JSON.stringify({ error: `Vision falhou: ${msg}` }),
+        JSON.stringify({ error: `Vision falhou: ${msg.slice(0, 300)}` }),
         {
-          status: 500,
+          status: err instanceof ExtracaoTruncada ? 422 : 502,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         },
       );
@@ -432,13 +584,12 @@ Deno.serve(async (req: Request) => {
       );
     }
 
-    const aumentoId =
-      typeof aumentoRpc === "string"
-        ? aumentoRpc
-        : (aumentoRpc as { id?: string } | null)?.id ?? aumentoRpc;
+    const aumentoId = typeof aumentoRpc === "string"
+      ? aumentoRpc
+      : (aumentoRpc as { id?: string } | null)?.id ?? aumentoRpc;
 
     console.log(
-      `[promocao-extrair-via-vision] OK aumento_id=${aumentoId} categorias=${extractedAum.categorias.length} confianca=${extractedAum.confianca}`,
+      `[promocao-extrair-via-vision] OK aumento_id=${aumentoId} categorias=${extractedAum.categorias.length} confianca=${extractedAum.confianca} tokens=${usageAum.input_tokens}/${usageAum.output_tokens} cache_read=${usageAum.cache_read_input_tokens}`,
     );
 
     return new Response(
@@ -463,21 +614,30 @@ Deno.serve(async (req: Request) => {
 
   // ===== FLUXO PROMOÇÃO (default — comportamento original) =====
   let extracted: ExtractedPromo;
+  let usagePromo: Record<string, number>;
   try {
-    extracted = await callVisionGateway(arquivoBase64, arquivoTipo);
+    const { input, usage } = await extrairViaTool(
+      client,
+      SYSTEM_PROMOCAO,
+      TOOL_PROMOCAO,
+      anexo.bloco,
+      "Extraia a campanha promocional deste documento usando a tool registrar_promocao.",
+    );
+    extracted = montarPromo(input);
+    usagePromo = usage;
   } catch (err) {
-    const msg = String(err).slice(0, 300);
-    console.error(`[promocao-extrair-via-vision] vision falhou: ${msg}`);
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[promocao-extrair-via-vision] vision falhou: ${msg.slice(0, 300)}`,
+    );
     return new Response(
-      JSON.stringify({ error: `Vision falhou: ${msg}` }),
+      JSON.stringify({ error: `Vision falhou: ${msg.slice(0, 300)}` }),
       {
-        status: 500,
+        status: err instanceof ExtracaoTruncada ? 422 : 502,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       },
     );
   }
-
-  // (upload já realizado antes da bifurcação por tipo_documento)
 
   const fornecedorCanonico = await normalizarFornecedor(
     supabase,
@@ -549,10 +709,10 @@ Deno.serve(async (req: Request) => {
 
     const r = resolucao as
       | {
-          qualidade?: string;
-          omie_codigo_produto?: number;
-          candidatos?: unknown;
-        }
+        qualidade?: string;
+        omie_codigo_produto?: number;
+        candidatos?: unknown;
+      }
       | null;
     const qualidade = r?.qualidade ?? "nao_encontrado";
     const skuOmie = qualidade === "unico" ? r?.omie_codigo_produto ?? null : null;
@@ -582,7 +742,7 @@ Deno.serve(async (req: Request) => {
   }
 
   console.log(
-    `[promocao-extrair-via-vision] OK campanha=${campanha.id} items=${extracted.items.length} confianca=${extracted.confianca}`,
+    `[promocao-extrair-via-vision] OK campanha=${campanha.id} items=${extracted.items.length} confianca=${extracted.confianca} tokens=${usagePromo.input_tokens}/${usagePromo.output_tokens} cache_read=${usagePromo.cache_read_input_tokens}`,
   );
 
   return new Response(
@@ -596,8 +756,7 @@ Deno.serve(async (req: Request) => {
       },
       items: itensResults,
       arquivo_url: arquivoUrl,
-      proximo_passo:
-        `Revisar em /admin/reposicao/promocoes/${campanha.id}`,
+      proximo_passo: `Revisar em /admin/reposicao/promocoes/${campanha.id}`,
     }),
     {
       headers: { ...corsHeaders, "Content-Type": "application/json" },

--- a/supabase/functions/promocao-extrair-via-vision/vision-helpers.ts
+++ b/supabase/functions/promocao-extrair-via-vision/vision-helpers.ts
@@ -1,0 +1,256 @@
+// Helpers PUROS da extração por vision — sem import remoto, para rodar sob
+// `deno test --no-remote` (o `test:edges` do CI). A edge (index.ts) importa
+// daqui; o SDK da Anthropic e o supabase-js ficam de fora deste módulo.
+//
+// Guards money-path: percentual extraído por LLM não entra em promoção/aumento
+// sem passar por `validarPercentual`. Item fora de faixa é REJEITADO e anotado
+// (precisão > recall), nunca gravado com número fabricado.
+
+/** Media types que a API da Anthropic aceita como imagem. */
+const MEDIA_TYPES_IMAGEM = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+const MEDIA_TYPE_PDF = "application/pdf";
+
+/** Teto de request da Anthropic (32 MB) com folga para o envelope JSON. */
+export const LIMITE_BASE64_BYTES = 30 * 1024 * 1024;
+
+/** Union literal — o SDK da Anthropic tipa `media_type` assim, `string` não casa. */
+export type MediaTypeImagem = (typeof MEDIA_TYPES_IMAGEM)[number];
+
+export type BlocoAnexo =
+  | {
+    type: "image";
+    source: { type: "base64"; media_type: MediaTypeImagem; data: string };
+  }
+  | {
+    type: "document";
+    source: { type: "base64"; media_type: "application/pdf"; data: string };
+  };
+
+export type ResultadoAnexo =
+  | { ok: true; bloco: BlocoAnexo; mediaType: string; extensao: string }
+  | { ok: false; erro: string };
+
+/**
+ * Normaliza o `arquivo_tipo` do body ("pdf" ou o MIME do File) para o media
+ * type da Anthropic e monta o content block correspondente.
+ *
+ * Fail-closed: tipo não suportado vira erro explícito aqui, em vez de um 400
+ * opaco vindo da API depois de já termos gasto o upload.
+ */
+export function montarBlocoAnexo(
+  arquivoTipo: string,
+  base64: string,
+): ResultadoAnexo {
+  const tipo = (arquivoTipo ?? "").trim().toLowerCase();
+  const dados = (base64 ?? "").trim();
+
+  if (!dados) return { ok: false, erro: "arquivo_base64 vazio" };
+  if (dados.length > LIMITE_BASE64_BYTES) {
+    const mb = (dados.length / (1024 * 1024)).toFixed(1);
+    return {
+      ok: false,
+      erro:
+        `arquivo grande demais para a API (${mb} MB em base64; limite ~30 MB). Comprima o PDF ou envie página por página.`,
+    };
+  }
+
+  if (tipo === "pdf" || tipo === MEDIA_TYPE_PDF) {
+    return {
+      ok: true,
+      mediaType: MEDIA_TYPE_PDF,
+      extensao: "pdf",
+      bloco: {
+        type: "document",
+        source: { type: "base64", media_type: MEDIA_TYPE_PDF, data: dados },
+      },
+    };
+  }
+
+  const imagem = MEDIA_TYPES_IMAGEM.find((m) => m === tipo);
+  if (imagem) {
+    return {
+      ok: true,
+      mediaType: imagem,
+      extensao: imagem === "image/jpeg" ? "jpg" : imagem.slice("image/".length),
+      bloco: {
+        type: "image",
+        source: { type: "base64", media_type: imagem, data: dados },
+      },
+    };
+  }
+
+  return {
+    ok: false,
+    erro:
+      `arquivo_tipo não suportado: "${arquivoTipo}". Aceitos: pdf, ${
+        MEDIA_TYPES_IMAGEM.join(", ")
+      }.`,
+  };
+}
+
+/**
+ * Guard money-path para percentual extraído pela IA.
+ * Devolve `null` (e o caller rejeita a linha) para ausente, não-finito, zero,
+ * negativo ou acima de 100 — nenhum desses vira número gravado.
+ */
+export function validarPercentual(valor: unknown): number | null {
+  const n = typeof valor === "number" ? valor : Number(valor);
+  if (!Number.isFinite(n)) return null;
+  if (n <= 0 || n > 100) return null;
+  return n;
+}
+
+/** Confiança fora de [0,1] ou ilegível degrada para 0, nunca para um valor inventado. */
+export function normalizarConfianca(valor: unknown): number {
+  const n = typeof valor === "number" ? valor : Number(valor);
+  if (!Number.isFinite(n) || n < 0 || n > 1) return 0;
+  return n;
+}
+
+/** Aceita apenas YYYY-MM-DD que exista de fato no calendário. */
+export function dataValida(valor: unknown): string | null {
+  if (typeof valor !== "string") return null;
+  const texto = valor.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(texto)) return null;
+  const d = new Date(`${texto}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return null;
+  // Rejeita overflow silencioso do Date (2026-02-31 → 2026-03-03).
+  return d.toISOString().slice(0, 10) === texto ? texto : null;
+}
+
+export interface ItemPromo {
+  codigo_fornecedor: string;
+  descricao: string | null;
+  desconto_perc: number;
+  volume_minimo: number | null;
+}
+
+export interface ItemRejeitado {
+  codigo: string;
+  motivo: string;
+}
+
+export interface ItensNormalizados {
+  itens: ItemPromo[];
+  rejeitados: ItemRejeitado[];
+}
+
+/**
+ * Filtra os itens vindos da tool: código não-vazio + desconto dentro da faixa.
+ * O que não passa sai da lista e vira `rejeitados` — visível na resposta e nas
+ * observações, em vez de virar linha com desconto errado em `promocao_item`.
+ */
+export function normalizarItensPromo(bruto: unknown): ItensNormalizados {
+  const itens: ItemPromo[] = [];
+  const rejeitados: ItemRejeitado[] = [];
+  if (!Array.isArray(bruto)) return { itens, rejeitados };
+
+  for (const cru of bruto) {
+    const linha = (cru ?? {}) as Record<string, unknown>;
+    const codigo = typeof linha.codigo_fornecedor === "string"
+      ? linha.codigo_fornecedor.trim()
+      : "";
+    if (!codigo) {
+      rejeitados.push({ codigo: "(sem código)", motivo: "codigo_fornecedor ausente" });
+      continue;
+    }
+
+    const desconto = validarPercentual(linha.desconto_perc);
+    if (desconto === null) {
+      rejeitados.push({
+        codigo,
+        motivo: `desconto_perc fora da faixa (0,100]: ${JSON.stringify(linha.desconto_perc)}`,
+      });
+      continue;
+    }
+
+    const volumeBruto = typeof linha.volume_minimo === "number"
+      ? linha.volume_minimo
+      : Number(linha.volume_minimo);
+    const volume = Number.isFinite(volumeBruto) && volumeBruto > 0
+      ? volumeBruto
+      : null;
+
+    itens.push({
+      codigo_fornecedor: codigo,
+      descricao: typeof linha.descricao === "string" && linha.descricao.trim()
+        ? linha.descricao.trim()
+        : null,
+      desconto_perc: desconto,
+      volume_minimo: volume,
+    });
+  }
+
+  return { itens, rejeitados };
+}
+
+export interface CategoriaAumento {
+  categoria_fornecedor: string;
+  aumento_perc: number;
+  data_vigencia_especifica: string | null;
+}
+
+export interface CategoriasNormalizadas {
+  categorias: CategoriaAumento[];
+  rejeitadas: ItemRejeitado[];
+}
+
+/** Mesma disciplina de `normalizarItensPromo`, para as categorias do aumento. */
+export function normalizarCategoriasAumento(
+  bruto: unknown,
+): CategoriasNormalizadas {
+  const categorias: CategoriaAumento[] = [];
+  const rejeitadas: ItemRejeitado[] = [];
+  if (!Array.isArray(bruto)) return { categorias, rejeitadas };
+
+  for (const cru of bruto) {
+    const linha = (cru ?? {}) as Record<string, unknown>;
+    const nome = typeof linha.categoria_fornecedor === "string"
+      ? linha.categoria_fornecedor.trim()
+      : "";
+    if (!nome) {
+      rejeitadas.push({
+        codigo: "(sem categoria)",
+        motivo: "categoria_fornecedor ausente",
+      });
+      continue;
+    }
+
+    const aumento = validarPercentual(linha.aumento_perc);
+    if (aumento === null) {
+      rejeitadas.push({
+        codigo: nome,
+        motivo: `aumento_perc fora da faixa (0,100]: ${JSON.stringify(linha.aumento_perc)}`,
+      });
+      continue;
+    }
+
+    categorias.push({
+      categoria_fornecedor: nome,
+      aumento_perc: aumento,
+      data_vigencia_especifica: dataValida(linha.data_vigencia_especifica),
+    });
+  }
+
+  return { categorias, rejeitadas };
+}
+
+/** Anexa o relatório de rejeições às observações que vão para o revisor humano. */
+export function anotarRejeicoes(
+  observacoes: string,
+  rejeitados: ItemRejeitado[],
+): string {
+  if (rejeitados.length === 0) return observacoes;
+  const lista = rejeitados
+    .map((r) => `${r.codigo}: ${r.motivo}`)
+    .join("; ");
+  const aviso =
+    `[${rejeitados.length} linha(s) DESCARTADA(S) por valor inválido — revisar no documento original] ${lista}`;
+  return observacoes ? `${observacoes} ${aviso}` : aviso;
+}

--- a/supabase/functions/promocao-extrair-via-vision/vision-helpers_test.ts
+++ b/supabase/functions/promocao-extrair-via-vision/vision-helpers_test.ts
@@ -1,0 +1,242 @@
+// Testa o CÓDIGO REAL de vision-helpers.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/promocao-extrair-via-vision/
+//
+// Foco: os guards money-path. Percentual extraído por LLM que não passa por
+// `validarPercentual` viraria desconto/aumento gravado em cima de preço real.
+import {
+  anotarRejeicoes,
+  dataValida,
+  LIMITE_BASE64_BYTES,
+  montarBlocoAnexo,
+  normalizarCategoriasAumento,
+  normalizarConfianca,
+  normalizarItensPromo,
+  validarPercentual,
+} from "./vision-helpers.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+// ─────────────────────────── montarBlocoAnexo ───────────────────────────
+
+Deno.test("montarBlocoAnexo: pdf vira content block document", () => {
+  const r = montarBlocoAnexo("pdf", "QUJD");
+  assert(r.ok, "deveria aceitar pdf");
+  if (!r.ok) return;
+  assertEquals(r.bloco.type, "document");
+  assertEquals(r.mediaType, "application/pdf");
+  assertEquals(r.extensao, "pdf");
+  assertEquals(r.bloco.source.data, "QUJD");
+});
+
+Deno.test("montarBlocoAnexo: application/pdf também é aceito", () => {
+  const r = montarBlocoAnexo("application/pdf", "QUJD");
+  assert(r.ok, "deveria aceitar application/pdf");
+});
+
+Deno.test("montarBlocoAnexo: imagens viram content block image com extensão certa", () => {
+  const casos: Array<[string, string]> = [
+    ["image/jpeg", "jpg"],
+    ["image/png", "png"],
+    ["image/webp", "webp"],
+    ["image/gif", "gif"],
+  ];
+  for (const [mime, ext] of casos) {
+    const r = montarBlocoAnexo(mime, "QUJD");
+    assert(r.ok, `deveria aceitar ${mime}`);
+    if (!r.ok) continue;
+    assertEquals(r.bloco.type, "image", mime);
+    assertEquals(r.bloco.source.media_type, mime, mime);
+    assertEquals(r.extensao, ext, `extensão de ${mime}`);
+  }
+});
+
+Deno.test("montarBlocoAnexo: MIME não suportado pela Anthropic é rejeitado aqui", () => {
+  // image/heic sai do iPhone e o <input> aceita; o gateway antigo tolerava.
+  for (const mime of ["image/heic", "image/bmp", "text/plain", ""]) {
+    const r = montarBlocoAnexo(mime, "QUJD");
+    assert(!r.ok, `${mime} deveria ser rejeitado`);
+  }
+});
+
+Deno.test("montarBlocoAnexo: base64 vazio é rejeitado", () => {
+  assert(!montarBlocoAnexo("pdf", "").ok, "vazio deveria ser rejeitado");
+  assert(!montarBlocoAnexo("pdf", "   ").ok, "só espaço deveria ser rejeitado");
+});
+
+Deno.test("montarBlocoAnexo: acima do teto de request é rejeitado com mensagem acionável", () => {
+  const grande = "A".repeat(LIMITE_BASE64_BYTES + 1);
+  const r = montarBlocoAnexo("pdf", grande);
+  assert(!r.ok, "deveria rejeitar acima do limite");
+  if (r.ok) return;
+  assert(r.erro.includes("MB"), "erro deveria informar o tamanho");
+});
+
+// ─────────────────────── validarPercentual (money-path) ───────────────────────
+
+Deno.test("validarPercentual: aceita faixa (0,100]", () => {
+  assertEquals(validarPercentual(20), 20);
+  assertEquals(validarPercentual(0.5), 0.5);
+  assertEquals(validarPercentual(100), 100);
+});
+
+Deno.test("validarPercentual: ausente/ilegível NÃO vira zero", () => {
+  // Number(null) === 0 é a armadilha canônica: 0% de desconto é um FATO
+  // diferente de "não consegui ler o desconto".
+  for (const v of [null, undefined, "", "abc", NaN, Infinity, -Infinity, {}, []]) {
+    assertEquals(validarPercentual(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("validarPercentual: zero, negativo e acima de 100 são rejeitados", () => {
+  for (const v of [0, -1, -0.01, 100.01, 5000]) {
+    assertEquals(validarPercentual(v), null, `entrada ${v}`);
+  }
+});
+
+// ─────────────────────────── normalizarConfianca ───────────────────────────
+
+Deno.test("normalizarConfianca: fora de [0,1] ou ilegível degrada para 0", () => {
+  assertEquals(normalizarConfianca(0.9), 0.9);
+  assertEquals(normalizarConfianca(0), 0);
+  assertEquals(normalizarConfianca(1), 1);
+  for (const v of [null, undefined, "alta", NaN, -0.1, 1.1]) {
+    assertEquals(normalizarConfianca(v), 0, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ─────────────────────────────── dataValida ───────────────────────────────
+
+Deno.test("dataValida: aceita YYYY-MM-DD real", () => {
+  assertEquals(dataValida("2026-04-16"), "2026-04-16");
+  assertEquals(dataValida("2024-02-29"), "2024-02-29"); // bissexto
+});
+
+Deno.test("dataValida: rejeita formato errado e data inexistente", () => {
+  for (const v of [
+    "16/04/2026",
+    "2026-4-16",
+    "2026-02-31", // overflow silencioso do Date
+    "2025-02-29", // não bissexto
+    "hoje",
+    null,
+    undefined,
+    20260416,
+  ]) {
+    assertEquals(dataValida(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ───────────────────────── normalizarItensPromo ─────────────────────────
+
+Deno.test("normalizarItensPromo: mantém item bom e preserva o código verbatim", () => {
+  const { itens, rejeitados } = normalizarItensPromo([
+    {
+      codigo_fornecedor: "YLO4.6269.02",
+      descricao: " Verniz PU ",
+      desconto_perc: 22.5,
+      volume_minimo: 10,
+    },
+  ]);
+  assertEquals(rejeitados.length, 0);
+  assertEquals(itens.length, 1);
+  assertEquals(itens[0].codigo_fornecedor, "YLO4.6269.02");
+  assertEquals(itens[0].descricao, "Verniz PU");
+  assertEquals(itens[0].desconto_perc, 22.5);
+  assertEquals(itens[0].volume_minimo, 10);
+});
+
+Deno.test("normalizarItensPromo: item com desconto inválido é DESCARTADO, não gravado com 0", () => {
+  const { itens, rejeitados } = normalizarItensPromo([
+    { codigo_fornecedor: "DR.4403", desconto_perc: 20 },
+    { codigo_fornecedor: "FL.6269.02", desconto_perc: null },
+    { codigo_fornecedor: "FL.9999.01", desconto_perc: "vinte" },
+    { codigo_fornecedor: "FL.8888.01", desconto_perc: 0 },
+    { codigo_fornecedor: "FL.7777.01", desconto_perc: 250 },
+  ]);
+  assertEquals(itens.length, 1, "só o item válido deveria passar");
+  assertEquals(itens[0].codigo_fornecedor, "DR.4403");
+  assertEquals(rejeitados.length, 4);
+  assert(
+    rejeitados.every((r) => r.motivo.includes("desconto_perc")),
+    "motivo deveria citar o campo",
+  );
+});
+
+Deno.test("normalizarItensPromo: item sem código é descartado", () => {
+  const { itens, rejeitados } = normalizarItensPromo([
+    { codigo_fornecedor: "  ", desconto_perc: 10 },
+    { desconto_perc: 10 },
+  ]);
+  assertEquals(itens.length, 0);
+  assertEquals(rejeitados.length, 2);
+});
+
+Deno.test("normalizarItensPromo: volume_minimo ilegível vira null, não 0", () => {
+  const { itens } = normalizarItensPromo([
+    { codigo_fornecedor: "A", desconto_perc: 10, volume_minimo: "n/a" },
+    { codigo_fornecedor: "B", desconto_perc: 10, volume_minimo: 0 },
+    { codigo_fornecedor: "C", desconto_perc: 10 },
+  ]);
+  assertEquals(itens.map((i) => i.volume_minimo), [null, null, null]);
+});
+
+Deno.test("normalizarItensPromo: entrada não-array não explode", () => {
+  assertEquals(normalizarItensPromo(null), { itens: [], rejeitados: [] });
+  assertEquals(normalizarItensPromo("x"), { itens: [], rejeitados: [] });
+});
+
+// ─────────────────── normalizarCategoriasAumento ───────────────────
+
+Deno.test("normalizarCategoriasAumento: categoria com aumento inválido é descartada", () => {
+  const { categorias, rejeitadas } = normalizarCategoriasAumento([
+    {
+      categoria_fornecedor: "Poliuretano",
+      aumento_perc: 7.5,
+      data_vigencia_especifica: "2026-05-01",
+    },
+    { categoria_fornecedor: "Nitro", aumento_perc: null },
+    { categoria_fornecedor: "Hidro", aumento_perc: 0 },
+  ]);
+  assertEquals(categorias.length, 1);
+  assertEquals(categorias[0].categoria_fornecedor, "Poliuretano");
+  assertEquals(categorias[0].aumento_perc, 7.5);
+  assertEquals(categorias[0].data_vigencia_especifica, "2026-05-01");
+  assertEquals(rejeitadas.length, 2);
+});
+
+Deno.test("normalizarCategoriasAumento: data específica inválida vira null sem derrubar a categoria", () => {
+  const { categorias } = normalizarCategoriasAumento([
+    {
+      categoria_fornecedor: "Poliuretano",
+      aumento_perc: 5,
+      data_vigencia_especifica: "01/05/2026",
+    },
+  ]);
+  assertEquals(categorias.length, 1);
+  assertEquals(categorias[0].data_vigencia_especifica, null);
+});
+
+// ─────────────────────────── anotarRejeicoes ───────────────────────────
+
+Deno.test("anotarRejeicoes: sem rejeição preserva a observação original", () => {
+  assertEquals(anotarRejeicoes("tudo certo", []), "tudo certo");
+});
+
+Deno.test("anotarRejeicoes: rejeição aparece na observação do revisor", () => {
+  const texto = anotarRejeicoes("obs original", [
+    { codigo: "FL.1", motivo: "desconto_perc fora da faixa (0,100]: null" },
+  ]);
+  assert(texto.includes("obs original"), "deveria manter a observação");
+  assert(texto.includes("DESCARTADA"), "deveria sinalizar o descarte");
+  assert(texto.includes("FL.1"), "deveria citar o código descartado");
+});


### PR DESCRIPTION
## Por quê

O **AI features usage limit** do Lovable (teto de 4 créditos/mês, estourado em 4,20) bloqueia o gateway de IA até 1/ago UTC. Ele serve **7 edges**; esta é a que dói: `promocao-extrair-via-vision` alimenta promoções e aumentos de preço na Reposição.

Fase 1 de 4 da saída do gateway. As outras 6 (`analyze-unified-order`, `generate-tactical-plan`, `generate-bundle-argument`, `copilot-analyze`, `identify-tool`, `analyze-services`) vêm depois.

## O que muda

Padrão do `CLAUDE.md:102`, os 5 itens: `claude-sonnet-4-6` via `npm:@anthropic-ai/sdk` + `ANTHROPIC_API_KEY` + prompt caching + **forced tool-use** + gate `authorizeCronOrStaff` preservado.

- PDF → content block `document`; imagem → `image`.
- O parsing de JSON de texto livre (com `stripJsonFences`) **sumiu** — o schema agora é contrato de tool.
- **Contrato de request/response inalterado.** O frontend não muda; as 3 alterações em `src/` são só strings que citavam "Gemini".

## Guards money-path

O percentual continua vindo de um LLM, então ele não entra sem passar por guard:

| Situação | Antes | Agora |
|---|---|---|
| `desconto_perc` ilegível/ausente/fora de (0,100] | gravava o que viesse | linha **descartada** + anotada em `extracao_observacoes` |
| resposta truncada (`max_tokens`) | gravaria lista parcial como completa | **422, não grava** (§8: teto que trunca fabrica completude) |
| MIME não suportado / arquivo >30 MB | erro opaco da API, após upload | falha **antes** do upload e da chamada paga |
| período/vigência ilegível | descartava os itens | placeholder sinalizado, **itens preservados** (revisor corrige a data em vez de re-pagar) |

`Number(null) === 0` era a porta aberta: 0% de desconto é um fato diferente de "não consegui ler o desconto".

## Prova

- **21 testes Deno** (`--no-remote`, lógica pura em `vision-helpers.ts` — o `test:edges` não aceita import remoto).
- **Falsificação**: 4 sabotagens × 2 locales (`C` e `pt_BR.UTF-8`), denominador fixo em 21, restauração verde. A sabotagem da faixa derruba exatamente os 4 testes-alvo, com `esperado: null · recebido: 0`.
- `deno check` da edge: **7 erros de tipo pré-existentes → 0**.

Sem migration/RPC/trigger/RLS no diff, então `prove-sql-money-path` não se aplica.

## Deploy (manual — mergear não publica)

1. **Confirmar** que `ANTHROPIC_API_KEY` está nos secrets do Supabase (as outras 8 edges já usam).
2. **Deploy da edge** pelo chat do Lovable, verbatim de `supabase/functions/promocao-extrair-via-vision/index.ts` — atenção: agora são **2 arquivos** (`index.ts` + `vision-helpers.ts`).
3. **Provar a versão** com a canária (`docs/agent/deploy.md` #1590 — no Lovable Cloud não há PAT, então esta é a única prova de *qual* versão está no ar):

```bash
curl -s -X POST "https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/promocao-extrair-via-vision" \
  -H "Authorization: Bearer <jwt staff>" -H 'content-type: application/json' \
  -d '{"probe":true}'
```

`{"ok":true,"motor":"anthropic",...}` = versão nova no ar. `400 arquivo_base64 obrigatório` = ainda a versão velha.

4. **Publish do frontend** (as 3 strings de UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)