### PR TITLE
docs(deploy): camada pendente é SINTOMA — achar UMA prova que o PR INTEIRO pode não ter subido

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -22,6 +22,14 @@ Como provar o que está **SERVIDO** nesse host (hash do index + grep nos chunks)
 2. **Frontend** → **Publish** manual no editor do Lovable. `steu.lovable.app` serve o **build velho** até o Publish (lição 2026-05-31: mergear e achar que foi pro ar é o erro recorrente).
 3. **Edge functions** → criadas/editadas pelo **chat do Lovable** (ele lê `supabase/functions/<nome>/index.ts` do repo e deploya **verbatim**), **NÃO** pela UI Cloud (que só mostra logs).
 
+**Achar UMA camada pendente é SINTOMA — audite as TRÊS do MESMO PR.** As camadas deployam separado, mas o PR que as tocou é um só: migration não-aplicada é evidência de **PR não-deployado**, não de migration esquecida. E o caminho de detecção enviesa — um `/fecho` que varre migrations acha migrations; frontend e edge nem entram no campo de visão. Ao detectar qualquer pendência, classifique o diff por camada antes de fechar o caso:
+
+```bash
+git show --name-only --format="" <sha> | awk '/^supabase\/migrations/{m++} /^supabase\/functions/{e++} /^src\//{f++} END{print "mig="m+0" edge="e+0" front="f+0}'
+```
+
+Mordido 2026-08-14 (#1520 `9f7e8962`, FU4-F fase 3): o `/fecho` pegou `…130000_fecha_product_costs.sql` mergeada e não aplicada, aplicou, verificou — caso encerrado. O mesmo PR trazia **5 migrations + frontend (já publicado) + 2 edges nunca confirmadas**, e edge velha ali é money-path concreto, porque o front novo é que mudou o contrato: `generate-bundle-argument` imprime `p.margin.toFixed(2)`/`bundle.lieBundle.toFixed(2)` num payload que o hook publicado **parou de mandar** (→ **TypeError**, argumento de venda não gera); `generate-tactical-plan` ordena as recomendações por `lie_bundle DESC`, hoje NULL em toda linha, e DESC implica NULLS FIRST → **topBundle arbitrário, plano tático sobre ranking fabricado**. ⚠️ O risco é assimétrico: com as duas metades faltando elas se cancelam, então **aplicar só a camada que apareceu pode ser o que ARMA a quebra** — é a armadilha do `carteira-rebuild` (abaixo) vista pelo lado do PR, não da edge.
+
 ## Edge — armadilhas
 
 - **Deploy SÓ depois do merge** — o chat lê a `main`; deployar antes pega o código velho.


### PR DESCRIPTION
## O caso (2026-08-14, #1520 `9f7e8962`)

Um `/fecho` detectou `20260725130000_authz_custo_fu4f_fase3_fecha_product_costs.sql` **mergeada na `main` e não aplicada em prod**. A sessão aplicou e verificou — caso encerrado.

Só que ao classificar o diff do #1520 apareceu o resto: o **mesmo PR** tocava as **três** camadas manuais do Lovable — 5 migrations, frontend (já publicado) e **2 edge functions cuja versão nunca foi confirmada** (`generate-bundle-argument`, `generate-tactical-plan`).

## A lição

**A camada achada não é o problema, é o sintoma.** As camadas deployam separado, mas o PR que as tocou é um só — migration pendente é evidência de *PR não-deployado*. E o caminho de detecção enviesa: um `/fecho` que varre migrations acha migrations; frontend e edge nem entram no campo de visão.

Edge velha aqui **não é cosmético** (verificado no diff, não inferido):

- `generate-bundle-argument` imprime `p.margin.toFixed(2)` / `bundle.lieBundle.toFixed(2)` num payload que o hook **já publicado** parou de mandar (`useBundleArguments.ts` removeu `margin`/`lieBundle` do contrato) → **TypeError**, argumento de venda não gera.
- `generate-tactical-plan` ordena as recomendações por `lie_bundle DESC` — hoje NULL em toda linha, e DESC implica NULLS FIRST → **topBundle arbitrário, plano tático sobre ranking fabricado**.

⚠️ E o risco é **assimétrico**: com as duas metades faltando elas se cancelam, então aplicar só a camada que apareceu pode ser o que **ARMA** a quebra — é a armadilha do `carteira-rebuild` já documentada, vista pelo lado do PR em vez do lado da edge.

## O que entra

8 linhas em [docs/agent/deploy.md](docs/agent/deploy.md), logo após a lista dos 3 deploys manuais: a regra + o pré-flight mecânico + o caso datado como âncora.

**Snippet do doc testado de verdade** (não colado às cegas):

- `#1520` → `mig=5 edge=2 front=34` (bate com o caso)
- `#1750` → `mig=0 edge=14 front=0` (imprime `0` corretamente na camada ausente)

## Fora de escopo, de propósito

- **`CLAUDE.md` NÃO tocado** — não autorizado e o orçamento está apertado (`claude:size` verde em 19202/20480 bytes, ~1,2 KB de folga). O doc/agent é justamente o lugar de não inflar o CLAUDE.md.
- Este PR **documenta**; não audita nem deploya as 2 edges do #1520 — a versão delas em prod **segue não confirmada** e é trabalho separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)