### PR TITLE
fix(scoring/carteira): leitura que FALHA deixa de virar score baixo, fila vazia e "nunca contatado" [money-path]

### DIFF
--- a/src/components/dashboard/TeamKpiTiles.tsx
+++ b/src/components/dashboard/TeamKpiTiles.tsx
@@ -40,8 +40,23 @@ export function TeamKpiTiles() {
 
   const receita = (v: number | undefined): string =>
     isError ? '—' : isLoading || v === undefined ? '…' : formatBRL(v);
-  const ativos = isError || isLoading || !data ? (isError ? '—' : '…') : String(data.ativosHoje);
-  const ativosSub = isError ? 'indisponível' : data ? `ativos hoje · 7d: ${data.ativos7d}` : 'ativos hoje';
+  // `ativosHoje === null` = a leitura de atividade falhou (a receita, que lança, seguiu viva).
+  // Mostrar "—" em vez de "0": zero aqui seria lido como "o time parou".
+  const ativos =
+    isError || isLoading || !data
+      ? isError
+        ? '—'
+        : '…'
+      : data.ativosHoje === null
+        ? '—'
+        : String(data.ativosHoje);
+  const ativosSub = isError
+    ? 'indisponível'
+    : data
+      ? data.ativosHoje === null
+        ? 'atividade indisponível'
+        : `ativos hoje · 7d: ${data.ativos7d}`
+      : 'ativos hoje';
   const escopoSub = `pedidos Omie · ${escopo}`;
   const mesSub: ReactNode = isError ? (
     'indisponível'

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -277,9 +277,16 @@ export const useCrossSellEngine = () => {
           supabase
             .from('profiles')
             .select('user_id, name, customer_type, cnae')
-            .in('user_id', batch) as unknown as Promise<{ data: ProfileRow[] | null }>,
+            // O cast declarava só `{ data }` e APAGAVA o `error` do tipo — o compilador
+            // deixava de cobrar a checagem, e um lote que falhasse virava "estes clientes
+            // não têm perfil" no cross-sell (segmento/CNAE ausentes = recomendação errada).
+            .in('user_id', batch) as unknown as Promise<{ data: ProfileRow[] | null; error: { message?: string } | null }>,
         ),
       );
+      const loteComFalha = batchResults.findIndex((r) => r.error);
+      if (loteComFalha >= 0) {
+        throw new Error(`cross-sell: lote ${loteComFalha + 1}/${batchResults.length} de profiles falhou — perfis incompletos, recomendação não calculada`);
+      }
       const allProfiles: ProfileRow[] = batchResults.flatMap((r) => r.data || []);
       const profileMap = new Map<string, ProfileRow>();
       allProfiles.forEach((p) => profileMap.set(p.user_id, p));

--- a/src/hooks/useFollowupsVisita.ts
+++ b/src/hooks/useFollowupsVisita.ts
@@ -53,7 +53,12 @@ export function useFollowupsVisita() {
           .eq('farmer_id', uid)
           .gte('started_at', desdeISO),
       ]);
+      // Os três erros importam, não só o das visitas: `agRes` vazio faz o cliente que JÁ tem
+      // visita agendada reaparecer como pendente (retrabalho), e `callRes` vazio fabrica
+      // "nunca contatado", que é o insumo da cadência.
       if (visRes.error) throw new Error(visRes.error.message);
+      if (agRes.error) throw new Error(agRes.error.message);
+      if (callRes.error) throw new Error(callRes.error.message);
       const visitas = (visRes.data ?? []) as VisitaFollowupRow[];
 
       const agendadasPendentes = new Set<string>(

--- a/src/hooks/useGamificationScore.ts
+++ b/src/hooks/useGamificationScore.ts
@@ -58,6 +58,20 @@ export function useGamificationScore(userId?: string) {
         supabase.from('orders').select('status, created_at').eq('user_id', targetUserId),
       ]);
 
