### PR TITLE
perf(contexto): Read para de despejar arquivo inteiro sem aviso — nudge por volume e por releitura

### DIFF
--- a/.claude/hooks/read-contexto-nudge.sh
+++ b/.claude/hooks/read-contexto-nudge.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# read-contexto-nudge.sh — PreToolUse(Read): disciplina de leitura.
+#
+# POR QUÊ: o Read é 60,2% de todo o texto que entra por ferramenta (18,2M tokens
+# em 48 dias; 8.836 chamadas, média 2.058 tok). E 82% do custo de token é ENTRADA
+# de contexto, não geração — então o alvo é o que ENTRA. Dois bolsos concentram
+# o desperdício:
+#   (a) VOLUME    — 226 leituras acima de 10k tokens = 2,6% das chamadas e 32%
+#                   do volume. Um Read de 50k no início de uma sessão de 1.000
+#                   requests é relido ~1.000 vezes (~US$ 25 sozinho).
+#   (b) RELEITURA — 2.457 leituras repetidas do MESMO arquivo na MESMA sessão
+#                   (28% dos Reads; campeão: um index.ts lido 24 vezes). A cópia
+#                   anterior não sai do contexto — a segunda só empilha.
+# O contraste com o subagente é a tese: ele lê muito, pensa muito e devolve 638
+# tokens em média. Por isso a mensagem EMPURRA para subagente; não proíbe Read.
+#
+# NÃO BLOQUEIA e NÃO DECIDE PERMISSÃO — só anexa contexto. Emitir
+# permissionDecision:"allow" pularia o prompt de permissão de toda leitura
+# (auto-aprovaria ler ~/.ssh/id_rsa); "deny"/"ask" quebraria investigação
+# legítima. O padrão do repo é nudge; o CI é o gate.
+#
+# LIMITAÇÃO ASSUMIDA: rodando em PreToolUse, o aviso chega ao modelo junto com o
+# resultado da leitura — ele não evita o custo DESTA leitura, muda a PRÓXIMA
+# decisão. Evitar a primeira exigiria "ask"/"deny", que foi descartado acima.
+#
+# BARATO DE PROPÓSITO: 1 jq + 1 stat + 1 head|wc + 1 grep numa marca pequena.
+# Roda antes de CADA Read (dezenas por turno), então nada de varrer transcript
+# nem chamar git — brigaria com a latência por turno e com o semáforo `heavy`.
+# Testes em scripts/test-read-contexto-nudge.sh.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+entrada="$(cat)"
+
+# Um único jq para os 5 campos: o hook roda antes de CADA Read (dezenas por
+# turno) e cada `printf | jq` custa um fork (~10ms medidos). `file_path` vem por
+# último porque `read` joga o resto da linha no último campo — assim um caminho
+# com tab não desloca os outros.
+campos="$(printf '%s' "$entrada" | jq -r '[(.tool_name // ""), (.session_id // "sem-id"),
+  ((.tool_input.limit // 0)|tostring), ((.tool_input.offset // 0)|tostring),
+  (.tool_input.file_path // "")] | @tsv' 2>/dev/null)"
+IFS="$(printf '\t')" read -r tool sessao limite inicio arquivo <<EOF
+$campos
+EOF
+
+[ "$tool" = "Read" ] || exit 0        # defesa se o matcher do settings.json mudar
+[ -n "${arquivo:-}" ] && [ -f "$arquivo" ] || exit 0   # inexistente: quem reporta é o Read
+
+# Binário/imagem/PDF: a heurística de bytes→tokens não vale (o custo não sai do
+# tamanho do arquivo). Silêncio é melhor que conselho errado.
+case "$(printf '%s' "$arquivo" | tr '[:upper:]' '[:lower:]')" in
+  *.png|*.jpg|*.jpeg|*.gif|*.webp|*.bmp|*.svg|*.ico|*.pdf|*.zip|*.gz|*.woff|*.woff2|*.ttf) exit 0 ;;
+esac
+
+# --- quanto ESTA leitura vai injetar -----------------------------------------
+# Não é o tamanho do arquivo: o Read lê no máximo `limit` linhas (default 2000) a
+# partir de `offset`. Medido no repo: types.ts tem 612KB mas só 58KB nas 2000
+# primeiras linhas (19.973 linhas curtas), enquanto bugs-resolvidos.md entrega
+# 486KB em 376 linhas (linha média de 1,3KB). Estimar pelo arquivo erraria os
+# dois lados — o que conta são as linhas EFETIVAMENTE lidas.
+case "$limite" in ''|*[!0-9]*|0) limite=2000 ;; esac    # default do Read
+case "$inicio" in ''|*[!0-9]*|0) inicio=1 ;; esac
+[ "$limite" -gt 0 ] || exit 0
+
+bytes="$(tail -n "+$inicio" "$arquivo" 2>/dev/null | head -n "$limite" 2>/dev/null | wc -c 2>/dev/null | tr -d ' ')"
+case "$bytes" in ''|*[!0-9]*) exit 0 ;; esac
+tokens=$(( bytes * 10 / 36 ))          # ~3,6 bytes/token em código e markdown
+
+# --- marca da sessão: o que já foi lido --------------------------------------
+# Uma linha por leitura: "<mtime>|<offset>|<limite>|<caminho>". mtime na chave
+# porque reler um arquivo QUE MUDOU é legítimo (o conteúdo no contexto está
+# velho); offset/limite porque ler OUTRO trecho é leitura complementar, não
+# desperdício. Só a repetição exata dos três é cópia pura.
+marca="${TMPDIR:-/tmp}/afiacao-read-${sessao}"
+mtime="$(stat -f '%m' "$arquivo" 2>/dev/null || stat -c '%Y' "$arquivo" 2>/dev/null || echo 0)"
+chave="${mtime}|${inicio}|${limite}|${arquivo}"
+vistas=0
+if [ -f "$marca" ]; then
+  vistas="$(command grep -Fxc -- "$chave" "$marca" 2>/dev/null || echo 0)"
+  case "$vistas" in ''|*[!0-9]*) vistas=0 ;; esac
+fi
+printf '%s\n' "$chave" >> "$marca" 2>/dev/null || true
+
+curto="$(basename -- "$arquivo")"
+tok_k=$(( tokens / 1000 ))
+
+# --- (b) releitura: tem precedência ------------------------------------------
+# Vem antes do volume de propósito: na 2ª leitura do mesmo arquivo grande o que
+# importa é que a cópia JÁ ESTÁ no contexto, não que o arquivo é grande. Sem
+# isso, um arquivo grande relido gritaria as duas coisas a cada leitura.
+#
+# READ-RELEITURA / READ-GRANDE são CONTRATO DE TESTE: marcadores ASCII, caixa
+# fixa, exclusivos de um ramo. scripts/test-read-contexto-nudge.sh casa por eles
+# com `command grep` sem -i — prosa acentuada casaria o ramo errado sob
+# pt_BR.UTF-8 e não sob LC_ALL=C (#1483). Não troque por trechos do português.
+if [ "$vistas" -gt 0 ]; then
+  n=$(( vistas + 1 ))
+  msg="🔁 Releitura: ${curto} (${n}ª vez nesta sessão, arquivo inalterado) — a 1ª cópia continua no contexto."
+  ctx="READ-RELEITURA: você já leu ${arquivo} nesta sessão (esta é a ${n}ª vez), no mesmo trecho, e o arquivo NÃO mudou desde então. O conteúdo continua no seu contexto acima — reler injeta uma segunda cópia idêntica e não traz informação nova. Role para cima e use o que já leu. Se precisa de OUTRO trecho, use offset/limit; se quer confirmar uma alteração sua, o resultado do Edit já mostrou o diff."
+else
+  # --- (a) volume: só na PRIMEIRA leitura daquele trecho ---------------------
+  # 10k tokens = o corte medido (2,6% das chamadas, 32% do volume). Abaixo disso
+  # o aviso viraria ruído: 96% dos arquivos do repo passam longe.
+  [ "$tokens" -ge 10000 ] || exit 0
+  if [ "$tokens" -ge 40000 ]; then
+    grito="🔴"; peso="Isso sozinho ocupa mais que muitas sessões inteiras."
+  else
+    grito="🟡"; peso="Cada turno seguinte relê esses ${tok_k}k."
+  fi
+  msg="${grito} Leitura cara: ${curto} ≈ ${tok_k}k tokens. ${peso}
+→ delegue a um subagente (ele devolve ~638 tok em média) ou use rg + Read com offset/limit."
+  ctx="READ-GRANDE: a leitura de ${arquivo} vai injetar cerca de ${tok_k}k tokens no contexto, e cada turno seguinte relê tudo isso. Antes de ler o arquivo inteiro de novo, considere, nesta ordem: (1) delegue a um subagente (Agent/Explore) — ele lê muito, pensa muito e devolve ~638 tokens em média, contra os ~2.058 de um Read médio; (2) localize o trecho com Grep/rg e leia só ele com offset/limit; (3) se o alvo é um dump, log ou arquivo gerado (schema-snapshot.sql, types.ts, package-lock.json), prefira consultar com rg/jq a trazer para o contexto. Se você realmente precisa do arquivo inteiro, siga em frente — isto é um lembrete, não um bloqueio."
+fi
+
+jq -n --arg m "$msg" --arg c "$ctx" \
+  '{systemMessage:$m, hookSpecificOutput:{hookEventName:"PreToolUse", additionalContext:$c}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -95,6 +95,16 @@
         ]
       },
       {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/read-contexto-nudge.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "Write|Edit",
         "hooks": [
           {

--- a/scripts/test-read-contexto-nudge.sh
+++ b/scripts/test-read-contexto-nudge.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# test-read-contexto-nudge.sh — TDD do hook .claude/hooks/read-contexto-nudge.sh
+#
+# Regra sob teste (duas, independentes):
+#   (a) VOLUME    — a leitura vai injetar >= 10k tokens estimados → avisa (marcador READ-GRANDE)
+#   (b) RELEITURA — mesmo arquivo, MESMO range, arquivo NÃO alterado, na mesma
+#                   sessão → avisa (marcador READ-RELEITURA)
+# Silêncio (exit 0, zero stdout) em tudo o mais. NUNCA emite permissionDecision:
+# o hook não bloqueia nem auto-aprova — só anexa contexto.
+#
+# Os marcadores casados aqui são ASCII puro, caixa fixa e EXCLUSIVOS de um ramo —
+# de propósito. `grep -i` sobre texto pt-BR acentuado casa o ramo errado sob
+# pt_BR.UTF-8 (o `grep` do shell é shim p/ ugrep, que dobra Ã↔ã) e não sob LC_ALL=C:
+# a asserção passaria a falsificar por acidente de locale, não por desenho (#1483).
+# Por isso: `command grep`, sem -i, string ASCII. NÃO troque os marcadores por
+# trechos da prosa em português — o hook os declara como contrato de teste.
+#
+# Uso:
+#   bash scripts/test-read-contexto-nudge.sh              # suíte (exit 0 = verde)
+#   bash scripts/test-read-contexto-nudge.sh --falsificar # sabota o hook e EXIGE vermelho
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="${HOOK_SOB_TESTE:-$here/../.claude/hooks/read-contexto-nudge.sh}"
+command -v jq >/dev/null 2>&1 || { echo "SKIP — jq ausente"; exit 0; }
+[ -f "$HOOK" ] || { echo "VERMELHO — hook não encontrado: $HOOK"; exit 1; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export TMPDIR="$tmp"          # isola as marcas de sessão deste teste
+
+# ------------------------------------------------------------ falsificação ---
+# Suíte verde não prova nada se ela não souber ficar vermelha. Aqui cada
+# sabotagem quebra UMA regra do hook e a suíte precisa acusar; se passar, é a
+# ASSERÇÃO que está frouxa, não o hook que está bom.
+#
+# Roda nos DOIS locales de propósito: uma asserção pode falsificar por acidente
+# de ambiente e não por desenho — `grep -qi` sobre pt-BR casa "NÃO"/"não" sob
+# pt_BR.UTF-8 (ugrep dobra Ã↔ã) e não sob LC_ALL=C, ficando vermelha só no shell
+# de quem escreveu (#1483). Se um locale acusa e o outro não, a suíte mente.
+# shellcheck disable=SC2016  # os padrões de sed abaixo usam aspas simples de
+# propósito: `${mtime}`/`${tokens}` são o TEXTO que o sed procura dentro do hook,
+# e precisam chegar até ele sem serem expandidos por este shell.
+if [ "${1:-}" = "--falsificar" ]; then
+  falhou=0
+  printf '== falsificacao (sabota o hook e EXIGE vermelho) ==\n'
+
+  # sabota <descricao> <regra-que-deve-quebrar> <expressao-sed>
+  # O delimitador do sed é `%` porque os padrões contêm `|` (o `||` do shell) —
+  # reusar `|` como delimitador produziria um sed INVÁLIDO, que escreveria uma
+  # cópia vazia. Cópia vazia também fica vermelha, e a falsificação passaria
+  # parecendo boa sem ter sabotado regra nenhuma. Daí as 3 travas abaixo.
+  sabota() {
+    local desc="$1" regra="$2" expr="$3" copia="$tmp/sabotado.sh" erro
+    erro="$(sed "$expr" "$HOOK" 2>&1 >"$copia")"
+    if [ -n "$erro" ]; then
+      printf '  \033[31mFALHA\033[0m "%s": sed invalido (%s) — falsificacao vazia\n' "$desc" "${erro:0:50}"; falhou=1; return
+    fi
+    if cmp -s "$HOOK" "$copia"; then
+      printf '  \033[31mFALHA\033[0m "%s": padrao nao casou, hook intacto — falsificacao vazia\n' "$desc"; falhou=1; return
+    fi
+    if ! bash -n "$copia" 2>/dev/null; then
+      printf '  \033[31mFALHA\033[0m "%s": quebrou a SINTAXE — vermelho pelo motivo errado\n' "$desc"; falhou=1; return
+    fi
+    for loc in C pt_BR.UTF-8; do
+      if LC_ALL="$loc" HOOK_SOB_TESTE="$copia" bash "$0" >/dev/null 2>&1; then
+        printf '  \033[31mFALHA\033[0m [%s] "%s" passou VERDE — a suite nao cobre: %s\n' "$loc" "$desc" "$regra"
+        falhou=1
+      else
+        printf '  \033[32mok\033[0m   [%-11s] "%s" -> vermelho\n' "$loc" "$desc"
+      fi
+    done
+  }
+
+  sabota "sempre silencia"      "avisar quando a leitura e cara" \
+         's%^jq -n --arg m%exit 0 # SABOTADO%'
+  sabota "sem corte de 10k"     "silenciar leitura barata" \
+         's%\[ "\$tokens" -ge 10000 \] || exit 0%:%'
+  sabota "mtime fora da chave"  "reler arquivo ALTERADO e legitimo" \
+         's%chave="\${mtime}|%chave="%'
+  sabota "range fora da chave"  "ler OUTRO trecho nao e releitura" \
+         's%\${inicio}|\${limite}|%%'
+  sabota "decide permissao"     "nunca emitir permissionDecision" \
+         's%hookEventName:"PreToolUse"%hookEventName:"PreToolUse", permissionDecision:"deny"%'
+
+  printf '\n'
+  if [ "$falhou" -eq 0 ]; then echo "VERDE — toda sabotagem foi detectada, nos 2 locales"; exit 0; fi
+  echo "VERMELHO — ha sabotagem passando despercebida"; exit 1
+fi
+
+# ---------------------------------------------------------------- fixtures ---
+# grande: 400 linhas de ~1KB = ~400KB → ~111k tokens. Espelha o formato que mais
+# dói de verdade (docs/historico/bugs-resolvidos.md: 376 linhas, 486KB) — poucas
+# linhas MUITO longas, que estouram mesmo dentro do teto de 2000 linhas do Read.
+linha="$(printf 'x%.0s' $(seq 1 1000))"
+grande="$tmp/grande.md";  : > "$grande"
+for _ in $(seq 1 400); do printf '%s\n' "$linha" >> "$grande"; done
+pequeno="$tmp/pequeno.ts"; printf 'export const a = 1;\n%.0s' $(seq 1 50) > "$pequeno"
+imagem="$tmp/diagrama.png"; printf 'PNG%s' "$linha" > "$imagem"
+
+run() {  # $1=file_path $2=session $3=limit(0=ausente) $4=offset(0=ausente)
+  jq -nc --arg f "$1" --arg s "$2" --argjson l "${3:-0}" --argjson o "${4:-0}" \
+    '{hook_event_name:"PreToolUse", tool_name:"Read", session_id:$s,
+      tool_input:({file_path:$f}
+                  + (if $l > 0 then {limit:$l} else {} end)
+                  + (if $o > 0 then {offset:$o} else {} end))}' \
+  | bash "$HOOK" 2>/dev/null
+}
+
+fail=0
+ok()  { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad() { printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
+# marcador ASCII exclusivo, sem -i, via `command grep` (o grep do shell é shim p/ ugrep)
+tem() { printf '%s' "$2" | command grep -q "$1"; }
+check(){ # $1=descrição $2=esperado(READ-GRANDE|READ-RELEITURA|silencio) $3=saída
+  local desc="$1" esp="$2" out="$3"
+  if [ "$esp" = "silencio" ]; then
+    if [ -z "$out" ]; then ok "$desc"; else bad "$desc (esperava silêncio, veio: '${out:0:70}')"; fi
+  else
+    if tem "$esp" "$out"; then ok "$desc"; else bad "$desc (esperava $esp, veio: '${out:0:70}')"; fi
+  fi
+}
+
+echo "== read-contexto-nudge =="
+
+# --- (a) volume --------------------------------------------------------------
+# 1. arquivo pequeno → silêncio
+check "arquivo pequeno → silêncio" silencio "$(run "$pequeno" s1)"
+
+# 2. arquivo grande → avisa volume
+out2="$(run "$grande" s2)"
+check "arquivo grande (~111k tok) → avisa volume" READ-GRANDE "$out2"
+
+# 3. JSON bem-formado com os dois canais (founder + agente).
+#    printf, não echo: echo interpreta o \n escapado e corrompe o JSON (CLAUDE.md).
+if printf '%s' "$out2" | jq -e '.systemMessage and .hookSpecificOutput.additionalContext' >/dev/null 2>&1
+then ok "JSON válido com systemMessage + additionalContext"
+else bad "JSON inválido ou incompleto"; fi
+
+# 4. hookEventName correto
+if printf '%s' "$out2" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null 2>&1
+then ok "hookEventName = PreToolUse"
+else bad "hookEventName errado"; fi
+
+# 5. NÃO decide permissão. Emitir permissionDecision:"allow" pularia o prompt de
+#    permissão de TODA leitura — auto-aprovaria ler ~/.ssh/id_rsa. E "deny"/"ask"
+#    quebraria investigação legítima. O hook só anexa contexto.
+if printf '%s' "$out2" | command grep -q 'permissionDecision'
+then bad "emitiu permissionDecision (não pode decidir permissão)"
+else ok "não decide permissão (nem allow, nem deny, nem ask)"; fi
+
+# 6. o que conta é o VOLUME lido, não a presença de `limit`. Com linhas de ~1KB,
+#    limit=10 lê ~10KB (~2,8k tok) → silêncio...
+check "grande + limit=10 (~2,8k tok) → silêncio" silencio "$(run "$grande" s6 10)"
+
+# 6b. ...mas limit=50 nas MESMAS linhas lê ~50KB (~13k tok) e ainda dói: `limit`
+#     não é garantia de leitura barata. Este caso já pegou uma premissa errada
+#     minha ("usou limit → não avisa") — o corte é por tokens, não por flag.
+check "grande + limit=50 (~13k tok) → avisa mesmo com limit" READ-GRANDE "$(run "$grande" s6b 50)"
+
+# 7. o teto de 2000 linhas do Read entra na conta: arquivo de linhas CURTAS cujo
+#    total passa de 10k tok, mas cujas 2000 primeiras linhas não → silêncio.
+curto="$tmp/muitas-linhas-curtas.ts"; : > "$curto"
+for _ in $(seq 1 12000); do printf 'const x = 1;\n' >> "$curto"; done
+check "60k linhas curtas (teto de 2000 linhas) → silêncio" silencio "$(run "$curto" s7)"
+
+# --- (b) releitura -----------------------------------------------------------
+# 8. mesmo arquivo, mesma sessão, sem alteração → avisa releitura
+_=$(run "$pequeno" s8)
+check "2ª leitura idêntica → avisa releitura" READ-RELEITURA "$(run "$pequeno" s8)"
+
+# 9. ranges diferentes NÃO são releitura — é leitura complementar do arquivo.
+#    Os dois ranges são pequenos E existem dentro do arquivo (400 linhas), senão
+#    o caso passaria por acidente: offset além do fim lê 0 byte e silenciaria
+#    sozinho, sem provar nada sobre a regra de releitura.
+_=$(run "$grande" s9 10 1)
+check "mesmo arquivo, range diferente → silêncio" silencio "$(run "$grande" s9 10 200)"
+
+# 10. arquivo alterado entre as leituras → releitura legítima, silêncio
+mudou="$tmp/mudou.ts"; printf 'a\n' > "$mudou"
+_=$(run "$mudou" s10)
+sleep 1; printf 'b\n' >> "$mudou"          # mtime muda
+check "arquivo alterado entre leituras → silêncio" silencio "$(run "$mudou" s10)"
+
+# 11. a marca é POR SESSÃO — outra sessão relendo o mesmo arquivo não herda
+_=$(run "$pequeno" s11)
+check "outra sessão, 1ª leitura → silêncio" silencio "$(run "$pequeno" s11b)"
+
+# --- fail-safes --------------------------------------------------------------
+# 12. arquivo inexistente → silêncio (o próprio Read reporta o erro)
+check "arquivo inexistente → silêncio" silencio "$(run "$tmp/nao-existe.ts" s12)"
+
+# 13. binário/imagem → silêncio (a heurística de bytes não vale; não dar conselho errado)
+check "imagem → silêncio" silencio "$(run "$imagem" s13)"
+
+# 14. outra ferramenta no payload → silêncio (defesa se o matcher mudar)
+check "tool_name != Read → silêncio" silencio \
+  "$(jq -nc --arg f "$grande" '{hook_event_name:"PreToolUse",tool_name:"Grep",session_id:"s14",tool_input:{file_path:$f}}' | bash "$HOOK" 2>/dev/null)"
+
+# 15. o aviso de volume sai UMA VEZ por arquivo/sessão — na 2ª vez quem fala é a
+#     releitura, senão o mesmo arquivo grande gritaria volume a cada leitura.
+_=$(run "$grande" s15)
+out15="$(run "$grande" s15)"
+if tem READ-RELEITURA "$out15" && ! tem READ-GRANDE "$out15"
+then ok "2ª leitura de arquivo grande → só releitura, sem repetir volume"
+else bad "2ª leitura de grande: esperava só READ-RELEITURA (veio: '${out15:0:70}')"; fi
+
+# 16. o payload real do Claude Code traz file_path relativo em alguns clientes;
+#     caminho não resolvível → silêncio, nunca erro.
+check "caminho relativo não resolvível → silêncio" silencio "$(run "src/nao/existe.ts" s16)"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "VERDE — todos os casos passaram"; exit 0; fi
+echo "VERMELHO — ha casos falhando"; exit 1


### PR DESCRIPTION
## O quê

Hook `PreToolUse(Read)` que avisa em dois casos, **sem bloquear**:

- **Volume** — a leitura vai injetar ≥10k tokens estimados → sugere subagente ou `rg` + `offset/limit`.
- **Releitura** — mesmo arquivo, mesmo trecho, arquivo inalterado, mesma sessão → avisa que a cópia já está no contexto.

## Por quê (medido, não estimado)

O Read é **60,2%** de todo o texto que entra por ferramenta (18,2M tok / 48 dias) e **82% do custo de token é ENTRADA de contexto**, não geração. Baseline de 7 dias deste repo: 21.059 requests, entrada = 83,5% do custo, contexto p50 de 258k por request.

| Bolso | Medição | Cobertura hoje |
|---|---|---|
| Leituras ≥10k tok | 3,6% das chamadas = **25% do volume** (3.292 Reads/14d) | nenhuma |
| Releitura consecutiva | 1.315 (14,8%) | harness já bloqueia (`Wasted call`) |
| **Releitura intercalada** | **1.151 (13,0%)** | **passa inteira** |

A proteção nativa do harness olha a leitura **anterior**; o hook olha a **sessão**. Os 13,0% intercalados são território que hoje não tem sinal nenhum.

## Decisões de desenho

- **Não bloqueia e não decide permissão.** Emitir `permissionDecision:"allow"` pularia o prompt de permissão de *toda* leitura — auto-aprovaria ler `~/.ssh/id_rsa`. `deny`/`ask` quebraria investigação legítima. Só anexa contexto. Há um caso de teste dedicado a isso.
- **Estima pelas linhas efetivamente lidas**, não pelo tamanho do arquivo. Medido aqui: `types.ts` tem 612KB mas só 58KB nas 2.000 primeiras linhas (teto do Read); `bugs-resolvidos.md` entrega 486KB em 376 linhas. Estimar pelo arquivo erraria nos dois sentidos.
- **Empurra para subagente** (~638 tok de retorno médio, contra ~2.058 de um Read médio) em vez de proibir Read.
- **Nada no CLAUDE.md, de propósito.** Ele é relido em TODO request (piso médio medido: 64.393 tok × 21.059 requests/7d). ~150 tokens de prosa custariam ~3,2M tok/semana; o hook entrega a mesma regra por ~47k, no instante em que ela importa. (O arquivo também está a 16 palavras do teto.)

## Limitação assumida

Em `PreToolUse` o aviso chega ao modelo **junto com** o resultado da leitura: muda a *próxima* decisão, não o custo desta. Evitar a primeira leitura cara exigiria `ask`/`deny`, descartado acima. Se o founder quiser essa mordida, é uma linha no hook — mas é uma decisão dele, não minha.

## Custo do próprio hook

~35ms por Read (1 `jq` + 1 `stat` + `head|wc` + `grep` numa marca pequena). Zero transcript, zero git — brigaria com a latência por turno e com o semáforo `heavy`.

## Testes

`scripts/test-read-contexto-nudge.sh` — 17 casos + `--falsificar` com 5 sabotagens.

Cada sabotagem tem 3 travas contra *falsificação vazia*: o `sed` precisa ser válido, o hook precisa ter mudado de verdade, e a sintaxe precisa continuar de pé (senão o vermelho vem do motivo errado). Tudo roda em `LC_ALL=C` **e** `pt_BR.UTF-8`, casando marcadores ASCII (`READ-GRANDE`/`READ-RELEITURA`) sem `-i` — prosa acentuada com `grep -i` acusaria o ramo errado sob um locale e não sob o outro (#1483).

```
suite         LC_ALL=C  EXIT=0 (17 ok)   |  pt_BR.UTF-8  EXIT=0 (17 ok)
falsificacao  LC_ALL=C  EXIT=0 (5 sab.)  |  pt_BR.UTF-8  EXIT=0 (5 sab.)
shellcheck scripts/*.sh .claude/hooks/*.sh  EXIT=0
```

Um caso já pagou por si: o teste reprovou minha premissa de que `limit` presente significa leitura barata — `limit=50` em linhas de 1KB injeta 13k tokens. O corte é por tokens, não por flag.

## Verificação end-to-end

O hook foi provado vivo nesta sessão: relendo um arquivo já lido, o `additionalContext` chegou como `system-reminder`.

## Como medir o depois

`scripts/tokens-report.sh --dias 7` e comparar o **cache_write médio por request** — mede quanto material novo entra por turno.

**Baseline de hoje: 9.036 tok/request** (21.059 requests, 7 dias).

⚠️ Esse script vem da Fase 1, que ainda **não** está mergeada — vive não-commitada em `.claude/worktrees/upbeat-ardinghelli-1bc353` (branch `claude/token-consumption-optimization-12d116`). Este PR não depende dela para funcionar, mas a régua do antes/depois depende.

🤖 Generated with [Claude Code](https://claude.com/claude-code)