### PR TITLE
feat(farmer): o scoring passa a ver TODA venda — a allowlist citava 2 status que não existem [money-path]

### DIFF
--- a/db/test-fu4f-fase3-paridade-ts-sql.sh
+++ b/db/test-fu4f-fase3-paridade-ts-sql.sh
@@ -184,9 +184,14 @@ for marca in \
   "const riscoSlots = Math.round(totalSlots * cfg.agenda_pct_risco);" ; do
   command grep -qF "$marca" "$SCRIPT" || { echo "   FAIL: o SCRIPT nao contem mais <$marca>"; falha_ts=1; }
 done
-# a allowlist do hook é o universo do lado TS — se ela mudar, o corpus deste harness ficou velho
-command grep -qF "'confirmado', 'faturado', 'entregue'" "$HOOK" || {
-  echo "   FAIL: a allowlist de status do hook MUDOU — o corpus deste harness nao representa mais o hook"; falha_ts=1; }
+# ⚠️ O hook FECHOU os dois eixos (2026-08-14): universo por DENYLIST + tela recortada pela
+# carteira. Logo `pedidos.csv` (allowlist) representa o hook HISTÓRICO, pré-#1543/#1730 — é o
+# baseline que este harness compara, e é assim de propósito: o valor dele é medir o que MUDOU.
+# O universo do hook ATUAL é `pedidos-denylist.csv` (cenário E, passo 10).
+command grep -qF "STATUS_NAO_VENDA_POSTGREST" "$HOOK" || {
+  echo "   FAIL: o hook nao usa mais a denylist compartilhada — o cenario E nao representa o hook"; falha_ts=1; }
+command grep -qE "\.in\(\s*'status'" "$HOOK" && {
+  echo "   FAIL: o hook VOLTOU a filtrar status por allowlist"; falha_ts=1; }
 [ "$falha_ts" -eq 0 ] || { echo "FAIL: copias verbatim divergiram do hook"; exit 1; }
 echo "   ✓ copias verbatim casam com o hook"
 

--- a/src/hooks/useFarmerScoring.ts
+++ b/src/hooks/useFarmerScoring.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { useCommercialRole } from '@/hooks/useCommercialRole';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { filtrarPorCarteira } from '@/lib/scoring/escopoCarteira';
+import { STATUS_NAO_VENDA_POSTGREST } from '@/lib/scoring/universoPedidos';
 import type { Tables } from '@/integrations/supabase/types';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
 import { fetchAllPages } from '@/lib/postgrest';
