### PR TITLE
perf(contexto): as duas premissas do C1/B1 eram falsas — subagente custa US$ 1,06 e o degrau de 250k já avisava cedo

### DIFF
--- a/.claude/hooks/read-contexto-nudge.sh
+++ b/.claude/hooks/read-contexto-nudge.sh
@@ -2,17 +2,22 @@
 # read-contexto-nudge.sh — PreToolUse(Read): disciplina de leitura.
 #
 # POR QUÊ: o Read é 60,2% de todo o texto que entra por ferramenta (18,2M tokens
-# em 48 dias; 8.836 chamadas, média 2.058 tok). E 82% do custo de token é ENTRADA
-# de contexto, não geração — então o alvo é o que ENTRA. Dois bolsos concentram
-# o desperdício:
+# em 48 dias; 8.836 chamadas, média 2.058 tok). E 89,6% do custo de token é
+# ENTRADA de contexto, não geração — então o alvo é o que ENTRA. Dois bolsos
+# concentram o desperdício:
 #   (a) VOLUME    — 226 leituras acima de 10k tokens = 2,6% das chamadas e 32%
 #                   do volume. Um Read de 50k no início de uma sessão de 1.000
 #                   requests é relido ~1.000 vezes (~US$ 25 sozinho).
 #   (b) RELEITURA — 2.457 leituras repetidas do MESMO arquivo na MESMA sessão
 #                   (28% dos Reads; campeão: um index.ts lido 24 vezes). A cópia
 #                   anterior não sai do contexto — a segunda só empilha.
-# O contraste com o subagente é a tese: ele lê muito, pensa muito e devolve 638
-# tokens em média. Por isso a mensagem EMPURRA para subagente; não proíbe Read.
+#
+# ⚠️ O conselho NÃO é "delegue sempre". A 1ª versão empurrava para subagente já a
+# partir de 10k, com base na intuição de que ele "devolve pouco". Medido depois:
+# um subagente custa US$ 1,06 na mediana — mais caro que a releitura que evita,
+# a não ser que a leitura seja grande E a sessão longa (break-even completo na
+# ramificação de volume, abaixo). Delegar é a recomendação a partir de 40k; sob
+# isso, o certo é RECORTAR (rg + offset/limit), que é gratuito.
 #
 # NÃO BLOQUEIA e NÃO DECIDE PERMISSÃO — só anexa contexto. Emitir
 # permissionDecision:"allow" pularia o prompt de permissão de toda leitura
@@ -103,14 +108,35 @@ else
   # 10k tokens = o corte medido (2,6% das chamadas, 32% do volume). Abaixo disso
   # o aviso viraria ruído: 96% dos arquivos do repo passam longe.
   [ "$tokens" -ge 10000 ] || exit 0
+
+  # A ORDEM do conselho vem do BREAK-EVEN MEDIDO (2026-08-06), não da intuição.
+  # Um subagente custa US$ 1,06 na MEDIANA (277 invocações do histórico; p75
+  # 1,98; p90 3,62; 19 requests em média) e devolve ~780 tokens (p50 273).
+  # Manter T tokens no contexto custa T x requests_restantes x US$0,50/MTok.
+  # Delegar só compensa quando:
+  #
+  #     T  >  780 + 1,06 x 2.000.000 / requests_restantes
+  #
+  #     restantes:  50 -> ~43k tokens      200 -> ~11k
+  #                100 -> ~22k             400 ->  ~6k
+  #
+  # As sessões caras deste parque vivem na faixa de 50-299 requests. Logo, abaixo
+  # de ~40k tokens delegar normalmente PERDE dinheiro: o subagente custa mais que
+  # a releitura que ele evita. A versão anterior deste hook mandava delegar já a
+  # partir de 10k — conselho errado na maioria dos disparos. Abaixo de 40k a
+  # recomendação passa a ser o RECORTE (rg + offset/limit), que é gratuito.
   if [ "$tokens" -ge 40000 ]; then
     grito="🔴"; peso="Isso sozinho ocupa mais que muitas sessões inteiras."
