### PR TITLE
fix(sync): callOmie do omie-analytics-sync para de classificar falha do Omie por dígito HTTP cru [money-path]

### DIFF
--- a/supabase/functions/_shared/omie-falha.ts
+++ b/supabase/functions/_shared/omie-falha.ts
@@ -99,7 +99,19 @@ const MARCADORES_TRANSITORIOS = [
 // SEM backoff: falha de servidor tratada como permanente (achado do challenge Codex do #1623).
 // O padrão cobre TODO 5xx e o 429 do rate-limit — e só esses: 4xx que não seja 429 não é
 // retentável (400/404 são o pedido errado, e repetir o pedido errado devolve o mesmo erro).
-const PADROES_TRANSITORIOS = [/(?:http|status):?\s+(?:429|5\d\d)/];
+//
+// As três fronteiras são todas do challenge Codex, e cada uma fecha um jeito de a âncora não
+// ancorar nada:
+//   `\b` à esquerda    — sem ele, `"prefixhttp 520 em campo ecoado"` casava: a âncora tem de ser
+//                        a PALAVRA `http`/`status`, não um sufixo dela;
+//   `(?!\d)` à direita — sem ele, `"status 503123456"` casava o prefixo de um IDENTIFICADOR, que
+//                        é exatamente o dígito-solto do #1614 voltando pela porta da âncora. De
+//                        quebra é o que torna a classe ESTÁVEL sob `redigirSegredo`: sem ele, o
+//                        mesmo texto classificava `transitorio` antes de redigir e
+//                        `indeterminada` depois (a máscara come o dígito longo);
+//   `(?:\s+code)?`     — `"Request failed with status code 503"` é a forma que cliente HTTP de
+//                        terceiro emite, e ela não casava nenhuma das duas âncoras.
+const PADROES_TRANSITORIOS = [/\b(?:http|status)(?:\s+code)?:?\s+(?:429|5\d\d)(?!\d)/];
 
 // Credencial/autorização/validação de acesso: a próxima chamada devolve exatamente o mesmo
 // erro. "Chave de acesso não cadastrada para o aplicativo" é o clássico do Omie quando a

--- a/supabase/functions/_shared/omie-falha.ts
+++ b/supabase/functions/_shared/omie-falha.ts
@@ -72,16 +72,6 @@ const MARCADORES_TRANSITORIOS = [
   "aguarde",
   "rate limit",
   "too many",
-  "http 429",
-  "http 500",
-  "http 502",
-  "http 503",
-  "http 504",
-  "status 429",
-  "status 500",
-  "status 502",
-  "status 503",
-  "status 504",
   "bad gateway",
   "service unavailable",
   "internal server error",
@@ -98,6 +88,18 @@ const MARCADORES_TRANSITORIOS = [
   "error sending request",
   "socket",
 ];
+
+// Códigos HTTP entram SÓ por aqui, e só ANCORADOS na forma que os wrappers do repo emitem
+// (`HTTP <n>`, `status <n>`) — nunca como substring solta. É a âncora que separa "código HTTP"
+// de "dígito dentro do identificador que a mensagem ecoa" (ver o bloco acima).
+//
+// ⚠️ A 1ª versão ancorada enumerava 500/502/503/504 À MÃO, e a enumeração erra pelo AVESSO do
+// dígito solto: casa de MENOS. Um 501/505/520 — as formas que gateway e CDN emitem — não casava
+// nada, caía em `indeterminada` e, no wrapper do omie-analytics-sync, abortava na 1ª tentativa
+// SEM backoff: falha de servidor tratada como permanente (achado do challenge Codex do #1623).
+// O padrão cobre TODO 5xx e o 429 do rate-limit — e só esses: 4xx que não seja 429 não é
+// retentável (400/404 são o pedido errado, e repetir o pedido errado devolve o mesmo erro).
+const PADROES_TRANSITORIOS = [/(?:http|status):?\s+(?:429|5\d\d)/];
 
 // Credencial/autorização/validação de acesso: a próxima chamada devolve exatamente o mesmo
 // erro. "Chave de acesso não cadastrada para o aplicativo" é o clássico do Omie quando a
@@ -138,6 +140,7 @@ export function classificarFaultstring(texto: string | null | undefined): Classe
   const t = normalizar(String(texto));
   if (MARCADORES_FIM.some((m) => t.includes(m))) return "fim_de_pagina";
   if (MARCADORES_TRANSITORIOS.some((m) => t.includes(m))) return "transitorio";
+  if (PADROES_TRANSITORIOS.some((p) => p.test(t))) return "transitorio";
   if (MARCADORES_PERMANENTES.some((m) => t.includes(m))) return "permanente";
   return "indeterminada";
 }

--- a/supabase/functions/_shared/omie-falha_test.ts
+++ b/supabase/functions/_shared/omie-falha_test.ts
@@ -113,6 +113,36 @@ Deno.test("classificarFaultstring — código HTTP ANCORADO na forma do wrapper 
   assertEquals(classificarFaultstring("Erro HTTP 429 do Omie (ListarClientes)"), "transitorio");
 });
 
