### PR TITLE
perf(contexto): Bash para de despejar saída grande em silêncio — e o erro medido não era esquecer o head

### DIFF
--- a/.claude/hooks/bash-contexto-nudge.sh
+++ b/.claude/hooks/bash-contexto-nudge.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# bash-contexto-nudge.sh — PostToolUse(Bash): disciplina de saída de comando.
+#
+# POR QUÊ: medido em scripts/ocupacao-contexto.sh sobre as 3 sessões mais caras
+# de uma janela de 7 dias, o custo de OCUPAÇÃO (tamanho x requests que ainda vão
+# reler aquilo) se divide em Read ~55% e Bash ~40% — juntos 95%. O Read já tem
+# guard (read-contexto-nudge.sh, #1647); este é o do Bash.
+# A cauda é curta e gorda: saídas >= 4.000 chars foram 2,6% das chamadas e 23,4%
+# do volume. Uma saída grande CEDO na sessão é relida em todos os requests
+# seguintes — é o item mais caro que existe.
+#
+# O ERRO REAL NÃO É ESQUECER O `head`: as maiores saídas medidas JÁ usavam
+# `| head -120` e `| head -60` e ainda assim despejaram 9.784 e 5.460 chars.
+# `head -n` limita LINHAS; o contexto se paga em BYTES. Em SQL, log e código a
+# linha média passa de 80 chars, então 120 linhas viram ~10k. Por isso a
+# mensagem empurra `head -c` / `cut -c` — não "use head".
+#
+# POST e não PRE de propósito: no PreToolUse só existe o COMANDO, e prever o
+# volume pela cara dele é fraco — 46,5% das chamadas medidas caíram em "outros"
+# (compostos, heredoc, script inline). Só depois de rodar se sabe o tamanho.
+# LIMITAÇÃO ASSUMIDA (mesma do read-nudge): não evita o custo DESTA saída, muda
+# a PRÓXIMA decisão.
+#
+# NÃO BLOQUEIA e NÃO DECIDE PERMISSÃO — só anexa contexto.
+#
+# BARATO DE PROPÓSITO: 1 jq só. Roda depois de CADA Bash (dezenas por turno).
+# Testes em scripts/test-bash-contexto-nudge.sh.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+entrada="$(cat)"
+
+# Um único jq: nome da ferramenta, tamanho da saída e o comando.
+# A saída do Bash pode vir como string ou como objeto {stdout,stderr,...} —
+# `tostring` cobre os dois sem ramificar. O comando vai por último porque `read`
+# joga o resto da linha no último campo (comando com tab não desloca os outros).
+campos="$(printf '%s' "$entrada" | jq -r '
+  [ (.tool_name // ""),
+    (((.tool_response // "") | tostring) | length | tostring),
+    ((.tool_input.command // "") | gsub("[\\t\\n]"; " "))
+  ] | @tsv' 2>/dev/null)"
+IFS="$(printf '\t')" read -r tool chars comando <<EOF
+$campos
+EOF
+
+[ "$tool" = "Bash" ] || exit 0          # defesa se o matcher do settings.json mudar
+case "${chars:-}" in ''|*[!0-9]*) exit 0 ;; esac
+
+# 4.000 chars = o corte medido (2,6% das chamadas, 23,4% do volume). Abaixo
+# disso o aviso viraria ruído: a saída mediana do Bash tem ~718 chars.
+[ "$chars" -ge 4000 ] || exit 0
+
+tokens=$(( chars * 10 / 36 ))           # ~3,6 bytes/token em log, SQL e código
+tok_k=$(( tokens / 1000 ))
+[ "$tok_k" -ge 1 ] || tok_k=1
+
+# Já tinha `head -n`/`tail -n` e MESMO ASSIM veio grande? Então o problema é a
+# unidade (linha vs byte), não a ausência do limite — e o conselho tem de ser
+# outro, senão o hook manda fazer o que já foi feito.
+tinha_head=0
+case "$comando" in
+  *"head -"*|*"tail -"*|*" head"*|*" tail"*) tinha_head=1 ;;
+esac
+
+# BASH-SAIDA-GRANDE / BASH-LIMITE-POR-LINHA são CONTRATO DE TESTE: marcadores
+# ASCII, caixa fixa, exclusivos de um ramo. scripts/test-bash-contexto-nudge.sh
+# casa por eles com `command grep` sem -i — prosa acentuada casaria o ramo errado
+# sob pt_BR.UTF-8 e não sob LC_ALL=C (#1483). Não troque por trechos em português.
+if [ "$tinha_head" -eq 1 ]; then
+  msg="🟡 Saída grande mesmo com head/tail: ≈${tok_k}k tokens. head -n corta LINHAS; o contexto paga BYTES.
+→ use head -c 2000 (ou cut -c1-200) para limitar de verdade."
+  ctx="BASH-LIMITE-POR-LINHA: este comando já limitava com head/tail e ainda assim a saída injetou cerca de ${tok_k}k tokens no contexto, que serão relidos em todo request seguinte desta sessão. A causa é a unidade: 'head -n N' corta N LINHAS, mas o contexto se paga em BYTES — em SQL, log e código a linha passa de 80 chars, então 120 linhas viram ~10k. Da próxima vez limite por bytes: 'head -c 2000', ou 'cut -c1-200' para cortar a largura de cada linha, ou combine ('head -40 | cut -c1-160'). Se precisa do conteúdo inteiro, mande para arquivo e traga só o recorte: 'cmd > /tmp/saida.txt 2>&1; echo \$?; head -c 1500 /tmp/saida.txt' — o arquivo continua lá para consultar com rg/jq sem reinjetar tudo."
+else
+  if [ "$chars" -ge 12000 ]; then
+    grito="🔴"; peso="Isso sozinho pesa mais que muitos arquivos inteiros."
+  else
+    grito="🟡"; peso="Cada turno seguinte relê esses ${tok_k}k."
+  fi
+  msg="${grito} Saída grande: ≈${tok_k}k tokens no contexto. ${peso}
+→ redirecione para arquivo e traga só o recorte (> /tmp/x.txt; head -c 1500 /tmp/x.txt)."
+  ctx="BASH-SAIDA-GRANDE: a saída deste comando injetou cerca de ${tok_k}k tokens no contexto, e cada request seguinte desta sessão relê tudo isso — saída grande no INÍCIO da sessão é o item mais caro que existe. Para os próximos comandos parecidos, nesta ordem: (1) mande a saída para arquivo e traga só o recorte — 'cmd > /tmp/saida.txt 2>&1; echo \$?; head -c 1500 /tmp/saida.txt' (mantém o exit code, que '| tail' engoliria, e o arquivo fica para consultar com rg/jq depois); (2) peça ao comando para responder menos: 'git diff --stat' em vez de 'git diff', 'grep -c'/'grep -l' em vez de listar tudo, 'psql' com LIMIT e colunas nomeadas em vez de SELECT *, 'jq' projetando só os campos que interessam; (3) limite por BYTES e não por linhas — 'head -c 2000', 'cut -c1-200'. Se você realmente precisa de tudo isso agora, siga em frente — isto é um lembrete, não um bloqueio."
+fi
+
+jq -n --arg m "$msg" --arg c "$ctx" \
+  '{systemMessage:$m, hookSpecificOutput:{hookEventName:"PostToolUse", additionalContext:$c}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -123,6 +123,17 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/bash-contexto-nudge.sh\""
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "compact",

--- a/docs/historico/piso-de-contexto.md
+++ b/docs/historico/piso-de-contexto.md
@@ -6,8 +6,9 @@ rentável de otimização (82% do custo de token é ENTRADA de contexto: `cache_
 `cache_write` 25,0%; gerar resposta é só 16,4%) — cortar 1 token de piso rende em 100% dos
 requests, para sempre.
 
-E é também onde as premissas plausíveis mais enganam. **Duas hipóteses razoáveis foram
-medidas e REFUTADAS** — as duas teriam virado "otimização" entregue sem número.
+E é também onde as premissas plausíveis mais enganam. **Três hipóteses razoáveis foram
+medidas e REFUTADAS** — uma delas chegou a PIORAR o piso. As três teriam virado
+"otimização" entregue sem número.
 
 ## Réguas (as duas são read-only e ficam no repo)
 
@@ -79,6 +80,50 @@ não fazer nada. Revertido.
 Fica valendo para roteamento (o modelo deixa de ver 113 skills irrelevantes), mas isso é
 uma afirmação NÃO medida — e o mecanismo de preenchimento sugere ceticismo: o que entra no
 lugar pode ser tão irrelevante quanto o que saiu.
+## ⚠️ CORREÇÃO — o orçamento existe, mas é CONFIGURÁVEL (e eu tinha concluído o contrário)
+
+As três medições acima estavam certas; a conclusão que tirei delas, não. Eu escrevi que o
+listing só encolhe removendo o provedor inteiro. **Errado** — o orçamento é uma chave do
+`settings.json`, e o schema do Claude Code expõe quatro que importam:
+
+| chave | default | o que faz |
+|---|---|---|
+| `skillListingBudgetFraction` | `0.01` (1% da janela) | **é o orçamento** que se reabastecia sozinho |
+| `skillListingMaxDescChars` | `1536` | teto por descrição (por isso as longas apareciam cortadas) |
+| `skillOverrides` | — | por skill: `name-only`, `user-invocable-only`, `off` |
+| `disableClaudeAiConnectors` | — | o switch CERTO dos connectors (`ENABLE_CLAUDEAI_MCP_SERVERS` **não** funciona) |
+
+Medido com a sonda (baseline 43.896), e o resultado tem uma inversão útil:
+
+| config | piso | economia | skills c/ descrição | as 8 skills que o founder USA |
+|---|---|---|---|---|
+| baseline (`0.01` / `1536`) | 43.896 | — | 55 | 8/8 |
+| `maxDescChars 300` | 43.273 | 623 | **123** | 8/8 |
+| `maxDescChars 300` + `fraction 0.005` | 37.806 | 6.090 | 49 | 8/8 |
+| **`maxDescChars 220` + `fraction 0.004`** | **36.720** | **7.176** | 43 | **8/8** ✅ |
+| `fraction 0.003` (só) | 35.563 | 8.333 | 13 | **0/8** ❌ |
+
+Cortar só o orçamento é a economia maior e a pior escolha: zera a descrição das 13 skills do
+projeto — `fecho`, `prove-sql-money-path`, `lovable-db-operator` viram nome solto e param de
+disparar sozinhas. **Capar a descrição é Pareto-superior**: com `maxDescChars 300` cabem 123
+skills descritas em vez de 55 (mais que o dobro de roteamento) e ainda sobra token.
+
+O ponto escolhido — `220` + `0.004` — economiza **7.176 tokens (16% do piso do CLI)** mantendo
+os gatilhos ("Use SEMPRE que…") de 8/8 das skills usadas. As 3 do projeto que perdem descrição
+(`cfo-colacor`, `farmer-industrial`, `goal`) já estavam sem ela no baseline e têm **uso zero em
+48 dias** — perda real: nenhuma.
+
+Isto também reabilita, por outro caminho, o corte revertido lá em cima: não era preciso editar
+13 `SKILL.md` à mão — uma chave faz o mesmo truncamento, e melhor.
+
+### E isto EXPLICA a premissa falsa nº 3
+
+A nº 3 mediu que esconder 113 skills PIORA o piso em +141 tokens, e diagnosticou a causa:
+"as descrições promovidas para o espaço liberado eram **mais longas** que as removidas".
+`skillListingMaxDescChars` ataca exatamente essa causa — com um teto por descrição, o que
+sobe para o espaço liberado não pode ser mais caro que o que saiu. As duas medições contam
+a mesma história por lados opostos: **mexer em QUEM está na lista não resolve (e pode
+piorar); mexer no TAMANHO de cada entrada resolve.**
 
 ## ✅ O que REALMENTE move o ponteiro: desabilitar o PLUGIN inteiro
 
@@ -136,7 +181,19 @@ saída ainda vai ficar no contexto. Uma leitura grande no início de uma sessão
 mais caro que existe; a mesma leitura no último request é quase de graça.
 
 Régua: `scripts/ocupacao-contexto.sh --top 3`. O guard de Read do #1647 (nudge por volume e
-por releitura) ataca justamente a fatia nº 1.
+por releitura) ataca a fatia nº 1; `.claude/hooks/bash-contexto-nudge.sh` ataca a nº 2.
+
+### O erro no Bash não é esquecer o `head`
+
+As maiores saídas medidas **já usavam** `| head -120` e `| head -60` — e ainda despejaram
+9.784 e 5.460 chars. `head -n` corta LINHAS; o contexto se paga em BYTES, e em SQL, log e
+código a linha passa de 80 chars. Por isso o guard tem dois ramos: quando já havia `head`/
+`tail`, ele ensina `head -c` / `cut -c` (a unidade certa) em vez de repetir o conselho que
+já tinha sido seguido.
+
+O guard é PostToolUse, não Pre, porque no Pre só existe o comando — e prever volume pela
+cara dele é fraco: 46,5% das chamadas medidas caíram em "outros" (compostos, heredoc,
+script inline). Só depois de rodar se sabe o tamanho.
 
 ## Pendente de medição — só o founder consegue (é na conta, não no repo)
 
@@ -155,14 +212,19 @@ comparar o piso com os 67.244 registrados aqui.
 
 ## Lição transferível
 
-> O piso não responde a cortes *dentro* de blocos de orçamento fixo (lista de skills,
-> descrições). Responde a **remover um provedor inteiro** (plugin, MCP, servidor).
+> O piso não responde a cortes *dentro* de um bloco de orçamento — o orçamento se reabastece.
+> Responde a **remover um provedor inteiro** (plugin, MCP, servidor) ou a **mudar o orçamento**
+> (ver a CORREÇÃO acima: ele é uma chave de settings, não uma constante do harness).
 > E: "encurtei X, logo economizei" é hipótese — o número vem da sonda, antes e depois.
 >
 > Corolário da nº 3: dentro de um bloco de orçamento fixo, cortar não é neutro — pode
 > **piorar**. O espaço liberado é repreenchido, e nada garante que o que entra seja menor
 > que o que saiu. "No pior caso não muda nada" é falso aqui, e foi a intuição que mediu
-> −0 e entregou +141.
+> −0 e entregou +141. O que funciona é limitar o TAMANHO de cada entrada, não escolher
+> quais entram.
+>
+> Antes de concluir "não dá para mexer nisso", **procure a chave**: o schema completo do
+> settings sai pela skill `update-config`, e foi lá que apareceram as quatro que faltavam.
 >
 > E antes de otimizar um alvo, **meça que fração do custo ele é**. O piso parecia o alvo
 > óbvio (é relido em 100% dos requests) e é só 26%. Otimizar bem a coisa errada perde para

--- a/scripts/test-bash-contexto-nudge.sh
+++ b/scripts/test-bash-contexto-nudge.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# test-bash-contexto-nudge.sh — prova do hook .claude/hooks/bash-contexto-nudge.sh
+#
+# Roda em DOIS locales (C e pt_BR.UTF-8) de propósito: no #1483 uma asserção
+# passou por acidente de ambiente porque `grep -i` sob pt_BR.UTF-8 dobra Ã↔ã e
+# casava o ramo errado. Aqui todo casamento é por marcador ASCII exclusivo, caixa
+# fixa, com `command grep` e SEM -i — e o teste é executado nos dois locales para
+# provar que a asserção não depende disso.
+#
+# Inclui FALSIFICAÇÃO: no fim, sabota o limiar do hook e exige que o teste do
+# silêncio fique VERMELHO. Um teste que passa com o código sabotado não prova nada.
+set -u
+
+HOOK="$(cd "$(dirname "$0")/.." && pwd)/.claude/hooks/bash-contexto-nudge.sh"
+[ -x "$HOOK" ] || { echo "hook não encontrado/executável: $HOOK" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq é necessário" >&2; exit 1; }
+
+falhas=0
+
+# Monta o JSON de entrada do PostToolUse com uma saída de N chars.
+entrada() { # <n_chars> <comando> [tool_name]
+  jq -n -c --arg cmd "$2" --arg tool "${3:-Bash}" --argjson n "$1" \
+    '{tool_name:$tool, tool_input:{command:$cmd},
+      tool_response:( "x" * $n )}'
+}
+
+# roda o hook e devolve stdout
+executa() { printf '%s' "$1" | bash "$HOOK" 2>/dev/null; }
+
+checa() { # <titulo> <esperado: MARCADOR|VAZIO> <json>
+  local titulo="$1" esperado="$2" json="$3" saida
+  saida="$(executa "$json")"
+  if [ "$esperado" = "VAZIO" ]; then
+    if [ -z "$saida" ]; then printf '  ok   %s\n' "$titulo"; return 0; fi
+    printf '  FALHA %s — esperava silêncio, veio: %s\n' "$titulo" "$(printf '%s' "$saida" | head -c 120)"
+    falhas=$((falhas + 1)); return 1
+  fi
+  # marcador tem de estar no additionalContext, não em qualquer lugar do JSON
+  if printf '%s' "$saida" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null \
+       | command grep -q "$esperado"; then
+    printf '  ok   %s\n' "$titulo"; return 0
+  fi
+  printf '  FALHA %s — esperava %s, veio: %s\n' "$titulo" "$esperado" "$(printf '%s' "$saida" | head -c 160)"
+  falhas=$((falhas + 1)); return 1
+}
+
+rodada() {
+  echo "--- locale: ${LC_ALL:-(herdado)} ---"
+
+  # (1) POSITIVO: saída grande sem limite -> BASH-SAIDA-GRANDE
+  checa "saida 5k sem head" "BASH-SAIDA-GRANDE" "$(entrada 5000 'psql -c "select * from t"')"
+
+  # (2) POSITIVO: saída grande QUE JÁ USAVA head -> o outro ramo
+  checa "saida 5k com head -120" "BASH-LIMITE-POR-LINHA" "$(entrada 5000 'cat arq.sql | head -120')"
+
+  # (3) POSITIVO: saída enorme -> ainda o ramo SAIDA-GRANDE (e o 🔴 na msg)
+  checa "saida 20k sem head" "BASH-SAIDA-GRANDE" "$(entrada 20000 'git diff')"
+
+  # (4) NEGATIVO: abaixo do limiar -> SILÊNCIO (o caso que a falsificação quebra)
+  checa "saida 500 (abaixo do limiar)" "VAZIO" "$(entrada 500 'ls')"
+
+  # (5) NEGATIVO: exatamente 3999 -> silêncio (fronteira)
+  checa "saida 3999 (fronteira)" "VAZIO" "$(entrada 3999 'ls')"
+
+  # (6) NEGATIVO: outra ferramenta -> silêncio
+  checa "tool_name=Read" "VAZIO" "$(entrada 9000 'irrelevante' 'Read')"
+
+  # (7) ROBUSTEZ: JSON inválido não pode quebrar nem falar
+  local saida
+  saida="$(printf '%s' 'isto não é json' | bash "$HOOK" 2>/dev/null)"
+  if [ -z "$saida" ]; then printf '  ok   entrada invalida -> silencio\n'
+  else printf '  FALHA entrada invalida falou: %s\n' "$saida"; falhas=$((falhas + 1)); fi
+
+  # (8) ROBUSTEZ: tool_response como OBJETO (formato alternativo) ainda mede
+  local j
+  j="$(jq -n -c '{tool_name:"Bash", tool_input:{command:"git log"},
+                  tool_response:{stdout:("y" * 9000), stderr:"", exitCode:0}}')"
+  checa "tool_response objeto 9k" "BASH-SAIDA-GRANDE" "$j"
+
+  # (9) o JSON emitido é válido e tem o hookEventName certo
+  local ev
+  ev="$(executa "$(entrada 5000 'ls')" | jq -r '.hookSpecificOutput.hookEventName' 2>/dev/null)"
+  if [ "$ev" = "PostToolUse" ]; then printf '  ok   hookEventName=PostToolUse\n'
+  else printf '  FALHA hookEventName veio "%s"\n' "$ev"; falhas=$((falhas + 1)); fi
+}
+
+echo "== bash-contexto-nudge =="
+LC_ALL=C rodada
+if locale -a 2>/dev/null | command grep -qi '^pt_BR.UTF-*8$'; then
+  LC_ALL=pt_BR.UTF-8 rodada
+else
+  echo "--- locale pt_BR.UTF-8 indisponível nesta máquina: pulado ---"
+fi
+
+# ---------------------------------------------------------------- falsificação
+# Sabota o limiar (4000 -> 1) e exige que o teste do SILÊNCIO fique vermelho.
+# Se continuar verde, a asserção (4) não estava provando nada.
+echo "--- falsificação (sabota o limiar; o silêncio TEM de quebrar) ---"
+sabotado="$(mktemp)"; trap 'rm -f "$sabotado"' EXIT
+# shellcheck disable=SC2016  # o $chars é literal de propósito: casa o TEXTO do hook, não expande
+sed 's/\[ "\$chars" -ge 4000 \]/[ "$chars" -ge 1 ]/' "$HOOK" > "$sabotado"
+if command grep -q '\-ge 1 \]' "$sabotado"; then
+  saida_sab="$(printf '%s' "$(entrada 500 'ls')" | bash "$sabotado" 2>/dev/null)"
+  if [ -n "$saida_sab" ]; then
+    echo "  ok   sabotagem detectada (o silêncio quebrou como esperado)"
+  else
+    echo "  FALHA a sabotagem NÃO quebrou o teste — a asserção do silêncio é teatro"
+    falhas=$((falhas + 1))
+  fi
+else
+  echo "  FALHA não consegui sabotar o hook (o padrão do limiar mudou?)"
+  falhas=$((falhas + 1))
+fi
+
+echo
+if [ "$falhas" -eq 0 ]; then echo "TODOS OS TESTES PASSARAM"; exit 0; fi
+echo "FALHAS: $falhas"; exit 1


### PR DESCRIPTION
Fase 3 da linha #1647 / #1648 / #1650. O custo de **ocupação** (tamanho × requests que ainda vão reler aquilo) mede **Read ~55% e Bash ~40%** — juntos 95%. O Read ganhou guard no #1647; este é o do Bash, a maior fatia que seguia descoberta.

## O erro real não é esquecer o `head`

As maiores saídas medidas **já usavam** `| head -120` e `| head -60` — e ainda despejaram 9.784 e 5.460 chars.

`head -n` corta **linhas**; o contexto se paga em **bytes**. Em SQL, log e código a linha passa de 80 chars, então 120 linhas viram ~10k. Por isso o guard tem dois ramos:

| situação | o que ensina |
|---|---|
| saída grande, sem limite | redirecionar para arquivo e trazer só o recorte; `--stat`, `grep -c`, `LIMIT` |
| saída grande **com** `head`/`tail` | `head -c` / `cut -c` — a unidade certa |

Sem o segundo ramo o hook mandaria fazer o que já tinha sido feito.

**PostToolUse e não Pre**: no Pre só existe o comando, e prever volume pela cara dele é fraco — 46,5% das chamadas medidas caem em "outros" (compostos, heredoc, script inline). Só depois de rodar se sabe o tamanho. Limitação assumida (a mesma do #1647): não evita o custo *desta* saída, muda a próxima decisão.

**Limiar 4.000 chars** = o corte medido: 2,6% das chamadas, 23,4% do volume. A saída mediana do Bash tem ~718 chars, então o aviso é raro por construção (~1 a cada 38 comandos).

## Correção do #1648

Eu havia concluído ali que o `skill_listing` só encolhe removendo o provedor inteiro. **Errado** — o orçamento é uma chave de settings. O schema expõe:

| chave | default | o que faz |
|---|---|---|
| `skillListingBudgetFraction` | `0.01` | **é** o orçamento que se reabastecia sozinho |
| `skillListingMaxDescChars` | `1536` | teto por descrição |
| `skillOverrides` | — | por skill: `name-only` / `off` |
| `disableClaudeAiConnectors` | — | o switch **certo** dos connectors (`ENABLE_CLAUDEAI_MCP_SERVERS` não funciona) |

Medido, com uma inversão útil:

| config | piso | economia | skills c/ descrição | **as 8 que o founder usa** |
|---|---|---|---|---|
| baseline | 43.896 | — | 55 | 8/8 |
| `maxDescChars 300` | 43.273 | 623 | **123** | 8/8 |
| **`220` + `fraction 0.004`** | **36.720** | **7.176** | 43 | **8/8** ✅ |
| `fraction 0.003` (só) | 35.563 | 8.333 | 13 | **0/8** ❌ |

Cortar só o orçamento é a economia maior e a pior escolha — zera a descrição de `fecho`, `prove-sql-money-path`, `lovable-db-operator`, que viram nome solto e param de disparar. Capar a descrição é Pareto-superior: cabem 123 skills descritas em vez de 55 **e** sobra token.

**As duas chaves não entram neste PR**: o classificador de permissão barrou a edição, e não contornei. Ficam documentadas com o número, para o founder decidir.

## Validação (evidência positiva)

- `shellcheck scripts/*.sh .claude/hooks/*.sh` → **exit 0**
- `scripts/test-bash-contexto-nudge.sh` → **exit 0**: 19 asserts em **dois locales** (C e pt_BR.UTF-8, por causa do #1483), positivos e negativos, incluindo fronteira (3999 → silêncio), outra ferramenta, JSON inválido e `tool_response` como objeto
- **Falsificação**: o teste sabota o limiar (4000 → 1) e exige que a asserção do silêncio fique vermelha. Ela quebra — não é teatro
- `test-read-contexto-nudge.sh` (#1647) segue verde → **exit 0**
- **O hook disparou na sessão real** e escolheu o ramo certo (`BASH-LIMITE-POR-LINHA` num `git log | head -60`)

Nada toca `src/`, `supabase/` ou runtime. Sem deploy do Lovable pendente. Sem colisão com PRs abertos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)