### PR TITLE
fix(dashboard/loyalty): leitura que FALHA deixa de virar "0 staff", "0 pendências" e programa sem movimento [money-path]

### DIFF
--- a/src/components/loyalty/useAdminLoyalty.ts
+++ b/src/components/loyalty/useAdminLoyalty.ts
@@ -49,6 +49,14 @@ export function useAdminLoyalty() {
         supabase.from('loyalty_redemptions').select('*').order('created_at', { ascending: false }),
       ]);
 
+      // Sem esta checagem a falha entrava nos `setState` abaixo como lista VAZIA: o painel
+      // do admin mostrava "nenhum cliente com pontos" e "nenhum resgate" — indistinguível de
+      // um programa de fidelidade sem movimento —, e um `profiles` vazio ainda renomeava todo
+      // mundo para "Desconhecido". Lançar cai no `catch` que já existe e preserva o último
+      // estado bom, em vez de sobrescrevê-lo com o vazio de uma leitura que falhou.
+      if (pointsRes.error) throw pointsRes.error;
+      if (profilesRes.error) throw profilesRes.error;
+      if (redemptionsRes.error) throw redemptionsRes.error;
       const points = (pointsRes.data || []) as PointRecord[];
       const profiles = profilesRes.data || [];
       const redData = (redemptionsRes.data || []) as RedemptionRecord[];

--- a/src/hooks/dashboard/useSistemaZone.ts
+++ b/src/hooks/dashboard/useSistemaZone.ts
@@ -28,8 +28,13 @@ export function useSistemaZone() {
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey,
     queryFn: async () => {
-      let aprovacoesPendentes = 0;
-      let staffAtivos = 0;
+      // `null` = a leitura FALHOU (≠ "zero aprovação pendente" / "zero staff"). Os três
+      // blocos abaixo têm `catch {}` que engole, então o valor inicial É o que a tela mostra
+      // quando algo quebra: começar em 0 fazia o KPI afirmar "0" com a mesma cara de um 0
+      // medido. Com null o KPI mostra "—" e o cartão de prioridade não dispara com base numa
+      // contagem que ninguém leu.
+      let aprovacoesPendentes: number | null = null;
+      let staffAtivos: number | null = null;
       let ultimaAtividadeIso: string | null = null;
       let topItems: TopListItem[] = [];
 
@@ -79,6 +84,11 @@ export function useSistemaZone() {
           supabase.from('orders').select('created_at').order('created_at', { ascending: false }).limit(1).maybeSingle(),
           supabase.from('sales_orders').select('created_at').order('created_at', { ascending: false }).limit(1).maybeSingle(),
         ]);
+        // Este KPI é o proxy de "o sistema está vivo": a leitura que falha não pode se
+        // disfarçar de "nenhum pedido jamais entrou". Lança → o `catch` abaixo deixa
+        // `ultimaAtividadeIso` em null → o KPI mostra "—" em vez de uma data errada.
+        if (ordersRes.error) throw ordersRes.error;
+        if (salesRes.error) throw salesRes.error;
         const o = (ordersRes.data as { created_at?: string | null } | null)?.created_at ?? null;
         const s = (salesRes.data as { created_at?: string | null } | null)?.created_at ?? null;
         if (o && s) {
@@ -97,15 +107,17 @@ export function useSistemaZone() {
   const kpis: KpiSpec[] = useMemo(() => {
     if (!data) return [];
     return [
-      { label: 'Aprovações', value: formatCount(data.aprovacoesPendentes) },
-      { label: 'Staff ativos', value: formatCount(data.staffAtivos) },
+      { label: 'Aprovações', value: data.aprovacoesPendentes === null ? '—' : formatCount(data.aprovacoesPendentes) },
+      { label: 'Staff ativos', value: data.staffAtivos === null ? '—' : formatCount(data.staffAtivos) },
       { label: 'Última atividade', value: formatTimeSince(data.ultimaAtividadeIso) },
     ];
   }, [data]);
 
   const priority: PriorityCandidate | null = useMemo(() => {
     if (!data) return null;
-    if (data.aprovacoesPendentes >= 3) {
+    // Leitura falhou (null) → NÃO dispara o cartão de prioridade: ele afirmaria um número
+    // de liberações que ninguém chegou a ler.
+    if (data.aprovacoesPendentes !== null && data.aprovacoesPendentes >= 3) {
       const score = 70;
       return {
         zone: 'sistema',


### PR DESCRIPTION
Fase 4 — **última de erradicação** — da classe **"leitura single-shot cuja falha vira zero"** em `src/`. Âncora financeira no #1600; reposição/custo no #1604; pedido/crédito no #1605; scoring/carteira no #1606. Com este PR os **30 sites afetados** da triagem estão fechados; falta a Fase 5, que estende o gate.

## `useSistemaZone` — o valor inicial É o que a tela mostra

Os três blocos do `queryFn` terminam em `catch { /* */ }`, que engole. Isso significa que os valores **iniciais** das variáveis são o que a UI exibe quando algo quebra — e eles eram `0`:

- `staffAtivos = 0` → KPI **"Staff ativos: 0"**, com a mesma cara de um zero medido.
- `aprovacoesPendentes = 0` → KPI "Aprovações: 0" **e** o cartão de prioridade (`>= 3`) decidindo sobre uma contagem que ninguém chegou a ler.

Agora começam em `null`: o KPI mostra `—` e o cartão de prioridade não dispara. As duas leituras de última atividade passam a checar `.error` — o proxy de *"o sistema está vivo"* não pode se disfarçar de *"nenhum pedido jamais entrou"*.

A mudança de tipo está contida: `staffAtivos`/`aprovacoesPendentes` não são lidos fora do hook (varredura no `src/` inteiro); os consumidores (`SistemaZone`, `DashboardShell`) usam `kpis`/`topItems`/`priority`.

## `useAdminLoyalty` — o vazio da falha sobrescrevia o estado bom

As três leituras caíam em `|| []` e entravam direto nos `setState`. O painel do admin mostrava **"nenhum cliente com pontos"** e **"nenhum resgate"** — indistinguível de um programa de fidelidade sem movimento — e um `profiles` vazio ainda renomeava todo mundo para **"Desconhecido"**.

Lançar cai no `catch` que já existia e **preserva o último estado bom**, em vez de sobrescrevê-lo com o vazio de uma leitura que falhou.

## Verificação

- `eslint` nos 2 arquivos → **exit 0**
- Consumidores do tipo alterado: varredura completa em `src/` → nenhum fora do próprio hook.
- `typecheck`/suíte: máquina do founder saturada (o semáforo `heavy` segue com 6 na fila) → **delegados ao CI `validate`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
