### PR TITLE
fix(preview): virtual:pwa-register ganha stub fora do PWA — o scan de deps do Vite deixa de abortar e de duplicar o React (tela branca)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
@@ -45,6 +45,34 @@ function buildEnvProbe(): string {
 }
 const commitSha = resolveCommitSha();
 const buildEnvKeys = buildEnvProbe();
+
+// 'virtual:pwa-register' só ganha resolvedor quando o VitePWA está ativo (produção
+// non-preview). Fora dele, o guard `__PWA_ENABLED__` protege o RUNTIME e o BUILD
+// (DCE), mas NÃO o scanner de deps do dev server: o esbuild segue o grafo estático
+// inteiro sem aplicar o DCE do `define`, encontra o virtual órfão em pwa-update.ts
+// e ABORTA o pré-bundle ("imported but could not be resolved") — o _metadata.json
+// nunca nasce, toda dep vira descoberta tardia re-otimizada em voo (?v= muda a cada
+// rodada) e o browser pode misturar gerações: duas cópias de React → dispatcher
+// null ("Cannot read properties of null (reading 'useEffect')") → tela branca no
+// preview do Lovable. O stub dá um resolvedor no-op ao virtual sempre que o plugin
+// real está fora, e o scan completa numa geração única.
+function pwaRegisterStub(): Plugin {
+  const VIRTUAL_ID = "virtual:pwa-register";
+  const RESOLVED_ID = "\0" + VIRTUAL_ID + "-stub";
+  return {
+    name: "pwa-register-stub",
+    resolveId(id) {
+      return id === VIRTUAL_ID ? RESOLVED_ID : undefined;
+    },
+    load(id) {
+      if (id === RESOLVED_ID) {
+        // Mesma forma do registerSW real: retorna um updateSW() assíncrono no-op.
+        return "export const registerSW = () => () => Promise.resolve();";
+      }
+      return undefined;
+    },
+  };
+}
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -272,6 +300,9 @@ export default defineConfig(({ mode }) => ({
         enabled: false,
       },
     }),
+    // Complemento EXATO da condição do VitePWA acima: onde o plugin real não
+    // está (dev e preview), o stub resolve o virtual pro scan de deps não abortar.
+    (mode !== "production" || isLovablePreview) && pwaRegisterStub(),
   ].filter(Boolean),
   resolve: {
     alias: {


### PR DESCRIPTION
## Sintoma

Tela branca no preview do Lovable com `TypeError: Cannot read properties of null (reading 'useEffect')` dentro de `QueryClientProvider` (`has_blank_screen: true`). O stack mostra módulos do cache de pré-bundle do Vite com **duas gerações diferentes** na mesma página (`chunk-QCHXOAYK.js?v=971274a9` ao lado de `chunk-T2SWDQEL.js?v=c5007d5a`).

## Causa raiz

Cadeia completa, reproduzida deterministicamente em cold start local:

1. `src/lib/pwa-update.ts` importa **estaticamente** `virtual:pwa-register` (linha 1). O módulo virtual só ganha resolvedor quando o `VitePWA` está ativo — e por desenho ele só entra em `mode === "production" && !isLovablePreview` (#1169/#1169-Onda-4).
2. O guard `__PWA_ENABLED__` em `main.tsx` protege o **runtime** (o bloco nunca executa em dev/preview) e o **build** (Rollup faz DCE do branch morto). Mas o **scanner de dependências do dev server** (esbuild) segue o grafo estático inteiro **sem aplicar o DCE do `define`**: encontra o virtual órfão e **aborta o pré-bundle inteiro**:
   ```
   Error: The following dependencies are imported but could not be resolved:
     virtual:pwa-register (imported by src/lib/pwa-update.ts)
   ```
3. Com o scan abortado, `node_modules/.vite/deps/_metadata.json` nunca nasce. **Toda** dependência vira "descoberta tardia": o optimizer re-bundleia sob demanda em rodadas sucessivas, cada uma com um `?v=` novo.
4. Quando o browser fica com metade dos módulos de uma geração e metade de outra (reload não-atômico no iframe do preview), há **duas instâncias de React** na página: o `react-dom` (geração nova) inicializa o dispatcher de hooks na cópia dele; o `@tanstack/react-query` chama `useEffect` na cópia velha, cujo `ReactCurrentDispatcher.current` é `null` → crash na montagem → tela branca.

Não é dependência duplicada real: o `bun.lock` tem exatamente uma resolução de `react@18.3.1` e uma de `react-dom@18.3.1`. A duplicação é do estado do cache do Vite. A janela existe desde o #1169 — o erro é intermitente, por isso só estourou visivelmente agora.

## Fix

Cirúrgico, só `vite.config.ts`: um plugin stub (`pwa-register-stub`) que resolve `virtual:pwa-register` para um `registerSW` no-op, registrado no **complemento exato** da condição do `VitePWA` (dev e preview). Com o virtual sempre resolvível, o scan completa e o pré-bundle nasce inteiro numa geração única.

- Produção real (Publish): nada muda — o `VitePWA` verdadeiro segue resolvendo o virtual, o stub nem é registrado.
- Bônus: a mudança de config invalida o hash do cache de deps, então o próprio deploy força uma re-otimização limpa no container do preview (mata o estado misto atual).

## Evidência

| Cenário | Scan | `_metadata.json` |
|---|---|---|
| Sem o fix (cold start `bunx vite`) | ❌ aborta com `virtual:pwa-register ... could not be resolved` | nunca é escrito |
| Com o fix (`vite optimize --force`) | ✅ completa | escrito, todas as deps numa geração única |
| Falsificação (config da main restaurado) | ❌ volta a abortar | ausente |

Varredura de classe: `virtual:pwa-register` é o **único** import `virtual:` em todo o `src/` — não há outro candidato ao mesmo buraco.

Sem teste vitest novo (decisão consciente): o teste real é o optimizer do Vite, que não cabe no `validate` sem criar um gate novo de ~1min de esbuild por run; o par falsificação/pass acima é a prova. O comentário no config documenta a armadilha (`define`-DCE não vale para o scanner).

## Deploy

Frontend/dev-server only — chega ao preview pelo sync GitHub→Lovable no merge (o dev server do preview reinicia e re-otimiza com config novo). Sem edge, sem migration. Publish de produção não é necessário para este fix (produção não é afetada pelo bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