+      // As CINCO leituras são insumo de um score que é PERSISTIDO logo abaixo
+      // (`upsert` em `gamification_scores`) e alimenta o ranking. Sem esta checagem, uma
+      // falha de RLS/timeout virava "0 ferramentas / 0 treinamentos / 0 indicações" e o
+      // score deflacionado ia para o banco como se fosse medição real — o mesmo padrão do
+      // cron que gravava caixa zero na âncora desta classe (#1600). Lançar cai no `catch`
+      // abaixo: `data` fica null, a tela não mostra score, e NADA é gravado.
+      for (const [nome, res] of [
+        ['user_tools', toolsRes], ['sending_quality_logs', qualityRes],
+        ['training_completions', trainingRes], ['referrals', referralsRes], ['orders', ordersRes],
+      ] as const) {
+        // Sem `new Error(msg, { cause })`: é ES2022 e o projeto compila com lib ES2020
+        // (mesma razão do `comCausa` em lib/postgrest.ts). O código do erro basta aqui.
+        if (res.error) throw new Error(`gamification: leitura de ${nome} falhou (${res.error.code ?? 'sem código'}) — score não calculado`);
+      }
       const tools = toolsRes.data || [];
       const qualityLogs = qualityRes.data || [];
       const trainings = trainingRes.data || [];

