### PR TITLE
chore(ci): consolidar @supabase/supabase-js num especificador só — 17 edges → npm:…@2 [money-path]

### DIFF
--- a/docs/historico/ci-testes-edge-deno.md
+++ b/docs/historico/ci-testes-edge-deno.md
@@ -154,9 +154,11 @@ Apertar para check completo é o destino natural, depois que a dívida encolher.
 
 ## Follow-ups (medidos)
 
-1. Consolidar `@supabase/supabase-js` numa versão só (hoje 6) — corta download e resolve 17 dos 141.
-2. Migrar `deno.land/std/http/server.ts` → `Deno.serve` (34 edges) e `esm.sh/@supabase/supabase-js` →
-   `npm:` (18 edges). Deixa `registry.npmjs.org` como host único.
+1. ~~Consolidar `@supabase/supabase-js` numa versão só (hoje 6) — corta download e resolve 17 dos 141.~~
+   ✅ **feito em 2026-08-07** — ver a sequela ao fim deste doc.
+2. ~~Migrar `deno.land/std/http/server.ts` → `Deno.serve` (34 edges) e `esm.sh/@supabase/supabase-js` →
+   `npm:` (18 edges). Deixa `registry.npmjs.org` como host único.~~ ✅ **feito em 2026-08-07** — e o 1 e o
+   2 eram **o mesmo trabalho**; ver a sequela ao fim deste doc.
 3. Zerar as 25 edges sujas e apertar o gate para check completo.
 4. Versionar `deno.lock` (hoje no `.gitignore`) — reprodutibilidade + chave de cache estável.
 
@@ -264,3 +266,150 @@ mutcheck-all: ✓ 11 contrato(s) honrado(s) — nenhuma regressão de cobertura.
 Os 9 contratos antigos saíram com os **mesmos números** de antes da mudança (`8/6/2`, `9/9/0`,
 `11/11/0`, `18/18/0`, `6/6/0`, `9/7/2`, `10/9/1`, `27/27/0`, `12/12/0`) — a prova de que o override
 por contrato não vaza para quem não o declara. Custo: o job foi de ~2m41s para ~3m54s (teto de 10min).
