### PR TITLE
feat(hooks): o guard de DUPLICATA desce para o `git commit` — no `gh pr create` o trabalho JÁ está pronto

### DIFF
--- a/.claude/hooks/pr-duplicata-guard.sh
+++ b/.claude/hooks/pr-duplicata-guard.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# pr-duplicata-guard.sh — PreToolUse(Bash): AVISA (não nega) na hora do `gh pr create` quando o
-# ARTEFATO que este PR introduz JÁ EXISTE na origin/main — i.e. a tarefa já foi ENTREGUE por outra
-# sessão. Eixo OBJETIVO; o irmão pr-collision-guard.sh cobre o eixo ARQUIVO (conflito de merge).
+# pr-duplicata-guard.sh — PreToolUse(Bash): AVISA (não nega) quando o ARTEFATO que este trabalho
+# introduz JÁ EXISTE na origin/main — i.e. a tarefa já foi ENTREGUE por outra sessão. Eixo
+# OBJETIVO; o irmão pr-collision-guard.sh cobre o eixo ARQUIVO (conflito de merge).
+# DOIS gatilhos: `git commit` e `gh pr create`.
 #
 # Por que um hook e não (mais) uma frase: em 2026-08-15 uma única sessão produziu 3 duplicatas no
 # mesmo dia, com a regra do eixo OBJETIVO já escrita desde 2026-07-23 (worktrees.md, "achado
@@ -11,16 +12,41 @@
 # sob "o eixo do gate passa a ver COMPRAS"). Contramedida textual reincide; gate estrutural para.
 #
 # O TESTE (por (arquivo, símbolo), três vias — esta é a parte falsificada):
-#   1. ausente do ARQUIVO na merge-base   (não existia quando eu comecei)
-#   2. presente no ARQUIVO no meu HEAD    (fui EU que introduzi)
-#   3. presente no ARQUIVO na origin/main (alguém JÁ entregou enquanto eu trabalhava)
+#   1. ausente do ARQUIVO na merge-base    (não existia quando eu comecei)
+#   2. presente no ARQUIVO no meu trabalho (fui EU que introduzi)
+#   3. presente no ARQUIVO na origin/main  (alguém JÁ entregou enquanto eu trabalhava)
 # As três juntas são a assinatura da duplicata. Se a main não andou naquele arquivo, (1) e (3) se
 # contradizem e o hook cala sozinho — o silêncio é estrutural, não sorte.
+#
+# GATILHO 2 — `git commit` (2026-08-18): o create é tarde, pelo mesmo motivo que fez o guard irmão
+# descer no #1770 (eixo TEMPO). No create o trabalho JÁ está pronto: a rede evita o merge duplicado,
+# não o DESPERDÍCIO (#1757 6 arq/+270; #1764 1 arq/+29, morto 36s depois de criado).
+#   - a fonte do "meu trabalho" muda por modo: no commit o ALVO do diff é o ÍNDICE
+#     (`mb..index` = STAGED ∪ commits da branch numa expressão só) e a ÁRVORE em `git commit -a`.
+#     Olhar só o `mb..HEAD` seria TEATRO: no PRIMEIRO commit ele é VAZIO e o #1764 tinha 1 commit.
+#   - anti-alarm-fatigue: avisa 1x por (branch, conjunto de achados); achado NOVO fura o silêncio e
+#     o `gh pr create` NUNCA é silenciado (último portão).
+#   - SEM cache de rede: o `git fetch` é a única rede aqui e o resultado dele não é cacheado, de
+#     propósito — cache de estado volátil num guard é falso-negativo silencioso (versão com TTL de
+#     2min foi escrita e DESCARTADA no #1770 por mascarar colisão verdadeira nos próprios testes).
+#     Quem corta ruído é o dedupe do AVISO (por conteúdo), não cache da RESPOSTA (por tempo).
+#
+# ⚠️ Descer o gatilho NÃO cria ocasião de alarme nova, e isso é ESTRUTURAL: disparar exige o símbolo
+# ausente em `mb:$f` e presente em `origin/main:$f` ⇒ a main mexeu em `$f` desde a merge-base ⇒ `$f`
+# já está no conjunto (a) do pr-collision-guard, que avisa no commit desde o #1770. Este guard só
+# acrescenta PRECISÃO (nomeia o símbolo) dentro de um aviso que já sairia de qualquer forma.
 #
 # ⚠️ O escopo é POR ARQUIVO, não repo-wide, e isso foi MEDIDO, não escolhido: `reposicao_pos_marcador`
 # já existia em 10 arquivos (migrations) na merge-base, então um teste repo-wide de "símbolo novo" o
 # excluiria como "não é novo" → falso negativo em 1 das 3 ocorrências. O que era novo era o símbolo
 # NAQUELE arquivo (o registro no scripts/authz-manifest.ts). Precisão vem do par, não do símbolo.
+#
+# ⚠️ Precisão MEDIDA (2026-08-18; 60 PRs mergeados, 797 pares concorrentes numa janela de 8h): num
+# teto PESSIMISTA o par (arquivo,símbolo) dispara em 51 de 134 pares que compartilham arquivo. O
+# "símbolo" inclui nome REFERENCIADO, não só criado, e o ruído concentra em arquivo append-only
+# compartilhado (docs/historico/*.md, scripts/audit-custom-migrations.sql). Por isso a mensagem diz
+# "possível" e manda CONFERIR — nunca "você duplicou". Filtrar `docs/` daria falso negativo: a
+# ocorrência 2 das 3 reais era exatamente um follow-up de doc.
 #
 # Candidato = identificador de ≥12 chars contendo `_` ou corcova camelCase. O filtro de forma existe
 # para que prosa portuguesa em .md ("imediatamente", "implementacao") não vire candidato — só
@@ -30,7 +56,7 @@
 # Fail-open TOTAL: sem jq/git → exit 0; fetch falha → segue com refs locais; sem merge-base → exit 0;
 # arquivo ausente da main → pula (nada a duplicar ali). AVISA via additionalContext com
 # permissionDecision=allow — NUNCA bloqueia (PR legítimo que ESTENDE trabalho recém-mergeado existe).
-# Testes: scripts/test-pr-duplicata-guard.sh.
+# Testes: scripts/test-pr-duplicata-guard.sh (roda no CI via `bun run test:hooks`).
 set -u
 
 command -v jq  >/dev/null 2>&1 || exit 0
@@ -40,7 +66,7 @@ input="$(cat)"
 cmd="$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)"
 [ -n "$cmd" ] || exit 0
 
