### PR TITLE
fix(migrations): a afinidade REAPLICA — o autoteste da 121000 abortou o apply em prod [money-path]

### DIFF
--- a/db/test-fu4f-fase3-afinidade-reaplica.sh
+++ b/db/test-fu4f-fase3-afinidade-reaplica.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ============================================================================================
+# Prova a migration 20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql num PG17 LOCAL.
+#
+# Por que existe: a 20260725121000 abortou em prod (23502) porque o autoteste A7 fazia INSERT
+# sem as colunas NOT NULL. Este harness prova que a reaplicação (a) roda até o fim, (b) tem
+# asserts com DENTE — cada sabotagem deixa a migration VERMELHA.
+#
+# Uso:  PGPORT_TEST=5881 bash db/test-fu4f-fase3-afinidade-reaplica.sh
+# ============================================================================================
+set -uo pipefail
+
+# macOS: sem locale fixo o postmaster morre em "became multithreaded during startup".
+export LC_ALL=C LANG=C
+
+PORT="${PGPORT_TEST:-5881}"
+PGBIN="/opt/homebrew/opt/postgresql@17/bin"
+[ -x "$PGBIN/initdb" ] || PGBIN="/usr/local/opt/postgresql@17/bin"
+[ -x "$PGBIN/initdb" ] || { echo "PG17 não encontrado"; exit 1; }
+
+TMP="$(mktemp -d)"
+DATA="$TMP/data"
+MIG="supabase/migrations/20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql"
+
+# shellcheck disable=SC2329  # invocada pelo `trap ... EXIT` abaixo (indireta, o shellcheck não vê)
+limpar() { "$PGBIN/pg_ctl" -D "$DATA" -m immediate stop >/dev/null 2>&1; rm -rf "$TMP"; }
+trap limpar EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres --no-sync >/dev/null 2>&1
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k $TMP -c listen_addresses=''" -l "$TMP/log" -w start >/dev/null 2>&1 \
+  || { echo "falha ao subir PG17 na porta $PORT"; cat "$TMP/log"; exit 1; }
+
+psql() { "$PGBIN/psql" -h "$TMP" -p "$PORT" -U postgres -d postgres -v ON_ERROR_STOP=1 "$@"; }
+
+ok=0; fail=0
+afirma() { # afirma <rotulo> <esperado: OK|FALHA> <arquivo_sql>
+  local rotulo="$1" esperado="$2" arq="$3" saida rc
+  saida="$(psql -q -f "$arq" 2>&1)"; rc=$?
+  if [ "$esperado" = "OK" ] && [ $rc -eq 0 ]; then
+    echo "  OK   [$rotulo] aplicou"; ok=$((ok+1))
+  elif [ "$esperado" = "FALHA" ] && [ $rc -ne 0 ]; then
+    echo "  OK   [$rotulo] MORDEU (a migration ficou vermelha)"; ok=$((ok+1))
+  else
+    echo "  FAIL [$rotulo] esperava $esperado, rc=$rc"
+    echo "$saida" | tail -3 | sed 's/^/       /'
+    fail=$((fail+1))
+  fi
+}
+
+# ── schema mínimo, fiel ao medido em prod por psql-ro ───────────────────────────────────────
+cat > "$TMP/schema.sql" <<'SQL'
+CREATE TABLE public.omie_products (id uuid PRIMARY KEY DEFAULT gen_random_uuid());
+
+-- 0 FKs, NOT NULL: farmer_id, customer_user_id (+ bundle_products/bundle_type COM default)
+CREATE TABLE public.farmer_bundle_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  bundle_products jsonb NOT NULL DEFAULT '[]'::jsonb,
+  bundle_type text NOT NULL DEFAULT 'association',
+  lie_bundle numeric
+);
+
+-- 2 FKs para omie_products, NOT NULL: farmer_id, customer_user_id, recommendation_type
+CREATE TABLE public.farmer_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  recommendation_type text NOT NULL
+    CHECK (recommendation_type = ANY (ARRAY['cross_sell'::text,'up_sell'::text])),
+  product_id uuid REFERENCES public.omie_products(id),
+  current_product_id uuid REFERENCES public.omie_products(id),
+  lie numeric
+);
+SQL
+
+echo "── baseline: a migration corrigida aplica ──"
+psql -q -f "$TMP/schema.sql" >/dev/null 2>&1 || { echo "schema falhou"; exit 1; }
+afirma "B1 migration corrigida" OK "$MIG"
+
+echo "── idempotência: rodar de novo não quebra ──"
+afirma "B2 re-apply" OK "$MIG"
+
+echo "── as colunas existem, numeric, SEM default ──"
+n="$(psql -tAc "SELECT count(*) FROM information_schema.columns WHERE table_schema='public' AND column_name IN ('affinity_score','affinity_bundle') AND data_type='numeric' AND column_default IS NULL")"
+if [ "$n" = "2" ]; then echo "  OK   [B3 2 colunas numeric sem default] (=2)"; ok=$((ok+1)); else echo "  FAIL [B3] veio $n"; fail=$((fail+1)); fi
+
+echo "── NaN e Infinity são REALMENTE recusados (o que o CHECK promete) ──"
+for v in NaN Infinity; do
+  if psql -q -c "INSERT INTO public.farmer_bundle_recommendations (farmer_id,customer_user_id,affinity_bundle) VALUES (gen_random_uuid(),gen_random_uuid(),'$v'::numeric)" >/dev/null 2>&1; then
+    echo "  FAIL [B4-$v aceito pelo CHECK]"; fail=$((fail+1))
+  else
+    echo "  OK   [B4-$v recusado]"; ok=$((ok+1))
+  fi
+done
+
+echo "── REGRESSÃO: o bug original (INSERT sem as NOT NULL) dá 23502, não 23514 ──"
+err="$(psql -q -c "INSERT INTO public.farmer_bundle_recommendations (bundle_products,affinity_bundle) VALUES ('[]'::jsonb,'NaN'::numeric)" 2>&1 | command grep -oE '23502|null value in column' | head -1)"
+if [ -n "$err" ]; then
+  echo "  OK   [B5 forma antiga do A7 morre em not_null_violation] (a causa do abort em prod)"; ok=$((ok+1))
+else
+  echo "  FAIL [B5] a forma antiga NÃO deu 23502 — o diagnóstico do abort estaria errado"; fail=$((fail+1))
+fi
+
+# ── FALSIFICAÇÃO: cada assert tem de MORDER ─────────────────────────────────────────────────
+echo "── S: falsificação (sabotar e exigir VERMELHO) ──"
+
+# S1: CHECK frouxo (só x > 0) — NaN > 0 é TRUE em numeric, então o CHECK "óbvio" deixa passar.
+psql -q -f "$TMP/schema.sql" >/dev/null 2>&1
+psql -q -c "DROP TABLE IF EXISTS public.farmer_recommendations, public.farmer_bundle_recommendations, public.omie_products CASCADE" >/dev/null 2>&1
+psql -q -f "$TMP/schema.sql" >/dev/null 2>&1
+sed "s/AND affinity_bundle < 'Infinity'::numeric//; s/affinity_bundle <> 'NaN'::numeric/affinity_bundle > -1/" "$MIG" > "$TMP/s1.sql"
+afirma "S1 CHECK frouxo aceita NaN → A7 tem de cair" FALHA "$TMP/s1.sql"
+
+# S2: reintroduzir o bug original no A7 — o 23502 volta a abortar a migration.
+psql -q -c "DROP TABLE IF EXISTS public.farmer_recommendations, public.farmer_bundle_recommendations, public.omie_products CASCADE" >/dev/null 2>&1
+psql -q -f "$TMP/schema.sql" >/dev/null 2>&1
+perl -0pe "s/\(farmer_id, customer_user_id, bundle_products, affinity_bundle\)\n    VALUES \(gen_random_uuid\(\), gen_random_uuid\(\), '\[\]'::jsonb, 'NaN'::numeric\)/(bundle_products, affinity_bundle)\n    VALUES ('[]'::jsonb, 'NaN'::numeric)/" "$MIG" > "$TMP/s2.sql"
+if ! diff -q "$MIG" "$TMP/s2.sql" >/dev/null; then
+  afirma "S2 bug original de volta → aborta (23502)" FALHA "$TMP/s2.sql"
+else
+  echo "  FAIL [S2] a sabotagem NÃO foi aplicada — o verde não provaria nada"; fail=$((fail+1))
+fi
+
+# S3: POR QUE product_id fica fora do A8. Sozinho, um uuid sintético não derruba nada — o CHECK é
+# avaliado durante o INSERT e a FK dispara como constraint trigger DEPOIS, então o check_violation
+# morde primeiro e o handler o captura (medido; eu supus o contrário antes de testar). O risco real
+# aparece COMBINADO: com o CHECK afrouxado, a FK passa a disparar e derruba a migration por
+# foreign_key_violation — mascarando o defeito que o A8 existe para gritar.
+psql -q -c "DROP TABLE IF EXISTS public.farmer_recommendations, public.farmer_bundle_recommendations, public.omie_products CASCADE" >/dev/null 2>&1
+psql -q -f "$TMP/schema.sql" >/dev/null 2>&1
+perl -0pe "s/\(farmer_id, customer_user_id, recommendation_type, affinity_score\)\n    VALUES \(gen_random_uuid\(\), gen_random_uuid\(\), 'cross_sell', 'NaN'::numeric\)/(farmer_id, customer_user_id, recommendation_type, product_id, affinity_score)\n    VALUES (gen_random_uuid(), gen_random_uuid(), 'cross_sell', gen_random_uuid(), 'NaN'::numeric)/" "$MIG" \
+  | sed "s/AND affinity_score < 'Infinity'::numeric//; s/affinity_score <> 'NaN'::numeric/affinity_score > -1/" > "$TMP/s3.sql"
+if diff -q "$MIG" "$TMP/s3.sql" >/dev/null; then
+  echo "  FAIL [S3] a sabotagem NÃO foi aplicada — o resultado não provaria nada"; fail=$((fail+1))
+else
+  saida="$(psql -q -f "$TMP/s3.sql" 2>&1)"
+  if echo "$saida" | command grep -q "A8 FALHOU"; then
+    echo "  FAIL [S3] caiu por A8 — a FK não mascarou, a justificativa de omitir cai"; fail=$((fail+1))
+  elif echo "$saida" | command grep -qE "23503|foreign key|chave estrangeira"; then
+    echo "  OK   [S3 CHECK frouxo + product_id → FK MASCARA o defeito (23503, não 'A8 FALHOU')]"; ok=$((ok+1))
+  else
+    echo "  FAIL [S3] desfecho inesperado"; echo "$saida" | tail -3 | sed 's/^/       /'; fail=$((fail+1))
+  fi
+fi
+
+echo "──────────────────────────────"
+echo "RESULTADO: $ok ok / $fail fail"
+if [ "$fail" -eq 0 ]; then echo "HARNESS VERDE"; exit 0; else echo "HARNESS VERMELHO"; exit 1; fi

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **468** custom migrations totais
+- **469** custom migrations totais
 - **1593** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 480
