### PR TITLE
feat(estoque): ATP fase 1 — reservas de estoque + RPC atômica fail-closed [money-path]

### DIFF
--- a/db/test-atp-reserva-estoque-fase1.sh
+++ b/db/test-atp-reserva-estoque-fase1.sh
@@ -1,0 +1,639 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — ATP/reserva de estoque FASE 1 (money-path)                       ║
+# ║  Migration: 20260806101417_atp_reserva_estoque_fase1.sql                       ║
+# ║                                                                                ║
+# ║  Invariantes provados:                                                         ║
+# ║   • disponivel = saldo_confiavel − reservas_ativas − estoque_seguranca         ║
+# ║   • FAIL-CLOSED: sem linha / stale >24h / saldo NULL/negativo/NaN → recusa     ║
+# ║   • pool 'oben' = eleição por frescor SÓ entre accounts 'vendas'/'oben'        ║
+# ║   • re-reserva do mesmo checkout SUBSTITUI (idempotente), não soma             ║
+# ║   • multi-item all-or-nothing; reserva vencida não desconta; liberar devolve   ║
+# ║   • gate staff/service (42501); contrato 22023/23514; RLS; escrita só via RPC  ║
+# ║   • concorrência: 2 conexões no mesmo saldo → exatamente 1 vence               ║
+# ║  Falsificações F1..F5 sabotam a migration e EXIGEM o vermelho correspondente.  ║
+# ║                                                                                ║
+# ║  Veredito por byte-compare do bash (eq) com sentinelas ASCII exclusivas do     ║
+# ║  teste — nenhum grep -i, nenhum acento no caminho de decisão → imune à dobra   ║
+# ║  de locale (C × pt_BR.UTF-8) que mordeu o #1483.                               ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="atp-fase1"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ERR $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup pronto (PG17 :$PORT) ==="
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migration LÊ/referencia mas não cria)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+GRANT USAGE ON SCHEMA private TO authenticated, service_role;
+
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('master','employee','customer');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.user_roles (
+  user_id uuid NOT NULL,
+  role public.app_role NOT NULL
+);
+
+-- espelho fiel do has_role de prod (SECDEF STABLE lendo user_roles)
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $f$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $f$;
+
+-- colunas reais de prod que o cálculo usa (schema conferido via psql-ro 2026-08-06)
+CREATE TABLE IF NOT EXISTS public.inventory_position (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  omie_codigo_produto bigint NOT NULL,
+  account text NOT NULL DEFAULT 'vendas',
+  saldo numeric DEFAULT 0,
+  cmc numeric DEFAULT 0,
+  synced_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.sku_parametros (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa text NOT NULL,
+  sku_codigo_omie bigint NOT NULL,
+  estoque_seguranca numeric
+);
+
+CREATE TABLE IF NOT EXISTS public.sales_orders (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  checkout_id uuid,
+  account text
+);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATION REAL
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260806101417_atp_reserva_estoque_fase1.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS + GRANTS
+# ══════════════════════════════════════════════════════════════════════════════
+STAFF='22222222-2222-2222-2222-222222222222'
+MASTER='33333333-3333-3333-3333-333333333333'
+CUST='44444444-4444-4444-4444-444444444444'
+CK_A='aaaaaaa1-0000-0000-0000-000000000001'
+CK_B='aaaaaaa1-0000-0000-0000-000000000002'
+CK_C='aaaaaaa1-0000-0000-0000-000000000003'
+CK_D='aaaaaaa1-0000-0000-0000-000000000004'
+CK_K1='aaaaaaa1-0000-0000-0000-00000000000a'
+CK_K2='aaaaaaa1-0000-0000-0000-00000000000b'
+
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$STAFF'), ('$MASTER'), ('$CUST') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES
+  ('$STAFF', 'employee'), ('$MASTER', 'master'), ('$CUST', 'customer');
+
+INSERT INTO public.inventory_position (omie_codigo_produto, account, saldo, synced_at) VALUES
+  (1001, 'vendas',         100,  now() - interval '1 hour'),   -- eleita (mais fresca DO POOL)
+  (1001, 'oben',           999,  now() - interval '30 days'),  -- velha: perde a eleição
+  (1001, 'colacor_vendas', 5000, now()),                       -- FORA do pool oben: ignorada
+  (1002, 'oben',           50,   now() - interval '25 hours'), -- STALE (>24h) → indisponível
+  (1004, 'vendas',         -5,   now()),                       -- negativo → indisponível
+  (1005, 'vendas',         NULL, now()),                       -- NULL → indisponível
+  (1006, 'vendas',         'NaN'::numeric, now()),             -- NaN → indisponível
+  (1007, 'vendas',         20,   now()),                       -- sem parâmetro → colchão 0
+  (1010, 'vendas',         10,   now()),                       -- concorrência K1
+  (1011, 'vendas',         30,   now()),                       -- falsificação F2
+  (1012, 'vendas',         20,   now()),                       -- falsificação F4
+  (1013, 'vendas',         10,   now());                       -- falsificação F5
+
+INSERT INTO public.sku_parametros (empresa, sku_codigo_omie, estoque_seguranca) VALUES
+  ('OBEN', 1001, 10),
+  ('OBEN', 1002, 0),
+  ('OBEN', 1012, 15);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "-- grupo P: caminho feliz + invariantes do calculo --"
+
+R=$(Pq <<SQL
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', '$CK_A', '[{"omie_codigo_produto":1001,"quantidade":50}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "P1 reserva feliz (staff, saldo 100 seg 10, pede 50)" "$(echo "$R" | tail -1)" "true"
+V=$(Pq -c "SELECT count(*)::text FROM public.estoque_reservas WHERE checkout_id='$CK_A' AND status='ativa';")
+eq "P1b exatamente 1 reserva ativa do checkout A" "$V" "1"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT COALESCE(disponivel::text, 'NULL') FROM public.atp_consultar('oben', ARRAY[1001]::bigint[]);
+SQL
+)
+eq "P2 consulta: disponivel = 100−50−10 = 40 (e a conta colacor_vendas 5000 NAO contamina o pool)" "$V" "40"
+
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', '$CK_B', '[{"omie_codigo_produto":1001,"quantidade":45}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "P3 checkout B pede 45 com 40 disponivel → recusa" "$R" "false"
+M=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT r.j->>'motivo' FROM (
+  SELECT jsonb_array_elements(public.reservar_estoque('oben', '$CK_B', '[{"omie_codigo_produto":1001,"quantidade":45}]'::jsonb, 30)->'recusas') AS j
+) r;
+SQL
+)
+eq "P3b motivo da recusa = saldo_insuficiente" "$M" "saldo_insuficiente"
+
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', '$CK_B', '[{"omie_codigo_produto":1001,"quantidade":40}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "P4 checkout B pede exatamente os 40 disponiveis → ok" "$R" "true"
+V=$(Pq -c "SELECT COALESCE(sum(quantidade),0)::text FROM public.estoque_reservas WHERE omie_codigo_produto=1001 AND status='ativa';")
+eq "P4b soma das ativas do SKU 1001 = 90" "$V" "90"
+
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', '$CK_A', '[{"omie_codigo_produto":1001,"quantidade":50}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "P5 re-reserva do MESMO checkout A (retry) → ok (exclui a propria do calculo)" "$R" "true"
+V=$(Pq -c "SELECT count(*)::text || '/' || COALESCE(sum(quantidade),0)::text FROM public.estoque_reservas WHERE checkout_id='$CK_A' AND status='ativa';")
+eq "P5b substituiu (nao somou): 1 ativa de 50 no checkout A" "$V" "1/50"
+
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', '$CK_C', '[{"omie_codigo_produto":1007,"quantidade":5},{"omie_codigo_produto":1003,"quantidade":1}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "P6 multi-item com 1 SKU inexistente → recusa o CONJUNTO" "$R" "false"
+V=$(Pq -c "SELECT count(*)::text FROM public.estoque_reservas WHERE checkout_id='$CK_C';")
+eq "P6b all-or-nothing: NENHUMA linha gravada p/ o checkout C (nem a do item bom)" "$V" "0"
+
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.liberar_reserva_checkout('$CK_B', 'oben', 'teste de liberacao')->>'liberadas';
+SQL
+)
+eq "P7 liberar checkout B → 1 liberada" "$R" "1"
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT COALESCE(disponivel::text, 'NULL') FROM public.atp_consultar('oben', ARRAY[1001]::bigint[]);
+SQL
+)
+eq "P7b disponivel volta a 40 apos liberar" "$V" "40"
+
+P -q -c "INSERT INTO public.estoque_reservas (pool, omie_codigo_produto, quantidade, checkout_id, status, expira_em) VALUES ('oben', 1001, 30, '$CK_D', 'ativa', now() - interval '1 minute');"
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT COALESCE(disponivel::text, 'NULL') FROM public.atp_consultar('oben', ARRAY[1001]::bigint[]);
+SQL
+)
+eq "P8 reserva VENCIDA (ativa, expira no passado) NAO desconta: disponivel segue 40" "$V" "40"
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.expirar_reservas_vencidas()->>'expiradas';
+SQL
+)
+eq "P8b expirar_reservas_vencidas marca 1" "$R" "1"
+V=$(Pq -c "SELECT status FROM public.estoque_reservas WHERE checkout_id='$CK_D';")
+eq "P8c status da vencida = expirada" "$V" "expirada"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT COALESCE(disponivel::text, 'NULL') FROM public.atp_consultar('oben', ARRAY[1007]::bigint[]);
+SQL
+)
+eq "P9 SKU sem sku_parametros → colchao 0: disponivel = saldo 20" "$V" "20"
+
+echo "-- grupo N: FAIL-CLOSED (ausente/stale/invalido → indisponivel, nunca 0 fabricado) --"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT confiavel::text || '/' || COALESCE(disponivel::text, 'NULL') || '/' || COALESCE(motivo, 'sem_motivo')
+FROM public.atp_consultar('oben', ARRAY[1003]::bigint[]);
+SQL
+)
+eq "N1 SKU sem linha em inventory_position → nao-confiavel, disponivel NULL" "$V" "false/NULL/saldo_indisponivel"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT confiavel::text || '/' || COALESCE(disponivel::text, 'NULL') FROM public.atp_consultar('oben', ARRAY[1002]::bigint[]);
+SQL
+)
+eq "N2 synced_at 25h atras (>24h) → STALE → nao-confiavel" "$V" "false/NULL"
+
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT r.j->>'motivo' FROM (
+  SELECT jsonb_array_elements(public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1002,"quantidade":1}]'::jsonb, 30)->'recusas') AS j
+) r;
+SQL
+)
+eq "N2b reservar SKU stale → recusa saldo_indisponivel" "$R" "saldo_indisponivel"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT confiavel::text FROM public.atp_consultar('oben', ARRAY[1004]::bigint[]);
+SQL
+)
+eq "N3 saldo negativo → nao-confiavel" "$V" "false"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT confiavel::text FROM public.atp_consultar('oben', ARRAY[1005]::bigint[]);
+SQL
+)
+eq "N4 saldo NULL → nao-confiavel" "$V" "false"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT confiavel::text FROM public.atp_consultar('oben', ARRAY[1006]::bigint[]);
+SQL
+)
+eq "N5 saldo NaN (ordena ACIMA de 0 em numeric!) → nao-confiavel" "$V" "false"
+
+echo "-- grupo C: contrato (SQLSTATE esperada + re-raise do resto) --"
+
+run_do() {  # roda um bloco DO como staff e devolve stdout+stderr (sentinelas via RAISE NOTICE)
+  P -tA 2>&1 <<SQL
+SET test.uid='$STAFF';
+$1
+SQL
+}
+
+R=$(run_do "DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('colacor', gen_random_uuid(), '[{\"omie_codigo_produto\":1,\"quantidade\":1}]'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_C1_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '22023' THEN RAISE NOTICE 'ATP_TESTE_C1_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;")
+case "$R" in
+  *ATP_TESTE_C1_BARROU_CERTO*) ok "C1 pool 'colacor' → 22023 (fase 1 = oben only)";;
+  *) bad "C1 pool invalido nao deu 22023: $R";;
+esac
+
+R=$(run_do "DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '[{\"omie_codigo_produto\":1001,\"quantidade\":1},{\"omie_codigo_produto\":1001,\"quantidade\":2}]'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_C2_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '22023' THEN RAISE NOTICE 'ATP_TESTE_C2_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;")
+case "$R" in
+  *ATP_TESTE_C2_BARROU_CERTO*) ok "C2 item duplicado no payload → 22023";;
+  *) bad "C2 duplicata nao deu 22023: $R";;
+esac
+
+R=$(run_do "DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '[{\"omie_codigo_produto\":1001,\"quantidade\":0}]'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_C3_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '22023' THEN RAISE NOTICE 'ATP_TESTE_C3_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;")
+case "$R" in
+  *ATP_TESTE_C3_BARROU_CERTO*) ok "C3 quantidade 0 → 22023";;
+  *) bad "C3 quantidade 0 nao deu 22023: $R";;
+esac
+
+R=$(run_do "DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '[{\"omie_codigo_produto\":1001,\"quantidade\":1}]'::jsonb, 300);
+  RAISE NOTICE 'ATP_TESTE_C4_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '22023' THEN RAISE NOTICE 'ATP_TESTE_C4_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;")
+case "$R" in
+  *ATP_TESTE_C4_BARROU_CERTO*) ok "C4 TTL 300min (>240) → 22023";;
+  *) bad "C4 TTL fora do range nao deu 22023: $R";;
+esac
+
+R=$(run_do "DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '{\"omie_codigo_produto\":1001}'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_C5_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '22023' THEN RAISE NOTICE 'ATP_TESTE_C5_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;")
+case "$R" in
+  *ATP_TESTE_C5_BARROU_CERTO*) ok "C5 p_itens objeto (nao array) → 22023";;
+  *) bad "C5 p_itens invalido nao deu 22023: $R";;
+esac
+
+R=$(P -tA 2>&1 <<'SQL'
+DO $$ BEGIN
+  INSERT INTO public.estoque_reservas (pool, omie_codigo_produto, quantidade, checkout_id, expira_em)
+  VALUES ('oben', 9999, -5, gen_random_uuid(), now() + interval '30 minutes');
+  RAISE NOTICE 'ATP_TESTE_C6_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '23514' THEN RAISE NOTICE 'ATP_TESTE_C6_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in
+  *ATP_TESTE_C6_BARROU_CERTO*) ok "C6 CHECK da tabela rejeita quantidade negativa (23514)";;
+  *) bad "C6 CHECK nao rejeitou: $R";;
+esac
+
+echo "-- grupo A: autorizacao (gate 42501, RLS, escrita so via RPC) --"
+
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$CUST';
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1001,"quantidade":1}]'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_A1_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '42501' THEN RAISE NOTICE 'ATP_TESTE_A1_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in
+  *ATP_TESTE_A1_BARROU_CERTO*) ok "A1 customer chama reservar_estoque → 42501 (gate)";;
+  *) bad "A1 customer nao foi barrado: $R";;
+esac
+
+R=$(P -tA 2>&1 <<'SQL'
+SET ROLE anon;
+DO $$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1001,"quantidade":1}]'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_A2_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '42501' THEN RAISE NOTICE 'ATP_TESTE_A2_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END $$;
+SQL
+)
+case "$R" in
+  *ATP_TESTE_A2_BARROU_CERTO*) ok "A2 anon sem EXECUTE → 42501";;
+  *) bad "A2 anon nao foi barrado: $R";;
+esac
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SET ROLE authenticated;
+SELECT (count(*) > 0)::text FROM public.estoque_reservas;
+SQL
+)
+eq "A3 RLS: staff (authenticated) LE as reservas" "$V" "true"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$CUST';
+SET ROLE authenticated;
+SELECT count(*)::text FROM public.estoque_reservas;
+SQL
+)
+eq "A3b RLS: customer le ZERO linhas" "$V" "0"
+
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$STAFF';
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  INSERT INTO public.estoque_reservas (pool, omie_codigo_produto, quantidade, checkout_id, expira_em)
+  VALUES ('oben', 1001, 1, gen_random_uuid(), now() + interval '30 minutes');
+  RAISE NOTICE 'ATP_TESTE_A4_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '42501' THEN RAISE NOTICE 'ATP_TESTE_A4_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in
+  *ATP_TESTE_A4_BARROU_CERTO*) ok "A4 INSERT direto de staff via PostgREST-role → 42501 (escrita SO via RPC)";;
+  *) bad "A4 INSERT direto nao foi barrado: $R";;
+esac
+
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$STAFF';
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  PERFORM * FROM private.atp_disponivel('oben', 1001, NULL);
+  RAISE NOTICE 'ATP_TESTE_A5_PASSOU_INDEVIDO';
+EXCEPTION WHEN sqlstate '42501' THEN RAISE NOTICE 'ATP_TESTE_A5_BARROU_CERTO';
+WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in
+  *ATP_TESTE_A5_BARROU_CERTO*) ok "A5 atp_disponivel (interna) inacessivel a authenticated → 42501 (sem bypass do gate)";;
+  *) bad "A5 authenticated executou a interna: $R";;
+esac
+
+V=$(Pq <<SQL | tail -1
+SET test.role='service_role';
+SET ROLE service_role;
+SELECT COALESCE(disponivel::text, 'NULL') FROM public.atp_consultar('oben', ARRAY[1007]::bigint[]);
+SQL
+)
+eq "A6 service_role consulta (engines/fase 3) → 20" "$V" "20"
+
+V=$(Pq <<SQL | tail -1
+SET test.uid='$MASTER';
+SELECT confiavel::text FROM public.atp_consultar('oben', ARRAY[1007]::bigint[]);
+SQL
+)
+eq "A7 master tambem passa no gate" "$V" "true"
+
+echo "-- grupo K: concorrencia (2 conexoes, mesmo saldo) --"
+# A reserva 8 de 10 e SEGURA a transacao aberta 3s; B (0.8s depois) pede 8 →
+# espera no advisory xact-lock → ve a reserva de A → recusa. Invariante final:
+# exatamente 1 vencedora, soma ativa ≤ saldo.
+P -q <<SQL &
+SET test.uid='$STAFF';
+BEGIN;
+SELECT public.reservar_estoque('oben', '$CK_K1', '[{"omie_codigo_produto":1010,"quantidade":8}]'::jsonb, 30);
+SELECT pg_sleep(3);
+COMMIT;
+SQL
+BG_PID=$!
+sleep 0.8
+R_B=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', '$CK_K2', '[{"omie_codigo_produto":1010,"quantidade":8}]'::jsonb, 30)->>'ok';
+SQL
+)
+wait "$BG_PID" || bad "K1-infra: a conexao A (background) falhou — resultado abaixo nao mede o lock"
+eq "K1 concorrente que chegou depois foi RECUSADO" "$R_B" "false"
+V=$(Pq -c "SELECT count(*)::text || '/' || COALESCE(sum(quantidade),0)::text FROM public.estoque_reservas WHERE omie_codigo_produto=1010 AND status='ativa';")
+eq "K1b invariante: exatamente 1 reserva ativa somando 8 (≤ saldo 10)" "$V" "1/8"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÕES (sabota → exige o vermelho → restaura via re-apply da MIG)
+# Cada sabotagem PROVA que aplicou (guard no-op / efeito observável) antes de julgar.
+# ══════════════════════════════════════════════════════════════════════════════
+echo "-- falsificacoes (a migration sabotada TEM de derrubar o assert correspondente) --"
+
+# F1: frescor 24h → 24000h (o bound de staleness deixa de existir)
+P -q <<'SQL'
+DO $$
+DECLARE def text; novo text;
+BEGIN
+  def := pg_get_functiondef('private.atp_disponivel(text,bigint,uuid)'::regprocedure);
+  novo := replace(def, $s$interval '24 hours'$s$, $s$interval '24000 hours'$s$);
+  IF novo = def THEN RAISE EXCEPTION 'FALSIF_F1_REPLACE_NOOP'; END IF;
+  EXECUTE novo;
+END $$;
+SQL
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1002,"quantidade":1}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "F1 SEM o bound de frescor, o SKU stale passa a reservar (dente do N2b provado)" "$R" "true"
+P -q -f "$MIG"
+V=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT confiavel::text FROM public.atp_consultar('oben', ARRAY[1002]::bigint[]);
+SQL
+)
+eq "F1r restaurado: stale volta a ser nao-confiavel" "$V" "false"
+
+# F2: desconto de reservas alheias zerado (status match sabotado → reservado = 0)
+R1=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1011,"quantidade":25}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "F2-baseline primeiro checkout reserva 25 de 30" "$R1" "true"
+R2=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1011,"quantidade":25}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "F2-baseline segundo checkout e recusado (25+25 > 30)" "$R2" "false"
+P -q <<'SQL'
+DO $$
+DECLARE def text; novo text;
+BEGIN
+  def := pg_get_functiondef('private.atp_disponivel(text,bigint,uuid)'::regprocedure);
+  novo := replace(def, $s$r.status = 'ativa'$s$, $s$r.status = 'sabotado_nunca'$s$);
+  IF novo = def THEN RAISE EXCEPTION 'FALSIF_F2_REPLACE_NOOP'; END IF;
+  EXECUTE novo;
+END $$;
+SQL
+R3=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1011,"quantidade":25}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "F2 SEM descontar reservas alheias, o oversell passa (dente do P3 provado)" "$R3" "true"
+P -q -f "$MIG"
+
+# F3: gate sabotado → cap_estoque_reservar sempre true
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION private.cap_estoque_reservar(_uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$ SELECT true; $function$;
+SQL
+V=$(Pq -c "SELECT private.cap_estoque_reservar(NULL)::text;")
+eq "F3-guard sabotagem aplicada (cap(NULL) virou true)" "$V" "true"
+R=$(P -tA 2>&1 <<SQL
+SET test.uid='$CUST';
+SET ROLE authenticated;
+DO \$\$ BEGIN
+  PERFORM public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1007,"quantidade":1}]'::jsonb, 30);
+  RAISE NOTICE 'ATP_TESTE_F3_CUSTOMER_ENTROU';
+EXCEPTION WHEN sqlstate '42501' THEN RAISE NOTICE 'ATP_TESTE_F3_AINDA_BARRADO';
+WHEN OTHERS THEN RAISE; END \$\$;
+SQL
+)
+case "$R" in
+  *ATP_TESTE_F3_CUSTOMER_ENTROU*) ok "F3 com o gate sabotado o customer ENTRA (dente do A1 provado)";;
+  *) bad "F3 sabotagem do gate nao abriu a porta — assert A1 sem dente? $R";;
+esac
+P -q -f "$MIG"
+V=$(Pq -c "SELECT private.cap_estoque_reservar(NULL)::text;")
+eq "F3r restaurado: cap(NULL) volta a false (fail-closed)" "$V" "false"
+
+# F4: colchão de segurança zerado (empresa do parametro sabotada)
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1012,"quantidade":10}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "F4-baseline saldo 20 seg 15 → pedir 10 e recusado (disponivel 5)" "$R" "false"
+P -q <<'SQL'
+DO $$
+DECLARE def text; novo text;
+BEGIN
+  def := pg_get_functiondef('private.atp_disponivel(text,bigint,uuid)'::regprocedure);
+  novo := replace(def, $s$WHEN 'oben' THEN 'OBEN'$s$, $s$WHEN 'oben' THEN 'SABOTADO'$s$);
+  IF novo = def THEN RAISE EXCEPTION 'FALSIF_F4_REPLACE_NOOP'; END IF;
+  EXECUTE novo;
+END $$;
+SQL
+R=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1012,"quantidade":10}]'::jsonb, 30)->>'ok';
+SQL
+)
+eq "F4 SEM o colchao, os 10 passam (dente do calculo de seguranca provado)" "$R" "true"
+P -q -f "$MIG"
+
+# F5: advisory lock trocado por SHARED (nao serializa) → corrida abre oversell
+P -q <<'SQL'
+DO $$
+DECLARE def text; novo text;
+BEGIN
+  def := pg_get_functiondef('public.reservar_estoque(text,uuid,jsonb,integer)'::regprocedure);
+  novo := replace(def, 'pg_advisory_xact_lock(', 'pg_advisory_xact_lock_shared(');
+  IF novo = def THEN RAISE EXCEPTION 'FALSIF_F5_REPLACE_NOOP'; END IF;
+  EXECUTE novo;
+END $$;
+SQL
+P -q <<SQL &
+SET test.uid='$STAFF';
+BEGIN;
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1013,"quantidade":8}]'::jsonb, 30);
+SELECT pg_sleep(3);
+COMMIT;
+SQL
+BG_PID=$!
+sleep 0.8
+R_B=$(Pq <<SQL | tail -1
+SET test.uid='$STAFF';
+SELECT public.reservar_estoque('oben', gen_random_uuid(), '[{"omie_codigo_produto":1013,"quantidade":8}]'::jsonb, 30)->>'ok';
+SQL
+)
+wait "$BG_PID" || bad "F5-infra: a conexao A (background) falhou — resultado abaixo nao mede a corrida"
+V=$(Pq -c "SELECT COALESCE(sum(quantidade),0)::text FROM public.estoque_reservas WHERE omie_codigo_produto=1013 AND status='ativa';")
+eq "F5 SEM o lock exclusivo, ambos entram e a soma estoura o saldo (16 > 10) — dente do K1 provado" "$R_B/$V" "true/16"
+P -q -f "$MIG"
+
+# ── veredito ──
+echo "------------------------------"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+TOTAL=$((PASS+FAIL))
+if [ "$TOTAL" != "50" ]; then
+  echo "ERR DENOMINADOR: esperava 50 asserts executados, rodaram $TOTAL — caminho pulado em silencio"
+  exit 1
+fi
+[ "$FAIL" = "0" ] || { echo "HARNESS VERMELHO"; exit 1; }
+echo "HARNESS VERDE (50/50, falsificacoes F1-F5 com dente provado)"