+
+---
+
+# Sequela (2026-08-07): os dois hosts saíram do caminho de entrega — e o follow-up 1 era o mesmo trabalho que o 2
+
+**Entrega:** PRs #1685 (34 edges), #1687 (7), #1690 (12), #1694 (17). Gatilho: o **#1670**, uma PR **só
+de documentação**, derrubada pelo `edges:typecheck` com
+
+```
+error: Import 'https://esm.sh/@supabase/supabase-js@2.112.2/dist/index.d.mts' failed: 500 Internal Server Error
+```
+
+O gate agiu certo — *"não conseguir checar não é o mesmo que estar limpo"* é o desenho — e o rerun
+passou. O problema não era ele: o `edges:typecheck` é o **único step do `validate` que precisa de rede**,
+e arrastava dois hosts que não estavam no caminho de entrega por nenhum outro motivo. Mesma forma do
+2026-07-16 (REST API do GitHub degradada matando todo PR em ~6s), que motivou o `bunpin:check`.
+
+## Os follow-ups 1 e 2 eram um trabalho só — e fazer só o 2 pioraria o 1
+
+O nº 2 (migrar de host) parecia independente do nº 1 (consolidar numa versão só). Não era. As edges que
+**já** usavam `npm:` o faziam com **4 especificadores distintos** (`@2`, `^2`, `@2.45.0`, `^2.95.3`), e as
+19 de `esm.sh` traziam mais 3 (`@2.45.0`, `@2`, `@2.39.0`). Migrar de host sem escolher a versão teria
+despejado as 19 no mesmo espalhamento que produzia os 17 `SupabaseClient not assignable` — **trocaria um
+problema por dois**.
+
+> **Regra viva:** migração de HOST e consolidação de VERSÃO são o mesmo trabalho quando o import carrega
+> as duas coisas na mesma string. Fazer só uma metade move o custo, não o remove.
+
+Especificador escolhido para o repo: **`npm:@supabase/supabase-js@2`**, por medição e não por gosto:
+
+- majoritário absoluto — **56 dos 74** imports `npm:` da main;
+- `@2` e `^2` são o **mesmo range semver** (`>=2.0.0 <3.0.0`) — normalizar é textual, não muda o que
+  resolve. Dos 17 do último PR, **14 eram exatamente esse caso**;
+- quem **cria** versão distinta no grafo é o pin exato (`@2.45.0`, `@2.39.0`, `^2.95.3`) — tirá-lo é o que
+  consolida de verdade;
+- reprodutibilidade contra "o range se move sozinho" é papel do **`deno.lock`** (follow-up 4, ainda
+  aberto), não do especificador — pin aqui duplicaria esse papel e criaria bump manual em 73 arquivos.
+
+## O que já se sabia sobre `esm.sh` — e estava escrito no lugar errado
+
+O achado que mais mudou o enquadramento não veio de medição nova: veio de **comentário em quatro edges**,
+deixado pelo #1592 e pelas sequelas dele:
+
+> `⚠️ usar npm: (não esm.sh) — esm.sh/@supabase/supabase-js falhava em resolver no boot do edge runtime,
+> dando RUNTIME_ERROR sem linha/stack`
+
+Ou seja: `esm.sh` **já tinha derrubado edge em produção**, e a correção já era `npm:`. Quatro edges
+migraram uma a uma, por incidente, cada uma deixando o aviso no próprio cabeçalho — e o padrão nunca
+virou varredura. O 500 do #1670 foi a mesma fonte cobrando pelo lado do CI.
+
+> **Regra viva:** aviso repetido em cabeçalho de arquivo é **classe não erradicada**, não documentação.
+> Quando o mesmo `⚠️` aparece no 3º arquivo, o que falta não é mais um comentário — é a varredura.
+
+Consequência prática para o redeploy: migrar `esm.sh` → `npm:` não é risco novo a observar, é aplicar a
+correção que 4 edges já validaram em produção.
+
+## A asserção não podia ser a óbvia
+
+O objetivo era "o host sumiu", e o grep natural —
+
+```
+grep -rlE "https://esm\.sh/|https://deno\.land/" supabase/functions/
+```
+
+— **nunca chega a zero**: 7 arquivos citam os hosts em **prosa de comentário** (os 4 avisos acima, mais 3
+explicando por que a suíte de edge roda offline). Um gate ancorado nele ficaria permanentemente vermelho
+e seria afrouxado até não valer nada.
+
+O que o `deno check` resolve é o `from "https://…"`. A asserção é sobre **import**, não sobre menção:
+
+```
+grep -rlE "from ['\"]https://(esm\.sh|deno\.land)/" supabase/functions/
+```
+
+> **Regra viva:** ao provar que uma classe sumiu, o padrão tem de casar a **forma que o compilador
+> enxerga**, não a string que dá o nome à classe. Prosa que descreve o bug mora no mesmo arquivo que o
+> bug — mesma armadilha do `escrita-critica.ts`, cujo cabeçalho cita a forma do bug de propósito e
+> apareceu como falso positivo no predicado do gate de §11 do `money-path.md`.
+
+## O que a migração NÃO consertou — e por que era previsível
+
+Seis das 12 edges de money-path importavam `type SupabaseClient` junto do `createClient`, então valia
+perguntar se a consolidação derrubaria ali a classe `TS2345`. **Não moveu: 36 antes, 36 depois.** É o
+esperado, e o diff mostra por quê — o valor e o tipo vinham da **mesma linha de import**, então não havia
+mismatch interno a corrigir.
+
+O que **não** era esperado: a consolidação completa também não moveu. Com o repo inteiro em `@2` —
+especificador único, uma versão só no grafo — o gate saiu em **`TS2345:36`, o mesmo número de antes de a
+série começar**. Os 136 tolerados ficaram idênticos, classe por classe, nos quatro PRs.
+
+> **Regra viva:** a previsão do follow-up 1 (*"corta download e resolve 17 dos 141"*) estava certa na
+> primeira metade e **errada na segunda**. O espalhamento de especificador custava download; ele **não
+> era a causa** do `SupabaseClient not assignable`. Estimativa escrita num follow-up é hipótese, não
+> medição — e quem executa o follow-up é quem tem a obrigação de medir o antes/depois em vez de herdar o
+> número. Sem essa medição, a série teria sido reportada como "resolve 17" e ninguém notaria por anos.
+
+A causa dessa classe segue em aberto e passa a ser dado do **follow-up 3**, com uma informação que antes
+não existia: ela **sobrevive à unificação de versão**, então não adianta atacá-la por ali.
+
+## Família B: `Deno.serve` — drop-in conferido, não assumido
+
+34 edges importavam `serve` de `deno.land/std@{0.168.0,0.190.0}/http/server.ts`. A troca só é drop-in se
+ninguém usar o 2º parâmetro do handler (`connInfo` no std, `Deno.ServeHandlerInfo` no nativo) nem as
+options. Medido antes de tocar: **0 handlers com 2º parâmetro, 0 chamadas com options**, 34/34 na forma
+`^serve(` top-level. As outras 61 edges já usavam `Deno.serve`.
+
+## Números
+
+| | Antes (main 2026-08-06) | Depois |
+|---|---|---|
+| imports `https://deno.land/` | 34 | **0** |
+| imports `https://esm.sh/` | 19 | **0** |
+| especificadores distintos de `@supabase/supabase-js` | 7 | **1** (`npm:…@2`) + 1 no bundle gerado |
+| hosts no `deno check` | `registry.npmjs.org` + `esm.sh` + `deno.land` | **só `registry.npmjs.org`** |
+
+`registry.npmjs.org` **já** estava no caminho de entrega via `bun install` — então o `edges:typecheck`
+deixa de ter host próprio.
+
+## Uma edge ficou de fora de propósito
+
+`supabase/functions/mcp/index.ts` usa `npm:@supabase/supabase-js@^2.95.3` e **não** foi normalizada: é
+bundle auto-gerado (`// AUTO-GENERATED by @lovable.dev/mcp-js — do not edit. Regenerated by the Vite
+plugin.`). O banner até oferece uma saída — *"To take ownership, delete this banner line"* — mas tomar
+posse do bundle para arrumar uma string seria trocar regeneração automática por manutenção manual de um
+arquivo gerado. A divergência é do **artefato**; a fonte (`src/lib/mcp/**`) não escolhe essa string.
+
+## Custo de redeploy: nenhum agora, e nenhum mutirão depois
+
+O `deno check` roda sobre o **repo**, então os hosts saem do CI **no merge**. As edges em produção seguem
+com o import antigo até serem redeployadas pelo chat do Lovable. **Não se faz mutirão de redeploy** —
+cada edge pega a mudança no próximo deploy natural dela. As duas edges onde o redeploy muda a versão
+resolvida de verdade (`omie-webhook`, pinada em `2.39.0`, a mais velha do repo; e os 3 pins `2.45.0` do
+portal Sayerlack) tiveram a superfície da lib medida antes: só `.from()` e `.rpc()`, zero
+`auth`/`storage`/`realtime`/`functions` — PostgREST puro, a parte que não mudou de contrato dentro do 2.x.
+
+## Follow-ups (atualizados)
+
+1. ~~Consolidar `@supabase/supabase-js` numa versão só~~ ✅ feito aqui (`npm:…@2`).
+2. ~~Migrar `deno.land/std/http/server.ts` → `Deno.serve` e `esm.sh` → `npm:`~~ ✅ feito aqui.
+3. Zerar as edges sujas e apertar o gate para check completo. **Com um dado novo:** a classe `TS2345`
+   (36, onde mora o `SupabaseClient not assignable`) **não** vem do espalhamento de especificador —
+   sobreviveu intacta à unificação. Quem pegar este follow-up começa sabendo que esse caminho já foi
+   tentado e não é por ali; use `bun run edges:typecheck --json` para ver as mensagens, que o resumo do
+   gate não guarda.
+4. Versionar `deno.lock` (hoje no `.gitignore`) — reprodutibilidade + chave de cache estável. **Subiu de
+   prioridade:** com todo o repo em `@2` (range, não pin), o lock passa a ser o *único* lugar que prende a
+   versão resolvida; sem ele, uma publicação do `@supabase/supabase-js` pode ficar vermelha num PR alheio.

