### PR TITLE
docs(fu4f): resgata o desenho da fase 3 da branch órfã — com errata do que envelheceu

### DIFF
--- a/docs/superpowers/plans/2026-07-20-fu4f-fase3-farmer-scoring-custo.md
+++ b/docs/superpowers/plans/2026-07-20-fu4f-fase3-farmer-scoring-custo.md
@@ -1,0 +1,1015 @@
+# FU4-F fase 3 — fechamento de custo no scoring do farmer
+
+## 🛑 ERRATA (2026-08-13) — NÃO EXECUTE ESTE PLANO COMO ESTÁ
+
+**Este plano está parcialmente implementado e parcialmente OBSOLETO.** Ele foi escrito em
+2026-07-20 e preservado aqui como registro; a implementação vive no
+[PR #1543](https://github.com/LucasSardenbergL/afiacao/pull/1543)
+(`feat/fu4f-fase3-hook-consome-helper`), **OPEN e DRAFT**. Executá-lo task-by-task hoje
+**reintroduziria uma mudança de produto que já foi rejeitada por medição**.
+
+| task | status | por quê |
+|---|---|---|
+| **Task 1 — helper `gDaFaixa`** | 🛑 **NÃO IMPLEMENTAR** | A função `gDaFaixa()` foi **deliberadamente não-criada**. Mapear faixa→`g` (`verde=1 · amarelo=0,5 · vermelho=0 · neutro=0`) descartaria a régua de percentis e mudaria o health score de **68% dos clientes com margem** (5,73 pontos em média, 14,42 no pior caso) — mudança de PRODUTO dentro de uma entrega de AUTORIZAÇÃO. O `src/lib/scoring/faixaMargem.ts` do #1543 documenta a ausência e o motivo. **Os testes das linhas 89-105 (`expect(gDaFaixa('verde')).toBe(1)`) testam uma função que não deve existir.** O que vale da Task 1: `FaixaMargem`, `FAIXA_LABEL` e `FAIXA_TOM`. |
+| **Task 2 — migration/RPC** | ✅ escrita no #1543 | `20260726170000_fu4f_fase3_carteira_margem_faixa.sql`. Ficou **fina**, como o bloco ⛔ abaixo previu: consome `private.margem_cliente_agregada()`. O `g` sai da própria RPC com a régua de percentis, e é **`NULL`** quando a margem não é apurável. |
+| **Task 5 — o hook** | ⚠️ diverge | A linha `const g = gDaFaixa(mf.faixa)` **não** é o que o #1543 faz: o `g` vem pronto do servidor e o `calcularHealthScore` renormaliza os pesos quando ele é `NULL`. |
+| Tasks 3, 4, 6, 7 | ✅ direção mantida | Harness, paridade, UI e tipos seguem o desenho. |
+
+**Fatos medidos em prod (2026-07-20)** — a linha `gross_margin_pct = 0 em 6.632/6.632, sem writer`
+**morreu em 2026-07-21**. Medido em 2026-08-13 (`psql-ro`): **1.075 não-zero · 5.558 NULL · 0
+zeros**. O writer é o `get_customer_margin_summary` do #1495; o zero fabricado saiu no
+[#1705](https://github.com/LucasSardenbergL/afiacao/pull/1705). As demais linhas da tabela seguem
+válidas. Detalhe em [`db/nota-1530-premissa-envelheceu.md`](../../../db/nota-1530-premissa-envelheceu.md).
+
+**Estado da entrega:** `public.get_carteira_margem_faixa` **não existe em prod** (`pg_proc`,
+2026-08-13) e [`useFarmerScoring.ts:189`](../../../src/hooks/useFarmerScoring.ts) **ainda baixa
+`product_costs` inteira** para o browser na `main`. O vazamento continua aberto — retomar é pelo
+#1543, não por uma execução limpa deste plano.
+
+Desenho: [`../specs/2026-07-20-fechamento-custo-farmer-scoring-design.md`](../specs/2026-07-20-fechamento-custo-farmer-scoring-design.md) (tem errata própria).
+
+---
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> 🛑 **Ressalva desta cópia:** leia a ERRATA acima antes de abrir qualquer task. A Task 1 não deve
+> ser implementada e a Task 5 diverge da implementação real.
+
+**Goal:** `useFarmerScoring` para de baixar o catálogo de custo (`product_costs`, 3.637 linhas) para o browser; a margem por cliente passa a vir de uma RPC gateada que devolve **faixa**, não número.
+
+**Architecture:** Espelha `get_preco_cockpit` (já em prod) um nível acima — de por-SKU para por-cliente. RPC `SECURITY DEFINER` lê custo internamente, classifica em `verde|amarelo|vermelho|neutro` e projeta o número só sob `private.cap_custo_ler`. O hook troca o `fetch` de custo por uma chamada `.rpc()`.
+
+**Tech Stack:** PostgreSQL 17 (plpgsql), Supabase/PostgREST, React + TypeScript, vitest, harness bash PG17.
+
+**Spec:** [`docs/superpowers/specs/2026-07-20-fechamento-custo-farmer-scoring-design.md`](../specs/2026-07-20-fechamento-custo-farmer-scoring-design.md)
+
+## ⛔ DEPENDÊNCIA — ler antes de começar (revisão de 2026-07-21)
+
+Este plano **não calcula mais a margem**. Ele consome `private.margem_cliente_agregada()`, entregue no **PR #1519** (branch `feat/margem-cliente-helper-compartilhado`).
+
+**Por quê:** a sessão paralela do PR #1495 construiu, ao mesmo tempo, o cálculo server-side da margem (`get_customer_margin_summary()`, para popular `farmer_client_scores.gross_margin_pct`). Medidas lado a lado sobre a prod, as duas lógicas divergem em **346 de 1.215 clientes (28,5%) na FAIXA**, com delta máximo de 112,57 p.p. Duas autoridades money-path discordando no sinal que o vendedor vê. Decisão do dono (2026-07-21): **um helper compartilhado, e o FU4-F fase 3 entra depois** do #1495 absorvê-lo.
+
+**Consequências para este plano:**
+
+1. A Task 2 vira uma função **fina** — classifica em faixa e aplica os dois gates. O JOIN, o custo canônico e o filtro de status vivem no helper.
+2. O helper **preserva o filtro de status do hook** (`'confirmado','faturado','entregue'` — dois inexistentes, 33% dos pedidos invisíveis). É deliberado: corrigir muda o score de todo cliente e é o chip **"Corrigir filtro de status do scoring do farmer"**, PR próprio com baseline. ⇒ a paridade da Task 4 continua válida.
+3. O helper resolve custo por `omie_codigo_produto → product_id`, **o mesmo caminho do hook** (`src/lib/scoring/margin.ts:23-24` + `costMap` por `product_id`). A paridade fica mais forte, não mais fraca.
+4. Cliente **sem custo conhecido agora VEM na resposta** com `margem_pct = NULL` (antes o INNER JOIN o descartava). O fallback `?? neutro` do hook segue necessário só para cliente **sem pedido nenhum**.
+
+**Ordem de merge:** #1519 → #1495 → este PR. Não comece a Task 2 antes do #1519 estar mergeado ou, no mínimo, com a migration do helper aplicada em prod.
+
+## Global Constraints
+
+- **Idioma:** código, rotas e commits em **pt-BR**.
+- **Migration de nome custom NÃO auto-aplica no Lovable** — o founder cola no SQL Editor. Toda migration sai com bloco pronto + query de validação read-only.
+- **Validação pós-apply LÊ CATÁLOGO** (`pg_proc`/`pg_get_functiondef`/`has_function_privilege`) — **nunca invoca** a função (invocar exige `EXECUTE`; sob `psql-ro` dá falso-negativo).
+- **`REVOKE` revoga de `PUBLIC` E por nome** (`anon`, `authenticated`) — só de `PUBLIC` é no-op no Supabase.
+- **`SET search_path` com `pg_temp` por último** em toda SECDEF nova.
+- **Atribuição no CORPO, nunca no `DECLARE`** — erro em inicialização de `DECLARE` não é capturável pelo `EXCEPTION` do próprio bloco.
+- **Comandos pesados prefixados com `heavy`** (semáforo de RAM da M2 8GB).
+- **Gate nunca com `| tail`** — engole o exit code. Use `> log 2>&1; echo $?`.
+- **Logs no scratchpad da sessão**, nunca `/tmp/<nome-genérico>` (compartilhado entre ~30 worktrees).
+- **Sessões paralelas ativas:** dois chips rodando tocam `useCrossSellEngine`/`useBundleEngine`/`calculate-scores`. **Não tocar nesses arquivos.** Conflito possível em `src/lib/custo/custoCanonico.ts` (compartilhado) e em timestamp de migration — conferir `origin/main` antes de commitar.
+
+## Fatos medidos em prod (2026-07-20) — não re-derivar
+
+| fato | valor |
+|---|---|
+| `farmer_client_scores.gross_margin_pct` | 0 em 6.632/6.632, sem writer |
+| `product_costs` | 3.637 linhas, 3.637 com custo, policy `master OR employee` |
+| universo de pedidos (3 status) | 20.095 pedidos |
+| itens: jsonb × relacional | 46.653 × 46.645 — **delta 8 (0,017%)**, 0 pedidos divergentes |
+| `order_items.product_id` NULL | 1.835/68.459 (2,7%) — **usar `omie_codigo_produto`, que é 100%** |
+| `omie_codigo_produto` em `omie_products` | único: 7.962/7.962, 1 account por código |
+| clientes com faixa real | 746 de 854 com pedido (87%); 108 → `neutro` |
+| distribuição da margem | p10 24,8% · mediana 52,9% · p90 73,5% · 7 negativos |
+
+## File Structure
+
+| arquivo | responsabilidade |
+|---|---|
+| `supabase/migrations/20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql` | RPC + seeds de config + ACL |
+| `db/test-authz-custo-fu4f-fase3.sql` | validação pós-apply (catálogo, roda em `psql-ro`) |
+| `db/test-authz-custo-fu4f-fase3.sh` | harness PG17: prova + falsificação |
+| `db/test-fu4f-fase3-paridade-margem.sh` | paridade TS×SQL (a faixa tem de bater) |
+| `src/lib/scoring/faixaMargem.ts` | mapeamento faixa→`g` + tipo `FaixaMargem` (puro, testável) |
+| `src/lib/scoring/__tests__/faixaMargem.test.ts` | testes do mapeamento |
+| `src/hooks/useFarmerScoring.ts` | remove o fetch de custo, chama a RPC |
+| `src/pages/FarmerDashboard.tsx` | exibe faixa no lugar do `%` |
+| `src/integrations/supabase/types.ts` | assinatura da RPC nova (à mão, ordem alfabética) |
+
+---
+
+### Task 1: Helper puro do mapeamento faixa→`g`
+
+> 🛑 **ERRATA — não implemente o `gDaFaixa()` desta task.** O mapeamento faixa→`g` foi rejeitado por
+> medição (mudaria o health score de 68% dos clientes com margem). Aproveite só `FaixaMargem`,
+> `FAIXA_LABEL` e `FAIXA_TOM`; o `g` vem do servidor. Ver errata no topo do arquivo.
+
+Começa aqui porque é TS puro, sem banco, e fixa o vocabulário que todo o resto usa.
+
+**Files:**
+- Create: `src/lib/scoring/faixaMargem.ts`
+- Test: `src/lib/scoring/__tests__/faixaMargem.test.ts`
+
+**Interfaces:**
+- Consumes: nada
+- Produces: `type FaixaMargem = 'verde' | 'amarelo' | 'vermelho' | 'neutro'`; `gDaFaixa(faixa: FaixaMargem): number`; `FAIXA_LABEL: Record<FaixaMargem, string>`
+
+- [ ] **Step 1: Escrever o teste que falha**
+
+```ts
+// src/lib/scoring/__tests__/faixaMargem.test.ts
+import { describe, it, expect } from 'vitest';
+import { gDaFaixa, FAIXA_LABEL, type FaixaMargem } from '../faixaMargem';
+
+describe('gDaFaixa', () => {
+  it('mapeia as quatro faixas para o componente G do health score', () => {
+    expect(gDaFaixa('verde')).toBe(1);
+    expect(gDaFaixa('amarelo')).toBe(0.5);
+    expect(gDaFaixa('vermelho')).toBe(0);
+  });
+
+  // Preserva o comportamento ATUAL (cliente sem custo conhecido já recebia g≈0).
+  // A fabricação está registrada como follow-up na spec §3.3 — NÃO consertar aqui.
+  it('mapeia neutro para 0, preservando o comportamento anterior', () => {
+    expect(gDaFaixa('neutro')).toBe(0);
+  });
+
+  it('devolve g dentro de [0,1] para toda faixa', () => {
+    const faixas: FaixaMargem[] = ['verde', 'amarelo', 'vermelho', 'neutro'];
+    for (const f of faixas) {
+      const g = gDaFaixa(f);
+      expect(g).toBeGreaterThanOrEqual(0);
+      expect(g).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('tem rótulo para toda faixa', () => {
+    const faixas: FaixaMargem[] = ['verde', 'amarelo', 'vermelho', 'neutro'];
+    for (const f of faixas) {
+      expect(FAIXA_LABEL[f]).toBeTruthy();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Rodar o teste e confirmar que falha**
+
+```bash
+cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/youthful-wright-ca4cec
+heavy bun run test -- src/lib/scoring/__tests__/faixaMargem.test.ts > "$SCRATCH/t1.log" 2>&1; echo "exit=$?"
+```
+
+Esperado: `exit=1`, com `Cannot find module '../faixaMargem'`. **Confirme que a contagem de testes falhados é 4** — exit≠0 sozinho não distingue "pegou" de "não rodou nada".
+
+- [ ] **Step 3: Implementar o mínimo**
+
+```ts
+// src/lib/scoring/faixaMargem.ts
+
+/**
+ * Faixa de margem do cliente — vocabulário herdado de `get_preco_cockpit` (FU4-F).
+ *
+ * `neutro` NÃO é uma cor pálida: é a degradação honesta para "sem custo conhecido".
+ * Sem ele, cliente sem custo seria empurrado para uma cor, fabricando sinal.
+ */
+export type FaixaMargem = 'verde' | 'amarelo' | 'vermelho' | 'neutro';
+
+export const FAIXA_LABEL: Record<FaixaMargem, string> = {
+  verde: 'Margem saudável',
+  amarelo: 'Margem abaixo do piso',
+  vermelho: 'Abaixo do custo',
+  neutro: 'Sem custo conhecido',
+};
+
+/**
+ * Componente G do health score a partir da faixa.
+ *
+ * ⚠️ `neutro → 0` preserva o comportamento ANTERIOR (o hook já dava g≈0 ao cliente sem
+ * custo conhecido, via `clientMargin = 0`). É uma fabricação conhecida — ausente ≠ zero —
+ * registrada como follow-up na spec §3.3. Consertá-la aqui misturaria mudança de score
+ * com conserto de autorização e destruiria o baseline de paridade.
+ */
+export function gDaFaixa(faixa: FaixaMargem): number {
+  switch (faixa) {
+    case 'verde': return 1;
+    case 'amarelo': return 0.5;
+    case 'vermelho': return 0;
+    case 'neutro': return 0;
+  }
+}
+```
+
+- [ ] **Step 4: Rodar e confirmar verde**
+
+```bash
+heavy bun run test -- src/lib/scoring/__tests__/faixaMargem.test.ts > "$SCRATCH/t1b.log" 2>&1; echo "exit=$?"
+```
+
+Esperado: `exit=0`, **4 testes passando**.
+
+- [ ] **Step 5: Registrar no manifesto de módulos**
+
+Arquivo novo em `src/` precisa de dono em `src/lib/modulos/manifesto.ts` (`codigo`/`testes`) — senão `manifesto.gate` falha **só no CI**, não no typecheck local. Abra o manifesto, ache a entrada do módulo que já possui `src/lib/scoring/` e acrescente os dois caminhos novos aos globs existentes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/scoring/faixaMargem.ts src/lib/scoring/__tests__/faixaMargem.test.ts src/lib/modulos/manifesto.ts
+git commit -m "feat(scoring): helper puro de faixa de margem (vocabulário do cockpit)"
+```
+
+---
+
+### Task 2: Migration — a RPC gateada
+
+**Files:**
+- Create: `supabase/migrations/20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql`
+
+**Interfaces:**
+- Consumes: `private.cap_custo_ler(_uid uuid) → boolean`, `private.cap_carteira_ler(_uid uuid) → boolean`, `private.carteira_visivel_para(_customer_user_id uuid, _uid uuid) → boolean` (todas SECDEF, medidas em prod)
+- Produces: `public.get_carteira_margem_faixa()` → `TABLE(customer_user_id uuid, faixa text, motivo text, margem_pct numeric)`
+
+⚠️ **O timestamp NÃO é a data de hoje — e isso é deliberado.** Os timestamps de migration deste repo estão **à frente do calendário**: em 2026-07-20 a maior na `main` era `20260724120000`. Um timestamp "de hoje" (`20260720…`) ordenaria **antes** das já aplicadas, violando a regra de que a sua ordena depois da última. Por isso `20260724130000`.
+
+**Antes de escrever, re-confirme o máximo** (as duas sessões paralelas podem ter criado uma nova):
+
+```bash
+git fetch -q origin
+git ls-tree --name-only origin/main supabase/migrations/ | command grep -oE '2026[0-9]{10}' | sort | tail -1
+```
+
+Se o retorno for ≥ `20260724130000`, escolha um timestamp maior e ajuste **todas** as referências neste plano (nome do arquivo, `git add`, os dois `psql -f` do harness da Task 3, e o corpo do PR).
+
+- [ ] **Step 1: Escrever a migration**
+
+```sql
+-- supabase/migrations/20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql
+--
+-- FU4-F fase 3 — o scoring do farmer para de baixar o catálogo de custo.
+--
+-- Espelha `get_preco_cockpit` um nível acima (por CLIENTE, não por SKU): a função lê o custo
+-- internamente e devolve a FAIXA; o número só sai sob `private.cap_custo_ler` (gate de projeção).
+--
+-- ⚠️ MIGRATION MANUAL: nome custom não auto-aplica no Lovable. Colar no SQL Editor → Run.
+-- Validação pós-apply: db/test-authz-custo-fu4f-fase3.sql (lê catálogo, não invoca).
+
+BEGIN;
+
+-- ── 1. Limiares da faixa (config, não código) ────────────────────────────────
+-- Semeados da distribuição REAL medida em 2026-07-20 sobre 746 clientes:
+--   p10 24,8% · p25 37,7% · mediana 52,9% · p75 65,4% · p90 73,5% · 7 negativos
+-- Com piso 30 / meta 50: 1% vermelho · 14% amarelo · 31% abaixo-da-meta · 54% saudável.
+-- Mudar os limiares é UPDATE nesta tabela, não deploy.
+INSERT INTO public.farmer_algorithm_config (key, value)
+VALUES ('margem_faixa_piso_pct', '30'),
+       ('margem_faixa_meta_pct', '50')
+ON CONFLICT (key) DO NOTHING;
+
+-- ── 2. A RPC ─────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.get_carteira_margem_faixa()
+RETURNS TABLE (customer_user_id uuid, faixa text, motivo text, margem_pct numeric)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  v_uid      uuid;
+  v_pode_num boolean;
+  v_piso     numeric;
+  v_meta     numeric;
+BEGIN
+  -- Atribuição no CORPO: erro na inicialização de DECLARE não é capturável pelo
+  -- EXCEPTION do próprio bloco e derrubaria a função inteira.
+  v_uid := (SELECT auth.uid());
+
+  -- Fail-closed: sem identidade, zero linhas.
+  IF v_uid IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_pode_num := COALESCE(private.cap_custo_ler(v_uid), false);
+
+  SELECT COALESCE(max(c.value::numeric) FILTER (WHERE c.key = 'margem_faixa_piso_pct'), 30),
+         COALESCE(max(c.value::numeric) FILTER (WHERE c.key = 'margem_faixa_meta_pct'), 50)
+    INTO v_piso, v_meta
+    FROM public.farmer_algorithm_config c
+   WHERE c.key IN ('margem_faixa_piso_pct', 'margem_faixa_meta_pct');
+
+  -- O CÁLCULO não mora aqui — mora em private.margem_cliente_agregada() (PR #1519), que é
+  -- também a fonte do #1495. Esta função só CLASSIFICA e aplica os dois gates. Duplicar o
+  -- cálculo foi exatamente o que produziu 28,5% de divergência entre as duas frentes.
+  RETURN QUERY
+  SELECT m.customer_user_id,
+         CASE WHEN m.margem_pct IS NULL  THEN 'neutro'
+              WHEN m.margem_pct < 0      THEN 'vermelho'
+              WHEN m.margem_pct < v_piso THEN 'amarelo'
+              ELSE                            'verde'   END,
+         CASE WHEN m.margem_pct IS NULL  THEN 'sem_custo'
+              WHEN m.margem_pct < 0      THEN 'abaixo_do_custo'
+              WHEN m.margem_pct < v_piso THEN 'abaixo_do_piso'
+              WHEN m.margem_pct < v_meta THEN 'abaixo_da_meta'
+              ELSE                            'saudavel' END,
+         -- Gate de PROJEÇÃO: o cálculo usa o valor real, a SAÍDA esconde.
+         -- A chave fica presente com NULL para o front tolerar.
+         CASE WHEN v_pode_num THEN m.margem_pct END
+    FROM private.margem_cliente_agregada() m
+   -- Escopo espelhando a RLS de farmer_client_scores (policy fcs_select_carteira).
+   WHERE COALESCE((SELECT private.cap_carteira_ler(v_uid)), false)
+      OR COALESCE(private.carteira_visivel_para(m.customer_user_id, v_uid), false);
+END;
+$fn$;
+
+-- ── 3. ACL ───────────────────────────────────────────────────────────────────
+-- O objeto NASCE aberto (default privilege do Supabase concede EXECUTE a anon/
+-- authenticated/service_role em toda função nova). Revogar de PUBLIC E por nome:
+-- só de PUBLIC é no-op.
+REVOKE ALL ON FUNCTION public.get_carteira_margem_faixa() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_carteira_margem_faixa() TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_carteira_margem_faixa() IS
+  'FU4-F fase 3: faixa de margem por cliente da carteira. O custo é lido internamente e '
+  'nunca sai; margem_pct só é projetada sob private.cap_custo_ler. Escopo espelha a RLS '
+  'de farmer_client_scores.';
+
+COMMIT;
+```
+
+- [ ] **Step 2: Conferir que o SQL é sintaticamente válido antes de qualquer coisa**
+
+⚠️ plpgsql é **late-bound**: `CREATE` passa com SQL inválido no corpo e só falha ao EXECUTAR. Este passo só pega erro de *sintaxe*, não de referência — a prova real é a Task 3.
+
+```bash
+cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/youthful-wright-ca4cec
+/opt/homebrew/opt/postgresql@17/bin/psql --version   # confirma o PG17 disponível
+```
+
+- [ ] **Step 3: Commit (sem aplicar — a prova vem na Task 3)**
+
+```bash
+git add supabase/migrations/20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql
+git commit -m "feat(authz): RPC get_carteira_margem_faixa — faixa por cliente, custo fechado"
+```
+
+⚠️ **NÃO peça o apply ao founder ainda.** A migration só vai para o SQL Editor depois da Task 3 verde + falsificação.
+
+---
+
+### Task 3: Harness PG17 — prova + falsificação
+
+**Files:**
+- Create: `db/test-authz-custo-fu4f-fase3.sh`
+
+**Interfaces:**
+- Consumes: a migration da Task 2 (aplicada REAL, não reescrita)
+- Produces: exit 0 com contagem explícita de asserts
+
+Use `db/test-authz-custo-fu4f-fase1.sh` como template estrutural (mesmo `initdb`/`pg_ctl`/`trap cleanup`/`P()`/`Pq()`, `LC_ALL=C`, `db/stubs-supabase.sql`).
+
+- [ ] **Step 1: Escrever o harness com os asserts**
+
+Cabeçalho e bootstrap idênticos ao `fase1.sh`, trocando `SLUG="fu4f3"` e `PORT="${PGPORT_TEST:-5463}"`. Depois dos stubs:
+
+```bash
+# ── stubs de identidade (iguais ao fase1) ────────────────────────────────────
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+
+-- Default privilege do Supabase: sem isto o harness nasce FECHADO por acidente
+-- e o teste de ACL dá falso-verde.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+-- Capabilities controláveis por GUC, para o teste variar o perfil do caller.
+CREATE OR REPLACE FUNCTION private.cap_custo_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT coalesce(nullif(current_setting('test.cap_custo', true),'')::boolean, false) $f$;
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT coalesce(nullif(current_setting('test.cap_carteira', true),'')::boolean, false) $f$;
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_customer_user_id uuid, _uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT EXISTS (SELECT 1 FROM public.carteira_teste ct WHERE ct.cid=_customer_user_id AND ct.dono=_uid) $f$;
+
+-- Tabelas mínimas espelhando a PROD (tipos e nullability reais).
+CREATE TABLE public.carteira_teste (cid uuid, dono uuid);
+CREATE TABLE public.farmer_algorithm_config (key text PRIMARY KEY, value text NOT NULL);
+CREATE TABLE public.omie_products (id uuid PRIMARY KEY, omie_codigo_produto bigint UNIQUE);
+CREATE TABLE public.product_costs (product_id uuid PRIMARY KEY, cost_final numeric, cost_price numeric);
+CREATE TABLE public.sales_orders (id uuid PRIMARY KEY, customer_user_id uuid, status text);
+CREATE TABLE public.order_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sales_order_id uuid, omie_codigo_produto bigint,
+  product_id uuid, quantity numeric, unit_price numeric, discount numeric);
+CREATE TABLE public.cliente_classificacao (user_id uuid PRIMARY KEY, excluir_da_carteira boolean);
+SQL
+
+# ── aplica a migration REAL (não uma cópia) ──────────────────────────────────
+P -q -f "$REPO_ROOT/supabase/migrations/20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql"
+
+# ── semeia ───────────────────────────────────────────────────────────────────
+P -q <<'SQL'
+-- vendedor A e vendedor B, cada um com 1 cliente
+INSERT INTO public.carteira_teste VALUES
+  ('11111111-1111-1111-1111-111111111111','aaaaaaaa-0000-0000-0000-000000000001'),
+  ('22222222-2222-2222-2222-222222222222','bbbbbbbb-0000-0000-0000-000000000002');
+
+INSERT INTO public.omie_products VALUES
+  ('dddddddd-0000-0000-0000-000000000001', 1001),
+  ('dddddddd-0000-0000-0000-000000000002', 1002),
+  ('dddddddd-0000-0000-0000-000000000003', 1003);
+
+-- SKU 1001: custo 60 → margem 40% (amarelo com piso 30? não: 40 >= 30 → verde/abaixo_da_meta)
+-- SKU 1002: custo 95 → margem  5% (amarelo)
+-- SKU 1003: SEM custo → cliente que só compra 1003 vira `neutro`
+INSERT INTO public.product_costs VALUES
+  ('dddddddd-0000-0000-0000-000000000001', 60, NULL),
+  ('dddddddd-0000-0000-0000-000000000002', 95, NULL);
+
+-- cliente 1 (do vendedor A): 1 pedido do SKU 1001 a 100 → margem 40% → verde/abaixo_da_meta
+INSERT INTO public.sales_orders VALUES
+  ('50000000-0000-0000-0000-000000000001','11111111-1111-1111-1111-111111111111','faturado'),
+  ('50000000-0000-0000-0000-000000000002','22222222-2222-2222-2222-222222222222','faturado');
+INSERT INTO public.order_items (sales_order_id, omie_codigo_produto, quantity, unit_price) VALUES
+  ('50000000-0000-0000-0000-000000000001', 1001, 1, 100),
+  ('50000000-0000-0000-0000-000000000002', 1002, 1, 100);
+SQL
+
+fail=0
+ok()  { echo "  ✅ $1"; }
+bad() { echo "  ❌ $1 — esperado [$2], veio [$3]"; fail=$((fail+1)); }
+eq()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1" "$2" "$3"; fi; }
+
+# Helper: roda a RPC como um caller específico.
+como() { # $1=uid $2=cap_custo $3=cap_carteira $4=sql
+  Pq -c "SET test.uid='$1'; SET test.cap_custo='$2'; SET test.cap_carteira='$3'; $4"
+}
+
+echo "── A. escopo de carteira ──"
+eq "A1 vendedor A vê o próprio cliente" "1" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT count(*) FROM public.get_carteira_margem_faixa();")"
+
+eq "A2 vendedor A NÃO vê o cliente de B" "0" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT count(*) FROM public.get_carteira_margem_faixa() WHERE customer_user_id='22222222-2222-2222-2222-222222222222';")"
+
+eq "A3 gestor (cap_carteira_ler) vê os dois" "2" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false true \
+     "SELECT count(*) FROM public.get_carteira_margem_faixa();")"
+
+eq "A4 fail-closed: sem auth.uid() devolve zero linhas" "0" \
+  "$(Pq -c "SET test.uid=''; SELECT count(*) FROM public.get_carteira_margem_faixa();")"
+
+echo "── B. gate de projeção do NÚMERO ──"
+# Valor EXATO, não "diferente de": um erro de SQL não pode contar como assert com dente.
+eq "B1 com cap_custo_ler, margem_pct é o valor exato" "40.0" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 true false \
+     "SELECT margem_pct FROM public.get_carteira_margem_faixa();")"
+
+eq "B2 SEM cap_custo_ler, margem_pct é NULL" "" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT coalesce(margem_pct::text,'') FROM public.get_carteira_margem_faixa();")"
+
+eq "B3 a FAIXA sai mesmo sem cap_custo_ler (o sinal fica)" "verde" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT faixa FROM public.get_carteira_margem_faixa();")"
+
+eq "B4 o MOTIVO sai mesmo sem cap_custo_ler" "abaixo_da_meta" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT motivo FROM public.get_carteira_margem_faixa();")"
+
+echo "── C. classificação ──"
+eq "C1 margem 5% cai em amarelo/abaixo_do_piso" "amarelo|abaixo_do_piso" \
+  "$(como bbbbbbbb-0000-0000-0000-000000000002 false false \
+     "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa();")"
+
+P -q -c "INSERT INTO public.order_items (sales_order_id, omie_codigo_produto, quantity, unit_price) VALUES ('50000000-0000-0000-0000-000000000001', 1002, 1, 50);"
+# cliente 1 agora: receita 150, custo 155 → margem negativa
+eq "C2 margem negativa cai em vermelho/abaixo_do_custo" "vermelho|abaixo_do_custo" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa();")"
+
+echo "── D. neutro e exclusão ──"
+P -q <<'SQL'
+INSERT INTO public.carteira_teste VALUES ('33333333-3333-3333-3333-333333333333','cccccccc-0000-0000-0000-000000000003');
+INSERT INTO public.sales_orders VALUES ('50000000-0000-0000-0000-000000000003','33333333-3333-3333-3333-333333333333','faturado');
+INSERT INTO public.order_items (sales_order_id, omie_codigo_produto, quantity, unit_price) VALUES
+  ('50000000-0000-0000-0000-000000000003', 1003, 1, 100);   -- SKU sem custo
+SQL
+# Cliente que só compra SKU sem custo NÃO aparece (INNER JOIN o descarta) — o hook
+# trata "sem linha" como neutro. Este assert trava esse contrato.
+eq "D1 cliente só com SKU sem custo não retorna linha (=> neutro no hook)" "0" \
+  "$(como cccccccc-0000-0000-0000-000000000003 false false \
+     "SELECT count(*) FROM public.get_carteira_margem_faixa();")"
+
+P -q -c "INSERT INTO public.cliente_classificacao VALUES ('11111111-1111-1111-1111-111111111111', true);"
+eq "D2 cliente excluído da carteira some do resultado" "0" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT count(*) FROM public.get_carteira_margem_faixa();")"
+P -q -c "DELETE FROM public.cliente_classificacao;"
+
+echo "── E. ACL ──"
+eq "E1 anon NÃO executa" "f" \
+  "$(Pq -c "SELECT has_function_privilege('anon','public.get_carteira_margem_faixa()','EXECUTE');")"
+eq "E2 authenticated executa" "t" \
+  "$(Pq -c "SELECT has_function_privilege('authenticated','public.get_carteira_margem_faixa()','EXECUTE');")"
+eq "E3 PUBLIC não executa" "f" \
+  "$(Pq -c "SELECT has_function_privilege('public','public.get_carteira_margem_faixa()','EXECUTE');")"
+
+echo "── F. idempotência ──"
+P -q -f "$REPO_ROOT/supabase/migrations/20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql"
+eq "F1 re-aplicar a migration não muda o resultado" "verde" \
+  "$(como aaaaaaaa-0000-0000-0000-000000000001 false false \
+     "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='11111111-1111-1111-1111-111111111111';")"
+eq "F2 re-aplicar não duplica os seeds de config" "2" \
+  "$(Pq -c "SELECT count(*) FROM public.farmer_algorithm_config WHERE key LIKE 'margem_faixa_%';")"
+
+echo "════════════════════════════════"
+if [ "$fail" -eq 0 ]; then echo "TODOS OS ASSERTS PASSARAM"; else echo "$fail ASSERT(S) VERMELHO(S)"; exit 1; fi
+```
+
+⚠️ Ao rodar pela primeira vez, se der `column reference "customer_user_id" is ambiguous`: os OUT params de `RETURNS TABLE` são visíveis como variáveis no corpo. Todo acesso já está qualificado (`so.customer_user_id`, `k.cid`) — se ainda ocorrer, adicione `#variable_conflict use_column` na primeira linha do bloco `DECLARE`.
+
+- [ ] **Step 2: Rodar o baseline e exigir VERDE**
+
+```bash
+cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/youthful-wright-ca4cec
+bash db/test-authz-custo-fu4f-fase3.sh > "$SCRATCH/fase3.log" 2>&1; echo "exit=$?"
+grep -c "✅" "$SCRATCH/fase3.log"
+```
+
+Esperado: `exit=0` e **15 asserts verdes**. Baseline verde ANTES de falsificar é obrigatório — sem ele, um exit≠0 na falsificação pode ser o comando quebrado, não o assert com dente.
+
+- [ ] **Step 3: Falsificação 1 — o gate de projeção**
+
+Edite a migration trocando `CASE WHEN v_pode_num THEN round(k.pct, 1) END` por `round(k.pct, 1)`. Rode de novo.
+
+Esperado: `exit=1` com **exatamente 1 vermelho: `B2`**. Se outro assert cair junto, a sabotagem foi mais larga do que se pretendia — reverta e refaça. **Reverta a sabotagem depois.**
+
+- [ ] **Step 4: Falsificação 2 — o gate de escopo**
+
+Troque o `WHERE` final por `WHERE true`. Rode.
+
+Esperado: `exit=1` com vermelhos em **`A2`** (A passa a ver o cliente de B) e **`D2`**. **Reverta.**
+
+- [ ] **Step 5: Falsificação 3 — o limiar da faixa**
+
+A falsificação do **caminho do JOIN** mudou de casa: agora ela vive no harness do helper (`db/test-margem-cliente-helper-compartilhado.sh`, F1), porque o JOIN mudou de casa junto. Aqui a sabotagem certa é o limiar.
+
+Troque `WHEN m.margem_pct < v_piso THEN 'amarelo'` por `WHEN m.margem_pct < 0 THEN 'amarelo'`. Rode.
+
+Esperado: `exit=1` com **`C1`** vermelho (margem 5% deixa de cair em amarelo e vira verde). Prova que a faixa lê o limiar de config, e não uma constante embutida. **Reverta.**
+
+⚠️ O harness desta task precisa **stubar** `private.margem_cliente_agregada()` — a função real vem do PR #1519 e não está no repo desta branch. O stub deve devolver `(customer_user_id, margem_pct)` controlável por seed, e o comentário tem de dizer que a fidelidade do CÁLCULO é provada lá, não aqui. Stubar o helper aqui é legítimo (esta função não o implementa); stubar o **gate** não seria.
+
+- [ ] **Step 6: Confirmar verde após reverter as três sabotagens**
+
+```bash
+bash db/test-authz-custo-fu4f-fase3.sh > "$SCRATCH/fase3-final.log" 2>&1; echo "exit=$?"
+grep -c "✅" "$SCRATCH/fase3-final.log"
+git diff --stat supabase/migrations/   # tem de vir VAZIO
+```
+
+Esperado: `exit=0`, 15 verdes, e **diff vazio na migration** (todas as sabotagens revertidas).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add db/test-authz-custo-fu4f-fase3.sh
+git commit -m "test(authz): prova PG17 da RPC de faixa de margem (15 asserts + 3 falsificações)"
+```
+
+---
+
+### Task 4: Harness de paridade TS×SQL
+
+Prova que a RPC não muda score — o baseline da entrega.
+
+**Files:**
+- Create: `db/test-fu4f-fase3-paridade-margem.sh`
+
+**Interfaces:**
+- Consumes: `accumulateMarginFromItems` (`src/lib/scoring/margin.ts`), a RPC da Task 2
+- Produces: exit 0 se **toda** faixa bate entre TS e SQL
+
+- [ ] **Step 1: Escrever o harness**
+
+Mesma estrutura PG17 (`SLUG="fu4f3par"`, `PORT="${PGPORT_TEST:-5464}"`), mas o cenário é: semear N clientes com margens em torno dos limiares, calcular a faixa **pelos dois caminhos** e exigir igualdade.
+
+O lado TS roda via `bun`, lendo o mesmo seed exportado como JSON:
+
+```bash
+# Exporta o seed do PG17 no formato que o helper TS consome.
+Pq -c "SELECT json_agg(row_to_json(t)) FROM (
+  SELECT so.customer_user_id AS cid,
+         json_agg(json_build_object(
+           'omie_codigo_produto', oi.omie_codigo_produto,
+           'quantity', oi.quantity,
+           'unit_price', oi.unit_price)) AS items
+    FROM public.sales_orders so JOIN public.order_items oi ON oi.sales_order_id=so.id
+   WHERE so.status IN ('confirmado','faturado','entregue')
+   GROUP BY 1) t;" > "$TMPSEED/pedidos.json"
+
+Pq -c "SELECT json_agg(row_to_json(t)) FROM (
+  SELECT op.omie_codigo_produto AS cod, op.id AS pid,
+         COALESCE(NULLIF(pc.cost_final,'NaN'), NULLIF(pc.cost_price,'NaN')) AS custo
+    FROM public.omie_products op JOIN public.product_costs pc ON pc.product_id=op.id
+   WHERE COALESCE(NULLIF(pc.cost_final,'NaN'), NULLIF(pc.cost_price,'NaN')) > 0) t;" > "$TMPSEED/custos.json"
+
+# Lado TS: replica exatamente o que o hook faz.
+cat > "$TMPSEED/paridade.ts" <<'TS'
+import { accumulateMarginFromItems } from '../../src/lib/scoring/margin';
+const pedidos = JSON.parse(await Bun.file(process.argv[2]).text() || '[]');
+const custos  = JSON.parse(await Bun.file(process.argv[3]).text() || '[]');
+const piso = Number(process.argv[4]); const meta = Number(process.argv[5]);
+
+const costMap = new Map<string, number>();
+const omieToProductId = new Map<number, string>();
+for (const c of custos) { costMap.set(c.pid, Number(c.custo)); omieToProductId.set(Number(c.cod), c.pid); }
+
+const out: Record<string, string> = {};
+for (const p of pedidos) {
+  const { revenue, cost } = accumulateMarginFromItems(p.items, costMap, omieToProductId);
+  if (revenue <= 0) { out[p.cid] = 'neutro'; continue; }
+  const pct = (revenue - cost) / revenue * 100;
+  out[p.cid] = pct < 0 ? 'vermelho' : pct < piso ? 'amarelo' : 'verde';
+}
+console.log(JSON.stringify(out));
+TS
+
+TS_OUT="$(bun run "$TMPSEED/paridade.ts" "$TMPSEED/pedidos.json" "$TMPSEED/custos.json" 30 50)"
+SQL_OUT="$(como <gestor-uid> false true \
+  "SELECT json_object_agg(customer_user_id, faixa)::text FROM public.get_carteira_margem_faixa();")"
+```
+
+Assert final:
+
+```bash
+# Compara chave a chave, com os dois lados NORMALIZADOS pelo mesmo jq.
+DIFF="$(printf '%s' "$TS_OUT"  | jq -S . > "$TMPSEED/ts.json";
+        printf '%s' "$SQL_OUT" | jq -S . > "$TMPSEED/sql.json";
+        diff "$TMPSEED/ts.json" "$TMPSEED/sql.json" || true)"
+if [ -z "$DIFF" ]; then ok "P1 TS e SQL produzem a MESMA faixa para todos os clientes";
+else bad "P1 divergência TS×SQL" "(sem diferença)" "$DIFF"; fi
+```
+
+⚠️ `printf '%s'`, **nunca `echo`** — no zsh o `echo` interpreta o `\n` escapado e corrompe o JSON antes do `jq`.
+
+- [ ] **Step 2: Semear os casos de fronteira**
+
+Semeie clientes com margem **exatamente** em 0%, 30% e 50% (os limiares) e ±0,05 em volta. É onde o delta de 8 itens entre jsonb e relacional poderia mover uma faixa.
+
+- [ ] **Step 3: Rodar e exigir verde**
+
+```bash
+bash db/test-fu4f-fase3-paridade-margem.sh > "$SCRATCH/par.log" 2>&1; echo "exit=$?"
+```
+
+Esperado: `exit=0`.
+
+- [ ] **Step 4: Falsificar a paridade**
+
+Mude o piso do lado TS para `35` (só no comando `bun run`, argumento 4). Rode.
+
+Esperado: `exit=1` com `P1` vermelho listando os clientes que mudaram de faixa. Prova que o comparador tem dente — sem isso, um `P1` verde poderia significar "os dois lados devolveram vazio". **Reverta para 30.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add db/test-fu4f-fase3-paridade-margem.sh
+git commit -m "test(scoring): paridade TS×SQL da faixa de margem (com falsificação)"
+```
+
+---
+
+### Task 5: O hook para de baixar custo
+
+> ⚠️ **ERRATA — o `const g = gDaFaixa(mf.faixa)` desta task não é o que o #1543 faz.** O `g` vem
+> pronto da RPC (régua de percentis) e é `NULL` quando a margem não é apurável; o
+> `calcularHealthScore` renormaliza os pesos. Ver errata no topo do arquivo.
+
+**Files:**
+- Modify: `src/hooks/useFarmerScoring.ts`
+
+**Interfaces:**
+- Consumes: `gDaFaixa`, `FaixaMargem` (Task 1); `get_carteira_margem_faixa()` (Task 2)
+- Produces: `ClientScore.margemFaixa: FaixaMargem`, `ClientScore.margemPct: number | null` (substituem `grossMarginPct: number`)
+
+- [ ] **Step 1: Trocar o tipo `ClientScore`**
+
+Em `src/hooks/useFarmerScoring.ts`, na interface `ClientScore` (bloco "// Raw"), substitua:
+
+```ts
+  grossMarginPct: number;
+```
+
+por:
+
+```ts
+  /** Faixa de margem vinda da RPC gateada. O número só vem com cap_custo_ler. */
+  margemFaixa: FaixaMargem;
+  margemPct: number | null;
+```
+
+E acrescente ao topo do arquivo:
+
+```ts
+import { gDaFaixa, type FaixaMargem } from '@/lib/scoring/faixaMargem';
+```
+
+- [ ] **Step 2: Remover o fetch de custo**
+
+Apague o bloco inteiro das linhas ~180-193 (comentário `// 2. Load product costs...`, o `fetchAllPages` de `product_costs`, a construção do `costMap` e o `import { custoCanonico }` se ficar órfão).
+
+⚠️ **Não remova** o fetch de `omie_products` (linhas ~195-210): o `omieToProductId` ainda é usado por `resolveProductIdsFromItems` para o componente X (diversidade de mix).
+
+- [ ] **Step 3: Substituir por a chamada à RPC**
+
+No lugar do bloco removido:
+
+```ts
+      // 2. Faixa de margem por cliente — o custo é lido no SERVIDOR e não vem para cá.
+      // FU4-F fase 3: a RPC devolve a faixa; `margem_pct` só é projetada sob cap_custo_ler.
+      const { data: faixasData, error: faixasErr } = await supabase
+        .rpc('get_carteira_margem_faixa');
+      // FAIL-CLOSED (money-path): se a faixa não vier, aborta em vez de pontuar todo
+      // mundo como neutro — um erro de RPC não pode virar "margem desconhecida" silenciosa.
+      if (faixasErr) {
+        console.warn('[useFarmerScoring] erro ao ler faixa de margem, abortando:', faixasErr.message);
+        setCalculating(false);
+        setLoading(false);
+        return;
+      }
+      const faixaPorCliente = new Map<string, { faixa: FaixaMargem; pct: number | null }>();
+      for (const r of faixasData ?? []) {
+        faixaPorCliente.set(r.customer_user_id, {
+          faixa: r.faixa as FaixaMargem,
+          pct: r.margem_pct == null ? null : Number(r.margem_pct),
+        });
+      }
+```
+
+- [ ] **Step 4: Remover a acumulação de custo do laço de pedidos**
+
+Nas linhas ~277-281, apague as três linhas de margem:
+
+```ts
+        const { revenue, cost } = accumulateMarginFromItems(items, costMap, omieToProductId);
+        cd.totalRevenue += revenue;
+        cd.totalCost += cost;
+```
+
+Remova também `totalRevenue`/`totalCost` da interface `CustomerData` e da inicialização em `customerMap.set(...)`.
+
+⚠️ **Mantenha** o laço `for (const pid of resolveProductIdsFromItems(...)) cd.categories.add(pid);` — é o componente X.
+
+- [ ] **Step 5: Remover o cálculo de percentis de margem**
+
+Nas linhas ~302-311, apague `allMargins` e o `if (cd.totalRevenue > 0) allMargins.push(...)`. Apague também `p10Margin`, `p90Margin` e `marginRange` onde forem computados. Os percentis agora vivem no servidor (nos limiares de config).
+
+- [ ] **Step 6: Trocar o cálculo de `g`**
+
+Na linha ~350-351, substitua:
+
+```ts
+        const clientMargin = cd.totalRevenue > 0 ? (cd.totalRevenue - cd.totalCost) / cd.totalRevenue : 0;
+        const g = clamp((clientMargin - p10Margin) / marginRange, 0, 1);
+```
+
+por:
+
+```ts
+        // Cliente sem linha na RPC = sem custo conhecido = neutro (o INNER JOIN o descarta).
+        const mf = faixaPorCliente.get(cid) ?? { faixa: 'neutro' as FaixaMargem, pct: null };
+        const g = gDaFaixa(mf.faixa);
+```
+
+- [ ] **Step 7: Trocar o campo emitido**
+
+Na linha ~410, substitua `grossMarginPct: Math.round(clientMargin * 1000) / 10,` por:
+
+```ts
+          margemFaixa: mf.faixa,
+          margemPct: mf.pct,
+```
+
+- [ ] **Step 8: Typecheck e lint**
+
+```bash
+cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/youthful-wright-ca4cec
+heavy bun run typecheck > "$SCRATCH/tc.log" 2>&1; echo "typecheck=$?"
+heavy bun run lint      > "$SCRATCH/lint.log" 2>&1; echo "lint=$?"
+```
+
+Esperado: ambos `=0`. O typecheck vai apontar `FarmerDashboard.tsx:442` (ainda usa `grossMarginPct`) — é a Task 6. Se quiser os dois verdes juntos, faça a Task 6 antes de commitar.
+
+- [ ] **Step 9: Commit (junto com a Task 6)**
+
+---
+
+### Task 6: A UI exibe a faixa
+
+**Files:**
+- Modify: `src/pages/FarmerDashboard.tsx:442`
+
+**Interfaces:**
+- Consumes: `ClientScore.margemFaixa`, `ClientScore.margemPct`, `FAIXA_LABEL` (Task 1)
+
+- [ ] **Step 1: Substituir a linha de métrica**
+
+Em `src/pages/FarmerDashboard.tsx:442`, troque:
+
+```tsx
+          <MetricRow label="Margem bruta" value={`${client.grossMarginPct.toFixed(1)}%`} />
+```
+
+por:
+
+```tsx
+          <MetricRow
+            label="Margem bruta"
+            value={
+              client.margemPct != null
+                ? `${client.margemPct.toFixed(1)}%`
+                : FAIXA_LABEL[client.margemFaixa]
+            }
+          />
+```
+
+E importe: `import { FAIXA_LABEL } from '@/lib/scoring/faixaMargem';`
+
+Quem tem `cap_custo_ler` continua vendo o número; quem não tem vê o rótulo da faixa.
+
+- [ ] **Step 2: Usar as cores de status do design system**
+
+Se acrescentar indicador visual, use `text-status-success/warning/error` — **não** `text-emerald-600`/`text-red-600`.
+
+- [ ] **Step 3: Rodar a stack de saúde inteira**
+
+```bash
+cd /Users/lucassardenberg/Projetos/afiacao/.claude/worktrees/youthful-wright-ca4cec
+heavy bun run typecheck > "$SCRATCH/h-tc.log"   2>&1; echo "typecheck=$?"
+heavy bun run test      > "$SCRATCH/h-test.log" 2>&1; echo "test=$?"
+heavy bun run lint      > "$SCRATCH/h-lint.log" 2>&1; echo "lint=$?"
+bunx knip               > "$SCRATCH/h-knip.log" 2>&1; echo "knip=$?"
+```
+
+Esperado: os quatro `=0`. **Espere TODOS** antes de commitar — o gate que você não esperou é o que pega a classe de erro que você não previu.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useFarmerScoring.ts src/pages/FarmerDashboard.tsx
+git commit -m "feat(farmer): scoring lê faixa de margem por RPC e para de baixar product_costs"
+```
+
+---
+
+### Task 7: Tipos, validação pós-apply e PR
+
+**Files:**
+- Modify: `src/integrations/supabase/types.ts`
+- Create: `db/test-authz-custo-fu4f-fase3.sql`
+
+- [ ] **Step 1: Acrescentar a RPC aos tipos**
+
+`types.ts` é gerado pelo **Lovable** e só regenera quando ELE aplica a migration. Migration colada à mão **não toca os tipos** — e o primeiro PR que referenciar a RPC deixa a `main` vermelha, travando o auto-merge de todos os PRs abertos.
+
+Em `types.ts`, no bloco `Functions:`, insira **em ordem alfabética** (convenção do gerador, para o diff ser mínimo quando o Lovable regenerar):
+
+```ts
+      get_carteira_margem_faixa: {
+        Args: Record<PropertyKey, never>
+        Returns: {
+          customer_user_id: string
+          faixa: string
+          motivo: string
+          margem_pct: number | null
+        }[]
+      }
+```
+
+- [ ] **Step 2: Escrever a validação pós-apply**
+
+```sql
+-- db/test-authz-custo-fu4f-fase3.sql
+-- Validação pós-apply do FU4-F fase 3. LÊ CATÁLOGO — nunca invoca a função
+-- (invocar exige EXECUTE e dá falso-negativo sob psql-ro, que é o REVOKE funcionando).
+--   ~/.config/afiacao/psql-ro -f db/test-authz-custo-fu4f-fase3.sql
+
+\echo '=== 1. a função existe e é SECURITY DEFINER STABLE ==='
+SELECT p.proname, p.prosecdef AS secdef, p.provolatile AS volatilidade,
+       p.proconfig AS search_path
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa';
+-- Esperado: 1 linha, secdef=t, volatilidade=s, search_path={"search_path=public, pg_temp"}
+
+\echo '=== 2. ACL: anon e PUBLIC fora; authenticated dentro ==='
+SELECT has_function_privilege('anon',          'public.get_carteira_margem_faixa()','EXECUTE') AS anon_exec,
+       has_function_privilege('authenticated', 'public.get_carteira_margem_faixa()','EXECUTE') AS auth_exec,
+       has_function_privilege('public',        'public.get_carteira_margem_faixa()','EXECUTE') AS public_exec;
+-- Esperado: f | t | f
+
+\echo '=== 3. o gate de projeção está no CORPO (âncora ESTRUTURAL, não substring) ==='
+SELECT (pg_get_functiondef(p.oid) ~ 'cap_custo_ler\(v_uid\)')                      AS tem_gate_custo,
+       (pg_get_functiondef(p.oid) ~ 'CASE WHEN v_pode_num THEN round')             AS tem_projecao,
+       (pg_get_functiondef(p.oid) ~ 'carteira_visivel_para\(k\.cid, v_uid\)')      AS tem_gate_escopo,
+       (pg_get_functiondef(p.oid) ~ 'omie_codigo_produto')                         AS usa_caminho_certo,
+       (pg_get_functiondef(p.oid) !~ 'cu\.cod = oi\.product_id')                   AS nao_usa_atalho
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+ WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa';
+-- Esperado: t | t | t | t | t
+
+\echo '=== 4. os limiares foram semeados ==='
+SELECT key, value FROM public.farmer_algorithm_config
+ WHERE key IN ('margem_faixa_piso_pct','margem_faixa_meta_pct') ORDER BY key;
+-- Esperado: 2 linhas — margem_faixa_meta_pct=50, margem_faixa_piso_pct=30
+```
+
+⚠️ **Teste os regexes contra a PROD antes de entregar** — validação que não casa nada é pior que nenhuma.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/integrations/supabase/types.ts db/test-authz-custo-fu4f-fase3.sql
+git commit -m "chore(authz): tipos da RPC de faixa + validação pós-apply do FU4-F fase 3"
+```
+
+- [ ] **Step 4: Abrir o PR em DRAFT**
+
+```bash
+git push -u origin feat/authz-fu4f-fase3-farmer-scoring-custo
+gh pr create --draft --title "feat(authz): FU4-F fase 3 — scoring do farmer para de baixar o catálogo de custo [money-path]" --body-file <(cat <<'MD'
+Fecha a maior via browser→custo: `useFarmerScoring` baixava `product_costs` INTEIRA
+(3.637 linhas, paginada de propósito para furar a capa de 1.000) e calculava margem em memória.
+
+**Decisão de produto (dono, 2026-07-20):** o NÚMERO de custo fecha, o SINAL fica.
+
+## O follow-up que originou isto estava errado — e vale registrar
+
+O enunciado apontava `farmer_client_scores.gross_margin_pct` como derivado invertível do custo.
+Medido em prod: **0 em 6.632/6.632 linhas, 1 valor distinto, sem writer nenhum**. Com margem 0
+para todos, não há custo a deduzir. A nota de desenho também errava ao propor `g_score` como
+substituto: o `g_score` persistido é **diversidade**, não margem (841 não-zero, acompanha
+`category_count`). Detalhe na spec.
+
+## O que este PR NÃO fecha
+
+**Faixa não é divulgação zero, é divulgação limitada.** Por cliente, a faixa agrega a cesta
+inteira e não se inverte para custo unitário — o estreitamento é forte, mas não nulo.
+`product_costs` continua com policy `master OR employee` e legível por outras vias
+(cross-sell/bundle, no chip irmão). Este PR fecha **uma** via e não altera a tabela.
+
+## ⚠️ Migration manual
+
+`20260724130000_authz_custo_fu4f_fase3_farmer_faixa.sql` — nome custom **não** auto-aplica.
+Colar no SQL Editor do Lovable → Run. Validar com `db/test-authz-custo-fu4f-fase3.sql`.
+Ordem: **migration → Publish do frontend** (o front novo depende da RPC).
+
+## Prova
+
+- `db/test-authz-custo-fu4f-fase3.sh` — 15 asserts + 3 falsificações (gate de projeção, gate de escopo, caminho do JOIN)
+- `db/test-fu4f-fase3-paridade-margem.sh` — paridade TS×SQL: a faixa tem de bater entre o cálculo do hook e o da RPC
+MD
+)
+```
+
+- [ ] **Step 5: Armar o watcher do PR**
+
+```bash
+bash scripts/pr-watch.sh <nº> &
+```
+
+Rodar com `run_in_background: true`. **Exit 6 ≠ 5**: 6 = não consegui consultar (estado DESCONHECIDO) → confirmar com `gh pr view` antes de avisar qualquer coisa.
+
+- [ ] **Step 6: Codex adversarial antes de tirar do draft**
+
+```bash
+bash scripts/codex-async.sh challenge --model gpt-5.6-sol --effort xhigh ...
+```
+
+Rodar em background. Apresentar o parecer **CRU** + a calibração **SEPARADA** — nunca só a síntese. Não deixar o Codex abrir `supabase/schema-snapshot.sql` (estoura o contexto e trava): pôr os fatos de schema no próprio prompt.
+
+---
+
+## Self-Review
+
+**Cobertura da spec:**
+
+| seção da spec | task |
+|---|---|
+| §3.1 contrato da RPC | Task 2 |
+| §3.1b limiar fixo configurável | Task 2 (seeds) |
+| §3.2 mudança no hook | Task 5 |
+| §3.3 `neutro → g=0` | Task 1 (`gDaFaixa`) + Task 5 |
+| §4 paridade TS×SQL | Task 4 |
+| §4 unicidade do JOIN | Task 3 (falsificação 3) + Task 7 (validação, `nao_usa_atalho`) |
+| §5 prova + falsificação | Tasks 3 e 4 |
+| §6 entrega (migration manual, tipos, Publish) | Task 7 |
+| §7 o que não fecha | Task 7 (corpo do PR) |
+
+**Consistência de tipos:** `FaixaMargem` (Task 1) é usado em Tasks 5 e 6; `gDaFaixa` só em Task 5; `FAIXA_LABEL` só em Task 6; a RPC devolve `customer_user_id/faixa/motivo/margem_pct` e as Tasks 5 e 7 usam exatamente esses quatro nomes.
+
+**Risco residual conhecido:** o delta de 8 itens (0,017%) entre o jsonb que o hook lê e o `order_items` que a RPC lê. Coberto pela Task 4 (paridade com casos de fronteira nos limiares) — se mover alguma faixa, aparece lá.

