### PR TITLE
test(hooks): as 7 lacunas do adversário viram contrato — e 2 eram invisíveis pelo STUB

### DIFF
--- a/scripts/mutcheck.d/pr-duplicata-guard.mut
+++ b/scripts/mutcheck.d/pr-duplicata-guard.mut
@@ -46,18 +46,42 @@ PEGA      | encadeado volta a casar como `create` | s{^if \[ -n "\$tem_commit" \
 # o stdout, então esta família inteira sobrevivia antes do caso 16 registrar a saída não-zero.
 PEGA      | sem achados o hook sai 1 (fail-closed) | s{^\[ -n "\$achados" \] \|\| exit 0}{[ -n "\$achados" ] || exit 1}
 
-# ─── LACUNAS CONHECIDAS, AINDA ABERTAS (2ª opinião Codex, 2026-08-19) ───────────────────────
-# Não estão aqui como mutação porque hoje SOBREVIVERIAM: a suíte precisa de caso novo antes.
-# Ficam registradas para não se perderem — lacuna documentada é dívida; lacuna esquecida é furo.
-#   - `origin/main` → `origin/master` na merge-base: o stub aceita qualquer ref.
-#   - remover `"$mb"` dos `git diff`: o stub só olha HEAD/--cached/árvore, então some sem sinal.
-#   - `base_c=""` → `continue`: duas sessões criando o MESMO arquivo novo deixam de ser
-#     detectadas (nenhum positivo usa arquivo ausente da merge-base). É a mais grave das abertas.
-#   - contrato JSON (`hookEventName`/`additionalContext`): `_avisa` casa o texto cru, então
-#     renomear a chave passa — e o host ignoraria o aviso.
-#   - `*.md` na lista de ignorados: o único fixture Markdown é negativo, então ignorar todo doc
-#     passa — e contradiz o cabeçalho do hook, que mediu que filtrar `docs/` dá falso negativo.
-#   - TTL do dedupe reduzido a `[ -f "$marca" ]`: silêncio virava permanente; os testes só
-#     fazem repetição imediata.
-#   - opções globais (`git -C dir commit`, `gh --repo x/y pr create`): só as formas simples
-#     são testadas.
+# Arquivo NOVO em ambas as sessões (o caso de duplicata mais caro): sem base, o fallback
+# `base_c=""` é o que mantém TUDO do diff como candidato. Trocá-lo por `continue` matava só
+# esse caminho — era a lacuna mais grave das que o Codex apontou, fechada pelo caso 7c.
+PEGA      | arquivo ausente da base e IGNORADO    | s{\|\| base_c=""}{|| continue}
+
+
+# Contrato JSON com o host: o aviso só CHEGA se vier em hookSpecificOutput.additionalContext
+# sob hookEventName PreToolUse. Grepar o stdout cru não vê renomeação de chave — fechado ao
+# fazer `_avisa` casar a ESTRUTURA (jq), não o texto.
+PEGA      | evento do JSON deixa de ser PreToolUse | s{hookEventName:"PreToolUse"}{hookEventName:"PostToolUse"}
+PEGA      | additionalContext muda de chave       | s{additionalContext:}{additional_context:}
+
+
+# Opções globais antes do subcomando: o grupo que pula flags é o que faz `git -C dir commit` e
+# `gh --repo x/y pr create` dispararem. Perdê-lo cala o guard em SILÊNCIO. `\Q..\E` cita o
+# regex literal (ele é cheio de metacaracteres) — fechado pelo caso 7d.
+PEGA      | git perde as opcoes globais           | s{\Qgit([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+commit\E}{git[[:space:]]+commit}
+PEGA      | gh perde as opcoes globais            | s{\Qgh([[:space:]]+-{1,2}[^[:space:]]+([[:space:]]+[^-][^[:space:]]*)?)*[[:space:]]+pr\E}{gh[[:space:]]+pr}
+
+# Doc é superfície de duplicata por MEDIÇÃO (a ocorrência 2 das 3 reais era follow-up de doc):
+# acrescentar *.md aos ignorados contradiz o cabeçalho — fechado pelo caso 7e.
+PEGA      | Markdown passa a ser ignorado         | s{\*\.svg \|}{*.svg | *.md |}
+
+
+# Ref e merge-base: o stub aceitava qualquer argumento, então estas três eram invisíveis.
+# Fechadas tornando o stub sensível a `origin/main` e à presença de `MB` nos diffs.
+PEGA      | merge-base usa a ref errada           | s{^(mb=.*)origin/main}{$1origin/master}
+PEGA      | diff de nomes perde a merge-base      | s{--name-only "\$mb" \$alvo}{--name-only \$alvo}
+PEGA      | diff de conteudo perde a merge-base   | s{git diff "\$mb" \$alvo -- "\$f"}{git diff \$alvo -- "\$f"}
+
+# TTL do dedupe: sem ele o silêncio vira PERMANENTE naquela branch — fechado pelo caso 12b.
+PEGA      | silencio do dedupe nunca expira       | s{^    if \[ -f "\$marca" \] && \[ -z "\$\(find.*}{    if [ -f "\$marca" ]; then}
+
+
+# ─── COBERTURA ───────────────────────────────────────────────────────────────────────────────
+# As 7 lacunas que a 2ª opinião adversária (Codex, 2026-08-19) apontou foram TODAS fechadas —
+# cada uma virou caso + mutação acima, e cada mutação foi medida PEGA. Duas exigiram tornar o
+# stub sensível a ref/merge-base: enquanto ele aceitava qualquer argumento, as mutações eram
+# invisíveis, e "invisível ao stub" lia-se como "coberto".

--- a/scripts/test-pr-duplicata-guard.sh
+++ b/scripts/test-pr-duplicata-guard.sh
@@ -44,9 +44,17 @@ _alvo() {
 }
 case "$1" in
   fetch) exit 0 ;;
-  merge-base) [ -n "${GIT_STUB_NO_MB:-}" ] && exit 128; echo MB ;;
+  # O stub aceitava QUALQUER ref: trocar origin/main por origin/master era invisível. Agora
+  # exige a ref certa — a mutação passa a virar merge-base ausente, que é o efeito real.
+  merge-base) [ -n "${GIT_STUB_NO_MB:-}" ] && exit 128
+    case " $* " in *" origin/main "*) ;; *) exit 128 ;; esac
+    echo MB ;;
   branch) printf '%s\n' "${GIT_STUB_BRANCH-minha-branch}" ;;
   diff)
