### PR TITLE
ci(deadcode): knip vira gate do validate — o verde local que expirava

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,24 @@ jobs:
       - name: Docs índice gate (nenhum doc invisível)
         run: bun run docs:indice
 
+      # Anti-regressão de DEAD CODE (export sem consumidor, dep sem import). Existe porque o gate
+      # só-local não barra ninguém, e isso foi MEDIDO: o #1212 zerou os 254 achados e verificou
+      # `exit 0` em 2026-07-07, mas ficou 4 semanas em CONFLICTING (estado em que o auto-merge
+      # nunca dispara) e só mergeou 566 commits depois, em 06/08. No dia seguinte já eram 64
+      # achados — e nenhum era regressão do próprio #1212: TODOS nasceram na janela, o último
+      # (`dedupeKeyProposta`, #1332) 21 MINUTOS antes do #1212 mergear. A faxina chegou na main já
+      # vencida porque nada na janela foi barrado. A lição que este step encerra: medição de gate
+      # FORA do CI expira, e a validade dela é a distância entre medir e mergear — verde local é
+      # fato sobre um worktree num instante, verde de CI é fato sobre a main.
+      # Roda `bunx knip` — o MESMO comando do health stack local (`/health`), de propósito: gate de
+      # CI que diverge do comando local recria a lacuna que ele veio fechar. Config: knip.json.
+      # Quando quebrar: des-exportar (não deletar) é o default — não altera comportamento e só
+      # reduz alcance. Export que é contrato de teste ou fronteira de paridade byte-exata vai para
+      # `ignore` no knip.json COM o porquê no commit (precedentes: sayerlack-sku.ts,
+      # embalagem-captura-helpers.ts). Registro: docs/historico/faxina-knip-2026-07-07.md
+      - name: Dead code gate (knip — export/dep sem consumidor)
+        run: bunx knip
+
       # ─── Alerta de regressão (Componente 1 — mitigação de reversão Lovable) ──
       # O bot do Lovable commita DIRETO na main sem PR/CI; quando quebra build/
       # typecheck (ex.: types.ts stale #1079), o CI fica vermelho mas passa

