### PR TITLE
fix(tokens): a régua contava 1 request como 2-5 linhas — dedupe por requestId (a semana era 2,2× menor) + switch de connectors inerte

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,6 @@
 {
   "model": "opus",
-  "env": {
-    "ENABLE_CLAUDEAI_MCP_SERVERS": "false"
-  },
+  "disableClaudeAiConnectors": true,
   "skillListingMaxDescChars": 220,
   "skillListingBudgetFraction": 0.004,
   "enabledPlugins": {

--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -174,4 +174,12 @@ list` mostra `WIP on <seu-branch>`), mas o susto é evitável.
 
 ## MCPs enxutas
 
-`.claude/settings.json` (comitado, **project > user**) desabilita 11 plugins sem uso no dev TS (adobe/mercadopago/sentry/slack/telegram/airtable/zapier/github/posthog/chrome-devtools/serena) + `ENABLE_CLAUDEAI_MCP_SERVERS=false`. **Mantidos:** superpowers/claude-mem/claude-md-management/context7. Religar pontual em `.claude/settings.local.json` (gitignored, precedência maior) + `/reload-plugins`. ⚠️ Desabilitar o **plugin** mata MCP **+ skills + hooks** dele. Worktrees criados via `bun run wt` (de `origin/main`) já nascem enxutos.
+`.claude/settings.json` (comitado, **project > user**) desabilita 11 plugins sem uso no dev TS (adobe/mercadopago/sentry/slack/telegram/airtable/zapier/github/posthog/chrome-devtools/serena) + `disableClaudeAiConnectors: true`. **Mantidos:** superpowers/claude-mem/claude-md-management/context7.
+
+⚠️ **`ENABLE_CLAUDEAI_MCP_SERVERS=false` era INERTE** (chave inventada, não existe no schema) — ficou 
+no arquivo parecendo que desligava os connectors da conta claude.ai enquanto Gmail/Calendar/Drive 
+carregavam em toda sessão do app. O switch certo é a chave de topo `disableClaudeAiConnectors`. 
+Falha SILENCIOSA e invisível ao CLI: `scripts/piso-contexto.sh` **não reproduz** isto — o CLI nunca 
+carrega connector da conta, então a sonda dá delta zero com ou sem o fix. Evidência tem que vir de 
+sessão NOVA do app (a lista de tools não pode mais ter servidor `mcp__<uuid>__*`) ou do 
+`tokens-report.sh`. Uso medido dos 3 connectors em 48 dias: **zero chamadas**. Religar pontual em `.claude/settings.local.json` (gitignored, precedência maior) + `/reload-plugins`. ⚠️ Desabilitar o **plugin** mata MCP **+ skills + hooks** dele. Worktrees criados via `bun run wt` (de `origin/main`) já nascem enxutos.

--- a/docs/historico/piso-de-contexto.md
+++ b/docs/historico/piso-de-contexto.md
@@ -31,6 +31,45 @@ piso absoluto.
   A diferença (~23k) é o ambiente do app: MCPs próprias + 172 skills de plugins da conta.
 - Distribuição do contexto por request: p50 258.927 · p90 449.812 · máx 782.883.
 
+## ⚠️ CORREÇÃO nº 2 (2026-08-06) — a RÉGUA contava cada request 2 a 5 vezes
+
+O `tokens-report.sh` somava **toda linha** do JSONL com `message.usage`. Mas uma chamada de
+API vira VÁRIAS linhas quando a resposta tem vários blocos (texto + `tool_use` + `tool_use`),
+e **todas repetem o mesmo `usage`** — verificado: cada `requestId` tem exatamente 1 valor
+distinto de `usage`. Fork/resume de sessão agrava (copia o transcript do pai, o mesmo request
+reaparece em outro arquivo).
+
+Medido em 2026-08-06 sobre todo o histórico: **131.605 linhas brutas para 60.376 requests
+reais — 2,18×**. Uma semana relatada como US$ 3.347 / 13.488 requests custou de fato
+**US$ 1.596 / 6.601 requests**.
+
+**O que muda e o que NÃO muda** (a distinção importa — nem todo número derivava da soma):
+
+| número | efeito |
+|---|---|
+| custo US$, contagem de requests | **inflados ~2,2×** — reler tudo que dependia disso |
+| piso por sessão (68.537) | **intacto** — é um MÍNIMO, duplicata não move mínimo |
+| p50/p90 de contexto | levemente enviesados (request duplicado pesa n× no percentil) |
+| **razões e percentuais** | **essencialmente intactos** — a duplicação é ~uniforme, então numerador e denominador inflam juntos |
+
+A última linha é o que salva as conclusões anteriores. `escolha-de-modelo.md` e o #1664 foram
+medidos com a régua torta, mas raciocinam em RAZÃO ("Fable = 34% do custo com 18% dos
+requests", "86,7% de cobertura por tráfego") — e razão sobrevive. **O que não sobrevive são as
+contagens absolutas** citadas naqueles docs (ex.: "1.260 requests" em 48h, "20.933 requests"
+na janela de 7 dias): divida por ~2,2. Nenhuma decisão tomada com base neles muda.
+
+Pós-dedupe a decomposição fica **cache_read 70,3% · cache_write 19,2% · output 10,4% ·
+input 0,2%** — ou seja, ~90% do custo é ENTRADA. A conclusão estrutural sempre esteve certa;
+só a escala estava errada.
+
+Corrigido com dedupe global por `requestId` (fallback `.uuid`, guard `NF < 9` para TSV
+antigo com `--pular-coleta`) + 4 casos em `test-tokens-report.sh`, os dois sentidos fechados
+(4 = não deduplicou · 1 = colapsou demais · só o certo dá 2) e falsificados por sabotagem
+nos locales `C` e `pt_BR.UTF-8`.
+
+**A lição não é o bug — é que a régua não tinha teste para a própria unidade de medida.**
+Havia teste para o recorte por data (#1660) e nenhum para "o que conta como 1 request".
+
 ## ❌ Premissa FALSA nº 1 — "encurtar a `description` das skills reduz o piso"
 
 Encurtei as `description` das 13 skills do projeto de **16.041 → 9.659 chars** (−6.382,

--- a/scripts/test-tokens-report.sh
+++ b/scripts/test-tokens-report.sh
@@ -91,6 +91,78 @@ else
   bad "POR MODELO deveria ter coluna %reqs com fable em 50%"; printf '%s\n' "$saida" | sed 's/^/      /'
 fi
 
+echo "== dedupe por requestId =="
+# UMA resposta com vários blocos (texto + tool_use + tool_use) vira VÁRIAS linhas
+# no JSONL, e TODAS repetem o mesmo message.usage — verificado: cada requestId tem
+# exatamente 1 valor distinto de usage. Somar linha a linha multiplica o custo.
+# Medido em 2026-08-06: 131.605 linhas brutas para 60.376 requests reais (2,18x).
+# O relatório inflado por isso chegou a US$ 3.347 numa semana que custou US$ 1.596.
+dup_dir() { # $1=nome -> cria dir de projects próprio e ecoa o caminho
+  local d="$tmp/$1"; mkdir -p "$d/proj"; printf '%s' "$d"
+}
+linha_req() { # $1=requestId ("" = ausente, transcript antigo) $2=uuid
+  jq -nc --arg r "$1" --arg u "$2" \
+    '{timestamp:"2026-08-04T10:00:00.000Z", sessionId:"s1", uuid:$u}
+     + (if $r == "" then {} else {requestId:$r} end)
+     + {message:{model:"claude-opus-5", usage:{input_tokens:10, output_tokens:5,
+         cache_creation_input_tokens:0, cache_read_input_tokens:1000}}}'
+}
+reqs_de() { # $1=dir de projects -> nº de requests que o relatório contou
+  CLAUDE_PROJECTS_DIR="$1" bash "$REPORT" --dias 0 2>/dev/null \
+    | command grep -E '^  requests ' | command tr -cd '0-9'
+}
+
+# 3 linhas do MESMO request (uuid distinto, como no JSONL real) + 1 request outro.
+D="$(dup_dir projects-dup)"
+{ linha_req req_AAA u1; linha_req req_AAA u2; linha_req req_AAA u3
+  linha_req req_BBB u4; } > "$D/proj/sessao.jsonl"
+n="$(reqs_de "$D")"
+# 4 = não deduplicou; 1 = colapsou requests distintos. Só o certo dá 2 — a
+# asserção fecha dos DOIS lados, então não passa por acidente.
+if [ "$n" = "2" ]; then
+  ok "3 linhas do mesmo requestId contam 1 request (total 2, não 4 nem 1)"
+else
+  bad "esperava 2 requests após dedupe, veio '$n'"
+fi
+
+# Mesmo request repetido em DOIS arquivos (fork/resume copia o transcript do pai):
+# o dedupe tem de ser GLOBAL, não por arquivo.
+D="$(dup_dir projects-fork)"
+linha_req req_CCC u1 > "$D/proj/pai.jsonl"
+{ linha_req req_CCC u1; linha_req req_DDD u2; } > "$D/proj/filho.jsonl"
+n="$(reqs_de "$D")"
+if [ "$n" = "2" ]; then
+  ok "requestId repetido entre arquivos (fork/resume) conta 1 vez"
+else
+  bad "esperava 2 requests com dedupe global, veio '$n'"
+fi
+
+# FALSIFICAÇÃO da chave: transcript SEM requestId (formato antigo) não pode
+# colapsar. Se o dedupe usasse campo vazio como chave, estes 2 virariam 1.
+D="$(dup_dir projects-sem-req)"
+{ linha_req "" u1; linha_req "" u2; } > "$D/proj/sessao.jsonl"
+n="$(reqs_de "$D")"
+if [ "$n" = "2" ]; then
+  ok "falsificação: linhas SEM requestId não colapsam (2 continuam 2)"
+else
+  bad "sem requestId os 2 requests deveriam sobreviver, veio '$n'"
+fi
+
+# TSV de 8 colunas (coletado por versão ANTERIOR ao dedupe) reusado com
+# --pular-coleta: a col. 9 não existe. Sem o guard NF < 9 a chave seria vazia e
+# IGUAL em toda linha — o arquivo inteiro colapsaria em 1 request. É a regressão
+# mais cara possível aqui: silenciosa, e para MENOS custo (parece otimização).
+T="$tmp/antigo.tsv"
+printf 'proj\t2026-08-04\tclaude-opus-5\t10\t5\t0\t1000\ts1\n'  > "$T"
+printf 'proj\t2026-08-04\tclaude-opus-5\t20\t7\t0\t2000\ts1\n' >> "$T"
+n="$(bash "$REPORT" --tsv "$T" --pular-coleta 2>/dev/null \
+     | command grep -E '^  requests ' | command tr -cd '0-9')"
+if [ "$n" = "2" ]; then
+  ok "TSV antigo (8 colunas) com --pular-coleta não colapsa (2 continuam 2)"
+else
+  bad "TSV de 8 colunas deveria manter 2 requests, veio '$n'"
+fi
+
 echo "== validação de entrada =="
 if bash "$REPORT" --dias 0 --desde "04/08/2026" >/dev/null 2>&1; then rc=0; else rc=$?; fi
 if [ "$rc" -eq 2 ]; then

--- a/scripts/tokens-report.sh
+++ b/scripts/tokens-report.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # tokens-report.sh — painel de consumo de tokens do Claude Code (READ-ONLY).
 #
-# POR QUÊ: 82% do custo de token é ENTRADA de contexto (cache_read 52% +
-# cache_write 29%), não geração (18%). Otimizar "resposta curta" mexe em 18%;
-# medir e cortar contexto mexe em 82%. Este script é a régua — sem baseline
-# não há como provar que uma otimização funcionou (regra da EVIDÊNCIA POSITIVA).
+# POR QUÊ: ~90% do custo de token é ENTRADA de contexto, não geração (medido
+# 2026-08-06, já deduplicado: cache_read 70,3% + cache_write 19,2% vs. output
+# 10,4%). Otimizar "resposta curta" mexe em 10%; medir e cortar contexto mexe
+# em 90%. Este script é a régua — sem baseline não há como provar que uma
+# otimização funcionou (regra da EVIDÊNCIA POSITIVA).
 #
 # Fonte: ~/.claude/projects/**/*.jsonl (campo message.usage de cada request).
 # Nada sai da máquina; nenhum arquivo do projeto é alterado.
@@ -78,7 +79,11 @@ if [ "$PULAR_COLETA" -eq 0 ]; then
     else
       find "$dir" -name '*.jsonl' -type f -print0 2>/dev/null
     fi | while IFS= read -r -d '' f; do
-      # 1 linha por request: projeto, dia, modelo, input, output, cache_w, cache_r, sessão
+      # 1 linha por LINHA do jsonl: projeto, dia, modelo, input, output, cache_w,
+      # cache_r, sessão, requestId. A col. 9 é a chave do dedupe abaixo — sem ela
+      # cada request entra 2-5x (uma resposta com vários blocos vira várias linhas,
+      # todas repetindo o MESMO usage). Fallback p/ .uuid: transcript antigo não
+      # tem requestId, e uuid é único por linha, então não colapsa nada.
       jq -rc --arg p "$proj" '
         select(.message.usage != null)
         | [ $p,
@@ -88,7 +93,8 @@ if [ "$PULAR_COLETA" -eq 0 ]; then
             (.message.usage.output_tokens // 0),
             (.message.usage.cache_creation_input_tokens // 0),
             (.message.usage.cache_read_input_tokens // 0),
-            (.sessionId // "?")
+            (.sessionId // "?"),
+            (.requestId // .uuid // "-")
           ] | @tsv' "$f" 2>/dev/null
     done
   done >> "$TSV"
@@ -97,16 +103,32 @@ fi
 [ -s "$TSV" ] || { echo "nenhum request na janela de ${DIAS} dias." >&2; exit 0; }
 echo "linhas coletadas: $(wc -l < "$TSV" | tr -d ' ')" >&2
 
+# ------------------------------------------------- dedupe por requestId -----
+# UMA chamada de API vira VÁRIAS linhas no JSONL quando a resposta tem vários
+# blocos (texto + tool_use + tool_use), e TODAS repetem o mesmo message.usage
+# (verificado: cada requestId tem exatamente 1 valor distinto de usage). Fork e
+# resume de sessão agravam — copiam o transcript do pai, então o mesmo request
+# reaparece em outro arquivo. Somar linha a linha multiplica o custo: medido em
+# 2026-08-06, 131.605 linhas brutas para 60.376 requests reais (2,18x), o que
+# inflou uma semana de US$ 1.596 para US$ 3.347. O dedupe é GLOBAL de propósito.
+#
+# NF < 9 mantém a linha: TSV coletado por versão anterior (8 colunas) usado com
+# --pular-coleta teria a chave vazia e colapsaria o arquivo inteiro em 1 linha.
+LIMPO="${TSV}.dedup"
+awk -F'\t' 'NF < 9 || $9 == "-" || !($9 in v) { v[$9] = 1; print }' "$TSV" > "$LIMPO"
+echo "requests após dedupe: $(wc -l < "$LIMPO" | tr -d ' ')" >&2
+
 # ------------------------------------------- recorte por data do REQUEST ----
-# O que os blocos abaixo leem é $DADOS, não $TSV: sem recorte são o mesmo
-# arquivo; com --desde/--ate, $DADOS é o subconjunto cuja data de REQUEST cai
-# na janela pedida (o $TSV bruto fica intacto e reusável com --pular-coleta).
+# O que os blocos abaixo leem é $DADOS, não $TSV: sem recorte é o $LIMPO
+# (deduplicado); com --desde/--ate, $DADOS é o subconjunto DELE cuja data de
+# REQUEST cai na janela pedida. O $TSV bruto fica intacto e reusável com
+# --pular-coleta — o dedupe roda de novo sobre ele a cada execução.
 # A data vem de .timestamp, que é UTC — o dia vira, aqui, 21h do dia anterior.
-DADOS="$TSV"
+DADOS="$LIMPO"
 if [ -n "$DESDE" ] || [ -n "$ATE" ]; then
   DADOS="${TSV}.recorte"
   awk -F'\t' -v d="${DESDE:-0000-00-00}" -v a="${ATE:-9999-99-99}" \
-    '$2 >= d && $2 <= a' "$TSV" > "$DADOS"
+    '$2 >= d && $2 <= a' "$LIMPO" > "$DADOS"
   echo "recorte por data do request: ${DESDE:-(início)} .. ${ATE:-(fim)} — $(wc -l < "$DADOS" | tr -d ' ') linhas" >&2
   [ -s "$DADOS" ] || { echo "nenhum request no recorte." >&2; exit 0; }
 fi


### PR DESCRIPTION
Investigação do gasto semanal que devolveu dois achados — o primeiro **contra o próprio instrumento de medição**.

## 1. `tokens-report.sh` inflava o custo em ~2,2×

O script somava **toda linha** do JSONL com `message.usage`. Mas uma chamada de API vira várias linhas quando a resposta tem vários blocos (texto + `tool_use` + `tool_use`), e **todas repetem o mesmo `usage`** — verificado: cada `requestId` tem exatamente 1 valor distinto de `usage`. Fork/resume de sessão agrava (copia o transcript do pai; o mesmo request reaparece em outro arquivo).

Medido sobre todo o histórico: **131.605 linhas brutas → 60.376 requests reais**.

| semana 07-28..08-04 | antes | depois |
|---|---|---|
| custo-equivalente | US$ 3.347 | **US$ 1.604** |
| requests faturáveis | 13.488 | **6.682** |

**O que NÃO muda:** razões e percentuais. A duplicação é ~uniforme, então numerador e denominador inflam juntos — as conclusões de `escolha-de-modelo.md` e do #1664 (que raciocinam em razão: "Fable 34% do custo com 18% dos requests", "86,7% de cobertura por tráfego") seguem válidas. Só as **contagens absolutas** citadas lá devem ser divididas por ~2,2. Nenhuma decisão tomada com base nelas muda.

O diagnóstico estrutural também sobrevive, e é o ponto: pós-dedupe, `cache_read` 70,1% + `cache_write` 19,3% = **89,6% do custo é ENTRADA de contexto**, contra 10,4% de output.

### Fix
Dedupe **global** por `requestId` (fallback `.uuid`; guard `NF < 9` para TSV de 8 colunas reusado com `--pular-coleta` — sem ele o arquivo inteiro colapsaria em 1 request, regressão silenciosa e *para menos* custo, logo parecendo otimização).

### Prova
4 casos novos, fechados **dos dois lados** (4 = não deduplicou · 1 = colapsou demais · só o certo dá 2):
- 3 linhas do mesmo `requestId` contam 1 request
- `requestId` repetido entre arquivos (fork/resume) conta 1 vez
- linhas sem `requestId` não colapsam
- TSV antigo de 8 colunas com `--pular-coleta` não colapsa

Falsificados por **sabotagem das duas mutações** (remover o guard `NF < 9`; trocar a chave para `$8`), ambas vermelhas, em `LC_ALL=C` **e** `pt_BR.UTF-8`. `shellcheck` limpo. Validação cruzada: o relatório corrigido (US$ 1.604) bate com um cálculo independente feito fora do script (US$ 1.596), 0,5% de diferença.

## 2. `ENABLE_CLAUDEAI_MCP_SERVERS` era chave inventada

Não existe no schema. Ficou no `.claude/settings.json` **parecendo** desligar os connectors da conta claude.ai enquanto Gmail/Calendar/Drive carregavam em toda sessão do app. O switch certo é a chave de topo `disableClaudeAiConnectors`.

Uso medido dos 3 connectors em 48 dias: **zero chamadas** — com o padrão falsificado contra 800+ chamadas MCP reais, então o zero é dado e não silêncio.

Armadilha documentada em `worktrees.md`: **`scripts/piso-contexto.sh` não valida isto** — o CLI nunca carrega connector de conta, então a sonda dá delta zero com ou sem o fix. A evidência tem de vir de sessão nova do app (nenhum servidor `mcp__<uuid>__*` na lista de tools).

## Lição registrada

A régua tinha teste para o recorte por data (#1660) e **nenhum para o que conta como 1 request** — a própria unidade de medida.

🤖 Generated with [Claude Code](https://claude.com/claude-code)