### PR TITLE
fix(reposição): leitura que FALHA deixa de virar "SKU sem demanda/custo/mínimo" [money-path]

### DIFF
--- a/src/components/reposicao/embalagem/useEmbalagemConsulta.ts
+++ b/src/components/reposicao/embalagem/useEmbalagemConsulta.ts
@@ -79,6 +79,7 @@ export function useEmbalagemConsulta(empresa: string): EmbalagemConsultaResult {
           .from('omie_products')
           .select('omie_codigo_produto, descricao')
           .in('omie_codigo_produto', skuNums);
+        if (prodResp.error) throw prodResp.error; // senão o SKU perde o rótulo e vira código cru
         ((prodResp.data ?? []) as unknown as { omie_codigo_produto: number | string; descricao: string | null }[])
           .forEach((p) => {
             const k = String(p.omie_codigo_produto);
@@ -95,6 +96,9 @@ export function useEmbalagemConsulta(empresa: string): EmbalagemConsultaResult {
           .select('sku_codigo_omie, demanda_media_diaria')
           .eq('empresa', emp)
           .in('sku_codigo_omie', skuNums);
+        // Falha ≠ "SKU sem demanda": o mapa vazio faz a cobertura em dias sumir da opção de
+        // embalagem, e a comparação entre embalagens sai como se o giro fosse desconhecido.
+        if (paramResp.error) throw paramResp.error;
         ((paramResp.data ?? []) as unknown as { sku_codigo_omie: number; demanda_media_diaria: number | null }[])
           .forEach((p) => demandaMap.set(String(p.sku_codigo_omie), p.demanda_media_diaria));
 
@@ -103,6 +107,9 @@ export function useEmbalagemConsulta(empresa: string): EmbalagemConsultaResult {
           .select('sku_codigo_omie, custo_capital_efetivo_perc')
           .eq('empresa', emp)
           .in('sku_codigo_omie', skuNums);
+        // Falha ≠ "custo de capital zero": o custo de capital é o que penaliza a embalagem
+        // grande (mais estoque parado). Sem ele a economia do lote maior sai INFLADA.
+        if (cmResp.error) throw cmResp.error;
         ((cmResp.data ?? []) as unknown as { sku_codigo_omie: number; custo_capital_efetivo_perc: number | null }[])
           .forEach((p) => cmMap.set(String(p.sku_codigo_omie), p.custo_capital_efetivo_perc));
       }

--- a/src/components/reposicao/pedidos/useDetalhesModal.ts
+++ b/src/components/reposicao/pedidos/useDetalhesModal.ts
@@ -70,11 +70,15 @@ export function useDetalhesModal({ pedido, open, onOpenChange, onApproved }: Use
 
       // Buscar estoque_minimo de sku_parametros (JOIN manual)
       const skuCodigos = baseItens.map((it) => Number(it.sku_codigo_omie)).filter((n) => !isNaN(n));
-      const { data: params } = await supabase
+      // O `error` NÃO pode ficar de fora da desestruturação: sem ele a falha vira `params`
+      // null → `minMap` vazio → `estoque_minimo: 0` (linha abaixo) exibido como se o SKU
+      // não tivesse mínimo cadastrado. Zero fabricado no dado que baliza reposição.
+      const { data: params, error: paramsErr } = await supabase
         .from('sku_parametros')
         .select('sku_codigo_omie, estoque_minimo')
         .eq('empresa', pedido.empresa)
         .in('sku_codigo_omie', skuCodigos);
+      if (paramsErr) throw paramsErr;
       const minMap = new Map<string, number>();
       (params ?? []).forEach((p) => {
         minMap.set(String(p.sku_codigo_omie), Number(p.estoque_minimo ?? 0));

--- a/src/components/reposicao/pedidos/useEmbalagemPedido.ts
+++ b/src/components/reposicao/pedidos/useEmbalagemPedido.ts
@@ -83,6 +83,9 @@ export function useEmbalagemPedido(
         .select('sku_codigo_omie, demanda_media_diaria')
         .eq('empresa', empresa)
         .in('sku_codigo_omie', skuNums);
+      // Mesma razão do `precoResp` acima: falha ≠ "SKU sem demanda". O mapa vazio apaga a
+      // cobertura em dias da opção de embalagem e esconde o giro real do comprador.
+      if (paramResp.error) throw paramResp.error;
       const demandaMap = new Map<string, number | null>();
       ((paramResp.data ?? []) as unknown as { sku_codigo_omie: number; demanda_media_diaria: number | null }[])
         .forEach((p) => demandaMap.set(String(p.sku_codigo_omie), p.demanda_media_diaria));
@@ -92,6 +95,9 @@ export function useEmbalagemPedido(
         .select('sku_codigo_omie, custo_capital_efetivo_perc')
         .eq('empresa', empresa)
         .in('sku_codigo_omie', skuNums);
+      // Falha ≠ "custo de capital zero": é o custo de capital que penaliza a embalagem grande
+      // (estoque parado). Sem ele a economia do lote maior sai INFLADA — e o pedido cresce.
+      if (cmResp.error) throw cmResp.error;
       const cmMap = new Map<string, number | null>();
       ((cmResp.data ?? []) as unknown as ParamRow[])
         .forEach((p) => cmMap.set(String(p.sku_codigo_omie), p.custo_capital_efetivo_perc));


### PR DESCRIPTION
Fase 1 da erradicação em `src/` da classe **"leitura single-shot cuja falha vira zero"** — a irmã não-paginada da classe dos ~20 PRs de paginação, fechada na âncora financeira pelo #1600.

**Instância única ou classe?** **CLASSE.** Triagem completa de `src/` feita nesta sessão: 130 ocorrências da forma em 57 arquivos → **30 afetados**, 69 falsos positivos (react-query, que expõe `error` num campo à parte) e 31 já-corretos. Este PR é a Fase 1 — reposição/custo, o lote mais money. Fases 2–4 saem em PRs próprios; a Fase 5 estende o gate do #1600 para `src/`.

## O defeito

A resposta do PostgREST é coalescida com `?? []` sem ninguém consultar o `error`. RLS, timeout 57014 ou 500 chega ao cálculo **indistinguível de "a tabela não tem essa linha"** — com resposta 200 e sem sinal na tela.

## Os 6 sites

| arquivo | site | o que a falha fabricava |
|---|---|---|
| `useEmbalagemConsulta` | `cmResp` | `custo_capital_efetivo_perc` é o que **penaliza a embalagem grande** (estoque parado). Mapa vazio = penalidade some = economia do lote maior **inflada** |
| `useEmbalagemConsulta` | `paramResp` | demanda média ausente → cobertura em dias some da comparação |
| `useEmbalagemConsulta` | `prodResp` | SKU perde o rótulo e vira código cru |
| `useEmbalagemPedido` | `cmResp`, `paramResp` | idem, no fluxo do pedido — aqui a economia inflada **faz o pedido crescer** |
| `useDetalhesModal` | `const { data: params }` | `error` descartado na desestruturação → `minMap` vazio → `estoque_minimo: 0` exibido como "sem mínimo cadastrado". Zero fabricado no dado que baliza reposição |

Os dois primeiros arquivos **já checavam** o `error` do `precoResp` (`// senão "sem preço" mascara falha de query [codex P2]`) — os vizinhos ficaram de fora. É o padrão da classe: o site que doeu foi corrigido, os irmãos não.

## Tolerado de propósito (não é omissão)

`useDetalhesModal` L100/L101 (`opRes`/`ssRes`, selo "inativo no Omie"): o código **já documenta** a degradação como consciente — *"falha da query degrada em silêncio (sem selo) — a barreira money-path é a trava do disparo"*. Decisão do autor, com barreira real noutro lugar. Vai para a baseline do gate com esse veredito, não para o fix.

## Furo da assinatura encontrado (vai para a Fase 5)

`const { data: X } = await …` seguido de `X ?? []` é **invisível** ao padrão do gate — a desestruturação some com o `.data`. Foi assim que o `useDetalhesModal` L73 escapou da medição original. O gate de paginação cobre a forma irmã com `.range(` (padrão G1); a variante single-shot é o furo.

## Verificação (evidência positiva)

- `bun run typecheck` → **exit 0**
- `eslint` nos 3 arquivos → **exit 0**
- Suíte canônica do CI → **exit 0** — 632 arquivos, 5755 casos, rodada já com o gate do #1600 incluído.

## Colisão conhecida

O #1212 (faxina de deadcode do knip) também toca `useEmbalagemConsulta.ts` e `useEmbalagemPedido.ts`. As regiões são disjuntas (lá remove exports não usados; aqui acrescenta checagem de `error` no meio do `queryFn`), então o conflito textual é improvável — quem mergear depois rebaseia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
