### PR TITLE
fix(farmer): plano tático e argumentação saem do gateway Lovable — e param de fabricar conteúdo de venda [money-path]

### DIFF
--- a/src/hooks/__tests__/cluster-margin-cobertura.test.tsx
+++ b/src/hooks/__tests__/cluster-margin-cobertura.test.tsx
@@ -60,7 +60,11 @@ function recordRpc(fn: string, args: Record<string, unknown>): Promise<{ data: u
   rpcCalls.push({ fn, args });
   return Promise.resolve({ data: 'plan-1', error: null });
 }
-const invokeMock = vi.fn().mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+// O hook usa invokeFunction (não supabase.functions.invoke cru), para que o
+// motivo REAL da edge — créditos esgotados, geração truncada — chegue ao
+// usuário em vez do genérico "non-2xx". O helper devolve o corpo direto.
+const invokeMock = vi.fn().mockResolvedValue({ strategic_objective: 'upsell_premium' });
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: (...a: unknown[]) => invokeMock(...a) }));
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: { from: (t: string) => chain(t), rpc: (fn: string, args: Record<string, unknown>) => recordRpc(fn, args), functions: { invoke: (...a: unknown[]) => invokeMock(...a) } },
 }));

--- a/src/hooks/__tests__/cluster-margin-paginacao.test.tsx
+++ b/src/hooks/__tests__/cluster-margin-paginacao.test.tsx
@@ -90,7 +90,11 @@ function chain(table: string): unknown {
 }
 
 let rpcCalls: Array<{ fn: string; args: Record<string, unknown> }> = [];
-const invokeMock = vi.fn().mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+// O hook usa invokeFunction (não supabase.functions.invoke cru), para que o
+// motivo REAL da edge — créditos esgotados, geração truncada — chegue ao
+// usuário em vez do genérico "non-2xx". O helper devolve o corpo direto.
+const invokeMock = vi.fn().mockResolvedValue({ strategic_objective: 'upsell_premium' });
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: (...a: unknown[]) => invokeMock(...a) }));
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: (t: string) => chain(t),

--- a/src/hooks/__tests__/tactical-plan-posse-dono.test.tsx
+++ b/src/hooks/__tests__/tactical-plan-posse-dono.test.tsx
@@ -82,6 +82,9 @@ const h = vi.hoisted(() => ({
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: { from: (t: string) => chain(t), rpc: (fn: string, args: Record<string, unknown>) => recordRpc(fn, args), functions: { invoke: (...a: unknown[]) => h.invoke(...a) } },
 }));
+// O hook usa invokeFunction (não o invoke cru): é o que faz o motivo real da
+// edge chegar ao usuário. O helper devolve o corpo direto, sem {data,error}.
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: (...a: unknown[]) => h.invoke(...a) }));
 vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => ({ isImpersonating: false, effectiveUserId: VIEWER }) }));
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: VIEWER }, isStaff: true }) }));
 vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => h.toastError(...a), success: (...a: unknown[]) => h.toastSuccess(...a) } }));
