### PR TITLE
fix(skill): /fecho dava "pode excluir" sem nunca olhar se a MAIN está verde

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -8,7 +8,8 @@ description: >-
   ad-hoc falha por partes — PR órfão descoberto dias depois (auto-merge não verificado), Publish
   esquecido, migration entregue mas nunca aplicada, chip sem rastreio. A skill responde com
   EVIDÊNCIA (gh/psql-ro/git), não de memória: PRs da sessão, migrations entregues × aplicadas,
-  edges deployadas, Publish, chips abertos, resumo de fecho padrão, wt:status. NÃO use para:
+  edges deployadas, Publish, main verde (PR verde ≠ main verde), chips abertos, resumo de
+  fecho padrão, wt:status. NÃO use para:
   fechar uma ENTREGA no meio da sessão (use lovable-deploy-verify) ou gerar briefing pra
   continuar em sessão nova (use handoff-sessao).
 ---
@@ -17,7 +18,7 @@ description: >-
 
 ## Princípio
 
-O veredito "pode excluir" sai de **evidência coletada agora**, nunca de memória da conversa.
+O veredito "pode arquivar" sai de **evidência coletada agora**, nunca de memória da conversa.
 Cada item abaixo tem um comando concreto; o resultado decide ✅/❌. Se QUALQUER item crítico
 estiver pendente, o veredito é "**ainda não** — falta X" com a lista numerada do que fica na
 mão do founder.
@@ -37,7 +38,7 @@ veredito, para nada ficar dependendo da memória dele:
 
 O veredito final rotula cada pendência com seu destino: ✔ resolvida agora · 🔘 chip
 "<título exato>" · 🚫 descartada (porquê) · 📌 registrada em <doc> com gatilho. **"PODE
-excluir" só quando TODA pendência tem destino** — "fica na sua mão lembrar" não é destino.
+ARQUIVAR" só quando TODA pendência tem destino** — "fica na sua mão lembrar" não é destino.
 
 Crie estes todos (TodoWrite) e siga em ordem:
 
@@ -45,9 +46,10 @@ Crie estes todos (TodoWrite) e siga em ordem:
 2. **Migrations** — entregues × APLICADAS no banco (psql-ro)
 3. **Edges** — deployadas via chat do Lovable?
 4. **Publish** — frontend publicado (ou pendente)?
-5. **Chips** — abertos nesta sessão, com título exato
-6. **Resumo de fecho** — formato padrão do CLAUDE.md
-7. **wt:status** — higiene de RAM + oferta de limpeza
+5. **A MAIN está verde?** — PR verde ≠ main verde (só se a sessão mergeou algo)
+6. **Chips** — abertos nesta sessão, com título exato
+7. **Resumo de fecho** — formato padrão do CLAUDE.md
+8. **wt:status** — higiene de RAM + oferta de limpeza
 
 ---
 
@@ -80,6 +82,12 @@ gh pr view <N> --json state,mergeStateStatus,statusCheckRollup,url
 # o que esta sessão criou/mergeou de migration
 git log origin/main --oneline -20 -- supabase/migrations/   # mergeadas recentes
 git diff --name-only origin/main...HEAD -- supabase/migrations/  # ainda no branch
