### PR TITLE
fix(ci): o edges:typecheck herdava o drift do FRONTEND — main vermelha 38min sem commit culpado

### DIFF
--- a/docs/historico/ci-testes-edge-deno.md
+++ b/docs/historico/ci-testes-edge-deno.md
@@ -413,3 +413,104 @@ portal Sayerlack) tiveram a superfície da lib medida antes: só `.from()` e `.r
 4. Versionar `deno.lock` (hoje no `.gitignore`) — reprodutibilidade + chave de cache estável. **Subiu de
    prioridade:** com todo o repo em `@2` (range, não pin), o lock passa a ser o *único* lugar que prende a
    versão resolvida; sem ele, uma publicação do `@supabase/supabase-js` pode ficar vermelha num PR alheio.
+
+# Sequela (2026-08-15): a main VERMELHA sem commit culpado — o gate herdava o drift do FRONTEND, e o gatilho era o RELÓGIO
+
+## O achado
+
+`validate` vermelho na `main`, step **"Type check (edge functions — Deno)"**:
+
+```
+error: Could not find npm package '@swc/core-linux-arm-gnueabihf' matching '1.16.0'.
+❌ NÃO FOI POSSÍVEL TYPE-CHECAR as edges (exit 1)
+```
+
+Auto-merge de **todos** os PRs parado (o `auto-merge.yml` exige `validate` verde), ~20 worktrees sem
+entregar. E nenhum commit para culpar: entre o último verde (09:37Z) e o primeiro vermelho (17:27Z) a
+`main` só recebeu dois commits do Lovable, ambos tocando **apenas** `src/integrations/supabase/types.ts`.
+`@swc/core` nem está no `package.json` — entra por `@vitejs/plugin-react-swc`.
+
+## A mecânica — três fatos que só juntos explicam
+
+1. **O gate lia o `package.json` do frontend.** O `spawnSync` roda com `cwd: raiz`, e o Deno
+   auto-resolve o `package.json` de lá. Prova mínima: um `deno check` de um `.ts` **vazio**, que não
+   importa nada, rodado da raiz com `DENO_DIR` virgem, baixa o packument de `vitest`, `@eslint/js`,
+   `@hookform/resolvers`, `@elevenlabs/react`… — as ~100 deps de build/UI, nenhuma usada por edge
+   alguma. O gate de *edge* era refém do grafo npm do *frontend*.
+2. **O Deno tem cooldown de supply-chain** (`--minimum-dependency-age`, default 24h): recusa versão
+   publicada há menos disso. A mensagem completa denuncia — e foi o fio da meada:
+   `A newer matching version was found, but it was not used because it was newer than the specified
+   minimum dependency date of 2026-08-14 17:49:11 UTC`.
+3. **Publicação escalonada + pin exato.** `@swc/core@1.16.0` saiu 14/08 **17:23:06Z**; seus **12**
+   binários de plataforma, pinados em versão **EXATA** nos `optionalDependencies`, terminaram de sair
+   só às **18:01:25Z**.
+
+Junte: a janela de 24h **desliza com o relógio**, então o pai entrou na janela 38 min antes dos filhos.
+Nessa fresta o Deno aceita `@swc/core@1.16.0` e recusa os binários dele — e como o pin é exato, **não há
+versão anterior para onde cair** (um range `^` teria degradado em silêncio para a 1.15.47 madura).
+
+Cronologia, e o encaixe é de 4 minutos:
+
+| momento | corte de 24h | estado |
+|---|---|---|
+| 15/08 09:37Z | 14/08 09:37Z | pai ainda "novo" → Deno cai para 1.15.47 → **verde** |
+| 15/08 **17:23:06Z** | = publicação do pai | pai entra na janela, filhos não |
+| 15/08 **17:27Z** | — | **primeiro run vermelho** |
+| 15/08 **18:01:25Z** | = último binário | fresta fecha → **volta a verde sozinho** |
+
+O erro **anda** entre binários conforme cada um amadurece (`linux-arm-gnueabihf` no CI às 17:34Z,
+`linux-arm64-gnu` no repro local às 17:49Z): assinatura inconfundível de janela deslizante.
+
+## O reflexo errado — e por que
+
+O diagnóstico natural é "o `^` deixou escorregar para uma versão quebrada; **pine** `@swc/core` via
+`overrides`". O Deno **respeita** `overrides` (verificado: com `"@swc/core": "1.13.2"` ele resolve
+1.13.2), então funcionaria. Mesmo assim é o conserto errado:
+
+- trata **um** pacote e deixa a **classe** viva — qualquer dep de build com binários de plataforma
+  repete isso na próxima release;
+- **congela o build do frontend** para consertar um gate de *edge* — acoplamento invertido;
+- mexe em `package.json` + **3** lockfiles, a superfície mais disputada do repo (~20 worktrees).
+
+O gate, aliás, **acertou**: ele é fail-closed de propósito e reprovou uma resolução que de fato não
+fechou. Afrouxá-lo (`--no-check`, allowlist) trocaria o problema por cegueira.
+
+## A correção
+
+`DENO_NO_PACKAGE_JSON=1` no `spawnSync` do gate (`scripts/edges-typecheck-gate.ts`) — o Deno para de
+auto-resolver o `package.json`. As edges seguem resolvendo seus `npm:` explícitos do registry, que é
+o que o Edge Runtime do Supabase faz de verdade (lá não existe `package.json`). Um arquivo, zero
+lockfile, e a classe inteira morre: o gate deixa de ter opinião sobre dependência de frontend.
+
+Extraído para `ambienteDeno()` (exportado) para o teste travar o invariante — a chave sumir devolve o
+gate à mercê do relógio, e a falha seria **intermitente**, ~24h depois de uma release alheia.
+
+## Falsificação
+
+A janela fecha sozinha às 18:01:25Z, então "passou" deixaria de distinguir **fix** de **auto-cura** —
+o oráculo tinha prazo de validade. `--minimum-dependency-age` aceita timestamp absoluto, o que torna o
+teste determinístico **a qualquer hora**, hoje ou daqui a um mês:
+
+```bash
+# corte que replica o 1º run vermelho (pai maduro, binários não)
+deno check --no-lock --node-modules-dir=none --minimum-dependency-age=2026-08-14T17:27:00Z x.ts
+```
+
+| | resultado |
+|---|---|
+| sem `DENO_NO_PACKAGE_JSON` | **exit 1** — `Could not find npm package '@swc/core-darwin-arm64' matching '1.16.0'` |
+| com `DENO_NO_PACKAGE_JSON=1` | **exit 0**, e **zero** downloads do registry npm |
+
+(`darwin-arm64` saiu 17:27:20Z — 20 s depois do corte.) O repro também exigiu `DENO_DIR` **virgem**: com
+cache quente o gate passava local enquanto o CI, sempre frio, quebrava — cache quente é ausência de
+sinal, não aprovação.
+
+## Lição transferível
+
+**Um gate só deve resolver o que ele checa.** O acoplamento aqui não foi escrito por ninguém — veio de
+graça do `cwd`, e ficou invisível enquanto o registro npm estava calmo. Vale a pergunta em qualquer
+gate: *o que ele baixa que não tem nada a ver com o que ele afirma?*
+
+E: **quando o gatilho é o relógio, o oráculo tem prazo de validade.** Um bug que se auto-cura fabrica
+falso-positivo em quem for validar depois — a prova precisou congelar o tempo (`--minimum-dependency-age`)
+em vez de correr contra ele.

--- a/scripts/edges-typecheck-gate.test.ts
+++ b/scripts/edges-typecheck-gate.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   CLASSES_BLOQUEANTES,
+  ambienteDeno,
   classificar,
   enumerarEdges,
   extrairOcorrencias,
@@ -186,6 +187,18 @@ describe('invariantes do gate', () => {
     for (const divida of ['TS2345', 'TS2322', 'TS2339', 'TS2571', 'TS2578', 'TS2769']) {
       expect(CLASSES_BLOQUEANTES.has(divida)).toBe(false);
     }
+  });
+
+  it('roda o deno SEM auto-resolver o package.json do frontend (armadilha 4)', () => {
+    // 2026-08-15: a main ficou VERMELHA por ~38 min sem que commit algum tocasse o package.json.
+    // O `cwd: raiz` fazia o Deno resolver as ~100 deps de build/UI, e o cooldown de supply-chain
+    // dele (--minimum-dependency-age, 24h) aceitou `@swc/core@1.16.0` às 17:23:06Z enquanto os 12
+    // binários de plataforma — pinados em versão EXATA — só entraram às 18:01:25Z. Tirar esta
+    // chave devolve o gate à mercê do RELÓGIO: falha ~24h depois de qualquer release de dep de
+    // build, intermitente, e trava o auto-merge de TODOS os PRs.
+    expect(ambienteDeno({}).DENO_NO_PACKAGE_JSON).toBe('1');
+    // e preserva o herdado — zerar o PATH viraria "não consegui executar o deno" (falha de infra).
+    expect(ambienteDeno({ PATH: '/usr/bin' }).PATH).toBe('/usr/bin');
   });
 
   it('enumera as edges do repo de verdade (glob vazio seria falso-verde)', () => {

--- a/scripts/edges-typecheck-gate.ts
+++ b/scripts/edges-typecheck-gate.ts
@@ -26,7 +26,7 @@
  * MENOR — e criaria um arquivo-lista que vira ímã de conflito entre as ~30 worktrees paralelas.
  * Apertar para check completo é o destino natural, depois que a dívida encolher.
  *
- * TRÊS ARMADILHAS VALIDADAS EMPIRICAMENTE (2026-07-21, deno 2.9.2 — o pin do CI):
+ * QUATRO ARMADILHAS VALIDADAS EMPIRICAMENTE (2026-07-21 e 2026-08-15, deno 2.9.2 — o pin do CI):
  *
  *  1. `--node-modules-dir=none` é OBRIGATÓRIO. Sem ele o `deno check` ABORTA na RESOLUÇÃO, antes
  *     de type-checar qualquer coisa: o package.json da raiz põe o Deno em modo node_modules e o
@@ -41,6 +41,22 @@
  *  3. Com o cache de check quente a saída é COMPLETAMENTE VAZIA e exit 0. Ou seja, "saída vazia"
  *     é o caso de SUCESSO normal — não pode ser lido como anomalia. A decisão pende do exit code
  *     + do marcador acima, nunca do volume de saída.
+ *
+ *  4. `DENO_NO_PACKAGE_JSON=1` é OBRIGATÓRIO, senão o gate herda o drift do FRONTEND (2026-08-15).
+ *     O `cwd: raiz` faz o Deno auto-resolver o package.json e buscar no registry o packument das
+ *     ~100 deps de build/UI — nenhuma usada por edge alguma: um `deno check` de um `.ts` VAZIO
+ *     rodado da raiz baixa `vitest`, `@eslint/js`, `@hookform/resolvers`… Somado ao cooldown de
+ *     supply-chain do Deno (`--minimum-dependency-age`, default 24h), o gate vira refém do RELÓGIO:
+ *     `@swc/core@1.16.0` (via `@vitejs/plugin-react-swc`) cruzou a janela de 24h às 17:23:06Z, mas
+ *     seus 12 binários de plataforma — pinados em versão EXATA nos `optionalDependencies` — só
+ *     terminaram de entrar às 18:01:25Z. Nessa fresta de 38 min a resolução não fecha e a MAIN
+ *     INTEIRA fica vermelha (auto-merge de todos os PRs parado) sem que commit algum toque o
+ *     package.json: verde 09:37Z, vermelho 17:27Z — 4 min após o pai cruzar o corte. Range `^`
+ *     degrada para a versão anterior madura; pin exato não tem para onde cair. NÃO consertar
+ *     pinando `@swc/core` (trata um pacote e deixa a classe viva, e congela o build do frontend
+ *     por causa de um gate de edge). Repro determinístico, a qualquer hora:
+ *       deno check --no-lock --node-modules-dir=none --minimum-dependency-age=2026-08-14T17:27:00Z x.ts
+ *     → falha sem a env var, passa com ela.
  *
  * FAIL-CLOSED (CLAUDE.md: "ausência de sinal NÃO é aprovação"):
  *   exit 0                              → passa
@@ -186,6 +202,18 @@ export function enumerarEdges(raiz: string): string[] {
 }
 
 /** Agrupa por código, para reportar a dívida tolerada de forma compacta. */
+/**
+ * Ambiente do `deno check`. `DENO_NO_PACKAGE_JSON=1` desacopla o gate do package.json do FRONTEND
+ * (armadilha 4 no cabeçalho) — sem ele o `cwd: raiz` arrasta ~100 deps de build/UI para dentro da
+ * resolução e o drift delas derruba a main. Preserva o ambiente herdado: zerar o PATH aqui viraria
+ * "não consegui executar o deno", ou seja, falha de INFRA disfarçada de gate.
+ */
+export function ambienteDeno(
+  base: Record<string, string | undefined> = process.env,
+): Record<string, string | undefined> {
+  return { ...base, DENO_NO_PACKAGE_JSON: '1' };
+}
+
 function resumirPorCodigo(ocs: Ocorrencia[]): string {
   const porCodigo = new Map<string, number>();
   for (const o of ocs) porCodigo.set(o.codigo, (porCodigo.get(o.codigo) ?? 0) + 1);
@@ -214,7 +242,12 @@ function main(): number {
   }
 
   const args = ['check', '--no-lock', '--node-modules-dir=none', ...edges];
-  const proc = spawnSync('deno', args, { cwd: raiz, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  const proc = spawnSync('deno', args, {
+    cwd: raiz,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+    env: ambienteDeno(),
+  });
 
   if (proc.error) {
     console.error(`❌ edges-typecheck-gate: não consegui executar o deno — ${proc.error.message}`);
@@ -229,7 +262,10 @@ function main(): number {
     return veredito.tipo === 'passa' ? 0 : 1;
   }
 
-  console.log(`🔎 edges-typecheck-gate — ${edges.length} edges · deno check ${args.slice(1, 3).join(' ')}`);
+  console.log(
+    `🔎 edges-typecheck-gate — ${edges.length} edges · deno check ${args.slice(1, 3).join(' ')}` +
+      ' · DENO_NO_PACKAGE_JSON=1',
+  );
 
   if (veredito.tipo === 'bloqueia' && veredito.motivo === 'infra') {
     console.error(


### PR DESCRIPTION
## O que aconteceu

`validate` vermelho na `main` no step **"Type check (edge functions — Deno)"** — auto-merge de **todos** os PRs parado (~20 worktrees sem entregar), e **nenhum commit para culpar**: entre o último verde (09:37Z) e o primeiro vermelho (17:27Z) a `main` só recebeu dois commits do Lovable, ambos tocando apenas `src/integrations/supabase/types.ts`.

```
error: Could not find npm package '@swc/core-linux-arm-gnueabihf' matching '1.16.0'.
```

## Causa raiz — o gatilho era o RELÓGIO, não o código

Três fatos que só juntos explicam:

1. **O gate lia o `package.json` do frontend.** `spawnSync` roda com `cwd: raiz` e o Deno auto-resolve o `package.json` de lá. Prova mínima: um `deno check` de um `.ts` **vazio**, que não importa nada, rodado da raiz com `DENO_DIR` virgem, baixa `vitest`, `@eslint/js`, `@hookform/resolvers`, `@elevenlabs/react`… — as ~100 deps de build/UI, **nenhuma** usada por edge alguma.
2. **O Deno tem cooldown de supply-chain** (`--minimum-dependency-age`, default 24h). A mensagem completa foi o fio da meada: *"A newer matching version was found, but it was not used because it was newer than the specified minimum dependency date of 2026-08-14 17:49:11 UTC"*.
3. **Publicação escalonada + pin exato.** `@swc/core@1.16.0` saiu 14/08 **17:23:06Z**; seus **12** binários de plataforma, pinados em versão **EXATA** nos `optionalDependencies`, só terminaram às **18:01:25Z**.

A janela de 24h **desliza com o relógio**, então o pai entrou 38 min antes dos filhos. Nessa fresta o Deno aceita `@swc/core@1.16.0` e recusa os binários — e como o pin é exato, **não há versão anterior para onde cair** (um range `^` teria degradado em silêncio para a 1.15.47 madura).

| momento | corte de 24h | estado |
|---|---|---|
| 15/08 09:37Z | 14/08 09:37Z | pai ainda "novo" → Deno cai para 1.15.47 → **verde** |
| 15/08 **17:23:06Z** | = publicação do pai | pai entra, filhos não |
| 15/08 **17:27Z** | — | **1º run vermelho** (4 min depois) |
| 15/08 **18:01:25Z** | = último binário | fresta fecha → **volta a verde sozinho** ✅ |

O erro **anda** entre binários conforme cada um amadurece (`linux-arm-gnueabihf` no CI às 17:34Z, `linux-arm64-gnu` no repro local às 17:49Z) — assinatura inconfundível de janela deslizante. **A `main` já se auto-curou** (run das 17:57:45Z fechou em `success`); este PR impede a recorrência, que é certa na próxima release de qualquer dep de build com binários de plataforma.

## Por que NÃO pinar `@swc/core`

O Deno **respeita** `overrides` (verificado: com `"@swc/core": "1.13.2"` ele resolve 1.13.2), então funcionaria. Ainda assim é o conserto errado: trata **um** pacote e deixa a **classe** viva; **congela o build do frontend** para consertar um gate de *edge* (acoplamento invertido); e mexe em `package.json` + **3** lockfiles, a superfície mais disputada do repo.

O gate **não foi afrouxado** — ele acertou ao reprovar (fail-closed; *"ausência de sinal não é aprovação"*). O que mudou é ele parar de arrastar dependência que não é dele.

## A correção

`DENO_NO_PACKAGE_JSON=1` no `spawnSync`. As edges seguem resolvendo seus `npm:` explícitos do registry — que é o que o Edge Runtime do Supabase faz de verdade (lá não existe `package.json`). Um arquivo, zero lockfile. Extraído para `ambienteDeno()` para o teste travar o invariante: a chave sumir devolve o gate à mercê do relógio, com falha **intermitente** ~24h depois de uma release alheia.

## Evidência

**94 edges, `DENO_DIR` virgem, com o fix:** exit 0, **0 classe-crash**, 136 tolerados com distribuição **idêntica ao baseline** — `TS2339:39 TS2345:36 TS2322:18 TS2578:13 TS2353:8 TS2571:8 TS2769:7 TS7006:4 TS2538:2 TS2561:1`. Nenhum poder de detecção perdido.

**Falsificação determinística.** A janela se auto-cura às 18:01:25Z, então "passou" deixaria de distinguir **fix** de **auto-cura** — o oráculo tinha prazo de validade. `--minimum-dependency-age` aceita timestamp absoluto, o que congela o tempo:

```bash
deno check --no-lock --node-modules-dir=none --minimum-dependency-age=2026-08-14T17:27:00Z x.ts
```

| | resultado |
|---|---|
| sem `DENO_NO_PACKAGE_JSON` | **exit 1** — `Could not find npm package '@swc/core-darwin-arm64' matching '1.16.0'` |
| com `DENO_NO_PACKAGE_JSON=1` | **exit 0**, e **zero** downloads do registry npm |

(`darwin-arm64` saiu 17:27:20Z — 20 s depois do corte.) O repro também exigiu `DENO_DIR` **virgem**: com cache quente o gate passava local enquanto o CI, sempre frio, quebrava.

Local: `scripts:typecheck` exit 0 · `edges-typecheck-gate.test.ts` **12 passed**.

## Lição registrada

`docs/historico/ci-testes-edge-deno.md` (nova sequela): **um gate só deve resolver o que ele checa** — o acoplamento não foi escrito por ninguém, veio de graça do `cwd`. E **quando o gatilho é o relógio, o oráculo tem prazo de validade**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)