### PR TITLE
feat(rota): a fila de ligação passa a dizer POR QUE veio vazia — 4 desfechos eram o mesmo pixel

### DIFF
--- a/src/lib/route/telemetria-fila.test.ts
+++ b/src/lib/route/telemetria-fila.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import { classificarFilaVazia, eventoDaFila, type FilaObservada } from './telemetria-fila';
+
+describe('classificarFilaVazia', () => {
+  // A fila tem 4 saídas-vazias OPERACIONALMENTE distintas, hoje indistinguíveis na UI.
+  // O motivo é DECLARADO no ponto que sabe (o queryFn), nunca inferido dos totais:
+  // "capacidade 0" e "nenhum candidato" produzem exatamente o mesmo `excluidos: []`.
+  it('sem cidade na rota do dia → sem_cidade', () => {
+    expect(classificarFilaVazia({ nCidades: 0, nCandidatos: 0, nVivos: 0, nFila: 0 })).toBe('sem_cidade');
+  });
+
+  it('cidades na rota mas nenhum cliente da carteira nelas → sem_candidato', () => {
+    expect(classificarFilaVazia({ nCidades: 3, nCandidatos: 0, nVivos: 0, nFila: 0 })).toBe('sem_candidato');
+  });
+
+  it('candidatos existem mas todos caíram num gate → todos_excluidos', () => {
+    expect(classificarFilaVazia({ nCidades: 3, nCandidatos: 826, nVivos: 0, nFila: 0 })).toBe('todos_excluidos');
+  });
+
+  it('candidatos passaram o gate mas a fila saiu vazia → sem_capacidade', () => {
+    // capacidade_ligacoes_dia = 0 zera a fila com 826 candidatos SAUDÁVEIS.
+    // Sem este ramo o caso viraria "sem_candidato" — diagnóstico fabricado (money-path §2).
+    expect(classificarFilaVazia({ nCidades: 3, nCandidatos: 826, nVivos: 826, nFila: 0 })).toBe('sem_capacidade');
+  });
+
+  it('fila com itens → null (não há o que classificar)', () => {
+    expect(classificarFilaVazia({ nCidades: 3, nCandidatos: 826, nVivos: 40, nFila: 40 })).toBeNull();
+  });
+
+  it('sem_cidade tem precedência — é a causa mais a montante', () => {
+    expect(classificarFilaVazia({ nCidades: 0, nCandidatos: 826, nVivos: 826, nFila: 0 })).toBe('sem_cidade');
+  });
+});
+
+/** Fila observável de teste — só o que a telemetria lê (contagens vêm de .length). */
+function fila(over: Partial<FilaObservada> = {}): FilaObservada {
+  return {
+    callQueue: new Array(40).fill(null),
+    resolvidosQueue: new Array(2).fill(null),
+    excluidos: new Array(786).fill(null),
+    cidades: ['DIVINOPOLIS', 'CARMO DO CAJURU', 'ITAUNA'],
+    routeDate: '2026-08-10',
+    dailyOnly: false,
+    cadenciaIndisponivel: false,
+    motivoFilaVazia: null,
+    ...over,
+  };
+}
+
+describe('eventoDaFila', () => {
+  it('carregando → não emite (estado transitório, não é desfecho)', () => {
+    expect(eventoDaFila({ isLoading: true, isError: false, data: undefined })).toBeNull();
+  });
+
+  it('sem erro e sem data → não emite (nada aconteceu ainda)', () => {
+    expect(eventoDaFila({ isLoading: false, isError: false, data: undefined })).toBeNull();
+  });
+
+  it('fila com itens → rota.fila_carregada com o tamanho e o contexto da rota', () => {
+    const ev = eventoDaFila({ isLoading: false, isError: false, data: fila() });
+    expect(ev?.evento).toBe('rota.fila_carregada');
+    expect(ev?.props.n_fila).toBe(40);
+    expect(ev?.props.n_resolvidos).toBe(2);
+    expect(ev?.props.n_excluidos).toBe(786);
+    expect(ev?.props.n_cidades).toBe(3);
+    expect(ev?.props.route_date).toBe('2026-08-10');
+    expect(ev?.props.daily_only).toBe(false);
+    expect(ev?.props.cadencia_indisponivel).toBe(false);
+  });
+
+  it('fila vazia → rota.fila_vazia carregando o motivo declarado', () => {
+    const ev = eventoDaFila({
+      isLoading: false,
+      isError: false,
+      data: fila({ callQueue: [], excluidos: [], motivoFilaVazia: 'sem_candidato' }),
+    });
+    expect(ev?.evento).toBe('rota.fila_vazia');
+    expect(ev?.props.motivo).toBe('sem_candidato');
+    expect(ev?.props.n_cidades).toBe(3);
+  });
+
+  it('fila vazia sem motivo declarado → motivo "desconhecido", nunca um palpite', () => {
+    const ev = eventoDaFila({
+      isLoading: false,
+      isError: false,
+      data: fila({ callQueue: [], motivoFilaVazia: null }),
+    });
+    expect(ev?.evento).toBe('rota.fila_vazia');
+    expect(ev?.props.motivo).toBe('desconhecido');
+  });
+
+  it('erro → rota.fila_erro com a mensagem', () => {
+    const ev = eventoDaFila({ isLoading: false, isError: true, mensagemErro: 'JWT expired', data: undefined });
+    expect(ev?.evento).toBe('rota.fila_erro');
+    expect(ev?.props.mensagem).toBe('JWT expired');
+  });
+
+  it('erro sem mensagem legível ainda emite o evento', () => {
+    const ev = eventoDaFila({ isLoading: false, isError: true, mensagemErro: null, data: undefined });
+    expect(ev?.evento).toBe('rota.fila_erro');
+    expect(ev?.props.mensagem).toBe('(sem mensagem)');
+  });
+
+  it('erro vence data de fetch anterior — o React Query preserva `data` em isError', () => {
+    // Sem esta precedência, uma query que PASSOU a falhar seguiria reportando
+    // fila_carregada com o retrato velho: falha mascarada de sucesso.
+    const ev = eventoDaFila({ isLoading: false, isError: true, mensagemErro: 'network', data: fila() });
+    expect(ev?.evento).toBe('rota.fila_erro');
+  });
+});
+
+describe('eventoDaFila — chave de deduplicação', () => {
+  it('mesmo desfecho gera a mesma chave (não reemite a cada render)', () => {
+    const a = eventoDaFila({ isLoading: false, isError: false, data: fila() });
+    const b = eventoDaFila({ isLoading: false, isError: false, data: fila() });
+    expect(a?.chave).toBe(b?.chave);
+  });
+
+  it('fila que esvazia é desfecho novo → chave diferente', () => {
+    const cheia = eventoDaFila({ isLoading: false, isError: false, data: fila() });
+    const vazia = eventoDaFila({
+      isLoading: false,
+      isError: false,
+      data: fila({ callQueue: [], motivoFilaVazia: 'todos_excluidos' }),
+    });
+    expect(cheia?.chave).not.toBe(vazia?.chave);
+  });
+
+  it('mesma fila em dia de rota diferente é desfecho novo', () => {
+    const hoje = eventoDaFila({ isLoading: false, isError: false, data: fila() });
+    const amanha = eventoDaFila({ isLoading: false, isError: false, data: fila({ routeDate: '2026-08-11' }) });
+    expect(hoje?.chave).not.toBe(amanha?.chave);
+  });
+});

