### PR TITLE
fix(scoring): leitura que FALHA deixa de virar "não visitou/não compra" no score [money-path]

### DIFF
--- a/src/__tests__/leitura-single-shot-gate.test.ts
+++ b/src/__tests__/leitura-single-shot-gate.test.ts
@@ -86,11 +86,13 @@ const G5 = /(?<!\?)\.data\s*(?:(?:\?\?|\|\|)\s*(?:\[\]|\{\}|0\b|null\b)|as\s[^;\
 // REPROVA. Contagem menor também reprova, pedindo a atualização — a lista só encolhe, e
 // encolhe registrada. Varredura de 2026-07-28, com veredito individual de cada site:
 //
-//  visit-score-recalc-client (6) — L215 classCfgRes e L218 scoresRes JÁ-CORRETOS (o
-//      arquivo checa .error dos dois e degrada de propósito, fail-safe do shadow-mode);
-//      L219 visitsRes, L220 ordersRes, L221 addressRes, L222 profileRes AFETADOS
-//      (nenhum checa .error → "nunca visitou"/"0 pedidos" fabricados no scoring).
-//  visit-score-recalc-batch (2)  — L107 callsRes, L114 visitsRes AFETADOS.
+//  visit-score-recalc-client (2) — era 6: L215 classCfgRes e L218 scoresRes seguem
+//      JÁ-CORRETOS (o arquivo checa .error dos dois e degrada de propósito, fail-safe do
+//      shadow-mode) e são os 2 que ficam. Os 4 AFETADOS (visitsRes, ordersRes, addressRes,
+//      profileRes) passaram a exigirLeitura sob try/catch que devolve {ok:false} — o
+//      contrato de recalcOne, que não pode lançar por cliente dentro do drain.
+//  visit-score-recalc-batch (0)  — era 2: callsRes e visitsRes viraram exigirLeitura com
+//      500 no catch, igual ao try/catch da carteira logo acima. Arquivo QUITADO.
 //  omie-financeiro (2)           — L1744 cfgRes TOLERADO (coluna opcional dre_tributario:
 //      quando não existe o PostgREST devolve ERRO, e checá-lo derrubaria a engine);
 //      L1747 histRes JÁ-CORRETO (`if (histRes.error) throw` na linha acima).
@@ -103,13 +105,15 @@ const G5 = /(?<!\?)\.data\s*(?:(?:\?\?|\|\|)\s*(?:\[\]|\{\}|0\b|null\b)|as\s[^;\
 //      tolerarLeitura e o folhaCatRes virou tolerarColunaAusente (que tolera SÓ os códigos
 //      de coluna inexistente e lança em timeout/RLS). Arquivo QUITADO, fora da baseline.
 //
-// ⇒ 6 AFETADOS, todos no domínio scoring/farmer, com chip de erradicação próprio.
+// ⇒ 0 AFETADOS. Os 6 do domínio scoring/farmer foram erradicados na entrega seguinte à
+// âncora; o que resta na baseline abaixo são os 5 sites JÁ-CORRETOS/TOLERADOS/falso
+// positivo, que a contagem textual enxerga mas o veredito acima absolve. A lista está no
+// piso: só encolhe se um deles for reescrito, e o gate reprova qualquer crescimento.
 const G5_BASELINE: ReadonlyMap<string, number> = new Map([
   ['supabase/functions/carteira-rebuild/index.ts', 1],
   ['supabase/functions/omie-financeiro/index.ts', 2],
   ['supabase/functions/omie-sync-vendas-items/index.ts', 1],
-  ['supabase/functions/visit-score-recalc-batch/index.ts', 2],
-  ['supabase/functions/visit-score-recalc-client/index.ts', 6],
+  ['supabase/functions/visit-score-recalc-client/index.ts', 2],
   ['supabase/functions/whatsapp-send-template/index.ts', 1],
 ]);
 

--- a/supabase/functions/visit-score-recalc-batch/index.ts
+++ b/supabase/functions/visit-score-recalc-batch/index.ts
@@ -36,6 +36,7 @@
 import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import { carregarExcluidosDaCarteira, carregarOwnerMap } from '../_shared/mapas-paginados.ts';
+import { exigirLeitura } from '../_shared/leitura-critica.ts';
 import type { BancoPostgrest } from '../_shared/paginate.ts';
 
 Deno.serve(async (req) => {
@@ -102,16 +103,36 @@ Deno.serve(async (req) => {
       .not('customer_user_id', 'is', null),
   ]);
 
+  // Fail-closed igual à carteira acima, e pelo mesmo motivo: com `?? []` cru a leitura que
+  // FALHAVA virava "ninguém teve atividade nesta fonte". O batch seguia respondendo 200,
+  // com um `recalculated` menor que ninguém tinha como conferir, e o decay diário
+  // simplesmente NÃO rodava para os clientes daquela fonte — o score envelhecia em
+  // silêncio, que é a falha mais cara aqui (a agenda do vendedor passa a ser ordenada por
+  // score velho). Melhor 500 e deixar o cron re-tentar do que um lote parcial mudo.
+  let calls: Array<{ customer_user_id: string; farmer_id: string }>;
+  let visitasAtivas: Array<{ customer_user_id: string; visited_by: string }>;
+  try {
+    calls = (exigirLeitura(callsRes, 'farmer_calls') ?? []) as Array<{ customer_user_id: string; farmer_id: string }>;
+    visitasAtivas = (exigirLeitura(visitsRes, 'route_visits') ?? []) as Array<{ customer_user_id: string; visited_by: string }>;
+  } catch (e) {
+    const motivo = e instanceof Error ? e.message : String(e);
+    console.error('[visit-score-recalc-batch] leitura de atividade falhou:', motivo);
+    return new Response(
+      JSON.stringify({ error: motivo, drained }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
   // Dedup por CLIENTE (1 score por cliente); farmer_id = dono (fallback: ator da atividade).
   const unique = new Map<string, { customer_user_id: string; farmer_id: string }>();
-  for (const row of (callsRes.data ?? []) as Array<{ customer_user_id: string; farmer_id: string }>) {
+  for (const row of calls) {
     if (flaggeds.has(row.customer_user_id)) continue;
     unique.set(row.customer_user_id, {
       customer_user_id: row.customer_user_id,
       farmer_id: ownerMap.get(row.customer_user_id) ?? row.farmer_id,
     });
   }
-  for (const row of (visitsRes.data ?? []) as Array<{ customer_user_id: string; visited_by: string }>) {
+  for (const row of visitasAtivas) {
     if (flaggeds.has(row.customer_user_id)) continue;
     unique.set(row.customer_user_id, {
       customer_user_id: row.customer_user_id,

--- a/supabase/functions/visit-score-recalc-client/index.ts
+++ b/supabase/functions/visit-score-recalc-client/index.ts
@@ -10,6 +10,7 @@
 
 import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
+import { exigirLeitura, FalhaLeituraCritica } from '../_shared/leitura-critica.ts';
 
 // =====================================================
 // --- Inline helpers ---
@@ -216,10 +217,38 @@ async function recalcOne(
   );
 
   const scores = (scoresRes.data ?? {}) as Record<string, unknown>;
-  const lastVisitAt = (visitsRes.data ?? [])[0]?.check_in_at ?? null;
-  const salesOrdersCount = (ordersRes.data ?? []).length;
-  const address = (addressRes.data ?? {}) as Record<string, unknown>;
-  const profile = (profileRes.data ?? {}) as Record<string, unknown>;
+
+  // FAIL-CLOSED (mesma regra do flagRes acima) nas 4 leituras que alimentam o SCORE, que
+  // até aqui descartavam `error`. O `?? []`/`?? {}` cru colapsava "a leitura FALHOU" em
+  // "o cliente não teve atividade", e o estrago não é um score ausente e visível — é um
+  // score BAIXO e plausível: sem route_visits o cliente vira "nunca visitado", sem
+  // sales_orders vira "não compra", e o profile perdido zera `is_prospect`, o que TROCA a
+  // missão primária. Um timeout de transporte rebaixava o cliente na agenda do vendedor,
+  // com 200 na resposta e o resultado PERSISTIDO no upsert lá embaixo. Melhor não
+  // recalcular do que recalcular errado em silêncio (docs/agent/money-path.md §2/§6/§7):
+  // o score anterior fica de pé, o motivo é gravado na fila (o drain marca `processed_at`
+  // mesmo em erro, anti poison-pill) e o cliente é re-enfileirado no próximo batch — o
+  // mesmo desfecho que o flagRes acima já dá.
+  // `exigirLeitura` lança só no `error`: `data` null/[] sem erro segue sendo ausência
+  // LEGÍTIMA, e o fallback abaixo continua valendo. A mensagem vai em domínio fechado
+  // (fonte + código), sem o `error.message` cru do Postgres que o retorno devolve ao
+  // cliente — o mesmo cuidado de PII que o helper documenta.
+  let visitas: Array<{ check_in_at?: string | null }>;
+  let pedidos: unknown[];
+  let address: Record<string, unknown>;
+  let profile: Record<string, unknown>;
+  try {
+    visitas = (exigirLeitura(visitsRes, 'route_visits') ?? []) as Array<{ check_in_at?: string | null }>;
+    pedidos = (exigirLeitura(ordersRes, 'sales_orders') ?? []) as unknown[];
+    address = (exigirLeitura(addressRes, 'addresses') ?? {}) as Record<string, unknown>;
+    profile = (exigirLeitura(profileRes, 'profiles') ?? {}) as Record<string, unknown>;
+  } catch (e) {
+    if (e instanceof FalhaLeituraCritica) return { ok: false, error: e.message };
+    throw e;
+  }
+
+  const lastVisitAt = visitas[0]?.check_in_at ?? null;
+  const salesOrdersCount = pedidos.length;
 
   const inputs: CustomerScoreInputs = {
     customer_user_id,


### PR DESCRIPTION
Erradica os **6 sites AFETADOS** da classe *"leitura single-shot cuja falha vira zero"* no domínio **scoring/farmer** — os que a `G5_BASELINE` do gate deixou registrados como dívida quando a âncora (`fin-cashflow-engine`) fechou a classe.

## Por que importa

Esses valores entram no **score do cliente**, que ordena a **agenda do vendedor**. O estrago não é um score ausente e visível — é um score **baixo e plausível**, com 200 na resposta e o resultado **persistido** no upsert.

## O que muda

**`visit-score-recalc-client` (4 sites)** — `route_visits`, `sales_orders`, `addresses` e `profiles` alimentavam o score descartando `error`:

| leitura | falha virava | efeito no score |
|---|---|---|
| `route_visits` | "nunca visitou" | `days_since_last_visit` fabricado |
| `sales_orders` | "não compra" | `sales_orders_count = 0` |
| `profiles` | perfil vazio | zera `is_prospect` → **troca a missão primária** |
| `addresses` | sem endereço | perde city/neighborhood/state |

Agora é fail-closed igual ao `flagRes` que o arquivo já tinha (*"erro ao ler a flag → NÃO recalcula"*): não recalcula, grava o motivo e re-enfileira no próximo batch. O `try/catch` converte para o contrato `{ok:false}` porque `recalcOne` **não pode lançar por cliente** dentro do drain concorrente — um erro derrubaria o chunk inteiro.

**`visit-score-recalc-batch` (2 sites)** — `farmer_calls` e `route_visits` definem **quem entra** no recálculo. Com o coalesce cru a leitura que falhava virava "ninguém teve atividade": o batch respondia 200 com um `recalculated` menor que ninguém conferia e o decay diário não rodava, **envelhecendo o score em silêncio**. Agora 500 e o cron re-tenta — mesmo `try/catch` que a carteira logo acima já usa.

## Decisões

- **`exigirLeitura`, não `exigirLinhas`**: lista vazia aqui é estado **legítimo** (cliente novo nunca visitado, prospect sem pedido, dia sem atividade). Só o `error` lança.
- **`classCfgRes` e `scoresRes` intactos**: já checam `.error` e degradam de propósito (fail-safe do shadow-mode). São os 2 que sobram na baseline.
- **PII**: a mensagem vai em domínio fechado (fonte + código). O retorno de `recalcOne` chega ao cliente, e o `error.message` cru do Postgres pode interpolar valor de linha.

## Baseline

`G5_BASELINE` atualizada com números **medidos pela própria regex do gate**, não estimados — a lista só encolhe, e encolhe registrada (sem isso o gate reprova a própria quitação):

- `visit-score-recalc-batch` **2 → 0** (sai da baseline, arquivo quitado)
- `visit-score-recalc-client` **6 → 2**

## Verificação

Todos com exit code capturado (sem `| tail`, que engole o código):

| comando | resultado |
|---|---|
| suíte de edges (Deno) | **exit 0** — 324 passed, 0 failed |
| gate `leitura-single-shot` | **exit 0** — 8/8 passed |
| `edges:typecheck` | **exit 0** — 0 erros de classe-crash |
| typecheck do app | **exit 0** |
| lint | **exit 0** — 0 errors |

O `deno check` das 2 edges mantém 3 erros pré-existentes (`upsert`/`SupabaseClient`, dívida tolerada) — e o fix **eliminou** um quarto (`TS2339` em `check_in_at`), que vinha justamente do coalesce sobre tipo `never`.

Rebaseado sobre o #1609 (que estendeu o gate para `src/`) e revalidado depois disso. Não colide com o #1610, que mexe no bloco do pin (`fin_contas_correntes`), ~90 linhas abaixo da baseline.

## Deploy

Edge — deploy manual pelo chat do Lovable (verbatim da main), nas duas: `visit-score-recalc-client` e `visit-score-recalc-batch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
