### PR TITLE
fix(vendas): a degradação das condições de pagamento chega à TELA — aviso, e bloqueio com prova [money-path]

### DIFF
--- a/src/components/sales/AvisoFormasPagamento.tsx
+++ b/src/components/sales/AvisoFormasPagamento.tsx
@@ -1,0 +1,84 @@
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import {
+  AVISO_FORMAS_DEGRADADAS,
+  AVISO_FORMAS_INDISPONIVEIS,
+  mensagemCondicoesIndisponiveis,
+} from '@/services/orderSubmission/formasDegradacao';
+
+interface AvisoFormasPagamentoProps {
+  /** Edge declarou fallback (`degraded`/`source`) — lista genérica no lugar das reais. */
+  degradado: boolean;
+  /** A consulta falhou por inteiro: nem a lista genérica chegou. */
+  erro?: boolean;
+  /** Motivo declarado pelo edge (mensagem do erro do Omie), quando houver. */
+  motivo?: string | null;
+  /** Códigos que este cliente/pedido usa e sumiram da lista — prova positiva. */
+  condicoesAusentes?: ReadonlyArray<string>;
+  /** Refaz a consulta ao Omie. Sem saída, o bloqueio viraria beco sem saída. */
+  onRecarregar?: () => void;
+  /**
+   * Substitui o texto padrão. Use quando a CONSEQUÊNCIA da degradação for outra — na
+   * impressão não há "opções padrão" na tela: o rótulo é omitido e sai o código cru.
+   */
+  texto?: string;
+  className?: string;
+}
+
+/**
+ * Aviso inline da degradação da listagem de condições de pagamento (money-path §7: a
+ * correção do edge #1597 só termina quando a degradação aparece na TELA).
+ *
+ * Dois níveis: `condicoesAusentes` não-vazio é a prova de que a lista NÃO serve para este
+ * cliente (erro — acompanha o bloqueio do envio); degradação sem prova é aviso (warning —
+ * a lista genérica pode até servir, mas o vendedor precisa saber que ela não é a do Omie).
+ */
+export function AvisoFormasPagamento({
+  degradado,
+  erro = false,
+  motivo,
+  condicoesAusentes = [],
+  onRecarregar,
+  texto,
+  className,
+}: AvisoFormasPagamentoProps) {
+  if (!degradado && !erro) return null;
+
+  const bloqueante = condicoesAusentes.length > 0;
+  const mensagem = bloqueante
+    ? mensagemCondicoesIndisponiveis(condicoesAusentes)
+    : texto
+      ?? (erro ? AVISO_FORMAS_INDISPONIVEIS : AVISO_FORMAS_DEGRADADAS);
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex items-start gap-2 rounded-md border px-3 py-2 text-xs',
+        bloqueante
+          ? 'bg-status-error-bg border-status-error/30 text-status-error'
+          : 'bg-status-warning-bg border-status-warning/30 text-status-warning',
+        className,
+      )}
+    >
+      <AlertTriangle className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+      <div className="min-w-0 flex-1 space-y-1">
+        <p>{mensagem}</p>
+        {motivo && <p className="opacity-70 break-words">Motivo: {motivo}</p>}
+        {onRecarregar && (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRecarregar}
+            className="h-7 gap-1.5 text-xs"
+          >
+            <RefreshCw className="h-3 w-3" />
+            Tentar de novo
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.formasDegradadas.test.tsx
+++ b/src/components/salesOrderEdit/__tests__/useSalesOrderEdit.formasDegradadas.test.tsx
@@ -1,0 +1,227 @@
+// Degradação da listagem de condições de pagamento (edge #1597) na EDIÇÃO de pedido.
+// Sob fallback genérico, a condição REAL já gravada no pedido pode não estar na lista —
+// o combobox então mostra rótulo vazio e convida o vendedor a escolher uma das 8 genéricas,
+// TROCANDO o prazo de um pedido já negociado (DSO errado). O seletor trava; a proteção
+// mesmo é o guard imperativo em handleSave (money-path §5).
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+const navigateSpy = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ id: 'ord-1' }),
+  useNavigate: () => navigateSpy,
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({}) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn(), functions: { invoke: vi.fn() }, rpc: vi.fn() },
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+import { useSalesOrderEdit } from '../useSalesOrderEdit';
+
+const mockedFrom = vi.mocked(supabase.from);
+const mockedInvoke = vi.mocked(supabase.functions.invoke);
+const mockedRpc = vi.mocked(supabase.rpc);
+
+interface PgBuilder {
+  select: () => PgBuilder; eq: () => PgBuilder; or: () => PgBuilder; order: () => PgBuilder;
+  range: () => Promise<{ data: unknown[]; error: null }>;
+}
+function emptyProductsBuilder(): PgBuilder {
+  const b = {} as PgBuilder;
+  b.select = () => b; b.eq = () => b; b.or = () => b; b.order = () => b;
+  b.range = () => Promise.resolve({ data: [], error: null });
+  return b;
+}
+
+const salesOrderRow = {
+  id: 'ord-1',
+  customer_user_id: 'cust-1',
+  items: [
+    { omie_codigo_produto: 1, codigo: 'C1', descricao: 'Lixa Grão 120', unidade: 'UN', quantidade: 2, valor_unitario: 10, valor_total: 20 },
+  ],
+  subtotal: 20, total: 20, status: 'pendente', notes: null, account: 'oben',
+  omie_pedido_id: 42, omie_numero_pedido: '1001', omie_payload: null, created_at: '2026-01-01',
+};
+
+const updateEqSpy = vi.fn().mockResolvedValue({ error: null });
+const updateSpy = vi.fn().mockReturnValue({ eq: updateEqSpy });
+
+function chainFor(table: string) {
+  if (table === 'sales_orders') {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: salesOrderRow, error: null }),
+        }),
+      }),
+      update: updateSpy,
+    };
+  }
+  if (table === 'profiles') {
+    return {
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({ data: { name: 'Cliente X' }, error: null }),
+        }),
+      }),
+    };
+  }
+  return emptyProductsBuilder();
+}
+
+/** O pedido usa 'A17' (condição negociada); a lista de fallback NÃO a contém. */
+const FORMAS_FALLBACK = [
+  { codigo: '999', descricao: 'A Vista' },
+  { codigo: '002', descricao: '30/60 dias' },
+];
+const FORMAS_OMIE = [...FORMAS_FALLBACK, { codigo: 'A17', descricao: '45/75/105 dias' }];
+
+/** `staff_get_sales_order_payload` devolve o payload com a parcela gravada no pedido. */
+function payloadComParcela(codigo: string | null) {
+  return [{
+    id: 'ord-1',
+    omie_payload: codigo ? { cabecalho: { codigo_parcela: codigo } } : null,
+    omie_response: null,
+  }];
+}
+
+function mockFormas(resposta: Record<string, unknown>) {
+  mockedInvoke.mockResolvedValue({ data: resposta, error: null } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateSpy.mockReturnValue({ eq: updateEqSpy });
+  mockedRpc.mockResolvedValue({ data: payloadComParcela('A17'), error: null } as never);
+  mockedFrom.mockImplementation((table) => chainFor(table as string) as never);
+});
+
+async function renderLoaded() {
+  const hook = renderHook(() => useSalesOrderEdit());
+  await waitFor(() => expect(hook.result.current.loading).toBe(false));
+  await waitFor(() => expect(hook.result.current.order).toBeTruthy());
+  return hook;
+}
+
+describe('useSalesOrderEdit — condição de pagamento sob listagem degradada', () => {
+  it('degradada E a condição do pedido ausente → trava o seletor e expõe o código', async () => {
+    mockFormas({ formas: FORMAS_FALLBACK, source: 'fallback', degraded: true, motivo: 'rate limit' });
+    const { result } = await renderLoaded();
+
+    expect(result.current.formasDegradadas).toBe(true);
+    expect(result.current.formasMotivo).toBe('rate limit');
+    expect(result.current.condicaoDoPedidoAusente).toEqual(['A17']);
+    expect(result.current.parcelaTravada).toBe(true);
+  });
+
+  it('degradada mas a condição do pedido ESTÁ na lista → avisa sem travar', async () => {
+    mockedRpc.mockResolvedValue({ data: payloadComParcela('999'), error: null } as never);
+    mockFormas({ formas: FORMAS_FALLBACK, source: 'fallback', degraded: true, motivo: null });
+    const { result } = await renderLoaded();
+
+    expect(result.current.formasDegradadas).toBe(true);
+    expect(result.current.parcelaTravada).toBe(false);
+  });
+
+  // O par que prova o detector: mesmo código ausente, veredito oposto sem degradação.
+  it('NÃO degradada e código ausente (parcela inativada no Omie) → não trava', async () => {
+    mockFormas({ formas: FORMAS_FALLBACK, source: 'omie', degraded: false, motivo: null });
+    const { result } = await renderLoaded();
+
+    expect(result.current.formasDegradadas).toBe(false);
+    expect(result.current.condicaoDoPedidoAusente).toEqual([]);
+    expect(result.current.parcelaTravada).toBe(false);
+  });
+
+  // COMPATIBILIDADE (item 3): edge antiga / ainda não deployada.
+  it('edge SEM os campos novos → não degradada, nada travado, nenhum aviso falso', async () => {
+    mockFormas({ success: true, formas: FORMAS_OMIE });
+    const { result } = await renderLoaded();
+
+    expect(result.current.formasDegradadas).toBe(false);
+    expect(result.current.formasErro).toBe(false);
+    expect(result.current.parcelaTravada).toBe(false);
+  });
+
+  it('BLOQUEIA salvar se a parcela for trocada por uma genérica sob degradação', async () => {
+    mockFormas({ formas: FORMAS_FALLBACK, source: 'fallback', degraded: true, motivo: null });
+    const { result } = await renderLoaded();
+    mockedInvoke.mockClear();
+    updateSpy.mockClear();
+
+    act(() => { result.current.setSelectedParcela('002'); });
+    await act(async () => { await result.current.handleSave(); });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(mockedInvoke).not.toHaveBeenCalledWith(
+      'omie-vendas-sync',
+      expect.objectContaining({ body: expect.objectContaining({ action: 'alterar_pedido' }) }),
+    );
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
+  it('PERMITE salvar mantendo a condição original — ela vai íntegra ao Omie', async () => {
+    mockFormas({ formas: FORMAS_FALLBACK, source: 'fallback', degraded: true, motivo: null });
+    const { result } = await renderLoaded();
+    mockedInvoke.mockClear();
+    updateSpy.mockClear();
+    mockedInvoke.mockResolvedValue({ data: { success: true }, error: null } as never);
+
+    await act(async () => { await result.current.handleSave(); });
+
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      'omie-vendas-sync',
+      expect.objectContaining({
+        body: expect.objectContaining({ action: 'alterar_pedido', codigo_parcela: 'A17' }),
+      }),
+    );
+    await waitFor(() => expect(navigateSpy).toHaveBeenCalledWith('/sales'));
+  });
+
+  it('SEM degradação, trocar a parcela continua livre (o guard não vaza pro caminho bom)', async () => {
+    mockFormas({ formas: FORMAS_OMIE, source: 'omie', degraded: false, motivo: null });
+    const { result } = await renderLoaded();
+    mockedInvoke.mockClear();
+    mockedInvoke.mockResolvedValue({ data: { success: true }, error: null } as never);
+
+    act(() => { result.current.setSelectedParcela('002'); });
+    await act(async () => { await result.current.handleSave(); });
+
+    expect(mockedInvoke).toHaveBeenCalledWith(
+      'omie-vendas-sync',
+      expect.objectContaining({
+        body: expect.objectContaining({ action: 'alterar_pedido', codigo_parcela: '002' }),
+      }),
+    );
+  });
+
+  // Metade do #1605, preservada na união e coberta aqui (ela mergeou sem teste próprio).
+  // O throw dele vem DEPOIS do setOrder, então a tela abre: o toast é o sinal imediato, e
+  // some. O estado de erro persistente é o que impede a tela de calar por omissão depois.
+  it('erro do invoke (transporte) → toast E aviso persistente, sem lista de formas', async () => {
+    mockedInvoke.mockResolvedValue({ data: null, error: { message: 'edge indisponível' } } as never);
+    const { result } = await renderLoaded();
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(result.current.formasErro).toBe(true);
+    expect(result.current.formasMotivo).toBe('edge indisponível');
+    expect(result.current.formas).toEqual([]);
+    // Não é degradação declarada: a lista genérica nem chegou.
+    expect(result.current.formasDegradadas).toBe(false);
+  });
+
+  // Distinto do acima: transporte OK (200), mas sem formas e sem degradação declarada —
+  // ambíguo, então avisa em vez de sumir o card e sugerir "este pedido não tem condição".
+  it('200 com lista VAZIA e sem degradação declarada → sinaliza erro sem derrubar a tela', async () => {
+    mockFormas({ success: true, formas: [] });
+    const { result } = await renderLoaded();
+
+    expect(result.current.formasErro).toBe(true);
+    expect(result.current.formasDegradadas).toBe(false);
+    expect(result.current.order).toBeTruthy();
+  });
+});

--- a/src/components/salesOrderEdit/types.ts
+++ b/src/components/salesOrderEdit/types.ts
@@ -44,8 +44,16 @@ export interface SalesOrder {
   created_at: string;
 }
 
+/**
+ * Resposta da action `listar_formas_pagamento`. `source`/`degraded`/`motivo` são ADITIVOS
+ * (edge #1597) e opcionais: edge antiga — ou ainda não deployada — devolve só `formas`, e a
+ * leitura em `@/services/orderSubmission/formasDegradacao` trata a ausência como NÃO-degradado.
+ */
 export interface FormasPagamentoResponse {
   formas?: Array<{ codigo: string; descricao: string }>;
+  source?: string | null;
+  degraded?: boolean | null;
+  motivo?: string | null;
 }
 
 export interface OmieProduct {

--- a/src/components/salesOrderEdit/useSalesOrderEdit.ts
+++ b/src/components/salesOrderEdit/useSalesOrderEdit.ts
@@ -18,6 +18,11 @@ import {
   type OmieProduct,
 } from './types';
 import { invalidPricedOrderItemIndices, invalidOrderPriceMessage } from './priceGuard';
+import {
+  lerRespostaFormas,
+  condicoesDoClienteIndisponiveis,
+  mensagemCondicoesIndisponiveis,
+} from '@/services/orderSubmission/formasDegradacao';
 
 export function useSalesOrderEdit() {
   const { id } = useParams<{ id: string }>();
@@ -32,6 +37,14 @@ export function useSalesOrderEdit() {
   const [saving, setSaving] = useState(false);
   const [formas, setFormas] = useState<Array<{ codigo: string; descricao: string }>>([]);
   const [selectedParcela, setSelectedParcela] = useState('');
+  // Degradação da listagem (edge #1597) + a condição ORIGINAL do pedido. Guardar o original
+  // é o que permite provar, sob degradação, que a lista exibida não contém a condição deste
+  // pedido — e barrar a TROCA por uma genérica (money-path §7: a degradação tem de chegar
+  // à tela; §2: ausente ≠ zero, aqui "lista genérica" ≠ "condições do cliente").
+  const [formasDegradadas, setFormasDegradadas] = useState(false);
+  const [formasErro, setFormasErro] = useState(false);
+  const [formasMotivo, setFormasMotivo] = useState<string | null>(null);
+  const [parcelaOriginal, setParcelaOriginal] = useState('');
 
   // Add product state
   const [showAddProduct, setShowAddProduct] = useState(false);
@@ -83,7 +96,7 @@ export function useSalesOrderEdit() {
       setItems(o.items || []);
       setNotes(o.notes || '');
       const parcela = o.omie_payload?.cabecalho?.codigo_parcela;
-      if (parcela) setSelectedParcela(parcela);
+      if (parcela) { setSelectedParcela(parcela); setParcelaOriginal(parcela); }
 
       const { data: profile } = await supabase
         .from('profiles')
@@ -124,13 +137,33 @@ export function useSalesOrderEdit() {
         }),
       ]);
 
-      // `functions.invoke` NÃO lança: devolve `{ data: null, error }`. Sem esta linha a falha
-      // escapava do `catch` abaixo, `setFormas` nunca era chamado e o editor abria com a
-      // lista de formas de pagamento VAZIA — indistinguível de "esta conta não tem forma
-      // cadastrada". Lançar leva ao toast "Erro ao carregar pedido", que é a verdade.
-      if (formasRes.error) throw formasRes.error;
-      const formasData = formasRes.data as FormasPagamentoResponse | null;
-      if (formasData?.formas) setFormas(formasData.formas);
+      // ── Duas metades do mesmo site, de PRs diferentes (money-path §9). Elas não são
+      // alternativas: tratam falhas DIFERENTES, e resolver por um lado reverteria a outra.
+      //
+      // (a) #1605 — TRANSPORTE falhou. `functions.invoke` NÃO lança: devolve
+      // `{ data: null, error }`. Sem esta linha a falha escapava do `catch` abaixo,
+      // `setFormas` nunca era chamado e o editor abria com a lista VAZIA — indistinguível
+      // de "esta conta não tem forma cadastrada". Lançar leva ao toast "Erro ao carregar
+      // pedido", que é a verdade.
+      // ⚠️ Mas o `setOrder` acima já rodou: o throw NÃO impede a tela de abrir, só pula o
+      // resto do load. O toast some em segundos e o que fica é uma tela sem card de
+      // pagamento — a mesma omissão, agora silenciosa. Por isso o estado de erro é gravado
+      // ANTES de lançar: o aviso persiste na tela depois que o toast passa (§7).
+      if (formasRes.error) {
+        setFormasErro(true);
+        setFormasMotivo(formasRes.error.message ?? null);
+        throw formasRes.error;
+      }
+      // (b) este PR — transporte OK, o OMIE é que degradou. O edge #1597 responde 200 com 8
+      // condições genéricas hardcoded e declara `degraded`/`source`/`motivo`. Ler só
+      // `formas` devolveria uma lista indistinguível da real; aqui a tela ABRE e avisa.
+      const estadoFormas = lerRespostaFormas(formasRes.data as FormasPagamentoResponse | null);
+      if (estadoFormas.formas.length > 0) setFormas(estadoFormas.formas);
+      setFormasDegradadas(estadoFormas.degradado);
+      // Sem erro de transporte e sem degradação declarada, lista vazia é ambígua (edge
+      // antiga com 200 vazio) — avisa em vez de sumir o card e sugerir "não tem condição".
+      setFormasErro(!estadoFormas.degradado && estadoFormas.formas.length === 0);
+      setFormasMotivo(estadoFormas.motivo);
       setCatalogProducts(products);
     } catch (e) {
       console.error(e);
@@ -262,6 +295,21 @@ export function useSalesOrderEdit() {
   // save e para o destaque na UI (aria-invalid + botão travado).
   const invalidPriceItemIndices = useMemo(() => invalidPricedOrderItemIndices(items), [items]);
 
+  // Prova positiva de que a lista exibida não serve para ESTE pedido: degradação declarada
+  // + a condição já gravada nele ausente da lista. Só a conjunção — no caminho bom, código
+  // ausente é parcela inativada no Omie (`cInativo === 'S'` é filtrado), estado legítimo.
+  const condicaoDoPedidoAusente = useMemo(
+    () => condicoesDoClienteIndisponiveis(
+      { formas, degradado: formasDegradadas, motivo: formasMotivo },
+      [parcelaOriginal],
+    ),
+    [formas, formasDegradadas, formasMotivo, parcelaOriginal],
+  );
+  // Trava o SELETOR (não a edição inteira): sem a lista real, trocar a condição por uma
+  // genérica altera o prazo de um pedido já negociado. Não mexer é seguro — `selectedParcela`
+  // continua sendo o código original e vai íntegro ao Omie. Editar item/observação segue livre.
+  const parcelaTravada = condicaoDoPedidoAusente.length > 0;
+
   const handleSave = async () => {
     if (!order) return;
     if (items.length === 0) {
@@ -273,6 +321,13 @@ export function useSalesOrderEdit() {
     // Omie, nos dois caminhos (com e sem omie_pedido_id) — fail-closed imperativo, não só UI.
     if (invalidPriceItemIndices.length > 0) {
       toast.error(invalidOrderPriceMessage(invalidPriceItemIndices.map((i) => items[i])));
+      return;
+    }
+    // Guard money-path da condição de pagamento: o seletor travado é feedback; a proteção
+    // é aqui, no caminho que grava (§5). Sob lista degradada que não contém a condição do
+    // pedido, a ÚNICA parcela aceitável é a original — qualquer outra veio das 8 genéricas.
+    if (parcelaTravada && selectedParcela !== parcelaOriginal) {
+      toast.error(mensagemCondicoesIndisponiveis(condicaoDoPedidoAusente));
       return;
     }
     setSaving(true);
@@ -398,6 +453,11 @@ export function useSalesOrderEdit() {
     formas,
     selectedParcela,
     setSelectedParcela,
+    formasDegradadas,
+    formasErro,
+    formasMotivo,
+    condicaoDoPedidoAusente,
+    parcelaTravada,
     showAddProduct,
     setShowAddProduct,
     productSearch,

--- a/src/components/unified-order/CartSummaryBar.tsx
+++ b/src/components/unified-order/CartSummaryBar.tsx
@@ -16,6 +16,13 @@ import type {
   ProductCartItem, ServiceCartItem, FormaPagamento,
 } from '@/hooks/useUnifiedOrder';
 import { findInvalidPricedProductItems } from '@/services/orderSubmission/priceGuard';
+import {
+  condicoesBloqueantesDoCarrinho,
+  mensagemCondicoesIndisponiveis,
+  ESTADO_FORMAS_UI_OK,
+  type EstadoFormasUI,
+} from '@/services/orderSubmission/formasDegradacao';
+import { AvisoFormasPagamento } from '@/components/sales/AvisoFormasPagamento';
 
 interface CartSummaryBarProps {
   cart: { length: number };
@@ -35,6 +42,10 @@ interface CartSummaryBarProps {
   loadingFormas: boolean;
   customerParcelaRankingOben: string[];
   customerParcelaRankingColacor: string[];
+  /** Degradação da listagem de condições por conta (edge #1597). Default = tudo ok. */
+  estadoFormasOben?: EstadoFormasUI;
+  estadoFormasColacor?: EstadoFormasUI;
+  onRecarregarFormas?: () => void;
   notes: string;
   setNotes: (v: string) => void;
   // Volumes (auto-calculated)
@@ -151,6 +162,9 @@ export function CartSummaryBar({
   selectedParcelaOben, setSelectedParcelaOben,
   selectedParcelaColacor, setSelectedParcelaColacor,
   loadingFormas, customerParcelaRankingOben, customerParcelaRankingColacor,
+  estadoFormasOben = ESTADO_FORMAS_UI_OK,
+  estadoFormasColacor = ESTADO_FORMAS_UI_OK,
+  onRecarregarFormas,
   ordemCompra, setOrdemCompra, isOrdemCompraCustomer,
   readyByDate, setReadyByDate,
   onSubmit, onSubmitQuote, offline = false,
@@ -163,7 +177,18 @@ export function CartSummaryBar({
     () => findInvalidPricedProductItems([...obenProductItems, ...colacorProductItems]).length > 0,
     [obenProductItems, colacorProductItems],
   );
-  const disableSubmit = submitting || serviceItems.some(s => !s.servico) || vendedorDivergencias.length > 0 || hasInvalidPrice;
+  // Guard money-path da condição de pagamento (espelha o submitOrder, que decide pelo MESMO
+  // helper): a listagem do Omie caiu no fallback genérico E este cliente usa condição que
+  // não está lá. Só as contas com item no carrinho contam. "Salvar como Orçamento" segue
+  // liberado de propósito — submitQuote não grava codigo_parcela, então é a saída sem risco.
+  const condicoesBloqueantes = useMemo(
+    () => condicoesBloqueantesDoCarrinho([
+      { temItens: obenProductItems.length > 0, estado: estadoFormasOben },
+      { temItens: colacorProductItems.length > 0, estado: estadoFormasColacor },
+    ]),
+    [obenProductItems.length, colacorProductItems.length, estadoFormasOben, estadoFormasColacor],
+  );
+  const disableSubmit = submitting || serviceItems.some(s => !s.servico) || vendedorDivergencias.length > 0 || hasInvalidPrice || condicoesBloqueantes.length > 0;
 
   // Generate weekdays (Mon-Fri) for current week
   const weekDays = useMemo(() => {
@@ -186,24 +211,46 @@ export function CartSummaryBar({
       <Card>
         <CardContent className="pt-4 space-y-3">
           {obenProductItems.length > 0 && (
-            <PaymentCombobox
-              label="Pagamento Oben"
-              formas={sortedFormasPagamentoOben}
-              selected={selectedParcelaOben}
-              onSelect={setSelectedParcelaOben}
-              customerRanking={customerParcelaRankingOben}
-              loading={loadingFormas}
-            />
+            <div className="space-y-1.5">
+              <PaymentCombobox
+                label="Pagamento Oben"
+                formas={sortedFormasPagamentoOben}
+                selected={selectedParcelaOben}
+                onSelect={setSelectedParcelaOben}
+                customerRanking={customerParcelaRankingOben}
+                loading={loadingFormas}
+              />
+              {!loadingFormas && (
+                <AvisoFormasPagamento
+                  degradado={estadoFormasOben.degradado}
+                  erro={estadoFormasOben.erro}
+                  motivo={estadoFormasOben.motivo}
+                  condicoesAusentes={estadoFormasOben.condicoesAusentes}
+                  onRecarregar={onRecarregarFormas}
+                />
+              )}
+            </div>
           )}
           {colacorProductItems.length > 0 && (
-            <PaymentCombobox
-              label="Pagamento Colacor"
-              formas={sortedFormasPagamentoColacor}
-              selected={selectedParcelaColacor}
-              onSelect={setSelectedParcelaColacor}
-              customerRanking={customerParcelaRankingColacor}
-              loading={loadingFormas}
-            />
+            <div className="space-y-1.5">
+              <PaymentCombobox
+                label="Pagamento Colacor"
+                formas={sortedFormasPagamentoColacor}
+                selected={selectedParcelaColacor}
+                onSelect={setSelectedParcelaColacor}
+                customerRanking={customerParcelaRankingColacor}
+                loading={loadingFormas}
+              />
+              {!loadingFormas && (
+                <AvisoFormasPagamento
+                  degradado={estadoFormasColacor.degradado}
+                  erro={estadoFormasColacor.erro}
+                  motivo={estadoFormasColacor.motivo}
+                  condicoesAusentes={estadoFormasColacor.condicoesAusentes}
+                  onRecarregar={onRecarregarFormas}
+                />
+              )}
+            </div>
           )}
           {isOrdemCompraCustomer && setOrdemCompra && (
             <div>
@@ -247,6 +294,13 @@ export function CartSummaryBar({
             <p className="text-xs text-status-error">
               <AlertCircle className="w-3 h-3 inline mr-1" />
               Defina um preço maior que zero para os itens destacados antes de enviar.
+            </p>
+          )}
+          {condicoesBloqueantes.length > 0 && (
+            <p className="text-xs text-status-error">
+              <AlertCircle className="w-3 h-3 inline mr-1" />
+              {mensagemCondicoesIndisponiveis(condicoesBloqueantes)}
+              {onSubmitQuote && ' Você pode salvar como orçamento e enviar quando o Omie voltar.'}
             </p>
           )}
           <Button className="w-full gap-2" onClick={onSubmit} disabled={disableSubmit}>

--- a/src/components/unified-order/__tests__/CartSummaryBar.formasDegradadas.test.tsx
+++ b/src/components/unified-order/__tests__/CartSummaryBar.formasDegradadas.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CartSummaryBar } from '../CartSummaryBar';
+import type { ProductCartItem } from '@/hooks/unifiedOrder/types';
+import type { EstadoFormasUI } from '@/services/orderSubmission/formasDegradacao';
+
+function prod(account: 'oben' | 'colacor'): ProductCartItem {
+  return {
+    type: 'product', account, quantity: 1, unit_price: 10,
+    product: { id: 'p', omie_codigo_produto: 'X', codigo: 'C', descricao: 'Lixa', unidade: 'UN' },
+  } as unknown as ProductCartItem;
+}
+
+const OK: EstadoFormasUI = { degradado: false, motivo: null, erro: false, condicoesAusentes: [] };
+const DEGRADADO: EstadoFormasUI = {
+  degradado: true, motivo: 'Omie: rate limit', erro: false, condicoesAusentes: [],
+};
+const DEGRADADO_COM_PROVA: EstadoFormasUI = {
+  degradado: true, motivo: 'Omie: rate limit', erro: false, condicoesAusentes: ['A17'],
+};
+
+function makeProps(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    cart: { length: 1 },
+    obenProductItems: [prod('oben')],
+    colacorProductItems: [] as ProductCartItem[],
+    serviceItems: [],
+    totalEstimated: 100,
+    submitting: false,
+    vendedorDivergencias: [] as string[],
+    sortedFormasPagamentoOben: [{ codigo: '999', descricao: 'A Vista' }],
+    sortedFormasPagamentoColacor: [],
+    selectedParcelaOben: '999',
+    setSelectedParcelaOben: vi.fn(),
+    selectedParcelaColacor: '999',
+    setSelectedParcelaColacor: vi.fn(),
+    loadingFormas: false,
+    customerParcelaRankingOben: [] as string[],
+    customerParcelaRankingColacor: [] as string[],
+    notes: '',
+    setNotes: vi.fn(),
+    volumesOben: 1,
+    volumesColacor: 0,
+    onSubmit: vi.fn(),
+    onSubmitQuote: vi.fn(),
+    ...over,
+  };
+}
+
+const botaoEnviar = () => screen.getByRole('button', { name: /enviar pedido/i }) as HTMLButtonElement;
+
+describe('CartSummaryBar — degradação das condições de pagamento chega à tela', () => {
+  it('sem degradação → nenhum aviso, envio liberado', () => {
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: OK })} />);
+    expect(screen.queryByText(/condições do omie indisponíveis/i)).toBeNull();
+    expect(botaoEnviar().disabled).toBe(false);
+  });
+
+  // COMPATIBILIDADE (item 3): edge antiga não manda `degraded` → o hook produz o default.
+  it('props de estado AUSENTES (edge antiga) → nenhum aviso falso, envio liberado', () => {
+    render(<CartSummaryBar {...makeProps()} />);
+    expect(screen.queryByText(/condições do omie indisponíveis/i)).toBeNull();
+    expect(botaoEnviar().disabled).toBe(false);
+  });
+
+  it('degradado SEM prova → aviso visível com motivo, mas envio segue liberado', () => {
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: DEGRADADO })} />);
+    expect(screen.getByText(/condições do omie indisponíveis/i)).toBeTruthy();
+    expect(screen.getByText(/rate limit/i)).toBeTruthy();
+    expect(botaoEnviar().disabled).toBe(false);
+  });
+
+  it('degradado COM prova (cliente usa condição ausente) → envio BLOQUEADO e o código citado', () => {
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: DEGRADADO_COM_PROVA })} />);
+    expect(botaoEnviar().disabled).toBe(true);
+    expect(screen.getAllByText(/A17/).length).toBeGreaterThan(0);
+  });
+
+  it('bloqueio NÃO trava o orçamento — é a saída do vendedor (não grava codigo_parcela)', () => {
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: DEGRADADO_COM_PROVA })} />);
+    const orcamento = screen.getByRole('button', { name: /orçamento/i }) as HTMLButtonElement;
+    expect(orcamento.disabled).toBe(false);
+  });
+
+  it('degradação de conta SEM item no carrinho não bloqueia (a condição dela não é enviada)', () => {
+    render(<CartSummaryBar {...makeProps({
+      obenProductItems: [prod('oben')],
+      colacorProductItems: [],
+      estadoFormasOben: OK,
+      estadoFormasColacor: DEGRADADO_COM_PROVA,
+    })} />);
+    expect(botaoEnviar().disabled).toBe(false);
+  });
+
+  it('a MESMA degradação na conta COM item bloqueia — o par que prova o detector', () => {
+    render(<CartSummaryBar {...makeProps({
+      obenProductItems: [],
+      colacorProductItems: [prod('colacor')],
+      estadoFormasOben: OK,
+      estadoFormasColacor: DEGRADADO_COM_PROVA,
+    })} />);
+    expect(botaoEnviar().disabled).toBe(true);
+  });
+
+  it('falha total da consulta → aviso de indisponível, sem inventar bloqueio', () => {
+    const erro: EstadoFormasUI = { degradado: false, motivo: null, erro: true, condicoesAusentes: [] };
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: erro })} />);
+    expect(screen.getByText(/não foi possível carregar as condições/i)).toBeTruthy();
+    expect(botaoEnviar().disabled).toBe(false);
+  });
+
+  it('oferece "Tentar de novo" quando há como recarregar', () => {
+    const onRecarregarFormas = vi.fn();
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: DEGRADADO, onRecarregarFormas })} />);
+    expect(screen.getByRole('button', { name: /tentar de novo/i })).toBeTruthy();
+  });
+
+  it('durante o loading não mostra aviso (estado ainda indefinido, não degradado)', () => {
+    render(<CartSummaryBar {...makeProps({ estadoFormasOben: DEGRADADO, loadingFormas: true })} />);
+    expect(screen.queryByText(/condições do omie indisponíveis/i)).toBeNull();
+  });
+});

