### PR TITLE
fix(authz): o fecho de EXECUTE de 3 funções existia só em PROD — registrado no repo, e a Parte E deixa de ser cega a elas [money-path]

### DIFF
--- a/db/test-authz-fecho-execute-registrado.sh
+++ b/db/test-authz-fecho-execute-registrado.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260818121919_authz_fecho_execute_registrado_3_funcoes.sql                    ║
+# ║  Rode: bash db/test-authz-fecho-execute-registrado.sh > /tmp/t.log 2>&1; echo "exit=$?"      ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                                      ║
+# ╚══════════════════════════════════════════════════════════════════════════════════════════════╝
+#
+# O QUE ESTA PROVA COBRE — e, tão importante quanto, o que ela NÃO cobre.
+# ------------------------------------------------------------------------------------------------
+# A migration sob teste não tem uma linha de plpgsql: são 3 `REVOKE`. Logo o risco clássico do
+# harness PG17 (late-bound — SQL que passa no CREATE e só quebra ao EXECUTAR) não é o risco aqui.
+# O risco aqui é de PRIVILÉGIO, e tem três formas, todas provadas EXECUTANDO abaixo:
+#   1. o REVOKE não fechar de verdade (a armadilha do `FROM PUBLIC`, nº 1 de docs/agent/database.md);
+#   2. o REVOKE fechar DEMAIS e quebrar quem consome (cron, os 2 triggers, service_role);
+#   3. o fecho existir no arquivo mas ficar invisível para o gate estático (REVOKE dentro de `DO $$`).
+#
+# ⚠️ HONESTIDADE SOBRE OS CORPOS: as 3 funções são recriadas aqui com corpo MÍNIMO e observável —
+#    não são os corpos de prod. Isso é deliberado e suficiente: a migration não toca corpo nenhum,
+#    só ACL, e o que precisa ser fiel para a prova valer é a TRÍPLICE (assinatura exata, SECURITY
+#    DEFINER, e o default privilege do schema `public`). As três são fiéis e MEDIDAS em prod
+#    (psql-ro 2026-08-15, reconfirmado 2026-08-18). Quem quiser provar a LÓGICA delas está no
+#    harness errado.
+#
+# ⚠️ LOCALE: o postmaster exige LC_ALL=C (sem isso aborta no startup), então este harness o força.
+#    Isso não enfraquece nada: toda asserção aqui compara o booleano ASCII `t`/`f` devolvido pelo
+#    Postgres — não há `grep -i` sobre string acentuada, que é o acidente do #1483. A prova de
+#    dois locales pertence a db/test-authz-funcoes-falsificacao.sh, onde as asserções SÃO strings.
+#
+# FALSIFICAÇÃO (Lei #3): a sabotagem escreve uma CÓPIA em $TMP, nunca o arquivo do repo — o
+# `restaurar()` por `git checkout --` dos harnesses estáticos já apagou trabalho não-commitado
+# neste repo, e aqui não há por que correr esse risco.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5473}"
+SLUG="authz-fecho-execute"
+TMPROOT="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")"
+DATA="$TMPROOT/data"
+export LC_ALL=C LANG=C
+
+MIG="$REPO_ROOT/supabase/migrations/20260818121919_authz_fecho_execute_registrado_3_funcoes.sql"
+[ -f "$MIG" ] || { echo "migration ausente: $MIG"; exit 2; }
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 2; }
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$TMPROOT"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# ⚠️ o INVERSO de eq, e é ele que dá dente à falsificação: exige que o valor NÃO seja o esperado.
+ne()  { if [ "$2" != "$3" ]; then ok "$1 (veio [$2], ≠ [$3] como a sabotagem exige)"; else bad "$1 — a sabotagem NÃO ficou vermelha: veio [$2], o assert não tem dente"; fi; }
+
+# EXECUTE de <role> sobre <assinatura> → 't'/'f' (ASCII, imune a locale).
+hfp() { Pq -c "SELECT has_function_privilege('$1', '$2', 'EXECUTE');"; }
+
+D_SIG='public.detectar_skus_sem_grupo(text)'
+S_SIG='public.set_status_envio_portal_on_disparo()'
+C_SIG='public.cmc_ledger_capture()'
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: o schema `public` do Supabase + as 3 funções + seus consumidores.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# O default privilege é a PREMISSA de tudo: sem ele o PG local nasce com proacl NULL e o teste
+# provaria outra coisa. Valor MEDIDO em pg_default_acl (schema public, objtype 'f'), 2026-08-15.
+P -q <<'SQL'
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT EXECUTE ON FUNCTIONS TO postgres, anon, authenticated, service_role;
+SQL
+
+# Recria do ZERO as 3 funções, tabelas e triggers. Idempotente e re-chamável: cada chamada zera o
+# ACL (a função renasce herdando o default privilege), que é o que permite reencenar a
+# falsificação num estado limpo sem derrubar o cluster.
+estado_pre_migration() {
+  P -q <<'SQL'
+DROP TABLE IF EXISTS public.pedido_compra_sugerido CASCADE;
+DROP TABLE IF EXISTS public.inventory_position     CASCADE;
+DROP TABLE IF EXISTS public.cmc_ledger             CASCADE;
+DROP FUNCTION IF EXISTS public.detectar_skus_sem_grupo(text);
+DROP FUNCTION IF EXISTS public.set_status_envio_portal_on_disparo();
+DROP FUNCTION IF EXISTS public.cmc_ledger_capture();
+
+CREATE TABLE public.pedido_compra_sugerido (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  status_envio_portal text
+);
+CREATE TABLE public.inventory_position (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sku text, cmc numeric
+);
+CREATE TABLE public.cmc_ledger (id bigserial PRIMARY KEY, sku text, cmc numeric);
+
+-- assinatura e SECURITY DEFINER fiéis ao prod (medidos); corpo mínimo e observável.
+CREATE FUNCTION public.detectar_skus_sem_grupo(p_empresa text)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $f$
+BEGIN RETURN 42; END $f$;
+
+CREATE FUNCTION public.set_status_envio_portal_on_disparo()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $f$
+BEGIN NEW.status_envio_portal := 'enviado'; RETURN NEW; END $f$;
+
+CREATE FUNCTION public.cmc_ledger_capture()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $f$
+BEGIN INSERT INTO public.cmc_ledger(sku, cmc) VALUES (NEW.sku, NEW.cmc); RETURN NEW; END $f$;
+
+CREATE TRIGGER trg_set_status_envio_portal BEFORE INSERT ON public.pedido_compra_sugerido
+  FOR EACH ROW EXECUTE FUNCTION public.set_status_envio_portal_on_disparo();
+CREATE TRIGGER trg_cmc_ledger_capture AFTER INSERT ON public.inventory_position
+  FOR EACH ROW EXECUTE FUNCTION public.cmc_ledger_capture();
+
+-- O DML é o privilégio que o trigger de fato exige do chamador — ver A9/A10.
+GRANT INSERT, SELECT ON public.pedido_compra_sugerido, public.inventory_position TO authenticated;
+
+-- ⇩ o ESTADO DO REPO ANTES desta entrega: exatamente as linhas 31-32 e 64-65 da
+--   20260510235956 ("Fatia E3 Fase 1"). cmc_ledger_capture não aparece porque NENHUMA migration
+--   do repo emitia GRANT/REVOKE sobre ela — ela fica no default privilege puro.
+REVOKE EXECUTE ON FUNCTION public.detectar_skus_sem_grupo(p_empresa text) FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.detectar_skus_sem_grupo(p_empresa text) TO authenticated, service_role;
+REVOKE EXECUTE ON FUNCTION public.set_status_envio_portal_on_disparo() FROM PUBLIC, anon;
+GRANT  EXECUTE ON FUNCTION public.set_status_envio_portal_on_disparo() TO authenticated, service_role;
+SQL
+}
+
+estado_pre_migration
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# FASE 1 — o estado que o REPO produzia (o problema, medido em vez de alegado)
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+echo "── fase 1: o que um replay do repo (DR) produzia ANTES desta migration ──"
+eq "A1a detectar_skus_sem_grupo: authenticated ALCANÇA (o repo concedia)" "$(hfp authenticated "$D_SIG")" "t"
+eq "A1b set_status_envio_portal: authenticated ALCANÇA (o repo concedia)" "$(hfp authenticated "$S_SIG")" "t"
+# A pior das três: sem NENHUM grant/revoke no repo, ela nasce alcançável até por `anon`.
+eq "A1c cmc_ledger_capture: anon ALCANÇA (default privilege puro)"        "$(hfp anon "$C_SIG")"          "t"
+eq "A1d cmc_ledger_capture: authenticated ALCANÇA (default privilege)"    "$(hfp authenticated "$C_SIG")" "t"
+
+# A ARMADILHA nº 1 de docs/agent/database.md, provada em vez de citada: revogar de PUBLIC não
+# desfaz o grant NOMEADO que veio do default privilege. É por isso que a migration nomeia as roles.
+P -q -c "REVOKE EXECUTE ON FUNCTION public.cmc_ledger_capture() FROM PUBLIC;"
+eq "A2 REVOKE FROM PUBLIC NÃO tira authenticated (por isso revoga-se por NOME)" "$(hfp authenticated "$C_SIG")" "t"
+eq "A2b REVOKE FROM PUBLIC NÃO tira anon"                                       "$(hfp anon "$C_SIG")"          "t"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1: o .sql commitado, byte-a-byte)
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+estado_pre_migration
+P -q -f "$MIG"
+echo "── fase 2: migration REAL aplicada ($(basename "$MIG")) ──"
+
+eq "A3 detectar_skus_sem_grupo: authenticated NÃO alcança" "$(hfp authenticated "$D_SIG")" "f"
+eq "A4 set_status_envio_portal: authenticated NÃO alcança" "$(hfp authenticated "$S_SIG")" "f"
+eq "A5 cmc_ledger_capture: authenticated NÃO alcança"      "$(hfp authenticated "$C_SIG")" "f"
+eq "A3b detectar_skus_sem_grupo: anon NÃO alcança"         "$(hfp anon "$D_SIG")"          "f"
+eq "A4b set_status_envio_portal: anon NÃO alcança"         "$(hfp anon "$S_SIG")"          "f"
+eq "A5b cmc_ledger_capture: anon NÃO alcança"              "$(hfp anon "$C_SIG")"          "f"
+
+# O fecho tem de parar EXATAMENTE nas 2 roles do browser: service_role é quem faz as 3 rodarem.
+eq "A6a service_role MANTÉM execute (detectar_skus_sem_grupo)" "$(hfp service_role "$D_SIG")" "t"
+eq "A6b service_role MANTÉM execute (set_status_envio_portal)" "$(hfp service_role "$S_SIG")" "t"
+eq "A6c service_role MANTÉM execute (cmc_ledger_capture)"      "$(hfp service_role "$C_SIG")" "t"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# FASE 3 — OS CONSUMIDORES CONTINUAM FUNCIONANDO (o outro lado do fecho)
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+echo "── fase 3: os 3 consumidores reais seguem funcionando ──"
+
+# A7 — o caminho do cron `detectar-outliers-diario`, que roda com username=postgres (superuser).
+eq "A7 cron (postgres, superuser) executa detectar_skus_sem_grupo" \
+   "$(Pq -c "SELECT public.detectar_skus_sem_grupo('OBEN');")" "42"
+
+# A8 — negativo COM SQLSTATE (Lei #2): authenticated é barrado com 42501, e QUALQUER outro erro
+#      é re-lançado. Um `WHEN OTHERS THEN 'OK'` aqui pintaria de verde até um erro de digitação.
+if P -q >/dev/null 2>&1 <<'SQL'
+DO $$
+BEGIN
+  SET LOCAL ROLE authenticated;
+  PERFORM public.detectar_skus_sem_grupo('OBEN');
+  RAISE EXCEPTION 'ASSERT_FALHOU_authenticated_executou';
+EXCEPTION
+  WHEN insufficient_privilege THEN NULL;   -- 42501: o ÚNICO desfecho aceito
+  WHEN OTHERS THEN RAISE;
+END $$;
+SQL
+then ok "A8 authenticated barrado com 42501 (insufficient_privilege)"
+else bad "A8 authenticated NÃO foi barrado pela SQLSTATE esperada"
+fi
+
+# A9/A10 — o ponto que justifica revogar sem medo das 2 funções de trigger: Postgres NÃO checa
+# EXECUTE da função de trigger no disparo; o privilégio checado é o DML na TABELA. Sem esta prova,
+# "o fecho não quebra os triggers" seria alegação — e uma alegação errada aqui derrubaria compras.
+# A escrita e a LEITURA vão em chamadas separadas de propósito: no mesmo `-c`, os command tags
+# (`SET`/`INSERT 0 1`/`RESET`) entram na captura e o `eq` compararia o log, não o efeito.
+P -q -c "SET ROLE authenticated; INSERT INTO public.pedido_compra_sugerido DEFAULT VALUES;" >/dev/null
+eq "A9 trigger BEFORE dispara p/ authenticated SEM execute na função" \
+   "$(Pq -c "SELECT status_envio_portal FROM public.pedido_compra_sugerido LIMIT 1;")" \
+   "enviado"
+P -q -c "SET ROLE authenticated; INSERT INTO public.inventory_position(sku, cmc) VALUES ('SKU-1', 9.9);" >/dev/null
+eq "A10 trigger AFTER dispara p/ authenticated SEM execute na função" \
+   "$(Pq -c "SELECT count(*) FROM public.cmc_ledger;")" \
+   "1"
+
+# A11 — idempotência: o founder pode colar duas vezes no SQL Editor.
+P -q -f "$MIG"
+eq "A11 re-aplicar a migration é no-op (idempotente)" "$(hfp authenticated "$D_SIG")" "f"
+
+# A12 — a migration precisa manter os REVOKE TOP-LEVEL. Dentro de `DO $$`, eles deixam de ser
+#       statements para o parser de scripts/lib/authz-funcoes.ts, a âncora fica MUDA e a migration
+#       para de cumprir o que se propõe — sem que nada no banco mude. Falha silenciosa exata.
+eq "A12 os 3 REVOKE são top-level (o gate estático consegue lê-los)" \
+   "$(command grep -cE '^REVOKE EXECUTE ON FUNCTION public\.' "$MIG")" "3"
+# ⚠️ conta só linhas de CÓDIGO: o cabeçalho da migration cita `DO $$` justamente para explicar por
+#    que não o usa, e contar o comentário faria este assert falhar sobre a própria documentação.
+eq "A12b a migration não embrulha nada em DO \$\$ (invisível ao parser)" \
+   "$(command grep -v '^--' "$MIG" | command grep -c 'DO \$\$' || true)" "0"
+
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# FASE 4 — FALSIFICAÇÃO (Lei #3): sabota a migration e EXIGE vermelho pelo motivo certo.
+# ══════════════════════════════════════════════════════════════════════════════════════════════
+# A sabotagem vai para uma CÓPIA em $TMPROOT — o arquivo do repo nunca é tocado.
+echo "── fase 4: falsificação ──"
+
+# F1 — a sabotagem mais perigosa porque é EXATAMENTE o falso-fecho que já existia no repo: revogar
+#      de `PUBLIC, anon` e esquecer `authenticated`. Se A3/A4/A5 sobrevivessem a isto, eles não
+#      estariam medindo o fecho — estariam medindo o default privilege.
+SAB1="$TMPROOT/sabotagem-sem-authenticated.sql"
+sed 's/FROM PUBLIC, anon, authenticated;/FROM PUBLIC, anon;/' "$MIG" > "$SAB1"
+command grep -q 'FROM PUBLIC, anon;' "$SAB1" || { echo "F1 não casou nada — o harness ficaria verde por vacuidade"; exit 2; }
+estado_pre_migration
+P -q -f "$SAB1"
+ne "F1 sem 'authenticated' no REVOKE → A3 fica VERMELHO" "$(hfp authenticated "$D_SIG")" "f"
+ne "F1 sem 'authenticated' no REVOKE → A5 fica VERMELHO" "$(hfp authenticated "$C_SIG")" "f"
+
+# F2 — a sabotagem canônica da armadilha: revogar SÓ de PUBLIC. É o que um autor desavisado
+#      escreveria, e o gate/prova têm de recusar.
+SAB2="$TMPROOT/sabotagem-so-public.sql"
+sed 's/FROM PUBLIC, anon, authenticated;/FROM PUBLIC;/' "$MIG" > "$SAB2"
+command grep -q 'FROM PUBLIC;' "$SAB2" || { echo "F2 não casou nada — vacuidade"; exit 2; }
+estado_pre_migration
+P -q -f "$SAB2"
+ne "F2 REVOKE só de PUBLIC → A5 fica VERMELHO (authenticated sobrevive)" "$(hfp authenticated "$C_SIG")" "f"
+ne "F2 REVOKE só de PUBLIC → A5b fica VERMELHO (anon sobrevive)"         "$(hfp anon "$C_SIG")"          "f"
+
+# F3 — CONTRAPROVA de F1/F2: sem ela, os `ne` acima passariam mesmo que o harness estivesse
+#      quebrado e sempre devolvesse 't'. Restaura a migration VERDADEIRA e exige verde de novo.
+estado_pre_migration
+P -q -f "$MIG"
+eq "F3 contraprova: migration verdadeira volta a fechar (authenticated)" "$(hfp authenticated "$C_SIG")" "f"
+eq "F3b contraprova: e service_role continua alcançando"                 "$(hfp service_role "$C_SIG")"  "t"
+
+echo "══════════════════════════════════════════════"
+echo "  PASS=$PASS  FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1
+echo "  ✅ prova verde: o fecho fecha, os 3 consumidores seguem, e a sabotagem fica vermelha."

