### PR TITLE
docs(agent): docs/ux-audit/ era invisível a partir do índice — o mapa do app a adota como PROVENIÊNCIA, não backlog

### DIFF
--- a/docs/agent/mapa-do-app.md
+++ b/docs/agent/mapa-do-app.md
@@ -69,4 +69,17 @@ Os 6 compromissos de produto que o app assumiu, com o estado de cada um. Valem c
 
 Ao mexer no estado de um deles, atualize a coluna aqui — o CLAUDE.md não carrega mais este placar.
 
+## De onde vieram esses padrões — a auditoria de UX (`docs/ux-audit/`, EXECUTADA)
+
+O placar acima e boa parte do §Design System do CLAUDE.md saíram de uma auditoria de UX em 4 fases (2026-05-13), arquivada em **[`docs/ux-audit/`](../ux-audit/)**. Ela está **entregue, 20/20** — leia-a como **proveniência ("por que a regra é essa"), nunca como backlog**: o `03-roadmap.md` é um plano de 20 itens JÁ executado, e reimplementá-lo é retrabalho puro.
+
+| Arquivo | O que é | Por que ainda se lê |
+|---|---|---|
+| [01-inventario.md](../ux-audit/01-inventario.md) | as 119 rotas com persona / densidade / plataforma / frequência / criticidade | o complemento deste mapa: aqui está o **módulo**, lá está **quem usa e se a operação para se a tela cair**. Snapshot datado — a rota exata segue sendo `grep` no `App.tsx` |
+| [02-heuristica.md](../ux-audit/02-heuristica.md) | Nielsen H1-H10 + domínio D1-D6 nas 10 telas top | o diagnóstico por trás de cada intervenção, e o vocabulário Retool: desktop-only assumido sem se desculpar (`:133`), atalhos `j/k` em lista (`:416`) |
+| [03-roadmap.md](../ux-audit/03-roadmap.md) | as 20 intervenções priorizadas por ICE | **a origem das regras vivas**: `:94` = Carbon Touch Target (44×44 mín, 56×56 para uso com luva) → `<Button size="touch">` e `balcao`; `:332` = Carbon tokens (todo sinal via token, nunca cor crua) → a regra `text-status-*`; `:270` = bulk actions do Retool |
+| [04-execucao.md](../ux-audit/04-execucao.md) | o que saiu, item a item (intervenção → arquivo tocado) | o que ficou **pendente de decisão do founder**: schema de `nfe_receipt_runs`/`user_segments` (hoje localStorage), tamanho do catálogo tintométrico offline, dual-view do picking mobile, política de conflito offline |
+
+Por que isto mora aqui e não no CLAUDE.md: é **arquivo de proveniência**, não regra que vale sempre — as regras que sobreviveram já estão no CLAUDE.md §Design System. O elenco de benchmarks (o que se toma de Carbon, Retool, Linear, Notion e Polaris — e por que Material 3 e Bootstrap são anti-referência) está consolidado em [`docs/visual-direction/01-direcao.md`](../visual-direction/01-direcao.md) §7. **Já custou uma sessão** concluir que "Carbon e Retool eram conhecimento perdido" por procurar só em `docs/visual-direction/`: quando a pergunta for *de onde veio essa decisão de UI*, os dois lugares são esta pasta e aquela §7.
+
 > Manutenção: quando um módulo NOVO nascer (prefixo novo no `App.tsx`), acrescente 1 linha aqui. Telas individuais que mudam de rota NÃO precisam entrar — o `grep` no `App.tsx` é a fonte exata.

--- a/docs/ux-audit/03-roadmap.md
+++ b/docs/ux-audit/03-roadmap.md
@@ -3,6 +3,8 @@
 > Data: 2026-05-13 · 20 intervenções derivadas dos padrões transversais e telas críticas da Fase 2. Ordenadas por ICE = Impact × Confidence × Ease (max 1000).
 >
 > **Esta fase NÃO toca em código.** A execução acontece na Fase 4, sob comando explícito por intervenção.
