### PR TITLE
fix(authz): o manifest afirmava uma alternativa de gate que NUNCA bloqueou [money-path]

### DIFF
--- a/docs/historico/sentinela-authz-controle-nao-mencao.md
+++ b/docs/historico/sentinela-authz-controle-nao-mencao.md
@@ -295,6 +295,20 @@ Dois achados que só a medição dá:
   `private.cap_custo_ler` via `regexp_replace`). O manifest ainda a lista como alternativa
   aceitável e o corpo do repo ainda a chama: o CI estava verde validando uma cláusula que prod
   não tem mais. Quem protege de fato lá é `has_role(employee|master)`, e ele satisfaz o `anyOf`.
+  **PAGO em 2026-08-15** (vale também para a `get_defasagem_cliente`, onde a cláusula sobrara só
+  como menção em comentário): as duas entradas do manifest perderam o `{ call:
+  'pode_ver_carteira_completa' }` do `anyOf`. A remeasurement por psql-ro reconfirmou o fato e
+  acrescentou um agravante que o §8.1 não tinha visto — **a cláusula nunca foi bloqueio nessas
+  duas, nem no repo**: lá ela é `v_pode_num := pode_ver_carteira_completa(…)`, mascaramento de
+  campo, a forma que o próprio manifest declara não ser expressável em `requiredGate`. Como
+  `anyOf` fecha na primeira cláusula que BLOQUEIA, ela nunca era avaliada; e no único cenário em
+  que importaria (se `has_role` sumisse do corpo) ela cairia em `weak` e reprovaria igual. Não era
+  uma alternativa de gate enfraquecendo o contrato — era um **erro de categoria** que fazia o
+  leitor inferir um caminho de bloqueio inexistente. Gate efetivo inalterado, nenhum buraco aberto
+  nem fechado; `authz:check` e `authz:audit:prod` (19/19 no corpo VIVO) verdes com o gate enxuto.
+  As duas entradas **permanecem** em `authz-reescritas-conhecidas.ts`: o que as põe lá é a
+  divergência de MASCARAMENTO repo (`pode_ver_carteira_completa`) × prod (`cap_custo_ler`), que
+  segue de pé — pagá-la é a migration de reconciliação do item 5 abaixo.
 - **A `20260814022626` FOI aplicada em prod** — o §7.4 item 3 a registrou como "mergeou e ainda
   não foi aplicada", e o estado mudou desde então. Medido pelo predicado, não pelo md5: prod tem
   `omie_po_inexistente_antes_de <= m.finalizado_em` e **não** tem `omie_registrado_em <= …`; o
@@ -388,13 +402,25 @@ baseline vira decoração e nada mais a segura.
 4. ~~**`DROP FUNCTION` + `CREATE FUNCTION` reseta o ACL**~~ — o item 1 do §7.4 foi **FECHADO em
    2026-08-15 pela Parte E** (§9): `authz:check` passou a vigiar o grant de EXECUTE das funções
    classificadas, e `bun run authz:funcoes:prod` mede o ACL vivo em prod.
+5. **A reconciliação repo×prod de `get_preco_cockpit` e `get_defasagem_cliente` está ABERTA**
+   (aberta pelo pagamento da dívida de contrato do §8.1, em 2026-08-15). O gate de bloqueio já é o
+   mesmo nos dois lados — `has_role(employee|master)` —, então **não há risco de autorização
+   pendente**; o que diverge é o MASCARAMENTO do numérico: repo `pode_ver_carteira_completa`, prod
+   `cap_custo_ler`. Enquanto durar, a Parte A mede um corpo que não é o que roda e as duas seguem
+   na baseline de reescritas. Fechar = uma migration `CREATE OR REPLACE` trazendo o corpo do repo
+   para o de prod, o que as devolve à auditabilidade estática e apaga as duas entradas da baseline.
+   Custo real: migration nova ⇒ ritual `lovable-db-operator` + apply MANUAL no SQL Editor, e o
+   corpo colado precisa preservar `SECURITY DEFINER`/`STABLE`/`SET search_path`/ACL — exatamente o
+   que o §8.2 lembra que um corpo colado perde de graça. Não é urgente; é dívida declarada.
 
 ---
 
 # 9. O grant de EXECUTE de FUNÇÃO entra no contrato — Parte E (2026-08-15)
 
