### PR TITLE
feat(farmer): o sensor da fila do Plano Tático — 3 das 4 saídas eram o mesmo pixel [money-path]

### DIFF
--- a/docs/historico/fila-plano-tatico.md
+++ b/docs/historico/fila-plano-tatico.md
@@ -327,3 +327,85 @@ viva que fecha esse buraco. Um mede que **houve** entrada; o outro, que **há** 
 Enquanto o gatilho é "alguém me avisa", ele herda a mesma falha do zero sem denominador — ninguém
 consegue conferir se já disparou. Escrever a query custou uma consulta e transformou a espera em algo
 que qualquer sessão futura resolve sozinha, sem interromper o founder.
+
+---
+
+# Fase 4 — o sensor: a tela passa a dizer POR QUE veio vazia (2026-08-13)
+
+> Aplicação direta da regra do #1726: *"fase N+1 exige SINAL da fase N — superfície de uso nasce
+> com o sensor; sem sensor, a fase N+1 é instalá-lo."* A errata acima previu este passo
+> ("instrumentar com `track()` — abertura + clique"); esta fase o instala. Padrão herdado do
+> **#1717** (`c1c5ad25`), que resolveu a mesma classe na tela irmã `/rota/ligacoes`.
+
+## A abertura já estava coberta — e duplicá-la seria o erro
+
+A rota `/farmer/tactical-plan` vive dentro do `AppShellLayout` → `AppShell` → `PageViewTracker`,
+que emite `$pageview` a cada mudança de rota. Um evento novo de "abertura" criaria um **segundo
+denominador, divergente do primeiro, para a mesma pergunta**. O que faltava era o **desfecho** da
+abertura. Mesma conclusão do #1717, verificada aqui em vez de assumida por analogia.
+
+## São 4 saídas, e 3 produziam o mesmo pixel
+
+`loadPlans` (`src/hooks/useTacticalPlan.ts`):
+
+| # | Saída | O que a tela mostrava | Estado da lista |
+|---|---|---|---|
+| 1 | `!effectiveUserId` → `return` | "Nenhum plano pendente" | intocada (nem liga o `loading`) |
+| 2 | **`error` da consulta** | "Nenhum plano pendente" | limpa |
+| 3 | `data` vazio | "Nenhum plano pendente" | limpa |
+| 4 | `catch` (só `console.error`) | **a lista ANTIGA** | **preservada** |
+
+A perigosa é a **(2)**: o código fazia `const { data } = await …`, **descartando o `error`**, e
+`!data` caía no mesmo `setPlans([])` da (3). Falha de consulta era pixel-idêntica a fila vazia —
+e classificá-la como "não há plano" é fabricar diagnóstico (money-path §2). O `error` passou a
+ser lido **apenas para declarar o motivo**; o que a tela renderiza é byte-a-byte o de antes.
+
+A **(4)** é a que o dado precisava dizer em voz alta: o `catch` não toca em `plans`, então a tela
+segue exibindo o retrato do carregamento anterior *como se fosse o atual*. Daí a propriedade
+`manteve_lista` — sem ela, "quebrou e esvaziou" e "quebrou e está mentindo em silêncio" são o
+mesmo evento.
+
+A **(1)** é hoje inalcançável por esta tela (`useFarmerTacticalPlan` gateia por `user?.id`, e
+`effectiveUserId` deriva do mesmo `user`). Instrumentada mesmo assim, para que um chamador futuro
+a torne visível em vez de silenciosa — declarado no código, não descoberto de novo.
+
+## Eventos (`<area>.<action>`, área `plano_tatico.` — nova, sem colisão)
+
+```
+plano_tatico.fila_carregada   { filtro, n_exibidos, total }
+plano_tatico.fila_vazia       { filtro, total, motivo: sem_escopo | sem_resposta | recorte_vazio }
+plano_tatico.fila_erro        { filtro, total, origem: consulta | excecao, mensagem, manteve_lista }
+plano_tatico.desfecho_clicado { plano_id, desfecho, origem: um_toque }
+plano_tatico.desfecho_erro    { plano_id, desfecho, mensagem }
+```
+
+**Precedência do erro sobre `data` — garantida pelo TIPO, não por ordem de `if`.** A variante de
+erro de `SaidaDaCarga` **não carrega `nExibidos`**: é inrepresentável reportar tamanho de lista
+num caminho de falha. Sem isso, uma carga que *passou* a falhar seguiria reportando sucesso com o
+número velho (que na saída 4 continua na tela).
+
+**`total` viaja como `null` quando não apurado, nunca como 0** — mesma regra do rótulo da tela.
+
+**O clique sai DEPOIS do guard e ANTES do `await`.** Depois do guard porque toque barrado (lente
+"Ver como" / gravação em curso) não é tentativa. Antes do `await` porque o caso que mais importa
+é *clicou e a gravação morreu*: no sucesso o dado já existe no banco (`call_result`); é a
+**tentativa** que não existia em lugar nenhum.
+
+`desfecho_erro` fica no `catch` de `recordResult`, então cobre os **dois** caminhos de registro
+(1 toque e dialog detalhado). O caminho do dialog não emite `desfecho_clicado` — o sucesso dele já
+é visível no banco, e o escopo desta fase são os 5 botões de 1 toque.
+
+## O que este sensor NÃO responde
+
+Ele mede a tela, não a operação. O denominador continua sendo a query do §"O gatilho virou query"
+— com `employee → ativos_7d = 0`, os cinco eventos vão registrar zero, e **esse zero também não
+julga o desenho**. A leitura só começa quando as vendedoras entram em operação. O que muda é que,
+a partir daí, o zero deixa de ser mudo.
+
+## Lição
+
+O sensor tem de nascer com a **taxonomia das saídas**, não com um contador. "Instrumentei a tela"
+com um evento único de abertura teria produzido exatamente o mesmo impasse um nível acima: um
+número sem como saber o que ele significa. O trabalho real não foi chamar `track()` — foi **ler o
+código e enumerar as saídas**, e descobrir que uma delas (o `error` descartado) já era um bug de
+observabilidade esperando para ser lido como veredito de produto.