--- a/supabase/functions/carteira-positivacao-snapshot/index.ts
+++ b/supabase/functions/carteira-positivacao-snapshot/index.ts
@@ -13,7 +13,7 @@
 //         (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1))
 //     ); $$);
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import {
   carregarCarteiraComElegibilidade,

--- a/supabase/functions/carteira-rebuild/index.ts
+++ b/supabase/functions/carteira-rebuild/index.ts
@@ -17,7 +17,7 @@
 //         (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1))
 //     ); $$);
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 
 type CarteiraSource = 'omie' | 'hunter_orphan';

--- a/supabase/functions/conciliar-pedido-portal/index.ts
+++ b/supabase/functions/conciliar-pedido-portal/index.ts
@@ -3,7 +3,7 @@
 // ficou em aceito_portal_sem_protocolo / indeterminado_requer_conciliacao,
 // marcamos como sucesso_portal e disparamos o Omie.
 
-import { createClient } from "npm:@supabase/supabase-js@2.45.0";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;

--- a/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/index.ts
@@ -2,7 +2,7 @@
 // Automatiza envio de pedidos aprovados (OBEN -> Sayerlack) via Browserless.io
 // Modos: ECO (validacao), lote (cron), individual (manual)
 
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",

--- a/supabase/functions/extrair-sinais-ligacao/index.ts
+++ b/supabase/functions/extrair-sinais-ligacao/index.ts
@@ -2,7 +2,7 @@ import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 // ⚠️ usar npm: (igual a kb-extract-specs/claude-spin-analyze/tarefa-extrair-voz/etc.).
 // O esm.sh/@supabase/supabase-js falhava em resolver no boot do edge runtime →
 // RUNTIME_ERROR sem linha/stack (módulo não carrega). npm: é o que o projeto roda.
-import { createClient } from "npm:@supabase/supabase-js@^2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 // Idempotência por CONTEÚDO: (source_transcript_hash + prompt_version). Bump PROMPT_VERSION

--- a/supabase/functions/kb-extract-specs/index.ts
+++ b/supabase/functions/kb-extract-specs/index.ts
@@ -1,7 +1,7 @@
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 // ⚠️ usar npm: (igual a tarefa-extrair-voz/melhoria-triagem/etc.). O esm.sh/@supabase/supabase-js
 // falhava em resolver no boot do edge runtime → RUNTIME_ERROR sem linha/stack (módulo não carrega).
-import { createClient } from "npm:@supabase/supabase-js@^2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeMaster, corsHeaders } from "../_shared/auth.ts";
 
 const SYSTEM_PROMPT_EXTRACT_SPECS = `Você extrai specs técnicos estruturados de boletins técnicos de tintas industriais para a base de conhecimento da Colacor (distribuidora Sayerlack).

--- a/supabase/functions/melhoria-triagem/index.ts
+++ b/supabase/functions/melhoria-triagem/index.ts
@@ -4,7 +4,7 @@
 // (RPCs com o JWT do CALLER — só quando caller == autor do item) + tool terminal `triar`.
 // A captação NUNCA depende daqui: falha => triagem_status='erro' e o item segue na fila.
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
-import { createClient } from "npm:@supabase/supabase-js@^2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;

--- a/supabase/functions/promocao-extrair-via-vision/index.ts
+++ b/supabase/functions/promocao-extrair-via-vision/index.ts
@@ -26,7 +26,7 @@
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
 // ⚠️ usar npm: (igual a kb-extract-specs/tarefa-extrair-voz/etc.). O esm.sh/@supabase/supabase-js
 // falhava em resolver no boot do edge runtime → RUNTIME_ERROR sem linha/stack.
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@^2";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import {
   anotarRejeicoes,

--- a/supabase/functions/reposicao-depara-sayerlack-auto/index.ts
+++ b/supabase/functions/reposicao-depara-sayerlack-auto/index.ts
@@ -25,7 +25,7 @@
 //       timeout_milliseconds := 120000
 //     ); $$);
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import { fetchAll } from '../_shared/paginate.ts';
 import { sugerirMapeamentos, validarGabarito, PARSER_VERSION } from '../_shared/sayerlack-sku.ts';

--- a/supabase/functions/sayerlack-captura-precos/index.ts
+++ b/supabase/functions/sayerlack-captura-precos/index.ts
@@ -17,7 +17,7 @@
 // 'embalagem_captura_automatica_habilitada' gateia SÓ o disparo cron (a captura
 // AUTOMÁTICA); manual staff roda com ele desligado (é como o spike-B valida em prod).
 
-import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.45.0";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 import {
   decidirLeituraEmbalagem,

--- a/supabase/functions/scoring-recalc-batch/index.ts
+++ b/supabase/functions/scoring-recalc-batch/index.ts
@@ -31,7 +31,7 @@
 //
 // Schedule é UTC (`cron.timezone` vazio, #1510): '0 6' = 03:00 BRT, como diz o cabeçalho acima.
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import { carregarExcluidosDaCarteira, carregarOwnerMap } from '../_shared/mapas-paginados.ts';
 import type { BancoPostgrest } from '../_shared/paginate.ts';

--- a/supabase/functions/scoring-recalc-client/index.ts
+++ b/supabase/functions/scoring-recalc-client/index.ts
@@ -7,7 +7,7 @@
 // Fonte canônica: src/lib/scoring/{decay,modulators,aggregate,types}.ts
 // TODO: PR-SCORING-V2.1 — extrair para _shared/scoring/ e remover duplicação.
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 
 // --- Inline: decay.ts ---

--- a/supabase/functions/sinais-batch/index.ts
+++ b/supabase/functions/sinais-batch/index.ts
@@ -14,7 +14,7 @@
 //     ); $$
 //   );
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 
 // Cada extração faz 1 LLM (~3-5s); concorrência baixa pra não estourar rate limit.

--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -57,7 +57,7 @@
 // Depois de criar: versione o cron numa migration — cron que vive só no banco some sem rastro
 // (docs/agent/sync.md; o de vendas ficou 8 dias morto por isso).
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCron, corsHeaders } from '../_shared/auth.ts';
 import { fetchAll } from '../_shared/paginate.ts';
 import {

--- a/supabase/functions/tarefa-extrair-voz/index.ts
+++ b/supabase/functions/tarefa-extrair-voz/index.ts
@@ -1,6 +1,6 @@
 // supabase/functions/tarefa-extrair-voz/index.ts
 import Anthropic from "npm:@anthropic-ai/sdk@^0.93.0";
-import { createClient } from "npm:@supabase/supabase-js@^2";
+import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders } from "../_shared/auth.ts";
 
 const SYSTEM_PROMPT = `Você estrutura COMANDOS DE VOZ de um gestor que está criando tarefas para vendedoras de uma distribuidora B2B.

--- a/supabase/functions/visit-score-recalc-batch/index.ts
+++ b/supabase/functions/visit-score-recalc-batch/index.ts
@@ -33,7 +33,7 @@
 //
 // Schedule é UTC (`cron.timezone` vazio, #1510): '0 7' = 04:00 BRT, como diz o cabeçalho acima.
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import { carregarExcluidosDaCarteira, carregarOwnerMap } from '../_shared/mapas-paginados.ts';
 import { exigirLeitura } from '../_shared/leitura-critica.ts';

--- a/supabase/functions/visit-score-recalc-client/index.ts
+++ b/supabase/functions/visit-score-recalc-client/index.ts
@@ -8,7 +8,7 @@
 //
 // Auth: authorizeCronOrStaff (cron via x-cron-secret OU staff JWT).
 
-import { createClient } from 'npm:@supabase/supabase-js@^2';
+import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff, corsHeaders } from '../_shared/auth.ts';
 import { exigirLeitura, FalhaLeituraCritica } from '../_shared/leitura-critica.ts';
 


