### PR TITLE
feat(sync): canária paginacao_probe prova os guards de paginação DEPLOYADOS no omie-financeiro [money-path]

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -55,12 +55,32 @@ Nas canárias ainda **não-versionadas** (`contrato` = `—`) só há `canary` +
 | `omie-vendas-sync` | `identidade_probe` | — | identidade derivada por documento |
 | `omie-analytics-sync` | `doc_ambiguo_probe` | — | doc ambíguo não vira vínculo |
 | `carteira-rebuild` | `?canary=1` | `trava-saida-v1` | conflito permanece com `eligible=false` (velho: some) **+** trava de saída do bootstrap (velho: grava ~Hunter) |
+| `omie-financeiro` | `paginacao_probe` | `paginacao-guards-v1` | guards de paginação do #1598: piso NÃO encolhe (vazia antes do fim = anomalia; velho: `\|\| 1` → "fim"), reversa só completa com sonda vazia (velho: `pagina < 1` → complete), fingerprint sem colisão (velho: `1ºcódigo:count`), resposta sem array LANÇA (velho: `\|\| []` → "página vazia" = fim) |
 
 ⚠️ **Só é canária se a resposta tiver `"canary":true` E o `contrato` esperado.** Duas falhas distintas:
 1. Deploy ANTERIOR à canária ignora o param e roda o **fluxo real** — no `carteira-rebuild` isso é um rebuild completo (lease + upserts; idempotente e guardado, mas é escrita). Resposta sem `canary:true` = canária não rodou **e** o deploy é velho: já é o veredito.
 2. Deploy **integralmente velho** (com a canária de uma fatia anterior) carrega o `expected` VELHO junto e compara velho×velho → responde `canary:true, ok:true` e **mente verde** (Codex 2026-07-20). Por isso o **`contrato` (version marker) é obrigatório na verificação**: `ok` sozinho não discrimina reversão de fatia. Faça **bump do marcador** a cada fatia que mude o contrato da canária — senão a próxima reversão volta a passar despercebida.
 
-⚠️ **Canária que não discrimina é teatro verde.** Se a mudança for no-op nos dados de hoje (caso do #1397: 0 conflitos em prod), a resposta do fluxo REAL é byte-idêntica com código velho ou novo — não prova deploy nenhum. A fixture tem de exercitar **o comportamento que mudou**, e o teste tem de provar que sob o comportamento ANTIGO a canária ficaria vermelha (ver `rebuild-helpers.test.ts` → "a fixture DISCRIMINA"). Sem esse assert, a canária só prova que a função responde.
+⚠️ **Canária que não discrimina é teatro verde.** Se a mudança for no-op nos dados de hoje (caso do #1397: 0 conflitos em prod), a resposta do fluxo REAL é byte-idêntica com código velho ou novo — não prova deploy nenhum. A fixture tem de exercitar **o comportamento que mudou**, e o teste tem de provar que sob o comportamento ANTIGO a canária ficaria vermelha (ver `rebuild-helpers.test.ts` → "a fixture DISCRIMINA"; e `_shared/omie-paginacao_test.ts` → bloco "CONTROLE DE CALIBRAÇÃO", que roda a forma pré-#1598 sobre os fixtures homônimos da `paginacao_probe`). Sem esse assert, a canária só prova que a função responde.
+
+**Como o founder invoca uma probe sem terminal** (ele não tem acesso de shell ao backend): cole no **SQL Editor do Lovable** — o segredo sai do vault, nunca do chat — e leia a resposta em `net._http_response`. Mesmo mecanismo do cron, com `timeout_milliseconds` EXPLÍCITO (default 5s mata silencioso). Trocando `action`/`url`, serve para as outras probes:
+
+```sql
+SELECT net.http_post(
+  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-financeiro',
+  headers := jsonb_build_object('Content-Type','application/json',
+    'x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
+  body := jsonb_build_object('action','paginacao_probe'),
+  timeout_milliseconds := 20000) AS request_id;
+-- ~5s depois, na MESMA aba:
+SELECT status_code, content::jsonb->'canary' AS canary, content::jsonb->'contrato' AS contrato,
+       content::jsonb->'ok' AS ok,
+       (SELECT jsonb_agg(c->'caso') FROM jsonb_array_elements(content::jsonb->'casos') c
+        WHERE (c->>'ok')::bool IS NOT TRUE) AS casos_vermelhos
+FROM net._http_response ORDER BY id DESC LIMIT 1;
+```
+
+Verde = `status_code 200` **E** `canary true` **E** `contrato` batendo com a tabela acima **E** `ok true` **E** `casos_vermelhos NULL` (os cinco, não só o `ok`). `400` com `"Ação desconhecida"` = **bundle velho**, a probe não subiu — e a lista `acoes_disponiveis` da resposta é a confirmação (não cita a action nova). ⚠️ Probe é **dry-run**: se um dia uma delas abrir linha em `fin_sync_log`, ela fabrica frescor — `_data_health_compute` e `fin_calcular_confiabilidade` leem essa tabela **sem filtrar `action`** (só o `fin_sync_heartbeat` filtra). No `omie-financeiro` isso é o `PROBE_ACTIONS` → `logId=""`, pinado no `edge-money-path-invariants`.
 
 ## Quando o Lovable reverte um fix — detectar e restaurar
 

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -2350,3 +2350,89 @@ describe('guardrail money-path: erro Omie permanente não prende o sync_all_clie
     ).toMatch(/contas_sem_credencial/);
   });
 });
