### PR TITLE
fix(farmer): cobertura parcial do batch tático para de zerar sempre a mesma vendedora [money-path]

### DIFF
--- a/supabase/functions/_shared/tactical-ordem.ts
+++ b/supabase/functions/_shared/tactical-ordem.ts
@@ -1,0 +1,74 @@
+// Ordem de execução dos alvos do batch noturno de planos táticos.
+//
+// Lógica PURA extraída para caber no `--no-remote` do `test:edges`.
+// Testes (e o histórico do incidente) em tactical-ordem_test.ts.
+//
+// POR QUE EXISTE — o batch concatenava os grupos do Map por farmer (`[A...A, B...B, C...C]`),
+// e essa ordem era ACIDENTAL: vinha da primeira ocorrência de cada farmer na paginação por
+// customer_user_id. Qualquer cobertura parcial come o SUFIXO, então o último farmer da
+// concatenação nunca recebia nada — medido em prod: 9/15/0 (30/07) e 9/16/0 (31/07), com o
+// mesmo farmer zerado nos dois dias, e o precedente de 2026-07-21 ("uma vendedora inteira
+// ficou sem plano", ver tactical-batch-resultado.ts).
+//
+// Este módulo NÃO conserta o volume — cobertura parcial continua possível por timeout, 429
+// ou 402. Ele garante que, quando ela acontecer, a perda seja DISTRIBUÍDA: com round-robin,
+// um prefixo de 24 sobre 9/25/25 vira 8/8/8 em vez de 9/15/0.
+
+export interface CarteiraFarmer {
+  farmer: string;
+  /** Clientes JÁ ordenados pelo caller (priority desc, customer_user_id asc). */
+  clientes: string[];
+}
+
+export interface AlvoOrdenado {
+  farmer: string;
+  customer: string;
+}
+
+const MS_POR_DIA = 86_400_000;
+
+/**
+ * Deslocamento da rodada a partir do dia operacional (BRT), no formato `YYYY-MM-DD`.
+ *
+ * Quando o prefizo executado não é divisível pelo número de farmers, o(s) alvo(s) extra(s)
+ * vão para quem abre a rodada. Fixar esse "quem" beneficiaria sempre a mesma vendedora, então
+ * ele ROTACIONA por dia — +1 por dia, previsível o bastante para auditar depois.
+ *
+ * Estável DENTRO do mesmo dia de propósito: um retry do batch tem de reproduzir a mesma
+ * ordem, senão a janela de idempotência por dia operacional vira loteria.
+ *
+ * Data ilegível → 0 em vez de NaN: NaN viraria índice inválido e derrubaria o batch inteiro
+ * por causa de uma string, quando seguir sem rotação é degradação honesta.
+ */
+export function rotacaoDoDia(diaIso: string): number {
+  const ms = Date.parse(`${diaIso}T00:00:00Z`);
+  if (!Number.isFinite(ms)) return 0;
+  // Clamp em 0: data anterior à epoch daria índice negativo no array de farmers.
+  return Math.max(0, Math.floor(ms / MS_POR_DIA));
+}
+
+/**
+ * Intercala os alvos em round-robin: um cliente de cada farmer por rodada, preservando a
+ * ordem interna de cada carteira. Farmer que acaba antes simplesmente sai das rodadas
+ * seguintes — os demais continuam.
+ */
+export function intercalarPorFarmer(
+  carteiras: CarteiraFarmer[],
+  rotacao: number,
+): AlvoOrdenado[] {
+  if (carteiras.length === 0) return [];
+
+  // Módulo não-negativo: rotação negativa ou fracionária não pode virar índice inválido.
+  const desloc = ((Math.trunc(rotacao) % carteiras.length) + carteiras.length) % carteiras.length;
+  const ordem = carteiras.map((_, i) => carteiras[(i + desloc) % carteiras.length]);
+
+  const maior = Math.max(...ordem.map((c) => c.clientes.length));
+  const alvos: AlvoOrdenado[] = [];
+  for (let i = 0; i < maior; i++) {
+    for (const c of ordem) {
+      const customer = c.clientes[i];
+      if (customer !== undefined) alvos.push({ farmer: c.farmer, customer });
+    }
+  }
+  return alvos;
+}

