### PR TITLE
feat(authz): `motivo` entra no gate de custo — a âncora que invertia o `g` some [money-path]

### DIFF
--- a/db/test-carteira-margem-faixa-motivo-gate.sh
+++ b/db/test-carteira-margem-faixa-motivo-gate.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# ╔═══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA — FU4-F fase 3c: `motivo` entra no gate de custo.                      ║
+# ║  As ÂNCORAS ABSOLUTAS (piso/meta) somem para quem não tem cap_custo_ler,      ║
+# ║  matando a inversão da transformação afim margem_pct = A + B*g.               ║
+# ║                                                                               ║
+# ║      bash db/test-carteira-margem-faixa-motivo-gate.sh > /tmp/t.log 2>&1; echo $?  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                       ║
+# ║                                                                               ║
+# ║  Migration sob teste: 20260813234112_carteira_margem_faixa_motivo_gate_custo  ║
+# ║  A RPC do #1543 é aplicada REAL antes (não stub): é o corpo que a nova        ║
+# ║  substitui, e só assim o CREATE OR REPLACE é exercido como em prod.           ║
+# ╚═══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5479}"
+SLUG="motivo-gate"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# Falsificação: exige o valor EXATO que a sabotagem produz. Um "!= esperado" aceitaria string
+# vazia ou erro de conexão como se fosse prova, e a sabotagem passaria por acidente.
+falsif() { if [ "$2" = "$3" ]; then ok "$1 (sabotagem produziu [$2], como exigido)"; else bad "$1 — a sabotagem NAO produziu o vermelho esperado [$3], veio [$2]"; fi; }
+
+MASTER='11111111-1111-1111-1111-111111111111'   # app_role master        → cap_custo_ler TRUE
+ATACA='22222222-2222-2222-2222-222222222222'    # employee + farmer      → cap_custo_ler FALSE
+ESTRAT='33333333-3333-3333-3333-333333333333'   # employee + estrategico → cap_custo_ler TRUE
+CLI='aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'      # cliente alvo, margem 42% → verde / abaixo_da_meta
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (definições REAIS de prod; o gate sob teste não é stub)
+# ═══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+CREATE TYPE public.app_role AS ENUM ('employee','customer','master');
+CREATE TYPE public.commercial_role AS ENUM
+  ('operacional','gerencial','estrategico','super_admin','farmer','hunter','closer','master');
+
+CREATE TABLE public.user_roles (user_id uuid NOT NULL, role public.app_role NOT NULL);
+CREATE TABLE public.commercial_roles (user_id uuid NOT NULL, commercial_role public.commercial_role NOT NULL);
+
+-- VERBATIM de prod (pg_get_functiondef, 2026-08-13)
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role app_role)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$ SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role) $function$;
+
+-- VERBATIM de prod — É o gate sob teste, não pode ser stub
+CREATE OR REPLACE FUNCTION private.cap_custo_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$
+  SELECT COALESCE(
+    _uid IS NOT NULL
+    AND (
+      public.has_role(_uid, 'master'::public.app_role)
+      OR (
+        public.has_role(_uid, 'employee'::public.app_role)
+        AND EXISTS (
+          SELECT 1 FROM public.commercial_roles cr
+           WHERE cr.user_id = _uid
+             AND cr.commercial_role IN ('estrategico','super_admin')
+        )
+      )
+    ), false);
+$function$;
+
+-- Dependências que NÃO são o objeto sob teste → stub honesto.
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(_uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public'
+AS $function$ SELECT public.has_role(_uid,'master'::public.app_role)
+                  OR public.has_role(_uid,'employee'::public.app_role) $function$;
+
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(_cliente uuid, _uid uuid)
+ RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $function$ SELECT true $function$;
+
+CREATE TABLE private.margem_seed (customer_user_id uuid, margem_pct numeric);
+CREATE OR REPLACE FUNCTION private.margem_cliente_agregada()
+ RETURNS TABLE(customer_user_id uuid, margem_pct numeric) LANGUAGE sql STABLE SECURITY DEFINER
+AS $function$ SELECT s.customer_user_id, s.margem_pct FROM private.margem_seed s $function$;
+
+CREATE TABLE public.farmer_algorithm_config (
+  id uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  key text NOT NULL UNIQUE,
+  value numeric NOT NULL,
+  description text,
+  updated_at timestamptz DEFAULT now()
+);
+ALTER TABLE public.farmer_algorithm_config ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Staff can view algorithm config" ON public.farmer_algorithm_config FOR SELECT
+  USING ((public.has_role(auth.uid(), 'master'::public.app_role) OR public.has_role(auth.uid(), 'employee'::public.app_role)));
+SQL
+
+# A RPC do #1543 — REAL. É o corpo que a migration nova substitui via CREATE OR REPLACE.
+P -q -f "$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+echo "pré-requisito aplicado: RPC real do #1543 (corpo ANTERIOR)"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — A MIGRATION SOB TESTE (Lei #1: o .sql commitado, não um stub da lógica)
+# ═══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# IDEMPOTÊNCIA — o apply é MANUAL (founder cola no SQL Editor) e re-colar após falha parcial é
+# rotina. O segundo Run TEM de passar limpo.
+if P -q -f "$MIG" >/dev/null 2>&1; then IDEM_OK=1; else IDEM_OK=0; fi
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED
+# ═══════════════════════════════════════════════════════════════════════════════
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$MASTER'),('$ATACA'),('$ESTRAT'),('$CLI') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id,role) VALUES
+  ('$MASTER','master'),('$ATACA','employee'),('$ESTRAT','employee');
+INSERT INTO public.commercial_roles(user_id,commercial_role) VALUES
+  ('$ATACA','farmer'),('$ESTRAT','estrategico');
+-- Um cliente por MOTIVO: é isso que dá ao atacante as âncoras que este PR remove.
+INSERT INTO private.margem_seed VALUES
+  ('$CLI', 42.0),                                          -- verde    / abaixo_da_meta
+  ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 10.0),          -- amarelo  / abaixo_do_piso
+  ('cccccccc-cccc-cccc-cccc-cccccccccccc', 80.0),          -- verde    / saudavel
+  ('dddddddd-dddd-dddd-dddd-dddddddddddd', -5.0),          -- vermelho / abaixo_do_custo
+  ('eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee', NULL);          -- neutro   / sem_custo
+SQL
+
+# helper: roda SQL como um usuário autenticado (GUC do JWT + SET ROLE).
+# `-q` é obrigatório: sem ele o psql ecoa a tag de comando de cada SET e o ruído entra na comparação.
+as_auth()   { Pq -q -c "SET test.uid='$1'; SET ROLE authenticated; $2"; }
+motivo_de() { as_auth "$1" "SELECT coalesce(motivo,'NULO') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';"; }
+faixa_de()  { as_auth "$1" "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';"; }
+pct_de()    { as_auth "$1" "SELECT coalesce(margem_pct::text,'NULO') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';"; }
+g_de()      { as_auth "$1" "SELECT CASE WHEN g IS NULL THEN 'NULO' ELSE 'PRESENTE' END FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';"; }
+# ÂNCORAS observáveis: quantos motivos DISTINTOS não-nulos a persona enxerga.
+ancoras_de() { as_auth "$1" "SELECT count(DISTINCT motivo)::text FROM public.get_carteira_margem_faixa() WHERE motivo IS NOT NULL;"; }
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── A. POSITIVO — com cap_custo_ler nada regride ──"
+eq "A1 master vê o motivo do alvo"            "$(motivo_de $MASTER)" "abaixo_da_meta"
+eq "A2 estrategico vê o motivo do alvo"       "$(motivo_de $ESTRAT)" "abaixo_da_meta"
+eq "A3 master vê margem_pct (gate anterior)"  "$(pct_de   $MASTER)"  "42.0"
+eq "A4 master vê as 5 âncoras de motivo"      "$(ancoras_de $MASTER)" "5"
+
+echo ""
+echo "── B. NEGATIVO — sem cap_custo_ler, a ÂNCORA some ──"
+eq "B1 atacante vê motivo NULO"                    "$(motivo_de $ATACA)" "NULO"
+eq "B2 atacante segue sem margem_pct (não regrediu)" "$(pct_de  $ATACA)" "NULO"
+eq "B3 ZERO âncoras observáveis pelo atacante"     "$(ancoras_de $ATACA)" "0"
+
+echo ""
+echo "── C. PRODUTO PRESERVADO — o sinal fica, o health score não muda ──"
+eq "C1 atacante ainda vê a FAIXA"        "$(faixa_de $ATACA)" "verde"
+eq "C2 atacante ainda recebe o \`g\`"     "$(g_de     $ATACA)" "PRESENTE"
+eq "C3 o \`g\` do atacante == o do master" \
+   "$(as_auth $ATACA "SELECT round(g,6)::text FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';")" \
+   "$(as_auth $MASTER "SELECT round(g,6)::text FROM public.get_carteira_margem_faixa() WHERE customer_user_id='$CLI';")"
+
+echo ""
+echo "── D. NÃO-REGRESSÃO de escopo/ACL/idempotência ──"
+eq "D1 fail-closed sem auth.uid()" \
+   "$(P -tA -q -c "SET test.uid=''; SELECT count(*)::text FROM public.get_carteira_margem_faixa();")" "0"
+eq "D2 anon NÃO executa"          "$(Pq -q -c "SELECT has_function_privilege('anon','public.get_carteira_margem_faixa()','EXECUTE')::text;")" "false"
+eq "D3 authenticated executa"     "$(Pq -q -c "SELECT has_function_privilege('authenticated','public.get_carteira_margem_faixa()','EXECUTE')::text;")" "true"
+eq "D4 função segue SECURITY DEFINER" \
+   "$(Pq -q -c "SELECT prosecdef::text FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")" "true"
+eq "D5 migration é idempotente (2º Run limpo)" "$IDEM_OK" "1"
+
+echo ""
+echo "── E. O ATAQUE — a calibração afim não fecha mais ──"
+# O atacante calibra B = (meta-piso)/(g_meta - g_piso). Sem motivo, ele não sabe QUAL g é qual,
+# então o par nem se forma: as duas pontas vêm NULAS.
+eq "E1 atacante não obtém o g da âncora do piso" \
+   "$(as_auth $ATACA "SELECT coalesce(max(g)::text,'NULO') FROM public.get_carteira_margem_faixa() WHERE motivo='abaixo_do_piso';")" "NULO"
+eq "E2 atacante não obtém o g da âncora da meta" \
+   "$(as_auth $ATACA "SELECT coalesce(max(g)::text,'NULO') FROM public.get_carteira_margem_faixa() WHERE motivo='abaixo_da_meta';")" "NULO"
+eq "E3 o master (legítimo) AINDA calibra — a capacidade não foi destruída para quem pode" \
+   "$(as_auth $MASTER "SELECT CASE WHEN max(g) FILTER (WHERE motivo='abaixo_da_meta') IS NOT NULL
+                                    AND max(g) FILTER (WHERE motivo='abaixo_do_piso') IS NOT NULL
+                                   THEN 'CALIBRA' ELSE 'NAO' END FROM public.get_carteira_margem_faixa();")" "CALIBRA"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota a migration e EXIGE o vermelho
+# ═══════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "── F. FALSIFICAÇÃO — os asserts têm dente? ──"
+SAB="/tmp/sab-${SLUG}.sql"
+
+# K1 — remove o gate do motivo (volta ao corpo do #1543). B1/B3 têm de ficar VERMELHOS.
+# O `.*?` com /s atravessa as 5 linhas do CASE interno; o wrapper some e o CASE interno vira a
+# projeção direta — exatamente o corpo anterior a este PR.
+perl -0pe "s/    CASE WHEN v_pode_num THEN\n(      CASE WHEN b\.pct IS NULL.*?'saudavel' END)\n    END,/\$1,/s" "$MIG" > "$SAB"
+# A sabotagem tem de PROVAR que aplicou: um padrão que não casa deixaria o teste medindo o
+# código ÍNTEGRO e reportando "sem dente" quando o assert está ótimo (§ money-path).
+# ⚠️ A âncora é `CASE WHEN v_pode_num THEN` NO FIM DA LINHA — só o gate do MOTIVO tem essa forma;
+# o de margem_pct é `CASE WHEN v_pode_num THEN b.pct END`, na mesma linha. Um `grep -F` com padrão
+# multilinha NÃO serve aqui: o grep trata cada linha do padrão como alternativa (OR), então a 1ª
+# linha casaria o gate de margem_pct e a checagem acusaria "não aplicou" com a sabotagem correta.
+if [ "$(command grep -c 'CASE WHEN v_pode_num THEN$' "$SAB")" != "0" ]; then
+  bad "K1 INVALIDA: a sabotagem NAO removeu o gate do motivo (padrao nao casou)"
+elif ! P -q -f "$SAB" >/dev/null 2>&1; then
+  bad "K1 INVALIDA: migration sabotada nao aplica (build quebrado != 'sem dente')"
+else
+  falsif "K1 sem o gate, o motivo VAZA (B1 fica vermelho)" "$(motivo_de $ATACA)" "abaixo_da_meta"
+  falsif "K1 sem o gate, as 5 âncoras VOLTAM (B3 fica vermelho)" "$(ancoras_de $ATACA)" "5"
+  P -q -f "$MIG" >/dev/null 2>&1   # restaura o corpo verdadeiro
+fi
+
+# K2 — gateia o `g` também. C2 tem de ficar VERMELHO: é o assert que prova que este PR
+#      NÃO mudou produto. Sem dente aqui, um gate acidental de `g` passaria despercebido.
+perl -0pe "s/    CASE WHEN b\.pct IS NULL THEN NULL\n         ELSE greatest\(0::numeric,/    CASE WHEN b.pct IS NULL OR NOT v_pode_num THEN NULL\n         ELSE greatest(0::numeric,/s" "$MIG" > "$SAB"
+if ! command grep -qF "b.pct IS NULL OR NOT v_pode_num" "$SAB"; then
+  bad "K2 INVALIDA: a sabotagem do \`g\` nao aplicou"
+else
+  P -q -f "$SAB" >/dev/null 2>&1 || bad "K2 INVALIDA: migration sabotada nao aplica"
+  falsif "K2 com \`g\` gateado, C2 fica vermelho" "$(g_de $ATACA)" "NULO"
+  P -q -f "$MIG" >/dev/null 2>&1
+fi
+
+# K3 — remove o gate de margem_pct. B2 tem de ficar VERMELHO (não-regressão do #1543).
+perl -0pe "s/    CASE WHEN v_pode_num THEN b\.pct END/    b.pct/s" "$MIG" > "$SAB"
+if command grep -qF "CASE WHEN v_pode_num THEN b.pct END" "$SAB"; then
+  bad "K3 INVALIDA: a sabotagem de margem_pct nao aplicou (padrao nao casou)"
+elif ! P -q -f "$SAB" >/dev/null 2>&1; then
+  bad "K3 INVALIDA: migration sabotada nao aplica (build quebrado != 'sem dente')"
+else
+  falsif "K3 sem o gate de margem_pct, B2 fica vermelho" "$(pct_de $ATACA)" "42.0"
+  P -q -f "$MIG" >/dev/null 2>&1
+fi
+
+# K4 — CANÁRIO: a migration íntegra voltou? Sem isto, um restore falho deixaria os asserts
+#      acima medindo uma função sabotada e ninguém saberia.
+eq "K4 canário: migration íntegra restaurada (motivo volta a ser NULO p/ o atacante)" \
+   "$(motivo_de $ATACA)" "NULO"
+eq "K4b canário: o master volta a ver o motivo" "$(motivo_de $MASTER)" "abaixo_da_meta"
+
+rm -f "$SAB"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 6 — IMPRESSÃO DIGITAL (herdada do #1543): esta migration MUDA o `prosrc`
+# ═══════════════════════════════════════════════════════════════════════════════
+# O #1543 gravou o md5 do corpo normalizado em db/valida-fu4f-fase3-carteira-margem-faixa.sql
+# (check c10) e o #1728 pôde afirmar "o corpo NÃO mudou" porque COMMENT não toca `prosrc`.
+# Esta migration é a PRIMEIRA a mudar o corpo desde então — logo a digital VENCE, e uma digital
+# vencida devolve `f` num banco CORRETO: falso alarme que pararia um deploy na mão do founder.
+# Este assert é o que impede a digital de envelhecer em silêncio.
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZONA 6b — O COMMENT do #1728 SOBREVIVEU? (união, não substituição)
+# ═══════════════════════════════════════════════════════════════════════════════
+# Esta migration roda DEPOIS da 20260813225057 e reescreve o COMMENT — "a última a escrever
+# vence". O #1728 tinha acabado de trocar uma promessa FALSA de equivalência de score pelo delta
+# medido; um COMMENT novo escrito do zero apagaria isso EM SILÊNCIO (nenhum gate de CI olha o
+# catálogo, e o harness dele aplica só a migration dele, então ficaria verde).
+# Estes asserts são a rede: eles falham se alguém (eu inclusive) voltar a substituir em vez de unir.
+echo ""
+echo "── G0. o COMMENT do #1728 sobreviveu à minha reescrita? ──"
+P -q -f "$REPO_ROOT/supabase/migrations/20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql" >/dev/null 2>&1
+P -q -f "$MIG" >/dev/null 2>&1   # ordem REAL de prod: a 3c por último
+com() { Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%$1%')::text;"; }
+eq "G0a a promessa falsa NÃO voltou (ausência de 'byte a byte')" "$(com 'byte a byte')" "false"
+eq "G0b a medição do #1728 sobreviveu (30.833 x 20.597)"        "$(com '30.833 pedidos contra 20.597')" "true"
+eq "G0c 'health score MUDA' sobreviveu"                          "$(com 'health score MUDA')" "true"
+eq "G0d o delta do #1721 sobreviveu (59,5%)"                     "$(com '59,5')" "true"
+eq "G0e 'AGENDA NAO muda' sobreviveu"                            "$(com 'AGENDA NAO muda')" "true"
+eq "G0f e a fase 3c foi ACRESCENTADA"                            "$(com 'FASE 3c')" "true"
+
+echo ""
+echo "── G. IMPRESSÃO DIGITAL do corpo (o #1543 amarrou o validador ao corpo testado) ──"
+MD5_APLICADO="$(Pq -q -c "SELECT md5(regexp_replace(prosrc, '[[:space:]]+', ' ', 'g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")"
+# `|| true`: sob pipefail, `sed` em arquivo ausente derrubaria o harness inteiro em silêncio.
+MD5_DOC="$(sed -n 's/.*IMPRESSAO_DIGITAL=\([0-9a-f]\{32\}\).*/\1/p' "$REPO_ROOT/db/valida-fu4f-fase3-carteira-margem-faixa.sql" 2>/dev/null | head -1 || true)"
+echo "  (md5 do corpo com o gate do motivo: $MD5_APLICADO)"
+eq "G1 a digital em db/valida-*.sql casa o corpo desta cadeia de migrations" "$MD5_DOC" "$MD5_APLICADO"
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "  PASS=$PASS  FAIL=$FAIL"
+echo "═══════════════════════════════════════════"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/db/test-comment-honesto-margem-faixa.sh
+++ b/db/test-comment-honesto-margem-faixa.sh
@@ -127,17 +127,30 @@ eq "B5 o corpo (prosrc) NÃO mudou — a digital do #1543 segue válida" \
    "$DIGITAL_ANTES"
 
 echo "-- C. a validação pós-apply do #1543 continua verde --"
+# ⚠️ A fase 3c (20260813234112) entra AQUI, e a posição é o ponto: depois do B5 — que prova que
+# `COMMENT` não toca `prosrc`, e por isso tem de rodar com o corpo ainda intocado — e antes do C1,
+# que roda o validador compartilhado. A 3c põe `motivo` sob cap_custo_ler e MUDA o corpo, então a
+# impressão digital em db/valida-*.sql passou a ser a da CADEIA (169677fe…, era 075209b9…). Sem
+# esta linha o validador acusaria `f` no c10 — vermelho por defasagem de estado, não por defeito
+# desta migration, e a leitura natural desse vermelho mandaria a próxima pessoa para o lado errado.
+P -q -f "$REPO_ROOT/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql"
 VAL="$(Pq -q -f "$REPO_ROOT/db/valida-fu4f-fase3-carteira-margem-faixa.sql")"
 eq "C1 os 11 checks do #1543 seguem 't' depois desta migration" \
    "$(printf '%s' "$VAL" | tr '|' '\n' | sort -u | tr -d '\n')" "t"
 
 echo "-- D. idempotência --"
+# ⚠️ O baseline do D2 é capturado AQUI, e não é mais o `$DIGITAL_ANTES` do topo. A propriedade que
+# este assert prova é "re-aplicar o COMMENT não mexe no corpo" — ela vale contra o corpo VIGENTE,
+# qualquer que ele seja. Prendê-la à digital do #1543 fazia o assert medir, de quebra, "o corpo
+# nunca mudou desde o #1543", que a fase 3c revoga de propósito: o vermelho apareceria aqui, longe
+# da causa, dizendo "COMMENT mexeu no corpo" — uma acusação FALSA contra a migration errada.
+DIGITAL_VIGENTE="$(Pq -q -c "SELECT md5(regexp_replace(prosrc,'[[:space:]]+',' ','g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")"
 P -q -f "$MIG_COM"
 eq "D1 re-aplicar mantém o comentário novo" \
    "$(Pq -q -c "SELECT (obj_description('public.get_carteira_margem_faixa()'::regprocedure) LIKE '%health score MUDA%')::text;")" "true"
 eq "D2 re-aplicar não mexe no corpo" \
    "$(Pq -q -c "SELECT md5(regexp_replace(prosrc,'[[:space:]]+',' ','g')) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='public' AND p.proname='get_carteira_margem_faixa';")" \
-   "$DIGITAL_ANTES"
+   "$DIGITAL_VIGENTE"
 
 echo "-- E. FALSIFICAÇÃO --"
 # Sem isto, B2/B3/B4 seriam decorativos: um arquivo que não aplicasse NADA deixaria o comentário

--- a/db/test-fu4f-fase3-carteira-margem-faixa.sh
+++ b/db/test-fu4f-fase3-carteira-margem-faixa.sh
@@ -88,6 +88,11 @@ SQL
 P -q -f "$REPO_ROOT/supabase/migrations/20260726150000_margem_cliente_helper_compartilhado.sql"
 P -q -f "$REPO_ROOT/supabase/migrations/20260726160000_margem_reconciliacao_universo_unico.sql"
 P -q -f "$REPO_ROOT/supabase/migrations/20260726170000_fu4f_fase3_carteira_margem_faixa.sql"
+# Fase 3c (2026-08-13): poe `motivo` sob cap_custo_ler e portanto RECRIA a funcao. Entra aqui
+# porque o assert L1 compara a digital documentada com o corpo APLICADO — sem esta linha o
+# harness mediria o corpo do #1543 contra a digital da cadeia e ficaria vermelho por defasagem,
+# nao por defeito. O gate do `motivo` em si e provado em db/test-carteira-margem-faixa-motivo-gate.sh.
+P -q -f "$REPO_ROOT/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql"
 
 # ── seed: 5 clientes com margens espalhadas, em 2 carteiras ──────────────────
 P -q <<'SQL'
@@ -162,20 +167,32 @@ eq "F2 SEM cap_custo_ler, margem_pct é NULL" \
    "$(como $A false false "SELECT coalesce(margem_pct::text,'') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" ""
 eq "F3 a FAIXA sai mesmo sem cap_custo_ler (o sinal fica)" \
    "$(como $A false false "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "amarelo"
-eq "F4 o MOTIVO sai mesmo sem cap_custo_ler" \
-   "$(como $A false false "SELECT motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "abaixo_do_piso"
+# ⚠️ REVISTO na fase 3c (2026-08-13). Este assert afirmava "o MOTIVO sai mesmo sem cap_custo_ler",
+# e essa era a decisão original do #1543. Ela foi REVOGADA de propósito: `motivo` carregava as
+# ÂNCORAS ABSOLUTAS (piso/meta) que, combinadas com `g` — afim na margem —, reconstruíam o número
+# exato (medido em prod: 859 clientes com erro máx. de 0,03 pp). Ver
+# 20260813234112_carteira_margem_faixa_motivo_gate_custo.sql e o harness dedicado.
+# O par de asserts fica: sem cap NÃO sai, com cap SAI — provar só um dos lados deixaria um gate
+# que nega todo mundo passar por correto.
+eq "F4 SEM cap_custo_ler, o MOTIVO é NULL (fase 3c: a âncora some)" \
+   "$(como $A false false "SELECT coalesce(motivo,'') FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" ""
+eq "F4b COM cap_custo_ler, o MOTIVO continua saindo" \
+   "$(como $A true false "SELECT motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "abaixo_do_piso"
 eq "F5 o campo g sai mesmo sem cap_custo_ler (é ele que preserva o score)" \
    "$(como $A false false "SELECT (g IS NOT NULL)::text FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "true"
 
 echo "-- G. classificação --"
+# ⚠️ Passaram a rodar COM cap_custo_ler na fase 3c: `motivo` agora é gateado, e sem cap o
+# `faixa||'|'||motivo` seria NULL — o assert mediria o GATE em vez da CLASSIFICAÇÃO, que é o que
+# ele existe para provar. A faixa sem cap continua coberta por F3 (e o gate, por F4/F4b).
 eq "G1 margem negativa → vermelho/abaixo_do_custo" \
-   "$(como $A false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c1000000-0000-0000-0000-000000000001';")" "vermelho|abaixo_do_custo"
+   "$(como $A true false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c1000000-0000-0000-0000-000000000001';")" "vermelho|abaixo_do_custo"
 eq "G2 40% → verde/abaixo_da_meta" \
-   "$(como $B false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c3000000-0000-0000-0000-000000000003';")" "verde|abaixo_da_meta"
+   "$(como $B true false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c3000000-0000-0000-0000-000000000003';")" "verde|abaixo_da_meta"
 eq "G3 90% → verde/saudavel" \
-   "$(como $B false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c4000000-0000-0000-0000-000000000004';")" "verde|saudavel"
+   "$(como $B true false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c4000000-0000-0000-0000-000000000004';")" "verde|saudavel"
 eq "G4 sem custo → neutro/sem_custo" \
