### PR TITLE
feat(farmer): a tela passa a mostrar a carteira, não a base inteira — o sinal de margem volta a 94% [money-path]

### DIFF
--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -1,6 +1,9 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { useCommercialRole } from '@/hooks/useCommercialRole';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { filtrarPorCarteira } from '@/lib/scoring/escopoCarteira';
 import type { Tables } from '@/integrations/supabase/types';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 import { fetchAllPages } from '@/lib/postgrest';
@@ -113,6 +116,16 @@ export const useFarmerScoring = (farmerId?: string) => {
   const { effectiveUserId } = useImpersonation();
   const targetFarmerId = farmerId || effectiveUserId;
 
+  // `cap_carteira_ler` = master OU employee gerencial/estrategico/super_admin — o MESMO predicado
+  // que `private.cap_carteira_ler` aplica dentro de `get_carteira_margem_faixa()`. Quem passa nele
+  // não é recortado (a RPC já lhe devolve tudo); quem não passa vê só a carteira.
+  //
+  // ⚠️ `loadingRole` importa: enquanto o papel não resolve, `canViewManagerial` é false, e calcular
+  // agora recortaria a tela de um gestor por um instante. O cálculo espera (dependência do effect).
+  const { isMaster } = useAuth();
+  const { canViewManagerial, loading: loadingRole } = useCommercialRole();
+  const capCarteiraLer = isMaster || canViewManagerial;
+
   const [config, setConfig] = useState<AlgorithmConfig>(DEFAULT_CONFIG);
   const [clientScores, setClientScores] = useState<ClientScore[]>([]);
   const [agenda, setAgenda] = useState<AgendaItem[]>([]);
@@ -186,6 +199,34 @@ export const useFarmerScoring = (farmerId?: string) => {
       );
       const flaggeds = new Set<string>(flaggedRows.map((r) => r.user_id));
 
+      // 1b. ESCOPO DA TELA — a carteira visível do caller (decisão do founder, 2026-08-14).
+      //
+      // Sem isto a tela listava `sales_orders` COMPANY-WIDE (a policy `sales_orders_select_staff`
+      // é staff-wide) enquanto `get_carteira_margem_faixa()` responde só pela carteira: medido em
+      // prod, 541 e 440 dos 835 clientes de cada vendedora eram de OUTRA carteira, e a margem
+      // aparecia como "Sem custo conhecido" em 562/464 deles. Alinhar os dois derruba para 21/24.
+      //
+      // A fonte é a RLS, não uma regra reescrita aqui: a policy de SELECT de `carteira_assignments`
+      // É `private.carteira_visivel_para(customer_user_id, auth.uid())` — a MESMA função que a RPC
+      // usa. Um `select` sem filtro de dono já volta recortado, e cobertura ativa entra de graça
+      // (hoje `carteira_coverage` tem 0 linhas, mas a regra não fica devendo quando tiver).
+      // O `.eq('eligible', true)` é redundante com o braço de assignment da função e está explícito
+      // de propósito: se a policy afrouxar, o recorte da tela não afrouxa junto.
+      //
+      // fetchAllPages (não `.select()` cru): são 7.301 assignments, muito além da capa de 1.000 do
+      // PostgREST — e o helper LANÇA em página que falha, então falha de transporte vira erro
+      // declarado, nunca carteira menor em silêncio (que seria cliente sumindo da tela).
+      const carteiraRows = capCarteiraLer ? [] : await fetchAllPages<{ customer_user_id: string }>((de, ate) =>
+        supabase
+          .from('carteira_assignments')
+          .select('customer_user_id')
+          .eq('eligible', true)
+          .order('customer_user_id', { ascending: true })
+          .range(de, ate) as unknown as PromiseLike<{ data: { customer_user_id: string }[] | null; error: unknown }>,
+        'carteira_assignments/scoring',
+      );
+      const carteira = new Set<string>(carteiraRows.map((r) => r.customer_user_id));
+
       // 2. Faixa de margem + componente G, vindos do SERVIDOR (FU4-F fase 3).
       //
       // Antes, este bloco baixava `product_costs` INTEIRA para o browser — 3.637 linhas de
@@ -226,11 +267,16 @@ export const useFarmerScoring = (farmerId?: string) => {
       //     REMOVE (472 e 379 perdem). Alinhar a allowlist daqui fecha o primeiro (delta do master
       //     vai a 1 cliente) e não toca o segundo — mas troca 9 dos 20 slots da agenda: é decisão
       //     de PRODUTO, do founder, não higiene de filtro.
-      //   • O eixo ESCOPO também foi medido (cenário D): restringir ESTA lista à carteira do
-      //     caller leva a tela de 835 para 294/395 clientes e derruba o delta de faixa a 8,5%/6,6%
-      //     — o patamar do master, ou seja, sobra só o universo. Custa 11–12 dos 20 slots, MAIS
-      //     que alinhar a allowlist, porque muda a POPULAÇÃO e com ela o p95 que normaliza `m`
-      //     (e portanto recover/priority, que a agenda lê). Também decisão de produto.
+      //   • O eixo ESCOPO foi medido (cenário D) e ✅ FECHADO em 2026-08-14 (decisão do founder):
+      //     esta lista passou a ser recortada pela carteira visível — ver o bloco "1b. ESCOPO DA
+      //     TELA" acima. Leva a tela de 835 para 294/395 clientes, derruba o delta de faixa a
+      //     8,5%/6,6% (o patamar do master, ou seja, sobra só o eixo universo) e o "sem margem"
+      //     de 562/464 para 21/24. Custou 11–12 dos 20 slots da agenda, MAIS que alinhar a
+      //     allowlist, porque muda a POPULAÇÃO e com ela o p95 que normaliza `m` (e portanto
+      //     recover/priority, que a agenda lê).
+      //   • O eixo UNIVERSO (a allowlist logo acima) segue ABERTO — de propósito. Fechá-lo troca
+      //     outros 9 slots e é decisão separada; o chip "Corrigir filtro de status do scoring do
+      //     farmer" continua valendo.
       //
       // `margem_pct` só vem preenchido para quem tem `cap_custo_ler`; para os demais é null e a
       // UI mostra a FAIXA no lugar do número. O gate é de PROJEÇÃO, no corpo da RPC.
@@ -344,6 +390,16 @@ export const useFarmerScoring = (farmerId?: string) => {
         // A margem NÃO é mais acumulada aqui — vem pronta da RPC (fase 3). O laço acima
         // continua porque `categories` alimenta o componente X (diversidade de mix), que não
         // depende de custo.
+      }
+
+      // 5b. Recorte da tela pela carteira — ANTES da população, e isso não é detalhe de ordem.
+      // Os percentis abaixo (p95 de spend) normalizam `m`, que entra em `recover` e `priority`,
+      // que a agenda LÊ. Filtrar depois mediria cada cliente contra uma população que a tela não
+      // mostra mais — número plausível e errado. Medido: a agenda troca 11–12 dos 20 slots
+      // justamente por isso (docs/historico/farmer-scoring-paridade-ts-sql.md §6).
+      const visiveis = new Set(filtrarPorCarteira([...customerMap.keys()], { capCarteiraLer, carteira }));
+      for (const cid of [...customerMap.keys()]) {
+        if (!visiveis.has(cid)) customerMap.delete(cid);
       }
 
       // Aggregate call data
@@ -562,11 +618,14 @@ export const useFarmerScoring = (farmerId?: string) => {
       setCalculating(false);
       setLoading(false);
     }
-  }, [targetFarmerId, config]);
+  }, [targetFarmerId, config, capCarteiraLer]);
 
   useEffect(() => {
-    if (targetFarmerId) calculateScores();
-  }, [targetFarmerId]);
+    // `!loadingRole`: calcular antes de o papel comercial resolver recortaria a tela de um gestor
+    // (canViewManagerial nasce false), e o recálculo só viria no próximo disparo. Esperar é a
+    // diferença entre "gestor vê a base" e "gestor pisca a carteira e depois vê a base".
+    if (targetFarmerId && !loadingRole) calculateScores();
+  }, [targetFarmerId, loadingRole, capCarteiraLer]);
 
   // Summary stats
   const summary = useMemo(() => {

--- a/src/lib/scoring/__tests__/escopoCarteira.test.ts
+++ b/src/lib/scoring/__tests__/escopoCarteira.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { filtrarPorCarteira } from '../escopoCarteira';
+
+/**
+ * O universo da TELA do farmer.
+ *
+ * Medido em prod (2026-08-13, `docs/historico/farmer-scoring-paridade-ts-sql.md` §6): o
+ * `useFarmerScoring` lista 835 clientes company-wide, mas só 294/395 são da carteira de cada
+ * vendedora — e a RPC de margem responde só pela carteira. Resultado: "Sem custo conhecido" em
+ * 562 de 835 clientes. Alinhar a tela ao escopo da RPC derruba isso para 21.
+ *
+ * A regra mora aqui, e não dentro do hook, pelo mesmo motivo de `healthScore.ts`: o que importa
+ * é o comportamento de BORDA (carteira vazia), e ele não é testável no meio de query + agregação.
+ */
+describe('filtrarPorCarteira — o universo da tela', () => {
+  const clientes = ['a', 'b', 'c'];
+
+  it('sem capability, mantém só os clientes da carteira', () => {
+    const r = filtrarPorCarteira(clientes, { capCarteiraLer: false, carteira: new Set(['a', 'c']) });
+    expect(r).toEqual(['a', 'c']);
+  });
+
+  it('com cap_carteira_ler (gestor/master), devolve todos e ignora a carteira', () => {
+    // O master é o CONTROLE do cenário medido: a RPC já lhe devolve tudo, então filtrar a tela
+    // dele mudaria o que ele vê sem fechar delta nenhum (medido: 835→835, 58→58, 0 slots).
+    const r = filtrarPorCarteira(clientes, { capCarteiraLer: true, carteira: new Set(['a']) });
+    expect(r).toEqual(['a', 'b', 'c']);
+  });
+
+  it('carteira VAZIA sem capability devolve lista vazia — nunca a base inteira', () => {
+    // Fail-closed. É o acidente do money-path.md §7 ao contrário: lá o caller leu lista vazia
+    // como "este farmer não tem carteira, deve ser super_admin" e recarregou SEM filtro, virando
+    // a base inteira o universo do cálculo. Vendedora sem carteira vê ZERO, não vê tudo.
+    const r = filtrarPorCarteira(clientes, { capCarteiraLer: false, carteira: new Set() });
+    expect(r).toEqual([]);
+  });
+
+  it('não inventa cliente que não estava na lista, mesmo se a carteira o contiver', () => {
+    // A carteira RECORTA o universo; não o expande. Um assignment para cliente sem pedido não
+    // pode fazer aparecer alguém que o motor não pontuou.
+    const r = filtrarPorCarteira(clientes, { capCarteiraLer: false, carteira: new Set(['a', 'zzz']) });
+    expect(r).toEqual(['a']);
+  });
+
+  it('preserva a ordem recebida', () => {
+    // A ordem de entrada carrega a prioridade já calculada; reordenar aqui mudaria a agenda por
+    // efeito colateral de um filtro.
+    const r = filtrarPorCarteira(['c', 'a', 'b'], { capCarteiraLer: false, carteira: new Set(['a', 'b', 'c']) });
+    expect(r).toEqual(['c', 'a', 'b']);
+  });
+});

--- a/src/lib/scoring/escopoCarteira.ts
+++ b/src/lib/scoring/escopoCarteira.ts
@@ -1,0 +1,36 @@
+// O universo da TELA do farmer — recorte de exibição alinhado ao escopo da RPC de margem.
+//
+// Extraído para cá (e não deixado inline no `useFarmerScoring`) pelo mesmo motivo de
+// `healthScore.ts`: a regra que importa é o comportamento de BORDA, e ele não era testável no
+// meio de query + agregação.
+//
+// POR QUE EXISTE (medido em prod 2026-08-13 — `docs/historico/farmer-scoring-paridade-ts-sql.md`):
+// o hook lista `sales_orders` company-wide (835 clientes), mas `get_carteira_margem_faixa()`
+// responde só pela carteira do caller. Para as duas vendedoras reais, 541 e 440 dos 835 clientes
+// da tela eram de OUTRA carteira — e apareciam com "Sem custo conhecido" em 562/464 casos.
+// Alinhar a tela ao escopo da RPC derruba isso para 21/24 e devolve o sinal de margem a ~94% da
+// carteira, ao custo de 11–12 dos 20 slots da agenda (decisão do founder, 2026-08-14).
+
+export interface EscopoCarteira {
+  /** `cap_carteira_ler` = master OU employee gerencial/estrategico/super_admin. */
+  capCarteiraLer: boolean;
+  /** Clientes visíveis. Vem da RLS de `carteira_assignments`, que JÁ é `carteira_visivel_para`. */
+  carteira: Set<string>;
+}
+
+/**
+ * Recorta a lista de clientes ao que o caller pode ver.
+ *
+ * ⚠️ FAIL-CLOSED: carteira vazia sem `cap_carteira_ler` devolve LISTA VAZIA, nunca a base
+ * inteira. É o acidente do money-path.md §7 ao contrário — lá o caller leu lista vazia como
+ * "este farmer não tem carteira, deve ser super_admin" e recarregou SEM filtro, transformando a
+ * base inteira no universo do cálculo. Vendedora sem carteira vê zero clientes, não vê todos.
+ *
+ * ⚠️ A carteira RECORTA, não expande: assignment de cliente sem pedido não faz aparecer alguém
+ * que o motor não pontuou. E a ORDEM de entrada é preservada, porque ela carrega a prioridade já
+ * calculada — reordenar aqui mudaria a agenda por efeito colateral de um filtro.
+ */
+export function filtrarPorCarteira(clientes: string[], escopo: EscopoCarteira): string[] {
+  if (escopo.capCarteiraLer) return clientes;
+  return clientes.filter((cid) => escopo.carteira.has(cid));
+}

--- a/src/pages/__tests__/FarmerDashboard.erro-honesto.test.tsx
+++ b/src/pages/__tests__/FarmerDashboard.erro-honesto.test.tsx
@@ -26,6 +26,7 @@ const FARMER_A = 'farmer-a';
 
 let falharScores = false;
 let falharFaixas = false;
+let falharCarteira = false;
 let farmerAtual = FARMER_A;
 
 const ERRO_TIMEOUT = { code: '57014', message: 'canceling statement due to statement timeout' };
@@ -43,12 +44,20 @@ const PERFIS = [{ user_id: 'c1', name: 'Cliente Um', phone: null }];
 // o número fecha, o sinal fica.
 const FAIXAS = [{ customer_user_id: 'c1', faixa: 'verde', motivo: 'saudavel', g: 0.8, margem_pct: null }];
 
+// A tela do farmer é recortada pela CARTEIRA visível (decisão de 2026-08-14): sem um assignment
+// para `c1`, o fail-closed de `filtrarPorCarteira` esvazia a lista — e é isso que deve acontecer.
+const CARTEIRA = [{ customer_user_id: 'c1' }];
+
 function resposta(table: string): unknown {
   if (table === 'sales_orders') {
     if (falharScores) return { data: null, error: ERRO_TIMEOUT };
     return { data: PEDIDOS, error: null };
   }
   if (table === 'profiles') return { data: PERFIS, error: null };
+  if (table === 'carteira_assignments') {
+    if (falharCarteira) return { data: null, error: ERRO_TIMEOUT };
+    return { data: CARTEIRA, error: null };
+  }
   return { data: [], error: null, count: 0 };
 }
 
@@ -78,7 +87,12 @@ vi.mock('@/contexts/ImpersonationContext', () => ({
   useImpersonation: () => ({ isImpersonating: false, effectiveUserId: farmerAtual }),
 }));
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ user: { id: FARMER_A }, isStaff: true, loading: false }),
+  useAuth: () => ({ user: { id: FARMER_A }, isStaff: true, isMaster: false, loading: false }),
+}));
+// Vendedora SEM `cap_carteira_ler`: é quem sofre o recorte da carteira (gestor/master lê tudo, e
+// para ele o filtro é inerte — medido: 835→835, zero slots trocados).
+vi.mock('@/hooks/useCommercialRole', () => ({
+  useCommercialRole: () => ({ canViewManagerial: false, loading: false }),
 }));
 vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