+    via="→ delegue a um subagente (~US\$ 1, devolve ~780 tok — neste tamanho se paga em ~30 turnos)"
+    ordem="(1) delegue a um subagente (Agent/Explore) — nesta faixa (>=40k) ele SE PAGA: custa ~US\$ 1,06 na mediana e devolve ~780 tokens, contra os ${tok_k}k que esta leitura passaria a injetar em TODOS os turnos seguintes; (2) se preferir ler aqui, ache o trecho com Grep/rg e leia só ele com offset/limit; (3) se o alvo é dump, log ou gerado (schema-snapshot.sql, types.ts, package-lock.json), consulte com rg/jq em vez de trazer para o contexto."
   else
     grito="🟡"; peso="Cada turno seguinte relê esses ${tok_k}k."
+    via="→ use rg + Read com offset/limit (custo zero). Subagente nesta faixa em geral NÃO compensa."
+    ordem="(1) localize o trecho com Grep/rg e leia só ele com offset/limit — é gratuito e resolve a maioria dos casos; (2) se o alvo é dump, log ou gerado (schema-snapshot.sql, types.ts, package-lock.json), consulte com rg/jq em vez de trazer para o contexto; (3) delegar a um subagente AQUI normalmente PERDE dinheiro — ele custa ~US\$ 1,06 na mediana, e evitar a releitura de ${tok_k}k só cobre isso se ainda faltarem ~200 requests de sessão. Só delegue se a sessão for longa E a tarefa exigir ler muita coisa além deste arquivo."
   fi
   msg="${grito} Leitura cara: ${curto} ≈ ${tok_k}k tokens. ${peso}
-→ delegue a um subagente (ele devolve ~638 tok em média) ou use rg + Read com offset/limit."
-  ctx="READ-GRANDE: a leitura de ${arquivo} vai injetar cerca de ${tok_k}k tokens no contexto, e cada turno seguinte relê tudo isso. Antes de ler o arquivo inteiro de novo, considere, nesta ordem: (1) delegue a um subagente (Agent/Explore) — ele lê muito, pensa muito e devolve ~638 tokens em média, contra os ~2.058 de um Read médio; (2) localize o trecho com Grep/rg e leia só ele com offset/limit; (3) se o alvo é um dump, log ou arquivo gerado (schema-snapshot.sql, types.ts, package-lock.json), prefira consultar com rg/jq a trazer para o contexto. Se você realmente precisa do arquivo inteiro, siga em frente — isto é um lembrete, não um bloqueio."
+${via}"
+  ctx="READ-GRANDE: a leitura de ${arquivo} vai injetar cerca de ${tok_k}k tokens no contexto, e cada turno seguinte relê tudo isso. Antes de ler o arquivo inteiro, considere, nesta ordem: ${ordem} Se você realmente precisa do arquivo inteiro, siga em frente — isto é um lembrete, não um bloqueio."
 fi
 
 jq -n --arg m "$msg" --arg c "$ctx" \

--- a/.claude/hooks/stop-contexto-caro.sh
+++ b/.claude/hooks/stop-contexto-caro.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # stop-contexto-caro.sh — Stop: avisa quando a sessão fica CARA de reler.
 #
-# POR QUÊ: 82% do custo de token é entrada de contexto, e 80 sessões longas
-# concentraram 62% do gasto medido (scripts/tokens-report.sh). O custo cresce
-# ~quadraticamente: o request N relê tudo que os N-1 acumularam, então uma
-# sessão de 2.000 turnos custa MUITO mais que 4 de 500 fazendo o mesmo.
+# POR QUÊ: 89,6% do custo de token é entrada de contexto, e 39 sessões (as de
+# 50+ requests) concentraram 96% do gasto medido — números já DEDUPLICADOS
+# (scripts/tokens-report.sh; a régua contava cada request 2-5x até 2026-08-06).
+# O custo cresce ~quadraticamente: o request N relê tudo que os N-1 acumularam,
+# então uma sessão de 2.000 turnos custa MUITO mais que 4 de 500 fazendo o mesmo.
 # O founder não tem como ver isso acontecendo — este hook torna visível.
 #
 # BARATO DE PROPÓSITO: lê `tail` do transcript + um `grep -c`. Zero parse do
@@ -54,10 +55,27 @@ ctx_custo="$(awk -v c="$ctx" -v p="$preco_read" 'BEGIN{ printf "%.0f", c * p / 0
 case "$ctx_custo" in ''|*[!0-9]*) exit 0 ;; esac
 
 # Só avisa ao CRUZAR um degrau novo.
