### PR TITLE
fix(hooks): `git commit && gh pr create` casava como create — os DOIS guards calavam no 1º commit

### DIFF
--- a/.claude/hooks/pr-collision-guard.sh
+++ b/.claude/hooks/pr-collision-guard.sh
@@ -46,10 +46,18 @@ else
 fi
 [ -n "$scan" ] || scan="$cmd"
 modo=""
-if printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
-  modo="create"
-elif printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])git([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'; then
+# Encadeado (`git commit -am x && gh pr create ...`) casava como `create` pela ORDEM do if/elif —
+# mas quem EXECUTA primeiro é o commit, e ali o `mb..HEAD` ainda está vazio (o #1764 tinha 1
+# commit só) ⇒ o guard calava justamente no cenário que o gatilho 2 existe para cobrir. O alvo do
+# commit é SUPERCONJUNTO do alvo do create, então o commit vence quando os dois aparecem.
+# (achado da 2ª opinião adversária — Codex, 2026-08-19)
+tem_create=""; tem_commit=""
+printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' && tem_create=1
+printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])git([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)' && tem_commit=1
+if [ -n "$tem_commit" ]; then
   modo="commit"
+elif [ -n "$tem_create" ]; then
+  modo="create"
 fi
 [ -n "$modo" ] || exit 0
 
@@ -121,8 +129,9 @@ fi
 
 # Anti-alarm-fatigue (só no commit): avisa 1x por (branch, conjunto colidente). Commit é
 # frequente — repetir o MESMO aviso cega o leitor. Colisão nova = assinatura nova = avisa.
-# O `gh pr create` é o último portão e NUNCA é silenciado por este cache.
-if [ "$modo" = "commit" ]; then
+# O `gh pr create` é o último portão e NUNCA é silenciado por este cache — inclusive
+# quando vem ENCADEADO com o commit (`$tem_create`), caso em que o modo é `commit`.
+if [ "$modo" = "commit" ] && [ -z "$tem_create" ]; then
   cache_dir="${PRCG_CACHE_DIR:-${TMPDIR:-/tmp}/prcg-$(id -u 2>/dev/null || echo 0)}"
   mkdir -p "$cache_dir" 2>/dev/null || true
   assin="$(printf '%s\n%s' "$(git branch --show-current 2>/dev/null)" "$avisos" \

--- a/.claude/hooks/pr-duplicata-guard.sh
+++ b/.claude/hooks/pr-duplicata-guard.sh
@@ -76,10 +76,18 @@ else
 fi
 [ -n "$scan" ] || scan="$cmd"
 modo=""
-if printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
-  modo="create"
-elif printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])git([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'; then
+# Encadeado (`git commit -am x && gh pr create ...`) casava como `create` pela ORDEM do if/elif —
+# mas quem EXECUTA primeiro é o commit, e ali o `mb..HEAD` ainda está vazio (o #1764 tinha 1
+# commit só) ⇒ o guard calava justamente no cenário que o gatilho 2 existe para cobrir. O alvo do
+# commit é SUPERCONJUNTO do alvo do create, então o commit vence quando os dois aparecem.
+# (achado da 2ª opinião adversária — Codex, 2026-08-19)
+tem_create=""; tem_commit=""
+printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])gh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' && tem_create=1
+printf '%s' "$scan" | grep -qE '(^|[^[:alnum:]_./-])git([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)' && tem_commit=1
+if [ -n "$tem_commit" ]; then
   modo="commit"
+elif [ -n "$tem_create" ]; then
+  modo="create"
 fi
 [ -n "$modo" ] || exit 0
 
@@ -144,8 +152,9 @@ EOF
 
 # Anti-alarm-fatigue (só no commit): avisa 1x por (branch, conjunto de achados). Commit é
 # frequente — repetir o MESMO aviso cega o leitor. Achado novo = assinatura nova = avisa.