-# É um `gh pr create`? Sanitiza aspas/heredoc antes (menção "gh pr create" ≠ execução) — mesma
+# É um `gh pr create` ou um `git commit`? Sanitiza aspas/heredoc antes (menção ≠ execução) — mesma
 # detecção do pr-collision-guard.sh, deliberadamente idêntica para os dois guards concordarem.
 # shellcheck disable=SC2016  # \x27/\x22 são literais do regex do perl, não expansão de shell
 if command -v perl >/dev/null 2>&1; then
@@ -49,7 +75,13 @@ else
   scan="$(printf '%s' "$cmd" | sed "s/'[^']*'//g; s/\"[^\"]*\"//g" 2>/dev/null)"
 fi
 [ -n "$scan" ] || scan="$cmd"
-printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' || exit 0
+modo=""
+if printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+  modo="create"
+elif printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])git([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'; then
+  modo="commit"
+fi
+[ -n "$modo" ] || exit 0
 
 if command -v timeout >/dev/null 2>&1; then
   timeout 8 git fetch origin main --quiet >/dev/null 2>&1 || true
@@ -60,7 +92,18 @@ fi
 mb="$(git merge-base HEAD origin/main 2>/dev/null)" || exit 0
 [ -n "$mb" ] || exit 0
 
-mine="$(git diff --name-only "$mb" HEAD 2>/dev/null)" || exit 0
+# ALVO do diff — é o que distingue os dois gatilhos. No create, os commits da branch (mb..HEAD).
+# No commit o trabalho ainda NÃO está commitado: comparar com o ÍNDICE dá STAGED ∪ commits da
+# branch de uma vez; com `-a` o alvo é a ÁRVORE, que ainda soma o não-staged. Sem `-a` a árvore
+# fica de fora de propósito — aquele arquivo nem entraria no commit (achado do Codex, #1770).
+alvo=HEAD
+if [ "$modo" = commit ]; then
+  alvo=--cached
+  printf '%s' "$scan" | grep -qE '(^|[[:space:]])(-[a-zA-Z]*a[a-zA-Z]*|--all)([[:space:]]|$)' && alvo=""
+fi
+
+# shellcheck disable=SC2086  # $alvo é UMA palavra (HEAD/--cached) ou vazio de propósito (árvore)
+mine="$(git diff --name-only "$mb" $alvo 2>/dev/null)" || exit 0
 [ -n "$mine" ] || exit 0
 
 # Identificador significativo: ≥12 chars, com underscore OU corcova camelCase.
@@ -82,7 +125,8 @@ while IFS= read -r f; do
   [ -n "$main_c" ] || continue
   base_c="$(git show "$mb:$f" 2>/dev/null)" || base_c=""
 
-  add_ids="$(git diff "$mb" HEAD -- "$f" 2>/dev/null | grep '^+' | grep -v '^+++' | _ids)"
+  # shellcheck disable=SC2086  # idem: $alvo é palavra única ou vazio intencional
+  add_ids="$(git diff "$mb" $alvo -- "$f" 2>/dev/null | grep '^+' | grep -v '^+++' | _ids)"
   [ -n "$add_ids" ] || continue
 
   novos="$(comm -23 <(printf '%s\n' "$add_ids") <(printf '%s\n' "$base_c" | _ids) 2>/dev/null)"
@@ -98,13 +142,41 @@ EOF
 
 [ -n "$achados" ] || exit 0
 
-msg="⚠️ Possível DUPLICATA por OBJETIVO na hora do gh pr create (eixo OBJETIVO — worktrees.md; caso: docs/historico/duplicata-por-objetivo.md).
+# Anti-alarm-fatigue (só no commit): avisa 1x por (branch, conjunto de achados). Commit é
+# frequente — repetir o MESMO aviso cega o leitor. Achado novo = assinatura nova = avisa.
+# O `gh pr create` é o último portão e NUNCA é silenciado por este cache.
+if [ "$modo" = commit ]; then
+  cache_dir="${PRDG_CACHE_DIR:-${TMPDIR:-/tmp}/prdg-$(id -u 2>/dev/null || echo 0)}"
+  mkdir -p "$cache_dir" 2>/dev/null || true
+  assin="$(printf '%s\n%s' "$(git branch --show-current 2>/dev/null)" "$achados" \
+    | cksum 2>/dev/null | tr -cd '0-9')"
+  if [ -n "$assin" ]; then
+    marca="$cache_dir/visto-$assin"
+    if [ -f "$marca" ] && [ -z "$(find "$marca" -mmin +"${PRDG_VISTO_TTL_MIN:-360}" 2>/dev/null)" ]; then
+      exit 0   # já avisei este MESMO achado nesta branch — não repito
+    fi
+    : > "$marca" 2>/dev/null || true
+  fi
+fi
+
+if [ "$modo" = commit ]; then
+  quando="ANTES de commitar"
+  acao="Decida AGORA, antes de escrever mais: se o núcleo já mergeou, o barato é reduzir já ao seu
+DIFERENCIAL (ou abortar). Descobrir isso com o PR pronto custou 2 PRs em 2026-08-15 (#1757/#1764)."
+else
+  quando="na hora do gh pr create"
+  acao="Se o núcleo já mergeou: fechar > reconciliar — salve só o SEU diferencial sobre o vencedor
+(o desenho alheio já foi melhor 2x: #1560 e a891ba9c). Se este PR ESTENDE de propósito o que já
+entrou, ignore este aviso."
+fi
+
+msg="⚠️ Possível DUPLICATA por OBJETIVO $quando (eixo OBJETIVO — worktrees.md; caso: docs/historico/duplicata-por-objetivo.md).
 
 Estes símbolos NÃO existiam no arquivo quando você começou, você os introduz — e eles JÁ ESTÃO no mesmo arquivo na origin/main:
 $achados
-Ou seja: outra sessão pode ter entregue esta tarefa enquanto você trabalhava (padrão #1744/#1763 — 3 duplicatas em 2026-08-15). Confira ANTES de criar:
+Ou seja: outra sessão pode ter entregue esta tarefa enquanto você trabalhava (padrão #1744/#1763 — 3 duplicatas em 2026-08-15). Confira antes de seguir:
   git log -S '<símbolo>' origin/main --oneline -- <arquivo>
-Se o núcleo já mergeou: fechar > reconciliar — salve só o SEU diferencial sobre o vencedor (o desenho alheio já foi melhor 2×: #1560 e a891ba9c). Se este PR ESTENDE de propósito o que já entrou, ignore este aviso."
+$acao"
 jq -n --arg m "$msg" \
   '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"allow",additionalContext:$m}}'
 exit 0

--- a/docs/agent/worktrees.md
+++ b/docs/agent/worktrees.md
@@ -102,8 +102,8 @@ PR o nome que tiver — e sem o `git fetch` na frente o grep devolve "não exist
 procura de verdade. Caso completo: [duplicata-por-objetivo.md](../historico/duplicata-por-objetivo.md).
 
 **Rede automática (2026-08-18):** hook `.claude/hooks/pr-duplicata-guard.sh` (PreToolUse Bash) —
-irmão do `pr-collision-guard.sh`, que cobre só o eixo ARQUIVO. Na hora do `gh pr create` ele testa,
-por **(arquivo, símbolo)**, três vias: ausente do arquivo na merge-base + introduzido por mim +
+irmão do `pr-collision-guard.sh`, que cobre só o eixo ARQUIVO. Nos DOIS chokepoints (`git commit` e
+`gh pr create`) ele testa, por **(arquivo, símbolo)**, três vias: ausente do arquivo na merge-base + introduzido por mim +
 **já presente no mesmo arquivo na `origin/main`**. As três juntas são a assinatura da duplicata; se a
 main não andou naquele arquivo, (1) e (3) se contradizem e o hook cala — o silêncio é estrutural, não
 sorte. **AVISA** via `additionalContext`, nunca nega (PR que ESTENDE de propósito o recém-mergeado
@@ -112,11 +112,63 @@ existe). Fail-open total (sem `jq`/`git`, sem merge-base, arquivo ausente da mai
 arquivos (migrations) na merge-base, então um teste repo-wide de "símbolo novo" o excluiria → falso
 negativo em 1 das 3 ocorrências. Candidato = identificador de ≥12 chars com `_` ou corcova camelCase
 (filtro de forma que mantém prosa portuguesa de `.md` fora). Testes:
-`scripts/test-pr-duplicata-guard.sh` — 8 casos + **falsificação por sabotagem de cada via** numa
-CÓPIA do hook (remover a via 1 ou a via 3, ou trocar o escopo por repo-wide, tem de virar vermelho).
+`scripts/test-pr-duplicata-guard.sh` — 13 casos + **falsificação por sabotagem de cada via E de cada
+decisão do gatilho 2** numa CÓPIA do hook (remover a via 1 ou a via 3, trocar o escopo por repo-wide,
+fazer o commit olhar `mb..HEAD` em vez do índice, ou matar o dedupe: cada uma tem de virar vermelho).
+⚠️ Ele **não rodava no CI** até 2026-08-18: o #1769 criou o arquivo e não o pôs no laço do
+`test:hooks` (que listava os guards por nome). Teste órfão é `grep` sem ocorrência — ausência de
+dado com cara de verde; corrigido junto com o gatilho 2.
 **Limite:** pega o símbolo que você **escreve**; a duplicata cujo artefato é puro comportamento (mesma
 correção, símbolos diferentes — o caso `DENO_NO_PACKAGE_JSON` só é pego porque o nome coincide)
 continua fora do alcance, como a race fria de duas sessões sem PR aberto.
+
+⚠️ **E o gatilho desceu para o `git commit` — o mesmo furo de TEMPO do guard irmão (2026-08-18).**
+No `gh pr create` o trabalho JÁ está pronto: a detecção evita o merge duplicado, não o DESPERDÍCIO
+(#1757 6 arq/+270; #1764 1 arq/+29, morto 36s depois de criado). O que muda no commit é a **fonte do
+"meu trabalho"**: o alvo do diff passa a ser o **ÍNDICE** (`git diff <mb> --cached` = STAGED ∪ commits
+da branch numa expressão só) e a **ÁRVORE** em `git commit -a`. Olhar só o `mb..HEAD` seria TEATRO —
+no PRIMEIRO commit ele é VAZIO e o #1764 tinha 1 commit só; é a sabotagem (D) do teste, que tem de
+emudecer o caso do #1764. Anti-alarm-fatigue (1 aviso por (branch, conjunto de achados); achado novo
+fura o silêncio; o `create` nunca é silenciado) e a **ausência de cache de rede** vieram idênticos do
+`pr-collision-guard`: o que corta ruído é o dedupe do AVISO (por conteúdo), nunca cache da RESPOSTA
+(por tempo).
+
+**Descer aqui não custa alarme NOVO, e isso é estrutural — não estimativa.** Disparar exige o símbolo
+ausente em `<mb>:<arquivo>` **e** presente em `origin/main:<arquivo>` ⇒ a main mexeu naquele arquivo
+desde a merge-base ⇒ o arquivo já está no conjunto (a) do `pr-collision-guard`, que avisa no commit
+desde o #1770. Ou seja: **o conjunto de disparos deste guard é subconjunto do daquele** — ele nunca
+fala onde o irmão cala, só acrescenta PRECISÃO (nomeia o símbolo) dentro de um aviso que já sairia.
+Foi esse teorema, e não uma aposta de ruído, que autorizou a descida.
+
+⚠️ **A precisão do eixo OBJETIVO é MODESTA — medido, não suposto (2026-08-18).** Replay do teste de
+3 vias sobre **797 pares de PRs mergeados concorrentemente** (janela de 8h, 60 PRs): num teto
+**pessimista** (merge-base propositalmente velha) o par (arquivo,símbolo) dispara em **51 de 134**
+pares que compartilham arquivo — e como os dois PRs de cada par mergearam, ali todo disparo é falso
+positivo.
+A causa é o que conta como símbolo: "novo NO arquivo" inclui nome **referenciado**, não só criado
+(`AUTHZ_MANIFEST`, `service_role`), e o ruído concentra em arquivo append-only compartilhado
+(`docs/historico/*.md` + `scripts/audit-custom-migrations.sql` sozinhos = 27 dos 51). ⇒ a mensagem diz
+"**possível** duplicata" e manda CONFERIR com `git log -S`; lê-la como veredito é erro de leitura.
+**Filtrar `docs/` foi REJEITADO:** a ocorrência 2 das 3 reais era exatamente um follow-up de doc — o
+filtro compraria silêncio ao preço de um falso negativo já medido.
+
+**O que NÃO foi medido (registrado, não resolvido):** o falso positivo que só o gatilho do commit
+pode criar — símbolo escrito no commit K e REMOVIDO até a ponta da branch, que o `create` nunca
+veria. O replay por-commit das 60 branches reais (buscadas por `refs/pull/N/head`, que dão o
+merge-base VERDADEIRO) foi montado e **não terminou** (~50min, morto antes do fim) ⇒ esse número não
+existe; não o invente. O que existe é o limite superior: **38 das 60 branches têm 1 commit só** — ali
+o gatilho dispara uma vez, com o trabalho inteiro no índice, e é a avaliação do `create` mais cedo,
+sem janela nenhuma para transitório. Sobram 22 branches (2 a 9 commits) onde o transitório é
+possível; e mesmo lá o aviso era VERDADEIRO no instante em que saiu (o símbolo estava escrito e
+estava na main). ⇒ classe pequena e limitada, não zero.
+
+**Custo que a descida introduz (medido no repo real, 2026-08-18):** ~4,2s por `git commit` — `git
+fetch origin main` ~0,8-1,1s + ~170ms por arquivo (3 invocações de `git` cada, teto de 25 ⇒ pior
+caso ~5s) — e isso **soma** com o fetch do `pr-collision-guard`, que roda no mesmo gatilho. Antes
+era 1× por PR; agora é por commit. Não há como cortar pelo lado da rede: pular o fetch por
+recência é justamente o cache de estado volátil rejeitado no #1770, e grep contra `origin/main`
+defasada devolve "não existe" com cara de procura de verdade. Fica REGISTRADO, não otimizado —
+otimizar sem sinal de incômodo é a fase N+1 sem sinal da fase N.
 
 **Rede automática (2026-07-23):** hook `.claude/hooks/pr-collision-guard.sh` (PreToolUse Bash)
 re-executa a conferência POR ARQUIVO na hora do `gh pr create` — fetch fresco + interseção de TRÊS

--- a/docs/historico/duplicata-por-objetivo.md
+++ b/docs/historico/duplicata-por-objetivo.md
@@ -92,8 +92,57 @@ Irmã da regra "sincronize antes de MEDIR" (`worktrees.md`).
 - **`.claude/hooks/pr-duplicata-guard.sh`** (2026-08-18) — o fecho ESTRUTURAL. A cláusula acima é
   contramedida textual, e a meta-regra do catálogo de retrabalho diz que contramedida textual
   reincide: a regra do eixo OBJETIVO já existia desde 2026-07-23 e não segurou as 3 ocorrências.
-  O hook testa as três vias por (arquivo, símbolo) na hora do `gh pr create` e AVISA.
+  O hook testa as três vias por (arquivo, símbolo) e AVISA — **no `git commit` e no `gh pr create`**
+  (o gatilho do commit desceu no mesmo dia; §abaixo).
 - Aqui — as 3 ocorrências e a falsificação.
+
+## O gatilho desceu para o `git commit` — e o que a medição autorizou (2026-08-18)
+
+O hook nasceu só no `gh pr create`, e isso repetia o furo de TEMPO que o guard irmão
+(`pr-collision-guard.sh`) já havia corrigido no #1770: **no `create` o trabalho JÁ está pronto**, então
+a rede evita o merge duplicado e não o DESPERDÍCIO — #1757 (6 arq, +270) e #1764 (1 arq, +29) foram
+escritos e descartados no mesmo dia, o #1764 morto 36s depois de criado. Decisões reusadas verbatim do
+irmão: conjunto = STAGED ∪ commits da branch (∪ árvore só em `-a`); 1 aviso por (branch, conjunto de
+achados), com achado novo furando o silêncio e o `create` nunca silenciado; e **nenhum cache de rede**.
+
+O que **não** era transplante — e por isso foi medido antes de implementar — é o risco próprio deste
+eixo: extrair "o símbolo que eu ia criar" é mais ruidoso que interseção de nomes de arquivo, e um
+detector impreciso disparando a cada commit cega o leitor e degrada o portão do `create` junto.
+
+**Duas evidências decidiram, em direções opostas:**
+
+1. **Contra descer — a precisão é modesta.** Replay do teste de 3 vias sobre **797 pares de PRs
+   mergeados concorrentemente** (janela de 8h, 60 PRs): num teto **pessimista** (merge-base velha) o par
+   (arquivo,símbolo) dispara em **51 de 134** pares que compartilham arquivo. Os dois PRs de cada par
+   mergearam ⇒ ali todo disparo é falso positivo. Causa: "símbolo novo NO arquivo" inclui nome
+   **referenciado**, não só criado (`AUTHZ_MANIFEST`, `service_role`), e o ruído concentra em arquivo
+   append-only compartilhado — `docs/historico/*.md` + `scripts/audit-custom-migrations.sql` sozinhos
+   são 27 dos 51.
+2. **A favor — descer não cria ocasião de alarme nova, e é teorema, não estimativa.** Disparar exige o
+   símbolo ausente em `<mb>:<arquivo>` **e** presente em `origin/main:<arquivo>` ⇒ a main mexeu naquele
+   arquivo desde a merge-base ⇒ o arquivo já está no conjunto (a) do `pr-collision-guard`, que avisa no
+   commit desde o #1770. **O conjunto de disparos deste guard é subconjunto do daquele:** ele nunca
+   fala onde o irmão cala. O custo marginal de descer não é "um alarme novo por commit" — é uma linha a
+   mais dentro de um alarme que já sairia, e essa linha nomeia o símbolo, que é justamente o que torna a
+   conferência barata.
+
+**O buraco honesto na medição:** o FP que só o commit pode criar — símbolo escrito no commit K e
+removido até a ponta — ficou SEM número. O replay por-commit das 60 branches reais (via
+`refs/pull/N/head`, que dá o merge-base verdadeiro) foi montado e morreu antes de terminar (~50min).
+O que sobrou é o limite: **38 das 60 branches têm 1 commit só**, e nelas o gatilho é a avaliação do
+`create` mais cedo, sem janela para transitório; nas outras 22 a classe existe mas o aviso era
+verdadeiro quando saiu. Classe pequena e limitada — não zero, e não medida. Registrado assim de
+propósito: inventar o número seria pior que admitir o buraco.
+
+⇒ **desce o gatilho, e a imprecisão vira redação:** a mensagem diz "**possível** duplicata" e manda
+conferir com `git log -S`, nunca "você duplicou". **Filtrar `docs/` foi REJEITADO** (para não voltar
+como ideia nova): a ocorrência 2 das 3 acima era exatamente um follow-up de doc — o filtro compraria
+silêncio ao preço de um falso negativo já medido.
+
+**Achado de tabela:** o `scripts/test-pr-duplicata-guard.sh` do #1769 **não rodava no CI** — o arquivo
+foi criado, mas o laço do `test:hooks` lista os guards por nome e ele ficou de fora. Teste órfão é a
+forma mais cara de "ausência de sinal com cara de verde" (irmã do `grep` sem ocorrência, do linter sem
+a regra). Corrigido nesta entrega, junto com os 5 casos novos e as 2 falsificações novas.
 
 ## Precedente
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "wt:label": "bash scripts/wt-map.sh label",
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
-    "test:hooks": "for t in heavy pr-collision migration-collision branch-pos-squash; do bash scripts/test-$t-guard.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash; do bash scripts/test-$t-guard.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 # test-pr-duplicata-guard.sh — TDD do hook pr-duplicata-guard.sh (git STUBADO, sem rede).
 #
-# Regra: `gh pr create` em que um símbolo (a) era AUSENTE do arquivo na merge-base, (b) é
-#        introduzido por mim e (c) JÁ ESTÁ no mesmo arquivo na origin/main → AVISA via
+# Regra (gatilho 1 — `gh pr create`): um símbolo (a) AUSENTE do arquivo na merge-base, (b)
+#        introduzido por mim e (c) JÁ no mesmo arquivo na origin/main → AVISA via
 #        additionalContext (permissionDecision=allow), SEM bloquear. Qualquer via faltando,
-#        comando ≠ `gh pr create`, ou erro de infra → stdout mudo. Fail-open.
+#        comando fora do gatilho, ou erro de infra → stdout mudo. Fail-open.
+#
+# Regra (gatilho 2 — `git commit`, 2026-08-18): mesma prova no chokepoint ANTERIOR, porque no
+#        create o trabalho JÁ está pronto — a rede evita o merge duplicado, não o DESPERDÍCIO
+#        (#1757: 6 arq/+270; #1764: 1 arq/+29, morto 36s após criado). No commit o trabalho ainda
+#        não está commitado: o alvo do diff passa a ser o ÍNDICE (mb..index = STAGED ∪ commits da
+#        branch numa expressão só), e a ÁRVORE em `git commit -a`. Olhar só o mb..HEAD seria
+#        TEATRO — no PRIMEIRO commit ele é VAZIO, e o #1764 tinha 1 commit só (caso 9).
+#        Anti-alarm-fatigue: 1 aviso por (branch, conjunto colidente); achado NOVO fura o
+#        silêncio e o `gh pr create` NUNCA é silenciado (último portão) — casos 12 e 13.
 #
 # O caso 8 é o que dá sentido ao desenho: ele codifica a MEDIÇÃO que escolheu o escopo por
 # ARQUIVO em vez de repo-wide (reposicao_pos_marcador já existia em 10 arquivos na merge-base;
@@ -20,19 +29,40 @@ stub="$(mktemp -d)"
 trap 'rm -rf "$stub"' EXIT
 export STUBDIR="$stub"
 
+# stub de git. O ALVO do diff é o que distingue os gatilhos e por isso o stub responde DIFERENTE
+# para cada um — se respondesse igual, os casos 9/10/11 passariam mesmo com o hook ignorando o
+# staged, e seriam teatro.  HEAD = create · --cached = commit · nenhum = commit -a (árvore).
 cat >"$stub/git" <<'STUB'
 #!/bin/sh
 _slug() { printf '%s' "$1" | tr '/.' '__'; }
+_alvo() {
+  case " $* " in
+    *" --cached "*) echo cached ;;
+    *" HEAD "*)     echo head ;;
+    *)              echo wt ;;
+  esac
+}
 case "$1" in
   fetch) exit 0 ;;
   merge-base) [ -n "${GIT_STUB_NO_MB:-}" ] && exit 128; echo MB ;;
+  branch) printf '%s\n' "${GIT_STUB_BRANCH-minha-branch}" ;;
   diff)
+    a="$(_alvo "$@")"
     case "$*" in
-      *--name-only*) cat "${GIT_STUB_MINE_FILE:-/dev/null}" ;;
+      *--name-only*)
+        case "$a" in
+          head)   cat "${GIT_STUB_MINE_FILE:-/dev/null}" ;;
+          cached) cat "${GIT_STUB_STAGED_FILE:-/dev/null}" ;;
+          wt)     cat "${GIT_STUB_WT_FILE:-/dev/null}" ;;
+        esac ;;
       *)
         f=""