@@ -105,6 +119,7 @@ const renderDashboard = () => {
 beforeEach(() => {
   falharScores = false;
   falharFaixas = false;
+  falharCarteira = false;
   farmerAtual = FARMER_A;
   vi.clearAllMocks();
 });
@@ -154,6 +169,26 @@ describe('FarmerDashboard — falha do scoring não vira "carteira vazia"', () =
     expect(
       screen.queryByText(/Nenhum cliente na agenda/i),
       'afirmou carteira vazia onde a verdade é falha ao ler a margem',
+    ).toBeNull();
+  });
+
+  it('falha ao ler a CARTEIRA é erro honesto — não a tela vazia que o fail-closed produziria', async () => {
+    // A carteira virou o universo da tela (2026-08-14), e com isso ganhou o poder de esvaziá-la:
+    // `filtrarPorCarteira` é fail-closed, então carteira vazia ⇒ zero clientes. Isso é CERTO para
+    // uma vendedora genuinamente sem carteira e seria uma MENTIRA para um timeout de leitura —
+    // as duas situações chegam aqui como "nenhum id". Quem as separa é o `fetchAllPages`, que
+    // LANÇA em página que falha em vez de devolver lista curta (money-path.md §6).
+    // Sem este teste, uma futura troca do helper por `.select()` cru trocaria "não consegui ler"
+    // por "você não tem clientes", que é exatamente o bug que este arquivo inteiro persegue.
+    falharCarteira = true;
+
+    renderDashboard();
+
+    const aviso = await screen.findByRole('alert');
+    expect(aviso.textContent, 'a falha ao ler a carteira morreu no console').toMatch(/indispon/i);
+    expect(
+      screen.queryByText(/Nenhum cliente na agenda/i),
+      'afirmou carteira vazia onde a verdade é falha ao ler a carteira',
     ).toBeNull();
   });
 


