### PR TITLE
chore(ci): família B — deno.land/std/http/server → Deno.serve nas 34 edges (tira um host do caminho de entrega)

### DIFF
--- a/supabase/functions/ai-ops-agent/index.ts
+++ b/supabase/functions/ai-ops-agent/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { fetchAll } from "../_shared/paginate.ts";
 
@@ -199,7 +198,7 @@ function calculateScore(m: CustomerMetric): {
   };
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/analyze-services/index.ts
+++ b/supabase/functions/analyze-services/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import {
@@ -26,7 +25,7 @@ interface UserTool {
   } | null;
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import {
@@ -157,7 +156,7 @@ interface OmieClienteCadastroResponse {
   }>;
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/biometric-auth/index.ts
+++ b/supabase/functions/biometric-auth/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { verifyAuthenticationResponse } from "npm:@simplewebauthn/server@10.0.1";
 
@@ -33,7 +32,7 @@ function getClientIp(req: Request): string {
   );
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/copilot-analyze/index.ts
+++ b/supabase/functions/copilot-analyze/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
@@ -18,7 +17,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/elevenlabs-scribe-token/index.ts
+++ b/supabase/functions/elevenlabs-scribe-token/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
@@ -7,7 +6,7 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version',
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/elevenlabs-transcribe/index.ts
+++ b/supabase/functions/elevenlabs-transcribe/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
@@ -9,7 +8,7 @@ const corsHeaders = {
 const MAX_AUDIO_SIZE = 10 * 1024 * 1024; // 10MB
 const ALLOWED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/webm', 'audio/mp4', 'audio/x-m4a'];
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/fin-cashflow-engine/index.ts
+++ b/supabase/functions/fin-cashflow-engine/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 // Anti-truncamento do PostgREST (cap default de 1000 linhas): a colacor tem ~11k CP e
 // ~29k CR não-cancelados; um .select() simples carregaria só as 1000 primeiras (quase
@@ -133,7 +132,7 @@ type Input = {
   save_snapshot?: boolean;
 };
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
 
   const auth = await authorizeCronOrStaff(req);

--- a/supabase/functions/fin-funding/index.ts
+++ b/supabase/functions/fin-funding/index.ts
@@ -4,7 +4,6 @@
 // fin_contas_receber (títulos antecipáveis) e compõe projeção via fin-cashflow-engine.
 // Helpers espelhados VERBATIM de src/lib/financeiro/funding-helpers.ts.
 // Spec: 2026-05-25-financeiro-funding-divida (sub-PR A: decisão de antecipação).
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 // Paginação robusta (anti-truncamento do cap de 1000 do PostgREST). Era uma CÓPIA local
 // do helper do fin-valor-cockpit, com o mesmo furo: `data ?? []` transformava resposta
@@ -354,7 +353,7 @@ type A4Response = {
 
 // ===================== Handler principal =====================
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   const auth = await authorizeMaster(req);
   if (!auth.ok) return auth.response;

--- a/supabase/functions/fin-ic-reconcile/index.ts
+++ b/supabase/functions/fin-ic-reconcile/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 // =============================================================
@@ -96,7 +95,7 @@ function daysBetween(a: string, b: string): number {
   );
 }
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/fin-next-best-action/index.ts
+++ b/supabase/functions/fin-next-best-action/index.ts
@@ -1,7 +1,6 @@
 // supabase/functions/fin-next-best-action/index.ts
 // A4 — Próxima Melhor Ação. Gate gestor+master. Compõe A1/A2/A3 via service_role.
 // Helper espelhado VERBATIM de src/lib/financeiro/next-best-action-helpers.ts.
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -110,7 +109,7 @@ async function invoke<T>(fn: string, body: unknown): Promise<T | null> {
   } catch { return null; } finally { clearTimeout(timer); }
 }
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   const auth = await authorizeGestorOuMaster(req);
   if (!auth.ok) return auth.response;

--- a/supabase/functions/fin-period-override/index.ts
+++ b/supabase/functions/fin-period-override/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 // =============================================================
@@ -75,7 +74,7 @@ type OverridePayload = {
   acao_planejada: string;
 };
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
 
   const auth = await authorizeCronOrStaff(req);

--- a/supabase/functions/fin-regime-tributario/index.ts
+++ b/supabase/functions/fin-regime-tributario/index.ts
@@ -3,7 +3,6 @@
 // Master-only. Lê DRE TTM (fin_dre_snapshots, regime competência) + inputs manuais (fin_regime_inputs).
 // Helpers espelhados VERBATIM de src/lib/financeiro/regime-tributario-helpers.ts (+ dre-tabelas-tributarias.ts
 // e aliquotaEfetivaSimples/faixaPorRBT12 de dre-helpers.ts). Estilo de leitura espelhado de fin-valor-engine.
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -550,7 +549,7 @@ async function calcularEmpresa(db: DbClient, empresa: Company): Promise<RegimeEm
 
 const NIVEL_NUM: Record<"alta" | "media" | "baixa", number> = { baixa: 1, media: 2, alta: 3 };
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   const auth = await authorizeMaster(req);
   if (!auth.ok) return auth.response;

--- a/supabase/functions/fin-suggest-mapping/index.ts
+++ b/supabase/functions/fin-suggest-mapping/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 // =============================================================
@@ -92,7 +91,7 @@ const KEYWORDS: Array<[RegExp, DreLinha]> = [
   [/cmv|mercador|insumo|mat[ée]ria.prima/i, 'cmv'],
 ];
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
   const auth = await authorizeCronOrStaff(req);
   if (!auth.ok) return auth.response;

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -1,7 +1,6 @@
 // supabase/functions/fin-valor-cockpit/index.ts
 // A3 — Cockpit de Valor (Oben). Gate: master OU commercial_role gerencial/estrategico/super_admin.
 // Helpers espelhados VERBATIM de src/lib/financeiro/valor-cockpit-helpers.ts.
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 // Paginação robusta (anti-truncamento do cap de 1000 do PostgREST). Era um helper LOCAL
 // (definido dentro do handler) com `data ?? []`: resposta malformada (data:null SEM
@@ -405,7 +404,7 @@ const COMPANY = "oben";
 const ESTOQUE_ACCOUNTS = ["vendas", "oben"];
 const CONFIG_DEFAULT: CockpitConfig = { margem_minima_pct: 0.15, desconto_max_pct: 0.10, prazo_alvo_dias: 30, dias_estoque_max: 120, sample_min_receita: 5000 };
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   const auth = await authorizeGestorOuMaster(req);
   if (!auth.ok) return auth.response;

--- a/supabase/functions/fin-valor-engine/index.ts
+++ b/supabase/functions/fin-valor-engine/index.ts
@@ -2,7 +2,6 @@
 // A2 — Retorno & Valor (ROIC/WACC/EVA). Master-only. Lê DRE TTM (fin_dre_snapshots),
 // NCG (fin_projecao_snapshots.ncg) e inputs manuais (fin_config_cashflow.valor_inputs),
 // e devolve o bloco "valor" por empresa. Helpers espelhados VERBATIM de src/lib/financeiro/valor-helpers.ts.
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -246,7 +245,7 @@ type ValorInputsRaw = {
   intercompany_giro?: unknown;
 };
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   const auth = await authorizeMaster(req);
   if (!auth.ok) return auth.response;

--- a/supabase/functions/generate-bundle-argument/index.ts
+++ b/supabase/functions/generate-bundle-argument/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import {
@@ -20,7 +19,7 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-supabase-client-platform, x-supabase-client-platform-version, x-supabase-client-runtime, x-supabase-client-runtime-version",
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
 
   try {

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -6,7 +6,6 @@
 // ele derrubou as 7 edges que serve, e o batch noturno de planos táticos — o maior
 // consumidor, 59 chamadas/dia — parou por completo (0 planos de 27/07 a 29/07).
 // Contrato de request/response inalterado: o front (useTacticalPlan) não muda.
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 // ⚠️ usar npm: (não esm.sh) — esm.sh/@supabase/supabase-js falhava em resolver no boot
 // do edge runtime, dando RUNTIME_ERROR sem linha/stack (lição do #1592).
@@ -51,7 +50,7 @@ function clampRecencyCapDays(raw: unknown): number {
   return Math.min(MAX_RECENCY_CAP_DAYS, Math.max(MIN_RECENCY_CAP_DAYS, Math.round(n)));
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response('ok', { headers: corsHeaders });
   }

--- a/supabase/functions/identify-tool/index.ts
+++ b/supabase/functions/identify-tool/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import {
@@ -23,7 +22,7 @@ const corsHeaders = {
 // folga sob o teto de 10 MB da API.
 const MAX_IMAGE_SIZE = 8 * 1024 * 1024;
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import {
@@ -226,7 +225,7 @@ async function authenticateRequest(req: Request): Promise<{ authenticated: boole
   return { authenticated: isStaff, isAdmin: roleData?.role === 'master' };
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { comRegistro, type DbRegistro } from "../_shared/registro-execucao.ts";
@@ -1931,7 +1930,7 @@ async function computeAssociationRules(db: SupabaseClient) {
 
 // ======== MAIN HANDLER ========
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/omie-cliente/index.ts
+++ b/supabase/functions/omie-cliente/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { fetchAll } from "../_shared/paginate.ts";
 import {
@@ -633,7 +632,7 @@ async function consultarClienteCompleto(codigoCliente: number): Promise<OmieClie
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 // Paginação canônica do PostgREST — lança em error E em `data:null` sem error (resposta
 // malformada ≠ fim da tabela). Substitui o laço à mão do carregarBaixaMapDRE, cujo
@@ -2246,7 +2245,7 @@ async function runLeasedCompanySync(
 }
 
 // ═══════════════ HANDLER PRINCIPAL ═══════════════
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }

--- a/supabase/functions/omie-malha-sync/index.ts
+++ b/supabase/functions/omie-malha-sync/index.ts
@@ -1,7 +1,6 @@
 // omie-malha-sync — espelha a ESTRUTURA de produtos (malha) do Omie Colacor para pcp_malha_staging.
 // Ações: {action:"probe"} → shape da página 1 (não escreve nada); {action:"sync"} → pagina até vazio + upsert.
 // Spec: docs/superpowers/specs/2026-07-03-pcp-colacor-blueprint-design.md (§3 Camada 0 item 2)
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { avaliarPagina, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
@@ -108,7 +107,7 @@ function extractPaiCodigo(item: unknown): number {
   return Number.isFinite(n) && n > 0 ? n : NaN;
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   // AuthResult da casa (_shared/auth.ts): no erro já traz uma Response 401 pronta (com CORS) — reusar.
   const auth = await authorizeCronOrStaff(req);

--- a/supabase/functions/omie-sync-metadados/index.ts
+++ b/supabase/functions/omie-sync-metadados/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCron, corsHeaders } from "../_shared/auth.ts";
 import { avaliarPagina, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
@@ -212,7 +211,7 @@ async function syncMetadadosAccount(
   };
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/omie-sync/index.ts
+++ b/supabase/functions/omie-sync/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { classificarFaultstring, redigirSegredo } from "../_shared/omie-falha.ts";
@@ -880,7 +879,7 @@ async function bumpRetryOsSync(
   return { order_id: orderId, retry: novasTent, em_min: backoffMin };
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { omieDateToIso, classifyOmieTransient, classifyPedidosPage, gerarJanelasMensais } from "./pagination.ts";
@@ -2289,7 +2288,7 @@ async function releaseVendasCursor(
   if (error) console.error(`[sync_pedidos][${account}] release falhou:`, error.message);
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/omie-webhook/index.ts
+++ b/supabase/functions/omie-webhook/index.ts
@@ -11,7 +11,6 @@
 //   6. Processar o evento em background
 // ============================================================================
 
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
 import { redigirSegredo } from "../_shared/omie-falha.ts";
 
@@ -170,7 +169,7 @@ async function processarEvento(
   }
 }
 
-serve(async (req: Request) => {
+Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/process-nfe/index.ts
+++ b/supabase/functions/process-nfe/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
@@ -148,7 +147,7 @@ interface StepResult {
   detail?: string;
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/process-recurring-orders/index.ts
+++ b/supabase/functions/process-recurring-orders/index.ts
@@ -1,8 +1,7 @@
-import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCron, corsHeaders } from "../_shared/auth.ts";
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/sync-reprocess/index.ts
+++ b/supabase/functions/sync-reprocess/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCron, corsHeaders } from "../_shared/auth.ts";
 import {
@@ -745,7 +744,7 @@ async function reprocessInventory(
 
 // ======== MAIN HANDLER ========
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/tint-import/index.ts
+++ b/supabase/functions/tint-import/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
 const corsHeaders = {
@@ -68,7 +67,7 @@ export function parseDecimalBR(input: string): number | null {
 // O espelho acima fica mesmo SEM uso local: `edge-parse-parity.test.ts` (vitest) lê ESTE
 // arquivo e exige a função verbatim + os marcadores MIRROR. Não remova por parecer órfão.
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/tint-omie-sync/index.ts
+++ b/supabase/functions/tint-omie-sync/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { avaliarPagina, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
@@ -116,7 +115,7 @@ async function callOmieApi(
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response(null, { headers: corsHeaders });
   }

--- a/supabase/functions/verify-employee/index.ts
+++ b/supabase/functions/verify-employee/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
@@ -169,7 +168,7 @@ async function buscarFuncionarioPorCPF(
   }
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
   }


### PR DESCRIPTION
## O que muda

As **34 edges** que ainda importavam `serve` de `https://deno.land/std@…/http/server.ts` passam a usar
`Deno.serve` nativo — a mesma API que as outras **61 edges do repo já usam**. O import some, a chamada
troca de `serve(handler)` para `Deno.serve(handler)`. Nada mais: 34 arquivos, +34 −68.

Com isso o host **`deno.land` sai do caminho de entrega de todo PR do repo**.

## Por quê — o `edges:typecheck` é o único step do `validate` que precisa de rede

O #1670, uma PR **só de documentação**, caiu com:

```
error: Import 'https://esm.sh/@supabase/supabase-js@2.112.2/dist/index.d.mts' failed: 500 Internal Server Error
```

O gate agiu certo (*"não conseguir checar não é o mesmo que estar limpo"* — o fail-closed é desenho) e o
rerun passou. Mas o `deno check` resolve o grafo de verdade, e hoje ele arrasta **dois hosts que não estão
no caminho de entrega por nenhum outro motivo**: `esm.sh` e `deno.land`. Todo PR do repo fica refém deles.
É a mesma forma do incidente de 2026-07-16 — a degradação da REST API do GitHub matou todo PR em ~6s —
que motivou o `bunpin:check`.

Este PR mata **`deno.land`** (família B). O `esm.sh` cai nos PRs seguintes (família A, 19 edges).
Follow-up nº 2 já medido em `docs/historico/ci-testes-edge-deno.md` §"Follow-ups (medidos)".

## Assinatura do handler — conferida, não assumida

`std/http/server.ts` passa `(req, connInfo)`; `Deno.serve` passa `(req, info)`. A troca só é drop-in se
ninguém usar o 2º parâmetro nem as options. Medido nos 34:

- handlers com 2º parâmetro: **0**
- `serve(handler, {...})` com options: **0**
- forma da chamada: **34/34** em `^serve(` no top-level, uma por arquivo

Sobrou `serve` em 6 lugares — todos a palavra portuguesa *"serve"* em comentário de prosa, nenhum código.
Conferido também o único teste textual que lê um `index.ts` da família (`tint-import/retired_test.ts`):
ele assere sobre `TINT_IMPORT_RETIRED`, `status: 410` e `.from("tint_` — nada sobre `serve(`.

## Produção: nada muda no merge, e o redeploy é a direção já provada

O `deno check` roda sobre o **repo**, então o host sai do CI **no merge**. As edges em produção seguem com
o import antigo até serem redeployadas pelo chat do Lovable — risco ~zero agora.

**Não faça mutirão de redeploy.** Deixe cada edge pegar a mudança no próximo deploy natural dela.

E vale dizer qual é a direção: `Deno.serve` é a API do próprio runtime, sem download, e é o que 61 edges
em produção já fazem. Não há interop nova a observar aqui — diferente da família A, onde a troca
`esm.sh` → `npm:` muda o caminho de resolução.

## Colisão com PRs em voo

Três PRs **draft** tocam arquivos desta família: #1622 (`analyze-unified-order`), #1520
(`generate-bundle-argument`), #1326 (`omie-analytics-sync`, `omie-vendas-sync`). Draft não auto-mergeia,
então o rebase é do lado deles, e o conflito é de duas linhas (remover o import, prefixar `Deno.`).

## Evidência

Rodados os **10 steps do `validate`**, não só os que pareciam relevantes ao diff — todos `exit 0`:

| Gate | Resultado |
|---|---|
| `bun run edges:typecheck` | 0 — 0 crash-class, 136 tolerados (**= baseline da main**) |
| `bun run test:edges` (`--no-remote`) | 0 — 613 passed, 0 failed |
| `bunx tsc --noEmit -p tsconfig.app.json` | 0 |
| `bun run test` (vitest) | 0 |
| `bun lint` | 0 |
| `bun run b‌uild` | 0 |
| `claude:size` · `authz:check` · `bunpin:check` · `docs:indice` | 0 |
| import de `deno.land` em `supabase/functions/` | **0** (era 34) |
| edges com `Deno.serve` | **95** (era 61) |

O `edges:typecheck` sair **idêntico ao baseline** é o resultado esperado, não um empate morno:
`Deno.serve` é tipado pelo próprio runtime, então a troca não devia mover o número em nenhuma direção.
Um delta aqui seria sinal de que a migração mudou mais do que se propôs.

> `bunx knip` saiu 1 e **não é gate do CI** — não aparece em nenhum workflow, é health stack local.
> Interseção entre os arquivos que ele aponta e os 34 deste diff: **0**. Dívida da main que andou desde
> o #1212, não regressão daqui.

> Os gates locais rodaram na base pré-rebase; a base final (pós-`cd056f22`) quem valida é o CI.

> Asserção sobre **import**, não sobre menção: `grep "https://deno\.land/"` cru nunca vai a zero — dois
> arquivos citam o host em comentário (`generate-bundle-argument/argumento-helpers_test.ts` e
> `omie-analytics-sync/politica-retry.ts`, ambos explicando por que a suíte de edge é offline). O que o
> `deno check` resolve é o `from "https://…"`, e é sobre ele que a contagem acima fala.