--- a/docs/historico/sentinela-authz-controle-nao-mencao.md
+++ b/docs/historico/sentinela-authz-controle-nao-mencao.md
@@ -481,9 +481,8 @@ que a reabrisse ficaria verde para sempre. `fechadaPor: null` diz a verdade — 
 repo, o estático não vigia, o audit de prod é a única guarda —, e o verde do `authz:check` nomeia
 as três.
 
-> **Follow-up para o founder (mudança de banco, não é decisão minha):** uma migration que emita
-> `REVOKE EXECUTE ON FUNCTION … FROM authenticated` nessas três traria as 3 para a vigilância
-> estática do CI. Enquanto ela não existir, elas dependem de alguém rodar `authz:funcoes:prod`.
+> **✅ Follow-up ENTREGUE** em `20260818121919_authz_fecho_execute_registrado_3_funcoes.sql` — as 3
+> passaram a ter âncora e o `authz:check` não emite mais nenhum `FUNCAO_FECHO_PENDENTE`. Ver §9.7.
 
 ## 9.5 Evidência
 
@@ -532,8 +531,8 @@ F3c é o que separa esta parte de um detector que só procura a palavra `REVOKE`
 1. **A Parte E prova o que o REPO declara, não o que prod tem** — mesma divisão das outras partes.
    Um `GRANT EXECUTE` colado à mão no SQL Editor é invisível para ela; quem o pega é o
    `authz:funcoes:prod`, que roda on-demand. Entre duas execuções, a janela existe.
