### PR TITLE
feat(sonda): a resposta passa a dizer QUAL edge respondeu — sem isso, 10 sondas viraram zero veredito [money-path]

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -27,7 +27,20 @@ import * as syncEstoque from "../omie-sync-estoque/versao.ts";
 import * as syncNfes from "../omie-sync-nfes-recebidas/versao.ts";
 import * as nfeWebhook from "../omie-nfe-webhook/versao.ts";
 
-const EDGES: Array<{ nome: string; mod: { VERSAO: string; EFEITO: string } }> = [
+/**
+ * `respostaSonda` (a maioria) ou `respostaSondaTactical` (a `generate-tactical-plan`, que embrulha o
+ * contrato num composer). O gate abaixo exige que UMA das duas exista — edge instrumentada sem
+ * nenhuma delas não tem como ser verificada em produção.
+ */
+type CorpoSonda = { ok: true; probe: true; versao: string; edge: string };
+type ModSonda = {
+  VERSAO: string;
+  EFEITO: string;
+  respostaSonda?: (versao: string) => CorpoSonda;
+  respostaSondaTactical?: () => CorpoSonda;
+};
+
+const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   { nome: "disparar-pedidos-aprovados", mod: disparar },
   { nome: "enviar-pedido-portal-sayerlack", mod: portalSayerlack },
   { nome: "conciliar-pedido-portal", mod: conciliar },
@@ -343,5 +356,49 @@ Deno.test("omie-sync-estoque: o EFEITO precisa dizer que o run APAGA o sinal de 
   // qualquer — e a decisão de retentar sai errada.
   if (!/sync_state|frescor|marcador/i.test(syncEstoque.EFEITO)) {
     throw new Error(`EFEITO não menciona o marcador de frescor: ${syncEstoque.EFEITO}`);
+  }
+});
+
+Deno.test("a resposta da sonda IDENTIFICA a edge que respondeu", () => {
+  // O bug que este gate fecha (2026-08-18): `versao` sozinho NÃO identifica quem respondeu — o
+  // marcador nasce igual em toda uma leva (o gate de marcadores acima até assere isso). Dez sondas
+  // voltaram 200 com corpos byte a byte idênticos e o veredito por edge foi IMPOSSÍVEL de emitir;
+  // nada no banco desfaz o empate (`net._http_response` não guarda a URL, a fila é esvaziada, os
+  // headers são só do Cloudflare). Ver `docs/historico/verificar-sonda-versao.md` §7.
+  for (const { nome, mod } of EDGES) {
+    const corpo = mod.respostaSonda?.(mod.VERSAO) ?? mod.respostaSondaTactical?.();
+    if (!corpo) {
+      throw new Error(`${nome}: não exporta respostaSonda nem respostaSondaTactical`);
+    }
+    if (corpo.edge !== nome) {
+      throw new Error(
+        `${nome}: a sonda se identifica como ${JSON.stringify(corpo.edge)} — o nome tem de ser o do ` +
+          `diretório da function, senão o veredito aponta para a edge errada`,
+      );
+    }
+    if (corpo.probe !== true) throw new Error(`${nome}: sonda sem o eco probe:true`);
+    if (corpo.versao !== mod.VERSAO) {
+      throw new Error(`${nome}: sonda devolve versao ${JSON.stringify(corpo.versao)} ≠ VERSAO`);
+    }
+  }
+});
+
+Deno.test("duas edges NUNCA produzem respostas de sonda idênticas", () => {
+  // A asserção que falha no desenho antigo: sem o campo `edge`, todas as edges de uma mesma leva
+  // devolviam exatamente o mesmo corpo. É esta indistinguibilidade — não a ausência do nome em si —
+  // que destrói a verificação quando mais de uma sonda é disparada.
+  const porCorpo = new Map<string, string[]>();
+  for (const { nome, mod } of EDGES) {
+    const corpo = mod.respostaSonda?.(mod.VERSAO) ?? mod.respostaSondaTactical?.();
+    const chave = JSON.stringify(corpo);
+    porCorpo.set(chave, [...(porCorpo.get(chave) ?? []), nome]);
+  }
+  const colisoes = [...porCorpo.values()].filter((edges) => edges.length > 1);
+  if (colisoes.length > 0) {
+    throw new Error(
+      `respostas de sonda indistinguíveis entre edges: ${
+        colisoes.map((e) => e.join(" ≡ ")).join("; ")
+      }`,
+    );
   }
 });