-        for a in "$@"; do f="$a"; done
-        cat "$STUBDIR/diff_$(_slug "$f")" 2>/dev/null || true ;;
+        for x in "$@"; do f="$x"; done
+        case "$a" in
+          head)   cat "$STUBDIR/diff_$(_slug "$f")"    2>/dev/null || true ;;
+          cached) cat "$STUBDIR/dcached_$(_slug "$f")" 2>/dev/null || true ;;
+          wt)     cat "$STUBDIR/dwt_$(_slug "$f")"     2>/dev/null || true ;;
+        esac ;;
     esac ;;
   show)
     case "$2" in
@@ -47,6 +77,11 @@ esac
 STUB
 chmod +x "$stub/git"
 export PATH="$stub:$PATH"
+
+# cache do dedupe ISOLADO por execução — senão o teste herda marcas de uma rodada anterior
+# (falso "mudo") ou suja o TMPDIR do founder.
+CACHE="$stub/cache"
+DEDUPE="PRDG_CACHE_DIR=$CACHE"
 
 fail=0
 # _hook "<envs>" "<cmd>" → stdout do hook
@@ -65,18 +100,30 @@ _deve_calar()  { if _avisa "$2"; then _bad "$1"; else _ok "$1"; fi; }
 
 # ---------- cenário base: eu adiciono `reposicao_pos_marcador` ao manifesto ----------
 CRIAR='gh pr create --title x --body y'
