### PR TITLE
feat(reposição): venda perdida + classificação Syntetos-Boylan advisory [money-path]

### DIFF
--- a/db/test-venda-perdida-rls.sh
+++ b/db/test-venda-perdida-rls.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Prova PG17 — RLS de venda_perdida_log + view v_sku_classe_sb (migration 20260802120000).
+# Rodar: bash db/test-venda-perdida-rls.sh > log 2>&1; echo "exit=$?"   (NAO pipe pra tail — engole exit)
+# Lei de Ferro: aplica a MIGRATION REAL; RLS provada sob SET ROLE authenticated + GUC (superuser bypassaria);
+# FALSIFICA (sabota a policy de INSERT -> exige vermelho -> restaura).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5473}"
+SLUG="venda-perdida-rls"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+MIG="$REPO_ROOT/supabase/migrations/20260802120000_venda_perdida_e_classe_sb.sql"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+# shellcheck disable=SC2329  # invocada via trap
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -qtA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  RED $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup PG17 :$PORT ==="
+
+# ── ZONA 1: roles + auth stub (GUC) + has_role REAL sobre user_roles + fontes da view ──
+P -q <<'SQL'
+CREATE ROLE anon NOLOGIN; CREATE ROLE authenticated NOLOGIN; CREATE ROLE service_role NOLOGIN;
+CREATE SCHEMA auth;
+CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE
+  AS $f$ SELECT nullif(current_setting('test.uid', true), '')::uuid $f$;
+GRANT USAGE ON SCHEMA auth TO authenticated, anon;   -- prod tem (harness tao permissivo quanto a prod)
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('master','employee','customer'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE TABLE public.user_roles (id uuid PRIMARY KEY DEFAULT gen_random_uuid(), user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE FUNCTION public.has_role(_user_id uuid, _role public.app_role) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER AS $f$
+  SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role)
+$f$;
+GRANT EXECUTE ON FUNCTION public.has_role(uuid, public.app_role) TO authenticated, anon;
+GRANT USAGE ON SCHEMA public TO authenticated, anon;
+
+-- fonte da view SB: stub minimo de venda_items_history + a view efetivo 1:1 (o assunto aqui e a
+-- RLS/estrutura, nao a consolidacao N->1 — provada em harness proprio)
+CREATE TABLE public.venda_items_history (empresa text, sku_codigo_omie bigint, data_emissao timestamptz, quantidade numeric);
+ALTER TABLE public.venda_items_history ENABLE ROW LEVEL SECURITY;
+GRANT SELECT ON public.venda_items_history TO authenticated;
+CREATE POLICY vih_staff_sel ON public.venda_items_history FOR SELECT TO authenticated
+  USING (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+-- espelha a PROD (conferido 2026-07-30 via psql-ro): a efetivo real é security_invoker=on.
+-- Stub sem o WITH roda como owner e BYPASSA a RLS da base — inventaria um vazamento que não existe.
+CREATE VIEW public.v_venda_items_history_efetivo WITH (security_invoker=on) AS SELECT * FROM public.venda_items_history;
+GRANT SELECT ON public.v_venda_items_history_efetivo TO authenticated;
+SQL
+echo "stubs ok"
+
+# ── ZONA 2: migration REAL ──
+P -q -f "$MIG"
+echo "migration aplicada"
+
+# ── ZONA 3: seeds (staff + customer + vendas p/ a view SB) ──
+P -q <<'SQL'
+INSERT INTO public.user_roles (user_id, role) VALUES
+ ('11111111-1111-1111-1111-111111111111', 'employee'),
+ ('22222222-2222-2222-2222-222222222222', 'customer');
+INSERT INTO public.venda_items_history (empresa, sku_codigo_omie, data_emissao, quantidade) VALUES
+ ('OBEN', 9001, '2026-05-01', 10), ('OBEN', 9001, '2026-05-20', 2), ('OBEN', 9001, '2026-07-01', 30);
+SQL
+
+# helper: roda um SQL sob authenticated com uid setado; imprime resultado ou SQLSTATE
+como() { # $1=uid  $2=sql
+  Pq -c "SET ROLE authenticated; SET test.uid = '$1'; $2" 2>&1 | tail -1
+}
+
+echo "=== RLS venda_perdida_log ==="
+# guard anti-teatro: o SET ROLE de fato vale dentro da MESMA sessao psql
+eq "guard current_user=authenticated" "$(Pq -c "SET ROLE authenticated; SELECT current_user;")" "authenticated"
+
+# staff INSERT ok
+R=$(como 11111111-1111-1111-1111-111111111111 "INSERT INTO public.venda_perdida_log (sku_codigo_omie, quantidade, motivo) VALUES ('9001', 5, 'sem_estoque') RETURNING 'INSERIU';")
+eq "staff INSERT permitido" "$R" "INSERIU"
+# staff SELECT ve
+R=$(como 11111111-1111-1111-1111-111111111111 "SELECT count(*) FROM public.venda_perdida_log;")
+eq "staff SELECT ve 1" "$R" "1"
+# customer INSERT negado (RLS 42501)
+R=$(como 22222222-2222-2222-2222-222222222222 "INSERT INTO public.venda_perdida_log (sku_codigo_omie, quantidade) VALUES ('9001', 1);" )
+case "$R" in *"42501"*|*"row-level security"*) ok "customer INSERT negado (RLS)";; *) bad "customer INSERT deveria ser negado — veio [$R]";; esac
+# customer SELECT 0 linhas (RLS filtra, nao erra)
+R=$(como 22222222-2222-2222-2222-222222222222 "SELECT count(*) FROM public.venda_perdida_log;")
+eq "customer SELECT ve 0" "$R" "0"
+# anon: sem grant -> permission denied
+R=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.venda_perdida_log;" 2>&1 | tail -1)
+case "$R" in *"permission denied"*) ok "anon sem acesso (permission denied)";; *) bad "anon deveria ser negado — veio [$R]";; esac
+
+echo "=== view v_sku_classe_sb ==="
+eq "view existe c/ security_invoker" "$(Pq -c "SELECT 'security_invoker=on' = ANY(reloptions) FROM pg_class WHERE relname='v_sku_classe_sb';")" "t"
+# staff le e o quadrante sai (3 dias de venda, ADI alto, CV2 alto -> lumpy)
+R=$(como 11111111-1111-1111-1111-111111111111 "SELECT quadrante FROM public.v_sku_classe_sb WHERE sku_codigo_omie = 9001;")
+eq "staff le a view (quadrante lumpy)" "$R" "lumpy"
+# customer: invoker herda a RLS da base -> 0 linhas (a view nao vaza)
+R=$(como 22222222-2222-2222-2222-222222222222 "SELECT count(*) FROM public.v_sku_classe_sb;")
+eq "customer ve 0 na view (invoker herda RLS)" "$R" "0"
+
+echo "=== FALSIFICACAO: policy de INSERT sabotada p/ WITH CHECK (true) -> o assert de negacao TEM de ficar vermelho ==="
+P -q -c "DROP POLICY venda_perdida_ins ON public.venda_perdida_log; CREATE POLICY venda_perdida_ins ON public.venda_perdida_log FOR INSERT TO authenticated WITH CHECK (true);"
+R=$(como 22222222-2222-2222-2222-222222222222 "INSERT INTO public.venda_perdida_log (sku_codigo_omie, quantidade) VALUES ('9001', 1) RETURNING 'INSERIU';")
+if [ "$R" = "INSERIU" ]; then ok "FALSIF pegou: com a policy sabotada o customer INSERE (o assert original tem dente)"; else bad "FALSIF invalida — sabotagem nao mudou o comportamento [$R]"; fi
+# restaura a policy REAL re-aplicando a migration (DROP POLICY IF EXISTS + CREATE dela)
+P -q -f "$MIG"
+R=$(como 22222222-2222-2222-2222-222222222222 "INSERT INTO public.venda_perdida_log (sku_codigo_omie, quantidade) VALUES ('9001', 1);" )
+case "$R" in *"42501"*|*"row-level security"*) ok "restaurada: customer negado de novo";; *) bad "restauracao falhou — [$R]";; esac
+
+echo ""
+echo "=== RESULTADO: PASS=$PASS FAIL=$FAIL ==="
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,6 +142,7 @@ const AdminReposicaoAumentoDetail = lazy(() => import("./pages/AdminReposicaoAum
 const AdminReposicaoOportunidades = lazy(() => import("./pages/AdminReposicaoOportunidades"));
 const AdminReposicaoNegociacaoParalela = lazy(() => import("./pages/AdminReposicaoNegociacaoParalela"));
 const AdminReposicaoBaixoGiro = lazy(() => import("./pages/AdminReposicaoBaixoGiro"));
+const AdminReposicaoVendaPerdida = lazy(() => import("./pages/AdminReposicaoVendaPerdida"));
 const AdminReposicaoCockpit = lazy(() => import("./pages/AdminReposicaoCockpit"));
 const AdminReposicaoParametros = lazy(() => import("./pages/AdminReposicaoParametros"));
 const AdminReposicaoMercado = lazy(() => import("./pages/AdminReposicaoMercado"));
@@ -385,6 +386,7 @@ const App = () => {
                 <Route path="admin/reposicao/oportunidades" element={<AdminReposicaoOportunidades />} />
                 <Route path="admin/reposicao/negociacao-paralela" element={<AdminReposicaoNegociacaoParalela />} />
                 <Route path="admin/reposicao/baixo-giro" element={<AdminReposicaoBaixoGiro />} />
+                <Route path="admin/reposicao/venda-perdida" element={<AdminReposicaoVendaPerdida />} />
                 <Route element={<ReposicaoSessionLayout />}>
                   <Route path="admin/reposicao/sessao" element={<AdminReposicaoCockpit />} />
                   <Route path="admin/reposicao/sessao/mercado" element={<AdminReposicaoMercado />} />

--- a/src/components/reposicao/baixoGiro/BaixoGiroTable.tsx
+++ b/src/components/reposicao/baixoGiro/BaixoGiroTable.tsx
@@ -10,6 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { classBadge, fmt, fmtBRL } from "@/lib/reposicao/sku-param";
+import { rotuloClasseSB } from "@/lib/reposicao/baixo-giro-helpers";
 import { type BadgeVariant } from "@/components/reposicao/revisao/types";
 import type { RowBaixoGiro } from "./types";
 
@@ -127,6 +128,9 @@ export function BaixoGiroTable({
                     <Badge variant={classBadge(row.classe_consolidada) as BadgeVariant}>
                       {row.classe_consolidada ?? "—"}
                     </Badge>
+                    {rotuloClasseSB(row.classe_sb) && (
+                      <div className="mt-0.5 text-[10px] text-muted-foreground">{rotuloClasseSB(row.classe_sb)}</div>
+                    )}
                   </TableCell>
                   <TableCell className="text-right tnum">{capitalCell}</TableCell>
                   <TableCell className="text-right tnum">{fmt(row.saldo, 0)}</TableCell>

--- a/src/components/reposicao/baixoGiro/types.ts
+++ b/src/components/reposicao/baixoGiro/types.ts
@@ -28,6 +28,8 @@ export interface RowBaixoGiro {
   giro_morto: boolean;
   /** Venda RARA (1-2 eventos no histórico) com estoque — candidato a virar sob-encomenda. */
   candidato_sob_encomenda: boolean;
+  /** Quadrante Syntetos-Boylan (v_sku_classe_sb, advisory): smooth|intermittent|erratic|lumpy|null. */
+  classe_sb: string | null;
 }
 
 export interface FiltrosBaixoGiro {

--- a/src/components/reposicao/baixoGiro/useBaixoGiro.ts
+++ b/src/components/reposicao/baixoGiro/useBaixoGiro.ts
@@ -31,13 +31,19 @@ export function useBaixoGiro() {
       // 2) enriquecimentos (.in) — última venda vem da fonte ALL-TIME (v_sku_ultima_venda):
       // a v_sku_demanda_estatisticas é janelada em 90d e mostrava "nunca" p/ quem vendeu há 4 meses.
       // (cast: a view é da migration 20260731120000 e só entra nos types gerados no próximo type-gen)
-      const [{ data: inv }, demRes, { data: sug }] = await Promise.all([
+      const [{ data: inv }, demRes, { data: sug }, sbRes] = await Promise.all([
         supabase.from("inventory_position").select("omie_codigo_produto, saldo, cmc").eq("account", empresa.toLowerCase()).in("omie_codigo_produto", codes),
         supabase.from("v_sku_ultima_venda" as never).select("sku_codigo_omie, ultima_venda_data, vendas_registradas").eq("empresa", empresa).in("sku_codigo_omie", codes) as unknown as PromiseLike<{
           data: { sku_codigo_omie: number; ultima_venda_data: string | null; vendas_registradas: number }[] | null;
           error: unknown;
         }>,
         supabase.from("v_sku_parametros_sugeridos").select("sku_codigo_omie, status_sugestao").eq("empresa", empresa).in("sku_codigo_omie", codes),
+        // Classificação Syntetos-Boylan (advisory; view da migration 20260802120000, cast pré-type-gen).
+        // Falha aqui NÃO derruba a tela: o badge some (advisory puro — nenhuma decisão em cima).
+        supabase.from("v_sku_classe_sb" as never).select("sku_codigo_omie, quadrante").eq("empresa", empresa).in("sku_codigo_omie", codes) as unknown as PromiseLike<{
+          data: { sku_codigo_omie: number; quadrante: string | null }[] | null;
+          error: unknown;
+        }>,
       ]);
       // Falha na fonte do giro morto LANÇA — "não consegui ler a última venda" viraria
       // vendas_registradas=0 ⇒ giro_morto=true na lista INTEIRA (veredito de descontinuar
@@ -46,6 +52,7 @@ export function useBaixoGiro() {
       const dem = demRes.data;
       const invMap = new Map((inv ?? []).map((r) => [Number(r.omie_codigo_produto), r]));
       const demMap = new Map((dem ?? []).map((r) => [Number(r.sku_codigo_omie), r]));
+      const sbMap = new Map((sbRes.error == null ? (sbRes.data ?? []) : []).map((r) => [Number(r.sku_codigo_omie), r.quadrante]));
       const sugMap = new Map((sug ?? []).map((r) => [Number(r.sku_codigo_omie), r]));
       const hoje = HOJE_ISO();
 
@@ -80,6 +87,7 @@ export function useBaixoGiro() {
           vendas_registradas: vendasRegistradas,
           giro_morto: ehGiroMorto({ diasSemVender: dias, vendasRegistradas, emColdStart }),
           candidato_sob_encomenda: ehCandidatoSobEncomenda({ vendasRegistradas, saldo, emColdStart }),
+          classe_sb: sbMap.get(code) ?? null,
         };
       });
     },

--- a/src/components/shell/CommandPalette.tsx
+++ b/src/components/shell/CommandPalette.tsx
@@ -96,6 +96,7 @@ export function CommandPalette() {
       { id: 'nav.repo-cockpit', label: 'Cockpit de Reposição', group: 'Reposição', icon: LayoutDashboard, keywords: ['compras', 'comprador'], perform: go('/admin/reposicao/cockpit') },
       { id: 'nav.repo-pedidos', label: 'Pedidos de compra sugeridos', group: 'Reposição', icon: Truck, perform: go('/admin/reposicao/pedidos') },
       { id: 'nav.repo-alertas', label: 'Alertas de reposição', group: 'Reposição', icon: BarChart3, perform: go('/admin/reposicao/alertas') },
+      { id: 'nav.repo-venda-perdida', label: 'Registrar venda perdida', group: 'Reposição', icon: BarChart3, keywords: ['faltou', 'sem estoque', 'ruptura'], perform: go('/admin/reposicao/venda-perdida') },
       // Financeiro
       { id: 'nav.fin-cockpit', label: 'Cockpit CFO', group: 'Financeiro', icon: Shield, keywords: ['CFO', 'caixa'], perform: go('/financeiro/cockpit') },
       { id: 'nav.fin-gestao', label: 'Gestão financeira', group: 'Financeiro', icon: DollarSign, perform: go('/financeiro/gestao') },

--- a/src/lib/reposicao/__tests__/baixo-giro-helpers.test.ts
+++ b/src/lib/reposicao/__tests__/baixo-giro-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   LIMIAR_GIRO_MORTO_DIAS,
   ehCandidatoSobEncomenda,
   ehGiroMorto,
+  rotuloClasseSB,
   somarCapitalMorto,
 } from "../baixo-giro-helpers";
 
@@ -119,5 +120,17 @@ describe("ehCandidatoSobEncomenda", () => {
     expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: 0, emColdStart: false })).toBe(false);
     expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: null, emColdStart: false })).toBe(false);
     expect(ehCandidatoSobEncomenda({ vendasRegistradas: 2, saldo: 5, emColdStart: true })).toBe(false);
+  });
+});
+
+describe("rotuloClasseSB", () => {
+  it("mapeia os 4 quadrantes e devolve null p/ desconhecido/ausente", () => {
+    expect(rotuloClasseSB("intermittent")).toBe("intermitente");
+    expect(rotuloClasseSB("lumpy")).toBe("lumpy");
+    expect(rotuloClasseSB("smooth")).toBe("regular");
+    expect(rotuloClasseSB("erratic")).toBe("errática");
+    expect(rotuloClasseSB("qualquer")).toBeNull();
+    expect(rotuloClasseSB(null)).toBeNull();
+    expect(rotuloClasseSB(undefined)).toBeNull();
   });
 });

