### PR TITLE
feat(reposicao): sonda read-only mede o contrato nativo do Omie — fatia 1 do receipt-first ledger [money-path]

### DIFF
--- a/docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md
+++ b/docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md
@@ -255,3 +255,33 @@ Todas com `~/.config/afiacao/psql-ro -X -c "…"`. Chaves: itens de PO via
 `pedido_compra_sugerido` (`criado_em`); vendas via `venda_items_history` (`data_emissao`).
 ⚠️ `sku_leadtime_history.sku_codigo_omie` é **bigint** e `pedido_compra_item.sku_codigo_omie` é **text** —
 o join exige `::text`.
+
+## 8. Errata da §3.2/§3.4 — a consolidação de nota é MUITO pior no conjunto que importa
+
+**Medido 2026-08-13 (fatia 1, `psql-ro`), corrigindo o universo da distribuição da §3.2.**
+
+A distribuição da §3.2 ("171 notas 1:1, 15 com 2 POs, …") está aritmeticamente correta, mas descreve
+**todas as 418 POs OBEN com `nid_receb`** — não as **244** que são alvo do desconto. Reproduzido:
+`171` notas 1:1 e `418` POs sobre a tabela inteira; a §3.2 é verdadeira ali. No subconjunto etapa-15
+com `t4` a foto é outra:
+
+| recorte | notas distintas | POs com nota exclusiva |
+|---|---|---|
+| todas as POs OBEN com nota | 230 | 171 (41% das 418) |
+| **as 244 POs alvo** | **68** | **14 (5,7%)** |
+
+**230 das 244 POs (94%) dividem a nota com outra PO** — a nota consolidada é a REGRA no conjunto que
+importa, não a exceção. Distribuição nas 244: 14 notas com 1 PO, 13 com 2, 16 com 3, 6 com 4, 5 com 5,
+5 com 6, 4 com 7, 2 com 8, 2 com 10, 1 com 13.
+
+**E a exclusividade é mesmo relativa — agora medido, não só argumentado.** O Codex derrubou a §3.4 em
+tese ("`nid_receb` exclusivo prova só que nenhuma outra PO *visível hoje* divide o cabeçalho"). Das
+**14** notas exclusivas dentro das 244, só **12 continuam exclusivas** quando a contagem olha a tabela
+OBEN inteira: 2 delas (14%) dividem a nota com POs fora do recorte etapa-15+`t4`. A exclusividade
+mudou **sem nenhum dado novo chegar** — apenas por ampliar a janela de observação sobre o MESMO
+espelho. Um predicado que vira falso ao mudar o `WHERE` da própria query não pode gatilhar desconto
+no money-path.
+
+**Consequência para o ledger (§6):** `receipt_allocation` N:N com quantidade **nullable** não é
+generalidade defensiva — é a forma dominante do dado. Qualquer desenho que pressuponha nota→PO 1:1
+cobre 5,7% do problema e erra os outros 94%.

--- a/docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md
+++ b/docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md
@@ -285,3 +285,15 @@ no money-path.
 **Consequência para o ledger (§6):** `receipt_allocation` N:N com quantidade **nullable** não é
 generalidade defensiva — é a forma dominante do dado. Qualquer desenho que pressuponha nota→PO 1:1
 cobre 5,7% do problema e erra os outros 94%.
+
+### 8.1 Correção de tipo no M1 — `nQtdeRec` é NUMBER, não string
+
+O M1 (§1) afirma que `nQtdeRec` "é a string literal `"0"`". A **conclusão** está certa e continua
+de pé — sobre os 2.740 itens de PO OBEN do espelho, `nQtdeRec` é `0` em **100%**, zero acima de zero,
+zero ausentes; o "a caminho" nunca decrementa. O que estava errado é o tipo: `jsonb_typeof` devolve
+`number` para `nQtdeRec` **e** para `nQtde` em 2.740 de 2.740.
+
+Registro porque muda código: quem implementar o parse do ledger a partir do M1 escreveria uma
+política para string onde o dado é número. O `parseQtd`/`parseRecebido` de `omie-sync-estoque` já
+trata os dois (string estrita **e** number), e o núcleo da sonda faz o mesmo — mas o comentário
+"Omie omite" ali descreve um caso que, no espelho de hoje, **não ocorre nenhuma vez**.

--- a/docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md
+++ b/docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md
@@ -297,3 +297,38 @@ Registro porque muda código: quem implementar o parse do ledger a partir do M1 
 política para string onde o dado é número. O `parseQtd`/`parseRecebido` de `omie-sync-estoque` já
 trata os dois (string estrita **e** number), e o núcleo da sonda faz o mesmo — mas o comentário
 "Omie omite" ali descreve um caso que, no espelho de hoje, **não ocorre nenhuma vez**.
+
+## 9. A terceira hipótese para a etapa-15 — e o que a sonda da fatia 1 NÃO mede
+
+### 9.1 O `t4` do espelho pode ser inferência NOSSA
+
+A §6 põe duas explicações para as 244 POs recebidas em etapa 15 (workflow paralelo × associação
+nunca feita). Há uma **terceira**, levantada pelo Codex e sustentada pelo próprio código:
+`omie-sync-nfes-recebidas` monta o vínculo PO↔NF-e a partir de `itensRecebimento[].itensInfoAdic.
+nNumPedCompra` — uma referência **textual** que o fornecedor escreve no XML — e **não** dos ids
+nativos `nIdPedido`/`nIdItPedido` (ver `extractPedidosFromDetalhe`). O `t4` é gravado quando
+`cRecebido=S` e **nunca é limpo** se o recebimento for revertido.
+
+Se esse for o caso dominante, "PO recebida" é **inferência do espelho**, não estado do Omie — e a
+etapa-15 deixa de ser contradição alguma. Medido junto: **nenhuma tabela do espelho guarda
+`nIdPedido`/`nIdItPedido`** (`nfe_recebimentos`, `nfe_recebimento_itens`, `sku_leadtime_history`),
+então a ausência do vínculo nativo aqui **nunca provou** ausência dele no Omie — provou que
+ninguém foi buscar. Por isso a sonda classifica cada item numa taxonomia (`native_exact`,
+`native_other_po`, `native_sem_item`, `xml_hint_only`, `xml_hint_outra_po`, `product_only`,
+`unassociated`) em vez de perguntar "o campo existe?".
+
+### 9.2 Limites conhecidos da sonda — leia antes de interpretar o resultado
+
+- **`dangling` não é verificado.** Um `nIdPedido` que aponta para PO inexistente/inconsultável cai
+  em `native_other_po`. Separar os dois exigiria uma consulta extra por id.
+- **Sem varredura de paginação.** Os candidatos de movimento leem a primeira página. O relatório
+  traz o total de páginas/registros **declarado**, justamente para que "página 1 vazia" não seja
+  lido como "não há dado".
+- **O período parte do `t4`, não do `dRegistro`.** É o `dRegistro` que governa o lançamento de
+  estoque, mas ele só é conhecido **depois** da S2 — a janela é ±7 dias em torno do `t4` como
+  aproximação. Uma segunda rodada pode reapontar usando o `dRegistro` que a S2 devolver.
+- **A amostra é de contrato, não censo.** 3 notas distintas (dos dois extremos da consolidação),
+  não as 68. Serve para fixar a FORMA do dado; frequência exige varredura.
+- **Fault de parâmetro ≠ método inexistente.** A camada A (`param: {}`) só separa isso quando a
+  faultstring é específica. Faultstring genérica não discrimina, e o relatório mostra o texto cru
+  para que a leitura não seja automática.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -96,6 +96,12 @@ verify_jwt = false
 [functions.omie-sync-metadados]
 verify_jwt = false
 
+# Sonda de diagnóstico read-only (fatia 1 do receipt-first ledger). Mesmo padrão da
+# omie-sync-estoque: o gate é da aplicação (authorizeCronOrStaff), não do JWT do Supabase,
+# para aceitar tanto x-cron-secret quanto bearer de staff/service_role.
+[functions.omie-sonda-recebimento]
+verify_jwt = false
+
 [functions.radar-ingest]
 verify_jwt = false
 