-   "$(como $B false false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c5000000-0000-0000-0000-000000000005';")" "neutro|sem_custo"
+   "$(como $B true false "SELECT faixa||'|'||motivo FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c5000000-0000-0000-0000-000000000005';")" "neutro|sem_custo"
 
 echo "-- H. o campo g (a decisao de desenho de 2026-07-22) --"
 # ⚠️ ASSERT DECISIVO: a régua é da POPULAÇÃO, não da carteira. O mesmo cliente tem de receber o
@@ -216,6 +233,9 @@ eq "J1 re-aplicar não muda a faixa" \
    "$(como $A false false "SELECT faixa FROM public.get_carteira_margem_faixa() WHERE customer_user_id='c2000000-0000-0000-0000-000000000002';")" "amarelo"
 eq "J2 re-aplicar preserva o REVOKE de anon" \
    "$(Pq -q -c "SELECT has_function_privilege('anon','public.get_carteira_margem_faixa()','EXECUTE');")" "f"
+# Re-aplica a fase 3c: o re-Run da 170000 acima devolveu o corpo PRÉ-gate-do-motivo, e sem esta
+# linha tudo abaixo mediria um corpo que não é o que prod terá.
+P -q -f "$REPO_ROOT/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql"
 
 echo "-- K. FALSIFICAÇÃO (o passo que separa prova de teatro) --"
 # Cada bloco SABOTA a migration e exige VERMELHO no assert que a sabotagem mira. Sem isto os
