### PR TITLE
perf(contexto): o piso era a MENOR metade — 74% do custo é conversa acumulada, e Read+Bash são 95% dela

### DIFF
--- a/docs/historico/piso-de-contexto.md
+++ b/docs/historico/piso-de-contexto.md
@@ -15,6 +15,7 @@ medidas e REFUTADAS** — as duas teriam virado "otimização" entregue sem núm
 |---|---|---|
 | `scripts/tokens-report.sh` | piso REAL das sessões vividas (lê `~/.claude/projects/**/*.jsonl`) | — |
 | `scripts/piso-contexto.sh` | piso de uma CONFIGURAÇÃO (roda uma sonda e lê o 1º request) | **±6 tokens** |
+| `scripts/ocupacao-contexto.sh` | de onde vem o contexto ACUMULADO (os 74% — ver seção 🎯) | — |
 
 A sonda é o oráculo: repetições da mesma config deram 43.964 / 43.958 / 43.962 / 43.980 /
 43.977. **Delta > ~50 tokens é sinal; abaixo disso é ruído.** O CLI não reproduz o app
@@ -70,6 +71,43 @@ system prompt do harness + schemas das tools built-in. No app soma-se o que as M
 próprias trazem. **Ordem de grandeza: ~2/3 do piso é do harness/app, não da configuração
 do repo.** Cortes locais somam alguns milhares de tokens, não dezenas.
 
+## 🎯 E o piso inteiro é a MENOR metade do problema
+
+Fechada a medição do piso, a pergunta seguinte é quanto ele representa do custo. Separando,
+request a request, o piso (o mínimo visto na sessão) do EXCEDENTE (o que a conversa
+acumulou), sobre os mesmos 20.933 requests:
+
+| | tokens de contexto | custo de entrada |
+|---|---|---|
+| piso (relido sempre) | 1,38 bi (24,3%) | US$ 1.181 (**25,9%**) |
+| conversa acumulada | 4,30 bi (75,7%) | US$ 3.374 (**74,1%**) |
+
+**Zerar o piso INTEIRO — impossível, 2/3 é harness — teto­aria em 26% do custo de entrada.**
+As alavancas locais reais (~4.500 tokens de 67.244) valem ~1,7%. A Fase 1 mirou, de boa-fé,
+a menor metade.
+
+### Onde estão os 74%: custo de OCUPAÇÃO
+
+Um `tool_result` não se paga uma vez — fica no histórico e é **relido em todo request
+seguinte**. O custo real é `tamanho x (requests que ainda virão depois dele)`. Medido nas 3
+sessões mais caras de 7 dias (US$1.209 somados), por duas implementações independentes que
+convergiram:
+
+| ferramenta | chamadas | maior saída | % do custo de ocupação |
+|---|---|---|---|
+| **Read** | 75 | 52.966 chars | **~55%** |
+| **Bash** | 769 | 15.583 chars | **~40%** |
+| Edit | 211 | 808 chars | ~3% |
+| todo o resto | — | — | <1% |
+
+O ponto que inverte a intuição: **Read teve 75 chamadas contra 769 do Bash — e custou
+MAIS.** Não é a frequência que manda, é o tamanho por chamada multiplicado pelo tempo que a
+saída ainda vai ficar no contexto. Uma leitura grande no início de uma sessão longa é o item
+mais caro que existe; a mesma leitura no último request é quase de graça.
+
+Régua: `scripts/ocupacao-contexto.sh --top 3`. O guard de Read do #1647 (nudge por volume e
+por releitura) ataca justamente a fatia nº 1.
+
 ## Pendente de medição — só o founder consegue (é na conta, não no repo)
 
 172 das 337 skills da sessão do app vêm de plugins da conta claude.ai **nunca usados em 48
@@ -90,3 +128,7 @@ comparar o piso com os 67.244 registrados aqui.
 > O piso não responde a cortes *dentro* de blocos de orçamento fixo (lista de skills,
 > descrições). Responde a **remover um provedor inteiro** (plugin, MCP, servidor).
 > E: "encurtei X, logo economizei" é hipótese — o número vem da sonda, antes e depois.
+>
+> E antes de otimizar um alvo, **meça que fração do custo ele é**. O piso parecia o alvo
+> óbvio (é relido em 100% dos requests) e é só 26%. Otimizar bem a coisa errada perde para
+> medir primeiro.