+COMITAR='git commit -m "wip"'
+COMITAR_A='git commit -am "wip"'
 printf 'scripts/authz-manifest.ts\n' > "$stub/mine.txt"
+: > "$stub/vazio.txt"
 MINE="GIT_STUB_MINE_FILE=$stub/mine.txt"
 
-# meu diff introduz o símbolo
-printf '+++ b/scripts/authz-manifest.ts\n+  reposicao_pos_marcador: { requiredGate: "compras" },\n' \
-  > "$stub/diff_scripts_authz-manifest_ts"
+# meu diff introduz o símbolo — mesmo conteúdo servido nos três alvos, para que a DIFERENÇA
+# entre os casos venha de QUAL alvo o hook pede, não do conteúdo.
+DIFF='+++ b/scripts/authz-manifest.ts\n+  reposicao_pos_marcador: { requiredGate: "compras" },\n'
+# shellcheck disable=SC2059  # DIFF é formato controlado deste teste, com \n intencional
+printf "$DIFF" > "$stub/diff_scripts_authz-manifest_ts"
+# shellcheck disable=SC2059
+printf "$DIFF" > "$stub/dcached_scripts_authz-manifest_ts"
+# shellcheck disable=SC2059
+printf "$DIFF" > "$stub/dwt_scripts_authz-manifest_ts"
 # na merge-base o arquivo NÃO tinha o símbolo
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n' \
-  > "$stub/base_scripts_authz-manifest_ts"
+BASE='export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n'
 # na origin/main o símbolo JÁ ESTÁ (outra sessão entregou)
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
-  > "$stub/main_scripts_authz-manifest_ts"
+MAIN='export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n'
+# shellcheck disable=SC2059
+_base() { printf "$BASE" > "$stub/base_scripts_authz-manifest_ts"; }
+# shellcheck disable=SC2059
+_main() { printf "$MAIN" > "$stub/main_scripts_authz-manifest_ts"; }
+_base; _main
 
 echo "== 1. as três vias satisfeitas → AVISA =="
 out="$(_hook "$MINE" "$CRIAR")"