--- a/supabase/functions/omie-sonda-recebimento/index.ts
+++ b/supabase/functions/omie-sonda-recebimento/index.ts
@@ -1,0 +1,464 @@
+// Edge function: omie-sonda-recebimento
+//
+// SONDA DE DIAGNÓSTICO — READ-ONLY ao Omie e ao banco. Não grava nada, não toca o motor de
+// reposição, não altera `sku_estoque_atual`. Existe para responder UMA pergunta que trava o
+// desenho do receipt-first ledger (spec docs/superpowers/specs/2026-08-13-reposicao-onorder-
+// po-recebida-medicao.md, §6):
+//
+//   244 POs já recebidas seguem em etapa 15. No fluxo NATIVO do Omie, associar itens da NF-e à
+//   PO move o pedido para "Recebido Parcialmente"/"Recebido". Então OU etapa-15 é um workflow
+//   paralelo ao estado nativo de recebimento, OU a associação item-a-item nunca é feita neste
+//   tenant. Até isso ser resolvido, `t4` não pode ser tratado como recebimento.
+//
+// As 4 sondas, todas sobre as MESMAS POs:
+//   S1  ConsultarPedCompra (id nativo) vs. o PesquisarPedCompra já espelhado — o detalhe expõe
+//       recebimento por item que a listagem esconde?
+//   S2  ConsultarRecebimento (nIdReceb) — a associação item-a-item existe neste tenant?
+//   S3  movimento de estoque ligado à NF-e — O SINAL QUE O LEDGER VAI USAR: existe, é
+//       consultável, tem produto + local + quantidade?
+//   S4  granularidade do saldo pendente + unidade/local do detalhe.
+//
+// Por que os métodos da S3 são DESCOBERTOS e não assumidos: "nome de endpoint não é contrato"
+// (Codex). A edge tenta candidatos e reporta o desfecho de cada um — um método inexistente é
+// RESULTADO da medição, não erro da execução. Os candidatos podem vir no corpo
+// (`candidatos_movimento`) para iterar a descoberta SEM um novo deploy a cada tentativa; a trava
+// `ehMetodoDeLeitura` garante que nada além de consulta chegue ao ERP de produção.
+//
+// Invocação: POST { empresa?, limite?, pedidos?, incluir_bruto?, candidatos_movimento? }
+// Gate: authorizeCronOrStaff.
+
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
+import { authorizeCronOrStaff, corsHeaders as sharedCors } from "../_shared/auth.ts";
+import { mensagemDeErro } from "../_shared/erro-mensagem.ts";
+import {
+  caminhosDeChave,
+  classificarResposta,
+  type Desfecho,
+  diffCaminhos,
+  ehMetodoDeLeitura,
+  localizarItens,
+  normalizarItemPO,
+  redigirSegredos,
+} from "./sondas.ts";
+
+const corsHeaders = { ...sharedCors, "Access-Control-Allow-Methods": "POST, OPTIONS" };
+
+const URL_PED_COMPRA = "https://app.omie.com.br/api/v1/produtos/pedidocompra/";
+const URL_RECEB_NFE = "https://app.omie.com.br/api/v1/produtos/recebimentonfe/";
+const URL_ESTOQUE = "https://app.omie.com.br/api/v1/estoque/consulta/";
+const URL_MOV_ESTOQUE = "https://app.omie.com.br/api/v1/estoque/movestoque/";
+const URL_AJUSTE_ESTOQUE = "https://app.omie.com.br/api/v1/estoque/ajuste/";
+
+const MAX_TENTATIVAS = 3;
+/** Teto duro de chamadas por execução — a sonda é barata por desenho; estourar isso é bug. */
+const MAX_CHAMADAS = 60;
+const LIMITE_PADRAO = 3;
+const BRUTO_MAX_CHARS = 20_000;
+
+interface Credenciais {
+  appKey: string;
+  appSecret: string;
+}
+
+function credenciais(empresa: string): Credenciais {
+  if (empresa === "OBEN") {
+    return {
+      appKey: Deno.env.get("OMIE_OBEN_APP_KEY") ?? "",
+      appSecret: Deno.env.get("OMIE_OBEN_APP_SECRET") ?? "",
+    };
+  }
+  return {
+    appKey: Deno.env.get("OMIE_COLACOR_APP_KEY") ?? "",
+    appSecret: Deno.env.get("OMIE_COLACOR_APP_SECRET") ?? "",
+  };
+}
+
+function json(body: Record<string, unknown>, status = 200): Response {
+  return new Response(JSON.stringify(body, null, 2), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+interface Chamada {
+  endpoint: string;
+  call: string;
+  param: Record<string, unknown>;
+}
+
+/**
+ * Contador POR EXECUÇÃO. Deliberadamente não é global de módulo: o runtime reaproveita a
+ * instância entre requisições, então um contador de módulo seria compartilhado por invocações
+ * concorrentes — uma zeraria o teto da outra.
+ */
+interface Ctx {
+  chamadas: number;
+}
+
+/**
+ * Chama o Omie e devolve o DESFECHO classificado. Fault NÃO lança: para uma sonda, "este método
+ * não existe" é o dado que se quer. Lança apenas o que impede medir (credencial, teto, transporte
+ * após retries) — e nunca deixa credencial vazar para mensagem de erro.
+ */
+async function chamarOmie(
+  { endpoint, call, param }: Chamada,
+  creds: Credenciais,
+  ctx: Ctx,
+): Promise<Desfecho> {
+  if (!ehMetodoDeLeitura(call)) {
+    // Defesa em profundidade: no MESMO endpoint de recebimento moram AlterarRecebimento e
+    // ConcluirRecebimento. A sonda nunca pode escrever no ERP, nem por candidato vindo do corpo.
+    throw new Error(`BLOQUEADO: "${call}" não é método de leitura — a sonda é read-only`);
+  }
+  if (ctx.chamadas >= MAX_CHAMADAS) {
+    throw new Error(`teto de ${MAX_CHAMADAS} chamadas atingido`);
+  }
+  if (!creds.appKey || !creds.appSecret) {
+    throw new Error("credenciais Omie ausentes no ambiente");
+  }
+
+  let ultimoErro: unknown = null;
+  for (let tentativa = 1; tentativa <= MAX_TENTATIVAS; tentativa++) {
+    try {
+      ctx.chamadas++;
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          call,
+          app_key: creds.appKey,
+          app_secret: creds.appSecret,
+          param: [param],
+        }),
+      });
+      const texto = await res.text();
+
+      if (res.status === 429) {
+        console.warn(`[sonda] 429 em ${call} (tentativa ${tentativa}), aguardando 5s`);
+        await new Promise((r) => setTimeout(r, 5000));
+        continue;
+      }
+      if (res.status === 401 || res.status === 403) {
+        throw new Error(`AUTH_ERRO ${res.status} em ${call}`);
+      }
+      return classificarResposta(res.status, texto);
+    } catch (err) {
+      ultimoErro = err;
+      const msg = mensagemDeErro(err) ?? `falha sem mensagem em ${call}`;
+      if (msg.startsWith("AUTH_ERRO")) throw err;
+      const espera = 1000 * Math.pow(2, tentativa - 1);
+      console.warn(`[sonda] ${call} tentativa ${tentativa}/${MAX_TENTATIVAS}: ${msg}`);
+      await new Promise((r) => setTimeout(r, espera));
+    }
+  }
+  throw ultimoErro ?? new Error(`falha desconhecida em ${call}`);
+}
+
+/** Resumo uniforme de um desfecho — o que entra no relatório de todas as sondas. */
+function resumirDesfecho(d: Desfecho): Record<string, unknown> {
+  switch (d.tipo) {
+    case "ok":
+      return { desfecho: "ok", caminhos: caminhosDeChave(d.json) };
+    case "fault":
+      return { desfecho: "fault", faultcode: d.faultcode, faultstring: d.faultstring };
+    case "http_erro":
+      return { desfecho: "http_erro", status: d.status, corpo: redigirSegredos(d.corpo) };
+    case "nao_json":
+      return { desfecho: "nao_json", status: d.status, corpo: redigirSegredos(d.corpo) };
+  }
+}
+
+/**
+ * Guarda o payload bruto redigido. Corta por TAMANHO sem reparsear: `JSON.parse` de uma string
+ * truncada lança, e uma sonda não pode morrer por causa do próprio anexo de diagnóstico.
+ */
+function guardarBruto(
+  destino: Record<string, unknown>,
+  chave: string,
+  json: Record<string, unknown>,
+): void {
+  const texto = redigirSegredos(JSON.stringify(json));
+  // Reparsear o texto REDIGIDO (não devolver `json`): o objeto original não passou pela redação.
+  destino[chave] = texto.length <= BRUTO_MAX_CHARS
+    ? JSON.parse(texto)
+    : { truncado: true, chars: texto.length, inicio: texto.slice(0, BRUTO_MAX_CHARS) };
+}
+
+/** Itens normalizados de um payload, com o CAMINHO onde foram encontrados (contrato medido). */
+function resumirItens(payload: unknown): Record<string, unknown> {
+  const achado = localizarItens(payload);
+  if (!achado) return { encontrados: false };
+  return {
+    encontrados: true,
+    caminho: achado.caminho,
+    n: achado.itens.length,
+    itens: achado.itens.slice(0, 12).map(normalizarItemPO),
+    chavesDoItem: caminhosDeChave(achado.itens[0] ?? {}),
+  };
+}
+
+interface LinhaPO {
+  omie_codigo_pedido: string | number | null;
+  numero_pedido: string | null;
+  nid_receb: number | null;
+  nfe_chave_acesso: string | null;
+  t4_data_recebimento: string | null;
+  raw_data: Record<string, unknown> | null;
+}
+
+async function carregarAmostra(
+  supabase: SupabaseClient,
+  empresa: string,
+  limite: number,
+  pedidos: string[] | null,
+): Promise<LinhaPO[]> {
+  let q = supabase
+    .from("purchase_orders_tracking")
+    .select(
+      "omie_codigo_pedido, numero_pedido, nid_receb, nfe_chave_acesso, t4_data_recebimento, raw_data",
+    )
+    .eq("empresa", empresa)
+    .not("t4_data_recebimento", "is", null)
+    .eq("raw_data->cabecalho_consulta->>cEtapa", "15");
+  if (pedidos && pedidos.length > 0) q = q.in("numero_pedido", pedidos);
+  const { data, error } = await q
+    .order("t4_data_recebimento", { ascending: false })
+    .limit(limite);
+  if (error) throw new Error(`leitura da amostra: ${error.message}`);
+  return (data ?? []) as LinhaPO[];
+}
+
+function ddmmyyyy(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}
+
+/**
+ * Candidatos da S3 — a descoberta do contrato de MOVIMENTO DE ESTOQUE.
+ *
+ * Duas decisões que definem o poder de discriminação da sonda:
+ *
+ * 1. CONTROLE POSITIVO. `ListarPosEstoque` e `ListarSaldoPendente` já rodam em produção
+ *    (omie-sync-estoque) e entram com os params EXATOS de lá. Se até eles falharem, o problema é
+ *    transporte/credencial — sem esse controle, um fault genérico seria lido como "o Omie não
+ *    expõe movimento de estoque", que é justamente a conclusão errada a evitar. Note que os dois
+ *    provam, sozinhos, que no MESMO endpoint convivem convenções diferentes de parâmetro
+ *    (`nPagina`/`nRegPorPagina` húngaro vs. `pagina`/`registros_por_pagina` snake_case PT) — mais
+ *    uma razão para não inferir o param de um método a partir do vizinho.
+ *
+ * 2. CANDIDATO DESCONHECIDO VAI COM `param: {}`. Parece preguiça, é o contrário: mandar param
+ *    chutado colapsa dois desfechos MUITO diferentes num fault só. Com param vazio, "método não
+ *    existe" e "falta o parâmetro obrigatório X" chegam como faultstrings distintas — e a segunda
+ *    PROVA que o método existe, além de nomear o parâmetro que ele quer. O fault vira contrato.
+ */
+function candidatosMovimentoPadrao(codProduto: string | null): Chamada[] {
+  const lista: Chamada[] = [
+    // ── controles positivos (params verbatim de omie-sync-estoque) ──
+    {
+      endpoint: URL_ESTOQUE,
+      call: "ListarPosEstoque",
+      param: {
+        nPagina: 1,
+        nRegPorPagina: 5,
+        dDataPosicao: ddmmyyyy(new Date()),
+        cExibeTodos: "S",
+      },
+    },
+    {
+      endpoint: URL_ESTOQUE,
+      call: "ListarSaldoPendente",
+      param: { pagina: 1, registros_por_pagina: 5, tipo: "ENTRADA" },
+    },
+    // ── candidatos: param vazio de propósito (ver nota 2) ──
+    { endpoint: URL_ESTOQUE, call: "ListarMovimentos", param: {} },
+    { endpoint: URL_ESTOQUE, call: "ListarMovimentoEstoque", param: {} },
+    { endpoint: URL_ESTOQUE, call: "ConsultarMovimentoEstoque", param: {} },
+    { endpoint: URL_MOV_ESTOQUE, call: "ListarMovimentos", param: {} },
+    { endpoint: URL_MOV_ESTOQUE, call: "ListarMovimentoEstoque", param: {} },
+    { endpoint: URL_AJUSTE_ESTOQUE, call: "ListarAjustes", param: {} },
+    { endpoint: URL_RECEB_NFE, call: "ListarRecebimentos", param: {} },
+  ];
+  if (codProduto) {
+    // Com produto real: se o método existir, a resposta já mostra a FORMA do movimento
+    // (produto, local, quantidade, data) — que é o que o ledger precisa da S3.
+    lista.push({
+      endpoint: URL_ESTOQUE,
+      call: "ObterEstoqueProduto",
+      param: { nIdProduto: Number(codProduto), dDia: ddmmyyyy(new Date()) },
+    });
+    lista.push({
+      endpoint: URL_ESTOQUE,
+      call: "ListarMovimentoProduto",
+      param: { nIdProduto: Number(codProduto) },
+    });
+  }
+  return lista;
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const auth = await authorizeCronOrStaff(req);
+  if (!auth.ok) return auth.response;
+
+  const ctx: Ctx = { chamadas: 0 };
+
+  try {
+    const corpo = await req.json().catch(() => ({})) as Record<string, unknown>;
+    const empresa = typeof corpo.empresa === "string" ? corpo.empresa : "OBEN";
+    const limite = typeof corpo.limite === "number"
+      ? Math.max(1, Math.min(10, corpo.limite))
+      : LIMITE_PADRAO;
+    const pedidos = Array.isArray(corpo.pedidos) ? corpo.pedidos.map(String) : null;
+    const incluirBruto = corpo.incluir_bruto === true;
+
+    const creds = credenciais(empresa);
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    const amostra = await carregarAmostra(supabase, empresa, limite, pedidos);
+    if (amostra.length === 0) {
+      return json({ ok: false, erro: "nenhuma PO etapa-15 com t4 encontrada para a amostra" }, 404);
+    }
+
+    const bruto: Record<string, unknown> = {};
+
+    // ── S1 — ConsultarPedCompra vs. o PesquisarPedCompra espelhado ────────────────────────────
+    const s1: Record<string, unknown>[] = [];
+    for (const po of amostra) {
+      const codPed = po.omie_codigo_pedido;
+      const linha: Record<string, unknown> = {
+        numeroPedido: po.numero_pedido,
+        omieCodigoPedido: codPed,
+        t4: po.t4_data_recebimento,
+      };
+      if (codPed == null) {
+        linha.desfecho = "sem_id_nativo_no_espelho";
+        s1.push(linha);
+        continue;
+      }
+      try {
+        const d = await chamarOmie(
+          {
+            endpoint: URL_PED_COMPRA,
+            call: "ConsultarPedCompra",
+            param: { nCodPed: Number(codPed) },
+          },
+          creds,
+          ctx,
+        );
+        Object.assign(linha, resumirDesfecho(d));
+        if (d.tipo === "ok") {
+          const caminhosDetalhe = caminhosDeChave(d.json);
+          const caminhosEspelho = caminhosDeChave(po.raw_data ?? {});
+          const dif = diffCaminhos(caminhosDetalhe, caminhosEspelho);
+          // A resposta da S1 em uma linha: o que o detalhe tem e a listagem não.
+          linha.soNoDetalhe = dif.soEmA;
+          linha.soNoEspelho = dif.soEmB;
+          linha.itens = resumirItens(d.json);
+          linha.itensEspelho = resumirItens(po.raw_data ?? {});
+          if (incluirBruto) guardarBruto(bruto, `s1_${po.numero_pedido}`, d.json);
+        }
+      } catch (err) {
+        // Uma PO que falha no transporte não pode levar S2 e S3 junto — medir 2 de 3 sondas é
+        // muito melhor do que perder a rodada inteira e ter que pedir outro deploy.
+        linha.desfecho = "nao_medido";
+        linha.motivo = redigirSegredos(
+          mensagemDeErro(err) ?? "falha sem mensagem ao consultar o pedido",
+        );
+      }
+      s1.push(linha);
+    }
+
+    // ── S2/S3 — ConsultarRecebimento por nIdReceb ─────────────────────────────────────────────
+    const s2: Record<string, unknown>[] = [];
+    const notasVistas = new Set<number>();
+    for (const po of amostra) {
+      const nid = po.nid_receb;
+      if (nid == null || notasVistas.has(nid)) continue;
+      notasVistas.add(nid);
+      const linha: Record<string, unknown> = {
+        nidReceb: nid,
+        chaveNfe: po.nfe_chave_acesso ? `…${po.nfe_chave_acesso.slice(-8)}` : null,
+        deQualPO: po.numero_pedido,
+      };
+      try {
+        const d = await chamarOmie(
+          {
+            endpoint: URL_RECEB_NFE,
+            call: "ConsultarRecebimento",
+            param: { nIdReceb: nid, cChaveNfe: po.nfe_chave_acesso ?? "" },
+          },
+          creds,
+          ctx,
+        );
+        Object.assign(linha, resumirDesfecho(d));
+        if (d.tipo === "ok") {
+          const caminhos = caminhosDeChave(d.json);
+          // A pergunta da S2: existe campo ligando o recebimento a um pedido de compra?
+          linha.camposQueCitamPedido = caminhos.filter((c) => /ped|compra|order/i.test(c));
+          linha.itens = resumirItens(d.json);
+          if (incluirBruto) guardarBruto(bruto, `s2_${nid}`, d.json);
+        }
+      } catch (err) {
+        linha.desfecho = "nao_medido";
+        linha.motivo = redigirSegredos(
+          mensagemDeErro(err) ?? "falha sem mensagem ao consultar o recebimento",
+        );
+      }
+      s2.push(linha);
+    }
+
+    // ── S3 — descoberta do contrato de MOVIMENTO DE ESTOQUE ───────────────────────────────────
+    const primeiroProduto = (() => {
+      const achado = localizarItens(amostra[0]?.raw_data ?? {});
+      return achado ? normalizarItemPO(achado.itens[0] ?? {}).codProduto : null;
+    })();
+    const candidatos = Array.isArray(corpo.candidatos_movimento)
+      ? (corpo.candidatos_movimento as Chamada[])
+      : candidatosMovimentoPadrao(primeiroProduto);
+
+    const s3: Record<string, unknown>[] = [];
+    for (const cand of candidatos) {
+      const linha: Record<string, unknown> = { endpoint: cand.endpoint, call: cand.call };
+      try {
+        const d = await chamarOmie(cand, creds, ctx);
+        Object.assign(linha, resumirDesfecho(d));
+        if (d.tipo === "ok") {
+          linha.itens = resumirItens(d.json);
+          if (incluirBruto) guardarBruto(bruto, `s3_${cand.call}`, d.json);
+        }
+      } catch (err) {
+        // Candidato bloqueado/estourando teto não pode derrubar a medição dos outros.
+        linha.desfecho = "nao_medido";
+        linha.motivo = mensagemDeErro(err) ?? "falha sem mensagem no candidato";
+      }
+      s3.push(linha);
+    }
+
+    return json({
+      ok: true,
+      empresa,
+      geradoEm: new Date().toISOString(),
+      readOnly: true,
+      chamadasAoOmie: ctx.chamadas,
+      amostra: amostra.map((p) => ({
+        numeroPedido: p.numero_pedido,
+        omieCodigoPedido: p.omie_codigo_pedido,
+        nidReceb: p.nid_receb,
+        t4: p.t4_data_recebimento,
+      })),
+      s1_detalhe_vs_listagem: s1,
+      s2_recebimento_por_item: s2,
+      s3_movimento_estoque: s3,
+      ...(incluirBruto ? { bruto } : {}),
+    });
+  } catch (err) {
+    const msg = mensagemDeErro(err) ?? "falha sem mensagem na sonda";
+    console.error(`[sonda] falhou: ${msg}`);
+    return json({ ok: false, erro: redigirSegredos(msg), chamadasAoOmie: ctx.chamadas }, 500);
+  }
+});

--- a/supabase/functions/omie-sonda-recebimento/index.ts
+++ b/supabase/functions/omie-sonda-recebimento/index.ts
@@ -188,11 +188,33 @@ async function chamarOmie(
   throw ultimoErro ?? new Error(`falha desconhecida em ${call}`);
 }
 
