### PR TITLE
fix(vendas): analyze-unified-order sai do gateway Lovable p/ Anthropic direta — e para de rotular toda foto como jpeg [money-path]

### DIFF
--- a/src/components/unifiedAI/useUnifiedAIAssistant.ts
+++ b/src/components/unifiedAI/useUnifiedAIAssistant.ts
@@ -245,9 +245,22 @@ export function useUnifiedAIAssistant({
     } catch (e: unknown) {
       console.error('[UnifiedOrder AI] Falha ao analisar pedido:', e);
       setAiFallbackActive(true);
-      setAiMessage('A análise inteligente está indisponível no momento. Você pode continuar montando o pedido manualmente.');
-      toast.success('Análise indisponível', {
-        description: 'Continue montando o pedido manualmente. Você pode tentar novamente depois.',
+      // A edge devolve motivo ACIONÁVEL no corpo (foto HEIC que precisa virar
+      // JPEG, resposta truncada, créditos esgotados) e o invokeFunction o
+      // propaga na mensagem do erro. Trocar isso pelo texto genérico escondia
+      // do vendedor por que a foto dele não entrou na análise.
+      const motivoDoServidor =
+        e instanceof Error && e.name === 'EdgeFunctionError' &&
+        !/non-2xx status code/i.test(e.message)
+          ? e.message
+          : null;
+      setAiMessage(
+        motivoDoServidor ??
+        'A análise inteligente está indisponível no momento. Você pode continuar montando o pedido manualmente.',
+      );
+      toast.success(motivoDoServidor ? 'Análise não concluída' : 'Análise indisponível', {
+        description:
+          motivoDoServidor ?? 'Continue montando o pedido manualmente. Você pode tentar novamente depois.',
       });
     } finally {
       setIsAnalyzing(false);

--- a/supabase/functions/analyze-unified-order/imagem-helpers.ts
+++ b/supabase/functions/analyze-unified-order/imagem-helpers.ts
@@ -1,0 +1,176 @@
+// Helpers PUROS de imagem — sem import remoto, para rodar sob `deno test --no-remote`
+// (o `test:edges` do CI). A edge (index.ts) importa daqui; o SDK da Anthropic e o
+// supabase-js ficam de fora deste módulo.
+//
+// Por que existe: o frontend aceita QUALQUER `image/*` e envia o base64 cru do
+// arquivo (useUnifiedAIAssistant faz `readAsDataURL` + split, sem converter).
+// O gateway antigo sniffava o conteúdo e tolerava rótulo errado; a API da
+// Anthropic valida o `media_type` DECLARADO e responde 400 quando ele não bate
+// com os bytes. Print de tela (PNG) e foto de iPhone (HEIC) são o caso comum.
+//
+// Disciplina money-path: imagem ilegível ou grande demais é REJEITADA e o
+// motivo sobe para quem está montando o pedido — nunca some calada, porque
+// pedido montado a partir de 3 de 5 fotos parece completo e não é.
+
+/** Media types que a API da Anthropic aceita como imagem. */
+export const MEDIA_TYPES_IMAGEM = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+/** Union literal — o SDK da Anthropic tipa `media_type` assim, `string` não casa. */
+export type MediaTypeImagem = (typeof MEDIA_TYPES_IMAGEM)[number];
+
+export interface BlocoImagem {
+  type: "image";
+  source: { type: "base64"; media_type: MediaTypeImagem; data: string };
+}
+
+export type ResultadoImagem =
+  | { ok: true; bloco: BlocoImagem; mediaType: MediaTypeImagem }
+  | { ok: false; erro: string };
+
+/**
+ * Teto de request da Anthropic (32 MB) com folga para o envelope JSON — que
+ * aqui não é pequeno: o system prompt carrega o catálogo de produtos.
+ * O frontend permite 5 fotos de 5 MB, e 25 MB de binário viram ~33 MB em
+ * base64: sem este guard o request estoura o limite e volta 413/400 opaco.
+ */
+export const LIMITE_TOTAL_BASE64_BYTES = 28 * 1024 * 1024;
+
+/** Aceita base64 puro ou data-URI inteiro (defensivo: nem todo caller tira o prefixo). */
+function limparBase64(bruto: string): string {
+  return (bruto ?? "").replace(/^data:[^,]*,/, "").replace(/\s/g, "");
+}
+
+/** Decodifica só o cabeçalho — nunca a imagem inteira. */
+function primeirosBytes(base64: string, quantos: number): Uint8Array | null {
+  // 4 chars base64 = 3 bytes; `atob` exige comprimento múltiplo de 4.
+  const desejado = Math.ceil(quantos / 3) * 4;
+  const disponivel = Math.min(base64.length, desejado);
+  const alinhado = disponivel - (disponivel % 4);
+  if (alinhado < 4) return null;
+  try {
+    const bin = atob(base64.slice(0, alinhado));
+    const out = new Uint8Array(Math.min(bin.length, quantos));
+    for (let i = 0; i < out.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function assinaturaBate(
+  bytes: Uint8Array,
+  assinatura: readonly number[],
+  deslocamento = 0,
+): boolean {
+  if (bytes.length < deslocamento + assinatura.length) return false;
+  return assinatura.every((b, i) => bytes[deslocamento + i] === b);
+}
+
+/**
+ * Detecta o media type pelos MAGIC BYTES do conteúdo — nunca pelo rótulo do
+ * caller. Devolve `null` para formato que a Anthropic não aceita (HEIC, BMP,
+ * TIFF, SVG) ou base64 ilegível: fail-closed, para não declarar tipo errado.
+ */
+export function detectarMediaTypeImagem(base64: string): MediaTypeImagem | null {
+  const limpo = limparBase64(base64);
+  if (!limpo) return null;
+  const b = primeirosBytes(limpo, 16);
+  if (!b) return null;
+
+  if (assinaturaBate(b, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (assinaturaBate(b, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (assinaturaBate(b, [0x47, 0x49, 0x46, 0x38])) return "image/gif"; // GIF87a/GIF89a
+  // WebP = "RIFF" + 4 bytes de tamanho + "WEBP" — os dois pedaços são necessários,
+  // senão qualquer container RIFF (AVI, WAV) passaria por imagem.
+  if (
+    assinaturaBate(b, [0x52, 0x49, 0x46, 0x46]) &&
+    assinaturaBate(b, [0x57, 0x45, 0x42, 0x50], 8)
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/** Monta o content block de UMA imagem, com o media type real detectado. */
+export function montarBlocoImagem(base64: string): ResultadoImagem {
+  const limpo = limparBase64(base64);
+  if (!limpo) return { ok: false, erro: "imagem vazia" };
+
+  const mediaType = detectarMediaTypeImagem(limpo);
+  if (!mediaType) {
+    return {
+      ok: false,
+      erro:
+        "formato não suportado pela IA (aceitos: JPEG, PNG, GIF, WebP). Foto de iPhone em HEIC precisa virar JPEG — tire um print ou reenvie pela galeria.",
+    };
+  }
+
+  return {
+    ok: true,
+    mediaType,
+    bloco: {
+      type: "image",
+      source: { type: "base64", media_type: mediaType, data: limpo },
+    },
+  };
+}
+
+export interface ImagemRejeitada {
+  indice: number;
+  motivo: string;
+}
+
+export interface ImagensPreparadas {
+  blocos: BlocoImagem[];
+  rejeitadas: ImagemRejeitada[];
+}
+
+/**
+ * Prepara o lote inteiro respeitando o teto de request. A imagem que não cabe
+ * (ou não é legível) sai da chamada e vira `rejeitadas` — o caller devolve isso
+ * ao vendedor, porque análise feita sobre um subconjunto das fotos não pode
+ * chegar com cara de análise completa.
+ */
+export function prepararImagens(brutas: readonly string[]): ImagensPreparadas {
+  const blocos: BlocoImagem[] = [];
+  const rejeitadas: ImagemRejeitada[] = [];
+  let acumulado = 0;
+
+  for (let i = 0; i < brutas.length; i++) {
+    const r = montarBlocoImagem(brutas[i]);
+    if (!r.ok) {
+      rejeitadas.push({ indice: i, motivo: r.erro });
+      continue;
+    }
+    const tamanho = r.bloco.source.data.length;
+    if (acumulado + tamanho > LIMITE_TOTAL_BASE64_BYTES) {
+      const mb = (tamanho / (1024 * 1024)).toFixed(1);
+      rejeitadas.push({
+        indice: i,
+        motivo:
+          `não coube no limite de ~28 MB por análise (${mb} MB somados às anteriores). Envie em duas levas.`,
+      });
+      continue;
+    }
+    acumulado += tamanho;
+    blocos.push(r.bloco);
+  }
+
+  return { blocos, rejeitadas };
+}
+
+/** Aviso legível para o vendedor quando alguma foto ficou de fora. */
+export function avisoImagensRejeitadas(rejeitadas: readonly ImagemRejeitada[]): string {
+  if (rejeitadas.length === 0) return "";
+  const lista = rejeitadas
+    .map((r) => `foto ${r.indice + 1} (${r.motivo})`)
+    .join("; ");
+  return `${rejeitadas.length} foto(s) NÃO analisada(s): ${lista}`;
+}

--- a/supabase/functions/analyze-unified-order/imagem-helpers.ts
+++ b/supabase/functions/analyze-unified-order/imagem-helpers.ts
@@ -98,10 +98,23 @@ export function detectarMediaTypeImagem(base64: string): MediaTypeImagem | null 
   return null;
 }
 
+/** Alfabeto base64 padrão + padding só no fim. */
+const BASE64_BEM_FORMADO = /^[A-Za-z0-9+/]+={0,2}$/;
+
 /** Monta o content block de UMA imagem, com o media type real detectado. */
 export function montarBlocoImagem(base64: string): ResultadoImagem {
   const limpo = limparBase64(base64);
   if (!limpo) return { ok: false, erro: "imagem vazia" };
+
+  // A detecção só lê o cabeçalho; sem esta checagem, arquivo truncado ou
+  // corrompido DEPOIS dos magic bytes passaria e só viraria 400 na API, com a
+  // análise já perdida. Valida o formato inteiro sem decodificar 28 MB.
+  if (limpo.length % 4 !== 0 || !BASE64_BEM_FORMADO.test(limpo)) {
+    return {
+      ok: false,
+      erro: "arquivo corrompido ou incompleto (base64 malformado). Reenvie a foto.",
+    };
+  }
 
   const mediaType = detectarMediaTypeImagem(limpo);
   if (!mediaType) {
@@ -138,10 +151,16 @@ export interface ImagensPreparadas {
  * ao vendedor, porque análise feita sobre um subconjunto das fotos não pode
  * chegar com cara de análise completa.
  */
-export function prepararImagens(brutas: readonly string[]): ImagensPreparadas {
+export function prepararImagens(
+  brutas: readonly string[],
+  orcamentoJaUsadoBytes = 0,
+): ImagensPreparadas {
   const blocos: BlocoImagem[] = [];
   const rejeitadas: ImagemRejeitada[] = [];
-  let acumulado = 0;
+  // O teto de 32 MB vale para o CORPO INTEIRO do request — o system prompt
+  // carrega o catálogo e conta junto. Começar do zero aqui superestimaria a
+  // folga e o request estouraria com 413.
+  let acumulado = Math.max(0, orcamentoJaUsadoBytes);
 
   for (let i = 0; i < brutas.length; i++) {
     const r = montarBlocoImagem(brutas[i]);

--- a/supabase/functions/analyze-unified-order/imagem-helpers_test.ts
+++ b/supabase/functions/analyze-unified-order/imagem-helpers_test.ts
@@ -34,6 +34,16 @@ function b64(bytes: number[]): string {
 
 const CORPO = Array.from({ length: 40 }, (_, i) => i % 256);
 
+/**
+ * JPEG grande e BEM FORMADO: cabeçalho de 3 bytes (4 chars, sem padding no
+ * meio) + enchimento em múltiplo de 4, senão a validação de formato o rejeita
+ * antes de o teto de tamanho ser exercitado.
+ */
+function jpegGrande(fracaoDoLimite: number): string {
+  const alvo = Math.ceil((LIMITE_TOTAL_BASE64_BYTES * fracaoDoLimite) / 4) * 4;
+  return b64([0xff, 0xd8, 0xff]) + "A".repeat(alvo);
+}
+
 const JPEG = b64([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, ...CORPO]);
 const PNG = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, ...CORPO]);
 const GIF87 = b64([0x47, 0x49, 0x46, 0x38, 0x37, 0x61, ...CORPO]);
@@ -125,6 +135,30 @@ Deno.test("montarBlocoImagem: HEIC dá erro ACIONÁVEL (é o caso do iPhone)", (
   assert(r.erro.includes("JPEG"), "erro deveria dizer o que fazer");
 });
 
+Deno.test("montarBlocoImagem: cabeçalho válido + corpo corrompido é REJEITADO", () => {
+  // A detecção só lê os magic bytes; sem checar o formato inteiro, arquivo
+  // truncado passaria e só viraria 400 na API, com a análise já perdida.
+  const corrompido = JPEG.slice(0, 12) + "!!!$$$@@@";
+  const r = montarBlocoImagem(corrompido);
+  assert(!r.ok, "base64 malformado deveria ser rejeitado");
+  if (r.ok) return;
+  assert(r.erro.includes("corrompido"), "erro deveria dizer que o arquivo está corrompido");
+});
+
+Deno.test("montarBlocoImagem: comprimento fora do múltiplo de 4 é rejeitado", () => {
+  assert(!montarBlocoImagem(JPEG + "A").ok, "truncado deveria ser rejeitado");
+});
+
+Deno.test("prepararImagens: orçamento já consumido reduz o que cabe", () => {
+  // O system prompt (catálogo) entra no MESMO request; ignorá-lo superestima a
+  // folga e o request estoura com 413.
+  const grande = jpegGrande(0.6);
+  assertEquals(prepararImagens([grande]).blocos.length, 1, "sozinha, cabe");
+  const comOrcamento = prepararImagens([grande], Math.ceil(LIMITE_TOTAL_BASE64_BYTES * 0.6));
+  assertEquals(comOrcamento.blocos.length, 0, "com o system ocupando 60%, não cabe mais");
+  assertEquals(comOrcamento.rejeitadas.length, 1);
+});
+
 Deno.test("montarBlocoImagem: o data-URI é removido dos dados enviados", () => {
   const r = montarBlocoImagem(`data:image/png;base64,${PNG}`);
   assert(r.ok, "deveria aceitar");
@@ -149,10 +183,7 @@ Deno.test("prepararImagens: mistura de formatos — bons passam, ruins viram rej
 Deno.test("prepararImagens: teto de request corta o excedente em vez de estourar a API", () => {
   // O frontend deixa 5 fotos de 5 MB; 25 MB de binário viram ~33 MB em base64,
   // acima do limite de 32 MB da Anthropic.
-  // 3 bytes = 4 chars base64 SEM padding: um "=" no meio da string quebraria o
-  // atob do cabeçalho e a imagem seria rejeitada por formato, não pelo teto.
-  const grande = b64([0xff, 0xd8, 0xff]) +
-    "A".repeat(Math.ceil(LIMITE_TOTAL_BASE64_BYTES * 0.6));
+  const grande = jpegGrande(0.6);
   const { blocos, rejeitadas } = prepararImagens([grande, grande, grande]);
   assertEquals(blocos.length, 1, "só a primeira cabe");
   assertEquals(rejeitadas.length, 2);

--- a/supabase/functions/analyze-unified-order/imagem-helpers_test.ts
+++ b/supabase/functions/analyze-unified-order/imagem-helpers_test.ts
@@ -1,0 +1,187 @@
+// Testa o CÓDIGO REAL de imagem-helpers.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/analyze-unified-order/
+//
+// Foco: a detecção por magic bytes. O frontend aceita qualquer `image/*` e o
+// código antigo rotulava TUDO como image/jpeg — o gateway sniffava e tolerava,
+// a Anthropic recusa com 400. Um rótulo errado aqui derruba a análise inteira
+// do pedido; um formato aceito calado sem estar na lista faz o mesmo.
+import {
+  avisoImagensRejeitadas,
+  detectarMediaTypeImagem,
+  LIMITE_TOTAL_BASE64_BYTES,
+  montarBlocoImagem,
+  prepararImagens,
+} from "./imagem-helpers.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+/** Monta base64 a partir de bytes crus — é assim que o arquivo real chega. */
+function b64(bytes: number[]): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+const CORPO = Array.from({ length: 40 }, (_, i) => i % 256);
+
+const JPEG = b64([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, ...CORPO]);
+const PNG = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, ...CORPO]);
+const GIF87 = b64([0x47, 0x49, 0x46, 0x38, 0x37, 0x61, ...CORPO]);
+const GIF89 = b64([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, ...CORPO]);
+// RIFF + 4 bytes de tamanho + WEBP
+const WEBP = b64([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+  0x57, 0x45, 0x42, 0x50, ...CORPO,
+]);
+// Container RIFF que NÃO é webp (WAVE) — precisa ser rejeitado.
+const WAVE = b64([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+  0x57, 0x41, 0x56, 0x45, ...CORPO,
+]);
+// HEIC: foto de iPhone. `ftypheic` no offset 4. A Anthropic não aceita.
+const HEIC = b64([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+  0x68, 0x65, 0x69, 0x63, ...CORPO,
+]);
+const BMP = b64([0x42, 0x4d, 0x36, 0x00, ...CORPO]);
+const PDF = b64([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, ...CORPO]);
+
+// ─────────────────────── detectarMediaTypeImagem ───────────────────────
+
+Deno.test("detecta os 4 formatos que a Anthropic aceita, pelos magic bytes", () => {
+  assertEquals(detectarMediaTypeImagem(JPEG), "image/jpeg");
+  assertEquals(detectarMediaTypeImagem(PNG), "image/png");
+  assertEquals(detectarMediaTypeImagem(GIF87), "image/gif");
+  assertEquals(detectarMediaTypeImagem(GIF89), "image/gif");
+  assertEquals(detectarMediaTypeImagem(WEBP), "image/webp");
+});
+
+Deno.test("PNG NÃO é rotulado como jpeg — a regressão que motivou o helper", () => {
+  // O código antigo mandava `data:image/jpeg;base64,<png>`; o Gemini sniffava
+  // e engolia, a Anthropic devolve 400 e o vendedor perde a análise inteira.
+  assertEquals(detectarMediaTypeImagem(PNG), "image/png");
+  const r = montarBlocoImagem(PNG);
+  assert(r.ok, "png deveria ser aceito");
+  if (!r.ok) return;
+  assertEquals(r.bloco.source.media_type, "image/png");
+});
+
+Deno.test("formato fora da lista da Anthropic é rejeitado, não adivinhado", () => {
+  for (const [nome, dados] of [["heic", HEIC], ["bmp", BMP], ["pdf", PDF], ["wave", WAVE]] as const) {
+    assertEquals(detectarMediaTypeImagem(dados), null, `${nome} deveria dar null`);
+  }
+});
+
+Deno.test("RIFF só vira webp com o marcador WEBP no offset 8", () => {
+  // Sem o segundo pedaço da assinatura, WAV/AVI passariam por imagem.
+  assertEquals(detectarMediaTypeImagem(WAVE), null);
+  assertEquals(detectarMediaTypeImagem(WEBP), "image/webp");
+});
+
+Deno.test("base64 ilegível/vazio/curto degrada para null, não explode", () => {
+  for (const v of ["", "   ", "!!!!", "@@", "A", "aa"]) {
+    assertEquals(detectarMediaTypeImagem(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("aceita data-URI inteiro além do base64 puro", () => {
+  assertEquals(detectarMediaTypeImagem(`data:image/png;base64,${PNG}`), "image/png");
+  // Rótulo do data-URI é IGNORADO: valem os bytes, não o que o caller diz.
+  assertEquals(detectarMediaTypeImagem(`data:image/jpeg;base64,${PNG}`), "image/png");
+});
+
+Deno.test("whitespace no meio do base64 não quebra a detecção", () => {
+  const comQuebras = PNG.slice(0, 8) + "\n  " + PNG.slice(8);
+  assertEquals(detectarMediaTypeImagem(comQuebras), "image/png");
+});
+
+// ─────────────────────────── montarBlocoImagem ───────────────────────────
+
+Deno.test("montarBlocoImagem: bloco no formato de content block da Anthropic", () => {
+  const r = montarBlocoImagem(JPEG);
+  assert(r.ok, "jpeg deveria ser aceito");
+  if (!r.ok) return;
+  assertEquals(r.bloco.type, "image");
+  assertEquals(r.bloco.source.type, "base64");
+  assertEquals(r.bloco.source.media_type, "image/jpeg");
+  assertEquals(r.bloco.source.data, JPEG);
+});
+
+Deno.test("montarBlocoImagem: HEIC dá erro ACIONÁVEL (é o caso do iPhone)", () => {
+  const r = montarBlocoImagem(HEIC);
+  assert(!r.ok, "heic deveria ser rejeitado");
+  if (r.ok) return;
+  assert(r.erro.includes("HEIC"), "erro deveria citar HEIC");
+  assert(r.erro.includes("JPEG"), "erro deveria dizer o que fazer");
+});
+
+Deno.test("montarBlocoImagem: o data-URI é removido dos dados enviados", () => {
+  const r = montarBlocoImagem(`data:image/png;base64,${PNG}`);
+  assert(r.ok, "deveria aceitar");
+  if (!r.ok) return;
+  assert(!r.bloco.source.data.startsWith("data:"), "o prefixo não pode ir para a API");
+  assertEquals(r.bloco.source.data, PNG);
+});
+
+// ──────────────────────────── prepararImagens ────────────────────────────
+
+Deno.test("prepararImagens: mistura de formatos — bons passam, ruins viram rejeitadas", () => {
+  const { blocos, rejeitadas } = prepararImagens([JPEG, HEIC, PNG, BMP, WEBP]);
+  assertEquals(blocos.length, 3);
+  assertEquals(blocos.map((b) => b.source.media_type), [
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+  ]);
+  assertEquals(rejeitadas.map((r) => r.indice), [1, 3], "índice preserva a posição original");
+});
+
+Deno.test("prepararImagens: teto de request corta o excedente em vez de estourar a API", () => {
+  // O frontend deixa 5 fotos de 5 MB; 25 MB de binário viram ~33 MB em base64,
+  // acima do limite de 32 MB da Anthropic.
+  // 3 bytes = 4 chars base64 SEM padding: um "=" no meio da string quebraria o
+  // atob do cabeçalho e a imagem seria rejeitada por formato, não pelo teto.
+  const grande = b64([0xff, 0xd8, 0xff]) +
+    "A".repeat(Math.ceil(LIMITE_TOTAL_BASE64_BYTES * 0.6));
+  const { blocos, rejeitadas } = prepararImagens([grande, grande, grande]);
+  assertEquals(blocos.length, 1, "só a primeira cabe");
+  assertEquals(rejeitadas.length, 2);
+  assert(rejeitadas.every((r) => r.motivo.includes("MB")), "motivo deveria citar o tamanho");
+});
+
+Deno.test("prepararImagens: lote inteiro inválido devolve zero blocos (fail-closed)", () => {
+  const { blocos, rejeitadas } = prepararImagens([HEIC, BMP, ""]);
+  assertEquals(blocos.length, 0);
+  assertEquals(rejeitadas.length, 3);
+});
+
+Deno.test("prepararImagens: lista vazia não inventa bloco nem rejeição", () => {
+  assertEquals(prepararImagens([]), { blocos: [], rejeitadas: [] });
+});
+
+// ─────────────────────── avisoImagensRejeitadas ───────────────────────
+
+Deno.test("avisoImagensRejeitadas: sem rejeição não gera ruído", () => {
+  assertEquals(avisoImagensRejeitadas([]), "");
+});
+
+Deno.test("avisoImagensRejeitadas: foto descartada aparece NUMERADA para o vendedor", () => {
+  // Análise sobre 3 de 5 fotos não pode chegar com cara de análise completa.
+  const texto = avisoImagensRejeitadas([
+    { indice: 1, motivo: "formato não suportado" },
+    { indice: 3, motivo: "não coube no limite" },
+  ]);
+  assert(texto.includes("2 foto(s) NÃO analisada(s)"), "deveria contar as descartadas");
+  assert(texto.includes("foto 2"), "índice 1 deveria virar 'foto 2' (1-based p/ humano)");
+  assert(texto.includes("foto 4"), "índice 3 deveria virar 'foto 4'");
+});

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -926,7 +926,7 @@ Responda SEMPRE usando a função identify_order_items.`;
     // ao carrinho: `"12.50" > 0` é true por coerção e explodiria no checkout;
     // `1 + "2"` viraria a quantidade "12".
     const bruto = extraido.input;
-    // deno-lint-ignore no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- saída de LLM consumida de forma dinâmica em ~20 pontos a jusante (resgate por fuzzy match, casamento de cliente); os campos money-path já foram travados por sanitizarListaIA acima
     const result: any = bruto && typeof bruto === "object" && !Array.isArray(bruto)
       ? { ...bruto }
       : {};

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -1,5 +1,12 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import {
+  avisoImagensRejeitadas,
+  type BlocoImagem,
+  type ImagemRejeitada,
+  prepararImagens,
+} from "./imagem-helpers.ts";
 
 // Strip diacritics/accents for fuzzy comparison
 function stripAccents(str: string): string {
@@ -110,10 +117,12 @@ interface AISuggestion {
   servico_descricao?: string;
 }
 
-interface AIChatMessage {
-  role: "system" | "user" | "assistant";
-  content: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
-}
+/** Content block da Anthropic: texto ou imagem base64 com media type real. */
+type BlocoConteudo = { type: "text"; text: string } | BlocoImagem;
+
+/** Modelo e teto de saída — ver convenção de LLM em edge no CLAUDE.md. */
+const MODELO = "claude-sonnet-4-6";
+const MAX_TOKENS = 8000;
 
 interface ToolPropertySchema {
   type: string | string[];
@@ -224,8 +233,8 @@ serve(async (req) => {
       });
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
+    const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!ANTHROPIC_API_KEY) throw new Error("ANTHROPIC_API_KEY is not configured");
 
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseKey);
@@ -698,20 +707,34 @@ REGRAS DE IDENTIFICAÇÃO DE CLIENTE (CRÍTICAS):
 ` : ""}
 Responda SEMPRE usando a função identify_order_items.`;
 
-    const messages: AIChatMessage[] = [
-      { role: "system", content: systemPrompt },
-    ];
+    // O system prompt (que carrega o catálogo inteiro) vai no parâmetro `system`
+    // da Anthropic, não como mensagem — é isso que habilita o prompt caching.
+    const conteudoUsuario: BlocoConteudo[] = [];
+    let imagensRejeitadas: ImagemRejeitada[] = [];
 
     if (allImages.length > 0) {
-      const content: Array<{ type: string; text?: string; image_url?: { url: string } }> = [
-        { type: "text", text: text || "Identifique os produtos, ferramentas e cliente nestas imagens e sugira os itens para o pedido:" },
-      ];
-      for (const img of allImages) {
-        content.push({ type: "image_url", image_url: { url: `data:image/jpeg;base64,${img}` } });
+      // Media type vem dos MAGIC BYTES. O gateway antigo sniffava o conteúdo e
+      // engolia o rótulo fixo `image/jpeg`; a Anthropic valida o declarado.
+      const preparadas = prepararImagens(allImages);
+      imagensRejeitadas = preparadas.rejeitadas;
+
+      // Nenhuma foto legível e nenhum texto: não há o que analisar. Responder
+      // "não identifiquei itens" aqui esconderia o motivo real do vendedor.
+      if (preparadas.blocos.length === 0 && !text) {
+        return new Response(JSON.stringify({
+          products: [], services: [], suggestions: [], customer: null,
+          imagens_rejeitadas: imagensRejeitadas,
+          error: avisoImagensRejeitadas(imagensRejeitadas),
+        }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
       }
-      messages.push({ role: "user", content });
+
+      conteudoUsuario.push({
+        type: "text",
+        text: text || "Identifique os produtos, ferramentas e cliente nestas imagens e sugira os itens para o pedido:",
+      });
+      conteudoUsuario.push(...preparadas.blocos);
     } else {
-      messages.push({ role: "user", content: text });
+      conteudoUsuario.push({ type: "text", text });
     }
 
     // Build tool schema
@@ -792,60 +815,73 @@ Responda SEMPRE usando a função identify_order_items.`;
       requiredFields.push("customer");
     }
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: allImages.length > 0 ? "google/gemini-2.5-flash" : "google/gemini-3-flash-preview",
-        messages,
+    const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+
+    let resposta;
+    try {
+      resposta = await anthropic.messages.create({
+        model: MODELO,
+        max_tokens: MAX_TOKENS,
+        // O catálogo domina o prompt e repete entre chamadas do mesmo vendedor —
+        // marcar o system como cacheável é o que segura o custo desta edge.
+        system: [
+          { type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } },
+        ],
         tools: [
           {
-            type: "function",
-            function: {
-              name: "identify_order_items",
-              description: "Retorna produtos, serviços e cliente identificados no pedido",
-              parameters: {
-                type: "object",
-                properties: toolProperties,
-                required: requiredFields,
-              },
+            name: "identify_order_items",
+            description: "Retorna produtos, serviços e cliente identificados no pedido",
+            input_schema: {
+              type: "object" as const,
+              properties: toolProperties,
+              required: requiredFields,
             },
           },
         ],
-        tool_choice: { type: "function", function: { name: "identify_order_items" } },
-      }),
-    });
-
-    if (!response.ok) {
-      if (response.status === 429) {
+        tool_choice: { type: "tool", name: "identify_order_items" },
+        messages: [{ role: "user", content: conteudoUsuario }],
+      });
+    } catch (e: unknown) {
+      const status = (e as { status?: number })?.status;
+      if (status === 429) {
         return new Response(JSON.stringify({ error: "Limite de requisições excedido. Tente novamente." }), {
           status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }
-      if (response.status === 402) {
-        return new Response(JSON.stringify({ error: "Créditos insuficientes." }), {
-          status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      if (status === 529 || status === 503) {
+        return new Response(JSON.stringify({ error: "IA sobrecarregada no momento. Tente de novo em instantes." }), {
+          status: 503, headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }
-      const errorText = await response.text();
-      console.error("AI gateway error:", response.status, errorText);
+      console.error("[analyze-unified-order] erro na API da Anthropic:", status, e instanceof Error ? e.message : e);
       throw new Error("Erro ao processar com IA");
     }
 
-    const aiResponse = await response.json();
-    const toolCall = aiResponse.choices?.[0]?.message?.tool_calls?.[0];
-
-    if (!toolCall) {
+    // §8 money-path: teto que trunca fabrica completude. Uma lista cortada no
+    // meio chega ao vendedor com cara de lista inteira e vira pedido incompleto.
+    if (resposta.stop_reason === "max_tokens") {
+      console.error(`[analyze-unified-order] resposta truncada em ${MAX_TOKENS} tokens`);
       return new Response(JSON.stringify({
         products: [], services: [], suggestions: [], customer: null,
+        error: "Pedido grande demais para analisar de uma vez — a resposta foi cortada. Divida em duas partes e envie de novo.",
+      }), { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    }
+
+    const blocoTool = resposta.content.find((b) => b.type === "tool_use");
+
+    if (!blocoTool) {
+      return new Response(JSON.stringify({
+        products: [], services: [], suggestions: [], customer: null,
+        imagens_rejeitadas: imagensRejeitadas,
         message: "Não consegui identificar itens. Seja mais específico ou selecione manualmente.",
       }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 
-    const result = JSON.parse(toolCall.function.arguments);
+    // `input` já vem como objeto validado contra o input_schema — sem JSON.parse.
+    // Tipo permissivo de propósito: o consumo abaixo (resgate por fuzzy match,
+    // casamento de cliente) é o mesmo de quando isto era `any` vindo do parse.
+    // deno-lint-ignore no-explicit-any
+    const result = blocoTool.input as any;
 
     // Validate product IDs - rescue invalid ones by fuzzy matching
     const validProductIds = new Set(prodList.map((p) => p.id));
@@ -1401,12 +1437,19 @@ Responda SEMPRE usando a função identify_order_items.`;
         }
       : null;
 
+    // Foto que ficou de fora entra na MENSAGEM, não só num campo: análise de 3
+    // de 5 fotos não pode chegar com cara de análise completa.
+    const avisoFotos = avisoImagensRejeitadas(imagensRejeitadas);
+    const mensagemBase = result.message ||
+      `Identificado ${validProducts.length} produto(s) e ${validServices.length} serviço(s).`;
+
     return new Response(JSON.stringify({
       products: validProducts,
       services: validServices,
       suggestions: validSuggestions,
       customer: safeCustomer,
-      message: result.message || `Identificado ${validProducts.length} produto(s) e ${validServices.length} serviço(s).`,
+      imagens_rejeitadas: imagensRejeitadas,
+      message: avisoFotos ? `${mensagemBase} ⚠️ ${avisoFotos}` : mensagemBase,
     }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
 
   } catch (error) {

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -7,6 +7,7 @@ import {
   type ImagemRejeitada,
   prepararImagens,
 } from "./imagem-helpers.ts";
+import { extrairToolUseUnico, sanitizarListaIA } from "./saida-ia.ts";
 
 // Strip diacritics/accents for fuzzy comparison
 function stripAccents(str: string): string {
@@ -715,7 +716,10 @@ Responda SEMPRE usando a função identify_order_items.`;
     if (allImages.length > 0) {
       // Media type vem dos MAGIC BYTES. O gateway antigo sniffava o conteúdo e
       // engolia o rótulo fixo `image/jpeg`; a Anthropic valida o declarado.
-      const preparadas = prepararImagens(allImages);
+      // O system prompt (catálogo + candidatos) entra no MESMO corpo de request,
+      // então desconta do orçamento antes de acomodar as fotos.
+      const bytesSystem = new TextEncoder().encode(systemPrompt).byteLength;
+      const preparadas = prepararImagens(allImages, bytesSystem);
       imagensRejeitadas = preparadas.rejeitadas;
 
       // Nenhuma foto legível e nenhum texto: não há o que analisar. Responder
@@ -822,11 +826,13 @@ Responda SEMPRE usando a função identify_order_items.`;
       resposta = await anthropic.messages.create({
         model: MODELO,
         max_tokens: MAX_TOKENS,
-        // O catálogo domina o prompt e repete entre chamadas do mesmo vendedor —
-        // marcar o system como cacheável é o que segura o custo desta edge.
-        system: [
-          { type: "text", text: systemPrompt, cache_control: { type: "ephemeral" } },
-        ],
+        // SEM cache_control de propósito: o prompt começa pelo catálogo,
+        // candidatos e histórico — tudo variável por request. Como o cache é por
+        // PREFIXO, cada chamada seria um miss pagando 1,25× de escrita e nunca
+        // colhendo o 0,1× de leitura. Para cachear de verdade seria preciso
+        // inverter o prompt (regras fixas primeiro, catálogo depois) — mudança
+        // de comportamento que não cabe numa troca de provedor.
+        system: systemPrompt,
         tools: [
           {
             name: "identify_order_items",
@@ -838,22 +844,42 @@ Responda SEMPRE usando a função identify_order_items.`;
             },
           },
         ],
-        tool_choice: { type: "tool", name: "identify_order_items" },
+        // `type:"tool"` sozinho NÃO desliga chamada paralela: o modelo poderia
+        // emitir um bloco por grupo de itens e o consumo pegaria só o primeiro,
+        // entregando pedido PARCIAL com cara de completo.
+        tool_choice: {
+          type: "tool",
+          name: "identify_order_items",
+          disable_parallel_tool_use: true,
+        },
         messages: [{ role: "user", content: conteudoUsuario }],
       });
     } catch (e: unknown) {
       const status = (e as { status?: number })?.status;
-      if (status === 429) {
-        return new Response(JSON.stringify({ error: "Limite de requisições excedido. Tente novamente." }), {
-          status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      const detalhe = e instanceof Error ? e.message : String(e);
+      console.error("[analyze-unified-order] erro na API da Anthropic:", status, detalhe);
+
+      // O 402 NÃO desapareceu com o gateway: a Anthropic devolve billing_error.
+      // Sem tratá-lo, a mesma falha que motivou esta migração voltaria como 500
+      // genérico e ninguém saberia que o problema é saldo.
+      const porStatus: Record<number, { http: number; msg: string }> = {
+        400: { http: 400, msg: "A IA recusou o conteúdo enviado. Tente outra foto ou descreva o pedido por texto." },
+        402: { http: 402, msg: "Créditos da IA esgotados — avise a equipe. Monte o pedido manualmente por enquanto." },
+        401: { http: 500, msg: "IA mal configurada — avise a equipe." },
+        403: { http: 500, msg: "IA mal configurada — avise a equipe." },
+        404: { http: 500, msg: "IA mal configurada — avise a equipe." },
+        413: { http: 413, msg: "Envio grande demais. Mande menos fotos por vez." },
+        429: { http: 429, msg: "Limite de requisições excedido. Tente novamente." },
+        500: { http: 503, msg: "IA sobrecarregada no momento. Tente de novo em instantes." },
+        503: { http: 503, msg: "IA sobrecarregada no momento. Tente de novo em instantes." },
+        529: { http: 503, msg: "IA sobrecarregada no momento. Tente de novo em instantes." },
+      };
+      const mapeado = status ? porStatus[status] : undefined;
+      if (mapeado) {
+        return new Response(JSON.stringify({ error: mapeado.msg, imagens_rejeitadas: imagensRejeitadas }), {
+          status: mapeado.http, headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
       }
-      if (status === 529 || status === 503) {
-        return new Response(JSON.stringify({ error: "IA sobrecarregada no momento. Tente de novo em instantes." }), {
-          status: 503, headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      console.error("[analyze-unified-order] erro na API da Anthropic:", status, e instanceof Error ? e.message : e);
       throw new Error("Erro ao processar com IA");
     }
 
@@ -867,21 +893,46 @@ Responda SEMPRE usando a função identify_order_items.`;
       }), { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 
-    const blocoTool = resposta.content.find((b) => b.type === "tool_use");
+    const extraido = extrairToolUseUnico(resposta.content);
 
-    if (!blocoTool) {
+    if (!extraido.ok) {
+      if (extraido.motivo === "multiplo") {
+        // Análise partida em vários blocos: não dá para provar que veio inteira,
+        // e consumir só o primeiro entregaria pedido parcial como se completo.
+        console.error(
+          `[analyze-unified-order] ${extraido.quantidade} blocos tool_use (esperado 1)`,
+        );
+        return new Response(JSON.stringify({
+          products: [], services: [], suggestions: [], customer: null,
+          imagens_rejeitadas: imagensRejeitadas,
+          error:
+            "A IA devolveu a análise em partes e não dá para garantir que veio inteira. Tente de novo ou divida o pedido.",
+        }), { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+      }
+
+      const avisoSemTool = avisoImagensRejeitadas(imagensRejeitadas);
+      const baseSemTool =
+        "Não consegui identificar itens. Seja mais específico ou selecione manualmente.";
       return new Response(JSON.stringify({
         products: [], services: [], suggestions: [], customer: null,
         imagens_rejeitadas: imagensRejeitadas,
-        message: "Não consegui identificar itens. Seja mais específico ou selecione manualmente.",
+        message: avisoSemTool ? `${baseSemTool} ⚠️ ${avisoSemTool}` : baseSemTool,
       }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
     }
 
-    // `input` já vem como objeto validado contra o input_schema — sem JSON.parse.
-    // Tipo permissivo de propósito: o consumo abaixo (resgate por fuzzy match,
-    // casamento de cliente) é o mesmo de quando isto era `any` vindo do parse.
+    // Forced tool-use garante que a ferramenta foi USADA — não que os tipos do
+    // input_schema foram respeitados (isso só com `strict:true`). Esta é a
+    // fronteira onde preço-string e quantidade-string param, antes de chegarem
+    // ao carrinho: `"12.50" > 0` é true por coerção e explodiria no checkout;
+    // `1 + "2"` viraria a quantidade "12".
+    const bruto = extraido.input;
     // deno-lint-ignore no-explicit-any
-    const result = blocoTool.input as any;
+    const result: any = bruto && typeof bruto === "object" && !Array.isArray(bruto)
+      ? { ...bruto }
+      : {};
+    result.products = sanitizarListaIA(result.products);
+    result.services = sanitizarListaIA(result.services);
+    result.suggestions = sanitizarListaIA(result.suggestions);
 
     // Validate product IDs - rescue invalid ones by fuzzy matching
     const validProductIds = new Set(prodList.map((p) => p.id));

--- a/supabase/functions/analyze-unified-order/saida-ia.ts
+++ b/supabase/functions/analyze-unified-order/saida-ia.ts
@@ -1,0 +1,109 @@
+// Guards money-path da SAÍDA da IA — puros, sem import remoto (rodam sob
+// `deno test --no-remote`, o `test:edges` do CI).
+//
+// Por que existe: forced tool-use garante que a ferramenta É USADA, não que os
+// tipos declarados no `input_schema` sejam respeitados — isso só com
+// `strict: true`. O gateway antigo era igualmente permissivo, então esta é uma
+// trava de FRONTEIRA (a edge é o ponto por onde todo esse dado passa), não uma
+// regressão da migração.
+//
+// Os caminhos concretos que fecha, confirmados no código consumidor:
+//   - `unit_price: "12.50"` (string) passa em `preco > 0` por coerção do JS,
+//     entra no carrinho como string e explode no `.toFixed(2)` do checkout;
+//   - `quantity: "2"` faz `1 + "2"` virar `"12"` ao somar com item existente —
+//     uma quantidade FABRICADA que ninguém digitou.
+
+/**
+ * Número utilizável a partir da saída da IA.
+ * Aceita number finito e string numérica LIMPA ("12.50"). Rejeita o ambíguo
+ * ("12,50", "R$ 12,50", "", "doze") — precisão > recall: preço que não dá para
+ * ler sem adivinhar não vira preço.
+ */
+export function numeroFinito(valor: unknown): number | null {
+  if (typeof valor === "number") return Number.isFinite(valor) ? valor : null;
+  if (typeof valor === "string") {
+    const texto = valor.trim();
+    if (!/^-?\d+(\.\d+)?$/.test(texto)) return null;
+    const n = Number(texto);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
+ * Preço só entra se for número positivo. Inválido devolve `undefined` para o
+ * caller REMOVER o campo — aí o frontend cai no preço de tabela (`usouTabela`),
+ * que é o fallback correto. Nunca 0: ausente ≠ zero.
+ */
+export function precoValido(valor: unknown): number | undefined {
+  const n = numeroFinito(valor);
+  return n !== null && n > 0 ? n : undefined;
+}
+
+/**
+ * Quantidade inválida/ausente vira 1 — o default DECLARADO no schema da tool
+ * ("Quantidade (padrão 1)"), não um número inventado. Fracionário é preservado
+ * (litro/kg são quantidades legítimas). O vendedor revisa antes de fechar.
+ */
+export function quantidadeValida(valor: unknown): number {
+  const n = numeroFinito(valor);
+  return n !== null && n > 0 ? n : 1;
+}
+
+/**
+ * Normaliza UM item vindo da IA. Devolve `null` para o que não é objeto —
+ * string solta ou number no array não vira item de pedido.
+ */
+export function sanitizarItemIA(cru: unknown): Record<string, unknown> | null {
+  if (!cru || typeof cru !== "object" || Array.isArray(cru)) return null;
+  const item = { ...(cru as Record<string, unknown>) };
+
+  // Sempre presente e numérico: `undefined` viraria NaN ao somar no carrinho.
+  item.quantity = quantidadeValida(item.quantity);
+
+  const preco = precoValido(item.unit_price);
+  if (preco === undefined) delete item.unit_price;
+  else item.unit_price = preco;
+
+  if ("omie_codigo_servico" in item) {
+    const cod = numeroFinito(item.omie_codigo_servico);
+    if (cod === null) delete item.omie_codigo_servico;
+    else item.omie_codigo_servico = cod;
+  }
+
+  return item;
+}
+
+/** Aplica `sanitizarItemIA` na lista; entrada não-array degrada para []. */
+export function sanitizarListaIA(bruto: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(bruto)) return [];
+  const out: Record<string, unknown>[] = [];
+  for (const cru of bruto) {
+    const item = sanitizarItemIA(cru);
+    if (item) out.push(item);
+  }
+  return out;
+}
+
+export type ResultadoToolUse =
+  | { ok: true; input: unknown }
+  | { ok: false; motivo: "ausente" | "multiplo"; quantidade: number };
+
+/**
+ * Exige EXATAMENTE um bloco `tool_use`.
+ *
+ * `tool_choice: {type:"tool"}` sozinho NÃO desliga chamada paralela — o modelo
+ * pode emitir um bloco por grupo de itens/foto. Pegar só o primeiro entregaria
+ * pedido PARCIAL com cara de completo, que é a falha money-path clássica.
+ * O caller manda `disable_parallel_tool_use: true`; este guard é a rede.
+ */
+export function extrairToolUseUnico(
+  blocos: ReadonlyArray<{ type: string; input?: unknown }>,
+): ResultadoToolUse {
+  const usos = blocos.filter((b) => b?.type === "tool_use");
+  if (usos.length === 0) return { ok: false, motivo: "ausente", quantidade: 0 };
+  if (usos.length > 1) {
+    return { ok: false, motivo: "multiplo", quantidade: usos.length };
+  }
+  return { ok: true, input: usos[0].input };
+}

--- a/supabase/functions/analyze-unified-order/saida-ia_test.ts
+++ b/supabase/functions/analyze-unified-order/saida-ia_test.ts
@@ -1,0 +1,176 @@
+// Testa o CÓDIGO REAL de saida-ia.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/analyze-unified-order/
+//
+// Foco: os dois caminhos de pedido incorreto achados no challenge do Codex —
+// preço string que explode no checkout e quantidade string que FABRICA número
+// ao somar; mais o tool_use múltiplo, que entregaria pedido parcial completo.
+import {
+  extrairToolUseUnico,
+  numeroFinito,
+  precoValido,
+  quantidadeValida,
+  sanitizarItemIA,
+  sanitizarListaIA,
+} from "./saida-ia.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+// ─────────────────────────────── numeroFinito ───────────────────────────────
+
+Deno.test("numeroFinito: aceita number finito e string numérica limpa", () => {
+  assertEquals(numeroFinito(12.5), 12.5);
+  assertEquals(numeroFinito("12.50"), 12.5);
+  assertEquals(numeroFinito(" 7 "), 7);
+  assertEquals(numeroFinito(0), 0);
+  assertEquals(numeroFinito(-3), -3);
+});
+
+Deno.test("numeroFinito: valor AMBÍGUO não vira número (precisão > recall)", () => {
+  // "12,50" é 12.5 ou 1250? Adivinhar aqui vira preço errado no pedido.
+  for (const v of ["12,50", "R$ 12,50", "12.50.00", "doze", "", "  ", "1e3", "0x10"]) {
+    assertEquals(numeroFinito(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("numeroFinito: não-finito e não-escalar degradam para null", () => {
+  for (const v of [NaN, Infinity, -Infinity, null, undefined, {}, [], true]) {
+    assertEquals(numeroFinito(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ──────────────────────────────── precoValido ────────────────────────────────
+
+Deno.test("precoValido: zero e negativo NÃO viram preço", () => {
+  // ausente ≠ zero: R$0 sugerido como "praticado" é fabricação.
+  for (const v of [0, -1, "0", "-5"]) {
+    assertEquals(precoValido(v), undefined, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("precoValido: string numérica vira NUMBER, não fica string", () => {
+  // O bug: "12.50" > 0 é true por coerção, entra no carrinho como string e
+  // explode no .toFixed(2) do checkout.
+  const p = precoValido("12.50");
+  assertEquals(p, 12.5);
+  assertEquals(typeof p, "number", "tem de sair como number");
+});
+
+// ────────────────────────────── quantidadeValida ──────────────────────────────
+
+Deno.test("quantidadeValida: string vira number — fecha o 1 + \"2\" = \"12\"", () => {
+  const q = quantidadeValida("2");
+  assertEquals(q, 2);
+  assertEquals(typeof q, "number");
+  assertEquals(1 + q, 3, "somar com item existente tem de dar 3, não \"12\"");
+});
+
+Deno.test("quantidadeValida: inválida/ausente cai no default 1 do schema", () => {
+  for (const v of [undefined, null, 0, -2, "abc", NaN, {}]) {
+    assertEquals(quantidadeValida(v), 1, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("quantidadeValida: fracionário é preservado (litro/kg são legítimos)", () => {
+  assertEquals(quantidadeValida(2.5), 2.5);
+  assertEquals(quantidadeValida("0.5"), 0.5);
+});
+
+// ─────────────────────────────── sanitizarItemIA ───────────────────────────────
+
+Deno.test("sanitizarItemIA: preço inválido SAI do item (cai na tabela)", () => {
+  const item = sanitizarItemIA({ product_id: "p1", unit_price: "abc", quantity: 3 });
+  assert(item !== null, "deveria sanitizar");
+  assert(!("unit_price" in item!), "campo tem de sumir, não virar 0");
+  assertEquals(item!.quantity, 3);
+});
+
+Deno.test("sanitizarItemIA: quantity ausente vira 1 em vez de virar NaN no carrinho", () => {
+  const item = sanitizarItemIA({ product_id: "p1" });
+  assertEquals(item!.quantity, 1);
+});
+
+Deno.test("sanitizarItemIA: preserva os demais campos verbatim", () => {
+  const item = sanitizarItemIA({
+    product_id: "p1",
+    codigo: "FL.6269.02",
+    descricao: "Verniz PU",
+    account: "oben",
+    unit_price: 30.5,
+    quantity: 2,
+  });
+  assertEquals(item!.codigo, "FL.6269.02");
+  assertEquals(item!.descricao, "Verniz PU");
+  assertEquals(item!.account, "oben");
+  assertEquals(item!.unit_price, 30.5);
+});
+
+Deno.test("sanitizarItemIA: omie_codigo_servico ilegível sai do item", () => {
+  const item = sanitizarItemIA({ userToolId: "t1", omie_codigo_servico: "n/a" });
+  assert(!("omie_codigo_servico" in item!), "código inválido não pode ir para o Omie");
+});
+
+Deno.test("sanitizarItemIA: não-objeto não vira item de pedido", () => {
+  for (const v of ["texto", 42, null, undefined, ["a"]]) {
+    assertEquals(sanitizarItemIA(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("sanitizarListaIA: entrada não-array degrada para lista vazia", () => {
+  assertEquals(sanitizarListaIA(null), []);
+  assertEquals(sanitizarListaIA("x"), []);
+  assertEquals(sanitizarListaIA(undefined), []);
+});
+
+Deno.test("sanitizarListaIA: item inválido é descartado, os bons passam", () => {
+  const out = sanitizarListaIA([
+    { product_id: "p1", unit_price: 10, quantity: 1 },
+    "lixo",
+    { product_id: "p2", unit_price: "20.00", quantity: "3" },
+  ]);
+  assertEquals(out.length, 2);
+  assertEquals(out[1].unit_price, 20);
+  assertEquals(out[1].quantity, 3);
+});
+
+// ───────────────────────────── extrairToolUseUnico ─────────────────────────────
+
+Deno.test("extrairToolUseUnico: um bloco devolve o input", () => {
+  const r = extrairToolUseUnico([
+    { type: "text" },
+    { type: "tool_use", input: { products: [] } },
+  ]);
+  assert(r.ok, "deveria aceitar um bloco");
+  if (!r.ok) return;
+  assertEquals(r.input, { products: [] });
+});
+
+Deno.test("extrairToolUseUnico: DOIS blocos são recusados, não silenciosamente cortados", () => {
+  // Sem disable_parallel_tool_use o modelo pode emitir um bloco por grupo de
+  // itens; pegar o primeiro entregaria pedido PARCIAL com cara de completo.
+  const r = extrairToolUseUnico([
+    { type: "tool_use", input: { products: [{ id: "a" }] } },
+    { type: "tool_use", input: { products: [{ id: "b" }] } },
+  ]);
+  assert(!r.ok, "dois blocos têm de ser recusados");
+  if (r.ok) return;
+  assertEquals(r.motivo, "multiplo");
+  assertEquals(r.quantidade, 2);
+});
+
+Deno.test("extrairToolUseUnico: nenhum bloco é 'ausente', distinto de 'multiplo'", () => {
+  const r = extrairToolUseUnico([{ type: "text" }]);
+  assert(!r.ok, "deveria recusar");
+  if (r.ok) return;
+  assertEquals(r.motivo, "ausente");
+  assertEquals(r.quantidade, 0);
+});


### PR DESCRIPTION
## Por quê

O orçamento do gateway de IA do Lovable estourou (limite de 4 créditos/mês, "limit reached") e a montagem de pedido por foto/texto parou em produção. Fase 2 de 4 da migração para a API da Anthropic direta — a fase 1 (`promocao-extrair-via-vision`) mergeou no #1592.

## O que muda

Troca do provedor em `analyze-unified-order`, **sem tocar na lógica de negócio**: validação de produto, resgate por fuzzy match, casamento de cliente e merge de preço ficam byte-idênticos.

| Antes (gateway Lovable) | Depois (Anthropic direta) |
|---|---|
| `google/gemini-2.5-flash` / `gemini-3-flash-preview` | `claude-sonnet-4-6` |
| `systemPrompt` como `role:"system"` | parâmetro `system` |
| `tool_calls[0].function.arguments` (string a parsear) | `tool_use.input`, com guard de bloco único |
| `LOVABLE_API_KEY` | `ANTHROPIC_API_KEY` |

## O bug que a migração desenterrou

O código antigo rotulava **toda** imagem como `data:image/jpeg;base64,` fixo. O Gemini farejava o conteúdo e tolerava o rótulo errado; a Anthropic valida o `media_type` declarado e responde 400.

Como o frontend aceita qualquer `image/*` e envia o base64 cru do arquivo (`readAsDataURL` + split, sem converter), **print de tela (PNG) e foto de iPhone (HEIC) derrubariam a análise inteira** depois da migração.

Daí `imagem-helpers.ts` (puro, testável sob `--no-remote`):

- **`detectarMediaTypeImagem`** — tipo real pelos magic bytes, nunca pelo rótulo do caller. WebP exige `RIFF` **e** `WEBP` no offset 8, senão WAV/AVI passariam por imagem.
- **fail-closed** — formato que a API não aceita é rejeitado com erro acionável, não adivinhado.
- **formato do base64 inteiro** — cabeçalho válido com corpo corrompido é recusado aqui, não na API com a análise já perdida.
- **teto de request** — 5 fotos × 5 MB ≈ 33 MB em base64, acima do limite de 32 MB; o system prompt (catálogo) desconta do mesmo orçamento.

## Money-path

- **Foto descartada nunca some calada** — vai em `imagens_rejeitadas` **e** na `message` que o vendedor lê, inclusive no caminho sem `tool_use`. O `catch` do frontend, que trocava qualquer erro por "análise indisponível", agora preserva o motivo acionável vindo da edge.
- **`tool_use` único obrigatório** — `disable_parallel_tool_use: true` mais um guard que recusa resposta partida em vários blocos. Consumir só o primeiro entregaria pedido **parcial com cara de completo**.
- **Preço e quantidade sanitizados na fronteira** — `"12.50"` (string) passava em `preco > 0` por coerção e explodia no `.toFixed(2)` do checkout; `"2"` fazia `1 + "2"` virar quantidade `"12"`. Agora saem number ou não saem.
- **`stop_reason === "max_tokens"` devolve 422 e descarta** (§8: teto que trunca fabrica completude).
- **Price path intocado** — o diff não contém nenhuma linha com `mergeCustomerPrices`, `priceMap`, `MIRROR` ou `expected = 123`; o bloco `MIRROR` tem hash byte-idêntico ao da `main`.
- **Gate de auth intocado** (staff-only, employee/master).

## Prova

| Gate | Resultado |
|---|---|
| `test:edges` | 329 passed · 0 failed · exit 0 |
| `deno check` da edge | 15 erros — **os mesmos 15** (códigos e ordem) que a `main` já tinha; 0 da classe "não resolve" |
| guardrail money-path | exit 0 · 154 asserções |
| bloco `MIRROR` | hash byte-idêntico à `main` |

**Falsificação** — 37 testes, baseline verde, 2 locales (`C` e `pt_BR.UTF-8`). Critério mais duro que contar vermelhos: cada sabotagem tem de derrubar os testes **nomeados**.

| Sabotagem | Vermelhos |
|---|---|
| "o que não reconheço, chuto jpeg" (o bug original) | 5/37 |
| WebP aceita qualquer container RIFF | 2/37 |
| teto de request removido | 1/37 |
| foto rejeitada fica invisível | 1/37 |
| preço fica string (explode no checkout) | 2/37 |
| quantidade fica string (`1 + "2"` = `"12"`) | 4/37 |
| volta a pegar o primeiro `tool_use` | 1/37 |
| preço zero passa a valer | 1/37 |

## 2ª opinião — Codex (`gpt-5.6-sol`, reasoning xhigh)

Status devolvido: **DONE_WITH_CONCERNS**, com "não faria o deploy manual ainda". Todos os achados abaixo foram **confirmados no código real antes de aceitar**.

<details><summary>Achados do Codex (verbatim)</summary>

> **[P1] A Anthropic pode retornar múltiplos `tool_use`, mas o código usa somente o primeiro.** O `tool_choice` não desabilita chamadas paralelas; depois, `.find()` conserva apenas uma. Caminho: Claude decide fazer uma chamada por grupo de itens/foto → primeira chamada contém parte do pedido → demais blocos são ignorados → a resposta parcial chega como completa.
>
> **[P1] O comentário "input validado contra o schema" está incorreto.** Forced tool-use força o uso da ferramenta, mas sem `strict: true` não garante campos, tipos ou estrutura. Caminho concreto: Claude devolve `unit_price: "12.50"` → valor passa pela comparação `> 0` e entra como string no carrinho → o checkout chama `.toFixed(2)` e explode. Com `quantity: "2"`, um item já existente pode virar `"12"` porque `1 + "2"` concatena.
>
> **[P1] "Foto rejeitada nunca some" é falso no consumo real do frontend.** O `catch` do assistente descarta o erro e mostra apenas "análise indisponível". Há ainda o retorno sem `tool_use`: a edge envia `imagens_rejeitadas`, mas o frontend nem tipa nem lê esse campo.
>
> **O helper não valida a imagem inteira:** decodifica somente os 16 primeiros bytes. Reproduzi um JPEG com cabeçalho válido seguido de base64 inválido e `montarBlocoImagem` devolveu `ok: true`.
>
> **O caching pode piorar custo e latência.** Qualquer alteração no catálogo, candidatos ou histórico muda o prefixo e causa cache miss. Uma gravação de cache custa 1,25× os tokens normais.
>
> **O 402 não deixou de existir.** A Anthropic documenta `402 billing_error`.
>
> **`type: ["object", "null"]` é aceito.** Não quebra 100% nem precisa virar `anyOf`. `customer` estar em `required` exige que a chave exista, não que seu valor seja objeto.
>
> **O que está certo:** MIRROR e canária não foram tocados · gate `employee/master` inalterado · os quatro media types corretos · `claude-sonnet-4-6` é válido · o fail-closed de `max_tokens` é a decisão correta para money-path.

</details>

**Calibração (minha, não do Codex):**

- **Aceitos e corrigidos**: `disable_parallel_tool_use` + guard de bloco único; sanitização de preço/quantidade na fronteira; aviso de foto no caminho sem `tool_use` e no `catch` do frontend; validação do base64 inteiro; `cache_control` removido; 402/413/400 mapeados.
- **Discordo do `strict: true`.** A referência de structured outputs lista os modelos suportados e `claude-sonnet-4-6` não está entre eles; além disso exigiria `additionalProperties: false` em todo o schema. A validação local que implementei é mais forte, porque não depende de suporte do modelo — e cobre o mesmo caminho de falha.
- **Sobre o caching, verifiquei e é pior do que ele supôs**: as partes dinâmicas (catálogo, ferramentas, histórico, candidatos) estão **no prefixo** do prompt e as regras estáveis vêm depois. Como o cache é por prefixo, nunca haveria hit. Removido. Follow-up possível: inverter a ordem do prompt para cachear de verdade — é mudança de comportamento, não cabia aqui.
- **`type: ["object","null"]` mantido**, agora com a confirmação dele de que é aceito.
- **Ressalva de procedência**: o sub-challenge independente do Codex não chegou a rodar (`mktemp` falhou no sandbox read-only, exit 70), então o parecer é a revisão adversária local dele. Não é uma terceira opinião.

## Depois do merge (deploy é manual — merge não deploya nada)

1. Confirmar `ANTHROPIC_API_KEY` nos secrets do Supabase.
2. Deployar a edge pelo chat do Lovable — **3 arquivos**: `index.ts`, `imagem-helpers.ts` e `saida-ia.ts`.
3. Provar o deploy com a canária: `POST` com `{"canary": true}` deve retornar `{"ok": true, "resolved": 123}`.
4. Publish do frontend (o `catch` do assistente mudou).
5. Conferir que nenhum commit "Changes" do bot reverteu os arquivos depois do merge.
