### PR TITLE
feat(hooks): o eixo OBJETIVO ganha rede estrutural — artefato já na main vira aviso no `gh pr create`

### DIFF
--- a/.claude/hooks/pr-duplicata-guard.sh
+++ b/.claude/hooks/pr-duplicata-guard.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# pr-duplicata-guard.sh — PreToolUse(Bash): AVISA (não nega) na hora do `gh pr create` quando o
+# ARTEFATO que este PR introduz JÁ EXISTE na origin/main — i.e. a tarefa já foi ENTREGUE por outra
+# sessão. Eixo OBJETIVO; o irmão pr-collision-guard.sh cobre o eixo ARQUIVO (conflito de merge).
+#
+# Por que um hook e não (mais) uma frase: em 2026-08-15 uma única sessão produziu 3 duplicatas no
+# mesmo dia, com a regra do eixo OBJETIVO já escrita desde 2026-07-23 (worktrees.md, "achado
+# COMPARTILHADO colide por DESENHO"). O detector que ela prescreve — varrer TÍTULO de PR — dá 0 hits
+# nas 3, por duas causas independentes: o entregador já MERGEOU (`gh pr list` lista aberto por
+# padrão) e o PR entrega sob o tema DELE (o c542210c registrou `reposicao_pos_marcador` no manifesto
+# sob "o eixo do gate passa a ver COMPRAS"). Contramedida textual reincide; gate estrutural para.
+#
+# O TESTE (por (arquivo, símbolo), três vias — esta é a parte falsificada):
+#   1. ausente do ARQUIVO na merge-base   (não existia quando eu comecei)
+#   2. presente no ARQUIVO no meu HEAD    (fui EU que introduzi)
+#   3. presente no ARQUIVO na origin/main (alguém JÁ entregou enquanto eu trabalhava)
+# As três juntas são a assinatura da duplicata. Se a main não andou naquele arquivo, (1) e (3) se
+# contradizem e o hook cala sozinho — o silêncio é estrutural, não sorte.
+#
+# ⚠️ O escopo é POR ARQUIVO, não repo-wide, e isso foi MEDIDO, não escolhido: `reposicao_pos_marcador`
+# já existia em 10 arquivos (migrations) na merge-base, então um teste repo-wide de "símbolo novo" o
+# excluiria como "não é novo" → falso negativo em 1 das 3 ocorrências. O que era novo era o símbolo
+# NAQUELE arquivo (o registro no scripts/authz-manifest.ts). Precisão vem do par, não do símbolo.
+#
+# Candidato = identificador de ≥12 chars contendo `_` ou corcova camelCase. O filtro de forma existe
+# para que prosa portuguesa em .md ("imediatamente", "implementacao") não vire candidato — só
+# identificador tem underscore ou corcova. Ambos os símbolos reais passam (reposicao_pos_marcador,
+# DENO_NO_PACKAGE_JSON).
+#
+# Fail-open TOTAL: sem jq/git → exit 0; fetch falha → segue com refs locais; sem merge-base → exit 0;
+# arquivo ausente da main → pula (nada a duplicar ali). AVISA via additionalContext com
+# permissionDecision=allow — NUNCA bloqueia (PR legítimo que ESTENDE trabalho recém-mergeado existe).
+# Testes: scripts/test-pr-duplicata-guard.sh.
+set -u
+
+command -v jq  >/dev/null 2>&1 || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+
+input="$(cat)"
+cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[ -n "$cmd" ] || exit 0
+
+# É um `gh pr create`? Sanitiza aspas/heredoc antes (menção "gh pr create" ≠ execução) — mesma
+# detecção do pr-collision-guard.sh, deliberadamente idêntica para os dois guards concordarem.
+# shellcheck disable=SC2016  # \x27/\x22 são literais do regex do perl, não expansão de shell
+if command -v perl >/dev/null 2>&1; then
+  scan="$(printf '%s' "$cmd" | perl -0777 -pe "s/<<-?\s*([\x27\x22]?)(\w+)\1.*?^\2[ \t]*\$//gms; s/\x27[^\x27]*\x27//g; s/\x22[^\x22]*\x22//g" 2>/dev/null)"
+else
+  scan="$(printf '%s' "$cmd" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null)"
+fi
+[ -n "$scan" ] || scan="$cmd"
+printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
+
+if command -v timeout >/dev/null 2>&1; then
+  timeout 8 git fetch origin main --quiet >/dev/null 2>&1 || true
+else
+  git fetch origin main --quiet >/dev/null 2>&1 || true
+fi
+
+mb="$(git merge-base HEAD origin/main 2>/dev/null)" || exit 0
+[ -n "$mb" ] || exit 0
+
+mine="$(git diff --name-only "$mb" HEAD 2>/dev/null)" || exit 0
+[ -n "$mine" ] || exit 0
+
+# Identificador significativo: ≥12 chars, com underscore OU corcova camelCase.
+IDRE='[A-Za-z_][A-Za-z0-9_]{11,}'
+_ids() { grep -oE "$IDRE" 2>/dev/null | grep -E '_|[a-z][A-Z]' 2>/dev/null | sort -u; }
+
+achados=""
+n=0
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  n=$((n + 1))
+  [ "$n" -le 25 ] || break
+  case "$f" in
+    *.lock | *.lockb | *lock.json | *.png | *.jpg | *.svg | *.ico | *.woff*) continue ;;
+  esac
+
+  # Sem o arquivo na main não há entrega alheia ali. (Erro de `git show` cai no mesmo ramo.)
+  main_c="$(git show "origin/main:$f" 2>/dev/null)" || continue
+  [ -n "$main_c" ] || continue
+  base_c="$(git show "$mb:$f" 2>/dev/null)" || base_c=""
+
+  add_ids="$(git diff "$mb" HEAD -- "$f" 2>/dev/null | grep '^+' | grep -v '^+++' | _ids)"
+  [ -n "$add_ids" ] || continue
+
+  novos="$(comm -23 <(printf '%s\n' "$add_ids") <(printf '%s\n' "$base_c" | _ids) 2>/dev/null)"
+  [ -n "$novos" ] || continue
+  dup="$(comm -12 <(printf '%s\n' "$novos") <(printf '%s\n' "$main_c" | _ids) 2>/dev/null | head -4)"
+  [ -n "$dup" ] || continue
+
+  achados="$achados  $f → $(printf '%s' "$dup" | tr '\n' ' ')
+"
+done <<EOF
+$mine
+EOF
+
+[ -n "$achados" ] || exit 0
+
+msg="⚠️ Possível DUPLICATA por OBJETIVO na hora do gh pr create (eixo OBJETIVO — worktrees.md; caso: docs/historico/duplicata-por-objetivo.md).
+
+Estes símbolos NÃO existiam no arquivo quando você começou, você os introduz — e eles JÁ ESTÃO no mesmo arquivo na origin/main:
+$achados
+Ou seja: outra sessão pode ter entregue esta tarefa enquanto você trabalhava (padrão #1744/#1763 — 3 duplicatas em 2026-08-15). Confira ANTES de criar:
+  git log -S '<símbolo>' origin/main --oneline -- <arquivo>
+Se o núcleo já mergeou: fechar > reconciliar — salve só o SEU diferencial sobre o vencedor (o desenho alheio já foi melhor 2×: #1560 e a891ba9c). Se este PR ESTENDE de propósito o que já entrou, ignore este aviso."
+jq -n --arg m "$msg" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"allow",additionalContext:$m}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -92,6 +92,10 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-collision-guard.sh\""
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pr-duplicata-guard.sh\""
           }
         ]
       },

