### PR TITLE
fix(gates): `--` dentro de literal cegava o stripper do authz — medi até o VEREDITO: 6/656 expostos, dano ZERO, troquei enquanto a troca é neutra

### DIFF
--- a/docs/historico/gates-textuais-cegos.md
+++ b/docs/historico/gates-textuais-cegos.md
@@ -87,25 +87,51 @@ extremo — e o comentário no teste diz explicitamente que ela NÃO teria pego 
   Latente, não ativo. Chip próprio.
 - **Sub-classe CSS** (`table-overscroll.test.ts`): insumo é um arquivo só (`src/index.css`), sob nosso
   controle; varredura deu **zero**. Registro, sem chip.
-- **Sub-classe SQL — NÃO está limpa, e o eixo é outro.** Medido em 2026-08-20 (2ª rodada, sobre as 656
-  migrations), separando os eixos:
+- **Sub-classe SQL — eixo `--`, medida ATÉ O VEREDITO (3ª rodada, 2026-08-20). Exposição real, dano
+  zero, blindada mesmo assim.** É irmã desta classe, não a mesma: mecanismo idêntico (limpeza que não
+  entende literal), delimitador `--` em vez de `/*`.
 
-  | eixo | exposição |
-  | --- | --- |
-  | `/*` dentro de literal | **0/656** |
-  | bloco ANINHADO (`/* /* */ */` — Postgres permite, e `[\s\S]*?` fecha no `*/` interno) | **0/656** |
-  | **`--` dentro de literal** | **16/656** |
+  | eixo | exposição | veredito do `authz:check` |
+  | --- | --- | --- |
+  | `/*` dentro de literal | 0/656 | — |
+  | bloco ANINHADO (`/* /* */ */` — Postgres permite, e `[\s\S]*?` fecha no `*/` interno) | 0/656 | — |
+  | **`--` dentro de literal** | **6/656** | **não muda (byte-a-byte)** |
 
-  `stripComments` (`scripts/lib/authz-contract.ts`) faz `.replace(/--[^\n]*/g, ' ')` **sem olhar string**,
-  e o docstring imediatamente acima dele afirma *"preserva strings e dollar-quotes"* — invariante
-  **DECLARADA** que o código não cumpre, no gate de **authz**: o lugar mais caro do repo para ficar cego.
-  Casos reais: `20260703090000_pedidos_programados.sql` tem `'FORMA DE PGTO BOLETO\n\n-- --\nOperação
-  contratada…'`; `20260727120000_tint_fase5_desativa_geracao_legada.sql` e
-  `20260724130000_authz_custo_fu4f_fase3_recommend.sql` carregam o literal `'--[^\n]*'` como DADO.
+  **O `16/656` da rodada anterior não reproduz.** Três métodos independentes convergem em **6**: (a)
+  walker de gramática recursivo, (b) diff do SQL entregue ao parser pelos dois strippers ignorando
+  espaço, (c) contagem ingênua de aspas ímpares antes do `--` na linha. Os três apontam o MESMO
+  conjunto de 6 arquivos. Denominador publicado só vale com o método junto.
 
