### PR TITLE
fix(carteira): snapshot de positivação para de carimbar esforço como zero [money-path]

### DIFF
--- a/supabase/functions/_shared/mapas-paginados.ts
+++ b/supabase/functions/_shared/mapas-paginados.ts
@@ -97,6 +97,56 @@ export async function carregarExcluidosDaCarteira(db: BancoPostgrest): Promise<S
   return new Set(linhas.map((l) => l.user_id));
 }
 
+// Clientes TOCADOS por esforço comercial num mês — o lado "causa" do snapshot de
+// positivação, que só tem valor cruzado com `had_order_in_month` (o lado "efeito").
+//
+// Por que a janela é `data_rota`/`visit_date` (date) e não `created_at` (timestamptz):
+// o mês do snapshot é BRT, e `created_at` é UTC — uma ligação às 22h de 31/jan (BRT)
+// grava 01/fev em UTC e seria contada no mês seguinte, atribuindo o esforço de janeiro
+// a fevereiro. As colunas date não têm fuso, e é o mesmo critério que
+// `carregarPedidosDoMes` já usa com `order_date_kpi`.
+//
+// Conta TENTATIVA, não só sucesso: `status` inclui 'sem_resposta', e quem não atendeu
+// consumiu esforço da operação igual. É o denominador honesto de "quantos clientes a
+// rota tocou" — a taxa de resposta sai depois, do log detalhado.
+export async function carregarContatadosNoMes(
+  db: BancoPostgrest,
+  mesIso: string,
+  fimIso: string,
+): Promise<Set<string>> {
+  const linhas = await fetchAll<{ customer_user_id: string | null }>(
+    (de, ate) =>
+      db.from<{ customer_user_id: string | null }>("route_contact_log")
+        .select("customer_user_id")
+        .gte("data_rota", mesIso)
+        .lt("data_rota", fimIso)
+        .order("id", { ascending: true })
+        .range(de, ate),
+    "route_contact_log",
+  );
+  // customer_user_id é NULLABLE nesta tabela: `new Set([null])` daria um membro fantasma
+  // que nunca casa com assignment, mas polui a contagem de esforço em qualquer diagnóstico.
+  return new Set(linhas.map((l) => l.customer_user_id).filter((id): id is string => !!id));
+}
+
+export async function carregarVisitadosNoMes(
+  db: BancoPostgrest,
+  mesIso: string,
+  fimIso: string,
+): Promise<Set<string>> {
+  const linhas = await fetchAll<{ customer_user_id: string }>(
+    (de, ate) =>
+      db.from<{ customer_user_id: string }>("route_visits")
+        .select("customer_user_id")
+        .gte("visit_date", mesIso)
+        .lt("visit_date", fimIso)
+        .order("id", { ascending: true })
+        .range(de, ate),
+    "route_visits",
+  );
+  return new Set(linhas.map((l) => l.customer_user_id));
+}
+
 interface LinhaProduto {
   id: string | null;
   omie_codigo_produto: number | string | null;

--- a/supabase/functions/carteira-positivacao-snapshot/index.ts
+++ b/supabase/functions/carteira-positivacao-snapshot/index.ts
@@ -17,9 +17,12 @@ import { createClient } from 'npm:@supabase/supabase-js@^2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import {
   carregarCarteiraComElegibilidade,
+  carregarContatadosNoMes,
   carregarPedidosDoMes,
+  carregarVisitadosNoMes,
 } from '../_shared/mapas-paginados.ts';
 import type { BancoPostgrest } from '../_shared/paginate.ts';
