### PR TITLE
feat(ia): cota por usuário nas 3 edges de IA — e a negação diz que é a SUA cota [money-path]

### DIFF
--- a/db/test-ia-uso-cota.sh
+++ b/db/test-ia-uso-cota.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — cota de IA por usuário (20260803093000_ia_uso_cota.sql)        ║
+# ║      bash db/test-ia-uso-cota.sh > /tmp/t.log 2>&1; echo "exit=$?"             ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  Rode nos DOIS locales — falsificar num só não prova a asserção (#1483):       ║
+# ║      bash db/test-ia-uso-cota.sh                                               ║
+# ║      HARNESS_LOCALE=pt_BR.UTF-8 bash db/test-ia-uso-cota.sh                    ║
+# ║  O postmaster SEMPRE sobe em C (aborta fora dele); quem varia é o locale do    ║
+# ║  SHELL, que é onde a comparação de sentinela pode dobrar acento.               ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="ia-uso-cota"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+
+# O SHELL herda o locale sob teste; o POSTGRES roda sempre em C (via `env` inline).
+export LC_ALL="${HARNESS_LOCALE:-C}" LANG="${HARNESS_LOCALE:-C}"
+PGC=(env LC_ALL=C LANG=C)
+echo "── locale do shell: $LC_ALL (postmaster sempre em C) ──"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "${PGC[@]}" "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"${PGC[@]}" "$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"${PGC[@]}" "$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"${PGC[@]}" "$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS
+# ══════════════════════════════════════════════════════════════════════════════
+# pg_cron não existe no PG local. O stub REGISTRA em cron.job (assim dá pra
+# asserir o job criado) e o unschedule LEVANTA quando o job não existe — que é o
+# comportamento do pg_cron real e o que o bloco DO/EXCEPTION da migration precisa
+# engolir para ser idempotente.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION cron.schedule(p_jobname text, p_schedule text, p_command text)
+RETURNS bigint LANGUAGE plpgsql AS $f$
+DECLARE v_id bigint;
+BEGIN
+  DELETE FROM cron.job WHERE jobname = p_jobname;
+  SELECT COALESCE(max(jobid), 0) + 1 INTO v_id FROM cron.job;
+  INSERT INTO cron.job(jobid, schedule, command, jobname, active)
+  VALUES (v_id, p_schedule, p_command, p_jobname, true);
+  RETURN v_id;
+END $f$;
+
+CREATE OR REPLACE FUNCTION cron.unschedule(p_jobname text)
+RETURNS boolean LANGUAGE plpgsql AS $f$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = p_jobname) THEN
+    RAISE EXCEPTION 'could not find valid entry for job %', p_jobname;
+  END IF;
+  DELETE FROM cron.job WHERE jobname = p_jobname;
+  RETURN true;
+END $f$;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260803093000_ia_uso_cota.sql"
+P -q -f "$MIG" >/dev/null
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS
+# ══════════════════════════════════════════════════════════════════════════════
+U1='11111111-1111-1111-1111-111111111111'
+U2='22222222-2222-2222-2222-222222222222'
+
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$U1'), ('$U2') ON CONFLICT DO NOTHING;
+
+-- Funções de TESTE com limites pequenos: exercita a mesma lógica sem semear 20
+-- linhas por assert. Os limites REAIS seguem provados pelos A1-A3.
+INSERT INTO public.ia_uso_limite (funcao, limite_hora, limite_dia) VALUES
+  ('teste-hora',    3,  50),
+  ('teste-dia',     5,   5),
+  ('teste-24h',     2,   2),
+  ('trava-teste',  10,  10)
+ON CONFLICT (funcao) DO NOTHING;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts ──"
+
+# ── A1-A3: o seed real das 3 edges entrou com os números do desenho ─────────
+V=$(Pq -c "SELECT limite_hora||'/'||limite_dia FROM public.ia_uso_limite WHERE funcao='identify-tool';")
+eq "A1 seed identify-tool" "$V" "20/60"
+V=$(Pq -c "SELECT limite_hora||'/'||limite_dia FROM public.ia_uso_limite WHERE funcao='analyze-services';")
+eq "A2 seed analyze-services" "$V" "20/50"
+V=$(Pq -c "SELECT limite_hora||'/'||limite_dia FROM public.ia_uso_limite WHERE funcao='copilot-analyze';")
+eq "A3 seed copilot-analyze" "$V" "600/2500"
+
+# ── A4/A5: caminho feliz — permite E registra ───────────────────────────────
+V=$(Pq -c "SELECT permitido||'|'||motivo||'|'||usado_hora||'|'||usado_dia FROM public.ia_consumir_cota('$U1','teste-hora');")
+eq "A4 1a chamada permitida" "$V" "true|ok|1|1"
+V=$(Pq -c "SELECT count(*) FROM public.ia_uso_evento WHERE user_id='$U1' AND funcao='teste-hora';")
+eq "A5 evento GRAVADO" "$V" "1"
+
+# ── A6: até o limite passa (limite 3: faltam a 2a e a 3a) ──────────────────
+Pq -c "SELECT permitido FROM public.ia_consumir_cota('$U1','teste-hora');" >/dev/null
+V=$(Pq -c "SELECT permitido||'|'||usado_hora FROM public.ia_consumir_cota('$U1','teste-hora');")
+eq "A6 3a chamada (=limite) ainda passa" "$V" "true|3"
+
+# ── A7/A8: a (limite+1) NEGA e NÃO grava ───────────────────────────────────
+V=$(Pq -c "SELECT permitido||'|'||motivo||'|'||usado_hora||'|'||limite_hora FROM public.ia_consumir_cota('$U1','teste-hora');")
+eq "A7 4a chamada NEGADA por hora" "$V" "false|hora|3|3"
+V=$(Pq -c "SELECT count(*) FROM public.ia_uso_evento WHERE user_id='$U1' AND funcao='teste-hora';")
+eq "A8 negada NAO gravou evento" "$V" "3"
+
+# ── A9: libera_em_segundos coerente (>0 e <= 3600) ─────────────────────────
+V=$(Pq -c "SELECT (libera_em_segundos > 0 AND libera_em_segundos <= 3600) FROM public.ia_consumir_cota('$U1','teste-hora');")
+eq "A9 libera_em_segundos na janela da hora" "$V" "t"
+
+# ── A10: isolamento entre usuários — a cota de U1 não afeta U2 ─────────────
+V=$(Pq -c "SELECT permitido||'|'||usado_hora FROM public.ia_consumir_cota('$U2','teste-hora');")
+eq "A10 cota e POR USUARIO" "$V" "true|1"
+
+# ── A11 (MONEY-PATH): janela DESLIZANTE — evento >1h não conta na hora, mas
+#     conta no dia. É o invariante que justificou log-de-evento em vez de bucket.
+P -q <<SQL
+UPDATE public.ia_uso_evento SET criado_em = now() - interval '2 hours'
+ WHERE user_id='$U1' AND funcao='teste-hora';
+SQL
+V=$(Pq -c "SELECT permitido||'|'||usado_hora||'|'||usado_dia FROM public.ia_consumir_cota('$U1','teste-hora');")
+eq "A11 evento de 2h NAO conta na hora, conta no dia" "$V" "true|1|4"
+
+# ── A12/A13: limite DIÁRIO morde com a janela da hora limpa ────────────────
+P -q <<SQL
+INSERT INTO public.ia_uso_evento (user_id, funcao, criado_em)
+SELECT '$U1','teste-dia', now() - interval '3 hours' - (g || ' minutes')::interval
+  FROM generate_series(1,5) g;
+SQL
+V=$(Pq -c "SELECT permitido||'|'||motivo||'|'||usado_hora||'|'||usado_dia FROM public.ia_consumir_cota('$U1','teste-dia');")
+eq "A12 limite do DIA morde com a hora limpa" "$V" "false|dia|0|5"
+V=$(Pq -c "SELECT (libera_em_segundos > 3600 AND libera_em_segundos <= 86400) FROM public.ia_consumir_cota('$U1','teste-dia');")
+eq "A13 libera_em_segundos na janela do dia" "$V" "t"
+
+# ── A14 (MONEY-PATH): evento >24h não conta em NADA ────────────────────────
+P -q <<SQL
+INSERT INTO public.ia_uso_evento (user_id, funcao, criado_em)
+SELECT '$U1','teste-24h', now() - interval '25 hours' - (g || ' minutes')::interval
+  FROM generate_series(1,9) g;
+SQL
+V=$(Pq -c "SELECT permitido||'|'||usado_hora||'|'||usado_dia FROM public.ia_consumir_cota('$U1','teste-24h');")
+eq "A14 evento de 25h nao conta em nada" "$V" "true|1|1"
+
+# ── A15: FAIL-CLOSED — função sem linha em ia_uso_limite é NEGADA ──────────
+V=$(Pq -c "SELECT permitido||'|'||motivo FROM public.ia_consumir_cota('$U1','edge-que-ninguem-configurou');")
+eq "A15 fail-closed: sem limite = negado" "$V" "false|sem_limite"
+
+# ── A16: argumento nulo levanta a SQLSTATE esperada (22023) ────────────────
+R=$(P -tA 2>&1 <<SQL
+DO \$do\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.ia_consumir_cota(NULL, 'teste-hora');
+    v_passou := true;
+  EXCEPTION
+    WHEN invalid_parameter_value THEN NULL;   -- 22023 = o erro ESPERADO
+    WHEN OTHERS THEN RAISE;                   -- qualquer outro: RELANÇA
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_A16_ACEITOU_NULO'; ELSE RAISE NOTICE 'SENT_A16_BARROU'; END IF;
+END \$do\$;
+SQL
+)
+case "$R" in
+  *SENT_A16_BARROU*)       ok  "A16 user_id nulo rejeitado (22023)" ;;
+  *SENT_A16_ACEITOU_NULO*) bad "A16 user_id nulo ACEITO" ;;
+  *)                       bad "A16 resultado inesperado: $R" ;;
+esac
+
+# ── A17/A18: CHECKs da tabela de limites ──────────────────────────────────
+R=$(P -tA 2>&1 <<'SQL'
+DO $do$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.ia_uso_limite (funcao, limite_hora, limite_dia) VALUES ('x-invalido', 50, 10);
+    v_passou := true;
+  EXCEPTION
+    WHEN check_violation THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_A17_ACEITOU'; ELSE RAISE NOTICE 'SENT_A17_BARROU'; END IF;
+END $do$;
+SQL
+)
+case "$R" in
+  *SENT_A17_BARROU*)  ok  "A17 CHECK barra limite_dia < limite_hora (23514)" ;;
+  *SENT_A17_ACEITOU*) bad "A17 CHECK NAO barrou limite_dia < limite_hora" ;;
+  *)                  bad "A17 resultado inesperado: $R" ;;
+esac
+
+R=$(P -tA 2>&1 <<'SQL'
+DO $do$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.ia_uso_limite (funcao, limite_hora, limite_dia) VALUES ('   ', 5, 5);
+    v_passou := true;
+  EXCEPTION
+    WHEN check_violation THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_A18_ACEITOU'; ELSE RAISE NOTICE 'SENT_A18_BARROU'; END IF;
+END $do$;
+SQL
+)
+case "$R" in
+  *SENT_A18_BARROU*)  ok  "A18 CHECK barra funcao vazia (23514)" ;;
+  *SENT_A18_ACEITOU*) bad "A18 CHECK NAO barrou funcao vazia" ;;
+  *)                  bad "A18 resultado inesperado: $R" ;;
+esac
+
+# ── A19: REVOKE de tabela — authenticated não LÊ (privilégio, 1a camada) ───
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE authenticated;
+DO $do$
+DECLARE v_passou boolean := false; v_n bigint;
+BEGIN
+  BEGIN
+    SELECT count(*) INTO v_n FROM public.ia_uso_evento;
+    v_passou := true;
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;   -- 42501 = o esperado
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_A19_LEU'; ELSE RAISE NOTICE 'SENT_A19_BARROU'; END IF;
+END $do$;
+SQL
+)
+case "$R" in
+  *SENT_A19_BARROU*) ok  "A19 REVOKE barra authenticated na tabela (42501)" ;;
+  *SENT_A19_LEU*)    bad "A19 authenticated LEU ia_uso_evento" ;;
+  *)                 bad "A19 resultado inesperado: $R" ;;
+esac
+
+# ── A20: RLS — mesmo COM privilégio, a RLS sem policy nega tudo (2a camada) ─
+# Concede de propósito para isolar a camada: se a RLS não estivesse ligada,
+# aqui apareceriam as linhas semeadas.
+P -q -c "GRANT SELECT ON TABLE public.ia_uso_evento TO authenticated;"
+V=$(Pq -c "SET ROLE authenticated; SELECT count(*) FROM public.ia_uso_evento;" | tail -1)
+eq "A20 RLS sem policy: 0 linhas mesmo com GRANT" "$V" "0"
+P -q -c "REVOKE ALL ON TABLE public.ia_uso_evento FROM authenticated;"
+
+# ── A21: REVOKE de EXECUTE — authenticated não chama a RPC ────────────────
+# Sem isto, um cliente chamaria a RPC com o user_id de OUTRO e queimaria a cota alheia.
+R=$(P -tA 2>&1 <<SQL
+SET ROLE authenticated;
+DO \$do\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.ia_consumir_cota('$U1','teste-hora');
+    v_passou := true;
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_A21_EXECUTOU'; ELSE RAISE NOTICE 'SENT_A21_BARROU'; END IF;
+END \$do\$;
+SQL
+)
+case "$R" in
+  *SENT_A21_BARROU*)    ok  "A21 REVOKE barra EXECUTE de authenticated (42501)" ;;
+  *SENT_A21_EXECUTOU*)  bad "A21 authenticated EXECUTOU a RPC" ;;
+  *)                    bad "A21 resultado inesperado: $R" ;;
+esac
+
+# ── A22: service_role EXECUTA (o grant que a edge usa de fato) ────────────
+V=$(Pq -c "SET ROLE service_role; SELECT permitido FROM public.ia_consumir_cota('$U2','teste-hora');" | tail -1)
+eq "A22 service_role executa a RPC" "$V" "t"
+
+# ── A23: cron de purga registrado com o DELETE certo ─────────────────────
+V=$(Pq -c "SELECT count(*) FROM cron.job WHERE jobname='ia-uso-evento-purga' AND command LIKE '%DELETE FROM public.ia_uso_evento%7 days%';")
+eq "A23 cron de purga registrado" "$V" "1"
+
+# ── A24: o advisory lock é REALMENTE adquirido ───────────────────────────
+# Uma 2a conexão segura o MESMO lock; a RPC tem de BLOQUEAR (55P03 sob
+# lock_timeout). Sem o lock, duas requisições simultâneas do mesmo usuário leem
+# o mesmo contador e ambas passam — a corrida que a cota existe para fechar.
+"$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -q -c \
+  "BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('${U1}:trava-teste', 0)); SELECT pg_sleep(8);" \
+  >/dev/null 2>&1 &
+LOCK_PID=$!
+# Espera determinística (sem sleep cego): poll até o lock aparecer em pg_locks.
+HELD=0
+for _ in $(seq 1 100); do
+  HELD=$(Pq -c "SELECT count(*) FROM pg_locks WHERE locktype='advisory';")
+  [ "$HELD" -ge 1 ] && break
+  sleep 0.1
+done
+eq "A24a lock de teste adquirido pela 2a sessao" "$HELD" "1"
+
+R=$(P -tA 2>&1 <<SQL
+SET lock_timeout='1500ms';
+DO \$do\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.ia_consumir_cota('$U1','trava-teste');
+    v_passou := true;
+  EXCEPTION
+    WHEN lock_not_available THEN NULL;   -- 55P03 = bloqueou como devia
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_A24_SEM_LOCK'; ELSE RAISE NOTICE 'SENT_A24_SERIALIZOU'; END IF;
+END \$do\$;
+SQL
+)
+kill "$LOCK_PID" 2>/dev/null || true
+wait "$LOCK_PID" 2>/dev/null || true
+case "$R" in
+  *SENT_A24_SERIALIZOU*) ok  "A24b RPC serializa por (usuario,funcao) via advisory lock" ;;
+  *SENT_A24_SEM_LOCK*)   bad "A24b RPC NAO pegou o advisory lock — corrida aberta" ;;
+  *)                     bad "A24b resultado inesperado: $R" ;;
+esac
+
+# ── A25: idempotência — re-aplicar NÃO desfaz ajuste manual do founder ────
+P -q -c "UPDATE public.ia_uso_limite SET limite_hora=99, limite_dia=199 WHERE funcao='identify-tool';"
+P -q -f "$MIG" >/dev/null
+V=$(Pq -c "SELECT limite_hora||'/'||limite_dia FROM public.ia_uso_limite WHERE funcao='identify-tool';")
+eq "A25 re-aplicar preserva ajuste manual" "$V" "99/199"
+P -q -c "UPDATE public.ia_uso_limite SET limite_hora=20, limite_dia=60 WHERE funcao='identify-tool';"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação (cada sabotagem tem de matar o assert que ela mira) ──"
+
+SAB="$(mktemp "/tmp/sabotagem-${SLUG}.XXXXXX.sql")"
+# Sabota via sed SOBRE A MIGRATION REAL: garante que só o trecho mirado muda.
+sabotar()   { sed -E "$1" "$MIG" > "$SAB"; cmp -s "$SAB" "$MIG" && { echo "  ❌ sed NAO casou nada — sabotagem inerte"; FAIL=$((FAIL+1)); return 1; }; P -q -f "$SAB" >/dev/null; }
+restaurar() { P -q -f "$MIG" >/dev/null; }
+dente()     { PASS=$((PASS+1)); echo "  ✅ $1 (sabotagem detectada)"; }
+falso()     { FAIL=$((FAIL+1)); echo "  ❌ FALSIFICAÇÃO FRACA: $1 — sabotei e o comportamento nao mudou"; }
+
+# ── F1 mira A7: gate da hora desligado ───────────────────────────────────
+if sabotar 's/IF v_usado_hora >= v_limite_hora THEN/IF false THEN/'; then
+  V=$(Pq -c "SELECT permitido FROM public.ia_consumir_cota('$U2','teste-hora');")
+  if [ "$V" = "t" ]; then dente "F1 gate da hora"; else falso "F1 gate da hora"; fi
+fi
+restaurar
+
+# ── F2 mira A15: fail-closed do limite ausente desligado ─────────────────
+if sabotar 's/^  IF NOT FOUND THEN/  IF false THEN/'; then
+  V=$(Pq -c "SELECT permitido FROM public.ia_consumir_cota('$U1','outra-edge-nao-configurada');")
+  if [ "$V" = "t" ]; then dente "F2 fail-closed sem_limite"; else falso "F2 fail-closed sem_limite"; fi
+fi
+restaurar
+
+# ── F3 mira A11: janela da hora vira 24h (exatamente o furo do bucket) ───
+# U1/teste-hora tem 3 eventos de 2h atrás + 1 recente: sob a janela sabotada os
+# 4 contam como "da hora" e o limite 3 passa a morder onde não devia.
+if sabotar "s/interval '1 hour'\\)::integer/interval '24 hours')::integer/"; then
+  V=$(Pq -c "SELECT permitido FROM public.ia_consumir_cota('$U1','teste-hora');")
+  if [ "$V" = "f" ]; then dente "F3 janela deslizante da hora"; else falso "F3 janela deslizante da hora"; fi
+fi
+restaurar
+
+# ── F4 mira A24b: advisory lock removido ────────────────────────────────
+if sabotar 's/^  PERFORM pg_advisory_xact_lock/  -- PERFORM pg_advisory_xact_lock/'; then
+  "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -q -c \
+    "BEGIN; SELECT pg_advisory_xact_lock(hashtextextended('${U2}:trava-teste', 0)); SELECT pg_sleep(8);" \
+    >/dev/null 2>&1 &
+  LOCK_PID=$!
+  for _ in $(seq 1 100); do
+    HELD=$(Pq -c "SELECT count(*) FROM pg_locks WHERE locktype='advisory';")
+    [ "$HELD" -ge 1 ] && break
+    sleep 0.1
+  done
+  R=$(P -tA 2>&1 <<SQL
+SET lock_timeout='1500ms';
+DO \$do\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.ia_consumir_cota('$U2','trava-teste');
+    v_passou := true;
+  EXCEPTION
+    WHEN lock_not_available THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_F4_SEM_LOCK'; ELSE RAISE NOTICE 'SENT_F4_SERIALIZOU'; END IF;
+END \$do\$;
+SQL
+)
+  kill "$LOCK_PID" 2>/dev/null || true
+  wait "$LOCK_PID" 2>/dev/null || true
+  case "$R" in
+    *SENT_F4_SEM_LOCK*) dente "F4 advisory lock" ;;
+    *)                  falso "F4 advisory lock" ;;
+  esac
+fi
+restaurar
+
+# ── F5 mira A21: EXECUTE liberado para authenticated ────────────────────
+P -q -c "GRANT EXECUTE ON FUNCTION public.ia_consumir_cota(uuid, text) TO authenticated;"
+R=$(P -tA 2>&1 <<SQL
+SET ROLE authenticated;
+DO \$do\$
+DECLARE v_passou boolean := false;
+BEGIN
+  BEGIN
+    PERFORM public.ia_consumir_cota('$U1','teste-hora');
+    v_passou := true;
+  EXCEPTION
+    WHEN insufficient_privilege THEN NULL;
+    WHEN OTHERS THEN RAISE;
+  END;
+  IF v_passou THEN RAISE NOTICE 'SENT_F5_EXECUTOU'; ELSE RAISE NOTICE 'SENT_F5_BARROU'; END IF;
+END \$do\$;
+SQL
+)
+case "$R" in
+  *SENT_F5_EXECUTOU*) dente "F5 REVOKE de EXECUTE" ;;
+  *)                  falso "F5 REVOKE de EXECUTE" ;;
+esac
+restaurar
+
+# ── F6 mira A20: policy permissiva fura a RLS ───────────────────────────
+P -q <<'SQL'
+GRANT SELECT ON TABLE public.ia_uso_evento TO authenticated;
+CREATE POLICY sabotagem_tudo_liberado ON public.ia_uso_evento FOR SELECT TO authenticated USING (true);
+SQL
+V=$(Pq -c "SET ROLE authenticated; SELECT (count(*) > 0) FROM public.ia_uso_evento;" | tail -1)
+if [ "$V" = "t" ]; then dente "F6 RLS sem policy"; else falso "F6 RLS sem policy"; fi
+P -q <<'SQL'
+DROP POLICY sabotagem_tudo_liberado ON public.ia_uso_evento;
+REVOKE ALL ON TABLE public.ia_uso_evento FROM authenticated;
+SQL
+restaurar
+rm -f "$SAB"
+
+# ── A26: pós-restauro, a migration real voltou inteira ──────────────────
+V=$(Pq -c "SELECT permitido||'|'||motivo FROM public.ia_consumir_cota('$U1','edge-que-ninguem-configurou');")
+eq "A26 pos-restauro: fail-closed de volta" "$V" "false|sem_limite"
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/superpowers/specs/2026-07-31-ia-cota-por-usuario-design.md
+++ b/docs/superpowers/specs/2026-07-31-ia-cota-por-usuario-design.md
@@ -1,0 +1,169 @@
+# Cota de IA por usuário — desenho
+
+**Data:** 2026-07-31
+**Origem:** achado P1 do challenge `/codex` sobre a fase 4 da migração do gateway Lovable → Anthropic (PRs #1592, #1608, #1618, #1626, #1631, #1640).
+**Natureza:** lacuna PRÉ-EXISTENTE, não regressão da migração. Ficou mais cara agora que o orçamento é da Anthropic e **organizacional** — o 429/402 de um abusador derruba a IA de todos os usuários e de todas as edges.
+
+## O problema
+
+`identify-tool` e `analyze-services` exigem apenas JWT válido (qualquer usuário autenticado,
+incluindo `customer`) e não têm nenhum limite de consumo. Um cliente pode repetir chamadas
+com imagens de até 8 MB (`identify-tool`) ou com 100 ferramentas (`analyze-services`) até
+bater 429/402 na Anthropic.
+
+O gate "customer pode usar" está **correto** para o produto — identificação por foto e pedido
+falado são features do cliente. O que falta é throttle/quota persistente.
+
+## Superfície de risco (medida em prod via psql-ro, 2026-07-31)
+
+| fato | valor |
+|---|---|
+| contas com role `customer` | **5.664** |
+| usuários que já logaram alguma vez (`last_sign_in_at`) | **3** |
+| clientes com ferramenta cadastrada | 2 (média 2, p95 2) |
+| tabela/função de rate-limit já existente | **nenhuma** |
+
+Duas consequências de desenho:
+
+1. **Não dá para calibrar por uso observado** (é praticamente zero). Os limites saem de uso
+   plausível de balcão, não de percentil histórico.
+2. **Não há uso legítimo para quebrar.** Estamos blindando antes da abertura — o momento
+   barato de fazer isso.
+
+Confirmado que não existe precedente: os hits de `rate.?limit` no repo são backoff da API do
+**Omie** (`_shared/omie-paginacao.ts` e afins), não quota de usuário. Em prod, as únicas
+tabelas que casam `cota|quota|limit|rate|uso|consum` são `prime_beneficio_uso` (benefício
+comercial do plano Prime) e `fin_custo_rateio` — nenhuma reaproveitável.
+
+## Desenho
+
+### Banco (uma migration)
+
+| objeto | papel |
+|---|---|
+| `ia_uso_evento` (`user_id`, `funcao`, `criado_em`) | uma linha por chamada; índice `(user_id, funcao, criado_em DESC)` |
+| `ia_uso_limite` (`funcao` PK, `limite_hora`, `limite_dia`) | os números, seedados |
+| `ia_consumir_cota(p_user_id, p_funcao)` SECURITY DEFINER | decide **e** registra na mesma transação |
+| cron `ia-uso-evento-purga` | `DELETE` de eventos > 7 dias, diário |
+
+**Log de evento e não bucket agregado.** Bucket por janela truncada (uma linha por hora) é
+mais barato, mas a janela vira *tumbling*: 20 chamadas às 10:59 + 20 às 11:00 = 40 em dois
+minutos, dentro do limite nominal de 20/hora. O log dá janela **deslizante** de verdade
+(`count(*) FILTER (WHERE criado_em > now() - interval '1 hour')`) e, de brinde, responde
+"quem gastou" quando o orçamento apertar. O volume é baixíssimo — uso humano de balcão.
+
+**Atomicidade.** A RPC abre com `pg_advisory_xact_lock(hashtextextended(user_id || ':' || funcao, 0))`.
+Sem esse lock, duas requisições simultâneas do mesmo usuário leem o mesmo contador e **ambas
+passam** — a quota vazaria exatamente sob o padrão de uso que ela existe para conter
+(repetição rápida). O lock é por (usuário, função), então não serializa usuários distintos.
+
+**Cálculo de `libera_em_segundos`.** Com janela deslizante, a próxima vaga abre quando a
+`limite`-ésima chamada mais recente sai da janela: ordenando por `criado_em DESC` e pegando
+`OFFSET (limite - 1) LIMIT 1`, o instante dela `+ 1 hora` (ou `+ 24 horas`) é a liberação.
+Vale também quando o limite foi reduzido a quente e `usado > limite`: `criado_em` é monotônico
+com a posição, então a expiração da N-ésima implica a expiração de todas as mais antigas.
+
+**Autorização.** Ambas as tabelas com RLS **habilitada e sem policy nenhuma**, mais `REVOKE`
+nominal de `anon` e `authenticated` — `REVOKE FROM PUBLIC` não alcança esses dois (grant
+explícito; ver `docs/agent/database.md`). Só a RPC toca as tabelas. `FORCE ROW LEVEL SECURITY`
+fica **fora** de propósito: com FORCE, a RLS valeria também para o owner e a própria RPC
+SECURITY DEFINER seria barrada no INSERT.
+
+A RPC recebe `EXECUTE` só de `service_role`, com `REVOKE` de `anon`/`authenticated`. Se
+`authenticated` pudesse executá-la, um cliente chamaria com o `user_id` de outro e queimaria a
+cota alheia.
+
+### Edge (`_shared/ia-cota.ts`)
+
+Módulo sem nenhum import remoto — obrigatório, porque `test:edges` roda com `--no-remote` e um
+`npm:`/`jsr:` no grafo de teste colocaria o registry no caminho de entrega de todo PR. O
+cliente entra por **interface estrutural mínima** (`{ rpc(nome, args) }`), então o teste usa um
+duplo e o módulo continua puro:
+
+```ts
+export interface ClienteRpc {
+  rpc(nome: string, args: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
+}
+```
+
+A checagem entra **depois** da autenticação e **depois** da validação de input (requisição
+malformada não queima cota) e **antes** da chamada à Anthropic.
+
+### Fail-closed, com voz própria
+
+Money-path: na dúvida, negar. Mas negar calado repetiria o sintoma que a migração inteira
+tentou resolver — "erro de IA" genérico escondendo a causa real. Três respostas distinguíveis:
+
+| situação | HTTP | mensagem |
+|---|---|---|
+| cota do usuário estourada | 429 + `Retry-After` | "Você atingiu seu limite de N <rótulo> nesta hora — é o seu limite de uso, não uma falha da IA. Libera em X minutos." |
+| RPC falhou ou devolveu payload malformado | 503 | "Não consegui verificar seu limite de uso agora. Tente de novo em instantes." |
+| 429 da própria Anthropic (já existia) | 429 | "Limite de requisições excedido. Tente novamente em alguns segundos." |
+
+**Duração relativa, não hora absoluta.** O banco é UTC e o balcão é America/Sao_Paulo;
+formatar "libera às 14:35" convidaria a um erro de fuso que ninguém notaria. A RPC devolve
+`libera_em_segundos` já calculado, o que também elimina dependência de clock skew entre
+Postgres e edge.
+
+**Função sem linha em `ia_uso_limite` → nega** (`motivo = 'sem_limite'`). Uma edge nova que
+esqueça o seed não ganha acesso irrestrito ao orçamento por omissão.
+
+### Números
+
+Custo estimado ≈ US$ 0,03–0,04 por chamada em Sonnet (imagem/texto de entrada + até 1,5–2k
+tokens de saída). Teto por usuário/dia entre parênteses:
+
+| edge | hora | dia | racional |
+|---|---|---|---|
+| `identify-tool` | 20 | 60 (~$1,80) | p95 real é 2 ferramentas/cliente; 60 cobre cadastro em lote com ~30× de folga |
+| `analyze-services` | 20 | 50 (~$2,00) | pedido falado com regravações; ~15/dia já é uso pesado |
+| `copilot-analyze` | 600 | 2.500 (~$75) | ligação real é ~450/h; corta o loop de aba esquecida (10.800/dia) |
+
+Ajustáveis por `UPDATE` no SQL Editor, sem redeploy de edge — que no Lovable é manual.
+
+### `copilot-analyze` avaliado separado
+
+Padrão de uso oposto: staff-only (2 employees + 1 master) e disparo a cada 8 s
+(`ANALYSIS_INTERVAL_MS`) enquanto a transcrição muda, ou seja ~450 chamadas por hora de ligação
+real. O risco ali não é abuso, é **loop acidental** — aba esquecida aberta a noite toda ou
+timer que não para. Daí o teto folgado: não toca ligação real, mas limita o dano de um loop a
+2.500 chamadas/dia em vez de 10.800.
+
+### Frontend do copiloto (achado durante o desenho)
+
+`useCopilotEngine` hoje **engole o erro**: o `catch` só faz `console.error` e marca
+`analiseObsoleta`. Pior, ele zera `lastAnalyzedRef` para o próximo tick tentar de novo — o que
+é correto para falha transitória, mas em quota estourada vira um martelo a cada 8 s contra um
+limite que não vai ceder, com a vendedora sem saber por que o copiloto parou.
+
+Então o copiloto passa a: exibir o motivo, e **suspender os disparos** até a janela liberar.
+Sem isso, colocar a quota só no servidor pioraria a experiência em vez de melhorar.
+
+## Prova antes de entregar
+
+`prove-sql-money-path` em PG17 local, aplicando a migration real:
+
+- limite respeitado (a N-ésima passa, a N+1 nega);
+- janela deslizante ignora evento fora dela;
+- função sem linha em `ia_uso_limite` é negada (fail-closed);
+- RLS sob `SET ROLE authenticated` (psql é superuser e bypassaria);
+- `EXECUTE` da RPC negado a `authenticated`;
+- **falsificação**: sabotar a migration e exigir vermelho, rodada em `LC_ALL=C` **e**
+  `pt_BR.UTF-8` (o #1483 mostrou que falsificar num locale só não prova a asserção).
+
+PL/pgSQL é late-bound: `CREATE` passar não diz nada. O teste **executa** a função.
+
+## Entrega (3 camadas manuais do Lovable)
+
+1. **Migration** → SQL Editor (nome custom não auto-aplica; falha silenciosa).
+2. **Edges** → chat do Lovable, verbatim: `_shared/ia-cota.ts`, `identify-tool/index.ts`,
+   `analyze-services/index.ts`, `copilot-analyze/index.ts`.
+3. **Publish** do frontend (mudança em `useCopilotEngine`).
+
+## Fora de escopo (decidido)
+
+**Disjuntor global** (teto diário da organização). Quota por usuário contém o abusador único,
+não o agregado de muitos usuários legítimos — mas com 3 logins reais esse cenário é hipotético,
+e um teto global tem risco próprio: por desenho ele derruba a feature para todos, virando o
+mesmo sintoma que queremos evitar, com uma mensagem que o usuário não pode resolver sozinho.
+O formato da tabela permite adicioná-lo depois sem migration nova.

--- a/src/hooks/useCopilotEngine.ts
+++ b/src/hooks/useCopilotEngine.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { invokeFunction } from '@/lib/invoke-function';
+import { EdgeFunctionError, invokeFunction } from '@/lib/invoke-function';
 import { useAuth } from '@/contexts/AuthContext';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -57,12 +57,18 @@ interface CopilotState {
   isAnalyzing: boolean;
   /** A leitura exibida ficou para trás (a última tentativa falhou). */
   analiseObsoleta: boolean;
+  /** Cota de IA estourada: a mensagem da edge, exibida como tal. Enquanto
+   *  preenchida, os ticks NÃO disparam — retentar de 8 em 8s contra um limite
+   *  que não vai ceder só gasta requisição e mantém a vendedora no escuro. */
+  avisoCota: string | null;
   suggestionsShown: number;
   suggestionsUsed: number;
 }
 
 const ANALYSIS_INTERVAL_MS = 8000; // Analyze every 8 seconds of new speech
 const MIN_TRANSCRIPT_LENGTH = 20;
+/** Sem `Retry-After` utilizável, espera um valor conservador antes de reabrir. */
+const ESPERA_COTA_PADRAO_MS = 5 * 60 * 1000;
 
 export const useCopilotEngine = () => {
   const { user } = useAuth();
@@ -74,12 +80,15 @@ export const useCopilotEngine = () => {
     analysisHistory: [],
     isAnalyzing: false,
     analiseObsoleta: false,
+    avisoCota: null,
     suggestionsShown: 0,
     suggestionsUsed: 0,
   });
 
   const analysisTimerRef = useRef<NodeJS.Timeout | null>(null);
   const lastAnalyzedRef = useRef<string>('');
+  /** Epoch em ms até quando a cota está estourada. 0 = liberado. */
+  const cotaBloqueadaAteRef = useRef<number>(0);
   // Descarta resposta fora de ordem: com tick de 8s, uma análise lenta pode
   // terminar DEPOIS de uma mais nova e sobrescrever a tela com leitura velha —
   // "risco" atual viraria "neutro" obsoleto.
@@ -116,6 +125,11 @@ export const useCopilotEngine = () => {
       customerContext: params.customerContext,
     };
 
+    // A cota é por janela de TEMPO, não por sessão: abrir uma ligação nova não
+    // devolve chamadas. Por isso o aviso só é limpo se a janela já virou —
+    // apagá-lo aqui deixaria a vendedora numa ligação com o copiloto mudo e sem
+    // explicação, que é o estado que este PR existe para eliminar.
+    const cotaAindaBloqueada = cotaBloqueadaAteRef.current > Date.now();
     setState(prev => ({
       ...prev,
       isActive: true,
@@ -124,6 +138,7 @@ export const useCopilotEngine = () => {
       currentAnalysis: null,
       analysisHistory: [],
       analiseObsoleta: false,
+      avisoCota: cotaAindaBloqueada ? prev.avisoCota : null,
       suggestionsShown: 0,
       suggestionsUsed: 0,
     }));
@@ -212,6 +227,17 @@ export const useCopilotEngine = () => {
         return prev;
       }
 
+      // Cota estourada: não dispara até a janela virar. Sem esta guarda o tick
+      // de 8s vira um martelo contra um limite que não cede — e o `catch`
+      // adiante solta `lastAnalyzedRef` de propósito, o que aqui realimentaria
+      // o loop a cada tick. O aviso na tela só sai quando uma análise VOLTA a
+      // funcionar (abaixo), não no relógio: some porque funcionou, não porque
+      // o tempo passou.
+      if (cotaBloqueadaAteRef.current > Date.now()) {
+        return prev;
+      }
+      cotaBloqueadaAteRef.current = 0;
+
       lastAnalyzedRef.current = fullText;
 
       // Fire async analysis
@@ -263,6 +289,8 @@ export const useCopilotEngine = () => {
             analysisHistory: [...s.analysisHistory, analysis],
             isAnalyzing: false,
             analiseObsoleta: false,
+            // Voltou a funcionar: é este o sinal que apaga o aviso de cota.
+            avisoCota: null,
             suggestionsShown: s.suggestionsShown + 1,
           }));
 
@@ -284,6 +312,27 @@ export const useCopilotEngine = () => {
           }
         } catch (err) {
           console.error('Analysis error:', err);
+
+          // 429 = a COTA de IA desta usuária acabou. É diferente em espécie de
+          // uma falha transitória: retentar não resolve, só gasta requisição —
+          // e antes disto o erro morria no console, com o painel seguindo em
+          // "AO VIVO" e ninguém sabendo por que as sugestões pararam.
+          const cotaEstourada = err instanceof EdgeFunctionError && err.status === 429;
+          if (cotaEstourada) {
+            const esperaMs = err.retryAfterSeconds
+              ? err.retryAfterSeconds * 1000
+              : ESPERA_COTA_PADRAO_MS;
+            cotaBloqueadaAteRef.current = Date.now() + esperaMs;
+            setState(s => ({
+              ...s,
+              isAnalyzing: false,
+              analiseObsoleta: s.currentAnalysis !== null,
+              // A mensagem da edge já explica qual limite e quando volta.
+              avisoCota: err.message,
+            }));
+            return;
+          }
+
           // Solta o texto para o próximo tick TENTAR DE NOVO. Sem isto o
           // copiloto morre calado: `lastAnalyzedRef` já foi marcado antes da
           // chamada, então uma falha (422, rede) faria todos os ticks seguintes

--- a/src/lib/invoke-function.test.ts
+++ b/src/lib/invoke-function.test.ts
@@ -72,7 +72,12 @@ describe('invokeFunction — status e Retry-After', () => {
 
   it('sem Retry-After utilizável, deixa undefined em vez de fabricar 0', async () => {
     // `Number(null)` é 0 — um retry de 0s reabriria o martelo imediatamente.
-    for (const headers of [{}, { 'Retry-After': 'depois' }, { 'Retry-After': '0' }]) {
+    const casos: Array<Record<string, string>> = [
+      {},
+      { 'Retry-After': 'depois' },
+      { 'Retry-After': '0' },
+    ];
+    for (const headers of casos) {
       invokeMock.mockResolvedValue(erroDeEdge(429, { error: 'cota' }, headers));
       try {
         await invokeFunction('copilot-analyze');

--- a/src/lib/invoke-function.test.ts
+++ b/src/lib/invoke-function.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// O erro do supabase-js sempre traz o genérico "non-2xx status code"; o motivo
+// REAL (e o status) vivem na Response guardada em `context`. É desse elo que
+// depende o copiloto distinguir "sua cota acabou" (esperar) de falha
+// transitória (retentar) — sem ele, o hook volta a martelar de 8 em 8s.
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(() =>
+        Promise.resolve({ data: { session: { access_token: 'token-de-teste' } } }),
+      ),
+    },
+    functions: { invoke: vi.fn() },
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+import { supabase } from '@/integrations/supabase/client';
+import { EdgeFunctionError, invokeFunction } from '@/lib/invoke-function';
+
+const invokeMock = supabase.functions.invoke as unknown as ReturnType<typeof vi.fn>;
+
+/** Reproduz o formato do FunctionsHttpError: mensagem genérica + Response. */
+function erroDeEdge(status: number, corpo: unknown, headers: Record<string, string> = {}) {
+  return {
+    data: null,
+    error: Object.assign(new Error('Edge Function returned a non-2xx status code'), {
+      context: new Response(JSON.stringify(corpo), { status, headers }),
+    }),
+  };
+}
+
+describe('invokeFunction — status e Retry-After', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('propaga o status HTTP da Response, não o do erro do supabase', async () => {
+    invokeMock.mockResolvedValue(
+      erroDeEdge(429, { error: 'Você atingiu seu limite de 20 análises do copiloto nesta hora.' }),
+    );
+
+    await expect(invokeFunction('copilot-analyze')).rejects.toMatchObject({
+      name: 'EdgeFunctionError',
+      status: 429,
+    });
+  });
+
+  it('propaga a mensagem do servidor no lugar do genérico non-2xx', async () => {
+    invokeMock.mockResolvedValue(erroDeEdge(429, { error: 'Libera em 22 minutos.' }));
+
+    await expect(invokeFunction('copilot-analyze')).rejects.toThrow('Libera em 22 minutos.');
+  });
+
+  it('lê Retry-After quando a edge manda', async () => {
+    invokeMock.mockResolvedValue(
+      erroDeEdge(429, { error: 'cota' }, { 'Retry-After': '1320' }),
+    );
+
+    try {
+      await invokeFunction('copilot-analyze');
+      throw new Error('devia ter lançado');
+    } catch (e) {
+      expect(e).toBeInstanceOf(EdgeFunctionError);
+      expect((e as EdgeFunctionError).retryAfterSeconds).toBe(1320);
+    }
+  });
+
+  it('sem Retry-After utilizável, deixa undefined em vez de fabricar 0', async () => {
+    // `Number(null)` é 0 — um retry de 0s reabriria o martelo imediatamente.
+    for (const headers of [{}, { 'Retry-After': 'depois' }, { 'Retry-After': '0' }]) {
+      invokeMock.mockResolvedValue(erroDeEdge(429, { error: 'cota' }, headers));
+      try {
+        await invokeFunction('copilot-analyze');
+        throw new Error('devia ter lançado');
+      } catch (e) {
+        expect((e as EdgeFunctionError).retryAfterSeconds).toBeUndefined();
+      }
+    }
+  });
+
+  it('distingue 503 (transitório) de 429 (cota) pelo status', async () => {
+    invokeMock.mockResolvedValue(
+      erroDeEdge(503, { error: 'Não consegui verificar seu limite de uso agora.' }),
+    );
+
+    try {
+      await invokeFunction('identify-tool');
+      throw new Error('devia ter lançado');
+    } catch (e) {
+      expect((e as EdgeFunctionError).status).toBe(503);
+    }
+  });
+
+  it('corpo não-JSON não derruba a extração — cai no genérico com o status', async () => {
+    invokeMock.mockResolvedValue({
+      data: null,
+      error: Object.assign(new Error('Edge Function returned a non-2xx status code'), {
+        context: new Response('<html>502</html>', { status: 502 }),
+      }),
+    });
+
+    try {
+      await invokeFunction('identify-tool');
+      throw new Error('devia ter lançado');
+    } catch (e) {
+      expect((e as EdgeFunctionError).status).toBe(502);
+      expect((e as Error).message).toContain('non-2xx');
+    }
+  });
+
+  it('sucesso devolve os dados e não lança', async () => {
+    invokeMock.mockResolvedValue({ data: { ok: true }, error: null });
+    await expect(invokeFunction<{ ok: boolean }>('identify-tool')).resolves.toEqual({ ok: true });
+  });
+});

--- a/src/lib/invoke-function.ts
+++ b/src/lib/invoke-function.ts
@@ -9,8 +9,16 @@ class AuthRequiredError extends Error {
   }
 }
 
-class EdgeFunctionError extends Error {
-  constructor(message: string, public functionName: string) {
+export class EdgeFunctionError extends Error {
+  constructor(
+    message: string,
+    public functionName: string,
+    /** Status HTTP real da edge. Sem ele, quem chama não distingue "sua cota
+     *  acabou" (429, esperar adianta) de falha transitória (retentar adianta). */
+    public status?: number,
+    /** Segundos do header `Retry-After`, quando a edge mandou. */
+    public retryAfterSeconds?: number,
+  ) {
     super(message);
     this.name = 'EdgeFunctionError';
   }
@@ -40,10 +48,17 @@ export async function invokeFunction<T = unknown>(
     // REAL do servidor (ex.: "Falha ao autenticar na Nvoip: 401"); o `error.message` do
     // supabase é sempre o genérico "Edge Function returned a non-2xx status code".
     let serverMessage: string | undefined;
+    let httpStatus: number | undefined = errWithMeta.status;
+    let retryAfterSeconds: number | undefined;
     const ctx = errWithMeta.context;
     if (ctx && typeof (ctx as Response).clone === 'function') {
+      const resp = ctx as Response;
+      // O status vive na Response, não em `error.status` — que costuma vir vazio.
+      if (typeof resp.status === 'number') httpStatus = resp.status;
+      const retry = Number(resp.headers?.get('Retry-After'));
+      if (Number.isFinite(retry) && retry > 0) retryAfterSeconds = retry;
       try {
-        const parsed: unknown = await (ctx as Response).clone().json();
+        const parsed: unknown = await resp.clone().json();
         if (
           parsed && typeof parsed === 'object' &&
           'error' in parsed && typeof (parsed as { error: unknown }).error === 'string'
@@ -57,13 +72,15 @@ export async function invokeFunction<T = unknown>(
     logger.error(`Edge function failed: ${functionName}`, {
       functionName,
       errorCode: errWithMeta.code,
-      httpStatus: errWithMeta.status,
+      httpStatus,
       serverMessage,
       error,
     });
     throw new EdgeFunctionError(
       serverMessage || error.message || `Erro ao chamar ${functionName}`,
       functionName,
+      httpStatus,
+      retryAfterSeconds,
     );
   }
 

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -698,6 +698,7 @@ export const MODULOS: ModuloApp[] = [
       "src/__tests__/potencial-nao-medido-gate.test.ts",
       "src/__tests__/segredo-em-log-gate.test.ts",
       "src/lib/escape-html.test.ts",
+      "src/lib/invoke-function.test.ts",
       "src/lib/__tests__/**",
       "src/components/__tests__/ErrorBoundary.test.tsx",
       "src/components/__tests__/RequireFinanceiroAccess.test.tsx",

--- a/src/pages/FarmerCopilot.tsx
+++ b/src/pages/FarmerCopilot.tsx
@@ -142,10 +142,20 @@ const FarmerCopilot = () => {
               </div>
             )}
 
+            {/* Cota de IA estourada. Precede o aviso de "desatualizada" porque
+                diz a causa REAL e a ação certa: aqui NÃO adianta esperar o
+                próximo tick — os disparos estão suspensos até a janela virar. */}
+            {copilot.avisoCota && (
+              <div className="flex items-start gap-1.5 justify-center py-1">
+                <AlertCircle className="w-3 h-3 text-status-warning shrink-0 mt-px" />
+                <span className="text-[10px] text-status-warning">{copilot.avisoCota}</span>
+              </div>
+            )}
+
             {/* A última leitura falhou e a tela ainda mostra a anterior. Sem este
                 aviso o painel segue em "AO VIVO" com uma direção que já passou —
                 e a vendedora age sobre ela achando que é o agora. */}
-            {!copilot.isAnalyzing && copilot.analiseObsoleta && (
+            {!copilot.isAnalyzing && copilot.analiseObsoleta && !copilot.avisoCota && (
               <div className="flex items-center gap-1.5 justify-center py-1">
                 <AlertCircle className="w-3 h-3 text-status-warning shrink-0" />
                 <span className="text-[10px] text-status-warning">

--- a/supabase/functions/_shared/ia-cota.ts
+++ b/supabase/functions/_shared/ia-cota.ts
@@ -1,0 +1,169 @@
+// Cota de IA por usuário — cliente da RPC `ia_consumir_cota` e as mensagens que
+// o usuário lê quando a cota morde.
+//
+// Existe porque os limites da Anthropic são ORGANIZACIONAIS: um usuário
+// repetindo chamadas até bater 429/402 derruba a IA de todos os outros e de
+// todas as edges. O gate "customer pode usar" está correto — o que faltava era
+// o throttle.
+//
+// Sem import remoto de propósito: `test:edges` roda com `--no-remote`, então o
+// cliente entra por interface ESTRUTURAL mínima e o teste usa um duplo. Isso
+// mantém o módulo inteiro exercitável sem rede.
+
+/** O mínimo do cliente Supabase que este módulo precisa. */
+export interface ClienteRpc {
+  rpc(
+    nome: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: unknown }>;
+}
+
+export type ResultadoCota =
+  | {
+    permitido: true;
+    /** Informativos. `null` quando a RPC não devolveu número utilizável —
+     *  ausente não vira zero (o consumo já foi registrado de qualquer forma). */
+    usadoHora: number | null;
+    limiteHora: number | null;
+    usadoDia: number | null;
+    limiteDia: number | null;
+  }
+  | {
+    permitido: false;
+    http: number;
+    mensagem: string;
+    /** Segundos para o header `Retry-After`; ausente quando não há espera útil. */
+    retryAposSegundos?: number;
+  };
+
+const MENSAGEM_INDISPONIVEL =
+  "Não consegui verificar seu limite de uso agora. Tente de novo em instantes.";
+const MENSAGEM_SEM_LIMITE =
+  "Limite de uso não configurado para esta função — avise a equipe.";
+
+function numeroFinito(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Espera em português, SEMPRE relativa.
+ *
+ * Hora absoluta exigiria converter UTC (banco) para America/Sao_Paulo (balcão) —
+ * um erro de fuso aqui produziria "libera às 11:35" quando faltam três horas, e
+ * ninguém notaria. Arredonda para CIMA: mandar o usuário voltar cedo demais
+ * frustra mais do que uma estimativa folgada.
+ */
+export function formatarEspera(segundos: number): string {
+  if (!Number.isFinite(segundos) || segundos <= 0) return "instantes";
+  if (segundos < 60) return "menos de um minuto";
+
+  // Arredonda para minutos UMA vez e só então quebra em h/min. Arredondar nos
+  // dois níveis criava a fronteira em que 3599s virava "60 minutos".
+  const totalMin = Math.ceil(segundos / 60);
+  if (totalMin < 60) return totalMin === 1 ? "1 minuto" : `${totalMin} minutos`;
+
+  const horas = Math.floor(totalMin / 60);
+  const minutos = totalMin % 60;
+  if (minutos === 0) return horas === 1 ? "1 hora" : `${horas} horas`;
+  return `${horas}h${minutos}min`;
+}
+
+/**
+ * Traduz a linha da RPC no que a edge devolve.
+ *
+ * FAIL-CLOSED: qualquer coisa que não seja uma linha reconhecível vira 503 com
+ * mensagem própria. Deixar passar na dúvida transformaria um soluço do banco na
+ * janela por onde o orçamento vaza.
+ *
+ * `rotulo` é o nome da ação na voz do usuário ("identificações por foto"), não
+ * o slug da edge — quem lê a mensagem é a pessoa no balcão.
+ */
+export function interpretarCota(payload: unknown, rotulo: string): ResultadoCota {
+  // A RPC é RETURNS TABLE: o supabase-js entrega array de linhas.
+  const linha = Array.isArray(payload) ? payload[0] : payload;
+  if (!linha || typeof linha !== "object") {
+    return { permitido: false, http: 503, mensagem: MENSAGEM_INDISPONIVEL };
+  }
+
+  const l = linha as Record<string, unknown>;
+  if (typeof l.permitido !== "boolean") {
+    return { permitido: false, http: 503, mensagem: MENSAGEM_INDISPONIVEL };
+  }
+
+  if (l.permitido) {
+    return {
+      permitido: true,
+      usadoHora: numeroFinito(l.usado_hora),
+      limiteHora: numeroFinito(l.limite_hora),
+      usadoDia: numeroFinito(l.usado_dia),
+      limiteDia: numeroFinito(l.limite_dia),
+    };
+  }
+
+  if (l.motivo === "sem_limite") {
+    return { permitido: false, http: 503, mensagem: MENSAGEM_SEM_LIMITE };
+  }
+
+  const espera = numeroFinito(l.libera_em_segundos);
+  const limiteHora = numeroFinito(l.limite_hora);
+  const limiteDia = numeroFinito(l.limite_dia);
+
+  // O número entra na frase. Sem ele não dá para dizer "seu limite de N" sem
+  // inventar o N — cai no genérico em vez de fabricar.
+  if (l.motivo === "hora" && limiteHora !== null) {
+    return {
+      permitido: false,
+      http: 429,
+      mensagem:
+        `Você atingiu seu limite de ${limiteHora} ${rotulo} nesta hora — é o seu limite de uso, ` +
+        `não uma falha da IA. Libera em ${formatarEspera(espera ?? 0)}.`,
+      retryAposSegundos: espera ?? undefined,
+    };
+  }
+
+  if (l.motivo === "dia" && limiteDia !== null) {
+    return {
+      permitido: false,
+      http: 429,
+      mensagem:
+        `Você atingiu seu limite de ${limiteDia} ${rotulo} por dia — é o seu limite de uso, ` +
+        `não uma falha da IA. Libera em ${formatarEspera(espera ?? 0)}.`,
+      retryAposSegundos: espera ?? undefined,
+    };
+  }
+
+  return { permitido: false, http: 503, mensagem: MENSAGEM_INDISPONIVEL };
+}
+
+/**
+ * Consome uma unidade da cota do usuário. Chame DEPOIS de autenticar e de
+ * validar o input (requisição malformada não deve queimar cota) e ANTES de
+ * chamar a Anthropic.
+ */
+export async function consumirCota(
+  cliente: ClienteRpc,
+  userId: string,
+  funcao: string,
+  rotulo: string,
+): Promise<ResultadoCota> {
+  try {
+    const { data, error } = await cliente.rpc("ia_consumir_cota", {
+      p_user_id: userId,
+      p_funcao: funcao,
+    });
+    if (error) {
+      console.error(`[ia-cota] RPC falhou para ${funcao}:`, error);
+      return { permitido: false, http: 503, mensagem: MENSAGEM_INDISPONIVEL };
+    }
+    return interpretarCota(data, rotulo);
+  } catch (e: unknown) {
+    console.error(`[ia-cota] erro ao consumir cota de ${funcao}:`, e);
+    return { permitido: false, http: 503, mensagem: MENSAGEM_INDISPONIVEL };
+  }
+}
+
+/** Headers do 429, para a edge anexar aos seus próprios. */
+export function headersDeCota(r: ResultadoCota): Record<string, string> {
+  if (r.permitido || r.retryAposSegundos === undefined) return {};
+  return { "Retry-After": String(Math.max(1, Math.ceil(r.retryAposSegundos))) };
+}

--- a/supabase/functions/_shared/ia-cota_test.ts
+++ b/supabase/functions/_shared/ia-cota_test.ts
@@ -1,0 +1,233 @@
+// Testa o CÓDIGO REAL de _shared/ia-cota.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/
+import {
+  type ClienteRpc,
+  consumirCota,
+  formatarEspera,
+  headersDeCota,
+  interpretarCota,
+} from "./ia-cota.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(msg);
+}
+
+const ROTULO = "identificações por foto";
+
+/** Duplo do cliente: devolve o que o teste mandar, sem tocar rede. */
+function clienteFake(
+  resposta: { data: unknown; error: unknown },
+): ClienteRpc & { chamadas: Array<Record<string, unknown>> } {
+  const chamadas: Array<Record<string, unknown>> = [];
+  return {
+    chamadas,
+    rpc(nome: string, args: Record<string, unknown>) {
+      chamadas.push({ nome, ...args });
+      return Promise.resolve(resposta);
+    },
+  };
+}
+
+/** Duplo que estoura — a edge não pode deixar a exceção escapar nem liberar. */
+function clienteQueExplode(): ClienteRpc {
+  return {
+    rpc(): Promise<{ data: unknown; error: unknown }> {
+      throw new Error("boom");
+    },
+  };
+}
+
+// ── formatarEspera ────────────────────────────────────────────────────────
+Deno.test("formatarEspera: abaixo de um minuto", () => {
+  assertEquals(formatarEspera(1), "menos de um minuto");
+  assertEquals(formatarEspera(59), "menos de um minuto");
+});
+
+Deno.test("formatarEspera: arredonda minutos para CIMA", () => {
+  assertEquals(formatarEspera(60), "1 minuto");
+  assertEquals(formatarEspera(61), "2 minutos");   // volta cedo frustra mais
+  assertEquals(formatarEspera(1320), "22 minutos");
+});
+
+Deno.test("formatarEspera: a fronteira 3599 não vira '1h 60min'", () => {
+  assertEquals(formatarEspera(3599), "1 hora");
+  assertEquals(formatarEspera(3600), "1 hora");
+  assertEquals(formatarEspera(5400), "1h30min");
+  assertEquals(formatarEspera(7200), "2 horas");
+  assertEquals(formatarEspera(75600), "21 horas");
+});
+
+Deno.test("formatarEspera: valor inútil não vira frase inútil", () => {
+  assertEquals(formatarEspera(0), "instantes");
+  assertEquals(formatarEspera(-5), "instantes");
+  assertEquals(formatarEspera(NaN), "instantes");
+});
+
+// ── interpretarCota: caminho permitido ────────────────────────────────────
+Deno.test("interpretarCota: permitido devolve os contadores", () => {
+  const r = interpretarCota([{
+    permitido: true,
+    motivo: "ok",
+    usado_hora: 3,
+    limite_hora: 20,
+    usado_dia: 8,
+    limite_dia: 60,
+    libera_em_segundos: 0,
+  }], ROTULO);
+  assert(r.permitido, "devia permitir");
+  if (r.permitido) {
+    assertEquals(r.usadoHora, 3);
+    assertEquals(r.limiteDia, 60);
+  }
+});
+
+Deno.test("interpretarCota: aceita objeto solto, não só array", () => {
+  const r = interpretarCota({ permitido: true, motivo: "ok" }, ROTULO);
+  assert(r.permitido, "devia permitir");
+});
+
+Deno.test("interpretarCota: contador ausente vira null, NÃO zero", () => {
+  // Number(null)===0 fabricaria "você usou 0 de 0" — ausente ≠ zero.
+  const r = interpretarCota([{ permitido: true, usado_hora: null }], ROTULO);
+  assert(r.permitido, "devia permitir");
+  if (r.permitido) {
+    assertEquals(r.usadoHora, null);
+    assertEquals(r.limiteHora, null);
+  }
+});
+
+// ── interpretarCota: negações ─────────────────────────────────────────────
+Deno.test("interpretarCota: limite da HORA — 429, o número certo e a espera", () => {
+  const r = interpretarCota([{
+    permitido: false,
+    motivo: "hora",
+    usado_hora: 20,
+    limite_hora: 20,
+    usado_dia: 20,
+    limite_dia: 60,
+    libera_em_segundos: 1320,
+  }], ROTULO);
+  assert(!r.permitido, "devia negar");
+  if (!r.permitido) {
+    assertEquals(r.http, 429);
+    assert(r.mensagem.includes("20 identificações por foto"), `número/rótulo ausentes: ${r.mensagem}`);
+    assert(r.mensagem.includes("22 minutos"), `espera ausente: ${r.mensagem}`);
+    // O ponto do achado: a mensagem tem de dizer que é a cota DELE, e negar
+    // explicitamente o diagnóstico errado ("a IA quebrou").
+    assert(r.mensagem.includes("seu limite de uso"), `não se identifica como cota: ${r.mensagem}`);
+    assert(r.mensagem.includes("não uma falha da IA"), `não contrasta com falha da IA: ${r.mensagem}`);
+    assertEquals(r.retryAposSegundos, 1320);
+  }
+});
+
+Deno.test("interpretarCota: limite do DIA usa o limite diário, não o horário", () => {
+  const r = interpretarCota([{
+    permitido: false,
+    motivo: "dia",
+    usado_hora: 2,
+    limite_hora: 20,
+    usado_dia: 60,
+    limite_dia: 60,
+    libera_em_segundos: 75600,
+  }], ROTULO);
+  assert(!r.permitido, "devia negar");
+  if (!r.permitido) {
+    assertEquals(r.http, 429);
+    assert(r.mensagem.includes("60 identificações por foto"), `limite errado: ${r.mensagem}`);
+    assert(r.mensagem.includes("por dia"), `janela errada: ${r.mensagem}`);
+    assert(r.mensagem.includes("21 horas"), `espera ausente: ${r.mensagem}`);
+  }
+});
+
+Deno.test("interpretarCota: sem_limite é 503 de configuração, não 429 do usuário", () => {
+  // Culpar o usuário por uma edge que ninguém configurou mandaria ele esperar
+  // uma janela que nunca abre.
+  const r = interpretarCota([{ permitido: false, motivo: "sem_limite" }], ROTULO);
+  assert(!r.permitido, "devia negar");
+  if (!r.permitido) {
+    assertEquals(r.http, 503);
+    assert(r.mensagem.includes("avise a equipe"), `mensagem errada: ${r.mensagem}`);
+    assertEquals(r.retryAposSegundos, undefined);
+  }
+});
+
+Deno.test("interpretarCota: negado com limite ilegível NÃO inventa o número", () => {
+  const r = interpretarCota([{
+    permitido: false,
+    motivo: "hora",
+    limite_hora: null,
+    libera_em_segundos: 60,
+  }], ROTULO);
+  assert(!r.permitido, "devia negar");
+  if (!r.permitido) {
+    assertEquals(r.http, 503);
+    assert(!r.mensagem.includes("null"), `vazou null na frase: ${r.mensagem}`);
+    assert(!r.mensagem.includes("NaN"), `vazou NaN na frase: ${r.mensagem}`);
+  }
+});
+
+// ── fail-closed ───────────────────────────────────────────────────────────
+Deno.test("interpretarCota: payload inútil é NEGADO (fail-closed)", () => {
+  for (const lixo of [null, undefined, [], {}, "erro", 42, [{ permitido: "sim" }]]) {
+    const r = interpretarCota(lixo, ROTULO);
+    assert(!r.permitido, `payload ${JSON.stringify(lixo)} devia ser negado`);
+    if (!r.permitido) assertEquals(r.http, 503);
+  }
+});
+
+Deno.test("consumirCota: erro da RPC é negado, não liberado", () => {
+  return consumirCota(
+    clienteFake({ data: null, error: { message: "conexão caiu" } }),
+    "u1",
+    "identify-tool",
+    ROTULO,
+  ).then((r) => {
+    assert(!r.permitido, "erro de RPC NÃO pode liberar a chamada");
+    if (!r.permitido) {
+      assertEquals(r.http, 503);
+      assert(r.mensagem.includes("limite de uso"), `mensagem genérica demais: ${r.mensagem}`);
+    }
+  });
+});
+
+Deno.test("consumirCota: exceção lançada é negada, não propagada", () => {
+  return consumirCota(clienteQueExplode(), "u1", "identify-tool", ROTULO).then((r) => {
+    assert(!r.permitido, "exceção NÃO pode liberar a chamada");
+    if (!r.permitido) assertEquals(r.http, 503);
+  });
+});
+
+Deno.test("consumirCota: manda os parâmetros que a RPC espera", () => {
+  const c = clienteFake({ data: [{ permitido: true }], error: null });
+  return consumirCota(c, "u-123", "analyze-services", ROTULO).then((r) => {
+    assert(r.permitido, "devia permitir");
+    assertEquals(c.chamadas, [{
+      nome: "ia_consumir_cota",
+      p_user_id: "u-123",
+      p_funcao: "analyze-services",
+    }]);
+  });
+});
+
+// ── headersDeCota ─────────────────────────────────────────────────────────
+Deno.test("headersDeCota: Retry-After só quando há espera", () => {
+  assertEquals(headersDeCota({ permitido: true, usadoHora: 1, limiteHora: 2, usadoDia: 1, limiteDia: 2 }), {});
+  assertEquals(headersDeCota({ permitido: false, http: 503, mensagem: "x" }), {});
+  assertEquals(
+    headersDeCota({ permitido: false, http: 429, mensagem: "x", retryAposSegundos: 90 }),
+    { "Retry-After": "90" },
+  );
+  // Retry-After é inteiro em segundos; fração viraria header inválido.
+  assertEquals(
+    headersDeCota({ permitido: false, http: 429, mensagem: "x", retryAposSegundos: 0.4 }),
+    { "Retry-After": "1" },
+  );
+});

--- a/supabase/functions/analyze-services/index.ts
+++ b/supabase/functions/analyze-services/index.ts
@@ -8,6 +8,7 @@ import {
   statusDoErro,
   traduzirErroAnthropic,
 } from "../_shared/anthropic.ts";
+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts";
 import { normalizarItens, TOOL_SERVICOS } from "./servico-tools.ts";
 
 const corsHeaders = {
@@ -83,10 +84,26 @@ serve(async (req) => {
       throw new Error("ANTHROPIC_API_KEY is not configured");
     }
 
-    // Buscar serviços disponíveis do banco
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseKey);
 
+    // COTA — depois da validação (requisição malformada não queima cota) e antes
+    // da Anthropic. Também poupa a consulta de serviços quando a cota já estourou.
+    // O gate acima só exige JWT válido: sem isto, um cliente repetindo pedidos
+    // com 100 ferramentas esgota o orçamento da ORGANIZAÇÃO — os limites da
+    // Anthropic não são por usuário da aplicação.
+    const cota = await consumirCota(supabase, user.id, "analyze-services", "análises de pedido");
+    if (!cota.permitido) {
+      return new Response(
+        JSON.stringify({ error: cota.mensagem }),
+        {
+          status: cota.http,
+          headers: { ...corsHeaders, ...headersDeCota(cota), "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    // Buscar serviços disponíveis do banco
     const { data: servicos, error: dbError } = await supabase
       .from("omie_servicos")
       .select("omie_codigo_servico, descricao")

--- a/supabase/functions/copilot-analyze/index.ts
+++ b/supabase/functions/copilot-analyze/index.ts
@@ -8,6 +8,7 @@ import {
   statusDoErro,
   traduzirErroAnthropic,
 } from "../_shared/anthropic.ts";
+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts";
 import { normalizarAnalise, TOOL_COPILOTO } from "./copiloto-tools.ts";
 
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "*";
@@ -53,6 +54,25 @@ serve(async (req) => {
       return new Response(
         JSON.stringify({ error: 'AI não configurada' }),
         { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // COTA — aqui o risco não é abuso (a edge é staff-only), é LOOP ACIDENTAL: o
+    // hook dispara a cada 8s enquanto a transcrição muda, então uma aba esquecida
+    // aberta a noite toda faz 10.800 chamadas sem ninguém perceber. O teto
+    // (600/h, 2500/dia) não toca ligação real, que faz ~450 por hora falada.
+    const supabaseCota = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+    );
+    const cota = await consumirCota(supabaseCota, user.id, 'copilot-analyze', 'análises do copiloto');
+    if (!cota.permitido) {
+      return new Response(
+        JSON.stringify({ error: cota.mensagem }),
+        {
+          status: cota.http,
+          headers: { ...corsHeaders, ...headersDeCota(cota), 'Content-Type': 'application/json' },
+        }
       );
     }
 

--- a/supabase/functions/identify-tool/index.ts
+++ b/supabase/functions/identify-tool/index.ts
@@ -8,6 +8,7 @@ import {
   traduzirErroAnthropic,
 } from "../_shared/anthropic.ts";
 import { montarBlocoImagem } from "../_shared/imagem.ts";
+import { consumirCota, headersDeCota } from "../_shared/ia-cota.ts";
 import { naoIdentificada, normalizarFerramenta, TOOL_FERRAMENTA } from "./ferramenta-tools.ts";
 
 const corsHeaders = {
@@ -75,6 +76,24 @@ serve(async (req) => {
       return new Response(JSON.stringify({ error: "Lista de categorias inválida" }), {
         status: 400,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // COTA — depois da validação (requisição malformada não queima cota do
+    // usuário) e antes da Anthropic. O gate acima só exige JWT válido: sem isto,
+    // um cliente repetindo fotos de até 8 MB esgota o orçamento da ORGANIZAÇÃO e
+    // derruba a IA de todo mundo, em todas as edges.
+    const supabaseCota = createClient(supabaseUrl, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+    const cota = await consumirCota(
+      supabaseCota,
+      user.id,
+      "identify-tool",
+      "identificações por foto",
+    );
+    if (!cota.permitido) {
+      return new Response(JSON.stringify({ error: cota.mensagem }), {
+        status: cota.http,
+        headers: { ...corsHeaders, ...headersDeCota(cota), "Content-Type": "application/json" },
       });
     }
 

--- a/supabase/migrations/20260803093000_ia_uso_cota.sql
+++ b/supabase/migrations/20260803093000_ia_uso_cota.sql
@@ -1,0 +1,254 @@
+-- ============================================================================
+-- Cota de IA por usuário — throttle persistente nas edges que chamam a Anthropic
+--
+-- Achado P1 do challenge /codex sobre a fase 4 da migração do gateway Lovable →
+-- Anthropic (#1640). PRÉ-EXISTENTE, não regressão: `identify-tool` e
+-- `analyze-services` sempre exigiram só JWT válido — qualquer usuário
+-- autenticado, inclusive `customer` — e nunca tiveram limite de consumo.
+--
+-- Ficou mais caro agora que o orçamento é da Anthropic e os limites dela são
+-- ORGANIZACIONAIS, não por usuário da aplicação: um cliente repetindo chamadas
+-- com imagem de até 8 MB (identify-tool) ou 100 ferramentas (analyze-services)
+-- até bater 429/402 derruba a IA de TODOS os usuários e de TODAS as edges.
+--
+-- O gate "customer pode usar" está CORRETO para o produto (identificação por
+-- foto e pedido falado são features do cliente). O que faltava era a cota.
+--
+-- SUPERFÍCIE, medida em prod via psql-ro em 2026-07-31:
+--   5.664 contas com role 'customer' … e 3 usuários que já logaram alguma vez.
+--   2 clientes com ferramenta cadastrada (média 2, p95 2).
+-- Ou seja: blindagem ANTES da abertura. Não há uso legítimo para quebrar, e
+-- também não há histórico para calibrar — os números saem de uso plausível de
+-- balcão, não de percentil observado.
+--
+-- Não havia precedente no repo: os hits de "rate limit" são backoff da API do
+-- OMIE (_shared/omie-paginacao.ts), não quota de usuário. Em prod, as únicas
+-- tabelas que casam cota|quota|limit|rate|uso|consum são prime_beneficio_uso
+-- (benefício comercial do Prime) e fin_custo_rateio — nenhuma reaproveitável.
+--
+-- ── Por que LOG DE EVENTO e não bucket agregado por janela ───────────────────
+--
+-- Bucket (uma linha por usuário/função/hora, contador incrementado) é mais
+-- barato e menor, mas a janela vira TUMBLING: 20 chamadas às 10:59 mais 20 às
+-- 11:00 são 40 em dois minutos, todas dentro de um limite nominal de 20/hora.
+-- O log de evento dá janela DESLIZANTE de verdade e, de brinde, responde "quem
+-- gastou" quando o orçamento apertar. O volume é uso humano de balcão — a
+-- purga de 7 dias mantém a tabela pequena.
+--
+-- ── Por que o advisory lock (o núcleo da correção) ───────────────────────────
+--
+-- Sem serialização, duas requisições simultâneas do mesmo usuário leem o MESMO
+-- contador e AMBAS passam. A quota vazaria exatamente sob o padrão de uso que
+-- ela existe para conter: repetição rápida. `pg_advisory_xact_lock` por
+-- (usuário, função) fecha isso sem serializar usuários distintos; o lock cai no
+-- COMMIT/ROLLBACK, então não há vazamento de lock em erro.
+-- ============================================================================
+
+-- ── 1) Eventos de consumo ───────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.ia_uso_evento (
+  id        bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id   uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  funcao    text NOT NULL,
+  criado_em timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ia_uso_evento_funcao_nao_vazia CHECK (btrim(funcao) <> '')
+);
+
+-- Serve a contagem por janela: igualdade em (user_id, funcao) e range/ordenação
+-- em criado_em.
+CREATE INDEX IF NOT EXISTS ia_uso_evento_janela_idx
+  ON public.ia_uso_evento (user_id, funcao, criado_em DESC);
+
+-- ── 2) Limites, configuráveis sem redeploy ──────────────────────────────────
+--
+-- Deploy de edge no Lovable é MANUAL (chat, verbatim). Número hardcoded na edge
+-- transformaria "afrouxar um limite apertado demais" num evento de deploy no
+-- meio do expediente. Aqui é um UPDATE no SQL Editor.
+CREATE TABLE IF NOT EXISTS public.ia_uso_limite (
+  funcao        text PRIMARY KEY,
+  limite_hora   integer NOT NULL,
+  limite_dia    integer NOT NULL,
+  atualizado_em timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT ia_uso_limite_funcao_nao_vazia CHECK (btrim(funcao) <> ''),
+  CONSTRAINT ia_uso_limite_positivos CHECK (limite_hora > 0 AND limite_dia >= limite_hora)
+);
+
+-- ON CONFLICT DO NOTHING de propósito: re-colar a migration NÃO pode desfazer
+-- um ajuste que o founder tenha feito à mão. O seed é piso inicial, não verdade
+-- perpétua.
+--
+-- Custo ≈ US$ 0,03–0,04 por chamada em Sonnet. Teto por usuário/dia:
+--   identify-tool    60 × $0,03 ≈ $1,80   (p95 real: 2 ferramentas/cliente)
+--   analyze-services 50 × $0,04 ≈ $2,00   (~15/dia já é uso pesado de verdade)
+--   copilot-analyze  2.500 × $0,03 ≈ $75  (ver nota abaixo)
+--
+-- copilot-analyze é STAFF-ONLY e dispara a cada 8s enquanto a transcrição muda
+-- (ANALYSIS_INTERVAL_MS em useCopilotEngine) ⇒ ~450 chamadas por HORA de ligação
+-- real. O risco ali não é abuso, é LOOP ACIDENTAL: aba esquecida aberta a noite
+-- toda dá 10.800 chamadas em 24h. O teto folgado não toca ligação real e corta
+-- o loop pela metade do dia.
+INSERT INTO public.ia_uso_limite (funcao, limite_hora, limite_dia) VALUES
+  ('identify-tool',     20,   60),
+  ('analyze-services',  20,   50),
+  ('copilot-analyze',  600, 2500)
+ON CONFLICT (funcao) DO NOTHING;
+
+-- ── 3) Autorização ──────────────────────────────────────────────────────────
+--
+-- RLS habilitada e SEM POLICY NENHUMA = nega tudo para anon/authenticated. Só a
+-- RPC (SECURITY DEFINER, roda como owner) toca as tabelas.
+--
+-- FORCE ROW LEVEL SECURITY fica FORA de propósito: com FORCE a RLS valeria
+-- também para o owner e a própria RPC seria barrada no INSERT.
+--
+-- REVOKE nominal porque `REVOKE FROM PUBLIC` NÃO tira anon/authenticated — eles
+-- têm grant explícito no Supabase (CLAUDE.md / docs/agent/database.md).
+ALTER TABLE public.ia_uso_evento ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.ia_uso_limite ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.ia_uso_evento FROM PUBLIC;
+REVOKE ALL ON TABLE public.ia_uso_limite FROM PUBLIC;
+REVOKE ALL ON TABLE public.ia_uso_evento FROM anon, authenticated;
+REVOKE ALL ON TABLE public.ia_uso_limite FROM anon, authenticated;
+
+-- ── 4) Consumo atômico ──────────────────────────────────────────────────────
+--
+-- DECIDE E REGISTRA na mesma transação. Separar em "consultar" + "registrar"
+-- reabriria a corrida que o lock fecha.
+CREATE OR REPLACE FUNCTION public.ia_consumir_cota(
+  p_user_id uuid,
+  p_funcao  text
+)
+RETURNS TABLE (
+  permitido          boolean,
+  motivo             text,
+  usado_hora         integer,
+  limite_hora        integer,
+  usado_dia          integer,
+  limite_dia         integer,
+  libera_em_segundos integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_limite_hora integer;
+  v_limite_dia  integer;
+  v_usado_hora  integer;
+  v_usado_dia   integer;
+  v_libera      integer;
+BEGIN
+  IF p_user_id IS NULL OR p_funcao IS NULL OR btrim(p_funcao) = '' THEN
+    RAISE EXCEPTION 'ia_consumir_cota: p_user_id e p_funcao são obrigatórios'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Serializa por (usuário, função). Cai sozinho no fim da transação.
+  PERFORM pg_advisory_xact_lock(hashtextextended(p_user_id::text || ':' || p_funcao, 0));
+
+  SELECT l.limite_hora, l.limite_dia
+    INTO v_limite_hora, v_limite_dia
+    FROM public.ia_uso_limite l
+   WHERE l.funcao = p_funcao;
+
+  -- FAIL-CLOSED: função sem limite configurado não gasta orçamento. Edge nova
+  -- que esqueça o seed é negada com motivo próprio, em vez de ganhar acesso
+  -- irrestrito por omissão.
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT false, 'sem_limite'::text, 0, 0, 0, 0, 0;
+    RETURN;
+  END IF;
+
+  -- Uma varredura só resolve as duas janelas: o filtro externo de 24h delimita,
+  -- o FILTER interno recorta a hora.
+  SELECT
+      count(*) FILTER (WHERE e.criado_em > now() - interval '1 hour')::integer,
+      count(*)::integer
+    INTO v_usado_hora, v_usado_dia
+    FROM public.ia_uso_evento e
+   WHERE e.user_id = p_user_id
+     AND e.funcao  = p_funcao
+     AND e.criado_em > now() - interval '24 hours';
+
+  IF v_usado_hora >= v_limite_hora THEN
+    -- Com janela deslizante, a vaga abre quando a `limite`-ésima chamada mais
+    -- recente sai da janela: as mais recentes que ela são limite-1, e todas as
+    -- mais antigas já saíram (criado_em é monotônico com a posição). Vale
+    -- inclusive se o limite foi REDUZIDO a quente e usado > limite.
+    SELECT GREATEST(1, ceil(extract(epoch FROM (x.criado_em + interval '1 hour' - now()))))::integer
+      INTO v_libera
+      FROM (
+        SELECT e.criado_em
+          FROM public.ia_uso_evento e
+         WHERE e.user_id = p_user_id
+           AND e.funcao  = p_funcao
+           AND e.criado_em > now() - interval '1 hour'
+         ORDER BY e.criado_em DESC
+        OFFSET (v_limite_hora - 1) LIMIT 1
+      ) x;
+
+    RETURN QUERY SELECT false, 'hora'::text, v_usado_hora, v_limite_hora,
+                        v_usado_dia, v_limite_dia, COALESCE(v_libera, 1);
+    RETURN;
+  END IF;
+
+  IF v_usado_dia >= v_limite_dia THEN
+    SELECT GREATEST(1, ceil(extract(epoch FROM (x.criado_em + interval '24 hours' - now()))))::integer
+      INTO v_libera
+      FROM (
+        SELECT e.criado_em
+          FROM public.ia_uso_evento e
+         WHERE e.user_id = p_user_id
+           AND e.funcao  = p_funcao
+           AND e.criado_em > now() - interval '24 hours'
+         ORDER BY e.criado_em DESC
+        OFFSET (v_limite_dia - 1) LIMIT 1
+      ) x;
+
+    RETURN QUERY SELECT false, 'dia'::text, v_usado_hora, v_limite_hora,
+                        v_usado_dia, v_limite_dia, COALESCE(v_libera, 1);
+    RETURN;
+  END IF;
+
+  INSERT INTO public.ia_uso_evento (user_id, funcao) VALUES (p_user_id, p_funcao);
+
+  -- Contadores JÁ incluem esta chamada: é o que a edge precisa para dizer
+  -- "você usou 18 de 20" sem uma segunda consulta.
+  RETURN QUERY SELECT true, 'ok'::text, v_usado_hora + 1, v_limite_hora,
+                      v_usado_dia + 1, v_limite_dia, 0;
+END;
+$$;
+
+-- Só service_role executa. Se `authenticated` pudesse, um cliente chamaria a
+-- RPC com o user_id de OUTRO e queimaria a cota alheia — a função aceita o
+-- user_id como parâmetro justamente porque quem a chama é a edge, que já
+-- autenticou o JWT e sabe de quem é.
+REVOKE ALL ON FUNCTION public.ia_consumir_cota(uuid, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.ia_consumir_cota(uuid, text) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.ia_consumir_cota(uuid, text) TO service_role;
+
+COMMENT ON FUNCTION public.ia_consumir_cota(uuid, text) IS
+  'Cota de IA por usuário: decide e registra o consumo numa transação só. '
+  'Fail-closed — função sem linha em ia_uso_limite é negada com motivo sem_limite. '
+  'Chamada apenas pelas edges (service_role).';
+
+-- ── 5) Purga ────────────────────────────────────────────────────────────────
+--
+-- 7 dias: a janela mais longa da cota é 24h, o resto é margem para auditoria
+-- ("quem gastou nesta semana"). DELETE puro, sem net.http_post — o alerta de
+-- timeout_milliseconds do CLAUDE.md não se aplica aqui.
+--
+-- Idempotente: unschedule antes de reagendar (cron.schedule já é upsert por
+-- nome; o unschedule limpa estado zumbi). Re-colar = no-op.
+DO $do$
+BEGIN
+  PERFORM cron.unschedule('ia-uso-evento-purga');
+EXCEPTION WHEN OTHERS THEN NULL;  -- idempotente: ignora se o job ainda não existe
+END
+$do$;
+
+SELECT cron.schedule(
+  'ia-uso-evento-purga',
+  '23 4 * * *',
+  $job$ DELETE FROM public.ia_uso_evento WHERE criado_em < now() - interval '7 days' $job$
+);


### PR DESCRIPTION
Achado **P1** do challenge `/codex` sobre a fase 4 da migração do gateway Lovable → Anthropic (#1640). **Pré-existente, não regressão** — ficou mais caro agora que o orçamento é da Anthropic e compartilhado.

## O problema

`identify-tool` e `analyze-services` exigiam apenas JWT válido (qualquer autenticado, inclusive `customer`) e não tinham nenhum limite de consumo. Como os limites da Anthropic são **organizacionais**, um cliente repetindo chamadas com imagens de até 8 MB ou 100 ferramentas até bater 429/402 **derruba a IA de todos os usuários e de todas as edges**.

O gate "customer pode usar" está **correto** para o produto — identificação por foto e pedido falado são features do cliente. O que faltava era o throttle.

## Superfície (medida em prod via psql-ro, 2026-07-31)

| fato | valor |
|---|---|
| contas com role `customer` | **5.664** |
| usuários que já logaram alguma vez | **3** |
| clientes com ferramenta cadastrada | 2 (média 2, p95 2) |
| tabela/função de rate-limit já existente | **nenhuma** |

Blindagem **antes** da abertura: não há uso legítimo para quebrar — e também não há histórico para calibrar, então os números saem de uso plausível de balcão. Confirmado que não havia precedente: os hits de `rate.?limit` no repo são backoff da API do **Omie**, não quota de usuário.

## Desenho

| objeto | papel |
|---|---|
| `ia_uso_evento` | uma linha por chamada, índice `(user_id, funcao, criado_em DESC)` |
| `ia_uso_limite` | os números, seedados — ajustáveis por `UPDATE` sem redeploy de edge |
| `ia_consumir_cota(...)` | **decide e registra na mesma transação** |
| cron `ia-uso-evento-purga` | `DELETE` de eventos > 7 dias |

Três decisões que são o núcleo:

1. **`pg_advisory_xact_lock` por (usuário, função).** Sem ele, duas requisições simultâneas do mesmo usuário leem o mesmo contador e **ambas passam** — a quota vazaria exatamente sob o padrão que ela existe para conter.
2. **Log de evento, não bucket agregado.** Bucket por janela truncada permitiria 20 chamadas às 10:59 + 20 às 11:00 = 40 em dois minutos, dentro de um limite nominal de 20/h. O log dá janela deslizante de verdade.
3. **Fail-closed com voz própria.** Função sem linha em `ia_uso_limite` é negada (edge nova que esqueça o seed não ganha acesso irrestrito por omissão); falha da RPC vira 503 com mensagem própria.

### A mensagem

Negar calado repetiria o sintoma que a migração inteira tentou resolver. Três respostas distinguíveis:

| situação | HTTP | o que o usuário lê |
|---|---|---|
| cota do usuário | 429 + `Retry-After` | "Você atingiu seu limite de 20 identificações por foto nesta hora — é o seu limite de uso, **não uma falha da IA**. Libera em 22 minutos." |
| RPC falhou / payload malformado | 503 | "Não consegui verificar seu limite de uso agora. Tente de novo em instantes." |
| 429 da própria Anthropic (já existia) | 429 | "Limite de requisições excedido. Tente novamente em alguns segundos." |

Duração **relativa**, não hora absoluta: o banco é UTC e o balcão é America/Sao_Paulo — "libera às 11:35" mentiria sem ninguém notar.

### Números

| edge | hora | dia | racional |
|---|---|---|---|
| `identify-tool` | 20 | 60 (~$1,80) | p95 real é 2 ferramentas/cliente; cobre cadastro em lote com ~30× de folga |
| `analyze-services` | 20 | 50 (~$2,00) | pedido falado com regravações; ~15/dia já é uso pesado |
| `copilot-analyze` | 600 | 2.500 (~$75) | ligação real é ~450/h |

`copilot-analyze` foi avaliado separado: é staff-only e dispara a cada 8 s, então o risco não é abuso — é **loop acidental** (aba esquecida a noite toda = 10.800 chamadas). O teto não toca ligação real e corta o loop.

## Achado extra: o copiloto martelava calado

`useCopilotEngine` engolia o erro (só `console.error`) e zerava `lastAnalyzedRef` — correto para falha transitória, mas em quota estourada vira um martelo a cada 8 s contra um limite que não cede, com a vendedora sem saber por que as sugestões pararam. Agora ele exibe o motivo e **suspende os disparos** até a janela virar, respeitando o `Retry-After`. Para isso, `invokeFunction` passou a propagar `status` e `retryAfterSeconds` (antes o status só era logado).

## Prova

`db/test-ia-uso-cota.sh` — PG17 descartável, migration **real** aplicada:

- **33 asserts**: limites, janela deslizante (evento de 2 h não conta na hora, de 25 h não conta em nada), fail-closed, isolamento entre usuários, CHECKs, RLS sob `SET ROLE authenticated`, `REVOKE` de tabela e de `EXECUTE`, cron registrado, idempotência (re-aplicar **não** desfaz ajuste manual do founder), e o advisory lock **realmente adquirido** (segunda conexão bloqueia com 55P03).
- **6 sabotagens**, cada uma mirando um assert: gate da hora, fail-closed, janela deslizante, advisory lock, `REVOKE EXECUTE`, RLS. Todas detectadas.
- Verde em `LC_ALL=C` **e** `pt_BR.UTF-8` (lição do #1483: falsificar num locale só não prova a asserção).

Dois bugs reais caíram nessa malha: `formatarEspera(3599)` devolvia **"60 minutos"** (guard de fronteira no ramo errado), e o meu próprio assert da janela deslizante estava mal montado (limite diário mascarava o horário).

## Gates

| gate | resultado |
|---|---|
| `bun run typecheck` | exit 0 |
| `bun run lint` | exit 0 (72 warnings pré-existentes) |
| `bun run test` | exit 0 — 646 arquivos, **5.914 testes** |
| `test:edges` (Deno `--no-remote`) | exit 0 — **579 testes** |
| `edges:typecheck` | exit 0 — 0 erros de classe-crash |
| `bunx knip` | nenhum arquivo deste PR no relatório |

## ⚠️ Deploy — 3 camadas MANUAIS

1. **Migration** → SQL Editor: `supabase/migrations/20260803093000_ia_uso_cota.sql` (nome custom **não** auto-aplica — falha silenciosa).
2. **Edges** → chat do Lovable, verbatim: `_shared/ia-cota.ts`, `identify-tool/index.ts`, `analyze-services/index.ts`, `copilot-analyze/index.ts`.
3. **Publish** do frontend (mudança em `useCopilotEngine` / `FarmerCopilot` / `invoke-function`).

**A ordem importa:** a migration vem PRIMEIRO. Sem as tabelas, o fail-closed nega tudo e as três features param — que é o comportamento correto, mas seria um apagão auto-infligido.

## Coordenação

O #1212 (aberto) também toca `src/lib/invoke-function.ts`, com base anterior à main atual. #1520 e #1332 tocam `src/lib/modulos/manifesto.ts`, onde meu diff é uma linha acrescentada a uma lista. Quem mergear primeiro obriga o outro a rebase — conflitos pequenos e localizados; o núcleo da cota é código novo que nenhum deles toca.

## Fora de escopo (decidido)

Disjuntor global (teto diário da organização): com 3 logins reais o cenário agregado é hipotético, e um teto global por desenho derruba a feature para todos — o mesmo sintoma que queremos evitar. O formato da tabela permite adicioná-lo depois sem migration nova.

Desenho completo: `docs/superpowers/specs/2026-07-31-ia-cota-por-usuario-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
