### PR TITLE
fix(rota): o `LIMIT` no corpo era o disfarce — 1.014 clientes truncando e um teto EXATAMENTE na capa [money-path]

### DIFF
--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -576,4 +576,73 @@ instantes por dia contra perda GARANTIDA de toda a cauda, todo dia. A cura real 
 
 **Sobrou para a 2ª fatia:** as 8 com `LIMIT` no corpo — `LIMIT` não é garantia (`LIMIT p_limit` com
 parâmetro grande não protege), e `reposicao_pos_candidatos` é money-path. Estão marcadas `nao_medido`
-com prazo, não "provavelmente pequenas".
+com prazo, não "provavelmente pequenas". *(Fechadas em 2026-08-20 — seção seguinte.)*
+
+## A 2ª fatia: o `LIMIT` no corpo era o disfarce — 1.014 truncando e um teto EXATAMENTE na capa (2026-08-20)
+
+Quarto e último capítulo da classe (#1782, #1801, #1816). O escopo era pequeno e fechado: medir as
+**8 chamadas `nao_medido`** e, para cada uma, registrar o teto com prova ou paginar. As 8 eram
+exatamente as que **tinham `LIMIT` no corpo** — o critério que na 1ª fatia parecia tranquilizador e
+que se revelou o disfarce.
+
+**Seis eram o que aparentavam.** `fin_regua_condicao_prazo` é `LIMIT 1`; `listar_pedidos_a_separar`,
+`LIMIT 100`; `get_whatsapp_pendentes`, `LIMIT 500` (universo hoje = 0); `radar_contagem_por_municipio`
+é `LIMIT GREATEST(1, LEAST(p_limit, 2000))` com os **dois** callers passando a constante `500`;
+`reposicao_pos_marcador` devolve exatamente 1 linha por construção (`FROM (SELECT 1) AS sempre LEFT
+JOIN LATERAL (… LIMIT 1)` — o "sem marcador" vem como NULL, não como zero linhas). A money-path
+`reposicao_pos_candidatos` precisou de contagem: o único `LIMIT` do corpo é o da CTE `marcador`, o
+`RETURN QUERY` não tem teto. Medida em **101** (OBEN; COLACOR, a outra da enum `empresa_reposicao`,
+tem 0) — e é teto SUPERIOR, porque os filtros `ls.run_id <> m.run_id` e `omie_po_inexistente_antes_de`
+só reduzem. Sem o filtro de status são 109, e a tabela INTEIRA tem 428 linhas: nem o universo
+acumulado alcança a capa.
+
+**Duas não eram — e cada uma escondia o `LIMIT` de um jeito diferente.**
+
+`carteira_por_municipio` **estava truncando, em produção, hoje**. O `LIMIT 1` que a fez parecer
+segura é do `SELECT … INTO` que resolve o NOME do município; o `RETURN QUERY` não tem LIMIT nenhum.
+Reproduzido o corpo como SELECT sobre a prod — `addresses` casado por `norm_cidade(city)` + UF com
+`radar_empresas`, `JOIN profiles` com `COALESCE(is_employee,false)=false`, agrupado por município —
+**DIVINÓPOLIS/MG = 1.014**. Catorze clientes da carteira caíam fora do planejamento de rota sem erro
+e sem toast: a assinatura exata do #1765, onde 227 clientes viraram veredito fabricado. Aqui o efeito
+é uma carteira que *parece* completa com 14 visitas a menos.
+
+`radar_prospects_para_rota` é o caso mais instrutivo da série, porque **hoje não perde nada**. O
+`LIMIT GREATEST(1, LEAST(p_limit, 2000))` com `PROSPECTS_POR_CIDADE = 1000` produz no máximo 1.000
+linhas — *exatamente* a capa. 1.000 pedidos, 1.000 entregues, nenhum sintoma. É o pior lugar em que
+um teto pode estar: o do TRANSPORTE e o do PRODUTO são o mesmo número por coincidência, e o do
+produto é uma **const TS que sobe com um caractere** — sem migration, sem SQL Editor, sem ritual.
+Subir para 1.500 devolveria 1.000 em silêncio, e há para onde subir: **80 municípios têm ≥1.000
+prospects elegíveis; São Paulo tem 25.512** (Divinópolis, 673, cabe inteira — o comentário no código
+dizia 600). Paginada, o teto passa a ser só o do produto.
+
+**Ordem total nas duas.** `user_id` é a chave do `DISTINCT ON (user_id)` da própria
+`carteira_por_municipio` — única por linha, e é o mesmo campo do dedupe entre cidades. `cnpj` é a
+**PK de `radar_empresas`** (`radar_empresas_pkey`), e os dois LEFT JOIN da função não multiplicam:
+`cep_geo` e `municipio_geo` têm PK única na coluna de junção (conferido no catálogo, zero duplicatas).
+Ordenar por `cnpj` não muda QUAIS linhas vêm: o `ORDER BY` de prioridade que escolhe as 1.000
+melhores é INTERNO à função, aplicado antes do LIMIT, e o consumidor re-pontua tudo com
+`enrichWithPriority`.
+
+**O furo do scanner, de novo — mesma cegueira, segundo disfarce.** No #1816 o Codex achou que o
+scanner só via `.rpc('nome')` com aspas simples. Desta vez o `(` **colado** em `.rpc` era o furo: o
+idioma dominante do repo para RPC ainda não tipada é o cast — `await (supabase.rpc as RpcFn)('nome',
+params)`. **53 das 125 ocorrências de `.rpc` em `src/` não são `.rpc(`**, e duas delas eram
+set-returning e estavam FORA da baseline: `radar_contagem_por_municipio` em
+`useRadarContagemMunicipios.ts` e `buscar_skus_candidatos` em `useProductSpecLink.ts`. Ambas com teto
+estrutural — mas isso o gate não sabia, porque nunca as viu. A tolerância entre `.rpc` e o literal
+passou de "nada" para "até 200 caracteres", e o que segura o falso positivo não é o regex: é a
+checagem no `types.ts`, porque o nome tem de ser uma função set-returning REAL. **Limite conhecido:**
+nome dinâmico (`.rpc(fn, params)`, em `services/pcp-apontamento.ts`) continua invisível — não há
+literal para casar, e heurística de fluxo aqui daria falsa cobertura. Vigiar por nome é o contrato.
+
+**Um silêncio de lado, fechado.** O `catch` de `loadCarteiraDaCidade` zerava a lista (fail-closed
+correto) mas **mudo** — tolerável enquanto a única falha possível era a leitura inteira cair. Com
+paginação nasce a falha PARCIAL (`fetchAllPages` lança se a página 2 falhar depois da 1 ter vindo), e
+aí "lista vazia sem aviso" fica indistinguível de "esta cidade não tem cliente na carteira". Ganhou
+`toast.error`, como o de prospects logo acima.
+
+**A lição que sobra não é sobre `LIMIT`, é sobre evidência.** "Tem `LIMIT` no corpo" descreve o
+**texto** da função, não o número de linhas que ela devolve. As duas perigosas só se separaram das
+seis seguras quando alguém contou — e uma delas já estava errando havia meses sem produzir um único
+sintoma. A BASELINE do gate ficou **sem nenhuma entrada `nao_medido`**: toda chamada set-returning
+sem `.range()` em `src/` hoje carrega teto com prova.

--- a/src/__tests__/rpc-set-returning-paginacao-gate.test.ts
+++ b/src/__tests__/rpc-set-returning-paginacao-gate.test.ts
@@ -37,6 +37,26 @@ import { resolve, join } from 'node:path';
  * — marcadas `nao_medido`, não "provavelmente pequeno", que seria o `Number(null)===0` da
  * apuração.
  *
+ * ⚠️ AS 8 ERAM AS QUE TINHAM `LIMIT` NO CORPO — e o `LIMIT` foi o disfarce, não a proteção.
+ * Medidas (2026-08-20, 2ª fatia), cinco tinham LIMIT constante mesmo e uma precisou de
+ * contagem; as outras duas eram as que o `LIMIT` escondia, cada uma de um jeito:
+ *
+ *   `carteira_por_municipio` — o `LIMIT 1` do corpo é do `SELECT … INTO` que resolve o NOME do
+ *       município. O `RETURN QUERY` não tem LIMIT nenhum. Teto = dado, e o dado é 1.014 em
+ *       DIVINÓPOLIS/MG: acima da capa. Não era risco futuro, estava truncando — 14 clientes da
+ *       carteira sumiam do planejamento de rota, em silêncio, exatamente como no #1765. PAGINA.
+ *
+ *   `radar_prospects_para_rota` — `LIMIT GREATEST(1, LEAST(p_limit, 2000))`, e o caller passa
+ *       `PROSPECTS_POR_CIDADE = 1000`. Teto EXATAMENTE igual à capa, que é o pior lugar para um
+ *       teto estar: nada se perde hoje (1.000 pedidos = 1.000 entregues), então nenhum sintoma
+ *       aponta para cá, e o número que separa "correto" de "trunca em silêncio" é uma const TS
+ *       que sobe com um caractere — sem migration, sem SQL Editor, sem ritual. E há para onde
+ *       subir: 80 municípios têm ≥1.000 prospects elegíveis, São Paulo tem 25.512. PAGINA.
+ *
+ * A lição que sobra é sobre a EVIDÊNCIA, não sobre `LIMIT`: "tem LIMIT no corpo" descreve o
+ * texto da função, não o número de linhas que ela devolve. As duas só se separaram das outras
+ * seis quando alguém contou.
+ *
  * ⚠️ Estar na baseline NÃO é atestado de segurança, e o waiver não é texto livre: cada entrada
  * declara a PROVA do teto e, quando essa prova envelhece (medição em dados), um PRAZO. O que
  * mora aqui é uma chamada que o gate CONSEGUE ver — durante um tempo o scanner só reconhecia
@@ -76,11 +96,36 @@ export function chamadasSemPaginacao(fonte: string, setReturning: Set<string>): 
   // em AdminReposicaoOportunidades). Enquanto o furo existiu, a frase "a baseline enumera a
   // dívida" era FALSA: o gate não olhava para o universo inteiro que dizia vigiar, e o
   // veredito verde vinha de não ter procurado — a versão-scanner do `Number(null)===0`.
-  // (Achado do Codex xhigh na revisão deste PR; conferido com `git grep '\.rpc("'`.)
-  for (const m of txt.matchAll(/\.rpc\(\s*(?:'([a-z0-9_]+)'|"([a-z0-9_]+)")/g)) {
+  // (Achado do Codex xhigh na revisão daquele PR; conferido com `git grep '\.rpc("'`.)
+  //
+  // E o `(` COLADO em `.rpc` era a MESMA cegueira num segundo disfarce, encontrado ao medir a
+  // 2ª fatia (2026-08-20). O idioma deste repo para RPC ainda não tipada é o cast:
+  //
+  //     await (supabase.rpc as RpcFn)('nome', params)
+  //     await (supabase.rpc as (fn: string, a: unknown) => ReturnType<typeof supabase.rpc>)('nome', p)
+  //
+  // — 53 das 125 ocorrências de `.rpc` em `src/` não são `\.rpc\(`, e duas delas eram
+  // set-returning e estavam FORA da baseline: `radar_contagem_por_municipio` em
+  // useRadarContagemMunicipios.ts e `buscar_skus_candidatos` em useProductSpecLink.ts. Ambas
+  // com teto estrutural — mas isso o gate não sabia, porque nunca as viu. Enumerar dívida com
+  // um scanner que não alcança o idioma dominante do repo é contar o que é fácil de contar.
+  //
+  // Por isso a tolerância entre `.rpc` e o literal deixou de ser "nada" e passou a ser "até 200
+  // caracteres", com a checagem de verdade no `types.ts`: o nome tem de ser uma função
+  // set-returning REAL. É o que segura o falso positivo — uma string arbitrária dentro da
+  // janela não vira achado por acaso; ela teria de coincidir com o nome de uma RPC que devolve
+  // ARRAY. Nome dinâmico (`.rpc(fn, params)`, como em `services/pcp-apontamento.ts`) continua
+  // invisível e é limite CONHECIDO: não há literal para casar, e inventar heurística de fluxo
+  // aqui daria falsa cobertura — vigiar por nome é o contrato deste gate.
+  const RE_RPC = /\.rpc\b[\s\S]{0,200}?(?:'([a-z0-9_]+)'|"([a-z0-9_]+)")/g;
+  for (const m of txt.matchAll(RE_RPC)) {
     const nome = m[1] ?? m[2];
     if (!setReturning.has(nome)) continue;
-    if (!/\.range\(/.test(txt.slice(m.index!, m.index! + 400))) achados.push(nome);
+    // A janela do `.range()` conta a partir do FIM do match, não do início: com o cast, o
+    // próprio match já consome até 200 caracteres, e medir da abertura encurtaria a busca
+    // justamente nas chamadas mais verbosas — que são as que este trecho passou a enxergar.
+    const depois = m.index! + m[0].length;
+    if (!/\.range\(/.test(txt.slice(depois, depois + 400))) achados.push(nome);
   }
   return achados;
 }
@@ -187,24 +232,29 @@ const BASELINE = new Map<string, Waiver>([
     { tipo: 'medido', teto: 3, medidoEm: '2026-08-20', revisarAte: '2027-08-20',
       prova: 'SELECT count(DISTINCT owner_user_id) FROM carteira_assignments = 3' }],
 
-  // ── NÃO medidas: 2ª fatia. Têm `LIMIT` no corpo, que NÃO é garantia — `LIMIT p_limit` com
-  //    parâmetro grande não protege, e o valor precisa ser conferido constante e < 1.000.
-  ['carteira_por_municipio @ src/hooks/useRoutePlanner.ts',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+  // ── 2ª fatia (2026-08-20): o `LIMIT` no corpo virou NÚMERO. Das 8, cinco tinham LIMIT
+  //    constante de verdade, uma precisou de contagem, e duas foram PAGINAR — ver o rodapé.
   ['fin_regua_condicao_prazo @ src/hooks/useCustoPrazoRegua.ts',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
-  ['get_whatsapp_pendentes @ src/hooks/useWhatsappPendentes.ts',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
-  ['listar_pedidos_a_separar @ src/queries/usePedidosASeparar.ts',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
-  ['radar_contagem_por_municipio @ src/queries/useRadarCidadesRota.ts',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
-  ['radar_prospects_para_rota @ src/hooks/useRoutePlanner.ts',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
-  ['reposicao_pos_candidatos @ src/pages/AdminReposicaoPedidos.tsx',
-    { tipo: 'nao_medido', bloqueio: 'MONEY-PATH: tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+    { tipo: 'estrutural', teto: 1, prova: '`LIMIT 1` constante no `RETURN QUERY` (busca a condição de pagamento por `codigo`+`empresa`)' }],
   ['reposicao_pos_marcador @ src/pages/AdminReposicaoPedidos.tsx',
-    { tipo: 'nao_medido', bloqueio: 'tem LIMIT no corpo; falta conferir se é constante e < 1.000', revisarAte: '2027-02-20' }],
+    { tipo: 'estrutural', teto: 1, prova: '`FROM (SELECT 1) AS sempre LEFT JOIN LATERAL (… ORDER BY seq DESC LIMIT 1)` — o lado esquerdo tem 1 linha e o LEFT JOIN preserva-a, então devolve exatamente 1 (o "sem marcador" vem como NULL, não como zero linhas)' }],
+  ['listar_pedidos_a_separar @ src/queries/usePedidosASeparar.ts',
+    { tipo: 'estrutural', teto: 100, prova: '`LIMIT 100` constante no `RETURN QUERY`' }],
+  ['get_whatsapp_pendentes @ src/hooks/useWhatsappPendentes.ts',
+    { tipo: 'estrutural', teto: 500, prova: '`LIMIT 500` constante (função SQL pura); o universo hoje é 0 — a janela é `last_inbound_at > now() - 24h` sem resposta' }],
+  ['radar_contagem_por_municipio @ src/queries/useRadarCidadesRota.ts',
+    { tipo: 'estrutural', teto: 500, prova: '`LIMIT GREATEST(1, LEAST(COALESCE(p_limit, 500), 2000))` nos DOIS ramos (fast e slow path) e o caller passa a constante literal `p_limit: 500`' }],
+  // ── Chamadas que o scanner só passou a ENXERGAR em 2026-08-20, quando aprendeu a ler o cast
+  //    `(supabase.rpc as RpcFn)('nome')`. Estavam no código o tempo todo, fora da baseline.
+  ['radar_contagem_por_municipio @ src/queries/useRadarContagemMunicipios.ts',
+    { tipo: 'estrutural', teto: 500, prova: 'mesma função da entrada acima, mesmo `LEAST(p_limit, 2000)`; este caller também passa a constante `p_limit: 500` (com os filtros do Radar, que só REDUZEM o conjunto)' }],
+  ['buscar_skus_candidatos @ src/hooks/useProductSpecLink.ts',
+    { tipo: 'estrutural', teto: 100, prova: '`LIMIT 100` constante no `RETURN QUERY` sobre `omie_products`' }],
+
+  // ── Teto MEDIDO nos dados: 2ª fatia ────────────────────────────────────────────────────
+  ['reposicao_pos_candidatos @ src/pages/AdminReposicaoPedidos.tsx',
+    { tipo: 'medido', teto: 101, medidoEm: '2026-08-20', revisarAte: '2027-08-20',
+      prova: 'MONEY-PATH. O único LIMIT do corpo é o `LIMIT 1` da CTE `marcador`; o `RETURN QUERY` não tem teto, então é dado. `SELECT upper(btrim(empresa)), count(*) FROM pedido_compra_sugerido WHERE status IN (disparado, aprovado_aguardando_disparo) AND omie_pedido_compra_id IS NOT NULL AND btrim(omie_pedido_compra_id) <> \'\' GROUP BY 1` — máx 101 (OBEN; COLACOR, a outra da enum `empresa_reposicao`, tem 0). É TETO SUPERIOR: os filtros `ls.run_id <> m.run_id` e `omie_po_inexistente_antes_de <= m.finalizado_em` só reduzem. Sem o filtro de status são 109, e a tabela INTEIRA tem 428 linhas — ou seja, nem o universo acumulado alcança a capa' }],
 ]);
 
 /**
@@ -330,6 +380,29 @@ describe('RPC set-returning chamada do frontend pagina', () => {
     // nem nos achados, e o verde do gate vinha de não ter procurado.
     expect(chamadasSemPaginacao(`const { data } = await supabase.rpc("minha_rpc_grande");`, setRet))
       .toEqual(['minha_rpc_grande']);
+
+    // CAST — o segundo disfarce da mesma cegueira, e o idioma DOMINANTE do repo para RPC ainda
+    // não tipada: 53 das 125 ocorrências de `.rpc` em `src/` não são `.rpc(`. Estas duas formas
+    // são literais dos dois callers que estavam fora da baseline até esta medição.
+    expect(
+      chamadasSemPaginacao(`const { data } = await (supabase.rpc as RpcFn)('minha_rpc_grande', params);`, setRet),
+    ).toEqual(['minha_rpc_grande']);
+    expect(
+      chamadasSemPaginacao(
+        `const { data, error } = await (\n` +
+          `  supabase.rpc as (fn: string, args: unknown) => ReturnType<typeof supabase.rpc>\n` +
+          `)('minha_rpc_grande', params);`,
+        setRet,
+      ),
+    ).toEqual(['minha_rpc_grande']);
+    // …e o cast PAGINADO continua absolvido: a janela do `.range()` conta do fim do match, senão
+    // a tolerância nova acusaria justamente quem já se defendeu.
+    expect(
+      chamadasSemPaginacao(
+        `fetchAllPages((de, ate) => (supabase.rpc as RpcFn)('minha_rpc_grande', p).order('id').range(de, ate), 'x')`,
+        setRet,
+      ),
+    ).toEqual([]);
     expect(
       chamadasSemPaginacao(
         `fetchAllPages((de, ate) => supabase.rpc("minha_rpc_grande").order('id').range(de, ate), 'x')`,

--- a/src/hooks/useRoutePlanner.ts
+++ b/src/hooks/useRoutePlanner.ts
@@ -46,10 +46,22 @@ import { montarDetalheAlvo, type AlvoDetalhe } from '@/lib/route/alvo-detalhe';
 import { ordenarFilaGeocode, ordenarFilaGeocodeCep } from '@/lib/route/geocode-fila';
 import { interpretarResolver } from '@/lib/route/cep-resolver';
 import { normalizarCep } from '@/lib/route/cep';
+import { fetchAllPages } from '@/lib/postgrest';
 
 // Teto de prospects por cidade pedido à RPC (a RPC capa em 2000 no SQL).
-// Divinópolis (600) cabe inteira; metrópole mostra os 1000 mais quentes.
+// Divinópolis (673) cabe inteira; metrópole mostra os 1000 mais quentes — e são MUITAS: em
+// 2026-08-20, 80 municípios têm ≥1.000 prospects elegíveis, São Paulo (7107) tem 25.512.
 const PROSPECTS_POR_CIDADE = 1000;
+
+/**
+ * O mínimo do builder do PostgREST que a paginação usa. Existe porque as duas RPCs abaixo
+ * entram por `as never` (tipos ainda não regenerados) e o `as never` apaga `.order`/`.range`
+ * do tipo — mesmo recurso de `financeiroV2Service.ts`.
+ */
+type LeituraOrdenavel<T> = {
+  order: (coluna: string, opts: { ascending: boolean }) => LeituraOrdenavel<T>;
+  range: (de: number, ate: number) => PromiseLike<{ data: T[] | null; error: unknown }>;
+};
 
 // Linha de route_visits enriquecida com o nome do cliente (resolvido via profiles).
 export type TodayVisitRow = Tables<'route_visits'> & { customerName: string };
@@ -813,19 +825,37 @@ export function useRoutePlanner() {
     setLoadingProspects(true);
     rawProspectById.current.clear();
     try {
-      const results = await Promise.all(
+      // PAGINADA: a capa de 1.000 do PostgREST vale para `.rpc()` e é SILENCIOSA (#1782, #1801).
+      // Aqui o empate era EXATO e por isso invisível: o `LIMIT GREATEST(1, LEAST(p_limit, 2000))`
+      // da RPC com `PROSPECTS_POR_CIDADE = 1000` produz no máximo 1.000 linhas — exatamente a
+      // capa. Hoje nada se perde (1.000 pedidos = 1.000 entregues), e é justamente esse empate
+      // que torna a armadilha traiçoeira: o teto do TRANSPORTE e o do PRODUTO são o mesmo número
+      // por coincidência, e o do produto é uma const TS que sobe com um caractere — sem migration,
+      // sem SQL Editor, sem ritual. Subir para 1.500 devolveria 1.000 sem erro e sem sinal, e a
+      // tela de rota mostraria "todos os prospects da cidade" com um terço a menos. Paginando, o
+      // teto passa a ser só o do produto (até os 2.000 do SQL).
+      //
+      // `cnpj` é a PK de `radar_empresas`, logo ordem TOTAL: LIMIT/OFFSET não pula nem repete.
+      // Ordenar por ela não altera QUAIS linhas vêm — o `ORDER BY` de prioridade que escolhe as
+      // 1.000 melhores é INTERNO à função, aplicado antes do LIMIT; o `.order()` daqui só ordena
+      // o resultado, e o consumidor abaixo re-pontua tudo com `enrichWithPriority`.
+      const porCidade = await Promise.all(
         cities.map((city) =>
-          supabase.rpc(
-            'radar_prospects_para_rota' as never,
-            { p_municipio_codigo: city.codigo, p_limit: PROSPECTS_POR_CIDADE } as never,
+          fetchAllPages<ProspectRow>(
+            (de, ate) =>
+              (
+                supabase.rpc(
+                  'radar_prospects_para_rota' as never,
+                  { p_municipio_codigo: city.codigo, p_limit: PROSPECTS_POR_CIDADE } as never,
+                ) as unknown as LeituraOrdenavel<ProspectRow>
+              )
+                .order('cnpj', { ascending: true })
+                .range(de, ate),
+            `radar_prospects_para_rota/${city.codigo}`,
           ),
         ),
       );
-      const rows: ProspectRow[] = [];
-      for (const { data, error } of results) {
-        if (error) throw error;
-        rows.push(...((data ?? []) as unknown as ProspectRow[]));
-      }
+      const rows: ProspectRow[] = porCidade.flat();
       const stops: RouteStop[] = rows.map((row) => {
         const draft = prospectRowToStopDraft(row);
         rawProspectById.current.set(draft.id, row);
@@ -871,13 +901,32 @@ export function useRoutePlanner() {
   const loadCarteiraDaCidade = useCallback(async (cities: CityOption[]) => {
     if (cities.length === 0) { setCarteiraCidadeStops([]); return; }
     try {
+      // PAGINADA, e aqui não era risco futuro: esta RPC não tem LIMIT nenhum no `RETURN QUERY`
+      // (o único `LIMIT 1` do corpo pertence ao `SELECT … INTO` que resolve o nome do município),
+      // então o teto é o DADO. Medido em prod 2026-08-20 via psql-ro, reproduzindo o corpo como
+      // SELECT — `SELECT count(DISTINCT a.user_id)` sobre `addresses` casado por
+      // `norm_cidade(city)` + UF com `radar_empresas`, `JOIN profiles` com
+      // `COALESCE(is_employee,false)=false`, agrupado por município: DIVINÓPOLIS/MG = 1.014.
+      // Acima da capa. Os 14 clientes da cauda sumiam do planejamento de rota em silêncio —
+      // é a assinatura exata do #1765, onde 227 clientes caíram fora do Map e viraram veredito
+      // fabricado. Aqui o efeito é uma carteira que PARECE completa com 14 visitas a menos.
+      //
+      // `user_id` é a chave do `DISTINCT ON (user_id)` da própria RPC, logo é única por linha:
+      // ordem TOTAL. É também o que o dedupe entre cidades usa logo abaixo.
       const perCity = await Promise.all(
         cities.map(async (city) => {
-          const { data, error } = await supabase.rpc('carteira_por_municipio', {
-            p_municipio_codigo: city.codigo,
-          });
-          if (error) throw error;
-          return { cityNome: city.nome, rows: (data ?? []) as unknown as CarteiraRow[] };
+          const rows = await fetchAllPages<CarteiraRow>(
+            (de, ate) =>
+              (
+                supabase.rpc('carteira_por_municipio', {
+                  p_municipio_codigo: city.codigo,
+                }) as unknown as LeituraOrdenavel<CarteiraRow>
+              )
+                .order('user_id', { ascending: true })
+                .range(de, ate),
+            `carteira_por_municipio/${city.codigo}`,
+          );
+          return { cityNome: city.nome, rows };
         }),
       );
       // Dedup por user_id (a primeira cidade que trouxe vence).
@@ -912,6 +961,13 @@ export function useRoutePlanner() {
     } catch (err) {
       console.error('Error loading carteira da cidade:', err);
       setCarteiraCidadeStops([]);
+      // O `catch` já zerava a lista (fail-closed correto), mas fazia isso MUDO — e mudo era
+      // tolerável enquanto a única falha possível era a leitura inteira cair. Com a paginação
+      // surge uma falha PARCIAL (`fetchAllPages` lança se a página 2 falhar depois da 1 ter
+      // vindo), e aí "lista vazia sem aviso" é indistinguível de "esta cidade não tem cliente
+      // na carteira" — o vazio-por-erro vestido de resposta legítima. O toast é o que separa
+      // os dois na tela; o prospects logo acima já avisava assim.
+      toast.error('Erro ao carregar a carteira da cidade');
     }
   }, []);
 


### PR DESCRIPTION
## Instância única ou classe?

**Classe — e esta é a fatia que a FECHA.** 4º capítulo de #1782 → #1801 → #1816. O escopo era
medir as 8 chamadas `nao_medido` da BASELINE do gate; o resultado é que a BASELINE fica **sem
nenhuma entrada `nao_medido`**: toda RPC set-returning chamada sem `.range()` em `src/` hoje
carrega teto com prova escrita.

## O que as 8 tinham em comum — e por que isso era o disfarce

As 8 restantes eram exatamente as que **tinham `LIMIT` no corpo**. Seis eram o que aparentavam.
Duas não, cada uma escondendo o `LIMIT` de um jeito diferente.

### 🔴 `carteira_por_municipio` — estava truncando EM PRODUÇÃO, hoje

O `LIMIT 1` que a fez parecer segura é do `SELECT … INTO` que resolve o **nome** do município.
O `RETURN QUERY` não tem LIMIT nenhum → o teto é o dado.

Medido na prod (psql-ro, reproduzindo o corpo como SELECT — `addresses` casado por
`norm_cidade(city)` + UF com `radar_empresas`, `JOIN profiles` com `COALESCE(is_employee,false)
= false`, agrupado por município):

| município | clientes |
|---|---|
| **DIVINÓPOLIS/MG** | **1.014** ← acima da capa |
| CARMO DO CAJURU/MG | 337 |
| NOVA SERRANA/MG | 317 |

**14 clientes da carteira caíam fora do planejamento de rota** — sem erro, sem toast. É a
assinatura exata do #1765 (227 clientes fora do Map → veredito fabricado). Aqui o efeito é uma
carteira que *parece* completa com 14 visitas a menos.

### 🟠 `radar_prospects_para_rota` — teto EXATAMENTE igual à capa

`LIMIT GREATEST(1, LEAST(p_limit, 2000))` e o caller passa `PROSPECTS_POR_CIDADE = 1000`. Hoje
**nada se perde** (1.000 pedidos = 1.000 entregues) — e é isso que torna a armadilha invisível:
nenhum sintoma aponta para cá. O teto do TRANSPORTE e o do PRODUTO são o mesmo número por
coincidência, e o do produto é uma **const TS que sobe com um caractere** — sem migration, sem
SQL Editor, sem ritual. Subir para 1.500 devolveria 1.000 em silêncio.

E há para onde subir: **80 municípios têm ≥1.000 prospects elegíveis; São Paulo tem 25.512**
(Divinópolis, 673, cabe inteira — o comentário no código dizia 600). Paginada, o teto passa a
ser só o do produto.

### ✅ As outras 6, com prova escrita na baseline

| RPC | teto | prova |
|---|---|---|
| `fin_regua_condicao_prazo` | 1 | `LIMIT 1` constante |
| `reposicao_pos_marcador` | 1 | `FROM (SELECT 1) LEFT JOIN LATERAL (… LIMIT 1)` — 1 linha por construção |
| `listar_pedidos_a_separar` | 100 | `LIMIT 100` constante |
| `get_whatsapp_pendentes` | 500 | `LIMIT 500` constante (universo hoje = 0) |
| `radar_contagem_por_municipio` | 500 | `LEAST(p_limit, 2000)` nos 2 ramos, **os 2 callers** passam `500` |
| `reposicao_pos_candidatos` ⚠️ money-path | **101** medido | teto SUPERIOR: os filtros de run/marcador só reduzem. Sem filtro de status = 109; a tabela INTEIRA = 428 |

## Ordem total (é o que faz paginação funcionar)

- `carteira_por_municipio` → **`user_id`**, a chave do `DISTINCT ON (user_id)` da própria RPC.
  É também o campo do dedupe entre cidades logo abaixo.
- `radar_prospects_para_rota` → **`cnpj`**, PK de `radar_empresas` (`radar_empresas_pkey`). Os
  dois LEFT JOIN não multiplicam: `cep_geo` e `municipio_geo` têm PK única na coluna de junção
  (conferido no catálogo, zero duplicatas). Ordenar por `cnpj` **não muda quais linhas vêm** —
  o `ORDER BY` de prioridade que escolhe as 1.000 melhores é INTERNO à função, antes do LIMIT,
  e o consumidor re-pontua tudo com `enrichWithPriority`.

## O furo do scanner: mesma cegueira do #1816, segundo disfarce

No #1816 o Codex achou que o scanner só via aspas simples. Desta vez o furo era o **`(` colado
em `.rpc`**. O idioma dominante do repo para RPC ainda não tipada é o cast:

```ts
await (supabase.rpc as RpcFn)('nome', params)
```

**53 das 125 ocorrências de `.rpc` em `src/` não são `.rpc(`**, e duas eram set-returning e
estavam FORA da baseline: `radar_contagem_por_municipio` (`useRadarContagemMunicipios.ts`) e
`buscar_skus_candidatos` (`useProductSpecLink.ts`). Ambas com teto estrutural — mas isso o gate
não sabia, porque nunca as viu.

A tolerância entre `.rpc` e o literal passou de "nada" para "até 200 caracteres". O que segura o
falso positivo **não é o regex**, é a checagem no `types.ts`: o nome tem de ser uma função
set-returning REAL.

**Limite conhecido, escrito no código:** nome dinâmico (`.rpc(fn, params)`, em
`services/pcp-apontamento.ts`) continua invisível — não há literal para casar, e heurística de
fluxo daria falsa cobertura. Vigiar por nome é o contrato deste gate.

## Um silêncio de lado, fechado

O `catch` de `loadCarteiraDaCidade` zerava a lista (fail-closed correto) mas **mudo** — tolerável
enquanto a única falha possível era a leitura inteira cair. Com paginação nasce a falha PARCIAL
(`fetchAllPages` lança se a página 2 falhar depois da 1 ter vindo), e aí "lista vazia sem aviso"
fica indistinguível de "esta cidade não tem cliente na carteira". Ganhou `toast.error`, como o de
prospects logo acima.

## Falsificação (o gate acusa de verdade)

3 sabotagens × 2 locales (`LC_ALL=C` e `pt_BR.UTF-8`), commit feito ANTES de sabotar, cada uma
ancorada no par `.rpc('<nome>')` + chave de ordem (não num `.order` solto — o arquivo tem ~10
`.from().order()` que casariam por acaso):

| sabotagem | C | pt_BR.UTF-8 |
|---|---|---|
| remove `.range()` de `carteira_por_municipio` | 🔴 exit 1, acusou | 🔴 exit 1, acusou |
| remove `.range()` de `radar_prospects_para_rota` | 🔴 exit 1, acusou | 🔴 exit 1, acusou |
| tira da BASELINE a chamada que **só o scanner novo enxerga** | 🔴 exit 1, acusou | 🔴 exit 1, acusou |
| **controle** (sem sabotagem) | 🟢 exit 0 | 🟢 exit 0 |

A 3ª é a que prova o scanner novo num **arquivo real**, não só nas fixtures puras (que também
ganharam os dois casos de cast).

## Validação

- `heavy bun run typecheck` → exit 0
- `heavy bun run test` (COMPLETO — mudar `.rpc()` quebra dublês por cascata) → ver checks
- `heavy bun lint` · `bunx knip` → ver checks

## Deploy

**Frontend-only, sem migration.** Nenhuma função SQL foi tocada — a medição foi toda por
`pg_get_functiondef` + reprodução do corpo como SELECT (leitura). Deploy = **Publish** do
frontend no Lovable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
