### PR TITLE
fix(financeiro): medi as 11 RPCs sem teto — uma estava a 88% da capa, e o gate só enxergava aspas simples [money-path]

### DIFF
--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -514,3 +514,66 @@ ignora a escalar, e tolera comentário longo entre `.rpc()` e `.range()`. Essa �
 falso positivo real: a primeira medição acusou o **próprio fix do #1782**, porque o comentário
 entre as duas chamadas estourava a janela. Gate inerte é o pior desfecho — passa verde para sempre
 e ninguém percebe.
+
+## A classe do cap de 1.000 nas RPCs: medir 15, paginar 2 — e o scanner que só via aspas simples (2026-08-20)
+
+Terceiro capítulo da classe (#1782, #1801). Desta vez o pedido não era achar mais um caso, era
+**fechar o universo**: as 11 RPCs set-returning sem teto interno estavam na BASELINE do gate com um
+motivo honesto porém cego — "`claude_ro` não tem EXECUTE, então não pude MEDIR".
+
+**O motivo caiu.** Dá para medir sem EXECUTE: ler `pg_get_functiondef` e reproduzir o corpo como
+SELECT sobre a prod (psql-ro). Medidas 15 chamadas em 2026-08-20. O resultado surpreende na direção
+contrária à esperada — **9 tinham teto ESTRUTURAL provado pela própria definição**, não por sorte de
+volume: `fin_projecao_13_semanas` é `FOR i IN 0..12` (13 linhas, sempre); `fin_consolidado_intercompany`
+é `UNION ALL` de 4 agregados; `fin_estimar_estoque_omie` e `get_whatsapp_funil` são um SELECT agregado
+sem GROUP BY (1 linha); `get_data_health` são 25 ramos de UNION ALL; `staff_get_sales_order_payload`
+recebe `[id]` em 2 dos 3 callers. Outras 4 têm teto nos dados, com folga: `get_ultimos_precos_cliente`
+407 (é `DISTINCT ON (product_id)` — o cliente de maior variedade), `get_whatsapp_proposta_cotacao` ≤412,
+`staff_get_sales_order_payload` no dashboard de impressão 68 (o lote é o de UM dia; pior dia da
+história = 68), `list_impersonation_targets` 3.
+
+**Uma passou:** `fin_analise_cp_dimensoes_rpc`, com **877 linhas** no pior caso REAL da tela — que é o
+estado INICIAL dela, mês = "todos" e empresa `all`. 88% da capa, e a série anual é monotônica:
+407 (2020) → 483 → 546 → 614 → 770 → **877** (2025), ~14% ao ano. `877 × 1,14 = 999,8`: a própria
+série prevê consumir toda a folga na safra seguinte. E 1.000 exatos são ambíguos por construção — não
+há como distinguir "acabou aqui" de "foi truncado". O consumidor **agrega** (`+=` de `qtd_titulos` e
+dos três totais) num Map por dimensão, então o truncamento não esvaziaria a tela: encolheria cada
+total em silêncio, e um "contas a pagar por categoria" 12% menor é indistinguível de um mês fraco.
+Paginada junto a `fin_analise_cr_dimensoes_rpc` (138, folga de 7×) — mesmo caller, mesmo `rpcParams`,
+mesmo `if/else`: paginar um ramo só deixaria uma assimetria que o próximo leitor teria de re-medir.
+
+**A ordem estável, que é o que faz paginação funcionar.** As matviews são AGREGADAS e não têm `id`. A
+chave é o `GROUP BY` inteiro (11 colunas), e a garantia não é estatística: o `REFRESH … CONCURRENTLY`
+do cron `fin-refresh-analise-dimensoes` **exige** índice UNIQUE, e ele existe (`idx_fin_analise_c{p,r}_unique`)
+sobre exatamente essas colunas menos `categoria_descricao`. Superconjunto de chave única é chave única.
+A contagem `count(*) = count(DISTINCT (…))` (4.693 e 622) só confirma o que o índice já impõe — era a
+prova fraca, e o Codex apontou.
+
+**O furo que o Codex achou e que valia mais que o resto:** o scanner do gate casava só
+`.rpc('nome')` — **aspas simples**. `src/` tem 10 chamadas `.rpc("nome")`, duas delas set-returning
+(`fin_projecao_13_semanas` em `CaixaCompraCard`, `ciclo_oportunidade_do_dia` em
+`AdminReposicaoOportunidades`). Enquanto o furo existiu, a frase "a BASELINE enumera a dívida" era
+**falsa**: o gate não olhava o universo que dizia vigiar, e o verde vinha de não ter procurado — a
+versão-scanner do `Number(null)===0`. As duas entraram na lista (ambas com teto estrutural).
+
+**O resíduo durável — waiver com prova e prazo.** A BASELINE deixou de ser `Set<string>` e virou
+`Map<string, Waiver>` com três formas: `estrutural` (a definição limita; NÃO expira, porque definição
+só muda por `CREATE OR REPLACE`, que passa pelo ritual de migration — dado é que cresce sozinho),
+`medido` (fotografia da prod, com `medidoEm` + `revisarAte`, e a query da medição escrita no campo
+`prova`) e `nao_medido` (dívida sem número, prazo mais curto). Três regras novas no CI: teto medido
+acima de **500** (metade da capa — o universo precisa DOBRAR para romper) não recebe waiver, tem de
+paginar; waiver vencido reprova; waiver sem prova escrita reprova. As regras são funções PURAS com
+fixtures de falsificação — regra de gate inerte passa verde para sempre e ninguém desconfia.
+Recusado do parecer do Codex o `definitionHash` para os estruturais: o gate roda no CI **sem banco**,
+o hash só poderia ser do arquivo de migration, e neste repo a prod diverge do repo por apply manual —
+daria verde com a prod já mudada e vermelho num refactor que não mudou a prod.
+
+**Limite conhecido, documentado no código:** páginas são requests HTTP distintos e não compartilham
+snapshot; o cron de refresh roda às 10h e 16h. Um refresh entre duas páginas pode pular/repetir linha
+apesar da ordem total. Hoje o risco é nulo (877 cabem na 1ª página, o laço encerra sem 2ª requisição)
+e nasce junto com o rompimento da capa. Mesmo então paginar é estritamente melhor: janela de dois
+instantes por dia contra perda GARANTIDA de toda a cauda, todo dia. A cura real é agregar server-side.
+
+**Sobrou para a 2ª fatia:** as 8 com `LIMIT` no corpo — `LIMIT` não é garantia (`LIMIT p_limit` com
+parâmetro grande não protege), e `reposicao_pos_candidatos` é money-path. Estão marcadas `nao_medido`
+com prazo, não "provavelmente pequenas".

--- a/src/__tests__/rpc-set-returning-paginacao-gate.test.ts
+++ b/src/__tests__/rpc-set-returning-paginacao-gate.test.ts
@@ -25,17 +25,22 @@ import { resolve, join } from 'node:path';
  * `types.ts` gerado do schema (`Returns: {...}[]`), então RPC nova entra sozinha na vigilância
  * — não há lista para alguém esquecer de atualizar.
  *
- * A BASELINE abaixo é dívida ENUMERADA, não aprovada. São as 23 chamadas que já existiam
- * quando o gate nasceu, e o motivo de estarem aqui em vez de corrigidas é honesto: `claude_ro`
- * não tem EXECUTE nessas funções, então eu não pude MEDIR o universo de cada uma, e paginar no
- * escuro mudaria comportamento de reposição/financeiro/pricing sem prova. Fabricar uma
- * justificativa por linha ("universo pequeno") seria exatamente o `Number(null)===0` da
- * apuração. O gate impede a lista de CRESCER e obriga a encolher: entrada que some do código
- * tem de sair daqui também.
+ * A BASELINE abaixo é dívida ENUMERADA, não aprovada, e o gate impede a lista de CRESCER e
+ * obriga a encolher: entrada que some do código tem de sair daqui também.
  *
- * ⚠️ Estar na baseline NÃO é atestado de segurança. Três são de risco money-path conhecido —
- * `get_ultimos_precos_cliente` (preço de partida), `reposicao_pos_candidatos` e
- * `get_carteira_margem_faixa`-like — e continuam registradas como chip do founder.
+ * Quando o gate nasceu (2026-08-19) as 23 entradas tinham um motivo honesto porém CEGO —
+ * `claude_ro` não tem EXECUTE nessas funções, então o universo de cada uma era desconhecido, e
+ * paginar no escuro mudaria comportamento de reposição/financeiro/pricing sem prova. Em
+ * 2026-08-20 esse motivo caiu para 15 delas: dá para medir sem EXECUTE, lendo
+ * `pg_get_functiondef` e reproduzindo o corpo como SELECT sobre a prod (psql-ro). Duas passaram
+ * a paginar e saíram; as outras trocaram o palpite por um teto com prova. Sobraram 8 sem número
+ * — marcadas `nao_medido`, não "provavelmente pequeno", que seria o `Number(null)===0` da
+ * apuração.
+ *
+ * ⚠️ Estar na baseline NÃO é atestado de segurança, e o waiver não é texto livre: cada entrada
+ * declara a PROVA do teto e, quando essa prova envelhece (medição em dados), um PRAZO. O que
+ * mora aqui é uma chamada que o gate CONSEGUE ver — durante um tempo o scanner só reconhecia
+ * `.rpc('…')` com aspas simples, e a própria frase "a baseline enumera a dívida" era falsa.
  */
 
 const RAIZ = resolve(__dirname, '../..');
@@ -65,9 +70,17 @@ export function nomesSetReturning(types: string): Set<string> {
 export function chamadasSemPaginacao(fonte: string, setReturning: Set<string>): string[] {
   const txt = semComentarios(fonte);
   const achados: string[] = [];
-  for (const m of txt.matchAll(/\.rpc\(\s*'([a-z0-9_]+)'/g)) {
-    if (!setReturning.has(m[1])) continue;
-    if (!/\.range\(/.test(txt.slice(m.index!, m.index! + 400))) achados.push(m[1]);
+  // ASPAS SIMPLES **OU DUPLAS**. O regex original só via `'` e por isso deixava passar
+  // `supabase.rpc("nome")` — que não é hipótese: `src/` tem 10 chamadas assim, duas delas
+  // set-returning (`fin_projecao_13_semanas` em CaixaCompraCard, `ciclo_oportunidade_do_dia`
+  // em AdminReposicaoOportunidades). Enquanto o furo existiu, a frase "a baseline enumera a
+  // dívida" era FALSA: o gate não olhava para o universo inteiro que dizia vigiar, e o
+  // veredito verde vinha de não ter procurado — a versão-scanner do `Number(null)===0`.
+  // (Achado do Codex xhigh na revisão deste PR; conferido com `git grep '\.rpc("'`.)
+  for (const m of txt.matchAll(/\.rpc\(\s*(?:'([a-z0-9_]+)'|"([a-z0-9_]+)")/g)) {
+    const nome = m[1] ?? m[2];
+    if (!setReturning.has(nome)) continue;
+    if (!/\.range\(/.test(txt.slice(m.index!, m.index! + 400))) achados.push(nome);
   }
   return achados;
 }
@@ -84,32 +97,140 @@ function arquivosFonte(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-/** Dívida existente quando o gate nasceu (2026-08-19). NÃO é aprovação — ver cabeçalho. */
-const BASELINE = new Set<string>([
-  'carteira_por_municipio @ src/hooks/useRoutePlanner.ts',
-  'fin_analise_cp_dimensoes_rpc @ src/services/financeiroV2Service.ts',
-  'fin_analise_cr_dimensoes_rpc @ src/services/financeiroV2Service.ts',
-  'fin_consolidado_intercompany @ src/pages/FinanceiroIntercompany.tsx',
-  'fin_estimar_estoque_omie @ src/hooks/useEstoqueValor.ts',
-  'fin_projecao_13_semanas @ src/hooks/dashboard/useFinanceiroZone.ts',
-  'fin_regua_condicao_prazo @ src/hooks/useCustoPrazoRegua.ts',
-  'gerar_pedidos_sugeridos_ciclo @ src/pages/AdminReposicaoPedidos.tsx',
-  'get_data_health @ src/hooks/useDataHealth.ts',
-  'get_ultimos_precos_cliente @ src/hooks/unifiedOrder/useCustomerSelection.ts',
-  'get_whatsapp_funil @ src/hooks/useWhatsappFunil.ts',
-  'get_whatsapp_pendentes @ src/hooks/useWhatsappPendentes.ts',
-  'get_whatsapp_proposta_cotacao @ src/pages/RotaPropostas.tsx',
-  'list_impersonation_targets @ src/hooks/useImpersonationTargets.ts',
-  'listar_pedidos_a_separar @ src/queries/usePedidosASeparar.ts',
-  'radar_contagem_por_municipio @ src/queries/useRadarCidadesRota.ts',
-  'radar_prospects_para_rota @ src/hooks/useRoutePlanner.ts',
-  'reposicao_pos_candidatos @ src/pages/AdminReposicaoPedidos.tsx',
-  'reposicao_pos_marcador @ src/pages/AdminReposicaoPedidos.tsx',
-  'reverter_run_auto @ src/hooks/useParamAutoMudancas.ts',
-  'staff_get_sales_order_payload @ src/components/salesOrderEdit/useSalesOrderEdit.ts',
-  'staff_get_sales_order_payload @ src/components/salesOrders/useSalesOrderDetail.ts',
-  'staff_get_sales_order_payload @ src/pages/SalesPrintDashboard.tsx',
+/**
+ * Folga mínima para uma chamada MEDIDA continuar sem paginar: metade da capa.
+ *
+ * Abaixo de 500 o universo precisa DOBRAR para romper os 1.000. Nas séries que medi o
+ * crescimento é de ~14% ao ano no pior caso — anos de margem, e um intervalo que cabe numa
+ * re-medição. Acima disso a distância vira uma safra de dados e o modo de falha não avisa.
+ * Foi por esta régua que `fin_analise_cp_dimensoes_rpc` saiu daqui: 877 medidos, 88% da capa.
+ * (O Codex propôs 80%; recusado por ser folga de 1,25× — uma única safra de 14% consome
+ * metade dela e o waiver continuaria verde.)
+ */
+const FOLGA_MINIMA = 500;
+
+/**
+ * Por que uma chamada pode ficar sem `.range()`. Não é texto livre: cada forma carrega a
+ * PROVA e, quando a prova envelhece, um PRAZO — um waiver que só o autor sabe interpretar é
+ * indistinguível de nenhum waiver.
+ *
+ * `estrutural` — a DEFINIÇÃO da função limita as linhas (`FOR i IN 0..12`, `UNION ALL` de
+ *   agregados, `RETURN NEXT` fora de laço, `WHERE id = ANY(arr)` com o caller passando `[id]`).
+ *   NÃO expira, e a diferença é de mecanismo, não de gosto: dado cresce sozinho, todo dia, sem
+ *   ninguém decidir nada; definição só muda por `CREATE OR REPLACE`, que neste repo passa pelo
+ *   ritual de migration + SQL Editor. O que protege o teto estrutural é aquele ritual, não um
+ *   prazo aqui. (O Codex pediu um `definitionHash` que revalidasse o estrutural. RECUSADO: o
+ *   gate roda no CI SEM banco, então o hash só poderia ser do arquivo de migration — e neste
+ *   repo a prod DIVERGE do repo por apply manual, o próprio motivo de o CLAUDE.md mandar
+ *   conferir `pg_get_functiondef` antes de qualquer replace. O hash daria verde com a prod já
+ *   mudada e vermelho num refactor de migration que não mudou a prod: falsa precisão nos dois
+ *   sentidos.)
+ *
+ * `medido` — contei o pior caso sobre os valores REAIS de parâmetro na prod. É uma fotografia:
+ *   verdadeira no dia, e por isso tem `medidoEm` + `revisarAte`. Vencido o prazo, o gate
+ *   reprova até alguém re-rodar a contagem que está em `prova`.
+ *
+ * `nao_medido` — dívida honesta: não sei o universo. Prazo mais CURTO que o do medido, porque
+ *   é a pior das três e a única que não tem número nenhum por trás.
+ */
+type Waiver =
+  | { tipo: 'estrutural'; teto: number; prova: string }
+  | { tipo: 'medido'; teto: number; prova: string; medidoEm: string; revisarAte: string }
+  | { tipo: 'nao_medido'; bloqueio: string; revisarAte: string };
+
+/**
+ * A dívida que existia quando o gate nasceu (2026-08-19), agora com o teto de cada entrada.
+ *
+ * Ao nascer, o gate registrou as chamadas com um motivo honesto porém cego: `claude_ro` não tem
+ * EXECUTE nessas funções, logo o universo era desconhecido. Em 2026-08-20 medi 15 delas por
+ * outra via — `pg_get_functiondef` + reprodução do corpo como SELECT sobre a prod (psql-ro).
+ * Duas ganharam paginação e saíram (`fin_analise_c{p,r}_dimensoes_rpc`); as demais trocaram o
+ * palpite por um número. Nenhuma linha aqui diz "universo provavelmente pequeno": ou tem prova,
+ * ou está marcada `nao_medido`.
+ */
+const BASELINE = new Map<string, Waiver>([
+  // ── Teto ESTRUTURAL: a definição limita, medido em 2026-08-20 ───────────────────────────
+  ['fin_projecao_13_semanas @ src/hooks/dashboard/useFinanceiroZone.ts',
+    { tipo: 'estrutural', teto: 13, prova: '`FOR i IN 0..12 LOOP … RETURN NEXT` — 13 linhas, sempre' }],
+  ['fin_projecao_13_semanas @ src/components/reposicao/pedidos/CaixaCompraCard.tsx',
+    { tipo: 'estrutural', teto: 13, prova: 'mesma função do hook acima; entrou na lista quando o scanner passou a ver `.rpc("…")`' }],
+  ['fin_consolidado_intercompany @ src/pages/FinanceiroIntercompany.tsx',
+    { tipo: 'estrutural', teto: 4, prova: '`UNION ALL` de 4 SELECTs agregados sem GROUP BY' }],
+  ['fin_estimar_estoque_omie @ src/hooks/useEstoqueValor.ts',
+    { tipo: 'estrutural', teto: 1, prova: 'um SELECT agregado (SUM/COUNT) sem GROUP BY' }],
+  ['get_whatsapp_funil @ src/hooks/useWhatsappFunil.ts',
+    { tipo: 'estrutural', teto: 1, prova: 'SELECT de subqueries escalares, sem FROM' }],
+  ['get_data_health @ src/hooks/useDataHealth.ts',
+    { tipo: 'estrutural', teto: 25, prova: 'CTE `checks` = 25 ramos UNION ALL, 1 linha cada; o único ramo com JOIN é limitado por `sync_state` (26 linhas)' }],
+  ['gerar_pedidos_sugeridos_ciclo @ src/pages/AdminReposicaoPedidos.tsx',
+    { tipo: 'estrutural', teto: 1, prova: '`RETURN QUERY SELECT v_pedidos, v_skus, v_valor, v_bloqueados` — variáveis, sem FROM' }],
+  ['reverter_run_auto @ src/hooks/useParamAutoMudancas.ts',
+    { tipo: 'estrutural', teto: 1, prova: 'um `RETURN NEXT` fora de laço' }],
+  ['ciclo_oportunidade_do_dia @ src/pages/AdminReposicaoOportunidades.tsx',
+    { tipo: 'estrutural', teto: 1, prova: 'dois `RETURN QUERY SELECT <escalares>` em ramos exclusivos (o primeiro seguido de `RETURN;`)' }],
+  ['staff_get_sales_order_payload @ src/components/salesOrderEdit/useSalesOrderEdit.ts',
+    { tipo: 'estrutural', teto: 1, prova: '`WHERE id = ANY(p_order_ids)` e o caller passa `[id]`' }],
+  ['staff_get_sales_order_payload @ src/components/salesOrders/useSalesOrderDetail.ts',
+    { tipo: 'estrutural', teto: 1, prova: '`WHERE id = ANY(p_order_ids)` e o caller passa `[id]`' }],
+
+  // ── Teto MEDIDO nos dados: pior caso sobre os parâmetros reais ──────────────────────────
+  ['get_ultimos_precos_cliente @ src/hooks/unifiedOrder/useCustomerSelection.ts',
+    { tipo: 'medido', teto: 407, medidoEm: '2026-08-20', revisarAte: '2027-08-20',
+      prova: 'SELECT customer_user_id, count(DISTINCT product_id) FROM order_items oi JOIN sales_orders so ON so.id=oi.sales_order_id (mesmos filtros da função: deleted_at IS NULL, status NOT IN (cancelado,orcamento), unit_price>0) GROUP BY 1 ORDER BY 2 DESC — máx 407' }],
+  ['get_whatsapp_proposta_cotacao @ src/pages/RotaPropostas.tsx',
+    { tipo: 'medido', teto: 412, medidoEm: '2026-08-20', revisarAte: '2027-08-20',
+      prova: 'devolve ≤ |p_skus|, e a cesta é principal (⊆ SKUs já comprados pelo cliente, ≤407 pela contagem acima) + 3 secundários + MAX_CROSS_SELL=2' }],
+  ['staff_get_sales_order_payload @ src/pages/SalesPrintDashboard.tsx',
+    { tipo: 'medido', teto: 68, medidoEm: '2026-08-20', revisarAte: '2027-08-20',
+      prova: 'o lote é o de UM dia (o caller filtra created_at entre dayStart/dayEnd); SELECT date(created_at), count(*) FROM sales_orders GROUP BY 1 ORDER BY 2 DESC — pior dia da história = 68' }],
+  ['list_impersonation_targets @ src/hooks/useImpersonationTargets.ts',
+    { tipo: 'medido', teto: 3, medidoEm: '2026-08-20', revisarAte: '2027-08-20',
+      prova: 'SELECT count(DISTINCT owner_user_id) FROM carteira_assignments = 3' }],
+
+  // ── NÃO medidas: 2ª fatia. Têm `LIMIT` no corpo, que NÃO é garantia — `LIMIT p_limit` com
+  //    parâmetro grande não protege, e o valor precisa ser conferido constante e < 1.000.
+  ['carteira_por_municipio @ src/hooks/useRoutePlanner.ts',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['fin_regua_condicao_prazo @ src/hooks/useCustoPrazoRegua.ts',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['get_whatsapp_pendentes @ src/hooks/useWhatsappPendentes.ts',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['listar_pedidos_a_separar @ src/queries/usePedidosASeparar.ts',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['radar_contagem_por_municipio @ src/queries/useRadarCidadesRota.ts',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['radar_prospects_para_rota @ src/hooks/useRoutePlanner.ts',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['reposicao_pos_candidatos @ src/pages/AdminReposicaoPedidos.tsx',
+    { tipo: 'nao_medido', bloqueio: 'MONEY-PATH: tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  ['reposicao_pos_marcador @ src/pages/AdminReposicaoPedidos.tsx',
+    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
 ]);
+
+/**
+ * Waivers cujo teto MEDIDO já não tem a folga mínima — esses precisam paginar, não ficar aqui.
+ * Puras de propósito (recebem a baseline como argumento): é o que as fixtures de falsificação
+ * lá embaixo exercitam sem tocar na lista real. Regra inerte é pior que regra nenhuma, porque
+ * passa verde para sempre e ninguém desconfia.
+ */
+export function waiversSemFolga(baseline: Map<string, Waiver>, folgaMinima: number): string[] {
+  const fora: string[] = [];
+  for (const [chave, w] of baseline) {
+    if (w.tipo === 'nao_medido') continue; // sem número não há folga a comparar — é o outro teste
+    if (w.teto > folgaMinima) fora.push(`${chave} (teto ${w.teto} > ${folgaMinima})`);
+  }
+  return fora.sort();
+}
+
+/** Waivers cuja prova envelheceu (data no formato ISO `AAAA-MM-DD`, comparável como string). */
+export function waiversVencidos(baseline: Map<string, Waiver>, hoje: string): string[] {
+  const vencidos: string[] = [];
+  for (const [chave, w] of baseline) {
+    if (w.tipo === 'estrutural') continue; // definição não envelhece sozinha — ver o tipo Waiver
+    if (w.revisarAte < hoje) vencidos.push(`${chave} (venceu em ${w.revisarAte})`);
+  }
+  return vencidos.sort();
+}
 
 function achadosAtuais(): string[] {
   const setReturning = nomesSetReturning(
@@ -140,8 +261,60 @@ describe('RPC set-returning chamada do frontend pagina', () => {
     // Sem isto a lista apodrece e passa a "aprovar" chamadas que não existem mais — e o
     // próximo leitor lê 23 dívidas onde há 5.
     const atuais = new Set(achadosAtuais());
-    const obsoletas = [...BASELINE].filter((b) => !atuais.has(b)).sort();
+    const obsoletas = [...BASELINE.keys()].filter((b) => !atuais.has(b)).sort();
     expect(obsoletas, `saíram do código — remova da BASELINE:\n${obsoletas.join('\n')}`).toEqual([]);
+  });
+
+  it('teto medido sem folga não fica na baseline: pagine', () => {
+    // A régua que tirou daqui `fin_analise_cp_dimensoes_rpc` (877 medidos, 88% da capa). Sem
+    // ela a medição vira decoração: alguém contaria 950, escreveria o número com orgulho e o
+    // gate aprovaria a chamada que rompe na safra seguinte.
+    const semFolga = waiversSemFolga(BASELINE, FOLGA_MINIMA);
+    expect(
+      semFolga,
+      `medido perto da capa de 1.000 — PAGINE em vez de registrar aqui ` +
+        `(fetchAllPages + .order() de ordem TOTAL + .range(), como em financeiroV2Service.ts):\n` +
+        semFolga.map((x) => `  - ${x}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('waiver medido em DADOS vence: a fotografia de um dia não aprova o universo de sempre', () => {
+    // `estrutural` não entra aqui de propósito (ver o tipo `Waiver`): dado cresce sozinho, todo
+    // dia; definição só muda por CREATE OR REPLACE, que passa pelo ritual de migration.
+    const hoje = new Date().toISOString().slice(0, 10);
+    const vencidos = waiversVencidos(BASELINE, hoje);
+    expect(
+      vencidos,
+      `waiver VENCIDO — re-rode a contagem que está no campo \`prova\` da entrada e escreva o ` +
+        `número novo (com \`medidoEm\`), ou pagine a chamada. Só empurrar \`revisarAte\` para a ` +
+        `frente sem medir é fabricar a apuração:\n` + vencidos.map((x) => `  - ${x}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('todo waiver carrega a prova do teto — placeholder vazio não passa', () => {
+    // Heurística contra o campo em branco / "ok" / "TODO", não contra prova FALSA: essa só o
+    // leitor humano pega. Serve para que o custo de registrar um waiver seja escrever a query.
+    const semProva: string[] = [];
+    for (const [chave, w] of BASELINE) {
+      const texto = w.tipo === 'nao_medido' ? w.bloqueio : w.prova;
+      if (texto.trim().length < 20) semProva.push(chave);
+    }
+    expect(semProva.sort(), `waiver sem prova escrita:\n${semProva.join('\n')}`).toEqual([]);
+  });
+
+  it('FALSIFICAÇÃO: as duas réguas do waiver acusam de verdade', () => {
+    const folga = (t: number): Map<string, Waiver> =>
+      new Map([['x @ y.ts', { tipo: 'medido', teto: t, prova: 'p', medidoEm: '2026-01-01', revisarAte: '2099-01-01' }]]);
+    expect(waiversSemFolga(folga(501), 500)).toEqual(['x @ y.ts (teto 501 > 500)']);
+    expect(waiversSemFolga(folga(500), 500)).toEqual([]);
+
+    // Estrutural NÃO vence, medido vence — a assimetria é o desenho, então tem de ser provada.
+    const emDia = new Map<string, Waiver>([
+      ['med @ a.ts', { tipo: 'medido', teto: 1, prova: 'p', medidoEm: '2026-01-01', revisarAte: '2026-06-30' }],
+      ['est @ b.ts', { tipo: 'estrutural', teto: 1, prova: 'RETURN NEXT único' }],
+    ]);
+    expect(waiversVencidos(emDia, '2026-06-30')).toEqual([]);
+    expect(waiversVencidos(emDia, '2026-07-01')).toEqual(['med @ a.ts (venceu em 2026-06-30)']);
   });
 
   it('FALSIFICAÇÃO: o gate acusa uma chamada crua e absolve a paginada', () => {
@@ -151,6 +324,18 @@ describe('RPC set-returning chamada do frontend pagina', () => {
 
     expect(chamadasSemPaginacao(`const { data } = await supabase.rpc('minha_rpc_grande');`, setRet))
       .toEqual(['minha_rpc_grande']);
+
+    // ASPAS DUPLAS — o furo real do scanner até 2026-08-20. `src/` tem 10 chamadas `.rpc("…")`
+    // e duas eram set-returning: enquanto o regex só via `'`, elas não estavam nem na baseline
+    // nem nos achados, e o verde do gate vinha de não ter procurado.
+    expect(chamadasSemPaginacao(`const { data } = await supabase.rpc("minha_rpc_grande");`, setRet))
+      .toEqual(['minha_rpc_grande']);
+    expect(
+      chamadasSemPaginacao(
+        `fetchAllPages((de, ate) => supabase.rpc("minha_rpc_grande").order('id').range(de, ate), 'x')`,
+        setRet,
+      ),
+    ).toEqual([]);
 
     expect(
       chamadasSemPaginacao(

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -132,6 +132,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/usePeriodOverride.test.tsx",
       "src/hooks/__tests__/useUtiContas.test.ts",
       "src/hooks/__tests__/ponto-equilibrio-folha-ambigua.test.ts",
+      "src/services/__tests__/getAnaliseDimensional.test.ts",
       "src/services/__tests__/getCapitalDeGiro.test.ts",
       "src/services/__tests__/getFluxoCaixa.test.ts",
       "src/services/__tests__/getResumoFinanceiro.test.ts",

--- a/src/services/__tests__/getAnaliseDimensional.test.ts
+++ b/src/services/__tests__/getAnaliseDimensional.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Teste de contrato da paginação de `getAnaliseDimensional` (tela /financeiro/analytics).
+ *
+ * Irmão dos #719/#720 (queries sem `.range()`) e dos #1782/#1801 (a mesma capa alcançando
+ * `.rpc()`): a capa de 1.000 linhas do PostgREST vale para RPC set-returning e é SILENCIOSA.
+ * Aqui o consumidor AGREGA as linhas num Map por dimensão, então truncar não esvazia a tela —
+ * encolhe cada total em silêncio, e um "contas a pagar por categoria" 12% menor é
+ * indistinguível de um mês mais fraco.
+ *
+ * Medido em prod (2026-08-20): `fin_analise_cp_dimensoes` devolve 877 linhas no pior caso real
+ * da tela (todas as empresas, ano 2025, mês = "todos"), numa série que cresce ~14% ao ano —
+ * 407 em 2020, 877 em 2025. O universo de 1.227 usado abaixo é o próximo degrau dessa curva.
+ *
+ * O dublê reproduz o comportamento REAL do PostgREST: `.range(from, to)` devolve a janela
+ * pedida, capada em 1.000 linhas por request.
+ */
+
+type Row = Record<string, unknown>;
+
+const state: {
+  universo: Row[];
+  erroNaPagina: number | null;
+  nullNaPagina: number | null;
+  chamadas: Array<{ nome: string; ordens: string[]; range: [number, number] | null }>;
+} = { universo: [], erroNaPagina: null, nullNaPagina: null, chamadas: [] };
+
+const CAPA_POSTGREST = 1000;
+
+function makeRpcBuilder(nome: string) {
+  const registro: { nome: string; ordens: string[]; range: [number, number] | null } = {
+    nome, ordens: [], range: null,
+  };
+  state.chamadas.push(registro);
+  const builder = {
+    order: (coluna: string, _opts?: unknown) => {
+      // Ordem DEPOIS do range seria aplicada tarde demais para estabilizar a janela; o registro
+      // guarda a sequência para o teste poder exigir a ordem certa.
+      registro.ordens.push(registro.range ? `DEPOIS_DO_RANGE:${coluna}` : coluna);
+      return builder;
+    },
+    range: (from: number, to: number) => {
+      registro.range = [from, to];
+      return builder;
+    },
+    then: (
+      resolve: (v: { data: Row[] | null; error: unknown }) => unknown,
+      reject?: (e: unknown) => unknown,
+    ) => {
+      try {
+        if (!registro.range) {
+          // Sem `.range()` o PostgREST devolve só o primeiro 1.000 — o defeito original.
+          return Promise.resolve(state.universo.slice(0, CAPA_POSTGREST)).then((data) =>
+            resolve({ data, error: null }),
+          );
+        }
+        const [from, to] = registro.range;
+        const pagina = Math.floor(from / CAPA_POSTGREST);
+        if (state.erroNaPagina === pagina) {
+          return Promise.resolve(
+            resolve({ data: null, error: { message: 'canceling statement due to statement timeout', code: '57014' } }),
+          );
+        }
+        if (state.nullNaPagina === pagina) {
+          return Promise.resolve(resolve({ data: null, error: null }));
+        }
+        const fim = Math.min(to + 1, from + CAPA_POSTGREST);
+        return Promise.resolve(resolve({ data: state.universo.slice(from, fim), error: null }));
+      } catch (e) {
+        return reject ? Promise.resolve(reject(e)) : Promise.reject(e);
+      }
+    },
+  };
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: (nome: string, _params: unknown) => makeRpcBuilder(nome) },
+}));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import { getAnaliseDimensional } from '@/services/financeiroV2Service';
+
+/** Uma linha da matview dimensional, com 1 título e R$ 10 — o total é a CONTAGEM de linhas. */
+const linha = (i: number, tipo: 'cp' | 'cr'): Row => ({
+  company: 'colacor',
+  ano: 2025,
+  mes: (i % 12) + 1,
+  categoria_codigo: `C${i}`,
+  categoria_descricao: 'CATEGORIA UNICA',
+  departamento: i % 3 === 0 ? null : `DEP${i % 3}`,
+  centro_custo: null,
+  cnpj_cpf: `${i}`,
+  status_titulo: 'A VENCER',
+  qtd_titulos: 1,
+  total_documento: 10,
+  total_saldo: 10,
+  ...(tipo === 'cp'
+    ? { nome_fornecedor: `F${i}`, tipo_documento: 'NF', total_pago: 10 }
+    : { vendedor_id: i, nome_cliente: `C${i}`, total_recebido: 10 }),
+});
+
+beforeEach(() => {
+  state.universo = [];
+  state.erroNaPagina = null;
+  state.nullNaPagina = null;
+  state.chamadas = [];
+});
+
+describe('getAnaliseDimensional pagina a RPC set-returning', () => {
+  it('O CORAÇÃO: lê o universo INTEIRO — 1.227 linhas viram 1.227 títulos, não 1.000', async () => {
+    // Sem paginação o resultado seria 1.000: plausível, silencioso e ERRADO em 18,5%. É o
+    // mesmo desfecho do #1801, onde 227 clientes da cauda viravam veredito fabricado.
+    state.universo = Array.from({ length: 1227 }, (_, i) => linha(i, 'cp'));
+
+    const out = await getAnaliseDimensional('cp', 'all', 'categoria', 2025);
+
+    expect(out).toHaveLength(1);
+    expect(out[0].qtd_titulos).toBe(1227);
+    expect(out[0].total_documento).toBe(12270);
+    expect(state.chamadas).toHaveLength(2); // 0-999 e 1000-1999 (a 2ª volta curta e encerra)
+  });
+
+  it('ordena pela chave TOTAL da matview ANTES do `.range()`', async () => {
+    // Sem ordem total o Postgres escolhe a ordem de cada página e o offset pula/duplica linha
+    // — o mesmo bug de volta, e intermitente. A chave é o GROUP BY da matview, que o índice
+    // UNIQUE do `REFRESH … CONCURRENTLY` impõe.
+    state.universo = Array.from({ length: 5 }, (_, i) => linha(i, 'cp'));
+
+    await getAnaliseDimensional('cp', 'colacor', 'categoria', 2025, 3);
+
+    const [chamada] = state.chamadas;
+    expect(chamada.ordens).toEqual([
+      'company', 'ano', 'mes', 'categoria_codigo', 'categoria_descricao', 'departamento',
+      'centro_custo', 'nome_fornecedor', 'cnpj_cpf', 'tipo_documento', 'status_titulo',
+    ]);
+    expect(chamada.range).toEqual([0, 999]);
+  });
+
+  it('o ramo CR pagina e ordena com a chave DELE (vendedor_id/nome_cliente, sem tipo_documento)', async () => {
+    state.universo = Array.from({ length: 1500 }, (_, i) => linha(i, 'cr'));
+
+    const out = await getAnaliseDimensional('cr', 'all', 'categoria', 2026);
+
+    expect(out[0].qtd_titulos).toBe(1500);
+    expect(state.chamadas[0].ordens).toEqual([
+      'company', 'ano', 'mes', 'categoria_codigo', 'categoria_descricao', 'departamento',
+      'centro_custo', 'vendedor_id', 'nome_cliente', 'cnpj_cpf', 'status_titulo',
+    ]);
+  });
+
+  it('FAIL-CLOSED: página que falha LANÇA — não devolve o acumulado como se fosse o todo', async () => {
+    // Paginar cura a capa, NÃO a falha no meio. Devolver as 1.000 primeiras linhas de um
+    // universo de 1.227 porque a 2ª página deu timeout é a leitura parcial silenciosa
+    // entrando pela outra porta.
+    state.universo = Array.from({ length: 1227 }, (_, i) => linha(i, 'cp'));
+    state.erroNaPagina = 1;
+
+    await expect(getAnaliseDimensional('cp', 'all', 'categoria', 2025)).rejects.toThrow();
+  });
+
+  it('FAIL-CLOSED: `data: null` sem error é resposta malformada, não fim de tabela', async () => {
+    // Era o que o `?? []` removido daqui transformava em "nenhum título" — zero fabricado.
+    state.universo = Array.from({ length: 1227 }, (_, i) => linha(i, 'cp'));
+    state.nullNaPagina = 1;
+
+    await expect(getAnaliseDimensional('cp', 'all', 'categoria', 2025)).rejects.toThrow();
+  });
+});

--- a/src/services/financeiroV2Service.ts
+++ b/src/services/financeiroV2Service.ts
@@ -1,4 +1,5 @@
 import { supabase } from "@/integrations/supabase/client";
+import { fetchAllPages } from "@/lib/postgrest";
 import type { Company } from "@/contexts/CompanyContext";
 import type { Json } from "@/integrations/supabase/types";
 import type { DimRowRaw } from "@/lib/financeiro/orcamento-drill-helpers";
@@ -400,6 +401,54 @@ export type Dimensao = 'categoria' | 'departamento' | 'centro_custo' | 'vendedor
 
 type DimRow = FinAnaliseCrDimensoesView | FinAnaliseCpDimensoesView;
 
+/**
+ * Chave de ordenação TOTAL de cada matview dimensional: o `GROUP BY` dela, INTEIRO.
+ *
+ * Paginar exige ordem total — sem ela o plano escolhe a ordem de cada página e o offset
+ * pula/duplica linha entre requests (o bug de volta, e intermitente). Estas matviews são
+ * AGREGADAS e não têm `id`; a chave é o conjunto de colunas do `GROUP BY`, porque duas linhas
+ * com os mesmos valores nele não podem coexistir — é o que agrupar significa.
+ *
+ * A unicidade aqui é IMPOSTA, não observada: as duas matviews têm índice UNIQUE
+ * (`idx_fin_analise_c{p,r}_unique`) sobre exatamente estas colunas menos `categoria_descricao`
+ * — o `REFRESH … CONCURRENTLY` do cron `fin-refresh-analise-dimensoes` exige um. Um superconjunto
+ * de uma chave única é chave única, então esta lista é ordem total por construção do banco. (A
+ * contagem `count(*) = count(DISTINCT (…))` de 2026-08-20 — 4.693 e 622 — só confirma o que o
+ * índice já garante; era a prova FRACA, e o Codex apontou isso.)
+ *
+ * ⚠️ NÃO encurte para um prefixo "que também é único hoje": unicidade observada nos dados de
+ * hoje não é ordem total amanhã, e o defeito que ela reintroduz é intermitente. O repo já
+ * pagou por isso um degrau abaixo, em `getCategoriasCompetenciaRaw` — lá foi
+ * `categoria_descricao` que empatava dentro de `categoria_codigo`.
+ */
+const CHAVE_TOTAL_CP = [
+  'company', 'ano', 'mes', 'categoria_codigo', 'categoria_descricao', 'departamento',
+  'centro_custo', 'nome_fornecedor', 'cnpj_cpf', 'tipo_documento', 'status_titulo',
+] as const;
+const CHAVE_TOTAL_CR = [
+  'company', 'ano', 'mes', 'categoria_codigo', 'categoria_descricao', 'departamento',
+  'centro_custo', 'vendedor_id', 'nome_cliente', 'cnpj_cpf', 'status_titulo',
+] as const;
+
+/** O mínimo do builder do PostgREST que a paginação usa — o `.rpc()` daqui já entra por `as never`. */
+type LeituraOrdenavel = {
+  order: (coluna: string, opts: { ascending: boolean; nullsFirst: boolean }) => LeituraOrdenavel;
+  range: (de: number, ate: number) => PromiseLike<{ data: unknown; error: unknown }>;
+};
+
+/**
+ * Encadeia um `.order()` por coluna da chave. `nullsFirst` é EXPLÍCITO de propósito: as colunas
+ * de dimensão são nullable (`departamento`, `centro_custo` e `cnpj_cpf` vêm nulos em títulos sem
+ * classificação) e o posicionamento dos nulos precisa ser o mesmo em TODAS as páginas — deixá-lo
+ * no default do servidor amarra a estabilidade da paginação a algo que não está escrito aqui.
+ */
+function ordenarPorChaveTotal(builder: unknown, chave: readonly string[]): LeituraOrdenavel {
+  return chave.reduce<LeituraOrdenavel>(
+    (q, coluna) => q.order(coluna, { ascending: true, nullsFirst: false }),
+    builder as LeituraOrdenavel,
+  );
+}
+
 export async function getAnaliseDimensional(
   tipo: 'cr' | 'cp',
   company: Company | 'all',
@@ -432,21 +481,63 @@ export async function getAnaliseDimensional(
     p_ano: ano ?? null,
     p_mes: mes ?? null,
   };
+  // PAGINADAS, com ordem TOTAL antes do `.range` — a capa de 1.000 do PostgREST vale para
+  // `.rpc()` e é SILENCIOSA (#1782, #1801). Medido em prod (2026-08-20, psql-ro, contando as
+  // matviews que as RPCs devolvem via `SETOF`), no pior caso REAL da tela — que é o estado
+  // INICIAL dela: mês = "todos" (`FinanceiroAnalytics.tsx` abre com `mes = null`) e ano
+  // corrente, com a empresa podendo ser `all` (⇒ `p_company: null`):
+  //
+  //   cp: 877 linhas (ano 2025, todas as empresas) — 88% da capa. A série anual é monotônica
+  //       e cresce ~14%/ano: 407 (2020) → 483 → 546 → 614 → 770 → 877 (2025). A próxima safra
+  //       fechada rompe 1.000; a matview inteira já tem 4.693.
+  //   cr: 138 linhas no pior ano. Folga de 7×, e ainda assim pagina: é o MESMO caller, o mesmo
+  //       `rpcParams` e o mesmo `.reduce` de ordem — paginar só um ramo do if/else deixaria uma
+  //       assimetria que o próximo leitor teria de re-medir para entender.
+  //
+  // O que o truncamento produziria aqui não é erro, é NÚMERO FABRICADO: o laço abaixo AGREGA
+  // (`+=` de qtd_titulos e dos três totais) num Map por dimensão, então perder a cauda não
+  // esvazia a tela — encolhe cada total em silêncio, e um "total de contas a pagar por
+  // categoria" 12% menor é indistinguível de um mês mais fraco.
+  //
+  // FAIL-CLOSED de lado: o `?? []` que estava aqui cobria `data: null` SEM error (resposta
+  // malformada, classe #1581) transformando-a em "nenhum título" — zero fabricado. `fetchAllPages`
+  // LANÇA nesse caso (`data_null_sem_error`), e o caller já trata erro (o `throw` de antes).
+  //
+  // ⚠️ LIMITE CONHECIDO, que a paginação NÃO cura (achado do Codex nesta revisão): páginas são
+  // requests HTTP distintos e não compartilham snapshot. O cron `fin-refresh-analise-dimensoes`
+  // roda `REFRESH MATERIALIZED VIEW CONCURRENTLY` às 10h e 16h; um refresh que caia ENTRE duas
+  // páginas pode fazer o offset pular ou repetir linha apesar da ordem total. Hoje o risco é
+  // nulo na prática — 877 linhas cabem na 1ª página e o laço encerra sem 2ª requisição — e ele
+  // nasce junto com o rompimento da capa, que é justamente o que esta paginação existe para
+  // atender. Mesmo então, paginar é estritamente melhor que não paginar: o risco vira uma janela
+  // de dois instantes por dia contra uma perda GARANTIDA de toda a cauda, todo dia. A cura de
+  // verdade é agregar server-side (a RPC devolver o Map já somado, em vez de N linhas cruas) —
+  // escopo próprio, deliberadamente fora deste.
   let rows: DimRow[];
   if (tipo === 'cr') {
-    const { data, error } = await supabase.rpc(
-      'fin_analise_cr_dimensoes_rpc' as never,
-      rpcParams as never,
+    rows = await fetchAllPages<FinAnaliseCrDimensoesView>(
+      (de, ate) =>
+        ordenarPorChaveTotal(
+          supabase.rpc('fin_analise_cr_dimensoes_rpc' as never, rpcParams as never),
+          CHAVE_TOTAL_CR,
+        ).range(de, ate) as unknown as PromiseLike<{
+          data: FinAnaliseCrDimensoesView[] | null;
+          error: unknown;
+        }>,
+      'fin_analise_cr_dimensoes_rpc/analise-dimensional',
     );
-    if (error) throw error;
-    rows = (data as unknown as FinAnaliseCrDimensoesView[]) ?? [];
   } else {
-    const { data, error } = await supabase.rpc(
-      'fin_analise_cp_dimensoes_rpc' as never,
-      rpcParams as never,
+    rows = await fetchAllPages<FinAnaliseCpDimensoesView>(
+      (de, ate) =>
+        ordenarPorChaveTotal(
+          supabase.rpc('fin_analise_cp_dimensoes_rpc' as never, rpcParams as never),
+          CHAVE_TOTAL_CP,
+        ).range(de, ate) as unknown as PromiseLike<{
+          data: FinAnaliseCpDimensoesView[] | null;
+          error: unknown;
+        }>,
+      'fin_analise_cp_dimensoes_rpc/analise-dimensional',
     );
-    if (error) throw error;
-    rows = (data as unknown as FinAnaliseCpDimensoesView[]) ?? [];
   }
 
   const col = (tipo === 'cr' ? dimColCr[dimensao] : dimColCp[dimensao]) as keyof DimRow;


### PR DESCRIPTION
## O que muda

A BASELINE do gate de paginação registrava 23 chamadas `.rpc()` set-returning com um motivo honesto porém **cego**: "`claude_ro` não tem EXECUTE nessas funções, então não pude MEDIR o universo". Esta entrega derruba esse motivo para 15 delas.

**Dá para medir sem EXECUTE:** ler `pg_get_functiondef` e reproduzir o corpo como SELECT sobre a prod (psql-ro). Medido em 2026-08-20.

### O resultado veio na direção contrária à esperada

**9 chamadas têm teto ESTRUTURAL** — provado pela definição, não por sorte de volume:

| RPC | teto | prova |
|---|---|---|
| `fin_projecao_13_semanas` (×2 callers) | 13 | `FOR i IN 0..12 LOOP … RETURN NEXT` |
| `fin_consolidado_intercompany` | 4 | `UNION ALL` de 4 agregados sem GROUP BY |
| `fin_estimar_estoque_omie` | 1 | SELECT agregado sem GROUP BY |
| `get_whatsapp_funil` | 1 | SELECT de subqueries escalares, sem FROM |
| `get_data_health` | 25 | CTE de 25 ramos UNION ALL, 1 linha cada |
| `gerar_pedidos_sugeridos_ciclo` · `reverter_run_auto` · `ciclo_oportunidade_do_dia` | 1 | `RETURN QUERY SELECT <variáveis>` / `RETURN NEXT` fora de laço |
| `staff_get_sales_order_payload` (2 dos 3 callers) | 1 | `WHERE id = ANY(p_order_ids)`, caller passa `[id]` |

**4 têm teto nos dados, com folga:** `get_ultimos_precos_cliente` **407** (é `DISTINCT ON (product_id)` — o cliente de maior variedade), `get_whatsapp_proposta_cotacao` ≤412, `staff_get_sales_order_payload` no dashboard de impressão **68** (o lote é o de UM dia; pior dia da história = 68), `list_impersonation_targets` **3**.

### Uma passou: `fin_analise_cp_dimensoes_rpc`

**877 linhas** no pior caso REAL da tela — que é o **estado inicial** dela (mês = "todos", empresa `all`). 88% da capa. A série anual é monotônica, ~14%/ano:

```
407 (2020) → 483 → 546 → 614 → 770 → 877 (2025)
```

`877 × 1,14 = 999,8` — a própria série prevê consumir toda a folga na safra seguinte. E 1.000 exatos são **ambíguos por construção**: não há como distinguir "acabou aqui" de "foi truncado".

**O modo de falha é número fabricado, não erro.** O consumidor AGREGA (`+=` de `qtd_titulos` e dos três totais) num Map por dimensão. Truncar não esvaziaria a tela — encolheria cada total em silêncio, e um "contas a pagar por categoria" 12% menor é indistinguível de um mês fraco.

Paginada junto com `fin_analise_cr_dimensoes_rpc` (138, folga de 7×): mesmo caller, mesmo `rpcParams`, mesmo `if/else`. Paginar um ramo só deixaria uma assimetria que o próximo leitor teria de re-medir.

**Ordem estável = o `GROUP BY` inteiro**, e a garantia não é estatística: o `REFRESH … CONCURRENTLY` do cron `fin-refresh-analise-dimensoes` **exige** índice UNIQUE, e ele existe (`idx_fin_analise_c{p,r}_unique`) sobre exatamente essas colunas menos `categoria_descricao`. Superconjunto de chave única é chave única.

### O furo que a 2ª opinião (Codex) achou — e que valia mais que o resto

O scanner do gate casava só `.rpc('nome')`, **aspas simples**. `src/` tem 10 chamadas com aspas duplas, **duas set-returning**: `fin_projecao_13_semanas` em `CaixaCompraCard` e `ciclo_oportunidade_do_dia` em `AdminReposicaoOportunidades`.

Enquanto o furo existiu, a frase "a BASELINE enumera a dívida" era **falsa** — o gate não olhava o universo que dizia vigiar, e o verde vinha de não ter procurado. É a versão-scanner do `Number(null)===0`. As duas entraram na lista (ambas com teto estrutural).

## Resíduo durável: waiver com prova e prazo

A BASELINE deixou de ser `Set<string>` e virou `Map<string, Waiver>`:

- **`estrutural`** — a definição limita. **Não expira**, e a diferença é de mecanismo: dado cresce sozinho, todo dia; definição só muda por `CREATE OR REPLACE`, que passa pelo ritual de migration.
- **`medido`** — fotografia da prod, com `medidoEm` + `revisarAte` e **a query da medição escrita no campo `prova`**.
- **`nao_medido`** — dívida sem número, prazo mais curto.

Três regras novas no CI, todas com fixtures de falsificação (regra de gate inerte passa verde para sempre e ninguém desconfia):

1. teto medido **> 500** (metade da capa — o universo precisa DOBRAR para romper) não recebe waiver: **pagine**;
2. waiver **vencido** reprova;
3. waiver **sem prova escrita** reprova.

**Recusado do parecer do Codex** o `definitionHash` para os estruturais: o gate roda no CI **sem banco**, o hash só poderia ser do arquivo de migration, e neste repo a prod diverge do repo por apply manual — daria verde com a prod já mudada e vermelho num refactor que não mudou a prod. Falsa precisão nos dois sentidos.

## Limite conhecido, documentado no código

Páginas são requests HTTP distintos e não compartilham snapshot; o cron de refresh roda às 10h e 16h. Um refresh entre duas páginas pode pular/repetir linha apesar da ordem total. **Hoje o risco é nulo** (877 cabem na 1ª página, o laço encerra sem 2ª requisição) e nasce junto com o rompimento da capa. Mesmo então, paginar é estritamente melhor: janela de dois instantes por dia contra perda **garantida** de toda a cauda, todo dia. A cura real é agregar server-side — escopo próprio.

## Teste que faltava

`getAnaliseDimensional` não tinha **nenhum** teste exercitando o caminho — a suíte verde provava só que nada quebrou, não que a paginação funciona. Entram 5 testes com dublê que reproduz a capa real do PostgREST: o coração (1.227 linhas viram 1.227 títulos, não 1.000), a ordem total antes do `.range()` nos dois ramos, e os dois fail-closed.

## Validação

| comando | resultado |
|---|---|
| `bun run typecheck` | exit 0 |
| `bun run test` (completo) | exit 0 — 688 arquivos, 6.447 testes |
| `bun lint` | exit 0 (75 warnings pré-existentes) |
| `bunx knip` | exit 0 |

**Falsificação (money-path), commit antes e nos dois locales (`LC_ALL=C` e `pt_BR.UTF-8`), com sabotagem ANCORADA no par `.rpc('<nome>')` + chave:**

| sabotagem | desfecho exigido | obtido |
|---|---|---|
| remover a paginação do ramo CP | coração vermelho | ✅ `expected 1000 to be 1227` — e o ramo **CR passou**, provando que a âncora foi cirúrgica |
| `teto: 3` → `900` num waiver medido | regra da folga vermelha | ✅ só o teste da folga |
| `revisarAte` → `2020-01-01` | regra de expiração vermelha | ✅ só o teste de expiração |
| regex de volta a só aspas simples | scanner vermelho | ✅ 2 testes independentes (a baseline órfã + a fixture) |

## Deploy

Frontend-only: **Publish** no Lovable. Sem migration, sem edge.

## Fora de escopo (2ª fatia)

As 8 com `LIMIT` no corpo — `LIMIT` não é garantia (`LIMIT p_limit` com parâmetro grande não protege), e `reposicao_pos_candidatos` é money-path. Ficam marcadas `nao_medido` **com prazo**, não "provavelmente pequenas".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