--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -101,6 +101,23 @@ comido o seu item (ali comeu DOIS — o registro da RPC e um follow-up de doc, n
 PR o nome que tiver — e sem o `git fetch` na frente o grep devolve "não existe" com cara de
 procura de verdade. Caso completo: [duplicata-por-objetivo.md](../historico/duplicata-por-objetivo.md).
 
+**Rede automática (2026-08-18):** hook `.claude/hooks/pr-duplicata-guard.sh` (PreToolUse Bash) —
+irmão do `pr-collision-guard.sh`, que cobre só o eixo ARQUIVO. Na hora do `gh pr create` ele testa,
+por **(arquivo, símbolo)**, três vias: ausente do arquivo na merge-base + introduzido por mim +
+**já presente no mesmo arquivo na `origin/main`**. As três juntas são a assinatura da duplicata; se a
+main não andou naquele arquivo, (1) e (3) se contradizem e o hook cala — o silêncio é estrutural, não
+sorte. **AVISA** via `additionalContext`, nunca nega (PR que ESTENDE de propósito o recém-mergeado
+existe). Fail-open total (sem `jq`/`git`, sem merge-base, arquivo ausente da main → no-op).
+⚠️ **O escopo por ARQUIVO foi medido, não escolhido:** `reposicao_pos_marcador` já vivia em 10
+arquivos (migrations) na merge-base, então um teste repo-wide de "símbolo novo" o excluiria → falso
+negativo em 1 das 3 ocorrências. Candidato = identificador de ≥12 chars com `_` ou corcova camelCase
+(filtro de forma que mantém prosa portuguesa de `.md` fora). Testes:
+`scripts/test-pr-duplicata-guard.sh` — 8 casos + **falsificação por sabotagem de cada via** numa
+CÓPIA do hook (remover a via 1 ou a via 3, ou trocar o escopo por repo-wide, tem de virar vermelho).
+**Limite:** pega o símbolo que você **escreve**; a duplicata cujo artefato é puro comportamento (mesma
+correção, símbolos diferentes — o caso `DENO_NO_PACKAGE_JSON` só é pego porque o nome coincide)
+continua fora do alcance, como a race fria de duas sessões sem PR aberto.
+
 **Rede automática (2026-07-23):** hook `.claude/hooks/pr-collision-guard.sh` (PreToolUse Bash)
 re-executa a conferência POR ARQUIVO na hora do `gh pr create` — fetch fresco + interseção de TRÊS
 pontos com a `origin/main` + `gh pr list --json files` dos PRs abertos de outras branches — e

--- a/docs/historico/duplicata-por-objetivo.md
+++ b/docs/historico/duplicata-por-objetivo.md
@@ -89,6 +89,10 @@ Irmã da regra "sincronize antes de MEDIR" (`worktrees.md`).
   um segundo eixo em `worktrees.md`).
 - **`docs/agent/worktrees.md`** — o detector falsificado, anexado ao bullet "achado COMPARTILHADO"
   de 2026-07-23, que é onde o eixo já morava.
