### PR TITLE
feat(reposição): sob encomenda em lote — postponement da cauda no painel de baixo giro [money-path]

### DIFF
--- a/src/components/reposicao/baixoGiro/BaixoGiroFiltros.tsx
+++ b/src/components/reposicao/baixoGiro/BaixoGiroFiltros.tsx
@@ -70,6 +70,7 @@ export function BaixoGiroFiltros({ filtros, onChange }: BaixoGiroFiltrosProps) {
           <SelectContent>
             <SelectItem value="todos">Qualquer giro</SelectItem>
             <SelectItem value="morto">Giro morto (≥270d)</SelectItem>
+            <SelectItem value="sob_encomenda_candidato">Candidato a sob-encomenda</SelectItem>
           </SelectContent>
         </Select>
       </div>

--- a/src/components/reposicao/baixoGiro/BaixoGiroKpis.tsx
+++ b/src/components/reposicao/baixoGiro/BaixoGiroKpis.tsx
@@ -1,12 +1,13 @@
 import { fmtBRL } from "@/lib/reposicao/sku-param";
 import { LIMIAR_GIRO_MORTO_DIAS, type somarCapitalMorto } from "@/lib/reposicao/baixo-giro-helpers";
 
-export function BaixoGiroKpis({ totalRs, semCustoN, comEstoqueN, totalItens, morto }: {
+export function BaixoGiroKpis({ totalRs, semCustoN, comEstoqueN, totalItens, morto, sobEncomenda }: {
   totalRs: number; semCustoN: number; comEstoqueN: number; totalItens: number;
   morto: ReturnType<typeof somarCapitalMorto>;
+  sobEncomenda: { totalRs: number; candidatosN: number };
 }) {
   return (
-    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
       <div className="rounded-md border p-4">
         <div className="text-xs text-muted-foreground">Capital parado na cauda</div>
         <div className="kpi-value text-2xl font-semibold tnum">{fmtBRL(totalRs)}</div>
@@ -21,6 +22,11 @@ export function BaixoGiroKpis({ totalRs, semCustoN, comEstoqueN, totalItens, mor
           {morto.mortosN} SKU(s), {morto.comEstoqueN} com estoque
           {morto.semCustoN > 0 ? ` · ${morto.semCustoN} sem custo` : ""}
         </div>
+      </div>
+      <div className="rounded-md border p-4">
+        <div className="text-xs text-muted-foreground">Candidatos a sob-encomenda</div>
+        <div className="kpi-value text-2xl font-semibold tnum">{fmtBRL(sobEncomenda.totalRs)}</div>
+        <div className="text-xs text-muted-foreground">{sobEncomenda.candidatosN} SKU(s) com 1–2 vendas no histórico</div>
       </div>
       <div className="rounded-md border p-4">
         <div className="text-xs text-muted-foreground">Itens na cauda</div>

--- a/src/components/reposicao/baixoGiro/types.ts
+++ b/src/components/reposicao/baixoGiro/types.ts
@@ -26,12 +26,14 @@ export interface RowBaixoGiro {
   vendas_registradas: number;
   /** Sem venda há >= LIMIAR_GIRO_MORTO_DIAS (ou nunca), fora de cold start. */
   giro_morto: boolean;
+  /** Venda RARA (1-2 eventos no histórico) com estoque — candidato a virar sob-encomenda. */
+  candidato_sob_encomenda: boolean;
 }
 
 export interface FiltrosBaixoGiro {
   situacao: SituacaoTipo | "todos";
   estoque: "todos" | "com_estoque" | "sem_estoque";
-  giro: "todos" | "morto";
+  giro: "todos" | "morto" | "sob_encomenda_candidato";
   busca: string;
 }
 

--- a/src/components/reposicao/baixoGiro/useBaixoGiro.ts
+++ b/src/components/reposicao/baixoGiro/useBaixoGiro.ts
@@ -3,7 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { useReposicaoEmpresa } from "@/contexts/ReposicaoEmpresaContext";
-import { BAIXO_GIRO_OR_FILTER, classificarSituacao, diasSemVender, ehGiroMorto, somarCapitalMorto, somarCapitalParado } from "@/lib/reposicao/baixo-giro-helpers";
+import { BAIXO_GIRO_OR_FILTER, classificarSituacao, diasSemVender, ehCandidatoSobEncomenda, ehGiroMorto, somarCapitalMorto, somarCapitalParado } from "@/lib/reposicao/baixo-giro-helpers";
 import type { RowBaixoGiro } from "./types";
 
 const HOJE_ISO = () => new Date().toISOString().slice(0, 10);
@@ -79,6 +79,7 @@ export function useBaixoGiro() {
           tipo_reposicao: r.tipo_reposicao,
           vendas_registradas: vendasRegistradas,
           giro_morto: ehGiroMorto({ diasSemVender: dias, vendasRegistradas, emColdStart }),
+          candidato_sob_encomenda: ehCandidatoSobEncomenda({ vendasRegistradas, saldo, emColdStart }),
         };
       });
     },
@@ -146,12 +147,34 @@ export function useBaixoGiro() {
     onError: (e: Error) => toast.error("Falha ao descontinuar em lote: " + e.message),
   });
 
+  // Postponement da cauda: SKU raro-mas-vivo vira order-driven — o motor para de repor
+  // (tipo_reposicao != 'automatica' sai do sku_base) e o estoque atual escoa. Reversível
+  // pela tela de Revisão. Mesma escrita/gate humano do fluxo Descontinuar.
+  const sobEncomendaLote = useMutation({
+    mutationFn: async (codes: number[]) => {
+      const { error } = await supabase
+        .from("sku_parametros")
+        .update({ tipo_reposicao: "sob_encomenda", habilitado_reposicao_automatica: false })
+        .eq("empresa", empresa)
+        .in("sku_codigo_omie", codes);
+      if (error) throw error;
+    },
+    onSuccess: (_d, codes) => {
+      toast.success(`${codes.length} SKU(s) marcado(s) sob encomenda — fora dos próximos ciclos`);
+      qc.invalidateQueries({ queryKey: ["reposicao-baixo-giro"] });
+      qc.invalidateQueries({ queryKey: ["reposicao-excesso-estoque"] });
+      qc.invalidateQueries({ queryKey: ["pedidos-ciclo"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao marcar sob encomenda: " + e.message),
+  });
+
   const kpis = useMemo(() => {
     const rows = query.data ?? [];
     const cap = somarCapitalParado(rows.map((r) => ({ saldo: r.saldo, cmc: r.cmc })));
     const morto = somarCapitalMorto(rows.map((r) => ({ giroMorto: r.giro_morto, saldo: r.saldo, cmc: r.cmc })));
-    return { ...cap, totalItens: rows.length, morto };
+    const soc = somarCapitalParado(rows.filter((r) => r.candidato_sob_encomenda).map((r) => ({ saldo: r.saldo, cmc: r.cmc })));
+    return { ...cap, totalItens: rows.length, morto, sobEncomenda: { totalRs: soc.totalRs, candidatosN: rows.filter((r) => r.candidato_sob_encomenda).length } };
   }, [query.data]);
 
-  return { rows: query.data ?? [], kpis, isLoading: query.isLoading, error: query.error, refetch: query.refetch, manterEmEstoque, descontinuar, descontinuarLote };
+  return { rows: query.data ?? [], kpis, isLoading: query.isLoading, error: query.error, refetch: query.refetch, manterEmEstoque, descontinuar, descontinuarLote, sobEncomendaLote };
 }

--- a/src/lib/reposicao/__tests__/baixo-giro-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/baixo-giro-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   diasSemVender,
   previewManterLote,
   LIMIAR_GIRO_MORTO_DIAS,
+  ehCandidatoSobEncomenda,
   ehGiroMorto,
   somarCapitalMorto,
 } from "../baixo-giro-helpers";
@@ -102,5 +103,21 @@ describe("somarCapitalMorto", () => {
       { giroMorto: false, saldo: 100, cmc: 100 }, // vivo — fora
     ]);
     expect(r).toEqual({ totalRs: 50, comEstoqueN: 2, semCustoN: 1, mortosN: 3 });
+  });
+});
+
+describe("ehCandidatoSobEncomenda", () => {
+  it("raro (1-2 eventos) com estoque = candidato", () => {
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 1, saldo: 5, emColdStart: false })).toBe(true);
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: 1, emColdStart: false })).toBe(true);
+  });
+  it("sem venda nenhuma NAO e candidato (e giro morto — fluxo proprio)", () => {
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 0, saldo: 5, emColdStart: false })).toBe(false);
+  });
+  it("3+ eventos, sem estoque, ou cold start = fora", () => {
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 3, saldo: 5, emColdStart: false })).toBe(false);
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: 0, emColdStart: false })).toBe(false);
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: null, emColdStart: false })).toBe(false);
+    expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: 5, emColdStart: true })).toBe(false);
   });
 });