### PR DESCRIPTION
## O que muda

Último PR da série. **17 edges** que já usavam `npm:` mas com especificador divergente passam a
`npm:@supabase/supabase-js@2`, e o `docs/historico/ci-testes-edge-deno.md` ganha a sequela que fecha os
follow-ups 1 e 2. Depois deste PR o repo tem **85 imports em `@2` e 1 em `^2.95.3`** — este último no
`mcp/index.ts`, que é bundle auto-gerado.

Série completa: #1685 (34 edges, `deno.land` → `Deno.serve`) · #1687 (7) · #1690 (12, money-path) · este.

## O risco não é uniforme nos 17 — e a divisão é medível

| Entra | Nº | Natureza |
|---|---|---|
| `npm:…@^2` | 14 | **`^2` e `@2` são o mesmo range semver** (`>=2.0.0 <3.0.0`). Normalização textual: não muda o que resolve, nem hoje nem depois. |
| `npm:…@2.45.0` | 3 | Pin → range. É a **única** mudança de comportamento possível, e as três são money-path do portal Sayerlack. |

Os três são `sayerlack-captura-precos`, `enviar-pedido-portal-sayerlack` e `conciliar-pedido-portal`.
Medi a superfície da lib neles antes de trocar, mesmo tratamento que dei ao `omie-webhook` no #1690:

