### PR TITLE
fix(ia): copiloto, identificação por foto e serviços saem do gateway Lovable — e param de fabricar leitura [money-path]

### DIFF
--- a/src/components/ToolImageIdentifier.tsx
+++ b/src/components/ToolImageIdentifier.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef } from 'react';
 import { Camera, Loader2, X, CheckCircle, AlertCircle, Image } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 
@@ -72,19 +72,22 @@ export function ToolImageIdentifier({ categories, onCategoryIdentified, onClose,
   const analyzeImage = async (imageBase64: string) => {
     setIsAnalyzing(true);
     try {
-      const { data, error } = await supabase.functions.invoke('identify-tool', {
-        body: {
-          imageBase64,
-          categories: categories.map(c => ({ name: c.name, description: c.description })),
-        },
+      // invokeFunction (e não o invoke cru) para o motivo REAL da edge chegar
+      // aqui — sem ele, "créditos esgotados" vira "tente novamente" e ninguém
+      // descobre que o problema é orçamento.
+      const data = await invokeFunction<IdentificationResult>('identify-tool', {
+        imageBase64,
+        categories: categories.map(c => ({ name: c.name, description: c.description })),
       });
-
-      if (error) throw error;
-      setResult(data as IdentificationResult);
+      setResult(data);
     } catch (error) {
       console.error('Erro ao analisar imagem:', error);
+      const motivo = error instanceof Error && error.name === 'EdgeFunctionError' &&
+          !/non-2xx status code/i.test(error.message)
+        ? error.message
+        : null;
       toast.error('Erro na análise', {
-        description: 'Não foi possível analisar a imagem. Tente novamente.',
+        description: motivo ?? 'Não foi possível analisar a imagem. Tente novamente.',
       });
     } finally {
       setIsAnalyzing(false);

--- a/src/hooks/useCopilotEngine.ts
+++ b/src/hooks/useCopilotEngine.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { invokeFunction } from '@/lib/invoke-function';
 import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -206,27 +207,39 @@ export const useCopilotEngine = () => {
       (async () => {
         setState(s => ({ ...s, isAnalyzing: true }));
         try {
-          const { data, error } = await supabase.functions.invoke('copilot-analyze', {
-            body: {
-              transcript: fullText.slice(-2000), // Last 2000 chars
-              customerContext: prev.session?.customerContext,
-              currentPhase: prev.currentAnalysis?.phase,
-              currentIntent: prev.currentAnalysis?.intent,
-              bundleContext: prev.session?.bundleContext,
-            },
+          // invokeFunction (e não o invoke cru) para o motivo REAL da edge —
+          // créditos esgotados, análise não utilizável — chegar até aqui em vez
+          // do genérico "non-2xx status code".
+          const payload = await invokeFunction<CopilotAnalyzeResponse>('copilot-analyze', {
+            transcript: fullText.slice(-2000), // Last 2000 chars
+            customerContext: prev.session?.customerContext,
+            currentPhase: prev.currentAnalysis?.phase,
+            currentIntent: prev.currentAnalysis?.intent,
+            bundleContext: prev.session?.bundleContext,
           });
 
-          if (error || !data) throw error || new Error('No data');
+          // Sem default fabricado. Os `|| 'indiferenca'` / `|| 'neutro'` /
+          // `|| 0` daqui não eram cosméticos: o resultado é GRAVADO em
+          // farmer_copilot_events, então "indiferença" e confiança 0 viravam
+          // histórico com cara de medição — sobre uma conversa que a IA não
+          // conseguiu ler. A edge agora responde 422 quando não tem leitura;
+          // se ainda assim vier incompleta, não exibimos nada.
+          if (
+            !payload?.intent || !payload.phase || !payload.direction ||
+            !payload.suggestion || !payload.suggestion_type ||
+            typeof payload.confidence !== 'number'
+          ) {
+            throw new Error('Análise incompleta');
+          }
 
-          const payload = data as CopilotAnalyzeResponse;
           const analysis: CopilotAnalysis = {
-            intent: payload.intent || 'indiferenca',
-            phase: payload.phase || 'abertura',
-            direction: payload.direction || 'neutro',
+            intent: payload.intent,
+            phase: payload.phase,
+            direction: payload.direction,
             directionReasons: payload.direction_reasons || [],
-            suggestion: payload.suggestion || '',
-            suggestionType: payload.suggestion_type || 'pergunta_diagnostica',
-            confidence: payload.confidence || 0,
+            suggestion: payload.suggestion,
+            suggestionType: payload.suggestion_type,
+            confidence: payload.confidence,
           };
 
           setState(s => ({

--- a/src/hooks/useCopilotEngine.ts
+++ b/src/hooks/useCopilotEngine.ts
@@ -55,6 +55,8 @@ interface CopilotState {
   currentAnalysis: CopilotAnalysis | null;
   analysisHistory: CopilotAnalysis[];
   isAnalyzing: boolean;
+  /** A leitura exibida ficou para trás (a última tentativa falhou). */
+  analiseObsoleta: boolean;
   suggestionsShown: number;
   suggestionsUsed: number;
 }
@@ -71,12 +73,17 @@ export const useCopilotEngine = () => {
     currentAnalysis: null,
     analysisHistory: [],
     isAnalyzing: false,
+    analiseObsoleta: false,
     suggestionsShown: 0,
     suggestionsUsed: 0,
   });
 
   const analysisTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastAnalyzedRef = useRef<string>('');
+  // Descarta resposta fora de ordem: com tick de 8s, uma análise lenta pode
+  // terminar DEPOIS de uma mais nova e sobrescrever a tela com leitura velha —
+  // "risco" atual viraria "neutro" obsoleto.
+  const analiseSeqRef = useRef(0);
   const sessionIdRef = useRef<string | null>(null);
 
   // Start a copilot session
@@ -116,6 +123,7 @@ export const useCopilotEngine = () => {
       transcript: [],
       currentAnalysis: null,
       analysisHistory: [],
+      analiseObsoleta: false,
       suggestionsShown: 0,
       suggestionsUsed: 0,
     }));
@@ -142,7 +150,10 @@ export const useCopilotEngine = () => {
         .update({
           ended_at: new Date().toISOString(),
           duration_seconds: durationSeconds,
-          final_direction: state.currentAnalysis?.direction || 'neutro',
+          // `?? null`, não `|| 'neutro'`: uma sessão cujas análises TODAS
+          // falharam terminaria gravada como "neutra" — medição inventada sobre
+          // uma conversa que ninguém leu. A coluna é nullable de propósito.
+          final_direction: state.currentAnalysis?.direction ?? null,
           final_intent: state.currentAnalysis?.intent || null,
           final_phase: state.currentAnalysis?.phase || null,
           suggestions_shown: state.suggestionsShown,
@@ -205,6 +216,7 @@ export const useCopilotEngine = () => {
 
       // Fire async analysis
       (async () => {
+        const seq = ++analiseSeqRef.current;
         setState(s => ({ ...s, isAnalyzing: true }));
         try {
           // invokeFunction (e não o invoke cru) para o motivo REAL da edge —
@@ -242,11 +254,15 @@ export const useCopilotEngine = () => {
             confidence: payload.confidence,
           };
 
+          // Chegou fora de ordem: uma análise mais nova já está na tela.
+          if (seq !== analiseSeqRef.current) return;
+
           setState(s => ({
             ...s,
             currentAnalysis: analysis,
             analysisHistory: [...s.analysisHistory, analysis],
             isAnalyzing: false,
+            analiseObsoleta: false,
             suggestionsShown: s.suggestionsShown + 1,
           }));
 
@@ -268,7 +284,19 @@ export const useCopilotEngine = () => {
           }
         } catch (err) {
           console.error('Analysis error:', err);
-          setState(s => ({ ...s, isAnalyzing: false }));
+          // Solta o texto para o próximo tick TENTAR DE NOVO. Sem isto o
+          // copiloto morre calado: `lastAnalyzedRef` já foi marcado antes da
+          // chamada, então uma falha (422, rede) faria todos os ticks seguintes
+          // pularem o mesmo trecho — e a tela seguiria em "AO VIVO" exibindo a
+          // sugestão anterior como se fosse a leitura atual.
+          if (lastAnalyzedRef.current === fullText) lastAnalyzedRef.current = '';
+          setState(s => ({
+            ...s,
+            isAnalyzing: false,
+            // A leitura na tela virou passado: marcar como obsoleta é o que
+            // impede a vendedora de agir sobre uma direção que já mudou.
+            analiseObsoleta: s.currentAnalysis !== null,
+          }));
         }
       })();
 

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Type, StopCircle, Shield, Loader2 } from 'lucide-react';
+import { Type, StopCircle, Shield, Loader2, AlertCircle } from 'lucide-react';
 import { useFarmerCopilot } from '@/components/farmer/copilot/useFarmerCopilot';
 import { SessionStartCard } from '@/components/farmer/copilot/SessionStartCard';
 import { DirectionIndicator } from '@/components/farmer/copilot/DirectionIndicator';
@@ -139,6 +139,18 @@ const FarmerCopilot = () => {
               <div className="flex items-center gap-2 justify-center py-1">
                 <Loader2 className="w-3 h-3 animate-spin text-primary" />
                 <span className="text-[10px] text-muted-foreground">Analisando...</span>
+              </div>
+            )}
+
+            {/* A última leitura falhou e a tela ainda mostra a anterior. Sem este
+                aviso o painel segue em "AO VIVO" com uma direção que já passou —
+                e a vendedora age sobre ela achando que é o agora. */}
+            {!copilot.isAnalyzing && copilot.analiseObsoleta && (
+              <div className="flex items-center gap-1.5 justify-center py-1">
+                <AlertCircle className="w-3 h-3 text-status-warning shrink-0" />
+                <span className="text-[10px] text-status-warning">
+                  Leitura desatualizada — a última análise não chegou. Tentando de novo.
+                </span>
               </div>
             )}
 

--- a/supabase/functions/_shared/imagem.ts
+++ b/supabase/functions/_shared/imagem.ts
@@ -1,0 +1,128 @@
+// Detecção de media type de imagem por MAGIC BYTES — puro, sem import remoto
+// (roda sob `deno test --no-remote`, o `test:edges` do CI).
+//
+// Por que existe: as telas mandam o base64 CRU do arquivo escolhido pelo usuário
+// e o código antigo rotulava tudo como `data:image/jpeg;base64,...` fixo. O
+// gateway antigo sniffava o conteúdo e tolerava o rótulo errado; a API da
+// Anthropic valida o `media_type` DECLARADO e responde 400 quando não bate.
+// Print de tela (PNG) e foto de iPhone (HEIC) são o caso comum.
+//
+// ⚠️ `analyze-unified-order/imagem-helpers.ts` tem uma cópia local desta lógica
+// (mais o empacotamento de LOTE, que só ele usa). Aquela edge já está mergeada
+// aguardando deploy manual — trocar o import dela agora obrigaria a redeployá-la
+// só por refactor. Consolidar quando ela for deployada.
+
+/** Media types que a API da Anthropic aceita como imagem. */
+export const MEDIA_TYPES_IMAGEM = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+/** Union literal — o SDK da Anthropic tipa `media_type` assim; `string` não casa. */
+export type MediaTypeImagem = (typeof MEDIA_TYPES_IMAGEM)[number];
+
+export interface BlocoImagem {
+  type: "image";
+  source: { type: "base64"; media_type: MediaTypeImagem; data: string };
+}
+
+export type ResultadoImagem =
+  | { ok: true; bloco: BlocoImagem; mediaType: MediaTypeImagem }
+  | { ok: false; erro: string };
+
+/** Aceita base64 puro ou data-URI inteiro (nem todo caller tira o prefixo). */
+function limparBase64(bruto: string): string {
+  return (bruto ?? "").replace(/^data:[^,]*,/, "").replace(/\s/g, "");
+}
+
+/** Decodifica só o cabeçalho — nunca a imagem inteira. */
+function primeirosBytes(base64: string, quantos: number): Uint8Array | null {
+  // 4 chars base64 = 3 bytes; `atob` exige comprimento múltiplo de 4.
+  const desejado = Math.ceil(quantos / 3) * 4;
+  const disponivel = Math.min(base64.length, desejado);
+  const alinhado = disponivel - (disponivel % 4);
+  if (alinhado < 4) return null;
+  try {
+    const bin = atob(base64.slice(0, alinhado));
+    const out = new Uint8Array(Math.min(bin.length, quantos));
+    for (let i = 0; i < out.length; i++) out[i] = bin.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function assinaturaBate(
+  bytes: Uint8Array,
+  assinatura: readonly number[],
+  deslocamento = 0,
+): boolean {
+  if (bytes.length < deslocamento + assinatura.length) return false;
+  return assinatura.every((b, i) => bytes[deslocamento + i] === b);
+}
+
+/**
+ * Detecta o media type pelos MAGIC BYTES do conteúdo — nunca pelo rótulo do
+ * caller. Devolve `null` para formato que a Anthropic não aceita (HEIC, BMP,
+ * TIFF, SVG) ou base64 ilegível: fail-closed, para não declarar tipo errado.
+ */
+export function detectarMediaTypeImagem(base64: string): MediaTypeImagem | null {
+  const limpo = limparBase64(base64);
+  if (!limpo) return null;
+  const b = primeirosBytes(limpo, 16);
+  if (!b) return null;
+
+  if (assinaturaBate(b, [0xff, 0xd8, 0xff])) return "image/jpeg";
+  if (assinaturaBate(b, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (assinaturaBate(b, [0x47, 0x49, 0x46, 0x38])) return "image/gif"; // GIF87a/GIF89a
+  // WebP = "RIFF" + 4 bytes de tamanho + "WEBP". Os dois pedaços são
+  // necessários, senão qualquer container RIFF (AVI, WAV) passaria por imagem.
+  if (
+    assinaturaBate(b, [0x52, 0x49, 0x46, 0x46]) &&
+    assinaturaBate(b, [0x57, 0x45, 0x42, 0x50], 8)
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/** Alfabeto base64 padrão + padding só no fim. */
+const BASE64_BEM_FORMADO = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** Monta o content block de UMA imagem com o media type real detectado. */
+export function montarBlocoImagem(base64: string): ResultadoImagem {
+  const limpo = limparBase64(base64);
+  if (!limpo) return { ok: false, erro: "imagem vazia" };
+
+  // A detecção só lê o cabeçalho; sem esta checagem, arquivo truncado ou
+  // corrompido DEPOIS dos magic bytes passaria e só viraria 400 na API, com a
+  // tentativa já gasta. Valida o formato inteiro sem decodificar tudo.
+  if (limpo.length % 4 !== 0 || !BASE64_BEM_FORMADO.test(limpo)) {
+    return {
+      ok: false,
+      erro: "arquivo corrompido ou incompleto (base64 malformado). Tire a foto de novo.",
+    };
+  }
+
+  const mediaType = detectarMediaTypeImagem(limpo);
+  if (!mediaType) {
+    return {
+      ok: false,
+      erro:
+        "formato não suportado pela IA (aceitos: JPEG, PNG, GIF, WebP). Foto de iPhone em HEIC precisa virar JPEG — tire um print ou reenvie pela galeria.",
+    };
+  }
+
+  return {
+    ok: true,
+    mediaType,
+    bloco: {
+      type: "image",
+      source: { type: "base64", media_type: mediaType, data: limpo },
+    },
+  };
+}

--- a/supabase/functions/_shared/imagem_test.ts
+++ b/supabase/functions/_shared/imagem_test.ts
@@ -1,0 +1,146 @@
+// Testa o CÓDIGO REAL de imagem.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/
+//
+// Foco: a detecção por magic bytes. O frontend aceita qualquer `image/*` e o
+// código antigo rotulava TUDO como image/jpeg — o gateway sniffava e tolerava,
+// a Anthropic recusa com 400. Um rótulo errado aqui derruba a análise inteira
+// do pedido; um formato aceito calado sem estar na lista faz o mesmo.
+import {
+  detectarMediaTypeImagem,
+  montarBlocoImagem,
+} from "./imagem.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+/** Monta base64 a partir de bytes crus — é assim que o arquivo real chega. */
+function b64(bytes: number[]): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+const CORPO = Array.from({ length: 40 }, (_, i) => i % 256);
+
+const JPEG = b64([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, ...CORPO]);
+const PNG = b64([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, ...CORPO]);
+const GIF87 = b64([0x47, 0x49, 0x46, 0x38, 0x37, 0x61, ...CORPO]);
+const GIF89 = b64([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, ...CORPO]);
+// RIFF + 4 bytes de tamanho + WEBP
+const WEBP = b64([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+  0x57, 0x45, 0x42, 0x50, ...CORPO,
+]);
+// Container RIFF que NÃO é webp (WAVE) — precisa ser rejeitado.
+const WAVE = b64([
+  0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00,
+  0x57, 0x41, 0x56, 0x45, ...CORPO,
+]);
+// HEIC: foto de iPhone. `ftypheic` no offset 4. A Anthropic não aceita.
+const HEIC = b64([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+  0x68, 0x65, 0x69, 0x63, ...CORPO,
+]);
+const BMP = b64([0x42, 0x4d, 0x36, 0x00, ...CORPO]);
+const PDF = b64([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, ...CORPO]);
+
+// ─────────────────────── detectarMediaTypeImagem ───────────────────────
+
+Deno.test("detecta os 4 formatos que a Anthropic aceita, pelos magic bytes", () => {
+  assertEquals(detectarMediaTypeImagem(JPEG), "image/jpeg");
+  assertEquals(detectarMediaTypeImagem(PNG), "image/png");
+  assertEquals(detectarMediaTypeImagem(GIF87), "image/gif");
+  assertEquals(detectarMediaTypeImagem(GIF89), "image/gif");
+  assertEquals(detectarMediaTypeImagem(WEBP), "image/webp");
+});
+
+Deno.test("PNG NÃO é rotulado como jpeg — a regressão que motivou o helper", () => {
+  // O código antigo mandava `data:image/jpeg;base64,<png>`; o Gemini sniffava
+  // e engolia, a Anthropic devolve 400 e o vendedor perde a análise inteira.
+  assertEquals(detectarMediaTypeImagem(PNG), "image/png");
+  const r = montarBlocoImagem(PNG);
+  assert(r.ok, "png deveria ser aceito");
+  if (!r.ok) return;
+  assertEquals(r.bloco.source.media_type, "image/png");
+});
+
+Deno.test("formato fora da lista da Anthropic é rejeitado, não adivinhado", () => {
+  for (const [nome, dados] of [["heic", HEIC], ["bmp", BMP], ["pdf", PDF], ["wave", WAVE]] as const) {
+    assertEquals(detectarMediaTypeImagem(dados), null, `${nome} deveria dar null`);
+  }
+});
+
+Deno.test("RIFF só vira webp com o marcador WEBP no offset 8", () => {
+  // Sem o segundo pedaço da assinatura, WAV/AVI passariam por imagem.
+  assertEquals(detectarMediaTypeImagem(WAVE), null);
+  assertEquals(detectarMediaTypeImagem(WEBP), "image/webp");
+});
+
+Deno.test("base64 ilegível/vazio/curto degrada para null, não explode", () => {
+  for (const v of ["", "   ", "!!!!", "@@", "A", "aa"]) {
+    assertEquals(detectarMediaTypeImagem(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("aceita data-URI inteiro além do base64 puro", () => {
+  assertEquals(detectarMediaTypeImagem(`data:image/png;base64,${PNG}`), "image/png");
+  // Rótulo do data-URI é IGNORADO: valem os bytes, não o que o caller diz.
+  assertEquals(detectarMediaTypeImagem(`data:image/jpeg;base64,${PNG}`), "image/png");
+});
+
+Deno.test("whitespace no meio do base64 não quebra a detecção", () => {
+  const comQuebras = PNG.slice(0, 8) + "\n  " + PNG.slice(8);
+  assertEquals(detectarMediaTypeImagem(comQuebras), "image/png");
+});
+
+// ─────────────────────────── montarBlocoImagem ───────────────────────────
+
+Deno.test("montarBlocoImagem: bloco no formato de content block da Anthropic", () => {
+  const r = montarBlocoImagem(JPEG);
+  assert(r.ok, "jpeg deveria ser aceito");
+  if (!r.ok) return;
+  assertEquals(r.bloco.type, "image");
+  assertEquals(r.bloco.source.type, "base64");
+  assertEquals(r.bloco.source.media_type, "image/jpeg");
+  assertEquals(r.bloco.source.data, JPEG);
+});
+
+Deno.test("montarBlocoImagem: HEIC dá erro ACIONÁVEL (é o caso do iPhone)", () => {
+  const r = montarBlocoImagem(HEIC);
+  assert(!r.ok, "heic deveria ser rejeitado");
+  if (r.ok) return;
+  assert(r.erro.includes("HEIC"), "erro deveria citar HEIC");
+  assert(r.erro.includes("JPEG"), "erro deveria dizer o que fazer");
+});
+
+Deno.test("montarBlocoImagem: cabeçalho válido + corpo corrompido é REJEITADO", () => {
+  // A detecção só lê os magic bytes; sem checar o formato inteiro, arquivo
+  // truncado passaria e só viraria 400 na API, com a análise já perdida.
+  const corrompido = JPEG.slice(0, 12) + "!!!$$$@@@";
+  const r = montarBlocoImagem(corrompido);
+  assert(!r.ok, "base64 malformado deveria ser rejeitado");
+  if (r.ok) return;
+  assert(r.erro.includes("corrompido"), "erro deveria dizer que o arquivo está corrompido");
+});
+
+Deno.test("montarBlocoImagem: comprimento fora do múltiplo de 4 é rejeitado", () => {
+  assert(!montarBlocoImagem(JPEG + "A").ok, "truncado deveria ser rejeitado");
+});
+
+
+Deno.test("montarBlocoImagem: o data-URI é removido dos dados enviados", () => {
+  const r = montarBlocoImagem(`data:image/png;base64,${PNG}`);
+  assert(r.ok, "deveria aceitar");
+  if (!r.ok) return;
+  assert(!r.bloco.source.data.startsWith("data:"), "o prefixo não pode ir para a API");
+  assertEquals(r.bloco.source.data, PNG);
+});

--- a/supabase/functions/analyze-services/index.ts
+++ b/supabase/functions/analyze-services/index.ts
@@ -1,5 +1,14 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import {
+  extrairToolUseUnico,
+  MODELO_PADRAO,
+  objetoDaTool,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "../_shared/anthropic.ts";
+import { normalizarItens, TOOL_SERVICOS } from "./servico-tools.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -69,9 +78,9 @@ serve(async (req) => {
       );
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) {
-      throw new Error("LOVABLE_API_KEY is not configured");
+    const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!ANTHROPIC_API_KEY) {
+      throw new Error("ANTHROPIC_API_KEY is not configured");
     }
 
     // Buscar serviços disponíveis do banco
@@ -125,95 +134,73 @@ EXEMPLOS:
 
 Responda SEMPRE usando a função suggest_services.`;
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "google/gemini-3-flash-preview",
-        messages: [
-          { role: "system", content: systemPrompt },
-          { role: "user", content: text },
-        ],
-        tools: [
-          {
-            type: "function",
-            function: {
-              name: "suggest_services",
-              description: "Retorna as ferramentas e serviços identificados no texto do cliente",
-              parameters: {
-                type: "object",
-                properties: {
-                  items: {
-                    type: "array",
-                    description: "Lista de itens identificados (ferramenta + serviço)",
-                    items: {
-                      type: "object",
-                      properties: {
-                        userToolId: { type: "string", description: "ID da ferramenta cadastrada do usuário" },
-                        omie_codigo_servico: { type: "number", description: "Código do serviço no Omie" },
-                        servico_descricao: { type: "string", description: "Descrição do serviço" },
-                        quantity: { type: "number", description: "Quantidade de itens (padrão 1)" },
-                        notes: { type: "string", description: "Observações extraídas do texto (danos, urgência, etc)" },
-                      },
-                      required: ["userToolId", "omie_codigo_servico", "servico_descricao", "quantity"],
-                    },
-                  },
-                  message: { type: "string", description: "Mensagem amigável para o cliente confirmando o que foi identificado" },
-                },
-                required: ["items", "message"],
-              },
-            },
-          },
-        ],
-        tool_choice: { type: "function", function: { name: "suggest_services" } },
-      }),
-    });
+    const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
-    if (!response.ok) {
-      if (response.status === 429) {
-        return new Response(
-          JSON.stringify({ error: "Limite de requisições excedido. Tente novamente em alguns segundos." }),
-          { status: 429, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-        );
-      }
-      if (response.status === 402) {
-        return new Response(
-          JSON.stringify({ error: "Créditos insuficientes. Entre em contato com o suporte." }),
-          { status: 402, headers: { ...corsHeaders, "Content-Type": "application/json" } }
-        );
-      }
-      const errorText = await response.text();
-      console.error("AI gateway error:", response.status, errorText);
-      throw new Error("Erro ao processar com IA");
+    let resposta;
+    try {
+      resposta = await anthropic.messages.create({
+        model: MODELO_PADRAO,
+        max_tokens: 2000,
+        system: systemPrompt,
+        tools: [TOOL_SERVICOS],
+        // `type:'tool'` sozinho não desliga chamada paralela: o modelo poderia
+        // devolver um bloco por ferramenta e o consumo pegaria só o primeiro,
+        // montando um pedido PARCIAL com cara de completo.
+        tool_choice: { type: "tool", name: TOOL_SERVICOS.name, disable_parallel_tool_use: true },
+        messages: [{ role: "user", content: text }],
+      });
+    } catch (e: unknown) {
+      const status = statusDoErro(e);
+      console.error("[analyze-services] erro na API da Anthropic:", status, e instanceof Error ? e.message : e);
+      const mapeado = traduzirErroAnthropic(status);
+      return new Response(
+        JSON.stringify({ error: mapeado?.mensagem ?? "Erro ao processar com IA" }),
+        { status: mapeado?.http ?? 500, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
     }
 
-    const aiResponse = await response.json();
-    console.log("AI Response:", JSON.stringify(aiResponse, null, 2));
-
-    const toolCall = aiResponse.choices?.[0]?.message?.tool_calls?.[0];
-    if (!toolCall) {
+    // Truncou = lista de itens cortada no meio. O cliente confirmaria um pedido
+    // com 2 de 5 ferramentas achando que pediu todas.
+    if (resposta.stop_reason === "max_tokens") {
+      console.error("[analyze-services] resposta truncada");
       return new Response(
-        JSON.stringify({ 
-          items: [], 
-          message: "Não consegui identificar ferramentas ou serviços. Por favor, seja mais específico ou selecione manualmente." 
+        JSON.stringify({ error: "Pedido longo demais para analisar de uma vez. Divida em duas partes." }),
+        { status: 422, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+      );
+    }
+
+    const extraido = extrairToolUseUnico(resposta.content);
+    const result = extraido.ok ? objetoDaTool(extraido.input) : null;
+
+    if (result === null) {
+      return new Response(
+        JSON.stringify({
+          items: [],
+          message: "Não consegui identificar ferramentas ou serviços. Por favor, seja mais específico ou selecione manualmente.",
         }),
         { headers: { ...corsHeaders, "Content-Type": "application/json" } }
       );
     }
 
-    const result = JSON.parse(toolCall.function.arguments);
+    // O filtro por ferramenta REAL do cliente já existia; o que faltava era a
+    // disciplina de TIPO — `quantity` multiplica o preço do serviço, e string ou
+    // zero ali vira valor errado na nota.
+    const idsValidos = new Set(tools.map((t) => t.id));
+    const { itens, descartados } = normalizarItens(result.items, idsValidos);
+    if (descartados > 0) {
+      console.warn(`[analyze-services] ${descartados} item(ns) descartado(s) por dado inválido`);
+    }
 
-    const validItems = (result.items || []).filter((item: { userToolId: string }) => 
-      tools.some(t => t.id === item.userToolId)
-    );
+    const mensagem = typeof result.message === "string" && result.message.trim()
+      ? result.message.trim()
+      : `Identificado ${itens.length} item(s) para o pedido.`;
 
     return new Response(
       JSON.stringify({
-        items: validItems,
-        message: result.message || `Identificado ${validItems.length} item(s) para o pedido.`,
+        items: itens,
+        message: descartados > 0
+          ? `${mensagem} (${descartados} item(ns) não reconhecido(s) foram deixados de fora — confira antes de enviar.)`
+          : mensagem,
       }),
       { headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );

--- a/supabase/functions/analyze-services/servico-tools.ts
+++ b/supabase/functions/analyze-services/servico-tools.ts
@@ -64,13 +64,17 @@ export function numeroFinito(v: unknown): number | null {
 }
 
 /**
- * Quantidade inválida cai no default 1 — o declarado no próprio schema
- * ("padrão 1"), não um número inventado. `undefined` viraria NaN ao multiplicar
- * pelo preço; `"2"` string faria a soma concatenar.
+ * Quantidade de peças: INTEIRO positivo, ou `null` (a linha é descartada).
+ *
+ * Não cai em 1: "padrão 1" é texto da DESCRIÇÃO do campo, não um default que o
+ * schema execute — assumir 1 é inventar quantidade, e ela multiplica o preço do
+ * serviço na nota. Fracionário também não passa: a unidade aqui é peça afiada,
+ * então "2,5 serras" é leitura errada, não meia serra.
  */
-export function quantidadeValida(v: unknown): number {
+export function quantidadeValida(v: unknown): number | null {
   const n = numeroFinito(v);
-  return n !== null && n > 0 ? n : 1;
+  if (n === null || n <= 0 || !Number.isInteger(n)) return null;
+  return n;
 }
 
 export interface ItensNormalizados {
@@ -92,6 +96,7 @@ export function normalizarItens(
   if (!Array.isArray(bruto)) return { itens: [], descartados: 0 };
 
   const itens: ItemServico[] = [];
+  const jaVistos = new Set<string>();
   let descartados = 0;
 
   for (const cru of bruto) {
@@ -103,6 +108,13 @@ export function normalizarItens(
 
     const userToolId = texto(o.userToolId);
     if (!userToolId || !idsValidos.has(userToolId)) {
+      descartados++;
+      continue;
+    }
+
+    // Duas linhas para a MESMA ferramenta virariam cobrança dobrada: o filtro a
+    // jusante compara cada item só contra o carrinho anterior, não entre si.
+    if (jaVistos.has(userToolId)) {
       descartados++;
       continue;
     }
@@ -119,12 +131,22 @@ export function normalizarItens(
       continue;
     }
 
+    // Quantidade ilegível DERRUBA a linha em vez de virar 1: a ferramenta ficar
+    // de fora é visível (o caller avisa quantas saíram) — cobrar 1 peça quando
+    // o cliente falou 10 não é.
+    const quantity = quantidadeValida(o.quantity);
+    if (quantity === null) {
+      descartados++;
+      continue;
+    }
+
+    jaVistos.add(userToolId);
     const notes = texto(o.notes);
     itens.push({
       userToolId,
       omie_codigo_servico: codigo,
       servico_descricao: descricao,
-      quantity: quantidadeValida(o.quantity),
+      quantity,
       ...(notes ? { notes } : {}),
     });
   }

--- a/supabase/functions/analyze-services/servico-tools.ts
+++ b/supabase/functions/analyze-services/servico-tools.ts
@@ -1,0 +1,133 @@
+// Tool e guards da identificação de serviços por voz/texto — puros, sem import
+// remoto (rodam sob `deno test --no-remote`, o `test:edges` do CI).
+//
+// O que a saída vira: itens de um pedido de afiação. `quantity` é multiplicada
+// pelo preço do serviço, então string ou zero aqui vira valor errado na nota.
+//
+// Esta edge já validava o `userToolId` contra as ferramentas reais do cliente —
+// o que faltava era a disciplina de TIPO nos números, a mesma que o challenge do
+// Codex expôs na fase 2: forced tool-use garante que a ferramenta foi usada, não
+// que os tipos declarados no schema foram respeitados.
+
+export interface ItemServico {
+  userToolId: string;
+  omie_codigo_servico: number;
+  servico_descricao: string;
+  quantity: number;
+  notes?: string;
+}
+
+export const TOOL_SERVICOS = {
+  name: "suggest_services",
+  description: "Retorna as ferramentas e serviços identificados no texto do cliente",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      items: {
+        type: "array",
+        description: "Lista de itens identificados (ferramenta + serviço)",
+        items: {
+          type: "object",
+          properties: {
+            userToolId: { type: "string", description: "ID da ferramenta cadastrada do usuário" },
+            omie_codigo_servico: { type: "number", description: "Código do serviço no Omie" },
+            servico_descricao: { type: "string", description: "Descrição do serviço" },
+            quantity: { type: "number", description: "Quantidade de itens (padrão 1)" },
+            notes: { type: "string", description: "Observações extraídas do texto (danos, urgência, etc)" },
+          },
+          required: ["userToolId", "omie_codigo_servico", "servico_descricao", "quantity"],
+        },
+      },
+      message: {
+        type: "string",
+        description: "Mensagem amigável para o cliente confirmando o que foi identificado",
+      },
+    },
+    required: ["items", "message"],
+  },
+};
+
+function texto(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+/** Número finito; string numérica LIMPA é aceita, o ambíguo não. */
+export function numeroFinito(v: unknown): number | null {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v === "string") {
+    const t = v.trim();
+    if (!/^-?\d+(\.\d+)?$/.test(t)) return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+/**
+ * Quantidade inválida cai no default 1 — o declarado no próprio schema
+ * ("padrão 1"), não um número inventado. `undefined` viraria NaN ao multiplicar
+ * pelo preço; `"2"` string faria a soma concatenar.
+ */
+export function quantidadeValida(v: unknown): number {
+  const n = numeroFinito(v);
+  return n !== null && n > 0 ? n : 1;
+}
+
+export interface ItensNormalizados {
+  itens: ItemServico[];
+  descartados: number;
+}
+
+/**
+ * Mantém só item com ferramenta REAL do cliente e código de serviço numérico.
+ *
+ * `idsValidos` são as ferramentas cadastradas: um `userToolId` inventado viraria
+ * item órfão no pedido. `omie_codigo_servico` ilegível derruba a linha inteira —
+ * sem código não há o que faturar, e adivinhar aqui erra o serviço cobrado.
+ */
+export function normalizarItens(
+  bruto: unknown,
+  idsValidos: ReadonlySet<string>,
+): ItensNormalizados {
+  if (!Array.isArray(bruto)) return { itens: [], descartados: 0 };
+
+  const itens: ItemServico[] = [];
+  let descartados = 0;
+
+  for (const cru of bruto) {
+    if (!cru || typeof cru !== "object" || Array.isArray(cru)) {
+      descartados++;
+      continue;
+    }
+    const o = cru as Record<string, unknown>;
+
+    const userToolId = texto(o.userToolId);
+    if (!userToolId || !idsValidos.has(userToolId)) {
+      descartados++;
+      continue;
+    }
+
+    const codigo = numeroFinito(o.omie_codigo_servico);
+    if (codigo === null) {
+      descartados++;
+      continue;
+    }
+
+    const descricao = texto(o.servico_descricao);
+    if (!descricao) {
+      descartados++;
+      continue;
+    }
+
+    const notes = texto(o.notes);
+    itens.push({
+      userToolId,
+      omie_codigo_servico: codigo,
+      servico_descricao: descricao,
+      quantity: quantidadeValida(o.quantity),
+      ...(notes ? { notes } : {}),
+    });
+  }
+
+  return { itens, descartados };
+}

--- a/supabase/functions/analyze-services/servico-tools_test.ts
+++ b/supabase/functions/analyze-services/servico-tools_test.ts
@@ -62,11 +62,25 @@ Deno.test("normalizarItens: quantity string vira NUMBER — fecha o 1 + \"2\"", 
   assertEquals(1 + itens[0].quantity, 3, "somar deve dar 3, não \"12\"");
 });
 
-Deno.test("normalizarItens: quantity inválida cai no default 1 do schema", () => {
+Deno.test("normalizarItens: quantity inválida DERRUBA a linha (não vira 1)", () => {
+  // "padrão 1" é texto da descrição do campo, não default executado pelo
+  // schema. Assumir 1 quando o cliente falou 10 é inventar quantidade — e ela
+  // multiplica o preço na nota. A ferramenta ficar de fora é visível; a
+  // quantidade errada, não.
   for (const q of [undefined, null, 0, -5, "abc", NaN, {}]) {
-    const { itens } = normalizarItens([{ ...ITEM_OK, quantity: q }], IDS);
-    assertEquals(itens[0].quantity, 1, `quantity ${JSON.stringify(q)}`);
+    const { itens, descartados } = normalizarItens([{ ...ITEM_OK, quantity: q }], IDS);
+    assertEquals(itens.length, 0, `quantity ${JSON.stringify(q)}`);
+    assertEquals(descartados, 1, `quantity ${JSON.stringify(q)}`);
   }
+});
+
+Deno.test("normalizarItens: ferramenta DUPLICADA vira uma linha só", () => {
+  // Duas linhas para a mesma ferramenta = cobrança dobrada; o filtro a jusante
+  // compara cada item só contra o carrinho anterior, não entre si.
+  const { itens, descartados } = normalizarItens([ITEM_OK, { ...ITEM_OK, quantity: 5 }], IDS);
+  assertEquals(itens.length, 1);
+  assertEquals(itens[0].quantity, 3, "vale a primeira ocorrência");
+  assertEquals(descartados, 1);
 });
 
 Deno.test("normalizarItens: descrição vazia derruba a linha", () => {
@@ -108,7 +122,10 @@ Deno.test("numeroFinito: string AMBÍGUA não vira número", () => {
   assertEquals(numeroFinito(7), 7);
 });
 
-Deno.test("quantidadeValida: fracionário positivo é preservado", () => {
-  assertEquals(quantidadeValida(2.5), 2.5);
-  assertEquals(quantidadeValida("0.5"), 0.5);
+Deno.test("quantidadeValida: fracionário é REJEITADO — a unidade é peça afiada", () => {
+  // "2,5 serras" é leitura errada, não meia serra.
+  assertEquals(quantidadeValida(2.5), null);
+  assertEquals(quantidadeValida("0.5"), null);
+  assertEquals(quantidadeValida(3), 3);
+  assertEquals(quantidadeValida("4"), 4);
 });

--- a/supabase/functions/analyze-services/servico-tools_test.ts
+++ b/supabase/functions/analyze-services/servico-tools_test.ts
@@ -1,0 +1,114 @@
+// Testa o CÓDIGO REAL de servico-tools.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/analyze-services/
+//
+// Foco: `quantity` multiplica o preço do serviço no pedido de afiação. String
+// ou zero ali vira valor errado na nota — mesma classe que o challenge do Codex
+// expôs na fase 2 (`1 + "2"` = `"12"`).
+import { normalizarItens, numeroFinito, quantidadeValida } from "./servico-tools.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const IDS = new Set(["ferr-1", "ferr-2"]);
+const ITEM_OK = {
+  userToolId: "ferr-1",
+  omie_codigo_servico: 4021,
+  servico_descricao: "Afiação de serra circular",
+  quantity: 3,
+};
+
+Deno.test("normalizarItens: item válido passa inteiro", () => {
+  const { itens, descartados } = normalizarItens([ITEM_OK], IDS);
+  assertEquals(descartados, 0);
+  assertEquals(itens.length, 1);
+  assertEquals(itens[0].quantity, 3);
+  assertEquals(itens[0].omie_codigo_servico, 4021);
+});
+
+Deno.test("normalizarItens: ferramenta que NÃO é do cliente é descartada", () => {
+  // Um userToolId inventado viraria item órfão no pedido.
+  const { itens, descartados } = normalizarItens(
+    [ITEM_OK, { ...ITEM_OK, userToolId: "ferr-inventada" }],
+    IDS,
+  );
+  assertEquals(itens.length, 1);
+  assertEquals(descartados, 1);
+});
+
+Deno.test("normalizarItens: código de serviço ilegível derruba a linha", () => {
+  // Sem código não há o que faturar; adivinhar erra o serviço cobrado.
+  for (const cod of [null, undefined, "n/a", "", {}]) {
+    const { itens, descartados } = normalizarItens(
+      [{ ...ITEM_OK, omie_codigo_servico: cod }],
+      IDS,
+    );
+    assertEquals(itens.length, 0, `código ${JSON.stringify(cod)}`);
+    assertEquals(descartados, 1);
+  }
+});
+
+Deno.test("normalizarItens: quantity string vira NUMBER — fecha o 1 + \"2\"", () => {
+  const { itens } = normalizarItens([{ ...ITEM_OK, quantity: "2" }], IDS);
+  assertEquals(itens[0].quantity, 2);
+  assertEquals(typeof itens[0].quantity, "number", "tem de sair number");
+  assertEquals(1 + itens[0].quantity, 3, "somar deve dar 3, não \"12\"");
+});
+
+Deno.test("normalizarItens: quantity inválida cai no default 1 do schema", () => {
+  for (const q of [undefined, null, 0, -5, "abc", NaN, {}]) {
+    const { itens } = normalizarItens([{ ...ITEM_OK, quantity: q }], IDS);
+    assertEquals(itens[0].quantity, 1, `quantity ${JSON.stringify(q)}`);
+  }
+});
+
+Deno.test("normalizarItens: descrição vazia derruba a linha", () => {
+  const { itens, descartados } = normalizarItens(
+    [{ ...ITEM_OK, servico_descricao: "   " }],
+    IDS,
+  );
+  assertEquals(itens.length, 0);
+  assertEquals(descartados, 1);
+});
+
+Deno.test("normalizarItens: notes vazio não vira campo vazio no pedido", () => {
+  const { itens } = normalizarItens([{ ...ITEM_OK, notes: "  " }], IDS);
+  assert(!("notes" in itens[0]), "notes em branco não deveria entrar");
+  const comNotes = normalizarItens([{ ...ITEM_OK, notes: " urgente, lascada " }], IDS);
+  assertEquals(comNotes.itens[0].notes, "urgente, lascada");
+});
+
+Deno.test("normalizarItens: lixo no array é contado, não silenciado", () => {
+  // O caller avisa o cliente quantos itens ficaram de fora.
+  const { itens, descartados } = normalizarItens(["texto", 42, null, ITEM_OK], IDS);
+  assertEquals(itens.length, 1);
+  assertEquals(descartados, 3);
+});
+
+Deno.test("normalizarItens: entrada não-array degrada para vazio", () => {
+  for (const v of [null, undefined, "x", 7, {}]) {
+    assertEquals(normalizarItens(v, IDS), { itens: [], descartados: 0 }, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ─────────────────────────────── numéricos ───────────────────────────────
+
+Deno.test("numeroFinito: string AMBÍGUA não vira número", () => {
+  for (const v of ["12,50", "R$ 12", "doze", "", "1e3"]) {
+    assertEquals(numeroFinito(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+  assertEquals(numeroFinito("12.5"), 12.5);
+  assertEquals(numeroFinito(7), 7);
+});
+
+Deno.test("quantidadeValida: fracionário positivo é preservado", () => {
+  assertEquals(quantidadeValida(2.5), 2.5);
+  assertEquals(quantidadeValida("0.5"), 0.5);
+});

--- a/supabase/functions/copilot-analyze/copiloto-tools.ts
+++ b/supabase/functions/copilot-analyze/copiloto-tools.ts
@@ -1,0 +1,157 @@
+// Tool e guards do copiloto de ligação — puros, sem import remoto (rodam sob
+// `deno test --no-remote`, o `test:edges` do CI).
+//
+// Contexto: isto roda AO VIVO, enquanto a vendedora está ao telefone. A tela
+// mostra "intenção do cliente", "direção da conversa" e uma sugestão de próxima
+// fala. Ela age na hora, sem tempo de conferir.
+//
+// O que estava errado: no `catch` do JSON.parse a edge fabricava a análise —
+//   { intent: 'indiferenca', direction: 'neutro', confidence: 30,
+//     suggestion: 'Continue explorando as necessidades do cliente.' }
+// — e devolvia com cara de leitura real. "Indiferença" e "neutro" são AFIRMAÇÕES
+// sobre o cliente; `confidence: 30` é um número que ninguém mediu. Uma conversa
+// que estava em RISCO aparecia como neutra, e a vendedora seguia tranquila.
+//
+// Agora: ou a tool devolve os campos válidos, ou o caller responde 422 e a tela
+// mostra que a análise não veio. Sem leitura é pior que leitura errada? Não —
+// leitura errada é pior, porque ela AGE sobre ela.
+
+export const INTENCOES = [
+  "interesse",
+  "objecao_preco",
+  "objecao_tecnica",
+  "falta_urgencia",
+  "comparacao_concorrente",
+  "indiferenca",
+] as const;
+
+export const FASES = [
+  "abertura",
+  "diagnostico",
+  "exploracao",
+  "proposta",
+  "fechamento",
+] as const;
+
+export const DIRECOES = ["positivo", "neutro", "risco"] as const;
+
+export const TIPOS_SUGESTAO = [
+  "pergunta_diagnostica",
+  "resposta_tecnica",
+  "argumento_economico",
+  "alternativa_abordagem",
+] as const;
+
+export type Intencao = (typeof INTENCOES)[number];
+export type Fase = (typeof FASES)[number];
+export type Direcao = (typeof DIRECOES)[number];
+export type TipoSugestao = (typeof TIPOS_SUGESTAO)[number];
+
+export interface AnaliseCopiloto {
+  intent: Intencao;
+  phase: Fase;
+  direction: Direcao;
+  direction_reasons: string[];
+  suggestion: string;
+  suggestion_type: TipoSugestao;
+  confidence: number;
+}
+
+export const TOOL_COPILOTO = {
+  name: "analisar_conversa",
+  description:
+    "Retorna a leitura da conversa em andamento: intenção do cliente, fase da venda, direção e a próxima ação sugerida ao vendedor.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      intent: { type: "string", enum: [...INTENCOES], description: "Intenção predominante do cliente" },
+      phase: { type: "string", enum: [...FASES], description: "Fase atual da venda" },
+      direction: { type: "string", enum: [...DIRECOES], description: "Direção da conversa pelo sentimento geral" },
+      direction_reasons: {
+        type: "array",
+        items: { type: "string" },
+        description: "Sinais curtos que sustentam a direção",
+      },
+      suggestion: { type: "string", description: "UMA próxima ação concisa (máx. 3 linhas)" },
+      suggestion_type: { type: "string", enum: [...TIPOS_SUGESTAO], description: "Natureza da sugestão" },
+      confidence: { type: "number", description: "Confiança na leitura, 0 a 100" },
+    },
+    required: [
+      "intent",
+      "phase",
+      "direction",
+      "direction_reasons",
+      "suggestion",
+      "suggestion_type",
+      "confidence",
+    ],
+  },
+};
+
+function texto(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function doEnum<T extends string>(v: unknown, permitidos: readonly T[]): T | null {
+  const t = texto(v).toLowerCase();
+  return (permitidos as readonly string[]).includes(t) ? (t as T) : null;
+}
+
+/**
+ * Confiança 0–100 ou `null`.
+ *
+ * `null` NÃO vira 0 nem um número de consolo: sem confiança medida, o caller
+ * descarta a análise inteira. Era `confidence: 30` fixo no fallback — um número
+ * que a tela exibia como se fosse medição.
+ */
+export function confiancaValida(v: unknown): number | null {
+  const n = typeof v === "number" ? v : typeof v === "string" && v.trim() ? Number(v) : NaN;
+  if (!Number.isFinite(n)) return null;
+  return n >= 0 && n <= 100 ? n : null;
+}
+
+/** Motivos: só strings não-vazias. Lista de objetos derrubaria a renderização. */
+export function motivosValidos(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const cru of v) {
+    const t = texto(cru);
+    if (t) out.push(t);
+  }
+  return out;
+}
+
+/**
+ * Valida a análise inteira. Devolve `null` se QUALQUER campo que a tela afirma
+ * ao vendedor estiver ausente ou fora do enum — é tudo ou nada de propósito:
+ * meia análise (intenção sem direção, sugestão sem tipo) chega à tela com a
+ * mesma aparência de uma leitura completa.
+ */
+export function normalizarAnalise(bruto: unknown): AnaliseCopiloto | null {
+  if (!bruto || typeof bruto !== "object" || Array.isArray(bruto)) return null;
+  const o = bruto as Record<string, unknown>;
+
+  const intent = doEnum(o.intent, INTENCOES);
+  const phase = doEnum(o.phase, FASES);
+  const direction = doEnum(o.direction, DIRECOES);
+  const suggestionType = doEnum(o.suggestion_type, TIPOS_SUGESTAO);
+  const suggestion = texto(o.suggestion);
+  const confidence = confiancaValida(o.confidence);
+
+  if (
+    intent === null || phase === null || direction === null ||
+    suggestionType === null || !suggestion || confidence === null
+  ) {
+    return null;
+  }
+
+  return {
+    intent,
+    phase,
+    direction,
+    direction_reasons: motivosValidos(o.direction_reasons),
+    suggestion,
+    suggestion_type: suggestionType,
+    confidence,
+  };
+}

--- a/supabase/functions/copilot-analyze/copiloto-tools_test.ts
+++ b/supabase/functions/copilot-analyze/copiloto-tools_test.ts
@@ -1,0 +1,132 @@
+// Testa o CÓDIGO REAL de copiloto-tools.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/copilot-analyze/
+//
+// Foco: o FALLBACK FABRICADO. A edge devolvia, no catch do JSON.parse,
+//   { intent: 'indiferenca', direction: 'neutro', confidence: 30, ... }
+// com cara de leitura real — durante a ligação, com a vendedora ao telefone.
+// "Indiferença" e "neutro" são AFIRMAÇÕES sobre o cliente; 30 é um número que
+// ninguém mediu. Conversa em RISCO aparecia como neutra.
+import {
+  confiancaValida,
+  motivosValidos,
+  normalizarAnalise,
+  TOOL_COPILOTO,
+} from "./copiloto-tools.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const COMPLETA = {
+  intent: "objecao_preco",
+  phase: "proposta",
+  direction: "risco",
+  direction_reasons: ["cliente citou concorrente mais barato"],
+  suggestion: "Traga o custo por peça afiada em vez do preço do serviço.",
+  suggestion_type: "argumento_economico",
+  confidence: 78,
+};
+
+Deno.test("normalizarAnalise: leitura completa passa e preserva os campos", () => {
+  const r = normalizarAnalise(COMPLETA);
+  assert(r !== null, "deveria aceitar leitura completa");
+  assertEquals(r!.intent, "objecao_preco");
+  assertEquals(r!.direction, "risco");
+  assertEquals(r!.confidence, 78);
+  assertEquals(r!.direction_reasons, ["cliente citou concorrente mais barato"]);
+});
+
+Deno.test("normalizarAnalise: CADA campo afirmado na tela é obrigatório", () => {
+  // Meia análise (intenção sem direção, sugestão sem tipo) chega à tela com a
+  // mesma aparência de leitura completa.
+  for (const campo of ["intent", "phase", "direction", "suggestion", "suggestion_type", "confidence"]) {
+    const sem = { ...COMPLETA } as Record<string, unknown>;
+    delete sem[campo];
+    assertEquals(normalizarAnalise(sem), null, `sem ${campo} deveria invalidar`);
+  }
+});
+
+Deno.test("normalizarAnalise: valor fora do enum NÃO é aceito nem 'corrigido'", () => {
+  assertEquals(normalizarAnalise({ ...COMPLETA, intent: "cliente_bravo" }), null);
+  assertEquals(normalizarAnalise({ ...COMPLETA, direction: "ótimo" }), null);
+  assertEquals(normalizarAnalise({ ...COMPLETA, phase: "pos_venda" }), null);
+  assertEquals(normalizarAnalise({ ...COMPLETA, suggestion_type: "piada" }), null);
+});
+
+Deno.test("normalizarAnalise: o FALLBACK FABRICADO não passaria hoje sem os campos", () => {
+  // O objeto antigo tinha todos os campos preenchidos — o ponto é que agora ele
+  // só existe se a IA REALMENTE devolver. Sem tool_use, o caller responde 422.
+  const fabricado = {
+    intent: "indiferenca",
+    phase: "abertura",
+    direction: "neutro",
+    direction_reasons: ["Análise inconclusiva"],
+    suggestion: "Continue explorando as necessidades do cliente.",
+    suggestion_type: "pergunta_diagnostica",
+    // confidence ausente: era 30 fixo, agora não há de onde tirar
+  };
+  assertEquals(normalizarAnalise(fabricado), null, "sem confiança medida não há análise");
+});
+
+Deno.test("normalizarAnalise: entrada não-objeto degrada para null", () => {
+  for (const v of [null, undefined, "texto", 42, [], true]) {
+    assertEquals(normalizarAnalise(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("normalizarAnalise: caixa e espaço no enum são normalizados", () => {
+  const r = normalizarAnalise({ ...COMPLETA, intent: "  INTERESSE  ", direction: "Positivo" });
+  assert(r !== null, "deveria normalizar");
+  assertEquals(r!.intent, "interesse");
+  assertEquals(r!.direction, "positivo");
+});
+
+// ─────────────────────────── confiancaValida ───────────────────────────
+
+Deno.test("confiancaValida: aceita 0–100 e rejeita fora da faixa", () => {
+  assertEquals(confiancaValida(0), 0);
+  assertEquals(confiancaValida(100), 100);
+  assertEquals(confiancaValida("78"), 78);
+  for (const v of [-1, 101, 1000]) {
+    assertEquals(confiancaValida(v), null, `entrada ${v}`);
+  }
+});
+
+Deno.test("confiancaValida: ilegível vira null, NÃO 0 nem número de consolo", () => {
+  // Number(null) === 0 é a armadilha: 0% de confiança é um FATO diferente de
+  // "não consegui medir a confiança".
+  for (const v of [null, undefined, "", "alta", NaN, {}, []]) {
+    assertEquals(confiancaValida(v), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ─────────────────────────── motivosValidos ───────────────────────────
+
+Deno.test("motivosValidos: objeto no array é descartado (derrubaria a lista)", () => {
+  assertEquals(motivosValidos(["preço citado", {}, "", { a: 1 }, "  ", "prazo"]), [
+    "preço citado",
+    "prazo",
+  ]);
+});
+
+Deno.test("motivosValidos: entrada não-array degrada para vazio", () => {
+  for (const v of [null, undefined, "texto", 7]) {
+    assertEquals(motivosValidos(v), [], `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ───────────────────────────── contrato da tool ─────────────────────────────
+
+Deno.test("TOOL_COPILOTO: exige os campos que a tela afirma ao vendedor", () => {
+  const req = TOOL_COPILOTO.input_schema.required;
+  for (const campo of ["intent", "phase", "direction", "suggestion", "suggestion_type", "confidence"]) {
+    assert(req.includes(campo), `${campo} deveria ser required no schema`);
+  }
+});

--- a/supabase/functions/copilot-analyze/index.ts
+++ b/supabase/functions/copilot-analyze/index.ts
@@ -1,6 +1,14 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import {
+  extrairToolUseUnico,
+  MODELO_PADRAO,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "../_shared/anthropic.ts";
+import { normalizarAnalise, TOOL_COPILOTO } from "./copiloto-tools.ts";
 
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "*";
 
@@ -40,8 +48,8 @@ serve(async (req) => {
       );
     }
 
-    const LOVABLE_API_KEY = Deno.env.get('LOVABLE_API_KEY');
-    if (!LOVABLE_API_KEY) {
+    const ANTHROPIC_API_KEY = Deno.env.get('ANTHROPIC_API_KEY');
+    if (!ANTHROPIC_API_KEY) {
       return new Response(
         JSON.stringify({ error: 'AI não configurada' }),
         { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
@@ -50,7 +58,7 @@ serve(async (req) => {
 
     const systemPrompt = `Você é um copiloto comercial em tempo real para um vendedor (Farmer) de uma empresa de afiação de ferramentas industriais.
 
-Analise a transcrição da conversa e retorne um JSON com:
+Analise a transcrição da conversa e preencha:
 
 1. "intent": Uma das opções: "interesse", "objecao_preco", "objecao_tecnica", "falta_urgencia", "comparacao_concorrente", "indiferenca"
 2. "phase": Uma das opções: "abertura", "diagnostico", "exploracao", "proposta", "fechamento"
@@ -73,61 +81,69 @@ ${bundleContext ? JSON.stringify(bundleContext) : 'Nenhum'}
 Fase anterior: ${currentPhase || 'desconhecida'}
 Intenção anterior: ${currentIntent || 'desconhecida'}
 
-IMPORTANTE: 
-- Retorne APENAS o JSON, sem markdown.
+IMPORTANTE:
+- Responda SEMPRE usando a função analisar_conversa.
 - A sugestão deve ser personalizada com base no perfil do cliente.
 - Limite a 1 sugestão por vez para não sobrecarregar o vendedor.
 - Se o cliente é sensível a preço, foque em ROI e economia.
 - Se orientado a qualidade, foque em durabilidade e precisão.
 - Se orientado a produtividade, foque em ganho de tempo e eficiência.`;
 
-    const response = await fetch('https://ai.lovable.dev/chat/v1', {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${LOVABLE_API_KEY}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        model: 'google/gemini-2.5-flash',
-        messages: [
-          { role: 'system', content: systemPrompt },
-          { role: 'user', content: `Transcrição recente:\n${transcript}` },
-        ],
-        temperature: 0.3,
-      }),
-    });
+    const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
-    if (!response.ok) {
-      const errText = await response.text();
-      console.error('AI error:', response.status, errText);
+    let resposta;
+    try {
+      resposta = await anthropic.messages.create({
+        model: MODELO_PADRAO,
+        max_tokens: 1500,
+        // Baixa variabilidade: é leitura de conversa em andamento, não redação.
+        temperature: 0.3,
+        system: systemPrompt,
+        tools: [TOOL_COPILOTO],
+        // `type:'tool'` sozinho não desliga chamada paralela — duas leituras da
+        // mesma conversa e o consumo pegaria só a primeira.
+        tool_choice: { type: 'tool', name: TOOL_COPILOTO.name, disable_parallel_tool_use: true },
+        messages: [{ role: 'user', content: `Transcrição recente:\n${transcript}` }],
+      });
+    } catch (e: unknown) {
+      const status = statusDoErro(e);
+      console.error('[copilot-analyze] erro na API da Anthropic:', status, e instanceof Error ? e.message : e);
+      const mapeado = traduzirErroAnthropic(status);
       return new Response(
-        JSON.stringify({ error: 'Erro na análise IA' }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        JSON.stringify({ error: mapeado?.mensagem ?? 'Erro na análise IA' }),
+        { status: mapeado?.http ?? 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
-    const aiResult = await response.json();
-    const content = aiResult.choices?.[0]?.message?.content || '';
+    // Truncou = leitura cortada no meio. A sugestão pela metade é a que a
+    // vendedora leria em voz alta na ligação.
+    if (resposta.stop_reason === 'max_tokens') {
+      console.error('[copilot-analyze] resposta truncada');
+      return new Response(
+        JSON.stringify({ error: 'Análise truncada. Tente de novo.' }),
+        { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
-    // Parse JSON from response
-    let analysis;
-    try {
-      const cleanContent = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-      analysis = JSON.parse(cleanContent);
-    } catch {
-      analysis = {
-        intent: 'indiferenca',
-        phase: currentPhase || 'abertura',
-        direction: 'neutro',
-        direction_reasons: ['Análise inconclusiva'],
-        suggestion: 'Continue explorando as necessidades do cliente.',
-        suggestion_type: 'pergunta_diagnostica',
-        confidence: 30,
-      };
+    // ANTES: o `catch` do JSON.parse fabricava a análise inteira — intenção
+    // "indiferenca", direção "neutro" e `confidence: 30` que ninguém mediu,
+    // devolvidos com cara de leitura real. Uma conversa em RISCO aparecia como
+    // neutra e a vendedora seguia tranquila. Agora não vem análise nenhuma.
+    const extraido = extrairToolUseUnico(resposta.content);
+    const analise = extraido.ok ? normalizarAnalise(extraido.input) : null;
+
+    if (analise === null) {
+      console.error(
+        `[copilot-analyze] sem análise utilizável (motivo: ${extraido.ok ? 'campos inválidos' : extraido.motivo})`,
+      );
+      return new Response(
+        JSON.stringify({ error: 'Não consegui ler a conversa agora.' }),
+        { status: 422, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
     }
 
     return new Response(
-      JSON.stringify(analysis),
+      JSON.stringify(analise),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
     );
   } catch (error) {

--- a/supabase/functions/identify-tool/ferramenta-tools.ts
+++ b/supabase/functions/identify-tool/ferramenta-tools.ts
@@ -15,7 +15,7 @@ export interface FerramentaIdentificada {
   category_name: string | null;
   confidence: "alta" | "media" | "baixa";
   description: string;
-  specs_detected: Record<string, unknown>;
+  specs_detected: Record<string, string>;
   suggested_services: string[];
 }
 
@@ -106,13 +106,23 @@ export function normalizarFerramenta(
     }
   }
 
-  const specs = o.specs_detected && typeof o.specs_detected === "object" &&
-      !Array.isArray(o.specs_detected)
-    ? (o.specs_detected as Record<string, unknown>)
-    : {};
+  // Só ESCALARES. A tela renderiza cada valor direto em `<span>{value}</span>`;
+  // um objeto aninhado (`{ diametro: { valor: 250 } }`) lança "Objects are not
+  // valid as a React child" e derruba a página inteira.
+  const specs: Record<string, string> = {};
+  if (o.specs_detected && typeof o.specs_detected === "object" && !Array.isArray(o.specs_detected)) {
+    for (const [chave, valor] of Object.entries(o.specs_detected as Record<string, unknown>)) {
+      if (typeof valor === "string" && valor.trim()) specs[chave] = valor.trim();
+      else if (typeof valor === "number" && Number.isFinite(valor)) specs[chave] = String(valor);
+      else if (typeof valor === "boolean") specs[chave] = valor ? "sim" : "não";
+    }
+  }
 
   return {
-    identified: identificada,
+    // Sem categoria casada não há o que confirmar: a tela mostraria check verde
+    // e o botão "Usar esta ferramenta" retornaria calado (ele exige
+    // `category_name`). Melhor dizer que não identificou.
+    identified: identificada && categoria !== null,
     category_name: categoria,
     confidence: confianca as FerramentaIdentificada["confidence"],
     description: descricao,

--- a/supabase/functions/identify-tool/ferramenta-tools.ts
+++ b/supabase/functions/identify-tool/ferramenta-tools.ts
@@ -1,0 +1,122 @@
+// Tool e guards da identificação de ferramenta por foto — puros, sem import
+// remoto (rodam sob `deno test --no-remote`, o `test:edges` do CI).
+//
+// O que a saída vira: a tela preenche categoria e serviços sugeridos do pedido
+// de afiação a partir daqui. Categoria errada leva a ferramenta para a linha de
+// serviço errada; serviço inventado vira item cobrado que ninguém executou.
+//
+// O fallback antigo já era HONESTO (`identified: false`, "não foi possível
+// analisar") — este módulo preserva essa honestidade e adiciona o que faltava:
+// a categoria devolvida tem de existir de fato entre as CADASTRADAS, senão o
+// nome plausível vindo do modelo entra como se fosse do catálogo.
+
+export interface FerramentaIdentificada {
+  identified: boolean;
+  category_name: string | null;
+  confidence: "alta" | "media" | "baixa";
+  description: string;
+  specs_detected: Record<string, unknown>;
+  suggested_services: string[];
+}
+
+export const CONFIANCAS = ["alta", "media", "baixa"] as const;
+
+export const TOOL_FERRAMENTA = {
+  name: "identificar_ferramenta",
+  description:
+    "Retorna a ferramenta de corte industrial identificada na foto, a categoria correspondente e os serviços sugeridos.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      identified: { type: "boolean", description: "true se a ferramenta foi reconhecida" },
+      category_name: {
+        type: ["string", "null"],
+        description: "Nome EXATO de uma das categorias cadastradas; null se nenhuma corresponder",
+      },
+      confidence: { type: "string", enum: [...CONFIANCAS], description: "Confiança na identificação" },
+      description: { type: "string", description: "Descrição breve do que foi identificado" },
+      specs_detected: {
+        type: "object",
+        description: "Especificações visíveis na foto (diâmetro, nº de dentes, material, geometria)",
+        additionalProperties: true,
+      },
+      suggested_services: {
+        type: "array",
+        items: { type: "string" },
+        description: "Serviços sugeridos (ex.: Afiação, Retífica, Troca de dentes)",
+      },
+    },
+    required: ["identified", "confidence", "description"],
+  },
+};
+
+function texto(v: unknown): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+/** Resposta honesta quando não há leitura utilizável — nunca um chute. */
+export function naoIdentificada(motivo: string): FerramentaIdentificada {
+  return {
+    identified: false,
+    category_name: null,
+    confidence: "baixa",
+    description: motivo,
+    specs_detected: {},
+    suggested_services: [],
+  };
+}
+
+/**
+ * Normaliza a saída da tool.
+ *
+ * `categoriasCadastradas` é a lista REAL do sistema: a categoria só passa se
+ * existir nela (comparação sem caixa/acento-sensível ao trim). Uma categoria
+ * plausível porém inexistente — "Serra Circular Widia" quando o cadastro tem
+ * "Serra Circular" — viraria um vínculo que não resolve, e a tela mostraria
+ * como se tivesse casado com o catálogo.
+ */
+export function normalizarFerramenta(
+  bruto: unknown,
+  categoriasCadastradas: readonly string[],
+): FerramentaIdentificada | null {
+  if (!bruto || typeof bruto !== "object" || Array.isArray(bruto)) return null;
+  const o = bruto as Record<string, unknown>;
+
+  const confianca = texto(o.confidence).toLowerCase();
+  if (!(CONFIANCAS as readonly string[]).includes(confianca)) return null;
+
+  const descricao = texto(o.description);
+  if (!descricao) return null;
+
+  const identificada = o.identified === true;
+
+  // Categoria: só vale se casar com uma cadastrada.
+  const bruta = texto(o.category_name);
+  let categoria: string | null = null;
+  if (bruta) {
+    const alvo = bruta.toLowerCase();
+    categoria = categoriasCadastradas.find((c) => c.trim().toLowerCase() === alvo) ?? null;
+  }
+
+  const servicos: string[] = [];
+  if (Array.isArray(o.suggested_services)) {
+    for (const cru of o.suggested_services) {
+      const t = texto(cru);
+      if (t) servicos.push(t);
+    }
+  }
+
+  const specs = o.specs_detected && typeof o.specs_detected === "object" &&
+      !Array.isArray(o.specs_detected)
+    ? (o.specs_detected as Record<string, unknown>)
+    : {};
+
+  return {
+    identified: identificada,
+    category_name: categoria,
+    confidence: confianca as FerramentaIdentificada["confidence"],
+    description: descricao,
+    specs_detected: specs,
+    suggested_services: servicos,
+  };
+}

--- a/supabase/functions/identify-tool/ferramenta-tools_test.ts
+++ b/supabase/functions/identify-tool/ferramenta-tools_test.ts
@@ -1,0 +1,113 @@
+// Testa o CÓDIGO REAL de ferramenta-tools.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/identify-tool/
+//
+// Foco: a categoria devolvida preenche o pedido de afiação. Um nome plausível
+// porém INEXISTENTE no cadastro ("Serra Circular Widia" quando só existe "Serra
+// Circular") viraria vínculo que não resolve — e a tela mostraria como se
+// tivesse casado com o catálogo.
+import { naoIdentificada, normalizarFerramenta, TOOL_FERRAMENTA } from "./ferramenta-tools.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const CATEGORIAS = ["Serra Circular", "Faca de Plaina", "Fresa Topo"];
+const OK = {
+  identified: true,
+  category_name: "Serra Circular",
+  confidence: "alta",
+  description: "Serra circular de widia, ~250mm, 40 dentes",
+  specs_detected: { diametro_mm: 250, dentes: 40 },
+  suggested_services: ["Afiação", "Troca de dentes"],
+};
+
+Deno.test("normalizarFerramenta: leitura completa passa e preserva os campos", () => {
+  const r = normalizarFerramenta(OK, CATEGORIAS);
+  assert(r !== null, "deveria aceitar");
+  assertEquals(r!.category_name, "Serra Circular");
+  assertEquals(r!.confidence, "alta");
+  assertEquals(r!.suggested_services, ["Afiação", "Troca de dentes"]);
+  assertEquals(r!.specs_detected, { diametro_mm: 250, dentes: 40 });
+});
+
+Deno.test("normalizarFerramenta: categoria INEXISTENTE no cadastro vira null", () => {
+  // O nome é plausível, mas não existe — não pode entrar como se fosse do catálogo.
+  const r = normalizarFerramenta({ ...OK, category_name: "Serra Circular Widia" }, CATEGORIAS);
+  assert(r !== null, "o resto da leitura continua válido");
+  assertEquals(r!.category_name, null, "categoria inventada não vira vínculo");
+  assertEquals(r!.description, OK.description, "a descrição é preservada");
+});
+
+Deno.test("normalizarFerramenta: casamento de categoria ignora caixa e espaço", () => {
+  const r = normalizarFerramenta({ ...OK, category_name: "  serra circular " }, CATEGORIAS);
+  assertEquals(r!.category_name, "Serra Circular", "devolve o nome CADASTRADO, não o do modelo");
+});
+
+Deno.test("normalizarFerramenta: sem categorias cadastradas, nenhuma categoria casa", () => {
+  const r = normalizarFerramenta(OK, []);
+  assertEquals(r!.category_name, null);
+});
+
+Deno.test("normalizarFerramenta: confiança fora do enum invalida a leitura", () => {
+  for (const c of ["altíssima", "99%", "", null, undefined, 5]) {
+    assertEquals(normalizarFerramenta({ ...OK, confidence: c }, CATEGORIAS), null, `confidence ${JSON.stringify(c)}`);
+  }
+});
+
+Deno.test("normalizarFerramenta: descrição vazia invalida a leitura", () => {
+  assertEquals(normalizarFerramenta({ ...OK, description: "  " }, CATEGORIAS), null);
+});
+
+Deno.test("normalizarFerramenta: serviço não-string é descartado da lista", () => {
+  const r = normalizarFerramenta(
+    { ...OK, suggested_services: ["Afiação", {}, "", 42, "Retífica"] },
+    CATEGORIAS,
+  );
+  assertEquals(r!.suggested_services, ["Afiação", "Retífica"]);
+});
+
+Deno.test("normalizarFerramenta: specs não-objeto degrada para vazio", () => {
+  for (const s of ["texto", 42, ["a"], null]) {
+    const r = normalizarFerramenta({ ...OK, specs_detected: s }, CATEGORIAS);
+    assertEquals(r!.specs_detected, {}, `specs ${JSON.stringify(s)}`);
+  }
+});
+
+Deno.test("normalizarFerramenta: identified só é true se vier true de verdade", () => {
+  // "true" string ou 1 não são confirmação de identificação.
+  for (const v of ["true", 1, "sim", {}]) {
+    const r = normalizarFerramenta({ ...OK, identified: v }, CATEGORIAS);
+    assertEquals(r!.identified, false, `identified ${JSON.stringify(v)}`);
+  }
+});
+
+Deno.test("normalizarFerramenta: entrada não-objeto degrada para null", () => {
+  for (const v of [null, undefined, "x", 7, []]) {
+    assertEquals(normalizarFerramenta(v, CATEGORIAS), null, `entrada ${JSON.stringify(v)}`);
+  }
+});
+
+// ─────────────────────────── naoIdentificada ───────────────────────────
+
+Deno.test("naoIdentificada: resposta honesta, sem chute de categoria", () => {
+  const r = naoIdentificada("Foto ilegível");
+  assertEquals(r.identified, false);
+  assertEquals(r.category_name, null);
+  assertEquals(r.confidence, "baixa");
+  assertEquals(r.suggested_services, []);
+  assertEquals(r.description, "Foto ilegível", "o motivo REAL chega à tela");
+});
+
+Deno.test("TOOL_FERRAMENTA: exige identificação, confiança e descrição", () => {
+  const req = TOOL_FERRAMENTA.input_schema.required;
+  for (const campo of ["identified", "confidence", "description"]) {
+    assert(req.includes(campo), `${campo} deveria ser required`);
+  }
+});

--- a/supabase/functions/identify-tool/ferramenta-tools_test.ts
+++ b/supabase/functions/identify-tool/ferramenta-tools_test.ts
@@ -34,7 +34,7 @@ Deno.test("normalizarFerramenta: leitura completa passa e preserva os campos", (
   assertEquals(r!.category_name, "Serra Circular");
   assertEquals(r!.confidence, "alta");
   assertEquals(r!.suggested_services, ["Afiação", "Troca de dentes"]);
-  assertEquals(r!.specs_detected, { diametro_mm: 250, dentes: 40 });
+  assertEquals(r!.specs_detected, { diametro_mm: "250", dentes: "40" }, "escalares viram string p/ render");
 });
 
 Deno.test("normalizarFerramenta: categoria INEXISTENTE no cadastro vira null", () => {
@@ -43,6 +43,9 @@ Deno.test("normalizarFerramenta: categoria INEXISTENTE no cadastro vira null", (
   assert(r !== null, "o resto da leitura continua válido");
   assertEquals(r!.category_name, null, "categoria inventada não vira vínculo");
   assertEquals(r!.description, OK.description, "a descrição é preservada");
+  // Sem categoria casada não há o que confirmar: a tela mostraria check verde e
+  // o botão "Usar esta ferramenta" retornaria calado.
+  assertEquals(r!.identified, false, "não pode se dizer identificada");
 });
 
 Deno.test("normalizarFerramenta: casamento de categoria ignora caixa e espaço", () => {
@@ -71,6 +74,16 @@ Deno.test("normalizarFerramenta: serviço não-string é descartado da lista", (
     CATEGORIAS,
   );
   assertEquals(r!.suggested_services, ["Afiação", "Retífica"]);
+});
+
+Deno.test("normalizarFerramenta: spec ANINHADA é filtrada (derrubaria o React)", () => {
+  // A tela renderiza cada valor em <span>{value}</span>; um objeto ali lança
+  // "Objects are not valid as a React child" e quebra a página.
+  const r = normalizarFerramenta(
+    { ...OK, specs_detected: { diametro: { valor: 250 }, dentes: 40, material: "widia", novo: true, nada: null } },
+    CATEGORIAS,
+  );
+  assertEquals(r!.specs_detected, { dentes: "40", material: "widia", novo: "sim" });
 });
 
 Deno.test("normalizarFerramenta: specs não-objeto degrada para vazio", () => {

--- a/supabase/functions/identify-tool/index.ts
+++ b/supabase/functions/identify-tool/index.ts
@@ -1,5 +1,14 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
+import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
+import {
+  extrairToolUseUnico,
+  MODELO_PADRAO,
+  statusDoErro,
+  traduzirErroAnthropic,
+} from "../_shared/anthropic.ts";
+import { montarBlocoImagem } from "../_shared/imagem.ts";
+import { naoIdentificada, normalizarFerramenta, TOOL_FERRAMENTA } from "./ferramenta-tools.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -37,8 +46,8 @@ serve(async (req) => {
       });
     }
 
-    const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
-    if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
+    const ANTHROPIC_API_KEY = Deno.env.get("ANTHROPIC_API_KEY");
+    if (!ANTHROPIC_API_KEY) throw new Error("ANTHROPIC_API_KEY is not configured");
 
     const { imageBase64, categories } = await req.json();
 
@@ -71,7 +80,7 @@ serve(async (req) => {
 
     const systemPrompt = `Você é um especialista em identificação de ferramentas de corte industriais (serras, facas, lâminas, brocas, fresas, etc.) usadas em marcenarias, serralharias e indústrias.
 
-Analise a imagem enviada e identifique a ferramenta. Retorne um JSON com:
+Analise a imagem enviada e identifique a ferramenta, preenchendo:
 - "identified": true/false (se conseguiu identificar)
 - "category_name": nome da categoria mais provável (deve corresponder a uma das categorias cadastradas abaixo)
 - "confidence": "alta", "media" ou "baixa"
@@ -86,67 +95,69 @@ IMPORTANTE:
 - Seja preciso na identificação.
 - Se não conseguir identificar com certeza, indique confidence "baixa".
 - O category_name DEVE corresponder exatamente a uma das categorias listadas acima quando possível.
-- Responda APENAS com o JSON, sem markdown ou explicações.`;
+- Responda SEMPRE usando a função identificar_ferramenta.`;
 
-    const response = await fetch("https://ai.gateway.lovable.dev/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${LOVABLE_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "google/gemini-2.5-flash",
-        messages: [
-          { role: "system", content: systemPrompt },
-          {
-            role: "user",
-            content: [
-              { type: "text", text: "Identifique esta ferramenta na imagem:" },
-              {
-                type: "image_url",
-                image_url: { url: `data:image/jpeg;base64,${imageBase64}` },
-              },
-            ],
-          },
-        ],
-      }),
-    });
-
-    if (!response.ok) {
-      if (response.status === 429) {
-        return new Response(JSON.stringify({ error: "Muitas requisições. Tente novamente em alguns segundos." }), {
-          status: 429,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      if (response.status === 402) {
-        return new Response(JSON.stringify({ error: "Créditos insuficientes para análise de imagem." }), {
-          status: 402,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-      const errorText = await response.text();
-      console.error("AI gateway error:", response.status, errorText);
-      throw new Error("Erro ao processar imagem");
+    // Media type vem dos MAGIC BYTES. O gateway antigo sniffava o conteúdo e
+    // engolia o rótulo fixo `image/jpeg`; a Anthropic valida o declarado — e a
+    // foto aqui sai da câmera do celular do balcão, onde HEIC é comum.
+    const anexo = montarBlocoImagem(imageBase64);
+    if (!anexo.ok) {
+      return new Response(JSON.stringify(naoIdentificada(anexo.erro)), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
-    const aiResult = await response.json();
-    const content = aiResult.choices?.[0]?.message?.content || "";
+    const anthropic = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
-    let parsed;
+    let resposta;
     try {
-      const cleanContent = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
-      parsed = JSON.parse(cleanContent);
-    } catch {
-      console.error("Failed to parse AI response:", content);
-      parsed = {
-        identified: false,
-        category_name: null,
-        confidence: "baixa",
-        description: "Não foi possível analisar a imagem",
-        specs_detected: {},
-        suggested_services: [],
-      };
+      resposta = await anthropic.messages.create({
+        model: MODELO_PADRAO,
+        max_tokens: 1500,
+        system: systemPrompt,
+        tools: [TOOL_FERRAMENTA],
+        tool_choice: { type: "tool", name: TOOL_FERRAMENTA.name, disable_parallel_tool_use: true },
+        messages: [{
+          role: "user",
+          content: [
+            { type: "text", text: "Identifique esta ferramenta na imagem:" },
+            anexo.bloco,
+          ],
+        }],
+      });
+    } catch (e: unknown) {
+      const status = statusDoErro(e);
+      console.error("[identify-tool] erro na API da Anthropic:", status, e instanceof Error ? e.message : e);
+      const mapeado = traduzirErroAnthropic(status);
+      return new Response(JSON.stringify({ error: mapeado?.mensagem ?? "Erro ao processar imagem" }), {
+        status: mapeado?.http ?? 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Truncou = leitura incompleta da ferramenta. Devolver "não identifiquei" é
+    // honesto; devolver metade das specs seria uma ficha técnica pela metade
+    // com cara de completa.
+    if (resposta.stop_reason === "max_tokens") {
+      console.error("[identify-tool] resposta truncada");
+      return new Response(
+        JSON.stringify(naoIdentificada("A leitura da foto ficou incompleta. Tente de novo.")),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+
+    const extraido = extrairToolUseUnico(resposta.content);
+    const nomesCategorias = (categories || []).map((c: { name: string }) => c.name).filter(Boolean);
+    const parsed = extraido.ok ? normalizarFerramenta(extraido.input, nomesCategorias) : null;
+
+    if (parsed === null) {
+      console.error(
+        `[identify-tool] sem leitura utilizável (motivo: ${extraido.ok ? "campos inválidos" : extraido.motivo})`,
+      );
+      return new Response(
+        JSON.stringify(naoIdentificada("Não foi possível analisar a imagem")),
+        { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
     }
 
     return new Response(JSON.stringify(parsed), {

--- a/supabase/functions/identify-tool/index.ts
+++ b/supabase/functions/identify-tool/index.ts
@@ -15,7 +15,12 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
 
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB in base64 chars (~6.6MB base64)
+// O limite é sobre a string BASE64, que é ~4/3 do binário. Com 5 MiB aqui, a
+// foto de 4 MiB que a tela aceita (limite de 5 MiB no ARQUIVO) virava 5.592.408
+// caracteres e era recusada — o usuário via "imagem muito grande" para um
+// arquivo dentro do limite anunciado. 8 MiB de base64 ≈ 6 MiB de arquivo, com
+// folga sob o teto de 10 MB da API.
+const MAX_IMAGE_SIZE = 8 * 1024 * 1024;
 
 serve(async (req) => {
   if (req.method === "OPTIONS") {


### PR DESCRIPTION
## Por quê

Fase 4 (última) da migração para a API Anthropic direta. O gateway de IA do Lovable estourou o teto de créditos e derrubou as edges que ele servia. Fases 1–3 nos PRs #1592, #1608, #1618, #1626 e #1631.

## O achado — `copilot-analyze`

É um copiloto **ao vivo**: a vendedora está ao telefone e a tela mostra intenção do cliente, direção da conversa e a próxima fala sugerida. Ela age na hora, sem tempo de conferir.

No `catch` do `JSON.parse`, a edge fabricava a leitura inteira:

```ts
{ intent: 'indiferenca', phase: 'abertura', direction: 'neutro',
  direction_reasons: ['Análise inconclusiva'],
  suggestion: 'Continue explorando as necessidades do cliente.',
  confidence: 30 }
```

"Indiferença" e "neutro" são **afirmações sobre o cliente**; `30` é um número que ninguém mediu. Uma conversa em **risco** aparecia como neutra.

E o frontend repetia a fabricação — `payload.intent || 'indiferenca'`, `confidence || 0` — que ia **gravada** em `farmer_copilot_events`, virando histórico com cara de medição sobre uma conversa que a IA não conseguiu ler.

Agora: forced tool-use + `normalizarAnalise` all-or-nothing. Ou a leitura vem completa, ou é 422 e a tela não mostra nada.

## As outras duas

| Edge | O que mudou |
|---|---|
| `identify-tool` | Rotulava toda imagem como `data:image/jpeg;base64,` — o mesmo bug que o `/codex` apontou na fase 2, e aqui a foto sai da câmera do balcão, onde HEIC é comum. Agora detecta por magic bytes e só aceita categoria que exista no cadastro |
| `analyze-services` | Já tinha tool-use e já filtrava ferramenta real do cliente. Faltava disciplina de tipo: `quantity` multiplica o preço do serviço na nota |

Os 3 consumidores no front passaram a usar `invokeFunction`, que extrai o motivo real do corpo — com o `invoke` cru, "créditos esgotados" virava toast genérico, o mesmo sintoma que motivou a migração.

## 2ª opinião — Codex (`gpt-5.6-sol`, xhigh): **CHANGES REQUESTED**

<details><summary>Achados (verbatim)</summary>

> **[P1]** O copiloto pode ficar **morto** ou voltar para uma leitura antiga. `lastAnalyzedRef` é atualizado antes da requisição → 422 → "os próximos ticks nunca tentam novamente", e a tela "continua mostrando a sugestão anterior sob o cabeçalho AO VIVO". Há ainda concorrência: se A demora mais de 8s e B termina primeiro, "A termina e sobrescreve B com uma leitura velha".
>
> **[P1]** O fallback fabricado **ainda existe na sessão**: `final_direction: state.currentAnalysis?.direction || 'neutro'`. "Sessão com todas as análises em 422 termina gravada como neutra."
>
> **[P1]** `analyze-services` valida tipos, mas não as invariantes que chegam à OS: quantidade fracionária/ilimitada e ferramentas duplicadas passam. "Quantidade inválida deve descartar a linha. 'Padrão 1' é apenas texto da descrição, não um default executado pelo schema."
>
> **[P1]** `identify-tool` produz resposta **internamente contraditória**: `identified: true` com `category_name: null` → check verde e botão que "retorna silenciosamente". E `specs_detected` aceita valores arbitrários: um objeto aninhado faz o React lançar "Objects are not valid as a React child".
>
> **[P1 disponibilidade]** Sem quota por usuário, um cliente autenticado pode esgotar o orçamento compartilhado — "os limites da Anthropic são organizacionais, não isolamento por usuário da aplicação".
>
> **Certo:** `disable_parallel_tool_use` aplicado corretamente nas três · a assimetria 200/erro do `identify-tool` está correta · os casamentos de categoria não discordam em estado estável · a duplicação do helper de imagem é dívida aceitável.

</details>

**Calibração (minha, não do Codex):**

- **P1-1 é regressão minha.** O `lastAnalyzedRef` já era assim, mas antes o fallback fabricado sempre "dava certo" — trocar por 422 transformou "funciona mal" em "para calado". Corrigi com retry, guard de corrida por sequência e aviso visível de leitura desatualizada.
- **P1-2 é constrangedor**: é o mesmo padrão que removi 100 linhas acima, no mesmo arquivo, e não peguei o segundo ponto.
- **P1-3: concordo com a conclusão, não com toda a premissa.** Ele sugere respeitar a quantidade cadastrada da ferramenta, mas isso é regra que a edge não conhece (o front já aplica no "+"). Implementei o que é defensável na fronteira: inteiro positivo, descarte da linha inválida, dedupe.
- **P1-5 (quota) fica de fora**: é lacuna pré-existente, não regressão da migração. Chip aberto.
- **Ressalva de procedência**: pela terceira fase seguida, o sub-challenge independente dele não iniciou (sandbox bloqueou o app-server). É a revisão adversária local do próprio Codex.

## Prova

| Gate | Resultado |
|---|---|
| `heavy bun run test` | **641 arquivos · 5874 testes · 0 falhas** |
| `heavy bun run typecheck` | exit 0 · 0 erros |
| `test:edges` | 543 passed · 0 failed |
| `eslint .` | exit 0 · **0 erros** |

**Falsificação** — 48 testes, baseline verde, 2 locales (`C` e `pt_BR.UTF-8`), cada sabotagem tendo de derrubar os testes **nomeados**:

| Sabotagem | Vermelhos |
|---|---|
| análise do copiloto sem sugestão passa | 1/48 |
| confiança ilegível vira 0 | 3/48 |
| categoria inventada vira vínculo | 3/48 |
| quantidade solta (fracionária/zero/string) | 2/48 |
| ferramenta alheia entra no pedido | 1/48 |
| ferramenta duplicada vira duas linhas | 1/48 |
| `identified: true` sem categoria casada | 1/48 |
| spec aninhada passa (quebra o React) | 1/48 |
| "o que não reconheço, chuto jpeg" | 3/48 |

Uma sabotagem que tentei **não serviu**, e o motivo é informativo: remover os guards de `null` do `copilot-analyze` **quebra o build** — os tipos `| null` vazam para o retorno e o TS recusa. É prova estrutural mais forte que teste, mas build quebrado não conta como vermelho, então troquei por uma que compila.

## ⚠️ Ordem do deploy importa (achado do Codex)

Deploye **`copilot-analyze` ANTES do frontend**. Se o front novo subir com a edge antiga ainda rodando, o fallback fabricado dela passa pela validação nova e continua sendo gravado como leitura real.

1. Confirmar `ANTHROPIC_API_KEY` nos secrets do Supabase.
2. Edges pelo chat do Lovable — **6 arquivos**: `_shared/imagem.ts`, `copilot-analyze/{index.ts,copiloto-tools.ts}`, `identify-tool/{index.ts,ferramenta-tools.ts}`, `analyze-services/{index.ts,servico-tools.ts}`.
3. **Publish do frontend** (depois da edge do copiloto).
4. Conferir que nenhum commit "Changes" do bot reverteu os arquivos.