--- a/docs/historico/programa-cabreuva-colacor.md
+++ b/docs/historico/programa-cabreuva-colacor.md
@@ -35,7 +35,7 @@ CD de R$ 1,3 bi que mudou a operação da Renner: abastecimento por SKU conforme
 - ⏳ **PR3 — Giro executivo no Cockpit:** capital em estoque + margem TTM + retorno-sobre-estoque rotulado proxy (CMC ausente = indisponível).
 
 **Pista B — épicos (ordem de dependência):**
-- ⏳ **ATP/reserva (P0, 3 fases):** pool por conta/depósito + reserva atômica → checkout idempotente → reconciliação Omie + órfãs. prove-sql + Codex por fase.
+- 🔄 **ATP/reserva (P0, 3 fases):** ① banco ✅ (2026-08-06: `estoque_reservas` + `reservar_estoque`/`liberar_reserva_checkout`/`expirar_reservas_vencidas`/`atp_consultar`, `disponivel = saldo_confiavel − reservas_ativas − estoque_seguranca`, fail-closed frescor 24h, pool oben = eleição por frescor `vendas`/`oben`, gate `private.cap_estoque_reservar`, prova PG17 50/50 ×2 locales com 5 falsificações — migration `20260806101417`, apply manual no SQL Editor) → ② checkout idempotente ⏳ → ③ reconciliação Omie + órfãs ⏳. prove-sql + Codex por fase.
 - ⏳ **Pedido sugerido (3 fases, após ATP):** perfil cliente×SKU → sugestão explicável staff → opt-in do cliente. Sem autoenvio.
 - ⏳ **GMROI completo (2 fases):** estoque médio histórico + metas por classe com link pra desova.
 - ⏳ **Expedição (3 fases):** remessa/romaneio → ondas por cliente/rota → rastreio/POD.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **448** custom migrations totais
