### PR TITLE
fix(sync): resposta do Omie que FALHA deixa de virar fato — quita a dívida G6 [money-path]

### DIFF
--- a/src/__tests__/paginacao-artesanal-gate.test.ts
+++ b/src/__tests__/paginacao-artesanal-gate.test.ts
@@ -313,21 +313,59 @@ const G5_ALLOW: ReadonlyMap<string, number> = new Map(
 // Regra: `await fetch(` cuja chamada menciona Omie precisa de `.ok`/`.status` antes do consumo.
 //
 // LIMITAÇÃO CONHECIDA (registrada, não é descuido — a versão completa exigiria dataflow): o
-// detector aceita QUALQUER menção a `.status`, então um tratamento PARCIAL (só 425/429, a forma
-// que o omie-sync-vendas-items tinha) o satisfaz enquanto o 500 continua passando. Está fixado
-// no controle de calibração abaixo, para a limitação ser um fato medido e não uma surpresa —
-// e é por isso que ela não substitui a leitura do wrapper ao mexer nele.
-const JANELA_G6 = 1200;
+// detector aceita qualquer COMPARAÇÃO de `.status`, então um tratamento PARCIAL (só 425/429, a
+// forma que o omie-sync-vendas-items tinha) o satisfaz enquanto o 500 continua passando. Está
+// fixado no controle de calibração abaixo, para a limitação ser um fato medido e não uma surpresa
+// — e é por isso que ela não substitui a leitura do wrapper ao mexer nele.
+//
+// ⚠️ A janela era uma DISTÂNCIA FIXA (1200 chars) e errava nos DOIS sentidos — medido ao quitar a
+// dívida, com os dois erros no mesmo arquivo-conjunto:
+//  · falso VERMELHO: `omie-vendas-sync` tem o `if (!response.ok) throw` na ordem canônica, ~1.400
+//    chars abaixo do fetch (o retry/backoff da faultstring vive entre os dois). Ficava baselinado
+//    como dívida um wrapper CORRETO — e dívida falsa ensina a ignorar a lista.
+//  · falso VERDE, o caro: em `process-nfe` a janela alcançava o `if (!__auth.ok)` do gate de
+//    AUTORIZAÇÃO do handler, 30 linhas abaixo e em OUTRA função. Um `.ok` de objeto sem relação
+//    nenhuma com a resposta HTTP satisfazia o detector, e o wrapper (sem guard nenhum) media zero.
+//    Não era "arquivo auditado": era o detector lendo o guard errado (§"O DETECTOR mente").
+// Alargar a distância piora o segundo: a 4000 o `verify-employee` também ficava verde, pelo mesmo
+// mecanismo. O que separa os dois casos não é TAMANHO, é ESCOPO — o guard de uma resposta tem de
+// estar na função que fez o fetch. Daí a janela ser léxica: até o `}` que fecha a função (coluna
+// 0), truncada no próximo `await fetch(` (para o guard de um site nunca cobrir o do vizinho) e num
+// teto duro. Medido no repo inteiro: revela `process-nfe`, quita `omie-vendas-sync`, e não mexe em
+// mais nada.
+const TETO_G6 = 4000;
+
+function janelaG6(fonte: string, i: number): string {
+  let fim = i + TETO_G6;
+  const proximoFetch = fonte.indexOf('await fetch(', i + 1);
+  if (proximoFetch !== -1) fim = Math.min(fim, proximoFetch);
+  const fechaFuncao = /\n\}/.exec(fonte.slice(i)); // `}` na coluna 0 = fim da função top-level
+  if (fechaFuncao) fim = Math.min(fim, i + fechaFuncao.index);
+  return fonte.slice(i, fim);
+}
 
 function fetchsOmieSemStatus(fonte: string): number {
   let i = -1;
   let n = 0;
   while ((i = fonte.indexOf('await fetch(', i + 1)) !== -1) {
     if (!/omie/i.test(fonte.slice(i, i + 260))) continue; // só o Omie; Supabase/LLM têm outro contrato
-    if (!/\.ok\b|\.status\s*(===|!==|>=|<|==)/.test(fonte.slice(i, i + JANELA_G6))) n++;
+    if (!/\.ok\b|\.status\s*(===|!==|>=|<|==)/.test(janelaG6(fonte, i))) n++;
   }
   return n;
 }
+
+// Allowlist G6 (por CONTAGEM) — tratamento CORRETO numa forma que a regex não casa. Não é dívida:
+// cada entrada foi lida linha a linha, e a entrada existe porque afrouxar a regex para acomodá-la
+// deixaria passar o furo real.
+const G6_ALLOW: ReadonlyMap<string, number> = new Map([
+  // `classifyOmieResponse(res.status, fs)` — o status vai como ARGUMENTO a um classificador puro
+  // (omie-sync-nfes-recebidas/retry.ts, coberto por `retry_test.ts`), então não há operador de
+  // comparação para a regex casar. O tratamento é o mais completo do repo e na ordem canônica:
+  // faultstring → 429 retry → >=500 retry → >=400 permanent → ok. Aceitar `.status` sem operador
+  // resolveria esta entrada e cobriria de verde todo `throw new Error(\`HTTP ${res.status}\`)`
+  // decorativo, que é exatamente a forma que não decide nada.
+  ['supabase/functions/omie-sync-nfes-recebidas/index.ts', 1],
+]);
 
 // DÍVIDA G6 (baselinada 2026-07-29, por CONTAGEM — mesma regra das outras): 7 sites REVELADOS
 // pelo detector novo, em edges que o PR que o criou não toca. Auditar cada um exige ler o
