### PR TITLE
feat(financeiro): giro executivo no Cockpit — capital em estoque, dinheiro morto e retorno proxy [money-path]

### DIFF
--- a/src/lib/financeiro/__tests__/valor-cockpit-giro.test.ts
+++ b/src/lib/financeiro/__tests__/valor-cockpit-giro.test.ts
@@ -1,0 +1,55 @@
+// Giro executivo (programa Cabreúva-Colacor, PR3): capital em estoque nível-empresa
+// + dinheiro morto (capital sem venda no TTM) + retorno-sobre-estoque PROXY (rotulado).
+// Régua money-path: capital não medido (cmc ausente) fica FORA do total e vira cobertura
+// explícita — nunca 0 fabricado; retorno sem denominador/numerador → null, nunca Infinity.
+import { describe, it, expect } from 'vitest';
+import { calcularGiroExecutivo } from '../valor-cockpit-helpers';
+
+describe('calcularGiroExecutivo', () => {
+  it('soma capital medido, separa dinheiro morto (SKU sem venda TTM) e calcula retorno proxy', () => {
+    const g = calcularGiroExecutivo({
+      estoquePorSKU: new Map([
+        ['A', 1000],  // vendeu no TTM
+        ['B', 500],   // NÃO vendeu → dinheiro morto
+        ['C', null],  // cmc ausente → não medido
+      ]),
+      skusComVendaTTM: new Set(['A', 'X']),
+      cmTTM: 300,
+    });
+    expect(g.capital_medido).toBe(1500);
+    expect(g.capital_sem_venda_ttm).toBe(500);
+    expect(g.skus_medidos).toBe(2);
+    expect(g.skus_sem_valor).toBe(1);
+    expect(g.retorno_proxy).toBeCloseTo(300 / 1500, 10);
+  });
+
+  it('cm null → retorno null (não fabrica); capital segue reportado', () => {
+    const g = calcularGiroExecutivo({
+      estoquePorSKU: new Map([['A', 1000]]),
+      skusComVendaTTM: new Set(['A']),
+      cmTTM: null,
+    });
+    expect(g.retorno_proxy).toBeNull();
+    expect(g.capital_medido).toBe(1000);
+  });
+
+  it('capital 0 ou nada medido → retorno null, nunca Infinity/NaN', () => {
+    const zero = calcularGiroExecutivo({ estoquePorSKU: new Map([['A', 0]]), skusComVendaTTM: new Set(), cmTTM: 100 });
+    expect(zero.retorno_proxy).toBeNull();
+    const vazio = calcularGiroExecutivo({ estoquePorSKU: new Map([['A', null]]), skusComVendaTTM: new Set(), cmTTM: 100 });
+    expect(vazio.capital_medido).toBe(0);
+    expect(vazio.skus_medidos).toBe(0);
+    expect(vazio.retorno_proxy).toBeNull();
+  });
+
+  it('capital negativo/NaN não entra no total (dado sujo não vira número)', () => {
+    const g = calcularGiroExecutivo({
+      estoquePorSKU: new Map([['A', 100], ['B', -50], ['C', Number.NaN]]),
+      skusComVendaTTM: new Set(['A', 'B', 'C']),
+      cmTTM: 10,
+    });
+    expect(g.capital_medido).toBe(100);
+    expect(g.skus_medidos).toBe(1);
+    expect(g.skus_sem_valor).toBe(2);
+  });
+});

