### PR TITLE
fix(reposicao): o detector de PO sumido para de acusar PO que ainda nem existia [money-path]

### DIFF
--- a/db/test-pos-candidatos-guard-temporal.sh
+++ b/db/test-pos-candidatos-guard-temporal.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — guard temporal do detector de PO excluído (money-path)                  ║
+# ║  Migration: supabase/migrations/20260813195914_reposicao_pos_candidatos_guard_temporal ║
+# ║  Rode: bash db/test-pos-candidatos-guard-temporal.sh > /tmp/t.log 2>&1; echo $?        ║
+# ║        (NÃO pipe pra tail — engole o exit code)                                        ║
+# ║                                                                                        ║
+# ║  O QUE PROVA                                                                           ║
+# ║   G1  PO registrado DEPOIS do marcador não é candidato  ← o bug de 13/08 (4/4 falsos)  ║
+# ║   G2  PO registrado ANTES e não-visto SEGUE candidato   ← o sinal real (caso 281/286)  ║
+# ║   G3  omie_registrado_em NULL SEGUE candidato           ← fail-closed do NULL          ║
+# ║   G4  registrado EXATAMENTE no finalizado_em segue      ← borda `<=`: dúvida não some  ║
+# ║   G5  PO visto no marcador atual não é candidato        ← comportamento antigo intacto ║
+# ║   A   sem marcador válido → VAZIO                       ← fail-closed preservado       ║
+# ║   D   gate authz: não-staff nega, staff passa, cron passa                              ║
+# ║                                                                                        ║
+# ║  FALSIFICA (o teste tem de FICAR VERMELHO com a migration sabotada)                     ║
+# ║   F1  guard removido            → G1 vermelho    F4  gate FU4-G regredido → apply falha ║
+# ║   F2  guard sem o ramo IS NULL  → G3 vermelho    F5  sem private.cap_compras_ler → 42883║
+# ║   F3  `<` no lugar de `<=`      → G4 vermelho                                          ║
+# ╚══════════════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5479}"
+SLUG="pos-candidatos-guard-temporal"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+MIG_BASE="$REPO_ROOT/supabase/migrations/20260721190000_reposicao_pos_candidatos.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260813195914_reposicao_pos_candidatos_guard_temporal.sql"
+TMP="$(mktemp -d "/tmp/pgtest-${SLUG}-sql.XXXXXX")"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")" "$TMP"; }
+trap cleanup EXIT
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK   $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 -- esperado [$3], veio [$2]"; fi; }
+
+echo "=== setup (PG17 :$PORT) ==="
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+# ── ZONA 1: schema fiel à PROD (tipos conferidos por psql-ro 13/08) ───────────────────────────
+# `omie_registrado_em` e `finalizado_em` são as duas colunas que o guard novo lê. `empresa` de
+# pedido_compra_sugerido é TEXT em prod; as demais usam o ENUM — a RPC compara as duas.
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+CREATE TYPE public.empresa_reposicao AS ENUM ('OBEN','COLACOR');
+CREATE TABLE public.user_roles       (user_id uuid, role text);
+CREATE TABLE public.commercial_roles (user_id uuid, commercial_role text);
+
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role text)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id=_user_id AND role=_role) $fn$;
+-- Gate ANTERIOR (a migration-base 20260721190000 ainda o referencia; a nova o substitui).
+CREATE OR REPLACE FUNCTION public.pode_ver_carteira_completa(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$ SELECT public.has_role(_uid,'master') $fn$;
+-- Gate VIVO em prod (FU4-G, #1434): master-only e — o ponto — NUNCA devolve NULL (COALESCE).
+CREATE OR REPLACE FUNCTION private.cap_compras_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $fn$ SELECT COALESCE(public.has_role(_uid,'master'), false) $fn$;
+
+CREATE TABLE public.pedido_compra_sugerido (
+  id bigint PRIMARY KEY,
+  empresa text NOT NULL,                       -- TEXT em prod (não enum)
+  status text NOT NULL,
+  omie_pedido_compra_id text,
+  omie_registrado_em timestamptz,              -- nullable em prod -> ramo IS NULL do guard
+  data_ciclo date NOT NULL,
+  fornecedor_nome text,
+  canal_usado text,
+  portal_protocolo text,
+  status_envio_portal text,
+  resposta_canal jsonb
+);
+CREATE TABLE public.pedido_compra_item (pedido_id bigint, sku_codigo_omie text, valor_linha numeric);
+CREATE TABLE public.purchase_orders_tracking (
+  empresa public.empresa_reposicao NOT NULL,
+  omie_codigo_pedido bigint NOT NULL
+);
+CREATE TABLE public.reposicao_pedidos_compra_run (
+  run_id uuid PRIMARY KEY, seq bigint NOT NULL UNIQUE,
+  empresa public.empresa_reposicao NOT NULL,
+  status text NOT NULL DEFAULT 'ok', volume_ok boolean,
+  finalizado_em timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+CREATE TABLE public.reposicao_po_last_seen (
+  empresa public.empresa_reposicao NOT NULL,
+  omie_codigo_pedido bigint NOT NULL,
+  run_id uuid NOT NULL,
+  PRIMARY KEY (empresa, omie_codigo_pedido)
+);
+INSERT INTO auth.users(id) VALUES
+  ('33333333-3333-3333-3333-333333333333'),   -- master (staff)
+  ('44444444-4444-4444-4444-444444444444');   -- customer (não-staff)
+INSERT INTO public.user_roles(user_id, role) VALUES ('33333333-3333-3333-3333-333333333333','master');
+SQL
+
+# ── ZONA 2: migrations REAIS, na ordem de prod (base cria os helpers __po_id/__trim) ──────────
+P -q -f "$MIG_BASE"
+P -q -f "$MIG"
+echo "migrations aplicadas: $(basename "$MIG_BASE") -> $(basename "$MIG")"
+
+# ── ZONA 3: seeds ─────────────────────────────────────────────────────────────────────────────
+# Marcador: run seq=2 terminou 13/08 12:17Z (o run REAL de prod). Um run seq=1 anterior existe para
+# provar que o fencing continua escolhendo o maior seq.
+RID_ATUAL='ffffffff-ffff-ffff-ffff-ffffffffffff'
+RID_VELHO='11111111-1111-1111-1111-111111111111'
+P -q <<SQL
+INSERT INTO public.reposicao_pedidos_compra_run(run_id,seq,empresa,status,volume_ok,finalizado_em) VALUES
+  ('$RID_VELHO',1,'OBEN','ok',true ,'2026-08-12 14:17:00+00'),
+  ('$RID_ATUAL',2,'OBEN','ok',true ,'2026-08-13 12:17:00+00');
+
+-- Os 5 casos do guard. Todos 'disparado' com PO legível e NUNCA carimbados no marcador atual —
+-- ou seja: ANTES do fix, TODOS apareceriam como candidatos.
+INSERT INTO public.pedido_compra_sugerido
+  (id,empresa,status,omie_pedido_compra_id,omie_registrado_em,data_ciclo,fornecedor_nome,canal_usado,portal_protocolo,status_envio_portal) VALUES
+  -- G1: nasceu DEPOIS do marcador (o caso real de 13/08: PO 12168090540, R\$21.621,84)
+  (901,'OBEN','disparado','12168090540','2026-08-13 21:15:15+00','2026-08-13','RENNER SAYERLACK S/A','portal_sayerlack','2120226','sucesso_portal'),
+  -- G2: nasceu ANTES do marcador e segue sem carimbo = o sinal VERDADEIRO (PO sumiu mesmo)
+  (902,'OBEN','disparado','12160000001','2026-08-11 09:00:00+00','2026-08-11','RENNER SAYERLACK S/A','portal_sayerlack','2097501','sucesso_portal'),
+  -- G3: sem data de registro -> não dá para provar impossibilidade -> fail-closed
+  (903,'OBEN','disparado','12160000002',NULL                    ,'2026-08-11','RENNER SAYERLACK S/A','portal_sayerlack','2097910','sucesso_portal'),
+  -- G4: registrado EXATAMENTE no instante do finalizado_em (borda do <=) -> dúvida, segue candidato
+  (904,'OBEN','disparado','12160000003','2026-08-13 12:17:00+00','2026-08-13','RENNER SAYERLACK S/A','portal_sayerlack','2120100','sucesso_portal'),
+  -- G5: nasceu antes E foi VISTO no marcador atual -> nunca foi candidato
+  (905,'OBEN','disparado','12160000004','2026-08-11 10:00:00+00','2026-08-11','RENNER SAYERLACK S/A','portal_sayerlack','2097999','sucesso_portal');
+
+INSERT INTO public.reposicao_po_last_seen(empresa,omie_codigo_pedido,run_id) VALUES
+  ('OBEN',12160000004,'$RID_ATUAL');            -- só o G5 carimbado no run atual
+SQL
+
+# helper: ids devolvidos pela RPC (como service_role/cron: uid NULL passa no gate)
+cand() { Pq -c "SELECT coalesce(string_agg(pedido_id::text,',' ORDER BY pedido_id),'') FROM public.reposicao_pos_candidatos('OBEN');"; }
+tem()  { Pq -c "SELECT EXISTS(SELECT 1 FROM public.reposicao_pos_candidatos('OBEN') WHERE pedido_id=$1);"; }
+
+echo "== G: guard temporal =="
+eq "G1 PO nascido DEPOIS do marcador nao e candidato" "$(tem 901)" "f"
+eq "G2 PO nascido ANTES e nao-visto SEGUE candidato"  "$(tem 902)" "t"
+eq "G3 omie_registrado_em NULL SEGUE candidato"       "$(tem 903)" "t"
+eq "G4 registrado NO finalizado_em SEGUE candidato"   "$(tem 904)" "t"
+eq "G5 PO visto no marcador atual nao e candidato"    "$(tem 905)" "f"
+eq "G6 conjunto final exato"                          "$(cand)"    "902,903,904"
+
+echo "== A: fail-closed sem marcador valido =="
+P -q -c "UPDATE public.reposicao_pedidos_compra_run SET volume_ok=false;"
+eq "A1 sem run valido -> VAZIO" "$(cand)" ""
+P -q -c "UPDATE public.reposicao_pedidos_compra_run SET volume_ok=true;"
+eq "A2 restaurado" "$(cand)" "902,903,904"
+
+echo "== D: gate de authz =="
+D_NEGA=$(Pq <<'SQL'
+DO $t$
+BEGIN
+  PERFORM set_config('test.uid','44444444-4444-4444-4444-444444444444',true);
+  PERFORM * FROM public.reposicao_pos_candidatos('OBEN');
+  RAISE EXCEPTION 'VAZOU-NAO-BARROU';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'barrou-como-esperado';
+  WHEN OTHERS THEN RAISE;          -- Lei #2: qualquer outro erro RE-LANCA
+END $t$;
+SELECT 'barrado';
+SQL
+)
+# tail -1: o psql imprime o 'DO' do bloco anonimo antes do SELECT final.
+eq "D1 nao-staff barrado com 42501" "$(printf '%s' "$D_NEGA" | tail -1)" "barrado"
+eq "D2 master passa" "$(Pq -c "SELECT set_config('test.uid','33333333-3333-3333-3333-333333333333',true) IS NOT NULL; SELECT count(*)::text FROM public.reposicao_pos_candidatos('OBEN');" | tail -1)" "3"
+eq "D3 uid NULL (cron SQL-local) passa" "$(Pq -c "SELECT set_config('test.uid','',true) IS NOT NULL; SELECT count(*)::text FROM public.reposicao_pos_candidatos('OBEN');" | tail -1)" "3"
+
+# ══════════════════════════ FALSIFICACAO ══════════════════════════
+# Sem isto o teste e teatro: cada assert acima precisa FICAR VERMELHO com a migration sabotada.
+echo "== FALSIFICACAO =="
+# Só o CREATE OR REPLACE (sem os blocos DO de pre/pos-condicao, testados em F4/F5).
+awk '/^CREATE OR REPLACE FUNCTION public.reposicao_pos_candidatos/,/^\$\$;$/' "$MIG" > "$TMP/fn.sql"
+[ -s "$TMP/fn.sql" ] || { echo "FATAL: extracao da funcao falhou"; exit 1; }
+GUARD='AND (p.omie_registrado_em IS NULL OR p.omie_registrado_em <= m.finalizado_em)'
+grep -qF "$GUARD" "$TMP/fn.sql" || { echo "FATAL: guard nao encontrado no corpo extraido"; exit 1; }
+
+falsifica() { # $1=nome  $2=arquivo sql sabotado  $3=id do pedido  $4=resultado ESPERADO SOB SABOTAGEM
+  P -q -f "$2"
+  local got; got="$(tem "$3")"
+  if [ "$got" = "$4" ]; then ok "$1 (sabotado -> $got, assert teria ficado vermelho)"
+  else bad "$1 -- SABOTAGEM NAO MUDOU NADA (veio $got): o assert NAO tem dente"; fi
+  P -q -f "$TMP/fn.sql"     # restaura a versao verdadeira
+}
+
+# F1: guard REMOVIDO -> volta o bug de 13/08 (901 reaparece)
+grep -vF "$GUARD" "$TMP/fn.sql" > "$TMP/f1.sql"
+falsifica "F1 guard removido -> G1 reprova" "$TMP/f1.sql" 901 "t"
+
+# F2: guard SEM o ramo IS NULL -> 903 (registro desconhecido) seria suprimido em silencio
+sed "s|$GUARD|AND p.omie_registrado_em <= m.finalizado_em|" "$TMP/fn.sql" > "$TMP/f2.sql"
+falsifica "F2 guard sem IS NULL -> G3 reprova" "$TMP/f2.sql" 903 "f"
+
+# F3: `<` no lugar de `<=` -> a borda exata (904) sumiria: duvida tratada como impossibilidade
+sed 's|omie_registrado_em <= m.finalizado_em|omie_registrado_em < m.finalizado_em|' "$TMP/fn.sql" > "$TMP/f3.sql"
+falsifica "F3 < no lugar de <= -> G4 reprova" "$TMP/f3.sql" 904 "f"
+
+# Falsificacoes da POS-CONDICAO: sabotam o arquivo INTEIRO e exigem que o apply ABORTE.
+# A sentinela e a mensagem EXATA do ramo certo -- ASCII, caixa fixa, sem -i (CLAUDE.md: `grep -i` sob
+# pt_BR.UTF-8 dobra acento e casa o ramo errado). `command grep`: o `grep` do shell aqui e shim de ugrep.
+pos_falsifica() { # $1=nome  $2=sql sabotado  $3=trecho ASCII exclusivo da mensagem esperada
+  local out
+  # ⚠️ capturar ANTES de filtrar: sob `set -o pipefail` o psql que aborta (exit!=0) derruba o pipeline
+  # inteiro, e o grep nunca decide nada -- todo ramo caia no else, mascarando um dente que existia.
+  out="$(P -f "$2" 2>&1 || true)"
+  if printf '%s\n' "$out" | command grep -qF 'guard-temporal:'; then
+    if printf '%s\n' "$out" | command grep -qF "$3"; then ok "$1 -> apply abortado com a mensagem certa"
+    else bad "$1 -- abortou por OUTRO ramo: $(printf '%s\n' "$out" | command grep -F 'guard-temporal:' | head -1)"; fi
+  else
+    bad "$1 -- a migration NAO abortou pela pos/pre-condicao: a defesa nao tem dente"
+  fi
+  P -q -f "$MIG" >/dev/null   # restaura a versao verdadeira (idempotente)
+}
+
+# F4: gate FU4-G regredido -> pos-condicao barra. (A 1a versao da pos-condicao usava
+# position('cap_compras_ler' in def) e passava VERDE aqui: os COMENTARIOS do corpo citam o nome.
+# Este assert e o que exigiu trocar a sentinela por regex de CHAMADA.)
+sed 's|private\.cap_compras_ler((SELECT auth.uid()))|public.pode_ver_carteira_completa((SELECT auth.uid()))|' "$MIG" > "$TMP/f4.sql"
+pos_falsifica "F4 gate regredido" "$TMP/f4.sql" "gate de authz REGREDIU"
+
+# F6: guard temporal ausente no arquivo inteiro -> pos-condicao barra (o fix nao pode sumir em silencio)
+grep -vF "$GUARD" "$MIG" > "$TMP/f6.sql"
+pos_falsifica "F6 guard ausente" "$TMP/f6.sql" "guard temporal NAO entrou"
+
+eq "F4b restaurado apos falsificacao" "$(cand)" "902,903,904"
+
+# F5: sem private.cap_compras_ler -> a PRE-CONDICAO barra (banco limpo, so os helpers)
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove_f5
+Q() { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove_f5 -v ON_ERROR_STOP=1 "$@"; }
+Q -q -f "$REPO_ROOT/db/stubs-supabase.sql" >/dev/null 2>&1
+if Q -q -f "$MIG" >/dev/null 2>&1; then
+  bad "F5 sem cap_compras_ler -- a migration APLICOU: a pre-condicao nao tem dente"
+else
+  F5ERR="$(Q -f "$MIG" 2>&1 | grep -c 'cap_compras_ler(uuid) ausente' || true)"
+  if [ "$F5ERR" -ge 1 ]; then ok "F5 sem cap_compras_ler -> pre-condicao barrou com a mensagem certa"
+  else bad "F5 barrou, mas NAO pela pre-condicao esperada"; fi
+fi
+
+echo
+echo "=== RESULTADO: $PASS OK / $FAIL FAIL ==="
+[ "$FAIL" -eq 0 ] || exit 1

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **457** custom migrations totais
-- **1572** objetos esperados (criados por estas migrations)
+- **458** custom migrations totais
+- **1573** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 468
+  - `function`: 469
   - `rls_policy`: 392
   - `index`: 238
   - `cron_job`: 164
@@ -3839,6 +3839,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.criar_plano_tatico` | — |
+
+### `20260813195914_reposicao_pos_candidatos_guard_temporal.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.reposicao_pos_candidatos` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 457
+-- Total de custom migrations: 458
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -498,7 +498,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260807210912', 'expirar_planos_taticos', '20260807210912_expirar_planos_taticos.sql'),
   ('20260807223000', 'check_finitude_money_path', '20260807223000_check_finitude_money_path.sql'),
   ('20260808012000', 'atp_reconciliacao_fase3', '20260808012000_atp_reconciliacao_fase3.sql'),
-  ('20260808020000', 'tactical_plan_idempotencia_janela', '20260808020000_tactical_plan_idempotencia_janela.sql')
+  ('20260808020000', 'tactical_plan_idempotencia_janela', '20260808020000_tactical_plan_idempotencia_janela.sql'),
+  ('20260813195914', 'reposicao_pos_candidatos_guard_temporal', '20260813195914_reposicao_pos_candidatos_guard_temporal.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2059,7 +2060,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('atp_reconciliacao_fase3', 'function', 'public', 'atp_reservas_pendentes', ''),
   ('atp_reconciliacao_fase3', 'index', 'public', 'idx_estoque_reservas_pedido_ativa', 'estoque_reservas'),
   ('atp_reconciliacao_fase3', 'cron_job', 'cron', 'atp-reconciliar', ''),
-  ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', '')
+  ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', ''),
+  ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3668,7 +3670,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('atp_reconciliacao_fase3', 'function', 'public', 'atp_reservas_pendentes', ''),
   ('atp_reconciliacao_fase3', 'index', 'public', 'idx_estoque_reservas_pedido_ativa', 'estoque_reservas'),
   ('atp_reconciliacao_fase3', 'cron_job', 'cron', 'atp-reconciliar', ''),
-  ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', '')
+  ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', ''),
+  ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260813195914_reposicao_pos_candidatos_guard_temporal.sql
+++ b/supabase/migrations/20260813195914_reposicao_pos_candidatos_guard_temporal.sql
@@ -1,0 +1,262 @@
+-- Reposição — o detector de PO excluído para de acusar PO que ainda NEM EXISTIA (money-path)
+-- ============================================================================
+-- SINTOMA (13/08/2026, prod): o card "pedido sem PO no Omie" mostrou 4 pedidos Sayerlack do MESMO dia
+-- (protocolos 2119991/2120199/2120226 + 1, até R$21.621,84) instruindo o comprador a ligar para o
+-- fornecedor e conferir o Omie à mão. Os 4 POs existem. Dois deles já estavam no espelho
+-- (`purchase_orders_tracking`) no instante do alerta.
+--
+-- CAUSA — o detector compara com um retrato que é ANTERIOR ao próprio PO:
+--   `reposicao_po_last_seen` só é carimbado no run COMPLETO e LIMPO (`reposicao_publicar_run_completo`,
+--   1×/dia; as varreduras incrementais de 2h NÃO carimbam). O marcador de 13/08 fechou 12:17Z; os 4 POs
+--   nasceram 14:07Z, 20:09Z, 21:15Z e 21:51Z. Um run que TERMINOU antes de o PO existir não pode
+--   testemunhar a ausência dele — mas o predicado lia esse silêncio como "não apareceu".
+--   Medido em prod (30d): 42 pedidos disparados, cada um passando em MÉDIA 11,0h dentro do alerta
+--   (máx 50,4h). Não é o azar de um dia: é a latência do detector virando alarme, para TODO pedido.
+--
+-- POR QUE ISSO IMPORTA MAIS QUE O RUÍDO: o card existe por um caso REAL (pedidos 281/286, ~R$3.060,
+-- PO excluído no Omie com o pedido vivo no fornecedor) e sua instrução central — "não cancele, recrie" —
+-- está certa, porque cancelar faz o motor re-sugerir e a compra sai DUAS vezes. Um detector que grita
+-- todo dia treina o comprador a passar o olho e seguir; quando o caso verdadeiro chegar, ele estará na
+-- mesma fila dos falsos. Ruído em alerta de money-path não é incômodo, é perda de sensibilidade.
+--
+-- O QUE MUDA — uma linha no predicado: PO cujo `omie_registrado_em` é POSTERIOR ao `finalizado_em` do
+-- marcador deixa de ser candidato. Só isso. O que NÃO muda importa tanto quanto:
+--   • Não afirma que o PO existe — apenas se recusa a afirmar AUSÊNCIA sem base para tal. A RPC segue
+--     LISTANDO e EVIDENCIANDO, sem decidir (o desenho do PR2 fica intacto).
+--   • Ambiguidade continua alertando: PO registrado ANTES do `finalizado_em` mas durante a coleta (a
+--     varredura leva ~3min) pode legitimamente não ter sido visto ⇒ segue candidato. Suprimo apenas o
+--     caso logicamente IMPOSSÍVEL, nunca o duvidoso.
+--   • `omie_registrado_em IS NULL` segue candidato (fail-closed). Hoje são 0 de 94 linhas, mas a coluna
+--     é nullable e "hoje é zero" não é garantia estrutural — comparação com NULL daria NULL, e o
+--     `AND` engoliria a linha em silêncio, que é o oposto do que se quer.
+--   • O espelho `purchase_orders_tracking` continua NÃO sendo usado como supressor: o sync é
+--     upsert-only (nunca remove), então presença lá não prova existência ATUAL do PO no Omie.
+--
+-- ⚠️ PRÉ-FLIGHT (CLAUDE.md — `CREATE OR REPLACE` diverge repo×prod, a última a recriar VENCE):
+-- a definição VIVA em prod não é a da migration 20260721190000. A 20260720120000 (FU4-G) chegou depois
+-- e trocou o gate por `private.cap_compras_ler` via regexp sobre `pg_get_functiondef`. O corpo abaixo é
+-- o da PROD (capturado por psql-ro em 13/08) — partir do arquivo do repo teria REGREDIDO a autorização
+-- de volta para `pode_ver_carteira_completa`. O bloco de pré-condição barra esse acidente.
+--
+-- Prova PG17: db/test-pos-candidatos-guard-temporal.sh
+-- NÃO editar esta migration depois de aplicada (snapshot é a fonte de DR).
+-- ============================================================================
+BEGIN;
+
+-- ── PRÉ-CONDIÇÃO: o gate de authz atual precisa existir ANTES de recriarmos a função ──────────
+-- Sem isto, aplicar esta migration num banco onde o FU4-G ainda não passou criaria uma RPC SECURITY
+-- DEFINER chamando uma função inexistente: `CREATE` passa (plpgsql é late-bound) e a falha só apareceria
+-- ao EXECUTAR — com o card de compras morto em silêncio.
+DO $pre$
+BEGIN
+  IF to_regprocedure('private.cap_compras_ler(uuid)') IS NULL THEN
+    RAISE EXCEPTION 'guard-temporal: private.cap_compras_ler(uuid) ausente — aplique o FU4-G (20260720120000) antes'
+      USING ERRCODE = '42883';
+  END IF;
+END $pre$;
+
+CREATE OR REPLACE FUNCTION public.reposicao_pos_candidatos(p_empresa text)
+RETURNS TABLE (
+  pedido_id              bigint,
+  omie_codigo_pedido     text,
+  data_ciclo             date,
+  idade_dias             integer,
+  na_janela_7d           boolean,
+  valor_total            numeric,
+  itens_sem_valor        integer,
+  visto_status           text,
+  po_no_espelho          boolean,
+  fornecedor_nome        text,
+  canal_usado            text,
+  portal_protocolo       text,
+  status_envio_portal    text,
+  resposta_canal         jsonb,
+  tem_protocolo          boolean,
+  tem_status_portal      boolean,
+  tem_resposta_canal     boolean,
+  tem_canal              boolean,
+  algum_sinal_de_canal   boolean,
+  marcador_run_id        uuid,
+  marcador_seq           bigint
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_empresa public.empresa_reposicao := upper(btrim(p_empresa))::public.empresa_reposicao;
+BEGIN
+  -- Gate cron-or-staff NULL-aware: uid presente exige staff; uid NULL (service_role/cron SQL-local) passa.
+  -- ⚠️ NUNCA gatear por auth.role()='service_role' — o pg_cron roda como postgres SEM JWT (auth.role()=NULL)
+  -- e o gate mataria o cron em SILÊNCIO (reposicao.md: mordido 2x, migrations 20260627130000/20260627200000).
+  IF (SELECT auth.uid()) IS NOT NULL
+     -- ⚠️ IS NOT TRUE, não NOT(...): pode_ver_carteira_completa() era TRI-STATE (o gate ANTERIOR;
+     -- private.cap_compras_ler faz COALESCE e nunca devolve NULL, entao IS NOT TRUE fica como defesa em
+     -- profundidade). Para um `employee` SEM linha em commercial_roles ela retornava NULL, e `NOT NULL` =
+     -- NULL — o IF não entrava e a SECURITY DEFINER ENTREGAVA TUDO (protocolo, fornecedor, JSON cru).
+     -- Bypass real (Codex v11), e viola o fail-closed do CLAUDE.md. IS NOT TRUE trata NULL como negado e
+     -- preserva o uid NULL do cron, que é barrado antes pelo primeiro AND.
+     AND (SELECT private.cap_compras_ler((SELECT auth.uid()))) IS NOT TRUE THEN
+    RAISE EXCEPTION 'reposicao_pos_candidatos: acesso negado' USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH marcador AS (
+    -- "último completo válido" = maior fencing seq com volume_ok TRUE. Sem marcador → CROSS JOIN vazio →
+    -- retorna VAZIO. Fail-closed: sem base de verdade não se classifica ninguém como ausente.
+    -- `finalizado_em` entra aqui para o guard temporal do WHERE (ver abaixo).
+    SELECT r.run_id, r.seq, r.finalizado_em
+    FROM public.reposicao_pedidos_compra_run r
+    WHERE r.empresa = v_empresa AND r.status = 'ok' AND r.volume_ok IS TRUE
+    ORDER BY r.seq DESC
+    LIMIT 1
+  ),
+  base AS (
+    SELECT
+      p.id AS pedido_id,
+      p.omie_pedido_compra_id AS omie_codigo_pedido,
+      p.data_ciclo::date AS data_ciclo,
+      (now()::date - p.data_ciclo::date)::integer AS idade_dias,
+      p.fornecedor_nome,
+      p.canal_usado,
+      p.portal_protocolo,
+      p.status_envio_portal,
+      p.resposta_canal,
+      m.run_id AS marcador_run_id,
+      m.seq AS marcador_seq,
+      ls.run_id AS visto_run_id,
+      -- ⚠️ sum() IGNORA NULL: itens (100.00, NULL) davam 100.00, apresentando SUBTOTAL como total apurado —
+      -- fabricação de número, o que o money-path.md proíbe ("ausente ≠ zero"). Agora o total só existe se
+      -- TODOS os itens têm valor; senão NULL, e itens_sem_valor diz por quê (Codex v8).
+      (SELECT CASE WHEN count(*) FILTER (WHERE i.valor_linha IS NULL) = 0
+                   THEN sum(i.valor_linha) END
+         FROM public.pedido_compra_item i WHERE i.pedido_id = p.id) AS valor_total,
+      (SELECT count(*) FILTER (WHERE i.valor_linha IS NULL)
+         FROM public.pedido_compra_item i WHERE i.pedido_id = p.id)::integer AS itens_sem_valor,
+      -- ⚠️ NULL (não FALSE) quando a identidade é ILEGÍVEL: `EXISTS(... = NULL)` retorna false, e a RPC
+      -- estaria AFIRMANDO ausência no espelho sem sequer conseguir identificar o PO (Codex v7).
+      -- "Não apurei" ≠ "não há" — a mesma distinção de visto_status='identidade_nao_interpretavel'.
+      CASE WHEN public.reposicao__po_id(p.omie_pedido_compra_id) IS NULL THEN NULL ELSE EXISTS (
+        SELECT 1 FROM public.purchase_orders_tracking t
+        WHERE t.empresa = v_empresa
+          -- identidade NUMÉRICA canônica (reposicao__po_id): '00101' e '101' são o MESMO PO; whitespace de
+          -- borda tolerado, interno invalida; fora do range de bigint → NULL em vez de derrubar a RPC.
+          AND t.omie_codigo_pedido = public.reposicao__po_id(p.omie_pedido_compra_id)
+      ) END AS po_no_espelho
+    FROM public.pedido_compra_sugerido p
+    CROSS JOIN marcador m
+    LEFT JOIN public.reposicao_po_last_seen ls
+           ON ls.empresa = v_empresa
+          AND ls.omie_codigo_pedido = public.reposicao__po_id(p.omie_pedido_compra_id)
+    -- ⚠️ `pedido_compra_sugerido.empresa` é **text** ('OBEN'); as outras tabelas usam o ENUM empresa_reposicao.
+    -- text = enum direto é erro de TIPO em runtime (PL/pgSQL late-bound: o CREATE passa, quebra ao EXECUTAR).
+    WHERE upper(btrim(p.empresa)) = v_empresa::text
+      AND p.status IN ('disparado', 'aprovado_aguardando_disparo')
+      AND p.omie_pedido_compra_id IS NOT NULL
+      AND btrim(p.omie_pedido_compra_id) <> ''
+      -- CANDIDATO = o PO não foi visto no marcador atual (carimbado por run ANTERIOR ou NUNCA carimbado).
+      AND (ls.run_id IS NULL OR ls.run_id <> m.run_id)
+      -- ⚠️ GUARD TEMPORAL: um run que TERMINOU antes de o PO existir não testemunha NADA sobre ele.
+      -- O carimbo de `last_seen` só sai no run COMPLETO (1×/dia); todo PO criado depois dele ficava
+      -- "não visto" por até ~22h e virava alerta de conferência manual (prod 13/08: 4 de 4 candidatos,
+      -- média histórica de 11,0h por pedido). Sem este guard o detector acusa o próprio atraso.
+      --
+      -- Deliberadamente CONSERVADOR nos dois lados:
+      --   • `IS NULL` → segue candidato: sem data de registro não dá para provar impossibilidade, e a
+      --     comparação devolveria NULL, que o AND descartaria em SILÊNCIO (supressão acidental).
+      --   • `<=` (não `<`) mantém candidato o PO registrado DURANTE a coleta — ele pode legitimamente
+      --     não ter entrado na varredura. Suprime-se o impossível, nunca o duvidoso.
+      AND (p.omie_registrado_em IS NULL OR p.omie_registrado_em <= m.finalizado_em)
+  )
+  SELECT
+    b.pedido_id,
+    b.omie_codigo_pedido,
+    b.data_ciclo,
+    b.idade_dias,
+    -- DANO ATIVO = a CTE em_transito só soma disparados dos últimos 7d. Idade = PRIORIDADE, não verdade.
+    -- NOME FACTUAL: a RPC apura a JANELA, nao o dano (um aprovado_aguardando_disparo de 3 dias sem canal
+    -- nenhum recebia dano_ativo=true so pela idade — Codex v9). Quem decide se ha dano e o consumidor.
+    (b.idade_dias BETWEEN 0 AND 7) AS na_janela_7d,
+    b.valor_total,
+    b.itens_sem_valor,
+    -- ⚠️ identidade ILEGÍVEL não é "nunca visto": o LEFT JOIN não pôde nem comparar. Afirmar ausência aqui
+    -- era falha ABERTA (Codex v6 P1) — e o assert J3 chegava a FIXAR esse falso-positivo como esperado.
+    CASE
+      WHEN public.reposicao__po_id(b.omie_codigo_pedido) IS NULL THEN 'identidade_nao_interpretavel'
+      -- 'sem_registro_last_seen', não 'nunca_carimbado': a RPC prova a ausência ATUAL da linha, não que o PO
+      -- nunca foi visto — a linha pode ter sido apagada/reconstruída (Codex v10). "Nunca" é afirmação de
+      -- histórico, e histórico esta RPC não consulta.
+      WHEN b.visto_run_id IS NULL                                THEN 'sem_registro_last_seen'
+      -- 'outro_run', não 'anterior': a RPC só prova `run_id <> marcador`. O outro run pode ser POSTERIOR
+      -- (seq maior, ainda não promovido a marcador) ou um UUID sem linha na tabela de runs (Codex v11).
+      -- Afirmar "anterior" seria temporalidade não apurada.
+      ELSE 'visto_em_outro_run'
+    END AS visto_status,
+    -- SINAL FRACO: o sync do tracking é upsert-only (nunca remove) → ausência do espelho NÃO prova exclusão.
+    b.po_no_espelho,
+    b.fornecedor_nome,
+    b.canal_usado,
+    -- 🔑 SEM REGEX SEMÂNTICA (Codex v9). Quatro rodadas seguidas acharam um valor que enganava o rótulo:
+    -- 'su cesso' virava sucesso por coerção de whitespace; 'sem sucesso' casava a regex; e a guarda de
+    -- negação criou falso-NEGATIVO ('login: sucesso' — o `in` casa no fim de "log-IN") e falso-POSITIVO
+    -- ('não houve sucesso' — o [^a-z]* não atravessa "houve"). Interpretar texto LIVRE de terceiro por regex
+    -- não converge, e o rótulo não decide nada desde que a coluna `rota` morreu na v4.
+    -- Ficam só FATOS BINÁRIOS incontestáveis. O humano/PR3 lê os campos crus (portal_protocolo,
+    -- status_envio_portal, resposta_canal, canal_usado) e interpreta com o contexto que a RPC não tem.
+    b.portal_protocolo,
+    b.status_envio_portal,
+    b.resposta_canal,
+    (public.reposicao__trim(b.portal_protocolo) <> '')    AS tem_protocolo,
+    (public.reposicao__trim(b.status_envio_portal) <> '') AS tem_status_portal,
+    -- ⚠️ JSON null ('null'::jsonb) NÃO é SQL NULL: `IS NOT NULL` dava true e a RPC afirmava resposta
+    -- existente onde não há nenhuma (Codex v10).
+    (b.resposta_canal IS NOT NULL AND jsonb_typeof(b.resposta_canal) <> 'null') AS tem_resposta_canal,
+    (public.reposicao__trim(b.canal_usado) <> '')         AS tem_canal,
+    -- "há algum indício de que o fornecedor foi acionado?" — OR simples, sem inferência.
+    (public.reposicao__trim(b.portal_protocolo) <> ''
+      OR public.reposicao__trim(b.status_envio_portal) <> ''
+      OR (b.resposta_canal IS NOT NULL AND jsonb_typeof(b.resposta_canal) <> 'null')
+      OR public.reposicao__trim(b.canal_usado) <> '')     AS algum_sinal_de_canal,
+    b.marcador_run_id,
+    b.marcador_seq
+  FROM base b
+  ORDER BY (b.idade_dias BETWEEN 0 AND 7) DESC, b.valor_total DESC NULLS LAST, b.pedido_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.reposicao_pos_candidatos(text) IS
+  'PR2 (NÃO-MUTANTE): pedidos disparado/aprovado cujo PO não apareceu no último run VÁLIDO. LISTA e EVIDENCIA — NÃO decide. GUARD TEMPORAL (13/08/2026): PO com omie_registrado_em POSTERIOR ao finalizado_em do marcador NÃO é candidato — o carimbo de last_seen só sai no run completo (1x/dia) e um run que terminou antes de o PO existir não testemunha a ausência dele (prod: 4/4 candidatos falsos, média de 11h de alerta indevido por pedido disparado). Suprime só o IMPOSSÍVEL: registro NULL e registro durante a coleta seguem candidatos (fail-closed). Deliberadamente SEM rota automática: em prod 59/59 dos disparados acionaram portal do fornecedor, então "elegível a auto-cancelamento" é logicamente vazio; e canal/status/resposta são text/jsonb livres onde regex prova presença, nunca ausência. Todo candidato exige decisão humana (provável: RECRIAR o PO, não cancelar). Sem marcador válido retorna VAZIO (fail-closed).';
+
+REVOKE ALL ON FUNCTION public.reposicao_pos_candidatos(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.reposicao_pos_candidatos(text) TO authenticated, service_role;
+
+-- ── PÓS-CONDIÇÃO: a função recriada tem o gate NOVO e o guard NOVO ────────────────────────────
+-- O acidente que esta migration quase cometeu (partir do corpo do repo e regredir o gate FU4-G) é o
+-- mesmo que a PRÓXIMA pode cometer. Aqui ele falha ALTO, dentro da transação, em vez de virar bypass
+-- silencioso de autorização em produção.
+-- ⚠️ Casar a CHAMADA, nunca a MENÇÃO. A 1ª versão testava `position('cap_compras_ler' in v_def) > 0`
+-- e a falsificação F4 provou que ela NÃO tinha dente: os comentários do próprio corpo citam
+-- `private.cap_compras_ler`, então a migration com o gate REGREDIDO para pode_ver_carteira_completa
+-- aplicava verde. Sentinela que casa comentário mente. Os regexes de chamada abaixo (mesmo padrão da
+-- 20260720120000) exigem o `(( SELECT` da invocação real — e o 2º barra a regressão mesmo que alguém
+-- deixe as duas chamadas no corpo.
+DO $pos$
+DECLARE
+  v_def   text := pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure);
+  c_novo  constant text := 'private\.cap_compras_ler\s*\(\s*\(\s*SELECT';
+  c_velho constant text := 'pode_ver_carteira_completa\s*\(\s*\(\s*SELECT';
+  c_guard constant text := 'AND \(p\.omie_registrado_em IS NULL OR p\.omie_registrado_em <= m\.finalizado_em\)';
+BEGIN
+  IF v_def !~ c_novo THEN
+    RAISE EXCEPTION 'guard-temporal: gate de authz REGREDIU — sem CHAMADA a private.cap_compras_ler' USING ERRCODE = '42501';
+  END IF;
+  IF v_def ~ c_velho THEN
+    RAISE EXCEPTION 'guard-temporal: gate ANTIGO (pode_ver_carteira_completa) ainda é CHAMADO — FU4-G regrediu' USING ERRCODE = '42501';
+  END IF;
+  IF v_def !~ c_guard THEN
+    RAISE EXCEPTION 'guard-temporal: o guard temporal NAO entrou na definição final' USING ERRCODE = '22000';
+  END IF;
+END $pos$;
+
+COMMIT;


### PR DESCRIPTION
## O que aconteceu

O card "pedido sem PO no Omie" mostrou hoje **4 pedidos Sayerlack do mesmo dia** (protocolos 2119991 / 2120199 / 2120226 + 1, até **R$ 21.621,84**) instruindo o comprador a ligar para o fornecedor e conferir o Omie à mão. **Os 4 POs existem** — dois deles já estavam no espelho (`purchase_orders_tracking`) no instante do alerta.

## Causa

`reposicao_po_last_seen` só é carimbado no run **COMPLETO** e limpo (`reposicao_publicar_run_completo`, 1×/dia; as varreduras incrementais de 2h **não** carimbam). O marcador de 13/08 fechou **12:17Z**; os POs nasceram **14:07Z, 20:09Z, 21:15Z e 21:51Z**.

Um run que **terminou antes de o PO existir** não pode testemunhar a ausência dele — mas o predicado lia esse silêncio como "não apareceu".

Medido em prod (30d, via `psql-ro`): **42 pedidos disparados**, cada um passando em **média 11,0h** dentro do alerta (**máx 50,4h**). Não é o azar de um dia — é a latência do detector virando alarme, para todo pedido disparado.

## Por que isso importa mais que o ruído

O card existe por um caso **real** (pedidos 281/286, ~R$3.060, PO excluído no Omie com o pedido vivo no fornecedor), e sua instrução central — *"não cancele, recrie"* — está certa: cancelar faz o motor re-sugerir e a compra sai **duas vezes**. Um detector que grita todo dia treina o comprador a passar o olho e seguir; quando o caso verdadeiro chegar, ele estará na mesma fila dos falsos. Ruído em alerta de money-path não é incômodo, é **perda de sensibilidade**.

## O que muda

Uma linha no predicado: PO com `omie_registrado_em` **posterior** ao `finalizado_em` do marcador deixa de ser candidato.

O que **não** muda importa tanto quanto:

- Não afirma que o PO existe — apenas se recusa a afirmar **ausência** sem base. A RPC segue listando e evidenciando, sem decidir.
- **Ambiguidade continua alertando:** PO registrado antes do `finalizado_em` mas durante a coleta (~3min) pode legitimamente não ter sido visto ⇒ segue candidato. Suprime-se o impossível, nunca o duvidoso.
- `omie_registrado_em IS NULL` segue candidato (fail-closed). Hoje são 0 de 94, mas a coluna é nullable — e comparação com NULL daria NULL, que o `AND` engoliria em silêncio.
- O espelho `purchase_orders_tracking` **não** vira supressor: o sync é upsert-only, então presença lá não prova existência atual do PO no Omie.

## ⚠️ Pré-flight pegou uma armadilha de authz

A definição **viva em prod não é a do repo**: o FU4-G (`20260720120000`) chegou depois da `20260721190000` e trocou o gate para `private.cap_compras_ler` via `regexp_replace` sobre `pg_get_functiondef`. **Partir do arquivo do repo teria regredido a autorização** de volta para `pode_ver_carteira_completa` (o bypass tri-state que o #1472 fechou).

O corpo desta migration é o **da PROD** (capturado por `psql-ro`), e ela carrega pré/pós-condições que fazem esse acidente falhar alto — dentro da transação — em vez de virar bypass silencioso.

## Prova

`db/test-pos-candidatos-guard-temporal.sh` — **18 asserts, 0 falhas, 5 falsificações**:

| | prova |
|---|---|
| G1 | PO nascido depois do marcador não é candidato (o bug de hoje) |
| G2 | PO nascido antes e não-visto **segue** candidato (o sinal real, 281/286) |
| G3 | `omie_registrado_em` NULL segue candidato (fail-closed) |
| G4 | registrado exatamente no `finalizado_em` segue candidato (borda `<=`) |
| G5/A/D | comportamento antigo, fail-closed sem marcador e gate de authz intactos |
| F1–F3 | guard removido / sem `IS NULL` / `<` no lugar de `<=` → o assert correspondente fica **vermelho** |
| F4, F6 | gate regredido / guard ausente → o apply **aborta** |
| F5 | sem `private.cap_compras_ler` → pré-condição barra (42883) |

**A falsificação F4 pegou teatro real:** a 1ª pós-condição testava `position('cap_compras_ler' in def) > 0` e passava verde com o gate regredido — porque os **comentários** do corpo citam o nome. Sentinela que casa comentário mente. Trocada por regex de **chamada** (`cap_compras_ler\s*\(\s*\(\s*SELECT`), mais a checagem negativa do gate antigo.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260813195914_reposicao_pos_candidatos_guard_temporal.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor e rodar.

Validação pós-apply (rodo eu, via `psql-ro`):

```sql
SELECT CASE
  WHEN pg_get_functiondef('public.reposicao_pos_candidatos(text)'::regprocedure)
       ~ 'AND \(p\.omie_registrado_em IS NULL OR p\.omie_registrado_em <= m\.finalizado_em\)'
  THEN 'OK guard temporal ativo' ELSE 'FALTANDO — migration nao aplicada' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