+import { montarLinhasSnapshot } from './montar-linhas.ts';
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -52,9 +55,17 @@ Deno.serve(async (req) => {
   const db = supabase as unknown as BancoPostgrest;
   let assignments: Awaited<ReturnType<typeof carregarCarteiraComElegibilidade>>;
   let pedidosDoMes: Awaited<ReturnType<typeof carregarPedidosDoMes>>;
+  let contatados: Set<string>;
+  let visitados: Set<string>;
   try {
     assignments = await carregarCarteiraComElegibilidade(db);
     pedidosDoMes = await carregarPedidosDoMes(db, mesIso, fimIso);
+    // Mesmo fail-closed dos pedidos, e pelo mesmo motivo: leitura de esforço que falha e
+    // degrada para conjunto vazio grava `contacted_in_month:false` num cliente que FOI
+    // contatado — "não consegui ler" carimbado como "ninguém ligou", congelado num mês que
+    // ninguém recalcula. Subdimensionar o esforço infla a positivação espontânea aparente.
+    contatados = await carregarContatadosNoMes(db, mesIso, fimIso);
+    visitados = await carregarVisitadosNoMes(db, mesIso, fimIso);
   } catch (e) {
     const motivo = e instanceof Error ? e.message : String(e);
     console.error('[carteira-positivacao-snapshot] leitura falhou, snapshot NÃO gravado:', motivo);
@@ -64,27 +75,9 @@ Deno.serve(async (req) => {
     );
   }
 
-  // Pedidos válidos do mês por cliente (receita + 1ª data). order_date_kpi é não-nulo (backfill).
-  const byCustomer = new Map<string, { receita: number; primeira: string | null }>();
-  for (const o of pedidosDoMes) {
-    const cur = byCustomer.get(o.customer_user_id) ?? { receita: 0, primeira: null };
-    cur.receita += Number(o.total ?? 0);
-    if (!cur.primeira || o.order_date_kpi < cur.primeira) cur.primeira = o.order_date_kpi;
-    byCustomer.set(o.customer_user_id, cur);
-  }
-
-  const rows = assignments.map((a) => {
-    const ped = byCustomer.get(a.customer_user_id);
-    return {
-      mes: mesIso,
-      customer_user_id: a.customer_user_id,
-      owner_user_id: a.owner_user_id,
-      eligible: a.eligible,
-      had_order_in_month: !!ped,
-      first_order_date_in_month: ped?.primeira ?? null,
-      revenue_month: ped?.receita ?? 0,
-    };
-  });
+  // Montagem em `montar-linhas.ts` (pura) — o index importa `npm:` e é intestável sob
+  // `--no-remote`, então a regra que decide cada campo mora onde o teste alcança.
+  const rows = montarLinhasSnapshot(mesIso, assignments, pedidosDoMes, contatados, visitados);
 
   let upserted = 0;
   let errors = 0;

--- a/supabase/functions/carteira-positivacao-snapshot/montar-linhas.ts
+++ b/supabase/functions/carteira-positivacao-snapshot/montar-linhas.ts
@@ -1,0 +1,57 @@
+// Montagem PURA das linhas do snapshot mensal de positivação.
+//
+// Mora fora do index.ts porque `test:edges` roda com `--no-remote`: o index importa
+// `npm:@supabase/supabase-js` e por isso é intestável: só a lógica pura pode ser coberta
+// (CLAUDE.md, "Edge tem suíte PRÓPRIA (Deno)"). Ver montar-linhas_test.ts.
+//
+// O que esta função carrega de invariante (docs/agent/money-path.md):
+//   • `had_order_in_month` e `contacted_in_month` são DUAS pontas independentes. O snapshot
+//     existe para cruzar as duas — sem o par, "a rota converte?" não tem resposta.
+//   • Esforço de quem não está na carteira NÃO cria linha: o snapshot é uma fotografia da
+//     carteira do mês, e uma linha órfã viraria denominador fantasma na taxa de positivação.
+//   • `total: null` degrada para 0 na SOMA (não vira NaN, que contaminaria o mês inteiro).
+import type { LinhaAssignment, LinhaPedidoMes } from "../_shared/mapas-paginados.ts";
+
+export interface LinhaSnapshot {
+  mes: string;
+  customer_user_id: string;
+  owner_user_id: string;
+  eligible: boolean;
+  had_order_in_month: boolean;
+  first_order_date_in_month: string | null;
+  revenue_month: number;
+  contacted_in_month: boolean;
+  visited_in_month: boolean;
+}
+
+export function montarLinhasSnapshot(
+  mesIso: string,
+  assignments: LinhaAssignment[],
+  pedidosDoMes: LinhaPedidoMes[],
+  contatados: Set<string>,
+  visitados: Set<string>,
+): LinhaSnapshot[] {
+  // Pedidos válidos do mês por cliente (receita + 1ª data). order_date_kpi é não-nulo (backfill).
+  const byCustomer = new Map<string, { receita: number; primeira: string | null }>();
+  for (const o of pedidosDoMes) {
+    const cur = byCustomer.get(o.customer_user_id) ?? { receita: 0, primeira: null };
+    cur.receita += Number(o.total ?? 0);
+    if (!cur.primeira || o.order_date_kpi < cur.primeira) cur.primeira = o.order_date_kpi;
+    byCustomer.set(o.customer_user_id, cur);
+  }
+
+  return assignments.map((a) => {
+    const ped = byCustomer.get(a.customer_user_id);
+    return {
+      mes: mesIso,
+      customer_user_id: a.customer_user_id,
+      owner_user_id: a.owner_user_id,
+      eligible: a.eligible,
+      had_order_in_month: !!ped,
+      first_order_date_in_month: ped?.primeira ?? null,
+      revenue_month: ped?.receita ?? 0,
+      contacted_in_month: contatados.has(a.customer_user_id),
+      visited_in_month: visitados.has(a.customer_user_id),
+    };
+  });
+}

--- a/supabase/functions/carteira-positivacao-snapshot/montar-linhas_test.ts
+++ b/supabase/functions/carteira-positivacao-snapshot/montar-linhas_test.ts
@@ -1,0 +1,118 @@
+// Testa o CÓDIGO REAL de montar-linhas.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/carteira-positivacao-snapshot/montar-linhas_test.ts
+//
+// Por que este teste existe: até 2026-08 o snapshot mensal gravava 7 campos e NUNCA
+// escrevia `contacted_in_month`/`visited_in_month` — as colunas ficavam no DEFAULT false
+// nas 28.027 linhas de prod. O efeito não é "campo vazio": é que o par esforço→resultado
+// (ligou/visitou × comprou) fica indistinguível de "ninguém ligou", então a pergunta que
+// justifica a rota — "contatar converte?" — era irrespondível por construção.
+import { montarLinhasSnapshot } from "./montar-linhas.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+const MES = "2026-07-01";
+const A = (customer_user_id: string, eligible = true) => ({
+  customer_user_id,
+  owner_user_id: "owner-1",
+  eligible,
+});
+
+// ── o par esforço→resultado (o que o bug apagava) ──────────────────────────
+
+Deno.test("contatado E comprou → as duas pontas verdadeiras (a conversão fica visível)", () => {
+  const linhas = montarLinhasSnapshot(
+    MES,
+    [A("c1")],
+    [{ customer_user_id: "c1", total: 100, order_date_kpi: "2026-07-10" }],
+    new Set(["c1"]),
+    new Set(),
+  );
+  assertEquals(linhas[0].contacted_in_month, true);
+  assertEquals(linhas[0].had_order_in_month, true);
+});
+
+Deno.test("contatado e NÃO comprou → esforço registrado sem resultado (o denominador honesto)", () => {
+  const linhas = montarLinhasSnapshot(MES, [A("c1")], [], new Set(["c1"]), new Set());
+  assertEquals(linhas[0].contacted_in_month, true);
+  assertEquals(linhas[0].had_order_in_month, false);
+  assertEquals(linhas[0].revenue_month, 0);
+});
+
+Deno.test("comprou SEM contato → compra espontânea não vira crédito da rota", () => {
+  const linhas = montarLinhasSnapshot(
+    MES,
+    [A("c1")],
+    [{ customer_user_id: "c1", total: 100, order_date_kpi: "2026-07-10" }],
+    new Set(),
+    new Set(),
+  );
+  assertEquals(linhas[0].contacted_in_month, false);
+  assertEquals(linhas[0].had_order_in_month, true);
+});
+
+Deno.test("visita é canal independente do contato telefônico", () => {
+  const linhas = montarLinhasSnapshot(MES, [A("c1")], [], new Set(), new Set(["c1"]));
+  assertEquals(linhas[0].visited_in_month, true);
+  assertEquals(linhas[0].contacted_in_month, false);
+});
+
+Deno.test("sem esforço nenhum → false explícito, nunca null/undefined", () => {
+  const linhas = montarLinhasSnapshot(MES, [A("c1")], [], new Set(), new Set());
+  assertEquals(linhas[0].contacted_in_month, false);
+  assertEquals(linhas[0].visited_in_month, false);
+});
+
+// ── agregação de pedidos (comportamento preservado do index.ts) ────────────
+
+Deno.test("vários pedidos → receita somada e PRIMEIRA data do mês", () => {
+  const linhas = montarLinhasSnapshot(
+    MES,
+    [A("c1")],
+    [
+      { customer_user_id: "c1", total: 100, order_date_kpi: "2026-07-20" },
+      { customer_user_id: "c1", total: 50, order_date_kpi: "2026-07-03" },
+    ],
+    new Set(),
+    new Set(),
+  );
+  assertEquals(linhas[0].revenue_month, 150);
+  assertEquals(linhas[0].first_order_date_in_month, "2026-07-03");
+});
+
+Deno.test("total null não vira NaN (ausente ≠ zero só vale pro SINAL, soma degrada pra 0)", () => {
+  const linhas = montarLinhasSnapshot(
+    MES,
+    [A("c1")],
+    [{ customer_user_id: "c1", total: null, order_date_kpi: "2026-07-10" }],
+    new Set(),
+    new Set(),
+  );
+  assertEquals(linhas[0].revenue_month, 0);
+  assertEquals(Number.isNaN(linhas[0].revenue_month), false);
+});
+
+Deno.test("sem pedido → data null (não fabrica data)", () => {
+  const linhas = montarLinhasSnapshot(MES, [A("c1")], [], new Set(), new Set());
+  assertEquals(linhas[0].first_order_date_in_month, null);
+  assertEquals(linhas[0].had_order_in_month, false);
+});
+
+// ── escopo e formato ──────────────────────────────────────────────────────
+
+Deno.test("uma linha por assignment, carimbada com o mês pedido", () => {
+  const linhas = montarLinhasSnapshot(MES, [A("c1"), A("c2", false)], [], new Set(), new Set());
+  assertEquals(linhas.length, 2);
+  assertEquals(linhas[0].mes, MES);
+  assertEquals(linhas[1].eligible, false);
+});
+
+Deno.test("esforço de quem NÃO está na carteira não inventa linha", () => {
+  const linhas = montarLinhasSnapshot(MES, [A("c1")], [], new Set(["fantasma"]), new Set(["fantasma"]));
+  assertEquals(linhas.length, 1);
+  assertEquals(linhas[0].customer_user_id, "c1");
+  assertEquals(linhas[0].contacted_in_month, false);
+});


### PR DESCRIPTION
## O problema

`carteira_positivacao_snapshot` existe para cruzar **esforço** (ligou/visitou) com **resultado** (comprou) — é o par que responde *"a rota converte?"*. A edge montava 7 campos e **nunca escrevia `contacted_in_month`/`visited_in_month`**.

Estado em prod antes deste PR:

```
total | contacted_true | visited_true | dias_preenchido | churn_preenchido
28027 |              0 |            0 |               0 |                0
```

As colunas ficaram no `DEFAULT false` desde abr/2026. O efeito não é "campo vazio" — é que o lado da **causa** fica indistinguível de "ninguém ligou", então toda positivação aparece como espontânea e a pergunta que justifica o módulo Farmer é irrespondível por construção.

## O que muda

- **`carregarContatadosNoMes` / `carregarVisitadosNoMes`** em `_shared/mapas-paginados.ts`, com o mesmo `fetchAll` fail-closed dos pedidos. Leitura que falha e degrada para conjunto vazio gravaria "não contatado" num cliente que **foi** contatado, congelado num mês que ninguém recalcula (money-path §2 — ausente ≠ zero).
- **Janela por `data_rota`/`visit_date` (`date`), não `created_at` (timestamptz).** O mês do snapshot é BRT: uma ligação às 22h de 31/jan grava 01/fev em UTC e contaria o esforço de janeiro em fevereiro. É o mesmo critério do `order_date_kpi` que a edge já usa.
- **Montagem extraída para `montar-linhas.ts` (pura).** O `index.ts` importa `npm:` e é intestável sob `--no-remote`, então a regra que decide cada campo passa a morar onde `test:edges` alcança.

## Fora do escopo, de propósito

`churn_risk_at_month_start` segue NULL. A fonte não guarda histórico e preencher retroativamente seria fabricar número.

## Prova (falsificado, não só verde)

O primeiro "ver vermelho" foi engolido pela fila do `heavy`, então sabotei cada campo separadamente:

| Sabotagem | Resultado |
|---|---|
| `contacted_in_month: false` | **2 vermelhos** / 8 passes |
| `visited_in_month: false` | **1 vermelho** / 9 passes |
| restaurado | **10/10** |

- `test:edges` — **642/642**, exit 0
- `edges:typecheck` — **0 erros de classe-crash** (dívida tolerada 136, abaixo do baseline 141)
- `tsc --noEmit -p tsconfig.app.json` — exit 0, 0 erros

## Ressalva declarada

**A suíte vitest não rodou nesta máquina** — semáforo `heavy` saturado por 13+ processos vitest de outras sessões, fila parada por minutos. O diff não toca `src/` nem `scripts/`, que é todo o escopo dela. O CI é o gate autoritativo.

## Depois do merge

Isto conserta a **contabilidade** do esforço, mas o esforço hoje é zero: `route_contact_log` e `route_queue_snapshot` estão vazios, apesar do pipeline íntegro (config ativa desde 30/05, 429 candidatos disponíveis hoje para a vendedora ativa, RPC íntegra, tela no menu). A tela não tem `track()`, então "nunca aberta" e "abre e quebra" são indistinguíveis — instrumentá-la é o próximo passo.

Backfill dos meses fechados: re-invocar a edge com `{"mes":"2026-0X-01"}` (upsert idempotente). Para abr–jul o resultado será `false` honesto, já que de fato não houve contato registrado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