@@ -90,19 +137,19 @@ echo "== 2. símbolo JÁ existia na merge-base → mudo (uso normal, não criaç
 cp "$stub/main_scripts_authz-manifest_ts" "$stub/base_scripts_authz-manifest_ts"
 out="$(_hook "$MINE" "$CRIAR")"
 _deve_calar "mudo quando o símbolo é pré-existente" "$out"
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n' \
-  > "$stub/base_scripts_authz-manifest_ts"
+_base
 
 echo "== 3. símbolo novo AUSENTE da main → mudo (trabalho genuinamente novo) =="
 cp "$stub/base_scripts_authz-manifest_ts" "$stub/main_scripts_authz-manifest_ts"
 out="$(_hook "$MINE" "$CRIAR")"
 _deve_calar "mudo no caminho feliz (ninguém entregou)" "$out"
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
-  > "$stub/main_scripts_authz-manifest_ts"
+_main
 
-echo "== 4. comando não é gh pr create → mudo =="
-for c in 'echo "gh pr create"' 'gh pr list' 'git commit -m "fala de gh pr create"'; do
-  out="$(_hook "$MINE" "$c")"
+echo "== 4. comando fora dos DOIS gatilhos → mudo =="
+# `git commit` agora É gatilho — o que tem de continuar mudo é a MENÇÃO (aspas/heredoc) e
+# comandos vizinhos de nome parecido.
+for c in 'echo "gh pr create"' 'echo "git commit -m x"' 'gh pr list' 'git commit-tree -m x' 'git log --grep=commit'; do
+  out="$(_hook "$MINE $DEDUPE" "$c")"
   _deve_calar "mudo em: $c" "$out"
 done
 