--- a/src/lib/route/telemetria-fila.ts
+++ b/src/lib/route/telemetria-fila.ts
@@ -1,0 +1,108 @@
+/**
+ * Telemetria da fila de ligação por rota (/rota/ligacoes).
+ *
+ * PROBLEMA QUE ISTO RESOLVE: a tela tinha 4 desfechos que produziam o MESMO
+ * pixel — "sem rota hoje". Com `route_contact_log` e `route_queue_snapshot`
+ * zerados desde a origem, era impossível distinguir "a vendedora nunca abriu"
+ * de "abriu e veio vazia" de "abriu e quebrou". O $pageview (PageViewTracker)
+ * responde só a primeira; estes eventos respondem o resto.
+ *
+ * O MOTIVO É DECLARADO, NUNCA INFERIDO. Inferir dos totais erra: capacidade 0
+ * e "nenhum candidato" produzem ambos `excluidos: []` — classificar um como o
+ * outro é fabricar diagnóstico (money-path §2: ausente ≠ zero).
+ */
+
+export type MotivoFilaVazia =
+  | 'sem_cidade'       // a rota D-1 não tem cidade programada (dia legítimo sem rota)
+  | 'sem_candidato'    // há cidade, mas nenhum cliente da carteira mora nela
+  | 'todos_excluidos'  // há candidatos, mas todos caíram num gate (opt-out/cadência/valor/jit)
+  | 'sem_capacidade';  // candidatos passaram o gate e a fila AINDA saiu vazia (cap=0)
+
+export interface ContagensFila {
+  nCidades: number;
+  nCandidatos: number;
+  /** candidatos que sobreviveram aos gates de `buildContactList`. */
+  nVivos: number;
+  nFila: number;
+}
+
+/**
+ * Classifica POR QUE a fila saiu vazia, a partir das contagens que o queryFn
+ * tem em mãos no momento de cada saída. Ordem = da causa mais a montante para
+ * a mais a jusante, para que o motivo aponte a origem e não o sintoma.
+ */
+export function classificarFilaVazia(c: ContagensFila): MotivoFilaVazia | null {
+  if (c.nFila > 0) return null;
+  if (c.nCidades === 0) return 'sem_cidade';
+  if (c.nCandidatos === 0) return 'sem_candidato';
+  if (c.nVivos === 0) return 'todos_excluidos';
+  return 'sem_capacidade';
+}
+
+/** Recorte de `RouteContactListData` que a telemetria lê. Estrutural de propósito:
+ *  não arrasta o client Supabase para o teste. */
+export interface FilaObservada {
+  callQueue: readonly unknown[];
+  resolvidosQueue: readonly unknown[];
+  excluidos: readonly unknown[];
+  cidades: readonly string[];
+  routeDate: string | null;
+  dailyOnly: boolean;
+  cadenciaIndisponivel: boolean;
+  motivoFilaVazia: MotivoFilaVazia | null;
+}
+
+export interface EstadoConsultaFila {
+  isLoading: boolean;
+  isError: boolean;
+  mensagemErro?: string | null;
+  data: FilaObservada | undefined;
+}
+
+export interface EventoFila {
+  evento: string;
+  props: Record<string, string | number | boolean | null>;
+  /** Identidade do DESFECHO — o chamador emite 1× por chave, não por render. */
+  chave: string;
+}
+
+/**
+ * Traduz o estado do useQuery no evento a emitir (ou null, quando ainda não há
+ * desfecho). O erro vem ANTES do data porque o React Query preserva o `data` do
+ * fetch anterior quando `isError` — sem esta ordem, uma query que PASSOU a
+ * falhar seguiria reportando sucesso com o retrato velho.
+ */
+export function eventoDaFila(estado: EstadoConsultaFila): EventoFila | null {
+  if (estado.isError) {
+    const mensagem = estado.mensagemErro || '(sem mensagem)';
+    return { evento: 'rota.fila_erro', props: { mensagem }, chave: `erro:${mensagem}` };
+  }
+  if (estado.isLoading) return null;
+  const d = estado.data;
+  if (!d) return null;
+
+  const nFila = d.callQueue.length;
+  const props = {
+    n_fila: nFila,
+    n_resolvidos: d.resolvidosQueue.length,
+    n_excluidos: d.excluidos.length,
+    n_cidades: d.cidades.length,
+    route_date: d.routeDate,
+    daily_only: d.dailyOnly,
+    cadencia_indisponivel: d.cadenciaIndisponivel,
+  };
+
+  if (nFila === 0) {
+    // Fila vazia SEM motivo declarado é um buraco de instrumentação, não um
+    // motivo — reportá-lo como 'desconhecido' mantém o sinal honesto em vez de
+    // escolher o palpite mais provável.
+    const motivo = d.motivoFilaVazia ?? 'desconhecido';
+    return {
+      evento: 'rota.fila_vazia',
+      props: { ...props, motivo },
+      chave: `vazia:${d.routeDate}:${motivo}`,
+    };
+  }
+
+  return { evento: 'rota.fila_carregada', props, chave: `carregada:${d.routeDate}:${nFila}` };
+}

