### PR TITLE
perf(contexto): as duas hipóteses de corte do piso eram FALSAS — refutadas com número, e o oráculo vira script

### DIFF
--- a/docs/historico/piso-de-contexto.md
+++ b/docs/historico/piso-de-contexto.md
@@ -1,0 +1,92 @@
+# Piso de contexto — o que REALMENTE o reduz (medido, 2026-07-31)
+
+**Piso de contexto** = o que é relido em TODO request de TODA sessão: system prompt do
+harness + schemas das tools + lista de skills + CLAUDE.md + saída dos hooks. É o alvo mais
+rentável de otimização (82% do custo de token é ENTRADA de contexto: `cache_read` 58,5% +
+`cache_write` 25,0%; gerar resposta é só 16,4%) — cortar 1 token de piso rende em 100% dos
+requests, para sempre.
+
+E é também onde as premissas plausíveis mais enganam. **Duas hipóteses razoáveis foram
+medidas e REFUTADAS** — as duas teriam virado "otimização" entregue sem número.
+
+## Réguas (as duas são read-only e ficam no repo)
+
+| ferramenta | mede | precisão |
+|---|---|---|
+| `scripts/tokens-report.sh` | piso REAL das sessões vividas (lê `~/.claude/projects/**/*.jsonl`) | — |
+| `scripts/piso-contexto.sh` | piso de uma CONFIGURAÇÃO (roda uma sonda e lê o 1º request) | **±6 tokens** |
+
+A sonda é o oráculo: repetições da mesma config deram 43.964 / 43.958 / 43.962 / 43.980 /
+43.977. **Delta > ~50 tokens é sinal; abaixo disso é ruído.** O CLI não reproduz o app
+(a sessão do app desktop carrega MCPs próprias e os plugins da conta claude.ai, e tem piso
+maior) — use a sonda para comparar CONFIGURAÇÕES entre si, e o `tokens-report.sh` para o
+piso absoluto.
+
+## Baseline medido (janela de 7 dias, 20.933 requests)
+
+- Piso médio das sessões reais: **68.537 tokens** — o menor contexto visto por sessão.
+- Sessão do app desktop: piso **67.244**; sonda equivalente no CLI: **43.9xx**.
+  A diferença (~23k) é o ambiente do app: MCPs próprias + 172 skills de plugins da conta.
+- Distribuição do contexto por request: p50 258.927 · p90 449.812 · máx 782.883.
+
+## ❌ Premissa FALSA nº 1 — "encurtar a `description` das skills reduz o piso"
+
+Encurtei as `description` das 13 skills do projeto de **16.041 → 9.659 chars** (−6.382,
+preservando todos os gatilhos; a justificativa já vivia no corpo do `SKILL.md`).
+
+| | piso | listing | skills com descrição |
+|---|---|---|---|
+| antes | 43.964 / 43.958 | 30.446 chars | 55 |
+| depois | 43.905 / 43.901 | 30.312 chars | **62** |
+
+**Ganho: 57 tokens (0,13% — ruído).** O `skill_listing` tem **orçamento ~fixo** (~30.4k
+chars, batido em dois ambientes independentes: 30.446 e 30.431) e **preenche o espaço
+liberado com outras descrições** — 55 → 62. O corte foi revertido: mudança de risco em
+skills que o founder usa 86/83/77/70 vezes, com ganho zero, não se entrega.
+
+## ❌ Premissa FALSA nº 2 — "menos skills na lista → lista menor"
+
+Desabilitar `superpowers` tirou 14 skills (186 → 172). O listing **não encolheu**:
+29.994 → 30.001 chars. Mesmo mecanismo de orçamento.
+
+## ✅ O que REALMENTE move o ponteiro: desabilitar o PLUGIN inteiro
+
+O ganho não vem da lista — vem do payload que o plugin injeta por conta própria (system
+prompt, hooks, agents, MCP instructions). Medido, baseline 43.962:
+
+| plugin | delta no piso | usos em 48 dias | veredito |
+|---|---|---|---|
+| `claude-mem@thedotmack` | **−1.438** | 21 chamadas | caro para o uso — decisão do founder |
+| `superpowers@…` | −1.016 | ~270 invocações | **manter** (paga-se) |
+| `context7@…` | −141 | 3 | irrelevante nos dois sentidos |
+| os 4 juntos (com `claude-md-management`) | −2.543 | — | aditivo (2.595 esperado vs 2.543 medido) |
+
+Repetível: `--sem-plugin claude-mem@thedotmack` deu −1.438 e depois −1.440.
+
+## O que sobra é ESTRUTURAL (e não é cortável daqui)
+
+Com tudo desligável desligado (`--safe-mode`), a sonda ainda marca **21.678 tokens**:
+system prompt do harness + schemas das tools built-in. No app soma-se o que as MCPs
+próprias trazem. **Ordem de grandeza: ~2/3 do piso é do harness/app, não da configuração
+do repo.** Cortes locais somam alguns milhares de tokens, não dezenas.
+
+## Pendente de medição — só o founder consegue (é na conta, não no repo)
+
+172 das 337 skills da sessão do app vêm de plugins da conta claude.ai **nunca usados em 48
+dias** (`legal`, `marketing`, `engineering`, `finance`, `sales`, `data`, `human-resources`,
+`operations`, `product-management`, `customer-support`, `common-room`, `brand-voice`,
+`enterprise-search`, `design`, `figma`, `postiz`, `productivity`, `anthropic-skills`,
+`pdf-viewer`). Eles não existem no marketplace local (`~/.claude/plugins/marketplaces/`) —
+vêm do servidor, então **nenhum `settings.json` local os desliga** e a sonda do CLI não os
+enxerga. Trazem ainda 6 agents (`brand-voice:*`, `zapier:*` = 9.173 chars de `agent_listing`).
+
+Pela regra medida acima (o custo está no payload do plugin, não na lista), a estimativa é
+da ordem de alguns milhares de tokens — **estimativa, não medição**. Como testar de verdade:
+desligar na UI do claude.ai → abrir sessão NOVA → `scripts/tokens-report.sh --dias 1` e
+comparar o piso com os 67.244 registrados aqui.
+
+## Lição transferível
+
+> O piso não responde a cortes *dentro* de blocos de orçamento fixo (lista de skills,
+> descrições). Responde a **remover um provedor inteiro** (plugin, MCP, servidor).
+> E: "encurtei X, logo economizei" é hipótese — o número vem da sonda, antes e depois.