--- a/src/hooks/useUnifiedOrder.ts
+++ b/src/hooks/useUnifiedOrder.ts
@@ -24,6 +24,14 @@ import { maskDocument } from '@/lib/format';
 import { buildOmieCustomer } from '@/lib/unified-order/build-omie-customer';
 import { computeCheckoutFingerprint, decideCheckoutEnvelope, type CheckoutEnvelope } from '@/services/orderSubmission/checkout-envelope';
 import { resolveBridgeMetadata } from '@/services/orderSubmission/origem';
+import {
+  lerRespostaFormas,
+  condicoesDoClienteIndisponiveis,
+  condicoesBloqueantesDoCarrinho,
+  mensagemCondicoesIndisponiveis,
+  type EstadoFormasPagamento,
+  type EstadoFormasUI,
+} from '@/services/orderSubmission/formasDegradacao';
 
 const CHECKOUT_ENV_KEY = 'unified_order_checkout_env';
 function loadCheckoutEnv(): CheckoutEnvelope | null {
@@ -58,7 +66,6 @@ import type {
   ServiceCartItem,
   CartItem,
   OmieCustomer,
-  FormaPagamento,
   CompanyProfile,
   ToolCategory,
   UserTool,
@@ -140,21 +147,24 @@ export function useUnifiedOrder() {
     },
   });
 
