### PR TITLE
feat(tint): Camada B do watchdog da Fase 5 — a chave sem preço e o tombstone órfão, em tipos separados [money-path]

### DIFF
--- a/db/test-tint-fase5-watchdog.sh
+++ b/db/test-tint-fase5-watchdog.sh
@@ -1,0 +1,466 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — tint_watchdog_fase5_check()  (Fase 5b#2, PR 2 — Camada B)        ║
+# ║  bash db/test-tint-fase5-watchdog.sh > /tmp/t.log 2>&1; echo "exit=$?"         ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                        ║
+# ║                                                                                ║
+# ║  O ORÁCULO É A VIEW REAL. O script EXTRAI v_tint_formula_canonica da última    ║
+# ║  migration que a define, em vez de stubar o predicado — stubar provaria que a  ║
+# ║  função concorda com o stub, não que ela mede o que o balcão lê.               ║
+# ║                                                                                ║
+# ║  O QUE PROVA (a migration 20260730120000):                                     ║
+# ║   B1  estado saudável -> silêncio total                                        ║
+# ║   B2  marcador sync_state tint_watchdog_fase5 avança em sucesso COMPLETO       ║
+# ║       (é ele que ATIVA o dead-man cruzado que o PR 1 já tem em prod)           ║
+# ║   B3  chave carimbada sem canônica válida -> tint_fase5_chave_sem_preco        ║
+# ║   B4  e-mail enfileirado para S1                                               ║
+# ║   B5  severidade escala: >=1000 chaves -> critico (Codex [P2])                 ║
+# ║   B6  fonte retirou a chave -> tint_fase5_fonte_retirada (TIPO SEPARADO)       ║
+# ║   B7  S1 e S2 COEXISTEM sem se silenciar  <-- o achado [P1] do Codex           ║
+# ║   B8  volta ao normal -> dismiss dos dois                                      ║
+# ║   B9  agravamento de S1 com alerta aberto -> atualiza + re-emite               ║
+# ║   B10 universo encolhe >1% -> tint_fase5_universo_encolheu (vigia de vacuidade)║
+# ║   B11 dismiss MANUAL re-ancora o patamar -> silêncio no ciclo seguinte         ║
+# ║   B12 auto-dismiss NÃO é lido como aceite manual (âncora avança junto)         ║
+# ║   B13 chave com OUTRO fallback válido não conta — e PASSA a contar quando o    ║
+# ║       fallback some (prova positiva: o assert mede o fallback, não o silêncio) ║
+# ║   B14 anti-sobreposição: lock tomado -> sai SEM avançar o marcador             ║
+# ║  FALSIFICAÇÕES (cada uma declara o CONJUNTO EXATO que derruba):                ║
+# ║   F1 anti-join ignora receita_valida    -> S1 cega                             ║
+# ║   F2 junta as 2 classes no MESMO tipo   -> reproduz o bug que o Codex apontou  ║
+# ║   F3 mata o vigia de cardinalidade      -> {B10,B12}                           ║
+# ║   F4 marcador sob outro nome            -> {B2,B13a,B13b}                      ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5459}"
+SLUG="tintf5wd"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0; FALHAS=()
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); FALHAS+=("$1"); echo "  XX  $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup PG17 :$PORT ==="
+
+# ══ ZONA 1 — pré-requisitos (o que a migration LÊ mas não cria) ══
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS cron;
+CREATE TABLE IF NOT EXISTS cron.job (jobid bigserial, jobname text, schedule text, command text, active boolean DEFAULT true);
+CREATE OR REPLACE FUNCTION cron.schedule(p_name text, p_sched text, p_cmd text)
+RETURNS bigint LANGUAGE plpgsql AS $f$
+DECLARE v bigint; BEGIN
+  DELETE FROM cron.job WHERE jobname = p_name;
+  INSERT INTO cron.job (jobname, schedule, command) VALUES (p_name, p_sched, p_cmd) RETURNING jobid INTO v;
+  RETURN v;
+END $f$;
+
+-- roles que a migration revoga por NOME (REVOKE FROM PUBLIC não os alcança)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='anon') THEN CREATE ROLE anon; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated') THEN CREATE ROLE authenticated; END IF;
+END $$;
+
+CREATE TABLE public.omie_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  valor_unitario numeric, ativo boolean, descricao text, codigo text);
+CREATE TABLE public.tint_corantes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  omie_product_id uuid, volume_total_ml numeric, ativo boolean DEFAULT true);
+CREATE TABLE public.tint_subcolecoes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account text NOT NULL DEFAULT 'oben', id_subcolecao_sayersystem text);
+CREATE TABLE public.tint_formulas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  account text NOT NULL DEFAULT 'oben', sku_id uuid, cor_id text, nome_cor text,
+  preco_final_sayersystem numeric, subcolecao_id uuid, personalizada boolean DEFAULT false,
+  updated_at timestamptz DEFAULT now(),
+  desativada_em timestamptz, desativada_motivo text);
+CREATE TABLE public.tint_formula_itens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  formula_id uuid, corante_id uuid, qtd_ml numeric);
+-- os CHECKs REAIS de prod: os dois vocabulários de severidade são DIFERENTES,
+-- e é o que faz o helper derivar um do outro em vez de recebê-los soltos.
+CREATE TABLE public.fin_alertas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  company text NOT NULL, tipo text NOT NULL, severidade text NOT NULL, mensagem text NOT NULL,
+  contexto jsonb, criado_em timestamptz NOT NULL DEFAULT now(),
+  dismissed_at timestamptz, email_enfileirado_em timestamptz,
+  CONSTRAINT fin_alertas_company_check CHECK (company = ANY (ARRAY['oben','colacor','colacor_sc'])),
+  CONSTRAINT fin_alertas_severidade_check CHECK (severidade = ANY (ARRAY['info','aviso','critico'])));
+CREATE UNIQUE INDEX fin_alertas_unique_ativo ON public.fin_alertas (company, tipo) WHERE dismissed_at IS NULL;
+CREATE TABLE public.fornecedor_alerta (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text, tipo text, severidade text, titulo text, mensagem text, status text,
+  criado_em timestamptz DEFAULT now(),
+  CONSTRAINT fornecedor_alerta_severidade_check CHECK (severidade = ANY (ARRAY['info','atencao','urgente'])),
+  CONSTRAINT fornecedor_alerta_status_check CHECK (status = ANY (ARRAY['pendente_notificacao','notificado','falha_notificacao','ignorado'])),
+  CONSTRAINT fornecedor_alerta_tipo_check CHECK (tipo = ANY (ARRAY['promocao_suspensa','aumento_anunciado','promocao_nova','polling_erro','mapeamento_pendente','oportunidade_calculada','tarefa_atrasada','whatsapp_sla','erro_app','outro','param_auto_resumo','reposicao_pedido_minimo'])));
+CREATE TABLE public.sync_state (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type text NOT NULL, account text NOT NULL DEFAULT 'vendas',
+  last_sync_at timestamptz, status text DEFAULT 'idle', error_message text,
+  metadata jsonb DEFAULT '{}'::jsonb, created_at timestamptz DEFAULT now(), updated_at timestamptz DEFAULT now());
+CREATE UNIQUE INDEX sync_state_entity_account_uq ON public.sync_state (entity_type, account);
+
+-- a função do PR 1: a migration desta camada faz REVOKE nela (correção do furo
+-- anon=X medido em prod). Sem ela existir, o REVOKE aborta a migration inteira.
+CREATE OR REPLACE FUNCTION public.tint_watchdog_corante_check() RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public','pg_temp'
+AS $f$ BEGIN RETURN; END $f$;
+GRANT EXECUTE ON FUNCTION public.tint_watchdog_corante_check() TO anon, authenticated;
+SQL
+
+# ── a VIEW REAL, extraída da última migration que a define (não um stub) ──
+VIEWSQL="/tmp/_f5wd_view.sql"
+python3 - "$REPO_ROOT" "$VIEWSQL" <<'PY'
+import sys, os, re, glob
+repo, dst = sys.argv[1], sys.argv[2]
+ANCORA = "CREATE OR REPLACE VIEW public.v_tint_formula_canonica"
+cands = sorted(f for f in glob.glob(os.path.join(repo, "supabase/migrations/*.sql"))
+               if ANCORA in open(f).read())
+if not cands:
+    sys.stderr.write("nenhuma migration define a view\n"); sys.exit(3)
+src = cands[-1]                      # a mais recente por ordem lexical = a de prod
+s = open(src).read()
+i = s.index(ANCORA)
+seg = s[i:]
+j = seg.index("SELECT")
+m = re.search(r";\s*\n", seg[j:])    # fecha no 1o ';' após o corpo
+if not m:
+    sys.stderr.write("nao achei o fim do CREATE VIEW\n"); sys.exit(3)
+open(dst, "w").write(seg[: j + m.end()])
+sys.stderr.write("view extraida de %s\n" % os.path.basename(src))
+PY
+P -q -f "$VIEWSQL"
+echo "=== view real aplicada ==="
+
+# ══ ZONA 2 — a migration REAL (Lei #1: nunca um stub da lógica) ══
+MIG="$REPO_ROOT/supabase/migrations/20260730120000_tint_watchdog_fase5_chave.sql"
+[ -f "$MIG" ] || { echo "migration nao encontrada: $MIG"; exit 1; }
+P -q -f "$MIG"
+echo "=== migration aplicada ==="
+
+P -q -c "CREATE TABLE _bkp AS SELECT pg_get_functiondef('public.tint_watchdog_fase5_check()'::regprocedure) AS def;"
+restaura() { Pq -c "SELECT def FROM _bkp;" > /tmp/_f5wd_real.sql; P -q -f /tmp/_f5wd_real.sql; }
+
+# ══ ZONA 3 — seeds ══
+# Cada chave (account, sku_id, cor_id) tem a '1' CARIMBADA pela Fase 5 + uma SL.
+#   K1 SAUDAVEL  : SL ativa e válida                      -> nunca alarma
+#   K2 DEGRADADA : alavanca de S1 (chave sem preço)
+#   K3 RETIRADA  : alavanca de S2 (a fonte tira a SL)
+#   K4 FALLBACK  : SL ativa INVÁLIDA + outra ativa VÁLIDA -> não conta (precisão)
+#   +1000 chaves BULK saudáveis: massa para a severidade (>=1000) e para o 1%
+#   do vigia de cardinalidade.
+P -q <<'SQL'
+INSERT INTO public.omie_products (id, valor_unitario, ativo, descricao) VALUES
+ ('a0000000-0000-0000-0000-0000000000ff', 600, true, 'CONCENTRADO OK'),
+ ('a0000000-0000-0000-0000-0000000000bb', 0,   true, 'CONCENTRADO SEM CUSTO');
+INSERT INTO public.tint_corantes (id, omie_product_id, volume_total_ml) VALUES
+ ('c0000000-0000-0000-0000-0000000000ff','a0000000-0000-0000-0000-0000000000ff', 810),  -- OK
+ ('c0000000-0000-0000-0000-0000000000bb','a0000000-0000-0000-0000-0000000000bb', 810);  -- IMPAGÁVEL
+INSERT INTO public.tint_subcolecoes (id, account, id_subcolecao_sayersystem) VALUES
+ ('50000000-0000-0000-0000-0000000000a1', 'oben', 'SL'),
+ ('50000000-0000-0000-0000-0000000000a2', 'oben', '1');
+
+CREATE OR REPLACE FUNCTION _seed_chave(p_n int, p_cor text, p_corante uuid)
+RETURNS void LANGUAGE plpgsql AS $f$
+DECLARE v_sku uuid := ('5c000000-0000-0000-0000-' || lpad(p_n::text, 12, '0'))::uuid;
+        v_leg uuid := ('11000000-0000-0000-0000-' || lpad(p_n::text, 12, '0'))::uuid;
+        v_sl  uuid := ('51000000-0000-0000-0000-' || lpad(p_n::text, 12, '0'))::uuid;
+BEGIN
+  -- a geração '1', CARIMBADA pela Fase 5 (é ela que define o universo vigiado)
+  INSERT INTO public.tint_formulas (id, account, sku_id, cor_id, subcolecao_id,
+                                    preco_final_sayersystem, desativada_em, desativada_motivo)
+  VALUES (v_leg, 'oben', v_sku, p_cor, '50000000-0000-0000-0000-0000000000a2',
+          100, now(), 'fase5_geracao_legada');
+  -- a gêmea SL que a substituiu
+  INSERT INTO public.tint_formulas (id, account, sku_id, cor_id, subcolecao_id,
+                                    preco_final_sayersystem)
+  VALUES (v_sl, 'oben', v_sku, p_cor, '50000000-0000-0000-0000-0000000000a1', 120);
+  INSERT INTO public.tint_formula_itens (formula_id, corante_id, qtd_ml)
+  VALUES (v_sl, p_corante, 10);
+END $f$;
+
+-- DO $$..$$ em vez de SELECT solto: PERFORM não devolve linha, e 1004 tabelas de
+-- retorno vazias no log só atrapalham a leitura dos asserts.
+DO $$ BEGIN
+  PERFORM _seed_chave(1, 'COR1', 'c0000000-0000-0000-0000-0000000000ff');  -- K1
+  PERFORM _seed_chave(2, 'COR2', 'c0000000-0000-0000-0000-0000000000ff');  -- K2
+  PERFORM _seed_chave(3, 'COR3', 'c0000000-0000-0000-0000-0000000000ff');  -- K3
+  PERFORM _seed_chave(4, 'COR4', 'c0000000-0000-0000-0000-0000000000bb');  -- K4: SL INVÁLIDA
+END $$;
+
+-- K4 ganha uma SEGUNDA ativa, não-SL, com receita VÁLIDA: é o fallback que mantém
+-- a chave precificável. rank 1 (válida não-SL) < rank 2 (SL sem corantes_ok), logo
+-- ela vence a disputa de canônica e a chave NÃO entra em S1.
+INSERT INTO public.tint_formulas (id, account, sku_id, cor_id, subcolecao_id, preco_final_sayersystem)
+VALUES ('52000000-0000-0000-0000-000000000004', 'oben',
+        '5c000000-0000-0000-0000-000000000004', 'COR4', NULL, 130);
+INSERT INTO public.tint_formula_itens (formula_id, corante_id, qtd_ml)
+VALUES ('52000000-0000-0000-0000-000000000004', 'c0000000-0000-0000-0000-0000000000ff', 10);
+
+-- 1000 chaves BULK saudáveis
+DO $$ DECLARE g int; BEGIN
+  FOR g IN 1001..2000 LOOP
+    PERFORM _seed_chave(g, 'BULK' || g, 'c0000000-0000-0000-0000-0000000000ff');
+  END LOOP;
+END $$;
+SQL
+
+# ── alavancas de estado ──
+CO_OK='c0000000-0000-0000-0000-0000000000ff'
+CO_RUIM='c0000000-0000-0000-0000-0000000000bb'
+SL2='51000000-0000-0000-0000-000000000002'
+SL3='51000000-0000-0000-0000-000000000003'
+SL_BULK1='51000000-0000-0000-0000-000000001001'
+FALLBACK4='52000000-0000-0000-0000-000000000004'
+
+degrada()       { P -q -c "UPDATE public.tint_formula_itens SET corante_id='$CO_RUIM' WHERE formula_id='$1';"; }
+sara()          { P -q -c "UPDATE public.tint_formula_itens SET corante_id='$CO_OK'  WHERE formula_id='$1';"; }
+retira_fonte()  { P -q -c "UPDATE public.tint_formulas SET desativada_em=now(), desativada_motivo=NULL WHERE id='$1';"; }
+devolve_fonte() { P -q -c "UPDATE public.tint_formulas SET desativada_em=NULL WHERE id='$1';"; }
+degrada_bulk()  { P -q -c "UPDATE public.tint_formula_itens SET corante_id='$CO_RUIM' WHERE formula_id IN (SELECT id FROM public.tint_formulas WHERE cor_id LIKE 'BULK%' AND subcolecao_id='50000000-0000-0000-0000-0000000000a1');"; }
+sara_bulk()     { P -q -c "UPDATE public.tint_formula_itens SET corante_id='$CO_OK'  WHERE formula_id IN (SELECT id FROM public.tint_formulas WHERE cor_id LIKE 'BULK%' AND subcolecao_id='50000000-0000-0000-0000-0000000000a1');"; }
+# encolhe/restaura o UNIVERSO carimbado — 50 de 1004 chaves = ~5% (limiar é 1%)
+encolhe_universo()  { P -q -c "UPDATE public.tint_formulas SET desativada_motivo='limpo_manualmente' WHERE id IN (SELECT id FROM public.tint_formulas WHERE desativada_motivo='fase5_geracao_legada' ORDER BY id LIMIT 50);"; }
+restaura_universo() { P -q -c "UPDATE public.tint_formulas SET desativada_motivo='fase5_geracao_legada' WHERE desativada_motivo='limpo_manualmente';"; }
+
+reset_estado() { P -q -c "DELETE FROM public.fin_alertas; DELETE FROM public.fornecedor_alerta; DELETE FROM public.sync_state;"; }
+# >/dev/null: sem isso cada ciclo cospe a tabela de retorno do SELECT e afoga os
+# asserts no log — e evidência que não se lê não é evidência.
+roda()         { Pq -c "SELECT public.tint_watchdog_fase5_check();" >/dev/null; }
+ativos()       { Pq -c "SELECT count(*) FROM public.fin_alertas WHERE tipo='$1' AND dismissed_at IS NULL;"; }
+sev()          { Pq -c "SELECT COALESCE(max(severidade),'AUSENTE') FROM public.fin_alertas WHERE tipo='$1' AND dismissed_at IS NULL;"; }
+emails()       { Pq -c "SELECT count(*) FROM public.fornecedor_alerta WHERE titulo LIKE '%$1%';"; }
+marcador()     { Pq -c "SELECT COALESCE(max(status),'AUSENTE') FROM public.sync_state WHERE entity_type='tint_watchdog_fase5';"; }
+meta()         { Pq -c "SELECT COALESCE(metadata->>'$1','AUSENTE') FROM public.sync_state WHERE entity_type='tint_watchdog_fase5';"; }
+
+# ══ ZONA 4 — a suíte ══
+roda_suite() {
+  PASS=0; FAIL=0; FALHAS=()
+
+  # ── B1/B2: tudo saudável -> silêncio, e o marcador avança
+  reset_estado
+  roda
+  eq "B1 saudavel nao alarma S1" "$(ativos tint_fase5_chave_sem_preco)" "0"
+  eq "B2 marcador avanca em sucesso completo" "$(marcador)" "complete"
+
+  # ── B13: K4 tem SL INVÁLIDA mas outro fallback válido. Medir só o silêncio aqui
+  #    não distingue "o fallback segurou" de "nada foi avaliado" — então a prova é
+  #    POSITIVA: tira o fallback e a mesma chave TEM de passar a contar.
+  eq "B13a chave com fallback valido nao conta" "$(meta chaves_sem_preco)" "0"
+  P -q -c "UPDATE public.tint_formulas SET desativada_em=now() WHERE id='$FALLBACK4';"
+  roda
+  eq "B13b sem o fallback a mesma chave conta" "$(meta chaves_sem_preco)" "1"
+  P -q -c "UPDATE public.tint_formulas SET desativada_em=NULL WHERE id='$FALLBACK4';"
+  roda
+
+  # ── B3/B4: a SL de K2 perde o corante -> a chave deixa de precificar
+  # B4 mede o DELTA, não o acumulado: o B13b acima é uma transição ok->degradado
+  # legítima e já enfileirou o e-mail dela. Contar desde o reset atribuiria os dois
+  # e-mails a esta transição e mediria "quantos incidentes houve na suíte", não
+  # "esta transição emitiu e-mail" — o assert perderia o alvo.
+  local e0; e0="$(emails 'chaves da Fase 5 sem preco')"
+  degrada "$SL2"
+  roda
+  eq "B3 chave sem preco alarma" "$(ativos tint_fase5_chave_sem_preco)" "1"
+  eq "B4 e-mail S1 enfileirado" "$(( $(emails 'chaves da Fase 5 sem preco') - e0 ))" "1"
+
+  # ── B6/B7: a fonte retira K3 COM o alerta de S1 aberto. No mesmo tipo, o
+  #    ON CONFLICT DO NOTHING silenciaria um dos dois (o achado [P1] do Codex).
+  retira_fonte "$SL3"
+  roda
+  eq "B6 fonte retirada alarma em tipo proprio" "$(ativos tint_fase5_fonte_retirada)" "1"
+  eq "B7 S1 e S2 coexistem sem se silenciar" "$(ativos tint_fase5_chave_sem_preco)" "1"
+
+  # ── B9: S1 piora (1 -> 2 chaves) com o alerta já aberto -> re-emite
+  degrada "$SL_BULK1"
+  roda
+  eq "B9 agravamento re-emite e-mail" "$(emails 'AGRAVOU')" "1"
+
+  # ── B8: tudo volta -> dismiss dos dois
+  sara "$SL2"; sara "$SL_BULK1"; devolve_fonte "$SL3"
+  roda
+  eq "B8a dismiss de S1 ao voltar a zero" "$(ativos tint_fase5_chave_sem_preco)" "0"
+  eq "B8b dismiss de S2 ao voltar a zero" "$(ativos tint_fase5_fonte_retirada)" "0"
+
+  # ── B5: 1000 chaves degradadas de uma vez -> severidade critica
+  degrada_bulk
+  roda
+  eq "B5 severidade escala para critico" "$(sev tint_fase5_chave_sem_preco)" "critico"
+  sara_bulk
+  roda
+
+  # ── B10: o universo carimbado encolhe ~5% (limpeza do carimbo)
+  encolhe_universo
+  roda
+  eq "B10 encolhimento do universo alarma" "$(ativos tint_fase5_universo_encolheu)" "1"
+
+  # ── B11: o founder DISPENSA (aceitou o patamar novo) -> re-ancora e silencia,
+  #    senão o alerta ficaria imortal e treinaria o founder a ignorar alertas.
+  P -q -c "UPDATE public.fin_alertas SET dismissed_at=now() WHERE tipo='tint_fase5_universo_encolheu' AND dismissed_at IS NULL;"
+  roda
+  eq "B11 dismiss manual re-ancora e silencia" "$(ativos tint_fase5_universo_encolheu)" "0"
+
+  # ── B12: o universo VOLTA (auto-dismiss) e encolhe de novo -> tem de alarmar
+  #    outra vez. Se o auto-dismiss contasse como aceite manual, ficaria mudo.
+  restaura_universo
+  roda
+  encolhe_universo
+  roda
+  eq "B12 auto-dismiss nao vira aceite manual" "$(ativos tint_fase5_universo_encolheu)" "1"
+  restaura_universo
+  roda
+
+  # ── B14: com o lock tomado por outra sessão, a função SAI sem avançar o marcador
+  P -q -c "DELETE FROM public.sync_state WHERE entity_type='tint_watchdog_fase5';"
+  "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -q -c \
+    "BEGIN; SELECT pg_advisory_xact_lock(hashtext('tint_watchdog_fase5')); SELECT pg_sleep(6); COMMIT;" \
+    >/dev/null 2>&1 &
+  local lockpid=$!
+  sleep 2
+  roda
+  eq "B14 lock tomado -> nao avanca o marcador" "$(marcador)" "AUSENTE"
+  wait "$lockpid" 2>/dev/null || true
+}
+
+echo "=== BASELINE (migration real) ==="
+roda_suite
+BASE_PASS=$PASS; BASE_FAIL=$FAIL
+echo "--- baseline: $BASE_PASS ok / $BASE_FAIL falhas ---"
+if [ "$BASE_FAIL" -ne 0 ]; then
+  echo "BASELINE VERMELHO — a migration real nao passa. Falhas: ${FALHAS[*]}"
+  exit 1
+fi
+echo "TOTAL_ASSERTS=$BASE_PASS"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# FALSIFICAÇÃO (Lei #3) — sabota a migration em UM ponto e exige o conjunto
+# EXATO de asserts vermelhos. "Falsificação prova que o assert tem dente; só
+# instrumentar o RESULTADO prova que ele é ESPECÍFICO" (lição #1505).
+# Cada sabotagem PROVA QUE APLICOU antes de medir — senão "não casou nada" se
+# leria como "o assert não tem dente".
+# ══════════════════════════════════════════════════════════════════════════════
+FALSIF_ERR=0
+
+sabota_e_mede() {   # $1=rotulo  $2=busca  $3=troca  $4..=asserts esperados
+  local rot="$1" busca="$2" troca="$3"; shift 3
+  local esperado="$*"
+  local sab="/tmp/_f5wd_sab_${rot}.sql"
+
+  python3 - "$MIG" "$sab" "$busca" "$troca" <<'PY'
+import sys
+src, dst, busca, troca = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+s = open(src).read()
+n = s.count(busca)
+if n != 1:
+    sys.stderr.write("ANCORA NAO UNICA (%d ocorrencias)\n" % n); sys.exit(3)
+open(dst, "w").write(s.replace(busca, troca))
+PY
+  if [ $? -ne 0 ]; then
+    echo "  FALSIF XX  $rot: a sabotagem NAO aplicou (ancora nao casou) — INVALIDA, nao leia como 'sem dente'"
+    FALSIF_ERR=$((FALSIF_ERR+1)); return
+  fi
+  if ! command grep -q -- "$troca" "$sab"; then
+    echo "  FALSIF XX  $rot: texto sabotado ausente no arquivo — INVALIDA"
+    FALSIF_ERR=$((FALSIF_ERR+1)); return
+  fi
+
+  P -q -f "$sab" >/dev/null 2>&1
+  roda_suite > /tmp/_f5wd_suite.log 2>&1
+
+  local caidos=""
+  if [ "${#FALHAS[@]}" -gt 0 ]; then
+    for f in "${FALHAS[@]}"; do caidos="$caidos $(printf '%s' "$f" | awk '{print $1}')"; done
+  fi
+  caidos="$(printf '%s' "$caidos" | tr ' ' '\n' | command grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+  local esp="$(printf '%s' "$esperado" | tr ' ' '\n' | command grep -v '^$' | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+
+  if [ "$caidos" = "$esp" ]; then
+    echo "  FALSIF OK  $rot derrubou EXATAMENTE [$caidos]"
+  else
+    echo "  FALSIF XX  $rot: esperado [$esp], veio [$caidos]"
+    FALSIF_ERR=$((FALSIF_ERR+1))
+  fi
+  restaura
+}
+
+echo "=== FALSIFICACOES ==="
+
+# F1 — o anti-join deixa de exigir receita_valida: qualquer canônica, mesmo sem
+#      preço, passa a "cobrir" a chave. S1 fica CEGO.
+#      Conjunto MAIOR que {B3}: sem S1 não há e-mail (B4), nem agravamento (B9),
+#      nem escalada de severidade (B5), e B13b (a chave passa a contar quando o
+#      fallback some) também morre. Declarado como MEDIDO — prever {B3} e
+#      "consertar" o harness para casar seria repintar de verde uma sabotagem que
+#      morde mais fundo.
+sabota_e_mede "F1" \
+  "    SELECT account, sku_id, cor_id
+      FROM v_tint_formula_canonica
+     WHERE receita_valida" \
+  "    SELECT account, sku_id, cor_id
+      FROM v_tint_formula_canonica
+     WHERE true" \
+  B13b B3 B4 B5 B7 B9
+# ^ B7 entra por CASCATA LOGICA de uma sabotagem so: F1 cega o S1, e B7 afirma que
+#   S1 e S2 COEXISTEM sem se silenciar — sem S1 detectado, B7 nao tem como valer.
+#   Declarado como MEDIDO (a previsao de 5 asserts e que estava incompleta): reduzir
+#   a sabotagem para casar a previsao esconderia que ela morde mais fundo.
+
+# F2 — junta as DUAS classes no MESMO tipo: é literalmente o desenho que o Codex
+#      REPROVOU. O ON CONFLICT DO NOTHING faz a 2a classe ficar muda.
+sabota_e_mede "F2" \
+  "v_conta, 'tint_fase5_fonte_retirada', v_s2," \
+  "v_conta, 'tint_fase5_chave_sem_preco', v_s2," \
+  B6
+
+# F3 — mata o vigia de cardinalidade: o universo pode sumir sem ninguém saber
+#      (o "verde por vacuidade" que o Codex apontou).
+sabota_e_mede "F3" \
+  "IF v_max > 0 AND v_queda >= 0.01 THEN" \
+  "IF false THEN" \
+  B10 B12
+
+# F4 — grava o marcador sob outro nome: o dead-man cruzado que o PR 1 já tem em
+#      prod continuaria inerte, e "sem alerta" seguiria indistinguível de "morto".
+#      Derruba também B13a/B13b, que leem o metadata DESSE marcador.
+sabota_e_mede "F4" \
+  "VALUES ('tint_watchdog_fase5', v_conta, now(), 'complete', NULL," \
+  "VALUES ('tint_watchdog_NOME_ERRADO', v_conta, now(), 'complete', NULL," \
+  B2 B10 B12 B13a B13b
+# ^ B10/B12 entram por CASCATA: o high-water-mark (universo_max/ancora_em) e LIDO do
+#   MESMO marcador sync_state que a sabotagem renomeia. Sem marcador, v_max=0, a
+#   guarda `v_max > 0` nunca passa e o vigia de cardinalidade fica mudo. Ou seja: o
+#   marcador nao e so telemetria do dead-man — e ESTADO do qual S3 depende. Medido,
+#   nao previsto; declarado como medido.
+
+# ══ fecho: re-roda a suíte na versão REAL e exige verde ══
+echo "=== VERIFICACAO FINAL (migration real restaurada) ==="
+roda_suite
+echo "--- final: $PASS ok / $FAIL falhas | falsificacoes invalidas/erradas: $FALSIF_ERR ---"
+if [ "$FAIL" -ne 0 ] || [ "$FALSIF_ERR" -ne 0 ]; then
+  echo "RESULTADO: VERMELHO"
+  exit 1
+fi
+echo "RESULTADO: VERDE — $PASS asserts + 4 falsificacoes com conjunto exato"

--- a/supabase/migrations/20260730120000_tint_watchdog_fase5_chave.sql
+++ b/supabase/migrations/20260730120000_tint_watchdog_fase5_chave.sql
@@ -1,0 +1,379 @@
+-- ═══════════════════════════════════════════════════════════════════════════
+-- Tintométrico — WATCHDOG da Fase 5, Camada B: a CHAVE carimbada sem preço
+-- (Fase 5b#2, PR 2 de 2 — spec docs/superpowers/specs/2026-07-22-tint-fase5-watchdog-design.md)
+--
+-- POR QUE EXISTE. A Fase 5 (20260727120000) desativou 463.995 fórmulas da geração
+-- '1' porque cada chave (account, sku_id, cor_id) tinha gêmea SL ATIVA E VÁLIDA.
+-- Os guards provaram isso NO INSTANTE DO APPLY — a propriedade NÃO É DURÁVEL.
+-- O PR 1 (20260727150000) vigia a CAUSA-RAIZ dominante (corante impagável, 14
+-- linhas, 214ms, */5). Esta camada vigia o EFEITO, com fidelidade ao que o balcão
+-- lê: a chave que ficou sem NENHUMA fórmula precificável.
+--
+-- POR QUE AS DUAS. A Camada A não vê receita corrompida numa fórmula isolada nem
+-- chave retirada pela fonte; a B só detectaria a avalanche na varredura seguinte e
+-- ignora dano fora do tombstone. São complementares, com funções e crons PRÓPRIOS
+-- (Codex [P1]: "A e B no mesmo job = dependência de falha").
+--
+-- ORÁCULO = a própria v_tint_formula_canonica, não uma reimplementação do
+-- predicado. (i) É o que o balcão lê, então mede o dano REAL em vez de um proxy;
+-- (ii) precisão > recall — não alarma se a chave tiver outro fallback válido;
+-- (iii) o predicado de validade já vive em 2 lugares (a view e a migration da Fase
+-- 5); uma TERCEIRA cópia é exatamente o acoplamento da lição §9 do money-path.
+--
+-- NAO vive no _data_health_compute, e não é preferência: authenticated tem
+-- statement_timeout=8s e o dashboard /health chama get_data_health() -> o compute
+-- (useDataHealth.ts:21, repetido pelo DataHealthBadge). SECURITY DEFINER troca
+-- privilégio, NAO o statement_timeout. Esta varredura custa ~53s: ali derrubaria o
+-- dashboard para todo mundo. Este cron roda como supabase_admin (timeout 0).
+--
+-- ── A FORMA DA QUERY É PARTE DO DESENHO (medido em prod 2026-07-23) ──
+-- A formulação óbvia — `NOT EXISTS (SELECT 1 FROM v_tint_formula_canonica v WHERE
+-- v.account=... AND v.receita_valida)` correlacionado por chave — NAO TERMINOU em
+-- 180s: são 464k avaliações de uma view que já é cara. A forma abaixo (agregação
+-- + LEFT JOIN anti-join, materializando a view UMA vez) mede 52,7s. Não troque uma
+-- pela outra "por legibilidade": a primeira não roda.
+--
+-- ── AS DUAS CLASSES SÃO DISJUNTAS, E ISSO É O ACHADO [P1] DO CODEX ──
+-- Partição por "a chave ainda existe na fonte?":
+--   S1 tem linha ATIVA e nenhuma canônica válida -> a chave existe e NAO PRECIFICA.
+--      Dano de venda real. Remediação: consertar corante/receita.
+--   S2 não tem linha ativa nenhuma -> a FONTE retirou a chave e o tombstone da '1'
+--      ficou órfão (o writer tint_apply_keys_snapshot desativa a SL sem setar
+--      desativada_motivo). Higiene, não venda perdida. Remediação: recarimbar (5b#1).
+-- Juntar as duas no MESMO tipo as silencia pelo ON CONFLICT DO NOTHING: com ~30
+-- retiradas/dia o alerta nunca voltaria a zero, e a degradação real (S1) ficaria
+-- MUDA atrás de um alerta cronicamente aberto de S2. Daí tipos separados.
+--
+-- ── Achados do challenge Codex (gpt-5.6-sol, 2026-07-22) endereçados aqui ──
+--  [P0] "B diária deixa a avalanche invisível por 24h" -> 6h, não diária.
+--  [P1] "classes distintas no mesmo tipo se silenciam"  -> tipos separados (acima).
+--  [P1] "A e B no mesmo job"                            -> função e cron PRÓPRIOS.
+--  [P1] "sem last_success_at, ausência de alerta não é saúde" -> marcador
+--       sync_state tint_watchdog_fase5, que só avança em sucesso COMPLETO. É o
+--       marcador que o dead-man cruzado do PR 1 JA espera (>13h => alerta
+--       tint_watchdog_fase5_parado): esta migration ATIVA uma vigilância que já
+--       está em prod, hoje inerte por ausência do marcador.
+--  [P1] "carimbo não é fundamento durável: delete/limpeza fazem o universo sumir
+--       => zero => verde"                               -> S3, vigia de
+--       CARDINALIDADE do universo (substituto barato do ledger, que fica p/ v2).
+--  [P2] "falta política de agravamento"                 -> severidade escala com a
+--       contagem, e um conjunto que PIORA re-emite e-mail em vez de ficar mudo.
+--
+-- LIMITE CONHECIDO (registrado, não corrigido): os dois oráculos compartilham a
+-- definição de validade, logo não são independentes — Codex [P2], aceito.
+-- E `base_disponivel` fica FORA do gatilho de propósito: 296.536 das carimbadas
+-- (64%) já tinham base indisponível ANTES da Fase 5; incluí-la produziria 296k
+-- alertas no dia 1 sobre condição pré-existente (o watchdog nasceria como ruído).
+--
+-- Prova: db/test-tint-fase5-watchdog.sh (PG17, migration REAL, view REAL, falsificação).
+-- ═══════════════════════════════════════════════════════════════════════════
+
+BEGIN;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- Helper de TRANSIÇÃO de alerta — uma cópia para os 3 sinais.
+-- O PR 1 tem essa lógica inline porque tinha um sinal só; aqui são três, e três
+-- cópias divergiriam. Encapsula o ciclo completo: abre / agrava+re-emite / dismissa.
+-- `_n` no contexto é a grandeza comparável entre ciclos (é o que define "piorou").
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public._tint_watchdog_fase5_transicao(
+  p_company  text,
+  p_tipo     text,
+  p_n        bigint,   -- 0 => estado saudável => dismiss
+  p_sev      text,     -- 'info' | 'aviso' | 'critico'  (CHECK de fin_alertas)
+  p_titulo   text,
+  p_msg      text,
+  p_ctx      jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_ant      bigint;
+  -- fornecedor_alerta tem CHECK próprio e vocabulário DIFERENTE de fin_alertas
+  -- (info/atencao/urgente vs info/aviso/critico). Derivar aqui, em vez de passar
+  -- como parâmetro, elimina o modo de falha "severidade inválida derruba o cron".
+  v_sev_forn text := CASE p_sev WHEN 'critico' THEN 'urgente'
+                                WHEN 'aviso'   THEN 'atencao'
+                                ELSE 'info' END;
+BEGIN
+  IF p_n <= 0 THEN
+    UPDATE fin_alertas SET dismissed_at = now()
+     WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL;
+    RETURN;
+  END IF;
+
+  INSERT INTO fin_alertas (company, tipo, severidade, mensagem, contexto)
+  VALUES (p_company, p_tipo, p_sev, p_msg,
+          p_ctx || jsonb_build_object('_n', p_n, 'avaliado_em', now()))
+  ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+
+  IF FOUND THEN
+    INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+    VALUES (p_company, 'outro', v_sev_forn, p_titulo, p_msg, 'pendente_notificacao');
+    RETURN;
+  END IF;
+
+  -- Alerta já aberto. Com ON CONFLICT DO NOTHING puro, uma PIORA durante um
+  -- incidente aberto ficaria MUDA (Codex [P1]). Se o conjunto cresceu, atualiza o
+  -- alerta e re-enfileira o e-mail.
+  SELECT COALESCE((contexto->>'_n')::bigint, 0) INTO v_ant
+    FROM fin_alertas
+   WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL;
+
+  IF p_n > COALESCE(v_ant, 0) THEN
+    UPDATE fin_alertas
+       SET severidade = p_sev,
+           mensagem   = p_msg,
+           contexto   = p_ctx || jsonb_build_object('_n', p_n, 'avaliado_em', now(),
+                                                    'agravou_de', v_ant)
+     WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL;
+
+    INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+    VALUES (p_company, 'outro', v_sev_forn, 'AGRAVOU: ' || p_titulo,
+            p_msg || E'\n\n(agravamento: eram ' || v_ant || ')', 'pendente_notificacao');
+  END IF;
+END;
+$function$;
+
+COMMENT ON FUNCTION public._tint_watchdog_fase5_transicao(text,text,bigint,text,text,text,jsonb) IS
+  'Privada da Camada B (Fase 5b#2 PR 2): ciclo de vida de um alerta fin_alertas + '
+  'e-mail via fornecedor_alerta. n=0 dismissa; n>0 abre, ou RE-EMITE se piorou em '
+  'relação ao contexto->>_n do alerta aberto (ON CONFLICT DO NOTHING sozinho '
+  'silenciaria o agravamento). Deriva a severidade de fornecedor_alerta da de '
+  'fin_alertas — os dois CHECKs têm vocabulários diferentes.';
+
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- A varredura da Camada B.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.tint_watchdog_fase5_check()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  -- tint_watchdog_fase5 guard v1 — MARCADOR do guard anti-rollback. Uma versão
+  -- SUCESSORA que recrie esta função DEVE trocar este marcador (v2, v3...), para que
+  -- re-aplicar ESTA por cima dela ABORTE em vez de revertê-la em silêncio.
+  v_conta      text := 'oben';   -- 100% do catálogo tint é oben (medido)
+  v_t0         timestamptz := clock_timestamp();
+  v_s1         bigint;
+  v_s2         bigint;
+  v_universo   bigint;
+  v_max        bigint;
+  v_ancora     timestamptz;
+  v_dismiss    timestamptz;
+  v_queda      numeric;
+  v_msg        text;
+BEGIN
+  -- Anti-sobreposição. A varredura custa ~53s contra um ciclo de 6h (margem 400x),
+  -- mas um ciclo preso não pode empilhar um segundo por cima. Se já há um rodando,
+  -- SAI SEM avançar o marcador — e é justamente o marcador parado que faz o
+  -- dead-man cruzado do PR 1 alarmar em 13h. Falha aberta vira alerta, não silêncio.
+  IF NOT pg_try_advisory_xact_lock(hashtext('tint_watchdog_fase5')) THEN
+    RETURN;
+  END IF;
+
+  -- ── VARREDURA ÚNICA (ver "A FORMA DA QUERY" no cabeçalho) ───────────────
+  -- Uma passada só produz os 3 sinais: materializar a view duas vezes dobraria o
+  -- custo, e duas varreduras em instantes diferentes poderiam se contradizer.
+  SELECT count(*) FILTER (WHERE k.tem_ativa AND v.account IS NULL),
+         count(*) FILTER (WHERE NOT k.tem_ativa),
+         count(*)
+    INTO v_s1, v_s2, v_universo
+  FROM (
+    -- as chaves carimbadas pela Fase 5, com "ainda existe na fonte?" por agregação
+    SELECT f.account, f.sku_id, f.cor_id,
+           bool_or(f.desativada_em IS NULL AND f.sku_id IS NOT NULL) AS tem_ativa
+      FROM tint_formulas f
+     WHERE (f.account, f.sku_id, f.cor_id) IN (
+             SELECT account, sku_id, cor_id
+               FROM tint_formulas
+              WHERE desativada_motivo = 'fase5_geracao_legada')
+     GROUP BY f.account, f.sku_id, f.cor_id
+  ) k
+  LEFT JOIN (
+    -- o oráculo: o que o balcão consegue precificar hoje
+    SELECT account, sku_id, cor_id
+      FROM v_tint_formula_canonica
+     WHERE receita_valida
+  ) v ON v.account = k.account AND v.sku_id = k.sku_id AND v.cor_id = k.cor_id;
+
+  -- ── S3: CARDINALIDADE do universo (Codex [P1]: o carimbo não é durável) ──
+  -- Sem isto, limpar o carimbo (follow-up 5b#1) ou deletar as linhas esvazia o
+  -- universo, S1 e S2 vão a zero por VACUIDADE, e o watchdog fica "verde" tendo
+  -- perdido a visão. Âncora = maior universo já visto.
+  SELECT COALESCE((metadata->>'universo_max')::bigint, 0),
+         COALESCE((metadata->>'ancora_em')::timestamptz, '-infinity'::timestamptz)
+    INTO v_max, v_ancora
+    FROM sync_state
+   WHERE entity_type = 'tint_watchdog_fase5' AND account = v_conta;
+  v_max    := COALESCE(v_max, 0);
+  v_ancora := COALESCE(v_ancora, '-infinity'::timestamptz);
+
+  -- Um encolhimento DELIBERADO (a limpeza do 5b#1) não pode deixar um alerta preso
+  -- para sempre — alerta imortal treina o founder a ignorar alertas. O dismiss
+  -- MANUAL é o aceite do novo patamar: re-ancora. O auto-dismiss abaixo avança a
+  -- âncora junto, então nunca é lido como aceite manual.
+  SELECT max(dismissed_at) INTO v_dismiss
+    FROM fin_alertas
+   WHERE company = v_conta AND tipo = 'tint_fase5_universo_encolheu'
+     AND dismissed_at IS NOT NULL;
+
+  IF v_dismiss IS NOT NULL AND v_dismiss > v_ancora THEN
+    v_max := v_universo; v_ancora := now();
+  END IF;
+
+  IF v_universo > v_max THEN                    -- high-water-mark sobe sozinho
+    v_max := v_universo; v_ancora := now();
+  END IF;
+
+  v_queda := CASE WHEN v_max > 0
+                  THEN (v_max - v_universo)::numeric / v_max ELSE 0 END;
+
+  -- Limiar de 1%: este sinal é sobre o universo COLAPSAR (o vigia de vacuidade),
+  -- não sobre erosão de unidades. O universo é estático por desenho — nada o
+  -- escreve — então tolerar <1% custa recall irrelevante e compra silêncio.
+  IF v_max > 0 AND v_queda >= 0.01 THEN
+    v_msg := 'Tintometrico/Fase 5: o universo carimbado ENCOLHEU de ' || v_max ||
+             ' para ' || v_universo || ' chaves (' ||
+             round(v_queda * 100, 1) || '%). O watchdog por chave mede sobre esse ' ||
+             'universo: se ele sumir, S1/S2 vao a zero por VACUIDADE e a rede fica ' ||
+             'cega sem nunca ficar vermelha. Se a limpeza foi deliberada (5b#1), ' ||
+             'dispense este alerta que o patamar novo vira a referencia.';
+    PERFORM public._tint_watchdog_fase5_transicao(
+      v_conta, 'tint_fase5_universo_encolheu', v_max - v_universo,
+      CASE WHEN v_universo = 0 OR v_queda >= 0.5 THEN 'critico' ELSE 'aviso' END,
+      '[Tintometrico] universo carimbado da Fase 5 encolheu', v_msg,
+      jsonb_build_object('universo', v_universo, 'universo_max', v_max,
+                         'queda_pct', round(v_queda * 100, 2)));
+  ELSE
+    PERFORM public._tint_watchdog_fase5_transicao(
+      v_conta, 'tint_fase5_universo_encolheu', 0, 'info', '', '', '{}'::jsonb);
+    v_ancora := now();   -- auto-dismiss NAO pode parecer aceite manual
+  END IF;
+
+  -- ── S1: a chave existe e NAO PRECIFICA (dano de venda real) ─────────────
+  IF v_s1 > 0 THEN
+    v_msg := 'Tintometrico: ' || v_s1 || ' chave(s) desativada(s) pela Fase 5 estao ' ||
+             'SEM formula precificavel - a RPC devolve precoFinal NULL (fail-closed) ' ||
+             'e o balcao nao vende essas cores. A geracao 1 que as respaldava ja foi ' ||
+             'desativada e NAO e mais fallback. Causa tipica: corante sem custo Omie ' ||
+             'ou receita corrompida por sync.';
+    PERFORM public._tint_watchdog_fase5_transicao(
+      v_conta, 'tint_fase5_chave_sem_preco', v_s1,
+      CASE WHEN v_s1 >= 1000 THEN 'critico' ELSE 'aviso' END,
+      '[Tintometrico] chaves da Fase 5 sem preco', v_msg,
+      jsonb_build_object('chaves', v_s1, 'universo', v_universo));
+  ELSE
+    PERFORM public._tint_watchdog_fase5_transicao(
+      v_conta, 'tint_fase5_chave_sem_preco', 0, 'info', '', '', '{}'::jsonb);
+  END IF;
+
+  -- ── S2: a FONTE retirou a chave, tombstone órfão (higiene) ──────────────
+  -- Tipo SEPARADO de S1 de propósito: remediação diferente, cadência diferente
+  -- (~30/dia esperados), e no mesmo tipo silenciaria S1 pelo ON CONFLICT.
+  IF v_s2 > 0 THEN
+    v_msg := 'Tintometrico: ' || v_s2 || ' chave(s) carimbada(s) pela Fase 5 nao tem ' ||
+             'mais NENHUMA formula ativa - a fonte retirou a chave e o carimbo da ' ||
+             'geracao 1 ficou orfao (o writer tint_apply_keys_snapshot desativa a SL ' ||
+             'sem setar desativada_motivo). Nao e venda perdida: a cor saiu do ' ||
+             'catalogo. E higiene do carimbo - recarimbar/limpar e o follow-up 5b#1.';
+    PERFORM public._tint_watchdog_fase5_transicao(
+      v_conta, 'tint_fase5_fonte_retirada', v_s2,
+      CASE WHEN v_s2 >= 10000 THEN 'critico'
+           WHEN v_s2 >= 100   THEN 'aviso' ELSE 'info' END,
+      '[Tintometrico] fonte retirou chaves com carimbo da Fase 5', v_msg,
+      jsonb_build_object('chaves', v_s2, 'universo', v_universo));
+  ELSE
+    PERFORM public._tint_watchdog_fase5_transicao(
+      v_conta, 'tint_fase5_fonte_retirada', 0, 'info', '', '', '{}'::jsonb);
+  END IF;
+
+  -- ── MARCADOR DE SUCESSO (Codex [P1]: "verde por construção") ────────────
+  -- last_sync_at = último sucesso COMPLETO. Só chega aqui quem varreu E transicionou
+  -- os 3 alertas; qualquer exceção acima aborta a função e NAO avança o marcador.
+  -- É este marcador que o dead-man cruzado do PR 1 (*/5) vigia: >13h sem sucesso
+  -- => alerta tint_watchdog_fase5_parado. Sem ele, "sem alerta" seria
+  -- indistinguível de "nunca rodou" — que é o modo de falha do vigia silencioso.
+  INSERT INTO sync_state (entity_type, account, last_sync_at, status, error_message, metadata)
+  VALUES ('tint_watchdog_fase5', v_conta, now(), 'complete', NULL,
+          jsonb_build_object('chaves_sem_preco', v_s1, 'fonte_retirada', v_s2,
+                             'universo', v_universo, 'universo_max', v_max,
+                             'ancora_em', v_ancora,
+                             'duracao_s', round(EXTRACT(epoch FROM clock_timestamp() - v_t0)::numeric, 1)))
+  ON CONFLICT (entity_type, account) DO UPDATE
+    SET last_sync_at  = now(),
+        status        = 'complete',
+        error_message = NULL,
+        updated_at    = now(),
+        metadata      = EXCLUDED.metadata;
+END;
+$function$;
+
+COMMENT ON FUNCTION public.tint_watchdog_fase5_check() IS
+  'Fase 5b#2 (PR 2): Camada B do watchdog - vigia a CHAVE carimbada pela Fase 5 que '
+  'ficou sem formula precificavel, usando v_tint_formula_canonica como oraculo (o que '
+  'o balcao le), nao uma 3a copia do predicado de validade. Emite 3 sinais em tipos '
+  'SEPARADOS: chave sem preco (venda perdida), fonte retirada (tombstone orfao) e '
+  'universo encolheu (o carimbo sumiu => risco de verde por vacuidade). Roda 6h '
+  '(~53s). Grava o marcador sync_state tint_watchdog_fase5 que o dead-man cruzado do '
+  'PR 1 vigia. NAO pode migrar para _data_health_compute: authenticated tem '
+  'statement_timeout=8s e o dashboard /health chama aquele caminho.';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- SUPERFÍCIE DE EXECUÇÃO. Função SECURITY DEFINER nasce com EXECUTE para PUBLIC:
+-- exposta como RPC do PostgREST, qualquer anon dispararia uma varredura de 53s
+-- (amplificação de DoS barata) e escreveria em fin_alertas/sync_state.
+-- Medido em prod: tint_watchdog_corante_check (PR 1) está HOJE com anon=X e
+-- authenticated=X — corrigido aqui junto, por REVOKE puro (não recria a função,
+-- logo não colide com o guard anti-rollback dela).
+-- REVOKE FROM PUBLIC NAO tira anon/authenticated (grant explícito) => por nome.
+-- ───────────────────────────────────────────────────────────────────────────
+REVOKE EXECUTE ON FUNCTION public.tint_watchdog_fase5_check()
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public._tint_watchdog_fase5_transicao(text,text,bigint,text,text,text,jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.tint_watchdog_corante_check()
+  FROM PUBLIC, anon, authenticated;
+
+-- Cron SQL-local (roda no Postgres como supabase_admin => statement_timeout=0).
+-- NAO usa net.http_post, então não precisa de timeout_milliseconds; e o
+-- job_run_details aqui carrega o erro plpgsql REAL (cron SQL-local é fonte
+-- primária confiável - docs/agent/sync.md).
+-- 6h, não diária: o Codex reprovou 24h de cegueira ([P0]). cron.schedule faz
+-- upsert por nome => idempotente. O nome bate com o texto do alerta do PR 1.
+SELECT cron.schedule(
+  'tint-watchdog-fase5-6h',
+  '0 */6 * * *',
+  $cron$SELECT public.tint_watchdog_fase5_check();$cron$
+);
+
+COMMIT;
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- VALIDAÇÃO PÓS-APPLY (read-only; o founder cola, ou eu rodo via psql-ro)
+--   1) funções + cron armado:
+--      SELECT to_regprocedure('public.tint_watchdog_fase5_check()') IS NOT NULL AS fn_ok,
+--             (SELECT active FROM cron.job WHERE jobname='tint-watchdog-fase5-6h') AS cron_ativo;
+--   2) anon/authenticated FORA das 3 funções (esperado: 0 linhas):
+--      SELECT p.proname FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+--       WHERE n.nspname='public'
+--         AND p.proname IN ('tint_watchdog_fase5_check','_tint_watchdog_fase5_transicao',
+--                           'tint_watchdog_corante_check')
+--         AND (array_to_string(p.proacl,' ') ~ '(^| )(anon|authenticated)='
+--              OR array_to_string(p.proacl,' ') ~ '(^| )=X');
+--   3) primeira execução (~53s) + marcador (esperado 2026-07-23: 0 / 0 / 463995):
+--      SELECT public.tint_watchdog_fase5_check();
+--      SELECT status, last_sync_at, metadata FROM public.sync_state
+--       WHERE entity_type='tint_watchdog_fase5' AND account='oben';
+--   4) nasce VERDE, e o dead-man cruzado do PR 1 para de ser inerte:
+--      SELECT count(*) FROM public.fin_alertas
+--       WHERE tipo IN ('tint_fase5_chave_sem_preco','tint_fase5_fonte_retirada',
+--                      'tint_fase5_universo_encolheu','tint_watchdog_fase5_parado')
+--         AND dismissed_at IS NULL;   -- esperado 0
+-- ───────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
**PR 2 de 2** do follow-up 5b#2. O [#1577](https://github.com/LucasSardenbergL/afiacao/pull/1577) (Camada A) está no ar desde 23/07 — **jobid 166**, `*/5`, 1.156 execuções sem falha. Esta é a Camada B.

> ⚠️ **Este trabalho foi recuperado.** A sessão que o escreveu produziu migration e harness mas **nunca commitou** — estavam untracked numa worktree. Eu revisei o código, rodei a prova, corrigi 2 falsificações e estou publicando. Crédito do desenho é dela; a verificação é minha.

## O que vigia

O PR 1 pega a **causa-raiz** (corante impagável, 14 linhas, 214ms). Esta pega o **efeito**, com fidelidade ao que o balcão lê: a chave carimbada pela Fase 5 que ficou sem **nenhuma** fórmula precificável. São complementares — A não vê receita corrompida numa fórmula isolada nem chave retirada pela fonte; B só veria a avalanche na varredura seguinte.

**Oráculo = a própria `v_tint_formula_canonica`**, não uma reimplementação. O predicado de validade já vive em 2 lugares; uma terceira cópia é o acoplamento da lição §9 do money-path.

## Três sinais, tipos separados — e a prod validou o achado do Codex

| Sinal | Significado | **Medido em prod hoje** |
|---|---|---|
| `tint_fase5_chave_sem_preco` (S1) | a chave existe e **não precifica** — venda perdida real | **0** |
| `tint_fase5_fonte_retirada` (S2) | a fonte retirou a chave, carimbo órfão — higiene | **300** ⚠️ |
| `tint_fase5_universo_encolheu` (S3) | high-water-mark do universo carimbado | 0 (ancora na 1ª execução) |

**S2 era 0 em 23/07 e hoje é 300** — a fonte retira ~60 chaves/dia. E é isso que torna os tipos separados não-negociáveis: no desenho que o Codex reprovou (S1 e S2 no mesmo tipo), essas 300 chaves de *higiene* manteriam um alerta cronicamente aberto que **silenciaria qualquer venda perdida futura** pelo `ON CONFLICT DO NOTHING`. A produção materializou o modo de falha em 5 dias.

## O marcador ativa uma vigilância que já está em prod

Grava `sync_state` `tint_watchdog_fase5`, que só avança em sucesso **completo**. É exatamente o marcador que o **dead-man cruzado do PR 1 já espera** (>13h sem sucesso → `tint_watchdog_fase5_parado`). Hoje aquela vigilância está inerte por ausência do marcador; aplicar esta migration a liga.

Se o lock anti-sobreposição estiver tomado, a função sai **sem** avançar o marcador — travamento vira alerta em 13h, não silêncio.

## A forma da query é parte do desenho

A formulação óbvia (`NOT EXISTS` correlacionado por chave) **não termina em 180s** — 464k avaliações de uma view cara. A forma usada (agregação + anti-join, materializando a view uma vez) mede **52,3s**, que eu confirmei de forma independente hoje via `psql-ro`. Não troque uma pela outra "por legibilidade": a primeira não roda.

Por isso também **não** pode viver no `_data_health_compute`: `authenticated` tem `statement_timeout=8s` e o dashboard `/health` chama aquele caminho. Este cron roda como `supabase_admin` (timeout 0).

## Prova

`db/test-tint-fase5-watchdog.sh` — PG17, migration REAL, **view real** extraída da migration que a define (stubar o predicado provaria concordância com o stub, não com o balcão):

```
baseline: 16 ok / 0 falhas
FALSIF OK  F1 derrubou EXATAMENTE [B13b B3 B4 B5 B7 B9]
FALSIF OK  F2 derrubou EXATAMENTE [B6]
FALSIF OK  F3 derrubou EXATAMENTE [B10 B12]
FALSIF OK  F4 derrubou EXATAMENTE [B10 B12 B13a B13b B2]
RESULTADO: VERDE — 16 asserts + 4 falsificações com conjunto exato
```

**Duas expectativas corrigidas para o conjunto medido** (a sabotagem morde mais fundo que o previsto — declarar o real é o oposto de repintar de verde):
- **F1** derruba também **B7**: cegar S1 impede provar que "S1 e S2 coexistem".
- **F4** derruba também **B10/B12**: o high-water-mark é lido do **mesmo** marcador que a sabotagem renomeia — o marcador não é só telemetria do dead-man, é **estado** do qual S3 depende.

## ⚠️ Handoff — o que falta você fazer

Cole no **SQL Editor do Lovable**: `supabase/migrations/20260730120000_tint_watchdog_fase5_chave.sql`

**Espere um e-mail logo depois:** `[Tintometrico] fonte retirou chaves com carimbo da Fase 5`, severidade **aviso**, com 300 chaves. É **sinal honesto, não incidente** — não é venda perdida, é o carimbo órfão que o follow-up **5b#1** (recarimbar no promote) resolve. S1, que mede venda perdida de verdade, nasce em **0**.

Depois eu valido via `psql-ro`: função criada, cron `tint-watchdog-fase5-6h` ativo, marcador gravado, e o `tint_watchdog_fase5_parado` do PR 1 dispensado.

## Limites conhecidos (registrados, não corrigidos)

Os dois oráculos compartilham a definição de validade, logo não são independentes (Codex [P2], aceito). `base_disponivel` fica **fora do gatilho** de propósito: 296.536 das carimbadas (64%) já tinham base indisponível **antes** da Fase 5 — incluí-la geraria 296k alertas no dia 1 sobre condição pré-existente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
