### PR TITLE
fix(farmer): a gravação das recomendações de bundle para de falhar calada

### DIFF
--- a/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
+++ b/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Guard — a gravação das recomendações de bundle não pode falhar CALADA.
+ *
+ * Irmão do `bundle-regras-substituicao-atomica.test.tsx` (mesmo hook, mesmo defeito de
+ * classe, outro bloco). Lá o #1574 fechou a substituição de `farmer_association_rules`;
+ * aqui fecha o último escritor do engine que ainda descartava o `error`:
+ *
+ *   for (const cb of allCustomerBundles)
+ *     for (const bundle of cb.bundles)
+ *       await supabase.from('farmer_bundle_recommendations').insert({ … });  // error ignorado
+ *
+ * SEVERIDADE MENOR que a do #1574, de propósito: é INSERT puro, sem DELETE — nada é
+ * destruído. O pior caso é a recomendação não ser gravada enquanto a UI já mostrou o
+ * bundle em memória, então quem lê a TABELA (`OfertaCruaCard`, `useTacticalPlan`) não vê
+ * a oferta que o operador acabou de ver na tela. Divergência silenciosa entre a tela e a
+ * tabela — o operador não tem como saber que precisa recalcular.
+ *
+ * DISCRIMINADOR: nenhum caminho em que o INSERT falha pode terminar em `toast.success`.
+ * O toast já é honesto quanto às REGRAS (`desfechoRegras`, #1574); passa a ser honesto
+ * quanto às RECOMENDAÇÕES pelo mesmo critério.
+ *
+ * Escrito para sobreviver ao #1520 (que troca `m_bundle`/`lie_bundle` por `affinityBundle`
+ * e tira o custo do browser): as asserções olham o TOAST e a CONTAGEM de INSERTs, nunca o
+ * shape do payload; e o cenário alimenta as duas fontes de "SKU vendável" — a tabela
+ * `product_costs` (hoje) e a RPC `get_skus_margem_positiva` (pós-#1520) — de modo que o
+ * mesmo arquivo vale nos dois mundos.
+ */
+const FARMER = 'farmer-real';
+const C1 = 'cliente-1';
+const C2 = 'cliente-2';
+
+type Q = { table: string; metodos: string[]; payloads: unknown[] };
+type ChamadaRpc = { nome: string; args: Record<string, unknown> };
+
+let queries: Q[] = [];
+let rpcs: ChamadaRpc[] = [];
+let insertRecsFalha = false;
+let regrasFalham = false;
+let naLente = false;
+
+const ERRO_INSERT = { code: '23503', message: 'insert or update violates foreign key', details: '', hint: '' };
+const ERRO_RPC = { code: '08006', message: 'connection failure', details: '', hint: '' };
+
+/**
+ * Sete cestas desenhadas para o Apriori achar P1→P2 e P1→P3 acima dos pisos
+ * (minSupport 0.01, minLift 1.05) e para C1/C2 — que só compraram P1 — receberem
+ * o bundle {P2,P3}:
+ *
+ *   itemFreq: P1=4, P2=2, P3=2, P4=3   ·   pair(P1,P2)=pair(P1,P3)=2 de 7 cestas
+ *   lift(P1→P2) = (2/4) / (2/7) = 1.75 ≥ 1.05
+ *
+ * As três cestas de P4 são o RUÍDO que segura o lift acima do piso; sem elas
+ * lift(P1→P2) cai para 1.0 e nenhuma regra nasce.
+ */
+const PEDIDOS = [
+  { customer_user_id: C1, items: [{ product_id: 'P1' }], total: 100, created_at: '2026-07-01T00:00:00Z' },
+  { customer_user_id: C2, items: [{ product_id: 'P1' }], total: 100, created_at: '2026-07-02T00:00:00Z' },
+  { customer_user_id: 'c-outro', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-03T00:00:00Z' },
+  { customer_user_id: 'c-outro', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-04T00:00:00Z' },
+  { customer_user_id: 'c-ruido', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-05T00:00:00Z' },
+  { customer_user_id: 'c-ruido', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-06T00:00:00Z' },
+  { customer_user_id: 'c-ruido', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-07T00:00:00Z' },
+];
+
+const IDS = ['P1', 'P2', 'P3', 'P4'];
+
+const PRODUTOS = IDS.map((id) => ({
+  id, codigo: id, descricao: `Produto ${id}`, valor_unitario: 100,
+  metadata: null, ativo: true, omie_codigo_produto: null,
+}));
+
+/** Custo 40 < preço 100 → margem positiva, o SKU entra no bundle (mundo pré-#1520). */
+const CUSTOS = IDS.map((id) => ({ product_id: id, cost_final: 40, cost_price: 40 }));
+
+/** Mesma informação que os custos acima, na forma que o #1520 passa a usar. */
+const VENDAVEIS = IDS.map((id) => ({ product_id: id }));
+
+const scoreDe = (cid: string) => ({
+  customer_user_id: cid, health_score: 80, answer_rate_60d: 50,
+  whatsapp_reply_rate_60d: 50, avg_monthly_spend_180d: 1000,
+  gross_margin_pct: 30, category_count: 2, days_since_last_purchase: 10,
+});
+
+function dadosDa(tabela: string): unknown[] {
+  switch (tabela) {
+    // Só C1 e C2 pontuam: 'c-outro' já comprou P2 e P3 (nenhuma regra lhe é aplicável)
+    // e 'c-ruido' não tem antecedente. Assim o total de recomendações é exatamente 2.
+    case 'farmer_client_scores': return [scoreDe(C1), scoreDe(C2)];
+    case 'omie_products': return PRODUTOS;
+    case 'product_costs': return CUSTOS;
+    case 'profiles': return [
+      { user_id: C1, name: 'Cliente 1', customer_type: 'moveleiro', cnae: '3101' },
+      { user_id: C2, name: 'Cliente 2', customer_type: 'moveleiro', cnae: '3101' },
+    ];
+    case 'sales_orders': return PEDIDOS;
+    default: return [];
+  }
+}
+
+const ehInsertDeRecomendacao = (q: Q) =>
+  q.table === 'farmer_bundle_recommendations' && q.metodos.includes('insert');
+
+function respostaDe(q: Q) {
+  if (ehInsertDeRecomendacao(q) && insertRecsFalha) return { data: null, error: ERRO_INSERT };
+  return { data: dadosDa(q.table), error: null, count: 0 };
+}
+
+function chain(table: string): unknown {
+  const q: Q = { table, metodos: [], payloads: [] };
+  queries.push(q);
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'eq', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) {
+    c[m] = (arg?: unknown) => {
+      q.metodos.push(m);
+      if (m === 'insert' || m === 'upsert') q.payloads.push(arg);
+      return c;
+    };
+  }
+  c.then = (resolve: (v: unknown) => void) => resolve(respostaDe(q));
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (t: string) => chain(t),
+    rpc: (nome: string, args: Record<string, unknown>) => {
+      rpcs.push({ nome, args });
+      // Pós-#1520 o engine pergunta quais SKUs são vendáveis em vez de baixar custo.
+      if (nome === 'get_skus_margem_positiva') return Promise.resolve({ data: VENDAVEIS, error: null });
+      if (regrasFalham) return Promise.resolve({ data: null, error: ERRO_RPC });
+      return Promise.resolve({ data: 2, error: null });
+    },
+  },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: naLente, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: FARMER }, isStaff: true }) }));
+
+const toastMock = { error: vi.fn(), success: vi.fn(), warning: vi.fn() };
+vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => toastMock.error(...a),
+                                    success: (...a: unknown[]) => toastMock.success(...a),
+                                    warning: (...a: unknown[]) => toastMock.warning(...a) } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import { useBundleEngine } from '../useBundleEngine';
+
+beforeEach(() => {
+  queries = []; rpcs = [];
+  insertRecsFalha = false; regrasFalham = false; naLente = false;
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+const insertsDeRecomendacao = () => queries.filter(ehInsertDeRecomendacao);
+
+/** Linhas efetivamente enviadas, somando lote e chamada-a-chamada. */
+const linhasEnviadas = () =>
+  insertsDeRecomendacao().flatMap((q) => q.payloads.flatMap((p) => (Array.isArray(p) ? p : [p])));
+
+const avisos = () => toastMock.warning.mock.calls.map((c) => String(c[0]));
+
+async function calcular() {
+  const { result } = renderHook(() => useBundleEngine());
+  await act(async () => { await result.current.calculateBundles(); });
+  return result;
+}
+
+describe('useBundleEngine — a gravação das recomendações de bundle não falha calada', () => {
+  it('o cenário gera recomendações (senão os testes abaixo seriam vacuamente verdes)', async () => {
+    const result = await calcular();
+
+    expect(linhasEnviadas()).toHaveLength(2);
+    expect(result.current.customerBundles.length).toBeGreaterThan(0);
+  });
+
+  it('INSERT falhando NÃO emite toast de sucesso — o aviso cita as recomendações', async () => {
+    insertRecsFalha = true;
+    await calcular();
+
+    // O ponto: falhou, então a tela não pode dizer que gravou.
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(toastMock.warning).toHaveBeenCalledTimes(1);
+    // 'recomenda' é ASCII e exclusivo deste ramo: as mensagens de regra falam em
+    // "anteriores seguem valendo" / "preservadas", e a de sucesso em "regras e bundles".
+    expect(avisos()[0]).toContain('recomenda');
+  });
+
+  it('as duas falhas juntas (regras + recomendações) aparecem no MESMO aviso', async () => {
+    regrasFalham = true;
+    insertRecsFalha = true;
+    await calcular();
+
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(toastMock.warning).toHaveBeenCalledTimes(1);
+    expect(avisos()[0]).toContain('recomenda');
+    expect(avisos()[0]).toContain('anteriores seguem valendo');
+  });
+
+  it('grava as recomendações num ÚNICO insert em lote, não uma por vez', async () => {
+    await calcular();
+
+    // As linhas são independentes: N round-trips não compram nada e multiplicam a
+    // janela de falha parcial (ficar com metade das recomendações gravadas).
+    expect(insertsDeRecomendacao()).toHaveLength(1);
+    expect(linhasEnviadas()).toHaveLength(2);
+  });
+
+  it('caminho feliz mantém o toast de sucesso', async () => {
+    await calcular();
+
+    expect(toastMock.success).toHaveBeenCalledTimes(1);
+    expect(toastMock.warning).not.toHaveBeenCalled();
+  });
+
+  it('INSERT falhando não some com os bundles da tela — só a tabela fica para trás', async () => {
+    insertRecsFalha = true;
+    const result = await calcular();
+
+    // A severidade menor deste bug mora aqui: a UI em memória segue correta.
+    expect(result.current.customerBundles.length).toBeGreaterThan(0);
+  });
+
+  it('na lente "Ver como" não grava recomendação nenhuma', async () => {
+    naLente = true;
+    await calcular();
+
+    expect(insertsDeRecomendacao()).toHaveLength(0);
+  });
+});

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -577,37 +577,69 @@ export const useBundleEngine = () => {
 
       // Persist bundle recommendations — PULADO na lente "Ver como" (só leitura: o
       // master inspeciona os bundles do alvo sem regravar a carteira dele).
+      //
+      // UM insert em lote, não um por bundle: as linhas são independentes, então os N
+      // round-trips não compravam atomicidade nenhuma — só multiplicavam a janela de falha
+      // parcial (metade das recomendações gravadas, metade não).
+      //
+      // E o `error` é CAPTURADO. Descartá-lo era o mesmo defeito de classe que o #1574 tirou
+      // do bloco de `farmer_association_rules` logo acima, porém sem DELETE: nada é destruído,
+      // o pior caso é a recomendação não existir na TABELA enquanto a UI já mostrou o bundle
+      // em memória — e quem lê a tabela (`OfertaCruaCard`, `useTacticalPlan`) não vê a oferta
+      // que o operador acabou de ver na tela, sem ninguém ficar sabendo.
+      //
+      // Sem `throw`: os bundles em memória continuam válidos e já foram exibidos; só o toast
+      // final deixa de dizer que deu tudo certo.
+      let recomendacoesNaoGravadas = 0;
       if (!isImpersonating) {
-        for (const cb of allCustomerBundles) {
-          for (const bundle of cb.bundles) {
-            await supabase.from('farmer_bundle_recommendations').insert({
-              farmer_id: effectiveUserId,
-              customer_user_id: bundle.customerId,
-              bundle_products: bundle.products as unknown as Json,
-              support: bundle.support,
-              confidence: bundle.confidence,
-              lift: bundle.lift,
-              p_bundle: bundle.pBundle,
-              m_bundle: bundle.mBundle,
-              lie_bundle: bundle.lieBundle,
-              complexity_factor: bundle.complexityFactor,
-              status: 'pendente',
-            });
+        const recomendacoes = allCustomerBundles.flatMap((cb) =>
+          cb.bundles.map((bundle) => ({
+            farmer_id: effectiveUserId,
+            customer_user_id: bundle.customerId,
+            bundle_products: bundle.products as unknown as Json,
+            support: bundle.support,
+            confidence: bundle.confidence,
+            lift: bundle.lift,
+            p_bundle: bundle.pBundle,
+            m_bundle: bundle.mBundle,
+            lie_bundle: bundle.lieBundle,
+            complexity_factor: bundle.complexityFactor,
+            status: 'pendente',
+          })),
+        );
+
+        if (recomendacoes.length > 0) {
+          const { error: erroRecs } = await supabase
+            .from('farmer_bundle_recommendations')
+            .insert(recomendacoes);
+          if (erroRecs) {
+            console.error('Falha ao gravar farmer_bundle_recommendations:', erroRecs);
+            recomendacoesNaoGravadas = recomendacoes.length;
           }
         }
       }
 
       // O toast reflete o que REALMENTE aconteceu. Antes ele era `success` incondicional —
       // com a persistência falhando calada, o operador via "regras gravadas" e ia embora.
+      // Regras e recomendações falham de forma INDEPENDENTE, então os dois desfechos entram
+      // no mesmo aviso: reportar só um deixaria o outro invisível.
       const totalBundles = allCustomerBundles.reduce((s, c) => s + c.bundles.length, 0);
+      const problemas: string[] = [];
       if (desfechoRegras === 'falhou') {
-        toast.warning(
-          `${totalBundles} bundles gerados, mas as regras NÃO foram salvas — as anteriores seguem valendo`,
-        );
+        problemas.push('as regras NÃO foram salvas — as anteriores seguem valendo');
       } else if (desfechoRegras === 'sem_regras') {
-        toast.warning(
-          `Nenhuma regra atingiu os pisos — as regras anteriores foram preservadas (${totalBundles} bundles)`,
+        problemas.push('nenhuma regra atingiu os pisos — as regras anteriores foram preservadas');
+      }
+      if (recomendacoesNaoGravadas > 0) {
+        problemas.push(
+          recomendacoesNaoGravadas === 1
+            ? '1 recomendação NÃO foi gravada — as telas de oferta seguem com as anteriores'
+            : `${recomendacoesNaoGravadas} recomendações NÃO foram gravadas — as telas de oferta seguem com as anteriores`,
         );
+      }
+
+      if (problemas.length > 0) {
+        toast.warning(`${totalBundles} bundles gerados, mas ${problemas.join('; e ')}`);
       } else {
         toast.success(`${discoveredRules.length} regras e ${totalBundles} bundles gerados`);
       }

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -280,6 +280,7 @@ export const MODULOS: ModuloApp[] = [
     testes: [
       "src/components/intelligence/__tests__/tabs-erro-honesto.test.tsx",
       "src/hooks/__tests__/bundle-escopo-sob-falha.test.tsx",
+      "src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx",
       "src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx",
       "src/hooks/__tests__/cluster-margin-cobertura.test.tsx",
       "src/hooks/__tests__/cluster-margin-paginacao.test.tsx",


### PR DESCRIPTION
## O defeito

O loop final de `useBundleEngine.ts` que insere em `farmer_bundle_recommendations` **descartava o `error`** do Supabase. O toast seguinte já era honesto quanto às REGRAS (`desfechoRegras`, herdado do #1574), mas dizia "N regras e M bundles gerados" mesmo quando nenhuma recomendação chegou à tabela.

Pior caso: a UI mostra o bundle (que existe em memória e já foi renderizado) e a tabela não tem nada. Quem lê a tabela — [`OfertaCruaCard`](src/components/farmer/copilot/OfertaCruaCard.tsx), [`useTacticalPlan`](src/hooks/useTacticalPlan.ts) — **não vê a oferta que o operador acabou de ver na tela**. Divergência silenciosa tela↔tabela, sem ninguém ficar sabendo.

Severidade menor que a do #1574: **não há DELETE aqui** — nada é destruído, só deixa de ser gravado.

## O que muda

1. **captura o `error`** do insert e conta as linhas não gravadas;
2. **o toast passa a ser honesto quanto às RECOMENDAÇÕES** pelo mesmo critério que já era quanto às regras — e como os dois desfechos falham de forma independente, ambos entram no MESMO aviso (reportar só um deixaria o outro invisível);
3. **troca o loop N+1 por um único insert em lote**: as linhas são independentes, então os N round-trips não compravam atomicidade nenhuma — só multiplicavam a janela de falha parcial (metade gravada, metade não).

Sem `throw`: os bundles em memória continuam válidos e já foram exibidos. Só o toast deixa de afirmar que deu tudo certo.

## Passo 0 da `matar-classe` — instância ou classe?

**INSTÂNCIA** de uma classe conhecida: *escrita no Supabase com `error` descartado* (~123 sites no repo). Este é o último escritor do bundle engine que ainda tinha o defeito — o bloco de `farmer_association_rules` logo acima foi corrigido no #1574.

A varredura da classe **não é feita aqui**: tem chip próprio, "**Varrer classe: escrita Supabase com error descartado**". Este PR fecha a instância.

## Teste

`src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx` — 7 asserts, registrado em `src/lib/modulos/manifesto.ts`.

Escrito para **sobreviver ao #1520**: olha o toast e a contagem de inserts, nunca o shape do payload, e alimenta as duas fontes de "SKU vendável" (`product_costs` hoje, a RPC `get_skus_margem_positiva` depois).

**Falsificado em duas dimensões** — a asserção morre quando o defeito volta, e só ela:
- (A) descartar o `error` de novo → só as 2 asserções de toast ficam vermelhas;
- (B) voltar ao N+1 mantendo a captura → só a asserção de lote fica vermelha.

## Gates

Rodados nesta sessão, sobre a base rebaseada final (`5fc28847` sobre `4fc5e518`):

| gate | resultado |
|---|---|
| `bunx vitest run src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx` | **7/7 passed, exit 0** |
| `bun run typecheck` | **exit 0** (log vazio) |
| `bun run lint` | **exit 0** (72 warnings pré-existentes, 0 errors) |

**A suíte completa (`bun run test`, 5705 testes) NÃO foi rodada localmente** — o semáforo `heavy` estava com 14 sessões na fila e não andava. Ela fica com o CI `validate`, que é o gate autoritativo do repo e roda em infra própria. O commit original registra `test 5705/5705 exit 0` da sessão anterior, mas isso é de antes deste rebase — não conto como evidência desta entrega.

*(o `lint` rodou sobre `b9015c29`; o rebase seguinte trouxe só `docs/agent/deploy.md`, que o ESLint não cobre)*

## Por que DRAFT

O #1520 (`fu4f-fase3-product-costs`, também draft) reescreve exatamente o payload deste insert — `m_bundle: null`, `lie_bundle: bundle.affinityBundle`, e tira `cost`/`margin` de `bundle_products`. **Ele voltou a se mexer hoje**, então este PR fica **draft para não disputar a ordem de merge com ele**. Tirar do draft é um clique quando o #1520 se resolver.

Nota para quem resolver o conflito: ele é localizado no bloco do insert, e o #1520 já ia rebasear este arquivo de qualquer forma (o #1574 mexeu em `useBundleEngine.ts` depois do último commit dele). **Se o conflito for resolvido descartando o lado deste PR, o `bundle-recomendacoes-erro-silencioso.test.tsx` fica vermelho no CI** — o teste é o gate que impede o defeito de voltar sem ninguém notar. Ele não olha o shape do payload, então a troca para `affinityBundle` não deve exigir edição nenhuma nele.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