--- a/src/lib/financeiro/valor-cockpit-helpers.ts
+++ b/src/lib/financeiro/valor-cockpit-helpers.ts
@@ -494,6 +494,36 @@ export function classificarCanalPedido(p: { origem: string | null; checkout_id: 
   return 'outro'; // valor desconhecido NÃO cai em bucket conhecido (origem não tem CHECK no banco)
 }
 
+// ===== Giro executivo (programa Cabreúva-Colacor, PR3) =====
+// Capital em estoque nível-empresa + dinheiro morto (capital de SKU sem venda no TTM) +
+// retorno-sobre-estoque PROXY (cm TTM ÷ snapshot de capital — NÃO é GMROI definitivo: falta
+// estoque MÉDIO histórico; a UI rotula proxy). cmc ausente/sujo fica FORA (cobertura explícita).
+export type GiroExecutivo = {
+  capital_medido: number;          // Σ capital dos SKUs com valor válido (≥0 finito)
+  capital_sem_venda_ttm: number;   // fatia do medido em SKUs SEM venda no TTM (dinheiro morto)
+  skus_medidos: number;
+  skus_sem_valor: number;          // cmc/saldo ausente ou sujo → não medido (nunca 0 fabricado)
+  retorno_proxy: number | null;    // cmTTM/capital_medido; null se cm null ou capital ≤ 0
+};
+
+export function calcularGiroExecutivo(input: {
+  estoquePorSKU: Map<string, number | null>;
+  skusComVendaTTM: Set<string>;
+  cmTTM: number | null;
+}): GiroExecutivo {
+  let capital = 0, morto = 0, medidos = 0, semValor = 0;
+  for (const [sku, valor] of input.estoquePorSKU) {
+    if (valor == null || !Number.isFinite(valor) || valor < 0) { semValor++; continue; }
+    medidos++;
+    capital += valor;
+    if (!input.skusComVendaTTM.has(sku)) morto += valor;
+  }
+  const retorno = input.cmTTM != null && Number.isFinite(input.cmTTM) && capital > 0
+    ? input.cmTTM / capital
+    : null;
+  return { capital_medido: capital, capital_sem_venda_ttm: morto, skus_medidos: medidos, skus_sem_valor: semValor, retorno_proxy: retorno };
+}
+
 export type ItemCanalInput = { sales_order_id: string; cliente: string; receita_liquida: number; quantidade: number; desconto: number; custo_unitario: number | null };
 export type RollupCanal = { canal: CanalPedido; pedidos: number; clientes: number; receita: number; quantidade: number; desconto: number; cm: number | null; cm_incompleto: boolean; receita_sem_cm: number };
 

--- a/src/pages/FinanceiroValorCockpit.tsx
+++ b/src/pages/FinanceiroValorCockpit.tsx
@@ -226,6 +226,26 @@ export default function FinanceiroValorCockpit() {
         </p>
       )}
 
+      {data.giroExecutivo && data.giroExecutivo.skus_medidos > 0 && (
+        <Card>
+          <CardContent className="py-3 text-sm flex flex-wrap gap-x-6 gap-y-1 items-baseline">
+            <span>
+              Capital em estoque (medido): <span className="font-tabular font-medium">{brl(data.giroExecutivo.capital_medido)}</span>
+            </span>
+            <span>
+              Dinheiro morto (sem venda no TTM): <span className={`font-tabular font-medium ${data.giroExecutivo.capital_sem_venda_ttm > 0 ? 'text-status-warning' : ''}`}>{brl(data.giroExecutivo.capital_sem_venda_ttm)}</span>
+            </span>
+            <span>
+              Retorno s/ estoque (proxy): <span className="font-tabular font-medium">{data.giroExecutivo.retorno_proxy != null ? `${(data.giroExecutivo.retorno_proxy * 100).toFixed(0)}%` : '—'}</span>
+            </span>
+            <span className="text-xs text-muted-foreground">
+              margem TTM ÷ snapshot de capital — proxy, não GMROI (sem estoque médio histórico)
+              {data.giroExecutivo.skus_sem_valor > 0 && ` · ${data.giroExecutivo.skus_sem_valor} SKU(s) sem valor confiável fora do total`}
+            </span>
+          </CardContent>
+        </Card>
+      )}
+
       <div className="flex gap-2">
         <Button
           variant={aba === 'cliente' ? 'default' : 'outline'}