--- a/src/hooks/useTeamKpis.ts
+++ b/src/hooks/useTeamKpis.ts
@@ -11,8 +11,9 @@ export interface TeamKpis {
   receitaMesAnterior: number;
   /** Variação (fração) da receita do mês vs. mesmo período do mês anterior; null sem base. */
   variacaoMes: number | null;
-  ativosHoje: number;
-  ativos7d: number;
+  /** `null` = a leitura de atividade FALHOU (≠ zero vendedor ativo). Tile mostra "—". */
+  ativosHoje: number | null;
+  ativos7d: number | null;
 }
 
 /**
@@ -59,14 +60,18 @@ export function useTeamKpis() {
       const receitaMesAnterior = somarReceita(ordersAnterior, prior.de, prior.ate);
       const variacaoMes = variacaoPct(receitaMes, receitaMesAnterior);
 
-      // Atividade best-effort (erro → []): sales(empresa) ∪ calls ∪ visits.
+      // Atividade continua sem DERRUBAR o tile (a receita acima é que lança) — mas a falha
+      // deixa de virar zero. `contarAtivos` sobre lista vazia devolve 0, e "0 vendedores
+      // ativos hoje" é lido pela gestão como "o time parou", não como "a leitura falhou":
+      // número fabricado, exatamente a classe. Degrada para `null` → o tile mostra "—".
+      const atividadeIndisponivel = Boolean(salesRes.error || callsRes.error || visitsRes.error);
       const atividade: AtividadeRow[] = [
         ...(salesRes.data ?? []).map((r) => ({ id: r.created_by, ts: r.created_at })),
         ...(callsRes.data ?? []).map((r) => ({ id: r.farmer_id, ts: r.started_at })),
         ...(visitsRes.data ?? []).map((r) => ({ id: r.visited_by, ts: r.check_in_at })),
       ];
-      const ativosHoje = contarAtivos(atividade, inicioHojeUTC);
-      const ativos7d = contarAtivos(atividade, inicio7dUTC);
+      const ativosHoje = atividadeIndisponivel ? null : contarAtivos(atividade, inicioHojeUTC);
+      const ativos7d = atividadeIndisponivel ? null : contarAtivos(atividade, inicio7dUTC);
 
       return { receitaHoje, receitaMes, receitaMesAnterior, variacaoMes, ativosHoje, ativos7d };
     },

--- a/src/queries/useRouteContactList.ts
+++ b/src/queries/useRouteContactList.ts
@@ -224,6 +224,13 @@ export function useRouteContactList(workdayIso: string) {
           .select('win_back_reserva_pct, cold_start_piso_dia, capacidade_ligacoes_dia, cadencia_min_dias')
           .eq('id', true).maybeSingle(),
       ]);
+      // Agenda vazia é um estado LEGÍTIMO ("hoje não tem rota") — e é exatamente por isso
+      // que a falha não pode se disfarçar dela: sem esta checagem, um erro de RLS/timeout
+      // fazia `resolvePrepForWorkday` devolver zero cidade e a vendedora abria a fila de
+      // ligações VAZIA, indistinguível de um dia sem rota programada.
+      if (schedRes.error) throw schedRes.error;
+      if (ovrRes.error) throw ovrRes.error;
+      if (cfgRes.error) throw cfgRes.error;
       const sched = (schedRes.data ?? []) as RouteScheduleRow[];
       const ovr = (ovrRes.data ?? []) as RouteOverrideRow[];
       const cfgRow = (cfgRes.data ?? null) as RouteConfigRow | null;


### PR DESCRIPTION
Fase 3 da erradicação em `src/` da classe **"leitura single-shot cuja falha vira zero"** — âncora financeira no #1600, reposição/custo no #1604, pedido/crédito no #1605. **14 sites em 5 hooks**, o maior lote da triagem.

## O mais grave: score fabricado que vai para o BANCO

`useGamificationScore` lê cinco tabelas em paralelo e todas caíam em `|| []`. O score calculado a partir delas é **persistido logo abaixo** (`upsert` em `gamification_scores`) e alimenta o **ranking**. Uma falha de RLS ou timeout virava *"0 ferramentas, 0 treinamentos, 0 indicações"* — e o score deflacionado ia para o banco **como se fosse medição real**. É exatamente o padrão da âncora desta classe (#1600), onde o cron diário persistia caixa zero em `fin_projecao_snapshots` e disparava alerta falso.

Agora lança: cai no `catch` que já existia, `data` fica `null`, a tela não mostra score e **nada é gravado**.

## Os outros quatro

| hook | o que a falha fabricava |
|---|---|
| `useRouteContactList` | agenda vazia é estado **legítimo** ("hoje não tem rota") — e era disso que a falha se disfarçava. A vendedora abria a fila de ligações vazia sem saber que a leitura quebrou |
| `useFollowupsVisita` | só `visRes.error` era checado. `agRes` vazio faz o cliente que **já tem visita agendada** reaparecer como pendente (retrabalho); `callRes` vazio fabrica **"nunca contatado"**, que é o insumo da cadência |
| `useCrossSellEngine` | o cast `as unknown as Promise<{ data: ProfileRow[] \| null }>` **apagava o `error` do tipo** — o compilador nem cobrava a checagem. Um lote de profiles que falhasse virava "estes clientes não têm perfil": segmento/CNAE ausentes = recomendação errada |
| `useTeamKpis` + `TeamKpiTiles` | ver abaixo |

## O caso que NÃO virou `throw`

Em `useTeamKpis` a atividade era best-effort **de propósito** — o autor documentou: *"a query de receita (money) LANÇA em erro → tile '—' honesto; atividade (calls/visits) é best-effort"*. A intenção (não derrubar a receita por causa da atividade) é boa; o custo é que `contarAtivos([])` devolve `0`, e **"0 vendedores ativos hoje" é lido pela gestão como "o time parou"**, não como "a leitura falhou".

Então a degradação virou honesta em vez de virar exceção: `ativosHoje`/`ativos7d` passam a `number | null`, e o tile mostra `—` com o subtítulo "atividade indisponível". A receita segue lançando como antes. O `TeamKpiTiles` **já tinha** o caminho de erro (`isError ? '—'`) — faltava só o caso em que a query inteira sobrevive e só a atividade falhou.

## Verificação

- `eslint` nos 6 arquivos → **exit 0**
- A mudança de tipo está contida: `ativosHoje`/`ativos7d` só são consumidos em `TeamKpiTiles` (varredura no `src/` inteiro), e `team-kpis.test.ts` cobre as funções puras, que não mudaram.
- `typecheck`/suíte: a máquina do founder está saturada (30 sessões; o semáforo `heavy` chegou a 7 na fila) → **delegados ao CI `validate`**, que é a autoridade e o que o auto-merge espera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