--- a/supabase/functions/_shared/tactical-ordem_test.ts
+++ b/supabase/functions/_shared/tactical-ordem_test.ts
@@ -1,0 +1,165 @@
+// Testa o CÓDIGO REAL de tactical-ordem.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/tactical-ordem_test.ts
+//
+// POR QUE ESTE MÓDULO EXISTE — a cobertura PARCIAL do batch noturno não é hipótese, é
+// rotina, e ela cai SEMPRE na mesma pessoa:
+//   2026-07-21: "UMA VENDEDORA INTEIRA ficou sem plano" (ver tactical-batch-resultado.ts)
+//   2026-07-30: alvos 9/25/25 → gerados 9/15/0   (farmer 700657a1 zerado)
+//   2026-07-31: alvos 9/25/25 → gerados 9/16/0   (farmer 700657a1 zerado de novo)
+// A causa da CONCENTRAÇÃO é a ordem: o batch concatenava os grupos do Map
+// (`[A...A, B...B, C...C]`), então qualquer truncamento — timeout, 429, 402 — come o
+// sufixo inteiro e o ÚLTIMO farmer nunca recebe nada. A ordem era acidental: vinha da
+// primeira ocorrência de cada farmer na paginação por customer_user_id.
+//
+// Este módulo NÃO conserta o volume (isso é o batch retomável). Ele garante que, quando
+// a cobertura for parcial — e ela SEMPRE pode ser, por 429/402/queda —, a perda seja
+// distribuída em vez de recair inteira sobre uma vendedora.
+import { intercalarPorFarmer, rotacaoDoDia } from "./tactical-ordem.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+/** Conta quantos alvos de cada farmer caem num prefixo de tamanho `n`. */
+function contarNoPrefixo(alvos: Array<{ farmer: string; customer: string }>, n: number) {
+  const conta = new Map<string, number>();
+  for (const a of alvos.slice(0, n)) conta.set(a.farmer, (conta.get(a.farmer) ?? 0) + 1);
+  return conta;
+}
+
+function carteira(farmer: string, quantos: number) {
+  return {
+    farmer,
+    clientes: Array.from({ length: quantos }, (_, i) => `${farmer}-c${i + 1}`),
+  };
+}
+
+// ── intercalarPorFarmer ──────────────────────────────────────────────────────
+
+Deno.test("intercala em round-robin: um de cada farmer por rodada", () => {
+  const alvos = intercalarPorFarmer(
+    [carteira("A", 2), carteira("B", 2), carteira("C", 2)],
+    0,
+  );
+  assertEquals(alvos.map((a) => a.customer), [
+    "A-c1", "B-c1", "C-c1",
+    "A-c2", "B-c2", "C-c2",
+  ]);
+});
+
+Deno.test("preserva a ordem interna de cada farmer (priority desc já vem do caller)", () => {
+  const alvos = intercalarPorFarmer([carteira("A", 3), carteira("B", 3)], 0);
+  const soA = alvos.filter((a) => a.farmer === "A").map((a) => a.customer);
+  assertEquals(soA, ["A-c1", "A-c2", "A-c3"]);
+});
+
+Deno.test("farmer que acaba antes sai da rodada; os outros continuam", () => {
+  const alvos = intercalarPorFarmer([carteira("A", 1), carteira("B", 3)], 0);
+  assertEquals(alvos.map((a) => a.customer), ["A-c1", "B-c1", "B-c2", "B-c3"]);
+});
+
+Deno.test("nenhum alvo é perdido nem duplicado", () => {
+  const alvos = intercalarPorFarmer(
+    [carteira("A", 9), carteira("B", 25), carteira("C", 25)],
+    0,
+  );
+  assertEquals(alvos.length, 59);
+  assertEquals(new Set(alvos.map((a) => a.customer)).size, 59);
+});
+
+// ── A invariante que este módulo existe para garantir ────────────────────────
+
+Deno.test("prefixo de 24 sobre 9/25/25 distribui 8/8/8 — nenhum farmer zerado", () => {
+  const alvos = intercalarPorFarmer(
+    [carteira("A", 9), carteira("B", 25), carteira("C", 25)],
+    0,
+  );
+  const conta = contarNoPrefixo(alvos, 24);
+  assertEquals(conta.get("A"), 8);
+  assertEquals(conta.get("B"), 8);
+  assertEquals(conta.get("C"), 8);
+});
+
+Deno.test("o truncamento REAL de 30/07 (24 de 59) deixaria de zerar qualquer farmer", () => {
+  const alvos = intercalarPorFarmer(
+    [carteira("A", 9), carteira("B", 25), carteira("C", 25)],
+    0,
+  );
+  for (const f of ["A", "B", "C"]) {
+    const n = contarNoPrefixo(alvos, 24).get(f) ?? 0;
+    if (n === 0) throw new Error(`farmer ${f} ficou ZERADO no prefixo de 24 — regressão da concentração`);
+  }
+});
+
+Deno.test("prefixo indivisível por 3 dá o extra a um só farmer, e a rotação muda quem", () => {
+  const carteiras = [carteira("A", 9), carteira("B", 25), carteira("C", 25)];
+  const dia0 = contarNoPrefixo(intercalarPorFarmer(carteiras, 0), 25);
+  assertEquals([dia0.get("A"), dia0.get("B"), dia0.get("C")], [9, 8, 8]);
+
+  const dia1 = contarNoPrefixo(intercalarPorFarmer(carteiras, 1), 25);
+  assertEquals([dia1.get("A"), dia1.get("B"), dia1.get("C")], [8, 9, 8]);
+
+  const dia2 = contarNoPrefixo(intercalarPorFarmer(carteiras, 2), 25);
+  assertEquals([dia2.get("A"), dia2.get("B"), dia2.get("C")], [8, 8, 9]);
+});
+
+Deno.test("rotação é módulo: dia 3 volta ao mesmo beneficiário do dia 0", () => {
+  const carteiras = [carteira("A", 9), carteira("B", 25), carteira("C", 25)];
+  assertEquals(
+    intercalarPorFarmer(carteiras, 3).map((a) => a.customer),
+    intercalarPorFarmer(carteiras, 0).map((a) => a.customer),
+  );
+});
+
+// ── Bordas ───────────────────────────────────────────────────────────────────
+
+Deno.test("lista vazia devolve vazio (não lança)", () => {
+  assertEquals(intercalarPorFarmer([], 0), []);
+});
+
+Deno.test("farmer sem clientes não trava a rodada dos demais", () => {
+  const alvos = intercalarPorFarmer([carteira("A", 0), carteira("B", 2)], 0);
+  assertEquals(alvos.map((a) => a.customer), ["B-c1", "B-c2"]);
+});
+
+Deno.test("um único farmer degenera para a própria ordem", () => {
+  const alvos = intercalarPorFarmer([carteira("A", 3)], 0);
+  assertEquals(alvos.map((a) => a.customer), ["A-c1", "A-c2", "A-c3"]);
+});
+
+Deno.test("rotação não perde nem duplica alvo em nenhum deslocamento", () => {
+  const carteiras = [carteira("A", 9), carteira("B", 25), carteira("C", 25)];
+  for (let r = 0; r < 6; r++) {
+    const alvos = intercalarPorFarmer(carteiras, r);
+    assertEquals(alvos.length, 59, `rotacao ${r} perdeu alvo`);
+    assertEquals(new Set(alvos.map((a) => a.customer)).size, 59, `rotacao ${r} duplicou alvo`);
+  }
+});
+
+// ── rotacaoDoDia ─────────────────────────────────────────────────────────────
+// Deriva o deslocamento do DIA OPERACIONAL. Precisa ser estável dentro do mesmo dia
+// (senão um retry do batch reordena e a idempotência por dia vira loteria) e mudar
+// entre dias (senão o mesmo farmer leva o extra para sempre).
+
+Deno.test("rotação é estável dentro do mesmo dia operacional", () => {
+  assertEquals(rotacaoDoDia("2026-07-31"), rotacaoDoDia("2026-07-31"));
+});
+
+Deno.test("rotação muda entre dias consecutivos", () => {
+  const a = rotacaoDoDia("2026-07-31");
+  const b = rotacaoDoDia("2026-08-01");
+  if (a === b) throw new Error("dias consecutivos deram a mesma rotação — o extra ficaria fixo");
+});
+
+Deno.test("rotação avança de 1 por dia (previsível para auditar)", () => {
+  const d0 = rotacaoDoDia("2026-07-31");
+  assertEquals(rotacaoDoDia("2026-08-01"), d0 + 1);
+  assertEquals(rotacaoDoDia("2026-08-02"), d0 + 2);
+});
+
+Deno.test("rotação é não-negativa mesmo para data anterior à epoch", () => {
+  const r = rotacaoDoDia("1969-12-31");
+  if (r < 0) throw new Error(`rotação negativa (${r}) — o índice do array sairia da faixa`);
+});