--- a/src/pages/RotaListaLigacao.tsx
+++ b/src/pages/RotaListaLigacao.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Phone, CheckCircle2 } from 'lucide-react';
 import { useRouteContactList } from '@/queries/useRouteContactList';
@@ -14,6 +14,9 @@ import { OutcomeMenu } from '@/components/call/OutcomeMenu';
 import { FichaPreContato } from '@/components/call/FichaPreContato';
 import { RouteDisparoConfigPanel } from '@/components/rota/RouteDisparoConfigPanel';
 import { spBusinessDate } from '@/lib/time/sp-day';
+import { eventoDaFila } from '@/lib/route/telemetria-fila';
+import { track } from '@/lib/analytics';
+import { mensagemDeErro } from '@/lib/erro-mensagem';
 
 const BUCKET_LABEL: Record<string, string> = {
   top: 'Prioridade',
@@ -43,8 +46,22 @@ function ResolvidosSection({ itens }: { itens: RouteContactItem[] }) {
 export default function RotaListaLigacao() {
   // data de NEGÓCIO em SP (não UTC — senão das ~21h às 24h locais a data vira o dia seguinte → rota errada).
   const workday = useMemo(() => spBusinessDate(new Date()), []);
-  const { data, isLoading, isError, refetch } = useRouteContactList(workday);
+  const { data, isLoading, isError, error, refetch } = useRouteContactList(workday);
   const { isMaster, isGestorComercial } = useAuth();
+
+  // Telemetria do DESFECHO da tela. O $pageview (PageViewTracker) já conta a
+  // abertura; o que faltava era separar "abriu e veio fila" de "abriu e veio
+  // vazia (por qual motivo)" de "abriu e quebrou" — os três eram o mesmo pixel,
+  // e é por isso que route_contact_log/route_queue_snapshot zerados não diziam
+  // se a tela era inútil ou se ninguém entrava. Emite 1× por DESFECHO (chave),
+  // não por render. INCONDICIONAL: hooks não podem ficar atrás de return.
+  const ultimoDesfecho = useRef<string | null>(null);
+  useEffect(() => {
+    const ev = eventoDaFila({ isLoading, isError, mensagemErro: mensagemDeErro(error), data });
+    if (!ev || ultimoDesfecho.current === ev.chave) return;
+    ultimoDesfecho.current = ev.chave;
+    track(ev.evento, ev.props);
+  }, [isLoading, isError, error, data]);
 
   // Grava (idempotente, best-effort) a fila de ligação aberta — denominador do painel.
   // Chamada INCONDICIONAL (hooks não podem ficar atrás de return).

--- a/src/queries/useRegistrarContato.ts
+++ b/src/queries/useRegistrarContato.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { track } from '@/lib/analytics';
+import { mensagemDeErro } from '@/lib/erro-mensagem';
 import type { OutcomeStatus } from '@/lib/route/route-outcome';
 
 // route_* não está no types.ts gerado → cast do client (mesmo padrão de useMyPositivacao).
@@ -32,6 +33,10 @@ export function useRegistrarContato() {
       return (data ?? { id: '', deduped: false }) as { id: string; deduped: boolean };
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['route-contact-list'] }),
+    // O OutcomeMenu engole a falha num catch que só mostra toast: uma RPC
+    // quebrada (gate de carteira, RLS, rede) ficava invisível justo no passo
+    // que ALIMENTA route_contact_log. Cobre erro do PostgREST e exceção de rede.
+    onError: (e) => track('rota.contato_erro', { mensagem: mensagemDeErro(e) ?? '(sem mensagem)' }),
   });
 }
 