-2. **3 funções sem âncora no repo** (§9.4) não são vigiadas pelo CI. Está declarado no verde do
-   `authz:check` e no do audit, mas declarar não é cobrir.
+2. ~~**3 funções sem âncora no repo** (§9.4) não são vigiadas pelo CI.~~ **RESOLVIDO** na entrega do
+   §9.7: as 3 ganharam âncora, e hoje `fechadaPor: null` não sobra em nenhuma das 40.
 3. **O detector julga por NOME, não por assinatura.** Overloads colapsam em `schema.name`, que é a
    granularidade do `AUTHZ_MANIFEST`. Um `DROP`+`CREATE` que recriasse só UM overload e revogasse
    dele passaria como fecho completo. No audit de prod a regra é fail-closed entre overloads (um
@@ -545,3 +544,51 @@ F3c é o que separa esta parte de um detector que só procura a palavra `REVOKE`
    funções já classificadas; quem exige que uma SECDEF sensível nova seja classificada é a Parte B.
    Uma função nova que não toque o eixo sensível nasce alcançável por `anon` e ninguém reclama —
    é o modelo da plataforma, e mudar isso é decisão de produto, não de sentinela.
+
+## 9.7 O fecho das 3 saiu de prod e entrou no repo (follow-up do §9.4, PR pós-#1768)
+
+`20260818121919_authz_fecho_execute_registrado_3_funcoes.sql` emite os 3
+`REVOKE EXECUTE ON FUNCTION … FROM PUBLIC, anon, authenticated`. Com a âncora apontada nas 3
+entradas de `scripts/authz-funcoes-fechadas.ts`, o `authz:check` deixou de emitir
+`FUNCAO_FECHO_PENDENTE` (11 → 8 avisos) e o `authz:funcoes:prod` passou a fechar com **40 vigiadas
+e 0 fora do repo** — o `⚠️` que o verde carregava sumiu.
+
+**A migration é NO-OP em prod, e isso é o ponto, não um defeito.** As 3 já estavam fechadas
+(medido; reconfirmado 2026-08-18). O que não existia era o REGISTRO. O ganho é duplo: o vetor
+`DROP`+`CREATE` nelas passa a ser pego no PR, e um replay do repo (DR) passa a reproduzir o ACL de
+prod — antes não reproduzia, e a diferença não era cosmética: sem GRANT/REVOKE algum sobre
+`cmc_ledger_capture`, um replay a fazia nascer alcançável **por `anon`**.
+
+> ⚠️ **Consequência de ser no-op: o apply em prod é INOBSERVÁVEL por ACL.** `has_function_privilege`
+> devolve o mesmo antes e depois do Run, então o `authz:funcoes:prod` verde **não é evidência de
+> que a migration foi colada** — é evidência de que prod bate com o contrato, que já batia. É o
+> caso em que a "query de validação pós-apply" do ritual `lovable-db-operator` não consegue
+> discriminar, e dizer isso vale mais do que entregar uma query que finge discriminar. O único
+> observável do apply é o `INSERT` opcional em `supabase_migrations.schema_migrations`.
+
+**Prova executada** — `db/test-authz-fecho-execute-registrado.sh` (PG17 descartável, 28 asserts,
+exit 0). Ele reproduz a premissa em vez de presumi-la: aplica o default privilege MEDIDO
+(`public`/`f` → `{postgres,anon,authenticated,service_role}`) e o estado que a `20260510235956`
+deixava, e só então roda a migration real. O que ficou provado, e não alegado:
+
+| # | asserção |
+|---|---|
+| A1c | sem esta migration, um replay do repo faz `cmc_ledger_capture` nascer alcançável por **`anon`** |
+| A2 | `REVOKE … FROM PUBLIC` **não** tira `authenticated` nem `anon` — a armadilha nº 1 de `database.md`, executada |
+| A3-A5b | depois da migration, as 2 roles do browser não alcançam nenhuma das 3 |
+| A6 | `service_role` **mantém** EXECUTE nas 3 — o fecho para exatamente onde devia |
+| A7/A8 | o cron (`postgres`, superuser) executa; `authenticated` é barrado com **42501**, com re-raise de qualquer outra SQLSTATE |
+| **A9/A10** | **os 2 triggers DISPARAM para `authenticated` sem EXECUTE na função** — Postgres não checa esse privilégio no disparo, o privilégio checado é o DML na tabela |
+| A12/A12b | os 3 `REVOKE` são **top-level** |
+| F1/F2/F3 | sabotar o REVOKE (tirar `authenticated`; deixar só `PUBLIC`) fica **vermelho**; a migration verdadeira volta ao verde |
+
+**A9/A10 é a asserção que autorizou a entrega.** "Revogar não quebra os triggers" era exatamente o
+tipo de alegação plausível que, errada, derrubaria a escrita em `pedido_compra_sugerido` e
+`inventory_position`. Provada executando, virou fato.
+
+**A12 congela uma falha silenciosa nova.** O parser de `scripts/lib/authz-funcoes.ts` julga
+statements que começam com o verbo, sobre um SQL sem comentários/strings — mas `stripNoise` **não
+trata dollar-quote**. Um `REVOKE` embrulhado em `DO $$ … $$` deixa de ser statement para o gate: o
+banco fecharia igual, a âncora ficaria **muda**, e a migration não cumpriria o que se propõe sem
+nada ficar vermelho. É a razão de os 3 REVOKE serem top-level, e A12 é o que impede alguém de
+"melhorar" isso depois com um guard de existência.

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,14 +21,14 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **473** custom migrations totais
-- **1606** objetos esperados (criados por estas migrations)
+- **475** custom migrations totais
+- **1616** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 486
-  - `rls_policy`: 398
-  - `index`: 240
+  - `function`: 489
+  - `rls_policy`: 400
+  - `index`: 243
   - `cron_job`: 164
-  - `table`: 154
+  - `table`: 156
   - `trigger`: 86
   - `view`: 74
   - `enum_value`: 4
@@ -3949,6 +3949,25 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.data_health_watchdog` | — |
+
+### `20260815181500_farmer_geracao_head_sensor.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public.farmer_geracao_registrar` | — |
+| `function` | `public.farmer_recomendacoes_substituir` | — |
+| `function` | `public.farmer_bundle_recomendacoes_substituir` | — |
+| `table` | `public.farmer_geracao_vigente` | — |
+| `table` | `public.farmer_geracao_execucoes` | — |
+| `index` | `public.farmer_geracao_vigente_motor_farmer_uk` | `farmer_geracao_vigente` |
+| `index` | `public.farmer_geracao_execucoes_run_uk` | `farmer_geracao_execucoes` |
+| `index` | `public.farmer_geracao_execucoes_medicao_idx` | `farmer_geracao_execucoes` |
+| `rls_policy` | `public.fgv_select_carteira` | `farmer_geracao_vigente` |
+| `rls_policy` | `public.fge_select_carteira` | `farmer_geracao_execucoes` |
+
+### `20260818121919_authz_fecho_execute_registrado_3_funcoes.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 473
+-- Total de custom migrations: 475
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -514,7 +514,9 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260814160441', 'fu4f_fase3_afinidade_colunas_reaplica', '20260814160441_fu4f_fase3_afinidade_colunas_reaplica.sql'),
   ('20260814222000', 'data_health_watchdog_reemissao', '20260814222000_data_health_watchdog_reemissao.sql'),
   ('20260814223445', 'farmer_recomendacoes_geracao_vigente', '20260814223445_farmer_recomendacoes_geracao_vigente.sql'),
-  ('20260815153218', 'data_health_contrato_severity_idade', '20260815153218_data_health_contrato_severity_idade.sql')
+  ('20260815153218', 'data_health_contrato_severity_idade', '20260815153218_data_health_contrato_severity_idade.sql'),
+  ('20260815181500', 'farmer_geracao_head_sensor', '20260815181500_farmer_geracao_head_sensor.sql'),
+  ('20260818121919', 'authz_fecho_execute_registrado_3_funcoes', '20260818121919_authz_fecho_execute_registrado_3_funcoes.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2109,7 +2111,17 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_fbrec_farmer_status_pendente', 'farmer_bundle_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_frec_exige_run_id', 'farmer_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations'),
-  ('data_health_contrato_severity_idade', 'function', 'public', 'data_health_watchdog', '')
+  ('data_health_contrato_severity_idade', 'function', 'public', 'data_health_watchdog', ''),
+  ('farmer_geracao_head_sensor', 'function', 'public', 'farmer_geracao_registrar', ''),
+  ('farmer_geracao_head_sensor', 'function', 'public', 'farmer_recomendacoes_substituir', ''),
+  ('farmer_geracao_head_sensor', 'function', 'public', 'farmer_bundle_recomendacoes_substituir', ''),
+  ('farmer_geracao_head_sensor', 'table', 'public', 'farmer_geracao_vigente', ''),
+  ('farmer_geracao_head_sensor', 'table', 'public', 'farmer_geracao_execucoes', ''),
+  ('farmer_geracao_head_sensor', 'index', 'public', 'farmer_geracao_vigente_motor_farmer_uk', 'farmer_geracao_vigente'),
+  ('farmer_geracao_head_sensor', 'index', 'public', 'farmer_geracao_execucoes_run_uk', 'farmer_geracao_execucoes'),
+  ('farmer_geracao_head_sensor', 'index', 'public', 'farmer_geracao_execucoes_medicao_idx', 'farmer_geracao_execucoes'),
+  ('farmer_geracao_head_sensor', 'rls_policy', 'public', 'fgv_select_carteira', 'farmer_geracao_vigente'),
+  ('farmer_geracao_head_sensor', 'rls_policy', 'public', 'fge_select_carteira', 'farmer_geracao_execucoes')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3752,7 +3764,17 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('farmer_recomendacoes_geracao_vigente', 'index', 'public', 'idx_fbrec_farmer_status_pendente', 'farmer_bundle_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_frec_exige_run_id', 'farmer_recommendations'),
   ('farmer_recomendacoes_geracao_vigente', 'trigger', 'public', 'trg_fbrec_exige_run_id', 'farmer_bundle_recommendations'),
-  ('data_health_contrato_severity_idade', 'function', 'public', 'data_health_watchdog', '')
+  ('data_health_contrato_severity_idade', 'function', 'public', 'data_health_watchdog', ''),
+  ('farmer_geracao_head_sensor', 'function', 'public', 'farmer_geracao_registrar', ''),
+  ('farmer_geracao_head_sensor', 'function', 'public', 'farmer_recomendacoes_substituir', ''),
+  ('farmer_geracao_head_sensor', 'function', 'public', 'farmer_bundle_recomendacoes_substituir', ''),
+  ('farmer_geracao_head_sensor', 'table', 'public', 'farmer_geracao_vigente', ''),
+  ('farmer_geracao_head_sensor', 'table', 'public', 'farmer_geracao_execucoes', ''),
+  ('farmer_geracao_head_sensor', 'index', 'public', 'farmer_geracao_vigente_motor_farmer_uk', 'farmer_geracao_vigente'),
+  ('farmer_geracao_head_sensor', 'index', 'public', 'farmer_geracao_execucoes_run_uk', 'farmer_geracao_execucoes'),
+  ('farmer_geracao_head_sensor', 'index', 'public', 'farmer_geracao_execucoes_medicao_idx', 'farmer_geracao_execucoes'),
+  ('farmer_geracao_head_sensor', 'rls_policy', 'public', 'fgv_select_carteira', 'farmer_geracao_vigente'),
+  ('farmer_geracao_head_sensor', 'rls_policy', 'public', 'fge_select_carteira', 'farmer_geracao_execucoes')
 )
 SELECT
   e.migration,

