### PR TITLE
fix(reposicao): erro TERMINAL do portal deixa de virar estoque a caminho [money-path]

### DIFF
--- a/db/test-em-transito-erro-terminal.sh
+++ b/db/test-em-transito-erro-terminal.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Prova PG17 — gerar_pedidos_sugeridos_ciclo: erro TERMINAL do portal deixa de virar "estoque a caminho".
+# Incidente: pedido #1276 (OBEN/Sayerlack) travado em aprovado_aguardando_disparo + erro_nao_retentavel
+# inflou o estoque efetivo por 7 dias e SUPRIMIU a recompra de 4 SKUs.
+# Rodar: bash db/test-em-transito-erro-terminal.sh > log 2>&1; echo "exit=$?"  (NAO pipe pra tail — engole exit)
+# Lei de Ferro: aplica as MIGRATIONS REAIS (base 20260730130000 + a nova); asserts numericos por cenario;
+# FALSIFICA (sabota -> exige vermelho ESPECIFICO -> restaura). Sentinelas ASCII, caixa fixa.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5479}"
+SLUG="em-transito-erro-terminal"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+MIG_BASE="$REPO_ROOT/supabase/migrations/20260730130000_reposicao_teto_cobertura_motor.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql"
+FIXTURE="$REPO_ROOT/db/embalagem-motor-rpc.sql"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+# shellcheck disable=SC2329  # invocada via trap
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -qtA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  RED $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup PG17 :$PORT ==="
+
+# ── ZONA 1: roles/schemas + stubs das tabelas que a funcao LE (espelham a prod) ──
+P -q <<'SQL'
+CREATE ROLE anon NOLOGIN; CREATE ROLE authenticated NOLOGIN; CREATE ROLE service_role NOLOGIN;
+CREATE SCHEMA auth;
+CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $$ SELECT NULL::uuid $$;
+CREATE SCHEMA private;
+CREATE FUNCTION private.cap_compras_ler(p uuid) RETURNS boolean LANGUAGE sql STABLE AS $$ SELECT true $$;
+
+CREATE TABLE public.sku_parametros (empresa text, sku_codigo_omie bigint, sku_descricao text, fornecedor_nome text,
+  ponto_pedido numeric, estoque_maximo numeric, minimo_forcado_manual numeric,
+  habilitado_reposicao_automatica boolean, tipo_reposicao text,
+  demanda_media_diaria numeric, classe_abc character(1), classe_forcada text);
+CREATE TABLE public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_pendente_entrada numeric, fonte_sync text);
+CREATE TABLE public.sku_embalagem_equivalencia (empresa text, grupo_id uuid, sku_codigo_omie text, fator_para_base numeric, ativo boolean);
+CREATE TABLE public.sku_preco_fornecedor_capturado (empresa text, sku_codigo_omie text, preco numeric, status text, capturado_em timestamptz);
+CREATE TABLE public.sku_fornecedor_externo (empresa text, sku_omie text, sku_portal text, ativo boolean);
+CREATE TABLE public.inventory_position (omie_codigo_produto bigint, account text, saldo numeric DEFAULT 0, cmc numeric, synced_at timestamptz);
+CREATE TABLE public.company_config (key text UNIQUE, value text);
+CREATE TABLE public.omie_products (omie_codigo_produto bigint, account text, descricao text, familia text, ativo boolean, tipo_produto text, metadata jsonb DEFAULT '{}');
+CREATE TABLE public.sku_grupo_producao (empresa text, sku_codigo_omie text, grupo_codigo text);
+CREATE TABLE public.sku_leadtime_history (empresa text, sku_codigo_omie text, quantidade_recebida numeric, valor_total numeric);
+CREATE VIEW public.v_sku_leadtime_efetivo AS
+  SELECT empresa, sku_codigo_omie, quantidade_recebida, valor_total FROM public.sku_leadtime_history;
+CREATE TABLE public.reposicao_motor_run (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid NOT NULL, empresa text NOT NULL, data_ciclo date NOT NULL,
+  pedidos_gerados integer NOT NULL DEFAULT 0, skus_incluidos integer NOT NULL DEFAULT 0,
+  suprimidos_n integer NOT NULL DEFAULT 0, criado_em timestamptz NOT NULL DEFAULT now()
+);
+CREATE TABLE public.fornecedor_habilitado_reposicao (empresa text, fornecedor_nome text, horario_corte_pedido interval, valor_maximo_mensal numeric, delta_max_perc numeric, lt_logistica_dias int);
+CREATE TABLE public.familia_nao_comprada (id bigserial PRIMARY KEY, empresa text, familia text);
+CREATE TABLE public.sku_status_omie (empresa text, sku_codigo_omie text, ativo_no_omie boolean);
+CREATE TABLE public.pedido_compra_sugerido (id bigserial PRIMARY KEY, empresa text, fornecedor_nome text, grupo_codigo text,
+  data_ciclo date, horario_corte_planejado timestamptz, valor_total numeric NOT NULL DEFAULT 0, num_skus int, status text,
+  condicao_pagamento_codigo text, condicao_pagamento_descricao text, num_parcelas int, dias_parcelas text, condicao_origem text,
+  tipo_ciclo text, status_envio_portal text, portal_protocolo text, omie_pedido_compra_numero text, atualizado_em timestamptz);
+CREATE TABLE public.pedido_compra_item (id bigserial PRIMARY KEY, pedido_id bigint REFERENCES pedido_compra_sugerido(id) ON DELETE CASCADE,
+  sku_codigo_omie text, sku_descricao text, estoque_atual numeric, ponto_pedido numeric, estoque_maximo numeric,
+  qtde_sugerida numeric, qtde_final numeric, preco_unitario numeric, valor_linha numeric, primeira_compra boolean,
+  estoque_fisico numeric, estoque_a_caminho numeric);
+CREATE TABLE public.reposicao_estoque_nao_confirmado_log (id uuid DEFAULT gen_random_uuid(), run_id uuid, criado_em timestamptz DEFAULT now(),
+  empresa text, sku_codigo_omie text, sku_descricao text, grupo_codigo text, motivo text, estoque_efetivo numeric, ponto_pedido numeric, fonte_sync text);
+SQL
+echo "stubs criados"
+
+# ── ZONA 2: MIGRATIONS REAIS, na ordem (base cria log/ALTERs/config; a nova recria a funcao = a que vence) ──
+P -q -f "$MIG_BASE"
+P -q -f "$MIG"
+echo "migrations aplicadas: $(basename "$MIG_BASE") -> $(basename "$MIG")"
+
+# baseline de que a funcao viva e a NOVA (detector com objeto vivo, nao grep de arquivo)
+eq "funcao em prod tem a clausula do erro terminal" \
+   "$(Pq -c "SELECT (pg_get_functiondef(oid) LIKE '%erro_nao_retentavel%')::text FROM pg_proc WHERE proname='gerar_pedidos_sugeridos_ciclo'")" "true"
+
+# ── ZONA 3: seeds — 6 SKUs, 1 por cenario. Todos identicos EXCETO o estado do pedido anterior. ──
+# Desenho: pp=3, max=5, fisico=1, pedido anterior qtde_final=4.
+#   sem fantasma -> efetivo 1 <= pp 3 -> SUGERE ceil(5-1)=4
+#   com fantasma -> efetivo 1+4=5  > pp 3 -> AUSENTE
+# classe A: fora do teto de cobertura (isola a variavel testada). fonte_sync confirmada.
+P -q <<'SQL'
+INSERT INTO omie_products (omie_codigo_produto, account, descricao, familia, ativo, tipo_produto) VALUES
+ (9201,'oben','S1 ERRO TERMINAL LIMPO','Tintas',true,'00'),
+ (9202,'oben','S2 APROVADO SAUDAVEL','Tintas',true,'00'),
+ (9203,'oben','S3 ERRO COM PROTOCOLO','Tintas',true,'00'),
+ (9204,'oben','S4 ERRO COM OMIE','Tintas',true,'00'),
+ (9205,'oben','S5 ERRO RETENTAVEL','Tintas',true,'00'),
+ (9206,'oben','S6 DISPARADO','Tintas',true,'00');
+INSERT INTO fornecedor_habilitado_reposicao (empresa, fornecedor_nome, horario_corte_pedido, lt_logistica_dias) VALUES
+ ('OBEN','Sayerlack', interval '18:00:00', 7);
+
+INSERT INTO sku_parametros (empresa, sku_codigo_omie, sku_descricao, fornecedor_nome, ponto_pedido, estoque_maximo,
+                            minimo_forcado_manual, habilitado_reposicao_automatica, tipo_reposicao,
+                            demanda_media_diaria, classe_abc, classe_forcada)
+SELECT 'OBEN', g, 'S'||g, 'Sayerlack', 3, 5, NULL, true, 'automatica', 0.5, 'A', NULL
+FROM generate_series(9201,9206) g;
+
+INSERT INTO sku_estoque_atual (empresa, sku_codigo_omie, estoque_fisico, estoque_pendente_entrada, fonte_sync)
+SELECT 'OBEN', g::text, 1, 0, 'ListarPosEstoque' FROM generate_series(9201,9206) g;
+
+-- pedidos anteriores (data_ciclo dentro da janela de 7 dias do ciclo de teste 2026-07-03)
+INSERT INTO pedido_compra_sugerido (id, empresa, fornecedor_nome, data_ciclo, status, status_envio_portal, portal_protocolo, omie_pedido_compra_numero, tipo_ciclo) VALUES
+ (1,'OBEN','Sayerlack','2026-07-01','aprovado_aguardando_disparo','erro_nao_retentavel', NULL,   NULL,   'normal'),
+ (2,'OBEN','Sayerlack','2026-07-01','aprovado_aguardando_disparo','nao_aplicavel',        NULL,   NULL,   'normal'),
+ (3,'OBEN','Sayerlack','2026-07-01','aprovado_aguardando_disparo','erro_nao_retentavel','PROTO-9',NULL,   'normal'),
+ (4,'OBEN','Sayerlack','2026-07-01','aprovado_aguardando_disparo','erro_nao_retentavel', NULL,   '7788',  'normal'),
+ (5,'OBEN','Sayerlack','2026-07-01','aprovado_aguardando_disparo','erro_retentavel',      NULL,   NULL,   'normal'),
+ (6,'OBEN','Sayerlack','2026-07-01','disparado',                  'erro_nao_retentavel', NULL,   NULL,   'normal');
+SELECT setval(pg_get_serial_sequence('pedido_compra_sugerido','id'), 100);
+
+INSERT INTO pedido_compra_item (pedido_id, sku_codigo_omie, sku_descricao, qtde_final) VALUES
+ (1,'9201','S1',4),(2,'9202','S2',4),(3,'9203','S3',4),(4,'9204','S4',4),(5,'9205','S5',4),(6,'9206','S6',4);
+SQL
+echo "seeds ok"
+
+run_ciclo() { Pq -c "SELECT (gerar_pedidos_sugeridos_ciclo('$1','$2')).skus_incluidos"; }
+# qtde_final sugerida para o SKU no ciclo (pedido recem-gerado = pendente_aprovacao), ou AUSENTE
+qf() { Pq -c "SELECT COALESCE((SELECT pci.qtde_final::text FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id=pci.pedido_id WHERE pcs.empresa='$1' AND pcs.data_ciclo='$2' AND pci.sku_codigo_omie='$3' AND pcs.status='pendente_aprovacao'), 'AUSENTE')"; }
+# estoque_a_caminho gravado na linha (prova o fantasma no numero, nao so na presenca)
+qac() { Pq -c "SELECT COALESCE((SELECT pci.estoque_a_caminho::text FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id=pci.pedido_id WHERE pcs.empresa='$1' AND pcs.data_ciclo='$2' AND pci.sku_codigo_omie='$3' AND pcs.status='pendente_aprovacao'), 'AUSENTE')"; }
+
+echo "=== R1: ciclo com a correcao aplicada ==="
+run_ciclo OBEN 2026-07-03 >/dev/null
+eq "P1 erro terminal limpo VOLTA a ser sugerido (caso #1276)" "$(qf OBEN 2026-07-03 9201)" "4"
+eq "P1 e o a-caminho dele e ZERO (fantasma sumiu)"            "$(qac OBEN 2026-07-03 9201)" "0"
+eq "N1 aprovado SAUDAVEL segue contando (nao recompra)"       "$(qf OBEN 2026-07-03 9202)" "AUSENTE"
+eq "N2 erro terminal COM PROTOCOLO segue contando"            "$(qf OBEN 2026-07-03 9203)" "AUSENTE"
+eq "N3 erro terminal COM Nº OMIE segue contando"              "$(qf OBEN 2026-07-03 9204)" "AUSENTE"
+eq "N4 erro RETENTAVEL segue contando (ainda pode ir)"        "$(qf OBEN 2026-07-03 9205)" "AUSENTE"
+eq "N5 DISPARADO nunca e excluido"                            "$(qf OBEN 2026-07-03 9206)" "AUSENTE"
+eq "R1 exatamente 1 SKU sugerido no ciclo"                    "$(Pq -c "SELECT count(*) FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id=pci.pedido_id WHERE pcs.data_ciclo='2026-07-03' AND pcs.status='pendente_aprovacao'")" "1"
+
+echo "=== R2: fora da janela de 7 dias o pedido sai sozinho (nao mascara a correcao) ==="
+# ciclo 2026-07-09: data_ciclo 07-01 < 07-02 -> TODOS saem da janela -> todos voltam a ser sugeridos.
+# Prova que os AUSENTE de R1 vieram da janela+guarda, e nao de um SKU inelegivel por outro motivo.
+run_ciclo OBEN 2026-07-09 >/dev/null
+eq "R2 os 6 SKUs sao elegiveis fora da janela" "$(Pq -c "SELECT count(*) FROM pedido_compra_item pci JOIN pedido_compra_sugerido pcs ON pcs.id=pci.pedido_id WHERE pcs.data_ciclo='2026-07-09' AND pcs.status='pendente_aprovacao'")" "6"
+
+echo "=== FALSIFICACOES (baseline verde acima; cada sabotagem exige vermelho ESPECIFICO e restaura) ==="
+SAB_DIR="$(mktemp -d "/tmp/sab-${SLUG}.XXXXXX")"
+
+falsifica() {  # $1=nome  $2=sed-expr  $3=descricao  $4=query  $5=valor_sabotado_esperado
+  local nome="$1" sedexpr="$2" query="$4" esperado_sab="$5"
+  sed "$sedexpr" "$FIXTURE" > "$SAB_DIR/$nome.sql"
+  if cmp -s "$FIXTURE" "$SAB_DIR/$nome.sql"; then bad "FALSIF $nome: sed NAO aplicou (padrao nao casou)"; return; fi
+  P -q -f "$SAB_DIR/$nome.sql" 2>/dev/null || { bad "FALSIF $nome: sabotagem nao compilou"; return; }
+  P -q -c "DELETE FROM pedido_compra_item WHERE pedido_id > 6; DELETE FROM pedido_compra_sugerido WHERE id > 6; DELETE FROM reposicao_motor_run;" >/dev/null
+  run_ciclo OBEN 2026-07-05 >/dev/null
+  local veio; veio="$(eval "$query")"
+  if [ "$veio" = "$esperado_sab" ]; then ok "FALSIF $nome pegou a sabotagem ($3)"; else bad "FALSIF $nome NAO detectou — esperado sob sabotagem [$esperado_sab], veio [$veio]"; fi
+  P -q -f "$FIXTURE"   # restaura a funcao REAL
+}
+
+# F1: a exclusao nunca casa (equivale a REVERTER a correcao) -> o caso #1276 volta a ser suprimido.
+#     Prova que o assert P1 tem dente: sem a correcao ele fica vermelho.
+falsifica "F1-correcao-morta" \
+  "s/^           AND pcs2.status_envio_portal = 'erro_nao_retentavel'\$/           AND pcs2.status_envio_portal = 'NUNCA_CASA_ZZZ'/" \
+  "correcao revertida volta a suprimir o #1276" \
+  "qf OBEN 2026-07-05 9201" "AUSENTE"
+
+# F2: derruba a guarda do PROTOCOLO -> pedido que EFETIVOU no portal passaria a ser recomprado (compra dupla).
+falsifica "F2-sem-guarda-protocolo" \
+  "s/^           AND pcs2.portal_protocolo IS NULL\$/           AND true/" \
+  "sem a guarda, pedido com protocolo vira compra dupla" \
+  "qf OBEN 2026-07-05 9203" "4"
+
+# F3: derruba a guarda do Nº OMIE -> pedido que existe no Omie passaria a ser recomprado.
+#     Ancorada em ^...$ de proposito: a MESMA condicao aparece no 2o ramo da CTE (sem ancora, o sed
+#     casaria os dois e a sabotagem provaria outra coisa).
+falsifica "F3-sem-guarda-omie" \
+  "s/^           AND pcs2.omie_pedido_compra_numero IS NULL\$/           AND true/" \
+  "sem a guarda, pedido ja no Omie vira compra dupla" \
+  "qf OBEN 2026-07-05 9204" "4"
+
+# F4: derruba a guarda de STATUS -> 'disparado' passaria a ser elegivel a exclusao.
+falsifica "F4-sem-guarda-status" \
+  "s/^           pcs2.status = 'aprovado_aguardando_disparo'\$/           true/" \
+  "sem a guarda, pedido DISPARADO vira compra dupla" \
+  "qf OBEN 2026-07-05 9206" "4"
+
+rm -rf "$SAB_DIR"
+
+echo ""
+echo "=== RESULTADO: PASS=$PASS FAIL=$FAIL ==="
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **441** custom migrations totais
-- **1517** objetos esperados (criados por estas migrations)
+- **442** custom migrations totais
+- **1518** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 441
+  - `function`: 442
   - `rls_policy`: 386
   - `index`: 226
   - `cron_job`: 160
