### PR TITLE
feat(farmer): a geração VAZIA passa a existir — o zero que ninguém conseguia contar [money-path]

### DIFF
--- a/db/test-farmer-head-geracao.sh
+++ b/db/test-farmer-head-geracao.sh
@@ -1,0 +1,759 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA — 20260815181500_farmer_geracao_head_sensor.sql                       ║
+# ║      bash db/test-farmer-head-geracao.sh > /tmp/t.log 2>&1; echo "exit=$?"   ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                      ║
+# ║                                                                               ║
+# ║  O que se prova: o head de geração AVANÇA mesmo quando a geração é VAZIA —   ║
+# ║  o caso que o #1756 deixou de fora — sem expirar nada, e distinguindo         ║
+# ║  "nunca rodou" de "rodou e deu vazio". Mais a REGRESSÃO do #1756: as duas     ║
+# ║  RPCs de substituição foram RECRIADAS (aridade nova) e não podem ter perdido  ║
+# ║  nenhuma das defesas que aquela migration provou.                             ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5472}"
+SLUG="farmer-head"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+GRANT USAGE ON SCHEMA auth TO authenticated, anon;
+GRANT EXECUTE ON FUNCTION auth.uid(), auth.role() TO authenticated, anon;
+SQL
+
+# Os asserts POSITIVOS rodam pelo caminho de servidor (service_role), como o cron/edge.
+"$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d postgres -q -c "ALTER DATABASE prove SET test.role = 'service_role';"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# usado SÓ na falsificação: espelha eq() mas com o veredito INVERTIDO (queremos vermelho).
+eq_esperando_vermelho() {
+  if [ "$2" = "$3" ]; then bad "FALSIFICAÇÃO SEM DENTE: $1 continuou [$2] com a migration sabotada"
+  else ok "falsificação mordeu: $1 virou [$2] (íntegro seria [$3])"; fi
+}
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (espelham o schema REAL de prod, medido via psql-ro)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.caps (user_id uuid PRIMARY KEY, escrever boolean DEFAULT false, ler boolean DEFAULT false);
+CREATE OR REPLACE FUNCTION private.cap_carteira_escrever(p_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'private','pg_temp'
+  AS $f$ SELECT coalesce((SELECT escrever FROM private.caps WHERE user_id = p_uid), false) $f$;
+CREATE OR REPLACE FUNCTION private.cap_carteira_ler(p_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'private','pg_temp'
+  AS $f$ SELECT coalesce((SELECT ler FROM private.caps WHERE user_id = p_uid), false) $f$;
+CREATE OR REPLACE FUNCTION private.carteira_visivel_para(p_cliente uuid, p_uid uuid) RETURNS boolean
+  LANGUAGE sql STABLE AS $f$ SELECT false $f$;
+
+CREATE TABLE IF NOT EXISTS public.omie_products (id uuid PRIMARY KEY, descricao text);
+
+CREATE TABLE IF NOT EXISTS public.farmer_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  recommendation_type text NOT NULL,
+  product_id uuid REFERENCES public.omie_products(id),
+  current_product_id uuid REFERENCES public.omie_products(id),
+  p_ij numeric DEFAULT 0, m_ij numeric DEFAULT 0, lie numeric DEFAULT 0,
+  complexity_factor numeric DEFAULT 1, cluster_volume_estimate numeric DEFAULT 1,
+  offered_at timestamptz, accepted_at timestamptz, rejected_at timestamptz,
+  actual_margin numeric, time_spent_seconds integer,
+  status text DEFAULT 'pendente',
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  affinity_score numeric,
+  CONSTRAINT farmer_recommendations_recommendation_type_check
+    CHECK (recommendation_type = ANY (ARRAY['cross_sell'::text,'up_sell'::text])),
+  CONSTRAINT farmer_recommendations_status_check
+    CHECK (status = ANY (ARRAY['pendente'::text,'ofertado'::text,'aceito'::text,'rejeitado'::text,'expirado'::text]))
+);
+
+CREATE TABLE IF NOT EXISTS public.farmer_bundle_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL,
+  customer_user_id uuid NOT NULL,
+  bundle_products jsonb NOT NULL DEFAULT '[]'::jsonb,
+  bundle_type text NOT NULL DEFAULT 'cross_sell',
+  support numeric DEFAULT 0, confidence numeric DEFAULT 0, lift numeric DEFAULT 0,
+  p_bundle numeric DEFAULT 0, m_bundle numeric DEFAULT 0, lie_bundle numeric DEFAULT 0,
+  complexity_factor numeric DEFAULT 1,
+  status text DEFAULT 'pendente',
+  offered_at timestamptz, accepted_at timestamptz, rejected_at timestamptz,
+  actual_margin numeric, time_spent_seconds integer, accepted_products jsonb,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  affinity_bundle numeric,
+  CONSTRAINT farmer_bundle_recommendations_status_check
+    CHECK (status = ANY (ARRAY['pendente'::text,'ofertado'::text,'aceito_total'::text,'aceito_parcial'::text,'rejeitado'::text]))
+);
+
+ALTER TABLE public.farmer_recommendations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.farmer_bundle_recommendations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY frec_select_carteira ON public.farmer_recommendations FOR SELECT TO authenticated
+  USING ((SELECT private.cap_carteira_ler((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid()))
+         OR private.carteira_visivel_para(customer_user_id, (SELECT auth.uid())));
+CREATE POLICY frec_insert_own_or_gestor ON public.farmer_recommendations FOR INSERT TO authenticated
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY frec_update_own_or_gestor ON public.farmer_recommendations FOR UPDATE TO authenticated
+  USING ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())))
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+
+CREATE POLICY fbrec_select_carteira ON public.farmer_bundle_recommendations FOR SELECT TO authenticated
+  USING ((SELECT private.cap_carteira_ler((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY fbrec_insert_own_or_gestor ON public.farmer_bundle_recommendations FOR INSERT TO authenticated
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+CREATE POLICY fbrec_update_own_or_gestor ON public.farmer_bundle_recommendations FOR UPDATE TO authenticated
+  USING ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())))
+  WITH CHECK ((SELECT private.cap_carteira_escrever((SELECT auth.uid()))) OR (farmer_id = (SELECT auth.uid())));
+SQL
+
+FARMER_A='aaaaaaaa-1111-1111-1111-111111111111'
+FARMER_B='bbbbbbbb-2222-2222-2222-222222222222'
+FARMER_C='cccccccc-3333-3333-3333-333333333333'   # nunca roda o motor: prova o head AUSENTE
+CLI_1='ccccccc1-1111-1111-1111-111111111111'
+CLI_2='ccccccc2-2222-2222-2222-222222222222'
+PROD_1='dddddddd-1111-1111-1111-111111111111'
+PROD_2='dddddddd-2222-2222-2222-222222222222'
+
+# Seed do LEGADO ANTES da migration do #1756 — a trigger trg_frec_exige_run_id rejeita
+# pendente sem run_id, então esta ordem é a única que reproduz a realidade de prod.
+P -q <<SQL
+INSERT INTO auth.users(id) VALUES ('$FARMER_A'),('$FARMER_B'),('$FARMER_C'),('$CLI_1'),('$CLI_2') ON CONFLICT DO NOTHING;
+INSERT INTO public.omie_products(id, descricao) VALUES ('$PROD_1','Lixa 120'),('$PROD_2','Verniz PU') ON CONFLICT DO NOTHING;
+
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, p_ij, affinity_score, status, created_at)
+VALUES
+  ('$FARMER_A','$CLI_1','cross_sell','$PROD_1', 9.9, 0.99, 'pendente', now() - interval '70 days'),
+  ('$FARMER_A','$CLI_2','up_sell',   '$PROD_1', 3.0, 0.30, 'pendente', now() - interval '70 days');
+
+-- Linha com DESFECHO: histórico, tem de sobreviver a todo recálculo (regressão do #1756).
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, p_ij, affinity_score, status, offered_at, accepted_at)
+VALUES ('$FARMER_A','$CLI_1','cross_sell','$PROD_1', 7.0, 0.70, 'aceito', now() - interval '60 days', now() - interval '59 days');
+
+INSERT INTO public.farmer_recommendations
+  (farmer_id, customer_user_id, recommendation_type, product_id, p_ij, affinity_score, status)
+VALUES ('$FARMER_B','$CLI_2','cross_sell','$PROD_1', 8.0, 0.80, 'pendente');
+
+INSERT INTO public.farmer_bundle_recommendations
+  (farmer_id, customer_user_id, bundle_products, affinity_bundle, status, created_at)
+VALUES ('$FARMER_A','$CLI_1','[{"id":"x","name":"velho","price":10}]'::jsonb, 0.88, 'pendente', now() - interval '70 days');
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1b — GUARD DE ORDEM DE APPLY (a migration NOVA aborta sem a do #1756)
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── guard de dependência (pré-apply) ──"
+MIG_BASE="$REPO_ROOT/supabase/migrations/20260814223445_farmer_recomendacoes_geracao_vigente.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260815181500_farmer_geracao_head_sensor.sql"
+
+# Aplicada numa base SEM a 20260814223445, tem de recusar nomeando-a — e não morrer
+# com um 42883 críptico ao tentar dropar uma função que não existe.
+DEP=$(P -tA -f "$MIG" 2>&1 || true)
+case "$DEP" in
+  *"DEPENDENCIA FALTANDO"*) ok "D1 migration aborta sem a 20260814223445, nomeando-a" ;;
+  *) bad "D1 migration NAO abortou sem a dependência — veio: $(printf '%s' "$DEP" | head -c 200)" ;;
+esac
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR AS DUAS MIGRATIONS REAIS, na ordem (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q -f "$MIG_BASE"
+P -q -f "$MIG"
+echo "migrations aplicadas: $(basename "$MIG_BASE") + $(basename "$MIG")"
+P -q -f "$MIG"
+ok "I1 migration nova é idempotente (aplicada 2x sem erro)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — GRANTS + payloads
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+GRANT USAGE ON SCHEMA private TO authenticated;
+GRANT EXECUTE ON FUNCTION private.cap_carteira_escrever(uuid), private.cap_carteira_ler(uuid),
+                           private.carteira_visivel_para(uuid,uuid) TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.farmer_recommendations, public.farmer_bundle_recommendations TO authenticated;
+GRANT SELECT ON public.omie_products TO authenticated;
+SQL
+
+LOTE_OK=$(cat <<JSON
+[{"customer_user_id":"$CLI_1","recommendation_type":"cross_sell","product_id":"$PROD_2","p_ij":4.4,"affinity_score":0.44,"complexity_factor":1,"cluster_volume_estimate":3},
+ {"customer_user_id":"$CLI_2","recommendation_type":"up_sell","product_id":"$PROD_1","p_ij":2.2,"affinity_score":0.22,"complexity_factor":1,"cluster_volume_estimate":1}]
+JSON
+)
+INSUMOS='{"scores":{"ok":true,"n":3858},"catalogo":{"ok":true,"n":3108},"vendaveis":{"ok":true,"n":1200},"pedidos":{"ok":true,"n":861}}'
+RUN_1='11111111-aaaa-aaaa-aaaa-111111111111'
+RUN_2='22222222-aaaa-aaaa-aaaa-222222222222'
+RUN_3='33333333-aaaa-aaaa-aaaa-333333333333'
+RUN_B='bbbbbbbb-aaaa-aaaa-aaaa-bbbbbbbbbbbb'
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── head: o caminho COM linhas ──"
+
+# H1 — a substituição move o head na MESMA transação, com resultado='linhas'.
+Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_1',NULL,'$LOTE_OK'::jsonb,'completo',NULL,'$INSUMOS'::jsonb);" >/dev/null
+eq "H1 head criado pela substituição (motor cross_sell)" \
+   "$(Pq -c "SELECT run_id||'|'||resultado||'|'||linhas_geradas||'|'||completude FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" \
+   "$RUN_1|linhas|2|completo"
+
+# H2 — os `insumos` (a EVIDÊNCIA por trás do rótulo) chegam íntegros.
+eq "H2 insumos preservados (n de scores)" \
+   "$(Pq -c "SELECT insumos->'scores'->>'n' FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "3858"
+
+# H3 — o head AVANÇA (upsert), não empilha: 2ª execução deixa 1 linha só, com o run novo.
+GER=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+HEAD_H3=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_2','$GER'::uuid,'$LOTE_OK'::jsonb,'completo',NULL,'$INSUMOS'::jsonb,'$HEAD_H3'::uuid);" >/dev/null
+eq "H3 head AVANÇA em vez de empilhar (1 linha por motor+farmer)" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "1"
+eq "H4 head aponta para a geração NOVA" \
+   "$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "$RUN_2"
+
+# H5 — a assinatura de 4 ARGS ainda funciona (bundle velho em cache, Publish não-instantâneo)
+# e grava `desconhecido` — NUNCA `completo`. Ausente ≠ completo (§2), aplicado à instrumentação.
+GER=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_3','$GER'::uuid,'$LOTE_OK'::jsonb);" >/dev/null
+eq "H5 chamada de 4 args funciona E grava 'desconhecido' (não 'completo')" \
+   "$(Pq -c "SELECT completude FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "desconhecido"
+
+# H6 — bundle tem head PRÓPRIO, na mesma tabela, sem colidir com o do cross_sell.
+Pq -c "SELECT public.farmer_bundle_recomendacoes_substituir('$FARMER_A','$RUN_B',NULL,'[{\"customer_user_id\":\"$CLI_1\",\"bundle_products\":[{\"id\":\"y\",\"name\":\"novo\",\"price\":20}],\"affinity_bundle\":0.42,\"support\":0.1,\"confidence\":0.5,\"lift\":1.5,\"p_bundle\":3.3}]'::jsonb,'completo',NULL,'$INSUMOS'::jsonb);" >/dev/null
+eq "H6 bundle tem head próprio (motor='bundle')" \
+   "$(Pq -c "SELECT run_id||'|'||linhas_geradas FROM public.farmer_geracao_vigente WHERE motor='bundle' AND farmer_id='$FARMER_A';")" "$RUN_B|1"
+eq "H7 os dois motores coexistem para o mesmo farmer" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE farmer_id='$FARMER_A';")" "2"
+
+echo "── head: a geração VAZIA (o caso que o #1756 deixou de fora) ──"
+
+# H8 — O PONTO DA ENTREGA: geração legitimamente vazia MOVE o head.
+# Sem isto, um cálculo que conclui "não deve haver recomendação nenhuma" não deixa
+# rastro nenhum, e a geração anterior sobrevive indefinidamente.
+HEAD_VISTO=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+VAZIO_1='e0000000-aaaa-aaaa-aaaa-000000000001'
+Pq -c "SELECT public.farmer_geracao_registrar('cross_sell','$FARMER_A','$VAZIO_1','vazio',0,'completo',NULL,'$INSUMOS'::jsonb,'$HEAD_VISTO'::uuid);" >/dev/null
+eq "H8 geração VAZIA move o head (resultado='vazio', completude='completo')" \
+   "$(Pq -c "SELECT run_id||'|'||resultado||'|'||linhas_geradas||'|'||completude FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" \
+   "$VAZIO_1|vazio|0|completo"
+
+# H9 — e NÃO expira/toca linha nenhuma (o escopo desta fase é SENSOR, não expiração).
+eq "H9 o registro vazio NÃO expirou nenhuma pendente" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente';")" "2"
+
+# H10 — "NUNCA RODOU" ≠ "RODOU E DEU VAZIO". Em prod (2026-08-15) esses dois estados eram
+# indistinguíveis: os dois eram ausência de linha. É o que o head resolve já nesta fase.
+eq "H10a farmer que nunca rodou: head AUSENTE" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE farmer_id='$FARMER_C';")" "0"
+eq "H10b farmer que rodou e deu vazio: head PRESENTE com resultado='vazio'" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE farmer_id='$FARMER_A' AND motor='cross_sell' AND resultado='vazio';")" "1"
+
+# H11 — o vazio DEGRADADO (dado faltando a montante) é distinguível do vazio completo.
+# É exatamente esta distinção que a fase 2 precisa para poder expirar sem zerar carteira.
+VAZIO_2='e0000000-aaaa-aaaa-aaaa-000000000002'
+Pq -c "SELECT public.farmer_geracao_registrar('cross_sell','$FARMER_B','$VAZIO_2','vazio',0,'degradado','sem farmer_client_scores para este farmer','{\"scores\":{\"ok\":true,\"n\":0}}'::jsonb,NULL);" >/dev/null
+eq "H11 vazio DEGRADADO carrega o motivo (≠ vazio completo)" \
+   "$(Pq -c "SELECT completude||'|'||motivo FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_B';")" \
+   "degradado|sem farmer_client_scores para este farmer"
+
+# H12 — A QUERY DE DECISÃO da fase 2: só conta o vazio+completo. O degradado do FARMER_B
+# NÃO pode entrar no numerador — se entrasse, a fase 2 ligaria a expiração com base em
+# falha a montante, que é precisamente o desfecho que o desenho existe para evitar.
+eq "H12 a query de decisão separa vazio-completo de vazio-degradado" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE resultado='vazio' AND completude='completo';")" "1"
+
+echo "── log append-only: o head NÃO mede frequência, o log mede ──"
+
+# Sobrescreve o head com um run de LINHAS, logo depois do vazio de H8. É o cenário exato
+# em que o head perde o evento — e o log tem de guardá-lo.
+GER_L=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+HEAD_L=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+RUN_L='e0000000-aaaa-aaaa-aaaa-0000000000cc'
+Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$RUN_L','$GER_L'::uuid,'$LOTE_OK'::jsonb,'completo',NULL,'$INSUMOS'::jsonb,'$HEAD_L'::uuid);" >/dev/null
+
+# L1 — o log guarda TODAS as execuções, enquanto o head guarda 1 por par.
+# Achado do challenge Codex: um vazio+completo pode acontecer e SUMIR do head no run
+# seguinte. Se a medição saísse do head, a resposta seria "nunca aconteceu".
+eq "L1 log tem mais execuções que o head tem linhas (histórico ≠ estado)" \
+   "$(Pq -c "SELECT (SELECT count(*) FROM public.farmer_geracao_execucoes) > (SELECT count(*) FROM public.farmer_geracao_vigente);")" "t"
+
+# L2 — O TESTE QUE JUSTIFICA O LOG: sobrescreve o head com um run de LINHAS e prova que
+# o vazio+completo anterior CONTINUA no log. Sem o log, este evento estaria perdido.
+eq "L2 o vazio+completo sobrevive no log depois do head ser sobrescrito" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_execucoes WHERE resultado='vazio' AND completude='completo' AND farmer_id='$FARMER_A';")" "1"
+eq "L2b e o head já NÃO mostra mais esse vazio (é por isso que ele não serve de medição)" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE resultado='vazio' AND farmer_id='$FARMER_A' AND motor='cross_sell';")" "0"
+
+# L3 — idempotência: retry do MESMO run não vira 2 execuções (senão a frequência mede retry).
+HL=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+N_ANTES=$(Pq -c "SELECT count(*) FROM public.farmer_geracao_execucoes;")
+Pq -c "SELECT public.farmer_geracao_registrar('cross_sell','$FARMER_A','$HL','linhas',(SELECT count(*)::int FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND run_id='$HL' AND status='pendente'),'completo',NULL,NULL,'$HL'::uuid);" >/dev/null 2>&1 || true
+eq "L3 retry do mesmo run NÃO duplica a execução no log" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_execucoes;")" "$N_ANTES"
+
+echo "── escrita: as tabelas do sensor NÃO aceitam DML direto de authenticated ──"
+
+# W1/W2 — O FURO QUE O CHALLENGE ACHOU: com GRANT INSERT/UPDATE, o browser fazia
+# `UPDATE ... SET resultado='vazio', completude='completo'` DIRETO e pulava FG105/106/107
+# inteiros. Guard que se contorna pela porta ao lado não é guard.
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_A'; SET test.role='authenticated'; SET ROLE authenticated;
+UPDATE public.farmer_geracao_vigente SET resultado='vazio', linhas_geradas=0, completude='completo'
+WHERE farmer_id='$FARMER_A' AND motor='cross_sell';
+SQL
+)
+case "$R" in
+  *"permission denied"*) ok "W1 UPDATE direto no head é negado (o guard não tem porta ao lado)" ;;
+  *) bad "W1 UPDATE direto PASSOU — o browser forja o head sem passar pelas RPCs: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_A'; SET test.role='authenticated'; SET ROLE authenticated;
+INSERT INTO public.farmer_geracao_execucoes (motor,farmer_id,run_id,resultado,linhas_geradas,completude)
+VALUES ('cross_sell','$FARMER_A','e0000000-aaaa-aaaa-aaaa-0000000000ff','vazio',0,'completo');
+SQL
+)
+case "$R" in
+  *"permission denied"*) ok "W2 INSERT direto no log é negado (a série da medição é imutável de fora)" ;;
+  *) bad "W2 INSERT direto no log PASSOU — a medição é forjável: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# W3 — mas LER continua permitido (o farmer precisa enxergar o próprio head/execuções).
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_A'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT count(*) FROM public.farmer_geracao_execucoes WHERE farmer_id='$FARMER_A';
+SQL
+)
+eq "W3 o farmer LÊ as próprias execuções (a revogação é só de escrita)" \
+   "$(printf '%s' "$R" | tail -1 | tr -d '[:space:]' | command grep -qE '^[0-9]+$' && echo ok || echo nao)" "ok"
+
+echo "── regressão do #1756 (as RPCs foram RECRIADAS: nada pode ter se perdido) ──"
+
+# R1 — a linha com DESFECHO continua intocável (o invariante mais caro do #1756).
+eq "R1 linha 'aceito' sobreviveu a todos os recálculos" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE status='aceito' AND accepted_at IS NOT NULL AND expired_at IS NULL;")" "1"
+# R2 — expirar não deleta.
+eq "R2 a carteira do farmer B segue intacta" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE farmer_id='$FARMER_B' AND status='pendente';")" "1"
+# R3 — m_ij/lie continuam fixados em NULL (dinheiro não volta pelo browser).
+eq "R3 m_ij/lie seguem NULL nas linhas novas" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='$RUN_3' AND m_ij IS NULL AND lie IS NULL;")" "2"
+# R4 — as expiradas seguem carimbando quem as matou.
+eq "R4 expiradas carimbam expired_by_run" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE status='expirado' AND expired_by_run IS NULL;")" "0"
+
+echo "── asserts negativos (SQLSTATE esperada + re-raise) ──"
+
+espera_sqlstate() { # $1=nome  $2=sqlstate  $3=chamada SQL
+  local OUT
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM $3;
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION
+  WHEN SQLSTATE '$2' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+  WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_BARROU_CERTO*) ok "$1 (SQLSTATE $2)" ;;
+    *SENTINELA_NAO_BARROU*)   bad "$1 — NAO barrou (esperava $2)" ;;
+    *)                        bad "$1 — erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+}
+
+HV=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+
+# N1/N2 — COERÊNCIA resultado × contagem. O head mentiroso ("linhas com 0 linhas") é como
+# uma medição se corrompe sem ninguém ver — e a medição é o produto inteiro desta entrega.
+espera_sqlstate "N1 resultado='linhas' com 0 linhas recusado" "FG103" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','linhas',0,'completo',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N2 resultado='vazio' com linhas>0 recusado" "FG103" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',5,'completo',NULL,NULL,'$HV'::uuid)"
+
+# N3 — degradado SEM motivo: rótulo sem conteúdo, e o motivo é justamente o que a fase 2
+# usa para separar "zero de verdade" de "zero por dado faltando".
+espera_sqlstate "N3 degradado sem motivo recusado" "FG104" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'degradado',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N3b degradado com motivo em branco recusado" "FG104" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'degradado','   ',NULL,'$HV'::uuid)"
+
+espera_sqlstate "N4 motor inválido recusado" "FG102" \
+  "public.farmer_geracao_registrar('foo','$FARMER_A','$RUN_1','vazio',0,'completo',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N5 completude inválida recusada" "FG103" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'quase',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N6 resultado inválido recusado" "FG103" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','talvez',0,'completo',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N7 run_id nulo recusado" "FG101" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A',NULL,'vazio',0,'completo',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N8 insumos não-objeto recusado" "FG103" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'completo',NULL,'[1,2]'::jsonb,'$HV'::uuid)"
+
+# N9 — CAS DO HEAD. Sem ele, um run VAZIO lento sobrescreve o head de um run COM LINHAS
+# que terminou antes — e a medição registra `vazio` para um estado que é `linhas`.
+espera_sqlstate "N9 CAS: head_visto ≠ vigente recusado" "FG106" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'completo',NULL,NULL,'99999999-9999-9999-9999-999999999999'::uuid)"
+# N9b — o caso simétrico e mais fácil de errar: head JÁ EXISTE e o chamador manda NULL
+# ("achei que era a primeira execução"). NULL casa NULL só quando o head é de fato ausente.
+espera_sqlstate "N9b CAS: head existente com head_visto NULL recusado" "FG106" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'completo',NULL,NULL,NULL)"
+
+# N9e — O CAS ASSIMÉTRICO, fechado. A substituição COM LINHAS agora compara o head que o
+# CHAMADOR viu, não o que ela lê sob o lock. Antes, um run vazio mais NOVO era sobrescrito
+# por um run com linhas que leu snapshot mais velho: o CAS da etapa 5 compara LINHAS, e o
+# vazio não mexe em linha nenhuma, então passava despercebido (achado Codex xhigh).
+GER_N9=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+espera_sqlstate "N9e substituição com head_visto DEFASADO é recusada (CAS simétrico)" "FG106" \
+  "public.farmer_recomendacoes_substituir('$FARMER_A','e0000000-aaaa-aaaa-aaaa-0000000000aa',$([ -z "$GER_N9" ] && echo NULL || echo "'$GER_N9'::uuid"),'$LOTE_OK'::jsonb,'completo',NULL,NULL,'99999999-9999-9999-9999-999999999999'::uuid)"
+
+# N9f — e a recusa é ATÔMICA: nenhuma linha entrou, nenhuma foi expirada.
+eq "N9f a recusa do CAS do head não deixou linha do run recusado" \
+   "$(Pq -c "SELECT count(*) FROM public.farmer_recommendations WHERE run_id='e0000000-aaaa-aaaa-aaaa-0000000000aa';")" "0"
+
+# N9g — contagem DECLARADA ≠ contagem REAL é recusada (o `EXISTS` sozinho aceitava
+# "1 linha real, 999 declaradas", e `linhas_geradas` é o que a fase 2 leria).
+espera_sqlstate "N9g linhas_geradas divergente da contagem real recusado" "FG107" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$GER_N9','linhas',999,'completo',NULL,NULL,'$HV'::uuid)"
+
+# N9h — declarar 'vazio' num run que TEM linhas é um head que contradiz a própria tabela.
+espera_sqlstate "N9h resultado='vazio' com linhas gravadas naquele run recusado" "FG107" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','$GER_N9','vazio',0,'completo',NULL,NULL,'$HV'::uuid)"
+
+# N9c — ANTI-FORJA: `resultado` vem do browser, e o head é MEDIÇÃO. Sem ancorar em linha
+# real, um cliente grava um head afirmando "linhas" sem existir nenhuma — e é sobre essa
+# medição que a fase 2 decidiria ligar a expiração.
+espera_sqlstate "N9c resultado='linhas' sem linha real recusado" "FG107" \
+  "public.farmer_geracao_registrar('cross_sell','$FARMER_A','e0000000-aaaa-aaaa-aaaa-00000000dead','linhas',7,'completo',NULL,NULL,'$HV'::uuid)"
+espera_sqlstate "N9d anti-forja vale para o bundle também" "FG107" \
+  "public.farmer_geracao_registrar('bundle','$FARMER_A','e0000000-aaaa-aaaa-aaaa-00000000beef','linhas',3,'completo',NULL,NULL,'$RUN_B'::uuid)"
+
+# N10 — TODAS as recusas acima deixaram o head onde estava.
+eq "N10 nenhuma recusa moveu o head" \
+   "$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "$HV"
+
+# N11/N12 — as invariantes moram na TABELA, não só no writer: um writer futuro que
+# insira direto tem de esbarrar no CHECK.
+R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_geracao_vigente (motor,farmer_id,run_id,resultado,linhas_geradas,completude) VALUES ('cross_sell','$FARMER_C','$RUN_1','linhas',0,'completo');" || true)
+case "$R" in
+  *farmer_geracao_vigente_linhas_coerente*) ok "N11 CHECK barra 'linhas' com 0 linhas (23514)" ;;
+  *) bad "N11 CHECK NAO barrou — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_geracao_vigente (motor,farmer_id,run_id,resultado,linhas_geradas,completude) VALUES ('cross_sell','$FARMER_C','$RUN_1','vazio',0,'degradado');" || true)
+case "$R" in
+  *farmer_geracao_vigente_motivo_coerente*) ok "N12 CHECK barra 'degradado' sem motivo (23514)" ;;
+  *) bad "N12 CHECK NAO barrou — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_geracao_vigente (motor,farmer_id,run_id,resultado,linhas_geradas,completude) VALUES ('outro','$FARMER_C','$RUN_1','vazio',0,'completo');" || true)
+case "$R" in
+  *farmer_geracao_vigente_motor_check*) ok "N13 CHECK barra motor desconhecido (23514)" ;;
+  *) bad "N13 CHECK NAO barrou — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# N14 — a UNIQUE que faz o head ser HEAD (e não um log que empilha).
+R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_geracao_vigente (motor,farmer_id,run_id,resultado,linhas_geradas,completude) VALUES ('cross_sell','$FARMER_A','$RUN_1','vazio',0,'completo');" || true)
+case "$R" in
+  *farmer_geracao_vigente_motor_farmer_uk*) ok "N14 UNIQUE(motor,farmer) barra 2ª linha para o mesmo par (23505)" ;;
+  *) bad "N14 UNIQUE NAO barrou — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+echo "── asserts de autorização (RLS + gate) ──"
+
+# A1 — farmer B (sem cap) NÃO registra geração de A.
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_B'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'completo',NULL,NULL,'$HV'::uuid);
+SQL
+)
+case "$R" in
+  *"Acesso negado"*) ok "A1 farmer B barrado ao registrar geração de A (42501)" ;;
+  *) bad "A1 farmer B NAO foi barrado — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A2 — o próprio farmer A CONSEGUE (a autorização não é fail-closed demais).
+A2_RUN='e0000000-aaaa-aaaa-aaaa-00000000000a'
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_A'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT public.farmer_geracao_registrar('cross_sell','$FARMER_A','$A2_RUN','vazio',0,'completo',NULL,NULL,'$HV'::uuid);
+SQL
+)
+case "$R" in
+  *resultado*) ok "A2 o próprio farmer A registra a geração dele" ;;
+  *) bad "A2 farmer A NAO conseguiu registrar — veio: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A3 — SESSÃO SEM IDENTIDADE NENHUMA é barrada (regressão do three-valued logic).
+# `IF NOT (a OR b OR c)` NÃO barra aqui: sem JWT a disjunção vira NULL e `IF NOT NULL`
+# não dispara em PL/pgSQL — o guard devolveria nulo em vez de negar.
+HV2=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+R=$(P -tA 2>&1 <<SQL || true
+SET test.role=''; SET test.uid='';
+DO \$\$
+BEGIN
+  PERFORM public.farmer_geracao_registrar('cross_sell','$FARMER_A','$RUN_1','vazio',0,'completo',NULL,NULL,'$HV2'::uuid);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE '42501' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+case "$R" in
+  *SENTINELA_BARROU_CERTO*) ok "A3 sessão sem identidade barrada (o gate fecha em TRUE, não em NOT-NULL)" ;;
+  *SENTINELA_NAO_BARROU*)   bad "A3 sessão SEM identidade PASSOU — o gate está em three-valued logic" ;;
+  *)                        bad "A3 erro inesperado: $(printf '%s' "$R" | head -c 200)" ;;
+esac
+
+# A4 — RLS de LEITURA: farmer B não enxerga o head de A.
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_B'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT count(*) FROM public.farmer_geracao_vigente WHERE farmer_id='$FARMER_A';
+SQL
+)
+# `tail -1`: o psql ecoa um "SET" por comando de sessão antes do resultado — sem isolar a
+# última linha o assert compara "SETSETSET0" com "0" e fica vermelho por ruído do harness,
+# não por defeito da migration (que é o vermelho que não se pode confundir com o de verdade).
+eq "A4 RLS: farmer B não lê o head de A" "$(printf '%s' "$R" | tail -1 | tr -d '[:space:]')" "0"
+
+# A5 — quem ESCREVE precisa LER (senão o CAS fica cego). Gestor com cap_carteira_escrever
+# e SEM cap_carteira_ler tem de enxergar o head, ou passaria o CAS trivialmente.
+GESTOR='eeeeeeee-4444-4444-4444-444444444444'
+P -q -c "INSERT INTO auth.users(id) VALUES ('$GESTOR') ON CONFLICT DO NOTHING;
+         INSERT INTO private.caps(user_id, escrever, ler) VALUES ('$GESTOR', true, false)
+         ON CONFLICT (user_id) DO UPDATE SET escrever=true, ler=false;"
+R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$GESTOR'; SET test.role='authenticated'; SET ROLE authenticated;
+SELECT count(*) FROM public.farmer_geracao_vigente WHERE farmer_id='$FARMER_A' AND motor='cross_sell';
+SQL
+)
+eq "A5 gestor com escrever-mas-não-ler ENXERGA o head (CAS cego não é CAS)" "$(printf '%s' "$R" | tail -1 | tr -d '[:space:]')" "1"
+
+# A6 — anon não executa a RPC (REVOKE por nome; REVOKE FROM PUBLIC não tiraria anon).
+eq "A6 anon NÃO executa farmer_geracao_registrar" \
+   "$(Pq -c "SELECT has_function_privilege('anon','public.farmer_geracao_registrar(text,uuid,uuid,text,integer,text,text,jsonb,uuid)','EXECUTE');")" "f"
+
+echo "── falsificação ──"
+
+SAB="/tmp/farmer-head-sabotado-$$.sql"
+restaura() { P -q -f "$MIG"; }
+
+sabota() { # $1=nome  $2=expressão perl  $3=marca que TEM de aparecer no resultado
+  perl -0777 -pe "$2" "$MIG" > "$SAB"
+  if ! command grep -q -- "$3" "$SAB"; then
+    bad "SABOTAGEM $1 NAO APLICOU (padrão não casou) — falsificação INVÁLIDA"
+    return 1
+  fi
+  P -q -f "$SAB"
+  return 0
+}
+
+# F1 — `coalesce(p_completude,'desconhecido')` vira `'completo'`: a janela de Publish
+#      passaria a gravar falsos `completo`, envenenando exatamente a medição sobre a qual
+#      a fase 2 decidiria ligar a expiração. H5 tem de ficar VERMELHO.
+if sabota "F1" "s/v_completude := coalesce\(p_completude, 'desconhecido'\);/v_completude := coalesce(p_completude, 'completo');/" "coalesce(p_completude, 'completo')"; then
+  GER=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','f1000000-aaaa-aaaa-aaaa-000000000001',$([ -z "$GER" ] && echo NULL || echo "'$GER'"),'$LOTE_OK'::jsonb);" >/dev/null 2>&1 || true
+  eq_esperando_vermelho "H5 chamada de 4 args grava 'desconhecido'" \
+    "$(Pq -c "SELECT completude FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "desconhecido"
+  restaura
+fi
+
+# F2 — desligar o CAS do head. N9 deixa de barrar, e um run vazio lento passa a
+#      sobrescrever o head de um run com linhas que terminou antes.
+if sabota "F2" "s/  IF v_head_atual IS DISTINCT FROM p_head_visto THEN/  IF false THEN/" "IF false THEN"; then
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM public.farmer_geracao_registrar('cross_sell','$FARMER_A','f2000000-aaaa-aaaa-aaaa-000000000002','vazio',0,'completo',NULL,NULL,'99999999-9999-9999-9999-999999999999'::uuid);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE 'FG106' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: sem o CAS, o head de outro run é sobrescrito (N9 seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: N9 barrou mesmo com o CAS do head desligado" ;;
+    *) bad "F2 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+# F3 — remover o CHECK de coerência resultado×linhas da TABELA. N11 tem de ficar vermelho:
+#      sem ele, "resultado=linhas com 0 linhas" entra e a medição mente em silêncio.
+if sabota "F3" "s/      CHECK \(linhas_geradas >= 0 AND \(resultado = 'linhas'\) = \(linhas_geradas > 0\)\);/      CHECK (linhas_geradas >= 0);/" "CHECK (linhas_geradas >= 0);"; then
+  P -q -c "ALTER TABLE public.farmer_geracao_vigente DROP CONSTRAINT IF EXISTS farmer_geracao_vigente_linhas_coerente;" >/dev/null
+  P -q -f "$SAB" >/dev/null
+  R=$(P -tA 2>&1 -c "INSERT INTO public.farmer_geracao_vigente (motor,farmer_id,run_id,resultado,linhas_geradas,completude) VALUES ('bundle','$FARMER_C','f3000000-aaaa-aaaa-aaaa-000000000003','linhas',0,'completo');" || true)
+  case "$R" in
+    *farmer_geracao_vigente_linhas_coerente*) bad "FALSIFICAÇÃO SEM DENTE: N11 barrou mesmo sem o CHECK de coerência" ;;
+    *ERROR*) bad "F3 erro inesperado: $(printf '%s' "$R" | head -c 200)" ;;
+    *) ok "falsificação mordeu: sem o CHECK, 'linhas' com 0 linhas ENTRA (N11 seria falso-verde)" ;;
+  esac
+  P -q -c "DELETE FROM public.farmer_geracao_vigente WHERE farmer_id='$FARMER_C';" >/dev/null
+  restaura
+fi
+
+# F4 — a substituição para de mover o head (remove o PERFORM). H1 tem de ficar vermelho:
+#      sem isso o head e as linhas divergem, e head divergente é MEDIÇÃO CORROMPIDA.
+if sabota "F4" "s/  PERFORM public\.farmer_geracao_registrar\(\n    'cross_sell', p_farmer_id, p_run_id, 'linhas', v_inseridas,\n    p_completude, p_motivo, p_insumos, v_head_atual\n  \);/  NULL;/" "  NULL;"; then
+  P -q -c "DELETE FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';" >/dev/null
+  GER=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  F4_RUN='f4000000-aaaa-aaaa-aaaa-000000000004'
+  Pq -c "SELECT public.farmer_recomendacoes_substituir('$FARMER_A','$F4_RUN',$([ -z "$GER" ] && echo NULL || echo "'$GER'"),'$LOTE_OK'::jsonb,'completo',NULL,'$INSUMOS'::jsonb);" >/dev/null 2>&1 || true
+  eq_esperando_vermelho "H1 a substituição move o head" \
+    "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")" "1"
+  restaura
+fi
+
+# F5 — o gate volta à forma "óbvia" `IF NOT (...)`. A3 tem de ficar VERMELHO: com NULL na
+# disjunção o RAISE nunca acontece e uma sessão sem identidade passa direto.
+# A checagem é feita à mão nos DOIS sentidos (a forma antiga apareceu E a nova sumiu):
+# sabotagem parcial mediria a função ainda íntegra e devolveria verde de código sabotado.
+perl -0777 -pe "s/  IF \(\n    coalesce\(auth\.role\(\), ''\) = 'service_role'\n    OR p_farmer_id = auth\.uid\(\)\n    OR coalesce\(private\.cap_carteira_escrever\(auth\.uid\(\)\), false\)\n  \) IS NOT TRUE THEN/  IF NOT (\n    coalesce(auth.role(), '') = 'service_role'\n    OR p_farmer_id = auth.uid()\n    OR private.cap_carteira_escrever(auth.uid())\n  ) THEN/g" "$MIG" > "$SAB"
+if ! command grep -q "IF NOT (" "$SAB"; then
+  bad "SABOTAGEM F5 NAO APLICOU (padrão não casou) — falsificação INVÁLIDA"
+elif command grep -q "IS NOT TRUE THEN" "$SAB"; then
+  bad "SABOTAGEM F5 PARCIAL (sobrou IS NOT TRUE) — falsificação INVÁLIDA"
+else
+  P -q -f "$SAB"
+  # O head vigente REAL: sem ele o CAS recusaria com FG106 e o `WHEN OTHERS THEN RAISE`
+  # relançaria — o vermelho seria do harness, não da sabotagem. O alvo aqui é o gate de
+  # AUTORIZAÇÃO, então todo o resto tem de estar coerente para o fluxo chegar até ele.
+  HV3=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+  OUT=$(P -tA 2>&1 <<SQL || true
+SET test.role=''; SET test.uid='';
+DO \$\$
+BEGIN
+  PERFORM public.farmer_geracao_registrar('cross_sell','$FARMER_A','f5000000-aaaa-aaaa-aaaa-000000000005','vazio',0,'completo',NULL,NULL,$([ -z "$HV3" ] && echo NULL || echo "'$HV3'::uuid"));
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE '42501' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: com 'IF NOT (...)' a sessão sem identidade PASSA (A3 seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: A3 barrou mesmo com o gate em three-valued logic" ;;
+    *) bad "F5 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+# F6 — desligar o guard ANTI-FORJA. N9c tem de ficar vermelho: o head volta a aceitar
+#      "linhas" na palavra do browser, sem nenhuma linha por trás.
+if sabota "F6" "s/  IF p_resultado = 'linhas' THEN\n    IF p_motor = 'cross_sell' THEN/  IF false THEN\n    IF p_motor = 'cross_sell' THEN/" "IF false THEN"; then
+  HV4=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_A';")
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM public.farmer_geracao_registrar('cross_sell','$FARMER_A','f6000000-aaaa-aaaa-aaaa-000000000006','linhas',7,'completo',NULL,NULL,$([ -z "$HV4" ] && echo NULL || echo "'$HV4'::uuid"));
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE 'FG107' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: sem o anti-forja, o head aceita 'linhas' sem linha (N9c seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: N9c barrou mesmo com o anti-forja desligado" ;;
+    *) bad "F6 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+# F7 — devolver o GRANT de escrita a `authenticated` (a 1ª versão desta migration). W1 tem
+#      de ficar vermelho: o browser volta a forjar o head por UPDATE direto, pulando
+#      FG105/FG106/FG107 inteiros. É o furo que o challenge Codex encontrou.
+if sabota "F7" "s/GRANT SELECT ON TABLE public\.farmer_geracao_vigente   TO authenticated;/GRANT SELECT, INSERT, UPDATE ON TABLE public.farmer_geracao_vigente TO authenticated;/" "GRANT SELECT, INSERT, UPDATE ON TABLE public.farmer_geracao_vigente"; then
+  # A policy de UPDATE também precisa existir para o teste medir o GRANT, e não a RLS:
+  # sem ela o vermelho viria da policy ausente e não provaria nada sobre o grant.
+  P -q -c "CREATE POLICY fgv_update_sabotada ON public.farmer_geracao_vigente FOR UPDATE TO authenticated
+           USING (farmer_id = (SELECT auth.uid())) WITH CHECK (farmer_id = (SELECT auth.uid()));" >/dev/null
+  R=$(P -tA 2>&1 <<SQL || true
+SET test.uid='$FARMER_A'; SET test.role='authenticated'; SET ROLE authenticated;
+UPDATE public.farmer_geracao_vigente SET resultado='vazio', linhas_geradas=0, completude='completo'
+WHERE farmer_id='$FARMER_A' AND motor='cross_sell';
+SQL
+)
+  case "$R" in
+    *"permission denied"*) bad "FALSIFICAÇÃO SEM DENTE: W1 barrou mesmo com o GRANT de escrita devolvido" ;;
+    *ERROR*) bad "F7 erro inesperado: $(printf '%s' "$R" | head -c 200)" ;;
+    *) ok "falsificação mordeu: com GRANT de escrita, o head é forjado por UPDATE direto (W1 seria falso-verde)" ;;
+  esac
+  P -q -c "DROP POLICY IF EXISTS fgv_update_sabotada ON public.farmer_geracao_vigente;" >/dev/null
+  restaura
+fi
+
+# F8 — a substituição volta a ler o head DENTRO do lock em vez de usar o do chamador.
+#      N9e tem de ficar vermelho: o CAS passa por construção e o run antigo com linhas
+#      volta a poder sobrescrever um vazio mais novo.
+if sabota "F8" "s/  IF p_completude IS NULL THEN\n    SELECT run_id INTO v_head_atual\n    FROM public\.farmer_geracao_vigente\n    WHERE motor = 'cross_sell' AND farmer_id = p_farmer_id;\n  ELSE\n    v_head_atual := p_head_visto;\n  END IF;/  SELECT run_id INTO v_head_atual FROM public.farmer_geracao_vigente WHERE motor = 'cross_sell' AND farmer_id = p_farmer_id;/" "SELECT run_id INTO v_head_atual FROM public.farmer_geracao_vigente WHERE motor = 'cross_sell'"; then
+  GER_F8=$(Pq -c "SELECT run_id FROM public.farmer_recommendations WHERE farmer_id='$FARMER_A' AND status='pendente' ORDER BY created_at DESC, id DESC LIMIT 1;")
+  OUT=$(P -tA 2>&1 <<SQL || true
+DO \$\$
+BEGIN
+  PERFORM public.farmer_recomendacoes_substituir('$FARMER_A','f8000000-aaaa-aaaa-aaaa-000000000008',$([ -z "$GER_F8" ] && echo NULL || echo "'$GER_F8'::uuid"),'$LOTE_OK'::jsonb,'completo',NULL,NULL,'99999999-9999-9999-9999-999999999999'::uuid);
+  RAISE NOTICE 'SENTINELA_NAO_BARROU';
+EXCEPTION WHEN SQLSTATE 'FG106' THEN RAISE NOTICE 'SENTINELA_BARROU_CERTO';
+          WHEN OTHERS THEN RAISE;
+END \$\$;
+SQL
+)
+  case "$OUT" in
+    *SENTINELA_NAO_BARROU*) ok "falsificação mordeu: lendo o head sob o lock, o CAS passa por construção (N9e seria falso-verde)" ;;
+    *SENTINELA_BARROU_CERTO*) bad "FALSIFICAÇÃO SEM DENTE: N9e barrou mesmo com o head lido internamente" ;;
+    *) bad "F8 erro inesperado: $(printf '%s' "$OUT" | head -c 200)" ;;
+  esac
+  restaura
+fi
+
+# F9 — tirar o INSERT no log append-only. L2 tem de ficar vermelho: o vazio+completo
+#      volta a existir só no head, e some no run seguinte — a medição de FREQUÊNCIA morre.
+if sabota "F9" "s/  ON CONFLICT \(motor, farmer_id, run_id\) DO NOTHING;/  ON CONFLICT (motor, farmer_id, run_id) DO NOTHING;\n  DELETE FROM public.farmer_geracao_execucoes WHERE run_id = p_run_id;/" "DELETE FROM public.farmer_geracao_execucoes WHERE run_id = p_run_id;"; then
+  P -q -c "DELETE FROM public.farmer_geracao_execucoes WHERE farmer_id='$FARMER_B';" >/dev/null
+  HV_F9=$(Pq -c "SELECT run_id FROM public.farmer_geracao_vigente WHERE motor='cross_sell' AND farmer_id='$FARMER_B';")
+  Pq -c "SELECT public.farmer_geracao_registrar('cross_sell','$FARMER_B','f9000000-aaaa-aaaa-aaaa-000000000009','vazio',0,'completo',NULL,NULL,$([ -z "$HV_F9" ] && echo NULL || echo "'$HV_F9'::uuid"));" >/dev/null 2>&1 || true
+  eq_esperando_vermelho "L2 o vazio+completo sobrevive no log" \
+    "$(Pq -c "SELECT count(*) FROM public.farmer_geracao_execucoes WHERE farmer_id='$FARMER_B' AND resultado='vazio';")" "1"
+  restaura
+fi
+
+rm -f "$SAB"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/docs/superpowers/specs/2026-08-15-farmer-head-geracao-sensor-design.md
+++ b/docs/superpowers/specs/2026-08-15-farmer-head-geracao-sensor-design.md
@@ -1,0 +1,364 @@
+# Head de geração do farmer — o SENSOR antes da decisão
+
+> Follow-up da limitação declarada no #1756 (`20260814223445_farmer_recomendacoes_geracao_vigente.sql`):
+> o recálculo aposenta a geração anterior, mas **só quando produz linha**. A geração
+> legitimamente VAZIA não avança nada, e o banco segue servindo exatamente as
+> recomendações que o novo cálculo decidiu que não deveriam existir.
+
+## 1. A medição (prod, 2026-08-15 ~17:30 UTC, via `psql-ro`)
+
+**O denominador é 3 farmers** — não os 473 grupos do #1756, que eram `(farmer, cliente)`.
+O escopo da RPC de substituição é o farmer.
+
+| farmer | `farmer_client_scores` | c/ pedido | pendentes | geração vigente |
+|---|--:|--:|--:|---|
+| `414a9727` | 3.858 | 171 | 671 | `run_id=71946f20` — recalculado hoje 17:31 UTC |
+| `33f59dc7` | 1.245 | 294 | 690 | **`run_id` NULL**, de 2026-04-10 (**127 dias**) |
+| `700657a1` | 1.530 | 396 | **0** | **nenhuma — nunca rodou** |
+
+**O #1756 está vivo e fez efeito real.** O run `71946f20` inseriu 671 linhas e **expirou
+5.325** no mesmo instante (`expired_at = 17:31:29.702`). A trigger `trg_frec_exige_run_id`
+está ativa (`tgenabled='O'`) e recusa `pendente` sem `run_id` (FG008).
+
+### 1.1 A frequência de recálculo vazio é estruturalmente NÃO-MENSURÁVEL hoje
+
+Um recálculo que produz zero linhas **não deixa rastro nenhum**:
+
+- sai por `return` mudo em `useCrossSellEngine.ts:225` (sem `clientScores`) e `:296`
+  (nenhum cliente com pedido) — sem exceção, sem toast, sem escrita;
+- não grava linha (é o que "vazio" significa);
+- `acoes_execucoes` não tem **nenhum** slug de farmer/cross/bundle (medido: 0 linhas).
+
+Existem **28 execuções com linha** entre 2026-03-02 e 2026-08-15 (agrupando por
+`(farmer_id, minuto)`). Esse é o numerador. O denominador — quantas vezes o motor rodou —
+**não existe em lugar nenhum**. Se a tela tivesse sido aberta 500 vezes e 472 devolvessem
+zero, o rastro no banco seria **idêntico** ao de hoje.
+
+É o `Number(null) === 0` da adoção, e é a regra do CLAUDE.md em forma pura: *"superfície de
+uso nasce COM o sensor; sem sensor, a fase N+1 é instalá-lo"*. **Esta entrega é o sensor.**
+
+O que se pode afirmar com denominador: **nenhum dos 3 farmers está perto do zero-por-dado-faltando**
+(1.245–3.858 scores; 171–396 clientes com pedido). Os dois caminhos de zero silencioso estão
+longe de disparar. O zero que aconteceria hoje seria o do FIM do funil — o "zero de verdade".
+
+### 1.2 O achado que a medição revelou sem ser procurado
+
+`700657a1` tem insumos fartos (1.530 scores, 396 clientes com pedido) e **zero recomendação**.
+No banco de hoje, **"nunca rodou" e "rodou e deu vazio" são o mesmo estado**: ausência de linha.
+Essa indistinguibilidade é o custo real e já visível do desenho atual — independente de a
+expiração-por-vazio ser ligada ou não.
+
+O recálculo dispara **sozinho ao abrir a tela** (`FarmerRecommendations.tsx:40`, `useEffect`),
+não por botão. Logo `33f59dc7` serve oferta de 127 dias simplesmente porque essa vendedora não
+abre a tela — e o #1756 a corrige automaticamente na próxima abertura. **Decisão do founder
+(2026-08-15): deixar como está**, sem escrita manual em prod.
+
+## 2. Escopo desta entrega — SENSOR, sem expirar
+
+**Decisão do founder (2026-08-15):** instalar o head como sensor; **não** ligar a
+expiração-por-vazio agora.
+
+O motivo é o §2 aplicado à própria decisão de produto: sem um único `vazio` medido, ligar a
+expiração é assumir o risco de zerar a carteira de uma vendedora **sem contrapartida medida**.
+A expiração vira o passo que se liga quando o sensor mostrar o primeiro `vazio` + `completo` real.
+
+**Fora de escopo, declarado:** expirar por vazio; TTL/frescor por idade; backfill do head para
+os farmers atuais; loop de feedback de desfecho.
+
+## 3. Desenho
+
+### 3.1 Tabela `public.farmer_geracao_vigente`
+
+Uma linha por `(motor, farmer_id)` — UNIQUE — que **avança sempre**, inclusive quando a
+geração é vazia. É isto que a existência-de-linha não consegue representar.
+
+| coluna | tipo | papel |
+|---|---|---|
+| `motor` | text | `'cross_sell'` \| `'bundle'` |
+| `farmer_id` | uuid | com `motor`, a chave que avança |
+| `run_id` | uuid NOT NULL | a geração vigente — **existe mesmo quando não há linha** |
+| `resultado` | text | `'linhas'` \| `'vazio'` |
+| `linhas_geradas` | integer | quantas (0 exatamente quando `vazio`) |
+| `completude` | text | `'completo'` \| `'degradado'` \| `'desconhecido'` |
+| `motivo` | text | **obrigatório** quando `degradado` (CHECK) |
+| `insumos` | jsonb | por insumo: `{ok, n}` — a EVIDÊNCIA por trás do rótulo |
+| `calculado_em` / `atualizado_em` | timestamptz | `clock_timestamp()`, não `now()` |
+
+**Invariantes na TABELA, não só no writer** (money-path §2):
+
+- `(resultado = 'linhas') = (linhas_geradas > 0)` — impede o head mentiroso
+  *"resultado=linhas com 0 linhas"*, que é como uma medição se corrompe sem ninguém ver.
+- `completude <> 'degradado' OR motivo IS NOT NULL` — degradado sem motivo é um rótulo
+  sem conteúdo, e a fase 2 precisaria justamente do motivo para decidir.
+- `linhas_geradas >= 0`.
+
+Todas as colunas do predicado são `NOT NULL`, então não há o three-valued logic que obrigou
+o `status IS NOT NULL AND` do #1756 — o CHECK aqui não pode devolver NULL.
+
+**Sem backfill, de propósito.** Head ausente significa *"não houve execução observada desde o
+sensor"* — que é uma verdade, não uma fabricação. Semear head para os farmers atuais exigiria
+inventar um `run_id` para a geração legada (`run_id` NULL) ou tornar a coluna nullable; as duas
+opções pioram a leitura em troca de nada, já que o head nasce na primeira execução real.
+
+### 3.2 `insumos` é jsonb — e por que isso não viola a regra do CLAUDE.md
+
+*"Sinal money-path nunca em coluna jsonb multi-writer (upsert destrutivo) → coluna dedicada + 1 writer."*
+
+Aqui: **os sinais de decisão (`resultado`, `completude`, `linhas_geradas`) são colunas
+dedicadas**, e o jsonb carrega só o detalhe diagnóstico. Há **1 writer** (as RPCs desta
+migration; a tabela não recebe grant de escrita direta). A regra é respeitada.
+
+O papel do `insumos` é o inverso do que parece: **o rótulo `completude` é a DECLARAÇÃO do
+motor, e as contagens em `insumos` são a evidência que permite auditá-la.** Se a fase 2
+confiar só no rótulo para expirar, repete o *"rótulo com DEFAULT constante não é fato"* (§5)
+— por isso a decisão de expirar exigirá contagens plausíveis (`n_scores > 0`, `n_vendaveis > 0`),
+não a string `'completo'`.
+
+### 3.3 `desconhecido` é estado de primeira classe
+
+As RPCs de substituição ganham os parâmetros novos **com `DEFAULT NULL`**. Isso importa por um
+motivo operacional concreto: no Lovable o **Publish do frontend é manual e não é instantâneo**,
+então existe uma janela em que a migration já está aplicada e o browser ainda roda o bundle
+velho, chamando a assinatura de 4 argumentos.
+
+Nessa janela o head grava `completude='desconhecido'` — **nunca `'completo'`**. É o §2 aplicado
+à própria instrumentação: ausente ≠ completo. Sem isso, a janela de deploy envenena a medição
+com falsos `completo`, e a fase 2 decidiria em cima deles.
+
+### 3.4 Atomicidade: o head é gravado DENTRO da transação que substitui as linhas
+
+`farmer_recomendacoes_substituir` e `farmer_bundle_recomendacoes_substituir` passam a gravar o
+head no mesmo `BEGIN`, depois do UPDATE+INSERT. Uma RPC nova cobre só o caminho que não toca
+linha:
+
+```
+farmer_geracao_registrar(p_motor, p_farmer_id, p_run_id, p_resultado,
+                         p_linhas_geradas, p_completude, p_motivo,
+                         p_insumos, p_head_visto)
+```
+
+Duas transações separadas deixariam head e linhas divergentes — e head divergente é
+**medição corrompida**, que é exatamente o insumo com que a fase 2 decidiria ligar a expiração.
+
+**Serialização.** A RPC de registro toma o **mesmo** advisory lock da RPC de substituição do
+motor correspondente (`hashtext('farmer_recomendacoes_substituir')` ou
+`hashtext('farmer_bundle_recomendacoes_substituir')`, com `hashtext(farmer_id::text)`), para
+que um registro de "vazio" não corra em paralelo com uma substituição com linhas. Locks
+diferentes serializariam cada caminho consigo mesmo e com mais ninguém — que é o mesmo que
+não serializar.
+
+**CAS do head (`p_head_visto`).** O caminho vazio compara a geração de head que leu com a
+vigente; divergiu, recusa (FG106) sem escrever. É o mesmo raciocínio do §10 (o run mais lento
+é o degradado, e "terminar depois" é o desfecho esperado, não o azar) — aplicado ao registro:
+sem isso, um run vazio lento sobrescreveria o head de um run com linhas que terminou antes, e a
+medição registraria `vazio` para um estado que é `linhas`. **Não depende de relógio nenhum** —
+nem do browser, nem do servidor.
+
+A RPC de substituição **não** precisa de CAS próprio para o head: ela já detém o advisory lock
+e já fez o CAS contra a linha, então dentro do lock ler-e-escrever o head é seguro.
+
+### 3.4.1 O que o head representa (a sutileza que decide a fase 2)
+
+**O head registra a última execução CONCLUÍDA do motor — não o conteúdo de
+`farmer_recommendations`.** Com `resultado='vazio'` as linhas pendentes anteriores
+**continuam lá**: é exatamente o buraco que o sensor existe para medir. Os dois só
+convergem quando a fase 2 ligar a expiração.
+
+Duas consequências, ambas escritas no `COMMENT` da tabela para não se perderem:
+
+1. Até a fase 2, **nenhum leitor de oferta pode usar o head como fonte** — a autoridade
+   sobre o que a vendedora vê continua sendo a tabela de linhas.
+2. Uma execução que **não conclui** não move o head. Por isso o caminho em que a leitura
+   das regras de associação falha (que lança **sem** limpar a tela, deixando o resultado
+   anterior visível) **não** registra: mover o head ali afirmaria um desfecho que não
+   houve. Já o caminho de `get_skus_margem_positiva` limpa a tela antes de lançar — ali o
+   resultado exibido é de fato vazio, e o head registra `degradado`.
+
+### 3.5 Os três caminhos de zero passam a se declarar
+
+| caminho no motor | hoje | passa a ser |
+|---|---|---|
+| `:225` sem `clientScores` | `return` mudo | `vazio` + `degradado` + motivo |
+| `:296` nenhum cliente com pedido | `return` mudo | `vazio` + `degradado` + motivo |
+| `get_skus_margem_positiva` falha | lança (fail-closed) | registra `degradado` **antes** de lançar |
+| fim do funil com 0 linhas | `return` mudo | **`vazio` + `completo`** ← o "zero de verdade" |
+| geração com linhas | RPC | `linhas` + `completo`, na mesma transação |
+
+O motor já **sabe** por qual caminho saiu — ele só nunca transmitiu essa informação. É por isso
+que a completude é uma declaração do produtor, e não algo que se possa inferir do resultado.
+
+**A completude é do SNAPSHOT, não do resultado**: `completo` significa *"li todos os insumos
+com sucesso e nenhum insumo estruturalmente obrigatório veio vazio"*. Com `fetchAllPages` já
+lançando em falha de página (§6/§7), leitura parcial não chega mais como lista vazia — o que
+resta é a semântica, e é isso que o motor declara.
+
+A regra vive em `src/lib/farmer/completude-snapshot.ts` (helper puro, testado isoladamente),
+com duas formas distintas de degradar:
+
+- **`ok: false`** (não consegui ler) degrada para **qualquer** insumo, obrigatório ou não —
+  um universo lido pela metade produz resultado que parece completo e não é;
+- **`n === 0`** (li e veio vazio) degrada só nos **obrigatórios** — é a diferença entre "a
+  base não tem esse padrão" (legítimo) e "esse insumo não existe" (falta).
+
+**`carteira_ativa` é um insumo separado de `pedidos`, e a distinção importa.** `pedidos` é
+global (a base tem histórico?); `carteira_ativa` é a interseção carteira × clientes com
+pedido — o universo REAL do cálculo. Um farmer cujos clientes nunca compraram tem `pedidos`
+farto e `carteira_ativa` zero, e aí o zero final não julga o portfólio: só diz que não há
+coocorrência de onde tirar recomendação. Sem separar os dois, esse caso sairia rotulado
+`completo` e viraria licença para expirar.
+
+**Insumo obrigatório não declarado também degrada** — ausente ≠ zero aplicado à própria
+medição. Se um caminho novo esquecer de declarar um insumo, o head sai `degradado`, nunca
+`completo` por omissão: licença de expirar concedida por descuido é o pior modo de falha
+deste desenho.
+
+### 3.6 O registro do head é FAIL-OPEN — e isso limita o que ele pode decidir
+
+Falha ao gravar o head **não pode** derrubar a tela da vendedora: o cálculo é válido e já foi
+exibido. Consequência declarada, herdada do §11 (`acoes_execucoes`): **sendo fail-open, o head
+não pode ser a fonte de completude**. Ele mede o que o motor conseguiu declarar; a completude
+de verdade se mede contra o **esperado**, não contra o que o próprio registro julgou.
+
+Na fase 1 isso é inofensivo (o head não decide nada). Na fase 2 é a restrição central, e está
+escrita aqui para não se perder.
+
+### 3.7 RLS
+
+Tabela nova nasce com RLS (regra do CLAUDE.md). Policies espelhando as de
+`farmer_recommendations`: SELECT para o próprio farmer ou `cap_carteira_ler`; INSERT/UPDATE
+para o próprio farmer ou `cap_carteira_escrever`. As RPCs são SECURITY INVOKER — **a RLS é
+quem autoriza**, o gate na RPC é de MENSAGEM — igual ao #1756, e fechando em `IS NOT TRUE`
+pelo mesmo motivo (numa sessão sem JWT, `auth.uid()` é NULL e `NOT (…)` devolve NULL, que
+não dispara o `IF`).
+
+## 4. Códigos de erro (faixa FG1xx, para não colidir com FG0xx do #1756)
+
+| código | significado |
+|---|---|
+| FG101 | `p_motor`/`p_farmer_id`/`p_run_id` obrigatórios |
+| FG102 | `p_motor` fora de `('cross_sell','bundle')` |
+| FG103 | `p_resultado`/`p_completude` inválidos, ou `linhas_geradas` incoerente |
+| FG104 | `degradado` sem motivo |
+| FG105 | outro recálculo deste farmer em andamento (advisory lock) |
+| FG106 | head mudou durante o cálculo (CAS) |
+| FG107 | `resultado=linhas` sem nenhuma linha gravada para aquele `run_id` |
+
+**FG107 é o guard anti-forja.** `resultado` chega do browser, e o head é *medição* — medição
+forjável é medição corrompida, e é sobre ela que a fase 2 decidiria ligar a expiração. Por
+isso `'linhas'` é ancorado na realidade: a RPC exige que existam de fato pendentes com aquele
+`run_id`. Funciona porque as RPCs de substituição inserem **antes** de chamar o registro, na
+mesma transação. O caminho `'vazio'` não precisa do espelho — o run é novo, então "não há
+linha com este `run_id`" é trivialmente verdade, e forjar `vazio` só prejudica o próprio
+farmer (o único que o gate deixa passar), sem expirar nada nesta fase.
+
+## 5. Prova
+
+- `db/test-farmer-head-geracao.sh` — PG17 local, asserts positivos + negativos (SQLSTATE
+  esperada + re-raise) + RLS sob `SET ROLE authenticated` + falsificações.
+- `db/test-farmer-geracao-vigente.sh` (35 asserts + 5 falsificações do #1756) **tem de
+  continuar verde** — as RPCs de substituição são alteradas, e a assinatura de 4 args
+  precisa seguir funcionando.
+- Falsificação rodada sob `LC_ALL=C` **e** `pt_BR.UTF-8`, com baseline verde explícito antes
+  e conferência da CONTAGEM e dos NOMES dos vermelhos.
+
+## 6. Quando medir (é query, não recado)
+
+```sql
+SELECT motor, resultado, completude, count(*) AS farmers,
+       max(calculado_em) AS ultimo
+FROM public.farmer_geracao_vigente
+GROUP BY 1,2,3 ORDER BY 1,2,3;
+```
+
+**A fase 2 (ligar a expiração) exige ≥1 `resultado='vazio'` com `completude='completo'` e
+`insumos` plausíveis.** Enquanto essa query não devolver essa linha, a expiração-por-vazio não
+tem sinal que a justifique — e "está no ar e ninguém reclamou" continua sendo ausência de dado.
+
+---
+
+## 7. O que o challenge do Codex (xhigh) mudou no desenho
+
+O parecer veio depois da 1ª implementação estar verde (49 asserts, 6 falsificações) e
+derrubou três premissas. Registrado aqui porque **duas delas eram contradições entre o que
+este spec afirmava e o que a migration fazia** — o tipo de erro que passa despercebido
+justamente por estar escrito certo no documento.
+
+### 7.1 A tabela tinha `GRANT INSERT, UPDATE` para `authenticated` (CRÍTICO)
+
+O §3.2 dizia *"há 1 writer (as RPCs desta migration; a tabela não recebe grant de escrita
+direta)"* — e a migration fazia `GRANT SELECT, INSERT, UPDATE ... TO authenticated`. Com
+esse grant, o browser dispensa a RPC inteira:
+
+```sql
+UPDATE farmer_geracao_vigente SET resultado='vazio', completude='completo' WHERE ...
+```
+
+Isso pula FG105 (lock), FG106 (CAS) e FG107 (anti-forja) de uma vez. **Guard que se
+contorna pela porta ao lado não é guard** — e aqui o contorno falsifica a *medição*, que é
+o produto inteiro da entrega.
+
+**Correção:** nenhum grant de escrita e nenhuma policy de INSERT/UPDATE para
+`authenticated` (só `SELECT`); `farmer_geracao_registrar` passa a `SECURITY DEFINER`, o que
+a torna a única porta. DEFINER bypassa RLS, então o gate da função é a autorização inteira
+— ele já existia, já fecha em `IS NOT TRUE`, e `auth.uid()` continua sendo o do chamador
+(lê o JWT, não o role do Postgres), então o DEFINER não o afrouxa.
+
+### 7.2 O head não mede FREQUÊNCIA — e apaga o evento procurado (o mais importante)
+
+`ON CONFLICT DO UPDATE` sobrescreve a única linha do par. Logo um `vazio+completo` pode
+acontecer hoje e **sumir** no próximo run com linhas. O head responde *"qual é o último
+estado dos até 6 pares"* — e a pergunta que originou esta entrega é *"com que frequência o
+recálculo produz zero?"*. Sem histórico, a ausência de `vazio+completo` continuaria sendo
+ausência de dado: exatamente o defeito que o sensor existe para curar.
+
+**Correção:** tabela append-only `farmer_geracao_execucoes`, escrita na mesma transação,
+com `UNIQUE(motor, farmer_id, run_id)` para que um retry não conte como execução nova
+(senão a "frequência" mede retries). Divisão de trabalho declarada: **head = estado + CAS;
+log = medição.** As queries do §6 passam a sair do log. Volume não era objeção — 28
+execuções em 5,5 meses.
+
+### 7.3 O CAS era assimétrico (eu tinha chegado nisso; ele mostrou que dava para fechar)
+
+Cenário: run L (linhas) e run E (vazio) leem o mesmo head. E termina primeiro e move o
+head. L termina depois — e seu CAS da etapa 5 **passa**, porque ele compara *linhas* e E
+não mexeu em linha nenhuma. L então sobrescreve um vazio mais novo.
+
+O sistema misturava duas ordens: frescor causal para o vazio, ordem-de-commit para as
+linhas. Eu ia declarar isso como limitação conhecida (o viés é conservador — subestima o
+vazio, o que atrasa a fase 2 em vez de acelerá-la). O Codex está certo de que dá para
+fechar barato.
+
+**Correção:** as RPCs de substituição recebem `p_head_visto` — o head que o **browser** viu
+antes do cálculo — em vez de lerem o head sob o próprio lock (o que satisfazia o CAS por
+construção). `p_completude IS NULL` continua sendo o marcador de chamador anterior ao
+sensor, e só nesse caso se cai no head corrente.
+
+### 7.4 Correções menores
+
+- **`EXISTS` não é contagem** (FG107): aceitava *"1 linha real, 999 declaradas"*, e
+  `linhas_geradas` é o que a fase 2 leria para dimensionar. Agora conta no servidor e
+  compara; `vazio` também é ancorado (declarar vazio num run que tem linhas é recusado).
+- **`NOTIFY pgrst, 'reload schema'`** no fim: sem ele a janela entre apply e reload devolve
+  PGRST202 para a RPC nova — e como o registro é fail-open, isso sairia só num
+  `console.error`: o sensor nasceria cego sem ninguém perceber.
+- **Cobertura de perfil** (§3.5): o motor faz `if (!profile) continue`, e a base tem 1.633
+  usuários sem `profiles` (aliases fiscais, `database.md` §5). Contar o universo global
+  (`n > 0`) não pega um farmer cujos clientes ativos caiam todos nesse grupo — contar a
+  **interseção** pega. Novo insumo obrigatório `clientes_com_profile`.
+- **Sobre a reentrância do lock:** o parecer confirmou o comportamento e corrigiu com razão
+  a minha justificativa — `pg_locks = 1` mostra o lock *tag*, não todo o bookkeeping
+  interno, então não "prova" ausência de refcount. O que vale é o documentado: lock
+  transacional é reentrante e é liberado no fim da transação, sem dívida de unlock.
+
+### 7.5 O que NÃO foi aceito, e por quê
+
+- **RPCs versionadas (`*_v2`) em vez de DROP+CREATE.** Medido em prod: zero dependências em
+  `pg_depend`, zero cron, nenhuma sobrecarga pré-existente, e o único chamador é o browser
+  via PostgREST — que resolve pela aridade, preservada pelos DEFAULTs. Versionar deixaria
+  duas funções money-path vivas fazendo a mesma coisa, que é a dívida que o repo
+  historicamente paga caro.
+- **Cobertura de "histórico utilizável" (itens mapeáveis por pedido).** Procede como
+  crítica, mas exige percorrer os itens de todos os pedidos só para instrumentar. Fica
+  **declarado como limitação**: `carteira_ativa` conta clientes com pedido, não clientes
+  com pedido cujos itens resolvem para SKU do catálogo. A fase 2 precisa fechar isso antes
+  de expirar — está anotado no §6 como pré-requisito, não como pendência vaga.

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -6,6 +6,12 @@ import { toast } from 'sonner';
 import { margemConhecida } from '@/lib/scoring/margin';
 import { fetchAllPages } from '@/lib/postgrest';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import {
+  avaliarCompletude,
+  INSUMOS_OBRIGATORIOS_BUNDLE,
+  type InsumosSnapshot,
+} from '@/lib/farmer/completude-snapshot';
+import { lerHeadVigente, registrarGeracaoFarmer } from '@/lib/farmer/registrar-geracao';
 
 // ─── Types ───────────────────────────────────────────────────────────
 export interface AssociationRule {
@@ -160,13 +166,37 @@ export const useBundleEngine = () => {
     setCalculating(true);
     setLoading(true);
 
+    // Snapshot dos insumos DESTA execução (ver useCrossSellEngine para o racional): o head
+    // precisa declarar se o zero veio de um snapshot íntegro, e isso não se infere do
+    // resultado — só o produtor sabe.
+    const insumos: InsumosSnapshot = {};
+    // `undefined` = não consegui ler o head → registro PULADO, nunca às cegas.
+    let headVisto: string | null | undefined;
+    const runId = crypto.randomUUID();
+
+    const registrarVazio = async () => {
+      if (isImpersonating || headVisto === undefined) return;
+      const { completude, motivo } = avaliarCompletude(insumos, INSUMOS_OBRIGATORIOS_BUNDLE);
+      await registrarGeracaoFarmer({
+        motor: 'bundle',
+        farmerId: effectiveUserId,
+        runId,
+        resultado: 'vazio',
+        linhasGeradas: 0,
+        completude,
+        motivo,
+        insumos,
+        headVisto,
+      });
+    };
+
     try {
       // 0. Identidade desta EXECUÇÃO + a geração de bundles que ela substitui.
       // Lido ANTES do snapshot (money-path §10: reivindicar depois deixa a corrida
       // aberta pela porta de trás). Espelha useCrossSellEngine — ver o racional lá.
-      const runId = crypto.randomUUID();
       let geracaoVista: string | null = null;
       if (!isImpersonating) {
+        headVisto = await lerHeadVigente('bundle', effectiveUserId);
         // Mesma ordem que a RPC usa para eleger a geração vigente (created_at desc, id desc).
         const { data: vigente, error: erroVigente } = await supabase
           .from('farmer_bundle_recommendations')
@@ -237,16 +267,31 @@ export const useBundleEngine = () => {
         supabase.rpc('get_skus_margem_positiva') as unknown as Promise<{ data: { product_id: string }[] | null; error: unknown }>,
       ]);
 
+      // `fetchAllPages` LANÇA em falha de página, então chegar aqui já significa leitura
+      // íntegra — `ok: true`. O que ainda pode ser zero é o CONTEÚDO.
+      insumos.catalogo = { ok: true, n: (products || []).length };
+      insumos.scores = { ok: true, n: clientScores.length };
+
       // FAIL-CLOSED: falha na RPC → NENHUM bundle. Degradar para "monta bundle com tudo" poria
       // produto de PREJUÍZO na oferta combinada, que é o pior desfecho possível aqui.
       if (vendaveisResult.error || !vendaveisResult.data) {
         console.error('get_skus_margem_positiva falhou — sem bundles (fail-closed):', vendaveisResult.error);
+        // `ok: false` = "não consegui ler", não "veio vazio". Um head degradado por aqui
+        // nunca poderá autorizar expiração.
+        insumos.vendaveis = { ok: false, n: 0 };
         setCustomerBundles([]);
+        await registrarVazio();
         return;
       }
       const vendaveis = new Set(vendaveisResult.data.map((r) => r.product_id));
+      insumos.vendaveis = { ok: true, n: vendaveis.size };
 
-      if (!clientScores?.length) { setCustomerBundles([]); return; }
+      if (!clientScores?.length) {
+        setCustomerBundles([]);
+        // Era um `return` MUDO — a razão de a frequência do zero nunca ter sido mensurável.
+        await registrarVazio();
+        return;
+      }
 
       // Load ALL sales orders (avoid huge .in() URL)
       // Mesmo defeito do loop manual acima — aqui a perda é do HISTÓRICO que alimenta as regras
@@ -272,6 +317,19 @@ export const useBundleEngine = () => {
       });
       const profileMap = new Map<string, ProfileRow>();
       (profiles || []).forEach((p) => profileMap.set(p.user_id, p));
+
+      // Dois insumos distintos: `pedidos` é global (a base tem histórico?) e
+      // `carteira_ativa` é o universo REAL deste cálculo (a carteira DESTE farmer tem?).
+      const clientesComPedido = new Set((salesOrders || []).map((o) => o.customer_user_id));
+      insumos.pedidos = { ok: true, n: clientesComPedido.size };
+      const ativos = clientScores.filter((c) => clientesComPedido.has(c.customer_user_id));
+      insumos.carteira_ativa = { ok: true, n: ativos.length };
+      // COBERTURA de perfil: o motor faz `if (!profile) continue` mais abaixo — cliente sem
+      // perfil é pulado em silêncio (ver useCrossSellEngine para o racional completo).
+      insumos.clientes_com_profile = {
+        ok: true,
+        n: ativos.filter((c) => profileMap.has(c.customer_user_id)).length,
+      };
 
       // 2. Build transaction baskets per customer
       const baskets: string[][] = [];
@@ -653,6 +711,14 @@ export const useBundleEngine = () => {
         // Lote vazio não chama a RPC (ela recusaria com FG003): expirar a geração por
         // "não achei bundle nenhum" tiraria a oferta da tela por um dado que falta a
         // montante. Mesmo critério das regras de associação logo acima.
+        //
+        // O que MUDOU: o vazio deixou de ser silencioso — ele move o HEAD declarando se o
+        // snapshot estava íntegro. Vazio com snapshot completo é o "zero de verdade", e é
+        // o único sinal que autorizaria a fase 2 a ligar a expiração.
+        const { completude, motivo } = avaliarCompletude(insumos, INSUMOS_OBRIGATORIOS_BUNDLE);
+        if (recomendacoes.length === 0) {
+          await registrarVazio();
+        }
         if (recomendacoes.length > 0) {
           const { error: erroRecs } = await supabase.rpc(
             'farmer_bundle_recomendacoes_substituir' as never,
@@ -661,6 +727,13 @@ export const useBundleEngine = () => {
               p_run_id: runId,
               p_geracao_vista: geracaoVista,
               p_linhas: recomendacoes,
+              // O head é movido pela própria RPC, na MESMA transação.
+              p_completude: completude,
+              p_motivo: motivo,
+              p_insumos: insumos,
+              // Ver useCrossSellEngine: sem o head ORIGINAL, um run vazio mais novo seria
+              // sobrescrito por este, que leu snapshot mais velho.
+              p_head_visto: headVisto ?? null,
             } as never,
           );
           if (erroRecs) {

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -3,6 +3,12 @@ import { supabase } from '@/integrations/supabase/client';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { fetchAllPages } from '@/lib/postgrest';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import {
+  avaliarCompletude,
+  INSUMOS_OBRIGATORIOS_CROSS_SELL,
+  type InsumosSnapshot,
+} from '@/lib/farmer/completude-snapshot';
+import { lerHeadVigente, registrarGeracaoFarmer } from '@/lib/farmer/registrar-geracao';
 import { toast } from 'sonner';
 
 // ─── Types ───────────────────────────────────────────────────────────
@@ -158,6 +164,37 @@ export const useCrossSellEngine = () => {
     // desta execução, e chamá-los de desatualizados mentiria na direção oposta).
     let resultadoDestaExecucao = false;
 
+    // Snapshot dos insumos DESTA execução: por insumo, se a leitura deu certo e quantas
+    // linhas vieram. É o que permite ao head declarar a completude — e, mais importante,
+    // é a EVIDÊNCIA que deixa auditar a declaração em vez de confiar no rótulo.
+    const insumos: InsumosSnapshot = {};
+    // O head que esta execução VIU antes de calcular (lado "compare" do CAS do head).
+    // `undefined` = não consegui ler → o registro é PULADO, nunca feito às cegas: `null`
+    // significa "não há head" e faria o CAS passar como primeira execução, sobrescrevendo
+    // um head que existe.
+    let headVisto: string | null | undefined;
+    const runId = crypto.randomUUID();
+
+    /**
+     * Registra a geração VAZIA (ou degradada) — os caminhos que não chamam a RPC de
+     * substituição. Fail-open por dentro: nunca derruba a tela.
+     */
+    const registrarVazio = async () => {
+      if (isImpersonating || headVisto === undefined) return;
+      const { completude, motivo } = avaliarCompletude(insumos, INSUMOS_OBRIGATORIOS_CROSS_SELL);
+      await registrarGeracaoFarmer({
+        motor: 'cross_sell',
+        farmerId: effectiveUserId,
+        runId,
+        resultado: 'vazio',
+        linhasGeradas: 0,
+        completude,
+        motivo,
+        insumos,
+        headVisto,
+      });
+    };
+
     try {
       // 0. Identidade desta EXECUÇÃO + a geração que ela está substituindo.
       //
@@ -169,9 +206,10 @@ export const useCrossSellEngine = () => {
       // (nem do browser, nem do servidor).
       //
       // Na lente "Ver como" a persistência é pulada, então nem lemos.
-      const runId = crypto.randomUUID();
       let geracaoVista: string | null = null;
       if (!isImpersonating) {
+        // O head do motor, lido na MESMA janela que a geração vigente e pelo mesmo motivo.
+        headVisto = await lerHeadVigente('cross_sell', effectiveUserId);
         // Mesma ordem que a RPC usa para eleger a geração vigente (created_at desc, id desc):
         // divergir aqui faria o compare-and-swap comparar com outra linha e recusar sempre.
         const { data: vigente, error: erroVigente } = await supabase
@@ -222,9 +260,19 @@ export const useCrossSellEngine = () => {
         clientScores = await fetchAllScores();
       }
 
+      // `fetchAllPages` LANÇA em falha de página (#1545), então chegar aqui já significa
+      // leitura íntegra — `ok: true`. O que ainda pode ser zero é o CONTEÚDO, e é essa a
+      // diferença que o head passa a registrar.
+      insumos.scores = { ok: true, n: clientScores.length };
+
       if (!clientScores?.length) {
         aplicarRecomendacoes([]);
         resultadoDestaExecucao = true;
+        // Este `return` era MUDO: o recálculo saía por aqui sem gravar linha, sem
+        // registrar execução e sem toast — e era por isso que a frequência do zero não
+        // tinha como ser medida. Agora ele move o head declarando POR QUE deu zero
+        // (`degradado`: carteira sem score é dado faltando a montante, não "nada a ofertar").
+        await registrarVazio();
         return;
       }
 
@@ -249,8 +297,13 @@ export const useCrossSellEngine = () => {
       const { data: skusVendaveis, error: erroVendaveis } = (await supabase.rpc(
         'get_skus_margem_positiva',
       )) as unknown as { data: { product_id: string }[] | null; error: unknown };
+      insumos.catalogo = { ok: true, n: products.length };
       if (erroVendaveis || !skusVendaveis) {
         console.error('get_skus_margem_positiva falhou — sem recomendação (fail-closed):', erroVendaveis);
+        // `ok: false` — não é "veio vazio", é "não consegui ler". A distinção é o produto
+        // desta entrega: um head `degradado` por aqui NUNCA poderá autorizar expiração.
+        insumos.vendaveis = { ok: false, n: 0 };
+        await registrarVazio();
         // Fail-closed E DECLARADO. Só limpar a lista e sair repetiria, num caminho NOVO, o defeito
         // que o #1606 tirou deste hook: a tela mostrava fila vazia e o operador não distinguia
         // "não há o que recomendar" de "não consegui calcular" — e ia embora achando que era a
@@ -268,6 +321,7 @@ export const useCrossSellEngine = () => {
         );
       }
       const vendaveis = new Set(skusVendaveis.map((r) => r.product_id));
+      insumos.vendaveis = { ok: true, n: vendaveis.size };
 
       // 3. Load ALL sales history (avoid huge .in() URL with 3598 IDs)
       // Mesmo defeito do loop manual acima — e aqui a perda é do HISTÓRICO que alimenta as
@@ -292,10 +346,19 @@ export const useCrossSellEngine = () => {
       // Filter clientScores to only those with orders (avoid processing 3598 empty clients)
       const activeClientScores = clientScores.filter((c) => customerIdsWithOrders.has(c.customer_user_id));
       const customerIds = activeClientScores.map((c) => c.customer_user_id);
+      // Dois insumos distintos de propósito: `pedidos` é global (a base tem histórico?) e
+      // `carteira_ativa` é o universo REAL deste cálculo (a carteira DESTE farmer tem?).
+      insumos.pedidos = { ok: true, n: customerIdsWithOrders.size };
+      insumos.carteira_ativa = { ok: true, n: customerIds.length };
 
       if (!customerIds.length) {
         aplicarRecomendacoes([]);
         resultadoDestaExecucao = true;
+        // Outro `return` que era MUDO. Degrada (não "completo"): sem nenhum cliente com
+        // histórico não há coocorrência de onde tirar recomendação, então o zero não julga
+        // o portfólio — e um zero que não julga o portfólio não pode virar licença para
+        // expirar a carteira.
+        await registrarVazio();
         return;
       }
 
@@ -317,11 +380,18 @@ export const useCrossSellEngine = () => {
         .gte('confidence', 0.05)
         .gte('lift', 1.0)) as unknown as { data: AssocRuleRow[] | null; error: unknown };
       if (erroAssoc) {
+        // NÃO move o head: este caminho lança SEM limpar a tela, então a execução não
+        // concluiu e o que o operador vê segue sendo o resultado anterior. O head registra
+        // execução CONCLUÍDA — mover aqui afirmaria um desfecho que não houve.
         throw new Error(
           mensagemDeErro(erroAssoc) ??
             'Não consegui ler as regras de associação — o cálculo seria parcial e substituiria as recomendações atuais, então nada foi alterado.',
         );
       }
+      // `regras` NÃO é obrigatório-não-vazio: base sem padrão de coocorrência é estado
+      // legítimo e o motor ainda recomenda por popularidade. Mas `ok: false` acima degrada,
+      // porque aí o universo foi lido pela metade.
+      insumos.regras = { ok: true, n: (assocRules || []).length };
 
       // Build map: antecedent product -> consequent products with scores
       const assocMap = new Map<string, { productId: string; confidence: number; lift: number; support: number }[]>();
@@ -365,6 +435,17 @@ export const useCrossSellEngine = () => {
       const allProfiles: ProfileRow[] = batchResults.flatMap((r) => r.data || []);
       const profileMap = new Map<string, ProfileRow>();
       allProfiles.forEach((p) => profileMap.set(p.user_id, p));
+
+      // COBERTURA de perfil, não só contagem (achado do challenge Codex xhigh). Mais
+      // abaixo o motor faz `if (!profile) continue`: cliente sem perfil é PULADO em
+      // silêncio, e a base tem 1.633 usuários `@placeholder.local` sem `profiles` (aliases
+      // fiscais — ver database.md §5). Um farmer cujos clientes ativos caiam todos nesse
+      // grupo produziria zero com todos os insumos "não-vazios" — `completo` sem ser.
+      // Medir o universo global (`n > 0`) não pega isso; medir a INTERSEÇÃO pega.
+      insumos.clientes_com_profile = {
+        ok: true,
+        n: customerIds.filter((id) => profileMap.has(id)).length,
+      };
 
       // 6. Build omie_codigo_produto -> product UUID map
       const omieToProductId = new Map<number, string>();
@@ -595,10 +676,20 @@ export const useCrossSellEngine = () => {
       // Persistência PULADA na lente "Ver como" (somente leitura: o master inspeciona
       // as recomendações do alvo sem regravar a carteira dele).
       //
-      // `length > 0` continua sendo o guard: lote vazio quase sempre é dado faltando a
-      // montante, e expirar a carteira por causa disso deixaria a vendedora sem NENHUMA
-      // oferta. A RPC recusa o lote vazio de qualquer jeito (FG003) — não a chamamos só
-      // para tomar o erro. Mesmo raciocínio do bloco de regras no useBundleEngine.
+      // `length > 0` continua sendo o guard, e continua NÃO expirando: lote vazio pode ser
+      // dado faltando a montante, e expirar a carteira por causa disso deixaria a vendedora
+      // sem NENHUMA oferta. A RPC recusa o lote vazio de qualquer jeito (FG003).
+      //
+      // O que MUDOU: o vazio deixou de ser silencioso. Ele move o HEAD, declarando se o
+      // snapshot estava íntegro. Chegar aqui com `recRows` vazio e todos os insumos
+      // completos é o "ZERO DE VERDADE" — o cálculo concluiu que não deve haver
+      // recomendação nenhuma — e é o único sinal que autoriza a fase 2 a ligar a
+      // expiração. Até esta entrega esse estado não tinha COMO ser registrado, e é por
+      // isso que a frequência dele era desconhecida.
+      const { completude, motivo } = avaliarCompletude(insumos, INSUMOS_OBRIGATORIOS_CROSS_SELL);
+      if (!isImpersonating && recRows.length === 0) {
+        await registrarVazio();
+      }
       if (!isImpersonating && recRows.length > 0) {
         // O `error` é CAPTURADO. O supabase-js NÃO lança em erro de banco — resolve normal
         // com `error` preenchido — então o `await` solto devolveria sucesso SEM ter gravado.
@@ -611,6 +702,15 @@ export const useCrossSellEngine = () => {
             p_run_id: runId,
             p_geracao_vista: geracaoVista,
             p_linhas: recRows,
+            // O head é movido pela própria RPC, na MESMA transação: head e linhas em
+            // transações separadas divergiriam, e head divergente é medição corrompida.
+            p_completude: completude,
+            p_motivo: motivo,
+            p_insumos: insumos,
+            // O head que ESTA execução viu, lido antes do cálculo. Sem ele a RPC compararia
+            // o head consigo mesmo e um run vazio mais NOVO seria sobrescrito por este, que
+            // leu snapshot mais velho (achado do challenge Codex xhigh).
+            p_head_visto: headVisto ?? null,
           } as never,
         );
         if (erroPersistencia) {

--- a/src/lib/farmer/__tests__/completude-snapshot.test.ts
+++ b/src/lib/farmer/__tests__/completude-snapshot.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  avaliarCompletude,
+  INSUMOS_OBRIGATORIOS_CROSS_SELL,
+  type InsumosSnapshot,
+} from '../completude-snapshot';
+
+/**
+ * O que estes testes protegem: `completude='completo'` é o ÚNICO rótulo que a fase 2
+ * poderá usar para expirar a geração de um farmer. Um falso `completo` não produz número
+ * errado — apaga a carteira inteira de uma vendedora. Por isso todo caso duvidoso tem um
+ * teste exigindo `degradado`.
+ */
+
+const COMPLETO: InsumosSnapshot = {
+  scores: { ok: true, n: 3858 },
+  catalogo: { ok: true, n: 3108 },
+  vendaveis: { ok: true, n: 1200 },
+  pedidos: { ok: true, n: 861 },
+  carteira_ativa: { ok: true, n: 171 },
+  clientes_com_profile: { ok: true, n: 168 },
+  regras: { ok: true, n: 450 },
+};
+
+const OBRIGATORIOS = ['scores', 'catalogo', 'vendaveis', 'pedidos', 'carteira_ativa', 'clientes_com_profile'];
+
+describe('avaliarCompletude', () => {
+  it('snapshot íntegro é completo, sem motivo', () => {
+    expect(avaliarCompletude(COMPLETO, INSUMOS_OBRIGATORIOS_CROSS_SELL)).toEqual({
+      completude: 'completo',
+      motivo: null,
+    });
+  });
+
+  // ─── "não consegui ler" degrada SEMPRE ───────────────────────────────────
+  it.each(OBRIGATORIOS)(
+    'insumo obrigatório com ok:false degrada (%s)',
+    (nome) => {
+      const r = avaliarCompletude(
+        { ...COMPLETO, [nome]: { ok: false, n: 0 } },
+        INSUMOS_OBRIGATORIOS_CROSS_SELL,
+      );
+      expect(r.completude).toBe('degradado');
+      expect(r.motivo).toContain(nome);
+    },
+  );
+
+  it('insumo NÃO-obrigatório com ok:false também degrada — leitura parcial é leitura parcial', () => {
+    // `regras` pode vir legitimamente VAZIO, mas não pode vir MAL LIDO: um universo lido
+    // pela metade produz um resultado que parece completo e não é (money-path §6).
+    const r = avaliarCompletude(
+      { ...COMPLETO, regras: { ok: false, n: 0 } },
+      INSUMOS_OBRIGATORIOS_CROSS_SELL,
+    );
+    expect(r.completude).toBe('degradado');
+    expect(r.motivo).toContain('regras');
+  });
+
+  // ─── "li e veio vazio" degrada só nos obrigatórios ───────────────────────
+  it.each(OBRIGATORIOS)(
+    'insumo obrigatório vazio degrada (%s)',
+    (nome) => {
+      const r = avaliarCompletude(
+        { ...COMPLETO, [nome]: { ok: true, n: 0 } },
+        INSUMOS_OBRIGATORIOS_CROSS_SELL,
+      );
+      expect(r.completude).toBe('degradado');
+      expect(r.motivo).toContain(nome);
+    },
+  );
+
+  it('regras vazias NÃO degradam — base sem coocorrência é estado legítimo', () => {
+    // Este é o caso que separa "zero de verdade" de "zero por dado faltando": a base pode
+    // simplesmente não ter padrão, e o motor ainda recomenda por popularidade.
+    expect(
+      avaliarCompletude({ ...COMPLETO, regras: { ok: true, n: 0 } }, INSUMOS_OBRIGATORIOS_CROSS_SELL),
+    ).toEqual({ completude: 'completo', motivo: null });
+  });
+
+  // ─── ausente ≠ zero, aplicado à própria medição ──────────────────────────
+  it('insumo obrigatório NÃO DECLARADO degrada, e o motivo diz que é ausência', () => {
+    // Um insumo que o motor nem tentou ler não pode ser lido como "veio vazio". Se um
+    // caminho novo esquecer de declarar um insumo, o head tem de sair degradado — nunca
+    // completo por omissão, que seria licença de expirar concedida por descuido.
+    const { carteira_ativa: _omitido, ...semCarteira } = COMPLETO;
+    const r = avaliarCompletude(semCarteira, INSUMOS_OBRIGATORIOS_CROSS_SELL);
+    expect(r.completude).toBe('degradado');
+    expect(r.motivo).toContain('não declarado');
+    expect(r.motivo).toContain('carteira_ativa');
+  });
+
+  it('snapshot VAZIO não é completo por vacuidade', () => {
+    const r = avaliarCompletude({}, INSUMOS_OBRIGATORIOS_CROSS_SELL);
+    expect(r.completude).toBe('degradado');
+  });
+
+  // ─── determinismo do motivo ──────────────────────────────────────────────
+  it('o motivo é ESTÁVEL: a mesma falha em ordens de inserção diferentes dá o mesmo texto', () => {
+    // Sem ordem estável, duas execuções com a MESMA falha gravam motivos diferentes, e
+    // agregar o head por motivo passa a contar duas causas onde há uma.
+    const a: InsumosSnapshot = { scores: { ok: false, n: 0 }, catalogo: { ok: false, n: 0 } };
+    const b: InsumosSnapshot = { catalogo: { ok: false, n: 0 }, scores: { ok: false, n: 0 } };
+    expect(avaliarCompletude(a, INSUMOS_OBRIGATORIOS_CROSS_SELL).motivo).toBe(
+      avaliarCompletude(b, INSUMOS_OBRIGATORIOS_CROSS_SELL).motivo,
+    );
+  });
+
+  it('a falha de LEITURA tem precedência sobre o vazio — o motivo aponta a causa raiz', () => {
+    // Com scores mal lidos E catálogo vazio, o que explica o zero é o primeiro: reportar
+    // "catálogo vazio" mandaria quem investiga para o lugar errado.
+    const r = avaliarCompletude(
+      { ...COMPLETO, scores: { ok: false, n: 0 }, catalogo: { ok: true, n: 0 } },
+      INSUMOS_OBRIGATORIOS_CROSS_SELL,
+    );
+    expect(r.motivo).toContain('não consegui ler');
+    expect(r.motivo).toContain('scores');
+  });
+
+  it('degradado SEMPRE tem motivo — a RPC recusa com FG104 sem ele', () => {
+    const casos: InsumosSnapshot[] = [
+      { ...COMPLETO, scores: { ok: false, n: 0 } },
+      { ...COMPLETO, pedidos: { ok: true, n: 0 } },
+      {},
+    ];
+    for (const insumos of casos) {
+      const r = avaliarCompletude(insumos, INSUMOS_OBRIGATORIOS_CROSS_SELL);
+      expect(r.completude).toBe('degradado');
+      expect(r.motivo).toBeTruthy();
+      expect(r.motivo!.trim()).not.toBe('');
+    }
+  });
+
+  it('completo SEMPRE tem motivo null — a coluna só é preenchida quando degrada', () => {
+    expect(avaliarCompletude(COMPLETO, INSUMOS_OBRIGATORIOS_CROSS_SELL).motivo).toBeNull();
+  });
+});

--- a/src/lib/farmer/completude-snapshot.ts
+++ b/src/lib/farmer/completude-snapshot.ts
@@ -1,0 +1,126 @@
+/**
+ * Completude do SNAPSHOT do motor farmer — o que separa "zero de verdade" de
+ * "zero por dado faltando".
+ *
+ * Por que existe: o #1756 fez o recálculo APOSENTAR a geração anterior, mas só quando
+ * ele produz linha. A geração legitimamente VAZIA não movia nada, e o banco seguia
+ * servindo as recomendações que o novo cálculo decidiu que não deveriam existir. Para
+ * um dia poder expirar por vazio sem zerar a carteira de uma vendedora por causa de uma
+ * falha a montante, é preciso saber se o zero veio de um snapshot ÍNTEGRO.
+ *
+ * Isso não se infere do resultado — só o produtor sabe. Daí a completude ser uma
+ * DECLARAÇÃO do motor, e as contagens (`n`) serem a evidência que permite auditá-la:
+ * "rótulo com DEFAULT constante não é fato" (money-path §5).
+ *
+ * ⚠️ O rótulo `completo` é o único que a fase 2 poderá usar para expirar. Por isso a
+ * regra fecha em precisão > recall: qualquer dúvida vira `degradado`, e `degradado`
+ * nunca autoriza expirar. Errar para `degradado` custa uma oferta velha a mais na tela;
+ * errar para `completo` custa a carteira inteira da vendedora.
+ */
+
+/** Um insumo do snapshot: foi lido com sucesso, e quantas linhas vieram. */
+export interface InsumoLido {
+  /** `false` = a leitura FALHOU (exceção, página perdida, RPC recusada). */
+  ok: boolean;
+  /** Quantas linhas o insumo devolveu. Só faz sentido quando `ok`. */
+  n: number;
+}
+
+export type InsumosSnapshot = Record<string, InsumoLido>;
+
+export type Completude = 'completo' | 'degradado';
+
+export interface VeredictoCompletude {
+  completude: Completude;
+  /** `null` quando completo; a RPC EXIGE motivo quando degradado (FG104). */
+  motivo: string | null;
+}
+
+/**
+ * Insumos sem os quais o motor de cross-sell não pode concluir "não há o que recomendar".
+ *
+ * `regras` (associação) NÃO entra: uma base sem padrão de coocorrência é um estado
+ * legítimo, e o motor ainda recomenda por popularidade. Já `vendaveis` entra mesmo
+ * podendo ser legitimamente vazio (todo SKU sem custo conhecido é fail-closed por
+ * desenho, #1466) — porque "nenhum SKU rentável em toda a base" é muito mais provável
+ * ser custo não calculado do que verdade comercial, e o empate resolve fail-closed.
+ */
+export const INSUMOS_OBRIGATORIOS_CROSS_SELL = [
+  'scores',
+  'catalogo',
+  'vendaveis',
+  'pedidos',
+  // `carteira_ativa` (carteira ∩ clientes com pedido) é o universo REAL do cálculo, e é
+  // diferente de `pedidos`, que é global. Um farmer cujos clientes nunca compraram tem
+  // `pedidos` farto e `carteira_ativa` zero — e aí o zero final não diz nada sobre o
+  // portfólio, só que não há histórico de onde tirar coocorrência. Sem separar os dois,
+  // esse caso seria rotulado `completo` e viraria licença para expirar.
+  'carteira_ativa',
+  // COBERTURA, não universo: o motor faz `if (!profile) continue`, então cliente sem
+  // perfil é pulado em silêncio. A base tem 1.633 usuários sem `profiles` (aliases fiscais
+  // — database.md §5); um farmer cujos clientes ativos caiam todos nesse grupo produz zero
+  // com todos os universos globais "não-vazios". Contar `n > 0` no universo não pega isso;
+  // contar a INTERSEÇÃO com a carteira pega.
+  'clientes_com_profile',
+] as const;
+
+/** Idem para o motor de bundles, que parte das regras de associação. */
+export const INSUMOS_OBRIGATORIOS_BUNDLE = [
+  'scores',
+  'catalogo',
+  'vendaveis',
+  'pedidos',
+  'carteira_ativa',
+  'clientes_com_profile',
+] as const;
+
+/**
+ * Avalia a completude de um snapshot.
+ *
+ * Duas formas de degradar, e elas são diferentes:
+ *  1. **Não consegui ler** (`ok: false`) — falha de transporte. Sempre degrada, para
+ *     QUALQUER insumo, obrigatório ou não: um universo lido pela metade produz um
+ *     resultado que parece completo e não é (money-path §6).
+ *  2. **Li e veio vazio** (`n === 0`) — só degrada nos obrigatórios. É a diferença
+ *     entre "a base não tem esse padrão" (legítimo) e "esse insumo não existe" (falta).
+ *
+ * @param insumos          o que o motor leu, por nome
+ * @param obrigatoriosNaoVazios quais insumos não podem vir vazios
+ */
+export function avaliarCompletude(
+  insumos: InsumosSnapshot,
+  obrigatoriosNaoVazios: readonly string[],
+): VeredictoCompletude {
+  // Ordem estável (não a de inserção do objeto): com dois insumos quebrados, o motivo
+  // gravado precisa ser o mesmo em toda execução, senão duas falhas idênticas viram
+  // duas linhas de head diferentes e a agregação por motivo mente.
+  const nomes = Object.keys(insumos).sort();
+
+  const falharam = nomes.filter((nome) => !insumos[nome].ok);
+  if (falharam.length > 0) {
+    return {
+      completude: 'degradado',
+      motivo: `não consegui ler: ${falharam.join(', ')}`,
+    };
+  }
+
+  // `ausentes` ≠ `vaziosDeVerdade`: um obrigatório que o motor NEM TENTOU ler não pode
+  // ser tratado como "li e veio vazio" — é o §2 (ausente ≠ zero) na própria medição.
+  const ausentes = obrigatoriosNaoVazios.filter((nome) => !(nome in insumos));
+  if (ausentes.length > 0) {
+    return {
+      completude: 'degradado',
+      motivo: `insumo obrigatório não declarado: ${[...ausentes].sort().join(', ')}`,
+    };
+  }
+
+  const vazios = obrigatoriosNaoVazios.filter((nome) => insumos[nome].n === 0);
+  if (vazios.length > 0) {
+    return {
+      completude: 'degradado',
+      motivo: `insumo obrigatório veio vazio: ${[...vazios].sort().join(', ')}`,
+    };
+  }
+
+  return { completude: 'completo', motivo: null };
+}

--- a/src/lib/farmer/completude-snapshot.ts
+++ b/src/lib/farmer/completude-snapshot.ts
@@ -18,8 +18,11 @@
  * errar para `completo` custa a carteira inteira da vendedora.
  */
 
+// Não exportado de propósito: os consumidores montam o snapshot como objeto literal e
+// falam em `InsumosSnapshot`. Exportar sem consumidor faz o gate de dead-code (knip)
+// reprovar no CI — e o `bun run test` local NÃO cobre esse gate (o health stack sim).
 /** Um insumo do snapshot: foi lido com sucesso, e quantas linhas vieram. */
-export interface InsumoLido {
+interface InsumoLido {
   /** `false` = a leitura FALHOU (exceção, página perdida, RPC recusada). */
   ok: boolean;
   /** Quantas linhas o insumo devolveu. Só faz sentido quando `ok`. */

--- a/src/lib/farmer/registrar-geracao.ts
+++ b/src/lib/farmer/registrar-geracao.ts
@@ -1,0 +1,85 @@
+import { supabase } from '@/integrations/supabase/client';
+import { mensagemDeErro } from '@/lib/erro-mensagem';
+import type { Completude, InsumosSnapshot } from './completude-snapshot';
+
+/**
+ * Move o HEAD de geração do farmer — o caminho que NÃO toca linha.
+ *
+ * A geração COM linhas move o head dentro da própria RPC de substituição (mesma
+ * transação, `20260815181500_farmer_geracao_head_sensor.sql`). Esta função existe para
+ * o caminho que a RPC de substituição recusa por desenho: a geração VAZIA, e a
+ * DEGRADADA. Sem ela, um recálculo que conclui "não há o que recomendar" não deixa
+ * rastro nenhum — que é exatamente por que a frequência desse caso era, até aqui,
+ * impossível de medir.
+ *
+ * ⚠️ **FAIL-OPEN, e é desenho.** Falha aqui NÃO derruba a tela: o cálculo é válido e já
+ * foi exibido, e o head é observabilidade. A consequência está declarada no §11 do
+ * money-path e vale repetir aqui: sendo fail-open, **o head não pode ser a fonte de
+ * completude** — ele mede o que o motor conseguiu declarar, não o que de fato aconteceu.
+ * Quem for ligar a expiração por vazio (fase 2) precisa medir contra o ESPERADO.
+ */
+export async function registrarGeracaoFarmer(params: {
+  motor: 'cross_sell' | 'bundle';
+  farmerId: string;
+  runId: string;
+  resultado: 'linhas' | 'vazio';
+  linhasGeradas: number;
+  completude: Completude;
+  motivo: string | null;
+  insumos: InsumosSnapshot;
+  /** O head que este cálculo VIU antes de rodar — o lado "compare" do compare-and-swap. */
+  headVisto: string | null;
+}): Promise<void> {
+  // O `error` é CAPTURADO: o supabase-js NÃO lança em erro de banco, resolve normal com
+  // `error` preenchido — um `await` solto devolveria sucesso sem ter gravado (§11).
+  const { error } = await supabase.rpc('farmer_geracao_registrar' as never, {
+    p_motor: params.motor,
+    p_farmer_id: params.farmerId,
+    p_run_id: params.runId,
+    p_resultado: params.resultado,
+    p_linhas_geradas: params.linhasGeradas,
+    p_completude: params.completude,
+    p_motivo: params.motivo,
+    p_insumos: params.insumos,
+    p_head_visto: params.headVisto,
+  } as never);
+
+  if (error) {
+    // FG106 = outro recálculo moveu o head no meio deste. Não é falha: é a recusa
+    // funcionando, e o head no banco é MAIS novo que este. Registrar por cima seria
+    // trocar o resultado mais recente pelo mais velho (money-path §10).
+    const codigo = (error as { code?: string } | null)?.code;
+    const rotulo = codigo === 'FG106' ? 'head já avançou (recusa correta)' : 'falha';
+    // Só console: a tela não pode quebrar por causa do sensor.
+    console.error(
+      `[farmer/head] ${rotulo} ao registrar geração ${params.motor}/${params.resultado}:`,
+      mensagemDeErro(error) ?? error,
+    );
+  }
+}
+
+/**
+ * Lê o head vigente de um motor para um farmer — o lado "compare" do CAS.
+ *
+ * FAIL-CLOSED ao contrário do registro: se não deu para ler, devolvemos `undefined`
+ * (≠ `null`), porque `null` significa "não há head" e faria o CAS passar como se fosse
+ * a primeira execução — sobrescrevendo um head que existe. Ausente ≠ zero, aplicado ao
+ * próprio CAS. O caller trata `undefined` pulando o registro.
+ */
+export async function lerHeadVigente(
+  motor: 'cross_sell' | 'bundle',
+  farmerId: string,
+): Promise<string | null | undefined> {
+  const { data, error } = await supabase
+    .from('farmer_geracao_vigente' as never)
+    .select('run_id')
+    .eq('motor', motor)
+    .eq('farmer_id', farmerId)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`[farmer/head] não consegui ler o head vigente de ${motor}:`, mensagemDeErro(error) ?? error);
+    return undefined;
+  }
+  return ((data as { run_id?: string } | null)?.run_id ?? null) as string | null;
+}

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -641,6 +641,9 @@ export const MODULOS: ModuloApp[] = [
       "src/lib/analytics.ts",
       "src/lib/erro-mensagem.ts",
       "src/lib/escape-html.ts",
+      // Compartilhado entre `vendas` (useCrossSellEngine) e `farmer-inteligencia`
+      // (useBundleEngine) — por isso mora em plataforma, e não num dos dois.
+      "src/lib/farmer/**",
       "src/lib/format.ts",
       "src/lib/help-utils.ts",
       "src/lib/invoke-function.ts",
@@ -714,6 +717,9 @@ export const MODULOS: ModuloApp[] = [
       "src/lib/escape-html.test.ts",
       "src/lib/invoke-function.test.ts",
       "src/lib/__tests__/**",
+      // Co-localizado com a fonte (`src/lib/farmer/**`), no MESMO módulo: teste que
+      // importa código de outro módulo é vazamento de fronteira.
+      "src/lib/farmer/__tests__/**",
       "src/components/__tests__/ErrorBoundary.test.tsx",
       "src/components/__tests__/RequireFinanceiroAccess.test.tsx",
       "src/components/__tests__/RequireStaff.test.tsx",

--- a/supabase/migrations/20260815181500_farmer_geracao_head_sensor.sql
+++ b/supabase/migrations/20260815181500_farmer_geracao_head_sensor.sql
@@ -1,0 +1,882 @@
+-- ============================================================
+-- HEAD de geração do farmer — o SENSOR, antes da decisão.
+--
+-- PROBLEMA (limitação DECLARADA no #1756 / 20260814223445, achado do challenge
+--   Codex xhigh): aquela migration fez o recálculo APOSENTAR a geração anterior —
+--   mas só quando ele produz linha. Os hooks só chamam a RPC se `linhas.length > 0`
+--   e a própria RPC recusa lote vazio (FG003). Quando o cálculo conclui CORRETAMENTE
+--   que não deve haver recomendação nenhuma (carteira esvaziada, nenhum SKU vendável
+--   sobrando, regras abaixo do piso), o banco continua servindo exatamente as
+--   recomendações que o novo cálculo decidiu que não deveriam existir. O topo antigo
+--   sobrevive indefinidamente. A causa estrutural é inferir a geração vigente da
+--   EXISTÊNCIA de uma linha: um conjunto vazio não tem onde carimbar sua identidade.
+--
+-- MEDIÇÃO (prod, 2026-08-15 ~17:30 UTC, via psql-ro). O denominador é 3 FARMERS —
+--   não os 473 grupos do #1756, que eram (farmer, cliente):
+--     · 414a9727 — 3.858 scores, 171 c/ pedido, 671 pendentes, run_id=71946f20
+--       (recalculado hoje 17:31 UTC: 671 inseridas e 5.325 EXPIRADAS no mesmo
+--        instante — o #1756 está vivo e fez efeito real)
+--     · 33f59dc7 — 1.245 scores, 294 c/ pedido, 690 pendentes com run_id NULL,
+--       de 2026-04-10: 127 DIAS servindo a mesma oferta
+--     · 700657a1 — 1.530 scores, 396 c/ pedido, ZERO recomendação: nunca rodou
+--
+--   ⚠️ A frequência de recálculo VAZIO é hoje estruturalmente NÃO-MENSURÁVEL. Um
+--   recálculo que produz zero linhas sai por `return` mudo (useCrossSellEngine.ts:225
+--   e :296), não grava linha e não registra execução (acoes_execucoes: 0 linhas com
+--   slug de farmer). Há 28 execuções COM linha entre 03/03 e 15/08 — esse é o
+--   numerador; o denominador não existe em lugar nenhum. Se a tela tivesse sido
+--   aberta 500 vezes e 472 devolvessem zero, o rastro seria IDÊNTICO ao de hoje.
+--   É o `Number(null)===0` da adoção, e é por isso que esta migration é um SENSOR e
+--   não uma correção: "superfície de uso nasce COM o sensor" (CLAUDE.md).
+--
+--   E a medição revelou, sem ser procurado, o custo que já se paga: em 700657a1,
+--   "NUNCA RODOU" e "RODOU E DEU VAZIO" são o MESMO estado no banco (ausência de
+--   linha). Essa indistinguibilidade existe independente de a expiração ser ligada.
+--
+-- ESCOPO (decisão do founder, 2026-08-15): SENSOR, sem expirar. O head avança sempre
+--   — inclusive na geração vazia — mas NADA é expirado por vazio nesta entrega. Sem
+--   um único `vazio` medido, ligar a expiração seria assumir o risco de zerar a
+--   carteira de uma vendedora sem contrapartida medida. Fora de escopo, declarado:
+--   expiração por vazio, TTL por idade, backfill do head, loop de feedback.
+--
+-- SEM BACKFILL, de propósito: head ausente significa "não houve execução observada
+--   desde o sensor" — uma verdade, não uma fabricação. Semear head para os farmers
+--   atuais exigiria inventar um run_id para a geração legada (run_id NULL) ou tornar
+--   a coluna nullable; as duas pioram a leitura em troca de nada, já que o head nasce
+--   na primeira execução real.
+--
+-- DESENHO — DUAS tabelas, porque são DUAS perguntas:
+--   · farmer_geracao_vigente   = HEAD (1 linha por motor+farmer). Serve o compare-and-swap
+--     e responde "qual é o estado corrente". É o que deixa o CAS de pé sem depender de
+--     haver linha — o pedido original do challenge.
+--   · farmer_geracao_execucoes = LOG append-only. Responde "com que FREQUÊNCIA o vazio
+--     acontece", que é a pergunta que originou a entrega. O head sozinho NÃO responde:
+--     `ON CONFLICT DO UPDATE` sobrescreve, então um vazio+completo de hoje SOME no run
+--     com linhas de amanhã, e a medição diria "nunca aconteceu" (achado do challenge
+--     Codex xhigh). Escritos na MESMA transação, pela mesma RPC.
+--
+-- ESCRITA SÓ PELA RPC: as duas tabelas não têm grant de DML para `authenticated`, e
+--   `farmer_geracao_registrar` é SECURITY DEFINER. A 1ª versão desta migration dava
+--   GRANT INSERT/UPDATE e o browser podia forjar o head por UPDATE direto, pulando
+--   FG105/FG106/FG107 — guard com porta ao lado não é guard, e aqui o contorno falsifica
+--   a MEDIÇÃO, que é o produto inteiro.
+--
+-- DEPENDE de 20260814223445 (run_id/expired_at + as RPCs de substituição). O guard
+--   abaixo ABORTA com a instrução no texto se ela não tiver sido aplicada.
+-- ============================================================
+
+-- ─── 0) Guard de ordem de apply (fail-closed, com a instrução no texto) ───
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'farmer_recommendations'
+      AND column_name = 'run_id'
+  ) THEN
+    RAISE EXCEPTION 'DEPENDENCIA FALTANDO: aplique ANTES a migration 20260814223445_farmer_recomendacoes_geracao_vigente.sql (coluna farmer_recommendations.run_id ausente nesta base)'
+      USING ERRCODE = 'FG100';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public' AND p.proname = 'farmer_recomendacoes_substituir'
+  ) THEN
+    RAISE EXCEPTION 'DEPENDENCIA FALTANDO: aplique ANTES a migration 20260814223445 (função farmer_recomendacoes_substituir ausente nesta base)'
+      USING ERRCODE = 'FG100';
+  END IF;
+END $$;
+
+-- ─── 1) A tabela do head ───
+-- Uma linha por (motor, farmer_id) que AVANÇA — inclusive quando a geração é vazia.
+-- É exatamente isto que a existência-de-linha não consegue representar.
+CREATE TABLE IF NOT EXISTS public.farmer_geracao_vigente (
+  id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  motor          text        NOT NULL,
+  farmer_id      uuid        NOT NULL,
+  run_id         uuid        NOT NULL,
+  resultado      text        NOT NULL,
+  linhas_geradas integer     NOT NULL,
+  completude     text        NOT NULL,
+  motivo         text,
+  insumos        jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  calculado_em   timestamptz NOT NULL DEFAULT clock_timestamp(),
+  atualizado_em  timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+-- A chave que AVANÇA. `IF NOT EXISTS` no índice único para o apply ser idempotente
+-- (o snapshot do Lovable pode reaplicar).
+CREATE UNIQUE INDEX IF NOT EXISTS farmer_geracao_vigente_motor_farmer_uk
+  ON public.farmer_geracao_vigente (motor, farmer_id);
+
+-- ─── 2) Invariantes na TABELA, não só no writer (money-path §2) ───
+-- Todas as colunas destes predicados são NOT NULL, então — ao contrário do
+-- `status IS NOT NULL AND` que o #1756 precisou — nenhum CHECK aqui pode devolver
+-- NULL (que o Postgres ACEITA num CHECK: só `false` reprova).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_geracao_vigente_motor_check') THEN
+    ALTER TABLE public.farmer_geracao_vigente ADD CONSTRAINT farmer_geracao_vigente_motor_check
+      CHECK (motor = ANY (ARRAY['cross_sell'::text, 'bundle'::text]));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_geracao_vigente_resultado_check') THEN
+    ALTER TABLE public.farmer_geracao_vigente ADD CONSTRAINT farmer_geracao_vigente_resultado_check
+      CHECK (resultado = ANY (ARRAY['linhas'::text, 'vazio'::text]));
+  END IF;
+  -- `desconhecido` é estado de PRIMEIRA CLASSE, não um buraco: no Lovable o Publish do
+  -- frontend é manual, então existe uma janela em que a migration já está aplicada e o
+  -- browser ainda roda o bundle velho (assinatura de 4 args). Nessa janela o head grava
+  -- `desconhecido` — NUNCA `completo`. É o §2 aplicado à própria instrumentação:
+  -- ausente ≠ completo. Sem isso a janela de deploy envenena a medição com falsos
+  -- `completo`, e é sobre essa medição que a fase 2 decidiria ligar a expiração.
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_geracao_vigente_completude_check') THEN
+    ALTER TABLE public.farmer_geracao_vigente ADD CONSTRAINT farmer_geracao_vigente_completude_check
+      CHECK (completude = ANY (ARRAY['completo'::text, 'degradado'::text, 'desconhecido'::text]));
+  END IF;
+  -- Impede o head MENTIROSO ("resultado=linhas com 0 linhas"), que é como uma medição
+  -- se corrompe sem ninguém ver — e a medição é o produto inteiro desta entrega.
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_geracao_vigente_linhas_coerente') THEN
+    ALTER TABLE public.farmer_geracao_vigente ADD CONSTRAINT farmer_geracao_vigente_linhas_coerente
+      CHECK (linhas_geradas >= 0 AND (resultado = 'linhas') = (linhas_geradas > 0));
+  END IF;
+  -- Degradado sem motivo é rótulo sem conteúdo — e o motivo é justamente o que a
+  -- fase 2 precisa para separar "zero de verdade" de "zero por dado faltando".
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_geracao_vigente_motivo_coerente') THEN
+    ALTER TABLE public.farmer_geracao_vigente ADD CONSTRAINT farmer_geracao_vigente_motivo_coerente
+      CHECK (completude <> 'degradado' OR motivo IS NOT NULL);
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.farmer_geracao_vigente IS
+  'HEAD de geração por (motor, farmer): avança a cada execução CONCLUÍDA do motor, INCLUSIVE quando a geração é vazia. Sensor instalado em 2026-08-15 — nesta fase NÃO expira nada. Head ausente = não houve execução observada desde o sensor (não há backfill, de propósito). ⚠️ O head registra a ÚLTIMA EXECUÇÃO CONCLUÍDA, não o conteúdo de farmer_recommendations: com resultado=vazio as linhas pendentes anteriores CONTINUAM lá (é justamente o buraco que o sensor mede). Os dois só convergem quando a fase 2 ligar a expiração — e é por isso que, até lá, nenhum leitor de oferta pode usar o head como fonte.';
+COMMENT ON COLUMN public.farmer_geracao_vigente.resultado IS
+  'linhas | vazio. `vazio` com completude=completo é o "zero de verdade" — o sinal que a fase 2 (ligar a expiração) exige para existir.';
+COMMENT ON COLUMN public.farmer_geracao_vigente.completude IS
+  'Completude do SNAPSHOT, não do resultado: `completo` = todos os insumos lidos com sucesso e nenhum insumo estruturalmente obrigatório veio vazio. `desconhecido` = quem chamou não declarou (cliente anterior ao sensor). É DECLARAÇÃO do motor — audite pela evidência em `insumos`, não pelo rótulo.';
+COMMENT ON COLUMN public.farmer_geracao_vigente.insumos IS
+  'Evidência por trás do rótulo: por insumo, {ok, n}. Os SINAIS de decisão moram em colunas dedicadas (resultado/completude/linhas_geradas) e há 1 writer só (as RPCs desta migration) — por isso este jsonb não recai na regra "sinal money-path nunca em jsonb multi-writer". Serve para a fase 2 exigir contagens plausíveis em vez de confiar na string `completo` ("rótulo com DEFAULT constante não é fato").';
+
+-- ─── 2b) O LOG APPEND-ONLY — o head sozinho NÃO mede frequência ───
+-- Achado do challenge Codex xhigh: `ON CONFLICT DO UPDATE` sobrescreve a única linha do
+-- par, então um `vazio+completo` pode acontecer HOJE e sumir no próximo run com linhas.
+-- Um head responde "qual é o último estado dos até 6 pares", não "quantas vezes o vazio
+-- aconteceu" — e a pergunta que originou esta entrega é EXATAMENTE a segunda. Sem o log,
+-- a ausência de `vazio+completo` continuaria sendo ausência de dado, que é o defeito que
+-- o sensor existe para curar.
+--   Volume não é objeção: 28 execuções em 5,5 meses, 3 farmers.
+-- Divisão de trabalho: `farmer_geracao_vigente` é o HEAD (serve o CAS, 1 linha por par);
+-- `farmer_geracao_execucoes` é o HISTÓRICO (serve a medição, append-only). Escritos na
+-- MESMA transação pela mesma RPC — divergir seria medir uma coisa e decidir por outra.
+CREATE TABLE IF NOT EXISTS public.farmer_geracao_execucoes (
+  id             uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  motor          text        NOT NULL,
+  farmer_id      uuid        NOT NULL,
+  run_id         uuid        NOT NULL,
+  resultado      text        NOT NULL,
+  linhas_geradas integer     NOT NULL,
+  completude     text        NOT NULL,
+  motivo         text,
+  insumos        jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  calculado_em   timestamptz NOT NULL DEFAULT clock_timestamp()
+);
+
+-- Idempotência do registro: um retry do mesmo run não vira duas execuções na contagem
+-- (sem isto, "frequência" mediria retries junto com execuções).
+CREATE UNIQUE INDEX IF NOT EXISTS farmer_geracao_execucoes_run_uk
+  ON public.farmer_geracao_execucoes (motor, farmer_id, run_id);
+CREATE INDEX IF NOT EXISTS farmer_geracao_execucoes_medicao_idx
+  ON public.farmer_geracao_execucoes (resultado, completude, calculado_em DESC);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'farmer_geracao_execucoes_coerente') THEN
+    ALTER TABLE public.farmer_geracao_execucoes ADD CONSTRAINT farmer_geracao_execucoes_coerente
+      CHECK (
+        motor      = ANY (ARRAY['cross_sell'::text, 'bundle'::text])
+        AND resultado  = ANY (ARRAY['linhas'::text, 'vazio'::text])
+        AND completude = ANY (ARRAY['completo'::text, 'degradado'::text, 'desconhecido'::text])
+        AND linhas_geradas >= 0
+        AND (resultado = 'linhas') = (linhas_geradas > 0)
+        AND (completude <> 'degradado' OR motivo IS NOT NULL)
+      );
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.farmer_geracao_execucoes IS
+  'HISTÓRICO append-only de execuções CONCLUÍDAS do motor farmer. É daqui que sai a resposta a "com que frequência o recálculo produz zero?" — o head (farmer_geracao_vigente) guarda só o último estado e apagaria o evento. Nunca receber UPDATE/DELETE: a série é o produto.';
+
+-- ─── 3) RLS (tabela nova nasce com RLS — regra do CLAUDE.md) ───
+-- ⚠️ ESCRITA SÓ PELAS RPCs. A 1ª versão desta migration dava `GRANT INSERT, UPDATE` a
+-- `authenticated` — o que deixava o browser fazer `UPDATE ... SET resultado='vazio',
+-- completude='completo'` DIRETO na tabela, pulando FG105/FG106/FG107 inteiros (achado do
+-- challenge Codex xhigh; o spec já dizia "a tabela não recebe grant de escrita direta" e a
+-- migration fazia o contrário). Guard que se contorna pela porta ao lado não é guard —
+-- e aqui o contorno falsifica a MEDIÇÃO, que é o produto.
+-- Por isso `farmer_geracao_registrar` é SECURITY DEFINER: ela é a única porta de escrita,
+-- e o gate DELA é a autorização (não a RLS, que o DEFINER bypassa — CLAUDE.md).
+ALTER TABLE public.farmer_geracao_vigente ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.farmer_geracao_execucoes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS fgv_select_carteira      ON public.farmer_geracao_vigente;
+DROP POLICY IF EXISTS fgv_insert_own_or_gestor ON public.farmer_geracao_vigente;
+DROP POLICY IF EXISTS fgv_update_own_or_gestor ON public.farmer_geracao_vigente;
+DROP POLICY IF EXISTS fge_select_carteira      ON public.farmer_geracao_execucoes;
+
+-- ⚠️ `cap_carteira_escrever` entra no SELECT de propósito (a policy irmã de
+-- farmer_recommendations não o tem). Quem escreve PRECISA ler: o CAS do head lê a linha
+-- vigente antes de decidir, e um gestor com escrever-mas-não-ler veria NULL, passaria o
+-- CAS trivialmente e sobrescreveria o head de outro run. CAS cego não é CAS.
+CREATE POLICY fgv_select_carteira ON public.farmer_geracao_vigente
+  FOR SELECT TO authenticated
+  USING ((SELECT private.cap_carteira_ler((SELECT auth.uid())))
+         OR (SELECT private.cap_carteira_escrever((SELECT auth.uid())))
+         OR (farmer_id = (SELECT auth.uid())));
+
+CREATE POLICY fge_select_carteira ON public.farmer_geracao_execucoes
+  FOR SELECT TO authenticated
+  USING ((SELECT private.cap_carteira_ler((SELECT auth.uid())))
+         OR (SELECT private.cap_carteira_escrever((SELECT auth.uid())))
+         OR (farmer_id = (SELECT auth.uid())));
+
+-- ⚠️ NENHUMA policy de INSERT/UPDATE, e NENHUM grant de escrita: sem policy a RLS já nega,
+-- mas o grant é a fechadura que importa — `REVOKE FROM PUBLIC` NÃO tira anon/authenticated
+-- (grant explícito, revogar por nome). Escrita só pela RPC SECURITY DEFINER.
+-- E DELETE nunca: a série do log é o produto.
+REVOKE ALL ON TABLE public.farmer_geracao_vigente   FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.farmer_geracao_execucoes FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.farmer_geracao_vigente   TO authenticated;
+GRANT SELECT ON TABLE public.farmer_geracao_execucoes TO authenticated;
+GRANT ALL    ON TABLE public.farmer_geracao_vigente   TO service_role;
+GRANT ALL    ON TABLE public.farmer_geracao_execucoes TO service_role;
+
+-- ─── 4) A RPC de registro — o caminho que NÃO toca linha ───
+-- É a única via para a geração VAZIA (e para a degradada). O caminho COM linhas passa
+-- pelas RPCs de substituição, que chamam esta aqui DENTRO da mesma transação.
+CREATE OR REPLACE FUNCTION public.farmer_geracao_registrar(
+  p_motor          text,
+  p_farmer_id      uuid,
+  p_run_id         uuid,
+  p_resultado      text,
+  p_linhas_geradas integer,
+  p_completude     text    DEFAULT NULL,
+  p_motivo         text    DEFAULT NULL,
+  p_insumos        jsonb   DEFAULT NULL,
+  p_head_visto     uuid    DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+-- ⚠️ SECURITY DEFINER, e é a decisão central de autorização desta migration. As tabelas
+-- do sensor não têm grant de escrita para `authenticated`, então esta função é a ÚNICA
+-- porta — e é isso que faz FG103/FG105/FG106/FG107 valerem alguma coisa. Com grant direto
+-- (a 1ª versão desta migration tinha) o browser contornava todos por um UPDATE simples.
+-- DEFINER bypassa RLS (CLAUDE.md), então o GATE ABAIXO é a autorização inteira: ele roda
+-- ANTES de qualquer escrita e fecha em `IS NOT TRUE`. `auth.uid()` continua sendo o do
+-- CHAMADOR (lê o JWT, não o role do Postgres), então o DEFINER não afrouxa o gate.
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_head_atual  uuid;
+  v_completude  text;
+  v_existia     boolean;
+  v_reais       integer;
+BEGIN
+  -- 1) Obrigatórios.
+  IF p_motor IS NULL OR p_farmer_id IS NULL OR p_run_id IS NULL THEN
+    RAISE EXCEPTION 'p_motor, p_farmer_id e p_run_id são obrigatórios' USING ERRCODE = 'FG101';
+  END IF;
+
+  -- 2) Gate de MENSAGEM (a RLS é quem autoriza). `IS NOT TRUE`, não `NOT (...)`:
+  -- numa sessão SEM JWT (pg_cron, psql) auth.uid() é NULL, a disjunção vira NULL e
+  -- `IF NOT NULL THEN` NÃO dispara em PL/pgSQL — a forma "óbvia" é um guard que não
+  -- nega, ele devolve nulo. Mesma lição do #1756.
+  IF (
+    coalesce(auth.role(), '') = 'service_role'
+    OR p_farmer_id = auth.uid()
+    OR coalesce(private.cap_carteira_escrever(auth.uid()), false)
+  ) IS NOT TRUE THEN
+    RAISE EXCEPTION 'Acesso negado: só o próprio farmer ou quem tem cap_carteira_escrever registra geração'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_motor NOT IN ('cross_sell', 'bundle') THEN
+    RAISE EXCEPTION 'p_motor inválido: % (esperado cross_sell ou bundle)', p_motor
+      USING ERRCODE = 'FG102';
+  END IF;
+
+  -- 3) Coerência resultado × contagem. Recusar aqui — e não deixar o CHECK da tabela
+  -- pegar — dá ao chamador uma SQLSTATE própria e a mensagem com os dois valores.
+  IF p_resultado IS NULL OR p_resultado NOT IN ('linhas', 'vazio') THEN
+    RAISE EXCEPTION 'p_resultado inválido: % (esperado linhas ou vazio)',
+      coalesce(p_resultado, 'null') USING ERRCODE = 'FG103';
+  END IF;
+  IF p_linhas_geradas IS NULL OR p_linhas_geradas < 0 THEN
+    RAISE EXCEPTION 'p_linhas_geradas deve ser >= 0 (recebido: %)',
+      coalesce(p_linhas_geradas::text, 'null') USING ERRCODE = 'FG103';
+  END IF;
+  IF (p_resultado = 'linhas') <> (p_linhas_geradas > 0) THEN
+    RAISE EXCEPTION 'resultado=% é incoerente com linhas_geradas=%', p_resultado, p_linhas_geradas
+      USING ERRCODE = 'FG103';
+  END IF;
+
+  -- 4) Completude: ausente vira `desconhecido`, NUNCA `completo` (§2: ausente ≠ completo).
+  v_completude := coalesce(p_completude, 'desconhecido');
+  IF v_completude NOT IN ('completo', 'degradado', 'desconhecido') THEN
+    RAISE EXCEPTION 'p_completude inválido: % (esperado completo, degradado ou desconhecido)', p_completude
+      USING ERRCODE = 'FG103';
+  END IF;
+  IF v_completude = 'degradado' AND (p_motivo IS NULL OR btrim(p_motivo) = '') THEN
+    RAISE EXCEPTION 'completude=degradado exige p_motivo — sem ele o rótulo não distingue "zero de verdade" de "zero por dado faltando"'
+      USING ERRCODE = 'FG104';
+  END IF;
+
+  IF p_insumos IS NOT NULL AND jsonb_typeof(p_insumos) <> 'object' THEN
+    RAISE EXCEPTION 'p_insumos deve ser objeto jsonb (recebido: %)', jsonb_typeof(p_insumos)
+      USING ERRCODE = 'FG103';
+  END IF;
+  -- Teto: o payload é diagnóstico, não carga. ~8 kB cobre uma dezena de insumos com folga.
+  IF p_insumos IS NOT NULL AND length(p_insumos::text) > 8000 THEN
+    RAISE EXCEPTION 'p_insumos excede 8000 chars (%) — é diagnóstico, não carga', length(p_insumos::text)
+      USING ERRCODE = 'FG103';
+  END IF;
+
+  -- 4b) `resultado='linhas'` é ANCORADO NA REALIDADE, não na palavra de quem chama.
+  -- Sem isto, o browser pode gravar um head afirmando "linhas" sem existir linha nenhuma —
+  -- e o head é MEDIÇÃO: medição forjável é medição corrompida, e é sobre ela que a fase 2
+  -- decidiria ligar a expiração. Funciona porque as RPCs de substituição INSEREM antes de
+  -- chamar esta função, na MESMA transação, então as linhas já estão visíveis aqui.
+  -- (O caminho 'vazio' não precisa do espelho: o run é novo, então "não há linha com este
+  -- run_id" é trivialmente verdade. Forjar 'vazio' só prejudica o próprio farmer, que é o
+  -- único que o gate deixa passar — e nesta fase nada é expirado por causa disso.)
+  -- ⚠️ CONTA no servidor, não confia no número do chamador. `EXISTS` sozinho aceitava
+  -- "1 linha real, 999 declaradas" (achado do challenge Codex xhigh) — e `linhas_geradas`
+  -- é o que a fase 2 leria para dimensionar. O parâmetro do chamador vira o que ele
+  -- sempre foi: uma alegação, conferida contra o fato.
+  IF p_resultado = 'linhas' THEN
+    IF p_motor = 'cross_sell' THEN
+      SELECT count(*) INTO v_reais FROM public.farmer_recommendations
+      WHERE farmer_id = p_farmer_id AND run_id = p_run_id AND status = 'pendente';
+    ELSE
+      SELECT count(*) INTO v_reais FROM public.farmer_bundle_recommendations
+      WHERE farmer_id = p_farmer_id AND run_id = p_run_id AND status = 'pendente';
+    END IF;
+
+    IF v_reais = 0 THEN
+      RAISE EXCEPTION 'resultado=linhas sem nenhuma linha gravada para o run % — o head não inventa geração', p_run_id
+        USING ERRCODE = 'FG107';
+    END IF;
+    IF v_reais <> p_linhas_geradas THEN
+      RAISE EXCEPTION 'resultado=linhas declarou % linha(s), mas há % gravada(s) para o run %',
+        p_linhas_geradas, v_reais, p_run_id USING ERRCODE = 'FG107';
+    END IF;
+  ELSE
+    -- `vazio` também é ancorado: declarar vazio com linhas pendentes daquele run seria
+    -- um head que contradiz a própria tabela. (O run é novo no caminho normal, então isto
+    -- é trivialmente verdade — o guard existe para o chamador que reusa um run_id.)
+    IF p_motor = 'cross_sell' THEN
+      SELECT count(*) INTO v_reais FROM public.farmer_recommendations
+      WHERE farmer_id = p_farmer_id AND run_id = p_run_id AND status = 'pendente';
+    ELSE
+      SELECT count(*) INTO v_reais FROM public.farmer_bundle_recommendations
+      WHERE farmer_id = p_farmer_id AND run_id = p_run_id AND status = 'pendente';
+    END IF;
+    IF v_reais > 0 THEN
+      RAISE EXCEPTION 'resultado=vazio, mas há % linha(s) pendente(s) gravada(s) para o run %',
+        v_reais, p_run_id USING ERRCODE = 'FG107';
+    END IF;
+  END IF;
+
+  -- 5) SERIALIZAÇÃO — o MESMO lock da RPC de substituição do motor correspondente.
+  -- Lock próprio serializaria este caminho só consigo mesmo, o que é o mesmo que não
+  -- serializar: um registro de "vazio" correria em paralelo com uma substituição com
+  -- linhas. Reentrante de propósito: quando a própria RPC de substituição chama esta
+  -- função, a transação JÁ detém o lock e o try devolve true.
+  -- ⚠️ A reentrância é APOSTA de desenho, então foi MEDIDA no PG17 antes de confiar nela
+  -- (3 `pg_try_advisory_xact_lock` com as mesmas chaves na mesma transação):
+  --   1ª/2ª/3ª => true, true, true
+  --   pg_locks WHERE locktype='advisory' => 1 (uma entrada, não três: o variante `xact`
+  --     NÃO faz refcount como o `pg_advisory_lock` de sessão, então não há unlock a dever)
+  --   após COMMIT => 0 (some sozinho, que é o motivo de ser `xact` e não de sessão)
+  IF NOT pg_try_advisory_xact_lock(
+        hashtext(CASE p_motor
+                   WHEN 'cross_sell' THEN 'farmer_recomendacoes_substituir'
+                   ELSE                    'farmer_bundle_recomendacoes_substituir'
+                 END),
+        hashtext(p_farmer_id::text)) THEN
+    RAISE EXCEPTION 'outro recálculo deste farmer está em andamento — o head não foi movido'
+      USING ERRCODE = 'FG105';
+  END IF;
+
+  -- 6) CAS do head. O advisory lock cobre só ESTA transação — não a janela longa entre
+  -- "o motor leu o head" e "o motor chamou esta função". Sem o CAS, um run VAZIO lento
+  -- sobrescreveria o head de um run COM LINHAS que terminou antes, e a medição
+  -- registraria `vazio` para um estado que é `linhas` (money-path §10: o degradado
+  -- terminar depois do saudável é o desfecho ESPERADO, não o azar). Não depende de
+  -- relógio nenhum — nem do browser, nem do servidor. NULL casa NULL: head ainda ausente.
+  SELECT run_id INTO v_head_atual
+  FROM public.farmer_geracao_vigente
+  WHERE motor = p_motor AND farmer_id = p_farmer_id;
+  v_existia := FOUND;
+
+  IF v_head_atual IS DISTINCT FROM p_head_visto THEN
+    RAISE EXCEPTION 'head de geração mudou durante o cálculo (visto: %, atual: %) — nada foi registrado',
+      coalesce(p_head_visto::text, 'nenhum'), coalesce(v_head_atual::text, 'nenhum')
+      USING ERRCODE = 'FG106';
+  END IF;
+
+  -- 7) O head AVANÇA — inclusive quando resultado='vazio'. É o ponto inteiro da entrega.
+  INSERT INTO public.farmer_geracao_vigente AS h (
+    motor, farmer_id, run_id, resultado, linhas_geradas, completude, motivo, insumos,
+    calculado_em, atualizado_em
+  )
+  VALUES (
+    p_motor, p_farmer_id, p_run_id, p_resultado, p_linhas_geradas, v_completude,
+    p_motivo, coalesce(p_insumos, '{}'::jsonb), clock_timestamp(), clock_timestamp()
+  )
+  ON CONFLICT (motor, farmer_id) DO UPDATE
+    SET run_id         = EXCLUDED.run_id,
+        resultado      = EXCLUDED.resultado,
+        linhas_geradas = EXCLUDED.linhas_geradas,
+        completude     = EXCLUDED.completude,
+        motivo         = EXCLUDED.motivo,
+        insumos        = EXCLUDED.insumos,
+        calculado_em   = EXCLUDED.calculado_em,
+        -- `clock_timestamp()`, não `now()`: now() é o instante do BEGIN, e entre o BEGIN
+        -- e esta escrita pode haver espera arbitrária (money-path §2).
+        atualizado_em  = clock_timestamp();
+
+  -- 8) O LOG, na MESMA transação — é ele que responde "com que FREQUÊNCIA", porque o head
+  -- acima acabou de sobrescrever o estado anterior. `DO NOTHING` no conflito: um retry do
+  -- mesmo run não pode virar duas execuções na contagem, senão a frequência mede retries.
+  INSERT INTO public.farmer_geracao_execucoes (
+    motor, farmer_id, run_id, resultado, linhas_geradas, completude, motivo, insumos, calculado_em
+  )
+  VALUES (
+    p_motor, p_farmer_id, p_run_id, p_resultado, p_linhas_geradas, v_completude,
+    p_motivo, coalesce(p_insumos, '{}'::jsonb), clock_timestamp()
+  )
+  ON CONFLICT (motor, farmer_id, run_id) DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'motor',      p_motor,
+    'run_id',     p_run_id,
+    'resultado',  p_resultado,
+    'completude', v_completude,
+    'criado',     NOT v_existia
+  );
+END;
+$function$;
+
+-- ─── 5) As RPCs de substituição passam a mover o head na MESMA transação ───
+-- Head e linhas em transações separadas divergiriam — e head divergente é MEDIÇÃO
+-- CORROMPIDA, que é justamente o insumo com que a fase 2 decidiria ligar a expiração.
+--
+-- ⚠️ DROP + CREATE, não `CREATE OR REPLACE`: os parâmetros novos mudam a ARIDADE, e
+-- `CREATE OR REPLACE` com aridade diferente cria uma SOBRECARGA em vez de substituir —
+-- aí uma chamada de 4 args fica ambígua (42725) e o motor quebra em produção. Os
+-- DEFAULTs preservam a assinatura de 4 args para o bundle velho em cache (o Publish do
+-- Lovable é manual e não é instantâneo); nessa janela o head grava `desconhecido`.
+--
+-- O DROP foi medido em PROD antes de ser proposto — dropar função money-path às cegas é
+-- como se derruba um caminho que ninguém sabia que existia (2026-08-15, psql-ro):
+--   · pg_depend (deptype <> 'n') sobre as 2 funções ......... 0 dependentes
+--     (nenhuma view, trigger ou DEFAULT de coluna presa a elas)
+--   · funções cujo corpo as menciona ......................... só a própria MENSAGEM de
+--     erro da trigger farmer_rec_exige_run_id e a auto-referência dos comentários delas
+--     — nenhum chamador SQL real
+--   · cron.job apontando para elas ........................... 0
+--   · sobrecargas pré-existentes ............................. nenhuma (só a de 4 args)
+-- Ou seja: o único chamador é o browser, via PostgREST — e ele resolve pela aridade, que
+-- os DEFAULTs preservam.
+DROP FUNCTION IF EXISTS public.farmer_recomendacoes_substituir(uuid, uuid, uuid, jsonb);
+DROP FUNCTION IF EXISTS public.farmer_bundle_recomendacoes_substituir(uuid, uuid, uuid, jsonb);
+
+CREATE OR REPLACE FUNCTION public.farmer_recomendacoes_substituir(
+  p_farmer_id     uuid,
+  p_run_id        uuid,
+  p_geracao_vista uuid,
+  p_linhas        jsonb,
+  p_completude    text  DEFAULT NULL,
+  p_motivo        text  DEFAULT NULL,
+  p_insumos       jsonb DEFAULT NULL,
+  p_head_visto    uuid  DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_total          integer;
+  v_invalidas      integer;
+  v_geracao_atual  uuid;
+  v_expiradas      integer;
+  v_inseridas      integer;
+  v_head_atual     uuid;
+BEGIN
+  -- 1) Gate de MENSAGEM (a RLS é quem autoriza — ver cabeçalho).
+  IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
+    RAISE EXCEPTION 'p_farmer_id e p_run_id são obrigatórios' USING ERRCODE = 'FG001';
+  END IF;
+  -- ⚠️ `IS NOT TRUE`, não `NOT (...)`. Numa sessão SEM JWT (pg_cron, psql) `auth.uid()`
+  -- devolve NULL, então `p_farmer_id = auth.uid()` é NULL e a disjunção inteira vira
+  -- NULL — e `IF NOT NULL THEN` NÃO dispara em PL/pgSQL. Medido em prod:
+  --   NOT (false OR NULL OR false)          => NULL   (o RAISE nunca acontece)
+  --   (false OR NULL OR false) IS NOT TRUE  => true   (barra, como se quer)
+  IF (
+    coalesce(auth.role(), '') = 'service_role'
+    OR p_farmer_id = auth.uid()
+    OR coalesce(private.cap_carteira_escrever(auth.uid()), false)
+  ) IS NOT TRUE THEN
+    RAISE EXCEPTION 'Acesso negado: só o próprio farmer ou quem tem cap_carteira_escrever substitui recomendações'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- 2) FORMATO.
+  IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
+    RAISE EXCEPTION 'p_linhas deve ser um array jsonb (recebido: %)',
+      coalesce(jsonb_typeof(p_linhas), 'null') USING ERRCODE = 'FG002';
+  END IF;
+
+  v_total := jsonb_array_length(p_linhas);
+
+  -- 3) LOTE VAZIO = RECUSA, não "expira tudo e deixa o farmer sem oferta".
+  -- Zero recomendação quase sempre é dado faltando a montante (catálogo, scores,
+  -- get_skus_margem_positiva), não "este farmer não tem o que oferecer" — mesmo
+  -- raciocínio que farmer_association_rules_substituir aplica ao lote vazio.
+  -- ⚠️ Isto SEGUE valendo depois do head: quem tem geração legitimamente vazia
+  -- chama `farmer_geracao_registrar` (que move o head e não toca em linha nenhuma),
+  -- e não esta função. Afrouxar aqui religaria a expiração — que está FORA do escopo
+  -- desta fase por decisão explícita.
+  IF v_total = 0 THEN
+    RAISE EXCEPTION 'lote vazio: as % recomendação(ões) pendentes deste farmer foram preservadas',
+      (SELECT count(*) FROM public.farmer_recommendations
+        WHERE farmer_id = p_farmer_id AND status = 'pendente')
+      USING ERRCODE = 'FG003';
+  END IF;
+
+  -- Teto defensivo: a maior geração medida em prod tem ~1.000 linhas
+  -- (3 cross + 2 up por cliente). 50k é ~50x isso — folga sem ficar ilimitado.
+  IF v_total > 50000 THEN
+    RAISE EXCEPTION 'lote de % linhas excede o teto de 50000', v_total USING ERRCODE = 'FG004';
+  END IF;
+
+  -- 4) SERIALIZAÇÃO por FARMER (não global: duas vendedoras recalculando ao mesmo
+  -- tempo mexem em escopos disjuntos e não têm por que esperar uma pela outra).
+  -- `xact` = o lock sai sozinho no commit/rollback.
+  IF NOT pg_try_advisory_xact_lock(
+        hashtext('farmer_recomendacoes_substituir'), hashtext(p_farmer_id::text)) THEN
+    RAISE EXCEPTION 'outro recálculo deste farmer está em andamento — nada foi alterado'
+      USING ERRCODE = 'FG005';
+  END IF;
+
+  -- 5) GUARD CAUSAL (compare-and-swap).
+  -- O advisory lock acima só cobre a TRANSAÇÃO da RPC — ele não cobre a janela
+  -- longa entre "o motor leu o snapshot" e "o motor chamou esta função". Sem este
+  -- guard, dois recálculos sobrepostos terminam com o MAIS LENTO vencendo, e o
+  -- mais lento é justamente o que leu o snapshot mais VELHO (money-path §10: o
+  -- degradado terminar depois do saudável é o desfecho esperado, não o azar).
+  -- NULL casa NULL: primeira execução, e as linhas legadas (run_id NULL).
+  SELECT run_id INTO v_geracao_atual
+  FROM public.farmer_recommendations
+  WHERE farmer_id = p_farmer_id AND status = 'pendente'
+  ORDER BY created_at DESC, id DESC
+  LIMIT 1;
+
+  IF v_geracao_atual IS DISTINCT FROM p_geracao_vista THEN
+    RAISE EXCEPTION 'geração vigente mudou durante o cálculo (vista: %, atual: %) — nada foi alterado',
+      coalesce(p_geracao_vista::text, 'nenhuma'), coalesce(v_geracao_atual::text, 'nenhuma')
+      USING ERRCODE = 'FG006';
+  END IF;
+
+  -- 6) VALIDAÇÃO ANTES DE MEXER (nada é expirado se o lote tem lixo).
+  SELECT count(*) INTO v_invalidas
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    affinity_score          numeric
+  )
+  WHERE r.customer_user_id IS NULL
+     OR r.product_id IS NULL
+     OR r.recommendation_type IS NULL
+     OR r.recommendation_type NOT IN ('cross_sell', 'up_sell')
+     -- Finitude nos TRÊS lados. `>= 0` sozinho NÃO sanea: medido em prod,
+     -- `'NaN' >= 0` é TRUE e `'Infinity' >= 0` é TRUE (money-path §2).
+     OR r.affinity_score IS NULL
+     OR NOT (
+          r.affinity_score >= 0
+          AND r.affinity_score < 'Infinity'::numeric
+          AND r.affinity_score <> 'NaN'::numeric
+        );
+
+  IF v_invalidas > 0 THEN
+    RAISE EXCEPTION '% de % linha(s) inválidas (cliente/produto/tipo ausente, ou afinidade nula/negativa/NaN/Infinita) — nada foi expirado',
+      v_invalidas, v_total USING ERRCODE = 'FG007';
+  END IF;
+
+  -- 7) A TROCA — os dois statements na MESMA transação.
+  -- Só 'pendente' é tocado: linha com desfecho ('ofertado'/'aceito'/'rejeitado')
+  -- é histórico e fica imutável. E é UPDATE, nunca DELETE.
+  UPDATE public.farmer_recommendations
+     SET status         = 'expirado',
+         expired_at     = clock_timestamp(),
+         expired_by_run = p_run_id,
+         updated_at     = clock_timestamp()
+   WHERE farmer_id = p_farmer_id
+     AND status = 'pendente';
+  GET DIAGNOSTICS v_expiradas = ROW_COUNT;
+
+  INSERT INTO public.farmer_recommendations (
+    farmer_id, customer_user_id, recommendation_type, product_id, current_product_id,
+    p_ij, m_ij, lie, affinity_score, complexity_factor, cluster_volume_estimate,
+    status, run_id
+  )
+  SELECT
+    p_farmer_id, r.customer_user_id, r.recommendation_type, r.product_id, r.current_product_id,
+    r.p_ij,
+    -- m_ij e lie são DINHEIRO e saíram de cena no #1520 (o custo não chega mais ao
+    -- browser). Fixados em NULL aqui, não copiados do payload: o cliente não tem
+    -- como fabricá-los de volta.
+    NULL, NULL,
+    r.affinity_score, coalesce(r.complexity_factor, 1), coalesce(r.cluster_volume_estimate, 1),
+    'pendente', p_run_id
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id        uuid,
+    recommendation_type     text,
+    product_id              uuid,
+    current_product_id      uuid,
+    p_ij                    numeric,
+    affinity_score          numeric,
+    complexity_factor       numeric,
+    cluster_volume_estimate numeric
+  );
+  GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+
+  -- 8) O HEAD, na MESMA transação — com o head que o CHAMADOR viu ANTES do cálculo.
+  --
+  -- ⚠️ A 1ª versão lia o head AQUI DENTRO e o passava adiante, o que satisfazia o CAS por
+  -- construção e abria a assimetria que o challenge Codex xhigh encontrou: um run VAZIO
+  -- que commita entre a leitura e a escrita de um run COM LINHAS não é visto pelo CAS da
+  -- etapa 5 (ele compara LINHAS, e o vazio não mexeu em linha nenhuma), então o run antigo
+  -- sobrescrevia um vazio mais novo. O sistema misturava duas ordens: frescor causal para
+  -- o vazio e ordem-de-commit para as linhas. Comparar o head ORIGINAL alinha as duas.
+  --
+  -- `p_completude IS NULL` é o marcador de chamador ANTERIOR ao sensor (assinatura de 4
+  -- args, bundle velho em cache): ele não tem head para declarar, então cai no head
+  -- corrente em vez de ser recusado por não saber de algo que não existia quando foi
+  -- escrito. Os dois sinais de "cliente antigo" são o mesmo, de propósito.
+  IF p_completude IS NULL THEN
+    SELECT run_id INTO v_head_atual
+    FROM public.farmer_geracao_vigente
+    WHERE motor = 'cross_sell' AND farmer_id = p_farmer_id;
+  ELSE
+    v_head_atual := p_head_visto;
+  END IF;
+
+  PERFORM public.farmer_geracao_registrar(
+    'cross_sell', p_farmer_id, p_run_id, 'linhas', v_inseridas,
+    p_completude, p_motivo, p_insumos, v_head_atual
+  );
+
+  RETURN jsonb_build_object(
+    'run_id',    p_run_id,
+    'expiradas', v_expiradas,
+    'inseridas', v_inseridas
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.farmer_bundle_recomendacoes_substituir(
+  p_farmer_id     uuid,
+  p_run_id        uuid,
+  p_geracao_vista uuid,
+  p_linhas        jsonb,
+  p_completude    text  DEFAULT NULL,
+  p_motivo        text  DEFAULT NULL,
+  p_insumos       jsonb DEFAULT NULL,
+  p_head_visto    uuid  DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_total         integer;
+  v_invalidas     integer;
+  v_geracao_atual uuid;
+  v_expiradas     integer;
+  v_inseridas     integer;
+  v_head_atual    uuid;
+BEGIN
+  IF p_farmer_id IS NULL OR p_run_id IS NULL THEN
+    RAISE EXCEPTION 'p_farmer_id e p_run_id são obrigatórios' USING ERRCODE = 'FG001';
+  END IF;
+  IF (
+    coalesce(auth.role(), '') = 'service_role'
+    OR p_farmer_id = auth.uid()
+    OR coalesce(private.cap_carteira_escrever(auth.uid()), false)
+  ) IS NOT TRUE THEN
+    RAISE EXCEPTION 'Acesso negado: só o próprio farmer ou quem tem cap_carteira_escrever substitui recomendações'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_linhas IS NULL OR jsonb_typeof(p_linhas) <> 'array' THEN
+    RAISE EXCEPTION 'p_linhas deve ser um array jsonb (recebido: %)',
+      coalesce(jsonb_typeof(p_linhas), 'null') USING ERRCODE = 'FG002';
+  END IF;
+
+  v_total := jsonb_array_length(p_linhas);
+
+  IF v_total = 0 THEN
+    RAISE EXCEPTION 'lote vazio: os % bundle(s) pendentes deste farmer foram preservados',
+      (SELECT count(*) FROM public.farmer_bundle_recommendations
+        WHERE farmer_id = p_farmer_id AND status = 'pendente')
+      USING ERRCODE = 'FG003';
+  END IF;
+
+  IF v_total > 50000 THEN
+    RAISE EXCEPTION 'lote de % linhas excede o teto de 50000', v_total USING ERRCODE = 'FG004';
+  END IF;
+
+  IF NOT pg_try_advisory_xact_lock(
+        hashtext('farmer_bundle_recomendacoes_substituir'), hashtext(p_farmer_id::text)) THEN
+    RAISE EXCEPTION 'outro recálculo de bundles deste farmer está em andamento — nada foi alterado'
+      USING ERRCODE = 'FG005';
+  END IF;
+
+  SELECT run_id INTO v_geracao_atual
+  FROM public.farmer_bundle_recommendations
+  WHERE farmer_id = p_farmer_id AND status = 'pendente'
+  ORDER BY created_at DESC, id DESC
+  LIMIT 1;
+
+  IF v_geracao_atual IS DISTINCT FROM p_geracao_vista THEN
+    RAISE EXCEPTION 'geração vigente de bundles mudou durante o cálculo (vista: %, atual: %) — nada foi alterado',
+      coalesce(p_geracao_vista::text, 'nenhuma'), coalesce(v_geracao_atual::text, 'nenhuma')
+      USING ERRCODE = 'FG006';
+  END IF;
+
+  SELECT count(*) INTO v_invalidas
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id uuid,
+    bundle_products  jsonb,
+    affinity_bundle  numeric
+  )
+  WHERE r.customer_user_id IS NULL
+     OR r.bundle_products IS NULL
+     OR jsonb_typeof(r.bundle_products) <> 'array'
+     OR jsonb_array_length(r.bundle_products) = 0
+     OR r.affinity_bundle IS NULL
+     OR NOT (
+          r.affinity_bundle >= 0
+          AND r.affinity_bundle < 'Infinity'::numeric
+          AND r.affinity_bundle <> 'NaN'::numeric
+        );
+
+  IF v_invalidas > 0 THEN
+    RAISE EXCEPTION '% de % bundle(s) inválidos (cliente/produtos ausentes, ou afinidade nula/negativa/NaN/Infinita) — nada foi expirado',
+      v_invalidas, v_total USING ERRCODE = 'FG007';
+  END IF;
+
+  UPDATE public.farmer_bundle_recommendations
+     SET status         = 'expirado',
+         expired_at     = clock_timestamp(),
+         expired_by_run = p_run_id,
+         updated_at     = clock_timestamp()
+   WHERE farmer_id = p_farmer_id
+     AND status = 'pendente';
+  GET DIAGNOSTICS v_expiradas = ROW_COUNT;
+
+  INSERT INTO public.farmer_bundle_recommendations (
+    farmer_id, customer_user_id, bundle_products, support, confidence, lift,
+    p_bundle, m_bundle, lie_bundle, affinity_bundle, complexity_factor,
+    status, run_id
+  )
+  SELECT
+    p_farmer_id, r.customer_user_id, r.bundle_products,
+    r.support, r.confidence, r.lift, r.p_bundle,
+    -- m_bundle/lie_bundle: dinheiro, fora de cena desde o #1520 (ver RPC irmã).
+    NULL, NULL,
+    r.affinity_bundle, coalesce(r.complexity_factor, 1),
+    'pendente', p_run_id
+  FROM jsonb_to_recordset(p_linhas) AS r(
+    customer_user_id  uuid,
+    bundle_products   jsonb,
+    support           numeric,
+    confidence        numeric,
+    lift              numeric,
+    p_bundle          numeric,
+    affinity_bundle   numeric,
+    complexity_factor numeric
+  );
+  GET DIAGNOSTICS v_inseridas = ROW_COUNT;
+
+  -- O HEAD, na MESMA transação, com o head ORIGINAL do chamador (ver RPC irmã para o
+  -- racional da assimetria que isto fecha).
+  IF p_completude IS NULL THEN
+    SELECT run_id INTO v_head_atual
+    FROM public.farmer_geracao_vigente
+    WHERE motor = 'bundle' AND farmer_id = p_farmer_id;
+  ELSE
+    v_head_atual := p_head_visto;
+  END IF;
+
+  PERFORM public.farmer_geracao_registrar(
+    'bundle', p_farmer_id, p_run_id, 'linhas', v_inseridas,
+    p_completude, p_motivo, p_insumos, v_head_atual
+  );
+
+  RETURN jsonb_build_object(
+    'run_id',    p_run_id,
+    'expiradas', v_expiradas,
+    'inseridas', v_inseridas
+  );
+END;
+$function$;
+
+-- ─── 6) Permissões das assinaturas NOVAS ───
+-- As antigas (4 args) foram DROPADAS acima, junto com os grants delas.
+REVOKE ALL ON FUNCTION public.farmer_geracao_registrar(text, uuid, uuid, text, integer, text, text, jsonb, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.farmer_recomendacoes_substituir(uuid, uuid, uuid, jsonb, text, text, jsonb, uuid) FROM PUBLIC, anon;
+REVOKE ALL ON FUNCTION public.farmer_bundle_recomendacoes_substituir(uuid, uuid, uuid, jsonb, text, text, jsonb, uuid) FROM PUBLIC, anon;
+
+GRANT EXECUTE ON FUNCTION public.farmer_geracao_registrar(text, uuid, uuid, text, integer, text, text, jsonb, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.farmer_recomendacoes_substituir(uuid, uuid, uuid, jsonb, text, text, jsonb, uuid) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.farmer_bundle_recomendacoes_substituir(uuid, uuid, uuid, jsonb, text, text, jsonb, uuid) TO authenticated, service_role;
+
+-- ⚠️ O PostgREST só enxerga assinatura nova depois de recarregar o schema cache. Sem isto,
+-- a janela entre o apply e o reload devolve 404/PGRST202 para a RPC nova — e como o
+-- registro do head é fail-open, a falha sairia só num console.error: o sensor nasceria
+-- cego sem ninguém perceber. O repo já usa este NOTIFY (padrão das migrations tint).
+NOTIFY pgrst, 'reload schema';
+
+-- ─── 7) QUANDO MEDIR — é query, não recado ───
+-- ⚠️ A medição sai do LOG (`farmer_geracao_execucoes`), NÃO do head: o head guarda só o
+-- último estado de cada par, então um `vazio+completo` que aconteceu ontem e foi seguido
+-- de um run com linhas SUMIRIA dele. Perguntar frequência ao head devolveria "nunca
+-- aconteceu" para algo que aconteceu — a mesma ausência-de-dado que o sensor cura.
+--
+--   -- FREQUÊNCIA (a pergunta que originou a entrega), com DENOMINADOR:
+--   SELECT motor, resultado, completude,
+--          count(*)                                        AS execucoes,
+--          round(100.0*count(*)/sum(count(*)) OVER (PARTITION BY motor), 1) AS pct_do_motor,
+--          count(DISTINCT farmer_id)                       AS farmers,
+--          min(calculado_em)::date                         AS desde,
+--          max(calculado_em)                               AS ultima
+--   FROM public.farmer_geracao_execucoes
+--   GROUP BY 1,2,3 ORDER BY 1,2,3;
+--
+--   -- O SINAL que a fase 2 exige (>= 1 linha aqui, com insumos plausíveis):
+--   SELECT farmer_id, run_id, calculado_em, insumos
+--   FROM public.farmer_geracao_execucoes
+--   WHERE resultado = 'vazio' AND completude = 'completo'
+--     AND (insumos->'scores'->>'n')::int    > 0
+--     AND (insumos->'vendaveis'->>'n')::int > 0
+--   ORDER BY calculado_em DESC;
+--
+-- Enquanto a 2ª query não devolver linha, "está no ar e ninguém reclamou" continua sendo
+-- AUSÊNCIA DE DADO — e a expiração por vazio não tem sinal que a justifique.
+--
+-- O head segue útil para outra pergunta (estado corrente + o CAS):
+--   SELECT motor, farmer_id, resultado, completude, calculado_em
+--   FROM public.farmer_geracao_vigente ORDER BY 1,2;


### PR DESCRIPTION
Follow-up da **limitação declarada no #1756**: o recálculo aposenta a geração anterior, mas **só quando produz linha**. Quando o cálculo conclui corretamente que não deve haver recomendação nenhuma, nada avança — e o banco segue servindo o que o novo cálculo já descartou.

A causa é estrutural: inferir a geração vigente da **existência de uma linha**. Um conjunto vazio não tem onde carimbar a própria identidade.

## Medição primeiro (prod, `psql-ro`)

**O denominador é 3 farmers** — não os 473 grupos do #1756, que eram `(farmer, cliente)`.

| farmer | scores | c/ pedido | pendentes | geração |
|---|--:|--:|--:|---|
| `414a9727` | 3.858 | 171 | 671 | recalculado durante a sessão |
| `33f59dc7` | 1.245 | 294 | 690 | `run_id` NULL, de 10/04 — **127 dias** |
| `700657a1` | 1.530 | 396 | **0** | **nunca rodou** |

**O #1756 está vivo e fez efeito real**: durante esta sessão um run inseriu 671 linhas e **expirou 5.325** no mesmo instante.

**A frequência do vazio era estruturalmente não-mensurável.** Ele saía por `return` mudo (`useCrossSellEngine` :225 e :296), sem gravar linha e sem registrar execução. As 28 execuções *com linha* em 5,5 meses são numerador; o denominador não existia em lugar nenhum. Se a tela tivesse sido aberta 500 vezes e 472 devolvessem zero, o rastro seria **idêntico**.

E a medição revelou, sem ser procurado, o custo que já se paga: em `700657a1`, **"nunca rodou" e "rodou e deu vazio" são o mesmo estado** — ausência de linha.

## Escopo: SENSOR, sem expirar (decisão do founder)

Sem um único vazio medido, ligar a expiração é assumir o risco de zerar a carteira de uma vendedora **sem contrapartida medida**. **Fora de escopo, declarado:** expiração por vazio, TTL por idade, backfill, loop de feedback.

## Duas tabelas, porque são duas perguntas

- **`farmer_geracao_vigente`** = HEAD (1 por motor+farmer). Serve o CAS e o estado corrente — deixa o compare-and-swap de pé sem depender de haver linha.
- **`farmer_geracao_execucoes`** = LOG append-only. Responde a **frequência**. O head sozinho não responde: `ON CONFLICT` sobrescreve, então um `vazio+completo` de hoje some no run de amanhã e a medição diria *"nunca aconteceu"*.

## O ponto difícil: separar os dois zeros

Não se infere do resultado — só o produtor sabe. O motor **declara** a completude do snapshot, e as contagens por insumo ficam como **evidência para auditar o rótulo** (*"rótulo com DEFAULT constante não é fato"*). `ok:false` degrada sempre; `n:0` degrada nos obrigatórios; insumo não declarado degrada (ausente ≠ zero, aplicado à própria medição). `completude` ausente vira `desconhecido`, **nunca** `completo` — a janela do Publish manual envenenaria a medição com falsos completo.

## O challenge Codex (xhigh) derrubou 3 premissas — 2 eram contradições entre o spec e o código

- **a tabela tinha `GRANT INSERT/UPDATE`** para `authenticated`: o browser forjava o head por UPDATE direto, pulando FG105/106/107. Agora só `SELECT`, e a RPC é `SECURITY DEFINER` (única porta).
- **o head não media frequência** e apagava o evento procurado → log append-only.
- **o CAS era assimétrico**: um run antigo com linhas sobrescrevia um vazio mais novo, porque o CAS compara *linhas* e o vazio não mexe em linha → as RPCs passam a comparar o head que o **browser** viu.
- FG107 checava `EXISTS`, não contagem → conta no servidor.
- faltava `NOTIFY pgrst` → o sensor nasceria cego atrás do schema cache.
- cobertura de perfil: o motor faz `if (!profile) continue` e a base tem 1.633 users sem `profiles` → conta a **interseção**, não o universo.

Não aceitos, com motivo no spec §7.5: RPCs versionadas (medido: zero dependências, zero cron, único chamador é o browser) e cobertura de "histórico utilizável" (fica declarada como limitação e pré-requisito da fase 2).

## Evidência

| checagem | resultado |
|---|---|
| `db/test-farmer-head-geracao.sh` | **63 asserts, 9 falsificações mordendo**, exit 0 — `LC_ALL=C` **e** `pt_BR.UTF-8` |
| `db/test-farmer-geracao-vigente.sh` (#1756) | **35 asserts**, exit 0 — as RPCs foram recriadas e nada regrediu |
| `heavy heavy bun run typecheck` | exit 0 |
| `heavy heavy bun run test` | **673 arquivos / 6302 testes**, exit 0 |
| `bun lint` | exit 0, **0 errors** |

Reentrância do advisory lock **medida** no PG17 antes de confiar nela (3 aquisições na mesma transação → todas `true`; 1 entrada em `pg_locks`; 0 após commit).

## ⚠️ Deploy — 3 camadas manuais

1. **SQL Editor**: `supabase/migrations/20260815181500_farmer_geracao_head_sensor.sql` (depende da `20260814223445`, e o guard aborta nomeando-a se faltar)
2. **Publish do frontend**
3. Nenhuma edge nova

A ordem é segura nos dois sentidos: a assinatura de 4 args é preservada por DEFAULTs, então o bundle velho segue funcionando entre (1) e (2) — gravando `desconhecido`, nunca `completo`.

## Quando medir (é query, não recado)

A fase 2 exige **≥1 linha** com `resultado='vazio'` e `completude='completo'` e insumos plausíveis — a query está no rodapé da migration. Enquanto ela não devolver linha, *"está no ar e ninguém reclamou"* segue sendo ausência de dado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)