--- a/scripts/piso-contexto.sh
+++ b/scripts/piso-contexto.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# piso-contexto.sh — mede o PISO DE CONTEXTO de uma configuração do Claude Code.
+#
+# POR QUÊ: o piso (system prompt + schemas de tools + lista de skills + CLAUDE.md
+# + hooks) é relido em TODO request de TODA sessão — 82% do custo de token é
+# ENTRADA de contexto. Cortar 1 token de piso rende em 100% dos requests. Mas
+# "parece que vai cortar" não é evidência: já houve DUAS premissas plausíveis e
+# FALSAS sobre este piso (ver docs/historico/piso-de-contexto.md). Este script é
+# o oráculo — roda um prompt trivial e lê o consumo REAL do 1º request.
+#
+# Precisão medida: ±6 tokens em repetições da mesma config (43.964 / 43.958 /
+# 43.962). Qualquer delta acima de ~50 tokens é sinal; abaixo disso é ruído.
+#
+# Uso:
+#   scripts/piso-contexto.sh                        # piso da config atual
+#   scripts/piso-contexto.sh -n 3                   # 3 repetições (ver ruído)
+#   scripts/piso-contexto.sh --sem-plugin claude-mem@thedotmack
+#   scripts/piso-contexto.sh --flags --disable-slash-commands
+#   MODELO=claude-opus-5 scripts/piso-contexto.sh   # troca o modelo da sonda
+#
+# CUSTO: cada sonda é 1 request curto (~44k de contexto, resposta de 1 token).
+# Em plano de assinatura não é desembolso; ainda assim não rode em laço.
+#
+# ATENÇÃO — o CLI não reproduz o app: uma sessão do app desktop carrega MAIS
+# (MCPs próprios, plugins da conta claude.ai) e tem piso maior. Use este script
+# para comparar CONFIGURAÇÕES entre si (o delta é válido); para o piso absoluto
+# das sessões reais use scripts/tokens-report.sh.
+set -euo pipefail
+
+REPS=1
+MODELO="${MODELO:-claude-opus-4-8}"
+EXTRA=()
+SEM_PLUGIN=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--repeticoes) REPS="${2:?-n exige um número}"; shift 2 ;;
+    --sem-plugin)    SEM_PLUGIN+=("${2:?--sem-plugin exige nome@marketplace}"); shift 2 ;;
+    --flags)         shift; EXTRA=("$@"); break ;;
+    -h|--help)       sed -n '2,28p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "opção desconhecida: $1 (use --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v claude >/dev/null || { echo "claude CLI não encontrado" >&2; exit 1; }
+command -v jq     >/dev/null || { echo "jq é necessário (brew install jq)" >&2; exit 1; }
+command -v uuidgen >/dev/null || { echo "uuidgen é necessário" >&2; exit 1; }
+
+# --sem-plugin A --sem-plugin B  ->  --settings '{"enabledPlugins":{"A":false,"B":false}}'
+if [ "${#SEM_PLUGIN[@]}" -gt 0 ]; then
+  json=$(printf '%s\n' "${SEM_PLUGIN[@]}" \
+    | jq -R . | jq -s '{enabledPlugins: (map({(.): false}) | add)}' -c)
+  EXTRA+=(--settings "$json")
+fi
+
+echo "modelo: $MODELO   repetições: $REPS" >&2
+[ "${#EXTRA[@]}" -gt 0 ] && echo "flags extras: ${EXTRA[*]}" >&2
+echo >&2
+
+soma=0
+for i in $(seq 1 "$REPS"); do
+  uuid=$(uuidgen | tr '[:upper:]' '[:lower:]')
+  saida=$(mktemp)
+  # O prompt é trivial de propósito: queremos medir o PISO, não o trabalho.
+  if ! timeout 300 claude -p "responda exatamente: ok" \
+        --model "$MODELO" --session-id "$uuid" --output-format json \
+        ${EXTRA[@]+"${EXTRA[@]}"} > "$saida" 2>/dev/null; then
+    echo "sonda $i FALHOU (timeout ou erro do CLI)" >&2
+    rm -f "$saida"; exit 1
+  fi
+  # piso = tudo que entrou como contexto no 1º request, cacheado ou não.
+  total=$(jq -r '.usage | .input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens' "$saida")
+  printf "  sonda %d: %8d tokens\n" "$i" "$total"
+  soma=$((soma + total))
+  rm -f "$saida"
+done
+
+printf "\nPISO (média de %d): %d tokens\n" "$REPS" "$((soma / REPS))"

