### PR TITLE
docs(sonda): `omie-cliente` no ar e o `edge` do #1789 confirmado em PROD — e o rastro do bot não é sinal

### DIFF
--- a/docs/historico/verificar-sonda-versao.md
+++ b/docs/historico/verificar-sonda-versao.md
@@ -199,3 +199,52 @@ automáticos / 301 total com carimbo de 31/07 — inalterados pela sonda de `rep
 Mesma checagem nas 5 do #1772: `reposicao_estoque_full` parado em 18/08 19:40 e `fin_sync_log` em
 00:20, ambos anteriores às sondas das 00:54. A resposta diz "o bundle novo está no ar"; só o banco
 diz "e ele não fez nada".
+
+## Lote do #1772 (2026-08-19/20) — `omie-cliente` no ar, e o `edge` do #1789 confirmado EM PRODUÇÃO
+
+O founder colou os 5 prompts de deploy do #1772 em **2026-08-19 ~01:45 UTC**. A sonda da
+`omie-cliente` (SQL Editor, `{"probe":true}` + `x-cron-secret`) devolveu, às 23:50 do mesmo dia:
+
+```
+status 200 · {"ok":true,"probe":true,"versao":"v1.0-sensor-inicial","edge":"omie-cliente"}
+```
+
+Dois vereditos numa resposta só: a edge está na versão nova, **e o campo `edge` do #1789 está no ar**
+— a §"PENDENTE" acima previa o formato antigo (sem `edge`) enquanto o deploy não acontecesse, e para
+esta edge ele já aconteceu. O campo veio porque o #1789 entrou na `main` às **01:45 UTC**, minutos
+antes de o founder colar os prompts: o Lovable leu a main já corrigida.
+
+⚠️ **Campo inesperado em produção é "a main andou" ANTES de ser "o Lovable melhorou o código".** O
+`edge` não existia no worktree de quem sondou (18 commits atrás), e a primeira hipótese levantada foi
+adulteração no deploy — que é a acusação cara, e estava errada. O desempate é uma linha:
+`git log -S'edge' origin/main -- supabase/functions/_shared/sonda-versao.ts`. Worktree defasado
+produz "achado" que não existe; sincronize antes de acusar.
+
+⚠️ **O rastro do commit do bot NÃO serve como sinal de deploy pelo chat.** Esperei **22h** por um
+commit `Deployed …`/`Redeployed …` que nunca veio — com **122 commits do tipo** no histórico, o que
+tornava a ausência aparentemente informativa. O deploy tinha acontecido: a sonda provou. Rastro
+ausente **não** degrada para "não deployou"; ele não é sinal de nada neste caminho, e tratá-lo como
+sinal me fez reportar "provavelmente não executou" sobre algo que estava no ar. Só a sonda (ou a
+verificação passiva do §1) decide.
+
+### Segurança de sonda nas 5 do #1772 — lido no bundle velho (`77e46ab9^1`)
+
+Mesma técnica da §"Reduzir o risco sem sondar às cegas", aplicada a este lote:
+
+| edge | o bundle VELHO faz o quê com `{"probe":true}` | seguro? |
+| --- | --- | --- |
+| `omie-cliente` | `switch (action)`; sem `action` cai no `default:` → 400 "Ação não reconhecida" | ✅ provado em prod |
+| `fin-cashflow-engine` | `save_snapshot ?? false`, e os 2 `insert` estão dentro de `if (save)` → calcula e devolve, não grava | ✅ |
+| `omie-nfe-webhook` | exige `x-webhook-secret` (a sonda manda `x-cron-secret`) → 401 antes de qualquer escrita | ✅ |
+| `omie-sync-estoque` | `authorizeCronOrStaff` **aceita** `x-cron-secret` → passa o gate e roda o sync, reescrevendo o saldo que o motor de reposição consome | ❌ |
+| `omie-sync-nfes-recebidas` | idem — gate próprio que aceita `x-cron-secret`, sem parâmetro que barre | ❌ |
+
+**O discriminante não é a edge ser "leve"** — é o bundle velho ter um **ponto de recusa antes da
+primeira escrita**: dispatch por ação, segredo diferente, ou flag de escrita que nasce `false`.
+Conferir só o dispatch não basta: as duas ❌ não têm `switch (action)` e ainda assim são perigosas,
+porque o gate delas aceita exatamente a credencial com que a sonda é invocada. **Leia o gate junto
+com o dispatch.**
+
+Para as duas ❌ sobra a via passiva (§1): `omie-sync-estoque` tem cron (`0 9` + `40 9,11,13,15,17,19`),
+então a próxima execução carimba `versao` de graça — dentro da janela de ~6h da §5.
+`omie-sync-nfes-recebidas` **não tem cron**: só o painel do Lovable.


### PR DESCRIPTION
Contribuição ao [`docs/historico/verificar-sonda-versao.md`](docs/historico/verificar-sonda-versao.md) (não duplica: só acrescenta o que foi verificado em primeira mão neste ciclo).

## O fato

Primeira evidência de que uma das **16 edges pendentes** subiu — e de que o conserto do §7 saiu do repo para a produção:

```
status 200 · {"ok":true,"probe":true,"versao":"v1.0-sensor-inicial","edge":"omie-cliente"}
```

O campo `edge` está lá. A §PENDENTE previa o formato antigo (sem ele) enquanto o deploy não acontecesse; para esta edge, aconteceu. O #1789 entrou na `main` às **01:45 UTC**, minutos antes de o founder colar os prompts — o Lovable leu a main já corrigida.

## Duas armadilhas de método que este ciclo pagou

1. **Campo inesperado em prod é "a main andou" ANTES de ser "o Lovable adulterou".** O `edge` não existia no worktree de quem sondou (18 commits atrás) e a primeira hipótese levantada foi adulteração no deploy — a acusação cara, e errada. Desempate de uma linha: `git log -S'edge' origin/main -- _shared/sonda-versao.ts`.

2. **O rastro do commit do bot não é sinal de deploy pelo chat.** 22h de espera por um `Deployed …` que nunca veio, com **122 commits do tipo** no histórico — o que fazia a ausência parecer informativa. O deploy já estava no ar. Ausência de rastro não degrada para "não deployou".

## Classificação de segurança das 5 do #1772

Mesma técnica da §"Reduzir o risco sem sondar às cegas", lida no bundle velho (`77e46ab9^1`):

| edge | bundle velho com `{"probe":true}` | seguro? |
| --- | --- | --- |
| `omie-cliente` | `switch (action)` → `default:` 400 | ✅ provado |
| `fin-cashflow-engine` | `save_snapshot ?? false`; inserts sob `if (save)` | ✅ |
| `omie-nfe-webhook` | exige `x-webhook-secret` → 401 | ✅ |
| `omie-sync-estoque` | `authorizeCronOrStaff` **aceita** `x-cron-secret` → roda o sync | ❌ |
| `omie-sync-nfes-recebidas` | idem | ❌ |

**Ler o gate junto com o dispatch:** as duas perigosas não têm `switch (action)` — é o gate que as torna perigosas, porque aceita exatamente a credencial com que a sonda é invocada. Conferir só o dispatch teria classificado as duas como inofensivas.

Doc-only. Nenhuma das 3 camadas de deploy do Lovable se aplica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)