--- a/docs/historico/faxina-knip-2026-07-07.md
+++ b/docs/historico/faxina-knip-2026-07-07.md
@@ -43,3 +43,11 @@ No dia seguinte ao merge, `bunx knip` já acusava **64 achados** (2 deps + 27 un
 - **`papaparse` + `@types/papaparse`**: zero ocorrências em todo o repo versionado — nem import estático, nem dinâmico, nem em script/JSON/MD. (Seguem no `package-lock.json`, que é fóssil no repo: o lockfile vivo é o `bun.lock`.)
 
 **Política adotada: des-exportar, não deletar.** Remover o `export` não altera comportamento algum e só *reduz* alcance, o que neutraliza por construção a regra do money-path ("não pergunte quem chama, pergunte o que acontece se alguém chamar") — uma função com efeito destrutivo e sem chamador fica menos alcançável, não mais. Delete só entraria onde o `noUnusedLocals` do tsc strict provasse órfão, e não foi o caso de nenhum dos 64.
+
+## Desfecho: knip virou gate do CI (2026-08-08)
+
+Zerar de novo não resolvia nada sozinho — o #1707 nasceria com a **mesma meia-vida** do #1212, porque a causa não era a sujeira, era o gate morar fora do CI. O step `Dead code gate (knip)` entrou no job `validate` (`.github/workflows/ci.yml`), rodando `bunx knip`: o **mesmo** comando do health stack local, de propósito — gate de CI que diverge do comando local recria a lacuna que veio fechar. Falsificado antes de entregar: canário `export` morto → exit 1 apontando o símbolo nominalmente; sem ele → exit 0.
+
+A partir daqui a afirmação "knip está exit 0" deixa de ser sobre o worktree de alguém num instante e passa a ser sobre a `main`. **Quando o gate quebrar**, o default é des-exportar (não deletar); export que seja contrato de teste ou fronteira de paridade byte-exata vai para `ignore` no `knip.json` **com o porquê no commit** — precedentes: `sayerlack-sku.ts` e `embalagem-captura-helpers.ts`.
+
+Uma correção de registro: a seção acima disse que `papaparse` seguia num `package-lock.json` "fóssil". A investigação de 08/08 confirmou que ele é fóssil **desde 2026-03-28** e está defasado do `package.json` em dezenas de deps (`@hookform/resolvers` ^3.10.0 vs ^5.2.2, `@lovable.dev/mcp-js` ausente), com a produção rodando o tempo todo. Isso **prova** que o build do Lovable não usa `npm ci`, que rejeitaria a divergência — a hipótese de risco levantada na sessão (o Publish quebrar pela dessincronia introduzida em #1707) está descartada por evidência. O arquivo é inerte; regenerá-lo produz um diff de ~9k linhas que ninguém validou, então ficou como está.


### PR DESCRIPTION
Fecha o follow-up que o #1707 deixou aberto de propósito: **promover knip a gate do CI**. Sem isso o #1707 nasceria com a mesma meia-vida do #1212 — a causa da regressão não era a sujeira, era o gate morar fora do CI.

## A evidência que justifica o gate

O #1212 zerou os 254 achados e verificou `exit 0` em **07/07**. Ficou 4 semanas em `CONFLICTING` (estado em que o auto-merge nunca dispara) e mergeou **566 commits depois**, em 06/08. No dia seguinte já eram **64 achados** — e nenhum era regressão do próprio #1212: todos nasceram na janela, o último (`dedupeKeyProposta`, #1332) **21 minutos** antes do #1212 mergear.

A faxina chegou na main já vencida porque, sendo knip só health stack local, nada na janela foi barrado. **Medição de gate fora do CI expira, e a validade dela é a distância entre medir e mergear.** Verde local é fato sobre um worktree num instante; verde de CI é fato sobre a main.

## Desenho

Roda `bunx knip` — o **mesmo** comando do health stack local (`/health`), de propósito: um gate de CI que diverge do comando local recria exatamente a lacuna que veio fechar. Bloqueante, como os demais gates do `validate` (`authz:check`, `bunpin:check`, `docs:indice`) — e coerente com a intenção declarada no #1212, que já chamava knip de "gate de regressão de dead code"; só nunca tinha ido para o CI.

## Verificação

- `bunx knip` **exit 0 na base** — o gate não nasce vermelho.
- **Falsificado**: com um `export` morto → **exit 1 apontando o canário nominalmente**; sem ele → exit 0. O gate morde.
- YAML parseia (`js-yaml`) e o step está no job `validate` (16 steps).
- `bunpin:check` 0 (lê `.github/workflows/`) · `lint` 0 · `docs:indice` 0.
- Nenhum PR aberto toca `ci.yml`.

## O que esperar

PRs abertos hoje só passam a ver o gate quando rebasearem. Quando ele quebrar, o default é **des-exportar, não deletar** (não altera comportamento, só reduz alcance); export que seja contrato de teste ou fronteira de paridade byte-exata vai para `ignore` no `knip.json` com o porquê no commit — precedentes `sayerlack-sku.ts` e `embalagem-captura-helpers.ts`. Está tudo registrado em `docs/historico/faxina-knip-2026-07-07.md`.

## Nota sobre o `package-lock.json`

Investiguei a hipótese de que o #1707 tivesse quebrado o Publish ao remover `papaparse` do `package.json` sem remover do lock. **Descartada por evidência**: o lock não é tocado desde **2026-03-28** e está defasado em dezenas de deps, com a produção rodando o tempo todo — o build do Lovable não usa `npm ci`, que rejeitaria a divergência. Regenerá-lo produz ~9k linhas de diff não validadas, então fica como está. Registrado no doc.