--- a/scripts/ocupacao-contexto.sh
+++ b/scripts/ocupacao-contexto.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# ocupacao-contexto.sh — de ONDE vem o contexto acumulado de uma sessão (READ-ONLY).
+#
+# POR QUÊ: o piso de contexto (scripts/piso-contexto.sh) é só 25,9% do custo de
+# entrada — os outros 74,1% são a CONVERSA ACUMULADA (medido em 20.933 requests).
+# E um tool_result não se paga uma vez: fica no histórico e é RELIDO em todo
+# request seguinte da sessão. Logo o custo real de um resultado é
+#
+#     tamanho x (nº de requests que ainda virão depois dele)
+#
+# e NÃO o tamanho. Um Read de 50k tokens no começo de uma sessão de 500 requests
+# custa mais que cem Reads de 5k no último terço. Este script mede isso.
+#
+# Primeira medição (3 sessões mais caras de uma janela de 7 dias, US$1.209):
+#   Read 56,4% · Bash 39,5% · Edit 2,7% · todo o resto <1%.
+#   Read tinha 75 chamadas contra 769 do Bash — e custou MAIS. O tamanho por
+#   chamada é que manda, porque ele é relido para sempre.
+#
+# Uso:
+#   scripts/ocupacao-contexto.sh <arquivo.jsonl> [outro.jsonl ...]
+#   scripts/ocupacao-contexto.sh --sessao <uuid>   # procura em ~/.claude/projects
+#   scripts/ocupacao-contexto.sh --top 5           # as N sessões mais pesadas (7d)
+#
+# Nada sai da máquina; nenhum arquivo do projeto é alterado.
+set -euo pipefail
+
+RAIZ="${CLAUDE_PROJECTS_DIR:-$HOME/.claude/projects}"
+CHARS_POR_TOKEN=3.5   # aproximação p/ mistura pt-BR + código
+ALVOS=()
+TOP=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --sessao)
+      alvo=$(find "$RAIZ" -name "${2:?--sessao exige um uuid}.jsonl" -type f 2>/dev/null | head -1)
+      [ -n "$alvo" ] || { echo "sessão ${2} não encontrada em $RAIZ" >&2; exit 1; }
+      ALVOS+=("$alvo"); shift 2 ;;
+    --top)     TOP="${2:?--top exige um número}"; shift 2 ;;
+    -h|--help) sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) ALVOS+=("$1"); shift ;;
+  esac
+done
+
+command -v jq >/dev/null || { echo "jq é necessário (brew install jq)" >&2; exit 1; }
+
+# --top N: as N sessões maiores em bytes. O custo cresce ~quadraticamente com o
+# nº de requests, então as maiores dominam — é um proxy barato de "sessão cara".
+if [ "$TOP" -gt 0 ]; then
+  while IFS= read -r linha; do
+    ALVOS+=("$linha")
+  done < <(find "$RAIZ" -name '*.jsonl' -type f -mtime -7 2>/dev/null \
+      | while IFS= read -r f; do printf '%s\t%s\n' "$(wc -c < "$f" | tr -d ' ')" "$f"; done \
+      | sort -rn | head -"$TOP" | cut -f2)
+fi
+
+[ "${#ALVOS[@]}" -gt 0 ] || { echo "informe ao menos um .jsonl (use --help)" >&2; exit 2; }
+echo "sessões analisadas: ${#ALVOS[@]}" >&2
+
+# Fluxo ordenado de eventos; o awk faz a contabilidade:
+#   REQ              -> passou um request faturável (marca o tempo)
+#   USE <id> <nome>  -> amarra tool_use_id ao nome da ferramenta
+#   RES <id> <chars> -> um resultado entrou no histórico
+for f in "${ALVOS[@]}"; do
+  jq -rc '
+    (if (.message.usage != null) then "REQ" else empty end),
+    ( .message.content? | if type=="array" then .[] else empty end
+      | if .type=="tool_use" then "USE\t\(.id // "?")\t\(.name // "?")"
+        elif .type=="tool_result" then "RES\t\(.tool_use_id // "?")\t\((.content|tostring)|length)"
+        else empty end )
+  ' "$f" 2>/dev/null
+done | awk -F'\t' -v cpt="$CHARS_POR_TOKEN" '
+$1=="REQ" { req++; next }
+$1=="USE" { nome[$2] = $3; next }
+# a posição importa: só se sabe quantos requests vêm DEPOIS no fim do arquivo
+$1=="RES" { n++; rid[n]=$2; rtam[n]=$3; rpos[n]=req; next }
+END {
+  if (n == 0) { print "  (nenhum tool_result encontrado)"; exit }
+  for (i = 1; i <= n; i++) {
+    k = (rid[i] in nome) ? nome[rid[i]] : "?"
+    restantes = req - rpos[i]; if (restantes < 0) restantes = 0
+    o = (rtam[i] / cpt) * restantes
+    ocup[k] += o; chars[k] += rtam[i]; cnt[k]++; soma += o
+    if (rtam[i] > maior[k]) maior[k] = rtam[i]
+  }
+  if (soma <= 0) soma = 1
+  # zero-padding no 1º campo p/ ordenar numericamente com sort(1) sem perder a chave
+  for (k in ocup)
+    printf "%018.3f\t%s\t%d\t%d\t%d\t%.1f\n", ocup[k], k, cnt[k], chars[k], maior[k], 100*ocup[k]/soma
+}' | sort -rn | head -14 | awk -F'\t' '
+BEGIN { printf "\n%-30s %6s %12s %9s %13s %7s\n", "ferramenta", "n", "chars tot", "maior", "tok*req(M)", "%" }
+{ printf "%-30s %6d %12d %9d %13.1f %6.1f%%\n", $2, $3, $4, $5, ($1+0)/1e6, $6 }'
+
+echo
+echo "regra: o que pesa não é o tamanho da saída, é tamanho x quanto tempo ela ainda" >&2
+echo "fica no contexto. Saída grande CEDO na sessão é a mais cara de todas." >&2


