### PR TITLE
test(mutcheck): contrato .mut de EDGE deixa de ser impossível — runner por contrato

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,9 @@ jobs:
       # helper local. Consequência a saber: teste de edge que precise de `npm:`/`jsr:` NÃO roda aqui
       # — a saída é extrair a lógica PURA e testar ela (o que os 11 arquivos já fazem), não afrouxar
       # o flag.
+      #
+      # O pin do deno tem 2 ocorrências (esta e o job `mutation-check`, que roda contrato .mut de
+      # edge) — bump alinha as duas.
       - name: Setup Deno
         uses: denoland/setup-deno@v2
         with:
@@ -300,6 +303,17 @@ jobs:
 
       - name: Install deps
         run: bun install --frozen-lockfile
+
+      # O job precisa do runtime de TODO contrato registrado, não só do default. Desde
+      # `scripts/mutcheck.d/cmc-snapshot-retry.mut` há contrato de EDGE, cujo `# @test_cmd:`/
+      # `# @compile_cmd:` é `deno` — sem este step o `deno` não existe no PATH, o compila-check do
+      # SRC ORIGINAL falha e o mutcheck aborta com "harness/ambiente quebrado", derrubando o job
+      # inteiro por ambiente, não por cobertura. Pin alinhado ao job `validate` (2ª ocorrência —
+      # bump conferindo `deno --version` e alinhando as duas).
+      - name: Setup Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: 2.9.2
 
       - name: mutcheck — selftest (mecânica da ferramenta, sem vitest)
         run: bun run mutcheck:selftest

--- a/scripts/mutcheck-all.sh
+++ b/scripts/mutcheck-all.sh
@@ -9,8 +9,27 @@
 #   - ficar dessincronizado (perl não casa = INVÁLIDO → o .mut está stale após um
 #     refactor do helper; atualize o .mut pro novo texto).
 #
+# Diretivas OPCIONAIS por contrato (mesmo parse das obrigatórias):
+#   # @test_cmd:     runner do contrato    → MUTCHECK_TEST_CMD
+#   # @compile_cmd:  compila-check         → MUTCHECK_COMPILE_CMD
+#
+# Existem porque o default do mutcheck.sh ('bunx vitest run' + 'bun build') só serve
+# a helper de `src/`. Um helper de EDGE roda em Deno: o vitest não conhece `Deno.test`
+# e daria baseline VERMELHO, abortando o contrato — e um .mut de edge no diretório
+# derrubaria o job inteiro do CI. Era por isso que a política do #1643/#1644 ficou
+# FALSIFICADA à mão sem contrato versionado. Com as diretivas, o contrato carrega o
+# runner que lhe cabe (`deno test --no-remote …`, o mesmo do script `test:edges`).
+#
+# ⚠️ Valor VAZIO conta como ausente (cai no default). Para DESLIGAR o compila-check
+# use '# @compile_cmd: true' — `true <src>` sai 0 sempre, que é o contrato de
+# `compila()`. '# @compile_cmd:' pelado devolveria `bun build`, que num alvo Deno
+# aborta o contrato com "harness/ambiente quebrado" — mensagem que aponta pro lugar
+# errado.
+#
 # Uso:  bash scripts/mutcheck-all.sh    (ou: bun run mutcheck)
 # CI:   job 'mutation-check' (não-required por ora — ver .github/workflows/ci.yml).
+#       O job precisa do runtime de TODO contrato registrado: hoje bun (default) E
+#       deno (o contrato de edge abaixo) — ver o step 'Setup Deno' de lá.
 #
 set -uo pipefail
 
@@ -32,8 +51,21 @@ for mut in "${muts[@]}"; do
     echo "✗ $mut — falta diretiva '# @src:' ou '# @test:'"
     failed+=("$mut (sem alvo)"); continue
   fi
