### PR TITLE
fix(farmer): a fila do Plano Tático parava de regenerar a si mesma — 533 planos eram 80 clientes [money-path]

### DIFF
--- a/db/test-tactical-idempotencia-janela.sh
+++ b/db/test-tactical-idempotencia-janela.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — criar_plano_tatico: idempotência por JANELA da fila (PTPL fase 2)║
+# ║      bash db/test-tactical-idempotencia-janela.sh > /tmp/t.log 2>&1; echo $?   ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                        ║
+# ║                                                                                ║
+# ║  O QUE ESTÁ SOB PROVA: a trava deixou de perguntar "já gerei HOJE?" e passou a ║
+# ║  perguntar "este cliente já está na FILA?". Medido em prod (2026-08-08): a     ║
+# ║  trava por dia deixava o cliente voltar a ser candidato toda madrugada — 533   ║
+# ║  planos para 80 clientes, fila viva com 169 planos para 35 clientes (14 deles  ║
+# ║  com 7 cópias), e 23 dos 25 planos de 07/08 eram regeração.                    ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"
+SLUG="ptpl-janela"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+# Assert negativo (Lei #2): captura a SQLSTATE ESPERADA e RE-LANÇA qualquer outra.
+# As sentinelas são ASCII, caixa fixa, e NÃO aparecem em lugar nenhum da migration nem
+# das mensagens que a RPC emite — senão o `case` casaria o próprio texto do código e o
+# assert mentiria (a armadilha do #1483, registrada no CLAUDE.md).
+espera_sqlstate() {
+  local desc="$1" chamada="$2" estado="$3" R
+  R=$(P -tA 2>&1 <<EOF || true
+SET test.role='service_role';
+DO \$do\$
+BEGIN
+  PERFORM $chamada;
+  RAISE NOTICE 'SENTINELA_NAO_LEVANTOU_NADA';
+EXCEPTION
+  WHEN SQLSTATE '$estado' THEN RAISE NOTICE 'SENTINELA_PEGOU_O_ESPERADO';
+  WHEN OTHERS THEN RAISE;
+END
+\$do\$;
+EOF
+)
+  case "$R" in
+    *SENTINELA_PEGOU_O_ESPERADO*) ok "$desc" ;;
+    *) bad "$desc — saida: $(printf '%s' "$R" | tr '\n' ' ' | cut -c1-220)" ;;
+  esac
+}
+
+# Cria o plano e devolve 't' se veio um uuid. Falha do psql vira 'ERRO' (não mata o script).
+# `-q` é obrigatório: sem ele o psql ecoa o "SET" do primeiro comando junto com a tupla, e a
+# comparação vira "SET\nt" != "t" — um vermelho que não é do código sob teste.
+cria() {
+  P -tAq -c "SET test.role='service_role'; SELECT public.criar_plano_tatico('$1'::uuid,'$2'::uuid,'${3:-{\}}'::jsonb) IS NOT NULL;" 2>/dev/null || echo "ERRO"
+}
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migration LÊ mas não cria)
+# ══════════════════════════════════════════════════════════════════════════════
+# Stub FIEL ao DDL de prod (information_schema lido via psql-ro em 2026-08-08): a RPC faz
+# `jsonb_populate_record(NULL::public.farmer_tactical_plans, _payload)`, que é sensível ao
+# TIPO de cada coluna — um stub com o tipo errado (ex.: ltv_projection text em vez de jsonb)
+# provaria uma função diferente da que vai rodar.
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE public.farmer_tactical_plans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid,
+  customer_user_id uuid,
+  bundle_recommendation_id uuid,
+  health_score numeric DEFAULT 0,
+  churn_risk numeric DEFAULT 0,
+  mix_gap integer DEFAULT 0,
+  current_margin_pct numeric DEFAULT 0,
+  cluster_avg_margin_pct numeric DEFAULT 0,
+  expansion_potential numeric DEFAULT 0,
+  strategic_objective text DEFAULT 'expansao_mix',
+  customer_profile text DEFAULT 'misto',
+  top_bundle jsonb DEFAULT '{}'::jsonb,
+  bundle_lie numeric,
+  bundle_probability numeric,
+  bundle_incremental_margin numeric,
+  best_individual_lie numeric,
+  diagnostic_questions jsonb DEFAULT '[]'::jsonb,
+  implication_question text,
+  offer_transition text,
+  probable_objections jsonb DEFAULT '[]'::jsonb,
+  approach_strategy text,
+  plan_followed boolean,
+  call_result text,
+  actual_margin numeric,
+  call_duration_seconds integer,
+  objection_type text,
+  notes text,
+  effectiveness_score numeric,
+  status text DEFAULT 'gerado',
+  generated_at timestamptz DEFAULT now(),
+  used_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  plan_type text DEFAULT 'essencial',
+  approach_strategy_b text,
+  second_bundle jsonb DEFAULT '{}'::jsonb,
+  ltv_projection jsonb,
+  expected_result jsonb,
+  operational_risks jsonb DEFAULT '[]'::jsonb
+);
+
+CREATE TABLE public.carteira_assignments (
+  customer_user_id uuid PRIMARY KEY,
+  owner_user_id uuid,
+  eligible boolean DEFAULT true
+);
+
+-- Índice único parcial COMO EM PROD (pg_indexes lido via psql-ro). Existe aqui porque a
+-- fase 2 muda a relação entre ele e a RPC: a janela CONTÉM o dia, então a RPC passa a ser
+-- estritamente mais restritiva. O teste A9 prova que essa direção se manteve.
+CREATE UNIQUE INDEX ux_farmer_tactical_plans_dia_operacional
+  ON public.farmer_tactical_plans
+  USING btree (farmer_id, customer_user_id,
+    ((((created_at AT TIME ZONE 'UTC'::text) - '03:00:00'::interval))::date),
+    COALESCE(plan_type, 'essencial'::text))
+  WHERE ((status = 'gerado'::text)
+    AND ((((created_at AT TIME ZONE 'UTC'::text) - '03:00:00'::interval))::date >= '2026-07-22'::date));
+
+-- Gate de posse do ramo AUTENTICADO. Stub honesto: devolve true só quando o uid é o dono.
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_customer uuid, _uid uuid)
+RETURNS boolean LANGUAGE sql STABLE AS $f$
+  SELECT EXISTS (SELECT 1 FROM public.carteira_assignments a
+                  WHERE a.customer_user_id = _customer AND a.owner_user_id = _uid);
+$f$;
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260808020000_tactical_plan_idempotencia_janela.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS
+# ══════════════════════════════════════════════════════════════════════════════
+FA='aaaaaaaa-0000-0000-0000-00000000000a'   # farmer A
+FB='bbbbbbbb-0000-0000-0000-00000000000b'   # farmer B
+C1='cccccccc-0000-0000-0000-000000000001'   # sem plano nenhum
+C2='cccccccc-0000-0000-0000-000000000002'   # plano gerado 3 dias atrás  → DENTRO da janela
+C3='cccccccc-0000-0000-0000-000000000003'   # plano gerado 8 dias atrás  → FORA da janela
+C4='cccccccc-0000-0000-0000-000000000004'   # plano EXPIRADO 3 dias atrás
+C5='cccccccc-0000-0000-0000-000000000005'   # plano CONCLUIDO 3 dias atrás
+C6='cccccccc-0000-0000-0000-000000000006'   # plano do OUTRO farmer, 3 dias atrás
+C7='cccccccc-0000-0000-0000-000000000007'   # plano 3 dias atrás com plan_type 'essencial'
+C8='cccccccc-0000-0000-0000-000000000008'   # plano 3 dias atrás com generated_at NULL
+C9='cccccccc-0000-0000-0000-000000000009'   # MASCARADO (eligible=false)
+
+P -q <<SQL
+INSERT INTO public.carteira_assignments (customer_user_id, owner_user_id, eligible) VALUES
+  ('$C1','$FA',true), ('$C2','$FA',true), ('$C3','$FA',true), ('$C4','$FA',true),
+  ('$C5','$FA',true), ('$C6','$FA',true), ('$C7','$FA',true), ('$C8','$FA',true),
+  ('$C9','$FA',false);
+
+-- created_at acompanha generated_at: em prod as duas são idênticas nas 533 linhas, e o
+-- índice único parcial indexa created_at. Divergir aqui testaria um mundo que não existe.
+INSERT INTO public.farmer_tactical_plans
+  (farmer_id, customer_user_id, status, plan_type, generated_at, created_at) VALUES
+  ('$FA','$C2','gerado',    'estrategico', now() - interval '3 days',  now() - interval '3 days'),
+  ('$FA','$C3','gerado',    'estrategico', now() - interval '8 days',  now() - interval '8 days'),
+  ('$FA','$C4','expirado',  'estrategico', now() - interval '3 days',  now() - interval '3 days'),
+  ('$FA','$C5','concluido', 'estrategico', now() - interval '3 days',  now() - interval '3 days'),
+  ('$FB','$C6','gerado',    'estrategico', now() - interval '3 days',  now() - interval '3 days'),
+  ('$FA','$C7','gerado',    'essencial',   now() - interval '3 days',  now() - interval '3 days'),
+  ('$FA','$C8','gerado',    'estrategico', NULL,                       now() - interval '3 days');
+SQL
+
+PL='{"plan_type":"estrategico"}'
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts ──"
+
+# A1 — caminho feliz: cliente sem plano nenhum recebe o seu.
+eq "A1 cliente sem plano → gera" "$(cria "$C1" "$FA" "$PL")" "t"
+
+# A2 — O CORAÇÃO DA FASE 2. Plano de 3 dias atrás ainda está na fila ⇒ RECUSA.
+#      Com a trava velha (dia operacional) isto PASSARIA e viraria a 4ª cópia do cliente.
+espera_sqlstate "A2 plano aberto de 3 dias atras BLOQUEIA (janela)" \
+  "public.criar_plano_tatico('$C2'::uuid,'$FA'::uuid,'$PL'::jsonb)" "23505"
+
+# A3 — O OUTRO LADO da mesma régua: fora da janela, o cliente VOLTA a ser candidato.
+#      É isto que faz a fila circular; sem ele a fase 2 só trocaria "entope" por "congela".
+eq "A3 plano de 8 dias atras (fora da janela) → gera de novo" "$(cria "$C3" "$FA" "$PL")" "t"
+
+# A4 — `expirado` não é fila. O cron da fase 1 devolve o cliente para o pool.
+eq "A4 plano EXPIRADO nao bloqueia" "$(cria "$C4" "$FA" "$PL")" "t"
+
+# A5 — `concluido` não bloqueia: desfecho registrado é o fim daquele ciclo, não uma trava.
+eq "A5 plano CONCLUIDO nao bloqueia" "$(cria "$C5" "$FA" "$PL")" "t"
+
+# A6 — chave (farmer, customer): plano do farmer B não pode bloquear o farmer A. Cliente
+#      reatribuído precisa de plano sob o dono NOVO — senão a reatribuição o deixaria órfão.
+eq "A6 plano de OUTRO farmer nao bloqueia" "$(cria "$C6" "$FA" "$PL")" "t"
+
+# A7 — plan_type faz parte da chave (mesma do índice único): 'essencial' aberto não impede
+#      um 'estrategico'. São planos com propósitos diferentes.
+eq "A7 plan_type diferente nao bloqueia" "$(cria "$C7" "$FA" "$PL")" "t"
+
+# A8 — FAIL-CLOSED do COALESCE. `generated_at` é nullable, e `coluna >= x` com NULL é NULL:
+#      sem o COALESCE este plano não bloquearia (fail-OPEN) e a duplicata voltaria em
+#      silêncio justamente na linha de dado defeituoso. Indecidível RECUSA.
+espera_sqlstate "A8 plano com generated_at NULL BLOQUEIA (fail-closed)" \
+  "public.criar_plano_tatico('$C8'::uuid,'$FA'::uuid,'$PL'::jsonb)" "23505"
+
+# A9 — direção da divergência RPC × índice único: a RPC recusa ANTES, então o 23505 cru do
+#      índice nunca vaza. Reinserir hoje o que A1 acabou de criar tem de dar a mensagem da
+#      RPC (23505 tratado), não uma violação de constraint sem tratamento.
+espera_sqlstate "A9 RPC recusa antes do indice unico (mesma SQLSTATE, mensagem tratada)" \
+  "public.criar_plano_tatico('$C1'::uuid,'$FA'::uuid,'$PL'::jsonb)" "23505"
+
+# A10 — a mensagem que a edge casa (`ehJaNaFilaDaRpc` → PADROES_JA_NA_FILA). Se a redação
+#       mudar sem atualizar o predicado, a trava volta como http_500 e o lote a conta como
+#       ERRO. Este assert é o que trava a redação.
+MSG=$(P -tA 2>&1 <<EOF || true
+SET test.role='service_role';
+DO \$do\$
+BEGIN
+  PERFORM public.criar_plano_tatico('$C2'::uuid,'$FA'::uuid,'$PL'::jsonb);
+EXCEPTION WHEN SQLSTATE '23505' THEN RAISE NOTICE 'CAPTUREI:%', SQLERRM;
+END
+\$do\$;
+EOF
+)
+case "$MSG" in
+  *"aberto na fila para este cliente"*) ok "A10 mensagem casa o predicado da edge" ;;
+  *) bad "A10 mensagem NAO casa — veio: $(printf '%s' "$MSG" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
+
+# ── regressões das fases anteriores (não quebrei o que já existia) ───────────
+# A11 — máscara `eligible` continua fail-closed inclusive para service_role (#1422).
+espera_sqlstate "A11 cliente MASCARADO recusado (42501)" \
+  "public.criar_plano_tatico('$C9'::uuid,'$FA'::uuid,'$PL'::jsonb)" "42501"
+
+# A12 — race de posse: dono atual diverge do esperado.
+espera_sqlstate "A12 race de posse recusado" \
+  "public.criar_plano_tatico('$C2'::uuid,'$FB'::uuid,'$PL'::jsonb)" "P0001"
+
+# A13 — ramo AUTENTICADO: quem não é dono não passa no gate de carteira.
+R13=$(P -tA 2>&1 <<EOF || true
+SET test.role='authenticated';
+SET test.uid='$FB';
+DO \$do\$
+BEGIN
+  PERFORM public.criar_plano_tatico('$C1'::uuid,'$FB'::uuid,'$PL'::jsonb);
+  RAISE NOTICE 'SENTINELA_NAO_LEVANTOU_NADA';
+EXCEPTION
+  WHEN SQLSTATE '42501' THEN RAISE NOTICE 'SENTINELA_PEGOU_O_ESPERADO';
+  WHEN OTHERS THEN RAISE;
+END
+\$do\$;
+EOF
+)
+case "$R13" in
+  *SENTINELA_PEGOU_O_ESPERADO*) ok "A13 autenticado fora da carteira recusado (42501)" ;;
+  *) bad "A13 — saida: $(printf '%s' "$R13" | tr '\n' ' ' | cut -c1-200)" ;;
+esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificacao (sabota → exige VERMELHO → restaura) ──"
+
+# Roda um assert isolado e diz se ele PASSOU, sem mexer nos contadores globais.
+# Usado só pelas sabotagens: aqui "passou" é o resultado RUIM.
+passou_23505() {
+  local R
+  R=$(P -tA 2>&1 <<EOF || true
+SET test.role='service_role';
+DO \$do\$
+BEGIN
+  PERFORM public.criar_plano_tatico('$1'::uuid,'$FA'::uuid,'$PL'::jsonb);
+  RAISE NOTICE 'SENTINELA_NAO_LEVANTOU_NADA';
+EXCEPTION
+  WHEN SQLSTATE '23505' THEN RAISE NOTICE 'SENTINELA_PEGOU_O_ESPERADO';
+  WHEN OTHERS THEN RAISE;
+END
+\$do\$;
+EOF
+)
+  case "$R" in
+    *SENTINELA_PEGOU_O_ESPERADO*) echo "sim" ;;
+    *) echo "nao" ;;
+  esac
+}
+
+# F1 — SABOTAGEM: volta a trava da FASE 1 (chave = dia operacional). O A2 tem de ficar
+#      VERMELHO: é exatamente esta versão que produzia uma cópia por dia em prod. Se o A2
+#      continuasse verde, ele não estaria provando a janela — estaria provando outra coisa.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.criar_plano_tatico(_customer_user_id uuid, _expected_owner uuid, _payload jsonb)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $function$
+DECLARE _owner uuid; _eligible boolean; _rec public.farmer_tactical_plans; _new_id uuid; _dia_hoje date;
+BEGIN
+  SELECT a.owner_user_id, a.eligible INTO _owner, _eligible FROM public.carteira_assignments a
+   WHERE a.customer_user_id = _customer_user_id FOR UPDATE;
+  _rec := jsonb_populate_record(NULL::public.farmer_tactical_plans, _payload);
+  _dia_hoje := ((now() AT TIME ZONE 'UTC') - interval '3 hours')::date;
+  IF EXISTS (SELECT 1 FROM public.farmer_tactical_plans p
+              WHERE p.farmer_id = _owner AND p.customer_user_id = _customer_user_id
+                AND p.status = 'gerado'
+                AND COALESCE(p.plan_type,'essencial') = COALESCE(_rec.plan_type,'essencial')
+                AND (((p.created_at AT TIME ZONE 'UTC') - interval '3 hours')::date) = _dia_hoje)
+  THEN RAISE EXCEPTION 'trava da fase 1' USING ERRCODE = '23505'; END IF;
+  INSERT INTO public.farmer_tactical_plans (farmer_id, customer_user_id, status, plan_type)
+  VALUES (_owner, _customer_user_id, 'gerado', COALESCE(_rec.plan_type,'essencial')) RETURNING id INTO _new_id;
+  RETURN _new_id;
+END $function$;
+SQL
+if [ "$(passou_23505 "$C2")" = "nao" ]; then
+  ok "F1 sabotagem (trava por DIA) deixou A2 VERMELHO — o assert tem dente"
+else
+  bad "F1 A2 continuou verde com a trava da fase 1 — o assert NAO prova a janela"
+fi
+
+# F2 — SABOTAGEM: remove o COALESCE do generated_at. O A8 tem de ficar VERMELHO — sem ele,
+#      `NULL >= x` é NULL, o EXISTS não casa, e a linha de dado defeituoso passa batido.
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.criar_plano_tatico(_customer_user_id uuid, _expected_owner uuid, _payload jsonb)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $function$
+DECLARE _owner uuid; _eligible boolean; _rec public.farmer_tactical_plans; _new_id uuid;
+BEGIN
+  SELECT a.owner_user_id, a.eligible INTO _owner, _eligible FROM public.carteira_assignments a
+   WHERE a.customer_user_id = _customer_user_id FOR UPDATE;
+  _rec := jsonb_populate_record(NULL::public.farmer_tactical_plans, _payload);
+  IF EXISTS (SELECT 1 FROM public.farmer_tactical_plans p
+              WHERE p.farmer_id = _owner AND p.customer_user_id = _customer_user_id
+                AND p.status = 'gerado'
+                AND COALESCE(p.plan_type,'essencial') = COALESCE(_rec.plan_type,'essencial')
+                AND p.generated_at >= now() - make_interval(days => 7))
+  THEN RAISE EXCEPTION 'sem coalesce' USING ERRCODE = '23505'; END IF;
+  INSERT INTO public.farmer_tactical_plans (farmer_id, customer_user_id, status, plan_type)
+  VALUES (_owner, _customer_user_id, 'gerado', COALESCE(_rec.plan_type,'essencial')) RETURNING id INTO _new_id;
+  RETURN _new_id;
+END $function$;
+SQL
+if [ "$(passou_23505 "$C8")" = "nao" ]; then
+  ok "F2 sabotagem (sem COALESCE) deixou A8 VERMELHO — o guard fail-closed tem dente"
+else
+  bad "F2 A8 continuou verde sem o COALESCE — o assert NAO prova o fail-closed"
+fi
+
+# F3 — SABOTAGEM: janela absurda (365 dias). O A3 tem de ficar VERMELHO — o cliente de 8
+#      dias atrás voltaria a ser bloqueado, e a fila deixaria de circular. Prova que o A3
+#      mede a JANELA e não só "existe algum plano".
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION public.criar_plano_tatico(_customer_user_id uuid, _expected_owner uuid, _payload jsonb)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public' AS $function$
+DECLARE _owner uuid; _eligible boolean; _rec public.farmer_tactical_plans; _new_id uuid;
+BEGIN
+  SELECT a.owner_user_id, a.eligible INTO _owner, _eligible FROM public.carteira_assignments a
+   WHERE a.customer_user_id = _customer_user_id FOR UPDATE;
+  _rec := jsonb_populate_record(NULL::public.farmer_tactical_plans, _payload);
+  IF EXISTS (SELECT 1 FROM public.farmer_tactical_plans p
+              WHERE p.farmer_id = _owner AND p.customer_user_id = _customer_user_id
+                AND p.status = 'gerado'
+                AND COALESCE(p.plan_type,'essencial') = COALESCE(_rec.plan_type,'essencial')
+                AND COALESCE(p.generated_at, p.created_at, now()) >= now() - make_interval(days => 365))
+  THEN RAISE EXCEPTION 'janela absurda' USING ERRCODE = '23505'; END IF;
+  INSERT INTO public.farmer_tactical_plans (farmer_id, customer_user_id, status, plan_type)
+  VALUES (_owner, _customer_user_id, 'gerado', COALESCE(_rec.plan_type,'essencial')) RETURNING id INTO _new_id;
+  RETURN _new_id;
+END $function$;
+SQL
+# C3 já recebeu um plano novo em A3, então uso um cliente virgem com plano ANTIGO para
+# medir só o efeito da janela esticada.
+CX='cccccccc-0000-0000-0000-00000000000f'
+P -q <<SQL
+INSERT INTO public.carteira_assignments (customer_user_id, owner_user_id, eligible) VALUES ('$CX','$FA',true);
+INSERT INTO public.farmer_tactical_plans (farmer_id, customer_user_id, status, plan_type, generated_at, created_at)
+VALUES ('$FA','$CX','gerado','estrategico', now() - interval '8 days', now() - interval '8 days');
+SQL
+if [ "$(passou_23505 "$CX")" = "sim" ]; then
+  ok "F3 sabotagem (janela 365d) bloqueou o plano de 8 dias — A3 mede a JANELA de verdade"
+else
+  bad "F3 janela de 365 dias NAO bloqueou — o A3 nao esta medindo a janela"
+fi
+
+# RESTAURA a versão verdadeira e re-roda os dois asserts centrais (a restauração tem de
+# devolver o comportamento; sem isto, um erro no restore passaria despercebido).
+P -q -f "$MIG"
+eq "R1 restaurada: plano de 8 dias volta a gerar" "$(cria "$CX" "$FA" "$PL")" "t"
+if [ "$(passou_23505 "$C2")" = "sim" ]; then
+  ok "R2 restaurada: plano dentro da janela volta a bloquear"
+else
+  bad "R2 restauracao NAO devolveu a trava da janela"
+fi
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/agent/money-path.md
+++ b/docs/agent/money-path.md
@@ -109,6 +109,20 @@ Helper TS puro (testado com vitest) **espelhado verbatim** no edge (Deno não im
 
 Edge só-TS (sem contraparte SQL): a paridade vira **textual no CI** — bloco entre `// MIRROR-START/END` comparado normalizado src×edge (pega reescrita do Lovable no deploy) — **mais** uma **canária comportamental** `{canary:true}` staff-gated que roda o helper REAL deployado com fixture fixo e retorna `{resolved, expected, ok}`. Probe HTTP = única prova do COMPORTAMENTO em produção: o guard textual cobre a FONTE, a canária cobre o DEPLOY. ⚠️ A canária prova "helper deployado + lógica certa", **não** que o real-path usa o helper (isso é o guard textual + paridade). Ex.: merge de preço do `analyze-unified-order` (#1089); `identidade_probe` (`omie-vendas-sync`); `doc_ambiguo_probe` (`omie-analytics-sync`, P1b — indispensável ali: a ausência do helper é invisível no dado, a proof-table só encolhe com duplicata-CNPJ real na conta, que não há).
 
+## Idempotência: a chave é o ciclo do CONSUMIDOR, não o do produtor
+
+Trava do tipo "já fiz isso hoje?" casa com a periodicidade de quem PRODUZ. Se quem consome trabalha noutro ritmo, a mesma trava — correta, testada, e criada para um incidente real — passa a **autorizar exatamente uma cópia por ciclo do produtor**. É invisível como defeito: nada falha, nada alerta, e o volume parece adoção.
+
+Medido no PTPL (2026-08-08, fase 2 de `docs/historico/fila-plano-tatico.md`): `criar_plano_tatico` travava por dia operacional e o batch passou a rodar diariamente → **533 planos para 80 clientes**; a fila viva tinha 169 planos para 35 clientes, 14 deles com **7 cópias** cada. A chave certa era a JANELA da fila ("este item já está aberto para alguém?"), que é o ciclo do consumidor.
+
+Duas consequências ao trocar a chave:
+- **Prove o par, não só o bloqueio.** "Dentro da janela BLOQUEIA" sozinho é satisfeito por uma trava permanente — que troca *entope* por *congela*. O assert gêmeo ("fora da janela VOLTA a gerar") é o que separa os dois, e a falsificação correspondente estica a janela para exigir que ele quebre.
+- **Filtro de "já na fila" vem ANTES do corte do top-N.** Depois do corte, o produtor escolhe sempre os mesmos N, a trava os pula, e o item N+1 nunca entra. Com N grande isso é invisível; com N pequeno, congela a fila. Por isso a exclusão mora no oráculo puro (parâmetro de `selecionarParaPregeracao`), não no call-site.
+
+Numa trava, **coluna nullable é fail-OPEN**: `coluna >= x` com NULL é NULL, o `EXISTS` não casa e a linha de dado defeituoso deixa de bloquear em silêncio. Feche com `COALESCE(..., now())` — indecidível RECUSA.
+
+Sinal para revisão: **tabela de intenção que cresce sem a contagem de entidades DISTINTAS crescer** ⇒ o defeito está na chave de idempotência, não no volume. É uma query, e nenhuma tela mostra.
+
 ## Diagnóstico
 
 "Diagnosticado ≠ corrigido" — ver `diagnose-supabase-sync` (estados rígidos de saída; só declara RECUPERADO com novo ciclo + efeito no dado; a ação corretiva é entregue ao humano, nunca aplicada às cegas).

--- a/docs/historico/README.md
+++ b/docs/historico/README.md
@@ -10,7 +10,7 @@ Registro consultável de **PRs/bugs/programas/auditorias já entregues** — a n
 | --- | --- |
 | [bugs-resolvidos.md](bugs-resolvidos.md) | (era §10) cada bug/contradição/débito resolvido, com PR + lição (multi-domínio: KB, Radar, reposição, sync…) |
 | [programas-vendas.md](programas-vendas.md) | WhatsApp + Motor de Rota; copiloto "Buddy" |
-| [fila-plano-tatico.md](fila-plano-tatico.md) | PTPL: 533 planos com zero desfecho e 72% inalcançáveis — a fila sem saída (expiração + recorte por risco) |
+| [fila-plano-tatico.md](fila-plano-tatico.md) | PTPL fase 1: 533 planos com zero desfecho e 72% inalcançáveis — a fila sem saída (expiração + recorte por risco). Fase 2: os 533 eram **80 clientes** — a trava de idempotência media o DIA, e a fila mede a JANELA |
 | [auditoria-ux-redesign.md](auditoria-ux-redesign.md) | (era §9/§9b/§11) auditoria UX 2026-05-13 + redesign visual v3 + premissas/glossário |
 | [estoque-picking-recebimento.md](estoque-picking-recebimento.md) | offline-first + closed-loop (Picking Bridge Oben, Recebimento honesto) |
 | [tintometrico.md](tintometrico.md) | vínculo `tint_skus`↔Omie (resgate de 62 cores que somem do seletor) + lições de matching de catálogo |

--- a/docs/historico/fila-plano-tatico.md
+++ b/docs/historico/fila-plano-tatico.md
@@ -77,7 +77,7 @@ o assert de REVOKE passaria por acidente de ambiente — falso-verde.
 
 - **A geração continua em ~30/dia para 3 donos.** ~10 planos/dia por vendedor não é executável em
   venda consultiva. Reduzir é config (`farmer_algorithm_config`, 17 linhas), não código — ficou
-  como item separado.
+  como item separado. → **resolvido na fase 2, mas por outro motivo que não o esperado; ver abaixo.**
 - **O custo de registrar continua alto.** O `RecordResultDialog` pede 4 campos, entre eles a
   **margem realizada** digitada, que a vendedora dificilmente sabe durante a ligação. O caminho
   natural é registro de 1 toque (ligou / não atendeu / vendeu / recusou) com a margem vindo do
@@ -98,3 +98,96 @@ nenhuma tela comunica isso sozinha.
 
 E a leitura que veio da matéria: **desfecho que depende de digitação manual não é capturado.**
 É por isso que 70% dos dados se perdem no modelo antigo, e é exatamente o padrão aqui.
+
+---
+
+# Fase 2 — 533 planos eram 80 clientes: a fila regenerava a si mesma
+
+> 2026-08-08. A fase 1 deu SAÍDA à fila. A fase 2 fecha a ENTRADA, e a causa achada no
+> caminho não era a que a fase 1 previa.
+
+## A hipótese herdada estava certa no sintoma e errada na causa
+
+A fase 1 registrou: *"a geração continua em ~30/dia para 3 donos; reduzir é config"*. A leitura
+implícita era "o `TOP_N = 25` da edge é grande demais". Duas medições desmontaram isso:
+
+1. **`TOP_N` é por FARMER, não global** (o loop de `tactical-plans-batch/index.ts` chama
+   `selecionarParaPregeracao` uma vez por carteira). O teto seria 9+25+25 = 59 alvos/dia, e a
+   produção real é ~25 — ou seja, **o `TOP_N` nunca foi o limitante**. O que fixa 25 é o batch
+   truncando (hipótese: o `timeout_milliseconds := 150000` do `net.http_post` cortando o fan-out;
+   não confirmável em retrospecto porque `net._http_response` só retém ~6h e o batch roda 08:00 UTC).
+2. **95% da geração diária era repetição.** Dos 25 planos de 07/08, **23** eram de cliente que já
+   tinha plano nos 7 dias anteriores; em 05/08 e 31/07, **25 de 25**.
+
+| Medição (psql-ro, 2026-08-08) | Valor |
+|---|---|
+| 533 planos ⇒ clientes DISTINTOS | **80** |
+| Fila viva (169 `gerado`) ⇒ clientes | **35** — 14 deles com **7 cópias** cada |
+| Candidatos que passam o gate de R$/h | 174 — **97 nunca receberam plano** |
+| `gross_margin_pct` preenchido | 1.075 de 6.633 (16%) — o batch é cego em 84% da carteira |
+
+A vendedora não via "10 clientes por dia". Via **o mesmo cliente sete vezes** — uma cópia por dia
+da janela — enquanto 97 clientes elegíveis nunca foram alcançados.
+
+## A causa: a idempotência media o DIA, e a fila mede a JANELA
+
+`criar_plano_tatico` perguntava *"já gerei para este cliente HOJE?"* (dia operacional BRT). Aquilo
+consertou as 30 duplicatas do mesmo dia do incidente 2026-07-21/22 — e foi correto para aquele bug.
+Mas com o batch rodando diariamente, o cliente voltava a ser candidato toda madrugada. A trava
+casava com a periodicidade do produtor, não com a do consumidor.
+
+A pergunta certa é **"este cliente já está na fila de alguém?"**. Enquanto o plano estiver aberto,
+outro plano para o mesmo cliente só produz cópia. Quando ele sai — expirado pelo cron da fase 1 ou
+concluído — o cliente volta ao pool. É isso que faz a fila **circular**.
+
+## A correção
+
+1. **RPC (fronteira):** `criar_plano_tatico` bloqueia por plano `gerado` dentro da janela de 7 dias,
+   não pelo dia operacional. `COALESCE(generated_at, created_at, now())` porque as duas colunas são
+   nullable e `coluna >= x` com NULL é NULL — numa trava isso é fail-**open**, e a linha de dado
+   defeituoso deixaria de bloquear em silêncio. Indecidível RECUSA.
+2. **Edge (economia):** `tactical-plans-batch` lê a fila aberta e exclui esses clientes **antes** do
+   corte do top-N; `generate-tactical-plan` pula sem chamar a IA. Novo contador `ja_na_fila`.
+3. **`TOP_N` 25 → 2.** Com o dedupe, o `TOP_N` deixa de ser "tamanho do lote" e vira **taxa de
+   entrada de clientes novos**: a fila estabiliza em `TOP_N × 7`. 2/dia ⇒ ~14 por vendedora
+   (calibrado com o founder).
+
+### O detalhe que quase virou um bug pior
+
+Com `TOP_N` pequeno, **a ordem das operações é tudo**. Se o filtro de "já na fila" rodasse *depois*
+do `slice(topN)`, o batch escolheria todo dia os mesmos 2 de maior priority, a idempotência os
+pularia, e o cliente da posição 3 **nunca entraria** — a fila congelaria com aparência de
+funcionamento. Por isso `jaNaFila` é parâmetro do oráculo (`selecionarParaPregeracao`) e não um
+filtro no call-site: a invariante fica testada nos dois espelhos, não confiada a quem chama.
+
+Pelo mesmo motivo `semMargem` continua contado sobre a carteira **inteira**, sobrepondo-se a
+`naFila`: ele mede a cegueira do batch, e se passasse a excluir quem está na fila, encher a fila
+faria a cegueira "melhorar" sozinha.
+
+### O gate de R$/h NÃO subiu — e a medição é o motivo
+
+A pergunta em aberto era se `PROFIT_PER_HOUR_THRESHOLD` (50) deveria subir junto. Medido: os top-5
+por priority de cada carteira já têm R$/h entre **52 e 14.513**. Com `TOP_N = 2`, quem entra já passa
+folgado — subir a régua seria mexer numa fronteira de negócio sem que ela mudasse resultado nenhum.
+
+## Prova
+
+`db/test-tactical-idempotencia-janela.sh` (PG17, 18 asserts + 3 falsificações). Os asserts que
+importam são o par: **A2** (plano de 3 dias bloqueia) e **A3** (plano de 8 dias volta a gerar) —
+sozinho, o A2 seria satisfeito por uma trava permanente, que troca "entope" por "congela".
+
+A falsificação **F1** restaura a trava da fase 1 e exige que o A2 fique vermelho; **F2** remove o
+`COALESCE` e exige que o A8 (`generated_at` NULL) fique vermelho; **F3** estica a janela para 365
+dias e exige que o A3 quebre — sem ela, o A3 estaria provando apenas "existe algum plano", não a
+janela.
+
+## Lição
+
+**Uma trava de idempotência tem de casar com o ciclo do CONSUMIDOR, não com o do produtor.** A
+chave "por dia" era invisível como defeito: ela funcionava, tinha teste, e o incidente que a
+motivou era real. O que mudou foi o produtor virar diário — e aí a mesma trava correta passou a
+autorizar exatamente uma cópia por dia.
+
+Corolário para revisão: **quando uma tabela de intenção cresce mas a contagem de entidades
+distintas não, o defeito está na chave de idempotência, não no volume.** 533 planos e 80 clientes
+é um número que se lê em uma query e que nenhuma tela mostra.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **454** custom migrations totais
-- **1561** objetos esperados (criados por estas migrations)
+- **455** custom migrations totais
+- **1562** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 459
+  - `function`: 460
   - `rls_policy`: 392
   - `index`: 237
   - `cron_job`: 163
@@ -3813,6 +3813,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260807223000_check_finitude_money_path.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260808020000_tactical_plan_idempotencia_janela.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.criar_plano_tatico` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 454
+-- Total de custom migrations: 455
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -495,7 +495,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260806225052', 'atp_reserva_estoque_fase1_1_hardening', '20260806225052_atp_reserva_estoque_fase1_1_hardening.sql'),
   ('20260807015000', 'atp_gate_pedido_fase2', '20260807015000_atp_gate_pedido_fase2.sql'),
   ('20260807210912', 'expirar_planos_taticos', '20260807210912_expirar_planos_taticos.sql'),
-  ('20260807223000', 'check_finitude_money_path', '20260807223000_check_finitude_money_path.sql')
+  ('20260807223000', 'check_finitude_money_path', '20260807223000_check_finitude_money_path.sql'),
+  ('20260808020000', 'tactical_plan_idempotencia_janela', '20260808020000_tactical_plan_idempotencia_janela.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2045,7 +2046,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('atp_gate_pedido_fase2', 'index', 'public', 'idx_atp_decisoes_created', 'atp_decisoes'),
   ('atp_gate_pedido_fase2', 'rls_policy', 'public', 'atp_decisoes_select_staff', 'atp_decisoes'),
   ('expirar_planos_taticos', 'function', 'public', 'expirar_planos_taticos', ''),
-  ('expirar_planos_taticos', 'cron_job', 'cron', 'expirar-planos-taticos', '')
+  ('expirar_planos_taticos', 'cron_job', 'cron', 'expirar-planos-taticos', ''),
+  ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3643,7 +3645,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('atp_gate_pedido_fase2', 'index', 'public', 'idx_atp_decisoes_created', 'atp_decisoes'),
   ('atp_gate_pedido_fase2', 'rls_policy', 'public', 'atp_decisoes_select_staff', 'atp_decisoes'),
   ('expirar_planos_taticos', 'function', 'public', 'expirar_planos_taticos', ''),
-  ('expirar_planos_taticos', 'cron_job', 'cron', 'expirar-planos-taticos', '')
+  ('expirar_planos_taticos', 'cron_job', 'cron', 'expirar-planos-taticos', ''),
+  ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', '')
 )
 SELECT
   e.migration,

--- a/src/__tests__/erro-object-object-gate.test.ts
+++ b/src/__tests__/erro-object-object-gate.test.ts
@@ -30,10 +30,20 @@ const DIRS = ['src', 'supabase/functions', 'scripts'];
 const EXT = /\.(ts|tsx)$/;
 const IGNORAR = /(\.test\.|_test\.|\.d\.ts$|__tests__|\.stories\.)/;
 
-// O helper é a ÚNICA fonte legítima de `String(err)` no repo: é o ramo de último recurso
-// DELE, que só roda para primitivo não-objeto (número, symbol, boolean) — exatamente o
+// Os helpers são a ÚNICA fonte legítima de `String(err)` no repo: é o ramo de último recurso
+// DELES, que só roda para primitivo não-objeto (número, symbol, boolean) — exatamente o
 // caso em que `String()` produz texto útil e nunca "[object Object]".
-const HELPER = 'src/lib/erro-mensagem.ts';
+//
+// São DOIS porque Deno não importa de `src/`: o de `_shared` é o espelho verbatim que o
+// comentário de A_DIVIDA aqui embaixo pedia ("as ~93 edges Deno […] precisam de um
+// `_shared/erro-mensagem.ts` próprio"). Sem ele, um sítio NOVO em edge só tinha duas saídas:
+// reintroduzir o idiom (vermelho, correto) ou driblar o regex renomeando a variável (verde,
+// mentira). A isenção vale para o ARQUIVO INTEIRO — mantenha os dois helpers pequenos e sem
+// outra lógica, porque o que entrar neles deixa de ser fiscalizado.
+const HELPERS: ReadonlySet<string> = new Set([
+  'src/lib/erro-mensagem.ts',
+  'supabase/functions/_shared/erro-mensagem.ts',
+]);
 
 function listarFontes(dir: string, acc: string[] = []): string[] {
   for (const nome of readdirSync(resolve(RAIZ, dir))) {
@@ -85,7 +95,7 @@ function contarPorArquivo(re: RegExp): Map<string, number> {
   const mapa = new Map<string, number>();
   for (const dir of DIRS) {
     for (const arquivo of listarFontes(dir)) {
-      if (arquivo === HELPER) continue;
+      if (HELPERS.has(arquivo)) continue;
       const n = contar(re, readFileSync(resolve(RAIZ, arquivo), 'utf8'));
       if (n > 0) mapa.set(arquivo, n);
     }

--- a/src/lib/tactical/__tests__/pregeracao.test.ts
+++ b/src/lib/tactical/__tests__/pregeracao.test.ts
@@ -91,4 +91,60 @@ describe('selecionarParaPregeracao', () => {
     expect(selecionados).toEqual([]); // nenhum dos dois gera plano...
     expect(semMargem.map((s) => s.customerUserId)).toEqual(['margem-ausente']); // ...mas por motivos DIFERENTES
   });
+
+  // ── fase 2: quem já está na fila não disputa vaga ──────────────────────────
+  describe('jaNaFila', () => {
+    it('exclui de selecionados quem já tem plano aberto', () => {
+      const scores = [base('a', 90, 1000, 30), base('b', 80, 1000, 30)];
+      const { selecionados } = selecionarParaPregeracao(scores, 25, new Set(['a']));
+      expect(selecionados.map((s) => s.customerUserId)).toEqual(['b']);
+    });
+
+    it('FILTRA ANTES DE CORTAR: o cliente seguinte sobe para a vaga liberada', () => {
+      // ESTE é o teste que protege a correção inteira. Se o filtro rodasse DEPOIS do
+      // slice(topN), o batch escolheria todo dia os mesmos topN de maior priority, a
+      // idempotência os pularia, e 'c' JAMAIS entraria — fila parada com aparência de
+      // funcionamento. Medido em prod: 169 planos vivos para 35 clientes, e 97 dos 174
+      // candidatos elegíveis nunca haviam recebido plano.
+      const scores = [
+        base('a', 90, 1000, 30), // já na fila
+        base('b', 80, 1000, 30), // já na fila
+        base('c', 70, 1000, 30), // deveria SUBIR e ser gerado
+        base('d', 60, 1000, 30),
+      ];
+      const { selecionados } = selecionarParaPregeracao(scores, 2, new Set(['a', 'b']));
+      expect(selecionados.map((s) => s.customerUserId)).toEqual(['c', 'd']);
+    });
+
+    it('contabiliza os excluídos em naFila — no silent caps', () => {
+      const scores = [base('a', 90, 1000, 30), base('b', 80, 1000, 30)];
+      const { naFila } = selecionarParaPregeracao(scores, 25, new Set(['a']));
+      expect(naFila.map((s) => s.customerUserId)).toEqual(['a']);
+    });
+
+    it('estar na fila não isenta do gate: quem está na fila E reprova sai só uma vez de cada lista', () => {
+      // naFila e semMargem são recortes independentes e PODEM se sobrepor — a asserção
+      // documenta isso, para que ninguém "conserte" a sobreposição somando os contadores.
+      const scores = [base('x', 90, 1000, null)];
+      const { selecionados, semMargem, naFila } = selecionarParaPregeracao(scores, 25, new Set(['x']));
+      expect(selecionados).toEqual([]);
+      expect(semMargem.map((s) => s.customerUserId)).toEqual(['x']);
+      expect(naFila.map((s) => s.customerUserId)).toEqual(['x']);
+    });
+
+    it('semMargem é contado sobre a carteira TODA, não só sobre quem está fora da fila', () => {
+      // Se semMargem passasse a excluir quem está na fila, encher a fila faria a cegueira
+      // do batch "melhorar" sozinha — e o número deixaria de servir como sinal.
+      const scores = [base('na-fila', 90, 1000, null), base('fora', 80, 1000, null)];
+      const { semMargem } = selecionarParaPregeracao(scores, 25, new Set(['na-fila']));
+      expect(semMargem.map((s) => s.customerUserId)).toEqual(['na-fila', 'fora']);
+    });
+
+    it('sem jaNaFila o comportamento é o de antes (default vazio)', () => {
+      const scores = [base('a', 90, 1000, 30), base('b', 80, 1000, 30)];
+      const { selecionados, naFila } = selecionarParaPregeracao(scores, 25);
+      expect(selecionados.map((s) => s.customerUserId)).toEqual(['a', 'b']);
+      expect(naFila).toEqual([]);
+    });
+  });
 });

--- a/src/lib/tactical/pregeracao.ts
+++ b/src/lib/tactical/pregeracao.ts
@@ -31,24 +31,43 @@ export function profitPerHora(
   return marginPerCall / (AVG_CALL_MINUTES / 60);
 }
 
-/** Top-N por priorityScore desc, filtrando quem passa no gate de R$/h.
+/** Top-N por priorityScore desc, filtrando quem passa no gate de R$/h e ainda NÃO está na fila.
  *  Filtra ANTES de cortar: retorna os N de maior priority DENTRE OS ELEGÍVEIS.
  *
  *  Quem tem margem desconhecida sai em `semMargem`, NÃO em `selecionados`: o gate não é
  *  decidível sem margem, e tratá-lo como reprovado o confundiria com um cliente de margem
  *  genuinamente ruim. `semMargem` existe para o chamador CONTABILIZAR o descarte — corte
- *  silencioso leria como "cobri todo mundo" sem ter coberto (money-path: no silent caps). */
+ *  silencioso leria como "cobri todo mundo" sem ter coberto (money-path: no silent caps).
+ *
+ *  `jaNaFila` (clientes com plano ABERTO) é excluído AQUI e não no call-site, e a ordem é o
+ *  ponto todo: com topN pequeno, filtrar DEPOIS do corte congelaria a fila. O batch escolheria
+ *  todo dia os mesmos topN de maior priority, a idempotência os pularia, e o cliente de posição
+ *  topN+1 nunca entraria — fila parada com aparência de funcionamento. Medido em prod
+ *  (2026-08-08): 23 dos 25 planos do dia eram regeração de cliente que já estava na fila; a
+ *  fila viva tinha 169 planos para 35 clientes, 14 deles com 7 cópias cada.
+ *
+ *  `naFila` e `semMargem` PODEM SE SOBREPOR — são recortes independentes, não uma partição.
+ *  `semMargem` mede a cegueira da CARTEIRA (quantos clientes não são avaliáveis) e por isso é
+ *  contado sobre todos os scores: se ele passasse a excluir quem está na fila, encher a fila
+ *  faria a cegueira "melhorar" sozinha, e o número deixaria de servir de sinal. */
 export function selecionarParaPregeracao(
   scores: ScoreParaSelecao[],
   topN: number,
-): { selecionados: ScoreParaSelecao[]; semMargem: ScoreParaSelecao[] } {
+  jaNaFila: ReadonlySet<string> = new Set(),
+): {
+  selecionados: ScoreParaSelecao[];
+  semMargem: ScoreParaSelecao[];
+  naFila: ScoreParaSelecao[];
+} {
   const ordenados = [...scores].sort((a, b) => b.priorityScore - a.priorityScore);
   const semMargem = ordenados.filter((s) => margemConhecida(s.marginPct) == null);
+  const naFila = ordenados.filter((s) => jaNaFila.has(s.customerUserId));
   const selecionados = ordenados
     .filter((s) => {
+      if (jaNaFila.has(s.customerUserId)) return false;
       const pph = profitPerHora(s);
       return pph != null && pph >= PROFIT_PER_HOUR_THRESHOLD;
     })
     .slice(0, topN);
-  return { selecionados, semMargem };
+  return { selecionados, semMargem, naFila };
 }

--- a/supabase/functions/_shared/erro-mensagem.ts
+++ b/supabase/functions/_shared/erro-mensagem.ts
@@ -1,0 +1,41 @@
+// Mensagem legível de um erro capturado — incluindo os que NÃO são `Error`.
+//
+// ESPELHO de src/lib/erro-mensagem.ts (Deno não importa de `src/`). Mudou lá, mude aqui.
+// Testes em erro-mensagem_test.ts.
+//
+// POR QUE EXISTE: `err instanceof Error ? err.message : String(err)` é o idiom do repo, e ele
+// falha justamente no erro mais comum desta camada. O supabase-js só constrói um
+// `PostgrestError` (que herda de `Error`) quando se usa `.throwOnError()`; no caminho normal
+// — `const { error } = await supabase.from(...)` — o `error` é um objeto PLANO
+// `{ message, details, hint, code }` parseado do JSON da resposta. Um `throw` desses cai no
+// ramo `String(err)` e o que chega ao log/resposta é **"[object Object]"**: ruído com cara de
+// diagnóstico, no lugar da mensagem acionável que o servidor mandou.
+//
+// O gate estrutural `src/__tests__/erro-object-object-gate.test.ts` (classe #1642) vigia a
+// reintrodução do idiom. `src/` está em ZERO; as ~93 edges Deno são dívida baselinada POR
+// CONTAGEM, e este módulo é o que o comentário daquele gate pedia para que ela possa encolher.
+// Sítio NOVO em edge deve usar isto — a baseline só encolhe, nunca cresce.
+
+/**
+ * Ordem de preferência: `message` string não-vazia (cobre `Error` e o objeto plano do
+ * PostgREST) → `String(err)` como último recurso.
+ *
+ * NUNCA devolve "[object Object]": sem mensagem utilizável devolve `null`, e o chamador
+ * decide o texto de fallback do seu contexto — ausente ≠ mensagem fabricada (money-path).
+ */
+export function mensagemDeErro(err: unknown): string | null {
+  if (typeof err === "string") {
+    const t = err.trim();
+    return t.length > 0 ? t : null;
+  }
+  if (err && typeof err === "object") {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === "string" && m.trim().length > 0) return m.trim();
+    // Objeto sem `message` utilizável: `String(err)` daria "[object Object]". Melhor admitir
+    // que não há mensagem do que devolver um texto que parece diagnóstico e não é.
+    return null;
+  }
+  if (err == null) return null;
+  const s = String(err).trim();
+  return s.length > 0 ? s : null;
+}

--- a/supabase/functions/_shared/erro-mensagem_test.ts
+++ b/supabase/functions/_shared/erro-mensagem_test.ts
@@ -1,0 +1,54 @@
+// Testa o CÓDIGO REAL de erro-mensagem.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/erro-mensagem_test.ts
+//
+// Espelha o oráculo vitest de src/lib/erro-mensagem.ts. O caso que motiva o módulo é o
+// segundo teste: o `error` do supabase-js é objeto PLANO, e o idiom antigo
+// (`instanceof Error ? err.message : String(err)`) o transforma em "[object Object]".
+import { mensagemDeErro } from "./erro-mensagem.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (a !== b) throw new Error(msg ?? `esperava ${JSON.stringify(b)}, veio ${JSON.stringify(a)}`);
+}
+
+Deno.test("Error normal → a message", () => {
+  assertEquals(mensagemDeErro(new Error("falhou de verdade")), "falhou de verdade");
+});
+
+Deno.test("objeto PLANO do supabase-js → a message (o caso que motiva o módulo)", () => {
+  // `String()` neste objeto renderia "[object Object]" — a mensagem acionável existe e
+  // morreria na fronteira.
+  assertEquals(
+    mensagemDeErro({ message: "canceling statement due to statement timeout", code: "57014" }),
+    "canceling statement due to statement timeout",
+  );
+});
+
+Deno.test("objeto SEM message → null, NUNCA '[object Object]'", () => {
+  // Ausente ≠ mensagem fabricada: quem chama decide o fallback do seu contexto.
+  assertEquals(mensagemDeErro({ code: "57014" }), null);
+});
+
+Deno.test("string crua → ela mesma, aparada", () => {
+  assertEquals(mensagemDeErro("  boom  "), "boom");
+});
+
+Deno.test("string vazia / só espaço → null", () => {
+  assertEquals(mensagemDeErro(""), null);
+  assertEquals(mensagemDeErro("   "), null);
+});
+
+Deno.test("message vazia ou não-string → null", () => {
+  assertEquals(mensagemDeErro({ message: "" }), null);
+  assertEquals(mensagemDeErro({ message: "   " }), null);
+  assertEquals(mensagemDeErro({ message: 42 }), null);
+});
+
+Deno.test("null / undefined → null", () => {
+  assertEquals(mensagemDeErro(null), null);
+  assertEquals(mensagemDeErro(undefined), null);
+});
+
+Deno.test("primitivo não-string → String() dele (último recurso, sem risco de [object Object])", () => {
+  assertEquals(mensagemDeErro(404), "404");
+  assertEquals(mensagemDeErro(false), "false");
+});

--- a/supabase/functions/_shared/tactical-batch-resultado.ts
+++ b/supabase/functions/_shared/tactical-batch-resultado.ts
@@ -33,7 +33,7 @@ export interface ResumoLote {
 /**
  * Classifica a resposta de UM alvo (chamada a generate-tactical-plan).
  *
- * `skipped` é caminho ESPERADO, não falha: `ja_gerado_hoje` (idempotência),
+ * `skipped` é caminho ESPERADO, não falha: `ja_na_fila` (idempotência),
  * `sem_score` e `rpc_error` (race de reatribuição — a edge alvo já o trata).
  * Tratá-lo como erro apagaria o sinal que distingue "pulei de propósito" de
  * "quebrei" — foi `pulados: 0` que provou, no incidente, que os 28 erros não

--- a/supabase/functions/_shared/tactical-fila.ts
+++ b/supabase/functions/_shared/tactical-fila.ts
@@ -1,0 +1,53 @@
+// Janela da fila do Plano Tático — a régua que diz se um plano ainda está ABERTO.
+//
+// Lógica PURA extraída para caber no `--no-remote` do `test:edges`.
+// Testes em tactical-fila_test.ts.
+//
+// POR QUE EXISTE — a fase 2 (2026-08-08). A idempotência da geração era "já gerei HOJE?"
+// (dia-operacional.ts), e o cliente voltava a ser candidato na madrugada seguinte. Efeito
+// medido em prod: 23 dos 25 planos de 07/08 eram regeração de cliente que JÁ estava na fila;
+// a fila viva tinha 169 planos para 35 clientes distintos, 14 deles com 7 cópias — uma por
+// dia da janela. A vendedora abria a tela e via o mesmo cliente sete vezes.
+//
+// A régua certa não é o DIA, é a JANELA: enquanto o plano estiver aberto na fila de alguém,
+// gerar outro para o mesmo cliente só produz cópia. Quando ele sai (expirado pelo cron
+// `expirar-planos-taticos`, ou concluído), o cliente volta a ser candidato — é o que faz a
+// fila circular em vez de entupir.
+//
+// ⚠️ TRÊS LUGARES compartilham este 7, e divergir tem consequência assimétrica:
+//   1. src/hooks/useTacticalPlan.ts:238  `JANELA_FILA_DIAS` — o recorte que a tela exibe
+//   2. expirar_planos_taticos(_dias=7)   — o cron que muda `gerado` → `expirado`
+//   3. esta constante                    — a idempotência da geração
+// Se esta janela ficar MAIOR que a da tela, o cliente sai de vista mas continua bloqueado, e
+// ninguém gera plano para ele — buraco silencioso. Se ficar MENOR, volta a duplicata. Mantenha
+// as três iguais; ao mudar uma, mude as três.
+//
+// Por que a idempotência não olha só `status = 'gerado'` (sem janela nenhuma): isso a deixaria
+// dependente do cron de expiração ter rodado. Cron morto ⇒ nada expira ⇒ NENHUM plano novo é
+// gerado para ninguém, e a fila congela inteira. Com a janela explícita, um plano velho demais
+// deixa de bloquear mesmo que o cron não tenha passado — a fase 1 tomou a mesma decisão do lado
+// da tela ("o front aplica a janela por conta própria em vez de confiar que o cron rodou").
+
+/** Dias que um plano permanece na fila. Espelha useTacticalPlan.ts:238 e expirar_planos_taticos. */
+export const JANELA_FILA_DIAS = 7;
+
+const DIA_MS = 86_400_000;
+
+/**
+ * Limite inferior (ISO) da janela da fila — use com `>=` sobre `created_at`.
+ *
+ * Janela DESLIZANTE de 7×24h, idêntica ao front (`Date.now() - JANELA_FILA_DIAS * 86_400_000`),
+ * e não dia-calendário: as duas pontas precisam concordar sobre quem está na fila, e uma
+ * janela por calendário discordaria da outra por até 24h todo dia.
+ *
+ * `agora` é parâmetro (não `Date.now()` interno) para o comportamento ser testável sem
+ * depender do relógio da máquina — mesmo padrão de dia-operacional.ts.
+ */
+export function inicioDaJanelaFila(agora: Date, dias: number = JANELA_FILA_DIAS): string {
+  // Guard fail-closed, espelhando o 22023 de expirar_planos_taticos: com `dias <= 0` a janela
+  // seria vazia ou futura, TODO plano deixaria de bloquear, e a duplicata voltaria em silêncio.
+  if (!Number.isFinite(dias) || dias < 1) {
+    throw new RangeError(`janela da fila inválida: ${dias} (esperado inteiro >= 1)`);
+  }
+  return new Date(agora.getTime() - dias * DIA_MS).toISOString();
+}

--- a/supabase/functions/_shared/tactical-fila_test.ts
+++ b/supabase/functions/_shared/tactical-fila_test.ts
@@ -1,0 +1,88 @@
+// Testa o CÓDIGO REAL de tactical-fila.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/tactical-fila_test.ts
+//
+// POR QUE EXISTE — fase 2 da fila do Plano Tático (2026-08-08). A janela é a régua que
+// decide se um cliente ainda está bloqueado para nova geração. Errar nela reabre a duplicata
+// que o PR conserta (janela curta demais) ou cria um buraco silencioso onde o cliente sai da
+// tela mas continua bloqueado (janela longa demais que a do front).
+//
+// `agora` é injetado: janela com relógio real é não-determinística e varia entre a máquina de
+// quem escreve e o CI — mesmo padrão de dia-operacional_test.ts.
+import { inicioDaJanelaFila, JANELA_FILA_DIAS } from "./tactical-fila.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (a !== b) throw new Error(msg ?? `esperava ${JSON.stringify(b)}, veio ${JSON.stringify(a)}`);
+}
+
+function assertThrows(fn: () => unknown, msg: string) {
+  let lancou = false;
+  try {
+    fn();
+  } catch {
+    lancou = true;
+  }
+  if (!lancou) throw new Error(msg);
+}
+
+Deno.test("janela é de 7 dias — o mesmo número do front e do cron de expiração", () => {
+  // Se este assert quebrar, os TRÊS lugares precisam mudar juntos (ver o cabeçalho do módulo):
+  // useTacticalPlan.ts:238, expirar_planos_taticos(_dias) e esta constante.
+  assertEquals(JANELA_FILA_DIAS, 7);
+});
+
+Deno.test("recua exatamente 7×24h do instante dado", () => {
+  assertEquals(
+    inicioDaJanelaFila(new Date("2026-08-08T11:00:00.000Z")),
+    "2026-08-01T11:00:00.000Z",
+  );
+});
+
+Deno.test("é janela DESLIZANTE, não dia-calendário: preserva a hora do instante", () => {
+  // O front usa `Date.now() - 7*86400000`. Se aqui a janela truncasse no dia, as duas pontas
+  // discordariam sobre quem está na fila por até 24h todo dia — e a discordância é justamente
+  // a duplicata (edge gera o que a tela já mostra) ou o buraco (tela esconde o que bloqueia).
+  assertEquals(
+    inicioDaJanelaFila(new Date("2026-08-08T23:59:59.000Z")),
+    "2026-08-01T23:59:59.000Z",
+  );
+});
+
+Deno.test("atravessa fronteira de mês sem cair no dia errado", () => {
+  assertEquals(
+    inicioDaJanelaFila(new Date("2026-03-03T09:30:00.000Z")),
+    "2026-02-24T09:30:00.000Z",
+  );
+});
+
+Deno.test("aceita janela custom >= 1", () => {
+  assertEquals(
+    inicioDaJanelaFila(new Date("2026-08-08T11:00:00.000Z"), 1),
+    "2026-08-07T11:00:00.000Z",
+  );
+});
+
+// ── Guard fail-closed (espelha o 22023 de expirar_planos_taticos) ───────────────────────────
+// Com dias <= 0 a janela seria vazia ou futura: NENHUM plano aberto bloquearia, e a duplicata
+// voltaria em silêncio — exatamente o bug que este PR remove. Falhar alto é o comportamento
+// certo, porque um batch que não roda é visível e um batch que duplica não é.
+Deno.test("dias = 0 levanta — janela vazia reabriria a duplicata", () => {
+  assertThrows(
+    () => inicioDaJanelaFila(new Date("2026-08-08T11:00:00.000Z"), 0),
+    "esperava throw com dias=0",
+  );
+});
+
+Deno.test("dias negativo levanta — janela no futuro não bloquearia ninguém", () => {
+  assertThrows(
+    () => inicioDaJanelaFila(new Date("2026-08-08T11:00:00.000Z"), -7),
+    "esperava throw com dias negativo",
+  );
+});
+
+Deno.test("dias NaN levanta — não degrada para a janela padrão", () => {
+  // Cair no default silenciosamente esconderia um bug de configuração do chamador.
+  assertThrows(
+    () => inicioDaJanelaFila(new Date("2026-08-08T11:00:00.000Z"), NaN),
+    "esperava throw com dias NaN",
+  );
+});

--- a/supabase/functions/_shared/tactical-margem.ts
+++ b/supabase/functions/_shared/tactical-margem.ts
@@ -43,25 +43,37 @@ export interface LinhaSelecao {
   marginPct: number | null;
 }
 
-/** Top-N por priority desc DENTRE os que passam no gate de R$/h (filtra ANTES de cortar).
+/** Top-N por priority desc DENTRE os que passam no gate de R$/h e ainda NÃO estão na fila
+ *  (filtra ANTES de cortar).
  *
  *  Margem desconhecida sai em `semMargem`, não em `selecionados`: sem margem o gate não é
  *  decidível, e reprovar por omissão confundiria "não sei" com "cliente ruim". O chamador
  *  DEVE reportar `semMargem` — corte silencioso leria como "cobri todo mundo" sem ter
- *  coberto (money-path: no silent caps). */
+ *  coberto (money-path: no silent caps).
+ *
+ *  `jaNaFila` (clientes com plano ABERTO) é excluído AQUI, antes do corte, e a ordem é o ponto
+ *  todo: com topN pequeno, filtrar DEPOIS congelaria a fila — o batch escolheria todo dia os
+ *  mesmos topN de maior priority, a idempotência os pularia, e o cliente topN+1 nunca entraria.
+ *
+ *  `naFila` e `semMargem` PODEM SE SOBREPOR (recortes independentes, não partição): `semMargem`
+ *  é contado sobre TODOS os scores porque mede a cegueira da carteira — excluir quem está na
+ *  fila faria a cegueira "melhorar" só por a fila ter enchido. */
 export function selecionarParaPregeracao(
   scores: LinhaSelecao[],
   topN: number,
-): { selecionados: LinhaSelecao[]; semMargem: LinhaSelecao[] } {
+  jaNaFila: ReadonlySet<string> = new Set(),
+): { selecionados: LinhaSelecao[]; semMargem: LinhaSelecao[]; naFila: LinhaSelecao[] } {
   const ordenados = [...scores].sort((a, b) => b.priority - a.priority);
   const semMargem = ordenados.filter((s) => margemConhecida(s.marginPct) == null);
+  const naFila = ordenados.filter((s) => jaNaFila.has(s.customer));
   const selecionados = ordenados
     .filter((s) => {
+      if (jaNaFila.has(s.customer)) return false;
       const pph = profitPerHora(s.rev, s.avg, s.marginPct);
       return pph != null && pph >= PROFIT_PER_HOUR_THRESHOLD;
     })
     .slice(0, topN);
-  return { selecionados, semMargem };
+  return { selecionados, semMargem, naFila };
 }
 
 /** Margem média dos PARES da carteira, contando SÓ quem tem margem conhecida.

--- a/supabase/functions/_shared/tactical-margem_test.ts
+++ b/supabase/functions/_shared/tactical-margem_test.ts
@@ -105,6 +105,52 @@ Deno.test("selecao: margem 0 conhecida reprova o gate mas NÃO é semMargem", ()
   assertEquals(semMargem.map((s) => s.customer), ["ausente"]);
 });
 
+// ── fase 2: quem já está na fila não disputa vaga ────────────────────────────
+Deno.test("selecao: exclui de selecionados quem já tem plano aberto", () => {
+  const scores = [linha("a", 90, 1000, 30), linha("b", 80, 1000, 30)];
+  const { selecionados } = selecionarParaPregeracao(scores, 25, new Set(["a"]));
+  assertEquals(selecionados.map((s) => s.customer), ["b"]);
+});
+
+Deno.test("selecao: FILTRA A FILA ANTES DE CORTAR — o seguinte sobe para a vaga", () => {
+  // ESTE é o teste que protege a correção inteira. Filtrar DEPOIS do slice(topN) faria o
+  // batch escolher todo dia os mesmos topN de maior priority, a idempotência os pularia, e
+  // 'c' JAMAIS entraria — fila parada com aparência de funcionamento. Medido em prod
+  // (2026-08-08): 169 planos vivos para 35 clientes, e 97 dos 174 candidatos elegíveis
+  // nunca haviam recebido plano nenhum.
+  const scores = [
+    linha("a", 90, 1000, 30), // já na fila
+    linha("b", 80, 1000, 30), // já na fila
+    linha("c", 70, 1000, 30), // deveria SUBIR
+    linha("d", 60, 1000, 30),
+  ];
+  const { selecionados } = selecionarParaPregeracao(scores, 2, new Set(["a", "b"]));
+  assertEquals(selecionados.map((s) => s.customer), ["c", "d"]);
+});
+
+Deno.test("selecao: os excluídos pela fila são CONTABILIZADOS em naFila (no silent caps)", () => {
+  const scores = [linha("a", 90, 1000, 30), linha("b", 80, 1000, 30)];
+  const { naFila } = selecionarParaPregeracao(scores, 25, new Set(["a"]));
+  assertEquals(naFila.map((s) => s.customer), ["a"]);
+});
+
+Deno.test("selecao: semMargem conta a carteira TODA, mesmo quem está na fila", () => {
+  // Se semMargem excluísse quem está na fila, encher a fila faria a cegueira do batch
+  // "melhorar" sozinha e o número deixaria de servir como sinal. naFila e semMargem são
+  // recortes independentes e podem se sobrepor — de propósito.
+  const scores = [linha("na-fila", 90, 1000, null), linha("fora", 80, 1000, null)];
+  const { semMargem, naFila } = selecionarParaPregeracao(scores, 25, new Set(["na-fila"]));
+  assertEquals(semMargem.map((s) => s.customer), ["na-fila", "fora"]);
+  assertEquals(naFila.map((s) => s.customer), ["na-fila"]);
+});
+
+Deno.test("selecao: sem o 3º argumento o comportamento é o de antes (default vazio)", () => {
+  const scores = [linha("a", 90, 1000, 30), linha("b", 80, 1000, 30)];
+  const { selecionados, naFila } = selecionarParaPregeracao(scores, 25);
+  assertEquals(selecionados.map((s) => s.customer), ["a", "b"]);
+  assertEquals(naFila.length, 0);
+});
+
 Deno.test("selecao: threshold é 50 R$/h (paridade com o front)", () => {
   assertEquals(PROFIT_PER_HOUR_THRESHOLD, 50);
 });

--- a/supabase/functions/generate-tactical-plan/index.ts
+++ b/supabase/functions/generate-tactical-plan/index.ts
@@ -13,9 +13,9 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { avaliarCanariaMargem, calcularClusterMargin, classifyProfile, margemConhecida, selectObjective } from "../_shared/tactical-margem.ts";
-import { inicioDiaOperacional } from "../_shared/dia-operacional.ts";
+import { inicioDaJanelaFila } from "../_shared/tactical-fila.ts";
 import {
-  ehJaGeradoHojeDaRpc,
+  ehJaNaFilaDaRpc,
   ehSkipLegitimoDaRpc,
   extrairToolUseUnico,
   MAX_TOKENS,
@@ -149,16 +149,26 @@ Deno.serve(async (req) => {
       const admin = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!, { auth: { persistSession: false } });
       const { customerId, farmerId } = body;
 
-      // Idempotência: pula se já há plano 'gerado' no DIA OPERACIONAL (BRT), não no dia UTC.
-      // Era `>= 00:00 UTC` e errava nos DOIS sentidos (incidente 2026-07-21/22, 30 duplicatas):
-      // run às 22:48 BRT não via o das 19:03 do mesmo dia; e o cron das 05:00 BRT do dia
-      // seguinte via o da véspera e pulava o dia inteiro. Ver _shared/dia-operacional.ts.
-      const hojeIso = inicioDiaOperacional(new Date());
+      // Idempotência: pula se o cliente JÁ TEM plano aberto na JANELA da fila (7 dias), não
+      // apenas no dia de hoje. Ver _shared/tactical-fila.ts.
+      //
+      // Era o DIA OPERACIONAL (BRT) — que consertou as 30 duplicatas do mesmo dia do incidente
+      // 2026-07-21/22, mas deixava o cliente voltar a ser candidato na madrugada seguinte. Com
+      // o batch rodando diariamente, isso virou uma cópia por dia: medido em 2026-08-08, a fila
+      // viva tinha 169 planos para 35 clientes, 14 deles com 7 cópias cada, e 23 dos 25 planos
+      // de 07/08 eram regeração. A pergunta certa não é "já gerei hoje?" e sim "este cliente já
+      // está na fila de alguém?" — enquanto estiver, outro plano só produz cópia.
+      //
+      // A janela é DESLIZANTE e não depende do cron de expiração ter rodado (mesma decisão que
+      // a fase 1 tomou no front): plano velho demais deixa de bloquear mesmo que ainda esteja
+      // com status 'gerado', senão um cron morto congelaria a geração inteira.
+      const desdeIso = inicioDaJanelaFila(new Date());
       const { data: existente } = await admin.from('farmer_tactical_plans')
         .select('id').eq('farmer_id', farmerId).eq('customer_user_id', customerId)
-        .eq('status', 'gerado').gte('created_at', hojeIso).limit(1);
+        // `generated_at`: mesma coluna do recorte da tela, do cron de expiração e da RPC.
+        .eq('status', 'gerado').gte('generated_at', desdeIso).limit(1);
       if (existente?.length) {
-        return new Response(JSON.stringify({ id: existente[0].id, skipped: 'ja_gerado_hoje' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+        return new Response(JSON.stringify({ id: existente[0].id, skipped: 'ja_na_fila' }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
       }
 
       // Pares da carteira do dono para o cluster de margem. TRÊS correções vs. a versão
@@ -424,7 +434,7 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
       });
       if (rpcErr) {
         console.error('criar_plano_tatico falhou', body.customerId, rpcErr.message);
-        // A TRAVA DE IDEMPOTÊNCIA PEGOU. O `ja_gerado_hoje` do começo do handler é um
+        // A TRAVA DE IDEMPOTÊNCIA PEGOU. O `ja_na_fila` do começo do handler é um
         // check-then-insert: dois batches simultâneos consultam antes de qualquer insert,
         // ambos pagam a chamada à Anthropic e ambos inserem (o `FOR UPDATE` da RPC trava a
         // carteira, mas ela não repetia o teste de existência e não havia índice único).
@@ -432,8 +442,8 @@ ${JSON.stringify(historicalObjections || [], null, 2)}`;
         // já gasto vira um skip honesto em vez de um http_500 que o lote contaria como erro.
         // Motivo PRÓPRIO (não `rpc_race`): o relatório precisa distinguir "a trava funcionou"
         // de "a carteira mudou no meio da geração".
-        if (ehJaGeradoHojeDaRpc(rpcErr.message)) {
-          return new Response(JSON.stringify({ skipped: 'ja_gerado_hoje', detail: rpcErr.message }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
+        if (ehJaNaFilaDaRpc(rpcErr.message)) {
+          return new Response(JSON.stringify({ skipped: 'ja_na_fila', detail: rpcErr.message }), { headers: { ...corsHeaders, 'Content-Type': 'application/json' } });
         }
         // Race de reatribuição / cliente sem dono / cliente mascarado → SKIP legítimo: o
         // próximo ciclo re-lista farmer_client_scores já reconciliado e gera sob o dono

--- a/supabase/functions/generate-tactical-plan/plano-helpers.ts
+++ b/supabase/functions/generate-tactical-plan/plano-helpers.ts
@@ -592,35 +592,44 @@ export const PADROES_SKIP_RPC = [
 
 export function ehSkipLegitimoDaRpc(mensagem: unknown): boolean {
   if (typeof mensagem !== "string") return false;
-  if (ehJaGeradoHojeDaRpc(mensagem)) return false; // motivo PRÓPRIO — ver abaixo
+  if (ehJaNaFilaDaRpc(mensagem)) return false; // motivo PRÓPRIO — ver abaixo
   const m = mensagem.toLowerCase();
   return PADROES_SKIP_RPC.some((p) => m.includes(p));
 }
 
 /**
- * Recusa da RPC por JÁ EXISTIR plano do dia — a trava de idempotência funcionando.
+ * Recusa da RPC por o cliente JÁ TER plano aberto na fila — a trava de idempotência funcionando.
  *
  * POR QUE É UM MOTIVO SEPARADO de `ehSkipLegitimoDaRpc`: os dois são `skipped`, mas o
  * relatório do lote agrega POR MOTIVO (`_shared/tactical-batch-resultado.ts`), e
- * `ja_gerado_hoje` ("a trava pegou") não é `rpc_race` ("a carteira mudou durante a
+ * `ja_na_fila` ("a trava pegou") não é `rpc_race` ("a carteira mudou durante a
  * geração"). Somá-los apagaria justamente o sinal que diz se a idempotência está viva.
  *
- * POR QUE EXISTE: a checagem "já gerei hoje?" do `index.ts` roda ANTES da chamada à
- * Anthropic e é um check-then-insert — dois batches simultâneos consultam antes de
- * qualquer insert, ambos pagam a IA, e ambos inserem. A trava REAL é o índice único
- * parcial + o re-teste dentro da RPC (depois do `FOR UPDATE` de `carteira_assignments`);
- * este predicado é o que converte a recusa do banco em `skipped` honesto em vez de um
- * 500 genérico que o lote contaria como erro.
+ * POR QUE EXISTE: a checagem barata do `index.ts` roda ANTES da chamada à Anthropic e é um
+ * check-then-insert — dois batches simultâneos consultam antes de qualquer insert, ambos
+ * pagam a IA, e ambos inserem. A trava REAL é o índice único parcial + o re-teste dentro da
+ * RPC (depois do `FOR UPDATE` de `carteira_assignments`); este predicado é o que converte a
+ * recusa do banco em `skipped` honesto em vez de um 500 genérico que o lote contaria como erro.
  *
- * Trecho ASCII e exclusivo do ramo certo, pelo mesmo motivo de `PADROES_SKIP_RPC`: a
+ * DOIS PADRÕES, de propósito — o deploy aqui NÃO é atômico (migration pelo SQL Editor, edge
+ * pelo chat do Lovable, em momentos diferentes; docs/agent/deploy.md). Entre um e outro, a
+ * edge nova conversa com a RPC velha ou vice-versa; reconhecer só a mensagem nova faria a
+ * trava antiga voltar como http_500 e o lote contá-la como ERRO durante a janela de deploy.
+ * O padrão "gerado hoje" pode sair deste array depois que a fase 2 estiver aplicada em prod.
+ *
+ * Trechos ASCII e exclusivos do ramo certo, pelo mesmo motivo de `PADROES_SKIP_RPC`: a
  * mensagem em produção tem acento ("Já existe plano tático…") e comparar o pedaço sem
  * acento evita depender de normalização unicode entre o Postgres e o runtime.
  */
-const PADRAO_JA_GERADO_HOJE = "gerado hoje para este cliente";
+const PADROES_JA_NA_FILA = [
+  "aberto na fila para este cliente", // fase 2 — janela da fila
+  "gerado hoje para este cliente", // fase 1 — dia operacional (transição de deploy)
+] as const;
 
-export function ehJaGeradoHojeDaRpc(mensagem: unknown): boolean {
+export function ehJaNaFilaDaRpc(mensagem: unknown): boolean {
   if (typeof mensagem !== "string") return false;
-  return mensagem.toLowerCase().includes(PADRAO_JA_GERADO_HOJE);
+  const m = mensagem.toLowerCase();
+  return PADROES_JA_NA_FILA.some((p) => m.includes(p));
 }
 
 /**

--- a/supabase/functions/generate-tactical-plan/plano-helpers_test.ts
+++ b/supabase/functions/generate-tactical-plan/plano-helpers_test.ts
@@ -7,7 +7,7 @@
 //      genérico gravado com status 'gerado';
 //   2. `Number(null) === 0`: margem/probabilidade não medida virando 0.
 import {
-  ehJaGeradoHojeDaRpc,
+  ehJaNaFilaDaRpc,
   ehSkipLegitimoDaRpc,
   extrairToolUseUnico,
   montarPlano,
@@ -544,37 +544,51 @@ Deno.test("numerosDoBundle: best_individual_lie e SEMPRE null (ninguem o calcula
 });
 
 // ---------------------------------------------------------------------------
-// ehJaGeradoHojeDaRpc — o skip de idempotência vindo do banco
+// ehJaNaFilaDaRpc — o skip de idempotência vindo do banco
 // ---------------------------------------------------------------------------
 
 // VERBATIM da mensagem que `criar_plano_tatico` levanta — mantida igual à da migration
-// 20260802130000_tactical_plan_idempotencia_dia.sql. Se a migration mudar o texto, este
+// 20260808_tactical_plan_idempotencia_janela.sql. Se a migration mudar o texto, este
 // teste é o que trava: sem o casamento, a recusa vira `http_500` no relatório do lote.
-const MSG_RPC_DUPLICATA =
+const MSG_RPC_JA_NA_FILA =
+  "Já existe plano tático aberto na fila para este cliente (janela de 7 dias)";
+
+// A mensagem da fase 1, que a RPC ainda levanta ENQUANTO a migration da fase 2 não for
+// aplicada. O deploy não é atômico (migration pelo SQL Editor, edge pelo chat do Lovable),
+// então as duas convivem durante a janela — ver PADROES_JA_NA_FILA.
+const MSG_RPC_FASE1 =
   "Já existe plano tático gerado hoje para este cliente (dia operacional BRT)";
 
-Deno.test("ehJaGeradoHojeDaRpc: reconhece a recusa da RPC por plano ja gerado hoje", () => {
+Deno.test("ehJaNaFilaDaRpc: reconhece a recusa da RPC por plano ja aberto na fila", () => {
   // Casado por trecho ASCII (sem acento) pelo mesmo motivo de PADROES_SKIP_RPC — mas a
   // mensagem ACENTUADA de produção é a que precisa passar, então é ela que o assert usa.
-  assert(ehJaGeradoHojeDaRpc(MSG_RPC_DUPLICATA), "deveria reconhecer a recusa por duplicata do dia");
+  assert(ehJaNaFilaDaRpc(MSG_RPC_JA_NA_FILA), "deveria reconhecer a recusa por plano na fila");
   assert(
-    ehJaGeradoHojeDaRpc("Ja existe plano tatico gerado hoje para este cliente (dia operacional BRT)"),
+    ehJaNaFilaDaRpc("Ja existe plano tatico aberto na fila para este cliente (janela de 7 dias)"),
     "a variante sem acento tambem tem de casar (normalizacao unicode do driver)",
   );
 });
 
-Deno.test("ehJaGeradoHojeDaRpc: NAO confunde com os outros skips nem com erro real", () => {
-  // Discriminador: se casar largo demais, um erro de infra vira "pulei de propósito"
-  // e o lote reporta ok:true sem ter gravado (a classe do incidente de 2026-07-21).
-  assertEquals(ehJaGeradoHojeDaRpc("Cliente x sem dono de carteira"), false);
-  assertEquals(ehJaGeradoHojeDaRpc("canceling statement due to statement timeout"), false);
-  assertEquals(ehJaGeradoHojeDaRpc(null), false);
-  assertEquals(ehJaGeradoHojeDaRpc(undefined), false);
+Deno.test("ehJaNaFilaDaRpc: ainda reconhece a mensagem da fase 1 (deploy nao-atomico)", () => {
+  // Entre o deploy da edge e o apply da migration, a RPC em prod ainda fala a mensagem
+  // antiga. Sem este casamento a trava voltaria como http_500 e o lote a contaria como
+  // ERRO — um falso alarme de quebra justamente durante a janela de deploy.
+  assert(ehJaNaFilaDaRpc(MSG_RPC_FASE1), "a mensagem da fase 1 tem de continuar casando");
 });
 
-Deno.test("ehJaGeradoHojeDaRpc: a duplicata do dia NAO entra no skip de race de posse", () => {
+Deno.test("ehJaNaFilaDaRpc: NAO confunde com os outros skips nem com erro real", () => {
+  // Discriminador: se casar largo demais, um erro de infra vira "pulei de propósito"
+  // e o lote reporta ok:true sem ter gravado (a classe do incidente de 2026-07-21).
+  assertEquals(ehJaNaFilaDaRpc("Cliente x sem dono de carteira"), false);
+  assertEquals(ehJaNaFilaDaRpc("canceling statement due to statement timeout"), false);
+  assertEquals(ehJaNaFilaDaRpc(null), false);
+  assertEquals(ehJaNaFilaDaRpc(undefined), false);
+});
+
+Deno.test("ehJaNaFilaDaRpc: a trava da fila NAO entra no skip de race de posse", () => {
   // Os dois são `skipped`, mas com motivos DIFERENTES no relatório do lote
-  // (`ja_gerado_hoje` vs `rpc_race`) — misturá-los apaga a distinção entre
+  // (`ja_na_fila` vs `rpc_race`) — misturá-los apaga a distinção entre
   // "a trava funcionou" e "a carteira mudou no meio".
-  assertEquals(ehSkipLegitimoDaRpc(MSG_RPC_DUPLICATA), false);
+  assertEquals(ehSkipLegitimoDaRpc(MSG_RPC_JA_NA_FILA), false);
+  assertEquals(ehSkipLegitimoDaRpc(MSG_RPC_FASE1), false);
 });

--- a/supabase/functions/tactical-plans-batch/index.ts
+++ b/supabase/functions/tactical-plans-batch/index.ts
@@ -1,7 +1,7 @@
 // supabase/functions/tactical-plans-batch/index.ts
 //
 // Cron noturno que, para cada vendedora (farmer) com carteira, seleciona o
-// top-25 dos clientes por priority_score que passam no gate de R$/h e dispara
+// top-N dos clientes por priority_score que passam no gate de R$/h e dispara
 // a pré-geração do plano tático chamando generate-tactical-plan no modo
 // self-contained. Idempotência fica na edge alvo (skipped: 'ja_gerado_hoje').
 //
@@ -9,8 +9,11 @@
 //   profitPerHora = ((rev > 0 ? rev : avg) * (margin / 100) * 0.1) / (15 / 60)
 //   Threshold: R$ 50/h.
 //
-// Semântica top-N: filtra o gate ANTES de cortar no TOP_25 — pega os 25 de
-// maior priority DENTRE os que passam (não os 25 de maior priority e filtra depois).
+// Semântica top-N: filtra o gate E a fila aberta ANTES de cortar no TOP_N — pega os N de
+// maior priority DENTRE os que passam (não os N de maior priority e filtra depois). Com
+// TOP_N pequeno essa ordem deixou de ser refinamento e virou requisito: filtrar a fila
+// depois do corte escolheria todo dia os mesmos N, que a idempotência pularia, e o cliente
+// N+1 nunca entraria — fila congelada com aparência de funcionamento.
 //
 // Ordem de EXECUÇÃO: round-robin entre farmers (_shared/tactical-ordem.ts), não a
 // concatenação dos grupos. Cobertura parcial é rotina (timeout/429/402) e sempre come o
@@ -76,8 +79,15 @@ import {
   rotacaoDoDia,
 } from '../_shared/tactical-ordem.ts';
 import { inicioDiaOperacional } from '../_shared/dia-operacional.ts';
+import { inicioDaJanelaFila } from '../_shared/tactical-fila.ts';
+import { mensagemDeErro } from '../_shared/erro-mensagem.ts';
 
-const TOP_N = 25;
+// TOP_N é a taxa de entrada de clientes NOVOS por vendedora por dia — não o tamanho da fila.
+// Com a janela de 7 dias (tactical-fila.ts), a fila estabiliza em TOP_N × 7 por vendedora:
+// 2/dia ⇒ ~14 cartões, que é o que cabe numa semana de venda consultiva B2B (calibrado com o
+// founder em 2026-08-08). Era 25 — que somado à regeração diária produzia 169 planos vivos
+// para 35 clientes. Para mudar o tamanho da fila, mexa AQUI, não na janela.
+const TOP_N = 2;
 const CONCURRENCY = 5; // cada chamada faz 1 LLM (~3-5s); 5 em paralelo ~5s/chunk
 
 // Ausente ≠ zero (money-path): revenue_potential nunca teve writer — NULL em 6.633/6.633
@@ -203,14 +213,72 @@ Deno.serve(async (req) => {
     );
   }
 
-  // 2. Por farmer: ordena por priority desc, filtra gate R$/h, corta em TOP_N.
-  //    Semântica: pega os 25 de maior priority DENTRE os que passam no gate.
+  // 1b. FILA ABERTA: quem já tem plano dentro da janela não volta a disputar vaga.
+  //     Sem isto, o batch regenerava o mesmo cliente todo dia — a idempotência só cobria o DIA
+  //     operacional, então na madrugada seguinte o cliente era candidato de novo. Medido em prod
+  //     (2026-08-08): 23 dos 25 planos de 07/08 eram regeração; a fila viva tinha 169 planos para
+  //     35 clientes, 14 deles com 7 cópias — uma por dia da janela. E dos 174 clientes que passam
+  //     no gate de R$/h, 97 NUNCA tinham recebido plano: a cota diária inteira ia para repetição.
+  //
+  //     Chave (farmer, customer), igual à da RPC criar_plano_tatico: cliente reatribuído precisa
+  //     de plano sob o dono NOVO, e uma chave só por customer o deixaria bloqueado pelo plano do
+  //     dono antigo.
+  //
+  //     Falha ALTO, como os passos 0 e 1: seguir com a fila vazia não degrada — RESSUSCITA a
+  //     duplicata que este passo existe para remover, e em silêncio.
+  const filaPorFarmer = new Map<string, Set<string>>();
+  try {
+    const desdeIso = inicioDaJanelaFila(new Date());
+    const abertos = await fetchAll<{ farmer_id: string; customer_user_id: string }>(
+      (from, to) => supabase
+        .from('farmer_tactical_plans')
+        .select('farmer_id, customer_user_id')
+        .eq('status', 'gerado')
+        // `generated_at`, a MESMA coluna do recorte da tela (useTacticalPlan.ts) e do cron
+        // expirar_planos_taticos. "Estar na fila" precisa ter uma definição só: filtrar por
+        // created_at aqui e generated_at lá faria as pontas discordarem se as duas colunas
+        // divergissem (hoje são idênticas nas 533 linhas, mas isso é acidente, não garantia).
+        // O COALESCE fail-closed contra data nula vive na RPC — aqui é filtro de ECONOMIA
+        // (evitar a chamada paga à IA), não a fronteira; o caso patológico que escapar daqui
+        // é recusado lá e vira skip honesto.
+        .gte('generated_at', desdeIso)
+        .order('id', { ascending: true }) // PK ⇒ ordem total, estável entre páginas
+        .range(from, to),
+      'fila aberta de planos táticos',
+    );
+    for (const p of abertos) {
+      const s = filaPorFarmer.get(p.farmer_id) ?? new Set<string>();
+      s.add(p.customer_user_id);
+      filaPorFarmer.set(p.farmer_id, s);
+    }
+  } catch (e) {
+    // `mensagemDeErro`, não `instanceof Error ? … : String(e)`: o erro que chega aqui vem do
+    // supabase-js, que no caminho sem `.throwOnError()` devolve um objeto PLANO — e `String()`
+    // nele rende "[object Object]", apagando a mensagem que diria se foi timeout, RLS ou rede.
+    // O gate estrutural erro-object-object-gate (classe #1642) vigia isso por CONTAGEM por
+    // arquivo; as 2 ocorrências antigas deste arquivo são dívida baselinada, e sítio novo não
+    // pode aumentá-la.
+    return new Response(
+      JSON.stringify({ ok: false, error: mensagemDeErro(e) ?? 'falha ao ler a fila aberta de planos táticos' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
+  // 2. Por farmer: ordena por priority desc, tira quem já está na fila, filtra gate R$/h,
+  //    corta em TOP_N. Semântica: os TOP_N de maior priority DENTRE os que passam no gate
+  //    e ainda NÃO têm plano aberto.
   const carteiras: CarteiraFarmer[] = [];
   let semMargemIndecidivel = 0;
+  let jaNaFila = 0;
 
   for (const [farmer, scores] of porFarmer) {
-    const { selecionados, semMargem } = selecionarParaPregeracao(scores, TOP_N);
+    const { selecionados, semMargem, naFila } = selecionarParaPregeracao(
+      scores,
+      TOP_N,
+      filaPorFarmer.get(farmer) ?? new Set<string>(),
+    );
     semMargemIndecidivel += semMargem.length;
+    jaNaFila += naFila.length;
     carteiras.push({ farmer, clientes: selecionados.map((s) => s.customer) });
   }
 
@@ -275,9 +343,24 @@ Deno.serve(async (req) => {
       // "cobri todo mundo" sem ter coberto (money-path — no silent caps).
       mascarados_ignorados: mascaradosIgnorados,
       // clientes que saíram do ranking por FALTA DE MARGEM (gate indecidível), não por
-      // reprovação no gate. Enquanto nenhum writer calcular gross_margin_pct, este número
-      // tende ao total da carteira — e é o sinal de que o batch está cego, não ocioso.
+      // reprovação no gate. NÃO é disjunto de `ja_na_fila`: é contado sobre a carteira toda
+      // de propósito, para que encher a fila não o faça "melhorar" sozinho.
+      //
+      // ⚠️ NÃO leia este número como "o batch está cego" — a versão anterior deste comentário
+      // dizia isso, e a medição desmente. Cruzamento em prod (2026-08-08, 6.633 scores):
+      //     compra nos 180d + margem: 405  |  compra sem margem:   1
+      //     sem compra      + margem: 670  |  sem compra, s/margem: 5.557
+      // O writer de gross_margin_pct FUNCIONA — cobre 405 dos 406 clientes com compra (99,8%).
+      // O número é alto porque a carteira é ~94% INATIVA, e sem compra nos 180 dias não há
+      // margem a calcular. Ausência honesta, não writer quebrado. Tratá-la como bug levaria a
+      // "consertar" um writer que está certo; o que este número mede é o tamanho do pool vivo.
       sem_margem_indecidivel: semMargemIndecidivel,
+      // clientes que não disputaram vaga por JÁ TEREM plano aberto na janela. Antes eram
+      // regerados e viravam cópia; agora são pulados ANTES da chamada paga à IA. Publicado
+      // porque um corte silencioso leria como "não havia mais ninguém" (money-path: no
+      // silent caps) — e porque é este número que mostra a fila circulando: ele sobe
+      // enquanto a fila enche e cai conforme os planos expiram ou são concluídos.
+      ja_na_fila: jaNaFila,
     }),
     { headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
   );

--- a/supabase/migrations/20260808020000_tactical_plan_idempotencia_janela.sql
+++ b/supabase/migrations/20260808020000_tactical_plan_idempotencia_janela.sql
@@ -1,0 +1,161 @@
+-- ============================================================
+-- criar_plano_tatico — a idempotência passa do DIA para a JANELA da fila (PTPL, fase 2)
+--
+-- PROBLEMA (medido em prod via psql-ro, 2026-08-08):
+--   A trava perguntava "já gerei para este cliente HOJE?" (dia operacional BRT). Ela
+--   consertou as 30 duplicatas do MESMO dia do incidente 2026-07-21/22, mas deixava o
+--   cliente voltar a ser candidato na madrugada seguinte. Com o batch rodando todo dia,
+--   isso virou uma cópia por dia:
+--     · 533 planos gerados desde 21/07 para apenas 80 clientes DISTINTOS
+--     · fila viva: 169 planos `gerado` para 35 clientes — 14 deles com 7 cópias cada,
+--       uma por dia da janela (a vendedora abre a tela e vê o mesmo cliente 7 vezes)
+--     · em 07/08, 23 dos 25 planos do dia eram regeração; em 05/08 e 31/07, 25 de 25
+--     · dos 174 clientes que passam o gate de R$/h, 97 NUNCA receberam plano — a cota
+--       diária inteira ia para repetição, e o resto da carteira nunca era alcançado
+--
+-- A pergunta certa não é "já gerei hoje?" e sim "este cliente já está na fila de alguém?".
+-- Enquanto o plano estiver aberto, outro plano para o mesmo cliente só produz cópia.
+-- Quando ele sai (expirado pelo cron `expirar-planos-taticos` da fase 1, ou concluído),
+-- o cliente volta a ser candidato — é isso que faz a fila CIRCULAR em vez de entupir.
+--
+-- RELAÇÃO COM O ÍNDICE ÚNICO `ux_farmer_tactical_plans_dia_operacional`: a janela CONTÉM
+-- o dia, então esta RPC passa a ser estritamente MAIS restritiva que o índice. O sentido
+-- importa — a versão anterior avisava que divergir faria a RPC "autorizar o que o índice
+-- depois recusaria com 23505 cru". Aqui a divergência é no sentido seguro: tudo que a RPC
+-- autoriza, o índice também autoriza. O índice segue como rede final para corridas do
+-- mesmo dia e NÃO precisa mudar.
+--
+-- JANELA = 7 dias, o mesmo número de outros TRÊS lugares. Ao mudar, mude todos:
+--   · src/hooks/useTacticalPlan.ts:238            JANELA_FILA_DIAS (o recorte da tela)
+--   · supabase/functions/_shared/tactical-fila.ts JANELA_FILA_DIAS (o filtro do batch)
+--   · expirar_planos_taticos(_dias => 7)          o cron que expira
+-- Janela AQUI maior que a da tela = cliente sai de vista mas segue bloqueado (buraco
+-- silencioso). Menor = a duplicata volta.
+--
+-- Preflight feito: `pg_get_functiondef` da PROD lido em 2026-08-08 antes de escrever este
+-- REPLACE (apply manual diverge do repo — docs/agent/database.md). Esta versão é a de
+-- produção com o bloco de idempotência trocado; nenhuma outra linha foi alterada.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.criar_plano_tatico(_customer_user_id uuid, _expected_owner uuid, _payload jsonb)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  _uid        uuid    := auth.uid();
+  _is_service boolean := COALESCE(auth.role() = 'service_role', false);
+  _owner      uuid;
+  _eligible   boolean;
+  _rec        public.farmer_tactical_plans;
+  _new_id     uuid;
+  -- Janela da fila. `constant` porque não é configurável em runtime: mudá-la sem mudar as
+  -- outras três pontas produz buraco ou duplicata (ver cabeçalho).
+  _janela_dias constant integer := 7;
+BEGIN
+  IF NOT _is_service THEN
+    IF _uid IS NULL THEN
+      RAISE EXCEPTION 'Não autenticado' USING ERRCODE = '42501';
+    END IF;
+    IF NOT private.carteira_visivel_para(_customer_user_id, _uid) THEN
+      RAISE EXCEPTION 'Cliente fora da sua carteira' USING ERRCODE = '42501';
+    END IF;
+    -- [Codex #4] chamador autenticado NÃO pode pular o race-check passando NULL.
+    IF _expected_owner IS NULL THEN
+      RAISE EXCEPTION 'expected_owner é obrigatório para chamador autenticado (race-check da posse)';
+    END IF;
+  END IF;
+
+  -- [Codex #3] FOR UPDATE: trava a linha de carteira_assignments deste cliente até o commit.
+  -- [#1422] `eligible` sai do MESMO SELECT travado — ler a máscara fora do lock reabriria o
+  -- race pelo outro lado (mascarar concorrente entre a checagem e o INSERT).
+  SELECT a.owner_user_id, a.eligible INTO _owner, _eligible
+  FROM public.carteira_assignments a
+  WHERE a.customer_user_id = _customer_user_id
+  FOR UPDATE;
+
+  IF _owner IS NULL THEN
+    RAISE EXCEPTION 'Cliente % sem dono de carteira', _customer_user_id;
+  END IF;
+
+  -- [#1422 — máscara eligible] Fail-closed p/ TODO caller, inclusive service_role e master.
+  IF _eligible IS NOT TRUE THEN
+    RAISE EXCEPTION 'Cliente % está mascarado na carteira (eligible) — plano tático não é materializado', _customer_user_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF _expected_owner IS NOT NULL AND _owner <> _expected_owner THEN
+    RAISE EXCEPTION 'Carteira do cliente % foi reatribuída durante a geração (dono atual diverge do esperado)', _customer_user_id;
+  END IF;
+
+  _rec := jsonb_populate_record(NULL::public.farmer_tactical_plans, _payload);
+
+  -- [#1618-followup — idempotência] O teste de existência do caller é check-then-insert e
+  -- roda ANTES da chamada paga à IA: dois batches simultâneos passam os dois. Aqui já
+  -- seguramos o lock de carteira_assignments deste cliente, então os concorrentes estão
+  -- serializados e o perdedor enxerga a linha do vencedor (READ COMMITTED: este SELECT
+  -- usa um snapshot posterior à espera pelo lock).
+  --
+  -- [fase 2] A chave passou do DIA para a JANELA: qualquer plano ABERTO do mesmo cliente,
+  -- dentro dos últimos _janela_dias, bloqueia. Ver o cabeçalho para a medição.
+  --
+  -- COALESCE(..., now()): `generated_at` e `created_at` são nullable (default now()), e
+  -- `coluna >= x` com NULL é NULL — numa TRAVA isso é fail-OPEN, e o plano de data
+  -- desconhecida deixaria de bloquear em silêncio. Com o COALESCE, data ausente conta como
+  -- agora, ou seja, dentro da janela: o caso indecidível RECUSA em vez de autorizar.
+  -- (Hoje 0 de 533 linhas têm qualquer uma das duas nula — o guard é para não depender disso.)
+  IF EXISTS (
+    SELECT 1 FROM public.farmer_tactical_plans p
+     WHERE p.farmer_id = _owner
+       AND p.customer_user_id = _customer_user_id
+       AND p.status = 'gerado'
+       AND COALESCE(p.plan_type, 'essencial') = COALESCE(_rec.plan_type, 'essencial')
+       AND COALESCE(p.generated_at, p.created_at, now()) >= now() - make_interval(days => _janela_dias)
+  ) THEN
+    RAISE EXCEPTION 'Já existe plano tático aberto na fila para este cliente (janela de % dias)', _janela_dias
+      USING ERRCODE = '23505';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.farmer_tactical_plans (
+      farmer_id, customer_user_id, status,
+      bundle_recommendation_id, health_score, churn_risk, mix_gap,
+      current_margin_pct, cluster_avg_margin_pct, expansion_potential,
+      strategic_objective, customer_profile, plan_type,
+      top_bundle, second_bundle, bundle_lie, bundle_probability, bundle_incremental_margin,
+      best_individual_lie, diagnostic_questions, implication_question, offer_transition,
+      probable_objections, approach_strategy, approach_strategy_b,
+      ltv_projection, expected_result, operational_risks
+    ) VALUES (
+      _owner, _customer_user_id, 'gerado',
+      _rec.bundle_recommendation_id, _rec.health_score, _rec.churn_risk, _rec.mix_gap,
+      _rec.current_margin_pct, _rec.cluster_avg_margin_pct, _rec.expansion_potential,
+      COALESCE(_rec.strategic_objective, 'expansao_mix'),
+      COALESCE(_rec.customer_profile, 'misto'),
+      COALESCE(_rec.plan_type, 'essencial'),
+      COALESCE(_rec.top_bundle, '{}'::jsonb), COALESCE(_rec.second_bundle, '{}'::jsonb),
+      _rec.bundle_lie, _rec.bundle_probability, _rec.bundle_incremental_margin,
+      _rec.best_individual_lie,
+      COALESCE(_rec.diagnostic_questions, '[]'::jsonb), _rec.implication_question, _rec.offer_transition,
+      COALESCE(_rec.probable_objections, '[]'::jsonb), _rec.approach_strategy, _rec.approach_strategy_b,
+      _rec.ltv_projection, _rec.expected_result, COALESCE(_rec.operational_risks, '[]'::jsonb)
+    )
+    RETURNING id INTO _new_id;
+  EXCEPTION WHEN unique_violation THEN
+    -- Rede final: qualquer caminho que escape do EXISTS acima (writer futuro, corrida que o
+    -- lock não cubra) fala a MESMA língua, e o caller a lê como skip em vez de erro de infra.
+    -- O índice único só cobre o DIA, então esta mensagem continua sendo a do caso "mesmo dia";
+    -- o predicado da edge (ehJaNaFilaDaRpc) casa as duas redações.
+    RAISE EXCEPTION 'Já existe plano tático aberto na fila para este cliente (janela de % dias)', _janela_dias
+      USING ERRCODE = '23505';
+  END;
+
+  RETURN _new_id;
+END;
+$function$;
+
+-- A RPC é a FRONTEIRA (SECURITY DEFINER bypassa RLS). O grant permanece como estava: o
+-- chamador autenticado passa pelo gate de carteira no topo da função; service_role/cron
+-- entra pelo ramo `_is_service`. Este REPLACE não altera privilégio nenhum — e, por não
+-- mudar a assinatura, não cria sobrecarga que deixasse a versão velha viva em paralelo.


### PR DESCRIPTION
Fase 2 da fila do Plano Tático. A [fase 1](https://github.com/LucasSardenbergL/afiacao/pull/1693) deu **saída** à fila; esta fecha a **entrada** — e a causa não era a que a fase 1 previa.

## A hipótese herdada estava certa no sintoma e errada na causa

O handoff apontava o `TOP_N = 25` da edge como origem do volume. Duas medições desmontaram isso:

1. **`TOP_N` é por FARMER, não global.** O loop chama `selecionarParaPregeracao` uma vez por carteira: o teto seria 9+25+25 = 59 alvos/dia, e a produção real é ~25. O `TOP_N` **nunca foi o limitante**.
2. **95% da geração diária era repetição.** Dos 25 planos de 07/08, **23** eram de cliente que já tinha plano nos 7 dias anteriores. Em 05/08 e 31/07: **25 de 25**.

## Medido em prod (psql-ro, 2026-08-08)

| Fato | Valor |
|---|---|
| 533 planos desde 21/07 ⇒ clientes **distintos** | **80** |
| Fila viva (169 `gerado`) ⇒ clientes | **35** — 14 deles com **7 cópias** cada |
| Candidatos que passam o gate de R$/h | 174 — **97 nunca receberam plano** |
| `gross_margin_pct` preenchido | 1.075 de 6.633 (16%) |

A vendedora não via "10 clientes por dia". Via **o mesmo cliente sete vezes** — uma cópia por dia da janela — enquanto 97 clientes elegíveis nunca eram alcançados.

## A causa: a trava media o DIA, a fila mede a JANELA

`criar_plano_tatico` perguntava *"já gerei para este cliente **hoje**?"*. Isso consertou as 30 duplicatas do mesmo dia do incidente 2026-07-21/22 e estava **correto para aquele bug**. Mas com o batch rodando diariamente, o cliente voltava a ser candidato toda madrugada: a trava casava com o ciclo do **produtor**, não com o do **consumidor**.

A pergunta certa é *"este cliente já está na fila de alguém?"*. Enquanto o plano estiver aberto, outro só produz cópia; quando sai (expirado pelo cron da fase 1, ou concluído), o cliente volta ao pool — é isso que faz a fila **circular**.

## A correção

1. **RPC (fronteira)** — bloqueia por plano `gerado` dentro da janela de 7 dias. `COALESCE(generated_at, created_at, now())` porque as colunas são nullable e `coluna >= x` com NULL é NULL: numa trava isso é fail-**open**, e a linha de dado defeituoso deixaria de bloquear em silêncio. Indecidível **recusa**.
2. **Edges (economia)** — o batch lê a fila aberta e exclui esses clientes **antes** do corte do top-N; `generate-tactical-plan` pula sem chamar a IA. Novo contador `ja_na_fila` no resumo.
3. **`TOP_N` 25 → 2** — com o dedupe ele deixa de ser "tamanho do lote" e vira **taxa de entrada**: a fila estabiliza em `TOP_N × 7` ⇒ **~14 por vendedora** (calibrado com o founder).

### O detalhe que quase virou um bug pior

Com `TOP_N` pequeno, **a ordem das operações é tudo**. Se o filtro de "já na fila" rodasse *depois* do `slice(topN)`, o batch escolheria todo dia os mesmos 2 de maior priority, a idempotência os pularia, e o cliente da posição 3 **nunca entraria** — fila congelada com aparência de funcionamento. Por isso `jaNaFila` é parâmetro do oráculo, não filtro no call-site: a invariante fica testada nos dois espelhos.

Pelo mesmo motivo `semMargem` continua contado sobre a carteira **inteira**, sobrepondo-se a `naFila` — ele mede a cegueira do batch, e excluir quem está na fila faria a cegueira "melhorar" só por a fila ter enchido.

### O gate de R$/h NÃO subiu, e a medição é o motivo

A pergunta em aberto era se `PROFIT_PER_HOUR_THRESHOLD` (50) deveria subir junto. Medido: os top-5 por priority de cada carteira já têm **R$/h entre 52 e 14.513**. Com `TOP_N = 2` quem entra passa folgado — subir a régua mexeria numa fronteira de negócio sem mudar resultado nenhum.

## Prova

`db/test-tactical-idempotencia-janela.sh` — **PG17, 18 asserts, 3 falsificações**, exit 0.

O par que importa é **A2** (plano de 3 dias bloqueia) + **A3** (plano de 8 dias volta a gerar): sozinho, o A2 seria satisfeito por uma trava permanente, que troca *entope* por *congela*.

- **F1** restaura a trava da fase 1 → exige A2 **vermelho**
- **F2** remove o `COALESCE` → exige A8 (`generated_at` NULL) **vermelho**
- **F3** estica a janela para 365 dias → exige A3 **vermelho** (sem ela, o A3 provaria apenas "existe algum plano", não a janela)

Também: `deno test` dos módulos tocados (112 + 16 testes, exit 0) e `edges:typecheck` (exit 0, 0 erros de classe-crash).

### `_shared/erro-mensagem.ts` — o gate #1642 pegou, e estava certo

O primeiro CI reprovou no `erro-object-object-gate`: meu `catch` novo usava `e instanceof Error ? e.message : String(e)`, copiado dos passos vizinhos da mesma edge. O gate conta **por arquivo** e crescer reprova — e o motivo dele se aplica exatamente aqui: o `error` do supabase-js é objeto **plano**, e `String()` nele rende `"[object Object]"`, apagando se foi timeout, RLS ou rede.

A saída não foi subir a baseline nem renomear a variável para driblar o regex (o anti-padrão que o próprio gate documenta), e sim criar o **`supabase/functions/_shared/erro-mensagem.ts`** — espelho verbatim de `src/lib/erro-mensagem.ts` — que o comentário de `A_DIVIDA` já pedia: *"as ~93 edges Deno […] precisam de um `_shared/erro-mensagem.ts` próprio"*. `tactical-plans-batch/index.ts` volta às 2 ocorrências da baseline.

O gate ganhou `HELPERS` (set de dois caminhos) no lugar de `HELPER`, porque a isenção de `String(err)` precisa valer para o espelho de edge também — Deno não importa de `src/`. A isenção vale para o arquivo inteiro, então os dois helpers ficam pequenos e sem outra lógica.

Isso **não** migra as ~93 edges da dívida; só cria a ferramenta que permite ela encolher e impede que ela cresça por este PR.

## Deploy — 2 passos manuais, nesta ordem

Merge na main **não** aplica nenhum dos dois:

1. 🗄️ **SQL Editor** — `supabase/migrations/20260808020000_tactical_plan_idempotencia_janela.sql`
2. 💬 **chat do Lovable** — deploy das edges `tactical-plans-batch` **e** `generate-tactical-plan`

A ordem é flexível: o predicado `ehJaNaFilaDaRpc` casa **as duas redações** da RPC de propósito, porque o deploy não é atômico — reconhecer só a nova faria a trava voltar como `http_500` e o lote contá-la como **erro** durante a janela entre os dois passos.

Depois do merge, conferir que o sync bidirecional do Lovable não atropelou o arquivo:

```
git log -S 'inicioDaJanelaFila' -- supabase/functions/tactical-plans-batch/index.ts
```

## Como medir o efeito

```sql
SELECT created_at::date AS dia, count(*) AS planos,
       count(DISTINCT customer_user_id) AS clientes
FROM farmer_tactical_plans GROUP BY 1 ORDER BY 1 DESC LIMIT 7;
```

Esperado após o deploy: `planos ≈ clientes` (hoje é 25 planos para ~7 clientes novos) e o total diário caindo de ~25 para ~6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
