### PR TITLE
fix(farmer): calculate-scores para de fabricar zero de decisão — o WRITER da família [money-path]

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -2520,3 +2520,53 @@ describe('guardrail money-path: visit-score-recalc-client não coage score de mi
     expect(coercoesSemWriterVisitScore(semComentarios(prosa))).toEqual([]);
   });
 });
+
+// ── Guard money-path: a renormalização de calculate-scores é um módulo TESTÁVEL, não inline ──
+// `priority_score` e `health_score` são calculados dentro do laço de `calculate-scores/index.ts`,
+// que importa `npm:@supabase/supabase-js` — e `test:edges` roda com `--no-remote`. Enquanto a
+// aritmética morou lá, ela era estruturalmente inalcançável por teste de comportamento e só um gate
+// de FONTE a vigiava; gate de fonte pega a reintrodução do `|| 0`, não a renormalização feita errado
+// (dividir pelo denominador cheio devolve número plausível e sistematicamente baixo). O módulo
+// `_shared/score-ponderado.ts` existe para tornar isso testável — se alguém reinlinar a conta, o
+// teste de comportamento morre em silêncio, e é isso que este bloco pega.
+const SCORE_PONDERADO = 'supabase/functions/_shared/score-ponderado.ts';
+const CALCULATE_SCORES = 'supabase/functions/calculate-scores/index.ts';
+
+describe('guardrail money-path: calculate-scores renormaliza via módulo testável', () => {
+  const modulo = read(SCORE_PONDERADO);
+  const edge = read(CALCULATE_SCORES);
+
+  it('sentinela: leu os arquivos reais (módulo + edge)', () => {
+    expect(modulo).toContain('export function mediaPonderadaRenormalizada');
+    expect(edge).toContain('calculate-scores');
+  });
+
+  it('PARIDADE: o bloco valor-medido do módulo é IDÊNTICO ao helper de src/', () => {
+    expect(
+      mirrorBlockNamed(modulo, 'valor-medido'),
+      'score-ponderado.ts divergiu de src/lib/scoring/margin.ts — o Lovable reescreveu no deploy?',
+    ).toBe(mirrorBlockNamed(read(MARGIN_HELPER), 'valor-medido'));
+  });
+
+  it('o edge USA o módulo nos DOIS scores (não só o define)', () => {
+    expect(edge, 'calculate-scores parou de importar a renormalização compartilhada').toContain(
+      '../_shared/score-ponderado.ts',
+    );
+    // Duas chamadas: uma para o health, outra para o priority. Uma só significa que um dos dois
+    // scores voltou a somar direto — meio-conserto na mesma função (money-path.md §7).
+    const chamadas = (edge.match(/mediaPonderadaRenormalizada\s*\(/g) ?? []).length;
+    expect(chamadas, 'health e priority precisam AMBOS renormalizar').toBeGreaterThanOrEqual(2);
+    expect(edge, 'o teto do potencial voltou a incluir o não medido').toContain('maximoMedido(');
+  });
+
+  it('o zero fabricado não volta pelo arredondamento nem pela chave omitida', () => {
+    // `Math.round(null)` é 0, e as três colunas de destino são nullable com DEFAULT 0: omitir a
+    // chave faz o Postgres refabricar o mesmo zero. Os dois caminhos precisam do null EXPLÍCITO.
+    for (const campo of ['x_score', 's_score', 'margin_potential_component']) {
+      expect(
+        new RegExp(`${campo}:[^,\\n]*== null \\? null`).test(edge),
+        `${campo} perdeu o null explícito — Math.round(null) grava 0 e o histórico volta a mentir`,
+      ).toBe(true);
+    }
+  });
+});

--- a/src/__tests__/potencial-nao-medido-gate.test.ts
+++ b/src/__tests__/potencial-nao-medido-gate.test.ts
@@ -46,6 +46,12 @@ const CAMPOS = [
   'recuperacao_score',
   'relacionamento_score',
   'prospeccao_score',
+  // Cross-sell e engajamento (2026-08-07): mesma família, mesma medição — 6.633/6.633 NULL em
+  // farmer_client_scores. Entram aqui em PARIDADE com o gate da edge, que passou a vigiar o writer
+  // (`calculate-scores`): fechar só o writer deixaria a porta do front aberta para a reintrodução,
+  // que é o arranjo de dois gates que estes dois arquivos existem para manter.
+  'x_score',
+  's_score',
 ];
 
 /**
@@ -60,7 +66,9 @@ const CAMPOS = [
 function coercoes(codigo: string): string[] {
   const achados: string[] = [];
   for (const campo of CAMPOS) {
-    for (const m of codigo.matchAll(new RegExp(`${campo}[^;\\n]{0,80}?(\\?\\?|\\|\\|)\\s*0`, 'g'))) {
+    // `\b` na abertura é obrigatório desde que `x_score` entrou na lista: sem ele o padrão casa
+    // DENTRO de outro identificador (`max_score || 0`) e o gate reprova código alheio e íntegro.
+    for (const m of codigo.matchAll(new RegExp(`\\b${campo}[^;\\n]{0,80}?(\\?\\?|\\|\\|)\\s*0`, 'g'))) {
       achados.push(m[0]);
     }
   }
@@ -110,6 +118,9 @@ describe('gate: potencial sem writer não é coagido a 0 (src/)', () => {
       // Forma pt-BR real: a reescrita hipotética de useMyVisitSuggestions.ts que este gate existe
       // pra pegar (linhas ~142-145 coagindo o score de volta a 0 no caminho do tooltip).
       'expansao: { score: s.expansao_score ?? 0, insumosAusentes: [] },',
+      // As formas VIVAS que o PR do writer removeu de supabase/functions/calculate-scores/index.ts.
+      'const crossSellScore = Number(client.x_score || 0);',
+      'const engagementScore = Number(client.s_score || 0);',
     ];
     for (const forma of formasReais) {
       expect(coercoes(forma).length, `o detector NÃO pegou: ${forma}`).toBeGreaterThan(0);
@@ -121,6 +132,10 @@ describe('gate: potencial sem writer não é coagido a 0 (src/)', () => {
       'const revenuePotential = valorMedido(score.revenue_potential);',
       'const expansionPotential = valorMedido(score.expansion_score);',
       'expansionPotential: valorMedido(d.expansion_potential),',
+      'x_score: crossSellScore == null ? null : Math.round(crossSellScore),',
+      // Controle da ÂNCORA `\b`: identificador que CONTÉM "x_score" e coage por conta própria não é
+      // deste gate. Sem o `\b` esta linha reprovaria código alheio e íntegro.
+      'const teto = Math.max(...linhas.map(l => l.max_score || 0), 1);',
     ];
     for (const forma of corretas) {
       expect(coercoes(forma), `falso-VERMELHO em código correto: ${forma}`).toEqual([]);

--- a/supabase/functions/_shared/potencial-nao-medido_test.ts
+++ b/supabase/functions/_shared/potencial-nao-medido_test.ts
@@ -39,8 +39,15 @@ function semComentario(linha: string): string {
   return linha.replace(/\/\/.*$/, "");
 }
 
-/** As duas colunas sem writer. Nomes em snake_case (como saem do banco) e camelCase (front). */
-const CAMPOS = ["expansion_score", "revenue_potential"];
+/**
+ * As colunas sem writer. Nomes em snake_case (como saem do banco) e camelCase (front).
+ *
+ * `x_score` (cross-sell) e `s_score` (engajamento) entraram em 2026-08-07: mesma família, mesmo
+ * defeito, e a medição em prod é idêntica à das outras — 6.633/6.633 NULL, 0 zeros, 0 positivos.
+ * `calculate-scores` as relia e regravava com `Number(x || 0)`, o que deixou `health_score_history`
+ * com x=0 e s=0 em 673.790/673.790 linhas, ZERO nulos: o zero fabricado virava histórico.
+ */
+const CAMPOS = ["expansion_score", "revenue_potential", "x_score", "s_score"];
 
 /**
  * Coerção a zero aplicada a um dos campos. Ancorado no NOME da coluna e não na forma do
@@ -54,7 +61,11 @@ const CAMPOS = ["expansion_score", "revenue_potential"];
 function coercoesEmLinha(codigo: string): string[] {
   const achados: string[] = [];
   for (const campo of CAMPOS) {
-    const padrao = new RegExp(`${campo}[^;\\n]{0,80}?(\\?\\?|\\|\\|)\\s*0`, "g");
+    // `\b` na abertura é obrigatório desde que `x_score` entrou na lista: sem ele o padrão casa
+    // DENTRO de outro identificador (`max_score || 0`, `aux_score ?? 0`) e o gate acusa código
+    // alheio — falso-VERMELHO que treina quem lê a suprimir o gate. Provado pelo controle negativo
+    // do par-detector abaixo.
+    const padrao = new RegExp(`\\b${campo}[^;\\n]{0,80}?(\\?\\?|\\|\\|)\\s*0`, "g");
     for (const m of codigo.matchAll(padrao)) achados.push(m[0]);
   }
   return achados;
@@ -67,7 +78,7 @@ function coercoesEmLinha(codigo: string): string[] {
 function numAplicadoACampo(codigo: string): string[] {
   const achados: string[] = [];
   for (const campo of CAMPOS) {
-    for (const m of codigo.matchAll(new RegExp(`\\bnum\\s*\\([^)]*${campo}`, "g"))) achados.push(m[0]);
+    for (const m of codigo.matchAll(new RegExp(`\\bnum\\s*\\([^)]*\\b${campo}`, "g"))) achados.push(m[0]);
   }
   return achados;
 }
@@ -89,6 +100,14 @@ const VIGIADOS: Array<{ rotulo: string; url: URL }> = [
   {
     rotulo: "tactical-plans-batch/index.ts",
     url: new URL("../tactical-plans-batch/index.ts", import.meta.url),
+  },
+  // O WRITER da família, adicionado em 2026-08-07. Os três acima são leitores que montam prompt;
+  // este é quem GRAVA — e enquanto ele coagia, consertar os leitores era enxugar gelo: o zero
+  // fabricado voltava para a tabela a cada run e de lá para o próximo leitor (money-path.md §2, o
+  // par consumidor E produtor).
+  {
+    rotulo: "calculate-scores/index.ts",
+    url: new URL("../calculate-scores/index.ts", import.meta.url),
   },
 ];
 
@@ -127,6 +146,10 @@ Deno.test("[POT-DET] o DETECTOR enxerga a coerção quando ela existe (par obrig
     "revenue_potential: (score.revenue_potential as number) || 0,",
     "expansionPotential: num(score.expansion_score),",
     "revenuePotential: num(score.revenue_potential), salesHistoryStatus };",
+    // As duas formas VIVAS que este PR removeu de calculate-scores/index.ts — copiadas verbatim da
+    // main anterior. Sem elas, a entrada nova em CAMPOS seria decorativa.
+    "const crossSellScore = Number(client.x_score || 0);",
+    "const engagementScore = Number(client.s_score || 0);",
   ];
   for (const forma of formasReais) {
     const pegou = coercoesEmLinha(forma).length + numAplicadoACampo(forma).length;
@@ -138,6 +161,12 @@ Deno.test("[POT-DET] o DETECTOR enxerga a coerção quando ela existe (par obrig
     "const revenuePotential = valorMedido(score.revenue_potential);",
     "const expansionPotential = numeroValido(score.expansion_score);",
     "expansionPotential: valorMedido(d.expansion_potential),",
+    // O pós-fix real deste PR: o null tem de atravessar o arredondamento.
+    "x_score: crossSellScore == null ? null : Math.round(crossSellScore),",
+    // Controle da ÂNCORA `\b`: identificadores que CONTÊM "x_score"/"s_score" e coagem por conta
+    // própria não são deste gate. Sem o `\b` estas duas linhas reprovariam código alheio e íntegro.
+    "const teto = Math.max(...linhas.map(l => l.max_score || 0), 1);",
+    "const aux = dados.aux_score ?? 0;",
   ];
   for (const forma of formasCorretas) {
     const pegou = coercoesEmLinha(forma).length + numAplicadoACampo(forma).length;

--- a/supabase/functions/_shared/score-ponderado.ts
+++ b/supabase/functions/_shared/score-ponderado.ts
@@ -1,0 +1,98 @@
+/**
+ * Média ponderada que RENORMALIZA o peso do componente não medido, em vez de deixá-lo contribuir 0.
+ *
+ * Existe como módulo próprio — e não inline no `index.ts` de quem usa — por uma razão medida: a
+ * renormalização da margem em `calculate-scores` vivia dentro do laço do `index.ts`, que importa
+ * `npm:@supabase/supabase-js`, e `test:edges` roda com `--no-remote`. Ou seja: a única aritmética
+ * do repo que decide `priority_score` e `health_score` era estruturalmente inalcançável por teste
+ * de comportamento, e só um gate de FONTE a vigiava. Gate de fonte pega a reintrodução do `|| 0`;
+ * não pega a renormalização feita errado (dividir pelo denominador cheio, esquecer o clamp,
+ * deixar o ausente entrar no máximo). Essas são as falhas que este módulo permite testar de fato.
+ *
+ * A regra de negócio, em uma frase: **componente sem produtor sai do numerador E do denominador**.
+ * Contribuir 0 seria afirmar "pior cliente possível neste eixo" sobre quem apenas não foi medido —
+ * a fabricação de número que `docs/agent/money-path.md` §2 proíbe no money-path.
+ */
+
+// O helper canônico é `valorMedido` de `src/lib/scoring/margin.ts`; Deno não importa de `src/`, daí
+// o espelho VERBATIM abaixo. A paridade textual é pinada por
+// `src/__tests__/edge-money-path-invariants.test.ts`, que existe para pegar a reversão do deploy do
+// Lovable (o bot já reescreveu edge por cima da main — CLAUDE.md, #1445→#1478).
+// MIRROR-START valor-medido — espelhado verbatim de src/lib/scoring/margin.ts
+export function valorMedido(raw: unknown): number | null {
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string') {
+    const t = raw.trim();
+    if (t.length === 0) return null;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+// MIRROR-END
+
+/** Um eixo do score: o valor já normalizado em 0-100 (ou `null` = não medido) e o peso dele. */
+export interface ComponentePonderado {
+  /** `null` = sem produtor / não medido. NUNCA use 0 para representar ausência. */
+  valor: number | null;
+  /** Peso configurado. Não-finito ou ≤ 0 é tratado como componente DESLIGADO (nem numerador nem denominador). */
+  peso: number;
+}
+
+/**
+ * Média ponderada só dos componentes MEDIDOS, dividida pelo peso REALMENTE disponível.
+ *
+ * `null` quando nenhum componente foi medido (ou todos os pesos estão desligados) — o chamador
+ * decide o que fazer com "não sei", e a decisão dele fica visível no call-site em vez de escondida
+ * aqui num `?? 0`.
+ *
+ * ⚠️ A forma errada é sedutora e devolve um número plausível: filtrar o numerador e dividir pelo
+ * denominador CHEIO. Isso é aritmeticamente idêntico a deixar o ausente contribuir 0 — o bug que
+ * esta função existe para impedir —, e a saída parece perfeitamente razoável (só sistematicamente
+ * baixa). Mesma armadilha que `mediaMargensConhecidas` documenta em `src/lib/scoring/margin.ts`:
+ * numerador e denominador têm de sair da MESMA lista filtrada.
+ */
+export function mediaPonderadaRenormalizada(componentes: readonly ComponentePonderado[]): number | null {
+  let soma = 0;
+  let pesoDisponivel = 0;
+  for (const { valor, peso } of componentes) {
+    if (valor == null) continue;
+    if (!Number.isFinite(peso) || peso <= 0) continue;
+    soma += valor * peso;
+    pesoDisponivel += peso;
+  }
+  if (pesoDisponivel <= 0) return null;
+  return soma / pesoDisponivel;
+}
+
+/**
+ * Maior valor MEDIDO da lista, ou `null` se nenhum foi medido.
+ *
+ * O `Math.max(...xs.map(x => Number(x || 0)), 1)` que este helper substitui erra duas vezes de uma
+ * só: faz o desconhecido participar da normalização como se fosse zero (deprimindo o teto e
+ * inflando o score relativo de todo mundo) e, quando a coluna inteira é NULL, devolve o piso `1`
+ * — um teto FABRICADO, contra o qual todo cliente pontua 0.
+ */
+export function maximoMedido(valores: Iterable<unknown>): number | null {
+  let max: number | null = null;
+  for (const bruto of valores) {
+    const v = valorMedido(bruto);
+    if (v == null) continue;
+    if (max == null || v > max) max = v;
+  }
+  return max;
+}
+
+/**
+ * Posição relativa de `valor` contra `max`, em 0-100, ou `null` se qualquer um dos dois for ausente.
+ *
+ * `max <= 0` devolve 0 e não `null`: aí todos os valores medidos são zero ou negativos, o que é um
+ * VEREDITO ("ninguém tem potencial") e não ausência de dado. Distinguir os dois é a regra inteira.
+ * O clamp mantém o eixo em 0-100 mesmo com valor negativo medido — piso, nunca negativo, senão um
+ * único cliente no prejuízo arrastaria o score composto para baixo do zero.
+ */
+export function normalizarPorMaximo(valor: number | null, max: number | null): number | null {
+  if (valor == null || max == null) return null;
+  if (max <= 0) return 0;
+  return Math.max(0, Math.min(100, (valor / max) * 100));
+}

--- a/supabase/functions/_shared/score-ponderado_test.ts
+++ b/supabase/functions/_shared/score-ponderado_test.ts
@@ -1,0 +1,131 @@
+// Testes de COMPORTAMENTO da renormalização que decide `priority_score` e `health_score`.
+//
+// Por que importa que sejam de comportamento e não só de fonte: o gate de fonte
+// (`potencial-nao-medido_test.ts`) pega a REINTRODUÇÃO do `|| 0` no call-site. Ele não pega a
+// renormalização escrita errado — dividir pelo denominador cheio, deixar o ausente entrar no
+// máximo, esquecer o clamp. Essas três produzem números plausíveis e sistematicamente errados,
+// que é a falha pior (money-path.md §2). Os dois gates se complementam; nenhum substitui o outro.
+//
+// Sem import remoto: `test:edges` roda com `--no-remote` e um `jsr:`/`npm:` aqui colocaria a
+// rede no caminho de entrega de TODO PR (CLAUDE.md).
+
+import {
+  maximoMedido,
+  mediaPonderadaRenormalizada,
+  normalizarPorMaximo,
+  valorMedido,
+} from "./score-ponderado.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+// Os pesos DEFAULT do health score em `calculate-scores` (hs_weight_*, /100).
+const HS = { recency: 0.25, frequency: 0.20, margin: 0.20, diversity: 0.15, crosssell: 0.10, engagement: 0.10 };
+
+Deno.test("[SP-RENORM] componente ausente sai do DENOMINADOR, não contribui 0", () => {
+  // Cenário REAL da prod (medido 2026-08-07): margem, x_score e s_score ausentes — 40% do peso do
+  // health score sem produtor. Sobram recência(25) + frequência(20) + diversidade(15) = 60.
+  const componentes = [
+    { valor: 80, peso: HS.recency },
+    { valor: 50, peso: HS.frequency },
+    { valor: null, peso: HS.margin },
+    { valor: 20, peso: HS.diversity },
+    { valor: null, peso: HS.crosssell },
+    { valor: null, peso: HS.engagement },
+  ];
+  // (80*.25 + 50*.20 + 20*.15) / (.25+.20+.15) = 33/0.60 = 55
+  assertEquals(mediaPonderadaRenormalizada(componentes), 55);
+
+  // E o CONTRASTE que dá sentido ao teste: a forma antiga (ausente = 0, denominador cheio) daria
+  // 33 — o mesmo cliente rotulado "critico" em vez de "estavel" pelos limiares 25/50/75 da edge.
+  const formaAntiga = componentes.reduce((s, c) => s + (c.valor ?? 0) * c.peso, 0);
+  assertEquals(formaAntiga, 33);
+});
+
+Deno.test("[SP-RENORM] zero MEDIDO deprime o score (0 é veredito, não ausência)", () => {
+  // A distinção inteira em um teste: trocar `null` por `0` tem de MUDAR o resultado. Se este
+  // teste e o anterior dessem o mesmo número, a função estaria tratando ausência como zero.
+  const comZeroMedido = [
+    { valor: 80, peso: HS.recency },
+    { valor: 50, peso: HS.frequency },
+    { valor: 0, peso: HS.margin },
+    { valor: 20, peso: HS.diversity },
+    { valor: 0, peso: HS.crosssell },
+    { valor: 0, peso: HS.engagement },
+  ];
+  // Agora o denominador é 1,0 e o numerador segue 33 → 33, não 55.
+  assertEquals(mediaPonderadaRenormalizada(comZeroMedido), 33);
+});
+
+Deno.test("[SP-RENORM] tudo medido com pesos somando 1 é IDENTIDADE (não reescala quem tem dado)", () => {
+  // Garante que o PR não mexe no score de quem TEM os componentes — o efeito tem de ser cirúrgico.
+  const todos = [
+    { valor: 40, peso: HS.recency },
+    { valor: 60, peso: HS.frequency },
+    { valor: 100, peso: HS.margin },
+    { valor: 0, peso: HS.diversity },
+    { valor: 10, peso: HS.crosssell },
+    { valor: 90, peso: HS.engagement },
+  ];
+  const ponderadaCrua = todos.reduce((s, c) => s + c.valor * c.peso, 0);
+  assertEquals(mediaPonderadaRenormalizada(todos), ponderadaCrua);
+});
+
+Deno.test("[SP-RENORM] nenhum componente medido → null (jamais 0)", () => {
+  assertEquals(mediaPonderadaRenormalizada([{ valor: null, peso: 0.5 }, { valor: null, peso: 0.5 }]), null);
+  assertEquals(mediaPonderadaRenormalizada([]), null);
+});
+
+Deno.test("[SP-RENORM] peso desligado ou corrompido não entra no denominador", () => {
+  // `config[k]` vem de `Number(r.value)` em `farmer_algorithm_config` — um value não-numérico vira
+  // NaN. NaN no denominador contaminaria o score de TODA a base com NaN.
+  assertEquals(mediaPonderadaRenormalizada([{ valor: 100, peso: 0.5 }, { valor: 0, peso: 0 }]), 100);
+  assertEquals(mediaPonderadaRenormalizada([{ valor: 100, peso: 0.5 }, { valor: 0, peso: NaN }]), 100);
+  assertEquals(mediaPonderadaRenormalizada([{ valor: 100, peso: 0.5 }, { valor: 0, peso: -1 }]), 100);
+  assertEquals(mediaPonderadaRenormalizada([{ valor: 50, peso: NaN }]), null);
+});
+
+Deno.test("[SP-MAX] coluna inteira NULL → null, e não o piso 1 que fabricava teto", () => {
+  // O estado REAL de `farmer_client_scores.revenue_potential`: 6.633/6.633 NULL (psql-ro,
+  // 2026-08-07). O `Math.max(...map(Number(x||0)), 1)` devolvia 1 aqui — teto inventado contra o
+  // qual todo cliente pontuava 0, que é o `margin_potential_component` sempre 0 das 673.790
+  // linhas de `priority_score_log`.
+  assertEquals(maximoMedido([null, null, null]), null);
+  assertEquals(maximoMedido([]), null);
+});
+
+Deno.test("[SP-MAX] o ausente não participa do máximo; o zero medido participa", () => {
+  assertEquals(maximoMedido([null, 40, undefined, 90, null]), 90);
+  assertEquals(maximoMedido([0, null]), 0);
+  assertEquals(maximoMedido(["120.5", null, 30]), 120.5);
+  // Lixo não vira 0: `Number("")`, `Number([])` e `Number(false)` são todos 0 e atravessariam um
+  // `isFinite` como um zero de aparência perfeita.
+  assertEquals(maximoMedido(["", [], false, NaN, Infinity]), null);
+});
+
+Deno.test("[SP-NORM] ausência propaga; máximo não-positivo é veredito 0; clamp em 0-100", () => {
+  assertEquals(normalizarPorMaximo(null, 100), null);
+  assertEquals(normalizarPorMaximo(50, null), null);
+  assertEquals(normalizarPorMaximo(50, 200), 25);
+  assertEquals(normalizarPorMaximo(200, 100), 100);   // clamp superior
+  assertEquals(normalizarPorMaximo(-30, 100), 0);     // piso: negativo medido não vira score negativo
+  assertEquals(normalizarPorMaximo(0, 0), 0);         // ninguém tem potencial → veredito, não ausência
+});
+
+Deno.test("[SP-VM] valorMedido: só número finito e string numérica contam", () => {
+  assertEquals(valorMedido(0), 0);
+  assertEquals(valorMedido(-3.5), -3.5);
+  assertEquals(valorMedido("42"), 42);
+  assertEquals(valorMedido(null), null);
+  assertEquals(valorMedido(undefined), null);
+  assertEquals(valorMedido(""), null);
+  assertEquals(valorMedido("   "), null);
+  assertEquals(valorMedido("abc"), null);
+  assertEquals(valorMedido(NaN), null);
+  assertEquals(valorMedido(Infinity), null);
+  assertEquals(valorMedido([]), null);
+  assertEquals(valorMedido(false), null);
+});

--- a/supabase/functions/calculate-scores/index.ts
+++ b/supabase/functions/calculate-scores/index.ts
@@ -4,6 +4,16 @@ import { authorizeCronOrStaff } from "../_shared/auth.ts";
 // de `decidirClaim`, que decide o passo inteiro do claim. Mantê-lo importado viraria símbolo órfão.
 import { decidirClaim, esperaClaimMs } from "../_shared/lease.ts";
 import { fetchAll } from "../_shared/paginate.ts";
+// Renormalização testável: componente sem produtor sai do numerador E do denominador. Mora em
+// `_shared` (e não inline aqui) porque este arquivo importa `npm:@supabase/supabase-js` e
+// `test:edges` roda com `--no-remote` — inline, a aritmética que decide os dois scores seria
+// estruturalmente inalcançável por teste de comportamento. Ver `_shared/score-ponderado_test.ts`.
+import {
+  maximoMedido,
+  mediaPonderadaRenormalizada,
+  normalizarPorMaximo,
+  valorMedido,
+} from "../_shared/score-ponderado.ts";
 
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "*";
 
@@ -123,8 +133,13 @@ interface HealthHistoryRecord {
   rf_score: number;
   m_score: number | null;   // null = margem desconhecida neste run (PR 3-zero); nunca 0 por default
   g_score: number;
-  x_score: number;
-  s_score: number;
+  // x_score/s_score: mesma disciplina do m_score. NENHUM writer os calcula — 6.633/6.633 NULL em
+  // `farmer_client_scores` (psql-ro, 2026-08-07) —, e esta edge os relia e regravava como 0: as
+  // 673.790 linhas de `health_score_history` têm x=0 e s=0, ZERO nulos. A coluna é nullable com
+  // DEFAULT 0, então o null tem de ir EXPLÍCITO no payload: omitir a chave faz o Postgres fabricar
+  // o mesmo 0 (money-path.md §2 — o par consumidor E produtor).
+  x_score: number | null;
+  s_score: number | null;
   churn_risk: number;
 }
 
@@ -132,7 +147,11 @@ interface PriorityLogRecord {
   customer_user_id: string;
   farmer_id: string;
   priority_score: number;
-  margin_potential_component: number;
+  // null = `revenue_potential` não medido, logo o componente NÃO participou do priority_score (o
+  // peso foi renormalizado). Gravar 0 aqui afirmaria "potencial apurado, deu zero" — e é o que as
+  // 673.790 linhas do log dizem hoje, sem nunca ter havido produtor. Coluna nullable com DEFAULT 0
+  // → null EXPLÍCITO, senão o Postgres refabrica o zero.
+  margin_potential_component: number | null;
   churn_risk_component: number;
   repurchase_component: number;
   goal_proximity_component: number;
@@ -469,6 +488,19 @@ Deno.serve(async (req) => {
       goal_proximity: (config['ps_weight_goal_proximity'] ?? 15) / 100,
     };
 
+    // O priority score passou a DIVIDIR pela soma dos pesos disponíveis, pelo mesmo motivo que o
+    // health já dividia: `revenue_potential` não tem produtor e o peso dele (35%, o MAIOR dos
+    // quatro) precisa ser redistribuído em vez de contribuir 0. Com soma 1,0 a divisão é identidade
+    // para quem TEM o componente; com soma diferente, reescala todo mundo — comportamento correto
+    // (um score 0-100 deve usar 100% do peso disponível), mas silencioso demais para não deixar rastro.
+    const somaPesosPs = ps_w.margin_potential + ps_w.churn_risk + ps_w.repurchase + ps_w.goal_proximity;
+    if (Math.abs(somaPesosPs - 1) > 0.001) {
+      console.warn(
+        `[calculate-scores] pesos do priority score somam ${(somaPesosPs * 100).toFixed(1)}, não 100 — ` +
+        `os scores serão normalizados por essa soma. Confira farmer_algorithm_config.ps_weight_*.`,
+      );
+    }
+
     // Recência: teto (dias até zerar) configurável, guardrail [30,999] (achado /codex: T>999
     // ressuscitaria o sentinela 999). Default 180. Ajustável sem redeploy via farmer_algorithm_config.
     const recencyCapDays = clampRecencyCapDays(config['hs_recency_cap_days']);
@@ -752,7 +784,12 @@ Deno.serve(async (req) => {
     // como se fosse margem zero, deprimindo o teto e inflando o score relativo de todo mundo.
     const maxMarginPct = Math.max(...clients.map(c => margemConhecida(c.gross_margin_pct) ?? 0), 1);
     const maxCategories = Math.max(...clients.map(c => Number(c.category_count || 0)), 1);
-    const maxRevPotential = Math.max(...clients.map(c => Number(c.revenue_potential || 0)), 1);
+    // Teto do potencial: só valores MEDIDOS. O `Math.max(...map(Number(x || 0)), 1)` anterior errava
+    // duas vezes — fazia o desconhecido normalizar como zero E, com a coluna inteira NULL (o estado
+    // real: 6.633/6.633), devolvia o piso `1`, um teto FABRICADO contra o qual todo cliente pontuava
+    // 0. Daí `margin_potential_component = 0` em 673.790/673.790 linhas de priority_score_log.
+    // `null` = ninguém tem potencial medido → o componente sai do score de todos (renormalização).
+    const maxRevPotential = maximoMedido(clients.map(c => c.revenue_potential));
 
     const healthHistoryRecords: HealthHistoryRecord[] = [];
     const priorityLogRecords: PriorityLogRecord[] = [];
@@ -782,32 +819,38 @@ Deno.serve(async (req) => {
         ? Math.min(100, (Number(client.category_count || 0) / maxCategories) * 100)
         : 0;
       
-      const crossSellScore = Number(client.x_score || 0);
-      const engagementScore = Number(client.s_score || 0);
+      // Cross-sell e engajamento: MESMO defeito da margem, na mesma função. Nenhum writer os
+      // calcula (6.633/6.633 NULL), e o `Number(x || 0)` transformava "não medi" no veredito "pior
+      // cliente possível neste eixo" — 20% do health score afirmando um fato que ninguém apurou.
+      const crossSellScore = valorMedido(client.x_score);
+      const engagementScore = valorMedido(client.s_score);
 
-      // Renormalização: sem margem conhecida, o peso dela é redistribuído entre os componentes que
-      // existem, em vez de contribuir 0 (contribuir 0 seria afirmar "pior cliente neste eixo" para
-      // quem só não foi medido).
+      // Renormalização: o peso do componente NÃO MEDIDO é redistribuído entre os que existem, em vez
+      // de contribuir 0 (contribuir 0 afirmaria "pior cliente neste eixo" sobre quem só não foi
+      // medido). Valia só para a margem; passa a valer também para cross-sell e engajamento, que têm
+      // exatamente o mesmo defeito — os três juntos são 50% do peso, e nenhum tem produtor hoje.
       //
-      // Com os pesos DEFAULT a divisão é identidade para quem TEM margem — 25+20+20+15+10+10 = 100,
-      // logo pesoTotal = 1,0. Mas isso é propriedade dos defaults, não garantia: farmer_algorithm_config
-      // é editável e hoje não tem NENHUMA linha hs_weight% (medido 2026-07-21 — os seis valores vêm
-      // dos defaults do código). Se alguém configurar pesos que não somem 100, a divisão deixa de ser
-      // identidade e passa a normalizar o score de TODOS os clientes, inclusive os com margem
-      // conhecida. Isso é o comportamento correto (um score 0-100 deve usar 100% do peso disponível;
-      // pesos somando 90 faziam o teto ser 90), mas é uma mudança silenciosa demais para acontecer
-      // sem rastro — daí o aviso abaixo, emitido uma única vez por run.
-      const pesoMargem = marginScore == null ? 0 : hs_w.margin;
-      const pesoTotal = hs_w.recency + hs_w.frequency + pesoMargem
-                      + hs_w.diversity + hs_w.crosssell + hs_w.engagement;
-      const somaPonderada =
-        recencyScore * hs_w.recency +
-        freqScore * hs_w.frequency +
-        (marginScore ?? 0) * pesoMargem +
-        diversityScore * hs_w.diversity +
-        crossSellScore * hs_w.crosssell +
-        engagementScore * hs_w.engagement;
-      const healthScore = Math.round(pesoTotal > 0 ? somaPonderada / pesoTotal : 0);
+      // Com os pesos DEFAULT a divisão é identidade para quem TEM os componentes — 25+20+20+15+10+10
+      // = 100, logo o peso disponível é 1,0. Mas isso é propriedade dos defaults, não garantia:
+      // farmer_algorithm_config é editável e hoje não tem NENHUMA linha hs_weight% (medido
+      // 2026-07-21 — os seis valores vêm dos defaults do código). Se alguém configurar pesos que não
+      // somem 100, a divisão deixa de ser identidade e passa a normalizar o score de TODOS os
+      // clientes, inclusive os completos. Isso é o comportamento correto (um score 0-100 deve usar
+      // 100% do peso disponível; pesos somando 90 faziam o teto ser 90), mas é uma mudança silenciosa
+      // demais para acontecer sem rastro — daí o aviso emitido uma única vez por run, acima.
+      //
+      // O `?? 0` NÃO é fabricação: `null` aqui só acontece com TODOS os seis pesos zerados na config
+      // (recência, frequência e diversidade são sempre número), o que é ausência de CONFIGURAÇÃO e
+      // não de dado — e preserva exatamente o `pesoTotal > 0 ? … : 0` anterior.
+      const healthMedia = mediaPonderadaRenormalizada([
+        { valor: recencyScore, peso: hs_w.recency },
+        { valor: freqScore, peso: hs_w.frequency },
+        { valor: marginScore, peso: hs_w.margin },
+        { valor: diversityScore, peso: hs_w.diversity },
+        { valor: crossSellScore, peso: hs_w.crosssell },
+        { valor: engagementScore, peso: hs_w.engagement },
+      ]);
+      const healthScore = Math.round(healthMedia ?? 0);
 
       let healthClass = 'critico';
       if (healthScore >= 75) healthClass = 'saudavel';
@@ -817,9 +860,9 @@ Deno.serve(async (req) => {
       const churnRisk = Math.max(0, Math.min(100, 100 - healthScore));
 
       // --- Priority Score ---
-      const marginPotentialComp = maxRevPotential > 0
-        ? (Number(client.revenue_potential || 0) / maxRevPotential) * 100
-        : 0;
+      // `null` = potencial não medido (deste cliente ou de toda a base). O componente sai do score,
+      // e os 35% de peso — o MAIOR dos quatro — são redistribuídos entre churn, recompra e meta.
+      const marginPotentialComp = normalizarPorMaximo(valorMedido(client.revenue_potential), maxRevPotential);
       
       const churnComp = churnRisk;
       
@@ -833,12 +876,18 @@ Deno.serve(async (req) => {
         ? Math.min(100, (Number(client.avg_monthly_spend_180d || 0) / maxSpend) * 100)
         : 0;
 
-      const priorityScore = Math.round(
-        marginPotentialComp * ps_w.margin_potential +
-        churnComp * ps_w.churn_risk +
-        repurchaseComp * ps_w.repurchase +
-        goalComp * ps_w.goal_proximity
-      );
+      // Mesma renormalização do health. Antes o `marginPotentialComp` entrava como 0 para 100% da
+      // base e comia 35 dos 100 pontos possíveis: o priority_score tinha teto REAL de 65 (medido:
+      // max 43, média 29,13 em 6.633 linhas) enquanto a tela o apresenta como 0-100.
+      // O `?? 0` cobre só "todos os quatro pesos zerados na config" — churn, recompra e meta são
+      // sempre número —, preservando o comportamento anterior nesse caso.
+      const priorityMedia = mediaPonderadaRenormalizada([
+        { valor: marginPotentialComp, peso: ps_w.margin_potential },
+        { valor: churnComp, peso: ps_w.churn_risk },
+        { valor: repurchaseComp, peso: ps_w.repurchase },
+        { valor: goalComp, peso: ps_w.goal_proximity },
+      ]);
+      const priorityScore = Math.round(priorityMedia ?? 0);
 
       updates.push({
         id: client.id,
@@ -892,8 +941,10 @@ Deno.serve(async (req) => {
         rf_score: Math.round(recencyScore),
         m_score: marginScore == null ? null : Math.round(marginScore),  // idem: null ≠ 0
         g_score: Math.round(diversityScore),
-        x_score: Math.round(crossSellScore),
-        s_score: Math.round(engagementScore),
+        // Math.round(null) é 0 — o arredondamento refabricaria justamente o zero que este PR remove.
+        // O null tem de atravessar até a coluna (nullable, DEFAULT 0 → chave presente com null).
+        x_score: crossSellScore == null ? null : Math.round(crossSellScore),
+        s_score: engagementScore == null ? null : Math.round(engagementScore),
         churn_risk: churnRisk,
       });
 
@@ -901,7 +952,8 @@ Deno.serve(async (req) => {
         customer_user_id: client.customer_user_id,
         farmer_id: client.farmer_id,
         priority_score: priorityScore,
-        margin_potential_component: Math.round(marginPotentialComp),
+        // idem: null = componente ausente do score, não "apurei e deu zero".
+        margin_potential_component: marginPotentialComp == null ? null : Math.round(marginPotentialComp),
         churn_risk_component: Math.round(churnComp),
         repurchase_component: Math.round(repurchaseComp),
         goal_proximity_component: Math.round(goalComp),


### PR DESCRIPTION
PR 2 do programa aberto pelo #1676. `calculate-scores` era o **writer** da família: enquanto ele
coagia, consertar os leitores era enxugar gelo — o zero fabricado voltava para a tabela a cada run
e de lá para o próximo leitor.

## O que estava errado

Três colunas sem nenhum produtor, lidas como fato medido (medido em prod via psql-ro, 2026-08-07):

| coluna | NULL | zeros | positivos | peso que ela carrega |
|---|---|---|---|---|
| `revenue_potential` | 6.633/6.633 | 0 | 0 | **35%** do `priority_score` |
| `x_score` (cross-sell) | 6.633/6.633 | 0 | 0 | 10% do `health_score` |
| `s_score` (engajamento) | 6.633/6.633 | 0 | 0 | 10% do `health_score` |

`Number(x || 0)` transformava "ninguém apurou" no veredito "pior cliente possível neste eixo". O
rastro disso está nas tabelas de auditoria, e não é sutil:

- `priority_score_log`: **673.790/673.790** linhas com `margin_potential_component = 0`, zero nulos.
- `health_score_history`: **673.790/673.790** linhas com `x_score = 0` e `s_score = 0`, zero nulos.

Consequência aritmética: o `priority_score` tinha teto REAL de 65 enquanto a tela o apresenta como
0-100 (baseline medido: **max 43**, média 29,13 em 6.633 linhas). E o `health_score` gastava 20% do
peso em dois eixos que ninguém calcula.

## O que mudou

Componente sem produtor **sai do numerador E do denominador** — o peso é redistribuído entre os
componentes que existem, em vez de contribuir 0. É a renormalização que a margem já tinha ao lado
desde o #1498, agora aplicada aos três casos restantes da mesma função (o meio-conserto na mesma
função é o que `money-path.md` §7 proíbe).

O null atravessa até a coluna nas duas tabelas de auditoria: `x_score`, `s_score` e
`margin_potential_component` passam a gravar NULL quando não medidos. As três são nullable **com
`DEFAULT 0`**, então o null vai EXPLÍCITO no payload — omitir a chave faria o Postgres refabricar o
mesmo zero. **Nenhuma migration é necessária.**

## Por que um módulo novo em `_shared`

A aritmética que decide os dois scores morava dentro do laço do `index.ts`, que importa
`npm:@supabase/supabase-js` — e `test:edges` roda com `--no-remote`. Ou seja: era estruturalmente
inalcançável por teste de comportamento, e só um gate de FONTE a vigiava. Gate de fonte pega a
reintrodução do `|| 0`; **não** pega a renormalização escrita errado (dividir pelo denominador
cheio devolve um número plausível e sistematicamente baixo — pior que um erro visível).

`_shared/score-ponderado.ts` torna isso testável, e é usado pelos DOIS scores. `valorMedido` entra
como bloco `MIRROR` verbatim do helper de `src/lib/scoring/margin.ts`, com paridade textual pinada
— o mecanismo que pega a reversão do deploy do Lovable.

## Efeito esperado (a declarar antes de medir)

Os dois scores **sobem**, por construção, e a mudança é de ESCALA, não de ranking: como o
componente ausente falta para 100% da base, a transformação é quase-uniforme e a ordem relativa se
preserva. O que muda é o número que a pessoa lê e qualquer limiar absoluto sobre ele.

- `priority_score`: ÷0,65 → média 29,13 deve ir para ~44; max 43 para ~66.
- `health_score`: ÷0,60 (sem margem) ou ÷0,80 (com) → 1,25x–1,33x.
- `health_class` **reclassifica** (limiares 25/50/75). Hoje: 6.190 críticos, 0 saudáveis.

⚠️ Isto **não** conserta o `health_avg = 4,0` — o spec já registrou que os 20% mortos não explicam
aquilo sozinhos, e segue sendo fio solto próprio, não afirmado como consequência desta classe.

Nenhum limiar absoluto sobre `priority_score` existe no código (varrido). Ambas as tabelas de
auditoria são write-only: nenhum leitor no app quebra.

## Validação

- `test:edges` · `bun run test` · `bun run typecheck` · `bun lint` · `deno check` da edge alterada.
- Teste de COMPORTAMENTO novo (9 casos) provando o que o gate de fonte não alcança: ausente sai do
  denominador; zero MEDIDO continua deprimindo (a distinção inteira); tudo-medido é identidade;
  peso NaN/≤0 não contamina; coluna toda NULL não vira o teto fabricado `1`.
- Gates estendidos: `x_score`/`s_score` entram nos dois gates de fonte (edge + src), e o writer
  entra na lista de vigiados. Âncora `\b` adicionada — sem ela `max_score || 0` casaria dentro de
  `x_score` e o gate reprovaria código alheio.
- **Falsificação**: 5 canários, cada um deixando VERMELHO o gate que o vigia, com a sabotagem
  confirmada por `grep -qF` ASCII antes de rodar e restauração por backup-cópia (não `git
  checkout`, que destruiria fix uncommitted do mesmo arquivo).

## Deploy

💬 **Chat do Lovable: deploy da edge `calculate-scores`, verbatim da main.** Sem migration e sem
Publish. Merge na main **não** publica edge.

Baseline a remedir depois do deploy (dos dois lados — o que a mudança altera e o que ela deve
deixar intacto): `priority_score`/`health_score` avg+max, distribuição de `health_class`, e os
nulos honestos aparecendo em `priority_score_log` / `health_score_history`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