+  # Overrides opcionais. Só entram no ambiente quando o contrato DECLARA — assim
+  # nenhum .mut existente muda de comportamento (e `MUTCHECK_COMPILE_CMD=""` no
+  # mutcheck.sh usa `${VAR-default}`, então exportar vazio DESLIGARIA o compila-check
+  # de todo mundo, calado).
+  test_cmd=$(sed -n 's/^#[[:space:]]*@test_cmd:[[:space:]]*//p' "$mut" | head -1)
+  compile_cmd=$(sed -n 's/^#[[:space:]]*@compile_cmd:[[:space:]]*//p' "$mut" | head -1)
+  envs=()
+  [[ -n "$test_cmd" ]] && envs+=("MUTCHECK_TEST_CMD=$test_cmd")
+  [[ -n "$compile_cmd" ]] && envs+=("MUTCHECK_COMPILE_CMD=$compile_cmd")
+
   echo "──────────────────────────────────────────────────────────"
-  if bash "$MUTCHECK" "$src" "$tst" "$mut"; then :; else
+  # o runner sai no log: sem isso, "baseline VERMELHO" num contrato de edge parece
+  # cobertura quebrada quando é runtime ausente no PATH.
+  [[ ${#envs[@]} -gt 0 ]] && printf '  runner do contrato: %s\n' "${envs[@]}"
+  if env ${envs[@]+"${envs[@]}"} bash "$MUTCHECK" "$src" "$tst" "$mut"; then :; else
     failed+=("$mut (exit $?)")
   fi
 done

--- a/scripts/mutcheck.d/cmc-snapshot-retry.mut
+++ b/scripts/mutcheck.d/cmc-snapshot-retry.mut
@@ -1,0 +1,21 @@
+# Invariantes money-path da política de retentativa/redação do `callOmie` das edges
+# `cmc-snapshot-smoke` e `cmc-snapshot-backfill` (#1644).
+# @src: supabase/functions/_shared/cmc-snapshot-retry.ts
+# @test: supabase/functions/_shared/cmc-snapshot-retry_test.ts
+# @test_cmd: deno test --no-remote --allow-read=supabase/functions
+# @compile_cmd: deno check --no-remote
+# Rode: bash scripts/mutcheck-all.sh   (o runner sai das diretivas acima — vitest não conhece Deno.test)
+# PEGA = a suíte DEVE matar (gate de cobertura). SOBREVIVE = benigno conhecido. ? = exploratório.
+#
+# ⚠️ `@compile_cmd` aqui é `deno check`, que TYPE-checa — mais forte que o `bun build` default (só
+# sintaxe). Mutação que só quebra tipo vira INVÁLIDA (morta pelo compilador), não falso-PEGA.
+PEGA      | defeito nº1 volta: dígito HTTP cru        | s/const classe = classificarFaultstring\(mensagem\);/const classe = \/50[0-9]|429\/.test(mensagem) ? "transitorio" : classificarFaultstring(mensagem);/
+PEGA      | permanente volta a retentar               | s/const retentavel = classe === "transitorio" \|\| classe === "indeterminada";/const retentavel = classe !== "fim_de_pagina";/
+PEGA      | indeterminada para de retentar            | s/const retentavel = classe === "transitorio" \|\| classe === "indeterminada";/const retentavel = classe === "transitorio";/
+PEGA      | fim_de_pagina passa a dormir e retentar   | s/const retentavel = classe === "transitorio" \|\| classe === "indeterminada";/const retentavel = classe !== "permanente";/
+PEGA      | base do backoff 1000 -> 800               | s/const ATRASO_BASE_MS = 1000;/const ATRASO_BASE_MS = 800;/
+PEGA      | teto de 5s do helper aplicado à curva     | s/return ATRASO_BASE_MS \* 2 \*\* \(Math\.max\(1, Math\.floor\(tentativa\)\) - 1\);/return Math.min(ATRASO_BASE_MS * 2 ** (Math.max(1, Math.floor(tentativa)) - 1), 5000);/
+PEGA      | teto de tentativas 5 -> 4                 | s/MAX_TENTATIVAS_CMC_SNAPSHOT = 5;/MAX_TENTATIVAS_CMC_SNAPSHOT = 4;/
+PEGA      | redação da faultstring removida           | s/redigirSegredo\(String\(faultstring\)\)/String(faultstring)/
+PEGA      | trunca ANTES de redigir (app_key na borda)| s/redigirSegredo\(corpo\)\.slice\(0, 300\)/redigirSegredo(corpo.slice(0, 300))/
+SOBREVIVE | piso do expoente (tentativa<1 não é testada) | s/Math\.max\(1, Math\.floor\(tentativa\)\)/Math.floor(tentativa)/

--- a/scripts/mutcheck.d/omie-analytics-politica-retry.mut
+++ b/scripts/mutcheck.d/omie-analytics-politica-retry.mut
@@ -1,0 +1,26 @@
+# Invariantes money-path da política de retentativa/redação do `callOmie` do `omie-analytics-sync` (#1643).
+# @src: supabase/functions/omie-analytics-sync/politica-retry.ts
+# @test: supabase/functions/omie-analytics-sync/politica-retry_test.ts
+# @test_cmd: deno test --no-remote --allow-read=supabase/functions
+# @compile_cmd: deno check --no-remote
+# Rode: bash scripts/mutcheck-all.sh   (o runner sai das diretivas acima — vitest não conhece Deno.test)
+# PEGA = a suíte DEVE matar (gate de cobertura). SOBREVIVE = benigno conhecido. ? = exploratório.
+#
+# ⚠️ A política daqui NÃO é a do `_shared/cmc-snapshot-retry.ts`: lá `indeterminada` RETENTA, aqui
+# falha rápido — divergência deliberada, a conta está no doc do `decidirRetentativaOmie`. Por isso
+# as duas mutações de `retentavel` abaixo esperam PEGA com o sinal TROCADO em relação ao outro .mut.
+PEGA      | defeito nº1 volta: dígito HTTP cru        | s/const classe = classificarFaultstring\(mensagem\);/const classe = \/50[0-9]|429\/.test(mensagem) ? "transitorio" : classificarFaultstring(mensagem);/
+PEGA      | indeterminada passa a retentar            | s/const retentar = classe === "transitorio" && tentativa < maxTentativas;/const retentar = classe !== "permanente" && tentativa < maxTentativas;/
+PEGA      | transitorio para de retentar              | s/const retentar = classe === "transitorio" && tentativa < maxTentativas;/const retentar = classe === "permanente" && tentativa < maxTentativas;/
+PEGA      | 'Aguarde N' passa a alongar o sleep       | s/atrasoRetentativaMs\(tentativa\)/atrasoRetentativaMs(tentativa, mensagem)/
+PEGA      | teto de tentativas 4 -> 3                 | s/MAX_TENTATIVAS_OMIE = 4;/MAX_TENTATIVAS_OMIE = 3;/
+PEGA      | redação da faultstring removida           | s/redigirSegredo\(String\(texto\)\)/String(texto)/
+PEGA      | status do corpo não-JSON perde a âncora   | s/: HTTP \$\{status\} \(corpo/: codigo \${status} (corpo/
+# ⚠️ SOBREVIVENTE MEDIDA, e é BURACO, não benigno — por isso `?` e não SOBREVIVE. O código está
+# CERTO (redige e só então trunca), mas nada o prende: inverter para truncar-antes parte a app_key
+# na borda dos 200 caracteres e deixa um resto curto que escapa da máscara `\d{8,}` — o segredo sai
+# pela metade, que para efeito de vazamento é sair. É o mesmo furo que o `cmc-snapshot-retry_test.ts`
+# fechou no gêmeo de 300 caracteres (e lá a 1ª fixture usava enchimento `a`, hexadecimal, e a
+# mutação SOBREVIVIA por acidente do alfabeto — use caractere não-hex ao escrever o teste).
+# Vira PEGA quando o teste existir; até lá fica reportado e versionado, não esquecido.
+?         | trunca ANTES de redigir (200 chars) — SEM teste | s/redigirSegredo\(erro instanceof Error \? erro\.message : String\(erro\)\)\.slice\(0, 200\)/redigirSegredo((erro instanceof Error ? erro.message : String(erro)).slice(0, 200))/


### PR DESCRIPTION
## O problema

A política de retry do Omie de #1643 e #1644 foi **falsificada à mão** (9/9 e 4/4 mutações pegas) e o resultado morreu no chat: não havia como registrar o contrato em `scripts/mutcheck.d/`.

O `mutcheck-all.sh` invocava `bash mutcheck.sh "$src" "$tst" "$mut"` **sem env por contrato**, e o default é `bunx heavy vitest run` — que não conhece `Deno.test`. Um `.mut` de edge no diretório deixaria o baseline VERMELHO e abortaria o job `mutation-check` inteiro. Ou seja: justamente os helpers cuja suíte foi medida eram os únicos que não podiam ter a medição versionada.

## A mudança

Duas diretivas **opcionais** por contrato, lidas com o mesmo `sed` de `@src:`/`@test:`:

```
# @test_cmd:     → MUTCHECK_TEST_CMD
# @compile_cmd:  → MUTCHECK_COMPILE_CMD
```

Só entram no ambiente quando o contrato **declara**, e isso é o ponto: `mutcheck.sh` lê `${MUTCHECK_COMPILE_CMD-default}` (sem `:`), então exportar a variável **vazia** para todo mundo desligaria o compila-check dos 9 contratos existentes em silêncio — o guard que separa "morto por teste" de "morto pelo compilador".

Pegadinha documentada no cabeçalho: `# @compile_cmd:` pelado conta como ausente e cairia no `bun build`, que num alvo Deno aborta o contrato com *"harness/ambiente quebrado"*. Para desligar de verdade: `# @compile_cmd: true`.

## Contratos registrados

| Contrato | Resultado |
|---|---|
| `cmc-snapshot-retry.mut` (#1644) | 10 mutações · **9 pegas** · 1 sobrevivente · 0 inválidas |
| `omie-analytics-politica-retry.mut` (#1643) | 8 mutações · **7 pegas** · 1 sobrevivente · 0 inválidas |

A sobrevivente do `politica-retry` é `?`, **não** `SOBREVIVE`, e a distinção é o achado: `mensagemCorpoNaoJson` está **certo** (redige e só então trunca em 200), mas nada o prende — inverter para truncar-antes parte a app_key na borda e deixa um resto que escapa da máscara `\d{8,}`. É o mesmo furo que `cmc-snapshot-retry_test.ts` já fechou no gêmeo de 300. Fica reportado e versionado até o teste existir (follow-up separado).

## CI

O job `mutation-check` só tinha Bun. Com contrato de edge, o `deno check` do SRC **original** falharia e o mutcheck abortaria com *"harness/ambiente quebrado"* — o job vermelho por **ambiente**, não por cobertura, que é a mensagem que aponta pro lugar errado. Setup Deno pinado em `2.9.2`, alinhado ao `validate` (2ª ocorrência, anotado nos dois lados).

## Evidência

```
bun run mutcheck ANTES   → exit 0, 9 contrato(s) honrado(s)
bun run mutcheck DEPOIS  → exit 0, 11 contrato(s) honrado(s)
diff do fingerprint (header + sumário) dos 9 antigos → IDÊNTICO (diff exit 0)
bash scripts/mutcheck.sh --selftest → exit 0
shellcheck scripts/mutcheck*.sh → exit 0
```

Sem deploy: é ferramenta de CI, não toca edge, frontend nem banco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)