### PR TITLE
fix(farmer): argumentação de bundle sai do gateway Lovable — e o motivo real da falha para de sumir [money-path]

### DIFF
--- a/src/hooks/__tests__/cluster-margin-cobertura.test.tsx
+++ b/src/hooks/__tests__/cluster-margin-cobertura.test.tsx
@@ -60,7 +60,11 @@ function recordRpc(fn: string, args: Record<string, unknown>): Promise<{ data: u
   rpcCalls.push({ fn, args });
   return Promise.resolve({ data: 'plan-1', error: null });
 }
-const invokeMock = vi.fn().mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+// O hook usa invokeFunction (não supabase.functions.invoke cru), para que o
+// motivo REAL da edge — créditos esgotados, geração truncada — chegue ao
+// usuário em vez do genérico "non-2xx". O helper devolve o corpo direto.
+const invokeMock = vi.fn().mockResolvedValue({ strategic_objective: 'upsell_premium' });
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: (...a: unknown[]) => invokeMock(...a) }));
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: { from: (t: string) => chain(t), rpc: (fn: string, args: Record<string, unknown>) => recordRpc(fn, args), functions: { invoke: (...a: unknown[]) => invokeMock(...a) } },
 }));

--- a/src/hooks/__tests__/cluster-margin-paginacao.test.tsx
+++ b/src/hooks/__tests__/cluster-margin-paginacao.test.tsx
@@ -90,7 +90,11 @@ function chain(table: string): unknown {
 }
 
 let rpcCalls: Array<{ fn: string; args: Record<string, unknown> }> = [];
-const invokeMock = vi.fn().mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+// O hook usa invokeFunction (não supabase.functions.invoke cru), para que o
+// motivo REAL da edge — créditos esgotados, geração truncada — chegue ao
+// usuário em vez do genérico "non-2xx". O helper devolve o corpo direto.
+const invokeMock = vi.fn().mockResolvedValue({ strategic_objective: 'upsell_premium' });
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: (...a: unknown[]) => invokeMock(...a) }));
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: (t: string) => chain(t),

--- a/src/hooks/__tests__/tactical-plan-posse-dono.test.tsx
+++ b/src/hooks/__tests__/tactical-plan-posse-dono.test.tsx
@@ -82,6 +82,9 @@ const h = vi.hoisted(() => ({
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: { from: (t: string) => chain(t), rpc: (fn: string, args: Record<string, unknown>) => recordRpc(fn, args), functions: { invoke: (...a: unknown[]) => h.invoke(...a) } },
 }));
+// O hook usa invokeFunction (não o invoke cru): é o que faz o motivo real da
+// edge chegar ao usuário. O helper devolve o corpo direto, sem {data,error}.
+vi.mock('@/lib/invoke-function', () => ({ invokeFunction: (...a: unknown[]) => h.invoke(...a) }));
 vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => ({ isImpersonating: false, effectiveUserId: VIEWER }) }));
 vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: VIEWER }, isStaff: true }) }));
 vi.mock('sonner', () => ({ toast: { error: (...a: unknown[]) => h.toastError(...a), success: (...a: unknown[]) => h.toastSuccess(...a) } }));
