### PR TITLE
fix(farmer): a tela de bundles culpava a LEITURA por falha de GRAVAÇÃO, e o zero legítimo virava "ainda não calculei" [money-path]

### DIFF
--- a/src/components/farmer/bundles/useFarmerBundles.ts
+++ b/src/components/farmer/bundles/useFarmerBundles.ts
@@ -7,8 +7,9 @@ import { useBundleArguments } from '@/hooks/useBundleArguments';
 import { useDiagnosticQuestions } from '@/hooks/useDiagnosticQuestions';
 
 export function useFarmerBundles() {
-  const { customerBundles, rules, loading, calculating, calculateBundles, erro, desatualizado } =
-    useBundleEngine();
+  const {
+    customerBundles, rules, loading, calculating, calculateBundles, erro, desatualizado, calculado,
+  } = useBundleEngine();
   const { arguments: bundleArgs, generating: argGenerating, generateArgument } = useBundleArguments();
   const diagHook = useDiagnosticQuestions();
   const [expandedCustomer, setExpandedCustomer] = useState<string | null>(null);
@@ -27,6 +28,7 @@ export function useFarmerBundles() {
     calculating,
     erro,
     desatualizado,
+    calculado,
     calculateBundles,
     bundleArgs,
     argGenerating,

--- a/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
+++ b/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { toast } from 'sonner';
+
+/**
+ * Guard money-path — a leitura do "melhor individual" não pode virar nem um zero fabricado
+ * nem um head `vazio/completo`.
+ *
+ * O motor lê `farmer_recommendations` UMA VEZ POR CLIENTE, dentro do laço, para montar a
+ * comparação "bundle × melhor produto individual". O `error` dessa consulta era DESCARTADO na
+ * desestruturação (`const { data: existingRecs } = await ...`), e daí saíam dois defeitos de
+ * gravidade bem diferente:
+ *
+ *  1. `{ data: null, error }` resolvido — a falha vira "não há recomendação pendente":
+ *     `bestIndividual` fica `null`, o cliente sem bundle próprio é OMITIDO da lista inteira, e
+ *     ao fim a execução ainda emite `toast.success`. É o §2 (ausente ≠ zero) na forma de
+ *     rótulo: uma leitura que não aconteceu apresentada como veredicto.
+ *
+ *  2. A Promise REJEITADA (rede/CORS) é pior, e é o achado do challenge Codex (gpt-5.6-sol,
+ *     xhigh): a exceção escapa do laço para o `catch` externo. Nesse ponto TODOS os insumos
+ *     obrigatórios já foram declarados íntegros (são lidos antes do laço) e `linhasProduzidas`
+ *     ainda é `false` — então `registrarVazio()` grava `resultado='vazio'` com
+ *     `completude='completo'`. Esse par é a licença exata que a fase 2 usaria para EXPIRAR a
+ *     carteira de ofertas da vendedora. Mesmo defeito que o #1791 fechou, por outra porta.
+ *
+ * DISCRIMINADOR: nenhum registro de head `vazio` + `completo` nascido desta leitura, e nenhum
+ * `toast.success` quando ela falhou.
+ */
+const FARMER = 'farmer-real';
+
+/** 'nao' | 'erro' (resolvido) | 'rejeita' (Promise rejeitada). */
+let falhaMelhorIndividual: 'nao' | 'erro' | 'rejeita' = 'nao';
+
+const registros: Array<Record<string, unknown>> = [];
+
+const ERRO_TIMEOUT = { code: '57014', message: 'canceling statement due to statement timeout' };
+
+/**
+ * Mesmo seed de `bundle-head-nao-mente-apos-linhas.test.tsx`: seis cestas que fazem o Apriori
+ * achar DUAS regras com o mesmo antecedente (P1→P2 e P1→P3), e `c7` — que comprou só P1 —
+ * receber o par P2+P3 como bundle. Sem isso o teste passaria por vacuidade.
+ */
+const PEDIDOS = [
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-01T00:00:00Z' },
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-02T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-03T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-04T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-05T00:00:00Z' },
+  { customer_user_id: 'c7', items: [{ product_id: 'P1' }], total: 100, created_at: '2026-07-06T00:00:00Z' },
+];
+const PRODUTOS = ['P1', 'P2', 'P3', 'P4'].map((id) => ({
+  id, codigo: id, descricao: `Produto ${id}`, valor_unitario: 100,
+  metadata: null, ativo: true, omie_codigo_produto: null,
+}));
+const score = (cid: string, health: number) => ({
+  customer_user_id: cid, farmer_id: FARMER, health_score: health, answer_rate_60d: 60,
+  whatsapp_reply_rate_60d: 60, avg_monthly_spend_180d: 1000, gross_margin_pct: 30,
+  category_count: 2, days_since_last_purchase: 10,
+});
+const perfil = (cid: string) => ({ user_id: cid, name: `Cliente ${cid}`, customer_type: 'moveleiro', cnae: '3101' });
+
+function dadosDa(tabela: string): unknown[] {
+  switch (tabela) {
+    case 'farmer_client_scores': return [score('c9', 80), score('c8', 70), score('c7', 75)];
+    case 'omie_products': return PRODUTOS;
+    case 'profiles': return ['c9', 'c8', 'c7'].map(perfil);
+    case 'sales_orders': return PEDIDOS;
+    default: return [];
+  }
+}
+
+function chain(table: string): unknown {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'eq', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) c[m] = () => c;
+  c.then = (resolve: (v: unknown) => void, reject: (e: unknown) => void) => {
+    if (table === 'farmer_recommendations') {
+      // A REJEIÇÃO é o caminho perigoso: escapa do laço e cai no `catch` externo com todos os
+      // insumos obrigatórios já íntegros. O `{ error }` resolvido é o silencioso.
+      if (falhaMelhorIndividual === 'rejeita') return reject(new Error('Failed to fetch'));
+      if (falhaMelhorIndividual === 'erro') return resolve({ data: null, error: ERRO_TIMEOUT });
+    }
+    return resolve({ data: dadosDa(table), error: null, count: 0 });
+  };
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (t: string) => chain(t),
+    rpc: (nome: string, args?: Record<string, unknown>) => {
+      // Paginada desde o #1782 — builder com `.order().range()`, não Promise crua.
+      if (nome === 'get_skus_margem_positiva') {
+        const c: Record<string, unknown> = {
+          order: () => c,
+          range: () => c,
+          then: (resolve: (v: unknown) => void) =>
+            resolve({ data: PRODUTOS.map((p) => ({ product_id: p.id })), error: null }),
+        };
+        return c;
+      }
+      if (nome === 'farmer_geracao_registrar') {
+        registros.push(args ?? {});
+        return Promise.resolve({ data: null, error: null });
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+  },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: FARMER }, isStaff: true }) }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import { useBundleEngine } from '../useBundleEngine';
+
+beforeEach(() => {
+  falhaMelhorIndividual = 'nao';
+  registros.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('useBundleEngine — a leitura do melhor individual não fabrica zero nem head completo', () => {
+  it('DETECTOR: o caminho feliz produz bundles e anuncia sucesso', async () => {
+    // Sem isto, "não achei o toast de sucesso" e "o cenário nunca produziu bundle" seriam
+    // indistinguíveis, e as asserções abaixo passariam por vacuidade.
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+
+    expect(result.current.customerBundles.length).toBeGreaterThan(0);
+    expect(toast.success).toHaveBeenCalled();
+  });
+
+  it('a Promise REJEITADA não vira head "vazio/completo"', async () => {
+    falhaMelhorIndividual = 'rejeita';
+
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+
+    const licenca = registros.filter(
+      (r) => r.p_resultado === 'vazio' && r.p_completude === 'completo',
+    );
+    expect(
+      licenca,
+      'gravou a licença exata para a fase 2 expirar a carteira por uma falha de leitura',
+    ).toEqual([]);
+  });
+
+  it('a falha não é apresentada como sucesso', async () => {
+    falhaMelhorIndividual = 'erro';
+
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+
+    expect(
+      toast.success,
+      'anunciou sucesso com uma leitura que falhou — o operador vai embora achando que está tudo lido',
+    ).not.toHaveBeenCalled();
+  });
+
+  it('a falha NÃO aborta os bundles já descobertos', async () => {
+    // Precisão > recall não é fail-closed cego: a comparação individual é acessória e não
+    // entra no payload da RPC de substituição, então derrubar a carteira inteira por causa
+    // dela trocaria uma mentira por um prejuízo maior.
+    falhaMelhorIndividual = 'erro';
+
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+
+    expect(
+      result.current.customerBundles.length,
+      'a falha de um insumo acessório levou junto os bundles válidos',
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -177,6 +177,11 @@ export const useBundleEngine = () => {
    *
    * Descreve a ÚLTIMA execução, não a sessão: um recálculo que morre na leitura volta o
    * flag a `false`, senão o veredicto velho responderia por um cálculo que não existiu.
+   *
+   * ⚠️ Marcado nos pontos de CONCLUSÃO, nunca dentro de `aplicarBundles`. O fail-closed de
+   * `vendaveis` também chama `aplicarBundles([])` — para limpar a lista antes de lançar — e
+   * ali NADA foi calculado: marcar junto da publicação faria esse caminho anunciar "o cálculo
+   * terminou, só não salvou", que é exatamente a mentira que este flag existe para desfazer.
    */
   const [calculado, setCalculado] = useState(false);
 
@@ -186,11 +191,6 @@ export const useBundleEngine = () => {
   const aplicarBundles = useCallback((bs: CustomerBundles[]) => {
     bundlesRef.current = bs;
     setCustomerBundles(bs);
-    // Marcado AQUI, e não junto de `resultadoDestaExecucao`: esta é a única função que
-    // publica resultado na tela, e ela também atende o `return` precoce de "nenhum cliente
-    // com score" — que conclui de verdade, com `aplicarBundles([])`, e cuja tela vazia é um
-    // veredicto do motor, não um cálculo que ninguém pediu.
-    setCalculado(true);
   }, []);
 
   const calculateBundles = useCallback(async (config = DEFAULT_CONFIG) => {
@@ -397,6 +397,9 @@ export const useBundleEngine = () => {
 
       if (!clientScores?.length) {
         aplicarBundles([]);
+        // CONCLUIU: "esta carteira não tem cliente com score" é um veredicto do motor, não uma
+        // falha — e a tela precisa dizer isso em vez de "clique em Calcular".
+        setCalculado(true);
         // Era um `return` MUDO — a razão de a frequência do zero nunca ter sido mensurável.
         await registrarVazio();
         return;
@@ -864,6 +867,9 @@ export const useBundleEngine = () => {
       // Marcados JUNTOS e aqui, não na gravação: a partir deste ponto a tela mostra o
       // resultado DESTE cálculo, e ele produziu linhas — os dois fatos que o `catch` precisa.
       resultadoDestaExecucao = true;
+      // CONCLUIU: daqui para baixo só resta PERSISTIR, então qualquer falha adiante é de
+      // gravação — e é este flag que impede a tela de culpar a leitura por ela.
+      setCalculado(true);
       // Linhas PERSISTÍVEIS, não clientes: um cliente entra em `allCustomerBundles` só com
       // `bestIndividual` e nenhum bundle, e essa comparação não vira linha nenhuma no payload
       // da RPC. Contando clientes, esse caso travava o `registrarVazio()` do `catch` sobre uma

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -165,6 +165,20 @@ export const useBundleEngine = () => {
   // `FarmerBundles` só sabia dizer "Clique em Calcular" — o mesmo texto de quem nunca calculou.
   const [erro, setErro] = useState<Error | null>(null);
   const [desatualizado, setDesatualizado] = useState(false);
+  /**
+   * "A execução mais recente chegou a PUBLICAR um resultado (mesmo vazio) na tela?"
+   *
+   * Dois estados dependiam disso e não tinham como perguntar (challenge Codex do #1791):
+   *  - a lista vazia de um cálculo CONCLUÍDO ficava idêntica à de quem nunca clicou em
+   *    Calcular — "não há oportunidade nesta carteira" apresentado como "não comecei";
+   *  - sob `erro`, a tela culpava a LEITURA mesmo quando a leitura foi perfeita e o que
+   *    falhou foi a GRAVAÇÃO (a RPC roda DEPOIS de `aplicarBundles`), desacreditando
+   *    bundles válidos e desta execução.
+   *
+   * Descreve a ÚLTIMA execução, não a sessão: um recálculo que morre na leitura volta o
+   * flag a `false`, senão o veredicto velho responderia por um cálculo que não existiu.
+   */
+  const [calculado, setCalculado] = useState(false);
 
   // A ref existe para o `catch` saber se sobrou resultado de uma execução ANTERIOR na tela:
   // ler `customerBundles` de dentro do `useCallback` pegaria a closure velha.
@@ -172,6 +186,11 @@ export const useBundleEngine = () => {
   const aplicarBundles = useCallback((bs: CustomerBundles[]) => {
     bundlesRef.current = bs;
     setCustomerBundles(bs);
+    // Marcado AQUI, e não junto de `resultadoDestaExecucao`: esta é a única função que
+    // publica resultado na tela, e ela também atende o `return` precoce de "nenhum cliente
+    // com score" — que conclui de verdade, com `aplicarBundles([])`, e cuja tela vazia é um
+    // veredicto do motor, não um cálculo que ninguém pediu.
+    setCalculado(true);
   }, []);
 
   const calculateBundles = useCallback(async (config = DEFAULT_CONFIG) => {
@@ -180,6 +199,7 @@ export const useBundleEngine = () => {
     setLoading(true);
     setErro(null);
     setDesatualizado(false);
+    setCalculado(false);
     // "Esta execução produziu o que está na tela?" — separa INDISPONÍVEL de DESATUALIZADO.
     let resultadoDestaExecucao = false;
     // "Este cálculo chegou a PRODUZIR linhas?" — trava o registro de `vazio` no `catch`.
@@ -645,6 +665,8 @@ export const useBundleEngine = () => {
 
       // 5. Generate bundles per customer
       const allCustomerBundles: CustomerBundles[] = [];
+      /** Clientes cuja comparação com o melhor produto individual não pôde ser lida. */
+      let comparacaoIndisponivel = 0;
 
       for (const score of clientScores) {
         const cid = score.customer_user_id;
@@ -743,27 +765,61 @@ export const useBundleEngine = () => {
 
         // Best individual product (from cross-sell engine data)
         let bestIndividual: IndividualComparison | null = null;
-        const { data: existingRecs } = (await supabase
-          .from('farmer_recommendations')
-          .select('product_id, affinity_score, recommendation_type')
-          .eq('farmer_id', effectiveUserId)
-          .eq('customer_user_id', cid)
-          .eq('status', 'pendente')
-          // `.not(...is null)` é fail-closed: com todas as linhas antigas, ordenar não ordena nada
-          // e o `.limit(1)` elegeria um "melhor individual" arbitrário. `nullsFirst: false` cobre
-          // a MISTURA (DESC implica NULLS FIRST no Postgres); o filtro cobre o caso TODAS-NULL.
-          .not('affinity_score', 'is', null)
-          .order('affinity_score', { ascending: false, nullsFirst: false })
-          // ⚠️ `created_at` deixou de desempatar: desde a migration 20260814223445 a geração
-          // inteira entra num único INSERT, e `now()` é o instante da TRANSAÇÃO — todas as
-          // linhas do run compartilham o mesmo carimbo. `id` é a PK: última chave, sempre
-          // total (achado do challenge Codex xhigh).
-          .order('updated_at', { ascending: false }) // desempate determinístico
-          .order('id', { ascending: false })
-          .limit(1)) as unknown as { data: ExistingRecRow[] | null };
+        // O `error` desta consulta era DESCARTADO na desestruturação, e a falha virava um
+        // veredicto: `bestIndividual` nulo (= "não há oferta individual melhor"), cliente sem
+        // bundle próprio OMITIDO da lista inteira, e `toast.success` no fim. É o §2 (ausente ≠
+        // zero) na forma de rótulo.
+        //
+        // O `try` existe porque erro RESOLVIDO e Promise REJEITADA são portas diferentes para o
+        // mesmo defeito, e a segunda é a pior (achado do challenge Codex gpt-5.6-sol/xhigh):
+        // uma rejeição de rede/CORS escapava do laço para o `catch` externo, onde todos os
+        // insumos obrigatórios JÁ foram declarados íntegros (são lidos antes do laço) e
+        // `linhasProduzidas` ainda é false — e `registrarVazio()` gravava `resultado='vazio'`
+        // com `completude='completo'`. Esse par é a licença exata que a fase 2 usaria para
+        // EXPIRAR a carteira. Mesmo defeito do #1791, por outra porta.
+        let recsIndividuais: ExistingRecRow[] | null = null;
+        try {
+          const { data, error } = (await supabase
+            .from('farmer_recommendations')
+            .select('product_id, affinity_score, recommendation_type')
+            .eq('farmer_id', effectiveUserId)
+            .eq('customer_user_id', cid)
+            .eq('status', 'pendente')
+            // `.not(...is null)` é fail-closed: com todas as linhas antigas, ordenar não ordena
+            // nada e o `.limit(1)` elegeria um "melhor individual" arbitrário. `nullsFirst:
+            // false` cobre a MISTURA (DESC implica NULLS FIRST no Postgres); o filtro cobre o
+            // caso TODAS-NULL.
+            .not('affinity_score', 'is', null)
+            .order('affinity_score', { ascending: false, nullsFirst: false })
+            // ⚠️ `created_at` deixou de desempatar: desde a migration 20260814223445 a geração
+            // inteira entra num único INSERT, e `now()` é o instante da TRANSAÇÃO — todas as
+            // linhas do run compartilham o mesmo carimbo. `id` é a PK: última chave, sempre
+            // total (achado do challenge Codex xhigh).
+            .order('updated_at', { ascending: false }) // desempate determinístico
+            .order('id', { ascending: false })
+            .limit(1)) as unknown as { data: ExistingRecRow[] | null; error: unknown };
+          if (error) throw error;
+          recsIndividuais = data;
+        } catch (erroIndividual) {
+          console.error(`Falha ao ler o melhor individual de ${cid}:`, erroIndividual);
+          // Sem `throw`: esta comparação é ACESSÓRIA — ela não entra em `recomendacoes`, o
+          // payload da RPC de substituição, então derrubar a carteira inteira por causa dela
+          // trocaria uma afirmação errada por um prejuízo maior. O que a falha NÃO pode é
+          // sumir: ela reprova o toast de sucesso logo abaixo.
+          //
+          // ⚠️ De propósito NÃO vira insumo do `InsumosSnapshot`: `avaliarCompletude` degrada
+          // com um único `ok:false`, e esta consulta roda uma vez POR CLIENTE — numa carteira
+          // de centenas, uma falha isolada carimbaria `degradado` em quase toda execução. O
+          // head ficaria degradado para sempre, e um sinal que nunca varia não é sinal: a
+          // fase 2 aprenderia a ignorá-lo. Vale porque `p_linhas` é INVARIANTE a esta leitura
+          // (cliente com bundle entra de qualquer jeito; cliente sem bundle contribui zero
+          // linhas com ou sem ela), logo a integridade do ZERO DE BUNDLES — que é o que a
+          // completude julga — não depende dela.
+          comparacaoIndisponivel += 1;
+        }
 
-        if (existingRecs?.length) {
-          const rec = existingRecs[0];
+        if (recsIndividuais?.length) {
+          const rec = recsIndividuais[0];
           const prod = productMap.get(rec.product_id);
           // Ausente ≠ zero: `Number(null)` é 0 e afirmaria afinidade nula medida.
           const afinidade = rec.affinity_score == null ? NaN : Number(rec.affinity_score);
@@ -808,7 +864,12 @@ export const useBundleEngine = () => {
       // Marcados JUNTOS e aqui, não na gravação: a partir deste ponto a tela mostra o
       // resultado DESTE cálculo, e ele produziu linhas — os dois fatos que o `catch` precisa.
       resultadoDestaExecucao = true;
-      linhasProduzidas = allCustomerBundles.length > 0;
+      // Linhas PERSISTÍVEIS, não clientes: um cliente entra em `allCustomerBundles` só com
+      // `bestIndividual` e nenhum bundle, e essa comparação não vira linha nenhuma no payload
+      // da RPC. Contando clientes, esse caso travava o `registrarVazio()` do `catch` sobre uma
+      // execução que de fato não produziu nada — o head parava de se mover e "nenhum registro
+      // novo" voltava a significar duas coisas opostas (challenge Codex xhigh).
+      linhasProduzidas = allCustomerBundles.some((cb) => cb.bundles.length > 0);
 
       // Persist bundle recommendations — via RPC que SUBSTITUI a geração anterior.
       // PULADO na lente "Ver como" (só leitura: o master inspeciona os bundles do alvo
@@ -922,6 +983,16 @@ export const useBundleEngine = () => {
           'já havia um recálculo deste vendedor em andamento — os bundles daqui não foram salvos; espere ele terminar e confira',
         );
       }
+      // A lista pode ter ficado INCOMPLETA: o cliente que só entraria pela comparação
+      // individual foi omitido quando a leitura dele falhou. Dizer o número é o que separa
+      // "não há mais nada" de "não consegui ver o resto".
+      if (comparacaoIndisponivel > 0) {
+        problemas.push(
+          comparacaoIndisponivel === 1
+            ? '1 cliente ficou sem a comparação com o melhor produto individual — a leitura falhou, e ele pode ter ficado fora da lista'
+            : `${comparacaoIndisponivel} clientes ficaram sem a comparação com o melhor produto individual — a leitura falhou, e eles podem ter ficado fora da lista`,
+        );
+      }
 
       if (problemas.length > 0) {
         toast.warning(`${totalBundles} bundles gerados, mas ${problemas.join('; e ')}`);
@@ -970,6 +1041,7 @@ export const useBundleEngine = () => {
     calculating,
     erro,
     desatualizado,
+    calculado,
     calculateBundles,
     config: DEFAULT_CONFIG,
   };

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -304,6 +304,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/useLastVisit.test.tsx",
       "src/hooks/__tests__/useMyVisitSuggestions.test.ts",
       "src/hooks/__tests__/useDashboardCompany.test.ts",
+      "src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx",
       "src/pages/__tests__/FarmerDashboard.erro-honesto.test.tsx",
       "src/pages/__tests__/FarmerRecommendations.erro-honesto.test.tsx",
     ],

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -285,6 +285,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/bundle-escopo-sob-falha.test.tsx",
       "src/hooks/__tests__/bundle-head-degradado-todos-insumos.test.tsx",
       "src/hooks/__tests__/bundle-head-nao-mente-apos-linhas.test.tsx",
+      "src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx",
       "src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx",
       "src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx",
       "src/hooks/__tests__/bundle-vendaveis-erro-honesto.test.tsx",

--- a/src/pages/FarmerBundles.tsx
+++ b/src/pages/FarmerBundles.tsx
@@ -19,6 +19,7 @@ const FarmerBundles = () => {
     calculateBundles,
     erro,
     desatualizado,
+    calculado,
     bundleArgs,
     argGenerating,
     generateArgument,
@@ -52,17 +53,24 @@ const FarmerBundles = () => {
 
         {/* A falha do engine PRECISA chegar aqui. Sem isto a tela ficava idêntica à de um
             cálculo bem-sucedido que não achou bundle — o vendedor via a lista vazia e ia
-            embora achando que não havia oportunidade, quando na verdade não houve leitura. */}
+            embora achando que não havia oportunidade, quando na verdade não houve leitura.
+
+            Os TRÊS casos são separados (igual `FarmerRecommendations`) porque o `catch` do
+            engine é um só e cobre fases diferentes: `calculado` diz que a leitura terminou e
+            o resultado desta execução já foi publicado, então o que sobrou para falhar foi a
+            GRAVAÇÃO — e aí acusar a leitura descarta bundles válidos que estão logo abaixo. */}
         {erro && (
           <div
             role="alert"
-            className={`rounded-lg border p-3 text-xs ${desatualizado
+            className={`rounded-lg border p-3 text-xs ${desatualizado || calculado
               ? 'border-status-warning/30 bg-status-warning/5 text-status-warning'
               : 'border-status-error/30 bg-status-error/5 text-status-error'}`}
           >
             {desatualizado
               ? 'Exibindo o último cálculo bem-sucedido — a atualização mais recente falhou. Os bundles podem estar desatualizados.'
-              : 'Não foi possível calcular os bundles — a leitura da base falhou. Nada abaixo foi estimado.'}
+              : calculado
+                ? 'O cálculo terminou, mas o resultado não pôde ser salvo. O que está na tela é desta execução; as outras telas de oferta seguem com o cálculo anterior.'
+                : 'Não foi possível calcular os bundles — a leitura da base falhou. Nada abaixo foi estimado.'}
           </div>
         )}
 
@@ -84,7 +92,20 @@ const FarmerBundles = () => {
             {loading && !customerBundles.length ? (
               <PageSkeleton variant="list" />
             ) : customerBundles.length === 0 ? (
-              <Card><CardContent className="p-6 text-center"><Package className="w-8 h-8 mx-auto mb-2 opacity-40" /><p className="text-xs text-muted-foreground">{erro ? 'O cálculo falhou — nenhum bundle pôde ser gerado.' : 'Clique em "Calcular" para gerar bundles.'}</p></CardContent></Card>
+              <Card><CardContent className="p-6 text-center"><Package className="w-8 h-8 mx-auto mb-2 opacity-40" /><p className="text-xs text-muted-foreground">{
+                // Três estados, e só um deles é trabalho a fazer. Um cálculo que RODOU e
+                // concluiu "não há bundle" é um veredicto do motor — dizer a esse vendedor
+                // para clicar em Calcular o manda repetir o que acabou de rodar, e apaga a
+                // única informação que ele tinha: não há oportunidade nesta carteira agora.
+                // `calculado` vem primeiro porque, com erro DE GRAVAÇÃO sobre um resultado
+                // vazio, o veredicto continua sendo o do motor — quem conta o resto é o
+                // alerta acima.
+                calculado
+                  ? 'O cálculo rodou e não encontrou nenhum bundle para esta carteira.'
+                  : erro
+                    ? 'O cálculo falhou — nenhum bundle pôde ser gerado.'
+                    : 'Clique em "Calcular" para gerar bundles.'
+              }</p></CardContent></Card>
             ) : (
               customerBundles.map(cb => (
                 <CustomerBundleCard

--- a/src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx
+++ b/src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx
@@ -29,6 +29,12 @@ const FARMER = 'farmer-real';
 
 /** Falha na LEITURA (scores) — a exceção nasce antes de qualquer resultado. */
 let falharLeitura = false;
+/**
+ * Falha na RPC de vendáveis — o fail-closed. Caminho traiçoeiro: ele chama `aplicarBundles([])`
+ * para LIMPAR a lista antes de lançar (manter bundles velhos poria SKU sem margem confirmada na
+ * oferta), e essa publicação não é um cálculo concluído.
+ */
+let falharVendaveis = false;
 /** Falha na GRAVAÇÃO — a exceção nasce depois de os bundles já estarem na tela. */
 let falharGravacao = false;
 /** Seed sem coocorrência: o Apriori não acha regra e o motor conclui vazio SEM erro. */
@@ -109,7 +115,11 @@ vi.mock('@/integrations/supabase/client', () => ({
           order: () => c,
           range: () => c,
           then: (resolve: (v: unknown) => void) =>
-            resolve({ data: PRODUTOS.map((p) => ({ product_id: p.id })), error: null }),
+            resolve(
+              falharVendaveis
+                ? { data: null, error: ERRO_TIMEOUT }
+                : { data: PRODUTOS.map((p) => ({ product_id: p.id })), error: null },
+            ),
         };
         return c;
       }
@@ -135,6 +145,7 @@ import FarmerBundles from '../FarmerBundles';
 
 beforeEach(() => {
   falharLeitura = false;
+  falharVendaveis = false;
   falharGravacao = false;
   semBundles = false;
   vi.clearAllMocks();
@@ -186,6 +197,31 @@ describe('FarmerBundles — o texto na tela descreve o que aconteceu', () => {
     expect(aviso.textContent, 'a falha de leitura deixou de ser anunciada').toMatch(
       /leitura da base falhou|n[ãa]o foi poss[íi]vel calcular/i,
     );
+  });
+
+  it('o fail-closed de vendáveis NÃO se apresenta como "calculei, só não salvei"', async () => {
+    // Este caminho publica `aplicarBundles([])` e LANÇA logo depois. Se o flag de "concluí"
+    // for marcado junto da publicação (em vez de nos pontos de conclusão), a tela passa a
+    // dizer que o cálculo terminou e só a gravação falhou — o defeito desta entrega ao
+    // contrário, e mais perigoso: aqui o motor não confirmou margem de SKU nenhum.
+    falharVendaveis = true;
+
+    render(<FarmerBundles />);
+    calcular();
+
+    const aviso = await screen.findByRole('alert');
+    expect(
+      aviso.textContent,
+      'uma falha de LEITURA foi anunciada como falha de gravação',
+    ).not.toMatch(/n[ãa]o p[ôo]de ser salvo|desta execu[çc][ãa]o/i);
+    expect(aviso.textContent, 'o alerta não diz que o cálculo não pôde ser feito').toMatch(
+      /n[ãa]o foi poss[íi]vel calcular|leitura da base falhou/i,
+    );
+    // E o empty state segue no ramo de falha, não no de "rodou e não achou".
+    expect(
+      screen.queryByText(/não encontrou nenhum bundle/i),
+      'anunciou veredicto de carteira vazia sobre um cálculo que nem rodou',
+    ).toBeNull();
   });
 
   it('separa "calculei e não há bundle" de "clique em Calcular"', async () => {

--- a/src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx
+++ b/src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Guard money-path — a tela de bundles tem de descrever o que REALMENTE aconteceu.
+ *
+ * O #1791 fez o `useBundleEngine` expor `erro`/`desatualizado` e a página renderizar um
+ * alerta. O challenge Codex (gpt-5.6-sol, xhigh) daquele PR apontou que sobraram três
+ * estados em que o texto ainda mente. Dois deles são desta suíte:
+ *
+ *  1. O alerta trata QUALQUER exceção como falha de LEITURA ("a leitura da base falhou.
+ *     Nada abaixo foi estimado"). Mas o `catch` também pega a falha da GRAVAÇÃO — a RPC
+ *     `farmer_bundle_recomendacoes_substituir` roda DEPOIS de `aplicarBundles`, então os
+ *     bundles na tela são válidos e desta execução. Desacreditá-los é jogar fora o
+ *     trabalho bom: o vendedor tem uma oferta legítima na mão e o aviso manda ignorá-la.
+ *
+ *  2. O empty state diz 'Clique em "Calcular"' tanto para quem nunca clicou quanto para um
+ *     cálculo que RODOU e concluiu honestamente "não há bundle para esta carteira". São
+ *     coisas diferentes: uma é trabalho a fazer, a outra é o veredicto do motor. O irmão
+ *     `FarmerRecommendations` já separa os três casos.
+ *
+ * DISCRIMINADOR: o texto na tela distingue leitura-falhou / calculado-mas-não-salvo /
+ * calculado-e-vazio / nunca-calculado — sem colapsar dois estados no mesmo texto.
+ *
+ * Aqui o hook roda de VERDADE (só o supabase é mockado): mockar o hook provaria apenas que
+ * a página sabe renderizar um estado que eu mesmo montei.
+ */
+const FARMER = 'farmer-real';
+
+/** Falha na LEITURA (scores) — a exceção nasce antes de qualquer resultado. */
+let falharLeitura = false;
+/** Falha na GRAVAÇÃO — a exceção nasce depois de os bundles já estarem na tela. */
+let falharGravacao = false;
+/** Seed sem coocorrência: o Apriori não acha regra e o motor conclui vazio SEM erro. */
+let semBundles = false;
+
+const ERRO_TIMEOUT = { code: '57014', message: 'canceling statement due to statement timeout' };
+
+/**
+ * Seis cestas desenhadas para o Apriori achar DUAS regras com o mesmo antecedente e
+ * consequentes distintos (P1→P2 e P1→P3). Isso importa: o motor só monta bundle combinando
+ * DUAS regras aplicáveis, então um cliente com uma regra só não produz linha — e o teste
+ * passaria por vacuidade. `c7` comprou apenas P1: o par P2+P3 vira bundle para ele.
+ * (Mesmo seed de `bundle-head-nao-mente-apos-linhas.test.tsx`.)
+ */
+const PEDIDOS = [
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-01T00:00:00Z' },
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }, { product_id: 'P2' }, { product_id: 'P3' }], total: 300, created_at: '2026-07-02T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-03T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-04T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P4' }], total: 50, created_at: '2026-07-05T00:00:00Z' },
+  { customer_user_id: 'c7', items: [{ product_id: 'P1' }], total: 100, created_at: '2026-07-06T00:00:00Z' },
+];
+
+/**
+ * Cada cliente compra um SKU só e nenhum par se repete: existe histórico (a carteira está
+ * viva, os insumos vêm todos não-vazios), mas não há coocorrência de onde tirar regra. É o
+ * "zero de verdade" — o cálculo roda inteiro e conclui que não há bundle.
+ */
+const PEDIDOS_SEM_PADRAO = [
+  { customer_user_id: 'c9', items: [{ product_id: 'P1' }], total: 100, created_at: '2026-07-01T00:00:00Z' },
+  { customer_user_id: 'c8', items: [{ product_id: 'P2' }], total: 100, created_at: '2026-07-02T00:00:00Z' },
+  { customer_user_id: 'c7', items: [{ product_id: 'P3' }], total: 100, created_at: '2026-07-03T00:00:00Z' },
+];
+
+const PRODUTOS = ['P1', 'P2', 'P3', 'P4'].map((id) => ({
+  id, codigo: id, descricao: `Produto ${id}`, valor_unitario: 100,
+  metadata: null, ativo: true, omie_codigo_produto: null,
+}));
+
+const score = (cid: string, health: number) => ({
+  customer_user_id: cid, farmer_id: FARMER, health_score: health, answer_rate_60d: 60,
+  whatsapp_reply_rate_60d: 60, avg_monthly_spend_180d: 1000, gross_margin_pct: 30,
+  category_count: 2, days_since_last_purchase: 10,
+});
+const perfil = (cid: string) => ({ user_id: cid, name: `Cliente ${cid}`, customer_type: 'moveleiro', cnae: '3101' });
+
+function resposta(tabela: string): unknown {
+  switch (tabela) {
+    case 'farmer_client_scores':
+      if (falharLeitura) return { data: null, error: ERRO_TIMEOUT };
+      return { data: [score('c9', 80), score('c8', 70), score('c7', 75)], error: null, count: 0 };
+    case 'omie_products': return { data: PRODUTOS, error: null, count: 0 };
+    case 'profiles': return { data: ['c9', 'c8', 'c7'].map(perfil), error: null, count: 0 };
+    case 'sales_orders':
+      return { data: semBundles ? PEDIDOS_SEM_PADRAO : PEDIDOS, error: null, count: 0 };
+    default: return { data: [], error: null, count: 0 };
+  }
+}
+
+function chain(table: string): unknown {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'eq', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) c[m] = () => c;
+  c.then = (resolve: (v: unknown) => void) => resolve(resposta(table));
+  return c;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (t: string) => chain(t),
+    rpc: (nome: string) => {
+      // Paginada desde o #1782 — builder com `.order().range()`, não Promise crua.
+      if (nome === 'get_skus_margem_positiva') {
+        const c: Record<string, unknown> = {
+          order: () => c,
+          range: () => c,
+          then: (resolve: (v: unknown) => void) =>
+            resolve({ data: PRODUTOS.map((p) => ({ product_id: p.id })), error: null }),
+        };
+        return c;
+      }
+      // A rejeição (e não `{ error }`) é o que leva a exceção ao `catch` do hook — que é
+      // exatamente o caminho em que o alerta acusava a LEITURA de uma falha da GRAVAÇÃO.
+      if (nome === 'farmer_bundle_recomendacoes_substituir' && falharGravacao) {
+        return Promise.reject(new Error('connection failure'));
+      }
+      return Promise.resolve({ data: null, error: null });
+    },
+  },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: FARMER }, isStaff: true, loading: false }),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import FarmerBundles from '../FarmerBundles';
+
+beforeEach(() => {
+  falharLeitura = false;
+  falharGravacao = false;
+  semBundles = false;
+  vi.clearAllMocks();
+});
+
+/** A página não calcula sozinha — o cálculo é sempre um clique do vendedor. */
+const calcular = () => fireEvent.click(screen.getByRole('button', { name: /Calcular/i }));
+
+describe('FarmerBundles — o texto na tela descreve o que aconteceu', () => {
+  it('DETECTOR: o caminho feliz renderiza o bundle e nenhum alerta', async () => {
+    // Sem isto, "não achei o alerta" e "a tela nem chegou a montar" seriam indistinguíveis.
+    render(<FarmerBundles />);
+    calcular();
+
+    expect(await screen.findByText('Cliente c7')).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('não acusa a LEITURA quando quem falhou foi a GRAVAÇÃO', async () => {
+    falharGravacao = true;
+
+    render(<FarmerBundles />);
+    calcular();
+
+    const aviso = await screen.findByRole('alert');
+    // Os bundles abaixo do alerta são desta execução e são válidos — dizer que a leitura
+    // falhou e que nada foi estimado descarta trabalho bom.
+    expect(
+      aviso.textContent,
+      'culpou a leitura por uma falha de gravação',
+    ).not.toMatch(/leitura da base falhou|nada abaixo foi estimado/i);
+    expect(
+      aviso.textContent,
+      'o alerta não diz que o cálculo deu certo e só a gravação falhou',
+    ).toMatch(/n[ãa]o (foi poss[íi]vel )?(pud|p[ôo]d)e(ram)? ser salv|n[ãa]o (foram|foi) salv/i);
+    // Pré-condição: o cenário PRECISA ter produzido bundle, senão o teste passa por vacuidade.
+    await waitFor(() => { expect(screen.getByText('Cliente c7')).toBeTruthy(); });
+  });
+
+  it('CONTRAPROVA: quando a LEITURA falha mesmo, o alerta continua acusando a leitura', async () => {
+    // O conserto acima não pode virar o defeito oposto — a falha de transporte real precisa
+    // seguir dizendo que nada abaixo foi estimado.
+    falharLeitura = true;
+
+    render(<FarmerBundles />);
+    calcular();
+
+    const aviso = await screen.findByRole('alert');
+    expect(aviso.textContent, 'a falha de leitura deixou de ser anunciada').toMatch(
+      /leitura da base falhou|n[ãa]o foi poss[íi]vel calcular/i,
+    );
+  });
+
+  it('separa "calculei e não há bundle" de "clique em Calcular"', async () => {
+    semBundles = true;
+
+    render(<FarmerBundles />);
+    calcular();
+
+    // O cálculo roda inteiro e conclui, honestamente, que não há bundle nesta carteira.
+    // Esperar pelo texto NOVO (e não pela ausência do velho): enquanto o cálculo corre a
+    // tela mostra o skeleton, e ali o texto antigo também está ausente — um `waitFor` sobre
+    // a ausência passaria por vacuidade antes de o resultado existir.
+    expect(
+      await screen.findByText(/nenhum bundle|não (há|encontr)/i),
+      'a tela não diz que o cálculo rodou e não achou bundle',
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/Clique em "Calcular"/i),
+      'um cálculo concluído foi apresentado como "ainda não comecei"',
+    ).toBeNull();
+    // E não pode virar alarme: não houve falha nenhuma.
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('CONTRAPROVA: antes do primeiro cálculo a tela continua dizendo "Clique em Calcular"', async () => {
+    // O defeito oposto — anunciar "não há bundle para esta carteira" para quem nunca calculou
+    // é a mesma mentira ao contrário.
+    render(<FarmerBundles />);
+
+    expect(screen.getByText(/Clique em "Calcular"/i)).toBeTruthy();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});


### PR DESCRIPTION
Os três estados que o challenge Codex do #1791 apontou e ficaram fora do escopo daquele PR — mais dois defeitos piores que apareceram ao investigá-los.

## Os três da tela

**1. O alerta acusava a LEITURA numa falha de GRAVAÇÃO.** O texto era "a leitura da base falhou. Nada abaixo foi estimado", mas o `catch` do engine é um só e a RPC de persistência roda *depois* de `aplicarBundles` — então os bundles na tela eram válidos e daquela execução. O aviso mandava o vendedor ignorar uma oferta boa que ele tinha na mão.

**2. O zero legítimo virava "ainda não calculei".** Um cálculo que rodou e concluiu "não há bundle nesta carteira" renderizava o mesmo `Clique em "Calcular"` de quem nunca clicou — um veredicto do motor apresentado como trabalho a fazer.

Os dois saem de um estado novo, `calculado` ("a última execução publicou um resultado, mesmo vazio"), espelhando o que `FarmerRecommendations` já fazia. A tela passa a separar quatro casos: desatualizado / calculado-mas-não-salvo / leitura-falhou / nunca-calculado.

**3. O `error` da consulta do "melhor individual" era descartado** (pré-existente). A falha virava veredicto: `bestIndividual` nulo, cliente sem bundle próprio omitido da lista inteira, e `toast.success` no fim.

## O que o challenge Codex (gpt-5.6-sol, xhigh) mudou

Conduzido sobre o defeito 3, por ser money-path. Ele derrubou o desenho que eu ia entregar e achou dois defeitos piores:

**A Promise rejeitada produzia `vazio` + `completo`.** Capturar só o `error` resolvido deixava a pior porta aberta: uma rejeição de rede/CORS naquela consulta escapa do laço para o `catch` externo, onde todos os insumos obrigatórios já estão declarados íntegros (são lidos antes do laço) e `linhasProduzidas` ainda é `false` — e `registrarVazio()` gravava o par que autorizaria a fase 2 a **expirar a carteira**. É o mesmo defeito que o #1791 fechou, por outra porta. Verificado no código antes de aceitar.

**`linhasProduzidas` contava CLIENTES, não linhas.** Um cliente que entra só pela comparação individual não gera linha nenhuma no payload da RPC, e travava o `registrarVazio()` do `catch` sobre uma execução que não produziu nada. Passa a contar linhas persistíveis.

### O que NÃO foi feito, de propósito

Declarar `melhor_individual` como insumo do `InsumosSnapshot`. `avaliarCompletude` degrada com um único `ok:false`, e essa consulta roda **uma vez por cliente** — numa carteira de centenas, uma falha isolada carimbaria `degradado` em quase toda execução, e um sinal que nunca varia deixa de ser sinal: a fase 2 aprenderia a ignorá-lo. A escolha se sustenta porque `p_linhas` é **invariante** a essa leitura (cliente com bundle entra de qualquer jeito; cliente sem bundle contribui zero linhas com ou sem ela), logo a integridade do *zero de bundles* — que é o que a completude julga — não depende dela. A falha vira aviso contado no toast, e o porquê está comentado no código para ninguém reintroduzir.

## Um bug meu, achado pela colisão

O terceiro commit conserta um defeito que eu mesmo introduzi no primeiro. Eu marcava `calculado` dentro de `aplicarBundles`, na premissa de que publicar resultado == ter concluído. Não é: o fail-closed de `vendaveis` chama `aplicarBundles([])` para limpar a lista antes de lançar, e ali nada foi calculado — a tela passaria a dizer "o cálculo terminou, só não salvou" num caminho em que o motor não confirmou a margem de SKU nenhum. O defeito desta entrega ao contrário.

Apareceu ao conferir a colisão com #1798, que mexe na mesma região. Agora `calculado` é marcado nos dois pontos de conclusão, nunca na publicação — o que também tira o flag de um call-site que aquele PR edita.

## Convivência com #1798

`git merge-tree` sobre o merge-base comum: **zero conflitos**. As regiões de `useBundleEngine.ts` são disjuntas (ele mexe na leitura de vendáveis, eu no laço de clientes e no estado da tela) e a interação semântica que existia está resolvida acima.

## Validação

| | |
|---|---|
| `bun run test` | **683 arquivos / 6405 testes, exit 0** |
| `bun run typecheck` | exit 0 |
| `bun lint` | exit 0 erros (75 warnings pré-existentes) |
| Falsificação | 4 sabotagens, cada uma vermelha **nos dois locales** (`LC_ALL=C` e `pt_BR.UTF-8`), sempre só no teste alvo |

As falsificações: reverter o ramo do alerta → cai só o guard da gravação (a contraprova da leitura segue verde); reverter o empty state → cai só o guard do vazio; remover o `try/catch` da consulta → caem os dois guards do head; devolver a marcação para dentro de `aplicarBundles` → cai o guard do fail-closed.

**Sem cobertura própria:** a mudança de `linhasProduzidas` para linhas persistíveis. Com o `try/catch` no lugar, o cenário que a distingue exige uma exceção entre `aplicarBundles` e o registro do vazio, com nenhum cliente tendo bundle — não achei como montá-lo sem fabricar um mock que não corresponde a falha real. Está justificada pelo significado do campo, e o guard do #1791 garante que o caso principal não regrediu.

## Deploy

Só `src/` — precisa de **Publish manual** no editor do Lovable. Merge na main não publica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)