### PR TITLE
fix(intelligence): o botão de recalcular scores era INALCANÇÁVEL — o tipo negava o papel que existe

### DIFF
--- a/src/hooks/__tests__/useCommercialRole.test.tsx
+++ b/src/hooks/__tests__/useCommercialRole.test.tsx
@@ -131,6 +131,44 @@ describe('useCommercialRole — contrato v2 (matriz aplicada): capability conced
     expect(result.current.canViewStrategic).toBe(false);
   });
 
+  // ── Os papéis que EXISTEM em produção ────────────────────────────────────────────────────────
+  // Distribuição real medida por psql-ro em 2026-07-29: farmer=2, master=1, super_admin=ZERO. Os
+  // testes acima cobrem só os quatro valores que o TIPO conhecia — nenhum deles atribuído a ninguém.
+  // O tipo negava 'master'/'farmer', e o `as CommercialRole` do fetch escondia a divergência, então
+  // esta suíte inteira provava um mundo que não existe. Estes dois fixam o mundo real.
+  it('master (o papel do dono do sistema) atravessa o cast e chega intacto', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'master' }, error: null });
+    const { result } = renderHook(() => useCommercialRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.commercialRole).toBe('master');
+    expect(result.current.isSuperAdmin).toBe(false); // 'master' ≠ 'super_admin' — papéis distintos
+  });
+
+  it('farmer idem (2 usuários em prod)', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'farmer' }, error: null });
+    const { result } = renderHook(() => useCommercialRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.commercialRole).toBe('farmer');
+    expect(result.current.isSuperAdmin).toBe(false);
+  });
+
+  // ⚠️ DOCUMENTA UM ACHADO, NÃO O CORRIGE. Nenhum dos papéis realmente atribuídos concede as
+  // capabilities: os predicados comparam contra operacional/gerencial/estrategico/super_admin, e
+  // ninguém tem nenhum deles. Na prática canViewManagerial/Strategic são false para 100% da base.
+  // Não é regressão desta mudança — é o estado que ela tornou VISÍVEL, e mexer nisso é decisão de
+  // autorização com superfície própria (governa também 5 telas de Governança). O assert existe para
+  // que uma correção futura falhe aqui de propósito, em vez de mudar autorização em silêncio.
+  it('ACHADO: nenhum papel real de prod concede capability (master inclusive)', async () => {
+    maybeSingleMock.mockResolvedValue({ data: { commercial_role: 'master' }, error: null });
+    const { result } = renderHook(() => useCommercialRole(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.canViewManagerial).toBe(false);
+    expect(result.current.canViewStrategic).toBe(false);
+  });
+
   it('erro na consulta do PAPEL → fail-closed mesmo com o contrato em v2', async () => {
     maybeSingleMock.mockResolvedValue({ data: null, error: { message: 'boom' } });
     const { result } = renderHook(() => useCommercialRole(), { wrapper });

--- a/src/hooks/useCommercialRole.ts
+++ b/src/hooks/useCommercialRole.ts
@@ -3,7 +3,28 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuthzContract } from '@/hooks/useAuthzContract';
 
-export type CommercialRole = 'operacional' | 'gerencial' | 'estrategico' | 'super_admin';
+/**
+ * Espelha o enum `commercial_role` do banco — os OITO valores, não quatro.
+ *
+ * Estava incompleto (só operacional/gerencial/estrategico/super_admin) enquanto o enum em prod tem
+ * também farmer/hunter/closer/master, e o `as CommercialRole` do fetch abaixo ESCONDIA a
+ * divergência: o cast afirmava um dos quatro para um valor que em runtime podia ser 'master'.
+ *
+ * Não era teórico — é a distribuição REAL de prod (medida 2026-07-29): farmer=2, master=1, e
+ * `super_admin` com ZERO linhas. Ou seja, os três únicos usuários com papel comercial tinham um
+ * valor que o tipo negava existir, e todo predicado deste arquivo lia `false` para eles.
+ *
+ * `useMyCommercialRole.ts` já listava os oito; os dois tipos agora concordam entre si e com o banco.
+ */
+export type CommercialRole =
+  | 'operacional'
+  | 'gerencial'
+  | 'estrategico'
+  | 'super_admin'
+  | 'farmer'
+  | 'hunter'
+  | 'closer'
+  | 'master';
 
 /**
  * 🔐 Contrato de autorização gerencial (E1 #1424 → E2/FU4 — spec de 2026-07-18).

--- a/src/pages/IntelligenceDashboard.tsx
+++ b/src/pages/IntelligenceDashboard.tsx
@@ -23,6 +23,20 @@ export default function IntelligenceDashboard() {
   const effectiveFarmerId = simulatingAs || ((!canViewManagerial && !isAdmin) ? user?.id : undefined);
   const defaultTab = canViewStrategic ? 'strategic' : canViewManagerial ? 'managerial' : 'operational';
 
+  // Quem enxerga o botão de recompute. Gatear só por `isSuperAdmin` tornava o botão INALCANÇÁVEL:
+  // `commercial_roles` em prod tem farmer=2 e master=1, e NINGUÉM tem 'super_admin' (medido
+  // 2026-07-29). O valor existe no enum, mas nunca foi atribuído — então o botão nunca renderizou
+  // para pessoa alguma, e nem o próprio dono do sistema conseguia disparar o recálculo pela UI.
+  //
+  // Isto NÃO amplia privilégio: a fronteira REAL é a edge, e `authorizeCronOrStaff` já aceita JWT
+  // com role admin/employee/manager/master. O gate da UI segue MAIS restritivo que ela — quem clica
+  // aqui já podia chamar a função por outra via. Guard na fronteira que toda via cruza, não na UI.
+  //
+  // Escopo deliberadamente limitado a ESTE botão: `isSuperAdmin` também governa 5 telas de
+  // Governança (usuários, permissões, auditoria, parâmetros, settings), e mudar quem as vê é
+  // decisão de autorização com superfície própria — fora do que este ajuste se propõe.
+  const podeRecalcularScores = isSuperAdmin || commercialRole === 'master';
+
   const [runningScores, setRunningScores] = useState(false);
   const runScoreCalc = async () => {
     setRunningScores(true);
@@ -62,7 +76,7 @@ export default function IntelligenceDashboard() {
           <p className="text-sm text-muted-foreground">Análise de performance, carteira e métricas estratégicas</p>
         </div>
         <div className="flex items-center gap-2 flex-wrap">
-          {isSuperAdmin && (
+          {podeRecalcularScores && (
             <Button size="sm" variant="outline" onClick={runScoreCalc} disabled={runningScores} className="h-7 text-xs">
               <RefreshCw className={`w-3 h-3 mr-1 ${runningScores ? 'animate-spin' : ''}`} />
               Recalcular Scores


### PR DESCRIPTION
## O sintoma

O founder — dono do sistema — abriu `/intelligence` e o botão **"Recalcular Scores" não estava lá**. Suspeita inicial: deploy do frontend pendente. Era outra coisa.

## A causa

O gate exige `isSuperAdmin`, e a distribuição **real** de `commercial_roles` em produção (psql-ro, 2026-07-29):

| `commercial_role` | usuários |
|---|---|
| `farmer` | 2 |
| `master` | 1 ← o founder |
| `super_admin` | **0** |

O valor existe no enum e **nunca foi atribuído a ninguém**. O botão nunca renderizou para pessoa alguma.

## A raiz — que só apareceu quando o typecheck reclamou

Trocar o gate deu erro:

```
error TS2367: This comparison appears to be unintentional because the types
'CommercialRole | null' and '"master"' have no overlap.
```

O tipo listava **quatro** valores contra **oito** no enum do banco:

```ts
// antes
export type CommercialRole = 'operacional' | 'gerencial' | 'estrategico' | 'super_admin';
// banco: + farmer, hunter, closer, master
```

E o fetch fazia `data?.commercial_role as CommercialRole` — um cast que **afirmava** um dos quatro para um valor que em runtime era `'master'` ou `'farmer'`. Os três únicos usuários com papel comercial tinham um valor que o tipo negava existir, e o cast escondia isso. `useMyCommercialRole.ts` já listava os oito; agora os dois tipos concordam entre si e com o banco.

## Isto NÃO amplia privilégio

A fronteira real é a **edge**, e `authorizeCronOrStaff` já aceita JWT com role `admin/employee/manager/master`. O gate da UI continua **mais restritivo** que ela — quem clica aqui já podia chamar a função por outra via. É guard na fronteira que toda via cruza, com a UI como defesa em profundidade.

## Escopo

Deliberadamente limitado a **este botão**. `isSuperAdmin` também governa 5 telas de Governança (usuários, permissões, auditoria, parâmetros matemáticos, settings) — mudar quem as vê é decisão de autorização com superfície própria, fora do que este ajuste se propõe.

## ⚠️ Achado que documento mas NÃO corrijo

**Nenhum papel realmente atribuído concede capability.** Os predicados comparam contra `operacional/gerencial/estrategico/super_admin`, e ninguém tem nenhum deles — logo `canViewManagerial` e `canViewStrategic` são `false` para **100% da base**, inclusive o dono.

Não é regressão desta mudança: é o estado que ela tornou visível. Há um assert fixando o comportamento atual, para que uma correção futura **falhe de propósito** ali em vez de mudar autorização em silêncio.

## Provas

3 testes novos (13 no arquivo), cobrindo os papéis que existem de verdade. Falsificados:

| Sabotagem | Resultado |
|---|---|
| cast volta a coagir papel real → `null` | 🔴 2 failed (pegou) |
| `isSuperAdmin` passa a aceitar `master` | 🔴 2 failed (pegou) |

`typecheck` ✅ · `lint` ✅ 0 errors · `test` ✅ 5758/5758.

## Deploy

Só frontend — **Publish** no editor do Lovable. Sem migration, sem edge.