--- a/supabase/functions/_shared/sonda-versao.ts
+++ b/supabase/functions/_shared/sonda-versao.ts
@@ -56,13 +56,32 @@ export function classificarSonda(body: unknown): DecisaoSonda {
 }
 
 /**
- * Corpo da resposta da sonda. O eco `probe:true` é OBRIGATÓRIO na verificação: um bundle ANTERIOR
- * à sonda IGNORA o parâmetro e roda o FLUXO REAL (`docs/agent/deploy.md` §Canárias, armadilha 1) —
- * sem o eco, a resposta do fluxo real se confundiria com "a sonda respondeu". Resposta sem
- * `probe:true` já é o veredito: bundle velho — e ele executou o efeito caro.
+ * Fábrica do corpo da resposta da sonda, LIGADA à edge que a serve.
+ *
+ * O eco `probe:true` é OBRIGATÓRIO na verificação: um bundle ANTERIOR à sonda IGNORA o parâmetro e
+ * roda o FLUXO REAL (`docs/agent/deploy.md` §Canárias, armadilha 1) — sem o eco, a resposta do fluxo
+ * real se confundiria com "a sonda respondeu". Resposta sem `probe:true` já é o veredito: bundle
+ * velho — e ele executou o efeito caro.
+ *
+ * O campo `edge` existe porque `versao` NÃO identifica quem respondeu: o marcador nasce igual em
+ * todas as edges de uma leva (o gate de contrato até assere isso), então duas respostas de edges
+ * diferentes eram byte a byte IDÊNTICAS. E nada no banco desfazia o empate — `net._http_response`
+ * não guarda a URL, a `net.http_request_queue` é esvaziada ao processar, os headers são só do
+ * Cloudflare e o `created` é o ciclo de coleta do worker do pg_net (respostas de edges distintas
+ * compartilham timestamp ao microssegundo). Custo real (2026-08-18): 10 sondas respondidas com
+ * sucesso e NENHUM veredito por edge possível — a verificação inteira se perdeu.
+ * Detalhe: `docs/historico/verificar-sonda-versao.md` §7.
+ *
+ * É fábrica, e não um parâmetro a mais em cada chamada, para que a identidade fique declarada UMA
+ * vez no `versao.ts` da edge — o `index.ts` segue chamando `respostaSonda(VERSAO)` sem mudança, e
+ * não há como uma chamada nova esquecer de passar o nome.
  */
