### PR TITLE
fix(sentinela): dois validadores meus cegaram 7 dos 17 checks no 1º tick [money-path]

### DIFF
--- a/db/test-data-health-watchdog-reemissao.sh
+++ b/db/test-data-health-watchdog-reemissao.sh
@@ -208,6 +208,26 @@ echo "migration aplicada: $(basename "$MIG")"
 # Idempotência: re-aplicar por cima de si mesma (marcador presente) e' no-op seguro.
 if P -q -f "$MIG" >/dev/null 2>&1; then ok "C15d migration e' idempotente (marcador reconhecido)"; else bad "C15d re-aplicar a migration falhou"; fi
 
+# A v2 desfaz 2 validadores da v1 que reprovavam dado LEGITIMO de prod (medido no 1o tick).
+MIG2="$REPO_ROOT/supabase/migrations/20260815153218_data_health_contrato_severity_idade.sql"
+P -q -f "$MIG2" >/dev/null
+echo "migration aplicada: $(basename "$MIG2")"
+V2=$(Pq -c "SELECT CASE WHEN pg_get_functiondef('public.data_health_watchdog()'::regprocedure) LIKE '%data_health reemissao v2%' THEN 'SIM' ELSE 'NAO' END;")
+eq "C15e marcador subiu para v2" "$V2" "SIM"
+if P -q -f "$MIG" >/dev/null 2>&1; then
+  bad "C15f re-aplicar a v1 por cima da v2 PASSOU (reintroduziria os validadores errados)"
+else ok "C15f re-aplicar a v1 por cima da v2 ABORTA (marcador versionado com dente)"; fi
+# a v1 pode ter deixado o corpo sabotado? nao -- ela abortou antes de tocar em nada. Confirma:
+V2B=$(Pq -c "SELECT CASE WHEN pg_get_functiondef('public.data_health_watchdog()'::regprocedure) LIKE '%data_health reemissao v2%' THEN 'SIM' ELSE 'NAO' END;")
+eq "C15g e o corpo vivo continua sendo a v2" "$V2B" "SIM"
+
+
+
+# shellcheck disable=SC2016  # $function$ e' o dollar-quote do plpgsql: literal de proposito.
+so_episodio() { sed -n '/CREATE OR REPLACE FUNCTION public._data_health_episodio/,/^\$function\$;$/p' ; }
+# shellcheck disable=SC2016
+so_watchdog() { sed -n '/CREATE OR REPLACE FUNCTION public.data_health_watchdog/,/^\$function\$;$/p' ; }
+
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 3 — HELPERS DE CENÁRIO
 # ══════════════════════════════════════════════════════════════════════════════
@@ -566,11 +586,15 @@ reset_tudo
 set_check vendas_pedidos stale warning 'Vendas: parado' 100000
 rodar
 eq "K5a alerta aberto" "$(alertas vendas_pedidos)" "1"
-# a conta de frescor quebra: volta 'ok' com idade nula
+# ⚠️ INVERTIDO pela v2 (20260815153218), depois de MEDIR a prod: `ok` com age_seconds NULL e'
+# o estado SAUDAVEL de 3 checks de frescor -- eles derivam a idade de min() sobre as linhas
+# PENDENTES, entao zero pendente => min NULL => idade NULL => ok. Reprovar isso cegou 7 dos 17
+# checks no 1o tick em producao. O oraculo nao era o teste (semeado com a premissa errada) --
+# era o corpo vivo de _data_health_compute.
 P -q -c "UPDATE public._dh_control SET status='ok', severity='info', age_seconds=NULL WHERE source='vendas_pedidos';" >/dev/null
 rodar