@@ -3706,6 +3706,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260801120000_drop_calcular_gatilhos_reposicao.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.gerar_pedidos_sugeridos_ciclo` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 441
+-- Total de custom migrations: 442
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -482,7 +482,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260730130000', 'reposicao_teto_cobertura_motor', '20260730130000_reposicao_teto_cobertura_motor.sql'),
   ('20260731120000', 'farmer_assoc_rules_delete_qualificado', '20260731120000_farmer_assoc_rules_delete_qualificado.sql'),
   ('20260731120000', 'v_sku_ultima_venda', '20260731120000_v_sku_ultima_venda.sql'),
-  ('20260801120000', 'drop_calcular_gatilhos_reposicao', '20260801120000_drop_calcular_gatilhos_reposicao.sql')
+  ('20260801120000', 'drop_calcular_gatilhos_reposicao', '20260801120000_drop_calcular_gatilhos_reposicao.sql'),
+  ('20260802120000', 'reposicao_erro_terminal_nao_e_estoque_a_caminho', '20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -1988,7 +1989,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('reposicao_teto_cobertura_motor', 'index', 'public', 'idx_teto_cobertura_log_emp_data', 'reposicao_teto_cobertura_log'),
   ('reposicao_teto_cobertura_motor', 'rls_policy', 'public', 'teto_cobertura_log_sel', 'reposicao_teto_cobertura_log'),
   ('reposicao_teto_cobertura_motor', 'rls_policy', 'public', 'teto_cobertura_log_ins', 'reposicao_teto_cobertura_log'),
-  ('v_sku_ultima_venda', 'view', 'public', 'v_sku_ultima_venda', '')
+  ('v_sku_ultima_venda', 'view', 'public', 'v_sku_ultima_venda', ''),
+  ('reposicao_erro_terminal_nao_e_estoque_a_caminho', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3542,7 +3544,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('reposicao_teto_cobertura_motor', 'index', 'public', 'idx_teto_cobertura_log_emp_data', 'reposicao_teto_cobertura_log'),
   ('reposicao_teto_cobertura_motor', 'rls_policy', 'public', 'teto_cobertura_log_sel', 'reposicao_teto_cobertura_log'),
   ('reposicao_teto_cobertura_motor', 'rls_policy', 'public', 'teto_cobertura_log_ins', 'reposicao_teto_cobertura_log'),
-  ('v_sku_ultima_venda', 'view', 'public', 'v_sku_ultima_venda', '')
+  ('v_sku_ultima_venda', 'view', 'public', 'v_sku_ultima_venda', ''),
+  ('reposicao_erro_terminal_nao_e_estoque_a_caminho', 'function', 'public', 'gerar_pedidos_sugeridos_ciclo', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql
+++ b/supabase/migrations/20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql
@@ -1,57 +1,21 @@
--- Migration: embalagem econômica DENTRO do motor de pedidos (QT↔GL) + consolidação de estoque de grupo
--- ⚠️ APLICADA MANUALMENTE no SQL Editor do Lovable em 2026-06-26 (NÃO vai em supabase/migrations/ — CLAUDE.md §5;
---     é CREATE OR REPLACE de função existente). Este arquivo é a FONTE versionada + fixture da regressão db/test-embalagem-motor.sh.
--- Spec: docs/superpowers/specs/2026-06-26-reposicao-embalagem-no-motor-spec.md
--- Money-path. Recria gerar_pedidos_sugeridos_ciclo (pré-flight pg_get_functiondef feito; base = prod 26/06).
+-- Migration: erro TERMINAL do portal deixa de virar "estoque a caminho" no motor de reposição.
+-- Money-path. ⚠️ NÃO auto-aplica (nome custom) — colar no SQL Editor do Lovable.
+-- Provada em PG17: db/test-em-transito-erro-terminal.sh (falsificada). Fonte viva do corpo:
+-- db/embalagem-motor-rpc.sql (guard de paridade src/lib/reposicao/__tests__/embalagem-motor-paridade.test.ts
+-- — por isso o CREATE OR REPLACE é o ÚLTIMO statement deste arquivo, byte-idêntico à fixture até EOF).
 --
--- DUAS mudanças cirúrgicas, tudo o mais PRESERVADO:
---   1) CONSOLIDA o estoque no nível do grupo de equivalência (Σ membros: GREATEST(inv,sea) físico + pendente + trânsito).
---      O gatilho passa a olhar o estoque do GRUPO → para de comprar quando há galão parado.
---   2) ESCOLHE a embalagem mais barata por unidade-base (galão), ESTRITO: só troca o quartinho pelo galão
---      quando AMBOS têm preço-app fresco (≤ N dias) + portal-map + catálogo OK, e o galão é estritamente mais barato/base.
---      Senão mantém o quartinho. Custo da linha do galão = preço-app (R$/embalagem), nunca 0.
+-- INCIDENTE (pedido #1276, OBEN/Sayerlack, 23/07/2026): o gate de grupo barrou o envio (SKU do grupo
+-- 'rapido' dentro de pedido 'normal' — Prz Ent 5 != LT 8). O pedido ficou em 'aprovado_aguardando_disparo'
+-- com status_envio_portal='erro_nao_retentavel'. A CTE em_transito conta 'aprovado_aguardando_disparo'
+-- por 7 dias SEM olhar o status do portal ⇒ 25 unidades que nunca existiram entraram no estoque efetivo
+-- e SUPRIMIRAM a recompra de 4 SKUs por 7 dias (3 classe A; um deles com 1 un. físico contra pp 3).
+-- Verificado: o pedido não chegou ao Omie (0 ocorrências de AFI-1276 em purchase_orders_tracking) nem
+-- ao portal (evidence.efetivarAttempted=false, sem protocolo).
 --
--- Unidade (cravada em prod): qtde_final = nº de EMBALAGENS do SKU; preco_unitario = R$/embalagem; o disparo
--- consome ceil(qtde_final) direto (fator_conversao=1). Quartinho NÃO é tocado (mantém cmc cru).
--- ⚠️ Case: equivalencia/preço_capturado = lower(empresa); parametros/estoque/fornecedor_externo = empresa (upper).
---
--- Revisão pós-Codex (xhigh) — 6 correções vs. o 1º rascunho:
---   P0-a GREATEST(inventory_position.saldo, sku_estoque_atual): galão parado vive em fontes DIFERENTES por SKU.
---   P0-b em_transito do galão × fator_para_base (2 galões em voo = 8 unidades-base, não 2) → anti double-buy.
---   P1-c âncora NÃO pode ser membro fator>1 (galão) de um grupo → impede 2 linhas do mesmo GL.
---   P1-d anti-duplicidade de oportunidade cobre a âncora E o SKU escolhido (galão).
---   P1-e minimo_forcado_manual respeitado também na troca p/ galão (piso aplicado ANTES de dividir pelo fator).
---   P1-f filtros de catálogo (ativo/tipo 04/família/status omie) aplicados ao MEMBRO escolhido, não só à âncora.
--- Granularidade (P2 Codex, aceito): nº_galões = ceil(necessidade / fator) na escala "unidades-âncora" — NUNCA
---   compra menos que o legado QT (herda o descasamento litros↔embalagem pré-existente, fora de escopo).
---
--- ➕ 2026-06-27 — GATE de estoque-NÃO-CONFIRMADO (money-path; spec 2026-06-27-reposicao-gate-estoque-nao-confirmado).
---   Bug provado: cold-start semeia sku_estoque_atual de omie_products.estoque (82% zerado na OBEN), fonte_sync=
---   'cold_start_seed'. Se o motor roda na janela cold-start→ListarPosEstoque, lê o seed=0 e compra por cima de
---   estoque existente. FIX (Codex consult 019f0968 + ausente≠zero): estoque cuja ÚNICA fonte é cold_start_seed (sem
---   inventory_position) é DESCONHECIDO → o motor SUPRIME a sugestão (nível LINHA e GRUPO) + LOGA em
---   reposicao_estoque_nao_confirmado_log. Zero CONFIRMADO (ListarPosEstoque/0) segue comprando — auto-liberante.
---   ⚠️ Esta fixture é SÓ a função; a tabela de log + RLS vivem na migration formal (e nos harnesses de teste).
---   Migration: supabase/migrations/20260627180000_reposicao_gate_estoque_nao_confirmado.sql (corpo da função idêntico).
---
--- ➕ 2026-07-08 — MARCADOR DE RUN (reposicao_motor_run) — a fila da tela ancora no ÚLTIMO recálculo, NÃO no último
---   recálculo QUE TEVE supressão. Bug: run limpo não grava no log de suprimidos → a mensagem "N fora da compra"
---   grudava por até 24h após o sync já ter confirmado o estoque (Codex 2026-07-08 → Opção 2: fonte-de-verdade, não
---   render). A RPC carimba TODO run (limpo ou não) ao fim; a tela lê o último marker (some quando suprimidos_n=0).
---   Tabela reposicao_motor_run + RLS na migration *_reposicao_motor_run_marker.sql (mesmo padrão do log; corpo idêntico).
---
--- ➕ 2026-07-29 — TETO DE COBERTURA pós-compra (B/C) — spec 2026-07-29-reposicao-teto-cobertura-motor-spec.md.
---   Medido em prod: B/C com R$90k acima do alvo; ~R$25k/tri de compras criando cobertura >90d(B)/60d(C); dente de
---   serra 1↔2 nos CZ. CAP só-reduz no lote do ciclo NORMAL: qtde_final ≤ max(floor(teto·d − estoque_efetivo),
---   piso_de_serviço ceil(pp − estoque_efetivo)) — o cap corta o "encher até o máximo" ACIMA do ponto de pedido,
---   nunca a proteção (pp/ss intactos; a recalibração global de jun/2026 segue enterrada). Pós-Codex xhigh:
---   grupos de embalagem FICAM FORA do cap (estoque consolidado QT+GL ÷ demanda só da âncora = subcompra) · config
---   POR EMPRESA (reposicao_teto_cobertura_<empresa>_{ativa,dias_b,dias_c}; flag nasce false, parse regex-blindado
---   fail-off) · classe efetiva = classe_forcada→classe_abc · minimo_forcado_manual vence o teto · linha capada a
---   ZERO sai do pedido (filtro qtde_final>0 centralizado em skus_inseriveis p/ os DOIS INSERTs) e LOGA em
---   reposicao_teto_cobertura_log · rastro no item (qtde_sem_teto, teto_cobertura_aplicado — forward_buying pode
---   sobrescrever qtde_final DEPOIS: exceção documentada à invariante) · capados_n no marker do run.
---   Tabela do log + colunas novas + config na migration *_reposicao_teto_cobertura_motor.sql (corpo idêntico).
+-- O que muda: um único predicado na CTE em_transito. Erro terminal + sem protocolo + sem nº Omie deixa
+-- de contar como a caminho. Fail-CLOSED (as 3 guardas juntas): qualquer sinal de que algo chegou mantém
+-- o pedido contando — o risco assimétrico aqui é comprar DUAS vezes, não subcomprar.
+-- Rollback: reaplicar a migration 20260730130000 (a anterior a recriar a função).
 
 CREATE OR REPLACE FUNCTION public.gerar_pedidos_sugeridos_ciclo(p_empresa text DEFAULT 'OBEN'::text, p_data_ciclo date DEFAULT CURRENT_DATE)
  RETURNS TABLE(pedidos_gerados integer, skus_incluidos integer, valor_total_ciclo numeric, bloqueados integer)


### PR DESCRIPTION
## O incidente

Pedido **#1276** (OBEN/Sayerlack, 23/07, R$ 8.237,08) foi barrado pelo gate de grupo: o SKU
**DILUENTE PU DF.4056LT** é do grupo `rapido` (Prz Ent 5) e estava num pedido `normal` (LT 8).
O gate agiu certo — sem ele o pedido entraria com prazo de entrega errado.

O problema é o que veio **depois**. O pedido ficou em `aprovado_aguardando_disparo` +
`status_envio_portal='erro_nao_retentavel'`, e a CTE `em_transito` do motor conta
`aprovado_aguardando_disparo` por 7 dias **sem olhar o status do portal**. Resultado: 25 unidades
que nunca existiram entraram no estoque efetivo como "a caminho" e **suprimiram a recompra de 4
SKUs por 7 dias** — 3 classe A, um com 1 unidade física contra ponto de pedido 3. O ciclo de hoje
(#1390) não trouxe nenhum deles.

O de-para foi corrigido em 24/07 00:24 — mas a retentativa 3 minutos depois falhou idêntica,
porque o pedido já gerado carrega o grupo congelado. Não existe caminho de recompor pedido.

### Verificado nos dois lados antes do fix

| Onde | Evidência |
|---|---|
| **Omie** | 0 ocorrências de `AFI-1276` em `purchase_orders_tracking` (716 POs, sync de 1h). Nenhum PO desde 23/07 contém os SKUs. Busca **falsificada** com controle positivo (o PO 1144 casa o SKU esperado) — negativa real, não sonda quebrada. |
| **Portal** | `evidence.efetivarAttempted=false`, sem protocolo, 2 tentativas. Itens chegaram à *sessão* do portal; "Efetivar" e "Salvar Proposta" nunca foram clicados. |

> Um caminho que **não** serve de prova: `estoque_pendente_entrada` mostra 0 nesses SKUs, mas o
> sync de-duplica exatamente contra o `AFI-1276` para não contar em dobro.

## O fix

Um predicado na CTE `em_transito`: erro terminal + sem protocolo + sem nº Omie deixa de contar.

**Seguro por desenho:** `erro_nao_retentavel` só é alcançado com `efetivarAttempted=false` — o
resultado ambíguo tem estado próprio (`aceito_portal_sem_protocolo` /
`indeterminado_requer_conciliacao`). As 3 guardas são **fail-CLOSED**: qualquer sinal de que algo
chegou mantém o pedido contando, porque o risco assimétrico aqui é comprar **duas vezes**, não
subcomprar.

## Prova

`db/test-em-transito-erro-terminal.sh` — PG17, **14 asserts**, 6 cenários (um por estado de pedido):

- **P1** erro terminal limpo volta a ser sugerido (o #1276) e o a-caminho dele é **zero**
- **N1** aprovado saudável segue contando · **N2** com protocolo segue · **N3** com nº Omie segue
- **N4** `erro_retentavel` segue · **N5** `disparado` nunca é excluído
- **R2** fora da janela de 7 dias os 6 voltam — prova que os AUSENTE vieram da guarda, não de SKU inelegível

**Falsificado** (4 sabotagens, cada uma exigindo vermelho específico):
reverter a correção volta a suprimir o #1276; derrubar cada uma das 3 guardas gera compra dupla.
A sabotagem do nº Omie é ancorada em `^...$` de propósito — a mesma condição existe no 2º ramo da CTE.

**Regressão verde:** teto-cobertura 35 ok · embalagem-motor 31 ok · gate-estoque 29 ok · guard de
paridade fixture↔migration · suíte 5870 testes · typecheck 0 erros · lint 0 errors.

**Pré-voo:** sem drift repo↔prod (`pg_get_functiondef` idêntico) · sem colisão de objeto em 59 worktrees.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql`.
**Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor e rodar.

Validação pós-apply (discrimina — hoje retorna ❌, medido via psql-ro):

```sql
SELECT CASE WHEN pg_get_functiondef(oid) LIKE '%erro_nao_retentavel%'
  THEN '✅ motor atualizado — erro terminal não conta mais como estoque a caminho'
  ELSE '❌ FALTANDO — migration não aplicada' END AS status
FROM pg_proc WHERE proname = 'gerar_pedidos_sugeridos_ciclo';
```

## Não coberto (deliberado)

O pedido #1276 em si se resolve **cancelando pelo app** (`/admin/reposicao/pedidos` → ✕), que a RPC
já permite nesse status. Este PR mata a **classe**; o caso individual é 3 cliques.
Recompor um pedido gerado com grupo errado continua sem caminho — fica como frente separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
