### PR TITLE
fix(farmer): potencial de receita/expansão para de chegar ao prompt da IA como R$ 0 [money-path]

### DIFF
--- a/src/__tests__/potencial-nao-medido-gate.test.ts
+++ b/src/__tests__/potencial-nao-medido-gate.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Gate de REGRESSÃO (lado `src/`): `revenue_potential` e `expansion_score` não voltam a ser
+ * coagidos a 0 no caminho do front que alimenta o prompt da IA.
+ *
+ * Irmão de `supabase/functions/_shared/potencial-nao-medido_test.ts`, que vigia a edge. Os dois
+ * existem porque o plano tático tem DUAS portas para o mesmo prompt — o cron (self-contained,
+ * na edge) e o botão da tela (`useTacticalPlan.generatePlan`, aqui) — e corrigir uma só deixa a
+ * fabricação viva pela outra. O gate de edge não alcança este arquivo: `test:edges` roda com
+ * `--allow-read=supabase/functions`.
+ *
+ * O DADO que torna isto money-path, medido em prod via psql-ro em 2026-07-29 (6.633 linhas de
+ * farmer_client_scores):
+ *   revenue_potential → 6.633 NULL / 0 zeros / 0 positivos   (column_default removido)
+ *   expansion_score   → 6.633 NULL / 0 zeros / 0 positivos   (column_default removido)
+ * A migration 20260727130000_farmer_scores_colunas_orfas_null nulou as duas de propósito —
+ * nenhum writer as calcula. Com `|| 0`, o prompt recebia "revenuePotential: 0" para 100% da
+ * base, e o system prompt instrui a IA a ler número como MEDIDO.
+ *
+ * Por que um gate de FONTE e não só teste de comportamento: o helper (`valorMedido`) já é
+ * testado; o defeito desta família nunca esteve no helper, e sim em NÃO CHAMÁ-LO no call-site
+ * (docs/agent/money-path.md §7). Só quem olha o call-site pega a reintrodução.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Neutraliza comentário antes do predicado. Sem isto o gate mede PROSA: o arquivo vigiado
+ * EXPLICA em comentário o `|| 0` que removeu, e a explicação dispararia o teste com o código
+ * íntegro — o falso-VERMELHO que money-path.md §"O ALVO mente" manda prevenir.
+ */
+function semComentario(linha: string): string {
+  const t = linha.trim();
+  if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return '';
+  return linha.replace(/\/\/.*$/, '');
+}
+
+const CAMPOS = ['expansion_score', 'revenue_potential', 'expansion_potential'];
+
+/**
+ * Coerção a zero aplicada a um dos campos, ancorada no NOME da coluna e não na forma do
+ * fallback — `Number(x || 0)`, `x ?? 0` e `Number(x ?? 0)` são a mesma fabricação, e uma regex
+ * por forma vira corrida entre o gate e a criatividade de quem escreve (money-path.md §"O GATE
+ * mente quando a regex não conhece a forma REAL do repo": lá o `\s*` não atravessava um cast e
+ * o gate media 0 em arquivos com sites vivos).
+ *
+ * `[^;\n]{0,80}?` aceita cast e parênteses no meio sem atravessar statement.
+ */
+function coercoes(codigo: string): string[] {
+  const achados: string[] = [];
+  for (const campo of CAMPOS) {
+    for (const m of codigo.matchAll(new RegExp(`${campo}[^;\\n]{0,80}?(\\?\\?|\\|\\|)\\s*0`, 'g'))) {
+      achados.push(m[0]);
+    }
+  }
+  return achados;
+}
+
+const VIGIADOS = [
+  'src/hooks/useTacticalPlan.ts',
+];
+
+describe('gate: potencial sem writer não é coagido a 0 (src/)', () => {
+  it('nenhum call-site do front coage expansion_score/revenue_potential', () => {
+    const ofensas: string[] = [];
+
+    for (const rel of VIGIADOS) {
+      const fonte = readFileSync(resolve(process.cwd(), rel), 'utf8');
+      fonte.split('\n').forEach((linha, i) => {
+        for (const trecho of coercoes(semComentario(linha))) {
+          ofensas.push(`${rel}:${i + 1}: ${trecho.trim()}`);
+        }
+      });
+    }
+
+    expect(
+      ofensas,
+      'Campo sem writer coagido a 0 no caminho do prompt da IA — "ausente != zero".\n' +
+        'revenue_potential e expansion_score sao NULL em 6.633/6.633 linhas em prod.\n' +
+        'Use valorMedido de @/lib/scoring/margin:\n  ' +
+        ofensas.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('o DETECTOR enxerga a coerção quando ela existe (par obrigatório)', () => {
+    // Sem este par, "nenhuma ofensa" e "o predicado está quebrado" têm o mesmo output — um
+    // seletor morto passa sempre (money-path.md §"O DETECTOR mente" e a versão UI dele).
+    const formasReais = [
+      'const revenuePotential = Number(score.revenue_potential || 0);',
+      'const expansionPotential = Number(score.expansion_score || 0);',
+      'expansionPotential: Number(d.expansion_potential || 0),',
+      'revenuePotential: Number(score.revenue_potential ?? 0),',
+      'const rev = (score.revenue_potential as number) || 0;',
+    ];
+    for (const forma of formasReais) {
+      expect(coercoes(forma).length, `o detector NÃO pegou: ${forma}`).toBeGreaterThan(0);
+    }
+  });
+
+  it('não acusa o código correto nem o comentário que cita o bug', () => {
+    const corretas = [
+      'const revenuePotential = valorMedido(score.revenue_potential);',
+      'const expansionPotential = valorMedido(score.expansion_score);',
+      'expansionPotential: valorMedido(d.expansion_potential),',
+    ];
+    for (const forma of corretas) {
+      expect(coercoes(forma), `falso-VERMELHO em código correto: ${forma}`).toEqual([]);
+    }
+
+    const prosa = '      // Com `|| 0` o revenue_potential || 0 chegava como 0 para toda a base';
+    expect(semComentario(prosa)).toBe('');
+    expect(coercoes(semComentario(prosa))).toEqual([]);
+  });
+});

--- a/src/components/farmer/tacticalPlan/PlanCard.tsx
+++ b/src/components/farmer/tacticalPlan/PlanCard.tsx
@@ -80,7 +80,10 @@ export const PlanCard = ({
             <Section title="Diagnóstico Resumido" icon={Heart}>
               <MetricRow label="Margem atual" value={formatMargemPct(plan.currentMarginPct)} />
               <MetricRow label="Média cluster" value={plan.clusterAvgMarginPct == null ? '—' : `${plan.clusterAvgMarginPct.toFixed(1)}%`} />
-              <MetricRow label="Potencial expansão" value={`${plan.expansionPotential.toFixed(0)}%`} />
+              {/* "—" e não "0%": expansion_score não tem writer (NULL em 6.633/6.633 linhas), e
+                  "0%" leria como veredito de que o cliente não tem espaço para crescer. Mesmo
+                  tratamento do clusterAvgMarginPct logo acima. */}
+              <MetricRow label="Potencial expansão" value={plan.expansionPotential == null ? '—' : `${plan.expansionPotential.toFixed(0)}%`} />
               <MetricRow label="Perfil" value={profileLabels[plan.customerProfile] || plan.customerProfile} />
             </Section>
 

--- a/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
@@ -111,6 +111,34 @@ describe("PlanCard", () => {
     });
   });
 
+  // Mesmo raciocínio da margem, no campo irmão que ficou para trás. `expansion_score` não tem
+  // writer: é NULL em 6.633/6.633 linhas de farmer_client_scores (psql-ro, 2026-07-29), então
+  // "0%" aqui não seria um caso de borda — era o que a vendedora via para TODO cliente, lido
+  // como "não há espaço para crescer nesta conta".
+  describe("potencial de expansão — ausência não pode virar 0%", () => {
+    // O prefixo ASCII é âncora de falsificação: o harness casa "[POT-CARD]" com `grep -F`, e o
+    // nome acentuado não serve para isso (o `grep` deste shell é shim para ugrep, que dobra
+    // acento em todo locale — money-path.md manda ancorar em trecho ASCII, caixa fixa). A
+    // primeira rodada da falsificação reportou "vermelho no lugar errado" só por causa disso.
+    it("[POT-CARD] potencial não medido exibe travessão, não 0%", () => {
+      setup({ expanded: true, plan: makePlan({ expansionPotential: null }) });
+      expect(screen.getAllByText("—").length).toBeGreaterThan(0);
+      expect(screen.queryByText("0%")).toBeNull();
+    });
+
+    it("potencial ZERO medido continua sendo 0% — é veredito, não ausência", () => {
+      // O par que impede a correção de virar "esconde tudo": no dia em que um produtor
+      // apurar potencial nulo, esse fato tem de chegar à tela.
+      setup({ expanded: true, plan: makePlan({ expansionPotential: 0 }) });
+      expect(screen.getByText("0%")).toBeTruthy();
+    });
+
+    it("potencial medido é exibido como percentual", () => {
+      setup({ expanded: true, plan: makePlan({ expansionPotential: 60 }) });
+      expect(screen.getByText("60%")).toBeTruthy();
+    });
+  });
+
   // LTV/cenários são blocos PARCIALMENTE mensuráveis: a edge grava número no campo que a
   // IA apurou e null no que ela não apurou. Os guards do card (`plan.ltvProjection && …`)
   // só testam o OBJETO — com um campo null lá dentro, o `fmt()` antigo executava

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { invokeFunction } from '@/lib/invoke-function';
 import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
-import { margemConhecida, mediaMargensConhecidas } from '@/lib/scoring/margin';
+import { margemConhecida, mediaMargensConhecidas, valorMedido } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
 import { ownersAtivosDoAlvo } from '@/lib/carteira/escopo-clientes';
 import { useAuth } from '@/contexts/AuthContext';
@@ -29,7 +29,9 @@ export interface TacticalPlan {
   /** PERCENTUAL (0–100), ou null quando a margem era desconhecida na geração do plano. */
   currentMarginPct: number | null;
   clusterAvgMarginPct: number | null;
-  expansionPotential: number;
+  /** PERCENTUAL, ou null quando o potencial não foi medido — hoje, 100% da base
+   *  (farmer_client_scores.expansion_score é NULL em 6.633/6.633; nenhum writer o calcula). */
+  expansionPotential: number | null;
 
   // Strategy
   strategicObjective: string;
@@ -257,7 +259,11 @@ export const useTacticalPlan = () => {
       // pode ser null, e `Number(null || 0)` a exibiria como "0,0%" — margem nula apurada.
       currentMarginPct: margemConhecida(d.current_margin_pct),
       clusterAvgMarginPct: d.cluster_avg_margin_pct == null ? null : Number(d.cluster_avg_margin_pct),
-      expansionPotential: Number(d.expansion_potential || 0),
+      // Mesma razão do currentMarginPct logo acima, e o irmão que ficou para trás: o plano
+      // persistido pode ter gravado null (potencial não medido na geração), e
+      // `Number(null || 0)` o exibiria como "0%" — um veredito de "cliente sem espaço para
+      // crescer" que ninguém apurou. A coluna expansion_potential é nullable em prod.
+      expansionPotential: valorMedido(d.expansion_potential),
       strategicObjective: d.strategic_objective,
       customerProfile: d.customer_profile,
       approachStrategy: d.approach_strategy || '',
@@ -369,16 +375,24 @@ export const useTacticalPlan = () => {
       return { estimatedProfitPerHour: null, threshold: PROFIT_PER_HOUR_THRESHOLD, isAboveThreshold: null, motivo: 'indisponivel' };
     }
 
-    const revPotential = Number(score.revenue_potential || 0);
+    // Tri-estado explícito: revenue_potential é NULL em 6.633/6.633 linhas (nenhum writer o
+    // calcula). O `|| 0` anterior transformava "não medido" em `0` e só não fabricava número
+    // por ACIDENTE — o `> 0 ?` logo abaixo o mandava para o avgSpend. Acidente não é guard: no
+    // dia em que um produtor gravar potencial 0 APURADO, o código o trataria como ausência.
+    const revPotential = valorMedido(score.revenue_potential);
     const avgSpend = Number(score.avg_monthly_spend_180d || 0);
     // Margem desconhecida → R$/h INDECIDÍVEL, não zero. Com `|| 0` o gate reprovava o cliente por
     // omissão, e "não sei" ficava indistinguível de "não vale a ligação" na tela da vendedora.
     // Espelha profitPerHora de supabase/functions/_shared/tactical-margem.ts.
     const marginPct = margemConhecida(score.gross_margin_pct);
     const avgCallMinutes = 15;
+    // Base do cálculo: o potencial quando MEDIDO e positivo; senão o gasto médio observado.
+    // Potencial ausente e potencial 0 caem ambos no avgSpend — comportamento PRESERVADO desta
+    // entrega (só o `|| 0` saiu), agora por decisão declarada em vez de coincidência aritmética.
+    const baseReceita = revPotential != null && revPotential > 0 ? revPotential : avgSpend;
     const estimatedProfitPerHour = marginPct == null
       ? null
-      : ((revPotential > 0 ? revPotential : avgSpend) * (marginPct / 100) * 0.1) / (avgCallMinutes / 60);
+      : (baseReceita * (marginPct / 100) * 0.1) / (avgCallMinutes / 60);
 
     return {
       estimatedProfitPerHour,
@@ -435,8 +449,16 @@ export const useTacticalPlan = () => {
       const marginPct = margemConhecida(score.gross_margin_pct);
       const categoryCount = Number(score.category_count || 0);
       const daysSince = Number(score.days_since_last_purchase || 0);
-      const expansionPotential = Number(score.expansion_score || 0);
-      const revenuePotential = Number(score.revenue_potential || 0);
+      // [money-path "ausente ≠ zero"] Espelha a edge generate-tactical-plan: estas duas colunas
+      // foram nuladas de propósito (20260727130000_farmer_scores_colunas_orfas_null) porque
+      // nenhum writer as calcula — 6.633/6.633 NULL em prod, `column_default` removido. Com
+      // `|| 0` os dois campos chegavam ao prompt como `0` para TODA a base, e o system prompt
+      // instrui a IA a ler número como MEDIDO: "revenuePotential: 0" afirma "cliente sem
+      // potencial" e muda a abordagem que a vendedora leva para a rua. Nenhum dos dois entra
+      // em comparação relacional daqui para baixo (só no prompt e no payload, ambos nullable),
+      // então o tri-estado não reabre a armadilha do `null < x`.
+      const expansionPotential = valorMedido(score.expansion_score);
+      const revenuePotential = valorMedido(score.revenue_potential);
       const salesHistoryStatus = score.sales_history_status ?? null;
 
       // [GUARD money-path] Cluster = média de margem dos PARES da carteira do DONO (ownerId), não

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -693,6 +693,7 @@ export const MODULOS: ModuloApp[] = [
       "src/__tests__/leitura-single-shot-gate.test.ts",
       "src/__tests__/paginacao-artesanal-gate.test.ts",
       "src/__tests__/escrita-critica-gate.test.ts",
+      "src/__tests__/potencial-nao-medido-gate.test.ts",
       "src/lib/escape-html.test.ts",
       "src/lib/__tests__/**",
       "src/components/__tests__/ErrorBoundary.test.tsx",

--- a/src/lib/scoring/__tests__/potencial-nao-medido.test.ts
+++ b/src/lib/scoring/__tests__/potencial-nao-medido.test.ts
@@ -1,0 +1,55 @@
+/**
+ * "Ausente ≠ zero" para os campos de POTENCIAL — os irmãos que ficaram para trás quando o
+ * #1495/#1498 corrigiram a margem.
+ *
+ * Contexto medido em prod (psql-ro, 2026-07-29, 6.633 linhas de farmer_client_scores):
+ *   revenue_potential → 6.633 NULL / 0 zeros / 0 positivos   (column_default removido)
+ *   expansion_score   → 6.633 NULL / 0 zeros / 0 positivos   (column_default removido)
+ * A migration 20260727130000_farmer_scores_colunas_orfas_null nulou as duas de propósito
+ * (nenhum writer as calcula). Cada `|| 0` sobre elas afirmava "potencial zero" a respeito de
+ * 100% da base — e o número entrava no prompt do plano tático, de onde sai a abordagem
+ * comercial. Não é defesa preventiva: era fabricação ATIVA.
+ */
+import { describe, it, expect } from 'vitest';
+import { valorMedido } from '../margin';
+
+describe('valorMedido — o tri-estado', () => {
+  it('trata ausência, em todas as formas, como null', () => {
+    // `[]`/`[0]`/`true` estão aqui porque `Number([]) === 0`, `Number([0]) === 0` e
+    // `Number(true) === 1`: um guard escrito como `Number(x)` + `isFinite` os deixaria passar
+    // como valor medido. O caso `[]` reprovou a primeira versão deste helper na edge irmã.
+    for (const ausente of [null, undefined, NaN, Infinity, -Infinity, 'abc', '', '   ', {}, [], [0], true, false]) {
+      expect(valorMedido(ausente), `${JSON.stringify(ausente)} deveria ser null`).toBeNull();
+    }
+  });
+
+  it('trata ZERO como valor MEDIDO, não como ausência', () => {
+    // A metade que se esquece: 0 é um veredito apurado ("sem potencial"), e confundi-lo com
+    // "não medido" é o mesmo erro na direção oposta — precisão nos dois sentidos.
+    expect(valorMedido(0)).toBe(0);
+    expect(valorMedido('0')).toBe(0);
+  });
+
+  it('aceita número e string numérica (numeric do Postgres chega como string)', () => {
+    expect(valorMedido(42)).toBe(42);
+    expect(valorMedido('12.5')).toBe(12.5);
+  });
+
+  it('NÃO fabrica número onde o `|| 0` fabricava', () => {
+    // O assert que traduz o bug: a expressão antiga e a nova sobre o MESMO dado de prod.
+    const doBanco = null; // revenue_potential real: 6.633/6.633 linhas
+    expect(Number(doBanco || 0)).toBe(0); // o que chegava ao prompt
+    expect(valorMedido(doBanco)).toBeNull(); // o que chega agora
+  });
+});
+
+describe('a armadilha relacional que o tri-estado NÃO pode reabrir', () => {
+  it('null coage a 0 em comparação — por isso o guard != null é obrigatório', () => {
+    // money-path.md §2 (corolário JS): trocar `?? 0` por null sem revisar as comparações
+    // MOVE a fabricação em vez de eliminá-la. Este teste existe para que a armadilha fique
+    // escrita ao lado do helper, e não como surpresa de quem for adotá-lo no próximo campo.
+    const naoMedido = valorMedido(null);
+    expect(naoMedido as unknown as number < 20).toBe(true); // <- o perigo, em uma linha
+    expect(naoMedido != null && naoMedido < 20).toBe(false); // <- a forma correta
+  });
+});

--- a/src/lib/scoring/margin.ts
+++ b/src/lib/scoring/margin.ts
@@ -23,6 +23,44 @@ export function margemConhecida(raw: unknown): number | null {
 }
 
 /**
+ * A MESMA disciplina de `margemConhecida`, com nome neutro: valor numérico medido, ou `null`.
+ *
+ * Existe separada porque a regra "ausente ≠ zero" não é sobre margem — é sobre qualquer número
+ * que uma pessoa vai ler como fato. Chamar `margemConhecida(revenue_potential)` funcionaria e
+ * mentiria para o próximo leitor sobre o que está sendo medido.
+ *
+ * Nasceu para `farmer_client_scores.revenue_potential` e `expansion_score`, que a migration
+ * 20260727130000_farmer_scores_colunas_orfas_null nulou porque nenhum writer os calcula:
+ * **6.633 de 6.633 linhas são NULL** (medido em prod via psql-ro, 2026-07-29). Cada `|| 0`
+ * sobre elas afirma "potencial zero" a respeito de 100% da base — e esse número entra no
+ * prompt do plano tático, de onde sai a abordagem que a vendedora leva para a rua.
+ *
+ * ⚠️ Vale o mesmo alerta relacional: `null < 20` é `true` em JS. Ao adotar o tri-estado num
+ * campo que já participava de comparação, o guard `!= null` passa a ser obrigatório — trocar
+ * `?? 0` por null sem ele TROCA a fabricação de lugar em vez de eliminá-la (money-path.md §2).
+ *
+ * ⚠️ Allowlist por `typeof`, e não `Number()` seguido de `isFinite`: `Number("") === 0` e
+ * `Number([]) === 0`, então um campo em branco ou um payload malformado atravessariam o
+ * `isFinite` como um zero de aparência perfeita — a coerção já teria fabricado o número antes
+ * do guard olhar. (`margemConhecida` acima é mais permissivo por histórico; código novo usa
+ * este.) Diferença medida por teste, não suposta.
+ *
+ * Espelhado por `numeroValido` em
+ * `supabase/functions/generate-tactical-plan/plano-helpers.ts` e por `valorMedido` em
+ * `supabase/functions/generate-bundle-argument/argumento-helpers.ts` (Deno não importa de `src/`).
+ */
+export function valorMedido(raw: unknown): number | null {
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string') {
+    const t = raw.trim();
+    if (t.length === 0) return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
  * Média das margens conhecidas, ou `null` se nenhuma for conhecida.
  *
  * Existe como função própria porque a forma errada é sedutora: filtrar o numerador e esquecer

--- a/supabase/functions/_shared/potencial-nao-medido_test.ts
+++ b/supabase/functions/_shared/potencial-nao-medido_test.ts
@@ -1,0 +1,146 @@
+// Gate de REGRESSÃO: `farmer_client_scores.expansion_score` e `revenue_potential` não são
+// coagidos a 0 no caminho que alimenta o prompt da IA.
+//
+// POR QUE UM GATE DE FONTE, e não só teste de comportamento: a montagem do `customerContext`
+// mora no `index.ts` da edge, que importa `npm:@anthropic-ai/sdk` e `npm:@supabase/supabase-js`
+// — `test:edges` roda com `--no-remote` e não resolve nenhum dos dois, então o wiring é
+// estruturalmente inalcançável por teste de comportamento. O helper `numeroValido` já era
+// testado quando o `num = (v) => Number(v ?? 0)` foi escrito ao lado dele; o defeito não estava
+// no helper, estava em NÃO CHAMÁ-LO (docs/agent/money-path.md §7 — consertar o helper não
+// conserta o call-site).
+//
+// O DADO que torna isto money-path, medido em prod via psql-ro em 2026-07-29:
+//   revenue_potential → 6.633 NULL / 0 zeros / 0 positivos de 6.633   (column_default removido)
+//   expansion_score   → 6.633 NULL / 0 zeros / 0 positivos de 6.633   (column_default removido)
+// A migration 20260727130000_farmer_scores_colunas_orfas_null nulou as duas de propósito
+// (nenhum writer as calcula). Com `?? 0` / `|| 0` o prompt recebia "revenuePotential: 0" para
+// 100% da base — e o system prompt manda a IA ler número como MEDIDO.
+//
+// Falsificado: reintroduzir a coerção em qualquer um dos dois arquivos deixa este teste
+// VERMELHO nomeando arquivo, linha e o trecho ofensor.
+
+// Sem import remoto (`--no-remote`) — padrão do repo, ver _shared/escrita-critica_test.ts.
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+/**
+ * Neutraliza comentário antes do predicado. Sem isto o gate mede PROSA: os dois arquivos
+ * vigiados EXPLICAM em comentário por que não coagem estes campos (citando o `?? 0` que
+ * removeram), e essa frase dispararia o teste com o código íntegro. É o `stripComments` que o
+ * money-path.md §"O ALVO mente" exige de todo assert sobre texto — lá o falso-VERDE veio de um
+ * comentário escrito pela própria migration sob teste.
+ */
+function semComentario(linha: string): string {
+  const t = linha.trim();
+  if (t.startsWith("//") || t.startsWith("*") || t.startsWith("/*")) return "";
+  return linha.replace(/\/\/.*$/, "");
+}
+
+/** As duas colunas sem writer. Nomes em snake_case (como saem do banco) e camelCase (front). */
+const CAMPOS = ["expansion_score", "revenue_potential"];
+
+/**
+ * Coerção a zero aplicada a um dos campos. Ancorado no NOME da coluna e não na forma do
+ * fallback: `Number(x ?? 0)`, `Number(x || 0)`, `num(x)` e `x ?? 0` são a mesma fabricação, e
+ * uma regex por forma vira corrida entre o gate e a criatividade de quem escreve
+ * (money-path.md §"O GATE mente quando a regex não conhece a forma REAL do repo").
+ *
+ * `[^;\n]{0,80}?` aceita cast e parênteses no meio (`(score.revenue_potential as number) || 0`)
+ * sem atravessar statement — a forma que o formatador automático produz e que já enganou o G4.
+ */
+function coercoesEmLinha(codigo: string): string[] {
+  const achados: string[] = [];
+  for (const campo of CAMPOS) {
+    const padrao = new RegExp(`${campo}[^;\\n]{0,80}?(\\?\\?|\\|\\|)\\s*0`, "g");
+    for (const m of codigo.matchAll(padrao)) achados.push(m[0]);
+  }
+  return achados;
+}
+
+/**
+ * O `num()` da edge é um alias LOCAL de `Number(v ?? 0)` — aplicá-lo a um dos campos coage
+ * sem que nenhum `?? 0` apareça na linha. O predicado acima não o pegaria.
+ */
+function numAplicadoACampo(codigo: string): string[] {
+  const achados: string[] = [];
+  for (const campo of CAMPOS) {
+    for (const m of codigo.matchAll(new RegExp(`\\bnum\\s*\\([^)]*${campo}`, "g"))) achados.push(m[0]);
+  }
+  return achados;
+}
+
+// Só edges: `test:edges` roda com `--allow-read=supabase/functions` e não enxerga `src/`.
+// O caminho do FRONT monta o MESMO customerContext e chama a MESMA edge — corrigir um lado
+// só deixaria a fabricação viva pela outra porta —, e por isso tem gate irmão em vitest:
+// `src/__tests__/potencial-nao-medido-gate.test.ts`. Os dois se complementam; nenhum
+// substitui o outro (mesmo arranjo de escrita-critica: contrato em Deno, call-sites no CI do src).
+const VIGIADOS: Array<{ rotulo: string; url: URL }> = [
+  {
+    rotulo: "generate-tactical-plan/index.ts",
+    url: new URL("../generate-tactical-plan/index.ts", import.meta.url),
+  },
+];
+
+Deno.test("expansion_score/revenue_potential não são coagidos a 0 antes do prompt", async () => {
+  const ofensas: string[] = [];
+
+  for (const { rotulo, url } of VIGIADOS) {
+    const fonte = await Deno.readTextFile(url);
+    fonte.split("\n").forEach((linha, i) => {
+      const codigo = semComentario(linha);
+      for (const trecho of [...coercoesEmLinha(codigo), ...numAplicadoACampo(codigo)]) {
+        ofensas.push(`${rotulo}:${i + 1}: ${trecho.trim()}`);
+      }
+    });
+  }
+
+  assertEquals(
+    ofensas,
+    [],
+    `Campo sem writer coagido a 0 no caminho do prompt da IA — "ausente != zero"\n` +
+      `(revenue_potential e expansion_score sao NULL em 6.633/6.633 linhas em prod).\n` +
+      `Use numeroValido (edge) ou valorMedido (src/lib/scoring/margin.ts):\n  ` +
+      ofensas.join("\n  "),
+  );
+});
+
+// Prefixo ASCII "[POT-DET]" para a falsificação ancorar com `grep -F` — nome acentuado não
+// serve de âncora (o `grep` do shell é shim para ugrep, que dobra acento em todo locale).
+Deno.test("[POT-DET] o DETECTOR enxerga a coerção quando ela existe (par obrigatório)", () => {
+  // Sem este teste, "nenhuma ofensa" e "o predicado está quebrado" têm o mesmo output — e um
+  // gate que nunca casa nada é uma tautologia verde (money-path.md §"O DETECTOR mente": um
+  // assert de existência precisa provar que enxerga o objeto VIVO).
+  const formasReais = [
+    "const revenuePotential = Number(score.revenue_potential || 0);",
+    "expansionPotential: Number(score.expansion_score ?? 0),",
+    "revenue_potential: (score.revenue_potential as number) || 0,",
+    "expansionPotential: num(score.expansion_score),",
+    "revenuePotential: num(score.revenue_potential), salesHistoryStatus };",
+  ];
+  for (const forma of formasReais) {
+    const pegou = coercoesEmLinha(forma).length + numAplicadoACampo(forma).length;
+    assertEquals(pegou > 0, true, `o detector NÃO pegou uma coerção real: ${forma}`);
+  }
+
+  // E o controle negativo: o código pós-fix não pode casar, senão o gate reprova o correto.
+  const formasCorretas = [
+    "const revenuePotential = valorMedido(score.revenue_potential);",
+    "const expansionPotential = numeroValido(score.expansion_score);",
+    "expansionPotential: valorMedido(d.expansion_potential),",
+  ];
+  for (const forma of formasCorretas) {
+    const pegou = coercoesEmLinha(forma).length + numAplicadoACampo(forma).length;
+    assertEquals(pegou, 0, `falso-VERMELHO: o detector acusou código correto: ${forma}`);
+  }
+});
+
+Deno.test("comentário que cita o bug não dispara o gate", () => {
+  // O falso-VERMELHO que a falsificação do gate irmão (paginacao-delegada) pegou: os arquivos
+  // vigiados documentam o `?? 0` que removeram, e sem semComentario o gate mede a explicação.
+  const prosa = "      // Com `num()` elas chegavam como revenue_potential ?? 0 para 100% da base";
+  assertEquals(semComentario(prosa), "");
+  assertEquals(coercoesEmLinha(semComentario(prosa)).length, 0);
+});

--- a/supabase/functions/generate-bundle-argument/argumento-helpers.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-helpers.ts
@@ -1,0 +1,108 @@
+// Lógica PURA do gerador de argumentação de bundle: montagem do bloco de contexto do
+// cliente que vai no prompt. Puro de propósito — `test:edges` roda com `--no-remote` e não
+// resolve `npm:`/`jsr:`, então tudo que precisa de teste mora aqui e o index.ts só orquestra.
+//
+// MONEY-PATH — este módulo existe para um invariante só:
+// a argumentação é lida por uma vendedora como análise DAQUELE cliente. Campo que ninguém
+// mediu tem de chegar ao modelo como "não medido", nunca como número. `Number(null) === 0`,
+// `?? 0` e `|| 0` são as portas de fabricação — e num prompt de TEXTO a porta é a
+// interpolação: `R$ ${x || 0}` imprime "R$ 0", que o modelo lê como um valor apurado.
+//
+// Antes desta correção o bloco dizia "Gasto médio mensal: R$ 0" e "Categorias compradas: 0"
+// para qualquer cliente cujo dado não tivesse chegado — e o modelo concluía "cliente pequeno,
+// sensível a preço", que é uma abordagem comercial diferente da que o cliente merecia.
+
+/** Rótulo único para ausência. Texto, não número — é o que impede o modelo de calcular com ele. */
+export const NAO_MEDIDO = "não medido";
+
+/**
+ * Número FINITO ou null. Aceita number e string numérica (o contexto trafega em JSON e o
+ * front às vezes manda `"12.5"`), e rejeita TODO o resto.
+ *
+ * ⚠️ A allowlist por `typeof` não é preciosismo — `Number()` coage silenciosamente vários
+ * valores a 0: `Number("") === 0` (campo em branco viraria gasto medido de R$ 0) e
+ * `Number([]) === 0` (payload malformado que traz array vazio no lugar do número, pego pelo
+ * teste deste módulo). Testar `Number.isFinite` DEPOIS da coerção chega tarde: nesse ponto a
+ * fabricação já aconteceu e o resultado é um zero de aparência perfeita.
+ *
+ * Espelha `numeroValido` de `generate-tactical-plan/plano-helpers.ts` e `valorMedido` de
+ * `src/lib/scoring/margin.ts`.
+ */
+export function valorMedido(raw: unknown): number | null {
+  if (typeof raw === "number") return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === "string") {
+    const t = raw.trim();
+    if (t.length === 0) return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/** Texto não-vazio aparado, ou null. */
+function textoOuNull(v: unknown): string | null {
+  if (typeof v !== "string") return null;
+  const t = v.trim();
+  return t.length > 0 ? t : null;
+}
+
+/**
+ * Renderiza um número para o prompt: o valor quando medido, o rótulo textual quando não.
+ * `prefixo`/`sufixo` só entram quando há número — "R$ não medido" seria pior que a ausência.
+ */
+export function campoNumerico(
+  raw: unknown,
+  { prefixo = "", sufixo = "" }: { prefixo?: string; sufixo?: string } = {},
+): string {
+  const n = valorMedido(raw);
+  return n == null ? NAO_MEDIDO : `${prefixo}${n}${sufixo}`;
+}
+
+export interface ContextoCliente {
+  name?: unknown;
+  cnae?: unknown;
+  customerType?: unknown;
+  healthScore?: unknown;
+  daysSinceLastPurchase?: unknown;
+  avgMonthlySpend?: unknown;
+  categoryCount?: unknown;
+  recentProducts?: unknown;
+}
+
+/**
+ * Bloco de contexto do cliente, compartilhado pelos dois modos (argument e
+ * diagnostic_questions) — eram dois templates COPIADOS, e a fabricação vivia nos dois.
+ *
+ * ⚠️ `daysSinceLastPurchase` merece atenção contrária: o `|| 'N/A'` anterior engolia o **0
+ * legítimo** (cliente que comprou HOJE) e o exibia como ausência — a mesma confusão
+ * ausente↔zero, no sentido inverso. Aqui 0 é um fato e chega como "0".
+ */
+export function blocoCliente(customer: ContextoCliente): string {
+  const produtos = Array.isArray(customer.recentProducts)
+    ? customer.recentProducts.filter((p): p is string => typeof p === "string" && p.trim().length > 0)
+    : [];
+
+  return [
+    `Cliente: ${textoOuNull(customer.name) ?? NAO_MEDIDO}`,
+    `Segmento/CNAE: ${textoOuNull(customer.cnae) ?? "Não informado"}`,
+    `Tipo: ${textoOuNull(customer.customerType) ?? "Não informado"}`,
+    `Health Score: ${campoNumerico(customer.healthScore, { sufixo: "/100" })}`,
+    `Dias desde última compra: ${campoNumerico(customer.daysSinceLastPurchase)}`,
+    `Gasto médio mensal: ${campoNumerico(customer.avgMonthlySpend, { prefixo: "R$ " })}`,
+    `Categorias compradas: ${campoNumerico(customer.categoryCount)}`,
+  ].join("\n") + `\n\nHistórico de compras recentes: ${produtos.length > 0 ? produtos.join(", ") : "Sem dados"}`;
+}
+
+/**
+ * Instrução de dado ausente para o system prompt. Sem ela o rótulo "não medido" chega ao
+ * modelo sem contrato e ele preenche a lacuna sozinho — trocar o número fabricado por uma
+ * palavra só move a fabricação de camada. Espelha REGRA_DADO_AUSENTE de
+ * `generate-tactical-plan/plano-helpers.ts`.
+ */
+export const REGRA_DADO_AUSENTE =
+  `DADO AUSENTE: um campo com o valor "${NAO_MEDIDO}" significa NÃO MEDIDO — não é zero, não é
+valor baixo e não é sinal de cliente pequeno. NUNCA estime, preencha ou infira um número para ele,
+e não construa argumento econômico sobre ele. Em especial, "Gasto médio mensal: ${NAO_MEDIDO}" NÃO
+autoriza tratar o cliente como sensível a preço. Se um argumento seu dependeria de um dado não
+medido, escreva o argumento sem número em vez de inventar um valor plausível. Um número inventado
+que chega à vendedora como medido é pior do que a ausência do dado.`;

--- a/supabase/functions/generate-bundle-argument/argumento-helpers_test.ts
+++ b/supabase/functions/generate-bundle-argument/argumento-helpers_test.ts
@@ -1,0 +1,141 @@
+// Provas do bloco de contexto que vai ao modelo. O invariante é um só: dado que ninguém
+// mediu chega como "não medido", nunca como número (docs/agent/money-path.md §2).
+//
+// O caso que motivou o arquivo: `Gasto médio mensal: R$ ${customer.avgMonthlySpend || 0}`
+// imprimia "R$ 0" para cliente sem o dado — e o modelo concluía "cliente pequeno, sensível a
+// preço", mudando a abordagem comercial que a vendedora leva para a rua.
+
+// Sem import remoto: `test:edges` roda com `--no-remote` e um `https://deno.land/std/...`
+// colocaria o jsr/deno.land no caminho de entrega de TODO PR (CLAUDE.md). Asserts locais são
+// o padrão do repo — ver _shared/escrita-critica_test.ts e _shared/lease_test.ts.
+import {
+  blocoCliente,
+  campoNumerico,
+  NAO_MEDIDO,
+  REGRA_DADO_AUSENTE,
+  valorMedido,
+} from "./argumento-helpers.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+function assertStringIncludes(texto: string, esperado: string, msg?: string) {
+  if (!texto.includes(esperado)) {
+    throw new Error(msg ?? `esperava encontrar ${JSON.stringify(esperado)} em:\n${texto}`);
+  }
+}
+
+// ── valorMedido: o tri-estado ──────────────────────────────────────────────────
+
+Deno.test("valorMedido: ausência em todas as suas formas vira null", () => {
+  // `[]` e `[0]` estão aqui porque `Number([]) === 0` e `Number([0]) === 0`: um payload
+  // malformado atravessaria um guard escrito como `Number(x)` + `isFinite` como um zero de
+  // aparência perfeita. Este caso REPROVOU a primeira versão do helper — a allowlist por
+  // `typeof` entrou por causa dele, não por precaução teórica.
+  for (const ausente of [null, undefined, "", "   ", NaN, Infinity, -Infinity, "abc", {}, [], [0], true, false]) {
+    assertEquals(valorMedido(ausente), null, `${JSON.stringify(ausente)} deveria ser null`);
+  }
+});
+
+Deno.test("valorMedido: ZERO é medido, não ausente", () => {
+  // A metade que se esquece. `0` é um fato apurado ("não gastou nada"), e confundi-lo com
+  // ausência é o mesmo erro na direção oposta.
+  assertEquals(valorMedido(0), 0);
+  assertEquals(valorMedido("0"), 0);
+  assertEquals(valorMedido(1234.5), 1234.5);
+  assertEquals(valorMedido("12.5"), 12.5); // JSON às vezes traz número como string
+});
+
+// ── campoNumerico: a renderização ──────────────────────────────────────────────
+
+Deno.test("campoNumerico: ausente não ganha prefixo de moeda", () => {
+  // "R$ não medido" seria pior que a ausência — parece um valor formatado.
+  assertEquals(campoNumerico(null, { prefixo: "R$ " }), NAO_MEDIDO);
+  assertEquals(campoNumerico(undefined, { sufixo: "/100" }), NAO_MEDIDO);
+});
+
+Deno.test("campoNumerico: medido conserva prefixo e sufixo", () => {
+  assertEquals(campoNumerico(1500, { prefixo: "R$ " }), "R$ 1500");
+  assertEquals(campoNumerico(0, { prefixo: "R$ " }), "R$ 0"); // zero medido continua "R$ 0"
+  assertEquals(campoNumerico(72, { sufixo: "/100" }), "72/100");
+});
+
+// ── blocoCliente: o prompt real ────────────────────────────────────────────────
+
+Deno.test("blocoCliente: gasto ausente NÃO vira R$ 0 (o bug que originou o módulo)", () => {
+  const bloco = blocoCliente({ name: "Marcenaria Alfa", healthScore: 40 });
+
+  assertStringIncludes(bloco, `Gasto médio mensal: ${NAO_MEDIDO}`);
+  // O assert que tem dente: a string fabricada não pode aparecer em lugar NENHUM do bloco.
+  assertEquals(
+    bloco.includes("R$ 0"),
+    false,
+    `bloco fabricou um gasto de R$ 0:\n${bloco}`,
+  );
+});
+
+Deno.test("blocoCliente: categorias ausentes NÃO viram 0", () => {
+  const bloco = blocoCliente({ name: "Marcenaria Alfa", healthScore: 40 });
+  assertStringIncludes(bloco, `Categorias compradas: ${NAO_MEDIDO}`);
+  assertEquals(bloco.includes("Categorias compradas: 0"), false, bloco);
+});
+
+Deno.test("blocoCliente: gasto MEDIDO continua chegando como número", () => {
+  // O par obrigatório do teste acima: sem ele, um helper que devolvesse "não medido" para
+  // TUDO passaria — e teria destruído o contexto em vez de corrigi-lo.
+  const bloco = blocoCliente({
+    name: "Alfa",
+    healthScore: 80,
+    avgMonthlySpend: 3200,
+    categoryCount: 6,
+    daysSinceLastPurchase: 12,
+  });
+  assertStringIncludes(bloco, "Gasto médio mensal: R$ 3200");
+  assertStringIncludes(bloco, "Categorias compradas: 6");
+  assertStringIncludes(bloco, "Health Score: 80/100");
+  // Com TODO campo numérico medido, o rótulo de ausência não pode aparecer em nenhum deles.
+  assertEquals(bloco.includes(NAO_MEDIDO), false, bloco);
+});
+
+Deno.test("blocoCliente: gasto ZERO medido é preservado como R$ 0", () => {
+  // Precisão nos dois sentidos: cliente que de fato não gastou nada não pode virar "não medido".
+  const bloco = blocoCliente({ name: "Alfa", healthScore: 10, avgMonthlySpend: 0, categoryCount: 0 });
+  assertStringIncludes(bloco, "Gasto médio mensal: R$ 0");
+  assertStringIncludes(bloco, "Categorias compradas: 0");
+});
+
+Deno.test("blocoCliente: 0 dias desde a última compra é FATO, não ausência", () => {
+  // O `|| 'N/A'` anterior engolia o cliente que comprou HOJE — mesma confusão, sentido inverso.
+  const bloco = blocoCliente({ name: "Alfa", healthScore: 90, daysSinceLastPurchase: 0 });
+  assertStringIncludes(bloco, "Dias desde última compra: 0");
+  assertEquals(bloco.includes(`Dias desde última compra: ${NAO_MEDIDO}`), false, bloco);
+});
+
+Deno.test("blocoCliente: string vazia não vira número zero", () => {
+  // `Number("") === 0` é a porta de fabricação mais silenciosa da família.
+  const bloco = blocoCliente({ name: "Alfa", healthScore: 50, avgMonthlySpend: "", categoryCount: "  " });
+  assertStringIncludes(bloco, `Gasto médio mensal: ${NAO_MEDIDO}`);
+  assertStringIncludes(bloco, `Categorias compradas: ${NAO_MEDIDO}`);
+});
+
+Deno.test("blocoCliente: histórico vazio não inventa produtos", () => {
+  const semNada = blocoCliente({ name: "Alfa", healthScore: 50 });
+  assertStringIncludes(semNada, "Histórico de compras recentes: Sem dados");
+
+  const comProdutos = blocoCliente({ name: "Alfa", healthScore: 50, recentProducts: ["Serra", "Fresa"] });
+  assertStringIncludes(comProdutos, "Histórico de compras recentes: Serra, Fresa");
+});
+
+// ── o contrato com o modelo ────────────────────────────────────────────────────
+
+Deno.test("REGRA_DADO_AUSENTE acompanha o rótulo que o bloco realmente emite", () => {
+  // Se o rótulo mudar e a instrução não, o modelo recebe uma palavra sem contrato e preenche
+  // a lacuna sozinho — a fabricação só teria mudado de camada.
+  assertStringIncludes(REGRA_DADO_AUSENTE, NAO_MEDIDO);
+  assertStringIncludes(REGRA_DADO_AUSENTE, "NÃO MEDIDO");
+  // O erro específico a impedir: ausência de gasto lida como cliente sensível a preço.
+  assertStringIncludes(REGRA_DADO_AUSENTE, "sensível a preço");
+});

--- a/supabase/functions/generate-bundle-argument/index.ts
+++ b/supabase/functions/generate-bundle-argument/index.ts
@@ -13,6 +13,7 @@ import {
   TOOL_ARGUMENTO,
   TOOL_PERGUNTAS,
 } from "./argumento-tools.ts";
+import { blocoCliente, REGRA_DADO_AUSENTE } from "./argumento-helpers.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -68,6 +69,8 @@ REGRAS:
 - Baseadas em dados reais do cliente
 - Linguagem técnica mas acessível
 
+${REGRA_DADO_AUSENTE}
+
 Retorne EXATAMENTE um JSON (sem markdown, sem code blocks):
 {
   "questions": [
@@ -98,21 +101,13 @@ Retorne EXATAMENTE um JSON (sem markdown, sem code blocks):
   ]
 }`;
 
-      const userPrompt = `Cliente: ${customer.name}
-Segmento/CNAE: ${customer.cnae || 'Não informado'}
-Tipo: ${customer.customerType || 'Não informado'}
-Health Score: ${customer.healthScore}/100
-Dias desde última compra: ${customer.daysSinceLastPurchase || 'N/A'}
-Gasto médio mensal: R$ ${customer.avgMonthlySpend || 0}
-Categorias compradas: ${customer.categoryCount || 0}
+      const userPrompt = `${blocoCliente(customer)}
 
 Bundle sugerido (${bundle.products.length} produtos):
 ${bundle.products.map((p: { name: string; price: number; margin: number }, i: number) => `${i + 1}. ${p.name} - Preço: R$ ${p.price.toFixed(2)} | Margem: R$ ${p.margin.toFixed(2)}`).join('\n')}
 
 LIE do Bundle: R$ ${bundle.lieBundle.toFixed(2)}
-Confidence: ${(bundle.confidence * 100).toFixed(1)}%
-
-Histórico de compras recentes: ${customer.recentProducts?.join(', ') || 'Sem dados'}`;
+Confidence: ${(bundle.confidence * 100).toFixed(1)}%`;
 
       let resposta;
       try {
@@ -180,6 +175,8 @@ PERFIL DO CLIENTE: ${customerProfile}
 - Se "orientado_produtividade": foque em velocidade, uptime, menos paradas
 - Se "misto": balance todos os argumentos
 
+${REGRA_DADO_AUSENTE}
+
 Retorne EXATAMENTE um JSON com esta estrutura (sem markdown, sem code blocks):
 {
   "diagnostico": "Diagnóstico implícito baseado no histórico (1-2 frases)",
@@ -192,22 +189,14 @@ Retorne EXATAMENTE um JSON com esta estrutura (sem markdown, sem code blocks):
   "versao_tecnica": "Versão técnica detalhada (parágrafo completo)"
 }`;
 
-    const userPrompt = `Cliente: ${customer.name}
-Segmento/CNAE: ${customer.cnae || 'Não informado'}
-Tipo: ${customer.customerType || 'Não informado'}
-Health Score: ${customer.healthScore}/100
-Dias desde última compra: ${customer.daysSinceLastPurchase || 'N/A'}
-Gasto médio mensal: R$ ${customer.avgMonthlySpend || 0}
-Categorias compradas: ${customer.categoryCount || 0}
+    const userPrompt = `${blocoCliente(customer)}
 
 Bundle sugerido (${bundle.products.length} produtos):
 ${bundle.products.map((p: { name: string; price: number; margin: number }, i: number) => `${i + 1}. ${p.name} - Preço: R$ ${p.price.toFixed(2)} | Margem: R$ ${p.margin.toFixed(2)}`).join('\n')}
 
 LIE do Bundle: R$ ${bundle.lieBundle.toFixed(2)}
 Confidence: ${(bundle.confidence * 100).toFixed(1)}%
-Lift: ${bundle.lift.toFixed(2)}
-
-Histórico de compras recentes do cliente: ${customer.recentProducts?.join(', ') || 'Sem dados'}`;
+Lift: ${bundle.lift.toFixed(2)}`;
 
     let resposta;
     try {

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -22,6 +22,7 @@ import {
   MODELO,
   type Modo,
   montarPlano,
+  numeroValido,
   statusDeErroIa,
   systemDoModo,
   toolDoModo,
@@ -196,9 +197,27 @@ serve(async (req) => {
         return new Response(JSON.stringify({ skipped: 'sem_score' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
       }
 
+      // `num` só sobrevive nos campos cuja ausência NÃO chega aqui: health_score, churn_risk,
+      // avg_monthly_spend_180d, category_count e days_since_last_purchase têm 0 nulos em prod
+      // (medido via psql-ro em 2026-07-29, 6.633 linhas) e alimentam decisão DETERMINÍSTICA —
+      // classifyProfile/selectObjective/mixGap. Nulá-los seria pior que inerte: `null < 500` é
+      // `true` em JS, então "não medido" viraria o rótulo `sensivel_preco` e `8 - null` daria
+      // mixGap 8 (money-path.md §2, corolário JS). Só se troca `?? 0` por null onde a ausência
+      // REALMENTE chega — e onde o consumidor sabe tratá-la.
       const num = (v: unknown) => Number(v ?? 0);
       const healthScore = num(score.health_score), churnRisk = num(score.churn_risk), avgSpend = num(score.avg_monthly_spend_180d);
       const categoryCount = num(score.category_count), daysSince = num(score.days_since_last_purchase);
+      // [money-path "ausente ≠ zero"] expansion_score e revenue_potential são as DUAS colunas
+      // que a 20260727130000_farmer_scores_colunas_orfas_null nulou de propósito (nenhum writer
+      // as calcula) — e a migration está APLICADA: 6.633/6.633 NULL, `column_default` removido
+      // (psql-ro, 2026-07-29). Com `num()` elas chegavam ao prompt como `0` para 100% da base, e
+      // o system prompt manda a IA ler número como MEDIDO — "revenuePotential: 0" afirma
+      // "cliente sem potencial" sobre um cliente que ninguém mediu, e é a partir disso que a
+      // vendedora decide a abordagem. `numeroValido` devolve o null honesto que a instrução
+      // DADO AUSENTE (plano-helpers.ts) já sabe interpretar. Nenhum dos dois entra em
+      // comparação relacional aqui — só no prompt e no payload (colunas nullable).
+      const expansionPotential = numeroValido(score.expansion_score);
+      const revenuePotential = numeroValido(score.revenue_potential);
       // money-path "ausente ≠ zero": margem desconhecida fica `null` e é EXCLUÍDA dos
       // cálculos — nunca 0 (que afirmaria "cliente sem margem") nem a média fabricada.
       const marginPct = margemConhecida(score.gross_margin_pct);
@@ -231,14 +250,14 @@ serve(async (req) => {
         .map((e: { event_data: { intent?: unknown } | null }) => (e.event_data as { intent?: unknown } | null)?.intent)
         .filter((i: unknown): i is string => typeof i === 'string' && i.startsWith('objecao')).slice(0, 5);
 
-      customerContext = { name: profile?.name, cnae: profile?.cnae, customerType: profile?.customer_type, profile: customerProfile, healthScore, churnRisk, avgMonthlySpend: avgSpend, grossMarginPct: marginPct, categoryCount, daysSinceLastPurchase: daysSince, mixGap, clusterAvgMargin: clusterMargin, expansionPotential: num(score.expansion_score), revenuePotential: num(score.revenue_potential), salesHistoryStatus };
+      customerContext = { name: profile?.name, cnae: profile?.cnae, customerType: profile?.customer_type, profile: customerProfile, healthScore, churnRisk, avgMonthlySpend: avgSpend, grossMarginPct: marginPct, categoryCount, daysSinceLastPurchase: daysSince, mixGap, clusterAvgMargin: clusterMargin, expansionPotential, revenuePotential, salesHistoryStatus };
       bundleContext = topBundleRow ? { products: topBundleRow.bundle_products, lie: topBundleRow.lie_bundle, probability: topBundleRow.p_bundle, margin: topBundleRow.m_bundle } : null;
       diagnosticData = { strategicObjective };
       // Paridade com o front: no modo estratégico, inclui o 2º bundle p/ comparação.
       if (mode === 'estrategico' && secondBundleRow) {
         (diagnosticData as Record<string, unknown>).secondBundle = { products: secondBundleRow.bundle_products, lie: secondBundleRow.lie_bundle, probability: secondBundleRow.p_bundle, margin: secondBundleRow.m_bundle };
       }
-      (body as Record<string, unknown>)._derived = { healthScore, churnRisk, mixGap, marginPct, clusterMargin, expansionPotential: num(score.expansion_score), customerProfile, strategicObjective };
+      (body as Record<string, unknown>)._derived = { healthScore, churnRisk, mixGap, marginPct, clusterMargin, expansionPotential, customerProfile, strategicObjective };
     }
 
     const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY');
@@ -355,9 +374,11 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
     // race em vez de gravar dono stale (precisão>recall). farmer_id/customer/status são do servidor.
     if (selfContained) {
       const admin = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!, { auth: { persistSession: false } });
-      // marginPct/clusterMargin podem ser null (margem desconhecida). As colunas
-      // current_margin_pct/cluster_avg_margin_pct são nullable — o plano grava "não sei"
-      // em vez de um número, e a UI mostra "—" em vez de uma margem inventada.
+      // marginPct/clusterMargin/expansionPotential podem ser null (dado não medido). As colunas
+      // current_margin_pct/cluster_avg_margin_pct/expansion_potential são nullable (conferido em
+      // prod via psql-ro) — o plano grava "não sei" em vez de um número, e a UI mostra "—" em vez
+      // de um potencial inventado. Gravar o 0 fabricado seria pior que exibi-lo: ele PERSISTE e
+      // vira histórico com cara de medição.
       const d = (body as { _derived: Record<string, number | string | null> })._derived;
       const { data: newId, error: rpcErr } = await admin.rpc('criar_plano_tatico', {
         _customer_user_id: body.customerId,

--- a/supabase/functions/generate-tactical-plan/plano-helpers.ts
+++ b/supabase/functions/generate-tactical-plan/plano-helpers.ts
@@ -315,12 +315,20 @@ export function montarPlano(
 // Contrato com o modelo
 // ---------------------------------------------------------------------------
 
+// Os exemplos citam os QUATRO campos que hoje chegam null de verdade — os dois de margem
+// (#1495) e os dois de potencial, nulados pela 20260727130000_farmer_scores_colunas_orfas_null
+// porque nenhum writer os calcula (6.633/6.633 NULL em prod, medido 2026-07-29). Manter a lista
+// alinhada com o que o contexto REALMENTE traz importa: exemplo que não corresponde ao dado
+// ensina o modelo a esperar outra coisa.
 const REGRA_DADO_AUSENTE =
-  `DADO AUSENTE: campo com valor null no contexto (ex.: "grossMarginPct": null, "clusterAvgMargin": null)
-significa NÃO MEDIDO — não é zero nem valor baixo. NUNCA estime, preencha ou infira um número para ele,
-e não construa argumento sobre margem a partir dele. Se um campo numérico da sua resposta dependeria de
-um dado não medido, responda null nele em vez de um número plausível. Um número inventado que chega à
-vendedora como medido é pior do que a ausência do campo.`;
+  `DADO AUSENTE: campo com valor null no contexto (ex.: "grossMarginPct": null, "clusterAvgMargin": null,
+"revenuePotential": null, "expansionPotential": null) significa NÃO MEDIDO — não é zero nem valor baixo.
+NUNCA estime, preencha ou infira um número para ele, e não construa argumento sobre margem, potencial de
+receita ou expansão a partir dele. Em especial: "revenuePotential": null NÃO significa cliente sem
+potencial, e "expansionPotential": null NÃO significa cliente sem espaço para crescer — significa que
+ninguém mediu. Se um campo numérico da sua resposta dependeria de um dado não medido, responda null nele
+em vez de um número plausível. Um número inventado que chega à vendedora como medido é pior do que a
+ausência do campo.`;
 
 const REGRA_SEM_HISTORICO =
   `Se "salesHistoryStatus" for "sem_historico" (SEM venda válida registrada — pode nunca ter comprado OU


### PR DESCRIPTION
Achado do challenge `/codex` durante a migração das edges de IA para a Anthropic.

O system prompt do plano tático **já mandava a disciplina certa** — *"campo com valor null significa NÃO MEDIDO — não é zero nem valor baixo. NUNCA estime, preencha ou infira um número para ele"* — mas os dados chegavam ao modelo **já adulterados**: `Number(v ?? 0)` na edge e `Number(score.revenue_potential || 0)` no front convertiam a ausência em `0` antes de montar o contexto. A instrução vigiava um contexto que nunca continha `null`.

## A medição mudou o peso do achado

Pré-flight canônico em prod (`psql-ro`, 2026-07-29, 6.633 linhas de `farmer_client_scores`):

| coluna | NULL | zeros | positivos | `column_default` |
|---|---|---|---|---|
| `revenue_potential` | **6.633** | 0 | 0 | removido |
| `expansion_score` | **6.633** | 0 | 0 | removido |
| `gross_margin_pct` | 5.564 | 0 | 1.059 | removido (#1495) |
| `avg_monthly_spend_180d` | 0 | 6.221 | 412 | `0` |
| `health_score` · `churn_risk` · `category_count` · `days_since_last_purchase` | 0 | — | — | — |

A migration `20260727130000_farmer_scores_colunas_orfas_null` nulou as duas primeiras de propósito (nenhum writer as calcula) **e está aplicada**. Ou seja: isto **não é defesa preventiva** — a IA recebia `"revenuePotential": 0` para **100% da base**, concluía "cliente sem valor / sensível a preço", e isso muda a abordagem comercial que a vendedora leva para a rua. A própria migration citava *"plano tático → LLM"* como o consumidor ainda não corrigido.

## O que muda

- **`generate-tactical-plan`** — `expansion_score`/`revenue_potential` passam por `numeroValido`, o helper que **já existia** em `plano-helpers.ts` e que o orquestrador simplesmente não chamava (§7: consertar o helper não conserta o call-site). Como o `customerContext` vai ao prompt via `JSON.stringify`, o `null` chega literalmente — e a instrução `DADO AUSENTE` já sabe interpretá-lo. Os exemplos dessa instrução passaram a citar os 4 campos que hoje chegam null de verdade.
- **`useTacticalPlan`** — mesmo tri-estado no caminho do front: prompt, payload gravado (`expansion_potential`, coluna nullable conferida em prod) e leitura do plano persistido.
- **`PlanCard`** — `"—"` em vez de `"0%"` para potencial não medido, como a margem já fazia.
- **`generate-bundle-argument`** — bloco de contexto extraído para `argumento-helpers.ts` (puro, testável sob `--no-remote`). `"Gasto médio mensal: R$ 0"` vira `"não medido"`, e os dois system prompts ganham `REGRA_DADO_AUSENTE`: trocar o número por uma palavra **sem dar contrato ao modelo** só moveria a fabricação de camada.

### O `num()` sobrevive de propósito

`health_score`, `churn_risk`, `avg_monthly_spend_180d`, `category_count` e `days_since_last_purchase` têm **0 nulos** em prod e alimentam decisão **determinística** (`classifyProfile`/`selectObjective`/`mixGap`). Nulá-los seria pior que inerte: `null < 500` é `true` em JS → todo cliente de gasto desconhecido viraria `sensivel_preco`, e `8 - null` daria `mixGap` 8 (money-path §2, corolário JS). Só se troca `?? 0` por null **onde a ausência realmente chega**.

### Zero é medido

Todo guard tem par: `0` apurado continua chegando como `0` ao prompt e à tela. Sem isso a correção viraria "esconde tudo" e destruiria o contexto em vez de honrá-lo.

### De brinde

`daysSinceLastPurchase || 'N/A'` engolia o **0 legítimo** (cliente que comprou **hoje**) e o exibia como ausência — a mesma confusão ausente↔zero, no sentido inverso.

### Bug pego pelo próprio teste

`valorMedido([])` devolvia `0`, porque **`Number([]) === 0`** — irmão do `Number('') === 0`. Os helpers passaram a usar allowlist por `typeof`: testar `isFinite` **depois** da coerção chega tarde, a fabricação já aconteceu e o resultado é um zero de aparência perfeita.

## Coordenação — união, não escolha de lado

O #1626 mergeou **durante esta sessão** e reescreveu `generate-bundle-argument` (migração para Anthropic), sem tocar na fabricação. No rebase o conflito foi resolvido por **união** (§9: *conflito entre dois fixes do mesmo site não se resolve por lado, se resolve por união*) — a migração do #1626 + este fix coexistem, verificado por grep dos dois lados. O #1624, que cobria esta superfície, está fechado.

## Gates — exit 0 em todos, pós-rebase

| gate | resultado |
|---|---|
| `typecheck` | 0 erros TS |
| `test` | **5851/5851** |
| `test:edges` | **490/490** |
| `edges:typecheck` | 0 erros de classe-crash |
| `build` · `lint` · `claude:size` · `authz:check` · `bunpin:check` | exit 0 (lint: 0 errors, 72 warnings preexistentes) |

`knip` falha **igual na main** (medido com a árvore limpa) — dívida preexistente; nenhum símbolo desta entrega aparece na lista.

## Falsificação — 6/6 sabotagens deram o vermelho ESPERADO

Conferido por **nome de teste** e por **denominador** (em suíte JS o tell de "não rodou nada" é o TOTAL, não o exit code, que mente igual):

| # | sabotagem | vermelho exigido | denominador |
|---|---|---|---|
| S1 | edge volta a `num(revenue_potential)` | gate de edge | 489+1=490 |
| S2 | front volta a `\|\| 0` | gate `src/` | 43+1=44 |
| S3 | helper imprime `0` no lugar do rótulo | 4 comportamentais | 486+4=490 |
| S4 | `PlanCard` volta a exibir `0%` | `[POT-CARD]` | 43+1=44 |
| S5 | detector do gate cego | `[POT-DET]` — anti-tautologia | 489+1=490 |
| S6 | `semComentario` neutralizado | prova que a prosa enganaria o gate | 489+1=490 |

**S5 e S6 são os que importam mais**: S5 prova que o gate não é tautologia verde (§"O DETECTOR mente" — um predicado que nunca casa nada passa sempre), e S6 prova que sem `semComentario` o gate mediria a própria explicação do bug (§"O ALVO mente"). O harness aborta se a sabotagem não aplicar, se o vermelho vier com 0 testes falhos, ou se o denominador não fechar.

Os testes-chave ganharam prefixo ASCII (`[POT-CARD]`/`[POT-DET]`) porque a 1ª rodada reportou *"vermelho no lugar errado"* só por ancorar em nome acentuado — o `grep` deste shell é shim para `ugrep`, que dobra acento em todo locale.

## Gates de regressão que ficam

- `supabase/functions/_shared/potencial-nao-medido_test.ts` (Deno) — vigia a edge
- `src/__tests__/potencial-nao-medido-gate.test.ts` (vitest) — vigia o front, porque `test:edges` roda com `--allow-read=supabase/functions` e não alcança `src/`

Os dois se complementam: o plano tático tem **duas portas** para o mesmo prompt (cron self-contained e botão da tela), e fechar uma só deixaria a fabricação viva pela outra.

## Deploy (Lovable — 3 camadas manuais)

- **Edges:** `generate-tactical-plan` (+ `plano-helpers.ts`) e `generate-bundle-argument` (+ `argumento-helpers.ts`) — deploy pelo chat do Lovable, verbatim do repo
- **Frontend:** Publish (mudou `useTacticalPlan`, `PlanCard`, `margin.ts`)
- **Migration:** nenhuma

🤖 Generated with [Claude Code](https://claude.com/claude-code)