### PR TITLE
fix(authz): o COMMENT da RPC de margem troca a promessa falsa pelo delta medido [money-path]

### DIFF
--- a/db/test-comment-honesto-margem-faixa.sh
+++ b/db/test-comment-honesto-margem-faixa.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  Prova PG17 de 20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql    ║
+# ║    bash db/test-comment-honesto-margem-faixa.sh > log 2>&1; echo $?          ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                       ║
+# ║                                                                              ║
+# ║  O que prova:                                                                ║
+# ║   · o COMMENT novo entra e a frase FALSA ("byte a byte") sai                  ║
+# ║   · `prosrc` NÃO muda ⇒ a impressão digital do #1543 segue válida e a         ║
+# ║     validação pós-apply dele continua dando `t` nos 11 checks                 ║
+# ║   · o guard `IF EXISTS` deixa a migration rodar num banco SEM a função        ║
+# ║     (restore de DR anterior à 20260726170000) em vez de abortar               ║
+# ║   · idempotência: re-aplicar não degrada                                      ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+# 5474: 5471 é do #1495, 5472 do helper compartilhado, 5473 do harness da RPC.
+PORT="${PGPORT_TEST:-5474}"
+SLUG="fu4f3comment"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+MIG_RPC="$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+MIG_COM="$REPO_ROOT/supabase/migrations/20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql"
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  XX  $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+
+echo "-- A. o guard, ANTES de a função existir (cenário de restore de DR) --"
+# ⚠️ Este é o assert que justifica o DO/IF EXISTS. `COMMENT ON FUNCTION` de objeto ausente é
+# ERRO, e um restore que reaplique as migrations em ordem pararia aqui. Roda ANTES de qualquer
+# outra coisa, no banco ainda vazio.
+if P -q -f "$MIG_COM" >/dev/null 2>&1; then
+  ok "A1 a migration roda sem a função existir (guard IF EXISTS segura)"
+else
+  bad "A1 a migration ABORTOU num banco sem a função — o guard não está segurando"
+fi
+
+# ── setup mínimo para a RPC existir (espelha o harness da própria RPC) ───────
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $f$
+  SELECT nullif(current_setting('test.uid', true), '')::uuid $f$;
+CREATE SCHEMA IF NOT EXISTS private;
+ALTER DEFAULT PRIVILEGES IN SCHEMA private GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public  GRANT EXECUTE ON FUNCTIONS TO anon, authenticated, service_role;
+GRANT USAGE ON SCHEMA private TO authenticated, anon, service_role;
+
+CREATE TABLE public.carteira_teste (cid uuid, dono uuid);
+CREATE TABLE public.farmer_algorithm_config (key text PRIMARY KEY, value text NOT NULL);
+CREATE TABLE public.omie_products (id uuid PRIMARY KEY, omie_codigo_produto bigint UNIQUE);
+CREATE TABLE public.product_costs (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                                   product_id uuid UNIQUE, cost_final numeric, cost_price numeric);
+CREATE TABLE public.sales_orders (id uuid PRIMARY KEY, status text, deleted_at timestamptz);
+CREATE TABLE public.order_items (id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+                                 sales_order_id uuid, customer_user_id uuid,
+                                 omie_codigo_produto bigint, product_id uuid,
+                                 quantity numeric, unit_price numeric);
+CREATE TABLE public.cliente_classificacao (user_id uuid PRIMARY KEY, excluir_da_carteira boolean);
+
+CREATE OR REPLACE FUNCTION private.cap_custo_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT coalesce(nullif(current_setting('test.cap_custo',true),'')::boolean,false) $f$;
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT coalesce(nullif(current_setting('test.cap_carteira',true),'')::boolean,false) $f$;
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_customer_user_id uuid, _uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT EXISTS (SELECT 1 FROM public.carteira_teste c
+                                             WHERE c.cid=_customer_user_id AND c.dono=_uid) $f$;
+SQL
+
+P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
+P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
+P -q -f "$MIG_RPC"
+
+DIGITAL_ANTES="$(Pq -q -c "SELECT md5(regexp_replace(prosrc,'[[:space:]]+',' ','g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")"
+
+echo "-- B. o COMMENT muda, o corpo NÃO --"
+eq "B1 baseline: o comentário da 170000 AFIRMA 'byte a byte'" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%byte a byte%')::text;")" "true"
+
+P -q -f "$MIG_COM"
+
+eq "B2 a frase FALSA saiu do catálogo" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%byte a byte%')::text;")" "false"
+# Ancora no NÚMERO medido, não em palavra solta: um comentário que só trocasse "byte a byte" por
+# "aproximadamente igual" passaria num assert de ausência, e continuaria mentindo por omissão.
+eq "B3 o comentário novo carrega a medição (30.833 × 20.597)" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%30.833 pedidos contra 20.597%')::text;")" "true"
+eq "B4 e diz explicitamente que o score MUDA" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%health score MUDA%')::text;")" "true"
+# ⚠️ "muda" sozinho seria alarme sem tamanho. O #1721 mediu o delta sobre as personas REAIS de
+# prod, e o comentário tem de carregar o número — senão troca uma imprecisão (equivalência falsa)
+# por outra (pânico sem escala).
+eq "B4b o comentário carrega o delta medido pelo #1721 (59,5% / 14,5)" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%59,5%' AND obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%14,5%')::text;")" "true"
+# O #1721 REFUTOU o que o comentário do hook do #1543 afirmava ("a ordem da agenda pode mudar").
+# Nenhuma quota lê o health score. Gravar isso no catálogo impede que a próxima pessoa reintroduza
+# o medo — que foi meu, e estava errado.
+eq "B4c e registra que a AGENDA NAO muda (refutado pelo #1721)" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%AGENDA NAO muda%')::text;")" "true"
+
+# ⚠️ O assert que protege o #1543: se `prosrc` mudasse, a impressão digital gravada em
+# db/valida-fu4f-fase3-carteira-margem-faixa.sql viraria mentira e o founder receberia `f` num
+# banco correto — falso alarme que pararia um deploy.
+eq "B5 o corpo (prosrc) NÃO mudou — a digital do #1543 segue válida" \
+   "$(Pq -q -c "SELECT md5(regexp_replace(prosrc,'[[:space:]]+',' ','g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")" \
+   "$DIGITAL_ANTES"
+
+echo "-- C. a validação pós-apply do #1543 continua verde --"
+VAL="$(Pq -q -f "$REPO_ROOT/db/valida-fu4f-fase3-carteira-margem-faixa.sql")"
+eq "C1 os 11 checks do #1543 seguem 't' depois desta migration" \
+   "$(printf '%s' "$VAL" | tr '|' '\n' | sort -u | tr -d '\n')" "t"
+
+echo "-- D. idempotência --"
+P -q -f "$MIG_COM"
+eq "D1 re-aplicar mantém o comentário novo" \
+   "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%health score MUDA%')::text;")" "true"
+eq "D2 re-aplicar não mexe no corpo" \
+   "$(Pq -q -c "SELECT md5(regexp_replace(prosrc,'[[:space:]]+',' ','g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")" \
+   "$DIGITAL_ANTES"
+
+echo "-- E. FALSIFICAÇÃO --"
+# Sem isto, B2/B3/B4 seriam decorativos: um arquivo que não aplicasse NADA deixaria o comentário
+# velho em pé, e só um assert com dente distingue "corrigi" de "não fiz nada".
+SAB="/tmp/sabota-${SLUG}.sql"
+sed 's/COMMENT ON FUNCTION public.get_carteira_margem_faixa() IS/RAISE NOTICE %sabotado%; -- COMMENT ON FUNCTION public.get_carteira_margem_faixa() IS/' "$MIG_COM" > "$SAB"
+if cmp -s "$SAB" "$MIG_COM"; then
+  bad "E0 SABOTAGEM NÃO APLICADA — o sed não casou nada"
+else
+  # restaura o comentário FALSO e tenta aplicar a versão sabotada (que não comenta nada)
+  P -q -f "$MIG_RPC"
+  P -q -f "$SAB" >/dev/null 2>&1 || true
+  RES="$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%byte a byte%')::text;")"
+  if [ "$RES" = "true" ]; then
+    ok "E1 migration sabotada NÃO corrige o comentário → B2 ficaria vermelho (assert tem dente)"
+    PASS=$((PASS))
+  else
+    bad "E1 ASSERT SEM DENTE: o comentário ficou correto mesmo com a migration sabotada"
+  fi
+  # restaura o estado bom
+  P -q -f "$MIG_COM"
+fi
+
+echo "========================================"
+echo "  $PASS verde(s), $FAIL vermelho(s)"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "  TODOS OS ASSERTS PASSARAM"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **459** custom migrations totais
+- **460** custom migrations totais
 - **1576** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 469
@@ -3853,6 +3853,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.reposicao_pos_candidatos` | — |
+
+### `20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 459
+-- Total de custom migrations: 460
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -500,7 +500,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260808012000', 'atp_reconciliacao_fase3', '20260808012000_atp_reconciliacao_fase3.sql'),
   ('20260808020000', 'tactical_plan_idempotencia_janela', '20260808020000_tactical_plan_idempotencia_janela.sql'),
   ('20260813150000', 'farmer_config_limiar_faixa_escrita_custo', '20260813150000_farmer_config_limiar_faixa_escrita_custo.sql'),
-  ('20260813195914', 'reposicao_pos_candidatos_guard_temporal', '20260813195914_reposicao_pos_candidatos_guard_temporal.sql')
+  ('20260813195914', 'reposicao_pos_candidatos_guard_temporal', '20260813195914_reposicao_pos_candidatos_guard_temporal.sql'),
+  ('20260813225057', 'fu4f_fase3_comment_honesto_margem_faixa', '20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),

--- a/supabase/migrations/20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql
+++ b/supabase/migrations/20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql
@@ -1,0 +1,70 @@
+-- FU4-F fase 3 — o COMMENT de `public.get_carteira_margem_faixa()` para de prometer score idêntico.
+--
+-- POR QUE ESTA MIGRATION EXISTE: o `COMMENT ON FUNCTION` aplicado pela
+-- `20260726170000_fu4f_fase3_carteira_margem_faixa.sql` afirma que a RPC preserva o health score
+-- "byte a byte". A frase está VIVA no catálogo de produção (conferida por `obj_description`) e é
+-- FALSA — medida como falsa em prod (2026-08-13, `psql-ro`) na própria sessão que entregou o PR.
+-- Como o arquivo daquela migration é imutável depois de commitado e aplicado (o snapshot de
+-- `supabase/migrations/` é a fonte de DR), a correção vem por migration NOVA, que é o caminho do
+-- repo para corrigir objeto já aplicado.
+--
+-- ── O QUE FOI MEDIDO ─────────────────────────────────────────────────────────────────────────
+-- A RÉGUA é a mesma (percentis p10/p90 da população, como o hook fazia). O UNIVERSO não:
+--   · o hook filtrava status por ALLOWLIST (`confirmado`/`faturado`/`entregue`);
+--   · `private.margem_cliente_agregada` — autoridade única desde o #1519, de onde esta RPC
+--     deriva — filtra por DENYLIST (tudo que não é `cancelado`/`rascunho`/`pendente`/`orcamento`).
+-- Contagem real de `sales_orders` com `deleted_at IS NULL`:
+--     faturado 20.597 (nos dois) · importado 5.419 · separacao 2.809 · enviado 2.008 (só helper)
+--     `confirmado` e `entregue`: ZERO linhas — a allowlist do hook citava status inexistentes
+--   ⇒ 30.833 pedidos contra 20.597: ~50% a mais alimentando a margem.
+-- Segundo delta: `sales_orders` é company-wide para staff, mas a RPC devolve só a carteira do
+-- caller ⇒ para um VENDEDOR, cliente fora da carteira perde o componente `g` e o
+-- `calcularHealthScore` renormaliza os pesos (não penaliza, mas muda o número).
+--
+-- Nada disso é defeito: é a reconciliação PRETENDIDA pelo #1519, depois que o #1495 achou duas
+-- autoridades money-path divergindo em 28,5% dos clientes. O defeito era só a promessa.
+--
+-- ⚠️ NÃO altera comportamento nem autorização: `COMMENT ON FUNCTION` não toca `prosrc`, então a
+-- impressão digital em `db/valida-fu4f-fase3-carteira-margem-faixa.sql` (assert L1 do harness)
+-- segue válida — o harness continua verde e a validação pós-apply do #1543 continua dando `t`.
+--
+-- ⚠️ MIGRATION MANUAL: nome custom não auto-aplica no Lovable. Colar no SQL Editor → Run.
+
+BEGIN;
+
+-- Guardado por `IF EXISTS`: `COMMENT ON FUNCTION` de objeto ausente é ERRO, e isto precisa ser
+-- re-rodável em qualquer ambiente — inclusive um banco de DR restaurado num ponto anterior à
+-- 20260726170000, onde a função ainda não existe. Sem o guard, a restauração pararia aqui.
+DO $mig$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public'
+       AND p.proname = 'get_carteira_margem_faixa'
+       AND p.pronargs = 0
+  ) THEN
+    COMMENT ON FUNCTION public.get_carteira_margem_faixa() IS
+      'FU4-F fase 3: faixa de margem + componente g por cliente da carteira. O custo e lido no '
+      'SERVIDOR (via private.margem_cliente_agregada) e nunca sai; margem_pct so e projetada sob '
+      'private.cap_custo_ler. `g` usa a regua de percentis da POPULACAO. '
+      'ATENCAO: a REGUA e a mesma que o hook usava, mas o UNIVERSO nao. O hook filtrava status por '
+      'allowlist (confirmado/faturado/entregue, das quais duas tem ZERO linhas) e o helper filtra '
+      'por denylist: 30.833 pedidos contra 20.597, medido em 2026-08-13. E o escopo por carteira '
+      'tira o `g` de cliente fora dela, com renormalizacao dos pesos. Logo o health score MUDA - '
+      'medido no PR #1721 sobre as 3 personas reais de prod: ate 59,5% dos clientes mudam de faixa, '
+      'delta medio de 1,4 a 4,1 pontos e maximo 14,5 (o teto do peso de G). Mas a AGENDA NAO muda: '
+      'nenhuma quota le o health score (risco ordena por churnRisk, expansao por expansionScore, '
+      'follow-up por priorityScore) - so o rotulo healthClass exibido. '
+      'Ate 2026-08-13 este comentario prometia equivalencia EXATA de score, o que era falso. '
+      -- A frase antiga NAO e citada aqui de proposito: repeti-la literalmente faria toda auditoria
+      -- por substring (a minha inclusive - foi o assert B2 do harness que pegou) continuar achando
+      -- a promessa no catalogo, agora dentro da propria negacao.
+      'Escopo espelha a RLS de farmer_client_scores.';
+  ELSE
+    RAISE NOTICE 'get_carteira_margem_faixa() ausente - COMMENT ignorado (aplique a 20260726170000 antes)';
+  END IF;
+END
+$mig$;
+
+COMMIT;


### PR DESCRIPTION
O `COMMENT ON FUNCTION` de `public.get_carteira_margem_faixa()` — aplicado pelo #1543 e **vivo no
catálogo de produção** — afirma que a RPC preserva o health score do hook *"byte a byte"*.

**É falso, e foi medido como falso na própria sessão que entregou o #1543** (2026-08-13, `psql-ro`).
A régua é a mesma; o universo de pedidos não:

| | hook (antes) | helper `margem_cliente_agregada` (agora) |
|---|---|---|
| filtro de status | allowlist `confirmado`/`faturado`/`entregue` | denylist (tudo menos `cancelado`/`rascunho`/`pendente`/`orcamento`) |
| pedidos alcançados | **20.597** | **30.833** (+50%) |

`confirmado` e `entregue` têm **zero** linhas em prod — a allowlist do hook citava status que não
existem. Há um segundo delta, de escopo: `sales_orders` é company-wide para staff, mas a RPC devolve
só a carteira do caller, então para um **vendedor** cliente fora da carteira perde o componente `g` e
o `calcularHealthScore` renormaliza os pesos.

Nada disso é defeito — é a reconciliação **pretendida** pelo #1519, depois que o #1495 achou duas
autoridades money-path divergindo em 28,5% dos clientes. O defeito era só a promessa no comentário.

## O texto mudou no meio do caminho — o #1721 mergeou e mediu

A primeira versão deste comentário dizia *"o quanto NÃO foi medido cliente a cliente"*. Entre escrever
isso e abrir o PR, o **#1721** mergeou e mediu, sobre as **3 personas reais de prod**. O comentário
passou a carregar o número em vez da lacuna:

| persona | muda de faixa | Δ health (méd / máx) | muda de classe | **agenda** |
|---|---:|---:|---:|---:|
| master | 6,9% | 1,36 / 14,5 | 1,7% | **0** |
| farmer A | 59,5% | 4,08 / 14,5 | 9,3% | **0** |
| farmer B | 48,5% | 3,56 / 14,5 | 5,3% | **0** |

E o #1721 **refutou** o que eu havia escrito no comentário do hook no #1543 — *"a ordem da agenda pode
mudar junto"*. **Não muda**: nenhuma quota lê o health score (risco ordena por `churnRisk`, expansão
por `expansionScore`, follow-up por `priorityScore`); só o rótulo `healthClass` exibido. Isso entra no
catálogo justamente para a próxima pessoa não reintroduzir o medo — que era meu, e estava errado.

Reconferido após o #1723 (que fechou o oráculo de limiar): ele não tocou a RPC, e o `md5` do `prosrc`
em prod segue `075209b9…` — a impressão digital do #1543 continua válida.

A correção veio por migration **nova** porque o arquivo da `20260726170000` é imutável depois de
commitado e aplicado (o snapshot de `supabase/migrations/` é a fonte de DR) — é o caminho do repo
para corrigir objeto já aplicado.

## ⚠️ ATENÇÃO: migration manual necessária

Adiciona `supabase/migrations/20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql`. **Lovable
não aplica automaticamente** — mergear NÃO toca o banco.

**Não altera comportamento nem autorização.** `COMMENT ON FUNCTION` não toca `prosrc`, então a
impressão digital gravada em `db/valida-fu4f-fase3-carteira-margem-faixa.sql` (assert L1 do harness
do #1543) segue válida e a validação pós-apply dele continua dando `t` nos 11 checks — provado, ver
abaixo. Sem urgência de deploy e sem ordem acoplada com Publish.

Validação pós-apply (read-only, lê catálogo):

```sql
SELECT obj_description('public.get_carteira_margem_faixa()'::regprocedure) NOT LIKE '%byte a byte%'
       AND obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%health score MUDA%'
       AS comentario_honesto;
```

## Duas decisões que o harness forçou

**O `IF EXISTS` não é paranoia.** `COMMENT ON FUNCTION` de objeto ausente é **erro**, não no-op. Sem
o guard, um restore de DR que reaplicasse as migrations em ordem abortaria aqui — o banco no ponto
anterior à `20260726170000` não tem a função. O assert A1 roda a migration num banco vazio antes de
qualquer outra coisa, exatamente para provar isso.

**O comentário novo não cita a frase antiga.** A primeira versão dizia *«até 2026-08-13 este
comentário dizia "…byte a byte", o que era falso»* — e o assert B2 ficou **vermelho**: repetir a
frase literalmente faz toda auditoria por substring continuar achando a promessa no catálogo, agora
dentro da própria negação. O texto passou a descrever a promessa antiga sem reproduzi-la.

## Prova

`db/test-comment-honesto-margem-faixa.sh` — PG17 descartável, aplica as migrations **reais**:

```
12 verde(s), 0 vermelho(s) — exit 0
```

- **A1** guard: roda num banco sem a função (cenário de restore de DR)
- **B1-B4c** baseline com a frase falsa → ela sai; o texto novo carrega a **medição** (`30.833 contra
  20.597`), não um adjetivo, e diz que o score **MUDA**
- **B5 / D2** `prosrc` inalterado — a digital do #1543 (`075209b9…`) segue válida
- **C1** os 11 checks da validação pós-apply do #1543 seguem `t` **depois** desta migration
- **D1** idempotência
- **E1** falsificação: migration sabotada (que não comenta nada) deixa o comentário velho em pé ⇒ B2
  ficaria vermelho. Sem isso, B2-B4 não distinguiriam "corrigi" de "não fiz nada"

Gates locais com evidência positiva (`> log 2>&1; echo $?`): `typecheck` 0 · `lint` 0 (0 errors) ·
`knip` 0 · `shellcheck` 0. `wt:preflight --full`: 🟢 sem colisão (92.933 objetos concorrentes).

⚠️ **`bun run test` deu exit 1 na minha máquina, e não estou chamando isso de verde.** Cinco testes
falharam — quatro gates estruturais (`paginacao-artesanal`, `erro-object-object`, `segredo-em-log`,
`manifesto.gate`) e o `SalesQuotes.accountGuard` — todos com `Error: Test timed out in 20000ms` e
duração de 23–32 s. São gates que varrem a árvore inteira de arquivos, e a máquina estava com 7 GB
de 8 em swap. **Rodados isolados, os cinco passam** (45 + 3 asserts, ~1,3 s por arquivo, exit 0), e
nenhum deles cobre o que este PR toca — o commit só mexe em `db/`, `supabase/migrations/` e nos dois
artefatos de audit, nada em `src/`. Contenção de recurso local é ausência de dado, não reprovação;
**o CI é a autoridade aqui.**
