### PR TITLE
test(hooks): os três guards restantes saem do poder NÃO-MEDIDO — e o `heavy` não afirmava o deny

### DIFF
--- a/scripts/mutcheck.d/branch-pos-squash-guard.mut
+++ b/scripts/mutcheck.d/branch-pos-squash-guard.mut
@@ -1,0 +1,33 @@
+# Invariantes do guard de BRANCH PÓS-SQUASH (.claude/hooks/branch-pos-squash-guard.sh).
+# @src: .claude/hooks/branch-pos-squash-guard.sh
+# @test: scripts/test-branch-pos-squash-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+
+# CONTROLE+ : nunca avisar tem de reprovar o caso-alvo.
+PEGA      | controle+: guard nunca avisa          | s{^\[ "\$verdict" = "merged" \] \|\| exit 0}{exit 0}
+
+# main/master é exceção de DESENHO (lá o commit é legítimo).
+PEGA      | main/master deixa de ser excecao      | s{case "\$branch" in main\|master\) exit 0 ;; esac}{:}
+
+# Sem commits locais fora da main não há nada a avisar (o squash já bastou).
+PEGA      | commits locais deixam de ser exigidos | s{^\[ "\$n" -gt 0 \] 2>/dev/null \|\| exit 0}{:}
+
+# `gh` fora do ar é fail-open: não avisa e NÃO cacheia (chutar aqui vira alarme falso eterno).
+PEGA      | gh fora do ar passa a CHUTAR merged   | s{\[ -n "\$merged_n" \] \|\| exit 0}{[ -n "\$merged_n" ] || merged_n=1}
+
+# Menção ≠ execução (mesma família dos guards irmãos).
+PEGA      | sanitizacao heredoc/aspas desligada   | s{^\[ -n "\$scan" \] \|\| scan="\$cmd"}{scan="\$cmd"}
+
+# --- eram lacunas; medidas na 1a rodada (2 sobreviventes + 1 inválida) e fechadas ---
+# A do `--state` exigiu tornar o STUB de gh sensível ao argumento: enquanto ele aceitava
+# qualquer coisa, a mutação era invisível — "invisível ao dublê" lia-se como "coberto".
+PEGA      | consulta PR aberto em vez de merged   | s{--head "\$branch" --state merged}{--head "\$branch" --state open}
+# Quem IMPÕE o TTL é a comparação interna, não o `[ "$ttl" -gt 0 ]` externo — mirei o externo na
+# 1a rodada e a mutação sobreviveu por estar mal-apontada, não por falta de teste.
+PEGA      | TTL nunca expira (silencio eterno)    | s{\[ "\$\(\( now - mtime \)\)" -lt "\$ttl" \] && verdict=}{verdict=}
+# TRIADO E NÃO TESTADO (teatro reverso): remover o `[ "$ttl" -gt 0 ]` externo é INOBSERVÁVEL —
+# com ttl=0 a comparação interna (`-lt 0`) já é falsa para qualquer idade, e com ttl não-numérico
+# o teste interno também falha. É redundância defensiva, não invariante.
+PEGA      | evento do JSON deixa de ser PreToolUse | s{hookEventName:"PreToolUse"}{hookEventName:"PostToolUse"}
+PEGA      | additionalContext muda de chave       | s{additionalContext:}{additional_context:}

