### PR TITLE
fix(farmer): churn desconhecido sai do denominador do IPF — lacuna de dado não é desempenho ruim [money-path]

### DIFF
--- a/src/hooks/useFarmerPerformance.ts
+++ b/src/hooks/useFarmerPerformance.ts
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { toast } from 'sonner';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import { proporcaoChurnBaixo } from '@/lib/scoring/churn';
 
 export interface PerformanceScore {
   id: string;
@@ -298,12 +299,17 @@ export const useFarmerPerformance = () => {
         : 0;
       const ipfLtvEvolution = Math.round(Math.min(100, (avgSpend / 2000) * 100));
 
-      // 5. Churn reduction: % of clients with low churn risk (<30%)
-      // `?? 100` (não `|| 100`): churn ausente conta como pior caso (não é "baixo churn"), mas
-      // churn REAL = 0 (cliente perfeitamente saudável) tem de contar — `|| 100` o tratava como 100.
-      const lowChurnClients = clientArr.filter((c) => Number(c.churn_risk ?? 100) < 30).length;
-      const ipfChurnReduction = clientArr.length > 0
-        ? Math.round((lowChurnClients / clientArr.length) * 100)
+      // 5. Churn reduction: % de clientes com risco de churn conhecido E baixo (<30%).
+      // A BASE é quem tem risco conhecido, não a carteira inteira. O `?? 100` do #1561 consertou
+      // o numerador (churn REAL = 0 voltou a contar como bom), mas o desconhecido continuava no
+      // denominador — então cada cliente sem score derrubava o índice do vendedor por lacuna de
+      // DADO, não por desempenho. Numerador e denominador saem agora da mesma base filtrada.
+      const { abaixo: lowChurnClients, comRisco } = proporcaoChurnBaixo(
+        clientArr.map((c) => c.churn_risk),
+        30,
+      );
+      const ipfChurnReduction = comRisco > 0
+        ? Math.round((lowChurnClients / comRisco) * 100)
         : 0;
 
       // IPF Total (weighted average)

--- a/src/lib/scoring/__tests__/churn.test.ts
+++ b/src/lib/scoring/__tests__/churn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { churnConhecido } from '../churn';
+import { churnConhecido, proporcaoChurnBaixo } from '../churn';
 
 /**
  * `churn_risk` está 100% preenchido em prod hoje (6.633/6.633), então estes testes fixam
@@ -43,5 +43,30 @@ describe('o guard relacional que o helper existe para permitir', () => {
     // E 0 — o melhor cliente — continua contando como risco baixo, não como ausência.
     const semRisco = churnConhecido(0);
     expect(semRisco != null && semRisco < 30).toBe(true);
+  });
+});
+
+describe('proporcaoChurnBaixo', () => {
+  it('conta numerador e denominador sobre a MESMA base conhecida', () => {
+    // 2 conhecidos abaixo de 30 (10, 20), 2 conhecidos acima (80, 90), 2 desconhecidos.
+    const r = proporcaoChurnBaixo([10, 20, 80, 90, null, undefined], 30);
+    expect(r).toEqual({ abaixo: 2, comRisco: 4 });
+    // 2/4 = 50%. A forma errada (denominador = 6) daria 33% — plausível e sistematicamente baixo.
+    expect(Math.round((r.abaixo / r.comRisco) * 100)).toBe(50);
+  });
+
+  it('conta o risco ZERO como baixo — não como desconhecido', () => {
+    const r = proporcaoChurnBaixo([0, 90], 30);
+    expect(r).toEqual({ abaixo: 1, comRisco: 2 });
+  });
+
+  it('não classifica desconhecido como risco baixo', () => {
+    // `null < 30` é true em JS. Sem o guard, estes dois entrariam como "churn baixo".
+    const r = proporcaoChurnBaixo([null, undefined], 30);
+    expect(r).toEqual({ abaixo: 0, comRisco: 0 });
+  });
+
+  it('devolve base zero quando nenhum risco é conhecido (o consumidor decide o que exibir)', () => {
+    expect(proporcaoChurnBaixo([], 30)).toEqual({ abaixo: 0, comRisco: 0 });
   });
 });

--- a/src/lib/scoring/churn.ts
+++ b/src/lib/scoring/churn.ts
@@ -24,3 +24,32 @@ export function churnConhecido(raw: unknown): number | null {
   const n = Number(raw);
   return Number.isFinite(n) ? n : null;
 }
+
+/**
+ * Proporção de clientes com risco de churn ABAIXO de `limite`, contada só sobre quem tem risco
+ * conhecido.
+ *
+ * Existe como função própria porque a forma errada é sedutora e foi a que estava no código:
+ * filtrar o numerador (empurrando o desconhecido para fora dos "bons") e dividir pelo total
+ * INCLUINDO os desconhecidos. O resultado é um número plausível e sistematicamente baixo — pior
+ * que um erro visível, porque não parece errado. Aqui numerador e denominador saem da MESMA
+ * lista filtrada.
+ */
+export interface ProporcaoChurnBaixo {
+  /** Clientes com risco conhecido E abaixo do limite. */
+  abaixo: number;
+  /** Clientes com risco CONHECIDO (a base honesta da proporção; 0 conta, ausente não). */
+  comRisco: number;
+}
+
+export function proporcaoChurnBaixo(valores: Iterable<unknown>, limite: number): ProporcaoChurnBaixo {
+  let abaixo = 0;
+  let comRisco = 0;
+  for (const v of valores) {
+    const c = churnConhecido(v);
+    if (c == null) continue;
+    comRisco++;
+    if (c < limite) abaixo++;
+  }
+  return { abaixo, comRisco };
+}


### PR DESCRIPTION
Recuperado da branch órfã `claude/churn-coacao-fixture` (commit `d0e56825`, 2026-07-23 — worktree apagado, **nunca virou PR**), na triagem do `bun run wt:orfas`. Só o **diferencial**: o helper `churnConhecido` e o uso em `escopo-clientes` já tinham chegado à main por outro caminho; ficou de fora exatamente a parte que conserta a métrica.

## O buraco

`ipf_churn_reduction` = clientes com churn baixo **÷ carteira inteira**.

O #1561 já havia corrigido o **numerador** (`|| 100` → `?? 100`, devolvendo o cliente de risco ZERO ao grupo dos bons), mas o **denominador** continuou contando quem não tem score. Efeito: cada cliente sem churn conhecido derruba o índice do vendedor — por lacuna de **dado**, não por desempenho.

Com 2 de 6 clientes sem score, **50% real vira 33% exibido**: plausível, sistematicamente baixo, e não parece errado. É a regra `ausente ≠ zero` mordendo um KPI em vez de um número na tela.

## O fix

`proporcaoChurnBaixo(valores, limite)` devolve `{abaixo, comRisco}` — numerador e denominador saem da **mesma** lista filtrada, como em `mediaMargensConhecidas`. Sem risco conhecido em ninguém, `comRisco = 0` e o consumidor decide o que exibir (aqui: 0 — o comportamento atual, sem inventar).

O guard de `null` não é decorativo: **`null < 30` é `true` em JS** (null coage a 0), então filtrar sem checar classificaria como "risco baixo" justamente quem não foi medido. Um dos 4 casos novos trava isso.

## O que NÃO veio junto

A branch órfã estava **atrás** da main em duas coisas, deixadas de fora de propósito: ela reverteria o helper `mensagemDeErro` (`@/lib/erro-mensagem`) para `err instanceof Error ? … : String(err)`, e apagaria o `describe` do guard relacional que a suíte ganhou depois.

## Gates

| gate | resultado |
|---|---|
| `vitest churn` | ✅ **9/9** (5 da main + 4 novos) |
| `bun lint` | ✅ exit 0 (74 warnings pré-existentes, 0 erros) |
| tipos | ⚠️ **não concluiu localmente** — o semáforo `heavy` abortou por timeout de fila (1800s) 2×, sem chegar a rodar. Fica com o CI, que é o gate autoritativo. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