@@ -159,14 +160,19 @@ export const useFarmerScoring = (farmerId?: string) => {
     setCalculating(true);
 
     try {
-      // 1. Load all customers with sales orders (paginado: 19.978 pedidos nos 3 status).
+      // 1. Load all customers with sales orders (paginado: 30.834 pedidos na denylist).
       // Sem paginar, TODO o scoring — recência, frequência, spend, margem, mix — enxergava
       // só as primeiras 1.000 linhas, ~5% do histórico. Cross-sell e bundle já paginavam.
       const salesOrders = await fetchAllPages<SalesOrderRow>((de, ate) =>
         supabase
           .from('sales_orders')
           .select('id, customer_user_id, items, total, created_at, order_date_kpi, status')
-          .in('status', ['confirmado', 'faturado', 'entregue'])
+          // DENYLIST + `deleted_at IS NULL`: o MESMO universo de `private.margem_cliente_agregada()`.
+          // A allowlist anterior citava dois status inexistentes (`confirmado`/`entregue`, zero
+          // linhas), resolvia para só `faturado` e escondia 10.236 pedidos reais — a margem vinha
+          // de um universo e o resto do score de outro.
+          .not('status', 'in', STATUS_NAO_VENDA_POSTGREST)
+          .is('deleted_at', null)
           .order('id', { ascending: true })
           .range(de, ate) as unknown as PromiseLike<{ data: SalesOrderRow[] | null; error: unknown }>,
         'sales_orders/scoring',
@@ -274,9 +280,15 @@ export const useFarmerScoring = (farmerId?: string) => {
       //     de 562/464 para 21/24. Custou 11–12 dos 20 slots da agenda, MAIS que alinhar a
       //     allowlist, porque muda a POPULAÇÃO e com ela o p95 que normaliza `m` (e portanto
       //     recover/priority, que a agenda lê).
-      //   • O eixo UNIVERSO (a allowlist logo acima) segue ABERTO — de propósito. Fechá-lo troca
-      //     outros 9 slots e é decisão separada; o chip "Corrigir filtro de status do scoring do
-      //     farmer" continua valendo.
+      //   • O eixo UNIVERSO ✅ FECHADO em 2026-08-14 (decisão do founder): a query acima passou
+      //     de allowlist para a DENYLIST compartilhada (`STATUS_NAO_VENDA_POSTGREST`) + deleted_at.
+      //     Com os DOIS eixos fechados a paridade TS×SQL some — delta de faixa 8,5%/6,6% → 0,2%/0%
+      //     (master 0,1%) —, a tela vai de 294/395 para 431/526 clientes e a agenda troca 15 e 10
+      //     dos 20 slots (medido no cenário E; mais que os 9 do cenário C isolado, porque agora o
+      //     universo maior incide sobre a CARTEIRA e não sobre a base inteira).
+      //     ⚠️ "Sem custo conhecido" SOBE em absoluto (21→51, 24→44): os clientes que entram só
+      //     tinham pedido em `importado`/`separacao`/`enviado` e nem todos têm custo apurado. É
+      //     ganho de cobertura com uma cauda honesta de desconhecido, não regressão do sinal.
       //
       // `margem_pct` só vem preenchido para quem tem `cap_custo_ler`; para os demais é null e a
       // UI mostra a FAIXA no lugar do número. O gate é de PROJEÇÃO, no corpo da RPC.

--- a/src/lib/scoring/__tests__/universoPedidos.test.ts
+++ b/src/lib/scoring/__tests__/universoPedidos.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { STATUS_NAO_VENDA } from '../universoPedidos';
+
+/**
+ * O universo de PEDIDOS do scoring do farmer.
+ *
+ * Toda esta frente nasceu de as duas pontas discordarem: o hook filtrava por ALLOWLIST
+ * (`confirmado`/`faturado`/`entregue`) e `private.margem_cliente_agregada()` por DENYLIST. Como
+ * `confirmado` e `entregue` têm ZERO linhas em prod, a allowlist resolvia para só `faturado` e
+ * escondia 10.236 pedidos reais (`importado`/`separacao`/`enviado`).
+ *
+ * O teste que importa não é "a constante tem 4 itens" — é que ela **continue espelhando o SQL**,
+ * e que o hook **não volte para uma allowlist**. Uma divergência aqui é invisível no typecheck,
+ * no lint e na tela: só aparece como número diferente entre a margem e o resto do score.
+ */
+describe('universo de pedidos do scoring', () => {
+  it('espelha a denylist de private.margem_cliente_agregada()', () => {
+    // Verbatim do corpo em PROD (pg_get_functiondef, 2026-08-13):
+    //   WHERE so.status NOT IN ('cancelado', 'rascunho', 'pendente', 'orcamento')
+    expect([...STATUS_NAO_VENDA].sort()).toEqual(
+      ['cancelado', 'orcamento', 'pendente', 'rascunho'],
+    );
+  });
+
+  it('o hook consome a denylist e NÃO reintroduz a allowlist de status', () => {
+    // Gate estrutural (padrão de `paginacao-artesanal-gate.test.ts`): lê o FONTE, porque a
+    // regressão aqui é textual — alguém "restaura" o `.in('status', [...])` num rebase e nada
+    // quebra, só a tela volta a divergir da autoridade.
+    // Caminho a partir da raiz do repo (cwd do vitest), como os demais gates que leem fonte —
+    // `new URL(..., import.meta.url)` não resolve como file:// aqui.
+    const hook = readFileSync('src/hooks/useFarmerScoring.ts', 'utf8');
+    const semComentarios = hook
+      .split('\n')
+      .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/*'))
+      .join('\n');
+
+    expect(
+      /\.in\(\s*['"]status['"]/.test(semComentarios),
+      'o hook voltou a filtrar status por allowlist — diverge de margem_cliente_agregada()',
+    ).toBe(false);
+    expect(
+      semComentarios.includes('STATUS_NAO_VENDA'),
+      'o hook não usa mais a denylist compartilhada',
+    ).toBe(true);
+    expect(
+      /\.is\(\s*['"]deleted_at['"]\s*,\s*null\s*\)/.test(semComentarios),
+      'o hook não filtra deleted_at — o helper filtra, e a denylist sozinha traria pedido apagado',
+    ).toBe(true);
+  });
+});

--- a/src/lib/scoring/universoPedidos.ts
+++ b/src/lib/scoring/universoPedidos.ts
@@ -1,0 +1,27 @@
+// O universo de PEDIDOS do scoring do farmer — DENYLIST, espelhando a autoridade da margem.
+//
+// POR QUE EXISTE: o hook filtrava por ALLOWLIST `('confirmado','faturado','entregue')` enquanto
+// `private.margem_cliente_agregada()` filtra por DENYLIST. E `confirmado`/`entregue` têm ZERO
+// linhas em prod, então a allowlist resolvia para só `faturado` e escondia 10.236 pedidos reais
+// (`importado` 5.419 · `separacao` 2.809 · `enviado` 2.008) — R$ 6.985.425,66, 26% do faturamento.
+// Consequência medida: a margem vinha de um universo e o resto do score de outro.
+//
+// ⚠️ NULL: tanto este filtro quanto o SQL da autoridade descartam `status IS NULL` — em SQL,
+// `NULL NOT IN (...)` é NULL (não passa), e no PostgREST o `not.in` é NULL-blind do mesmo jeito.
+// A paridade é intencional: espelhar a autoridade inclui espelhar como ela trata o nulo. Medido
+// em prod (2026-08-13): 0 linhas com status nulo, então hoje o ponto é teórico.
+//
+// ⚠️ `deleted_at IS NULL` anda JUNTO. A allowlist antiga mascarava o problema; a denylist sozinha
+// traria pedido apagado (hoje 0 linhas, mas o helper filtra e a paridade exige que este também
+// filtre).
+
+/** Status que NÃO são venda. Verbatim do corpo em prod de `private.margem_cliente_agregada()`. */
+export const STATUS_NAO_VENDA: readonly string[] = [
+  'cancelado',
+  'rascunho',
+  'pendente',
+  'orcamento',
+];
+
+/** Valor pronto para o `.not('status', 'in', …)` do PostgREST: `("a","b",…)`. */
+export const STATUS_NAO_VENDA_POSTGREST = `("${STATUS_NAO_VENDA.join('","')}")`;


### PR DESCRIPTION
Fecha o eixo **universo**, o segundo e último dos dois deltas medidos no #1721/#1727. Com o #1730 (eixo escopo), a tela do farmer e a autoridade da margem passam a **concordar**.

O hook filtrava `status IN ('confirmado','faturado','entregue')` enquanto `private.margem_cliente_agregada()` filtra por denylist. **`confirmado` e `entregue` têm zero linhas em prod**: a allowlist resolvia para só `faturado` e escondia **10.236 pedidos reais** — `importado` 5.419 · `separacao` 2.809 · `enviado` 2.008 (R$ 6.985.425,66, 26% do faturamento). A margem vinha de um universo e o resto do score de outro.

## Medido (cenário E — denylist + a carteira já restrita pelo #1730)

| | farmer `33f59dc7` | farmer `700657a1` | master |
|---|---:|---:|---:|
| clientes na tela | 294 → **431** | 395 → **526** | 835 → 1.195 |
| delta faixa TS×SQL | 8,5% → **0,2%** | 6,6% → **0%** | 6,9% → **0,1%** |
| agenda troca | **15 de 20** | **10 de 20** | 9 de 20 |

**A paridade TS×SQL fecha** (~0%): com os dois eixos resolvidos, a tela e a autoridade da margem medem o mesmo universo.

## Duas ressalvas honestas

⚠️ **O custo subiu em relação ao que estimei** quando apresentei o eixo: **15 slots** no farmer maior, não os 9 do cenário C isolado. A razão é que o universo maior agora incide sobre a **carteira** (294 clientes) e não sobre a base inteira (835), então cada cliente novo pesa mais. A decisão foi tomada com o número de 9; o de 15 está registrado aqui e no doc.

⚠️ **"Sem custo conhecido" sobe em absoluto** (21→51, 24→44). Os clientes que entram só tinham pedido em `importado`/`separacao`/`enviado`, e nem todos têm custo apurado. É ganho de cobertura com uma cauda honesta de desconhecido — não regressão do sinal.

## NULL, de propósito

Tanto o `.not(...in...)` do PostgREST quanto o `NOT IN` do SQL descartam `status IS NULL` (em SQL, `NULL NOT IN (...)` é `NULL`). A paridade é intencional: espelhar a autoridade inclui espelhar **como ela trata o nulo**. Medido: 0 linhas com status nulo. `deleted_at IS NULL` anda junto — a denylist sozinha traria pedido apagado (0 hoje, mas o helper filtra).

## Gate estrutural + falsificação

`universoPedidos.test.ts` (TDD): a constante espelha o SQL, e o hook **não pode** reintroduzir `.in('status', ...)`. A regressão aqui é textual — alguém "restaura" a allowlist num rebase e nada quebra, só a tela volta a divergir da autoridade.

**Falsificado** reintroduzindo a allowlist: baseline 2/2 verde → **1 de 2 vermelho, e só o gate**.

⚠️ Na primeira tentativa o `trap EXIT` não sobreviveu ao SIGKILL do timeout e **a sabotagem ficou no working tree** — refeita em script auto-restaurável, com o fonte conferido limpo depois (0 ocorrências).

Gates: `typecheck 0` · `lint 0` · **suíte 6141/6141**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)