-export function respostaSonda(versao: string): { ok: true; probe: true; versao: string } {
-  return { ok: true, probe: true, versao };
+export function criarRespostaSonda(edge: string) {
+  return function respostaSonda(
+    versao: string,
+  ): { ok: true; probe: true; versao: string; edge: string } {
+    return { ok: true, probe: true, versao, edge };
+  };
 }
 
 /** Mensagem do 400 de `probe` ambíguo. `efeito` descreve o custo real daquela edge. */

--- a/supabase/functions/_shared/sonda-versao_test.ts
+++ b/supabase/functions/_shared/sonda-versao_test.ts
@@ -6,7 +6,7 @@
 // pedido submetido no portal do fornecedor (`enviar-pedido-portal-sayerlack`). Por isso o default
 // cai no lado caro: `probe` presente mas não reconhecido é AMBÍGUO, nunca execução por omissão.
 
-import { classificarSonda, erroSondaAmbigua, respostaSonda } from "./sonda-versao.ts";
+import { classificarSonda, criarRespostaSonda, erroSondaAmbigua } from "./sonda-versao.ts";
 
 function assertEquals(a: unknown, b: unknown, msg?: string) {
   if (JSON.stringify(a) !== JSON.stringify(b)) {
@@ -16,10 +16,30 @@ function assertEquals(a: unknown, b: unknown, msg?: string) {
   }
 }
 
-Deno.test("respostaSonda: eco `probe` + a versão que o chamador passou", () => {
+Deno.test("respostaSonda: eco `probe` + a versão que o chamador passou + a EDGE que respondeu", () => {
   // O eco `probe:true` não é enfeite: um bundle ANTERIOR à sonda ignora o parâmetro e cai no
   // FLUXO REAL (docs/agent/deploy.md §Canárias, armadilha 1). Ausência do eco = bundle velho.
-  assertEquals(respostaSonda("v1.0-x"), { ok: true, probe: true, versao: "v1.0-x" });
+  //
+  // O `edge` também não: `versao` nasce IGUAL em toda uma leva, então sem ele duas respostas de
+  // edges diferentes são byte a byte idênticas e o veredito por edge se perde — aconteceu em
+  // 2026-08-18 com 10 sondas respondidas (docs/historico/verificar-sonda-versao.md §7).
+  const respostaSonda = criarRespostaSonda("edge-x");
+  assertEquals(respostaSonda("v1.0-x"), {
+    ok: true,
+    probe: true,
+    versao: "v1.0-x",
+    edge: "edge-x",
+  });
+});
+
+Deno.test("criarRespostaSonda: fábricas de edges distintas NÃO colidem", () => {
+  // A propriedade que o desenho antigo não tinha, no menor caso possível: mesmo marcador, corpos
+  // distinguíveis.
+  const a = criarRespostaSonda("edge-a")("v1.0-igual");
+  const b = criarRespostaSonda("edge-b")("v1.0-igual");
+  if (JSON.stringify(a) === JSON.stringify(b)) {
+    throw new Error("duas edges com o mesmo marcador produziram respostas idênticas");
+  }
 });
 
 Deno.test("corpo de chamador legítimo (sem a chave `probe`) → fluxo real", () => {

--- a/supabase/functions/conciliar-pedido-portal/versao.ts
+++ b/supabase/functions/conciliar-pedido-portal/versao.ts
@@ -5,7 +5,11 @@
 // `disparar-pedidos-aprovados` (guard anti-duplicado por `omie_pedido_compra_id`, §4.4). É a mesma
 // classe de efeito da edge que ela chama — por isso a sonda precisa responder ANTES de tudo.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("conciliar-pedido-portal");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/disparar-pedidos-aprovados/versao.ts
+++ b/supabase/functions/disparar-pedidos-aprovados/versao.ts
@@ -10,7 +10,11 @@
 // aprovados o fluxo expira oportunidades e grava `sync_reprocess_log`. A única prova de deploy era
 // esperar um pedido ser disparado de verdade.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("disparar-pedidos-aprovados");
 
 /**
  * Marcador de versão servido pela edge. **Atualize a cada mudança relevante de comportamento** —

--- a/supabase/functions/enviar-pedido-portal-sayerlack/versao.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/versao.ts
@@ -6,7 +6,11 @@
 // `disparar-pedidos-aprovados` para registrar o PO no Omie. Não existe caminho de diagnóstico
 // barato sem a sonda.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("enviar-pedido-portal-sayerlack");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/fin-cashflow-engine/versao.ts
+++ b/supabase/functions/fin-cashflow-engine/versao.ts
@@ -14,7 +14,11 @@
 // O gate desta edge é um `authorizeCronOrStaff` INLINE (não o de `_shared/auth.ts`), e ele JÁ
 // aceita `x-cron-secret`: a sonda entra logo APÓS ele, sem gate próprio.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("fin-cashflow-engine");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/generate-bundle-argument/versao.ts
+++ b/supabase/functions/generate-bundle-argument/versao.ts
@@ -18,7 +18,11 @@
 // `x-cron-secret`, não `Authorization`). 401 aqui é veredito de "bundle velho", não de permissão —
 // e custa zero, porque o 401 vem antes de qualquer token gasto.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("generate-bundle-argument");
 
 /**
  * Marcador de versão servido pela edge. **Atualize a cada mudança relevante de comportamento** —

--- a/supabase/functions/generate-tactical-plan/versao.ts
+++ b/supabase/functions/generate-tactical-plan/versao.ts
@@ -21,7 +21,10 @@
 // re-exportar seria export sem consumidor — o `knip` do CI barra, e com razão.
 export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
 
-import { respostaSonda } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Local, não exportado: a resposta desta edge sai pelo composer abaixo (knip barraria o export). */
+const respostaSonda = criarRespostaSonda("generate-tactical-plan");
 import { MODELO, toolDoModo } from "./plano-helpers.ts";
 
 /**
@@ -53,6 +56,7 @@ export function respostaSondaTactical(): {
   ok: true;
   probe: true;
   versao: string;
+  edge: string;
   motor: "anthropic";
   modelo: string;
   tool: string;

--- a/supabase/functions/gerar-pedidos-diario/versao.ts
+++ b/supabase/functions/gerar-pedidos-diario/versao.ts
@@ -5,7 +5,11 @@
 // O e-mail é externo e não se desfaz; a regeneração mexe no ciclo que o comprador está olhando.
 // Menos grave que submeter pedido ao fornecedor, mas ainda sem caminho de diagnóstico barato.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("gerar-pedidos-diario");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/omie-cliente/versao.ts
+++ b/supabase/functions/omie-cliente/versao.ts
@@ -21,7 +21,11 @@
 // como o founder invoca a sonda pelo SQL Editor. Por isso a sonda tem gate PRÓPRIO
 // (`authorizeCronOrStaff`) e responde antes do dispatch; ver o comentário no `index.ts`.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-cliente");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/omie-nfe-recebimento/versao.ts
+++ b/supabase/functions/omie-nfe-recebimento/versao.ts
@@ -11,7 +11,11 @@
 // lê `nfe_recebimentos` + `ConsultarRecebimento` e retorna) — mas ele não responde "qual bundle
 // está no ar", e custa 1 chamada ao Omie. A sonda responde isso sem tocar em nada.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-nfe-recebimento");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/omie-nfe-webhook/versao.ts
+++ b/supabase/functions/omie-nfe-webhook/versao.ts
@@ -15,7 +15,11 @@
 // JWT) — ele NÃO aceita `x-cron-secret`, que é como o founder invoca a sonda pelo SQL Editor.
 // Daí o gate próprio da sonda no `index.ts`; ver o comentário lá.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-nfe-webhook");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/omie-sync-estoque/versao.ts
+++ b/supabase/functions/omie-sync-estoque/versao.ts
@@ -13,7 +13,11 @@
 // O gate desta edge é `authorizeCronOrStaff` (`_shared/auth.ts`), que JÁ aceita `x-cron-secret`:
 // a sonda entra logo APÓS ele, sem gate próprio — diferente das edges de NF-e (#1753/#1766).
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-sync-estoque");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/omie-sync-nfes-recebidas/versao.ts
+++ b/supabase/functions/omie-sync-nfes-recebidas/versao.ts
@@ -15,7 +15,11 @@
 // O gate desta edge é um `authorizeCronOrStaff` INLINE (não o de `_shared/auth.ts`), e ele JÁ
 // aceita `x-cron-secret`: a sonda entra logo APÓS ele, sem gate próprio.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-sync-nfes-recebidas");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/pedido-programado-enviar/versao.ts
+++ b/supabase/functions/pedido-programado-enviar/versao.ts
@@ -5,7 +5,11 @@
 // como `enviado` e dispara `omie-vendas-sync`. O efeito é no BANCO, não num sistema de terceiro —
 // mas é escrita de money-path que muda o que o comercial vê, e não há caminho barato sem a sonda.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("pedido-programado-enviar");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/process-nfe/versao.ts
+++ b/supabase/functions/process-nfe/versao.ts
@@ -10,7 +10,11 @@
 // (`docs/agent/deploy.md`: comentário que promete caminho seguro inexistente já mordeu 2×).
 // Antes desta sonda não havia NENHUMA forma de perguntar qual bundle estava no ar.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("process-nfe");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/reposicao-depara-sayerlack-auto/versao.ts
+++ b/supabase/functions/reposicao-depara-sayerlack-auto/versao.ts
@@ -14,7 +14,11 @@
 // Nota: esta edge não lia o corpo da requisição (o cron dispara sem body). O parse foi introduzido
 // junto da sonda e é tolerante — body ausente/inválido continua sendo o caminho do cron.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("reposicao-depara-sayerlack-auto");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";

--- a/supabase/functions/sayerlack-captura-precos/versao.ts
+++ b/supabase/functions/sayerlack-captura-precos/versao.ts
@@ -15,7 +15,11 @@
 // `src/lib/reposicao/__tests__/embalagem-captura-edge-invariants.test.ts` quebra o CI se um token
 // de finalização aparecer no arquivo. Promessa com fiador, não comentário solto.
 
-export { classificarSonda, erroSondaAmbigua, respostaSonda } from "../_shared/sonda-versao.ts";
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("sayerlack-captura-precos");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
 export const VERSAO = "v1.0-sensor-inicial";


### PR DESCRIPTION
Fecha a classe descrita em `docs/historico/verificar-sonda-versao.md` §7 (mergeado no #1780).

## O problema

`respostaSonda(VERSAO)` devolvia `{ok,probe,versao}` — e `versao` **não identifica quem respondeu**: o marcador nasce igual em toda uma leva (o gate de contrato assere isso de propósito). Duas respostas de edges diferentes eram **byte a byte idênticas**, e nada no banco desfaz o empate:

| fonte | por que não resolve |
| --- | --- |
| `net._http_response` | não tem coluna de URL |
| `net.http_request_queue` | esvaziada ao processar |
| `headers` | só Cloudflare |
| `created` | ciclo de coleta do worker do pg_net |

**Custo real (2026-08-18):** 10 sondas respondidas com sucesso — 200 + `probe:true` em todas — e nenhum veredito por edge possível. A verificação inteira se perdeu.

> Nota de coordenação: o #1788 (outra sessão) mostra que um lote **homogêneo** — todas verdes — ainda dá veredito, porque a permutação é irrelevante quando todas responderam sonda. Isso não dispensa este PR: basta **uma** divergir para o veredito voltar a ser impossível, e é exatamente o caso interessante (a que não subiu). Com `edge` na resposta, o lote heterogêneo também fica legível.

## O conserto

Uma **fábrica**, não um parâmetro a mais: `criarRespostaSonda(edge)` é declarada uma vez no `versao.ts` de cada edge.

- **Nenhum `index.ts` muda** — seguem chamando `respostaSonda(VERSAO)` igual. A superfície tocada exclui os arquivos grandes de money-path.
- Não há chamada nova que possa **esquecer** de passar o nome.
- A `respostaSonda` livre **saiu** do `_shared` (fail-closed): quem não declarar identidade não compila.
- A `generate-tactical-plan` mantém o composer dela, agora com `edge` no tipo.

Resposta nova:

```json
{"ok":true,"probe":true,"versao":"v1.0-sensor-inicial","edge":"process-nfe"}
```

## Gates novos (contrato das 17 edges instrumentadas)

1. **a sonda se identifica com o nome do DIRETÓRIO da function** — nome errado apontaria o veredito para a edge errada;
2. **duas edges NUNCA produzem respostas idênticas** — a asserção que *falha no desenho antigo*, porque é a indistinguibilidade, e não a ausência do nome em si, que destrói a verificação.

## Verificação

- `bun run test:edges` → **exit 0**, 765 passed / 0 failed
- `bun run edges:typecheck` → **exit 0**, 0 erros de classe-crash
- **Falsificado:** com `edge` forçado a `""` (simulando o desenho antigo), os dois gates novos ficam **FAILED** com a mensagem de colisão; restaurado, `21 passed / 0 failed` (exit 0). A diferença entre sabotado e restaurado são exatamente os dois testes novos.

## Deploy

As 16 edges precisam de **deploy pelo chat do Lovable** para a identidade chegar em produção — merge na main não publica edge. Até lá as sondas seguem respondendo o formato antigo (sem `edge`), o que é degradação limpa: o campo ausente significa "bundle anterior a este PR", não erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)