--- a/src/lib/reposicao/baixo-giro-helpers.ts
+++ b/src/lib/reposicao/baixo-giro-helpers.ts
@@ -94,6 +94,21 @@ export function ehCandidatoSobEncomenda(args: {
   return (args.saldo ?? 0) > 0;
 }
 
+/**
+ * Rótulo pt-BR do quadrante Syntetos-Boylan (v_sku_classe_sb — ADVISORY, não alimenta o motor).
+ * Medido 2026-07-30: zero "smooth"/"erratic" na carteira — 160 intermitentes + 73 lumpy.
+ * Quadrante desconhecido/ausente → null (a UI mostra nada, nunca inventa rótulo).
+ */
+export function rotuloClasseSB(quadrante: string | null | undefined): string | null {
+  switch (quadrante) {
+    case "smooth": return "regular";
+    case "intermittent": return "intermitente";
+    case "erratic": return "errática";
+    case "lumpy": return "lumpy";
+    default: return null;
+  }
+}
+
 /** Capital parado dos mortos (cmc ausente não fabrica R$0 — conta separada, como somarCapitalParado). */
 export function somarCapitalMorto(
   itens: Array<{ giroMorto: boolean; saldo: number | null; cmc: number | null }>,

--- a/src/pages/AdminReposicaoVendaPerdida.tsx
+++ b/src/pages/AdminReposicaoVendaPerdida.tsx
@@ -1,0 +1,213 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { supabase } from "@/integrations/supabase/client";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { EMPRESA } from "@/components/reposicao/pedidos/shared";
+import { track } from "@/lib/analytics";
+import { useAuth } from "@/contexts/AuthContext";
+
+/**
+ * Registro de VENDA PERDIDA — a série de demanda censurada que não existia (lacuna P0 apontada
+ * pelo challenge do Codex na análise de nível de serviço, 2026-07-30). "Cliente pediu e não
+ * tinha" (ou desistiu por preço/prazo): registrar leva segundos e, com meses de dado, responde
+ * "quanto a ruptura realmente custa" com número em vez de fé. NENHUM consumo automático no motor.
+ */
+
+const MOTIVOS = [
+  { value: "sem_estoque", label: "Sem estoque" },
+  { value: "preco", label: "Preço" },
+  { value: "prazo", label: "Prazo de entrega" },
+  { value: "outro", label: "Outro" },
+] as const;
+
+interface ProdutoOpcao { omie_codigo_produto: number; descricao: string | null }
+interface RegistroPerdido {
+  id: string; criado_em: string; sku_codigo_omie: string; sku_descricao: string | null;
+  quantidade: number; cliente_nome: string | null; motivo: string; observacao: string | null;
+}
+
+export default function AdminReposicaoVendaPerdida() {
+  const { user } = useAuth();
+  const qc = useQueryClient();
+  const [busca, setBusca] = useState("");
+  const [produto, setProduto] = useState<ProdutoOpcao | null>(null);
+  const [quantidade, setQuantidade] = useState("");
+  const [cliente, setCliente] = useState("");
+  const [motivo, setMotivo] = useState<string>("sem_estoque");
+  const [observacao, setObservacao] = useState("");
+
+  const buscaAtiva = busca.trim().length >= 2 && !produto;
+  const opcoes = useQuery({
+    queryKey: ["venda-perdida-busca-sku", busca],
+    enabled: buscaAtiva,
+    staleTime: 60_000,
+    queryFn: async (): Promise<ProdutoOpcao[]> => {
+      const termo = busca.trim();
+      const porCodigo = /^\d+$/.test(termo);
+      let q = supabase
+        .from("omie_products")
+        .select("omie_codigo_produto, descricao")
+        .eq("account", EMPRESA.toLowerCase())
+        .eq("ativo", true)
+        .limit(10);
+      q = porCodigo ? q.eq("omie_codigo_produto", Number(termo)) : q.ilike("descricao", `%${termo}%`);
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data ?? []).map((r) => ({ omie_codigo_produto: Number(r.omie_codigo_produto), descricao: r.descricao }));
+    },
+  });
+
+  const registrar = useMutation({
+    mutationFn: async () => {
+      const qtde = Number(quantidade.replace(",", "."));
+      if (!produto) throw new Error("Escolha o produto");
+      if (!Number.isFinite(qtde) || qtde <= 0) throw new Error("Quantidade inválida");
+      const { error } = await supabase.from("venda_perdida_log" as never).insert({
+        empresa: EMPRESA,
+        sku_codigo_omie: String(produto.omie_codigo_produto),
+        sku_descricao: produto.descricao,
+        quantidade: qtde,
+        cliente_nome: cliente.trim() || null,
+        motivo,
+        observacao: observacao.trim() || null,
+        criado_por: user?.id ?? null,
+      } as never);
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      toast.success("Venda perdida registrada");
+      track("reposicao.venda_perdida_registrada", { motivo });
+      setProduto(null); setBusca(""); setQuantidade(""); setCliente(""); setObservacao("");
+      qc.invalidateQueries({ queryKey: ["venda-perdida-recentes"] });
+    },
+    onError: (e: Error) => toast.error("Falha ao registrar: " + e.message),
+  });
+
+  const recentes = useQuery({
+    queryKey: ["venda-perdida-recentes", EMPRESA],
+    staleTime: 30_000,
+    queryFn: async (): Promise<RegistroPerdido[]> => {
+      const { data, error } = await supabase
+        .from("venda_perdida_log" as never)
+        .select("id, criado_em, sku_codigo_omie, sku_descricao, quantidade, cliente_nome, motivo, observacao")
+        .eq("empresa", EMPRESA)
+        .order("criado_em", { ascending: false })
+        .limit(20);
+      if (error) throw error;
+      return (data ?? []) as unknown as RegistroPerdido[];
+    },
+  });
+
+  const rotuloMotivo = useMemo(() => new Map<string, string>(MOTIVOS.map((m) => [m.value, m.label])), []);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4">
+      <header>
+        <h1 className="font-display text-3xl">Venda perdida</h1>
+        <p className="text-sm text-muted-foreground">
+          Cliente pediu e não fechou (faltou, preço, prazo)? Registrar leva segundos e cria a série
+          que hoje não existe — com meses de dado, ela diz quanto a ruptura realmente custa.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">Registrar</CardTitle></CardHeader>
+        <CardContent className="space-y-3">
+          {produto ? (
+            <div className="flex items-center justify-between rounded-md border p-2 text-sm">
+              <span className="truncate">{produto.descricao ?? produto.omie_codigo_produto}</span>
+              <Button variant="ghost" size="sm" onClick={() => { setProduto(null); setBusca(""); }}>trocar</Button>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <Input
+                placeholder="Buscar produto por descrição ou código"
+                value={busca}
+                onChange={(e) => setBusca(e.target.value)}
+              />
+              {buscaAtiva && (
+                <div className="max-h-48 overflow-y-auto rounded-md border text-sm">
+                  {opcoes.isLoading ? (
+                    <div className="p-2 text-muted-foreground">Buscando…</div>
+                  ) : (opcoes.data ?? []).length === 0 ? (
+                    <div className="p-2 text-muted-foreground">Nenhum produto encontrado.</div>
+                  ) : (
+                    (opcoes.data ?? []).map((o) => (
+                      <button
+                        key={o.omie_codigo_produto}
+                        type="button"
+                        className="block w-full truncate px-2 py-1.5 text-left hover:bg-muted"
+                        onClick={() => setProduto(o)}
+                      >
+                        {o.descricao ?? o.omie_codigo_produto}
+                      </button>
+                    ))
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <Input placeholder="Quantidade" inputMode="decimal" value={quantidade} onChange={(e) => setQuantidade(e.target.value)} />
+            <Select value={motivo} onValueChange={setMotivo}>
+              <SelectTrigger><SelectValue placeholder="Motivo" /></SelectTrigger>
+              <SelectContent>
+                {MOTIVOS.map((m) => <SelectItem key={m.value} value={m.value}>{m.label}</SelectItem>)}
+              </SelectContent>
+            </Select>
+            <Input placeholder="Cliente (opcional)" value={cliente} onChange={(e) => setCliente(e.target.value)} />
+          </div>
+          <Input placeholder="Observação (opcional)" value={observacao} onChange={(e) => setObservacao(e.target.value)} />
+          <Button onClick={() => registrar.mutate()} disabled={registrar.isPending || !produto || !quantidade.trim()}>
+            {registrar.isPending ? "Registrando…" : "Registrar venda perdida"}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2"><CardTitle className="text-base">Últimos registros</CardTitle></CardHeader>
+        <CardContent>
+          {recentes.isError ? (
+            <p className="text-sm text-muted-foreground">
+              Não consegui ler os registros — a tabela pode ainda não existir em produção (migration pendente).
+            </p>
+          ) : (recentes.data ?? []).length === 0 ? (
+            <p className="text-sm text-muted-foreground">Nenhum registro ainda.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Quando</TableHead>
+                    <TableHead>Produto</TableHead>
+                    <TableHead className="text-right">Qtde</TableHead>
+                    <TableHead>Motivo</TableHead>
+                    <TableHead>Cliente</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {(recentes.data ?? []).map((r) => (
+                    <TableRow key={r.id}>
+                      <TableCell className="whitespace-nowrap text-xs tnum">{new Date(r.criado_em).toLocaleDateString("pt-BR")}</TableCell>
+                      <TableCell>
+                        <div className="text-sm">{r.sku_descricao ?? r.sku_codigo_omie}</div>
+                      </TableCell>
+                      <TableCell className="text-right tnum">{r.quantidade}</TableCell>
+                      <TableCell className="text-xs">{rotuloMotivo.get(r.motivo) ?? r.motivo}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">{r.cliente_nome ?? "—"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/supabase/migrations/20260802120000_venda_perdida_e_classe_sb.sql
+++ b/supabase/migrations/20260802120000_venda_perdida_e_classe_sb.sql
@@ -1,0 +1,81 @@
+-- Migration: registro de VENDA PERDIDA + classificação Syntetos-Boylan advisory.
+-- ⚠️ NÃO auto-aplica (nome custom) — colar no SQL Editor do Lovable.
+--
+-- (1) venda_perdida_log — a série que NÃO EXISTE hoje e que o challenge do Codex (2026-07-30)
+--     apontou como lacuna P0 da análise de serviço: demanda censurada por indisponibilidade.
+--     Registro MANUAL de staff ("cliente pediu e não tinha"); nenhum consumo automático no motor
+--     (o valor é acumular a série; análises vêm depois, com meses de dado).
+-- (2) v_sku_classe_sb — quadrantes Syntetos-Boylan (ADI × CV² dos tamanhos de venda diários,
+--     cutoffs canônicos 1,32/0,49) sobre a demanda consolidada. ADVISORY: não entra no motor;
+--     medido 2026-07-30: zero SKUs "smooth" — carteira inteira intermitente (160) ou lumpy (73).
+
+-- ── 1) venda_perdida_log ─────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.venda_perdida_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  criado_em timestamptz NOT NULL DEFAULT now(),
+  criado_por uuid,
+  empresa text NOT NULL DEFAULT 'OBEN',
+  sku_codigo_omie text NOT NULL,
+  sku_descricao text,
+  quantidade numeric NOT NULL CHECK (quantidade > 0),
+  cliente_nome text,
+  motivo text NOT NULL DEFAULT 'sem_estoque' CHECK (motivo IN ('sem_estoque', 'preco', 'prazo', 'outro')),
+  observacao text
+);
+COMMENT ON TABLE public.venda_perdida_log IS
+  'Demanda que NAO virou venda (registro manual de staff). Serie de censura p/ analises futuras de servico; sem consumo automatico no motor.';
+CREATE INDEX IF NOT EXISTS idx_venda_perdida_emp_data ON public.venda_perdida_log (empresa, criado_em DESC);
+CREATE INDEX IF NOT EXISTS idx_venda_perdida_sku ON public.venda_perdida_log (empresa, sku_codigo_omie);
+
+ALTER TABLE public.venda_perdida_log ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.venda_perdida_log FROM PUBLIC;
+REVOKE ALL ON public.venda_perdida_log FROM anon;
+REVOKE ALL ON public.venda_perdida_log FROM authenticated;
+GRANT SELECT, INSERT ON public.venda_perdida_log TO authenticated;
+GRANT ALL ON public.venda_perdida_log TO service_role;
+
+DROP POLICY IF EXISTS venda_perdida_sel ON public.venda_perdida_log;
+CREATE POLICY venda_perdida_sel ON public.venda_perdida_log
+  FOR SELECT TO authenticated
+  USING (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+DROP POLICY IF EXISTS venda_perdida_ins ON public.venda_perdida_log;
+CREATE POLICY venda_perdida_ins ON public.venda_perdida_log
+  FOR INSERT TO authenticated
+  WITH CHECK (has_role(auth.uid(), 'master'::app_role) OR has_role(auth.uid(), 'employee'::app_role));
+
+-- ── 2) v_sku_classe_sb (advisory) ────────────────────────────────────────────────────────────
+-- security_invoker=on EXPLÍCITO (e repetido em TODO replace — omitir RESETA e a view passaria a
+-- ler como o OWNER, bypassando a RLS staff de venda_items_history; provado no PG17: com a cadeia
+-- invoker, customer vê 0 linhas). OR REPLACE p/ apply idempotente no SQL Editor.
+CREATE OR REPLACE VIEW public.v_sku_classe_sb
+WITH (security_invoker = on) AS
+WITH vendas AS (
+  SELECT empresa, sku_codigo_omie, data_emissao::date AS dia, SUM(quantidade) AS q
+  FROM public.v_venda_items_history_efetivo
+  WHERE quantidade > 0
+  GROUP BY empresa, sku_codigo_omie, data_emissao::date
+), stats AS (
+  SELECT empresa, sku_codigo_omie,
+         COUNT(*) AS n_dias_venda,
+         (MAX(dia) - MIN(dia))::numeric / NULLIF(COUNT(*) - 1, 0) AS adi,
+         CASE WHEN AVG(q) > 0 THEN power(stddev_samp(q) / AVG(q), 2) END AS cv2
+  FROM vendas
+  GROUP BY empresa, sku_codigo_omie
+  HAVING COUNT(*) >= 3
+)
+SELECT empresa, sku_codigo_omie, n_dias_venda,
+       round(adi, 2) AS adi,
+       round(cv2, 2) AS cv2,
+       CASE
+         WHEN adi < 1.32 AND cv2 < 0.49 THEN 'smooth'
+         WHEN adi >= 1.32 AND cv2 < 0.49 THEN 'intermittent'
+         WHEN adi < 1.32 AND cv2 >= 0.49 THEN 'erratic'
+         ELSE 'lumpy'
+       END AS quadrante
+FROM stats
+WHERE adi IS NOT NULL AND cv2 IS NOT NULL;
+
+COMMENT ON VIEW public.v_sku_classe_sb IS
+  'Quadrantes Syntetos-Boylan (ADI x CV2, cutoffs 1.32/0.49) por SKU — ADVISORY, nao alimenta o motor.';
+GRANT SELECT ON public.v_sku_classe_sb TO authenticated;
+GRANT SELECT ON public.v_sku_classe_sb TO service_role;


### PR DESCRIPTION
## O que entra (itens 3 e 4 do plano de literatura aprovado pelo founder)

**1. Registro de venda perdida** — a série de demanda censurada que NÃO existia (lacuna P0 do challenge Codex na análise de serviço): tabela `venda_perdida_log` + página [/admin/reposicao/venda-perdida] (busca de produto, quantidade, motivo, cliente opcional, últimos 20 registros) + comando global no Cmd-K ("Registrar venda perdida", keywords: faltou/sem estoque/ruptura). **Nenhum consumo automático no motor** — o valor é acumular o dado; com meses de série, "quanto a ruptura custa" vira número.

**2. Classificação Syntetos-Boylan (advisory)** — view `v_sku_classe_sb` (ADI × CV² dos tamanhos diários, cutoffs canônicos 1,32/0,49) + rótulo pt-BR sob a classe ABC/XYZ na tabela de baixo giro. Medido em prod: **zero "smooth" — 160 intermitentes + 73 lumpy**; o quadrante refina o candidato a sob-encomenda. Fail-soft: view ausente → badge some, tela intacta.

## Prova (PG17 + falsificação — `db/test-venda-perdida-rls.sh`)

11/11 asserts: staff INSERT/SELECT ok · customer INSERT negado (42501) e SELECT vê 0 · anon permission denied · view com `security_invoker=on` e **customer vê 0 via herança de RLS** (o stub inicial sem invoker na view-fonte inventou um vazamento; conferido em prod via psql-ro: a cadeia real é invoker até a base — stub corrigido para espelhar a prod) · **falsificação**: policy de INSERT sabotada para `WITH CHECK (true)` → customer insere (assert tem dente) → migration re-aplicada restaura (idempotente, `CREATE OR REPLACE VIEW` com `WITH` repetido).

Gates: typecheck strict · **5.874 testes / 641 arquivos** · lint 0 errors · shellcheck do harness. Knip: nada do diff (baseline de 67 pré-existentes intocado).

## Pós-merge (founder)

1. 🟣 Lovable → SQL Editor → colar `supabase/migrations/20260802120000_venda_perdida_e_classe_sb.sql` → Run. Validação pós-apply (deve voltar `t | 2 | t | ok`):
```sql
SELECT (to_regclass('public.venda_perdida_log') IS NOT NULL),
       (SELECT count(*) FROM pg_policy WHERE polrelid='public.venda_perdida_log'::regclass),
       (SELECT 'security_invoker=on' = ANY(reloptions) FROM pg_class WHERE relname='v_sku_classe_sb'),
       CASE WHEN EXISTS (SELECT 1 FROM public.v_sku_classe_sb LIMIT 1) THEN 'ok' ELSE 'ok' END;
```
2. **Publish** no editor do Lovable (migration ANTES do Publish — a página nova lê a tabela).

Fecha os itens 3+4 do plano; o item 1 (sob-encomenda) já está no ar (#1635). Restam com o founder: validar os grupos multi-litragem (equivalência) e as pautas comerciais (blanket order, SLA Sayerlack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)