--- a/scripts/authz-funcoes-fechadas.ts
+++ b/scripts/authz-funcoes-fechadas.ts
@@ -215,15 +215,14 @@ export const AUTHZ_FUNCOES_FECHADAS: Record<string, FuncaoFechada> = {
     motivo: 'aplica snapshot de reposição — cron/service_role',
   },
   'public.cmc_ledger_capture': {
-    // ⚠️ A ÚNICA das 40 sem âncora no repo: prod tem o ACL fechado
-    // ({postgres,service_role,sandbox_exec}, auth=NÃO, anon=NÃO — medido 2026-08-15), mas
-    // NENHUMA migration emite GRANT/REVOKE sobre ela. O fecho veio de fora do repo (apply à mão
-    // ou snapshot). Declarar uma âncora falsa aqui seria pior que a lacuna: apontaria o gate para
-    // um arquivo que não fecha nada. `null` mantém o FECHO_PENDENTE visível e deixa o audit de
-    // prod ser quem afirma — que é exatamente a divisão de trabalho das duas guardas.
-    fechadaPor: null,
+    // Era a única das 40 sobre a qual NENHUMA migration emitia GRANT ou REVOKE — nem parcial: ela
+    // nasce por `CREATE OR REPLACE` em 20260614170000_cmc_ledger.sql e herdava o default
+    // privilege, e o fecho medido em prod ({postgres,service_role,sandbox_exec}, auth=NÃO,
+    // anon=NÃO) vinha inteiramente de fora do repo. A âncora abaixo REGISTRA esse fecho (no-op em
+    // prod, de propósito), que é o que a traz para dentro da vigilância estática da Parte E.
+    fechadaPor: '20260818121919_authz_fecho_execute_registrado_3_funcoes.sql',
     permitido: PORTA_FECHADA,
-    motivo: 'captura no ledger de cmc (trigger/service_role) — fechada em prod, fecho AUSENTE do repo',
+    motivo: 'captura no ledger de cmc — trigger trg_cmc_ledger_capture em inventory_position',
   },
   'public.reposicao_cold_start_parametros': {
     fechadaPor: '20260627130000_reposicao_cold_start_fix_gate_cron.sql',
@@ -246,21 +245,20 @@ export const AUTHZ_FUNCOES_FECHADAS: Record<string, FuncaoFechada> = {
     permitido: PORTA_GATE,
     motivo: 'margem por faixa na carteira — o vendedor no browser alcança; fecha por escopo+projeção',
   },
-  // ⚠️ REVELADA pelo detector, e baselinada em vez de acomodada (§7 do histórico). A única
-  // migration que toca o ACL desta é a 20260510235956 ("Fatia E3 Fase 1"), que revoga de
-  // `PUBLIC, anon` e **mantém `GRANT EXECUTE … TO authenticated`** — o repo, portanto, AFIRMA que
-  // authenticated executa. Prod diz o contrário (medido 2026-08-15: auth=NÃO, ACL explícito
-  // `{postgres,service_role,sandbox_exec}`), logo o REVOKE de `authenticated` aconteceu FORA do
-  // repo. Declarar `permitido.authenticated = true` para calar o gate seria fabricar contrato
-  // falso na pior direção: passaria a AUTORIZAR a role que hoje não alcança, e um DROP+CREATE que
-  // a reabrisse ficaria verde. `fechadaPor: null` diz a verdade — o fecho não está no repo, o
-  // gate estático não a vigia, e quem afirma o ACL dela é `bun run authz:funcoes:prod`.
+  // ⚠️ REVELADA pelo detector, e baselinada em vez de acomodada (§7 do histórico). Até
+  // 20260818121919, a última migration a tocar o ACL desta era a 20260510235956 ("Fatia E3
+  // Fase 1"), que revoga de `PUBLIC, anon` e **mantém `GRANT EXECUTE … TO authenticated`** — ou
+  // seja, o repo AFIRMAVA que authenticated executa, enquanto prod dizia o contrário (medido
+  // 2026-08-15 e reconfirmado 2026-08-18: auth=NÃO, ACL `{postgres,service_role,sandbox_exec}`).
+  // A saída NÃO foi declarar `permitido.authenticated = true` para calar o gate — isso fabricaria
+  // contrato falso na pior direção, AUTORIZANDO a role que hoje não alcança e deixando verde um
+  // DROP+CREATE que a reabrisse. Foi REGISTRAR o fecho: a âncora abaixo revoga de `authenticated`
+  // por NOME (revogar de PUBLIC não a tiraria), no-op em prod, e o gate estático passa a vigiar.
   'public.detectar_skus_sem_grupo': {
-    fechadaPor: null,
+    fechadaPor: '20260818121919_authz_fecho_execute_registrado_3_funcoes.sql',
     permitido: PORTA_FECHADA,
     motivo:
-      'self-heal de SKU sem grupo — cron detectar-outliers-diario; fechada para authenticated em PROD, ' +
-      'e esse fecho NÃO está no repo (a 20260510235956 ainda concede a authenticated)',
+      'self-heal de SKU sem grupo — cron detectar-outliers-diario, que roda como postgres (superuser)',
   },
   'public.reposicao_alerta_pedido_minimo_tick': {
     fechadaPor: '20260615210000_reposicao_auto_aprovacao_v2.sql',
@@ -302,12 +300,15 @@ export const AUTHZ_FUNCOES_FECHADAS: Record<string, FuncaoFechada> = {
     permitido: PORTA_FECHADA,
     motivo: 'arredonda/persiste qtde inteira do pedido — edge disparar-pedidos-aprovados',
   },
-  // ⚠️ Mesmo caso da `detectar_skus_sem_grupo` acima, mesma migration, mesma razão para o `null`.
+  // ⚠️ Mesmo caso da `detectar_skus_sem_grupo` acima — mesma 20260510235956 concedendo a
+  // authenticated, mesma âncora registrando o fecho. Sendo `RETURNS trigger`, o EXECUTE nem é o
+  // que a faz rodar: Postgres não checa esse privilégio no disparo do trigger (provado em
+  // db/test-authz-fecho-execute-registrado.sh), então aqui o fecho é 2ª tranca — vale contra a
+  // chamada DIRETA por PostgREST, não contra o trigger.
   'public.set_status_envio_portal_on_disparo': {
-    fechadaPor: null,
+    fechadaPor: '20260818121919_authz_fecho_execute_registrado_3_funcoes.sql',
     permitido: PORTA_FECHADA,
     motivo:
-      'RETURNS trigger em pedido_compra_sugerido (sem rota PostgREST, o fecho é 2ª tranca); fechada ' +
-      'para authenticated em PROD, e esse fecho NÃO está no repo (a 20260510235956 ainda concede)',
+      'RETURNS trigger em pedido_compra_sugerido (trg_set_status_envio_portal), sem rota PostgREST',
   },
 };

--- a/supabase/migrations/20260818121919_authz_fecho_execute_registrado_3_funcoes.sql
+++ b/supabase/migrations/20260818121919_authz_fecho_execute_registrado_3_funcoes.sql
@@ -1,0 +1,67 @@
+-- ============================================================================================
+-- authz — REGISTRA NO REPO o fecho de EXECUTE de 3 funções que só existia em PRODUÇÃO
+-- ============================================================================================
+-- Follow-up da Parte E do `authz:check` (§9.4 / §9.6 item 2 de
+-- docs/historico/sentinela-authz-controle-nao-mencao.md).
+--
+-- O QUE ESTA MIGRATION MUDA EM PROD: **NADA**. É deliberado — ela não corrige um buraco, ela
+-- corrige uma LACUNA DE REGISTRO. As 3 funções abaixo já estão fechadas no banco; o que não
+-- existia era uma migration que dissesse isso. Sem âncora no repo, `fechadaPor` era `null` e o
+-- gate estático do CI **não as vigiava**: a única guarda era alguém lembrar de rodar
+-- `bun run authz:funcoes:prod` à mão. Depois desta, as 3 entram na vigilância da Parte E.
+--
+-- MEDIÇÃO QUE JUSTIFICA CADA LINHA (psql-ro, `has_function_privilege` + `proacl` cru;
+-- 2026-08-15, RECONFIRMADA em 2026-08-18) — as 3 idênticas:
+--     anon = NÃO · authenticated = NÃO · proacl = {postgres=X, service_role=X, sandbox_exec=X}
+-- Logo todo REVOKE aqui é NO-OP no banco de hoje. O valor é outro, e é duplo:
+--   (a) traz as 3 para o gate estático (a reabertura por `DROP`+`CREATE` passa a ser pega no PR);
+--   (b) um replay do repo (DR) passa a reproduzir o ACL de prod. Hoje NÃO reproduz: veja abaixo.
+--
+-- POR QUE O REPO DIVERGIA DE PROD, função a função:
+--   · detectar_skus_sem_grupo / set_status_envio_portal_on_disparo — a última migration a tocar
+--     o ACL delas é a 20260510235956 ("Fatia E3 Fase 1"), que revoga de `PUBLIC, anon` e
+--     **MANTÉM `GRANT EXECUTE … TO authenticated`** (linhas 31-32 e 64-65 de lá). O repo, portanto,
+--     AFIRMA que `authenticated` executa; prod diz o contrário. O REVOKE de `authenticated`
+--     aconteceu FORA do repo (apply à mão, ou baseline parqueado no snapshot).
+--   · cmc_ledger_capture — NENHUMA migration do repo emite GRANT ou REVOKE sobre ela, nem
+--     parcial. Ela é criada por `CREATE OR REPLACE` em 20260614170000_cmc_ledger.sql e herda o
+--     default privilege; o fecho veio inteiramente de fora do repo.
+--
+-- ⚠️ POR QUE REVOGAR **POR NOME**, e não só de PUBLIC (armadilha nº 1 de docs/agent/database.md):
+--     `REVOKE … FROM PUBLIC` **NÃO** tira `anon`/`authenticated`. O EXECUTE delas é grant
+--     EXPLÍCITO, herdado por NOME do default privilege do schema `public` — que é
+--     {postgres, anon, authenticated, service_role} (MEDIDO em `pg_default_acl`, não presumido).
+--     Uma migration que revogasse só de PUBLIC ficaria verde por cima do buraco: é exatamente o
+--     falso-fecho que a 20260510235956 produziu para `anon` e que esta linha fecha para
+--     `authenticated`. `PUBLIC` continua na lista por idempotência/reafirmação, não como o fecho.
+--
+-- ⚠️ POR QUE OS `REVOKE` SÃO TOP-LEVEL (e não embrulhados em `DO $$ … $$`): o parser do gate
+--     (scripts/lib/authz-funcoes.ts) julga statements que COMEÇAM com o verbo, sobre um SQL sem
+--     comentários/strings. Dentro de um bloco `DO`, o REVOKE deixa de ser um statement e o gate
+--     não o enxerga — a âncora ficaria muda e esta migration não cumpriria o que se propõe.
+--     Não há perda: `REVOKE` é idempotente por natureza, re-colar é seguro.
+--
+-- ⚠️ `service_role` NÃO é tocado — é ele que faz as 3 funcionarem (ver abaixo). Revogar dele
+--     quebraria cron, trigger e edge de uma vez.
+--
+-- OS CONSUMIDORES CONTINUAM FUNCIONANDO (medido em prod, 2026-08-18 — nenhum entra como
+-- `authenticated` via PostgREST):
+--   · detectar_skus_sem_grupo(p_empresa text) → cron `detectar-outliers-diario`, que roda com
+--     `username = postgres` (superuser: imune a REVOKE). Nenhuma chamada em src/ ou
+--     supabase/functions/ — a única menção no frontend é a assinatura em types.ts (gerada).
+--   · set_status_envio_portal_on_disparo() → trigger `trg_set_status_envio_portal` em
+--     `pedido_compra_sugerido`.
+--   · cmc_ledger_capture() → trigger `trg_cmc_ledger_capture` em `inventory_position`.
+--     Postgres **não** checa EXECUTE da função de trigger no disparo (o privilégio checado é o
+--     DML na tabela), então revogar de `authenticated` não impede o trigger de rodar para um
+--     usuário autenticado que escreve na tabela. Isso não é folclore: está PROVADO executando em
+--     db/test-authz-fecho-execute-registrado.sh (PG17), com falsificação.
+--
+-- Idempotente: `REVOKE` de privilégio ausente é no-op. Pode ser colada mais de uma vez.
+-- ============================================================================================
+
+REVOKE EXECUTE ON FUNCTION public.detectar_skus_sem_grupo(p_empresa text) FROM PUBLIC, anon, authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.set_status_envio_portal_on_disparo() FROM PUBLIC, anon, authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.cmc_ledger_capture() FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
Follow-up do #1768 (§9.4 e §9.6 item 2 de `docs/historico/sentinela-authz-controle-nao-mencao.md`).

## O problema

`detectar_skus_sem_grupo`, `set_status_envio_portal_on_disparo` e `cmc_ledger_capture` estavam com `fechadaPor: null` na allowlist da Parte E — **não porque estivessem abertas**, mas porque o fecho delas existia só em PROD, sem nenhuma migration que o registrasse. Consequência declarada no próprio #1768: o gate estático **não as vigiava**; a única guarda era alguém lembrar de rodar `bun run authz:funcoes:prod` à mão.

- 2 delas (`detectar_skus_sem_grupo`, `set_status_envio_portal_on_disparo`): a `20260510235956` ("Fatia E3 Fase 1") revoga de `PUBLIC, anon` e **mantém `GRANT EXECUTE … TO authenticated`** — o repo AFIRMAVA o oposto de prod.
- `cmc_ledger_capture`: **nenhuma** migration emitia GRANT/REVOKE sobre ela. Num replay do repo ela nasce alcançável **até por `anon`** (provado, assert A1c).

## O que entra

Uma migration com 3 `REVOKE EXECUTE … FROM PUBLIC, anon, authenticated` + as 3 âncoras apontadas em `scripts/authz-funcoes-fechadas.ts`.

**É NO-OP em prod, e isso é o ponto.** As 3 já estão em `{postgres,service_role,sandbox_exec}` (medido psql-ro 2026-08-15, reconfirmado 2026-08-18). O ganho é (a) o vetor `DROP`+`CREATE` nelas passa a ser pego no PR e (b) um replay do repo (DR) passa a reproduzir o ACL de prod — antes não reproduzia.

Duas decisões de desenho que não são cosméticas:
- **Revoga por NOME**, não só de `PUBLIC`: o grant de `anon`/`authenticated` é explícito, vindo do default privilege. `REVOKE … FROM PUBLIC` não o tira (armadilha nº 1 de `docs/agent/database.md` — provada no assert A2).
- **REVOKE top-level**, nunca em `DO $$`: `stripNoise` não trata dollar-quote, então dentro de um bloco `DO` o REVOKE deixa de ser statement para o parser do gate — o banco fecharia igual, a âncora ficaria **muda**, e a migration não cumpriria o que se propõe sem nada ficar vermelho. O assert A12 congela isso.

## Os consumidores continuam funcionando (medido, não alegado)

| função | consumidor | por que o revoke não a atinge |
|---|---|---|
| `detectar_skus_sem_grupo` | cron `detectar-outliers-diario` | roda com `username=postgres` (superuser) |
| `set_status_envio_portal_on_disparo` | trigger `trg_set_status_envio_portal` | Postgres não checa EXECUTE no disparo do trigger |
| `cmc_ledger_capture` | trigger `trg_cmc_ledger_capture` | idem |

`service_role` mantém EXECUTE nas 3. Nenhuma chamada em `src/` ou `supabase/functions/`.

## Evidência

| o quê | resultado |
|---|---|
| `bun run authz:check` | exit 0 — os 3 `FUNCAO_FECHO_PENDENTE` sumiram (11 → 8 avisos) |
| `bun run authz:funcoes:prod` | exit 0 — **40 vigiadas, 0 fora do repo** (o `⚠️` do verde sumiu) |
| `db/test-authz-fecho-execute-registrado.sh` (PG17) | **28 asserts, 0 falhas**, com falsificação F1/F2 vermelhas e contraprova F3 verde |
| `db/test-authz-funcoes-falsificacao.sh` | exit 0 nos **dois** locales (`C` e `pt_BR.UTF-8`), 16 OK / 0 falhas |
| `shellcheck` do harness novo | 0 achados |
| `bun run wt:preflight --full` | 🟢 sem colisão (99.246 objetos concorrentes) |

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `20260818121919_authz_fecho_execute_registrado_3_funcoes.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco.

> **Mas leia antes de colar:** como a migration é no-op em prod, o apply é **inobservável por ACL** — `has_function_privilege` devolve o mesmo antes e depois. O `authz:funcoes:prod` verde **não prova** que foi colada (ele já estava verde). Colar é seguro e idempotente; o único observável é o `INSERT` opcional no ledger de migrations.

<details><summary>SQL pra aplicar</summary>

```sql
-- ============================================================================================
-- authz — REGISTRA NO REPO o fecho de EXECUTE de 3 funções que só existia em PRODUÇÃO
-- ============================================================================================
-- Follow-up da Parte E do `authz:check` (§9.4 / §9.6 item 2 de
-- docs/historico/sentinela-authz-controle-nao-mencao.md).
--
-- O QUE ESTA MIGRATION MUDA EM PROD: **NADA**. É deliberado — ela não corrige um buraco, ela
-- corrige uma LACUNA DE REGISTRO. As 3 funções abaixo já estão fechadas no banco; o que não
-- existia era uma migration que dissesse isso. Sem âncora no repo, `fechadaPor` era `null` e o
-- gate estático do CI **não as vigiava**: a única guarda era alguém lembrar de rodar
-- `bun run authz:funcoes:prod` à mão. Depois desta, as 3 entram na vigilância da Parte E.
--
-- MEDIÇÃO QUE JUSTIFICA CADA LINHA (psql-ro, `has_function_privilege` + `proacl` cru;
-- 2026-08-15, RECONFIRMADA em 2026-08-18) — as 3 idênticas:
--     anon = NÃO · authenticated = NÃO · proacl = {postgres=X, service_role=X, sandbox_exec=X}
-- Logo todo REVOKE aqui é NO-OP no banco de hoje. O valor é outro, e é duplo:
--   (a) traz as 3 para o gate estático (a reabertura por `DROP`+`CREATE` passa a ser pega no PR);
--   (b) um replay do repo (DR) passa a reproduzir o ACL de prod. Hoje NÃO reproduz: veja abaixo.
--
-- POR QUE O REPO DIVERGIA DE PROD, função a função:
--   · detectar_skus_sem_grupo / set_status_envio_portal_on_disparo — a última migration a tocar
--     o ACL delas é a 20260510235956 ("Fatia E3 Fase 1"), que revoga de `PUBLIC, anon` e
--     **MANTÉM `GRANT EXECUTE … TO authenticated`** (linhas 31-32 e 64-65 de lá). O repo, portanto,
--     AFIRMA que `authenticated` executa; prod diz o contrário. O REVOKE de `authenticated`
--     aconteceu FORA do repo (apply à mão, ou baseline parqueado no snapshot).
--   · cmc_ledger_capture — NENHUMA migration do repo emite GRANT ou REVOKE sobre ela, nem
--     parcial. Ela é criada por `CREATE OR REPLACE` em 20260614170000_cmc_ledger.sql e herda o
--     default privilege; o fecho veio inteiramente de fora do repo.
--
-- ⚠️ POR QUE REVOGAR **POR NOME**, e não só de PUBLIC (armadilha nº 1 de docs/agent/database.md):
--     `REVOKE … FROM PUBLIC` **NÃO** tira `anon`/`authenticated`. O EXECUTE delas é grant
--     EXPLÍCITO, herdado por NOME do default privilege do schema `public` — que é
--     {postgres, anon, authenticated, service_role} (MEDIDO em `pg_default_acl`, não presumido).
--     Uma migration que revogasse só de PUBLIC ficaria verde por cima do buraco: é exatamente o
--     falso-fecho que a 20260510235956 produziu para `anon` e que esta linha fecha para
--     `authenticated`. `PUBLIC` continua na lista por idempotência/reafirmação, não como o fecho.
--
-- ⚠️ POR QUE OS `REVOKE` SÃO TOP-LEVEL (e não embrulhados em `DO $$ … $$`): o parser do gate
--     (scripts/lib/authz-funcoes.ts) julga statements que COMEÇAM com o verbo, sobre um SQL sem
--     comentários/strings. Dentro de um bloco `DO`, o REVOKE deixa de ser um statement e o gate
--     não o enxerga — a âncora ficaria muda e esta migration não cumpriria o que se propõe.
--     Não há perda: `REVOKE` é idempotente por natureza, re-colar é seguro.
--
-- ⚠️ `service_role` NÃO é tocado — é ele que faz as 3 funcionarem (ver abaixo). Revogar dele
--     quebraria cron, trigger e edge de uma vez.
--
-- OS CONSUMIDORES CONTINUAM FUNCIONANDO (medido em prod, 2026-08-18 — nenhum entra como
-- `authenticated` via PostgREST):
--   · detectar_skus_sem_grupo(p_empresa text) → cron `detectar-outliers-diario`, que roda com
--     `username = postgres` (superuser: imune a REVOKE). Nenhuma chamada em src/ ou
--     supabase/functions/ — a única menção no frontend é a assinatura em types.ts (gerada).
--   · set_status_envio_portal_on_disparo() → trigger `trg_set_status_envio_portal` em
--     `pedido_compra_sugerido`.
--   · cmc_ledger_capture() → trigger `trg_cmc_ledger_capture` em `inventory_position`.
--     Postgres **não** checa EXECUTE da função de trigger no disparo (o privilégio checado é o
--     DML na tabela), então revogar de `authenticated` não impede o trigger de rodar para um
--     usuário autenticado que escreve na tabela. Isso não é folclore: está PROVADO executando em
--     db/test-authz-fecho-execute-registrado.sh (PG17), com falsificação.
--
-- Idempotente: `REVOKE` de privilégio ausente é no-op. Pode ser colada mais de uma vez.
-- ============================================================================================

REVOKE EXECUTE ON FUNCTION public.detectar_skus_sem_grupo(p_empresa text) FROM PUBLIC, anon, authenticated;

REVOKE EXECUTE ON FUNCTION public.set_status_envio_portal_on_disparo() FROM PUBLIC, anon, authenticated;

REVOKE EXECUTE ON FUNCTION public.cmc_ledger_capture() FROM PUBLIC, anon, authenticated;
```
</details>