@@ -336,17 +374,29 @@ function fetchsOmieSemStatus(fonte: string): number {
 // Os 6 wrappers do PR que criou este gate (cmc-snapshot-backfill, cmc-snapshot-smoke,
 // omie-sync-metadados, sync-reprocess, tint-omie-sync, omie-sync-vendas-items) NÃO estão aqui:
 // foram corrigidos, e é isso que a ausência deles significa.
-const G6_DIVIDA: ReadonlyMap<string, number> = new Map([
-  ['supabase/functions/analyze-unified-order/index.ts', 1],
-  ['supabase/functions/omie-analytics-sync/index.ts', 1],
-  // omie-cliente (1→0) QUITADO pelo #1614 (que mergeou entre a baseline e este PR): o wrapper
-  // passou a classificar a falha do Omie antes de consumir o corpo. Primeira quitação registrada
-  // deste gate, e ela veio de outro PR — o gate pegou sozinho, no rebase.
-  ['supabase/functions/omie-sync/index.ts', 1],
-  ['supabase/functions/omie-sync-nfes-recebidas/index.ts', 1],
-  ['supabase/functions/omie-vendas-sync/index.ts', 1],
-  ['supabase/functions/verify-employee/index.ts', 1],
-]);
+//
+// ── DÍVIDA QUITADA (chip de erradicação G6). A lista chegou a ZERO: a próxima entrada aqui é
+// reintrodução, não herança. Auditoria site a site — e a leitura do consumo REAL era o trabalho,
+// porque dos 7 baselinados só 4 eram furo:
+//  · omie-cliente (1→0) — pelo #1614, que mergeou entre a baseline e o PR que criou o gate.
+//  · omie-sync (1→0) — FURO, e o mais caro. `IncluirOS` gravava a OS como "enviado" com
+//    `omie_codigo_os` undefined, e `ListarClientes` via lista vazia (porta do cadastro duplicado).
+//    O guard de status sozinho seria PIOR que o bug: `sync_deleted_orders` apagava o pedido de 6
+//    tabelas em QUALQUER exceção, então o 5xx que antes voltava `{}` (e por acidente não deletava)
+//    passaria a apagar a carteira inteira num incidente do Omie. Wrapper e consumidor foram
+//    juntos: deleção agora exige prova POSITIVA de ausência (money-path §7).
+//  · verify-employee (1→0) — FURO: 5xx virava o veredito "este CPF não é funcionário".
+//  · omie-analytics-sync (1→0) — FURO: 5xx chegava aos laços sem total e sem lista. O transitório
+//    reusa o backoff que já existia; só o esgotamento lança.
+//  · analyze-unified-order (1→0) — FURO leve: o preço do Omie só preenche gap, então o efeito é
+//    recall, não número fabricado. Corrigido para o motivo parar de ser invisível.
+//  · omie-sync-nfes-recebidas (1→0) — NÃO era furo: tratamento completo via `classifyOmieResponse`.
+//    Foi para a G6_ALLOW acima, com justificativa.
+//  · omie-vendas-sync (1→0) — NÃO era furo: `if (!response.ok) throw` na ordem canônica, longe
+//    demais para a janela FIXA enxergar. Quitou sozinho quando a janela virou léxica.
+// E o detector consertado revelou um site novo (process-nfe), corrigido aqui em vez de baselinado:
+// o ciclo do §9 — um PR conserta o detector e baselina o revelado, o outro corrige e esvazia.
+const G6_DIVIDA: ReadonlyMap<string, number> = new Map([]);
 
 describe('gate estrutural: paginação artesanal que trata falha como fim (classe #1338→#1564)', () => {
   it('sentinela: o walker anda de verdade (glob quebrado = verde eterno, ausência de sinal ≠ aprovação)', () => {
@@ -500,7 +550,8 @@ describe('gate estrutural: paginação artesanal que trata falha como fim (class
   });
 
   it('G6: nenhuma resposta do Omie consumida sem checar o status HTTP, além da dívida', () => {
-    const { reintroducoes, quitacoes } = desvios(contarPorArquivo(fetchsOmieSemStatus), G6_DIVIDA);
+    const base = new Map([...G6_ALLOW, ...G6_DIVIDA]);
+    const { reintroducoes, quitacoes } = desvios(contarPorArquivo(fetchsOmieSemStatus), base);
     expect(
       reintroducoes,
       `REINTRODUÇÃO da classe uma camada ACIMA do laço (F6 — resposta do Omie usada sem olhar o ` +
@@ -548,6 +599,109 @@ describe('gate estrutural: paginação artesanal que trata falha como fim (class
       const res = await fetch(\`\${SUPA_URL}/rest/v1/tabela\`, { headers });
       const linhas = await res.json();`;
     expect(fetchsOmieSemStatus(outroServico), 'G6 alcançou fetch que não é do Omie').toBe(0);
+
+    // ── Os dois erros que a JANELA FIXA cometia, fixados como controle ──────────────────────
+    // (a) Falso VERDE: `.ok` de OUTRA função depois do `}` não pode valer como guard. Forma REAL
+    // do process-nfe pré-fix — o `!__auth.ok` é o gate de autorização do handler, não a resposta.
+    // Se este assert cair, o gate voltou a aceitar o guard errado e todo verde dele é suspeito.
+    const guardDeOutraFuncao = `
+      const res = await fetch(\`\${OMIE_BASE}\${endpoint}\`, { method: "POST", body });
+      const text = await res.text();
+      const data = JSON.parse(text);
+      if (typeof data.faultstring === "string") throw new Error(\`Omie: \${data.faultstring}\`);
+      return data;
+}
+
+serve(async (req) => {
+  const __auth = await authorizeCronOrStaff(req);
+  if (!__auth.ok) return __auth.response;`;
+    expect(
+      fetchsOmieSemStatus(guardDeOutraFuncao),
+      'G6 aceitou o `.ok` de OUTRA função como guard da resposta (o falso-verde do process-nfe)',
+    ).toBe(1);
+
+    // (b) Falso VERMELHO: guard CORRETO longe do fetch, mas dentro da MESMA função — a forma REAL
+    // do omie-vendas-sync (transcrita do arquivo), onde o retry inteiro da faultstring vive entre
+    // o fetch e o `!response.ok`. Baselinar isso como dívida é registrar débito sobre código
+    // correto, e lista falsa ensina a ignorar a lista.
+    //
+    // ⚠️ O COMPRIMENTO deste fixture é a asserção. A 1ª versão tinha 701 chars entre o fetch e o
+    // guard, contra 1.942 do arquivo real — e por isso ficou VERDE quando a falsificação reduziu
+    // o teto para 1200, exatamente a regressão que ele deveria pegar (o gate acusou o arquivo real
+    // e o controle não sentiu nada). Fixture mais curto que o código que ele representa é um
+    // detector que não conhece a forma real do repo — a armadilha do §9 aplicada ao próprio
+    // controle. O assert de distância abaixo prende isso: encurtar o fixture reprova.
+    const guardLongeMesmaFuncao = `
+      const response = await fetch(\`\${OMIE_API_URL}/\${endpoint}\`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+      const result = (await response.json()) as OmieGenericResponse;
+
+      if (result.faultstring) {
+        const fs = String(result.faultstring);
+        const isRateLimit = fs.includes("Já existe uma requisição desse método")
+          || fs.includes("Consumo redundante")
+          || fs.includes("REDUNDANT")
+          || fs.includes("consumo redundante");
+        const isTransient = fs.includes("SOAP-ERROR")
+          || fs.includes("Broken response")
+          || fs.includes("Application Server")
+          || fs.includes("timeout")
+          || fs.includes("Timeout");
+        if (isRateLimit || isTransient) {
+          if (attempt < maxRetries) {
+            const waitMatch = fs.match(/Aguarde (\\d+) segundos/);
+            const requestedDelay = waitMatch ? parseInt(waitMatch[1]) : (attempt + 1) * 5;
+            const delay = Math.min(requestedDelay + 2, 15) * 1000;
+            console.log(\`[Omie Vendas][\${account}] Rate limit, waiting \${delay/1000}s (attempt \${attempt + 1}/\${maxRetries})\`);
+            await new Promise(r => setTimeout(r, delay));
+            continue;
+          }
+          if (opts?.throwOnTransient) {
+            throw new Error(\`OMIE_TRANSIENT (\${account}): rate limit persistiu após \${maxRetries} tentativas — não dá pra afirmar ausência\`);
+          }
+          console.log(\`[Omie Vendas][\${account}] Transient error persists after \${maxRetries} retries, returning null\`);
+          return null;
+        }
+        if (fs.includes("Não existem registros para a página")) {
+          console.log(\`[Omie Vendas][\${account}] Nenhum registro encontrado, retornando null\`);
+          return null;
+        }
+        throw new Error(\`Erro Omie Vendas (\${account}): \${fs}\`);
+      }
+
+      if (!response.ok) {
+        const httpMessage = result?.descricao_status || \`HTTP \${response.status}\`;
+        throw new Error(\`Erro Omie Vendas (\${account}): \${httpMessage}\`);
+      }
+      return result;`;
+    const distanciaFixture = guardLongeMesmaFuncao.indexOf('!response.ok')
+      - guardLongeMesmaFuncao.indexOf('await fetch(');
+    expect(
+      distanciaFixture,
+      'fixture encurtou abaixo da distância REAL do omie-vendas-sync (1.942 chars) — ele deixaria ' +
+        'de sentir uma regressão do teto, que é a única coisa que este controle mede',
+    ).toBeGreaterThan(1900);
+    expect(
+      fetchsOmieSemStatus(guardLongeMesmaFuncao),
+      'G6 ficou falso-VERMELHO sobre guard correto na mesma função (o caso omie-vendas-sync)',
+    ).toBe(0);
+
+    // (c) O guard de um fetch não cobre o do vizinho: a janela trunca no próximo `await fetch(`.
+    // Sem isso, alargar a janela faria um wrapper correto absolver o wrapper de baixo.
+    const doisFetchs = `
+      const a = await fetch(\`\${OMIE_API_URL}/x\`, { method: "POST" });
+      const da = await a.json();
+      const b = await fetch(\`\${OMIE_API_URL}/y\`, { method: "POST" });
+      if (!b.ok) throw new Error("Omie HTTP");
+      const db = await b.json();`;
+    expect(
+      fetchsOmieSemStatus(doisFetchs),
+      'G6 deixou o guard do 2º fetch cobrir o 1º (janela não truncou no fetch vizinho)',
+    ).toBe(1);
   });
 
   it('G4 (controle de calibração): as DUAS formas do total cru são detectadas — inclusive com cast', () => {

--- a/src/hooks/useAdminOrderDetail.ts
+++ b/src/hooks/useAdminOrderDetail.ts
@@ -162,7 +162,16 @@ export function useAdminOrderDetail(id: string | undefined) {
       if (profileData) setProfile(profileData);
 
       const osCheck = await checkOsExistsInOmie(data.id);
-      if (!osCheck.exists) {
+      // `indeterminado` vem ANTES do teste de existência de propósito. A edge devolve
+      // `exists: true` quando não consegue verificar — fail-safe correto, porque este ramo APAGA
+      // o pedido —, mas sem o aviso a tela ficaria idêntica à de uma verificação bem-sucedida:
+      // "não consegui falar com o Omie" com cara de "OS confirmada" (money-path §2, e o achado
+      // do challenge Codex de que o campo novo era diagnóstico morto no consumidor).
+      if (osCheck.indeterminado) {
+        toast.warning('Não foi possível verificar a OS no Omie', {
+          description: 'O pedido foi mantido. Se ela tiver sido excluída no Omie, a limpeza acontece no próximo ciclo.',
+        });
+      } else if (!osCheck.exists) {
         toast.error('Pedido excluído no Omie', {
           description: 'Esta OS foi excluída no Omie. O pedido será removido.',
         });

--- a/src/services/omieService.ts
+++ b/src/services/omieService.ts
@@ -321,12 +321,18 @@ export async function deleteOrderFromOmie(orderId: string): Promise<{ success: b
   }
 }
 
-export async function checkOsExistsInOmie(orderId: string): Promise<{ exists: boolean }> {
+export async function checkOsExistsInOmie(
+  orderId: string,
+): Promise<{ exists: boolean; indeterminado?: boolean; motivo?: string }> {
   try {
     const { data, error } = await supabase.functions.invoke("omie-sync", {
       body: { action: "check_os_exists", orderId },
     });
-    if (error) return { exists: true }; // Assume exists on error
+    // `indeterminado` acompanha o `exists` em vez de substituí-lo: quem consome faz
+    // `if (!exists) → apaga o pedido`, então qualquer falsy novo viraria deleção por falha de
+    // rede. O tipo precisa carregar a flag, senão o edge reporta "não consegui verificar" e a
+    // informação morre aqui — a correção do wrapper só termina quando chega à tela (money-path §7).
+    if (error) return { exists: true, indeterminado: true, motivo: error.message };
     return data;
   } catch (error) {
     logger.warn('Failed to check OS exists in Omie (assuming exists)', {
@@ -335,6 +341,10 @@ export async function checkOsExistsInOmie(orderId: string): Promise<{ exists: bo
       orderId,
       error,
     });
-    return { exists: true };
+    return {
+      exists: true,
+      indeterminado: true,
+      motivo: error instanceof Error ? error.message : 'falha ao consultar o Omie',
+    };
   }
 }

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -1385,6 +1385,17 @@ Responda SEMPRE usando a função identify_order_items.`;
                     }],
                   }),
                 });
+                // `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo corpo parseia limpo devolvia
+                // `pedido_venda_produto` ausente → `|| []` → zero preços, indistinguível de "este
+                // cliente nunca comprou". Aqui o efeito é RECALL, não fabricação de número (o
+                // histórico do Omie só PREENCHE GAP — `mergeCustomerPrices` faz order_items vencer,
+                // e `isValidUnitPrice` barra valor inválido), então o desfecho continua sendo o
+                // best-effort que este caminho sempre foi: o catch abaixo devolve `{}`. O que muda
+                // é o motivo deixar de ser invisível — "0 preços" e "o Omie respondeu 503" tinham
+                // exatamente o mesmo log, e só o segundo explica um orçamento sem preço praticado.
+                if (!omieRes.ok) {
+                  throw new Error(`Omie HTTP ${omieRes.status} em ListarPedidos (preços do cliente)`);
+                }
                 const data = await omieRes.json();
                 const precos: Record<number, number> = {};
                 const pedidos = data.pedido_venda_produto || [];

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -182,7 +182,26 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
         body: JSON.stringify(body),
       });
       const result = (await res.json()) as OmieApiResponseBase;
+      // `faultstring` ANTES do status. ⚠️ Aqui a ordem NÃO preserva EOF nenhum — este wrapper
+      // lança em TODA faultstring, inclusive na de fim de página, e isso é comportamento
+      // preexistente que este PR não muda (achado Codex xhigh, contra a 1ª redação deste
+      // comentário, que prometia preservar o fim real). O que a ordem preserva é a MENSAGEM: é
+      // ela que o catch abaixo classifica para decidir entre retentar e falhar, e um `HTTP 503`
+      // genérico apagaria a faultstring específica que torna o motivo acionável.
       if (result.faultstring) throw new Error(`Omie (${account}): ${result.faultstring}`);
+      // Sem faultstring, só um 2xx é resposta. `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo
+      // corpo parseia sem fault (o `{}` de proxy/gateway) voltava como resposta boa e chegava aos
+      // laços de enumeração sem `total_de_paginas` e sem lista — o piso degrada para 1 e a página
+      // vazia vira fim da fonte, com todos os guards de paginação corretos e nenhum consultado.
+      // Emitido como `HTTP <n>` para reusar o backoff do catch em vez de virar falha diária —
+      // mas o classificador local casa dígito CRU e só conhece 429/500/502/503/504: um 501/520
+      // aborta na 1ª tentativa (dívida preexistente do classificador, não deste guard; o helper
+      // canônico `_shared/omie-falha.ts` é quem já ancora o marcador na forma `http <n>`).
+      if (!res.ok) throw new Error(`Omie (${account}): HTTP ${res.status}`);
+      // `faultcode` sem `faultstring` fecha a ordem canônica: um `200 {"faultcode":"5113"}` chegava
+      // aos laços como página boa e vazia, e o sync publicava `status:"complete"` sobre um retrato
+      // parcial — a fabricação de completude que o G6 existe para barrar, uma casa adiante.
+      if (result.faultcode) throw new Error(`Omie (${account}): faultcode ${result.faultcode}`);
       return result;
     } catch (e) {
       lastErr = e instanceof Error ? e : new Error(String(e));

--- a/supabase/functions/omie-sync-nfes-recebidas/retry.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/retry.ts
@@ -46,6 +46,14 @@ export function classifyOmieResponse(
   if (status === 429) return { kind: "retry", reason: "rate_limit" };
   if (status >= 500) return { kind: "retry", reason: "transient" };
   if (status >= 400) return { kind: "permanent" };
+  // `ok` exige 2xx — não "tudo que não é 4xx/5xx". A versão anterior terminava com o `return
+  // {kind:"ok"}` cru, então 1xx e 3xx (300/302/399) eram aprovados como resposta boa: o corpo `{}`
+  // de um redirect degradava o total para 1 e a lista para `[]`, e a conta fechava `complete` com
+  // zero erros — a MESMA fabricação de completude que este classificador existe para impedir,
+  // entrando pela faixa de status que ninguém enumerou (achado Codex xhigh, confirmado por
+  // execução). Improvável não é impossível: `fetch` segue redirect sozinho, mas basta um proxy
+  // com `redirect: manual` na frente, e o custo de fechar a faixa é uma linha.
+  if (status < 200 || status >= 300) return { kind: "permanent" };
   return { kind: "ok" };
 }
 

--- a/supabase/functions/omie-sync-nfes-recebidas/retry_test.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/retry_test.ts
@@ -57,6 +57,21 @@ Deno.test("classifyOmieResponse: 4xx (não-429) → permanent, nunca mascarado p
 
 Deno.test("classifyOmieResponse: 2xx limpo → ok", () => {
   assertEquals(classifyOmieResponse(200, undefined), { kind: "ok" });
+  assertEquals(classifyOmieResponse(201, undefined), { kind: "ok" });
+  assertEquals(classifyOmieResponse(299, undefined), { kind: "ok" });
+});
+
+// FALSIFICAÇÃO 3: `ok` é 2xx, não "o resto". A versão anterior terminava num `return {kind:"ok"}`
+// cru depois de testar 429/5xx/4xx, então 1xx e 3xx caíam em `ok` — e um corpo `{}` de redirect
+// aprovado como resposta boa degrada o total para 1, a lista para `[]`, e a conta fecha `complete`
+// com zero erros (achado Codex xhigh). Enumerar só as faixas de ERRO deixa a faixa não enumerada
+// virar sucesso por omissão: o default de um classificador de resposta tem de ser o lado caro.
+Deno.test("classifyOmieResponse: fora de 2xx nunca é `ok` — 3xx/1xx são permanent", () => {
+  assertEquals(classifyOmieResponse(300, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(302, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(399, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(100, undefined), { kind: "permanent" });
+  assertEquals(classifyOmieResponse(0, undefined), { kind: "permanent" });
 });
 
 // Precedência: faultstring transitório vence o status HTTP (Omie manda 200 + fault).

--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarFaultstring, redigirSegredo } from "../_shared/omie-falha.ts";
 // Resend usado via fetch direto à REST API (https://api.resend.com/emails) para evitar dep npm
 
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "*";
@@ -77,12 +78,6 @@ interface OmieListarContasCorrentesResponse {
   faultstring?: string;
 }
 
-interface OmieConsultarOSResponse {
-  nCodOS?: number;
-  cNumOS?: string;
-  faultstring?: string;
-}
-
 interface ServicoLocalRow {
   id: string;
   omie_codigo_servico: number;
@@ -124,11 +119,68 @@ async function callOmieApi(
   const result = await response.json();
   console.log(`[Omie API] Resposta:`, JSON.stringify(result, null, 2));
 
+  // `faultstring` ANTES do status (ordem canônica do #1614 — docs/agent/sync.md): o EOF do
+  // contrato Omie chega às vezes acompanhado de 5xx, e lê-lo como falha de transporte trocaria
+  // ausência REAL por erro. Quem separa "não existe" de "não consegui ver" são os call-sites,
+  // pelo TEXTO da faultstring — por isso ela tem de sobreviver ao guard de status.
   if (result.faultstring) {
-    throw new Error(`Erro Omie: ${result.faultstring}`);
+    throw new Error(`Erro Omie: ${redigirSegredo(String(result.faultstring))}`);
+  }
+
+  // Sem faultstring, só um 2xx é resposta. `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo
+  // corpo parseia sem `faultstring` (o `{}` de proxy/gateway) chegava aqui como resposta BOA, e
+  // cada call-site o lia como um fato afirmado pelo Omie — `IncluirOS` gravava a OS com status
+  // "enviado" e `omie_codigo_os` undefined (pedido carimbado como enviado ao ERP sem existir
+  // lá), e o `ListarClientes` do self-service via `clientes_cadastro ?? []` = cliente inexistente,
+  // porta de entrada para cadastro DUPLICADO. `HTTP <n>` é a forma que `classificarFaultstring`
+  // reconhece como transitória (marcador ancorado, nunca o dígito solto — §"O MARCADOR mente").
+  if (!response.ok) {
+    throw new Error(`Erro Omie: HTTP ${response.status} em ${call}`);
+  }
+
+  // `faultcode` sem `faultstring` é a mesma família (erro sinalizado que o parse não enxerga) e
+  // fecha a ordem canônica do #1614. Sem isto, um `200 {"faultcode":"5113"}` passava como sucesso:
+  // o `sync_services` lia `cadastros` ausente como `[]` e INATIVAVA todo serviço local, e o
+  // `IncluirOS` seguia gravando a OS como enviada (achado Codex xhigh).
+  if (result.faultcode) {
+    throw new Error(`Erro Omie: faultcode ${redigirSegredo(String(result.faultcode))} em ${call}`);
   }
 
   return result;
+}
+
+// Prova POSITIVA de que a OS não existe mais no Omie — o ÚNICO desfecho que autoriza a deleção
+// local (o `sync_deleted_orders` apaga o pedido de 6 tabelas, e isso não tem volta).
+//
+// A classe transitória/permanente vence ANTES de qualquer marcador de ausência, e é essa ordem
+// que faz o predicado valer: um "sem permissão para consultar" (credencial revogada) e um
+// "timeout" carregam o vocabulário da negação sem provar ausência nenhuma — e devolveriam o
+// mesmo erro para TODA OS da varredura, transformando um incidente do Omie em deleção da
+// carteira inteira. Falha de transporte é "não consegui verificar", nunca "não existe".
+//
+// A lista é deliberadamente CONSERVADORA (precisão > recall): errar para "não deletar" deixa um
+// pedido órfão visível, que o ciclo seguinte reavalia; errar para "deletar" destrói pedido,
+// mensagens, avaliações e pontos de fidelidade de um cliente real. Ela é auto-instrumentada — o
+// `console.warn` do call-site imprime toda mensagem que NÃO casou, então a faultstring real de
+// OS inexistente aparece nos logs em vez de ser adivinhada aqui.
+const MARCADORES_OS_AUSENTE = ["nao existe", "nao encontrad", "nao cadastrad"];
+
+function osAusenteNoOmie(erro: unknown): boolean {
+  const texto = erro instanceof Error ? erro.message : String(erro);
+  const classe = classificarFaultstring(texto);
+  // Só a classe INDETERMINADA chega aos marcadores. Barrar apenas transitório/permanente era o
+  // furo: `fim_de_pagina` — o EOF do contrato Omie, "Não existem registros para a página" — passava
+  // pela peneira e, normalizado, casava o marcador "nao existe" (achado Codex xhigh, confirmado
+  // executando `classificarFaultstring`). O EOF de PAGINAÇÃO chegando por um `ConsultarOS` (que
+  // não pagina) é sinal fora de contexto, e a resposta a sinal fora de contexto não pode ser
+  // apagar 6 tabelas. Exigir `indeterminada` barra exatamente a frase do EOF sem cegar as demais
+  // formas de ausência, que não citam "para a página".
+  if (classe !== "indeterminada") return false;
+  // Normalização ASCII (sem acento, minúsculo) — o Omie mistura caixa e acentuação entre
+  // mensagens, e casar acento é armadilha recorrente do repo (money-path §"a sabotagem não
+  // casou nada"). Sequência de ESCAPE, nunca combining mark literal no fonte.
+  const t = texto.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+  return MARCADORES_OS_AUSENTE.some((m) => t.includes(m));
 }
 
 // Função para enviar notificação de novo pedido para administração
@@ -1494,14 +1546,34 @@ serve(async (req) => {
         }
 
         try {
-          const consultaResult = await callOmieApi("servicos/os/", "ConsultarOS", {
+          await callOmieApi("servicos/os/", "ConsultarOS", {
             nCodOS: osCheck.omie_codigo_os,
-          }) as unknown as OmieConsultarOSResponse;
+          });
 
-          result = { exists: !consultaResult.faultstring };
-        } catch {
-          // If error contains "não encontrada" or similar, OS was deleted
-          result = { exists: false };
+          // 2xx sem faultstring = existe. (O `!consultaResult.faultstring` de antes era código
+          // morto — o wrapper já lança em faultstring, então este ramo só é alcançado no sucesso.)
+          result = { exists: true };
+        } catch (erro) {
+          // Mesma regra do sync_deleted_orders: só a prova positiva de ausência afirma que a OS
+          // sumiu. Falha de transporte devolvia `exists:false` — "não consegui verificar" com
+          // cara de fato, e o consumidor não tinha como distinguir (money-path §2).
+          if (osAusenteNoOmie(erro)) {
+            result = { exists: false };
+          } else {
+            // Indeterminado responde `exists: true`, e isso NÃO é fabricar um fato: é o mesmo
+            // fail-safe que o consumidor já escolhe sozinho nas outras duas portas de falha
+            // (`checkOsExistsInOmie` devolve `{exists:true}` em erro de invoke e no catch —
+            // "assume exists on error"). O motivo é o efeito: `useAdminOrderDetail` faz
+            // `if (!osCheck.exists) → deleteOrderFromOmie()`, então QUALQUER valor falsy — `false`,
+            // `null`, `undefined` — apaga o pedido do cliente. Um campo novo `exists: null` seria
+            // falsy e viraria deleção por falha de rede; a flag separada preserva o diagnóstico
+            // sem tocar no predicado que decide (money-path §7 — a correção termina na tela).
+            result = {
+              exists: true,
+              indeterminado: true,
+              motivo: redigirSegredo(erro instanceof Error ? erro.message : String(erro)),
+            };
+          }
         }
         break;
       }
@@ -1533,30 +1605,48 @@ serve(async (req) => {
 
         // Outer loop também paraleliza (chunks de 5) pra não floodar API Omie.
         // ConsultarOS chama API externa; manter concorrência conservadora.
+        //
+        // ⚠️ Este laço DELETA o pedido de 6 tabelas. Antes, o `catch` deletava em QUALQUER
+        // exceção — timeout, rede, credencial revogada, rate-limit — e o ramo `if
+        // (consultaResult.faultstring)` dentro do try era código MORTO (o wrapper lança em
+        // faultstring), então 100% das deleções já vinham do catch genérico. Um incidente do
+        // Omie apagava a carteira de pedidos inteira, com `success:true`. E o guard de status
+        // recém-posto no wrapper AMPLIARIA isso: o 5xx que antes voltava `{}` (e por acidente
+        // não deletava) passa a lançar. Consertar a leitura sem consertar o consumidor torna o
+        // caminho ruim ALCANÇÁVEL — money-path §7, e aqui o efeito é destrutivo e irreversível.
+        //
+        // Regra: deleção exige PROVA POSITIVA de ausência (§1, precisão > recall). Falha de
+        // transporte é "não consegui verificar", nunca "não existe" — o pedido fica, e o
+        // resultado REPORTA quantos ficaram por verificar (ausência de sinal ≠ aprovação).
         const CHUNK = 5;
+        let naoVerificados = 0;
         for (let i = 0; i < (allOs || []).length; i += CHUNK) {
           const chunk = (allOs || []).slice(i, i + CHUNK);
           await Promise.all(chunk.map(async (os) => {
             try {
-              const consultaResult = await callOmieApi("servicos/os/", "ConsultarOS", {
+              await callOmieApi("servicos/os/", "ConsultarOS", {
                 nCodOS: os.omie_codigo_os,
-              }) as unknown as OmieConsultarOSResponse;
-
-              if (consultaResult.faultstring) {
-                console.log(`[Omie] OS ${os.omie_numero_os} não existe mais no Omie, excluindo localmente...`);
-                await deleteOrphanOs(os.order_id);
-                deletedCount++;
+              });
+              // 2xx sem faultstring = a OS EXISTE no Omie. Nada a fazer.
+            } catch (erro) {
+              if (!osAusenteNoOmie(erro)) {
+                naoVerificados++;
+                console.warn(
+                  `[Omie] OS ${os.omie_numero_os} NÃO verificada (mantida): ${redigirSegredo(erro instanceof Error ? erro.message : String(erro))}`,
+                );
+                return;
               }
-            } catch {
-              console.log(`[Omie] OS ${os.omie_numero_os} possivelmente excluída, removendo...`);
+              console.log(`[Omie] OS ${os.omie_numero_os} não existe mais no Omie, excluindo localmente...`);
               await deleteOrphanOs(os.order_id);
               deletedCount++;
             }
           }));
         }
 
-        console.log(`[Omie] Sincronização de exclusões concluída: ${deletedCount} pedidos removidos`);
-        result = { success: true, deleted: deletedCount };
+        console.log(
+          `[Omie] Sincronização de exclusões concluída: ${deletedCount} pedidos removidos, ${naoVerificados} não verificados`,
+        );
+        result = { success: true, deleted: deletedCount, nao_verificados: naoVerificados, parcial: naoVerificados > 0 };
         break;
       }
 

--- a/supabase/functions/process-nfe/index.ts
+++ b/supabase/functions/process-nfe/index.ts
@@ -112,8 +112,30 @@ async function callOmie(endpoint: string, call: string, params: Record<string, u
     throw new Error(`Resposta inválida da API Omie: ${text.substring(0, 300)}`);
   }
 
+  // `faultstring` ANTES do status (ordem canônica do #1614 — docs/agent/sync.md): o EOF do
+  // contrato Omie chega às vezes acompanhado de 5xx, e classificá-lo como falha de transporte
+  // apagaria a mensagem específica que o call-site usa para decidir.
   if (typeof data.faultstring === "string") {
     throw new Error(`Omie: ${data.faultstring}`);
+  }
+
+  // Sem faultstring, só um 2xx é resposta. `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo
+  // corpo parseia limpo (o `{}` de proxy/gateway) voltava daqui como resposta BOA, e cada
+  // consumidor lia o campo ausente como fato do Omie — nota sem itens, sem pedido casado, sem
+  // fornecedor. Site revelado ao trocar a janela fixa do gate G6 pelo escopo LÉXICO da função: o
+  // `.ok` que satisfazia o detector era o `!__auth.ok` do gate de AUTORIZAÇÃO do handler, 30
+  // linhas abaixo e em outra função — um objeto sem relação nenhuma com esta resposta HTTP. O
+  // zero medido aqui não era "auditado", era o detector lendo o guard errado (§"O DETECTOR mente").
+  if (!res.ok) {
+    throw new Error(`Omie: HTTP ${res.status} em ${call}`);
+  }
+
+  // `faultcode` sem `faultstring` fecha a ordem canônica do #1614. Aqui o efeito é o pior da
+  // família: os retornos de `AlterarRecebimento`/`AlterarEtapaRecebimento`/`ConcluirRecebimento`
+  // são IGNORADOS pelos call-sites, então um `200 {"faultcode":"5113"}` fazia a edge responder
+  // `success:true` sem nenhuma das mutações ter acontecido no ERP (achado Codex xhigh).
+  if (typeof data.faultcode === "string" || typeof data.faultcode === "number") {
+    throw new Error(`Omie: faultcode ${String(data.faultcode)} em ${call}`);
   }
 
   return data;

--- a/supabase/functions/verify-employee/index.ts
+++ b/supabase/functions/verify-employee/index.ts
@@ -63,6 +63,32 @@ async function callOmieApi(
   });
 
   const result = await response.json();
+
+  // `faultstring` ANTES do status (ordem canônica do #1614 — docs/agent/sync.md): este wrapper
+  // NÃO lança em fault, de propósito — quem separa a ausência legítima ("Nenhum registro" /
+  // "não encontrado" ⇒ CPF não cadastrado) do erro real é o call-site, pelo TEXTO. Como o EOF
+  // do contrato Omie chega às vezes acompanhado de 5xx, checar o status primeiro converteria
+  // "não é cliente" em exceção.
+  if (result.faultstring) return result;
+
+  // Sem faultstring, só um 2xx é resposta. `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo
+  // corpo parseia sem fault chegava ao call-site sem `clientes_cadastro`, e o
+  // `if (!clientes || clientes.length === 0)` respondia `isEmployee: false` — o Omie fora do ar
+  // virava o FATO "este CPF não é funcionário", indistinguível de uma consulta bem-sucedida.
+  // A mensagem não casa os marcadores de ausência do catch, então a falha SOBE em vez de virar
+  // veredito (money-path §2 — degradação honesta: ausente ≠ inexistente).
+  if (!response.ok) {
+    throw new Error(`Erro Omie: HTTP ${response.status} em ${call}`);
+  }
+
+  // `faultcode` sem `faultstring` fecha a ordem canônica do #1614: um `200 {"faultcode":"5113"}`
+  // chegava ao call-site sem `clientes_cadastro` e virava `isEmployee:false` — erro sinalizado
+  // pelo Omie lido como veredito sobre a pessoa (achado Codex xhigh). A mensagem não casa os
+  // marcadores de ausência do catch, então sobe em vez de virar "não é funcionário".
+  if (result.faultcode) {
+    throw new Error(`Erro Omie: faultcode ${result.faultcode} em ${call}`);
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Fecha a dívida `G6_DIVIDA` do gate `src/__tests__/paginacao-artesanal-gate.test.ts`, criada pelo #1615. A lista chegou a **zero**: a próxima entrada ali é reintrodução, não herança.

## O que a auditoria achou

Dos 6 baselinados, **só 4 eram furo**. Ler o consumo real era o trabalho — o detector acusava dois wrappers corretos e era cego para um terceiro que ninguém tinha olhado.

| Edge | Veredito | Efeito do 429/5xx que parseia limpo |
|---|---|---|
| `omie-sync` | **FURO (o mais caro)** | `IncluirOS` gravava a OS como `enviado` com `omie_codigo_os` undefined; `ListarClientes` via lista vazia (porta do cadastro duplicado) |
| `verify-employee` | **FURO** | virava o veredito "este CPF não é funcionário" |
| `omie-analytics-sync` | **FURO** | chegava aos laços sem total e sem lista → `complete` sobre retrato parcial |
| `analyze-unified-order` | **FURO leve** | perde o preço praticado (recall, não número fabricado — o Omie só preenche gap) |
| `omie-sync-nfes-recebidas` | ✅ correto | `classifyOmieResponse` completo → foi para `G6_ALLOW`, com justificativa |
| `omie-vendas-sync` | ✅ correto | `if (!response.ok) throw` na ordem canônica, longe demais para a janela fixa ver |

## O guard sozinho seria PIOR que o bug (money-path §7)

`sync_deleted_orders` apagava o pedido de **6 tabelas** (`orders`, `order_messages`, `order_reviews`, `loyalty_points`, `sending_quality_logs`, `omie_ordens_servico`) em **qualquer** exceção — e o ramo `if (consultaResult.faultstring)` dentro do `try` era **código morto** (o wrapper já lança em faultstring), então 100% das deleções vinham do `catch` genérico. Com o `!response.ok` novo, um 503 do Omie passaria a apagar a carteira inteira, com `success:true`.

Wrapper e consumidor foram juntos: deleção agora exige **prova positiva de ausência** (`osAusenteNoOmie`), falha de transporte é "não consegui verificar", e o resultado reporta `nao_verificados`. Mesma regra no `check_os_exists` — que devolve `exists:true` sob indeterminação, porque `useAdminOrderDetail:165` faz `if (!osCheck.exists) → deleta o pedido` e **qualquer** falsy (inclusive um `null` novo) apagaria dado por falha de rede. O aviso chega à tela.

## O detector: janela fixa → escopo léxico

A janela de 1200 chars errava nos dois sentidos, medido:

- **falso vermelho** — `omie-vendas-sync` tem o guard 1.942 chars abaixo do fetch (o retry inteiro vive no meio). Dívida falsa ensina a ignorar a lista.
- **falso verde, o caro** — em `process-nfe` o `.ok` que satisfazia o gate era o **`!__auth.ok` do gate de autorização do handler**, em outra função. O zero medido não era "auditado": era o detector lendo o guard errado.

Alargar a distância piora o segundo (a 4000, `verify-employee` também fica verde pelo mesmo mecanismo). O que separa os casos não é tamanho, é **escopo** — o guard de uma resposta tem de estar na função que fez o fetch. A janela agora vai até o `}` que fecha a função, truncada no próximo `await fetch(` e num teto. Isso **revelou `process-nfe`**, corrigido aqui em vez de baselinado.

## Challenge /codex (xhigh) — 6 achados, todos acatados

1. **[P1]** `osAusenteNoOmie` aceitava o EOF canônico como prova de deleção: `classificarFaultstring("Não existem registros para a página")` devolve `fim_de_pagina`, que eu não barrava, e normalizado casa `"nao existe"` → apagaria as 6 tabelas. Agora só `indeterminada` chega aos marcadores.
2. **[P1]** `classifyOmieResponse` aprovava **3xx** como `ok` (o `return {kind:"ok"}` cru depois de enumerar só as faixas de erro) — a `G6_ALLOW` estaria absolvendo um wrapper com buraco. Fechado + teste.
3. **[P1]** `faultcode` sem `faultstring` (HTTP 200) passava como sucesso nos 4 wrappers — no `process-nfe` isso dava `success:true` sem nenhuma mutação ter ocorrido no ERP. Ordem canônica fechada.
4. **[P2]** o comentário do analytics prometia preservar EOF, e aquele wrapper lança em toda faultstring — a ordem preserva a **mensagem**, não o fim. Comentário corrigido.
5. **[P2]** o mesmo comentário prometia backoff para "429/5xx"; o classificador local só conhece 500/502/503/504. Registrado como dívida preexistente, sem fingir cobertura.
6. **[P2]** `indeterminado` era diagnóstico morto no consumidor — agora chega ao toast.

## Gates

Baseline **28/28 verde**, e falsificado com 3 sabotagens sob `LC_ALL=C` **e** `pt_BR.UTF-8` (denominador 28 fixado em todas — o discriminador de "não rodou nada"):

| sabotagem | vermelho esperado | resultado |
|---|---|---|
| remove o guard de status do `omie-sync` | G6 acusa reintrodução | ✅ 1 vermelho, o G6 |
| teto 4000 → 1200 | falso-vermelho volta | ✅ 2 vermelhos: o G6 real **e** o controle (b) |
| remove o escopo léxico | `.ok` de outra função é aceito | ✅ 1 vermelho, o controle (a) |

A 1ª versão do controle (b) tinha 701 chars entre fetch e guard contra 1.942 do arquivo real, e ficou **verde** na sabotagem do teto — fixture mais curto que o código que representa é um detector que não conhece a forma real do repo. Corrigido, com assert de distância prendendo o comprimento.

## Deploy manual (Lovable)

**5 edges alteradas** — deploy pelo chat do Lovable, verbatim da main:
`omie-sync` · `verify-employee` · `omie-analytics-sync` · `analyze-unified-order` · `process-nfe` · `omie-sync-nfes-recebidas` (6, com o `retry.ts`)

**Publish do frontend** (toca `src/`): `omieService.ts` e `useAdminOrderDetail.ts`.

Sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