@@ -3913,6 +3913,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.reposicao_marco_pre_omie` | — |
 | `function` | `public.reposicao__po_inexistente_antes_guard` | — |
 | `trigger` | `public.trg_po_inexistente_antes_de_guard` | `pedido_compra_sugerido` |
+
+### `20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 468
+-- Total de custom migrations: 469
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -509,7 +509,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260813225057', 'fu4f_fase3_comment_honesto_margem_faixa', '20260813225057_fu4f_fase3_comment_honesto_margem_faixa.sql'),
   ('20260813234112', 'carteira_margem_faixa_motivo_gate_custo', '20260813234112_carteira_margem_faixa_motivo_gate_custo.sql'),
   ('20260814000125', 'reposicao_pos_frescor_marcador', '20260814000125_reposicao_pos_frescor_marcador.sql'),
-  ('20260814022626', 'reposicao_po_inexistente_antes_de', '20260814022626_reposicao_po_inexistente_antes_de.sql')
+  ('20260814022626', 'reposicao_po_inexistente_antes_de', '20260814022626_reposicao_po_inexistente_antes_de.sql'),
+  ('20260814160441', 'fu4f_fase3_afinidade_colunas_reaplica', '20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),

--- a/supabase/migrations/20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql
+++ b/supabase/migrations/20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql
@@ -1,0 +1,182 @@
+-- ============================================================================================
+-- FU4-F fase 3 — REAPLICA as colunas de afinidade que a 20260725121000 não conseguiu criar.
+--
+-- POR QUE EXISTE (não é duplicata):
+-- A 20260725121000 abortou no primeiro apply em prod (2026-08-14, SQL Editor) com
+--   ERROR: 23502: null value in column "farmer_id" ... violates not-null constraint
+-- O autoteste A7 dela prova, EXECUTANDO, que o CHECK de finitude recusa NaN — mas o INSERT de
+-- prova omitia `farmer_id` e `customer_user_id`, que são NOT NULL sem default. O INSERT então
+-- morria em not_null_violation (23502) ANTES de alcançar o CHECK, e o handler só capturava
+-- check_violation (23514) — o 23502 escapou e derrubou a transação inteira. Conferido por
+-- psql-ro logo depois: 0 de 2 colunas criadas, rollback limpo, sem estado parcial.
+--
+-- Migration committed é imutável (o snapshot é fonte de DR e o apply é manual), então a correção
+-- entra como migration NOVA em vez de edição da anterior.
+--
+-- Tudo aqui é idempotente: se a 20260725121000 for reaplicada um dia (corrigida) ou se esta rodar
+-- duas vezes, nada quebra e nada é duplicado.
+--
+-- Colar no SQL Editor do Lovable (Lovable não aplica migrations de nome custom automaticamente).
+-- ============================================================================================
+
+BEGIN;
+
+-- ─────────────────────────────────────────────────
+-- 1. As colunas. `numeric` (não `numeric(p,s)`): o score é uma razão sem escala fixa, e um typmod
+--    apertado arredondaria pontuações vizinhas para o mesmo valor — empate fabricado no ranking.
+--    Sem NOT NULL/DEFAULT: linha antiga tem afinidade DESCONHECIDA, e um default constante seria
+--    "rótulo com DEFAULT constante não é fato" (a armadilha do gross_margin_pct, #1498).
+-- ─────────────────────────────────────────────────
+ALTER TABLE public.farmer_recommendations
+  ADD COLUMN IF NOT EXISTS affinity_score numeric;
+
+ALTER TABLE public.farmer_bundle_recommendations
+  ADD COLUMN IF NOT EXISTS affinity_bundle numeric;
+
+-- ─────────────────────────────────────────────────
+-- 1b. FINITUDE. `numeric` sem typmod aceita 'NaN' e 'Infinity', e em Postgres NaN é o MAIOR valor
+--     numeric — num `ORDER BY affinity DESC` ele lidera SEMPRE. Uma linha envenenada viraria o
+--     topo permanente da oferta, e o guard "óbvio" não pega: ('NaN' > 0) é TRUE e
+--     ('NaN' > 'Infinity') é TRUE, então `CHECK (x > 0)` aceita NaN e `CHECK (x > 0 AND x <> 'NaN')`
+--     aceita Infinity. Fecham-se os TRÊS lados. Nulável de propósito: NULL é "não medida".
+-- ─────────────────────────────────────────────────
+DO $chk$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_recommendations_affinity_score_finita') THEN
+    ALTER TABLE public.farmer_recommendations
+      ADD CONSTRAINT farmer_recommendations_affinity_score_finita
+      CHECK (affinity_score IS NULL
+             OR (affinity_score <> 'NaN'::numeric
+                 AND affinity_score < 'Infinity'::numeric
+                 AND affinity_score >= 0));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_bundle_recommendations_affinity_bundle_finita') THEN
+    ALTER TABLE public.farmer_bundle_recommendations
+      ADD CONSTRAINT farmer_bundle_recommendations_affinity_bundle_finita
+      CHECK (affinity_bundle IS NULL
+             OR (affinity_bundle <> 'NaN'::numeric
+                 AND affinity_bundle < 'Infinity'::numeric
+                 AND affinity_bundle >= 0));
+  END IF;
+END
+$chk$;
+
+COMMENT ON COLUMN public.farmer_recommendations.affinity_score IS
+  'FU4-F fase 3: score de AFINIDADE do cross/up-sell (adimensional, ~0,009). NAO e dinheiro e NAO deriva de custo — substitui o uso de `lie` como chave de ranking. Nunca formatar como R$.';
+
+COMMENT ON COLUMN public.farmer_bundle_recommendations.affinity_bundle IS
+  'FU4-F fase 3: score de AFINIDADE do bundle (adimensional). NAO e dinheiro e NAO deriva de custo — substitui o uso de `lie_bundle` como chave de ranking. Nunca formatar como R$.';
+
+-- ─────────────────────────────────────────────────
+-- 2. ASSERTS DE APLICACAO — dentro da transacao: qualquer um falha, tudo volta.
+--    Leem CATALOGO; a única exceção é o A7, que precisa provar EXECUTANDO.
+-- ─────────────────────────────────────────────────
+DO $post$
+DECLARE
+  v_tipo text;
+  v_n    int;
+BEGIN
+  SELECT data_type INTO v_tipo FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='farmer_recommendations' AND column_name='affinity_score';
+  IF v_tipo IS NULL THEN
+    RAISE EXCEPTION 'A1 FALHOU: farmer_recommendations.affinity_score nao existe apos o ALTER';
+  END IF;
+  IF v_tipo <> 'numeric' THEN
+    RAISE EXCEPTION 'A2 FALHOU: farmer_recommendations.affinity_score e % (esperado numeric)', v_tipo;
+  END IF;
+
+  SELECT data_type INTO v_tipo FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle';
+  IF v_tipo IS NULL THEN
+    RAISE EXCEPTION 'A3 FALHOU: farmer_bundle_recommendations.affinity_bundle nao existe apos o ALTER';
+  END IF;
+  IF v_tipo <> 'numeric' THEN
+    RAISE EXCEPTION 'A4 FALHOU: farmer_bundle_recommendations.affinity_bundle e % (esperado numeric)', v_tipo;
+  END IF;
+
+  -- A coluna NAO pode nascer com default: default constante viraria "afinidade 0 medida" para
+  -- as linhas historicas.
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public'
+      AND ((table_name='farmer_recommendations' AND column_name='affinity_score')
+        OR (table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle'))
+      AND column_default IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'A5 FALHOU: coluna de afinidade nasceu com DEFAULT — linha historica passaria a afirmar afinidade medida';
+  END IF;
+
+  -- A6: os CHECKs de finitude existem E VALIDAM (constraint NOT VALID passaria despercebida,
+  -- valendo só para escrita nova com o passivo invisível).
+  SELECT count(*) INTO v_n FROM pg_constraint
+  WHERE conname IN ('farmer_recommendations_affinity_score_finita',
+                    'farmer_bundle_recommendations_affinity_bundle_finita')
+    AND contype = 'c' AND convalidated;
+  IF v_n <> 2 THEN
+    RAISE EXCEPTION 'A6 FALHOU: esperava 2 CHECKs de finitude VALIDADOS, encontrei %', v_n;
+  END IF;
+
+  -- A7: o CHECK precisa REALMENTE recusar NaN. Provar EXECUTANDO — `NaN > 0` e `NaN > 'Infinity'`
+  -- sao TRUE em numeric, entao um CHECK mal escrito se le como protecao e deixa passar.
+  --
+  -- ⚠️ AQUI ESTAVA O BUG QUE ABORTOU A 20260725121000. As colunas NOT NULL sem default
+  -- (farmer_id, customer_user_id) entram EXPLICITAMENTE: sem elas o INSERT morre em
+  -- not_null_violation (23502) ANTES de alcançar o CHECK e, como o handler abaixo captura apenas
+  -- check_violation, o 23502 escapa e derruba a migration inteira.
+  --
+  -- Os uuid sao sinteticos e a tabela nao tem FK alguma (conferido por psql-ro em prod), entao nao
+  -- ha linha real a referenciar. A linha nunca chega a existir: o CHECK a recusa, que e o ponto.
+  -- Se um dia surgir OUTRA coluna NOT NULL, este assert volta a falhar ALTO — que e o correto.
+  -- Capturar `WHEN OTHERS` para "consertar" isso transformaria a prova em teatro: passaria a
+  -- engolir justamente o erro que revelou o defeito.
+  BEGIN
+    INSERT INTO public.farmer_bundle_recommendations
+      (farmer_id, customer_user_id, bundle_products, affinity_bundle)
+    VALUES (gen_random_uuid(), gen_random_uuid(), '[]'::jsonb, 'NaN'::numeric);
+    RAISE EXCEPTION 'A7 FALHOU: o CHECK aceitou affinity_bundle = NaN (lideraria todo ORDER BY DESC)';
+  EXCEPTION
+    WHEN check_violation THEN NULL;  -- 23514: exatamente o esperado
+  END;
+
+  -- A8: o mesmo para farmer_recommendations — a 20260725121000 so provava o lado do bundle, e as
+  -- duas constraints sao independentes (uma pode estar certa e a outra nao).
+  --
+  -- Esta tabela NAO e simetrica a de bundle e o INSERT tem de respeitar isso (medido por psql-ro):
+  --   · NOT NULL sem default: farmer_id, customer_user_id, recommendation_type (3, nao 2);
+  --   · recommendation_type tem CHECK ANY(ARRAY['cross_sell','up_sell']) — texto arbitrario
+  --     dispararia check_violation pelo motivo ERRADO e o assert passaria por acidente;
+  --   · 2 FKs para omie_products(id): product_id e current_product_id. Ambas ficam de FORA do
+  --     INSERT de proposito — sao NULLABLE, e NULL nao e checado por FK.
+  --
+  -- Sobre as FKs, o registro honesto (medido no PG17 do harness, porque eu supus errado antes de
+  -- testar): preenche-las com uuid sintetico NAO derrubaria este bloco hoje. CHECK e avaliado
+  -- durante o INSERT e FK dispara como constraint trigger DEPOIS, entao o check_violation morde
+  -- primeiro e o handler o captura — a FK nunca chega a ser alcancada. Omiti-las nao e, portanto,
+  -- correcao de um erro atual; e nao DEPENDER dessa ordem: no dia em que o CHECK for afrouxado
+  -- (exatamente o que o assert existe para detectar), a FK passaria a disparar 23503 e derrubaria
+  -- a migration pelo motivo errado, escondendo o defeito real atras de um erro de referencia.
+  BEGIN
+    INSERT INTO public.farmer_recommendations
+      (farmer_id, customer_user_id, recommendation_type, affinity_score)
+    VALUES (gen_random_uuid(), gen_random_uuid(), 'cross_sell', 'NaN'::numeric);
+    RAISE EXCEPTION 'A8 FALHOU: o CHECK aceitou affinity_score = NaN';
+  EXCEPTION
+    WHEN check_violation THEN NULL;  -- 23514: esperado
+  END;
+
+  RAISE NOTICE 'FU4-F fase 3: affinity_score/affinity_bundle criadas (numeric, sem default, finitas)';
+END
+$post$;
+
+COMMIT;
+
+-- ────────────────────────────────────────────────────────────────────────────────────────────
+-- VALIDACAO POS-APPLY (read-only; esperado: 2 linhas, ambas numeric e sem default)
+--
+--   SELECT table_name, column_name, data_type, column_default, is_nullable
+--   FROM information_schema.columns
+--   WHERE table_schema='public'
+--     AND ((table_name='farmer_recommendations'        AND column_name='affinity_score')
+--       OR (table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle'));
+-- ────────────────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## O que aconteceu

A migration `20260725121000_..._afinidade_colunas.sql` **abortou no primeiro apply em produção**
(2026-08-14, SQL Editor):

```
ERROR: 23502: null value in column "farmer_id" of relation "farmer_bundle_recommendations"
violates not-null constraint
```

O autoteste **A7** dela prova, executando, que o CHECK de finitude recusa `NaN` — mas o INSERT de
prova omitia `farmer_id` e `customer_user_id`, que são `NOT NULL` sem default. O INSERT morria em
`not_null_violation` (23502) **antes** de alcançar o CHECK, e o handler capturava apenas
`check_violation` (23514) — o 23502 escapou e derrubou a transação inteira.

Conferido por `psql-ro` logo depois: **0 de 2 colunas criadas**, rollback limpo, sem estado parcial.

Isso bloqueia o Publish do front: `useBundleEngine` grava `affinity_bundle` e `useCrossSellEngine`
lê `affinity_score` — o código já está na main (#1520).

## Por que migration NOVA e não edição

Migration committed é imutável (o snapshot é fonte de DR e o apply é manual) — editar diverge
repo×banco e não re-aplica. O hook do repo bloqueia a edição, corretamente.

## O que muda

Reaplica as colunas + constraints (tudo idempotente: `ADD COLUMN IF NOT EXISTS`, guards em
`pg_constraint`), com o A7 corrigido e um **A8 novo** cobrindo `farmer_recommendations` — a
original só provava o lado do bundle, e as duas constraints são independentes.

O A8 respeita as assimetrias da tabela, medidas em prod (não supostas): 3 colunas `NOT NULL` sem
default (não 2), `recommendation_type` com `CHECK ANY(ARRAY['cross_sell','up_sell'])`, e 2 FKs para
`omie_products`.

### Uma correção ao meu próprio raciocínio, que a falsificação pegou

Eu havia escrito no comentário que preencher `product_id` com uuid sintético daria
`foreign_key_violation`. **Está errado, e o harness provou**: `CHECK` é avaliado durante o INSERT e
FK dispara como constraint trigger **depois**, então o `check_violation` morde primeiro e o handler
o captura — a FK nunca é alcançada. Omitir `product_id` segue certo, mas por outro motivo: não
depender dessa ordem. No dia em que o CHECK for afrouxado (o que o assert existe para detectar), a
FK passaria a disparar e derrubaria a migration **pelo motivo errado**, mascarando o defeito real.
O comentário foi reescrito com o fato medido, e o S3 do harness prova exatamente esse mascaramento.

## Prova

`db/test-fu4f-fase3-afinidade-reaplica.sh` — PG17 local, schema fiel ao medido em prod:

| | |
|---|---|
| B1 | a migration corrigida aplica |
| B2 | idempotência — re-apply não quebra |
| B3 | 2 colunas `numeric`, sem default |
| B4 | `NaN` e `Infinity` realmente recusados (os dois lados) |
| B5 | **regressão**: a forma antiga do A7 morre em `not_null_violation` — confirma o diagnóstico do abort |
| S1 | CHECK frouxo aceita `NaN` → A7 cai ✅ mordeu |
| S2 | bug original de volta → aborta em 23502 ✅ mordeu |
| S3 | CHECK frouxo + `product_id` → FK **mascara** o defeito (23503, não "A8 FALHOU") ✅ mordeu |

**9 ok / 0 fail.** `shellcheck` exit 0. `bun run audit:migrations` regenerado e commitado.

## ⚠️ Migration manual necessária

Lovable não aplica migrations de nome custom — mergear NÃO toca o banco. Precisa ser colada no
SQL Editor. Validação pós-apply (read-only, lê catálogo):

```sql
SELECT table_name, column_name, data_type, column_default, is_nullable
FROM information_schema.columns
WHERE table_schema='public'
  AND ((table_name='farmer_recommendations'        AND column_name='affinity_score')
    OR (table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle'));
```

Esperado: 2 linhas, ambas `numeric`, `column_default` nulo, `is_nullable = YES`.