+// A 1ª lista ancorada enumerava 500/502/503/504 À MÃO, então um 5xx FORA da enumeração
+// (501/505/520 — as formas que gateway e CDN emitem) caía em `indeterminada` e, no wrapper do
+// omie-analytics-sync, abortava na 1ª tentativa SEM backoff: falha de servidor tratada como
+// permanente (achado do challenge Codex do #1623). A enumeração à mão é a mesma classe de erro
+// do dígito solto — só que pelo avesso: lá o marcador casava demais, aqui casa de menos.
+Deno.test("classificarFaultstring — 5xx FORA da enumeração à mão (501/505/520) também é transitório", () => {
+  for (const codigo of [500, 501, 502, 503, 504, 505, 520, 521, 522, 598]) {
+    assertEquals(
+      classificarFaultstring(`Omie (vendas): HTTP ${codigo}`),
+      "transitorio",
+      `HTTP ${codigo} tinha de ser transitório (5xx é falha de servidor, sempre)`,
+    );
+  }
+});
+
+// O alargamento acima NÃO pode reabrir a porta que o #1614 fechou: a âncora (`http `/`status `)
+// é o que separa "código HTTP" de "dígito dentro de um identificador ecoado". Sem este negativo,
+// trocar a enumeração por um padrão genérico de 5xx é indistinguível de voltar ao dígito cru.
+Deno.test("classificarFaultstring — 5xx genérico NÃO afrouxa a âncora: dígito solto segue não casando", () => {
+  // app_key contendo 520/501: a família de mensagem que MAIS aparece precisa seguir permanente.
+  assertEquals(classificarFaultstring("Chave de acesso não cadastrada para o aplicativo [1520123456]"), "permanente");
+  assertEquals(classificarFaultstring("app_key [5019384756] inválida"), "permanente");
+  // Sem âncora e sem marcador nenhum: indeterminada, não transitório fabricado.
+  assertEquals(classificarFaultstring("Produto 520 sem estrutura cadastrada"), "indeterminada");
+  assertEquals(classificarFaultstring("idProduto=1503498712 nao possui malha"), "indeterminada");
+  // 4xx que NÃO é 429 não é retentável — só o rate-limit é.
+  assertEquals(classificarFaultstring("Omie (vendas): HTTP 400"), "indeterminada");
+  assertEquals(classificarFaultstring("Omie (vendas): HTTP 404"), "indeterminada");
+});
+
 // "Falha temporária ao validar credenciais" casava `credencia` e virava permanente — abandonava
 // a conta por um erro que passa sozinho. `temporari` entra antes, no lado que retenta.
 Deno.test("classificarFaultstring — falha TEMPORÁRIA que cita credencial é transitória, não permanente", () => {

--- a/supabase/functions/_shared/omie-falha_test.ts
+++ b/supabase/functions/_shared/omie-falha_test.ts
@@ -141,6 +141,12 @@ Deno.test("classificarFaultstring — 5xx genérico NÃO afrouxa a âncora: díg
   // 4xx que NÃO é 429 não é retentável — só o rate-limit é.
   assertEquals(classificarFaultstring("Omie (vendas): HTTP 400"), "indeterminada");
   assertEquals(classificarFaultstring("Omie (vendas): HTTP 404"), "indeterminada");
+  // A âncora tem de ser a PALAVRA: `http` como sufixo de outra não ancora nada (fronteira `\b`).
+  assertEquals(classificarFaultstring("prefixhttp 520 em campo ecoado"), "indeterminada");
+  // …e o código não pode ser o PREFIXO de um identificador longo (fronteira `(?!\d)`) — este é o
+  // dígito-solto do #1614 tentando voltar por dentro da própria âncora.
+  assertEquals(classificarFaultstring("status 503123456 dentro do identificador"), "indeterminada");
+  assertEquals(classificarFaultstring("http 5031234 é um id, não um código"), "indeterminada");
 });
 
 // "Falha temporária ao validar credenciais" casava `credencia` e virava permanente — abandonava

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -8,7 +8,12 @@ import { recomporCustoProducao } from "../_shared/recompor-custo-producao.ts";
 import { buildProductIdMap, montarCatalogoPorCod } from "../_shared/product-idmap.ts";
 import { avaliarPagina, MAX_PAGINAS_LISTAGEM, MAX_PAGINAS_POS_ESTOQUE, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
 import { acumularPosicoesDaPagina, type PosicaoEstoque } from "../_shared/pos-estoque.ts";
-import { atrasoRetentativaMs, classificarFaultstring, redigirSegredo } from "../_shared/omie-falha.ts";
+import {
+  decidirRetentativaOmie,
+  MAX_TENTATIVAS_OMIE,
+  mensagemCorpoNaoJson,
+  mensagemFalhaOmie,
+} from "./politica-retry.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -182,17 +187,12 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
   // (money-path §"O MARCADOR mente", #1614); (b) a enumeração à mão de 5xx deixava 501/505/520 —
   // gateway/CDN — abortar sem backoff nenhum (#1623).
   //
-  // ⚠️ Só `transitorio` retenta. `indeterminada` falha RÁPIDO aqui, e essa é uma divergência
-  // DELIBERADA da política de `decidirDesfechoFalha` (onde indeterminada retenta) — a unidade de
-  // trabalho é outra. Lá o retry é por PÁGINA e desistir custa uma conta inteira; aqui o
-  // `ConsultarEstrutura` roda por PRODUTO dentro de um laço de ~1.3k alvos em lotes de 8, com o
-  // caller degradando honesto (`custo_producao_status='erro_api'`). Medido em prod 2026-07-31:
-  // 825 produtos falham por ciclo. Retentar indeterminada custaria 825/8 × 5,6s ≈ 578s de sleep
-  // contra um orçamento de ~150s do worker — trocaria uma falha reportada e parcial pelo
-  // WORKER_RESOURCE_LIMIT que o lote paralelo do `syncCustoProducao` existe para evitar, com o
-  // sync_state preso em 'running'. Quem mudar isto tem de refazer essa conta com o número de
-  // falhas do ciclo; o gate em politica-retry_test.ts pina a política.
-  const maxAttempts = 4;
+  // ⚠️ A POLÍTICA (o que retenta, quanto dorme, o que é redigido) vive em `./politica-retry.ts`,
+  // que é puro e importável pelo teste — este arquivo não é (traz `deno.land` e `npm:`, e a suíte
+  // roda com `--no-remote`). A 1ª versão desta entrega deixava a política aqui e a "provava" com
+  // gates que liam o fonte atrás de tokens; o challenge do Codex passou pelos três com mutações
+  // triviais. Decisão de money-path não se prova por token: mora onde o teste a EXECUTA.
+  const maxAttempts = MAX_TENTATIVAS_OMIE;
   let lastErr: Error | null = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
@@ -201,22 +201,28 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      const result = (await res.json()) as OmieApiResponseBase;
+      // ⚠️ O parse vem ANTES do guard de status (a faultstring é mais acionável que o código), e
+      // é por isso que ele precisa do próprio catch: um 5xx de gateway com corpo de TEXTO estoura
+      // aqui e nunca chega ao `!res.ok`. A mensagem do parser ecoa o corpo ("Unexpected token
+      // 'E', \"ERROR 503\" is not valid JSON") — o classificador antigo via o `503` solto ali e
+      // retentava; sem este ramo, a forma ancorada não veria nada e o 503 de gateway falharia na
+      // 1ª tentativa. Regressão de transporte achada pelo challenge do Codex.
+      let result: OmieApiResponseBase;
+      try {
+        result = (await res.json()) as OmieApiResponseBase;
+      } catch (erroJson) {
+        throw new Error(mensagemCorpoNaoJson(account, res.status, erroJson));
+      }
       // `faultstring` ANTES do status. ⚠️ Aqui a ordem NÃO preserva EOF nenhum — este wrapper
       // lança em TODA faultstring, inclusive na de fim de página, e isso é comportamento
       // preexistente que este PR não muda (achado Codex xhigh, contra a 1ª redação deste
       // comentário, que prometia preservar o fim real). O que a ordem preserva é a MENSAGEM: é
       // ela que o catch abaixo classifica para decidir entre retentar e falhar, e um `HTTP 503`
       // genérico apagaria a faultstring específica que torna o motivo acionável.
-      // ⚠️ `redigirSegredo` porque esta faultstring ECOA a credencial: a mensagem mais comum da
-      // família é `"Chave de acesso não cadastrada para o aplicativo [<app_key>]"`, e daqui o
-      // texto vai CRU para três sinks — `sync_state.error_message` (PERSISTIDO, nos catch de
-      // syncCustomers/syncProducts/syncInventory/syncCustoProducao), o `console.error` do laço de
-      // `ConsultarEstrutura`, e o corpo da resposta 500 do handler. Redigir no THROW cobre os
-      // três de uma vez. O que se mascara é dígito LONGO (app_key) e hex longo
-      // (app_secret); número de página e código HTTP sobrevivem — são o que torna o motivo
-      // acionável (money-path §"O MARCADOR mente", corolário de privacidade).
-      if (result.faultstring) throw new Error(`Omie (${account}): ${redigirSegredo(String(result.faultstring))}`);
+      // `mensagemFalhaOmie` REDIGE o texto do Omie: esta faultstring ECOA a credencial, e daqui
+      // ela ia crua para três sinks (o `sync_state.error_message` persistido, o console e o corpo
+      // da resposta 500). O porquê e o que se preserva estão em `politica-retry.ts`.
+      if (result.faultstring) throw new Error(mensagemFalhaOmie(account, String(result.faultstring)));
       // Sem faultstring, só um 2xx é resposta. `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo
       // corpo parseia sem fault (o `{}` de proxy/gateway) voltava como resposta boa e chegava aos
       // laços de enumeração sem `total_de_paginas` e sem lista — o piso degrada para 1 e a página
@@ -224,27 +230,18 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
       // Emitido como `HTTP <n>` — a forma ANCORADA que `classificarFaultstring` reconhece, para
       // reusar o backoff do catch em vez de virar falha diária. Todo 5xx (não só 500/502/503/504)
       // e o 429 casam o padrão; a âncora é o que impede o dígito de casar dentro de um id ecoado.
-      if (!res.ok) throw new Error(`Omie (${account}): HTTP ${res.status}`);
+      if (!res.ok) throw new Error(mensagemFalhaOmie(account, `HTTP ${res.status}`, "runtime"));
       // `faultcode` sem `faultstring` fecha a ordem canônica: um `200 {"faultcode":"5113"}` chegava
       // aos laços como página boa e vazia, e o sync publicava `status:"complete"` sobre um retrato
       // parcial — a fabricação de completude que o G6 existe para barrar, uma casa adiante.
-      if (result.faultcode) throw new Error(`Omie (${account}): faultcode ${redigirSegredo(String(result.faultcode))}`);
+      if (result.faultcode) throw new Error(mensagemFalhaOmie(account, `faultcode ${result.faultcode}`));
       return result;
     } catch (e) {
       const erro = e instanceof Error ? e : new Error(String(e));
       lastErr = erro;
-      // `classificarFaultstring` (e não `classificarExcecao`) porque o texto que chega aqui é, no
-      // caminho dominante, a própria faultstring do Omie que o throw acima embrulhou — e o EOF do
-      // contrato ("Não existem registros para a página") tem de continuar visível como
-      // `fim_de_pagina`. A distinção não muda o desfecho (só `transitorio` retenta, e o EOF nunca
-      // é transitório): muda o que a classe DIZ, e classe que mente é o começo do próximo bug.
-      const classe = classificarFaultstring(erro.message);
-      if (classe === "transitorio" && attempt < maxAttempts) {
-        // Mesma curva de antes (0,8s / 1,6s / 3,2s) e, de quebra, honra o "Aguarde N segundos"
-        // que o Omie manda no rate-limit, com teto de 5s. Dormir o que o servidor pediu é o
-        // oposto de martelar 0,8s enquanto ele pede espera.
-        const espera = atrasoRetentativaMs(attempt, erro.message);
-        await new Promise((r) => setTimeout(r, espera));
+      const decisao = decidirRetentativaOmie(erro.message, attempt, maxAttempts);
+      if (decisao.retentar) {
+        await new Promise((r) => setTimeout(r, decisao.atrasoMs));
         continue;
       }
       throw erro;

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -8,6 +8,7 @@ import { recomporCustoProducao } from "../_shared/recompor-custo-producao.ts";
 import { buildProductIdMap, montarCatalogoPorCod } from "../_shared/product-idmap.ts";
 import { avaliarPagina, MAX_PAGINAS_LISTAGEM, MAX_PAGINAS_POS_ESTOQUE, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
 import { acumularPosicoesDaPagina, type PosicaoEstoque } from "../_shared/pos-estoque.ts";
+import { atrasoRetentativaMs, classificarFaultstring, redigirSegredo } from "../_shared/omie-falha.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -171,7 +172,26 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
   // Retry com backoff p/ erros TRANSITÓRIOS do Omie/rede (ex.: "SOAP-ERROR: Broken response from
   // Application Server" — flakiness intermitente do servidor do Omie que matava a enumeração de ~105
   // páginas). ListarClientes/ListarProdutos são leitura idempotente → seguro re-tentar. Erro PERMANENTE
-  // (credencial/validação) falha rápido (não casa os marcadores transitórios). Backoff: 0.8s, 1.6s, 3.2s.
+  // (credencial/validação) falha rápido. Backoff: 0.8s, 1.6s, 3.2s (`atrasoRetentativaMs`).
+  //
+  // ⚠️ A classificação é do helper canônico `_shared/omie-falha.ts`, NÃO ad-hoc aqui. A versão
+  // anterior casava os códigos HTTP CRUS (`msg.includes("503")`) e tinha os dois defeitos que o
+  // helper já fechou: (a) o dígito casa DENTRO do identificador que a própria mensagem ecoa — a
+  // app_key de `"Chave de acesso não cadastrada para o aplicativo [1503123456]"` e o idProduto do
+  // `ConsultarEstrutura` contêm 503, então o erro PERMANENTE mais comum comprava as 4 tentativas
+  // (money-path §"O MARCADOR mente", #1614); (b) a enumeração à mão de 5xx deixava 501/505/520 —
+  // gateway/CDN — abortar sem backoff nenhum (#1623).
+  //
+  // ⚠️ Só `transitorio` retenta. `indeterminada` falha RÁPIDO aqui, e essa é uma divergência
+  // DELIBERADA da política de `decidirDesfechoFalha` (onde indeterminada retenta) — a unidade de
+  // trabalho é outra. Lá o retry é por PÁGINA e desistir custa uma conta inteira; aqui o
+  // `ConsultarEstrutura` roda por PRODUTO dentro de um laço de ~1.3k alvos em lotes de 8, com o
+  // caller degradando honesto (`custo_producao_status='erro_api'`). Medido em prod 2026-07-31:
+  // 825 produtos falham por ciclo. Retentar indeterminada custaria 825/8 × 5,6s ≈ 578s de sleep
+  // contra um orçamento de ~150s do worker — trocaria uma falha reportada e parcial pelo
+  // WORKER_RESOURCE_LIMIT que o lote paralelo do `syncCustoProducao` existe para evitar, com o
+  // sync_state preso em 'running'. Quem mudar isto tem de refazer essa conta com o número de
+  // falhas do ciclo; o gate em politica-retry_test.ts pina a política.
   const maxAttempts = 4;
   let lastErr: Error | null = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -188,34 +208,46 @@ async function callOmie(account: OmieAccount, endpoint: string, call: string, pa
       // comentário, que prometia preservar o fim real). O que a ordem preserva é a MENSAGEM: é
       // ela que o catch abaixo classifica para decidir entre retentar e falhar, e um `HTTP 503`
       // genérico apagaria a faultstring específica que torna o motivo acionável.
-      if (result.faultstring) throw new Error(`Omie (${account}): ${result.faultstring}`);
+      // ⚠️ `redigirSegredo` porque esta faultstring ECOA a credencial: a mensagem mais comum da
+      // família é `"Chave de acesso não cadastrada para o aplicativo [<app_key>]"`, e daqui o
+      // texto vai CRU para três sinks — `sync_state.error_message` (PERSISTIDO, nos catch de
+      // syncCustomers/syncProducts/syncInventory/syncCustoProducao), o `console.error` do laço de
+      // `ConsultarEstrutura`, e o corpo da resposta 500 do handler. Redigir no THROW cobre os
+      // três de uma vez. O que se mascara é dígito LONGO (app_key) e hex longo
+      // (app_secret); número de página e código HTTP sobrevivem — são o que torna o motivo
+      // acionável (money-path §"O MARCADOR mente", corolário de privacidade).
+      if (result.faultstring) throw new Error(`Omie (${account}): ${redigirSegredo(String(result.faultstring))}`);
       // Sem faultstring, só um 2xx é resposta. `fetch` NÃO lança em HTTP não-2xx: um 429/5xx cujo
       // corpo parseia sem fault (o `{}` de proxy/gateway) voltava como resposta boa e chegava aos
       // laços de enumeração sem `total_de_paginas` e sem lista — o piso degrada para 1 e a página
       // vazia vira fim da fonte, com todos os guards de paginação corretos e nenhum consultado.
-      // Emitido como `HTTP <n>` para reusar o backoff do catch em vez de virar falha diária —
-      // mas o classificador local casa dígito CRU e só conhece 429/500/502/503/504: um 501/520
-      // aborta na 1ª tentativa (dívida preexistente do classificador, não deste guard; o helper
-      // canônico `_shared/omie-falha.ts` é quem já ancora o marcador na forma `http <n>`).
+      // Emitido como `HTTP <n>` — a forma ANCORADA que `classificarFaultstring` reconhece, para
+      // reusar o backoff do catch em vez de virar falha diária. Todo 5xx (não só 500/502/503/504)
+      // e o 429 casam o padrão; a âncora é o que impede o dígito de casar dentro de um id ecoado.
       if (!res.ok) throw new Error(`Omie (${account}): HTTP ${res.status}`);
       // `faultcode` sem `faultstring` fecha a ordem canônica: um `200 {"faultcode":"5113"}` chegava
       // aos laços como página boa e vazia, e o sync publicava `status:"complete"` sobre um retrato
       // parcial — a fabricação de completude que o G6 existe para barrar, uma casa adiante.
-      if (result.faultcode) throw new Error(`Omie (${account}): faultcode ${result.faultcode}`);
+      if (result.faultcode) throw new Error(`Omie (${account}): faultcode ${redigirSegredo(String(result.faultcode))}`);
       return result;
     } catch (e) {
-      lastErr = e instanceof Error ? e : new Error(String(e));
-      const msg = lastErr.message.toLowerCase();
-      const transient = msg.includes("broken response") || msg.includes("soap-error") ||
-        msg.includes("timeout") || msg.includes("timed out") || msg.includes("network") ||
-        msg.includes("connection") || msg.includes("fetch failed") ||
-        msg.includes("502") || msg.includes("503") || msg.includes("504") || msg.includes("500") ||
-        msg.includes("429") || msg.includes("too many") || msg.includes("rate limit");
-      if (transient && attempt < maxAttempts) {
-        await new Promise((r) => setTimeout(r, 800 * Math.pow(2, attempt - 1)));
+      const erro = e instanceof Error ? e : new Error(String(e));
+      lastErr = erro;
+      // `classificarFaultstring` (e não `classificarExcecao`) porque o texto que chega aqui é, no
+      // caminho dominante, a própria faultstring do Omie que o throw acima embrulhou — e o EOF do
+      // contrato ("Não existem registros para a página") tem de continuar visível como
+      // `fim_de_pagina`. A distinção não muda o desfecho (só `transitorio` retenta, e o EOF nunca
+      // é transitório): muda o que a classe DIZ, e classe que mente é o começo do próximo bug.
+      const classe = classificarFaultstring(erro.message);
+      if (classe === "transitorio" && attempt < maxAttempts) {
+        // Mesma curva de antes (0,8s / 1,6s / 3,2s) e, de quebra, honra o "Aguarde N segundos"
+        // que o Omie manda no rate-limit, com teto de 5s. Dormir o que o servidor pediu é o
+        // oposto de martelar 0,8s enquanto ele pede espera.
+        const espera = atrasoRetentativaMs(attempt, erro.message);
+        await new Promise((r) => setTimeout(r, espera));
         continue;
       }
-      throw lastErr;
+      throw erro;
     }
   }
   throw lastErr ?? new Error(`Omie (${account}): falha após ${maxAttempts} tentativas`);

--- a/supabase/functions/omie-analytics-sync/politica-retry.ts
+++ b/supabase/functions/omie-analytics-sync/politica-retry.ts
@@ -1,0 +1,105 @@
+// Política de retentativa e redação do `callOmie` (omie-analytics-sync) — lógica PURA.
+//
+// ── Por que este módulo existe separado do index.ts ────────────────────────────────────────────
+// O `index.ts` importa `https://deno.land/...` e `npm:@supabase/supabase-js`, e a suíte de edge
+// roda com `--no-remote` — logo ele NÃO é importável por teste. A 1ª versão desta entrega tentou
+// contornar isso com gates que liam o FONTE procurando tokens (`includes("503")`,
+// `=== "transitorio"`, a palavra `redigirSegredo`). O challenge do Codex derrubou os três
+// executando mutações contra os próprios predicados: trocar a classificação por um REGEX de
+// dígito cru passava; fixar `classe = "permanente"` e deixar o helper importado sem uso passava;
+// emitir o segredo cru com `redigirSegredo` num ramo morto passava. Gate de token não tem vínculo
+// semântico com o que a edge faz.
+//
+// A correção é a doutrina do repo (CLAUDE.md: "Precisa de dep? Extraia a lógica PURA e teste
+// ela"): a decisão vive aqui, sem I/O e sem import remoto, e o `callOmie` vira o transporte que a
+// consulta. O teste passa a medir COMPORTAMENTO (dada a mensagem e a tentativa, retenta? quanto
+// dorme? o texto sai redigido?) em vez de procurar palavras no fonte.
+import { atrasoRetentativaMs, type ClasseFalhaOmie, classificarFaultstring, redigirSegredo } from "../_shared/omie-falha.ts";
+
+export interface DecisaoRetentativa {
+  retentar: boolean;
+  atrasoMs: number;
+  classe: ClasseFalhaOmie;
+}
+
+/** Teto de tentativas por chamada — 1 original + 3 retentativas (backoff 0,8s / 1,6s / 3,2s). */
+export const MAX_TENTATIVAS_OMIE = 4;
+
+/**
+ * Decide se a chamada ao Omie deve ser repetida.
+ *
+ * ⚠️ Só `transitorio` retenta. `indeterminada` falha RÁPIDO, e essa é uma divergência DELIBERADA
+ * de `decidirDesfechoFalha` (a política do helper, onde indeterminada retenta) — a unidade de
+ * trabalho é outra. Lá o retry é por PÁGINA e desistir custa uma conta inteira. Aqui o
+ * `ConsultarEstrutura` roda por PRODUTO num laço de ~1.334 alvos em lotes de 8, com o caller
+ * degradando honesto (`custo_producao_status='erro_api'`), e o orçamento do worker é de ~150s.
+ *
+ * A conta, medida em produção 2026-07-31 (825 dos ~1.334 alvos falhando por ciclo): o sleep é
+ * pago por LOTE que contenha ao menos uma falha, então o custo de retentar indeterminada fica
+ * entre `ceil(825/8) × 5,6s ≈ 582s` (empacotamento perfeito, todas as falhas juntas) e
+ * `ceil(1334/8) × 5,6s ≈ 935s` (falhas espalhadas, todo lote com uma) — sem contar as chamadas
+ * HTTP extras. Os dois extremos estouram os ~150s, o que troca uma falha parcial REPORTADA pelo
+ * WORKER_RESOURCE_LIMIT que o lote paralelo existe para evitar, com o sync_state preso em
+ * 'running'. Quem for mudar isto refaz a conta com o número de falhas do ciclo, não com este.
+ *
+ * @param tentativa 1-based, já contando a que acabou de falhar.
+ */
+export function decidirRetentativaOmie(
+  mensagem: string,
+  tentativa: number,
+  maxTentativas: number = MAX_TENTATIVAS_OMIE,
+): DecisaoRetentativa {
+  const classe = classificarFaultstring(mensagem);
+  const retentar = classe === "transitorio" && tentativa < maxTentativas;
+  // ⚠️ `atrasoRetentativaMs` SEM a faultstring, de propósito: com ela, o helper honra o
+  // "Aguarde N segundos" do rate-limit do Omie (teto de 5s POR TENTATIVA), e o challenge do Codex
+  // mediu o efeito — "Aguarde 3 segundos" leva o total de 5,6s para 10,5s, e "Aguarde 90" para
+  // 15s. Num laço de 167 lotes isso é orçamento do worker, não cortesia. A curva fica idêntica à
+  // que esta edge já tinha (0,8s / 1,6s / 3,2s). Honrar o pedido do servidor é melhora legítima,
+  // mas exige medir o custo no laço de lotes primeiro — follow-up, não carona nesta entrega.
+  return { retentar, atrasoMs: retentar ? atrasoRetentativaMs(tentativa) : 0, classe };
+}
+
+/**
+ * Monta a mensagem de falha que SAI da edge, redigindo o texto produzido pelo Omie.
+ *
+ * ⚠️ Não é higiene: a faultstring de credencial ECOA a app_key ("Chave de acesso não cadastrada
+ * para o aplicativo [1503123456]"), e daqui o texto vai para três sinks — `sync_state.error_message`
+ * (PERSISTIDO, nos catch de syncCustomers/syncProducts/syncInventory/syncCustoProducao), o
+ * `console.error` do laço de `ConsultarEstrutura`, e o corpo da resposta 500 do handler.
+ * Redigir na CONSTRUÇÃO da mensagem cobre os três de uma vez.
+ *
+ * `origem` diz quem produziu o texto: só `omie` é redigido. `runtime` é para valor que a própria
+ * edge produz (o `res.status` do fetch) — redigi-lo seria código morto sugerindo um risco que não
+ * existe, e número curto é justamente o que torna o motivo acionável.
+ */
+export function mensagemFalhaOmie(
+  account: string,
+  texto: string,
+  origem: "omie" | "runtime" = "omie",
+): string {
+  return `Omie (${account}): ${origem === "omie" ? redigirSegredo(String(texto)) : String(texto)}`;
+}
+
+/**
+ * Mensagem para resposta cujo CORPO não é JSON — página de erro de gateway/CDN no caminho.
+ *
+ * ⚠️ O `callOmie` chama `res.json()` ANTES de testar `res.ok`, então um 5xx com corpo de texto
+ * estoura no parser e nunca chega ao guard de status. A mensagem do parser do Deno ecoa o corpo
+ * ("Unexpected token 'E', \"ERROR 503\" is not valid JSON") — o classificador ANTIGO via o `503`
+ * solto ali e retentava; o novo, que exige a forma ancorada, não veria nada e falharia na 1ª
+ * tentativa. Regressão real de transporte, achada pelo challenge do Codex.
+ *
+ * Por isso, quando o corpo não parseia, o STATUS é o único sinal confiável e ele sai na forma
+ * ANCORADA (`HTTP <n>`) — que é o que faz um 502/503/520 de gateway voltar a ganhar backoff.
+ *
+ * Num 2xx com corpo não-JSON o status não diz nada (é 200), então não há o que ancorar: a
+ * mensagem sai como falha indeterminada e falha rápido — mesmo desfecho que o classificador
+ * antigo dava a essa forma, já que a mensagem do parser não carrega código HTTP nenhum.
+ */
+export function mensagemCorpoNaoJson(account: string, status: number, erro: unknown): string {
+  const detalhe = redigirSegredo(erro instanceof Error ? erro.message : String(erro)).slice(0, 200);
+  return status >= 200 && status < 300
+    ? `Omie (${account}): resposta HTTP ${status} com corpo não-JSON — ${detalhe}`
+    : `Omie (${account}): HTTP ${status} (corpo não-JSON) — ${detalhe}`;
+}

--- a/supabase/functions/omie-analytics-sync/politica-retry_test.ts
+++ b/supabase/functions/omie-analytics-sync/politica-retry_test.ts
@@ -9,13 +9,21 @@
 //      §"O MARCADOR mente", #1614) — a app_key e o idProduto contêm 503;
 //   2. a enumeração à mão de 5xx não cobre 501/505/520 (challenge Codex do #1623).
 // Trocar um classificador por outro num caminho com 7 crons ativos exige mais do que "o helper é
-// melhor": exige que NENHUMA falha de transporte que retentava antes deixe de retentar. É essa
-// implicação que os testes abaixo medem, mais o gate de fonte que impede a volta do dígito cru.
+// melhor": exige que NENHUMA falha de transporte que retentava antes deixe de retentar.
 //
-// Este teste não importa o `index.ts` (ele traz `https://deno.land/...` e `npm:`, e `test:edges`
-// roda com `--no-remote`): a lógica sob teste é a do helper puro, e o WIRING é medido lendo o
-// FONTE — o mesmo padrão do `paginacao-artesanal-gate` (money-path §9).
-import { atrasoRetentativaMs, classificarFaultstring } from "../_shared/omie-falha.ts";
+// ⚠️ Estes testes EXECUTAM a política real (`./politica-retry.ts`), não procuram palavras no
+// fonte. A 1ª versão fazia o contrário — três gates que liam o `index.ts` atrás de tokens — e o
+// challenge do Codex passou pelos três com mutações triviais (regex de dígito cru no lugar do
+// `includes`, `classe` fixada em "permanente" com o helper importado sem uso, `redigirSegredo`
+// num ramo morto). O gate de fonte que sobrou no fim do arquivo é só a amarra de DELEGAÇÃO: ele
+// não afirma comportamento nenhum, e diz isso.
+import {
+  decidirRetentativaOmie,
+  MAX_TENTATIVAS_OMIE,
+  mensagemCorpoNaoJson,
+  mensagemFalhaOmie,
+} from "./politica-retry.ts";
+import { classificarFaultstring, redigirSegredo } from "../_shared/omie-falha.ts";
 
 function assertEquals(a: unknown, b: unknown, msg?: string) {
   if (JSON.stringify(a) !== JSON.stringify(b)) {
@@ -40,6 +48,9 @@ function transitorioLegado(mensagem: string): boolean {
     msg.includes("429") || msg.includes("too many") || msg.includes("rate limit");
 }
 
+/** Retenta de verdade? (1ª tentativa, longe do teto — isola a CLASSE do esgotamento.) */
+const retenta = (msg: string) => decidirRetentativaOmie(msg, 1, MAX_TENTATIVAS_OMIE).retentar;
+
 // Falhas de TRANSPORTE reais, na forma exata em que o `callOmie` as emite (`Omie (<conta>): …`)
 // ou em que o runtime as lança. Toda linha daqui retentava ontem e TEM de retentar hoje.
 const TRANSPORTE = [
@@ -55,6 +66,17 @@ const TRANSPORTE = [
   "error sending request for url (https://app.omie.com.br/api/v1/geral/produtos/): connection closed",
   "TypeError: network error",
   "fetch failed",
+  // ⚠️ O 5xx de gateway com corpo NÃO-JSON. O `res.json()` roda antes do guard de status, então
+  // esta é a forma em que um 503 de CDN realmente chega ao catch — e o classificador antigo a
+  // retentava por ver o `503` solto na mensagem do parser. Foi a regressão que o challenge do
+  // Codex achou: sem `mensagemCorpoNaoJson` ancorando o status, as 4 tentativas viravam 1.
+  mensagemCorpoNaoJson("vendas", 503, new SyntaxError(`Unexpected token 'E', "ERROR 503" is not valid JSON`)),
+  mensagemCorpoNaoJson("vendas", 502, new SyntaxError(`Unexpected token '<', "<html>" is not valid JSON`)),
+  // `status code <n>` é a forma que cliente HTTP de terceiro emite. O legado a retentava (por ver
+  // o dígito solto); a 1ª versão do padrão ancorado NÃO a reconhecia — era uma regressão de
+  // equivalência escondida, achada pelo challenge do Codex. O `(?:\s+code)?` do padrão é o que a
+  // devolve ao lado certo.
+  "Request failed with status code 503",
 ];
 
 // Transporte que o classificador ad-hoc NÃO reconhecia e passa a retentar. Direção segura (o
@@ -69,6 +91,18 @@ const ALARGAMENTO = [
   "ECONNRESET",
 ];
 
+// Mensagens que PARAM de retentar. Cada uma é o defeito sendo consertado, não efeito colateral.
+const BAIT: Array<[string, string]> = [
+  // A família de mensagem de credencial MAIS comum do Omie: a app_key contém 503.
+  ["Omie (vendas): Chave de acesso não cadastrada para o aplicativo [1503123456]", "permanente"],
+  ["Omie (servicos): app_key [4290384756] inválida", "permanente"],
+  // Mesma armadilha, outra família: o idProduto ecoado. É o caminho do `ConsultarEstrutura`,
+  // onde 825 dos ~1.334 alvos JÁ falham por ciclo em produção (medido 2026-07-31) — os que por
+  // acaso carregam 500/502/503/504/429 no código queimavam 4 chamadas cada, por acidente de dígito.
+  ["Omie (colacor_vendas): idProduto=1503498712 nao possui estrutura", "indeterminada"],
+  ["Omie (colacor_vendas): Produto 1502938475 sem malha cadastrada", "indeterminada"],
+];
+
 // ⚠️ A implicação que autoriza a troca. Não é "as duas listas são iguais" (não são, e não podem
 // ser — a desigualdade é o conserto): é "o conjunto que RETENTAVA não encolheu por transporte".
 Deno.test("EQUIVALÊNCIA — toda falha de transporte que retentava no classificador ad-hoc segue retentando", () => {
@@ -78,11 +112,7 @@ Deno.test("EQUIVALÊNCIA — toda falha de transporte que retentava no classific
       true,
       `fixture inválida: o classificador ANTIGO não retentava isto — o corpus não mede o que promete: ${msg}`,
     );
-    assertEquals(
-      classificarFaultstring(msg),
-      "transitorio",
-      `REGRESSÃO: retentava ontem e não retenta hoje — transitório virando falha diária: ${msg}`,
-    );
+    assertEquals(retenta(msg), true, `REGRESSÃO: retentava ontem e não retenta hoje: ${msg}`);
   }
 });
 
@@ -93,34 +123,22 @@ Deno.test("ALARGAMENTO — transporte que o classificador ad-hoc não reconhecia
       false,
       `fixture inválida: o classificador ANTIGO já retentava isto — não é alargamento: ${msg}`,
     );
-    assertEquals(classificarFaultstring(msg), "transitorio", `deixou de ser reconhecido: ${msg}`);
+    assertEquals(retenta(msg), true, `deixou de ser reconhecido: ${msg}`);
   }
 });
 
-// As ÚNICAS mensagens que deixam de retentar — e cada uma é o defeito sendo consertado, não um
-// efeito colateral. `transitorioLegado === true` aqui é a prova de que o bug existia de fato.
 Deno.test("O CONSERTO — dígito ecoado dentro de identificador para de comprar 4 tentativas", () => {
-  const bait: Array<[string, string]> = [
-    // A família de mensagem de credencial MAIS comum do Omie: a app_key contém 503.
-    ["Omie (vendas): Chave de acesso não cadastrada para o aplicativo [1503123456]", "permanente"],
-    ["Omie (servicos): app_key [4290384756] inválida", "permanente"],
-    // Mesma armadilha, outra família: o idProduto ecoado. É o caminho do `ConsultarEstrutura`,
-    // onde 825 produtos JÁ falham por ciclo em produção (medido 2026-07-31) — os que por acaso
-    // carregam 500/502/503/504/429 no código queimavam 4 chamadas cada, por acidente de dígito.
-    ["Omie (colacor_vendas): idProduto=1503498712 nao possui estrutura", "indeterminada"],
-    ["Omie (colacor_vendas): Produto 1502938475 sem malha cadastrada", "indeterminada"],
-  ];
-  for (const [msg, esperado] of bait) {
+  for (const [msg, esperado] of BAIT) {
     assertEquals(
       transitorioLegado(msg),
       true,
       `fixture inválida: se o classificador ANTIGO já não retentava isto, não há defeito a consertar: ${msg}`,
     );
-    assertEquals(classificarFaultstring(msg), esperado, `classe errada para: ${msg}`);
+    assertEquals(retenta(msg), false, `deveria falhar rápido: ${msg}`);
+    assertEquals(decidirRetentativaOmie(msg, 1).classe, esperado, `classe errada para: ${msg}`);
   }
 });
 
-// Defeito 2: 5xx fora da enumeração à mão abortava na 1ª tentativa, SEM backoff.
 Deno.test("O CONSERTO — 5xx de gateway/CDN (501/505/520) passa a ganhar backoff", () => {
   for (const codigo of [501, 505, 520, 521, 522]) {
     const msg = `Omie (vendas): HTTP ${codigo}`;
@@ -129,26 +147,78 @@ Deno.test("O CONSERTO — 5xx de gateway/CDN (501/505/520) passa a ganhar backof
       false,
       `fixture inválida: o classificador ANTIGO já retentava ${codigo} — não há defeito a consertar`,
     );
-    assertEquals(classificarFaultstring(msg), "transitorio", `HTTP ${codigo} tinha de retentar`);
+    assertEquals(retenta(msg), true, `HTTP ${codigo} tinha de retentar`);
   }
 });
 
 // O backoff é parte do contrato que não pode mudar: o `callOmie` dormia `800 * 2^(n-1)` ms.
-Deno.test("EQUIVALÊNCIA — o backoff do helper reproduz os 0,8s / 1,6s / 3,2s do callOmie", () => {
+Deno.test("EQUIVALÊNCIA — o atraso reproduz os 0,8s / 1,6s / 3,2s do callOmie", () => {
+  const msg = "Omie (vendas): HTTP 503";
   for (let tentativa = 1; tentativa <= 3; tentativa++) {
     assertEquals(
-      atrasoRetentativaMs(tentativa),
+      decidirRetentativaOmie(msg, tentativa).atrasoMs,
       800 * Math.pow(2, tentativa - 1),
       `backoff divergiu na tentativa ${tentativa}`,
     );
   }
 });
 
-// ── Gate de FONTE: o wiring ────────────────────────────────────────────────────────────────────
-// Os testes acima provam o que o HELPER decide; nada neles prova que a edge o CONSULTA. Sem este
-// gate, alguém reintroduz o dígito cru no `callOmie` e a suíte inteira segue verde.
-// Medido com os comentários REMOVIDOS — este arquivo e o próprio `callOmie` citam a forma do bug
-// de propósito, e um predicado que lê a prosa acusa a documentação (money-path §"o ALVO mente").
+// ⚠️ O helper SABE honrar o "Aguarde N segundos" do Omie, e esta edge deliberadamente NÃO usa.
+// Medido no challenge do Codex: "Aguarde 3 segundos" levaria o total de 5,6s para 10,5s e
+// "Aguarde 90" para 15s (o teto de 5s é POR TENTATIVA). Num laço de 167 lotes isso é orçamento
+// do worker. Sem este teste, alguém "melhora" a chamada passando a faultstring e ninguém vê.
+Deno.test("O 'Aguarde N segundos' do Omie NÃO alonga o sleep desta edge (decisão, não esquecimento)", () => {
+  const comPedido = "Omie (vendas): Rate limit. Aguarde 90 segundos.";
+  assertEquals(decidirRetentativaOmie(comPedido, 1).retentar, true);
+  assertEquals(
+    decidirRetentativaOmie(comPedido, 1).atrasoMs,
+    800,
+    "o atraso passou a honrar o 'Aguarde N' — mede o custo no laço de lotes antes de ligar isso",
+  );
+});
+
+Deno.test("TETO — a última tentativa não retenta, mesmo sendo transitória", () => {
+  const msg = "Omie (vendas): HTTP 503";
+  assertEquals(decidirRetentativaOmie(msg, MAX_TENTATIVAS_OMIE - 1).retentar, true);
+  assertEquals(decidirRetentativaOmie(msg, MAX_TENTATIVAS_OMIE).retentar, false, "estourou o teto");
+  assertEquals(decidirRetentativaOmie(msg, MAX_TENTATIVAS_OMIE).atrasoMs, 0, "não dorme sem retentar");
+});
+
+// ── Redação ────────────────────────────────────────────────────────────────────────────────────
+Deno.test("REDAÇÃO — a app_key ecoada pelo Omie não sai da edge", () => {
+  const cru = "Chave de acesso não cadastrada para o aplicativo [1503123456]";
+  const saida = mensagemFalhaOmie("vendas", cru);
+  if (saida.includes("1503123456")) throw new Error(`app_key vazando: ${saida}`);
+  if (!saida.includes("Omie (vendas)")) throw new Error(`perdeu a conta, que é o que distingue a falha: ${saida}`);
+  // O motivo tem de continuar acionável: a forma da mensagem sobrevive à máscara.
+  if (!saida.includes("Chave de acesso")) throw new Error(`motivo virou inútil: ${saida}`);
+});
+
+Deno.test("REDAÇÃO — valor produzido pelo RUNTIME passa intacto (código HTTP é o motivo acionável)", () => {
+  assertEquals(mensagemFalhaOmie("vendas", "HTTP 503", "runtime"), "Omie (vendas): HTTP 503");
+});
+
+// ⚠️ A redação acontece ANTES da classificação (o throw redige, o catch classifica o texto já
+// redigido). Se mascarar dígito longo pudesse mudar a CLASSE, a política dependeria da ordem —
+// e o challenge do Codex mostrou exatamente isso na 1ª versão do padrão, sem a fronteira `(?!\d)`
+// (`"status 503123456"` era transitorio antes de redigir e indeterminada depois).
+Deno.test("INVARIANTE — redigir o segredo não muda a classe de nenhuma mensagem do corpus", () => {
+  const corpus = [...TRANSPORTE, ...ALARGAMENTO, ...BAIT.map(([m]) => m), "status 503123456 dentro do identificador"];
+  for (const msg of corpus) {
+    assertEquals(
+      classificarFaultstring(redigirSegredo(msg)),
+      classificarFaultstring(msg),
+      `a classe MUDOU ao redigir — a política passa a depender da ordem: ${msg}`,
+    );
+  }
+});
+
+// ── Gate de DELEGAÇÃO ──────────────────────────────────────────────────────────────────────────
+// ⚠️ Este gate NÃO prova comportamento — quem prova são os testes acima, que executam a política.
+// Ele só amarra o `index.ts` (não importável sob `--no-remote`) ao módulo testado, para que a
+// política não volte a ser reimplementada inline, onde nenhum teste a alcança. Medido com os
+// comentários REMOVIDOS: este arquivo e o `callOmie` citam a forma do bug de propósito, e um
+// predicado que lê a prosa acusa a documentação (money-path §"o ALVO mente").
 function semComentarios(fonte: string): string {
   return fonte
     .replace(/\/\*[\s\S]*?\*\//g, "")
@@ -157,52 +227,26 @@ function semComentarios(fonte: string): string {
     .join("\n");
 }
 
-const FONTE_EDGE = semComentarios(
-  await Deno.readTextFile(new URL("./index.ts", import.meta.url)),
-);
+const FONTE_EDGE = semComentarios(await Deno.readTextFile(new URL("./index.ts", import.meta.url)));
 
-Deno.test("GATE — o callOmie não classifica falha por código HTTP cru", () => {
-  const digitosCrus = FONTE_EDGE.match(/includes\(\s*["'](?:429|4\d\d|5\d\d)["']\s*\)/g);
-  if (digitosCrus) {
-    throw new Error(
-      `código HTTP CRU de volta na classificação (${digitosCrus.join(", ")}) — ele casa dentro da ` +
-        `app_key/idProduto que a mensagem ecoa. Use _shared/omie-falha.ts.`,
-    );
+Deno.test("GATE — o callOmie delega a política, em vez de reimplementá-la fora do alcance do teste", () => {
+  if (!/from\s+["']\.\/politica-retry\.ts["']/.test(FONTE_EDGE)) {
+    throw new Error("omie-analytics-sync parou de importar ./politica-retry.ts — a política saiu do alcance do teste");
   }
-});
-
-Deno.test("GATE — o callOmie delega a classificação ao helper canônico e retenta só o transitório", () => {
-  if (!/from\s+["']\.\.\/_shared\/omie-falha\.ts["']/.test(FONTE_EDGE)) {
-    throw new Error("omie-analytics-sync parou de importar _shared/omie-falha.ts");
+  // Os três pontos de delegação. `mensagemCorpoNaoJson` é o que mais importa amarrar aqui: ele é
+  // o único cujo COMPORTAMENTO os testes acima cobrem mas cuja CHAMADA depende de o `res.json()`
+  // continuar dentro de um try — e essa parte só existe no index.ts.
+  for (const simbolo of ["decidirRetentativaOmie", "mensagemFalhaOmie", "mensagemCorpoNaoJson"]) {
+    if (!new RegExp(`${simbolo}\\s*\\(`).test(FONTE_EDGE)) {
+      throw new Error(`o callOmie não chama mais \`${simbolo}\` — a decisão saiu do alcance do teste`);
+    }
   }
-  if (!FONTE_EDGE.includes('=== "transitorio"')) {
-    throw new Error(
-      'o callOmie não retenta mais por `=== "transitorio"` — a política de retentativa mudou sem ' +
-        "passar por este gate (indeterminada retentando estoura o orçamento do ConsultarEstrutura)",
-    );
-  }
-});
-
-Deno.test("GATE — todo texto PRODUZIDO PELO OMIE é redigido antes de sair da edge", () => {
-  // A faultstring de credencial ECOA a app_key, e daqui ela vai para `sync_state.error_message`
-  // (persistido), para o console e para o corpo da resposta 500. Redigir no THROW cobre os três.
-  //
-  // O alvo é o texto que o OMIE produz (`result.faultstring`, `result.faultcode`) — terceiro, e
-  // sobre texto de terceiro não se afirma "não tem segredo" sem verificar quem o escreve
-  // (money-path §"Garantia de PRIVACIDADE afirmada sem verificar o SINK"). `res.status` fica de
-  // fora de propósito: é um número do runtime, e redigi-lo seria código morto sugerindo um risco
-  // que não existe — gate não pode ditar código pior do que o que ele protege.
-  const throwsOmie = FONTE_EDGE.match(/throw new Error\(`Omie[^`]*`\)/g) ?? [];
-  const throwsComTextoDoOmie = throwsOmie.filter((t) => t.includes("result."));
-  if (throwsComTextoDoOmie.length < 2) {
-    throw new Error(
-      `o gate perdeu o alvo: esperava >= 2 throws com texto do Omie (faultstring, faultcode), achei ${throwsComTextoDoOmie.length}`,
-    );
-  }
-  const semRedacao = throwsComTextoDoOmie.filter((t) => !t.includes("redigirSegredo"));
-  if (semRedacao.length > 0) {
-    throw new Error(
-      `mensagem do Omie saindo CRUA da edge (${semRedacao.length}): ${semRedacao.join(" | ")}`,
-    );
+  // Classificar/atrasar por conta própria é o que este PR remove; reintroduzir devolve a decisão
+  // para um arquivo que nenhum teste consegue importar.
+  const inline = FONTE_EDGE.match(
+    /classificarFaultstring\s*\(|atrasoRetentativaMs\s*\(|includes\(\s*["']\d{3}["']\s*\)|\/[^\n/]*\b\d{3}\b[^\n/]*\/\s*\.test\(/g,
+  );
+  if (inline) {
+    throw new Error(`classificação/atraso reimplementados dentro da edge (${inline.join(", ")}) — mova para politica-retry.ts`);
   }
 });

--- a/supabase/functions/omie-analytics-sync/politica-retry_test.ts
+++ b/supabase/functions/omie-analytics-sync/politica-retry_test.ts
@@ -1,0 +1,208 @@
+// Política de retentativa do `callOmie` (omie-analytics-sync) — prova de EQUIVALÊNCIA.
+// Roda com: deno test --no-remote --allow-read=supabase/functions supabase/functions/omie-analytics-sync/
+//
+// ── O que este arquivo protege ────────────────────────────────────────────────────────────────
+// O `callOmie` classificava falha do Omie com marcadores de texto PRÓPRIOS, contendo os códigos
+// HTTP CRUS ("502"/"503"/"504"/"500"/"429"). Dois defeitos, os dois já resolvidos no helper
+// canônico `_shared/omie-falha.ts`:
+//   1. dígito solto casa DENTRO do identificador que a própria mensagem ecoa (money-path
+//      §"O MARCADOR mente", #1614) — a app_key e o idProduto contêm 503;
+//   2. a enumeração à mão de 5xx não cobre 501/505/520 (challenge Codex do #1623).
+// Trocar um classificador por outro num caminho com 7 crons ativos exige mais do que "o helper é
+// melhor": exige que NENHUMA falha de transporte que retentava antes deixe de retentar. É essa
+// implicação que os testes abaixo medem, mais o gate de fonte que impede a volta do dígito cru.
+//
+// Este teste não importa o `index.ts` (ele traz `https://deno.land/...` e `npm:`, e `test:edges`
+// roda com `--no-remote`): a lógica sob teste é a do helper puro, e o WIRING é medido lendo o
+// FONTE — o mesmo padrão do `paginacao-artesanal-gate` (money-path §9).
+import { atrasoRetentativaMs, classificarFaultstring } from "../_shared/omie-falha.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+/**
+ * Réplica FIEL do classificador ad-hoc que este PR REMOVE (fonte: `callOmie`, index.ts, pré-fix).
+ *
+ * Não é um helper espelhado — é um artefato HISTÓRICO congelado: o código que ele copia deixa de
+ * existir no mesmo commit, então não há do que divergir. Ele existe para que a afirmação "quem
+ * retentava continua retentando" seja MEDIDA contra o comportamento real de ontem, e não afirmada
+ * de memória.
+ */
+function transitorioLegado(mensagem: string): boolean {
+  const msg = mensagem.toLowerCase();
+  return msg.includes("broken response") || msg.includes("soap-error") ||
+    msg.includes("timeout") || msg.includes("timed out") || msg.includes("network") ||
+    msg.includes("connection") || msg.includes("fetch failed") ||
+    msg.includes("502") || msg.includes("503") || msg.includes("504") || msg.includes("500") ||
+    msg.includes("429") || msg.includes("too many") || msg.includes("rate limit");
+}
+
+// Falhas de TRANSPORTE reais, na forma exata em que o `callOmie` as emite (`Omie (<conta>): …`)
+// ou em que o runtime as lança. Toda linha daqui retentava ontem e TEM de retentar hoje.
+const TRANSPORTE = [
+  "Omie (vendas): SOAP-ERROR: Broken response from Application Server",
+  "Omie (servicos): Timeout na consulta",
+  "Omie (colacor_vendas): HTTP 500",
+  "Omie (vendas): HTTP 502",
+  "Omie (vendas): HTTP 503",
+  "Omie (vendas): HTTP 504",
+  "Omie (vendas): HTTP 429",
+  "Omie (vendas): Rate limit atingido",
+  "Omie (vendas): too many requests",
+  "error sending request for url (https://app.omie.com.br/api/v1/geral/produtos/): connection closed",
+  "TypeError: network error",
+  "fetch failed",
+];
+
+// Transporte que o classificador ad-hoc NÃO reconhecia e passa a retentar. Direção segura (o
+// caro é declarar permanente sem prova), e nenhuma delas é falha de negócio: são as formas em
+// que o próprio Omie pede espera ("Aguarde", "consumo redundante") ou em que o gateway responde.
+const ALARGAMENTO = [
+  "Omie (vendas): Ja existe uma requisicao desse metodo em andamento, aguarde",
+  "Omie (vendas): ERROR: Consumo redundante detectado",
+  "Omie (vendas): Service Unavailable",
+  "Omie (vendas): Bad Gateway",
+  "TypeError: error sending request",
+  "ECONNRESET",
+];
+
+// ⚠️ A implicação que autoriza a troca. Não é "as duas listas são iguais" (não são, e não podem
+// ser — a desigualdade é o conserto): é "o conjunto que RETENTAVA não encolheu por transporte".
+Deno.test("EQUIVALÊNCIA — toda falha de transporte que retentava no classificador ad-hoc segue retentando", () => {
+  for (const msg of TRANSPORTE) {
+    assertEquals(
+      transitorioLegado(msg),
+      true,
+      `fixture inválida: o classificador ANTIGO não retentava isto — o corpus não mede o que promete: ${msg}`,
+    );
+    assertEquals(
+      classificarFaultstring(msg),
+      "transitorio",
+      `REGRESSÃO: retentava ontem e não retenta hoje — transitório virando falha diária: ${msg}`,
+    );
+  }
+});
+
+Deno.test("ALARGAMENTO — transporte que o classificador ad-hoc não reconhecia passa a retentar", () => {
+  for (const msg of ALARGAMENTO) {
+    assertEquals(
+      transitorioLegado(msg),
+      false,
+      `fixture inválida: o classificador ANTIGO já retentava isto — não é alargamento: ${msg}`,
+    );
+    assertEquals(classificarFaultstring(msg), "transitorio", `deixou de ser reconhecido: ${msg}`);
+  }
+});
+
+// As ÚNICAS mensagens que deixam de retentar — e cada uma é o defeito sendo consertado, não um
+// efeito colateral. `transitorioLegado === true` aqui é a prova de que o bug existia de fato.
+Deno.test("O CONSERTO — dígito ecoado dentro de identificador para de comprar 4 tentativas", () => {
+  const bait: Array<[string, string]> = [
+    // A família de mensagem de credencial MAIS comum do Omie: a app_key contém 503.
+    ["Omie (vendas): Chave de acesso não cadastrada para o aplicativo [1503123456]", "permanente"],
+    ["Omie (servicos): app_key [4290384756] inválida", "permanente"],
+    // Mesma armadilha, outra família: o idProduto ecoado. É o caminho do `ConsultarEstrutura`,
+    // onde 825 produtos JÁ falham por ciclo em produção (medido 2026-07-31) — os que por acaso
+    // carregam 500/502/503/504/429 no código queimavam 4 chamadas cada, por acidente de dígito.
+    ["Omie (colacor_vendas): idProduto=1503498712 nao possui estrutura", "indeterminada"],
+    ["Omie (colacor_vendas): Produto 1502938475 sem malha cadastrada", "indeterminada"],
+  ];
+  for (const [msg, esperado] of bait) {
+    assertEquals(
+      transitorioLegado(msg),
+      true,
+      `fixture inválida: se o classificador ANTIGO já não retentava isto, não há defeito a consertar: ${msg}`,
+    );
+    assertEquals(classificarFaultstring(msg), esperado, `classe errada para: ${msg}`);
+  }
+});
+
+// Defeito 2: 5xx fora da enumeração à mão abortava na 1ª tentativa, SEM backoff.
+Deno.test("O CONSERTO — 5xx de gateway/CDN (501/505/520) passa a ganhar backoff", () => {
+  for (const codigo of [501, 505, 520, 521, 522]) {
+    const msg = `Omie (vendas): HTTP ${codigo}`;
+    assertEquals(
+      transitorioLegado(msg),
+      false,
+      `fixture inválida: o classificador ANTIGO já retentava ${codigo} — não há defeito a consertar`,
+    );
+    assertEquals(classificarFaultstring(msg), "transitorio", `HTTP ${codigo} tinha de retentar`);
+  }
+});
+
+// O backoff é parte do contrato que não pode mudar: o `callOmie` dormia `800 * 2^(n-1)` ms.
+Deno.test("EQUIVALÊNCIA — o backoff do helper reproduz os 0,8s / 1,6s / 3,2s do callOmie", () => {
+  for (let tentativa = 1; tentativa <= 3; tentativa++) {
+    assertEquals(
+      atrasoRetentativaMs(tentativa),
+      800 * Math.pow(2, tentativa - 1),
+      `backoff divergiu na tentativa ${tentativa}`,
+    );
+  }
+});
+
+// ── Gate de FONTE: o wiring ────────────────────────────────────────────────────────────────────
+// Os testes acima provam o que o HELPER decide; nada neles prova que a edge o CONSULTA. Sem este
+// gate, alguém reintroduz o dígito cru no `callOmie` e a suíte inteira segue verde.
+// Medido com os comentários REMOVIDOS — este arquivo e o próprio `callOmie` citam a forma do bug
+// de propósito, e um predicado que lê a prosa acusa a documentação (money-path §"o ALVO mente").
+function semComentarios(fonte: string): string {
+  return fonte
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((linha) => !/^\s*\/\//.test(linha))
+    .join("\n");
+}
+
+const FONTE_EDGE = semComentarios(
+  await Deno.readTextFile(new URL("./index.ts", import.meta.url)),
+);
+
+Deno.test("GATE — o callOmie não classifica falha por código HTTP cru", () => {
+  const digitosCrus = FONTE_EDGE.match(/includes\(\s*["'](?:429|4\d\d|5\d\d)["']\s*\)/g);
+  if (digitosCrus) {
+    throw new Error(
+      `código HTTP CRU de volta na classificação (${digitosCrus.join(", ")}) — ele casa dentro da ` +
+        `app_key/idProduto que a mensagem ecoa. Use _shared/omie-falha.ts.`,
+    );
+  }
+});
+
+Deno.test("GATE — o callOmie delega a classificação ao helper canônico e retenta só o transitório", () => {
+  if (!/from\s+["']\.\.\/_shared\/omie-falha\.ts["']/.test(FONTE_EDGE)) {
+    throw new Error("omie-analytics-sync parou de importar _shared/omie-falha.ts");
+  }
+  if (!FONTE_EDGE.includes('=== "transitorio"')) {
+    throw new Error(
+      'o callOmie não retenta mais por `=== "transitorio"` — a política de retentativa mudou sem ' +
+        "passar por este gate (indeterminada retentando estoura o orçamento do ConsultarEstrutura)",
+    );
+  }
+});
+
+Deno.test("GATE — todo texto PRODUZIDO PELO OMIE é redigido antes de sair da edge", () => {
+  // A faultstring de credencial ECOA a app_key, e daqui ela vai para `sync_state.error_message`
+  // (persistido), para o console e para o corpo da resposta 500. Redigir no THROW cobre os três.
+  //
+  // O alvo é o texto que o OMIE produz (`result.faultstring`, `result.faultcode`) — terceiro, e
+  // sobre texto de terceiro não se afirma "não tem segredo" sem verificar quem o escreve
+  // (money-path §"Garantia de PRIVACIDADE afirmada sem verificar o SINK"). `res.status` fica de
+  // fora de propósito: é um número do runtime, e redigi-lo seria código morto sugerindo um risco
+  // que não existe — gate não pode ditar código pior do que o que ele protege.
+  const throwsOmie = FONTE_EDGE.match(/throw new Error\(`Omie[^`]*`\)/g) ?? [];
+  const throwsComTextoDoOmie = throwsOmie.filter((t) => t.includes("result."));
+  if (throwsComTextoDoOmie.length < 2) {
+    throw new Error(
+      `o gate perdeu o alvo: esperava >= 2 throws com texto do Omie (faultstring, faultcode), achei ${throwsComTextoDoOmie.length}`,
+    );
+  }
+  const semRedacao = throwsComTextoDoOmie.filter((t) => !t.includes("redigirSegredo"));
+  if (semRedacao.length > 0) {
+    throw new Error(
+      `mensagem do Omie saindo CRUA da edge (${semRedacao.length}): ${semRedacao.join(" | ")}`,
+    );
+  }
+});


### PR DESCRIPTION
## O defeito

O `callOmie` do `omie-analytics-sync` (7 crons ativos — caminho quente de sync) classificava falha do Omie com marcadores de texto próprios, contendo os **códigos HTTP crus**:

```ts
msg.includes("502") || msg.includes("503") || msg.includes("504") || msg.includes("500") || msg.includes("429")
```

**1. O dígito solto casa DENTRO do identificador que a mensagem ecoa** — money-path §"O MARCADOR mente" (#1614). `"Chave de acesso não cadastrada para o aplicativo [1503123456]"`, a mensagem de credencial mais comum do Omie, contém `503` na app_key: o erro **permanente mais frequente** era classificado como transitório e comprava as 4 tentativas.

Segunda família, que o #1614 não citava: **o `idProduto` ecoado pelo `ConsultarEstrutura`**. Medido em produção 2026-07-31 — 825 dos ~1.334 alvos falham por ciclo (`custo_producao_status='erro_api'`), e os que por acaso carregam `500`/`502`/`503`/`504`/`429` no código queimavam 4 chamadas cada, por acidente de dígito.

**2. Enumeração incompleta de 5xx** — só 500/502/503/504, então 501/505/520 (gateway/CDN) abortavam na 1ª tentativa sem backoff (challenge Codex do #1623).

## A mudança

- **Helper** (`_shared/omie-falha.ts`): as 10 entradas literais ancoradas viraram um padrão único — `/\b(?:http|status)(?:\s+code)?:?\s+(?:429|5\d\d)(?!\d)/`. Cobre todo 5xx sem afrouxar a âncora que separa "código HTTP" de "dígito dentro de identificador".
- **Política** (`omie-analytics-sync/politica-retry.ts`, **novo**): módulo PURO com a decisão de retentativa e a construção da mensagem redigida. O `index.ts` não é importável por teste (traz `deno.land` e `npm:`, e a suíte roda `--no-remote`) — então a decisão de money-path mora onde o teste a **executa**.
- **`redigirSegredo`** no texto produzido pelo Omie (`faultstring`, `faultcode`). Ele ia cru para três sinks: `sync_state.error_message` (**persistido**), o `console.error` do laço de custo e o corpo da resposta 500. `res.status` fica de fora de propósito — é número do runtime; redigi-lo seria código morto sugerindo um risco inexistente.

## Equivalência de retry (a afirmação que autoriza a troca)

Não é "as duas listas são iguais" — a desigualdade **é** o conserto. É **"o conjunto que retentava não encolheu por transporte"**, e isso é medido contra uma réplica congelada do classificador antigo (artefato histórico: o código que ela copia deixa de existir neste commit).

| | antes | depois |
|---|---|---|
| Transporte (SOAP-ERROR, timeout, connection, HTTP 5xx/429, corpo não-JSON de gateway) | retenta | **retenta** |
| Credencial com app_key contendo 503 | retenta (bug) | falha rápido |
| Fault de negócio com id contendo 503 | retenta (bug) | falha rápido |
| HTTP 501/505/520 | aborta na 1ª | **retenta** |
| "Aguarde"/"consumo redundante"/ECONNRESET | aborta na 1ª | **retenta** |

Backoff idêntico: **0,8s / 1,6s / 3,2s**.

## Política de retry — divergência deliberada de `decidirDesfechoFalha`

Retenta **só `transitorio`**; `indeterminada` falha rápido, como antes. A política do helper (onde indeterminada retenta) vale para retry **por página**, onde desistir custa uma conta inteira. Aqui o `ConsultarEstrutura` roda **por produto** em lotes de 8, e o sleep é pago por lote com ao menos uma falha: retentar indeterminada custaria entre `ceil(825/8) × 5,6s ≈ 582s` e `ceil(1334/8) × 5,6s ≈ 935s`, contra ~150s de orçamento do worker. Trocaria uma falha parcial **reportada** pelo `WORKER_RESOURCE_LIMIT` que o lote paralelo existe para evitar, com o `sync_state` preso em `'running'`.

## Ritual /codex (money-path) — 3 P1 + 3 P2, todos procedentes

O challenge (gpt-5.6-sol, xhigh) derrubou a 1ª versão. O que ele achou:

1. **P1 — 5xx com corpo não-JSON perdeu o retry.** `res.json()` roda antes do guard de `res.ok`; um 503 de gateway com corpo de texto estoura no parser, e a mensagem do parser ecoa o corpo (`Unexpected token 'E', "ERROR 503"…`). O legado via o `503` ali e retentava. Regressão real → `mensagemCorpoNaoJson` ancora o status quando o corpo não parseia.
2. **P1 — os 3 gates de fonte eram token checks.** Ele passou pelos três com mutações triviais. Correção: a política virou módulo puro e os testes medem comportamento; sobrou um único gate de **delegação**, que declara não provar comportamento.
3. **P1 — honrar "Aguarde N segundos" alongava o sleep** (5,6s → 10,5s, ou 15s com "Aguarde 90"; o teto de 5s é por tentativa). Era escopo que eu adicionei sem pedido — removido, com teste pinando a decisão.
4. **P2** — a conta de 578s era limite inferior (faixa real 582–935s); o padrão não tinha fronteiras (`\b`, `(?!\d)`, `status code`); em `omie-sync` o efeito é **bloquear** deleção de OS (direção segura), e em `omie-cliente` um 501 vai de 2 para 6 chamadas (bounded, correto).

## Prova

- **38 testes** — equivalência contra a réplica congelada, alargamento, o conserto, teto, redação, e o invariante de que **redigir não muda a classe** (a redação acontece antes da classificação).
- **8 sabotagens → 8 vermelhos**, incluindo as 3 mutações do Codex. Duas tentativas foram **inertes por acertarem o comentário** que cita a forma do bug, não o código — diagnosticadas antes de concluir (§"A FALSIFICAÇÃO mente").

## Gates (exit capturado)

| gate | exit | resultado |
|---|---|---|
| `heavy bun run test` | 0 | 641 arquivos · 5.874 testes |
| `bun run test:edges` | 0 | 508 passed |
| `bun run edges:typecheck` | 0 | 0 erros de classe-crash |
| `bun lint` | 0 | 0 erros |

## ⚠️ Deploy manual (Lovable) — edge alterada

`supabase/functions/omie-analytics-sync/index.ts` **e o novo** `supabase/functions/omie-analytics-sync/politica-retry.ts`, mais `supabase/functions/_shared/omie-falha.ts`.

**Deployar pelo chat do Lovable, verbatim da `main` pós-merge.** Sem frontend (`Publish`) e sem migration nesta entrega. Como `_shared/omie-falha.ts` muda, as edges que o importam (`omie-cliente`, `omie-sync`) também devem ser redeployadas para pegar a versão nova do helper.

## Fora de escopo (chip aberto)

`cmc-snapshot-smoke` e `cmc-snapshot-backfill` têm o bloco ad-hoc **idêntico**, com o agravante de marcadores acentuados (`"já existe uma requisição"`) casados contra texto só-minúsculo, sem normalização NFD.