+#
+# O PRIMEIRO degrau é 150k, não 250k. Medido em 2026-08-06 sobre dados já
+# deduplicados (ver piso-de-contexto.md), perguntando "quando o degrau dispara,
+# quanto da sessão JÁ foi gasto?" — a métrica que decide se o aviso tem alavanca:
+#
+#   degrau | sessões | % do custo coberto | % já gasto | sessões triviais (<US$1)
+#    120k  |   46    |       99,1%        |   12,3%    |  0
+#    150k  |   44    |       98,8%        |   16,2%    |  0
+#    250k  |   35    |       94,3%        |   29,1%    |  0
+#
+# 250k avisava com 29,1% do custo já gasto e deixava 16 sessões CARAS mudas
+# (ctx_max 159k-248k, US$ 85 = 5,3% da semana). 150k cobre 98,8% do custo e
+# dobra a alavanca — e o ruído medido é ZERO: nenhuma sessão trivial chega a
+# 150k, porque o piso já é ~81k e 150k exige conversa acumulada de verdade.
+# 120k cobre marginalmente mais (99,1%), mas fica a só 39k acima do piso: o
+# aviso chegaria antes de haver trabalho a dividir.
 if   [ "$ctx_custo" -ge 700000 ]; then degrau=700; acao="pare e faça o split AGORA"
-elif [ "$ctx_custo" -ge 500000 ]; then degrau=500; acao="split recomendado"
-elif [ "$ctx_custo" -ge 350000 ]; then degrau=350; acao="hora de decidir"
-elif [ "$ctx_custo" -ge 250000 ]; then degrau=250; acao="atenção"
+elif [ "$ctx_custo" -ge 500000 ]; then degrau=500; acao="split fortemente recomendado"
+elif [ "$ctx_custo" -ge 350000 ]; then degrau=350; acao="split recomendado"
+elif [ "$ctx_custo" -ge 250000 ]; then degrau=250; acao="hora de decidir"
+elif [ "$ctx_custo" -ge 150000 ]; then degrau=150; acao="atenção — ainda dá para dividir barato"
 else exit 0
 fi
 
@@ -69,18 +87,31 @@ case "$anterior" in ''|*[!0-9]*) anterior=0 ;; esac
 printf '%s' "$degrau" > "$marca" 2>/dev/null || true
 
 # Custo estimado desta sessão. `command grep` porque o `grep` do shell é shim
-# p/ ugrep. Calibração conferida contra o custo real de uma sessão (US$ 31,79
-# medidos vs 29,6 estimados = 7% de erro); a 1ª versão errava 2,4x porque só
-# contava cache_read — write + output são 47% do custo e não podem sair da conta.
-reqs="$(command grep -c '"usage"' "$transcript" 2>/dev/null || echo 0)"
+# p/ ugrep.
+#
+# ⚠️ `grep -c '"usage"'` contava LINHAS, não requests: uma resposta com vários
+# blocos (texto + tool_use) vira várias linhas no JSONL, todas repetindo o mesmo
+# usage. Medido: 2,18x de inflação. A "calibração" antiga (US$ 31,79 reais vs
+# 29,6 estimados, 7% de erro) era o encontro de DOIS erros — o custo "real" vinha
+# do tokens-report.sh, que tinha exatamente a mesma dupla contagem. Agora conta
+# requestId DISTINTO (`awk '!a[$0]++'` em vez de `sort -u`: uma passada, sem
+# ordenar 70MB). Fallback para a contagem de linhas se o transcript não tiver
+# requestId — melhor superestimar que zerar o aviso.
+reqs="$(command grep -o '"requestId":"[^"]*"' "$transcript" 2>/dev/null \
+        | command awk '!a[$0]++' | command wc -l | command tr -d ' ')"
 case "$reqs" in ''|*[!0-9]*) reqs=0 ;; esac
+if [ "$reqs" -eq 0 ]; then
+  reqs="$(command grep -c '"usage"' "$transcript" 2>/dev/null || echo 0)"
+  case "$reqs" in ''|*[!0-9]*) reqs=0 ;; esac
+fi
 