--- a/docs/superpowers/specs/2026-07-20-fechamento-custo-farmer-scoring-design.md
+++ b/docs/superpowers/specs/2026-07-20-fechamento-custo-farmer-scoring-design.md
@@ -1,0 +1,354 @@
+# FU4-F fase 3 — o scoring do farmer para de baixar o catálogo de custo
+
+> Spec de desenho. Escopo: **apenas** `useFarmerScoring`. As outras vias browser→custo estão
+> inventariadas na §9 e ficam para PRs próprios.
+>
+> Decisão de produto (dono, 2026-07-20): **o NÚMERO de custo fecha, o SINAL fica.**
+
+---
+
+## ⚠️ ERRATA (2026-08-13) — leia antes do corpo
+
+Este documento nasceu numa branch que nunca virou PR (`feat/authz-fu4f-fase3-farmer-scoring-custo`)
+e chega à `main` **três semanas depois de escrito**, para não morrer com a branch. O corpo abaixo
+está **preservado como foi escrito em 2026-07-20** — é o registro do raciocínio datado, não uma
+descrição do código de hoje. O padrão é o da [`db/nota-1530-premissa-envelheceu.md`](../../../db/nota-1530-premissa-envelheceu.md):
+corrigir por errata datada, nunca reescrevendo o original.
+
+**A implementação vive no [PR #1543](https://github.com/LucasSardenbergL/afiacao/pull/1543)
+(`feat/fu4f-fase3-hook-consome-helper`), OPEN e DRAFT.** Em três pontos ela **divergiu deste spec
+de propósito**, e em todos os três o código é a autoridade:
+
+| § | o que o spec diz | o que vale hoje |
+|---|---|---|
+| **§1**, §9.1 e a tabela de medição | `gross_margin_pct` é coluna **estruturalmente morta**: 6.632/6.632 em zero, 1 valor distinto, sem writer | **Falso desde 2026-07-21.** Medido em prod 2026-08-13 (`psql-ro`): **1.075 não-zero · 5.558 NULL · 0 zeros** (6.633 linhas). O #1495 criou o writer (`get_customer_margin_summary`) e o [#1705](https://github.com/LucasSardenbergL/afiacao/pull/1705) removeu o zero fabricado. O follow-up §9.1 ("popular ou dropar") **está resolvido: populada.** |
+| **§3.2** (último item) e **§3.3** | `g` deriva da faixa — `verde=1.0 · amarelo=0.5 · vermelho=0.0 · neutro=0.0`; o `neutro → g=0` **preserva** a fabricação de propósito | **Rejeitado por medição** no #1543. Mapear faixa→`g` descartaria a régua de percentis e mudaria o health score de **68% dos clientes com margem** (5,73 pontos em média, 14,42 no pior caso) — mudança de PRODUTO embutida numa entrega de AUTORIZAÇÃO. O `g` passou a vir **calculado do servidor**, com a mesma régua de sempre, e é **`NULL`** quando a margem não é apurável (o `calcularHealthScore` renormaliza os pesos). Ou seja: a fabricação que a §3.3 dizia deixar para follow-up **foi consertada junto**. |
+| **§4** (o JOIN, o custo canônico, o filtro de status) | tudo isso vive dentro da RPC nova | Migrou para `private.margem_cliente_agregada()` ([#1519](https://github.com/LucasSardenbergL/afiacao/pull/1519), **já aplicada em prod**), depois que o #1495 mostrou duas autoridades money-path divergindo em 28,5% dos clientes na faixa. A `get_carteira_margem_faixa()` do #1543 é a camada **fina** por cima. As medições da §4 continuam válidas — são elas que justificam o caminho do helper. |
+
+**O que NÃO envelheceu** (e é por isso que este documento foi preservado): a calibragem medida dos
+limiares — `piso = 30` / `meta = 50` sobre 746 clientes, §3.1b — que hoje são os `COALESCE` da
+migration do #1543; o vocabulário `verde|amarelo|vermelho|neutro` herdado do cockpit; os dois gates
+(`cap_custo_ler` para o número, escopo de carteira para a linha); e o **caminho do JOIN descartado
+por medição** (§4): `order_items.product_id` tem 1.835/68.459 nulos (2,7%) e `omie_codigo_produto`
+cobre 100% — a decisão que sobreviveu ao helper e explica por que ele resolve custo por código.
+
+**O vazamento que motivou tudo continua aberto**: [`useFarmerScoring.ts:189`](../../../src/hooks/useFarmerScoring.ts)
+ainda baixa `product_costs` inteira para o browser na `main`, e `public.get_carteira_margem_faixa`
+não existe em prod (conferido em `pg_proc`, 2026-08-13). Este spec descreve trabalho **pendente**,
+não entregue.
+
+⚠️ **Ao retomar o #1543, não implemente `gDaFaixa()`** — a função foi deliberadamente não-criada, e
+o plano-irmão ainda a especifica. Ver a errata de lá.
+
+---
+
+## 1. O follow-up que originou isto estava errado — e o erro importa
+
+⚠️ **ERRATA: a medição desta seção é de 2026-07-20 e virou em 2026-07-21.** A coluna deixou de ser
+morta — hoje são 1.075 não-zero e 5.558 NULL, zero fabricado nenhum. O raciocínio abaixo (a
+distinção `m_score`=margem × `g_score`=diversidade, e o erro do enunciado) **continua correto e é o
+motivo de a seção ficar aqui**; só a tabela de contagens envelheceu. Ver errata no topo.
+
+O enunciado do FU4-F fase 3 apontava `farmer_client_scores.gross_margin_pct` como derivado
+persistido do custo, invertível por `custo = receita × (1 − margem%)`. **Medido em prod
+(2026-07-20, `psql-ro`), o vazamento não existe:**
+
+| métrica | valor |
+|---|---|
+| linhas | 6.632 |
+| não-nulas | 6.632 |
+| **≠ 0** | **0** |
+| valores distintos | **1** (zero) |
+| último `calculated_at` | 2026-07-20 06:00:33 (cron rodou) |
+
+A coluna é estruturalmente morta: [`calculate-scores/index.ts:355`](../../../supabase/functions/calculate-scores/index.ts)
+grava `gross_margin_pct: 0` literal no seed, e a interface `ScoreUpdate` (`:69-90`) — o payload do
+`apply_score_updates` — não contém a coluna, então o UPDATE diário nunca a toca. Confirmado pelo
+catálogo, não pelo repo: **zero** funções em `pg_proc` mencionam a coluna e nenhum cron SQL-inline
+a escreve. Com margem 0 para todos, `custo = receita × (1 − 0) = receita` — não há o que deduzir.
+
+**A nota de desenho do enunciado também estava errada.** Ela propunha `g_score` como "o componente
+de margem normalizado, substituto natural". Previsão falsificável testada contra prod:
+
+| coluna persistida | medido | o que realmente é |
+|---|---|---|
+| `m_score` | 0 não-zero, **1 valor distinto** | margem — morto (deriva de `gross_margin_pct`) |
+| `g_score` | 841 não-zero, 52 distintos, 0–100; acompanha `category_count` monotonicamente | **diversidade** |
+
+A edge grava `g_score: Math.round(diversityScore)` ([`:546`](../../../supabase/functions/calculate-scores/index.ts)).
+As duas implementações usam as mesmas letras para grandezas diferentes — no hook `m`=monetário,
+`g`=margem, `x`=diversidade; na edge `m_score`=margem, `g_score`=diversidade. Adotar `g_score` como
+substituto trocaria margem por diversidade em silêncio.
+
+**Consequência que facilita o conserto:** como `marginScore=0` para todos, o `health_score`
+**persistido já ignora margem** (peso de 20% zerado). O hook é o único lugar onde margem influencia
+score — grosseirizar o `g` do hook o aproxima da edge, não o afasta.
+
+## 2. O vazamento real
+
+[`useFarmerScoring.ts:181-193`](../../../src/hooks/useFarmerScoring.ts) baixa o catálogo de custo
+inteiro para o browser:
+
+```ts
+const productCosts = await fetchAllPages<ProductCostRow>((de, ate) =>
+  supabase.from('product_costs').select('product_id, cost_final, cost_price')...
+```
+
+Paginado **de propósito** para furar a capa de 1.000 do PostgREST (comentário: *"3.637 linhas > capa
+de 1.000"*). Em prod: 3.637 linhas, 3.637 com custo. `product_costs` segue com policy
+`master OR employee`, sem `cap_custo_ler` — exatamente o que o [#1473](https://github.com/LucasSardenbergL/afiacao/pull/1473)
+documentou como não-fechado.
+
+O hook calcula margem por cliente em memória e a expõe duas vezes: `grossMarginPct`
+(renderizado em [`FarmerDashboard.tsx:442`](../../../src/pages/FarmerDashboard.tsx)) e o componente
+`g` do health score.
+
+**O vazamento é a resposta de rede, não o número renderizado.** Mascarar a saída mantendo o `fetch`
+deixa as 3.637 linhas visíveis no DevTools. O conserto tem de remover a busca. Por isso o padrão do
+#1473 (view operacional sem a coluna sensível) não transporta: ali havia uma coluna a projetar; aqui
+o hook lê a tabela inteira e não há o que projetar — há o que **não entregar**.
+
+## 3. Desenho: espelhar `get_preco_cockpit` um nível acima
+
+`get_preco_cockpit` já é a implementação de referência do padrão exato de que precisamos, por SKU.
+Este desenho a espelha, agregando por cliente — **não inventa padrão novo**:
+
+| elemento | valor herdado do cockpit |
+|---|---|
+| gate de custo | `private.cap_custo_ler(auth.uid())` |
+| faixa | `verde` · `amarelo` · `vermelho` · `neutro` |
+| motivo | `saudavel` · `abaixo_da_meta` · `abaixo_do_piso` · `abaixo_do_custo` · `sem_custo` |
+| gate de projeção | `CASE WHEN v_pode_num THEN to_jsonb(v) ELSE 'null'::jsonb END` |
+| assinatura | `plpgsql STABLE SECURITY DEFINER` |
+
+O `neutro` é obrigatório: o cockpit **não força** um item sem custo para uma faixa colorida. Sem ele,
+cliente sem custo conhecido seria empurrado para uma cor, fabricando sinal.
+
+### 3.1 Contrato da RPC
+
+`get_carteira_margem_faixa()` — uma linha por cliente da carteira do caller:
+
+| campo | tipo | regra |
+|---|---|---|
+| `customer_user_id` | `uuid` | — |
+| `faixa` | `text` | `verde\|amarelo\|vermelho\|neutro` — **sempre presente** |
+| `motivo` | `text` | vocabulário acima |
+| `margem_pct` | `numeric \| null` | **só** quando `cap_custo_ler(auth.uid())`; senão `null` com a chave presente |
+
+Propriedades exigidas:
+
+- `SECURITY DEFINER`, `STABLE`, `SET search_path TO 'public', pg_temp` (`pg_temp` **por último** — regra do FU7)
+- **Escopo espelhando a RLS de `farmer_client_scores`**: `private.cap_carteira_ler(uid) OR private.carteira_visivel_para(customer_user_id, uid)`. Um vendedor recebe só a própria carteira.
+- **Fail-closed**: `auth.uid() IS NULL` → zero linhas
+- `REVOKE EXECUTE FROM PUBLIC, anon` **e** `GRANT EXECUTE TO authenticated` — revogar só de `PUBLIC` é no-op (default privilege do Supabase concede por nome)
+- O custo é lido dentro da função e **nunca** sai dela
+
+### 3.1b O que determina a faixa — limiar fixo configurável
+
+No cockpit, `amarelo` significa "abaixo do piso de markup do SKU", com o piso vindo de
+`resolve_markup_policy`. Para a margem **agregada de um cliente** esse piso não existe: é preciso
+definir o que separa as faixas. **Decisão do dono (2026-07-20): limiar fixo configurável.**
+
+Duas chaves novas em `farmer_algorithm_config` (tabela `key`/`value` numérica, que o hook já lê em
+[`:119`](../../../src/hooks/useFarmerScoring.ts)):
+
+| chave | papel |
+|---|---|
+| `margem_faixa_piso_pct` | abaixo ⇒ `amarelo` (motivo `abaixo_do_piso`) |
+| `margem_faixa_meta_pct` | abaixo ⇒ `verde`/`abaixo_da_meta`; acima ⇒ `verde`/`saudavel` |
+
+Classificação (espelha a cascata do cockpit):
+
+```
+margem desconhecida        → neutro    / sem_custo
+margem < 0                 → vermelho  / abaixo_do_custo
+margem < piso              → amarelo   / abaixo_do_piso
+margem < meta              → verde     / abaixo_da_meta
+caso contrário             → verde     / saudavel
+```
+
+**Por que fixo e não percentil da população:** com percentil, ~10% dos clientes seriam vermelhos
+**por construção**, mesmo num mês em que todos dessem lucro, e a faixa de um cliente mudaria quando
+a população mudasse sem ele fazer nada. O limiar fixo é estável (a faixa só muda se o comportamento
+do cliente mudar) e explicável para a vendedora.
+
+**Valores-semente propostos: `piso = 30`, `meta = 50`.** Medidos em prod (2026-07-20), não
+escolhidos por intuição — distribuição real da margem por cliente sobre **746 clientes** com margem
+calculável:
+
+| p10 | p25 | mediana | p75 | p90 | margem negativa |
+|---|---|---|---|---|---|
+| 24,8% | 37,7% | 52,9% | 65,4% | 73,5% | 7 clientes |
+
+Com piso 30 / meta 50, a carteira se distribui assim:
+
+| faixa | clientes | % |
+|---|---|---|
+| `vermelho` (margem < 0) | 7 | 1% |
+| `amarelo` (0–30%) | 107 | 14% |
+| `verde` / `abaixo_da_meta` (30–50%) | 229 | 31% |
+| `verde` / `saudavel` (≥50%) | 403 | 54% |
+
+~15% da carteira pedindo atenção é uma proporção acionável (nem alarme constante, nem tudo verde).
+Como são linhas de `farmer_algorithm_config`, mudar os limiares é um `UPDATE`, não um deploy.
+
+**Cobertura da faixa** (medida): dos 6.632 registros de `farmer_client_scores`, apenas **854 clientes
+têm pedido** nos 3 status — o resto são linhas sem compra (inclui os ~1.459 clones/aliases fiscais
+documentados em `database.md` §5). Desses 854, **746 recebem faixa real (87%)** e **108 caem em
+`neutro`**. A lacuna 6.632→854 não é falha de cobertura; é a tabela de scores conter clientes que
+nunca compraram.
+
+### 3.2 Mudança no hook
+
+- Sai o `fetchAllPages` de `product_costs` e o `costMap` (linhas 181-193)
+- Entra a chamada à RPC
+- `ClientScore.grossMarginPct: number` → `margemFaixa: 'verde'|'amarelo'|'vermelho'|'neutro'` + `margemPct: number | null`
+- `FarmerDashboard:442` passa a exibir a faixa
+- `g` deriva da faixa: **verde=1.0 · amarelo=0.5 · vermelho=0.0 · neutro=0.0**
+  — ⚠️ **ERRATA: este item foi rejeitado por medição.** O `g` vem do servidor com a régua de
+  percentis; não existe `gDaFaixa()`. Ver errata no topo.
+
+### 3.3 O `neutro` mapeia para 0 **de propósito** neste PR
+
+⚠️ **ERRATA: esta seção inteira não descreve o código.** O #1543 mapeia `neutro → g = NULL` e
+renormaliza os pesos — a fabricação foi consertada nesta mesma entrega, não adiada. Ver errata no topo.
+
+Hoje, cliente sem SKU de custo conhecido cai em `clientMargin = 0` (ternário da
+[linha 350](../../../src/hooks/useFarmerScoring.ts)) e recebe `g≈0` — tratado como **pior margem
+possível**. É o `Number(null)===0` que o money-path proíbe, e o `neutro` o nomeia pela primeira vez.
+
+**Este PR preserva esse comportamento** (`neutro → g=0`). Consertar a fabricação junto misturaria
+conserto de autorização com mudança de score e destruiria o baseline que prova que nada mais mudou.
+Aprovado pelo dono (2026-07-20). Follow-up registrado na §9.
+
+Nuance a preservar na paridade: a população dos percentis (`allMargins`,
+[linha 309](../../../src/hooks/useFarmerScoring.ts)) inclui **apenas** clientes com
+`totalRevenue > 0`, mas `g` é calculado para todos — inclusive os que não entram na população.
+
+## 4. Paridade TS×SQL — o que tem de casar exatamente
+
+A RPC recalcula server-side o que o hook calcula client-side. Divergência aqui muda score por motivo
+**alheio à segurança** — é o risco principal desta entrega.
+
+| dimensão | o que o hook faz | fonte |
+|---|---|---|
+| universo de pedidos | `.in('status', ['confirmado','faturado','entregue'])` | `:146` |
+| data | `order_date_kpi ?? created_at` | `:265` |
+| exclusão | `cliente_classificacao.excluir_da_carteira = true` sai **antes** do cálculo; leitura falha ⇒ **aborta** (fail-closed) | `:159-178` |
+| mapeamento SKU | `omie_products.omie_codigo_produto → .id → product_costs.product_id` | `:207-210` |
+| custo canônico | `custoValido(cost_final) ?? custoValido(cost_price)`, onde válido = finito **e > 0** | `custoCanonico.ts` |
+| margem | só sobre SKU com custo **conhecido**; `(totalRevenue − totalCost) / totalRevenue`, `0` se receita 0 | `:277-281`, `:350` |
+| percentis | p10/p90 sobre clientes com `totalRevenue > 0` | `:309-311` |
+
+⚠️ **`NaN`**: `custoValido` usa `Number.isFinite`. Em `numeric` do Postgres `'NaN'` é valor legítimo
+(o próprio `get_preco_cockpit` testa `<> 'NaN'::numeric`) — o SQL precisa excluí-lo, senão a paridade
+quebra exatamente onde ninguém olha.
+
+⚠️ **O atalho do JOIN está DESCARTADO por medição — a RPC segue o caminho do hook.** `order_items`
+tem `product_id` **direto** (colunas reais: `id, sales_order_id, customer_user_id, product_id,
+omie_codigo_produto, quantity, unit_price, discount, created_at, hash_payload`), então o SQL
+*poderia* ir direto a `product_costs.product_id`. Medido em prod: dos **68.459** itens, **1.835 têm
+`product_id` NULL** (2,7%) e **zero** têm `omie_codigo_produto` NULL. O hook chega ao custo por
+`omie_codigo_produto → omie_products.id`, que cobre **100%** dos itens; o atalho **descartaria 1.835
+itens em silêncio**, mudando a margem dos clientes afetados.
+
+⇒ **A RPC usa `omie_codigo_produto → omie_products.id → product_costs.product_id`.** Não é
+preferência estilística: é a diferença entre paridade e uma divergência de 2,7% que nenhum teste de
+"a RPC funciona" pegaria. Custou uma rodada de calibragem — a primeira medição desta spec usou o
+atalho e perdeu 2 clientes inteiros além de distorcer percentis.
+
+⚠️ **Duplicação de JOIN — medida, não suposta.** O `database.md` avisa que
+*"`omie_products.account` é convenção EMPRESA; JOIN account-blind em RPC money-path duplica
+silenciosamente"*. O hook usa `Map.set()` (last-write-wins, escolhe **um** `product_id`); um JOIN em
+SQL produziria N linhas. Medido em prod: `omie_codigo_produto` é **único** (7.962 linhas / 7.962
+distintos, cada código em exatamente **1** account) e `product_costs` tem 1 linha por `product_id`
+(3.637/3.637) ⇒ **o JOIN não duplica hoje**. Mas isso é um fato do **dado**, não uma constraint: um
+sync de account nova o quebra em silêncio. **O harness deve travar a unicidade com assert próprio**,
+para que a regressão apareça como teste vermelho e não como margem dobrada.
+
+## 5. Como se prova
+
+1. **Harness de paridade TS×SQL** (padrão do repo, ex.: `db/test-city-norm-paridade.sh`): mesma
+   cesta de clientes, margem pelo TS e pela RPC, exigindo a **mesma faixa**. É o baseline que prova
+   que o conserto não mexe em score.
+2. **PG17 via `prove-sql-money-path`**: asserts positivos e negativos com `SQLSTATE` + re-raise,
+   escopo de carteira sob `SET ROLE authenticated` + GUC do JWT (nunca `SET LOCAL` — em autocommit
+   ele só emite WARNING e o assert fica falso-verde), guard abortando se `current_user ≠ authenticated`.
+3. **Assert de unicidade** do §4 (trava o JOIN).
+4. **Falsificações** — cada uma exige o vermelho do assert que ela mira, com baseline verde e
+   contagem/nomes conferidos antes:
+   - sabotar o gate de projeção (`v_pode_num` → sempre `true`) ⇒ vermelho no assert de que
+     `margem_pct` é `null` sem `cap_custo_ler`
+   - sabotar o gate de escopo ⇒ vermelho no assert de que o vendedor A não vê cliente de B
+   - sabotar a unicidade (semear código duplicado em 2 accounts) ⇒ vermelho no assert de duplicação
+5. **Codex adversarial** (`gpt-5.6-sol`, `xhigh`) antes de tirar do draft.
+
+Asserts ancoram na **estrutura** (chamada com argumentos), nunca em substring solta — a migration é
+fonte do texto que o assert lê de volta por `pg_get_functiondef`, e `.` casa newline no regex do
+Postgres (lição do #1472).
+
+## 6. Entrega
+
+1. Migration custom com a RPC — **aplicada à mão pelo founder no SQL Editor** (nome custom não
+   auto-aplica no Lovable; falha silenciosa)
+2. Validação pós-apply que **lê catálogo** (`pg_proc`/`pg_get_functiondef`/`has_function_privilege`)
+   e **nunca invoca** a função — invocar exige `EXECUTE` e dá falso-negativo sob `psql-ro` (lição do #1462)
+3. `src/integrations/supabase/types.ts`: a RPC nova **não** regenera os tipos sozinha. Tratar como
+   parte da entrega — senão o primeiro PR que a referenciar deixa a `main` vermelha e trava o
+   auto-merge de todos os PRs abertos
+4. Publish do frontend (Lovable) — merge na `main` ≠ produção
+
+**Ordem de deploy acoplada:** a migration entra **antes** do Publish (o front novo depende da RPC).
+Como este PR não revoga nada em `product_costs`, não há a janela de quebra do padrão REVOKE — o front
+velho continua funcionando até o Publish.
+
+## 7. O que este PR NÃO fecha — dizer no corpo do PR
+
+**Faixa não é divulgação zero, é divulgação limitada.** Por cliente, a faixa agrega a cesta inteira e
+não se inverte para custo unitário — o estreitamento é forte. Mas não é nulo, e precisão>recall exige
+declarar isso em vez de anunciar o custo "fechado".
+
+`product_costs` **continua** com policy `master OR employee` e legível por outras vias (§9). Este PR
+fecha **uma** via — a maior — e não altera a tabela.
+
+## 8. Alternativas descartadas
+
+| alternativa | por que não |
+|---|---|
+| View operacional sem a coluna (padrão #1473) | Não há coluna a projetar: o hook lê `product_costs` inteira. Não transporta. |
+| Mascarar `grossMarginPct` na UI | Fachada — o `fetch` continua e o catálogo aparece no DevTools. |
+| RPC devolver `g` normalizado (0..1) em vez da faixa | Mais fino, mas invertível: `margem = g·(p90−p10) + p10`. Contraria a decisão de produto. |
+| Ler o `g_score` persistido | É **diversidade**, não margem (§1). Trocaria a grandeza em silêncio. |
+| Popular `gross_margin_pct` corretamente e ler o persistido | Cria o vazamento que o enunciado imaginava, e o valor diário fica stale vs. o hook, que é ao vivo. |
+| Faixa por percentil da população (p10/p90) | ~10% vermelhos **por construção**, mesmo com todos lucrativos; faixa muda sem o cliente mudar (§3.1b). |
+| Faixa derivada de `resolve_markup_policy` | Semanticamente o mais fiel (mesmo significado de "abaixo do piso" no cockpit e no scoring), mas exige regra de agregação ponderada por SKU/família/conta — desproporcional para esta entrega. Reavaliar se as duas telas divergirem na prática. |
+
+## 9. Fora de escopo — follow-ups com evidência
+
+Vias browser→custo inventariadas e **não** endereçadas aqui:
+
+| via | o que puxa | desenho provável |
+|---|---|---|
+| [`useCrossSellEngine.ts:171`](../../../src/hooks/useCrossSellEngine.ts) | `product_costs` completa | ranqueamento server-side |
+| [`useBundleEngine.ts:203`](../../../src/hooks/useBundleEngine.ts) | `product_costs` completa | ranqueamento server-side |
+| [`RecommendationCard.tsx:120`](../../../src/components/RecommendationCard.tsx) | renderiza `Custo:` direto, atrás de `showAdminBreakdown` | gate de projeção |
+| [`useBaixoGiro.ts:33`](../../../src/components/reposicao/baixoGiro/useBaixoGiro.ts) | `inventory_position` cru com `cmc` | **verificar o gate antes de concluir** — é tela de reposição, e comprador lê custo legitimamente (`cap_compras_ler`) |
+
+⚠️ **Assimetria de desenho para cross-sell/bundle:** faixa **por SKU** é mais fraca que por cliente.
+O preço do SKU é legítimo e conhecido pelo cliente, então a faixa limita o custo unitário a um
+intervalo — sobre os 3.637 SKUs. Para esses dois, o que precisa ir ao servidor é o **ranqueamento**,
+não a faixa (mesma lição do #1488: *"se o cliente avalia o predicado offline, ele acha o limiar por
+busca binária"*).
+
+Outros dois achados desta sessão, independentes desta entrega:
+
+1. **`gross_margin_pct` é coluna morta com 5 consumidores degradando em silêncio** — o peso `hs_w.margin`
+   (20%) do health score está zerado; o gate econômico de `tactical-plans-batch:152` reprova todos; os
+   KPIs de margem em `IntelligenceStrategicTab:156` e `IntelligenceManagerialTab:123` renderizam `0.0%`;
+   `CustomerHero:137` pinta todo cliente de vermelho. Decidir entre popular ou dropar (com
+   `db/preflight-dependencia-tabela.sql` antes).
+2. **Inconsistência de escala latente** entre consumidores da mesma coluna: `Customer360View`/`CustomerHero`
+   tratam como fração (`*100`, `>=0.3`); `IntelligenceManagerialTab`, `useBundleEngine` e
+   `generate-tactical-plan` tratam como 0–100 (`<20`, `>35`). Hoje mascarada porque tudo é zero —
+   volta a morder no dia em que a coluna for populada.
+3. **A fabricação do `neutro`** (§3.3): cliente sem custo conhecido é hoje tratado como pior margem.


### PR DESCRIPTION
Resgata da branch órfã `feat/authz-fu4f-fase3-farmer-scoring-custo` os dois documentos de desenho da FU4-F fase 3 — **com errata datada do que envelheceu**. Só docs, área fria, não toca o #1543.

## Por que

Na triagem das 38 branches órfãs (#1709), essa branch ficou como decisão pendente. Ela tem 5 commits, 1.281 linhas e **zero código**. O código da fase 3 está no **#1543** (OPEN/DRAFT desde 2026-07-22), que **não carrega os `.md`** — então a calibragem medida dos limiares e o caminho do JOIN descartado **por medição** (as decisões que explicam por que o código é como é) dependiam de uma branch que ninguém rastreia.

Confirmado antes de abrir: nenhum PR aberto (#1520, #1543, #1456) carrega esses arquivos, e nenhum dos dois nomes existe na `main`.

## Por que com errata, e não verbatim

Em três pontos o desenho **contradiz** a implementação. Preservar desenho obsoleto é pior que não preservar — sobretudo o plano, que carrega `REQUIRED SUB-SKILL: implement this plan task-by-task` no topo e seria executável por um agente. A errata vem **antes** dessa linha, com marcadores inline nos pontos exatos. Padrão da `db/nota-1530-premissa-envelheceu.md`: corrigir por errata datada, nunca reescrevendo o original.

| § | o desenho diz | medido hoje |
|---|---|---|
| §1 / §9.1 | `gross_margin_pct` é coluna **morta**: 6.632/6.632 em zero, sem writer | **Falso desde 2026-07-21.** `psql-ro` 2026-08-13: **1.075 não-zero · 5.558 NULL · 0 zeros** (6.633). Writer = `get_customer_margin_summary` (#1495); zero fabricado removido no #1705. O follow-up "popular ou dropar" **está resolvido: populada**. |
| §3.2 / §3.3 + **Task 1 inteira** | `g` deriva da faixa (`verde=1 · amarelo=0,5 · vermelho=0`); `neutro → g=0` preserva a fabricação | **Rejeitado por medição** no #1543: descartaria a régua de percentis e mudaria o health score de **68% dos clientes com margem** (5,73 pts médios, 14,42 no pior caso) — mudança de PRODUTO dentro de entrega de AUTORIZAÇÃO. O `gDaFaixa()` que o plano especifica **não deve ser criado**; o `g` vem do servidor e é `NULL` quando não apurável. A fabricação foi **consertada junto**, não adiada. |
| §4 | JOIN, custo canônico e filtro de status vivem na RPC | Migraram para `private.margem_cliente_agregada()` (#1519, **já em prod**). A RPC do #1543 é a camada fina. |

## O que NÃO envelheceu — o motivo do resgate

- **Limiares `piso=30` / `meta=50`**, calibrados sobre 746 clientes com distribuição real (p10 24,8% · mediana 52,9% · p90 73,5%) — hoje são literalmente os `COALESCE` da migration do #1543. Sem este doc, viram números mágicos.
- **O JOIN descartado por medição:** `order_items.product_id` tem **1.835/68.459 nulos (2,7%)** contra **100%** de `omie_codigo_produto`. É o que justifica o caminho do helper — e a diferença entre paridade e uma divergência silenciosa de 2,7%.
- Vocabulário `verde|amarelo|vermelho|neutro` herdado do cockpit, os dois gates, e a unicidade medida do `omie_codigo_produto` (7.962/7.962).

## Estado da entrega (não é este PR que fecha)

`public.get_carteira_margem_faixa` **não existe** em `pg_proc` e o `useFarmerScoring.ts:189` **ainda baixa `product_costs` inteira** para o browser na `main`. O vazamento segue aberto; retomar é pelo #1543.

## Validação

- `bun run docs:indice` → **exit 0** (`docs/superpowers/` fica fora do gate de índice, que cobre `historico`/`runbooks`).
- Os 5 links relativos adicionados resolvem para arquivo existente (conferido um a um).
- Sem código: nada a type-checar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