-eq "K5b frescor com idade NULA nao resolve (conta quebrada != recuperacao)" "$(alertas vendas_pedidos)" "1"
-eq "K5c e e' contabilizado como falha" "$(Pq -c "SELECT checks_falhos FROM public.data_health_watchdog_estado WHERE id;")" "1"
+eq "K5b frescor 'ok' com idade NULA e' LEGITIMO (zero pendente) e resolve" "$(alertas vendas_pedidos)" "0"
+eq "K5c e NAO e' contabilizado como falha" "$(Pq -c "SELECT checks_falhos FROM public.data_health_watchdog_estado WHERE id;")" "0"
 # ⚠️ mas o recorte e' SO' no ramo 'ok': frescor legitimamente BROKEN porque a fonte nunca
 # sincronizou devolve idade NULL (max(...) nulo => EXTRACT nulo). Barrar ali trocaria um alerta
 # especifico por um generico "vigia com check falhando" -- pior que o bug que se quer fechar.
@@ -585,9 +609,13 @@ eq "K5e e NAO e' contabilizado como falha" "$(Pq -c "SELECT checks_falhos FROM p
 reset_tudo
 set_check pedidos_compra_sync stale critical 'Pedidos: sync parado' 90000
 rodar
+# ⚠️ INVERTIDO pela v2: `severity` e' LITERAL POR CHECK ('critical'::text sem CASE nenhum) --
+# descreve quao grave e' o check QUANDO degrada, nao o estado atual. `ok`+`critical` e' o
+# estado normal de um check critico SAUDAVEL, nao contradicao.
 P -q -c "UPDATE public._dh_control SET status='ok', severity='critical' WHERE source='pedidos_compra_sync';" >/dev/null
 rodar