-# 1) contexto médio da sessão ≈ (piso + atual)/2 — o piso medido é ~61k, não 0,
-#    então partir de zero subestima. 2) `preco_read` da família do modelo, já
-#    definido acima. 3) cache_read é 52% do custo total (medido): dividir por
-#    isso recompõe write + output sem precisar somar o transcript inteiro.
+# 1) contexto médio da sessão ≈ (piso + atual)/2 — o piso medido (deduplicado)
+#    é ~81k, não 0, então partir de zero subestima. 2) `preco_read` da família do
+#    modelo, já definido acima. 3) cache_read é 70,1% do custo total (medido
+#    2026-08-06, deduplicado — era 52% com a contagem inflada): dividir por isso
+#    recompõe write + output sem precisar somar o transcript inteiro.
 custo="$(awk -v r="$reqs" -v c="$ctx" -v p="$preco_read" \
-  'BEGIN{ printf "%.0f", (r * ((61000 + c)/2) * p / 1000000) / 0.52 }')"
+  'BEGIN{ printf "%.0f", (r * ((81000 + c)/2) * p / 1000000) / 0.701 }')"
 ctx_k=$(( ctx / 1000 ))
 
 # Nota de MODELO — só quando ele custa mais que a referência (hoje: Fable). Não

--- a/docs/historico/piso-de-contexto.md
+++ b/docs/historico/piso-de-contexto.md
@@ -246,6 +246,59 @@ O guard é PostToolUse, não Pre, porque no Pre só existe o comando — e preve
 cara dele é fraco: 46,5% das chamadas medidas caíram em "outros" (compostos, heredoc,
 script inline). Só depois de rodar se sabe o tamanho.
 
+## 🎚️ Calibração dos avisos (2026-08-06) — as DUAS premissas eram falsas
+
+Com a régua consertada, dá para perguntar coisas que antes não se podia. As duas
+respostas contrariaram o que eu ia implementar.
+
+### B1 — "o aviso de contexto dispara tarde demais" ❌ REFUTADO (mas achou outra coisa)
+
+A métrica certa não é "em que contexto dispara", é **quanto do custo da sessão já foi
+gasto quando dispara** — é isso que decide se o aviso ainda tem alavanca:
+
+| degrau | sessões | % do custo coberto | % já gasto ao disparar | sessões triviais atingidas |
+|---|---|---|---|---|
+| 120k | 46 | 99,1% | 12,3% | **0** |
+| **150k** | **44** | **98,8%** | **16,2%** | **0** |
+| 180k | 43 | 98,4% | 22,0% | 0 |
+| 250k (era) | 35 | 94,3% | 29,1% | 0 |
+
+A 250k o aviso chega com **71% do custo ainda pela frente** — não é tarde. O problema
+real era outro: **16 sessões CARAS nunca eram avisadas** (ctx_max 159k-248k, US$ 85 =
+5,3% da semana). Primeiro degrau desceu para 150k: cobre 98,8%, dobra a alavanca, e o
+ruído medido é **zero** — com piso de ~81k, nenhuma sessão trivial chega a 150k. 120k
+cobriria marginalmente mais, mas fica a 39k do piso: avisaria antes de haver o que dividir.
+
+Achado colateral: o hook tinha **a mesma dupla contagem da régua** (`grep -c '"usage"'`
+conta linha, não request) e o divisor `0.52` fora calibrado contra o custo igualmente
+inflado — dois erros que se cancelavam e produziam um "7% de erro" ilusório. O US$ exibido
+estava ~1,6× alto. Agora conta `requestId` distinto e usa 0,701.
+
+### C1 — "delegar leitura a subagente economiza" ❌ REFUTADO
+
+Medido sobre **277 invocações** do histórico: um subagente custa **US$ 1,06 na mediana**
+(p75 1,98 · p90 3,62 · máx 10,46 · 19 requests em média) e devolve ~780 tokens (p50 273).
+Manter T tokens no contexto custa `T × requests_restantes × US$0,50/MTok`. Logo:
+
+> delegar compensa quando **T > 780 + 1,06 × 2.000.000 / requests_restantes**
+
+| requests restantes | leitura precisa ter |
+|---|---|
+| 50 | ~43k tokens |
+| 100 | ~22k |
+| 200 | ~11k |
+| 400 | ~6k |
+
+O `read-contexto-nudge.sh` mandava delegar **a partir de 10k** — o que só se paga com
+~200 requests pela frente, enquanto as sessões caras deste parque vivem na faixa de
+50-299. **Na maioria dos disparos o conselho perdia dinheiro.** Corrigido: ≥40k recomenda
+subagente (aí se paga em ~30 turnos); 10-40k recomenda **recorte** (`rg` + `offset/limit`),
+que é gratuito.
+
+O erro de origem foi comparar a coisa errada: "o subagente devolve 638 tokens contra 2.058
+de um Read" é verdade e é **irrelevante** — o que importa não é o que ele devolve, é o que
+ele **cobra para rodar**, e isso ninguém tinha medido.
+
 ## Pendente de medição — só o founder consegue (é na conta, não no repo)
 
 172 das 337 skills da sessão do app vêm de plugins da conta claude.ai **nunca usados em 48
