### PR TITLE
test(gates): a perna Deno da limpeza cega — 5 sítios (não 4) e o stripper que só via comentário no COMEÇO da linha

### DIFF
--- a/docs/historico/gates-textuais-cegos.md
+++ b/docs/historico/gates-textuais-cegos.md
@@ -80,11 +80,7 @@ extremo — e o comentário no teste diz explicitamente que ela NÃO teria pego 
 
 ## O que sobrou aberto (medido, não presumido)
 
-- **4 gates Deno** (`supabase/functions/**/*_test.ts`) ainda têm cópia local: não podem importar de `src/`
-  (`--no-remote`), precisam de um `_shared/limpeza-fonte.ts` + teste de paridade. **Medido hoje: zero
-  impacto** — os alvos deles (`calculate-scores/index.ts`, `generate-bundle-argument/index.ts`,
-  `_shared/cmc-snapshot-retry.ts`, `omie-analytics-sync/politica-retry.ts`) não estão na tabela acima.
-  Latente, não ativo. Chip próprio.
+- ~~**4 gates Deno**~~ — **FECHADO** (ver §"Perna Deno" abaixo).
 - **Sub-classe CSS** (`table-overscroll.test.ts`): insumo é um arquivo só (`src/index.css`), sob nosso
   controle; varredura deu **zero**. Registro, sem chip.
 - **Sub-classe SQL — eixo `--`, medida ATÉ O VEREDITO (3ª rodada, 2026-08-20). Exposição real, dano
@@ -133,6 +129,49 @@ extremo — e o comentário no teste diz explicitamente que ela NÃO teria pego 
   2,3× abaixo do estrago — a mesma folga do sentinela irmão (150 sobre 88). O teste também **prova o
   alarme disparando** num arquivo envenenado: alarme que nunca se viu disparar é decoração.
 
+## Perna Deno — fechada (2026-08-20, mesmo dia)
+
+`supabase/functions/_shared/limpeza-fonte.ts` é **espelho byte-idêntico** de `src/lib/gates/limpeza-fonte.ts`,
+amarrado por `src/lib/gates/__tests__/limpeza-fonte.parity.test.ts`. A duplicação é obrigatória, não
+preguiça: `test:edges` roda `deno test --no-remote`, e sob esse flag um teste de edge não pode importar
+de `src/` — o jeito de não ter duas verdades é provar que os bytes são os mesmos.
+
+**5 sítios** trocados em 4 arquivos (o `sonda-versao-contrato_test.ts` tinha dois — o `codigoDaEdge` e um
+`semComentario` local dentro do teste de calibração):
+
+| arquivo | sítios |
+| --- | --- |
+| `calculate-scores/ordem-lease_test.ts` | 1 |
+| `_shared/cmc-snapshot-retry_test.ts` | 1 |
+| `_shared/sonda-versao-contrato_test.ts` | 2 |
+| `omie-analytics-sync/politica-retry_test.ts` | 1 |
+
+### Re-medição dos alvos (não presumida)
+
+Confirma o que a tabela do topo já dizia: **a classe estava LATENTE aqui, não ativa**. Nenhum alvo tinha
+`/*` dentro de string; o maior bloco descartado foi 56 linhas (`omie-analytics-sync/index.ts`), bem abaixo
+do teto de 150, e a fração preservada ficou entre 0,63 e 0,87.
+
+O que MUDOU não é a classe catastrófica e sim uma **segunda cegueira, menor e real**: 4 dos 5 sítios usavam
+`.filter((l) => !/^\s*\/\//.test(l))`, que só descarta a linha que **começa** com barra-barra —
+comentário no FIM de uma linha de código continuava sendo medido como se fosse código (9 linhas em
+`omie-analytics-sync/index.ts`, 3 em `cmc-snapshot-backfill/index.ts`). Isso produz **falso VERMELHO**:
+um comentário de fim-de-linha que cite a forma proibida reprova uma edge correta. O módulo remove os dois
+tipos. **Nenhum veredito virou** — `test:edges` seguiu 765/765 antes e depois.
+
+### Falsificação (todo gate exigido em vermelho)
+
+- **Stripper portado vira no-op** (`return fonte`): `politica-retry`, `cmc-snapshot-retry` e
+  `sonda-versao-contrato` ficam **vermelhos** (3 testes). `ordem-lease` **continua verde** — a proteção
+  dele também é latente hoje: nenhuma das agulhas que ele usa (`claim_calculate_scores`,
+  `farmer_algorithm_config`, `finalizar_calculate_scores`) aparece em comentário do `index.ts`.
+- **Controle positivo 2×2 para o `ordem-lease`** (o único que a sabotagem sozinha não discriminava):
+  injetando no topo do `calculate-scores/index.ts` um comentário que cita `farmer_algorithm_config`,
+  o gate fica **verde com o stripper real** e **vermelho com o no-op**
+  (`ORDEM QUEBRADA: os pesos (indice 26) sao lidos ANTES do claim (indice 52)` — o índice 26 é a PROSA).
+  Prova que a limpeza é carga, e que sem ela o modo de falha é falso-vermelho contra edge correta.
+- **Paridade**: 1 byte de divergência no espelho → `limpeza-fonte.parity.test.ts` vermelho.
+
 ## Assinatura para varredura futura
 
 ```bash
@@ -140,7 +179,22 @@ rg -n "replace\(/\\\\/\\\\\*\[\\\\s\\\\S\]\*\?\\\\\*\\\\//" src/ supabase/ scrip
 ```
 
 Casa toda cópia do stripper regex. Em `.ts/.tsx` de `src/`, o correto é importar
