### PR TITLE
test(hooks): os dois guards de DENY saem do poder não-medido — e 4 suítes órfãs entram no CI

### DIFF
--- a/.claude/hooks/read-contexto-nudge.sh
+++ b/.claude/hooks/read-contexto-nudge.sh
@@ -78,7 +78,18 @@ tokens=$(( bytes * 10 / 36 ))          # ~3,6 bytes/token em código e markdown
 # velho); offset/limite porque ler OUTRO trecho é leitura complementar, não
 # desperdício. Só a repetição exata dos três é cópia pura.
 marca="${TMPDIR:-/tmp}/afiacao-read-${sessao}"
-mtime="$(stat -f '%m' "$arquivo" 2>/dev/null || stat -c '%Y' "$arquivo" 2>/dev/null || echo 0)"
+# GNU primeiro e validando NUMERO: no Linux `stat -f %m` NAO falha do jeito que o
+# `||` supunha — `-f` la e --file-system e nao consome formato, entao '%m' vira um
+# OPERANDO invalido: o stat sai !=0 (disparando o fallback) mas ANTES ja despejou no
+# stdout o bloco multi-linha do filesystem do arquivo. Os dois se concatenavam e o
+# mtime virava lixo de 6 linhas. Chave multi-linha envenena o `grep -Fx` abaixo: cada
+# linha vira um PADRAO independente e as constantes do bloco casam sempre, entao o
+# hook gritava "releitura" justamente quando reler e LEGITIMO (outro trecho, ou
+# arquivo alterado). Verde no macOS, cego no Linux — mesmo defeito ja corrigido em
+# branch-pos-squash-guard.sh. A validacao numerica e a trava: garante 1 linha so.
+mtime="$(stat -c '%Y' "$arquivo" 2>/dev/null)"
+case "$mtime" in ''|*[!0-9]*) mtime="$(stat -f '%m' "$arquivo" 2>/dev/null)" ;; esac
+case "$mtime" in ''|*[!0-9]*) mtime=0 ;; esac
 chave="${mtime}|${inicio}|${limite}|${arquivo}"
 vistas=0
 if [ -f "$marca" ]; then

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wt:label": "bash scripts/wt-map.sh label",
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status; do bash scripts/test-$t.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/mutcheck.d/destructive-bash-guard.mut
+++ b/scripts/mutcheck.d/destructive-bash-guard.mut
@@ -1,0 +1,35 @@
+# Invariantes do guard de COMANDO DESTRUTIVO (.claude/hooks/destructive-bash-guard.sh).
+# @src: .claude/hooks/destructive-bash-guard.sh
+# @test: scripts/test-destructive-bash-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+#
+# Guard de DENY com dois modos de falha caros e OPOSTOS: deixar passar o irreversível, e negar
+# a alternativa SEGURA que a própria mensagem recomenda (aí o founder aprende a contornar o guard).
+
+# CONTROLE+ : nunca negar reprova os casos-alvo.
+PEGA      | controle+: guard nunca nega           | s{^\[ -n "\$deny" \] \|\| exit 0}{exit 0}
+
+# O bypass exige a confirmação NO INÍCIO do comando. Sem a âncora, MENCIONAR
+# CONFIRM_DESTRUCTIVE em qualquer lugar viraria passe livre.
+PEGA      | bypass deixa de exigir o INICIO       | s{\Q'^[[:space:]]*CONFIRM_DESTRUCTIVE=(1|true)([[:space:]]|$)'\E}{'CONFIRM_DESTRUCTIVE=(1|true)'}
+
+# --- medidas: 7 de 10 já eram load-bearing ---
+# `--force-with-lease` é a alternativa SEGURA que a mensagem recomenda: o `[^-]` existe para não
+# negá-la. Perdê-lo faz o guard proibir o remédio que ele mesmo receita.
+PEGA      | push nega ate o --force-with-lease    | s{\Q--force([^-]|\$)\E}{--force}
+# `git clean -n`/`-fdn` é dry-run: negar dry-run é falso positivo puro.
+PEGA      | clean passa a negar ate o dry-run     | s{ && ! det "\$\{B\}\$\{G\}clean\[\^;&\|\]\*\(-\[a-zA-Z\]\*n\|--dry-run\)"}{}
+# PERGUNTA DE DESENHO EM ABERTO, deliberadamente NÃO fechada (2026-08-20).
+# Estas duas sobreviveram, e as duas deixam o guard MAIS ESTRITO — só um caso de *allow* as
+# pegaria, e escrevê-lo CRAVARIA como intencional que `rm -f *` (force sem recursão) e
+# `rm -r /` (recursão sem force) passem. Isso é decisão do founder, não do teste: pinar aqui
+# transformaria uma dúvida em contrato. Ficam marcadas `?` — reportadas, não silenciadas.
+?         | rm deixa de exigir recursao           | s{\Qgrep -qE '(-[a-zA-Z]*[rR]|--recursive)' || return 1\E}{grep -qE '(-[a-zA-Z]*[rR]|--recursive)' || true}
+?         | rm deixa de exigir force              | s{\Qgrep -qE '(-[a-zA-Z]*f|--force)'        || return 1\E}{grep -qE '(-[a-zA-Z]*f|--force)'        || true}
+PEGA      | rm: qualquer alvo vira catastrofico   | s{^      "/"\|}{      *|"/"|}
+# Menção ≠ execução.
+PEGA      | sanitizacao heredoc/aspas desligada   | s{^\[ -n "\$scan" \] \|\| scan="\$cmd"}{scan="\$cmd"}
+# Contrato com o host.
+PEGA      | decisao vira allow                    | s{permissionDecision:"deny"}{permissionDecision:"allow"}
+PEGA      | evento do JSON deixa de ser PreToolUse | s{hookEventName:"PreToolUse"}{hookEventName:"PostToolUse"}