--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -12,6 +12,11 @@
 // Semântica top-N: filtra o gate ANTES de cortar no TOP_25 — pega os 25 de
 // maior priority DENTRE os que passam (não os 25 de maior priority e filtra depois).
 //
+// Ordem de EXECUÇÃO: round-robin entre farmers (_shared/tactical-ordem.ts), não a
+// concatenação dos grupos. Cobertura parcial é rotina (timeout/429/402) e sempre come o
+// SUFIXO — com a concatenação, o último farmer ficava zerado (9/15/0 em 30/07, 9/16/0 em
+// 31/07, o mesmo farmer). Intercalado, um prefixo de 24 sobre 9/25/25 dá 8/8/8.
+//
 // Margem AUSENTE não é margem zero (money-path princípio 2): sem margem o gate de R$/h
 // não é decidível, então o cliente sai do ranking e é CONTADO em `sem_margem_indecidivel`.
 // Antes, `Number(null ?? 0)` fabricava R$ 0/h — indistinguível de um cliente de margem
@@ -65,6 +70,12 @@ import {
   type Classificacao,
   classificarAlvo,
 } from '../_shared/tactical-batch-resultado.ts';
+import {
+  type CarteiraFarmer,
+  intercalarPorFarmer,
+  rotacaoDoDia,
+} from '../_shared/tactical-ordem.ts';
+import { inicioDiaOperacional } from '../_shared/dia-operacional.ts';
 
 const TOP_N = 25;
 const CONCURRENCY = 5; // cada chamada faz 1 LLM (~3-5s); 5 em paralelo ~5s/chunk
