### PR TITLE
fix(farmer): `AGUARDE` sem taxa é espera infinita — o que falta à fase 2 não é sensor, é USO [money-path]

### DIFF
--- a/db/gatilho-farmer-fase2.sql
+++ b/db/gatilho-farmer-fase2.sql
@@ -42,6 +42,14 @@
 --    virariam `ENCERRE`, encerrando a linha do BUNDLE com dado que é todo do cross-sell.
 --    Por isso a query devolve UMA LINHA POR MOTOR, e o esqueleto de motores é fixo: motor sem
 --    execução tem de aparecer com zero, nunca sumir da saída (ausente ≠ zero, de novo).
+--
+-- 5. **`AGUARDE` sem prazo é indistinguível de espera infinita.** O veredito exige 20 julgáveis,
+--    e nada garante que 20 cheguem: medido em 20/08, 3 farmers TÊM carteira, 1 só executou
+--    alguma vez, e as ultimas 24h tiveram ZERO execucoes — as 10 de 19/08 sairam todas num
+--    intervalo de 1h04 (sessao de teste, nao rotina). Esperar nao produz denominador quando a
+--    superficie nao esta em uso; a fase N+1 aqui e INSTALAR O USO, nao aguardar o sinal.
+--    Por isso `taxa_7d` e `farmers_com_carteira` saem na propria linha: um denominador que nao
+--    cresce e um fato observavel, e o veredito ESTAGNADO o nomeia em vez de repetir "aguarde".
 WITH motores AS (
   -- Esqueleto FIXO: o motor que nunca executou precisa APARECER com zero. Um `GROUP BY motor`
   -- sozinho simplesmente não produz linha para ele, e a ausência seria lida como "não há nada
@@ -98,6 +106,12 @@ obs AS (
                        AND m.completude = 'completo'
                        AND NOT (m.insumos ? 'carteira_com_historico_utilizavel')) AS vazios_pre_cobertura,
     count(DISTINCT m.farmer_id)                                       AS farmers,
+    -- Taxa OBSERVAVEL: sem ela, "3/20" nao distingue "crescendo devagar" de "parado".
+    count(*) FILTER (WHERE m.calculado_em > now() - interval '7 days')  AS exec_7d,
+    -- Denominador de USUARIOS (global, nao por motor): farmer que tem carteira mas nunca
+    -- executou nao aparece em `farmers`, e some — a mesma cobertura-vs-universo do insumo
+    -- carteira_com_historico_utilizavel, agora aplicada a ADOCAO da propria tela.
+    (SELECT count(DISTINCT farmer_id) FROM public.farmer_client_scores) AS farmers_com_carteira,
     min(m.calculado_em)::date                                         AS desde,
     max(m.calculado_em)                                               AS ultima
   FROM corte c
@@ -109,7 +123,7 @@ obs AS (
 )
 SELECT
   motor, execucoes_totais, julgaveis, vazios_completos, vazios_pre_cobertura,
-  descartadas_cap, farmers, desde, ultima,
+  descartadas_cap, farmers, farmers_com_carteira, exec_7d, desde, ultima,
   CASE
     WHEN cap_ativo THEN
       'CONTAMINADO (ATIVO) — a execucao MAIS RECENTE deste motor ainda traz insumo de exatamente '
@@ -134,11 +148,18 @@ SELECT
       'ENCERRE — ' || julgaveis || ' execucoes julgaveis DESTE motor e ZERO vazios: o '
       || 'vazio-de-verdade nao acontece nele. Nao ligue a expiracao; encerre a linha DELE '
       || '(o veredito e por motor: nao decide nada sobre o outro).'
+    WHEN execucoes_totais > 0 AND exec_7d = 0 THEN
+      'ESTAGNADO — ' || julgaveis || '/20 julgaveis e ZERO execucoes nos ultimos 7 dias. O '
+      || 'denominador NAO esta crescendo: aguardar nao produz sinal quando a superficie nao '
+      || 'esta em uso (' || farmers || ' de ' || farmers_com_carteira || ' farmers com carteira '
+      || 'ja executaram alguma vez). A fase seguinte aqui e INSTALAR O USO — nao esperar.'
     ELSE
       'AGUARDE — denominador insuficiente (' || julgaveis || '/20 julgaveis'
       || CASE WHEN descartadas_cap > 0
               THEN '; ' || descartadas_cap || ' execucao(oes) DESCARTADAS por truncamento, '
                    || 'denominador recomecado' ELSE '' END
+      || '; ' || exec_7d || ' execucao(oes) nos ultimos 7 dias, ' || farmers || '/'
+      || farmers_com_carteira || ' farmers com carteira ja executaram'
       || '). NAO interprete como "o vazio nao acontece": e ausencia de dado.'
   END AS veredito
 FROM obs

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -287,6 +287,23 @@ motor cujo denominador é **zero** — o `ausente=zero` promovido a veredito. **
 mais de uma superfície, o denominador é por superfície**; e superfícies que se exercem de formas
 diferentes (automático vs. manual) nunca compartilham denominador, mesmo medindo a mesma coisa.
 
+⚠️ **E o `AGUARDE` que nunca vira nada — porque falta USO, não sensor.** O gatilho exigia 20
+execuções julgáveis. Medido em 20/08: **3 farmers têm carteira, 1 executou alguma vez, e as últimas
+24h tiveram ZERO execuções** — as 10 de 19/08 saíram todas num intervalo de 1h04, que é sessão de
+teste, não rotina. Nesse ritmo o 20 não chega nunca, e o veredito repetiria "aguarde" para sempre.
+
+Este é o topo da escada que este documento sobe: primeiro faltava o sensor, depois o sensor não
+media a pergunta, depois o agregado escondia o motor zerado — e no fim **o que falta não é medição,
+é a superfície ser usada**. Um `AGUARDE` sem taxa não distingue "crescendo devagar" de "parado", e a
+diferença decide a ação: no primeiro caso espera-se, no segundo **a fase seguinte é instalar o uso**.
+Correção: `taxa_7d` e `farmers_com_carteira` saem na própria linha, e o ramo `ESTAGNADO` nomeia o
+denominador que não cresce. Falsificado com 5 execuções há 30 dias (`ESTAGNADO`) contra 5 há 2 dias
+(`AGUARDE`).
+
+**A regra:** todo veredito de espera tem de carregar a taxa que o justifica. Sem ela, "aguarde" não
+é uma decisão — é o silêncio com cara de decisão.
+
+
 
 ### Onde a regra NÃO se aplica
 


### PR DESCRIPTION
## O defeito

O gatilho exige 20 execuções julgáveis, e **nada garantia que 20 chegassem**. Medido em prod (20/08):

| | |
|---|---|
| farmers com carteira | **3** |
| farmers que já executaram | **1** |
| execuções nas últimas 24h | **0** |

As 10 execuções de 19/08 saíram todas num intervalo de **1h04** — sessão de teste, não rotina de vendedora. Nesse ritmo o denominador não cresce e o veredito repetiria `AGUARDE` para sempre.

Um veredito de espera que não pode mudar de estado é o mesmo defeito das duas correções anteriores desta linha (#1805, #1809), agora um nível acima: **não falta medição, falta a superfície ser usada.**

`AGUARDE` sem taxa não distingue *"crescendo devagar"* de *"parado"* — e a diferença decide a ação: no primeiro caso espera-se; no segundo, a fase seguinte é **instalar o uso**.

## A correção

- **`exec_7d`** (taxa observável) e **`farmers_com_carteira`** (denominador de **adoção**) saem na própria linha. Farmer que tem carteira e nunca executou não aparecia em `farmers` e sumia — é a mesma cobertura-vs-universo do insumo `carteira_com_historico_utilizavel`, agora aplicada à própria tela;
- ramo **`ESTAGNADO`**: execuções existem mas zero nos últimos 7 dias → nomeia o denominador parado em vez de repetir "aguarde";
- o `AGUARDE` genérico passa a carregar taxa e adoção.

## Falsificação

| cenário | veredito |
|---|---|
| 5 execuções há **30 dias** | `ESTAGNADO — 5/20 e ZERO execucoes nos ultimos 7 dias` |
| 5 execuções há **2 dias** | `AGUARDE — ... 5 execucao(oes) nos ultimos 7 dias` |

## Contra prod, agora

```
cross_sell | AGUARDE (3/20; 7 descartadas; 3 execucoes em 7 dias; 1/3 farmers ja executaram)
bundle     | SEM DENOMINADOR — nunca executou
```

Read-only: script de consulta (`psql-ro`), não migration. Nada a aplicar nem publicar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)