+- **`.claude/hooks/pr-duplicata-guard.sh`** (2026-08-18) — o fecho ESTRUTURAL. A cláusula acima é
+  contramedida textual, e a meta-regra do catálogo de retrabalho diz que contramedida textual
+  reincide: a regra do eixo OBJETIVO já existia desde 2026-07-23 e não segurou as 3 ocorrências.
+  O hook testa as três vias por (arquivo, símbolo) na hora do `gh pr create` e AVISA.
 - Aqui — as 3 ocorrências e a falsificação.
 
 ## Precedente

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# test-pr-duplicata-guard.sh — TDD do hook pr-duplicata-guard.sh (git STUBADO, sem rede).
+#
+# Regra: `gh pr create` em que um símbolo (a) era AUSENTE do arquivo na merge-base, (b) é
+#        introduzido por mim e (c) JÁ ESTÁ no mesmo arquivo na origin/main → AVISA via
+#        additionalContext (permissionDecision=allow), SEM bloquear. Qualquer via faltando,
+#        comando ≠ `gh pr create`, ou erro de infra → stdout mudo. Fail-open.
+#
+# O caso 8 é o que dá sentido ao desenho: ele codifica a MEDIÇÃO que escolheu o escopo por
+# ARQUIVO em vez de repo-wide (reposicao_pos_marcador já existia em 10 arquivos na merge-base;
+# repo-wide o excluiria como "não é novo" → falso negativo em 1 das 3 ocorrências reais).
+#
+# Uso: bash scripts/test-pr-duplicata-guard.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+HOOK="$here/../.claude/hooks/pr-duplicata-guard.sh"
+
+stub="$(mktemp -d)"
+trap 'rm -rf "$stub"' EXIT
+export STUBDIR="$stub"
+
+cat >"$stub/git" <<'STUB'
+#!/bin/sh
+_slug() { printf '%s' "$1" | tr '/.' '__'; }
+case "$1" in
+  fetch) exit 0 ;;
+  merge-base) [ -n "${GIT_STUB_NO_MB:-}" ] && exit 128; echo MB ;;
+  diff)
+    case "$*" in
+      *--name-only*) cat "${GIT_STUB_MINE_FILE:-/dev/null}" ;;
+      *)
+        f=""
+        for a in "$@"; do f="$a"; done
+        cat "$STUBDIR/diff_$(_slug "$f")" 2>/dev/null || true ;;
+    esac ;;
+  show)
+    case "$2" in
+      origin/main:*) file="$STUBDIR/main_$(_slug "${2#origin/main:}")" ;;
+      MB:*)          file="$STUBDIR/base_$(_slug "${2#MB:}")" ;;
+      *) exit 128 ;;
+    esac
+    [ -f "$file" ] || exit 128
+    cat "$file" ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$stub/git"
+export PATH="$stub:$PATH"
+
+fail=0
+# _hook "<envs>" "<cmd>" → stdout do hook
+_hook() {
+  local envs="$1" cmd="$2" json
+  json="$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
+  # shellcheck disable=SC2086  # envs é lista KEY=VAL, precisa expandir em palavras
+  printf '%s' "$json" | env $envs bash "$HOOK" 2>/dev/null
+}
+_ok()   { printf '  ✓ %s\n' "$1"; }
+_bad()  { printf '  ✗ %s\n' "$1"; fail=1; }
+_avisa()  { [ -n "$1" ] && printf '%s' "$1" | grep -q 'DUPLICATA por OBJETIVO'; }
+# if/then explícito: A && B || C roda C mesmo com A verdadeiro se B falhar (SC2015).
+_deve_avisar() { if _avisa "$2"; then _ok "$1"; else _bad "$1"; fi; }
+_deve_calar()  { if _avisa "$2"; then _bad "$1"; else _ok "$1"; fi; }
+
+# ---------- cenário base: eu adiciono `reposicao_pos_marcador` ao manifesto ----------
+CRIAR='gh pr create --title x --body y'
+printf 'scripts/authz-manifest.ts\n' > "$stub/mine.txt"
+MINE="GIT_STUB_MINE_FILE=$stub/mine.txt"
+
+# meu diff introduz o símbolo
+printf '+++ b/scripts/authz-manifest.ts\n+  reposicao_pos_marcador: { requiredGate: "compras" },\n' \
+  > "$stub/diff_scripts_authz-manifest_ts"
+# na merge-base o arquivo NÃO tinha o símbolo
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n' \
+  > "$stub/base_scripts_authz-manifest_ts"
+# na origin/main o símbolo JÁ ESTÁ (outra sessão entregou)
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
+  > "$stub/main_scripts_authz-manifest_ts"
+
+echo "== 1. as três vias satisfeitas → AVISA =="
+out="$(_hook "$MINE" "$CRIAR")"
+_deve_avisar "avisa na assinatura da duplicata" "$out"
+if printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision=="allow"' >/dev/null 2>&1; then
+  _ok "permissionDecision=allow (avisa, não bloqueia)"; else _bad "deveria ser allow"; fi
+if printf '%s' "$out" | grep -q 'reposicao_pos_marcador'; then
+  _ok "nomeia o símbolo culpado"; else _bad "deveria nomear o símbolo"; fi
+
+echo "== 2. símbolo JÁ existia na merge-base → mudo (uso normal, não criação) =="
+cp "$stub/main_scripts_authz-manifest_ts" "$stub/base_scripts_authz-manifest_ts"
+out="$(_hook "$MINE" "$CRIAR")"
+_deve_calar "mudo quando o símbolo é pré-existente" "$out"
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n' \
+  > "$stub/base_scripts_authz-manifest_ts"
+
+echo "== 3. símbolo novo AUSENTE da main → mudo (trabalho genuinamente novo) =="
+cp "$stub/base_scripts_authz-manifest_ts" "$stub/main_scripts_authz-manifest_ts"
+out="$(_hook "$MINE" "$CRIAR")"
+_deve_calar "mudo no caminho feliz (ninguém entregou)" "$out"
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
+  > "$stub/main_scripts_authz-manifest_ts"
+
+echo "== 4. comando não é gh pr create → mudo =="
+for c in 'echo "gh pr create"' 'gh pr list' 'git commit -m "fala de gh pr create"'; do
+  out="$(_hook "$MINE" "$c")"
+  _deve_calar "mudo em: $c" "$out"
+done
+
+echo "== 5. arquivo ausente da origin/main → mudo =="
+rm -f "$stub/main_scripts_authz-manifest_ts"
+out="$(_hook "$MINE" "$CRIAR")"
+_deve_calar "mudo sem o arquivo na main (nada a duplicar)" "$out"
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
+  > "$stub/main_scripts_authz-manifest_ts"
+
+echo "== 6. fail-open: sem merge-base → mudo =="
+out="$(_hook "$MINE GIT_STUB_NO_MB=1" "$CRIAR")"
+if [ -z "$out" ]; then _ok "silencioso sem merge-base"; else _bad "devia ser mudo"; fi
+
+echo "== 7. filtro de forma: prosa .md não vira candidato =="
+printf 'docs/nota.md\n' > "$stub/mine_md.txt"
+printf '+++ b/docs/nota.md\n+A regra vale imediatamente para toda implementacao subsequente.\n' \
+  > "$stub/diff_docs_nota_md"
+printf 'Documento.\n' > "$stub/base_docs_nota_md"
+printf 'Documento. A regra vale imediatamente para toda implementacao subsequente.\n' \
+  > "$stub/main_docs_nota_md"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine_md.txt" "$CRIAR")"
+_deve_calar "prosa portuguesa não dispara" "$out"
+
+echo "== 8. REGRESSÃO do escopo: símbolo existe repo-wide, mas é novo NO ARQUIVO → AVISA =="
+# É a ocorrência 1 real: reposicao_pos_marcador vivia em 10 arquivos (migrations) na merge-base.
+# O escopo por arquivo tem de disparar mesmo assim; repo-wide daria falso negativo.
+printf 'supabase/migrations/x.sql\nscripts/authz-manifest.ts\n' > "$stub/mine8.txt"
+printf 'CREATE FUNCTION reposicao_pos_marcador() ...\n' > "$stub/base_supabase_migrations_x_sql"
+printf 'CREATE FUNCTION reposicao_pos_marcador() ...\n' > "$stub/main_supabase_migrations_x_sql"
+: > "$stub/diff_supabase_migrations_x_sql"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine8.txt" "$CRIAR")"
+_deve_avisar "dispara apesar do símbolo existir noutro arquivo na base" "$out"
+
+echo
+if [ "$fail" -eq 0 ]; then echo "✅ pr-duplicata-guard: tudo verde"; else echo "❌ pr-duplicata-guard: FALHAS acima"; fi
+exit "$fail"

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -54,7 +54,7 @@ _hook() {
   local envs="$1" cmd="$2" json
   json="$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
   # shellcheck disable=SC2086  # envs é lista KEY=VAL, precisa expandir em palavras
-  printf '%s' "$json" | env $envs bash "$HOOK" 2>/dev/null
+  printf '%s' "$json" | env $envs bash "${HOOK_ATUAL:-$HOOK}" 2>/dev/null
 }
 _ok()   { printf '  ✓ %s\n' "$1"; }
 _bad()  { printf '  ✗ %s\n' "$1"; fail=1; }