+>
+> **Estado: EXECUTADO — 20/20.** Isto é registro de **proveniência** ("de onde veio a regra"), **não backlog**: o que de fato saiu, item a item, está em [04-execucao.md](04-execucao.md), e as regras que sobreviveram vivem no CLAUDE.md §Design System. Antes de "implementar" qualquer item daqui, confira o 04 — reimplementar é retrabalho puro.
 
 ---
 

--- a/docs/visual-direction/01-direcao.md
+++ b/docs/visual-direction/01-direcao.md
@@ -282,10 +282,10 @@ Atenção ao ler a §1: ali **Polaris**, **Notion** e **Material** aparecem desc
 |---|---|---|
 | **Vercel · Mercury · Stripe Dashboard** | Direção primária: tipografia geométrica, tabular nums, border > sombra, easing próprio | §2-§5 · tokens de `src/index.css` |
 | **Linear** | Quase-neutro que aguenta jornada longa; densidade alta como **escolha**, não como aperto | Decisão A1 e D1 (§5) · `src/index.css:306` |
-| **Notion** | Navegação por seções, Recentes/Favoritos na sidebar, stagger na expansão | `05-revisao-skill.md` SB1/SB2 · `docs/ux-audit/03-roadmap.md:141` |
-| **Polaris** (Shopify) | Componentes de dado B2B: EmptyState compacto, ResourceList | `docs/ux-audit/03-roadmap.md:221,268` |
-| **Carbon** (IBM) | **Rigor de sistema, não estética** — (a) *design tokens*: todo sinal semântico via token, nunca cor crua; (b) *touch target spec*: 44×44 mínimo, 56×56 para uso com luva | A regra `text-status-*` (em vez de `text-emerald-600`) vem de `03-roadmap.md:330`; `<Button size="touch">` 44px e `balcao` 56px vêm de `03-roadmap.md:92` |
-| **Retool** | O vocabulário de **ferramenta interna**: a tabela densa é a superfície principal — bulk actions, atalhos `j/k`, e tela de gestão pode ser desktop-only sem se desculpar | `src/index.css:306` (32px densos em ponteiro fino, decisão explícita) · `docs/ux-audit/02-heuristica.md:133,416` · `03-roadmap.md:268` |
+| **Notion** | Navegação por seções, Recentes/Favoritos na sidebar, stagger na expansão | `05-revisao-skill.md` SB1/SB2 · `docs/ux-audit/03-roadmap.md:143` |
+| **Polaris** (Shopify) | Componentes de dado B2B: EmptyState compacto, ResourceList | `docs/ux-audit/03-roadmap.md:223,270` |
+| **Carbon** (IBM) | **Rigor de sistema, não estética** — (a) *design tokens*: todo sinal semântico via token, nunca cor crua; (b) *touch target spec*: 44×44 mínimo, 56×56 para uso com luva | A regra `text-status-*` (em vez de `text-emerald-600`) vem de `03-roadmap.md:332`; `<Button size="touch">` 44px e `balcao` 56px vêm de `03-roadmap.md:94` |
+| **Retool** | O vocabulário de **ferramenta interna**: a tabela densa é a superfície principal — bulk actions, atalhos `j/k`, e tela de gestão pode ser desktop-only sem se desculpar | `src/index.css:306` (32px densos em ponteiro fino, decisão explícita) · `docs/ux-audit/02-heuristica.md:133,416` · `03-roadmap.md:270` |
 
 Carbon e Retool entram exatamente onde as três primárias **não alcançam**: Vercel/Mercury/Stripe são produtos de sessão curta e superfície pequena; o Afiação é operação de 8h com tabela densa, coletor e luva. Carbon dá a régua de sistema (token semântico e alvo de toque), Retool o precedente de densidade — juntos são o que sustenta `density-compact` global convivendo com `size="balcao"` de 56px na mesma base de código.
 


### PR DESCRIPTION
## O problema

`docs/ux-audit/` (4 docs, 120KB) é a fonte real de regras que HOJE vivem no `CLAUDE.md` — `<Button size="touch">` 44px / `balcao` 56px, e a regra `text-status-*` em vez de `text-emerald-600`. Mas a pasta **não era citada em nenhum arquivo de `docs/agent/`**, o índice que todo agente lê.