--- a/src/components/farmer/tacticalPlan/BotoesDesfecho.tsx
+++ b/src/components/farmer/tacticalPlan/BotoesDesfecho.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
+import { track } from '@/lib/analytics';
 import type { RecordResultPayload } from './types';
 
 /**
@@ -83,6 +84,13 @@ export const BotoesDesfecho = ({
   const registrar = async (valor: string) => {
     if (salvando || isImpersonating) return;
     setSalvando(valor);
+    // [SENSOR] Emitido DEPOIS do guard e ANTES do await, de propósito:
+    //  - depois do guard, porque toque barrado (lente / gravação em curso) não é tentativa —
+    //    contá-lo inflaria o numerador com cliques que nunca chegaram à RPC;
+    //  - antes do await, porque o caso que mais interessa medir é "clicou e a gravação morreu".
+    //    No sucesso o dado já existe no banco (`call_result`); é a TENTATIVA que não existia em
+    //    lugar nenhum, e é ela que separa "não registram" de "tentaram e o sistema recusou".
+    track('plano_tatico.desfecho_clicado', { desfecho: valor, plano_id: planId, origem: 'um_toque' });
     try {
       await onRecord(planId, payloadDeUmToque(valor));
     } catch (err) {

--- a/src/components/farmer/tacticalPlan/__tests__/BotoesDesfecho.test.tsx
+++ b/src/components/farmer/tacticalPlan/__tests__/BotoesDesfecho.test.tsx
@@ -4,9 +4,15 @@ import { BotoesDesfecho, DESFECHOS, payloadDeUmToque, rotuloDoDesfecho } from '.
 
 const impMock = vi.fn(() => ({ isImpersonating: false }));
 vi.mock('@/contexts/ImpersonationContext', () => ({ useImpersonation: () => impMock() }));
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+import { track } from '@/lib/analytics';
+
+const eventos = () => (track as ReturnType<typeof vi.fn>).mock.calls as [string, Record<string, unknown>][];
 
 beforeEach(() => {
   impMock.mockReturnValue({ isImpersonating: false });
+  vi.clearAllMocks();
 });
 
 function setup(onRecord = vi.fn(async () => {})) {
@@ -123,5 +129,57 @@ describe('BotoesDesfecho — interação', () => {
     }
     fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
     expect(onRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('BotoesDesfecho — telemetria do clique', () => {
+  // O sensor previsto pela errata de #1716. Com 533 planos gerados e 0 desfechos, o clique é
+  // a metade que faltava: sem ele, "não abrem a tela" e "abrem, clicam e a RPC recusa" são o
+  // mesmo zero em `farmer_tactical_plans.call_result`.
+  it('[TELE-1T] cada um dos CINCO botões emite desfecho_clicado com o seu valor', () => {
+    for (const d of DESFECHOS) {
+      vi.clearAllMocks();
+      const { unmount } = render(<BotoesDesfecho planId="p1" onRecord={vi.fn(async () => {})} />);
+      fireEvent.click(screen.getByRole('button', { name: d.rotulo }));
+      expect(eventos()).toContainEqual([
+        'plano_tatico.desfecho_clicado',
+        { desfecho: d.valor, plano_id: 'p1', origem: 'um_toque' },
+      ]);
+      unmount();
+    }
+  });
+
+  it('[TELE-1T] o clique é emitido ANTES do await — falha de rede não some com a intenção', async () => {
+    // Se o evento saísse no `onSuccess`, o caso que mais interessa (clicou e a gravação
+    // morreu) não deixaria rastro nenhum — e é justamente ele que separa "não registram"
+    // de "tentaram registrar e o sistema recusou".
+    render(<BotoesDesfecho planId="p1" onRecord={vi.fn(async () => { throw new Error('rede'); })} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    // Síncrono de propósito: o evento tem de existir ANTES de a promise da gravação resolver.
+    expect(eventos().map(([e]) => e)).toContain('plano_tatico.desfecho_clicado');
+    // Deixa o `finally` reabilitar os botões dentro do act — senão o React avisa que houve
+    // update fora dele, e teste que polui a saída esconde o próximo aviso de verdade.
+    await waitFor(() => {
+      expect((screen.getByRole('button', { name: 'Vendeu' }) as HTMLButtonElement).disabled).toBe(false);
+    });
+  });
+
+  it('[TELE-1T] clique BARRADO pelo guard não vira evento — intenção ≠ tentativa', () => {
+    // Sob a lente e durante a gravação o clique é ignorado. Contá-lo inflaria o numerador
+    // com toques que nunca chegaram à RPC.
+    impMock.mockReturnValue({ isImpersonating: true });
+    render(<BotoesDesfecho planId="p1" onRecord={vi.fn(async () => {})} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    expect(eventos()).toHaveLength(0);
+  });
+
+  it('[TELE-1T] toque duplo emite UMA vez — 1× por desfecho, não por toque', async () => {
+    let liberar: () => void = () => {};
+    render(<BotoesDesfecho planId="p1" onRecord={vi.fn(() => new Promise<void>((r) => { liberar = r; }))} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Vendeu' }));
+    expect(eventos().filter(([e]) => e === 'plano_tatico.desfecho_clicado')).toHaveLength(1);
+    liberar();
+    await waitFor(() => expect(eventos().filter(([e]) => e === 'plano_tatico.desfecho_clicado')).toHaveLength(1));
   });
 });

--- a/src/hooks/__tests__/telemetria-plano-tatico.test.tsx
+++ b/src/hooks/__tests__/telemetria-plano-tatico.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * O SENSOR da fila do Plano Tático — instalado porque a fase N+1 exige sinal da fase N.
+ *
+ * Medido em 2026-08-13 (docs/historico/fila-plano-tatico.md, errata): 533 planos gerados,
+ * ZERO desfecho, e ZERO `track()` na tela. Sem sensor não se separa "não abrem" de "abrem e
+ * não registram" — e o `loadPlans` piorava isso: das suas quatro saídas, três produziam o
+ * MESMO pixel ("Nenhum plano pendente") e a quarta deixava a lista ANTIGA na tela.
+ *
+ * DISCRIMINADOR: o `loadPlans` fazia `const { data } = await …`, DESCARTANDO o `error` da
+ * consulta da lista. Um teste que só checasse "emitiu evento" passaria na versão velha, que
+ * classificava falha de consulta como fila vazia. Os asserts abaixo travam a diferença.
+ */
+const MASTER = 'master-id';
+
+type Modo = 'ok' | 'lista_vazia' | 'erro_consulta' | 'sem_resposta' | 'excecao';
+let modo: Modo = 'ok';
+let erroRpc: { message: string } | null = null;
+
+const PLANO = {
+  id: 'p1', customer_user_id: 'c1', status: 'gerado',
+  strategic_objective: 'consolidacao_margem', customer_profile: 'x',
+  generated_at: '2026-08-01T00:00:00Z',
+};
+
+function resultadoDaLista(): unknown {
+  if (modo === 'lista_vazia') return { data: [], error: null };
+  if (modo === 'erro_consulta') return { data: null, error: { message: 'statement timeout', code: '57014' } };
+  if (modo === 'sem_resposta') return { data: null, error: null };
+  if (modo === 'excecao') throw new Error('Failed to fetch');
+  return { data: [PLANO], error: null };
+}
+
+function chain(table: string): unknown {
+  let head = false;
+  const c: Record<string, unknown> = {};
+  for (const m of ['in', 'lt', 'lte', 'is', 'not', 'or', 'filter', 'update', 'range', 'neq', 'eq', 'gte', 'order', 'limit']) c[m] = () => c;
+  c.select = (_cols: string, opts?: { count?: string; head?: boolean }) => {
+    if (opts?.head) head = true;
+    return c;
+  };
+  c.single = () => c;
+  c.maybeSingle = () => c;
+  c.then = (resolve: (v: unknown) => void) => {
+    if (table === 'farmer_tactical_plans' && head) return resolve({ data: null, count: 169, error: null });
+    if (table === 'farmer_tactical_plans') return resolve(resultadoDaLista());
+    return resolve({ data: [], error: null });
+  };
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (t: string) => chain(t),
+    rpc: () => Promise.resolve({ data: null, error: erroRpc }),
+  },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: MASTER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: MASTER }, isStaff: true }) }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }));
+
+import { track } from '@/lib/analytics';
+import { useTacticalPlan } from '../useTacticalPlan';
+
+const eventos = () => (track as ReturnType<typeof vi.fn>).mock.calls as [string, Record<string, unknown>][];
+const ultimo = (nome: string) => eventos().filter(([e]) => e === nome).at(-1);
+
+beforeEach(() => {
+  modo = 'ok';
+  erroRpc = null;
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('telemetria da carga da fila', () => {
+  it('fila com planos emite fila_carregada com tamanho, total e filtro', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    const ev = ultimo('plano_tatico.fila_carregada');
+    expect(ev).toBeDefined();
+    expect(ev![1]).toMatchObject({ n_exibidos: 1, total: 169, filtro: 'pendentes' });
+  });
+
+  it('fila vazia emite fila_vazia com motivo recorte_vazio', async () => {
+    modo = 'lista_vazia';
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    expect(ultimo('plano_tatico.fila_vazia')![1]).toMatchObject({ motivo: 'recorte_vazio' });
+    expect(eventos().map(([e]) => e)).not.toContain('plano_tatico.fila_carregada');
+  });
+
+  it('CONSULTA QUE FALHA emite fila_erro — jamais fila_vazia (o `error` era descartado)', async () => {
+    modo = 'erro_consulta';
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    // Este é o caso que motivou o PR: sem capturar o `error`, "a query morreu" ficava
+    // indistinguível de "não há plano nenhum" — o mesmo pixel, o mesmo evento, o mesmo zero.
+    const ev = ultimo('plano_tatico.fila_erro');
+    expect(ev).toBeDefined();
+    expect(ev![1]).toMatchObject({ origem: 'consulta', mensagem: 'statement timeout', manteve_lista: false });
+    expect(eventos().map(([e]) => e)).not.toContain('plano_tatico.fila_vazia');
+  });
+
+  it('resposta sem data E sem error vira motivo sem_resposta, não um palpite', async () => {
+    modo = 'sem_resposta';
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    expect(ultimo('plano_tatico.fila_vazia')![1]).toMatchObject({ motivo: 'sem_resposta' });
+  });
+
+  it('EXCEÇÃO: reporta erro e sinaliza que a lista ANTIGA continua na tela', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+    expect(r.current.plans).toHaveLength(1);
+
+    modo = 'excecao';
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+
+    // Precedência do erro sobre `data`: o catch de loadPlans NÃO limpa `plans`, então a tela
+    // segue exibindo o retrato do carregamento anterior. Reportar fila_carregada a partir
+    // desse estado seria dizer "sucesso" sobre uma carga que quebrou.
+    expect(r.current.plans).toHaveLength(1);
+    const ev = ultimo('plano_tatico.fila_erro');
+    expect(ev![1]).toMatchObject({ origem: 'excecao', manteve_lista: true });
+    expect(eventos().filter(([e]) => e === 'plano_tatico.fila_carregada')).toHaveLength(1);
+  });
+
+  it('contagem que falha viaja como total null — nunca 0', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => { await r.current.loadPlans('pendentes'); });
+    // O harness devolve count=169 sem erro; o guard de "ausente ≠ zero" na contagem já é
+    // coberto por fila-plano-tatico.test.tsx. Aqui só se trava que o total ATRAVESSA o evento.
+    expect(ultimo('plano_tatico.fila_carregada')![1].total).toBe(169);
+  });
+});
+
+describe('telemetria do desfecho', () => {
+  it('RPC que recusa o registro emite desfecho_erro com a mensagem real', async () => {
+    erroRpc = { message: 'Plano fora da sua carteira' };
+    const { result: r } = renderHook(() => useTacticalPlan());
+
+    await act(async () => {
+      await r.current.recordResult('p1', {
+        planFollowed: null, callResult: 'venda_realizada', actualMargin: null, callDurationSeconds: null,
+      });
+    });
+
+    // O catch mostra toast e some — a falha ficava invisível JUSTO no passo que alimenta o
+    // dado escasso (`call_result`). Sem este evento, clique sem linha no banco é indistinguível
+    // de "ela nem clicou".
+    const ev = ultimo('plano_tatico.desfecho_erro');
+    expect(ev).toBeDefined();
+    expect(ev![1]).toMatchObject({ mensagem: 'Plano fora da sua carteira', desfecho: 'venda_realizada' });
+  });
+
+  it('registro que dá certo NÃO emite desfecho_erro (o sucesso já é visível no banco)', async () => {
+    const { result: r } = renderHook(() => useTacticalPlan());
+    await act(async () => {
+      await r.current.recordResult('p1', {
+        planFollowed: null, callResult: 'nao_atendeu', actualMargin: null, callDurationSeconds: null,
+      });
+    });
+
+    expect(eventos().map(([e]) => e)).not.toContain('plano_tatico.desfecho_erro');
+  });
+});

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -6,6 +6,8 @@ import { margemConhecida, mediaMargensConhecidas, valorMedido } from '@/lib/scor
 import { numerosDoBundle } from '@/lib/tactical/bundle-numeros';
 import { ehJaGeradoHoje } from '@/lib/tactical/plano-duplicata';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import { eventoDaCarga, type SaidaDaCarga } from '@/lib/tactical/telemetria-fila-plano';