@@ -280,3 +333,15 @@ comparar o piso com os 67.244 registrados aqui.
 > E antes de otimizar um alvo, **meça que fração do custo ele é**. O piso parecia o alvo
 > óbvio (é relido em 100% dos requests) e é só 26%. Otimizar bem a coisa errada perde para
 > medir primeiro.
+>
+> **Meça o preço do REMÉDIO, não só o da doença.** O nudge de leitura empurrava para
+> subagente porque "ele devolve 638 tokens contra 2.058 de um Read" — verdadeiro, e
+> irrelevante: ninguém tinha medido quanto o subagente **cobra para rodar** (US$ 1,06 na
+> mediana, mais que a releitura que evitava na maioria dos casos). Toda recomendação de
+> trocar A por B precisa do custo de B, não só do de A.
+>
+> **E confira a UNIDADE antes da conclusão.** Três achados desta linha (o custo semanal, o
+> US$ do hook, a "calibração de 7% de erro") vieram do mesmo defeito: contar LINHA do JSONL
+> como se fosse REQUEST. Dois erros na mesma direção chegaram a se cancelar e produzir uma
+> validação falsa. Quando duas medições independentes concordam bem demais, desconfie de
+> que compartilham a mesma fonte.

--- a/scripts/test-read-contexto-nudge.sh
+++ b/scripts/test-read-contexto-nudge.sh
@@ -157,6 +157,22 @@ check "grande + limit=10 (~2,8k tok) → silêncio" silencio "$(run "$grande" s6
 #     minha ("usou limit → não avisa") — o corte é por tokens, não por flag.
 check "grande + limit=50 (~13k tok) → avisa mesmo com limit" READ-GRANDE "$(run "$grande" s6b 50)"
 
+# 6c. O CONSELHO muda de lado no break-even medido (2026-08-06): um subagente
+#     custa US$ 1,06 na mediana, então delegar só compensa a partir de ~40k
+#     tokens — abaixo disso o certo é recortar (rg + offset/limit), de graça.
+#     A 1ª versão do hook mandava delegar já a partir de 10k, conselho que PERDIA
+#     dinheiro na maioria dos disparos. Marcadores ASCII em CAIXA FIXA ("SE PAGA"
+#     / "PERDE"), sem -i: prosa acentuada casaria o ramo errado sob pt_BR (#1483).
+grande_out="$(run "$grande" s6c)"          # ~111k tok → faixa do subagente
+peq_out="$(run "$grande" s6d 50)"          # ~13k tok  → faixa do recorte
+if tem "SE PAGA" "$grande_out" && ! tem "PERDE" "$grande_out"
+then ok "leitura >=40k: conselho é DELEGAR (o subagente se paga)"
+else bad "leitura de 111k deveria recomendar subagente (veio: '${grande_out:0:80}')"; fi
+
+if tem "PERDE" "$peq_out" && ! tem "SE PAGA" "$peq_out"
+then ok "leitura 10-40k: conselho é RECORTAR (delegar perderia dinheiro)"
+else bad "leitura de 13k deveria desaconselhar subagente (veio: '${peq_out:0:80}')"; fi
+
 # 7. o teto de 2000 linhas do Read entra na conta: arquivo de linhas CURTAS cujo
 #    total passa de 10k tok, mas cujas 2000 primeiras linhas não → silêncio.
 curto="$tmp/muitas-linhas-curtas.ts"; : > "$curto"

--- a/scripts/test-stop-contexto-caro.sh
+++ b/scripts/test-stop-contexto-caro.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
 # test-stop-contexto-caro.sh — TDD do hook .claude/hooks/stop-contexto-caro.sh
 #
