### PR TITLE
feat(authz): o eixo do gate passa a ver COMPRAS — 12 SECDEF invisíveis viram contrato medido [money-path]

### DIFF
--- a/docs/historico/sentinela-authz-controle-nao-mencao.md
+++ b/docs/historico/sentinela-authz-controle-nao-mencao.md
@@ -119,13 +119,136 @@ Registrar a função exigiu rodar o detector contra a definição real primeiro.
 
 ## 6. Follow-ups deixados
 
-1. **Ampliar o eixo de `touchesSensitive` para compras** (`fornecedor_nome`, `portal_protocolo`,
-   `pedido_compra_sugerido`, `purchase_orders_tracking`): medido — revelaria **15 SECDEF** não
-   classificadas. É entrega própria, porque classificar cada uma exige auditoria de grants em prod;
-   classificar sem medir seria fabricar. Enquanto não for feita, **RPC nova do eixo compras não é
-   coberta automaticamente** — registre à mão no manifest.
-2. **`public.reposicao_pos_marcador`** — a sessão paralela do frescor do marcador
-   (`claude/frescor-marcador-pos-candidatos`) cria essa SECDEF com o mesmo gate e a **mesma
-   pós-condição por regex**. O padrão está se propagando. Registrar no manifest quando aquele PR
-   mergear. (A recriação de `reposicao_pos_candidatos` naquela migration usa a forma idêntica de
-   gate e **passa** neste gate — conferido antes deste PR.)
+1. ~~**Ampliar o eixo de `touchesSensitive` para compras**~~ — **FEITO em 2026-08-14**, §7 abaixo.
+2. ~~**`public.reposicao_pos_marcador`**~~ — **FEITO** junto, no mesmo PR (§7.2). O PR paralelo
+   mergeou (`20260814000125`), o gate foi medido em prod e a RPC entrou no manifest.
+
+---
+
+# 7. O eixo de COMPRAS entra no contrato — e as 12 reveladas são baselinadas (2026-08-14)
+
+> Follow-up 1 do §6, fechado. A Parte B passou a exigir classificação também no eixo **comercial de
+> compras**. Isso revelou **12 SECDEF** sem classificação; cada uma foi classificada pelos **grants
+> REAIS de prod**, medidos um a um. Nenhuma regra do detector foi afrouxada.
+
+## 7.1 O que mudou, e por que a medição é a entrega
+
+`SENSITIVE_*` ([scripts/lib/authz-contract.ts](../../scripts/lib/authz-contract.ts)) ganhou 4 tokens
+— tabelas `pedido_compra_sugerido`, `purchase_orders_tracking`; colunas `fornecedor_nome`,
+`portal_protocolo`. Os 4 foram conferidos como objetos REAIS de prod antes de entrar (token morto
+seria contrato falso na direção oposta): `fornecedor_nome` existe em **25 tabelas**, e é ele que dá
+alcance ao eixo.
+
+Com os tokens e **sem** classificar: `bun run authz:check` → **exit 1, exatamente 12 erros**. Esse
+vermelho é o produto intermediário que prova que o eixo tem dente — sem ele, "verde depois de
+classificar" não distinguiria cobertura de silêncio.
+
+A fronteira entre as duas listas **não é julgamento de estilo, é medição**:
+
+| lista | significa | como se decide |
+|---|---|---|
+| `AUTHZ_MANIFEST` | alcançável por `authenticated`/`anon` — fecha por **gate no corpo** | `has_function_privilege('authenticated', oid, 'EXECUTE')` = **t** |
+| `ACKNOWLEDGED_SENSITIVE` | fecha por **PRIVILÉGIO** (sem EXECUTE para essas roles) | o mesmo, = **f**, com `proacl` cru confirmando que não é `NULL` (que valeria PUBLIC) |
+
+Medido em prod (`psql-ro`, 2026-08-14 — 16 nomes pedidos, **16 linhas devolvidas**, nenhum overload):
+
+| resultado | funções |
+|---|---|
+| `auth=SIM · anon=NAO · svc=SIM` → **AUTHZ_MANIFEST** | `converter_sugestao_em_campanha_flat`, `pedido_compra_split` (+ `reposicao_pos_candidatos`, já lá) |
+| `auth=NAO · anon=NAO · svc=SIM` → **ACKNOWLEDGED** | as outras 10 (+ `_data_health_compute` e `reposicao_cold_start_parametros`, já lá — reconfirmadas) |
+
+`anon` não alcança **nenhuma** das 12. As 10 fechadas têm ACL explícito
+(`postgres=X # service_role=X # sandbox_exec=X`): o EXECUTE de `authenticated` não está lá, e não
+está **por omissão** — nenhuma tem `proacl` NULL.
+
+O consumidor de cada uma das 10 também foi verificado (`cron.job`, `pg_trigger`, grep nas edges),
+porque "não é executável por `authenticated`" responde quem **não** chama; a justificativa precisa
+dizer quem **chama**: 3 por cron (`detectar-outliers-diario`, `reposicao-alerta-pedido-minimo`,
+`sayerlack-retry-orfaos`), 5 por edge com `service_role`, 1 só pelo tick de cron
+(`reposicao_pedido_auto_aprovavel`, medida em `pg_proc.prosrc`) e 1 é **função de TRIGGER**
+(`set_status_envio_portal_on_disparo`, `RETURNS trigger`, via `trg_set_status_envio_portal`) — essa
+não tem sequer rota PostgREST.
+
+> ⚠️ Pôr gate de papel numa dessas 10 **quebraria** o cron: pg_cron roda sem JWT ⇒ `auth.uid()` NULL
+> ⇒ `has_role` false ⇒ higiene INAGENDÁVEL. É a mesma armadilha já anotada no fim do `AUTHZ_MANIFEST`
+> para `private.expirar_reservas_vencidas_job`. ACK aqui não é indulgência: é o modelo de fecho certo.
+
+## 7.2 As 3 que entraram no manifest — e a que o eixo NÃO revelou
+
+Antes de registrar, o detector foi rodado contra o **corpo real** de cada uma (lição do §3), e o
+corpo do repo foi comparado com o de prod por md5 do `prosrc` normalizado:
+
+| função | gate real | `blocksOnCall` | md5 repo vs prod |
+|---|---|---|---|
+| `converter_sugestao_em_campanha_flat` | `IF auth.uid() IS NULL OR NOT (has_role(employee) OR has_role(master)) THEN RAISE` | ✅ | **igual** (`a2ea61e7…`) |
+| `pedido_compra_split` | `IF auth.uid() IS NOT NULL THEN IF NOT (has_role…) THEN RAISE` | ✅ | **igual** (`9ccb9dd5…`) |
+| `reposicao_pos_marcador` | `(SELECT cap_compras_ler(…)) IS NOT TRUE` (forma initplan) | ✅ | **igual** (`99ebc805…`) |
+
+⚠️ **A forma do `pedido_compra_split` tem um limite que ficou escrito na entrada:** com `auth.uid()`
+NULL o gate não roda. Isso não abre buraco de browser, e a razão é **medida, não presumida** —
+`anon` não tem EXECUTE, então o único caminho de uid NULL é `service_role`/`postgres`. Se um dia
+`anon` ganhar EXECUTE, a função vira anônima e o gate a deixa passar.
+
+**`reposicao_pos_marcador` (follow-up 2) NÃO foi revelada pela ampliação** — ela lê
+`reposicao_pedidos_compra_run` e não cita nenhum dos 4 tokens. Entrou por registro **manual**, pela
+mesma rota da irmã. Isso é o dado honesto sobre o alcance: ampliar o eixo **reduz** o ponto cego,
+não o elimina.
+
+## 7.3 Evidência
+
+| o quê | resultado |
+|---|---|
+| baseline `authz:check` (antes de tudo) | exit **0**, 1 aviso (o `omie_sync_identity_snapshot` não-parseável, pré-existente) |
+| `authz:check` com tokens, **sem** classificar | exit **1**, **12 erros** — o dente do eixo |
+| `authz:check` final | exit **0**, **o mesmo 1 aviso** — nenhuma dívida nova, nenhuma escondida |
+| `bun run test` | **671 arquivos / 6.256 testes**, exit 0 |
+| os 2 arquivos de teste de authz | 67 → **86** testes: **delta +19**, exatamente os escritos |
+| `bun run scripts:typecheck` | exit **0** |
+| `bunx eslint` nos 5 arquivos tocados | exit **0**, zero achados |
+
+> A tabela acima foi medida **duas vezes**: a `main` andou **7 commits** durante a entrega (2 deles
+> criando migrations). Rebase + **re-medição** antes de fechar — 15 reveladas, **0 sem
+> classificação**, todos os números idênticos. É a regra do #1743 aplicada: base defasada dá achado
+> falso, e neste caso o achado falso seria "o baseline está completo".
+
+**Falsificação** (harness próprio; asserção pelo **exit code** do vitest, que não depende de locale):
+
+| | sabotagem | esperado | obtido |
+|---|---|---|---|
+| C0/C1 | nenhuma (canário, antes e depois) | verde | exit 0 |
+| F1 | tokens do eixo removidos do contrato | vermelho | exit 1 — e as **3** que caem são exatamente as do eixo de compras (causa conferida, não só o exit) |
+| F2 | 1 chave de `ACKNOWLEDGED` removida | vermelho | exit 1 |
+| F3 | 1 entrada de `AUTHZ_MANIFEST` removida | vermelho | exit 1 |
+| F4 | chave de ACK com **typo** (`…claim_id`) | vermelho | exit 1 |
+| F5 | mesma chave nas **duas** listas | vermelho | exit 1 |
+
+F4 é o teste que separa "a lista está certa" de "a lista tem 10 strings dentro": chave escrita
+errada não silencia nada. F5 protege contra o contrato que se contradiz — o manifest venceria em
+silêncio e a justificativa do ACK seria mentira.
+
+Os testes de manifest sabotam o **arquivo real** da migration, e o recorte é por função: a linha de
+gate `IF auth.uid() IS NULL OR NOT (has_role…)` aparece **5×** em `20260512101121`, e a primeira
+pertence a `fin_consolidado_intercompany` — um `replace` ingênuo teria sabotado a função errada e
+deixado o teste verde pelo motivo errado.
+
+## 7.4 Limites declarados e o que sobra
+
+1. **`DROP FUNCTION` + `CREATE FUNCTION` reseta o ACL.** `CREATE OR REPLACE` o preserva; o par
+   DROP+CREATE não, e a função renasce com o default privilege do Supabase (que concede às roles
+   nomeadas). É o irmão exato do vetor `RECRIACAO` que a Parte C pega em **tabela**
+   ([sentinela-grants-tabelas-fechadas.md](sentinela-grants-tabelas-fechadas.md)) e que **ninguém
+   pega em função**. Enquanto não houver esse detector, a reconfirmação das 12 entradas por
+   privilégio é o audit read-only — o mesmo `has_function_privilege` desta entrega.
+2. **Migration que reescreve por `regexp_replace` é invisível ao gate estático** — e isto deixou de
+   ser hipótese durante esta própria sessão: a `20260814022626` (#1737) recria
+   `reposicao_pos_candidatos` aplicando `regexp_replace` sobre `pg_get_functiondef` da definição
+   VIVA, sem escrever nenhum `CREATE FUNCTION`. O parser não a vê, então o *last-writer* do repo
+   continua sendo a `20260814000125`. A Parte A segue medindo uma definição válida (não há
+   falso-verde), mas **não está medindo a última**. O manifesto já registrava que o FU4-G fizera
+   isso uma vez; agora aconteceu de novo, na mesma função, 2 dias depois. É padrão, não acidente.
+3. **Drift medido, fora do escopo deste PR:** o corpo de `reposicao_pos_candidatos` em prod
+   (`md5 63296444…`) **não** é o do repo (`2439966a…`) — prod não tem o diagnóstico do #1737
+   (conferido por marcador no `prosrc`). A `20260814022626` mergeou e **ainda não foi aplicada** no
+   SQL Editor. As outras 3 funções desta entrega batem byte a byte.
+4. O gate continua provando que a chamada **governa um ramo alcançável que levanta exceção** — não
+   que a exceção acontece para quem deve. Isso é asserção EXECUTADA (harness PG17), inalterado.

--- a/scripts/authz-gate-check.test.ts
+++ b/scripts/authz-gate-check.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { auditAuthz, auditCompleto, type Migration } from './authz-gate-check';
 import { AUTHZ_TABELAS_FECHADAS } from './authz-tabelas-fechadas';
+import { AUTHZ_MANIFEST, ACKNOWLEDGED_SENSITIVE, manifestKey } from './authz-manifest';
 
 function mig(file: string, sql: string): Migration {
   return { file, sql };
@@ -266,5 +267,155 @@ AS $$ BEGIN RETURN QUERY SELECT 1; END $$;`;
     ).filter((e) => e.fn.includes('reposicao_pos_candidatos'));
     expect(err).toHaveLength(1);
     expect(err[0].file).toBe('20991231000000_recria.sql');
+  });
+});
+
+// ══════════ EIXO COMERCIAL DE COMPRAS — a classe fechada (2026-08-14) ══════════
+// Follow-up 1 de docs/historico/sentinela-authz-controle-nao-mencao.md. A RPC do bloco acima entrou
+// no manifest À MÃO porque a Parte B só exigia classificação no eixo custo/preço/estoque. Ampliar
+// `SENSITIVE_*` para compras revelou 12 SECDEF sem classificação (medido: `authz:check` exit 1 com
+// 12 erros ANTES de classificar). Cada uma foi classificada pelos GRANTS REAIS de prod (psql-ro):
+// 2 alcançáveis por `authenticated` → AUTHZ_MANIFEST; 10 fechadas por privilégio → ACKNOWLEDGED.
+//
+// Os testes abaixo existem porque baseline é o momento de maior risco de contrato FALSO: uma lista
+// pode ficar verde por estar silenciando, e não por estar cobrindo.
+const COMPRAS_MANIFEST: Array<{ nome: string; gate: string; arquivo: string; de: string }> = [
+  {
+    nome: 'pedido_compra_split',
+    gate: 'has_role',
+    arquivo: '20260515213420_868822bb-e38c-4fcf-8879-c64e48bd7630.sql',
+    de: "IF NOT (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role)) THEN",
+  },
+  {
+    nome: 'converter_sugestao_em_campanha_flat',
+    gate: 'has_role',
+    arquivo: '20260512101121_a96fa007-f688-4c3a-8cd9-43f9d88e5505.sql',
+    de: "IF auth.uid() IS NULL OR NOT (public.has_role(auth.uid(), 'employee'::app_role) OR public.has_role(auth.uid(), 'master'::app_role)) THEN",
+  },
+  {
+    nome: 'reposicao_pos_marcador',
+    gate: 'cap_compras_ler',
+    arquivo: '20260814000125_reposicao_pos_frescor_marcador.sql',
+    de: 'AND (SELECT private.cap_compras_ler((SELECT auth.uid()))) IS NOT TRUE THEN',
+  },
+];
+
+/** as 10 que fecham por PRIVILÉGIO (auth=NAO/anon=NAO medido em prod) — baseline desta entrega */
+const COMPRAS_ACK = [
+  'public.detectar_skus_sem_grupo',
+  'public.reposicao_alerta_pedido_minimo_tick',
+  'public.sayerlack_retry_orfaos',
+  'public.reposicao_pedido_auto_aprovavel',
+  'public.reposicao_aplicar_depara_sayerlack_auto',
+  'public.envio_portal_lock_candidatos',
+  'public.envio_portal_claim_ids',
+  'public.iniciar_envio_portal_pre_claim',
+  'public.reposicao_persistir_qtde_inteira',
+  'public.set_status_envio_portal_on_disparo',
+];
+
+/** SECDEF sintética que toca o eixo de compras, sem gate nenhum */
+function secdefCompras(nome: string): string {
+  return `CREATE OR REPLACE FUNCTION public.${nome}()
+ RETURNS numeric LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$ BEGIN RETURN (SELECT count(*) FROM public.pedido_compra_sugerido WHERE fornecedor_nome IS NOT NULL); END; $function$;`;
+}
+
+describe('Parte B — o eixo de compras alcança o que o eixo de custo não alcançava', () => {
+  it('SECDEF nova que toca pedido_compra_sugerido/fornecedor_nome e não está classificada → ERRO', () => {
+    const err = errorsOf(auditAuthz([mig('20991231000000_nova.sql', secdefCompras('fuga_de_compras'))]));
+    expect(err).toHaveLength(1);
+    expect(err[0].fn).toContain('public.fuga_de_compras');
+    expect(err[0].msg).toContain('pedido_compra_sugerido');
+  });
+
+  it('SECURITY INVOKER no eixo de compras continua ignorado (não bypassa RLS)', () => {
+    const invoker = secdefCompras('fuga_invoker').replace('SECURITY DEFINER', 'SECURITY INVOKER');
+    expect(errorsOf(auditAuthz([mig('20991231000000_x.sql', invoker)]))).toHaveLength(0);
+  });
+
+  it('as 10 chaves de ACKNOWLEDGED silenciam DE VERDADE (pega chave com typo)', () => {
+    // Uma chave escrita errada não silencia nada e a função fica sem classificação — este teste é
+    // o que separa "a lista está certa" de "a lista tem 10 strings dentro".
+    for (const chave of COMPRAS_ACK) {
+      expect(ACKNOWLEDGED_SENSITIVE.has(chave)).toBe(true);
+      const nome = chave.replace('public.', '');
+      const err = errorsOf(auditAuthz([mig('20991231000000_ack.sql', secdefCompras(nome))]));
+      expect(err.filter((e) => e.fn.includes(nome))).toHaveLength(0);
+    }
+  });
+});
+
+describe('AUTHZ_MANIFEST — as 3 entradas de compras estão VIVAS, não apenas silenciosas', () => {
+  /**
+   * Recorta a definição de UMA função no arquivo REAL e sabota só dentro dela.
+   * `String.replace(string, …)` troca a PRIMEIRA ocorrência, e a linha de gate
+   * `IF auth.uid() IS NULL OR NOT (has_role…)` aparece 5× em 20260512101121 — a primeira pertence
+   * a `fin_consolidado_intercompany`, não à função sob teste. Sabotar a função errada deixaria o
+   * teste verde pelo motivo errado, que é o modo de falha que este arquivo inteiro existe p/ evitar.
+   */
+  function sabotaFn(sql: string, nome: string, de: string, para: string): string {
+    const ancora = `CREATE OR REPLACE FUNCTION public.${nome}(`;
+    const ini = sql.indexOf(ancora);
+    expect(ini).toBeGreaterThan(-1);
+    expect(sql.indexOf(ancora, ini + 1)).toBe(-1); // âncora única: senão o recorte é ambíguo
+    const prox = sql.indexOf('CREATE OR REPLACE FUNCTION', ini + ancora.length);
+    const fim = prox === -1 ? sql.length : prox;
+    const trecho = sql.slice(ini, fim);
+    expect(trecho).toContain(de); // sabotagem que não casa nada deixaria o teste verde à toa
+    return sql.slice(0, ini) + trecho.replace(de, para) + sql.slice(fim);
+  }
+
+  const leia = (arq: string) => readFileSync(join(process.cwd(), 'supabase', 'migrations', arq), 'utf8');
+
+  for (const alvo of COMPRAS_MANIFEST) {
+    it(`${alvo.nome}: a migration REAL passa no contrato (senão o CI ficaria vermelho por falso positivo)`, () => {
+      expect(AUTHZ_MANIFEST[manifestKey('public', alvo.nome)]).toBeDefined();
+      const err = errorsOf(auditAuthz([mig(alvo.arquivo, leia(alvo.arquivo))])).filter((e) => e.fn.includes(alvo.nome));
+      expect(err).toHaveLength(0);
+    });
+
+    it(`${alvo.nome}: gate REMOVIDO do arquivo real → ERRO nomeando ${alvo.gate}`, () => {
+      const s = sabotaFn(leia(alvo.arquivo), alvo.nome, alvo.de, 'IF false THEN');
+      const err = errorsOf(auditAuthz([mig(alvo.arquivo, s)])).filter((e) => e.fn.includes(alvo.nome));
+      expect(err).toHaveLength(1);
+      expect(err[0].msg).toContain(alvo.gate);
+    });
+
+    it(`${alvo.nome}: recriação POSTERIOR sem gate vence a com gate (last-writer)`, () => {
+      const err = errorsOf(
+        auditAuthz([mig(alvo.arquivo, leia(alvo.arquivo)), mig('20991231000000_recria.sql', secdefCompras(alvo.nome))]),
+      ).filter((e) => e.fn.includes(alvo.nome));
+      expect(err).toHaveLength(1);
+      expect(err[0].file).toBe('20991231000000_recria.sql');
+    });
+  }
+
+  it('gate DECORATIVO (chamada presente, sem bloquear) não salva a entrada', () => {
+    // A distinção que o #1729 comprou: presença de chamada ≠ controle.
+    const decorativo = `CREATE OR REPLACE FUNCTION public.pedido_compra_split(p_pedido_id bigint)
+ RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public'
+AS $function$ DECLARE v boolean; BEGIN
+  v := public.has_role(auth.uid(), 'employee'::app_role);
+  INSERT INTO public.pedido_compra_sugerido (fornecedor_nome) VALUES ('x');
+END; $function$;`;
+    const err = errorsOf(auditAuthz([mig('20991231000000_dec.sql', decorativo)])).filter((e) => e.fn.includes('pedido_compra_split'));
+    expect(err).toHaveLength(1);
+    expect(err[0].msg).toContain('decorativo');
+  });
+});
+
+describe('contrato de classificação — as duas listas não podem se contradizer', () => {
+  it('nenhuma chave está nas DUAS listas (manifest venceria em silêncio e a justificativa do ACK seria mentira)', () => {
+    const nas2 = Object.keys(AUTHZ_MANIFEST).filter((k) => ACKNOWLEDGED_SENSITIVE.has(k));
+    expect(nas2).toEqual([]);
+  });
+
+  it('toda chave está na forma de manifestKey (lowercase schema.name) — chave torta nunca casa', () => {
+    const tortas = [...Object.keys(AUTHZ_MANIFEST), ...ACKNOWLEDGED_SENSITIVE].filter((k) => {
+      const [schema, ...resto] = k.split('.');
+      return resto.length !== 1 || manifestKey(schema, resto[0]) !== k;
+    });
+    expect(tortas).toEqual([]);
   });
 });

--- a/scripts/authz-gate-check.ts
+++ b/scripts/authz-gate-check.ts
@@ -11,8 +11,10 @@
  *    o gate esperado EM FORMA DE BLOQUEIO. Ausência, gate decorativo (presente sem bloquear), ou
  *    recriação que o parser não conseguiu extrair (fail-closed) → erro nomeando a migration.
  *  - Parte B (cobertura): no estado final (last-writer por ASSINATURA, p/ não perder overloads),
- *    TODA SECDEF que toca custo/preço/estoque deve estar classificada — `gated` ou `acknowledged`.
- *    Uma SECDEF sensível nova não classificada → erro.
+ *    TODA SECDEF que toca o eixo sensível deve estar classificada — `gated` ou `acknowledged`.
+ *    Uma SECDEF sensível nova não classificada → erro. O eixo é custo/preço/estoque **e**
+ *    comercial de compras (`SENSITIVE_*` em scripts/lib/authz-contract.ts — o 2º entrou em
+ *    2026-08-14, ver o cabeçalho daquele arquivo).
  *
  * Uso:  bun run authz:check           # roda no CI (ci.yml, job validate) e local
  *       bun scripts/authz-gate-check.ts --json
@@ -116,7 +118,7 @@ export function auditAuthz(migrations: Migration[]): Finding[] {
     if (sensitive.length > 0) {
       findings.push({ level: 'error', file, fn: mkey, msg: `SECURITY DEFINER que toca dado sensível (${sensitive.join(', ')}) NÃO foi parseável (fail-closed) e não está classificada. Classifique ${mkey} em scripts/authz-manifest.ts e/ou ajuste o parser (scripts/lib/authz-contract.ts).` });
     } else {
-      findings.push({ level: 'warn', file, fn: mkey, msg: `CREATE FUNCTION ${mkey} não extraído pelo parser — se for SECDEF que toca custo/preço/estoque, classifique manualmente.` });
+      findings.push({ level: 'warn', file, fn: mkey, msg: `CREATE FUNCTION ${mkey} não extraído pelo parser — se for SECDEF que toca custo/preço/estoque ou dado comercial de compras, classifique manualmente.` });
     }
   }
 

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -3,9 +3,16 @@
  * ============================================================================================
  *
  * Fonte de verdade CURADA do check anti-regressão de gate (scripts/authz-gate-check.ts).
- * Cada função SECDEF que toca custo/preço/estoque e é EXECUTÁVEL por `authenticated` DEVE estar
+ * Cada função SECDEF que toca o eixo sensível — custo/preço/estoque **ou** comercial de compras
+ * (`SENSITIVE_*` em scripts/lib/authz-contract.ts) — e é EXECUTÁVEL por `authenticated` DEVE estar
  * aqui, com o gate de bloqueio esperado. O check garante que nenhuma migration recrie a função
  * sem esse gate (Parte A) e que nenhuma SECDEF sensível nova fique sem classificação (Parte B).
+ *
+ * ⚠️ A fronteira MANIFEST vs ACKNOWLEDGED é uma medição, não um julgamento de estilo:
+ * `AUTHZ_MANIFEST` = alcançável por `authenticated`/`anon`, fecha por GATE NO CORPO;
+ * `ACKNOWLEDGED_SENSITIVE` = fecha por PRIVILÉGIO (sem EXECUTE para essas roles).
+ * Decidir sem medir `has_function_privilege` em prod fabrica um contrato falso — e contrato falso
+ * é pior que lacuna, porque o CI passa a AFIRMAR cobertura que não existe.
  *
  * Ao adicionar/gatear uma função SECDEF sensível: classifique-a aqui (o CI falha até você fazê-lo).
  * Ao MUDAR o gate de uma função (decisão de política): atualize o requiredGate aqui — é o ponto
@@ -167,6 +174,59 @@ export const AUTHZ_MANIFEST: Record<string, AuthzEntry> = {
     motivo:
       'detector de PO sumido — protocolo/fornecedor/jsonb cru p/ authenticated; master-only pelo FU4-G',
   },
+
+  // ════════ eixo COMERCIAL DE COMPRAS — o follow-up 1 fechado (2026-08-14) ════════
+  // A entrada acima entrou À MÃO justamente porque a Parte B não a alcançava. Este bloco fecha a
+  // CLASSE: `SENSITIVE_*` ganhou `pedido_compra_sugerido`/`purchase_orders_tracking`/
+  // `fornecedor_nome`/`portal_protocolo`, o que revelou 12 SECDEF sem classificação (`authz:check`
+  // exit 1, 12 erros — medido antes de classificar, para provar que o eixo tem dente).
+  //
+  // Cada uma das 12 foi classificada por MEDIÇÃO em prod (psql-ro, 2026-08-14), nunca por leitura
+  // do corpo: `has_function_privilege(<role>, <oid>, 'EXECUTE')` para `authenticated` E `anon`,
+  // mais o `proacl` cru. Resultado: **2 são alcançáveis por `authenticated`** e entram AQUI, com o
+  // gate que de fato têm; as outras 10 têm `auth=NAO, anon=NAO, svc=SIM` (ACL explícito, sem
+  // `authenticated`) e fecham por PRIVILÉGIO → ACKNOWLEDGED_SENSITIVE, abaixo. `anon` não alcança
+  // NENHUMA das 12.
+  //
+  // Antes de registrar, o detector foi rodado contra o corpo REAL de cada uma (lição §3 do
+  // histórico: "um detector calibrado só na forma canônica não vigia o código que existe") —
+  // `blocksOnCall` = true nas duas, então nenhuma entra aqui só para deixar o CI vermelho.
+  // E o corpo do repo é byte-idêntico ao de prod nas duas (md5 do `prosrc` normalizado): não há
+  // drift de apply manual escondido atrás desta entrada.
+
+  // md5 a2ea61e7… (repo == prod). Gate FAIL-CLOSED também no uid NULL:
+  //   `IF auth.uid() IS NULL OR NOT (has_role(employee) OR has_role(master)) THEN RAISE 42501`.
+  // Escreve `promocao_campanha`/`promocao_item` (o `fornecedor_nome` que o detector pega é o
+  // literal 'RENNER SAYERLACK S/A' da campanha) e fecha a sugestão de negociação.
+  'public.converter_sugestao_em_campanha_flat': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }] },
+    motivo: 'converte sugestão de negociação em campanha de desconto flat — cria condição comercial com fornecedor; staff-only',
+  },
+  // md5 9ccb9dd5… (repo == prod). Divide um pedido de compra aprovado em pedidos-filho.
+  // ⚠️ A FORMA do gate é diferente da irmã acima e o limite precisa ficar escrito:
+  //   `IF auth.uid() IS NOT NULL THEN IF NOT (has_role(employee) OR has_role(master)) THEN RAISE`.
+  // Com uid NULL o gate NÃO roda — idioma de compatibilidade com cron/service_role (mesma família
+  // do `private.expirar_reservas_vencidas_job` comentado no fim deste manifesto). Aqui isso não
+  // abre buraco de browser, e a razão é MEDIDA, não presumida: `anon` não tem EXECUTE (anon=NAO),
+  // então o único caminho de uid NULL é service_role/postgres. Se um dia `anon` ganhar EXECUTE,
+  // esta função vira anônima — o gate a deixaria passar. Quem conceder, reescreve o gate antes.
+  'public.pedido_compra_split': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }] },
+    motivo: 'divide pedido de compra aprovado em filhos (fornecedor/condição de pagamento herdados); staff-only quando há JWT',
+  },
+  // md5 99ebc805… (repo == prod). RPC irmã do detector de PO, mesma migration 20260814000125.
+  // Este é o **follow-up 2** do mesmo histórico, e ele NÃO foi revelado pela ampliação do eixo:
+  // o corpo lê `reposicao_pedidos_compra_run` e não cita nenhum dos tokens novos. Está aqui por
+  // registro MANUAL — a mesma rota pela qual a `reposicao_pos_candidatos` entrou, e a prova de
+  // que ampliar o eixo reduz o ponto cego sem eliminá-lo. Gate idêntico ao da irmã, na forma
+  // initplan `(SELECT gate(…)) IS NOT TRUE` que só passou a ser reconhecida com `unwrapSelectScalar`.
+  'public.reposicao_pos_marcador': {
+    sensitive: true,
+    requiredGate: { anyOf: [{ call: 'cap_compras_ler' }] },
+    motivo: 'marcador de frescor do detector de PO (run_id/seq/finalizado_em) p/ authenticated; master-only pelo mesmo cap_compras_ler da irmã',
+  },
   // ⚠️ ATP fase 1.1 (migration 20260806225052): existe uma 5ª função que ESCREVE em
   // estoque_reservas e NÃO tem gate — `private.expirar_reservas_vencidas_job()`. É
   // DE PROPÓSITO e não é furo: pg_cron nativo roda SEM JWT, então auth.role() e
@@ -301,6 +361,41 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // K1-K3 exigem o vermelho exato (K2 sabota gateando `g`, que é o assert que protege o produto)
   // e K4/K4b são o canário do restore.
   'public.get_carteira_margem_faixa',
+
+  // ══════ eixo COMERCIAL DE COMPRAS — as 10 que fecham por PRIVILÉGIO (2026-08-14) ══════
+  // Reveladas pela ampliação de `SENSITIVE_*` (follow-up 1 do #1729). TODAS medidas em prod no
+  // mesmo run (psql-ro, `has_function_privilege` + `proacl` cru):
+  //   `auth=NAO · anon=NAO · svc=SIM`, ACL explícito `postgres=X # service_role=X # sandbox_exec=X`
+  // — isto é, o EXECUTE de `authenticated` não está lá, e não está por omissão: nenhuma delas tem
+  // `proacl` NULL (que valeria EXECUTE implícito a PUBLIC). Elas fecham como a `private.atp_disponivel`
+  // do topo desta lista: por privilégio, não por gate no corpo. Por isso ACK e não AUTHZ_MANIFEST —
+  // pôr gate de papel numa função de cron/edge a tornaria INAGENDÁVEL (pg_cron roda sem JWT ⇒
+  // auth.uid() NULL ⇒ has_role false), que é a armadilha já documentada no fim do AUTHZ_MANIFEST.
+  //
+  // O consumidor de cada uma também foi verificado (cron.job / pg_trigger / grep nas edges), porque
+  // "não é executável por authenticated" responde QUEM não chama, e a justificativa precisa dizer
+  // quem CHAMA:
+  'public.detectar_skus_sem_grupo', // self-heal de SKU sem grupo — cron `detectar-outliers-diario`
+  'public.reposicao_alerta_pedido_minimo_tick', // tick do alerta de pedido mínimo — cron `reposicao-alerta-pedido-minimo`
+  'public.sayerlack_retry_orfaos', // retry de envios órfãos ao portal — cron `sayerlack-retry-orfaos`
+  'public.reposicao_pedido_auto_aprovavel', // veredito de auto-aprovação; chamada SÓ pelo tick acima (medido em pg_proc.prosrc), nunca direto
+  'public.reposicao_aplicar_depara_sayerlack_auto', // de-para automático do boletim Sayerlack — edge `reposicao-depara-sayerlack-auto` (cron → edge, service_role)
+  'public.envio_portal_lock_candidatos', // lock dos candidatos a envio — edge `enviar-pedido-portal-sayerlack`
+  'public.envio_portal_claim_ids', // claim por lista positiva de ids — edges `disparar-pedidos-aprovados` e `enviar-pedido-portal-sayerlack`
+  'public.iniciar_envio_portal_pre_claim', // pré-claim antes do disparo — edge `disparar-pedidos-aprovados`
+  'public.reposicao_persistir_qtde_inteira', // arredonda/persiste qtde inteira do pedido — edge `disparar-pedidos-aprovados`
+  // Esta é a única que não é nem RPC nem chamada por edge: `RETURNS trigger`, disparada por
+  // `trg_set_status_envio_portal` em `pedido_compra_sugerido` (medido em pg_trigger). Função de
+  // trigger não tem rota PostgREST — o fecho por privilégio é a segunda tranca, não a primeira.
+  'public.set_status_envio_portal_on_disparo',
+  //
+  // ⚠️ LIMITE DECLARADO desta baseline, e ele vale para TODA entrada desta lista: o fecho por
+  // privilégio é estado de PROD, e o gate estático não o vigia. `CREATE OR REPLACE` preserva o
+  // ACL, mas `DROP FUNCTION` + `CREATE FUNCTION` o RESETA — e a função renasce com o default
+  // privilege do Supabase, que concede EXECUTE às roles nomeadas. É o irmão exato do vetor
+  // `RECRIACAO` que a Parte C pega em TABELA (docs/historico/sentinela-grants-tabelas-fechadas.md)
+  // e que ninguém pega em FUNÇÃO. Enquanto não houver esse detector, a reconfirmação é o audit
+  // read-only em prod — o mesmo `has_function_privilege` que classificou estas 10.
 ]);
 
 /** chave de lookup a partir de schema+name (case-insensitive, sem assinatura) */

--- a/scripts/lib/authz-contract.test.ts
+++ b/scripts/lib/authz-contract.test.ts
@@ -109,6 +109,30 @@ describe('touchesSensitive', () => {
   });
 });
 
