### PR TITLE
perf(contexto): o orçamento do skill listing sai do default — −7.179 tokens em TODO request, sem perder gatilho

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,8 @@
   "env": {
     "ENABLE_CLAUDEAI_MCP_SERVERS": "false"
   },
+  "skillListingMaxDescChars": 220,
+  "skillListingBudgetFraction": 0.004,
   "enabledPlugins": {
     "adobe-for-creativity@claude-plugins-official": false,
     "mercadopago@claude-plugins-official": false,

--- a/docs/historico/piso-de-contexto.md
+++ b/docs/historico/piso-de-contexto.md
@@ -116,6 +116,18 @@ os gatilhos ("Use SEMPRE que…") de 8/8 das skills usadas. As 3 do projeto que 
 Isto também reabilita, por outro caminho, o corte revertido lá em cima: não era preciso editar
 13 `SKILL.md` à mão — uma chave faz o mesmo truncamento, e melhor.
 
+**APLICADO** no `.claude/settings.json` do repo e reconfirmado no ambiente real, com a régua
+versionada (`scripts/piso-contexto.sh`):
+
+| | piso | listing | skills c/ descrição | skills USADAS c/ descrição |
+|---|---|---|---|---|
+| defaults (`1536` / `0.01`) | 43.950 | 30.446 chars | 55 | 8/8 |
+| **aplicado (`220` / `0.004`)** | **36.771** | **12.148 chars** | 43 | **8/8** |
+
+**−7.179 tokens**, batendo os 7.176 previstos (erro de 3, dentro do ruído de ±6), e
+reprodutível: 36.771 / 36.771 em repetições. O listing caiu 60% sem perder um gatilho sequer
+das skills que o founder de fato invoca.
+
 ### E isto EXPLICA a premissa falsa nº 3
 
 A nº 3 mediu que esconder 113 skills PIORA o piso em +141 tokens, e diagnosticou a causa:


### PR DESCRIPTION
O #1652 documentou que o `skill_listing` tem **orçamento configurável** — corrigindo a conclusão do #1648, que dizia só dar para encolher removendo o provedor inteiro. Este PR aplica o ponto medido.

## Duas chaves, dois efeitos — e a diferença entre elas é o PR inteiro

```
skillListingBudgetFraction  0.01 → 0.004    (o tamanho do bolo)
skillListingMaxDescChars    1536 → 220      (o teto de cada fatia)
```

Cortar **só o orçamento** economiza mais (−8.333) e é a **pior** escolha: zera a descrição das 13 skills do projeto — `fecho`, `prove-sql-money-path` e `lovable-db-operator` viram nome solto e param de disparar sozinhas.

**Capar a descrição é Pareto-superior**: mais skills cabem no mesmo espaço, porque o que sobe para o lugar liberado não pode ser mais caro que o que saiu. É também o que **explica a premissa falsa nº 3 do #1651** — esconder skills piorava o piso em +141 tokens justamente porque as descrições promovidas eram mais longas. Aqui isso não pode acontecer: há teto.

## Medido no ambiente real (`scripts/piso-contexto.sh`)

| | piso | listing | skills c/ descrição | **skills USADAS c/ descrição** |
|---|---|---|---|---|
| defaults (`1536` / `0.01`) | 43.950 | 30.446 chars | 55 | 8/8 |
| **aplicado (`220` / `0.004`)** | **36.771** | **12.148 chars** | 43 | **8/8** ✅ |

**−7.179 tokens (16% do piso)**, batendo os 7.176 previstos no #1652 — erro de 3, dentro do ruído de ±6 da sonda. Reprodutível: 36.771 / 36.771 em repetições.

O listing cai **60%** e nenhuma das 8 skills que o founder de fato invoca perde o gatilho ("Use SEMPRE que…"). As 3 do projeto que ficam sem descrição — `cfo-colacor`, `farmer-industrial`, `goal` — **já estavam sem ela no baseline** e têm uso zero em 48 dias. Perda real: nenhuma.

Como o piso é relido em 100% dos requests de todas as sessões do repo, isso rende para sempre e sem trade-off de qualidade.

## Escopo

Diff de **2 linhas** no `.claude/settings.json`. Os 13 hooks seguem intactos (conferido explicitamente — ver abaixo). Nada toca `src/`, `supabase/` ou runtime. Sem deploy do Lovable pendente.

## Validação

- `shellcheck scripts/*.sh .claude/hooks/*.sh` → exit 0
- `scripts/test-bash-contexto-nudge.sh` → exit 0 · `scripts/test-read-contexto-nudge.sh` → exit 0
- `jq -e` no `settings.json` → exit 0; contagem de hooks: **13 antes, 13 depois**
- Ganho medido antes/depois com a régua versionada, reprodutível

## ⚠️ Achado durante o preparo (vale registrar)

O `.claude/settings.json` **local** da worktree tinha as duas chaves já aplicadas à mão, mas sobre uma versão **defasada** do arquivo: sem o hook de Read (#1647) e sem o `PostToolUse` de Bash (#1652). Commitar aquele arquivo teria **apagado os dois hooks da main** — a mesma classe de reversão silenciosa que o CLAUDE.md documenta para o sync do Lovable. Este PR parte de `origin/main` e adiciona só as 2 linhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)