### PR TITLE
docs(visual-direction): o elenco de benchmarks vivia em docs/ux-audit/ — a §7 faz a ponte; Material 3 e Bootstrap eram o buraco real

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Health stack (`/health`): typecheck · lint · test · `bunx knip` (deadcode) ·
 
 ## Design System (v3 — "fintech premium": Vercel/Mercury/Stripe Dashboard)
 
-Tokens em `src/index.css` (paleta quase-neutra low-fatigue; `--status-*` dessaturadas; radius 6px; motion easing Vercel; dark via `next-themes`; `density-compact` global). Direção completa: `docs/visual-direction/`. Benchmark UX: Linear/Notion/Carbon/Polaris/Retool (anti-referências: Material 3, Bootstrap, Stripe landing consumer). **Convenções de código novo:**
+Tokens em `src/index.css` (paleta quase-neutra low-fatigue; `--status-*` dessaturadas; radius 6px; motion easing Vercel; dark via `next-themes`; `density-compact` global). Direção, benchmarks (pattern nominal, nunca skin) e anti-referências: `docs/visual-direction/`. **Convenções de código novo:**
 
 - Status colors: `text-status-success/warning/error/info` — **não** `text-emerald-600`/`text-red-600`.
 - Filtros de lista: `useUrlState` — não `useState`. Listas grandes: `useInfiniteScroll` + `useInfiniteQuery`.

--- a/docs/visual-direction/01-direcao.md
+++ b/docs/visual-direction/01-direcao.md
@@ -267,3 +267,34 @@ Todos com versões `-bg` muito claras (light) ou muito escuras (dark) pra fundos
 - **Opção γ** — `AdminCustomers`: tabela densa com filtros, segmentos (que acabamos de implementar), avatar de cliente. Boa pra mostrar tipografia + tabela + chips + tabular nums em coluna "gasto mensal".
 
 Próximo doc (`02-tokens.md`) é independente da escolha — define os tokens novos no nível CSS. Mas `03-pilotos.md` depende dessa escolha. Aguardo sua resposta.
+
+---
+
+## 7. Elenco de referências — o que se toma de cada uma (2026-08-20)
+
+As §2-§5 destilam as **três primárias** (Vercel · Mercury · Stripe Dashboard). O elenco de apoio nasceu depois, na auditoria de UX (`docs/ux-audit/`), e nunca foi consolidado aqui — por isso a lista de benchmarks citada no `CLAUDE.md` tinha nomes sem rastro nesta pasta. Esta seção é o mapa: **cada referência, o que se toma dela, e onde isso já está aplicado.**
+
+Atenção ao ler a §1: ali **Polaris**, **Notion** e **Material** aparecem descrevendo a identidade **antiga** (`HubSpot Canvas + Polaris + Gong`, azul saturado, easing Material) — é diagnóstico do que saiu, não benchmark.
+
+### Benchmarks
+
+| Referência | O que se toma | Onde já está aplicado |
+|---|---|---|
+| **Vercel · Mercury · Stripe Dashboard** | Direção primária: tipografia geométrica, tabular nums, border > sombra, easing próprio | §2-§5 · tokens de `src/index.css` |
+| **Linear** | Quase-neutro que aguenta jornada longa; densidade alta como **escolha**, não como aperto | Decisão A1 e D1 (§5) · `src/index.css:306` |
+| **Notion** | Navegação por seções, Recentes/Favoritos na sidebar, stagger na expansão | `05-revisao-skill.md` SB1/SB2 · `docs/ux-audit/03-roadmap.md:141` |
+| **Polaris** (Shopify) | Componentes de dado B2B: EmptyState compacto, ResourceList | `docs/ux-audit/03-roadmap.md:221,268` |
+| **Carbon** (IBM) | **Rigor de sistema, não estética** — (a) *design tokens*: todo sinal semântico via token, nunca cor crua; (b) *touch target spec*: 44×44 mínimo, 56×56 para uso com luva | A regra `text-status-*` (em vez de `text-emerald-600`) vem de `03-roadmap.md:330`; `<Button size="touch">` 44px e `balcao` 56px vêm de `03-roadmap.md:92` |
+| **Retool** | O vocabulário de **ferramenta interna**: a tabela densa é a superfície principal — bulk actions, atalhos `j/k`, e tela de gestão pode ser desktop-only sem se desculpar | `src/index.css:306` (32px densos em ponteiro fino, decisão explícita) · `docs/ux-audit/02-heuristica.md:133,416` · `03-roadmap.md:268` |
+
+Carbon e Retool entram exatamente onde as três primárias **não alcançam**: Vercel/Mercury/Stripe são produtos de sessão curta e superfície pequena; o Afiação é operação de 8h com tabela densa, coletor e luva. Carbon dá a régua de sistema (token semântico e alvo de toque), Retool o precedente de densidade — juntos são o que sustenta `density-compact` global convivendo com `size="balcao"` de 56px na mesma base de código.
+
+### Anti-referências
+
+| Anti-referência | Por quê | O que contradiz aqui |
+|---|---|---|
+| **Material 3** | É **de onde o app saiu**, não um caminho que se deixou de tomar: a §1 registra o azul saturado "tipo HubSpot/Material" e o easing `cubic-bezier(0.4, 0, 0.2, 1)` como "sem assinatura própria". O M3 aprofunda justamente o que o redesign desfez — cor tonal saturada, profundidade por elevação/sombra, shape bem arredondado e alvos generosos herdados de mobile-touch. | As quatro decisões da §5 ao mesmo tempo: A1 (quase-neutro), D1 (radius 6px), E1 (border 1px, sombra só em overlay), G1 (easing Vercel) |
+| **Bootstrap** | Piso genérico: componente com identidade de "site" (primário saturado, sombra e radius default) e utilitário de cor **crua**, sem camada semântica. Adotar esse vocabulário reintroduz `text-red-600` no lugar de `text-status-error` — o débito de ~50 callsites que a auditoria de UX está pagando. | A camada `--status-*` de `src/index.css` · o veredicto da §1 (piso decente, nenhuma escolha visual cria identidade) |
+| **Stripe landing** (consumer) | O Stripe entra **só pelo Dashboard**. A landing é consumer-facing: radius maior, ilustração, respiro — outro produto. | Já registrado na Dimensão D (§3): "mais friendly, mais Stripe-landing-page. Não combina com fintech sério" |
+
+> **Regra prática:** benchmark aqui é **pattern nominal** (o componente e a régua), nunca skin. A identidade do Afiação segue sendo tipografia + quase-neutro + densidade; copiar a estética de qualquer um dos cinco quebraria a decisão A1.