--- a/scripts/tokens-report.sh
+++ b/scripts/tokens-report.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# tokens-report.sh — painel de consumo de tokens do Claude Code (READ-ONLY).
+#
+# POR QUÊ: 82% do custo de token é ENTRADA de contexto (cache_read 52% +
+# cache_write 29%), não geração (18%). Otimizar "resposta curta" mexe em 18%;
+# medir e cortar contexto mexe em 82%. Este script é a régua — sem baseline
+# não há como provar que uma otimização funcionou (regra da EVIDÊNCIA POSITIVA).
+#
+# Fonte: ~/.claude/projects/**/*.jsonl (campo message.usage de cada request).
+# Nada sai da máquina; nenhum arquivo do projeto é alterado.
+#
+# Uso:
+#   scripts/tokens-report.sh                 # últimos 30 dias
+#   scripts/tokens-report.sh --dias 7        # janela menor (mais rápido)
+#   scripts/tokens-report.sh --dias 0        # todo o histórico (lento)
+#   scripts/tokens-report.sh --tsv X --pular-coleta   # reusa coleta anterior
+#
+# Preços = tabela pública da API (US$/MTok de input); output 5x, cache_write
+# 1.25x (TTL 5min), cache_read 0.1x. O total é CUSTO-EQUIVALENTE de API — em
+# plano de assinatura não é desembolso, serve para priorizar desperdício.
+set -euo pipefail
+
+DIAS=30
+TSV=""
+PULAR_COLETA=0
+RAIZ="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dias)         DIAS="${2:?--dias exige um número}"; shift 2 ;;
+    --tsv)          TSV="${2:?--tsv exige um caminho}"; shift 2 ;;
+    --pular-coleta) PULAR_COLETA=1; shift ;;
+    -h|--help)      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "opção desconhecida: $1 (use --help)" >&2; exit 2 ;;
+  esac
+done
+
+[ -d "$RAIZ" ] || { echo "não encontrei $RAIZ" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq é necessário (brew install jq)" >&2; exit 1; }
+[ -n "$TSV" ] || TSV="${TMPDIR:-/tmp}/tokens-report-$$.tsv"
+
+# ---------------------------------------------------------------- coleta ----
+if [ "$PULAR_COLETA" -eq 0 ]; then
+  echo "coletando de $RAIZ (janela: ${DIAS} dias; 0 = tudo)..." >&2
+  : > "$TSV"
+  for dir in "$RAIZ"/*/; do
+    [ -d "$dir" ] || continue
+    # PULA SYMLINK. Existe um `projects -> ~/.claude/projects` (symlink para o
+    # próprio pai): o glob `*/` o expande e o `find` com barra final RESOLVE o
+    # link, varrendo todo o histórico de novo sob outro nome. Sem este guard o
+    # relatório conta cada request DUAS VEZES (razão medida: exatamente 2.0000).
+    [ -L "${dir%/}" ] && continue
+    proj=$(basename "$dir")
+    if [ "$DIAS" -gt 0 ]; then
+      find "$dir" -name '*.jsonl' -type f -mtime "-${DIAS}" -print0 2>/dev/null
+    else
+      find "$dir" -name '*.jsonl' -type f -print0 2>/dev/null
+    fi | while IFS= read -r -d '' f; do
+      # 1 linha por request: projeto, dia, modelo, input, output, cache_w, cache_r, sessão
+      jq -rc --arg p "$proj" '
+        select(.message.usage != null)
+        | [ $p,
+            (.timestamp // "?")[0:10],
+            (.message.model // "?"),
+            (.message.usage.input_tokens // 0),
+            (.message.usage.output_tokens // 0),
+            (.message.usage.cache_creation_input_tokens // 0),
+            (.message.usage.cache_read_input_tokens // 0),
+            (.sessionId // "?")
+          ] | @tsv' "$f" 2>/dev/null
+    done
+  done >> "$TSV"
+fi
+
+[ -s "$TSV" ] || { echo "nenhum request na janela de ${DIAS} dias." >&2; exit 0; }
+echo "linhas coletadas: $(wc -l < "$TSV" | tr -d ' ')" >&2
+echo >&2
+
+# BSD awk (macOS) não tem asorti nem array multidimensional: o que precisa de
+# ordem sai prefixado e é ordenado por `sort`. Locais = parâmetros extras.
+PRECOS='
+function pin(m,   _) {
+  if (m ~ /fable|mythos/) return 10
+  if (m ~ /opus/)         return 5
+  if (m ~ /sonnet/)       return 3
+  if (m ~ /haiku/)        return 1
+  return 0
+}
+function custo(m, i, o, cw, cr,   q) {
+  q = pin(m); return (i*q + o*q*5 + cw*q*1.25 + cr*q*0.1) / 1000000
+}
+'
+
+# ------------------------------------------- 1. totais e decomposição -------
+awk -F'\t' "$PRECOS"'
+$3 == "<synthetic>" || $3 == "?" { next }
+{
+  c = custo($3,$4,$5,$6,$7); q = pin($3)
+  T += c; R++; TK += $4 + $5 + $6 + $7
+  CR += $7*q*0.1/1e6; CW += $6*q*1.25/1e6; OU += $5*q*5/1e6; IN += $4*q/1e6
+}
+END {
+  if (R == 0) { print "  (sem requests faturáveis na janela)"; exit }
+  printf "===== TOTAL (custo-equivalente de API) =====\n"
+  printf "  requests      : %12d\n", R
+  printf "  tokens        : %12.0f   (%.1f bilhões)\n", TK, TK/1e9
+  printf "  US$           : %12.0f\n\n", T
+  printf "  ONDE O TOKEN VAI\n"
+  printf "    cache_read  : %9.0f  (%4.1f%%)  <- RELER contexto\n", CR, 100*CR/T
+  printf "    cache_write : %9.0f  (%4.1f%%)\n", CW, 100*CW/T
+  printf "    output      : %9.0f  (%4.1f%%)  <- gerar\n", OU, 100*OU/T
+  printf "    input cru   : %9.0f  (%4.1f%%)\n", IN, 100*IN/T
+  printf "    ENTRADA     : %9.0f  (%4.1f%%)\n", CR+CW+IN, 100*(CR+CW+IN)/T
+}' "$TSV"
+
+# ------------------------------------------------------- 2. por modelo ------
+echo
+echo "===== POR MODELO ====="
+printf "  %-30s %8s %10s %8s\n" modelo reqs "US\$" "%"
+awk -F'\t' "$PRECOS"'
+$3 == "<synthetic>" || $3 == "?" { next }
+{ c = custo($3,$4,$5,$6,$7); C[$3] += c; N[$3]++; T += c }
+END { for (m in C) printf "%.4f\t%s\t%d\t%.1f\n", C[m], m, N[m], 100*C[m]/T }' "$TSV" \
+  | sort -rn | awk -F'\t' '{printf "  %-30s %8s %10.0f %7.1f%%\n", $2, $3, $1, $4}'
+
+# ------------------------------- 3. piso de contexto e concentração ---------
+echo
+awk -F'\t' "$PRECOS"'
+$3 == "<synthetic>" || $3 == "?" { next }
+{
+  c = custo($3,$4,$5,$6,$7); ctx = $4 + $6 + $7
+  SC[$8] += c; SR[$8]++; T += c
+  # piso só de sessões principais: subagentes Haiku têm preâmbulo próprio,
+  # bem menor, e diluiriam a média do que a sessão de verdade paga.
+  if ($3 !~ /haiku/ && (!($8 in SM) || ctx < SM[$8])) SM[$8] = ctx
+}
+END {
+  if (T == 0) exit
+  print  "===== PISO DE CONTEXTO POR SESSÃO ====="
+  print  "  (menor contexto visto na sessão = system prompt + tools + CLAUDE.md +"
+  print  "   lista de skills; é relido em TODO request — cortá-lo rende em 100% deles)"
+  for (s in SM) { n++; soma += SM[s] }
+  if (n > 0) printf "  sessões principais: %d    piso médio: %.0f tokens\n", n, soma/n
+  print  ""
+  print  "===== CONCENTRAÇÃO POR TAMANHO DE SESSÃO ====="
+  print  "  (custo cresce ~quadraticamente: o request N relê o que os N-1 acumularam)"
+  for (s in SC) {
+    if      (SR[s] >= 2000) f = "5. >=2000 req"
+    else if (SR[s] >= 1000) f = "4. 1000-1999 "
+    else if (SR[s] >=  300) f = "3. 300-999   "
+    else if (SR[s] >=   50) f = "2. 50-299    "
+    else                    f = "1. <50       "
+    FC[f] += SC[s]; FN[f]++; FR[f] += SR[s]
+  }
+  printf "  %-14s %8s %10s %11s %8s\n", "faixa", "sessões", "requests", "US$", "%custo"
+  split("1. <50       |2. 50-299    |3. 300-999   |4. 1000-1999 |5. >=2000 req", o, "|")
+  for (k = 1; k <= 5; k++) {
+    f = o[k]
+    if (FN[f] > 0) printf "  %-14s %8d %10d %11.0f %7.1f%%\n", f, FN[f], FR[f], FC[f], 100*FC[f]/T
+  }
+}' "$TSV"
+
+# ---------------------------------------------------------- 4. por dia ------
+echo
+echo "===== POR DIA (últimos 30) ====="
+printf "  %-12s %8s %12s %10s\n" dia reqs ctx_médio "US\$"
+awk -F'\t' "$PRECOS"'
+$3 == "<synthetic>" || $3 == "?" { next }
+{ C[$2] += custo($3,$4,$5,$6,$7); N[$2]++; X[$2] += $4 + $6 + $7 }
+END { for (d in C) printf "%s\t%d\t%.0f\t%.0f\n", d, N[d], X[d]/N[d], C[d] }' "$TSV" \
+  | sort | tail -30 | awk -F'\t' '{printf "  %-12s %8s %12s %10s\n", $1, $2, $3, $4}'
+
+# ------------------------------------------- 5. distribuição do contexto ----
+echo
+echo "===== TAMANHO DE CONTEXTO POR REQUEST ====="
+CTX="${TSV}.ctx"
+awk -F'\t' '$3 != "<synthetic>" && $3 != "?" { print $4 + $6 + $7 }' "$TSV" | sort -n > "$CTX"
+N=$(wc -l < "$CTX" | tr -d ' ')
+if [ "$N" -gt 0 ]; then
+  for p in 50 75 90 99; do
+    L=$(( N * p / 100 )); [ "$L" -lt 1 ] && L=1
+    printf "  p%-3s : %10s tokens\n" "$p" "$(sed -n "${L}p" "$CTX")"
+  done
+  printf "  máx  : %10s tokens\n" "$(tail -1 "$CTX")"
+fi
+rm -f "$CTX"
+
+echo
+echo "TSV bruto: $TSV" >&2


### PR DESCRIPTION
## O problema

O **piso de contexto** — system prompt + schemas de tools + lista de skills + CLAUDE.md + hooks — é relido em **todo request de toda sessão**. Medido em 7 dias (20.933 requests): **82% do custo de token é ENTRADA de contexto** (`cache_read` 58,5% + `cache_write` 25,0%); gerar resposta é só 16,4%. Cortar 1 token de piso rende em 100% dos requests, para sempre.

Piso medido: **68.537 tokens** de média por sessão.

## O que este PR entrega

Não entrega um corte. Entrega **o número que mostra por que os cortes óbvios não funcionam** — e a régua para testar o próximo.

### ❌ Hipótese 1: "encurtar a `description` das skills reduz o piso" — FALSA

Encurtei as `description` das 13 skills do projeto de **16.041 → 9.659 chars** (−6.382, preservando todos os gatilhos; a justificativa já vivia no corpo do `SKILL.md`).

| | piso | listing | skills com descrição |
|---|---|---|---|
| antes | 43.964 / 43.958 | 30.446 chars | 55 |
| depois | 43.905 / 43.901 | 30.312 chars | **62** |

**Ganho: 57 tokens (0,13% — ruído).** O `skill_listing` tem **orçamento ~fixo** (~30.4k chars, batido em dois ambientes independentes: 30.446 e 30.431) e **preenche o espaço liberado com outras descrições** — 55 → 62.

**Revertido.** Mudança de risco em skills que o founder invoca 86/83/77/70 vezes, com ganho zero, não se entrega.

### ❌ Hipótese 2: "menos skills na lista → lista menor" — FALSA

Desabilitar `superpowers` tirou 14 skills (186 → 172). Listing: **29.994 → 30.001 chars**. Não encolheu.

### ✅ O que move o ponteiro: desabilitar o PLUGIN inteiro

O custo está no payload que o plugin injeta por conta própria (system prompt, hooks, agents), não na lista:

| plugin | delta no piso | usos em 48 dias | veredito |
|---|---|---|---|
| `claude-mem` | **−1.438** | 21 | caro para o uso — decisão do founder |
| `superpowers` | −1.016 | ~270 | **manter**, se paga |
| `context7` | −141 | 3 | irrelevante |
| os 4 juntos | −2.543 | — | aditivo (2.595 esperado) |

E **~2/3 do piso é estrutural**: com tudo desligável desligado (`--safe-mode`) a sonda ainda marca **21.678 tokens** de harness. Cortes locais somam milhares de tokens, não dezenas de milhares.

## Arquivos

- **`scripts/piso-contexto.sh`** (novo) — sonda o piso de uma configuração, precisão **±6 tokens** (repetições: 43.964 / 43.958 / 43.962 / 43.980 / 43.977). É o oráculo: sem ele, a próxima hipótese plausível também passaria por óbvia.
- **`scripts/tokens-report.sh`** — painel read-only do consumo real. Existia solto na worktree da sessão anterior e **nunca tinha sido versionado**.
- **`docs/historico/piso-de-contexto.md`** — números, método e a lição transferível.

Nada toca `src/`, `supabase/` ou runtime — são duas ferramentas read-only e um doc. Sem deploy do Lovable pendente.

## Validação

- `shellcheck scripts/*.sh .claude/hooks/*.sh` → **exit 0** (gate do CI).
- Sonda testada de ponta a ponta: config atual 43.980 / 43.977; `--sem-plugin claude-mem@thedotmack` → 42.538 (delta −1.440, reproduzindo o −1.438 medido antes).
- Sem colisão com o #1647 (mesma família, arquivos disjuntos).

## Fica para o founder (não dá para medir daqui)

**172 das 337 skills** da sessão do app vêm de plugins da conta claude.ai **nunca usados em 48 dias** (`legal`, `marketing`, `engineering`, `finance`, `sales`, `data`, `human-resources`, `figma`, `brand-voice`, …). Eles não existem no marketplace local — vêm do servidor, então **nenhum `settings.json` local os desliga** e a sonda do CLI não os enxerga. Como testar de verdade: desligar na UI do claude.ai → abrir sessão **nova** → `scripts/tokens-report.sh --dias 1` e comparar com os 67.244 registrados aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)