### PR TITLE
fix(farmer): o objetivo VÁLIDO e errado da IA para de vencer o fato medido [money-path]

### DIFF
--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { invokeFunction } from '@/lib/invoke-function';
-import { selectObjective, clampRecencyCapDays } from '@/lib/scoring/objective';
+import { selectObjective, clampRecencyCapDays, objetivoFinal } from '@/lib/scoring/objective';
 import { margemConhecida, mediaMargensConhecidas, valorMedido } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
 import { ownersAtivosDoAlvo } from '@/lib/carteira/escopo-clientes';
@@ -587,6 +587,20 @@ export const useTacticalPlan = () => {
       // _expected_owner=ownerId faz a RPC ABORTAR se a carteira foi reatribuída durante a
       // geração da IA (race) em vez de gravar o dono stale; farmer_id/customer_user_id/status
       // são autoritativos do servidor (o client não controla mais a posse).
+      // O enum barra objetivo inventado, não o objetivo VÁLIDO e errado: com
+      // `sem_historico` o derivado é `ativacao` por fato binário (não há venda),
+      // e um "recuperacao" da IA venceria — plano de recuperação para cliente
+      // que nunca comprou. Mesma reconciliação do edge (helper espelhado).
+      const { objetivo: objetivoDoPlano, sobrescrito } = objetivoFinal(
+        aiPlan?.strategic_objective,
+        strategicObjective,
+      );
+      if (sobrescrito) {
+        console.warn(
+          `[useTacticalPlan] objetivo "${aiPlan?.strategic_objective}" da IA descartado: cliente ${customerId} é sem_historico (derivado: ativacao)`,
+        );
+      }
+
       const { error: rpcError } = await supabase.rpc('criar_plano_tatico' as never, {
         _customer_user_id: customerId,
         _expected_owner: ownerId,
@@ -598,7 +612,7 @@ export const useTacticalPlan = () => {
           current_margin_pct: marginPct,
           cluster_avg_margin_pct: clusterMargin,
           expansion_potential: expansionPotential,
-          strategic_objective: aiPlan?.strategic_objective || strategicObjective,
+          strategic_objective: objetivoDoPlano,
           customer_profile: customerProfile,
           plan_type: planType,
           top_bundle: topBundle ? topBundle.bundle_products : {},

--- a/src/lib/scoring/__tests__/objetivo-final.test.ts
+++ b/src/lib/scoring/__tests__/objetivo-final.test.ts
@@ -1,0 +1,108 @@
+// `objetivoFinal` — reconciliação do objetivo da IA com o derivado por regra medida.
+//
+// Espelhado em `supabase/functions/generate-tactical-plan/plano-helpers.ts` (Deno
+// não importa de src/). Os CASOS abaixo são os mesmos do teste do edge: se os dois
+// lados divergirem, o plano gravado pelo cron e o gravado pela tela passam a
+// contar histórias diferentes sobre o mesmo cliente.
+//
+// O que se prova aqui não é o enum (esse já barra texto inventado), e sim o
+// objetivo VÁLIDO e ERRADO — o que passa na validação e mesmo assim contradiz um
+// fato medido.
+import { describe, it, expect } from 'vitest';
+import { objetivoFinal, selectObjective } from '../objective';
+
+/** Tabela ÚNICA de casos — espelhada no teste do edge. */
+const CASOS: Array<{
+  nome: string;
+  daIA: string | null;
+  doServidor: string | null;
+  objetivo: string | null;
+  sobrescrito: boolean;
+}> = [
+  {
+    nome: 'sem_historico: servidor vence "recuperacao" da IA',
+    daIA: 'recuperacao',
+    doServidor: 'ativacao',
+    objetivo: 'ativacao',
+    sobrescrito: true,
+  },
+  {
+    nome: 'sem_historico: servidor vence "reativacao" da IA',
+    daIA: 'reativacao',
+    doServidor: 'ativacao',
+    objetivo: 'ativacao',
+    sobrescrito: true,
+  },
+  {
+    nome: 'faixa heurística: leitura da IA prevalece',
+    daIA: 'upsell_premium',
+    doServidor: 'expansao_mix',
+    objetivo: 'upsell_premium',
+    sobrescrito: false,
+  },
+  {
+    nome: 'IA nula cai no derivado',
+    daIA: null,
+    doServidor: 'ativacao',
+    objetivo: 'ativacao',
+    sobrescrito: false,
+  },
+  {
+    nome: 'IA concordando com ativacao não é sobrescrita',
+    daIA: 'ativacao',
+    doServidor: 'ativacao',
+    objetivo: 'ativacao',
+    sobrescrito: false,
+  },
+  {
+    nome: 'ambos nulos',
+    daIA: null,
+    doServidor: null,
+    objetivo: null,
+    sobrescrito: false,
+  },
+];
+
+describe('objetivoFinal — objetivo VÁLIDO porém contraditório', () => {
+  it.each(CASOS)('$nome', ({ daIA, doServidor, objetivo, sobrescrito }) => {
+    expect(objetivoFinal(daIA, doServidor)).toEqual({ objetivo, sobrescrito });
+  });
+
+  it('o caminho completo: cliente sem venda válida NÃO recebe plano de recuperação', () => {
+    // selectObjective é a fonte do derivado; sem_historico precede tudo (#1026).
+    const derivado = selectObjective(
+      95, // churnRisk altíssimo — sozinho pediria "recuperacao"
+      5,
+      null,
+      null,
+      400, // dormência longa — sozinha pediria "reativacao"
+      180,
+      'sem_historico',
+    );
+    expect(derivado).toBe('ativacao');
+
+    // A IA, olhando churn 95 e 400 dias, "conclui" recuperação. Passa no enum.
+    const { objetivo, sobrescrito } = objetivoFinal('recuperacao', derivado);
+    expect(objetivo).toBe('ativacao');
+    expect(sobrescrito).toBe(true);
+  });
+
+  it('entrada suja da IA não vira objetivo: espaço/caixa são normalizados', () => {
+    expect(objetivoFinal('  RECUPERACAO  ', 'ativacao')).toEqual({
+      objetivo: 'ativacao',
+      sobrescrito: true,
+    });
+    // String vazia é ausência, não objetivo — cai no derivado sem marcar sobrescrita.
+    expect(objetivoFinal('   ', 'expansao_mix')).toEqual({
+      objetivo: 'expansao_mix',
+      sobrescrito: false,
+    });
+  });
+
+  it('undefined (campo ausente na resposta) se comporta como null', () => {
+    expect(objetivoFinal(undefined, 'ativacao')).toEqual({
+      objetivo: 'ativacao',
+      sobrescrito: false,
+    });
+  });
+});

--- a/src/lib/scoring/objective.ts
+++ b/src/lib/scoring/objective.ts
@@ -74,3 +74,30 @@ export function clampRecencyCapDays(raw: unknown): number {
   if (!Number.isFinite(n)) return DEFAULT_RECENCY_CAP_DAYS;
   return Math.min(MAX_RECENCY_CAP_DAYS, Math.max(MIN_RECENCY_CAP_DAYS, Math.round(n)));
 }
+
+/**
+ * Reconcilia o objetivo vindo da IA com o derivado aqui, por regra medida.
+ *
+ * Espelho VERBATIM de `objetivoFinal` em
+ * `supabase/functions/generate-tactical-plan/plano-helpers.ts` (Deno não importa
+ * de src/) — mudou aqui, mude lá.
+ *
+ * O enum barra objetivo inventado, mas não o objetivo VÁLIDO e errado. Com
+ * `sem_historico`, `selectObjective` devolve `ativacao` a partir de um fato
+ * binário: não existe venda válida no resumo. Um "recuperacao" vindo da IA passa
+ * no enum e, com `aiPlan?.strategic_objective || derivado`, VENCE o fato — a
+ * vendedora recebe plano de recuperação para cliente que nunca comprou.
+ *
+ * Nos demais objetivos o derivado sai de FAIXAS (churn, mix, recência), onde a
+ * leitura da IA pode ser melhor que o corte numérico, e ela prevalece.
+ */
+export function objetivoFinal(
+  daIA: string | null | undefined,
+  doServidor: string | null | undefined,
+): { objetivo: string | null; sobrescrito: boolean } {
+  const ia = typeof daIA === 'string' && daIA.trim() ? daIA.trim().toLowerCase() : null;
+  if (doServidor === 'ativacao' && ia !== null && ia !== 'ativacao') {
+    return { objetivo: 'ativacao', sobrescrito: true };
+  }
+  return { objetivo: ia ?? doServidor ?? null, sobrescrito: false };
+}

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -23,6 +23,8 @@ import {
   type Modo,
   montarPlano,
   numeroValido,
+  objetivoFinal,
+  objetivoValido,
   statusDeErroIa,
   systemDoModo,
   toolDoModo,
@@ -380,6 +382,21 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
       // de um potencial inventado. Gravar o 0 fabricado seria pior que exibi-lo: ele PERSISTE e
       // vira histórico com cara de medição.
       const d = (body as { _derived: Record<string, number | string | null> })._derived;
+
+      // O enum barra objetivo inventado, não o objetivo VÁLIDO e errado. Com
+      // `sem_historico` o servidor derivou `ativacao` de um fato binário (não há
+      // venda válida); um "recuperacao" vindo do modelo passaria no enum e
+      // venceria, gravando plano de recuperação para quem nunca comprou.
+      const { objetivo: objetivoDoPlano, sobrescrito } = objetivoFinal(
+        objetivoValido(plan.strategic_objective),
+        typeof d.strategicObjective === 'string' ? d.strategicObjective : null,
+      );
+      if (sobrescrito) {
+        console.warn(
+          `[generate-tactical-plan] objetivo "${plan.strategic_objective}" do modelo descartado: cliente ${body.customerId} é sem_historico (servidor: ativacao)`,
+        );
+      }
+
       const { data: newId, error: rpcErr } = await admin.rpc('criar_plano_tatico', {
         _customer_user_id: body.customerId,
         _expected_owner: body.farmerId,
@@ -387,7 +404,7 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
           bundle_recommendation_id: (topBundleRow as { id?: string } | null)?.id ?? null,
           health_score: d.healthScore, churn_risk: d.churnRisk, mix_gap: d.mixGap,
           current_margin_pct: d.marginPct, cluster_avg_margin_pct: d.clusterMargin, expansion_potential: d.expansionPotential,
-          strategic_objective: plan.strategic_objective || d.strategicObjective, customer_profile: d.customerProfile, plan_type: mode,
+          strategic_objective: objetivoDoPlano, customer_profile: d.customerProfile, plan_type: mode,
           top_bundle: (topBundleRow ? topBundleRow.bundle_products : {}),
           second_bundle: (secondBundleRow ? (secondBundleRow as { bundle_products: unknown }).bundle_products : {}),
           bundle_lie: Number((topBundleRow as { lie_bundle?: unknown } | null)?.lie_bundle ?? 0),

--- a/supabase/functions/generate-tactical-plan/plano-helpers.ts
+++ b/supabase/functions/generate-tactical-plan/plano-helpers.ts
@@ -120,6 +120,34 @@ export function objetivoValido(v: unknown): Objetivo | null {
 }
 
 /**
+ * Reconcilia o objetivo do modelo com o derivado no servidor.
+ *
+ * O enum barra texto inventado, mas NÃO barra o valor válido e errado — e é esse
+ * que faz estrago. `sem_historico → ativacao` é a primeira regra de
+ * `selectObjective` (#1026) e vem de um fato binário: não existe venda válida no
+ * resumo. Se o modelo devolve "recuperacao" ali, passa por `objetivoValido` e,
+ * com `plan.strategic_objective || derivado`, VENCE o fato — a vendedora recebe
+ * um plano de recuperação para um cliente que nunca comprou, com abordagem que
+ * pressupõe uma relação que nunca existiu. O prompt já pede `ativacao` nesse
+ * caso, mas instrução no prompt não é garantia estrutural.
+ *
+ * Nos demais objetivos o derivado sai de FAIXAS (churn, mix, recência) — ali a
+ * leitura do modelo pode ser melhor que o corte numérico, e ela prevalece.
+ *
+ * `sobrescrito` existe para o caller logar: divergência silenciosa vira ruído
+ * invisível, e é justamente o sinal de que o prompt não está sendo obedecido.
+ */
+export function objetivoFinal(
+  doModelo: Objetivo | null,
+  doServidor: string | null | undefined,
+): { objetivo: string | null; sobrescrito: boolean } {
+  if (doServidor === "ativacao" && doModelo !== null && doModelo !== "ativacao") {
+    return { objetivo: "ativacao", sobrescrito: true };
+  }
+  return { objetivo: doModelo ?? doServidor ?? null, sobrescrito: false };
+}
+
+/**
  * Perguntas diagnósticas. Uma pergunta sem `question` não é pergunta — é descartada.
  * `purpose`/`expected_insight` ausentes viram "" (são acessórios na UI, não afirmam dado).
  */

--- a/supabase/functions/generate-tactical-plan/plano-helpers_test.ts
+++ b/supabase/functions/generate-tactical-plan/plano-helpers_test.ts
@@ -17,6 +17,7 @@ import {
   normalizarRiscos,
   numeroNoIntervalo,
   numeroValido,
+  objetivoFinal,
   objetivoValido,
   statusDeErroIa,
   textoValido,
@@ -443,4 +444,42 @@ Deno.test("tool: margem e probabilidade aceitam null no schema", () => {
   for (const campo of ["best_case_margin", "likely_margin", "worst_case_margin"]) {
     assertEquals(cenarios[campo].type, ["number", "null"], `${campo} precisa aceitar null`);
   }
+});
+
+// ─────────────────────────────── objetivoFinal ───────────────────────────────
+// O enum barra objetivo INVENTADO; estes testes cobrem o objetivo VÁLIDO e ERRADO,
+// que é o que faz estrago — passa em `objetivoValido` e venceria o fato medido.
+
+Deno.test("objetivoFinal: com sem_historico, o SERVIDOR vence a IA", () => {
+  // `sem_historico → ativacao` é fato binário (não há venda válida no resumo).
+  // "recuperacao" pressupõe uma relação que nunca existiu.
+  const r = objetivoFinal("recuperacao", "ativacao");
+  assertEquals(r.objetivo, "ativacao");
+  assertEquals(r.sobrescrito, true, "a divergência precisa ser sinalizada p/ log");
+});
+
+Deno.test("objetivoFinal: qualquer objetivo != ativacao é descartado sob sem_historico", () => {
+  for (const daIa of ["reativacao", "expansao_mix", "upsell_premium", "consolidacao_margem"]) {
+    const r = objetivoFinal(daIa as never, "ativacao");
+    assertEquals(r.objetivo, "ativacao", `IA disse ${daIa}`);
+    assertEquals(r.sobrescrito, true, `IA disse ${daIa}`);
+  }
+});
+
+Deno.test("objetivoFinal: nos demais derivados a leitura da IA prevalece", () => {
+  // Ali o derivado sai de FAIXAS (churn/mix/recência) — o corte numérico é
+  // grosseiro e a IA pode ter contexto melhor.
+  const r = objetivoFinal("upsell_premium", "expansao_mix");
+  assertEquals(r.objetivo, "upsell_premium");
+  assertEquals(r.sobrescrito, false);
+});
+
+Deno.test("objetivoFinal: IA nula cai no derivado, sem marcar sobrescrita", () => {
+  assertEquals(objetivoFinal(null, "ativacao"), { objetivo: "ativacao", sobrescrito: false });
+  assertEquals(objetivoFinal(null, "recuperacao"), { objetivo: "recuperacao", sobrescrito: false });
+  assertEquals(objetivoFinal(null, null), { objetivo: null, sobrescrito: false });
+});
+
+Deno.test("objetivoFinal: IA concordando com ativacao não é sobrescrita", () => {
+  assertEquals(objetivoFinal("ativacao", "ativacao"), { objetivo: "ativacao", sobrescrito: false });
 });


### PR DESCRIPTION
## Por quê

Follow-up do #1618, que migrou o `generate-tactical-plan` para a Anthropic. Achado do `/codex` no challenge da fase 3 — confirmado no código já mergeado.

## O defeito

Forced tool-use com `enum` barra objetivo **inventado**. Não barra o objetivo **válido e errado** — que é o que faz estrago.

`sem_historico → ativacao` é a primeira regra de `selectObjective` (#1026) e vem de um **fato binário**: não existe venda válida no resumo do cliente. Quando o modelo devolve `"recuperacao"` ali, o valor passa por `objetivoValido` (está no enum) e, com

```ts
plan.strategic_objective || d.strategicObjective
```

**vence o fato**. A vendedora recebe um plano de recuperação para um cliente que nunca comprou — com abordagem que pressupõe uma relação que nunca existiu.

O prompt já instrui a usar `ativacao` nesse caso. Instrução no prompt não é garantia estrutural: é exatamente a classe de erro que o schema não cobre.

## Onde estava

Nos **dois** caminhos de gravação, com o mesmo padrão:

| Caminho | Arquivo |
|---|---|
| cron (self-contained) | `generate-tactical-plan/index.ts`, no payload de `criar_plano_tatico` |
| frontend | `src/hooks/useTacticalPlan.ts`, no mesmo payload |

## A correção

`objetivoFinal` reconcilia os dois: sob `sem_historico` o servidor vence e a divergência vai para `console.warn` — silêncio ali é justamente o sinal de que o prompt deixou de ser obedecido, e sem log isso vira ruído invisível.

Nos demais objetivos o derivado sai de **faixas** (churn, mix, recência), onde o corte numérico é grosseiro e a leitura do modelo pode ser melhor — ali ela prevalece. O recorte é deliberado: só o fato binário sobrepõe a IA.

**Helper espelhado** (Deno não importa de `src/`): `plano-helpers.ts` × `src/lib/scoring/objective.ts`, com a **mesma tabela de casos** nos dois testes. Se divergirem, o plano gravado pelo cron e o gravado pela tela passam a contar histórias diferentes sobre o mesmo cliente.

## O que NÃO entra aqui

O outro achado do challenge — crash de tela por projeção parcial (`fmt(null)`) — **já foi resolvido pelo #1618**, e melhor do que a correção que eu tinha preparado: ele fez `fmt` renderizar `—` por campo, preservando o valor medido, em vez de descartar a projeção inteira.

## Prova

| Gate | Resultado |
|---|---|
| `heavy bun run test` | **641 arquivos · 5870 testes · 0 falhas** |
| `heavy bun run typecheck` | exit 0 · 0 erros |
| `test:edges` | 495 passed · 0 failed |
| `eslint .` | exit 0 · **0 erros** |
| `manifesto.gate` | 2/2 |

**Falsificação nos dois lados** — o guard só vale se a sabotagem ficar vermelha em ambos:

| Lado | Sabotagem | Vermelhos |
|---|---|---|
| edge | o fato medido volta a perder para a IA | **2/46**, nos testes nomeados, locales `C` e `pt_BR.UTF-8` |
| front | idem | **4/9** |

Restauração byte-idêntica (`cmp`) verde nos dois.

## Depois do merge (deploy é manual)

1. Deployar `generate-tactical-plan` pelo chat do Lovable — **2 arquivos**: `index.ts` + `plano-helpers.ts`.
2. **Publish do frontend** (`useTacticalPlan.ts` e `objective.ts`).
3. Conferir que nenhum commit "Changes" do bot reverteu os arquivos.
