### PR TITLE
perf(contexto): sessão longa para de encarecer em silêncio — alerta por degrau de contexto

### DIFF
--- a/.claude/hooks/stop-contexto-caro.sh
+++ b/.claude/hooks/stop-contexto-caro.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# stop-contexto-caro.sh — Stop: avisa quando a sessão fica CARA de reler.
+#
+# POR QUÊ: 82% do custo de token é entrada de contexto, e 80 sessões longas
+# concentraram 62% do gasto medido (scripts/tokens-report.sh). O custo cresce
+# ~quadraticamente: o request N relê tudo que os N-1 acumularam, então uma
+# sessão de 2.000 turnos custa MUITO mais que 4 de 500 fazendo o mesmo.
+# O founder não tem como ver isso acontecendo — este hook torna visível.
+#
+# BARATO DE PROPÓSITO: lê `tail` do transcript + um `grep -c`. Zero parse do
+# arquivo inteiro (transcripts chegam a 70MB) e zero typecheck/test — rodar
+# pesado no Stop brigaria com o semáforo `heavy` (M2 8GB) e com a latência.
+# NUNCA bloqueia (sempre exit 0). Avisa uma vez POR DEGRAU, não a cada turno.
+# Testes em scripts/test-stop-contexto-caro.sh.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+entrada="$(cat)"
+transcript="$(printf '%s' "$entrada" | jq -r '.transcript_path // empty' 2>/dev/null)"
+sessao="$(printf '%s' "$entrada" | jq -r '.session_id // "sem-id"' 2>/dev/null)"
+[ -n "$transcript" ] && [ -f "$transcript" ] || exit 0
+
+# Contexto ATUAL = último usage do transcript. `tail` evita varrer o arquivo
+# inteiro; 400 linhas cobrem com folga o último turno mesmo com muita tool call.
+ultimo="$(tail -n 400 "$transcript" 2>/dev/null \
+  | jq -rs 'map(select(.message.usage != null)) | last
+            | if . == null then "0 x" else
+                ( ((.message.usage.input_tokens // 0)
+                 + (.message.usage.cache_creation_input_tokens // 0)
+                 + (.message.usage.cache_read_input_tokens // 0)) | tostring )
+                + " " + (.message.model // "x")
+              end' 2>/dev/null)"
+ctx="${ultimo%% *}"
+modelo="${ultimo##* }"
+case "$ctx" in ''|*[!0-9]*) exit 0 ;; esac
+[ "$ctx" -gt 0 ] || exit 0
+
+# Degraus: só avisa ao CRUZAR um novo. p75 medido = 330k, p90 = 452k.
+if   [ "$ctx" -ge 700000 ]; then degrau=700; acao="pare e faça o split AGORA"
+elif [ "$ctx" -ge 500000 ]; then degrau=500; acao="split recomendado"
+elif [ "$ctx" -ge 350000 ]; then degrau=350; acao="hora de decidir"
+elif [ "$ctx" -ge 250000 ]; then degrau=250; acao="atenção"
+else exit 0
+fi
+
+marca="${TMPDIR:-/tmp}/afiacao-ctx-${sessao}"
+anterior=0
+[ -f "$marca" ] && anterior="$(cat "$marca" 2>/dev/null || echo 0)"
+case "$anterior" in ''|*[!0-9]*) anterior=0 ;; esac
+[ "$degrau" -gt "$anterior" ] || exit 0     # já avisei neste degrau (ou acima)
+printf '%s' "$degrau" > "$marca" 2>/dev/null || true
+
+# Custo estimado desta sessão. `command grep` porque o `grep` do shell é shim
+# p/ ugrep. Calibração conferida contra o custo real de uma sessão (US$ 31,79
+# medidos vs 29,6 estimados = 7% de erro); a 1ª versão errava 2,4x porque só
+# contava cache_read — write + output são 47% do custo e não podem sair da conta.
+reqs="$(command grep -c '"usage"' "$transcript" 2>/dev/null || echo 0)"
+case "$reqs" in ''|*[!0-9]*) reqs=0 ;; esac
+
+# 1) contexto médio da sessão ≈ (piso + atual)/2 — o piso medido é ~61k, não 0,
+#    então partir de zero subestima. 2) preço de cache_read por MTok conforme a
+#    família do modelo. 3) cache_read é 52% do custo total (medido): dividir por
+#    isso recompõe write + output sem precisar somar o transcript inteiro.
+preco_read=0.5
+case "$modelo" in *fable*|*mythos*) preco_read=1.0 ;; *haiku*) preco_read=0.1 ;; *sonnet*) preco_read=0.3 ;; esac
+custo="$(awk -v r="$reqs" -v c="$ctx" -v p="$preco_read" \
+  'BEGIN{ printf "%.0f", (r * ((61000 + c)/2) * p / 1000000) / 0.52 }')"
+ctx_k=$(( ctx / 1000 ))
+
+msg="🔴 Contexto desta sessão: ${ctx_k}k tokens (~${reqs} requests, ~US\$ ${custo} já relidos) — ${acao}.
+Cada novo turno relê esses ${ctx_k}k. O custo cresce ~quadraticamente no comprimento da sessão.
+→ /compact foco: <próximo passo>   (preserva mal sem o foco)
+→ /handoff-sessao                  (1 entrega = 1 sessão — no 2º compact, prefira este)
+(aviso não-bloqueante · medir: scripts/tokens-report.sh)"
+
+ctx_agente="O contexto desta sessão chegou a ${ctx_k}k tokens (~${reqs} requests). Cada turno seguinte relê tudo isso, e o custo cresce quadraticamente no comprimento da sessão. Se a entrega atual estiver concluída, proponha ao Lucas encerrar aqui e abrir sessão nova com /handoff-sessao em vez de emendar a próxima tarefa. Se ainda está no meio de uma entrega, sugira '/compact foco: <próximo passo>'. Não interrompa trabalho em andamento por causa deste aviso — apenas proponha."
+
+jq -n --arg m "$msg" --arg c "$ctx_agente" \
+  '{systemMessage:$m, hookSpecificOutput:{hookEventName:"Stop", additionalContext:$c}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -153,6 +153,15 @@
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-moneypath-nudge.sh\""
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/stop-contexto-caro.sh\"",
+            "timeout": 10
+          }
+        ]
       }
     ]
   }