-# Regra: contexto da sessão >= 250k tokens-OPUS → emite systemMessage (aviso), UMA
-# VEZ por degrau (250/350/500/700k). Abaixo do degrau, transcript ausente ou sem
-# usage → silêncio (exit 0). NUNCA bloqueia (não emite decision:block).
+# Regra: contexto da sessão >= 150k tokens-OPUS → emite systemMessage (aviso), UMA
+# VEZ por degrau (150/250/350/500/700k). Abaixo do degrau, transcript ausente ou
+# sem usage → silêncio (exit 0). NUNCA bloqueia (não emite decision:block).
+#
+# O primeiro degrau era 250k e virou 150k em 2026-08-06: medido sobre dados já
+# deduplicados, 250k avisava com 29,1% do custo da sessão JÁ gasto e deixava 16
+# sessões caras mudas (5,3% da semana); 150k cobre 98,8% do custo, avisa com
+# 16,2% gasto e o ruído medido é ZERO (nenhuma sessão trivial chega a 150k, pois
+# o piso já é ~81k). Detalhe em docs/historico/piso-de-contexto.md.
 #
 # "tokens-OPUS" = o degrau é de CUSTO, não de token cru: o contexto é multiplicado
 # pelo preço da família do modelo sobre o do Opus (a referência da calibração).
-# Fable custa 2x → avisa na METADE do contexto (125k); Haiku custa 1/5 → 1,25M.
+# Fable custa 2x → avisa na METADE do contexto (75k); Haiku custa 1/5 → 750k.
 #
 # Uso: bash scripts/test-stop-contexto-caro.sh   (exit 0 = verde)
 set -u
@@ -99,36 +105,85 @@ check "transcript sem usage → silêncio" silencio "$(run "$tmp/t4.jsonl" s4)"
 # 10. FALSIFICAÇÃO — o teste precisa saber ficar vermelho. Um hook que avisasse
 #     SEMPRE passaria nos casos 2/6/7; é o caso 1 (silêncio abaixo do degrau)
 #     que separa "funciona" de "grita sempre". Confirma que aquele caso é real:
-mk_transcript "$tmp/t5.jsonl" 249000 3
+mk_transcript "$tmp/t5.jsonl" 149000 3
 saida_abaixo="$(run "$tmp/t5.jsonl" s5)"
 if [ -z "$saida_abaixo" ]
-then ok "falsificação: 249k (1 abaixo do degrau) permanece em silêncio"
-else bad "falsificação: avisou a 249k — o degrau não está sendo respeitado"; fi
+then ok "falsificação: 149k (1 abaixo do degrau) permanece em silêncio"
+else bad "falsificação: avisou a 149k — o degrau não está sendo respeitado"; fi
+
+# 10b. 150k e 250k são degraus SEPARADOS: cruzar o primeiro não consome o segundo.
+#      Sem isto, colar um degrau novo no topo da escada poderia calar o antigo.
+mk_transcript "$tmp/t6.jsonl" 160000 3
+check "cruzou o degrau novo de 150k → avisa" msg "$(run "$tmp/t6.jsonl" s6)"
+mk_transcript "$tmp/t7.jsonl" 260000 5
+check "mesma sessão sobe 150k→250k → avisa DE NOVO (degraus separados)" msg "$(run "$tmp/t7.jsonl" s6)"
 
 echo "== degrau normalizado por CUSTO (o degrau é em tokens-Opus) =="
 
 # 11. Opus explícito: fator 1 → os degraus calibrados ficam INTACTOS (não-regressão)
 mk_transcript "$tmp/o1.jsonl" 260000 5 claude-opus-5
 check "opus 260k → avisa (fator 1, degrau intacto)" msg "$(run "$tmp/o1.jsonl" so1)"
-mk_transcript "$tmp/o2.jsonl" 240000 5 claude-opus-5
-check "opus 240k → silêncio (fator 1, degrau intacto)" silencio "$(run "$tmp/o2.jsonl" so2)"
+mk_transcript "$tmp/o2.jsonl" 140000 5 claude-opus-5
+check "opus 140k → silêncio (fator 1, degrau intacto)" silencio "$(run "$tmp/o2.jsonl" so2)"
 
-# 12. Fable custa 2x → 130k de contexto = 260k tokens-Opus, cruza o degrau
-mk_transcript "$tmp/f1.jsonl" 130000 5 claude-fable-5
+# 12. Fable custa 2x → 80k de contexto = 160k tokens-Opus, cruza o degrau novo
+mk_transcript "$tmp/f1.jsonl" 80000 5 claude-fable-5
 out_fable="$(run "$tmp/f1.jsonl" sf1)"
-check "fable 130k → avisa (=260k tokens-Opus, metade do caminho)" msg "$out_fable"
+check "fable 80k → avisa (=160k tokens-Opus, metade do caminho)" msg "$out_fable"
 