+/**
+ * Indicadores de paginação, quando o método os declarar.
+ *
+ * Existe para impedir uma leitura errada do relatório: "página 1 vazia" NÃO é "não há dado" — pode
+ * ser filtro, período ou local padrão. Com o total declarado à vista, quem lê sabe se o vazio é
+ * fim de lista ou só o começo dela.
+ */
+function paginacaoDeclarada(json: Record<string, unknown>): Record<string, unknown> | null {
+  const campos = {
+    totalPaginas: buscarValorProfundo(json, ["nTotPaginas", "total_de_paginas", "nTotalPaginas"]),
+    totalRegistros: buscarValorProfundo(json, ["nTotRegistros", "total_de_registros"]),
+    registrosNaPagina: buscarValorProfundo(json, ["nRegistros", "registros"]),
+    pagina: buscarValorProfundo(json, ["nPagina", "pagina"]),
+  };
+  const presentes = Object.entries(campos).filter(([, v]) => v !== undefined);
+  return presentes.length > 0 ? Object.fromEntries(presentes) : null;
+}
+
 /** Resumo uniforme de um desfecho — o que entra no relatório de todas as sondas. */
 function resumirDesfecho(d: Desfecho): Record<string, unknown> {
   switch (d.tipo) {
     case "ok":
-      return { desfecho: "ok", caminhos: caminhosDeChave(d.json) };
+      return {
+        desfecho: "ok",
+        caminhos: caminhosDeChave(d.json),
+        paginacao: paginacaoDeclarada(d.json),
+      };
     case "fault":
       return { desfecho: "fault", faultcode: d.faultcode, faultstring: d.faultstring };
     case "http_erro":
@@ -354,6 +376,10 @@ function candidatosMovimentoPadrao(
   ];
 
   // ── camada B: params reais ──
+  // `lista_local_estoque: "TODOS"` é deliberado: sem ele alguns métodos do Omie respondem só pelo
+  // local PADRÃO, e movimento em quarentena ou armazém de terceiro sumiria — o relatório diria
+  // "sem movimento" onde há movimento em outro local. Se o método não conhecer o param, o fault
+  // aparece no relatório e a camada A (sem params) serve de contraprova.
   lista.push({
     servico: "estoque_consulta",
     call: "ListarMovimentoEstoque",
@@ -362,9 +388,10 @@ function candidatosMovimentoPadrao(
       nRegPorPagina: 20,
       dDtInicial: de,
       dDtFinal: ate,
+      lista_local_estoque: "TODOS",
       ...(codProduto ? { nIdProduto: Number(codProduto) } : {}),
     },
-    nota: "camada B — período em torno do t4 da PO alvo",
+    nota: "camada B — período em torno do t4 da PO alvo, todos os locais",
   });
   if (codProduto) {
     lista.push({

--- a/supabase/functions/omie-sonda-recebimento/index.ts
+++ b/supabase/functions/omie-sonda-recebimento/index.ts
@@ -36,6 +36,7 @@ import {
   type Desfecho,
   diffCaminhos,
   ehMetodoDeLeitura,
+  etapaDaPO,
   localizarItens,
   normalizarItemPO,
   redigirSegredos,
@@ -206,26 +207,60 @@ interface LinhaPO {
   raw_data: Record<string, unknown> | null;
 }
 
+const COLUNAS_PO =
+  "omie_codigo_pedido, numero_pedido, nid_receb, nfe_chave_acesso, t4_data_recebimento, raw_data";
+const ETAPA_ALVO = "15";
+/** 360 POs OBEN têm `t4` hoje (244 delas em etapa 15) — folga sobre isso, longe da capa de 1.000. */
+const TETO_FALLBACK = 500;
+
+/**
+ * Carrega a amostra de POs etapa-15 já recebidas.
+ *
+ * O filtro por caminho jsonb aninhado (`raw_data->cabecalho_consulta->>cEtapa`) tem precedente no
+ * repo só com UM nível (`metadata->>segmento`, rag-search). Se essa forma não for aceita, o risco
+ * não é erro visível — é a query voltar VAZIA e a sonda concluir "não há PO alvo", trocando
+ * "não consegui filtrar" por "não existe". Então: tenta o filtro no banco e, se ele falhar OU vier
+ * vazio, refaz sem o filtro e resolve a etapa em memória — sempre reportando qual caminho valeu.
+ */
 async function carregarAmostra(
   supabase: SupabaseClient,
   empresa: string,
   limite: number,
   pedidos: string[] | null,
-): Promise<LinhaPO[]> {
+): Promise<{ linhas: LinhaPO[]; via: "filtro_jsonb" | "fallback_memoria" }> {
   let q = supabase
     .from("purchase_orders_tracking")
-    .select(
-      "omie_codigo_pedido, numero_pedido, nid_receb, nfe_chave_acesso, t4_data_recebimento, raw_data",
-    )
+    .select(COLUNAS_PO)
     .eq("empresa", empresa)
     .not("t4_data_recebimento", "is", null)
-    .eq("raw_data->cabecalho_consulta->>cEtapa", "15");
+    .eq(`raw_data->cabecalho_consulta->>cEtapa`, ETAPA_ALVO);
   if (pedidos && pedidos.length > 0) q = q.in("numero_pedido", pedidos);
   const { data, error } = await q
     .order("t4_data_recebimento", { ascending: false })
     .limit(limite);
-  if (error) throw new Error(`leitura da amostra: ${error.message}`);
-  return (data ?? []) as LinhaPO[];
+
+  if (!error && (data?.length ?? 0) > 0) {
+    return { linhas: data as LinhaPO[], via: "filtro_jsonb" };
+  }
+  if (error) {
+    console.warn(`[sonda] filtro jsonb recusado (${error.message}) — caindo no fallback`);
+  }
+
+  let q2 = supabase
+    .from("purchase_orders_tracking")
+    .select(COLUNAS_PO)
+    .eq("empresa", empresa)
+    .not("t4_data_recebimento", "is", null);
+  if (pedidos && pedidos.length > 0) q2 = q2.in("numero_pedido", pedidos);
+  const { data: todas, error: erro2 } = await q2
+    .order("t4_data_recebimento", { ascending: false })
+    .limit(TETO_FALLBACK);
+  if (erro2) throw new Error(`leitura da amostra: ${erro2.message}`);
+
+  const linhas = ((todas ?? []) as LinhaPO[])
+    .filter((l) => etapaDaPO(l.raw_data) === ETAPA_ALVO)
+    .slice(0, limite);
+  return { linhas, via: "fallback_memoria" };
 }
 
 function ddmmyyyy(d: Date): string {
@@ -319,7 +354,12 @@ Deno.serve(async (req: Request): Promise<Response> => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
     );
 
-    const amostra = await carregarAmostra(supabase, empresa, limite, pedidos);
+    const { linhas: amostra, via: viaAmostra } = await carregarAmostra(
+      supabase,
+      empresa,
+      limite,
+      pedidos,
+    );
     if (amostra.length === 0) {
       return json({ ok: false, erro: "nenhuma PO etapa-15 com t4 encontrada para a amostra" }, 404);
     }
@@ -444,6 +484,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       empresa,
       geradoEm: new Date().toISOString(),
       readOnly: true,
+      viaAmostra,
       chamadasAoOmie: ctx.chamadas,
       amostra: amostra.map((p) => ({
         numeroPedido: p.numero_pedido,

--- a/supabase/functions/omie-sonda-recebimento/index.ts
+++ b/supabase/functions/omie-sonda-recebimento/index.ts
@@ -1,28 +1,36 @@
 // Edge function: omie-sonda-recebimento
 //
 // SONDA DE DIAGNÓSTICO — READ-ONLY ao Omie e ao banco. Não grava nada, não toca o motor de
-// reposição, não altera `sku_estoque_atual`. Existe para responder UMA pergunta que trava o
-// desenho do receipt-first ledger (spec docs/superpowers/specs/2026-08-13-reposicao-onorder-
-// po-recebida-medicao.md, §6):
+// reposição, não altera `sku_estoque_atual`. Existe para responder a pergunta que trava o desenho
+// do receipt-first ledger (spec docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-
+// medicao.md, §6):
 //
 //   244 POs já recebidas seguem em etapa 15. No fluxo NATIVO do Omie, associar itens da NF-e à
 //   PO move o pedido para "Recebido Parcialmente"/"Recebido". Então OU etapa-15 é um workflow
-//   paralelo ao estado nativo de recebimento, OU a associação item-a-item nunca é feita neste
-//   tenant. Até isso ser resolvido, `t4` não pode ser tratado como recebimento.
+//   paralelo ao estado nativo, OU a associação item-a-item nunca é feita neste tenant.
 //
-// As 4 sondas, todas sobre as MESMAS POs:
-//   S1  ConsultarPedCompra (id nativo) vs. o PesquisarPedCompra já espelhado — o detalhe expõe
+// Há uma TERCEIRA hipótese, levantada pelo Codex e sustentada pelo próprio código do espelho:
+// `omie-sync-nfes-recebidas` monta o vínculo PO↔NF-e a partir de `itensInfoAdic.nNumPedCompra`
+// — uma referência TEXTUAL escrita pelo fornecedor no XML — e não dos ids nativos
+// `nIdPedido`/`nIdItPedido`. Se for esse o caso dominante, o `t4` do espelho é INFERÊNCIA NOSSA,
+// não recebimento do Omie, e a etapa-15 deixa de ser contradição. Por isso a S2 classifica CADA
+// item numa taxonomia de vínculo, em vez de só perguntar "o campo existe?".
+//
+// As sondas, todas sobre as MESMAS POs:
+//   S1  ConsultarPedCompra (id nativo) × PesquisarPedCompra espelhado — o detalhe expõe
 //       recebimento por item que a listagem esconde?
-//   S2  ConsultarRecebimento (nIdReceb) — a associação item-a-item existe neste tenant?
-//   S3  movimento de estoque ligado à NF-e — O SINAL QUE O LEDGER VAI USAR: existe, é
-//       consultável, tem produto + local + quantidade?
-//   S4  granularidade do saldo pendente + unidade/local do detalhe.
+//   S2  ConsultarRecebimento (nIdReceb) — taxonomia de vínculo por item + estado CORRENTE do
+//       recebimento (cRecebido/cCancelada/cEtapa) contra o `t4` local, que é histórico e nunca
+//       é limpo em reversão.
+//   S3  movimento de estoque — O SINAL QUE O LEDGER VAI USAR. Métodos descobertos em duas
+//       camadas: `{}` para a taxonomia do fault, e params reais (produto, período, local) para
+//       a forma do dado.
+//   S4  unidade, local e granularidade do saldo pendente.
 //
-// Por que os métodos da S3 são DESCOBERTOS e não assumidos: "nome de endpoint não é contrato"
-// (Codex). A edge tenta candidatos e reporta o desfecho de cada um — um método inexistente é
-// RESULTADO da medição, não erro da execução. Os candidatos podem vir no corpo
-// (`candidatos_movimento`) para iterar a descoberta SEM um novo deploy a cada tentativa; a trava
-// `ehMetodoDeLeitura` garante que nada além de consulta chegue ao ERP de produção.
+// SEGURANÇA: o destino é um ENUM fechado (`urlDoServico`), nunca dado de entrada — a edge envia
+// app_key/app_secret no corpo, então URL vinda da invocação seria exfiltração de credencial.
+// A allowlist de método (`ehMetodoDeLeitura`) é a segunda camada: no MESMO serviço de recebimento
+// moram AlterarRecebimento e ConcluirRecebimento.
 //
 // Invocação: POST { empresa?, limite?, pedidos?, incluir_bruto?, candidatos_movimento? }
 // Gate: authorizeCronOrStaff.
@@ -31,30 +39,34 @@ import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff, corsHeaders as sharedCors } from "../_shared/auth.ts";
 import { mensagemDeErro } from "../_shared/erro-mensagem.ts";
 import {
+  buscarValorProfundo,
   caminhosDeChave,
+  type ClasseAssociacao,
+  classificarAssociacao,
   classificarResposta,
   type Desfecho,
   diffCaminhos,
   ehMetodoDeLeitura,
+  escolherPorNotaDiversa,
   etapaDaPO,
+  idNativo,
   localizarItens,
   normalizarItemPO,
+  normalizarItemRecebimento,
   redigirSegredos,
+  servicosConhecidos,
+  urlDoServico,
 } from "./sondas.ts";
 
 const corsHeaders = { ...sharedCors, "Access-Control-Allow-Methods": "POST, OPTIONS" };
 
-const URL_PED_COMPRA = "https://app.omie.com.br/api/v1/produtos/pedidocompra/";
-const URL_RECEB_NFE = "https://app.omie.com.br/api/v1/produtos/recebimentonfe/";
-const URL_ESTOQUE = "https://app.omie.com.br/api/v1/estoque/consulta/";
-const URL_MOV_ESTOQUE = "https://app.omie.com.br/api/v1/estoque/movestoque/";
-const URL_AJUSTE_ESTOQUE = "https://app.omie.com.br/api/v1/estoque/ajuste/";
-
 const MAX_TENTATIVAS = 3;
 /** Teto duro de chamadas por execução — a sonda é barata por desenho; estourar isso é bug. */
-const MAX_CHAMADAS = 60;
+const MAX_CHAMADAS = 80;
 const LIMITE_PADRAO = 3;
-const BRUTO_MAX_CHARS = 20_000;
+const BRUTO_MAX_CHARS = 40_000;
+/** Itens normalizados no relatório. Alto de propósito: uma associação no item 26 não pode sumir. */
+const ITENS_NO_RELATORIO = 200;
 
 interface Credenciais {
   appKey: string;
@@ -81,10 +93,25 @@ function json(body: Record<string, unknown>, status = 200): Response {
   });
 }
 
+function ddmmyyyy(d: Date): string {
+  const dd = String(d.getDate()).padStart(2, "0");
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}
+
+function somarDias(d: Date, dias: number): Date {
+  const x = new Date(d.getTime());
+  x.setDate(x.getDate() + dias);
+  return x;
+}
+
+/** Chamada ao Omie. `servico` é chave do enum — NUNCA uma URL. */
 interface Chamada {
-  endpoint: string;
+  servico: string;
   call: string;
   param: Record<string, unknown>;
+  /** Rótulo para o relatório quando o mesmo método é tentado com params diferentes. */
+  nota?: string;
 }
 
 /**
@@ -98,17 +125,23 @@ interface Ctx {
 
 /**
  * Chama o Omie e devolve o DESFECHO classificado. Fault NÃO lança: para uma sonda, "este método
- * não existe" é o dado que se quer. Lança apenas o que impede medir (credencial, teto, transporte
- * após retries) — e nunca deixa credencial vazar para mensagem de erro.
+ * não existe" é o dado que se quer. Lança apenas o que impede medir (destino inválido, método de
+ * escrita, credencial, teto, transporte após retries).
  */
 async function chamarOmie(
-  { endpoint, call, param }: Chamada,
+  { servico, call, param }: Chamada,
   creds: Credenciais,
   ctx: Ctx,
 ): Promise<Desfecho> {
+  const endpoint = urlDoServico(servico);
+  if (endpoint === null) {
+    throw new Error(
+      `BLOQUEADO: serviço "${servico}" não está no enum — conhecidos: ${
+        servicosConhecidos().join(", ")
+      }`,
+    );
+  }
   if (!ehMetodoDeLeitura(call)) {
-    // Defesa em profundidade: no MESMO endpoint de recebimento moram AlterarRecebimento e
-    // ConcluirRecebimento. A sonda nunca pode escrever no ERP, nem por candidato vindo do corpo.
     throw new Error(`BLOQUEADO: "${call}" não é método de leitura — a sonda é read-only`);
   }
   if (ctx.chamadas >= MAX_CHAMADAS) {
@@ -146,7 +179,7 @@ async function chamarOmie(
     } catch (err) {
       ultimoErro = err;
       const msg = mensagemDeErro(err) ?? `falha sem mensagem em ${call}`;
-      if (msg.startsWith("AUTH_ERRO")) throw err;
+      if (msg.startsWith("AUTH_ERRO") || msg.startsWith("BLOQUEADO")) throw err;
       const espera = 1000 * Math.pow(2, tentativa - 1);
       console.warn(`[sonda] ${call} tentativa ${tentativa}/${MAX_TENTATIVAS}: ${msg}`);
       await new Promise((r) => setTimeout(r, espera));
@@ -170,30 +203,30 @@ function resumirDesfecho(d: Desfecho): Record<string, unknown> {
 }
 
 /**
- * Guarda o payload bruto redigido. Corta por TAMANHO sem reparsear: `JSON.parse` de uma string
- * truncada lança, e uma sonda não pode morrer por causa do próprio anexo de diagnóstico.
+ * Guarda o payload bruto redigido. Corta por TAMANHO sem reparsear o texto cortado: `JSON.parse`
+ * de string truncada lança, e a sonda não pode morrer por causa do próprio anexo de diagnóstico.
  */
 function guardarBruto(
   destino: Record<string, unknown>,
   chave: string,
-  json: Record<string, unknown>,
+  payload: Record<string, unknown>,
 ): void {
-  const texto = redigirSegredos(JSON.stringify(json));
-  // Reparsear o texto REDIGIDO (não devolver `json`): o objeto original não passou pela redação.
+  const texto = redigirSegredos(JSON.stringify(payload));
+  // Reparsear o texto REDIGIDO (não devolver o objeto): o original não passou pela redação.
   destino[chave] = texto.length <= BRUTO_MAX_CHARS
     ? JSON.parse(texto)
     : { truncado: true, chars: texto.length, inicio: texto.slice(0, BRUTO_MAX_CHARS) };
 }
 
-/** Itens normalizados de um payload, com o CAMINHO onde foram encontrados (contrato medido). */
-function resumirItens(payload: unknown): Record<string, unknown> {
+/** Itens de PO normalizados, com o CAMINHO onde foram encontrados (contrato medido). */
+function resumirItensPO(payload: unknown): Record<string, unknown> {
   const achado = localizarItens(payload);
   if (!achado) return { encontrados: false };
   return {
     encontrados: true,
     caminho: achado.caminho,
     n: achado.itens.length,
-    itens: achado.itens.slice(0, 12).map(normalizarItemPO),
+    itens: achado.itens.slice(0, ITENS_NO_RELATORIO).map(normalizarItemPO),
     chavesDoItem: caminhosDeChave(achado.itens[0] ?? {}),
   };
 }
@@ -210,124 +243,149 @@ interface LinhaPO {
 const COLUNAS_PO =
   "omie_codigo_pedido, numero_pedido, nid_receb, nfe_chave_acesso, t4_data_recebimento, raw_data";
 const ETAPA_ALVO = "15";
-/** 360 POs OBEN têm `t4` hoje (244 delas em etapa 15) — folga sobre isso, longe da capa de 1.000. */
-const TETO_FALLBACK = 500;
+/** 360 POs OBEN têm `t4` hoje (244 em etapa 15) — folga sobre isso, longe da capa de 1.000. */
+const TETO_LEITURA = 500;
 
 /**
- * Carrega a amostra de POs etapa-15 já recebidas.
+ * Carrega POs etapa-15 já recebidas, de NOTAS DISTINTAS.
  *
- * O filtro por caminho jsonb aninhado (`raw_data->cabecalho_consulta->>cEtapa`) tem precedente no
- * repo só com UM nível (`metadata->>segmento`, rag-search). Se essa forma não for aceita, o risco
- * não é erro visível — é a query voltar VAZIA e a sonda concluir "não há PO alvo", trocando
- * "não consegui filtrar" por "não existe". Então: tenta o filtro no banco e, se ele falhar OU vier
- * vazio, refaz sem o filtro e resolve a etapa em memória — sempre reportando qual caminho valeu.
+ * Duas armadilhas evitadas aqui:
+ *
+ * 1. O filtro por caminho jsonb aninhado tem precedente no repo só com UM nível
+ *    (`metadata->>segmento`, rag-search). Se a forma não for aceita, o risco não é erro visível —
+ *    é a query voltar VAZIA e a sonda concluir "não há PO alvo", trocando "não consegui filtrar"
+ *    por "não existe". Por isso há fallback em memória, e o caminho usado vai no relatório.
+ * 2. "As N POs mais recentes" tende a pegar N POs da MESMA nota: 94% das POs alvo dividem nota.
+ *    A S2 rodaria uma vez só. `escolherPorNotaDiversa` garante notas distintas e cobre os dois
+ *    extremos da consolidação.
  */
 async function carregarAmostra(
   supabase: SupabaseClient,
   empresa: string,
   limite: number,
   pedidos: string[] | null,
-): Promise<{ linhas: LinhaPO[]; via: "filtro_jsonb" | "fallback_memoria" }> {
-  let q = supabase
-    .from("purchase_orders_tracking")
-    .select(COLUNAS_PO)
-    .eq("empresa", empresa)
-    .not("t4_data_recebimento", "is", null)
-    .eq(`raw_data->cabecalho_consulta->>cEtapa`, ETAPA_ALVO);
-  if (pedidos && pedidos.length > 0) q = q.in("numero_pedido", pedidos);
-  const { data, error } = await q
-    .order("t4_data_recebimento", { ascending: false })
-    .limit(limite);
+): Promise<{ linhas: LinhaPO[]; via: string; candidatasLidas: number }> {
+  const base = () => {
+    let q = supabase
+      .from("purchase_orders_tracking")
+      .select(COLUNAS_PO)
+      .eq("empresa", empresa)
+      .not("t4_data_recebimento", "is", null);
+    if (pedidos && pedidos.length > 0) q = q.in("numero_pedido", pedidos);
+    return q;
+  };
 
+  const { data, error } = await base()
+    .eq(`raw_data->cabecalho_consulta->>cEtapa`, ETAPA_ALVO)
+    .order("t4_data_recebimento", { ascending: false })
+    .limit(TETO_LEITURA);
+
+  let candidatas: LinhaPO[];
+  let via: string;
   if (!error && (data?.length ?? 0) > 0) {
-    return { linhas: data as LinhaPO[], via: "filtro_jsonb" };
+    candidatas = data as LinhaPO[];
+    via = "filtro_jsonb";
+  } else {
+    if (error) {
+      console.warn(`[sonda] filtro jsonb recusado (${error.message}) — caindo no fallback`);
+    }
+    const { data: todas, error: erro2 } = await base()
+      .order("t4_data_recebimento", { ascending: false })
+      .limit(TETO_LEITURA);
+    if (erro2) throw new Error(`leitura da amostra: ${erro2.message}`);
+    candidatas = ((todas ?? []) as LinhaPO[]).filter((l) => etapaDaPO(l.raw_data) === ETAPA_ALVO);
+    via = "fallback_memoria";
   }
-  if (error) {
-    console.warn(`[sonda] filtro jsonb recusado (${error.message}) — caindo no fallback`);
-  }
 
-  let q2 = supabase
-    .from("purchase_orders_tracking")
-    .select(COLUNAS_PO)
-    .eq("empresa", empresa)
-    .not("t4_data_recebimento", "is", null);
-  if (pedidos && pedidos.length > 0) q2 = q2.in("numero_pedido", pedidos);
-  const { data: todas, error: erro2 } = await q2
-    .order("t4_data_recebimento", { ascending: false })
-    .limit(TETO_FALLBACK);
-  if (erro2) throw new Error(`leitura da amostra: ${erro2.message}`);
-
-  const linhas = ((todas ?? []) as LinhaPO[])
-    .filter((l) => etapaDaPO(l.raw_data) === ETAPA_ALVO)
-    .slice(0, limite);
-  return { linhas, via: "fallback_memoria" };
-}
-
-function ddmmyyyy(d: Date): string {
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  return `${dd}/${mm}/${d.getFullYear()}`;
+  // Quando o chamador pediu POs específicas, respeitar a escolha dele — não diversificar.
+  const linhas = pedidos && pedidos.length > 0
+    ? candidatas.slice(0, limite)
+    : escolherPorNotaDiversa(candidatas, limite);
+  return { linhas, via, candidatasLidas: candidatas.length };
 }
 
 /**
- * Candidatos da S3 — a descoberta do contrato de MOVIMENTO DE ESTOQUE.
+ * Candidatos da S3 — descoberta do contrato de MOVIMENTO DE ESTOQUE, em duas camadas.
  *
- * Duas decisões que definem o poder de discriminação da sonda:
+ * Camada A (`param: {}`): serve para a TAXONOMIA DO FAULT. "falta o parâmetro obrigatório X" é
+ * evidência forte de que o método EXISTE e ainda nomeia o que ele quer; "método não encontrado"
+ * rejeita aquele nome naquele serviço. O que `{}` NÃO faz é medir dado — por isso não é a única
+ * camada, correção que veio do Codex.
  *
- * 1. CONTROLE POSITIVO. `ListarPosEstoque` e `ListarSaldoPendente` já rodam em produção
- *    (omie-sync-estoque) e entram com os params EXATOS de lá. Se até eles falharem, o problema é
- *    transporte/credencial — sem esse controle, um fault genérico seria lido como "o Omie não
- *    expõe movimento de estoque", que é justamente a conclusão errada a evitar. Note que os dois
- *    provam, sozinhos, que no MESMO endpoint convivem convenções diferentes de parâmetro
- *    (`nPagina`/`nRegPorPagina` húngaro vs. `pagina`/`registros_por_pagina` snake_case PT) — mais
- *    uma razão para não inferir o param de um método a partir do vizinho.
+ * Camada B (params reais): produto, período e local de verdade, para ver a FORMA do movimento —
+ * é isso que decide se o `stock_posting` do ledger é alimentável.
  *
- * 2. CANDIDATO DESCONHECIDO VAI COM `param: {}`. Parece preguiça, é o contrário: mandar param
- *    chutado colapsa dois desfechos MUITO diferentes num fault só. Com param vazio, "método não
- *    existe" e "falta o parâmetro obrigatório X" chegam como faultstrings distintas — e a segunda
- *    PROVA que o método existe, além de nomear o parâmetro que ele quer. O fault vira contrato.
+ * Os controles positivos (`ListarPosEstoque`, `ListarSaldoPendente`) usam os params verbatim de
+ * `omie-sync-estoque`. Sem eles, um fault genérico seria lido como "o Omie não expõe movimento de
+ * estoque" — a conclusão errada que a sonda existe para evitar. Eles também provam que no MESMO
+ * serviço convivem convenções diferentes de parâmetro (`nPagina`/`nRegPorPagina` húngaro ×
+ * `pagina`/`registros_por_pagina` snake_case PT), então nome de param não se infere do vizinho.
  */
-function candidatosMovimentoPadrao(codProduto: string | null): Chamada[] {
+function candidatosMovimentoPadrao(
+  codProduto: string | null,
+  t4: string | null,
+): Chamada[] {
+  const hoje = new Date();
+  const ref = t4 ? new Date(t4) : hoje;
+  const de = ddmmyyyy(somarDias(ref, -7));
+  const ate = ddmmyyyy(somarDias(ref, 7));
+
   const lista: Chamada[] = [
-    // ── controles positivos (params verbatim de omie-sync-estoque) ──
+    // ── controles positivos ──
     {
-      endpoint: URL_ESTOQUE,
+      servico: "estoque_consulta",
       call: "ListarPosEstoque",
-      param: {
-        nPagina: 1,
-        nRegPorPagina: 5,
-        dDataPosicao: ddmmyyyy(new Date()),
-        cExibeTodos: "S",
-      },
+      param: { nPagina: 1, nRegPorPagina: 5, dDataPosicao: ddmmyyyy(hoje), cExibeTodos: "S" },
+      nota: "controle positivo (params verbatim de omie-sync-estoque)",
     },
     {
-      endpoint: URL_ESTOQUE,
+      servico: "estoque_consulta",
       call: "ListarSaldoPendente",
       param: { pagina: 1, registros_por_pagina: 5, tipo: "ENTRADA" },
+      nota: "controle positivo + S4 (granularidade do saldo pendente)",
     },
-    // ── candidatos: param vazio de propósito (ver nota 2) ──
-    { endpoint: URL_ESTOQUE, call: "ListarMovimentos", param: {} },
-    { endpoint: URL_ESTOQUE, call: "ListarMovimentoEstoque", param: {} },
-    { endpoint: URL_ESTOQUE, call: "ConsultarMovimentoEstoque", param: {} },
-    { endpoint: URL_MOV_ESTOQUE, call: "ListarMovimentos", param: {} },
-    { endpoint: URL_MOV_ESTOQUE, call: "ListarMovimentoEstoque", param: {} },
-    { endpoint: URL_AJUSTE_ESTOQUE, call: "ListarAjustes", param: {} },
-    { endpoint: URL_RECEB_NFE, call: "ListarRecebimentos", param: {} },
+    // ── camada A: taxonomia do fault ──
+    { servico: "estoque_consulta", call: "ListarMovimentoEstoque", param: {}, nota: "camada A" },
+    { servico: "estoque_consulta", call: "MovimentoEstoque", param: {}, nota: "camada A" },
+    { servico: "estoque_resumo", call: "ObterEstoqueProduto", param: {}, nota: "camada A" },
+    { servico: "estoque_movestoque", call: "ListarMovimentos", param: {}, nota: "camada A" },
+    { servico: "estoque_ajuste", call: "ListarAjusteEstoque", param: {}, nota: "camada A" },
+    { servico: "estoque_local", call: "ListarLocaisEstoque", param: {}, nota: "camada A" },
   ];
+
+  // ── camada B: params reais ──
+  lista.push({
+    servico: "estoque_consulta",
+    call: "ListarMovimentoEstoque",
+    param: {
+      nPagina: 1,
+      nRegPorPagina: 20,
+      dDtInicial: de,
+      dDtFinal: ate,
+      ...(codProduto ? { nIdProduto: Number(codProduto) } : {}),
+    },
+    nota: "camada B — período em torno do t4 da PO alvo",
+  });
   if (codProduto) {
-    // Com produto real: se o método existir, a resposta já mostra a FORMA do movimento
-    // (produto, local, quantidade, data) — que é o que o ledger precisa da S3.
     lista.push({
-      endpoint: URL_ESTOQUE,
+      servico: "estoque_resumo",
       call: "ObterEstoqueProduto",
-      param: { nIdProduto: Number(codProduto), dDia: ddmmyyyy(new Date()) },
+      param: { nIdProduto: Number(codProduto), dDia: ddmmyyyy(hoje) },
+      nota: "camada B — produto real da PO alvo",
     });
     lista.push({
-      endpoint: URL_ESTOQUE,
-      call: "ListarMovimentoProduto",
-      param: { nIdProduto: Number(codProduto) },
+      servico: "estoque_consulta",
+      call: "MovimentoEstoque",
+      param: { nIdProduto: Number(codProduto), dDtInicial: de, dDtFinal: ate },
+      nota: "camada B — produto real + período",
     });
   }
+  lista.push({
+    servico: "estoque_movestoque",
+    call: "ListarMovimentos",
+    param: { nPagina: 1, nRegPorPagina: 20, dDtInicial: de, dDtFinal: ate },
+    nota: "camada B — controle: agregado diário, não rastreia recebimento",
+  });
   return lista;
 }
 
@@ -354,26 +412,32 @@ Deno.serve(async (req: Request): Promise<Response> => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
     );
 
-    const { linhas: amostra, via: viaAmostra } = await carregarAmostra(
+    const { linhas: amostra, via: viaAmostra, candidatasLidas } = await carregarAmostra(
       supabase,
       empresa,
       limite,
       pedidos,
     );
     if (amostra.length === 0) {
-      return json({ ok: false, erro: "nenhuma PO etapa-15 com t4 encontrada para a amostra" }, 404);
+      return json({
+        ok: false,
+        erro: "nenhuma PO etapa-15 com t4 encontrada para a amostra",
+        viaAmostra,
+        candidatasLidas,
+      }, 404);
     }
 
     const bruto: Record<string, unknown> = {};
 
-    // ── S1 — ConsultarPedCompra vs. o PesquisarPedCompra espelhado ────────────────────────────
+    // ── S1 — ConsultarPedCompra × PesquisarPedCompra espelhado ────────────────────────────────
     const s1: Record<string, unknown>[] = [];
     for (const po of amostra) {
       const codPed = po.omie_codigo_pedido;
       const linha: Record<string, unknown> = {
         numeroPedido: po.numero_pedido,
         omieCodigoPedido: codPed,
-        t4: po.t4_data_recebimento,
+        t4Local: po.t4_data_recebimento,
+        etapaNoEspelho: etapaDaPO(po.raw_data),
       };
       if (codPed == null) {
         linha.desfecho = "sem_id_nativo_no_espelho";
@@ -383,7 +447,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       try {
         const d = await chamarOmie(
           {
-            endpoint: URL_PED_COMPRA,
+            servico: "pedido_compra",
             call: "ConsultarPedCompra",
             param: { nCodPed: Number(codPed) },
           },
@@ -392,19 +456,19 @@ Deno.serve(async (req: Request): Promise<Response> => {
         );
         Object.assign(linha, resumirDesfecho(d));
         if (d.tipo === "ok") {
-          const caminhosDetalhe = caminhosDeChave(d.json);
-          const caminhosEspelho = caminhosDeChave(po.raw_data ?? {});
-          const dif = diffCaminhos(caminhosDetalhe, caminhosEspelho);
-          // A resposta da S1 em uma linha: o que o detalhe tem e a listagem não.
+          const dif = diffCaminhos(caminhosDeChave(d.json), caminhosDeChave(po.raw_data ?? {}));
+          // A resposta da S1 em duas listas: o que o detalhe tem e a listagem não, e vice-versa.
           linha.soNoDetalhe = dif.soEmA;
           linha.soNoEspelho = dif.soEmB;
-          linha.itens = resumirItens(d.json);
-          linha.itensEspelho = resumirItens(po.raw_data ?? {});
+          // Estado CORRENTE no Omie contra o `t4` local, que é histórico e nunca é limpo.
+          linha.etapaAgoraNoOmie = idNativo(buscarValorProfundo(d.json, ["cEtapa"]));
+          linha.itens = resumirItensPO(d.json);
+          linha.itensEspelho = resumirItensPO(po.raw_data ?? {});
           if (incluirBruto) guardarBruto(bruto, `s1_${po.numero_pedido}`, d.json);
         }
       } catch (err) {
         // Uma PO que falha no transporte não pode levar S2 e S3 junto — medir 2 de 3 sondas é
-        // muito melhor do que perder a rodada inteira e ter que pedir outro deploy.
+        // muito melhor do que perder a rodada e ter que pedir outro deploy.
         linha.desfecho = "nao_medido";
         linha.motivo = redigirSegredos(
           mensagemDeErro(err) ?? "falha sem mensagem ao consultar o pedido",
@@ -413,34 +477,58 @@ Deno.serve(async (req: Request): Promise<Response> => {
       s1.push(linha);
     }
 
-    // ── S2/S3 — ConsultarRecebimento por nIdReceb ─────────────────────────────────────────────
+    // ── S2 — ConsultarRecebimento: taxonomia de vínculo por item ──────────────────────────────
     const s2: Record<string, unknown>[] = [];
-    const notasVistas = new Set<number>();
     for (const po of amostra) {
       const nid = po.nid_receb;
-      if (nid == null || notasVistas.has(nid)) continue;
-      notasVistas.add(nid);
+      if (nid == null) continue;
+      const alvo = {
+        idPedido: idNativo(po.omie_codigo_pedido),
+        numeroPedido: idNativo(po.numero_pedido),
+      };
       const linha: Record<string, unknown> = {
         nidReceb: nid,
-        chaveNfe: po.nfe_chave_acesso ? `…${po.nfe_chave_acesso.slice(-8)}` : null,
-        deQualPO: po.numero_pedido,
+        poAlvo: po.numero_pedido,
+        idPedidoAlvo: alvo.idPedido,
+        chaveNfeFinal: po.nfe_chave_acesso ? `…${po.nfe_chave_acesso.slice(-8)}` : null,
       };
       try {
+        // Só `nIdReceb`: mandar `cChaveNfe` junto (ou vazio) pode fazer o backend combinar
+        // filtros e falhar apesar do id correto — falso negativo caro.
         const d = await chamarOmie(
-          {
-            endpoint: URL_RECEB_NFE,
-            call: "ConsultarRecebimento",
-            param: { nIdReceb: nid, cChaveNfe: po.nfe_chave_acesso ?? "" },
-          },
+          { servico: "recebimento_nfe", call: "ConsultarRecebimento", param: { nIdReceb: nid } },
           creds,
           ctx,
         );
         Object.assign(linha, resumirDesfecho(d));
         if (d.tipo === "ok") {
-          const caminhos = caminhosDeChave(d.json);
-          // A pergunta da S2: existe campo ligando o recebimento a um pedido de compra?
-          linha.camposQueCitamPedido = caminhos.filter((c) => /ped|compra|order/i.test(c));
-          linha.itens = resumirItens(d.json);
+          // Estado CORRENTE do recebimento — o `t4` local não é limpo se houve reversão.
+          linha.estadoCorrente = {
+            cRecebido: buscarValorProfundo(d.json, ["cRecebido"]) ?? null,
+            cCancelada: buscarValorProfundo(d.json, ["cCancelada"]) ?? null,
+            cDevolvido: buscarValorProfundo(d.json, ["cDevolvido"]) ?? null,
+            cEtapa: buscarValorProfundo(d.json, ["cEtapa"]) ?? null,
+            dRegistro: buscarValorProfundo(d.json, ["dRegistro", "dDtRegistro"]) ?? null,
+          };
+          const achado = localizarItens(d.json);
+          const itens = (achado?.itens ?? []).slice(0, ITENS_NO_RELATORIO)
+            .map(normalizarItemRecebimento);
+          const classes = itens.map((i) => classificarAssociacao(i, alvo));
+          const contagem: Partial<Record<ClasseAssociacao, number>> = {};
+          for (const c of classes) contagem[c] = (contagem[c] ?? 0) + 1;
+
+          linha.itens = {
+            caminho: achado?.caminho ?? null,
+            n: achado?.itens.length ?? 0,
+            chavesDoItem: caminhosDeChave(achado?.itens[0] ?? {}),
+            detalhe: itens.map((i, k) => ({ ...i, classe: classes[k] })),
+          };
+          // A resposta da S2 em uma linha: como os itens desta nota se ligam à PO alvo.
+          linha.classesDeAssociacao = contagem;
+          linha.temVinculoNativoPorItem = classes.some((c) => c === "native_exact");
+          linha.camposQueCitamPedido = caminhosDeChave(d.json).filter((c) =>
+            /ped|compra|order/i.test(c)
+          );
           if (incluirBruto) guardarBruto(bruto, `s2_${nid}`, d.json);
         }
       } catch (err) {
@@ -459,20 +547,25 @@ Deno.serve(async (req: Request): Promise<Response> => {
     })();
     const candidatos = Array.isArray(corpo.candidatos_movimento)
       ? (corpo.candidatos_movimento as Chamada[])
-      : candidatosMovimentoPadrao(primeiroProduto);
+      : candidatosMovimentoPadrao(primeiroProduto, amostra[0]?.t4_data_recebimento ?? null);
 
     const s3: Record<string, unknown>[] = [];
     for (const cand of candidatos) {
-      const linha: Record<string, unknown> = { endpoint: cand.endpoint, call: cand.call };
+      const linha: Record<string, unknown> = {
+        servico: cand.servico,
+        call: cand.call,
+        nota: cand.nota ?? null,
+        param: cand.param,
+      };
       try {
         const d = await chamarOmie(cand, creds, ctx);
         Object.assign(linha, resumirDesfecho(d));
         if (d.tipo === "ok") {
-          linha.itens = resumirItens(d.json);
-          if (incluirBruto) guardarBruto(bruto, `s3_${cand.call}`, d.json);
+          linha.itens = resumirItensPO(d.json);
+          if (incluirBruto) guardarBruto(bruto, `s3_${cand.servico}_${cand.call}`, d.json);
         }
       } catch (err) {
-        // Candidato bloqueado/estourando teto não pode derrubar a medição dos outros.
+        // Candidato bloqueado ou estourando o teto não pode derrubar a medição dos outros.
         linha.desfecho = "nao_medido";
         linha.motivo = mensagemDeErro(err) ?? "falha sem mensagem no candidato";
       }
@@ -485,6 +578,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
       geradoEm: new Date().toISOString(),
       readOnly: true,
       viaAmostra,
+      candidatasLidas,
       chamadasAoOmie: ctx.chamadas,
       amostra: amostra.map((p) => ({
         numeroPedido: p.numero_pedido,
@@ -493,7 +587,7 @@ Deno.serve(async (req: Request): Promise<Response> => {
         t4: p.t4_data_recebimento,
       })),
       s1_detalhe_vs_listagem: s1,
-      s2_recebimento_por_item: s2,
+      s2_associacao_por_item: s2,
       s3_movimento_estoque: s3,
       ...(incluirBruto ? { bruto } : {}),
     });

--- a/supabase/functions/omie-sonda-recebimento/sondas.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas.ts
@@ -1,0 +1,257 @@
+// Núcleo PURO da sonda de contrato do Omie (fatia 1 do receipt-first ledger).
+//
+// Premissa de desenho: "nome de endpoint não é contrato". Estas funções não assumem a forma do
+// payload — elas a MEDEM. Um método que não existe vira `fault` (dado), não exceção; um campo
+// ausente vira `null` marcado, não zero; a lista de itens é LOCALIZADA, não pressuposta.
+//
+// Puro de propósito: `test:edges` roda com --no-remote, então nada aqui pode importar rede.
+
+// ── Desfecho de uma chamada ao Omie ────────────────────────────────────────────────────────
+
+export type Desfecho =
+  | { tipo: "ok"; json: Record<string, unknown> }
+  | {
+    tipo: "fault";
+    faultcode: string | null;
+    faultstring: string;
+    json: Record<string, unknown>;
+  }
+  | { tipo: "http_erro"; status: number; corpo: string }
+  | { tipo: "nao_json"; status: number; corpo: string };
+
+const CORPO_MAX = 400;
+
+/**
+ * Classifica a resposta crua do Omie.
+ *
+ * Regras herdadas de incidentes do repo:
+ *  - `faultstring` SEM `faultcode` também é fault (senão vira "página vazia" → zeros no pendente);
+ *  - HTTP não-ok COM faultstring é fault de negócio (o Omie usa 500 para "não existem registros");
+ *  - corpo ilegível é `nao_json` e NUNCA colapsa em objeto vazio ("não consegui ler" ≠ "não existe");
+ *  - JSON válido que não é objeto (array/escalar) também é `nao_json`: não dá para ler faultstring
+ *    dele, então tratá-lo como sucesso seria assumir contrato — fail-closed.
+ */
+export function classificarResposta(status: number, texto: string): Desfecho {
+  let bruto: unknown;
+  try {
+    bruto = JSON.parse(texto);
+  } catch {
+    return { tipo: "nao_json", status, corpo: texto.slice(0, CORPO_MAX) };
+  }
+  if (typeof bruto !== "object" || bruto === null || Array.isArray(bruto)) {
+    return { tipo: "nao_json", status, corpo: texto.slice(0, CORPO_MAX) };
+  }
+  const json = bruto as Record<string, unknown>;
+
+  const faultstring = typeof json.faultstring === "string" ? json.faultstring : null;
+  if (faultstring) {
+    return {
+      tipo: "fault",
+      faultcode: typeof json.faultcode === "string" ? json.faultcode : null,
+      faultstring,
+      json,
+    };
+  }
+  if (status < 200 || status >= 300) {
+    return { tipo: "http_erro", status, corpo: texto.slice(0, CORPO_MAX) };
+  }
+  return { tipo: "ok", json };
+}
+
+// ── Inventário de chaves ───────────────────────────────────────────────────────────────────
+
+const PROFUNDIDADE_PADRAO = 6;
+const ELEMENTOS_AMOSTRADOS = 25;
+
+/**
+ * Devolve os caminhos de chave de um payload, ordenados e sem repetição.
+ *
+ * Arrays colapsam em `campo[]` e as chaves dos elementos são UNIDAS — um campo presente em
+ * apenas alguns itens não pode desaparecer do inventário. Array vazio e `null` registram o
+ * caminho mesmo assim: "existe e está vazio" ≠ "não existe", e essa diferença é o achado.
+ */
+export function caminhosDeChave(
+  valor: unknown,
+  opts: { profundidadeMax?: number } = {},
+): string[] {
+  const profundidadeMax = opts.profundidadeMax ?? PROFUNDIDADE_PADRAO;
+  const achados = new Set<string>();
+
+  function anda(v: unknown, prefixo: string, nivel: number): void {
+    if (Array.isArray(v)) {
+      const base = `${prefixo}[]`;
+      if (v.length === 0 || nivel >= profundidadeMax) {
+        achados.add(base);
+        return;
+      }
+      for (const el of v.slice(0, ELEMENTOS_AMOSTRADOS)) anda(el, base, nivel);
+      return;
+    }
+    if (typeof v === "object" && v !== null) {
+      const chaves = Object.keys(v as Record<string, unknown>);
+      if (chaves.length === 0 || nivel >= profundidadeMax) {
+        if (prefixo) achados.add(prefixo);
+        return;
+      }
+      for (const k of chaves) {
+        const caminho = prefixo ? `${prefixo}.${k}` : k;
+        anda((v as Record<string, unknown>)[k], caminho, nivel + 1);
+      }
+      return;
+    }
+    if (prefixo) achados.add(prefixo);
+  }
+
+  anda(valor, "", 0);
+  return [...achados].sort();
+}
+
+export function diffCaminhos(
+  a: readonly string[],
+  b: readonly string[],
+): { soEmA: string[]; soEmB: string[]; comuns: string[] } {
+  const sa = new Set(a);
+  const sb = new Set(b);
+  return {
+    soEmA: [...sa].filter((k) => !sb.has(k)).sort(),
+    soEmB: [...sb].filter((k) => !sa.has(k)).sort(),
+    comuns: [...sa].filter((k) => sb.has(k)).sort(),
+  };
+}
+
+// ── Localização da lista de itens ──────────────────────────────────────────────────────────
+
+/** Marcadores de "isto é um item de compra/recebimento" — identidade de produto ou quantidade. */
+const CHAVES_DE_ITEM = [
+  "nCodProd",
+  "nIdProduto",
+  "cCodigoProduto",
+  "nCodItem",
+  "nQtde",
+  "nQtdeNFe",
+  "nQtdeRecebida",
+];
+
+/**
+ * Encontra a lista de itens dentro de um payload SEM assumir onde ela mora — o ponto da sonda é
+ * justamente que o nome do campo no `ConsultarPedCompra`/`ConsultarRecebimento` não é conhecido.
+ * Havendo mais de uma candidata, devolve a MAIOR (a lista de itens é a densa; parcelas e
+ * departamentos são curtas).
+ */
+export function localizarItens(
+  payload: unknown,
+  opts: { profundidadeMax?: number } = {},
+): { caminho: string; itens: Record<string, unknown>[] } | null {
+  const profundidadeMax = opts.profundidadeMax ?? PROFUNDIDADE_PADRAO;
+  let melhor: { caminho: string; itens: Record<string, unknown>[] } | null = null;
+
+  function anda(v: unknown, prefixo: string, nivel: number): void {
+    if (nivel > profundidadeMax) return;
+    if (Array.isArray(v)) {
+      const objetos = v.filter(
+        (el): el is Record<string, unknown> =>
+          typeof el === "object" && el !== null && !Array.isArray(el),
+      );
+      const pareceItem = objetos.length > 0 &&
+        objetos.some((el) => CHAVES_DE_ITEM.some((k) => k in el));
+      if (pareceItem && prefixo && (melhor === null || objetos.length > melhor.itens.length)) {
+        melhor = { caminho: prefixo, itens: objetos };
+      }
+      for (const el of v.slice(0, ELEMENTOS_AMOSTRADOS)) anda(el, prefixo, nivel + 1);
+      return;
+    }
+    if (typeof v === "object" && v !== null) {
+      for (const [k, filho] of Object.entries(v as Record<string, unknown>)) {
+        anda(filho, prefixo ? `${prefixo}.${k}` : k, nivel + 1);
+      }
+    }
+  }
+
+  anda(payload, "", 0);
+  return melhor;
+}
+
+// ── Normalização de item (ausente ≠ zero) ──────────────────────────────────────────────────
+
+export interface ItemPONormalizado {
+  codProduto: string | null;
+  codItem: string | null;
+  unidade: string | null;
+  localEstoque: string | null;
+  qtde: number | null;
+  recebido: number | null;
+  /** true SÓ quando a chave não veio no payload — distingue "Omie omitiu" de "veio torto". */
+  recebidoAusente: boolean;
+  /** valor cru de nQtdeRec, para o relatório mostrar o que o Omie realmente mandou. */
+  recebidoBruto: unknown;
+}
+
+/**
+ * Parse ESTRITO (espelho da política de `pendente-entrada-po.ts`): `Number()` mascara dado torto
+ * — ""/null/false/[] viram 0, "0x10" vira 16. Aqui qualquer coisa fora de número decimal simples
+ * vira `null`, e quem lê decide o que fazer com o desconhecido.
+ */
+function parseQtdEstrito(v: unknown): number | null {
+  if (typeof v === "number") return Number.isFinite(v) ? v : null;
+  if (typeof v !== "string") return null;
+  const s = v.trim();
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)$/.test(s)) return null;
+  const n = Number(s);
+  return Number.isFinite(n) ? n : null;
+}
+
+function texto(v: unknown): string | null {
+  if (typeof v === "string") return v.trim() === "" ? null : v.trim();
+  if (typeof v === "number") return String(v);
+  return null;
+}
+
+const CAMPOS_QTDE_RECEBIDA = ["nQtdeRec", "nQtdeRecebida", "nQtdeReceb"] as const;
+
+export function normalizarItemPO(item: Record<string, unknown>): ItemPONormalizado {
+  const campoRec = CAMPOS_QTDE_RECEBIDA.find((c) => c in item);
+  const bruto = campoRec ? item[campoRec] : undefined;
+  return {
+    codProduto: texto(item.nCodProd ?? item.nIdProduto ?? item.cCodigoProduto),
+    codItem: texto(item.nCodItem ?? item.nSequencia),
+    unidade: texto(item.cUnidade ?? item.cUnidadeNfe),
+    localEstoque: texto(item.codigo_local_estoque ?? item.nCodLocal),
+    qtde: parseQtdEstrito(item.nQtde ?? item.nQtdeNFe),
+    recebido: campoRec === undefined ? null : parseQtdEstrito(bruto),
+    recebidoAusente: campoRec === undefined,
+    recebidoBruto: bruto,
+  };
+}
+
+// ── Trava de leitura ───────────────────────────────────────────────────────────────────────
+
+/** Prefixos de método que o Omie usa para CONSULTA. Allowlist — tudo o mais é negado. */
+const PREFIXOS_DE_LEITURA = ["Consultar", "Listar", "Pesquisar", "Obter"] as const;
+
+/**
+ * Verdadeiro só para métodos de CONSULTA do Omie.
+ *
+ * Esta é a trava que faz "a sonda é read-only ao ERP" ser uma propriedade verificável e não uma
+ * promessa do comentário: os métodos candidatos podem vir no corpo da requisição (para iterar a
+ * descoberta sem um novo deploy), e no MESMO endpoint de recebimento moram `AlterarRecebimento`
+ * e `ConcluirRecebimento`, que mudam estado no ERP de produção. Allowlist por prefixo, ancorada
+ * no início e case-sensitive: desconhecido é negado, não tolerado.
+ */
+export function ehMetodoDeLeitura(call: string): boolean {
+  const m = call.trim();
+  if (m === "" || m !== call) return false;
+  return PREFIXOS_DE_LEITURA.some((p) => m.startsWith(p));
+}
+
+// ── Redação de segredo ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Mascara credenciais antes que qualquer payload vire log, resposta HTTP ou colagem em PR.
+ * A transcrição de sessão persiste em disco — segredo não pode transitar em texto plano.
+ */
+export function redigirSegredos(texto: string): string {
+  return texto.replace(
+    /("(?:app_key|app_secret)"\s*:\s*)"[^"]*"/gi,
+    '$1"***"',
+  );
+}

--- a/supabase/functions/omie-sonda-recebimento/sondas.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas.ts
@@ -223,6 +223,22 @@ export function normalizarItemPO(item: Record<string, unknown>): ItemPONormaliza
   };
 }
 
+// ── Etapa da PO ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Lê `cabecalho_consulta.cEtapa` de um `raw_data` de PO, sem confiar na forma do objeto.
+ * Devolve `null` quando não dá para saber — quem chama decide, e "não sei" nunca vira "não é".
+ */
+export function etapaDaPO(raw: unknown): string | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const cab = (raw as Record<string, unknown>).cabecalho_consulta;
+  if (typeof cab !== "object" || cab === null) return null;
+  const etapa = (cab as Record<string, unknown>).cEtapa;
+  if (typeof etapa === "string") return etapa.trim() === "" ? null : etapa.trim();
+  if (typeof etapa === "number") return String(etapa);
+  return null;
+}
+
 // ── Trava de leitura ───────────────────────────────────────────────────────────────────────
 
 /** Prefixos de método que o Omie usa para CONSULTA. Allowlist — tudo o mais é negado. */

--- a/supabase/functions/omie-sonda-recebimento/sondas.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas.ts
@@ -127,10 +127,14 @@ const CHAVES_DE_ITEM = [
   "nIdProduto",
   "cCodigoProduto",
   "nCodItem",
+  "nIdItPedido",
   "nQtde",
   "nQtdeNFe",
   "nQtdeRecebida",
 ];
+
+/** Profundidade da busca DENTRO do elemento ao decidir se um array é de itens. */
+const PROF_MARCADOR = 3;
 
 /**
  * Encontra a lista de itens dentro de um payload SEM assumir onde ela mora — o ponto da sonda é
@@ -152,8 +156,15 @@ export function localizarItens(
         (el): el is Record<string, unknown> =>
           typeof el === "object" && el !== null && !Array.isArray(el),
       );
+      // Busca o marcador EM PROFUNDIDADE dentro do elemento: `itensRecebimento[]` guarda tudo
+      // sob `itensCabec`/`itensAjustes`/`itensInfoAdic`, então olhar só o topo do elemento
+      // devolvia "sem itens" num payload cheio deles (bug apontado pelo Codex).
       const pareceItem = objetos.length > 0 &&
-        objetos.some((el) => CHAVES_DE_ITEM.some((k) => k in el));
+        objetos.some((el) =>
+          CHAVES_DE_ITEM.some((k) =>
+            buscarValorProfundo(el, [k], { profundidadeMax: PROF_MARCADOR }) !== undefined
+          )
+        );
       if (pareceItem && prefixo && (melhor === null || objetos.length > melhor.itens.length)) {
         melhor = { caminho: prefixo, itens: objetos };
       }
@@ -223,6 +234,185 @@ export function normalizarItemPO(item: Record<string, unknown>): ItemPONormaliza
   };
 }
 
+// ── Identificador nativo ───────────────────────────────────────────────────────────────────
+
+/**
+ * Normaliza um ID nativo do Omie, tratando ZERO como AUSÊNCIA.
+ *
+ * Este é o detalhe que decide a medição inteira (Codex): `nIdPedido: 0` é como o Omie diz "este
+ * item não está associado a pedido nenhum". Se 0 virasse id válido, "sem vínculo" seria contado
+ * como "vínculo com a PO 0" — um falso positivo exatamente no campo que a fatia 1 existe para
+ * medir. Presença de NOME não é presença de VALOR.
+ */
+export function idNativo(v: unknown): string | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === "number") return Number.isFinite(v) && v !== 0 ? String(v) : null;
+  if (typeof v !== "string") return null;
+  const s = v.trim();
+  if (s === "") return null;
+  // "0", "00", "000": zero escrito de qualquer jeito continua sendo ausência.
+  if (/^0+$/.test(s)) return null;
+  return s;
+}
+
+// ── Busca por nome, em profundidade ────────────────────────────────────────────────────────
+
+/**
+ * Procura o primeiro dos `nomes` em qualquer profundidade do objeto e devolve seu valor cru.
+ *
+ * Buscar por NOME em vez de por caminho fixo é deliberado: o item de recebimento aninha os campos
+ * em `itensCabec` / `itensAjustes` / `itensInfoAdic` / `itensIde`, e hardcodar o caminho seria
+ * assumir o contrato — o erro que esta sonda existe para não cometer. A ordem dos `nomes` é a
+ * ordem de preferência (o Omie alterna grafias, ex.: `cChaveNFe` × `cChaveNfe`).
+ */
+export function buscarValorProfundo(
+  obj: unknown,
+  nomes: readonly string[],
+  opts: { profundidadeMax?: number } = {},
+): unknown {
+  const profundidadeMax = opts.profundidadeMax ?? PROFUNDIDADE_PADRAO;
+  for (const nome of nomes) {
+    const achado = procurar(obj, nome, 0, profundidadeMax);
+    if (achado !== undefined) return achado;
+  }
+  return undefined;
+}
+
+function procurar(v: unknown, nome: string, nivel: number, max: number): unknown {
+  if (nivel > max || v === null || typeof v !== "object") return undefined;
+  if (Array.isArray(v)) {
+    for (const el of v.slice(0, ELEMENTOS_AMOSTRADOS)) {
+      const r = procurar(el, nome, nivel + 1, max);
+      if (r !== undefined) return r;
+    }
+    return undefined;
+  }
+  const reg = v as Record<string, unknown>;
+  if (nome in reg) return reg[nome];
+  for (const filho of Object.values(reg)) {
+    const r = procurar(filho, nome, nivel + 1, max);
+    if (r !== undefined) return r;
+  }
+  return undefined;
+}
+
+// ── Item de recebimento e a taxonomia de associação ────────────────────────────────────────
+
+export interface ItemRecebimentoNormalizado {
+  sequencia: string | null;
+  idItemRecebimento: string | null;
+  /** `nIdPedido` — o vínculo NATIVO com o pedido de compra. null quando o Omie manda 0. */
+  idPedido: string | null;
+  /** `nIdItPedido` — o vínculo NATIVO com o ITEM do pedido; é ele que o ledger precisa. */
+  idItemPedido: string | null;
+  /** `nNumPedCompra` — referência TEXTUAL vinda do XML do fornecedor, não vínculo nativo. */
+  numPedidoTexto: string | null;
+  numItemPedidoTexto: string | null;
+  idProduto: string | null;
+  codigoProduto: string | null;
+  unidade: string | null;
+  localEstoque: string | null;
+  qtdeNfe: number | null;
+  qtdeRecebida: number | null;
+  /** `cNaoGerarMovEstoque`: se "S", houve recebimento fiscal SEM movimento de estoque. */
+  naoGeraMovEstoque: string | null;
+}
+
+export function normalizarItemRecebimento(item: unknown): ItemRecebimentoNormalizado {
+  const buscar = (nomes: readonly string[]) => buscarValorProfundo(item, nomes);
+  return {
+    sequencia: idNativo(buscar(["nSequencia"])),
+    idItemRecebimento: idNativo(buscar(["nIdItem"])),
+    idPedido: idNativo(buscar(["nIdPedido", "nIdPedidoExistente"])),
+    idItemPedido: idNativo(buscar(["nIdItPedido", "nIdItPedidoExistente"])),
+    numPedidoTexto: idNativo(buscar(["nNumPedCompra", "cNumPedCompra"])),
+    numItemPedidoTexto: idNativo(buscar(["cNumItPedCompra", "nNumItPedCompra"])),
+    idProduto: idNativo(buscar(["nIdProduto"])),
+    codigoProduto: texto(buscar(["cCodigoProduto", "cCodigo"])),
+    unidade: texto(buscar(["cUnidadeNfe", "cUnidade"])),
+    localEstoque: idNativo(buscar(["codigo_local_estoque", "nCodLocalEstoque"])),
+    qtdeNfe: parseQtdEstrito(buscar(["nQtdeNFe", "nQtde"])),
+    qtdeRecebida: parseQtdEstrito(buscar(["nQtdeRecebida", "nQtdeReceb"])),
+    naoGeraMovEstoque: texto(buscar(["cNaoGerarMovEstoque", "cNaoGerarMovEstoq"])),
+  };
+}
+
+/**
+ * Como este item de NF-e se liga (ou não) à PO alvo. É a resposta da fatia 1 por item.
+ *
+ * `native_exact` é o único estado que autorizaria, mais adiante, um desconto do "a caminho" —
+ * e ainda assim só depois de amarrado a movimento de estoque postado. `xml_hint_only` é a
+ * hipótese que o código do espelho torna provável: `omie-sync-nfes-recebidas` monta o vínculo
+ * PO↔NF-e a partir de `nNumPedCompra`, uma referência textual do XML do fornecedor. Se for esse
+ * o estado dominante, o `t4` do espelho é INFERÊNCIA NOSSA, não recebimento do Omie — e a
+ * etapa-15 deixa de ser contradição.
+ */
+export type ClasseAssociacao =
+  | "native_exact"
+  | "native_other_po"
+  | "native_sem_item"
+  | "xml_hint_only"
+  | "xml_hint_outra_po"
+  | "product_only"
+  | "unassociated";
+
+export function classificarAssociacao(
+  item: ItemRecebimentoNormalizado,
+  alvo: { idPedido: string | null; numeroPedido: string | null },
+): ClasseAssociacao {
+  if (item.idPedido !== null) {
+    if (alvo.idPedido !== null && item.idPedido !== alvo.idPedido) return "native_other_po";
+    return item.idItemPedido !== null ? "native_exact" : "native_sem_item";
+  }
+  if (item.numPedidoTexto !== null) {
+    if (alvo.numeroPedido !== null && item.numPedidoTexto !== alvo.numeroPedido) {
+      return "xml_hint_outra_po";
+    }
+    return "xml_hint_only";
+  }
+  if (item.idProduto !== null || item.codigoProduto !== null) return "product_only";
+  return "unassociated";
+}
+
+// ── Escolha da amostra ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Escolhe POs de NOTAS distintas, cobrindo os dois extremos da consolidação.
+ *
+ * Sem isto, "as 3 POs mais recentes" pode selecionar três POs da MESMA nota (94% das POs alvo
+ * dividem nota com outra) — a S2 rodaria uma vez só e a amostra não representaria nada. A ordem
+ * alterna a nota que cobre MAIS POs (o caso dominante, onde a atribuição é ambígua) com a que
+ * cobre menos (o caso raro de nota exclusiva), porque os dois lados decidem coisas diferentes
+ * no ledger.
+ */
+export function escolherPorNotaDiversa<T extends { nid_receb: number | null }>(
+  linhas: readonly T[],
+  limite: number,
+): T[] {
+  const porNota = new Map<number, T[]>();
+  for (const l of linhas) {
+    if (l.nid_receb == null) continue;
+    const g = porNota.get(l.nid_receb);
+    if (g) g.push(l);
+    else porNota.set(l.nid_receb, [l]);
+  }
+  // Grupos ordenados por quantidade de POs na nota (desc) — empate resolvido pelo id, para a
+  // escolha ser determinística entre execuções.
+  const grupos = [...porNota.entries()]
+    .sort((a, b) => b[1].length - a[1].length || a[0] - b[0]);
+
+  const escolhidas: T[] = [];
+  let inicio = 0;
+  let fim = grupos.length - 1;
+  let pegarDoInicio = true;
+  while (escolhidas.length < limite && inicio <= fim) {
+    const g = pegarDoInicio ? grupos[inicio++] : grupos[fim--];
+    escolhidas.push(g[1][0]);
+    pegarDoInicio = !pegarDoInicio;
+  }
+  return escolhidas;
+}
+
 // ── Etapa da PO ────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -237,6 +427,42 @@ export function etapaDaPO(raw: unknown): string | null {
   if (typeof etapa === "string") return etapa.trim() === "" ? null : etapa.trim();
   if (typeof etapa === "number") return String(etapa);
   return null;
+}
+
+// ── Destino: enum fechado, nunca dado de entrada ───────────────────────────────────────────
+
+/**
+ * Serviços do Omie que a sonda pode consultar. URLs HARDCODED, por segurança, não por estilo.
+ *
+ * A edge manda `app_key`/`app_secret` no CORPO de cada requisição. Se o destino viesse do corpo
+ * da invocação — como vinha na primeira versão, via `candidatos_movimento[].endpoint` — quem
+ * chamasse a sonda poderia apontá-la para um host próprio e receber a credencial do ERP de
+ * produção. A allowlist de MÉTODO não fecha isso: ela restringe o verbo, não o destino.
+ *
+ * Por que não uma allowlist exata de pares (serviço, método), como o Codex sugeriu: descobrir
+ * método ainda não catalogado é justamente o trabalho da S3. O par serviço-fechado + método
+ * restrito a consulta preserva a descoberta sem deixar a credencial sair do host do Omie.
+ */
+const SERVICOS: Readonly<Record<string, string>> = {
+  pedido_compra: "https://app.omie.com.br/api/v1/produtos/pedidocompra/",
+  recebimento_nfe: "https://app.omie.com.br/api/v1/produtos/recebimentonfe/",
+  estoque_consulta: "https://app.omie.com.br/api/v1/estoque/consulta/",
+  estoque_resumo: "https://app.omie.com.br/api/v1/estoque/resumo/",
+  estoque_movestoque: "https://app.omie.com.br/api/v1/estoque/movestoque/",
+  estoque_ajuste: "https://app.omie.com.br/api/v1/estoque/ajuste/",
+  estoque_local: "https://app.omie.com.br/api/v1/estoque/local/",
+};
+
+export type Servico = keyof typeof SERVICOS;
+
+export function servicosConhecidos(): string[] {
+  return Object.keys(SERVICOS).sort();
+}
+
+/** URL do serviço, ou `null` para qualquer entrada que não seja uma chave EXATA do enum. */
+export function urlDoServico(servico: string): string | null {
+  if (typeof servico !== "string") return null;
+  return Object.prototype.hasOwnProperty.call(SERVICOS, servico) ? SERVICOS[servico] : null;
 }
 
 // ── Trava de leitura ───────────────────────────────────────────────────────────────────────

--- a/supabase/functions/omie-sonda-recebimento/sondas.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas.ts
@@ -453,7 +453,9 @@ const SERVICOS: Readonly<Record<string, string>> = {
   estoque_local: "https://app.omie.com.br/api/v1/estoque/local/",
 };
 
-export type Servico = keyof typeof SERVICOS;
+// Sem `export type Servico = keyof typeof SERVICOS`: o serviço chega como string do corpo da
+// requisição e é validado em RUNTIME por `urlDoServico`. Um tipo estático aqui daria falsa
+// segurança sobre um valor que o compilador nunca vê — e o knip acusaria o export morto.
 
 export function servicosConhecidos(): string[] {
   return Object.keys(SERVICOS).sort();

--- a/supabase/functions/omie-sonda-recebimento/sondas_test.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas_test.ts
@@ -8,14 +8,21 @@
 // RESULTADO (fault), não como crash.
 
 import {
+  buscarValorProfundo,
   caminhosDeChave,
+  classificarAssociacao,
   classificarResposta,
   diffCaminhos,
   ehMetodoDeLeitura,
+  escolherPorNotaDiversa,
   etapaDaPO,
+  idNativo,
   localizarItens,
   normalizarItemPO,
+  normalizarItemRecebimento,
   redigirSegredos,
+  servicosConhecidos,
+  urlDoServico,
 } from "./sondas.ts";
 
 function assertEquals(a: unknown, b: unknown, msg?: string) {
@@ -132,6 +139,21 @@ Deno.test("localizarItens: ignora arrays que não são de item de compra", () =>
   assertEquals(r, null);
 });
 
+Deno.test("localizarItens: acha itensRecebimento[] com as chaves ANINHADAS", () => {
+  // BUG achado pelo Codex: itensRecebimento[] tem itensCabec/itensAjustes aninhados, e a versão
+  // que só olhava as chaves no topo do elemento não encontrava nada — a S2 voltaria "sem itens"
+  // num payload cheio deles, e eu leria isso como "o Omie não expõe a associação".
+  const payload = {
+    itensRecebimento: [
+      { itensCabec: { nIdProduto: 1, nQtdeNFe: 2 }, itensAjustes: { nQtdeRecebida: 2 } },
+      { itensCabec: { nIdProduto: 3, nQtdeNFe: 4 }, itensAjustes: { nQtdeRecebida: 4 } },
+    ],
+  };
+  const r = localizarItens(payload);
+  assertEquals(r?.caminho, "itensRecebimento");
+  assertEquals(r?.itens.length, 2);
+});
+
 Deno.test("localizarItens: prefere a lista MAIOR quando há mais de uma candidata", () => {
   const r = localizarItens({
     a: [{ nCodProd: 1 }],
@@ -189,6 +211,125 @@ Deno.test("redigirSegredos: mascara mesmo com espaçamento alternativo", () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// idNativo — "0" e 123 são mundos opostos nesta decisão (Codex)
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("idNativo: zero em qualquer forma é AUSÊNCIA de vínculo, não vínculo com id 0", () => {
+  // O ponto do Codex: `nIdPedido: 0` significa "não associado". Tratar como id válido
+  // transformaria "sem vínculo" em "vínculo com a PO 0" — falso positivo no coração da medição.
+  assertEquals(idNativo(0), null);
+  assertEquals(idNativo("0"), null);
+  assertEquals(idNativo("000"), null);
+  assertEquals(idNativo(""), null);
+  assertEquals(idNativo("  "), null);
+  assertEquals(idNativo(null), null);
+  assertEquals(idNativo(undefined), null);
+});
+
+Deno.test("idNativo: id real vira string estável", () => {
+  assertEquals(idNativo(123), "123");
+  assertEquals(idNativo("123"), "123");
+  assertEquals(idNativo(" 123 "), "123");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buscarValorProfundo — acha o campo sem hardcodar ONDE ele mora
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("buscarValorProfundo: acha em objeto aninhado", () => {
+  // itensRecebimento[] tem itensCabec/itensAjustes/itensInfoAdic ANINHADOS — o Codex mostrou
+  // que procurar a chave no topo do elemento não encontra nada.
+  const item = { itensCabec: { nIdPedido: 77 }, itensAjustes: { nQtdeRecebida: 3 } };
+  assertEquals(buscarValorProfundo(item, ["nIdPedido"]), 77);
+  assertEquals(buscarValorProfundo(item, ["nQtdeRecebida"]), 3);
+});
+
+Deno.test("buscarValorProfundo: primeiro nome da lista que existir vence", () => {
+  const item = { a: { cChaveNFe: "x" }, b: { cChaveNfe: "y" } };
+  assertEquals(buscarValorProfundo(item, ["cChaveNFe", "cChaveNfe"]), "x");
+  assertEquals(buscarValorProfundo(item, ["cChaveNfe", "cChaveNFe"]), "y");
+});
+
+Deno.test("buscarValorProfundo: ausente devolve undefined (não null, não 0)", () => {
+  assertEquals(buscarValorProfundo({ x: 1 }, ["nIdPedido"]), undefined);
+  assertEquals(buscarValorProfundo(null, ["nIdPedido"]), undefined);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// normalizarItemRecebimento + classificarAssociacao — o núcleo da S2
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ALVO = { idPedido: "1001", numeroPedido: "1133" };
+
+Deno.test("classificarAssociacao: vínculo nativo por ITEM que casa com a PO alvo", () => {
+  const item = normalizarItemRecebimento({
+    itensCabec: { nIdItem: 9, nIdPedido: 1001, nIdItPedido: 5501, nIdProduto: 42 },
+  });
+  assertEquals(item.idPedido, "1001");
+  assertEquals(item.idItemPedido, "5501");
+  assertEquals(classificarAssociacao(item, ALVO), "native_exact");
+});
+
+Deno.test("classificarAssociacao: nativo apontando OUTRA PO (nota consolidada)", () => {
+  // 94% das POs alvo dividem nota — este caso é o esperado, não a exceção.
+  const item = normalizarItemRecebimento({ itensCabec: { nIdPedido: 2002, nIdItPedido: 7 } });
+  assertEquals(classificarAssociacao(item, ALVO), "native_other_po");
+});
+
+Deno.test("classificarAssociacao: cabeçalho casa mas SEM item — não é exact", () => {
+  // Exclusividade de cabeçalho não prova propriedade do item (§3.4 do spec).
+  const item = normalizarItemRecebimento({ itensCabec: { nIdPedido: 1001, nIdItPedido: 0 } });
+  assertEquals(classificarAssociacao(item, ALVO), "native_sem_item");
+});
+
+Deno.test("classificarAssociacao: só o hint TEXTUAL do XML — o caso que o sync usa hoje", () => {
+  // omie-sync-nfes-recebidas cria o vínculo por itensInfoAdic.nNumPedCompra, não pelo id nativo.
+  // Se for só isto, "PO recebida" é inferência do espelho, não estado do Omie.
+  const item = normalizarItemRecebimento({
+    itensCabec: { nIdPedido: 0, nIdItPedido: 0 },
+    itensInfoAdic: { nNumPedCompra: "1133", cNumItPedCompra: "1" },
+  });
+  assertEquals(item.idPedido, null);
+  assertEquals(item.numPedidoTexto, "1133");
+  assertEquals(classificarAssociacao(item, ALVO), "xml_hint_only");
+});
+
+Deno.test("classificarAssociacao: hint textual de OUTRA PO não vira vínculo do alvo", () => {
+  const item = normalizarItemRecebimento({ itensInfoAdic: { nNumPedCompra: "9999" } });
+  assertEquals(classificarAssociacao(item, ALVO), "xml_hint_outra_po");
+});
+
+Deno.test("classificarAssociacao: só produto, e nada", () => {
+  assertEquals(
+    classificarAssociacao(normalizarItemRecebimento({ itensCabec: { nIdProduto: 42 } }), ALVO),
+    "product_only",
+  );
+  assertEquals(
+    classificarAssociacao(normalizarItemRecebimento({ itensCabec: {} }), ALVO),
+    "unassociated",
+  );
+});
+
+Deno.test("normalizarItemRecebimento: captura quantidade, unidade, local e o flag de estoque", () => {
+  const item = normalizarItemRecebimento({
+    itensCabec: { nQtdeNFe: "10", cUnidadeNfe: "KG", nIdProduto: 42, cCodigoProduto: "PRD1" },
+    itensAjustes: { nQtdeRecebida: 3, codigo_local_estoque: 77, cNaoGerarMovEstoque: "S" },
+  });
+  assertEquals(item.qtdeNfe, 10);
+  assertEquals(item.qtdeRecebida, 3);
+  assertEquals(item.unidade, "KG");
+  assertEquals(item.localEstoque, "77");
+  assertEquals(item.naoGeraMovEstoque, "S");
+  assertEquals(item.codigoProduto, "PRD1");
+});
+
+Deno.test("normalizarItemRecebimento: quantidade ausente é null, não 0", () => {
+  const item = normalizarItemRecebimento({ itensCabec: { nIdProduto: 1 } });
+  assertEquals(item.qtdeNfe, null);
+  assertEquals(item.qtdeRecebida, null);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // etapaDaPO — usada no fallback quando o filtro jsonb do PostgREST não estiver disponível
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -213,6 +354,86 @@ Deno.test("etapaDaPO: forma inesperada devolve null, não string vazia", () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // ehMetodoDeLeitura — a trava que torna "read-only ao Omie" uma propriedade, não uma promessa
 // ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// escolherPorNotaDiversa — 94% das POs alvo dividem nota; amostra ingênua mede uma nota só
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("escolherPorNotaDiversa: nunca devolve duas POs da MESMA nota", () => {
+  const linhas = [
+    { nid_receb: 1, po: "a" },
+    { nid_receb: 1, po: "b" },
+    { nid_receb: 1, po: "c" },
+    { nid_receb: 2, po: "d" },
+    { nid_receb: 3, po: "e" },
+  ];
+  const r = escolherPorNotaDiversa(linhas, 3);
+  assertEquals(r.length, 3);
+  assertEquals(new Set(r.map((x) => x.nid_receb)).size, 3);
+});
+
+Deno.test("escolherPorNotaDiversa: cobre os dois extremos — nota consolidada E exclusiva", () => {
+  // A primeira escolha é a nota mais consolidada (atribuição ambígua, caso dominante); a
+  // segunda é a mais exclusiva (o caso raro). Os dois decidem coisas diferentes no ledger.
+  const linhas = [
+    { nid_receb: 9, po: "x" }, // nota exclusiva
+    { nid_receb: 7, po: "a" },
+    { nid_receb: 7, po: "b" },
+    { nid_receb: 7, po: "c" }, // nota com 3 POs
+  ];
+  const r = escolherPorNotaDiversa(linhas, 2);
+  assertEquals(r.map((x) => x.nid_receb), [7, 9]);
+});
+
+Deno.test("escolherPorNotaDiversa: ignora linha sem nota e respeita o limite", () => {
+  const linhas = [
+    { nid_receb: null, po: "z" },
+    { nid_receb: 5, po: "a" },
+    { nid_receb: 6, po: "b" },
+  ];
+  assertEquals(escolherPorNotaDiversa(linhas, 5).length, 2);
+  assertEquals(escolherPorNotaDiversa(linhas, 1).length, 1);
+  assertEquals(escolherPorNotaDiversa([], 3), []);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// urlDoServico — a credencial NUNCA pode ir para uma URL vinda do corpo (SSRF)
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("urlDoServico: resolve serviço conhecido para URL do Omie", () => {
+  assertEquals(
+    urlDoServico("estoque_consulta"),
+    "https://app.omie.com.br/api/v1/estoque/consulta/",
+  );
+});
+
+Deno.test("urlDoServico: NEGA qualquer coisa que não seja um serviço do enum", () => {
+  // O ataque que isto fecha: a edge envia app_key/app_secret no corpo da requisição. Se o
+  // destino viesse do corpo, quem chama a sonda exfiltraria a credencial do ERP para um host
+  // próprio. A URL não pode ser dado de entrada — nem parcialmente.
+  for (
+    const tentativa of [
+      "https://evil.example.com/",
+      "http://app.omie.com.br.evil.example/",
+      "https://app.omie.com.br/api/v1/estoque/consulta/",
+      "//evil.example.com",
+      "estoque_consulta/../../x",
+      "ESTOQUE_CONSULTA",
+      "",
+      "   ",
+    ]
+  ) {
+    assertEquals(urlDoServico(tentativa), null, `deveria negar: ${tentativa}`);
+  }
+});
+
+Deno.test("urlDoServico: todo destino do enum é https no host do Omie", () => {
+  for (const nome of servicosConhecidos()) {
+    const url = urlDoServico(nome);
+    assertEquals(url !== null, true, nome);
+    assertEquals(url!.startsWith("https://app.omie.com.br/api/v1/"), true, `${nome} → ${url}`);
+  }
+});
 
 Deno.test("ehMetodoDeLeitura: aceita os prefixos de consulta", () => {
   for (const m of ["ConsultarPedCompra", "ListarSaldoPendente", "PesquisarPedCompra", "ObterX"]) {

--- a/supabase/functions/omie-sonda-recebimento/sondas_test.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas_test.ts
@@ -1,0 +1,225 @@
+// Testa o CÓDIGO REAL de sondas.ts no runtime real (Deno), sem import remoto (test:edges roda
+// com --no-remote). Roda com: deno test supabase/functions/omie-sonda-recebimento/sondas_test.ts
+//
+// O que estas funções sustentam: a sonda EXISTE para descobrir o contrato do Omie, não para
+// confirmar um contrato assumido ("nome de endpoint não é contrato" — Codex, spec 2026-08-13).
+// Por isso todo o núcleo puro é agnóstico à forma do payload: inventaria caminhos de chave,
+// localiza a lista de itens onde quer que ela esteja, e classifica um método inexistente como
+// RESULTADO (fault), não como crash.
+
+import {
+  caminhosDeChave,
+  classificarResposta,
+  diffCaminhos,
+  ehMetodoDeLeitura,
+  localizarItens,
+  normalizarItemPO,
+  redigirSegredos,
+} from "./sondas.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(
+      `${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`,
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classificarResposta — um método que não existe é DADO, não exceção
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("classificarResposta: 200 com JSON limpo → ok", () => {
+  const d = classificarResposta(200, '{"cabecalho":{"nCodPed":123}}');
+  assertEquals(d.tipo, "ok");
+  if (d.tipo === "ok") assertEquals(d.json, { cabecalho: { nCodPed: 123 } });
+});
+
+Deno.test("classificarResposta: faultstring SEM faultcode também é fault", () => {
+  // Lição do repo (omie-sync-estoque): passar adiante virava 'página vazia' → zeros no pendente.
+  const d = classificarResposta(200, '{"faultstring":"Metodo nao encontrado"}');
+  assertEquals(d.tipo, "fault");
+  if (d.tipo === "fault") {
+    assertEquals(d.faultcode, null);
+    assertEquals(d.faultstring, "Metodo nao encontrado");
+  }
+});
+
+Deno.test("classificarResposta: HTTP 500 com faultstring é fault (não http_erro)", () => {
+  // O Omie sinaliza erro de negócio com HTTP 500 + faultstring (ex.: fim de paginação, 5113).
+  const d = classificarResposta(
+    500,
+    '{"faultcode":"SOAP-ENV:Client-5113","faultstring":"Nao existem registros"}',
+  );
+  assertEquals(d.tipo, "fault");
+  if (d.tipo === "fault") assertEquals(d.faultcode, "SOAP-ENV:Client-5113");
+});
+
+Deno.test("classificarResposta: corpo não-JSON NUNCA colapsa em vazio", () => {
+  // Classe #1581: trocar 'não consegui ler' por 'não existe' fabrica ausência.
+  const d = classificarResposta(200, "<html>gateway timeout</html>");
+  assertEquals(d.tipo, "nao_json");
+});
+
+Deno.test("classificarResposta: JSON válido que não é objeto é nao_json (fail-closed)", () => {
+  // Array no topo impede ler faultstring — tratar como 'não consegui ler', não como sucesso.
+  assertEquals(classificarResposta(200, "[1,2,3]").tipo, "nao_json");
+  assertEquals(classificarResposta(200, "null").tipo, "nao_json");
+});
+
+Deno.test("classificarResposta: HTTP 500 com JSON sem fault → http_erro", () => {
+  const d = classificarResposta(500, '{"mensagem":"erro interno"}');
+  assertEquals(d.tipo, "http_erro");
+  if (d.tipo === "http_erro") assertEquals(d.status, 500);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// caminhosDeChave — o inventário que responde "o detalhe expõe o que a listagem esconde?"
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("caminhosDeChave: objeto aninhado vira caminho pontuado", () => {
+  assertEquals(caminhosDeChave({ a: { b: 1, c: "x" } }), ["a.b", "a.c"]);
+});
+
+Deno.test("caminhosDeChave: array COLAPSA em [] e une as chaves dos elementos", () => {
+  // União (não o 1º elemento): campo presente só em alguns itens não pode sumir do inventário.
+  assertEquals(
+    caminhosDeChave({ itens: [{ d: 1 }, { e: 2 }] }),
+    ["itens[].d", "itens[].e"],
+  );
+});
+
+Deno.test("caminhosDeChave: array vazio e null registram o caminho (chave existe)", () => {
+  // 'Existe e está vazio' ≠ 'não existe' — a diferença é o achado da sonda.
+  assertEquals(caminhosDeChave({ itens: [], obs: null }), ["itens[]", "obs"]);
+});
+
+Deno.test("caminhosDeChave: respeita profundidade máxima", () => {
+  const fundo = { a: { b: { c: { d: 1 } } } };
+  assertEquals(caminhosDeChave(fundo, { profundidadeMax: 2 }), ["a.b"]);
+});
+
+Deno.test("caminhosDeChave: ordena e deduplica", () => {
+  assertEquals(caminhosDeChave({ b: 1, a: 2, l: [{ x: 1 }, { x: 2 }] }), ["a", "b", "l[].x"]);
+});
+
+Deno.test("diffCaminhos: separa exclusivos de comuns", () => {
+  assertEquals(diffCaminhos(["a", "b"], ["b", "c"]), {
+    soEmA: ["a"],
+    soEmB: ["c"],
+    comuns: ["b"],
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// localizarItens — acha a lista de itens SEM assumir o nome do campo
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("localizarItens: acha produtos_consulta no topo", () => {
+  const r = localizarItens({ produtos_consulta: [{ nCodProd: 7, nQtde: 2 }] });
+  assertEquals(r?.caminho, "produtos_consulta");
+  assertEquals(r?.itens.length, 1);
+});
+
+Deno.test("localizarItens: acha itens sob nome DESCONHECIDO (o contrato pode divergir)", () => {
+  const r = localizarItens({ envelope: { lista_qualquer: [{ nCodProd: 9, nQtde: 1 }] } });
+  assertEquals(r?.caminho, "envelope.lista_qualquer");
+});
+
+Deno.test("localizarItens: ignora arrays que não são de item de compra", () => {
+  const r = localizarItens({ parcelas: [{ nParcela: 1, nValor: 10 }] });
+  assertEquals(r, null);
+});
+
+Deno.test("localizarItens: prefere a lista MAIOR quando há mais de uma candidata", () => {
+  const r = localizarItens({
+    a: [{ nCodProd: 1 }],
+    b: [{ nCodProd: 2 }, { nCodProd: 3 }],
+  });
+  assertEquals(r?.caminho, "b");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// normalizarItemPO — ausente ≠ zero (invariante money-path do repo)
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("normalizarItemPO: string numérica vira número", () => {
+  const i = normalizarItemPO({ nCodProd: 42, nQtde: "5", nQtdeRec: "0", cUnidade: "UN" });
+  assertEquals(i.qtde, 5);
+  assertEquals(i.recebido, 0);
+  assertEquals(i.unidade, "UN");
+});
+
+Deno.test("normalizarItemPO: campo AUSENTE vira null, não 0", () => {
+  // Number(undefined)=NaN e Number(null)=0 — ambos fabricariam fato. A sonda mede, não infere.
+  const i = normalizarItemPO({ nCodProd: 42, nQtde: 5 });
+  assertEquals(i.recebido, null);
+  assertEquals(i.recebidoAusente, true);
+});
+
+Deno.test("normalizarItemPO: valor inválido vira null e marca o bruto", () => {
+  const i = normalizarItemPO({ nCodProd: 1, nQtde: "5,5", nQtdeRec: "abc" });
+  assertEquals(i.qtde, null);
+  assertEquals(i.recebido, null);
+  assertEquals(i.recebidoAusente, false);
+  assertEquals(i.recebidoBruto, "abc");
+});
+
+Deno.test("normalizarItemPO: não confunde 0 legítimo com ausência", () => {
+  const i = normalizarItemPO({ nCodProd: 1, nQtdeRec: 0 });
+  assertEquals(i.recebido, 0);
+  assertEquals(i.recebidoAusente, false);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// redigirSegredos — a saída da sonda é lida por humanos e colada em PR/chat
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("redigirSegredos: mascara app_key e app_secret", () => {
+  const s = redigirSegredos('{"app_key":"abc123","app_secret":"s3cr3t","call":"X"}');
+  assertEquals(s.includes("abc123"), false);
+  assertEquals(s.includes("s3cr3t"), false);
+  assertEquals(s.includes('"call":"X"'), true);
+});
+
+Deno.test("redigirSegredos: mascara mesmo com espaçamento alternativo", () => {
+  const s = redigirSegredos('{ "app_secret" : "s3cr3t" }');
+  assertEquals(s.includes("s3cr3t"), false);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ehMetodoDeLeitura — a trava que torna "read-only ao Omie" uma propriedade, não uma promessa
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("ehMetodoDeLeitura: aceita os prefixos de consulta", () => {
+  for (const m of ["ConsultarPedCompra", "ListarSaldoPendente", "PesquisarPedCompra", "ObterX"]) {
+    assertEquals(ehMetodoDeLeitura(m), true, m);
+  }
+});
+
+Deno.test("ehMetodoDeLeitura: NEGA toda escrita conhecida do fluxo de recebimento", () => {
+  // Estes existem de verdade em omie-nfe-recebimento e MUDAM estado no ERP do founder.
+  for (
+    const m of [
+      "AlterarRecebimento",
+      "ConcluirRecebimento",
+      "AlterarEtapaRecebimento",
+      "IncluirPedCompra",
+      "ExcluirRecebimento",
+      "CancelarPedido",
+      "AlterarProduto",
+    ]
+  ) {
+    assertEquals(ehMetodoDeLeitura(m), false, m);
+  }
+});
+
+Deno.test("ehMetodoDeLeitura: fail-closed em desconhecido, vazio e disfarce", () => {
+  assertEquals(ehMetodoDeLeitura("MetodoNovoQualquer"), false);
+  assertEquals(ehMetodoDeLeitura(""), false);
+  assertEquals(ehMetodoDeLeitura("   "), false);
+  // Não basta CONTER um prefixo de leitura — tem que COMEÇAR com ele.
+  assertEquals(ehMetodoDeLeitura("AlterarConsultarRecebimento"), false);
+  // Case-sensitive: o contrato do Omie é PascalCase; variação é desconhecido → negado.
+  assertEquals(ehMetodoDeLeitura("consultarPedCompra"), false);
+});

--- a/supabase/functions/omie-sonda-recebimento/sondas_test.ts
+++ b/supabase/functions/omie-sonda-recebimento/sondas_test.ts
@@ -12,6 +12,7 @@ import {
   classificarResposta,
   diffCaminhos,
   ehMetodoDeLeitura,
+  etapaDaPO,
   localizarItens,
   normalizarItemPO,
   redigirSegredos,
@@ -185,6 +186,28 @@ Deno.test("redigirSegredos: mascara app_key e app_secret", () => {
 Deno.test("redigirSegredos: mascara mesmo com espaçamento alternativo", () => {
   const s = redigirSegredos('{ "app_secret" : "s3cr3t" }');
   assertEquals(s.includes("s3cr3t"), false);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// etapaDaPO — usada no fallback quando o filtro jsonb do PostgREST não estiver disponível
+// ─────────────────────────────────────────────────────────────────────────────
+
+Deno.test("etapaDaPO: lê a etapa do cabeçalho", () => {
+  assertEquals(etapaDaPO({ cabecalho_consulta: { cEtapa: "15" } }), "15");
+});
+
+Deno.test("etapaDaPO: aceita número e normaliza espaço", () => {
+  assertEquals(etapaDaPO({ cabecalho_consulta: { cEtapa: 15 } }), "15");
+  assertEquals(etapaDaPO({ cabecalho_consulta: { cEtapa: " 15 " } }), "15");
+});
+
+Deno.test("etapaDaPO: forma inesperada devolve null, não string vazia", () => {
+  // "não sei" tem que ficar distinguível de "é outra etapa" — senão o fallback silencia POs.
+  assertEquals(etapaDaPO(null), null);
+  assertEquals(etapaDaPO({}), null);
+  assertEquals(etapaDaPO({ cabecalho_consulta: null }), null);
+  assertEquals(etapaDaPO({ cabecalho_consulta: { cEtapa: "" } }), null);
+  assertEquals(etapaDaPO({ cabecalho_consulta: { cEtapa: null } }), null);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## O que trava, e o que este PR entrega

O [spec da medição](docs/superpowers/specs/2026-08-13-reposicao-onorder-po-recebida-medicao.md) (#1714)
fechou a decisão — **receipt-first ledger** — e deixou **uma** pergunta bloqueando o desenho:

> As 244 POs já recebidas seguem em **etapa 15**. No fluxo NATIVO do Omie, associar itens da NF-e à PO
> move o pedido para "Recebido Parcialmente"/"Recebido". Então **ou** etapa-15 é um workflow paralelo ao
> estado nativo de recebimento, **ou** a associação item-a-item nunca é feita neste tenant.

Enquanto isso não for medido, `t4` não pode ser tratado como recebimento. Este PR entrega a **ferramenta
de medição**, não o ledger.

## A terceira hipótese — e por que ela muda a sonda

O Codex levantou uma explicação que o **próprio repo sustenta**, e que não estava no spec:
`omie-sync-nfes-recebidas` monta o vínculo PO↔NF-e a partir de `itensInfoAdic.nNumPedCompra` — uma
referência **textual** escrita pelo fornecedor no XML — e **não** dos ids nativos `nIdPedido`/
`nIdItPedido`. Verificado em `extractPedidosFromDetalhe`.

Se esse for o caso dominante, o `t4` do espelho é **inferência nossa**, não recebimento do Omie — e a
etapa-15 deixa de ser contradição. Medido junto: **nenhuma tabela do espelho guarda `nIdPedido`/
`nIdItPedido`**, então a ausência do vínculo aqui nunca provou ausência lá. Por isso a S2 não pergunta
"o campo existe?", e sim classifica **cada item** em: `native_exact`, `native_other_po`,
`native_sem_item`, `xml_hint_only`, `xml_hint_outra_po`, `product_only`, `unassociated`.

## Read-only por desenho, e uma correção de segurança

Não grava nada — nem no Omie, nem no banco. Não toca `sku_estoque_atual`, não toca o motor. Sem SQL de
decisão, então **`prove-sql-money-path` não se aplica** (nenhuma migration neste PR; se aparecer uma,
passa a valer).

**SSRF de credencial, fechado.** Na primeira versão deste PR, `candidatos_movimento[].endpoint` vinha do
corpo da requisição — e a edge manda `app_key`/`app_secret` no corpo de cada chamada. Quem invocasse a
sonda podia apontá-la para um host próprio e receber a credencial do ERP de produção. A allowlist de
método restringe o **verbo**, não o **destino**. Agora o destino é um enum fechado (`urlDoServico`) e
URL nunca é dado de entrada; a allowlist de método fica como segunda camada, porque no mesmo serviço
moram `AlterarRecebimento` e `ConcluirRecebimento`.

Não adotei a allowlist exata de pares (serviço, método) que o Codex sugeriu: descobrir método ainda não
catalogado **é** o trabalho da S3. Serviço fechado + método restrito a consulta preserva a descoberta
sem deixar a credencial sair do host do Omie.

## As 4 sondas

| # | Sonda | Fixa o contrato de |
|---|---|---|
| S1 | `ConsultarPedCompra` (id nativo) × `PesquisarPedCompra` espelhado — **diff de caminhos de chave** | o detalhe expõe recebimento por item que a listagem esconde? |
| S2 | `ConsultarRecebimento` por `nIdReceb` — **taxonomia de vínculo por item** + estado corrente | a associação item-a-item existe neste tenant, ou o `t4` é inferência nossa? |
| S3 | descoberta do contrato de **movimento de estoque**, em duas camadas | **o sinal que o ledger vai usar** |
| S4 | unidade, local e granularidade do saldo pendente | unidade-base × comercial; local no saldo |

## Decisões que definem o poder de discriminação

**O contrato é descoberto, não assumido** ("nome de endpoint não é contrato" — Codex). O núcleo puro
inventaria caminhos de chave, **localiza** a lista de itens onde quer que ela esteja — inclusive quando os
campos moram aninhados em `itensCabec`/`itensAjustes`/`itensInfoAdic` — e trata método inexistente como
`fault` (dado), não como crash.

**Presença de nome não é presença de valor.** `nIdPedido: 0` é como o Omie diz "não associado"; contar
isso como vínculo seria falso positivo no coração da medição. `idNativo()` trata zero em qualquer grafia
como ausência.

**`param: {}` é camada, não estratégia.** Camada A manda `{}` para colher a **taxonomia do fault** —
"falta o parâmetro obrigatório X" prova que o método existe e ainda nomeia o que ele quer. Camada B manda
produto, período e local **reais**, porque `{}` sozinho nunca mede a forma do dado.

**Controle positivo obrigatório.** `ListarPosEstoque` e `ListarSaldoPendente` entram com os params
verbatim de `omie-sync-estoque`. Sem controle, um fault genérico seria lido como "o Omie não expõe
movimento de estoque" — exatamente a conclusão errada que a sonda existe para evitar. De quebra, esses
dois provam sozinhos que no **mesmo** serviço convivem convenções de parâmetro diferentes
(`nPagina`/`nRegPorPagina` húngaro × `pagina`/`registros_por_pagina` snake_case PT).

**A amostra é por nota distinta.** Com 94% de consolidação, "as 3 POs mais recentes" pode selecionar três
POs da **mesma** nota e a S2 rodaria uma vez só. `escolherPorNotaDiversa` garante notas distintas e cobre
os dois extremos — a nota mais consolidada e a exclusiva.

## Errata ao spec (§8) — medida, não inferida

A distribuição do §3.2 ("171 notas 1:1") está correta, mas descreve **todas as 418 POs OBEN com nota** —
não as **244** que são alvo do desconto. No conjunto que importa:

| recorte | notas distintas | POs com nota exclusiva |
|---|---|---|
| todas as POs OBEN com nota | 230 | 171 (41%) |
| **as 244 POs alvo** | **68** | **14 (5,7%)** |

**94% das POs alvo dividem a nota com outra.** E das 14 exclusivas, só **12** continuam exclusivas ao
olhar a tabela inteira: a exclusividade muda **sem nenhum dado novo chegar**, apenas por ampliar o
`WHERE`. Isso mede empiricamente o que o Codex argumentou em tese ao derrubar o §3.4 — e mostra que
`receipt_allocation` N:N com quantidade nullable é a **forma dominante do dado**, não generalidade
defensiva.

**§8.1 — correção de tipo no M1.** O spec diz que `nQtdeRec` "é a string literal `"0"`". A conclusão
está certa e segue de pé (`0` em 100% dos 2.740 itens, nunca decrementa), mas `jsonb_typeof` devolve
**`number`** para `nQtdeRec` e `nQtde` em 2.740 de 2.740. Registro porque muda código: quem
implementar o parse do ledger a partir do M1 escreveria política de string onde o dado é número.

## Validação

- `test:edges` 721 ✅ · `edges:typecheck` ✅ · `typecheck` ✅ · `vitest` ✅ · `lint` ✅
- 48 testes Deno no núcleo puro, sem import remoto (`--no-remote`)
- **Falsificação** (3 invariantes sabotadas, cada uma vermelha nos testes certos):
  - "ausente vira zero" → derrubou 2 testes de `normalizarItemPO`
  - "faultstring só conta com faultcode" → derrubou o teste de fault sem faultcode
  - "aceitar `https://` cru em `urlDoServico`" → derrubou o teste de SSRF com
    `deveria negar: https://evil.example.com/`
- Funções puras rodadas contra **payload real** de PO vindo do banco: acha `produtos_consulta` (não
  `parcelas_consulta` nem `frete_consulta`), lê etapa 15 e normaliza o item corretamente.
- Erro tratado com `mensagemDeErro()` do `_shared` — o gate `erro-object-object-gate` (classe #1642)
  pegou os 5 sítios do idiom antigo antes do merge.

## Depois do merge

💬 **Precisa de deploy pelo chat do Lovable** (merge na main ≠ produção) — a edge **e** a entrada nova no
`supabase/config.toml`. Sem migration, sem Publish de frontend.

⚠️ Após o deploy, confirmar `git log -S omie-sonda-recebimento` antes de invocar — o sync bidirecional do
Lovable já reverteu edge por auto-commit "Changes" (#1076).