@@ -92,9 +95,9 @@ beforeEach(() => {
   queries = [];
   rpcCalls = [];
   scoreFarmerId = OWNER;
-  h.invoke.mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+  h.invoke.mockResolvedValue({ strategic_objective: 'upsell_premium' });
   vi.clearAllMocks();
-  h.invoke.mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+  h.invoke.mockResolvedValue({ strategic_objective: 'upsell_premium' });
 });
 
 describe('generatePlan — POSSE do plano = DONO da carteira (não o executor)', () => {

--- a/src/hooks/useBundleArguments.ts
+++ b/src/hooks/useBundleArguments.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { toast } from 'sonner';
 import { margemConhecida } from '@/lib/scoring/margin';
 
@@ -76,23 +77,22 @@ export const useBundleArguments = () => {
     setGenerating(prev => ({ ...prev, [bundleKey]: true }));
 
     try {
-      const { data, error } = await supabase.functions.invoke('generate-bundle-argument', {
-        body: { bundle, customer, customerProfile },
+      // invokeFunction extrai o motivo REAL do corpo da resposta. O `data.error`
+      // de antes só pegava erro devolvido com status 200 — a edge agora responde
+      // 402/422, e com o invoke cru o motivo (créditos esgotados, geração
+      // truncada) virava o toast genérico "Erro ao gerar argumentação".
+      const argument = await invokeFunction<BundleArgument>('generate-bundle-argument', {
+        bundle, customer, customerProfile,
       });
-
-      if (error) throw error;
-
-      if (data?.error) {
-        toast.error(data.error);
-        return null;
-      }
-
-      const argument = data as BundleArgument;
       setArguments(prev => ({ ...prev, [bundleKey]: argument }));
       return argument;
     } catch (error) {
       console.error('Error generating argument:', error);
-      toast.error('Erro ao gerar argumentação');
+      const motivo = error instanceof Error && error.name === 'EdgeFunctionError' &&
+          !/non-2xx status code/i.test(error.message)
+        ? error.message
+        : null;
+      toast.error(motivo ?? 'Erro ao gerar argumentação');
       return null;
     } finally {
       setGenerating(prev => ({ ...prev, [bundleKey]: false }));

--- a/src/hooks/useDiagnosticQuestions.ts
+++ b/src/hooks/useDiagnosticQuestions.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
@@ -61,15 +62,13 @@ export const useDiagnosticQuestions = () => {
     setGenerating(prev => ({ ...prev, [bundleKey]: true }));
 
     try {
-      const { data, error } = await supabase.functions.invoke('generate-bundle-argument', {
-        body: { bundle, customer, customerProfile, mode: 'diagnostic_questions' },
-      });
-
-      if (error) throw error;
-      if (data?.error) {
-        toast.error(data.error);
-        return null;
-      }
+      // invokeFunction extrai o motivo REAL do corpo (ver useBundleArguments):
+      // a edge agora responde 402/422 e o `data.error` de antes só via erro
+      // devolvido com status 200.
+      const data = await invokeFunction<{ questions?: DiagnosticQuestion[] }>(
+        'generate-bundle-argument',
+        { bundle, customer, customerProfile, mode: 'diagnostic_questions' },
+      );
 
       const qs: QuestionWithResponse[] = (data.questions || []).map((q: DiagnosticQuestion) => ({
         ...q,
@@ -80,7 +79,11 @@ export const useDiagnosticQuestions = () => {
       return qs;
     } catch (error) {
       console.error('Error generating diagnostic questions:', error);
-      toast.error('Erro ao gerar perguntas diagnósticas');
+      const motivo = error instanceof Error && error.name === 'EdgeFunctionError' &&
+          !/non-2xx status code/i.test(error.message)
+        ? error.message
+        : null;
+      toast.error(motivo ?? 'Erro ao gerar perguntas diagnósticas');
       return null;
     } finally {
       setGenerating(prev => ({ ...prev, [bundleKey]: false }));

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
 import { margemConhecida, mediaMargensConhecidas } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
@@ -525,8 +526,12 @@ export const useTacticalPlan = () => {
         };
       }
 
-      const { data: aiPlan, error: aiError } = await supabase.functions.invoke<AiPlanResponse>('generate-tactical-plan', {
-        body: {
+      // invokeFunction (e não supabase.functions.invoke cru) porque o erro do
+      // supabase é sempre o genérico "non-2xx status code": o motivo REAL da
+      // edge — créditos esgotados, geração truncada — vem no corpo e só o
+      // helper o extrai. Com o invoke cru, o estouro de orçamento que motivou
+      // esta migração continuaria invisível para quem usa.
+      const aiPlan = await invokeFunction<AiPlanResponse>('generate-tactical-plan', {
           customerContext: {
             name: profile?.name,
             cnae: profile?.cnae,
@@ -548,10 +553,7 @@ export const useTacticalPlan = () => {
           diagnosticData,
           historicalObjections,
           planType,
-        },
       });
-
-      if (aiError) throw aiError;
 
       // Escrita via RPC-fronteira (#1037 + split de RLS): a posse (farmer_id) é re-resolvida
       // server-side de carteira_assignments e a RLS pós-split NEGA insert direto do client.

--- a/supabase/functions/_shared/anthropic.ts
+++ b/supabase/functions/_shared/anthropic.ts
@@ -23,20 +23,27 @@ export interface RespostaErro {
  */
 export function traduzirErroAnthropic(status: number | undefined): RespostaErro | null {
   switch (status) {
+    // 400 é REQUISIÇÃO INVÁLIDA — schema/parâmetro incompatível, quase sempre
+    // defeito nosso. Recusa do modelo por conteúdo NÃO chega como 400: vem numa
+    // resposta 200 com `stop_reason: "refusal"`. Chamar isto de "a IA recusou"
+    // mandaria a vendedora tentar outra foto quando o bug é do código.
     case 400:
-      return { http: 400, mensagem: "A IA recusou o conteúdo enviado." };
+      return { http: 500, mensagem: "Falha na requisição à IA — avise a equipe." };
     case 401:
     case 403:
     case 404:
       return { http: 500, mensagem: "IA mal configurada — avise a equipe." };
     case 402:
       return { http: 402, mensagem: "Créditos da IA esgotados — avise a equipe." };
+    case 409:
+      return { http: 409, mensagem: "Conflito momentâneo na IA. Tente novamente." };
     case 413:
       return { http: 413, mensagem: "Envio grande demais para a IA." };
     case 429:
       return { http: 429, mensagem: "Limite de requisições excedido. Tente novamente em alguns segundos." };
     case 500:
     case 503:
+    case 504:
     case 529:
       return { http: 503, mensagem: "IA sobrecarregada no momento. Tente de novo em instantes." };
     default:

--- a/supabase/functions/_shared/anthropic.ts
+++ b/supabase/functions/_shared/anthropic.ts
@@ -1,0 +1,87 @@
+// Peças comuns das chamadas à API da Anthropic nas edges — puras o bastante para
+// rodar sob `deno test --no-remote` (nada aqui importa o SDK; o cliente é
+// construído na própria edge).
+//
+// Existe porque o mapeamento de erro é sutil e errar nele é SILENCIOSO: sem o
+// 402, saldo esgotado vira "erro interno" e ninguém descobre que o problema é
+// crédito — foi exatamente o que aconteceu com o gateway do Lovable, cujo
+// estouro de orçamento derrubou as features de IA sem sinal claro.
+
+/** Modelo padrão das edges — ver convenção de LLM em edge no CLAUDE.md. */
+export const MODELO_PADRAO = "claude-sonnet-4-6";
+
+export interface RespostaErro {
+  http: number;
+  mensagem: string;
+}
+
+/**
+ * Traduz o status da API da Anthropic para a resposta que a edge devolve.
+ *
+ * `null` = não é erro conhecido da API: o caller deve tratar como falha interna
+ * (500) em vez de inventar uma mensagem tranquilizadora para o usuário.
+ */
+export function traduzirErroAnthropic(status: number | undefined): RespostaErro | null {
+  switch (status) {
+    case 400:
+      return { http: 400, mensagem: "A IA recusou o conteúdo enviado." };
+    case 401:
+    case 403:
+    case 404:
+      return { http: 500, mensagem: "IA mal configurada — avise a equipe." };
+    case 402:
+      return { http: 402, mensagem: "Créditos da IA esgotados — avise a equipe." };
+    case 413:
+      return { http: 413, mensagem: "Envio grande demais para a IA." };
+    case 429:
+      return { http: 429, mensagem: "Limite de requisições excedido. Tente novamente em alguns segundos." };
+    case 500:
+    case 503:
+    case 529:
+      return { http: 503, mensagem: "IA sobrecarregada no momento. Tente de novo em instantes." };
+    default:
+      return null;
+  }
+}
+
+/** Extrai o status HTTP de um erro do SDK sem assumir o formato. */
+export function statusDoErro(e: unknown): number | undefined {
+  const s = (e as { status?: unknown })?.status;
+  return typeof s === "number" ? s : undefined;
+}
+
+export type ResultadoToolUse =
+  | { ok: true; input: unknown }
+  | { ok: false; motivo: "ausente" | "multiplo"; quantidade: number };
+
+/**
+ * Exige EXATAMENTE um bloco `tool_use`.
+ *
+ * `tool_choice: {type:"tool"}` sozinho NÃO desliga chamada paralela — o modelo
+ * pode emitir vários blocos. Consumir só o primeiro entrega resultado PARCIAL
+ * com cara de completo. Mande `disable_parallel_tool_use: true` na chamada;
+ * este guard é a rede.
+ */
+export function extrairToolUseUnico(
+  blocos: ReadonlyArray<{ type: string; input?: unknown }>,
+): ResultadoToolUse {
+  const usos = (blocos ?? []).filter((b) => b?.type === "tool_use");
+  if (usos.length === 0) return { ok: false, motivo: "ausente", quantidade: 0 };
+  if (usos.length > 1) {
+    return { ok: false, motivo: "multiplo", quantidade: usos.length };
+  }
+  return { ok: true, input: usos[0].input };
+}
+
+/**
+ * Objeto utilizável a partir do `input` da tool.
+ *
+ * Forced tool-use garante que a ferramenta foi USADA, não que o schema foi
+ * respeitado (isso só com `strict:true`). Entrada que não é objeto vira `null`
+ * para o caller falhar explicitamente, em vez de seguir com campos `undefined`
+ * e gravar um registro vazio que parece preenchido.
+ */
+export function objetoDaTool(input: unknown): Record<string, unknown> | null {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  return input as Record<string, unknown>;
+}

--- a/supabase/functions/_shared/anthropic_test.ts
+++ b/supabase/functions/_shared/anthropic_test.ts
@@ -1,0 +1,111 @@
+// Testa o CÓDIGO REAL de _shared/anthropic.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/
+import {
+  extrairToolUseUnico,
+  objetoDaTool,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "./anthropic.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+// ───────────────────────── traduzirErroAnthropic ─────────────────────────
+
+Deno.test("402 é tratado — saldo esgotado não pode virar 'erro interno'", () => {
+  // Foi o estouro de orçamento silencioso que derrubou as features de IA.
+  const r = traduzirErroAnthropic(402);
+  assert(r !== null, "402 tem de ser reconhecido");
+  assertEquals(r!.http, 402);
+  assert(/[Cc]réditos/.test(r!.mensagem), "mensagem deveria citar créditos");
+});
+
+Deno.test("sobrecarga (500/503/529) vira 503, não repassa 500 cru", () => {
+  for (const s of [500, 503, 529]) {
+    assertEquals(traduzirErroAnthropic(s)!.http, 503, `status ${s}`);
+  }
+});
+
+Deno.test("erro de configuração (401/403/404) não vaza como problema do usuário", () => {
+  for (const s of [401, 403, 404]) {
+    const r = traduzirErroAnthropic(s)!;
+    assertEquals(r.http, 500, `status ${s}`);
+    assert(/equipe/.test(r.mensagem), "deveria mandar avisar a equipe");
+  }
+});
+
+Deno.test("429 e 413 têm resposta própria e acionável", () => {
+  assertEquals(traduzirErroAnthropic(429)!.http, 429);
+  assertEquals(traduzirErroAnthropic(413)!.http, 413);
+});
+
+Deno.test("status desconhecido devolve null — caller falha explícito", () => {
+  // Devolver uma mensagem tranquilizadora para status que não conhecemos
+  // esconderia falha nova; null obriga o caller a tratar como erro interno.
+  for (const s of [undefined, 0, 200, 418, 999]) {
+    assertEquals(traduzirErroAnthropic(s as number | undefined), null, `status ${s}`);
+  }
+});
+
+// ─────────────────────────────── statusDoErro ───────────────────────────────
+
+Deno.test("statusDoErro: lê number, ignora o resto", () => {
+  assertEquals(statusDoErro({ status: 429 }), 429);
+  assertEquals(statusDoErro({ status: "429" }), undefined);
+  assertEquals(statusDoErro(new Error("x")), undefined);
+  assertEquals(statusDoErro(null), undefined);
+  assertEquals(statusDoErro(undefined), undefined);
+});
+
+// ───────────────────────── extrairToolUseUnico ─────────────────────────
+
+Deno.test("um tool_use devolve o input", () => {
+  const r = extrairToolUseUnico([{ type: "text" }, { type: "tool_use", input: { a: 1 } }]);
+  assert(r.ok, "deveria aceitar");
+  if (!r.ok) return;
+  assertEquals(r.input, { a: 1 });
+});
+
+Deno.test("DOIS tool_use são recusados, não cortados em silêncio", () => {
+  const r = extrairToolUseUnico([
+    { type: "tool_use", input: { parte: 1 } },
+    { type: "tool_use", input: { parte: 2 } },
+  ]);
+  assert(!r.ok, "dois blocos têm de ser recusados");
+  if (r.ok) return;
+  assertEquals(r.motivo, "multiplo");
+  assertEquals(r.quantidade, 2);
+});
+
+Deno.test("nenhum tool_use é 'ausente', distinto de 'multiplo'", () => {
+  const r = extrairToolUseUnico([{ type: "text" }]);
+  assert(!r.ok, "deveria recusar");
+  if (r.ok) return;
+  assertEquals(r.motivo, "ausente");
+});
+
+Deno.test("lista vazia/inválida não explode", () => {
+  assertEquals(extrairToolUseUnico([]).ok, false);
+  assertEquals(
+    extrairToolUseUnico(null as unknown as { type: string }[]).ok,
+    false,
+  );
+});
+
+// ─────────────────────────────── objetoDaTool ───────────────────────────────
+
+Deno.test("objetoDaTool: só objeto passa", () => {
+  assertEquals(objetoDaTool({ a: 1 }), { a: 1 });
+  for (const v of [null, undefined, "texto", 42, [], [1, 2], true]) {
+    assertEquals(objetoDaTool(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});

--- a/supabase/functions/generate-bundle-argument/argumento-tools.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-tools.ts
@@ -1,0 +1,152 @@
+// Schemas das tools e normalização da saída — puro, sem import remoto
+// (roda sob `deno test --no-remote`, o `test:edges` do CI).
+//
+// Por que forced tool-use: o código antigo pedia JSON no texto, fazia
+// `content.match(/\{[\s\S]*\}/)` + `JSON.parse`, e no catch montava um objeto
+// de fallback com dois problemas graves:
+//
+//   versao_whatsapp: content.slice(0, 150)   ← texto CRU do modelo virando a
+//                                              mensagem enviada AO CLIENTE
+//   beneficio_economico: "Economia potencial identificada"  ← afirmação
+//                                              econômica fabricada
+//
+// Com tool-use o schema é satisfeito ou a chamada falha explícito — não existe
+// mensagem de WhatsApp montada a partir de raciocínio truncado do modelo.
+
+const TIPOS_SPIN = ["situacao", "problema", "implicacao", "direcionamento"] as const;
+
+export const TOOL_PERGUNTAS = {
+  name: "registrar_perguntas_diagnosticas",
+  description: "Registra as perguntas diagnósticas SPIN para validar hipóteses antes do bundle",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      questions: {
+        type: "array",
+        description: "Máximo 4 perguntas, uma por tipo SPIN",
+        items: {
+          type: "object" as const,
+          properties: {
+            type: { type: "string", enum: [...TIPOS_SPIN] },
+            main: { type: "string", description: "Pergunta principal" },
+            alt: { type: "string", description: "Variação alternativa adaptada ao perfil" },
+            rationale: { type: "string", description: "Por que esta pergunta é relevante" },
+          },
+          required: ["type", "main", "alt", "rationale"],
+        },
+      },
+    },
+    required: ["questions"],
+  },
+};
+
+export const TOOL_ARGUMENTO = {
+  name: "registrar_argumentacao",
+  description: "Registra a argumentação consultiva personalizada para a venda do bundle",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      diagnostico: { type: "string", description: "Diagnóstico implícito baseado no histórico" },
+      insight_tecnico: { type: "string", description: "Insight sobre o processo produtivo" },
+      beneficio_operacional: { type: "string", description: "Benefício operacional concreto" },
+      beneficio_economico: {
+        type: "string",
+        description:
+          "Benefício econômico. Use APENAS cifras presentes no contexto; sem número disponível, escreva de forma qualitativa — não estime economia, payback nem percentual.",
+      },
+      objecao_antecipada: { type: "string", description: "Objeção provável e resposta" },
+      versao_phone: { type: "string", description: "Script curto para ligação" },
+      versao_whatsapp: { type: "string", description: "Mensagem resumida para WhatsApp" },
+      versao_tecnica: { type: "string", description: "Versão técnica completa" },
+    },
+    required: [
+      "diagnostico",
+      "insight_tecnico",
+      "beneficio_operacional",
+      "beneficio_economico",
+      "objecao_antecipada",
+      "versao_phone",
+      "versao_whatsapp",
+      "versao_tecnica",
+    ],
+  },
+};
+
+function texto(valor: unknown): string {
+  return typeof valor === "string" ? valor.trim() : "";
+}
+
+export interface PerguntaSpin {
+  type: string;
+  main: string;
+  alt: string;
+  rationale: string;
+}
+
+/**
+ * Mantém só pergunta com tipo SPIN conhecido e enunciado não-vazio.
+ * Pergunta sem `main` apareceria como item em branco na tela da vendedora.
+ */
+export function normalizarPerguntas(bruto: unknown): PerguntaSpin[] {
+  const lista = (bruto as { questions?: unknown })?.questions;
+  if (!Array.isArray(lista)) return [];
+
+  const out: PerguntaSpin[] = [];
+  for (const cru of lista) {
+    if (!cru || typeof cru !== "object") continue;
+    const item = cru as Record<string, unknown>;
+    const tipo = texto(item.type).toLowerCase();
+    const main = texto(item.main);
+    if (!main) continue;
+    if (!(TIPOS_SPIN as readonly string[]).includes(tipo)) continue;
+    out.push({
+      type: tipo,
+      main,
+      alt: texto(item.alt),
+      rationale: texto(item.rationale),
+    });
+  }
+  return out;
+}
+
+export interface Argumentacao {
+  diagnostico: string;
+  insight_tecnico: string;
+  beneficio_operacional: string;
+  beneficio_economico: string;
+  objecao_antecipada: string;
+  versao_phone: string;
+  versao_whatsapp: string;
+  versao_tecnica: string;
+}
+
+/** Campos que vão para o cliente ou embasam a conversa — vazio invalida a saída. */
+export const CAMPOS_ESSENCIAIS = [
+  "diagnostico",
+  "versao_phone",
+  "versao_whatsapp",
+] as const;
+
+export function normalizarArgumentacao(bruto: unknown): Argumentacao | null {
+  if (!bruto || typeof bruto !== "object" || Array.isArray(bruto)) return null;
+  const o = bruto as Record<string, unknown>;
+
+  const arg: Argumentacao = {
+    diagnostico: texto(o.diagnostico),
+    insight_tecnico: texto(o.insight_tecnico),
+    beneficio_operacional: texto(o.beneficio_operacional),
+    beneficio_economico: texto(o.beneficio_economico),
+    objecao_antecipada: texto(o.objecao_antecipada),
+    versao_phone: texto(o.versao_phone),
+    versao_whatsapp: texto(o.versao_whatsapp),
+    versao_tecnica: texto(o.versao_tecnica),
+  };
+
+  // Sem os essenciais não há argumentação utilizável. Devolver o objeto pela
+  // metade faria a tela abrir com campos em branco e a vendedora mandar uma
+  // mensagem vazia para o cliente.
+  for (const campo of CAMPOS_ESSENCIAIS) {
+    if (!arg[campo]) return null;
+  }
+  return arg;
+}

--- a/supabase/functions/generate-bundle-argument/argumento-tools.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-tools.ts
@@ -120,11 +120,22 @@ export interface Argumentacao {
   versao_tecnica: string;
 }
 
-/** Campos que vão para o cliente ou embasam a conversa — vazio invalida a saída. */
+/**
+ * TODOS os campos são essenciais: a tela mostra as cinco linhas de argumentação
+ * e as três abas (phone/whatsapp/técnica) incondicionalmente, com botão de
+ * copiar. Campo vazio vira linha em branco que a vendedora copia e manda ao
+ * cliente. Como a geração é retriável e não há como recuperar um campo perdido,
+ * é tudo ou nada de verdade.
+ */
 export const CAMPOS_ESSENCIAIS = [
   "diagnostico",
+  "insight_tecnico",
+  "beneficio_operacional",
+  "beneficio_economico",
+  "objecao_antecipada",
   "versao_phone",
   "versao_whatsapp",
+  "versao_tecnica",
 ] as const;
 
 export function normalizarArgumentacao(bruto: unknown): Argumentacao | null {

--- a/supabase/functions/generate-bundle-argument/argumento-tools_test.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-tools_test.ts
@@ -1,0 +1,149 @@
+// Testa o CÓDIGO REAL de argumento-tools.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/generate-bundle-argument/
+//
+// Foco: `versao_whatsapp` é a mensagem que a vendedora ENVIA AO CLIENTE. O
+// fallback antigo a preenchia com `content.slice(0,150)` — texto cru do modelo.
+// Nada aqui pode deixar passar argumentação pela metade.
+import {
+  CAMPOS_ESSENCIAIS,
+  normalizarArgumentacao,
+  normalizarPerguntas,
+  TOOL_ARGUMENTO,
+  TOOL_PERGUNTAS,
+} from "./argumento-tools.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const ARG_COMPLETO = {
+  diagnostico: "Cliente com queda de recompra em abrasivos.",
+  insight_tecnico: "Provável desgaste prematuro por grão inadequado.",
+  beneficio_operacional: "Menos trocas de disco por turno.",
+  beneficio_economico: "Redução de paradas na linha.",
+  objecao_antecipada: "Preço acima do atual — responder com vida útil.",
+  versao_phone: "Olá, notei que a recompra de abrasivos caiu…",
+  versao_whatsapp: "Oi! Reparei uma queda no consumo de abrasivos 👀",
+  versao_tecnica: "Análise técnica completa do caso.",
+};
+
+// ───────────────────────────── schema das tools ─────────────────────────────
+
+Deno.test("schema: tools têm nomes DISTINTOS (o caller força uma por modo)", () => {
+  assert(
+    TOOL_PERGUNTAS.name !== TOOL_ARGUMENTO.name,
+    "nomes iguais fariam o modo errado ser forçado",
+  );
+});
+
+Deno.test("schema: os 8 campos da argumentação são obrigatórios", () => {
+  const req = TOOL_ARGUMENTO.input_schema.required as string[];
+  for (const campo of Object.keys(ARG_COMPLETO)) {
+    assert(req.includes(campo), `${campo} deveria ser required`);
+  }
+});
+
+Deno.test("schema: beneficio_economico instrui a NÃO estimar cifra", () => {
+  // Sem margem no contexto, qualquer número de economia seria fabricado.
+  const props = TOOL_ARGUMENTO.input_schema.properties as Record<
+    string,
+    { description?: string }
+  >;
+  const d = props.beneficio_economico.description ?? "";
+  assert(/não estime|qualitativa/i.test(d), "a descrição deveria proibir estimativa");
+});
+
+// ───────────────────────────── normalizarPerguntas ─────────────────────────────
+
+Deno.test("normalizarPerguntas: aceita os 4 tipos SPIN", () => {
+  const r = normalizarPerguntas({
+    questions: [
+      { type: "situacao", main: "a", alt: "x", rationale: "r" },
+      { type: "problema", main: "b", alt: "x", rationale: "r" },
+      { type: "implicacao", main: "c", alt: "x", rationale: "r" },
+      { type: "direcionamento", main: "d", alt: "x", rationale: "r" },
+    ],
+  });
+  assertEquals(r.length, 4);
+  assertEquals(r.map((q) => q.type), ["situacao", "problema", "implicacao", "direcionamento"]);
+});
+
+Deno.test("normalizarPerguntas: pergunta SEM enunciado é descartada", () => {
+  // Item em branco na tela da vendedora não é pergunta.
+  const r = normalizarPerguntas({
+    questions: [
+      { type: "situacao", main: "  ", alt: "x", rationale: "r" },
+      { type: "problema", alt: "x", rationale: "r" },
+      { type: "implicacao", main: "vale", alt: "x", rationale: "r" },
+    ],
+  });
+  assertEquals(r.length, 1);
+  assertEquals(r[0].main, "vale");
+});
+
+Deno.test("normalizarPerguntas: tipo SPIN desconhecido é descartado", () => {
+  const r = normalizarPerguntas({
+    questions: [
+      { type: "fechamento", main: "a", alt: "x", rationale: "r" },
+      { type: "", main: "b", alt: "x", rationale: "r" },
+    ],
+  });
+  assertEquals(r.length, 0);
+});
+
+Deno.test("normalizarPerguntas: entrada inválida degrada para lista vazia", () => {
+  for (const v of [null, undefined, {}, { questions: "três" }, { questions: null }, "x"]) {
+    assertEquals(normalizarPerguntas(v), [], `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("normalizarPerguntas: alt/rationale ausentes viram vazio, não undefined", () => {
+  const r = normalizarPerguntas({ questions: [{ type: "situacao", main: "a" }] });
+  assertEquals(r[0].alt, "");
+  assertEquals(r[0].rationale, "");
+});
+
+// ──────────────────────────── normalizarArgumentacao ────────────────────────────
+
+Deno.test("normalizarArgumentacao: saída completa passa inteira", () => {
+  assertEquals(normalizarArgumentacao(ARG_COMPLETO), ARG_COMPLETO);
+});
+
+Deno.test("normalizarArgumentacao: versao_whatsapp VAZIA invalida tudo", () => {
+  // É a mensagem enviada ao cliente — melhor erro explícito que mensagem vazia.
+  assertEquals(normalizarArgumentacao({ ...ARG_COMPLETO, versao_whatsapp: "" }), null);
+  assertEquals(normalizarArgumentacao({ ...ARG_COMPLETO, versao_whatsapp: "   " }), null);
+});
+
+Deno.test("normalizarArgumentacao: cada campo essencial ausente invalida", () => {
+  for (const campo of CAMPOS_ESSENCIAIS) {
+    const parcial = { ...ARG_COMPLETO } as Record<string, unknown>;
+    delete parcial[campo];
+    assertEquals(normalizarArgumentacao(parcial), null, `sem ${campo}`);
+  }
+});
+
+Deno.test("normalizarArgumentacao: campo NÃO essencial vazio não derruba a saída", () => {
+  const r = normalizarArgumentacao({ ...ARG_COMPLETO, insight_tecnico: "" });
+  assert(r !== null, "não deveria invalidar por campo secundário");
+  assertEquals(r!.insight_tecnico, "");
+});
+
+Deno.test("normalizarArgumentacao: não-objeto vira null", () => {
+  for (const v of [null, undefined, "texto", 42, [], true]) {
+    assertEquals(normalizarArgumentacao(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("normalizarArgumentacao: campo não-string não vira texto acidental", () => {
+  // `{diagnostico: 42}` não pode virar "42" no material que vai ao cliente.
+  assertEquals(normalizarArgumentacao({ ...ARG_COMPLETO, diagnostico: 42 }), null);
+});

--- a/supabase/functions/generate-bundle-argument/argumento-tools_test.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-tools_test.ts
@@ -131,10 +131,16 @@ Deno.test("normalizarArgumentacao: cada campo essencial ausente invalida", () =>
   }
 });
 
-Deno.test("normalizarArgumentacao: campo NÃO essencial vazio não derruba a saída", () => {
-  const r = normalizarArgumentacao({ ...ARG_COMPLETO, insight_tecnico: "" });
-  assert(r !== null, "não deveria invalidar por campo secundário");
-  assertEquals(r!.insight_tecnico, "");
+Deno.test("normalizarArgumentacao: TODOS os 8 campos são exigidos", () => {
+  // A tela mostra as 5 linhas e as 3 abas incondicionalmente, com botão de
+  // copiar: campo vazio vira texto em branco que a vendedora manda ao cliente.
+  for (const campo of Object.keys(ARG_COMPLETO)) {
+    assertEquals(
+      normalizarArgumentacao({ ...ARG_COMPLETO, [campo]: "" }),
+      null,
+      `${campo} vazio deveria invalidar`,
+    );
+  }
 });
 
 Deno.test("normalizarArgumentacao: não-objeto vira null", () => {

--- a/supabase/functions/generate-bundle-argument/index.ts
+++ b/supabase/functions/generate-bundle-argument/index.ts
@@ -119,6 +119,9 @@ Histórico de compras recentes: ${customer.recentProducts?.join(', ') || 'Sem da
         resposta = await anthropic.messages.create({
           model: MODELO_PADRAO,
           max_tokens: 2000,
+          // Explícito: omitir usaria o default 1 da API. Material comercial pede
+          // baixa variabilidade — e o Gemini anterior não tinha o mesmo default.
+          temperature: 0.4,
           system: systemPrompt,
           tools: [TOOL_PERGUNTAS],
           tool_choice: { type: "tool", name: TOOL_PERGUNTAS.name, disable_parallel_tool_use: true },
@@ -211,6 +214,9 @@ Histórico de compras recentes do cliente: ${customer.recentProducts?.join(', ')
       resposta = await anthropic.messages.create({
         model: MODELO_PADRAO,
         max_tokens: 2000,
+        // Explícito: omitir usaria o default 1 da API. Material comercial pede
+        // baixa variabilidade — e o Gemini anterior não tinha o mesmo default.
+        temperature: 0.4,
         system: systemPrompt,
         tools: [TOOL_ARGUMENTO],
         tool_choice: { type: "tool", name: TOOL_ARGUMENTO.name, disable_parallel_tool_use: true },

--- a/supabase/functions/generate-bundle-argument/index.ts
+++ b/supabase/functions/generate-bundle-argument/index.ts
@@ -1,5 +1,18 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import {
+  extrairToolUseUnico,
+  MODELO_PADRAO,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "../_shared/anthropic.ts";
+import {
+  normalizarArgumentacao,
+  normalizarPerguntas,
+  TOOL_ARGUMENTO,
+  TOOL_PERGUNTAS,
+} from "./argumento-tools.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -24,8 +37,9 @@ serve(async (req) => {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
+    const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!ANTHROPIC_API_KEY) throw new Error("ANTHROPIC_API_KEY is not configured");
+    const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
     const { bundle, customer, customerProfile, mode } = await req.json();
 
@@ -100,50 +114,48 @@ Confidence: ${(bundle.confidence * 100).toFixed(1)}%
 
 Histórico de compras recentes: ${customer.recentProducts?.join(', ') || 'Sem dados'}`;
 
-      const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${LOVABLE_API_KEY}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "google/gemini-2.5-flash",
-          messages: [
-            { role: "system", content: systemPrompt },
-            { role: "user", content: userPrompt },
-          ],
-        }),
-      });
-
-      if (!response.ok) {
-        if (response.status === 429) {
-          return new Response(JSON.stringify({ error: "Rate limit exceeded. Tente novamente em alguns segundos." }), {
-            status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" },
-          });
-        }
-        if (response.status === 402) {
-          return new Response(JSON.stringify({ error: "Créditos insuficientes. Adicione créditos ao workspace." }), {
-            status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" },
-          });
-        }
-        const t = await response.text();
-        console.error("AI gateway error:", response.status, t);
-        throw new Error(`AI gateway error: ${response.status}`);
-      }
-
-      const data = await response.json();
-      const content = data.choices?.[0]?.message?.content || "";
-
-      let parsed;
+      let resposta;
       try {
-        const jsonMatch = content.match(/\{[\s\S]*\}/);
-        parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : JSON.parse(content);
-      } catch {
-        console.error("Failed to parse AI response:", content);
-        parsed = { questions: [] };
+        resposta = await anthropic.messages.create({
+          model: MODELO_PADRAO,
+          max_tokens: 2000,
+          system: systemPrompt,
+          tools: [TOOL_PERGUNTAS],
+          tool_choice: { type: "tool", name: TOOL_PERGUNTAS.name, disable_parallel_tool_use: true },
+          messages: [{ role: "user", content: userPrompt }],
+        });
+      } catch (e: unknown) {
+        const status = statusDoErro(e);
+        console.error("[generate-bundle-argument] erro na API (perguntas):", status, e instanceof Error ? e.message : e);
+        const mapeado = traduzirErroAnthropic(status);
+        return new Response(JSON.stringify({ error: mapeado?.mensagem ?? "Erro ao gerar perguntas" }), {
+          status: mapeado?.http ?? 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
       }
 
-      return new Response(JSON.stringify(parsed), {
+      // Truncou = perguntas cortadas no meio. Entregar as que couberam faria a
+      // vendedora ir para a visita com um roteiro SPIN incompleto achando que
+      // está inteiro.
+      if (resposta.stop_reason === "max_tokens") {
+        console.error("[generate-bundle-argument] perguntas truncadas");
+        return new Response(JSON.stringify({ error: "Geração truncada. Tente novamente." }), {
+          status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+
+      // ANTES: `JSON.parse` do texto e, no catch, `{ questions: [] }` — lista
+      // vazia silenciosa que a tela mostrava como "sem perguntas" em vez de
+      // "não consegui gerar".
+      const extraido = extrairToolUseUnico(resposta.content);
+      const perguntas = extraido.ok ? normalizarPerguntas(extraido.input) : [];
+      if (perguntas.length === 0) {
+        console.error("[generate-bundle-argument] sem perguntas utilizáveis");
+        return new Response(JSON.stringify({ error: "A IA não devolveu perguntas utilizáveis. Tente novamente." }), {
+          status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ questions: perguntas }), {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
@@ -194,56 +206,46 @@ Lift: ${bundle.lift.toFixed(2)}
 
 Histórico de compras recentes do cliente: ${customer.recentProducts?.join(', ') || 'Sem dados'}`;
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "google/gemini-2.5-flash",
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-      }),
-    });
-
-    if (!response.ok) {
-      if (response.status === 429) {
-        return new Response(JSON.stringify({ error: "Rate limit exceeded. Tente novamente em alguns segundos." }), {
-          status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      if (response.status === 402) {
-        return new Response(JSON.stringify({ error: "Créditos insuficientes. Adicione créditos ao workspace." }), {
-          status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      const t = await response.text();
-      console.error("AI gateway error:", response.status, t);
-      throw new Error(`AI gateway error: ${response.status}`);
+    let resposta;
+    try {
+      resposta = await anthropic.messages.create({
+        model: MODELO_PADRAO,
+        max_tokens: 2000,
+        system: systemPrompt,
+        tools: [TOOL_ARGUMENTO],
+        tool_choice: { type: "tool", name: TOOL_ARGUMENTO.name, disable_parallel_tool_use: true },
+        messages: [{ role: "user", content: userPrompt }],
+      });
+    } catch (e: unknown) {
+      const status = statusDoErro(e);
+      console.error("[generate-bundle-argument] erro na API (argumento):", status, e instanceof Error ? e.message : e);
+      const mapeado = traduzirErroAnthropic(status);
+      return new Response(JSON.stringify({ error: mapeado?.mensagem ?? "Erro ao gerar argumentação" }), {
+        status: mapeado?.http ?? 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content || "";
+    // Truncou = argumentação cortada. As versões phone/whatsapp são os últimos
+    // campos do schema, então é justamente o texto que vai ao cliente que some.
+    if (resposta.stop_reason === "max_tokens") {
+      console.error("[generate-bundle-argument] argumentação truncada");
+      return new Response(JSON.stringify({ error: "Geração truncada. Tente novamente." }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
 
-    let parsed;
-    try {
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : JSON.parse(content);
-    } catch {
-      console.error("Failed to parse AI response:", content);
-      parsed = {
-        diagnostico: "Análise em processamento",
-        insight_tecnico: "Consulte dados técnicos",
-        beneficio_operacional: "Melhoria operacional esperada",
-        beneficio_economico: "Economia potencial identificada",
-        objecao_antecipada: "Avalie custo-benefício",
-        versao_phone: content.slice(0, 200),
-        versao_whatsapp: content.slice(0, 150),
-        versao_tecnica: content,
-      };
+    // ANTES: no catch do JSON.parse, `versao_whatsapp` virava `content.slice(0,150)`
+    // — o texto CRU do modelo (raciocínio, markdown quebrado, JSON pela metade)
+    // como mensagem enviada AO CLIENTE — e `beneficio_economico` virava
+    // "Economia potencial identificada", uma afirmação econômica fabricada.
+    // Com tool-use, ou o schema é satisfeito, ou a edge falha explícito.
+    const extraido = extrairToolUseUnico(resposta.content);
+    const parsed = extraido.ok ? normalizarArgumentacao(extraido.input) : null;
+    if (!parsed) {
+      console.error("[generate-bundle-argument] sem argumentação utilizável");
+      return new Response(JSON.stringify({ error: "A IA não devolveu uma argumentação utilizável. Tente novamente." }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     return new Response(JSON.stringify(parsed), {

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -9,7 +9,7 @@ import {
   statusDoErro,
   traduzirErroAnthropic,
 } from "../_shared/anthropic.ts";
-import { normalizarPlano, planoTemConteudo, toolDoModo } from "./plano-tools.ts";
+import { normalizarPlano, objetivoFinal, planoTemConteudo, toolDoModo } from "./plano-tools.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { avaliarCanariaMargem, calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
 import { inicioDiaOperacional } from "../_shared/dia-operacional.ts";
@@ -354,7 +354,7 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
     }
 
     const plan = normalizarPlano(bruto);
-    if (!planoTemConteudo(plan)) {
+    if (!planoTemConteudo(plan, mode)) {
       console.error('[generate-tactical-plan] plano sem conteúdo acionável');
       return new Response(
         JSON.stringify({ error: 'A IA devolveu um plano vazio. Tente novamente.' }),
@@ -376,6 +376,20 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
       // current_margin_pct/cluster_avg_margin_pct são nullable — o plano grava "não sei"
       // em vez de um número, e a UI mostra "—" em vez de uma margem inventada.
       const d = (body as { _derived: Record<string, number | string | null> })._derived;
+
+      // "sem_historico → ativacao" é fato medido, não heurística: se a IA
+      // devolveu outro objetivo (passa no enum, contradiz o fato), o servidor
+      // vence — plano de recuperação pressupõe relação que nunca existiu.
+      const { objetivo: objetivoDoPlano, sobrescrito } = objetivoFinal(
+        plan.strategic_objective,
+        typeof d.strategicObjective === 'string' ? d.strategicObjective : null,
+      );
+      if (sobrescrito) {
+        console.warn(
+          `[generate-tactical-plan] objetivo da IA "${plan.strategic_objective}" descartado: cliente ${body.customerId} é sem_historico (servidor: ativacao)`,
+        );
+      }
+
       const { data: newId, error: rpcErr } = await admin.rpc('criar_plano_tatico', {
         _customer_user_id: body.customerId,
         _expected_owner: body.farmerId,
@@ -383,7 +397,7 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
           bundle_recommendation_id: (topBundleRow as { id?: string } | null)?.id ?? null,
           health_score: d.healthScore, churn_risk: d.churnRisk, mix_gap: d.mixGap,
           current_margin_pct: d.marginPct, cluster_avg_margin_pct: d.clusterMargin, expansion_potential: d.expansionPotential,
-          strategic_objective: plan.strategic_objective || d.strategicObjective, customer_profile: d.customerProfile, plan_type: mode,
+          strategic_objective: objetivoDoPlano, customer_profile: d.customerProfile, plan_type: mode,
           top_bundle: (topBundleRow ? topBundleRow.bundle_products : {}),
           second_bundle: (secondBundleRow ? (secondBundleRow as { bundle_products: unknown }).bundle_products : {}),
           bundle_lie: Number((topBundleRow as { lie_bundle?: unknown } | null)?.lie_bundle ?? 0),

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -1,6 +1,15 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import {
+  extrairToolUseUnico,
+  MODELO_PADRAO,
+  objetoDaTool,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "../_shared/anthropic.ts";
+import { normalizarPlano, planoTemConteudo, toolDoModo } from "./plano-tools.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { avaliarCanariaMargem, calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
 import { inicioDiaOperacional } from "../_shared/dia-operacional.ts";
@@ -199,8 +208,8 @@ serve(async (req) => {
       (body as Record<string, unknown>)._derived = { healthScore, churnRisk, mixGap, marginPct, clusterMargin, expansionPotential: num(score.expansion_score), customerProfile, strategicObjective };
     }
 
-    const LOVABLE_API_KEY = Deno.env.get('LOVABLE_API_KEY');
-    if (!LOVABLE_API_KEY) {
+    const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY');
+    if (!ANTHROPIC_API_KEY) {
       return new Response(
         JSON.stringify({ error: 'AI não configurada' }),
         { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -296,69 +305,65 @@ ${JSON.stringify(diagnosticData || {}, null, 2)}
 Objeções históricas do cluster:
 ${JSON.stringify(historicalObjections || [], null, 2)}`;
 
-    const response = await fetch('https://ai.gateway.lovable.dev/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${LOVABLE_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'google/gemini-3-flash-preview',
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: userPrompt },
-        ],
+    const tool = toolDoModo(mode);
+    let resposta;
+    try {
+      resposta = await new Anthropic({ apiKey: ANTHROPIC_API_KEY }).messages.create({
+        model: MODELO_PADRAO,
+        max_tokens: 4000,
         temperature: 0.4,
-      }),
-    });
-
-    if (!response.ok) {
-      const errText = await response.text();
-      console.error('AI error:', response.status, errText);
-      
-      if (response.status === 429) {
-        return new Response(
-          JSON.stringify({ error: 'Limite de requisições excedido. Tente novamente em alguns segundos.' }),
-          { status: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-      if (response.status === 402) {
-        return new Response(
-          JSON.stringify({ error: 'Créditos de IA esgotados.' }),
-          { status: 402, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-        );
-      }
-      
+        system: systemPrompt,
+        tools: [tool],
+        // Sem `disable_parallel_tool_use` o modelo poderia devolver o plano em
+        // vários blocos e o consumo pegaria só um pedaço.
+        tool_choice: { type: 'tool', name: tool.name, disable_parallel_tool_use: true },
+        messages: [{ role: 'user', content: userPrompt }],
+      });
+    } catch (e: unknown) {
+      const status = statusDoErro(e);
+      console.error('[generate-tactical-plan] erro na API da Anthropic:', status, e instanceof Error ? e.message : e);
+      const mapeado = traduzirErroAnthropic(status);
       return new Response(
-        JSON.stringify({ error: 'Erro na geração do plano tático' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: mapeado?.mensagem ?? 'Erro na geração do plano tático' }),
+        { status: mapeado?.http ?? 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const aiResult = await response.json();
-    const content = aiResult.choices?.[0]?.message?.content || '';
+    // Truncou = plano cortado no meio. Gravar metade dele entregaria à vendedora
+    // uma tela preenchida sem as objeções/perguntas que faltaram.
+    if (resposta.stop_reason === 'max_tokens') {
+      console.error('[generate-tactical-plan] resposta truncada');
+      return new Response(
+        JSON.stringify({ error: 'Plano truncado na geração. Tente novamente.' }),
+        { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
-    let plan;
-    try {
-      const cleanContent = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-      plan = JSON.parse(cleanContent);
-    } catch {
-      plan = {
-        strategic_objective: 'expansao_mix',
-        approach_strategy: 'Abordagem consultiva padrão.',
-        diagnostic_questions: [
-          { question: 'Como está o ritmo de produção atualmente?', purpose: 'Entender contexto', expected_insight: 'Volume de trabalho' },
-          { question: 'Quais ferramentas mais utilizam no dia a dia?', purpose: 'Mapear mix', expected_insight: 'Oportunidades de cross-sell' },
-          { question: 'Têm tido algum problema com durabilidade das afiações?', purpose: 'Identificar dores', expected_insight: 'Qualidade percebida' },
-        ],
-        implication_question: 'Quanto isso impacta na produtividade mensal da equipe?',
-        offer_transition: 'Com base no que você me contou, temos uma solução que pode ajudar...',
-        probable_objections: [],
-      };
+    // ANTES: pedia JSON no texto, fazia JSON.parse e, no catch, montava um plano
+    // GENÉRICO que era gravado como se fosse gerado para este cliente. Agora não
+    // existe plano inventado: sem tool_use válido, a edge falha explícito.
+    const extraido = extrairToolUseUnico(resposta.content);
+    const bruto = extraido.ok ? objetoDaTool(extraido.input) : null;
+    if (!bruto) {
+      const motivo = extraido.ok ? 'input_invalido' : extraido.motivo;
+      console.error('[generate-tactical-plan] sem plano utilizável:', motivo);
+      return new Response(
+        JSON.stringify({ error: 'A IA não devolveu um plano utilizável. Tente novamente.' }),
+        { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const plan = normalizarPlano(bruto);
+    if (!planoTemConteudo(plan)) {
+      console.error('[generate-tactical-plan] plano sem conteúdo acionável');
+      return new Response(
+        JSON.stringify({ error: 'A IA devolveu um plano vazio. Tente novamente.' }),
+        { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
     }
 
     // Add plan_type to response
-    plan.plan_type = mode;
+    const planComTipo = { ...plan, plan_type: mode };
 
     // Modo self-contained (cron): grava o plano via RPC-fronteira criar_plano_tatico.
     // A posse (farmer_id) é re-resolvida server-side de carteira_assignments — não confiamos
@@ -402,7 +407,7 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
     }
 
     return new Response(
-      JSON.stringify(plan),
+      JSON.stringify(planComTipo),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (error) {

--- a/supabase/functions/generate-tactical-plan/plano-tools.ts
+++ b/supabase/functions/generate-tactical-plan/plano-tools.ts
@@ -1,0 +1,234 @@
+// Schema da tool e normalização do plano tático — puro, sem import remoto
+// (roda sob `deno test --no-remote`, o `test:edges` do CI).
+//
+// Por que forced tool-use: o código antigo pedia "retorne APENAS o JSON" no
+// texto e fazia `JSON.parse` depois de raspar ```json. Quando o parse falhava,
+// montava um plano GENÉRICO ("Abordagem consultiva padrão", perguntas padrão) —
+// que no modo cron era GRAVADO via criar_plano_tatico sem nenhuma marca de
+// fallback. A vendedora abria o plano do cliente e lia recomendação genérica
+// achando que era análise daquele cliente. Com tool-use, ou o schema é
+// satisfeito, ou é erro explícito: não existe plano inventado.
+//
+// Money-path do schema: o prompt manda deixar `null` quando a margem não está
+// medida ("NUNCA estime, preencha ou infira"). Portanto os campos de projeção
+// são NULLABLE de propósito — um schema que os obrigasse forçaria exatamente a
+// fabricação que o prompt proíbe.
+
+export const OBJETIVOS_ESTRATEGICOS = [
+  "ativacao",
+  "recuperacao",
+  "expansao_mix",
+  "upsell_premium",
+  "reativacao",
+  "consolidacao_margem",
+] as const;
+
+export type ObjetivoEstrategico = (typeof OBJETIVOS_ESTRATEGICOS)[number];
+
+const PERGUNTA_DIAGNOSTICA = {
+  type: "object" as const,
+  properties: {
+    question: { type: "string", description: "Pergunta diagnóstica" },
+    purpose: { type: "string", description: "Por que fazer essa pergunta" },
+    expected_insight: { type: "string", description: "O que esperar da resposta" },
+  },
+  required: ["question", "purpose", "expected_insight"],
+};
+
+const OBJECAO = {
+  type: "object" as const,
+  properties: {
+    objection: { type: "string", description: "Objeção provável" },
+    technical_response: { type: "string", description: "Resposta técnica" },
+    economic_response: { type: "string", description: "Resposta econômica" },
+    probability: { type: "number", description: "Probabilidade de 0 a 100" },
+  },
+  required: ["objection", "technical_response", "economic_response", "probability"],
+};
+
+/** Campos comuns aos dois modos. */
+const BASE = {
+  strategic_objective: {
+    type: "string",
+    enum: [...OBJETIVOS_ESTRATEGICOS],
+    description:
+      "Objetivo estratégico. Se salesHistoryStatus for 'sem_historico', use 'ativacao' — não assuma relação prévia.",
+  },
+  approach_strategy: { type: "string", description: "Abordagem ideal" },
+  diagnostic_questions: {
+    type: "array",
+    items: PERGUNTA_DIAGNOSTICA,
+    description: "Exatamente 3 perguntas diagnósticas",
+  },
+  probable_objections: { type: "array", items: OBJECAO },
+};
+
+export const TOOL_PLANO_ESSENCIAL = {
+  name: "registrar_plano_tatico",
+  description: "Registra o Plano Tático ESSENCIAL (rápido) para o vendedor",
+  input_schema: {
+    type: "object" as const,
+    properties: { ...BASE },
+    required: [
+      "strategic_objective",
+      "approach_strategy",
+      "diagnostic_questions",
+      "probable_objections",
+    ],
+  },
+};
+
+export const TOOL_PLANO_ESTRATEGICO = {
+  name: "registrar_plano_tatico",
+  description: "Registra o Plano Tático ESTRATÉGICO COMPLETO para o vendedor",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      ...BASE,
+      approach_strategy_b: {
+        type: "string",
+        description: "Abordagem alternativa caso a principal falhe",
+      },
+      implication_question: {
+        type: "string",
+        description: "Pergunta de implicação (impacto financeiro/operacional)",
+      },
+      offer_transition: { type: "string", description: "Transição para a oferta do bundle" },
+      // NULLABLE de propósito: projetar faturamento sobre dado ausente entrega
+      // à vendedora um número que parece medido e não é.
+      ltv_projection: {
+        type: ["object", "null"],
+        description: "null se não houver base medida para projetar",
+        properties: {
+          current_annual: { type: ["number", "null"] },
+          projected_annual: { type: ["number", "null"] },
+          growth_pct: { type: ["number", "null"] },
+        },
+      },
+      // NULLABLE nos três cenários: é o que o prompt exige quando a margem
+      // atual do cliente é null (não medida).
+      expected_result: {
+        type: ["object", "null"],
+        description: "null (ou os três cenários null) quando a margem não está medida",
+        properties: {
+          best_case_margin: { type: ["number", "null"] },
+          likely_margin: { type: ["number", "null"] },
+          worst_case_margin: { type: ["number", "null"] },
+        },
+      },
+      operational_risks: { type: "array", items: { type: "string" } },
+    },
+    required: [
+      "strategic_objective",
+      "approach_strategy",
+      "approach_strategy_b",
+      "diagnostic_questions",
+      "implication_question",
+      "offer_transition",
+      "probable_objections",
+    ],
+  },
+};
+
+export function toolDoModo(mode: string) {
+  return mode === "estrategico" ? TOOL_PLANO_ESTRATEGICO : TOOL_PLANO_ESSENCIAL;
+}
+
+/** Número medido ou `null` — nunca 0 como substituto de "não sei". */
+export function numeroOuNulo(valor: unknown): number | null {
+  if (typeof valor === "number") return Number.isFinite(valor) ? valor : null;
+  if (typeof valor === "string") {
+    const t = valor.trim();
+    if (!/^-?\d+(\.\d+)?$/.test(t)) return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+export interface ProjecaoNormalizada {
+  [campo: string]: number | null;
+}
+
+/**
+ * Normaliza um objeto de projeção (ltv_projection / expected_result).
+ * Devolve `null` quando o objeto inteiro está ausente, e mantém `null` campo a
+ * campo — a UI mostra "—" em vez de um número que ninguém mediu.
+ */
+export function normalizarProjecao(
+  bruto: unknown,
+  campos: readonly string[],
+): ProjecaoNormalizada | null {
+  if (!bruto || typeof bruto !== "object" || Array.isArray(bruto)) return null;
+  const origem = bruto as Record<string, unknown>;
+  const out: ProjecaoNormalizada = {};
+  let algumMedido = false;
+  for (const campo of campos) {
+    const n = numeroOuNulo(origem[campo]);
+    out[campo] = n;
+    if (n !== null) algumMedido = true;
+  }
+  // Nenhum campo medido: é "não sei" inteiro, não uma projeção de zeros.
+  return algumMedido ? out : null;
+}
+
+export const CAMPOS_LTV = ["current_annual", "projected_annual", "growth_pct"] as const;
+export const CAMPOS_RESULTADO = [
+  "best_case_margin",
+  "likely_margin",
+  "worst_case_margin",
+] as const;
+
+export interface PlanoNormalizado {
+  strategic_objective: string | null;
+  approach_strategy: string;
+  approach_strategy_b: string;
+  diagnostic_questions: unknown[];
+  implication_question: string;
+  offer_transition: string;
+  probable_objections: unknown[];
+  ltv_projection: ProjecaoNormalizada | null;
+  expected_result: ProjecaoNormalizada | null;
+  operational_risks: unknown[];
+}
+
+function texto(valor: unknown): string {
+  return typeof valor === "string" ? valor.trim() : "";
+}
+
+function lista(valor: unknown): unknown[] {
+  return Array.isArray(valor) ? valor : [];
+}
+
+/**
+ * Normaliza a saída da tool para o formato que a RPC/UI consomem.
+ *
+ * `strategic_objective` fora do enum vira `null` — o caller decide se cai no
+ * objetivo derivado server-side (que é medido) em vez de aceitar um rótulo
+ * inventado que mudaria a estratégia de abordagem do cliente.
+ */
+export function normalizarPlano(bruto: Record<string, unknown>): PlanoNormalizado {
+  const objetivo = texto(bruto.strategic_objective);
+  const objetivoValido = (OBJETIVOS_ESTRATEGICOS as readonly string[]).includes(objetivo);
+
+  return {
+    strategic_objective: objetivoValido ? objetivo : null,
+    approach_strategy: texto(bruto.approach_strategy),
+    approach_strategy_b: texto(bruto.approach_strategy_b),
+    diagnostic_questions: lista(bruto.diagnostic_questions),
+    implication_question: texto(bruto.implication_question),
+    offer_transition: texto(bruto.offer_transition),
+    probable_objections: lista(bruto.probable_objections),
+    ltv_projection: normalizarProjecao(bruto.ltv_projection, CAMPOS_LTV),
+    expected_result: normalizarProjecao(bruto.expected_result, CAMPOS_RESULTADO),
+    operational_risks: lista(bruto.operational_risks),
+  };
+}
+
+/**
+ * Um plano sem NENHUM conteúdo acionável não vale ser gravado: entregaria à
+ * vendedora uma tela preenchida sem orientação real.
+ */
+export function planoTemConteudo(plano: PlanoNormalizado): boolean {
+  return plano.approach_strategy.length > 0 || plano.diagnostic_questions.length > 0;
+}

--- a/supabase/functions/generate-tactical-plan/plano-tools.ts
+++ b/supabase/functions/generate-tactical-plan/plano-tools.ts
@@ -152,8 +152,13 @@ export interface ProjecaoNormalizada {
 
 /**
  * Normaliza um objeto de projeção (ltv_projection / expected_result).
- * Devolve `null` quando o objeto inteiro está ausente, e mantém `null` campo a
- * campo — a UI mostra "—" em vez de um número que ninguém mediu.
+ *
+ * ALL-OR-NULL: basta UM membro ilegível para o objeto inteiro virar `null`.
+ * Não é preciosismo — a UI renderiza `fmt(v) = v.toLocaleString(...)` depois de
+ * checar só se o OBJETO existe (`plan.ltvProjection && …`), então um membro
+ * `null` chega em `fmt(null)` e derruba a tela do plano. Projeção pela metade
+ * também não é projeção: melhor não mostrar do que mostrar 1 de 3 números como
+ * se fosse o quadro completo.
  */
 export function normalizarProjecao(
   bruto: unknown,
@@ -162,14 +167,12 @@ export function normalizarProjecao(
   if (!bruto || typeof bruto !== "object" || Array.isArray(bruto)) return null;
   const origem = bruto as Record<string, unknown>;
   const out: ProjecaoNormalizada = {};
-  let algumMedido = false;
   for (const campo of campos) {
     const n = numeroOuNulo(origem[campo]);
+    if (n === null) return null;
     out[campo] = n;
-    if (n !== null) algumMedido = true;
   }
-  // Nenhum campo medido: é "não sei" inteiro, não uma projeção de zeros.
-  return algumMedido ? out : null;
+  return out;
 }
 
 export const CAMPOS_LTV = ["current_annual", "projected_annual", "growth_pct"] as const;
@@ -183,21 +186,83 @@ export interface PlanoNormalizado {
   strategic_objective: string | null;
   approach_strategy: string;
   approach_strategy_b: string;
-  diagnostic_questions: unknown[];
+  diagnostic_questions: PerguntaDiagnostica[];
   implication_question: string;
   offer_transition: string;
-  probable_objections: unknown[];
+  probable_objections: ObjecaoNormalizada[];
   ltv_projection: ProjecaoNormalizada | null;
   expected_result: ProjecaoNormalizada | null;
-  operational_risks: unknown[];
+  operational_risks: string[];
 }
 
 function texto(valor: unknown): string {
   return typeof valor === "string" ? valor.trim() : "";
 }
 
-function lista(valor: unknown): unknown[] {
-  return Array.isArray(valor) ? valor : [];
+export interface PerguntaDiagnostica {
+  question: string;
+  purpose: string;
+  expected_insight: string;
+}
+
+/** Pergunta sem enunciado apareceria como item em branco na tela da vendedora. */
+export function normalizarPerguntas(bruto: unknown): PerguntaDiagnostica[] {
+  if (!Array.isArray(bruto)) return [];
+  const out: PerguntaDiagnostica[] = [];
+  for (const cru of bruto) {
+    if (!cru || typeof cru !== "object" || Array.isArray(cru)) continue;
+    const o = cru as Record<string, unknown>;
+    const question = texto(o.question);
+    if (!question) continue;
+    out.push({
+      question,
+      purpose: texto(o.purpose),
+      expected_insight: texto(o.expected_insight),
+    });
+  }
+  return out;
+}
+
+export interface ObjecaoNormalizada {
+  objection: string;
+  technical_response: string;
+  economic_response: string;
+  probability: number | null;
+}
+
+/** Objeção sem enunciado não é objeção; probabilidade ilegível vira null, não 0. */
+export function normalizarObjecoes(bruto: unknown): ObjecaoNormalizada[] {
+  if (!Array.isArray(bruto)) return [];
+  const out: ObjecaoNormalizada[] = [];
+  for (const cru of bruto) {
+    if (!cru || typeof cru !== "object" || Array.isArray(cru)) continue;
+    const o = cru as Record<string, unknown>;
+    const objection = texto(o.objection);
+    if (!objection) continue;
+    const p = numeroOuNulo(o.probability);
+    out.push({
+      objection,
+      technical_response: texto(o.technical_response),
+      economic_response: texto(o.economic_response),
+      probability: p !== null && p >= 0 && p <= 100 ? p : null,
+    });
+  }
+  return out;
+}
+
+/**
+ * Riscos são renderizados como `<span>{risk}</span>`. Um objeto aí dentro
+ * derruba o React inteiro ("Objects are not valid as a React child"), então só
+ * string não-vazia passa.
+ */
+export function normalizarRiscos(bruto: unknown): string[] {
+  if (!Array.isArray(bruto)) return [];
+  const out: string[] = [];
+  for (const cru of bruto) {
+    const t = texto(cru);
+    if (t) out.push(t);
+  }
+  return out;
 }
 
 /**
@@ -215,20 +280,55 @@ export function normalizarPlano(bruto: Record<string, unknown>): PlanoNormalizad
     strategic_objective: objetivoValido ? objetivo : null,
     approach_strategy: texto(bruto.approach_strategy),
     approach_strategy_b: texto(bruto.approach_strategy_b),
-    diagnostic_questions: lista(bruto.diagnostic_questions),
+    diagnostic_questions: normalizarPerguntas(bruto.diagnostic_questions),
     implication_question: texto(bruto.implication_question),
     offer_transition: texto(bruto.offer_transition),
-    probable_objections: lista(bruto.probable_objections),
+    probable_objections: normalizarObjecoes(bruto.probable_objections),
     ltv_projection: normalizarProjecao(bruto.ltv_projection, CAMPOS_LTV),
     expected_result: normalizarProjecao(bruto.expected_result, CAMPOS_RESULTADO),
-    operational_risks: lista(bruto.operational_risks),
+    operational_risks: normalizarRiscos(bruto.operational_risks),
   };
 }
 
 /**
- * Um plano sem NENHUM conteúdo acionável não vale ser gravado: entregaria à
- * vendedora uma tela preenchida sem orientação real.
+ * Reconcilia o objetivo da IA com o derivado no servidor.
+ *
+ * `sem_historico → ativacao` é a PRIMEIRA regra de `selectObjective` e vem de um
+ * fato binário verificável: não existe venda válida registrada. Se a IA devolve
+ * "recuperacao" ali, ela passa no enum mas contradiz o fato — e um plano de
+ * recuperação pressupõe uma relação que nunca existiu. Nesse caso o servidor
+ * vence. Nos demais objetivos (faixas de churn/mix/recência, heurísticas), a
+ * leitura da IA continua valendo.
  */
-export function planoTemConteudo(plano: PlanoNormalizado): boolean {
-  return plano.approach_strategy.length > 0 || plano.diagnostic_questions.length > 0;
+export function objetivoFinal(
+  daIA: string | null,
+  doServidor: string | null | undefined,
+): { objetivo: string | null; sobrescrito: boolean } {
+  if (doServidor === "ativacao" && daIA !== null && daIA !== "ativacao") {
+    return { objetivo: "ativacao", sobrescrito: true };
+  }
+  return { objetivo: daIA ?? doServidor ?? null, sobrescrito: false };
+}
+
+/**
+ * Um plano sem conteúdo acionável não vale ser gravado: entregaria à vendedora
+ * uma tela preenchida sem orientação real.
+ *
+ * O modo estratégico é mais exigente porque a tela dele TEM as seções de
+ * abordagem B, implicação e transição — gravar sem elas abre um plano
+ * "completo" com metade dos blocos vazios.
+ */
+export function planoTemConteudo(
+  plano: PlanoNormalizado,
+  mode = "essencial",
+): boolean {
+  const base = plano.approach_strategy.length > 0 &&
+    plano.diagnostic_questions.length > 0;
+  if (!base) return false;
+  if (mode !== "estrategico") return true;
+  return (
+    plano.approach_strategy_b.length > 0 &&
+    plano.implication_question.length > 0 &&
+    plano.offer_transition.length > 0
+  );
 }

--- a/supabase/functions/generate-tactical-plan/plano-tools_test.ts
+++ b/supabase/functions/generate-tactical-plan/plano-tools_test.ts
@@ -7,9 +7,13 @@
 import {
   CAMPOS_LTV,
   CAMPOS_RESULTADO,
+  normalizarObjecoes,
+  normalizarPerguntas,
   normalizarPlano,
   normalizarProjecao,
+  normalizarRiscos,
   numeroOuNulo,
+  objetivoFinal,
   OBJETIVOS_ESTRATEGICOS,
   planoTemConteudo,
   TOOL_PLANO_ESSENCIAL,
@@ -97,12 +101,27 @@ Deno.test("normalizarProjecao: projeção toda ilegível vira null, não objeto 
   assertEquals(r, null, "sem nenhum campo medido é 'não sei' inteiro");
 });
 
-Deno.test("normalizarProjecao: campo medido preserva, campo ausente fica null", () => {
-  const r = normalizarProjecao(
-    { current_annual: 120000, projected_annual: null, growth_pct: "15" },
-    CAMPOS_LTV,
+Deno.test("normalizarProjecao: projeção PARCIAL é invalidada inteira (all-or-null)", () => {
+  // Não é preciosismo: a UI faz `plan.ltvProjection && …` (checa o OBJETO) e
+  // depois `fmt(v) = v.toLocaleString(...)` em cada membro. Um membro null
+  // chega em fmt(null) e DERRUBA a tela do plano.
+  assertEquals(
+    normalizarProjecao({ current_annual: 120000, projected_annual: null, growth_pct: 15 }, CAMPOS_LTV),
+    null,
+    "1 de 3 ausente invalida",
   );
-  assertEquals(r, { current_annual: 120000, projected_annual: null, growth_pct: 15 });
+  assertEquals(
+    normalizarProjecao({ current_annual: 120000 }, CAMPOS_LTV),
+    null,
+    "campos faltando invalidam",
+  );
+});
+
+Deno.test("normalizarProjecao: projeção COMPLETA passa, coagindo string numérica", () => {
+  assertEquals(
+    normalizarProjecao({ current_annual: 120000, projected_annual: "138000", growth_pct: 15 }, CAMPOS_LTV),
+    { current_annual: 120000, projected_annual: 138000, growth_pct: 15 },
+  );
 });
 
 Deno.test("normalizarProjecao: não-objeto degrada para null", () => {
@@ -160,13 +179,114 @@ Deno.test("planoTemConteudo: plano vazio NÃO é gravável", () => {
   );
 });
 
-Deno.test("planoTemConteudo: basta abordagem OU perguntas para valer", () => {
-  assert(
+Deno.test("planoTemConteudo: exige abordagem E perguntas — uma só não basta", () => {
+  assertEquals(
     planoTemConteudo(normalizarPlano({ approach_strategy: "Focar em mix." })),
-    "abordagem sozinha vale",
+    false,
+    "abordagem sem perguntas não é plano",
+  );
+  assertEquals(
+    planoTemConteudo(normalizarPlano({ diagnostic_questions: [{ question: "q" }] })),
+    false,
+    "perguntas sem abordagem não é plano",
   );
   assert(
-    planoTemConteudo(normalizarPlano({ diagnostic_questions: [{ question: "q" }] })),
-    "perguntas sozinhas valem",
+    planoTemConteudo(
+      normalizarPlano({
+        approach_strategy: "Focar em mix.",
+        diagnostic_questions: [{ question: "q" }],
+      }),
+    ),
+    "os dois juntos valem",
   );
+});
+
+Deno.test("planoTemConteudo: modo estratégico exige também B, implicação e transição", () => {
+  // A tela do estratégico TEM essas seções; gravar sem elas abre um plano
+  // "completo" com metade dos blocos vazios.
+  const base = {
+    approach_strategy: "A",
+    diagnostic_questions: [{ question: "q" }],
+  };
+  assertEquals(planoTemConteudo(normalizarPlano(base), "estrategico"), false);
+  assert(
+    planoTemConteudo(
+      normalizarPlano({
+        ...base,
+        approach_strategy_b: "B",
+        implication_question: "impacto?",
+        offer_transition: "transição",
+      }),
+      "estrategico",
+    ),
+    "com todos os campos do estratégico vale",
+  );
+  assert(planoTemConteudo(normalizarPlano(base), "essencial"), "essencial não exige os extras");
+});
+
+// ─────────────────── itens internos das listas (crash de UI) ───────────────────
+
+Deno.test("normalizarPerguntas: objeto VAZIO no array não vira pergunta", () => {
+  // `diagnostic_questions: [{}]` passava no guard antigo (length 1) e virava
+  // item em branco na tela.
+  assertEquals(normalizarPerguntas([{}, { purpose: "p" }]), []);
+});
+
+Deno.test("normalizarPerguntas: pergunta válida preserva os 3 campos", () => {
+  const r = normalizarPerguntas([{ question: "Como está o ritmo?", purpose: "p", expected_insight: "e" }]);
+  assertEquals(r.length, 1);
+  assertEquals(r[0], { question: "Como está o ritmo?", purpose: "p", expected_insight: "e" });
+});
+
+Deno.test("normalizarObjecoes: sem enunciado é descartada; probabilidade fora de 0-100 vira null", () => {
+  const r = normalizarObjecoes([
+    {},
+    { objection: "Preço alto", probability: 250 },
+    { objection: "Prazo", probability: 70 },
+  ]);
+  assertEquals(r.length, 2);
+  assertEquals(r[0].probability, null, "250 não é probabilidade");
+  assertEquals(r[1].probability, 70);
+});
+
+Deno.test("normalizarRiscos: objeto no array é descartado — derrubaria o React", () => {
+  // A UI faz <span>{risk}</span>; um objeto ali lança
+  // "Objects are not valid as a React child" e quebra a página inteira.
+  assertEquals(normalizarRiscos(["Risco real", {}, "", { a: 1 }, "  ", "Outro"]), [
+    "Risco real",
+    "Outro",
+  ]);
+});
+
+Deno.test("normalizarRiscos: entrada não-array degrada para vazio", () => {
+  for (const v of [null, undefined, "texto", 42]) {
+    assertEquals(normalizarRiscos(v), [], `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ─────────────────────────────── objetivoFinal ───────────────────────────────
+
+Deno.test("objetivoFinal: servidor VENCE quando derivou ativacao (sem_historico é fato)", () => {
+  // Cliente sem venda válida registrada. "recuperacao" passa no enum mas
+  // pressupõe uma relação que nunca existiu.
+  const r = objetivoFinal("recuperacao", "ativacao");
+  assertEquals(r.objetivo, "ativacao");
+  assertEquals(r.sobrescrito, true, "a divergência tem de ser sinalizada");
+});
+
+Deno.test("objetivoFinal: nos demais objetivos a leitura da IA prevalece", () => {
+  // São faixas de churn/mix/recência — heurísticas, onde a IA pode ter contexto.
+  const r = objetivoFinal("upsell_premium", "expansao_mix");
+  assertEquals(r.objetivo, "upsell_premium");
+  assertEquals(r.sobrescrito, false);
+});
+
+Deno.test("objetivoFinal: IA nula cai no derivado sem marcar sobrescrita", () => {
+  assertEquals(objetivoFinal(null, "ativacao"), { objetivo: "ativacao", sobrescrito: false });
+  assertEquals(objetivoFinal(null, "expansao_mix"), { objetivo: "expansao_mix", sobrescrito: false });
+  assertEquals(objetivoFinal(null, null), { objetivo: null, sobrescrito: false });
+});
+
+Deno.test("objetivoFinal: IA concordando com ativacao não conta como sobrescrita", () => {
+  assertEquals(objetivoFinal("ativacao", "ativacao"), { objetivo: "ativacao", sobrescrito: false });
 });

--- a/supabase/functions/generate-tactical-plan/plano-tools_test.ts
+++ b/supabase/functions/generate-tactical-plan/plano-tools_test.ts
@@ -1,0 +1,172 @@
+// Testa o CÓDIGO REAL de plano-tools.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/generate-tactical-plan/
+//
+// Foco: o plano tático guia a abordagem comercial de um cliente real. Número
+// projetado sobre dado ausente chega à vendedora com cara de medido, e objetivo
+// estratégico inventado muda a estratégia inteira da visita.
+import {
+  CAMPOS_LTV,
+  CAMPOS_RESULTADO,
+  normalizarPlano,
+  normalizarProjecao,
+  numeroOuNulo,
+  OBJETIVOS_ESTRATEGICOS,
+  planoTemConteudo,
+  TOOL_PLANO_ESSENCIAL,
+  TOOL_PLANO_ESTRATEGICO,
+  toolDoModo,
+} from "./plano-tools.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const PLANO_MINIMO = {
+  strategic_objective: "expansao_mix",
+  approach_strategy: "Abordagem consultiva focada em mix.",
+  diagnostic_questions: [{ question: "q", purpose: "p", expected_insight: "e" }],
+  probable_objections: [],
+};
+
+// ───────────────────────────── schema da tool ─────────────────────────────
+
+Deno.test("schema: os dois modos usam o MESMO nome de tool (o caller força por nome)", () => {
+  assertEquals(TOOL_PLANO_ESSENCIAL.name, TOOL_PLANO_ESTRATEGICO.name);
+});
+
+Deno.test("schema: projeções são NULLABLE — obrigar número forçaria fabricação", () => {
+  // O prompt manda: "se a margem atual for null, retorne expected_result com
+  // null nos três cenários". Um schema que exigisse number contradiria isso.
+  const props = TOOL_PLANO_ESTRATEGICO.input_schema.properties as Record<
+    string,
+    { type?: unknown }
+  >;
+  assertEquals(props.expected_result.type, ["object", "null"]);
+  assertEquals(props.ltv_projection.type, ["object", "null"]);
+  const req = TOOL_PLANO_ESTRATEGICO.input_schema.required as string[];
+  assert(!req.includes("expected_result"), "expected_result NÃO pode ser required");
+  assert(!req.includes("ltv_projection"), "ltv_projection NÃO pode ser required");
+});
+
+Deno.test("schema: objetivo estratégico é enum fechado", () => {
+  const props = TOOL_PLANO_ESSENCIAL.input_schema.properties as Record<
+    string,
+    { enum?: string[] }
+  >;
+  assertEquals(props.strategic_objective.enum, [...OBJETIVOS_ESTRATEGICOS]);
+});
+
+Deno.test("toolDoModo: só 'estrategico' pega o schema completo", () => {
+  assertEquals(toolDoModo("estrategico"), TOOL_PLANO_ESTRATEGICO);
+  for (const m of ["essencial", "", "ESTRATEGICO", "outro"]) {
+    assertEquals(toolDoModo(m), TOOL_PLANO_ESSENCIAL, `modo ${JSON.stringify(m)}`);
+  }
+});
+
+// ─────────────────────────────── numeroOuNulo ───────────────────────────────
+
+Deno.test("numeroOuNulo: ausente/ilegível vira null, NUNCA zero", () => {
+  // Number(null) === 0 fabricaria margem zero onde não há medição.
+  for (const v of [null, undefined, "", "n/a", NaN, Infinity, {}, [], "12,5"]) {
+    assertEquals(numeroOuNulo(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("numeroOuNulo: zero MEDIDO continua valendo zero", () => {
+  // Diferente de ausente: 0 informado é um fato.
+  assertEquals(numeroOuNulo(0), 0);
+  assertEquals(numeroOuNulo("0"), 0);
+  assertEquals(numeroOuNulo(-3.5), -3.5);
+});
+
+// ───────────────────────────── normalizarProjecao ─────────────────────────────
+
+Deno.test("normalizarProjecao: projeção toda ilegível vira null, não objeto de zeros", () => {
+  const r = normalizarProjecao(
+    { best_case_margin: null, likely_margin: "n/a", worst_case_margin: undefined },
+    CAMPOS_RESULTADO,
+  );
+  assertEquals(r, null, "sem nenhum campo medido é 'não sei' inteiro");
+});
+
+Deno.test("normalizarProjecao: campo medido preserva, campo ausente fica null", () => {
+  const r = normalizarProjecao(
+    { current_annual: 120000, projected_annual: null, growth_pct: "15" },
+    CAMPOS_LTV,
+  );
+  assertEquals(r, { current_annual: 120000, projected_annual: null, growth_pct: 15 });
+});
+
+Deno.test("normalizarProjecao: não-objeto degrada para null", () => {
+  for (const v of [null, undefined, "x", 42, []]) {
+    assertEquals(normalizarProjecao(v, CAMPOS_LTV), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ────────────────────────────── normalizarPlano ──────────────────────────────
+
+Deno.test("normalizarPlano: objetivo fora do enum vira null (não vale rótulo inventado)", () => {
+  // O caller cai no objetivo derivado server-side, que é medido.
+  const p = normalizarPlano({ ...PLANO_MINIMO, strategic_objective: "dominar_o_mercado" });
+  assertEquals(p.strategic_objective, null);
+});
+
+Deno.test("normalizarPlano: cada objetivo válido do enum é aceito", () => {
+  for (const obj of OBJETIVOS_ESTRATEGICOS) {
+    const p = normalizarPlano({ ...PLANO_MINIMO, strategic_objective: obj });
+    assertEquals(p.strategic_objective, obj, `objetivo ${obj}`);
+  }
+});
+
+Deno.test("normalizarPlano: campos ausentes viram vazio, não undefined", () => {
+  const p = normalizarPlano({});
+  assertEquals(p.approach_strategy, "");
+  assertEquals(p.diagnostic_questions, []);
+  assertEquals(p.probable_objections, []);
+  assertEquals(p.operational_risks, []);
+  assertEquals(p.ltv_projection, null);
+  assertEquals(p.expected_result, null);
+});
+
+Deno.test("normalizarPlano: lista que veio como não-array não explode", () => {
+  const p = normalizarPlano({ ...PLANO_MINIMO, diagnostic_questions: "três perguntas" });
+  assertEquals(p.diagnostic_questions, []);
+});
+
+Deno.test("normalizarPlano: margem não medida NÃO vira projeção de zeros", () => {
+  const p = normalizarPlano({
+    ...PLANO_MINIMO,
+    expected_result: { best_case_margin: null, likely_margin: null, worst_case_margin: null },
+  });
+  assertEquals(p.expected_result, null, "três nulls = não medido, e a UI mostra —");
+});
+
+// ────────────────────────────── planoTemConteudo ──────────────────────────────
+
+Deno.test("planoTemConteudo: plano vazio NÃO é gravável", () => {
+  // Gravar isto entregaria uma tela preenchida sem orientação nenhuma.
+  assertEquals(planoTemConteudo(normalizarPlano({})), false);
+  assertEquals(
+    planoTemConteudo(normalizarPlano({ approach_strategy: "   ", diagnostic_questions: [] })),
+    false,
+  );
+});
+
+Deno.test("planoTemConteudo: basta abordagem OU perguntas para valer", () => {
+  assert(
+    planoTemConteudo(normalizarPlano({ approach_strategy: "Focar em mix." })),
+    "abordagem sozinha vale",
+  );
+  assert(
+    planoTemConteudo(normalizarPlano({ diagnostic_questions: [{ question: "q" }] })),
+    "perguntas sozinhas valem",
+  );
+});


### PR DESCRIPTION
## Por quê

O orçamento do gateway de IA do Lovable estourou (4 créditos/mês) e as features de IA pararam em produção. Fase 3 de 4 da migração para a API Anthropic direta — fases 1 e 2 nos PRs #1592 e #1608.

## O que muda

`generate-tactical-plan` e `generate-bundle-argument` saem do gateway. Mas o achado principal não é a troca de provedor: **os fallbacks do `JSON.parse` fabricavam conteúdo comercial**.

### `generate-tactical-plan`

No `catch` do parse, montava um plano genérico — "Abordagem consultiva padrão" e 3 perguntas fixas — e, no modo cron, **gravava no banco** via `criar_plano_tatico` sem nenhuma marca de fallback. A vendedora abria o plano tático do cliente e lia recomendação genérica achando que era análise daquele cliente.

### `generate-bundle-argument`

```ts
versao_whatsapp: content.slice(0, 150)
beneficio_economico: "Economia potencial identificada"
```

A **mensagem enviada ao cliente** virava os primeiros 150 caracteres do texto cru do modelo — raciocínio, markdown quebrado, JSON pela metade. E o benefício econômico virava afirmação fabricada, justamente o que o #1520 (draft) tenta proibir no prompt sem tocar no fallback.

**Forced tool-use elimina os dois pela raiz**: ou o schema é satisfeito, ou é 422 explícito — nada é gravado nem enviado.

## Desenho do schema (money-path)

O prompt do plano manda, literalmente, deixar `null` quando a margem não está medida ("NUNCA estime, preencha ou infira"). Um `input_schema` que exigisse esses números **forçaria a fabricação que o prompt proíbe** — então `ltv_projection` e `expected_result` são nullable e ficam fora de `required`.

## 2ª opinião — Codex (`gpt-5.6-sol`, xhigh): **REQUEST CHANGES**

Todos os achados foram **confirmados no código antes de aceitar**.

<details><summary>Achados do Codex (verbatim)</summary>

> **[1]** `normalizarProjecao` **não está correto com a UI atual**. `{ ltv_projection: { current_annual: 120000 } }` → devolve objeto com nulls → `PlanCard` chama `fmt(null)` → `toLocaleString` lança exceção. "Portanto, o comentário 'a UI mostra —' é falso hoje."
>
> **[2]** O mais perigoso é a IA devolver objetivo **válido porém errado**: servidor deriva `ativacao` por `sem_historico`, IA devolve `recuperacao`, passa no enum e vence o derivado → "plano de recuperação é gravado para cliente sem histórico".
>
> **[3]** `planoTemConteudo` não é guard suficiente: `diagnostic_questions: [{}]` passa pelo `length 1`. "Pior: `operational_risks: [{}]` passa como `unknown[]`, é persistido e pode derrubar o React ao tentar renderizar o objeto como filho."
>
> **[4]** A implementação **não é** tudo-ou-nada: 5 dos 8 campos podem ficar vazios, mas a UI mostra as 5 linhas e as 3 abas com botão de copiar.
>
> **[7]** `400 → "A IA recusou o conteúdo"` está errado — 400 é requisição inválida, "frequentemente defeito nosso"; recusa vem como `stop_reason: "refusal"`. Faltam 504 e 409.
>
> **Extra**: o 402 continua invisível no front — os hooks não usam `invoke-function.ts`. "Isso recria exatamente o sintoma 'feature parou sem sinal claro de orçamento'."
>
> **Certo**: exactly-one aplicado corretamente nas 3 chamadas · guards de `max_tokens` presentes · fail-closed de status desconhecido → 500 é boa escolha · temperature continua atuando com forced tool-use.

</details>

**Calibração (minha, não do Codex):**

- **[1] era crash de tela e eu documentei errado.** `fmt = (v: number) => v.toLocaleString(...)` explode com `null`, e o `PlanCard` só checa se o objeto existe. Meu comentário "a UI mostra —" era falso. Virou all-or-null.
- **[2] aceito, com recorte.** `selectObjective:111` confirma que `sem_historico → ativacao` é a primeira regra e vem de fato binário. O servidor vence **nesse caso**; nos demais objetivos (faixas de churn/mix/recência, heurísticas) a IA continua valendo. Divergência vai para log.
- **[3] e [4] aceitos integralmente.**
- **[7] aceito** — 400 virou 500 "avise a equipe"; somados 504 e 409.
- **Discordo do `strict: true`**: `claude-sonnet-4-6` não consta entre os modelos com structured outputs, e exigiria `additionalProperties: false` em todo o schema. A validação local cobre os mesmos caminhos sem depender de suporte do modelo.
- **Corrigi um furo meu antes do parecer**: `stop_reason === "max_tokens"` faltava nas 2 chamadas do bundle.
- **Fora de escopo, com chip aberto**: ele mostrou que `Number(v ?? 0)` já fabrica zero **antes** do prompt (`revenue_potential` NULL em ~6.633 linhas). É real e money-path, mas é bug pré-existente em outro trecho.
- **Ressalva de procedência**: o sub-challenge independente dele não rodou (`mktemp` bloqueado no sandbox read-only), então é a revisão adversária local do próprio Codex.

## Prova

| Gate | Resultado |
|---|---|
| `test:edges` | 455 passed · 0 failed |
| `eslint .` | exit 0 · **0 erros** |
| `deno check` tactical-plan | **6 erros (baseline main) → 0** — o plano deixou de ser `any` do `JSON.parse` |
| `deno check` bundle-argument | 0 → 0 |

**Falsificação** — 52 testes, baseline verde, 2 locales (`C` e `pt_BR.UTF-8`), cada sabotagem tendo de derrubar os testes **nomeados**:

| Sabotagem | Vermelhos |
|---|---|
| projeção parcial volta a passar (crash da tela) | 3/52 |
| objetivo inventado pela IA passa | 1/52 |
| plano vazio volta a ser gravável | 2/52 |
| argumentação pela metade (WhatsApp vazio ao cliente) | 4/52 |
| pergunta sem enunciado entra na lista | 1/52 |
| 402 deixa de ser reconhecido | 1/52 |
| objeto no array de riscos passa (quebra o React) | 1/52 |
| IA vence o fato medido `sem_historico` | 1/52 |
| volta a exigir só 3 dos 8 campos | 1/52 |

## Conflito conhecido

O **#1520 (draft)** muda o *texto do prompt* do `generate-bundle-argument` (remove margem por SKU, proíbe estimar economia). Este PR mexe na *chamada*. Quem mergear depois resolve — é localizado. Vale notar que o #1520 não toca o fallback que este PR elimina.

## Depois do merge (deploy é manual — merge não deploya nada)

1. Confirmar `ANTHROPIC_API_KEY` nos secrets do Supabase.
2. Deployar pelo chat do Lovable — **5 arquivos**: `_shared/anthropic.ts`, `generate-tactical-plan/{index.ts,plano-tools.ts}`, `generate-bundle-argument/{index.ts,argumento-tools.ts}`.
3. **Publish do frontend** (3 hooks mudaram para `invokeFunction`).
4. Conferir que nenhum commit "Changes" do bot reverteu os arquivos depois do merge.
