### PR TITLE
docs(farmer): o gatilho da fase 2 recusa o vazio ENVENENADO pelo cap de 1.000 [money-path]

### DIFF
--- a/db/gatilho-farmer-fase2.sql
+++ b/db/gatilho-farmer-fase2.sql
@@ -1,0 +1,62 @@
+-- GATILHO da fase 2 do farmer (expirar geração por vazio) — a QUERY decide, ninguém "avisa".
+--
+-- Rode isto ANTES de abrir qualquer análise da fase 2. Ele responde a única pergunta que
+-- importa — "já há o que analisar?" — com denominador explícito, e recusa as duas formas de
+-- errar: interpretar zero-sem-denominador como "o vazio não acontece", e aceitar um vazio
+-- ENVENENADO como se fosse sinal legítimo.
+--
+--   ~/.config/afiacao/psql-ro -f db/gatilho-farmer-fase2.sql
+--
+-- Contexto: docs/historico/fase-sem-sinal.md (caso 4) · spec do sensor em
+-- docs/superpowers/specs/2026-08-15-farmer-head-geracao-sensor-design.md
+--
+-- ⚠️ Duas leituras que este arquivo existe para impedir:
+--
+-- 1. `execucoes_totais = 0` NÃO é "o vazio não acontece". É denominador zero — o defeito que
+--    o sensor foi instalado para curar. Duas análises já foram abertas contra este zero
+--    (2026-08-15 e 2026-08-18) e as duas voltaram sem poder concluir nada.
+--
+-- 2. `completude='completo'` significa "nenhum insumo FALHOU ao ser lido" — e `ok:true` em
+--    `insumos` quer dizer "a leitura não lançou exceção", NÃO "a leitura veio inteira". Uma
+--    leitura truncada em silêncio (cap de 1.000 do PostgREST sobre RPC sem paginação) chega
+--    aqui como `ok:true`, e o vazio que ela produz veste a roupa exata do sinal legítimo.
+--    Por isso a coluna `suspeita_cap` abaixo: n≡1000 é a assinatura do truncamento.
+WITH obs AS (
+  SELECT
+    count(*)                                                          AS execucoes_totais,
+    -- O cliente ANTERIOR ao Publish não declarava insumo nenhum: conta como "rodou",
+    -- nunca como evidência sobre completude.
+    count(*) FILTER (WHERE completude <> 'desconhecido')              AS julgaveis,
+    count(*) FILTER (WHERE resultado = 'vazio'
+                       AND completude = 'completo'
+                       AND COALESCE((insumos->'scores'->>'n')::int, 0)    > 0
+                       AND COALESCE((insumos->'vendaveis'->>'n')::int, 0) > 0) AS vazios_completos,
+    -- Assinatura de truncamento: QUALQUER insumo com exatamente 1.000 linhas. O cap do
+    -- PostgREST devolve 1.000 e sucesso; nenhum insumo real tem esse tamanho por acaso.
+    count(*) FILTER (WHERE EXISTS (
+                       SELECT 1 FROM jsonb_each(insumos) AS i(nome, val)
+                       WHERE (val->>'n')::int = 1000))                 AS suspeita_cap,
+    count(DISTINCT farmer_id)                                         AS farmers,
+    min(calculado_em)::date                                           AS desde,
+    max(calculado_em)                                                 AS ultima
+  FROM public.farmer_geracao_execucoes
+)
+SELECT
+  execucoes_totais, julgaveis, vazios_completos, suspeita_cap, farmers, desde, ultima,
+  CASE
+    WHEN suspeita_cap > 0 THEN
+      'CONTAMINADO — ' || suspeita_cap || ' execucao(oes) com insumo de exatamente 1000 linhas. '
+      || 'Truncamento silencioso: o vazio nao prova ausencia de oportunidade. '
+      || 'Corrija a paginacao, DESCARTE o periodo e recomece o denominador.'
+    WHEN vazios_completos > 0 THEN
+      'DECIDA — ha ' || vazios_completos || ' vazio+completo. Antes de expirar, feche o '
+      || 'pre-requisito da §7.5: carteira_ativa conta cliente com PEDIDO, nao cliente cujos '
+      || 'itens resolvem para SKU do catalogo. Sem isso o vazio pode vir de historico inutilizavel.'
+    WHEN julgaveis >= 20 THEN
+      'ENCERRE — ' || julgaveis || ' execucoes julgaveis e ZERO vazios: o vazio-de-verdade nao '
+      || 'acontece nesses farmers. Nao ligue a expiracao; encerre a linha.'
+    ELSE
+      'AGUARDE — denominador insuficiente (' || julgaveis || '/20 julgaveis). '
+      || 'NAO interprete como "o vazio nao acontece": e ausencia de dado.'
+  END AS veredito
+FROM obs;

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -170,6 +170,64 @@ próprio spec afirmar *"a tabela não recebe grant de escrita direta"* enquanto 
 contrário — **contradição entre o documento e o código passa justamente porque o documento está
 certo.**
 