+// ── eixo 2: comercial de COMPRAS (2026-08-14, follow-up 1 do #1729) ──
+// O eixo nasceu de um ponto cego MEDIDO: `public.reposicao_pos_candidatos` é SECDEF com EXECUTE
+// para `authenticated` e devolve protocolo do portal, fornecedor e jsonb cru — e não tocava
+// NENHUM token do eixo custo/preço/estoque, então a Parte B nunca exigiu sua classificação.
+describe('touchesSensitive — eixo comercial de compras', () => {
+  it('pega as tabelas do eixo (pedido_compra_sugerido, purchase_orders_tracking)', () => {
+    expect(touchesSensitive('insert into public.pedido_compra_sugerido (empresa) values (1)')).toContain('pedido_compra_sugerido');
+    expect(touchesSensitive('select 1 from public.purchase_orders_tracking')).toContain('purchase_orders_tracking');
+  });
+  it('pega as colunas do eixo (fornecedor_nome, portal_protocolo)', () => {
+    expect(touchesSensitive('select fornecedor_nome, portal_protocolo from x')).toEqual(
+      expect.arrayContaining(['fornecedor_nome', 'portal_protocolo']),
+    );
+  });
+  it('coluna casa por PALAVRA INTEIRA — `fornecedor` e `fornecedor_id` sozinhos NÃO ativam o eixo', () => {
+    // O token é largo (existe em 25 tabelas de prod) mas não é frouxo: se `fornecedor` bastasse,
+    // meia reposição viraria "sensível" e a lista de classificação perderia o sentido.
+    expect(touchesSensitive('select fornecedor_id, fornecedor from sku_parametros')).toHaveLength(0);
+  });
+  it('o eixo 1 continua valendo (ampliar não substituiu)', () => {
+    expect(touchesSensitive('select cmc from inventory_position')).toEqual(expect.arrayContaining(['inventory_position', 'cmc']));
+  });
+});
+
 // ── endurecimentos do challenge Codex (2026-07-09) ──
 describe('blocksOnCall — anti falso-negativo', () => {
   it('REJEITA guard invertido (IS NOT NULL AND gate → dispara p/ quem É staff)', () => {

--- a/scripts/lib/authz-contract.ts
+++ b/scripts/lib/authz-contract.ts
@@ -38,8 +38,45 @@ import { balancedParens, normalizeSignature } from './migration-objects';
 // Sem `export`: consumidos só por `touchesSensitive()` logo abaixo. Quem precisa da resposta
 // chama a função, que é a superfície pública — a lista crua exportada convidava a duplicar a
 // decisão de "o que é sensível" fora daqui.
-const SENSITIVE_TABLES = ['inventory_position', 'product_costs', 'sku_estoque_atual'];
-const SENSITIVE_COLUMNS = ['cmc', 'custo', 'preco', 'cost_price', 'unit_price'];
+//
+// DOIS EIXOS, e o segundo nasceu de um ponto cego MEDIDO (2026-08-14, follow-up 1 de
+// docs/historico/sentinela-authz-controle-nao-mencao.md):
+//  1. custo/preço/estoque — o eixo original (2026-07-09);
+//  2. comercial de COMPRAS — `public.reposicao_pos_candidatos` é SECDEF, tem GRANT EXECUTE a
+//     `authenticated` e devolve protocolo do portal do fornecedor, nome do fornecedor e a
+//     `resposta_canal` jsonb CRUA. Ela não tocava NENHUM token do eixo 1, então a Parte B nunca
+//     EXIGIU sua classificação: ela entrou no manifest à mão, e a CLASSE ficou aberta. Ampliar o
+//     eixo revelou mais 12 SECDEF não classificadas — todas baselinadas em scripts/authz-manifest.ts
+//     com os grants REAIS de prod medidos um a um (`has_function_privilege`), nunca por palpite.
+//
+// ⚠️ Ao acrescentar token aqui, saiba o que está comprando: cada token novo pode revelar SECDEF
+// que o CI passa a EXIGIR classificadas. Isso é o desenho (a lacuna vira trabalho visível), mas
+// classificar sem medir os grants fabricaria um contrato falso — pior que a lacuna, porque o CI
+// passaria a AFIRMAR cobertura que não existe. Meça primeiro; baselinar o revelado é o certo,
+// afrouxar o detector não é.
+const SENSITIVE_TABLES = [
+  // eixo 1 — custo/preço/estoque
+  'inventory_position',
+  'product_costs',
+  'sku_estoque_atual',
+  // eixo 2 — comercial de compras (2026-08-14)
+  'pedido_compra_sugerido',
+  'purchase_orders_tracking',
+];
+const SENSITIVE_COLUMNS = [
+  // eixo 1
+  'cmc',
+  'custo',
+  'preco',
+  'cost_price',
+  'unit_price',
+  // eixo 2 — `fornecedor_nome` é LARGO de propósito (medido: existe em 25 tabelas de prod, de
+  // `pedido_compra_sugerido` a `sku_preco_fornecedor_capturado`) — é o token que faz o eixo de
+  // compras ter alcance real. `portal_protocolo` (pedido_compra_sugerido) é o identificador do
+  // pedido no portal do fornecedor.
+  'fornecedor_nome',
+  'portal_protocolo',
+];
 
 export interface FunctionDef {
   schema: string;


### PR DESCRIPTION
Fecha o **follow-up 1** (e de quebra o 2) de `docs/historico/sentinela-authz-controle-nao-mencao.md`.

## O problema

A Parte B do `authz:check` só **exigia** classificação de SECDEF no eixo custo/preço/estoque. `public.reposicao_pos_candidatos` — SECDEF, `GRANT EXECUTE` a `authenticated`, devolve protocolo do portal do fornecedor, nome do fornecedor e `resposta_canal` jsonb **crua** — não tocava nenhum daqueles tokens. Ela entrou no manifest **à mão**; a **classe** continuou aberta: RPC nova do eixo compras não era coberta automaticamente, e "o gate de CI está verde" era lido como "a função está coberta".

## O que entrou

`SENSITIVE_*` ganha 4 tokens — `pedido_compra_sugerido`, `purchase_orders_tracking`, `fornecedor_nome`, `portal_protocolo` — conferidos como objetos **reais** de prod antes de entrar (token morto seria contrato falso na direção oposta; `fornecedor_nome` existe em 25 tabelas, e é ele que dá alcance ao eixo).

Com os tokens e **sem** classificar: `authz:check` → **exit 1, exatamente 12 erros**. Esse vermelho é o produto intermediário que prova que o eixo tem dente — sem ele, "verde depois de classificar" não distingue cobertura de silêncio.

## A regra que torna isto entrega, e não afrouxamento

Cada uma das 12 foi classificada pelos **grants REAIS de prod** (`psql-ro`: `has_function_privilege` para `authenticated` **e** `anon`, mais o `proacl` cru), nunca por leitura do corpo:

| medido em prod | destino | quantas |
|---|---|---|
| `auth=SIM · anon=NAO` | **AUTHZ_MANIFEST** (fecha por gate no corpo) | 2 |
| `auth=NAO · anon=NAO`, ACL explícito | **ACKNOWLEDGED_SENSITIVE** (fecha por PRIVILÉGIO) | 10 |

`anon` não alcança **nenhuma**. As 10 não estão abertas por omissão: nenhuma tem `proacl` NULL. Pôr gate de papel nelas **quebraria o cron** (pg_cron roda sem JWT ⇒ `auth.uid()` NULL ⇒ `has_role` false) — é a armadilha já anotada para `expirar_reservas_vencidas_job`.

O **consumidor** de cada uma das 10 também foi verificado (`cron.job`, `pg_trigger`, grep nas edges): "não é executável por `authenticated`" responde quem *não* chama; a justificativa precisa dizer quem **chama**.

Antes de registrar, o detector rodou contra o **corpo real** das 3 do manifest, e o repo foi comparado com prod por md5 do `prosrc` normalizado — os 3 batem byte a byte.

**Follow-up 2 fechado junto:** `reposicao_pos_marcador` (auth=SIM, gate `cap_compras_ler`) **não** foi revelada pela ampliação — entrou por registro manual. Ampliar o eixo **reduz** o ponto cego, não o elimina, e isso ficou escrito.

## Evidência

| o quê | resultado |
|---|---|
| `authz:check` baseline | exit **0**, 1 aviso pré-existente |
| `authz:check` com tokens, sem classificar | exit **1**, **12 erros** |
| `authz:check` final | exit **0**, **o mesmo 1 aviso** — nenhuma dívida nova nem escondida |
| suíte completa (vitest) | **671 arquivos / 6.256 testes**, exit 0 |
| os 2 arquivos de teste de authz | 67 → **86**: delta **+19**, exatamente os escritos |
| `scripts:typecheck` · `eslint` | exit **0** · exit **0**, zero achados |

**Falsificação** (exit code do vitest — independente de locale): token removido → 🔴 (e as 3 que caem são exatamente as do eixo, causa conferida) · ACK removido → 🔴 · manifest removido → 🔴 · chave com **typo** → 🔴 · chave nas **duas** listas → 🔴 · canário antes/depois → 🟢. **7 ok / 0 fail.**

A sabotagem dos testes de manifest é recortada **por função**: a linha de gate aparece **5×** em `20260512101121` e a primeira pertence a `fin_consolidado_intercompany` — um `replace` ingênuo sabotaria a função errada e ficaria verde pelo motivo errado.

Medido **2×**: a `main` andou 7 commits durante a entrega (2 criando migrations) → rebase + re-medição, números idênticos. Regra do #1743.

## Limites declarados (no doc, §7.4)

1. **`DROP FUNCTION` + `CREATE FUNCTION` reseta o ACL** — irmão exato do vetor `RECRIACAO` que a Parte C pega em *tabela* e que ninguém pega em *função*.
2. **Migration que reescreve por `regexp_replace` é invisível ao parser** — e deixou de ser hipótese: a `20260814022626` (#1737) recria `reposicao_pos_candidatos` sobre a definição VIVA, sem `CREATE FUNCTION`. Sem falso-verde (a Parte A mede uma def válida), mas **não a última**.
3. ⚠️ **Drift medido, fora do escopo:** o corpo de `reposicao_pos_candidatos` em prod **não** é o do repo — a `20260814022626` mergeou e **ainda não foi aplicada** no SQL Editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
