### PR TITLE
docs(gates): a sub-classe SQL não estava limpa — o eixo vivo é `--` em literal (16/656), não `/*`

### DIFF
--- a/docs/historico/gates-textuais-cegos.md
+++ b/docs/historico/gates-textuais-cegos.md
@@ -85,9 +85,27 @@ extremo — e o comentário no teste diz explicitamente que ela NÃO teria pego 
   impacto** — os alvos deles (`calculate-scores/index.ts`, `generate-bundle-argument/index.ts`,
   `_shared/cmc-snapshot-retry.ts`, `omie-analytics-sync/politica-retry.ts`) não estão na tabela acima.
   Latente, não ativo. Chip próprio.
-- **Sub-classe SQL** (`scripts/lib/authz-contract.ts`, `import-tint-formulas-aposentada-gate`) e
-  **sub-classe CSS** (`table-overscroll.test.ts`): gramática diferente (`--`, dollar-quoting; `content:`).
-  Varredura de hoje: **zero** `/*` dentro de literal em `supabase/migrations/*.sql` e em `src/index.css`.
+- **Sub-classe CSS** (`table-overscroll.test.ts`): insumo é um arquivo só (`src/index.css`), sob nosso
+  controle; varredura deu **zero**. Registro, sem chip.
+- **Sub-classe SQL — NÃO está limpa, e o eixo é outro.** Medido em 2026-08-20 (2ª rodada, sobre as 656
+  migrations), separando os eixos:
+
+  | eixo | exposição |
+  | --- | --- |
+  | `/*` dentro de literal | **0/656** |
+  | bloco ANINHADO (`/* /* */ */` — Postgres permite, e `[\s\S]*?` fecha no `*/` interno) | **0/656** |
+  | **`--` dentro de literal** | **16/656** |
+
+  `stripComments` (`scripts/lib/authz-contract.ts`) faz `.replace(/--[^\n]*/g, ' ')` **sem olhar string**,
+  e o docstring imediatamente acima dele afirma *"preserva strings e dollar-quotes"* — invariante
+  **DECLARADA** que o código não cumpre, no gate de **authz**: o lugar mais caro do repo para ficar cego.
+  Casos reais: `20260703090000_pedidos_programados.sql` tem `'FORMA DE PGTO BOLETO\n\n-- --\nOperação
+  contratada…'`; `20260727120000_tint_fase5_desativa_geracao_legada.sql` e
+  `20260724130000_authz_custo_fu4f_fase3_recommend.sql` carregam o literal `'--[^\n]*'` como DADO.
+
+  É irmã desta classe, não a mesma: o mecanismo é idêntico (limpeza que não entende literal), o
+  delimitador é `--` em vez de `/*`. Chip próprio — e o passo 1 dele é MEDIR se algum veredito do
+  `authz:check` muda, porque exposição não é dano até a medição dizer que é.
 
 ## Assinatura para varredura futura
 


### PR DESCRIPTION
## Instância única ou classe?

**Correção de um denominador que publiquei sem medir no eixo certo.** O #1825 registrou a sub-classe SQL como "zero" — e era zero **no eixo `/*`**. Separando os eixos sobre as 656 migrations:

| eixo | exposição |
| --- | --- |
| `/*` dentro de literal | 0/656 |
| bloco **ANINHADO** (`/* /* */ */` — o Postgres permite, e `[\s\S]*?` fecha no `*/` interno) | 0/656 |
| **`--` dentro de literal** | **16/656** |

## Por que importa

`stripComments` em `scripts/lib/authz-contract.ts`:

```ts
return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
```

O segundo `.replace` come até o fim da linha **sem olhar se está dentro de literal** — e o docstring imediatamente acima da função **afirma** *"preserva strings e dollar-quotes"*. É invariante **declarada** que o código não cumpre, e o consumidor é `extractFunctions` + `authz-reescrita.ts` — o gate de **authz**, o lugar mais caro do repo para ficar cego.

Casos reais nas migrations:
- `20260703090000_pedidos_programados.sql` — `'FORMA DE PGTO BOLETO\n\n-- --\nOperação contratada…'`
- `20260727120000_tint_fase5_desativa_geracao_legada.sql` e `20260724130000_authz_custo_fu4f_fase3_recommend.sql` — carregam o literal `'--[^\n]*'` como **dado**

## O que este PR faz (e o que NÃO faz)

Só corrige o registro. **Não** mexe no stripper SQL — porque **exposição não é dano até a medição dizer que é**, e a medição certa é rodar o `authz:check` com os dois strippers e comparar veredito a veredito. Isso é o passo 1 do chip, não deste PR.

Chip criado: **"Medir se o `--` em literal cega o gate de authz"** — com os três eixos já medidos no briefing e a instrução explícita de começar medindo, não consertando.

## Validação

- `scripts/docs-citacoes-gate-check.ts` → exit 0
- `scripts/docs-indice-gate-check.ts` → exit 0
- Diff é só `docs/historico/gates-textuais-cegos.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)