- `.from(…)` — 70 ocorrências
- `.rpc(…)` — 4 ocorrências
- zero `auth`, `storage`, `realtime`, `functions`, `channel`

PostgREST puro — a parte da lib que não mudou de contrato dentro do 2.x. O salto de `2.45.0` para o topo
do 2.x, quando cada uma for redeployada, não toca nenhuma área onde a v2 evoluiu.

## Uma edge fica de fora, de propósito

`supabase/functions/mcp/index.ts` usa `^2.95.3` e **não** foi normalizada:

```
// AUTO-GENERATED by @lovable.dev/mcp-js — do not edit. Regenerated by the Vite plugin.
// To take ownership, delete this banner line; the plugin then leaves the file alone.
```

O banner até oferece a saída, mas tomar posse do bundle para arrumar uma string trocaria regeneração
automática por manutenção manual de um arquivo gerado. A divergência é do **artefato**; a fonte
(`src/lib/mcp/**`) não escolhe essa string.

## O que a série NÃO consertou — e isso está no doc

O follow-up 1 original previa que consolidar a versão *"corta download e **resolve 17 dos 141**"*. A
primeira metade se confirmou. A segunda **não**: com o repo inteiro em `@2` — especificador único, uma
versão só no grafo — o gate saiu em **`TS2345:36`, exatamente o número de antes da série começar**. Os 136
tolerados ficaram idênticos, classe por classe, nos quatro PRs.