### PR DESCRIPTION
Fecha o eixo **escopo** medido no #1727 (decisão do founder, 2026-08-14).

O `useFarmerScoring` listava `sales_orders` **company-wide** (a policy `sales_orders_select_staff` é staff-wide), enquanto `get_carteira_margem_faixa()` responde só pela carteira do caller. Medido em prod: **541 e 440 dos 835** clientes que cada vendedora via na tela eram de **outra carteira**, e a margem aparecia como "Sem custo conhecido" em 562/464 deles.

## Efeito medido (cenário D do harness)

| | farmer `33f59dc7` | farmer `700657a1` | master (**controle**) |
|---|---:|---:|---:|
| clientes na tela | 835 → **294** | 835 → **395** | 835 → 835 |
| **sem margem** | 562 → **21** | 464 → **24** | 71 → 71 |
| delta faixa TS×SQL | 59,5% → **8,5%** | 48,5% → **6,6%** | 6,9% → 6,9% |
| agenda | troca **11 de 20** | troca **12 de 20** | **0 de 20** |

O sinal de margem volta a cobrir **~94% da carteira**. O custo — 11–12 slots da agenda — é o que foi aceito na decisão. O master não se move em nada: tem `cap_carteira_ler`, e a RPC já lhe devolvia tudo.