-# O `gh pr create` é o último portão e NUNCA é silenciado por este cache.
-if [ "$modo" = commit ]; then
+# O `gh pr create` é o último portão e NUNCA é silenciado por este cache — inclusive
+# quando vem ENCADEADO com o commit (`$tem_create`), caso em que o modo é `commit`.
+if [ "$modo" = commit ] && [ -z "$tem_create" ]; then
   cache_dir="${PRDG_CACHE_DIR:-${TMPDIR:-/tmp}/prdg-$(id -u 2>/dev/null || echo 0)}"
   mkdir -p "$cache_dir" 2>/dev/null || true
   assin="$(printf '%s\n%s' "$(git branch --show-current 2>/dev/null)" "$achados" \

--- a/scripts/mutcheck.d/pr-collision-guard.mut
+++ b/scripts/mutcheck.d/pr-collision-guard.mut
@@ -1,0 +1,30 @@
+# Invariantes do guard de COLISÃO por ARQUIVO (.claude/hooks/pr-collision-guard.sh).
+# @src: .claude/hooks/pr-collision-guard.sh
+# @test: scripts/test-pr-collision-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+#
+# POR QUE ESTE ARQUIVO: o irmão (pr-duplicata) trouxe falsificação embutida e AINDA tinha furo
+# na periferia. Este aqui não tem falsificação nenhuma — o poder da suíte dele nunca foi MEDIDO.
+# Predizer furo não é achá-lo; isto mede.
+
+# CONTROLE+ : matar a colisão-por-main tem de reprovar o caso-alvo (a). Se sobreviver, o
+# problema é o harness, não a suíte.
+PEGA      | controle+: colisao por main removida | s{^  col_main=.*}{  col_main=""}
+
+# Periferia 1 — sanitização de aspas/heredoc desligada: MENÇÃO passa a valer como EXECUÇÃO.
+PEGA      | sanitizacao heredoc/aspas desligada  | s{^\[ -n "\$scan" \] \|\| scan="\$cmd"}{scan="\$cmd"}
+
+# Periferia 2 — o cache de anti-alarm-fatigue vaza para o `create`. O cabeçalho AFIRMA que o
+# `gh pr create` é o último portão e NUNCA é silenciado. Âncora ASCII-única (a linha do `if`
+# se repete 3x); flag atribuído pelo RESULTADO do s///, nunca incrementado como gate.
+PEGA      | cache de dedupe vaza p/ o `create`   | $arm = 1 if /silenciado por este cache/; if ($arm && !$done) { $done = s{^if \[ "\$modo" = "commit" \]; then}{if true; then}; }
+
+# Periferia 3 — a detecção de `-a` some: a árvore deixa de entrar em `git commit -a`.
+PEGA      | deteccao de `git commit -a` neutralizada | s{&& wt="\$\(git diff --name-only 2>/dev/null\)"}{&& wt=""}
+
+# Periferia 4 — a colisão por PR ABERTO de outra branch morre (fica só o eixo main).
+PEGA      | colisao por PR aberto removida       | s{^    if \[ -n "\$col_prs" \]; then}{    if false; then}
+
+# Periferia 5 — o TEATRO do 3-pontos: no commit, ignorar staged/árvore e olhar só mb..HEAD.
+PEGA      | commit ignora staged (so 3-pontos)   | if (!$done) { $done = s{^if \[ "\$modo" = "commit" \]; then}{if false; then}; }

