### PR TITLE
feat(financeiro): margem por canal + espelho de digitalização no Cockpit de Valor [money-path]

### DIFF
--- a/docs/historico/programa-cabreuva-colacor.md
+++ b/docs/historico/programa-cabreuva-colacor.md
@@ -1,0 +1,44 @@
+# Programa Cabreúva-Colacor (benchmark: CD da Renner)
+
+> Fonte: [Brazil Journal — "Cabreúva: o mega CD que vai colocar a Renner 'sete anos à frente da concorrência'"](https://braziljournal.com/cabreuva-o-mega-cd-que-vai-colocar-a-renner-sete-anos-a-frente-da-concorrencia/) (14/07/2026).
+> Processo: skill `benchmark-externo` (tabela de gaps com evidência → priorização Codex → fases-PR). Sessão 2026-08-03.
+
+## Leitura do benchmark
+
+CD de R$ 1,3 bi que mudou a operação da Renner: abastecimento por SKU conforme demanda do ponto de venda (fim do pack fixo), estoque único omnicanal ("quem compra primeiro"), e-commerce tão rentável quanto loja (economia POR CANAL medida), margem via menos remarcação/estoque enxuto, picking unitário numa esteira só, entrega consolidada multi-marca, plataforma que dá "day zero" a marca nova, ROIC como bússola (14,7%→20% até 2030).
+
+**Padrão do gap aqui:** a Renner dos DIAGNÓSTICOS nós já somos (motor de reposição por SKU, baixo-giro, venda-perdida, picking mobile, 3 empresas numa plataforma). O que falta é a Renner das AÇÕES e da PONTA: reservar (ATP), sugerir (reabastecimento por cliente), desovar (excesso→campanha), expedir (romaneio/consolidação), medir por canal.
+
+**Achado de dado que reordenou o programa (psql-ro 2026-08-03):** `sales_orders.origem` é ~100% NULL — 30.650 pedidos, **1** classificado; 12 meses com ZERO pedido real nascido no app (1 teste em jun/2026). Toda a venda entra pelo ERP (Omie). Logo "margem por canal" nasce como **espelho de digitalização da venda**, e a adoção do canal digital (pedido sugerido staff → cliente) é A alavanca, não um nice-to-have.
+
+## Tabela de gaps (evidência da varredura, 2026-08-03)
+
+| Prática Renner | Estado | Evidência |
+|---|---|---|
+| Estoque único com reserva/ATP | 🔴 gap | `submitOrder.ts` não checa nem reserva saldo |
+| Expedição/entrega consolidada | 🔴 gap | zero arquivos `expedic`; picking termina em `concluido` (`picking_bridge.sql`) |
+| Consolidação do grupo na ponta | 🔴 gap | nada cross-company; grupos financeiros existem (`useGrupoFinanceiro.ts`) |
+| Pedido sugerido por consumo | 🟡 parcial | `RecommendationsPanel` é contextual (pedido/Customer360); nada calcula reabastecimento |
+| Rentabilidade por canal | 🟡 parcial | `origem.ts:31` grava; financeiro não consumia (**PR1 fecha**) |
+| Excesso com AÇÃO de desova | 🟡 parcial | baixo-giro diagnostica; "Resolver" era stub `toast.info` (**PR2 fecha**) |
+| GMROI/capital em estoque exec. | 🟡 parcial | `capital_excedente_rs` no baixo-giro; Cockpit de Valor tem capital por SKU (**PR3**) |
+| Linha nova "day zero" | 🟡 parcial | cadeia-logistica + sla-fornecedor + grupos-producao (parametrização espalhada) |
+| Reposição por SKU (compra) | 🟢 tem | `admin/reposicao/sessao/*` |
+| Picking unitário esteira única | 🟢 tem | `admin/estoque/picking` + `TouchPickingView` + `picking_tasks` |
+| Plataforma multi-empresa | 🟢 tem | `CompanyContext` (colacor/oben/colacor_sc) |
+
+## Fases (prioridade Codex 2026-08-03: duas pistas)
+
+**Pista A — quick-wins:**
+- 🔄 **PR1 — Margem por canal + espelho de digitalização** no Cockpit de Valor (aba "Por canal"; edge `fin-valor-cockpit` devolve `porCanal`; helpers espelhados + vitest). 💬 redeploy da edge · 🖱️ Publish.
+- ⏳ **PR2 — Desova acionável:** "Resolver" do baixo-giro → criar campanha (reuso de Promoções/Negociação), rascunho + piso de preço + aprovação humana. money-path preço.
+- ⏳ **PR3 — Giro executivo no Cockpit:** capital em estoque + margem TTM + retorno-sobre-estoque rotulado proxy (CMC ausente = indisponível).
+
+**Pista B — épicos (ordem de dependência):**
+- ⏳ **ATP/reserva (P0, 3 fases):** pool por conta/depósito + reserva atômica → checkout idempotente → reconciliação Omie + órfãs. prove-sql + Codex por fase.
+- ⏳ **Pedido sugerido (3 fases, após ATP):** perfil cliente×SKU → sugestão explicável staff → opt-in do cliente. Sem autoenvio.
+- ⏳ **GMROI completo (2 fases):** estoque médio histórico + metas por classe com link pra desova.
+- ⏳ **Expedição (3 fases):** remessa/romaneio → ondas por cliente/rota → rastreio/POD.
+- ⏳ **Consolidação do grupo (3 fases, por último):** identidade canônica → plano único de entrega (docs fiscais separados por CNPJ) → SLA único. Crítico fiscal (aliases, CLAUDE.md §5).
+
+Riscos money-path por item e fases detalhadas: parecer Codex na sessão de origem. Status vive no PR de cada fase.

--- a/src/lib/financeiro/__tests__/valor-cockpit-canal.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-canal.test.ts
@@ -1,0 +1,97 @@
+// Canal do pedido no Cockpit de Valor (programa Cabreúva-Colacor, PR1).
+// Contexto de dado (psql-ro 2026-08-03): origem é ~100% NULL em prod (30.650 pedidos, 1 web_staff);
+// TODA a venda entra pelo ERP → o rollup por canal nasce como ESPELHO DE DIGITALIZAÇÃO
+// (quanto da venda passa pelo app) e vira comparação de margem quando houver volume digital.
+import { describe, it, expect } from 'vitest';
+import { classificarCanalPedido, agregarPorCanal, type CanalPedido } from '../valor-cockpit-helpers';
+
+describe('classificarCanalPedido', () => {
+  it('origem explícita manda: web_customer → app_cliente, web_staff → app_staff', () => {
+    expect(classificarCanalPedido({ origem: 'web_customer', checkout_id: null })).toBe('app_cliente');
+    expect(classificarCanalPedido({ origem: 'web_staff', checkout_id: 'c1' })).toBe('app_staff');
+  });
+
+  it('ligações (sainte e entrante) caem no canal ligacao', () => {
+    expect(classificarCanalPedido({ origem: 'ligacao_sainte', checkout_id: 'c1' })).toBe('ligacao');
+    expect(classificarCanalPedido({ origem: 'ligacao_entrante', checkout_id: 'c1' })).toBe('ligacao');
+  });
+
+  it('sem origem: checkout presente → app_sem_origem (nasceu no app antes do rastreio); sem nada → erp_direto', () => {
+    expect(classificarCanalPedido({ origem: null, checkout_id: 'chk-1' })).toBe('app_sem_origem');
+    expect(classificarCanalPedido({ origem: null, checkout_id: null })).toBe('erp_direto');
+  });
+
+  it('origem desconhecida NÃO é fabricada em bucket conhecido → outro', () => {
+    expect(classificarCanalPedido({ origem: 'whatsapp_bot', checkout_id: null })).toBe('outro');
+  });
+
+  it('string vazia/espaços = ausência de origem (normaliza antes de classificar)', () => {
+    expect(classificarCanalPedido({ origem: '', checkout_id: null })).toBe('erp_direto');
+    expect(classificarCanalPedido({ origem: '  ', checkout_id: 'c1' })).toBe('app_sem_origem');
+  });
+});
+
+describe('agregarPorCanal', () => {
+  const canalDe = (pares: Record<string, CanalPedido>) => new Map(Object.entries(pares));
+
+  it('agrega receita/qtd/desconto por canal e conta pedidos e clientes DISTINTOS', () => {
+    const rollups = agregarPorCanal(
+      [
+        { sales_order_id: 'p1', cliente: 'A', receita_liquida: 100, quantidade: 2, desconto: 5, custo_unitario: 10 },
+        { sales_order_id: 'p1', cliente: 'A', receita_liquida: 50, quantidade: 1, desconto: 0, custo_unitario: 20 },
+        { sales_order_id: 'p2', cliente: 'B', receita_liquida: 300, quantidade: 3, desconto: 10, custo_unitario: 50 },
+      ],
+      canalDe({ p1: 'app_staff', p2: 'erp_direto' }),
+    );
+    const app = rollups.find((r) => r.canal === 'app_staff')!;
+    expect(app).toMatchObject({ pedidos: 1, clientes: 1, receita: 150, quantidade: 3, desconto: 5 });
+    // cm item a item: (100 − 10·2) + (50 − 20·1) = 80 + 30 = 110
+    expect(app.cm).toBe(110);
+    expect(app.cm_incompleto).toBe(false);
+    expect(app.receita_sem_cm).toBe(0);
+    const erp = rollups.find((r) => r.canal === 'erp_direto')!;
+    expect(erp).toMatchObject({ pedidos: 1, clientes: 1, receita: 300, cm: 150 });
+  });
+
+  it('custo ausente NÃO fabrica margem: item sem custo sai do cm, marca cm_incompleto e soma receita_sem_cm', () => {
+    const [r] = agregarPorCanal(
+      [
+        { sales_order_id: 'p1', cliente: 'A', receita_liquida: 100, quantidade: 1, desconto: 0, custo_unitario: 40 },
+        { sales_order_id: 'p1', cliente: 'A', receita_liquida: 70, quantidade: 1, desconto: 0, custo_unitario: null },
+      ],
+      canalDe({ p1: 'erp_direto' }),
+    );
+    expect(r.cm).toBe(60); // só o item com custo (100−40); o de 70 NÃO vira margem 70
+    expect(r.cm_incompleto).toBe(true);
+    expect(r.receita_sem_cm).toBe(70);
+  });
+
+  it('canal onde NENHUM item tem custo → cm null (ausente ≠ zero)', () => {
+    const [r] = agregarPorCanal(
+      [{ sales_order_id: 'p1', cliente: 'A', receita_liquida: 100, quantidade: 1, desconto: 0, custo_unitario: null }],
+      canalDe({ p1: 'ligacao' }),
+    );
+    expect(r.cm).toBeNull();
+    expect(r.receita_sem_cm).toBe(100);
+  });
+
+  it('pedido fora do mapa de canais cai em outro (defensivo — não fabrica erp_direto)', () => {
+    const [r] = agregarPorCanal(
+      [{ sales_order_id: 'orfao', cliente: 'A', receita_liquida: 10, quantidade: 1, desconto: 0, custo_unitario: 1 }],
+      canalDe({}),
+    );
+    expect(r.canal).toBe('outro');
+  });
+
+  it('ordena por receita desc e não inventa canal sem item', () => {
+    const rollups = agregarPorCanal(
+      [
+        { sales_order_id: 'p1', cliente: 'A', receita_liquida: 10, quantidade: 1, desconto: 0, custo_unitario: 1 },
+        { sales_order_id: 'p2', cliente: 'B', receita_liquida: 999, quantidade: 1, desconto: 0, custo_unitario: 1 },
+      ],
+      canalDe({ p1: 'app_cliente', p2: 'erp_direto' }),
+    );
+    expect(rollups.map((r) => r.canal)).toEqual(['erp_direto', 'app_cliente']);
+    expect(rollups).toHaveLength(2);
+  });
+});

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -476,3 +476,47 @@ export function scoreConfiancaCockpit(input: {
 
   return { nivel: nivel === 3 ? 'alta' : nivel === 2 ? 'media' : 'baixa', motivos };
 }
+
+// ===== Canal do pedido (programa Cabreúva-Colacor, PR1) =====
+// sales_orders.origem só é gravada por pedido nascido no app (submitOrder, sem CHECK no banco);
+// prod 2026-08-03 (psql-ro): 30.650 pedidos, origem ~100% NULL → o rollup por canal nasce como
+// ESPELHO DE DIGITALIZAÇÃO da venda (quanto nasce no app vs ERP) e vira comparação de margem
+// entre canais quando o canal digital tiver volume. checkout_id presente sem origem = pedido do
+// app anterior ao rastreio (app_sem_origem, não fabricado em app_staff/app_cliente).
+export type CanalPedido = 'erp_direto' | 'app_cliente' | 'app_staff' | 'ligacao' | 'app_sem_origem' | 'outro';
+
+export function classificarCanalPedido(p: { origem: string | null; checkout_id: string | null }): CanalPedido {
+  const origem = p.origem?.trim() || null;
+  if (origem == null) return p.checkout_id != null ? 'app_sem_origem' : 'erp_direto';
+  if (origem === 'web_customer') return 'app_cliente';
+  if (origem === 'web_staff') return 'app_staff';
+  if (origem === 'ligacao_sainte' || origem === 'ligacao_entrante') return 'ligacao';
+  return 'outro'; // valor desconhecido NÃO cai em bucket conhecido (origem não tem CHECK no banco)
+}
+
+export type ItemCanalInput = { sales_order_id: string; cliente: string; receita_liquida: number; quantidade: number; desconto: number; custo_unitario: number | null };
+export type RollupCanal = { canal: CanalPedido; pedidos: number; clientes: number; receita: number; quantidade: number; desconto: number; cm: number | null; cm_incompleto: boolean; receita_sem_cm: number };
+
+export function agregarPorCanal(itens: ItemCanalInput[], canalPorPedido: Map<string, CanalPedido>): RollupCanal[] {
+  type Acc = { canal: CanalPedido; pedidos: Set<string>; clientes: Set<string>; receita: number; quantidade: number; desconto: number; cm: number; cmNull: boolean; cm_incompleto: boolean; receita_sem_cm: number };
+  const m = new Map<CanalPedido, Acc>();
+  for (const it of itens) {
+    // Pedido fora do mapa → 'outro' (defensivo): não fabricar 'erp_direto' para dado inconsistente.
+    const canal = canalPorPedido.get(it.sales_order_id) ?? 'outro';
+    const acc = m.get(canal) ?? { canal, pedidos: new Set<string>(), clientes: new Set<string>(), receita: 0, quantidade: 0, desconto: 0, cm: 0, cmNull: true, cm_incompleto: false, receita_sem_cm: 0 };
+    acc.pedidos.add(it.sales_order_id);
+    acc.clientes.add(it.cliente);
+    acc.receita += it.receita_liquida;
+    acc.quantidade += it.quantidade;
+    acc.desconto += it.desconto;
+    // Margem item a item pela MESMA régua dos combos (custo ausente ≠ zero → item sai do cm e
+    // engorda receita_sem_cm; canal 100% sem custo → cm null, nunca 0 fabricado).
+    const cm = margemContribuicao({ receita_liquida: it.receita_liquida, custo_unitario: it.custo_unitario, quantidade: it.quantidade });
+    if (cm == null) { acc.cm_incompleto = true; acc.receita_sem_cm += it.receita_liquida; }
+    else { acc.cm += cm; acc.cmNull = false; }
+    m.set(canal, acc);
+  }
+  return [...m.values()]
+    .map((a) => ({ canal: a.canal, pedidos: a.pedidos.size, clientes: a.clientes.size, receita: a.receita, quantidade: a.quantidade, desconto: a.desconto, cm: a.cmNull ? null : a.cm, cm_incompleto: a.cm_incompleto, receita_sem_cm: a.receita_sem_cm }))
+    .sort((a, b) => b.receita - a.receita);
+}

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -6,7 +6,7 @@ import { useValorCockpit } from '@/hooks/useValorCockpit';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
-import type { CockpitRollupCliente, CockpitRollupSKU } from '@/services/financeiroService';
+import type { CockpitRollupCliente, CockpitRollupSKU, CockpitRollupCanal, CanalPedido } from '@/services/financeiroService';
 
 const brl = (x: number | null | undefined) =>
   x == null
@@ -19,9 +19,103 @@ function nivelClasses(n: 'alta' | 'media' | 'baixa') {
   return 'text-status-error bg-status-error-bg';
 }
 
+// ===== Por canal (PR1 Cabreúva-Colacor): espelho de digitalização + margem por canal =====
+const CANAL_LABEL: Record<CanalPedido, string> = {
+  erp_direto: 'ERP direto (Omie)',
+  app_cliente: 'App — cliente (self-service)',
+  app_staff: 'App — vendedor',
+  ligacao: 'Ligação (tele)',
+  app_sem_origem: 'App — sem origem registrada',
+  outro: 'Outro / não classificado',
+};
+// Digital = passou pelo app (qualquer forma). 'outro' fica FORA dos dois lados (não fabricar leitura).
+const CANAIS_DIGITAIS: ReadonlySet<CanalPedido> = new Set(['app_cliente', 'app_staff', 'ligacao', 'app_sem_origem']);
+
+function CanalSection({ porCanal }: { porCanal: CockpitRollupCanal[] | undefined }) {
+  if (!porCanal) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-sm text-muted-foreground">
+          Dados de canal indisponíveis — a edge fin-valor-cockpit em produção ainda não devolve o rollup por canal (redeploy pendente).
+        </CardContent>
+      </Card>
+    );
+  }
+  const receitaTotal = porCanal.reduce((s, c) => s + c.receita, 0);
+  const receitaDigital = porCanal.filter((c) => CANAIS_DIGITAIS.has(c.canal)).reduce((s, c) => s + c.receita, 0);
+  const pedidosTotal = porCanal.reduce((s, c) => s + c.pedidos, 0);
+  const pedidosDigital = porCanal.filter((c) => CANAIS_DIGITAIS.has(c.canal)).reduce((s, c) => s + c.pedidos, 0);
+  const pctDigital = receitaTotal > 0 ? receitaDigital / receitaTotal : 0;
+  const pct = (x: number) => `${(x * 100).toFixed(x > 0 && x < 0.01 ? 2 : 1)}%`;
+  return (
+    <div className="space-y-3">
+      {pctDigital < 0.01 && (
+        <Card>
+          <CardContent className="py-3 text-sm text-status-warning">
+            O canal digital ainda não tem volume — {pct(1 - pctDigital)} da receita TTM entra direto no ERP
+            ({pedidosDigital} de {pedidosTotal} pedidos nasceram no app). A comparação de margem entre canais
+            fica armada e ativa sozinha quando houver venda pelo app.
+          </CardContent>
+        </Card>
+      )}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Digitalização da venda: {pct(pctDigital)} da receita nasce no app · {pct(receitaTotal > 0 ? 1 - pctDigital : 0)} direto no ERP
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="text-sm overflow-x-auto">
+          <table className="w-full min-w-[600px]">
+            <thead>
+              <tr className="text-muted-foreground text-xs">
+                <th className="text-left py-1">Canal</th>
+                <th className="text-right">Pedidos</th>
+                <th className="text-right">Clientes</th>
+                <th className="text-right">Receita</th>
+                <th className="text-right">Margem contrib.</th>
+                <th className="text-right">Margem %</th>
+                <th className="text-right">Ticket médio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {porCanal.map((c) => {
+                // Margem % só sobre a fatia COM custo (senão itens sem custo diluiriam o percentual).
+                const receitaComCm = c.receita - c.receita_sem_cm;
+                const cmPct = c.cm != null && receitaComCm > 0 ? c.cm / receitaComCm : null;
+                return (
+                  <tr key={c.canal} className="border-t border-border">
+                    <td className="py-1">{CANAL_LABEL[c.canal]}</td>
+                    <td className="text-right font-tabular">{c.pedidos.toLocaleString('pt-BR')}</td>
+                    <td className="text-right font-tabular">{c.clientes.toLocaleString('pt-BR')}</td>
+                    <td className="text-right font-tabular">{brl(c.receita)}</td>
+                    <td className="text-right font-tabular">
+                      {brl(c.cm)}
+                      {c.cm_incompleto && (
+                        <div className="text-[10px] leading-tight text-muted-foreground">
+                          parcial · {brl(c.receita_sem_cm)} sem custo
+                        </div>
+                      )}
+                    </td>
+                    <td className="text-right font-tabular">{cmPct == null ? '—' : `${(cmPct * 100).toFixed(1)}%`}</td>
+                    <td className="text-right font-tabular">{c.pedidos > 0 ? brl(c.receita / c.pedidos) : '—'}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+          <p className="text-xs text-muted-foreground mt-3">
+            Margem de contribuição (receita − custo), não lucro: sem imposto, frete e encargo de capital.
+            Margem % calculada só sobre a fatia com custo cadastrado. Base: itens Oben faturáveis no TTM.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 export default function FinanceiroValorCockpit() {
   const { isMaster, isGestorComercial } = useAuth();
-  const [aba, setAba] = useState<'cliente' | 'sku'>('cliente');
+  const [aba, setAba] = useState<'cliente' | 'sku' | 'canal'>('cliente');
   const podeVer = isMaster || isGestorComercial;
   const { data, isLoading, error } = useValorCockpit(podeVer);
 
@@ -146,8 +240,18 @@ export default function FinanceiroValorCockpit() {
         >
           Por SKU
         </Button>
+        <Button
+          variant={aba === 'canal' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setAba('canal')}
+        >
+          Por canal
+        </Button>
       </div>
 
+      {aba === 'canal' ? (
+        <CanalSection porCanal={data.porCanal} />
+      ) : (
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Piores destruidores de valor primeiro</CardTitle>
@@ -239,6 +343,7 @@ export default function FinanceiroValorCockpit() {
           )}
         </CardContent>
       </Card>
+      )}
 
       <p className="text-xs text-muted-foreground">
         Direcional: custo é médio atual (sem BOM), imposto estimado nível-empresa, estoque é snapshot run-rate. Escopo: Oben.

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1064,6 +1064,21 @@ export interface CockpitEmpresaEVP {
   min_folga_positiva_receita: number | null; // receita do combo DONO do min — LOCATOR, não severidade: a UI suprime o headline quando imaterial (< sample_min_receita)
   capital_conhecido: number | null; // Σ capital das células reais → deriva EVP a outros hurdles
 }
+// Canal do pedido (PR1 Cabreúva-Colacor): espelho de digitalização da venda + margem por canal.
+// origem ~100% NULL em prod (2026-08-03) → hoje a leitura dominante é erp_direto; a comparação de
+// margem entre canais fica ARMADA para quando o canal digital tiver volume.
+export type CanalPedido = 'erp_direto' | 'app_cliente' | 'app_staff' | 'ligacao' | 'app_sem_origem' | 'outro';
+export interface CockpitRollupCanal {
+  canal: CanalPedido;
+  pedidos: number;          // pedidos DISTINTOS com item Oben na janela
+  clientes: number;         // clientes distintos
+  receita: number;
+  quantidade: number;
+  desconto: number;
+  cm: number | null;        // margem de contribuição (NÃO lucro): null se nenhum item com custo
+  cm_incompleto: boolean;   // há itens sem custo → cm subestima a margem do canal
+  receita_sem_cm: number;   // receita dos itens sem custo (transparência da fatia sem margem)
+}
 export interface ValorCockpitResult {
   company: string;
   k: number | null;                 // hurdle (Ke); null quando ausente/inválido (não fabricado)
@@ -1073,6 +1088,7 @@ export interface ValorCockpitResult {
   motivo?: string;
   porCliente: CockpitRollupCliente[];
   porSKU: CockpitRollupSKU[];
+  porCanal?: CockpitRollupCanal[]; // opcional: edge antiga (pré-deploy) não devolve — UI degrada honesta
   empresa: CockpitEmpresaEVP;
   recomendacoesCliente: Array<{ cliente: string; recomendacoes: CockpitRecomendacao[] }>;
   confianca: { nivel: 'alta' | 'media' | 'baixa'; motivos: string[] };

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -307,6 +307,43 @@ function scoreConfiancaCockpit(input: { cobertura_receita: number; custo_ausente
   return { nivel: (nivel === 3 ? "alta" : nivel === 2 ? "media" : "baixa") as "alta" | "media" | "baixa", motivos };
 }
 
+// ===== Canal do pedido, espelhado VERBATIM de valor-cockpit-helpers.ts (PR1 Cabreúva-Colacor) =====
+// origem ~100% NULL em prod (2026-08-03) → o rollup por canal nasce como espelho de digitalização.
+type CanalPedido = 'erp_direto' | 'app_cliente' | 'app_staff' | 'ligacao' | 'app_sem_origem' | 'outro';
+function classificarCanalPedido(p: { origem: string | null; checkout_id: string | null }): CanalPedido {
+  const origem = p.origem?.trim() || null;
+  if (origem == null) return p.checkout_id != null ? 'app_sem_origem' : 'erp_direto';
+  if (origem === 'web_customer') return 'app_cliente';
+  if (origem === 'web_staff') return 'app_staff';
+  if (origem === 'ligacao_sainte' || origem === 'ligacao_entrante') return 'ligacao';
+  return 'outro'; // valor desconhecido NÃO cai em bucket conhecido (origem não tem CHECK no banco)
+}
+type ItemCanalInput = { sales_order_id: string; cliente: string; receita_liquida: number; quantidade: number; desconto: number; custo_unitario: number | null };
+type RollupCanal = { canal: CanalPedido; pedidos: number; clientes: number; receita: number; quantidade: number; desconto: number; cm: number | null; cm_incompleto: boolean; receita_sem_cm: number };
+function agregarPorCanal(itens: ItemCanalInput[], canalPorPedido: Map<string, CanalPedido>): RollupCanal[] {
+  type Acc = { canal: CanalPedido; pedidos: Set<string>; clientes: Set<string>; receita: number; quantidade: number; desconto: number; cm: number; cmNull: boolean; cm_incompleto: boolean; receita_sem_cm: number };
+  const m = new Map<CanalPedido, Acc>();
+  for (const it of itens) {
+    // Pedido fora do mapa → 'outro' (defensivo): não fabricar 'erp_direto' para dado inconsistente.
+    const canal = canalPorPedido.get(it.sales_order_id) ?? 'outro';
+    const acc = m.get(canal) ?? { canal, pedidos: new Set<string>(), clientes: new Set<string>(), receita: 0, quantidade: 0, desconto: 0, cm: 0, cmNull: true, cm_incompleto: false, receita_sem_cm: 0 };
+    acc.pedidos.add(it.sales_order_id);
+    acc.clientes.add(it.cliente);
+    acc.receita += it.receita_liquida;
+    acc.quantidade += it.quantidade;
+    acc.desconto += it.desconto;
+    // Margem item a item pela MESMA régua dos combos (custo ausente ≠ zero → item sai do cm e
+    // engorda receita_sem_cm; canal 100% sem custo → cm null, nunca 0 fabricado).
+    const cm = margemContribuicao({ receita_liquida: it.receita_liquida, custo_unitario: it.custo_unitario, quantidade: it.quantidade });
+    if (cm == null) { acc.cm_incompleto = true; acc.receita_sem_cm += it.receita_liquida; }
+    else { acc.cm += cm; acc.cmNull = false; }
+    m.set(canal, acc);
+  }
+  return [...m.values()]
+    .map((a) => ({ canal: a.canal, pedidos: a.pedidos.size, clientes: a.clientes.size, receita: a.receita, quantidade: a.quantidade, desconto: a.desconto, cm: a.cmNull ? null : a.cm, cm_incompleto: a.cm_incompleto, receita_sem_cm: a.receita_sem_cm }))
+    .sort((a, b) => b.receita - a.receita);
+}
+
 // ===== Custo: régua do cockpit, espelhada VERBATIM de src/lib/custos/cost-source.ts (Deno não importa de src/) =====
 // Régua do COCKPIT (computa-e-degrada #1003): exibe a margem mesmo de proxy e marca baixaConfianca p/ rebaixar a
 // confiança — DISTINTA de resolverCustoConfiavel (recommend/audit, que NULIFICA proxy). Mudou? Mude lá e rode
@@ -397,8 +434,8 @@ serve(async (req: Request) => {
     // barato. pedidosNaJanela = faturável (exclui cancelado/rascunho/soft-deletado, régua v_caca) E
     // order_date_kpi ∈ [ttm_inicio, ttm_fim] (Bug C: janela pela DATA DO PEDIDO, não pela carga). SEM filtro
     // de account na faturabilidade (vale p/ qualquer conta); o recorte Oben vem por product_id/SKU abaixo.
-    type SalesOrderRow = { id: string; status: string | null; deleted_at: string | null; order_date_kpi: string | null; account: string | null };
-    const salesOrdersAll = await fetchAll<SalesOrderRow>((f, t) => db.from("sales_orders").select("id, status, deleted_at, order_date_kpi, account").order("id", { ascending: true }).range(f, t), "sales_orders");
+    type SalesOrderRow = { id: string; status: string | null; deleted_at: string | null; order_date_kpi: string | null; account: string | null; origem: string | null; checkout_id: string | null };
+    const salesOrdersAll = await fetchAll<SalesOrderRow>((f, t) => db.from("sales_orders").select("id, status, deleted_at, order_date_kpi, account, origem, checkout_id").order("id", { ascending: true }).range(f, t), "sales_orders");
     // order_date_kpi é DATE → comparação de string 'YYYY-MM-DD' é cronológica (mesmo padrão de
     // carteira-positivacao-snapshot). Reúsa a régua UTC que o cockpit já aplica ao AR (ttm_inicio/ttm_fim).
     const pedidosNaJanela = new Set(
@@ -499,6 +536,19 @@ serve(async (req: Request) => {
     const comboVals = [...comboMap.values()];
     const combos: ComboInput[] = comboVals.map((c) => ({ cliente: c.cliente, sku: c.sku, receita_liquida: c.receita, quantidade: c.qtd, custo_unitario: c.product_id ? (custoPorProduto.get(c.product_id) ?? null) : null }));
 
+    // Canal do pedido (PR1 Cabreúva-Colacor): MESMA base de linhas do cockpit (janela por
+    // order_date_kpi + faturável + recorte Oben) agregada pelo canal de origem do pedido pai.
+    const canalPorPedido = new Map<string, CanalPedido>(salesOrdersAll.map((so) => [so.id, classificarCanalPedido({ origem: so.origem ?? null, checkout_id: so.checkout_id ?? null })]));
+    const itensCanal: ItemCanalInput[] = linhas.map((l) => ({
+      sales_order_id: l.sales_order_id,
+      cliente: userToOmie.get(l.customer_user_id) ?? `app:${l.customer_user_id}`,
+      receita_liquida: l.unit_price * l.quantity - (l.discount ?? 0),
+      quantidade: l.quantity,
+      desconto: l.discount ?? 0,
+      custo_unitario: l.product_id ? (custoPorProduto.get(l.product_id) ?? null) : null,
+    }));
+    const porCanal = agregarPorCanal(itensCanal, canalPorPedido);
+
     // AR da Oben relevante à janela (emitido na janela OU ainda em aberto) — serve p/ AR por cliente e cobertura.
     type CR = { omie_codigo_cliente: number | null; omie_codigo_lancamento: number | null; valor_documento: number; saldo: number; valor_recebido: number; data_emissao: string | null; data_vencimento: string | null; status_titulo: string };
     const crsAll = await fetchAll<CR>((f, t) => db.from("fin_contas_receber").select("omie_codigo_cliente, omie_codigo_lancamento, valor_documento, saldo, valor_recebido, data_emissao, data_vencimento, status_titulo").eq("company", COMPANY).or(`data_recebimento.is.null,data_recebimento.gte.${ttm_inicio},data_emissao.gte.${ttm_inicio}`).order("id", { ascending: true }).range(f, t), "fin_contas_receber");
@@ -583,7 +633,7 @@ serve(async (req: Request) => {
     const porClienteComNome = res.porCliente.map((c) => ({ ...c, nome: clienteParaNome.get(c.cliente) ?? null }));
     return jsonResponse({
       company: COMPANY, k, hurdle_indisponivel, ttm: { inicio: ttm_inicio, fim: ttm_fim },
-      porCliente: porClienteComNome, porSKU: porSKUcomDescricao, empresa: res.empresa,
+      porCliente: porClienteComNome, porSKU: porSKUcomDescricao, porCanal, empresa: res.empresa,
       recomendacoesCliente, confianca, cobertura_receita, cobertura_app_por_ar: app_por_ar,
       cobertura_baixa_ar: coberturaBaixaAR, // Fase 3: fração da AR liquidada com baixa derivada REAL (vs vencimento-proxy)
       // transparência por receita (omissão honesta do EVP otimista — sucede evp_teto_receita_pct):


### PR DESCRIPTION
## Programa Cabreúva-Colacor — PR1 (Pista A)

**Origem:** benchmark externo [CD Cabreúva da Renner (Brazil Journal, 14/07)](https://braziljournal.com/cabreuva-o-mega-cd-que-vai-colocar-a-renner-sete-anos-a-frente-da-concorrencia/), processado pela skill `benchmark-externo` + priorização Codex. Programa completo: `docs/historico/programa-cabreuva-colacor.md` (neste PR).

**O que a Renner faz:** mede a economia POR CANAL — e-commerce ficou tão rentável quanto loja. **O que o nosso dado gritou (psql-ro 2026-08-03):** `sales_orders.origem` é ~100% NULL — 30.650 pedidos, 1 classificado, 12 meses com ZERO pedido real nascido no app. Toda a venda entra pelo ERP. Então a aba nova nasce como **espelho de digitalização da venda** (ERP direto × app-vendedor × app-cliente × ligação) e a comparação de margem entre canais fica armada pra quando houver volume digital.

### Mudanças
- `valor-cockpit-helpers.ts`: `classificarCanalPedido` + `agregarPorCanal` (puros; **10 asserts** em `valor-cockpit-canal.test.ts`), espelhados VERBATIM na edge (padrão do arquivo).
- Edge `fin-valor-cockpit`: select ganha `origem, checkout_id`; payload ganha `porCanal` (mesma base: janela por `order_date_kpi` + faturável + recorte Oben).
- Cockpit de Valor: aba **Por canal** — headline de digitalização, margem de contribuição (nunca rotulada lucro), margem % só sobre a fatia COM custo, banner honesto quando canal digital < 1%.

### Fail-closed (money-path)
- Custo ausente ≠ zero → item sai do cm e engorda `receita_sem_cm`; canal 100% sem custo → `cm: null`.
- `origem` desconhecida → bucket `outro` (coluna sem CHECK; nada é fabricado em bucket conhecido).
- Edge antiga sem `porCanal` → UI degrada com aviso explícito (campo opcional).

### Evidência
- Suíte vitest completa: **647 files / 5.924 passed, exit 0**
- tsc (projeto app) exit 0 · `deno check` da edge exit 0 · ESLint exit 0 (nada nos arquivos tocados)

### Deploy manual do founder (Lovable)
- 💬 **Redeploy da edge `fin-valor-cockpit`** pelo chat (ler do repo, verbatim) — sem ele a aba mostra o aviso de edge desatualizada.
- 🖱️ **Publish** do frontend.
- 🟣 Migration: **não há**.

Nota multi-sessão: #1212 (faxina knip) toca o meio de `valor-cockpit-helpers.ts`; este PR adiciona no fim — merge 3-vias limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