--- a/src/queries/useRouteContactList.ts
+++ b/src/queries/useRouteContactList.ts
@@ -7,6 +7,7 @@ import { buildContactList } from '@/lib/whatsapp/contact-list';
 import type { ContactCandidate, ContactConfig, ScoredCandidate } from '@/lib/whatsapp/contact-list';
 import { spBusinessDate } from '@/lib/time/sp-day';
 import { derivarSinaisContato, type ContatoLog, type OutcomeStatus, type SinaisContato } from '@/lib/route/route-outcome';
+import { classificarFilaVazia, type MotivoFilaVazia } from '@/lib/route/telemetria-fila';
 import { logger } from '@/lib/logger';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
@@ -58,6 +59,10 @@ export interface RouteContactListData {
   cidades: string[];
   dailyStats: DailyStats;
   cadenciaIndisponivel: boolean;          // true se a leitura do log falhou (fail-open)
+  // POR QUE a fila saiu vazia — declarado no ponto que sabe, nunca inferido pela
+  // UI: capacidade 0 e "nenhum candidato" produzem o mesmo `excluidos: []`, e
+  // confundir os dois é fabricar diagnóstico. null = fila não está vazia.
+  motivoFilaVazia: MotivoFilaVazia | null;
 }
 
 // margem média da empresa (v1 — spec §6.5 q2; calibrar no piloto/codex)
