### PR TITLE
test(hooks): a falsificação embutida cobria o NÚCLEO — o furo estava na periferia do guard de duplicata

### DIFF
--- a/docs/historico/duplicata-por-objetivo.md
+++ b/docs/historico/duplicata-por-objetivo.md
@@ -144,6 +144,31 @@ foi criado, mas o laço do `test:hooks` lista os guards por nome e ele ficou de 
 forma mais cara de "ausência de sinal com cara de verde" (irmã do `grep` sem ocorrência, do linter sem
 a regra). Corrigido nesta entrega, junto com os 5 casos novos e as 2 falsificações novas.
 
+## Auditoria de PODER da suíte (mutation-check, 2026-08-18)
+
+O guard nasceu com bloco de **falsificação embutido** (5 sabotagens: as 3 vias, o escopo por-arquivo,
+o alvo do commit, o dedupe) — e mesmo assim tinha 1 furo. Contrato executável agora em
+[`scripts/mutcheck.d/pr-duplicata-guard.mut`](../../scripts/mutcheck.d/pr-duplicata-guard.mut)
+(6 mutações, todas PEGA; primeiro alvo **shell** do `mutcheck.d` — `@test_cmd: bash`,
+`@compile_cmd: bash -n`).
+
+O que a auditoria mostrou, e vale além deste hook:
+
+1. **A falsificação escrita junto com a feature cobre o NÚCLEO — a periferia é o que o autor não
+   estava pensando.** As 5 sabotagens embutidas miravam o miolo do algoritmo; o furo estava na
+   sanitização de heredoc/aspas (a decisão "menção ≠ execução"), afirmada no cabeçalho e **sem
+   nenhuma sabotagem**. Desligar a sanitização inteira **sobrevivia à suíte**.
+2. **Por que sobrevivia — e a lição geral: asserção negativa só tem poder se TODO caminho
+   alternativo estiver ARMADO para falar.** O caso 4 testava a menção (`echo "git commit -m x"`)
+   com `_deve_calar`, mas rodava só com `GIT_STUB_MINE_FILE`. Ao escapar da sanitização o hook
+   entrava em modo `commit` e lia `GIT_STUB_STAGED_FILE` — **não setado**, default `/dev/null` →
+   calava por **acidente do fixture**, não pela invariante. Correção: o caso 4 arma os três alvos
+   do stub (`ARMADO`) e ganhou caso de **heredoc**; a mutação passou a reprovar.
+3. **Fechado também o limiar de 12 chars** (caso 7b): irmão do filtro de forma, mas eixo
+   independente — sem ele, baixar o limiar de precisão não reprovava nada.
+
+Suíte: 31 → 33 asserções. `bun run test:hooks` verde; contrato roda no job `mutation-check`.
+
 ## Precedente
 
 | quando | caso | forma |

