### PR TITLE
feat(reposição): fila de desova — aba Excesso de estoque no painel de baixo giro [money-path]

### DIFF
--- a/src/components/reposicao/baixoGiro/ExcessoKpis.tsx
+++ b/src/components/reposicao/baixoGiro/ExcessoKpis.tsx
@@ -1,0 +1,25 @@
+import { fmtBRL } from "@/lib/reposicao/sku-param";
+import type { KpisExcesso } from "@/lib/reposicao/excesso-helpers";
+
+export function ExcessoKpis({ capitalExcedenteRs, capitalEstruturalRs, skusN, estruturaisN, semCustoN }: KpisExcesso) {
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      <div className="rounded-md border p-4">
+        <div className="text-xs text-muted-foreground">Capital acima do máximo</div>
+        <div className="kpi-value text-2xl font-semibold tnum">{fmtBRL(capitalExcedenteRs)}</div>
+        {semCustoN > 0 && (
+          <div className="text-xs text-status-warning">+ {semCustoN} SKU(s) sem custo conhecido</div>
+        )}
+      </div>
+      <div className="rounded-md border p-4">
+        <div className="text-xs text-muted-foreground">Parcela estrutural (giro não digere em 180d)</div>
+        <div className="kpi-value text-2xl font-semibold tnum">{fmtBRL(capitalEstruturalRs)}</div>
+        <div className="text-xs text-muted-foreground">{estruturaisN} SKU(s)</div>
+      </div>
+      <div className="rounded-md border p-4">
+        <div className="text-xs text-muted-foreground">SKUs em excesso</div>
+        <div className="kpi-value text-2xl font-semibold tnum">{skusN}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reposicao/baixoGiro/ExcessoTable.tsx
+++ b/src/components/reposicao/baixoGiro/ExcessoTable.tsx
@@ -1,0 +1,79 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { fmtBRL } from "@/lib/reposicao/sku-param";
+import type { SituacaoExcesso } from "@/lib/reposicao/excesso-helpers";
+import type { RowExcesso } from "./types";
+
+const SITUACAO_LABEL: Record<SituacaoExcesso, { label: string; cls: string }> = {
+  digerivel: { label: "Venda digere", cls: "text-status-success" },
+  estrutural: { label: "Estrutural", cls: "text-status-warning" },
+  sem_giro: { label: "Sem giro", cls: "text-status-error" },
+};
+
+export function ExcessoTable({ rows, onDescontinuar }: {
+  rows: RowExcesso[];
+  onDescontinuar: (r: RowExcesso) => void;
+}) {
+  if (rows.length === 0) {
+    return <div className="rounded-md border p-6 text-sm text-muted-foreground">Nenhum SKU com estoque acima do máximo da política.</div>;
+  }
+  return (
+    <div className="overflow-x-auto rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>SKU</TableHead>
+            <TableHead className="text-center">Classe</TableHead>
+            <TableHead className="text-right">Saldo / Máx</TableHead>
+            <TableHead className="text-right">Excedente</TableHead>
+            <TableHead className="text-right">Capital excedente</TableHead>
+            <TableHead className="text-right">Digere em</TableHead>
+            <TableHead className="text-right">Últ. venda</TableHead>
+            <TableHead className="text-center">Situação</TableHead>
+            <TableHead className="text-right">Ação</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((r) => {
+            const sit = SITUACAO_LABEL[r.situacao_excesso];
+            const reposicaoDesligada = r.habilitado_reposicao_automatica === false || r.tipo_reposicao === "descontinuado";
+            return (
+              <TableRow key={r.id}>
+                <TableCell>
+                  <div className="font-medium">{r.sku_descricao ?? r.sku_codigo_omie}</div>
+                  <div className="font-mono text-xs text-muted-foreground">{r.sku_codigo_omie}{r.fornecedor_nome ? ` · ${r.fornecedor_nome}` : ""}</div>
+                </TableCell>
+                <TableCell className="text-center"><Badge variant="outline">{r.classe_consolidada ?? "—"}</Badge></TableCell>
+                <TableCell className="text-right tnum">{r.saldo ?? "—"} / {r.estoque_maximo ?? "—"}</TableCell>
+                <TableCell className="text-right tnum font-medium">{r.excedente_un}</TableCell>
+                <TableCell className="text-right tnum font-medium">
+                  {r.capital_excedente != null ? fmtBRL(r.capital_excedente) : <span className="text-status-warning">sem custo</span>}
+                </TableCell>
+                <TableCell className="text-right tnum">
+                  {r.tempo_digerir_dias != null ? `${r.tempo_digerir_dias}d` : "—"}
+                </TableCell>
+                <TableCell className="text-right tnum">
+                  {r.dias_sem_vender != null ? `há ${r.dias_sem_vender}d` : "nunca"}
+                </TableCell>
+                <TableCell className="text-center">
+                  <span className={`text-xs font-medium ${sit.cls}`}>{sit.label}</span>
+                  {reposicaoDesligada && (
+                    <div className="text-xs text-muted-foreground">reposição off</div>
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  {!reposicaoDesligada && (
+                    <Button variant="outline" size="sm" onClick={() => onDescontinuar(r)}>
+                      Descontinuar
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/components/reposicao/baixoGiro/types.ts
+++ b/src/components/reposicao/baixoGiro/types.ts
@@ -1,4 +1,5 @@
 import type { SituacaoTipo, SituacaoCta } from "@/lib/reposicao/baixo-giro-helpers";
+import type { SituacaoExcesso } from "@/lib/reposicao/excesso-helpers";
 
 export interface RowBaixoGiro {
   id: string;                       // `${sku_codigo_omie}`
@@ -27,4 +28,25 @@ export interface FiltrosBaixoGiro {
   situacao: SituacaoTipo | "todos";
   estoque: "todos" | "com_estoque" | "sem_estoque";
   busca: string;
+}
+
+/** Fila de desova — SKU com saldo acima do estoque_maximo da política. */
+export interface RowExcesso {
+  id: string;                          // `${sku_codigo_omie}`
+  sku_codigo_omie: number;
+  sku_descricao: string | null;
+  fornecedor_nome: string | null;
+  classe_consolidada: string | null;
+  saldo: number | null;                // inventory_position (linha mais recente entre accounts)
+  cmc: number | null;
+  ponto_pedido: number | null;
+  estoque_maximo: number | null;
+  excedente_un: number;                // saldo − estoque_maximo (> 0 por construção)
+  capital_excedente: number | null;    // excedente×cmc (null se cmc ausente — nunca R$0)
+  tempo_digerir_dias: number | null;   // ceil(excedente/demanda_media_diaria); null = sem giro
+  situacao_excesso: SituacaoExcesso;
+  demanda_media_diaria: number | null;
+  dias_sem_vender: number | null;
+  habilitado_reposicao_automatica: boolean | null;
+  tipo_reposicao: string | null;
 }

--- a/src/components/reposicao/baixoGiro/useBaixoGiro.ts
+++ b/src/components/reposicao/baixoGiro/useBaixoGiro.ts
@@ -104,6 +104,7 @@ export function useBaixoGiro() {
     onSuccess: () => {
       toast.success("SKU descontinuado — fora dos próximos ciclos");
       qc.invalidateQueries({ queryKey: ["reposicao-baixo-giro"] });
+      qc.invalidateQueries({ queryKey: ["reposicao-excesso-estoque"] });
       qc.invalidateQueries({ queryKey: ["pedidos-ciclo"] });
     },
     onError: (e: Error) => toast.error("Falha ao descontinuar: " + e.message),

--- a/src/components/reposicao/baixoGiro/useExcessoEstoque.ts
+++ b/src/components/reposicao/baixoGiro/useExcessoEstoque.ts
@@ -1,0 +1,138 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
+import { fetchAllPages } from "@/lib/postgrest";
+import { diasSemVender } from "@/lib/reposicao/baixo-giro-helpers";
+import {
+  accountsDaEmpresa,
+  calcularLinhaExcesso,
+  dedupePosicaoMaisRecente,
+  ordenarPorCapitalExcedente,
+  somarKpisExcesso,
+  type PosicaoEstoque,
+  type SituacaoExcesso,
+} from "@/lib/reposicao/excesso-helpers";
+import type { RowExcesso } from "./types";
+
+const HOJE_ISO = () => new Date().toISOString().slice(0, 10);
+
+interface ParamRow {
+  sku_codigo_omie: number;
+  sku_descricao: string | null;
+  fornecedor_nome: string | null;
+  classe_consolidada: string | null;
+  demanda_media_diaria: number | null;
+  ponto_pedido: number | null;
+  estoque_maximo: number | null;
+  habilitado_reposicao_automatica: boolean | null;
+  tipo_reposicao: string | null;
+}
+
+/**
+ * Fila de desova — SKUs com estoque ACIMA do `estoque_maximo` da política.
+ * Universo: TODO sku_parametros ativo com máximo definido (inclusive reposição desabilitada —
+ * capital em excesso é capital, esteja o SKU comprável ou não). Saldo pelo padrão canônico do
+ * motor: accounts da empresa, linha mais recente por SKU.
+ */
+export function useExcessoEstoque() {
+  const { empresa } = useReposicaoEmpresa();
+
+  const query = useQuery({
+    queryKey: ["reposicao-excesso-estoque", empresa],
+    staleTime: 60_000,
+    queryFn: async (): Promise<RowExcesso[]> => {
+      const params = await fetchAllPages<ParamRow>(
+        (de, ate) =>
+          supabase
+            .from("sku_parametros")
+            .select("sku_codigo_omie, sku_descricao, fornecedor_nome, classe_consolidada, demanda_media_diaria, ponto_pedido, estoque_maximo, habilitado_reposicao_automatica, tipo_reposicao")
+            .eq("empresa", empresa)
+            .eq("ativo", true)
+            .not("estoque_maximo", "is", null)
+            .order("sku_codigo_omie", { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: ParamRow[] | null; error: unknown }>,
+        "sku_parametros/excesso",
+      );
+      const codes = params.map((r) => Number(r.sku_codigo_omie));
+      if (codes.length === 0) return [];
+
+      const [posicoes, demandas] = await Promise.all([
+        fetchAllPages<PosicaoEstoque>(
+          (de, ate) =>
+            supabase
+              .from("inventory_position")
+              .select("omie_codigo_produto, saldo, cmc, synced_at")
+              .in("account", accountsDaEmpresa(empresa))
+              .in("omie_codigo_produto", codes)
+              .order("id", { ascending: true })
+              .range(de, ate) as unknown as PromiseLike<{ data: PosicaoEstoque[] | null; error: unknown }>,
+          "inventory_position/excesso",
+        ),
+        fetchAllPages<{ sku_codigo_omie: number; ultima_venda_data: string | null }>(
+          (de, ate) =>
+            supabase
+              .from("v_sku_demanda_estatisticas")
+              .select("sku_codigo_omie, ultima_venda_data")
+              .eq("empresa", empresa)
+              .in("sku_codigo_omie", codes)
+              .order("sku_codigo_omie", { ascending: true })
+              .range(de, ate) as unknown as PromiseLike<{ data: { sku_codigo_omie: number; ultima_venda_data: string | null }[] | null; error: unknown }>,
+          "v_sku_demanda_estatisticas/excesso",
+        ),
+      ]);
+
+      const posMap = dedupePosicaoMaisRecente(
+        posicoes.map((p) => ({ ...p, omie_codigo_produto: Number(p.omie_codigo_produto) })),
+      );
+      const demMap = new Map(demandas.map((d) => [Number(d.sku_codigo_omie), d.ultima_venda_data]));
+      const hoje = HOJE_ISO();
+
+      const rows: RowExcesso[] = [];
+      for (const p of params) {
+        const code = Number(p.sku_codigo_omie);
+        const pos = posMap.get(code);
+        const linha = calcularLinhaExcesso({
+          saldo: pos?.saldo ?? null,
+          estoqueMaximo: p.estoque_maximo,
+          demandaMediaDiaria: p.demanda_media_diaria,
+          cmc: pos?.cmc ?? null,
+        });
+        if (!linha) continue;
+        rows.push({
+          id: String(code),
+          sku_codigo_omie: code,
+          sku_descricao: p.sku_descricao,
+          fornecedor_nome: p.fornecedor_nome,
+          classe_consolidada: p.classe_consolidada,
+          saldo: pos?.saldo ?? null,
+          cmc: pos?.cmc ?? null,
+          ponto_pedido: p.ponto_pedido,
+          estoque_maximo: p.estoque_maximo,
+          excedente_un: linha.excedenteUn,
+          capital_excedente: linha.capitalExcedente,
+          tempo_digerir_dias: linha.tempoDigerirDias,
+          situacao_excesso: linha.situacao,
+          demanda_media_diaria: p.demanda_media_diaria,
+          dias_sem_vender: diasSemVender(demMap.get(code) ?? null, hoje),
+          habilitado_reposicao_automatica: p.habilitado_reposicao_automatica,
+          tipo_reposicao: p.tipo_reposicao,
+        });
+      }
+      return ordenarPorCapitalExcedente(rows, (r) => r.capital_excedente);
+    },
+  });
+
+  const kpis = useMemo(
+    () =>
+      somarKpisExcesso(
+        (query.data ?? []).map((r) => ({
+          capitalExcedente: r.capital_excedente,
+          situacao: r.situacao_excesso as SituacaoExcesso,
+        })),
+      ),
+    [query.data],
+  );
+
+  return { rows: query.data ?? [], kpis, isLoading: query.isLoading, error: query.error, refetch: query.refetch };
+}

--- a/src/lib/reposicao/__tests__/excesso-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/excesso-helpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIMIAR_ESTRUTURAL_DIAS,
+  accountsDaEmpresa,
+  calcularLinhaExcesso,
+  dedupePosicaoMaisRecente,
+  ordenarPorCapitalExcedente,
+  somarKpisExcesso,
+} from "@/lib/reposicao/excesso-helpers";
+
+describe("accountsDaEmpresa", () => {
+  it("espelha o CASE canônico da RPC do motor", () => {
+    expect(accountsDaEmpresa("OBEN")).toEqual(["vendas", "oben"]);
+    expect(accountsDaEmpresa("COLACOR")).toEqual(["colacor_vendas", "colacor"]);
+    expect(accountsDaEmpresa("COLACOR_SC")).toEqual(["servicos", "colacor_sc"]);
+    expect(accountsDaEmpresa("OUTRA")).toEqual(["outra"]);
+  });
+});
+
+describe("dedupePosicaoMaisRecente", () => {
+  it("fica com a linha mais recente entre accounts", () => {
+    const m = dedupePosicaoMaisRecente([
+      { omie_codigo_produto: 1, saldo: 10, cmc: 5, synced_at: "2026-07-01T00:00:00Z" },
+      { omie_codigo_produto: 1, saldo: 14, cmc: 5, synced_at: "2026-07-20T00:00:00Z" },
+    ]);
+    expect(m.get(1)?.saldo).toBe(14);
+  });
+  it("linha com synced_at null perde para linha datada, mas existe sozinha", () => {
+    const m = dedupePosicaoMaisRecente([
+      { omie_codigo_produto: 1, saldo: 3, cmc: 2, synced_at: null },
+      { omie_codigo_produto: 1, saldo: 7, cmc: 2, synced_at: "2026-07-20T00:00:00Z" },
+      { omie_codigo_produto: 2, saldo: 4, cmc: 1, synced_at: null },
+    ]);
+    expect(m.get(1)?.saldo).toBe(7);
+    expect(m.get(2)?.saldo).toBe(4);
+  });
+});
+
+describe("calcularLinhaExcesso", () => {
+  it("sem excesso (saldo <= máximo) → null", () => {
+    expect(calcularLinhaExcesso({ saldo: 2, estoqueMaximo: 2, demandaMediaDiaria: 1, cmc: 10 })).toBeNull();
+    expect(calcularLinhaExcesso({ saldo: 1, estoqueMaximo: 2, demandaMediaDiaria: 1, cmc: 10 })).toBeNull();
+  });
+  it("dados ausentes não afirmam excesso (saldo/max null → null)", () => {
+    expect(calcularLinhaExcesso({ saldo: null, estoqueMaximo: 2, demandaMediaDiaria: 1, cmc: 10 })).toBeNull();
+    expect(calcularLinhaExcesso({ saldo: 5, estoqueMaximo: null, demandaMediaDiaria: 1, cmc: 10 })).toBeNull();
+  });
+  it("excesso digerível: tempo = ceil(excedente/d)", () => {
+    const l = calcularLinhaExcesso({ saldo: 14, estoqueMaximo: 2, demandaMediaDiaria: 0.5, cmc: 100 });
+    expect(l).toMatchObject({ excedenteUn: 12, capitalExcedente: 1200, tempoDigerirDias: 24, situacao: "digerivel" });
+  });
+  it("excesso estrutural: acima do limiar", () => {
+    const l = calcularLinhaExcesso({ saldo: 14, estoqueMaximo: 2, demandaMediaDiaria: 0.05, cmc: 100 });
+    expect(l?.tempoDigerirDias).toBe(240);
+    expect(l?.tempoDigerirDias).toBeGreaterThan(LIMIAR_ESTRUTURAL_DIAS);
+    expect(l?.situacao).toBe("estrutural");
+  });
+  it("demanda zero/null = sem giro (nunca fabrica tempo)", () => {
+    expect(calcularLinhaExcesso({ saldo: 5, estoqueMaximo: 2, demandaMediaDiaria: 0, cmc: 10 })?.situacao).toBe("sem_giro");
+    expect(calcularLinhaExcesso({ saldo: 5, estoqueMaximo: 2, demandaMediaDiaria: null, cmc: 10 })?.tempoDigerirDias).toBeNull();
+  });
+  it("cmc ausente/zero: capital null, nunca R$0 fabricado", () => {
+    expect(calcularLinhaExcesso({ saldo: 5, estoqueMaximo: 2, demandaMediaDiaria: 1, cmc: null })?.capitalExcedente).toBeNull();
+    expect(calcularLinhaExcesso({ saldo: 5, estoqueMaximo: 2, demandaMediaDiaria: 1, cmc: 0 })?.capitalExcedente).toBeNull();
+  });
+});
+
+describe("somarKpisExcesso", () => {
+  it("separa estrutural (inclui sem_giro) e conta sem-custo fora do total", () => {
+    const k = somarKpisExcesso([
+      { capitalExcedente: 100, situacao: "digerivel" },
+      { capitalExcedente: 200, situacao: "estrutural" },
+      { capitalExcedente: 50, situacao: "sem_giro" },
+      { capitalExcedente: null, situacao: "estrutural" },
+    ]);
+    expect(k).toEqual({ capitalExcedenteRs: 350, capitalEstruturalRs: 250, skusN: 4, estruturaisN: 3, semCustoN: 1 });
+  });
+});
+
+describe("ordenarPorCapitalExcedente", () => {
+  it("desc, sem-custo (null) por último, sem mutar a entrada", () => {
+    const entrada = [
+      { capitalExcedente: null }, { capitalExcedente: 10 }, { capitalExcedente: 300 },
+    ];
+    const saida = ordenarPorCapitalExcedente(entrada, (l) => l.capitalExcedente);
+    expect(saida.map((s) => s.capitalExcedente)).toEqual([300, 10, null]);
+    expect(entrada[0].capitalExcedente).toBeNull();
+  });
+});

--- a/src/lib/reposicao/excesso-helpers.ts
+++ b/src/lib/reposicao/excesso-helpers.ts
@@ -1,0 +1,114 @@
+/**
+ * Fila de desova — excesso de estoque acima do `estoque_maximo` da política.
+ *
+ * O motor de reposição só COMPRA (dispara em estoque<=ponto e enche até o máximo); nada no app
+ * media o caminho inverso — estoque ACIMA do próprio máximo. Medido em prod (2026-07-28, OBEN):
+ * R$69,8k de capital excedente, dos quais ~R$24,5k a venda de 180d não digere. Este módulo é a
+ * LEITURA dessa fila: helpers puros (vitest) consumidos por useExcessoEstoque.
+ *
+ * Regras money-path: cmc ausente ≠ zero (capital vira null + contagem separada, nunca R$0);
+ * demanda <=0 não fabrica tempo de digestão (null = "sem giro", que é o caso MAIS estrutural).
+ */
+
+/** Acima deste tempo-para-digerir (dias corridos, pela demanda média 90d) o excesso é estrutural. */
+export const LIMIAR_ESTRUTURAL_DIAS = 180;
+
+/** Mapa canônico empresa→accounts do Omie (mesmo CASE da RPC gerar_pedidos_sugeridos_ciclo). */
+export function accountsDaEmpresa(empresa: string): string[] {
+  switch (empresa.toLowerCase()) {
+    case "oben": return ["vendas", "oben"];
+    case "colacor": return ["colacor_vendas", "colacor"];
+    case "colacor_sc": return ["servicos", "colacor_sc"];
+    default: return [empresa.toLowerCase()];
+  }
+}
+
+export interface PosicaoEstoque {
+  omie_codigo_produto: number;
+  saldo: number | null;
+  cmc: number | null;
+  synced_at: string | null;
+}
+
+/**
+ * 1 linha por SKU: a mais recente entre as accounts (o saldo OBEN vive em 'vendas' E 'oben',
+ * quase-espelhos que podem divergir por SKU — mesmo DISTINCT ON ... synced_at DESC do motor).
+ */
+export function dedupePosicaoMaisRecente(rows: PosicaoEstoque[]): Map<number, PosicaoEstoque> {
+  const porSku = new Map<number, PosicaoEstoque>();
+  for (const r of rows) {
+    const atual = porSku.get(r.omie_codigo_produto);
+    if (!atual) { porSku.set(r.omie_codigo_produto, r); continue; }
+    const tNovo = r.synced_at ? Date.parse(r.synced_at) : Number.NEGATIVE_INFINITY;
+    const tAtual = atual.synced_at ? Date.parse(atual.synced_at) : Number.NEGATIVE_INFINITY;
+    if (tNovo > tAtual) porSku.set(r.omie_codigo_produto, r);
+  }
+  return porSku;
+}
+
+export type SituacaoExcesso = "digerivel" | "estrutural" | "sem_giro";
+
+export interface LinhaExcesso {
+  excedenteUn: number;
+  /** null = cmc ausente/zero (nunca fabrica R$0). */
+  capitalExcedente: number | null;
+  /** Dias corridos p/ a demanda média consumir o excedente; null = demanda <=0 (sem giro). */
+  tempoDigerirDias: number | null;
+  situacao: SituacaoExcesso;
+}
+
+/**
+ * Excedente acima do máximo da política e o tempo que a demanda média leva para digeri-lo.
+ * Devolve null quando NÃO há excesso (saldo <= máximo, ou dados insuficientes p/ afirmar excesso).
+ */
+export function calcularLinhaExcesso(args: {
+  saldo: number | null;
+  estoqueMaximo: number | null;
+  demandaMediaDiaria: number | null;
+  cmc: number | null;
+}): LinhaExcesso | null {
+  const { saldo, estoqueMaximo, demandaMediaDiaria, cmc } = args;
+  if (saldo == null || estoqueMaximo == null) return null;
+  if (!(Number.isFinite(saldo) && Number.isFinite(estoqueMaximo))) return null;
+  const excedenteUn = saldo - estoqueMaximo;
+  if (excedenteUn <= 0) return null;
+
+  const capitalExcedente = cmc != null && cmc > 0 ? excedenteUn * cmc : null;
+
+  const d = demandaMediaDiaria;
+  const tempoDigerirDias = d != null && d > 0 ? Math.ceil(excedenteUn / d) : null;
+  const situacao: SituacaoExcesso =
+    tempoDigerirDias == null ? "sem_giro"
+    : tempoDigerirDias > LIMIAR_ESTRUTURAL_DIAS ? "estrutural"
+    : "digerivel";
+
+  return { excedenteUn, capitalExcedente, tempoDigerirDias, situacao };
+}
+
+export interface KpisExcesso {
+  capitalExcedenteRs: number;
+  /** Parcela estrutural: sem giro OU tempo de digestão acima do limiar. */
+  capitalEstruturalRs: number;
+  skusN: number;
+  estruturaisN: number;
+  semCustoN: number;
+}
+
+export function somarKpisExcesso(
+  linhas: Array<Pick<LinhaExcesso, "capitalExcedente" | "situacao">>,
+): KpisExcesso {
+  let capitalExcedenteRs = 0, capitalEstruturalRs = 0, estruturaisN = 0, semCustoN = 0;
+  for (const l of linhas) {
+    const estrutural = l.situacao !== "digerivel";
+    if (estrutural) estruturaisN++;
+    if (l.capitalExcedente == null) { semCustoN++; continue; }
+    capitalExcedenteRs += l.capitalExcedente;
+    if (estrutural) capitalEstruturalRs += l.capitalExcedente;
+  }
+  return { capitalExcedenteRs, capitalEstruturalRs, skusN: linhas.length, estruturaisN, semCustoN };
+}
+
+/** Ordena a fila por capital excedente desc; sem-custo (null) por último. Não muta a entrada. */
+export function ordenarPorCapitalExcedente<T>(linhas: T[], capital: (l: T) => number | null): T[] {
+  return [...linhas].sort((a, b) => (capital(b) ?? -1) - (capital(a) ?? -1));
+}

--- a/src/pages/AdminReposicaoBaixoGiro.tsx
+++ b/src/pages/AdminReposicaoBaixoGiro.tsx
@@ -1,10 +1,14 @@
 import { useMemo, useState } from "react";
 import { useBaixoGiro } from "@/components/reposicao/baixoGiro/useBaixoGiro";
+import { useExcessoEstoque } from "@/components/reposicao/baixoGiro/useExcessoEstoque";
 import { BaixoGiroKpis } from "@/components/reposicao/baixoGiro/BaixoGiroKpis";
 import { BaixoGiroFiltros } from "@/components/reposicao/baixoGiro/BaixoGiroFiltros";
 import { BaixoGiroTable } from "@/components/reposicao/baixoGiro/BaixoGiroTable";
+import { ExcessoKpis } from "@/components/reposicao/baixoGiro/ExcessoKpis";
+import { ExcessoTable } from "@/components/reposicao/baixoGiro/ExcessoTable";
 import { ManterEmEstoqueDialog } from "@/components/reposicao/baixoGiro/ManterEmEstoqueDialog";
 import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -15,15 +19,46 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import type { FiltrosBaixoGiro, RowBaixoGiro } from "@/components/reposicao/baixoGiro/types";
+import type { FiltrosBaixoGiro, RowBaixoGiro, RowExcesso } from "@/components/reposicao/baixoGiro/types";
+import { track } from "@/lib/analytics";
 import { toast } from "sonner";
+
+/** Alvo comum dos dois fluxos de descontinuação (baixo giro e excesso). */
+type AlvoDescontinuar = Pick<RowBaixoGiro, "sku_codigo_omie" | "sku_descricao">;
+
+function exportarCsvExcesso(rows: RowExcesso[]) {
+  const head = ["sku", "descricao", "fornecedor", "classe", "saldo", "estoque_maximo", "excedente_un", "capital_excedente_rs", "digere_em_dias", "dias_sem_vender", "situacao"];
+  const linhas = rows.map((r) =>
+    [
+      r.sku_codigo_omie,
+      JSON.stringify(r.sku_descricao ?? ""),
+      JSON.stringify(r.fornecedor_nome ?? ""),
+      r.classe_consolidada ?? "",
+      r.saldo ?? "",
+      r.estoque_maximo ?? "",
+      r.excedente_un,
+      r.capital_excedente ?? "",
+      r.tempo_digerir_dias ?? "",
+      r.dias_sem_vender ?? "",
+      r.situacao_excesso,
+    ].join(","),
+  );
+  const blob = new Blob([head.join(",") + "\n" + linhas.join("\n")], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `excesso-estoque-${new Date().toISOString().slice(0, 10)}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
 
 export default function AdminReposicaoBaixoGiro() {
   const { rows, kpis, isLoading, manterEmEstoque, descontinuar } = useBaixoGiro();
+  const excesso = useExcessoEstoque();
   const [filtros, setFiltros] = useState<FiltrosBaixoGiro>({ situacao: "todos", estoque: "todos", busca: "" });
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [dialogAlvos, setDialogAlvos] = useState<RowBaixoGiro[] | null>(null);
-  const [descontinuarAlvo, setDescontinuarAlvo] = useState<RowBaixoGiro | null>(null);
+  const [descontinuarAlvo, setDescontinuarAlvo] = useState<AlvoDescontinuar | null>(null);
 
   const filtered = useMemo(() => {
     return rows.filter((r) => {
@@ -45,41 +80,89 @@ export default function AdminReposicaoBaixoGiro() {
       <header>
         <h1 className="font-display text-3xl">Baixo giro &amp; estoque parado</h1>
       </header>
-      <BaixoGiroKpis {...kpis} />
-      <BaixoGiroFiltros filtros={filtros} onChange={setFiltros} />
-      {selected.size > 0 && (
-        <Button
-          onClick={() =>
-            setDialogAlvos(filtered.filter((r) => selected.has(r.sku_codigo_omie)))
-          }
-        >
-          Manter em estoque — {selected.size} selecionado(s)
-        </Button>
-      )}
-      <BaixoGiroTable
-        rows={filtered}
-        selected={selected}
-        onToggle={(c) =>
-          setSelected((prev) => {
-            const n = new Set(prev);
-            if (n.has(c)) n.delete(c);
-            else n.add(c);
-            return n;
-          })
-        }
-        onToggleAll={(codes) =>
-          setSelected((prev) =>
-            prev.size === codes.length ? new Set() : new Set(codes)
-          )
-        }
-        onResolverBloqueio={(r) =>
-          toast.info(
-            `Resolver: ${r.situacao_label} — ${r.sku_descricao ?? r.sku_codigo_omie}`
-          )
-        }
-        onManter={(r) => setDialogAlvos([r])}
-        onDescontinuar={(r) => setDescontinuarAlvo(r)}
-      />
+      <Tabs
+        defaultValue="baixo-giro"
+        onValueChange={(v) => {
+          if (v === "excesso") track("reposicao.excesso_aba_aberta");
+        }}
+      >
+        <TabsList>
+          <TabsTrigger value="baixo-giro">Baixo giro</TabsTrigger>
+          <TabsTrigger value="excesso">Excesso de estoque{excesso.kpis.skusN > 0 ? ` (${excesso.kpis.skusN})` : ""}</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="baixo-giro" className="space-y-4">
+          <BaixoGiroKpis {...kpis} />
+          <BaixoGiroFiltros filtros={filtros} onChange={setFiltros} />
+          {selected.size > 0 && (
+            <Button
+              onClick={() =>
+                setDialogAlvos(filtered.filter((r) => selected.has(r.sku_codigo_omie)))
+              }
+            >
+              Manter em estoque — {selected.size} selecionado(s)
+            </Button>
+          )}
+          <BaixoGiroTable
+            rows={filtered}
+            selected={selected}
+            onToggle={(c) =>
+              setSelected((prev) => {
+                const n = new Set(prev);
+                if (n.has(c)) n.delete(c);
+                else n.add(c);
+                return n;
+              })
+            }
+            onToggleAll={(codes) =>
+              setSelected((prev) =>
+                prev.size === codes.length ? new Set() : new Set(codes)
+              )
+            }
+            onResolverBloqueio={(r) =>
+              toast.info(
+                `Resolver: ${r.situacao_label} — ${r.sku_descricao ?? r.sku_codigo_omie}`
+              )
+            }
+            onManter={(r) => setDialogAlvos([r])}
+            onDescontinuar={(r) => setDescontinuarAlvo(r)}
+          />
+          {isLoading && (
+            <div className="text-sm text-muted-foreground">Carregando…</div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="excesso" className="space-y-4">
+          <ExcessoKpis {...excesso.kpis} />
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-muted-foreground">
+              Estoque acima do máximo da política. Tempo de digestão pela demanda média (90d) — o motor não
+              compra estes SKUs enquanto estiverem acima do ponto; a saída é comercial (queima/kit) ou descontinuar.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={excesso.rows.length === 0}
+              onClick={() => {
+                exportarCsvExcesso(excesso.rows);
+                track("reposicao.excesso_export_csv", { skus: excesso.rows.length });
+              }}
+            >
+              Exportar CSV
+            </Button>
+          </div>
+          <ExcessoTable rows={excesso.rows} onDescontinuar={(r) => setDescontinuarAlvo(r)} />
+          {excesso.isLoading && (
+            <div className="text-sm text-muted-foreground">Carregando…</div>
+          )}
+          {excesso.error != null && (
+            <div className="text-sm text-status-error">
+              Não consegui ler a posição de estoque — a fila pode estar incompleta. Recarregue a página.
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
       <ManterEmEstoqueDialog
         open={!!dialogAlvos}
         onOpenChange={(v) => {
@@ -96,9 +179,6 @@ export default function AdminReposicaoBaixoGiro() {
           });
         }}
       />
-      {isLoading && (
-        <div className="text-sm text-muted-foreground">Carregando…</div>
-      )}
       <AlertDialog open={!!descontinuarAlvo} onOpenChange={(v) => { if (!v) setDescontinuarAlvo(null); }}>
         <AlertDialogContent>
           <AlertDialogHeader>


### PR DESCRIPTION
## O problema (medido em prod, OBEN, 2026-07-28)

O motor de reposição só **compra** (dispara em `estoque ≤ ponto` e enche até o máximo); nada no app media o caminho inverso. Resultado acumulado:

- **R$69.832 de capital ACIMA do próprio `estoque_maximo`** da política (114 SKUs — 47% do capital de estoque está em SKUs em excesso);
- **R$24.463 são estruturais**: a venda de 180 dias não digere (47 SKUs, quase tudo classe C);
- A tela de baixo giro olha classe+demanda — **nenhum lugar do app calcula `saldo > estoque_maximo`** (verificado por varredura).

## A entrega

Aba nova **“Excesso de estoque”** em `/admin/reposicao/baixo-giro`:

- **Universo:** `sku_parametros` ativo com máximo definido (inclusive reposição desabilitada — capital é capital) × `inventory_position` pelo **padrão canônico do motor** (accounts da empresa `['vendas','oben']`, linha mais recente por SKU via `synced_at`).
- **KPIs:** capital acima do máximo · parcela estrutural (giro não digere em 180d, inclui sem-giro) · nº de SKUs.
- **Tabela** ordenada por capital excedente: saldo/máx, excedente, tempo-para-digerir (pela demanda média 90d — a mesma do motor), última venda, situação; **export CSV** para ação comercial (queima/kit).
- **Ações:** reusa o fluxo **Descontinuar** existente (gate humano na escrita) com invalidação cruzada das queries.

## Money-path

- `cmc` ausente → capital `null` + contagem separada no KPI (**nunca R$0 fabricado**);
- demanda ≤0 → **“sem giro”** (nunca fabrica tempo de digestão) — e sem-giro conta como estrutural;
- leituras via `fetchAllPages` (`.order` estável + falha alta — sem leitura parcial silenciosa; `inventory_position` pode passar de 1.000 linhas com 2 accounts).

## Testes

Helpers puros com vitest (`excesso-helpers.test.ts`): dedupe entre accounts, linha de excesso (bordas: saldo/max null, cmc 0, demanda 0), KPIs, ordenação. Suíte completa verde: **5825 testes / 637 arquivos** · typecheck strict · lint 0 errors.

## Par

Metade “drenar o acumulado” do programa de ciclo financeiro. A metade “estancar o fluxo” (teto de cobertura B/C no motor) vem no PR seguinte — spec `docs/superpowers/specs/2026-07-29-reposicao-teto-cobertura-motor-spec.md`.

Pós-merge: só **Publish** do frontend (sem migration, sem edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)