-# 13. FALSIFICAÇÃO da normalização: 120k em Fable = 240k tokens-Opus, ABAIXO do
+# 13. FALSIFICAÇÃO da normalização: 70k em Fable = 140k tokens-Opus, ABAIXO do
 #     degrau. Sem a conversão o hook ficaria mudo aqui e no caso 12 — este par é
 #     o que separa "normalizou por preço" de "só baixou o degrau para todo mundo".
-mk_transcript "$tmp/f2.jsonl" 120000 5 claude-fable-5
+#     O par está colado na fronteira (70k/80k) de propósito: é onde a conversão
+#     decide, e um par frouxo passaria mesmo com o fator errado.
+mk_transcript "$tmp/f2.jsonl" 70000 5 claude-fable-5
 if [ -z "$(run "$tmp/f2.jsonl" sf2)" ]
-then ok "falsificação: fable 120k (=240k tokens-Opus) permanece em silêncio"
-else bad "falsificação: avisou a 120k em fable — o degrau virou 120k para todos"; fi
+then ok "falsificação: fable 70k (=140k tokens-Opus) permanece em silêncio"
+else bad "falsificação: avisou a 70k em fable — o degrau virou 70k para todos"; fi
 
 # 14. Haiku custa 1/5 do Opus → 600k de contexto ainda é só 120k tokens-Opus
 mk_transcript "$tmp/h1.jsonl" 600000 5 claude-haiku-4-5-20251001
 check "haiku 600k → silêncio (=120k tokens-Opus)" silencio "$(run "$tmp/h1.jsonl" sh1)"
+
+echo "== custo estimado conta REQUEST, não linha do transcript =="
+
+# Uma resposta com vários blocos vira várias linhas no JSONL repetindo o MESMO
+# usage. O hook contava linhas (`grep -c '"usage"'`) e inflava o US$ em ~2,2x —
+# a mesma dupla contagem que o tokens-report.sh tinha. Aqui: dois transcripts com
+# o MESMO nº de linhas e o MESMO contexto, um com 1 requestId e outro com 12.
+mk_req() {  # $1=arquivo $2=cache_read final $3=nº linhas $4=modo(mesmo|distinto)
+  local f="$1" ctx="$2" n="$3" modo="$4" k=1 rid
+  : > "$f"
+  while [ "$k" -lt "$n" ]; do
+    [ "$modo" = mesmo ] && rid="req_UNICO" || rid="req_$k"
+    printf '{"type":"assistant","requestId":"%s","message":{"usage":{"input_tokens":4,"cache_creation_input_tokens":100,"cache_read_input_tokens":1000}}}\n' "$rid" >> "$f"
+    k=$(( k + 1 ))
+  done
+  [ "$modo" = mesmo ] && rid="req_UNICO" || rid="req_FINAL"
+  printf '{"type":"assistant","requestId":"%s","message":{"usage":{"input_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":%s}}}\n' "$rid" "$ctx" >> "$f"
+}
+usd() { printf '%s' "$1" | command grep -o 'US\$ [0-9]*' | command head -1 | command tr -cd '0-9'; }
+
+mk_req "$tmp/r1.jsonl" 300000 12 mesmo
+mk_req "$tmp/r2.jsonl" 300000 12 distinto
+u1="$(usd "$(run "$tmp/r1.jsonl" sr1)")"
+u2="$(usd "$(run "$tmp/r2.jsonl" sr2)")"
+# 12 linhas / 1 request vs 12 linhas / 12 requests: o 2º tem de custar MAIS.
+# Se o hook contasse linhas, os dois dariam o mesmo número.
+if [ -n "$u1" ] && [ -n "$u2" ] && [ "$u2" -gt "$u1" ]; then
+  ok "12 linhas com 1 requestId estimam MENOS que 12 requests distintos (US\$ $u1 < $u2)"
+else
+  bad "estimativa ignorou o requestId (US\$ '$u1' vs '$u2' — esperava o 1º menor)"
+fi
+
+# FALSIFICAÇÃO: transcript SEM requestId (formato antigo) não pode zerar o aviso
+# — o fallback para contagem de linhas tem de manter a mensagem de pé.
+mk_transcript "$tmp/r3.jsonl" 300000 12
+if printf '%s' "$(run "$tmp/r3.jsonl" sr3)" | command grep -q 'systemMessage'; then
+  ok "falsificação: transcript sem requestId ainda avisa (fallback de linhas)"
+else
+  bad "sem requestId o hook emudeceu — o fallback não segurou"
+fi
 
 echo "== nota de modelo (só quando o modelo custa mais que a referência) =="
 