Reporto isso porque o caminho fácil aqui era herdar o número do follow-up e escrever "resolve 17" sem
medir — ninguém teria conferido. O `SupabaseClient not assignable` **sobrevive à unificação de versão**,
então não vem do espalhamento de especificador. A causa segue aberta e virou dado do follow-up 3, com a
observação de que esse caminho já foi tentado.

## Produção: nada muda no merge

O `deno check` roda sobre o **repo**. As edges em produção seguem com o import antigo até serem
redeployadas pelo chat do Lovable.

**Não faça mutirão de redeploy** — deixe cada edge pegar a mudança no próximo deploy natural dela. Isso
vale para os 4 PRs da série: são 70 edges no total, e nenhuma precisa de ação sua agora.

## Evidência

| Gate | Resultado |
|---|---|
| `bun run edges:typecheck` | 0 — 0 crash-class, 136 tolerados (**= baseline**, ver acima) |
| `bun run test:edges` (`--no-remote`) | 0 — 632 passed, 0 failed |
| `bun run typecheck` | 0 |
| `bun lint` | 0 |
| `bun run test` (vitest) | 0 — 6030 passed |
| `shellcheck` | 0 |
| `docs:indice` · `claude:size` · `authz:check` · `bunpin:check` | 0 (rodados após a edição do doc) |
| imports `esm.sh` + `deno.land` | **0** |
| especificadores distintos | **1** (`@2`) + 1 no bundle gerado |

> `bunx knip` saiu 1 e **não é gate do CI** — 0 ocorrências em `.github/workflows/`. Interseção com os 18
> arquivos deste diff: **0**.

> **Nota:** `build`, `mutcheck` e `mutcheck:selftest` ficaram em 6º na fila do semáforo de RAM e o PR foi
> aberto declarando isso como ausência de dado. Eles terminaram logo depois, e todos saíram **0** —
> `mutcheck` com "11 contrato(s) honrado(s), nenhuma regressão de cobertura". A lista de gates está
> completa e verde; a ressalva fica registrada porque na hora de abrir eu não tinha o dado.

> Os gates rodaram na base pré-rebase; a base final (pós-`eda391e9`) quem valida é o CI. O rebase trouxe
> #1690/#1691/#1692, todos já verdes na main, e o único arquivo em comum foi o
> `carteira-positivacao-snapshot` — o #1692 mexeu na lógica (linha 41+), este PR na linha 16 do import.

> **Asserção sobre import, não sobre menção.** O grep óbvio —
> `grep -rlE "https://(esm\.sh|deno\.land)/" supabase/functions/` — **nunca** chega a zero: 7 arquivos
> citam os hosts em comentário de prosa (os 4 avisos do #1592, mais 3 explicando por que a suíte de edge
> roda offline). O que o `deno check` resolve é o `from "https://…"`, e é sobre essa forma que a contagem
> acima fala.
