### PR TITLE
fix(farmer): `completo` não garante o UNIVERSO certo — o gatilho ganha ÉPOCA e o cross-sell zera [money-path]

### DIFF
--- a/db/gatilho-farmer-fase2.sql
+++ b/db/gatilho-farmer-fase2.sql
@@ -50,6 +50,19 @@
 --    superficie nao esta em uso; a fase N+1 aqui e INSTALAR O USO, nao aguardar o sinal.
 --    Por isso `taxa_7d` e `farmers_com_carteira` saem na propria linha: um denominador que nao
 --    cresce e um fato observavel, e o veredito ESTAGNADO o nomeia em vez de repetir "aguarde".
+--
+-- 6. **`completo` não garante que o universo lido era o CERTO.** Até o #1822 (merge 20/08
+--    23:58) os dois motores filtravam `sales_orders` por `status IN ('confirmado','faturado',
+--    'entregue')` — e DOIS desses status nunca existiram nesta tabela: a allowlist tinha sido
+--    copiada de outra. As leituras não falhavam, não truncavam em 1.000, e saíam `ok:true`;
+--    simplesmente enxergavam menos base. Medido: as 10 execucoes de cross_sell leram
+--    `pedidos=861`; a 1a execucao POSTERIOR ao fix leu **1227** — mesma farmer, +42%.
+--
+--    Nenhuma assinatura numerica pega isso (n=1000 e cap do PostgREST, nao allowlist errada),
+--    e `completude='completo'` e verdadeiro e inutil aqui: o insumo FOI lido com sucesso, da
+--    fonte errada. Por isso a EPOCA abaixo — execucao anterior a ela mediu outro universo e
+--    nao entra no mesmo denominador, do mesmo jeito que `vazios_pre_cobertura`. Ao corrigir
+--    um bug que muda o UNIVERSO lido, AVANCE a epoca; o que conta e o Publish, nao o merge.
 WITH motores AS (
   -- Esqueleto FIXO: o motor que nunca executou precisa APARECER com zero. Um `GROUP BY motor`
   -- sozinho simplesmente não produz linha para ele, e a ausência seria lida como "não há nada
@@ -68,11 +81,20 @@ marcada AS (
             WHERE (val->>'n')::int = 1000) AS tem_cap
   FROM public.farmer_geracao_execucoes
 ),