--- a/scripts/mutcheck.d/migration-immutability-guard.mut
+++ b/scripts/mutcheck.d/migration-immutability-guard.mut
@@ -1,0 +1,27 @@
+# Invariantes do guard de IMUTABILIDADE DE MIGRATION (.claude/hooks/migration-immutability-guard.sh).
+# @src: .claude/hooks/migration-immutability-guard.sh
+# @test: scripts/test-migration-immutability-guard.sh
+# @test_cmd: bash
+# @compile_cmd: bash -n
+#
+# O que ele protege é a fonte de DR: editar um .sql já committado diverge repo×banco e NÃO
+# re-aplica (o apply é manual, no SQL Editor). Os dois modos de falha doem: deixar editar o
+# committed, e barrar a migration NOVA (aí o founder não consegue trabalhar).
+
+# CONTROLE+ : nunca negar reprova o caso-alvo.
+PEGA      | controle+: guard nunca nega           | s{^git -C "\$toptop" cat-file -e "HEAD:\$rel" 2>/dev/null \|\| exit 0}{exit 0}
+
+# --- medidas: 4 de 7 já eram load-bearing ---
+# O inverso: negar SEMPRE, inclusive a migration nova que ainda não está no HEAD.
+PEGA      | nega ate a migration NOVA             | s{cat-file -e "HEAD:\$rel" 2>/dev/null \|\| exit 0}{cat-file -e "HEAD:\$rel" 2>/dev/null; :}
+# A ref consultada: com HEAD~1 a migration do ÚLTIMO commit deixa de ser protegida.
+PEGA      | consulta a ref errada (HEAD~1)        | s{"HEAD:\$rel"}{"HEAD~1:\$rel"}
+# Caminho relativo some do filtro (irmão do migration-collision, mesma lacuna).
+PEGA      | filtro perde o caminho relativo       | s{ \| supabase/migrations/\*\.sql\) ;;}{) ;;}
+# TRIADO E NÃO TESTADO (teatro reverso): sem o `|| exit 0`, o $fdir fica VAZIO, o caminho
+# absoluto não cai sob o toplevel e o guard sai pela porta de contenção — comportamento
+# OBSERVÁVEL idêntico. É redundância defensiva, não invariante. Fica `?` de propósito.
+?         | dir inexistente deixa de ser allow    | s{^fdir="\$\(cd "\$\(dirname "\$fpath"\)" 2>/dev/null && pwd -P\)" \|\| exit 0}{fdir="\$(cd "\$(dirname "\$fpath")" 2>/dev/null && pwd -P)"}
+# Contrato com o host.
+PEGA      | decisao vira allow                    | s{permissionDecision:"deny"}{permissionDecision:"allow"}
+PEGA      | evento do JSON deixa de ser PreToolUse | s{hookEventName:"PreToolUse"}{hookEventName:"PostToolUse"}