-  É irmã desta classe, não a mesma: o mecanismo é idêntico (limpeza que não entende literal), o
-  delimitador é `--` em vez de `/*`. Chip próprio — e o passo 1 dele é MEDIR se algum veredito do
-  `authz:check` muda, porque exposição não é dano até a medição dizer que é.
+  **O que a medição do dano diz** — e é o ponto: rodar `authz:check --json` com o stripper velho e com
+  o novo dá saída **byte-a-byte idêntica** (`ok:true`, 8 avisos). A sonda mais sensível, um dump de
+  `extractFunctions` + `detectarReescritaViva` das 656 migrations, também é **idêntica** — e a sonda foi
+  **falsificada** (com o stripper virando no-op, 254/656 arquivos mudam, então ela enxerga).
+  A razão é **estrutural, não sorte**: os 6 sítios ficam **fora de corpo de `CREATE FUNCTION`** — 5 dentro
+  de bloco `DO $tag$` (assertivas que fazem `regexp_replace(pg_get_functiondef(…), '--[^\n]*', …)`, ou
+  seja, carregam o próprio padrão como DADO) e 1 num arquivo sem função nenhuma (o template fiscal
+  `E'FORMA DE PGTO BOLETO\n\n-- --\n…'` de `20260703090000_pedidos_programados.sql`). O parser da Parte
+  A/B só lê corpo de `CREATE FUNCTION`; a Parte D exige `pg_get_functiondef` **+ EXECUTE**.
+
+  **Mesmo assim foi trocado**, e a neutralidade é justamente o argumento: `stripComments` passou a
+  delegar para `scripts/lib/sql-comentarios.ts` (máquina de estados: `''` escapado, `E'…\'…'`,
+  `"ident"`, `$tag$` recursivo, bloco ANINHADO). Trocar quando a saída é **provadamente igual** é a
+  adoção mais barata que existe — depois vira migração de veredito. E o que estava aberto não era a
+  exposição, era a **invariante DECLARADA**: o docstring afirmava *"preserva strings e dollar-quotes"*
+  enquanto o código não preservava. A inércia de hoje é contingente ao corpus: o dia em que alguém
+  escrever `regexp_replace(…, '--[^\n]*', …)` **dentro** de uma SECDEF — e há um `DO` block a poucas
+  linhas de distância que já faz exatamente isso — a cegueira cai sobre o gate de authz.
+
+  **Decisão de gramática que não é óbvia:** `$tag$…$tag$` **não** é tratado como opaco. Um lexer puro
+  pararia ali; aqui o consumidor é o gate de authz, cuja razão de existir é não ser enganado por
+  `-- gate comentado` DENTRO do corpo. Medido: tratar como opaco divergia do stripper anterior em
+  **277/656** migrations. O interior é re-analisado com a mesma gramática.
+
+  **Sentinela** (herdado de `maiorBlocoDescartado`): `maiorBlocoDescartadoSql` + teto de **300** linhas
+  em `scripts/sql-comentarios.test.ts`. Calibração medida: maior bloco LEGÍTIMO descartado nas 656
+  migrations = **175** (`20260615130000_tint_vigia_cobertura_sentinela.sql`); um `/*` que nunca fecha
+  no quarto inicial dos 3 maiores arquivos devolve **676–762**. O teto fica 1,7× acima do legítimo e
+  2,3× abaixo do estrago — a mesma folga do sentinela irmão (150 sobre 88). O teste também **prova o
+  alarme disparando** num arquivo envenenado: alarme que nunca se viu disparar é decoração.
 
 ## Assinatura para varredura futura
 
@@ -115,3 +141,11 @@ rg -n "replace\(/\\\\/\\\\\*\[\\\\s\\\\S\]\*\?\\\\\*\\\\//" src/ supabase/ scrip
 
 Casa toda cópia do stripper regex. Em `.ts/.tsx` de `src/`, o correto é importar
 `removerComentarios` de `@/lib/gates/limpeza-fonte`.
+
+O eixo `--` (SQL) tem assinatura própria — casa quem limpa comentário de SQL sem gramática:
+
+```bash
+rg -n "replace\(/--\[\^" src/ supabase/ scripts/ db/
+```
+
+Quem lê SQL deve importar `removerComentariosSql` de `scripts/lib/sql-comentarios.ts`.

--- a/scripts/lib/authz-contract.ts
+++ b/scripts/lib/authz-contract.ts
@@ -34,6 +34,7 @@
  * migration maliciosa passa por review humano; o complemento é o audit read-only periódico em PROD).
  */
 import { balancedParens, normalizeSignature } from './migration-objects';
+import { removerComentariosSql } from './sql-comentarios';
 
 // Sem `export`: consumidos só por `touchesSensitive()` logo abaixo. Quem precisa da resposta
 // chama a função, que é a superfície pública — a lista crua exportada convidava a duplicar a