@@ -92,9 +95,9 @@ beforeEach(() => {
   queries = [];
   rpcCalls = [];
   scoreFarmerId = OWNER;
-  h.invoke.mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+  h.invoke.mockResolvedValue({ strategic_objective: 'upsell_premium' });
   vi.clearAllMocks();
-  h.invoke.mockResolvedValue({ data: { strategic_objective: 'upsell_premium' }, error: null });
+  h.invoke.mockResolvedValue({ strategic_objective: 'upsell_premium' });
 });
 
 describe('generatePlan — POSSE do plano = DONO da carteira (não o executor)', () => {

--- a/src/hooks/useBundleArguments.ts
+++ b/src/hooks/useBundleArguments.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { toast } from 'sonner';
 import { margemConhecida } from '@/lib/scoring/margin';
 
@@ -76,23 +77,22 @@ export const useBundleArguments = () => {
     setGenerating(prev => ({ ...prev, [bundleKey]: true }));
 
     try {
-      const { data, error } = await supabase.functions.invoke('generate-bundle-argument', {
-        body: { bundle, customer, customerProfile },
+      // invokeFunction extrai o motivo REAL do corpo da resposta. O `data.error`
+      // de antes só pegava erro devolvido com status 200 — a edge agora responde
+      // 402/422, e com o invoke cru o motivo (créditos esgotados, geração
+      // truncada) virava o toast genérico "Erro ao gerar argumentação".
+      const argument = await invokeFunction<BundleArgument>('generate-bundle-argument', {
+        bundle, customer, customerProfile,
       });
-
-      if (error) throw error;
-
-      if (data?.error) {
-        toast.error(data.error);
-        return null;
-      }
-
-      const argument = data as BundleArgument;
       setArguments(prev => ({ ...prev, [bundleKey]: argument }));
       return argument;
     } catch (error) {
       console.error('Error generating argument:', error);
-      toast.error('Erro ao gerar argumentação');
+      const motivo = error instanceof Error && error.name === 'EdgeFunctionError' &&
+          !/non-2xx status code/i.test(error.message)
+        ? error.message
+        : null;
+      toast.error(motivo ?? 'Erro ao gerar argumentação');
       return null;
     } finally {
       setGenerating(prev => ({ ...prev, [bundleKey]: false }));

--- a/src/hooks/useDiagnosticQuestions.ts
+++ b/src/hooks/useDiagnosticQuestions.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
@@ -61,15 +62,13 @@ export const useDiagnosticQuestions = () => {
     setGenerating(prev => ({ ...prev, [bundleKey]: true }));
 
     try {
-      const { data, error } = await supabase.functions.invoke('generate-bundle-argument', {
-        body: { bundle, customer, customerProfile, mode: 'diagnostic_questions' },
-      });
-
-      if (error) throw error;
-      if (data?.error) {
-        toast.error(data.error);
-        return null;
-      }
+      // invokeFunction extrai o motivo REAL do corpo (ver useBundleArguments):
+      // a edge agora responde 402/422 e o `data.error` de antes só via erro
+      // devolvido com status 200.
+      const data = await invokeFunction<{ questions?: DiagnosticQuestion[] }>(
+        'generate-bundle-argument',
+        { bundle, customer, customerProfile, mode: 'diagnostic_questions' },
+      );
 
       const qs: QuestionWithResponse[] = (data.questions || []).map((q: DiagnosticQuestion) => ({
         ...q,
@@ -80,7 +79,11 @@ export const useDiagnosticQuestions = () => {
       return qs;
     } catch (error) {
       console.error('Error generating diagnostic questions:', error);
-      toast.error('Erro ao gerar perguntas diagnósticas');
+      const motivo = error instanceof Error && error.name === 'EdgeFunctionError' &&
+          !/non-2xx status code/i.test(error.message)
+        ? error.message
+        : null;
+      toast.error(motivo ?? 'Erro ao gerar perguntas diagnósticas');
       return null;
     } finally {
       setGenerating(prev => ({ ...prev, [bundleKey]: false }));

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
 import { margemConhecida, mediaMargensConhecidas } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
@@ -530,8 +531,12 @@ export const useTacticalPlan = () => {
         };
       }
 
-      const { data: aiPlan, error: aiError } = await supabase.functions.invoke<AiPlanResponse>('generate-tactical-plan', {
-        body: {
+      // invokeFunction (e não supabase.functions.invoke cru) porque o erro do
+      // supabase é sempre o genérico "non-2xx status code": o motivo REAL da
+      // edge — créditos esgotados, geração truncada — vem no corpo e só o
+      // helper o extrai. Com o invoke cru, o estouro de orçamento que motivou
+      // a migração continuaria invisível para quem usa.
+      const aiPlan = await invokeFunction<AiPlanResponse>('generate-tactical-plan', {
           customerContext: {
             name: profile?.name,
             cnae: profile?.cnae,
@@ -553,10 +558,7 @@ export const useTacticalPlan = () => {
           diagnosticData,
           historicalObjections,
           planType,
-        },
       });
-
-      if (aiError) throw aiError;
 
       // Escrita via RPC-fronteira (#1037 + split de RLS): a posse (farmer_id) é re-resolvida
       // server-side de carteira_assignments e a RLS pós-split NEGA insert direto do client.

--- a/supabase/functions/_shared/anthropic.ts
+++ b/supabase/functions/_shared/anthropic.ts
@@ -1,0 +1,94 @@
+// Peças comuns das chamadas à API da Anthropic nas edges — puras o bastante para
+// rodar sob `deno test --no-remote` (nada aqui importa o SDK; o cliente é
+// construído na própria edge).
+//
+// Existe porque o mapeamento de erro é sutil e errar nele é SILENCIOSO: sem o
+// 402, saldo esgotado vira "erro interno" e ninguém descobre que o problema é
+// crédito — foi exatamente o que aconteceu com o gateway do Lovable, cujo
+// estouro de orçamento derrubou as features de IA sem sinal claro.
+
+/** Modelo padrão das edges — ver convenção de LLM em edge no CLAUDE.md. */
+export const MODELO_PADRAO = "claude-sonnet-4-6";
+
+export interface RespostaErro {
+  http: number;
+  mensagem: string;
+}
+
+/**
+ * Traduz o status da API da Anthropic para a resposta que a edge devolve.
+ *
+ * `null` = não é erro conhecido da API: o caller deve tratar como falha interna
+ * (500) em vez de inventar uma mensagem tranquilizadora para o usuário.
+ */
+export function traduzirErroAnthropic(status: number | undefined): RespostaErro | null {
+  switch (status) {
+    // 400 é REQUISIÇÃO INVÁLIDA — schema/parâmetro incompatível, quase sempre
+    // defeito nosso. Recusa do modelo por conteúdo NÃO chega como 400: vem numa
+    // resposta 200 com `stop_reason: "refusal"`. Chamar isto de "a IA recusou"
+    // mandaria a vendedora tentar outra foto quando o bug é do código.
+    case 400:
+      return { http: 500, mensagem: "Falha na requisição à IA — avise a equipe." };
+    case 401:
+    case 403:
+    case 404:
+      return { http: 500, mensagem: "IA mal configurada — avise a equipe." };
+    case 402:
+      return { http: 402, mensagem: "Créditos da IA esgotados — avise a equipe." };
+    case 409:
+      return { http: 409, mensagem: "Conflito momentâneo na IA. Tente novamente." };
+    case 413:
+      return { http: 413, mensagem: "Envio grande demais para a IA." };
+    case 429:
+      return { http: 429, mensagem: "Limite de requisições excedido. Tente novamente em alguns segundos." };
+    case 500:
+    case 503:
+    case 504:
+    case 529:
+      return { http: 503, mensagem: "IA sobrecarregada no momento. Tente de novo em instantes." };
+    default:
+      return null;
+  }
+}
+
+/** Extrai o status HTTP de um erro do SDK sem assumir o formato. */
+export function statusDoErro(e: unknown): number | undefined {
+  const s = (e as { status?: unknown })?.status;
+  return typeof s === "number" ? s : undefined;
+}
+
+export type ResultadoToolUse =
+  | { ok: true; input: unknown }
+  | { ok: false; motivo: "ausente" | "multiplo"; quantidade: number };
+
+/**
+ * Exige EXATAMENTE um bloco `tool_use`.
+ *
+ * `tool_choice: {type:"tool"}` sozinho NÃO desliga chamada paralela — o modelo
+ * pode emitir vários blocos. Consumir só o primeiro entrega resultado PARCIAL
+ * com cara de completo. Mande `disable_parallel_tool_use: true` na chamada;
+ * este guard é a rede.
+ */
+export function extrairToolUseUnico(
+  blocos: ReadonlyArray<{ type: string; input?: unknown }>,
+): ResultadoToolUse {
+  const usos = (blocos ?? []).filter((b) => b?.type === "tool_use");
+  if (usos.length === 0) return { ok: false, motivo: "ausente", quantidade: 0 };
+  if (usos.length > 1) {
+    return { ok: false, motivo: "multiplo", quantidade: usos.length };
+  }
+  return { ok: true, input: usos[0].input };
+}
+
+/**
+ * Objeto utilizável a partir do `input` da tool.
+ *
+ * Forced tool-use garante que a ferramenta foi USADA, não que o schema foi
+ * respeitado (isso só com `strict:true`). Entrada que não é objeto vira `null`
+ * para o caller falhar explicitamente, em vez de seguir com campos `undefined`
+ * e gravar um registro vazio que parece preenchido.
+ */
+export function objetoDaTool(input: unknown): Record<string, unknown> | null {
+  if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+  return input as Record<string, unknown>;
+}

--- a/supabase/functions/_shared/anthropic_test.ts
+++ b/supabase/functions/_shared/anthropic_test.ts
@@ -1,0 +1,111 @@
+// Testa o CÓDIGO REAL de _shared/anthropic.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/
+import {
+  extrairToolUseUnico,
+  objetoDaTool,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "./anthropic.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+// ───────────────────────── traduzirErroAnthropic ─────────────────────────
+
+Deno.test("402 é tratado — saldo esgotado não pode virar 'erro interno'", () => {
+  // Foi o estouro de orçamento silencioso que derrubou as features de IA.
+  const r = traduzirErroAnthropic(402);
+  assert(r !== null, "402 tem de ser reconhecido");
+  assertEquals(r!.http, 402);
+  assert(/[Cc]réditos/.test(r!.mensagem), "mensagem deveria citar créditos");
+});
+
+Deno.test("sobrecarga (500/503/529) vira 503, não repassa 500 cru", () => {
+  for (const s of [500, 503, 529]) {
+    assertEquals(traduzirErroAnthropic(s)!.http, 503, `status ${s}`);
+  }
+});
+
+Deno.test("erro de configuração (401/403/404) não vaza como problema do usuário", () => {
+  for (const s of [401, 403, 404]) {
+    const r = traduzirErroAnthropic(s)!;
+    assertEquals(r.http, 500, `status ${s}`);
+    assert(/equipe/.test(r.mensagem), "deveria mandar avisar a equipe");
+  }
+});
+
+Deno.test("429 e 413 têm resposta própria e acionável", () => {
+  assertEquals(traduzirErroAnthropic(429)!.http, 429);
+  assertEquals(traduzirErroAnthropic(413)!.http, 413);
+});
+
+Deno.test("status desconhecido devolve null — caller falha explícito", () => {
+  // Devolver uma mensagem tranquilizadora para status que não conhecemos
+  // esconderia falha nova; null obriga o caller a tratar como erro interno.
+  for (const s of [undefined, 0, 200, 418, 999]) {
+    assertEquals(traduzirErroAnthropic(s as number | undefined), null, `status ${s}`);
+  }
+});
+
+// ─────────────────────────────── statusDoErro ───────────────────────────────
+
+Deno.test("statusDoErro: lê number, ignora o resto", () => {
+  assertEquals(statusDoErro({ status: 429 }), 429);
+  assertEquals(statusDoErro({ status: "429" }), undefined);
+  assertEquals(statusDoErro(new Error("x")), undefined);
+  assertEquals(statusDoErro(null), undefined);
+  assertEquals(statusDoErro(undefined), undefined);
+});
+
+// ───────────────────────── extrairToolUseUnico ─────────────────────────
+
+Deno.test("um tool_use devolve o input", () => {
+  const r = extrairToolUseUnico([{ type: "text" }, { type: "tool_use", input: { a: 1 } }]);
+  assert(r.ok, "deveria aceitar");
+  if (!r.ok) return;
+  assertEquals(r.input, { a: 1 });
+});
+
+Deno.test("DOIS tool_use são recusados, não cortados em silêncio", () => {
+  const r = extrairToolUseUnico([
+    { type: "tool_use", input: { parte: 1 } },
+    { type: "tool_use", input: { parte: 2 } },
+  ]);
+  assert(!r.ok, "dois blocos têm de ser recusados");
+  if (r.ok) return;
+  assertEquals(r.motivo, "multiplo");
+  assertEquals(r.quantidade, 2);
+});
+
+Deno.test("nenhum tool_use é 'ausente', distinto de 'multiplo'", () => {
+  const r = extrairToolUseUnico([{ type: "text" }]);
+  assert(!r.ok, "deveria recusar");
+  if (r.ok) return;
+  assertEquals(r.motivo, "ausente");
+});
+
+Deno.test("lista vazia/inválida não explode", () => {
+  assertEquals(extrairToolUseUnico([]).ok, false);
+  assertEquals(
+    extrairToolUseUnico(null as unknown as { type: string }[]).ok,
+    false,
+  );
+});
+
+// ─────────────────────────────── objetoDaTool ───────────────────────────────
+
+Deno.test("objetoDaTool: só objeto passa", () => {
+  assertEquals(objetoDaTool({ a: 1 }), { a: 1 });
+  for (const v of [null, undefined, "texto", 42, [], [1, 2], true]) {
+    assertEquals(objetoDaTool(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});

--- a/supabase/functions/generate-bundle-argument/argumento-tools.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-tools.ts
@@ -1,0 +1,163 @@
+// Schemas das tools e normalização da saída — puro, sem import remoto
+// (roda sob `deno test --no-remote`, o `test:edges` do CI).
+//
+// Por que forced tool-use: o código antigo pedia JSON no texto, fazia
+// `content.match(/\{[\s\S]*\}/)` + `JSON.parse`, e no catch montava um objeto
+// de fallback com dois problemas graves:
+//
+//   versao_whatsapp: content.slice(0, 150)   ← texto CRU do modelo virando a
+//                                              mensagem enviada AO CLIENTE
+//   beneficio_economico: "Economia potencial identificada"  ← afirmação
+//                                              econômica fabricada
+//
+// Com tool-use o schema é satisfeito ou a chamada falha explícito — não existe
+// mensagem de WhatsApp montada a partir de raciocínio truncado do modelo.
+
+const TIPOS_SPIN = ["situacao", "problema", "implicacao", "direcionamento"] as const;
+
+export const TOOL_PERGUNTAS = {
+  name: "registrar_perguntas_diagnosticas",
+  description: "Registra as perguntas diagnósticas SPIN para validar hipóteses antes do bundle",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      questions: {
+        type: "array",
+        description: "Máximo 4 perguntas, uma por tipo SPIN",
+        items: {
+          type: "object" as const,
+          properties: {
+            type: { type: "string", enum: [...TIPOS_SPIN] },
+            main: { type: "string", description: "Pergunta principal" },
+            alt: { type: "string", description: "Variação alternativa adaptada ao perfil" },
+            rationale: { type: "string", description: "Por que esta pergunta é relevante" },
+          },
+          required: ["type", "main", "alt", "rationale"],
+        },
+      },
+    },
+    required: ["questions"],
+  },
+};
+
+export const TOOL_ARGUMENTO = {
+  name: "registrar_argumentacao",
+  description: "Registra a argumentação consultiva personalizada para a venda do bundle",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      diagnostico: { type: "string", description: "Diagnóstico implícito baseado no histórico" },
+      insight_tecnico: { type: "string", description: "Insight sobre o processo produtivo" },
+      beneficio_operacional: { type: "string", description: "Benefício operacional concreto" },
+      beneficio_economico: {
+        type: "string",
+        description:
+          "Benefício econômico. Use APENAS cifras presentes no contexto; sem número disponível, escreva de forma qualitativa — não estime economia, payback nem percentual.",
+      },
+      objecao_antecipada: { type: "string", description: "Objeção provável e resposta" },
+      versao_phone: { type: "string", description: "Script curto para ligação" },
+      versao_whatsapp: { type: "string", description: "Mensagem resumida para WhatsApp" },
+      versao_tecnica: { type: "string", description: "Versão técnica completa" },
+    },
+    required: [
+      "diagnostico",
+      "insight_tecnico",
+      "beneficio_operacional",
+      "beneficio_economico",
+      "objecao_antecipada",
+      "versao_phone",
+      "versao_whatsapp",
+      "versao_tecnica",
+    ],
+  },
+};
+
+function texto(valor: unknown): string {
+  return typeof valor === "string" ? valor.trim() : "";
+}
+
+export interface PerguntaSpin {
+  type: string;
+  main: string;
+  alt: string;
+  rationale: string;
+}
+
+/**
+ * Mantém só pergunta com tipo SPIN conhecido e enunciado não-vazio.
+ * Pergunta sem `main` apareceria como item em branco na tela da vendedora.
+ */
+export function normalizarPerguntas(bruto: unknown): PerguntaSpin[] {
+  const lista = (bruto as { questions?: unknown })?.questions;
+  if (!Array.isArray(lista)) return [];
+
+  const out: PerguntaSpin[] = [];
+  for (const cru of lista) {
+    if (!cru || typeof cru !== "object") continue;
+    const item = cru as Record<string, unknown>;
+    const tipo = texto(item.type).toLowerCase();
+    const main = texto(item.main);
+    if (!main) continue;
+    if (!(TIPOS_SPIN as readonly string[]).includes(tipo)) continue;
+    out.push({
+      type: tipo,
+      main,
+      alt: texto(item.alt),
+      rationale: texto(item.rationale),
+    });
+  }
+  return out;
+}
+
+export interface Argumentacao {
+  diagnostico: string;
+  insight_tecnico: string;
+  beneficio_operacional: string;
+  beneficio_economico: string;
+  objecao_antecipada: string;
+  versao_phone: string;
+  versao_whatsapp: string;
+  versao_tecnica: string;
+}
+
+/**
+ * TODOS os campos são essenciais: a tela mostra as cinco linhas de argumentação
+ * e as três abas (phone/whatsapp/técnica) incondicionalmente, com botão de
+ * copiar. Campo vazio vira linha em branco que a vendedora copia e manda ao
+ * cliente. Como a geração é retriável e não há como recuperar um campo perdido,
+ * é tudo ou nada de verdade.
+ */
+export const CAMPOS_ESSENCIAIS = [
+  "diagnostico",
+  "insight_tecnico",
+  "beneficio_operacional",
+  "beneficio_economico",
+  "objecao_antecipada",
+  "versao_phone",
+  "versao_whatsapp",
+  "versao_tecnica",
+] as const;
+
+export function normalizarArgumentacao(bruto: unknown): Argumentacao | null {
+  if (!bruto || typeof bruto !== "object" || Array.isArray(bruto)) return null;
+  const o = bruto as Record<string, unknown>;
+
+  const arg: Argumentacao = {
+    diagnostico: texto(o.diagnostico),
+    insight_tecnico: texto(o.insight_tecnico),
+    beneficio_operacional: texto(o.beneficio_operacional),
+    beneficio_economico: texto(o.beneficio_economico),
+    objecao_antecipada: texto(o.objecao_antecipada),
+    versao_phone: texto(o.versao_phone),
+    versao_whatsapp: texto(o.versao_whatsapp),
+    versao_tecnica: texto(o.versao_tecnica),
+  };
+
+  // Sem os essenciais não há argumentação utilizável. Devolver o objeto pela
+  // metade faria a tela abrir com campos em branco e a vendedora mandar uma
+  // mensagem vazia para o cliente.
+  for (const campo of CAMPOS_ESSENCIAIS) {
+    if (!arg[campo]) return null;
+  }
+  return arg;
+}

--- a/supabase/functions/generate-bundle-argument/argumento-tools_test.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-tools_test.ts
@@ -1,0 +1,155 @@
+// Testa o CÓDIGO REAL de argumento-tools.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/generate-bundle-argument/
+//
+// Foco: `versao_whatsapp` é a mensagem que a vendedora ENVIA AO CLIENTE. O
+// fallback antigo a preenchia com `content.slice(0,150)` — texto cru do modelo.
+// Nada aqui pode deixar passar argumentação pela metade.
+import {
+  CAMPOS_ESSENCIAIS,
+  normalizarArgumentacao,
+  normalizarPerguntas,
+  TOOL_ARGUMENTO,
+  TOOL_PERGUNTAS,
+} from "./argumento-tools.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const ARG_COMPLETO = {
+  diagnostico: "Cliente com queda de recompra em abrasivos.",
+  insight_tecnico: "Provável desgaste prematuro por grão inadequado.",
+  beneficio_operacional: "Menos trocas de disco por turno.",
+  beneficio_economico: "Redução de paradas na linha.",
+  objecao_antecipada: "Preço acima do atual — responder com vida útil.",
+  versao_phone: "Olá, notei que a recompra de abrasivos caiu…",
+  versao_whatsapp: "Oi! Reparei uma queda no consumo de abrasivos 👀",
+  versao_tecnica: "Análise técnica completa do caso.",
+};
+
+// ───────────────────────────── schema das tools ─────────────────────────────
+
+Deno.test("schema: tools têm nomes DISTINTOS (o caller força uma por modo)", () => {
+  assert(
+    TOOL_PERGUNTAS.name !== TOOL_ARGUMENTO.name,
+    "nomes iguais fariam o modo errado ser forçado",
+  );
+});
+
+Deno.test("schema: os 8 campos da argumentação são obrigatórios", () => {
+  const req = TOOL_ARGUMENTO.input_schema.required as string[];
+  for (const campo of Object.keys(ARG_COMPLETO)) {
+    assert(req.includes(campo), `${campo} deveria ser required`);
+  }
+});
+
+Deno.test("schema: beneficio_economico instrui a NÃO estimar cifra", () => {
+  // Sem margem no contexto, qualquer número de economia seria fabricado.
+  const props = TOOL_ARGUMENTO.input_schema.properties as Record<
+    string,
+    { description?: string }
+  >;
+  const d = props.beneficio_economico.description ?? "";
+  assert(/não estime|qualitativa/i.test(d), "a descrição deveria proibir estimativa");
+});
+
+// ───────────────────────────── normalizarPerguntas ─────────────────────────────
+
+Deno.test("normalizarPerguntas: aceita os 4 tipos SPIN", () => {
+  const r = normalizarPerguntas({
+    questions: [
+      { type: "situacao", main: "a", alt: "x", rationale: "r" },
+      { type: "problema", main: "b", alt: "x", rationale: "r" },
+      { type: "implicacao", main: "c", alt: "x", rationale: "r" },
+      { type: "direcionamento", main: "d", alt: "x", rationale: "r" },
+    ],
+  });
+  assertEquals(r.length, 4);
+  assertEquals(r.map((q) => q.type), ["situacao", "problema", "implicacao", "direcionamento"]);
+});
+
+Deno.test("normalizarPerguntas: pergunta SEM enunciado é descartada", () => {
+  // Item em branco na tela da vendedora não é pergunta.
+  const r = normalizarPerguntas({
+    questions: [
+      { type: "situacao", main: "  ", alt: "x", rationale: "r" },
+      { type: "problema", alt: "x", rationale: "r" },
+      { type: "implicacao", main: "vale", alt: "x", rationale: "r" },
+    ],
+  });
+  assertEquals(r.length, 1);
+  assertEquals(r[0].main, "vale");
+});
+
+Deno.test("normalizarPerguntas: tipo SPIN desconhecido é descartado", () => {
+  const r = normalizarPerguntas({
+    questions: [
+      { type: "fechamento", main: "a", alt: "x", rationale: "r" },
+      { type: "", main: "b", alt: "x", rationale: "r" },
+    ],
+  });
+  assertEquals(r.length, 0);
+});
+
+Deno.test("normalizarPerguntas: entrada inválida degrada para lista vazia", () => {
+  for (const v of [null, undefined, {}, { questions: "três" }, { questions: null }, "x"]) {
+    assertEquals(normalizarPerguntas(v), [], `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("normalizarPerguntas: alt/rationale ausentes viram vazio, não undefined", () => {
+  const r = normalizarPerguntas({ questions: [{ type: "situacao", main: "a" }] });
+  assertEquals(r[0].alt, "");
+  assertEquals(r[0].rationale, "");
+});
+
+// ──────────────────────────── normalizarArgumentacao ────────────────────────────
+
+Deno.test("normalizarArgumentacao: saída completa passa inteira", () => {
+  assertEquals(normalizarArgumentacao(ARG_COMPLETO), ARG_COMPLETO);
+});
+
+Deno.test("normalizarArgumentacao: versao_whatsapp VAZIA invalida tudo", () => {
+  // É a mensagem enviada ao cliente — melhor erro explícito que mensagem vazia.
+  assertEquals(normalizarArgumentacao({ ...ARG_COMPLETO, versao_whatsapp: "" }), null);
+  assertEquals(normalizarArgumentacao({ ...ARG_COMPLETO, versao_whatsapp: "   " }), null);
+});
+
+Deno.test("normalizarArgumentacao: cada campo essencial ausente invalida", () => {
+  for (const campo of CAMPOS_ESSENCIAIS) {
+    const parcial = { ...ARG_COMPLETO } as Record<string, unknown>;
+    delete parcial[campo];
+    assertEquals(normalizarArgumentacao(parcial), null, `sem ${campo}`);
+  }
+});
+
+Deno.test("normalizarArgumentacao: TODOS os 8 campos são exigidos", () => {
+  // A tela mostra as 5 linhas e as 3 abas incondicionalmente, com botão de
+  // copiar: campo vazio vira texto em branco que a vendedora manda ao cliente.
+  for (const campo of Object.keys(ARG_COMPLETO)) {
+    assertEquals(
+      normalizarArgumentacao({ ...ARG_COMPLETO, [campo]: "" }),
+      null,
+      `${campo} vazio deveria invalidar`,
+    );
+  }
+});
+
+Deno.test("normalizarArgumentacao: não-objeto vira null", () => {
+  for (const v of [null, undefined, "texto", 42, [], true]) {
+    assertEquals(normalizarArgumentacao(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("normalizarArgumentacao: campo não-string não vira texto acidental", () => {
+  // `{diagnostico: 42}` não pode virar "42" no material que vai ao cliente.
+  assertEquals(normalizarArgumentacao({ ...ARG_COMPLETO, diagnostico: 42 }), null);
+});

--- a/supabase/functions/generate-bundle-argument/index.ts
+++ b/supabase/functions/generate-bundle-argument/index.ts
@@ -1,5 +1,18 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import {
+  extrairToolUseUnico,
+  MODELO_PADRAO,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "../_shared/anthropic.ts";
+import {
+  normalizarArgumentacao,
+  normalizarPerguntas,
+  TOOL_ARGUMENTO,
+  TOOL_PERGUNTAS,
+} from "./argumento-tools.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -24,8 +37,9 @@ serve(async (req) => {
       return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
+    const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!ANTHROPIC_API_KEY) throw new Error("ANTHROPIC_API_KEY is not configured");
+    const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
     const { bundle, customer, customerProfile, mode } = await req.json();
 
@@ -100,50 +114,51 @@ Confidence: ${(bundle.confidence * 100).toFixed(1)}%
 
 Histórico de compras recentes: ${customer.recentProducts?.join(', ') || 'Sem dados'}`;
 
-      const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${LOVABLE_API_KEY}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "google/gemini-2.5-flash",
-          messages: [
-            { role: "system", content: systemPrompt },
-            { role: "user", content: userPrompt },
-          ],
-        }),
-      });
-
-      if (!response.ok) {
-        if (response.status === 429) {
-          return new Response(JSON.stringify({ error: "Rate limit exceeded. Tente novamente em alguns segundos." }), {
-            status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" },
-          });
-        }
-        if (response.status === 402) {
-          return new Response(JSON.stringify({ error: "Créditos insuficientes. Adicione créditos ao workspace." }), {
-            status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" },
-          });
-        }
-        const t = await response.text();
-        console.error("AI gateway error:", response.status, t);
-        throw new Error(`AI gateway error: ${response.status}`);
-      }
-
-      const data = await response.json();
-      const content = data.choices?.[0]?.message?.content || "";
-
-      let parsed;
+      let resposta;
       try {
-        const jsonMatch = content.match(/\{[\s\S]*\}/);
-        parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : JSON.parse(content);
-      } catch {
-        console.error("Failed to parse AI response:", content);
-        parsed = { questions: [] };
+        resposta = await anthropic.messages.create({
+          model: MODELO_PADRAO,
+          max_tokens: 2000,
+          // Explícito: omitir usaria o default 1 da API. Material comercial pede
+          // baixa variabilidade — e o Gemini anterior não tinha o mesmo default.
+          temperature: 0.4,
+          system: systemPrompt,
+          tools: [TOOL_PERGUNTAS],
+          tool_choice: { type: "tool", name: TOOL_PERGUNTAS.name, disable_parallel_tool_use: true },
+          messages: [{ role: "user", content: userPrompt }],
+        });
+      } catch (e: unknown) {
+        const status = statusDoErro(e);
+        console.error("[generate-bundle-argument] erro na API (perguntas):", status, e instanceof Error ? e.message : e);
+        const mapeado = traduzirErroAnthropic(status);
+        return new Response(JSON.stringify({ error: mapeado?.mensagem ?? "Erro ao gerar perguntas" }), {
+          status: mapeado?.http ?? 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
       }
 
-      return new Response(JSON.stringify(parsed), {
+      // Truncou = perguntas cortadas no meio. Entregar as que couberam faria a
+      // vendedora ir para a visita com um roteiro SPIN incompleto achando que
+      // está inteiro.
+      if (resposta.stop_reason === "max_tokens") {
+        console.error("[generate-bundle-argument] perguntas truncadas");
+        return new Response(JSON.stringify({ error: "Geração truncada. Tente novamente." }), {
+          status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+
+      // ANTES: `JSON.parse` do texto e, no catch, `{ questions: [] }` — lista
+      // vazia silenciosa que a tela mostrava como "sem perguntas" em vez de
+      // "não consegui gerar".
+      const extraido = extrairToolUseUnico(resposta.content);
+      const perguntas = extraido.ok ? normalizarPerguntas(extraido.input) : [];
+      if (perguntas.length === 0) {
+        console.error("[generate-bundle-argument] sem perguntas utilizáveis");
+        return new Response(JSON.stringify({ error: "A IA não devolveu perguntas utilizáveis. Tente novamente." }), {
+          status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+        });
+      }
+
+      return new Response(JSON.stringify({ questions: perguntas }), {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
@@ -194,56 +209,49 @@ Lift: ${bundle.lift.toFixed(2)}
 
 Histórico de compras recentes do cliente: ${customer.recentProducts?.join(', ') || 'Sem dados'}`;
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "google/gemini-2.5-flash",
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: userPrompt },
-        ],
-      }),
-    });
-
-    if (!response.ok) {
-      if (response.status === 429) {
-        return new Response(JSON.stringify({ error: "Rate limit exceeded. Tente novamente em alguns segundos." }), {
-          status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      if (response.status === 402) {
-        return new Response(JSON.stringify({ error: "Créditos insuficientes. Adicione créditos ao workspace." }), {
-          status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      const t = await response.text();
-      console.error("AI gateway error:", response.status, t);
-      throw new Error(`AI gateway error: ${response.status}`);
+    let resposta;
+    try {
+      resposta = await anthropic.messages.create({
+        model: MODELO_PADRAO,
+        max_tokens: 2000,
+        // Explícito: omitir usaria o default 1 da API. Material comercial pede
+        // baixa variabilidade — e o Gemini anterior não tinha o mesmo default.
+        temperature: 0.4,
+        system: systemPrompt,
+        tools: [TOOL_ARGUMENTO],
+        tool_choice: { type: "tool", name: TOOL_ARGUMENTO.name, disable_parallel_tool_use: true },
+        messages: [{ role: "user", content: userPrompt }],
+      });
+    } catch (e: unknown) {
+      const status = statusDoErro(e);
+      console.error("[generate-bundle-argument] erro na API (argumento):", status, e instanceof Error ? e.message : e);
+      const mapeado = traduzirErroAnthropic(status);
+      return new Response(JSON.stringify({ error: mapeado?.mensagem ?? "Erro ao gerar argumentação" }), {
+        status: mapeado?.http ?? 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content || "";
+    // Truncou = argumentação cortada. As versões phone/whatsapp são os últimos
+    // campos do schema, então é justamente o texto que vai ao cliente que some.
+    if (resposta.stop_reason === "max_tokens") {
+      console.error("[generate-bundle-argument] argumentação truncada");
+      return new Response(JSON.stringify({ error: "Geração truncada. Tente novamente." }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
 
-    let parsed;
-    try {
-      const jsonMatch = content.match(/\{[\s\S]*\}/);
-      parsed = jsonMatch ? JSON.parse(jsonMatch[0]) : JSON.parse(content);
-    } catch {
-      console.error("Failed to parse AI response:", content);
-      parsed = {
-        diagnostico: "Análise em processamento",
-        insight_tecnico: "Consulte dados técnicos",
-        beneficio_operacional: "Melhoria operacional esperada",
-        beneficio_economico: "Economia potencial identificada",
-        objecao_antecipada: "Avalie custo-benefício",
-        versao_phone: content.slice(0, 200),
-        versao_whatsapp: content.slice(0, 150),
-        versao_tecnica: content,
-      };
+    // ANTES: no catch do JSON.parse, `versao_whatsapp` virava `content.slice(0,150)`
+    // — o texto CRU do modelo (raciocínio, markdown quebrado, JSON pela metade)
+    // como mensagem enviada AO CLIENTE — e `beneficio_economico` virava
+    // "Economia potencial identificada", uma afirmação econômica fabricada.
+    // Com tool-use, ou o schema é satisfeito, ou a edge falha explícito.
+    const extraido = extrairToolUseUnico(resposta.content);
+    const parsed = extraido.ok ? normalizarArgumentacao(extraido.input) : null;
+    if (!parsed) {
+      console.error("[generate-bundle-argument] sem argumentação utilizável");
+      return new Response(JSON.stringify({ error: "A IA não devolveu uma argumentação utilizável. Tente novamente." }), {
+        status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
     return new Response(JSON.stringify(parsed), {


### PR DESCRIPTION
## Por quê

O orçamento do gateway de IA do Lovable estourou e as features de IA pararam em produção. Fase 3 da migração para a API Anthropic direta — fases 1 e 2 nos PRs #1592 e #1608.

**Sobre o escopo:** duas sessões migraram o `generate-tactical-plan` em paralelo. O **#1618** mergeou primeiro, com diagnóstico de produção que este trabalho não tinha (nenhum plano gerado desde 27/07, 59 erros/dia, e a descoberta de que o gateway devolve o "usage limit" fora dos status 429/402 tratados). Cedi essa edge a ele — este PR ficou só com o diferencial.

## O que muda

### `generate-bundle-argument` → Anthropic com forced tool-use

O ganho principal não é o provedor. No `catch` do `JSON.parse`, a edge montava:

```ts
versao_whatsapp: content.slice(0, 150)
beneficio_economico: "Economia potencial identificada"
```

A **mensagem enviada ao cliente** virava os primeiros 150 caracteres do texto cru do modelo — raciocínio, markdown quebrado, JSON pela metade. E o benefício econômico virava afirmação fabricada.

Agora, sem `tool_use` válido ou com `stop_reason: max_tokens`, é **422 explícito** e nada é enviado. Os **8 campos** são exigidos: a tela mostra as 5 linhas e as 3 abas com botão de copiar, então campo vazio vira texto em branco que a vendedora manda ao cliente.

### O 402 parava de chegar a quem usa

Achado do `/codex` no challenge desta fase. Os 3 hooks chamavam `supabase.functions.invoke` cru e tratavam `data.error` — que **só existe em resposta 200**. Como a edge agora responde 402/422, o motivo real virava o toast genérico: exatamente o sintoma *"feature parou sem sinal claro de orçamento"* que motivou a migração inteira.

Trocados por `invokeFunction`, que extrai a mensagem do corpo. Os 3 testes de `generatePlan` acompanham o mock.

### `_shared/anthropic.ts` (novo)

Mapa de erro `400/401/402/403/404/409/413/429/500/503/504/529` + `extrairToolUseUnico`. Havia 10 edges repetindo o padrão sem helper.

Dois pontos que o Codex corrigiu no desenho:
- **`400` não é "a IA recusou"** — é requisição inválida, quase sempre defeito nosso; recusa vem em 200 com `stop_reason: "refusal"`. Virou 500 "avise a equipe".
- **Status desconhecido devolve `null`** e o caller trata como 500, em vez de inventar mensagem tranquilizadora para uma falha nova.

## Prova

| Gate | Resultado |
|---|---|
| `test:edges` | 475 passed · 0 failed |
| `eslint .` | exit 0 · **0 erros** |
| `deno check` bundle-argument | 0 erros |

**Falsificação** — 25 testes, baseline verde, 2 locales (`C` e `pt_BR.UTF-8`), cada sabotagem tendo de derrubar os testes **nomeados**:

| Sabotagem | Vermelhos |
|---|---|
| argumentação pela metade (WhatsApp vazio ao cliente) | 4/25 |
| pergunta sem enunciado entra na lista | 1/25 |
| volta a exigir só 3 dos 8 campos | 1/25 |
| 402 deixa de ser reconhecido | 1/25 |
| status desconhecido devolve mensagem tranquilizadora | 1/25 |
| dois `tool_use` voltam a ser cortados no primeiro | 1/25 |

## ⚠️ Dois guards seguem abertos no `generate-tactical-plan` (follow-up)

O challenge do Codex nesta fase achou dois defeitos que **o #1618 não cobre** — confirmei no código já mergeado:

1. **Crash de tela.** `normalizarLtv`/`normalizarCenarios` usam `algum ? obj : null`, devolvendo o objeto quando **ao menos um** campo está medido. `PlanCard` checa só se o objeto existe e chama `fmt(v) = v.toLocaleString(...)` em cada membro — `fmt(null)` lança e derruba o plano.
2. **Objetivo contraditório.** `plan.strategic_objective || d.strategicObjective` deixa a IA vencer o derivado. Com `sem_historico` (fato binário: não há venda registrada), a IA devolvendo `recuperacao` passa no enum e grava plano de recuperação para cliente que nunca comprou.

Vão em PR separado sobre o #1618, para não misturar com este escopo.

## Depois do merge (deploy é manual — merge não deploya nada)

1. Confirmar `ANTHROPIC_API_KEY` nos secrets do Supabase.
2. Deployar pelo chat do Lovable — **3 arquivos**: `_shared/anthropic.ts`, `generate-bundle-argument/index.ts`, `generate-bundle-argument/argumento-tools.ts`.
3. **Publish do frontend** (3 hooks passaram a usar `invokeFunction`).
4. Conferir que nenhum commit "Changes" do bot reverteu os arquivos depois do merge.
