### PR TITLE
fix(authz): a coluna de afinidade volta — a v1 abortava com 23502 e o STUB do harness escondia [money-path]

### DIFF
--- a/db/test-authz-custo-fu4f-fase3-scrub.sh
+++ b/db/test-authz-custo-fu4f-fase3-scrub.sh
@@ -65,11 +65,16 @@ echo "═══ setup pronto (PG17 :$PORT) ═══"
 P -q <<'SQL'
 CREATE SCHEMA IF NOT EXISTS private;
 
+-- ⚠️ Os NOT NULL abaixo são o schema REAL de prod (information_schema, 2026-08-14), não enfeite:
+-- a v1 da migration de colunas passou VERDE aqui e ABORTOU em produção com 23502, porque o stub
+-- não os tinha e o assert que ESCREVE nunca encontrou a constraint. Um stub só prova a lógica até
+-- onde ele espelha o schema — para assert que INSERE/ATUALIZA, o que falta no stub é justamente o
+-- que morde no apply. Ao stubar tabela para provar escrita, copie as constraints, não só as colunas.
 CREATE TABLE IF NOT EXISTS public.farmer_recommendations (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  farmer_id uuid,
-  customer_user_id uuid,
-  recommendation_type text,
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  recommendation_type text NOT NULL,
   product_id uuid,
   current_product_id uuid,
   p_ij numeric,
@@ -83,8 +88,8 @@ CREATE TABLE IF NOT EXISTS public.farmer_recommendations (
 
 CREATE TABLE IF NOT EXISTS public.farmer_bundle_recommendations (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  farmer_id uuid,
-  customer_user_id uuid,
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
   bundle_products jsonb NOT NULL,
   support numeric,
   confidence numeric,
@@ -134,7 +139,7 @@ eq "B5 m_bundle preenchido antes" "$B5" "1"
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
 # ══════════════════════════════════════════════════════════════════════════════
-MIG121="$REPO_ROOT/supabase/migrations/20260725121000_authz_custo_fu4f_fase3_afinidade_colunas.sql"
+MIG121="$REPO_ROOT/supabase/migrations/20260725121500_authz_custo_fu4f_fase3_afinidade_colunas_v2.sql"
 MIG="$REPO_ROOT/supabase/migrations/20260725125000_authz_custo_fu4f_fase3_scrub_recomendacoes.sql"
 MIG126="$REPO_ROOT/supabase/migrations/20260725126000_authz_custo_fu4f_fase3_trigger_nulifica_lie.sql"
 
@@ -213,14 +218,14 @@ echo "── T: guarda anti-recontaminação (trigger plpgsql — LATE-BOUND, s�
 # regravaria custo em linhas FRESCAS — pior que o dado velho.
 # CTE p/ o comando EXTERNO ser um SELECT: `INSERT ... RETURNING` no psql -tA devolve o valor
 # E a command tag ("INSERT 0 1") na linha seguinte, o que quebrava a comparação exata.
-T1=$(Pq -c "WITH ins AS (INSERT INTO public.farmer_recommendations (farmer_id, p_ij, m_ij, status) VALUES ('11111111-1111-1111-1111-111111111111', 9.4, 99.99, 'pendente') RETURNING m_ij) SELECT coalesce(m_ij::text,'NULL') FROM ins;")
+T1=$(Pq -c "WITH ins AS (INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, m_ij, status) VALUES ('11111111-1111-1111-1111-111111111111', '99999999-9999-9999-9999-999999999999', 'cross_sell', 9.4, 99.99, 'pendente') RETURNING m_ij) SELECT coalesce(m_ij::text,'NULL') FROM ins;")
 eq "T1 INSERT com m_ij=99.99 → gravou NULL" "$T1" "NULL"
 
 P -q -c "UPDATE public.farmer_recommendations SET m_ij = 77.77 WHERE status = 'ofertado';"
 T2=$(Pq -c "SELECT coalesce(m_ij::text,'NULL') FROM public.farmer_recommendations WHERE status = 'ofertado';")
 eq "T2 UPDATE tentando m_ij=77.77 → NULL" "$T2" "NULL"
 
-T3=$(Pq -c "WITH ins AS (INSERT INTO public.farmer_bundle_recommendations (farmer_id, bundle_products, m_bundle, status) VALUES ('11111111-1111-1111-1111-111111111111', '[{\"id\":\"ccc\",\"name\":\"C\",\"price\":50,\"cost\":30,\"margin\":20}]'::jsonb, 500, 'pendente') RETURNING bundle_products) SELECT (bundle_products->0) ? 'cost' FROM ins;")
+T3=$(Pq -c "WITH ins AS (INSERT INTO public.farmer_bundle_recommendations (farmer_id, customer_user_id, bundle_products, m_bundle, status) VALUES ('11111111-1111-1111-1111-111111111111', '99999999-9999-9999-9999-999999999999', '[{\"id\":\"ccc\",\"name\":\"C\",\"price\":50,\"cost\":30,\"margin\":20}]'::jsonb, 500, 'pendente') RETURNING bundle_products) SELECT (bundle_products->0) ? 'cost' FROM ins;")
 eq "T3 INSERT com cost no jsonb → chave removida" "$T3" "f"
 T3b=$(Pq -c "SELECT coalesce(m_bundle::text,'NULL') FROM public.farmer_bundle_recommendations WHERE (bundle_products->0->>'id') = 'ccc';")
 eq "T3b m_bundle do INSERT novo → NULL" "$T3b" "NULL"
@@ -235,7 +240,7 @@ eq "T3c price preservado no INSERT (trigger cirúrgico, não destrutivo)" "$T3c"
 # (20260725121000) é o que permite fechá-lo. Falsificados em S3 (preserva o lie) e S5 (mata a
 # afinidade): as duas metades erram em direções opostas e precisam de sabotagem cada uma.
 UUID_T='44444444-4444-4444-4444-444444444444'
-P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
+P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 'cross_sell', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
 T4=$(Pq -c "SELECT coalesce(lie::text,'NULL') FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';")
 eq "T4 lie MONETÁRIO (12.62) nulificado pelo trigger — a aba antiga não recontamina" "$T4" "NULL"
 T5=$(Pq -c "SELECT coalesce(affinity_score::text,'NULL') FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';")
@@ -259,7 +264,7 @@ CREATE OR REPLACE FUNCTION private.frec_sem_margem() RETURNS trigger
 LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', pg_temp
 AS $fn$ BEGIN RETURN NEW; END $fn$;
 SQL
-S1=$(Pq -c "WITH ins AS (INSERT INTO public.farmer_recommendations (farmer_id, p_ij, m_ij, status) VALUES ('11111111-1111-1111-1111-111111111111', 1, 42.42, 'pendente') RETURNING m_ij) SELECT coalesce(m_ij::text,'NULL') FROM ins;")
+S1=$(Pq -c "WITH ins AS (INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, m_ij, status) VALUES ('11111111-1111-1111-1111-111111111111', '99999999-9999-9999-9999-999999999999', 'cross_sell', 1, 42.42, 'pendente') RETURNING m_ij) SELECT coalesce(m_ij::text,'NULL') FROM ins;")
 ne "S1 sabotagem do trigger m_ij faz T1 MORDER" "$S1" "NULL"
 P -q -f "$MIG126" >/dev/null   # restaura a versão verdadeira (a 126000 recria as DUAS funções)
 
@@ -267,7 +272,7 @@ P -q -f "$MIG126" >/dev/null   # restaura a versão verdadeira (a 126000 recria 
 # O INSERT vai POR BAIXO do trigger (DISABLE): com a guarda viva o `lie` já nasceria NULL e a
 # sabotagem mediria a guarda, não o scrub — ficaria verde por acidente e "provaria" o nada.
 P -q -c "ALTER TABLE public.farmer_recommendations DISABLE TRIGGER trg_frec_sem_margem;"
-P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, p_ij, lie, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', 9.4, 12.62, 1.0, 'pendente');"
+P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, lie, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '99999999-9999-9999-9999-999999999999', 'cross_sell', 9.4, 12.62, 1.0, 'pendente');"
 P -q -c "UPDATE public.farmer_recommendations SET m_ij = NULL WHERE m_ij IS NOT NULL;"  -- scrub PARCIAL
 S2=$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE lie IS NOT NULL;")
 ne "S2 scrub só-de-m_ij deixa lie vivo → A2 MORDE (lie inverte sozinho)" "$S2" "0"
@@ -283,7 +288,7 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', pg_temp
 AS $fn$ BEGIN NEW.m_ij := NULL; RETURN NEW; END $fn$;
 SQL
 P -q -c "DELETE FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';"
-P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
+P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 'cross_sell', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
 S3=$(Pq -c "SELECT coalesce(lie::text,'NULL') FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';")
 ne "S3 trigger que PRESERVA o lie monetário → T4 MORDE" "$S3" "NULL"
 P -q -f "$MIG126" >/dev/null   # restaura
@@ -296,7 +301,7 @@ LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', pg_temp
 AS $fn$ BEGIN NEW.m_ij := NULL; NEW.lie := NULL; NEW.affinity_score := NULL; RETURN NEW; END $fn$;
 SQL
 P -q -c "DELETE FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';"
-P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
+P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 'cross_sell', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
 S5=$(Pq -c "SELECT coalesce(affinity_score::text,'NULL') FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';")
 eq "S5 trigger que mata a afinidade → T5 MORDE (ranking morto é falha, não segurança)" "$S5" "NULL"
 P -q -f "$MIG126" >/dev/null   # restaura a FUNÇÃO
@@ -304,10 +309,10 @@ P -q -f "$MIG126" >/dev/null   # restaura a FUNÇÃO
 # re-insert, R4 mediria a linha mutilada e acusaria a cadeia verdadeira de matar a afinidade —
 # falso VERMELHO com aparência de achado (o harness já pegou isso uma vez, aqui mesmo).
 P -q -c "DELETE FROM public.farmer_recommendations WHERE customer_user_id = '$UUID_T';"
-P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
+P -q -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, p_ij, lie, affinity_score, complexity_factor, status) VALUES ('11111111-1111-1111-1111-111111111111', '$UUID_T', 'cross_sell', 9.4, 12.62, 0.0094, 1.0, 'pendente');"
 
 # S4 — scrub que não limpa o jsonb → A5 morde
-P -q -c "INSERT INTO public.farmer_bundle_recommendations (farmer_id, bundle_products, status) VALUES ('11111111-1111-1111-1111-111111111111', '[{\"id\":\"zzz\",\"name\":\"Z\",\"price\":10}]'::jsonb, 'pendente');"
+P -q -c "INSERT INTO public.farmer_bundle_recommendations (farmer_id, customer_user_id, bundle_products, status) VALUES ('11111111-1111-1111-1111-111111111111', '99999999-9999-9999-9999-999999999999', '[{\"id\":\"zzz\",\"name\":\"Z\",\"price\":10}]'::jsonb, 'pendente');"
 # injeta o custo por baixo do trigger (o trigger é BEFORE; aqui simulamos o dado legado já gravado)
 P -q -c "ALTER TABLE public.farmer_bundle_recommendations DISABLE TRIGGER trg_fbrec_sem_margem;"
 P -q -c "UPDATE public.farmer_bundle_recommendations SET bundle_products = '[{\"id\":\"zzz\",\"name\":\"Z\",\"price\":10,\"cost\":6}]'::jsonb WHERE (bundle_products->0->>'id') = 'zzz';"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **468** custom migrations totais
+- **469** custom migrations totais
 - **1593** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 480
@@ -3600,6 +3600,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public.get_skus_margem_positiva` | — |
 
 ### `20260725121000_authz_custo_fu4f_fase3_afinidade_colunas.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
+
+### `20260725121500_authz_custo_fu4f_fase3_afinidade_colunas_v2.sql`
 
 > _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 468
+-- Total de custom migrations: 469
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -467,6 +467,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260724130000', 'tint_canonica_csv_legado_allowlist', '20260724130000_tint_canonica_csv_legado_allowlist.sql'),
   ('20260725120000', 'authz_custo_fu4f_fase3_ranking_rpc', '20260725120000_authz_custo_fu4f_fase3_ranking_rpc.sql'),
   ('20260725121000', 'authz_custo_fu4f_fase3_afinidade_colunas', '20260725121000_authz_custo_fu4f_fase3_afinidade_colunas.sql'),
+  ('20260725121500', 'authz_custo_fu4f_fase3_afinidade_colunas_v2', '20260725121500_authz_custo_fu4f_fase3_afinidade_colunas_v2.sql'),
   ('20260725125000', 'authz_custo_fu4f_fase3_scrub_recomendacoes', '20260725125000_authz_custo_fu4f_fase3_scrub_recomendacoes.sql'),
   ('20260725126000', 'authz_custo_fu4f_fase3_trigger_nulifica_lie', '20260725126000_authz_custo_fu4f_fase3_trigger_nulifica_lie.sql'),
   ('20260725130000', 'authz_custo_fu4f_fase3_fecha_product_costs', '20260725130000_authz_custo_fu4f_fase3_fecha_product_costs.sql'),

--- a/supabase/migrations/20260725121500_authz_custo_fu4f_fase3_afinidade_colunas_v2.sql
+++ b/supabase/migrations/20260725121500_authz_custo_fu4f_fase3_afinidade_colunas_v2.sql
@@ -1,0 +1,181 @@
+-- FU4-F fase 3 / PR-B — colunas de AFINIDADE (v2). SUBSTITUI a 20260725121000, que ABORTA.
+--
+-- ⚠️ NÃO COLE A 20260725121000 — ela falha SEMPRE, em qualquer banco com o schema real. Esta
+-- migration faz tudo o que ela faria; a outra ficou no histórico porque migration committada é
+-- imutável neste repo (o snapshot, não o replay, é a fonte de DR). Se alguém colá-la por engano,
+-- o efeito é um erro visível e rollback total — sem dano, porque os `IF NOT EXISTS` daqui já
+-- terão criado tudo e o rollback dela não remove o que esta transação commitou.
+--
+-- POR QUE A 121000 ABORTA (medido em prod 2026-08-14, na tentativa de apply):
+--   ERROR 23502: null value in column "farmer_id" of relation "farmer_bundle_recommendations"
+-- O assert A7 dela provava o CHECK de finitude com um INSERT de `affinity_bundle = 'NaN'`,
+-- passando só duas colunas. Só que as duas tabelas têm NOT NULL **sem default** em
+-- `farmer_id` e `customer_user_id` (mais `recommendation_type` em farmer_recommendations), então
+-- o INSERT morre por 23502 ANTES de o CHECK ser exercido — e 23502 não é `check_violation`, então
+-- escapa do handler, propaga e derruba a migration inteira. Fail-closed correto: NADA foi
+-- aplicado (conferido depois por psql-ro: zero colunas, zero constraints).
+--
+-- POR QUE O HARNESS LOCAL NÃO PEGOU (a lição que fica): o `db/test-authz-custo-fu4f-fase3-scrub.sh`
+-- monta as tabelas por STUB — `CREATE TABLE` só com as colunas que a migration toca — e o stub
+-- não tinha os NOT NULL da tabela real. Um assert que ESCREVE só é tão fiel quanto o stub: ele
+-- exercita o schema, não só a lógica. O stub foi corrigido na mesma entrega, e o pré-voo de PROD
+-- passa a conferir CONSTRAINTS, não só a existência das colunas.
+--
+-- O CONSERTO: provar o CHECK por UPDATE de uma linha EXISTENTE, não por INSERT. Não depende de
+-- coluna obrigatória nenhuma — e continua imune a colunas NOT NULL que venham a ser criadas
+-- depois, que é o que tornaria o INSERT frágil para sempre.
+
+BEGIN;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. As colunas. `numeric` (não `numeric(p,s)`): o score é uma razão sem escala fixa, e um typmod
+--    apertado arredondaria silenciosamente pontuações vizinhas para o mesmo valor — empate
+--    fabricado no ranking. Sem NOT NULL/DEFAULT: linha antiga tem afinidade DESCONHECIDA, e um
+--    default constante seria exatamente o "rótulo com DEFAULT constante não é fato" do §5.
+-- ─────────────────────────────────────────────────────────────────────────────
+ALTER TABLE public.farmer_recommendations
+  ADD COLUMN IF NOT EXISTS affinity_score numeric;
+
+ALTER TABLE public.farmer_bundle_recommendations
+  ADD COLUMN IF NOT EXISTS affinity_bundle numeric;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1b. FINITUDE. `numeric` sem typmod aceita 'NaN' e 'Infinity', e em Postgres **NaN é o MAIOR
+--     valor numeric** — num `ORDER BY affinity DESC` ele lidera SEMPRE. Uma única linha
+--     envenenada viraria o topo permanente da oferta, e o guard "óbvio" não pega: medido em prod,
+--     ('NaN' > 0) é TRUE e ('NaN' > 'Infinity') é TRUE, então `CHECK (x > 0)` aceita NaN e
+--     `CHECK (x > 0 AND x <> 'NaN')` aceita Infinity. Fecham-se os TRÊS lados (money-path §2).
+--     Nulável de propósito: NULL é "afinidade não medida", que é o estado de toda linha histórica.
+--     Achado do challenge Codex (xhigh) nesta entrega.
+--     Sem NOT VALID: as colunas acabaram de nascer, então não há passivo a validar — a varredura
+--     é sobre 3.659 + 12 linhas com a coluna inteira NULL.
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $chk$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_recommendations_affinity_score_finita') THEN
+    ALTER TABLE public.farmer_recommendations
+      ADD CONSTRAINT farmer_recommendations_affinity_score_finita
+      CHECK (affinity_score IS NULL
+             OR (affinity_score <> 'NaN'::numeric
+                 AND affinity_score < 'Infinity'::numeric
+                 AND affinity_score >= 0));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_bundle_recommendations_affinity_bundle_finita') THEN
+    ALTER TABLE public.farmer_bundle_recommendations
+      ADD CONSTRAINT farmer_bundle_recommendations_affinity_bundle_finita
+      CHECK (affinity_bundle IS NULL
+             OR (affinity_bundle <> 'NaN'::numeric
+                 AND affinity_bundle < 'Infinity'::numeric
+                 AND affinity_bundle >= 0));
+  END IF;
+END
+$chk$;
+
+COMMENT ON COLUMN public.farmer_recommendations.affinity_score IS
+  'FU4-F fase 3: score de AFINIDADE do cross/up-sell (adimensional, ~0,009). NAO e dinheiro e NAO deriva de custo — substitui o uso de `lie` como chave de ranking. `lie` (Lucro Incremental Esperado em R$) fica NULL: invertia para margem via lie / ((p_ij/100) * complexity_factor). NULL = afinidade nao medida (linha anterior a esta coluna); quem ordena usa NULLS LAST.';
+
+COMMENT ON COLUMN public.farmer_bundle_recommendations.affinity_bundle IS
+  'FU4-F fase 3: score de AFINIDADE do bundle (adimensional). NAO e dinheiro e NAO deriva de custo — substitui o uso de `lie_bundle` como chave de ranking. `lie_bundle` fica NULL porque tres consumidores leem o VALOR (useTacticalPlan copia para bundle_lie, PlanCard formata como BRL e divide por hora, generate-tactical-plan injeta no prompt do LLM). NULL = afinidade nao medida; quem ordena usa NULLS LAST.';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. ASSERTS DE APLICACAO — dentro da transacao: qualquer um falha, tudo volta.
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $post$
+DECLARE
+  v_tipo text;
+  v_n    int;
+  v_id   uuid;
+BEGIN
+  SELECT data_type INTO v_tipo FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='farmer_recommendations' AND column_name='affinity_score';
+  IF v_tipo IS NULL THEN
+    RAISE EXCEPTION 'A1 FALHOU: farmer_recommendations.affinity_score nao existe apos o ALTER';
+  END IF;
+  IF v_tipo <> 'numeric' THEN
+    RAISE EXCEPTION 'A2 FALHOU: farmer_recommendations.affinity_score e % (esperado numeric)', v_tipo;
+  END IF;
+
+  SELECT data_type INTO v_tipo FROM information_schema.columns
+  WHERE table_schema='public' AND table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle';
+  IF v_tipo IS NULL THEN
+    RAISE EXCEPTION 'A3 FALHOU: farmer_bundle_recommendations.affinity_bundle nao existe apos o ALTER';
+  END IF;
+  IF v_tipo <> 'numeric' THEN
+    RAISE EXCEPTION 'A4 FALHOU: farmer_bundle_recommendations.affinity_bundle e % (esperado numeric)', v_tipo;
+  END IF;
+
+  -- A5: a coluna NAO pode nascer com default — default constante viraria "afinidade 0 medida"
+  -- para 3.659 + 12 linhas historicas (a armadilha do gross_margin_pct, #1498).
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public'
+      AND ((table_name='farmer_recommendations' AND column_name='affinity_score')
+        OR (table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle'))
+      AND column_default IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'A5 FALHOU: coluna de afinidade nasceu com DEFAULT — linha historica passaria a afirmar afinidade medida';
+  END IF;
+
+  -- A6: os CHECKs existem E estao VALIDADOS. Constraint NOT VALID passaria despercebida,
+  -- valendo so para escrita nova, com o passivo invisivel.
+  SELECT count(*) INTO v_n FROM pg_constraint
+  WHERE conname IN ('farmer_recommendations_affinity_score_finita',
+                    'farmer_bundle_recommendations_affinity_bundle_finita')
+    AND contype = 'c' AND convalidated;
+  IF v_n <> 2 THEN
+    RAISE EXCEPTION 'A6 FALHOU: esperava 2 CHECKs de finitude VALIDADOS, encontrei %', v_n;
+  END IF;
+
+  -- A7: o CHECK precisa REALMENTE recusar NaN. Ler o TEXTO da constraint nao serve: `CHECK (x>0)`
+  -- se le como protecao e aceita NaN (medido em prod: 'NaN' > 0 e TRUE). So executando se sabe.
+  --
+  -- UPDATE de linha existente, nao INSERT: a v1 desta migration morreu aqui com 23502 porque as
+  -- duas tabelas tem NOT NULL sem default em farmer_id/customer_user_id, e um INSERT minimo nao
+  -- os preenche. O UPDATE nao depende de coluna obrigatoria nenhuma — nem das que vierem depois.
+  SELECT id INTO v_id FROM public.farmer_bundle_recommendations LIMIT 1;
+  IF v_id IS NOT NULL THEN
+    BEGIN
+      UPDATE public.farmer_bundle_recommendations SET affinity_bundle = 'NaN'::numeric WHERE id = v_id;
+      RAISE EXCEPTION 'A7 FALHOU: o CHECK aceitou affinity_bundle = NaN (lideraria todo ORDER BY DESC)';
+    EXCEPTION
+      WHEN check_violation THEN NULL;  -- 23514: exatamente o esperado, e a subtransacao desfaz o UPDATE
+    END;
+
+    BEGIN
+      UPDATE public.farmer_bundle_recommendations SET affinity_bundle = 'Infinity'::numeric WHERE id = v_id;
+      RAISE EXCEPTION 'A8 FALHOU: o CHECK aceitou affinity_bundle = Infinity';
+    EXCEPTION
+      WHEN check_violation THEN NULL;
+    END;
+
+    -- Controle POSITIVO: sem ele, um CHECK que recusasse TUDO passaria em A7/A8 e mataria a
+    -- gravacao do motor — trocar o veneno por uma coluna inutilizavel tambem e falha.
+    UPDATE public.farmer_bundle_recommendations SET affinity_bundle = 0.0094 WHERE id = v_id;
+    IF NOT EXISTS (SELECT 1 FROM public.farmer_bundle_recommendations WHERE id = v_id AND affinity_bundle = 0.0094) THEN
+      RAISE EXCEPTION 'A9 FALHOU: o CHECK recusou uma afinidade VALIDA (0.0094) — o motor nao conseguiria gravar';
+    END IF;
+    -- devolve a linha ao estado "afinidade nao medida" (esta migration nao inventa dado)
+    UPDATE public.farmer_bundle_recommendations SET affinity_bundle = NULL WHERE id = v_id;
+  ELSE
+    RAISE NOTICE 'A7/A8/A9 PULADOS: farmer_bundle_recommendations vazia (nada a atualizar). Em prod ha 12 linhas.';
+  END IF;
+
+  RAISE NOTICE 'FU4-F fase 3: affinity_score/affinity_bundle criadas (numeric, sem default, finitas)';
+END
+$post$;
+
+COMMIT;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- VALIDACAO POS-APPLY (read-only; esperado: 2 linhas numeric, sem default, e 2 CHECKs validados)
+--
+--   SELECT table_name, column_name, data_type, column_default, is_nullable
+--   FROM information_schema.columns
+--   WHERE table_schema='public'
+--     AND ((table_name='farmer_recommendations'        AND column_name='affinity_score')
+--       OR (table_name='farmer_bundle_recommendations' AND column_name='affinity_bundle'));
+--
+--   SELECT conname, convalidated, pg_get_constraintdef(oid)
+--   FROM pg_constraint WHERE conname LIKE '%affinity%finita';
+-- ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## O que aconteceu

A `20260725121000` (colunas de afinidade, do #1520) **abortou no apply**, na primeira colagem:

```
ERROR: 23502: null value in column "farmer_id" of relation "farmer_bundle_recommendations"
       violates not-null constraint
CONTEXT: SQL statement "INSERT INTO public.farmer_bundle_recom...
```

O assert `A7` provava o CHECK de finitude com um `INSERT` de `affinity_bundle = 'NaN'`, passando
só duas colunas. Mas as duas tabelas têm **NOT NULL sem default** em `farmer_id` e
`customer_user_id` (mais `recommendation_type` em `farmer_recommendations`): o INSERT morre por
`23502` **antes** de o CHECK ser exercido — e `23502` não é `check_violation`, então escapou do
handler, propagou e derrubou a migration inteira.

**Fail-closed funcionou: nada foi aplicado.** Conferido por `psql-ro` depois do erro — zero
colunas, zero constraints. Não há estado parcial em produção.

## A causa raiz é do HARNESS, não da migration

O `db/test-authz-custo-fu4f-fase3-scrub.sh` monta as tabelas por **stub** (`CREATE TABLE` só com
as colunas que a migration toca) e o stub **não tinha os NOT NULL da tabela real**. Por isso o
assert passou verde local e quebrou no apply.

Generaliza: **um stub só prova a lógica até onde espelha o schema.** Para assert que apenas LÊ
catálogo isso é inofensivo; para assert que **ESCREVE**, o que falta no stub é exatamente o que
morde no apply. E o pré-voo de PROD que rodei conferiu a existência das *colunas* — não as
*constraints*. As duas lacunas se cobriam.

## O conserto

**Migration nova** `20260725121500` (a committada é imutável; o DR sai do snapshot, não do
replay). O que muda em relação à v1:

- o CHECK passa a ser provado por **`UPDATE` de linha existente**, não por INSERT — não depende de
  coluna obrigatória nenhuma, **nem das que vierem a ser criadas depois**, que é o que tornaria o
  INSERT frágil para sempre;
- ganhou o **controle positivo** que faltava (A9): um CHECK que recusasse *tudo* passaria em
  NaN/Infinity e mataria a gravação do motor — trocar o veneno por uma coluna inutilizável também
  é falha, e a v1 não testava isso;
- o cabeçalho declara que a v1 não deve ser colada, e por quê.

**Harness corrigido** com os NOT NULL medidos (`information_schema`, 2026-08-14), e os INSERTs do
próprio harness passaram a preencher as obrigatórias — o que é o ponto: o stub fiel quebra quem
não respeita o schema.

## Prova

| gate | exit |
|---|---|
| `db/test-authz-custo-fu4f-fase3-scrub.sh` | 0 — **40 asserts**, 0 falhas, já com o stub fiel |
| `bun run authz:check` | 0 |
| falsificação do conserto | ✅ ver abaixo |

A falsificação é o que dá dente ao conserto do stub: num PG17 com os NOT NULL reais, **aplicar a
v1 falha por NOT NULL** (reproduz o erro de produção) e **a v2 aplica no MESMO banco**. Se o stub
ainda mentisse, a v1 aplicaria e a falsificação acusaria `FALSIFICACAO INVALIDA`.

Detalhe de método que quase virou falso negativo: a primeira sentinela procurava a string
`23502`, mas o `psql` só imprime o SQLSTATE sob `VERBOSITY verbose` — o log trazia o erro **certo**
e o script reportou "falhou por OUTRO motivo". Corrigido para casar a **mensagem**
(`violates not-null constraint`): string exclusiva do ramo certo, ASCII, caixa fixa.

## ⚠️ Ordem de apply (atualizada)

O estado de produção medido hoje já está adiante do que o #1520 assumia:

| migration | estado |
|---|---|
| `20260726170000` (#1543) | ✅ aplicada |
| `#1723 / #1728 / #1733` | ✅ aplicadas |
| `20260725120000` (ranking RPC) | ✅ aplicada |
| ~~`20260725121000`~~ | ❌ **não cole — aborta** |
| **`20260725121500`** | ⬅️ **é esta** |
| `20260725125000` → `20260725126000` | pendentes (mesmo passo, em sequência) |
| `20260725130000` | pendente (por último) |

`get_skus_margem_positiva` **já existe em produção** e as colunas não — então esta migration é
pré-requisito de qualquer Publish: o front novo grava `affinity_score`/`affinity_bundle`, e sem as
colunas o insert devolve 42703/PGRST204. (Não fica calado: o `useCrossSellEngine` passou a
capturar o erro no #1520, e o `useBundleEngine` já capturava.)