### PR DESCRIPTION
Continuação direta do #1648, que mediu o piso de contexto e refutou as duas hipóteses de corte. Faltava a pergunta que reposiciona tudo: **quanto o piso representa do custo total?**

## A resposta muda o alvo

Separando, request a request, o piso (o mínimo visto na sessão) do excedente que a conversa acumulou — mesmos 20.933 requests da janela de 7 dias:

| | tokens de contexto | custo de entrada |
|---|---|---|
| piso (relido sempre) | 1,38 bi (24,3%) | US$ 1.181 (**25,9%**) |
| conversa acumulada | 4,30 bi (75,7%) | US$ 3.374 (**74,1%**) |

**Zerar o piso inteiro** — impossível, 2/3 dele é harness — **teria teto em 26%.** As alavancas locais reais medidas no #1648 (~4.500 de 67.244 tokens) valem **~1,7%** do custo de entrada.

A Fase 1 mirou, de boa-fé, a menor metade do problema. O piso *parecia* o alvo óbvio porque é relido em 100% dos requests — e é, mas é pequeno perto do que a conversa acumula.

## Onde estão os 74%: custo de OCUPAÇÃO

Um `tool_result` não se paga uma vez: fica no histórico e é **relido em todo request seguinte**. O custo real é `tamanho × (requests que ainda virão depois dele)`, não o tamanho.

Medido nas 3 sessões mais caras de 7 dias (US$1.209 somados), por **duas implementações independentes** (Python e awk) que convergiram:

| ferramenta | chamadas | maior saída | % do custo de ocupação |
|---|---|---|---|
| **Read** | 75 | 52.966 chars | **~55%** |
| **Bash** | 769 | 15.583 chars | **~40%** |
| Edit | 211 | 808 chars | ~3% |
| todo o resto | — | — | <1% |

O ponto que inverte a intuição: **Read teve 75 chamadas contra 769 do Bash — e custou mais.** Não é a frequência que manda; é o tamanho por chamada multiplicado pelo tempo que a saída ainda vai ficar no contexto. Uma leitura grande no *início* de uma sessão longa é o item mais caro que existe; a mesma leitura no último request é quase de graça.

Isso **valida por número** o guard de Read do #1647 (nudge por volume e por releitura), que ataca exatamente a fatia nº 1 — e aponta a próxima: saída de Bash.

## Arquivos

- **`scripts/ocupacao-contexto.sh`** (novo) — a régua da Fase 2, irmã do `piso-contexto.sh` (Fase 1). `--top 3` reproduz a tabela acima; `--sessao <uuid>` analisa uma sessão específica.
- **`docs/historico/piso-de-contexto.md`** — nova seção com a decomposição piso × acumulado e a lição.

Nada toca `src/`, `supabase/` ou runtime — uma ferramenta read-only e um doc. Sem deploy do Lovable pendente.

## Validação

- `shellcheck scripts/*.sh .claude/hooks/*.sh` → **exit 0**.
- O script bash reproduz o protótipo Python de forma independente (Read 54,1% vs 56,4%; Bash 40,5% vs 39,5%) — mesma conclusão por dois caminhos.
- Sem colisão com #1647 (mergeado), #1648 (mergeado) nem #1649 (aberto, arquivos disjuntos).

## Lição registrada

> Antes de otimizar um alvo, meça que **fração do custo** ele é. Otimizar bem a coisa errada perde para medir primeiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)