--- a/src/services/financeiroService.ts
+++ b/src/services/financeiroService.ts
@@ -1079,6 +1079,15 @@ export interface CockpitRollupCanal {
   cm_incompleto: boolean;   // há itens sem custo → cm subestima a margem do canal
   receita_sem_cm: number;   // receita dos itens sem custo (transparência da fatia sem margem)
 }
+// Giro executivo (PR3 Cabreúva): capital em estoque nível-empresa + dinheiro morto +
+// retorno-sobre-estoque PROXY (cm TTM ÷ snapshot; NÃO é GMROI — falta estoque médio histórico).
+export interface CockpitGiroExecutivo {
+  capital_medido: number;
+  capital_sem_venda_ttm: number;   // capital em SKUs SEM venda no TTM (dinheiro morto)
+  skus_medidos: number;
+  skus_sem_valor: number;          // presentes no estoque mas sem valor confiável (cmc/saldo)
+  retorno_proxy: number | null;    // null se cm indisponível ou capital ≤ 0 (nunca Infinity)
+}
 export interface ValorCockpitResult {
   company: string;
   k: number | null;                 // hurdle (Ke); null quando ausente/inválido (não fabricado)
@@ -1089,6 +1098,7 @@ export interface ValorCockpitResult {
   porCliente: CockpitRollupCliente[];
   porSKU: CockpitRollupSKU[];
   porCanal?: CockpitRollupCanal[]; // opcional: edge antiga (pré-deploy) não devolve — UI degrada honesta
+  giroExecutivo?: CockpitGiroExecutivo; // idem (PR3): ausente na edge antiga → UI omite o bloco
   empresa: CockpitEmpresaEVP;
   recomendacoesCliente: Array<{ cliente: string; recomendacoes: CockpitRecomendacao[] }>;
   confianca: { nivel: 'alta' | 'media' | 'baixa'; motivos: string[] };

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -344,6 +344,32 @@ function agregarPorCanal(itens: ItemCanalInput[], canalPorPedido: Map<string, Ca
     .sort((a, b) => b.receita - a.receita);
 }
 
+// ===== Giro executivo, espelhado VERBATIM de valor-cockpit-helpers.ts (PR3 Cabreúva-Colacor) =====
+type GiroExecutivo = {
+  capital_medido: number;
+  capital_sem_venda_ttm: number;
+  skus_medidos: number;
+  skus_sem_valor: number;
+  retorno_proxy: number | null;
+};
+function calcularGiroExecutivo(input: {
+  estoquePorSKU: Map<string, number | null>;
+  skusComVendaTTM: Set<string>;
+  cmTTM: number | null;
+}): GiroExecutivo {
+  let capital = 0, morto = 0, medidos = 0, semValor = 0;
+  for (const [sku, valor] of input.estoquePorSKU) {
+    if (valor == null || !Number.isFinite(valor) || valor < 0) { semValor++; continue; }
+    medidos++;
+    capital += valor;
+    if (!input.skusComVendaTTM.has(sku)) morto += valor;
+  }
+  const retorno = input.cmTTM != null && Number.isFinite(input.cmTTM) && capital > 0
+    ? input.cmTTM / capital
+    : null;
+  return { capital_medido: capital, capital_sem_venda_ttm: morto, skus_medidos: medidos, skus_sem_valor: semValor, retorno_proxy: retorno };
+}
+
 // ===== Custo: régua do cockpit, espelhada VERBATIM de src/lib/custos/cost-source.ts (Deno não importa de src/) =====
 // Régua do COCKPIT (computa-e-degrada #1003): exibe a margem mesmo de proxy e marca baixaConfianca p/ rebaixar a
 // confiança — DISTINTA de resolverCustoConfiavel (recommend/audit, que NULIFICA proxy). Mudou? Mude lá e rode
@@ -598,6 +624,14 @@ serve(async (req: Request) => {
 
     const res = montarCelulasComboEVP({ combos, capitalClientes, capitalSKUs, k });
 
+    // Giro executivo (PR3 Cabreúva): capital nível-empresa sobre o MESMO estoque eleito do
+    // cockpit; dinheiro morto = capital de SKU sem venda no TTM. Retorno é PROXY (snapshot).
+    const giroExecutivo = calcularGiroExecutivo({
+      estoquePorSKU: estoqueValorPorSKU,
+      skusComVendaTTM: new Set(comboVals.map((c) => c.sku)),
+      cmTTM: res.empresa.cm,
+    });
+
     // Recomendações por cliente. NOTA: prazo_medio_dias/dias_estoque ainda não computados por cliente/SKU
     // (deferido) → as regras de prazo/estoque ficam inertes; as de desconto/preço usam dados reais.
     const descontoPorCliente = new Map<string, number>();
@@ -633,7 +667,7 @@ serve(async (req: Request) => {
     const porClienteComNome = res.porCliente.map((c) => ({ ...c, nome: clienteParaNome.get(c.cliente) ?? null }));
     return jsonResponse({
       company: COMPANY, k, hurdle_indisponivel, ttm: { inicio: ttm_inicio, fim: ttm_fim },
-      porCliente: porClienteComNome, porSKU: porSKUcomDescricao, porCanal, empresa: res.empresa,
+      porCliente: porClienteComNome, porSKU: porSKUcomDescricao, porCanal, giroExecutivo, empresa: res.empresa,
       recomendacoesCliente, confianca, cobertura_receita, cobertura_app_por_ar: app_por_ar,
       cobertura_baixa_ar: coberturaBaixaAR, // Fase 3: fração da AR liquidada com baixa derivada REAL (vs vencimento-proxy)
       // transparência por receita (omissão honesta do EVP otimista — sucede evp_teto_receita_pct):


### PR DESCRIPTION
## Programa Cabreúva-Colacor — PR3 (Pista A, fecha os quick-wins)

**Benchmark:** a Renner governa o CD por retorno sobre capital (ROIC 14,7%→20% até 2030). Nosso análogo imediato: **quanto capital está parado em estoque e quanto ele rende** — nível-empresa, na mesma tela onde gestor já olha valor (Cockpit de Valor).

### O que entra
- **Bloco "giro executivo"** no topo do Cockpit: capital em estoque (medido) · **dinheiro morto** (capital em SKUs SEM venda no TTM) · retorno-sobre-estoque **rotulado proxy** (margem TTM ÷ snapshot de capital — explicitamente NÃO é GMROI: falta estoque médio histórico, que é o épico GMROI da Pista B).
- `calcularGiroExecutivo` (puro, **4 testes**; espelho VERBATIM na edge `fin-valor-cockpit`, padrão do arquivo): reusa o estoque ELEITO que a edge já computa (`estoqueValorPorSKU` — linha mais fresca com cmc>0, ponte de contas vendas/oben) e o cm TTM da empresa.

### Régua money-path
- cmc/saldo ausente ou sujo (negativo/NaN) fica **fora** do total e vira contagem explícita de cobertura (`skus_sem_valor`) — nunca 0 fabricado.
- Retorno sem numerador (cm null) ou denominador (capital ≤ 0) → **null** (nunca Infinity/NaN).
- Edge antiga sem o campo → UI **omite** o bloco (campo opcional, degradação honesta).

### Evidência
- `valor-cockpit-giro`: 4/4 vitest exit 0 · typecheck exit 0 · `deno check` da edge exit 0
- Árvore exata do PR: lint exit 0 · suíte completa **648 files / 5.928 tests passed, exit 0**

### Deploy manual do founder (Lovable)
- 💬 **Redeploy da edge `fin-valor-cockpit`** (mesma edge do #1659 — um redeploy cobre os dois PRs se aplicado depois deste merge).
- 🖱️ **Publish** do frontend.
- 🟣 Migration: não há.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
