### PR TITLE
fix(docs): índice de docs para de apodrecer em silêncio — gate estrutural

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,19 @@ jobs:
       - name: Bun pin gate check (semver estrito x.y.z)
         run: bun run bunpin:check
 
+      # Anti-regressão do ÍNDICE dos diretórios de docs que têm README (hoje `docs/historico/` e
+      # `docs/runbooks/`). Doc sem linha no índice — ou linha apontando para arquivo que sumiu — é
+      # bug SILENCIOSO por construção: o arquivo existe, o CI passa, e ninguém o encontra. Medido:
+      # o #1658 reconciliou o índice do histórico à mão (9 arquivos invisíveis, metade do histórico
+      # recente) e HORAS depois o #1659 — uma PR de FEATURE que só por acaso escreveu um doc — já
+      # reintroduziu um. A convenção textual ("registre aqui") existia o tempo todo. Gate de
+      # PRECISÃO: só diretório COM README (ter README é a declaração de "aqui há índice");
+      # `docs/agent/` fica fora porque quem o indexa é a tabela do CLAUDE.md, que enumera DOMÍNIOS —
+      # review.md/threat-model-template.md/csv-governo-br.md são sub-docs alcançáveis a um salto e
+      # seriam 3 falsos-positivos permanentes. Estático: lê docs/, sem rede.
+      - name: Docs índice gate (nenhum doc invisível)
+        run: bun run docs:indice
+
       # ─── Alerta de regressão (Componente 1 — mitigação de reversão Lovable) ──
       # O bot do Lovable commita DIRETO na main sem PR/CI; quando quebra build/
       # typecheck (ex.: types.ts stale #1079), o CI fica vermelho mas passa

--- a/docs/historico/README.md
+++ b/docs/historico/README.md
@@ -4,6 +4,8 @@ Registro consultável de **PRs/bugs/programas/auditorias já entregues** — a n
 
 **Não é lido a cada sessão** — o CLAUDE.md ficou só com regras vivas. Venha aqui quando precisar do **detalhe/contexto** de uma entrega. Ao concluir uma entrega nova, **registre aqui** (não no CLAUDE.md).
 
+> 🚦 **A tabela abaixo é GATEADA** (`scripts/docs-indice-gate-check.ts`, dentro do `bun run test`): `.md` neste diretório sem linha na tabela — ou linha apontando para arquivo que não existe — deixa o CI **vermelho**. Não é burocracia: a frase acima já existia e o índice apodreceu duas vezes — o #1658 reconciliou **9 arquivos invisíveis** e horas depois o #1659 (uma PR de feature) reintroduziu um. Contramedida textual reincide; gate estrutural para. Vale igual para `docs/runbooks/`.
+
 | Arquivo | O que tem |
 | --- | --- |
 | [bugs-resolvidos.md](bugs-resolvidos.md) | (era §10) cada bug/contradição/débito resolvido, com PR + lição (multi-domínio: KB, Radar, reposição, sync…) |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -2,6 +2,9 @@
 
 Passo-a-passo estável pra tocar áreas sensíveis. **Leia o runbook relevante ANTES de agir.** As REGRAS-chave estão destiladas no CLAUDE.md (§0 Armadilhas + §5 "Banco & deploy"); aqui fica o detalhe operacional completo.
 
+> 🚦 **A tabela abaixo é GATEADA** (`scripts/docs-indice-gate-check.ts`, dentro do `bun run test`): runbook sem linha aqui — ou linha apontando para arquivo que não existe — deixa o CI **vermelho**. O `tint-sync-corte-csv.md` viveu fora do índice **sem um único link no repo inteiro**: existia e era inalcançável.
+
 | Runbook | Quando ler |
 | --- | --- |
 | [lovable-supabase.md](lovable-supabase.md) | tocar **banco, migration, edge function, deploy do frontend, cron, schema** no Lovable/Supabase |
+| [tint-sync-corte-csv.md](tint-sync-corte-csv.md) | **aposentar o CSV manual** do catálogo tintométrico e ligar o sync SayerSystem em tempo real (faxina → re-scan → reconciliação → flip). ⚠️ money-path: o **flip** é a operação de risco — só depois da reconciliação provar divergência ~zero |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "audit:migrations": "bun scripts/audit-custom-migrations.ts",
     "authz:check": "bun scripts/authz-gate-check.ts",
     "bunpin:check": "bun scripts/bun-pin-gate-check.ts",