@@ -136,6 +136,52 @@ printf 'CREATE FUNCTION reposicao_pos_marcador() ...\n' > "$stub/main_supabase_m
 : > "$stub/diff_supabase_migrations_x_sql"
 out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine8.txt" "$CRIAR")"
 _deve_avisar "dispara apesar do símbolo existir noutro arquivo na base" "$out"
+
+# ---------------------------------------------------------------------------------------
+# 9. FALSIFICAÇÃO — sabotar e EXIGIR vermelho. Sem isto os 8 casos acima são teatro: um hook
+# que nunca avisasse passaria em 2,3,4,5,6,7 e um que sempre avisasse passaria em 1 e 8.
+# A sabotagem é aplicada numa CÓPIA (nunca no original) — restaurar por `git checkout --`
+# destruiria trabalho não-commitado, armadilha já registrada no §9 do money-path.
+# ---------------------------------------------------------------------------------------
+echo "== 9. falsificação: cada via do teste tem de ser LOAD-BEARING =="
+
+_sabota() { # $1=nome  $2=expr sed  $3=cenário(mine)  $4=veredito esperado da SABOTADA
+  local nome="$1" expr="$2" mine="$3" esperado="$4" out
+  sed "$expr" "$HOOK" > "$stub/sabotado.sh"
+  if cmp -s "$HOOK" "$stub/sabotado.sh"; then
+    _bad "sabotagem '$nome' não mudou nada (padrão sed obsoleto — o teste estaria cego)"
+    return
+  fi
+  out="$(HOOK_ATUAL=$stub/sabotado.sh _hook "GIT_STUB_MINE_FILE=$mine" "$CRIAR")"
+  if [ "$esperado" = avisa ]; then
+    if _avisa "$out"; then _ok "sabotagem '$nome' → vermelho como esperado (via é load-bearing)"
+    else _bad "sabotagem '$nome' NÃO mudou o veredito — a via não está sendo testada"; fi
+  else
+    if _avisa "$out"; then _bad "sabotagem '$nome' NÃO mudou o veredito — a via não está sendo testada"
+    else _ok "sabotagem '$nome' → vermelho como esperado (via é load-bearing)"; fi
+  fi
+}
+
+# (A) remover a via 1 (ausência na merge-base): o cenário 2 — símbolo PRÉ-EXISTENTE — passa a avisar.
+cp "$stub/main_scripts_authz-manifest_ts" "$stub/base_scripts_authz-manifest_ts"
+# shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
+_sabota "sem a via 1 (ausencia na base)" 's|^  novos=.*|  novos="$add_ids"|' "$stub/mine.txt" avisa
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n' \
+  > "$stub/base_scripts_authz-manifest_ts"
+
+# (C) remover a via 3 (presença na main): o cenário 3 — ninguém entregou — passa a avisar.
+cp "$stub/base_scripts_authz-manifest_ts" "$stub/main_scripts_authz-manifest_ts"
+# shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
+_sabota "sem a via 3 (presenca na main)" 's|^  dup=.*|  dup="$novos"|' "$stub/mine.txt" avisa
+printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
+  > "$stub/main_scripts_authz-manifest_ts"
+
+# (B) trocar o ESCOPO por repo-wide (acumular a base de todos os arquivos): o cenário 8 emudece.
+# É a variante que a medição rejeitou — 1 falso negativo em 3 ocorrências reais.
+# shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
+_sabota "escopo repo-wide em vez de por arquivo" \
+  's|^  base_c=.*|  base_c="${acc:-}$(git show "$mb:$f" 2>/dev/null)"; acc="$base_c"|' \
+  "$stub/mine8.txt" cala
 
 echo
 if [ "$fail" -eq 0 ]; then echo "✅ pr-duplicata-guard: tudo verde"; else echo "❌ pr-duplicata-guard: FALHAS acima"; fi