-- **1535** objetos esperados (criados por estas migrations)
+- **449** custom migrations totais
+- **1548** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 447
-  - `rls_policy`: 388
-  - `index`: 231
+  - `function`: 453
+  - `rls_policy`: 390
+  - `index`: 235
   - `cron_job`: 161
-  - `table`: 151
+  - `table`: 152
   - `trigger`: 79
   - `view`: 74
   - `enum_value`: 4
@@ -3759,6 +3759,24 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `table` | `public.ia_uso_limite` | — |
 | `index` | `public.ia_uso_evento_janela_idx` | `ia_uso_evento` |
 | `cron_job` | `cron.ia-uso-evento-purga` | — |
+
+### `20260806101417_atp_reserva_estoque_fase1.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `private.cap_estoque_reservar` | — |
+| `function` | `private.atp_disponivel` | — |
+| `function` | `public.atp_consultar` | — |
+| `function` | `public.reservar_estoque` | — |
+| `function` | `public.liberar_reserva_checkout` | — |
+| `function` | `public.expirar_reservas_vencidas` | — |
+| `table` | `public.estoque_reservas` | — |
+| `index` | `public.idx_estoque_reservas_ativa` | `estoque_reservas` |
+| `index` | `public.idx_estoque_reservas_checkout` | `estoque_reservas` |
+| `index` | `public.idx_estoque_reservas_expira` | `estoque_reservas` |
+| `index` | `public.estoque_reservas_checkout_item_ativa_uq` | `estoque_reservas` |
+| `rls_policy` | `public.estoque_reservas_select_staff` | `estoque_reservas` |
+| `rls_policy` | `public.estoque_reservas_service_all` | `estoque_reservas` |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 448
+-- Total de custom migrations: 449
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -489,7 +489,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260802120000', 'reposicao_erro_terminal_nao_e_estoque_a_caminho', '20260802120000_reposicao_erro_terminal_nao_e_estoque_a_caminho.sql'),
   ('20260802120000', 'venda_perdida_e_classe_sb', '20260802120000_venda_perdida_e_classe_sb.sql'),
   ('20260802130000', 'tactical_plan_idempotencia_dia', '20260802130000_tactical_plan_idempotencia_dia.sql'),
-  ('20260803093000', 'ia_uso_cota', '20260803093000_ia_uso_cota.sql')
+  ('20260803093000', 'ia_uso_cota', '20260803093000_ia_uso_cota.sql'),
+  ('20260806101417', 'atp_reserva_estoque_fase1', '20260806101417_atp_reserva_estoque_fase1.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2013,7 +2014,20 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('ia_uso_cota', 'table', 'public', 'ia_uso_evento', ''),
   ('ia_uso_cota', 'table', 'public', 'ia_uso_limite', ''),
   ('ia_uso_cota', 'index', 'public', 'ia_uso_evento_janela_idx', 'ia_uso_evento'),
-  ('ia_uso_cota', 'cron_job', 'cron', 'ia-uso-evento-purga', '')
+  ('ia_uso_cota', 'cron_job', 'cron', 'ia-uso-evento-purga', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'private', 'cap_estoque_reservar', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'private', 'atp_disponivel', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'atp_consultar', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'reservar_estoque', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'liberar_reserva_checkout', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'expirar_reservas_vencidas', ''),
+  ('atp_reserva_estoque_fase1', 'table', 'public', 'estoque_reservas', ''),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'idx_estoque_reservas_ativa', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'idx_estoque_reservas_checkout', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'idx_estoque_reservas_expira', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'estoque_reservas_checkout_item_ativa_uq', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'rls_policy', 'public', 'estoque_reservas_select_staff', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'rls_policy', 'public', 'estoque_reservas_service_all', 'estoque_reservas')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3585,7 +3599,20 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('ia_uso_cota', 'table', 'public', 'ia_uso_evento', ''),
   ('ia_uso_cota', 'table', 'public', 'ia_uso_limite', ''),
   ('ia_uso_cota', 'index', 'public', 'ia_uso_evento_janela_idx', 'ia_uso_evento'),
-  ('ia_uso_cota', 'cron_job', 'cron', 'ia-uso-evento-purga', '')
+  ('ia_uso_cota', 'cron_job', 'cron', 'ia-uso-evento-purga', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'private', 'cap_estoque_reservar', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'private', 'atp_disponivel', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'atp_consultar', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'reservar_estoque', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'liberar_reserva_checkout', ''),
+  ('atp_reserva_estoque_fase1', 'function', 'public', 'expirar_reservas_vencidas', ''),
+  ('atp_reserva_estoque_fase1', 'table', 'public', 'estoque_reservas', ''),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'idx_estoque_reservas_ativa', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'idx_estoque_reservas_checkout', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'idx_estoque_reservas_expira', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'index', 'public', 'estoque_reservas_checkout_item_ativa_uq', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'rls_policy', 'public', 'estoque_reservas_select_staff', 'estoque_reservas'),
+  ('atp_reserva_estoque_fase1', 'rls_policy', 'public', 'estoque_reservas_service_all', 'estoque_reservas')
 )
 SELECT
   e.migration,

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -96,6 +96,30 @@ export const AUTHZ_MANIFEST: Record<string, AuthzEntry> = {
     requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }] },
     motivo: 'clientes por produto (preço/volume 12m)',
   },