--- a/scripts/mutcheck.d/pr-collision-guard.mut
+++ b/scripts/mutcheck.d/pr-collision-guard.mut
@@ -18,7 +18,7 @@ PEGA      | sanitizacao heredoc/aspas desligada  | s{^\[ -n "\$scan" \] \|\| sca
 # Periferia 2 — o cache de anti-alarm-fatigue vaza para o `create`. O cabeçalho AFIRMA que o
 # `gh pr create` é o último portão e NUNCA é silenciado. Âncora ASCII-única (a linha do `if`
 # se repete 3x); flag atribuído pelo RESULTADO do s///, nunca incrementado como gate.
-PEGA      | cache de dedupe vaza p/ o `create`   | $arm = 1 if /silenciado por este cache/; if ($arm && !$done) { $done = s{^if \[ "\$modo" = "commit" \]; then}{if true; then}; }
+PEGA      | cache de dedupe vaza p/ o `create`   | $arm = 1 if /silenciado por este cache/; if ($arm && !$done) { $done = s{^if \[ "\$modo" = "commit" \] && \[ -z "\$tem_create" \]; then}{if true; then}; }
 
 # Periferia 3 — a detecção de `-a` some: a árvore deixa de entrar em `git commit -a`.
 PEGA      | deteccao de `git commit -a` neutralizada | s{&& wt="\$\(git diff --name-only 2>/dev/null\)"}{&& wt=""}
@@ -28,3 +28,7 @@ PEGA      | colisao por PR aberto removida       | s{^    if \[ -n "\$col_prs" \
 
 # Periferia 5 — o TEATRO do 3-pontos: no commit, ignorar staged/árvore e olhar só mb..HEAD.
 PEGA      | commit ignora staged (so 3-pontos)   | if (!$done) { $done = s{^if \[ "\$modo" = "commit" \]; then}{if false; then}; }
+
+# --- achados da 2ª opinião adversária (Codex, 2026-08-19), portados do irmão ---
+PEGA      | encadeado volta a casar como `create` | s{^if \[ -n "\$tem_commit" \]; then}{if [ -n "\$tem_commit" ] && [ -z "\$tem_create" ]; then}
+PEGA      | sem avisos o hook sai 1 (fail-closed) | s{^\[ -n "\$avisos" \] \|\| exit 0}{[ -n "\$avisos" ] || exit 1}

--- a/scripts/mutcheck.d/pr-duplicata-guard.mut
+++ b/scripts/mutcheck.d/pr-duplicata-guard.mut
@@ -20,7 +20,7 @@ PEGA      | controle+: via 3 (presenca na main) removida | s{^  dup=.*}{  dup="\
 # O cache de anti-alarm-fatigue vaza para o `create`. O cabeçalho AFIRMA "o gh pr create NUNCA é
 # silenciado por este cache (último portão)" — invariante em prosa. `!$done++` restringe à 1ª
 # ocorrência (a linha é byte-idêntica à do bloco de mensagem, adiante).
-PEGA      | cache de dedupe vaza p/ o `create`   | $arm = 1 if /silenciado por este cache/; if ($arm && !$done) { $done = s{^if \[ "\$modo" = commit \]; then}{if true; then}; }
+PEGA      | cache de dedupe vaza p/ o `create`   | $arm = 1 if /silenciado por este cache/; if ($arm && !$done) { $done = s{^if \[ "\$modo" = commit \] && \[ -z "\$tem_create" \]; then}{if true; then}; }
 
 # A detecção de `-a` some: `git commit -a` volta a ler só o ÍNDICE, e o trabalho não-staged
 # (que ENTRARIA no commit) fica invisível ao guard.
@@ -36,3 +36,28 @@ PEGA      | filtro de forma do identificador removido | s{grep -E '_\|\[a-z\]\[A
 # O limiar de 12 chars. Sobreviveu na 1a rodada; triado como BORDA CANONICA (o cabecalho declara
 # o limiar como decisao de precisao MEDIDA, nao detalhe interno) e fechado pelo caso 7b.
 PEGA      | limiar do identificador 12 -> 3 chars | s/\{11,\}/{2,}/
+
+# --- achados da 2ª opinião adversária (Codex, 2026-08-19) ---
+# Precedência no comando ENCADEADO: restaurar o bug (create vence quando os dois aparecem).
+# Era invisível: nenhum caso usava `git commit ... && gh pr create ...`.
+PEGA      | encadeado volta a casar como `create` | s{^if \[ -n "\$tem_commit" \]; then}{if [ -n "\$tem_commit" ] && [ -z "\$tem_create" ]; then}
+
+# Fail-open perdido: o hook passa a sair 1 quando não há achado. TODAS as asserções olhavam só
+# o stdout, então esta família inteira sobrevivia antes do caso 16 registrar a saída não-zero.
+PEGA      | sem achados o hook sai 1 (fail-closed) | s{^\[ -n "\$achados" \] \|\| exit 0}{[ -n "\$achados" ] || exit 1}
+
+# ─── LACUNAS CONHECIDAS, AINDA ABERTAS (2ª opinião Codex, 2026-08-19) ───────────────────────
+# Não estão aqui como mutação porque hoje SOBREVIVERIAM: a suíte precisa de caso novo antes.
+# Ficam registradas para não se perderem — lacuna documentada é dívida; lacuna esquecida é furo.
+#   - `origin/main` → `origin/master` na merge-base: o stub aceita qualquer ref.
+#   - remover `"$mb"` dos `git diff`: o stub só olha HEAD/--cached/árvore, então some sem sinal.
+#   - `base_c=""` → `continue`: duas sessões criando o MESMO arquivo novo deixam de ser
+#     detectadas (nenhum positivo usa arquivo ausente da merge-base). É a mais grave das abertas.
+#   - contrato JSON (`hookEventName`/`additionalContext`): `_avisa` casa o texto cru, então
+#     renomear a chave passa — e o host ignoraria o aviso.
+#   - `*.md` na lista de ignorados: o único fixture Markdown é negativo, então ignorar todo doc
+#     passa — e contradiz o cabeçalho do hook, que mediu que filtrar `docs/` dá falso negativo.
+#   - TTL do dedupe reduzido a `[ -f "$marca" ]`: silêncio virava permanente; os testes só
+#     fazem repetição imediata.
+#   - opções globais (`git -C dir commit`, `gh --repo x/y pr create`): só as formas simples
+#     são testadas.

--- a/scripts/test-pr-collision-guard.sh
+++ b/scripts/test-pr-collision-guard.sh
@@ -73,6 +73,11 @@ _hook() {
   json="$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
   # shellcheck disable=SC2086  # envs é lista KEY=VAL controlada (valores sem espaço) — split intencional
   printf '%s' "$json" | env $envs bash "$HOOK" 2>/dev/null
+  # fail-open TOTAL: o hook DEVE sair 0 sempre. As asserções olham só o stdout, então trocar
+  # um `exit 0` por `exit 1` sobrevivia a todas (achado do Codex, 2026-08-19). Subshell não
+  # propaga variável: registro por ARQUIVO, conferido no fim.
+  _rc=$?
+  [ "$_rc" -eq 0 ] || printf 'rc=%s cmd=%s\n' "$_rc" "$cmd" >> "$stub/exit-nao-zero.log"
 }
 
 # expect_warn <nome> <envs> <cmd> <token1> [token2] — allow + additionalContext com os tokens (ASCII, caixa fixa)
@@ -184,6 +189,26 @@ expect_warn "commit: colisao NOVA fura o dedupe" \
 expect_warn "create NAO herda o silencio do commit (mesmo conjunto)" \
   "$C $M GIT_STUB_GAINED_FILE=$stub/gained_hit.txt GH_STUB_FILE=$stub/prs_miss.json" \
   'gh pr create --fill' 'origin/main' 'src/lib/quente.ts'
+
+echo "── ENCADEADO: git commit + gh pr create é modo COMMIT (lê o índice) ──"
+# A ordem do if/elif casava `create` primeiro, mas quem EXECUTA antes é o commit — e ali o
+# 3-pontos está vazio no 1o commit (#1764), então o guard calava. Fixture DISCRIMINANTE: o
+# 3-pontos (MINE) vazio e o staged colidente — se o modo virar `create`, lê MINE vazio e cala.
+ENC="PRCG_CACHE_DIR=$stub/cache_enc GIT_STUB_MINE_FILE=/dev/null"
+ENC="$ENC GIT_STUB_STAGED_FILE=$stub/staged_hit.txt GIT_STUB_GAINED_FILE=$stub/gained_hit.txt"
+ENC="$ENC GH_STUB_FILE=$stub/prs_miss.json"
+expect_warn "encadeado le o indice (nao o 3-pontos vazio)" "$ENC" \
+  'git commit -am "wip" && gh pr create --fill' 'origin/main' 'src/lib/quente.ts'
+# o ultimo portao vale tambem no encadeado: repetir NAO pode calar (o comando contem create).
+expect_warn "encadeado nao e silenciado pelo dedupe (contem create)" "$ENC" \
+  'git commit -am "wip" && gh pr create --fill' 'origin/main' 'src/lib/quente.ts'
+
+echo "── fail-open TOTAL: o hook nunca sai não-zero ──"
+if [ -s "$stub/exit-nao-zero.log" ]; then
+  echo "  FAIL  hook saiu não-zero: $(head -1 "$stub/exit-nao-zero.log")"; fail=1
+else
+  echo "  ok    todas as chamadas saíram 0 (fail-open preservado)"
+fi
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -90,6 +90,11 @@ _hook() {
   json="$(jq -n --arg c "$cmd" '{tool_name:"Bash",tool_input:{command:$c}}')"
   # shellcheck disable=SC2086  # envs é lista KEY=VAL, precisa expandir em palavras
   printf '%s' "$json" | env $envs bash "${HOOK_ATUAL:-$HOOK}" 2>/dev/null
+  # O hook é fail-open TOTAL: DEVE sair 0 sempre. As asserções olham só o stdout, então
+  # trocar um `exit 0`/`continue` por `exit 1` sobrevivia a TODAS elas (achado do Codex,
+  # 2026-08-19). Subshell não propaga variável: o registro vai por ARQUIVO, conferido no fim.
+  _rc=$?
+  [ "$_rc" -eq 0 ] || [ -n "${HOOK_ATUAL:-}" ] || printf 'rc=%s cmd=%s\n' "$_rc" "$cmd" >> "$stub/exit-nao-zero.log"
 }
 _ok()   { printf '  ✓ %s\n' "$1"; }
 _bad()  { printf '  ✗ %s\n' "$1"; fail=1; }
@@ -321,6 +326,28 @@ else
   out="$(HOOK_ATUAL=$stub/sem-dedupe.sh _hook "$C9" "$COMITAR")"
   if _avisa "$out"; then _ok "sabotagem 'sem dedupe' → 2º commit volta a avisar (dedupe é load-bearing)"
   else _bad "sabotagem 'sem dedupe' NÃO mudou o veredito — o silêncio do caso 12 não é do dedupe"; fi
+fi
+
+echo "== 15. ENCADEADO: \`git commit\` + \`gh pr create\` é modo COMMIT =="
+# A ordem do if/elif casava `create` primeiro, mas quem EXECUTA antes é o commit — e ali o
+# mb..HEAD está vazio no 1º commit (#1764), então o guard calava. Fixture: HEAD vazio; staged E
+# árvore armados (o `-am` faz o alvo ser a ÁRVORE — armar só o índice deixaria o caso passar
+# por acidente, que é o furo que este mesmo PR corrige no caso 4).
+# ATENÇÃO: crase dentro de aspas duplas é substituição de comando — escapar SEMPRE no header.
+rm -rf "$CACHE"
+ENC="GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt"
+ENC="$ENC GIT_STUB_WT_FILE=$stub/mine.txt $DEDUPE"
+out="$(_hook "$ENC" 'git commit -am "wip" && gh pr create --fill')"
+_deve_avisar "encadeado lê índice/árvore (não o HEAD vazio)" "$out"
+# o último portão vale também no encadeado: repetir NÃO pode calar (o comando contém create).
+out="$(_hook "$ENC" 'git commit -am "wip" && gh pr create --fill')"
+_deve_avisar "encadeado não é silenciado pelo dedupe (contém create)" "$out"
+
+echo "== 16. fail-open TOTAL: o hook nunca sai não-zero =="
+if [ -s "$stub/exit-nao-zero.log" ]; then
+  _bad "hook saiu não-zero: $(head -1 "$stub/exit-nao-zero.log")"
+else
+  _ok "todas as chamadas saíram 0 (fail-open preservado)"
 fi
 
 echo


### PR DESCRIPTION
Saiu de um ciclo de mutation-check sobre os guards de hook. O #1790 fechou um furo no `pr-duplicata-guard`; aqui a **2ª opinião adversária do Codex** achou o que o meu próprio contrato de mutação **estruturalmente não conseguia ver** — todas as minhas mutações miravam comportamento visível no *stdout*, e o harness descartava o *exit status*.

## 1. Bug real, nos dois guards

Em `git commit -am x && gh pr create --fill`, a **ordem do if/elif** casava `create` primeiro — mas quem **executa** antes é o commit. O guard então lia `mb..HEAD`, que no **primeiro commit está vazio** (#1764 tinha 1 commit só) ⇒ silêncio exatamente no cenário que o gatilho de commit existe para cobrir.

Verifiquei por medição antes de mexer (parecer de outro modelo não é verdade até medir):

```
scan=[git commit -am  && gh pr create --fill]
modo detectado = create   (o comando EXECUTADO primeiro é o git commit)
```

**Correção:** o commit vence quando os dois aparecem — o alvo dele (índice/árvore) é **superconjunto** do alvo do create (HEAD). E o dedupe passa a exigir `-z "$tem_create"`: sem isso o encadeado poderia ser silenciado pelo cache e o "último portão" deixaria de ser último.

## 2. Cegueira estrutural da suíte

`_hook` descartava o **status de saída**. Todas as asserções olhavam só o stdout, então trocar qualquer `exit 0`/`continue` por `exit 1` **sobrevivia à suíte inteira** — o hook deixaria de ser fail-open TOTAL sem nada ficar vermelho. Subshell não propaga variável, então o registro vai por arquivo e é conferido no fim.

## 3. O poder do `pr-collision-guard` estava não-medido

Ele não tinha falsificação nenhuma. Hipótese: estaria pior que o irmão. **Falsificada** — 6/6 PEGA de cara. O bloco de falsificação não é o discriminante: nem necessário (o collision passa sem ele), nem suficiente (o duplicata tinha e furou). O que discrimina é a **fixture armada** nas asserções negativas.

## Evidência

```
bun run test:hooks     exit 0   (5 suítes)
mutcheck duplicata     8/8 PEGA · 0 sobreviventes · 0 inválidas · controle+ 8/8
mutcheck collision     8/8 PEGA · 0 sobreviventes · 0 inválidas · controle+ 8/8
shellcheck             exit 0
```

A mutação "encadeado volta a casar como `create`" **sobrevivia** antes dos casos novos — foi ela que provou que o teste tem dente, em vez de eu afirmar.

## Lacunas que NÃO fechei

Registradas no fim de `scripts/mutcheck.d/pr-duplicata-guard.mut`, porque lacuna documentada é dívida e lacuna esquecida é furo. A pior: **`base_c=""` → `continue`** — duas sessões criando o **mesmo arquivo novo** deixam de ser detectadas, e nenhum caso positivo usa arquivo ausente da merge-base. Também abertas: `origin/main`→`origin/master`, perda do `mb` nos diffs, contrato JSON (`hookEventName`/`additionalContext`), `*.md` na lista de ignorados, TTL do dedupe, e opções globais (`git -C dir commit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)