+### ⚠️ O sinal pode chegar ENVENENADO pela camada de baixo (2026-08-18, follow-up do #1765)
+
+O caso anterior é sobre a ESTRUTURA do sensor comportar a resposta. Este é o passo seguinte: a
+estrutura está certa, o sensor está armado em prod — e mesmo assim o **primeiro sinal que ele vai
+registrar é falso**.
+
+**O estado medido (prod, via `psql-ro`):** `farmer_geracao_execucoes` = **0 linhas**, e
+`farmer_geracao_vigente` = 0. Duas análises foram abertas contra esse zero (15/08 e 18/08); as duas
+voltaram sem poder concluir nada. A auditoria do sensor descartou as falhas silenciosas — tabelas
+aplicadas, RPC `farmer_geracao_registrar` `SECURITY DEFINER` com EXECUTE para `authenticated` e não
+para `anon`, policies de SELECT no lugar, definição em prod idêntica à do repo. **O sensor está
+correto; o que falta é o Publish do frontend.**
+
+**O discriminante do Publish não é o cross-sell — é o bundle.** São dois motores com cadências
+opostas, e medir só um induz ao erro:
+
+| motor | tela | última gravação | leitura |
+|---|---|---|---|
+| cross-sell (`farmer_recommendations`) | `/farmer/recommendations` (`useEffect`) | 2026-08-15 17:32 UTC | 3 dias de silêncio — normal: **junho e julho tiveram ZERO gerações** |
+| bundle (`farmer_association_rules`) | outra tela | **2026-08-18 07:30 UTC** | roda quase todo dia |
+
+O `useBundleEngine` da `main` **já registra o vazio** (`registrarVazio()`). Logo: o motor de bundle
+rodou hoje, produziu vazio, e não deixou linha no sensor ⇒ o bundle no ar é o **anterior** ao
+Publish. Medir só `farmer_recommendations` levaria à conclusão oposta ("ninguém abre a tela").
+
+**O veneno.** O #1782 mostrou que o motor de bundle produz vazio **todo dia por bug**: a RPC
+`get_skus_margem_positiva` devolve 2.462 linhas e era lida **sem paginação**, então o cap de 1.000
+do PostgREST entrega mil linhas **e sucesso**. No `useBundleEngine`, esse retorno truncado não cai
+no ramo fail-closed — cai aqui:
+
+```ts
+const vendaveis = new Set(vendaveisResult.data.map((r) => r.product_id));
+insumos.vendaveis = { ok: true, n: vendaveis.size };   // ok:true, n:1000
+```
+
+`avaliarCompletude` só degrada quando algum insumo tem `ok:false`. Nenhum tem. O resultado é uma
+execução `resultado='vazio'` + `completude='completo'` + `scores.n>0` + `vendaveis.n>0` — que é
+**exatamente** o predicado que a fase 2 definiu como "o sinal que autoriza ligar a expiração".
+
+> **`ok:true` quer dizer "a leitura não lançou", não "a leitura veio inteira".** Um sensor de
+> completude construído sobre esse `ok` herda, sem saber, todo truncamento silencioso da camada
+> de baixo — e o entrega com a roupa do sinal legítimo.
+
+Se o Publish tivesse saído antes do #1782, o sensor teria coletado esse falso positivo **todo dia**,
+e ligar a expiração por vazio teria **zerado a carteira** de vendedoras cujos bundles existiam e
+foram perdidos na cauda truncada. O sensor não teria errado nada: ele mediria com precisão um
+número já envenenado.
+
+**Ordem operacional que isto impõe:** o #1782 entra **antes** do Publish do sensor. Publicar com o
+bug vivo não é neutro — contamina o denominador que vai levar meses para se acumular.
+
+**O resíduo:** [`db/gatilho-farmer-fase2.sql`](../../db/gatilho-farmer-fase2.sql). A query decide
+sozinha entre `AGUARDE` / `CONTAMINADO` / `DECIDA` / `ENCERRE`, e carrega a guarda que faltava —
+qualquer insumo com **exatamente 1.000** linhas é assinatura de cap do PostgREST e derruba o
+veredito para `CONTAMINADO` antes de ele virar `DECIDA`. Os quatro ramos foram falsificados contra
+a lógica publicada (tabela substituída por cenário sintético); no ramo `CONTAMINADO` o cenário tem
+`vazios_completos=1`, isto é, sem a guarda ele **teria** autorizado a fase 2.
+
 ### Onde a regra NÃO se aplica
 
 Instrumentar tudo tem custo, e regra que grita errado treina a ignorar o vermelho. O gatilho é a
@@ -190,3 +248,10 @@ sensor** que deixava qualquer história caber no mesmo vazio.
 **Corolário para revisão:** quando um plano diz "fase 2" ou "próximo passo", a primeira pergunta não
 é sobre o desenho da fase 2. É: *qual linha de dado prova que a fase 1 foi usada, e quantos podiam
 tê-la usado?* Se a resposta for uma inferência em vez de uma query, a fase 2 é instalar o sensor.