+
+# ⚠️ E o que OUTRAS sessões mergearam durante a janela desta — com ~30 worktrees paralelas,
+# migration custom de terceiro entra na main sem ninguém aqui saber, e ela também NÃO se
+# auto-aplica. Custa uma query e a falha é SILENCIOSA (2026-08-06: a ATP fase 1 entrou entre
+# dois merges meus; conferida, estava aplicada — mas ninguém a teria conferido).
+git log origin/main --since="<hora de início da sessão>" --name-only --format="" -- supabase/migrations/ | sort -u
 ```
 
 Pra cada migration da sessão, **prove no banco** (leitura direta — não pergunte ao founder):
@@ -109,28 +117,57 @@ Se a sessão tocou `src/` e a mudança já mergeou: o Publish foi feito e verifi
 `lovable-deploy-verify` passo 4)? Pendente → item na lista do founder: "**Publish** no editor do
 Lovable (depois me peça a verificação por bytes em sessão viva, ou rode-a você)".
 
-### Passo 5 — Chips (spawn_task)
+### Passo 5 — A MAIN está verde? (só se a sessão mergeou algo)
+
+**PR verde ≠ main verde.** O verde do PR atesta a base do momento em que o CI *rodou*; entre
+ele e o merge cabe outro PR que muda a régua. Dois PRs verdes ISOLADAMENTE podem quebrar a
+main JUNTOS — conflito semântico, que o git mescla sem reclamar. Não é hipótese: em
+2026-08-06 o #1670 (gate de índice de docs) e o #1212 (que trazia um `.md` de julho, sem
+linha no índice) mergearam com **135 segundos** de diferença e derrubaram a main por ~5h.
+
+⚠️ **`gh run list --branch main` NÃO serve para isso.** O `auto-merge.yml` usa
+`secrets.GITHUB_TOKEN` e, pela proteção anti-loop do GitHub, o push dele **não aciona
+workflow nenhum** — o último run de `push` na main costuma ser de semanas atrás (só a via do
+bot do Lovable cai ali). Consultar isso dá "verde por ausência de dado". Dispare de verdade:
+
+```bash
+gh workflow run CI --ref main            # o botão "validar a main agora" (~6 min)
+sleep 60 && gh run list --branch main --workflow CI --limit 1 --json databaseId,status,conclusion
+```
+
+- `success` → ✅ pode fechar.
+- `failure` → ❌ **investigue antes de fechar** — mas distinga REPROVAÇÃO de AUSÊNCIA DE
+  RUNNER: job `cancelled` sem nenhum step executado, com duração ≈ `timeout-minutes`, é fila
+  de runner, não defeito. Confirme pelo passe vizinho (outro run do repo verde na mesma
+  janela) antes de re-rodar; sem isso, rerun só apaga sinal.
+- Não deu tempo de esperar → entregue o link do run na mensagem de fecho como pendência com
+  destino (o `schedule` diário das 09:17 UTC pega de qualquer forma, mas só no dia seguinte).
+
+### Passo 6 — Chips (spawn_task)
 
 Liste TODO chip criado nesta sessão com o **título exato** e 1 linha do que faz — o founder é
 quem clica, e chip sem rastreio já gerou confusão ("não consegui identificar qual é este chip").
 Se um chip ficou obsoleto pelo próprio trabalho da sessão, diga explicitamente que pode ignorar.
 
-### Passo 6 — Resumo de fecho (formato padrão)
+### Passo 7 — Resumo de fecho (formato padrão)
 
 > **Problema** → **Diagnóstico** → **Decisões (e pareceres Codex)** → **Implementado**
 > (arquivos · PRs · migrations) → **Verificação** (o que foi provado e como) →
 > **Pendências do founder** (lista numerada, com destino rotulado: 🟣 SQL Editor / 💬 chat
 > Lovable / 🖱️ Publish / 🔘 chip) → **Onde está persistido** (PRs, docs/historico, docs/agent).
 
-### Passo 7 — Higiene de RAM
+### Passo 8 — Higiene de RAM
 
 ```bash
-bun run wt:status
+bun run wt:status   # ⚠️ com a máquina em swap passa de 120s → rode com run_in_background:true
 ```
 
 Reporte o resultado e ofereça `wt:clean` / `wt:reap` (e `wt:prune` se houver worktree de
-conversa já excluída). Ao fechar ESTA sessão: lembre que `wt:clean --include-current` libera o
-node_modules dela.
+conversa já excluída) — isso vale para as **outras** worktrees paradas.
+
+**Para ESTA sessão, não ofereça `wt:clean --include-current`:** arquivar já para o processo
+**e limpa o worktree** por padrão (e a sessão segue reabrível pela lista de Arquivadas).
+Sugerir a limpeza manual em cima disso é redundante e faz o founder trabalhar à toa.
 
 ---
 
@@ -142,14 +179,20 @@ node_modules dela.
 ✅ PRs: #A, #B mergeados (CI verde)
 ✅ Migrations: 2026…_x.sql aplicada (validação psql-ro ✅)
 ✅ Edges/Publish: n/a (sessão só de tooling)
+✅ Main: CI completo verde (run <id>, disparado agora)
 Pendências (TODAS com destino — nenhuma "na memória"):
   ✔ <pendência resolvida agora, com a evidência>
   🔘 chip "<título exato>" (faz X — clique quando quiser)
   🚫 <pendência descartada> — porquê em 1 linha
   📌 <pendência futura> — registrada em <doc/plano>, vira chip quando <gatilho>
 
-Veredito: PODE excluir a sessão. / AINDA NÃO — falta (1)…
+Veredito: PODE ARQUIVAR a sessão. / AINDA NÃO — falta (1)…
 ```
 