@@ -238,7 +258,13 @@ sabota() { # $1 = expressão sed
   fi
   P -q -f "$SABOTADA"
 }
-restaura() { P -q -f "$MIG"; }
+# ⚠️ Restaura a CADEIA, não só `$MIG`. A fase 3c recria a função por cima da 170000; restaurar só
+# a 170000 devolveria o corpo PRÉ-gate-do-motivo e o assert L1 (a impressão digital) fecharia o
+# harness em vermelho por defasagem de estado, não por defeito — e a leitura natural desse
+# vermelho ("mexi na migration e esqueci de regravar a digital") mandaria a próxima pessoa para o
+# lado errado.
+MIG_3C="$REPO_ROOT/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql"
+restaura() { P -q -f "$MIG"; P -q -f "$MIG_3C"; }
 # Passa quando o valor MUDOU sob sabotagem — ou seja, o assert original teria ficado vermelho.
 ne() {
   if [ "$2" != "$3" ]; then ok "$1 (sob sabotagem virou [$2], íntegro era [$3])"

--- a/db/valida-fu4f-fase3-carteira-margem-faixa.sql
+++ b/db/valida-fu4f-fase3-carteira-margem-faixa.sql
@@ -5,11 +5,20 @@
 -- falso-negativo sob a role read-only, que nao o tem. Todos os checks tem de vir `t`.
 -- Qualquer `f` = a migration nao aplicou como desenhada -> NAO faca o Publish do frontend.
 --
--- IMPRESSAO_DIGITAL=075209b91d13be52c58220f6ddc88521
+-- IMPRESSAO_DIGITAL=169677feb2e686d3e73ec31426c608b6
 --   md5 do corpo (prosrc) com whitespace colapsado. E o que amarra "o que foi COLADO" a "o que
 --   foi TESTADO": db/test-fu4f-fase3-carteira-margem-faixa.sh (assert L1) recalcula esta digital
 --   contra a migration real num PG17 e falha se as duas divergirem. Mexeu na migration sem
 --   regravar aqui -> vermelho no harness, nao na producao.
+--
+--   ⚠️ A digital cobre a CADEIA de migrations que recriam esta funcao, nao um arquivo so — e
+--   mudou em 2026-08-13 (era 075209b91d13be52c58220f6ddc88521, o corpo do #1543). A fase 3c
+--   (20260813234112_carteira_margem_faixa_motivo_gate_custo.sql) poe o campo `motivo` sob
+--   `private.cap_custo_ler`, e isso ALTERA o prosrc. Os dois harnesses aplicam a cadeia inteira
+--   e recalculam a digital: db/test-fu4f-fase3-carteira-margem-faixa.sh (L1) e
+--   db/test-carteira-margem-faixa-motivo-gate.sh (G1). Quem recriar a funcao de novo regrava
+--   aqui — senao este validador devolve `f` num banco CORRETO e para um deploy por falso alarme.
+--   (O #1728 nao aparece nesta lista de proposito: COMMENT nao toca `prosrc`.)
 
 SELECT
   -- ── existencia e forma ──────────────────────────────────────────────────────
@@ -48,7 +57,7 @@ SELECT
   (SELECT md5(regexp_replace(p.prosrc, '[[:space:]]+', ' ', 'g'))
      FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
      WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa')
-    = '075209b91d13be52c58220f6ddc88521'                                           AS c10_corpo_identico_ao_testado,
+    = '169677feb2e686d3e73ec31426c608b6'                                           AS c10_corpo_identico_ao_testado,
 
   -- ── a dependencia que faz o custo NAO sair do servidor ───────────────────────
   -- Sem o helper aplicado (#1519), a funcao criaria bem e so quebraria em RUNTIME (plpgsql e

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **460** custom migrations totais
-- **1576** objetos esperados (criados por estas migrations)
+- **461** custom migrations totais
+- **1577** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 469
+  - `function`: 470
   - `rls_policy`: 395
   - `index`: 238
   - `cron_job`: 164
@@ -3857,6 +3857,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 ### `20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260813234112_carteira_margem_faixa_motivo_gate_custo.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.get_carteira_margem_faixa` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 460
+-- Total de custom migrations: 461
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -501,7 +501,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260808020000', 'tactical_plan_idempotencia_janela', '20260808020000_tactical_plan_idempotencia_janela.sql'),
   ('20260813150000', 'farmer_config_limiar_faixa_escrita_custo', '20260813150000_farmer_config_limiar_faixa_escrita_custo.sql'),
   ('20260813195914', 'reposicao_pos_candidatos_guard_temporal', '20260813195914_reposicao_pos_candidatos_guard_temporal.sql'),
-  ('20260813225057', 'fu4f_fase3_comment_honesto_margem_faixa', '20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql')
+  ('20260813225057', 'fu4f_fase3_comment_honesto_margem_faixa', '20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql'),
+  ('20260813234112', 'carteira_margem_faixa_motivo_gate_custo', '20260813234112_carteira_margem_faixa_motivo_gate_custo.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2066,7 +2067,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_insert_exige_cap_custo', 'farmer_algorithm_config'),
   ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_update_exige_cap_custo', 'farmer_algorithm_config'),
   ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_delete_exige_cap_custo', 'farmer_algorithm_config'),
-  ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', '')
+  ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', ''),
+  ('carteira_margem_faixa_motivo_gate_custo', 'function', 'public', 'get_carteira_margem_faixa', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3679,7 +3681,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_insert_exige_cap_custo', 'farmer_algorithm_config'),
   ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_update_exige_cap_custo', 'farmer_algorithm_config'),
   ('farmer_config_limiar_faixa_escrita_custo', 'rls_policy', 'public', 'limiar_faixa_margem_delete_exige_cap_custo', 'farmer_algorithm_config'),
-  ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', '')
+  ('reposicao_pos_candidatos_guard_temporal', 'function', 'public', 'reposicao_pos_candidatos', ''),
+  ('carteira_margem_faixa_motivo_gate_custo', 'function', 'public', 'get_carteira_margem_faixa', '')
 )
 SELECT
   e.migration,

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -221,6 +221,38 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // exato, incluindo "UPDATE sem USING" (S2), que prova que o USING não é decorativo: só com
   // WITH CHECK, `SET key='outra' WHERE key='margem_faixa_piso_pct'` some com a key protegida e
   // devolve o limiar ao default.
+  //
+  // 2026-08-13 — fase 3c: `motivo` entra no gate de PROJEÇÃO, junto de `margem_pct`. A revisão
+  // adversarial do #1723 (Codex gpt-5.6-sol) achou um vazamento de LEITURA pior que o oráculo de
+  // ESCRITA que a fase 3b fechou — este não precisa escrever nada e resolve numa ÚNICA resposta.
+  // Mecanismo: `g` é AFIM na margem (`margem_pct = A + B*g`, A=100*p10, B=100*max(p90-p10,0.01)),
+  // e `motivo` dava as duas ÂNCORAS ABSOLUTAS que faltavam ('abaixo_do_piso' ⇒ margem<30,
+  // 'abaixo_da_meta' ⇒ 30≤margem<50). Tomando o MAIOR `g` de cada motivo, o atacante resolve
+  // B=(50-30)/(g50-g30) e A=30-B*g30 e inverte a carteira inteira.
+  // MEDIDO em prod (read-only, 2026-08-13): A_est=29,4560 vs 29,4260 real (erro 0,03 pp) e
+  // B_est=45,7780 vs 45,7780 (erro ZERO); 859 dos 1.075 clientes com margem reconstruídos com
+  // erro MÁXIMO de 0,03 pp. Não era risco teórico.
+  // ⚠️ Lição transferível (irmã da fase 3b): lá o gate de projeção caía por uma entrada
+  // ESCREVÍVEL; aqui cai por um rótulo LEGÍVEL que ancora a escala. Um campo derivado que é
+  // transformação MONÓTONA do número protegido só resiste enquanto ninguém publicar dois pontos
+  // conhecidos da curva — e um vocabulário categórico com limiares FIXOS é exatamente isso.
+  // Ao gatear um número, enumere o que mais na MESMA resposta permite reconstruí-lo.
+  // ⚠️ O que NÃO foi feito, e por quê: `g` continua saindo sem gate. Gateá-lo fecharia o eixo,
+  // mas `calcularHealthScore` renormaliza os pesos com `g` null, então o score de quem não tem
+  // cap MUDARIA — produto embutido em entrega de autorização (o que o #1543 evitou). O custo foi
+  // MEDIDO antes de descartar (harness `scripts/impacto-gate-g.ts`): 640 visões de cliente
+  // mudariam de score nos 2 farmers sem cap (Δ médio 5,88/6,02; máx 14,5), 91 mudariam de classe,
+  // AGENDA idêntica. Decisão do founder (2026-08-13): fechar a âncora, preservar o score.
+  // ⚠️ Limite honesto da defesa: ela depende de `p10 > 0` (hoje 29,43%). A fronteira 'vermelho'
+  // (margem<0) só não é 2ª âncora porque está SATURADA (todo pct<p10 tem g=0). Se a população
+  // ganhar margem negativa relevante, p10 cai e aquela fronteira devolve a âncora sozinha. E a
+  // ORDENAÇÃO por margem segue exposta por construção. Quem mexer na régua revisita isto.
+  // Provado em db/test-carteira-margem-faixa-motivo-gate.sh (24 asserts): A1-A4 (com cap nada
+  // regride), B1-B3 (sem cap a âncora some), C1-C3 (faixa e `g` PRESERVADOS — a prova de que não
+  // houve mudança de produto), D1-D5 (escopo/ACL/idempotência), E1-E3 (a calibração não fecha, e
+  // o master legítimo AINDA calibra — sem E3 os E1/E2 passariam por vacuidade). Falsificações
+  // K1-K3 exigem o vermelho exato (K2 sabota gateando `g`, que é o assert que protege o produto)
+  // e K4/K4b são o canário do restore.
   'public.get_carteira_margem_faixa',
 ]);
 

--- a/scripts/impacto-gate-g.ts
+++ b/scripts/impacto-gate-g.ts
@@ -1,0 +1,378 @@
+/**
+ * Quanto custaria GATEAR o componente `g` de `public.get_carteira_margem_faixa()`.
+ *
+ * Contexto: a revisão adversarial do #1723 (Codex gpt-5.6-sol, 2026-08-13) mostrou que `g` sai sem
+ * gate de custo e é uma transformação AFIM da margem (`margem_pct = A + B*g`), enquanto o campo
+ * `motivo` fornece ÂNCORAS ABSOLUTAS (piso 30 / meta 50) que permitem calibrar A e B numa única
+ * resposta — reconstruindo a margem de toda a carteira sem escrever nada. Fechar isso gateando `g`
+ * para NULL é a opção óbvia, e é justamente a que muda PRODUTO: `calcularHealthScore` renormaliza
+ * os pesos quando `g` é null, então o health score de quem não tem `cap_custo_ler` MUDA.
+ *
+ * Este script mede esse custo em cima do corpus REAL de prod, para não decidir no escuro — o mesmo
+ * método do baseline de paridade do #1721, do qual ele é derivado.
+ *
+ * O que compara, por persona:
+ *   • ATUAL — `g` como a RPC devolve hoje (sai para todos, com ou sem cap_custo_ler);
+ *   • GATE  — `g` NULL para quem NÃO tem `cap_custo_ler` (as demais dimensões intactas).
+ *
+ * ⚠️ Tudo mais é mantido IDÊNTICO de propósito: rf/m/x/s, churn, recover, expansion e priority
+ * saem do MESMO cálculo nos dois lados. O gate mexe só na disponibilidade de `g`.
+ *
+ * Os helpers de negócio são IMPORTADOS de `src/` (código real de produção). O que está copiado
+ * verbatim — `percentile`, `classifyHealth`, `clamp` e os laços da agenda — vive INLINE no hook
+ * sem export; o wrapper `db/mede-impacto-gate-g.sh` tem assert de fidelidade contra o hook.
+ *
+ * Uso: bun scripts/impacto-gate-g.ts <dir-do-corpus> <saida.json>
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { accumulateMarginFromItems, resolveProductIdsFromItems } from '../src/lib/scoring/margin';
+import { custoCanonico } from '../src/lib/custo/custoCanonico';
+import { calcularHealthScore } from '../src/lib/scoring/healthScore';
+
+// ─── CSV (RFC4180) — mesmo parser do harness de paridade ──────────────────────────────────────
+function parseCSV(texto: string): Record<string, string>[] {
+  const linhas: string[][] = [];
+  let campo = '';
+  let linha: string[] = [];
+  let emAspas = false;
+  for (let i = 0; i < texto.length; i++) {
+    const c = texto[i];
+    if (emAspas) {
+      if (c === '"') {
+        if (texto[i + 1] === '"') { campo += '"'; i++; } else emAspas = false;
+      } else campo += c;
+    } else if (c === '"') emAspas = true;
+    else if (c === ',') { linha.push(campo); campo = ''; }
+    else if (c === '\n') { linha.push(campo); linhas.push(linha); linha = []; campo = ''; }
+    else if (c !== '\r') campo += c;
+  }
+  if (campo.length > 0 || linha.length > 0) { linha.push(campo); linhas.push(linha); }
+  if (linhas.length === 0) return [];
+  const header = linhas[0];
+  return linhas.slice(1).map((l) => {
+    const o: Record<string, string> = {};
+    header.forEach((h, i) => { o[h] = l[i] ?? ''; });
+    return o;
+  });
+}
+const csv = (dir: string, nome: string) => parseCSV(readFileSync(join(dir, nome), 'utf8'));
+
+// COPIA-INICIO percentile — verbatim de src/hooks/useFarmerScoring.ts
+function percentile(arr: number[], p: number): number {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = (p / 100) * (sorted.length - 1);
+  const lo = Math.floor(idx);
+  const hi = Math.ceil(idx);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (idx - lo);
+}
+// COPIA-FIM percentile
+
+// COPIA-INICIO classifyHealth — verbatim de src/hooks/useFarmerScoring.ts
+function classifyHealth(score: number): 'saudavel' | 'estavel' | 'atencao' | 'critico' {
+  if (score >= 80) return 'saudavel';
+  if (score >= 60) return 'estavel';
+  if (score >= 40) return 'atencao';
+  return 'critico';
+}
+// COPIA-FIM classifyHealth
+
+// COPIA-INICIO clamp — verbatim de src/hooks/useFarmerScoring.ts
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+// COPIA-FIM clamp
+
+const dir = process.argv[2];
+const saida = process.argv[3];
+if (!dir || !saida) {
+  console.error('uso: bun scripts/impacto-gate-g.ts <dir-do-corpus> <saida.json>');
+  process.exit(1);
+}
+
+const AGORA = Number(readFileSync(join(dir, 'agora.txt'), 'utf8').trim());
+if (!Number.isFinite(AGORA)) throw new Error('agora.txt ilegível — o relógio do harness precisa ser fixo');
+
+const cfg: Record<string, number> = {
+  k1: 1.0, k2: 1.0, cat_target: 5,
+  health_w_rf: 0.35, health_w_m: 0.20, health_w_g: 0.15, health_w_x: 0.15, health_w_s: 0.15,
+  priority_w_churn: 0.40, priority_w_recover: 0.30, priority_w_expansion: 0.20, priority_w_eff: 0.10,
+  agenda_pct_risco: 0.50, agenda_pct_expansao: 0.30, agenda_pct_followup: 0.20, sla_contact_days: 14,
+};
+for (const r of csv(dir, 'config.csv')) {
+  const n = Number(r.value);
+  if (Number.isFinite(n)) cfg[r.key] = n;
+}
+
+// ─── Corpus ───────────────────────────────────────────────────────────────────────────────────
+const omieToProductId = new Map<number, string>();
+for (const p of csv(dir, 'produtos.csv')) {
+  if (p.omie_codigo_produto !== '') omieToProductId.set(Number(p.omie_codigo_produto), p.id);
+}
+
+const costMap = new Map<string, number>();
+for (const pc of csv(dir, 'custos.csv')) {
+  const c = custoCanonico({
+    cost_final: pc.cost_final === '' ? null : pc.cost_final,
+    cost_price: pc.cost_price === '' ? null : pc.cost_price,
+  });
+  if (c != null) costMap.set(pc.product_id, c);
+}
+
+const flaggeds = new Set(csv(dir, 'excluidos.csv').map((r) => r.user_id));
+const profileMap = new Map<string, { name: string }>();
+for (const p of csv(dir, 'profiles.csv')) profileMap.set(p.user_id, { name: p.name });
+
+interface CustomerData {
+  orderDates: number[];
+  spend180d: number;
+  categories: Set<string>;
+}
+const sixMonthsAgo = AGORA - 180 * 24 * 60 * 60 * 1000;
+const sixtyDaysAgo = AGORA - 60 * 24 * 60 * 60 * 1000;
+
+const customerMap = new Map<string, CustomerData>();
+for (const order of csv(dir, 'pedidos.csv')) {
+  const cid = order.customer_user_id;
+  if (!cid) continue;
+  if (flaggeds.has(cid)) continue;
+  if (!customerMap.has(cid)) customerMap.set(cid, { orderDates: [], spend180d: 0, categories: new Set() });
+  const cd = customerMap.get(cid)!;
+  const orderTime = new Date(order.order_date_kpi !== '' ? order.order_date_kpi : order.created_at).getTime();
+  cd.orderDates.push(orderTime);
+  if (orderTime >= sixMonthsAgo) cd.spend180d += Number(order.total || 0);
+  let items: unknown = [];
+  try { items = JSON.parse(order.items || '[]'); } catch { items = []; }
+  const arr = Array.isArray(items) ? items : [];
+  // Mantido para paridade de custo de parsing com o hook; a margem aqui vem da RPC.
+  void accumulateMarginFromItems(arr, costMap, omieToProductId);
+  for (const pid of resolveProductIdsFromItems(arr, omieToProductId)) cd.categories.add(pid);
+}
+
+const callsPorFarmer = new Map<string, Record<string, string>[]>();
+for (const c of csv(dir, 'calls.csv')) {
+  if (!callsPorFarmer.has(c.farmer_id)) callsPorFarmer.set(c.farmer_id, []);
+  callsPorFarmer.get(c.farmer_id)!.push(c);
+}
+
+// `g` como a RPC devolve (réplica verbatim extraída pelo wrapper).
+const sqlPorCliente = new Map<string, { g: number | null; pct: number | null }>();
+for (const r of csv(dir, 'sql-faixa.csv')) {
+  sqlPorCliente.set(r.customer_user_id, {
+    g: r.g === '' ? null : Number(r.g),
+    pct: r.margem_pct === '' ? null : Number(r.margem_pct),
+  });
+}
+
+const carteiraDe = new Map<string, Set<string>>();
+for (const a of csv(dir, 'carteiras.csv')) {
+  if (a.eligible !== 't' && a.eligible !== 'true') continue;
+  if (!carteiraDe.has(a.owner_user_id)) carteiraDe.set(a.owner_user_id, new Set());
+  carteiraDe.get(a.owner_user_id)!.add(a.customer_user_id);
+}
+
+interface Persona { id: string; rotulo: string; capTodo: boolean; capCusto: boolean }
+const personas: Persona[] = JSON.parse(readFileSync(join(dir, 'personas-cap.json'), 'utf8'));
+
+const allMonthlySpends: number[] = [];
+customerMap.forEach((cd) => { allMonthlySpends.push(cd.spend180d / 6); });
+const p95MonthlySpend = percentile(allMonthlySpends, 95) || 1;
+
+interface Score {
+  cid: string;
+  churnRisk: number; expansionScore: number; priorityScore: number;
+  healthAtual: number; healthGate: number;
+  classeAtual: string; classeGate: string;
+  g: number | null;
+}
+
+function pontuar(persona: Persona): Score[] {
+  const porCliente = new Map<string, { calls60d: number; ok60d: number; wa60d: number; waResp60d: number; last: number }>();
+  for (const call of callsPorFarmer.get(persona.id) ?? []) {
+    const cid = call.customer_user_id;
+    if (!cid || !customerMap.has(cid)) continue;
+    if (!porCliente.has(cid)) porCliente.set(cid, { calls60d: 0, ok60d: 0, wa60d: 0, waResp60d: 0, last: 0 });
+    const a = porCliente.get(cid)!;
+    const t = new Date(call.created_at).getTime();
+    if (t > a.last) a.last = t;
+    if (t >= sixtyDaysAgo) {
+      a.calls60d++;
+      if (call.call_result === 'contato_sucesso') a.ok60d++;
+      if (call.is_whatsapp === 't' || call.is_whatsapp === 'true') {
+        a.wa60d++;
+        if (call.whatsapp_replied === 't' || call.whatsapp_replied === 'true') a.waResp60d++;
+      }
+    }
+  }
+
+  const visiveis = carteiraDe.get(persona.id) ?? new Set<string>();
+  const scores: Score[] = [];
+
+  customerMap.forEach((cd, cid) => {
+    if (!profileMap.has(cid)) return; // VERBATIM: cliente sem profile não é pontuado
+
+    const datas = [...cd.orderDates].sort((a, b) => a - b);
+    const lastPurchase = datas[datas.length - 1];
+    const D = Math.max(0, Math.floor((AGORA - lastPurchase) / (1000 * 60 * 60 * 24)));
+
+    let I = 30;
+    if (datas.length >= 2) {
+      const intervals: number[] = [];
+      for (let i = 1; i < datas.length; i++) intervals.push((datas[i] - datas[i - 1]) / (1000 * 60 * 60 * 24));
+      I = intervals.reduce((s, v) => s + v, 0) / intervals.length;
+    }
+
+    const rfRatio = Math.max((D / Math.max(I, 1)) - 1, 0);
+    const rf = Math.exp(-cfg.k2 * rfRatio);
+    const avgMonthly = cd.spend180d / 6;
+    const m = clamp(Math.log(1 + avgMonthly) / Math.log(1 + p95MonthlySpend), 0, 1);
+    const x = clamp(cd.categories.size / cfg.cat_target, 0, 1);
+
+    const ag = porCliente.get(cid);
+    const answerRate = ag && ag.calls60d > 0 ? ag.ok60d / ag.calls60d : 0;
+    const whatsappRate = ag && ag.wa60d > 0 ? ag.waResp60d / ag.wa60d : 0;
+    const s = 0.7 * answerRate + 0.3 * whatsappRate;
+
+    // ESCOPO da RPC: fora da carteira → ausente do mapa → g null nos DOIS cenários.
+    const noEscopo = persona.capTodo || visiveis.has(cid);
+    const gAtual = (noEscopo ? sqlPorCliente.get(cid)?.g : undefined) ?? null;
+    // O GATE: sem cap_custo_ler, `g` vira NULL — é a mudança que se está medindo.
+    const gGate = persona.capCusto ? gAtual : null;
+
+    const pesos = {
+      rf: cfg.health_w_rf, m: cfg.health_w_m, g: cfg.health_w_g, x: cfg.health_w_x, s: cfg.health_w_s,
+    };
+    const healthAtual = calcularHealthScore({ rf, m, g: gAtual, x, s }, pesos);
+    const healthGate = calcularHealthScore({ rf, m, g: gGate, x, s }, pesos);
+
+    const churnRisk = 100 * (1 - Math.exp(-cfg.k1 * rfRatio));
+    const delayedMonths = Math.max(0, (D - I) / 30);
+    const recoverScore = clamp(delayedMonths * avgMonthly / Math.max(p95MonthlySpend * 6, 1) * 100, 0, 100);
+    const mixGap = 1 - (cd.categories.size / Math.max(cfg.cat_target, 1));
+    const expansionScore = clamp((mixGap * 0.6 + m * 0.4) * 100, 0, 100);
+    const daysSinceContact = ag && ag.last > 0 ? Math.floor((AGORA - ag.last) / (1000 * 60 * 60 * 24)) : 999;
+    const effScore = clamp((1 - Math.min(daysSinceContact / cfg.sla_contact_days, 2) / 2) * 100, 0, 100);
+    const priorityScore =
+      cfg.priority_w_churn * churnRisk + cfg.priority_w_recover * recoverScore +
+      cfg.priority_w_expansion * expansionScore + cfg.priority_w_eff * effScore;
+
+    scores.push({
+      cid,
+      churnRisk: Math.round(churnRisk * 10) / 10,
+      expansionScore: Math.round(expansionScore * 10) / 10,
+      priorityScore: Math.round(priorityScore * 10) / 10,
+      healthAtual: Math.round(healthAtual * 10) / 10,
+      healthGate: Math.round(healthGate * 10) / 10,
+      classeAtual: classifyHealth(healthAtual),
+      classeGate: classifyHealth(healthGate),
+      g: gAtual,
+    });
+  });
+
+  scores.sort((a, b) => b.priorityScore - a.priorityScore);
+  return scores;
+}
+
+// COPIA-INICIO agenda — verbatim dos 3 laços de src/hooks/useFarmerScoring.ts
+function montarAgenda(scores: Score[]): string[] {
+  const totalSlots = Math.min(scores.length, 20);
+  const riscoSlots = Math.round(totalSlots * cfg.agenda_pct_risco);
+  const expansaoSlots = Math.round(totalSlots * cfg.agenda_pct_expansao);
+  const followUpSlots = totalSlots - riscoSlots - expansaoSlots;
+
+  const itens: { cid: string; tipo: string }[] = [];
+  const used = new Set<string>();
+
+  const riscoSorted = [...scores].sort((a, b) => b.churnRisk - a.churnRisk);
+  for (const s of riscoSorted) {
+    if (itens.filter((a) => a.tipo === 'risco').length >= riscoSlots) break;
+    if (used.has(s.cid)) continue;
+    used.add(s.cid); itens.push({ cid: s.cid, tipo: 'risco' });
+  }
+  const expSorted = [...scores].sort((a, b) => b.expansionScore - a.expansionScore);
+  for (const s of expSorted) {
+    if (itens.filter((a) => a.tipo === 'expansao').length >= expansaoSlots) break;
+    if (used.has(s.cid)) continue;
+    used.add(s.cid); itens.push({ cid: s.cid, tipo: 'expansao' });
+  }
+  for (const s of scores) {
+    if (itens.filter((a) => a.tipo === 'follow_up').length >= followUpSlots) break;
+    if (used.has(s.cid)) continue;
+    used.add(s.cid); itens.push({ cid: s.cid, tipo: 'follow_up' });
+  }
+  return itens.map((i) => `${i.tipo}:${i.cid}`);
+}
+// COPIA-FIM agenda
+
+const relatorio: Record<string, unknown> = {
+  corpus: {
+    pedidos: csv(dir, 'pedidos.csv').length,
+    clientes_no_sql: sqlPorCliente.size,
+    p95MonthlySpend,
+  },
+  personas: [],
+};
+
+for (const persona of personas) {
+  const scores = pontuar(persona);
+
+  // Só quem TEM `g` hoje pode perder — o resto é invariante por construção.
+  const comG = scores.filter((s) => s.g != null);
+  const mudouScore = scores.filter((s) => s.healthAtual !== s.healthGate);
+  const mudouClasse = scores.filter((s) => s.classeAtual !== s.classeGate);
+
+  const deltas = comG.map((s) => Math.abs(s.healthGate - s.healthAtual)).sort((a, b) => a - b);
+  const media = deltas.reduce((a, b) => a + b, 0) / (deltas.length || 1);
+  const p50 = deltas.length ? deltas[Math.floor(0.5 * (deltas.length - 1))] : 0;
+  const p90 = deltas.length ? deltas[Math.floor(0.9 * (deltas.length - 1))] : 0;
+  const maximo = deltas.length ? deltas[deltas.length - 1] : 0;
+  const sobem = comG.filter((s) => s.healthGate > s.healthAtual).length;
+  const descem = comG.filter((s) => s.healthGate < s.healthAtual).length;
+
+  // A agenda é montada nos DOIS cenários: se alguma dimensão de prioridade lesse `g`, divergiria.
+  const agendaAtual = montarAgenda(scores);
+  const agendaGate = montarAgenda([...scores].sort((a, b) => b.priorityScore - a.priorityScore));
+  const setAtual = new Set(agendaAtual.map((a) => a.split(':')[1]));
+  const setGate = new Set(agendaGate.map((a) => a.split(':')[1]));
+  const rotuloMudou = agendaAtual.filter((a) => {
+    const s = scores.find((x) => x.cid === a.split(':')[1]);
+    return s && s.classeAtual !== s.classeGate;
+  }).length;
+
+  const topDelta = [...comG]
+    .map((s) => ({
+      cid: s.cid,
+      delta: +(s.healthGate - s.healthAtual).toFixed(2),
+      g: s.g == null ? null : +s.g.toFixed(3),
+      classeAtual: s.classeAtual, classeGate: s.classeGate,
+    }))
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+    .slice(0, 5);
+
+  (relatorio.personas as unknown[]).push({
+    id: persona.id,
+    rotulo: persona.rotulo,
+    capTodo: persona.capTodo,
+    capCusto: persona.capCusto,
+    clientes: scores.length,
+    clientes_com_g: comG.length,
+    mudou_score: mudouScore.length,
+    mudou_score_pct: comG.length ? +(100 * mudouScore.length / comG.length).toFixed(1) : 0,
+    delta_medio: +media.toFixed(3),
+    delta_p50: +p50.toFixed(3),
+    delta_p90: +p90.toFixed(3),
+    delta_max: +maximo.toFixed(3),
+    sobem, descem,
+    mudou_classe: mudouClasse.length,
+    mudou_classe_pct: scores.length ? +(100 * mudouClasse.length / scores.length).toFixed(1) : 0,
+    top_delta: topDelta,
+    agenda_slots: agendaAtual.length,
+    agenda_saiu: [...setAtual].filter((c) => !setGate.has(c)).length,
+    agenda_entrou: [...setGate].filter((c) => !setAtual.has(c)).length,
+    agenda_identica: agendaAtual.join('|') === agendaGate.join('|'),
+    agenda_rotulo_mudou: rotuloMudou,
+  });
+}
+
+writeFileSync(saida, JSON.stringify(relatorio, null, 2));
+console.log(JSON.stringify(relatorio, null, 2));

--- a/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql
+++ b/supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql
@@ -1,0 +1,181 @@
+-- ============================================================
+-- FU4-F fase 3c — `motivo` entra no gate de custo: as ÂNCORAS ABSOLUTAS somem
+--
+-- O QUE ESTE PR FECHA
+-- O #1723 fechou a ESCRITA dos limiares `margem_faixa_*` (o oráculo de custo por busca binária,
+-- que exigia escritas repetidas). A revisão adversarial daquele PR (Codex gpt-5.6-sol, 2026-08-13)
+-- mostrou um vazamento ESTRUTURALMENTE PIOR, de LEITURA, numa única resposta e sem escrever nada:
+--
+--   `g` é uma transformação AFIM da margem:  margem_pct = A + B*g,
+--   com A = 100*p10 e B = 100*max(p90-p10, 0.01) — ambos desconhecidos do atacante.
+--
+-- Só que `motivo` fornecia as ÂNCORAS ABSOLUTAS que faltavam para resolver o sistema:
+--   'abaixo_do_piso' => margem < 30   e   'abaixo_da_meta' => 30 <= margem < 50.
+-- Ordenando os pares (g, motivo) e tomando o MAIOR g de cada motivo, o atacante calibra
+--   B = (50-30)/(g_50 - g_30)   e   A = 30 - B*g_30
+-- e daí reconstrói a margem de TODA a carteira visível. Com a receita à vista, deriva o custo.
+--
+-- MEDIDO EM PROD (read-only, 2026-08-13), o ataque não é teórico:
+--   A_est = 29,4560 contra A_real = 29,4260  → erro 0,03 pp
+--   B_est = 45,7780 contra B_real = 45,7780  → erro 0,0000
+--   859 dos 1.075 clientes com margem reconstruídos com erro MÁXIMO de 0,03 pp.
+--   Os 216 restantes estão saturados (g=0 ou g=1) e não invertem — mas entregam o limite
+--   (margem <= 29,46% ou >= 75,23%), que já é informação de custo.
+--
+-- A CORREÇÃO, e por que é ESTA
+-- `motivo` passa a ser projetado sob `private.cap_custo_ler`, exatamente como `margem_pct` já era.
+-- Sem as âncoras, sobra a fronteira do piso vinda de `faixa` — UMA equação para DUAS incógnitas,
+-- e a inversão absoluta não fecha.
+--
+-- ⚠️ O que este PR deliberadamente NÃO faz: gatear `g`. Gatear `g` fecharia o eixo por inteiro,
+-- mas `calcularHealthScore` RENORMALIZA os pesos quando `g` é null, então o health score de quem
+-- não tem cap MUDARIA — decisão de PRODUTO embutida numa entrega de AUTORIZAÇÃO, que é
+-- precisamente o que o #1543 evitou de propósito ("o número fecha, o sinal fica").
+-- O custo foi MEDIDO antes de descartar, não presumido (logs/impacto-gate-g, harness
+-- `scripts/impacto-gate-g.ts`): 640 visões de cliente mudariam de score nos 2 farmers sem cap
+-- (Δ médio 5,88 e 6,02 pontos; máx 14,5), 91 mudariam de classe, e a AGENDA ficaria idêntica.
+-- O founder optou por fechar a âncora e preservar o score (decisão de 2026-08-13).
+--
+-- ⚠️ Limite honesto desta defesa: ela depende de `p10 > 0` (hoje 29,43%). A fronteira 'vermelho'
+-- (margem < 0) só não serve de 2ª âncora porque está SATURADA — todo cliente com margem abaixo de
+-- p10 tem g=0, e 108 deles são indistinguíveis entre si. Se a população passar a ter margem
+-- negativa relevante, p10 cai abaixo de zero, aquela fronteira sai da saturação e devolve a 2ª
+-- âncora sozinha. É defesa boa hoje, NÃO é invariante — quem mexer na régua revisita isto.
+-- A ORDENAÇÃO por margem também segue exposta por construção (g é monótono na margem): quem tem
+-- a margem real de UM cliente por fora fecha o sistema. Fechar isso exige gatear `g`.
+--
+-- Migration anterior desta função: 20260726170000_fu4f_fase3_carteira_margem_faixa.sql
+-- Corpo abaixo conferido contra `pg_get_functiondef` da PROD em 2026-08-13 (pré-flight do
+-- lovable-db-operator §2.7): idêntico ao vivo, exceto o CASE do `motivo`.
+-- Prova: db/test-carteira-margem-faixa-motivo-gate.sh (PG17, com falsificação).
+-- ============================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.get_carteira_margem_faixa()
+RETURNS TABLE(customer_user_id uuid, faixa text, motivo text, g numeric, margem_pct numeric)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $fn$
+DECLARE
+  v_uid      uuid;
+  v_pode_num boolean;
+  v_cap_todo boolean;
+  v_piso     numeric;
+  v_meta     numeric;
+BEGIN
+  -- Atribuição no CORPO, nunca no DECLARE: erro na inicialização de DECLARE não é capturável
+  -- pelo EXCEPTION do próprio bloco e derrubaria a função inteira.
+  v_uid := (SELECT auth.uid());
+
+  -- Fail-closed: sem identidade, zero linhas.
+  IF v_uid IS NULL THEN
+    RETURN;
+  END IF;
+
+  v_pode_num := COALESCE(private.cap_custo_ler(v_uid), false);
+  v_cap_todo := COALESCE(private.cap_carteira_ler(v_uid), false);
+
+  -- Limiares em CONFIG, não em código: mudar a faixa é UPDATE, não deploy.
+  SELECT COALESCE(max(c.value::numeric) FILTER (WHERE c.key = 'margem_faixa_piso_pct'), 30),
+         COALESCE(max(c.value::numeric) FILTER (WHERE c.key = 'margem_faixa_meta_pct'), 50)
+    INTO v_piso, v_meta
+    FROM public.farmer_algorithm_config c
+   WHERE c.key IN ('margem_faixa_piso_pct', 'margem_faixa_meta_pct');
+
+  RETURN QUERY
+  WITH base AS (
+    SELECT m.customer_user_id AS cid, m.margem_pct AS pct
+      FROM private.margem_cliente_agregada() m
+  ),
+  regua AS (
+    -- p10/p90 sobre a POPULAÇÃO INTEIRA (ver nota de escopo acima). `margem_pct` vem em pontos
+    -- percentuais (0–100); o hook trabalha em fração (0–1). Dividir por 100 mantém a régua
+    -- idêntica à dele: a normalização é invariante a escala, mas manter a mesma unidade evita
+    -- que uma futura mudança de limiar leia errado.
+    SELECT percentile_cont(0.10) WITHIN GROUP (ORDER BY b.pct / 100.0)::numeric AS p10,
+           percentile_cont(0.90) WITHIN GROUP (ORDER BY b.pct / 100.0)::numeric AS p90
+      FROM base b
+     WHERE b.pct IS NOT NULL
+  )
+  SELECT
+    b.cid,
+    CASE WHEN b.pct IS NULL   THEN 'neutro'
+         WHEN b.pct < 0       THEN 'vermelho'
+         WHEN b.pct < v_piso  THEN 'amarelo'
+         ELSE                      'verde'   END,
+    -- Gate de PROJEÇÃO do MOTIVO (fase 3c). `motivo` carregava as âncoras ABSOLUTAS do piso e da
+    -- meta; com elas, `g` — que é afim na margem — inverte para o número exato. Sem cap, o
+    -- vocabulário de motivo não sai. A FAIXA continua saindo: ela é o sinal que o produto quer
+    -- ("o número fecha, o sinal fica") e ancora só a fronteira do piso, que sozinha não fecha o
+    -- sistema de duas incógnitas.
+    -- ⚠️ NULL, não uma string genérica ('indisponivel'/'—'): rótulo constante é fato fabricado, e
+    -- o §5 do money-path já pagou por isso (`empresa_omie` com DEFAULT respondendo por 100%).
+    CASE WHEN v_pode_num THEN
+      CASE WHEN b.pct IS NULL   THEN 'sem_custo'
+           WHEN b.pct < 0       THEN 'abaixo_do_custo'
+           WHEN b.pct < v_piso  THEN 'abaixo_do_piso'
+           WHEN b.pct < v_meta  THEN 'abaixo_da_meta'
+           ELSE                      'saudavel' END
+    END,
+    -- `g` com a MESMA régua do hook: clamp((margem - p10) / max(p90 - p10, 0.01), 0, 1).
+    -- NULL quando a margem não é apurável — o calcularHealthScore renormaliza os pesos.
+    CASE WHEN b.pct IS NULL THEN NULL
+         ELSE greatest(0::numeric,
+                least(1::numeric,
+                  (b.pct / 100.0 - r.p10) / greatest(r.p90 - r.p10, 0.01::numeric)))
+    END,
+    -- Gate de PROJEÇÃO: esconde na SAÍDA, não no cálculo.
+    CASE WHEN v_pode_num THEN b.pct END
+  FROM base b CROSS JOIN regua r
+  -- Escopo espelhando fcs_select_carteira. O filtro vem DEPOIS da régua, de propósito.
+  WHERE v_cap_todo
+     OR COALESCE(private.carteira_visivel_para(b.cid, v_uid), false);
+END;
+$fn$;
+
+-- ⚠️ UNIÃO, não substituição. O #1728 (20260813225057) acabou de trocar a promessa FALSA de
+-- equivalência de score pelo delta MEDIDO, e tem um harness que assere sobre ESTE texto
+-- (db/test-comment-honesto-margem-faixa.sh, B2-B4c: exige a AUSÊNCIA de "byte a byte" e a
+-- presença de "30.833 pedidos contra 20.597", "health score MUDA", "59,5%"/"14,5" e
+-- "AGENDA NAO muda"). Como esta migration roda DEPOIS dele e `COMMENT` faz a última a escrever
+-- VENCER, reescrever do zero apagaria o trabalho dele em silêncio — a armadilha "a última a
+-- recriar vence" do CLAUDE.md. O texto dele vai INTEIRO abaixo; a fase 3c só ACRESCENTA no fim.
+-- ⚠️ Nunca mais reescreva este comentário sem os marcadores acima: rode
+-- db/test-comment-honesto-margem-faixa.sh depois de mexer.
+COMMENT ON FUNCTION public.get_carteira_margem_faixa() IS
+  'FU4-F fase 3: faixa de margem + componente g por cliente da carteira. O custo e lido no '
+  'SERVIDOR (via private.margem_cliente_agregada) e nunca sai; margem_pct so e projetada sob '
+  'private.cap_custo_ler. `g` usa a regua de percentis da POPULACAO. '
+  'ATENCAO: a REGUA e a mesma que o hook usava, mas o UNIVERSO nao. O hook filtrava status por '
+  'allowlist (confirmado/faturado/entregue, das quais duas tem ZERO linhas) e o helper filtra '
+  'por denylist: 30.833 pedidos contra 20.597, medido em 2026-08-13. E o escopo por carteira '
+  'tira o `g` de cliente fora dela, com renormalizacao dos pesos. Logo o health score MUDA - '
+  'medido no PR #1721 sobre as 3 personas reais de prod: ate 59,5% dos clientes mudam de faixa, '
+  'delta medio de 1,4 a 4,1 pontos e maximo 14,5 (o teto do peso de G). Mas a AGENDA NAO muda: '
+  'nenhuma quota le o health score (risco ordena por churnRisk, expansao por expansionScore, '
+  'follow-up por priorityScore) - so o rotulo healthClass exibido. '
+  'Ate 2026-08-13 este comentario prometia equivalencia EXATA de score, o que era falso. '
+  -- A frase antiga NAO e citada aqui de proposito: repeti-la literalmente faria toda auditoria
+  -- por substring continuar achando a promessa no catalogo, agora dentro da propria negacao.
+  'Escopo espelha a RLS de farmer_client_scores. '
+  'FASE 3c (2026-08-13): `motivo` passou a ser projetado sob private.cap_custo_ler, junto de '
+  'margem_pct. Ele carregava as ANCORAS ABSOLUTAS (piso 30 / meta 50) e, como `g` e AFIM na '
+  'margem (margem_pct = A + B*g), o maior `g` de cada motivo calibrava A e B e reconstruia a '
+  'carteira inteira numa unica resposta - medido em prod: erro de 0,03 pp em 859 dos 1.075 '
+  'clientes com margem. `faixa` e `g` CONTINUAM saindo sem cap: gatear `g` mudaria o health '
+  'score de quem nao tem cap (renormalizacao dos pesos), que e produto, nao autorizacao - o '
+  'custo foi medido (640 clientes, 91 de classe, agenda identica) e o founder optou por '
+  'preservar o score. A defesa depende de p10 > 0: a fronteira vermelho (margem < 0) so nao e '
+  '2a ancora porque esta SATURADA; se p10 cair abaixo de zero ela volta sozinha.';
+
+-- Fechamento por privilégio — reafirmado (idempotente). Função nova nasce com proacl NULL =
+-- EXECUTE implícito a PUBLIC, e o default privilege do Supabase concede às roles nomeadas.
+-- ⚠️ `authenticated` MANTÉM o EXECUTE: é o role do vendedor no browser, e o gate está no CORPO.
+REVOKE ALL ON FUNCTION public.get_carteira_margem_faixa() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.get_carteira_margem_faixa() FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_carteira_margem_faixa() TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
Follow-up do #1723. A revisão adversarial daquele PR (`/codex` gpt-5.6-sol, 2026-08-13) achou um vazamento de custo **pior** que o oráculo de escrita que ele fechou: este não precisa escrever nada e resolve numa **única resposta**.

## O ataque (medido, não teórico)

`public.get_carteira_margem_faixa()` gateia `margem_pct` por `private.cap_custo_ler`, mas devolvia `g` **e** `motivo` para todos. E `g` é uma transformação **afim** da margem:

```
margem_pct = A + B*g       A = 100*p10        B = 100*max(p90-p10, 0.01)
```

O atacante (employee sem `cap_custo_ler`) não conhece A nem B — mas `motivo` dava as **âncoras absolutas** que faltavam: `abaixo_do_piso` ⇒ margem < 30, `abaixo_da_meta` ⇒ 30 ≤ margem < 50. Tomando o **maior `g` de cada motivo**, ele resolve o sistema:

```
B = (50-30)/(g_50 - g_30)          A = 30 - B*g_30
```

**Executado sobre a prod (read-only, via `psql-ro`):**

| | estimado pelo atacante | real | erro |
|---|---|---|---|
| A | 29,4560 | 29,4260 | **0,03 pp** |
| B | 45,7780 | 45,7780 | **0,0000** |

**859 dos 1.075 clientes com margem reconstruídos com erro máximo de 0,03 pp.** Os 216 restantes estão saturados (`g`=0 ou 1) e não invertem exatamente — mas entregam o limite (margem ≤ 29,46% ou ≥ 75,23%), que já é informação de custo. Com a receita à vista, deriva-se o custo.

## O que este PR faz

`motivo` passa a ser projetado sob `cap_custo_ler`, exatamente como `margem_pct` já era. Sem as âncoras, sobra a fronteira do piso vinda de `faixa` — **uma equação para duas incógnitas**, e a inversão absoluta não fecha.

`faixa` e `g` **continuam saindo** para todos. Isso é deliberado e é a metade importante do PR.

## O que este PR NÃO faz, e por que — com o número na mão

Gatear `g` fecharia o eixo inteiro. Mas `calcularHealthScore` **renormaliza os pesos** quando `g` é null, então o health score de quem não tem cap **mudaria** — mudança de PRODUTO embutida numa entrega de AUTORIZAÇÃO, exatamente o que o #1543 evitou de propósito.

O custo foi **medido antes de descartar**, não presumido (harness novo `scripts/impacto-gate-g.ts`, sobre o corpus real de prod do #1721):

| persona | clientes c/ `g` | mudam score | Δ médio | Δ máx | mudam de classe | agenda |
|---|---|---|---|---|---|---|
| farmer A | 273 | 271 | 5,88 | 14,5 | 28 (3,4%) | **idêntica** |
| farmer B | 371 | 369 | 6,02 | 14,5 | 63 (7,5%) | **idêntica** |
| master (controle) | 764 | **0** | 0 | 0 | 0 | idêntica |

Falsificado: desligar o gate zera tudo `[0,0,0]`; gatear todos tira o master de 0 para 760 — o zero dele é efeito real do `capCusto`, não comparador morto.

**Decisão do founder (2026-08-13): fechar a âncora, preservar o score.**

## ⚠️ Limite honesto desta defesa

Ela depende de **`p10 > 0`** (hoje 29,43%). A fronteira `vermelho` (margem < 0) só não serve de 2ª âncora porque está **saturada** — todo cliente abaixo de p10 tem `g`=0, e 108 deles são indistinguíveis entre si. Se a população passar a ter margem negativa relevante, p10 cai abaixo de zero, aquela fronteira sai da saturação e **devolve a 2ª âncora sozinha**.

É defesa boa hoje, **não é invariante**. A **ordenação** por margem também segue exposta por construção (`g` é monótono na margem): quem tiver a margem real de um cliente por fora fecha o sistema. Fechar isso exige gatear `g` — a opção que este PR mediu e o founder escolheu não pagar agora.

## Lição transferível

Irmã da do #1723. Lá o gate de projeção caía por uma entrada **escrevível**; aqui cai por um rótulo **legível** que ancora a escala. Um campo derivado que é transformação **monótona** do número protegido só resiste enquanto ninguém publicar **dois pontos conhecidos da curva** — e um vocabulário categórico com limiares fixos é exatamente isso. Ao gatear um número, enumere o que mais na **mesma resposta** permite reconstruí-lo.

## Dois efeitos colaterais tratados (achados pela coordenação multi-sessão)

Os dois foram pegos pela re-checagem de `origin/main` imediatamente antes do `gh pr create` — a main tinha avançado 5 commits desde o início da sessão, dois deles nesta função.

**1. O COMMENT — "a última a escrever vence".** O #1728 mergeou horas antes trocando a promessa falsa de equivalência de score pelo delta medido, e tem um harness que **assere sobre o texto do comentário**. Meu `COMMENT ON FUNCTION` o apagaria em silêncio (nenhum gate de CI olha o catálogo, e o harness dele aplica só a migration dele — ficaria verde). O comentário desta migration é a **união**: o texto dele inteiro, mais o parágrafo da 3c. E o harness ganhou **G0a-G0f**, que falham se alguém voltar a substituir em vez de unir.

**2. A impressão digital do `prosrc`.** Esta é a **primeira migration a mudar o corpo** desde o #1543 — o #1728 pôde afirmar "o corpo não mudou" justamente porque `COMMENT` não toca `prosrc`. A digital em `db/valida-fu4f-fase3-carteira-margem-faixa.sql` foi para `169677fe…` (era `075209b9…`, que confirmei ser o corpo vivo em prod). Sem isso o validador devolveria `f` num banco **correto** — falso alarme que pararia um deploy.

Os três harnesses da cadeia foram alinhados, cada um preservando o que provava:

| harness | ajuste | por quê |
|---|---|---|
| #1543 | aplica a 3c; `F4`/`G1-G4` passam a usar persona **com** cap | sem isso mediriam o **gate**, não a **classificação** — e `F4` virou par (sem cap NÃO sai / com cap SAI), porque provar só um lado deixa passar um gate que nega todo mundo |
| #1728 | aplica a 3c entre `B5` e `C1`; `D2` compara com o corpo **vigente** | `B5` precisa do corpo intocado para provar que COMMENT não o altera; prender `D2` à digital do #1543 fazia o assert acusar "COMMENT mexeu no corpo" — **acusação falsa contra a migration errada** |

Cadeia inteira verde: **31/0, 35/0, 12/0**, `shellcheck` limpo.

## Prova

`db/test-carteira-margem-faixa-motivo-gate.sh` — PG17 local, **24 asserts, exit 0**, aplicando a migration REAL sobre o corpo real do #1543:

- **A1-A4** com cap nada regride (motivo, margem_pct e as 5 âncoras seguem visíveis)
- **B1-B3** sem cap a âncora some (motivo NULL, margem_pct NULL, **zero** motivos distintos)
- **C1-C3** `faixa` e `g` PRESERVADOS, e o `g` do atacante é **idêntico** ao do master — a prova de que não houve mudança de produto
- **D1-D5** escopo fail-closed, ACL (anon negado), SECURITY DEFINER, idempotência do 2º Run
- **E1-E3** a calibração não fecha — e **E3 é a contraprova**: o master legítimo **ainda calibra**, sem o que E1/E2 passariam por vacuidade

Falsificações **K1-K3** exigem o vermelho exato (K2 sabota gateando `g` — é o assert que protege o produto), **K4/K4b** são o canário do restore. Cada sabotagem prova que aplicou antes de rodar, e distingue *build quebrado* de *assert sem dente*.

> Nota de processo: a 1ª K1 acusou "sabotagem não aplicou" — e estava certa. `grep -F` com padrão multilinha trata cada linha como **alternativa (OR)**, então a 1ª linha casava o gate de `margem_pct` e a checagem reprovava a sabotagem correta. Ancorado em `CASE WHEN v_pode_num THEN$` (fim de linha), que só o gate do motivo tem.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260813234112_carteira_margem_faixa_motivo_gate_custo.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Precisa colar no SQL Editor do Lovable e rodar.

Pré-voo feito: `wt:preflight` 🟡 (evolução serial da 20260726170000, já commitada — só ordem), e o corpo foi conferido contra o `pg_get_functiondef` da PROD em 2026-08-13 (idêntico ao vivo, exceto o CASE do `motivo`).

Validação pós-apply:

```sql
SELECT CASE WHEN pg_get_functiondef(p.oid) LIKE '%CASE WHEN v_pode_num THEN
      CASE WHEN b.pct IS NULL%'
  THEN '✅ motivo gateado' ELSE '❌ FALTANDO — migration não aplicada' END AS status
FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
WHERE n.nspname = 'public' AND p.proname = 'get_carteira_margem_faixa';
```

`src/integrations/supabase/types.ts` segue dizendo `motivo: string` (o campo agora é nullable). Não editado à mão porque é gerado — e o #1723 estabeleceu a convenção de não tocá-lo. Sem impacto: **`motivo` não tem nenhum consumidor** no repo; o hook, único chamador da RPC, lê só `faixa`, `g` e `margem_pct`.