@@ -237,12 +242,13 @@ export function useRouteContactList(workdayIso: string) {
       const cfgRow = (cfgRes.data ?? null) as RouteConfigRow | null;
 
       const prep = resolvePrepForWorkday(workdayIso, sched, ovr);
-      const empty: RouteContactListData = {
+      const vazia = (motivoFilaVazia: MotivoFilaVazia): RouteContactListData => ({
         callQueue: [], whatsappQueue: [], resolvidosQueue: [], excluidos: [],
         routeDate: prep.routeDate, dailyOnly: prep.dailyOnly, cidades: prep.cities.map(c => c.city),
         dailyStats: { ligados: 0, atenderam: 0, fecharam: 0 }, cadenciaIndisponivel: false,
-      };
-      if (prep.cities.length === 0) return empty;
+        motivoFilaVazia,
+      });
+      if (prep.cities.length === 0) return vazia('sem_cidade');
 
       // 2) candidatos das cidades-alvo — filtrados NO SERVIDOR por city_norm
       // (#16-full; ver fetchVisitScoresByCityNorm). O cityKeyEquals no client
@@ -262,7 +268,7 @@ export function useRouteContactList(workdayIso: string) {
       }
       const cands0 = [...candByUser.values()];
 
-      if (cands0.length === 0) return empty;
+      if (cands0.length === 0) return vazia('sem_candidato');
 
       // 3) métricas econômicas + perfis (nome/telefone) em lote
       const userIds = [...new Set(cands0.map(c => c.customer_user_id))];
@@ -363,6 +369,14 @@ export function useRouteContactList(workdayIso: string) {
         cidades: prep.cities.map(c => c.city),
         dailyStats: { ligados, atenderam, fecharam },
         cadenciaIndisponivel,
+        // "vivos" = candidatos que sobreviveram aos gates. Separa "todos caíram
+        // num gate" de "passaram e a fila AINDA saiu vazia" (capacidade 0).
+        motivoFilaVazia: classificarFilaVazia({
+          nCidades: prep.cities.length,
+          nCandidatos: candidates.length,
+          nVivos: candidates.length - result.excluidos.length,
+          nFila: result.callQueue.length,
+        }),
       };
     },
   });


### PR DESCRIPTION
## O problema

A tela `/rota/ligacoes` tinha **4 desfechos que produziam o mesmo pixel** — "sem rota hoje". Com `route_contact_log` e `route_queue_snapshot` zerados desde a origem, era impossível distinguir:

1. a vendedora nunca abriu a tela
2. abriu e a fila veio vazia — e por qual dos motivos
3. abriu e a query quebrou

Isso foi o que travou a investigação anterior: o pipeline está íntegro (24 cidades ativas, config viva, RPC íntegra, centenas de candidatos por cidade), mas nenhum contato jamais foi registrado. Sem telemetria, "nunca aberta" e "abre e falha" são o mesmo dado.

## O que muda

**Não são 2 motivos de fila vazia, são 4.** Além de `prep.cities.length === 0` e `cands0.length === 0`, `buildContactList` tem duas outras saídas-vazias que ninguém distinguia:

- **`todos_excluidos`** — há candidatos, mas todos caíram num gate (opt-out, cadência, valor, jit)
- **`sem_capacidade`** — os candidatos **passaram** o gate e a fila ainda saiu vazia, porque `cap = Math.floor(capacidadeLigacoes)` era 0

O quarto é o perigoso: com `cap = 0`, `excluidos` fica **vazio** (ninguém foi gated) — exatamente igual a "nenhum candidato". Inferir o motivo dos totais classificaria um como o outro, que é fabricar diagnóstico (money-path §2). Por isso **o motivo é declarado no ponto que sabe**, nunca inferido pela UI.

### Eventos

