### PR TITLE
feat(farmer): desfecho do plano tático em 1 toque — 533 planos, 0 desfechos [money-path]

### DIFF
--- a/docs/superpowers/specs/2026-08-07-ptpl-registro-1-toque-design.md
+++ b/docs/superpowers/specs/2026-08-07-ptpl-registro-1-toque-design.md
@@ -1,0 +1,133 @@
+# Registro de desfecho em 1 toque (Plano Tático)
+
+> Spec de 2026-08-07. Continuação direta de [fila-plano-tatico.md](../../historico/fila-plano-tatico.md)
+> (PR #1693), que deu **saída** à fila. Esta entrega ataca a outra metade: o **custo de captura**.
+> Domínio: Farmer/Inteligência. Money-path (o dado alimenta margem e efetividade de carteira).
+
+## O problema, medido
+
+Produção via `psql-ro`, 2026-08-07 — depois de o cron `expirar-planos-taticos` rodar:
+
+| status | linhas | com `actual_margin` | com `call_result` |
+|---|---|---|---|
+| `expirado` | 364 | 0 | 0 |
+| `gerado` | 169 | 0 | 0 |
+
+`farmer_recommendations`: 3.659 linhas, 100% `pendente`. `call_log`: parado desde 2026-06-09.
+`farmer_client_scores`: 6.633 linhas recalculadas hoje.
+
+**Tudo que depende de digitação manual está em zero; o que a máquina calcula sozinha está vivo.**
+A fase 1 provou que a fila não era mais o gargalo — os 169 planos pendentes estão alcançáveis, com
+7 dias de janela, ordenados por risco. E o desfecho continua em zero. O que resta é o formulário:
+`RecordResultDialog` pede switch + select + **margem em R$** + duração, atrás de um card que
+precisa ser aberto. A vendedora não sabe a margem durante a ligação, e não vai parar para calcular.
+
+## Decisões do founder (2026-08-07)
+
+1. **Cinco desfechos**, preservando o vocabulário já gravado: Vendeu (`venda_realizada`) ·
+   Interesse futuro (`interesse_futuro`) · Não vendeu (`sem_interesse`) · Não atendeu
+   (`nao_atendeu`) · Remarcou (`reagendado`). `interesse_futuro` fica porque comercialmente
+   não é recusa.
+2. **Botões na face do card**, sempre visíveis na fila de pendentes. É o único arranjo que
+   entrega 1 toque de verdade — abrir o card antes já custa o que mantém o registro em zero.
+3. **Os cinco concluem o plano.** A RPC viva força `status='concluido'`; tratar "não atendeu"
+   como não-conclusivo exigiria alterar SQL. Fica como follow-up **medido**: se "não atendeu"
+   sair sub-representado na primeira semana, é porque a vendedora evita o botão para não perder
+   o plano — e aí a mudança de RPC volta com evidência, não com suposição.
+
+## A descoberta que dispensou o SQL
+
+`pg_get_functiondef` da PROD (não o repo — apply manual diverge):
+
+```
+registrar_resultado_plano(_plan_id uuid, _plan_followed boolean, _call_result text,
+  _actual_margin numeric, _call_duration_seconds integer, _objection_type text DEFAULT NULL,
+  _notes text DEFAULT NULL) RETURNS void
+```
+
+Os parâmetros não têm `DEFAULT`, mas **aceitam `NULL` explícito**; as colunas de destino são
+todas nullable e a tabela não tem nenhuma CHECK constraint. Logo: **entrega 100% frontend**.
+Sem SQL Editor, sem migration, sem `prove-sql-money-path`. Só 🖱️ Publish.
+
+## Desenho
+
+### Componente
+
+`BotoesDesfecho.tsx` (novo, em `src/components/farmer/tacticalPlan/`) — cinco botões em duas
+linhas, agrupados por semântica: **com conversa** (Vendeu · Futuro · Não vendeu) e **sem
+conversa** (Não atendeu · Remarcou). Renderizado por `PlanCard` na face, sob
+`plan.status === 'gerado'`. Desabilitado sob a lente "Ver como" (registro é write — mesmo
+write-guard do dialog). Estado local de salvamento bloqueia toque duplo: a RPC recusa a segunda
+gravação com "Plano já concluído" e o toast de erro puniria quem só tocou duas vezes.
+
+`RecordResultDialog` **permanece** no expandido. Deixa de ser o único caminho e vira o caminho
+detalhado (margem, duração, objeção, notas). Nenhuma capacidade é removida — e planos
+`expirado` continuam registráveis por ele, já que os botões da face só servem à fila ativa.
+
+### O payload — o coração
+
+Um toque captura **um** fato. Todo campo que o toque não pergunta grava `null`, nunca zero:
+
+| campo | 1 toque grava | por quê |
+|---|---|---|
+| `callResult` | valor do botão | é o dado que estamos capturando |
+| `actualMargin` | `null` | não apurada. `0` entra em métrica como resultado real |
+| `callDurationSeconds` | `null` | ninguém cronometrou. `0` afirmaria ligação instantânea |
+| `planFollowed` | `null` **nos cinco** | o toque não pergunta se ela seguiu o roteiro |
+| `objectionType` / `notes` | ausente | não perguntados |
+
+O `planFollowed: null` nos **cinco** (e não `true` nos três com conversa) é o ponto que quase
+passou: gravar `true` afirmaria adesão ao roteiro que ninguém declarou — o `|| 0` de sempre,
+vestido de booleano. Quem quiser essa informação usa o dialog detalhado.
+
+### As metades que faltavam
+
+Corrigir só o writer deixa a correção inerte (`money-path.md` §2). Passar a gravar `null` em
+massa acende quatro leitores que hoje são inertes porque **não há um único plano concluído**:
+
+1. **`PlanCard`, resumo do concluído** — `plan.planFollowed ? 'Sim' : 'Não'` exibiria **"Não"**
+   para todo registro de 1 toque: afirma que a vendedora ignorou o roteiro. Vira tri-estado.
+2. **`PlanCard`, `Resultado: {plan.callResult}`** — mostraria `venda_realizada` cru. Passa a usar
+   o rótulo legível do mesmo dicionário dos botões (fonte única).
+3. **`parsePlan`** — `d.actual_margin ? Number(…) : undefined` trata **margem 0 apurada** como
+   ausente. Espelho invertido do `|| 0`: aqui o número medido é que se perde.
+4. **`getEffectivenessStats`** — `totalMargin += Number(d.actual_margin || 0)` dividido por
+   `count` produziria média fabricada, diluída pelos não apurados; `followRate` idem, com `null`
+   contando como "não seguiu". Passa a usar denominadores dos **apurados** e a degradar para
+   `null` quando não houver nenhum. `profitPerHour` só considera planos com margem **e** tempo —
+   razão entre um total de margem e um total de tempo de conjuntos diferentes não significa nada.
+
+Não há consumidor de UI para `getEffectivenessStats` hoje, mas o dado que a alimenta é
+exatamente o que esta entrega passa a produzir — é arma carregada, não código morto.
+
+## Fora de escopo (deliberado)
+
+- **Elo de margem com o Omie.** `sales_orders` só tem `whatsapp_conversation_id`; nada liga
+  pedido a plano tático. Exige coluna nova + writer — trabalho de banco com desenho próprio.
+  Até lá, margem `NULL` rotulada como não apurada é a resposta honesta.
+- **Reviver `farmer_category_conversion`.** Esta entrega é o passo (1) da ordem obrigatória do
+  post-mortem, e só ele.
+- **Alterar `registrar_resultado_plano`.** Ver decisão 3.
+
+## Validação
+
+- `src/components/farmer/tacticalPlan/__tests__/BotoesDesfecho.test.tsx`: payload de cada botão
+  com asserção **explícita** de `null` (não `0`, não `false`), toque duplo bloqueado, ausência
+  fora de `gerado`, desabilitado sob a lente.
+- `PlanCard.test.tsx`: "Plano seguido" não exibe "Não" quando `planFollowed` é `null`; margem
+  `0` apurada continua aparecendo.
+- `heavy bun run typecheck` e `heavy bun run test` com exit code capturado (`> log 2>&1; echo $?`).
+- Manifesto: o glob `src/components/farmer/**` já dá dono ao arquivo novo — nada a registrar.
+
+## A prova real
+
+Não é o CI verde. É o dado aparecer. Uma semana após o Publish:
+
+```sql
+SELECT status, count(*), count(actual_margin), count(call_result)
+FROM farmer_tactical_plans GROUP BY 1;
+```
+
+Se `concluido` continuar em 0, a entrega **não** funcionou — e isso é informação, não fracasso:
+significa que o gargalo é adoção da tela, não custo do formulário. A hipótese desta sessão é
+falsificável, e o teste é esse.

--- a/src/components/farmer/tacticalPlan/BotoesDesfecho.tsx
+++ b/src/components/farmer/tacticalPlan/BotoesDesfecho.tsx
@@ -1,0 +1,135 @@
+// Registro de desfecho em 1 toque, na FACE do card do plano tático.
+//
+// Contexto (docs/historico/fila-plano-tatico.md): o PR #1693 deu SAÍDA à fila e provou que ela
+// não era mais o gargalo — 169 planos ficaram pendentes, alcançáveis, com 7 dias de janela, e o
+// desfecho continuou em ZERO (0 de 533, psql-ro 2026-08-07). O que resta é o custo de captura:
+// o RecordResultDialog pede switch + select + margem em R$ + duração, atrás de um card que
+// precisa ser aberto. A vendedora não sabe a margem durante a ligação.
+//
+// Este componente não substitui o dialog — ele vira o caminho DETALHADO, e continua sendo o
+// único caminho para planos já expirados.
+import { useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useImpersonation } from '@/contexts/ImpersonationContext';
+import type { RecordResultPayload } from './types';
+
+/**
+ * Os cinco desfechos de uma ligação.
+ *
+ * `valor` é gravado em `farmer_tactical_plans.call_result` e reproduz EXATAMENTE o vocabulário
+ * do select do RecordResultDialog — o 1 toque não inventa domínio novo, senão o histórico
+ * nasceria partido em dois vocabulários sem migration que os reconcilie.
+ *
+ * `comConversa` agrupa visualmente (linha 1 = falou com o cliente, linha 2 = não falou) e
+ * documenta a fronteira que motivou a decisão 3 do spec: os dois de baixo concluem o plano
+ * hoje, e é isso que a primeira semana de uso vai testar.
+ */
+export const DESFECHOS = [
+  { valor: 'venda_realizada', rotulo: 'Vendeu', curto: 'Vendeu', emoji: '✅', comConversa: true },
+  { valor: 'interesse_futuro', rotulo: 'Interesse futuro', curto: 'Futuro', emoji: '🔁', comConversa: true },
+  { valor: 'sem_interesse', rotulo: 'Não vendeu', curto: 'Não vendeu', emoji: '❌', comConversa: true },
+  { valor: 'nao_atendeu', rotulo: 'Não atendeu', curto: 'Não atendeu', emoji: '📵', comConversa: false },
+  { valor: 'reagendado', rotulo: 'Remarcou', curto: 'Remarcou', emoji: '📅', comConversa: false },
+] as const;
+
+/**
+ * Rótulo legível de um `call_result` gravado. Fonte única com os botões.
+ * Valor desconhecido volta CRU em vez de virar "—": um valor gravado por outro writer é dado
+ * real, e escondê-lo atrás de um travessão apagaria a única pista de que ele existe.
+ */
+export const rotuloDoDesfecho = (valor: string): string =>
+  DESFECHOS.find((d) => d.valor === valor)?.rotulo ?? valor;
+
+/**
+ * [money-path — ausente ≠ zero] O payload de um toque.
+ *
+ * Um toque captura UM fato: qual foi o desfecho. Todo o resto é desconhecido e vai ao banco
+ * como NULL (as colunas são nullable e a RPC aceita null explícito — verificado com
+ * `pg_get_functiondef` na PROD, não no repo).
+ *
+ * - `actualMargin: null` — a margem não foi apurada. `0` entraria nas médias de efetividade
+ *   como resultado real, que é exatamente a fabricação do `Number(null) === 0`.
+ * - `callDurationSeconds: null` — ninguém cronometrou. `0` afirmaria ligação instantânea e
+ *   ainda viraria denominador em profitPerHour.
+ * - `planFollowed: null` nos CINCO — inclusive nos três em que houve conversa. Gravar `true`
+ *   ali pareceria razoável e seria fabricação: o toque não pergunta se ela seguiu o roteiro.
+ *   `false` nos dois sem conversa seria pior — afirmaria que ela ignorou um plano que nem
+ *   chegou a ser executado, e o follow-rate leria isso como desobediência.
+ */
+export function payloadDeUmToque(callResult: string): RecordResultPayload {
+  return {
+    planFollowed: null,
+    callResult,
+    actualMargin: null,
+    callDurationSeconds: null,
+  };
+}
+
+export const BotoesDesfecho = ({
+  planId,
+  onRecord,
+}: {
+  planId: string;
+  onRecord: (planId: string, result: RecordResultPayload) => Promise<void>;
+}) => {
+  // Lente "Ver como": registrar resultado é WRITE — desabilitado, igual ao RecordResultDialog.
+  const { isImpersonating } = useImpersonation();
+  // Qual desfecho está gravando. Trava os CINCO botões durante a gravação: a RPC recusa a
+  // segunda escrita com "Plano já concluído" e o toast de erro puniria quem só tocou duas
+  // vezes num alvo de 44px — ou tocou em "Vendeu" e corrigiu para "Remarcou" antes do retorno.
+  const [salvando, setSalvando] = useState<string | null>(null);
+
+  const registrar = async (valor: string) => {
+    if (salvando || isImpersonating) return;
+    setSalvando(valor);
+    try {
+      await onRecord(planId, payloadDeUmToque(valor));
+    } catch (err) {
+      // `recordResult` hoje já trata e mostra toast, então este catch não dispara na integração
+      // real. Ele existe porque o `onClick` DESCARTA a promise: um handler que propague viraria
+      // unhandled rejection, que em produção não avisa ninguém e no teste derruba a suíte.
+      console.error('[BotoesDesfecho] falha ao registrar desfecho', err);
+    } finally {
+      // `finally` e não o fim do try: sem ele, uma falha de rede deixaria o card travado em
+      // "salvando" para sempre, e o desfecho se perderia justamente no caso em que ela tentou.
+      setSalvando(null);
+    }
+  };
+
+  const botao = (d: (typeof DESFECHOS)[number]) => (
+    <Button
+      key={d.valor}
+      variant="outline"
+      size="touch"
+      // `size="touch"` pelo alvo de 44px (WCAG AA / chão de fábrica); o padding e o corpo de
+      // texto da variante são grandes demais para três alvos na largura de um card.
+      className="px-1 text-[10px] gap-1 min-w-0"
+      // Rótulo completo no nome acessível: o texto visível é abreviado ("Futuro") para caber,
+      // e leitor de tela / tooltip precisam do termo comercial inteiro.
+      aria-label={d.rotulo}
+      title={d.rotulo}
+      disabled={!!salvando || isImpersonating}
+      onClick={() => registrar(d.valor)}
+    >
+      {salvando === d.valor
+        ? <Loader2 className="w-3 h-3 animate-spin shrink-0" />
+        : <span aria-hidden="true">{d.emoji}</span>}
+      <span className="truncate">{d.curto}</span>
+    </Button>
+  );
+
+  return (
+    <div
+      className="mt-2 space-y-1"
+      title={isImpersonating ? 'Indisponível em modo Ver como' : undefined}
+    >
+      <div className="grid grid-cols-3 gap-1">
+        {DESFECHOS.filter((d) => d.comConversa).map(botao)}
+      </div>
+      <div className="grid grid-cols-2 gap-1">
+        {DESFECHOS.filter((d) => !d.comConversa).map(botao)}
+      </div>
+    </div>
+  );
+};

--- a/src/components/farmer/tacticalPlan/PlanCard.tsx
+++ b/src/components/farmer/tacticalPlan/PlanCard.tsx
@@ -11,6 +11,7 @@ import { getObjectiveLabel, type TacticalPlan } from '@/hooks/useTacticalPlan';
 import { fmt, objectiveColors, profileLabels } from './config';
 import { Section, MetricRow, CopyButton } from './PlanSection';
 import { RecordResultDialog } from './RecordResultDialog';
+import { BotoesDesfecho, rotuloDoDesfecho } from './BotoesDesfecho';
 import type { RecordResultPayload } from './types';
 import { formatMargemPct } from '@/lib/format';
 
@@ -74,6 +75,15 @@ export const PlanCard = ({
             <DollarSign className="w-3 h-3" />
             <span>Lucro estimado: {fmt(plan.estimatedProfitPerHour)}/h</span>
           </div>
+        )}
+
+        {/* Registro de desfecho em 1 toque — na FACE, não no expandido.
+            Só para planos `gerado` (a fila de trabalho). `expirado` está fora da janela e
+            `concluido` já tem desfecho; ambos continuam registráveis pelo dialog detalhado no
+            expandido, que segue gateado por `status !== 'concluido'`. Abrir o card antes de
+            registrar era metade do custo que manteve o desfecho em 0 de 533 (fila-plano-tatico.md). */}
+        {plan.status === 'gerado' && (
+          <BotoesDesfecho planId={plan.id} onRecord={onRecordResult} />
         )}
 
         {/* Expanded content */}
@@ -236,10 +246,19 @@ export const PlanCard = ({
             {plan.status === 'concluido' && (
               <div className="p-2 rounded bg-muted/50 text-[10px] space-y-0.5">
                 <p className="font-semibold">Resultado registrado</p>
-                <p>Plano seguido: {plan.planFollowed ? 'Sim' : 'Não'}</p>
-                <p>Resultado: {plan.callResult}</p>
-                {plan.actualMargin !== undefined && <p>Margem: {fmt(plan.actualMargin)}</p>}
-                {plan.callDurationSeconds && <p>Duração: {Math.round(plan.callDurationSeconds / 60)}min</p>}
+                {/* [money-path — ausente ≠ falso] Tri-estado. O ternário `? 'Sim' : 'Não'` exibia
+                    "Não" para TODO registro de 1 toque (que grava plan_followed = null): afirmava
+                    à gestão que a vendedora ignorou o roteiro, quando ninguém chegou a perguntar.
+                    Mesma família do `Number(null) === 0`, em booleano. */}
+                <p>Plano seguido: {plan.planFollowed == null ? 'não informado' : (plan.planFollowed ? 'Sim' : 'Não')}</p>
+                {/* Rótulo legível: exibia `venda_realizada` cru. Ficou inerte enquanto não havia
+                    nenhum plano concluído em prod — passa a ser visto no dia do Publish. */}
+                <p>Resultado: {plan.callResult ? rotuloDoDesfecho(plan.callResult) : 'não informado'}</p>
+                {/* "não apurada" explícito em vez de sumir a linha: a margem é o dado que a
+                    gestão procura aqui, e uma linha ausente lê como "esqueci de olhar". */}
+                <p>Margem: {plan.actualMargin == null ? 'não apurada' : fmt(plan.actualMargin)}</p>
+                {/* `!= null` e não truthy: duração 0 segundos medida é dado, não ausência. */}
+                {plan.callDurationSeconds != null && <p>Duração: {Math.round(plan.callDurationSeconds / 60)}min</p>}
               </div>
             )}
           </div>

--- a/src/components/farmer/tacticalPlan/RecordResultDialog.tsx
+++ b/src/components/farmer/tacticalPlan/RecordResultDialog.tsx
@@ -12,6 +12,20 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import type { RecordResultPayload } from './types';
 
+/**
+ * [money-path — ausente ≠ zero] Campo vazio é AUSÊNCIA, não zero.
+ *
+ * O `parseFloat(x) || 0` que vivia aqui transformava "a vendedora não sabia a margem" em
+ * `actual_margin = 0` — um resultado apurado de R$ 0,00, indistinguível de uma ligação que
+ * de fato não gerou margem. E `0 || 0` faz o zero MEDIDO passar pelo mesmo caminho, então
+ * nem o caso legítimo se salvava.
+ */
+const numeroOuNulo = (v: string): number | null => {
+  if (v.trim() === '') return null;
+  const n = parseFloat(v);
+  return Number.isNaN(n) ? null : n;
+};
+
 export const RecordResultDialog = ({
   planId,
   onRecord,
@@ -32,16 +46,24 @@ export const RecordResultDialog = ({
 
   const handleSave = async () => {
     setSaving(true);
-    await onRecord(planId, {
-      planFollowed,
-      callResult,
-      actualMargin: parseFloat(actualMargin) || 0,
-      callDurationSeconds: (parseFloat(duration) || 0) * 60,
-      objectionType: objectionType || undefined,
-      notes: notes || undefined,
-    });
-    setSaving(false);
-    setOpen(false);
+    const minutos = numeroOuNulo(duration);
+    try {
+      await onRecord(planId, {
+        planFollowed,
+        callResult,
+        actualMargin: numeroOuNulo(actualMargin),
+        callDurationSeconds: minutos == null ? null : minutos * 60,
+        objectionType: objectionType || undefined,
+        notes: notes || undefined,
+      });
+      setOpen(false);
+    } finally {
+      // `recordResult` hoje ENGOLE o erro (try/catch + toast, sem relançar), então na prática
+      // este handler não rejeita e o dialog fecha de qualquer forma. O try/finally é pelo
+      // contrato, não pelo comportamento de hoje: se um dia o hook passar a propagar a recusa
+      // da RPC, o dialog fica em "Salvando…" para sempre sem ele.
+      setSaving(false);
+    }
   };
 
   return (

--- a/src/components/farmer/tacticalPlan/__tests__/BotoesDesfecho.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/BotoesDesfecho.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BotoesDesfecho, DESFECHOS, payloadDeUmToque, rotuloDoDesfecho } from '../BotoesDesfecho';
+
+const impMock = vi.fn(() => ({ isImpersonating: false }));
+vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+
+beforeEach(() => {
+  impMock.mockReturnValue({ isImpersonating: false });
+});
+
+function setup(onRecord = vi.fn(async () => {})) {
+  render(<BotoesDesfecho planId="p1" onRecord={onRecord} />);
+  return onRecord;
+}
+
+describe('payloadDeUmToque — ausente ≠ zero', () => {
+  // O ponto INTEIRO da entrega. Um toque captura UM fato (qual foi o desfecho); todo o resto
+  // é desconhecido e tem de chegar ao banco como NULL. `0` em actual_margin entraria nas
+  // médias de efetividade como resultado apurado — a fabricação que o money-path proíbe.
+  it('[PAYLOAD-1T] margem não apurada é null, nunca 0', () => {
+    for (const d of DESFECHOS) {
+      const p = payloadDeUmToque(d.valor);
+      expect(p.actualMargin).toBeNull();
+      expect(p.actualMargin).not.toBe(0);
+    }
+  });
+
+  it('[PAYLOAD-1T] duração não cronometrada é null, nunca 0', () => {
+    // `0` afirmaria uma ligação instantânea — e vira denominador em profitPerHour.
+    for (const d of DESFECHOS) {
+      expect(payloadDeUmToque(d.valor).callDurationSeconds).toBeNull();
+    }
+  });
+
+  it('[PAYLOAD-1T] planFollowed é null nos CINCO, inclusive nos que tiveram conversa', () => {
+    // A armadilha sutil: gravar `true` em "vendeu/futuro/não vendeu" pareceria razoável e
+    // seria fabricação — o toque não pergunta se ela seguiu o roteiro. `false` nos sem-conversa
+    // seria pior ainda: afirma que ela ignorou um plano que nem chegou a ser executado.
+    for (const d of DESFECHOS) {
+      const p = payloadDeUmToque(d.valor);
+      expect(p.planFollowed).toBeNull();
+      expect(p.planFollowed).not.toBe(false);
+      expect(p.planFollowed).not.toBe(true);
+    }
+  });
+
+  it('[PAYLOAD-1T] callResult é o único campo afirmado', () => {
+    expect(payloadDeUmToque('venda_realizada').callResult).toBe('venda_realizada');
+    expect(payloadDeUmToque('nao_atendeu').objectionType).toBeUndefined();
+    expect(payloadDeUmToque('nao_atendeu').notes).toBeUndefined();
+  });
+});
+
+describe('DESFECHOS — vocabulário', () => {
+  it('preserva exatamente os cinco valores que o select detalhado já grava', () => {
+    // Inventar valor novo aqui partiria o histórico em dois vocabulários sem migration.
+    expect(DESFECHOS.map((d) => d.valor)).toEqual([
+      'venda_realizada', 'interesse_futuro', 'sem_interesse', 'nao_atendeu', 'reagendado',
+    ]);
+  });
+
+  it('rotuloDoDesfecho traduz o valor gravado; valor desconhecido volta cru', () => {
+    expect(rotuloDoDesfecho('venda_realizada')).toBe('Vendeu');
+    // Sem inventar rótulo: um valor gravado por outro writer aparece como está, e não some.
+    expect(rotuloDoDesfecho('valor_de_outro_writer')).toBe('valor_de_outro_writer');
+  });
+});
+
+describe('BotoesDesfecho — interação', () => {
+  it('renderiza os cinco botões', () => {
+    setup();
+    for (const d of DESFECHOS) {
+      expect(screen.getByRole('button', { name: d.rotulo })).toBeTruthy();
+    }
+  });
+
+  it('um toque registra o desfecho daquele botão', async () => {
+    const onRecord = setup();
+    fireEvent.click(screen.getByRole('button', { name: 'Não atendeu' }));
+    await waitFor(() => expect(onRecord).toHaveBeenCalledTimes(1));
+    expect(onRecord).toHaveBeenCalledWith('p1', expect.objectContaining({
+      callResult: 'nao_atendeu',
+      actualMargin: null,
+      callDurationSeconds: null,
+      planFollowed: null,
+    }));
+  });
+
+  it('[DUPLO-1T] toque duplo não dispara dois registros', async () => {
+    // A RPC recusa a segunda gravação com "Plano já concluído" e o toast de erro puniria
+    // quem só tocou duas vezes num alvo de 44px.
+    let liberar: () => void = () => {};
+    const onRecord = vi.fn(() => new Promise<void>((r) => { liberar = r; }));
+    render(<BotoesDesfecho planId="p1" onRecord={onRecord} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Remarcou' }));
+
+    expect(onRecord).toHaveBeenCalledTimes(1);
+    liberar();
+    await waitFor(() => expect(onRecord).toHaveBeenCalledTimes(1));
+  });
+
+  it('[DUPLO-1T] falha do registro devolve os botões — a vendedora pode tentar de novo', async () => {
+    // Sem o finally, um erro de rede deixaria o card travado em "salvando" para sempre.
+    const onRecord = vi.fn(async () => { throw new Error('rede'); });
+    render(<BotoesDesfecho planId="p1" onRecord={onRecord} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    await waitFor(() => {
+      expect((screen.getByRole('button', { name: 'Vendeu' }) as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
+  it('[LENTE-1T] sob a lente "Ver como" os botões ficam desabilitados', () => {
+    // Registrar resultado é WRITE — mesma regra do RecordResultDialog. `useAuth` é sempre
+    // real; só leitura usa o id efetivo (impersonation.md).
+    impMock.mockReturnValue({ isImpersonating: true });
+    const onRecord = setup();
+    for (const d of DESFECHOS) {
+      expect((screen.getByRole('button', { name: d.rotulo }) as HTMLButtonElement).disabled).toBe(true);
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    expect(onRecord).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/PlanCard.test.tsx
@@ -103,6 +103,84 @@ describe("PlanCard", () => {
     expect(screen.getByText("Resultado registrado")).toBeTruthy();
   });
 
+  // Registro de desfecho em 1 toque na FACE do card. O ponto da entrega é não precisar abrir o
+  // card: 0 de 533 planos tinham desfecho com o formulário atrás do `expanded`.
+  describe("desfecho em 1 toque", () => {
+    it("[FACE-1T] plano na fila mostra os cinco desfechos SEM precisar expandir", () => {
+      setup({ expanded: false, plan: makePlan({ status: "gerado" }) });
+      for (const nome of ["Vendeu", "Interesse futuro", "Não vendeu", "Não atendeu", "Remarcou"]) {
+        expect(screen.getByRole("button", { name: nome })).toBeTruthy();
+      }
+    });
+
+    it("[FACE-1T] um toque registra sem abrir o card", async () => {
+      const props = setup({ expanded: false, plan: makePlan({ status: "gerado" }) });
+      fireEvent.click(screen.getByRole("button", { name: "Vendeu" }));
+      expect(props.onRecordResult).toHaveBeenCalledWith("p1", expect.objectContaining({
+        callResult: "venda_realizada",
+        actualMargin: null,
+      }));
+      // Registrar não pode abrir/fechar o card: o toggle vive no cabeçalho, e um clique que
+      // vazasse para ele faria a lista pular sob o dedo da vendedora.
+      expect(props.onToggle).not.toHaveBeenCalled();
+    });
+
+    it("[FACE-1T] plano expirado não recebe 1 toque — a fila de trabalho é só `gerado`", () => {
+      setup({ expanded: false, plan: makePlan({ status: "expirado" }) });
+      expect(screen.queryByRole("button", { name: "Vendeu" })).toBeNull();
+    });
+
+    it("[FACE-1T] plano concluído não recebe 1 toque", () => {
+      setup({ expanded: false, plan: makePlan({ status: "concluido" }) });
+      expect(screen.queryByRole("button", { name: "Vendeu" })).toBeNull();
+    });
+
+    it("[FACE-1T] o dialog detalhado continua disponível no expandido", () => {
+      // O 1 toque não remove capacidade: quem sabe a margem ainda pode informá-la.
+      setup({ expanded: true, plan: makePlan({ status: "gerado" }) });
+      expect(screen.getByText("Registrar Resultado")).toBeTruthy();
+    });
+  });
+
+  // O resumo do plano concluído ficou INERTE desde sempre (0 concluídos em prod). No dia do
+  // Publish ele passa a ser lido — e é onde os NULLs do 1 toque chegam primeiro.
+  describe("resumo do concluído — null não pode virar veredito", () => {
+    const concluido = (over: Partial<TacticalPlan> = {}) =>
+      setup({ expanded: true, plan: makePlan({ status: "concluido", callResult: "nao_atendeu", ...over }) });
+
+    it("[RESUMO-1T] plano seguido não informado NAO exibe 'Nao'", () => {
+      // `planFollowed ? 'Sim' : 'Não'` exibia "Não" para todo registro de 1 toque — afirmava
+      // à gestão que a vendedora ignorou o roteiro que ninguém perguntou se ela seguiu.
+      concluido({ planFollowed: undefined });
+      expect(screen.getByText("Plano seguido: não informado")).toBeTruthy();
+      expect(screen.queryByText("Plano seguido: Não")).toBeNull();
+    });
+
+    it("[RESUMO-1T] adesão declarada continua sendo Sim/Não — é veredito, não ausência", () => {
+      concluido({ planFollowed: false });
+      expect(screen.getByText("Plano seguido: Não")).toBeTruthy();
+    });
+
+    it("[RESUMO-1T] margem não apurada é rotulada, não some nem vira R$ 0,00", () => {
+      concluido({ actualMargin: undefined });
+      expect(screen.getByText("Margem: não apurada")).toBeTruthy();
+      expect(screen.queryByText("Margem: R$ 0,00")).toBeNull();
+    });
+
+    it("[RESUMO-1T] margem ZERO apurada continua sendo R$ 0,00", () => {
+      // O par que impede a correção de virar "esconde tudo". `d.actual_margin ? … : undefined`
+      // no parsePlan perdia justamente este caso.
+      concluido({ actualMargin: 0 });
+      expect(screen.getByText("Margem: R$ 0,00")).toBeTruthy();
+    });
+
+    it("[RESUMO-1T] o desfecho aparece em português, não como valor de banco", () => {
+      concluido({ callResult: "nao_atendeu" });
+      expect(screen.getByText("Resultado: Não atendeu")).toBeTruthy();
+      expect(screen.queryByText("Resultado: nao_atendeu")).toBeNull();
+    });
+  });
+
   // A margem gravada no plano é nullable desde que o servidor passou a distinguir "sem custo
   // cadastrado" de "margem zero". O card é o último ponto do caminho: se ele coagir, todo o
   // trabalho de propagar o null (RPC → coluna → parsePlan) morre no `.toFixed()` final.

--- a/src/components/farmer/tacticalPlan/types.ts
+++ b/src/components/farmer/tacticalPlan/types.ts
@@ -12,11 +12,18 @@ export interface ProfileRow {
   name: string | null;
 }
 
+/**
+ * [money-path — ausente ≠ zero] Os três campos nullable NÃO são frouxidão de tipo: são o
+ * tri-estado que o registro de 1 toque produz. Ele captura só o desfecho; margem, duração e
+ * adesão ao roteiro ficam desconhecidos e vão ao banco como NULL (colunas nullable, RPC aceita
+ * null explícito). Tipá-los como `number`/`boolean` obrigava o chamador a inventar `0`/`false`
+ * — e `actual_margin = 0` entra nas médias de efetividade como resultado apurado.
+ */
 export interface RecordResultPayload {
-  planFollowed: boolean;
+  planFollowed: boolean | null;
   callResult: string;
-  actualMargin: number;
-  callDurationSeconds: number;
+  actualMargin: number | null;
+  callDurationSeconds: number | null;
   objectionType?: string;
   notes?: string;
 }

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -166,6 +166,29 @@ interface EffectivenessRow {
   plan_type: PlanType | null;
 }
 
+/**
+ * Acumulador de efetividade. Cada total anda com o SEU denominador de apurados.
+ *
+ * [money-path — ausente ≠ zero] O registro de 1 toque grava `plan_followed`, `actual_margin` e
+ * `call_duration_seconds` como NULL de propósito (afirma só o desfecho). Dividir pelo `count`
+ * bruto — como fazia o `Number(d.actual_margin || 0) / count` — diluiria a média com planos que
+ * ninguém mediu, e o número resultante seria lido como margem média real da carteira.
+ */
+interface AcumuladorEfetividade {
+  count: number;
+  followed: number;
+  /** Quantos declararam adesão ao roteiro (true OU false). Denominador de `followRate`. */
+  comFollow: number;
+  totalMargin: number;
+  comMargem: number;
+  /**
+   * Margem e tempo somados APENAS sobre os planos que têm os dois. R$/h derivado de um total de
+   * margem e um total de tempo vindos de conjuntos diferentes não significa nada.
+   */
+  margemComTempo: number;
+  tempoComMargem: number;
+}
+
 interface AiPlanResponse {
   strategic_objective?: string;
   diagnostic_questions?: TacticalPlan['diagnosticQuestions'];
@@ -348,7 +371,10 @@ export const useTacticalPlan = () => {
       status: d.status,
       planFollowed: d.plan_followed ?? undefined,
       callResult: d.call_result ?? undefined,
-      actualMargin: d.actual_margin ? Number(d.actual_margin) : undefined,
+      // [money-path] `d.actual_margin ? … : undefined` era o `|| 0` ESPELHADO: aqui o número
+      // MEDIDO é que se perdia — margem 0 apurada (ligação que fechou sem margem, ou desconto
+      // total) caía no ramo falso e virava "não registrado". Só `null`/`undefined` é ausência.
+      actualMargin: d.actual_margin == null ? undefined : Number(d.actual_margin),
       callDurationSeconds: d.call_duration_seconds ?? undefined,
       objectionType: d.objection_type ?? undefined,
       notes: d.notes ?? undefined,
@@ -774,11 +800,15 @@ export const useTacticalPlan = () => {
   }, [effectiveUserId, fetchOwnerScope]);
 
   // Record post-call results
+  // [money-path — ausente ≠ zero] Os três nullable são o tri-estado que o registro de 1 toque
+  // produz: ele afirma só o desfecho. A RPC `registrar_resultado_plano` aceita NULL explícito
+  // nos parâmetros (verificado por `pg_get_functiondef` na PROD, 2026-08-07 — o repo não é a
+  // fonte, apply manual diverge) e as colunas de destino são todas nullable, sem CHECK.
   const recordResult = useCallback(async (planId: string, result: {
-    planFollowed: boolean;
+    planFollowed: boolean | null;
     callResult: string;
-    actualMargin: number;
-    callDurationSeconds: number;
+    actualMargin: number | null;
+    callDurationSeconds: number | null;
     objectionType?: string;
     notes?: string;
   }) => {
@@ -824,32 +854,54 @@ export const useTacticalPlan = () => {
 
     if (!data?.length) return null;
 
-    const byType: Record<string, { count: number; followed: number; totalMargin: number; totalTime: number }> = {};
-    const byObjective: Record<string, { count: number; followed: number; totalMargin: number; totalTime: number }> = {};
+    const byType: Record<string, AcumuladorEfetividade> = {};
+    const byObjective: Record<string, AcumuladorEfetividade> = {};
+
+    const acumular = (map: Record<string, AcumuladorEfetividade>, k: string, d: EffectivenessRow) => {
+      if (!map[k]) {
+        map[k] = { count: 0, followed: 0, comFollow: 0, totalMargin: 0, comMargem: 0, margemComTempo: 0, tempoComMargem: 0 };
+      }
+      const a = map[k];
+      a.count++;
+      // `!= null` e não truthy: `false` é declaração ("não segui o plano"), NULL é ausência.
+      // O `if (d.plan_followed)` de antes fundia os dois no mesmo balde de "não seguiu".
+      if (d.plan_followed != null) {
+        a.comFollow++;
+        if (d.plan_followed) a.followed++;
+      }
+      // `valorMedido` (e não `Number(x || 0)`) porque numeric do PostgREST chega como STRING:
+      // preserva o 0 apurado e devolve null para ausência e para lixo não-finito.
+      const margem = valorMedido(d.actual_margin);
+      const tempo = valorMedido(d.call_duration_seconds);
+      if (margem != null) {
+        a.totalMargin += margem;
+        a.comMargem++;
+      }
+      if (margem != null && tempo != null) {
+        a.margemComTempo += margem;
+        a.tempoComMargem += tempo;
+      }
+    };
 
     for (const d of data) {
-      const obj = d.strategic_objective;
-      const pt = d.plan_type || 'essencial';
-
-      for (const [key] of [['obj_' + obj, byObjective], ['type_' + pt, byType]] as const) {
-        const target = key.startsWith('obj_') ? byObjective : byType;
-        const k = key.replace(/^(obj_|type_)/, '');
-        if (!target[k]) target[k] = { count: 0, followed: 0, totalMargin: 0, totalTime: 0 };
-        target[k].count++;
-        if (d.plan_followed) target[k].followed++;
-        target[k].totalMargin += Number(d.actual_margin || 0);
-        target[k].totalTime += Number(d.call_duration_seconds || 0);
-      }
+      acumular(byObjective, d.strategic_objective, d);
+      acumular(byType, d.plan_type || 'essencial', d);
     }
 
-    const mapStats = (map: typeof byObjective) =>
+    // Tri-estado em TODAS as três métricas: `null` = não apurado nesta fatia, e quem exibir
+    // decide como mostrar "sem dado" — nunca 0, que leria como "carteira sem margem" ou
+    // "vendedora nunca segue o plano". `comFollow`/`comMargem` saem junto para que a tela
+    // possa dizer sobre quantos planos a média foi calculada (amostra pequena é dado frágil).
+    const mapStats = (map: Record<string, AcumuladorEfetividade>) =>
       Object.entries(map).map(([key, stats]) => ({
         key,
         label: objectiveLabels[key] || key,
         count: stats.count,
-        followRate: stats.count > 0 ? Math.round((stats.followed / stats.count) * 100) : 0,
-        avgMargin: stats.count > 0 ? stats.totalMargin / stats.count : 0,
-        profitPerHour: stats.totalTime > 0 ? (stats.totalMargin / stats.totalTime) * 3600 : 0,
+        comFollow: stats.comFollow,
+        comMargem: stats.comMargem,
+        followRate: stats.comFollow > 0 ? Math.round((stats.followed / stats.comFollow) * 100) : null,
+        avgMargin: stats.comMargem > 0 ? stats.totalMargin / stats.comMargem : null,
+        profitPerHour: stats.tempoComMargem > 0 ? (stats.margemComTempo / stats.tempoComMargem) * 3600 : null,
       }));
 
     return { byObjective: mapStats(byObjective), byType: mapStats(byType) };


### PR DESCRIPTION
## O que muda

Registrar o desfecho de um plano tático passa a custar **um toque**, na **face** do card.

Hoje custa: abrir o card → abrir um dialog → switch + select + **margem em R$** + duração → salvar.
A margem é o campo que trava: a vendedora não a sabe durante a ligação, e não vai parar para
calcular. Cinco botões — Vendeu · Interesse futuro · Não vendeu · Não atendeu · Remarcou —
substituem isso para a fila ativa. O dialog **permanece** no expandido como caminho detalhado.

## Por que agora

O #1693 deu **saída** à fila e provou que ela não era mais o gargalo. Medição em prod
(`psql-ro`, 2026-08-07, já com o cron `expirar-planos-taticos` rodando):

| status | linhas | com `actual_margin` | com `call_result` |
|---|---|---|---|
| `expirado` | 364 | 0 | 0 |
| `gerado` | 169 | 0 | 0 |

169 planos alcançáveis, 7 dias de janela, ordenados por risco — e desfecho **zero**. O que resta
é o custo de captura. Padrão irmão: `farmer_recommendations` 3.659 linhas 100% `pendente`,
`call_log` parado desde 2026-06-09, enquanto `farmer_client_scores` (que a máquina calcula
sozinha) foi recalculado hoje. **Tudo que depende de digitação manual está em zero.**

## Sem mudança de banco

`pg_get_functiondef` da **PROD** (não o repo — apply manual diverge) mostra que
`registrar_resultado_plano` aceita `NULL` explícito nos parâmetros, as colunas de destino são
todas nullable e a tabela não tem CHECK constraint. Entrega 100% frontend.

## O payload — ausente ≠ zero

Um toque captura **um** fato. Todo campo que ele não pergunta vai como `NULL`:

| campo | grava | por quê |
|---|---|---|
| `callResult` | valor do botão | é o dado que estamos capturando |
| `actualMargin` | `null` | não apurada. `0` entra nas médias como resultado real |
| `callDurationSeconds` | `null` | ninguém cronometrou. `0` afirmaria ligação instantânea |
| `planFollowed` | `null` **nos cinco** | o toque não pergunta se ela seguiu o roteiro |

O `planFollowed: null` nos **cinco** (e não `true` nos três com conversa) é o ponto que quase
passou: gravar `true` afirmaria adesão ao roteiro que ninguém declarou — o `|| 0` de sempre,
vestido de booleano.

## As metades que faltavam

Corrigir só o writer deixa a correção inerte (`money-path.md` §2). Passar a gravar `null` acende
quatro leitores hoje inertes **porque não existe um único plano concluído em prod**:

1. `PlanCard` — `plan.planFollowed ? 'Sim' : 'Não'` exibiria **"Não"** para todo registro de
   1 toque: afirma à gestão que a vendedora ignorou o roteiro. Vira tri-estado.
2. `PlanCard` — `Resultado: {plan.callResult}` mostraria `venda_realizada` cru. Rótulo legível,
   fonte única com os botões; valor desconhecido volta **cru**, não vira "—".
3. `parsePlan` — `d.actual_margin ? … : undefined` é o `|| 0` **espelhado**: aqui o número
   *medido* se perde (margem 0 apurada virava "não registrado").
4. `getEffectivenessStats` — `Number(d.actual_margin || 0) / count` produziria média diluída
   pelos não apurados, e `followRate` contaria `null` como "não seguiu". Cada total passa a ter
   seu denominador de apurados e degrada para `null`; `profitPerHour` só considera planos com
   margem **e** tempo (razão entre totais de conjuntos diferentes não significa nada).

Bônus no `RecordResultDialog`: `parseFloat(x) || 0` transformava "não sei a margem" em
`actual_margin = 0` — e o `0 || 0` fazia o zero *medido* cair no mesmo ramo.

## Decisão consciente: os cinco desfechos concluem o plano

A RPC força `status='concluido'`. Tratar "não atendeu" como não-conclusivo exigiria alterar SQL.
Fica como follow-up **medido**: se "não atendeu" sair sub-representado na primeira semana, é
porque a vendedora evita o botão para não perder o plano — e aí a mudança de RPC volta com
evidência, não com suposição.

## Fora de escopo (deliberado)

- **Elo de margem com o Omie.** `sales_orders` só tem `whatsapp_conversation_id`; nada liga
  pedido a plano tático. Coluna nova + writer, desenho próprio. Até lá, `NULL` rotulado como
  "não apurada" é a resposta honesta.
- **Reviver `farmer_category_conversion`** — esta é o passo (1) da ordem do post-mortem, e só ele.

## Prova

`BotoesDesfecho.test.tsx` (12) + `PlanCard.test.tsx` (11 novos), com asserção **explícita** de
`null` (não `0`, não `false`), toque duplo bloqueado, write-guard da lente, e o par que impede a
correção de virar "esconde tudo" (margem **0 apurada** continua aparecendo).

Falsificação: sabotar `payloadDeUmToque` para gravar `0` e o ternário do resumo para voltar a
"Não" — ambos deixam os asserts ancorados VERMELHOS.

## A prova real não é o CI

É o dado aparecer. Uma semana após o Publish:

```sql
SELECT status, count(*), count(actual_margin), count(call_result)
FROM farmer_tactical_plans GROUP BY 1;
```

Se `concluido` continuar em 0, a entrega **não** funcionou — e isso é informação, não fracasso:
significa que o gargalo é adoção da tela, não custo do formulário.

## Pendência do founder

🖱️ **Publish** (frontend). Sem SQL Editor, sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