+    # Todo diff do hook passa a merge-base. Sem esta exigência, REMOVER "$mb" do comando era
+    # invisível ao stub (ele só olhava HEAD/--cached/árvore) e os commits da branch sumiriam
+    # do conjunto em produção, calando o guard. (lacuna da 2ª opinião, Codex 2026-08-19)
+    case " $* " in *" MB "*) ;; *) exit 128 ;; esac
     a="$(_alvo "$@")"
     case "$*" in
       *--name-only*)
@@ -98,7 +106,15 @@ _hook() {
 }
 _ok()   { printf '  ✓ %s\n' "$1"; }
 _bad()  { printf '  ✗ %s\n' "$1"; fail=1; }
-_avisa()  { [ -n "$1" ] && printf '%s' "$1" | grep -q 'DUPLICATA por OBJETIVO'; }
+# Casa o CONTRATO, não só o texto: o host lê `hookSpecificOutput.additionalContext` sob
+# `hookEventName:"PreToolUse"`. Grepar o JSON cru deixava passar renomear a chave — o aviso
+# continuaria no stdout e seria IGNORADO pelo host (lacuna da 2ª opinião, Codex 2026-08-19).
+# `printf '%s' | jq` e nunca `echo` — no zsh o echo corrompe o \n escapado do JSON (CLAUDE.md).
+_avisa()  { [ -n "$1" ] || return 1
+  printf '%s' "$1" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"
+    and .hookSpecificOutput.permissionDecision == "allow"
+    and ((.hookSpecificOutput.additionalContext // "") | test("DUPLICATA por OBJETIVO"))' \
+    >/dev/null 2>&1; }
 # if/then explícito: A && B || C roda C mesmo com A verdadeiro se B falhar (SC2015).
 _deve_avisar() { if _avisa "$2"; then _ok "$1"; else _bad "$1"; fi; }
 _deve_calar()  { if _avisa "$2"; then _bad "$1"; else _ok "$1"; fi; }
@@ -209,6 +225,46 @@ const cor_x = 1
 out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine_curto.txt" "$CRIAR")"
 _deve_calar "cor_x (5 chars, forma válida) não dispara" "$out"
 
+echo "== 7c. arquivo NOVO (ausente da merge-base): duas sessões criaram o mesmo => AVISA =="
+# O caso de duplicata mais CARO: as duas sessões criaram o MESMO arquivo novo. Aqui o
+# git show MB:<f> falha (o arquivo não existia) e o hook degrada para base_c="" — de
+# propósito, porque sem base TUDO que o diff adiciona é novo. Trocar esse fallback por
+# `continue` mataria exatamente este caso, e nenhum outro positivo usa arquivo ausente da
+# merge-base. Lacuna apontada pela 2ª opinião (Codex, 2026-08-19) e a mais grave delas.
+printf 'src/lib/modulo-novo.ts\n' > "$stub/mine_novo.txt"
+printf '+++ b/src/lib/modulo-novo.ts\n+export function registrar_modulo_novo() {}\n' \
+  > "$stub/diff_src_lib_modulo-novo_ts"
+# NÃO existe base_src_lib_modulo-novo_ts: é essa AUSÊNCIA que faz o git show sair 128.
+rm -f "$stub/base_src_lib_modulo-novo_ts"
+printf 'export function registrar_modulo_novo() {}\n' > "$stub/main_src_lib_modulo-novo_ts"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine_novo.txt" "$CRIAR")"
+_deve_avisar "arquivo novo em ambas as sessões dispara" "$out"
+
+echo "== 7d. opções GLOBAIS do git/gh contam como gatilho =="
+# O regex do modo pula flags antes do subcomando de propósito. Sem caso, perder esse grupo
+# faria git -C dir commit e gh --repo x/y pr create deixarem de disparar — em SILÊNCIO.
+# (lacuna da 2ª opinião, Codex 2026-08-19; a mesma forma que ele achou nos hooks do ECC)
+# cache PRÓPRIO: usar o $DEDUPE compartilhado gravaria o marcador desta MESMA assinatura e
+# silenciaria o caso 9 adiante (acoplamento de ordem — visto ao vivo ao escrever este caso).
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt PRDG_CACHE_DIR=$stub/cache7d" \
+  'git -C /tmp/repo commit -m "wip"')"
+_deve_avisar "git -C <dir> commit dispara" "$out"
+out="$(_hook "$MINE" 'gh --repo lucas/afiacao pr create --fill')"
+_deve_avisar "gh --repo <x/y> pr create dispara" "$out"
+
+echo "== 7e. .md POSITIVO: doc também é superfície de duplicata =="
+# O caso 7 prova que PROSA não vira candidato; falta o outro lado. O cabeçalho do hook diz
+# que filtrar docs/ daria falso negativo — a ocorrência 2 das 3 reais era follow-up de doc.
+# Sem este caso, acrescentar *.md aos ignorados passava, contradizendo o desenho medido.
+printf 'docs/historico/registro.md\n' > "$stub/mine_docpos.txt"
+printf '+++ b/docs/historico/registro.md\n+O gate agora cobre reposicao_pos_marcador.\n' \
+  > "$stub/diff_docs_historico_registro_md"
+printf 'Registro.\n' > "$stub/base_docs_historico_registro_md"
+printf 'Registro. O gate agora cobre reposicao_pos_marcador.\n' \
+  > "$stub/main_docs_historico_registro_md"
+out="$(_hook "GIT_STUB_MINE_FILE=$stub/mine_docpos.txt" "$CRIAR")"
+_deve_avisar "símbolo repetido em .md dispara" "$out"
+
 echo "== 8. REGRESSÃO do escopo: símbolo existe repo-wide, mas é novo NO ARQUIVO → AVISA =="
 # É a ocorrência 1 real: reposicao_pos_marcador vivia em 10 arquivos (migrations) na merge-base.
 # O escopo por arquivo tem de disparar mesmo assim; repo-wide daria falso negativo.
@@ -260,6 +316,20 @@ _deve_avisar "colisão NOVA fura o silêncio do dedupe" "$out"
 # ...e a branch faz parte da assinatura: outra branch com o MESMO achado volta a avisar
 out="$(_hook "$C9 GIT_STUB_BRANCH=outra-branch" "$COMITAR")"
 _deve_avisar "outra branch com o mesmo achado avisa (assinatura inclui a branch)" "$out"
+
+echo "== 12b. o silêncio do dedupe EXPIRA (TTL) =="
+# O caso 12 prova que o MESMO achado não repete; falta provar que o silêncio não é ETERNO.
+# Sem isto, reduzir a checagem a [ -f "$marca" ] passava e o guard emudecia para sempre
+# naquela branch. (lacuna da 2ª opinião, Codex 2026-08-19)
+rm -rf "$CACHE"
+C12B="GIT_STUB_MINE_FILE=$stub/vazio.txt GIT_STUB_STAGED_FILE=$stub/mine.txt $DEDUPE"
+_hook "$C12B" "$COMITAR" >/dev/null
+out="$(_hook "$C12B" "$COMITAR")"
+_deve_calar "2a vez seguida: mudo (dedupe ativo)" "$out"
+# envelhece a marca além do TTL — `touch -t` no formato POSIX vale no macOS E no GNU.
+find "$CACHE" -type f -exec touch -t 202001010000 {} +
+out="$(_hook "$C12B" "$COMITAR")"
+_deve_avisar "depois do TTL o aviso VOLTA (silêncio não é permanente)" "$out"
 
 echo "== 13. o \`gh pr create\` NUNCA é silenciado pelo dedupe (último portão) =="
 out="$(_hook "$MINE $DEDUPE" "$CRIAR")"; _deve_avisar "create avisa a 1ª vez" "$out"


### PR DESCRIPTION
Fecha a dívida deixada pelo #1797. Contrato do `pr-duplicata-guard`: **11 → 18 mutações, todas PEGA**. O hook **não muda** — só suíte, stub e contrato.

## O achado de método

Duas das lacunas (`origin/main`→`origin/master`, e remover `"$mb"` dos `git diff`) sobreviviam **porque o stub aceitava qualquer argumento** — ele só olhava `HEAD`/`--cached`/árvore. Não era a suíte que estava fraca: era o **dublê que não distinguia o caso certo do errado**. Enquanto isso valesse, *"invisível ao stub"* lia-se como *"coberto"*.

É o mesmo erro de fixture que fechei no #1790 (asserção negativa com caminho alternativo desarmado), agora um nível abaixo — no dublê em vez de na asserção. O stub passa a exigir a ref certa na merge-base e a presença de `MB` em todo diff.

## Casos novos

| | |
|---|---|
| **7c** | arquivo **NOVO** em ambas as sessões (o `git show` da base falha ⇒ `base_c=""`). A lacuna mais grave: é o caso de duplicata mais caro, e nenhum positivo usava arquivo ausente da merge-base |
| **7d** | opções globais (`git -C dir commit`, `gh --repo x/y pr create`) — perder o grupo que pula flags calaria o guard em silêncio |
| **7e** | `.md` **positivo**. O caso 7 provava que prosa não vira candidato; faltava o outro lado, e sem ele acrescentar `*.md` aos ignorados passava — contradizendo a **medição** do cabeçalho (a ocorrência 2 das 3 reais era follow-up de doc) |
| **12b** | TTL: o silêncio do dedupe **expira**. Sem isso, reduzir a checagem a `[ -f "$marca" ]` fazia o guard emudecer para sempre naquela branch |

## Contrato JSON

`_avisa` passa a casar a **estrutura** via `jq` (`hookSpecificOutput.additionalContext` sob `hookEventName: PreToolUse`) em vez do texto cru. Renomear a chave deixava o aviso no stdout e **invisível para o host** — o guard pareceria funcionando e não chegaria a ninguém.

`printf '%s' | jq`, nunca `echo` (no zsh o `echo` corrompe o `\n` escapado do JSON — CLAUDE.md).

## Evidência

```
bun run test:hooks   exit 0   (5 suítes; duplicata 36 → 40 asserções)
mutcheck             18/18 PEGA · 0 sobreviventes · 0 inválidas · controle+ 18/18
shellcheck           exit 0
git diff .claude/hooks/   vazio (o hook não muda)
```

Um acoplamento de ordem apareceu ao escrever o 7d e está corrigido: usar o `$DEDUPE` compartilhado gravava o marcador da mesma assinatura e **silenciava o caso 9** adiante. O 7d tem cache próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)