### PR TITLE
fix(farmer): fila do Plano Tático ganha SAÍDA — 383 de 533 planos eram inalcançáveis [money-path]

### DIFF
--- a/db/test-expirar-planos-taticos.sh
+++ b/db/test-expirar-planos-taticos.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260807210912_expirar_planos_taticos.sql                        ║
+# ║      bash db/test-expirar-planos-taticos.sh > /tmp/t.log 2>&1; echo "exit=$?"  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  O que prova: a fila do Plano Tático ganha SAÍDA sem destruir desfecho.        ║
+# ║   · expira `gerado` fora da janela, preserva o de dentro                       ║
+# ║   · NUNCA toca plano `concluido` (o desfecho registrado é o dado escasso)      ║
+# ║   · `_dias` inválido é fail-closed (não expira a fila inteira)                 ║
+# ║   · REVOKE barra anon/authenticated (SECURITY DEFINER bypassa RLS)             ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="expirar-planos-taticos"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS
+# ══════════════════════════════════════════════════════════════════════════════
+# ⚠️ O `ALTER DEFAULT PRIVILEGES` abaixo NÃO é decoração: sem ele o `authenticated`
+# do stub nasceria SEM execute em qualquer função nova, e os asserts A12/A13
+# (REVOKE) passariam por acidente de ambiente — FALSO-VERDE. É a réplica do
+# default-privilege real do Supabase, e é o que dá dente à falsificação F3.
+# (Armadilha documentada em docs/agent/database.md.)
+P -q <<'SQL'
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+
+-- pg_cron não existe no PG17 limpo. `db/stubs-supabase.sql` já cria a TABELA
+-- cron.job (jobid bigint sem default) — aqui só faltam as FUNÇÕES, para que a
+-- migration REAL rode sem ser editada (Lei #1) e o A14 leia o que foi agendado.
+CREATE OR REPLACE FUNCTION cron.unschedule(_name text) RETURNS boolean
+  LANGUAGE sql AS $f$ DELETE FROM cron.job WHERE jobname = _name; SELECT true; $f$;
+CREATE OR REPLACE FUNCTION cron.schedule(_name text, _sched text, _cmd text) RETURNS bigint
+  LANGUAGE sql AS $f$
+    INSERT INTO cron.job(jobid, jobname, schedule, command, active)
+    VALUES (coalesce((SELECT max(jobid) FROM cron.job), 0) + 1, _name, _sched, _cmd, true)
+    RETURNING jobid; $f$;
+
+-- Stub da tabela-alvo, só com as colunas que a migration toca.
+CREATE TABLE IF NOT EXISTS public.farmer_tactical_plans (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id    uuid,
+  status       text NOT NULL DEFAULT 'gerado',
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATION REAL
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260807210912_expirar_planos_taticos.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED
+# ══════════════════════════════════════════════════════════════════════════════
+# Um plano por caso de borda. As idades são relativas a now() para o teste não
+# apodrecer com o calendário.
+P -q <<'SQL'
+INSERT INTO public.farmer_tactical_plans (id, status, generated_at) VALUES
+  ('11111111-1111-1111-1111-111111111111', 'gerado',    now() - interval '10 days'),  -- expira
+  ('22222222-2222-2222-2222-222222222222', 'gerado',    now() - interval '3 days'),   -- fica
+  ('33333333-3333-3333-3333-333333333333', 'concluido', now() - interval '30 days'),  -- INTOCÁVEL
+  ('44444444-4444-4444-4444-444444444444', 'gerado',    now() - interval '7 days 1 hour'), -- borda: expira
+  ('55555555-5555-5555-5555-555555555555', 'gerado',    now() - interval '6 days 23 hours'); -- borda: fica
+UPDATE public.farmer_tactical_plans SET updated_at = now() - interval '90 days';
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts ──"
+
+st() { Pq -c "SELECT status FROM public.farmer_tactical_plans WHERE id='$1';"; }
+
+# A1 — a função roda de verdade (late-bound) e devolve a contagem correta.
+N=$(Pq -c "SELECT public.expirar_planos_taticos(7);")
+eq "A1 retorno = nº de expirados" "$N" "2"
+
+eq "A2 antigo (10d) expirou"            "$(st 11111111-1111-1111-1111-111111111111)" "expirado"
+eq "A3 dentro da janela (3d) intacto"   "$(st 22222222-2222-2222-2222-222222222222)" "gerado"
+eq "A4 CONCLUIDO preservado"            "$(st 33333333-3333-3333-3333-333333333333)" "concluido"
+eq "A5 borda 7d+1h expirou"             "$(st 44444444-4444-4444-4444-444444444444)" "expirado"
+eq "A6 borda 6d23h intacto"             "$(st 55555555-5555-5555-5555-555555555555)" "gerado"
+
+# A7 — updated_at é tocado só em quem expirou (seed pôs 90 dias atrás em todos).
+UPD=$(Pq -c "SELECT count(*) FROM public.farmer_tactical_plans WHERE updated_at > now() - interval '1 minute';")
+eq "A7 updated_at tocado só nos 2 expirados" "$UPD" "2"
+
+# A8 — idempotência: a 2ª passada não re-expira nem conta de novo.
+N2=$(Pq -c "SELECT public.expirar_planos_taticos(7);")
+eq "A8 idempotente (2a passada = 0)" "$N2" "0"
+
+# ── negativos: capturam a SQLSTATE esperada e RE-LANÇAM o resto (Lei #2) ──
+# Sentinelas ASCII, caixa fixa, exclusivas do ramo — e AUSENTES do texto que a
+# migration emite (a mensagem dela fala "_dias deve ser >= 1").
+guard_barra() { # $1 = literal SQL do argumento
+  R=$(P -tA 2>&1 <<SQL || true
+DO \$t\$
+BEGIN
+  PERFORM public.expirar_planos_taticos($1);
+  RAISE NOTICE 'GUARDA_PASSOU_DIRETO';
+EXCEPTION
+  WHEN sqlstate '22023' THEN RAISE NOTICE 'GUARDA_BARROU_OK';
+  WHEN OTHERS THEN RAISE;
+END \$t\$;
+SQL
+)
+  case "$R" in *GUARDA_BARROU_OK*) echo "OK" ;; *) echo "FALHOU" ;; esac
+}
+eq "A9  _dias=0 rejeitado (22023)"    "$(guard_barra 0)"                "OK"
+eq "A10 _dias=-1 rejeitado (22023)"   "$(guard_barra -1)"               "OK"
+eq "A11 _dias=NULL rejeitado (22023)" "$(guard_barra 'NULL::integer')"  "OK"
+
+# A11b — o guard não é só cosmético: com _dias=0 a fila NÃO foi tocada.
+VIVOS=$(Pq -c "SELECT count(*) FROM public.farmer_tactical_plans WHERE status='gerado';")
+eq "A11b fila intacta após guard" "$VIVOS" "2"
+
+# ── REVOKE: SECURITY DEFINER bypassa RLS, então só cron/service_role executa ──
+exec_negado() { # $1 = role
+  R=$(P -tA 2>&1 <<SQL || true
+SET ROLE $1;
+DO \$t\$
+BEGIN
+  PERFORM public.expirar_planos_taticos(7);
+  RAISE NOTICE 'ROLE_CONSEGUIU_EXECUTAR';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'ROLE_FOI_NEGADA_OK';
+  WHEN OTHERS THEN RAISE;
+END \$t\$;
+SQL
+)
+  case "$R" in *ROLE_FOI_NEGADA_OK*) echo "OK" ;; *) echo "FALHOU" ;; esac
+}
+eq "A12 authenticated NÃO executa (42501)" "$(exec_negado authenticated)" "OK"
+eq "A13 anon NÃO executa (42501)"          "$(exec_negado anon)"          "OK"
+
+# A14 — o cron ficou agendado apontando para a função nomeada (não SQL inline).
+CMD=$(Pq -c "SELECT schedule||' :: '||command FROM cron.job WHERE jobname='expirar-planos-taticos';")
+eq "A14 cron agendado" "$CMD" "30 8 * * * ::  SELECT public.expirar_planos_taticos(7); "
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação (cada sabotagem TEM de virar vermelho) ──"
+fals() { if [ "$2" = "FALHOU" ]; then ok "F$1 sabotagem detectada"; else bad "F$1 SEM DENTE — sabotei e o assert seguiu verde"; fi; }
+
+# F1 — guard de _dias trocado por no-op. A9/A10/A11 devem morrer.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.expirar_planos_taticos(_dias integer DEFAULT 7)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE _n integer;
+BEGIN
+  UPDATE public.farmer_tactical_plans SET status='expirado', updated_at=now()
+   WHERE status='gerado' AND generated_at < now() - make_interval(days => _dias);
+  GET DIAGNOSTICS _n = ROW_COUNT; RETURN _n;
+END; $$;
+SQL
+fals 1 "$(guard_barra 0)"
+
+# F2 — filtro de status removido: `concluido` viraria `expirado` (destrói desfecho).
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.expirar_planos_taticos(_dias integer DEFAULT 7)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $$
+DECLARE _n integer;
+BEGIN
+  UPDATE public.farmer_tactical_plans SET status='expirado', updated_at=now()
+   WHERE generated_at < now() - make_interval(days => _dias);
+  GET DIAGNOSTICS _n = ROW_COUNT; RETURN _n;
+END; $$;
+SQL
+P -q -c "SELECT public.expirar_planos_taticos(7);"
+F2=$([ "$(st 33333333-3333-3333-3333-333333333333)" = "concluido" ] && echo "OK" || echo "FALHOU")
+fals 2 "$F2"
+
+# restaura a migration verdadeira antes de F3
+P -q -f "$MIG"
+P -q -c "UPDATE public.farmer_tactical_plans SET status='concluido' WHERE id='33333333-3333-3333-3333-333333333333';"
+
+# F3 — REVOKE desfeito: `authenticated` volta a executar.
+# É esta sabotagem que prova que A12 não passou por acidente de ambiente
+# (ver o ALTER DEFAULT PRIVILEGES na ZONA 1).
+P -q -c "GRANT EXECUTE ON FUNCTION public.expirar_planos_taticos(integer) TO authenticated;"
+fals 3 "$(exec_negado authenticated)"
+P -q -c "REVOKE ALL ON FUNCTION public.expirar_planos_taticos(integer) FROM authenticated;"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/historico/README.md
+++ b/docs/historico/README.md
@@ -10,6 +10,7 @@ Registro consultável de **PRs/bugs/programas/auditorias já entregues** — a n
 | --- | --- |
 | [bugs-resolvidos.md](bugs-resolvidos.md) | (era §10) cada bug/contradição/débito resolvido, com PR + lição (multi-domínio: KB, Radar, reposição, sync…) |
 | [programas-vendas.md](programas-vendas.md) | WhatsApp + Motor de Rota; copiloto "Buddy" |
