### PR TITLE
fix(farmer): `regras` vira insumo OBRIGATÓRIO do bundle — o vazio dele é por construção [money-path]

### DIFF
--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -463,6 +463,11 @@ export const useBundleEngine = () => {
       discoveredRules.sort((a, b) => b.lift - a.lift);
       setRules(discoveredRules.slice(0, 50)); // Keep top 50
 
+      // `regras` é insumo OBRIGATÓRIO do bundle (ver completude-snapshot): sem regra
+      // descoberta não há `applicableRules`, e o motor produz zero por construção. Declara-se
+      // o array INTEIRO — é ele que alimenta o filtro abaixo, não o top-50 que vai à tabela.
+      insumos.regras = { ok: true, n: discoveredRules.length };
+
       // Persist top rules — PULADO na lente "Ver como" (a tabela é GLOBAL: a troca
       // substitui as regras de toda a base; o master inspeciona os bundles do alvo sem
       // recalcular regras/recomendações da carteira dele).

--- a/src/lib/farmer/__tests__/completude-snapshot.test.ts
+++ b/src/lib/farmer/__tests__/completude-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   avaliarCompletude,
+  INSUMOS_OBRIGATORIOS_BUNDLE,
   INSUMOS_OBRIGATORIOS_CROSS_SELL,
   type InsumosSnapshot,
 } from '../completude-snapshot';
@@ -132,5 +133,33 @@ describe('avaliarCompletude', () => {
 
   it('completo SEMPRE tem motivo null — a coluna só é preenchida quando degrada', () => {
     expect(avaliarCompletude(COMPLETO, INSUMOS_OBRIGATORIOS_CROSS_SELL).motivo).toBeNull();
+  });
+
+  // ─── a assimetria entre os DOIS motores ────────────────────────────────────────
+  // Até aqui a suíte só exercia a lista do cross-sell; a do bundle não tinha teste algum,
+  // e foi por essa fresta que ela herdou `regras` como opcional — premissa que vale só
+  // para quem tem caminho por popularidade.
+
+  it('regras vazias DEGRADAM no bundle — lá o zero é por CONSTRUÇÃO, não falta de padrão', () => {
+    // Todo bundle nasce de `applicableRules`, que sai de `discoveredRules`. Sem regra o
+    // motor devolve zero sempre; `completo` aqui daria à fase 2 licença para expirar a
+    // carteira de bundles exatamente quando o histórico ficou insuficiente.
+    const r = avaliarCompletude({ ...COMPLETO, regras: { ok: true, n: 0 } }, INSUMOS_OBRIGATORIOS_BUNDLE);
+    expect(r.completude).toBe('degradado');
+    expect(r.motivo).toContain('regras');
+  });
+
+  it('a MESMA leitura dá veredicto diferente por motor — a assimetria é desenho, não acidente', () => {
+    const semRegras: InsumosSnapshot = { ...COMPLETO, regras: { ok: true, n: 0 } };
+    expect(avaliarCompletude(semRegras, INSUMOS_OBRIGATORIOS_CROSS_SELL).completude).toBe('completo');
+    expect(avaliarCompletude(semRegras, INSUMOS_OBRIGATORIOS_BUNDLE).completude).toBe('degradado');
+  });
+
+  it('bundle que NÃO declara regras degrada por AUSÊNCIA — ausente ≠ zero na própria medição', () => {
+    const { regras: _omitido, ...semRegras } = COMPLETO;
+    const r = avaliarCompletude(semRegras, INSUMOS_OBRIGATORIOS_BUNDLE);
+    expect(r.completude).toBe('degradado');
+    expect(r.motivo).toContain('não declarado');
+    expect(r.motivo).toContain('regras');
   });
 });

