### PR TITLE
feat(farmer): o recálculo passa a APOSENTAR a geração anterior — 197 de 473 grupos tinham 2+ vivas [money-path]

### DIFF
--- a/db/test-farmer-geracao-vigente.sh
+++ b/db/test-farmer-geracao-vigente.sh
@@ -1,0 +1,571 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA — 20260814223445_farmer_recomendacoes_geracao_vigente.sql              ║
+# ║      bash db/test-farmer-geracao-vigente.sh > /tmp/t.log 2>&1; echo "exit=$?" ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                      ║
+# ║                                                                               ║
+# ║  O que se prova: o recálculo do farmer APOSENTA a geração anterior em vez de  ║
+# ║  empilhar, atomicamente, sem NUNCA deletar linha com desfecho registrado.     ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="farmer-geracao"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+-- O Supabase real concede isto; sem ele uma RPC SECURITY INVOKER que chama
+-- auth.uid()/auth.role() morre com "permission denied for schema auth" e o teste
+-- acusaria a migration por um furo do STUB. Conferido na PROD via psql-ro:
+--   has_schema_privilege('authenticated','auth','USAGE')      = true
+--   has_function_privilege('authenticated','auth.uid()',…)    = true
+--   has_function_privilege('authenticated','auth.role()',…)   = true
+GRANT USAGE ON SCHEMA auth TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION auth.uid(), auth.role() TO authenticated, anon;
+SQL
+
+# Os asserts POSITIVOS rodam pelo caminho de servidor (service_role), como o cron/edge.
+# Sem isto eles rodariam sem JWT nenhum e o gate os barraria — corretamente, desde que o
+# gate fecha em `IS NOT TRUE` (ver A4). Os asserts de autorização sobrescrevem este GUC
+# na própria sessão, então o default global não os enfraquece.
+"$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d postgres -q -c "ALTER DATABASE prove SET test.role = 'service_role';"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# usado SÓ na falsificação: espelha eq() mas com o veredito INVERTIDO (queremos vermelho).
+eq_esperando_vermelho() {
+  if [ "$2" = "$3" ]; then bad "FALSIFICAÇÃO SEM DENTE: $1 continuou [$2] com a migration sabotada"
+  else ok "falsificação mordeu: $1 virou [$2] (íntegro seria [$3])"; fi
+}
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que a migration LÊ/ALTERA mas não cria)
+# ══════════════════════════════════════════════════════════════════════════════
+# Espelha o schema REAL de prod (medido 2026-08-14 via psql-ro), incluindo as
+# colunas affinity_* da 20260725121000 — dependência que a migration exige.
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+
+-- cap_carteira_escrever: a capability de gestor. Aqui é tabela-backed pra o teste
+-- poder conceder/revogar sem tocar a função.
+CREATE TABLE IF NOT EXISTS private.caps (user_id uuid PRIMARY KEY, escrever boolean DEFAULT false, ler boolean DEFAULT false);
+CREATE OR REPLACE FUNCTION private.cap_carteira_escrever(p_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'private','pg_temp'
+  AS $f$ SELECT coalesce((SELECT escrever FROM private.caps WHERE user_id = p_uid), false) $f$;
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(p_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'private','pg_temp'
+  AS $f$ SELECT coalesce((SELECT ler FROM private.caps WHERE user_id = p_uid), false) $f$;
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(p_cliente uuid, p_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT false $f$;
+
+CREATE TABLE IF NOT EXISTS public.omie_products (id uuid PRIMARY KEY, descricao text);
+
+CREATE TABLE IF NOT EXISTS public.farmer_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  recommendation_type text NOT NULL,
+  product_id uuid REFERENCES public.omie_products(id),
+  current_product_id uuid REFERENCES public.omie_products(id),
+  p_ij numeric DEFAULT 0,
+  m_ij numeric DEFAULT 0,
+  lie numeric DEFAULT 0,
+  complexity_factor numeric DEFAULT 1,
+  cluster_volume_estimate numeric DEFAULT 1,
+  offered_at timestamptz, accepted_at timestamptz, rejected_at timestamptz,
+  actual_margin numeric, time_spent_seconds integer,
+  status text DEFAULT 'pendente',
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  affinity_score numeric,
+  CONSTRAINT farmer_recommendations_recommendation_type_check
+    CHECK (recommendation_type = ANY (ARRAY['cross_sell'::text,'up_sell'::text])),
+  CONSTRAINT farmer_recommendations_status_check
+    CHECK (status = ANY (ARRAY['pendente'::text,'ofertado'::text,'aceito'::text,'rejeitado'::text,'expirado'::text]))
+);
+
+CREATE TABLE IF NOT EXISTS public.farmer_bundle_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  bundle_products jsonb NOT NULL DEFAULT '[]'::jsonb,
+  bundle_type text NOT NULL DEFAULT 'cross_sell',
+  support numeric DEFAULT 0, confidence numeric DEFAULT 0, lift numeric DEFAULT 0,
+  p_bundle numeric DEFAULT 0, m_bundle numeric DEFAULT 0, lie_bundle numeric DEFAULT 0,
+  complexity_factor numeric DEFAULT 1,
+  status text DEFAULT 'pendente',
+  offered_at timestamptz, accepted_at timestamptz, rejected_at timestamptz,
+  actual_margin numeric, time_spent_seconds integer, accepted_products jsonb,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  affinity_bundle numeric,
+  -- versão PRÉ-migration de propósito: sem 'expirado'. Se a migration não alargar
+  -- este CHECK, a RPC do bundle morre em runtime com 23514 (não no CREATE).
+  CONSTRAINT farmer_bundle_recommendations_status_check
+    CHECK (status = ANY (ARRAY['pendente'::text,'ofertado'::text,'aceito_total'::text,'aceito_parcial'::text,'rejeitado'::text]))
+);
+
+ALTER TABLE public.farmer_recommendations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.farmer_bundle_recommendations ENABLE ROW LEVEL SECURITY;
+
+-- Policies transcritas do pg_policies da PROD (não um resumo delas).
+CREATE POLICY frec_select_carteira ON public.farmer_recommendations FOR SELECT TO authenticated
+  USING ((SELECT private.cap_carteira_ler((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid()))
+         OR private.carteira_visivel_para(customer_user_id, (SELECT auth.uid())));
+CREATE POLICY frec_insert_own_or_gestor ON public.farmer_recommendations FOR INSERT TO authenticated
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY frec_update_own_or_gestor ON public.farmer_recommendations FOR UPDATE TO authenticated
+  USING ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())))
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY frec_delete_own_or_gestor ON public.farmer_recommendations FOR DELETE TO authenticated
+  USING ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+
+CREATE POLICY fbrec_select_carteira ON public.farmer_bundle_recommendations FOR SELECT TO authenticated
+  USING ((SELECT private.cap_carteira_ler((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY fbrec_insert_own_or_gestor ON public.farmer_bundle_recommendations FOR INSERT TO authenticated
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY fbrec_update_own_or_gestor ON public.farmer_bundle_recommendations FOR UPDATE TO authenticated
+  USING ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())))
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1a — SEED do LEGADO, aplicado ANTES da migration (como na realidade)
+# ══════════════════════════════════════════════════════════════════════════════
+# As 6.015 linhas pendentes de prod nasceram sem `run_id`, antes desta migration existir.
+# Semear isso DEPOIS da migration é impossível — e é impossível de propósito: a trigger
+# `trg_frec_exige_run_id` rejeita pendente sem run_id, que é justamente a invariante nova.
+# (Este seed já rodou depois uma vez e o harness morreu com FG008: a trigger provou-se
+# viva antes mesmo do assert A5 existir.) Semear aqui reproduz a ordem real dos fatos.
+FARMER_A='aaaaaaaa-1111-1111-1111-111111111111'
+FARMER_B='bbbbbbbb-2222-2222-2222-222222222222'
+CLI_1='ccccccc1-1111-1111-1111-111111111111'
+CLI_2='ccccccc2-2222-2222-2222-222222222222'
+PROD_1='dddddddd-1111-1111-1111-111111111111'
+PROD_2='dddddddd-2222-2222-2222-222222222222'
+
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$FARMER_A'),('$FARMER_B'),('$CLI_1'),('$CLI_2') ON CONFLICT DO NOTHING;
+INSERT INTO public.omie_products(id, descricao) VALUES ('$PROD_1','Lixa 120'),('$PROD_2','Verniz PU') ON CONFLICT DO NOTHING;
+
+-- Geração LEGADA (run_id ainda nem existe como coluna aqui).
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, p_ij, affinity_score, status, created_at)
+VALUES
+  ('$FARMER_A','$CLI_1','cross_sell','$PROD_1', 9.9, 0.99, 'pendente', now() - interval '70 days'),
+  ('$FARMER_A','$CLI_1','cross_sell','$PROD_2', 5.0, 0.50, 'pendente', now() - interval '70 days'),
+  ('$FARMER_A','$CLI_2','up_sell',   '$PROD_1', 3.0, 0.30, 'pendente', now() - interval '70 days');
+
+-- Linha com DESFECHO registrado: histórico, tem de sobreviver a todo recálculo.
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, p_ij, affinity_score, status, offered_at, accepted_at)
+VALUES ('$FARMER_A','$CLI_1','cross_sell','$PROD_1', 7.0, 0.70, 'aceito', now() - interval '60 days', now() - interval '59 days');
+
+-- Carteira de OUTRO farmer: nenhum recálculo de A pode tocá-la.
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, p_ij, affinity_score, status)
+VALUES ('$FARMER_B','$CLI_2','cross_sell','$PROD_1', 8.0, 0.80, 'pendente');
+
+INSERT INTO public.farmer_bundle_recommendations
+  (farmer_id, customer_user_id, bundle_products, affinity_bundle, status, created_at)
+VALUES ('$FARMER_A','$CLI_1','[{"id":"x","name":"velho","price":10}]'::jsonb, 0.88, 'pendente', now() - interval '70 days');
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1b — O GUARD DE ORDEM DE APPLY (a migration aborta sem a dependência)
+# ══════════════════════════════════════════════════════════════════════════════
+# Provado ANTES de aplicar de verdade: numa base sem affinity_score, a migration
+# tem de recusar com instrução legível, não morrer com um 42703 críptico.
+echo "── guard de dependência (pré-apply) ──"
+P -q -c "ALTER TABLE public.farmer_recommendations DROP COLUMN affinity_score;"
+DEP=$(P -tA -f "$REPO_ROOT/supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql" 2>&1 || true)
+case "$DEP" in
+  *"DEPENDENCIA FALTANDO"*) ok "D1 migration aborta sem a 20260725121000, nomeando-a" ;;
+  *) bad "D1 migration NAO abortou sem affinity_score — veio: $(printf '%s' "$DEP" | head -c 160)" ;;
+esac
+P -q -c "ALTER TABLE public.farmer_recommendations ADD COLUMN affinity_score numeric;"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+# Idempotência: o founder pode re-colar (re-apply após falha parcial).
+P -q -f "$MIG"
+ok "I1 migration é idempotente (aplicada 2x sem erro)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED + GRANTS
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<SQL
+GRANT USAGE ON SCHEMA private TO authenticated;
+GRANT EXECUTE ON FUNCTION private.cap_carteira_escrever(uuid), private.cap_carteira_ler(uuid),
+                           private.carteira_visivel_para(uuid,uuid) TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.farmer_recommendations, public.farmer_bundle_recommendations TO authenticated;
+GRANT SELECT ON public.omie_products TO authenticated;
+SQL
+
+# payload de 2 linhas válidas para o FARMER_A
+LOTE_OK=$(cat <<JSON
+[{"customer_user_id":"$CLI_1","recommendation_type":"cross_sell","product_id":"$PROD_2","p_ij":4.4,"affinity_score":0.44,"complexity_factor":1,"cluster_volume_estimate":3},
+ {"customer_user_id":"$CLI_2","recommendation_type":"up_sell","product_id":"$PROD_1","p_ij":2.2,"affinity_score":0.22,"complexity_factor":1,"cluster_volume_estimate":1}]
+JSON
+)
+RUN_1='11111111-aaaa-aaaa-aaaa-111111111111'
+RUN_2='22222222-aaaa-aaaa-aaaa-222222222222'
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── asserts positivos ──"
+
+TOT_ANTES=$(Pq -c "SELECT count(*) FROM public.farmer_recommendations;")
+
+# P1 — a substituição roda e devolve o balanço (3 pendentes de A expiram, 2 entram).
+R=$(Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1',NULL,'$LOTE_OK'::jsonb);")
+echo "$R" > /tmp/farmer-r1.json
+eq "P1 expiradas" "$(printf '%s' "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin)["expiradas"])')" "3"
+eq "P2 inseridas" "$(printf '%s' "$R" | python3 -c 'import json,sys; print(json.load(sys.stdin)["inseridas"])')" "2"
+
+# P3 — EXPIRAR NÃO DELETA: o total só cresce (money-path: deleção exige prova positiva).
+TOT_DEPOIS=$(Pq -c "SELECT count(*) FROM public.farmer_recommendations;")
+eq "P3 nada foi deletado (total antes+2)" "$TOT_DEPOIS" "$((TOT_ANTES + 2))"
+
+# P4 — as expiradas carimbam expired_at E expired_by_run (rastreabilidade de "quem matou").
+eq "P4 expiradas carimbadas com o run que as aposentou" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE status='expirado' AND expired_at IS NOT NULL AND expired_by_run='$RUN_1';")" "3"
+
+# P5 — A LINHA COM DESFECHO É INTOCÁVEL (o invariante mais caro desta migration).
+eq "P5 linha 'aceito' sobreviveu intacta" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE status='aceito' AND accepted_at IS NOT NULL AND expired_at IS NULL;")" "1"
+
+# P6 — a carteira do OUTRO farmer não foi tocada.
+eq "P6 carteira do farmer B intacta" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_B' AND status='pendente';")" "1"
+
+# P7 — as novas linhas carregam o run_id da execução.
+eq "P7 novas linhas com run_id" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='$RUN_1' AND status='pendente';")" "2"
+
+# P8 — m_ij/lie ficam NULL mesmo com o payload tentando mandá-los (dinheiro não volta pelo browser).
+LOTE_DINHEIRO="[{\"customer_user_id\":\"$CLI_1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD_1\",\"p_ij\":1,\"affinity_score\":0.11,\"m_ij\":999,\"lie\":888}]"
+Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_2','$RUN_1','$LOTE_DINHEIRO'::jsonb);" >/dev/null
+eq "P8 m_ij/lie ignorados do payload (ficam NULL)" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='$RUN_2' AND m_ij IS NULL AND lie IS NULL;")" "1"
+
+# P9 — o BUG ORIGINAL: depois de 2 recálculos, o topo por afinidade é da geração NOVA.
+# Sem a migration, a legada (affinity 0.99) continuaria vencendo a nova (0.11) para sempre.
+eq "P9 topo do cliente = geração vigente, não a de 70 dias" \
+   "$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND customer_user_id='$CLI_1' AND status='pendente' ORDER BY affinity_score DESC NULLS LAST, created_at DESC LIMIT 1;")" "$RUN_2"
+
+# P10 — bundle: o CHECK alargado deixa 'expirado' entrar (sem a migration seria 23514 em runtime).
+RB=$(Pq -c "SELECT public.farmer_bundle_recomendacoes_substituir('$FARMER_A','$RUN_1',NULL,'[{\"customer_user_id\":\"$CLI_1\",\"bundle_products\":[{\"id\":\"y\",\"name\":\"novo\",\"price\":20}],\"affinity_bundle\":0.42,\"support\":0.1,\"confidence\":0.5,\"lift\":1.5,\"p_bundle\":3.3}]'::jsonb);")
+eq "P10 bundle expirou a geração anterior" "$(printf '%s' "$RB" | python3 -c 'import json,sys; print(json.load(sys.stdin)["expiradas"])')" "1"
+eq "P11 bundle 'expirado' aceito pelo CHECK" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_bundle_recommendations WHERE status='expirado' AND expired_at IS NOT NULL;")" "1"
+
+echo "── asserts negativos (SQLSTATE esperada + re-raise) ──"
+
+# helper: roda um bloco DO que espera uma SQLSTATE; imprime OK_<code> ou relança.
+espera_sqlstate() { # $1=nome  $2=sqlstate  $3=chamada SQL
+  local OUT
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM $3;
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION
+  WHEN SQLSTATE '$2' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_BARROU_CERTO*) ok "$1 (SQLSTATE $2)" ;;
+    *SENTINELA_NAO_BARROU*)   bad "$1 — NAO barrou (esperava $2)" ;;
+    *)                        bad "$1 — erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+}
+
+PEND_ANTES=$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente';")
+
+# N1 — lote vazio RECUSA (não "expira tudo e deixa o farmer sem oferta").
+espera_sqlstate "N1 lote vazio recusado" "FG003" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','[]'::jsonb)"
+
+# N2 — GUARD CAUSAL: geração vista ≠ vigente (dois recálculos sobrepostos) → recusa.
+espera_sqlstate "N2 corrida barrada pelo compare-and-swap" "FG006" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_1'::uuid,'$LOTE_OK'::jsonb)"
+
+# N3/N4/N5/N6 — validação do lote ANTES de expirar nada.
+espera_sqlstate "N3 afinidade NaN recusada" "FG007" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','[{\"customer_user_id\":\"$CLI_1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD_1\",\"affinity_score\":\"NaN\"}]'::jsonb)"
+espera_sqlstate "N4 afinidade Infinity recusada" "FG007" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','[{\"customer_user_id\":\"$CLI_1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD_1\",\"affinity_score\":\"Infinity\"}]'::jsonb)"
+espera_sqlstate "N5 afinidade negativa recusada" "FG007" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','[{\"customer_user_id\":\"$CLI_1\",\"recommendation_type\":\"cross_sell\",\"product_id\":\"$PROD_1\",\"affinity_score\":-1}]'::jsonb)"
+espera_sqlstate "N6 tipo de recomendação inválido recusado" "FG007" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','[{\"customer_user_id\":\"$CLI_1\",\"recommendation_type\":\"foo\",\"product_id\":\"$PROD_1\",\"affinity_score\":0.5}]'::jsonb)"
+espera_sqlstate "N7 farmer_id nulo recusado" "FG001" \
+  "public.farmer_recomendacoes_substituir(NULL,'$RUN_1','$RUN_2','$LOTE_OK'::jsonb)"
+espera_sqlstate "N8 payload não-array recusado" "FG002" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','{\"a\":1}'::jsonb)"
+
+# N9 — teto defensivo (o lote não pode ser ilimitado).
+espera_sqlstate "N9 teto de 50000 linhas" "FG004" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2',(SELECT jsonb_agg(jsonb_build_object('customer_user_id','$CLI_1','recommendation_type','cross_sell','product_id','$PROD_1','affinity_score',0.5)) FROM generate_series(1,50001)))"
+
+# N10 — TODAS as recusas acima deixaram as pendentes INTACTAS (nada foi expirado "no meio").
+eq "N10 nenhuma recusa expirou linha (pendentes intactas)" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente';")" "$PEND_ANTES"
+
+# N11 — CHECK de coerência na TABELA: 'expirado' sem expired_at é rejeitado (23514).
+# A invariante mora na TABELA, não só no writer: o próximo writer que marcar
+# 'expirado' sem carimbar a data some dos leitores sem deixar rastro de quando.
+R=$(P -tA 2>&1 -c "UPDATE public.farmer_recommendations SET status='expirado', expired_at=NULL WHERE farmer_id='$FARMER_B';" || true)
+case "$R" in
+  *farmer_recommendations_expirado_coerente*) ok "N11 CHECK barra 'expirado' sem expired_at (23514)" ;;
+  *) bad "N11 CHECK NAO barrou — veio: $(printf '%s' "$R" | head -c 160)" ;;
+esac
+
+echo "── asserts de autorização (RLS + gate) ──"
+
+# A1 — farmer B (sem cap) NÃO substitui a carteira de A.
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_B'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1','$RUN_2','$LOTE_OK'::jsonb);
+SQL
+)
+case "$R" in
+  *"Acesso negado"*) ok "A1 farmer B barrado ao mexer na carteira de A (42501)" ;;
+  *) bad "A1 farmer B NAO foi barrado — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A2 — o próprio farmer A CONSEGUE (a autorização não é fail-closed demais).
+GER_ATUAL=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_A'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT public.farmer_recomendacoes_substituir('$FARMER_A','33333333-aaaa-aaaa-aaaa-333333333333','$GER_ATUAL'::uuid,'$LOTE_OK'::jsonb);
+SQL
+)
+case "$R" in
+  *inseridas*) ok "A2 o próprio farmer A substitui a carteira dele" ;;
+  *) bad "A2 farmer A NAO conseguiu substituir — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A4 — SESSÃO SEM IDENTIDADE NENHUMA é barrada (regressão do three-valued logic).
+# A forma "óbvia" do gate, `IF NOT (a OR b OR c)`, NÃO barra aqui: sem JWT `auth.uid()` é
+# NULL, `p_farmer_id = auth.uid()` é NULL, a disjunção inteira vira NULL, e `IF NOT NULL`
+# não dispara em PL/pgSQL — o guard devolve nulo em vez de negar. Medido em prod:
+#   NOT (false OR NULL OR false)         => NULL
+#   (false OR NULL OR false) IS NOT TRUE => true
+# Este assert existe porque o harness inteiro rodava VERDE exatamente por esse buraco:
+# os positivos passavam sem identidade, e ninguém percebia que o gate não barrava.
+R=$(P -tA 2>&1 <<SQL || true
+SET test.role=''; SET test.uid='';
+DO \$\$
+BEGIN
+  PERFORM public.farmer_recomendacoes_substituir('$FARMER_A','88888888-aaaa-aaaa-aaaa-888888888888',NULL,'$LOTE_OK'::jsonb);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE '42501' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_BARROU_CERTO*) ok "A4 sessão sem identidade barrada (o gate fecha em TRUE, não em NOT-NULL)" ;;
+  *SENTINELA_NAO_BARROU*)   bad "A4 sessão SEM identidade PASSOU — o gate está em three-valued logic" ;;
+  *)                        bad "A4 erro inesperado: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A5 — INSERT direto de linha pendente sem run_id é REJEITADO pela trigger.
+# O compare-and-swap é convenção dos hooks; esta é a invariante da TABELA. Sem ela, uma
+# aba com o JS antigo grava pendente com run_id NULL, escapa da substituição e volta a
+# competir no topo — o bug original de volta por um writer que a RPC nem vê.
+R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, product_id, status) VALUES ('$FARMER_A','$CLI_1','cross_sell','$PROD_1','pendente');" || true)
+case "$R" in
+  *"exige run_id"*) ok "A5 trigger barra INSERT direto de pendente sem run_id (FG008)" ;;
+  *) bad "A5 INSERT direto NAO foi barrado — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A6 — mas a trigger NÃO atrapalha o histórico: linha com desfecho entra sem run_id.
+R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_recommendations (farmer_id, customer_user_id, recommendation_type, product_id, status, offered_at) VALUES ('$FARMER_A','$CLI_1','cross_sell','$PROD_1','ofertado', now());" || true)
+case "$R" in
+  *ERROR*) bad "A6 trigger barrou linha de HISTÓRICO (ofertado) — cedo demais: $(printf '%s' "$R" | head -c 160)" ;;
+  *) ok "A6 trigger só mira 'pendente' — linha de desfecho passa" ;;
+esac
+
+# A3 — anon não executa (REVOKE da migration).
+R=$(P -tA 2>&1 <<SQL || true
+SET ROLE anon;
+SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1',NULL,'$LOTE_OK'::jsonb);
+SQL
+)
+case "$R" in
+  *"permission denied"*|*"permissão negada"*) ok "A3 anon sem EXECUTE na RPC" ;;
+  *) bad "A3 anon NAO foi barrado — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3)
+# ══════════════════════════════════════════════════════════════════════════════
+# Sabotagem em MEMÓRIA (CREATE OR REPLACE derivado do .sql por perl), nunca no
+# arquivo do repo — árvore suja + `git checkout --` já destruiu fix uncommitted
+# aqui antes (money-path §9). Cada sabotagem PROVA que aplicou antes de julgar:
+# sabotagem que não casa nada devolve verde de código íntegro, que se lê como
+# "o assert não tem dente" e convida a enfraquecê-lo.
+echo "── falsificação ──"
+
+SAB="/tmp/farmer-sabotado-$$.sql"
+restaura() { P -q -f "$MIG"; }
+
+sabota() { # $1=nome  $2=expressão perl  $3=marca que TEM de aparecer no resultado
+  perl -0777 -pe "$2" "$MIG" > "$SAB"
+  if ! command grep -q -- "$3" "$SAB"; then
+    bad "SABOTAGEM $1 NAO APLICOU (padrão não casou) — falsificação INVÁLIDA"
+    return 1
+  fi
+  P -q -f "$SAB"
+  return 0
+}
+
+# F1 — remover o guard `AND status='pendente'` do UPDATE de expiração.
+#      Deve arrastar a linha com DESFECHO junto (P5 fica vermelho).
+if sabota "F1" "s/     AND status = 'pendente';\n  GET DIAGNOSTICS v_expiradas/     AND true;\n  GET DIAGNOSTICS v_expiradas/" "AND true;"; then
+  P -q -c "UPDATE public.farmer_recommendations SET status='aceito', expired_at=NULL, accepted_at=now() WHERE farmer_id='$FARMER_A' AND status='expirado' AND id=(SELECT id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='expirado' LIMIT 1);"
+  ACEITO_ANTES=$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='aceito';")
+  G=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','44444444-aaaa-aaaa-aaaa-444444444444',$([ -z "$G" ] && echo NULL || echo "'$G'"),'$LOTE_OK'::jsonb);" >/dev/null 2>&1 || true
+  eq_esperando_vermelho "P5 linha com desfecho preservada" \
+    "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='aceito';")" "$ACEITO_ANTES"
+  restaura
+fi
+
+# F2 — desligar o guard causal. A corrida (N2) deixa de ser barrada.
+if sabota "F2" "s/IF v_geracao_atual IS DISTINCT FROM p_geracao_vista THEN/IF false THEN/g" "IF false THEN"; then
+  G=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM public.farmer_recomendacoes_substituir('$FARMER_A','55555555-aaaa-aaaa-aaaa-555555555555','99999999-9999-9999-9999-999999999999'::uuid,'$LOTE_OK'::jsonb);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE 'FG006' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: sem o guard causal, a corrida PASSA (N2 seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: N2 barrou mesmo com o guard causal desligado" ;;
+    *) bad "F2 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+# F3 — enfraquecer a finitude para só o sinal (`>= 0`), a forma que o money-path
+#      documenta como falso-saneamento: NaN e Infinity passam.
+if sabota "F3" "s/     OR NOT \(\n          r\.affinity_score >= 0\n          AND r\.affinity_score < 'Infinity'::numeric\n          AND r\.affinity_score <> 'NaN'::numeric\n        \);/     OR r.affinity_score < 0;/" "OR r.affinity_score < 0;"; then
+  G=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM public.farmer_recomendacoes_substituir('$FARMER_A','66666666-aaaa-aaaa-aaaa-666666666666',$([ -z "$G" ] && echo NULL || echo "'$G'"),
+    '[{"customer_user_id":"$CLI_1","recommendation_type":"cross_sell","product_id":"$PROD_1","affinity_score":"NaN"}]'::jsonb);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE 'FG007' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: com só '>= 0', NaN entra no ranking (N3 seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: N3 barrou NaN mesmo com o guard reduzido a sinal" ;;
+    *) bad "F3 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+# F4 — trocar a expiração por DELETE. P3 (nada é deletado) tem de ficar vermelho.
+if sabota "F4" "s/  UPDATE public\.farmer_recommendations\n     SET status         = 'expirado',\n         expired_at     = clock_timestamp\(\),\n         expired_by_run = p_run_id,\n         updated_at     = clock_timestamp\(\)\n   WHERE farmer_id = p_farmer_id\n     AND status = 'pendente';/  DELETE FROM public.farmer_recommendations WHERE farmer_id = p_farmer_id AND status = 'pendente';/" "DELETE FROM public.farmer_recommendations WHERE farmer_id"; then
+  G=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  T_ANTES=$(Pq -c "SELECT count(*) FROM public.farmer_recommendations;")
+  N_LOTE=2
+  Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','77777777-aaaa-aaaa-aaaa-777777777777',$([ -z "$G" ] && echo NULL || echo "'$G'"),'$LOTE_OK'::jsonb);" >/dev/null 2>&1 || true
+  eq_esperando_vermelho "P3 nada foi deletado (total antes+2)" \
+    "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations;")" "$((T_ANTES + N_LOTE))"
+  restaura
+fi
+
+# F5 — o gate volta à forma "óbvia" `IF NOT (...)`. A4 tem de ficar VERMELHO: com NULL na
+# disjunção o RAISE nunca acontece, e uma sessão sem identidade nenhuma passa direto.
+# Sabota AS DUAS RPCs (/g). O helper `sabota` valida por marca PRESENTE, e aqui o que
+# prova a aplicação é a forma NOVA estar AUSENTE — por isso a checagem é feita à mão,
+# nos dois sentidos (a antiga apareceu E a nova sumiu). Sabotagem parcial seria pior que
+# nenhuma: mediria a RPC ainda íntegra e devolveria verde de código sabotado.
+perl -0777 -pe "s/  IF \(\n    coalesce\(auth\.role\(\), ''\) = 'service_role'\n    OR p_farmer_id = auth\.uid\(\)\n    OR coalesce\(private\.cap_carteira_escrever\(auth\.uid\(\)\), false\)\n  \) IS NOT TRUE THEN/  IF NOT (\n    coalesce(auth.role(), '') = 'service_role'\n    OR p_farmer_id = auth.uid()\n    OR private.cap_carteira_escrever(auth.uid())\n  ) THEN/g" "$MIG" > "$SAB"
+if ! command grep -q "IF NOT (" "$SAB"; then
+  bad "SABOTAGEM F5 NAO APLICOU (padrão não casou) — falsificação INVÁLIDA"
+elif command grep -q "IS NOT TRUE THEN" "$SAB"; then
+  bad "SABOTAGEM F5 PARCIAL (sobrou IS NOT TRUE) — falsificação INVÁLIDA"
+else
+  P -q -f "$SAB"
+  # A geração vigente REAL: sem ela o CAS recusaria com FG006 e o `WHEN OTHERS THEN RAISE`
+  # relançaria — o assert leria "erro inesperado" e o vermelho seria do harness, não da
+  # sabotagem. O objetivo aqui é o gate de AUTORIZAÇÃO, então todo o resto tem de estar
+  # coerente para o fluxo chegar até ele e passar.
+  G=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  OUT=$(P -tA 2>&1 <<SQL || true
+SET test.role=''; SET test.uid='';
+DO \$\$
+BEGIN
+  PERFORM public.farmer_recomendacoes_substituir('$FARMER_A','99999999-aaaa-aaaa-aaaa-999999999999',$([ -z "$G" ] && echo NULL || echo "'$G'"),'$LOTE_OK'::jsonb);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE '42501' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: com 'IF NOT (...)' a sessão sem identidade PASSA (A4 seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: A4 barrou mesmo com o gate em three-valued logic" ;;
+    *) bad "F5 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+rm -f "$SAB"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,15 +21,15 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **471** custom migrations totais
-- **1598** objetos esperados (criados por estas migrations)
+- **472** custom migrations totais
+- **1605** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 482
+  - `function`: 485
   - `rls_policy`: 398
-  - `index`: 238
+  - `index`: 240
   - `cron_job`: 164
   - `table`: 154
-  - `trigger`: 84
+  - `trigger`: 86
   - `view`: 74
   - `enum_value`: 4
 
@@ -3931,6 +3931,18 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `table` | `public.data_health_watchdog_estado` | — |
 | `rls_policy` | `public.data_health_watchdog_estado_select_staff` | `data_health_watchdog_estado` |
 | `rls_policy` | `public.data_health_watchdog_estado_service_all` | `data_health_watchdog_estado` |
+
+### `20260814223445_farmer_recomendacoes_geracao_vigente.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.farmer_rec_exige_run_id` | — |
+| `function` | `public.farmer_recomendacoes_substituir` | — |
+| `function` | `public.farmer_bundle_recomendacoes_substituir` | — |
+| `index` | `public.idx_frec_farmer_status_pendente` | `farmer_recommendations` |
+| `index` | `public.idx_fbrec_farmer_status_pendente` | `farmer_bundle_recommendations` |
+| `trigger` | `public.trg_frec_exige_run_id` | `farmer_recommendations` |
+| `trigger` | `public.trg_fbrec_exige_run_id` | `farmer_bundle_recommendations` |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 471
+-- Total de custom migrations: 472
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -512,7 +512,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260814000125', 'reposicao_pos_frescor_marcador', '20260814000125_reposicao_pos_frescor_marcador.sql'),
   ('20260814022626', 'reposicao_po_inexistente_antes_de', '20260814022626_reposicao_po_inexistente_antes_de.sql'),
   ('20260814160441', 'fu4f_fase3_afinidade_colunas_reaplica', '20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql'),
-  ('20260814222000', 'data_health_watchdog_reemissao', '20260814222000_data_health_watchdog_reemissao.sql')
+  ('20260814222000', 'data_health_watchdog_reemissao', '20260814222000_data_health_watchdog_reemissao.sql'),
+  ('20260814223445', 'farmer_recomendacoes_geracao_vigente', '20260814223445_farmer_recomendacoes_geracao_vigente.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2099,7 +2100,14 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('data_health_watchdog_reemissao', 'function', 'public', 'data_health_watchdog', ''),
   ('data_health_watchdog_reemissao', 'table', 'public', 'data_health_watchdog_estado', ''),
   ('data_health_watchdog_reemissao', 'rls_policy', 'public', 'data_health_watchdog_estado_select_staff', 'data_health_watchdog_estado'),
-  ('data_health_watchdog_reemissao', 'rls_policy', 'public', 'data_health_watchdog_estado_service_all', 'data_health_watchdog_estado')
+  ('data_health_watchdog_reemissao', 'rls_policy', 'public', 'data_health_watchdog_estado_service_all', 'data_health_watchdog_estado'),
+  ('farmer_recomendacoes_geracao_vigente', 'function', 'public', 'farmer_rec_exige_run_id', ''),
+  ('farmer_recomendacoes_geracao_vigente', 'function', 'public', 'farmer_recomendacoes_substituir', ''),
+  ('farmer_recomendacoes_geracao_vigente', 'function', 'public', 'farmer_bundle_recomendacoes_substituir', ''),
+  ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_frec_farmer_status_pendente', 'farmer_recommendations'),
+  ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_fbrec_farmer_status_pendente', 'farmer_bundle_recommendations'),
+  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_frec_exige_run_id', 'farmer_recommendations'),
+  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3734,7 +3742,14 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('data_health_watchdog_reemissao', 'function', 'public', 'data_health_watchdog', ''),
   ('data_health_watchdog_reemissao', 'table', 'public', 'data_health_watchdog_estado', ''),
   ('data_health_watchdog_reemissao', 'rls_policy', 'public', 'data_health_watchdog_estado_select_staff', 'data_health_watchdog_estado'),
-  ('data_health_watchdog_reemissao', 'rls_policy', 'public', 'data_health_watchdog_estado_service_all', 'data_health_watchdog_estado')
+  ('data_health_watchdog_reemissao', 'rls_policy', 'public', 'data_health_watchdog_estado_service_all', 'data_health_watchdog_estado'),
+  ('farmer_recomendacoes_geracao_vigente', 'function', 'public', 'farmer_rec_exige_run_id', ''),
+  ('farmer_recomendacoes_geracao_vigente', 'function', 'public', 'farmer_recomendacoes_substituir', ''),
+  ('farmer_recomendacoes_geracao_vigente', 'function', 'public', 'farmer_bundle_recomendacoes_substituir', ''),
+  ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_frec_farmer_status_pendente', 'farmer_recommendations'),
+  ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_fbrec_farmer_status_pendente', 'farmer_bundle_recommendations'),
+  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_frec_exige_run_id', 'farmer_recommendations'),
+  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations')
 )
 SELECT
   e.migration,

--- a/src/__tests__/afinidade-nao-e-dinheiro-gate.test.ts
+++ b/src/__tests__/afinidade-nao-e-dinheiro-gate.test.ts
@@ -116,16 +116,49 @@ describe('gate: afinidade não é dinheiro', () => {
     expect(semFiltro).toEqual([]);
   });
 
-  it('G4 os writers gravam a afinidade na coluna DEDICADA e o LIE explicitamente NULL', () => {
+  it('G4 os writers gravam a afinidade na coluna DEDICADA e o LIE fica NULL — garantido no SERVIDOR', () => {
     // Pin ESPECÍFICO, não de forma: um gate genérico ("existe algum .order") ficaria verde se
     // alguém trocasse a coluna de volta. Quando a chave É a defesa, pine a chave.
+    //
+    // ⚠️ A garantia MUDOU DE LUGAR em 2026-08-15 (migration 20260814223445) e o pin acompanhou.
+    // Antes o browser mandava `lie: null` explícito no payload do upsert, e o gate lia isso.
+    // Hoje os writers vão pela RPC `farmer_*_substituir`, que fixa `NULL, NULL` em m_ij/lie no
+    // próprio INSERT — o payload nem carrega as colunas de dinheiro. Isso é ESTRITAMENTE MAIS
+    // FORTE: antes um browser adulterado podia mandar `lie: 999` e o upsert gravaria; agora o
+    // servidor descarta o que vier. Repinar no payload teria sido enfraquecer o gate para o
+    // formato antigo; o certo é pinar onde a defesa REALMENTE mora agora.
     const cross = semComentarios(readFileSync(resolve(RAIZ, 'src/hooks/useCrossSellEngine.ts'), 'utf8'));
-    expect(cross).toMatch(/lie:\s*null/);
     expect(cross).toMatch(/affinity_score:\s*rec\.affinityScore/);
+    // O browser NÃO manda mais dinheiro no payload — nem como null.
+    expect(cross).not.toMatch(/\blie:\s*/);
+    expect(cross).not.toMatch(/\bm_ij:\s*/);
 
     const bundle = semComentarios(readFileSync(resolve(RAIZ, 'src/hooks/useBundleEngine.ts'), 'utf8'));
-    expect(bundle).toMatch(/lie_bundle:\s*null/);
     expect(bundle).toMatch(/affinity_bundle:\s*bundle\.affinityBundle/);
+    expect(bundle).not.toMatch(/\blie_bundle:\s*/);
+    expect(bundle).not.toMatch(/\bm_bundle:\s*/);
+
+    // E a RPC que passou a ser a dona da garantia: o INSERT fixa NULL nas duas colunas de
+    // dinheiro. Sem este assert a propriedade ficaria SEM dono — os `not.toMatch` acima
+    // sozinhos provariam apenas que o browser parou de mandar, não que o servidor zera.
+    // ⚠️ `semComentarios` só conhece `//` e `/* */` — comentário SQL é `--`, e a migration
+    // explica o bug em prosa exatamente ENTRE `r.p_ij,` e o `NULL, NULL`. Sem tirar os `--`
+    // o regex não casa e o gate reprova código íntegro (falso-VERMELHO). É a mesma lição do
+    // §"o ALVO mente": todo predicado textual mede o CÓDIGO, nunca a prosa que o descreve —
+    // só que aqui a linguagem do alvo é outra.
+    const semComentariosSql = (s: string) =>
+      s.split('\n').filter((l) => !/^\s*--/.test(l)).join('\n');
+    const mig = semComentariosSql(
+      readFileSync(resolve(RAIZ, 'supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql'), 'utf8'),
+    );
+    // cross-sell: `r.p_ij,\n    NULL, NULL,\n    r.affinity_score`
+    expect(mig).toMatch(/r\.p_ij,\s*NULL,\s*NULL,\s*r\.affinity_score/);
+    // bundle: `r.p_bundle,\n    NULL, NULL,\n    r.affinity_bundle`
+    expect(mig).toMatch(/r\.p_bundle,\s*NULL,\s*NULL,\s*r\.affinity_bundle/);
+    // e as colunas de dinheiro seguem NA lista de INSERT (se saíssem, o DEFAULT 0 da tabela
+    // voltaria a preencher — que é exatamente o número fabricado que este gate existe p/ barrar).
+    expect(mig).toMatch(/p_ij,\s*m_ij,\s*lie,\s*affinity_score/);
+    expect(mig).toMatch(/p_bundle,\s*m_bundle,\s*lie_bundle,\s*affinity_bundle/);
   });
 
   it('G5 CALIBRAÇÃO: os padrões casam a forma PRÉ-fix e não casam a PÓS-fix', () => {

--- a/src/components/farmer/copilot/OfertaCruaCard.tsx
+++ b/src/components/farmer/copilot/OfertaCruaCard.tsx
@@ -59,7 +59,12 @@ export function OfertaCruaCard({ customerId }: Props) {
         // Sem afinidade, melhor não haver oferta crua — ela volta no recálculo do motor.
         .not('affinity_bundle', 'is', null)
         .order('affinity_bundle', { ascending: false, nullsFirst: false })
+        // ⚠️ `created_at` deixou de desempatar: desde a migration 20260814223445 a geração
+        // inteira entra num único INSERT, e `now()` é o instante da TRANSAÇÃO — todas as
+        // linhas do run compartilham o mesmo carimbo. `id` é a PK: última chave, sempre
+        // total (achado do challenge Codex xhigh).
         .order('created_at', { ascending: false }) // desempate determinístico (scores empatam)
+        .order('id', { ascending: false })
         .limit(1)
         .maybeSingle();
       return data ?? null;

--- a/src/components/intelligence/IntelligenceManagerialTab.tsx
+++ b/src/components/intelligence/IntelligenceManagerialTab.tsx
@@ -35,6 +35,8 @@ interface RecoLinha {
  * exatamente no dia em que o loop de feedback existir que a coluna passaria a mentir em silêncio.
  */
 const STATUS_ACEITO = 'aceito';
+/** Geração aposentada por um recálculo (migration 20260814223445) — nunca chegou a ser ofertada. */
+const STATUS_EXPIRADO = 'expirado';
 
 function IntelligenceManagerialTabImpl() {
   const { data: allScores, isLoading, isError } = useQuery({
@@ -103,6 +105,13 @@ function IntelligenceManagerialTabImpl() {
   }, {} as Record<string, typeof allScores>) || {};
 
   const recoAdoption = recommendations?.reduce((acc, r) => {
+    // `expirado` FORA do denominador. Desde 20260814223445 o recálculo aposenta a geração
+    // anterior em vez de empilhá-la, e uma recomendação que o motor descartou antes de
+    // chegar ao vendedor não é uma "não-adoção" dele — é uma não-oferta. Contá-la infla o
+    // denominador a cada recálculo e faz a taxa de adoção despencar sozinha, num painel
+    // que COMPARA vendedores. Mesmo espírito do `adocaoIndisponivel` abaixo: não acusar
+    // ninguém com um número que a nossa mecânica fabricou.
+    if (r.status === STATUS_EXPIRADO) return acc;
     if (!acc[r.farmer_id]) acc[r.farmer_id] = { total: 0, accepted: 0 };
     acc[r.farmer_id].total++;
     if (r.status === STATUS_ACEITO) acc[r.farmer_id].accepted++;

--- a/src/hooks/__tests__/bundle-custo-fora-do-browser.test.tsx
+++ b/src/hooks/__tests__/bundle-custo-fora-do-browser.test.tsx
@@ -28,6 +28,14 @@ const rpcsChamadas: string[] = [];
 // `linha` pode ser UMA linha ou um LOTE: o engine grava as recomendações num único
 // insert com array (#1594) e as regras de associação linha a linha.
 const inserts: Array<{ tabela: string; linha: Record<string, unknown> | Record<string, unknown>[] }> = [];
+/** A persistência virou RPC transacional (migration 20260814223445): o payload que antes
+ *  se lia do `.insert()` agora chega como `p_linhas` aqui. */
+const rpcArgs: Array<{ nome: string; args: Record<string, unknown> }> = [];
+const RPC_SUBSTITUIR = 'farmer_bundle_recomendacoes_substituir';
+const linhasPersistidas = (): Record<string, unknown>[] =>
+  rpcArgs
+    .filter((c) => c.nome === RPC_SUBSTITUIR)
+    .flatMap((c) => (c.args.p_linhas as Record<string, unknown>[]) ?? []);
 
 let rpcResultado: { data: unknown; error: unknown } = { data: [], error: null };
 
@@ -97,9 +105,11 @@ function stubChain(tabela: string): unknown {
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: (tabela: string) => { tabelasLidas.push(tabela); return stubChain(tabela); },
-    rpc: (nome: string) => {
+    rpc: (nome: string, args?: Record<string, unknown>) => {
       rpcsChamadas.push(nome);
-      return { then: (resolve: (v: unknown) => void) => resolve(rpcResultado) };
+      rpcArgs.push({ nome, args: args ?? {} });
+      const r = nome === RPC_SUBSTITUIR ? { data: null, error: null } : rpcResultado;
+      return { then: (resolve: (v: unknown) => void) => resolve(r) };
     },
   },
 }));
@@ -115,6 +125,7 @@ beforeEach(() => {
   tabelasLidas.length = 0;
   rpcsChamadas.length = 0;
   inserts.length = 0;
+  rpcArgs.length = 0;
   rpcResultado = { data: [{ product_id: SKU_B }, { product_id: SKU_C }], error: null };
   impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'farmer-1' });
 });
@@ -135,6 +146,7 @@ describe('useBundleEngine — custo fora do browser', () => {
 
     expect(result.current.customerBundles.flatMap((c) => c.bundles)).toEqual([]);
     expect(inserts.filter((i) => i.tabela === 'farmer_bundle_recommendations')).toEqual([]);
+    expect(rpcsChamadas).not.toContain(RPC_SUBSTITUIR); // não expira a geração vigente
   });
 
   it('C: não lê product_costs — consulta a RPC', async () => {
@@ -149,12 +161,10 @@ describe('useBundleEngine — custo fora do browser', () => {
     const { result } = renderHook(() => useBundleEngine());
     await act(async () => { await result.current.calculateBundles(); });
 
-    // O insert é EM LOTE (uma chamada com N linhas — #1594), então achatar é obrigatório:
-    // sem o flat, `linha` seria o próprio array, `linha.bundle_products` viria `undefined` e
-    // o laço abaixo rodaria zero vez — o assert passaria sem olhar produto nenhum.
-    const linhas = inserts
-      .filter((i) => i.tabela === 'farmer_bundle_recommendations')
-      .flatMap((i) => (Array.isArray(i.linha) ? i.linha : [i.linha]));
+    // A chamada é EM LOTE (uma RPC com N linhas), então achatar é obrigatório: sem o flat,
+    // `linha` seria o próprio array, `linha.bundle_products` viria `undefined` e o laço
+    // abaixo rodaria zero vez — o assert passaria sem olhar produto nenhum.
+    const linhas = linhasPersistidas();
     expect(linhas.length).toBeGreaterThan(0); // controle positivo: houve o que gravar
     for (const linha of linhas) {
       const produtos = (linha.bundle_products ?? []) as Record<string, unknown>[];
@@ -170,9 +180,7 @@ describe('useBundleEngine — custo fora do browser', () => {
     const { result } = renderHook(() => useBundleEngine());
     await act(async () => { await result.current.calculateBundles(); });
 
-    const linhas = inserts
-      .filter((i) => i.tabela === 'farmer_bundle_recommendations')
-      .flatMap((i) => (Array.isArray(i.linha) ? i.linha : [i.linha]));
+    const linhas = linhasPersistidas();
     expect(linhas.length).toBeGreaterThan(0); // controle positivo: houve o que gravar
     for (const linha of linhas) {
       // Três consumidores FORA deste módulo leem o VALOR de `lie_bundle`, não só a ordem:
@@ -181,7 +189,11 @@ describe('useBundleEngine — custo fora do browser', () => {
       // `generate-tactical-plan` o injeta no prompt do LLM. Com a afinidade (~0,0094) ali, o
       // card anunciaria "R$ 0,01" de LIE e ~R$ 0,02/h onde os planos de prod registram
       // R$ 1.250,50 / R$ 800. Ordenar por afinidade segue certo — na coluna própria.
-      expect(linha.lie_bundle ?? null).toBeNull();
+      // A garantia migrou para o servidor: a RPC fixa NULL em m_bundle/lie_bundle no INSERT,
+      // e a coluna nem sobe do browser. Asserto a AUSÊNCIA da chave — `?? null` passaria
+      // trivialmente numa chave inexistente, virando teatro.
+      expect(Object.prototype.hasOwnProperty.call(linha, 'lie_bundle')).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(linha, 'm_bundle')).toBe(false);
       expect(typeof linha.affinity_bundle).toBe('number');
       expect(Number(linha.affinity_bundle)).toBeGreaterThan(0);
     }

--- a/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
+++ b/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
@@ -100,11 +100,16 @@ function dadosDa(tabela: string): unknown[] {
   }
 }
 
-const ehInsertDeRecomendacao = (q: Q) =>
+/** Desde a migration 20260814223445 a persistência dos bundles não é mais `.insert()` na
+ *  tabela: é a RPC que EXPIRA a geração anterior e insere a nova numa transação só. O que
+ *  este arquivo mede (a falha não pode passar calada) não mudou — mudou onde ela ocorre. */
+const RPC_SUBSTITUIR = 'farmer_bundle_recomendacoes_substituir';
+
+/** Nenhum insert direto deve sobrar nesta tabela — se voltar, o empilhamento volta com ele. */
+const ehInsertDiretoDeRecomendacao = (q: Q) =>
   q.table === 'farmer_bundle_recommendations' && q.metodos.includes('insert');
 
 function respostaDe(q: Q) {
-  if (ehInsertDeRecomendacao(q) && insertRecsFalha) return { data: null, error: ERRO_INSERT };
   return { data: dadosDa(q.table), error: null, count: 0 };
 }
 
@@ -134,6 +139,11 @@ vi.mock('@/integrations/supabase/client', () => ({
       rpcs.push({ nome, args });
       // Pós-#1520 o engine pergunta quais SKUs são vendáveis em vez de baixar custo.
       if (nome === 'get_skus_margem_positiva') return Promise.resolve({ data: VENDAVEIS, error: null });
+      if (nome === RPC_SUBSTITUIR) {
+        return Promise.resolve(
+          insertRecsFalha ? { data: null, error: ERRO_INSERT } : { data: { expiradas: 0, inseridas: 2 }, error: null },
+        );
+      }
       if (regrasFalham) return Promise.resolve({ data: null, error: ERRO_RPC });
       return Promise.resolve({ data: 2, error: null });
     },
@@ -159,11 +169,11 @@ beforeEach(() => {
   vi.spyOn(console, 'error').mockImplementation(() => {});
 });
 
-const insertsDeRecomendacao = () => queries.filter(ehInsertDeRecomendacao);
+const insertsDeRecomendacao = () => rpcs.filter((r) => r.nome === RPC_SUBSTITUIR);
 
 /** Linhas efetivamente enviadas, somando lote e chamada-a-chamada. */
 const linhasEnviadas = () =>
-  insertsDeRecomendacao().flatMap((q) => q.payloads.flatMap((p) => (Array.isArray(p) ? p : [p])));
+  insertsDeRecomendacao().flatMap((r) => (r.args.p_linhas as Record<string, unknown>[]) ?? []);
 
 const avisos = () => toastMock.warning.mock.calls.map((c) => String(c[0]));
 
@@ -181,7 +191,7 @@ describe('useBundleEngine — a gravação das recomendações de bundle não fa
     expect(result.current.customerBundles.length).toBeGreaterThan(0);
   });
 
-  it('INSERT falhando NÃO emite toast de sucesso — o aviso cita as recomendações', async () => {
+  it('a gravação falhando NÃO emite toast de sucesso — o aviso cita as recomendações', async () => {
     insertRecsFalha = true;
     await calcular();
 
@@ -204,13 +214,32 @@ describe('useBundleEngine — a gravação das recomendações de bundle não fa
     expect(avisos()[0]).toContain('anteriores seguem valendo');
   });
 
-  it('grava as recomendações num ÚNICO insert em lote, não uma por vez', async () => {
+  it('grava as recomendações numa ÚNICA chamada em lote, não uma por vez', async () => {
     await calcular();
 
     // As linhas são independentes: N round-trips não compram nada e multiplicam a
     // janela de falha parcial (ficar com metade das recomendações gravadas).
     expect(insertsDeRecomendacao()).toHaveLength(1);
     expect(linhasEnviadas()).toHaveLength(2);
+  });
+
+  it('NÃO resta insert direto na tabela — o empilhamento voltaria com ele', async () => {
+    await calcular();
+
+    // Um `.insert()` direto não expira a geração anterior: é exatamente o writer que a
+    // migration 20260814223445 aposentou. Se alguém reintroduzir um (por conveniência, ou
+    // resolvendo conflito pelo lado errado), a substituição vira empilhamento de novo e
+    // nenhum outro assert deste arquivo perceberia — todos medem a RPC.
+    expect(queries.filter(ehInsertDiretoDeRecomendacao)).toHaveLength(0);
+  });
+
+  it('a chamada leva run_id e a geração vista (o compare-and-swap da corrida)', async () => {
+    await calcular();
+
+    const chamada = insertsDeRecomendacao()[0];
+    expect(chamada.args.p_farmer_id).toBe(FARMER);
+    expect(String(chamada.args.p_run_id)).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(Object.prototype.hasOwnProperty.call(chamada.args, 'p_geracao_vista')).toBe(true);
   });
 
   it('caminho feliz mantém o toast de sucesso', async () => {
@@ -220,7 +249,7 @@ describe('useBundleEngine — a gravação das recomendações de bundle não fa
     expect(toastMock.warning).not.toHaveBeenCalled();
   });
 
-  it('INSERT falhando não some com os bundles da tela — só a tabela fica para trás', async () => {
+  it('a gravação falhando não some com os bundles da tela — só a tabela fica para trás', async () => {
     insertRecsFalha = true;
     const result = await calcular();
 

--- a/src/hooks/__tests__/cross-sell-custo-fora-do-browser.test.tsx
+++ b/src/hooks/__tests__/cross-sell-custo-fora-do-browser.test.tsx
@@ -25,9 +25,22 @@ import { renderHook, act } from '@testing-library/react';
 const tabelasLidas: string[] = [];
 const rpcsChamadas: string[] = [];
 const upserts: Array<{ tabela: string; linhas: Record<string, unknown>[] }> = [];
+/** Args de cada RPC — a persistência virou `farmer_recomendacoes_substituir`, então o
+ *  payload que antes se lia do `.upsert()` agora chega aqui (migration 20260814223445). */
+const rpcArgs: Array<{ nome: string; args: Record<string, unknown> }> = [];
 
 /** Resultado da RPC, trocável por teste (data null + error = a RPC falhou). */
 let rpcResultado: { data: unknown; error: unknown } = { data: [], error: null };
+/** Resultado da RPC de SUBSTITUIÇÃO, separado: um teste precisa dela falhando com o
+ *  get_skus_margem_positiva OK, e um resultado único não permitiria isso. */
+let rpcSubstituirResultado: { data: unknown; error: unknown } = { data: null, error: null };
+const RPC_SUBSTITUIR = 'farmer_recomendacoes_substituir';
+
+/** Linhas que a RPC de substituição recebeu (o payload persistido). */
+const linhasPersistidas = (): Record<string, unknown>[] =>
+  rpcArgs
+    .filter((c) => c.nome === RPC_SUBSTITUIR)
+    .flatMap((c) => (c.args.p_linhas as Record<string, unknown>[]) ?? []);
 
 const SKU_COMPRADO = 'sku-ja-comprado';
 const SKU_NOVO = 'sku-vendavel-novo';
@@ -90,9 +103,11 @@ function stubChain(tabela: string): unknown {
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
     from: (tabela: string) => { tabelasLidas.push(tabela); return stubChain(tabela); },
-    rpc: (nome: string) => {
+    rpc: (nome: string, args?: Record<string, unknown>) => {
       rpcsChamadas.push(nome);
-      return { then: (resolve: (v: unknown) => void) => resolve(rpcResultado) };
+      rpcArgs.push({ nome, args: args ?? {} });
+      const r = nome === RPC_SUBSTITUIR ? rpcSubstituirResultado : rpcResultado;
+      return { then: (resolve: (v: unknown) => void) => resolve(r) };
     },
   },
 }));
@@ -107,7 +122,9 @@ beforeEach(() => {
   tabelasLidas.length = 0;
   rpcsChamadas.length = 0;
   upserts.length = 0;
+  rpcArgs.length = 0;
   rpcResultado = { data: [{ product_id: SKU_NOVO }], error: null };
+  rpcSubstituirResultado = { data: null, error: null };
   impMock.mockReturnValue({ isImpersonating: false, effectiveUserId: 'farmer-1' });
 });
 
@@ -128,6 +145,7 @@ describe('useCrossSellEngine — custo fora do browser', () => {
     // Degradar para "recomenda tudo" poria produto de PREJUÍZO no topo da lista da vendedora.
     expect(result.current.recommendations).toEqual([]);
     expect(upserts).toEqual([]);
+    expect(rpcsChamadas).not.toContain(RPC_SUBSTITUIR); // não expira a geração vigente
 
     // ...mas fail-closed CALADO é o defeito do #1606 num caminho novo: lista vazia por falha
     // fica indistinguível de "não há o que recomendar". A falha tem de ser DECLARADA, e o estado
@@ -144,20 +162,24 @@ describe('useCrossSellEngine — custo fora do browser', () => {
     expect(rpcsChamadas).toContain('get_skus_margem_positiva');
   });
 
-  it('D: a persistência não grava m_ij (m_ij ÷ cluster_volume_estimate = margem unitária)', async () => {
+  it('D: o payload não carrega m_ij (m_ij ÷ cluster_volume_estimate = margem unitária)', async () => {
     const { result } = renderHook(() => useCrossSellEngine());
     await act(async () => { await result.current.calculateRecommendations(); });
 
-    const linhas = upserts.filter((u) => u.tabela === 'farmer_recommendations').flatMap((u) => u.linhas);
+    const linhas = linhasPersistidas();
     expect(linhas.length).toBeGreaterThan(0); // controle positivo: houve o que gravar
-    for (const linha of linhas) expect(linha.m_ij ?? null).toBeNull();
+    // Antes o payload mandava `m_ij: null` explícito (o upsert do PostgREST preserva coluna
+    // ausente). Com a RPC a coluna nem viaja: quem fixa NULL é o INSERT server-side. Asserto a
+    // AUSÊNCIA da chave, não o valor null — `linha.m_ij ?? null` passaria trivialmente numa
+    // chave inexistente e o assert viraria teatro.
+    for (const linha of linhas) expect(Object.prototype.hasOwnProperty.call(linha, 'm_ij')).toBe(false);
   });
 
-  it('E: a afinidade vai na coluna DEDICADA — `lie` fica NULL (quem lê `lie` lê DINHEIRO)', async () => {
+  it('E: a afinidade vai na coluna DEDICADA e o dinheiro não sobe do browser', async () => {
     const { result } = renderHook(() => useCrossSellEngine());
     await act(async () => { await result.current.calculateRecommendations(); });
 
-    const linhas = upserts.filter((u) => u.tabela === 'farmer_recommendations').flatMap((u) => u.linhas);
+    const linhas = linhasPersistidas();
     expect(linhas.length).toBeGreaterThan(0); // controle positivo: houve o que gravar
     for (const linha of linhas) {
       // `lie` é Lucro Incremental Esperado em REAIS, e nem todo consumidor apenas ORDENA por
@@ -166,9 +188,36 @@ describe('useCrossSellEngine — custo fora do browser', () => {
       // `{ style: 'currency', currency: 'BRL' }` e divide por hora de ligação. Guardar um score
       // adimensional (~0,009) numa coluna de dinheiro exibe "R$ 0,01" de lucro esperado.
       // Ordenar por afinidade continua sendo o desejado — muda a COLUNA, não a intenção.
-      expect(linha.lie ?? null).toBeNull();
+      expect(Object.prototype.hasOwnProperty.call(linha, 'lie')).toBe(false);
       expect(typeof linha.affinity_score).toBe('number');
       expect(Number(linha.affinity_score)).toBeGreaterThan(0);
     }
+  });
+
+  it('F: a persistência SUBSTITUI a geração — manda run_id e a geração vista (compare-and-swap)', async () => {
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    const chamada = rpcArgs.find((c) => c.nome === RPC_SUBSTITUIR);
+    expect(chamada).toBeDefined();
+    expect(chamada!.args.p_farmer_id).toBe('farmer-1');
+    // run_id novo a cada execução, para a linha saber de qual recálculo veio.
+    expect(typeof chamada!.args.p_run_id).toBe('string');
+    expect(String(chamada!.args.p_run_id)).toMatch(/^[0-9a-f-]{36}$/i);
+    // Cenário semeia `farmer_recommendations: []` → não há geração vigente → NULL casa NULL
+    // na RPC. O que importa aqui é que o parâmetro EXISTE: sem ele a RPC perderia o
+    // compare-and-swap e dois recálculos sobrepostos voltariam a se sobrescrever.
+    expect(Object.prototype.hasOwnProperty.call(chamada!.args, 'p_geracao_vista')).toBe(true);
+    expect(chamada!.args.p_geracao_vista).toBeNull();
+  });
+
+  it('G: na lente "Ver como" NÃO persiste (o master inspeciona, não regrava a carteira do alvo)', async () => {
+    impMock.mockReturnValue({ isImpersonating: true, effectiveUserId: 'outro-farmer' });
+    const { result } = renderHook(() => useCrossSellEngine());
+    await act(async () => { await result.current.calculateRecommendations(); });
+
+    // Sem este assert, expirar-por-farmer na lente apagaria a geração vigente de OUTRA
+    // vendedora — o desenho novo torna a regressão mais cara que na época do upsert.
+    expect(rpcsChamadas).not.toContain(RPC_SUBSTITUIR);
   });
 });

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -5,6 +5,7 @@ import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { toast } from 'sonner';
 import { margemConhecida } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
+import { mensagemDeErro } from '@/lib/erro-mensagem';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AssociationRule {
@@ -160,6 +161,30 @@ export const useBundleEngine = () => {
     setLoading(true);
 
     try {
+      // 0. Identidade desta EXECUÇÃO + a geração de bundles que ela substitui.
+      // Lido ANTES do snapshot (money-path §10: reivindicar depois deixa a corrida
+      // aberta pela porta de trás). Espelha useCrossSellEngine — ver o racional lá.
+      const runId = crypto.randomUUID();
+      let geracaoVista: string | null = null;
+      if (!isImpersonating) {
+        // Mesma ordem que a RPC usa para eleger a geração vigente (created_at desc, id desc).
+        const { data: vigente, error: erroVigente } = await supabase
+          .from('farmer_bundle_recommendations')
+          .select('run_id')
+          .eq('farmer_id', effectiveUserId)
+          .eq('status', 'pendente')
+          .order('created_at', { ascending: false })
+          .order('id', { ascending: false })
+          .limit(1);
+        if (erroVigente) {
+          throw new Error(
+            mensagemDeErro(erroVigente) ??
+              'Não consegui ler a geração vigente de bundles — nada foi recalculado.',
+          );
+        }
+        geracaoVista = vigente?.[0]?.run_id ?? null;
+      }
+
       // 1. Load data with fallback for super_admin
       // Loop MANUAL com o mesmo defeito que o #1545 tirou do `fetchAllPages` — por não CHAMAR
       // o helper, ficou de fora daquele grep: descartava o `error`, tratava `data: null` como
@@ -533,7 +558,12 @@ export const useBundleEngine = () => {
           // a MISTURA (DESC implica NULLS FIRST no Postgres); o filtro cobre o caso TODAS-NULL.
           .not('affinity_score', 'is', null)
           .order('affinity_score', { ascending: false, nullsFirst: false })
+          // ⚠️ `created_at` deixou de desempatar: desde a migration 20260814223445 a geração
+          // inteira entra num único INSERT, e `now()` é o instante da TRANSAÇÃO — todas as
+          // linhas do run compartilham o mesmo carimbo. `id` é a PK: última chave, sempre
+          // total (achado do challenge Codex xhigh).
           .order('updated_at', { ascending: false }) // desempate determinístico
+          .order('id', { ascending: false })
           .limit(1)) as unknown as { data: ExistingRecRow[] | null };
 
         if (existingRecs?.length) {
@@ -580,26 +610,33 @@ export const useBundleEngine = () => {
 
       setCustomerBundles(allCustomerBundles);
 
-      // Persist bundle recommendations — PULADO na lente "Ver como" (só leitura: o
-      // master inspeciona os bundles do alvo sem regravar a carteira dele).
+      // Persist bundle recommendations — via RPC que SUBSTITUI a geração anterior.
+      // PULADO na lente "Ver como" (só leitura: o master inspeciona os bundles do alvo
+      // sem regravar a carteira dele).
       //
-      // UM insert em lote, não um por bundle: as linhas são independentes, então os N
-      // round-trips não compravam atomicidade nenhuma — só multiplicavam a janela de falha
-      // parcial (metade das recomendações gravadas, metade não).
+      // Era `.insert()` puro: cada recálculo EMPILHAVA uma geração nova sem aposentar a
+      // anterior, e como `OfertaCruaCard`/`useTacticalPlan` leem `status='pendente'`
+      // ordenado por `affinity_bundle` desc com `.limit(1)`/`.limit(2)`, um bundle ANTIGO
+      // de score maior seguia sendo o topo indefinidamente. Ver o cabeçalho da migration
+      // 20260814223445 para a medição.
       //
-      // E o `error` é CAPTURADO. Descartá-lo era o mesmo defeito de classe que o #1574 tirou
-      // do bloco de `farmer_association_rules` logo acima, porém sem DELETE: nada é destruído,
-      // o pior caso é a recomendação não existir na TABELA enquanto a UI já mostrou o bundle
-      // em memória — e quem lê a tabela (`OfertaCruaCard`, `useTacticalPlan`) não vê a oferta
-      // que o operador acabou de ver na tela, sem ninguém ficar sabendo.
+      // A RPC expira-e-insere numa transação só; em duas chamadas PostgREST seriam duas
+      // transações, e falhar entre elas deixaria o farmer sem NENHUM bundle pendente.
+      // `m_bundle`/`lie_bundle` saem do payload — a RPC os fixa em NULL.
       //
-      // Sem `throw`: os bundles em memória continuam válidos e já foram exibidos; só o toast
-      // final deixa de dizer que deu tudo certo.
+      // O `error` é CAPTURADO; sem `throw`, porque os bundles em memória continuam válidos
+      // e já foram exibidos — só o toast final deixa de dizer que deu tudo certo.
       let recomendacoesNaoGravadas = 0;
+      /** FG006: outro run JÁ gravou — a tabela tem algo mais NOVO que isto. */
+      let geracaoPerdida = false;
+      /** FG005: outro run está EM VOO — ninguém venceu ainda, e ele pode até dar rollback.
+       *  Separado de propósito: dizer "as telas estão com o resultado dele" quando o
+       *  concorrente ainda não commitou seria afirmar um desfecho que não existe, e o
+       *  operador desistiria de tentar de novo (achado do challenge Codex xhigh). */
+      let recalculoConcorrente = false;
       if (!isImpersonating) {
         const recomendacoes = allCustomerBundles.flatMap((cb) =>
           cb.bundles.map((bundle) => ({
-            farmer_id: effectiveUserId,
             customer_user_id: bundle.customerId,
             // Sem `cost`/`margin` por SKU — o jsonb guardava o custo LITERAL (12/12 linhas em
             // prod). Só id/name/price, e `price` é público.
@@ -608,29 +645,36 @@ export const useBundleEngine = () => {
             confidence: bundle.confidence,
             lift: bundle.lift,
             p_bundle: bundle.pBundle,
-            // m_bundle era a SOMA das margens; e mesmo apagando-o, `lie_bundle` monetário
-            // invertia sozinho: m_bundle ≈ lie_bundle / ((p_bundle/100) × complexity_factor).
-            // Por isso os dois saem juntos — e a afinidade que ordena a lista vai na coluna
-            // DEDICADA `affinity_bundle`. Guardá-la em `lie_bundle` ordenaria certo (afinidade e
-            // p_bundle são monotônicos entre si) e mentiria para os TRÊS consumidores que leem o
-            // VALOR: `useTacticalPlan` copia para `bundle_lie`, `PlanCard` formata como BRL e
-            // divide por hora de ligação, e a edge `generate-tactical-plan` injeta no prompt do
-            // LLM. Afinidade típica ~0,0094 viraria "R$ 0,01" de lucro esperado.
-            m_bundle: null,
-            lie_bundle: null,
             affinity_bundle: bundle.affinityBundle,
             complexity_factor: bundle.complexityFactor,
-            status: 'pendente',
           })),
         );
 
+        // Lote vazio não chama a RPC (ela recusaria com FG003): expirar a geração por
+        // "não achei bundle nenhum" tiraria a oferta da tela por um dado que falta a
+        // montante. Mesmo critério das regras de associação logo acima.
         if (recomendacoes.length > 0) {
-          const { error: erroRecs } = await supabase
-            .from('farmer_bundle_recommendations')
-            .insert(recomendacoes);
+          const { error: erroRecs } = await supabase.rpc(
+            'farmer_bundle_recomendacoes_substituir' as never,
+            {
+              p_farmer_id: effectiveUserId,
+              p_run_id: runId,
+              p_geracao_vista: geracaoVista,
+              p_linhas: recomendacoes,
+            } as never,
+          );
           if (erroRecs) {
-            console.error('Falha ao gravar farmer_bundle_recommendations:', erroRecs);
-            recomendacoesNaoGravadas = recomendacoes.length;
+            console.error('Falha ao substituir farmer_bundle_recommendations:', erroRecs);
+            // FG006 = outro recálculo gravou no meio deste. A tabela ficou com algo MAIS
+            // novo — dizer "não gravou, seguem as anteriores" inverteria o sentido.
+            const codigo = (erroRecs as { code?: string } | null)?.code;
+            if (codigo === 'FG006') {
+              geracaoPerdida = true;
+            } else if (codigo === 'FG005') {
+              recalculoConcorrente = true;
+            } else {
+              recomendacoesNaoGravadas = recomendacoes.length;
+            }
           }
         }
       }
@@ -651,6 +695,16 @@ export const useBundleEngine = () => {
           recomendacoesNaoGravadas === 1
             ? '1 recomendação NÃO foi gravada — as telas de oferta seguem com as anteriores'
             : `${recomendacoesNaoGravadas} recomendações NÃO foram gravadas — as telas de oferta seguem com as anteriores`,
+        );
+      }
+      if (geracaoPerdida) {
+        problemas.push(
+          'outro recálculo deste vendedor já gravou enquanto este rodava — os bundles daqui não foram salvos, e as telas estão com o resultado mais novo',
+        );
+      }
+      if (recalculoConcorrente) {
+        problemas.push(
+          'já havia um recálculo deste vendedor em andamento — os bundles daqui não foram salvos; espere ele terminar e confira',
         );
       }
 

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -159,6 +159,41 @@ export const useCrossSellEngine = () => {
     let resultadoDestaExecucao = false;
 
     try {
+      // 0. Identidade desta EXECUÇÃO + a geração que ela está substituindo.
+      //
+      // Lido ANTES do snapshot de propósito: reivindicar depois deixa a corrida aberta
+      // pela porta de trás (money-path §10). `geracaoVista` é o lado "compare" do
+      // compare-and-swap da RPC — se outro recálculo gravar entre esta leitura e a
+      // escrita lá embaixo, a RPC recusa com FG006 em vez de sobrescrever o resultado
+      // mais NOVO com o meu, que leu dado mais velho. Não depende de relógio nenhum
+      // (nem do browser, nem do servidor).
+      //
+      // Na lente "Ver como" a persistência é pulada, então nem lemos.
+      const runId = crypto.randomUUID();
+      let geracaoVista: string | null = null;
+      if (!isImpersonating) {
+        // Mesma ordem que a RPC usa para eleger a geração vigente (created_at desc, id desc):
+        // divergir aqui faria o compare-and-swap comparar com outra linha e recusar sempre.
+        const { data: vigente, error: erroVigente } = await supabase
+          .from('farmer_recommendations')
+          .select('run_id')
+          .eq('farmer_id', effectiveUserId)
+          .eq('status', 'pendente')
+          .order('created_at', { ascending: false })
+          .order('id', { ascending: false })
+          .limit(1);
+        // FAIL-CLOSED: sem saber qual é a geração vigente não dá para substituí-la com
+        // segurança. Degradar para `null` afirmaria "não há geração nenhuma" e faria a
+        // RPC recusar (ou, pior num desenho sem guard, expirar em cima de dado incerto).
+        if (erroVigente) {
+          throw new Error(
+            mensagemDeErro(erroVigente) ??
+              'Não consegui ler a geração vigente de recomendações — nada foi recalculado.',
+          );
+        }
+        geracaoVista = vigente?.[0]?.run_id ?? null;
+      }
+
       // 1. Load client scores with pagination. Era um loop MANUAL com o mesmo defeito que o
       // #1545 tirou do `fetchAllPages` — mas por não CHAMAR o helper, ficou de fora daquele
       // grep: descartava o `error` (`const { data } = await q`), tratava `data: null` como fim
@@ -265,11 +300,28 @@ export const useCrossSellEngine = () => {
       }
 
       // 4. Load association rules for personalized recommendations
-      const { data: assocRules } = (await supabase
+      //
+      // O `error` é CAPTURADO, e a falha LANÇA. Antes o cast declarava só `{ data }` e
+      // apagava o `error` do tipo: uma leitura falha virava `assocRules || []` → mapa de
+      // associação VAZIO → só o sinal de popularidade sobrava, e o cálculo seguia como se
+      // a base não tivesse padrão nenhum.
+      //
+      // Isso era ruim quando o resultado apenas se somava ao que já existia; virou GRAVE
+      // agora que a persistência SUBSTITUI: um snapshot degradado por falha de transporte
+      // expiraria a carteira inteira do farmer e apagaria cross-sells legítimos de todos os
+      // clientes dele. Expirar por farmer só é seguro se o snapshot for COMPLETO — então a
+      // completude precisa ser verificada, não presumida (achado do challenge Codex xhigh).
+      const { data: assocRules, error: erroAssoc } = (await supabase
         .from('farmer_association_rules')
         .select('antecedent_product_ids, consequent_product_ids, confidence, lift, support')
         .gte('confidence', 0.05)
-        .gte('lift', 1.0)) as unknown as { data: AssocRuleRow[] | null };
+        .gte('lift', 1.0)) as unknown as { data: AssocRuleRow[] | null; error: unknown };
+      if (erroAssoc) {
+        throw new Error(
+          mensagemDeErro(erroAssoc) ??
+            'Não consegui ler as regras de associação — o cálculo seria parcial e substituiria as recomendações atuais, então nada foi alterado.',
+        );
+      }
 
       // Build map: antecedent product -> consequent products with scores
       const assocMap = new Map<string, { productId: string; confidence: number; lift: number; support: number }[]>();
@@ -512,55 +564,77 @@ export const useCrossSellEngine = () => {
       aplicarRecomendacoes(allRecs);
       resultadoDestaExecucao = true;
 
-      // Persist recommendations (batch upsert único — antes era N×M serial)
+      // Persist recommendations — via RPC que SUBSTITUI a geração anterior.
+      //
+      // Era `.upsert(recRows)` SEM `onConflict` e sem `id` no payload: como a única chave
+      // é o uuid DEFAULT, nada nunca colidia e o "upsert" era um INSERT. Cada recálculo
+      // EMPILHAVA, e como os leitores pegam `status='pendente'` ordenado por afinidade
+      // desc com `.limit(1)`, uma recomendação ANTIGA de score maior seguia sendo o topo
+      // para sempre — o operador via uma oferta que o motor já não escolheria. Medido em
+      // prod (2026-08-14): 197 de 473 grupos (farmer,cliente) com ≥2 gerações vivas, e
+      // 18 grupos cujo topo vinha de uma geração de até 70 DIAS antes.
+      //
+      // Vai por RPC porque expirar-e-inserir são DUAS operações: em duas chamadas
+      // PostgREST são duas transações, e falhar entre elas deixaria o farmer com ZERO
+      // oferta pendente. Mesmo motivo que levou `farmer_association_rules_substituir` a
+      // existir. `m_ij`/`lie` saem do payload de vez — a RPC os fixa em NULL, então o
+      // browser não tem mais como fabricar dinheiro de volta nessas colunas.
+      // Provada em db/test-farmer-geracao-vigente.sh (31 asserts + 4 falsificações).
       const recRows = allRecs.flatMap((cr) =>
         [...cr.crossSell, ...cr.upSell].map((rec) => ({
-          farmer_id: effectiveUserId,
           customer_user_id: rec.customerId,
           recommendation_type: rec.type,
           product_id: rec.productId,
           current_product_id: rec.currentProductId || null,
           p_ij: rec.pij,
-          // m_ij explicitamente NULL, não omitido: o upsert do PostgREST só atualiza as colunas
-          // presentes no payload, então OMITIR deixaria o valor antigo intacto nas linhas que
-          // colidem — e `m_ij ÷ cluster_volume_estimate` devolve a margem unitária (conferido em
-          // prod: 134,26/2 = 67,13). A limpeza das linhas que NÃO colidem é a migration
-          // 20260725123000.
-          m_ij: null,
-          // `lie` é DINHEIRO (Lucro Incremental Esperado em R$) e sai de cena junto com `m_ij`:
-          // o valor antigo invertia sozinho — m_ij ≈ lie / ((p_ij/100) × complexity_factor).
-          // A afinidade que ordena a lista vai na coluna DEDICADA `affinity_score`, adimensional.
-          // Reaproveitar `lie` para o score ordenaria certo (são monotônicos entre si) e mentiria
-          // para quem lê o VALOR — o irmão `lie_bundle` é copiado para
-          // `farmer_tactical_plans.bundle_lie` e formatado como BRL no PlanCard.
-          // Explicitamente NULL, não omitido, pelo mesmo motivo do `m_ij` acima: no upsert do
-          // PostgREST a coluna ausente do payload preserva o valor antigo na linha que colide.
-          lie: null,
           affinity_score: rec.affinityScore,
           complexity_factor: rec.complexityFactor,
           cluster_volume_estimate: rec.clusterVolume,
-          status: 'pendente',
-          updated_at: new Date().toISOString(),
         })),
       );
       // Persistência PULADA na lente "Ver como" (somente leitura: o master inspeciona
       // as recomendações do alvo sem regravar a carteira dele).
+      //
+      // `length > 0` continua sendo o guard: lote vazio quase sempre é dado faltando a
+      // montante, e expirar a carteira por causa disso deixaria a vendedora sem NENHUMA
+      // oferta. A RPC recusa o lote vazio de qualquer jeito (FG003) — não a chamamos só
+      // para tomar o erro. Mesmo raciocínio do bloco de regras no useBundleEngine.
       if (!isImpersonating && recRows.length > 0) {
-        // O `error` é CAPTURADO. O supabase-js NÃO lança em erro de banco — resolve normal com
-        // `error` preenchido — então o `await` solto devolvia sucesso SEM ter gravado, e o `catch`
-        // abaixo nunca rodava. O caso concreto desta entrega: `affinity_score` só existe depois da
-        // migration 20260725121000; publicar o front antes dela devolve 42703/PGRST204 e as
-        // recomendações somem da tabela em silêncio, com a tela mostrando a lista calculada.
+        // O `error` é CAPTURADO. O supabase-js NÃO lança em erro de banco — resolve normal
+        // com `error` preenchido — então o `await` solto devolveria sucesso SEM ter gravado.
         // Sem `throw`: o cálculo em memória é válido e já foi exibido — quem falhou foi só a
-        // persistência, e derrubar a tela seria pior. Espelha o desfecho do useBundleEngine (#1594).
-        const { error: erroPersistencia } = await supabase
-          .from('farmer_recommendations')
-          .upsert(recRows);
+        // persistência, e derrubar a tela seria pior. Espelha o useBundleEngine (#1594).
+        const { error: erroPersistencia } = await supabase.rpc(
+          'farmer_recomendacoes_substituir' as never,
+          {
+            p_farmer_id: effectiveUserId,
+            p_run_id: runId,
+            p_geracao_vista: geracaoVista,
+            p_linhas: recRows,
+          } as never,
+        );
         if (erroPersistencia) {
-          console.error('Falha ao gravar farmer_recommendations:', erroPersistencia);
-          toast.error(
-            `${recRows.length} recomendação(ões) NÃO foram gravadas — as telas de oferta seguem com as anteriores. ${mensagemDeErro(erroPersistencia) ?? ''}`.trim(),
-          );
+          console.error('Falha ao substituir farmer_recommendations:', erroPersistencia);
+          // FG006 = outro recálculo gravou no meio do meu. Não é falha: é a recusa
+          // funcionando, e o dado na tabela é MAIS novo que o meu. Dizer "não foi
+          // gravado, as telas seguem com as anteriores" mentiria na direção oposta —
+          // as telas seguem com algo mais RECENTE do que isto aqui.
+          const codigo = (erroPersistencia as { code?: string } | null)?.code;
+          if (codigo === 'FG006') {
+            toast.warning(
+              'Outro recálculo mais recente já gravou enquanto este rodava — o dele valeu, e as telas de oferta estão com o resultado mais novo.',
+            );
+          } else if (codigo === 'FG005') {
+            // Advisory lock: há OUTRO recálculo deste farmer em voo agora. Distinto do
+            // FG006 (que já terminou e venceu) — aqui o desfecho ainda não existe.
+            toast.warning(
+              'Já há um recálculo deste vendedor em andamento — este não foi gravado. Espere ele terminar e veja o resultado.',
+            );
+          } else {
+            toast.error(
+              `${recRows.length} recomendação(ões) NÃO foram gravadas — as telas de oferta seguem com as anteriores. ${mensagemDeErro(erroPersistencia) ?? ''}`.trim(),
+            );
+          }
         }
       }
     } catch (error) {

--- a/src/hooks/useTacticalPlan.ts
+++ b/src/hooks/useTacticalPlan.ts
@@ -671,7 +671,12 @@ export const useTacticalPlan = () => {
         .order('affinity_bundle', { ascending: false, nullsFirst: false })
         // Desempate determinístico: os scores são arredondados e empatam com frequência; sem uma
         // 2ª chave o "top" oscila entre execuções. Mais recente ganha.
+        // ⚠️ `created_at` deixou de desempatar: desde a migration 20260814223445 a geração
+        // inteira entra num único INSERT, e `now()` é o instante da TRANSAÇÃO — todas as
+        // linhas do run compartilham o mesmo carimbo. `id` é a PK: última chave, sempre
+        // total (achado do challenge Codex xhigh).
         .order('created_at', { ascending: false })
+        .order('id', { ascending: false })
         .limit(2)) as unknown as { data: BundleRow[] | null };
 
       const mixGap = Math.max(0, 8 - categoryCount);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2415,6 +2415,8 @@ export type Database = {
           created_at: string | null
           customer_profile: string | null
           customer_user_id: string
+          expired_at: string | null
+          expired_by_run: string | null
           farmer_id: string
           id: string
           lie_bundle: number | null
@@ -2423,6 +2425,7 @@ export type Database = {
           offered_at: string | null
           p_bundle: number | null
           rejected_at: string | null
+          run_id: string | null
           status: string | null
           support: number | null
           time_spent_seconds: number | null
@@ -2445,6 +2448,8 @@ export type Database = {
           created_at?: string | null
           customer_profile?: string | null
           customer_user_id: string
+          expired_at?: string | null
+          expired_by_run?: string | null
           farmer_id: string
           id?: string
           lie_bundle?: number | null
@@ -2453,6 +2458,7 @@ export type Database = {
           offered_at?: string | null
           p_bundle?: number | null
           rejected_at?: string | null
+          run_id?: string | null
           status?: string | null
           support?: number | null
           time_spent_seconds?: number | null
@@ -2475,6 +2481,8 @@ export type Database = {
           created_at?: string | null
           customer_profile?: string | null
           customer_user_id?: string
+          expired_at?: string | null
+          expired_by_run?: string | null
           farmer_id?: string
           id?: string
           lie_bundle?: number | null
@@ -2483,6 +2491,7 @@ export type Database = {
           offered_at?: string | null
           p_bundle?: number | null
           rejected_at?: string | null
+          run_id?: string | null
           status?: string | null
           support?: number | null
           time_spent_seconds?: number | null
@@ -3295,6 +3304,8 @@ export type Database = {
           created_at: string | null
           current_product_id: string | null
           customer_user_id: string
+          expired_at: string | null
+          expired_by_run: string | null
           farmer_id: string
           id: string
           lie: number | null
@@ -3304,6 +3315,7 @@ export type Database = {
           product_id: string | null
           recommendation_type: string
           rejected_at: string | null
+          run_id: string | null
           status: string | null
           time_spent_seconds: number | null
           updated_at: string | null
@@ -3317,6 +3329,8 @@ export type Database = {
           created_at?: string | null
           current_product_id?: string | null
           customer_user_id: string
+          expired_at?: string | null
+          expired_by_run?: string | null
           farmer_id: string
           id?: string
           lie?: number | null
@@ -3326,6 +3340,7 @@ export type Database = {
           product_id?: string | null
           recommendation_type: string
           rejected_at?: string | null
+          run_id?: string | null
           status?: string | null
           time_spent_seconds?: number | null
           updated_at?: string | null
@@ -3339,6 +3354,8 @@ export type Database = {
           created_at?: string | null
           current_product_id?: string | null
           customer_user_id?: string
+          expired_at?: string | null
+          expired_by_run?: string | null
           farmer_id?: string
           id?: string
           lie?: number | null
@@ -3348,6 +3365,7 @@ export type Database = {
           product_id?: string | null
           recommendation_type?: string
           rejected_at?: string | null
+          run_id?: string | null
           status?: string | null
           time_spent_seconds?: number | null
           updated_at?: string | null

--- a/src/lib/whatsapp/proposta-preview-core.test.ts
+++ b/src/lib/whatsapp/proposta-preview-core.test.ts
@@ -51,7 +51,11 @@ describe('buildCrossSellCandidatos (codex Risco 2: rec→omie, ativo, órfão)',
     { id: 'uuid-a', omie_codigo_produto: 500, descricao: 'Verniz', ativo: true },
     { id: 'uuid-b', omie_codigo_produto: 600, descricao: 'Estopa', ativo: false }, // inativo
   ];
-  function rec(pid: string | null, afinidade: number | null, status: string | null = null): PreviewRec {
+  // Default 'pendente': é o status REAL das linhas vigentes (o CHECK da tabela é pt-BR —
+  // pendente/ofertado/aceito/rejeitado/expirado). O default anterior era `null`, que só
+  // passava porque o filtro de então era a denylist `status === 'rejected'` — rótulo em
+  // INGLÊS que a tabela nunca produz, logo um filtro que não filtrava nada.
+  function rec(pid: string | null, afinidade: number | null, status: string | null = 'pendente'): PreviewRec {
     return { product_id: pid, affinity_score: afinidade, status };
   }
   it('mapeia product_id → omie e mantém só ativos', () => {
@@ -61,7 +65,22 @@ describe('buildCrossSellCandidatos (codex Risco 2: rec→omie, ativo, órfão)',
   });
   it('descarta rec órfã (product_id sem produto), rejeitada e null', () => {
     const r = buildCrossSellCandidatos(
-      [rec('uuid-x', 10), rec('uuid-a', 20, 'rejected'), rec(null, 30)], prods);
+      [rec('uuid-x', 10), rec('uuid-a', 20, 'rejeitado'), rec(null, 30)], prods);
     expect(r).toEqual([]);
+  });
+  it('descarta a geração EXPIRADA por um recálculo, e status desconhecido/ausente', () => {
+    // Desde a migration 20260814223445 o recálculo aposenta a geração anterior marcando
+    // `status='expirado'`. Sem allowlist, essa linha entraria na proposta que vai pro
+    // cliente no WhatsApp — oferecendo um SKU que o motor já descartou.
+    const r = buildCrossSellCandidatos(
+      [rec('uuid-a', 90, 'expirado'), rec('uuid-a', 80, null), rec('uuid-a', 70, 'status_que_nao_existe')],
+      prods,
+    );
+    expect(r).toEqual([]);
+  });
+  it('mantém pendente E ofertado (a oferta já feita segue válida)', () => {
+    const r = buildCrossSellCandidatos(
+      [rec('uuid-a', 90, 'pendente'), rec('uuid-a', 80, 'ofertado')], prods);
+    expect(r).toHaveLength(2);
   });
 });

--- a/src/lib/whatsapp/proposta-preview-core.ts
+++ b/src/lib/whatsapp/proposta-preview-core.ts
@@ -49,12 +49,25 @@ export function assembleLinesEContexto(orders: PreviewOrder[], items: PreviewIte
   return { lines, account, statusesVistos, statusValidos };
 }
 
-/** farmer_recommendations × omie_products(by id) → candidatos de cross-sell (só ativos, não-rejeitados). */
+/**
+ * Status em que uma recomendação ainda é OFERECÍVEL. Allowlist, não denylist: status
+ * novo (hoje 'expirado', amanhã o que for) fica de fora por default — precisão > recall
+ * numa lista que vai pro cliente por WhatsApp.
+ *
+ * ⚠️ O filtro anterior era `r.status === 'rejected'` — rótulo que NÃO existe no domínio
+ * (o CHECK da tabela é pt-BR: pendente/ofertado/aceito/rejeitado/expirado), logo nunca
+ * casava nada. Isto aqui é DEFESA EM PROFUNDIDADE, não a correção de um bug ativo: a
+ * proteção real é o `.eq('status','pendente')` do usePropostaPreview. Vale escrever
+ * porque um helper puro que finge filtrar é pior que um que não filtra.
+ */
+const STATUS_OFERECIVEL = new Set(['pendente', 'ofertado']);
+
+/** farmer_recommendations × omie_products(by id) → candidatos de cross-sell (só ativos e oferecíveis). */
 export function buildCrossSellCandidatos(recs: PreviewRec[], prodById: PreviewProdById[]): CrossSellCand[] {
   const byId = new Map(prodById.map(p => [p.id, p]));
   const out: CrossSellCand[] = [];
   for (const r of recs) {
-    if (!r.product_id || r.status === 'rejected') continue;
+    if (!r.product_id || !STATUS_OFERECIVEL.has(r.status ?? '')) continue;
     const prod = byId.get(r.product_id);
     if (prod && prod.ativo) out.push({ omie_codigo_produto: prod.omie_codigo_produto, nome: prod.descricao, afinidade: r.affinity_score });
   }

--- a/src/queries/usePropostaPreview.ts
+++ b/src/queries/usePropostaPreview.ts
@@ -104,7 +104,12 @@ export function usePropostaPreview(customerUserId: string | undefined, opts?: { 
         const { data: recData } = await supabase
           .from('farmer_recommendations')
           .select('product_id, affinity_score, status')
-          .eq('customer_user_id', customerUserId!);
+          .eq('customer_user_id', customerUserId!)
+          // Só a geração VIGENTE. Desde 20260814223445 o recálculo aposenta a geração
+          // anterior marcando-a `status='expirado'` — sem este filtro a proposta que vai
+          // pro cliente no WhatsApp ofereceria SKU que o motor já descartou. Era inócuo
+          // enquanto nada era expirado; passou a morder no instante em que algo é.
+          .eq('status', 'pendente');
         const recs = (recData ?? []) as PreviewRec[];
         const recIds = [...new Set(recs.map(r => r.product_id).filter((x): x is string => !!x))];
         if (recIds.length > 0) {

--- a/supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql
+++ b/supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql
@@ -1,0 +1,499 @@
+-- ============================================================
+-- Geração VIGENTE das recomendações do farmer — o recálculo passa a APOSENTAR
+-- a geração anterior, em vez de empilhar por cima dela.
+--
+-- PROBLEMA (medido em prod 2026-08-14, achado do challenge Codex xhigh no #1520):
+--   `useCrossSellEngine` faz `.upsert(recRows)` SEM `onConflict` e sem `id` no
+--   payload — como a única chave é o uuid DEFAULT, nada nunca colide e o upsert é,
+--   na prática, um INSERT. `useBundleEngine` faz `.insert()` explícito. Nenhum dos
+--   dois aposenta o que gravou antes.
+--   Os leitores pegam `status='pendente'` ordenado por afinidade desc com
+--   `.limit(1)`/`.limit(2)` — então uma recomendação ANTIGA com score maior
+--   permanece "top" para sempre. O recálculo não substitui: só empilha.
+--
+--   Medido em prod via psql-ro (2026-08-15 00:5x UTC). farmer_recommendations:
+--   6.015 linhas, 100% status='pendente', ZERO desfecho (offered_at/accepted_at/
+--   rejected_at/actual_margin nulos em TODAS), 7 execuções entre 02/03 e 15/08.
+--     · 473 grupos (farmer_id, customer_user_id) com pendentes
+--     · 276 com 1 geração · 138 com 2 · 33 com 3 · 26 com 4+
+--     · 197 grupos (42%) com ≥2 gerações vivas, concentrando 4.535 das 6.015
+--       linhas (75%)
+--   E o bug JÁ se manifestou: medido pela chave de ranking vigente à época (p_ij,
+--   antes do #1520 mover o ranking para affinity_score), 18 grupos tinham como
+--   TOPO uma linha de até 70 DIAS antes. Hoje ele está temporariamente MASCARADO
+--   porque só a última geração (1.342 linhas) tem affinity_score preenchido e os
+--   leitores filtram `.not('affinity_score','is',null)` — as antigas estão
+--   acidentalmente invisíveis. Isso acaba na PRÓXIMA execução do motor, quando
+--   houver duas gerações com afinidade competindo. O motor rodou 3x nas 2h
+--   anteriores a esta medição, então "próxima execução" não é hipotético.
+--   farmer_bundle_recommendations: 12 linhas, 2 execuções separadas por 4 minutos,
+--   4 grupos — 2 deles já com as duas gerações vivas. Mesmo defeito, volume menor.
+--
+-- DESENHO: `run_id` por execução + RPC transacional que expira e insere numa
+--   transação só. Duas chamadas PostgREST (UPDATE depois INSERT) são duas
+--   transações: falha entre elas deixaria o farmer SEM nenhuma oferta pendente.
+--   Mesmo motivo que levou `farmer_association_rules_substituir` a existir.
+--
+-- EXPIRAR ≠ DELETAR: `status` guarda o desfecho ('ofertado'/'aceito'/'rejeitado')
+--   junto de `accepted_at`/`rejected_at`. A RPC só toca `status='pendente'` —
+--   linha com desfecho registrado é IMUTÁVEL aqui (money-path: "deleção exige
+--   prova positiva de ausência"). Medido: hoje 100% das linhas das duas tabelas
+--   são 'pendente' com ZERO desfecho (os métodos `markAsOffered`/`markAsAccepted`
+--   foram removidos em 2026-07-21 por não terem consumidor), então a expiração
+--   não destrói histórico nenhum — mas o guard fica, porque o loop de feedback é
+--   follow-up conhecido e vai começar a gravar desfecho. Ou seja: o guard nasce
+--   INERTE e é declarado como tal. Vale escrevê-lo porque defesa inerte tem prazo
+--   de validade curto neste repo — o precedente do #1495/#1498 saiu de inerte para
+--   ativa em 7 horas.
+--
+-- DEPENDE de 20260725121000 (colunas affinity_score/affinity_bundle do #1520).
+--   O bloco de guard abaixo ABORTA com instrução explícita se ela não tiver sido
+--   aplicada — em vez de morrer com um 42703 críptico no meio do apply.
+-- ============================================================
+
+-- ─── 0) Guard de ordem de apply (fail-closed, com a instrução no texto) ───
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'farmer_recommendations'
+      AND column_name = 'affinity_score'
+  ) THEN
+    RAISE EXCEPTION 'DEPENDENCIA FALTANDO: aplique ANTES a migration 20260725121000_authz_custo_fu4f_fase3_afinidade_colunas.sql (coluna farmer_recommendations.affinity_score ausente nesta base)'
+      USING ERRCODE = 'FG000';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'farmer_bundle_recommendations'
+      AND column_name = 'affinity_bundle'
+  ) THEN
+    RAISE EXCEPTION 'DEPENDENCIA FALTANDO: aplique ANTES a migration 20260725121000_authz_custo_fu4f_fase3_afinidade_colunas.sql (coluna farmer_bundle_recommendations.affinity_bundle ausente nesta base)'
+      USING ERRCODE = 'FG000';
+  END IF;
+END $$;
+
+-- ─── 1) Colunas de geração ───
+ALTER TABLE public.farmer_recommendations
+  ADD COLUMN IF NOT EXISTS run_id         uuid,
+  ADD COLUMN IF NOT EXISTS expired_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS expired_by_run uuid;
+
+ALTER TABLE public.farmer_bundle_recommendations
+  ADD COLUMN IF NOT EXISTS run_id         uuid,
+  ADD COLUMN IF NOT EXISTS expired_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS expired_by_run uuid;
+
+COMMENT ON COLUMN public.farmer_recommendations.run_id IS
+  'Execução do motor que produziu esta linha. NULL = geração legada (anterior a 2026-08-14). A geração VIGENTE de um farmer é o run_id das linhas status=pendente.';
+COMMENT ON COLUMN public.farmer_recommendations.expired_at IS
+  'Quando a linha foi aposentada por um recálculo. Só preenchido junto de status=expirado (invariante em CHECK).';
+COMMENT ON COLUMN public.farmer_recommendations.expired_by_run IS
+  'Qual execução aposentou esta linha — responde "quem matou" sem precisar inferir pela ordem de created_at.';
+
+-- ─── 2) `expirado` no CHECK do bundle ───
+-- farmer_recommendations JÁ aceita 'expirado'; farmer_bundle_recommendations NÃO
+-- (medido: ARRAY['pendente','ofertado','aceito_total','aceito_parcial','rejeitado']).
+-- Sem isto a RPC do bundle falharia em RUNTIME com 23514, não no CREATE.
+ALTER TABLE public.farmer_bundle_recommendations
+  DROP CONSTRAINT IF EXISTS farmer_bundle_recommendations_status_check;
+ALTER TABLE public.farmer_bundle_recommendations
+  ADD CONSTRAINT farmer_bundle_recommendations_status_check
+  CHECK (status = ANY (ARRAY['pendente'::text, 'ofertado'::text, 'aceito_total'::text,
+                             'aceito_parcial'::text, 'rejeitado'::text, 'expirado'::text]));
+
+-- ─── 3) Invariante na TABELA, não só no writer ───
+-- "O guard mora no WRITER; a invariante mora na TABELA" (money-path §2): o próximo
+-- writer que marcar 'expirado' sem carimbar `expired_at` produz uma linha que some
+-- dos leitores sem deixar rastro de QUANDO sumiu. Medido antes de propor: hoje 0
+-- linhas violam (100% 'pendente', expired_at nasce NULL), então o ADD valida limpo.
+-- Tabelas pequenas (936 kB e 32 kB) — ADD direto não precisa de NOT VALID.
+-- ⚠️ `status IS NOT NULL AND` na frente não é redundante: `status` é NULLABLE, e com
+-- status NULL a igualdade `(NULL = 'expirado') = (…)` vira NULL — que o Postgres
+-- ACEITA num CHECK (só `false` reprova). Sem esse termo, um writer que gravasse
+-- status NULL passaria pela constraint, sumiria de todo leitor (que filtra por status)
+-- e ainda entraria no denominador da adoção. É o mesmo three-valued logic do gate.
+ALTER TABLE public.farmer_recommendations
+  DROP CONSTRAINT IF EXISTS farmer_recommendations_expirado_coerente;
+ALTER TABLE public.farmer_recommendations
+  ADD CONSTRAINT farmer_recommendations_expirado_coerente
+  CHECK (status IS NOT NULL AND ((status = 'expirado') = (expired_at IS NOT NULL)));
+
+ALTER TABLE public.farmer_bundle_recommendations
+  DROP CONSTRAINT IF EXISTS farmer_bundle_recommendations_expirado_coerente;
+ALTER TABLE public.farmer_bundle_recommendations
+  ADD CONSTRAINT farmer_bundle_recommendations_expirado_coerente
+  CHECK (status IS NOT NULL AND ((status = 'expirado') = (expired_at IS NOT NULL)));
+
+-- ─── 4) Índices ───
+-- As duas tabelas tinham SÓ a PK: todo leitor (`farmer_id` + `status='pendente'`)
+-- e o UPDATE de expiração faziam seq scan.
+CREATE INDEX IF NOT EXISTS idx_frec_farmer_status_pendente
+  ON public.farmer_recommendations (farmer_id, customer_user_id)
+  WHERE status = 'pendente';
+CREATE INDEX IF NOT EXISTS idx_fbrec_farmer_status_pendente
+  ON public.farmer_bundle_recommendations (farmer_id, customer_user_id)
+  WHERE status = 'pendente';
+
+-- ─── 4b) A INVARIANTE MORA NA TABELA, não na convenção dos dois hooks ───
+-- Sem isto, o compare-and-swap é só um protocolo cooperativo: qualquer `.insert()`
+-- direto (uma aba com o JS antigo durante a janela de deploy, um script, um hook
+-- futuro) grava uma linha `pendente` com run_id NULL, que não toma o advisory lock,
+-- sobrevive à substituição e volta a competir no topo — o bug original de volta, e
+-- nenhum dos guards da RPC o veria. "O guard mora no WRITER; a invariante mora na
+-- TABELA" (money-path §2).
+--
+-- Só BEFORE INSERT: o UPDATE de expiração e os updates de argumento
+-- (useBundleArguments) precisam seguir funcionando sobre linhas legadas.
+-- As 6.015 linhas pendentes já existentes (run_id NULL) NÃO são afetadas — trigger de
+-- INSERT não revalida o passado; elas saem no primeiro recálculo de cada farmer.
+--
+-- ⚠️ ORDEM DE DEPLOY: entre esta migration e o Publish do frontend, uma aba com o JS
+-- antigo que clique em "Recalcular" recebe FG008 em vez de gravar. É deliberado e é o
+-- lado seguro: o toast do front antigo já diz "N recomendações NÃO foram gravadas — as
+-- telas seguem com as anteriores", que é verdade. O outro lado seria empilhar em
+-- silêncio, que é exatamente o defeito sendo corrigido.
+CREATE OR REPLACE FUNCTION public.farmer_rec_exige_run_id() RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF NEW.status = 'pendente' AND NEW.run_id IS NULL THEN
+    RAISE EXCEPTION 'recomendação pendente exige run_id: use as RPCs farmer_recomendacoes_substituir / farmer_bundle_recomendacoes_substituir (INSERT direto EMPILHA em vez de substituir a geração)'
+      USING ERRCODE = 'FG008';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+DROP TRIGGER IF EXISTS trg_frec_exige_run_id ON public.farmer_recommendations;
+CREATE TRIGGER trg_frec_exige_run_id
+  BEFORE INSERT ON public.farmer_recommendations
+  FOR EACH ROW EXECUTE FUNCTION public.farmer_rec_exige_run_id();
+
+DROP TRIGGER IF EXISTS trg_fbrec_exige_run_id ON public.farmer_bundle_recommendations;
+CREATE TRIGGER trg_fbrec_exige_run_id
+  BEFORE INSERT ON public.farmer_bundle_recommendations
+  FOR EACH ROW EXECUTE FUNCTION public.farmer_rec_exige_run_id();
+
+-- ============================================================
+-- 5) RPC — cross-sell / up-sell
+-- ============================================================
+-- SECURITY INVOKER (o default, declarado de propósito): a RLS destas tabelas JÁ
+-- expressa exatamente a regra desejada (`farmer_id = auth.uid()` OU
+-- `private.cap_carteira_escrever(auth.uid())`). Com DEFINER eu teria de REPLICAR
+-- esse predicado no corpo — e uma cópia que diverge vira escalação: um employee
+-- passaria `p_farmer_id` de outra vendedora e expiraria a carteira dela. Deixando
+-- INVOKER, a autoridade continua sendo a policy, com uma fonte de verdade só.
+-- O gate explícito abaixo existe para a MENSAGEM (sem ele o UPDATE afetaria 0
+-- linhas e o INSERT morreria com um 42501 cru da RLS), não para autorizar.
+CREATE OR REPLACE FUNCTION public.farmer_recomendacoes_substituir(
+  p_farmer_id     uuid,
+  p_run_id        uuid,
+  p_geracao_vista uuid,
+  p_linhas        jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_total          integer;
+  v_invalidas      integer;
+  v_geracao_atual  uuid;
+  v_expiradas      integer;
+  v_inseridas      integer;
+BEGIN
+  -- 1) Gate de MENSAGEM (a RLS é quem autoriza — ver cabeçalho).
+  IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
+    RAISE EXCEPTION 'p_farmer_id e p_run_id são obrigatórios' USING ERRCODE = 'FG001';
+  END IF;
+  -- ⚠️ `IS NOT TRUE`, não `NOT (...)`. Numa sessão SEM JWT (pg_cron, psql) `auth.uid()`
+  -- devolve NULL, então `p_farmer_id = auth.uid()` é NULL e a disjunção inteira vira
+  -- NULL — e `IF NOT NULL THEN` NÃO dispara em PL/pgSQL. Medido em prod:
+  --   NOT (false OR NULL OR false)          => NULL   (o RAISE nunca acontece)
+  --   (false OR NULL OR false) IS NOT TRUE  => true   (barra, como se quer)
+  -- Ou seja, a forma "óbvia" é um guard que não nega: ele devolve nulo. Fecha-se em
+  -- TRUE explícito — só quem provou ter direito passa (money-path: fail-closed).
+  IF (
+    coalesce(auth.role(), '') = 'service_role'
+    OR p_farmer_id = auth.uid()
+    OR coalesce(private.cap_carteira_escrever(auth.uid()), false)
+  ) IS NOT TRUE THEN
+    RAISE EXCEPTION 'Acesso negado: só o próprio farmer ou quem tem cap_carteira_escrever substitui recomendações'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- 2) FORMATO.
+  IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
+    RAISE EXCEPTION 'p_linhas deve ser um array jsonb (recebido: %)',
+      coalesce(jsonb_typeof(p_linhas), 'null') USING ERRCODE = 'FG002';
+  END IF;
+
+  v_total := jsonb_array_length(p_linhas);
+
+  -- 3) LOTE VAZIO = RECUSA, não "expira tudo e deixa o farmer sem oferta".
+  -- Zero recomendação quase sempre é dado faltando a montante (catálogo, scores,
+  -- get_skus_margem_positiva), não "este farmer não tem o que oferecer" — mesmo
+  -- raciocínio que farmer_association_rules_substituir aplica ao lote vazio.
+  IF v_total = 0 THEN
+    RAISE EXCEPTION 'lote vazio: as % recomendação(ões) pendentes deste farmer foram preservadas',
+      (SELECT count(*) FROM public.farmer_recommendations
+        WHERE farmer_id = p_farmer_id AND status = 'pendente')
+      USING ERRCODE = 'FG003';
+  END IF;
+
+  -- Teto defensivo: a maior geração medida em prod tem ~1.000 linhas
+  -- (3 cross + 2 up por cliente). 50k é ~50x isso — folga sem ficar ilimitado.
+  IF v_total > 50000 THEN
+    RAISE EXCEPTION 'lote de % linhas excede o teto de 50000', v_total USING ERRCODE = 'FG004';
+  END IF;
+
+  -- 4) SERIALIZAÇÃO por FARMER (não global: duas vendedoras recalculando ao mesmo
+  -- tempo mexem em escopos disjuntos e não têm por que esperar uma pela outra).
+  -- `xact` = o lock sai sozinho no commit/rollback.
+  IF NOT pg_try_advisory_xact_lock(
+        hashtext('farmer_recomendacoes_substituir'), hashtext(p_farmer_id::text)) THEN
+    RAISE EXCEPTION 'outro recálculo deste farmer está em andamento — nada foi alterado'
+      USING ERRCODE = 'FG005';
+  END IF;
+
+  -- 5) GUARD CAUSAL (compare-and-swap).
+  -- O advisory lock acima só cobre a TRANSAÇÃO da RPC — ele não cobre a janela
+  -- longa entre "o motor leu o snapshot" e "o motor chamou esta função". Sem este
+  -- guard, dois recálculos sobrepostos terminam com o MAIS LENTO vencendo, e o
+  -- mais lento é justamente o que leu o snapshot mais VELHO (money-path §10: o
+  -- degradado terminar depois do saudável é o desfecho esperado, não o azar).
+  -- Comparar geração vista × geração vigente não depende de relógio nenhum — nem
+  -- do browser (que o cliente controla) nem do servidor.
+  -- NULL casa NULL: primeira execução, e as 3.659 linhas legadas (run_id NULL).
+  SELECT run_id INTO v_geracao_atual
+  FROM public.farmer_recommendations
+  WHERE farmer_id = p_farmer_id AND status = 'pendente'
+  ORDER BY created_at DESC, id DESC
+  LIMIT 1;
+
+  IF v_geracao_atual IS DISTINCT FROM p_geracao_vista THEN
+    RAISE EXCEPTION 'geração vigente mudou durante o cálculo (vista: %, atual: %) — nada foi alterado',
+      coalesce(p_geracao_vista::text, 'nenhuma'), coalesce(v_geracao_atual::text, 'nenhuma')
+      USING ERRCODE = 'FG006';
+  END IF;
+
+  -- 6) VALIDAÇÃO ANTES DE MEXER (nada é expirado se o lote tem lixo).
+  SELECT count(*) INTO v_invalidas
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    affinity_score          numeric
+  )
+  WHERE r.customer_user_id IS NULL
+     OR r.product_id IS NULL
+     OR r.recommendation_type IS NULL
+     OR r.recommendation_type NOT IN ('cross_sell', 'up_sell')
+     -- Finitude nos TRÊS lados. `>= 0` sozinho NÃO sanea: medido em prod,
+     -- `'NaN' >= 0` é TRUE e `'Infinity' >= 0` é TRUE (money-path §2). Escrito na
+     -- forma positiva-negada de propósito — a variante `x <> 'NaN' IS NOT TRUE`
+     -- lê igual e erra a precedência. `affinity_score` é a chave que ordena a
+     -- oferta na tela: NaN aqui não dá número errado, DESLIGA a comparação.
+     OR r.affinity_score IS NULL
+     OR NOT (
+          r.affinity_score >= 0
+          AND r.affinity_score < 'Infinity'::numeric
+          AND r.affinity_score <> 'NaN'::numeric
+        );
+
+  IF v_invalidas > 0 THEN
+    RAISE EXCEPTION '% de % linha(s) inválidas (cliente/produto/tipo ausente, ou afinidade nula/negativa/NaN/Infinita) — nada foi expirado',
+      v_invalidas, v_total USING ERRCODE = 'FG007';
+  END IF;
+
+  -- 7) A TROCA — os dois statements na MESMA transação.
+  -- Só 'pendente' é tocado: linha com desfecho ('ofertado'/'aceito'/'rejeitado')
+  -- é histórico e fica imutável. E é UPDATE, nunca DELETE.
+  UPDATE public.farmer_recommendations
+     SET status         = 'expirado',
+         expired_at     = clock_timestamp(),
+         expired_by_run = p_run_id,
+         updated_at     = clock_timestamp()
+   WHERE farmer_id = p_farmer_id
+     AND status = 'pendente';
+  GET DIAGNOSTICS v_expiradas = ROW_COUNT;
+
+  INSERT INTO public.farmer_recommendations (
+    farmer_id, customer_user_id, recommendation_type, product_id, current_product_id,
+    p_ij, m_ij, lie, affinity_score, complexity_factor, cluster_volume_estimate,
+    status, run_id
+  )
+  SELECT
+    p_farmer_id, r.customer_user_id, r.recommendation_type, r.product_id, r.current_product_id,
+    r.p_ij,
+    -- m_ij e lie são DINHEIRO e saíram de cena no #1520 (o custo não chega mais ao
+    -- browser). Fixados em NULL aqui, não copiados do payload: o cliente não tem
+    -- como fabricá-los de volta.
+    NULL, NULL,
+    r.affinity_score, coalesce(r.complexity_factor, 1), coalesce(r.cluster_volume_estimate, 1),
+    'pendente', p_run_id
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    current_product_id      uuid,
+    p_ij                    numeric,
+    affinity_score          numeric,
+    complexity_factor       numeric,
+    cluster_volume_estimate numeric
+  );
+  GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'run_id',    p_run_id,
+    'expiradas', v_expiradas,
+    'inseridas', v_inseridas
+  );
+END;
+$function$;
+
+-- ============================================================
+-- 6) RPC — bundles (mesmo contrato, mesma tabela-irmã)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.farmer_bundle_recomendacoes_substituir(
+  p_farmer_id     uuid,
+  p_run_id        uuid,
+  p_geracao_vista uuid,
+  p_linhas        jsonb
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_total         integer;
+  v_invalidas     integer;
+  v_geracao_atual uuid;
+  v_expiradas     integer;
+  v_inseridas     integer;
+BEGIN
+  IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
+    RAISE EXCEPTION 'p_farmer_id e p_run_id são obrigatórios' USING ERRCODE = 'FG001';
+  END IF;
+  -- ⚠️ `IS NOT TRUE`, não `NOT (...)`. Numa sessão SEM JWT (pg_cron, psql) `auth.uid()`
+  -- devolve NULL, então `p_farmer_id = auth.uid()` é NULL e a disjunção inteira vira
+  -- NULL — e `IF NOT NULL THEN` NÃO dispara em PL/pgSQL. Medido em prod:
+  --   NOT (false OR NULL OR false)          => NULL   (o RAISE nunca acontece)
+  --   (false OR NULL OR false) IS NOT TRUE  => true   (barra, como se quer)
+  -- Ou seja, a forma "óbvia" é um guard que não nega: ele devolve nulo. Fecha-se em
+  -- TRUE explícito — só quem provou ter direito passa (money-path: fail-closed).
+  IF (
+    coalesce(auth.role(), '') = 'service_role'
+    OR p_farmer_id = auth.uid()
+    OR coalesce(private.cap_carteira_escrever(auth.uid()), false)
+  ) IS NOT TRUE THEN
+    RAISE EXCEPTION 'Acesso negado: só o próprio farmer ou quem tem cap_carteira_escrever substitui recomendações'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
+    RAISE EXCEPTION 'p_linhas deve ser um array jsonb (recebido: %)',
+      coalesce(jsonb_typeof(p_linhas), 'null') USING ERRCODE = 'FG002';
+  END IF;
+
+  v_total := jsonb_array_length(p_linhas);
+
+  IF v_total = 0 THEN
+    RAISE EXCEPTION 'lote vazio: os % bundle(s) pendentes deste farmer foram preservados',
+      (SELECT count(*) FROM public.farmer_bundle_recommendations
+        WHERE farmer_id = p_farmer_id AND status = 'pendente')
+      USING ERRCODE = 'FG003';
+  END IF;
+
+  IF v_total > 50000 THEN
+    RAISE EXCEPTION 'lote de % linhas excede o teto de 50000', v_total USING ERRCODE = 'FG004';
+  END IF;
+
+  IF NOT pg_try_advisory_xact_lock(
+        hashtext('farmer_bundle_recomendacoes_substituir'), hashtext(p_farmer_id::text)) THEN
+    RAISE EXCEPTION 'outro recálculo de bundles deste farmer está em andamento — nada foi alterado'
+      USING ERRCODE = 'FG005';
+  END IF;
+
+  SELECT run_id INTO v_geracao_atual
+  FROM public.farmer_bundle_recommendations
+  WHERE farmer_id = p_farmer_id AND status = 'pendente'
+  ORDER BY created_at DESC, id DESC
+  LIMIT 1;
+
+  IF v_geracao_atual IS DISTINCT FROM p_geracao_vista THEN
+    RAISE EXCEPTION 'geração vigente de bundles mudou durante o cálculo (vista: %, atual: %) — nada foi alterado',
+      coalesce(p_geracao_vista::text, 'nenhuma'), coalesce(v_geracao_atual::text, 'nenhuma')
+      USING ERRCODE = 'FG006';
+  END IF;
+
+  SELECT count(*) INTO v_invalidas
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id uuid,
+    bundle_products  jsonb,
+    affinity_bundle  numeric
+  )
+  WHERE r.customer_user_id IS NULL
+     OR r.bundle_products IS NULL
+     OR jsonb_typeof(r.bundle_products) <> 'array'
+     OR jsonb_array_length(r.bundle_products) = 0
+     OR r.affinity_bundle IS NULL
+     OR NOT (
+          r.affinity_bundle >= 0
+          AND r.affinity_bundle < 'Infinity'::numeric
+          AND r.affinity_bundle <> 'NaN'::numeric
+        );
+
+  IF v_invalidas > 0 THEN
+    RAISE EXCEPTION '% de % bundle(s) inválidos (cliente/produtos ausentes, ou afinidade nula/negativa/NaN/Infinita) — nada foi expirado',
+      v_invalidas, v_total USING ERRCODE = 'FG007';
+  END IF;
+
+  UPDATE public.farmer_bundle_recommendations
+     SET status         = 'expirado',
+         expired_at     = clock_timestamp(),
+         expired_by_run = p_run_id,
+         updated_at     = clock_timestamp()
+   WHERE farmer_id = p_farmer_id
+     AND status = 'pendente';
+  GET DIAGNOSTICS v_expiradas = ROW_COUNT;
+
+  INSERT INTO public.farmer_bundle_recommendations (
+    farmer_id, customer_user_id, bundle_products, support, confidence, lift,
+    p_bundle, m_bundle, lie_bundle, affinity_bundle, complexity_factor,
+    status, run_id
+  )
+  SELECT
+    p_farmer_id, r.customer_user_id, r.bundle_products,
+    r.support, r.confidence, r.lift, r.p_bundle,
+    -- m_bundle/lie_bundle: dinheiro, fora de cena desde o #1520 (ver RPC irmã).
+    NULL, NULL,
+    r.affinity_bundle, coalesce(r.complexity_factor, 1),
+    'pendente', p_run_id
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id  uuid,
+    bundle_products   jsonb,
+    support           numeric,
+    confidence        numeric,
+    lift              numeric,
+    p_bundle          numeric,
+    affinity_bundle   numeric,
+    complexity_factor numeric
+  );
+  GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'run_id',    p_run_id,
+    'expiradas', v_expiradas,
+    'inseridas', v_inseridas
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.farmer_recomendacoes_substituir(uuid, uuid, uuid, jsonb) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.farmer_bundle_recomendacoes_substituir(uuid, uuid, uuid, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.farmer_recomendacoes_substituir(uuid, uuid, uuid, jsonb) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.farmer_bundle_recomendacoes_substituir(uuid, uuid, uuid, jsonb) TO authenticated, service_role;


### PR DESCRIPTION
Os dois motores de recomendação do farmer **persistiam sem nunca aposentar a geração anterior**. Achado do challenge Codex xhigh durante o #1520, fora do escopo daquele PR.

- `useCrossSellEngine` fazia `.upsert(recRows)` **sem `onConflict`** e sem `id` no payload. Como a única chave é o uuid `DEFAULT`, nada nunca colidia: o "upsert" era um INSERT.
- `useBundleEngine` fazia `.insert()` explícito.

Os leitores pegam `status='pendente'` ordenado por afinidade desc com `.limit(1)`/`.limit(2)`. Logo uma recomendação **antiga com score maior permanecia "top" indefinidamente** — o operador via uma oferta que o motor já não escolheria.

## Medição antes de desenhar (psql-ro, prod, 2026-08-15)

`farmer_recommendations`: **6.015 linhas, 100% `pendente`, ZERO desfecho** (`offered_at`/`accepted_at`/`rejected_at`/`actual_margin` nulos em todas), 7 execuções entre 02/03 e 15/08.

| Gerações vivas no grupo (farmer, cliente) | Grupos |
|---|---|
| 1 | 276 |
| 2 | 138 |
| 3 | 33 |
| 4+ | 26 |

**197 dos 473 grupos (42%) com ≥2 gerações**, concentrando **4.535 das 6.015 linhas (75%)**.

O bug **já se manifestou**: medido pela chave de ranking vigente à época (`p_ij`, antes do #1520 mover o ranking para `affinity_score`), **18 grupos tinham como topo uma linha de até 70 dias antes**.

**Hoje ele está temporariamente mascarado** — só a última geração (1.342 linhas) tem `affinity_score` preenchido, e os leitores filtram `.not('affinity_score','is',null)`, então as antigas estão *acidentalmente* invisíveis. Isso acaba na **próxima execução do motor**, quando houver duas gerações com afinidade competindo. O motor rodou 3× nas 2h anteriores à medição — "próxima execução" não é hipotético.

`farmer_bundle_recommendations`: 12 linhas, 2 execuções separadas por 4 minutos, 4 grupos — 2 já com as duas gerações vivas.

## Desenho

`run_id` por execução + RPC transacional que **expira e insere numa transação só**. Duas chamadas PostgREST seriam duas transações, e falhar entre elas deixaria o farmer com **zero** oferta pendente — mesmo motivo que levou `farmer_association_rules_substituir` a existir.

**Expirar ≠ deletar.** A RPC só toca `status='pendente'`; linha com desfecho registrado é imutável (money-path: *"deleção exige prova positiva de ausência"*). Como os leitores já filtram `pendente`, **nenhum leitor precisou mudar** para a correção principal.

**Compare-and-swap em vez de relógio.** O advisory lock cobre só a transação da RPC, não a janela longa entre "o motor leu o snapshot" e "o motor chamou a função". Sem guard, dois recálculos sobrepostos terminam com o **mais lento** vencendo — e o mais lento é o que leu o snapshot mais velho (money-path §10). O hook lê a geração vigente **antes** do snapshot e a RPC recusa (`FG006`) se ela mudou. Não depende de relógio nenhum — nem do browser (que o cliente controla) nem do servidor.

**`SECURITY INVOKER`**, divergindo do `farmer_association_rules_substituir` (DEFINER). A RLS destas tabelas já expressa exatamente a regra (`farmer_id = auth.uid()` OU `cap_carteira_escrever`); com DEFINER eu teria que **replicar** o predicado no corpo, e uma cópia que diverge vira escalação — um employee passaria `p_farmer_id` de outra vendedora e expiraria a carteira dela. O gate explícito no corpo existe para a **mensagem**, não para autorizar.

## Efeitos colaterais tratados (§7: a correção só termina na tela)

Introduzir `'expirado'` torna alcançável um caminho que antes não existia. Três consumidores:

- **`usePropostaPreview`** não filtrava status — a proposta que vai ao cliente por WhatsApp ofereceria SKU que o motor já descartou. Passou a filtrar `pendente`.
- **`IntelligenceManagerialTab`** conta adoção por status; as expiradas inflariam o denominador e fariam a taxa despencar sozinha num painel que **compara vendedores**. `'expirado'` saiu do denominador — uma recomendação aposentada antes de chegar ao vendedor não é uma não-adoção dele, é uma não-oferta.
- **`proposta-preview-core`** filtrava `status === 'rejected'` — rótulo em inglês que a tabela **nunca produz** (o CHECK é pt-BR). Virou allowlist `{pendente, ofertado}`. Isto é defesa em profundidade, não correção de bug ativo: a proteção real é o filtro no SQL.

## Prova

`db/test-farmer-geracao-vigente.sh` — PG17 descartável, migration real aplicada:

- **31 asserts, 0 falhas, exit=0**
- Cobre: expiração + inserção atômica, **linha com desfecho intocável**, carteira de outro farmer intocada, `m_ij`/`lie` fixados NULL mesmo com o payload tentando mandá-los, o CHECK de coerência, o guard de ordem de apply, idempotência (aplicada 2×), lote vazio/NaN/Infinity/negativo/tipo inválido recusados **sem expirar nada**, teto de 50k, autorização (farmer B barrado, farmer A permitido, anon sem EXECUTE).
- **4 falsificações, todas morderam** (0 "não aplicou", 0 "sem dente"): remover `AND status='pendente'` arrasta a linha com desfecho; desligar o guard causal deixa a corrida passar; reduzir a finitude a `>= 0` deixa NaN entrar; trocar UPDATE por DELETE reduz o total.

O gate `afinidade-nao-e-dinheiro-gate` foi **repinado, não afrouxado**: a garantia `lie = NULL` migrou do payload do browser para o INSERT da RPC, o que é estritamente mais forte (antes um browser adulterado podia mandar `lie: 999`). O assert novo também pina que `m_ij`/`lie` seguem **na lista de colunas** do INSERT — se saíssem, o `DEFAULT 0` da tabela voltaria a fabricar zero.

## 2ª opinião — challenge Codex xhigh

Rodado sobre o desenho completo. Veredito inicial `DONE_WITH_CONCERNS`. **Cinco achados incorporados:**

1. **O gate estava em three-valued logic** — o mais grave, e o único que não era teórico. `IF NOT (a OR b OR c)` com `auth.uid()` NULL (sessão sem JWT) vira `IF NOT NULL`, que **não dispara** em PL/pgSQL: o guard devolvia nulo em vez de negar. Medido em prod: `NOT (false OR NULL OR false)` → `NULL`; `(false OR NULL OR false) IS NOT TRUE` → `true`. Fechado em TRUE explícito. **O harness inteiro rodava verde exatamente por esse buraco** — os asserts positivos passavam sem identidade nenhuma. Virou o assert `A4` + a falsificação `F5`.
2. **O protocolo era convenção, não invariante.** O compare-and-swap só valia entre as duas RPCs; um `.insert()` direto (aba com JS antigo, script, hook futuro) gravava pendente com `run_id` NULL, escapava da substituição e voltava a competir no topo. Fechado com trigger `BEFORE INSERT` nas duas tabelas (`FG008`) — a invariante passou a morar na tabela. Asserts `A5`/`A6`. A trigger provou-se viva antes do assert existir: ela barrou o **seed do próprio harness**, que precisou ser reordenado para antes da migration (que é a ordem real dos fatos).
3. **Snapshot degradado expiraria a carteira.** `farmer_association_rules` era lido com o `error` descartado no cast; uma falha de transporte virava mapa vazio e o cálculo seguia. Inócuo quando o resultado só se somava; **grave** agora que substitui. Passou a lançar.
4. **`FG005` comunicado como derrota.** O advisory lock significa "outro run em voo" — que pode até dar rollback. Dizer "as telas estão com o resultado dele" afirma um desfecho que não existe e desencoraja nova tentativa. Separado de `FG006` nos dois hooks.
5. **CHECK aceitava `status` NULL** (`(NULL='expirado') = (…)` → NULL, que o Postgres aprova) e **desempate não desempatava** (todas as linhas de um run compartilham `created_at`; faltava `id` como última chave nos 3 leitores com `limit`).

**Um achado foi verificado e não procede:** o Codex afirmou que o harness morreria no primeiro assert com `42501`, invalidando a prova. O log mostra P1 presente e 31 asserts executados — ele errou o sentido. Mas o defeito subjacente que ele farejou (o gate e a identidade) era real e virou o achado 1 acima, que é mais grave do que o relatado.

**Dois achados ficaram de fora, deliberadamente:**

- **Geração legitimamente vazia não substitui.** Os hooks só chamam a RPC com `length > 0` e a RPC recusa lote vazio. Quando o cálculo conclui corretamente que não deve haver nada, a geração antiga sobrevive. Mantive o precedente do repo (zero quase sempre é dado faltando a montante, e expirar por isso deixa a vendedora sem oferta nenhuma) — mas o custo é real e está registrado em chip próprio, com a medição pendente como primeiro passo.
- **Fallback de super_admin** grava geração com `farmer_id` próprio quando não há scores dele. Comportamento pré-existente ao PR, não introduzido nem agravado aqui (a expiração é escopada por `farmer_id`, então não toca carteira alheia).

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

**Ordem de apply:** depende de `20260725121000` (colunas `affinity_score`/`affinity_bundle` do #1520), que já está aplicada em prod. A migration tem um guard fail-closed que aborta com a instrução explícita caso não esteja, em vez de morrer com um `42703` críptico no meio.

**Janela entre migration e Publish:** a trigger `FG008` rejeita `.insert()` direto de pendente sem `run_id`. Entre aplicar a migration e publicar o frontend, uma aba com o JS antigo que clique em "Recalcular" recebe erro em vez de gravar. É deliberado e é o lado seguro — o toast do front antigo já diz *"N recomendações NÃO foram gravadas, as telas seguem com as anteriores"*, que é verdade. O outro lado seria empilhar em silêncio, que é o defeito sendo corrigido. Vale rodar os dois passos em sequência.

A validação pós-apply confere colunas, os dois CHECKs, os índices, as 2 triggers, as 2 RPCs como `INVOKER`, o gate fechando em `IS NOT TRUE` e os grants (`anon` sem EXECUTE).