-`removerComentarios` de `@/lib/gates/limpeza-fonte`.
+`removerComentarios` de `@/lib/gates/limpeza-fonte`; em `supabase/functions/**`, de
+`_shared/limpeza-fonte.ts` (espelho byte-idêntico — **não** editar só um dos lados).
+
+Medido na base de 2026-08-20 (pós-#1832/#1833), o comando acima devolve **8 ocorrências**, e o
+número sozinho não julga nada — o que julga é a classificação:
+
+| ocorrência | veredito |
+| --- | --- |
+| `src/lib/gates/limpeza-fonte.ts:5` · `supabase/functions/_shared/limpeza-fonte.ts:5` · `scripts/lib/sql-comentarios.ts:5` | cabeçalho citando a forma ANTIGA para explicar o que a substituiu |
+| `src/lib/gates/__tests__/limpeza-fonte.test.ts:9,56` · `scripts/sql-comentarios.test.ts:9` | controle deliberado — o teste roda a regex velha para exigir que ela FALHE onde a nova passa |
+| **`src/__tests__/import-tint-formulas-aposentada-gate.test.ts:47`** | **uso ATIVO** — sub-classe SQL, aberta acima |
+| **`src/components/ui/__tests__/table-overscroll.test.ts:25`** | **uso ATIVO** — sub-classe CSS, aberta acima |
+
+Ou seja: **6 legítimas e 2 usos ativos**, os dois já registrados como sub-classe aberta. Em
+`supabase/functions/` isoladamente a varredura devolve **1**, e é cabeçalho. Qualquer match novo
+fora dessas 8 é reincidência da classe.
 
 O eixo `--` (SQL) tem assinatura própria — casa quem limpa comentário de SQL sem gramática:
 

--- a/knip.json
+++ b/knip.json
@@ -41,6 +41,11 @@
     "db/**/*.ts"
   ],
   "ignore": [
+    // Espelhos BYTE-IDÊNTICOS de um canônico em `src/`, amarrados por um `*.parity.test.ts`. O
+    // knip acusa os exports que só o lado `src/` consome — e obedecê-lo (des-exportar aqui)
+    // quebraria a paridade, que é justamente o que impede as duas cópias de divergirem. A
+    // duplicação existe porque `test:edges` roda `deno test --no-remote`: edge não importa de `src/`.
+    "supabase/functions/_shared/limpeza-fonte.ts",
     "supabase/functions/_shared/sayerlack-sku.ts",
     "supabase/functions/_shared/embalagem-captura-helpers.ts",
     "src/integrations/supabase/types.ts",

--- a/src/lib/gates/__tests__/limpeza-fonte.parity.test.ts
+++ b/src/lib/gates/__tests__/limpeza-fonte.parity.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// O stripper de comentários é a lente de TODO gate textual do repo — os de `src/` (vitest) e os
+// das edges (Deno). Um gate mede a FONTE depois de passar por ele; se as duas cópias divergirem,
+// a mesma forma proibida passa num runtime e reprova no outro, e o fiscal fica verde por
+// CEGUEIRA num dos lados (a classe medida em docs/historico/gates-textuais-cegos.md).
+//
+// A duplicação é OBRIGATÓRIA, não preguiça: `bun run test:edges` roda `deno test --no-remote`, e
+// sob esse flag um teste de edge NÃO pode importar de `src/`. Então o jeito de não ter duas
+// verdades é provar que os bytes são os mesmos. Divergência = CI vermelho.
+//
+// Mesmo padrão de sayerlack-sku.parity.test.ts / costLadder.parity.test.ts.
+const ROOT = process.cwd();
+const CANONICO = resolve(ROOT, 'src/lib/gates/limpeza-fonte.ts');
+const ESPELHO = resolve(ROOT, 'supabase/functions/_shared/limpeza-fonte.ts');
+
+describe('paridade: limpeza-fonte (src) × limpeza-fonte (edge)', () => {
+  it('os dois arquivos são byte-idênticos', () => {
+    const canonico = readFileSync(CANONICO, 'utf8');
+    const espelho = readFileSync(ESPELHO, 'utf8');
+    expect(espelho).toBe(canonico);
+  });
+
+  // Controle positivo: sem isto, um `resolve` errado deixaria os dois lados lendo o MESMO arquivo
+  // (ou dois vazios) e o teste acima passaria sem comparar nada.
+  it('CALIBRAÇÃO: os dois caminhos são distintos e não-vazios', () => {
+    expect(CANONICO).not.toBe(ESPELHO);
+    expect(readFileSync(CANONICO, 'utf8').length).toBeGreaterThan(1000);
+    expect(readFileSync(ESPELHO, 'utf8').includes('export function removerComentarios')).toBe(true);
+  });
+});

--- a/supabase/functions/_shared/cmc-snapshot-retry_test.ts
+++ b/supabase/functions/_shared/cmc-snapshot-retry_test.ts
@@ -324,13 +324,14 @@ Deno.test("INVARIANTE — redigir o segredo não muda a classe de nenhuma mensag
 // política não volte a ser reimplementada inline, onde nenhum teste a alcança. Medido com os
 // comentários REMOVIDOS: este arquivo e os dois `callOmie` citam a forma do bug de propósito, e um
 // predicado que lê a prosa acusa a documentação (money-path §"o ALVO mente").
-function semComentarios(fonte: string): string {
-  return fonte
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter((linha) => !/^\s*\/\//.test(linha))
-    .join("\n");
-}
+// A limpeza vem do módulo COMPARTILHADO (espelho byte-idêntico de `src/lib/gates/limpeza-fonte.ts`,
+// amarrado por `limpeza-fonte.parity.test.ts`). A cópia local que vivia aqui era regex pura, e
+// além de não saber o que era string (um abre-bloco dentro de aspas pareava com o próximo
+// fecha-bloco REAL e apagava tudo entre os dois — verde por CEGUEIRA,
+// docs/historico/gates-textuais-cegos.md), ela só descartava a linha que COMEÇAVA com barra-barra:
+// comentário no FIM de uma linha de código continuava sendo medido como se fosse código. O módulo
+// remove os dois.
+import { removerComentarios as semComentarios } from "./limpeza-fonte.ts";
 
 const EDGES = ["cmc-snapshot-smoke", "cmc-snapshot-backfill"];
 const FONTES = new Map<string, string>(

--- a/supabase/functions/_shared/limpeza-fonte.ts
+++ b/supabase/functions/_shared/limpeza-fonte.ts
@@ -1,0 +1,240 @@
+// Limpeza de FONTE para gates textuais — a que entende string, template e regex literal.
+//
+// Por que existe (classe medida em 2026-08-20, docs/historico/sayerlack-pos-login-falso-positivo.md):
+// todo gate textual deste repo limpava comentário com
+//   `s.replace(/\/\*[\s\S]*?\*\//g, '')`
+// antes de medir. É regex: não sabe o que é string. Qualquer `/*` que apareça DENTRO de uma
+// string pareia com o próximo `*/` REAL do arquivo e apaga tudo entre os dois, ANTES de o fiscal
+// olhar. O gate fica verde por CEGUEIRA — indistinguível de verde por mérito, que é a assinatura
+// de falha mais cara que existe num fiscal (§"Validação só conta com EVIDÊNCIA POSITIVA").
+//
+// O caso que revelou: o header HTTP `'Accept': '...image/webp,*/*;q=0.8'` das edges Sayerlack
+// carrega `/*` no `*/*` do mimetype coringa. Em `sayerlack-captura-precos/index.ts`, 1.041 das
+// 1.226 linhas (85%) eram invisíveis aos gates — escondendo 2 sítios reais da classe #1642, que
+// só apareceram quando o par foi desfeito à mão.
+//
+// CONTRATO desta função: remove comentário de LINHA e de BLOCO, e NADA MAIS. String simples,
+// dupla, template literal (inclusive o interior de `${…}`) e regex literal saem intactos.
+//
+// LIMITE CONHECIDO (deliberado, e é o que torna a falha BARATA em vez de catastrófica): sem
+// parser de verdade, texto JSX solto (`<p>Don't</p>`) e divisão ambígua podem ser lidos como
+// abertura de string/regex. Por isso string de aspas e regex literal ABORTAM na quebra de linha
+// — como manda a própria gramática do JS — e o estrago máximo de uma leitura errada é o RESTO
+// DA LINHA, nunca 1.041 delas. `medirPreservacao` é o alarme de fumaça para o resto.
+
+// Um `/` só abre regex depois destes caracteres — senão é divisão.
+const ANTES_DE_REGEX = new Set([
+  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '+', '-', '*', '%', '~', '^', '<', '>', '\n',
+]);
+
+// Palavras-chave depois das quais um `/` abre regex (`return /re/.test(x)`).
+const PALAVRAS_ANTES_DE_REGEX =
+  /(?:^|[^\w$])(return|typeof|instanceof|in|of|new|delete|void|throw|case|do|else|yield|await)$/;
+
+function abreRegex(anterior: string): boolean {
+  const t = anterior.replace(/\s+$/, '');
+  if (t === '') return true;
+  const c = t[t.length - 1];
+  if (ANTES_DE_REGEX.has(c)) return true;
+  return PALAVRAS_ANTES_DE_REGEX.test(t);
+}
+
+// Remove comentários de `fonte` preservando as quebras de linha do que saiu — o número de linhas
+// do resultado é igual ao da entrada, de propósito: gate que casa com `^…` multiline e gate que
+// compara POSIÇÃO (`indexOf` de A antes de B) continuam medindo a mesma coisa.
+//
+export function removerComentarios(fonte: string): string {
+  const partes: string[] = [];
+  // CAUDA em vez do texto todo: `abreRegex` precisa do último caractere significativo, e olhar a
+  // saída acumulada a cada `/` fazia o stripper ser O(n²) — 27× mais lento que a regex que ele
+  // substitui, o bastante para estourar o timeout de 20s do vitest em gate que varre 2.390 fontes.
+  let cauda = '\n';
+  const empurrar = (t: string) => {
+    if (t === '') return;
+    partes.push(t);
+    cauda = (cauda + t).slice(-16);
+  };
+
+  let i = 0;
+  let inicioTrecho = 0;
+  const n = fonte.length;
+  const preservaLinhas = (trecho: string) => trecho.replace(/[^\n]/g, '');
+
+  while (i < n) {
+    const c = fonte[i];
+    if (c !== '/' && c !== '"' && c !== "'" && c !== '`') {
+      i++;
+      continue;
+    }
+    empurrar(fonte.slice(inicioTrecho, i));
+
+    const prox = fonte[i + 1];
+
+    if (c === '/' && prox === '/') {
+      while (i < n && fonte[i] !== '\n') i++;
+      inicioTrecho = i;
+      continue;
+    }
+
+    if (c === '/' && prox === '*') {
+      const fim = fonte.indexOf('*/', i + 2);
+      const ate = fim === -1 ? n : fim + 2;
+      empurrar(preservaLinhas(fonte.slice(i, ate)));
+      i = ate;
+      inicioTrecho = i;
+      continue;
+    }
+
+    if (c === '"' || c === "'") {
+      const fecha = fimDeString(fonte, i);
+      if (fecha !== -1) {
+        empurrar(fonte.slice(i, fecha + 1));
+        i = fecha + 1;
+        inicioTrecho = i;
+        continue;
+      }
+      // Não fechou na mesma linha: não era string (texto JSX, apóstrofo de prosa). Segue como
+      // código — o caractere sai verbatim e o resto da linha é reavaliado normalmente.
+      empurrar(c);
+      i++;
+      inicioTrecho = i;
+      continue;
+    }
+
+    if (c === '`') {
+      const fecha = fimDeTemplate(fonte, i);
+      const ate = fecha === -1 ? n : fecha + 1;
+      empurrar(fonte.slice(i, ate));
+      i = ate;
+      inicioTrecho = i;
+      continue;
+    }
+
+    if (abreRegex(cauda)) {
+      const fecha = fimDeRegex(fonte, i);
+      if (fecha !== -1) {
+        empurrar(fonte.slice(i, fecha + 1));
+        i = fecha + 1;
+        inicioTrecho = i;
+        continue;
+      }
+    }
+
+    empurrar(c);
+    i++;
+    inicioTrecho = i;
+  }
+
+  empurrar(fonte.slice(inicioTrecho, n));
+  return partes.join('');
+}
+
+// Índice da aspa de fechamento, ou -1 se a linha acabar antes (⇒ não era string).
+function fimDeString(s: string, ini: number): number {
+  const aspas = s[ini];
+  let i = ini + 1;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === '\\') { i += 2; continue; }
+    if (c === '\n') return -1;
+    if (c === aspas) return i;
+    i++;
+  }
+  return -1;
+}
+
+// Índice da crase de fechamento, respeitando `${…}` aninhado (que pode conter outra crase).
+function fimDeTemplate(s: string, ini: number): number {
+  let i = ini + 1;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === '\\') { i += 2; continue; }
+    if (c === '`') return i;
+    if (c === '$' && s[i + 1] === '{') {
+      let prof = 1;
+      i += 2;
+      while (i < s.length && prof > 0) {
+        const d = s[i];
+        if (d === '\\') { i += 2; continue; }
+        if (d === '`') { const f = fimDeTemplate(s, i); i = f === -1 ? s.length : f + 1; continue; }
+        if (d === "'" || d === '"') { const f = fimDeString(s, i); i = f === -1 ? i + 1 : f + 1; continue; }
+        if (d === '{') prof++;
+        if (d === '}') prof--;
+        i++;
+      }
+      continue;
+    }
+    i++;
+  }
+  return -1;
+}
+
+// Índice da `/` de fechamento do regex literal (classe `[…]` protege a barra), ou -1.
+function fimDeRegex(s: string, ini: number): number {
+  let i = ini + 1;
+  let classe = false;
+  while (i < s.length) {
+    const c = s[i];
+    if (c === '\\') { i += 2; continue; }
+    if (c === '\n') return -1;
+    if (classe) {
+      if (c === ']') classe = false;
+    } else if (c === '[') {
+      classe = true;
+    } else if (c === '/') {
+      return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+// Alarme de fumaça do stripper: quanto do arquivo SOBROU depois da limpeza.
+//
+// Os gates já provam que o walker anda (quantos ARQUIVOS leu). Isto é o denominador que faltava
+// no outro eixo: quanto de CADA arquivo o fiscal chegou a olhar. Um stripper que engole a
+// metade do arquivo por má-leitura devolve fração baixa aqui muito antes de alguém notar que
+// um gate virou decoração.
+//
+// Conta LINHAS NÃO-VAZIAS: linha de comentário some por desenho, então a fração nunca é 1 —
+// o que se vigia é o desabamento (o caso Sayerlack devolvia 0,15).
+//
+export function medirPreservacao(fonte: string): {
+  linhasOriginais: number;
+  linhasPreservadas: number;
+  fracao: number;
+} {
+  const naoVazias = (s: string) => s.split('\n').filter((l) => l.trim() !== '').length;
+  const linhasOriginais = naoVazias(fonte);
+  const linhasPreservadas = naoVazias(removerComentarios(fonte));
+  return {
+    linhasOriginais,
+    linhasPreservadas,
+    fracao: linhasOriginais === 0 ? 1 : linhasPreservadas / linhasOriginais,
+  };
+}
+
+// Alarme CALIBRADO do stripper: o maior BLOCO CONTÍGUO de linhas que a limpeza descartou.
+//
+// A fração acima é grossa demais para o caso real: `sayerlack-captura-precos/index.ts` envenenado
+// preservava 0,118 do arquivo, e há `versao.ts` legítimo em 0,154 — não dá para separar os dois
+// por fração. O que separa é a FORMA do estrago: comentário de verdade vem em cabeçalho, e o
+// maior cabeçalho honesto do repo tem 88 linhas (`useFarmerScoring.ts`, medido em 2026-08-20 nos
+// 2.390 fontes de `src/`+`supabase/functions/`+`scripts/`); a região comida pelo par falso tinha
+// 924. Um teto de 150 fica 1,7× acima do maior legítimo e 6× abaixo do estrago medido.
+//
+// Linha em branco no ORIGINAL é neutra (não interrompe o bloco): a região envenenada tinha linhas
+// vazias no meio, e contá-las como fronteira quebrava o bloco em pedaços de <88 — o alarme
+// silenciava exatamente no caso que ele existe para pegar.
+export function maiorBlocoDescartado(fonte: string): number {
+  const antes = fonte.split('\n');
+  const depois = removerComentarios(fonte).split('\n');
+  let maior = 0;
+  let atual = 0;
+  for (let i = 0; i < antes.length; i++) {
+    if (antes[i].trim() === '') continue;
+    atual = (depois[i] ?? '').trim() === '' ? atual + 1 : 0;
+    if (atual > maior) maior = atual;
+  }
+  return maior;
+}

--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -10,6 +10,7 @@
 // o `plano-helpers.ts` dela, que não importa nada), então `--no-remote` passa. Nenhum código de
 // produção importa através dessa fronteira.
 
+import { removerComentarios } from "./limpeza-fonte.ts";
 import * as disparar from "../disparar-pedidos-aprovados/versao.ts";
 import * as portalSayerlack from "../enviar-pedido-portal-sayerlack/versao.ts";
 import * as conciliar from "../conciliar-pedido-portal/versao.ts";
@@ -147,14 +148,15 @@ Deno.test("generate-tactical-plan: o marcador NOMEIA a fatia — 'sensor-inicial
 // Fonte da edge SEM comentário — o gate proíbe uma FORMA de código, e o comentário que explica por
 // que a forma saiu cita a forma. Sem o filtro, o gate fica vermelho contra uma edge correta
 // (aconteceu na primeira execução deste arquivo). Mesma solução do gate `afinidade não é dinheiro`.
-// Os blocos de comentário saem ANTES do filtro de linha: um JSDoc não começa com barra-barra em
-// toda linha, então o filtro de linha sozinho o deixaria passar inteiro.
+//
+// A limpeza vem do módulo COMPARTILHADO (espelho byte-idêntico de `src/lib/gates/limpeza-fonte.ts`,
+// amarrado por `limpeza-fonte.parity.test.ts`). A cópia local que vivia aqui era regex pura: não
+// sabia o que era string — um abre-bloco dentro de aspas pareava com o próximo fecha-bloco REAL do
+// arquivo e apagava tudo entre os dois ANTES da medição, verde por CEGUEIRA
+// (docs/historico/gates-textuais-cegos.md). Ela também só descartava a linha que COMEÇAVA com
+// barra-barra, deixando comentário de fim-de-linha ser medido como código.
 function codigoDaEdge(nome: string): string {
-  return Deno.readTextFileSync(`supabase/functions/${nome}/index.ts`)
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter((l) => !/^\s*\/\//.test(l))
-    .join("\n");
+  return removerComentarios(Deno.readTextFileSync(`supabase/functions/${nome}/index.ts`));
 }
 
 Deno.test("generate-bundle-argument: a sonda decide por classificarSonda, não por `=== true` cru", () => {
@@ -190,8 +192,7 @@ Deno.test("CALIBRAÇÃO: os padrões reprovam a forma PRÉ-fix e o filtro não c
   // Sem isto os dois testes acima só provariam que o arquivo existe (deploy.md: "canária que não
   // discrimina é teatro verde"). A forma antiga tem de FALHAR, e o filtro de comentário tem de
   // apagar SÓ comentário — se comesse código, a forma proibida voltaria em silêncio.
-  const semComentario = (s: string) =>
-    s.replace(/\/\*[\s\S]*?\*\//g, "").split("\n").filter((l) => !/^\s*\/\//.test(l)).join("\n");
+  const semComentario = removerComentarios;
 
   const soComentario = "  // `classificarSonda` no lugar de `body.probe === true`: o SQL Editor manda string";
   if (/\bbody\.probe\s*===\s*true/.test(semComentario(soComentario))) {

--- a/supabase/functions/calculate-scores/ordem-lease_test.ts
+++ b/supabase/functions/calculate-scores/ordem-lease_test.ts
@@ -14,23 +14,27 @@
 
 const FONTE = new URL("./index.ts", import.meta.url);
 
-/**
- * Remove comentários antes de medir a ordem.
- *
- * OBRIGATÓRIO, não higiene: os comentários deste arquivo citam `claim_calculate_scores` e
- * `farmer_client_scores` várias vezes, inclusive no bloco explicativo do topo — que vem ANTES de
- * tudo. Medir a ordem sobre o fonte cru casaria a PROSA e o assert ficaria verde mesmo com o
- * snapshot movido para antes do claim: o falso-verde do #1472/#1488, onde a defesa satisfaz o fiscal
- * que deveria fiscalizá-la.
- *
- * O `(?<!:)` preserva `https://` — sem ele um `://` seria lido como início de comentário e cortaria
- * o resto da linha.
- */
-function semComentarios(src: string): string {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, "")   // blocos /* ... */
-    .replace(/(?<!:)\/\/.*$/gm, "");    // linha // ... (preservando :// de URLs)
-}
+// Remove comentários antes de medir a ordem.
+//
+// OBRIGATÓRIO, não higiene: os comentários deste arquivo citam `claim_calculate_scores` e
+// `farmer_client_scores` várias vezes, inclusive no bloco explicativo do topo — que vem ANTES de
+// tudo. Medir a ordem sobre o fonte cru casaria a PROSA e o assert ficaria verde mesmo com o
+// snapshot movido para antes do claim: o falso-verde do #1472/#1488, onde a defesa satisfaz o
+// fiscal que deveria fiscalizá-la.
+//
+// A limpeza vem do módulo COMPARTILHADO (espelho byte-idêntico de `src/lib/gates/limpeza-fonte.ts`,
+// amarrado por `limpeza-fonte.parity.test.ts`). A cópia local que vivia aqui era regex pura: não
+// sabia o que era string — um abre-bloco dentro de uma string pareava com o próximo fecha-bloco
+// REAL do arquivo e apagava tudo entre os dois ANTES desta medição, verde por CEGUEIRA
+// (docs/historico/gates-textuais-cegos.md).
+//
+// O `(?<!:)` que a cópia local usava para preservar `https://` deixa de ser necessário: o walker
+// entende string, então um `://` dentro de aspas nunca é lido como comentário.
+//
+// NB: esta explicação usa comentário de LINHA de propósito. Escrever a sequência fecha-bloco
+// dentro de um bloco `/*` encerraria o próprio comentário — a mesma confusão léxica que o módulo
+// importado existe para resolver.
+import { removerComentarios as semComentarios } from "../_shared/limpeza-fonte.ts";
 
 function idxOuFalha(codigo: string, agulha: string, rotulo: string): number {
   const i = codigo.indexOf(agulha);

--- a/supabase/functions/omie-analytics-sync/politica-retry_test.ts
+++ b/supabase/functions/omie-analytics-sync/politica-retry_test.ts
@@ -219,13 +219,14 @@ Deno.test("INVARIANTE — redigir o segredo não muda a classe de nenhuma mensag
 // política não volte a ser reimplementada inline, onde nenhum teste a alcança. Medido com os
 // comentários REMOVIDOS: este arquivo e o `callOmie` citam a forma do bug de propósito, e um
 // predicado que lê a prosa acusa a documentação (money-path §"o ALVO mente").
-function semComentarios(fonte: string): string {
-  return fonte
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter((linha) => !/^\s*\/\//.test(linha))
-    .join("\n");
-}
+// A limpeza vem do módulo COMPARTILHADO (espelho byte-idêntico de `src/lib/gates/limpeza-fonte.ts`,
+// amarrado por `limpeza-fonte.parity.test.ts`). A cópia local que vivia aqui era regex pura, e
+// além de não saber o que era string (um abre-bloco dentro de aspas pareava com o próximo
+// fecha-bloco REAL e apagava tudo entre os dois — verde por CEGUEIRA,
+// docs/historico/gates-textuais-cegos.md), ela só descartava a linha que COMEÇAVA com barra-barra:
+// comentário no FIM de uma linha de código continuava sendo medido como se fosse código. O módulo
+// remove os dois.
+import { removerComentarios as semComentarios } from "../_shared/limpeza-fonte.ts";
 
 const FONTE_EDGE = semComentarios(await Deno.readTextFile(new URL("./index.ts", import.meta.url)));
 


### PR DESCRIPTION
Fecha a perna Deno da classe registrada em `docs/historico/gates-textuais-cegos.md` (#1825).

Os gates textuais das edges ainda limpavam comentário com uma cópia local de
`s.replace(/\/\*[\s\S]*?\*\//g, '')` — regex que não sabe o que é string, e onde um `/*` dentro de
literal pareia com o próximo `*/` REAL e apaga o miolo do arquivo ANTES da medição.

## O que entra

`supabase/functions/_shared/limpeza-fonte.ts` — espelho **byte-idêntico** de
`src/lib/gates/limpeza-fonte.ts`, amarrado por `src/lib/gates/__tests__/limpeza-fonte.parity.test.ts`
(padrão `sayerlack-sku.parity` / `costLadder.parity`). A duplicação é obrigatória, não preguiça:
`test:edges` roda `deno test --no-remote`, e sob esse flag teste de edge **não pode importar de
`src/`** — o jeito de não ter duas verdades é provar que os bytes são os mesmos.

**5 sítios em 4 arquivos**, não 4 — o `sonda-versao-contrato_test.ts` tinha dois (o `codigoDaEdge` e
um `semComentario` local dentro do próprio teste de calibração):

| arquivo | sítios |
| --- | --- |
| `calculate-scores/ordem-lease_test.ts` | 1 |
| `_shared/cmc-snapshot-retry_test.ts` | 1 |
| `_shared/sonda-versao-contrato_test.ts` | **2** |
| `omie-analytics-sync/politica-retry_test.ts` | 1 |

## Re-medição (não presumida)

A classe catastrófica estava **LATENTE** aqui, como o doc já dizia: nenhum alvo tem `/*` dentro de
string, maior bloco descartado **56** linhas (teto do alarme: 150), fração preservada 0,63–0,87.

O que MUDOU é uma **segunda cegueira, menor e real**: 4 dos 5 sítios usavam
`.filter((l) => !/^\s*\/\//.test(l))`, que só descarta a linha que **começa** com barra-barra —
comentário no FIM de uma linha de código seguia sendo medido como se fosse código (9 linhas em
`omie-analytics-sync/index.ts`, 3 em `cmc-snapshot-backfill/index.ts`). Isso produz **falso
VERMELHO**: um comentário de fim-de-linha que cite a forma proibida reprova uma edge correta.
**Nenhum veredito virou** — `test:edges` 765/765 antes e depois.

## Falsificação (exigido vermelho)

- **Stripper portado vira no-op** (`return fonte`) → `politica-retry`, `cmc-snapshot-retry` e
  `sonda-versao-contrato` ficam **vermelhos** (3 testes).
- `ordem-lease` **não** discrimina só com a sabotagem (a proteção dele também é latente hoje), então
  **controle positivo 2×2**: injetando no topo do `calculate-scores/index.ts` um comentário que cita
  `farmer_algorithm_config`, o gate fica **verde com o stripper real** e **vermelho com o no-op**
  (`ORDEM QUEBRADA: os pesos (indice 26) sao lidos ANTES do claim (indice 52)` — o índice 26 é a PROSA).
- **1 byte de divergência** no espelho → `limpeza-fonte.parity.test.ts` vermelho.

## `knip.json`

O espelho entra na ignore-list junto dos outros espelhos byte-idênticos (`sayerlack-sku`,
`embalagem-captura-helpers`): o knip acusa `medirPreservacao`/`maiorBlocoDescartado` como órfãos
(só o lado `src/` os consome), e **obedecer — des-exportar aqui — quebraria a paridade**, que é
justamente o que impede as duas cópias de divergirem.

## Gates

| gate | resultado |
| --- | --- |
| `bun run test:edges` | **765/765** · exit 0 (re-rodado na base rebaseada) |
| `bun run edges:typecheck` | 0 erros de classe-crash · exit 0 |
| `bun run test` (vitest) | **699/699** arquivos · **6550/6550** testes · exit 0 |
| `bunx knip` | exit 0 |
| `bun lint` | 0 erros (75 warnings pré-existentes) |
| `bun run typecheck` | **não verificado localmente** — a fila do `heavy` (≈28 sessões na M2 8GB) inviabilizou; a evidência fica com o `validate` deste CI |

## Assinatura — re-medida após o rebase sobre o #1832

Eu tinha escrito "**1 ocorrência**" medindo só `supabase/functions/`, mas o comando que o doc publica
varre `src/ supabase/ scripts/` — e lá dá **8**. Publicar o número sem medi-lo na fonte que o comando
lê é o erro do #1824, então re-medi e classifiquei: **6 legítimas** (3 cabeçalhos citando a forma
antiga + 3 controles deliberados que rodam a regex velha para exigir que ela falhe) e **2 usos
ativos** — `import-tint-formulas-aposentada-gate.test.ts:47` (sub-classe SQL) e
`table-overscroll.test.ts:25` (sub-classe CSS), ambos já registrados como sub-classe ABERTA no doc,
fora do escopo desta perna. Em `supabase/functions/` isolado: **1**, e é cabeçalho.

Rebaseado sobre o #1832 (conflito no doc — as duas adições eram complementares, fundidas: a minha
sobre o espelho Deno, a dele sobre o eixo `--`). `test:edges` re-rodado na base nova: **765/765**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)