### PR DESCRIPTION
Fecho estrutural da classe aberta no #1767.

## Por que um hook e não (mais) uma frase

O #1767 entregou a **contramedida textual** (cláusula na §Multi-sessão). Mas a meta-regra do catálogo de retrabalho deste repo diz que **contramedida textual reincide; gate estrutural para** — e este caso é a prova viva dela: a regra do eixo OBJETIVO **já existia desde 2026-07-23** (`worktrees.md`, "achado COMPARTILHADO colide por DESENHO") e não segurou as 3 duplicatas de 2026-08-15.

O irmão `pr-collision-guard.sh` cobre o eixo **ARQUIVO** (conflito de merge). Este cobre o eixo **OBJETIVO** (a tarefa já entregue).

## O teste — por `(arquivo, símbolo)`, três vias

1. **ausente do ARQUIVO na merge-base** — não existia quando comecei
2. **presente no ARQUIVO no meu HEAD** — fui eu que introduzi
3. **presente no ARQUIVO na `origin/main`** — alguém **já entregou** enquanto eu trabalhava

As três juntas são a assinatura da duplicata. Se a main não andou naquele arquivo, (1) e (3) se contradizem e o hook **cala sozinho** — o silêncio é estrutural, não sorte.

## O escopo por ARQUIVO foi MEDIDO, não escolhido