--- a/scripts/mutcheck.d/heavy-guard.mut
+++ b/scripts/mutcheck.d/heavy-guard.mut
@@ -1,0 +1,31 @@
+# Invariantes do heavy-guard (.claude/hooks/heavy-guard.sh) — semáforo de RAM da M2 8GB.
+# @src: .claude/hooks/heavy-guard.sh
+# @test: scripts/test-heavy-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+#
+# Guard que REESCREVE o comando do usuário: o modo de falha caro não é só deixar de agir, é
+# agir no lugar ERRADO (o #1778 reescreveu DENTRO de um heredoc e o `heavy` foi parar no ci.yml).
+
+# CONTROLE+ : nada é pesado ⇒ nunca reescreve nem nega.
+PEGA      | controle+: nada e considerado pesado  | s{printf '%s' "\$scan" \| grep -qE "\$heavy_re" \|\| exit 0}{exit 0}
+
+# Já prefixado com `heavy` é no-op (senão duplica o prefixo a cada passagem).
+PEGA      | ja-tem-heavy deixa de ser detectado   | s{printf '%s' "\$scan" \| grep -qE "\$re_ja_heavy" && exit 0}{:}
+
+# --- medidas na 1a rodada: heredoc e sanitizacao JA eram load-bearing; allowlist saiu
+#     INVALIDA (ancora errada, ausencia de dado) e as duas do DENY sobreviveram porque a
+#     suite nao tinha NENHUMA assercao sobre negar. Todas fechadas. ---
+# A proteção de heredoc/aspas na REESCRITA — exatamente o bug do #1778.
+PEGA      | reescrita perde a protecao de heredoc | s{\Q<<-?\s*(?<q>[\x27\x22]?)(?<tag>\w+)\k<q>[\s\S]*?^\k<tag>[ \t]*$|\E}{}
+# A sanitização da DETECÇÃO (menção ≠ execução) no caminho com perl.
+PEGA      | deteccao perde a sanitizacao          | s{^  scan="\$\(printf '%s' "\$cmd" \| perl -0777.*}{  scan="\$cmd"}
+# A allowlist de comandos inofensivos (echo/cat/git/...) some — mira o CORPO do case, que e
+# unico. Sem ancora de fim de linha: neste formato \$ vale CIFRAO LITERAL (e o que faz \$var
+# do shell casar), entao um \$ no fim NAO ancora — procura um cifrao que a linha nao tem, e a
+# mutacao sai INVALIDA. Ancora quer $ pelado; variavel do shell quer \$.
+PEGA      | allowlist de comandos leves some      | s{^    exit 0 ;;}{    : ;;}
+# A validação final: só vira `allow` se a reescrita REALMENTE mudou e ficou com heavy.
+PEGA      | reescrita invalida vira allow         | s{^if \[ "\$rewritten" != "\$cmd" \] && printf '%s' "\$rewritten" \| grep -qE "\$re_ja_heavy"; then}{if true; then}
+# O contrato do deny (caminho com jq).
+PEGA      | deny vira allow no caminho com jq     | s{permissionDecision:"deny",permissionDecisionReason:\$r}{permissionDecision:"allow",permissionDecisionReason:\$r}

--- a/scripts/mutcheck.d/migration-collision-guard.mut
+++ b/scripts/mutcheck.d/migration-collision-guard.mut
@@ -1,0 +1,27 @@
+# Invariantes do guard de COLISÃO DE MIGRATION (.claude/hooks/migration-collision-guard.sh).
+# @src: .claude/hooks/migration-collision-guard.sh
+# @test: scripts/test-migration-collision-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+#
+# Único guard de DENY do conjunto (os outros avisam). Aqui o modo de falha caro é o inverso:
+# deixar de negar = migration concorrente entra e o SQL Editor recebe as duas fora de ordem.
+
+# CONTROLE+ : nunca negar tem de reprovar o caso-alvo. Se sobreviver, o harness é que quebrou.
+PEGA      | controle+: guard nunca nega           | s{grep -q ': RED' \|\| exit 0}{exit 0}
+
+# O oposto: negar SEM ser RED (🟡 commitada / 🟢 inédito viram deny) — os 3 allow reprovam.
+PEGA      | nega em qualquer veredito, nao so RED | s{grep -q ': RED'}{grep -q ':'}
+
+# Contrato com o host: `deny` é o campo que BLOQUEIA de fato.
+PEGA      | decisao vira allow                    | s{permissionDecision:"deny"}{permissionDecision:"allow"}
+
+# --- eram lacunas; medidas SOBREVIVENTES na 1a rodada e fechadas por caso novo ---
+# Edit usa `new_string`, não `content`. O run() da suíte só monta tool_name:"Write".
+PEGA      | Edit deixa de ser lido (new_string)   | s{ // \.tool_input\.new_string}{}
+# Caminho RELATIVO some do filtro. A suíte só usa caminho absoluto ($tmp/...).
+PEGA      | filtro perde o caminho relativo       | s{ \| supabase/migrations/\*\.sql\) ;;}{) ;;}
+# Evento do JSON: o is_deny só casa permissionDecision, não o evento.
+PEGA      | evento do JSON deixa de ser PreToolUse | s{hookEventName:"PreToolUse"}{hookEventName:"PostToolUse"}
+# O motivo do bloqueio some: nega sem dizer por quê (o founder fica sem a instrução de coordenar).
+PEGA      | deny perde o motivo                   | s{permissionDecisionReason:\$r}{permissionDecisionReason:"x"}