### PR DESCRIPTION
Follow-up do #1666. Com a régua consertada dá para perguntar o que antes não se podia — e **as duas mudanças que eu ia implementar foram refutadas pela medição**. O que sobrou é o oposto do que a intuição escreveria.

## C1 — "delegar leitura a subagente economiza": errado abaixo de 40k

Medido sobre **277 invocações** do histórico: um subagente custa **US$ 1,06 na mediana** (p75 1,98 · p90 3,62 · máx 10,46 · 19 requests em média) e devolve ~780 tokens (p50 273). Manter T tokens no contexto custa `T × requests_restantes × US$0,50/MTok`. Delegar só compensa quando:

> **T > 780 + 1,06 × 2.000.000 / requests_restantes**

| requests restantes | leitura precisa ter |
|---|---|
| 50 | ~43k tokens |
| 100 | ~22k |
| 200 | ~11k |
| 400 | ~6k |

O `read-contexto-nudge.sh` mandava delegar **a partir de 10k** — que só se paga com ~200 requests pela frente, enquanto as sessões caras deste parque vivem na faixa de 50-299. **Na maioria dos disparos o conselho perdia dinheiro.**

Agora: **≥40k** recomenda subagente (aí se paga em ~30 turnos); **10-40k** recomenda **recorte** (`rg` + `offset/limit`), que é gratuito.

O erro de origem foi comparar a coisa errada: *"o subagente devolve 638 tokens contra 2.058 de um Read"* é verdade e é irrelevante — o que importa não é o que ele devolve, é **quanto ele cobra para rodar**, e isso ninguém tinha medido.

## B1 — "o aviso dispara tarde demais": refutado, mas achou outra coisa

A métrica certa não é em que contexto dispara, é **quanto do custo da sessão já foi gasto** quando dispara:

| degrau | sessões | % do custo coberto | % já gasto | triviais atingidas |
|---|---|---|---|---|
| 120k | 46 | 99,1% | 12,3% | **0** |
| **150k** | **44** | **98,8%** | **16,2%** | **0** |
| 250k (era) | 35 | 94,3% | 29,1% | 0 |

A 250k o aviso chega com **71% do custo ainda pela frente** — não era tarde. O problema real era outro: **16 sessões caras nunca eram avisadas** (ctx_max 159k-248k, US$ 85 = 5,3% da semana).

Primeiro degrau desceu para **150k**: cobre 98,8%, dobra a alavanca, e o ruído medido é **zero** — com piso de ~81k, nenhuma sessão trivial chega a 150k. 120k cobriria marginalmente mais, mas fica a 39k do piso: avisaria antes de haver o que dividir.

### Colateral: o hook tinha o mesmo bug da régua

`grep -c '"usage"'` conta **linha, não request**, e o divisor `0.52` fora calibrado contra o custo igualmente inflado — dois erros que se cancelavam e produziam um "7% de erro" ilusório. **O US$ exibido estava ~1,6× alto.** Agora conta `requestId` distinto (`awk '!a[$0]++'`, uma passada, sem ordenar 70MB) e usa 0,701.

## Prova

**52 asserções verdes** em `LC_ALL=C` **e** `pt_BR.UTF-8` (23 stop + 19 read + 10 tokens). `shellcheck` limpo em todos os hooks e scripts.

Casos novos:
- degrau de 150k avisa; **150k e 250k são degraus separados** (colar degrau novo no topo não pode calar o antigo)
- par de falsificação da normalização por preço **colado na fronteira** (fable 70k/80k — um par frouxo passaria com o fator errado)
- estimativa conta `requestId` distinto, não linha
- fallback sem `requestId` não emudece o aviso
- o conselho **muda de lado** no break-even (marcadores ASCII caixa-fixa `SE PAGA` / `PERDE`, sem `-i`)

Falsificado por sabotagem **semântica**, não sintática — a primeira tentativa quebrou a sintaxe do script e ficou vermelha pelo motivo errado, o que não prova nada. As 3 mutações válidas (remover o degrau de 150k; trocar o dedupe por `cat`; baixar o conselho de delegar para 10k) ficaram vermelhas na asserção certa, e a restauração voltou verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)