--- a/scripts/test-destructive-bash-guard.sh
+++ b/scripts/test-destructive-bash-guard.sh
@@ -19,7 +19,12 @@ run() { # <command> → stdout do hook
   enc="$(printf '%s' "$1" | jq -Rs .)"
   printf '{"tool_name":"Bash","tool_input":{"command":%s}}' "$enc" | bash "$HOOK" 2>/dev/null
 }
-is_deny() { grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; }
+# Casa o CONTRATO, não o texto: sob hookEventName errado o host ignora a decisão e o comando
+# destrutivo ROda — o "deny" ficaria no stdout sem bloquear nada. (mutation-check 2026-08-20)
+is_deny() { jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"
+  and .hookSpecificOutput.permissionDecision == "deny"
+  and ((.hookSpecificOutput.permissionDecisionReason // "") | test("CONFIRM_DESTRUCTIVE"))' \
+  >/dev/null 2>&1; }
 fail=0
 d() { if run "$1" | is_deny; then echo "  ok    deny  | $1"; else echo "  FAIL  want deny  | $1"; fail=1; fi; }
 a() { if run "$1" | is_deny; then echo "  FAIL  want allow | $1"; fail=1; else echo "  ok    allow | $1"; fi; }

--- a/scripts/test-migration-immutability-guard.sh
+++ b/scripts/test-migration-immutability-guard.sh
@@ -33,7 +33,13 @@ run() { # <file_path> <tool> → stdout do hook, com CLAUDE_PROJECT_DIR apontand
   printf '{"tool_name":"%s","tool_input":{"file_path":"%s","new_string":"x","content":"x"}}' "$tool" "$fp" \
     | CLAUDE_PROJECT_DIR="$repo" bash "$HOOK" 2>/dev/null
 }
-is_deny() { grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; }
+# Casa o CONTRATO, não o texto: sob hookEventName errado o host ignora a decisão e a edição
+# no .sql committed PASSA — o snapshot de DR diverge do banco em silêncio.
+# (mutation-check 2026-08-20: a mutação do evento sobrevivia)
+is_deny() { jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"
+  and .hookSpecificOutput.permissionDecision == "deny"
+  and ((.hookSpecificOutput.permissionDecisionReason // "") | test("imutável"))' \
+  >/dev/null 2>&1; }
 
 fail=0
 expect_deny()  { if run "$1" "${3:-Edit}" | is_deny; then echo "  ok    deny  | $2"; else echo "  FAIL  want deny  | $2"; fail=1; fi; }
@@ -51,6 +57,10 @@ expect_allow "$repo/supabase/migrations/20260303000000_inexistente.sql" "migrati
 
 echo "── bypass de path normalizado (Codex 2026-06-24) → deny ──"
 expect_deny "./supabase/migrations/20260101000000_committed.sql" "path com ./ (resolve relativo ao root)" Edit
+# ...e o relativo PURO (sem ./), que é o motivo de o filtro ter DOIS padrões: o `./` já casa o
+# primeiro (`*/supabase/...`), então sem este caso remover o segundo padrão passava batido.
+# (mutation-check 2026-08-20)
+expect_deny "supabase/migrations/20260101000000_committed.sql" "path relativo puro (sem ./)" Edit
 # CLAUDE_PROJECT_DIR divergente do toplevel: rel tem de vir do git toplevel, não do prefixo textual
 if printf '{"tool_name":"Edit","tool_input":{"file_path":"%s","new_string":"x"}}' \
      "$repo/supabase/migrations/20260101000000_committed.sql" \

--- a/scripts/test-read-contexto-nudge.sh
+++ b/scripts/test-read-contexto-nudge.sh
@@ -79,6 +79,13 @@ if [ "${1:-}" = "--falsificar" ]; then
          's%chave="\${mtime}|%chave="%'
   sabota "range fora da chave"  "ler OUTRO trecho nao e releitura" \
          's%\${inicio}|\${limite}|%%'
+  # A regressao de portabilidade: voltar ao `stat -f` na frente. So o bloco (c),
+  # com o stub do contrato GNU, deixa isto vermelho — no macOS puro passaria
+  # verde, que foi exatamente como o defeito entrou (#1808). Delimitador `#`
+  # porque o padrao tem `%`.
+  sabota "stat BSD na frente"   "mtime portavel entre BSD e GNU" \
+         's#^mtime="$(stat -c '"'"'%Y'"'"'#mtime="$(stat -f '"'"'%m'"'"'#'
+
   sabota "decide permissao"     "nunca emitir permissionDecision" \
          's%hookEventName:"PreToolUse"%hookEventName:"PreToolUse", permissionDecision:"deny"%'
 
@@ -200,6 +207,94 @@ check "arquivo alterado entre leituras → silêncio" silencio "$(run "$mudou" s
 # 11. a marca é POR SESSÃO — outra sessão relendo o mesmo arquivo não herda
 _=$(run "$pequeno" s11)
 check "outra sessão, 1ª leitura → silêncio" silencio "$(run "$pequeno" s11b)"
+
+# --- (c) portabilidade da chave: os DOIS contratos do `stat` ------------------
+# A chave da releitura carrega o mtime, e `stat` DIVERGE entre BSD (macOS, do
+# founder) e GNU (Linux, do CI): no GNU `-f` é --file-system e NÃO consome
+# formato, então `stat -f '%m' arq` trata '%m' como um segundo OPERANDO — sai
+# !=0 e ainda imprime no stdout o bloco MULTI-LINHA do filesystem. Num `a || b`
+# isso concatena os dois e o mtime vira lixo de várias linhas; a chave deixa de
+# ter uma linha só, e `grep -Fx` passa a ler cada linha como um PADRÃO
+# independente: as constantes do bloco casam sempre e o hook grita "releitura"
+# justamente quando reler é LEGÍTIMO. Verde no macOS, cego no Linux — o mesmo
+# defeito já corrigido em .claude/hooks/branch-pos-squash-guard.sh.
+# Verde num ambiente NÃO prova (#1483): aqui os dois contratos são exercitados
+# por stub, e o caso (i) existe para que um mtime CONSTANTE não passe de graça.
+echo "── portabilidade do stat: a chave discrimina nos DOIS contratos ──"
+STAT_REAL="$(command -v stat || echo /usr/bin/stat)"
+
+_porta() {  # $1=nome do contrato  $2=corpo do stub de `stat`
+  local nome="$1" corpo="$2" d="$tmp/statbox-$1" alvo="$tmp/port-$1.md" o
+  mkdir -p "$d"
+  # `_m` devolve o mtime REAL resolvendo sozinho o contrato do stat de verdade
+  # (o teste roda nas duas plataformas); `$STAT_REAL` é caminho absoluto, então
+  # o stub não chama a si mesmo.
+  # shellcheck disable=SC2016  # o corpo do stub é LITERAL: $STAT_REAL/$1/$v são
+  # dele, resolvidos quando o stub roda — expandir aqui escreveria um stub vazio.
+  { printf '%s\n' '#!/bin/sh' \
+      '_m() { v="$("$STAT_REAL" -c %Y "$1" 2>/dev/null)"' \
+      '  case "$v" in ""|*[!0-9]*) v="$("$STAT_REAL" -f %m "$1" 2>/dev/null)" ;; esac' \
+      '  case "$v" in ""|*[!0-9]*) v=0 ;; esac; printf "%s" "$v"; }'
+    printf '%s\n' "$corpo"; } > "$d/stat"
+  chmod +x "$d/stat"
+
+  _run() {  # mesma forma do run() global, com o stub de stat na frente do PATH
+    jq -nc --arg f "$1" --arg s "$2" --argjson l "${3:-0}" --argjson o "${4:-0}" \
+      '{hook_event_name:"PreToolUse", tool_name:"Read", session_id:$s,
+        tool_input:({file_path:$f}
+                    + (if $l > 0 then {limit:$l} else {} end)
+                    + (if $o > 0 then {offset:$o} else {} end))}' \
+    | env PATH="$d:$PATH" STAT_REAL="$STAT_REAL" bash "$HOOK" 2>/dev/null
+  }
+
+  # (i) ainda DETECTA a releitura de verdade. Sem este caso, um mtime constante
+  #     (o próprio bug, ou um `mtime=0` fixo) passaria (ii) e (iii) de graça.
+  printf 'a\n' > "$alvo"
+  _=$(_run "$alvo" "p$nome-1")
+  o="$(_run "$alvo" "p$nome-1")"
+  if tem READ-RELEITURA "$o"
+  then ok "[$nome] 2ª leitura idêntica ainda avisa releitura"
+  else bad "[$nome] releitura idêntica parou de avisar (veio: '${o:0:60}')"; fi
+
+  # (ii) o mtime discrimina: arquivo alterado entre as leituras não é releitura
+  _=$(_run "$alvo" "p$nome-2")
+  sleep 1; printf 'b\n' >> "$alvo"
+  check "[$nome] arquivo alterado → silêncio" silencio "$(_run "$alvo" "p$nome-2")"
+
+  # (iii) o range discrimina: outro trecho é leitura complementar, não releitura
+  _=$(_run "$grande" "p$nome-3" 10 1)
+  check "[$nome] range diferente → silêncio" silencio "$(_run "$grande" "p$nome-3" 10 200)"
+}
+
+# GNU: `-c %Y` devolve o epoch; `-f` NÃO consome formato — '%m' vira operando
+# inexistente (exit !=0) e o arquivo real despeja o bloco multi-linha. É o
+# contrato exato que cegou o hook no CI.
+# shellcheck disable=SC2016  # corpo literal do stub: $1/$@ são do stub, não desta shell
+_porta gnu 'case "$1" in
+  -c) [ "$2" = "%Y" ] && { _m "$3"; exit 0; }; exit 1 ;;
+  -f) shift; rc=0
+      for op in "$@"; do
+        if [ -e "$op" ]; then
+          echo "  File: \"$op\""
+          echo "    ID: 9a1b2c3d Namelen: 255     Type: ext2/ext3"
+          echo "Block size: 4096       Fundamental block size: 4096"
+          echo "Blocks: Total: 20971520   Free: 15000000   Available: 14000000"
+          echo "Inodes: Total: 5242880    Free: 5000000"
+        else
+          echo "stat: cannot read file system information for '"'"'$op'"'"'" >&2; rc=1
+        fi
+      done
+      exit "$rc" ;;
+esac
+exit 1'
+
+# BSD: `-c` não existe (falha limpo); `-f %m` devolve o epoch.
+# shellcheck disable=SC2016  # idem
+_porta bsd 'case "$1" in
+  -c) echo "stat: illegal option -- c" >&2; exit 1 ;;
+  -f) [ "$2" = "%m" ] && { _m "$3"; exit 0; }; exit 1 ;;
+esac
+exit 1'
 
 # --- fail-safes --------------------------------------------------------------
 # 12. arquivo inexistente → silêncio (o próprio Read reporta o erro)


