### PR TITLE
test(hooks): 2 suítes de guard existiam e NUNCA rodavam — teste órfão é ausência de dado

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,9 +227,13 @@ jobs:
       - name: CLAUDE.md size budget
         run: bun run claude:size
 
-      # Guards de colisão multi-sessão (PreToolUse): os 3 têm suíte com git+gh STUBADOS
-      # (hermética, sem rede, ~1s) que até 2026-08-18 NENHUM workflow rodava — teste órfão
-      # só vale quando alguém lembra, e guard que regride vira falso-negativo silencioso.
+      # Guards de PreToolUse (colisão multi-sessão, comando destrutivo, imutabilidade de migration):
+      # cada um tem suíte HERMÉTICA (sem rede) em scripts/test-*-guard.sh — os de colisão stubam
+      # git/gh num mktemp; os demais não saem do processo (só passam strings ao hook) ou montam um
+      # repo git temporário com `git init`.
+      # O loop do `test:hooks` é a ÚNICA coisa que os roda — script fora do loop é teste órfão, e
+      # teste que não roda é ausência de dado, não aprovação: o guard regride em silêncio.
+      # Ao criar um scripts/test-<x>-guard.sh, ACRESCENTE <x> ao `for t in ...` do package.json.
       - name: Hooks guard tests
         # sem `heavy` aqui: o semáforo de RAM é da M2 local e nao existe no runner (exit 127).
         run: bun run test:hooks

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "wt:label": "bash scripts/wt-map.sh label",
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash; do bash scripts/test-$t-guard.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability; do bash scripts/test-$t-guard.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/hooks-guard-cobertura.test.ts
+++ b/scripts/hooks-guard-cobertura.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Vigia de FORMA: todo `scripts/test-<x>-guard.sh` tem de estar no `for t in ...` do `test:hooks`.
+ *
+ * Por quê: até 2026-08-19 existiam 7 suítes de guard e o loop rodava 5 — `destructive-bash` e
+ * `migration-immutability` eram órfãs. Teste que existe e não roda é AUSÊNCIA DE DADO, não
+ * aprovação: o guard podia regredir sem nada ficar vermelho. (Foi assim que o #1770 quebrou o CI —
+ * o heavy-guard só passou a rodar no #1778.) Criar o script e esquecer o loop é o erro natural;
+ * este teste é o que o torna impossível de passar despercebido.
+ */
+
+const RAIZ = join(import.meta.dirname, '..');
+
+/** Extrai os `<x>` do `for t in <x> <y> ...;` do comando `test:hooks`. */
+export function alvosDoLoop(cmd: string): string[] {
+  const m = /for\s+t\s+in\s+([^;]+);/.exec(cmd);
+  if (!m) return [];
+  return m[1].trim().split(/\s+/).filter(Boolean);
+}
+
+/** Extrai os `<x>` de cada `test-<x>-guard.sh` presente no diretório. */
+export function alvosNoDisco(arquivos: string[]): string[] {
+  return arquivos
+    .map((f) => /^test-(.+)-guard\.sh$/.exec(f)?.[1])
+    .filter((x): x is string => Boolean(x))
+    .sort();
+}
+
+describe('alvosDoLoop — parser', () => {
+  it('lê a lista do for', () => {
+    expect(alvosDoLoop('for t in a b c; do bash scripts/test-$t-guard.sh || exit 1; done')).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+
+  it('devolve vazio quando o comando não tem o for (não finge cobertura)', () => {
+    expect(alvosDoLoop('bun run algo-outro')).toEqual([]);
+  });
+});
+
+describe('alvosNoDisco — parser', () => {
+  it('pega só os test-*-guard.sh e ignora o resto de scripts/', () => {
+    expect(
+      alvosNoDisco(['test-heavy-guard.sh', 'pr-watch.sh', 'test-pr-collision-guard.sh', 'x.test.ts']),
+    ).toEqual(['heavy', 'pr-collision']);
+  });
+});
+
+describe('cobertura real: package.json x scripts/', () => {
+  const pkg = JSON.parse(readFileSync(join(RAIZ, 'package.json'), 'utf8')) as {
+    scripts: Record<string, string>;
+  };
+  const noLoop = alvosDoLoop(pkg.scripts['test:hooks'] ?? '').sort();
+  const noDisco = alvosNoDisco(readdirSync(join(RAIZ, 'scripts')));
+
+  it('o loop do test:hooks não está vazio (falsifica um regex que casou com nada)', () => {
+    expect(noLoop.length).toBeGreaterThan(0);
+  });
+
+  it('nenhuma suíte de guard é ÓRFÃ — todo test-<x>-guard.sh está no loop', () => {
+    const orfaos = noDisco.filter((x) => !noLoop.includes(x));
+    expect(
+      orfaos,
+      `Suíte(s) de guard que NINGUÉM roda: ${orfaos.join(', ')}. ` +
+        `Acrescente ao \`for t in ...\` do script "test:hooks" no package.json.`,
+    ).toEqual([]);
+  });
+
+  it('nenhum alvo do loop é FANTASMA — todo <x> do for tem script em disco', () => {
+    const fantasmas = noLoop.filter((x) => !noDisco.includes(x));
+    expect(
+      fantasmas,
+      `O loop cita alvo(s) sem scripts/test-<x>-guard.sh: ${fantasmas.join(', ')}. ` +
+        `O \`bash\` de um caminho inexistente sai 127 e derruba o CI.`,
+    ).toEqual([]);
+  });
+});

--- a/scripts/test-destructive-bash-guard.sh
+++ b/scripts/test-destructive-bash-guard.sh
@@ -15,7 +15,8 @@ command -v jq >/dev/null 2>&1 || { echo "SKIP — jq ausente"; exit 0; }
 
 run() { # <command> → stdout do hook
   local enc
-  enc="$(printf '%s' "$1" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+  # jq (não python3): o script já exige jq acima — uma dependência a menos no runner do CI.
+  enc="$(printf '%s' "$1" | jq -Rs .)"
   printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$enc" | bash "$HOOK" 2>/dev/null
 }
 is_deny() { grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; }


### PR DESCRIPTION
## O buraco

`scripts/` tem 7 `test-*-guard.sh`. O loop do `test:hooks` — o que o CI roda no step **"Hooks guard tests"** — chamava 5. Ficavam de fora, sem rodar em lugar nenhum:

- `scripts/test-destructive-bash-guard.sh`
- `scripts/test-migration-immutability-guard.sh`

Teste que existe e não roda é **ausência de dado, não aprovação**: se um desses guards regredisse, nada ficaria vermelho. É a mesma classe do #1770 (o heavy-guard só passou a rodar no CI no #1778).

> Correção de premissa: o `pr-duplicata` **já entrara** no loop no #1781 — eram 2 órfãos, não 3.

## Evidência positiva (capturada, não inferida)

**1. Os 2 já estavam VERDES antes de entrar** — não havia dívida escondida, só o loop a corrigir:

| script | exit |
|---|---|
| `test-destructive-bash-guard.sh` | **0** |
| `test-migration-immutability-guard.sh` | **0** |
| `test-pr-duplicata-guard.sh` (já no loop) | **0** (41s) |

**2. `bun run test:hooks` completo → exit 0, 7 PASS, 189s.**

**3. Prova de que ENTRARAM na suíte** — `validate` verde sozinho não provaria isso. Log do step "Hooks guard tests" (run 32205041270):

```
$ for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability; do bash scripts/test-$t-guard.sh || exit 1; done
01:35:19.8028127Z PASS — migration-collision-guard
01:35:21.9693291Z PASS — destructive-bash-guard
01:35:22.1292881Z PASS — migration-immutability-guard
```

O step inteiro leva **6s** no runner (01:35:16 → 01:35:22) — os 189s locais são a M2 sob carga de ~28 sessões, não o custo real do CI.

**4. Falsificação — 2 sabotagens × 2 locales, 4/4 vermelhas**, cada uma casando string ASCII exclusiva do ramo certo (commit ANTES de sabotar; restauração é `git checkout --`):

```
===== locale C =====
  ok  vermelho [destructive-bash / C] exit=1 + casou: FAIL  want deny  | git stash drop
  ok  vermelho [migration-immutability / C] exit=1 + casou: FAIL  want deny  | path com ./
===== locale pt_BR.UTF-8 =====
  ok  vermelho [destructive-bash / pt_BR.UTF-8] exit=1 + casou: FAIL  want deny  | git stash drop
  ok  vermelho [migration-immutability / pt_BR.UTF-8] exit=1 + casou: FAIL  want deny  | path com ./
```

Sabotagens cirúrgicas (não "hook vira exit 0"): neutralizar o padrão `stash clear/drop` do detector; e trocar a resolução física de path (`cd … && pwd -P`) pelo `dirname` ingênuo — exatamente o bypass que o Codex apontou em 2026-06-24. O script aborta se a árvore estiver suja e falha se a sabotagem for no-op.

## Portabilidade pro `ubuntu-latest`

`test-destructive-bash-guard.sh` escapava o comando em JSON com **`python3` sem `command -v` de guarda** (só `jq` era guardado) — dependência não-declarada que um grep de padrões BSD não pega. Trocado por **`jq -Rs .`**, verificado idêntico ao `json.dumps` em 4 casos, inclusive heredoc com newline.

Nenhum dos dois usa `heavy`, `sed -i ''` ou flag BSD de `mktemp`; `shellcheck` exit 0. São herméticos por caminhos distintos: o de comando destrutivo não invoca git nenhum (só passa strings ao hook); o de migration monta um repo temporário com `git init`.

## Anti-recorrência

`scripts/hooks-guard-cobertura.test.ts` (vitest, mesmo padrão de `bun-pin-gate-check.test.ts`) falha nos dois sentidos: **órfão** (script existe, loop não chama) e **fantasma** (loop cita `<x>` sem script — o `bash` sairia 127 e derrubaria o CI). Sem isso, o próximo script criado vira órfão de novo — foi o erro natural que produziu este PR.

Também falsificado, 4/4 nos dois locales:

```
  ok  vermelho [orfao / C] exit=1 + casou: migration-immutability
  ok  vermelho [fantasma / C] exit=1 + casou: guard-que-nao-existe
  ok  vermelho [orfao / pt_BR.UTF-8] exit=1 + casou: migration-immutability
  ok  vermelho [fantasma / pt_BR.UTF-8] exit=1 + casou: guard-que-nao-existe
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)