--- a/scripts/mutcheck.d/pr-duplicata-guard.mut
+++ b/scripts/mutcheck.d/pr-duplicata-guard.mut
@@ -1,0 +1,38 @@
+# Invariantes do guard de DUPLICATA por OBJETIVO (.claude/hooks/pr-duplicata-guard.sh, #1781).
+# @src: .claude/hooks/pr-duplicata-guard.sh
+# @test: scripts/test-pr-duplicata-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+# ^ alvo SHELL (primeiro contrato nao-TS daqui): sem estas duas o mutcheck-all rodaria vitest na
+# suite e `bun build` no hook — os dois falham, o baseline fica vermelho e o JOB do CI aborta.
+# Rode: MUTCHECK_TEST_CMD=bash MUTCHECK_COMPILE_CMD="bash -n" \
+#   scripts/mutcheck.sh .claude/hooks/pr-duplicata-guard.sh scripts/test-pr-duplicata-guard.sh scripts/mutcheck.d/pr-duplicata-guard.mut
+#
+# ALVO DESTE ARQUIVO: as decisões que o bloco 14 (falsificação embutida) NÃO sabota. Ele já cobre
+# as 3 vias, o escopo por-arquivo, o alvo do commit e o dedupe. O que sobra sem guarda é a
+# PERIFERIA — e periferia de detector falha ABERTA (guard que não dispara = guard que não existe).
+
+# --- CONTROLE+ : mutação sabidamente coberta (caso 3). Se esta SOBREVIVE, o harness é que quebrou,
+# não a suíte — mutcheck dirigindo alvo shell é uso novo (todos os .mut daqui eram TS + vitest).
+PEGA      | controle+: via 3 (presenca na main) removida | s{^  dup=.*}{  dup="\$novos"}
+
+# --- Periferia sem sabotagem embutida ---
+# O cache de anti-alarm-fatigue vaza para o `create`. O cabeçalho AFIRMA "o gh pr create NUNCA é
+# silenciado por este cache (último portão)" — invariante em prosa. `!$done++` restringe à 1ª
+# ocorrência (a linha é byte-idêntica à do bloco de mensagem, adiante).
+PEGA      | cache de dedupe vaza p/ o `create`   | $arm = 1 if /silenciado por este cache/; if ($arm && !$done) { $done = s{^if \[ "\$modo" = commit \]; then}{if true; then}; }
+
+# A detecção de `-a` some: `git commit -a` volta a ler só o ÍNDICE, e o trabalho não-staged
+# (que ENTRARIA no commit) fica invisível ao guard.
+PEGA      | deteccao de `git commit -a` neutralizada | s{&& alvo=""}{&& alvo=--cached}
+
+# A sanitização de heredoc/aspas desliga: MENÇÃO a `gh pr create`/`git commit` dentro de string ou
+# heredoc passa a valer como EXECUÇÃO. É a classe de bypass que o Codex achou nos hooks do ECC.
+PEGA      | sanitizacao heredoc/aspas desligada  | s{^\[ -n "\$scan" \] \|\| scan="\$cmd"}{scan="\$cmd"}
+
+# O filtro de FORMA do identificador some: prosa portuguesa em .md vira candidato a símbolo.
+PEGA      | filtro de forma do identificador removido | s{grep -E '_\|\[a-z\]\[A-Z\]'}{grep -E '.'}
+
+# O limiar de 12 chars. Sobreviveu na 1a rodada; triado como BORDA CANONICA (o cabecalho declara
+# o limiar como decisao de precisao MEDIDA, nao detalhe interno) e fechado pelo caso 7b.
+PEGA      | limiar do identificador 12 -> 3 chars | s/\{11,\}/{2,}/

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -148,10 +148,24 @@ _main
 echo "== 4. comando fora dos DOIS gatilhos → mudo =="
 # `git commit` agora É gatilho — o que tem de continuar mudo é a MENÇÃO (aspas/heredoc) e
 # comandos vizinhos de nome parecido.
+# ARMADO: os TRÊS alvos do stub servem achado. Com só o $MINE (=HEAD) uma menção que escapasse da
+# sanitização e virasse modo `commit` leria o stub STAGED VAZIO e calaria — o caso passaria por
+# ACIDENTE do fixture, não pela sanitização. Asserção negativa só tem poder se TODO caminho
+# alternativo estivesse armado para FALAR. (mutation-check 2026-08-18: sem isto, desligar a
+# sanitização inteira sobrevivia à suíte.)
+ARMADO="$MINE GIT_STUB_STAGED_FILE=$stub/mine.txt GIT_STUB_WT_FILE=$stub/mine.txt"
 for c in 'echo "gh pr create"' 'echo "git commit -m x"' 'gh pr list' 'git commit-tree -m x' 'git log --grep=commit'; do
-  out="$(_hook "$MINE $DEDUPE" "$c")"
+  out="$(_hook "$ARMADO $DEDUPE" "$c")"
   _deve_calar "mudo em: $c" "$out"
 done
+# heredoc: menção no CORPO não é execução. Classe de bypass que o Codex achou nos hooks do ECC
+# (o guard chegou a bloquear o commit que a documentava).
+HD=$'cat <<'FIM'
+git commit -m x
+gh pr create --title x
+FIM'
+out="$(_hook "$ARMADO $DEDUPE" "$HD")"
+_deve_calar "mudo em: menção dentro de heredoc" "$out"
 
 echo "== 5. arquivo ausente da origin/main → mudo =="
 rm -f "$stub/main_scripts_authz-manifest_ts"
@@ -172,6 +186,23 @@ printf 'Documento. A regra vale imediatamente para toda implementacao subsequent
   > "$stub/main_docs_nota_md"
 out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine_md.txt" "$CRIAR")"
 _deve_calar "prosa portuguesa não dispara" "$out"