-eq "K6 status=ok com severity=critical nao resolve o alerta ativo" "$(alertas pedidos_compra_sync)" "1"
+eq "K6a status=ok com severity=critical e' LEGITIMO e resolve" "$(alertas pedidos_compra_sync)" "0"
+eq "K6b e a rodada segue COMPLETA (17/17, zero falhas)" "$(Pq -c "SELECT checks_avaliados||'/'||checks_falhos FROM public.data_health_watchdog_estado WHERE id;")" "17/0"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 5 — FALSIFICACAO (Lei #3): sabota => exige VERMELHO => restaura
@@ -599,7 +627,13 @@ verdicto() { # nome  resultado_do_cenario(0=verde,1=vermelho)
   if [ "$2" = "1" ]; then FALSIF_OK=$((FALSIF_OK+1)); echo "  [DENTE] $1 -- sabotagem ficou VERMELHA"
   else FALSIF_BAD=$((FALSIF_BAD+1)); echo "  [SEM-DENTE] $1 -- sabotagem passou VERDE (assert fraco)"; fi
 }
-restaurar() { P -q -f "$MIG" >/dev/null; }
+# Re-aplicar os arquivos inteiros nao serve mais: o guard da v1 ABORTA sobre o marcador v2
+# (de proposito). Restauramos exatamente as duas funcoes sob teste -- _data_health_episodio vem
+# da v1 (a v2 nao a recria) e data_health_watchdog vem da v2.
+restaurar() {
+  P -q -c "$(so_episodio < "$MIG")"  >/dev/null
+  P -q -c "$(so_watchdog < "$MIG2")" >/dev/null
+}
 
 # Cada cenario abaixo devolve 1 quando o invariante QUEBRA (ou seja: quando a sabotagem pegou).
 cen_lembrete() { reset_tudo; set_check carteira_scores stale warning 'M' 1000; rodar
@@ -657,10 +691,6 @@ sabota() { # nome  funcao  marcador_ascii  <sql-na-entrada-padrao>
 }
 EPIS='public._data_health_episodio(text,text,text,text,text,text,text,jsonb,text)'
 WD='public.data_health_watchdog()'
-# shellcheck disable=SC2016  # $function$ e' o dollar-quote do plpgsql: literal de proposito.
-so_episodio() { sed -n '/CREATE OR REPLACE FUNCTION public._data_health_episodio/,/^\$function\$;$/p' ; }
-# shellcheck disable=SC2016
-so_watchdog() { sed -n '/CREATE OR REPLACE FUNCTION public.data_health_watchdog/,/^\$function\$;$/p' ; }
 
 # --- F1: remove o predicado TEMPORAL (lembrete) ---
 if sabota "F1 predicado temporal" "$EPIS" "v_lembrete := false;" < <(perl -0pe 's/v_lembrete := [^;]*;/v_lembrete := false;/s' "$MIG" | so_episodio); then

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **472** custom migrations totais
-- **1605** objetos esperados (criados por estas migrations)
+- **473** custom migrations totais
+- **1606** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 485
+  - `function`: 486
   - `rls_policy`: 398
   - `index`: 240
   - `cron_job`: 164
@@ -3943,6 +3943,12 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.idx_fbrec_farmer_status_pendente` | `farmer_bundle_recommendations` |
 | `trigger` | `public.trg_frec_exige_run_id` | `farmer_recommendations` |
 | `trigger` | `public.trg_fbrec_exige_run_id` | `farmer_bundle_recommendations` |
+
+### `20260815153218_data_health_contrato_severity_idade.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.data_health_watchdog` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 472
+-- Total de custom migrations: 473
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -513,7 +513,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260814022626', 'reposicao_po_inexistente_antes_de', '20260814022626_reposicao_po_inexistente_antes_de.sql'),
   ('20260814160441', 'fu4f_fase3_afinidade_colunas_reaplica', '20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql'),
   ('20260814222000', 'data_health_watchdog_reemissao', '20260814222000_data_health_watchdog_reemissao.sql'),
-  ('20260814223445', 'farmer_recomendacoes_geracao_vigente', '20260814223445_farmer_recomendacoes_geracao_vigente.sql')
+  ('20260814223445', 'farmer_recomendacoes_geracao_vigente', '20260814223445_farmer_recomendacoes_geracao_vigente.sql'),
+  ('20260815153218', 'data_health_contrato_severity_idade', '20260815153218_data_health_contrato_severity_idade.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2107,7 +2108,8 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_frec_farmer_status_pendente', 'farmer_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_fbrec_farmer_status_pendente', 'farmer_bundle_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_frec_exige_run_id', 'farmer_recommendations'),
-  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations')
+  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations'),
+  ('data_health_contrato_severity_idade', 'function', 'public', 'data_health_watchdog', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3749,7 +3751,8 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_frec_farmer_status_pendente', 'farmer_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_fbrec_farmer_status_pendente', 'farmer_bundle_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_frec_exige_run_id', 'farmer_recommendations'),
-  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations')
+  ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations'),
+  ('data_health_contrato_severity_idade', 'function', 'public', 'data_health_watchdog', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260815153218_data_health_contrato_severity_idade.sql
+++ b/supabase/migrations/20260815153218_data_health_contrato_severity_idade.sql
@@ -1,0 +1,279 @@
+-- ============================================================================================
+-- Migration — Sentinela: desfaz DOIS validadores do contrato que reprovavam dado LEGÍTIMO
+-- (2026-08-15 · money-path · corrige a 20260814222000, medido em prod no 1º tick do v2)
+-- ============================================================================================
+-- INCIDENTE (auto-infligido, detectado pelo próprio dead-man): a 20260814222000 foi aplicada
+-- 2026-08-15 14:26 (SP). No PRIMEIRO tick do cron (14:30) o vigia registrou **7 dos 17 checks
+-- falhos** e `last_success_at` NÃO avançou — fail-closed funcionando, mas contra dado BOM:
+--
+--   status=ok + severity=critical  → vendas_pedidos · omie_tipo_produto_oben ·
+--                                    estoque_reposicao · pedidos_compra_sync
+--   ok + age_seconds NULL          → reposicao_portal_pipeline · reposicao_portal_humano ·
+--                                    tint_cobertura_bases
+--
+-- POR QUE OS DOIS ESTAVAM ERRADOS (medido no corpo vivo de `_data_health_compute`, não deduzido):
+--   1. `severity` é LITERAL POR CHECK — `'critical'::text AS severity` sem CASE nenhum (8
+--      ocorrências). Ela descreve "quão grave é ESTE check QUANDO degrada", não o estado atual.
+--      Logo `ok` + `critical` é o estado NORMAL de um check crítico saudável, não contradição.
+--   2. Os 3 de frescor derivam a idade de `min(atualizado_em)` sobre as linhas PENDENTES. Zero
+--      pendente ⇒ `min` NULL ⇒ `EXTRACT` NULL ⇒ `age_seconds` NULL COM `status='ok'`. É a
+--      forma de dizer "não há nada pendente, logo não há idade" — o caso SAUDÁVEL.
+--
+-- Custo real dos 30 min em que ficou no ar: os 7 checks NÃO eram avaliados (abortavam antes de
+-- qualquer coisa), o que inclui 2 vigias de money-path (`reposicao_portal_humano`,
+-- `pedidos_compra_sync`). Trocar silêncio-por-alerta-preso por silêncio-por-check-cego é pior
+-- que o bug original: pelo menos o preso tinha uma linha em `fin_alertas`.
+--
+-- LIÇÃO (a regra do repo que eu quebrei): "MEÇA o dado antes de propor o CHECK". Os dois
+-- validadores vieram de raciocínio do challenge Codex sobre combinações *teoricamente*
+-- contraditórias e foram para produção sem uma única query contra a distribuição REAL. O
+-- harness PG17 não pegou porque a mesa de controle foi semeada com a forma que eu ASSUMI — um
+-- fixture que reproduz a premissa errada confirma a premissa errada. O oráculo aqui não era o
+-- teste: era `pg_get_functiondef('_data_health_compute')` + um `SELECT` na distribuição.
+--
+-- O QUE FICA: todo o resto do contrato fail-closed permanece — status fora de
+-- {ok,stale,broken,unknown} e severity fora de {critical,warning,info} seguem abortando o
+-- check, sem resolver alerta ativo. Só os 2 predicados acima saem.
+--
+-- ⚠️ GUARD ANTI-DRIFT + marcador VERSIONADO: gerado do corpo VIVO de prod em 2026-08-15
+-- (md5 75befeb5f7e6607d0743ea45fba5b4d3, que é a v1 aplicada). Marcador sobe para
+-- 'data_health reemissao v2' — re-aplicar a 20260814222000 por cima desta ABORTA (o md5 não
+-- bate e o marcador v1 não está mais lá), em vez de reintroduzir os validadores em silêncio.
+--
+-- PROVA PG17: db/test-data-health-watchdog-reemissao.sh (aplica as DUAS migrations em ordem;
+-- K5/K6 invertidos para exigir que o dado legítimo seja ACEITO).
+-- ============================================================================================
+
+BEGIN;
+
+DO $guard$
+DECLARE
+  v_def text;
+  v_md5 text;
+BEGIN
+  IF to_regprocedure('public.data_health_watchdog()') IS NULL THEN
+    RAISE EXCEPTION USING message =
+      'PRE-FLIGHT ABORTOU: public.data_health_watchdog() não existe. Aplique antes a 20260814222000.';
+  END IF;
+  v_def := pg_get_functiondef('public.data_health_watchdog()'::regprocedure);
+  v_md5 := md5(v_def);
+  IF v_md5 <> '75befeb5f7e6607d0743ea45fba5b4d3' AND v_def NOT LIKE '%data_health reemissao v2%' THEN
+    RAISE EXCEPTION USING message =
+      'PRE-FLIGHT ABORTOU: data_health_watchdog vivo (md5 ' || v_md5 || ') não é a v1 esperada '
+      || '(md5 75befeb5f7e6607d0743ea45fba5b4d3) nem já é esta v2. Outra migration recriou a '
+      || 'função — rebasear sobre o pg_get_functiondef atual e re-gerar.';
+  END IF;
+END
+$guard$;
+
+CREATE OR REPLACE FUNCTION public.data_health_watchdog()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+-- data_health reemissao v2 (mig 20260815153218) — MARCADOR do guard anti-rollback.
+DECLARE
+  -- ⚠️ estoque_reposicao: 18º check, adicionado DIRETO EM PROD (migration fora do repo, drift §5),
+  --    promovido ao push (watchdog+heartbeat) lá. PRESERVADO aqui pra não revertê-lo do e-mail.
+  -- ⚠️ tint_vinculo_omie fica FORA de propósito (dashboard-only, [VIGIA tint 2026-06-15]).
+  -- Esta ARRAY é a fonte única: filtra o compute E define o esperado do dead-man. Duas listas
+  -- separadas driftariam, e o dead-man passaria a medir a própria omissão como sucesso.
+  v_sources text[] := ARRAY[
+    'vendas_pedidos','estoque_inventario','estoque_reposicao','reposicao_sugestoes','carteira_scores',
+    'custos_produtos','vendas_cadastros',
+    'reposicao_disparo','reposicao_portal_pipeline','reposicao_portal_humano',
+    'reposicao_sayerlack_fabricado','omie_tipo_produto_oben','vendas_familia_ausente',
+    'tint_cobertura_bases',
+    'custos_proxy_conf_alta','custos_product_cost_revivido','pedidos_compra_sync'];
+  v_deadman_h int := 3;   -- cron é */30 ⇒ 3h = 6 rodadas completas perdidas
+  r           record;
+  v_rows      jsonb;
+  v_n         int;
+  v_ndist     int;
+  v_esperado  int := array_length(v_sources, 1);
+  v_completa  boolean;
+  v_sev_fin   text;
+  v_fp        text;
+  v_msg_email text;
+  v_falhos    int := 0;
+  v_erros     text[] := '{}';
+  v_last_ok   timestamptz;
+  v_last_run  timestamptz;
+  v_cego      boolean;
+  v_msg_dm    text;
+BEGIN
+  -- ── DEAD-MAN (avalia o estado da rodada ANTERIOR, antes de sobrescrevê-lo) ────────────────
+  SELECT last_success_at, last_run_at INTO v_last_ok, v_last_run
+    FROM public.data_health_watchdog_estado WHERE id;
+
+  -- ⚠️ O ramo `last_success_at IS NULL` é obrigatório (achado Codex A3): um vigia que NUNCA
+  -- completou uma rodada tem marcador nulo, e ancorar só no marcador o deixaria calado
+  -- exatamente no cenário pior — quebrado desde o primeiro dia.
+  v_cego := (v_last_ok IS NOT NULL AND v_last_ok < clock_timestamp() - make_interval(hours => v_deadman_h))
+         OR (v_last_ok IS NULL AND v_last_run IS NOT NULL
+             AND v_last_run < clock_timestamp() - make_interval(hours => v_deadman_h));
+
+  IF v_cego THEN
+    v_msg_dm := 'Vigia de saúde de dados sem rodada COMPLETA desde '
+             || COALESCE(to_char(v_last_ok AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI'), 'NUNCA')
+             || ' — os checks estão sendo avaliados parcialmente e um incidente pode passar mudo.';
+    -- Isolado: se o OUTBOX estiver fora, o meta-alerta não pode derrubar a avaliação dos 17
+    -- checks. O sinal que sobrevive a um outbox morto é o marcador envelhecendo, não o e-mail.
+    BEGIN
+      PERFORM public._data_health_episodio(
+        'oben', 'data_health_watchdog_degradado', 'broken', 'critico',
+        '[Saúde de dados] vigia degradado', v_msg_dm, NULL,
+        jsonb_build_object('last_success_at', v_last_ok, 'limite_horas', v_deadman_h),
+        -- fingerprint ancorado no MINUTO do último sucesso: estável enquanto o vigia seguir cego
+        -- (senão o próprio dead-man viraria a tempestade que ele existe para denunciar).
+        md5('deadman|' || COALESCE(to_char(v_last_ok, 'YYYY-MM-DD"T"HH24:MI'), 'nunca')));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'data_health_watchdog: dead-man nao pode ser enfileirado: % %', SQLSTATE, SQLERRM;
+    END;
+  ELSIF v_last_ok IS NOT NULL THEN
+    UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+     WHERE company = 'oben' AND tipo = 'data_health_watchdog_degradado' AND dismissed_at IS NULL;
+  END IF;
+
+  INSERT INTO public.data_health_watchdog_estado (id, last_run_at, atualizado_em)
+  VALUES (true, clock_timestamp(), clock_timestamp())
+  ON CONFLICT (id) DO UPDATE SET last_run_at = clock_timestamp(), atualizado_em = clock_timestamp();
+
+  -- Materializa UMA execução do compute (é caro; e duas execuções poderiam divergir entre a
+  -- checagem de duplicata e o laço).
+  -- ⚠️ ISOLADO, e o laço fica CONDICIONADO ao sucesso (achado Codex A3): o `BEGIN/EXCEPTION` do
+  -- dead-man é subtransação, NÃO transação autônoma — um erro global DEPOIS dele (compute
+  -- quebrado, fonte duplicada) abortava a transação inteira e desfazia o próprio alerta do
+  -- dead-man, repetindo isso a cada 30 min sem deixar rastro nenhum.
+  v_rows := NULL;
+  BEGIN
+    SELECT COALESCE(jsonb_agg(to_jsonb(t)), '[]'::jsonb) INTO v_rows
+      FROM public._data_health_compute() t
+     WHERE t.source = ANY (v_sources);
+  EXCEPTION WHEN OTHERS THEN
+    IF left(SQLSTATE, 2) IN ('40','53','57','58','XX') THEN
+      RAISE;
+    END IF;
+    v_falhos := v_falhos + 1;
+    v_erros  := v_erros || ('_data_health_compute: ' || SQLSTATE || ' ' || SQLERRM);
+  END;
+
+  IF v_rows IS NULL THEN
+    v_n := 0; v_ndist := 0;
+  ELSE
+    SELECT count(*), count(DISTINCT x.source) INTO v_n, v_ndist
+      FROM jsonb_to_recordset(v_rows) AS x(source text);
+
+    -- Fonte DUPLICADA: o compute está quebrado. NÃO se avalia nada (nenhum alerta ativo pode ser
+    -- resolvido com base em dado que não se pode julgar) — mas também NÃO se aborta a transação,
+    -- senão o registro de estado e o meta-alerta iriam junto. Vira rodada incompleta, alta.
+    IF v_n <> v_ndist THEN
+      v_falhos := v_falhos + 1;
+      v_erros  := v_erros || ('_data_health_compute: fonte duplicada (' || v_n || ' linhas, '
+                              || v_ndist || ' fontes distintas) — laço NAO executado');
+      v_rows   := NULL;
+    END IF;
+  END IF;
+
+  v_completa := (v_rows IS NOT NULL AND v_n = v_esperado);
+
+  FOR r IN
+    SELECT * FROM jsonb_to_recordset(COALESCE(v_rows, '[]'::jsonb)) AS x(
+      source text, "domain" text, status text, age_seconds bigint,
+      expected_max_age_seconds bigint, freshness_basis text, message text,
+      last_error text, probable_cause text, how_to_fix text, severity text)
+  LOOP
+    -- Isolamento por check: um erro em 1 não pode cegar os outros 16. O preço do isolamento é
+    -- o silêncio — pago pelo dead-man + alerta dedicado abaixo.
+    BEGIN
+      IF r.status IS NULL OR r.status NOT IN ('ok','stale','broken','unknown') THEN
+        RAISE EXCEPTION 'status desconhecido em %: %', r.source, COALESCE(r.status,'<NULL>')
+          USING ERRCODE = '22023';
+      END IF;
+      IF r.severity IS NULL OR r.severity NOT IN ('critical','warning','info') THEN
+        RAISE EXCEPTION 'severity desconhecida em %: %', r.source, COALESCE(r.severity,'<NULL>')
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF r.status = 'ok' THEN
+        -- Resolução AUTOMÁTICA: só com 'ok' EXPLÍCITO. NULL/desconhecido nunca chega aqui.
+        UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+         WHERE company = 'oben' AND tipo = 'data_health_' || r.source AND dismissed_at IS NULL;
+      ELSE
+        v_sev_fin := CASE r.severity WHEN 'critical' THEN 'critico'
+                                     WHEN 'warning'  THEN 'aviso'
+                                     ELSE 'info' END;
+
+        -- FINGERPRINT: source|status|severity|message. Sem idade, sem timestamp, sem basis.
+        v_fp := md5(r.source || '|' || r.status || '|' || r.severity || '|' || COALESCE(r.message, ''));
+
+        -- DELTA [2026-07-08]: família-ausente e tint_cobertura_bases anexam a lista dos produtos
+        -- ao corpo do e-mail. COALESCE p/ não anexar se vier NULL. A lista fica FORA do
+        -- fingerprint de propósito (é volátil e enorme; a materialidade já está na contagem).
+        v_msg_email := CASE
+          WHEN r.source = 'vendas_familia_ausente'
+            THEN r.message || COALESCE(E'\n\n' || public._vendas_familia_ausente_lista_email(50), '')
+          WHEN r.source = 'tint_cobertura_bases'
+            THEN r.message || COALESCE(E'\n\n' || public._tint_cobertura_bases_lista_email(50), '')
+          ELSE r.message END;
+
+        PERFORM public._data_health_episodio(
+          'oben', 'data_health_' || r.source, r.status, v_sev_fin,
+          '[Saúde de dados] ' || r.source, r.message, v_msg_email,
+          jsonb_build_object('source', r.source, 'domain', r.domain, 'status', r.status,
+                             'age_seconds', r.age_seconds, 'freshness_basis', r.freshness_basis),
+          v_fp);
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      -- ⚠️ `WHEN OTHERS` ENGOLE falha SISTÊMICA (achado Codex F): permissão negada, tabela/coluna
+      -- inexistente, deadlock, disco cheio, erro interno — nada disso é "problema daquele check",
+      -- e engolir 17× troca um erro alto por 17 silêncios. Isolamento vale para falha LOCAL;
+      -- classe 40 (rollback/serialização), 53 (recursos), 57 (intervenção), 58 (sistema) e XX
+      -- (interno) são relançadas e derrubam a rodada inteira, alto e visível.
+      IF left(SQLSTATE, 2) IN ('40','53','57','58','XX') THEN
+        RAISE;
+      END IF;
+      v_falhos := v_falhos + 1;
+      v_erros  := v_erros || (COALESCE(r.source,'<?>') || ': ' || SQLSTATE || ' ' || SQLERRM);
+    END;
+  END LOOP;
+
+  -- ── Marcador de sucesso: só avança em rodada COMPLETA e SEM falha ─────────────────────────
+  UPDATE public.data_health_watchdog_estado SET
+      checks_avaliados = v_n,
+      checks_falhos    = v_falhos,
+      ultimo_erro      = CASE WHEN v_falhos = 0 AND v_completa THEN NULL
+                              ELSE left(array_to_string(v_erros, ' || '), 4000) END,
+      last_success_at  = CASE WHEN v_falhos = 0 AND v_completa THEN clock_timestamp()
+                              ELSE last_success_at END,
+      atualizado_em    = clock_timestamp()
+   WHERE id;
+
+  -- Falha BARULHENTA (não silenciosa): o isolamento por check só é aceitável com este alerta.
+  IF v_falhos > 0 OR NOT v_completa THEN
+    -- Isolado pelo mesmo motivo do dead-man: quando o próprio canal de e-mail é o que quebrou,
+    -- este INSERT também quebra — e derrubar a transação aqui APAGARIA o UPDATE de estado
+    -- acima, que é justamente a evidência durável de que a rodada foi ruim.
+    BEGIN
+      PERFORM public._data_health_episodio(
+        'oben', 'data_health_watchdog_erro', 'broken', 'critico',
+        '[Saúde de dados] vigia com check falhando',
+        'Rodada incompleta do vigia: ' || v_n || ' de ' || v_esperado || ' fonte(s) presente(s), '
+          || v_falhos || ' check(s) com erro. ' || COALESCE(left(array_to_string(v_erros, ' || '), 800), ''),
+        NULL,
+        jsonb_build_object('checks_avaliados', v_n, 'checks_esperados', v_esperado,
+                           'checks_falhos', v_falhos, 'erros', to_jsonb(v_erros)),
+        md5('vigia_erro|' || v_n::text || '|' || v_falhos::text || '|' || array_to_string(v_erros, '||')));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'data_health_watchdog: alerta de erro nao pode ser enfileirado: % %', SQLSTATE, SQLERRM;
+    END;
+    RAISE WARNING 'data_health_watchdog: % check(s) falharam; % de % fontes presentes',
+      v_falhos, v_n, v_esperado;
+  ELSE
+    UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+     WHERE company = 'oben' AND tipo = 'data_health_watchdog_erro' AND dismissed_at IS NULL;
+  END IF;
+END;
+$function$;
+COMMIT;


### PR DESCRIPTION
Correção urgente da [#1755](https://github.com/LucasSardenbergL/afiacao/pull/1755), medida no **primeiro tick do cron** depois do apply.

## O incidente (auto-infligido, e o próprio dead-man acusou)

A `20260814222000` entrou em prod às **14:26 (SP)**. Às **14:30**, primeira rodada do v2: **7 de 17 checks falhos**, `last_success_at` não avançou, alerta `data_health_watchdog_erro` aberto, 1 e-mail. O fail-closed funcionou — mas contra **dado bom**. Dois validadores que eu adicionei estavam errados:

| Validador meu | Checks que ele reprovou |
|---|---|
| `status=ok` + `severity=critical` | `vendas_pedidos` · `omie_tipo_produto_oben` · `estoque_reposicao` · `pedidos_compra_sync` |
| `ok` + `age_seconds` NULL | `reposicao_portal_pipeline` · `reposicao_portal_humano` · `tint_cobertura_bases` |

**Por que os dois estavam errados** — medido no corpo vivo de `_data_health_compute`, não deduzido:

1. **`severity` é LITERAL por check** (`'critical'::text AS severity`, sem `CASE` nenhum — 8 ocorrências). Descreve *quão grave é este check quando degrada*, não o estado atual. `ok` + `critical` é o estado **normal** de um check crítico saudável.
2. Os 3 de frescor derivam a idade de `min(atualizado_em)` sobre as linhas **pendentes**. Zero pendente ⇒ `min` NULL ⇒ `EXTRACT` NULL ⇒ `age_seconds` NULL **com `status='ok'`**. É a forma de dizer "não há nada pendente", o caso são.

**Custo real dos 30 min no ar:** os 7 checks não eram avaliados (abortavam antes de qualquer coisa), incluindo 2 vigias de money-path. Trocar *silêncio-por-alerta-preso* por *silêncio-por-check-cego* é pior que o bug original — pelo menos o preso tinha uma linha em `fin_alertas`.

## A regra que eu quebrei

Está no próprio repo: **"MEÇA o dado antes de propor o CHECK"**. Os dois validadores vieram de raciocínio do challenge Codex sobre combinações *teoricamente* contraditórias e foram para produção sem uma única query contra a distribuição real.

E o harness não pegou porque **a mesa de controle foi semeada com a forma que eu assumi** — um fixture que reproduz a premissa errada confirma a premissa errada. O oráculo aqui não era o teste: era `pg_get_functiondef('_data_health_compute')` mais um `SELECT` na distribuição. Fica registrado em `docs/agent/sync.md`.

## O que fica

Todo o resto do contrato fail-closed permanece: `status` fora de `{ok,stale,broken,unknown}` e `severity` fora de `{critical,warning,info}` seguem abortando o check sem resolver alerta ativo. Saem só os 2 predicados acima.

O marcador sobe para **`data_health reemissao v2`**: re-aplicar a `20260814222000` por cima desta **aborta** em vez de reintroduzir os validadores em silêncio (assert `C15f`).

## Prova

**91 asserts, 10 sabotagens todas vermelhas**, idênticos sob `LC_ALL=C` e `pt_BR.UTF-8`. O harness passa a aplicar as **duas** migrations em ordem; `K5`/`K6` foram **invertidos** — antes exigiam que o dado legítimo fosse recusado, agora exigem que seja aceito e que a rodada siga 17/0.

## ⚠️ Migration manual

Este PR adiciona `supabase/migrations/20260815153218_data_health_contrato_severity_idade.sql`. **Mergear não toca o banco** — enquanto não for colada no SQL Editor, os 7 checks seguem cegos a cada 30 min.