| evento | quando | props |
|---|---|---|
| `rota.fila_carregada` | fila com itens | `n_fila`, `n_resolvidos`, `n_excluidos`, `n_cidades`, `route_date`, `daily_only`, `cadencia_indisponivel` |
| `rota.fila_vazia` | fila vazia | as acima + `motivo` (4 valores + `desconhecido`) |
| `rota.fila_erro` | query falhou | `mensagem` |
| `rota.contato_erro` | RPC de registro falhou | `mensagem` |

O erro tem **precedência sobre o `data`**: o React Query preserva o `data` do fetch anterior quando `isError`, então sem essa ordem uma query que *passou* a falhar seguiria reportando sucesso com o retrato velho.

Emissão é **1× por desfecho** (via chave), não por render.

`rota.contato_erro` fecha um buraco vizinho: o `OutcomeMenu` engole a falha num `catch` que só mostra toast — uma RPC quebrada ficava invisível justo no passo que **alimenta** `route_contact_log`.

## O que NÃO muda

- Nenhuma migration. Nenhum comportamento de UI. Nenhuma linha nova em `route_queue_snapshot` — o painel lê essa tabela como denominador e uma linha-sentinela contaminaria a conta.
- `$pageview` já cobria a abertura da tela (a rota está sob `AppShellLayout` → `AppShell` → `PageViewTracker`). Este PR adiciona o **desfecho**, que é o que faltava.

## Prova

- `telemetria-fila.test.ts` — 17 asserções: os 4 motivos + precedência de `sem_cidade`, precedência do erro sobre data stale, motivo ausente vira `desconhecido` (não um palpite), e estabilidade da chave de dedupe.
- RED verificado por `Failed to resolve import "./telemetria-fila"` (feature ausente, não typo) antes de qualquer linha de produção.

## Descobertas de produção (via psql-ro, durante a sessão)

- `capacidade_ligacoes_dia = 40` — a hipótese `sem_capacidade` está **descartada** como causa da fila vazia atual
- `customer_visit_scores`: 6.633 linhas, **todas** com `visit_score > 0` → `pConverte > 0` para todos
- `customer_metrics_mv` é **inacessível** à role read-only (`permission denied for function has_role`) — o gate de `ticket_medio_90d` só é mensurável em runtime, que é exatamente o que esta instrumentação faz

## ⚠️ Leia isto antes de esperar resultado: hoje ninguém abre a tela

O #1716 mergeou hoje e mede que **não há vendedora ativa**. Confirmei por conta própria:

| role | usuários | login em 30d | último login |
|---|---|---|---|
| `master` | 1 | 1 | 2026-07-24 |
| `employee` | 2 | **0** | 2026-04-15 |
| `customer` | 5.664 | 0 | — |

**Consequência direta:** esta instrumentação **não vai revelar** por que a fila está vazia — porque ninguém abre a tela. Ela é o *sensor* que responde isso no instante em que as vendedoras voltarem, sem exigir nova investigação.

### Uma correção factual ao doc do #1716

`docs/historico/fila-plano-tatico.md` afirma na prosa que "as duas vendedoras não abrem o sistema **desde abril**" — mas a tabela do próprio doc registra `Sessão mais recente: 2026-06-23` para a Tatyana, e `auth.sessions` confirma:

```
employee | 2 sessões | updated_at mais recente = 2026-06-23
```

`last_sign_in_at` não atualiza no refresh de token; `auth.sessions.updated_at` sim. O silêncio real é de **~51 dias**, não ~4 meses.

Isso muda a leitura do problema: houve **~2 meses de presença ativa (abril→junho) com `route_contact_log` zerado**. Não é apenas "ninguém usa o app" — é "houve uso do app e ainda assim nenhum contato foi registrado". É exatamente a lacuna que estes eventos fecham.

Não editei o doc (é de outra sessão, recém-mergeado — evitar conflito). Fica registrado aqui.

## Achado fora de escopo (chip aberto)

`intGE0('')` → `parseInt('')` = NaN → **retorna 0** (`src/lib/whatsapp/disparo-config.ts:28`). Apagar o campo "Ligações/dia" no painel e salvar grava capacidade 0, o que zera a fila de todas as vendedoras em silêncio, com toast de sucesso. O painel é gated a master. Está em chip próprio, não neste PR — este PR *detecta* a ocorrência (`motivo: 'sem_capacidade'`), não a impede.