### PR DESCRIPTION
Continua o fechamento dos hooks. Aqui os dois de maior consequência — o que barra comando destrutivo e o que protege o snapshot de DR — mais um achado de processo que cobrou o preço logo no primeiro CI.

| guard | resultado | o que estava sem teste |
|---|---|---|
| `destructive-bash` | **8 pegas / 2 registradas** | contrato JSON |
| `migration-immutability` | **6 pegas / 1 registrada** | contrato JSON, caminho relativo puro |

## O contrato JSON, de novo

Nos dois, `is_deny` grepava o texto cru. Sob `hookEventName` errado o **host ignora a decisão**: o `"deny"` sai no stdout e o comando destrutivo **roda assim mesmo**. É o mesmo furo dos PRs anteriores, agora fechado com asserção estrutural via `jq`.

No `migration-immutability` havia ainda um caso relativo — mas com `./`, que já casa o **primeiro** padrão do filtro (`*/supabase/...`). O segundo padrão existe justamente para o relativo **puro**, e sem caso para ele podia ser removido sem nada reprovar.

## Duas mutações ficam abertas — por escolha, não por esquecimento

No `destructive-bash`, tirar a exigência de **recursão** (`rm -f *`) e a de **force** (`rm -r /`) deixa o guard **mais estrito**. Só um caso de *allow* as pegaria — e escrevê-lo **cravaria como intencional** que esses dois comandos passem.