### PR DESCRIPTION
## O que motivou

O corte da linha de benchmarks do `CLAUDE.md` estava **adiado de propósito**: `Carbon`, `Retool` e `Material 3` não aparecem em nenhum dos 5 arquivos de `docs/visual-direction/`, então cortar seria perda de conhecimento, não enxugamento.

## O que a varredura ampliada mostrou (`docs/` + `src/`, case-sensitive)

A premissa estava **parcialmente errada** — a busca original cobria 1 pasta:

| Referência | Situação real |
|---|---|
| **Carbon** (IBM) | ✅ **Já documentado** em `docs/ux-audit/`, com uso rastreável até o código: `<Button size="touch">` 44px e `balcao` 56px saem do *Carbon Touch Target spec* (`03-roadmap.md:92`); a regra `text-status-*` em vez de `text-emerald-600` sai do *Carbon tokens system* (`:330`); EmptyState cita *InlineNotification* (`:221`) |
| **Retool** | ✅ **Já documentado**: bulk actions de tabela (`03-roadmap.md:268`), desktop-only (`02-heuristica.md:133`), atalhos `j/k` (`:416`) — e citado no próprio **`src/index.css:306`** ("densidade alta ali é INTENCIONAL (Linear/Retool)") |
| **Material 3** | ❌ **0 ocorrências** em `docs/` e `src/` — buraco real |
| **Bootstrap** | ❌ **0 ocorrências** como framework (só `bootstrap` = inicialização) — **fora do escopo original**, mesmo problema |
| **Stripe landing** | ✅ Já coberto, grafado `Stripe-landing-page` (`01-direcao.md:138`) |

Bônus: em `visual-direction/`, **`Polaris` e `Notion` aparecem descrevendo a identidade ANTIGA a realinhar** (`HubSpot Canvas + Polaris + Gong`), não como benchmark — a cobertura substantiva do elenco inteiro sempre esteve em `docs/ux-audit/`.

## O que este PR faz

**1. `docs/visual-direction/01-direcao.md` — §7 nova (mapa, não doutrina paralela).**

Para Carbon/Retool, escrever justificativa nova **duplicaria** o que `docs/ux-audit/` já resolve melhor — então a §7 é uma tabela *referência → o que se toma → onde já está aplicado* (com `file:line`), que é a **ponte** que faltava entre as duas pastas. Só **Material 3** e **Bootstrap** ganham justificativa própria, ancorada no que o design system já decidiu:

- **Material 3** é *de onde o app saiu*, não um caminho não tomado — a §1 já registra o azul "tipo HubSpot/Material" e o easing `cubic-bezier(0.4, 0, 0.2, 1)` "sem assinatura própria". Contradiz A1 (quase-neutro), D1 (radius 6px), E1 (border 1px) e G1 (easing Vercel) **ao mesmo tempo**.
- **Bootstrap** é piso genérico com cor **crua** sem camada semântica — adotá-lo reintroduz `text-red-600` no lugar de `text-status-error`, o débito de ~50 callsites que a auditoria de UX está pagando.

**2. `CLAUDE.md` — a linha vira regra + ponteiro** (1 linha alterada).

## Gate

`bun run claude:size` → **exit 0** (exit code capturado colado no comando), re-rodado após o rebase:

```
✅ CLAUDE.md: 16678 bytes / 2200 palavras / ≈4765 tokens / maior linha 800 chars — dentro do orçamento
```

⚠️ **A economia é menor do que o esperado: 4 palavras / 66 bytes** (2204 → 2200), não as ~35 palavras estimadas — `wc -w` conta `Linear/Notion/Carbon/Polaris/Retool` como **UMA** palavra por não ter espaços. O valor deste PR é a documentação e a ponte, não a folga de orçamento (que segue larga: 2200 de 2600).

Doc-only: nenhum arquivo em `src/`, então `manifesto.gate` não se aplica; `claude:size` é o único gate do CI que toca estes arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)