Esta é a decisão de desenho que valia falsificar, e a falsificação **matou a variante óbvia**:

| ocorrência | símbolo novo **repo-wide**? | novo **no arquivo**? |
|---|---|---|
| `reposicao_pos_marcador` | ❌ já em **10 arquivos** (migrations) | ✅ ausente do `authz-manifest.ts` |
| `DENO_NO_PACKAGE_JSON` | ✅ | ✅ |

Um teste repo-wide de "símbolo novo" excluiria o primeiro como *"não é novo"* → **falso negativo em 1 das 3 ocorrências**. O que era novo era o símbolo **naquele arquivo**. Precisão vem do par, não do símbolo.

Candidato = identificador de **≥12 chars com `_` ou corcova camelCase** — filtro de **forma**, para que prosa portuguesa em `.md` ("imediatamente", "implementacao") não vire candidato. Os dois símbolos reais passam.

## Evidência end-to-end (não só stub)

Branch a partir de `c542210c^` + a entrada adicionada ao manifesto — **reprodução fiel da ocorrência 1** — e o hook disparou contra a `origin/main` **real**:

```
⚠️ Possível DUPLICATA por OBJETIVO na hora do gh pr create
  scripts/authz-manifest.ts → reposicao_pos_marcador
```

**Verdadeiro-negativo** conferido no PR deste próprio commit: **mudo** (trabalho genuinamente novo). Custo **660ms**, só no `gh pr create`.