+
+**Segundo corolário (2026-08-18):** quando o sensor finalmente acender, a pergunta não é só *"o
+sinal chegou?"* — é *"a fonte do sinal estava sã quando ele chegou?"*. Um número medido com
+precisão sobre um insumo truncado em silêncio é indistinguível do número legítimo, e a decisão que
+ele autoriza é irreversível para quem está do outro lado (aqui: a carteira da vendedora). Por isso
+o gatilho não devolve só o placar — ele **recusa** o veredito quando enxerga a assinatura do
+truncamento.


### PR DESCRIPTION
Follow-up do #1765 (sensor de geração do farmer). Um chip pediu a análise da fase 2; ele parou no pré-requisito — `farmer_geracao_execucoes` = **0 linhas**. É a segunda análise que volta vazia contra esse mesmo zero (15/08 e 18/08).

Este PR não desenha a fase 2. Ele entrega o que faltava para que a próxima tentativa não seja a terceira a voltar vazia — e um achado que muda a **ordem** das entregas.

## O sensor está correto; falta o Publish

Auditei antes de culpar o Publish, para descartar falha silenciosa:

| Verificação | Resultado |
|---|---|
| Tabelas em prod | ✅ migration aplicada |
| RPC `farmer_geracao_registrar` | ✅ `SECURITY DEFINER`, EXECUTE p/ `authenticated`, negado p/ `anon` |
| Policies de SELECT | ✅ `fgv_select_carteira`, `fge_select_carteira` |
| `pg_get_functiondef` prod ↔ repo | ✅ sem divergência |

**O discriminante do Publish é o motor de BUNDLE, não o cross-sell** — medir só um leva à conclusão oposta:

| motor | última gravação | leitura |
|---|---|---|
| cross-sell (`farmer_recommendations`) | 2026-08-15 17:32 UTC | 3 dias de silêncio — e **junho e julho tiveram ZERO gerações**. Normal. |
| bundle (`farmer_association_rules`) | **2026-08-18 07:30 UTC** | roda quase todo dia |

O `useBundleEngine` da `main` já chama `registrarVazio()`. O motor rodou hoje, produziu vazio e não deixou linha ⇒ **o bundle no ar é o anterior ao Publish**.

## O achado: o primeiro sinal do sensor seria FALSO

Sob o cap de 1.000 do PostgREST (#1782), `get_skus_margem_positiva` devolve mil linhas **e sucesso**. Isso não cai no ramo fail-closed do `useBundleEngine` — cai aqui:

```ts
const vendaveis = new Set(vendaveisResult.data.map((r) => r.product_id));
insumos.vendaveis = { ok: true, n: vendaveis.size };   // ok:true, n:1000
```

`avaliarCompletude` só degrada com algum insumo `ok:false`. Nenhum tem. O vazio diário do bundle sai como `resultado='vazio'` + `completude='completo'` + `scores.n>0` + `vendaveis.n>0` — **exatamente** o predicado que a fase 2 definiu como "o sinal que autoriza ligar a expiração".

> `ok:true` significa "a leitura não lançou", não "a leitura veio inteira".

Se o Publish tivesse saído antes do #1782, o sensor coletaria esse falso positivo **todo dia**, e ligar a expiração teria **zerado a carteira** de vendedoras cujos bundles se perderam na cauda truncada. O sensor não erraria nada — mediria com precisão um número já envenenado.

**Ordem que isto impõe: #1782 entra antes do Publish do sensor.** Publicar com o bug vivo contamina o denominador que levará meses para se acumular.

## O que entra

- **`db/gatilho-farmer-fase2.sql`** — a query decide sozinha entre `AGUARDE` / `CONTAMINADO` / `DECIDA` / `ENCERRE`. Gatilho é query, não recado. Carrega a guarda que faltava: qualquer insumo com **exatamente 1.000** linhas é assinatura de cap e derruba o veredito para `CONTAMINADO` **antes** de ele virar `DECIDA`.
- **`docs/historico/fase-sem-sinal.md`** — o caso 4 e o segundo corolário.

## Prova

Os quatro ramos foram falsificados contra a **lógica publicada** (o arquivo real, com a tabela substituída por cenário sintético — não uma cópia):

| cenário | `vazios_completos` | `suspeita_cap` | veredito |
|---|--:|--:|---|
| insumo com n=1000 | 1 | 1 | `CONTAMINADO` |
| mesmo dado, n=2462 | 1 | 0 | `DECIDA` |
| 20 execuções com linha | 0 | 0 | `ENCERRE` |
| só cliente velho (`desconhecido`) | 0 | 0 | `AGUARDE` (total=1, julgáveis=0) |

⚠️ No ramo `CONTAMINADO` o cenário tem `vazios_completos=1` — **sem a guarda, ele teria autorizado a fase 2**. É esse o dente da falsificação.

Contra a prod hoje: `exit 0`, `AGUARDE — denominador insuficiente (0/20 julgaveis)`.
Gate de índice de docs: `35 passed`, `exit 0`.

## Fora de escopo

Não liga a expiração, não toca `CLAUDE.md` (o #1782 já o edita — evita conflito) e não toca código de `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