-Nunca diga "pode excluir" com item ❌/⏳ crítico em aberto sem nomeá-lo na lista do founder —
+**Diga "pode ARQUIVAR", não "pode excluir".** Arquivar para o processo, limpa o worktree
+(mesma RAM e mesmo disco que excluir) e ainda deixa a sessão reabrível — não há motivo para
+recomendar a via destrutiva. Se o founder arquiva sessão a sessão na mão, mencione UMA vez a
+preferência **"Auto-archive on PR close"** nas Settings, que resolve isso estruturalmente.
+
+Nunca diga "pode arquivar" com item ❌/⏳ crítico em aberto sem nomeá-lo na lista do founder —
 e nunca com pendência SEM um dos 4 destinos acima ("fica na sua mão lembrar" não é destino).


### PR DESCRIPTION
## O buraco

O ritual verificava PRs, migrations, edges, Publish e chips — tudo do **PR** — e concluía. Mas **PR verde ≠ main verde**: o verde do PR atesta a base do momento em que o CI *rodou*, e entre ele e o merge cabe outro PR que muda a régua. Dois PRs verdes isoladamente quebram a main **juntos**, e o git mescla sem reclamar porque não é conflito de texto.

Não é hipótese. Em 2026-08-06, o #1670 (gate de índice de docs) e o #1212 (que trazia um `.md` de julho, sem linha no índice) mergearam com **135 segundos** de diferença e derrubaram a main por ~5h. O fecho daquela sessão teria dito "pode excluir" com a main vermelha.

## Mudanças

**1. Passo 5 novo — "a MAIN está verde?"** (só quando a sessão mergeou algo), com a armadilha que me fez errar o diagnóstico na hora: `gh run list --branch main` **não serve**, porque o `auto-merge.yml` usa `secrets.GITHUB_TOKEN` e a proteção anti-loop do GitHub impede que esse push acione workflow — o último run de push na main era de semanas antes. Consultar aquilo é "verde por ausência de dado". Tem que ser `gh workflow run CI --ref main`.

Inclui também como distinguir **reprovação** de **ausência de runner** (job `cancelled` sem nenhum step, duração ≈ `timeout-minutes`): confirmar pelo passe vizinho antes de re-rodar, senão o rerun só apaga sinal.

**2. Veredito passa a ser "pode ARQUIVAR"**, não "excluir". Arquivar para o processo, limpa o worktree (mesma RAM e mesmo disco que excluir) e ainda deixa a sessão reabrível — não há motivo para recomendar a via destrutiva. Sai também a oferta de `wt:clean --include-current` para a sessão atual, que era retrabalho: o archive já limpa o worktree dela. Entra a menção à preferência "Auto-archive on PR close" para quem arquiva uma a uma.

**3. Passo 2 amplia** para migrations que **outras** sessões mergearam na janela desta: com ~30 worktrees paralelas, migration custom de terceiro entra na main sem ninguém aqui saber, e também não se auto-aplica — falha silenciosa. Custa uma query.

**4. Passo 8**: `wt:status` passa de 120s com a máquina em swap → `run_in_background`.

## Verificação

- Numeração dos 8 passos consistente entre a lista e os `###` (conferido).
- As ocorrências de "excluir" que sobraram são só o **gatilho** no `description` do frontmatter ("Lucas perguntar se pode excluir/apagar") — que deve continuar casando o fraseado dele — e a frase que contrasta arquivar × excluir.
- Nenhum teste do repo lê `.claude/skills/` (`grep -rl` em `scripts`/`src`: 0), então a suíte não cobre este arquivo; a validação é a leitura + o CI.
- O comando novo (`gh workflow run CI --ref main`) foi **usado de verdade** na sessão que originou este fix (run `31136701379`, main verde).

Contexto completo: `docs/historico/prs-parados-2026-08-06.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)