+
+echo "== 7b. limiar de tamanho: identificador CURTO (<12) não vira candidato =="
+# Irmão do 7: lá quem filtra é a FORMA (prosa não tem underscore), aqui é o TAMANHO. São dois
+# filtros independentes e o de tamanho é decisão de PRECISÃO medida (cabeçalho do hook: 51/134
+# pares num teto pessimista) — sem este caso, baixar o limiar não reprovava nada.
+printf 'src/curto.ts
+' > "$stub/mine_curto.txt"
+printf '+++ b/src/curto.ts
++const cor_x = 1
+' > "$stub/diff_src_curto_ts"
+printf 'const a = 0
+' > "$stub/base_src_curto_ts"
+printf 'const a = 0
+const cor_x = 1
+' > "$stub/main_src_curto_ts"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine_curto.txt" "$CRIAR")"
+_deve_calar "cor_x (5 chars, forma válida) não dispara" "$out"
 
 echo "== 8. REGRESSÃO do escopo: símbolo existe repo-wide, mas é novo NO ARQUIVO → AVISA =="
 # É a ocorrência 1 real: reposicao_pos_marcador vivia em 10 arquivos (migrations) na merge-base.


### PR DESCRIPTION
## O achado

O `pr-duplicata-guard.sh` (#1781) **já nascera com bloco de falsificação próprio** — 5 sabotagens sobre as 3 vias, o escopo por-arquivo, o alvo do commit e o dedupe. Um mutation-check sobre ele mostrou que, ainda assim, **desligar a sanitização de heredoc/aspas inteira sobrevivia à suíte** — justamente a decisão ("menção ≠ execução") que o cabeçalho AFIRMA.

Regra derivada: *falsificação escrita junto com a feature cobre o **núcleo** — a periferia é exatamente o que o autor não estava pensando.*

## A causa (vale além deste hook)

**Asserção negativa só tem poder se TODO caminho alternativo estiver ARMADO para falar.**

O caso 4 testava a menção (`echo "git commit -m x"`) com `_deve_calar`, mas rodava só com `GIT_STUB_MINE_FILE`. Ao escapar da sanitização, o hook entrava em modo `commit` e lia `GIT_STUB_STAGED_FILE` — **não setado**, default `/dev/null` → `mine` vazio → `exit 0`. Calava por **acidente do fixture**, não pela invariante. Verde garantido, poder zero: o primo shell do `WHEN OTHERS THEN 'OK'`.

## O que muda

| | |
|---|---|
| caso 4 | arma os **três** alvos do stub (`ARMADO`) + ganha caso de **heredoc** (a classe de bypass que o Codex achou nos hooks do ECC) |
| caso 7b | fecha o **limiar de 12 chars** — eixo independente do filtro de forma; sem ele, baixar o limiar de precisão não reprovava nada |
| `scripts/mutcheck.d/pr-duplicata-guard.mut` | contrato executável, 6 mutações, **todas PEGA**. Primeiro alvo **shell** do `mutcheck.d` |

O hook **não muda** — só a suíte e o contrato. Triagem do 2º sobrevivente (limiar) foi explícita: borda **canônica** (o cabeçalho declara o limiar como decisão de precisão *medida*), não detalhe interno ⇒ fechar, não registrar.

⚠️ As diretivas `@test_cmd: bash` / `@compile_cmd: bash -n` são load-bearing para o CI: sem elas o job `mutation-check` rodaria `vitest`/`bun build` num alvo shell, o baseline ficaria vermelho e o job **abortaria** — derrubando os contratos dos outros.

## Evidência

```
bun run test:hooks                exit 0  (5 suítes; duplicata 31 → 33 asserções)
mutcheck (via parsing do mutcheck-all)  exit 0
  6 mutações · 6 pegas · 0 sobreviventes · 0 inválidas · controle+ ✓ (6/6)
shellcheck                        exit 0
```

Honestidade sobre o escopo da medição: rodei o contrato pelo **caminho exato de parsing** do `mutcheck-all.sh` (mesmas diretivas `sed`, mesmos envs), não o `bun run mutcheck` inteiro — os outros 11 contratos são vitest e a máquina está com swap alto. O job do CI roda o conjunto.

Residuo de método (fora do repo): `~/.claude/skills/auto-ensino/references/mutation-check.md` — a regra da asserção negativa armada, o uso do mutcheck em alvo não-TS, e o idioma do contador em mutação `perl -pe` (gate por `!$done++` consome em linha que não casa ⇒ a mutação não aplica; incrementar pelo RESULTADO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)