+| [fila-plano-tatico.md](fila-plano-tatico.md) | PTPL: 533 planos com zero desfecho e 72% inalcançáveis — a fila sem saída (expiração + recorte por risco) |
 | [auditoria-ux-redesign.md](auditoria-ux-redesign.md) | (era §9/§9b/§11) auditoria UX 2026-05-13 + redesign visual v3 + premissas/glossário |
 | [estoque-picking-recebimento.md](estoque-picking-recebimento.md) | offline-first + closed-loop (Picking Bridge Oben, Recebimento honesto) |
 | [tintometrico.md](tintometrico.md) | vínculo `tint_skus`↔Omie (resgate de 62 cores que somem do seletor) + lições de matching de catálogo |

--- a/docs/historico/fila-plano-tatico.md
+++ b/docs/historico/fila-plano-tatico.md
@@ -1,0 +1,100 @@
+# Fila do Plano Tático (PTPL) — 533 planos, zero desfecho, 72% inalcançáveis
+
+> Diagnóstico + correção de 2026-08-07. Origem: o founder pediu para extrair aprendizado de
+> [uma matéria sobre a Dionísio](https://revistapegn.globo.com/startups/noticia/2026/07/startup-capta-r-22-milhoes-para-transformar-whatsapp-em-maquina-de-vendas-para-restaurantes.ghtml)
+> (startup que captou R$ 2,2 mi para virar o WhatsApp de restaurantes em canal de vendas).
+> A frase que puxou o fio: *"mais de 70% dos dados que passam por restaurantes não são captados"*.
+> Medimos o equivalente aqui e o número foi pior.
+
+## O que foi medido (psql-ro, 2026-08-07)
+
+| Fato | Valor |
+|---|---|
+| Cron `tactical-plans-batch-nightly` | **ativo**, `0 8 * * *`, ~30 planos/dia |
+| `farmer_tactical_plans` | 533 linhas (21/07 a 07/08), **100% `gerado`** |
+| Com desfecho (`concluido`) | **0** |
+| Com `actual_margin` | **0** |
+| Donos distintos | 3 (285 / 124 / 124) |
+| Fora dos 50 slots da UI | **383 de 533 (72%)** |
+| Janela real de visibilidade | **6,7 dias** |
+
+Sinais laterais da mesma doença: `farmer_recommendations` 3.659 linhas 100% `pendente`
+(idêntico ao post-mortem de [farmer-aprendizado-conversao.md](farmer-aprendizado-conversao.md));
+`call_log` parado desde 2026-06-09. **Todo ponto de captura que depende de digitação manual
+está em zero.** O que está vivo é o que a máquina calcula sozinha (`farmer_client_scores`,
+recalculado diariamente).
+
+## O que NÃO era (hipóteses descartadas com evidência)
+
+- **Não era export morto.** Ao contrário do `farmer_category_conversion`, a cadeia está inteira:
+  `FarmerTacticalPlan.tsx` → `PlanCard.tsx:233` → `RecordResultDialog.tsx` → `recordResult` →
+  RPC `registrar_resultado_plano` (que grava `status='concluido'` + `actual_margin`).
+- **Não era botão escondido por status.** Renderiza sob `plan.status !== 'concluido'`, verdadeiro
+  nos 533.
+- **`used_at = 0 em 533` NÃO prova não-adoção.** A coluna **não tem writer nenhum** (nem em `src/`,
+  nem em `pg_proc`). Ler esse zero como "ninguém abriu os planos" seria repetir exatamente a
+  armadilha do post-mortem: *ler uma tabela vazia é pior que não ler*. A inferência foi retirada.
+
+## A causa: o sistema competia consigo mesmo
+
+`loadPlans` fazia `.order('created_at', desc).limit(50)`, **sem filtro de status e sem paginação**.
+Com ~30 planos novos por dia, a lista de 50 rotacionava inteira em menos de uma semana — e o plano
+saía de vista para sempre, sem nunca ter recebido desfecho.
+
+O ponto não-óbvio: **trocar só o critério de ordenação não resolveria.** Sem uma saída, qualquer
+ordenação estável entope — os mesmos 50 planos (de maior risco, ou mais antigos) ficariam no topo
+permanentemente, porque nada os remove. A fila só circula se tiver saída.
+
+## A correção
+
+1. **Saída (banco):** `expirar_planos_taticos(_dias integer DEFAULT 7)` + cron
+   `expirar-planos-taticos` (`30 8 * * *`, 30 min depois do batch de geração). Plano `gerado`
+   fora da janela vira `expirado`. Nunca toca `concluido` — o desfecho registrado é o dado escasso.
+   - Guard fail-closed: `_dias` nulo ou `< 1` levanta `22023` (com `_dias=0` a fila INTEIRA
+     expiraria, inclusive o lote da madrugada).
+   - `SECURITY DEFINER` + `REVOKE` nominal de `anon`/`authenticated` (revogar de `PUBLIC` não
+     basta no Supabase — grant explícito por default privileges).
+   - Efeito medido em prod antes do apply: **364 expirariam, 169 ficariam na fila.**
+2. **Recorte (front):** `status='gerado'` + janela móvel em `generated_at` + ordenação por
+   `churn_risk` desc com `generated_at` de desempate. O front aplica a janela por conta própria
+   em vez de confiar que o cron rodou — se o job falhar, a fila entupiria de novo.
+   - `churn_risk` foi escolhido por ter variância real (53 valores distintos, 33..89).
+     `bundle_lie` e `best_individual_lie` seriam o critério natural de valor, mas estão **NULL em
+     100% das 533 linhas** — ordenar por eles seria ordem indefinida disfarçada de priorização.
+3. **Contador honesto:** a tela passa a dizer "Mostrando 50 de N". Contagem que falha degrada para
+   `null` (o rótulo some), **nunca para 0** — "0 pendentes" é indistinguível de "a query morreu".
+4. **Abas** pendentes/concluídos/expirados (`useUrlState`), para que o histórico continue
+   alcançável. Valor fora do domínio na query string degrada para `pendentes`.
+
+Prova: `db/test-expirar-planos-taticos.sh` (PG17, 15 asserts + 3 falsificações) e
+`src/hooks/__tests__/fila-plano-tatico.test.tsx` (5 testes).
+
+⚠️ A falsificação F3 (re-`GRANT` para `authenticated`) só tem dente porque o harness replica o
+`ALTER DEFAULT PRIVILEGES` do Supabase. Sem isso o `authenticated` do stub nasceria sem EXECUTE e
+o assert de REVOKE passaria por acidente de ambiente — falso-verde.
+
+## O que este PR NÃO resolve (deliberadamente)
+
+- **A geração continua em ~30/dia para 3 donos.** ~10 planos/dia por vendedor não é executável em
+  venda consultiva. Reduzir é config (`farmer_algorithm_config`, 17 linhas), não código — ficou
+  como item separado.
+- **O custo de registrar continua alto.** O `RecordResultDialog` pede 4 campos, entre eles a
+  **margem realizada** digitada, que a vendedora dificilmente sabe durante a ligação. O caminho
+  natural é registro de 1 toque (ligou / não atendeu / vendeu / recusou) com a margem vindo do
+  pedido no Omie pelo elo, não do teclado.
+- **Não se sabe se a tela é aberta.** Não há telemetria server-side do módulo Farmer
+  (`farmer_audit_log` e `farmer_copilot_events` estão vazias); a fonte seria o PostHog.
+
+## Lição
+
+O post-mortem irmão catalogou o writer **inalcançável**. Este é o caso oposto e mais difícil de
+enxergar: **o writer é alcançável, funciona, e mesmo assim o registro nunca acontece** — porque a
+própria geração empurra o item para fora da janela antes que alguém aja sobre ele.
+
+Corolário para revisão: **quando uma tabela de intenção tem muitas linhas e nenhuma transição de
+estado, meça a taxa de PRODUÇÃO contra o tamanho da JANELA de consumo antes de culpar a adoção.**
+Uma fila que recebe 30/dia e mostra 50 no total dá ao humano menos de dois dias de folga — e
+nenhuma tela comunica isso sozinha.
+
+E a leitura que veio da matéria: **desfecho que depende de digitação manual não é capturado.**
+É por isso que 70% dos dados se perdem no modelo antigo, e é exatamente o padrão aqui.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,13 +21,13 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **453** custom migrations totais
-- **1559** objetos esperados (criados por estas migrations)
+- **454** custom migrations totais
+- **1561** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 458
+  - `function`: 459
   - `rls_policy`: 392
   - `index`: 237
-  - `cron_job`: 162
+  - `cron_job`: 163
   - `table`: 153
   - `trigger`: 79
   - `view`: 74
@@ -3802,6 +3802,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_atp_decisoes_pedido` | `atp_decisoes` |
 | `index` | `public.idx_atp_decisoes_created` | `atp_decisoes` |
 | `rls_policy` | `public.atp_decisoes_select_staff` | `atp_decisoes` |
+
+### `20260807210912_expirar_planos_taticos.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.expirar_planos_taticos` | — |
+| `cron_job` | `cron.expirar-planos-taticos` | — |
 
 ### `20260807223000_check_finitude_money_path.sql`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 453
+-- Total de custom migrations: 454
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -494,6 +494,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260806223407', 'drop_import_tint_formulas', '20260806223407_drop_import_tint_formulas.sql'),
   ('20260806225052', 'atp_reserva_estoque_fase1_1_hardening', '20260806225052_atp_reserva_estoque_fase1_1_hardening.sql'),
   ('20260807015000', 'atp_gate_pedido_fase2', '20260807015000_atp_gate_pedido_fase2.sql'),
+  ('20260807210912', 'expirar_planos_taticos', '20260807210912_expirar_planos_taticos.sql'),
   ('20260807223000', 'check_finitude_money_path', '20260807223000_check_finitude_money_path.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
@@ -2042,7 +2043,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('atp_gate_pedido_fase2', 'table', 'public', 'atp_decisoes', ''),
   ('atp_gate_pedido_fase2', 'index', 'public', 'idx_atp_decisoes_pedido', 'atp_decisoes'),
   ('atp_gate_pedido_fase2', 'index', 'public', 'idx_atp_decisoes_created', 'atp_decisoes'),
-  ('atp_gate_pedido_fase2', 'rls_policy', 'public', 'atp_decisoes_select_staff', 'atp_decisoes')
+  ('atp_gate_pedido_fase2', 'rls_policy', 'public', 'atp_decisoes_select_staff', 'atp_decisoes'),
+  ('expirar_planos_taticos', 'function', 'public', 'expirar_planos_taticos', ''),
+  ('expirar_planos_taticos', 'cron_job', 'cron', 'expirar-planos-taticos', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3638,7 +3641,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('atp_gate_pedido_fase2', 'table', 'public', 'atp_decisoes', ''),
   ('atp_gate_pedido_fase2', 'index', 'public', 'idx_atp_decisoes_pedido', 'atp_decisoes'),
   ('atp_gate_pedido_fase2', 'index', 'public', 'idx_atp_decisoes_created', 'atp_decisoes'),
-  ('atp_gate_pedido_fase2', 'rls_policy', 'public', 'atp_decisoes_select_staff', 'atp_decisoes')
+  ('atp_gate_pedido_fase2', 'rls_policy', 'public', 'atp_decisoes_select_staff', 'atp_decisoes'),
+  ('expirar_planos_taticos', 'function', 'public', 'expirar_planos_taticos', ''),
+  ('expirar_planos_taticos', 'cron_job', 'cron', 'expirar-planos-taticos', '')
 )
 SELECT
   e.migration,

--- a/src/components/farmer/tacticalPlan/__tests__/carteira-busca-paginacao.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/carteira-busca-paginacao.test.tsx
@@ -19,6 +19,12 @@
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+
+// `useFarmerTacticalPlan` lê o filtro da fila da URL (useUrlState → useSearchParams),
+// então o hook precisa de um Router no ambiente de teste.
+const ComRouter = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
 
 const OWNER = '414a9727-ad1d-4998-914e-9c6ccf26cf50';
 const PAGINA = 1000;
@@ -85,21 +91,21 @@ describe('carteira do PTPL: paginação + nomes em lote', () => {
   beforeEach(() => { queries = []; falhaSeLoteMaiorQue = Infinity; });
 
   it('carrega a carteira INTEIRA, não só a primeira página do PostgREST', async () => {
-    const { result: hook } = renderHook(() => useFarmerTacticalPlan());
+    const { result: hook } = renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(hook.current.filteredCustomers.length).toBe(TOTAL));
     // O tell da versão quebrada: exatamente 1.000 (a capa), não 1.500.
     expect(hook.current.filteredCustomers.length).not.toBe(PAGINA);
   });
 
   it('pagina com ordem TOTAL — priority_score empata em massa e sozinho pula/repete linha', async () => {
-    renderHook(() => useFarmerTacticalPlan());
+    renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(queries.some((q) => q.table === 'farmer_client_scores' && q.ranges.length)).toBe(true));
     const scoreQ = queries.filter((q) => q.table === 'farmer_client_scores');
     expect(scoreQ.every((q) => q.orders.includes('customer_user_id'))).toBe(true);
   });
 
   it('busca nomes em LOTES pequenos — nunca um .in() com a carteira toda', async () => {
-    renderHook(() => useFarmerTacticalPlan());
+    renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(queries.some((q) => q.table === 'profiles')).toBe(true));
     const lotes = queries.filter((q) => q.table === 'profiles');
     expect(lotes.length).toBeGreaterThan(1);
@@ -107,7 +113,7 @@ describe('carteira do PTPL: paginação + nomes em lote', () => {
   });
 
   it('nome REAL chega ao dropdown — o cliente é buscável pelo que o vendedor digita', async () => {
-    const { result: hook } = renderHook(() => useFarmerTacticalPlan());
+    const { result: hook } = renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     // Espera QUALQUER carga (não `=== TOTAL`): este teste é sobre o NOME, não sobre a paginação.
     // Amarrá-lo ao total faria a sabotagem da paginação derrubá-lo em cascata, e um vermelho que
     // não é sobre o que o teste afirma medir não prova nada sobre ele.
@@ -120,7 +126,7 @@ describe('carteira do PTPL: paginação + nomes em lote', () => {
 
   it('consulta de nomes que FALHA não vira nome fabricado — o rótulo denuncia', async () => {
     falhaSeLoteMaiorQue = 0; // toda página de profiles falha
-    const { result: hook } = renderHook(() => useFarmerTacticalPlan());
+    const { result: hook } = renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     // Idem: independente da paginação — o que se mede aqui é o RÓTULO sob falha de consulta.
     await waitFor(() => expect(hook.current.filteredCustomers.length).toBeGreaterThan(0));
     const nomes = hook.current.filteredCustomers.map((c) => c.name);

--- a/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
+++ b/src/components/farmer/tacticalPlan/useFarmerTacticalPlan.ts
@@ -5,7 +5,8 @@ import { useState, useEffect } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { useMyActiveCoverage } from '@/hooks/useCoverage';
-import { useTacticalPlan, type PlanType } from '@/hooks/useTacticalPlan';
+import { useUrlState } from '@/hooks/useUrlState';
+import { useTacticalPlan, type PlanType, type FiltroFila } from '@/hooks/useTacticalPlan';
 import { supabase } from '@/integrations/supabase/client';
 import { fetchAllPages } from '@/lib/postgrest';
 import type { FarmerClientScoreRow, ProfileRow, CustomerLite } from './types';
@@ -13,6 +14,8 @@ import type { FarmerClientScoreRow, ProfileRow, CustomerLite } from './types';
 // Lote do `.in()` de profiles. 200 UUIDs ≈ 7,4 KB de query string — abaixo do teto de ~8 KB do
 // PostgREST/proxy, com folga para o resto da URL. Ver o guard em `loadCustomers`.
 const PROFILES_BATCH = 200;
+
+const FILTROS_FILA: readonly FiltroFila[] = ['pendentes', 'concluidos', 'expirados'];
 
 export function useFarmerTacticalPlan() {
   const { user, isStaff } = useAuth();
@@ -26,7 +29,16 @@ export function useFarmerTacticalPlan() {
   const coveredIds = (coverage ?? []).map((c) => c.covered_user_id);
   const coveredKey = coveredIds.join(',');
   const ownerIds = isImpersonating && effectiveUserId ? [effectiveUserId] : (user ? [user.id, ...coveredIds] : []);
-  const { plans, loading, generating, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
+  const { plans, loading, generating, totalNaFila, loadPlans, generatePlan, checkEfficiency, recordResult } = useTacticalPlan();
+  // Filtro na URL (convenção do repo p/ filtro de lista): sobrevive a F5 e é
+  // compartilhável. ⚠️ A query string é input do usuário — `?fila=lixo` cairia num
+  // recorte inexistente e a tela voltaria vazia sem explicação. Valor fora do
+  // domínio degrada para `pendentes`.
+  const [{ fila }, setUrlState] = useUrlState({ fila: 'pendentes' });
+  const filtroFila: FiltroFila = (FILTROS_FILA as readonly string[]).includes(fila)
+    ? (fila as FiltroFila)
+    : 'pendentes';
+  const setFiltroFila = (f: FiltroFila) => setUrlState({ fila: f });
   const [customers, setCustomers] = useState<CustomerLite[]>([]);
   const [expandedPlan, setExpandedPlan] = useState<string | null>(null);
   const [copiedText, setCopiedText] = useState<string | null>(null);
@@ -34,12 +46,17 @@ export function useFarmerTacticalPlan() {
   const [efficiencyAlert, setEfficiencyAlert] = useState<{ customerId: string; profitPerHour: number | null; motivo?: 'sem_margem' | 'indisponivel'; planType: PlanType } | null>(null);
 
   useEffect(() => {
-    if (user?.id && isStaff) {
-      loadPlans();
-      loadCustomers();
-    }
+    if (user?.id && isStaff) loadPlans(filtroFila);
     // effectiveUserId/coveredKey na dep: ao entrar/sair da lente OU mudar a cobertura,
-    // recarrega planos + dropdown (que passa a incluir os clientes cobertos).
+    // recarrega os planos. `filtroFila` na dep: trocar de aba refaz a query.
+
+  }, [user, isStaff, effectiveUserId, coveredKey, filtroFila]);
+
+  // Separado do efeito acima DE PROPÓSITO: `loadCustomers` pagina a carteira inteira
+  // (até 3.858 clientes em prod, vários round-trips) e não depende do filtro da fila.
+  // Recarregá-la a cada troca de aba seria desperdício visível na tela.
+  useEffect(() => {
+    if (user?.id && isStaff) loadCustomers();
 
   }, [user, isStaff, effectiveUserId, coveredKey]);
 
@@ -131,6 +148,9 @@ export function useFarmerTacticalPlan() {
     plans,
     loading,
     generating,
+    totalNaFila,
+    filtroFila,
+    setFiltroFila,
     searchTerm,
     setSearchTerm,
     filteredCustomers,

--- a/src/hooks/__tests__/fila-plano-tatico.test.tsx
+++ b/src/hooks/__tests__/fila-plano-tatico.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Fila do Plano Tático (PTPL) — o recorte que devolve os planos inalcançáveis.
+ *
+ * Medido em prod (psql-ro, 2026-08-07): a cron `tactical-plans-batch-nightly` gera ~30
+ * planos/dia para 3 donos, e o `loadPlans` lia os 50 mais RECENTES, sem filtro de status
+ * e sem paginação. Resultado: 533 planos vivos, 100% `gerado`, ZERO desfecho — e 383
+ * deles (72%) fora dos 50 slots, ou seja, inalcançáveis pela UI. A janela real de
+ * visibilidade era de 6,7 dias antes de o plano ser empurrado para fora pelos mais novos.
+ *
+ * DISCRIMINADOR: a versão velha ordenava por `created_at` desc e não filtrava `status`.
+ * Um teste que só checasse "veio lista" ou "tem limit 50" passaria nas DUAS versões —
+ * por isso os asserts abaixo travam o predicado (status + janela) e a CHAVE de ordenação,
+ * e negam explicitamente a chave velha.
+ */
+const MASTER = 'master-id';
+
+type Q = {
+  table: string;
+  eq: Array<[string, unknown]>;
+  gte: Array<[string, unknown]>;
+  orders: Array<[string, boolean | undefined]>;
+  limit: number | null;
+  head: boolean;
+};
+let queries: Q[] = [];
+let falhaNaContagem = false;
+
+const PLANO = {
+  id: 'p1', customer_user_id: 'c1', status: 'gerado',
+  strategic_objective: 'consolidacao_margem', customer_profile: 'x',
+  generated_at: '2026-08-01T00:00:00Z',
+};
+
+function result(q: Q): unknown {
+  if (q.table === 'farmer_tactical_plans' && q.head) {
+    return falhaNaContagem
+      ? { data: null, count: null, error: { message: 'statement timeout', code: '57014' } }
+      : { data: null, count: 127, error: null };
+  }
+  if (q.table === 'farmer_tactical_plans') return { data: [PLANO], error: null };
+  return { data: [], error: null };
+}
+
+function chain(table: string): unknown {
+  const q: Q = { table, eq: [], gte: [], orders: [], limit: null, head: false };
+  queries.push(q);
+  const c: Record<string, unknown> = {};
+  for (const m of ['in', 'lt', 'lte', 'is', 'not', 'or', 'filter', 'update', 'range', 'neq']) c[m] = () => c;
+  c.select = (_cols: string, opts?: { count?: string; head?: boolean }) => {
+    if (opts?.head) q.head = true;
+    return c;
+  };
+  c.eq = (col: string, val: unknown) => { q.eq.push([col, val]); return c; };
+  c.gte = (col: string, val: unknown) => { q.gte.push([col, val]); return c; };
+  c.order = (col: string, opts?: { ascending?: boolean }) => { q.orders.push([col, opts?.ascending]); return c; };
+  c.limit = (n: number) => { q.limit = n; return c; };
+  c.single = () => c;
+  c.maybeSingle = () => c;
+  c.then = (resolve: (v: unknown) => void) => resolve(result(q));
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: (t: string) => chain(t), rpc: () => Promise.resolve({ data: null, error: null }) },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: MASTER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: MASTER }, isStaff: true }) }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { useTacticalPlan, JANELA_FILA_DIAS, LIMITE_FILA } from '../useTacticalPlan';
+
+beforeEach(() => { queries = []; falhaNaContagem = false; vi.clearAllMocks(); });
+
+const lista = () => queries.filter((q) => q.table === 'farmer_tactical_plans' && !q.head);
+const contagem = () => queries.filter((q) => q.table === 'farmer_tactical_plans' && q.head);
+
+describe('loadPlans — fila com status e janela móvel', () => {
+  it('pendentes: filtra status=gerado, aplica a janela em generated_at e ordena por risco', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    const q = lista().at(-1)!;
+    expect(q.eq).toContainEqual(['status', 'gerado']);
+    expect(q.limit).toBe(LIMITE_FILA);
+
+    // janela móvel: o corte cai a JANELA_FILA_DIAS atrás, não numa data fixa
+    const [col, valor] = q.gte.at(-1)!;
+    expect(col).toBe('generated_at');
+    const idadeDias = (Date.now() - new Date(valor as string).getTime()) / 86_400_000;
+    expect(idadeDias).toBeCloseTo(JANELA_FILA_DIAS, 1);
+
+    // ordena por risco (desc) com desempate estável — churn_risk tem 53 valores
+    // distintos em 533 linhas, então sem desempate a ordem entre empatados é indefinida
+    expect(q.orders[0]).toEqual(['churn_risk', false]);
+    expect(q.orders[1]?.[0]).toBe('generated_at');
+  });
+
+  it('NÃO ordena por created_at — a chave velha é o que produziu os 72% inalcançáveis', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    expect(lista().at(-1)!.orders.map(([c]) => c)).not.toContain('created_at');
+  });
+
+  it('concluidos/expirados: recorte por status, SEM janela (histórico não expira da vista)', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('concluidos'); });
+    expect(lista().at(-1)!.eq).toContainEqual(['status', 'concluido']);
+    expect(lista().at(-1)!.gte).toHaveLength(0);
+
+    await act(async () => { await r.current.loadPlans('expirados'); });
+    expect(lista().at(-1)!.eq).toContainEqual(['status', 'expirado']);
+    expect(lista().at(-1)!.gte).toHaveLength(0);
+  });
+
+  it('a contagem usa EXATAMENTE o mesmo recorte da lista — senão o contador mente', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    const l = lista().at(-1)!;
+    const c = contagem().at(-1)!;
+    expect(c.eq).toEqual(l.eq);
+    expect(c.gte.map(([col]) => col)).toEqual(l.gte.map(([col]) => col));
+    expect(r.current.totalNaFila).toBe(127);
+  });
+
+  it('recarga sem argumento preserva o filtro corrente (não pula para pendentes)', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('expirados'); });
+    await act(async () => { await r.current.loadPlans(); });
+
+    // `generatePlan` e `recordResult` recarregam a lista sem saber qual aba está
+    // aberta. Com default fixo em 'pendentes', a lista passaria a discordar da aba.
+    expect(lista().at(-1)!.eq).toContainEqual(['status', 'expirado']);
+  });
+
+  it('contagem que FALHA vira null, nunca 0 (ausente ≠ zero)', async () => {
+    falhaNaContagem = true;
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    // `0 pendentes` é indistinguível de "a query morreu" e faria a fila inteira
+    // desaparecer da tela sem sinal nenhum — a mesma família do `Number(null) === 0`.
+    expect(r.current.totalNaFila).toBeNull();
+    expect(r.current.totalNaFila).not.toBe(0);
+  });
+});

--- a/src/hooks/__tests__/lens-tactical-plan.test.tsx
+++ b/src/hooks/__tests__/lens-tactical-plan.test.tsx
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode } from 'react';
+
+// `useFarmerTacticalPlan` lê o filtro da fila da URL (useUrlState → useSearchParams),
+// então o hook precisa de um Router no ambiente de teste.
+const ComRouter = ({ children }: { children: ReactNode }) => <MemoryRouter>{children}</MemoryRouter>;
 
 /**
  * Guard de regressão da lente "Ver como pessoa" no PLANO TÁTICO (engine de IA).
@@ -82,7 +88,7 @@ describe('useTacticalPlan — lente "Ver como"', () => {
 describe('useFarmerTacticalPlan — lente "Ver como" + cobertura', () => {
   it('na lente: o dropdown (loadCustomers) filtra só pelo ALVO, nunca o master', async () => {
     impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
-    renderHook(() => useFarmerTacticalPlan());
+    renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
     expect(farmerInValue()).toContain('alvo-id');
     expect(farmerInValue()).not.toContain('master-id');
@@ -90,7 +96,7 @@ describe('useFarmerTacticalPlan — lente "Ver como" + cobertura', () => {
 
   it('fora da lente sem cobertura: filtra pelo próprio usuário', async () => {
     impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
-    renderHook(() => useFarmerTacticalPlan());
+    renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
     expect(farmerInValue()).toContain('master-id');
   });
@@ -98,7 +104,7 @@ describe('useFarmerTacticalPlan — lente "Ver como" + cobertura', () => {
   it('fora da lente COM cobertura: dropdown inclui o coberto (eu + cobertos)', async () => {
     impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'master-id' });
     coverageMock.mockReturnValue({ data: [{ covered_user_id: 'coberto-id' }] });
-    renderHook(() => useFarmerTacticalPlan());
+    renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
     expect(farmerInValue()).toEqual(expect.arrayContaining(['master-id', 'coberto-id']));
   });
@@ -106,7 +112,7 @@ describe('useFarmerTacticalPlan — lente "Ver como" + cobertura', () => {
   it('na lente NÃO vaza a cobertura do master (só o alvo)', async () => {
     impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'alvo-id' });
     coverageMock.mockReturnValue({ data: [{ covered_user_id: 'coberto-id' }] });
-    renderHook(() => useFarmerTacticalPlan());
+    renderHook(() => useFarmerTacticalPlan(), { wrapper: ComRouter });
     await waitFor(() => expect(inCalls.some(([col]) => col === 'farmer_id')).toBe(true));
     expect(farmerInValue()).toEqual(['alvo-id']);
     expect(farmerInValue()).not.toContain('coberto-id');

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { invokeFunction } from '@/lib/invoke-function';
 import { selectObjective, clampRecencyCapDays, objetivoFinal } from '@/lib/scoring/objective';
@@ -229,6 +229,35 @@ const classifyProfile = (healthScore: number, avgSpend: number, marginPct: numbe
 
 const PROFIT_PER_HOUR_THRESHOLD = 50; // R$/h configurable threshold
 
+/**
+ * Janela da fila de pendentes, em dias. Espelha o argumento do cron
+ * `expirar-planos-taticos` (migration `20260807210912`), que marca `expirado`
+ * fora dela. O front aplica a MESMA janela em vez de confiar que o job rodou:
+ * se o cron falhar, a fila voltaria a entupir e o plano some sem desfecho.
+ */
+export const JANELA_FILA_DIAS = 7;
+
+/** Teto de cards por carga. Não é paginação — é o tamanho do lote acionável. */
+export const LIMITE_FILA = 50;
+
+export type FiltroFila = 'pendentes' | 'concluidos' | 'expirados';
+
+/**
+ * Recorte da fila. Extraído para que a LISTA e a CONTAGEM usem exatamente o
+ * mesmo predicado — se divergirem, o contador da tela mente sobre quantos
+ * planos existem além dos exibidos, que é justamente o número que este PR
+ * passou a mostrar.
+ */
+function recorteDaFila<Q extends { eq: (c: string, v: string) => Q; gte: (c: string, v: string) => Q }>(
+  q: Q,
+  filtro: FiltroFila,
+  desdeIso: string,
+): Q {
+  if (filtro === 'concluidos') return q.eq('status', 'concluido');
+  if (filtro === 'expirados') return q.eq('status', 'expirado');
+  return q.eq('status', 'gerado').gte('generated_at', desdeIso);
+}
+
 export const useTacticalPlan = () => {
   const { user } = useAuth();
   // Lente "Ver como" + COBERTURA (#980): as leituras de EXIBIÇÃO (lista de planos, plano ativo do
@@ -248,6 +277,13 @@ export const useTacticalPlan = () => {
   const [plans, setPlans] = useState<TacticalPlan[]>([]);
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState<string | null>(null);
+  /** Total que casa o filtro atual (pode exceder LIMITE_FILA). `null` = não apurado. */
+  const [totalNaFila, setTotalNaFila] = useState<number | null>(null);
+  // Último recorte pedido. `generatePlan`/`recordResult` recarregam a lista sem saber
+  // qual aba está aberta; sem este ref o default os jogaria de volta em `pendentes` e
+  // a lista passaria a discordar da aba selecionada. Ref (não state): só alimenta o
+  // default da próxima carga, não deve disparar render.
+  const filtroAtual = useRef<FiltroFila>('pendentes');
 
   const parsePlan = (d: TacticalPlanRow, profileMap: Map<string, string>): TacticalPlan => {
     const topBundle: BundleSnapshot = d.top_bundle || {};
@@ -338,17 +374,44 @@ export const useTacticalPlan = () => {
   }, []);
 
   // Load existing plans
-  const loadPlans = useCallback(async () => {
+  const loadPlans = useCallback(async (filtro: FiltroFila = filtroAtual.current) => {
     if (!effectiveUserId) return;
+    filtroAtual.current = filtro;
     setLoading(true);
     try {
       const owners = await fetchOwnerScope(effectiveUserId);
-      const { data } = (await supabase
-        .from('farmer_tactical_plans')
-        .select('*')
-        .in('farmer_id', owners)
-        .order('created_at', { ascending: false })
-        .limit(50)) as unknown as { data: TacticalPlanRow[] | null };
+      const desdeIso = new Date(Date.now() - JANELA_FILA_DIAS * 86_400_000).toISOString();
+
+      // Ordena por RISCO, não por recência. `churn_risk` tem 53 valores distintos entre
+      // 33 e 89 nas 533 linhas de prod — discrimina de verdade. `bundle_lie` e
+      // `best_individual_lie` seriam o critério natural de VALOR, mas estão NULL em 100%
+      // das linhas (medido 2026-08-07): ordenar por eles seria ordem indefinida
+      // disfarçada de priorização. `generated_at` desempata (churn_risk tem empates
+      // massivos e, sem ordem total, a fatia de 50 é instável entre cargas).
+      const { data } = (await recorteDaFila(
+        supabase.from('farmer_tactical_plans').select('*').in('farmer_id', owners),
+        filtro,
+        desdeIso,
+      )
+        .order('churn_risk', { ascending: false })
+        .order('generated_at', { ascending: false })
+        .limit(LIMITE_FILA)) as unknown as { data: TacticalPlanRow[] | null };
+
+      // Contagem sob o MESMO recorte. Sem ela a tela não tem como avisar que existe
+      // plano além dos exibidos — foi exatamente assim que 383 de 533 sumiram sem
+      // deixar rastro nenhum na interface.
+      const { count, error: erroContagem } = (await recorteDaFila(
+        supabase
+          .from('farmer_tactical_plans')
+          .select('id', { count: 'exact', head: true })
+          .in('farmer_id', owners),
+        filtro,
+        desdeIso,
+      )) as unknown as { count: number | null; error: unknown };
+      // ausente ≠ zero: contagem que falhou degrada para `null` (a UI omite o rótulo),
+      // nunca para 0 — "0 pendentes" é indistinguível de "a query morreu", e some com
+      // a fila inteira sem sinal. Mesma família do `Number(null) === 0`.
+      setTotalNaFila(erroContagem ? null : (count ?? null));
 
       if (!data) { setPlans([]); return; }
 
@@ -796,6 +859,7 @@ export const useTacticalPlan = () => {
     plans,
     loading,
     generating,
+    totalNaFila,
     loadPlans,
     generatePlan,
     checkEfficiency,

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -285,6 +285,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/cluster-margin-cobertura.test.tsx",
       "src/hooks/__tests__/cluster-margin-paginacao.test.tsx",
       "src/hooks/__tests__/efficiency-margem-indisponivel.test.tsx",
+      "src/hooks/__tests__/fila-plano-tatico.test.tsx",
       "src/hooks/__tests__/useBundleArguments.test.ts",
       "src/hooks/__tests__/farmer-performance-cobertura-guard.test.tsx",
       "src/hooks/__tests__/lens-atividade-vendedor.test.tsx",

--- a/src/pages/FarmerTacticalPlan.tsx
+++ b/src/pages/FarmerTacticalPlan.tsx
@@ -2,11 +2,34 @@ import { useNavigate } from 'react-router-dom';
 import { Target, FileText } from 'lucide-react';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
 import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useAuth } from '@/contexts/AuthContext';
+import { JANELA_FILA_DIAS, LIMITE_FILA, type FiltroFila } from '@/hooks/useTacticalPlan';
 import { useFarmerTacticalPlan } from '@/components/farmer/tacticalPlan/useFarmerTacticalPlan';
 import { GerarPlanoCard } from '@/components/farmer/tacticalPlan/GerarPlanoCard';
 import { EfficiencyAlertDialog } from '@/components/farmer/tacticalPlan/EfficiencyAlertDialog';
 import { PlanCard } from '@/components/farmer/tacticalPlan/PlanCard';
+
+const ROTULO_FILA: Record<FiltroFila, string> = {
+  pendentes: 'pendentes',
+  concluidos: 'concluídos',
+  expirados: 'expirados',
+};
+
+/**
+ * Rodapé honesto da fila. O ponto do PR: a tela precisa DIZER quando existe plano
+ * além dos exibidos — antes, 383 de 533 ficavam fora dos 50 slots sem sinal nenhum.
+ *
+ * `total === null` = contagem não apurada (query falhou). Nesse caso o rótulo OMITE
+ * o total em vez de exibir 0 — "0 pendentes" seria fabricação (ausente ≠ zero).
+ */
+export function resumoDaFila(exibidos: number, total: number | null, filtro: FiltroFila): string {
+  const rotulo = ROTULO_FILA[filtro];
+  const janela = filtro === 'pendentes' ? ` · janela de ${JANELA_FILA_DIAS} dias` : '';
+  if (total === null) return `${exibidos} ${rotulo} exibidos${janela}`;
+  if (total > exibidos) return `Mostrando ${exibidos} de ${total} ${rotulo}${janela}`;
+  return `${total} ${rotulo}${janela}`;
+}
 
 const FarmerTacticalPlan = () => {
   const navigate = useNavigate();
@@ -15,6 +38,9 @@ const FarmerTacticalPlan = () => {
     plans,
     loading,
     generating,
+    totalNaFila,
+    filtroFila,
+    setFiltroFila,
     searchTerm,
     setSearchTerm,
     filteredCustomers,
@@ -64,6 +90,22 @@ const FarmerTacticalPlan = () => {
           onConfirm={confirmGenerate}
         />
 
+        {/* Fila: recorte + contador honesto do que ficou de fora */}
+        <Tabs value={filtroFila} onValueChange={(v) => setFiltroFila(v as FiltroFila)}>
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="pendentes">Pendentes</TabsTrigger>
+            <TabsTrigger value="concluidos">Concluídos</TabsTrigger>
+            <TabsTrigger value="expirados">Expirados</TabsTrigger>
+          </TabsList>
+        </Tabs>
+
+        {!loading && (
+          <p className="text-[10px] text-muted-foreground px-1">
+            {resumoDaFila(plans.length, totalNaFila, filtroFila)}
+            {totalNaFila !== null && totalNaFila > LIMITE_FILA && ' — priorizados por risco de churn'}
+          </p>
+        )}
+
         {/* Plans List */}
         {loading ? (
           <PageSkeleton variant="list" />
@@ -71,7 +113,11 @@ const FarmerTacticalPlan = () => {
           <Card>
             <CardContent className="p-6 text-center">
               <FileText className="w-8 h-8 mx-auto mb-2 opacity-40" />
-              <p className="text-xs text-muted-foreground">Nenhum plano tático gerado ainda.</p>
+              <p className="text-xs text-muted-foreground">
+                {filtroFila === 'pendentes'
+                  ? `Nenhum plano pendente nos últimos ${JANELA_FILA_DIAS} dias.`
+                  : `Nenhum plano ${ROTULO_FILA[filtroFila]}.`}
+              </p>
             </CardContent>
           </Card>
         ) : (

--- a/supabase/migrations/20260807210912_expirar_planos_taticos.sql
+++ b/supabase/migrations/20260807210912_expirar_planos_taticos.sql
@@ -1,0 +1,76 @@
+-- ============================================================
+-- expirar_planos_taticos — dá SAÍDA para a fila do Plano Tático (PTPL)
+--
+-- PROBLEMA (medido em prod via psql-ro, 2026-08-07):
+--   A cron `tactical-plans-batch-nightly` (0 8 * * *) gera ~30 planos/dia para
+--   3 donos. O `loadPlans` do front lia os 50 mais RECENTES, sem filtro de
+--   status e sem paginação. Resultado medido:
+--     · 533 planos vivos (21/07 a 07/08), 100% `gerado`
+--     · 0 `concluido`, 0 com `actual_margin` — nenhum desfecho, jamais
+--     · 383 de 533 (72%) FORA dos 50 slots = inalcançáveis pela UI
+--     · janela real de visibilidade: 6,7 dias antes de ser empurrado para fora
+--
+--   Sem uma SAÍDA, qualquer ordenação estável entope: os mesmos 50 planos
+--   ficam no topo para sempre, porque nada os remove. Trocar só o critério de
+--   ordenação (created_at → churn_risk) moveria o problema, não o resolveria.
+--
+-- ESTA FUNÇÃO É A SAÍDA: plano `gerado` com mais de N dias vira `expirado`.
+--   O front passa a ler `status='gerado'` dentro da janela, ordenado por
+--   churn_risk desc (53 valores distintos, 33..89 — discrimina de verdade;
+--   `bundle_lie` e `best_individual_lie` estão NULL em 100% das 533 linhas e
+--   NÃO servem para ordenar).
+--
+-- `expirado` é honesto: aquele plano nunca vai receber desfecho. Deixá-lo
+-- `gerado` para sempre é o mesmo tipo de mentira do "aprendizado que nunca
+-- aprendeu" (docs/historico/farmer-aprendizado-conversao.md) — um estado que
+-- afirma pendência quando não há pendência real.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.expirar_planos_taticos(_dias integer DEFAULT 7)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  _n integer;
+BEGIN
+  -- Guard: `_dias` <= 0 expiraria a fila INTEIRA, inclusive o lote gerado hoje
+  -- de madrugada. NULL vindo de chamada malformada faria o `<` devolver NULL e
+  -- o UPDATE não pegar nada — falha silenciosa. Fail-closed nos dois casos.
+  IF _dias IS NULL OR _dias < 1 THEN
+    RAISE EXCEPTION 'expirar_planos_taticos: _dias deve ser >= 1 (recebido: %)', _dias
+      USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.farmer_tactical_plans
+     SET status     = 'expirado',
+         updated_at = now()
+   WHERE status = 'gerado'
+     AND generated_at < now() - make_interval(days => _dias);
+
+  GET DIAGNOSTICS _n = ROW_COUNT;
+  RETURN _n;
+END;
+$$;
+
+-- SECURITY DEFINER bypassa RLS → só cron/service_role pode executar.
+-- `REVOKE ... FROM PUBLIC` NÃO tira anon/authenticated no Supabase (eles têm
+-- grant EXPLÍCITO via default privileges) → revogar por NOME. Ver database.md.
+REVOKE ALL ON FUNCTION public.expirar_planos_taticos(integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.expirar_planos_taticos(integer) FROM anon;
+REVOKE ALL ON FUNCTION public.expirar_planos_taticos(integer) FROM authenticated;
+
+-- Cron: 30 min DEPOIS do batch noturno (`tactical-plans-batch-nightly`, 0 8 * * *),
+-- para que o lote novo já esteja no lugar quando o velho sair da fila.
+-- SQL nomeado (não inline com o UPDATE cru): `cron.job.command` é invisível a
+-- `grep` e a `pg_proc`, então um UPDATE inline sumiria do preflight de
+-- dependência de tabela. Ver database.md §preflight.
+SELECT cron.unschedule('expirar-planos-taticos')
+  WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'expirar-planos-taticos');
+
+SELECT cron.schedule(
+  'expirar-planos-taticos',
+  '30 8 * * *',
+  $$ SELECT public.expirar_planos_taticos(7); $$
+);


### PR DESCRIPTION
## Problema (medido em prod, `psql-ro`, 2026-08-07)

A cron `tactical-plans-batch-nightly` (`0 8 * * *`) gera ~30 planos/dia para 3 donos. O `loadPlans`
lia os **50 mais recentes**, sem filtro de status e sem paginação:

| Fato | Valor |
|---|---|
| `farmer_tactical_plans` | 533 linhas (21/07 a 07/08), **100% `gerado`** |
| Com desfecho (`concluido`) | **0** |
| Com `actual_margin` | **0** |
| Fora dos 50 slots da UI | **383 de 533 (72%)** |
| Janela real de visibilidade | **6,7 dias** |

Não é export morto: a cadeia `FarmerTacticalPlan` → `PlanCard:233` → `RecordResultDialog` →
`recordResult` → RPC `registrar_resultado_plano` está inteira e funciona. O plano simplesmente
era empurrado para fora da lista pelos mais novos antes de alguém agir sobre ele.

**O ponto não-óbvio:** trocar só o critério de ordenação não resolveria. Sem uma saída, qualquer
ordenação estável entope — os mesmos 50 ficariam no topo para sempre, porque nada os remove.

## O que muda

1. **Saída (banco):** `expirar_planos_taticos(_dias)` + cron `expirar-planos-taticos` (`30 8 * * *`,
   30 min após o batch de geração). `gerado` fora da janela → `expirado`. **Nunca toca `concluido`.**
   - Guard fail-closed: `_dias` nulo ou `< 1` levanta `22023` (com `0` a fila inteira expiraria).
   - `SECURITY DEFINER` + `REVOKE` nominal de `anon`/`authenticated`.
   - Efeito medido antes do apply: **364 expirariam, 169 ficariam na fila.**
2. **Recorte (front):** `status='gerado'` + janela móvel em `generated_at` + ordenação por
   `churn_risk` desc (53 valores distintos, 33..89) com `generated_at` de desempate.
   `bundle_lie`/`best_individual_lie` estão **NULL em 100%** das linhas — ordenar por eles seria
   ordem indefinida disfarçada de priorização.
   O front aplica a janela por conta própria em vez de confiar que o cron rodou.
3. **Contador honesto:** "Mostrando 50 de N". Contagem que falha degrada para `null` (rótulo some),
   **nunca 0** — "0 pendentes" é indistinguível de "a query morreu".
4. **Abas** pendentes/concluídos/expirados via `useUrlState`; valor fora do domínio na query string
   degrada para `pendentes`.

## Prova

- `db/test-expirar-planos-taticos.sh` — PG17 descartável, **15 asserts + 3 falsificações**, exit 0.
  Cobre: expiração, preservação de `concluido`, bordas (7d+1h vs 6d23h), idempotência, guard de
  `_dias` (0/-1/NULL com SQLSTATE), REVOKE de `anon`/`authenticated`, cron agendado.
  ⚠️ A falsificação F3 só tem dente porque o harness replica o `ALTER DEFAULT PRIVILEGES` do
  Supabase — sem isso o `authenticated` do stub nasceria sem EXECUTE e o assert passaria por
  acidente de ambiente (falso-verde).
- `src/hooks/__tests__/fila-plano-tatico.test.tsx` — 6 testes, incluindo o discriminador explícito
  contra a chave velha (`not.toContain('created_at')`) e o `null` da contagem.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260807210912_expirar_planos_taticos.sql`. **Lovable não
aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor e rodar.

Validação pós-apply (read-only):

```sql
SELECT
  CASE WHEN EXISTS (SELECT 1 FROM pg_proc WHERE proname='expirar_planos_taticos'
                      AND pronamespace='public'::regnamespace)
       THEN '✅ função existe' ELSE '❌ FALTANDO' END AS fn,
  CASE WHEN EXISTS (SELECT 1 FROM cron.job WHERE jobname='expirar-planos-taticos')
       THEN '✅ cron agendado' ELSE '❌ FALTANDO' END AS cron,
  CASE WHEN NOT has_function_privilege('authenticated','public.expirar_planos_taticos(integer)','EXECUTE')
       THEN '✅ authenticated revogado' ELSE '❌ AINDA EXECUTA' END AS revoke_ok;
```

## Fora de escopo (deliberado)

- A geração segue em ~30/dia para 3 donos. Reduzir é config (`farmer_algorithm_config`), não código.
- O `RecordResultDialog` ainda pede **margem realizada digitada**, que a vendedora dificilmente sabe
  na ligação. Registro de 1 toque + margem vinda do pedido no Omie é o caminho natural.
- Não há telemetria server-side do módulo Farmer, então não se sabe se a tela é aberta.

Contexto e medições completas: [docs/historico/fila-plano-tatico.md](docs/historico/fila-plano-tatico.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