--- a/src/lib/reposicao/baixo-giro-helpers.ts
+++ b/src/lib/reposicao/baixo-giro-helpers.ts
@@ -76,6 +76,24 @@ export function ehGiroMorto(args: {
   return args.diasSemVender != null && args.diasSemVender >= LIMIAR_GIRO_MORTO_DIAS;
 }
 
+/**
+ * Candidato a SOB-ENCOMENDA (postponement da cauda): SKU VIVO mas de venda RARA — no máximo
+ * 2 eventos de venda em todo o histórico (fonte all-time v_sku_ultima_venda) — com estoque
+ * parado. Virar sob-encomenda elimina o estoque INTEIRO do SKU (ciclo+proteção+piso): o
+ * cliente espera o lead time. Medido 2026-07-30: 106 SKUs / R$38,7k nesse critério.
+ * Cold start fora (SKU novo sem venda é novo, não raro); sem venda nenhuma = giro morto
+ * (fluxo próprio: descontinuar), não sob-encomenda.
+ */
+export function ehCandidatoSobEncomenda(args: {
+  vendasRegistradas: number;
+  saldo: number | null;
+  emColdStart: boolean;
+}): boolean {
+  if (args.emColdStart) return false;
+  if (args.vendasRegistradas < 1 || args.vendasRegistradas > 2) return false;
+  return (args.saldo ?? 0) > 0;
+}
+
 /** Capital parado dos mortos (cmc ausente não fabrica R$0 — conta separada, como somarCapitalParado). */
 export function somarCapitalMorto(
   itens: Array<{ giroMorto: boolean; saldo: number | null; cmc: number | null }>,

--- a/src/pages/AdminReposicaoBaixoGiro.tsx
+++ b/src/pages/AdminReposicaoBaixoGiro.tsx
@@ -53,13 +53,14 @@ function exportarCsvExcesso(rows: RowExcesso[]) {
 }
 
 export default function AdminReposicaoBaixoGiro() {
-  const { rows, kpis, isLoading, manterEmEstoque, descontinuar, descontinuarLote } = useBaixoGiro();
+  const { rows, kpis, isLoading, manterEmEstoque, descontinuar, descontinuarLote, sobEncomendaLote } = useBaixoGiro();
   const excesso = useExcessoEstoque();
   const [filtros, setFiltros] = useState<FiltrosBaixoGiro>({ situacao: "todos", estoque: "todos", giro: "todos", busca: "" });
   const [selected, setSelected] = useState<Set<number>>(new Set());
   const [dialogAlvos, setDialogAlvos] = useState<RowBaixoGiro[] | null>(null);
   const [descontinuarAlvo, setDescontinuarAlvo] = useState<AlvoDescontinuar | null>(null);
   const [loteAlvos, setLoteAlvos] = useState<RowBaixoGiro[] | null>(null);
+  const [sobEncomendaAlvos, setSobEncomendaAlvos] = useState<RowBaixoGiro[] | null>(null);
 
   const filtered = useMemo(() => {
     return rows.filter((r) => {
@@ -67,6 +68,7 @@ export default function AdminReposicaoBaixoGiro() {
       if (filtros.estoque === "com_estoque" && !(r.saldo && r.saldo > 0)) return false;
       if (filtros.estoque === "sem_estoque" && r.saldo && r.saldo > 0) return false;
       if (filtros.giro === "morto" && !r.giro_morto) return false;
+      if (filtros.giro === "sob_encomenda_candidato" && !r.candidato_sob_encomenda) return false;
       const s = filtros.busca.trim().toLowerCase();
       if (s) {
         const byCode = /^\d+$/.test(s) ? String(r.sku_codigo_omie).includes(s) : false;
@@ -112,6 +114,14 @@ export default function AdminReposicaoBaixoGiro() {
                 }
               >
                 Descontinuar — {selected.size} selecionado(s)
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() =>
+                  setSobEncomendaAlvos(filtered.filter((r) => selected.has(r.sku_codigo_omie)))
+                }
+              >
+                Sob encomenda — {selected.size} selecionado(s)
               </Button>
             </div>
           )}
@@ -250,6 +260,46 @@ export default function AdminReposicaoBaixoGiro() {
               }}
             >
               Descontinuar {loteAlvos?.length ?? 0} SKU(s)
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+      <AlertDialog open={!!sobEncomendaAlvos} onOpenChange={(v) => { if (!v) setSobEncomendaAlvos(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Marcar {sobEncomendaAlvos?.length ?? 0} SKU(s) como sob encomenda?</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div>
+                <div className="max-h-48 overflow-y-auto rounded-md border p-2 text-xs">
+                  {(sobEncomendaAlvos ?? []).map((r) => (
+                    <div key={r.sku_codigo_omie} className="flex justify-between gap-2 py-0.5">
+                      <span className="truncate">{r.sku_descricao ?? r.sku_codigo_omie}</span>
+                      <span className="shrink-0 text-muted-foreground">
+                        {r.vendas_registradas} venda(s) no histórico
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <p className="mt-2">
+                  O motor para de repor (o item vira order-driven: compra-se quando o cliente pede e ele
+                  espera o lead time). O estoque atual escoa normalmente. Reversível pela tela de Revisão.
+                </p>
+              </div>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                const codes = (sobEncomendaAlvos ?? []).map((r) => r.sku_codigo_omie);
+                if (codes.length > 0) {
+                  sobEncomendaLote.mutate(codes, { onSuccess: () => setSelected(new Set()) });
+                  track("reposicao.sob_encomenda_lote", { skus: codes.length });
+                }
+                setSobEncomendaAlvos(null);
+              }}
+            >
+              Marcar sob encomenda
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## O problema (frente aprovada pelo founder)

Das práticas de supply aplicáveis ao perfil da OBEN (medição Syntetos-Boylan: **zero SKUs "smooth" — a carteira inteira é intermitente/lumpy**), o postponement é a maior alavanca restante: **106 SKUs habilitados têm apenas 1–2 eventos de venda em todo o histórico, com R$38,7k de capital parado** (+51 no limiar, R$22,1k). Quem compra 1×/ano aceita esperar o lead time (~10 d.u.) — virar order-driven elimina o estoque *inteiro* do SKU (ciclo + proteção + piso).

O campo `tipo_reposicao='sob_encomenda'` **já existia no motor** (o `sku_base` filtra `tipo='automatica'`); faltava o instrumento de decisão.

## A entrega

No painel de baixo giro:
- **Helper puro `ehCandidatoSobEncomenda`**: 1–2 vendas registradas (fonte all-time `v_sku_ultima_venda`) + estoque > 0; **cold start fora** (SKU novo não é raro); zero vendas = giro morto (fluxo próprio). Vitest nas bordas.
- **KPI** "Candidatos a sob-encomenda" (capital + contagem) · **filtro** dedicado · **ação em lote** com AlertDialog listando cada SKU e suas vendas — gate humano: o founder seleciona e confirma; reversível pela tela de Revisão.
- Mutation = mesma escrita do fluxo Descontinuar (`tipo_reposicao` + `habilitado=false`), invalidações cruzadas.

## Gates

typecheck verde · **5872 testes verdes** (o `manifesto.gate` deu timeout de 20s na 1ª rodada — flaky de swap com 25 sessões na máquina; re-provado verde isolado 2/2) · lint 0 errors.

Frontend puro — pós-merge só **Publish**. Sequência da mesma frente: registro de venda perdida + view Syntetos-Boylan advisory (próximo PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)