Isso é decisão sua, não do teste. Pinar aqui transformaria uma dúvida em contrato, então deixei marcadas `?` com a nota no `.mut`. **Se você quiser que `rm -f *` e `rm -r /` sejam bloqueados, é mudança no hook** — digo e faço num PR separado.

## O achado de processo: quatro testes que nunca rodaram

`scripts/test-{bash-contexto-nudge,read-contexto-nudge,stop-contexto-caro,stop-moneypath-nudge}.sh` existiam e **nunca executaram**. O loop do `test:hooks` anexa `-guard.sh`, e esses quatro não têm o sufixo. O próprio `ci.yml` avisa: *"script fora do loop é teste órfão"*.

## O que a primeira versão deste PR afirmou errado

Ela dizia "os quatro passam". **Passavam no meu Mac.** No primeiro CI real, `read-contexto-nudge` abriu **vermelho em 2 casos** — e o `|| exit 1` do laço derrubou a cadeia ali, então `stop-contexto-caro` e `stop-moneypath-nudge` **também não chegaram a rodar** naquele run.

Isso não é regressão do PR: é o PR funcionando. A suíte órfã era "verde por não rodar", que é ausência de dado com cara de aprovação. Ao entrar no CI ela expôs um defeito real **no hook**.

## O defeito que a suíte revelou

