### PR TITLE
feat(farmer): segundo disparo às 06:25 fecha a perda de frescor do lease [money-path]

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **434** custom migrations totais
-- **1504** objetos esperados (criados por estas migrations)
+- **437** custom migrations totais
+- **1510** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 437
+  - `function`: 440
   - `rls_policy`: 384
   - `index`: 224
-  - `cron_job`: 157
+  - `cron_job`: 160
   - `table`: 147
   - `trigger`: 79
   - `view`: 72
@@ -3639,6 +3639,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `rls_policy` | `public.omie_products_select_staff` | `omie_products` |
 
+### `20260727150000_tint_watchdog_corante_impagavel.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.tint_watchdog_corante_check` | — |
+| `cron_job` | `cron.tint-watchdog-corante-5min` | — |
+
 ### `20260728120000_farmer_persiste_cobertura_custo.sql`
 
 | Tipo | Objeto | Parent |
@@ -3660,6 +3667,20 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.farmer_association_rules_substituir` | — |
+
+### `20260730120000_tint_watchdog_fase5_chave.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._tint_watchdog_fase5_transicao` | — |
+| `function` | `public.tint_watchdog_fase5_check` | — |
+| `cron_job` | `cron.tint-watchdog-fase5-6h` | — |
+
+### `20260730120001_calculate_scores_reforco_0625.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `cron_job` | `cron.calculate-scores-reforco-0625` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 434
+-- Total de custom migrations: 437
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -473,9 +473,12 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260727120000', 'tint_fase5_desativa_geracao_legada', '20260727120000_tint_fase5_desativa_geracao_legada.sql'),
   ('20260727130000', 'farmer_scores_colunas_orfas_null', '20260727130000_farmer_scores_colunas_orfas_null.sql'),
   ('20260727140000', 'authz_preco_fecha_omie_products', '20260727140000_authz_preco_fecha_omie_products.sql'),
+  ('20260727150000', 'tint_watchdog_corante_impagavel', '20260727150000_tint_watchdog_corante_impagavel.sql'),
   ('20260728120000', 'farmer_persiste_cobertura_custo', '20260728120000_farmer_persiste_cobertura_custo.sql'),
   ('20260728120001', 'calculate_scores_lease', '20260728120001_calculate_scores_lease.sql'),