+  // ATP fase 1 (2026-08-06, programa Cabreúva Pista B): as 4 RPCs de reserva de estoque leem
+  // disponibilidade derivada de inventory_position (via private.atp_disponivel) e escrevem
+  // estoque_reservas. Gate único private.cap_estoque_reservar = staff (employee/master) OU
+  // service_role (engines/reconciliação fase 3). Custo (cmc) NUNCA atravessa o retorno.
+  'public.atp_consultar': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'cap_estoque_reservar' }] },
+    motivo: 'disponibilidade ATP (saldo−reservas−segurança) p/ staff de venda — sem custo',
+  },
+  'public.reservar_estoque': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'cap_estoque_reservar' }] },
+    motivo: 'cria reserva de estoque (writer único de estoque_reservas)',
+  },
+  'public.liberar_reserva_checkout': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'cap_estoque_reservar' }] },
+    motivo: 'libera reservas ativas de um checkout (cancelamento/abandono)',
+  },
+  'public.expirar_reservas_vencidas': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'cap_estoque_reservar' }] },
+    motivo: 'higiene de reservas vencidas (cron da fase 3 via service_role)',
+  },
 };
 
 /**
@@ -107,6 +131,10 @@ export const AUTHZ_MANIFEST: Record<string, AuthzEntry> = {
  * v2: auditar cada uma individualmente e cruzar com os grants reais.
  */
 export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
+  // ATP fase 1 (2026-08-06): cálculo interno disponivel = saldo−reservas−segurança. Lê
+  // inventory_position mas NÃO é executável por authenticated/anon (REVOKE ALL na própria
+  // migration; GRANT só service_role) — chamada exclusivamente pelas 4 RPCs gateadas acima.
+  'private.atp_disponivel',
   // Baseline 2026-07-09: as 7 SECDEF abaixo tocam custo/preço/estoque mas NÃO são executáveis por
   // authenticated nem anon (confirmado psql-ro: auth_exec=f, anon_exec=f) — service_role/cron/
   // trigger/interno, não customer-facing. Vazamento customer-facing exige EXECUTE p/ authenticated.