## Testes e falsificação

8 casos com `git` stubado + **falsificação de cada via**, aplicada numa **cópia** do hook (nunca no original — restaurar por `git checkout --` destrói trabalho não-commitado, §9 do money-path):

| sabotagem | efeito exigido |
|---|---|
| remover a via 1 (ausência na base) | caso 2 fica **vermelho** |
| remover a via 3 (presença na main) | caso 3 fica **vermelho** |
| trocar o escopo por **repo-wide** | caso 8 fica **vermelho** |

As três viraram. Sem isso os 8 casos seriam teatro: um hook que nunca avisasse passaria em 5 deles.

## Garantias e limite

- **Fail-open total** — sem `jq`/`git`, sem merge-base, arquivo ausente da main → no-op.
- **AVISA, nunca nega** (`permissionDecision=allow`): PR que **estende de propósito** o recém-mergeado existe.
- ⚠️ **Limite declarado:** pega o símbolo que você **escreve**. Duplicata cujo artefato é puro **comportamento** (mesma correção, símbolos diferentes) segue fora do alcance — `DENO_NO_PACKAGE_JSON` só é pego porque o nome coincidiu. A race fria (duas sessões, nenhum PR aberto) idem.

## Gates

`shellcheck` **0** (hook + teste) · `test-pr-duplicata-guard` **0** · `test-pr-collision-guard` **0** (irmão não regrediu) · `claude:size` **0** (CLAUDE.md **intocado** — a doc vai para `worktrees.md`, onde o eixo já morava).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