-  ('20260729120000', 'farmer_association_rules_substituicao_atomica', '20260729120000_farmer_association_rules_substituicao_atomica.sql')
+  ('20260729120000', 'farmer_association_rules_substituicao_atomica', '20260729120000_farmer_association_rules_substituicao_atomica.sql'),
+  ('20260730120000', 'tint_watchdog_fase5_chave', '20260730120000_tint_watchdog_fase5_chave.sql'),
+  ('20260730120001', 'calculate_scores_reforco_0625', '20260730120001_calculate_scores_reforco_0625.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1962,13 +1965,19 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('authz_preco_fecha_omie_products', 'rls_policy', 'public', 'omie_products_select_staff', 'omie_products'),
+  ('tint_watchdog_corante_impagavel', 'function', 'public', 'tint_watchdog_corante_check', ''),
+  ('tint_watchdog_corante_impagavel', 'cron_job', 'cron', 'tint-watchdog-corante-5min', ''),
   ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', ''),
   ('calculate_scores_lease', 'function', 'public', 'claim_calculate_scores', ''),
   ('calculate_scores_lease', 'function', 'public', 'finalizar_calculate_scores', ''),
   ('calculate_scores_lease', 'rls_policy', 'public', 'calculate_scores_lease_no_insert', 'sync_state'),
   ('calculate_scores_lease', 'rls_policy', 'public', 'calculate_scores_lease_no_update', 'sync_state'),
   ('calculate_scores_lease', 'rls_policy', 'public', 'calculate_scores_lease_no_delete', 'sync_state'),
-  ('farmer_association_rules_substituicao_atomica', 'function', 'public', 'farmer_association_rules_substituir', '')
+  ('farmer_association_rules_substituicao_atomica', 'function', 'public', 'farmer_association_rules_substituir', ''),
+  ('tint_watchdog_fase5_chave', 'function', 'public', '_tint_watchdog_fase5_transicao', ''),
+  ('tint_watchdog_fase5_chave', 'function', 'public', 'tint_watchdog_fase5_check', ''),
+  ('tint_watchdog_fase5_chave', 'cron_job', 'cron', 'tint-watchdog-fase5-6h', ''),
+  ('calculate_scores_reforco_0625', 'cron_job', 'cron', 'calculate-scores-reforco-0625', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3503,13 +3512,19 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('tint_canonica_piso_legado', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('tint_fase5_desativa_geracao_legada', 'view', 'public', 'v_tint_formula_canonica', ''),
   ('authz_preco_fecha_omie_products', 'rls_policy', 'public', 'omie_products_select_staff', 'omie_products'),
+  ('tint_watchdog_corante_impagavel', 'function', 'public', 'tint_watchdog_corante_check', ''),
+  ('tint_watchdog_corante_impagavel', 'cron_job', 'cron', 'tint-watchdog-corante-5min', ''),
   ('farmer_persiste_cobertura_custo', 'function', 'public', 'apply_score_updates', ''),
   ('calculate_scores_lease', 'function', 'public', 'claim_calculate_scores', ''),
   ('calculate_scores_lease', 'function', 'public', 'finalizar_calculate_scores', ''),
   ('calculate_scores_lease', 'rls_policy', 'public', 'calculate_scores_lease_no_insert', 'sync_state'),
   ('calculate_scores_lease', 'rls_policy', 'public', 'calculate_scores_lease_no_update', 'sync_state'),
   ('calculate_scores_lease', 'rls_policy', 'public', 'calculate_scores_lease_no_delete', 'sync_state'),
-  ('farmer_association_rules_substituicao_atomica', 'function', 'public', 'farmer_association_rules_substituir', '')
+  ('farmer_association_rules_substituicao_atomica', 'function', 'public', 'farmer_association_rules_substituir', ''),
+  ('tint_watchdog_fase5_chave', 'function', 'public', '_tint_watchdog_fase5_transicao', ''),
+  ('tint_watchdog_fase5_chave', 'function', 'public', 'tint_watchdog_fase5_check', ''),
+  ('tint_watchdog_fase5_chave', 'cron_job', 'cron', 'tint-watchdog-fase5-6h', ''),
+  ('calculate_scores_reforco_0625', 'cron_job', 'cron', 'calculate-scores-reforco-0625', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260730120001_calculate_scores_reforco_0625.sql
+++ b/supabase/migrations/20260730120001_calculate_scores_reforco_0625.sql
@@ -1,0 +1,78 @@
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- calculate-scores — SEGUNDO DISPARO às 06:15 (fecha a perda de frescor do lease)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- O QUE FECHA. O lease do #1578 serializa os runs, mas o run PERDEDOR é simplesmente pulado (200
+-- `skipped`) e não volta: o próximo disparo real era o cron do dia seguinte. Trocamos corrupção
+-- (last-writer-wins restaurando margem velha) por até 24h de dado velho — melhor que o bug, mas
+-- ainda uma regressão, e foi declarada como limitação no #1578 e no #1591.
+--
+-- Dois cenários que este disparo cobre, e que hoje só se resolvem no dia seguinte:
+--   1. o run das 06:00 ganhou o lease mas rodou DEGRADADO (`marginRefreshFatal` — a RPC de margem
+--      falhou, tipicamente por timeout): ele regrava o snapshot que leu e termina em erro. Às 06:15
+--      a RPC costuma estar de pé, e o segundo run mede a margem de verdade;
+--   2. dois disparos se sobrepuseram (cron + botão manual da staff dentro da mesma janela de ~30s):
+--      o perdedor foi pulado. Aos 06:15 o lease está livre.
+--
+-- POR QUE UM CRON, E NÃO ESPERAR DENTRO DA EDGE. A primeira tentativa de fechar isto foi retry com
+-- espera no claim, e o challenge /codex mostrou que a calibragem não fechava nada: a última
+-- tentativa caía em t=15s contra um run que MEDI em ~29s (28/07: cron 06:00:00, finalize do lease
+-- 06:00:29). Cobrir de verdade exigiria esperar >30s DENTRO da edge, consumindo a margem do
+-- wall-clock (150s Free / 400s pago) antes mesmo de começar o recompute. Um segundo disparo 15min
+-- depois não tem esse custo: cada run tem o wall-clock inteiro para si.
+--
+-- POR QUE É SEGURO RODAR DUAS VEZES. O recompute é IDEMPOTENTE por construção — lê o estado, calcula
+-- e reescreve as mesmas linhas (`apply_score_updates` é UPDATE-only por id, anti-ressurreição). Rodar
+-- 2× no mesmo dia produz o mesmo resultado que rodar 1×, com dado mais fresco. E o LEASE garante que
+-- os dois nunca se sobreponham: se por algum motivo o run das 06:00 ainda estiver vivo às 06:15 (o
+-- que exigiria ~15min de execução, contra os ~29s medidos), o segundo é pulado e nada acontece.
+--
+-- CUSTO: ~30s de edge por dia, mais 6.633 linhas em `health_score_history` e `priority_score_log`.
+-- Estas duas são séries temporais append-only de display/tendência (não estado money-path — a fonte
+-- é `farmer_client_scores`), então uma amostra a mais por dia é adensamento da série, não corrupção.
+-- ⚠️ Se o volume dessas tabelas virar problema, a saída é retenção/particionamento, NÃO remover o
+-- segundo disparo em silêncio — quem remover perde a cura do frescor sem perceber.
+--
+-- POR QUE 06:25 E NÃO 06:15. O horário foi escolhido olhando a VIZINHANÇA de crons (mapeada por
+-- psql-ro em 2026-07-28), não por número redondo. A hora 6 é congestionada:
+--   06:00 → daily-calculate-scores + fin-sync-base-diario + scoring-recalc-batch-nightly
+--            + sync-products-customers-daily (4 jobs)
+--   06:15 → sync-colacor-vendas-products + afiacao_customer_metrics_refresh_6h
+--   06:20 → vendas-sync-pedidos-colacor-2h + afiacao_oportunidade_badge_refresh_2h
+--   06:45 → compute-costs-daily
+-- 06:15 era a escolha óbvia e é justamente a ruim: o `sync-colacor-vendas-products` mexe em PRODUTO,
+-- e o recompute lê custo para calcular margem — ler no meio de uma atualização de catálogo é pedir
+-- para medir um estado intermediário. 06:25 só coincide com os watchdogs leves do `*/5`
+-- (afiacao-os-sync, sayerlack-portal-watchdog, tint-watchdog-corante-5min); os `*/10`, `*/15` e
+-- `*/30` não caem no minuto :25.
+--
+-- 25 MINUTOS de distância do run principal: tem de ser MAIOR que a duração de um run (~29s medido,
+-- folga de ~50×) para que o segundo disparo encontre o lease livre, e PEQUENO o bastante para que o
+-- dado fresco chegue antes do expediente. A vendedora abre a carteira de manhã; 06:25 é madrugada.
+
+-- Idempotente: `cron.schedule` com nome existente REAGENDA em vez de duplicar. Espelha VERBATIM o
+-- comando do job 36 (`daily-calculate-scores`, conferido por psql-ro em 2026-07-28) — inclusive o
+-- `timeout_milliseconds` explícito, sem o qual o default de 5s mataria a chamada em silêncio e o
+-- `cron.job_run_details` ainda diria 'succeeded' (só prova o ENQUEUE; a verdade HTTP está em
+-- `net._http_response`). O `triggered_by` distingue os dois disparos no log da edge.
+SELECT cron.schedule(
+  'calculate-scores-reforco-0625',
+  '25 6 * * *',
+  $cron$
+  SELECT net.http_post(
+    url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/calculate-scores',
+    headers := jsonb_build_object('Content-Type','application/json',
+      'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+    body := '{"triggered_by":"cron-reforco-0625"}'::jsonb,
+    timeout_milliseconds := 150000
+  );
+  $cron$
+);
+
+-- Validação pós-apply (read-only): o job existe, está ativo, no horário certo, e o comando carrega
+-- o timeout explícito (sem ele o default de 5s mata a chamada em silêncio).
+SELECT 'MIGRATION calculate_scores_segundo_disparo OK' AS status,
+  jobname, schedule, active,
+  (command LIKE '%timeout_milliseconds%')        AS tem_timeout_deve_ser_true,
+  (command LIKE '%cron-reforco-0625%')           AS tem_marcador_deve_ser_true,
+  (SELECT count(*) FROM cron.job WHERE command LIKE '%calculate-scores%' AND active)::int AS disparos_ativos_deve_ser_2
+FROM cron.job WHERE jobname = 'calculate-scores-reforco-0625';


### PR DESCRIPTION
Fecha a **perda de frescor** que ficou declarada como limitação no #1578 e no #1591.

## O que estava aberto

O lease serializa os runs, mas o **perdedor é simplesmente pulado** (`200 skipped`) e não volta — o próximo disparo real era o cron do dia seguinte. Trocávamos corrupção por até **24h de dado velho**. Melhor que o bug, mas ainda uma regressão.

Dois cenários que hoje só se resolvem no dia seguinte:

1. **Run degradado ganhou o lease.** A RPC de margem falhou (tipicamente timeout), o run regravou o snapshot que leu e terminou em erro. Às 06:25 a RPC costuma estar de pé.
2. **Dois disparos se sobrepuseram** (cron + botão manual dentro da mesma janela de ~30s). O perdedor foi pulado; às 06:25 o lease está livre.

## Por que um cron, e não esperar dentro da edge

A primeira tentativa foi retry com espera no claim (#1591). O challenge `/codex` mostrou que a calibragem **não fechava nada**: a última tentativa caía em `t=15s` contra um run que **medi em ~29s** (28/07 — cron `06:00:00`, finalize do lease `06:00:29`).

Cobrir de verdade exigiria esperar **>30s dentro da edge**, consumindo a margem do wall-clock (150s Free) *antes* de começar o recompute. Um segundo disparo 25min depois não tem esse custo: cada run tem o wall-clock inteiro para si.

## Por que 06:25 e não 06:15

O horário saiu da **vizinhança de crons** (mapeada por `psql-ro`), não de número redondo. A hora 6 é congestionada:

| Horário | Jobs |
|---|---|
| 06:00 | `daily-calculate-scores` + 3 outros |
| 06:15 | `sync-colacor-vendas-products`, `afiacao_customer_metrics_refresh_6h` |
| 06:20 | `vendas-sync-pedidos-colacor-2h`, `afiacao_oportunidade_badge_refresh_2h` |
| 06:45 | `compute-costs-daily` |
| **06:25** | **só watchdogs leves do `*/5`** |

**06:15 era a escolha óbvia e é justamente a ruim:** ali roda o `sync-colacor-vendas-products`, que mexe em **produto** — e o recompute lê custo para calcular margem. Ler no meio de uma atualização de catálogo é medir estado intermediário. Os `*/10`, `*/15` e `*/30` não caem no minuto `:25`.

## Por que é seguro rodar duas vezes

O recompute é **idempotente** por construção (`apply_score_updates` é UPDATE-only por id, anti-ressurreição), e o **lease garante que os dois nunca se sobreponham**: se o run das 06:00 ainda estivesse vivo às 06:25 — o que exigiria ~15min contra os ~29s medidos — o segundo é pulado e nada acontece.

## Custo, declarado

~30s de edge por dia + 6.633 linhas em `health_score_history` e `priority_score_log`. Ambas são séries temporais append-only de display/tendência, **não** estado money-path (a fonte é `farmer_client_scores`) — uma amostra a mais por dia é adensamento da série, não corrupção.

⚠️ Se o volume virar problema, a saída é retenção/particionamento, **não** remover o segundo disparo em silêncio: quem remover perde a cura do frescor sem perceber. Está escrito no corpo da migration.

## Provas

PG17 com stub de `cron`/`net`/`vault`, aplicando a migration REAL — **6 asserts**: job criado · horário `25 6 * * *` · `timeout_milliseconds` explícito (sem ele o default de 5s mata a chamada em silêncio e o `job_run_details` ainda diz `succeeded`) · marcador `cron-reforco-0625` no body · alvo correto · **idempotência** (re-colar não duplica — `cron.schedule` reagenda pelo nome).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260730120001_calculate_scores_reforco_0625.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

Validação pós-apply: a própria migration termina com o `SELECT`. Esperado: `active=t`, `schedule=25 6 * * *`, `tem_timeout_deve_ser_true=t`, `tem_marcador_deve_ser_true=t`, `disparos_ativos_deve_ser_2=2`.

Sem deploy de edge — este PR é só SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