@@ -110,8 +157,7 @@ echo "== 5. arquivo ausente da origin/main → mudo =="
 rm -f "$stub/main_scripts_authz-manifest_ts"
 out="$(_hook "$MINE" "$CRIAR")"
 _deve_calar "mudo sem o arquivo na main (nada a duplicar)" "$out"
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
-  > "$stub/main_scripts_authz-manifest_ts"
+_main
 
 echo "== 6. fail-open: sem merge-base → mudo =="
 out="$(_hook "$MINE GIT_STUB_NO_MB=1" "$CRIAR")"
@@ -137,51 +183,114 @@ printf 'CREATE FUNCTION reposicao_pos_marcador() ...\n' > "$stub/main_supabase_m
 out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine8.txt" "$CRIAR")"
 _deve_avisar "dispara apesar do símbolo existir noutro arquivo na base" "$out"
 
+# =======================================================================================
+# GATILHO 2 — `git commit`. O que estes casos provam é que a FONTE do conjunto muda por modo.
+# =======================================================================================
+echo "== 9. #1764: mb..HEAD VAZIO (primeiro commit) mas STAGED tem o símbolo → AVISA =="
+# O caso cego do diff de 3 pontos: 1 commit só. Se o hook olhasse mb..HEAD no commit, calaria.
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt $DEDUPE" "$COMITAR")"
+_deve_avisar "avisa no commit com o trabalho só no índice" "$out"
+if printf '%s' "$out" | grep -q 'ANTES de commitar'; then
+  _ok "mensagem do commit fala em decidir ANTES de escrever mais"; else _bad "mensagem devia ser a do commit"; fi
+
+echo "== 10. cada modo lê a SUA fonte (create=HEAD, commit=índice) =="
+rm -rf "$CACHE"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine.txt GIT_STUB_STAGED_FILE=$stub/vazio.txt $DEDUPE" "$COMITAR")"
+_deve_calar "commit ignora o mb..HEAD (nada staged = nada a avisar)" "$out"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine.txt GIT_STUB_STAGED_FILE=$stub/vazio.txt" "$CRIAR")"
+_deve_avisar "create ignora o índice e usa o mb..HEAD" "$out"
+
+echo "== 11. working-tree só entra em \`git commit -a\` =="
+rm -rf "$CACHE"
+WT="GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/vazio.txt GIT_STUB_WT_FILE=$stub/mine.txt"
+out="$(_hook "$WT $DEDUPE" "$COMITAR")"
+_deve_calar "commit sem -a não olha a árvore (o arquivo nem iria no commit)" "$out"
+rm -rf "$CACHE"
+out="$(_hook "$WT $DEDUPE" "$COMITAR_A")"
+_deve_avisar "commit -a olha a árvore" "$out"
+
+echo "== 12. anti-alarm-fatigue: mesmo achado não repete; achado NOVO fura o silêncio =="
+rm -rf "$CACHE"
+C9="GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt $DEDUPE"
+out="$(_hook "$C9" "$COMITAR")";  _deve_avisar "1º commit avisa" "$out"
+out="$(_hook "$C9" "$COMITAR")";  _deve_calar  "2º commit com o MESMO achado é mudo" "$out"
+# achado NOVO (outro arquivo/símbolo) tem de furar o silêncio
+printf 'src/lib/novo.ts\n' > "$stub/mine12.txt"
+printf '+++ b/src/lib/novo.ts\n+export const calcularMargemFaixa = 1\n' > "$stub/dcached_src_lib_novo_ts"
+printf 'export const outraCoisaQualquer = 0\n' > "$stub/base_src_lib_novo_ts"
+printf 'export const outraCoisaQualquer = 0\nexport const calcularMargemFaixa = 1\n' > "$stub/main_src_lib_novo_ts"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine12.txt $DEDUPE" "$COMITAR")"
+_deve_avisar "colisão NOVA fura o silêncio do dedupe" "$out"
+# ...e a branch faz parte da assinatura: outra branch com o MESMO achado volta a avisar
+out="$(_hook "$C9 GIT_STUB_BRANCH=outra-branch" "$COMITAR")"
+_deve_avisar "outra branch com o mesmo achado avisa (assinatura inclui a branch)" "$out"
+
+echo "== 13. o \`gh pr create\` NUNCA é silenciado pelo dedupe (último portão) =="
+out="$(_hook "$MINE $DEDUPE" "$CRIAR")"; _deve_avisar "create avisa a 1ª vez" "$out"
+out="$(_hook "$MINE $DEDUPE" "$CRIAR")"; _deve_avisar "create avisa DE NOVO — nunca é silenciado" "$out"
+
 # ---------------------------------------------------------------------------------------
