### PR TITLE
chore(ci): família A money-path — esm.sh → npm:@supabase/supabase-js@2 nas 12 edges [money-path]

### DIFF
--- a/supabase/functions/disparar-pedidos-aprovados/index.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/index.ts
@@ -2,7 +2,7 @@
 // Às 10:00 BRT (cron 0 13 * * *), processa pedidos aprovados do ciclo do dia.
 // - DRY-RUN: cria pedido no Omie via IncluirPedidoCompra, NÃO envia ao fornecedor
 // - PRODUÇÃO: cria no Omie + dispara notificação ao fornecedor pelo canal configurado
-import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/gerar-pedidos-diario/index.ts
+++ b/supabase/functions/gerar-pedidos-diario/index.ts
@@ -4,7 +4,7 @@
 // 2. Busca detalhes do ciclo gerado (por fornecedor)
 // 3. Envia email digest via Resend para empresa_configuracao_custos.email_notificacoes
 // 4. Grava log em sync_reprocess_log
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/omie-aplicar-parametros/index.ts
+++ b/supabase/functions/omie-aplicar-parametros/index.ts
@@ -3,7 +3,7 @@
 // Body: { empresa: 'OBEN', ids: number[] } — IDs de fila_aplicacao_omie a aplicar.
 // Para cada ID: revalida prontidão, chama Omie AlterarProduto, grava resposta.
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 
 const corsHeaders = {

--- a/supabase/functions/omie-sync-ctes-recebidos/index.ts
+++ b/supabase/functions/omie-sync-ctes-recebidos/index.ts
@@ -26,7 +26,7 @@
 // Body opcional:
 //   { "empresa": "OBEN" | "COLACOR" | "ALL", "dias": 30, "fornecedor_codigo_omie": 8689681266 }
 
-import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { avaliarPagina, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
 
 interface OmieCabec {

--- a/supabase/functions/omie-sync-nfes-recebidas/index.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/index.ts
@@ -21,7 +21,7 @@
 // Body opcional:
 //   { "empresa": "OBEN" | "COLACOR" | "ALL", "dias": 30, "fornecedor_codigo_omie": 8689681266 }
 
-import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { classifyOmieResponse, computeBackoffMs } from "./retry.ts";
 
 const corsHeaders = {

--- a/supabase/functions/omie-sync-pedidos-compra/index.ts
+++ b/supabase/functions/omie-sync-pedidos-compra/index.ts
@@ -5,7 +5,7 @@
 // Método Omie usado: PesquisarPedCompra
 // Doc: https://app.omie.com.br/api/v1/produtos/pedidocompra/#PesquisarPedCompra
 
-import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import {
   computeJanelaPrevisao,
   deveRodarCompleto,

--- a/supabase/functions/omie-sync-sku-items/index.ts
+++ b/supabase/functions/omie-sync-sku-items/index.ts
@@ -22,7 +22,7 @@
 //   4) Para cada item, tenta achar o pedido específico via numero_contrato_fornecedor = nNumPedCompra.
 //   5) UPSERT em sku_leadtime_history (tracking_id, sku_codigo_omie).
 
-import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 interface OmieItemCabec {
   nIdProduto?: number | string;

--- a/supabase/functions/omie-sync-status-produtos/index.ts
+++ b/supabase/functions/omie-sync-status-produtos/index.ts
@@ -3,7 +3,7 @@
 // para a tabela sku_status_omie. Usa ListarProdutos paginado (500 por página).
 // Aceita empresa OBEN, COLACOR ou ALL (processa todas as suportadas, em série).
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { resolverEmpresas, type Empresa } from "../_shared/empresas.ts";

--- a/supabase/functions/omie-sync-vendas-items/index.ts
+++ b/supabase/functions/omie-sync-vendas-items/index.ts
@@ -5,7 +5,7 @@
 // Body: { empresa: "OBEN" | "COLACOR", dias: number }
 // Defaults: empresa = "OBEN", dias = 180
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { avaliarPagina, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
 
 // ─── Type definitions ───

--- a/supabase/functions/omie-webhook/index.ts
+++ b/supabase/functions/omie-webhook/index.ts
@@ -11,7 +11,7 @@
 //   6. Processar o evento em background
 // ============================================================================
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.39.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { redigirSegredo } from "../_shared/omie-falha.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;

--- a/supabase/functions/pedido-programado-enviar/index.ts
+++ b/supabase/functions/pedido-programado-enviar/index.ts
@@ -10,7 +10,7 @@
 // ⚠️ DEPLOY: exige a migration aplicada ANTES (sem 'processando' no CHECK, o claim
 // falharia 23514 e nenhum envio seria processado).
 // ESPELHO: helpers de src/lib/pedidosProgramados/helpers.ts (verbatim — Deno não importa de src/).
-import { createClient, SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 // ── ESPELHO de src/lib/pedidosProgramados/helpers.ts (parte de envio, verbatim) ──

--- a/supabase/functions/pedido-programado-extrair/index.ts
+++ b/supabase/functions/pedido-programado-extrair/index.ts
@@ -4,7 +4,7 @@
 // recria os itens AINDA sem envio (não toca item já vinculado a envio).
 // Auth: staff (UI) ou service_role/cron.
 // ESPELHO: validarExtracao e tipos vêm de src/lib/pedidosProgramados/helpers.ts (verbatim).
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 


### PR DESCRIPTION
## O que muda

As **12 edges de money-path** que ainda importavam `@supabase/supabase-js` de `https://esm.sh/` passam a
importar de `npm:@supabase/supabase-js@2`. Troca de string, nada mais: 12 arquivos, +12 −12 — os nomes
importados (inclusive `type SupabaseClient`) ficam idênticos.

`disparar-pedidos-aprovados` · `gerar-pedidos-diario` · `omie-aplicar-parametros` ·
`omie-sync-{ctes-recebidos,nfes-recebidas,pedidos-compra,sku-items,status-produtos,vendas-items}` ·
`omie-webhook` · `pedido-programado-{enviar,extrair}`

Esta branch está rebaseada sobre a main já com o #1687, então a asserção é direta e não uma soma
prometida: **com este PR o repo chega a 0 import de `esm.sh` e 0 de `deno.land`.** O #1685 tinha tirado o
`deno.land`; este fecha o `esm.sh`. O `edges:typecheck`, único step do `validate` que precisa de rede,
passa a depender só de `registry.npmjs.org` — que **já estava** no caminho de entrega via `bun install`.

Fecha os follow-ups 1 e 2 de `docs/historico/ci-testes-edge-deno.md`.

## Por que money-path veio sozinho

Precisão > recall: as 19 edges da família A eram um diff só, e o que separa estas 12 das 7 do #1687 não é
a mudança — é o custo de errar. Estas movem pedido a fornecedor, NF-e/CT-e recebida, sync de vendas e
disparo de pedido programado. Diff pequeno e homogêneo é o que torna a revisão possível.

## O salto de versão real está em uma edge, e é medível

Os três especificadores que entram viram um só (`@2`):

| Entra | Nº | Vira |
|---|---|---|
| `esm.sh/…@2.45.0` | 9 | `npm:…@2` |
| `esm.sh/…@2` | 2 | `npm:…@2` |
| `esm.sh/…@2.39.0` | 1 (`omie-webhook`) | `npm:…@2` |

Para 11 delas o range `@2` (`>=2.0.0 <3.0.0`) cobre o que já resolvia. A exceção é o **`omie-webhook`**,
pinado em `2.39.0` — a versão mais velha do repo: no próximo deploy dele a lib salta para o topo do 2.x.
Vale dizer o que isso alcança, em vez de assumir. A superfície da lib usada **nas 12 edges inteiras** é:

- `.from(…)` — 108 ocorrências
- `.rpc(…)` — 9 ocorrências
- zero `auth` (além de `persistSession: false` no construtor), zero `storage`, `realtime`, `functions`,
  `channel`

Ou seja: PostgREST puro, a parte da lib que não mudou de contrato dentro do 2.x. O salto não toca nenhuma
das áreas onde a v2 evoluiu.

## Por que `@2` e não o pin

Follow-ups 1 e 2 de `docs/historico/ci-testes-edge-deno.md` **são o mesmo trabalho** — migrar de host sem
escolher a versão jogaria estas 12 no mesmo espalhamento (7 especificadores distintos) que produz os 17
`SupabaseClient not assignable`. Trocaria um problema por dois. O especificador é escolhido por medição:

- **majoritário absoluto** — 56 dos 74 imports `npm:` da main;
- `@2` e `^2` são o **mesmo range semver**: normalizar é textual, não muda o que resolve;
- quem **cria** versão distinta no grafo é o pin exato (`@2.45.0`, `@2.39.0`, `^2.95.3`) — tirá-lo é o
  que consolida;
- prender a versão resolvida é papel do **`deno.lock`** (follow-up 4, aberto), não do especificador.

Seis destas 12 importam `type SupabaseClient` junto do `createClient`, então valia perguntar se a
consolidação já derrubaria aqui a classe `TS2345` (onde mora o `SupabaseClient not assignable`). Medi:
**não moveu — 36 antes, 36 depois.** É o resultado esperado, e o diff mostra por quê: nas 12, o valor e o
tipo vêm da **mesma linha de import**, então nunca houve mismatch interno a corrigir. Essa classe mora
onde um client cruza fronteira de arquivo entre specifiers diferentes — é o que o PR seguinte ataca.

## `esm.sh` não é risco novo — já derrubou edge em produção

O gatilho da série foi o #1670, PR **só de documentação**, morta com
`Import 'https://esm.sh/…@2.112.2/dist/index.d.mts' failed: 500`. Mas o repo já sabia mais: quatro edges
carregam no cabeçalho o aviso deixado pelo #1592 —

> `⚠️ usar npm: (não esm.sh) — esm.sh/@supabase/supabase-js falhava em resolver no boot do edge runtime,
> dando RUNTIME_ERROR sem linha/stack`

`esm.sh` já quebrou edge **em produção**, a correção já era `npm:`, e quatro edges migraram uma a uma por
incidente — cada uma deixando o aviso, nenhuma virando varredura. O 500 do #1670 foi a mesma fonte
cobrando pelo lado do CI. Então trocar `esm.sh` → `npm:` **não é risco novo a observar**: é aplicar a
correção que 4 edges já validaram em produção.

## Produção: nada muda no merge

O `deno check` roda sobre o **repo**, então o efeito no CI é imediato no merge. As edges em produção
seguem com o import antigo até serem redeployadas pelo chat do Lovable.

**Não faça mutirão de redeploy** — deixe cada edge pegar a mudança no próximo deploy natural dela.

## Evidência

Rodados os gates do `validate`, não só os que pareciam relevantes ao diff:

| Gate | Resultado |
|---|---|
| `bun run edges:typecheck` | 0 — 0 crash-class, 136 tolerados (**= baseline da main**) |
| `bun run test:edges` (`--no-remote`) | 0 — 632 passed, 0 failed |
| `bun run typecheck` | 0 |
| `bun lint` | 0 |
| `bun run test` (vitest) | 0 — 6030 passed |
| `shellcheck` | 0 |
| imports `esm.sh` nesta branch | **0** (era 12) — e `deno.land` segue em **0** |

> `bunx knip` saiu 1 e **não é gate do CI** — 0 ocorrências em `.github/workflows/`, é health stack
> local. Interseção com os 12 arquivos deste diff: **0**. Dívida da main.

> Os gates rodaram na base pré-rebase; a base final (pós-`cff6557f`) quem valida é o CI.

> **Asserção sobre import, não sobre menção.** O grep óbvio —
> `grep -rlE "https://(esm\.sh|deno\.land)/" supabase/functions/` — **nunca** chega a zero, nem com o
> trabalho terminado: **7 arquivos** citam os hosts em **comentário de prosa** (os 4 avisos do #1592
> acima, mais 3 explicando por que a suíte de edge roda offline). Um gate ancorado nele ficaria
> permanentemente vermelho e acabaria afrouxado até não valer nada. O que o `deno check` resolve é o
> `from "https://…"`, e é sobre essa forma — a que o compilador enxerga — que a contagem acima fala:
>
> ```
> grep -rlE "from ['\"]https://(esm\.sh|deno\.land)/" supabase/functions/
> ```