@@ -122,9 +123,17 @@ export interface GateResult {
  * Exportado porque `authz-reescrita.ts` precisa da MESMA regra: lá os alvos são literais de
  * string (`'public.f(text)'`), então `stripNoise` — que mascara strings — apagaria justamente
  * o dado procurado. Duas cópias da regra divergiriam no primeiro ajuste.
+ *
+ * (2026-08-20) Este docstring era uma invariante DECLARADA que o código não cumpria: a
+ * implementação era um `.replace` de regex "`--` até a quebra de linha", que come sem olhar
+ * se está dentro de literal — e `'--[^\n]*'` aparece como DADO nas próprias migrations de authz.
+ * Trocado pelo walker de `./sql-comentarios`, que conhece a gramática. A troca foi medida antes
+ * de ser feita e é NEUTRA no corpus de hoje: `extractFunctions` + `detectarReescritaViva` dão
+ * saída idêntica nas 656 migrations e o `authz:check --json` sai byte-a-byte igual. Ver
+ * docs/historico/gates-textuais-cegos.md §sub-classe SQL.
  */
 export function stripComments(sql: string): string {
-  return sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+  return removerComentariosSql(sql);
 }
 
 /** remove comentários E mascara string-literais → '' (corpo executável p/ busca de gate/tabela) */

--- a/scripts/lib/sql-comentarios.ts
+++ b/scripts/lib/sql-comentarios.ts
@@ -1,0 +1,194 @@
+// Limpeza de COMENTÁRIO em SQL para gates textuais — a que entende a gramática do Postgres.
+//
+// Irmã da `src/lib/gates/limpeza-fonte.ts` (eixo `/*` em .ts/.tsx, classe medida em 2026-08-20,
+// docs/historico/gates-textuais-cegos.md). Aqui o eixo VIVO é outro: o stripper anterior era
+//   sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ')
+// e o segundo `.replace` come de `--` até o fim da linha SEM olhar se está dentro de literal.
+//
+// A gramática do Postgres pede quatro coisas que regex não sabe fazer:
+//  1. `'…'` é literal e `''` é a aspa escapada dentro dele — `--` ali dentro é DADO, não comentário;
+//  2. `E'…'` ainda aceita `\'` como escape (as outras formas não, com standard_conforming_strings);
+//  3. `$tag$…$tag$` delimita o corpo, e o `--` DENTRO dele ainda é comentário de PL/pgSQL;
+//  4. comentário de bloco ANINHA (`/* /* */ */` é UM comentário) — `[\s\S]*?` fecharia no `*/` interno.
+//
+// CONTRATO: remove comentário de linha e de bloco, e NADA MAIS. O que sai vira ESPAÇO, mas as
+// quebras de linha do trecho descartado são preservadas — o resultado tem o mesmo número de linhas
+// da entrada, de propósito (gate que casa `^…` multiline ou compara posição segue medindo o mesmo).
+//
+// DECISÃO — dollar-quote NÃO é tratado como opaco, e isto é deliberado (medido: tratá-lo como
+// opaco divergia do stripper anterior em 277/656 migrations, todas por deixar comentário de PL/pgSQL
+// entrar no corpo). Um lexer puro pararia no `$tag$`; aqui o CONSUMIDOR é o gate de authz, cuja
+// razão de existir é justamente não ser enganado por `-- gate comentado` DENTRO do corpo. Então o
+// interior é re-analisado com a mesma gramática. O preço: `$$texto -- com traço$$` usado como DADO
+// perderia o traço — igual ao stripper anterior, e irrelevante p/ quem lê estrutura de função.
+//
+// INVARIANTE: o resultado tem o MESMO comprimento da entrada (comentário vira espaço, `\n` fica).
+// É o que mantém `extractFunctions` — que fatia corpo por índice — coerente, e é falsificável.
+//
+// LIMITE CONHECIDO (deliberado): literal ou dollar-quote que NÃO fecha é lido como caractere comum
+// e o walker ressincroniza no próximo caractere — em vez de engolir até o EOF. Comentário de bloco
+// que não fecha é o único caso que consome até o fim (é o que um lexer de verdade faz); o alarme
+// para isso é `maiorBlocoDescartadoSql`, herdado do sentinela da irmã .ts.
+
+// Um `$` só abre dollar-quote se vier `$tag$` com tag vazia ou identificador (nunca começando com
+// dígito) — senão é parâmetro (`$1`) ou operador.
+const TAG_DOLLAR = /^\$(?:[A-Za-z_\u0080-\uffff][A-Za-z0-9_\u0080-\uffff]*)?\$/;
+
+// `E'…'`/`e'…'` liga escape de barra invertida; `U&'…'`, `B'…'`, `X'…'` e o literal nu não ligam.
+function ligaBarraInvertida(sql: string, aspa: number): boolean {
+  const anterior = sql[aspa - 1];
+  if (anterior !== 'E' && anterior !== 'e') return false;
+  // Só é prefixo se o `E` não for o fim de um identificador — `nome_e'…'` seria lido errado sem isto.
+  const antes = sql[aspa - 2];
+  return antes === undefined || !/[A-Za-z0-9_$\u0080-\uffff]/.test(antes);
+}
+
+// Índice logo APÓS a aspa que fecha o literal, ou -1 se não fechar.
+function fimDeLiteral(sql: string, ini: number, barraEscapa: boolean): number {
+  let i = ini + 1;
+  while (i < sql.length) {
+    const c = sql[i];
+    if (barraEscapa && c === '\\') {
+      i += 2;
+      continue;
+    }
+    if (c === "'") {
+      if (sql[i + 1] === "'") {
+        i += 2;
+        continue;
+      }
+      return i + 1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+// Índice logo APÓS a aspa dupla que fecha o identificador quotado (`""` escapa), ou -1.
+function fimDeIdentificador(sql: string, ini: number): number {
+  let i = ini + 1;
+  while (i < sql.length) {
+    if (sql[i] === '"') {
+      if (sql[i + 1] === '"') {
+        i += 2;
+        continue;
+      }
+      return i + 1;
+    }
+    i++;
+  }
+  return -1;
+}
+
+// Índice logo APÓS o `*/` que fecha o comentário de bloco, contando ANINHAMENTO; length se não fechar.
+function fimDeBloco(sql: string, ini: number): number {
+  let profundidade = 1;
+  let i = ini + 2;
+  while (i < sql.length && profundidade > 0) {
+    if (sql[i] === '/' && sql[i + 1] === '*') {
+      profundidade++;
+      i += 2;
+      continue;
+    }
+    if (sql[i] === '*' && sql[i + 1] === '/') {
+      profundidade--;
+      i += 2;
+      continue;
+    }
+    i++;
+  }
+  return i;
+}
+
+export function removerComentariosSql(sql: string): string {
+  const partes: string[] = [];
+  const branco = (trecho: string) => trecho.replace(/[^\n]/g, ' ');
+  let i = 0;
+  let inicioTrecho = 0;
+  const n = sql.length;
+
+  const empurrarCodigo = (ate: number) => {
+    if (ate > inicioTrecho) partes.push(sql.slice(inicioTrecho, ate));
+  };
+
+  while (i < n) {
+    const c = sql[i];
+    if (c !== '-' && c !== '/' && c !== "'" && c !== '"' && c !== '$') {
+      i++;
+      continue;
+    }
+
+    if (c === '-' && sql[i + 1] === '-') {
+      empurrarCodigo(i);
+      let j = i;
+      while (j < n && sql[j] !== '\n') j++;
+      partes.push(branco(sql.slice(i, j)));
+      i = j;
+      inicioTrecho = i;
+      continue;
+    }
+
+    if (c === '/' && sql[i + 1] === '*') {
+      empurrarCodigo(i);
+      const fim = fimDeBloco(sql, i);
+      partes.push(branco(sql.slice(i, fim)));
+      i = fim;
+      inicioTrecho = i;
+      continue;
+    }
+
+    if (c === "'") {
+      const fim = fimDeLiteral(sql, i, ligaBarraInvertida(sql, i));
+      i = fim === -1 ? i + 1 : fim; // não fechou ⇒ apóstrofo solto: ressincroniza, não engole
+      continue;
+    }
+
+    if (c === '"') {
+      const fim = fimDeIdentificador(sql, i);
+      i = fim === -1 ? i + 1 : fim;
+      continue;
+    }
+
+    if (c === '$') {
+      const m = TAG_DOLLAR.exec(sql.slice(i, i + 128));
+      if (m) {
+        const tag = m[0];
+        const fim = sql.indexOf(tag, i + tag.length);
+        if (fim === -1) {
+          i += 1; // não fechou ⇒ não era dollar-quote: ressincroniza
+          continue;
+        }
+        empurrarCodigo(i);
+        partes.push(tag);
+        partes.push(removerComentariosSql(sql.slice(i + tag.length, fim)));
+        partes.push(tag);
+        i = fim + tag.length;
+        inicioTrecho = i;
+        continue;
+      }
+    }
+
+    i++;
+  }
+
+  empurrarCodigo(n);
+  return partes.join('');
+}
+
+// Alarme calibrado do stripper: o maior BLOCO CONTÍGUO de linhas que a limpeza descartou.
+//
+// Mesma forma (e mesma razão) de `maiorBlocoDescartado` em src/lib/gates/limpeza-fonte.ts: fração
+// preservada é grossa demais para separar cabeçalho honesto de estrago; o que separa é a FORMA.
+// Linha vazia no ORIGINAL é neutra — não interrompe o bloco.
+export function maiorBlocoDescartadoSql(sql: string): number {
+  const antes = sql.split('\n');
+  const depois = removerComentariosSql(sql).split('\n');
+  let maior = 0;
+  let atual = 0;
+  for (let i = 0; i < antes.length; i++) {
+    if (antes[i].trim() === '') continue;
+    atual = (depois[i] ?? '').trim() === '' ? atual + 1 : 0;
+    if (atual > maior) maior = atual;
+  }
+  return maior;
+}

--- a/scripts/sql-comentarios.test.ts
+++ b/scripts/sql-comentarios.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { removerComentariosSql, maiorBlocoDescartadoSql } from './lib/sql-comentarios';
+import { stripComments } from './lib/authz-contract';
+
+// O stripper que este arquivo substituiu — mantido AQUI (e só aqui) como réu, para que os casos
+// digam o que mudou em vez de só afirmar o que passou a valer.
+const REGEX_ANTIGA = (sql: string) => sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ');
+
+const DIR_MIGRATIONS = join(process.cwd(), 'supabase', 'migrations');
+const migrations = readdirSync(DIR_MIGRATIONS)
+  .filter((f) => f.endsWith('.sql'))
+  .sort()
+  .map((f) => ({ f, sql: readFileSync(join(DIR_MIGRATIONS, f), 'utf8') }));
+
+describe('removerComentariosSql — gramática do Postgres', () => {
+  it('remove comentário de linha e de bloco', () => {
+    expect(removerComentariosSql('SELECT 1; -- some\nSELECT 2;')).toBe('SELECT 1;        \nSELECT 2;');
+    expect(removerComentariosSql('SELECT /* x */ 1;')).toBe('SELECT         1;');
+  });
+
+  it('comentário de bloco ANINHA (o Postgres permite; `[\\s\\S]*?` fecharia no `*/` interno)', () => {
+    expect(removerComentariosSql('SELECT /* a /* b */ c */ 1;')).toBe('SELECT                   1;');
+    // o réu deixa `c */ 1;` virar código órfão
+    expect(REGEX_ANTIGA('SELECT /* a /* b */ c */ 1;')).toBe('SELECT   c */ 1;');
+  });
+
+  it('`--` DENTRO de literal é DADO, não comentário — este é o eixo vivo', () => {
+    const sql = "SELECT 'a -- b';";
+    expect(removerComentariosSql(sql)).toBe(sql);
+    // o réu comia o fecho da string junto: sobra uma aspa aberta que reemparelha o resto do arquivo
+    expect(REGEX_ANTIGA(sql)).toBe("SELECT 'a  ");
+  });
+
+  it("`''` escapa a aspa dentro do literal", () => {
+    const sql = "SELECT 'a''-- b';";
+    expect(removerComentariosSql(sql)).toBe(sql);
+  });
+
+  it("E'…' ainda aceita `\\'` como escape", () => {
+    const sql = "SELECT E'a\\'-- b';";
+    expect(removerComentariosSql(sql)).toBe(sql);
+  });
+
+  it('identificador entre aspas duplas é preservado', () => {
+    expect(removerComentariosSql('SELECT "a--b" FROM t;')).toBe('SELECT "a--b" FROM t;');
+  });
+
+  it('`--` dentro do corpo $$…$$ CONTINUA sendo comentário (é PL/pgSQL, e é a razão do gate existir)', () => {
+    expect(removerComentariosSql('AS $$ x -- y\n z $$;')).toBe('AS $$ x     \n z $$;');
+    expect(removerComentariosSql('AS $fn$ -- z $fn$;')).toBe('AS $fn$      $fn$;');
+  });
+
+  it('literal DENTRO do corpo $$…$$ é preservado (a recursão herda a gramática)', () => {
+    const sql = "AS $$ v := '-- dado'; $$;";
+    expect(removerComentariosSql(sql)).toBe(sql);
+  });
+
+  it('`$1` é parâmetro, não abertura de dollar-quote', () => {
+    expect(removerComentariosSql('SELECT $1 -- c\n;')).toBe('SELECT $1     \n;');
+  });
+
+  it('stripComments do authz-contract usa este walker (uma regra só, não duas cópias)', () => {
+    const sql = "SELECT 'a -- b'; -- fora\n";
+    expect(stripComments(sql)).toBe(removerComentariosSql(sql));
+  });
+});
+
+describe('invariantes sobre as migrations REAIS', () => {
+  it('o corpus não encolheu por acidente (denominador explícito)', () => {
+    expect(migrations.length).toBeGreaterThanOrEqual(650);
+  });
+
+  // Comprimento preservado é o que mantém `extractFunctions` — que fatia corpo por ÍNDICE —
+  // coerente com o texto que ele mediu. Quebrar isso desalinha corpo de função silenciosamente.
+  it('preserva o comprimento de cada migration (comentário vira espaço, `\\n` fica)', () => {
+    const quebras = migrations.filter((m) => removerComentariosSql(m.sql).length !== m.sql.length);
+    expect(quebras.map((m) => m.f)).toEqual([]);
+  });
+
+  // Sentinela herdado de `maiorBlocoDescartado` (src/lib/gates/limpeza-fonte.ts). Calibração MEDIDA
+  // em 2026-08-20 sobre estas migrations: o maior bloco LEGÍTIMO descartado é 175 linhas
+  // (20260615130000_tint_vigia_cobertura_sentinela.sql); um `/*` que nunca fecha no quarto inicial
+  // dos 3 maiores arquivos devolve 676–762. O teto de 300 fica 1,7× acima do legítimo e 2,3× abaixo
+  // do estrago medido — a mesma razão de folga do sentinela irmão (150 sobre 88 legítimo).
+  const TETO_BLOCO = 300;
+  it(`nenhuma migration perde bloco contíguo > ${TETO_BLOCO} linhas`, () => {
+    const acima = migrations
+      .map((m) => ({ f: m.f, n: maiorBlocoDescartadoSql(m.sql) }))
+      .filter((x) => x.n > TETO_BLOCO);
+    expect(acima).toEqual([]);
+  });
+
+  // Alarme que nunca se viu disparar é decoração — este prova que ele dispara.
+  it('o sentinela DISPARA num arquivo envenenado (alarme não é decorativo)', () => {
+    const maior = [...migrations].sort((a, b) => b.sql.length - a.sql.length)[0];
+    const linhas = maior.sql.split('\n');
+    const corte = Math.floor(linhas.length / 4);
+    const envenenado = [...linhas.slice(0, corte), '/* bloco que nunca fecha', ...linhas.slice(corte)].join('\n');
+    expect(maiorBlocoDescartadoSql(maior.sql)).toBeLessThanOrEqual(TETO_BLOCO);
+    expect(maiorBlocoDescartadoSql(envenenado)).toBeGreaterThan(TETO_BLOCO);
+  });
+});


### PR DESCRIPTION
Chip do #1826 ("Medir se o `--` em literal cega o gate de authz"). O passo 1 era **medir**, não consertar. Medi — e o resultado é *"não mudou"*, com o denominador junto.

## Passo 1 — a exposição (e a correção do denominador)

| eixo | exposição |
| --- | --- |
| `/*` dentro de literal | 0/656 |
| bloco **ANINHADO** (`/* /* */ */`) | 0/656 |
| **`--` dentro de literal** | **6/656** |

**O `16/656` do #1826 não reproduz.** Três métodos independentes convergem nos **mesmos 6 arquivos**:

1. walker de gramática recursivo (literal `'…'` com `''`, `E'…\'…'`, `"ident"`, `$tag$` recursivo);
2. diff do SQL que cada stripper entrega ao parser, ignorando espaço;
3. contagem ingênua de aspas ímpares antes do `--` na linha.

Denominador publicado sem o método junto é o que produziu o 16 — a mesma lição do #1824.

Os 6: `20260703090000_pedidos_programados.sql` · `20260723150000_authz_custo_fu4f_fase2_regua.sql` · `20260724130000_authz_custo_fu4f_fase3_recommend.sql` · `20260727120000_tint_fase5_desativa_geracao_legada.sql` · `20260731120000_farmer_assoc_rules_delete_qualificado.sql` · `20260814022626_reposicao_po_inexistente_antes_de.sql`.

## Passo 1 — o dano: ZERO, e por estrutura, não por sorte

- `authz:check --json` com o stripper velho e com o novo → **saída byte-a-byte idêntica** (`ok:true`, 8 avisos).
- Sonda mais sensível — dump de `extractFunctions` + `detectarReescritaViva` das 656 migrations → **idêntica**.
- **A sonda foi falsificada:** com `stripComments` virando no-op, **254/656** arquivos mudam. Ela enxerga; o empate é real.

A razão: os 6 sítios ficam **fora de corpo de `CREATE FUNCTION`** — 5 dentro de bloco `DO $tag$` (assertivas que fazem `regexp_replace(pg_get_functiondef(…), '--[^\n]*', …)`, isto é, carregam o próprio padrão como **dado**) e 1 num arquivo sem função nenhuma (template fiscal `E'FORMA DE PGTO BOLETO\n\n-- --\n…'`). A Parte A/B só lê corpo de `CREATE FUNCTION`; a Parte D exige `pg_get_functiondef` **+ EXECUTE**.

## Passo 2 — troquei mesmo assim, e a neutralidade é o argumento

O que estava aberto não era a exposição, era a **invariante DECLARADA**: o docstring afirmava *"preserva strings e dollar-quotes"* enquanto o código fazia um `.replace` de "`--` até a quebra de linha". Ou o código passa a cumprir, ou o docstring mente — e docstring que mente num fiscal é a mesma assinatura de falha do #1825.

**Trocar quando a saída é provadamente igual é a adoção mais barata que existe.** Depois vira migração de veredito, com o ônus de separar "mudou porque consertei" de "mudou porque quebrei". E a inércia de hoje é contingente ao corpus: o dia em que alguém escrever `regexp_replace(…, '--[^\n]*', …)` **dentro** de uma SECDEF — e há um `DO` block a poucas linhas fazendo exatamente isso — a cegueira cai sobre o gate de authz.

`scripts/lib/sql-comentarios.ts`: máquina de estados, irmã de `src/lib/gates/limpeza-fonte.ts`.

**Decisão de gramática que não é óbvia:** `$tag$…$tag$` **não** é opaco. Um lexer puro pararia ali; aqui o consumidor é o gate de authz, cuja razão de existir é **não ser enganado por `-- gate comentado` DENTRO do corpo**. Medido: tratar como opaco divergia do stripper anterior em **277/656** migrations. O interior é re-analisado com a mesma gramática.

**Invariante nova, falsificável:** a saída tem o **mesmo comprimento** da entrada (comentário vira espaço, `\n` fica). É o que mantém `extractFunctions` — que fatia corpo por índice — coerente. 656/656 no teste.

**Sentinela herdado** (`maiorBlocoDescartadoSql`, teto **300**): maior bloco **legítimo** descartado nas 656 é **175** (`20260615130000_tint_vigia_cobertura_sentinela.sql`); um `/*` que nunca fecha no quarto inicial dos 3 maiores devolve **676–762**. 1,7× acima do legítimo, 2,3× abaixo do estrago — a mesma folga do irmão .ts (150 sobre 88). E o teste **prova o alarme disparando**: alarme que nunca se viu disparar é decoração.

## Passo 3 — falsificação (commitei antes)

5 sabotagens, todas **vermelhas**, controle verde:

| sabotagem | resultado |
| --- | --- |
| literal deixa de ser respeitado | 6 ✗ / 8 ✓ |
| bloco deixa de aninhar | 1 ✗ / 13 ✓ |
| dollar-quote vira opaco | 2 ✗ / 12 ✓ |
| sentinela vira decoração (`return 0`) | 1 ✗ / 13 ✓ |
| comprimento deixa de ser preservado | 4 ✗ / 10 ✓ |
| **controle (restaurado)** | **14 ✓** |

## Validação

- `bun run test -- scripts/sql-comentarios.test.ts` → **14/14**, exit 0
- `bun run authz:check` → exit 0, e o `--json` **byte-a-byte igual** ao baseline pré-troca
- `bun run scripts:typecheck` → exit 0 · `bunx knip` → exit 0 · `eslint` dos 3 arquivos → exit 0
- `docs-citacoes-gate-check` e `docs-indice-gate-check` → exit 0
- `bun run test -- scripts/` → **12 arquivos, 319 testes, exit 0** (a suíte inteira de `scripts/`, incluindo `authz-gate-check`, `authz-contract` e `authz-reescrita` — os dependentes diretos do stripper trocado). Demorou porque a M2 estava em load ~60–72 com 88 processos Claude e a fila do `heavy` não drenava; o resultado é POSITIVO e capturado, não ausência de sinal.

## Registro

`docs/historico/gates-textuais-cegos.md` — a sub-classe SQL sai de "aberta" para **medida até o veredito**, com o método ao lado de cada número.