-# 9. FALSIFICAÇÃO — sabotar e EXIGIR vermelho. Sem isto os 8 casos acima são teatro: um hook
-# que nunca avisasse passaria em 2,3,4,5,6,7 e um que sempre avisasse passaria em 1 e 8.
+# 14. FALSIFICAÇÃO — sabotar e EXIGIR vermelho. Sem isto os casos acima são teatro: um hook
+# que nunca avisasse passaria em 2,3,4,5,6,7,10a,11a,12b e um que sempre avisasse passaria no resto.
 # A sabotagem é aplicada numa CÓPIA (nunca no original) — restaurar por `git checkout --`
 # destruiria trabalho não-commitado, armadilha já registrada no §9 do money-path.
 # ---------------------------------------------------------------------------------------
-echo "== 9. falsificação: cada via do teste tem de ser LOAD-BEARING =="
+echo "== 14. falsificação: cada via/decisão tem de ser LOAD-BEARING =="
 
-_sabota() { # $1=nome  $2=expr sed  $3=cenário(mine)  $4=veredito esperado da SABOTADA
-  local nome="$1" expr="$2" mine="$3" esperado="$4" out
+_sabota() { # $1=nome  $2=expr sed  $3=envs do cenário  $4=cmd  $5=veredito esperado da SABOTADA
+  local nome="$1" expr="$2" envs="$3" cmd="$4" esperado="$5" out
   sed "$expr" "$HOOK" > "$stub/sabotado.sh"
   if cmp -s "$HOOK" "$stub/sabotado.sh"; then
     _bad "sabotagem '$nome' não mudou nada (padrão sed obsoleto — o teste estaria cego)"
     return
   fi
-  out="$(HOOK_ATUAL=$stub/sabotado.sh _hook "GIT_STUB_MINE_FILE=$mine" "$CRIAR")"
+  rm -rf "$CACHE"
+  out="$(HOOK_ATUAL=$stub/sabotado.sh _hook "$envs" "$cmd")"
   if [ "$esperado" = avisa ]; then
-    if _avisa "$out"; then _ok "sabotagem '$nome' → vermelho como esperado (via é load-bearing)"
-    else _bad "sabotagem '$nome' NÃO mudou o veredito — a via não está sendo testada"; fi
+    if _avisa "$out"; then _ok "sabotagem '$nome' → vermelho como esperado (é load-bearing)"
+    else _bad "sabotagem '$nome' NÃO mudou o veredito — não está sendo testada"; fi
   else
-    if _avisa "$out"; then _bad "sabotagem '$nome' NÃO mudou o veredito — a via não está sendo testada"
-    else _ok "sabotagem '$nome' → vermelho como esperado (via é load-bearing)"; fi
+    if _avisa "$out"; then _bad "sabotagem '$nome' NÃO mudou o veredito — não está sendo testada"
+    else _ok "sabotagem '$nome' → vermelho como esperado (é load-bearing)"; fi
   fi
 }
 
 # (A) remover a via 1 (ausência na merge-base): o cenário 2 — símbolo PRÉ-EXISTENTE — passa a avisar.
 cp "$stub/main_scripts_authz-manifest_ts" "$stub/base_scripts_authz-manifest_ts"
 # shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
-_sabota "sem a via 1 (ausencia na base)" 's|^  novos=.*|  novos="$add_ids"|' "$stub/mine.txt" avisa
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n}\n' \
-  > "$stub/base_scripts_authz-manifest_ts"
+_sabota "sem a via 1 (ausencia na base)" 's|^  novos=.*|  novos="$add_ids"|' "$MINE" "$CRIAR" avisa
+_base
 
 # (C) remover a via 3 (presença na main): o cenário 3 — ninguém entregou — passa a avisar.
 cp "$stub/base_scripts_authz-manifest_ts" "$stub/main_scripts_authz-manifest_ts"
 # shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
-_sabota "sem a via 3 (presenca na main)" 's|^  dup=.*|  dup="$novos"|' "$stub/mine.txt" avisa
-printf 'export const AUTHZ_MANIFEST = {\n  reposicao_pos_candidatos: { requiredGate: "compras" },\n  reposicao_pos_marcador: { requiredGate: "compras" },\n}\n' \
-  > "$stub/main_scripts_authz-manifest_ts"
+_sabota "sem a via 3 (presenca na main)" 's|^  dup=.*|  dup="$novos"|' "$MINE" "$CRIAR" avisa
+_main
 
 # (B) trocar o ESCOPO por repo-wide (acumular a base de todos os arquivos): o cenário 8 emudece.
 # É a variante que a medição rejeitou — 1 falso negativo em 3 ocorrências reais.
 # shellcheck disable=SC2016  # sed: o padrão é literal do hook, expandir aqui o quebraria
 _sabota "escopo repo-wide em vez de por arquivo" \
   's|^  base_c=.*|  base_c="${acc:-}$(git show "$mb:$f" 2>/dev/null)"; acc="$base_c"|' \