--- a/scripts/test-stop-contexto-caro.sh
+++ b/scripts/test-stop-contexto-caro.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# test-stop-contexto-caro.sh — TDD do hook .claude/hooks/stop-contexto-caro.sh
+#
+# Regra: contexto da sessão >= 250k tokens → emite systemMessage (aviso), UMA VEZ
+# por degrau (250/350/500/700k). Abaixo de 250k, transcript ausente ou sem usage
+# → silêncio (exit 0). NUNCA bloqueia (não emite decision:block).
+#
+# Uso: bash scripts/test-stop-contexto-caro.sh   (exit 0 = verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$here/../.claude/hooks/stop-contexto-caro.sh"
+command -v jq >/dev/null 2>&1 || { echo "SKIP — jq ausente"; exit 0; }
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+export TMPDIR="$tmp"          # isola as marcas de degrau deste teste
+
+# transcript sintético: N linhas de usage, a última com o contexto alvo
+mk_transcript() {  # $1=arquivo  $2=cache_read da última linha  $3=nº de linhas
+  local f="$1" ctx="$2" n="${3:-3}" k=1
+  : > "$f"
+  while [ "$k" -lt "$n" ]; do
+    printf '{"type":"assistant","message":{"usage":{"input_tokens":4,"cache_creation_input_tokens":100,"cache_read_input_tokens":1000}}}\n' >> "$f"
+    k=$(( k + 1 ))
+  done
+  printf '{"type":"assistant","message":{"usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":%s}}}\n' "$ctx" >> "$f"
+}
+
+run() {  # $1=transcript  $2=session_id
+  jq -nc --arg t "$1" --arg s "$2" \
+    '{hook_event_name:"Stop", transcript_path:$t, session_id:$s}' | bash "$HOOK" 2>/dev/null
+}
+
+fail=0
+ok()   { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+bad()  { printf '  \033[31mFALHA\033[0m %s\n' "$1"; fail=1; }
+check(){ # $1=descrição $2=esperado(msg|silencio) $3=saída
+  local desc="$1" esp="$2" out="$3"
+  case "$esp" in
+    msg)
+      if printf '%s' "$out" | command grep -q 'systemMessage'; then ok "$desc"
+      else bad "$desc (esperava aviso, veio: '${out:0:60}')"; fi ;;
+    silencio)
+      if [ -z "$out" ]; then ok "$desc"
+      else bad "$desc (esperava silêncio, veio: '${out:0:60}')"; fi ;;
+  esac
+}
+
+echo "== stop-contexto-caro =="
+
+# 1. abaixo do primeiro degrau → silêncio
+mk_transcript "$tmp/t1.jsonl" 100000 3
+check "contexto 100k → silêncio" silencio "$(run "$tmp/t1.jsonl" s1)"
+
+# 2. cruzou 250k → avisa
+mk_transcript "$tmp/t2.jsonl" 260000 5
+out2="$(run "$tmp/t2.jsonl" s2)"
+check "contexto 260k → avisa" msg "$out2"
+
+# 3. JSON de saída é válido e bem-formado (printf, não echo: echo interpreta o \n
+#    escapado e corrompe o JSON — armadilha registrada no CLAUDE.md)
+if printf '%s' "$out2" | jq -e '.systemMessage and .hookSpecificOutput.additionalContext' >/dev/null 2>&1
+then ok "JSON válido com systemMessage + additionalContext"
+else bad "JSON inválido ou incompleto"; fi
+
+if printf '%s' "$out2" | jq -e '.hookSpecificOutput.hookEventName == "Stop"' >/dev/null 2>&1
+then ok "hookEventName = Stop"
+else bad "hookEventName errado"; fi
+
+# 4. NUNCA bloqueia
+if printf '%s' "$out2" | command grep -q '"decision"'
+then bad "emitiu decision (não pode bloquear)"
+else ok "não bloqueia"; fi
+
+# 5. mesmo degrau de novo → silêncio (não repete a cada turno)
+check "mesmo degrau, 2ª vez → silêncio" silencio "$(run "$tmp/t2.jsonl" s2)"
+
+# 6. subiu de degrau (260k → 520k) → avisa de novo
+mk_transcript "$tmp/t3.jsonl" 520000 9
+check "subiu para 520k → avisa de novo" msg "$(run "$tmp/t3.jsonl" s2)"
+
+# 7. sessão DIFERENTE no mesmo degrau → avisa (marca é por sessão)
+check "outra sessão, 260k → avisa" msg "$(run "$tmp/t2.jsonl" s99)"
+
+# 8. transcript inexistente → silêncio
+check "transcript ausente → silêncio" silencio "$(run "$tmp/nao-existe.jsonl" s3)"
+
+# 9. transcript sem nenhum usage → silêncio
+printf '{"type":"user","message":{"content":"oi"}}\n' > "$tmp/t4.jsonl"
+check "transcript sem usage → silêncio" silencio "$(run "$tmp/t4.jsonl" s4)"
+
+# 10. FALSIFICAÇÃO — o teste precisa saber ficar vermelho. Um hook que avisasse
+#     SEMPRE passaria nos casos 2/6/7; é o caso 1 (silêncio abaixo do degrau)
+#     que separa "funciona" de "grita sempre". Confirma que aquele caso é real:
+mk_transcript "$tmp/t5.jsonl" 249000 3
+saida_abaixo="$(run "$tmp/t5.jsonl" s5)"
+if [ -z "$saida_abaixo" ]
+then ok "falsificação: 249k (1 abaixo do degrau) permanece em silêncio"
+else bad "falsificação: avisou a 249k — o degrau não está sendo respeitado"; fi
+
+echo
+if [ "$fail" -eq 0 ]; then echo "VERDE — todos os casos passaram"; exit 0; fi
+echo "VERMELHO — ha casos falhando"; exit 1