+
+// ── Canária comportamental dos guards de paginação do omie-financeiro (#1598 → paginacao_probe) ──
+// Assimetria de verificação deste setup: o Supabase é da org do Lovable e o founder não tem conta
+// com acesso ao ref, então a Management API (N2 — prova de VERSÃO da edge) é estruturalmente
+// indisponível (docs/agent/deploy.md #1590). Pós-deploy do #1598 só deu para provar N1 (existência)
+// + rastro do commit do bot; a canária é a ÚNICA prova do COMPORTAMENTO deployado. Os asserts
+// abaixo cobrem a FONTE na main (pegam remoção/rename pelo bot do Lovable); a probe HTTP cobre o
+// DEPLOY; o gate G4/G5 de paginacao-artesanal-gate cobre o REAL-PATH. Nenhum substitui os outros.
+
+const FIN_PAGINACAO = 'supabase/functions/omie-financeiro/index.ts';
+
+describe('guardrail money-path: canária paginacao_probe (omie-financeiro)', () => {
+  const src = read(FIN_PAGINACAO);
+  // Bloco INTEIRO da action, até o próximo case/default.
+  const PROBE_RE = /case "paginacao_probe":[\s\S]*?\n {6}(?=case |default:)/;
+
+  it('sentinela: leu o arquivo real da edge financeira', () => {
+    expect(src).toContain('ListarMovimentos');
+    expect(src).toContain('desfechoVarreduraReversa');
+  });
+
+  it('CANÁRIA de deploy: paginacao_probe existe, é versionada (contrato) e expõe {canary, ok, casos}', () => {
+    expect(
+      src,
+      'canária paginacao_probe ausente/renomeada — sem prova do COMPORTAMENTO deployado (sobra N1 + rastro do commit, mais fraco)',
+    ).toContain('case "paginacao_probe":');
+    const m = src.match(PROBE_RE);
+    expect(m, 'bloco da action paginacao_probe não encontrado').toBeTruthy();
+    const bloco = m![0];
+    expect(bloco, 'a probe perdeu o `canary: true` exigido por docs/agent/deploy.md').toMatch(/canary:\s*true/);
+    // Version marker: sem ele, um deploy INTEGRALMENTE velho compara velho×velho e mente ok:true.
+    expect(bloco, 'a probe perdeu o `contrato` (version marker) — deploy velho voltaria a mentir verde').toMatch(/contrato:\s*"paginacao-guards-v1"/);
+    expect(bloco, 'a probe perdeu o contrato {caso, resolved, expected, ok}').toMatch(/caso[\s\S]{0,120}resolved[\s\S]{0,120}expected[\s\S]{0,120}ok:/);
+    expect(bloco, 'o `ok` agregado deixou de exigir TODOS os casos').toMatch(/casosProbe\.every\(/);
+    // A action tem de ser anunciada no default — é o que discrimina binário velho de action com typo.
+    expect(src, '`paginacao_probe` sumiu de acoes_disponiveis: o default deixaria de discriminar bundle velho').toMatch(/acoes_disponiveis:[\s\S]{0,320}"paginacao_probe"/);
+  });
+
+  it('CANÁRIA read-only: paginacao_probe é dry-run puro (sem Omie, sem DB) e NÃO abre linha em fin_sync_log', () => {
+    const m = src.match(PROBE_RE);
+    expect(m, 'bloco da action paginacao_probe não encontrado').toBeTruthy();
+    const bloco = semComentarios(m![0]);
+    expect(bloco, 'a probe NÃO pode chamar o Omie — deixaria de ser dry-run determinístico').not.toMatch(/callOmie\(/);
+    expect(bloco, 'a probe NÃO pode tocar o DB (.insert/.update/.delete/.upsert/.rpc)').not.toMatch(/\.(insert|update|delete|upsert|rpc)\(/);
+    expect(bloco, 'a probe NÃO pode usar o client supabase').not.toMatch(/\bsupabase\b/);
+    // ⚠️ O invariante que não é óbvio: `logSync` roda ANTES do switch, e DOIS consumidores de frescor
+    // leem fin_sync_log sem filtrar action (`_data_health_compute` do cartão omie_sync_financeiro e
+    // `fin_calcular_confiabilidade`, conferidos via psql-ro). Uma probe logada carimbaria "sync
+    // financeiro recente" nas 3 empresas sem sincronizar nada — canária que envenena o dado que ela
+    // deveria proteger. Sem PROBE_ACTIONS no cálculo do logId, isso volta em silêncio.
+    const semCom = semComentarios(src);
+    expect(semCom, 'sumiu PROBE_ACTIONS — a canária voltaria a abrir linha em fin_sync_log').toMatch(/PROBE_ACTIONS\s*=\s*new Set\(\[[^\]]*"paginacao_probe"/);
+    expect(
+      semCom,
+      'REGRESSÃO: o logId da probe não é mais "" — fin_sync_log ganharia um "complete" que fabrica frescor em _data_health_compute/fin_calcular_confiabilidade',
+    ).toMatch(/usaLogPorCompany \|\| PROBE_ACTIONS\.has\(action\)[\s\S]{0,80}\?\s*""/);
+  });
+
+  it('CANÁRIA cobre os 5 helpers e os casos que se falsificam MUTUAMENTE', () => {
+    const m = src.match(PROBE_RE);
+    expect(m, 'bloco da action paginacao_probe não encontrado').toBeTruthy();
+    const bloco = m![0];
+    // Um helper sempre-X tem de reprovar algum caso. Os pares abaixo são o que garante isso.
+    for (const helper of ['proximoTotalPaginas(', 'avaliarPagina(', 'desfechoVarreduraReversa(', 'fingerprintPagina(', 'listaOmie<']) {
+      expect(bloco, `a probe deixou de exercitar ${helper} — o helper deployado ficaria sem prova`).toContain(helper);
+    }
+    for (const caso of [
+      // veredito de página: sem o par processar/anomalia/fim, um helper constante passaria
+      'pagina_com_itens_processar', 'pagina_vazia_ANTES_do_piso_anomalia', 'pagina_vazia_NO_piso_fim', 'pagina_vazia_ALEM_do_piso_fim',
+      // piso monotônico: crescer + os três "não encolhe" (ausente/0/menor) + o fail-fast do teto
+      'piso_cresce_com_declaracao_maior', 'piso_NAO_encolhe_sem_declaracao', 'piso_NAO_encolhe_com_declaracao_zero',
+      'piso_NAO_encolhe_com_declaracao_menor', 'teto_anti_runaway_LANCA',
+      // varredura reversa: completa só com sonda vazia E descida inteira
+      'reversa_desceu_tudo_e_sonda_VAZIA_completa', 'reversa_sonda_COM_dado_nao_completa_cursor_na_sonda', 'reversa_parou_no_meio_cursor_na_pagina_atual',
+      // fingerprint: o furo do `1ºcódigo:count` + determinismo (senão um hash aleatório passaria)
+      'fingerprint_NAO_colide_com_1o_codigo_ausente', 'fingerprint_deterministico_mesma_pagina',
+      // listaOmie: os dois lados — `[]` de verdade passa, ausente/null LANÇA
+      'lista_array_de_verdade_passa', 'lista_vazia_de_verdade_e_fim_legitimo', 'lista_campo_AUSENTE_lanca', 'lista_campo_NULL_lanca',
+    ]) {
+      expect(bloco, `a probe perdeu o caso ${caso} — a enumeração deixa de falsificar mutuamente`).toContain(caso);
+    }
+    // O caso negativo do listaOmie só vale se a exceção for CAPTURADA e AFIRMADA (deixar vazar
+    // derrubaria a probe inteira em 500 e o founder leria "edge quebrada", não "guard ausente").
+    expect(bloco, 'a probe deixou de capturar/afirmar o LANÇA do listaOmie').toMatch(/catch[\s\S]{0,120}lancou:\s*true/);
+  });
+});

--- a/supabase/functions/_shared/omie-paginacao_test.ts
+++ b/supabase/functions/_shared/omie-paginacao_test.ts
@@ -302,3 +302,64 @@ Deno.test("INVARIANTE — abandono e fim NUNCA devolvem hasMore (senão a conta 
 Deno.test("MAX_PAGINAS_POS_ESTOQUE preservado (500 — folga >10× sobre o maior uso atual)", () => {
   assertEquals(MAX_PAGINAS_POS_ESTOQUE, 500);
 });
+
+// ════════ CONTROLE DE CALIBRAÇÃO da canária `paginacao_probe` (omie-financeiro) ════════
+// "Canária que não discrimina é teatro verde" (docs/agent/deploy.md): a fixture tem de exercitar o
+// comportamento que MUDOU, e é preciso PROVAR que sob a implementação ANTIGA ela ficaria vermelha.
+// Sem estes asserts, a probe só provaria que a edge responde.
+//
+// Cada bloco abaixo reimplementa a forma PRÉ-#1598 e roda o MESMO input do fixture homônimo da
+// probe, exigindo que o resultado DIVIRJA do `expected` que ela carrega. Os nomes dos casos são os
+// da probe de propósito — renomear lá sem atualizar aqui é ruído que se vê no diff.
+// ⚠️ O que isto prova é a DISCRIMINAÇÃO da fixture (a escolha dos inputs). Que o helper deployado
+// está certo é a probe em si; que o real-path usa os helpers é o gate G4/G5
+// (src/__tests__/paginacao-artesanal-gate.test.ts). Três provas distintas, nenhuma substitui outra.
+
+// A forma PRÉ-#1353: o teto era recalculado POR RESPOSTA, sem memória do maior já declarado.
+const tetoPorResposta = (declarado: number | undefined) => declarado || 1;
+
+Deno.test("calibração: `piso_NAO_encolhe_sem_declaracao` fica VERMELHO sob o `|| 1` histórico", () => {
+  // Resposta intermediária sem o campo degradava o teto para 1. A canária espera
+  // {teto:5, veredito:"anomalia"}; a forma antiga produz teto 1 e "fim" — exatamente o carimbo de
+  // completude sobre retrato parcial que o #1353 pagou.
+  assertEquals(tetoPorResposta(undefined), 1);
+  assertEquals(avaliarPagina(0, 3, tetoPorResposta(undefined)), "fim");
+  assertEquals(avaliarPagina(0, 3, proximoTotalPaginas(5, undefined, 500)), "anomalia");
+});
+
+Deno.test("calibração: `piso_NAO_encolhe_com_declaracao_menor` fica VERMELHO sob o total por-resposta", () => {
+  // Declaração MENOR vencia a anterior: teto 3, e a p4 vazia passava por "fim" (retrato curto).
+  assertEquals(tetoPorResposta(3), 3);
+  assertEquals(avaliarPagina(0, 4, tetoPorResposta(3)), "fim");
+  assertEquals(avaliarPagina(0, 4, proximoTotalPaginas(5, 3, 500)), "anomalia");
+});
+
+Deno.test("calibração: `reversa_sonda_COM_dado_...` fica VERMELHO sob o `complete = pagina < 1`", () => {
+  const paginaFinal = 0;
+  // Forma antiga: descer até 1 bastava para completar (e zerar o cursor) — com o topo sub-reportado,
+  // as páginas MAIS RECENTES nunca voltavam a ser pedidas.
+  const antigo = { complete: paginaFinal < 1, nextPage: paginaFinal < 1 ? null : paginaFinal };
+  assertEquals(antigo, { complete: true, nextPage: null });
+  assertEquals(
+    desfechoVarreduraReversa({ paginaFinal, inicioVarredura: 80, tetoDeclarado: 80, topoVerificadoVazio: false, paginaSonda: 81 }),
+    { complete: false, nextPage: 81 },
+  );
+});
+
+Deno.test("calibração: `fingerprint_NAO_colide_com_1o_codigo_ausente` fica VERMELHO sob `1ºcódigo:count`", () => {
+  // Forma antiga: duas páginas CHEIAS e DIFERENTES cujo 1º título não tem código davam a MESMA
+  // string. A canária espera {colide:false}; a forma antiga responde {colide:true}.
+  const antigo = (codigos: ReadonlyArray<number | null>) => `${codigos[0] ?? ""}:${codigos.length}`;
+  assertEquals(antigo([null, 102, 103]) === antigo([null, 902, 903]), true);
+  assertEquals(fingerprintPagina([null, 102, 103]) === fingerprintPagina([null, 902, 903]), false);
+});
+
+Deno.test("calibração: `lista_campo_AUSENTE_lanca` fica VERMELHO sob o `|| []` histórico", () => {
+  // `listaOmie` é helper LOCAL do omie-financeiro (não importável aqui: o index.ts tem import
+  // remoto e o test:edges roda --no-remote). O que se prova aqui é a fixture: sob a forma antiga
+  // ela produz {lancou:false, itens:0} contra o {lancou:true, itens:null} que a canária espera —
+  // ou seja, um retorno sem o array viraria "página vazia" = FIM, com a cauda faltando.
+  const resposta: Record<string, unknown> = { nTotPaginas: 3 };
+  const antigo = (resposta["movimentos"] as unknown[] | undefined) || [];
+  assertEquals({ lancou: false, itens: antigo.length }, { lancou: false, itens: 0 });
+});

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -2195,6 +2195,17 @@ const LEASE_ACTIONS = new Set([
   "sync_all", "sync_contas_pagar", "sync_contas_receber", "sync_movimentacoes",
 ]);
 
+// Canárias de deploy: dry-run puro (helpers sobre fixtures; sem Omie, sem DB) → NÃO podem abrir
+// linha em fin_sync_log. Não é higiene, é money-path: DOIS consumidores de frescor leem essa
+// tabela SEM filtrar `action` (conferido via psql-ro 2026-07-29) — `_data_health_compute` pega o
+// último log com `completed_at IS NOT NULL` para o cartão `omie_sync_financeiro`, e
+// `fin_calcular_confiabilidade` faz `MAX(completed_at) WHERE status='complete' AND company =
+// ANY(companies)`. Como a probe roda sem `company` no body, `resolveCompanies` devolve as TRÊS:
+// uma probe logada carimbaria "sync financeiro recente" nas 3 empresas sem ter sincronizado nada —
+// exatamente a fabricação de frescor que o `skipped_busy` (completed_at NULL) existe para evitar.
+// Com logId="" o `completeSync` também vira no-op (`if (!logId) return`).
+const PROBE_ACTIONS = new Set(["paginacao_probe"]);
+
 // Roda o sync de UMA company sob o lease, com sua PRÓPRIA linha de fin_sync_log
 // (companies=[co]). ⚠️ POR QUÊ por-company e não 1 linha por invocação: numa chamada
 // multi-company (ex.: syncAll das 3), uma company pulada herdaria o 'complete' de
@@ -2278,7 +2289,11 @@ serve(async (req) => {
     // invocação (que teria companies[] compartilhado e mentiria frescor da company
     // pulada — achado Codex). logId="" p/ elas; o catch abaixo respeita isso.
     const usaLogPorCompany = LEASE_ACTIONS.has(action);
-    logId = usaLogPorCompany ? "" : await logSync(supabase, action, targetCompanies, auth.userId || "unknown");
+    // Canária (PROBE_ACTIONS) também sai com logId="" — não sincroniza nada, e logar fabricaria
+    // frescor nos consumidores que não filtram action (ver PROBE_ACTIONS).
+    logId = usaLogPorCompany || PROBE_ACTIONS.has(action)
+      ? ""
+      : await logSync(supabase, action, targetCompanies, auth.userId || "unknown");
 
     let result: Record<string, unknown> = {};
 
@@ -2474,6 +2489,160 @@ serve(async (req) => {
         break;
       }
 
+      case "paginacao_probe": {
+        // CANÁRIA COMPORTAMENTAL dos guards de paginação do #1598 — NÃO escreve, NÃO chama o Omie,
+        // NÃO toca o DB. Roda os helpers PUROS **deployados** sobre fixtures fixos e compara com o
+        // esperado. Molde: `doc_ambiguo_probe` (omie-analytics-sync) / `identidade_probe`
+        // (omie-vendas-sync). Gated pelo `validateCaller` como toda action; fora do `logSync`
+        // (ver PROBE_ACTIONS — probe que loga fabrica frescor de sync financeiro).
+        //
+        // POR QUE EXISTE: neste setup não há prova de VERSÃO de edge. O Supabase é da org do
+        // Lovable e o founder não tem conta com acesso ao ref — a Management API (N2) é
+        // estruturalmente indisponível (docs/agent/deploy.md, #1590). Depois de deployar o #1598
+        // só deu para provar N1 (existência) + rastro do commit do bot + inferência estatística
+        // fraca (47 chamadas Omie na run pós-deploy do colacor_sc contra baseline de 45 travada em
+        // 13 runs/7 dias — compatível com a sonda nova, mas a contagem de páginas do Omie também
+        // pode ter subido). Prova DUAS coisas que o commit de deploy não prova: (1) esta action
+        // RESPONDE → o bundle no ar é o desta árvore (binário velho devolve "Ação desconhecida" e
+        // a lista `acoes_disponiveis` do default nem cita `paginacao_probe`); (2) a tabela-verdade
+        // deployada está CERTA. Não prova que o real-path USA os helpers — isso é o gate estrutural
+        // `src/__tests__/paginacao-artesanal-gate.test.ts` (G4/G5) sobre a fonte na main.
+        //
+        // ⚠️ `contrato` é o version marker exigido por docs/agent/deploy.md §Canárias: sem ele um
+        // deploy INTEGRALMENTE velho (com a canária de uma fatia anterior) compara velho×velho e
+        // responde ok:true mentindo. Bump a cada fatia que mude o contrato desta canária.
+        // Igualdade estrutural ESTÁVEL (mesma mecânica do identidade_probe/doc_ambiguo_probe).
+        const stableId = (o: unknown): string =>
+          JSON.stringify(o, (_k, v) =>
+            v && typeof v === "object" && !Array.isArray(v)
+              ? Object.fromEntries(Object.entries(v as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b)))
+              : v);
+        const casosProbe: Array<{ caso: string; resolved: unknown; expected: unknown; ok: boolean }> = [];
+        const registrar = (caso: string, resolved: unknown, expected: unknown) =>
+          casosProbe.push({ caso, resolved, expected, ok: stableId(resolved) === stableId(expected) });
+
+        // ── (1+2) CONTRATO DE PÁGINA: o piso monotônico ALIMENTANDO o veredito ──────────────────
+        // Os dois helpers são deliberadamente exercitados JUNTOS, não em tabelas separadas: é o
+        // acoplamento que discrimina. Um piso que encolhe (o `|| 1` histórico do #1353) só é
+        // visível pelo veredito que ele produz — com teto encolhido, "página vazia ANTES do fim
+        // declarado" (anomalia, aborta fail-closed) vira "fim" e o retrato PARCIAL é carimbado
+        // como completo. Cada caso abaixo devolve as duas metades + o fail-fast anti-runaway.
+        const contratoPagina = (atual: number, declarado: number | undefined, itens: number, pagina: number) => {
+          try {
+            const teto = proximoTotalPaginas(atual, declarado, MAX_PAGINAS_FIN);
+            return { lancou: false, teto, veredito: avaliarPagina(itens, pagina, teto) };
+          } catch {
+            // Teto anti-runaway rejeita a DECLARAÇÃO (fail-fast, antes de girar a edge contra o Omie).
+            return { lancou: true, teto: null, veredito: null };
+          }
+        };
+        const fixturesPagina: Array<{
+          caso: string; atual: number; declarado: number | undefined; itens: number; pagina: number;
+          expected: { lancou: boolean; teto: number | null; veredito: string | null };
+        }> = [
+          // itens > 0 → processar (o caminho normal)
+          { caso: "pagina_com_itens_processar", atual: 1, declarado: 5, itens: 10, pagina: 1, expected: { lancou: false, teto: 5, veredito: "processar" } },
+          // vazia ANTES do piso → anomalia: fault transiente/rate-limit do Omie disfarçado de 200
+          // com lista vazia. Completar aqui deixaria a cauda stale com 'complete' mentindo.
+          { caso: "pagina_vazia_ANTES_do_piso_anomalia", atual: 1, declarado: 5, itens: 0, pagina: 3, expected: { lancou: false, teto: 5, veredito: "anomalia" } },
+          // vazia NO piso → fim normal (nada a processar, inofensivo)
+          { caso: "pagina_vazia_NO_piso_fim", atual: 1, declarado: 5, itens: 0, pagina: 5, expected: { lancou: false, teto: 5, veredito: "fim" } },
+          // vazia ALÉM do piso → fim (semântica segura; o total declarado é PISO, não verdade)
+          { caso: "pagina_vazia_ALEM_do_piso_fim", atual: 1, declarado: 5, itens: 0, pagina: 6, expected: { lancou: false, teto: 5, veredito: "fim" } },
+          // declaração MAIOR cresce o teto — sem o crescimento, avaliarPagina(0,7,5) daria "fim"
+          { caso: "piso_cresce_com_declaracao_maior", atual: 5, declarado: 9, itens: 0, pagina: 7, expected: { lancou: false, teto: 9, veredito: "anomalia" } },
+          // ⭐ o defeito #1353 EXATO: resposta intermediária SEM o campo degradava o teto p/ 1 e a
+          // run completava parcial. Com o piso, teto=5 e a p3 vazia é anomalia; sem ele seria "fim".
+          { caso: "piso_NAO_encolhe_sem_declaracao", atual: 5, declarado: undefined, itens: 0, pagina: 3, expected: { lancou: false, teto: 5, veredito: "anomalia" } },
+          { caso: "piso_NAO_encolhe_com_declaracao_zero", atual: 5, declarado: 0, itens: 0, pagina: 3, expected: { lancou: false, teto: 5, veredito: "anomalia" } },
+          // declaração MENOR também não encolhe (teto 3 daria "fim" na p4 — o retrato pararia curto)
+          { caso: "piso_NAO_encolhe_com_declaracao_menor", atual: 5, declarado: 3, itens: 0, pagina: 4, expected: { lancou: false, teto: 5, veredito: "anomalia" } },
+          // teto anti-runaway do PRÓPRIO omie-financeiro (MAX_PAGINAS_FIN): declaração lixo LANÇA
+          // fail-fast, em vez de ser descoberta na página 2001 depois de minutos contra o Omie.
+          { caso: "teto_anti_runaway_LANCA", atual: 5, declarado: 100000, itens: 0, pagina: 3, expected: { lancou: true, teto: null, veredito: null } },
+        ];
+        for (const f of fixturesPagina) {
+          registrar(f.caso, contratoPagina(f.atual, f.declarado, f.itens, f.pagina), f.expected);
+        }
+
+        // ── (3) DESFECHO DA VARREDURA REVERSA (ListarMovimentos vai do topo declarado até a p1) ──
+        // O `complete = pagina < 1` histórico carimbava como completo um retrato que nasceu abaixo
+        // do topo (sub-reporte do Omie) e zerava o cursor — a cauda MAIS RECENTE nunca mais era
+        // buscada. Quem prova o topo é a SONDA (I/O no caller), não o número declarado.
+        registrar(
+          "reversa_desceu_tudo_e_sonda_VAZIA_completa",
+          desfechoVarreduraReversa({ paginaFinal: 0, inicioVarredura: 80, tetoDeclarado: 80, topoVerificadoVazio: true, paginaSonda: 81 }),
+          { complete: true, nextPage: null },
+        );
+        registrar(
+          "reversa_sonda_COM_dado_nao_completa_cursor_na_sonda",
+          desfechoVarreduraReversa({ paginaFinal: 0, inicioVarredura: 80, tetoDeclarado: 80, topoVerificadoVazio: false, paginaSonda: 81 }),
+          { complete: false, nextPage: 81 },
+        );
+        // Parou no meio (budget/maxPages/streak) NUNCA completa, mesmo com a sonda vazia:
+        // fim-por-exaustão ≠ fim-da-fonte (money-path §8). Este caso é o que reprova um helper
+        // que completasse só olhando `topoVerificadoVazio`.
+        registrar(
+          "reversa_parou_no_meio_cursor_na_pagina_atual",
+          desfechoVarreduraReversa({ paginaFinal: 37, inicioVarredura: 80, tetoDeclarado: 80, topoVerificadoVazio: true, paginaSonda: 81 }),
+          { complete: false, nextPage: 37 },
+        );
+
+        // ── (4) FINGERPRINT DE PÁGINA — provar que NÃO colide ────────────────────────────────────
+        // O fingerprint antigo era `${primeiroCodigo}:${count}` e COLIDIA: duas páginas CHEIAS e
+        // DIFERENTES cujo 1º título não tem código produzem ambas ":100". Com repetição passando a
+        // LANÇAR, colisão vira sync travado. Aqui o `expected` é a RELAÇÃO (colide/igual), não o
+        // hash: o valor do FNV não é contrato — a não-colisão é.
+        registrar(
+          "fingerprint_NAO_colide_com_1o_codigo_ausente",
+          { colide: fingerprintPagina([null, 102, 103]) === fingerprintPagina([null, 902, 903]) },
+          { colide: false },
+        );
+        registrar(
+          "fingerprint_deterministico_mesma_pagina",
+          { igual: fingerprintPagina([101, 102, 103]) === fingerprintPagina([101, 102, 103]) },
+          { igual: true },
+        );
+        registrar(
+          "fingerprint_ordem_importa",
+          { colide: fingerprintPagina([1, 2, 3]) === fingerprintPagina([3, 2, 1]) },
+          { colide: false },
+        );
+        registrar(
+          "fingerprint_tamanhos_diferentes_nao_colidem",
+          { colide: fingerprintPagina([1, 2]) === fingerprintPagina([1, 2, 3]) },
+          { colide: false },
+        );
+
+        // ── (5) listaOmie — o helper LOCAL desta edge ────────────────────────────────────────────
+        // `(result.x as T[]) || []` num 200 com campo ausente/null virava "página vazia" = FIM, com
+        // a cauda faltando. Só `[]` de verdade é fim; qualquer outra coisa LANÇA. Como ele lança, o
+        // caso negativo captura a exceção e AFIRMA que ela veio (deixar vazar seria não testar).
+        const rodarLista = (resposta: OmieGenericResponse, campos: string[]) => {
+          try {
+            return { lancou: false, itens: listaOmie<unknown>(resposta, campos, "[Fin][probe] listaOmie").length };
+          } catch {
+            return { lancou: true, itens: null };
+          }
+        };
+        registrar("lista_array_de_verdade_passa", rodarLista({ movimentos: [{ a: 1 }, { a: 2 }] }, ["movimentos"]), { lancou: false, itens: 2 });
+        // `[]` legítimo é o fim honesto — sem este caso, um helper sempre-lança passaria.
+        registrar("lista_vazia_de_verdade_e_fim_legitimo", rodarLista({ movimentos: [] }, ["movimentos"]), { lancou: false, itens: 0 });
+        // Sem estes dois, um helper que volte ao `|| []` passaria: é o furo que o #1598 fechou.
+        registrar("lista_campo_AUSENTE_lanca", rodarLista({ nTotPaginas: 3 }, ["movimentos"]), { lancou: true, itens: null });
+        registrar("lista_campo_NULL_lanca", rodarLista({ movimentos: null }, ["movimentos"]), { lancou: true, itens: null });
+        // Alias: o Omie varia o nome do campo por endpoint; o 2º alias tem de ser alcançado.
+        registrar("lista_alias_2o_campo_encontrado", rodarLista({ conta_corrente_cadastro: [{ a: 1 }] }, ["ListarContasCorrentes", "conta_corrente_cadastro"]), { lancou: false, itens: 1 });
+
+        result = {
+          canary: true,
+          contrato: "paginacao-guards-v1",
+          ok: casosProbe.every((c) => c.ok), // true = a tabela-verdade deployada bate em TODOS os fixtures
+          casos: casosProbe,
+        };
+        break;
+      }
+
       default:
         await completeSync(supabase, logId, null, `Ação desconhecida: ${action}`, startTime);
         syncFinalized = true;
@@ -2483,7 +2652,7 @@ serve(async (req) => {
             acoes_disponiveis: [
               "sync_all", "sync_categorias", "sync_contas_correntes",
               "sync_contas_pagar", "sync_contas_receber", "sync_movimentacoes",
-              "calcular_dre", "calcular_dre_year", "debug_raw",
+              "calcular_dre", "calcular_dre_year", "debug_raw", "paginacao_probe",
             ],
           }),
           { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } }


### PR DESCRIPTION
## Problema (medido em 2026-07-28)

Neste setup **não existe prova de versão de edge**: o Supabase é da org do Lovable e o founder não tem conta com acesso ao ref `fzvklzpomgnyikkfkzai` — o N2 (Management API) é **estruturalmente indisponível** (`docs/agent/deploy.md`, #1590). Depois de deployar as 4 edges do #1598 só foi possível provar **N1** (existência) + rastro do commit do bot + uma inferência estatística fraca (47 chamadas Omie na run pós-deploy do `colacor_sc` contra baseline de 45 travada em 13 runs / 7 dias — compatível com a sonda nova de `syncMovimentacoes`, mas não conclusivo: a contagem de páginas do Omie também pode ter subido).

A doc é explícita: *"Edge sem canária: declare 'N1 + rastro; versão não provada' — nunca 'no ar'. Se a entrega for money-path e a prova importar, crie a canária junto do fix, porque depois não haverá como provar."* Os guards do #1598 entraram sem ela.

## O que entra

**`action: "paginacao_probe"`** no switch do `omie-financeiro` (junto de `debug_raw`), no molde verbatim de `doc_ambiguo_probe`/`identidade_probe`: dry-run puro (**não escreve, não chama o Omie, não toca o DB**), gated pelo `validateCaller` existente, retorna `{ canary, contrato, ok, casos:[{caso, resolved, expected, ok}] }`.

**19 casos** cobrindo os 5 helpers, em enumeração que se falsifica mutuamente:

| helper | casos |
|---|---|
| `avaliarPagina` + `proximoTotalPaginas` (acoplados) | 9 — itens>0→processar; vazia antes/no/além do piso; piso cresce; piso não encolhe (ausente/0/menor); teto anti-runaway LANÇA |
| `desfechoVarreduraReversa` | 3 — desceu tudo + sonda vazia→complete; sonda com dado→cursor na sonda; parou no meio→cursor na página atual |
| `fingerprintPagina` | 4 — não colide com 1º código ausente, determinístico, ordem importa, tamanhos diferentes |
| `listaOmie` (helper local) | 5 — array passa, `[]` é fim legítimo, campo ausente/null **LANÇA** (exceção capturada e afirmada), alias alcançado |

Duas decisões que valem registro:

1. **Piso e veredito são exercitados JUNTOS**, não em tabelas separadas — é o acoplamento que discrimina. Um teto encolhido só é visível pelo veredito que produz: com `|| 1`, `avaliarPagina(0, 3, 1)` responde `"fim"` onde o correto é `"anomalia"`. Separados, os dois lados passariam.
2. **A canária nasce VERSIONADA** (`contrato: "paginacao-guards-v1"`) — o `deploy.md` registra que canária sem version marker não protege contra deploy *integralmente* velho (compara velho×velho e mente `ok:true`).

## ⚠️ Achado: a probe não pode passar pelo `logSync`

`logSync` roda **antes** do switch, e dois consumidores de frescor leem `fin_sync_log` **sem filtrar `action`** (conferido via `psql-ro` 2026-07-29):

- `_data_health_compute` → cartão `omie_sync_financeiro`: último log com `completed_at IS NOT NULL`;
- `fin_calcular_confiabilidade` → `MAX(completed_at) WHERE status='complete' AND company = ANY(companies)`.

Como a probe roda sem `company` no body, `resolveCompanies` devolve as **três** empresas: uma probe logada carimbaria *"sync financeiro recente"* nas 3 sem ter sincronizado nada — a canária envenenando o dado que ela existe para proteger. Daí `PROBE_ACTIONS` → `logId=""` (que também torna `completeSync` um no-op). O invariante está pinado no guard textual. (`fin_sync_heartbeat` filtra `action='sync_'||…` e não era afetado.)

## Verificação

- `bun run test:edges` (Deno, `--no-remote`) — sem import remoto novo
- `bun run edges:typecheck` (`deno check` das 93)
- `bun lint` (o do CI) — pegou um `no-constant-binary-expression` meu na 1ª rodada; corrigido
- `bun run test` — `edge-money-path-invariants` (guard textual novo) + `paginacao-artesanal-gate` (G4/G5 continuam limpos com o call-site novo de `proximoTotalPaginas`)
- **Controle de calibração** em `omie-paginacao_test.ts`: 5 testes provando que sob a implementação **ANTIGA** cada fixture ficaria **vermelha** (`|| 1` no piso, `complete = pagina < 1` na reversa, `1ºcódigo:count` no fingerprint, `|| []` na lista). Sem isso a canária só provaria que a edge responde — "canária que não discrimina é teatro verde".
- **Prova de mecânica**: os 19 `expected` escritos à mão foram rodados contra os helpers **reais** — todos batem. Um `expected` errado faria a probe deployada responder `ok:false` sobre um guard são, e o founder leria "guard quebrado" onde o defeito seria a fixture. Falsificada: trocando um `expected` pelo que o `|| 1` antigo produziria (`teto:1, veredito:"fim"`), o script sai **exit 1** nomeando o caso.
- **Falsificação do guard textual**: com `contrato` trocado e `PROBE_ACTIONS` removido do cálculo do `logId`, os dois `it` correspondentes ficam vermelhos.

## Deploy (manual, founder)

Edge `omie-financeiro` pelo chat do Lovable, **verbatim da main**. Depois, a probe pelo SQL Editor (bloco pronto em `docs/agent/deploy.md` §Canárias — segredo sai do vault, `timeout_milliseconds` explícito). Verde = `200` **E** `canary true` **E** `contrato "paginacao-guards-v1"` **E** `ok true` **E** `casos_vermelhos NULL`. `400 "Ação desconhecida"` = bundle velho.

Sem migration. Sem mudança de frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
