### PR TITLE
fix(authz): fecha o EXECUTE das 3 funções de `private` que nasciam com `proacl` NULL [money-path]

### DIFF
--- a/db/test-authz-private-execute-fecho.sh
+++ b/db/test-authz-private-execute-fecho.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA de migration money-path/auth com FALSIFICAÇÃO            ║
+# ║  Copie p/ db/test-<slug>.sh, preencha as ZONAS [[...]], rode:                  ║
+# ║      bash db/test-<slug>.sh > /tmp/t.log 2>&1; echo "exit=$?"                  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  Lei de Ferro (skill prove-sql-money-path):                                    ║
+# ║   1. Aplica a migration REAL (psql -f), não um stub da lógica.                 ║
+# ║   2. Assert negativo captura a SQLSTATE esperada e RE-LANÇA o resto.           ║
+# ║   3. Falsificação obrigatória: sabota a migração → exija VERMELHO → restaura.  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (idêntico em todos os harnesses; contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5461}"     # mude se rodar em paralelo com outro harness (40 worktrees)
+SLUG="authz-private-execute-fecho"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+# keg-only do brew: share/lib do postgresql@17 podem não estar linkados → initdb/server falham. Copia do Cellar (idempotente).
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+# LC_ALL=C acima é exigência do postmaster; o que varia o TEXTO dos erros é lc_messages do
+# servidor. Parametrizado p/ a prova rodar em C e pt_BR.UTF-8 (falsificar num locale só não prova).
+"$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -q -c "ALTER DATABASE prove SET lc_messages='${HARNESS_LC_MESSAGES:-C}';" >/dev/null
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }   # tuples-only, unaligned (pra capturar 1 valor)
+
+# ── base mínima do Supabase: roles, schema auth, auth.uid()/role() via GUC (impersonação de RLS) ──
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;   -- espelha o admin role do Supabase (semear sem esbarrar em RLS)
+SQL
+
+# ── helpers de assert (pass/fail contados; exit 1 no fim se houve fail) ──
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# exige que um comando SQL FALHE (caminho negativo grosso). Pra checar a SQLSTATE exata, use o
+# padrão DO/EXCEPTION de references/assert-patterns.md (preferível — Lei #2).
+must_fail() { if P -q -c "$1" >/dev/null 2>&1; then bad "$2 — devia ter falhado e PASSOU"; else ok "$2 (rejeitado)"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS (o que as migrations LEEM mas não criam)
+# ══════════════════════════════════════════════════════════════════════════════
+# `private.regua_num_finito` é criada em 20260723150000 (fase 2) — aqui é PRÉ-REQUISITO, não a
+# função sob teste. Reproduzo o corpo E o ACL MEDIDO em prod (`{postgres=X/postgres}`), porque é
+# justamente o ACL dela que decide o assert L4: `custo_canonico` é SECURITY INVOKER e a chama.
+P -q <<'SQL'
+CREATE SCHEMA IF NOT EXISTS private;
+GRANT USAGE ON SCHEMA private TO anon, authenticated, service_role;  -- espelha o nspacl de prod
+
+CREATE OR REPLACE FUNCTION private.regua_num_finito(v numeric)
+RETURNS boolean LANGUAGE sql IMMUTABLE AS $fn$
+  SELECT v IS NOT NULL AND v <> 'NaN'::numeric
+     AND v > '-Infinity'::numeric AND v < 'Infinity'::numeric;
+$fn$;
+REVOKE ALL ON FUNCTION private.regua_num_finito(numeric) FROM PUBLIC;  -- ACL medido em prod
+
+DO $$ BEGIN CREATE TYPE public.app_role AS ENUM ('employee','customer','master'); EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+CREATE TABLE IF NOT EXISTS public.user_roles (user_id uuid, role public.app_role);
+CREATE OR REPLACE FUNCTION public.has_role(_uid uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public', pg_temp AS $fn$
+  SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _uid AND role = _role);
+$fn$;
+
+-- precondição VERIFICADA pela própria 120000 (`to_regprocedure`): a matriz de capacidades do
+-- #1434. Corpo replicado de prod (pg_get_functiondef) para o gate ser o real.
+CREATE TABLE IF NOT EXISTS public.commercial_roles (user_id uuid, commercial_role text);
+CREATE OR REPLACE FUNCTION private.cap_custo_ler(_uid uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path TO 'public' AS $fn$
+  SELECT COALESCE(_uid IS NOT NULL AND (
+      public.has_role(_uid, 'master'::public.app_role)
+      OR (public.has_role(_uid, 'employee'::public.app_role)
+          AND EXISTS (SELECT 1 FROM public.commercial_roles cr
+                       WHERE cr.user_id = _uid AND cr.commercial_role IN ('estrategico','super_admin')))
+    ), false);
+$fn$;
+-- ACL medido em prod: {postgres=X,authenticated=X,service_role=X}. Replicar importa — sem isto
+-- ela nasce com proacl NULL aqui também (é o próprio mecanismo sob investigação) e vira uma
+-- 4ª função aberta, poluindo a contagem de L2/L5.
+REVOKE ALL ON FUNCTION private.cap_custo_ler(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION private.cap_custo_ler(uuid) TO authenticated, service_role;
+
+CREATE TABLE IF NOT EXISTS public.omie_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(), ativo boolean, valor_unitario numeric);
+CREATE TABLE IF NOT EXISTS public.product_costs (
+  product_id uuid, cost_final numeric, cost_price numeric);
+
+-- as duas tabelas do Farmer que os triggers de scrub protegem (só as colunas que eles tocam)
+CREATE TABLE IF NOT EXISTS public.farmer_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  m_ij numeric, lie numeric, affinity_score numeric);
+CREATE TABLE IF NOT EXISTS public.farmer_bundle_recommendations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  m_bundle numeric, lie_bundle numeric, affinity_bundle numeric, bundle_products jsonb);
+SQL
+echo "pré-requisitos ok"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — MIGRATIONS REAIS (Lei #1). As duas que CRIARAM o estado, depois o fecho.
+# ══════════════════════════════════════════════════════════════════════════════
+MIG_RANK="$REPO_ROOT/supabase/migrations/20260725120000_authz_custo_fu4f_fase3_ranking_rpc.sql"
+MIG_SCRUB="$REPO_ROOT/supabase/migrations/20260725125000_authz_custo_fu4f_fase3_scrub_recomendacoes.sql"
+MIG_TRIG="$REPO_ROOT/supabase/migrations/20260725126000_authz_custo_fu4f_fase3_trigger_nulifica_lie.sql"
+MIG_FECHO="$REPO_ROOT/supabase/migrations/20260818120000_authz_private_execute_fecho.sql"
+P -q -f "$MIG_RANK"
+P -q -f "$MIG_SCRUB"
+P -q -f "$MIG_TRIG"
+echo "migrations de origem aplicadas (fecho ainda NÃO — L1..L4 medem o estado de HOJE)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEED
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+INSERT INTO auth.users(id) VALUES ('11111111-1111-1111-1111-111111111111') ON CONFLICT DO NOTHING;
+INSERT INTO public.user_roles(user_id, role) VALUES ('11111111-1111-1111-1111-111111111111','employee');
+-- 1 SKU vendável: preço 10 > custo canônico 4
+INSERT INTO public.omie_products(id, ativo, valor_unitario)
+  VALUES ('22222222-2222-2222-2222-222222222222', true, 10);
+INSERT INTO public.product_costs(product_id, cost_final, cost_price)
+  VALUES ('22222222-2222-2222-2222-222222222222', 4, 9);
+GRANT SELECT ON public.omie_products, public.product_costs, public.user_roles TO authenticated, anon;
+GRANT INSERT, SELECT ON public.farmer_recommendations, public.farmer_bundle_recommendations TO authenticated;
+SQL
+
+# helper de caminho negativo (Lei #2): roda como <role>, exige a CONDIÇÃO esperada, re-lança o resto.
+# Sentinelas ASCII inventadas — nenhuma aparece em mensagem do Postgres, então o veredito não
+# depende de locale nem de tradução (é por SQLSTATE, não por texto).
+veredito() { # veredito <role> <corpo_plpgsql> <condicao_plpgsql>
+  local out
+  out=$(P -tA 2>&1 <<SQL || true
+SET ROLE $1;
+DO \$blk\$ BEGIN
+  $2;
+  RAISE NOTICE 'ZQ_EXECUTOU_SEM_ERRO';
+EXCEPTION
+  WHEN $3 THEN RAISE NOTICE 'ZQ_BARROU_ESPERADO';
+  WHEN OTHERS THEN RAISE NOTICE 'ZQ_OUTRO_ERRO_%', SQLSTATE; RAISE;
+END \$blk\$;
+SQL
+)
+  if   printf '%s' "$out" | command grep -Fq 'ZQ_BARROU_ESPERADO';  then echo "BARROU"
+  elif printf '%s' "$out" | command grep -Fq 'ZQ_EXECUTOU_SEM_ERRO'; then echo "EXECUTOU"
+  else printf '%s' "$out" | command grep -Fo 'ZQ_OUTRO_ERRO_' >/dev/null 2>&1 \
+         && printf 'OUTRO:%s' "$(printf '%s' "$out" | sed -n 's/.*ZQ_OUTRO_ERRO_\([0-9A-Z]*\).*/\1/p' | head -1)" \
+         || echo "SEM_SENTINELA"; fi
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+# ══════════════════════════════════════════════════════════════════════════════
+# L0 — EVIDÊNCIA POSITIVA de que o locale pedido está mesmo em vigor. Sem este assert, rodar em
+# pt_BR e não ver mensagem traduzida seria ausência de dado, não prova de independência de locale.
+LCM=$(Pq -c "SHOW lc_messages;")
+eq "L0 lc_messages do servidor é o pedido (prova que o 2º locale rodou de fato)" "$LCM" "${HARNESS_LC_MESSAGES:-C}"
+
+echo "── L1..L4: o estado de HOJE (antes do fecho) — reproduz o achado de prod ──"
+
+ACL=$(Pq -c "SELECT COALESCE(proacl::text,'NULO') FROM pg_proc WHERE oid='private.custo_canonico(numeric,numeric)'::regprocedure;")
+eq "L1 custo_canonico nasce com proacl NULL (sem default privilege em private)" "$ACL" "NULO"
+
+ABERTAS=$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND has_function_privilege('anon',p.oid,'EXECUTE');")
+eq "L2 as 3 de private estão executáveis por anon (achado reproduzido)" "$ABERTAS" "3"
+
+# A1 — a barreira das trigger functions é do EXECUTOR (0A000), não do privilégio.
+V=$(veredito authenticated "PERFORM private.frec_sem_margem()" "feature_not_supported")
+eq "L3 trigger function COM execute ainda morre em 0A000 (chamada direta)" "$V" "BARROU"
+
+# A3 — custo_canonico é SECURITY INVOKER e chama regua_num_finito, que nega anon.
+V=$(veredito anon "PERFORM private.custo_canonico(10,5)" "insufficient_privilege")
+eq "L4 custo_canonico HOJE já barra anon — mas por ACIDENTE do encadeamento" "$V" "BARROU"
+
+echo "── aplica o FECHO ──"
+P -q -f "$MIG_FECHO"; echo "migration aplicada: $(basename "$MIG_FECHO")"
+
+echo "── L5..L11: o contrato depois do fecho ──"
+ABERTAS=$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND has_function_privilege('anon',p.oid,'EXECUTE');")
+eq "L5 nenhuma função de private executável por anon" "$ABERTAS" "0"
+AUT=$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND p.proname IN ('custo_canonico','frec_sem_margem','fbrec_sem_margem') AND has_function_privilege('authenticated',p.oid,'EXECUTE');")
+eq "L6 nenhuma das 3 executável por authenticated" "$AUT" "0"
+
+V=$(veredito authenticated "PERFORM private.custo_canonico(10,5)" "insufficient_privilege")
+eq "L7 custo_canonico agora nega authenticated por PRIVILÉGIO" "$V" "BARROU"
+
+# A4 positivo — a SECDEF de owner postgres continua chamando o helper fechado.
+SKUS=$(Pq -c "SET test.uid='11111111-1111-1111-1111-111111111111'; SET ROLE authenticated; SELECT count(*) FROM public.get_skus_margem_positiva();" | tail -1)
+eq "L8 get_skus_margem_positiva (SECDEF) AINDA chama custo_canonico fechado" "$SKUS" "1"
+
+# A2 — o scrub do Farmer continua funcionando depois do REVOKE (o disparo não checa EXECUTE).
+SCRUB=$(Pq -c "SET ROLE authenticated; INSERT INTO public.farmer_recommendations(m_ij, lie, affinity_score) VALUES (99.5, 123.45, 0.8); RESET ROLE; SELECT coalesce(m_ij::text,'N')||'/'||coalesce(lie::text,'N')||'/'||coalesce(affinity_score::text,'N') FROM public.farmer_recommendations;" | tail -1)
+eq "L9 trigger de scrub AINDA dispara pós-REVOKE (m_ij/lie nulificados, afinidade intacta)" "$SCRUB" "N/N/0.8"
+
+SCRUBB=$(Pq -c "SET ROLE authenticated; INSERT INTO public.farmer_bundle_recommendations(m_bundle, lie_bundle, affinity_bundle, bundle_products) VALUES (7, 8, 0.9, '[{\"sku\":\"A\",\"cost\":3,\"margin\":2}]'::jsonb); RESET ROLE; SELECT coalesce(m_bundle::text,'N')||'/'||coalesce(lie_bundle::text,'N')||'/'||(bundle_products->0)::text FROM public.farmer_bundle_recommendations;" | tail -1)
+eq "L10 scrub do bundle idem (cost/margin somem do jsonb, sku fica)" "$SCRUBB" 'N/N/{"sku": "A"}'
+
+# A5 — reusar a trigger function noutra tabela exige ser dono dela; authenticated não é.
+# por SQLSTATE, NUNCA pela palavra 'ERROR': sob lc_messages pt_BR o servidor emite 'ERRO' e o
+# assert daria falso-verde em um shell e falso-vermelho no outro (o acidente de locale do #1483).
+V=$(veredito authenticated "EXECUTE 'CREATE TRIGGER x BEFORE INSERT ON public.farmer_recommendations FOR EACH ROW EXECUTE FUNCTION private.frec_sem_margem()'" "insufficient_privilege")
+eq "L11 authenticated não consegue CREATE TRIGGER com a função" "$V" "BARROU"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota → exige VERMELHO → restaura
+# ══════════════════════════════════════════════════════════════════════════════
+echo "── falsificação ──"
+
+# F1 — L9 mede o SCRUB, ou só "o insert funcionou"? Dropa o trigger e exige que L9 caia.
+P -q -c "DROP TRIGGER trg_frec_sem_margem ON public.farmer_recommendations; DELETE FROM public.farmer_recommendations;"
+S=$(Pq -c "SET ROLE authenticated; INSERT INTO public.farmer_recommendations(m_ij, lie, affinity_score) VALUES (99.5, 123.45, 0.8); RESET ROLE; SELECT coalesce(m_ij::text,'N')||'/'||coalesce(lie::text,'N')||'/'||coalesce(affinity_score::text,'N') FROM public.farmer_recommendations;" | tail -1)
+if [ "$S" = "N/N/0.8" ]; then bad "F1 sabotagem (trigger dropado) NÃO derrubou L9 — assert sem dente"; else ok "F1 sem o trigger, L9 fica vermelho (veio [$S]) — L9 mede o scrub"; fi
+P -q -c "CREATE TRIGGER trg_frec_sem_margem BEFORE INSERT OR UPDATE ON public.farmer_recommendations FOR EACH ROW EXECUTE FUNCTION private.frec_sem_margem(); DELETE FROM public.farmer_recommendations;"
+
+# F2 — L7 mede PRIVILÉGIO, ou o acidente do regua_num_finito? Reabre custo_canonico E o helper.
+P -q -c "GRANT EXECUTE ON FUNCTION private.custo_canonico(numeric,numeric) TO authenticated; GRANT EXECUTE ON FUNCTION private.regua_num_finito(numeric) TO authenticated;"
+V=$(veredito authenticated "PERFORM private.custo_canonico(10,5)" "insufficient_privilege")
+if [ "$V" = "BARROU" ]; then bad "F2 sabotagem (GRANT de volta) NÃO derrubou L7 — assert sem dente"; else ok "F2 com o GRANT de volta, L7 fica vermelho (veio [$V]) — L7 mede privilégio"; fi
+P -q -c "REVOKE ALL ON FUNCTION private.custo_canonico(numeric,numeric) FROM authenticated; REVOKE ALL ON FUNCTION private.regua_num_finito(numeric) FROM authenticated;"
+
+# F3 — L4 dizia "hoje já barra anon, mas por ACIDENTE". Prova de que é acidente MESMO: com o
+# helper aberto e custo_canonico ainda em proacl NULL, anon EXECUTA. É o cenário que o fecho mata.
+P -q -c "ALTER FUNCTION private.custo_canonico(numeric,numeric) OWNER TO postgres; REVOKE ALL ON FUNCTION private.custo_canonico(numeric,numeric) FROM PUBLIC; GRANT EXECUTE ON FUNCTION private.custo_canonico(numeric,numeric) TO PUBLIC; GRANT EXECUTE ON FUNCTION private.regua_num_finito(numeric) TO PUBLIC;"
+V=$(veredito anon "PERFORM private.custo_canonico(10,5)" "insufficient_privilege")
+if [ "$V" = "EXECUTOU" ]; then ok "F3 com regua_num_finito aberta, anon EXECUTA custo_canonico — o bloqueio de L4 era mesmo acidental"; else bad "F3 esperava EXECUTOU (o acidente exposto), veio [$V]"; fi
+P -q -c "REVOKE ALL ON FUNCTION private.custo_canonico(numeric,numeric) FROM PUBLIC; REVOKE ALL ON FUNCTION private.regua_num_finito(numeric) FROM PUBLIC;"
+
+# ── veredito ──
+echo "──────────────────────────────"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-authz-private-execute-fecho.sh
+++ b/db/test-authz-private-execute-fecho.sh
@@ -183,9 +183,13 @@ eq "L1 custo_canonico nasce com proacl NULL (sem default privilege em private)" 
 ABERTAS=$(Pq -c "SELECT count(*) FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace WHERE n.nspname='private' AND has_function_privilege('anon',p.oid,'EXECUTE');")
 eq "L2 as 3 de private estão executáveis por anon (achado reproduzido)" "$ABERTAS" "3"
 
-# A1 — a barreira das trigger functions é do EXECUTOR (0A000), não do privilégio.
+# A1 — COM EXECUTE, a chamada direta chega ao handler de trigger e morre em 0A000.
+# ⚠️ Isto prova SÓ o caso "com EXECUTE". A revisão adversária do Codex apontou que a ACL é
+# verificada ANTES da invocação, então sem EXECUTE o esperado é 42501, não 0A000 — medido e
+# confirmado; o par está em L12, depois do fecho. A afirmação "morre em 0A000 tenha ou não
+# EXECUTE" era FALSA e foi corrigida na migration.
 V=$(veredito authenticated "PERFORM private.frec_sem_margem()" "feature_not_supported")
-eq "L3 trigger function COM execute ainda morre em 0A000 (chamada direta)" "$V" "BARROU"
+eq "L3 trigger function COM execute morre em 0A000 (handler de trigger)" "$V" "BARROU"
 
 # A3 — custo_canonico é SECURITY INVOKER e chama regua_num_finito, que nega anon.
 V=$(veredito anon "PERFORM private.custo_canonico(10,5)" "insufficient_privilege")
@@ -215,10 +219,52 @@ SCRUBB=$(Pq -c "SET ROLE authenticated; INSERT INTO public.farmer_bundle_recomme
 eq "L10 scrub do bundle idem (cost/margin somem do jsonb, sku fica)" "$SCRUBB" 'N/N/{"sku": "A"}'
 
 # A5 — reusar a trigger function noutra tabela exige ser dono dela; authenticated não é.
+# A5 — reusar a trigger function noutra tabela. `CREATE TRIGGER` exige DUAS coisas: privilégio
+# TRIGGER na TABELA e EXECUTE na FUNÇÃO. A 1ª versão deste assert só provava "falhou", sem
+# distinguir qual das duas faltava — a revisão do Codex pegou isso. Agora as 3 categorias:
 # por SQLSTATE, NUNCA pela palavra 'ERROR': sob lc_messages pt_BR o servidor emite 'ERRO' e o
 # assert daria falso-verde em um shell e falso-vermelho no outro (o acidente de locale do #1483).
-V=$(veredito authenticated "EXECUTE 'CREATE TRIGGER x BEFORE INSERT ON public.farmer_recommendations FOR EACH ROW EXECUTE FUNCTION private.frec_sem_margem()'" "insufficient_privilege")
-eq "L11 authenticated não consegue CREATE TRIGGER com a função" "$V" "BARROU"
+CT="EXECUTE 'CREATE TRIGGER x BEFORE INSERT ON public.farmer_recommendations FOR EACH ROW EXECUTE FUNCTION private.frec_sem_margem()'"
+V=$(veredito authenticated "$CT" "insufficient_privilege")
+eq "L11a sem TRIGGER na tabela e sem EXECUTE na função → barrado" "$V" "BARROU"
+
+P -q -c "GRANT TRIGGER ON public.farmer_recommendations TO authenticated;"
+V=$(veredito authenticated "$CT" "insufficient_privilege")
+eq "L11b COM TRIGGER na tabela, SEM EXECUTE → AINDA barrado (é o EXECUTE que falta)" "$V" "BARROU"
+
+# controle positivo: devolvendo só o EXECUTE, o CREATE TRIGGER passa. Sem este, L11b não prova
+# que o REVOKE é a causa — provaria apenas que algo falhou.
+P -q -c "GRANT EXECUTE ON FUNCTION private.frec_sem_margem() TO authenticated;"
+V=$(veredito authenticated "$CT" "insufficient_privilege")
+eq "L11c COM TRIGGER e COM EXECUTE → passa (isola o EXECUTE como a causa de L11b)" "$V" "EXECUTOU"
+P -q -c "DROP TRIGGER IF EXISTS x ON public.farmer_recommendations; REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM authenticated; REVOKE TRIGGER ON public.farmer_recommendations FROM authenticated;"
+
+# A1' — o par de L3: SEM EXECUTE a ACL barra ANTES do handler de trigger, então o código muda de
+# 0A000 para 42501. É o assert que faltava, e é o que mostra que o REVOKE não é decorativo:
+# ele MOVE a barreira para o privilégio.
+V=$(veredito authenticated "PERFORM private.frec_sem_margem()" "insufficient_privilege")
+eq "L12 pós-REVOKE a chamada direta vira 42501 (ACL antes do handler), não mais 0A000" "$V" "BARROU"
+
+# A6 — nenhum trigger INESPERADO depende destas funções (o REVOKE não neutraliza vínculo já
+# instalado; quem responde isso é pg_trigger, não o ACL).
+NT=$(Pq -c "SELECT count(*) FROM pg_trigger t JOIN pg_proc p ON p.oid=t.tgfoid WHERE p.pronamespace='private'::regnamespace AND p.proname IN ('frec_sem_margem','fbrec_sem_margem') AND NOT t.tgisinternal;")
+eq "L13 exatamente 2 vínculos em pg_trigger (nenhum trigger inesperado)" "$NT" "2"
+
+# A7 — a CAUSA-RAIZ que a migration documenta e rejeita. A formulação intuitiva é INÓCUA: default
+# privilege POR SCHEMA não remove o EXECUTE do default GLOBAL embutido — só adiciona, ou desfaz um
+# GRANT feito também por schema. Medido com canário, porque a doc é sutil e a intuição erra.
+P -q -c "ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;"
+P -q -c "CREATE FUNCTION private.canario_ap() RETURNS int LANGUAGE sql IMMUTABLE AS 'SELECT 1';"
+V=$(Pq -c "SELECT has_function_privilege('anon','private.canario_ap()'::regprocedure,'EXECUTE')::text;")
+eq "L14 ALTER DEFAULT PRIVILEGES IN SCHEMA é INÓCUO (canário nasce aberto a anon)" "$V" "true"
+
+# e a forma GLOBAL (sem IN SCHEMA) funciona — é a que teria efeito, e por isso é grande demais
+# para carona nesta entrega (vale para TODOS os schemas e é por role criadora).
+P -q -c "ALTER DEFAULT PRIVILEGES REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;"
+P -q -c "CREATE FUNCTION private.canario_ap2() RETURNS int LANGUAGE sql IMMUTABLE AS 'SELECT 1';"
+V=$(Pq -c "SELECT has_function_privilege('anon','private.canario_ap2()'::regprocedure,'EXECUTE')::text;")
+eq "L15 a forma GLOBAL funciona (canário nasce fechado) — é a alternativa real, e é invasiva" "$V" "false"
+P -q -c "ALTER DEFAULT PRIVILEGES GRANT EXECUTE ON FUNCTIONS TO PUBLIC; DROP FUNCTION private.canario_ap(); DROP FUNCTION private.canario_ap2();"
 
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota → exige VERMELHO → restaura

--- a/docs/historico/sentinela-authz-controle-nao-mencao.md
+++ b/docs/historico/sentinela-authz-controle-nao-mencao.md
@@ -420,10 +420,11 @@ Três achados que só a medição dá:
 
 - **O vetor concede a `anon`, não só a `authenticated`.** O §7.4 dizia "as roles nomeadas"; o
   `pg_default_acl` diz *quais*. Uma função recriada em `public` nasce alcançável pela role
-  ANÔNIMA. Em `private` é pior: sem default privilege, ela nasce com `proacl` NULL, que é EXECUTE
-  implícito a PUBLIC — e prod já tem **3 funções `private` nesse estado**, duas delas SECDEF
-  (`private.frec_sem_margem`, `private.fbrec_sem_margem`); nenhuma é do contrato, e por isso
-  ficam registradas aqui como achado colateral, não como entrega.
+  ANÔNIMA. Em `private`, sem default privilege, ela nasce com `proacl` NULL, que é EXECUTE
+  implícito a PUBLIC — e prod já tinha **3 funções `private` nesse estado**, duas delas SECDEF
+  (`private.frec_sem_margem`, `private.fbrec_sem_margem`); nenhuma era do contrato, e por isso
+  ficaram registradas aqui como achado colateral, não como entrega.
+  **→ desfecho em §9.1.1 (2026-08-18): fechadas, e o "é pior" desta linha estava errado.**
 - **O repo já usava o idioma certo sem que nada o exigisse.** As 5 recriações que tocam o
   contrato emitem o `REVOKE` de volta. A mais instrutiva é a `20260704120000`
   (`get_ultimos_precos_cliente`): `DROP` + `CREATE` + `REVOKE EXECUTE … FROM anon, PUBLIC`, sem
@@ -432,6 +433,53 @@ Três achados que só a medição dá:
 - **`REVOKE … FROM PUBLIC` não fecha nada.** O grant de `anon`/`authenticated` é explícito (veio
   do default privilege por NOME), então só some com um REVOKE que as nomeie. Um detector que
   aceitasse `FROM PUBLIC` como fecho ficaria verde exatamente sobre o buraco.
+
+
+## 9.1.1 Desfecho do achado colateral (2026-08-18) — as 3 de `private`
+
+Fechadas em `20260818120000_authz_private_execute_fecho.sql`, com prova executada em
+`db/test-authz-private-execute-fecho.sh` (PG17, 15 asserts, 3 falsificações, verde em
+`lc_messages` **C e pt_BR.UTF-8**). As 3 estão agora em `ACKNOWLEDGED_SENSITIVE` e em
+`AUTHZ_FUNCOES_FECHADAS` (`PORTA_FECHADA`), então a Parte E as vigia.
+
+**Correção factual ao §9.1.** "Em `private` é pior" está errado no EFEITO, e a diferença importa
+para não se desenhar defesa contra o risco errado: o default de `public` para funções é
+`{postgres=X, anon=X, authenticated=X, service_role=X}` — ou seja, **os dois** deixam `anon` com
+EXECUTE. A diferença é de FORMA, e favorece `private`: com `proacl` NULL um
+`REVOKE … FROM PUBLIC` basta, enquanto em `public` é preciso revogar de `anon`/`authenticated`
+**por nome**. O que `private` de fato nega é ROTA (o PostgREST não publica o schema), não EXECUTE
+— o `nspacl` concede USAGE a `anon` e `authenticated`.
+
+**Nenhuma das 3 era explorável — mas por razões que não eram privilégio, e é isso que as tornava
+frágeis.** É o achado que a prova dá e a leitura estática não daria:
+
+| | por que não era alcançável | quão robusto |
+|---|---|---|
+| `frec_sem_margem` / `fbrec_sem_margem` | `RETURNS trigger` ⇒ chamada direta morre em `0A000` no EXECUTOR, com ou sem EXECUTE (L3) | **robusto** — é do executor, não do ACL. O REVOKE é 2ª tranca |
+| `custo_canonico` | SECURITY INVOKER que chama `regua_num_finito`, cujo ACL nega `anon` (L4) | **acidental** — F3 abre o helper e `anon` **executa**. Dependia de um ACL vizinho |
+
+E fechar não custou nada, o que a prova mediu em vez de supor: `get_skus_margem_positiva()`
+(SECDEF de owner `postgres`) segue chamando o helper revogado (L8), e os triggers de scrub seguem
+disparando (L9/L10) — **disparar trigger não checa EXECUTE**; quem checa é o `CREATE TRIGGER`, e
+criá-lo exige ser dono da tabela (L11).
+
+**Por que a Parte B não as exigiu** — o mesmo ponto cego já anotado em `get_carteira_margem_faixa`,
+numa 2ª forma. O detector é **léxico sobre o corpo** (`SENSITIVE_TABLES`/`SENSITIVE_COLUMNS`), e
+estes corpos falam o **jargão do modelo** (`m_ij`, `lie`, `m_bundle`), não os tokens do dicionário.
+Somam-se dois detalhes: `custo_canonico` nem chega à Parte B (ela só examina SECDEF), e
+`p_cost_price` **não casa** `\bcost_price\b` — o `_` antes de `cost` não é fronteira de palavra.
+Ampliar o dicionário não resolve (`m_ij` como token sensível teria recall absurdo); o remédio
+continua sendo registro manual, como lá.
+
+**A causa-raiz ficou de fora, de propósito.** `ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE
+EXECUTE ON FUNCTIONS FROM PUBLIC` fecharia a classe para funções FUTURAS, mas: (1) só vale para
+objetos criados pelo **ROLE que executa o ALTER**, e o apply aqui é manual — cobertura parcial com
+aparência de total é pior que não ter, porque a Parte E passaria a confiar numa premissa falsa;
+(2) muda a **premissa medida** que o cabeçalho de `scripts/authz-funcoes-fechadas.ts` declara, e a
+Parte E emite `[FUNCAO_DEFAULT_PRIVILEGE_ALTERADO]` justamente para isso; (3) o ganho é menor do
+que parece — as 10 `cap_*` de `private` precisam de `authenticated=X` e já recebem GRANT explícito,
+então o default fechado só trocaria "nasce aberta em silêncio" por "quebra em runtime". Fail-closed
+é desejável, mas é mudança de comportamento de deploy e merece entrega própria, com prova própria.
 
 ## 9.2 Por que os DOIS, e não só o estático
 

--- a/docs/historico/sentinela-authz-controle-nao-mencao.md
+++ b/docs/historico/sentinela-authz-controle-nao-mencao.md
@@ -438,9 +438,9 @@ Três achados que só a medição dá:
 ## 9.1.1 Desfecho do achado colateral (2026-08-18) — as 3 de `private`
 
 Fechadas em `20260818120000_authz_private_execute_fecho.sql`, com prova executada em
-`db/test-authz-private-execute-fecho.sh` (PG17, 15 asserts, 3 falsificações, verde em
-`lc_messages` **C e pt_BR.UTF-8**). As 3 estão agora em `ACKNOWLEDGED_SENSITIVE` e em
-`AUTHZ_FUNCOES_FECHADAS` (`PORTA_FECHADA`), então a Parte E as vigia.
+`db/test-authz-private-execute-fecho.sh` (PG17, **21 asserts**, 3 falsificações, verde em
+`lc_messages` **C e pt_BR.UTF-8**). Revisado adversarialmente pelo Codex (gpt-5.6-sol, xhigh),
+que **derrubou duas afirmações factuais minhas** — ambas remedidas e corrigidas abaixo.
 
 **Correção factual ao §9.1.** "Em `private` é pior" está errado no EFEITO, e a diferença importa
 para não se desenhar defesa contra o risco errado: o default de `public` para funções é
@@ -451,17 +451,30 @@ EXECUTE. A diferença é de FORMA, e favorece `private`: com `proacl` NULL um
 — o `nspacl` concede USAGE a `anon` e `authenticated`.
 
 **Nenhuma das 3 era explorável — mas por razões que não eram privilégio, e é isso que as tornava
-frágeis.** É o achado que a prova dá e a leitura estática não daria:
+frágeis.**
 
 | | por que não era alcançável | quão robusto |
 |---|---|---|
-| `frec_sem_margem` / `fbrec_sem_margem` | `RETURNS trigger` ⇒ chamada direta morre em `0A000` no EXECUTOR, com ou sem EXECUTE (L3) | **robusto** — é do executor, não do ACL. O REVOKE é 2ª tranca |
+| `frec_sem_margem` / `fbrec_sem_margem` | `RETURNS trigger` ⇒ chamada direta morre no handler de trigger (`0A000`) | **robusto, mas não pelo motivo que escrevi** — ver correção abaixo |
 | `custo_canonico` | SECURITY INVOKER que chama `regua_num_finito`, cujo ACL nega `anon` (L4) | **acidental** — F3 abre o helper e `anon` **executa**. Dependia de um ACL vizinho |
 
-E fechar não custou nada, o que a prova mediu em vez de supor: `get_skus_margem_positiva()`
-(SECDEF de owner `postgres`) segue chamando o helper revogado (L8), e os triggers de scrub seguem
-disparando (L9/L10) — **disparar trigger não checa EXECUTE**; quem checa é o `CREATE TRIGGER`, e
-criá-lo exige ser dono da tabela (L11).
+**Correção 1 — "morre em `0A000` tenha ou não EXECUTE" era FALSO.** A ACL é verificada **antes**
+da invocação. Medido em PG17: **com** EXECUTE → `0A000`; **sem** → `42501` (L3 e L12). O erro da
+minha versão original foi provar só o caso "com EXECUTE" e generalizar. A consequência prática
+inverte o argumento a favor do fecho: o `REVOKE` não é decorativo, ele **move a barreira** do
+handler de trigger para o privilégio.
+
+**Correção 2 — `CREATE TRIGGER` exige DUAS coisas**, privilégio `TRIGGER` na **tabela** e
+`EXECUTE` na **função**; o assert original dizia "authenticated não consegue" sem distinguir qual
+faltava — não provava o que afirmava. Agora as 3 categorias (L11a/b/c): sem nenhum → barra; **com
+`TRIGGER` e sem `EXECUTE` → ainda barra**; com os dois → passa. O controle positivo é o que
+prova que a causa é o `EXECUTE`. Confirmado também que disparar trigger **não** revalida EXECUTE
+(L9/L10), e que existem exatamente **2** vínculos em `pg_trigger` para estas funções (L13) — o
+`REVOKE` não neutralizaria um vínculo já instalado, então isso se responde por `pg_trigger`, não
+por ACL.
+
+Fechar não custou nada, e isso foi medido em vez de suposto: `get_skus_margem_positiva()` (SECDEF
+de owner `postgres`) segue chamando o helper revogado (L8).
 
 **Por que a Parte B não as exigiu** — o mesmo ponto cego já anotado em `get_carteira_margem_faixa`,
 numa 2ª forma. O detector é **léxico sobre o corpo** (`SENSITIVE_TABLES`/`SENSITIVE_COLUMNS`), e
@@ -471,15 +484,62 @@ Somam-se dois detalhes: `custo_canonico` nem chega à Parte B (ela só examina S
 Ampliar o dicionário não resolve (`m_ij` como token sensível teria recall absurdo); o remédio
 continua sendo registro manual, como lá.
 
-**A causa-raiz ficou de fora, de propósito.** `ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE
-EXECUTE ON FUNCTIONS FROM PUBLIC` fecharia a classe para funções FUTURAS, mas: (1) só vale para
-objetos criados pelo **ROLE que executa o ALTER**, e o apply aqui é manual — cobertura parcial com
-aparência de total é pior que não ter, porque a Parte E passaria a confiar numa premissa falsa;
-(2) muda a **premissa medida** que o cabeçalho de `scripts/authz-funcoes-fechadas.ts` declara, e a
-Parte E emite `[FUNCAO_DEFAULT_PRIVILEGE_ALTERADO]` justamente para isso; (3) o ganho é menor do
-que parece — as 10 `cap_*` de `private` precisam de `authenticated=X` e já recebem GRANT explícito,
-então o default fechado só trocaria "nasce aberta em silêncio" por "quebra em runtime". Fail-closed
-é desejável, mas é mudança de comportamento de deploy e merece entrega própria, com prova própria.
+### A categoria nova: `ACL_ONLY_INTERNAL`
+
+A 1ª versão pôs as 3 em `ACKNOWLEDGED_SENSITIVE`, porque o teste "não inventa função" exige que
+toda chave de `AUTHZ_FUNCOES_FECHADAS` esteja classificada. O Codex achou o modo de falha que eu
+não vi: **aquele Set não é documentação, é a lista que faz a Parte B PULAR.** Com `custo_canonico`
+lá, a entrada seria inerte hoje (a função é INVOKER, e a Parte B só examina SECDEF) e **perigosa
+amanhã**: se ela renascesse SECDEF — a regressão que o gate existe para pegar — a entrada
+preexistente a suprimiria em silêncio.
+
+Daí a categoria própria, com **discriminante obrigatório**: quem está em `ACL_ONLY_INTERNAL` tem
+de continuar `SECURITY INVOKER`, e virar SECDEF é **erro** da Parte B
+(`[ACL_ONLY_INTERNAL_VIROU_SECDEF]`), não aviso. O check roda **antes** do filtro de
+`touchesSensitive` de propósito — depender do detector léxico deixaria a regressão passar
+exatamente na função que motivou a categoria (o corpo dela não casa token nenhum). Três testes
+cobrem isso, incluindo o de que a falha não depende do detector.
+
+Isso **não** é o teste afrouxado para ficar verde: é ele partido em duas afirmações mais fortes
+(união dos três catálogos + discriminante que as separa), cada uma com a checagem que a sustenta.
+`frec_sem_margem` e `fbrec_sem_margem` seguem em `ACKNOWLEDGED_SENSITIVE`, onde encaixam com
+precedente exato (2 das 21 entradas já eram `RETURNS trigger` SECDEF).
+
+Também saiu do desenho, pela mesma revisão, o `GRANT EXECUTE … TO service_role` em
+`custo_canonico`: o único consumidor medido é a SECDEF de owner `postgres`, que a alcança como
+owner — o grant só ampliaria superfície.
+
+### A causa-raiz ficou de fora, e a razão MUDOU depois de medida
+
+A formulação intuitiva **não funciona**:
+
+```sql
+ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;  -- INÓCUO
+```
+
+Medido com canário (L14): a função criada depois disso ainda nasce com `proacl` NULL e
+`has_function_privilege('anon', …) = true`. Default privilege **por schema** não remove o EXECUTE
+do default **global embutido** do Postgres — só adiciona, ou desfaz um `GRANT` feito também por
+schema. A forma que funciona é a **global**, sem `IN SCHEMA` (L15) — mas ela é por **role
+criadora** e vale para **todos** os schemas: mudança de postura do projeto inteiro, não um ajuste
+de `private`.
+
+Minha justificativa original ("fecharia a classe, mas só vale para o role que executa ⇒ cobertura
+parcial") estava certa na conclusão e **errada no mecanismo**. As razões que sobram, agora
+corretas: (1) a forma por schema é inócua e a global é invasiva e por-role-criadora — o apply aqui
+é manual, então a cobertura seria parcial com aparência de total, e a Parte E passaria a confiar
+numa premissa falsa; (2) muda a **premissa medida** que o cabeçalho de
+`scripts/authz-funcoes-fechadas.ts` declara, e a Parte E emite
+`[FUNCAO_DEFAULT_PRIVILEGE_ALTERADO]` justamente para isso; (3) o ganho é menor do que parece — as
+10 `cap_*` de `private` precisam de `authenticated=X` e já recebem GRANT explícito, então o default
+fechado só trocaria "nasce aberta em silêncio" por "quebra em runtime". Fail-closed é desejável,
+mas é mudança de comportamento de deploy e merece entrega própria, com prova própria.
+
+**Lição que sobra desta entrega.** As duas afirmações que caíram eram do mesmo tipo: eu **provei um
+caso e generalizei para a categoria** ("com EXECUTE morre em 0A000" → "tenha ou não"; "o comando
+fecha o default" → sem testar a forma por schema). O antídoto que funcionou não foi ler a doc com
+mais cuidado — foi o **canário**: criar o objeto depois da mudança e medir o ACL dele. Assert que
+cobre só o caso favorável é o mesmo teatro que a Lei #3 combate, uma camada acima.
 
 ## 9.2 Por que os DOIS, e não só o estático
 

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **475** custom migrations totais
+- **476** custom migrations totais
 - **1616** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 489
@@ -3964,6 +3964,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `index` | `public.farmer_geracao_execucoes_medicao_idx` | `farmer_geracao_execucoes` |
 | `rls_policy` | `public.fgv_select_carteira` | `farmer_geracao_vigente` |
 | `rls_policy` | `public.fge_select_carteira` | `farmer_geracao_execucoes` |
+
+### `20260818120000_authz_private_execute_fecho.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ### `20260818121919_authz_fecho_execute_registrado_3_funcoes.sql`
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 475
+-- Total de custom migrations: 476
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -516,6 +516,7 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260814223445', 'farmer_recomendacoes_geracao_vigente', '20260814223445_farmer_recomendacoes_geracao_vigente.sql'),
   ('20260815153218', 'data_health_contrato_severity_idade', '20260815153218_data_health_contrato_severity_idade.sql'),
   ('20260815181500', 'farmer_geracao_head_sensor', '20260815181500_farmer_geracao_head_sensor.sql'),
+  ('20260818120000', 'authz_private_execute_fecho', '20260818120000_authz_private_execute_fecho.sql'),
   ('20260818121919', 'authz_fecho_execute_registrado_3_funcoes', '20260818121919_authz_fecho_execute_registrado_3_funcoes.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES

--- a/scripts/authz-funcoes-fechadas.ts
+++ b/scripts/authz-funcoes-fechadas.ts
@@ -34,7 +34,7 @@
  * daquela migration.
  *
  * MEDIÇÃO QUE JUSTIFICA CADA ENTRADA (psql-ro, 2026-08-15, `has_function_privilege` +
- * `proacl` cru, nas 40 funções de `AUTHZ_MANIFEST` ∪ `ACKNOWLEDGED_SENSITIVE`):
+ * `proacl` cru, nas então 40 funções de `AUTHZ_MANIFEST` ∪ `ACKNOWLEDGED_SENSITIVE`):
  *   · 40 de 40 presentes no banco, **0** com `proacl` NULL;
  *   · **`anon` não alcança NENHUMA** — reconfirma a medição de 2026-08-14 e é o que autoriza
  *     `permitido.anon = false` em todas (declarar sem medir fabricaria contrato falso, o erro que
@@ -44,6 +44,14 @@
  *   · 20 das 21 de `ACKNOWLEDGED_SENSITIVE` **não** têm — fecham por PRIVILÉGIO. A 21ª,
  *     `get_carteira_margem_faixa`, tem `authenticated=X` de propósito (fecha por gate de ESCOPO e
  *     PROJEÇÃO, não por privilégio) e é a única exceção; ela está anotada abaixo.
+ *
+ * REMEDIÇÃO 2026-08-18 (após entrarem as 3 de `private`): o conjunto tem **43** funções (19
+ * manifest + 24 ACK), 43 de 43 presentes. Enquanto o fecho não for colado no SQL Editor, a
+ * medição de prod acusa **3** com `proacl` NULL e **3** alcançáveis por `anon` — são exatamente
+ * as 3 novas, e `bun run authz:funcoes:prod` as reporta como `[FUNCAO_NAO_APLICADA]`. Depois do
+ * apply o esperado volta a ser `proacl` NULL = 0, `anon` = 0 e `authenticated` = 20 (as 19 do
+ * manifest + `get_carteira_margem_faixa`); hoje são 23 porque `proacl` NULL concede a PUBLIC.
+ * Este parágrafo é o que impede o bloco acima de virar afirmação falsa — releia-o junto.
  *
  * `fechadaPor` é a ÂNCORA: a última migration do repo que estabelece o ACL declarado aqui. A
  * vigilância é dela **para a frente, INCLUSIVE** — diferente da Parte C de tabela, que olha só o

--- a/scripts/authz-funcoes-fechadas.ts
+++ b/scripts/authz-funcoes-fechadas.ts
@@ -16,8 +16,22 @@
  *     schema `public`, objtype `f` → {postgres=X, anon=X, authenticated=X, service_role=X, …}
  * Isto é, uma função nova em `public` nasce **executável por `anon` E `authenticated`** — o vetor
  * concede à role ANÔNIMA, não só à autenticada. E o schema `private` **não tem** default privilege
- * de função: lá a função nasce com `proacl` NULL, que é EXECUTE implícito a PUBLIC — pior ainda,
- * e já visível em prod (3 funções `private` estão nesse estado; 2 delas SECDEF).
+ * de função: lá a função nasce com `proacl` NULL, que é EXECUTE implícito a PUBLIC.
+ *
+ * ⚠️ O "pior ainda" que esta nota trazia na 1ª versão estava ERRADO no EFEITO, e a correção
+ * importa para não se desenhar defesa contra o risco errado: `proacl` NULL e o default de
+ * `public` deixam AMBOS o `anon` com EXECUTE. A diferença é de FORMA, e favorece `private` —
+ * com `proacl` NULL um `REVOKE ... FROM PUBLIC` basta, enquanto em `public` é preciso revogar
+ * de `anon`/`authenticated` POR NOME (a armadilha do CLAUDE.md).
+ *
+ * As 3 funções de `private` que estavam nesse estado (2 delas SECDEF) foram FECHADAS em
+ * 20260818120000_authz_private_execute_fecho.sql e estão declaradas no fim desta allowlist. A
+ * CAUSA-RAIZ segue de pé de propósito: um `ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE
+ * EXECUTE ON FUNCTIONS FROM PUBLIC` fecharia a classe para funções FUTURAS, mas só vale para
+ * objetos criados pelo ROLE que o executa — cobertura parcial com aparência de total — e mudaria
+ * a premissa medida deste cabeçalho (a Parte E emite [FUNCAO_DEFAULT_PRIVILEGE_ALTERADO] de
+ * propósito). É entrega própria, com prova própria; o raciocínio completo está no cabeçalho
+ * daquela migration.
  *
  * MEDIÇÃO QUE JUSTIFICA CADA ENTRADA (psql-ro, 2026-08-15, `has_function_privilege` +
  * `proacl` cru, nas 40 funções de `AUTHZ_MANIFEST` ∪ `ACKNOWLEDGED_SENSITIVE`):
@@ -310,5 +324,40 @@ export const AUTHZ_FUNCOES_FECHADAS: Record<string, FuncaoFechada> = {
     permitido: PORTA_FECHADA,
     motivo:
       'RETURNS trigger em pedido_compra_sugerido (trg_set_status_envio_portal), sem rota PostgREST',
+  },
+
+  // ═══════════ schema `private` — as 3 que nasciam com `proacl` NULL (#1768 §9.1) ═══════════
+  // MEDIDO (psql-ro, 2026-08-15, reconfirmado 2026-08-18): `pg_default_acl` não tem NENHUMA linha
+  // para o schema `private` ⇒ função criada lá nasce com `proacl` NULL = EXECUTE implícito a
+  // PUBLIC. E `private` concede USAGE a `anon` E `authenticated` (nspacl), então o schema não é
+  // barreira de EXECUTE — só de ROTA (o PostgREST não o publica). Estas 3 eram as únicas de 23
+  // nesse estado; as outras 20 já tinham ACL explícito.
+  //
+  // Nenhuma era explorável quando o fecho foi escrito — mas por razões que NÃO eram privilégio, e
+  // é isso que o fecho corrige. Provado em db/test-authz-private-execute-fecho.sh (15 asserts,
+  // 3 falsificações, verde em lc_messages C e pt_BR.UTF-8).
+  'private.custo_canonico': {
+    fechadaPor: '20260818120000_authz_private_execute_fecho.sql',
+    permitido: PORTA_FECHADA,
+    motivo:
+      'helper puro do custo canônico (SECURITY INVOKER, não lê tabela). Barrava anon só por ' +
+      'ACIDENTE — chama private.regua_num_finito, que nega anon; F3 do harness abre o helper e ' +
+      'mostra anon EXECUTANDO. Consumidor real: public.get_skus_margem_positiva (SECDEF, owner ' +
+      'postgres), que segue chamando após o REVOKE (L8)',
+  },
+  'private.frec_sem_margem': {
+    fechadaPor: '20260818120000_authz_private_execute_fecho.sql',
+    permitido: PORTA_FECHADA,
+    motivo:
+      'RETURNS trigger do scrub de margem do FU4-F fase 3 (nulifica m_ij/lie em ' +
+      'farmer_recommendations). Chamada direta já morria em 0A000 no EXECUTOR, com ou sem ' +
+      'EXECUTE (L3) — o REVOKE é 2ª tranca; disparar trigger não checa EXECUTE (L9)',
+  },
+  'private.fbrec_sem_margem': {
+    fechadaPor: '20260818120000_authz_private_execute_fecho.sql',
+    permitido: PORTA_FECHADA,
+    motivo:
+      'irmã da acima em farmer_bundle_recommendations (nulifica m_bundle/lie_bundle e remove ' +
+      'cost/margin do jsonb bundle_products). Mesma barreira de executor e mesma 2ª tranca (L10)',
   },
 };

--- a/scripts/authz-funcoes.test.ts
+++ b/scripts/authz-funcoes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { AUTHZ_FUNCOES_FECHADAS, type FuncaoFechada } from './authz-funcoes-fechadas';
-import { AUTHZ_MANIFEST, ACKNOWLEDGED_SENSITIVE } from './authz-manifest';
+import { AUTHZ_MANIFEST, ACKNOWLEDGED_SENSITIVE, ACL_ONLY_INTERNAL } from './authz-manifest';
 import {
   auditGrantsFuncoes,
   compararExecuteProd,
@@ -38,10 +38,23 @@ describe('AUTHZ_FUNCOES_FECHADAS — sanidade do contrato', () => {
   });
 
   it('não inventa função: toda chave da allowlist está classificada no manifesto', () => {
+    // A união é dos TRÊS catálogos. Não é o assert afrouxado: `ACL_ONLY_INTERNAL` traz consigo um
+    // discriminante próprio (tem de continuar INVOKER — Parte B), e o teste logo abaixo exige a
+    // cobertura na direção inversa. O princípio preservado é classificação EXAUSTIVA.
     const orfas = Object.keys(AUTHZ_FUNCOES_FECHADAS).filter(
-      (k) => !AUTHZ_MANIFEST[k] && !ACKNOWLEDGED_SENSITIVE.has(k),
+      (k) => !AUTHZ_MANIFEST[k] && !ACKNOWLEDGED_SENSITIVE.has(k) && !ACL_ONLY_INTERNAL.has(k),
     );
     expect(orfas).toEqual([]);
+  });
+
+  it('cobre TODA função do ACL_ONLY_INTERNAL (a direção inversa)', () => {
+    const faltando = [...ACL_ONLY_INTERNAL].filter((k) => !AUTHZ_FUNCOES_FECHADAS[k]);
+    expect(faltando).toEqual([]);
+  });
+
+  it('ACL_ONLY_INTERNAL e ACKNOWLEDGED_SENSITIVE são DISJUNTOS (categoria é discriminante)', () => {
+    const nos2 = [...ACL_ONLY_INTERNAL].filter((k) => ACKNOWLEDGED_SENSITIVE.has(k) || !!AUTHZ_MANIFEST[k]);
+    expect(nos2).toEqual([]);
   });
 
   it('toda entrada tem permitido booleano p/ anon e authenticated, e motivo não-vazio', () => {

--- a/scripts/authz-gate-check.test.ts
+++ b/scripts/authz-gate-check.test.ts
@@ -85,6 +85,46 @@ describe('auditAuthz — Parte B (cobertura)', () => {
 });
 
 // ── falsos-negativos do challenge Codex (2026-07-09): cada um DEVE virar erro ──
+describe('auditAuthz — discriminante do ACL_ONLY_INTERNAL', () => {
+  // `private.custo_canonico` declara-se helper SECURITY INVOKER fechado por privilégio. O corpo
+  // real dela é reproduzido aqui: repare que NÃO contém nenhum token de SENSITIVE_COLUMNS —
+  // `p_cost_price` não casa `\bcost_price\b` porque o `_` antes não é fronteira de palavra.
+  // É por isso que o discriminante não pode depender de `touchesSensitive`.
+  const CORPO = `SELECT CASE
+    WHEN private.regua_num_finito(p_cost_final) AND p_cost_final > 0 THEN p_cost_final
+    WHEN private.regua_num_finito(p_cost_price) AND p_cost_price  > 0 THEN p_cost_price
+    ELSE NULL END`;
+  const custoCanonico = (sec: 'INVOKER' | 'DEFINER') =>
+    `CREATE OR REPLACE FUNCTION private.custo_canonico(p_cost_final numeric, p_cost_price numeric)
+ RETURNS numeric LANGUAGE sql IMMUTABLE SECURITY ${sec}
+AS $function$ ${CORPO}; $function$;`;
+
+  it('passa enquanto ela continua SECURITY INVOKER (o estado declarado)', () => {
+    const f = auditAuthz([mig('20260818120000_ok.sql', custoCanonico('INVOKER'))]);
+    expect(errorsOf(f)).toHaveLength(0);
+  });
+
+  it('FALHA se ela renascer SECURITY DEFINER — a regressão que motivou a categoria', () => {
+    const f = auditAuthz([mig('20260901000000_regressao.sql', custoCanonico('DEFINER'))]);
+    const err = errorsOf(f);
+    expect(err).toHaveLength(1);
+    expect(err[0].msg).toContain('ACL_ONLY_INTERNAL_VIROU_SECDEF');
+    expect(err[0].fn).toContain('private.custo_canonico');
+  });
+
+  it('a falha NÃO depende do detector léxico: SECDEF com corpo sem token sensível ainda é erro', () => {
+    const f = auditAuthz([
+      mig(
+        '20260901000000_r2.sql',
+        `CREATE OR REPLACE FUNCTION private.custo_canonico(p_cost_final numeric, p_cost_price numeric)
+ RETURNS numeric LANGUAGE sql IMMUTABLE SECURITY DEFINER
+AS $function$ SELECT 1; $function$;`,
+      ),
+    ]);
+    expect(errorsOf(f).map((e) => e.msg).join()).toContain('ACL_ONLY_INTERNAL_VIROU_SECDEF');
+  });
+});
+
 describe('auditAuthz — anti falso-negativo (challenge Codex)', () => {
   it('gate DECORATIVO (presente sem bloquear) numa função do manifest → ERRO', () => {
     const body = `v_can := private.cap_custo_ler(auth.uid()); ${READ}`;

--- a/scripts/authz-gate-check.ts
+++ b/scripts/authz-gate-check.ts
@@ -24,7 +24,7 @@ import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { extractFunctions, checkGate, touchesSensitive, rawIsSensitiveSecdef, type FunctionDef } from './lib/authz-contract';
 import { detectarReescritaViva } from './lib/authz-reescrita';
-import { AUTHZ_MANIFEST, ACKNOWLEDGED_SENSITIVE, manifestKey } from './authz-manifest';
+import { AUTHZ_MANIFEST, ACKNOWLEDGED_SENSITIVE, ACL_ONLY_INTERNAL, manifestKey } from './authz-manifest';
 import { REESCRITAS_CONHECIDAS_INDEX, chaveReescrita } from './authz-reescritas-conhecidas';
 import { auditGrantsTabelas } from './lib/authz-grants';
 import { AUTHZ_TABELAS_FECHADAS } from './authz-tabelas-fechadas';
@@ -110,6 +110,24 @@ export function auditAuthz(migrations: Migration[]): Finding[] {
   // Parte B — cobertura: toda SECDEF sensível no estado final (por assinatura) está classificada.
   for (const [, { def, file }] of finalBySig) {
     if (!def.securityDefiner) continue;
+
+    // DISCRIMINANTE do ACL_ONLY_INTERNAL: quem está lá declarou-se helper INVOKER fechado por
+    // privilégio. Se renasceu SECDEF, a classificação virou mentira e precisa ser refeita.
+    // Roda ANTES do filtro de `touchesSensitive` DE PROPÓSITO: o detector é léxico sobre o corpo
+    // e `private.custo_canonico` não casa token nenhum (`p_cost_price` não casa `\bcost_price\b`
+    // — o `_` antes não é fronteira de palavra), então depender dele deixaria a regressão passar
+    // exatamente na função que motivou a categoria.
+    const mkeyInterno = manifestKey(def.schema, def.name);
+    if (ACL_ONLY_INTERNAL.has(mkeyInterno)) {
+      findings.push({
+        level: 'error',
+        file,
+        fn: def.signature ? `${mkeyInterno}(${def.signature})` : mkeyInterno,
+        msg: `[ACL_ONLY_INTERNAL_VIROU_SECDEF] ${mkeyInterno} está em ACL_ONLY_INTERNAL, que declara helper SECURITY INVOKER fechado por privilégio — e esta definição é SECURITY DEFINER. Reclassifique em scripts/authz-manifest.ts: se passou a precisar de gate, vá para AUTHZ_MANIFEST; se é SECDEF sensível sem gate customer-facing, para ACKNOWLEDGED_SENSITIVE. Não basta remover daqui — a Parte E ainda exige que ela esteja no universo admissível de AUTHZ_FUNCOES_FECHADAS.`,
+      });
+      continue;
+    }
+
     const sensitive = touchesSensitive(def.body);
     if (sensitive.length === 0) continue;
     const mkey = manifestKey(def.schema, def.name);

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -240,7 +240,9 @@ export const AUTHZ_MANIFEST: Record<string, AuthzEntry> = {
 };
 
 /**
- * SECDEF que tocam dado sensível mas NÃO precisam de gate customer-facing — baseline 2026-07-09.
+ * Funções classificadas como sensíveis que NÃO precisam de gate customer-facing — baseline
+ * 2026-07-09. Eram só SECDEF até 2026-08-18, quando `private.custo_canonico` (SECURITY
+ * INVOKER) entrou: ver a nota dela no fim da lista.
  * Cada entrada é uma decisão consciente: a função não é executável por `authenticated` (só
  * service_role/cron/staff-internal) OU o "toque" é falso-positivo do parser (menção em string
  * já mascarada / coluna homônima). Justificativa por linha. Semeado a partir do inventário PROD
@@ -388,6 +390,30 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // `trg_set_status_envio_portal` em `pedido_compra_sugerido` (medido em pg_trigger). Função de
   // trigger não tem rota PostgREST — o fecho por privilégio é a segunda tranca, não a primeira.
   'public.set_status_envio_portal_on_disparo',
+
+  // ─────────── 2026-08-18 — as 3 de `private` que nasciam com `proacl` NULL (#1768 §9.1) ───────────
+  // MEDIDO: `pg_default_acl` não tem linha para o schema `private`, então função criada lá nasce
+  // com `proacl` NULL = EXECUTE implícito a PUBLIC (e `private` dá USAGE a anon E authenticated —
+  // o schema nega ROTA, não EXECUTE). Fechadas por privilégio em
+  // 20260818120000_authz_private_execute_fecho.sql; ACL vigiado pela Parte E dali em diante.
+  //
+  // ⚠️ Nenhuma das 3 foi flagrada pela Parte B, e a razão é a MESMA do ponto cego já anotado em
+  // `get_carteira_margem_faixa` acima, numa 2ª forma: o detector é LÉXICO sobre o corpo, e estes
+  // corpos falam o jargão do modelo (`m_ij`, `lie`, `m_bundle`) em vez dos tokens de
+  // SENSITIVE_COLUMNS. Some-se que `custo_canonico` nem chega à Parte B (ela só examina SECDEF) e
+  // que `p_cost_price` não casa `\bcost_price\b` (o `_` antes não é fronteira de palavra).
+  // Registro manual, como lá — ampliar o dicionário não resolveria: `m_ij` como token sensível
+  // teria recall absurdo.
+  //
+  // ⚠️ `private.custo_canonico` é a PRIMEIRA entrada NÃO-SECDEF deste Set (as outras 21 são
+  // SECDEF; medido). Isso não afrouxa nada: a Parte B consulta este Set apenas para PULAR uma
+  // SECDEF já classificada, então uma não-SECDEF aqui não muda veredito nenhum dela. O Set ser
+  // 21/21 SECDEF era CONSEQUÊNCIA de ter sido semeado do inventário de SECDEF de prod, não
+  // invariante desejada — e o 2º papel que ele ganhou no #1768 (ser o universo admissível de
+  // AUTHZ_FUNCOES_FECHADAS) não tem razão para excluir função sensível não-SECDEF.
+  'private.custo_canonico',
+  'private.frec_sem_margem',
+  'private.fbrec_sem_margem',
   //
   // ⚠️ O fecho por privilégio é estado de PROD, e é a **Parte E** do `authz:check` que o vigia
   // desde 2026-08-15 (scripts/authz-funcoes-fechadas.ts + scripts/lib/authz-funcoes.ts; §9 de

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -240,9 +240,7 @@ export const AUTHZ_MANIFEST: Record<string, AuthzEntry> = {
 };
 
 /**
- * Funções classificadas como sensíveis que NÃO precisam de gate customer-facing — baseline
- * 2026-07-09. Eram só SECDEF até 2026-08-18, quando `private.custo_canonico` (SECURITY
- * INVOKER) entrou: ver a nota dela no fim da lista.
+ * SECDEF que tocam dado sensível mas NÃO precisam de gate customer-facing — baseline 2026-07-09.
  * Cada entrada é uma decisão consciente: a função não é executável por `authenticated` (só
  * service_role/cron/staff-internal) OU o "toque" é falso-positivo do parser (menção em string
  * já mascarada / coluna homônima). Justificativa por linha. Semeado a partir do inventário PROD
@@ -405,13 +403,11 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // Registro manual, como lá — ampliar o dicionário não resolveria: `m_ij` como token sensível
   // teria recall absurdo.
   //
-  // ⚠️ `private.custo_canonico` é a PRIMEIRA entrada NÃO-SECDEF deste Set (as outras 21 são
-  // SECDEF; medido). Isso não afrouxa nada: a Parte B consulta este Set apenas para PULAR uma
-  // SECDEF já classificada, então uma não-SECDEF aqui não muda veredito nenhum dela. O Set ser
-  // 21/21 SECDEF era CONSEQUÊNCIA de ter sido semeado do inventário de SECDEF de prod, não
-  // invariante desejada — e o 2º papel que ele ganhou no #1768 (ser o universo admissível de
-  // AUTHZ_FUNCOES_FECHADAS) não tem razão para excluir função sensível não-SECDEF.
-  'private.custo_canonico',
+  // ⚠️ `private.custo_canonico` foi tirada DAQUI e posta em `ACL_ONLY_INTERNAL` (abaixo) depois
+  // da revisão adversária do Codex, que achou o modo de falha que eu não vi: este Set não é
+  // documentação, é a lista que faz a Parte B PULAR. Hoje a entrada seria inerte (a função é
+  // INVOKER e a Parte B só examina SECDEF), mas no dia em que ela renascesse SECDEF — a
+  // regressão que o gate existe para pegar — a entrada preexistente a SUPRIMIRIA em silêncio.
   'private.frec_sem_margem',
   'private.fbrec_sem_margem',
   //
@@ -424,6 +420,33 @@ export const ACKNOWLEDGED_SENSITIVE = new Set<string>([
   // MEDIDO em `pg_default_acl`, concede EXECUTE a `anon` E `authenticated` no schema `public`.
   // Limite que continua valendo: o estático prova o que o REPO declara; grant colado à mão em
   // prod só aparece em `bun run authz:funcoes:prod`.
+]);
+
+/**
+ * Helpers INTERNOS fechados por ACL — categoria distinta de `ACKNOWLEDGED_SENSITIVE`, criada em
+ * 2026-08-18 a partir da revisão adversária do Codex (gpt-5.6-sol xhigh) sobre o fecho das 3
+ * funções de `private`.
+ *
+ * A DIFERENÇA QUE JUSTIFICA A CATEGORIA, e ela é de modo de falha, não de gosto:
+ *   · `ACKNOWLEDGED_SENSITIVE` é consultado pela Parte B para **PULAR** uma SECDEF sensível já
+ *     classificada. Pôr aqui uma função INVOKER seria inerte HOJE e perigoso AMANHÃ: se ela
+ *     renascesse SECDEF, a entrada preexistente suprimiria justamente a regressão que o gate
+ *     existe para pegar.
+ *   · Este Set NÃO suprime nada. Ele só declara "é helper interno, fechado por privilégio, e
+ *     pertence ao universo admissível de `AUTHZ_FUNCOES_FECHADAS`" — e vem com um DISCRIMINANTE
+ *     OBRIGATÓRIO: entrada daqui tem de continuar SECURITY INVOKER. Virar SECDEF é ERRO da
+ *     Parte B (não aviso), com a instrução de reclassificar.
+ *
+ * Ou seja: não é o teste "não inventa função" afrouxado para ficar verde — é ele partido em duas
+ * afirmações mais fortes, cada uma com a checagem que a sustenta.
+ */
+export const ACL_ONLY_INTERNAL = new Set<string>([
+  // Helper puro do custo canônico (cost_final → cost_price, finito e > 0, senão NULL). Não lê
+  // tabela: recebe dois numerics do próprio chamador e devolve um deles — não revela custo que o
+  // chamador já não tenha. Fechada por SUPERFÍCIE MÍNIMA, não por sensibilidade de capacidade.
+  // Consumidor real medido: `public.get_skus_margem_positiva()` (SECDEF, owner postgres), que a
+  // alcança como owner mesmo após o REVOKE. Fecho: 20260818120000_authz_private_execute_fecho.sql.
+  'private.custo_canonico',
 ]);
 
 /** chave de lookup a partir de schema+name (case-insensitive, sem assinatura) */

--- a/supabase/migrations/20260818120000_authz_private_execute_fecho.sql
+++ b/supabase/migrations/20260818120000_authz_private_execute_fecho.sql
@@ -2,6 +2,7 @@
 --
 -- ACHADO: colateral do #1768 (Parte E do `authz:check`), registrado no §9.1 de
 -- docs/historico/sentinela-authz-controle-nao-mencao.md e deliberadamente NAO mexido la.
+-- Desfecho e raciocinio completo no §9.1.1 do mesmo doc.
 --
 -- ─────────────────────────────────────────────────
 -- O QUE FOI MEDIDO (psql-ro em prod; 2026-08-15, reconfirmado 2026-08-18)
@@ -15,10 +16,15 @@
 --     chamada HTTP direta. EXECUTE de dentro do banco continua valendo.
 --   · 3 das 23 funcoes de `private` estao nesse estado; as outras 20 tem ACL explicito. O
 --     padrao do schema JA E fechar por privilegio — estas 3 escaparam, nao foram isentadas.
+--   · Owner das 3 = `postgres`, a mesma role do SQL Editor: o REVOKE abaixo tem permissao, e o
+--     owner NAO perde EXECUTE (e como a SECDEF de `get_skus_margem_positiva` segue chamando).
+--   · `pg_trigger`: existem EXATAMENTE 2 vinculos para estas funcoes (trg_frec_sem_margem em
+--     farmer_recommendations, trg_fbrec_sem_margem em farmer_bundle_recommendations), ambos
+--     `tgenabled='O'`. Nenhum trigger inesperado depende delas.
 --
 -- ⚠️ NAO e verdade que isto seja "pior que `public`" no efeito: o default privilege de `public`
---    para FUNCTIONS e `{postgres=X,anon=X,authenticated=X,service_role=X,...}` — tambem concede
---    a anon. A diferenca e de FORMA, e favorece `private`: com `proacl` NULL um
+--    para FUNCTIONS e `{postgres=X,anon=X,authenticated=X,service_role=X}` — tambem concede a
+--    anon. A diferenca e de FORMA, e favorece `private`: com `proacl` NULL um
 --    `REVOKE ... FROM PUBLIC` basta, enquanto em `public` e preciso revogar de `anon` e
 --    `authenticated` POR NOME (a armadilha ja documentada no CLAUDE.md). Revogamos dos tres
 --    aqui assim mesmo: idempotente, e imune a um grant explicito ter aparecido no meio-tempo.
@@ -29,58 +35,79 @@
 -- A prova executada (db/test-authz-private-execute-fecho.sh, PG17) mostra que as 3 sao HOJE
 -- inalcancaveis — mas por razoes que NAO sao privilegio, e e isso que as torna fragil:
 --
---   · `frec_sem_margem` / `fbrec_sem_margem` sao `RETURNS trigger`. Chamada direta morre no
---     executor com 0A000 ("trigger functions can only be called as triggers"), tenha o caller
---     EXECUTE ou nao. A barreira e do EXECUTOR, nao do ACL. Alem disso elas nao LEEM nada:
---     so escrevem NULL em NEW. Sao o mecanismo de SCRUB de margem do FU4-F fase 3 — o oposto
---     de um vazamento.
+--   · `frec_sem_margem` / `fbrec_sem_margem` sao `RETURNS trigger`. Elas nao LEEM nada: so
+--     escrevem NULL em NEW. Sao o mecanismo de SCRUB de margem do FU4-F fase 3 — o oposto de um
+--     vazamento.
+--     ⚠️ CORRECAO (revisao adversaria do Codex, medida e confirmada): NAO e verdade que a
+--     chamada direta morra em 0A000 "com ou sem EXECUTE". A ACL e verificada ANTES da
+--     invocacao. Medido em PG17: COM EXECUTE -> 0A000 (trigger function so pode ser chamada
+--     como trigger); SEM EXECUTE -> 42501. Ou seja, o REVOKE MOVE a barreira para o privilegio
+--     em vez de depender do handler de trigger — que e exatamente o ponto de fechar.
 --   · `custo_canonico` e SECURITY INVOKER e chama `private.regua_num_finito`, que nega anon.
 --     Ou seja, hoje ela falha para anon por um ACIDENTE do encadeamento: no dia em que alguem
---     abrir `regua_num_finito`, esta abre junto, calada. (E, medido: ela e funcao PURA de dois
---     numerics — nao le tabela, devolve um dos argumentos. Nao ha o que extrair dela; o dano
---     de deixar aberta e zero HOJE, mas o contrato fica dependendo de acidente.)
+--     abrir `regua_num_finito`, esta abre junto, calada (F3 do harness faz exatamente isso e
+--     mostra `anon` EXECUTANDO). E, medido: ela e funcao PURA de dois numerics — nao le tabela,
+--     devolve um dos argumentos. Nao ha o que extrair dela; o dano de deixar aberta e zero
+--     HOJE, mas o contrato fica dependendo de acidente.
 --
--- Fechar por privilegio custa nada (provado: o Farmer e a RPC de ranking seguem funcionando) e
--- troca "inalcancavel por acidente" por "inalcancavel por contrato" — que e o que a Parte E do
--- `authz:check` sabe vigiar a partir de agora (AUTHZ_FUNCOES_FECHADAS).
+-- Fechar por privilegio custa nada (provado: L8 mostra a RPC de ranking seguindo; L9/L10 mostram
+-- os triggers de scrub seguindo — disparar trigger NAO revalida EXECUTE) e troca "inalcancavel
+-- por acidente" por "inalcancavel por contrato", que e o que a Parte E sabe vigiar.
 --
 -- ─────────────────────────────────────────────────
 -- POR QUE **NAO** mexer no default privilege do schema (a causa-raiz)
 -- ─────────────────────────────────────────────────
--- `ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC` fecharia
--- a classe inteira para funcoes FUTURAS, e foi avaliado. Ficou de FORA desta migration:
---   1. `ALTER DEFAULT PRIVILEGES` so vale para objetos criados pelo ROLE que o executa. O apply
---      aqui e manual (SQL Editor do Lovable) e nem toda funcao de `private` nasce pela mesma
---      role — um default privilege que cobre so uma delas da cobertura PARCIAL com aparencia de
---      total, que e pior que nao ter (a Parte E passaria a confiar numa premissa falsa).
---   2. Ele muda a PREMISSA MEDIDA da allowlist: a Parte E emite
+-- ⚠️ MEDIDO, e o resultado derruba a formulacao obvia: em PG17,
+--     ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+--    e INOCUO. Um canario criado depois dele nasce com `proacl` NULL e
+--    `has_function_privilege('anon', ...) = true` — identico a nao ter rodado nada. Default
+--    privilege POR SCHEMA nao remove o EXECUTE do default GLOBAL embutido do Postgres; ele so
+--    adiciona, ou desfaz um GRANT feito tambem por schema.
+--    A forma que FUNCIONA e a global, sem `IN SCHEMA`: o canario passa a nascer
+--    `{postgres=X/postgres}` com `anon` sem EXECUTE. Mas ela e por ROLE CRIADORA e vale para
+--    TODOS os schemas — mudanca de postura do projeto inteiro, nao um ajuste de `private`.
+--
+-- Por isso a causa-raiz fica de fora desta migration:
+--   1. so vale para objetos criados pelo ROLE que executa o ALTER, e o apply aqui e manual —
+--      cobertura parcial com aparencia de total e pior que nao ter, porque a Parte E passaria a
+--      confiar numa premissa falsa;
+--   2. muda a PREMISSA MEDIDA da allowlist: a Parte E emite
 --      [FUNCAO_DEFAULT_PRIVILEGE_ALTERADO] de proposito para qualquer mudanca de default
 --      privilege sobre FUNCTIONS, e o cabecalho de scripts/authz-funcoes-fechadas.ts declara o
---      default medido. Mexer exige refazer aquela medicao e reescrever o cabecalho — entrega
---      propria, com sua propria prova, nao carona nesta.
---   3. O beneficio real e menor do que parece: as 10 funcoes `cap_*` de `private` PRECISAM de
---      `authenticated=X` (sao chamadas de dentro de policies RLS) e ja recebem GRANT explicito
---      na migration que as cria. O default fechado nao as afeta — ele so muda o ponto de
---      partida de quem ESQUECER o GRANT, trocando "nasce aberta em silencio" por "quebra em
---      runtime". E fail-closed e desejavel, mas e mudanca de comportamento de deploy e merece
---      ser decidida sozinha.
+--      default medido. Mexer exige refazer aquela medicao e reescrever o cabecalho;
+--   3. o beneficio e menor do que parece: as 10 funcoes `cap_*` de `private` PRECISAM de
+--      `authenticated=X` (chamadas de dentro de policies RLS) e ja recebem GRANT explicito na
+--      migration que as cria. O default fechado nao as afeta — ele so troca "nasce aberta em
+--      silencio" por "quebra em runtime" para quem ESQUECER o GRANT. Fail-closed e desejavel,
+--      mas e mudanca de comportamento de deploy e merece entrega propria, com prova propria.
 -- ─────────────────────────────────────────────────
 
--- 1) helper puro de custo canonico (SECURITY INVOKER, sem acesso a tabela).
---    O owner (postgres) mantem EXECUTE pos-REVOKE, e e como `public.get_skus_margem_positiva()`
---    — SECURITY DEFINER de owner postgres — continua chamando. service_role recebe GRANT pelo
---    mesmo padrao das irmas de `private` (atp_disponivel, margem_cliente_agregada): e a role do
---    backend confiavel, nunca chega ao browser.
+-- Precondicao: as 3 tem de existir, com ESTA assinatura, ANTES do primeiro REVOKE. Sem isto um
+-- rename/drop upstream faria a migration aplicar PELA METADE (o SQL Editor nao envolve o script
+-- numa transacao por conta propria), deixando parte fechada e parte aberta em silencio.
+DO $$
+BEGIN
+  IF to_regprocedure('private.custo_canonico(numeric,numeric)') IS NULL
+     OR to_regprocedure('private.frec_sem_margem()') IS NULL
+     OR to_regprocedure('private.fbrec_sem_margem()') IS NULL THEN
+    RAISE EXCEPTION 'precondicao FALHOU: alguma das 3 funcoes de private nao existe com a assinatura esperada (custo_canonico(numeric,numeric), frec_sem_margem(), fbrec_sem_margem())';
+  END IF;
+END $$;
+
+-- 1) helper puro do custo canonico (SECURITY INVOKER, sem acesso a tabela).
+--    SEM GRANT nenhum, de proposito: o unico consumidor MEDIDO e `public.get_skus_margem_positiva()`
+--    — SECURITY DEFINER de owner `postgres` —, e o owner mantem EXECUTE pos-REVOKE (L8 prova).
+--    Um `GRANT TO service_role` chegou a estar aqui e foi RETIRADO na revisao do Codex: sem
+--    consumidor direto comprovado, ele so ampliaria superficie.
 REVOKE ALL ON FUNCTION private.custo_canonico(numeric, numeric) FROM PUBLIC;
 REVOKE ALL ON FUNCTION private.custo_canonico(numeric, numeric) FROM anon;
 REVOKE ALL ON FUNCTION private.custo_canonico(numeric, numeric) FROM authenticated;
-GRANT EXECUTE ON FUNCTION private.custo_canonico(numeric, numeric) TO service_role;
 
 -- 2) as duas trigger functions do scrub de margem do Farmer.
---    SEM GRANT nenhum, de proposito: disparar um trigger NAO checa EXECUTE na funcao (provado
---    em L4/L5 do harness; quem checa EXECUTE e o CREATE TRIGGER, e criar trigger exige ser dono
---    da tabela). Sobra o owner — que e o padrao ja usado por `private.atp_reconciliar_job()` e
---    `private.expirar_reservas_vencidas_job()`, ambas `{postgres=X/postgres}` puro.
+--    SEM GRANT nenhum: disparar um trigger NAO revalida EXECUTE na funcao (L9/L10). Quem checa
+--    EXECUTE e o `CREATE TRIGGER` — e criar trigger exige TAMBEM o privilegio TRIGGER na tabela
+--    (L11 isola os dois). Sobra o owner, que e o padrao ja usado por
+--    `private.atp_reconciliar_job()` e `private.expirar_reservas_vencidas_job()`.
 REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM PUBLIC;
 REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM anon;
 REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM authenticated;

--- a/supabase/migrations/20260818120000_authz_private_execute_fecho.sql
+++ b/supabase/migrations/20260818120000_authz_private_execute_fecho.sql
@@ -1,0 +1,90 @@
+-- authz/private — fecha o EXECUTE das 3 funcoes que nasceram com `proacl` NULL
+--
+-- ACHADO: colateral do #1768 (Parte E do `authz:check`), registrado no §9.1 de
+-- docs/historico/sentinela-authz-controle-nao-mencao.md e deliberadamente NAO mexido la.
+--
+-- ─────────────────────────────────────────────────
+-- O QUE FOI MEDIDO (psql-ro em prod; 2026-08-15, reconfirmado 2026-08-18)
+-- ─────────────────────────────────────────────────
+--   · `pg_default_acl` nao tem NENHUMA linha para o schema `private` (count = 0, qualquer
+--     objtype). Logo, funcao criada la nasce com `proacl` NULL = EXECUTE IMPLICITO a PUBLIC,
+--     e PUBLIC inclui `anon` e `authenticated`.
+--   · O schema NAO e barreira: `private` concede USAGE a `authenticated` E `anon` (nspacl
+--     `{postgres=UC/postgres,authenticated=U/postgres,anon=U/postgres,service_role=U/postgres}`).
+--     O que `private` de fato nega e ROTA: o PostgREST nao publica o schema, entao nao ha
+--     chamada HTTP direta. EXECUTE de dentro do banco continua valendo.
+--   · 3 das 23 funcoes de `private` estao nesse estado; as outras 20 tem ACL explicito. O
+--     padrao do schema JA E fechar por privilegio — estas 3 escaparam, nao foram isentadas.
+--
+-- ⚠️ NAO e verdade que isto seja "pior que `public`" no efeito: o default privilege de `public`
+--    para FUNCTIONS e `{postgres=X,anon=X,authenticated=X,service_role=X,...}` — tambem concede
+--    a anon. A diferenca e de FORMA, e favorece `private`: com `proacl` NULL um
+--    `REVOKE ... FROM PUBLIC` basta, enquanto em `public` e preciso revogar de `anon` e
+--    `authenticated` POR NOME (a armadilha ja documentada no CLAUDE.md). Revogamos dos tres
+--    aqui assim mesmo: idempotente, e imune a um grant explicito ter aparecido no meio-tempo.
+--
+-- ─────────────────────────────────────────────────
+-- POR QUE FECHAR, se nenhuma das 3 e exploravel hoje
+-- ─────────────────────────────────────────────────
+-- A prova executada (db/test-authz-private-execute-fecho.sh, PG17) mostra que as 3 sao HOJE
+-- inalcancaveis — mas por razoes que NAO sao privilegio, e e isso que as torna fragil:
+--
+--   · `frec_sem_margem` / `fbrec_sem_margem` sao `RETURNS trigger`. Chamada direta morre no
+--     executor com 0A000 ("trigger functions can only be called as triggers"), tenha o caller
+--     EXECUTE ou nao. A barreira e do EXECUTOR, nao do ACL. Alem disso elas nao LEEM nada:
+--     so escrevem NULL em NEW. Sao o mecanismo de SCRUB de margem do FU4-F fase 3 — o oposto
+--     de um vazamento.
+--   · `custo_canonico` e SECURITY INVOKER e chama `private.regua_num_finito`, que nega anon.
+--     Ou seja, hoje ela falha para anon por um ACIDENTE do encadeamento: no dia em que alguem
+--     abrir `regua_num_finito`, esta abre junto, calada. (E, medido: ela e funcao PURA de dois
+--     numerics — nao le tabela, devolve um dos argumentos. Nao ha o que extrair dela; o dano
+--     de deixar aberta e zero HOJE, mas o contrato fica dependendo de acidente.)
+--
+-- Fechar por privilegio custa nada (provado: o Farmer e a RPC de ranking seguem funcionando) e
+-- troca "inalcancavel por acidente" por "inalcancavel por contrato" — que e o que a Parte E do
+-- `authz:check` sabe vigiar a partir de agora (AUTHZ_FUNCOES_FECHADAS).
+--
+-- ─────────────────────────────────────────────────
+-- POR QUE **NAO** mexer no default privilege do schema (a causa-raiz)
+-- ─────────────────────────────────────────────────
+-- `ALTER DEFAULT PRIVILEGES IN SCHEMA private REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC` fecharia
+-- a classe inteira para funcoes FUTURAS, e foi avaliado. Ficou de FORA desta migration:
+--   1. `ALTER DEFAULT PRIVILEGES` so vale para objetos criados pelo ROLE que o executa. O apply
+--      aqui e manual (SQL Editor do Lovable) e nem toda funcao de `private` nasce pela mesma
+--      role — um default privilege que cobre so uma delas da cobertura PARCIAL com aparencia de
+--      total, que e pior que nao ter (a Parte E passaria a confiar numa premissa falsa).
+--   2. Ele muda a PREMISSA MEDIDA da allowlist: a Parte E emite
+--      [FUNCAO_DEFAULT_PRIVILEGE_ALTERADO] de proposito para qualquer mudanca de default
+--      privilege sobre FUNCTIONS, e o cabecalho de scripts/authz-funcoes-fechadas.ts declara o
+--      default medido. Mexer exige refazer aquela medicao e reescrever o cabecalho — entrega
+--      propria, com sua propria prova, nao carona nesta.
+--   3. O beneficio real e menor do que parece: as 10 funcoes `cap_*` de `private` PRECISAM de
+--      `authenticated=X` (sao chamadas de dentro de policies RLS) e ja recebem GRANT explicito
+--      na migration que as cria. O default fechado nao as afeta — ele so muda o ponto de
+--      partida de quem ESQUECER o GRANT, trocando "nasce aberta em silencio" por "quebra em
+--      runtime". E fail-closed e desejavel, mas e mudanca de comportamento de deploy e merece
+--      ser decidida sozinha.
+-- ─────────────────────────────────────────────────
+
+-- 1) helper puro de custo canonico (SECURITY INVOKER, sem acesso a tabela).
+--    O owner (postgres) mantem EXECUTE pos-REVOKE, e e como `public.get_skus_margem_positiva()`
+--    — SECURITY DEFINER de owner postgres — continua chamando. service_role recebe GRANT pelo
+--    mesmo padrao das irmas de `private` (atp_disponivel, margem_cliente_agregada): e a role do
+--    backend confiavel, nunca chega ao browser.
+REVOKE ALL ON FUNCTION private.custo_canonico(numeric, numeric) FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.custo_canonico(numeric, numeric) FROM anon;
+REVOKE ALL ON FUNCTION private.custo_canonico(numeric, numeric) FROM authenticated;
+GRANT EXECUTE ON FUNCTION private.custo_canonico(numeric, numeric) TO service_role;
+
+-- 2) as duas trigger functions do scrub de margem do Farmer.
+--    SEM GRANT nenhum, de proposito: disparar um trigger NAO checa EXECUTE na funcao (provado
+--    em L4/L5 do harness; quem checa EXECUTE e o CREATE TRIGGER, e criar trigger exige ser dono
+--    da tabela). Sobra o owner — que e o padrao ja usado por `private.atp_reconciliar_job()` e
+--    `private.expirar_reservas_vencidas_job()`, ambas `{postgres=X/postgres}` puro.
+REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM anon;
+REVOKE ALL ON FUNCTION private.frec_sem_margem() FROM authenticated;
+
+REVOKE ALL ON FUNCTION private.fbrec_sem_margem() FROM PUBLIC;
+REVOKE ALL ON FUNCTION private.fbrec_sem_margem() FROM anon;
+REVOKE ALL ON FUNCTION private.fbrec_sem_margem() FROM authenticated;


### PR DESCRIPTION
## O que falhou

Duas colisões multi-sessão em 2026-08-15, **com as duas checagens da regra feitas** — dois PRs escritos, testados e descartados:

```
#1757  trabalho commitado 01:13 → PR criado 17:28 (16h depois) → fechado 17:39   6 arq, +270
#1754  vencedor da mesma edge, mergeou 01:37 — 24min APÓS o commit do perdedor
#1763  criado 18:07 → merge 18:12 — viveu 5min16s
#1764  commit 18:21 (9min depois de o vencedor já estar na main) → fechado 18:22   1 arq, +29
```

O detector **funcionou** — o #1764 morreu 36 s depois de criado. O furo é de **TIMING**: no `gh pr create` o trabalho já está pronto, então a rede evita o merge duplicado e **não** a hora perdida.

## O que muda

O `pr-collision-guard.sh` passa a rodar também no **`git commit`** — o chokepoint anterior, cadenciado pelo *trabalho* e não pelo relógio (as janelas medidas foram de 24 min e 9 min; um "re-cheque a cada 30 min" acerta por sorte). Cobre os dois incidentes: às 01:13 o #1754 estava aberto (via *PR aberto*); às 18:21 o #1763 já estava na main (via *main ganhou*).

Detalhes que separam rede de teatro:

- **Conjunto = STAGED ∪ commits da branch** (∪ working-tree só em `-a`). Só o diff de 3 pontos seria teatro: no **primeiro** commit ele é vazio (provado em repo descartável) — e o #1764 tinha 1 commit só.
- **Anti-alarm-fatigue:** avisa 1× por (branch, conjunto colidente); colisão nova fura o silêncio, e o `gh pr create` nunca é silenciado.
- **Sem cache da resposta do `gh`:** a versão com TTL de 2 min foi escrita e **descartada** — mascarou colisão verdadeira nos próprios testes. "Meu PR já mergeou" é monotônico; "quais PRs estão abertos" é volátil, e cache de estado volátil num guard é falso-negativo silencioso.

## Rejeitados (documentados para não voltarem como ideia nova)

- **PR draft vazio como lock:** o post-mortem do #1526 aponta *"PR represado em draft é ÍMÃ"* como causa nº 1; ~20 worktrees × draft vazio poluiriam o `gh pr list`, degradando o próprio sinal. Branch vazia + `ls-remote` troca poluição de PR por poluição de refs e só expõe o nome — no #1764 o vencedor era `claude/mystifying-wescoff-e5c20d`.
- **Re-checagem periódica por relógio:** erra por sorte nas janelas medidas e é ritual puro.

## CI

Os 3 testes de guard (pr-collision, migration-collision, branch-pos-squash) existem desde 2026-07 e **nenhum workflow os rodava**. Passam a rodar no `validate` (herméticos, git+gh stubados, ~1 s).

## Evidência

- 22 casos verdes (9 novos) · `shellcheck` limpo · `claude:size` **2581/2600 palavras**
- **Falsificado nos dois locales** (`C` e `pt_BR.UTF-8`): remover o gatilho, a união do staged, o dedupe ou o gate do `-a` deixa a suíte vermelha; sabotar qualquer um dos 3 testes deixa o `test:hooks` vermelho.
- **Prova de fumaça em produção:** o hook disparou no meu próprio `git commit` e detectou o #1769 tocando `docs/agent/worktrees.md`.

## Coordenação

Complementar ao #1767 (mergeado) e ao #1769 (aberto), que atacam o eixo **OBJETIVO** (*o que* procurar — o artefato). Este ataca o eixo **TEMPO** (*quando* conferir). O #1769 cria um hook separado (`pr-duplicata-guard.sh`) e não toca este; a única sobreposição é `docs/agent/worktrees.md`.

## Fora de escopo (2ª opinião do Codex, `-r xhigh`)

A **latência commit→PR** (as 16 h do #1757) segue sem sensor. O Codex propõe *lease* local na primeira mutação + Stop guard de "commits sem PR"; ficaram de fora por escopo — e valem só com sinal de que o backstop do commit não bastou.

⚠️ **O `CLAUDE.md` está a 19 palavras do teto** (2581/2600). A próxima entrega que tocá-lo precisará mover conteúdo para `docs/`.