--- a/scripts/test-branch-pos-squash-guard.sh
+++ b/scripts/test-branch-pos-squash-guard.sh
@@ -30,6 +30,10 @@ chmod +x "$stub/git"
 cat >"$stub/gh" <<'STUB'
 #!/bin/sh
 [ -n "${GH_STUB_EXIT:-}" ] && exit "$GH_STUB_EXIT"
+# O stub aceitava QUALQUER argumento, então trocar --state merged por --state open era
+# invisível — e a pergunta que o guard faz mudaria por completo. Agora só serve o fixture
+# para a pergunta CERTA; qualquer outra devolve lista vazia. (mutation-check 2026-08-20)
+case " $* " in *" --state merged "*) ;; *) printf '%s' '[]'; exit 0 ;; esac
 cat "${GH_STUB_FILE:-/dev/null}"
 STUB
 chmod +x "$stub/gh"
@@ -52,7 +56,10 @@ expect_warn() {  # dispara: allow + additionalContext mencionando 'squash'
   local nome="$1" out ctx
   out="$(_hook "$2" "$3")"
   ctx="$(printf '%s' "$out" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null)"
-  if printf '%s' "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"allow"' \
+  # o EVENTO faz parte do contrato: sob hookEventName errado o host ignora o additionalContext,
+  # e o aviso ficaria no stdout sem chegar a ninguém. (mutation-check 2026-08-20: sobrevivia)
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null 2>&1 \
+     && printf '%s' "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"allow"' \
      && printf '%s' "$ctx" | grep -qi 'squash'; then
     echo "  ok    warn  | $nome"
   else
@@ -97,6 +104,19 @@ if printf '%s' "$out1" | grep -qi 'squash' && printf '%s' "$out2" | grep -qi 'sq
   echo "  ok    cache HIT: 2ª chamada avisa mesmo com gh quebrado"
 else
   echo "  FAIL  cache não segurou o veredito | out1='$out1' out2='$out2'"; fail=1
+fi
+
+# ...e o cache EXPIRA: envelhecida a marca além do TTL, o veredito velho não vale mais. Com o gh
+# quebrado o hook tem de CALAR (fail-open), não reusar o cache vencido. Sem este caso, reduzir a
+# checagem a [ -f "$cache_file" ] passava e o veredito virava eterno. (mutation-check 2026-08-20)
+find "$cachedir" -type f -exec touch -t 202001010000 {} +
+out3="$(printf '%s' "$(jq -n '{tool_name:"Bash",tool_input:{command:"git commit -m z"}}')" \
+  | env GIT_STUB_BRANCH=feature-cache GIT_STUB_REVCOUNT=3 GH_STUB_EXIT=1 \
+        BSG_CACHE_DIR="$cachedir" BSG_CACHE_TTL=120 bash "$HOOK" 2>/dev/null)"
+if [ -z "$out3" ]; then
+  echo "  ok    cache EXPIRA: veredito vencido não é reusado"
+else
+  echo "  FAIL  cache vencido foi reusado | out3='$out3'"; fail=1
 fi
 
 # O cache le mtime via `stat`, cujo contrato DIVERGE entre BSD (macOS, do founder) e GNU (Linux,

--- a/scripts/test-heavy-guard.sh
+++ b/scripts/test-heavy-guard.sh
@@ -39,6 +39,20 @@ expect_rewrite() {
   fi
 }
 
+# deny: o guard NÃO conseguiu reescrever e bloqueia. Este caminho é a razão de ser do guard
+# (comando pesado que escaparia do semáforo) e não tinha NENHUMA asserção — trocar o
+# permissionDecision de "deny" para "allow" sobrevivia à suíte inteira, e o comando pesado
+# rodaria sem semáforo. (mutation-check 2026-08-20)
+expect_deny() {
+  local cmd="$1" out
+  out="$(run "$cmd")"
+  if printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"
+      and .hookSpecificOutput.permissionDecision == "deny"
+      and ((.hookSpecificOutput.permissionDecisionReason // "") | test("heavy"))' >/dev/null 2>&1
+  then echo "  ok    deny   | $cmd"
+  else echo "  FAIL  want deny | $cmd → '$out'"; fail=1; fi
+}
+
 # updatedInput preserva os demais campos do tool_input (description/timeout)
 expect_preserva_campos() {
   local out
@@ -128,6 +142,13 @@ expect_quiet 'cd /tmp/x && heavy bun run test'
 
 echo "── leves / não-pesados → não interfere ──"
 expect_quiet 'bun lint'
+
+# allowlist de comandos leves: MENCIONAR um comando pesado não é executá-lo. Sem ela o guard
+# reescreveria o texto do echo/da mensagem de commit — a mesma classe do #1778, que enfiou um
+# `heavy` dentro do ci.yml. Não havia caso: matar a allowlist inteira sobrevivia à suíte.
+# (mutation-check 2026-08-20)
+expect_quiet 'echo bun run test'
+expect_quiet 'git commit -m documenta o bun run test'
 expect_quiet 'bun run lint'
 expect_quiet 'bun dev'
 expect_quiet 'git status'
@@ -254,6 +275,16 @@ CASO
 )"
 expect_rewrite_rot 'heavy CITADO no heredoc não silencia o guard' \
   "$caso_heavy_citado" "$heavy_citado_quer"
+
+echo "── deny: pesado que o guard NÃO consegue reescrever é BLOQUEADO ──"
+# Dentro de crase o casamento acontece (a crase não é sanitizada), mas a reescrita não: ela só
+# insere o prefixo depois de ^ ou de [ \t;&|(] — e a crase não está na classe. Sobra rewritten
+# == cmd, e aí a única saída correta é negar: deixar passar rodaria o pesado sem semáforo.
+# shellcheck disable=SC2016  # a crase TEM de chegar literal ao guard — expandi-la aqui
+# executaria `bun run test` de verdade dentro da suíte, que é o oposto do teste.
+expect_deny 'resultado=`bun run test`'
+
+echo
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — todos os casos"; else echo "FALHOU"; fi

--- a/scripts/test-migration-collision-guard.sh
+++ b/scripts/test-migration-collision-guard.sh
@@ -25,7 +25,23 @@ run() { # <file_path> <content>  → stdout do hook
   enc="$(printf '%s' "$c" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
   printf '{"tool_name":"Write","tool_input":{"file_path":"%s","content":%s}}' "$fp" "$enc" | bash "$HOOK" 2>/dev/null
 }
-is_deny() { grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; }
+# Casa o CONTRATO, não o texto: o host só BLOQUEIA de fato se vier permissionDecision "deny"
+# sob hookEventName PreToolUse — e o MOTIVO é o que manda o founder coordenar (deny opaco é
+# deny que ele não sabe resolver). Grepar o JSON cru deixava as duas coisas passarem.
+# (mutation-check 2026-08-20; ambas sobreviviam)
+# O hook lê `.tool_input.content // .tool_input.new_string`: o segundo é o caminho do Edit.
+# Só com Write, perder o `new_string` do jq passava — e Edit em migration deixava de ser
+# checado em SILÊNCIO (fail-open). (mutation-check 2026-08-20)
+run_edit() { # <file_path> <new_string> → stdout do hook
+  local fp="$1" c="$2" enc
+  enc="$(printf '%s' "$c" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')"
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","new_string":%s}}' "$fp" "$enc" \
+    | bash "$HOOK" 2>/dev/null
+}
+is_deny() { jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"
+  and .hookSpecificOutput.permissionDecision == "deny"
+  and ((.hookSpecificOutput.permissionDecisionReason // "") | test("wt:preflight"))' \
+  >/dev/null 2>&1; }
 
 fail=0
 expect_deny() { if run "$1" "$2" | is_deny; then echo "  ok    deny  | $3"; else echo "  FAIL  want deny  | $3"; fail=1; fi; }
@@ -46,6 +62,17 @@ WT_PREFLIGHT_COMMITTED="20260101000000_a.sql" expect_allow "$mine" \
 WT_PREFLIGHT_COMMITTED="" expect_allow "$tmp/mine/src/foo.ts" \
   'CREATE OR REPLACE FUNCTION public.foo(x integer) RETURNS int AS $$ $$ LANGUAGE sql;' \
   "arquivo fora de supabase/migrations → no-op"
+
+echo "── o caminho do Edit (new_string) também é checado ──"
+expect_deny_edit() { if run_edit "$1" "$2" | is_deny; then echo "  ok    deny  | $3"; else echo "  FAIL  want deny  | $3"; fail=1; fi; }
+WT_PREFLIGHT_COMMITTED="" expect_deny_edit "$mine" \
+  'CREATE OR REPLACE FUNCTION public.foo(x integer) RETURNS int AS $$ select 1 $$ LANGUAGE sql;' \
+  "Edit em migration colidente também é bloqueado"
+
+echo "── caminho RELATIVO conta (o 2o padrão do filtro existe para isto) ──"
+WT_PREFLIGHT_COMMITTED="" expect_deny "supabase/migrations/20260202000000_mine.sql" \
+  'CREATE OR REPLACE FUNCTION public.foo(x integer) RETURNS int AS $$ select 1 $$ LANGUAGE sql;' \
+  "file_path relativo não escapa do filtro"
 
 echo
 if [ "$fail" -eq 0 ]; then echo "PASS — migration-collision-guard"; else echo "FALHOU"; fi


### PR DESCRIPTION
Fecha o conjunto: os **5 guards** do `test:hooks` passam a ter contrato executável no job `mutation-check`. Os hooks **não mudam** — só suítes, dublês e contratos.

| guard | resultado | o que estava sem teste |
|---|---|---|
| `heavy` | **7/7** | o caminho de **DENY** inteiro |
| `branch-pos-squash` | **9/9** | TTL do cache, evento do JSON, e o `--state` da consulta ao `gh` |
| `migration-collision` | **7/7** | Edit (`new_string`), caminho relativo, evento do JSON, motivo do deny |

## O achado principal: o `heavy` não afirmava o deny

A suíte tinha asserções sobre **reescrever** e sobre **calar** — nenhuma sobre **negar**. Trocar `permissionDecision:"deny"` por `"allow"` sobrevivia inteira, e o comando pesado rodaria **sem semáforo de RAM** na M2 de 8 GB. O mesmo valia para a validação final: forçá-la a `true` fazia uma reescrita que *não colocou o prefixo* virar `allow`.

Fechado com `expect_deny` (casa o contrato via `jq`) e um caso real:

```
resultado=`bun run test`
```

casa o regex de pesado, mas **não é reescrito** — a crase não está na classe de prefixos onde o `heavy` pode ser inserido. Sobra `rewritten == cmd`, e aí a única saída correta é negar.

A allowlist de comandos leves também não tinha caso: sem ela, `echo bun run test` seria **reescrito** — a mesma classe do #1778, que enfiou um `heavy` dentro do `ci.yml`.

Ponto positivo que vale registrar: a **proteção de heredoc na reescrita** e a **sanitização da detecção** já eram load-bearing. A lição do #1778 pegou.

## O dublê cego, de novo

No `branch-pos-squash`, trocar `--state merged` por `--state open` — que muda a **pergunta** que o guard faz por completo — era invisível, porque o stub de `gh` servia o mesmo fixture para qualquer argumento. Terceira vez que esse padrão aparece (o `git` cego a ref no #1802, a fixture desarmada no #1790). O stub agora só serve o fixture para a pergunta certa.

## Nota de método

No formato `.mut`, `\$` vale **cifrão literal** — é o que faz `\$var` do shell casar. Então um `\$` no fim **não ancora**: procura um cifrão que a linha não tem e a mutação sai `INVÁLIDA`, que é *ausência de dado*, não veredito. Âncora quer `$` pelado. Custou duas rodadas aqui e está comentado no `.mut`.

## Evidência

```
bun run test:hooks     exit 0   (5 suítes)
mutcheck heavy               7/7 PEGA · 0 sobreviventes · 0 inválidas
mutcheck branch-pos-squash   9/9 PEGA · 0 sobreviventes · 0 inválidas
mutcheck migration-collision 7/7 PEGA · 0 sobreviventes · 0 inválidas
shellcheck             exit 0
git diff .claude/hooks/   vazio
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)