### PR TITLE
test(caca): o aviso de lucro só é sólido porque a policy de custo IGNORA a linha — D1/D2 fixam a precondição [money-path]

### DIFF
--- a/docs/historico/authz-custo-fu4f.md
+++ b/docs/historico/authz-custo-fu4f.md
@@ -208,6 +208,38 @@ para o predicado pegar e **sem banner**. Fixado em `lucro-fora-do-indice.test.ts
 sob perda parcial a ordem **inverte**, ao contrário da perda uniforme, que é transformação afim e
 preserva ordem (B2/B3). Row-independence não é detalhe da policy — é a **precondição** do aviso.
 
+**O limiar real é 49,5%, não 50%.** `lucro_cobertura` sai da view já `round(…, 2)`, e
+`round(0.495, 2) = 0.50`, que passa em `>= 0.5` (medido). Então mais da metade da receita de um
+comprador pode estar sem custo e ele ainda conta como "confiável". O erro é sempre para BAIXO
+(lucro somado só sobre a fatia coberta) e **não tem teto**: sem limite para o custo oculto, a
+distorção pode inverter o top 20%, não só arranhar o número.
+
+**Rodada adversarial (Codex, gpt-5.6-sol/high) — o que ela mudou.** Veredito dele: NÃO-PROVADO.
+Duas objeções procediam e foram resolvidas MEDINDO (ele não tinha acesso a prod; eu tinha):
+
+| objeção | medição | desfecho |
+|---|---|---|
+| "a policy pode ERRAR se o caller não puder executar `cap_custo_ler`" | `has_function_privilege('authenticated', …,'EXECUTE') = t` | resolvida — a view degrada, não quebra |
+| "`pg_depend` não enxerga corpo de função; o inventário é insuficiente" | `prosrc ILIKE '%product_costs%'` → **3** funções (`margem_cliente_agregada`, `_data_health_compute`, **`get_skus_margem_positiva`**), as 3 `SECURITY DEFINER`; 0 triggers, 0 policies de outras tabelas, 0 crons | resolvida — **e o inventário anterior dizia 2**: `pg_depend` sozinho subcontou |
+
+Uma objeção foi **refutada por leitura** — a lição de não aceitar parecer de agente sem conferir:
+ele alegou que o `A7` de `db/test-seg-onda1-rls-views-matview.sh` quebraria porque espera `anon`
+lendo `v_caca_compradores`. Mas aquele harness cria uma `v_caca_compradores` **sintética** (3
+colunas sobre `profiles`/`sales_orders`) e menciona `product_costs` **zero** vezes: o REVOKE não a
+alcança. Ele inferiu pelo NOME do objeto sem ler o corpo do fixture.
+
+Outros dois pontos, medidos e sem ação: `relacl` **não tem entrada de grantee vazio**, logo `PUBLIC`
+não concede nada e o `REVOKE … FROM PUBLIC` é no-op (como a própria migration já dizia); `claude_ro`
+lê por `BYPASSRLS` + membership, não por grant, então o diagnóstico read-only sobrevive ao apply.
+⚠️ **Limite honesto:** `sandbox_exec` e `sandbox_exec_<ref>` mantêm `ar` (SELECT+INSERT) **por nome**
+— os asserts A3-A6 da migration só olham `authenticated` e `anon`. São roles de infra do editor SQL,
+fora do browser, mas "product_costs fecha" vale para o caminho do usuário, não para o catálogo todo.
+
+Ponto do Codex **aceito e não resolvido** (fica como dívida declarada): o aviso é sinal para o
+OPERADOR, não para engenharia — `caca.exibida` não carrega role/capability/cobertura, então ninguém
+é alertado no dia em que o primeiro hunter nascer degradado. A query de re-medição acima é o
+substituto pobre; o certo seria um evento `caca.ranking_degradado` com denominador por role.
+
 **Achado da falsificação (vale além da Caça):** ao sabotar `COBERTURA_MIN_LUCRO` de 0,5 para 0,7,
 **só o D2 ficou vermelho** — os outros 12 testes do arquivo passaram, inclusive o `A3`, que parece
 fixar o limiar mas o compara **consigo mesmo** (`lucroConfiavel({… cobertura: COBERTURA_MIN_LUCRO})`).

--- a/docs/historico/authz-custo-fu4f.md
+++ b/docs/historico/authz-custo-fu4f.md
@@ -148,6 +148,72 @@ quem pergunta — já em `database.md` §5). A variante nova: **grep de policy p
 `reposicao_param_auto_log` pareceu aberta porque filtrei por `cap_custo_ler` e ela usa `cap_compras_ler`
 — falso alarme desfeito ao ler o `qual` real. Case por `%cap\_%`, ou leia a expressão.
 
+### 11. A Caça: o `hunter` entra sem `cap_custo_ler` — e o aviso só cobre a perda UNIFORME
+
+Medido em **2026-08-14** (psql-ro, catálogo), antes de liberar o apply da `20260725130000`:
+
+| classe | medição |
+|---|---|
+| views dependentes de `product_costs` (`pg_depend`/`pg_rewrite`) | **1** — `v_caca_compradores`, `security_invoker=on` |
+| precondições da migration | as 3 passam (`cap_custo_ler`, `get_skus_margem_positiva`, `get_carteira_margem_faixa`) |
+| estado hoje | RLS ON, 2 policies antigas de pé, policy nova ausente → **não aplicada**; `anon` com SELECT+TRUNCATE+INSERT |
+
+**A degradação é honesta no SQL.** A view faz `LEFT JOIN product_costs` e soma
+`… FILTER (WHERE custo_efetivo > 0)`. Sem linhas visíveis o `SUM` cai sobre conjunto vazio e dá
+**NULL**, não zero — `lucro_proxy` vira `null` e `lucro_cobertura` vira 0. Não há 403 (o `GRANT
+SELECT` é preservado de propósito, a RLS é que filtra) **e não há número fabricado**. O front
+declara a perda desde o #1520 (`empresasSemLucroConfiavel` → banner `role="status"` nomeando as
+duas causas).
+
+**O acoplamento que ninguém tinha escrito:**
+
+```
+entra na Caça (RequireCaca) = master OR commercial_role ∈ {hunter, master, super_admin}
+cap_custo_ler               = master OR (employee AND commercial_role ∈ {estrategico, super_admin})
+```
+
+`hunter` — o dono **declarado** da tela ("a fila de look-alike é do HUNTER") — não está na segunda
+lista. Quem for promovido a hunter entra na Caça e roda o índice com 2 dos 3 termos (lucro pesa
+0,4), para sempre, com banner permanente. Hoje isso não atinge ninguém: só **3** usuários têm
+`commercial_role` (2 `farmer`, que nem entram, e 1 `master`, que **tem** a capability) e existem
+**zero hunters**. Por isso o apply é seguro e a RPC `SECURITY DEFINER` que devolveria o lucro foi
+**adiada** — construí-la para população zero é a "fase N+1 sem sinal" do CLAUDE.md.
+
+Re-medir (query, não recado) — se `entra_sem_custo > 0`, a decisão da RPC voltou à mesa:
+
+```sql
+WITH r AS (
+  SELECT cr.user_id, cr.commercial_role::text AS crole,
+         bool_or(ur.role='master')   AS is_master,
+         bool_or(ur.role='employee') AS is_employee
+    FROM public.commercial_roles cr
+    LEFT JOIN public.user_roles ur ON ur.user_id = cr.user_id
+   GROUP BY 1,2
+)
+SELECT count(*) FILTER (
+         WHERE (is_master OR crole IN ('hunter','master','super_admin'))
+           AND NOT (is_master OR (is_employee AND crole IN ('estrategico','super_admin')))
+       ) AS entra_sem_custo
+  FROM r;
+```
+
+**A precondição do aviso — e é ela que importa a longo prazo.** `product_costs_select_custo` usa
+`USING (private.cap_custo_ler(auth.uid()))`: o predicado **não olha a linha**, então o leitor vê a
+tabela inteira ou nenhuma linha. É *só por isso* que a perda por autorização é uniforme e cai no
+caso que o banner cobre. Se a policy virar row-dependent (custo por BU, por empresa, por
+fornecedor), a perda vira **parcial** — e `lucro_cobertura` é `receita_com_custo / receita`, de
+modo que 60% de visibilidade dá cobertura 0,6, que **passa** no limiar de 0,5. O comprador entra
+no percentil com lucro somado só sobre a fatia visível: número presente, enviesado, sem `null`
+para o predicado pegar e **sem banner**. Fixado em `lucro-fora-do-indice.test.ts` (D1/D2):
+sob perda parcial a ordem **inverte**, ao contrário da perda uniforme, que é transformação afim e
+preserva ordem (B2/B3). Row-independence não é detalhe da policy — é a **precondição** do aviso.
+
+**Achado da falsificação (vale além da Caça):** ao sabotar `COBERTURA_MIN_LUCRO` de 0,5 para 0,7,
+**só o D2 ficou vermelho** — os outros 12 testes do arquivo passaram, inclusive o `A3`, que parece
+fixar o limiar mas o compara **consigo mesmo** (`lucroConfiavel({… cobertura: COBERTURA_MIN_LUCRO})`).
+Assert que referencia a própria constante é tautologia quanto ao **valor**: prova a coerência
+interna e nada sobre o número. Para pinar um limiar é preciso um caso com o valor **literal**.
+
 ## Limite honesto herdado do #1465
 
 `get_preco_cockpit` mascara o número mas continua sendo **oráculo por bisseção**: o caller escolhe o
@@ -191,3 +257,9 @@ negativo**: a proteção vem da delegação (variante da lição 10).
   quando `product_costs` for fechada**: é o lembrete executável do limite. Ao fechar a fase 3, **corrija
   o assert** (não reverta o fix) e atualize a seção "limite honesto" da migration `20260723130000`.
 - `db/test-authz-pedido-compra-item.sh` — 15 asserts, 3 falsificações.
+- `src/lib/caca/__tests__/lucro-fora-do-indice.test.ts` — 13 casos. `D1`/`D2` fixam a precondição
+  de **row-independence** da lição 11 (só o D2 pega uma mudança do limiar de cobertura).
+  ⚠️ **Não é prova de SQL**: o `L1` do `fase2.sh` recria as policies antigas no **próprio fixture**
+  (linhas 125-135), então aplicar a `20260725130000` em prod **não** o deixa vermelho — depois do
+  apply a mensagem dele ("a porta segue aberta até lá") fica verdadeira no fixture e falsa em prod.
+  Corrigir o `L1` continua sendo follow-up do apply, não pré-requisito dele.

--- a/src/lib/caca/__tests__/lucro-fora-do-indice.test.ts
+++ b/src/lib/caca/__tests__/lucro-fora-do-indice.test.ts
@@ -149,3 +149,69 @@ describe('empresasSemLucroConfiavel — o aviso é POR EMPRESA', () => {
     expect(empresasSemLucroConfiavel(linhas)).toEqual(['oben']);
   });
 });
+
+/**
+ * D — o aviso só é SUFICIENTE porque a policy de custo é INDEPENDENTE DE LINHA.
+ *
+ * `product_costs_select_custo` (migration 20260725130000) tem
+ * `USING (private.cap_custo_ler(auth.uid()))`: o predicado não olha a linha, então o leitor vê
+ * a tabela INTEIRA ou NENHUMA linha. É por isso que a perda por autorização cai no caso C3
+ * (todas as empresas cegas de uma vez) e o banner cobre.
+ *
+ * Se algum dia a policy passar a depender da LINHA — custo visível por BU, por empresa, por
+ * fornecedor —, a perda vira PARCIAL: `lucro_cobertura` é `receita_com_custo / receita` (fração
+ * da receita cujo item tinha custo visível, medido no corpo da view em prod), então uma
+ * visibilidade de 60% produz cobertura 0,6, que PASSA no limiar de 0,5. O comprador entra no
+ * percentil com um lucro somado só sobre a fatia visível — número presente, enviesado, e sem
+ * nenhum `null` para o predicado pegar.
+ *
+ * Estes dois testes fixam o contraste que sustenta o desenho:
+ *   D1 — sob perda parcial a ordem INVERTE (ao contrário de B2/B3, onde a perda uniforme é
+ *        transformação afim e preserva ordem);
+ *   D2 — e o banner NÃO dispara, porque todo mundo continua "confiável".
+ *
+ * Logo: `declarar` só basta enquanto a perda for uniforme. Row-independence não é detalhe de
+ * implementação da policy — é a PRECONDIÇÃO do aviso. Quem tornar a policy row-dependent tem
+ * de trazer o sinal de cobertura junto, senão a Caça volta a falhar ABERTA.
+ */
+describe('D visibilidade PARCIAL de custo — o que o aviso não cobre', () => {
+  // volume e fidelidade idênticos: o lucro é o único discriminante (mesma calibração do B1).
+  const par = (lucroA: number, cobA: number, lucroB: number, cobB: number): CompradorRow[] => [
+    comprador({
+      documento: 'A',
+      empresa: 'oben',
+      volume: 1000,
+      n_pedidos: 5,
+      recencia_dias: 100,
+      lucro_proxy: lucroA,
+      lucro_cobertura: cobA,
+    }),
+    comprador({
+      documento: 'B',
+      empresa: 'oben',
+      volume: 1000,
+      n_pedidos: 5,
+      recencia_dias: 100,
+      lucro_proxy: lucroB,
+      lucro_cobertura: cobB,
+    }),
+  ];
+
+  const ordem = (linhas: CompradorRow[]) =>
+    selecionarMelhores(linhas, { fracaoTop: 1 }).melhores.map((m) => m.documento);
+
+  it('D1 perda PARCIAL reordena — B é o mais lucrativo e cai para segundo', () => {
+    // Verdade (custo 100% visível): B lucra 2000, A lucra 500 ⇒ B na frente.
+    expect(ordem(par(500, 1, 2000, 1))).toEqual(['B', 'A']);
+
+    // Mesmo mundo, mas o leitor só enxerga 60% dos itens de B: o lucro dele soma 300 sobre a
+    // fatia visível. Cobertura 0,6 PASSA no limiar ⇒ entra no percentil como se fosse o total.
+    expect(ordem(par(500, 1, 300, 0.6))).toEqual(['A', 'B']);
+  });
+
+  it('D2 e nenhum aviso dispara — os dois passam em lucroConfiavel', () => {
+    const parcial = par(500, 1, 300, 0.6);
+    expect(parcial.every((c) => lucroConfiavel(c))).toBe(true);
+    expect(empresasSemLucroConfiavel(parcial)).toEqual([]);
+  });
+});

--- a/src/lib/caca/__tests__/lucro-fora-do-indice.test.ts
+++ b/src/lib/caca/__tests__/lucro-fora-do-indice.test.ts
@@ -165,6 +165,10 @@ describe('empresasSemLucroConfiavel — o aviso é POR EMPRESA', () => {
  * percentil com um lucro somado só sobre a fatia visível — número presente, enviesado, e sem
  * nenhum `null` para o predicado pegar.
  *
+ * E o limiar efetivo é 49,5%, não 50%: a view já entrega `lucro_cobertura` como `round(…, 2)`, e
+ * `round(0,495; 2) = 0,50` (medido em PG17), que passa no `>=`. O erro é sempre para BAIXO e não
+ * tem teto — sem limite para o custo oculto, a distorção inverte o top 20%, não só o arranha.
+ *
  * Estes dois testes fixam o contraste que sustenta o desenho:
  *   D1 — sob perda parcial a ordem INVERTE (ao contrário de B2/B3, onde a perda uniforme é
  *        transformação afim e preserva ordem);


### PR DESCRIPTION
## O chip pedia uma coisa; a medição pediu outra

O chip "A Caça lê `product_costs` — o REVOKE do #1520 faz o lucro sumir do índice em silêncio"
dizia que fechar `product_costs` faria a Caça perder 0,4 do índice **sem sinal nenhum**. Medido em
prod (psql-ro, catálogo): **falso, por dois motivos independentes**.

**1. O sinal existe — e entrou no PRÓPRIO #1520.** `empresasSemLucroConfiavel` → banner
`role="status"` nomeando as duas causas (`CacaConteudo.tsx:107`). E o SQL degrada honesto:
`sum(…) FILTER (WHERE custo_efetivo > 0)` sobre conjunto vazio dá **NULL**, não zero. Sem 403
(o `GRANT SELECT` é preservado de propósito, a RLS filtra) e **sem número fabricado**.

**2. Ninguém é atingido hoje.** Só **3** usuários têm `commercial_role` — 2 `farmer` (que nem
entram na Caça) e 1 `master` (que **tem** `cap_custo_ler`). Existem **zero hunters**. As 3
precondições da migration passam em prod.

## O que estava mesmo sem registro: a PRECONDIÇÃO do aviso

`product_costs_select_custo` usa `USING (cap_custo_ler(auth.uid()))` — predicado que **não olha a
linha**. Por isso a perda é uniforme e cai no caso que o banner cobre. Se a policy virar
row-dependent (custo por BU/empresa/fornecedor), a perda vira **parcial**, e `lucro_cobertura` é
`receita_com_custo / receita`: 60% de visibilidade dá 0,6, que **passa** no limiar de 0,5. O
comprador entra no percentil com lucro somado só sobre a fatia visível — número presente,
enviesado, sem `null` para o predicado pegar e **sem banner**.

Pior: o limiar efetivo é **49,5%**, não 50% — a view entrega `round(…, 2)` e `round(0,495;2) = 0,50`
passa no `>=`. Mais da metade da receita pode estar sem custo e a linha ainda conta como confiável.

`D1` fixa que sob perda parcial a ordem **inverte** (perda uniforme é transformação afim e preserva
ordem — `B2`/`B3`). `D2` fixa que nenhum aviso dispara. **Row-independence deixa de ser detalhe da
policy e vira contrato testado.**

## O acoplamento latente, registrado

```
entra na Caça = master OR commercial_role ∈ {hunter, master, super_admin}
cap_custo_ler = master OR (employee AND commercial_role ∈ {estrategico, super_admin})
```

`hunter` — o dono **declarado** da tela — não está na segunda lista. A RPC `SECURITY DEFINER` que
devolveria o lucro foi **adiada de propósito**: população zero é a "fase N+1 sem sinal" do
CLAUDE.md. A lição 11 traz a **query** de re-medição (não recado); se `entra_sem_custo > 0`, a
decisão volta à mesa.

## Rodada adversarial (Codex gpt-5.6-sol/high)

Veredito dele: NÃO-PROVADO. Duas objeções procediam e foram resolvidas **medindo** (ele não tinha
acesso a prod; eu tinha):

| objeção | medição | desfecho |
|---|---|---|
| a policy pode ERRAR se o caller não puder executar `cap_custo_ler` | `has_function_privilege('authenticated',…,'EXECUTE') = t` | resolvida — degrada, não quebra |
| `pg_depend` não enxerga corpo de função | `prosrc ILIKE` → **3** funções, não 2 (faltava `get_skus_margem_positiva`), as 3 SECDEF; 0 triggers/policies/crons | resolvida — **e o inventário anterior subcontou** |

**Uma objeção refutada por leitura:** ele alegou que o `A7` de `test-seg-onda1-rls-views-matview.sh`
quebraria por esperar `anon` lendo `v_caca_compradores`. Aquele harness cria uma
`v_caca_compradores` **sintética** e menciona `product_costs` **zero** vezes. Inferiu pelo NOME sem
ler o corpo do fixture.

Ponto **aceito e não resolvido** (dívida declarada no doc): o banner avisa o OPERADOR, não
engenharia — ninguém é alertado no dia em que o primeiro hunter nascer degradado.

## Falsificação — e um achado que vale além da Caça

Duas sabotagens em `melhores.ts`, cada uma **conferida no arquivo** antes de ler o resultado:

| sabotagem | resultado |
|---|---|
| `pesoLucro` 0,4 → 0 | `D1` + `B1` vermelhos |
| `COBERTURA_MIN_LUCRO` 0,5 → 0,7 | **só `D2`** vermelho — os outros 12 passaram |

O segundo caso expõe que o `A3` **parece** fixar o limiar mas o compara **consigo mesmo**. Assert
que referencia a própria constante é **tautologia quanto ao valor**: prova coerência interna e nada
sobre o número. Restaurado — `git diff` de `melhores.ts` vazio.

## Nada de SQL neste PR

Só teste + doc. A migration `20260725130000` **não** foi tocada; segue mergeada e pendente de apply.

## Prova

- test: `heavy heavy bun run test` → **671 arquivos, 6258 testes**, exit 0
- typecheck: `heavy heavy bun run typecheck` → exit 0
- lint: `bun lint` → exit 0 (0 errors)
- authz: `bun run authz:check` → exit 0 (Partes A+B+C verdes), re-rodado após o #1744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