@@ -175,14 +186,27 @@ Deno.serve(async (req) => {
 
   // 2. Por farmer: ordena por priority desc, filtra gate R$/h, corta em TOP_N.
   //    Semântica: pega os 25 de maior priority DENTRE os que passam no gate.
-  const alvos: Array<{ farmer: string; customer: string }> = [];
+  const carteiras: CarteiraFarmer[] = [];
   let semMargemIndecidivel = 0;
 
   for (const [farmer, scores] of porFarmer) {
     const { selecionados, semMargem } = selecionarParaPregeracao(scores, TOP_N);
     semMargemIndecidivel += semMargem.length;
-    for (const s of selecionados) alvos.push({ farmer, customer: s.customer });
+    carteiras.push({ farmer, clientes: selecionados.map((s) => s.customer) });
   }
+
+  // 2b. ORDEM DE EXECUÇÃO em round-robin entre farmers (_shared/tactical-ordem.ts, testado).
+  //     Antes: concatenação dos grupos do Map (`[A...A, B...B, C...C]`), com a ordem vindo
+  //     da 1ª ocorrência de cada farmer na paginação por customer_user_id — acidental.
+  //     Como toda cobertura parcial come o SUFIXO, o último farmer da concatenação ficava
+  //     ZERADO: medido 9/15/0 em 30/07 e 9/16/0 em 31/07, o MESMO farmer nos dois dias
+  //     (e o precedente de 2026-07-21, "uma vendedora inteira sem plano").
+  //     Isto NÃO conserta o volume — o batch continua podendo truncar por timeout/429/402.
+  //     Conserta a DISTRIBUIÇÃO: um prefixo de 24 sobre 9/25/25 agora dá 8/8/8.
+  //     O dia operacional é BRT (mesma régua da idempotência): 00:00 BRT = 03:00 UTC do
+  //     mesmo dia, então o slice(0,10) do instante devolvido é o dia BRT correto.
+  const diaOperacional = inicioDiaOperacional(new Date()).slice(0, 10);
+  const alvos = intercalarPorFarmer(carteiras, rotacaoDoDia(diaOperacional));
 
   // 3. Fan-out concorrente em chunks de 5. Idempotência é na edge alvo.
   //    A classificação/agregação vive em _shared/tactical-batch-resultado.ts (testada):


### PR DESCRIPTION
## O que estava errado

O batch noturno montava os alvos concatenando os grupos do `Map` por farmer (`[A...A, B...B, C...C]`). Essa ordem era **acidental** — vinha da 1ª ocorrência de cada farmer na paginação por `customer_user_id`. Como toda cobertura parcial come o **sufixo**, o último farmer da concatenação nunca recebia nada.

## Evidência (produção, via psql-ro)

Alvos esperados reproduzidos a partir do estado exato que o batch leu — os crons de recálculo (06:00/07:30 UTC) são anteriores ao batch (08:00 UTC), então as tabelas de entrada ainda estavam intactas na hora da medição:

| dia | alvos | gerados | farmer zerado |
|---|---|---|---|
| 30/07 | 9/25/25 (59) | 9/15/0 (24) | `700657a1` |
| 31/07 | 9/25/25 (59) | 9/16/0 (25) | `700657a1` |

Não é rejeição: em 31/07 os **25 alvos tentados geraram 25 planos**. O corte é posicional — a reconstrução chunk a chunk (`CONCURRENCY = 5`) bate 24/24 e 25/25, com os planos formando um prefixo limpo por rank de priority.

Precedente da mesma classe em 2026-07-21, já documentado em `_shared/tactical-batch-resultado.ts`: *"uma vendedora inteira ficou sem plano"*.

## O que este PR NÃO faz

**Não conserta o volume.** O batch continua truncando: precisa de ~600s e morre entre 281s e 297s (interseção medida nos dois dias), porque cada chunk passou de ~9s para ~45s na migração do gateway Lovable para a Anthropic. Isso é o batch retomável, que vai em separado.

O que muda aqui é que a cobertura parcial deixa de ser **concentrada**. Com round-robin, um prefixo de 24 sobre 9/25/25 vira **8/8/8**. Quando o prefixo não divide pelo número de farmers, o extra vai para quem abre a rodada — e esse "quem" rotaciona por dia operacional (BRT, a mesma régua da idempotência), para não beneficiar sempre a mesma pessoa.

Cobertura parcial continua possível por 429/402/queda mesmo depois do batch retomável, então a ordem justa vale por si.

## O que não muda

Seleção intocada: gate de R$/h, `TOP_N`, allowlist de elegíveis, `sem_margem_indecidivel`. A ordem interna de cada carteira (`priority desc, customer_user_id asc`) é preservada. O gate de suficiência 422 do #1618 não é tocado.

## Testes

Lógica pura em `_shared/tactical-ordem.ts` para caber no `--no-remote` do `test:edges`. 16 testes, incluindo o cenário real de 30/07 e as bordas (farmer que acaba antes, carteira vazia, farmer único, rotação em todos os deslocamentos).

**Falsificados**: com a concatenação de volta, os 4 testes de distribuição ficam vermelhos — round-robin, prefixo 8/8/8, "não zera ninguém" e rotação do extra.

Gates: `test:edges` 579/579 · `edges:typecheck` 0 crash · `lint` 0 erros.

## ⚠️ Deploy

Mergear **não** coloca isto em produção — `tactical-plans-batch` é edge e precisa de deploy manual pelo chat do Lovable, verbatim do repo. Sem migration neste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Próxima fatia (handoff)

# Handoff — batch tático retomável (fase 3: VOLUME)

## 1. Objetivo desta sessão (UMA entrega)

Entregar o **batch noturno de planos táticos retomável**, mergeado e deployado, de modo que
os **59 alvos/dia** sejam gerados. Hoje saem **25**.

Fora de escopo (não puxe para cá): mexer no gate de suficiência 422, mudar o produto do plano
(modo essencial / max_tokens), canonicalizar histórico de cliente.

## 2. Estado na main (verificado agora)

- `origin/main` = **bcfc6a55**
- PRs já mergeados que importam:
  - **#1645** (bcfc6a55) — round-robin entre farmers na ordem de execução. **Já feito, reutilize.**
  - **#1642** (273db6d8) — idempotência estrutural por dia operacional + bundle honesto.
    **Migration APLICADA em prod e validada** (índice único · defaults removidos · RPC recusa duplicata).
  - **#1618** (5a0f2192) — migração do gateway Lovable para a Anthropic direta. **É a causa da lentidão.**

```bash
git log --oneline -6 origin/main -- supabase/functions/tactical-plans-batch supabase/functions/generate-tactical-plan supabase/functions/_shared
```

## 3. Arquivos/funções-chave

| caminho | papel |
|---|---|
| `supabase/functions/tactical-plans-batch/index.ts` | o batch a reescrever em modo `tick` |
| `supabase/functions/generate-tactical-plan/index.ts` | edge por alvo; **linhas ~163-180** = paginação de pares (ver §4) |
| `supabase/functions/_shared/tactical-ordem.ts` | round-robin + rotação do dia — **pronto, 16 testes** |
| `supabase/functions/_shared/tactical-margem.ts` | `selecionarParaPregeracao`, gate R$/h, `calcularClusterMargin` |
| `supabase/functions/_shared/tactical-batch-resultado.ts` | `classificarAlvo` / `agregar` (ok ≠ true com erro) |
| `supabase/functions/_shared/dia-operacional.ts` | dia BRT — régua da idempotência |

Ler ANTES: `docs/agent/money-path.md` · `docs/agent/sync.md` (cron/net._http_response) ·
`docs/historico/ci-testes-edge-deno.md` (por que `test:edges` não type-checa `index.ts`).

## 4. Decisões já tomadas (NÃO re-litigar)

**Diagnóstico fechado com evidência** — o batch trunca por tempo, não por rejeição:
- Alvos/dia = **59** (9 / 25 / 25). Reproduzido em SQL a partir do estado exato que o batch leu.
- Gerados: **24** (30/07) e **25** (31/07). Corte **posicional**, não por alvo — reconstrução
  chunk a chunk (`CONCURRENCY=5`) bate 24/24 e 25/25. Em 31/07, **25 de 25 alvos tentados
  geraram plano: zero rejeições do gate**.
- Cadência: **~9s/chunk** (gateway/Gemini) → **~45-49s/chunk** (Anthropic). Precisa ~600s.
- Morte observada entre **281s e 297s** (interseção dos dois dias).
- `pg_net` estoura em **150s** → a resposta vem com `content` NULL e
  `error_msg="Timeout of 150000 ms reached"`. **O resumo (`erros_por_motivo`) é inalcançável hoje.**
- O batch **não** registra execução durável (`acoes_execucoes` vazia para ele).

**Remédio escolhido — opção F (parecer /codex gpt-5.6-sol xhigh):** batch **retomável** com
snapshot durável dos alvos + workers de ≤5 itens acionados pelo mesmo cron (`*/2 8 * * *`).
Primeiro tick pagina/seleciona uma vez e grava run + itens atomicamente; ticks seguintes fazem
**claim atômico** de ≤5 itens, processam e persistem por item. ~24 min no total, `CONCURRENCY=5`
mantido. Tabelas `batch_runs` + `batch_items` com RPCs transacionais; ledger **fail-closed**
(não registrou o alvo → não chama a IA).

**Opções descartadas, com o motivo:**
- **A (subir concorrência p/ 25-30)** — cada `generate-tactical-plan` **pagina a carteira inteira
  do farmer** para o cluster de margem (até **3.858 linhas = 4 páginas PostgREST por chamada**).
  Multiplicar por 25-30 vira tempestade de banco, além do 429. E o resumo continua fora dos 150s.
- **B (`202` + `waitUntil`)** — `waitUntil` **não** amplia o wall-clock; promise morre com o worker.
  Útil só como transporte.
- **C (um cron por farmer)** — ~315s por farmer, acima da morte observada; repete as duas
  paginações 3×; não produz agregado único.
- **D (modo essencial / baixar max_tokens)** — muda o **produto** que a vendedora lê. Exige decisão
  de produto, não é remédio de incidente.
- **E (auto-encadeamento por offset)** — offset sobre lista recalculada pula/duplica alvo.
- **PGMQ/Supabase Queues** — não vale ativar outro módulo para 59 itens/dia.

**Invariantes que NÃO se afrouxam:**
- Gate de suficiência 422 (`montarPlano`, `!approach || perguntas.length === 0`) — fechou o P2
  do plano fabricado. **Precisão > recall.** Ele não é a causa do volume.
- `ok` do agregado é falso se houver erro (nunca `ok:true` com cobertura parcial).
- Sem corte silencioso: cobertura parcial tem de ficar VISÍVEL no resumo persistido.

**Ordem de deploy da fase 3 (oposta à do #1642):** **edge ANTES da migration**. A migration
reagenda o cron para `*/2`; se ela for primeiro, o batch monolítico atual rodaria 30×. A edge
nova deve aceitar temporariamente o body antigo.

**Otimização a fazer junto** (exata, não aproximada): o cluster de margem relê a carteira do
farmer a cada chamada — **136 requisições paginadas por noite** para uma média que só difere por
excluir uma linha. Some `S` e conte `N` das margens conhecidas **uma vez por farmer**, e por
cliente use `(S − mᵢ)/(N − 1)` quando a margem dele é conhecida, `S/N` quando não. **136 → 3.**
Cuidado: esse número é a RÉGUA do veredito de margem — exige teste de paridade com fixtures.

## 5. Validações a rodar (a prova da entrega)

```bash
heavy bun run test:edges        # suíte Deno, --no-remote: teste de edge NÃO pode ter import remoto
heavy bun run edges:typecheck   # o único gate que enxerga erro de tipo em index.ts
heavy bun run audit:migrations
heavy bun run lint && heavy bun run typecheck && heavy bun run test
```

Money-path: as RPCs de claim/finalização vão para a skill **`prove-sql-money-path`** (PG17 local),
com asserts positivos E negativos + **falsificação** (sabotar → exigir vermelho). PL/pgSQL é
late-bound: `CREATE` passa e só falha em RUNTIME. Provar concorrência de verdade: dois claimers
simultâneos recebem conjuntos **disjuntos**; lease abandonado expira e é reclamado; finalização
parcial é recusada.

Prova em produção, no dia seguinte ao deploy:

```bash
~/.config/afiacao/psql-ro -c "select left(farmer_id::text,8) farmer, count(*) from farmer_tactical_plans where created_at::date = current_date and created_at::time between '08:00' and '08:40' group by 1 order by 2 desc;"
```

Alvo: **59 no total**, distribuídos 9 / 25 / 25.

## 6. Pendências do founder

- ✅ **SQL Editor** — migration do #1642: **APLICADA e validada** (nada a fazer).
- 💬 **chat Lovable** — deploy das edges, verbatim do repo, **ainda não confirmado**:
  - `tactical-plans-batch` (traz o #1645, round-robin)
  - `generate-tactical-plan` (traz o #1642, bundle honesto)
  - Verificar depois: planos novos devem sair com `bundle_lie` **NULL**, não 0.
- 🖱️ Publish do frontend: **não se aplica** (nenhuma mudança em `src/`).

## 7. Abertura da sessão nova

```bash
bun run wt fase3-batch-retomavel
```

NUNCA reusar o worktree de sessão viva. Primeira mensagem: colar este briefing inteiro.