## Decisões de implementação

**A fonte do escopo é a RLS, não uma regra reescrita no client.** A policy de SELECT de `carteira_assignments` **é** `private.carteira_visivel_para(customer_user_id, auth.uid())` — a mesma função que a RPC usa. Um `select` sem filtro de dono já volta recortado, e cobertura ativa entra de graça (hoje `carteira_coverage` tem 0 linhas, mas a regra não fica devendo quando tiver). Replicar a regra aqui seria criar a segunda autoridade que o #1519 existiu para eliminar.

**O filtro vem ANTES da população**, e isso não é detalhe de ordem: os percentis (p95 de spend) normalizam `m`, que entra em `recover` e `priority`, que a agenda **lê**. Filtrar depois mediria cada cliente contra uma população que a tela não mostra mais — número plausível e errado. É exatamente por isso que a agenda troca 11–12 slots.

**Fail-closed.** `filtrarPorCarteira` (novo, TDD, 5 testes): carteira vazia sem `cap_carteira_ler` devolve lista **vazia**, nunca a base inteira. É o acidente do `money-path.md` §7 ao contrário — lá o caller leu lista vazia como *"este farmer não tem carteira, deve ser super_admin"* e recarregou **sem filtro**, virando a base inteira o universo do cálculo.

**O fail-closed ganhou o poder de esvaziar a tela** — então "não consegui ler a carteira" e "você não tem clientes" chegam iguais ao filtro. Quem os separa é o `fetchAllPages`, que **lança** em página que falha. Teste novo no `FarmerDashboard.erro-honesto` fixa isso, **falsificado** trocando o helper por `.select()` cru com `?? []`: **1 de 6 vermelho, e só ele**.

**`loadingRole` nas deps:** calcular antes de o papel comercial resolver recortaria a tela de um gestor por um instante (`canViewManagerial` nasce `false`).

## Fora de escopo, de propósito

O eixo **universo** (a allowlist de status, que resolve só para `faturado`) segue aberto — são outros 9 slots e decisão separada. O chip "Corrigir filtro de status do scoring do farmer" continua valendo.

A lente "Ver como" mantém o comportamento atual: a RLS usa `auth.uid()` real, então o master segue vendo tudo mesmo impersonando — que é o que o cenário D mediu para ele (835→835).

Gates: `typecheck 0` · `lint 0` · **suíte 6139/6139**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)