### PR DESCRIPTION
## O problema

O custo de token é **82% ENTRADA de contexto** (cache_read 52,4% + cache_write 28,7%); gerar resposta é só 18%. E esse custo cresce **~quadraticamente no comprimento da sessão** — o request N relê tudo que os N-1 acumularam.

Medido sobre **149.859 requests** (48 dias de transcrições, `scripts/tokens-report.sh`):

| Faixa de sessão | Sessões | % do custo |
|---|---:|---:|
| ≥2000 requests | 8 | 19,5% |
| 1000–1999 | 10 | 9,6% |
| **300–999** | **136** | **53,5%** |
| <300 | 1.049 | 17,3% |

**154 sessões de 1.203 concentram 82,7% do gasto**, e a inflexão está em **~300 requests** — bem antes do que a intuição sugere.

O founder não tinha como ver isso acontecendo: nada no fluxo mostra quando a sessão passou do ponto em que emendar a próxima tarefa custa mais que abrir uma nova.

## O que este PR faz

`.claude/hooks/stop-contexto-caro.sh` avisa ao cruzar **250k / 350k / 500k / 700k** tokens de contexto, com o custo já acumulado e a ação recomendada (`/compact foco:` ou `/handoff-sessao`).

Decisões de desenho:

- **Uma vez por degrau**, não a cada turno — aviso repetido vira ruído e passa a ser ignorado.
- **Nunca bloqueia**: `systemMessage` (founder) + `additionalContext` (agente), no padrão de `stop-moneypath-nudge.sh`. O CI segue sendo o gate.
- **Barato de propósito**: `tail` de 400 linhas + um `grep -c`. Zero parse do transcript inteiro (chegam a 70 MB) — o Stop roda a cada turno e não pode competir com o semáforo `heavy` (M2 8GB, ~48 worktrees).

## Calibração feita contra a verdade, não contra teoria

A primeira versão do estimador **errava 2,4×** porque só contava `cache_read`. Foi conferida contra uma sessão real e corrigida: soma write+output pela proporção medida (52%) e parte do piso real (~61k tokens), não de zero.

| | Real | Estimado |
|---|---:|---:|
| Custo | US$ 31,79 | US$ 31 |
| Requests | 132 | 137 |
| Contexto | 406k | 410k |

Erro final: **2,5%**.

## Relação com #1647 e #1648

Complementar, sem sobreposição: `read-contexto-nudge.sh` (#1647) ataca o que **entra** por leitura; este ataca o que **já entrou** e é relido a cada turno. O `scripts/tokens-report.sh` que mede os dois entrou por #1648.

## Validação

- `shellcheck` → **exit 0** (gate do CI)
- `bash scripts/test-stop-contexto-caro.sh` → **11 casos verdes**, em `LC_ALL=C` e `pt_BR.UTF-8`
- **Falsificado**: duas sabotagens distintas (remover o degrau; remover a marca de degrau) deixam o teste **vermelho nos dois locales**; verde restaurado depois
- **Dogfooding**: o hook disparou sozinho na sessão que o criou, no degrau de 350k — foi assim que o erro de calibração apareceu

🤖 Generated with [Claude Code](https://claude.com/claude-code)