--- a/supabase/migrations/20260806101417_atp_reserva_estoque_fase1.sql
+++ b/supabase/migrations/20260806101417_atp_reserva_estoque_fase1.sql
@@ -1,0 +1,495 @@
+-- ============================================================
+-- ATP/reserva de estoque — FASE 1: fundação no banco [money-path]
+-- Programa Cabreúva Pista B (docs/historico/programa-cabreuva-colacor.md)
+--
+-- disponivel = saldo_confiavel − reservas_ativas − estoque_seguranca
+--
+-- Decisões (parecer Codex 2026-08-03, handoff da fase):
+--  • FAIL-CLOSED: sem linha em inventory_position, synced_at defasado (>24h),
+--    saldo NULL/negativo/NaN → saldo NÃO-confiável → disponivel = NULL e a
+--    reserva é RECUSADA. Nunca fabricar disponibilidade (ausente ≠ zero).
+--  • Pool fase 1 = 'oben' (empresa Oben): saldo eleito por FRESCOR entre
+--    inventory_position.account IN ('vendas','oben') — padrão ESTOQUE_ACCOUNTS
+--    do fin-valor-cockpit. Colacor entra em fase futura (decisão de produto).
+--  • estoque_seguranca vem de sku_parametros (empresa 'OBEN'); parâmetro
+--    ausente = colchão 0 (default de política — não é dado fabricado).
+--  • 1 WRITER: escrita em estoque_reservas SÓ pelas RPCs SECURITY DEFINER
+--    deste arquivo (authenticated fica sem privilégio de INSERT/UPDATE/DELETE).
+--  • Reserva órfã: expira_em obrigatório; reserva vencida NÃO desconta no
+--    cálculo; expirar_reservas_vencidas() marca vencidas (higiene observável).
+--    Reconciliação completa (consumo pós-PV × sync Omie) é a fase 3.
+--  • Janela conhecida (fase 3 fecha): entre o PV criado e o sync refletir o
+--    saldo, a reserva 'consumida' não desconta e o saldo ainda não caiu.
+--    Na fase 1 nada marca 'consumida' — estado reservado ao desenho da fase 2/3.
+--  • Concorrência: pg_advisory_xact_lock por checkout e por SKU em ordem
+--    determinística (deadlock-free) — 2 reservas simultâneas do mesmo saldo
+--    serializam e a segunda é recusada. xact-lock vale aqui porque a reserva
+--    é UMA chamada/transação (a restrição do lease do money-path §10 é para
+--    estado que atravessa N chamadas HTTP).
+--  • Recusa de NEGÓCIO = retorno jsonb {ok:false, recusas:[...]} (nunca vira
+--    "[object Object]" no toast — money-path §12). Violação de CONTRATO/gate
+--    = RAISE com SQLSTATE testável (22023 / 42501).
+-- ============================================================
+
+-- ────────────────────────────────────────────────────────────
+-- 1) Gate de capability: staff (employee/master) OU service_role
+--    (service_role p/ engines/reconciliação da fase 3 — cron sem JWT de user)
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION private.cap_estoque_reservar(_uid uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  SELECT COALESCE(
+    (SELECT auth.role()) = 'service_role'
+    OR (
+      _uid IS NOT NULL
+      AND (
+        public.has_role(_uid, 'master'::public.app_role)
+        OR public.has_role(_uid, 'employee'::public.app_role)
+      )
+    ), false);
+$function$;
+
+REVOKE ALL ON FUNCTION private.cap_estoque_reservar(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.cap_estoque_reservar(uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION private.cap_estoque_reservar(uuid) TO authenticated, service_role;
+
+-- ────────────────────────────────────────────────────────────
+-- 2) Tabela de reservas
+-- ────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS public.estoque_reservas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- fase 1: só o pool 'oben' (contas Omie 'vendas'+'oben'); ampliar exige migration
+  pool text NOT NULL CONSTRAINT estoque_reservas_pool_check CHECK (pool = 'oben'),
+  omie_codigo_produto bigint NOT NULL,
+  quantidade numeric NOT NULL CONSTRAINT estoque_reservas_qtd_check
+    CHECK (quantidade > 0 AND quantidade <= 1000000),
+  -- elo idempotente com o checkout (sales_orders.checkout_id é uuid)
+  checkout_id uuid NOT NULL,
+  -- elo com o pedido (fase 2 popula; SET NULL p/ nunca travar deleção legítima)
+  sales_order_id uuid REFERENCES public.sales_orders(id) ON DELETE SET NULL,
+  status text NOT NULL DEFAULT 'ativa' CONSTRAINT estoque_reservas_status_check
+    CHECK (status IN ('ativa', 'liberada', 'consumida', 'expirada')),
+  expira_em timestamptz NOT NULL,
+  motivo text,
+  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  atualizado_em timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_estoque_reservas_ativa
+  ON public.estoque_reservas (pool, omie_codigo_produto) WHERE status = 'ativa';
+CREATE INDEX IF NOT EXISTS idx_estoque_reservas_checkout
+  ON public.estoque_reservas (checkout_id);
+CREATE INDEX IF NOT EXISTS idx_estoque_reservas_expira
+  ON public.estoque_reservas (expira_em) WHERE status = 'ativa';
+-- cinto de segurança da idempotência: no máx. 1 reserva ATIVA por item por checkout
+CREATE UNIQUE INDEX IF NOT EXISTS estoque_reservas_checkout_item_ativa_uq
+  ON public.estoque_reservas (checkout_id, pool, omie_codigo_produto) WHERE status = 'ativa';
+
+-- RLS: staff lê; escrita de authenticated NÃO existe (nem policy, nem privilégio)
+ALTER TABLE public.estoque_reservas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "estoque_reservas_select_staff" ON public.estoque_reservas;
+CREATE POLICY "estoque_reservas_select_staff"
+  ON public.estoque_reservas
+  FOR SELECT
+  USING ((SELECT private.cap_estoque_reservar((SELECT auth.uid()))));
+
+DROP POLICY IF EXISTS "estoque_reservas_service_all" ON public.estoque_reservas;
+CREATE POLICY "estoque_reservas_service_all"
+  ON public.estoque_reservas
+  FOR ALL
+  USING ((SELECT auth.role()) = 'service_role');
+
+REVOKE ALL ON TABLE public.estoque_reservas FROM PUBLIC;
+REVOKE ALL ON TABLE public.estoque_reservas FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.estoque_reservas FROM authenticated;
+GRANT SELECT ON TABLE public.estoque_reservas TO authenticated;
+GRANT ALL ON TABLE public.estoque_reservas TO service_role;
+
+-- ────────────────────────────────────────────────────────────
+-- 3) Cálculo interno do ATP (SEM gate próprio — REVOKE total abaixo;
+--    só as RPCs gateadas deste arquivo a chamam, como owner)
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION private.atp_disponivel(
+  p_pool text,
+  p_sku bigint,
+  p_excluir_checkout uuid DEFAULT NULL
+)
+RETURNS TABLE (
+  saldo numeric,
+  saldo_synced_at timestamptz,
+  saldo_confiavel boolean,
+  reservado numeric,
+  seguranca numeric,
+  disponivel numeric
+)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+  WITH linha AS (
+    -- eleição por frescor entre as contas do pool (padrão ESTOQUE_ACCOUNTS do
+    -- cockpit): a linha mais recente vence; empate → account em ordem estável
+    SELECT ip.saldo, ip.synced_at
+    FROM public.inventory_position ip
+    WHERE ip.omie_codigo_produto = p_sku
+      AND ip.account = ANY (CASE p_pool WHEN 'oben' THEN ARRAY['vendas','oben'] ELSE ARRAY[]::text[] END)
+    ORDER BY ip.synced_at DESC NULLS LAST, ip.account
+    LIMIT 1
+  ),
+  base AS (
+    SELECT
+      (SELECT l.saldo FROM linha l) AS saldo,
+      (SELECT l.synced_at FROM linha l) AS synced_at
+  ),
+  calc AS (
+    SELECT
+      b.saldo,
+      b.synced_at,
+      -- FAIL-CLOSED: linha presente + sync ≤24h + saldo numérico são.
+      -- NaN em numeric ordena ACIMA de tudo ('NaN'>=0 é true) → guard explícito.
+      (b.synced_at IS NOT NULL
+        AND b.synced_at > now() - interval '24 hours'
+        AND b.saldo IS NOT NULL
+        AND b.saldo <> 'NaN'::numeric
+        AND b.saldo >= 0) AS confiavel
+    FROM base b
+  ),
+  res AS (
+    SELECT COALESCE(sum(r.quantidade), 0) AS reservado
+    FROM public.estoque_reservas r
+    WHERE r.pool = p_pool
+      AND r.omie_codigo_produto = p_sku
+      AND r.status = 'ativa'
+      AND r.expira_em > now()
+      AND (p_excluir_checkout IS NULL OR r.checkout_id <> p_excluir_checkout)
+  ),
+  seg AS (
+    -- parâmetro ausente = sem colchão configurado (0) — default de política.
+    -- Duplicata improvável de (empresa, sku): vence o colchão MAIOR (conservador).
+    SELECT COALESCE((
+      SELECT sp.estoque_seguranca
+      FROM public.sku_parametros sp
+      WHERE sp.empresa = (CASE p_pool WHEN 'oben' THEN 'OBEN' END)
+        AND sp.sku_codigo_omie = p_sku
+        AND sp.estoque_seguranca IS NOT NULL
+        AND sp.estoque_seguranca >= 0
+      ORDER BY sp.estoque_seguranca DESC
+      LIMIT 1
+    ), 0) AS seguranca
+  )
+  SELECT
+    c.saldo,
+    c.synced_at,
+    COALESCE(c.confiavel, false),
+    r.reservado,
+    s.seguranca,
+    -- disponivel pode ser NEGATIVO (reservas+colchão > saldo após queda no sync):
+    -- informação honesta p/ a reconciliação — não clampar em 0.
+    CASE WHEN COALESCE(c.confiavel, false)
+         THEN c.saldo - r.reservado - s.seguranca
+         ELSE NULL END
+  FROM calc c
+  CROSS JOIN res r
+  CROSS JOIN seg s;
+$function$;
+
+REVOKE ALL ON FUNCTION private.atp_disponivel(text, bigint, uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.atp_disponivel(text, bigint, uuid) FROM anon;
+REVOKE ALL ON FUNCTION private.atp_disponivel(text, bigint, uuid) FROM authenticated;
+GRANT EXECUTE ON FUNCTION private.atp_disponivel(text, bigint, uuid) TO service_role;
+
+-- ────────────────────────────────────────────────────────────
+-- 4) Consulta de disponibilidade (leitura, sem efeito)
+--    NÃO expõe cmc/custo nem saldo cru — só o disponível e o veredito.
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.atp_consultar(p_pool text, p_skus bigint[])
+RETURNS TABLE (
+  omie_codigo_produto bigint,
+  disponivel numeric,
+  confiavel boolean,
+  motivo text,
+  saldo_synced_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+BEGIN
+  IF NOT private.cap_estoque_reservar(v_uid) THEN
+    RAISE EXCEPTION 'Sem permissão para consultar disponibilidade de estoque (staff apenas)'
+      USING ERRCODE = '42501';
+  END IF;
+  IF p_pool IS DISTINCT FROM 'oben' THEN
+    RAISE EXCEPTION 'Pool de estoque inválido: % — a fase 1 atende apenas ''oben''', COALESCE(p_pool, 'NULL')
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_skus IS NULL OR cardinality(p_skus) = 0 OR cardinality(p_skus) > 500 THEN
+    RAISE EXCEPTION 'p_skus deve ter entre 1 e 500 códigos' USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    s.sku,
+    d.disponivel,
+    d.saldo_confiavel,
+    CASE WHEN NOT d.saldo_confiavel
+         THEN 'saldo_indisponivel'::text
+         ELSE NULL::text END,
+    d.saldo_synced_at
+  FROM unnest(p_skus) AS s(sku)
+  CROSS JOIN LATERAL private.atp_disponivel(p_pool, s.sku, NULL) AS d;
+END;
+$function$;
+
+-- ────────────────────────────────────────────────────────────
+-- 5) Reservar (atômica, all-or-nothing, idempotente por checkout)
+--    Re-chamada do MESMO checkout SUBSTITUI as reservas ativas dele
+--    (estado-alvo do carrinho, não delta) — retry seguro.
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.reservar_estoque(
+  p_pool text,
+  p_checkout_id uuid,
+  p_itens jsonb,
+  p_ttl_minutos integer DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+  v_total integer;
+  v_distintos integer;
+  v_invalidos integer;
+  v_sku bigint;
+  v_item record;
+  v_calc record;
+  v_recusas jsonb := '[]'::jsonb;
+  v_reservas jsonb := '[]'::jsonb;
+  v_expira timestamptz;
+  v_id uuid;
+BEGIN
+  IF NOT private.cap_estoque_reservar(v_uid) THEN
+    RAISE EXCEPTION 'Sem permissão para reservar estoque (staff apenas)'
+      USING ERRCODE = '42501';
+  END IF;
+  IF p_pool IS DISTINCT FROM 'oben' THEN
+    RAISE EXCEPTION 'Pool de estoque inválido: % — a fase 1 atende apenas ''oben''', COALESCE(p_pool, 'NULL')
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_checkout_id IS NULL THEN
+    RAISE EXCEPTION 'p_checkout_id é obrigatório' USING ERRCODE = '22023';
+  END IF;
+  IF p_itens IS NULL OR jsonb_typeof(p_itens) <> 'array' OR jsonb_array_length(p_itens) = 0 THEN
+    RAISE EXCEPTION 'p_itens deve ser um array JSON não-vazio de {omie_codigo_produto, quantidade}'
+      USING ERRCODE = '22023';
+  END IF;
+  IF jsonb_array_length(p_itens) > 200 THEN
+    RAISE EXCEPTION 'p_itens excede o limite de 200 itens' USING ERRCODE = '22023';
+  END IF;
+  IF p_ttl_minutos IS NULL OR p_ttl_minutos < 5 OR p_ttl_minutos > 240 THEN
+    RAISE EXCEPTION 'p_ttl_minutos fora do intervalo [5, 240]: %', COALESCE(p_ttl_minutos::text, 'NULL')
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Shape dos itens: sku e quantidade obrigatórios, quantidade > 0, sem duplicata
+  SELECT count(*),
+         count(DISTINCT x.omie_codigo_produto),
+         count(*) FILTER (WHERE x.omie_codigo_produto IS NULL
+                             OR x.quantidade IS NULL
+                             OR x.quantidade <= 0
+                             OR x.quantidade > 1000000)
+    INTO v_total, v_distintos, v_invalidos
+  FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric);
+
+  IF v_invalidos > 0 THEN
+    RAISE EXCEPTION 'p_itens contém item inválido (sku/quantidade ausente, quantidade fora de (0, 1000000])'
+      USING ERRCODE = '22023';
+  END IF;
+  IF v_distintos <> v_total THEN
+    RAISE EXCEPTION 'p_itens contém omie_codigo_produto duplicado — agregue as quantidades antes de chamar'
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- Serialização: lock do checkout primeiro, depois SKUs em ordem (deadlock-free)
+  PERFORM pg_advisory_xact_lock(hashtextextended('atp:checkout:' || p_checkout_id::text, 0));
+  FOR v_sku IN
+    SELECT DISTINCT x.omie_codigo_produto
+    FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric)
+    ORDER BY 1
+  LOOP
+    PERFORM pg_advisory_xact_lock(hashtextextended('atp:sku:' || p_pool || ':' || v_sku::text, 0));
+  END LOOP;
+
+  -- Decide TUDO antes de escrever (all-or-nothing sem depender de exception).
+  -- O cálculo EXCLUI as reservas ativas do próprio checkout: a substituição
+  -- devolve o que ele mesmo segurava antes de decidir.
+  FOR v_item IN
+    SELECT x.omie_codigo_produto AS sku, x.quantidade AS qtd
+    FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric)
+    ORDER BY x.omie_codigo_produto
+  LOOP
+    SELECT * INTO v_calc FROM private.atp_disponivel(p_pool, v_item.sku, p_checkout_id);
+    IF NOT v_calc.saldo_confiavel THEN
+      v_recusas := v_recusas || jsonb_build_object(
+        'omie_codigo_produto', v_item.sku,
+        'motivo', 'saldo_indisponivel',
+        'detalhe', 'sem posição de estoque confiável (ausente, defasada >24h ou inválida)',
+        'solicitado', v_item.qtd,
+        'disponivel', NULL);
+    ELSIF v_item.qtd > v_calc.disponivel THEN
+      v_recusas := v_recusas || jsonb_build_object(
+        'omie_codigo_produto', v_item.sku,
+        'motivo', 'saldo_insuficiente',
+        'solicitado', v_item.qtd,
+        'disponivel', v_calc.disponivel);
+    END IF;
+  END LOOP;
+
+  IF jsonb_array_length(v_recusas) > 0 THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'pool', p_pool,
+      'checkout_id', p_checkout_id,
+      'recusas', v_recusas);
+  END IF;
+
+  -- Substituição: libera as ativas anteriores deste checkout+pool e grava o estado-alvo
+  UPDATE public.estoque_reservas
+     SET status = 'liberada',
+         motivo = 'substituida por nova reserva do mesmo checkout',
+         atualizado_em = now()
+   WHERE checkout_id = p_checkout_id
+     AND pool = p_pool
+     AND status = 'ativa';
+
+  v_expira := now() + make_interval(mins => p_ttl_minutos);
+
+  FOR v_item IN
+    SELECT x.omie_codigo_produto AS sku, x.quantidade AS qtd
+    FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric)
+    ORDER BY x.omie_codigo_produto
+  LOOP
+    INSERT INTO public.estoque_reservas
+      (pool, omie_codigo_produto, quantidade, checkout_id, status, expira_em, created_by)
+    VALUES
+      (p_pool, v_item.sku, v_item.qtd, p_checkout_id, 'ativa', v_expira, v_uid)
+    RETURNING id INTO v_id;
+    v_reservas := v_reservas || jsonb_build_object(
+      'id', v_id,
+      'omie_codigo_produto', v_item.sku,
+      'quantidade', v_item.qtd,
+      'expira_em', v_expira);
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'pool', p_pool,
+    'checkout_id', p_checkout_id,
+    'reservas', v_reservas);
+END;
+$function$;
+
+-- ────────────────────────────────────────────────────────────
+-- 6) Liberar (cancelamento/abandono do checkout)
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.liberar_reserva_checkout(
+  p_checkout_id uuid,
+  p_pool text DEFAULT NULL,
+  p_motivo text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+  v_n integer;
+BEGIN
+  IF NOT private.cap_estoque_reservar(v_uid) THEN
+    RAISE EXCEPTION 'Sem permissão para liberar reserva de estoque (staff apenas)'
+      USING ERRCODE = '42501';
+  END IF;
+  IF p_checkout_id IS NULL THEN
+    RAISE EXCEPTION 'p_checkout_id é obrigatório' USING ERRCODE = '22023';
+  END IF;
+  IF p_pool IS NOT NULL AND p_pool <> 'oben' THEN
+    RAISE EXCEPTION 'Pool de estoque inválido: % — a fase 1 atende apenas ''oben''', p_pool
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtextextended('atp:checkout:' || p_checkout_id::text, 0));
+
+  UPDATE public.estoque_reservas
+     SET status = 'liberada',
+         motivo = COALESCE(p_motivo, 'liberacao pelo caller'),
+         atualizado_em = now()
+   WHERE checkout_id = p_checkout_id
+     AND status = 'ativa'
+     AND (p_pool IS NULL OR pool = p_pool);
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+
+  RETURN jsonb_build_object('ok', true, 'checkout_id', p_checkout_id, 'liberadas', v_n);
+END;
+$function$;
+
+-- ────────────────────────────────────────────────────────────
+-- 7) Higiene: marca reservas vencidas (vencida já NÃO desconta no cálculo;
+--    isto dá observabilidade e evita acúmulo de 'ativa' morta)
+-- ────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.expirar_reservas_vencidas()
+RETURNS jsonb
+LANGUAGE plpgsql
+VOLATILE SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_uid uuid := (SELECT auth.uid());
+  v_n integer;
+BEGIN
+  IF NOT private.cap_estoque_reservar(v_uid) THEN
+    RAISE EXCEPTION 'Sem permissão para expirar reservas de estoque (staff apenas)'
+      USING ERRCODE = '42501';
+  END IF;
+
+  UPDATE public.estoque_reservas
+     SET status = 'expirada',
+         motivo = 'expirada por TTL',
+         atualizado_em = now()
+   WHERE status = 'ativa'
+     AND expira_em <= now();
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+
+  RETURN jsonb_build_object('ok', true, 'expiradas', v_n);
+END;
+$function$;
+
+-- ────────────────────────────────────────────────────────────
+-- 8) Privilégios das RPCs públicas: EXECUTE só a authenticated (gate interno
+--    barra customer com 42501) e service_role; anon/PUBLIC fora.
+-- ────────────────────────────────────────────────────────────
+REVOKE ALL ON FUNCTION public.atp_consultar(text, bigint[]) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.atp_consultar(text, bigint[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.atp_consultar(text, bigint[]) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.reservar_estoque(text, uuid, jsonb, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.reservar_estoque(text, uuid, jsonb, integer) FROM anon;
+GRANT EXECUTE ON FUNCTION public.reservar_estoque(text, uuid, jsonb, integer) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.liberar_reserva_checkout(uuid, text, text) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.liberar_reserva_checkout(uuid, text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.liberar_reserva_checkout(uuid, text, text) TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.expirar_reservas_vencidas() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.expirar_reservas_vencidas() FROM anon;
+GRANT EXECUTE ON FUNCTION public.expirar_reservas_vencidas() TO authenticated, service_role;


### PR DESCRIPTION
## Cabreúva Pista B — ATP/reserva de estoque, FASE 1 (fundação no banco) [money-path]

Primeira das 3 fases do épico ATP (programa `docs/historico/programa-cabreuva-colacor.md`, prioridade P0 do parecer Codex 2026-08-03): **tabela de reservas + RPCs atômicas de reservar/liberar**, sem tocar o checkout (fase 2) nem a reconciliação (fase 3).

### Semântica (fail-closed em todos os ramos)

`disponivel = saldo_confiavel − reservas_ativas − estoque_seguranca`

- **saldo_confiavel**: linha de `inventory_position` eleita por FRESCOR entre `account IN ('vendas','oben')` (padrão `ESTOQUE_ACCOUNTS` do fin-valor-cockpit). Sem linha, `synced_at` >24h, saldo NULL/negativo/NaN → **indisponível** (`disponivel = NULL`, recusa `saldo_indisponivel`) — nunca 0 fabricado (medido: sync normal cobre ~94% das linhas em 6h; 24h stale = incidente de sync = parar de prometer estoque).
- **reservas_ativas**: `status='ativa' AND expira_em > now()` — reserva vencida NÃO desconta (blindagem contra órfã); `expirar_reservas_vencidas()` dá a higiene observável.
- **estoque_seguranca**: `sku_parametros` (empresa `OBEN`); parâmetro ausente = colchão 0 (default de política, documentado no SQL).
- **Pool fase 1 = `'oben'`** (CHECK na tabela; ampliar = migration + decisão de produto).

### Garantias provadas

- **1 writer**: escrita em `estoque_reservas` SÓ via RPC SECURITY DEFINER — `authenticated` fica sem privilégio de INSERT/UPDATE/DELETE (provado: 42501 mesmo p/ staff via PostgREST-role).
- **Atomicidade**: multi-item all-or-nothing (1 SKU ruim → NADA é gravado); re-chamada do MESMO `checkout_id` SUBSTITUI (retry idempotente, espelha `ensureSalesOrderRow`).
- **Concorrência**: `pg_advisory_xact_lock` por checkout + por SKU em ordem determinística — 2 conexões disputando o mesmo saldo → exatamente 1 vence (provado com 2 conexões reais no PG17; a falsificação F5 troca o lock por shared e o oversell aparece: soma 16 > saldo 10).
- **Gate**: `private.cap_estoque_reservar` (staff OU service_role), registrado em `scripts/authz-manifest.ts` (as 4 RPCs no `AUTHZ_MANIFEST`; a interna `private.atp_disponivel` em `ACKNOWLEDGED_SENSITIVE` — REVOKE total, sem caminho de bypass, provado 42501).
- **Recusa de negócio = jsonb** `{ok:false, recusas:[{motivo, solicitado, disponivel}]}` (nunca vira "[object Object]" — money-path §12); violação de contrato = RAISE 22023/42501/23514 (SQLSTATEs testadas).

### Prova (evidência positiva)

- `db/test-atp-reserva-estoque-fase1.sh` — **PG17 real, 50/50 asserts, exit=0, rodado 2× (LC_ALL=C e pt_BR.UTF-8)**; denominador fixado no script (≠50 → falha).
- **Falsificações F1–F5 com dente provado** (sabotagem via `pg_get_functiondef`+replace com guard de no-op): frescor (F1), desconto de reservas alheias (F2), gate (F3), colchão (F4), lock (F5) — cada uma derruba o assert que a mira, e a restauração re-aplica a migration REAL (idempotência exercitada).
- `heavy heavy bun run typecheck` ✅ · `heavy heavy bun run test` ✅ 650 files/5940 tests · `bun run authz:check` ✅ · `bun run wt:preflight --full` 🟢 (71.879 objetos, sem colisão).
- Pré-voo PROD via psql-ro 🟢: referências existem (`sales_orders.id` PK, `auth.users`, `has_role`, schema `private`), NENHUM objeto novo colide (greenfield confirmado no banco).

### Fora do escopo (fases seguintes, já no programa)

- Fase 2: integração ao checkout (`submitOrder`) + tipos TS regenerados (a RPC nova NÃO está em `types.ts` até o Lovable regenerar — nada em `src/` a referencia neste PR, de propósito).
- Fase 3: reconciliação (consumo pós-PV × sync Omie — a janela entre PV criado e sync refletir o saldo está DOCUMENTADA no cabeçalho da migration como decisão explícita).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260806101417_atp_reserva_estoque_fase1.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. O founder precisa colar no SQL Editor do Lovable e rodar (re-colar é seguro: idempotente, provado no harness).

<details><summary>SQL pra aplicar (íntegro, byte-a-byte igual ao arquivo)</summary>

```sql
-- ============================================================
-- ATP/reserva de estoque — FASE 1: fundação no banco [money-path]
-- Programa Cabreúva Pista B (docs/historico/programa-cabreuva-colacor.md)
--
-- disponivel = saldo_confiavel − reservas_ativas − estoque_seguranca
--
-- Decisões (parecer Codex 2026-08-03, handoff da fase):
--  • FAIL-CLOSED: sem linha em inventory_position, synced_at defasado (>24h),
--    saldo NULL/negativo/NaN → saldo NÃO-confiável → disponivel = NULL e a
--    reserva é RECUSADA. Nunca fabricar disponibilidade (ausente ≠ zero).
--  • Pool fase 1 = 'oben' (empresa Oben): saldo eleito por FRESCOR entre
--    inventory_position.account IN ('vendas','oben') — padrão ESTOQUE_ACCOUNTS
--    do fin-valor-cockpit. Colacor entra em fase futura (decisão de produto).
--  • estoque_seguranca vem de sku_parametros (empresa 'OBEN'); parâmetro
--    ausente = colchão 0 (default de política — não é dado fabricado).
--  • 1 WRITER: escrita em estoque_reservas SÓ pelas RPCs SECURITY DEFINER
--    deste arquivo (authenticated fica sem privilégio de INSERT/UPDATE/DELETE).
--  • Reserva órfã: expira_em obrigatório; reserva vencida NÃO desconta no
--    cálculo; expirar_reservas_vencidas() marca vencidas (higiene observável).
--    Reconciliação completa (consumo pós-PV × sync Omie) é a fase 3.
--  • Janela conhecida (fase 3 fecha): entre o PV criado e o sync refletir o
--    saldo, a reserva 'consumida' não desconta e o saldo ainda não caiu.
--    Na fase 1 nada marca 'consumida' — estado reservado ao desenho da fase 2/3.
--  • Concorrência: pg_advisory_xact_lock por checkout e por SKU em ordem
--    determinística (deadlock-free) — 2 reservas simultâneas do mesmo saldo
--    serializam e a segunda é recusada. xact-lock vale aqui porque a reserva
--    é UMA chamada/transação (a restrição do lease do money-path §10 é para
--    estado que atravessa N chamadas HTTP).
--  • Recusa de NEGÓCIO = retorno jsonb {ok:false, recusas:[...]} (nunca vira
--    "[object Object]" no toast — money-path §12). Violação de CONTRATO/gate
--    = RAISE com SQLSTATE testável (22023 / 42501).
-- ============================================================

-- ────────────────────────────────────────────────────────────
-- 1) Gate de capability: staff (employee/master) OU service_role
--    (service_role p/ engines/reconciliação da fase 3 — cron sem JWT de user)
-- ────────────────────────────────────────────────────────────
CREATE OR REPLACE FUNCTION private.cap_estoque_reservar(_uid uuid)
RETURNS boolean
LANGUAGE sql
STABLE SECURITY DEFINER
SET search_path TO 'public'
AS $function$
  SELECT COALESCE(
    (SELECT auth.role()) = 'service_role'
    OR (
      _uid IS NOT NULL
      AND (
        public.has_role(_uid, 'master'::public.app_role)
        OR public.has_role(_uid, 'employee'::public.app_role)
      )
    ), false);
$function$;

REVOKE ALL ON FUNCTION private.cap_estoque_reservar(uuid) FROM PUBLIC;
REVOKE ALL ON FUNCTION private.cap_estoque_reservar(uuid) FROM anon;
GRANT EXECUTE ON FUNCTION private.cap_estoque_reservar(uuid) TO authenticated, service_role;

-- ────────────────────────────────────────────────────────────
-- 2) Tabela de reservas
-- ────────────────────────────────────────────────────────────
CREATE TABLE IF NOT EXISTS public.estoque_reservas (
  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
  -- fase 1: só o pool 'oben' (contas Omie 'vendas'+'oben'); ampliar exige migration
  pool text NOT NULL CONSTRAINT estoque_reservas_pool_check CHECK (pool = 'oben'),
  omie_codigo_produto bigint NOT NULL,
  quantidade numeric NOT NULL CONSTRAINT estoque_reservas_qtd_check
    CHECK (quantidade > 0 AND quantidade <= 1000000),
  -- elo idempotente com o checkout (sales_orders.checkout_id é uuid)
  checkout_id uuid NOT NULL,
  -- elo com o pedido (fase 2 popula; SET NULL p/ nunca travar deleção legítima)
  sales_order_id uuid REFERENCES public.sales_orders(id) ON DELETE SET NULL,
  status text NOT NULL DEFAULT 'ativa' CONSTRAINT estoque_reservas_status_check
    CHECK (status IN ('ativa', 'liberada', 'consumida', 'expirada')),
  expira_em timestamptz NOT NULL,
  motivo text,
  created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL,
  created_at timestamptz NOT NULL DEFAULT now(),
  atualizado_em timestamptz NOT NULL DEFAULT now()
);

CREATE INDEX IF NOT EXISTS idx_estoque_reservas_ativa
  ON public.estoque_reservas (pool, omie_codigo_produto) WHERE status = 'ativa';
CREATE INDEX IF NOT EXISTS idx_estoque_reservas_checkout
  ON public.estoque_reservas (checkout_id);
CREATE INDEX IF NOT EXISTS idx_estoque_reservas_expira
  ON public.estoque_reservas (expira_em) WHERE status = 'ativa';
-- cinto de segurança da idempotência: no máx. 1 reserva ATIVA por item por checkout
CREATE UNIQUE INDEX IF NOT EXISTS estoque_reservas_checkout_item_ativa_uq
  ON public.estoque_reservas (checkout_id, pool, omie_codigo_produto) WHERE status = 'ativa';

-- RLS: staff lê; escrita de authenticated NÃO existe (nem policy, nem privilégio)
ALTER TABLE public.estoque_reservas ENABLE ROW LEVEL SECURITY;

DROP POLICY IF EXISTS "estoque_reservas_select_staff" ON public.estoque_reservas;
CREATE POLICY "estoque_reservas_select_staff"
  ON public.estoque_reservas
  FOR SELECT
  USING ((SELECT private.cap_estoque_reservar((SELECT auth.uid()))));

DROP POLICY IF EXISTS "estoque_reservas_service_all" ON public.estoque_reservas;
CREATE POLICY "estoque_reservas_service_all"
  ON public.estoque_reservas
  FOR ALL
  USING ((SELECT auth.role()) = 'service_role');

REVOKE ALL ON TABLE public.estoque_reservas FROM PUBLIC;
REVOKE ALL ON TABLE public.estoque_reservas FROM anon;
REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
  ON TABLE public.estoque_reservas FROM authenticated;
GRANT SELECT ON TABLE public.estoque_reservas TO authenticated;
GRANT ALL ON TABLE public.estoque_reservas TO service_role;

-- ────────────────────────────────────────────────────────────
-- 3) Cálculo interno do ATP (SEM gate próprio — REVOKE total abaixo;
--    só as RPCs gateadas deste arquivo a chamam, como owner)
-- ────────────────────────────────────────────────────────────
CREATE OR REPLACE FUNCTION private.atp_disponivel(
  p_pool text,
  p_sku bigint,
  p_excluir_checkout uuid DEFAULT NULL
)
RETURNS TABLE (
  saldo numeric,
  saldo_synced_at timestamptz,
  saldo_confiavel boolean,
  reservado numeric,
  seguranca numeric,
  disponivel numeric
)
LANGUAGE sql
STABLE SECURITY DEFINER
SET search_path TO 'public'
AS $function$
  WITH linha AS (
    -- eleição por frescor entre as contas do pool (padrão ESTOQUE_ACCOUNTS do
    -- cockpit): a linha mais recente vence; empate → account em ordem estável
    SELECT ip.saldo, ip.synced_at
    FROM public.inventory_position ip
    WHERE ip.omie_codigo_produto = p_sku
      AND ip.account = ANY (CASE p_pool WHEN 'oben' THEN ARRAY['vendas','oben'] ELSE ARRAY[]::text[] END)
    ORDER BY ip.synced_at DESC NULLS LAST, ip.account
    LIMIT 1
  ),
  base AS (
    SELECT
      (SELECT l.saldo FROM linha l) AS saldo,
      (SELECT l.synced_at FROM linha l) AS synced_at
  ),
  calc AS (
    SELECT
      b.saldo,
      b.synced_at,
      -- FAIL-CLOSED: linha presente + sync ≤24h + saldo numérico são.
      -- NaN em numeric ordena ACIMA de tudo ('NaN'>=0 é true) → guard explícito.
      (b.synced_at IS NOT NULL
        AND b.synced_at > now() - interval '24 hours'
        AND b.saldo IS NOT NULL
        AND b.saldo <> 'NaN'::numeric
        AND b.saldo >= 0) AS confiavel
    FROM base b
  ),
  res AS (
    SELECT COALESCE(sum(r.quantidade), 0) AS reservado
    FROM public.estoque_reservas r
    WHERE r.pool = p_pool
      AND r.omie_codigo_produto = p_sku
      AND r.status = 'ativa'
      AND r.expira_em > now()
      AND (p_excluir_checkout IS NULL OR r.checkout_id <> p_excluir_checkout)
  ),
  seg AS (
    -- parâmetro ausente = sem colchão configurado (0) — default de política.
    -- Duplicata improvável de (empresa, sku): vence o colchão MAIOR (conservador).
    SELECT COALESCE((
      SELECT sp.estoque_seguranca
      FROM public.sku_parametros sp
      WHERE sp.empresa = (CASE p_pool WHEN 'oben' THEN 'OBEN' END)
        AND sp.sku_codigo_omie = p_sku
        AND sp.estoque_seguranca IS NOT NULL
        AND sp.estoque_seguranca >= 0
      ORDER BY sp.estoque_seguranca DESC
      LIMIT 1
    ), 0) AS seguranca
  )
  SELECT
    c.saldo,
    c.synced_at,
    COALESCE(c.confiavel, false),
    r.reservado,
    s.seguranca,
    -- disponivel pode ser NEGATIVO (reservas+colchão > saldo após queda no sync):
    -- informação honesta p/ a reconciliação — não clampar em 0.
    CASE WHEN COALESCE(c.confiavel, false)
         THEN c.saldo - r.reservado - s.seguranca
         ELSE NULL END
  FROM calc c
  CROSS JOIN res r
  CROSS JOIN seg s;
$function$;

REVOKE ALL ON FUNCTION private.atp_disponivel(text, bigint, uuid) FROM PUBLIC;
REVOKE ALL ON FUNCTION private.atp_disponivel(text, bigint, uuid) FROM anon;
REVOKE ALL ON FUNCTION private.atp_disponivel(text, bigint, uuid) FROM authenticated;
GRANT EXECUTE ON FUNCTION private.atp_disponivel(text, bigint, uuid) TO service_role;

-- ────────────────────────────────────────────────────────────
-- 4) Consulta de disponibilidade (leitura, sem efeito)
--    NÃO expõe cmc/custo nem saldo cru — só o disponível e o veredito.
-- ────────────────────────────────────────────────────────────
CREATE OR REPLACE FUNCTION public.atp_consultar(p_pool text, p_skus bigint[])
RETURNS TABLE (
  omie_codigo_produto bigint,
  disponivel numeric,
  confiavel boolean,
  motivo text,
  saldo_synced_at timestamptz
)
LANGUAGE plpgsql
STABLE SECURITY DEFINER
SET search_path TO 'public'
AS $function$
DECLARE
  v_uid uuid := (SELECT auth.uid());
BEGIN
  IF NOT private.cap_estoque_reservar(v_uid) THEN
    RAISE EXCEPTION 'Sem permissão para consultar disponibilidade de estoque (staff apenas)'
      USING ERRCODE = '42501';
  END IF;
  IF p_pool IS DISTINCT FROM 'oben' THEN
    RAISE EXCEPTION 'Pool de estoque inválido: % — a fase 1 atende apenas ''oben''', COALESCE(p_pool, 'NULL')
      USING ERRCODE = '22023';
  END IF;
  IF p_skus IS NULL OR cardinality(p_skus) = 0 OR cardinality(p_skus) > 500 THEN
    RAISE EXCEPTION 'p_skus deve ter entre 1 e 500 códigos' USING ERRCODE = '22023';
  END IF;

  RETURN QUERY
  SELECT
    s.sku,
    d.disponivel,
    d.saldo_confiavel,
    CASE WHEN NOT d.saldo_confiavel
         THEN 'saldo_indisponivel'::text
         ELSE NULL::text END,
    d.saldo_synced_at
  FROM unnest(p_skus) AS s(sku)
  CROSS JOIN LATERAL private.atp_disponivel(p_pool, s.sku, NULL) AS d;
END;
$function$;

-- ────────────────────────────────────────────────────────────
-- 5) Reservar (atômica, all-or-nothing, idempotente por checkout)
--    Re-chamada do MESMO checkout SUBSTITUI as reservas ativas dele
--    (estado-alvo do carrinho, não delta) — retry seguro.
-- ────────────────────────────────────────────────────────────
CREATE OR REPLACE FUNCTION public.reservar_estoque(
  p_pool text,
  p_checkout_id uuid,
  p_itens jsonb,
  p_ttl_minutos integer DEFAULT 30
)
RETURNS jsonb
LANGUAGE plpgsql
VOLATILE SECURITY DEFINER
SET search_path TO 'public'
AS $function$
DECLARE
  v_uid uuid := (SELECT auth.uid());
  v_total integer;
  v_distintos integer;
  v_invalidos integer;
  v_sku bigint;
  v_item record;
  v_calc record;
  v_recusas jsonb := '[]'::jsonb;
  v_reservas jsonb := '[]'::jsonb;
  v_expira timestamptz;
  v_id uuid;
BEGIN
  IF NOT private.cap_estoque_reservar(v_uid) THEN
    RAISE EXCEPTION 'Sem permissão para reservar estoque (staff apenas)'
      USING ERRCODE = '42501';
  END IF;
  IF p_pool IS DISTINCT FROM 'oben' THEN
    RAISE EXCEPTION 'Pool de estoque inválido: % — a fase 1 atende apenas ''oben''', COALESCE(p_pool, 'NULL')
      USING ERRCODE = '22023';
  END IF;
  IF p_checkout_id IS NULL THEN
    RAISE EXCEPTION 'p_checkout_id é obrigatório' USING ERRCODE = '22023';
  END IF;
  IF p_itens IS NULL OR jsonb_typeof(p_itens) <> 'array' OR jsonb_array_length(p_itens) = 0 THEN
    RAISE EXCEPTION 'p_itens deve ser um array JSON não-vazio de {omie_codigo_produto, quantidade}'
      USING ERRCODE = '22023';
  END IF;
  IF jsonb_array_length(p_itens) > 200 THEN
    RAISE EXCEPTION 'p_itens excede o limite de 200 itens' USING ERRCODE = '22023';
  END IF;
  IF p_ttl_minutos IS NULL OR p_ttl_minutos < 5 OR p_ttl_minutos > 240 THEN
    RAISE EXCEPTION 'p_ttl_minutos fora do intervalo [5, 240]: %', COALESCE(p_ttl_minutos::text, 'NULL')
      USING ERRCODE = '22023';
  END IF;

  -- Shape dos itens: sku e quantidade obrigatórios, quantidade > 0, sem duplicata
  SELECT count(*),
         count(DISTINCT x.omie_codigo_produto),
         count(*) FILTER (WHERE x.omie_codigo_produto IS NULL
                             OR x.quantidade IS NULL
                             OR x.quantidade <= 0
                             OR x.quantidade > 1000000)
    INTO v_total, v_distintos, v_invalidos
  FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric);

  IF v_invalidos > 0 THEN
    RAISE EXCEPTION 'p_itens contém item inválido (sku/quantidade ausente, quantidade fora de (0, 1000000])'
      USING ERRCODE = '22023';
  END IF;
  IF v_distintos <> v_total THEN
    RAISE EXCEPTION 'p_itens contém omie_codigo_produto duplicado — agregue as quantidades antes de chamar'
      USING ERRCODE = '22023';
  END IF;

  -- Serialização: lock do checkout primeiro, depois SKUs em ordem (deadlock-free)
  PERFORM pg_advisory_xact_lock(hashtextextended('atp:checkout:' || p_checkout_id::text, 0));
  FOR v_sku IN
    SELECT DISTINCT x.omie_codigo_produto
    FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric)
    ORDER BY 1
  LOOP
    PERFORM pg_advisory_xact_lock(hashtextextended('atp:sku:' || p_pool || ':' || v_sku::text, 0));
  END LOOP;

  -- Decide TUDO antes de escrever (all-or-nothing sem depender de exception).
  -- O cálculo EXCLUI as reservas ativas do próprio checkout: a substituição
  -- devolve o que ele mesmo segurava antes de decidir.
  FOR v_item IN
    SELECT x.omie_codigo_produto AS sku, x.quantidade AS qtd
    FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric)
    ORDER BY x.omie_codigo_produto
  LOOP
    SELECT * INTO v_calc FROM private.atp_disponivel(p_pool, v_item.sku, p_checkout_id);
    IF NOT v_calc.saldo_confiavel THEN
      v_recusas := v_recusas || jsonb_build_object(
        'omie_codigo_produto', v_item.sku,
        'motivo', 'saldo_indisponivel',
        'detalhe', 'sem posição de estoque confiável (ausente, defasada >24h ou inválida)',
        'solicitado', v_item.qtd,
        'disponivel', NULL);
    ELSIF v_item.qtd > v_calc.disponivel THEN
      v_recusas := v_recusas || jsonb_build_object(
        'omie_codigo_produto', v_item.sku,
        'motivo', 'saldo_insuficiente',
        'solicitado', v_item.qtd,
        'disponivel', v_calc.disponivel);
    END IF;
  END LOOP;

  IF jsonb_array_length(v_recusas) > 0 THEN
    RETURN jsonb_build_object(
      'ok', false,
      'pool', p_pool,
      'checkout_id', p_checkout_id,
      'recusas', v_recusas);
  END IF;

  -- Substituição: libera as ativas anteriores deste checkout+pool e grava o estado-alvo
  UPDATE public.estoque_reservas
     SET status = 'liberada',
         motivo = 'substituida por nova reserva do mesmo checkout',
         atualizado_em = now()
   WHERE checkout_id = p_checkout_id
     AND pool = p_pool
     AND status = 'ativa';

  v_expira := now() + make_interval(mins => p_ttl_minutos);

  FOR v_item IN
    SELECT x.omie_codigo_produto AS sku, x.quantidade AS qtd
    FROM jsonb_to_recordset(p_itens) AS x(omie_codigo_produto bigint, quantidade numeric)
    ORDER BY x.omie_codigo_produto
  LOOP
    INSERT INTO public.estoque_reservas
      (pool, omie_codigo_produto, quantidade, checkout_id, status, expira_em, created_by)
    VALUES
      (p_pool, v_item.sku, v_item.qtd, p_checkout_id, 'ativa', v_expira, v_uid)
    RETURNING id INTO v_id;
    v_reservas := v_reservas || jsonb_build_object(
      'id', v_id,
      'omie_codigo_produto', v_item.sku,
      'quantidade', v_item.qtd,
      'expira_em', v_expira);
  END LOOP;

  RETURN jsonb_build_object(
    'ok', true,
    'pool', p_pool,
    'checkout_id', p_checkout_id,
    'reservas', v_reservas);
END;
$function$;

-- ────────────────────────────────────────────────────────────
-- 6) Liberar (cancelamento/abandono do checkout)
-- ────────────────────────────────────────────────────────────
CREATE OR REPLACE FUNCTION public.liberar_reserva_checkout(
  p_checkout_id uuid,
  p_pool text DEFAULT NULL,
  p_motivo text DEFAULT NULL
)
RETURNS jsonb
LANGUAGE plpgsql
VOLATILE SECURITY DEFINER
SET search_path TO 'public'
AS $function$
DECLARE
  v_uid uuid := (SELECT auth.uid());
  v_n integer;
BEGIN
  IF NOT private.cap_estoque_reservar(v_uid) THEN
    RAISE EXCEPTION 'Sem permissão para liberar reserva de estoque (staff apenas)'
      USING ERRCODE = '42501';
  END IF;
  IF p_checkout_id IS NULL THEN
    RAISE EXCEPTION 'p_checkout_id é obrigatório' USING ERRCODE = '22023';
  END IF;
  IF p_pool IS NOT NULL AND p_pool <> 'oben' THEN
    RAISE EXCEPTION 'Pool de estoque inválido: % — a fase 1 atende apenas ''oben''', p_pool
      USING ERRCODE = '22023';
  END IF;

  PERFORM pg_advisory_xact_lock(hashtextextended('atp:checkout:' || p_checkout_id::text, 0));

  UPDATE public.estoque_reservas
     SET status = 'liberada',
         motivo = COALESCE(p_motivo, 'liberacao pelo caller'),
         atualizado_em = now()
   WHERE checkout_id = p_checkout_id
     AND status = 'ativa'
     AND (p_pool IS NULL OR pool = p_pool);
  GET DIAGNOSTICS v_n = ROW_COUNT;

  RETURN jsonb_build_object('ok', true, 'checkout_id', p_checkout_id, 'liberadas', v_n);
END;
$function$;

-- ────────────────────────────────────────────────────────────
-- 7) Higiene: marca reservas vencidas (vencida já NÃO desconta no cálculo;
--    isto dá observabilidade e evita acúmulo de 'ativa' morta)
-- ────────────────────────────────────────────────────────────
CREATE OR REPLACE FUNCTION public.expirar_reservas_vencidas()
RETURNS jsonb
LANGUAGE plpgsql
VOLATILE SECURITY DEFINER
SET search_path TO 'public'
AS $function$
DECLARE
  v_uid uuid := (SELECT auth.uid());
  v_n integer;
BEGIN
  IF NOT private.cap_estoque_reservar(v_uid) THEN
    RAISE EXCEPTION 'Sem permissão para expirar reservas de estoque (staff apenas)'
      USING ERRCODE = '42501';
  END IF;

  UPDATE public.estoque_reservas
     SET status = 'expirada',
         motivo = 'expirada por TTL',
         atualizado_em = now()
   WHERE status = 'ativa'
     AND expira_em <= now();
  GET DIAGNOSTICS v_n = ROW_COUNT;

  RETURN jsonb_build_object('ok', true, 'expiradas', v_n);
END;
$function$;

-- ────────────────────────────────────────────────────────────
-- 8) Privilégios das RPCs públicas: EXECUTE só a authenticated (gate interno
--    barra customer com 42501) e service_role; anon/PUBLIC fora.
-- ────────────────────────────────────────────────────────────
REVOKE ALL ON FUNCTION public.atp_consultar(text, bigint[]) FROM PUBLIC;
REVOKE ALL ON FUNCTION public.atp_consultar(text, bigint[]) FROM anon;
GRANT EXECUTE ON FUNCTION public.atp_consultar(text, bigint[]) TO authenticated, service_role;

REVOKE ALL ON FUNCTION public.reservar_estoque(text, uuid, jsonb, integer) FROM PUBLIC;
REVOKE ALL ON FUNCTION public.reservar_estoque(text, uuid, jsonb, integer) FROM anon;
GRANT EXECUTE ON FUNCTION public.reservar_estoque(text, uuid, jsonb, integer) TO authenticated, service_role;

REVOKE ALL ON FUNCTION public.liberar_reserva_checkout(uuid, text, text) FROM PUBLIC;
REVOKE ALL ON FUNCTION public.liberar_reserva_checkout(uuid, text, text) FROM anon;
GRANT EXECUTE ON FUNCTION public.liberar_reserva_checkout(uuid, text, text) TO authenticated, service_role;

REVOKE ALL ON FUNCTION public.expirar_reservas_vencidas() FROM PUBLIC;
REVOKE ALL ON FUNCTION public.expirar_reservas_vencidas() FROM anon;
GRANT EXECUTE ON FUNCTION public.expirar_reservas_vencidas() TO authenticated, service_role;
```
</details>

Validação pós-apply (read-only, por CATÁLOGO — eu rodo via psql-ro quando o founder avisar):

```sql
SELECT CASE WHEN
    (SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='estoque_reservas') = 1
AND (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
     WHERE n.nspname='private' AND p.proname IN ('cap_estoque_reservar','atp_disponivel')) = 2
AND (SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
     WHERE n.nspname='public' AND p.proname IN ('atp_consultar','reservar_estoque','liberar_reserva_checkout','expirar_reservas_vencidas')) = 4
AND (SELECT relrowsecurity FROM pg_class WHERE oid='public.estoque_reservas'::regclass)
AND (SELECT count(*) FROM pg_policy WHERE polrelid='public.estoque_reservas'::regclass) = 2
AND (SELECT count(*) FROM pg_indexes WHERE schemaname='public' AND tablename='estoque_reservas') = 5
AND NOT has_table_privilege('authenticated','public.estoque_reservas','INSERT')
AND NOT has_function_privilege('anon','public.reservar_estoque(text,uuid,jsonb,integer)','EXECUTE')
THEN '✅ ATP fase 1 aplicada (tabela+RLS+2 policies+5 índices+6 funções+privilégios fechados)'
ELSE '❌ INCOMPLETA — me avise o que retornou' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