-  "$stub/mine8.txt" cala
+  "GIT_STUB_MINE_FILE=$stub/mine8.txt" "$CRIAR" cala
+
+# (D) TEATRO do 3 pontos: se o commit olhasse mb..HEAD em vez do índice, o #1764 (caso 9) emudece.
+# É a falsificação que dá sentido ao gatilho 2 inteiro.
+_sabota "commit olhando mb..HEAD (o 3 pontos TEATRO)" 's|^  alvo=--cached$|  alvo=HEAD|' \
+  "GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt $DEDUPE" "$COMITAR" cala
+
+# (E) matar o dedupe: o 2º commit idêntico do caso 12 volta a avisar (o silêncio é REAL, não sorte).
+sed 's|^      exit 0 .*|      :|' "$HOOK" > "$stub/sem-dedupe.sh"
+if cmp -s "$HOOK" "$stub/sem-dedupe.sh"; then
+  _bad "sabotagem 'sem dedupe' não mudou nada (padrão sed obsoleto)"
+else
+  rm -rf "$CACHE"
+  C9="GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt $DEDUPE"
+  HOOK_ATUAL=$stub/sem-dedupe.sh _hook "$C9" "$COMITAR" >/dev/null
+  out="$(HOOK_ATUAL=$stub/sem-dedupe.sh _hook "$C9" "$COMITAR")"
+  if _avisa "$out"; then _ok "sabotagem 'sem dedupe' → 2º commit volta a avisar (dedupe é load-bearing)"
+  else _bad "sabotagem 'sem dedupe' NÃO mudou o veredito — o silêncio do caso 12 não é do dedupe"; fi
+fi
 
 echo
 if [ "$fail" -eq 0 ]; then echo "✅ pr-duplicata-guard: tudo verde"; else echo "❌ pr-duplicata-guard: FALHAS acima"; fi


### PR DESCRIPTION
O `pr-duplicata-guard.sh` (#1769, eixo OBJETIVO) nascia só no `gh pr create` e repetia o furo de TEMPO que o irmão `pr-collision-guard.sh` corrigiu no #1770: ali a rede evita o **merge duplicado**, não o **DESPERDÍCIO** — #1757 (6 arq, +270) e #1764 (1 arq, +29) foram escritos e descartados no mesmo dia, o #1764 morto 36s depois de criado.

## O que muda

No commit o trabalho ainda não está commitado, então o **alvo do diff** passa a ser o **ÍNDICE** (`git diff <mb> --cached` = STAGED ∪ commits da branch numa expressão só) e a **ÁRVORE** em `git commit -a`. Olhar só o `mb..HEAD` seria **TEATRO**: no primeiro commit ele é VAZIO e o #1764 tinha 1 commit só.

Reusado verbatim do guard irmão: anti-alarm-fatigue (1 aviso por `(branch, conjunto de achados)`, achado novo fura o silêncio, o `create` **nunca** é silenciado) e **nenhum cache de rede** (cache de estado volátil num guard é falso-negativo silencioso — a versão com TTL de 2min foi escrita e descartada no #1770).

## A tarefa pedia para PESAR antes de implementar — aqui está o peso

**Contra descer — a precisão é modesta, e isso foi medido.** Replay do teste de 3 vias sobre **797 pares de PRs mergeados concorrentemente** (janela de 8h, 60 PRs): num teto **pessimista** (merge-base propositalmente velha) o par (arquivo,símbolo) dispara em **51 de 134** pares que compartilham arquivo. Como os dois PRs de cada par mergearam, ali **todo disparo é falso positivo**. A causa é o que conta como símbolo: "novo NO arquivo" inclui nome **referenciado**, não só criado (`AUTHZ_MANIFEST`, `service_role`), e o ruído concentra em arquivo append-only compartilhado — `docs/historico/*.md` + `scripts/audit-custom-migrations.sql` sozinhos são **27 dos 51**.

**A favor — e isto é teorema, não estimativa.** Disparar exige o símbolo **ausente** em `<mb>:<arquivo>` **e presente** em `origin/main:<arquivo>` ⇒ a main mexeu naquele arquivo desde a merge-base ⇒ o arquivo **já está no conjunto (a) do `pr-collision-guard`**, que avisa no commit desde o #1770. Ou seja: **o conjunto de disparos deste guard é subconjunto do daquele** — ele nunca fala onde o irmão cala; só acrescenta PRECISÃO (nomeia o símbolo) dentro de um aviso que já sairia. **Descer não cria ocasião de alarme nova.** Foi isso, e não uma aposta de ruído, que autorizou a descida.

⇒ **desce o gatilho, e a imprecisão vira redação:** a mensagem diz "**possível** duplicata" e manda conferir com `git log -S`, nunca "você duplicou".

**Filtrar `docs/` foi REJEITADO** (registrado para não voltar como ideia nova): a ocorrência 2 das 3 reais era exatamente um follow-up de doc — o filtro compraria silêncio ao preço de um falso negativo já medido.

## Buracos e custos registrados (não resolvidos)

- **O FP que só o commit pode criar ficou SEM número.** Símbolo escrito no commit K e removido até a ponta da branch: o replay por-commit das 60 branches reais (via `refs/pull/N/head`, que dá o merge-base verdadeiro) foi montado e **morreu antes de terminar** (~50min). Não inventei o número. O limite que sobrou: **38 das 60 branches têm 1 commit só** — nelas o gatilho é a avaliação do `create` mais cedo, sem janela nenhuma para transitório; nas outras 22 a classe existe, mas o aviso era verdadeiro quando saiu.
- **Custo: ~4,2s por `git commit`** (fetch ~1s + ~170ms/arquivo, teto de 25), **somados** ao fetch do guard irmão no mesmo gatilho. Antes era 1× por PR. Não dá para cortar pela rede: pular o fetch por recência é o cache de estado volátil já rejeitado, e grep contra `origin/main` defasada devolve "não existe" com cara de procura de verdade.

## De tabela: o teste do #1769 não rodava no CI

`scripts/test-pr-duplicata-guard.sh` foi criado pelo #1769 mas **não entrou no laço do `test:hooks`** (que lista os guards por nome). Teste órfão é a forma mais cara de "ausência de sinal com cara de verde". Corrigido — e a linha foi **mesclada** com o `heavy` que o #1778 acabou de adicionar (colisão real, detectada pelo próprio `pr-collision-guard` no meu commit e resolvida por rebase).

## Verificação

- `bun run test:hooks` **verde pós-rebase** — 5 guards, incluindo o `pr-duplicata` que agora roda.
- **13 casos + 5 falsificações.** As duas novas são as que dão sentido ao gatilho 2: fazer o commit olhar `mb..HEAD` em vez do índice tem de **emudecer** o caso do #1764; matar o dedupe tem de fazer o 2º commit idêntico **voltar a avisar**.
- `shellcheck` limpo. Smoke test real no repo (fora do stub): os dois gatilhos rodam, exit 0, silêncio correto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