-  // Payment (forms list & method) — react-query por conta, 10min stale, só staff
-  const formasQueryFn = (account: ProductAccount) => async (): Promise<FormaPagamento[]> => {
+  // Payment (forms list & method) — react-query por conta, 10min stale, só staff.
+  // A query carrega o ENVELOPE inteiro (formas + degradação declarada pelo edge #1597), não
+  // só `formas`: ler só a lista devolve 8 condições genéricas indistinguíveis das reais do
+  // cliente (money-path §7 — a correção do edge só termina na tela).
+  const formasQueryFn = (account: ProductAccount) => async (): Promise<EstadoFormasPagamento> => {
     const { data, error } = await supabase.functions.invoke('omie-vendas-sync', {
       body: { action: 'listar_formas_pagamento', account },
     });
     if (error) throw error;
-    return (data?.formas || []) as FormaPagamento[];
+    return lerRespostaFormas(data);
   };
-  const obenFormasQuery = useQuery<FormaPagamento[]>({
+  const obenFormasQuery = useQuery<EstadoFormasPagamento>({
     queryKey: ['formas-pagamento', 'oben'],
     enabled: isStaff,
     staleTime: 10 * 60 * 1000,
     queryFn: formasQueryFn('oben'),
   });
-  const colacorFormasQuery = useQuery<FormaPagamento[]>({
+  const colacorFormasQuery = useQuery<EstadoFormasPagamento>({
     queryKey: ['formas-pagamento', 'colacor'],
     enabled: isStaff,
     staleTime: 10 * 60 * 1000,
@@ -162,9 +172,14 @@ export function useUnifiedOrder() {
   });
   // useMemo estabiliza a referência: `|| []` criava um array novo a cada render,
   // invalidando os useMemo/useCallback que dependem destes (sortedFormas*, submit).
-  const formasPagamentoOben = useMemo(() => obenFormasQuery.data || [], [obenFormasQuery.data]);
-  const formasPagamentoColacor = useMemo(() => colacorFormasQuery.data || [], [colacorFormasQuery.data]);
+  const formasPagamentoOben = useMemo(() => obenFormasQuery.data?.formas || [], [obenFormasQuery.data]);
+  const formasPagamentoColacor = useMemo(() => colacorFormasQuery.data?.formas || [], [colacorFormasQuery.data]);
   const loadingFormas = obenFormasQuery.isLoading || colacorFormasQuery.isLoading;
+  // Recarrega as DUAS contas: o vendedor não sabe (nem precisa saber) qual delas degradou.
+  const recarregarFormas = useCallback(() => {
+    void obenFormasQuery.refetch();
+    void colacorFormasQuery.refetch();
+  }, [obenFormasQuery, colacorFormasQuery]);
 
   const [ordemCompra, setOrdemCompra] = useState<string>('');
   const [afiacaoPaymentMethod, setAfiacaoPaymentMethod] = useState<string>('a_vista');
@@ -390,6 +405,37 @@ export function useUnifiedOrder() {
       return 0;
     });
   }, [formasPagamentoColacor, customerParcelaRankingColacor]);
+
+  // Estado da degradação por conta, já cruzado com o histórico REAL do cliente no Omie
+  // (`customerParcelaRanking*` + a parcela pré-selecionada, ambos da action
+  // `buscar_ultima_parcela` — fonte INDEPENDENTE desta query, logo não degradam juntas).
+  // `condicoesAusentes` não-vazio é a prova positiva de que a lista genérica não serve
+  // para ESTE cliente; é o que autoriza o bloqueio do envio (precisão > recall).
+  const estadoFormasOben = useMemo<EstadoFormasUI>(() => {
+    const estado = obenFormasQuery.data ?? { formas: [], degradado: false, motivo: null };
+    return {
+      degradado: estado.degradado,
+      motivo: estado.motivo,
+      erro: obenFormasQuery.isError,
+      condicoesAusentes: condicoesDoClienteIndisponiveis(
+        estado,
+        [selectedParcelaOben, ...customerParcelaRankingOben],
+      ),
+    };
+  }, [obenFormasQuery.data, obenFormasQuery.isError, selectedParcelaOben, customerParcelaRankingOben]);
+
+  const estadoFormasColacor = useMemo<EstadoFormasUI>(() => {
+    const estado = colacorFormasQuery.data ?? { formas: [], degradado: false, motivo: null };
+    return {
+      degradado: estado.degradado,
+      motivo: estado.motivo,
+      erro: colacorFormasQuery.isError,
+      condicoesAusentes: condicoesDoClienteIndisponiveis(
+        estado,
+        [selectedParcelaColacor, ...customerParcelaRankingColacor],
+      ),
+    };
+  }, [colacorFormasQuery.data, colacorFormasQuery.isError, selectedParcelaColacor, customerParcelaRankingColacor]);
 
   const isCustomerMode = !authLoading && !isStaff;
   const currentStep = isCustomerMode
@@ -739,6 +785,20 @@ export function useUnifiedOrder() {
       toast.info('Aguarde — ainda carregando os dados do cliente.');
       return;
     }
+    // Guard money-path da condição de pagamento: a listagem do Omie degradou para as 8
+    // genéricas E este cliente usa condição que não está entre elas (prova pelo histórico
+    // real de pedidos). Enviar gravaria um prazo diferente do combinado — DSO errado, ou
+    // rejeição do Omie. Fail-closed no CAMINHO DE ENVIO, não só no `disabled` do botão.
+    // Saída do vendedor: "Tentar de novo" (refetch) ou salvar como orçamento, que não
+    // grava codigo_parcela.
+    const bloqueioFormas = condicoesBloqueantesDoCarrinho([
+      { temItens: obenProductItems.length > 0, estado: estadoFormasOben },
+      { temItens: colacorProductItems.length > 0, estado: estadoFormasColacor },
+    ]);
+    if (bloqueioFormas.length > 0) {
+      toast.error(mensagemCondicoesIndisponiveis(bloqueioFormas));
+      return;
+    }
     if (submittingRef.current) return; // re-entrância: ver comentário na declaração
     submittingRef.current = true;
     setSubmitting(true);
@@ -883,6 +943,7 @@ export function useUnifiedOrder() {
     companyProfiles, defaultProductionAssigneeId,
     getServicePrice, clearCart, isCustomerMode,
     waitForAccountEnsure, loadingCustomer, searchParams,
+    estadoFormasOben, estadoFormasColacor,
   ]);
 
   // clearCustomer defined earlier (wraps useCustomerSelection.clearCustomer + clears cart/ordemCompra/userTools)
@@ -913,6 +974,7 @@ export function useUnifiedOrder() {
     selectedParcelaOben, setSelectedParcelaOben,
     selectedParcelaColacor, setSelectedParcelaColacor,
     loadingFormas, customerParcelaRankingOben, customerParcelaRankingColacor,
+    estadoFormasOben, estadoFormasColacor, recarregarFormas,
     afiacaoPaymentMethod, setAfiacaoPaymentMethod,
     volumesOben, volumesColacor,
     ordemCompra, setOrdemCompra,

--- a/src/pages/SalesOrderEdit.tsx
+++ b/src/pages/SalesOrderEdit.tsx
@@ -7,6 +7,7 @@ import { Loader2, Save, Plus, AlertCircle, X } from 'lucide-react';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { useSalesOrderEdit } from '@/components/salesOrderEdit/useSalesOrderEdit';
 import { PaymentComboboxEdit } from '@/components/salesOrderEdit/PaymentComboboxEdit';
+import { AvisoFormasPagamento } from '@/components/sales/AvisoFormasPagamento';
 import { AddProductSearch } from '@/components/salesOrderEdit/AddProductSearch';
 import { OrderItemCard } from '@/components/salesOrderEdit/OrderItemCard';
 
@@ -22,6 +23,11 @@ const SalesOrderEdit = () => {
     formas,
     selectedParcela,
     setSelectedParcela,
+    formasDegradadas,
+    formasErro,
+    formasMotivo,
+    condicaoDoPedidoAusente,
+    parcelaTravada,
     showAddProduct,
     setShowAddProduct,
     productSearch,
@@ -133,19 +139,35 @@ const SalesOrderEdit = () => {
           </CardContent>
         </Card>
 
-        {/* Forma de Pagamento */}
-        {formas.length > 0 && (
+        {/* Forma de Pagamento — o card aparece também quando a listagem degradou ou
+            falhou, mesmo sem opções: sumir levaria o aviso junto e a tela diria, por
+            omissão, que este pedido não tem condição de pagamento (§7). */}
+        {(formas.length > 0 || formasDegradadas || formasErro) && (
           <Card>
             <CardHeader className="pb-2">
               <CardTitle className="text-base">Forma de Pagamento</CardTitle>
             </CardHeader>
-            <CardContent>
-              <PaymentComboboxEdit
-                formas={formas}
-                selected={selectedParcela}
-                onSelect={setSelectedParcela}
-                disabled={isBlocked}
+            <CardContent className="space-y-2">
+              {formas.length > 0 && (
+                <PaymentComboboxEdit
+                  formas={formas}
+                  selected={selectedParcela}
+                  onSelect={setSelectedParcela}
+                  disabled={isBlocked || parcelaTravada}
+                />
+              )}
+              <AvisoFormasPagamento
+                degradado={formasDegradadas}
+                erro={formasErro}
+                motivo={formasMotivo}
+                condicoesAusentes={condicaoDoPedidoAusente}
               />
+              {parcelaTravada && (
+                <p className="text-xs text-muted-foreground">
+                  A condição atual do pedido ({selectedParcela}) foi mantida e vai íntegra ao
+                  Omie. Recarregue a página quando o Omie voltar para poder alterá-la.
+                </p>
+              )}
             </CardContent>
           </Card>
         )}

--- a/src/pages/SalesPrintDashboard.tsx
+++ b/src/pages/SalesPrintDashboard.tsx
@@ -13,8 +13,10 @@ import { openPrintOrder } from '@/components/OrderPrintLayout';
 import {
   COMPANY_LABELS, COMPANY_COLORS, getPeriod,
   type CompanyFilter, type SalesOrderRow, type ProfileLite, type AddressLite,
-  type FormaPagamento, type EnrichedOrder,
+  type EnrichedOrder,
 } from '@/components/sales/print/types';
+import { lerRespostaFormas } from '@/services/orderSubmission/formasDegradacao';
+import { AvisoFormasPagamento } from '@/components/sales/AvisoFormasPagamento';
 import { buildPrintData, buildSingleOrderHtml, buildPrintDocument } from '@/components/sales/print/buildPrintHtml';
 import { PrintFilters } from '@/components/sales/print/PrintFilters';
 import { OrderGroup } from '@/components/sales/print/OrderGroup';
@@ -47,23 +49,34 @@ const SalesPrintDashboard = () => {
 
   // Fetch sales_orders for the selected date
   // Fetch payment terms map (code -> description)
-  const { data: formasMap = {} } = useQuery({
+  // O mapa código→descrição rotula a condição de pagamento na VIA IMPRESSA que vai ao
+  // cliente. Sob degradação (edge #1597), as "formas" são 8 genéricas HARDCODED, não as
+  // do Omie — usá-las aqui fabricaria um rótulo ("30/60 dias") para um código cuja
+  // descrição real ninguém leu. Money-path §2, ausente ≠ zero: a conta degradada não entra
+  // no mapa, o código cru aparece na via (dado bruto verdadeiro) e a tela avisa o porquê.
+  const { data: formasPagamento, refetch: recarregarFormas } = useQuery({
     queryKey: ['sales-print-formas-pagamento'],
     queryFn: async () => {
-      const result: Record<string, string> = {};
+      const mapa: Record<string, string> = {};
+      const contasDegradadas: string[] = [];
       for (const acc of ['oben', 'colacor'] as const) {
         try {
           const { data } = await supabase.functions.invoke('omie-vendas-sync', {
             body: { action: 'listar_formas_pagamento', account: acc },
           });
-          const formas = (data?.formas ?? []) as FormaPagamento[];
-          formas.forEach((f) => { result[f.codigo] = f.descricao; });
-        } catch (_) { /* ignore */ }
+          const estado = lerRespostaFormas(data);
+          if (estado.degradado) { contasDegradadas.push(acc); continue; }
+          estado.formas.forEach((f) => { mapa[f.codigo] = f.descricao; });
+        } catch (_) { contasDegradadas.push(acc); }
       }
-      return result;
+      return { mapa, contasDegradadas };
     },
     staleTime: 1000 * 60 * 30, // cache 30 min
   });
+  // useMemo estabiliza a referência: `?? {}` criaria um objeto novo a cada render e
+  // invalidaria o useMemo de `filteredOrders`, que tem `formasMap` nas deps.
+  const formasMap = useMemo(() => formasPagamento?.mapa ?? {}, [formasPagamento]);
+  const contasComFormasDegradadas = formasPagamento?.contasDegradadas ?? [];
 
   const { data: salesOrders = [], isLoading: loadingSales } = useQuery({
     queryKey: ['sales-print', 'sales', dayStart],
@@ -405,6 +418,20 @@ const SalesPrintDashboard = () => {
             <p className="text-sm text-muted-foreground">Selecione a data e empresa para imprimir</p>
           </div>
         </div>
+
+        {/* Degradação da listagem de condições: a via impressa sai com o CÓDIGO da parcela
+            em vez da descrição — melhor um código cru verdadeiro que um rótulo genérico
+            errado no documento que vai ao cliente. */}
+        <AvisoFormasPagamento
+          degradado={contasComFormasDegradadas.length > 0}
+          onRecarregar={() => { void recarregarFormas(); }}
+          texto={
+            'Condições do Omie indisponíveis para '
+            + contasComFormasDegradadas.map((c) => (c === 'oben' ? 'Oben' : 'Colacor')).join(' e ')
+            + '. A impressão mostra o CÓDIGO da condição no lugar da descrição, para não '
+            + 'imprimir um prazo que não foi conferido.'
+          }
+        />
 
         {/* Filters */}
         <PrintFilters

--- a/src/pages/UnifiedOrder.tsx
+++ b/src/pages/UnifiedOrder.tsx
@@ -463,6 +463,9 @@ const UnifiedOrder = () => {
             condicaoPrazoOben={h.selectedParcelaOben}
           />
 
+          {/* estadoFormas + onRecarregarFormas: customer mode não escolhe condição de
+              pagamento (a query nem roda — enabled=isStaff), então espelham o mesmo corte
+              das formas ordenadas abaixo; `undefined` cai no default "sem degradação". */}
           {h.cart.length > 0 && h.selectedCustomer && (
             <CartSummaryBar
               cart={h.cart} obenProductItems={h.obenProductItems} colacorProductItems={h.colacorProductItems}
@@ -474,6 +477,9 @@ const UnifiedOrder = () => {
               selectedParcelaColacor={h.selectedParcelaColacor} setSelectedParcelaColacor={h.setSelectedParcelaColacor}
               loadingFormas={h.loadingFormas} customerParcelaRankingOben={h.customerParcelaRankingOben}
               customerParcelaRankingColacor={h.customerParcelaRankingColacor}
+              estadoFormasOben={isCustomerMode ? undefined : h.estadoFormasOben}
+              estadoFormasColacor={isCustomerMode ? undefined : h.estadoFormasColacor}
+              onRecarregarFormas={isCustomerMode ? undefined : h.recarregarFormas}
               notes={h.notes} setNotes={h.setNotes}
                volumesOben={h.volumesOben}
                volumesColacor={h.volumesColacor}

--- a/src/services/orderSubmission/__tests__/formasDegradacao.test.ts
+++ b/src/services/orderSubmission/__tests__/formasDegradacao.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  lerRespostaFormas,
+  condicoesConhecidasAusentes,
+  condicoesDoClienteIndisponiveis,
+  mensagemCondicoesIndisponiveis,
+  ESTADO_FORMAS_VAZIO,
+} from '../formasDegradacao';
+
+const FORMAS_OMIE = [
+  { codigo: '999', descricao: 'A Vista' },
+  { codigo: 'A17', descricao: '45/75/105 dias' },
+];
+const FORMAS_FALLBACK = [
+  { codigo: '999', descricao: 'A Vista' },
+  { codigo: '002', descricao: '30/60 dias' },
+];
+
+describe('lerRespostaFormas — a degradação chega ao consumidor', () => {
+  it('resposta boa do Omie → não degradado, formas preservadas', () => {
+    const estado = lerRespostaFormas({
+      success: true, formas: FORMAS_OMIE, source: 'omie', degraded: false, motivo: null,
+    });
+    expect(estado.degradado).toBe(false);
+    expect(estado.formas).toEqual(FORMAS_OMIE);
+    expect(estado.motivo).toBeNull();
+  });
+
+  it('fallback declarado → degradado, com motivo propagado', () => {
+    const estado = lerRespostaFormas({
+      success: true, formas: FORMAS_FALLBACK, source: 'fallback',
+      degraded: true, motivo: 'rate limit',
+    });
+    expect(estado.degradado).toBe(true);
+    expect(estado.motivo).toBe('rate limit');
+  });
+
+  it('degraded ausente mas source=fallback → degradado (2º sinal do mesmo contrato)', () => {
+    expect(lerRespostaFormas({ formas: FORMAS_FALLBACK, source: 'fallback' }).degradado).toBe(true);
+  });
+
+  it('degradado sem motivo → motivo null, nunca string vazia', () => {
+    const estado = lerRespostaFormas({ formas: FORMAS_FALLBACK, degraded: true, motivo: '' });
+    expect(estado.degradado).toBe(true);
+    expect(estado.motivo).toBeNull();
+  });
+
+  // COMPATIBILIDADE (item 3): edge anterior ao #1597 / ainda não deployada.
+  it('edge ANTIGA (sem degraded/source) → NÃO degradado — nada de aviso falso', () => {
+    const estado = lerRespostaFormas({ success: true, formas: FORMAS_OMIE });
+    expect(estado.degradado).toBe(false);
+    expect(estado.formas).toEqual(FORMAS_OMIE);
+  });
+
+  it('degraded undefined/null explícitos → NÃO degradado (teste estrito, sem coerção)', () => {
+    expect(lerRespostaFormas({ formas: [], degraded: undefined }).degradado).toBe(false);
+    expect(lerRespostaFormas({ formas: [], degraded: null }).degradado).toBe(false);
+  });
+
+  it('payload ausente/inválido → estado vazio, não degradado', () => {
+    expect(lerRespostaFormas(null)).toEqual(ESTADO_FORMAS_VAZIO);
+    expect(lerRespostaFormas(undefined)).toEqual(ESTADO_FORMAS_VAZIO);
+    expect(lerRespostaFormas('erro')).toEqual(ESTADO_FORMAS_VAZIO);
+  });
+
+  it('formas null/não-array → [] (nunca undefined pro .map da UI)', () => {
+    expect(lerRespostaFormas({ formas: null, degraded: true }).formas).toEqual([]);
+    expect(lerRespostaFormas({ formas: 'x' }).formas).toEqual([]);
+  });
+});
+
+describe('condicoesConhecidasAusentes — prova positiva de condição sumida', () => {
+  it('código do histórico ausente da lista → devolvido', () => {
+    expect(condicoesConhecidasAusentes(FORMAS_FALLBACK, ['A17'])).toEqual(['A17']);
+  });
+
+  it('todos os códigos presentes → nenhum ausente', () => {
+    expect(condicoesConhecidasAusentes(FORMAS_OMIE, ['999', 'A17'])).toEqual([]);
+  });
+
+  it('ignora código vazio/nulo — ausência não é prova', () => {
+    expect(condicoesConhecidasAusentes(FORMAS_FALLBACK, ['', null as unknown as string])).toEqual([]);
+  });
+
+  it('deduplica preservando a ordem de entrada', () => {
+    expect(condicoesConhecidasAusentes(FORMAS_FALLBACK, ['A17', 'B20', 'A17'])).toEqual(['A17', 'B20']);
+  });
+
+  it('lista vazia → todo código conhecido conta como ausente', () => {
+    expect(condicoesConhecidasAusentes([], ['999'])).toEqual(['999']);
+  });
+});
+
+describe('condicoesDoClienteIndisponiveis — só bloqueia com degradação DECLARADA', () => {
+  // O par crítico: mesmo input de códigos, veredito oposto conforme `degradado`.
+  it('degradado + código do cliente ausente → prova (bloqueia)', () => {
+    const estado = { formas: FORMAS_FALLBACK, degradado: true, motivo: null };
+    expect(condicoesDoClienteIndisponiveis(estado, ['A17'])).toEqual(['A17']);
+  });
+
+  it('NÃO degradado + mesmo código ausente → vazio (parcela inativada no Omie é legítimo)', () => {
+    const estado = { formas: FORMAS_FALLBACK, degradado: false, motivo: null };
+    expect(condicoesDoClienteIndisponiveis(estado, ['A17'])).toEqual([]);
+  });
+
+  it('degradado mas cliente sem histórico → vazio (só aviso, sem bloqueio)', () => {
+    const estado = { formas: FORMAS_FALLBACK, degradado: true, motivo: null };
+    expect(condicoesDoClienteIndisponiveis(estado, [])).toEqual([]);
+  });
+
+  it('degradado e o fallback cobre a condição do cliente → vazio', () => {
+    const estado = { formas: FORMAS_FALLBACK, degradado: true, motivo: null };
+    expect(condicoesDoClienteIndisponiveis(estado, ['999'])).toEqual([]);
+  });
+});
+
+describe('mensagemCondicoesIndisponiveis', () => {
+  it('cita os códigos que sumiram', () => {
+    const msg = mensagemCondicoesIndisponiveis(['A17', 'B20']);
+    expect(msg).toContain('A17, B20');
+    expect(msg).toContain('prazo diferente do combinado');
+  });
+});

--- a/src/services/orderSubmission/formasDegradacao.ts
+++ b/src/services/orderSubmission/formasDegradacao.ts
@@ -1,0 +1,168 @@
+// Guard money-path da CONDIÇÃO DE PAGAMENTO sob degradação da listagem do Omie.
+//
+// Contexto (#1597): `listarFormasPagamento` no edge omie-vendas-sync passou a usar
+// `throwOnTransient` — rate-limit/transitório ESGOTADO não devolve mais a lista PARCIAL
+// como se fosse completa. Em troca, cai num fallback HARDCODED de 8 condições genéricas
+// ("A Vista", "30 dias", "30/60 dias"…) e DECLARA a degradação no retorno
+// (`source: 'omie'|'fallback'`, `degraded`, `motivo`).
+//
+// Este módulo é o lar único da leitura desse envelope e da decisão que ele habilita —
+// money-path §7: "consertar o helper NÃO conserta a tela; a correção só termina na tela".
+// Sem isto o vendedor monta o pedido vendo 8 genéricas sem saber que as condições REAIS
+// daquele cliente não carregaram: escolhe uma que o Omie rejeita na gravação, ou — pior —
+// uma que o Omie ACEITA com prazo diferente do combinado (DSO errado).
+import type { FormaPagamento } from '@/hooks/unifiedOrder/types';
+
+/**
+ * Envelope da action `listar_formas_pagamento`. TODOS os campos além de `formas` são
+ * opcionais de propósito: edge ANTERIOR ao #1597 (ou ainda não deployada — merge na main
+ * ≠ produção) devolve só `{ success, formas }`, e aí `degraded` chega `undefined`.
+ */
+export interface RespostaFormasPagamento {
+  formas?: FormaPagamento[] | null;
+  source?: string | null;
+  degraded?: boolean | null;
+  motivo?: string | null;
+}
+
+/** Estado normalizado que a UI consome. `degradado` só é true sob declaração explícita. */
+export interface EstadoFormasPagamento {
+  formas: FormaPagamento[];
+  degradado: boolean;
+  /** Mensagem do erro do Omie que causou o fallback (pode faltar mesmo degradado). */
+  motivo: string | null;
+}
+
+export const ESTADO_FORMAS_VAZIO: EstadoFormasPagamento = {
+  formas: [],
+  degradado: false,
+  motivo: null,
+};
+
+/**
+ * Recorte que a UI precisa para avisar/bloquear — sem as `formas` (que trafegam por props
+ * próprias, já ordenadas pelo histórico do cliente). Um objeto por conta em vez de 4 props
+ * soltas: o `CartSummaryBar` já carrega ~25 props.
+ */
+export interface EstadoFormasUI {
+  degradado: boolean;
+  motivo: string | null;
+  /** A consulta falhou por inteiro (nem a lista genérica chegou). */
+  erro: boolean;
+  /** Códigos conhecidos deste cliente/pedido que sumiram da lista — prova de bloqueio. */
+  condicoesAusentes: string[];
+}
+
+export const ESTADO_FORMAS_UI_OK: EstadoFormasUI = {
+  degradado: false,
+  motivo: null,
+  erro: false,
+  condicoesAusentes: [],
+};
+
+/**
+ * Lê o envelope do edge sem NUNCA inferir degradação por ausência.
+ *
+ * Compatibilidade fail-OPEN deliberada (é o único ponto do módulo onde ausente vira "ok"):
+ * `degraded === true` e `source === 'fallback'` são testes ESTRITOS, então uma edge antiga
+ * — que não conhece nenhum dos dois campos — é lida como NÃO-degradada e a tela segue como
+ * hoje. O inverso (tratar `undefined` como degradado) pintaria de vermelho todo pedido
+ * enquanto a edge do #1597 não estiver deployada: aviso falso ensina a ignorar o aviso, e
+ * o próximo — o real — vira ruído (money-path, "o VALIDADOR mente").
+ *
+ * `source` entra como segundo sinal do MESMO contrato (nasceram no mesmo commit): não
+ * cobre edge antiga, só um payload que perdesse `degraded` no caminho.
+ */
+export function lerRespostaFormas(data: unknown): EstadoFormasPagamento {
+  if (!data || typeof data !== 'object') return ESTADO_FORMAS_VAZIO;
+  const resp = data as RespostaFormasPagamento;
+  const formas = Array.isArray(resp.formas) ? resp.formas : [];
+  const degradado = resp.degraded === true || resp.source === 'fallback';
+  return {
+    formas,
+    degradado,
+    motivo: typeof resp.motivo === 'string' && resp.motivo.length > 0 ? resp.motivo : null,
+  };
+}
+
+/**
+ * Códigos que sabidamente pertencem a ESTE cliente/pedido e sumiram da lista exibida —
+ * a prova positiva de que a degradação removeu uma condição que importa aqui.
+ *
+ * Fontes de `codigosConhecidos` (ambas independentes desta action, logo não degradam junto):
+ * o `parcela_ranking`/`ultima_parcela` do cliente (action `buscar_ultima_parcela`, histórico
+ * REAL de pedidos no Omie) e o `codigo_parcela` já gravado no pedido em edição.
+ *
+ * ⚠️ Só vale sob degradação declarada. No caminho BOM, código do histórico ausente da lista
+ * é legítimo — `listarFormasPagamento` filtra `cInativo === 'S'`, então parcela desativada no
+ * Omie some da lista e continua no histórico. Chamar isto sem checar `degradado` bloquearia
+ * venda por um estado normal; por isso o predicado de bloqueio abaixo exige as duas coisas.
+ */
+export function condicoesConhecidasAusentes(
+  formas: ReadonlyArray<FormaPagamento>,
+  codigosConhecidos: ReadonlyArray<string>,
+): string[] {
+  const disponiveis = new Set(formas.map((f) => f.codigo));
+  const vistos = new Set<string>();
+  const ausentes: string[] = [];
+  for (const codigo of codigosConhecidos) {
+    // Código vazio/nulo não é prova de nada (money-path: ausente ≠ fato).
+    if (!codigo || disponiveis.has(codigo) || vistos.has(codigo)) continue;
+    vistos.add(codigo);
+    ausentes.push(codigo);
+  }
+  return ausentes;
+}
+
+/**
+ * Prova positiva de que a lista degradada não serve para este cliente/pedido.
+ * Precisão > recall: exige degradação DECLARADA **e** um código conhecido ausente.
+ * Degradação sem código conhecido (cliente novo, histórico não carregado) → só aviso.
+ */
+export function condicoesDoClienteIndisponiveis(
+  estado: EstadoFormasPagamento,
+  codigosConhecidos: ReadonlyArray<string>,
+): string[] {
+  if (!estado.degradado) return [];
+  return condicoesConhecidasAusentes(estado.formas, codigosConhecidos);
+}
+
+/**
+ * Códigos que impedem o ENVIO do carrinho — lar único da decisão de bloqueio, consumido
+ * tanto pelo `disabled` do botão quanto pelo guard imperativo do submit (money-path §5: a
+ * UI é defense-in-depth, o guard no caminho de envio é a proteção; as duas re-decidindo
+ * separadamente esconderiam qual vale).
+ *
+ * Só conta a conta que REALMENTE tem item no carrinho: pedido só-Oben não pode ser barrado
+ * porque a listagem da Colacor degradou — a condição da Colacor não vai a lugar nenhum.
+ */
+export function condicoesBloqueantesDoCarrinho(
+  contas: ReadonlyArray<{ temItens: boolean; estado: EstadoFormasUI }>,
+): string[] {
+  const codigos: string[] = [];
+  for (const { temItens, estado } of contas) {
+    if (!temItens) continue;
+    for (const codigo of estado.condicoesAusentes) {
+      if (!codigos.includes(codigo)) codigos.push(codigo);
+    }
+  }
+  return codigos;
+}
+
+/** Aviso de degradação (lista genérica no lugar das condições reais do Omie). */
+export const AVISO_FORMAS_DEGRADADAS =
+  'Condições do Omie indisponíveis; mostrando opções padrão.';
+
+/** Aviso de falha total da consulta (nem a lista genérica chegou). */
+export const AVISO_FORMAS_INDISPONIVEIS =
+  'Não foi possível carregar as condições de pagamento do Omie.';
+
+/**
+ * Mensagem de bloqueio, citando os códigos que o cliente usa e que sumiram — o vendedor
+ * precisa saber QUAL condição não está na tela para decidir se espera ou salva orçamento.
+ */
+export function mensagemCondicoesIndisponiveis(codigos: ReadonlyArray<string>): string {
+  const lista = codigos.join(', ');
+  return `Este cliente usa condição de pagamento que não está na lista (${lista}). `
+    + 'As condições do Omie não carregaram — enviar agora gravaria um prazo diferente do combinado.';
+}


### PR DESCRIPTION
**Follow-up declarado do #1597.** Aquele PR fez `listarFormasPagamento` parar de devolver a lista PARCIAL de parcelas como se fosse completa (`throwOnTransient`) e passou a **declarar** a degradação no retorno (`source`, `degraded`, `motivo`) — mas escreveu no próprio código que os três consumidores do front ignoravam esses campos, e que exibir o aviso na tela era o follow-up. Este PR é esse follow-up.

Enquanto isso não chega à tela, a correção do edge está pela metade: o vendedor monta o pedido vendo **8 condições genéricas hardcoded** (`A Vista`, `30 dias`, `30/60 dias`…) indistinguíveis das reais do cliente. Ele escolhe uma que o Omie rejeita na gravação — ou, pior, uma que o Omie **aceita** com prazo diferente do combinado: DSO errado, sem ninguém saber. É o `money-path.md` §7 literal: *"consertar o helper NÃO conserta a tela — a correção só termina na tela"*.

## O que muda em cada consumidor

**1. Criação de pedido** (`useUnifiedOrder` → `CartSummaryBar`) — a query passa a carregar o envelope inteiro, não só `formas`. Aviso `status-warning` sob cada seletor da conta degradada, com o motivo e um botão **"Tentar de novo"** (refetch).

**2. Edição de pedido** (`useSalesOrderEdit` → `SalesOrderEdit`) — mesmo aviso. Quando a condição já gravada no pedido não está na lista degradada, o **seletor trava**: o combobox mostraria rótulo vazio (o código não casa com nenhuma opção), o que parece "não selecionado" e convida a escolher uma genérica — trocando o prazo de um pedido já negociado. Travado, `selectedParcela` continua sendo o código original e vai íntegro ao Omie; editar item/observação segue livre.

**3. Impressão** (`SalesPrintDashboard`) — a conta degradada **não entra** no mapa código→descrição. O fallback é uma lista escrita à mão, não dado do Omie: usá-la para rotular a condição na via que vai ao cliente fabricaria um prazo que ninguém conferiu. Sem o mapa, sai o **código cru** (dado bruto verdadeiro) e a tela explica o porquê. `money-path.md` §2, ausente ≠ zero.

## O bloqueio, e por que ele tem base

O item "considerar bloquear" só vale com **prova positiva** — precisão > recall, sem inventar bloqueio. A prova existe e vem de uma fonte **independente** desta query: a action `buscar_ultima_parcela` traz o `parcela_ranking`/`ultima_parcela` do cliente, o histórico REAL de pedidos dele no Omie (e, na edição, o `codigo_parcela` gravado no próprio pedido). Se um desses códigos **sumiu** da lista exibida **e** a degradação foi declarada, está provado que a lista genérica não serve para este cliente.

O envio é barrado só nessa conjunção:

| degradado | código conhecido ausente | efeito |
|---|---|---|
| não | sim | **nada** — parcela inativada no Omie (`cInativo === 'S'` é filtrado) é estado legítimo |
| sim | não (cliente novo, ou o fallback cobre) | só aviso |
| sim | **sim** | aviso + **envio bloqueado** |

Detalhes que mantêm o bloqueio estreito: só conta a conta que **tem item no carrinho** (pedido só-Oben não é barrado porque a listagem da Colacor caiu); o guard vive no `submitOrder`/`handleSave`, com o `disabled` do botão como defense-in-depth (§5), os dois decidindo pelo **mesmo helper**; e **"Salvar como Orçamento" segue liberado de propósito** — `submitQuote` não grava `codigo_parcela`, então é a saída sem risco enquanto o Omie não volta.

## Compatibilidade

`degraded === true` e `source === 'fallback'` são testes **estritos**: edge anterior ao #1597 — ou ainda não deployada — devolve só `{success, formas}`, `degraded` chega `undefined` e a tela se comporta exatamente como hoje. Tratar ausência como degradação pintaria de vermelho todo pedido e ensinaria a ignorar o aviso; o próximo, o real, viraria ruído.

## ⚠️ Esta defesa fica INERTE até a edge do #1597 ser deployada

Declarado como manda o §2 (a armadilha do #1498). O #1597 mergeou hoje e pede **deploy manual da `omie-vendas-sync`** pelo chat do Lovable — merge na main ≠ produção. Enquanto a edge em produção for a antiga, ela não emite `degraded`, e este PR não muda **nada** na tela (por desenho: é o caminho de compatibilidade acima). Publish do frontend sozinho não ativa o aviso. Confirmei que o símbolo `degraded: parcelas.degraded` segue vivo na `origin/main` (guarda contra o sync reverso do Lovable), mas o estado da edge **em produção** não é verificável daqui.

## União com o #1605 (mesmo site, PRs diferentes)

O #1605 mergeou durante esta entrega e tocou exatamente o ponto onde eu mexia — `money-path.md` §9: *"resolver o conflito pelo meu lado REVERTE a metade do outro"*. Ele fechou a metade **"`functions.invoke` não lança"** com `if (formasRes.error) throw formasRes.error`; eu fechava a metade **"a degradação não chega à tela"** e, de passagem, tratava o mesmo `formasRes.error` de outro jeito. Não são alternativas — são falhas diferentes —, e a resolução preserva a decisão dele:

- `formasRes.error` — **transporte** falhou ⇒ **throw** (#1605, mantido verbatim)
- `degraded === true` — transporte OK, o **Omie** é que degradou ⇒ a tela **abre e avisa** (este PR)

**E o teste do #1605 revelou um buraco que o toast sozinho deixava.** Escrevi um assert para cobrir a metade dele (ela mergeou sem teste) afirmando que o pedido não carregava — e ele **falhou**. O `setOrder` roda ~50 linhas ANTES do `throw`: a tela abre de qualquer jeito, o throw só pula o resto do load. O toast "Erro ao carregar pedido" aparece e **some em segundos**; o que fica é uma tela sem card de condição de pagamento e sem explicação — a mesma omissão que o #1605 atacou, agora silenciosa. Corrigido gravando o estado de erro **antes** de lançar, então o aviso persiste depois que o toast passa. O `throw` e o toast seguem intactos.

Vale registrar por que o assert falhou: eu tinha escrito no comentário do código *"fail-closed: o pedido não abre"* sem verificar a ordem das linhas. O teste é que estava certo em ficar vermelho — casar o assert com o comportamento observado teria canonizado a omissão.

## Gates

| gate | resultado |
|---|---|
| `heavy bun run test` | `exit=0` — **635/635 arquivos · 5796/5796 testes · 0 vermelhos** |
| `heavy bun run typecheck` | `exit=0` |
| `bun lint` | `exit=0` — 0 errors (72 warnings, todos pré-existentes) |
| `manifesto.gate` | verde — os 5 arquivos novos caem em globs já existentes do módulo `vendas` |
| testes novos | **37** (18 helper puro · 10 UI do carrinho · 9 edição) |

**Falsificação — 7 sabotagens, todas com vermelho dirigido.** Denominador fixado em cada rodada (28 e 8) porque em suíte JS o tell de "não rodou nada" é o total, não o exit code; cada sabotagem prova que aplicou (`grep`) antes de rodar; backup por cópia + `trap EXIT` (nunca `git checkout --`, que destrói fix uncommitted); sabotagem sempre no **valor de um predicado**, nunca na leitura de um símbolo.

| # | sabotagem | vermelhos |
|---|---|---|
| S1 | `lerRespostaFormas` nunca declara degradação | 3/28 — os asserts de `degraded`/`source`/motivo |
| S2 | `condicoesDoClienteIndisponiveis` ignora o gate `degradado` | 1/28 — exatamente o assert do falso positivo |
| S3 | bloqueio ignora se a conta tem itens | 1/28 — "conta SEM item não bloqueia" |
| S4 | botão Enviar deixa de olhar o bloqueio | 2/28 — os dois testes de bloqueio |
| S5 | `parcelaTravada` nunca trava | 2/8 — trava do seletor + bloqueio do save |
| S6 | guard do save inverte `!==` → `===` | 2/8 — bloqueia o certo e libera o errado |
| S7 | remove o `setFormasErro` antes do throw | 1/9 — o aviso persistente do erro de transporte |

Árvore conferida limpa depois (sem `.bak-falsif`, sem marcador de sabotagem, os 6 predicados íntegros).

## Deploy

Só `src/` → **Publish** do frontend no editor do Lovable. Sem migration, sem edge nova — **mas** ver o aviso acima: o efeito depende da `omie-vendas-sync` do #1597 já estar deployada.
