### PR TITLE
docs(historico): o veredito da RPC agregada de vendáveis se mantém — o gate de paginação exigiria `.range()` de quem nasceu para não paginar

### DIFF
--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -457,6 +457,21 @@ catálogo ativo, num domínio account-aware — mais grave que a inconsistência
 ofertado" é **frouxa por construção**: um SKU lido na 1ª página pode perder a margem antes de o cálculo
 terminar, e nem a RPC agregada fecha isso — só revalidação server-side na transação da persistência.
 
+**Reaberto e mantido em 2026-08-20 — e a conta acima estava INCOMPLETA.** O veredito segue de pé, agora
+por um motivo que não existia quando ele foi dado: o gate `rpc-set-returning-paginacao-gate`, nascido no
+mesmo 2026-08-19 (#1801), deriva "quem é set-returning" do `types.ts` e **exigiria `.range()` na função
+criada justamente para não paginar**. `RETURNS uuid[]` gera `Returns: string[]`, e o segundo padrão do
+classificador (`/Returns:\s*\w+\[\]/`) o captura — medido rodando o próprio `nomesSetReturning` contra a
+assinatura que o Supabase geraria, não deduzido da leitura do regex. A ironia é que a INTENÇÃO declarada
+do gate é o oposto ("Escalar não sofre capa de LINHAS"): a lacuna está no classificador, hoje inerte
+porque nenhuma função do schema retorna array escalar — a agregada seria a primeira a expô-la. Quem a
+fizer paga também o ajuste do classificador com falsificação própria; pôr a entrada na BASELINE seria
+registrar como dívida a própria correção, dentro do gate que existe para a lista não crescer. Custo
+remedido: **15** arquivos de teste tocam a RPC por nome (não ~14), e os consumidores são mesmo dois —
+`useFarmerScoring` só a cita em comentário. E o que a agregada compra continua sendo RECALL (SKU pulado,
+oferta menor), não a PRECISÃO do parágrafo anterior: pelo princípio nº1, o OFFSET já erra para o lado
+certo.
+
 ## A capa de 1.000 do PostgREST na 2ª RPC — `get_carteira_margem_faixa` fabricava faixa `neutro` (#1801)
 
 Irmão do #1782, achado enquanto se conferia se aquele fix já cobria a tarefa. Mesma classe, outro


### PR DESCRIPTION
## O que é

A tarefa da **RPC agregada `get_skus_margem_positiva_ids`** foi reaberta em 2026-08-20. O founder decidiu **manter** a escolha de 2026-08-19 (não implementar). Este PR não implementa nada — ele **completa a conta** que sustenta o veredito, porque ela estava incompleta.

Zero mudança de código de produção, SQL ou migration. Só `docs/historico/bugs-resolvidos.md`.

## O motivo novo, que não existia quando o veredito foi dado

O gate `rpc-set-returning-paginacao-gate` nasceu no **mesmo 2026-08-19** (#1801) e deriva "quem é set-returning" do `types.ts`. `RETURNS uuid[]` gera `Returns: string[]`, e o segundo padrão do classificador (`/Returns:\s*\w+\[\]/`) o captura — logo **o gate exigiria `.range()` exatamente na função desenhada para fazer UM round-trip**.

Medido, não deduzido da leitura do regex: rodei o próprio `nomesSetReturning` (extraído por `sed`, regex intacto) contra a assinatura que o Supabase geraria.

```
classificadas como set-returning: ["get_skus_margem_positiva","get_skus_margem_positiva_ids"]
a NOVA foi capturada pelo gate? true
```

A ironia é que a **intenção declarada** do gate é o oposto — *"Escalar não sofre capa de LINHAS"*. A lacuna está no classificador, hoje **inerte** porque nenhuma função do schema retorna array escalar (confirmado: `grep -E "Returns: (string|number|boolean|Json)\[\]"` no `types.ts` volta vazio). A agregada seria a primeira a expô-la.

Quem for fazer a agregada paga também esse ajuste, com falsificação própria. E pôr a entrada na `BASELINE` seria registrar como dívida a própria correção, dentro do gate que existe para a lista não crescer.

## Custo remedido

- **15** arquivos de teste tocam a RPC por nome (a conta anterior dizia ~14).
- Consumidores são mesmo **dois** (`useBundleEngine`, `useCrossSellEngine`). `useFarmerScoring` só a cita em comentário — não é chamador.

## Por que o veredito continua certo

O que a agregada compra é **recall** (SKU pulado → oferta menor). Não compra a **precisão** — o SKU que perde margem durante o cálculo, que só revalidação server-side na transação da persistência fecha. Pelo princípio nº1 do money-path, o OFFSET já erra para o lado certo.

## Verificação

- `heavy bun run test` → **6469/6470**. A única falha, `SalesQuotes.accountGuard.test.tsx`, é **flakiness de timeout sob carga** (`findByRole` não achou "Enviar Pedido"), não relacionada a uma mudança de markdown: passa **3/3 isolada**. Registrada à parte.
- Rebaseado em `8a96e4ad`; `git grep get_skus_margem_positiva_ids origin/main` confirma que ninguém pegou o tema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)