+    "docs:indice": "bun scripts/docs-indice-gate-check.ts",
     "mutcheck": "bash scripts/mutcheck-all.sh",
     "mutcheck:selftest": "bash scripts/mutcheck.sh --selftest",
     "wt": "bash scripts/new-worktree.sh",

--- a/scripts/docs-indice-gate-check.test.ts
+++ b/scripts/docs-indice-gate-check.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  auditarIndices,
+  type DirIndice,
+  lerDiretoriosIndexados,
+  linksDoIndice,
+} from './docs-indice-gate-check';
+
+/** Índice mínimo no formato real (tabela de duas colunas com link relativo). */
+function indice(...linhas: string[]): string {
+  return `# docs/x/ — diário\n\n| Arquivo | O que tem |\n| --- | --- |\n${linhas.join('\n')}\n`;
+}
+const linha = (f: string) => `| [${f}](${f}) | descrição |`;
+
+const dir = (readme: string, arquivos: string[]): DirIndice[] => [
+  { dir: 'docs/x', readme, arquivos },
+];
+
+const msgs = (a: ReturnType<typeof auditarIndices>) => a.map((f) => f.msg).join(' | ');
+
+describe('auditarIndices — invariante 1: arquivo ÓRFÃO (o bug do #1659)', () => {
+  it('passa quando todo arquivo está no índice', () => {
+    expect(auditarIndices(dir(indice(linha('a.md'), linha('b.md')), ['a.md', 'b.md']))).toHaveLength(0);
+  });
+
+  it('FALHA com um arquivo fora do índice — a forma exata do #1659', () => {
+    const a = auditarIndices(dir(indice(linha('a.md')), ['a.md', 'programa-cabreuva-colacor.md']));
+    expect(a).toHaveLength(1);
+    expect(a[0].arquivo).toBe('programa-cabreuva-colacor.md');
+    expect(a[0].level).toBe('error');
+  });
+
+  it('FALHA com os 9 invisíveis que o #1658 reconciliou à mão', () => {
+    const nove = [
+      'auditoria-health-2026-07-06.md',
+      'ci-testes-edge-deno.md',
+      'melhorias-code-2026-07.md',
+      'modularizacao.md',
+      'pcp.md',
+      'piso-de-contexto.md',
+      'reposicao-embalagem-captura.md',
+      'revisao-completa-2026-07-04.md',
+      'setup-agente.md',
+    ];
+    expect(auditarIndices(dir(indice(linha('a.md')), ['a.md', ...nove]))).toHaveLength(9);
+  });
+
+  // A mensagem tem de dizer por que o CI estava VERDE — senão quem lê acha que é falha de build.
+  it('a mensagem explica que o doc fica INVISÍVEL e diz onde consertar', () => {
+    const a = auditarIndices(dir(indice(linha('a.md')), ['a.md', 'novo.md']));
+    expect(a[0].msg).toContain('invisível');
+    expect(a[0].msg).toContain('docs/x/README.md');
+  });
+});
+
+describe('auditarIndices — invariante 2: LINK QUEBRADO (a direção oposta)', () => {
+  it('FALHA quando o índice aponta para arquivo que não existe', () => {
+    const a = auditarIndices(dir(indice(linha('a.md'), linha('sumiu.md')), ['a.md']));
+    expect(a).toHaveLength(1);
+    expect(a[0].arquivo).toBe('sumiu.md');
+    expect(a[0].msg).toContain('NÃO existe');
+  });
+
+  it('renomeação pela metade acusa NOS DOIS lados (órfão + link quebrado)', () => {
+    const a = auditarIndices(dir(indice(linha('nome-velho.md')), ['nome-novo.md']));
+    expect(a).toHaveLength(2);
+    expect(msgs(a)).toContain('nome-novo.md');
+    expect(msgs(a)).toContain('nome-velho.md');
+  });
+});
+
+describe('linksDoIndice — o que conta como "indexado"', () => {
+  it('aceita `](x.md)` e `](./x.md)`', () => {
+    expect(linksDoIndice('[a](a.md) [b](./b.md)')).toEqual(new Set(['a.md', 'b.md']));
+  });
+
+  // Linkar a seção certa de um doc longo é uso normal de markdown; sem a âncora opcional o gate
+  // acusaria "órfão" um arquivo que ESTÁ indexado — o falso-positivo mais provável desta regra.
+  it('aceita âncora: `](x.md#secao)` indexa x.md', () => {
+    expect(linksDoIndice('[a](a.md#o-achado) [b](./b.md#fases)')).toEqual(new Set(['a.md', 'b.md']));
+  });
+
+  it('arquivo com âncora não vira órfão', () => {
+    expect(auditarIndices(dir(indice('| [a](a.md#topo) | d |'), ['a.md']))).toHaveLength(0);
+  });
+
+  // Link para FORA do diretório não indexa o arquivo local: o índice de um diretório só responde
+  // pelos arquivos dele, e casar `../agent/x.md` como `x.md` daria indexação fantasma.
+  it('IGNORA link para outro diretório e para a web', () => {
+    const s = linksDoIndice('[a](../agent/a.md) [b](https://ex.com/b.md) [c](docs/historico/c.md)');
+    expect(s.size).toBe(0);
+  });
+
+  it('README sem link nenhum não indexa nada (não vira passe-livre)', () => {
+    expect(linksDoIndice('# só prosa, zero tabela').size).toBe(0);
+  });
+});
+
+describe('lerDiretoriosIndexados — descoberta', () => {
+  // Ter README É a declaração de "aqui há índice"; sem README o diretório não promete nada.
+  it('só devolve diretório de docs/ que TEM README.md', () => {
+    const dirs = lerDiretoriosIndexados();
+    for (const d of dirs) expect(d.dir).toMatch(/^docs\//);
+    const nomes = dirs.map((d) => d.dir);
+    expect(nomes).toContain('docs/historico');
+    expect(nomes).toContain('docs/runbooks');
+    // docs/agent NÃO entra: quem o indexa é a tabela do CLAUDE.md, e ela enumera DOMÍNIOS —
+    // review.md/threat-model-template.md/csv-governo-br.md são sub-docs alcançáveis a um salto.
+    expect(nomes).not.toContain('docs/agent');
+  });
+
+  it('raiz inexistente devolve lista vazia em vez de estourar', () => {
+    expect(lerDiretoriosIndexados('nao-existe-xyz')).toEqual([]);
+  });
+});
+
+describe('o repo de verdade', () => {
+  it('os índices REAIS do repo passam no gate', () => {
+    const achados = auditarIndices(lerDiretoriosIndexados());
+    expect(achados, `gate vermelho no repo: ${msgs(achados)}`).toHaveLength(0);
+  });
+
+  // ⚠️ Guarda ANTI-VÁCUO. Sem ela, um glob que para de casar (ou um `docs/` renomeado) faz o gate
+  // acima passar por não achar NADA — "verde por ausência de dado", a mesma família do "glob de
+  // teste que não casa nada sai 0 e parece verde" já registrado em ci-testes-edge-deno.md.
+  it('o gate de fato ENCONTRA os índices (não passa à toa, sem achar ocorrência nenhuma)', () => {
+    const dirs = lerDiretoriosIndexados();
+    expect(dirs.length).toBeGreaterThanOrEqual(2);
+    const total = dirs.reduce((n, d) => n + d.arquivos.length, 0);
+    expect(total).toBeGreaterThanOrEqual(20);
+  });
+});

--- a/scripts/docs-indice-gate-check.ts
+++ b/scripts/docs-indice-gate-check.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env bun
+/**
+ * docs-indice-gate-check.ts — gate de CI que prova que nenhum doc fica INVISÍVEL no índice.
+ * ============================================================================================
+ *
+ * A classe: diretório de docs cujo `README.md` se declara índice, com o índice mantido À MÃO.
+ * Adicionar um `.md` sem a linha correspondente é o bug — e ele é SILENCIOSO por construção: o
+ * arquivo existe, o CI fica verde, e o doc simplesmente não é encontrado por quem depende do
+ * índice. `docs/historico/README.md` diz de si mesmo "Ao concluir uma entrega, registre aqui" —
+ * convenção textual, sem nada que a segure.
+ *
+ * Por que um gate e não (mais) uma frase no README: medido neste repo. O PR #1658 reconciliou o
+ * índice do histórico — **9 arquivos invisíveis, metade do histórico recente**. Horas depois, no
+ * mesmo dia, o #1659 (uma PR de FEATURE, que só por acaso escreveu um doc) adicionou
+ * `programa-cabreuva-colacor.md` sem linha nenhuma, e o índice voltou a mentir. Uma reconciliação
+ * manual conserta o estado; ela não conserta a CLASSE, e a classe reincidiu em horas. É a
+ * meta-regra do catálogo de retrabalho: contramedida textual reincide, gate estrutural para.
+ *
+ * O gate é de PRECISÃO, não de recall (mesma doutrina do `edges:typecheck`): só olha diretório que
+ * TEM `README.md`, porque ter um README é a declaração de "aqui existe índice". `docs/agent/` fica
+ * de fora de propósito — a tabela que o indexa vive no CLAUDE.md e enumera DOMÍNIOS, não arquivos:
+ * `review.md`, `threat-model-template.md` e `csv-governo-br.md` são sub-documentos alcançáveis a um
+ * salto (de `money-path.md`/`skills.md`) e seriam três falsos-positivos permanentes. Gate que nasce
+ * com exceção é gate que treina a ignorar o vermelho.
+ *
+ * Duas invariantes, as duas direções da mesma mentira:
+ *  1. ÓRFÃO — arquivo existe e o índice não o lista (o bug do #1659).
+ *  2. LINK QUEBRADO — o índice lista e o arquivo não existe (renomeação/remoção pela metade).
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface DirIndice {
+  /** caminho do diretório, relativo à raiz do repo (ex.: 'docs/historico') */
+  dir: string;
+  /** conteúdo do README.md que serve de índice */
+  readme: string;
+  /** nomes dos `.md` irmãos, SEM o README.md */
+  arquivos: string[];
+}
+
+export interface Achado {
+  level: 'error';
+  dir: string;
+  arquivo: string;
+  msg: string;
+}
+
+/**
+ * Links markdown para irmãos do MESMO diretório: `](x.md)`, `](./x.md)`, `](x.md#secao)`.
+ *
+ * Não casa `](../agent/x.md)` nem `](https://…)` de propósito — o índice de um diretório só
+ * responde pelos arquivos dele, e link para fora não conta como "este arquivo está indexado".
+ *
+ * A âncora opcional (`#secao`) é o que impede o falso-positivo mais provável: linkar a seção certa
+ * de um doc longo é uso NORMAL de markdown, e sem o `(?:#…)?` o gate acusaria "órfão" um arquivo
+ * que está indexado. Gate que grita errado é gate que treina a ignorar o vermelho.
+ */
+const LINK_IRMAO = /\]\(\.?\/?([A-Za-z0-9._-]+\.md)(?:#[^)]*)?\)/g;
+
+export function linksDoIndice(readme: string): Set<string> {
+  return new Set(Array.from(readme.matchAll(LINK_IRMAO), (m) => m[1]));
+}
+
+export function auditarIndices(dirs: DirIndice[]): Achado[] {
+  const achados: Achado[] = [];
+  for (const { dir, readme, arquivos } of dirs) {
+    const linkados = linksDoIndice(readme);
+
+    for (const arquivo of arquivos) {
+      if (linkados.has(arquivo)) continue;
+      achados.push({
+        level: 'error',
+        dir,
+        arquivo,
+        msg:
+          `${dir}/${arquivo} existe e NÃO está no índice ${dir}/README.md — o doc fica invisível ` +
+          `para quem procura pelo índice (o CI passa, e ninguém acha o arquivo). Acrescente a linha ` +
+          `na tabela do README, com uma descrição do que o doc tem.`,
+      });
+    }
+
+    for (const link of linkados) {
+      if (arquivos.includes(link)) continue;
+      achados.push({
+        level: 'error',
+        dir,
+        arquivo: link,
+        msg:
+          `${dir}/README.md aponta para ${link}, que NÃO existe — renomeação ou remoção feita pela ` +
+          `metade. Corrija o link ou remova a linha.`,
+      });
+    }
+  }
+  return achados;
+}
+
+/** Descobre todo subdiretório de `docs/` que tenha `README.md` — ter README É a declaração de "aqui há índice". */
+export function lerDiretoriosIndexados(raiz = 'docs'): DirIndice[] {
+  if (!existsSync(raiz)) return [];
+  return readdirSync(raiz, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => join(raiz, e.name))
+    .filter((dir) => existsSync(join(dir, 'README.md')))
+    .map((dir) => ({
+      dir,
+      readme: readFileSync(join(dir, 'README.md'), 'utf8'),
+      arquivos: readdirSync(dir)
+        .filter((f) => f.endsWith('.md') && f !== 'README.md')
+        .sort(),
+    }));
+}
+
+if (import.meta.main) {
+  const achados = auditarIndices(lerDiretoriosIndexados());
+  if (achados.length === 0) {
+    console.log('docs-indice-gate: ✓ todo doc de diretório indexado está no índice.');
+    process.exit(0);
+  }
+  for (const a of achados) console.error(`✗ ${a.msg}`);
+  console.error(`\ndocs-indice-gate: ${achados.length} problema(s).`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Instância única ou classe?

**Classe** — e esta sessão produziu a prova enquanto a PR era escrita.

| Quando | O quê |
|---|---|
| #1658 | reconcilia o índice do histórico à mão — **9 arquivos invisíveis**, metade do histórico recente |
| #1659 | PR de **feature**, que só por acaso escreveu um doc, reintroduz 1 órfão |
| #1665 | reconcilia **de novo**, à mão, sem gate |

Três reconciliações manuais e duas reincidências em ~24h, contra uma contramedida **textual** (*"Ao concluir uma entrega, registre aqui"*) que estava lá o tempo todo. É a meta-regra do catálogo de retrabalho deste repo: contramedida textual reincide, gate estrutural para.

O bug é silencioso **por construção**: o arquivo existe, o CI passa, e ninguém o encontra.

## Assinatura, calibrada com controle pré/pós-fix

```
comm -23 <(.md do diretório) <(links do README)

pré-fix (e74c16d9, antes do #1658) → 9   ← exatamente os 9 que ele consertou
pós-fix (8af4e925, o #1658)        → 0
no momento da varredura            → 1   ← a reincidência do #1659
```

## Varredura do repo, com veredito por site

| Site | Veredito |
|---|---|
| `docs/runbooks/tint-sync-corte-csv.md` | **AFETADO** — órfão **total**: zero links no repo inteiro. Existia e era inalcançável. Corrigido aqui |
| `docs/historico/programa-cabreuva-colacor.md` | **AFETADO** na varredura; fechado pelo #1665 em paralelo (mantive a linha dele no rebase — mesma substância) |
| `docs/agent/review.md` | falso-positivo — alcançável via `money-path.md` |
| `docs/agent/threat-model-template.md` | falso-positivo — via `money-path.md` + 2 specs |
| `docs/agent/csv-governo-br.md` | falso-positivo — via `skills.md` |

Os três de `docs/agent/` são falso-positivo da assinatura ingênua: quem indexa aquele diretório é a tabela do CLAUDE.md, que enumera **domínios**, não arquivos. Por isso o gate **não** os cobre — **precisão, não recall**, a mesma doutrina do `edges:typecheck`. Um diretório entra no gate por **ter README**: ter README é a declaração de "aqui há índice".

## O gate

`scripts/docs-indice-gate-check.ts` — as duas direções da mesma mentira: arquivo órfão, e link apontando para arquivo que sumiu (renomeação pela metade). Roda no vitest (step já bloqueante) **e** como step nomeado `docs:indice`, seguindo a convenção de `authz:check`/`bunpin:check`.

**Falsificado no FS real**, não só em fixture: verde → *(doc novo sem linha)* **vermelho** → *(linha para arquivo inexistente)* **vermelho** → verde. E antes do fix ele acusou sozinho, pelo nome, os 2 sites que a varredura tinha achado.

Dois detalhes que evitam o gate virar decoração:

- **Guarda anti-vácuo** (≥2 diretórios, ≥20 arquivos): sem ela, um glob que para de casar faz o gate passar por não achar **nada** — "verde por ausência de dado", a mesma família do *glob de teste que não casa nada* já registrado em `ci-testes-edge-deno.md`.
- **Regex aceita âncora** (`](x.md#secao)`): linkar a seção de um doc longo é uso normal de markdown, e sem isso o gate acusaria órfão um arquivo que **está** indexado. Gate que grita errado treina a ignorar o vermelho.

## Evidência

```
heavy bun run typecheck   → exit 0 (0 erros TS)
bun lint            → exit 0 (0 errors; 72 warnings pré-existentes)
vitest do gate      → 15/15, exit 0
bun run docs:indice → exit 0
```

Sem deploy: docs, um script de gate e um step de CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)