```
mtime="$(stat -f '%m' "$arq" 2>/dev/null || stat -c '%Y' "$arq" 2>/dev/null || echo 0)"
```

No BSD (macOS) `-f` é o formato e devolve o epoch. No GNU (Linux/CI) `-f` é `--file-system` e **não consome formato**: `'%m'` vira um **operando** inválido, então o stat sai `!=0` — disparando o `||` — mas **antes já despejou no stdout o bloco multi-linha do filesystem**. Os dois se concatenam e o `mtime` vira lixo de 6 linhas.

A chave da marca de sessão deixa de ter uma linha só. Aí `grep -Fx` passa a ler **cada linha como um padrão independente**: as constantes do bloco casam sempre, `vistas > 0` em toda leitura, e o hook aconselha *"role para cima e use o que já leu"* justamente quando reler é **legítimo** — outro trecho do arquivo, ou arquivo alterado desde a última leitura. Falha **aberta**: conselho errado, não silêncio.

Consertei o **hook**, não a asserção. As duas asserções descrevem o desenho que o próprio hook declara em comentário (mtime na chave porque reler arquivo alterado é legítimo; range na chave porque outro trecho é leitura complementar), e o modo `--falsificar` já exigia que ambas soubessem ficar vermelhas.

Correção = o padrão canônico que `branch-pos-squash-guard.sh` **já adotou** (2026-08-18, mesmo defeito, mesma descoberta ao entrar no CI): **GNU primeiro, validando NÚMERO**. A validação numérica é a trava real — qualquer lixo vira `0` e a chave fica garantidamente de uma linha.

## A trava, porque verde num ambiente não prova (#1483)

Bloco `(c)` novo exercita os **dois contratos de `stat`** por stub, e a sabotagem `"stat BSD na frente"` exige vermelho. O caso `(i)` de cada contrato existe para que um `mtime` **constante** não passe `(ii)` e `(iii)` de graça.

Medido: sob essa sabotagem, a **única** asserção que fica vermelha é `[gnu] arquivo alterado`. Sem o bloco novo, a regressão passaria verde no macOS — que foi exatamente como o defeito entrou.

## Evidência

```
bun run test:hooks                 EXIT=0   (13 suítes: 8 guards + 5, era 9)
  └─ as 5 do 2º laço executaram: wt-status, bash-contexto-nudge,
     read-contexto-nudge, stop-contexto-caro, stop-moneypath-nudge
--falsificar                       EXIT=0   6 sabotagens × 2 locales (C e pt_BR.UTF-8)
reprodução do vermelho do CI       stub do contrato GNU no macOS → as MESMAS 2 falhas
shellcheck (5 .sh tocados)         EXIT=0
mutcheck destructive-bash          8 pegas · 2 registradas · 0 inválidas · controle+ ok
mutcheck migration-immutability    6 pegas · 1 registrada · 0 inválidas · controle+ ok
```

Conflito com a `main` resolvido por **união** dos dois laços — o `wt-status` que o #1838 registrou continua na lista (perdê-lo reintroduziria o órfão que aquele PR acabou de fechar).

## Fica registrado, não resolvido aqui

O `|| exit 1` do laço faz a **primeira** falha esconder as seguintes — foi por isso que duas suítes não tiveram medição nenhuma no run vermelho. Rodar todas e agregar no fim daria cobertura por run, mas é mudança de forma do `test:hooks` e não entra neste PR.

Falta ainda: contrato para `edge-guardrail` e para os 4 nudges recém-ligados. Vai em PR seguinte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
