### PR TITLE
chore(ci): família A (não-money) — esm.sh → npm:@supabase/supabase-js@2 nas 7 edges

### DIFF
--- a/supabase/functions/compare-customer-process/index.ts
+++ b/supabase/functions/compare-customer-process/index.ts
@@ -1,5 +1,5 @@
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 const SYSTEM_PROMPT = `Você é um copiloto de vendas técnico da Colacor (distribuidora Sayerlack).

--- a/supabase/functions/dispatch-notifications/index.ts
+++ b/supabase/functions/dispatch-notifications/index.ts
@@ -1,7 +1,7 @@
 // dispatch-notifications: processa fornecedor_alerta pendente_notificacao
 // Envia email via Gmail API + cria evento no Google Calendar via OAuth 2.0 (refresh token).
 // Sequencial: NUNCA processa alertas em paralelo.
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff } from '../_shared/auth.ts';
 
 const corsHeaders = {

--- a/supabase/functions/gmail-webhook-receiver/index.ts
+++ b/supabase/functions/gmail-webhook-receiver/index.ts
@@ -15,7 +15,7 @@
 //   bodyText?: string
 // }
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/kb-ingest-document/index.ts
+++ b/supabase/functions/kb-ingest-document/index.ts
@@ -1,5 +1,5 @@
 // supabase/functions/kb-ingest-document/index.ts
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import OpenAI from "npm:openai@^4.65.0";
 import pdfParse from "npm:pdf-parse@1.1.1";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";

--- a/supabase/functions/posthog-error-webhook/index.ts
+++ b/supabase/functions/posthog-error-webhook/index.ts
@@ -1,7 +1,7 @@
 // posthog-error-webhook: recebe alerta "issue created/reopened" do PostHog Error Tracking,
 // valida segredo, e delega à RPC enfileirar_erro_app (dedupe + anti-tempestade + insert atômico).
 // Helpers ESPELHADOS verbatim de src/lib/posthog-error/* (Deno não importa de src).
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.45.0';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 
 const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!;
 const SERVICE_ROLE_KEY = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;

--- a/supabase/functions/rag-reindex/index.ts
+++ b/supabase/functions/rag-reindex/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import OpenAI from "npm:openai@^4.65.0";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 import { chunkText } from "../_shared/chunk-text.ts";

--- a/supabase/functions/rag-search/index.ts
+++ b/supabase/functions/rag-search/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import OpenAI from "npm:openai@^4.65.0";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 


### PR DESCRIPTION
## O que muda

7 edges **fora do money-path** trocam `https://esm.sh/@supabase/supabase-js@2.45.0` por
`npm:@supabase/supabase-js@2`. Troca de string, nada mais: 7 arquivos, +7 −7.

`compare-customer-process` · `dispatch-notifications` · `gmail-webhook-receiver` ·
`kb-ingest-document` · `posthog-error-webhook` · `rag-reindex` · `rag-search`

Continuação do #1685 (família B, `deno.land` → `Deno.serve`). As 12 edges de money-path que ainda
usam `esm.sh` vêm no PR seguinte — é ele que zera o host.

## Por que `@2` e não o pin

Os follow-ups 1 e 2 de `docs/historico/ci-testes-edge-deno.md` **são o mesmo trabalho**, e essa é a
parte não-óbvia. As edges que já usavam `npm:` o faziam com 4 especificadores distintos (`@2`, `^2`,
`@2.45.0`, `^2.95.3`), e as de `esm.sh` traziam mais 3. Migrar de host sem escolher a versão jogaria
estas 7 no mesmo espalhamento que produz os 17 `SupabaseClient not assignable` — trocaria um problema
por dois. Então o especificador é escolhido aqui e vale para o repo inteiro:

- **é o majoritário absoluto** — 56 dos 74 imports `npm:` da main;
- `@2` e `^2` são o **mesmo range semver** (`>=2.0.0 <3.0.0`): normalizar é textual, não muda o que
  resolve;
- quem **cria** versão distinta no grafo é o pin exato (`@2.45.0`, `^2.95.3`) — tirá-lo é o que
  consolida;
- prender a versão resolvida é papel do **`deno.lock`** (follow-up 4, aberto), não do especificador:
  pin aqui duplicaria esse papel e criaria bump manual em 73 arquivos.

## `esm.sh` não é só risco de CI — já derrubou edge em produção

O gatilho desta série foi o #1670, uma PR **só de documentação**, derrubada pelo `edges:typecheck` com
`Import 'https://esm.sh/…@2.112.2/dist/index.d.mts' failed: 500`. Mas o repo já sabia mais do que isso.
Quatro edges carregam, no próprio cabeçalho, o aviso deixado pelo #1592:

> `⚠️ usar npm: (não esm.sh) — esm.sh/@supabase/supabase-js falhava em resolver no boot do edge
> runtime, dando RUNTIME_ERROR sem linha/stack`

Ou seja: `esm.sh` já tinha quebrado edge **em produção**, a correção já era `npm:`, e quatro edges
migraram uma a uma por incidente — cada uma deixando o aviso e nenhuma virando varredura. O 500 do
#1670 foi a mesma fonte cobrando pelo outro lado.

Isso muda a leitura do redeploy: trocar `esm.sh` → `npm:` **não é risco novo a observar**, é aplicar a
correção que 4 edges já validaram em produção.

## Produção: nada muda no merge

O `deno check` roda sobre o **repo**, então o efeito no CI é imediato no merge. As edges em produção
seguem com o import antigo até serem redeployadas pelo chat do Lovable.

**Não faça mutirão de redeploy** — deixe cada edge pegar a mudança no próximo deploy natural dela.

## Evidência

Rodados os gates do `validate`, não só os que pareciam relevantes ao diff:

| Gate | Resultado |
|---|---|
| `bun run edges:typecheck` | 0 — 0 crash-class, 136 tolerados (= baseline da main) |
| `bun run test:edges` (`--no-remote`) | 0 — 632 passed, 0 failed |
| `bun run typecheck` | 0 |
| `bun lint` | 0 |
| `bun run test` (vitest) | 0 |
| `shellcheck` | 0 |
| imports `esm.sh` no repo | **12** (era 19; o PR seguinte zera) |

> Asserção sobre **import**, não sobre menção: `grep "https://esm\.sh/"` cru não chega a zero nem ao
> fim da série — quatro arquivos citam o host em **comentário**, justamente os avisos do #1592 citados
> acima. O que o `deno check` resolve é o `from "https://…"`, e é sobre ele que a contagem fala.
