### PR TITLE
fix(authz): o LIMIAR da faixa deixa de ser oráculo de custo — fecha a busca binária do #1543 [money-path]

### DIFF
--- a/db/test-farmer-config-limiar-faixa.sh
+++ b/db/test-farmer-config-limiar-faixa.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA — FU4-F fase 3b: a escrita dos limiares `margem_faixa_*` exige         ║
+# ║  `private.cap_custo_ler`, matando o oráculo de custo por busca binária.       ║
+# ║                                                                               ║
+# ║      bash db/test-farmer-config-limiar-faixa.sh > /tmp/t.log 2>&1; echo $?    ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                       ║
+# ║                                                                               ║
+# ║  Migration sob teste: 20260813150000_farmer_config_limiar_faixa_escrita_custo ║
+# ║  A RPC do #1543 é aplicada REAL (não stub) para provar o ataque ponta-a-ponta.║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="limiar-faixa"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# Falsificação: exige o valor EXATO que a sabotagem produz (ex.: 'amarelo'), nunca um "!= esperado".
+# Um `ne` aceitaria string vazia/erro como se fosse prova, e a sabotagem passaria por acidente.
+falsif() { if [ "$2" = "$3" ]; then ok "$1 (sabotagem produziu [$2], como exigido)"; else bad "$1 — a sabotagem NÃO produziu o vermelho esperado [$3], veio [$2]"; fi; }
+
+MASTER='11111111-1111-1111-1111-111111111111'   # app_role master           → cap_custo_ler TRUE
+ATACA='22222222-2222-2222-2222-222222222222'    # employee + farmer         → cap_custo_ler FALSE
+ESTRAT='33333333-3333-3333-3333-333333333333'   # employee + estrategico    → cap_custo_ler TRUE
+CLI='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'      # cliente alvo, margem 42%
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (definições REAIS de prod para has_role e cap_custo_ler)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+CREATE TYPE public.app_role AS ENUM ('employee','customer','master');
+CREATE TYPE public.commercial_role AS ENUM
+  ('operacional','gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE public.commercial_roles (user_id uuid NOT NULL, commercial_role public.commercial_role NOT NULL);
+
+-- VERBATIM de prod (pg_get_functiondef, 2026-08-13)
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role app_role)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $function$;
+
+-- VERBATIM de prod (pg_get_functiondef, 2026-08-13) — é O gate sob teste, não pode ser stub
+CREATE OR REPLACE FUNCTION private.cap_custo_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT COALESCE(
+    _uid IS NOT NULL
+    AND (
+      public.has_role(_uid, 'master'::public.app_role)
+      OR (
+        public.has_role(_uid, 'employee'::public.app_role)
+        AND EXISTS (
+          SELECT 1 FROM public.commercial_roles cr
+           WHERE cr.user_id = _uid
+             AND cr.commercial_role IN ('estrategico','super_admin')
+        )
+      )
+    ), false);
+$function$;
+
+-- Dependências da RPC do #1543 que NÃO são o objeto sob teste → stub honesto.
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$ SELECT public.has_role(_uid,'master'::public.app_role)
+                  OR public.has_role(_uid,'employee'::public.app_role) $function$;
+
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_cliente uuid, _uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $function$ SELECT true $function$;
+
+CREATE TABLE private.margem_seed (customer_user_id uuid, margem_pct numeric);
+CREATE OR REPLACE FUNCTION private.margem_cliente_agregada()
+ RETURNS TABLE(customer_user_id uuid, margem_pct numeric) LANGUAGE sql STABLE SECURITY DEFINER
+AS $function$ SELECT s.customer_user_id, s.margem_pct FROM private.margem_seed s $function$;
+
+-- A tabela real + as DUAS policies permissivas VERBATIM de prod (pg_policy, 2026-08-13).
+CREATE TABLE public.farmer_algorithm_config (
+  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  key text NOT NULL UNIQUE,
+  value numeric NOT NULL,
+  description text,
+  updated_at timestamptz DEFAULT now()
+);
+ALTER TABLE public.farmer_algorithm_config ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Staff can view algorithm config" ON public.farmer_algorithm_config FOR SELECT
+  USING ((public.has_role(auth.uid(), 'master'::public.app_role) OR public.has_role(auth.uid(), 'employee'::public.app_role)));
+CREATE POLICY "Staff can manage algorithm config" ON public.farmer_algorithm_config FOR ALL
+  USING ((public.has_role(auth.uid(), 'master'::public.app_role) OR public.has_role(auth.uid(), 'employee'::public.app_role)))
+  WITH CHECK ((public.has_role(auth.uid(), 'master'::public.app_role) OR public.has_role(auth.uid(), 'employee'::public.app_role)));
+
+-- Espelha o GRANT de prod ANTES da migration (medido: authenticated e anon têm arwdDxtm, o `D`
+-- é TRUNCATE). Tem de vir antes, senão a migration revogaria e o seed reconcederia depois,
+-- e o assert de TRUNCATE ficaria verde por ordem de execução, não por efeito da migration.
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON public.farmer_algorithm_config TO authenticated, anon;
+SQL
+
+# A RPC do #1543 — REAL, para provar o ataque ponta-a-ponta (e pegar late-bound de plpgsql)
+P -q -f "$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+echo "pré-requisito aplicado: RPC real do #1543"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — A MIGRATION SOB TESTE (Lei #1: o .sql commitado)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260813150000_farmer_config_limiar_faixa_escrita_custo.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# IDEMPOTÊNCIA — o apply é MANUAL (founder cola no SQL Editor do Lovable) e re-colar após falha
+# parcial é rotina. O segundo Run TEM de passar limpo (Lei do lovable-db-operator).
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  IDEM_OK=1
+else
+  IDEM_OK=0
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED + GRANTS (espelha o grant de prod: authenticated tem DML na tabela)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$MASTER'),('$ATACA'),('$ESTRAT'),('$CLI') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id,role) VALUES
+  ('$MASTER','master'),('$ATACA','employee'),('$ESTRAT','employee');
+INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES
+  ('$ATACA','farmer'),('$ESTRAT','estrategico');
+-- margem do alvo = 42% → com piso 30 é 'verde'; se o piso subir p/ 45 vira 'amarelo'
+INSERT INTO private.margem_seed VALUES ('$CLI', 42.0),
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 10.0),
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 80.0);
+INSERT INTO public.farmer_algorithm_config(key,value) VALUES ('health_w_m', 0.20);
+SQL
+
+# helper: roda SQL como um usuário autenticado (GUC do JWT + SET ROLE).
+# `-q` é obrigatório: sem ele o psql ecoa a tag de comando de cada `SET`, o ruído entra na
+# comparação e um assert de desigualdade passaria por causa do ruído, não do efeito.
+as_auth() { Pq -q -c "SET test.uid='$1'; SET ROLE authenticated; $2"; }
+# helper: faixa que a RPC devolve para o cliente alvo, na visão de <uid>
+faixa_de() { as_auth "$1" "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';"; }
+piso()     { Pq -c "SELECT value::text FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';"; }
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts: estado inicial ──"
+eq "I0 migration é idempotente (2º apply limpo — o founder re-cola no SQL Editor)" "$IDEM_OK" "1"
+eq "I1 o 2º apply não duplicou policy" \
+   "$(Pq -c "SELECT count(*)::text FROM pg_policy WHERE polrelid='public.farmer_algorithm_config'::regclass AND polname LIKE 'limiar\_faixa\_%';")" "3"
+eq "S0 seed criou o piso" "$(piso)" "30"
+eq "S1 seed criou a meta" "$(Pq -c "SELECT value::text FROM public.farmer_algorithm_config WHERE key='margem_faixa_meta_pct';")" "50"
+
+echo "── asserts POSITIVOS (não quebrei quem escreve legitimamente) ──"
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET value=0.25 WHERE key='health_w_m';" >/dev/null
+eq "P1 employee SEM cap ainda ajusta PESO (health_w_m)" \
+   "$(Pq -c "SELECT value::text FROM public.farmer_algorithm_config WHERE key='health_w_m';")" "0.25"
+
+as_auth "$ATACA" "INSERT INTO public.farmer_algorithm_config(key,value) VALUES ('hs_weight_recency',25);" >/dev/null
+eq "P2 employee SEM cap ainda INSERE peso novo (hs_weight_recency)" \
+   "$(Pq -c "SELECT value::text FROM public.farmer_algorithm_config WHERE key='hs_weight_recency';")" "25"
+
+as_auth "$MASTER" "UPDATE public.farmer_algorithm_config SET value=31 WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "P3 MASTER escreve o limiar" "$(piso)" "31"
+
+as_auth "$ESTRAT" "UPDATE public.farmer_algorithm_config SET value=30 WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "P4 employee COM cap (estrategico) escreve o limiar — o gate é cap_custo_ler, não master" \
+   "$(piso)" "30"
+
+echo "── asserts NEGATIVOS (a defesa morde) ──"
+# UPDATE/DELETE negados por USING não levantam erro: a linha simplesmente não é vista.
+# Por isso estes asserts leem o ESTADO, não esperam exceção.
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET value=45 WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "N1 employee SEM cap NÃO altera o valor do limiar" "$(piso)" "30"
+
+as_auth "$ATACA" "DELETE FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "N2 employee SEM cap NÃO apaga o limiar (apagar = voltar ao default 30)" \
+   "$(Pq -c "SELECT count(*)::text FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';")" "1"
+
+# O desvio lateral que SÓ o USING pega: renomear a key faz a linha sumir do namespace protegido,
+# e a RPC volta ao COALESCE default. Com WITH CHECK sozinho isto PASSARIA.
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET key='zzz_neutralizado' WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "N3 employee SEM cap NÃO renomeia a key para fora do namespace protegido" \
+   "$(Pq -c "SELECT count(*)::text FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';")" "1"
+
+# INSERT negado por WITH CHECK levanta 42501 → aqui sim, padrão SQLSTATE + re-raise.
+# Sentinelas ASCII, caixa fixa, sem substring comum entre si e ausentes do texto do Postgres.
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$ATACA'; SET ROLE authenticated;
+DO \$\$
+BEGIN
+  INSERT INTO public.farmer_algorithm_config(key,value) VALUES ('margem_faixa_terceiro_pct', 7);
+  RAISE NOTICE 'VEREDITO_ACEITOU_A_ESCRITA';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'VEREDITO_RECUSOU_42501';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+if printf '%s' "$R" | command grep -qF 'VEREDITO_RECUSOU_42501'; then
+  ok "N4 employee SEM cap NÃO cria key nova no namespace (42501, prefixo cobre chave futura)"
+else
+  bad "N4 INSERT de key margem_faixa_* nova não foi barrado com 42501 — veio: $(printf '%s' "$R" | tr '\n' ' ' | cut -c1-200)"
+fi
+
+echo "── asserts MONEY-PATH: o oráculo de busca binária ──"
+eq "M0 a RPC não projeta o número para quem não tem cap" \
+   "$(as_auth "$ATACA" "SELECT coalesce(margem_pct::text,'NULL') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';")" "NULL"
+eq "M1 faixa inicial do alvo (margem 42, piso 30)" "$(faixa_de "$ATACA")" "verde"
+
+# CONTRAPROVA — sem ela, M3 passaria por vacuidade (se a RPC ignorasse o limiar, a faixa nunca
+# mudaria e o teste ficaria verde mesmo com a policy ausente). Aqui o oráculo é EXERCIDO por quem
+# pode: mover o piso 30→45 realmente vira a faixa do cliente de verde para amarelo.
+as_auth "$MASTER" "UPDATE public.farmer_algorithm_config SET value=45 WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "M2 CONTRAPROVA: com o limiar em 45, a faixa do alvo VIRA amarelo (o oráculo é real)" \
+   "$(faixa_de "$MASTER")" "amarelo"
+as_auth "$MASTER" "UPDATE public.farmer_algorithm_config SET value=30 WHERE key='margem_faixa_piso_pct';" >/dev/null
+
+# O ATAQUE: o employee sem cap tenta a mesma sonda que o master acabou de exercer com sucesso.
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET value=45 WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "M3 ATAQUE: employee SEM cap move o piso e a faixa NÃO se move — sonda morta" \
+   "$(faixa_de "$ATACA")" "verde"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3: sabota → exige VERMELHO → restaura)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação (cada sabotagem TEM de produzir vermelho) ──"
+
+# S1 — sem a policy de UPDATE, o ataque M3 volta a funcionar.
+P -q -c 'DROP POLICY "limiar_faixa_margem_update_exige_cap_custo" ON public.farmer_algorithm_config;'
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET value=45 WHERE key='margem_faixa_piso_pct';" >/dev/null
+falsif "S1 sabotagem (drop policy UPDATE) reabre o oráculo: a sonda do atacante move a faixa" \
+   "$(faixa_de "$ATACA")" "amarelo"
+as_auth "$MASTER" "UPDATE public.farmer_algorithm_config SET value=30 WHERE key='margem_faixa_piso_pct';" >/dev/null
+
+# S2 — o assert do desvio lateral (N3) só tem dente por causa do USING. Recria a policy de UPDATE
+# SÓ com WITH CHECK: o rename passa a ser aceito e a key protegida some.
+P -q <<'SQL'
+CREATE POLICY "limiar_faixa_margem_update_exige_cap_custo"
+  ON public.farmer_algorithm_config AS RESTRICTIVE FOR UPDATE
+  WITH CHECK (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+SQL
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET key='zzz_neutralizado' WHERE key='margem_faixa_piso_pct';" >/dev/null
+falsif "S2 sabotagem (UPDATE sem USING) deixa o rename passar — prova que o USING não é decorativo" \
+   "$(Pq -c "SELECT count(*)::text FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';")" "0"
+# restaura cirurgicamente: renomeia de volta e recria a policy verdadeira
+P -q <<'SQL'
+UPDATE public.farmer_algorithm_config SET key='margem_faixa_piso_pct' WHERE key='zzz_neutralizado';
+DROP POLICY "limiar_faixa_margem_update_exige_cap_custo" ON public.farmer_algorithm_config;
+CREATE POLICY "limiar_faixa_margem_update_exige_cap_custo"
+  ON public.farmer_algorithm_config AS RESTRICTIVE FOR UPDATE
+  USING (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  )
+  WITH CHECK (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+SQL
+
+# S3 — sem a policy de INSERT, a key nova entra (o caminho VIVO hoje, já que as keys não existiam).
+P -q -c 'DROP POLICY "limiar_faixa_margem_insert_exige_cap_custo" ON public.farmer_algorithm_config;'
+R2=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$ATACA'; SET ROLE authenticated;
+DO \$\$
+BEGIN
+  INSERT INTO public.farmer_algorithm_config(key,value) VALUES ('margem_faixa_terceiro_pct', 7);
+  RAISE NOTICE 'VEREDITO_ACEITOU_A_ESCRITA';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'VEREDITO_RECUSOU_42501';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+if printf '%s' "$R2" | command grep -qF 'VEREDITO_ACEITOU_A_ESCRITA'; then
+  ok "S3 sabotagem (drop policy INSERT) deixa a key nova entrar — assert N4 tem dente"
+else
+  bad "S3 a sabotagem do INSERT não produziu vermelho: N4 passaria de qualquer jeito"
+fi
+P -q <<'SQL'
+DELETE FROM public.farmer_algorithm_config WHERE key='margem_faixa_terceiro_pct';
+CREATE POLICY "limiar_faixa_margem_insert_exige_cap_custo"
+  ON public.farmer_algorithm_config AS RESTRICTIVE FOR INSERT
+  WITH CHECK (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+SQL
+
+# S4 — sem a policy de DELETE, apagar o limiar volta a funcionar (reseta ao default).
+P -q -c 'DROP POLICY "limiar_faixa_margem_delete_exige_cap_custo" ON public.farmer_algorithm_config;'
+as_auth "$ATACA" "DELETE FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';" >/dev/null
+falsif "S4 sabotagem (drop policy DELETE) deixa apagar o limiar" \
+   "$(Pq -c "SELECT count(*)::text FROM public.farmer_algorithm_config WHERE key='margem_faixa_piso_pct';")" "0"
+P -q <<'SQL'
+INSERT INTO public.farmer_algorithm_config(key,value) VALUES ('margem_faixa_piso_pct',30) ON CONFLICT DO NOTHING;
+CREATE POLICY "limiar_faixa_margem_delete_exige_cap_custo"
+  ON public.farmer_algorithm_config AS RESTRICTIVE FOR DELETE
+  USING (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+SQL
+
+echo "── re-verificação pós-restauro (a versão verdadeira voltou inteira) ──"
+as_auth "$ATACA" "UPDATE public.farmer_algorithm_config SET value=45 WHERE key='margem_faixa_piso_pct';" >/dev/null
+eq "R1 pós-falsificação o ataque segue morto" "$(faixa_de "$ATACA")" "verde"
+eq "R2 pós-falsificação o limiar segue 30" "$(piso)" "30"
+
+# ── TRUNCATE: a RLS NÃO o intercepta; quem barra é o REVOKE da migration ──────────────────────
+# Deixado por último de propósito: se passar, a tabela esvazia e contaminaria os outros asserts.
+echo "── assert TRUNCATE (fora do alcance da RLS) ──"
+trunca_como_atacante() {
+  P -tA 2>&1 <<SQL || true
+SET test.uid='$ATACA'; SET ROLE authenticated;
+DO \$\$
+BEGIN
+  TRUNCATE public.farmer_algorithm_config;
+  RAISE NOTICE 'VEREDITO_A_TABELA_FOI_ESVAZIADA';
+EXCEPTION
+  WHEN insufficient_privilege THEN RAISE NOTICE 'VEREDITO_SEM_PRIVILEGIO_DE_TRUNCATE';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+}
+if printf '%s' "$(trunca_como_atacante)" | command grep -qF 'VEREDITO_SEM_PRIVILEGIO_DE_TRUNCATE'; then
+  ok "T1 employee SEM cap não TRUNCA a config (o REVOKE pega o que a RLS não vê)"
+else
+  bad "T1 TRUNCATE não foi barrado — as 3 policies viram decoração: truncar reseta o limiar ao default"
+fi
+
+# S5 — devolve o privilégio e exige que o truncate volte a passar (senão T1 passaria de graça,
+# por a role nunca ter tido TRUNCATE, e não por causa do REVOKE da migration).
+P -q -c 'GRANT TRUNCATE ON public.farmer_algorithm_config TO authenticated;'
+if printf '%s' "$(trunca_como_atacante)" | command grep -qF 'VEREDITO_A_TABELA_FOI_ESVAZIADA'; then
+  ok "S5 sabotagem (re-GRANT de TRUNCATE) esvazia a tabela — T1 tem dente"
+else
+  bad "S5 re-conceder TRUNCATE não permitiu truncar: T1 passaria mesmo sem o REVOKE"
+fi
+
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,11 +21,11 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **458** custom migrations totais
-- **1573** objetos esperados (criados por estas migrations)
+- **459** custom migrations totais
+- **1576** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 469
-  - `rls_policy`: 392
+  - `rls_policy`: 395
   - `index`: 238
   - `cron_job`: 164
   - `table`: 153
@@ -3839,6 +3839,14 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.criar_plano_tatico` | — |
+
+### `20260813150000_farmer_config_limiar_faixa_escrita_custo.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `rls_policy` | `public.limiar_faixa_margem_insert_exige_cap_custo` | `farmer_algorithm_config` |
+| `rls_policy` | `public.limiar_faixa_margem_update_exige_cap_custo` | `farmer_algorithm_config` |
+| `rls_policy` | `public.limiar_faixa_margem_delete_exige_cap_custo` | `farmer_algorithm_config` |
 
 ### `20260813195914_reposicao_pos_candidatos_guard_temporal.sql`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 458
+-- Total de custom migrations: 459
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -499,6 +499,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260807223000', 'check_finitude_money_path', '20260807223000_check_finitude_money_path.sql'),
   ('20260808012000', 'atp_reconciliacao_fase3', '20260808012000_atp_reconciliacao_fase3.sql'),
   ('20260808020000', 'tactical_plan_idempotencia_janela', '20260808020000_tactical_plan_idempotencia_janela.sql'),
+  ('20260813150000', 'farmer_config_limiar_faixa_escrita_custo', '20260813150000_farmer_config_limiar_faixa_escrita_custo.sql'),
   ('20260813195914', 'reposicao_pos_candidatos_guard_temporal', '20260813195914_reposicao_pos_candidatos_guard_temporal.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
@@ -2061,6 +2062,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('atp_reconciliacao_fase3', 'index', 'public', 'idx_estoque_reservas_pedido_ativa', 'estoque_reservas'),
   ('atp_reconciliacao_fase3', 'cron_job', 'cron', 'atp-reconciliar', ''),
   ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', ''),
+  ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_insert_exige_cap_custo', 'farmer_algorithm_config'),
+  ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_update_exige_cap_custo', 'farmer_algorithm_config'),
+  ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_delete_exige_cap_custo', 'farmer_algorithm_config'),
   ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', '')
 ),
 obj_status AS (
@@ -3671,6 +3675,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('atp_reconciliacao_fase3', 'index', 'public', 'idx_estoque_reservas_pedido_ativa', 'estoque_reservas'),
   ('atp_reconciliacao_fase3', 'cron_job', 'cron', 'atp-reconciliar', ''),
   ('tactical_plan_idempotencia_janela', 'function', 'public', 'criar_plano_tatico', ''),
+  ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_insert_exige_cap_custo', 'farmer_algorithm_config'),
+  ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_update_exige_cap_custo', 'farmer_algorithm_config'),
+  ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_delete_exige_cap_custo', 'farmer_algorithm_config'),
   ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', '')
 )
 SELECT

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -197,6 +197,30 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // populacional (H1), K4 o WHERE de escopo (E1), K5 o `g` NULL virando 0 (H5); K6 é o canário
   // que prova que a migration íntegra voltou. `sed` que não casa nada FALHA o harness, em vez
   // de deixá-lo verde com uma sabotagem que nunca aconteceu.
+  //
+  // 2026-08-13 — fase 3b: o gate de PROJEÇÃO só vale se o LIMIAR não for escrevível por quem ele
+  // barra. `v_piso`/`v_meta` vêm de `public.farmer_algorithm_config` (keys `margem_faixa_*`), e
+  // essa tabela era escrita por QUALQUER staff (policy FOR ALL master OR employee + DML de
+  // `authenticated`): mover o piso e reler a FAIXA é uma comparação por chamada, e ~13 delas
+  // reconstroem a margem por busca binária — o número saía pelo canal lateral que o `CASE WHEN
+  // v_pode_num` fechava. Corrigido por 3 policies RESTRICTIVE (INSERT/UPDATE/DELETE) em
+  // `farmer_algorithm_config` gateadas pelo MESMO `private.cap_custo_ler` — quem já lê o número
+  // não ganha nada movendo o limiar, então esse é o corte exato (e não `has_role(master)`, que
+  // criaria um segundo eixo de autorização divergente deste). O SELECT fica aberto de propósito.
+  // ⚠️ Lição transferível: um gate de PROJEÇÃO é derrotado por qualquer entrada ESCREVÍVEL que
+  // mude o veredito exposto. Ao fechar um número atrás de um cap, feche também os PARÂMETROS que
+  // decidem o sinal que continua saindo.
+  // ⚠️ TRUNCATE não passa por RLS — policy nenhuma o vê. `authenticated` o tinha nesta tabela
+  // (o `D` do `arwdDxtm` default do Supabase), e truncar apagaria os limiares devolvendo a RPC
+  // ao COALESCE default: as 3 policies viravam decoração sem serem violadas. Revogado por NOME
+  // na mesma migration. Ao fechar escrita por RLS, cheque TRUNCATE — a RLS não o cobre.
+  // (Não era alcançável pelo browser: o PostgREST não tem verbo de TRUNCATE.)
+  // Provado em db/test-farmer-config-limiar-faixa.sh (22 asserts): aplica a RPC real do #1543,
+  // exerce o ataque ponta-a-ponta (M3) e traz a CONTRAPROVA (M2 — o master move o limiar e a
+  // faixa VIRA amarelo), sem a qual M3 passaria por vacuidade. 4 sabotagens exigem o vermelho
+  // exato, incluindo "UPDATE sem USING" (S2), que prova que o USING não é decorativo: só com
+  // WITH CHECK, `SET key='outra' WHERE key='margem_faixa_piso_pct'` some com a key protegida e
+  // devolve o limiar ao default.
   'public.get_carteira_margem_faixa',
 ]);
 

--- a/supabase/migrations/20260813150000_farmer_config_limiar_faixa_escrita_custo.sql
+++ b/supabase/migrations/20260813150000_farmer_config_limiar_faixa_escrita_custo.sql
@@ -1,0 +1,176 @@
+-- FU4-F fase 3b — o LIMIAR da faixa deixa de ser um oráculo de custo.
+--
+-- ── O PROBLEMA (medido em prod 2026-08-13; achado por revisão adversarial no #1543) ──────────
+-- O #1543 fechou o NÚMERO: `public.get_carteira_margem_faixa()` devolve a FAIXA sempre e
+-- `margem_pct` só sob `private.cap_custo_ler`. Mas a faixa é decidida por dois limiares LIDOS
+-- de `public.farmer_algorithm_config`:
+--
+--     WHEN b.pct < v_piso  THEN 'amarelo'   -- v_piso  = key 'margem_faixa_piso_pct'
+--     WHEN b.pct < v_meta  THEN 'abaixo_da_meta'  -- v_meta = key 'margem_faixa_meta_pct'
+--
+-- ...e essa tabela é escrita por QUALQUER staff. Medido:
+--   • policy `Staff can manage algorithm config` = FOR ALL, USING e WITH CHECK
+--     `has_role(master) OR has_role(employee)`;
+--   • `has_table_privilege('authenticated', ..., 'INSERT'/'UPDATE'/'DELETE')` = true.
+--
+-- Logo o gate de PROJEÇÃO é derrotável por BUSCA BINÁRIA. Um employee sem `cap_custo_ler`:
+--   1. escreve `margem_faixa_piso_pct = X`;
+--   2. chama a RPC e olha se o cliente virou `amarelo` (margem < X) ou seguiu `verde`;
+--   3. repete ~13 vezes → recupera a margem com precisão arbitrária.
+-- Como ele já vê a receita do cliente, `custo = receita × (1 − margem)`. O #1543 escondeu o
+-- número na SAÍDA; o limiar o devolvia por um canal lateral — cada chamada é uma comparação, e
+-- comparações bastam para reconstruir o valor.
+--
+-- `motivo` amplia a sonda (devolve os DOIS limiares por chamada: `abaixo_do_piso` vs
+-- `abaixo_da_meta` vs `saudavel`), mas não muda a natureza do furo: o que vaza é a ESCRITA.
+--
+-- ── A DECISÃO: quem escreve o limiar é quem JÁ PODE VER O NÚMERO ─────────────────────────────
+-- O gate desta migration é `private.cap_custo_ler(auth.uid())` — o MESMO predicado do gate de
+-- projeção da RPC — e não `has_role(master)`. Duas razões:
+--
+--   1. É o corte exato do ataque. O oráculo só tem valor para quem NÃO pode ler `margem_pct`;
+--      para quem já lê o número, mover o limiar não revela absolutamente nada. Gatear por
+--      `master` fecharia o furo, mas por uma coincidência (hoje `cap_custo_ler` ⊇ master), não
+--      pelo motivo certo.
+--   2. Não cria um segundo eixo de autorização. Com `cap_custo_ler`, "ver custo" e "calibrar a
+--      régua de custo" continuam sendo UM conceito: no dia em que o dono conceder
+--      `commercial_role = 'estrategico'` a alguém, essa pessoa ganha os dois de forma coerente,
+--      sem uma segunda migration. Com `master` hardcoded, os dois eixos divergiriam em silêncio.
+--
+-- Hoje em prod os dois recortes coincidem (`cap_custo_ler` = master OR employee com
+-- `estrategico`/`super_admin`; medido: 1 master, 2 employees, ZERO `estrategico`/`super_admin`),
+-- então o efeito imediato é idêntico a "só o master escreve" — a diferença é de DESENHO.
+--
+-- ── POR QUE NÃO QUEBRA QUEM AJUSTA OS PESOS (levantado antes de escrever) ────────────────────
+-- Os dois escritores da tabela no front:
+--   • `src/pages/GovernanceMathParams.tsx` — grava SÓ `hs_weight_*` / `ps_weight_*` (as listas
+--     `HEALTH_WEIGHTS`/`PRIORITY_WEIGHTS` são fixas no código). Nenhuma casa `margem_faixa_%`.
+--   • `src/hooks/useFarmerGovernance.ts::approveProposal` — grava as keys de uma proposta
+--     aprovada (arbitrárias). Tabela `farmer_governance_proposals` está VAZIA em prod.
+-- Ambos já gateiam na UI por `commercial_role = 'super_admin'`, que NINGUÉM tem em prod — e
+-- `farmer_audit_log` tem ZERO linhas com `entity_type='algorithm_config'`. Ou seja: nenhuma
+-- escrita legítima existe hoje, e as que o desenho prevê (pesos) seguem livres para todo staff.
+--
+-- ── FORMA: policy RESTRICTIVE por comando ────────────────────────────────────────────────────
+-- RESTRICTIVE é AND-ed com as permissivas existentes (que ficam intactas — menos risco de
+-- regressão que reescrever `Staff can manage algorithm config`), e falha FECHADA.
+-- Uma policy por comando, de propósito, para NÃO tocar o SELECT: `FOR ALL` restritiva também
+-- filtraria leitura, e `GovernanceMathParams` faz `select('*')` na tabela inteira.
+--
+-- Os três comandos são necessários — fechar só o UPDATE deixa o oráculo de pé:
+--   • INSERT — as keys HOJE NÃO EXISTEM (a RPC cai no COALESCE 30/50), então o atacante
+--              criaria a linha do zero. Este é o caminho vivo hoje, não o UPDATE.
+--   • UPDATE — precisa de USING **e** WITH CHECK. Só WITH CHECK deixaria passar o desvio
+--              lateral `SET key='outra' WHERE key='margem_faixa_piso_pct'`: a linha resultante
+--              não casa o predicado, o WITH CHECK aprova, e a key de faixa SOME — devolvendo o
+--              limiar ao default 30 sem nunca ter escrito uma linha de faixa.
+--   • DELETE — mesma classe do rename: apagar a linha reseta o limiar para o default.
+--
+-- `service_role` e `postgres` têm BYPASSRLS (medido) → edges e a própria RPC (SECURITY DEFINER,
+-- owner=postgres) não são afetadas.
+--
+-- ⚠️ Grants de tabela de `anon` NÃO são tocados aqui: `db/audit-anon-dml-bypass.sh` registra a
+-- decisão do repo de não revogar em massa (é o modelo do Supabase — grant amplo + RLS). `anon`
+-- já é barrado pelas policies permissivas (`auth.uid()` IS NULL → `has_role` false).
+--
+-- Prova: `db/test-farmer-config-limiar-faixa.sh` (PG17 local, asserts negativos com SQLSTATE +
+-- re-raise, RLS sob SET ROLE authenticated + GUC, e 4 sabotagens exigindo vermelho).
+
+BEGIN;
+
+-- ── 1) As linhas de limiar passam a EXISTIR ──────────────────────────────────────────────────
+-- Hoje ausentes: a RPC vinha caindo no `COALESCE(..., 30)` / `COALESCE(..., 50)`. Semear com
+-- exatamente esses valores é um NO-OP de comportamento (a faixa de todo mundo continua igual),
+-- e torna o limiar auditável e ajustável sem deploy — que é o desenho do spec.
+-- Os valores 30/50 foram medidos em prod (spec 2026-07-20 §3.1b, 746 clientes com margem).
+-- `DO NOTHING` e não `DO UPDATE`: se a linha já existir por qualquer motivo, um re-apply da
+-- migration não pode sobrescrever calibragem legítima. A validação pós-apply confere o valor.
+--
+-- ⚠️ EFEITO DURADOURO (não é no-op para sempre): a partir daqui o BANCO é a fonte efetiva desses
+-- limiares. Se um dia o `COALESCE` da RPC mudar para 35/55, as linhas persistidas em 30/50
+-- continuarão vencendo, e o default no código vira letra morta. Quem mexer no default da RPC
+-- precisa mexer nestas linhas junto — ou a mudança não terá efeito nenhum.
+INSERT INTO public.farmer_algorithm_config (key, value, description) VALUES
+  ('margem_faixa_piso_pct', 30,
+   'FU4-F: margem agregada abaixo deste % => faixa amarelo (motivo abaixo_do_piso). '
+   'Escrita gateada por private.cap_custo_ler: o limiar e um oraculo do custo.'),
+  ('margem_faixa_meta_pct', 50,
+   'FU4-F: margem agregada abaixo deste % => verde/abaixo_da_meta; acima => verde/saudavel. '
+   'Escrita gateada por private.cap_custo_ler: o limiar e um oraculo do custo.')
+ON CONFLICT (key) DO NOTHING;
+
+-- ── 2) A escrita das linhas de limiar exige o cap de custo ───────────────────────────────────
+-- Predicado por PREFIXO e não por lista de keys: uma terceira chave de faixa criada amanhã nasce
+-- protegida, sem precisar lembrar de editar a policy. O namespace `margem_faixa_` é o CONTRATO —
+-- qualquer key sob ele exige o cap por definição. O preço dessa escolha é conhecido: uma chave
+-- sensível batizada fora do prefixo (`margem_piso_novo`) nasceria DESPROTEGIDA. Por isso o
+-- COMMENT ON TABLE abaixo declara o namespace, em vez de deixá-lo como convenção tácita.
+--
+-- `ESCAPE '!'` explícito: `_` é wildcard no LIKE e escapá-lo com `\` depende do escape DEFAULT do
+-- Postgres. Declarar o escape torna o predicado independente dessa regra — sem isso, um dia com
+-- `standard_conforming_strings` diferente o `_` voltaria a casar qualquer caractere (o predicado
+-- ficaria mais FROUXO, nunca mais restrito).
+--
+-- `(SELECT ...)` envolvendo a chamada: forma que o planner avalia como InitPlan único por
+-- instrução, em vez de uma chamada por linha num UPDATE em lote.
+--
+-- NULL-safety: `key` é NOT NULL, mas o predicado é fail-closed por construção — se `key` fosse
+-- NULL, `NOT (NULL LIKE ...)` → NULL, e `NULL OR false` → NULL → a policy NEGA.
+
+-- `DROP ... IF EXISTS` antes de cada `CREATE`: o apply é MANUAL (SQL Editor do Lovable) e
+-- re-colar o bloco após uma falha parcial é rotina — sem isso o segundo Run morre em 42710.
+DROP POLICY IF EXISTS "limiar_faixa_margem_insert_exige_cap_custo" ON public.farmer_algorithm_config;
+CREATE POLICY "limiar_faixa_margem_insert_exige_cap_custo"
+  ON public.farmer_algorithm_config
+  AS RESTRICTIVE FOR INSERT
+  WITH CHECK (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+
+DROP POLICY IF EXISTS "limiar_faixa_margem_update_exige_cap_custo" ON public.farmer_algorithm_config;
+CREATE POLICY "limiar_faixa_margem_update_exige_cap_custo"
+  ON public.farmer_algorithm_config
+  AS RESTRICTIVE FOR UPDATE
+  USING (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  )
+  WITH CHECK (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+
+DROP POLICY IF EXISTS "limiar_faixa_margem_delete_exige_cap_custo" ON public.farmer_algorithm_config;
+CREATE POLICY "limiar_faixa_margem_delete_exige_cap_custo"
+  ON public.farmer_algorithm_config
+  AS RESTRICTIVE FOR DELETE
+  USING (
+    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
+    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
+  );
+
+-- ── 3) TRUNCATE: o buraco que a RLS não tapa ────────────────────────────────────────────────
+-- RLS **não se aplica a TRUNCATE** — nenhuma policy acima o intercepta. Medido em prod:
+-- `has_table_privilege('authenticated', ..., 'TRUNCATE')` = true (o grant `arwdDxtm` que o
+-- Supabase concede por default privilege inclui o `D`). Um TRUNCATE apagaria as linhas de limiar
+-- e a RPC voltaria ao `COALESCE` default — anulando as policies acima sem violá-las.
+--
+-- Alcance honesto: NÃO é explorável pelo browser. O PostgREST não tem verbo para TRUNCATE, então
+-- o employee com JWT não o alcança por HTTP; seria preciso conexão SQL direta, que ele não tem.
+-- Revogar é defense-in-depth barato (nenhum caminho legítimo trunca config de algoritmo) e
+-- fecha a classe inteira em vez de só o vetor conhecido.
+--
+-- Revogado POR NOME: `REVOKE ... FROM PUBLIC` seria no-op aqui — o Supabase concede às roles
+-- nomeadas, não via PUBLIC (regra do repo). Só TRUNCATE sai; SELECT/INSERT/UPDATE/DELETE ficam,
+-- porque é a RLS que os governa e revogá-los quebraria o app (`db/audit-anon-dml-bypass.sh`
+-- registra a decisão de não revogar DML em massa — o modelo do Supabase é grant amplo + RLS).
+REVOKE TRUNCATE ON public.farmer_algorithm_config FROM authenticated, anon;
+
+COMMENT ON TABLE public.farmer_algorithm_config IS
+  'Parametros do algoritmo do farmer (key/value numerico). Os pesos (hs_weight_*, ps_weight_*, '
+  'health_w_*, priority_w_*) sao escrita livre de staff. As keys margem_faixa_* sao EXCECAO: '
+  'a escrita delas exige private.cap_custo_ler, porque mover o limiar e chamar '
+  'get_carteira_margem_faixa reconstroi a margem por busca binaria (oraculo de custo).';
+
+COMMIT;


### PR DESCRIPTION
Fecha a via que a revisão adversarial do #1543 deixou declarada em "O que este PR NÃO fecha": o gate de **projeção** do número era derrotável por **busca binária no limiar**.

## O ataque (medido em prod 2026-08-13, via psql-ro)

`get_carteira_margem_faixa()` decide a faixa comparando a margem com dois limiares lidos de `farmer_algorithm_config` — e essa tabela era escrita por **qualquer staff**:

- policy `Staff can manage algorithm config` = `FOR ALL` para `has_role(master) OR has_role(employee)`;
- `has_table_privilege('authenticated', ..., 'INSERT'/'UPDATE'/'DELETE')` = `true`.

Então um employee **sem** `cap_custo_ler` escrevia `margem_faixa_piso_pct = X`, chamava a RPC e via se o cliente virou `amarelo`. Cada chamada é uma comparação; ~13 delas recuperam a margem. Com a receita à vista, `custo = receita × (1 − margem)`. O #1543 escondeu o número na **saída**; o limiar o devolvia por um canal lateral.

## A correção

3 policies **RESTRICTIVE** (INSERT/UPDATE/DELETE) gateadas por **`private.cap_custo_ler`** — o mesmo predicado do gate de projeção, **não** `has_role(master)`:

1. **É o corte exato.** O oráculo só vale para quem não pode ler `margem_pct`; para quem já lê o número, mover o limiar não revela nada. Gatear por `master` fecharia o furo por coincidência, não pelo motivo certo.
2. **Não cria um segundo eixo de autorização.** "Ver custo" e "calibrar a régua de custo" seguem sendo um conceito só — no dia em que alguém receber `commercial_role='estrategico'`, ganha os dois coerentemente, sem nova migration.

Hoje os dois recortes coincidem em prod (1 master, 2 employees, **zero** `estrategico`/`super_admin`), então o efeito imediato é idêntico a "só o master escreve" — a diferença é de desenho.

**Detalhes que a forma exige:**
- `UPDATE` precisa de `USING` **e** `WITH CHECK`. Só com `WITH CHECK`, o desvio lateral `SET key='outra' WHERE key='margem_faixa_piso_pct'` passaria: a linha resultante não casa o predicado, o check aprova, e a key protegida **some** — devolvendo o limiar ao default sem nunca escrever uma linha de faixa.
- `INSERT` é o caminho **vivo hoje**: as keys nem existiam em prod (a RPC caía no `COALESCE` 30/50). A migration as semeia com esses mesmos valores.
- `SELECT` fica de fora de propósito (`GovernanceMathParams` faz `select('*')`).
- **`REVOKE TRUNCATE`** — achado do `/codex`: RLS **não cobre TRUNCATE**, e `authenticated` o tinha (o `D` do `arwdDxtm` default do Supabase). Truncar apagaria os limiares e devolveria a RPC ao default: as 3 policies virariam decoração sem serem violadas. Não era alcançável pelo browser (o PostgREST não tem verbo de TRUNCATE), mas revogar por nome fecha a classe.

## Não quebra quem ajusta os pesos (levantado ANTES de escrever)

| escritor | keys que grava | gate de UI |
|---|---|---|
| `GovernanceMathParams.tsx` | só `hs_weight_*` / `ps_weight_*` (listas fixas no código) | `commercial_role='super_admin'` |
| `useFarmerGovernance.approveProposal` | keys de uma proposta aprovada | `commercial_role='super_admin'` |

Ninguém tem `super_admin` em prod, `farmer_governance_proposals` está **vazia** e `farmer_audit_log` tem **zero** linhas de `algorithm_config`. Ou seja: nenhuma escrita legítima existe hoje, e a que o desenho prevê (pesos) segue livre para todo staff. Provado no harness (P1/P2).

## Prova — `db/test-farmer-config-limiar-faixa.sh` (24 asserts, PG17 local)

Aplica a **RPC real do #1543** (não stub) e a migration real; RLS sob `SET ROLE authenticated` + GUC do JWT.

- **Positivos:** employee sem cap segue ajustando pesos; master e employee-`estrategico` escrevem o limiar.
- **Negativos:** UPDATE do valor, DELETE e **rename** barrados; INSERT de key nova barrado com **42501 + re-raise**.
- **Idempotência:** 2º apply limpo — que é exatamente como o founder cola no SQL Editor.
- **Money-path:** o ataque ponta-a-ponta (M3) + a **contraprova** (M2 — o master move o limiar e a faixa **vira amarelo**). Sem M2, M3 passaria por vacuidade.
- **5 sabotagens exigindo o vermelho exato**, entre elas `UPDATE sem USING` (prova que o `USING` não é decorativo) e `re-GRANT de TRUNCATE` (prova que o assert do REVOKE tem dente).

Gates: `typecheck` 0 · `lint` 0 erros · `authz:check` verde · `shellcheck` limpo · `wt:preflight --full` 🟢.

## 2ª opinião — `/codex` gpt-5.6-sol (xhigh)

Confirmou o fechamento do DML e a cobertura do rename. **Aplicado daqui:** `REVOKE TRUNCATE`, `ESCAPE '!'` explícito no `LIKE` (não depender do escape default) e a forma `(SELECT ...)` do predicado (InitPlan único em vez de chamada por linha). **Medido e descartado:** autoatribuição em `commercial_roles`/`user_roles` — ambas só aceitam escrita de `master`, então a via "vira estratégico e ganha o cap" não existe.

## ⚠️ O que este PR NÃO fecha

**`g` sai sem gate e é invertível.** O Codex mostrou que `g` é uma transformação afim da margem (`margem = A + B·g`), e `motivo` fornece **âncoras absolutas** (os cortes em 30 e 50): ordenando os pares `(g, motivo)`, o atacante calibra `A` e `B` e estima a margem de **toda a carteira numa única resposta** — sem escrever nada. É estruturalmente pior que o oráculo deste PR.

Não corrigi aqui **de propósito**: `g` é decisão de produto declarada do #1543 ("o número fecha, o sinal fica"), o `calcularHealthScore` **consome** `g`, e gateá-lo mudaria o score de todo vendedor sem cap — seria mudança de produto embutida numa entrega de autorização, exatamente o que o #1543 evitou. Fica como follow-up para decisão do dono.

Este PR **reduz** a precisão desse ataque (com o limiar fixo o atacante tem só duas âncoras, em vez de âncoras móveis com precisão arbitrária), mas não o elimina.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260813150000_farmer_config_limiar_faixa_escrita_custo.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

<details><summary>SQL pra aplicar (🟣 SQL Editor → cola → Run)</summary>

```sql
-- FU4-F fase 3b — o LIMIAR da faixa deixa de ser um oráculo de custo.
--
-- ── O PROBLEMA (medido em prod 2026-08-13; achado por revisão adversarial no #1543) ──────────
-- O #1543 fechou o NÚMERO: `public.get_carteira_margem_faixa()` devolve a FAIXA sempre e
-- `margem_pct` só sob `private.cap_custo_ler`. Mas a faixa é decidida por dois limiares LIDOS
-- de `public.farmer_algorithm_config`:
--
--     WHEN b.pct < v_piso  THEN 'amarelo'   -- v_piso  = key 'margem_faixa_piso_pct'
--     WHEN b.pct < v_meta  THEN 'abaixo_da_meta'  -- v_meta = key 'margem_faixa_meta_pct'
--
-- ...e essa tabela é escrita por QUALQUER staff. Medido:
--   • policy `Staff can manage algorithm config` = FOR ALL, USING e WITH CHECK
--     `has_role(master) OR has_role(employee)`;
--   • `has_table_privilege('authenticated', ..., 'INSERT'/'UPDATE'/'DELETE')` = true.
--
-- Logo o gate de PROJEÇÃO é derrotável por BUSCA BINÁRIA. Um employee sem `cap_custo_ler`:
--   1. escreve `margem_faixa_piso_pct = X`;
--   2. chama a RPC e olha se o cliente virou `amarelo` (margem < X) ou seguiu `verde`;
--   3. repete ~13 vezes → recupera a margem com precisão arbitrária.
-- Como ele já vê a receita do cliente, `custo = receita × (1 − margem)`. O #1543 escondeu o
-- número na SAÍDA; o limiar o devolvia por um canal lateral — cada chamada é uma comparação, e
-- comparações bastam para reconstruir o valor.
--
-- `motivo` amplia a sonda (devolve os DOIS limiares por chamada: `abaixo_do_piso` vs
-- `abaixo_da_meta` vs `saudavel`), mas não muda a natureza do furo: o que vaza é a ESCRITA.
--
-- ── A DECISÃO: quem escreve o limiar é quem JÁ PODE VER O NÚMERO ─────────────────────────────
-- O gate desta migration é `private.cap_custo_ler(auth.uid())` — o MESMO predicado do gate de
-- projeção da RPC — e não `has_role(master)`. Duas razões:
--
--   1. É o corte exato do ataque. O oráculo só tem valor para quem NÃO pode ler `margem_pct`;
--      para quem já lê o número, mover o limiar não revela absolutamente nada. Gatear por
--      `master` fecharia o furo, mas por uma coincidência (hoje `cap_custo_ler` ⊇ master), não
--      pelo motivo certo.
--   2. Não cria um segundo eixo de autorização. Com `cap_custo_ler`, "ver custo" e "calibrar a
--      régua de custo" continuam sendo UM conceito: no dia em que o dono conceder
--      `commercial_role = 'estrategico'` a alguém, essa pessoa ganha os dois de forma coerente,
--      sem uma segunda migration. Com `master` hardcoded, os dois eixos divergiriam em silêncio.
--
-- Hoje em prod os dois recortes coincidem (`cap_custo_ler` = master OR employee com
-- `estrategico`/`super_admin`; medido: 1 master, 2 employees, ZERO `estrategico`/`super_admin`),
-- então o efeito imediato é idêntico a "só o master escreve" — a diferença é de DESENHO.
--
-- ── POR QUE NÃO QUEBRA QUEM AJUSTA OS PESOS (levantado antes de escrever) ────────────────────
-- Os dois escritores da tabela no front:
--   • `src/pages/GovernanceMathParams.tsx` — grava SÓ `hs_weight_*` / `ps_weight_*` (as listas
--     `HEALTH_WEIGHTS`/`PRIORITY_WEIGHTS` são fixas no código). Nenhuma casa `margem_faixa_%`.
--   • `src/hooks/useFarmerGovernance.ts::approveProposal` — grava as keys de uma proposta
--     aprovada (arbitrárias). Tabela `farmer_governance_proposals` está VAZIA em prod.
-- Ambos já gateiam na UI por `commercial_role = 'super_admin'`, que NINGUÉM tem em prod — e
-- `farmer_audit_log` tem ZERO linhas com `entity_type='algorithm_config'`. Ou seja: nenhuma
-- escrita legítima existe hoje, e as que o desenho prevê (pesos) seguem livres para todo staff.
--
-- ── FORMA: policy RESTRICTIVE por comando ────────────────────────────────────────────────────
-- RESTRICTIVE é AND-ed com as permissivas existentes (que ficam intactas — menos risco de
-- regressão que reescrever `Staff can manage algorithm config`), e falha FECHADA.
-- Uma policy por comando, de propósito, para NÃO tocar o SELECT: `FOR ALL` restritiva também
-- filtraria leitura, e `GovernanceMathParams` faz `select('*')` na tabela inteira.
--
-- Os três comandos são necessários — fechar só o UPDATE deixa o oráculo de pé:
--   • INSERT — as keys HOJE NÃO EXISTEM (a RPC cai no COALESCE 30/50), então o atacante
--              criaria a linha do zero. Este é o caminho vivo hoje, não o UPDATE.
--   • UPDATE — precisa de USING **e** WITH CHECK. Só WITH CHECK deixaria passar o desvio
--              lateral `SET key='outra' WHERE key='margem_faixa_piso_pct'`: a linha resultante
--              não casa o predicado, o WITH CHECK aprova, e a key de faixa SOME — devolvendo o
--              limiar ao default 30 sem nunca ter escrito uma linha de faixa.
--   • DELETE — mesma classe do rename: apagar a linha reseta o limiar para o default.
--
-- `service_role` e `postgres` têm BYPASSRLS (medido) → edges e a própria RPC (SECURITY DEFINER,
-- owner=postgres) não são afetadas.
--
-- ⚠️ Grants de tabela de `anon` NÃO são tocados aqui: `db/audit-anon-dml-bypass.sh` registra a
-- decisão do repo de não revogar em massa (é o modelo do Supabase — grant amplo + RLS). `anon`
-- já é barrado pelas policies permissivas (`auth.uid()` IS NULL → `has_role` false).
--
-- Prova: `db/test-farmer-config-limiar-faixa.sh` (PG17 local, asserts negativos com SQLSTATE +
-- re-raise, RLS sob SET ROLE authenticated + GUC, e 4 sabotagens exigindo vermelho).

BEGIN;

-- ── 1) As linhas de limiar passam a EXISTIR ──────────────────────────────────────────────────
-- Hoje ausentes: a RPC vinha caindo no `COALESCE(..., 30)` / `COALESCE(..., 50)`. Semear com
-- exatamente esses valores é um NO-OP de comportamento (a faixa de todo mundo continua igual),
-- e torna o limiar auditável e ajustável sem deploy — que é o desenho do spec.
-- Os valores 30/50 foram medidos em prod (spec 2026-07-20 §3.1b, 746 clientes com margem).
-- `DO NOTHING` e não `DO UPDATE`: se a linha já existir por qualquer motivo, um re-apply da
-- migration não pode sobrescrever calibragem legítima. A validação pós-apply confere o valor.
--
-- ⚠️ EFEITO DURADOURO (não é no-op para sempre): a partir daqui o BANCO é a fonte efetiva desses
-- limiares. Se um dia o `COALESCE` da RPC mudar para 35/55, as linhas persistidas em 30/50
-- continuarão vencendo, e o default no código vira letra morta. Quem mexer no default da RPC
-- precisa mexer nestas linhas junto — ou a mudança não terá efeito nenhum.
INSERT INTO public.farmer_algorithm_config (key, value, description) VALUES
  ('margem_faixa_piso_pct', 30,
   'FU4-F: margem agregada abaixo deste % => faixa amarelo (motivo abaixo_do_piso). '
   'Escrita gateada por private.cap_custo_ler: o limiar e um oraculo do custo.'),
  ('margem_faixa_meta_pct', 50,
   'FU4-F: margem agregada abaixo deste % => verde/abaixo_da_meta; acima => verde/saudavel. '
   'Escrita gateada por private.cap_custo_ler: o limiar e um oraculo do custo.')
ON CONFLICT (key) DO NOTHING;

-- ── 2) A escrita das linhas de limiar exige o cap de custo ───────────────────────────────────
-- Predicado por PREFIXO e não por lista de keys: uma terceira chave de faixa criada amanhã nasce
-- protegida, sem precisar lembrar de editar a policy. O namespace `margem_faixa_` é o CONTRATO —
-- qualquer key sob ele exige o cap por definição. O preço dessa escolha é conhecido: uma chave
-- sensível batizada fora do prefixo (`margem_piso_novo`) nasceria DESPROTEGIDA. Por isso o
-- COMMENT ON TABLE abaixo declara o namespace, em vez de deixá-lo como convenção tácita.
--
-- `ESCAPE '!'` explícito: `_` é wildcard no LIKE e escapá-lo com `\` depende do escape DEFAULT do
-- Postgres. Declarar o escape torna o predicado independente dessa regra — sem isso, um dia com
-- `standard_conforming_strings` diferente o `_` voltaria a casar qualquer caractere (o predicado
-- ficaria mais FROUXO, nunca mais restrito).
--
-- `(SELECT ...)` envolvendo a chamada: forma que o planner avalia como InitPlan único por
-- instrução, em vez de uma chamada por linha num UPDATE em lote.
--
-- NULL-safety: `key` é NOT NULL, mas o predicado é fail-closed por construção — se `key` fosse
-- NULL, `NOT (NULL LIKE ...)` → NULL, e `NULL OR false` → NULL → a policy NEGA.

-- `DROP ... IF EXISTS` antes de cada `CREATE`: o apply é MANUAL (SQL Editor do Lovable) e
-- re-colar o bloco após uma falha parcial é rotina — sem isso o segundo Run morre em 42710.
DROP POLICY IF EXISTS "limiar_faixa_margem_insert_exige_cap_custo" ON public.farmer_algorithm_config;
CREATE POLICY "limiar_faixa_margem_insert_exige_cap_custo"
  ON public.farmer_algorithm_config
  AS RESTRICTIVE FOR INSERT
  WITH CHECK (
    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
  );

DROP POLICY IF EXISTS "limiar_faixa_margem_update_exige_cap_custo" ON public.farmer_algorithm_config;
CREATE POLICY "limiar_faixa_margem_update_exige_cap_custo"
  ON public.farmer_algorithm_config
  AS RESTRICTIVE FOR UPDATE
  USING (
    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
  )
  WITH CHECK (
    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
  );

DROP POLICY IF EXISTS "limiar_faixa_margem_delete_exige_cap_custo" ON public.farmer_algorithm_config;
CREATE POLICY "limiar_faixa_margem_delete_exige_cap_custo"
  ON public.farmer_algorithm_config
  AS RESTRICTIVE FOR DELETE
  USING (
    NOT (key LIKE 'margem!_faixa!_%' ESCAPE '!')
    OR COALESCE((SELECT private.cap_custo_ler((SELECT auth.uid()))), false)
  );

-- ── 3) TRUNCATE: o buraco que a RLS não tapa ────────────────────────────────────────────────
-- RLS **não se aplica a TRUNCATE** — nenhuma policy acima o intercepta. Medido em prod:
-- `has_table_privilege('authenticated', ..., 'TRUNCATE')` = true (o grant `arwdDxtm` que o
-- Supabase concede por default privilege inclui o `D`). Um TRUNCATE apagaria as linhas de limiar
-- e a RPC voltaria ao `COALESCE` default — anulando as policies acima sem violá-las.
--
-- Alcance honesto: NÃO é explorável pelo browser. O PostgREST não tem verbo para TRUNCATE, então
-- o employee com JWT não o alcança por HTTP; seria preciso conexão SQL direta, que ele não tem.
-- Revogar é defense-in-depth barato (nenhum caminho legítimo trunca config de algoritmo) e
-- fecha a classe inteira em vez de só o vetor conhecido.
--
-- Revogado POR NOME: `REVOKE ... FROM PUBLIC` seria no-op aqui — o Supabase concede às roles
-- nomeadas, não via PUBLIC (regra do repo). Só TRUNCATE sai; SELECT/INSERT/UPDATE/DELETE ficam,
-- porque é a RLS que os governa e revogá-los quebraria o app (`db/audit-anon-dml-bypass.sh`
-- registra a decisão de não revogar DML em massa — o modelo do Supabase é grant amplo + RLS).
REVOKE TRUNCATE ON public.farmer_algorithm_config FROM authenticated, anon;

COMMENT ON TABLE public.farmer_algorithm_config IS
  'Parametros do algoritmo do farmer (key/value numerico). Os pesos (hs_weight_*, ps_weight_*, '
  'health_w_*, priority_w_*) sao escrita livre de staff. As keys margem_faixa_* sao EXCECAO: '
  'a escrita delas exige private.cap_custo_ler, porque mover o limiar e chamar '
  'get_carteira_margem_faixa reconstroi a margem por busca binaria (oraculo de custo).';

COMMIT;
```
</details>

Validação pós-apply (read-only, lê catálogo):

```sql
SELECT
  (SELECT count(*) FROM pg_policy
    WHERE polrelid='public.farmer_algorithm_config'::regclass
      AND polname LIKE 'limiar!_faixa!_%' ESCAPE '!'
      AND NOT polpermissive)                                         AS policies_restritivas,  -- esperado 3
  (SELECT count(*) FROM public.farmer_algorithm_config
    WHERE key LIKE 'margem!_faixa!_%' ESCAPE '!')                    AS keys_limiar,           -- esperado 2
  has_table_privilege('authenticated','public.farmer_algorithm_config','TRUNCATE') AS trunc_auth, -- esperado f
  has_table_privilege('anon','public.farmer_algorithm_config','TRUNCATE')          AS trunc_anon; -- esperado f
```

Esperado: `3 | 2 | f | f`. Qualquer outra coisa = não pegou.