**Custo já pago:** em 2026-08-20 uma sessão concluiu que `Carbon`, `Retool` e `Material 3` eram "conhecimento perdido" por procurar só em `docs/visual-direction/`. Carbon e Retool estavam documentados o tempo todo. O #1803 corrigiu o **sintoma** (criou a §7 que faz a ponte); a causa — invisibilidade a partir do índice — seguia.

## Verificação de cobertura (a mesma armadilha que gerou o problema)

Varri `docs/` **e** `src/` inteiros com `command grep` (o `grep` daqui é shim de `ugrep`, que dá falso positivo por match aproximado). Antes deste PR, exatamente 2 arquivos citavam a pasta: `docs/historico/auditoria-ux-redesign.md` e `docs/visual-direction/01-direcao.md`.

## A saída escolhida: (b), ponteiro a partir de doc já indexado

Nova seção em [`docs/agent/mapa-do-app.md`](docs/agent/mapa-do-app.md) — **custo ZERO no orçamento do `CLAUDE.md`**, que fica intacto (16678B / 2200w, `claude:size` exit 0).

**Por que NÃO (a) linha no índice:** a tabela indexa `docs/agent/*` e se lê *"LEIA o doc ANTES de tocar o domínio"*. Uma auditoria **encerrada** de 120KB não é referência operacional — a semântica da tabela quebraria, e a linha custaria palavras de um teto apertado para hospedar um arquivo morto.

**Por que NÃO (c) consolidar/mover:** conferi o `04-execucao.md` antes de assumir, como pedido — a auditoria está **20/20 executada** (2026-05-13). Mas o valor residual dela não é backlog: é ser um snapshot **datado** com as referências nominais linha-a-linha. Mover destruiria justamente as citações que a §7 usa para provar de onde vem cada regra.

**Por que `mapa-do-app.md` é o hospedeiro certo** (mais forte do que a suposição inicial): `01-inventario.md` são as 119 rotas mapeadas de `App.tsx` com persona/densidade/criticidade — é literalmente o assunto desse doc; e o placar de "Princípios não-negociáveis" é **o que a auditoria mediu** (princípio 4 "44px touch" = Carbon `:94`; princípio 3 `density-compact` = Retool; princípio 1 offline-first = itens #16/#17/#19).

## O achado colateral: o doc mentia sobre o próprio estado

`03-roadmap.md` são 36KB que leem como backlog vivo de 20 itens — estando **20/20 entregues**. Quem cair ali reimplementa trabalho feito. Ganhou **1 linha** de estado ("EXECUTADO — 20/20, isto é proveniência, não backlog").

Isso **deslocou as citações de linha em +2**, inclusive as 5 que o #1803 gravou. Corrigidas e **todas re-verificadas por conteúdo**, não por confiança:

| citação | conteúdo real na linha |
|---|---|
| `03-roadmap.md:94` | "Carbon Touch Target spec (44×44 mínimo… 56×56 para uso com luva)" |
| `03-roadmap.md:143` | "Recentes/Favoritos do Notion sidebar" |
| `03-roadmap.md:223` | "Polaris EmptyState compact" |
| `03-roadmap.md:270` | "bulk actions bar do Retool table" |
| `03-roadmap.md:332` | "Carbon Design tokens system" |

**Falsificação:** sabotei o arquivo com 1 linha extra e o verificador ficou **vermelho (exit 1, 5 falhas)** — provando que discrimina; restaurei por backup (`cmp` = 0) e voltou a exit 0, 13 OKs.

## Gates

- `bun run claude:size` → **exit 0** (CLAUDE.md não foi tocado — `git status` vazio para ele)
- `bun run docs:indice` → **exit 0**

Nota: `docs/ux-audit/` não tem README, e o gate `docs:indice` cobre só diretórios **com** README ("ter README é a declaração de 'aqui há índice'") — é exatamente por isso que a pasta nunca foi cobrada. Considerei adicionar um README para opt-in no gate, mas ele não ajuda quem nunca chega à pasta, e adiciona superfície de gate a um arquivo congelado. O ponteiro a partir do índice resolve a causa; o README resolveria um problema que ninguém tem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)