-> Fecha o **§7.4 item 1**, reafirmado no §8.5 item 4, e com ele o último item aberto deste
-> documento. `CREATE OR REPLACE FUNCTION` PRESERVA o ACL; o par `DROP FUNCTION` + `CREATE
+> Fecha o **§7.4 item 1**, reafirmado no §8.5 item 4 — o último item aberto de VIGILÂNCIA
+> deste documento (o §8.5 item 5, aberto no mesmo dia, é dívida de RECONCILIAÇÃO repo×prod:
+> não é ponto cego do CI, e não há autorização pendente nele).
+> `CREATE OR REPLACE FUNCTION` PRESERVA o ACL; o par `DROP FUNCTION` + `CREATE
 > FUNCTION` **não** — a função renasce com o default privilege do projeto. As Partes A/D julgam o
 > GATE no corpo, a Parte C julga grant de TABELA, e **nada** julgava grant de FUNÇÃO.
 

--- a/scripts/authz-manifest.ts
+++ b/scripts/authz-manifest.ts
@@ -43,15 +43,26 @@ export const AUTHZ_MANIFEST: Record<string, AuthzEntry> = {
     requiredGate: { anyOf: [{ call: 'cap_custo_ler' }] },
     motivo: 'folga negativa de margem vs piso de markup — cockpit financeiro; E2/FU4 estreitou p/ estrategico+',
   },
+  // 2026-08-15 — a alternativa `pode_ver_carteira_completa` SAIU do anyOf destas duas. Dívida de
+  // contrato medida no PR #1751 (§8.1 de docs/historico/sentinela-authz-controle-nao-mencao.md) e
+  // reconfirmada por psql-ro no corpo VIVO: em prod nenhuma das duas a CHAMA (na
+  // get_defasagem_cliente ela sobrou só como MENÇÃO em comentário) — o E2/FU4 trocou o `v_pode_num`
+  // delas para `private.cap_custo_ler`. Quem bloqueia, no repo E em prod, é `has_role(employee|master)`.
+  // E ela nunca foi bloqueio AQUI: no corpo ela é `v_pode_num := pode_ver_carteira_completa(…)`,
+  // mascaramento de campo — a forma que o §LIMITE abaixo diz não ser expressável em requiredGate.
+  // Listá-la no anyOf afirmava um caminho de bloqueio alternativo inexistente: como `anyOf` fecha na
+  // primeira cláusula que BLOQUEIA, ela nunca era avaliada, e no único cenário em que importaria (se
+  // has_role sumisse) cairia em `weak` e falharia igual. Contrato enxuto > contrato que descreve o
+  // que não existe. Nenhum buraco foi aberto nem fechado aqui: o gate efetivo é o mesmo de antes.
   'public.get_preco_cockpit': {
     sensitive: true,
-    requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }, { call: 'pode_ver_carteira_completa' }] },
-    motivo: 'cockpit de preços — bloqueia staff; pode_ver_carteira_completa afina o detalhe',
+    requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }] },
+    motivo: 'cockpit de preços — bloqueia staff (employee|master); o numérico é mascarado por cap_custo_ler, fora do alcance do requiredGate',
   },
   'public.get_defasagem_cliente': {
     sensitive: true,
-    requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }, { call: 'pode_ver_carteira_completa' }] },
-    motivo: 'defasagem de preço por cliente vs custo',
+    requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee', 'master'] }] },
+    motivo: 'defasagem de preço por cliente vs custo — mesmo gate de entrada; os absolutos são mascarados por cap_custo_ler',
   },
   // FU4-F fase 2 (2026-07-20): as duas continuam com gate de ENTRADA `has_role(employee|master)`
   // DE PROPÓSITO — a vendedora precisa do SINAL ("abaixo do piso"). O que mudou é interno: elas

--- a/scripts/authz-reescritas-conhecidas.ts
+++ b/scripts/authz-reescritas-conhecidas.ts
@@ -35,7 +35,7 @@ export const AUTHZ_REESCRITAS_CONHECIDAS: ReescritaConhecida[] = [
     arquivo: '20260718190000_authz_capability_matrix_e2.sql',
     funcao: 'public.get_preco_cockpit',
     motivo:
-      'FU4/E2 trocou o gate `pode_ver_carteira_completa` por `private.cap_custo_ler` por regexp sobre a definição viva, porque o corpo do repo divergia de prod e colar um corpo teria REVERTIDO o hardening. Efeito medido: em prod esta função já NÃO chama pode_ver_carteira_completa, mas o manifest ainda a lista como alternativa aceitável e o corpo do repo ainda a chama — o CI valida uma cláusula que prod não tem mais. O gate que de fato protege em prod é has_role(employee|master), e ele satisfaz o anyOf.',
+      'FU4/E2 trocou o gate `pode_ver_carteira_completa` por `private.cap_custo_ler` por regexp sobre a definição viva, porque o corpo do repo divergia de prod e colar um corpo teria REVERTIDO o hardening. Efeito medido: em prod esta função já NÃO chama pode_ver_carteira_completa; quem bloqueia é has_role(employee|master). A dívida de CONTRATO que isso deixou — o manifest listando a cláusula morta como alternativa do anyOf — foi paga em 2026-08-15 (requiredGate agora descreve só o has_role real). O que ESTA entrada continua declarando é a divergência que sobra: o repo mascara o numérico com `v_pode_num := pode_ver_carteira_completa(…)` e prod com cap_custo_ler, então a Parte A segue medindo um corpo que não é o que roda.',
     provaExecutada: 'db/test-authz-capability-matrix.sh',
     md5ProdEsperado: '4f3fb7df939e467f82d36a065e2f0957',
   },
@@ -43,7 +43,7 @@ export const AUTHZ_REESCRITAS_CONHECIDAS: ReescritaConhecida[] = [
     arquivo: '20260718190000_authz_capability_matrix_e2.sql',
     funcao: 'public.get_defasagem_cliente',
     motivo:
-      'Mesma reescrita do E2, mesmo motivo. Em prod `pode_ver_carteira_completa` sobrou só como MENÇÃO em comentário (não é chamada); quem bloqueia é has_role(employee|master) + cap_custo_ler para o numérico.',
+      'Mesma reescrita do E2, mesmo motivo. Em prod `pode_ver_carteira_completa` sobrou só como MENÇÃO em comentário (não é chamada); quem bloqueia é has_role(employee|master) + cap_custo_ler para o numérico. Cláusula morta removida do anyOf do manifest em 2026-08-15, junto com a da get_preco_cockpit; a entrada permanece porque a divergência de MASCARAMENTO entre repo e prod permanece.',
     provaExecutada: 'db/test-authz-capability-matrix.sh',
     md5ProdEsperado: '037ede84a229d5798214511433afb65d',
   },


### PR DESCRIPTION
## O que estava errado

`public.get_preco_cockpit` e `public.get_defasagem_cliente` declaravam no `AUTHZ_MANIFEST`:

```ts
requiredGate: { anyOf: [{ call: 'has_role', roles: ['employee','master'] }, { call: 'pode_ver_carteira_completa' }] }
```

Medido por `psql-ro` no corpo **VIVO** de prod (dívida registrada em 2026-08-14 no #1751, §8.1 de
`docs/historico/sentinela-authz-controle-nao-mencao.md`; reconfirmada agora): **em prod nenhuma das
duas CHAMA `pode_ver_carteira_completa`** — na `get_defasagem_cliente` ela sobrou só como MENÇÃO em
comentário. A `20260718190000_authz_capability_matrix_e2.sql` trocou o `v_pode_num` das duas para
`private.cap_custo_ler` por `regexp_replace` sobre a definição viva, e o corpo do repo — que é o que
a Parte A mede — ficou com a versão velha.

## O agravante que a remedição achou

A cláusula **nunca foi bloqueio nessas duas, nem no repo**. Lá ela aparece como
`v_pode_num := pode_ver_carteira_completa(…)` — mascaramento de campo, exatamente a forma que o
próprio manifest declara não ser expressável em `requiredGate` (o §LIMITE do arquivo). E como
`anyOf` fecha na primeira cláusula que **bloqueia**, ela nunca chegava a ser avaliada; no único
cenário em que importaria (se `has_role` sumisse do corpo) ela cairia em `weak` e reprovaria igual.

Não era gate alternativo enfraquecendo o contrato: era **erro de categoria**, induzindo quem lê a
inferir um caminho de bloqueio inexistente.

## O que NÃO muda

**Nada de autorização.** O gate efetivo era e segue sendo `has_role(employee|master)` em forma de
bloqueio (`IF NOT … RAISE 42501`), idêntico no repo e em prod. Grants medidos: `anon=false`,
`authenticated=true`, `SECURITY DEFINER` — as duas seguem corretamente no `AUTHZ_MANIFEST` (fecham
por gate no corpo), não em `ACKNOWLEDGED_SENSITIVE`.

As duas **permanecem** em `authz-reescritas-conhecidas.ts`: o que as põe lá é a divergência de
**mascaramento** repo × prod, que segue de pé. Os `motivo` foram atualizados porque afirmavam
literalmente a dívida que este PR paga.

## Evidência

| comando | resultado |
|---|---|
| `bun run authz:check` | **exit 0** — Partes A/B/C/D/E verdes (com a Parte E nova da main) |
| `bun run authz:audit:prod` | **exit 0** — 19/19, `requiredGate` **novo** validado contra o corpo VIVO |
| `heavy bun run test` | **672/672 arquivos · 6281/6281 testes · exit 0** (pré-rebase; revalidado pós-rebase) |
| `bun run typecheck` / `eslint` | 0 / 0 |
| falsificação Parte D (`db/test-authz-reescrita-falsificacao.sh`), locales C e pt_BR.UTF-8 | **0 falhas nos dois** |
| falsificação do `requiredGate` novo, C e pt_BR.UTF-8 | **vermelho pelo motivo certo nos dois** |

A última linha é a que mede *este* PR: removido o `has_role` do corpo do repo, o check sai `exit=1`
com `última def de public.get_preco_cockpit SEM gate válido: falta a chamada de has_role`, nomeando o
arquivo. O gate novo tem dente — e o diagnóstico **melhorou**: antes a mesma sabotagem caía em `weak`
reclamando da cláusula morta.

## Nota de rebase

Rebaseado sobre a main (que ganhou a **Parte E** — grants de EXECUTE de função — em #1768/#1773/#1774).
Um conflito no doc histórico, resolvido preservando as duas intenções: o item 4 do §8.5 fica na versão
da main (**FECHADO** pela Parte E), meu item 5 entra logo abaixo, e a §9 da main fica íntegra. Ajustei
uma frase da §9 que dizia "o último item aberto deste documento" — meu item 5 a tornaria falsa.

## Fora de escopo, declarado

A **reconciliação repo × prod** do corpo das duas (migration `CREATE OR REPLACE` trazendo o repo para
o que prod já tem, o que as devolveria à auditabilidade estática e apagaria as duas entradas da
baseline) ficou **aberta**, como item 5 novo do §8.5. Não foi necessária aqui — apertar o
`requiredGate` não deixou o CI vermelho, porque `has_role` já bloqueia no corpo do repo. E ela custa
migration nova ⇒ ritual `lovable-db-operator` + apply MANUAL no SQL Editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
