### PR TITLE
fix(pedido/crédito): leitura que FALHA deixa de virar "produto inexistente" e "aprovador ausente" [money-path]

### DIFF
--- a/src/components/salesOrderEdit/useSalesOrderEdit.ts
+++ b/src/components/salesOrderEdit/useSalesOrderEdit.ts
@@ -124,6 +124,11 @@ export function useSalesOrderEdit() {
         }),
       ]);
 
+      // `functions.invoke` NÃO lança: devolve `{ data: null, error }`. Sem esta linha a falha
+      // escapava do `catch` abaixo, `setFormas` nunca era chamado e o editor abria com a
+      // lista de formas de pagamento VAZIA — indistinguível de "esta conta não tem forma
+      // cadastrada". Lançar leva ao toast "Erro ao carregar pedido", que é a verdade.
+      if (formasRes.error) throw formasRes.error;
       const formasData = formasRes.data as FormasPagamentoResponse | null;
       if (formasData?.formas) setFormas(formasData.formas);
       setCatalogProducts(products);

--- a/src/hooks/useExcecaoCredito.ts
+++ b/src/hooks/useExcecaoCredito.ts
@@ -78,7 +78,11 @@ export function useAprovadoresCredito(enabled: boolean) {
           .select('user_id')
           .in('commercial_role', ['gerencial', 'estrategico', 'super_admin']),
       ]);
+      // Os DOIS erros importam: `comerciais` ficava de fora, e a falha dela virava "não há
+      // gerencial/estratégico/super_admin" — a exceção de crédito sairia para uma lista de
+      // aprovadores incompleta, sem ninguém perceber que a leitura falhou.
       if (masters.error) throw new Error(masters.error.message);
+      if (comerciais.error) throw new Error(comerciais.error.message);
       const ids = [
         ...new Set([
           ...(masters.data ?? []).map((r) => r.user_id),

--- a/src/hooks/usePedidosProgramados.ts
+++ b/src/hooks/usePedidosProgramados.ts
@@ -205,17 +205,28 @@ export function useBuscaProdutoMapeamento(termo: string, codForn: string | null)
     staleTime: 60_000,
     queryFn: async () => {
       const sel = 'id, omie_codigo_produto, codigo, descricao, unidade, account, ativo';
-      const sugestoes = codForn
-        ? ((await supabase.from('omie_products').select(sel).eq('codigo', codForn).limit(4)).data ?? [])
-        : [];
-      const busca = termoUtil
-        ? ((await supabase
-            .from('omie_products')
-            .select(sel)
-            .or(ilikeOr(['codigo', 'descricao'], termo))
-            .order('descricao', { ascending: true })
-            .limit(20)).data ?? [])
-        : [];
+      // O `await` INLINE tornava o `error` inalcançável por construção (ninguém guardava a
+      // resposta): uma falha de RLS/timeout saía como "nenhum produto encontrado" na tela de
+      // mapeamento, e o operador amarraria o item do cliente ao SKU errado — ou criaria um
+      // mapeamento novo para um produto que já existe. Guardar a resposta e lançar deixa o
+      // react-query mostrar o erro em vez de uma lista vazia convincente.
+      let sugestoes: unknown[] = [];
+      if (codForn) {
+        const resp = await supabase.from('omie_products').select(sel).eq('codigo', codForn).limit(4);
+        if (resp.error) throw resp.error;
+        sugestoes = resp.data ?? [];
+      }
+      let busca: unknown[] = [];
+      if (termoUtil) {
+        const resp = await supabase
+          .from('omie_products')
+          .select(sel)
+          .or(ilikeOr(['codigo', 'descricao'], termo))
+          .order('descricao', { ascending: true })
+          .limit(20);
+        if (resp.error) throw resp.error;
+        busca = resp.data ?? [];
+      }
       return {
         sugestoes: sugestoes as unknown as ProdutoMapeado[],
         busca: busca as unknown as ProdutoMapeado[],


### PR DESCRIPTION
Fase 2 da erradicação em `src/` da classe **"leitura single-shot cuja falha vira zero"** — âncora financeira no #1600, Fase 1 (reposição/custo) no #1604.

Mesma forma nos três sites: a resposta do PostgREST/`functions.invoke` é consumida sem ninguém consultar o `error`, então RLS/timeout/500 chega ao consumidor **indistinguível de "não existe"**.

## Os 3 sites

**`usePedidosProgramados` — busca de produto para mapeamento**
O `await` era **inline**: `(await supabase.from('omie_products')…limit(4)).data ?? []`. O `error` era inalcançável *por construção* — ninguém guardava a resposta. Uma falha saía como **"nenhum produto encontrado"** na tela de mapeamento, e o operador amarraria o item do cliente ao SKU errado, ou criaria um mapeamento novo para um produto que já existe. Agora a resposta é guardada e o erro sobe para o react-query, que mostra o estado de erro em vez de uma lista vazia convincente.

**`useSalesOrderEdit` — formas de pagamento**
`supabase.functions.invoke` **não lança**: devolve `{ data: null, error }`. A falha escapava do `catch` que envolve o bloco inteiro, `setFormas` nunca era chamado, e o editor abria com a lista de formas de pagamento **vazia** — indistinguível de "esta conta não tem forma cadastrada". Com o `throw`, cai no `catch` que já existia e o toast "Erro ao carregar pedido" diz a verdade.

**`useExcecaoCredito` — lista de aprovadores**
`masters.error` era checado; `comerciais.error`, não. A falha virava "não há gerencial/estratégico/super_admin" e a exceção de crédito seguia para uma **lista de aprovadores incompleta**. É o padrão da classe: o irmão que doeu foi corrigido, o vizinho ficou.

## Verificação

- `eslint` nos 3 arquivos → **exit 0** (o único aviso é pré-existente, sobre deps de um `useEffect` que este PR não toca).
- `typecheck`/suíte local: a máquina do founder está saturada (30 sessões vivas; o semáforo `heavy` ficou com 6 na fila e não andou) → **delegados ao CI `validate`**, que é a autoridade e o que o auto-merge espera. O diff é pequeno; o único ponto de tipo é o `let sugestoes: unknown[]` que substitui o `await` inline, consumido logo abaixo pelo mesmo `as unknown as ProdutoMapeado[]` de antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