+epoca AS (
+  -- Merge do #1822 (o Publish veio depois; a 1a execucao com universo correto e 21/08 01:33).
+  -- Usar o merge e o piso CONSERVADOR: nunca inclui execucao que rodou com o codigo velho.
+  SELECT '2026-08-20T23:58:43Z'::timestamptz AS inicio
+),
 corte AS (
   -- Janela POR MOTOR: o cap que envenenou o cross-sell não pode descartar execução do bundle.
   SELECT
     mo.motor,
-    COALESCE(max(ma.calculado_em) FILTER (WHERE ma.tem_cap), '-infinity'::timestamptz) AS janela_desde,
+    GREATEST(
+      COALESCE(max(ma.calculado_em) FILTER (WHERE ma.tem_cap), '-infinity'::timestamptz),
+      (SELECT inicio FROM epoca)
+    )                                                                                  AS janela_desde,
+    count(*) FILTER (WHERE ma.calculado_em <= (SELECT inicio FROM epoca))               AS pre_epoca,
     count(*) FILTER (WHERE ma.tem_cap)                                                 AS descartadas_cap,
     -- Contaminação ATIVA ≠ passada: se a execução MAIS RECENTE deste motor ainda vem truncada,
     -- o cliente no ar segue truncando e nenhuma janela nova é confiável.
@@ -84,7 +106,7 @@ corte AS (
 ),
 obs AS (
   SELECT
-    c.motor, c.descartadas_cap, c.cap_ativo,
+    c.motor, c.descartadas_cap, c.cap_ativo, c.pre_epoca,
     count(m.calculado_em)                                             AS execucoes_totais,
     -- O cliente ANTERIOR ao Publish não declarava insumo nenhum: conta como "rodou",
     -- nunca como evidência sobre completude.
@@ -119,16 +141,21 @@ obs AS (
   -- a query tem de devolver a linha DELE dizendo isso, e nao omiti-lo — linha ausente seria
   -- lida como "nao ha o que relatar", que e o ausente=zero.
   LEFT JOIN marcada m ON m.motor = c.motor AND m.calculado_em > c.janela_desde
-  GROUP BY c.motor, c.descartadas_cap, c.cap_ativo
+  GROUP BY c.motor, c.descartadas_cap, c.cap_ativo, c.pre_epoca
 )
 SELECT
   motor, execucoes_totais, julgaveis, vazios_completos, vazios_pre_cobertura,
-  descartadas_cap, farmers, farmers_com_carteira, exec_7d, desde, ultima,
+  descartadas_cap, pre_epoca, farmers, farmers_com_carteira, exec_7d, desde, ultima,
   CASE
     WHEN cap_ativo THEN
       'CONTAMINADO (ATIVO) — a execucao MAIS RECENTE deste motor ainda traz insumo de exatamente '
       || '1000 linhas. O cliente no ar segue truncando em silencio: nenhuma janela nova e '
       || 'confiavel. Corrija a paginacao e faca o Publish ANTES de julgar qualquer vazio.'
+    WHEN execucoes_totais = 0 AND pre_epoca > 0 THEN
+      'ZERADO POR EPOCA — ' || pre_epoca || ' execucao(oes) existem, mas TODAS anteriores ao '
+      || 'fix da allowlist de status (#1822): elas leram um universo de pedidos MENOR (861 '
+      || 'contra 1227 apos o fix) e nao medem a mesma coisa. Nao e "nunca rodou" nem "deu '
+      || 'vazio" — e denominador ZERADO por troca de universo. Exercer a tela de novo repovoa.'
     WHEN execucoes_totais = 0 THEN
       'SEM DENOMINADOR — este motor NUNCA executou. Nao e "o vazio nao acontece": e superficie '
       || 'sem sensor exercido. Os dois motores nao acumulam igual — FarmerRecommendations '

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -303,6 +303,23 @@ denominador que não cresce. Falsificado com 5 execuções há 30 dias (`ESTAGNA
 **A regra:** todo veredito de espera tem de carregar a taxa que o justifica. Sem ela, "aguarde" não
 é uma decisão — é o silêncio com cara de decisão.
 
+⚠️ **E `completo` que não garante o UNIVERSO certo.** Até o #1822 os dois motores filtravam
+`sales_orders` por `status IN ('confirmado','faturado','entregue')` — e **dois desses status nunca
+existiram nesta tabela**: a allowlist tinha sido copiada de outra. As leituras não falhavam, não
+truncavam em 1.000, saíam `ok:true` e `completude='completo'`. Só enxergavam menos base. Medido no
+mesmo farmer: `pedidos=861` nas 10 execuções pré-fix contra **1227** na primeira pós-fix, +42%.
+
+Nenhuma assinatura numérica pega isso — `n=1000` é cap do PostgREST, não allowlist errada — e
+`completo` aqui é **verdadeiro e inútil**: o insumo foi lido com sucesso, da fonte errada. É o
+limite do rótulo que esta linha inteira construiu: completude atesta que a leitura não falhou,
+nunca que ela mirava o lugar certo.
+
+Daí a **época** (o conceito do #1796): execução anterior ao fix mediu outro universo e não entra no
+mesmo denominador. Ao corrigir um bug que muda o universo lido, **avance a época** — e o que conta
+é o Publish, não o merge. Efeito imediato e desconfortável: o cross-sell caiu de "3 julgáveis" para
+**zero**, porque as 3 que pareciam limpas liam a base errada.
+
+
 
 
 ### Onde a regra NÃO se aplica


### PR DESCRIPTION
## O defeito

Até o #1822 (merge 20/08 23:58) os dois motores filtravam `sales_orders` por `status IN ('confirmado','faturado','entregue')` — e **dois desses status nunca existiram nesta tabela**. A allowlist tinha sido copiada de outra.

As leituras não falhavam, não truncavam em 1.000, saíam `ok:true` e `completude='completo'`. Só **enxergavam menos base**.

Medido no mesmo farmer (`414a9727`):

| execuções | `pedidos` lidos |
|---|---|
| 10 de `cross_sell` (pré-fix) | **861** |
| 1 de `bundle` (pós-fix) | **1227** |

Só ~37 pedidos foram criados no intervalo — não é crescimento, é universo diferente.

**Nenhuma assinatura numérica pega isso** (`n=1000` é cap do PostgREST, não allowlist errada), e `completo` aqui é *verdadeiro e inútil*: o insumo foi lido com sucesso, **da fonte errada**. É o limite do rótulo que esta linha construiu — completude atesta que a leitura não falhou, nunca que ela mirava o lugar certo.

## A correção — época

Conceito do #1796. A janela julgável vira `GREATEST(ultima_contaminada, epoca)`, e execução anterior sai em **`pre_epoca`** — mesmo padrão de `vazios_pre_cobertura`, que existe justamente para não somar a zero o que não mede a mesma coisa.

Ramo novo **`ZERADO POR EPOCA`**, distinto de `SEM DENOMINADOR`: *"existem execuções, mas nenhuma comparável"* não é *"nunca rodou"*.

> ⚠️ Ao corrigir um bug que muda o **universo lido**, avance a época. O que conta é o **Publish**, não o merge.

## Efeito imediato, e é desconfortável

```
cross_sell | 0 julgaveis | ZERADO POR EPOCA — 10 execucoes, TODAS pre-fix
bundle     | 1 julgavel  | AGUARDE (1/20)
```

O cross-sell **cai de 3 julgáveis para zero**. As 3 que o gatilho reportava como limpas liam a base errada.

## Falsificação

| cenário | veredito |
|---|---|
| 5 execuções **antes** da época | `ZERADO POR EPOCA` |
| 5 execuções **depois** | `AGUARDE` |

Read-only: script de consulta (`psql-ro`), não migration. Nada a aplicar nem publicar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)