+import { track } from '@/lib/analytics';
 import { fetchAllPages } from '@/lib/postgrest';
 import { ownersAtivosDoAlvo } from '@/lib/carteira/escopo-clientes';
 import { useAuth } from '@/contexts/AuthContext';
@@ -401,7 +403,25 @@ export const useTacticalPlan = () => {
 
   // Load existing plans
   const loadPlans = useCallback(async (filtro: FiltroFila = filtroAtual.current) => {
-    if (!effectiveUserId) return;
+    // [SENSOR] Telemetria do DESFECHO da carga (docs/historico/fila-plano-tatico.md). Três das
+    // quatro saídas desta função produzem o MESMO pixel na tela — "Nenhum plano pendente" — e a
+    // quarta deixa a lista ANTIGA no lugar. Sem declarar o motivo em cada uma, "a consulta
+    // morreu" fica indistinguível de "não há plano", que é fabricar diagnóstico.
+    // `total` acompanha o que a carga JÁ apurou: null até a contagem responder, para que
+    // nenhum evento afirme um denominador que aquele ponto do código ainda não tinha.
+    let total: number | null = null;
+    const emitir = (saida: SaidaDaCarga) => {
+      const ev = eventoDaCarga(saida, { filtro, total });
+      track(ev.evento, ev.props);
+    };
+
+    if (!effectiveUserId) {
+      // Hoje inalcançável POR ESTA TELA (useFarmerTacticalPlan gateia por `user?.id`, e
+      // `effectiveUserId` deriva do mesmo `user`). Instrumentado mesmo assim: se outro chamador
+      // aparecer, a saída fica visível em vez de silenciosa — e ela nem liga o `loading`.
+      emitir({ tipo: 'vazia', motivo: 'sem_escopo' });
+      return;
+    }
     filtroAtual.current = filtro;
     setLoading(true);
     try {
@@ -414,14 +434,17 @@ export const useTacticalPlan = () => {
       // das linhas (medido 2026-08-07): ordenar por eles seria ordem indefinida
       // disfarçada de priorização. `generated_at` desempata (churn_risk tem empates
       // massivos e, sem ordem total, a fatia de 50 é instável entre cargas).
-      const { data } = (await recorteDaFila(
+      // [SENSOR] O `error` desta consulta era DESCARTADO no destructuring, e `!data` caía no
+      // mesmo `setPlans([])` de uma fila legitimamente vazia. Ele agora é lido — só para
+      // DECLARAR o motivo na telemetria; o que a tela renderiza é idêntico ao de antes.
+      const { data, error: erroLista } = (await recorteDaFila(
         supabase.from('farmer_tactical_plans').select('*').in('farmer_id', owners),
         filtro,
         desdeIso,
       )
         .order('churn_risk', { ascending: false })
         .order('generated_at', { ascending: false })
-        .limit(LIMITE_FILA)) as unknown as { data: TacticalPlanRow[] | null };
+        .limit(LIMITE_FILA)) as unknown as { data: TacticalPlanRow[] | null; error: unknown };
 
       // Contagem sob o MESMO recorte. Sem ela a tela não tem como avisar que existe
       // plano além dos exibidos — foi exatamente assim que 383 de 533 sumiram sem
@@ -438,8 +461,22 @@ export const useTacticalPlan = () => {
       // nunca para 0 — "0 pendentes" é indistinguível de "a query morreu", e some com
       // a fila inteira sem sinal. Mesma família do `Number(null) === 0`.
       setTotalNaFila(erroContagem ? null : (count ?? null));
+      total = erroContagem ? null : (count ?? null);
 
-      if (!data) { setPlans([]); return; }
+      // [SENSOR] O ERRO TEM PRECEDÊNCIA SOBRE `data`. As duas saídas abaixo faziam exatamente
+      // o mesmo `setPlans([]); return;` — e continuam fazendo, byte por byte, do ponto de vista
+      // da tela. O que mudou é que agora elas se DECLARAM: falha de consulta é `fila_erro`,
+      // e resposta sem `data` e sem `error` é indecidível assumida, não um palpite entre as duas.
+      if (erroLista) {
+        setPlans([]);
+        emitir({ tipo: 'erro', origem: 'consulta', mensagem: mensagemDeErro(erroLista), manteveLista: false });
+        return;
+      }
+      if (!data) {
+        setPlans([]);
+        emitir({ tipo: 'vazia', motivo: 'sem_resposta' });
+        return;
+      }
 
       const customerIdsSet = new Set<string>();
       data.forEach((d) => customerIdsSet.add(String(d.customer_user_id)));
@@ -453,8 +490,14 @@ export const useTacticalPlan = () => {
         (profiles || []).map((p) => [p.user_id ?? '', p.name ?? 'Cliente'])
       );
       setPlans(data.map((d) => parsePlan(d, profileMap)));
+      emitir({ tipo: 'lista', nExibidos: data.length });
     } catch (err) {
       console.error('Error loading plans:', err);
+      // [SENSOR] `manteveLista: true` porque este catch NÃO toca em `plans`: a tela continua
+      // exibindo o retrato do carregamento anterior como se fosse o atual. É a diferença entre
+      // "quebrou e esvaziou" e "quebrou e está mentindo em silêncio" — e ela só existe no dado
+      // se for declarada aqui.
+      emitir({ tipo: 'erro', origem: 'excecao', mensagem: mensagemDeErro(err), manteveLista: true });
     } finally {
       setLoading(false);
     }
@@ -835,6 +878,15 @@ export const useTacticalPlan = () => {
       // PostgREST, e o `String(err)` de antes exibia "[object Object]" no lugar da recusa
       // real da RPC ("Plano fora da sua carteira", constraint, timeout).
       const message = mensagemDeErro(err) ?? 'falha desconhecida';
+      // [SENSOR] O toast avisa a VENDEDORA e some. A falha ficava invisível para quem MEDE,
+      // justo no passo que alimenta o dado escasso (`call_result`): um clique cuja RPC foi
+      // recusada não deixa linha no banco e é indistinguível de "ela nem clicou". Cobre os
+      // DOIS caminhos de registro — 1 toque e dialog detalhado — porque ambos passam por aqui.
+      track('plano_tatico.desfecho_erro', {
+        plano_id: planId,
+        desfecho: result.callResult,
+        mensagem: message,
+      });
       toast.error('Erro ao registrar resultado', { description: message });
     }
   }, [loadPlans]);

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -293,6 +293,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/lens-tactical-plan.test.tsx",
       "src/hooks/__tests__/plano-bundle-ausente.test.tsx",
       "src/hooks/__tests__/tactical-plan-posse-dono.test.tsx",
+      "src/hooks/__tests__/telemetria-plano-tatico.test.tsx",
       "src/hooks/__tests__/useLastVisit.test.tsx",
       "src/hooks/__tests__/useMyVisitSuggestions.test.ts",
       "src/hooks/__tests__/useDashboardCompany.test.ts",

--- a/src/lib/tactical/telemetria-fila-plano.test.ts
+++ b/src/lib/tactical/telemetria-fila-plano.test.ts
@@ -33,7 +33,9 @@ describe('eventoDaCarga — a fila diz POR QUE veio vazia', () => {
     ['sem_escopo', 'a carga nem chegou a consultar (sem id efetivo)'],
     ['sem_resposta', 'sem error E sem data — indecidível, declarado como tal'],
     ['recorte_vazio', 'a consulta respondeu e o recorte não tem plano'],
-  ] as const)('motivo %s viaja no evento em vez de virar o mesmo pixel', (motivo) => {
+    // A 2ª coluna é o porquê de cada motivo — vai no nome do teste (%s) e o callback precisa
+    // recebê-la: sob TS strict, o callback de `it.each` tem de casar a ARIDADE da tupla.
+  ] as const)('motivo %s viaja no evento em vez de virar o mesmo pixel (%s)', (motivo, _porque) => {
     const ev = eventoDaCarga({ tipo: 'vazia', motivo }, { filtro: 'pendentes', total: null });
     expect(ev.evento).toBe('plano_tatico.fila_vazia');
     expect(ev.props.motivo).toBe(motivo);

--- a/src/lib/tactical/telemetria-fila-plano.test.ts
+++ b/src/lib/tactical/telemetria-fila-plano.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { eventoDaCarga, type SaidaDaCarga } from './telemetria-fila-plano';
+
+/**
+ * Telemetria da fila do Plano Tático — o SENSOR que a errata de #1716 previu.
+ *
+ * Discriminador destes testes: um teste que só checasse "emitiu algum evento" passaria
+ * numa versão que classifica erro como fila vazia — que é exatamente o defeito. Os asserts
+ * abaixo travam (a) o motivo DECLARADO de cada saída-vazia, (b) a precedência do erro sobre
+ * a lista, e (c) o fato de que o `catch` deixa a lista ANTIGA na tela.
+ */
+
+const ctx = { filtro: 'pendentes' as const, total: 169 };
+
+describe('eventoDaCarga — a fila diz POR QUE veio vazia', () => {
+  it('lista com planos → fila_carregada com o tamanho e o total sob o mesmo recorte', () => {
+    const ev = eventoDaCarga({ tipo: 'lista', nExibidos: 50 }, ctx);
+    expect(ev.evento).toBe('plano_tatico.fila_carregada');
+    expect(ev.props.n_exibidos).toBe(50);
+    expect(ev.props.total).toBe(169);
+    expect(ev.props.filtro).toBe('pendentes');
+  });
+
+  it('lista vazia → fila_vazia com motivo recorte_vazio (a consulta RESPONDEU zero)', () => {
+    const ev = eventoDaCarga({ tipo: 'lista', nExibidos: 0 }, { filtro: 'pendentes', total: 0 });
+    expect(ev.evento).toBe('plano_tatico.fila_vazia');
+    expect(ev.props.motivo).toBe('recorte_vazio');
+  });
+
+  // As três saídas-vazias que hoje produzem o MESMO pixel ("Nenhum plano pendente").
+  // Sem motivo declarado, "a consulta morreu" é indistinguível de "não há plano".
+  it.each([
+    ['sem_escopo', 'a carga nem chegou a consultar (sem id efetivo)'],
+    ['sem_resposta', 'sem error E sem data — indecidível, declarado como tal'],
+    ['recorte_vazio', 'a consulta respondeu e o recorte não tem plano'],
+  ] as const)('motivo %s viaja no evento em vez de virar o mesmo pixel', (motivo) => {
+    const ev = eventoDaCarga({ tipo: 'vazia', motivo }, { filtro: 'pendentes', total: null });
+    expect(ev.evento).toBe('plano_tatico.fila_vazia');
+    expect(ev.props.motivo).toBe(motivo);
+  });
+
+  it('contagem não apurada viaja como null, NUNCA como 0 (ausente ≠ zero)', () => {
+    const ev = eventoDaCarga({ tipo: 'lista', nExibidos: 12 }, { filtro: 'pendentes', total: null });
+    expect(ev.props.total).toBeNull();
+    expect(ev.props.total).not.toBe(0);
+  });
+
+  it('erro de CONSULTA → fila_erro, e a lista foi limpa', () => {
+    const ev = eventoDaCarga(
+      { tipo: 'erro', origem: 'consulta', mensagem: 'statement timeout', manteveLista: false },
+      ctx,
+    );
+    expect(ev.evento).toBe('plano_tatico.fila_erro');
+    expect(ev.props.origem).toBe('consulta');
+    expect(ev.props.mensagem).toBe('statement timeout');
+    expect(ev.props.manteve_lista).toBe(false);
+  });
+
+  it('EXCEÇÃO → fila_erro sinalizando que a lista ANTIGA continua na tela', () => {
+    // O `catch` de loadPlans só faz console.error: `plans` NÃO é atualizado, então a tela
+    // segue exibindo o retrato do carregamento anterior. Sem `manteve_lista` ninguém
+    // distingue "quebrou e esvaziou" de "quebrou e está mostrando dado velho".
+    const ev = eventoDaCarga(
+      { tipo: 'erro', origem: 'excecao', mensagem: 'Failed to fetch', manteveLista: true },
+      ctx,
+    );
+    expect(ev.evento).toBe('plano_tatico.fila_erro');
+    expect(ev.props.origem).toBe('excecao');
+    expect(ev.props.manteve_lista).toBe(true);
+  });
+
+  it('erro sem mensagem utilizável não fabrica diagnóstico', () => {
+    const ev = eventoDaCarga(
+      { tipo: 'erro', origem: 'consulta', mensagem: null, manteveLista: false },
+      ctx,
+    );
+    expect(ev.props.mensagem).toBe('(sem mensagem)');
+  });
+
+  it('o erro NUNCA reporta tamanho de lista — é inrepresentável no tipo', () => {
+    // Precedência do erro sobre `data`: no caminho de exceção o `plans` do hook é o retrato
+    // VELHO. Se a variante de erro carregasse `nExibidos`, uma carga que PASSOU a falhar
+    // reportaria sucesso com o número antigo. O tipo não deixa — este teste trava a garantia.
+    const erro: SaidaDaCarga = { tipo: 'erro', origem: 'consulta', mensagem: 'x', manteveLista: false };
+    expect(Object.keys(erro)).not.toContain('nExibidos');
+    expect(eventoDaCarga(erro, ctx).props.n_exibidos).toBeUndefined();
+  });
+
+  it('o filtro viaja em todas as saídas — a análise que importa é a aba pendentes', () => {
+    const saidas: SaidaDaCarga[] = [
+      { tipo: 'lista', nExibidos: 3 },
+      { tipo: 'lista', nExibidos: 0 },
+      { tipo: 'vazia', motivo: 'sem_escopo' },
+      { tipo: 'erro', origem: 'excecao', mensagem: 'x', manteveLista: true },
+    ];
+    for (const s of saidas) {
+      expect(eventoDaCarga(s, { filtro: 'expirados', total: null }).props.filtro).toBe('expirados');
+    }
+  });
+});

--- a/src/lib/tactical/telemetria-fila-plano.ts
+++ b/src/lib/tactical/telemetria-fila-plano.ts
@@ -31,13 +31,16 @@
 // hook (que importa este módulo). O tipo é do domínio da fila; o hook é só onde ele mora hoje.
 import type { FiltroFila } from '@/hooks/useTacticalPlan';
 
-export type MotivoFilaVazia =
+// Não exportados: só `SaidaDaCarga` e `eventoDaCarga` atravessam a fronteira do módulo, e
+// export sem consumidor quebra o gate de dead code (knip) — que é um gate à parte de
+// typecheck/lint/test, com visão própria.
+type MotivoFilaVazia =
   | 'sem_escopo'    // não havia id efetivo — a carga nem chegou a consultar
   | 'sem_resposta'  // sem `error` E sem `data`: indecidível, declarado como tal
   | 'recorte_vazio'; // a consulta RESPONDEU e o recorte não tem nenhum plano
 
 /** De onde veio a falha. `consulta` = o PostgREST devolveu `error`; `excecao` = throw no try. */
-export type OrigemErroFila = 'consulta' | 'excecao';
+type OrigemErroFila = 'consulta' | 'excecao';
 
 /**
  * O que cada saída de `loadPlans` observa. Note que a variante de ERRO **não carrega tamanho

--- a/src/lib/tactical/telemetria-fila-plano.ts
+++ b/src/lib/tactical/telemetria-fila-plano.ts
@@ -1,0 +1,107 @@
+/**
+ * Telemetria da fila do Plano Tático (PTPL, `/farmer/tactical-plan`).
+ *
+ * PROBLEMA QUE ISTO RESOLVE: 533 planos gerados, ZERO desfecho registrado, e ZERO `track()`
+ * na tela inteira (medido 2026-08-13 — docs/historico/fila-plano-tatico.md, errata). Sem
+ * sensor não há como separar "não abrem a tela" de "abrem e não registram", e a fase N+1
+ * dessa investigação depende exatamente dessa separação. Instalar o sensor É a fase N+1.
+ *
+ * A ABERTURA JÁ ESTÁ COBERTA. A rota vive dentro do `AppShellLayout` → `AppShell` →
+ * `PageViewTracker`, que emite `$pageview` a cada mudança de rota. Duplicar isso criaria um
+ * SEGUNDO denominador, divergente do primeiro, para a mesma pergunta. O que faltava — e o que
+ * estes eventos entregam — é o DESFECHO da abertura: veio fila, veio vazia (por qual motivo),
+ * ou quebrou.
+ *
+ * O MOTIVO É DECLARADO NO PONTO QUE SABE, NUNCA INFERIDO. `loadPlans` tem quatro saídas e
+ * três delas produzem o MESMO pixel na tela ("Nenhum plano pendente"):
+ *
+ *   1. `!effectiveUserId`  → sai antes de consultar qualquer coisa
+ *   2. `error` da consulta → a lista MORREU (e o `error` era descartado no destructuring)
+ *   3. `data` vazio        → o recorte respondeu e não tem plano
+ *   4. `catch`             → exceção; a lista ANTIGA continua na tela
+ *
+ * Reconstruir o motivo a partir dos totais classificaria (2) como (3) — falha de consulta
+ * lida como "não há plano" é fabricar diagnóstico (money-path §2: ausente ≠ zero).
+ */
+
+// `import type` de propósito: é apagado na compilação, então não cria ciclo em runtime com o
+// hook (que importa este módulo). O tipo é do domínio da fila; o hook é só onde ele mora hoje.
+import type { FiltroFila } from '@/hooks/useTacticalPlan';
+
+export type MotivoFilaVazia =
+  | 'sem_escopo'    // não havia id efetivo — a carga nem chegou a consultar
+  | 'sem_resposta'  // sem `error` E sem `data`: indecidível, declarado como tal
+  | 'recorte_vazio'; // a consulta RESPONDEU e o recorte não tem nenhum plano
+
+/** De onde veio a falha. `consulta` = o PostgREST devolveu `error`; `excecao` = throw no try. */
+export type OrigemErroFila = 'consulta' | 'excecao';
+
+/**
+ * O que cada saída de `loadPlans` observa. Note que a variante de ERRO **não carrega tamanho
+ * de lista** — e isso é a garantia estrutural da precedência do erro sobre `data`: no caminho
+ * de exceção o `plans` do hook é o retrato do carregamento ANTERIOR, e uma carga que passou a
+ * falhar seguiria reportando sucesso com o número velho se o tipo permitisse. Aqui não permite.
+ */
+export type SaidaDaCarga =
+  | { tipo: 'vazia'; motivo: MotivoFilaVazia }
+  | {
+      tipo: 'erro';
+      origem: OrigemErroFila;
+      mensagem: string | null;
+      /**
+       * A tela ficou com a lista ANTIGA? Declarado pelo chamador porque só ele sabe: o ramo de
+       * `error` faz `setPlans([])`, o `catch` não toca em `plans`. Sem este campo ninguém
+       * distingue "quebrou e esvaziou" de "quebrou e está exibindo dado velho como se fosse atual".
+       */
+      manteveLista: boolean;
+    }
+  | { tipo: 'lista'; nExibidos: number };
+
+export interface ContextoCarga {
+  filtro: FiltroFila;
+  /** Total sob o MESMO recorte da lista. `null` = não apurado (a contagem falhou ou nem rodou). */
+  total: number | null;
+}
+
+export interface EventoFila {
+  evento: string;
+  props: Record<string, string | number | boolean | null>;
+}
+
+/**
+ * Traduz a saída observada no evento a emitir. Chamado UMA vez por carga (dentro do
+ * `loadPlans`, que roda por carregamento e não por render) — não precisa de dedupe por chave.
+ */
+export function eventoDaCarga(saida: SaidaDaCarga, ctx: ContextoCarga): EventoFila {
+  // `total` viaja como `null` quando não apurado, nunca como 0: "0 pendentes" é
+  // indistinguível de "a contagem morreu" — a mesma família do `Number(null) === 0`.
+  const base = { filtro: ctx.filtro, total: ctx.total };
+
+  if (saida.tipo === 'erro') {
+    return {
+      evento: 'plano_tatico.fila_erro',
+      props: {
+        ...base,
+        origem: saida.origem,
+        // Sem mensagem utilizável, admite a ausência em vez de inventar um diagnóstico.
+        mensagem: saida.mensagem || '(sem mensagem)',
+        manteve_lista: saida.manteveLista,
+      },
+    };
+  }
+
+  if (saida.tipo === 'vazia') {
+    // Sem `n_exibidos` de propósito: nestas saídas o `plans` do hook não foi reescrito, então
+    // afirmar "0 na tela" seria alegar um fato que este ponto do código não observou.
+    return { evento: 'plano_tatico.fila_vazia', props: { ...base, motivo: saida.motivo } };
+  }
+
+  if (saida.nExibidos === 0) {
+    return {
+      evento: 'plano_tatico.fila_vazia',
+      props: { ...base, motivo: 'recorte_vazio' satisfies MotivoFilaVazia, n_exibidos: 0 },
+    };
+  }
+
+  return { evento: 'plano_tatico.fila_carregada', props: { ...base, n_exibidos: saida.nExibidos } };
+}

--- a/src/lib/tactical/telemetria-fila-plano.ts
+++ b/src/lib/tactical/telemetria-fila-plano.ts
@@ -15,7 +15,10 @@
  * O MOTIVO É DECLARADO NO PONTO QUE SABE, NUNCA INFERIDO. `loadPlans` tem quatro saídas e
  * três delas produzem o MESMO pixel na tela ("Nenhum plano pendente"):
  *
- *   1. `!effectiveUserId`  → sai antes de consultar qualquer coisa
+ *   1. sem id efetivo    → sai antes de consultar qualquer coisa
+ *                          (o identificador não é citado aqui de propósito: o gate
+ *                           anti-write-leak o varre por TEXTO, e este módulo não tem
+ *                           por que mencioná-lo nem em prosa)
  *   2. `error` da consulta → a lista MORREU (e o `error` era descartado no destructuring)
  *   3. `data` vazio        → o recorte respondeu e não tem plano
  *   4. `catch`             → exceção; a lista ANTIGA continua na tela


### PR DESCRIPTION
A tela do Plano Tático tinha **zero `track()`** — contra 66 arquivos do repo que usam — e nenhuma
telemetria server-side no módulo Farmer (`farmer_audit_log` e `farmer_copilot_events` vazias). Com
533 planos gerados e 0 desfechos, ninguém conseguia separar "não abrem a tela" de "abrem e não
registram". A errata do #1716 previu exatamente este passo; ele nunca foi instalado.

É a regra do #1726 aplicada: **superfície de uso nasce com o sensor; sem sensor, a fase N+1 é
instalá-lo.** Padrão herdado do #1717 (`c1c5ad25`), que resolveu a mesma classe em `/rota/ligacoes`.

## A abertura já estava coberta — e duplicá-la seria o erro

A rota vive dentro de `AppShellLayout` → `AppShell` → `PageViewTracker`, que emite `$pageview` a
cada mudança de rota. Um evento novo de "abertura" criaria um SEGUNDO denominador, divergente do
primeiro, para a mesma pergunta. O que faltava é o **desfecho** da abertura. Verificado, não
assumido por analogia com o #1717.

## São 4 saídas, 3 produziam o mesmo pixel — e uma delas era um bug de observabilidade

`loadPlans` (`src/hooks/useTacticalPlan.ts`):

| # | Saída | Tela mostrava | Lista |
|---|---|---|---|
| 1 | `!effectiveUserId` → `return` | "Nenhum plano pendente" | intocada (nem liga o `loading`) |
| 2 | **`error` da consulta** | "Nenhum plano pendente" | limpa |
| 3 | `data` vazio | "Nenhum plano pendente" | limpa |
| 4 | `catch` (só `console.error`) | **a lista ANTIGA** | **preservada** |

A perigosa é a **(2)**: o código fazia `const { data } = await …`, **descartando o `error`**, e
`!data` caía no mesmo `setPlans([])` da (3). Falha de consulta era pixel-idêntica a fila vazia —
classificá-la como "não há plano" é fabricar diagnóstico (money-path §2). O `error` passou a ser
lido **só para declarar o motivo**: as duas saídas continuam fazendo o mesmo `setPlans([]); return;`
de antes, então **a tela é byte-a-byte igual**.

A **(4)** é a que o dado precisava dizer em voz alta: o `catch` não toca em `plans`, então a tela
segue exibindo o retrato do carregamento anterior *como se fosse o atual*. Daí `manteve_lista` —
sem ela, "quebrou e esvaziou" e "quebrou e está mentindo em silêncio" são o mesmo evento.

A **(1)** é hoje inalcançável por esta tela (`useFarmerTacticalPlan` gateia por `user?.id`, e
`effectiveUserId` deriva do mesmo `user`). Instrumentada mesmo assim, e o motivo está no código.

## Eventos (`<area>.<action>`, área `plano_tatico.` — nova, sem colisão no repo)

```
plano_tatico.fila_carregada   { filtro, n_exibidos, total }
plano_tatico.fila_vazia       { filtro, total, motivo: sem_escopo | sem_resposta | recorte_vazio }
plano_tatico.fila_erro        { filtro, total, origem: consulta | excecao, mensagem, manteve_lista }
plano_tatico.desfecho_clicado { plano_id, desfecho, origem: um_toque }
plano_tatico.desfecho_erro    { plano_id, desfecho, mensagem }
```

**Precedência do erro sobre `data` — garantida pelo TIPO, não por ordem de `if`.** A variante de
erro de `SaidaDaCarga` **não carrega `nExibidos`**: reportar tamanho de lista num caminho de falha é
inrepresentável. Sem isso, uma carga que *passou* a falhar seguiria reportando sucesso com o número
velho — que na saída (4) continua na tela.

**`total` viaja como `null` quando não apurado, nunca 0** — mesma regra do rótulo honesto da tela.

**O clique sai DEPOIS do guard e ANTES do `await`.** Depois do guard porque toque barrado (lente
"Ver como" / gravação em curso) não é tentativa e inflaria o numerador. Antes do `await` porque o
caso que mais importa é *clicou e a gravação morreu*: no sucesso o dado já existe no banco
(`call_result`); é a **tentativa** que não existia em lugar nenhum.

`desfecho_erro` fica no `catch` de `recordResult` e cobre os **dois** caminhos de registro (1 toque
e dialog detalhado). O dialog não emite `desfecho_clicado` — o sucesso dele já é visível no banco, e
o escopo aqui são os 5 botões de 1 toque.

## Sem migration, sem mudança de UI, sem tabela nova. É só telemetria.

## O que este sensor NÃO responde

Ele mede a tela, não a operação. O denominador continua sendo a query do gatilho
(`docs/historico/fila-plano-tatico.md` §"O gatilho virou query"): com `employee → ativos_7d = 0`,
os cinco eventos vão registrar zero — e **esse zero também não julga o desenho**. O que muda é que,
a partir de agora, o zero deixa de ser mudo.

## Prova

RED verificado por `Failed to resolve import "./telemetria-fila-plano"` antes de qualquer linha de
produção. Testes: 9 no módulo puro, 8 no hook (incluindo o discriminador — consulta que falha emite
`fila_erro` e **jamais** `fila_vazia`, que é o que a versão velha fazia), 4 nos botões.

Co-authored-by: Claude Opus 5 <noreply@anthropic.com>