--- a/src/lib/farmer/completude-snapshot.ts
+++ b/src/lib/farmer/completude-snapshot.ts
@@ -42,8 +42,11 @@ export interface VeredictoCompletude {
 /**
  * Insumos sem os quais o motor de cross-sell não pode concluir "não há o que recomendar".
  *
- * `regras` (associação) NÃO entra: uma base sem padrão de coocorrência é um estado
- * legítimo, e o motor ainda recomenda por popularidade. Já `vendaveis` entra mesmo
+ * `regras` (associação) NÃO entra AQUI: uma base sem padrão de coocorrência é um estado
+ * legítimo para ESTE motor, que segue recomendando por popularidade (`clusterAdherence`).
+ * A justificativa é do cross-sell e NÃO se transporta — o bundle não tem caminho por
+ * popularidade, e lá `regras` é obrigatório (ver `INSUMOS_OBRIGATORIOS_BUNDLE`). Já
+ * `vendaveis` entra mesmo
  * podendo ser legitimamente vazio (todo SKU sem custo conhecido é fail-closed por
  * desenho, #1466) — porque "nenhum SKU rentável em toda a base" é muito mais provável
  * ser custo não calculado do que verdade comercial, e o empate resolve fail-closed.
@@ -67,7 +70,10 @@ export const INSUMOS_OBRIGATORIOS_CROSS_SELL = [
   'clientes_com_profile',
 ] as const;
 
-/** Idem para o motor de bundles, que parte das regras de associação. */
+/**
+ * Idem para o motor de bundles — que, ao contrário do cross-sell, parte EXCLUSIVAMENTE das
+ * regras de associação.
+ */
 export const INSUMOS_OBRIGATORIOS_BUNDLE = [
   'scores',
   'catalogo',
@@ -75,6 +81,19 @@ export const INSUMOS_OBRIGATORIOS_BUNDLE = [
   'pedidos',
   'carteira_ativa',
   'clientes_com_profile',
+  // `regras` É obrigatório aqui, ao contrário do cross-sell: todo bundle nasce de
+  // `applicableRules`, que sai de `discoveredRules`. Sem regra descoberta o motor produz
+  // zero por CONSTRUÇÃO, não por não haver o que ofertar — e rotular esse zero de
+  // `completo` daria à fase 2 licença para expirar a carteira de bundles justamente
+  // quando o histórico ficou insuficiente. O próprio `useBundleEngine` já trata o caso
+  // assim ("zero regra descoberta quase sempre é dado faltando a montante, não 'a base
+  // não tem padrão'") e preserva as regras anteriores; era a completude que discordava
+  // dele.
+  //
+  // Não é hipótese: medido em 18/08/2026, 12 das 24 regras vivas tinham support 1,04%
+  // contra o piso de 1,00% — 5 cestas de 479 — e morrem assim que as cestas passarem
+  // de 499.
+  'regras',
 ] as const;
 
 /**


### PR DESCRIPTION
Follow-up do #1765 (sensor de geração do farmer). Fecha um dos dois pré-requisitos da fase 2 — e um que só apareceu porque o dry-run substituiu a espera passiva por medição.

## O defeito

`completude-snapshot.ts` excluía `regras` dos obrigatórios com uma justificativa registrada em comentário:

> uma base sem padrão de coocorrência é um estado legítimo, e o motor ainda recomenda por popularidade

Isso é verdade **para o cross-sell** — ele tem `clusterAdherence` e recomenda sem regra nenhuma. **Não é verdade para o bundle**: todo bundle nasce de `applicableRules`, que sai de `discoveredRules`. Sem regra descoberta ele devolve zero **sempre**, e esse zero sairia rotulado `completo`.

Como `completo` é o único rótulo que a fase 2 poderá usar para expirar, o zero-por-falta-de-regra viraria licença para apagar a carteira de bundles de uma vendedora justamente quando o histórico ficou insuficiente — o desfecho que o sensor inteiro existe para evitar.

O próprio `useBundleEngine` já discordava da completude: ao descobrir zero regras ele anota `desfecho='sem_regras'` e **preserva** as anteriores, comentando que *"zero regra descoberta quase sempre é dado faltando a montante, não 'a base não tem padrão'"*. Dois arquivos, duas leituras opostas do mesmo fato.

## Não é hipotético — medido em prod (18/08/2026, `psql-ro`)

| support | cestas da regra | morre acima de | regras |
|---|---|---|---|
| 1,04% | 5 | 499 cestas | **12** |
| 1,25% | 6 | 600 | 4 |
| 1,46–2,09% | 7–10 | 699–999 | 8 |

- piso `minSupport` = **1,00%**; a regra mais fraca está em **1,04%**, sobre **479 cestas**
- metade das regras morre quando as cestas passarem de **499** — estamos a 20 delas
- o volume mensal de pedidos com item resolvido oscila entre **155 e 428**, então o denominador varia muito de execução para execução

Dry-run dos dois motores no mesmo dia: o cross-sell não produz vazio nem no cliente mais saturado (folga de **217** SKUs elegíveis não comprados); o bundle depende inteiramente dessas 24 regras.

## O que muda

- `INSUMOS_OBRIGATORIOS_BUNDLE` passa a incluir `regras`; a lista do cross-sell **não** muda (a assimetria é o ponto).
- `useBundleEngine` declara `insumos.regras` com o array **inteiro** (`discoveredRules.length`) — é ele que alimenta `applicableRules`, não o top-50 gravado. Sem declarar, a lista nova tornaria toda execução `degradado` por ausência: fail-safe, mas cego.

## Testes

A suíte só exercia a lista do cross-sell — **a do bundle não tinha teste algum**, e foi por essa fresta que ela herdou `regras` como opcional. Três casos novos travam a assimetria nos dois sentidos, incluindo a mesma leitura dando veredicto diferente por motor.

**Falsificado:** removendo `'regras'` da lista, falham exatamente os 3 testes novos (`3 failed | 21 passed`) e os 21 antigos seguem verdes. Restaurado, `24 passed`.

Local: `typecheck` exit 0 · `bunx knip` exit 0 · teste alvo exit 0.

## Fora de escopo

O outro pré-requisito da fase 2 — cobertura de "histórico utilizável" (§7.5 do design do #1765) — fica de fora. Medido: **60,1%** dos itens resolvem para SKU do catálogo ativo (28.675 de 47.735), e **107 de 861** clientes têm pedido mas nenhum item utilizável. Fica registrado com número de partida, não fechado aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)