### PR TITLE
fix(recommend): o motor via 1.000 de 3.140 SKUs — as 6 leituras paginam e a falha para de virar catálogo parcial [money-path]

### DIFF
--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -713,3 +713,33 @@ antes/depois medido, não de carona. Segurar a entrega deixaria 68% do catálogo
 tempo. **Defeito fora de escopo se escreve no código** (os dois estão nomeados por extenso nos
 comentários) **e vira chip** — o que não pode é sair do diff sem deixar rastro e passar por
 consertado.
+
+**A 2ª rodada do Codex foi sobre o CÓDIGO, e achou o que a 1ª (sobre o desenho) não podia
+achar.** Vale como método: a 1ª rodada corrige a ideia, a 2ª corrige a implementação, e as duas
+encontram classes diferentes. O que ela pegou, tudo dentro do que eu tinha acabado de escrever:
+
+- **`amostraSaturada` prometia mais do que media.** Com 1.000 compras existentes e 1.000 lidas,
+  nada foi cortado — e o campo era `true`. Virou **`amostraNoTeto`**, que é o que o código sabe;
+  afirmar "há mais" exigiria `count:'exact'`. É a mesma classe que a entrega combate, cometida
+  no nome do próprio remédio.
+- **O campo era contrato MORTO** — ninguém o lia. Sinal que não chega em consumidor é o cap
+  silencioso com outro nome; ligado a um `console.warn` na edge.
+- **Minha afirmação sobre `cause` estava errada.** Eu escrevi que o erro original do PostgREST
+  ficava em `cause`; `fetchAll` o reduz a `new Error(label+message)` ANTES, então o `code`
+  (57014, 42501) morria ali. Corrigido interceptando `res.error` **antes** de entregar ao
+  helper — diagnóstico preservado e mensagem pública fechada, com um teste que afirma as duas
+  metades juntas (`codigo === "57014"` **e** ausência de `"boom"`).
+- **Seis falsos-verdes na minha própria suíte**, cada um com uma saída errada concreta: teto
+  comparado com a **constante importada** (tautologia — subir 100→1000 ficava verde e dividia
+  `sim` por 1.000 lendo compras de 50); double ignorando `.select()` (tirar `cost_final` ficava
+  verde e sumia com margem/EIP em prod); double registrando `.order()` sem ordenar nem olhar
+  `ascending` (descendente é ordem *estável* e trocaria QUAIS 100 clientes entram); nenhum caso
+  `data:null, error:null` para lista (o `exigirLista` estava certo mas **não falsificado**);
+  saturação testada em 1.500 e não no teto exato. **Um teste que não falsifica cada asserção
+  que faz é inventário, não prova** — e "22 asserções" soava suficiente até alguém perguntar
+  qual saída errada cada uma pega. 22 → 33, com 9 sabotagens vermelhas ao todo.
+- **Derrubou também uma afirmação minha por leitura de schema:** eu escrevi que o prefixo por PK
+  pegaria "provavelmente os mais antigos"; `farmer_client_scores.id` é `UUID DEFAULT
+  gen_random_uuid()`, então os 100 menores UUIDs são amostra pseudoaleatória determinística, não
+  prefixo temporal. O viés continua (mesmo subconjunto para todos, tamanho pequeno), mas **não é
+  o viés que eu tinha escrito** — e a versão errada estava a caminho do PR.

--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -650,3 +650,66 @@ aí "lista vazia sem aviso" fica indistinguível de "esta cidade não tem client
 seis seguras quando alguém contou — e uma delas já estava errando havia meses sem produzir um único
 sintoma. A BASELINE do gate ficou **sem nenhuma entrada `nao_medido`**: toda chamada set-returning
 sem `.range()` em `src/` hoje carrega teto com prova.
+
+## A capa de 1.000 num `Promise.all` de SEIS leituras — e a lição do DENOMINADOR (2026-08-20)
+
+A mesma classe, agora fora das RPCs: a edge `recommend` (motor de recomendação, money-path — é o
+top-N que o vendedor oferece). O `Promise.all` de `recommend()` desestruturava **apenas `{ data }`
+nas seis leituras** e **nenhuma paginava**. Medido via psql-ro: `omie_products WHERE ativo` tem
+**3.140** linhas e a edge via **1.000**; `product_costs`, **3.676** → 1.000; `order_items` do
+cliente chega a **2.849**, e **8 clientes** — os maiores — estouravam a capa.
+
+**A lição nova é o denominador, e ela custou uma afirmação errada minha.** Eu tinha escrito "73%
+dos custos ausentes" a partir de `1.000/3.676`. Isso é cobertura de **linhas da tabela lida**. O
+challenge Codex apontou que a pergunta é outra: quantos **CANDIDATOS** ficam sem custo. Medido —
+dos 3.140 produtos ativos, só **833 (26,5%)** têm custo na primeira página `ORDER BY id`. A
+conclusão sobreviveu (73,5%), mas por sorte: as duas contas só coincidem quando as duas tabelas
+estão alinhadas por id, e nada garantia isso. **Cobertura da FONTE não é cobertura do CONSUMIDOR
+— derive o número do lado de quem sofre o dano.** É a regra do denominador (#1829, `fase-sem-sinal.md`)
+aplicada a truncagem em vez de a adoção.
+
+**O efeito canônico do §6 NÃO era o efeito aqui.** "Custo ausente infla margem" é a patologia que
+o money-path.md ensina, e foi o que eu esperava encontrar. Mas neste call-site o consumidor já
+degradava honesto: `derivarMargensCandidato` devolve `margemExibida = null` e `margemRank` cai em
+`?? 0` ("EIP neutro, não máximo" — está comentado no código). Então não havia número inflado. O
+dano era outro: o componente de **lucro**, que tem o **maior peso** (`w_eip` 0.35), passava a ser
+decidido sobre um quarto dos custos, com corte **não-determinístico** (sem `ORDER BY` o Postgres
+não promete sequência). Perda por **omissão**, não por fabricação. Conferir qual dos dois é o dano
+muda o que se escreve no PR e o que se testa — assumir a patologia canônica teria produzido uma
+afirmação falsa sobre a própria correção.
+
+**O `--no-remote` como força de DESENHO.** A edge importa `npm:@supabase/supabase-js@2` e
+`test:edges` roda `--no-remote`, então **nada afirmado dentro do `index.ts` é provável por
+execução**. Enquanto as leituras morassem lá, "o catálogo volta inteiro" era leitura, não prova.
+Extrair para `_shared/recommend-leituras.ts` — contra a interface estrutural `BancoPostgrest` de
+`paginate.ts` — é o que tornou as 22 asserções executáveis. **A restrição do runner é critério de
+onde o código mora**, não um obstáculo a contornar. Ver `ci-testes-edge-deno.md`.
+
+**O double precisa SIMULAR o cap, senão a suíte é teatro.** Um double que devolve a tabela inteira
+aprovaria a leitura NÃO paginada. O daqui corta em 1.000 sem `.range()`, como o Data API real — e
+há um **controle de calibração** que afirma isso diretamente. Falsificado: quando o double para de
+capar, é o controle que fica vermelho, não os testes de conteúdo. Sabotagens e desfechos: tirar a
+paginação → 3 vermelhos; engolir o erro → 7; tirar o `.order("id")` → 1; double sem cap → 1.
+
+**Dois achados que a LEITURA não pegou e o TESTE pegou.** (1) `fetchAll` lança
+``new Error(`${label}: ${error.message}`)`` — o MESSAGE cru do Postgres —, e o `catch` do
+`Deno.serve` devolve `message` no corpo da resposta: o texto do servidor **saía da edge**, o
+"privacidade afirmada sem verificar o SINK". Envelopado em domínio fechado só no módulo novo,
+porque `fetchAll` tem 21 call-sites e `visit-score-recalc-client:361` já ramifica em
+`instanceof FalhaLeituraCritica` — fechar a classe no helper é entrega própria. (2) `exigirLeitura`
+**mistura cardinalidades**: para `.maybeSingle()` o `data:null` é ausência legítima, mas para uma
+lista o mesmo `null` coalescido com `?? []` é o **EOF falso** que `fetchAll` já rejeita no laço,
+entrando pela porta do lado numa leitura de página única. Daí o `exigirLista`.
+
+**O que NÃO foi consertado, e por quê.** `.order("id").limit(100)` na amostra do cluster é
+**prefixo por PK, não amostragem**: dos 6.185 clientes `critico` saem sempre os mesmos 100. O
+`.order()` é melhora real (antes o `sim_score` do mesmo cliente mudava entre execuções sem nada
+mudar), mas troca viés aleatório por viés **estável** — reprodutibilidade, não representatividade.
+E `clusterSize` conta 100 clientes enquanto as compras vêm de 50, então `sim` sai pela metade
+(invariante sob `minMaxNorm`, mas os cortes em `sim` cru — 0.1/0.15/0.2 — sentem). O Codex pediu
+para **bloquear o merge** até redesenhar a amostra; recusado com motivo: é desenho de **ranking**,
+outro eixo que truncagem de **transporte**, e mudá-lo altera o top-N que o vendedor vê — precisa de
+antes/depois medido, não de carona. Segurar a entrega deixaria 68% do catálogo invisível por mais
+tempo. **Defeito fora de escopo se escreve no código** (os dois estão nomeados por extenso nos
+comentários) **e vira chip** — o que não pode é sair do diff sem deixar rastro e passar por
+consertado.

--- a/supabase/functions/_shared/leitura-critica.ts
+++ b/supabase/functions/_shared/leitura-critica.ts
@@ -60,6 +60,8 @@ export class FalhaLeituraCritica extends Error {
     super(
       codigo === 'SEM_LINHAS'
         ? `${fonte} não tem nenhuma linha para esta empresa — valor DESCONHECIDO, não zero. Verifique o cadastro.`
+        : codigo === 'MALFORMADA'
+        ? `Leitura de ${fonte} veio malformada (data null sem erro) — DESCONHECIDO, não lista vazia.`
         : `Leitura de ${fonte} falhou (código ${codigo}) — dado indisponível, não zero.`,
     );
     this.name = 'FalhaLeituraCritica';
@@ -100,6 +102,26 @@ export function exigirLinhas<T>(res: RespostaLeitura<T>, fonte: string): T {
   const dados = exigirLeitura(res, fonte);
   if (dados == null || (Array.isArray(dados) && dados.length === 0)) {
     throw new FalhaLeituraCritica(fonte, { code: 'SEM_LINHAS' });
+  }
+  return dados;
+}
+
+/**
+ * Leitura de LISTA: `data` tem de vir array. `data:null` SEM `error` é resposta MALFORMADA
+ * do PostgREST, não "a lista está vazia" — vazio legítimo é `[]`.
+ *
+ * Existe porque `exigirLeitura` mistura as duas CARDINALIDADES (achado do challenge Codex
+ * nesta entrega): para um `.maybeSingle()` o `data:null` é ausência legítima e o caller deve
+ * mesmo cair no default; para um `.select()` de lista o mesmo `null` coalescido com `?? []`
+ * vira "ninguém comprou nada" — que é o EOF falso que `fetchAll` já rejeita no laço, entrando
+ * pela porta do lado na leitura de uma página só.
+ *
+ * Lista VAZIA passa: `[]` é estado de negócio (quem precisa de ≥1 linha usa `exigirLinhas`).
+ */
+export function exigirLista<T>(res: RespostaLeitura<T[]>, fonte: string): T[] {
+  const dados = exigirLeitura(res, fonte);
+  if (!Array.isArray(dados)) {
+    throw new FalhaLeituraCritica(fonte, { code: 'MALFORMADA' });
   }
   return dados;
 }

--- a/supabase/functions/_shared/mapas-paginados_test.ts
+++ b/supabase/functions/_shared/mapas-paginados_test.ts
@@ -91,6 +91,14 @@ function fakeDb(
         reg.ranges.push([de, ate]);
         return q;
       },
+      limit(_n: number): QueryPostgrest<Linha> {
+        // Este double modela só paginação por `.range()`. Se um loader passar a usar
+        // `.limit()`, é para o teste ficar VERMELHO na hora — não para ser ignorado.
+        throw new Error("double: .limit() não é modelado aqui");
+      },
+      maybeSingle(): PromiseLike<{ data: Linha | null; error: { message: string } | null }> {
+        throw new Error("double: .maybeSingle() não é modelado aqui");
+      },
       then<R1, R2>(
         resolve?: ((v: RespostaPostgrest<Linha>) => R1 | PromiseLike<R1>) | null,
         rejeitar?: ((motivo: unknown) => R2 | PromiseLike<R2>) | null,

--- a/supabase/functions/_shared/paginacao-delegada_test.ts
+++ b/supabase/functions/_shared/paginacao-delegada_test.ts
@@ -35,6 +35,13 @@ const VIGIADAS = [
   "visit-score-recalc-batch",
   "sync-reprocess",
   "omie-vendas-sync",
+  // `recommend` entrou por CONVERSÃO, não por reescrita: as seis leituras do motor eram um
+  // `Promise.all` sem paginação nenhuma (o catálogo ativo tem 3.140 linhas e a edge via as
+  // 1.000 do cap) e mudaram para `_shared/recommend-leituras.ts`. O invariante do `.order()`
+  // dessas páginas NÃO cabe aqui — este gate só lê `<edge>/index.ts`, e lá não há mais
+  // `.range(` nenhum. Quem vigia a ordem estável é `recommend-leituras_test.ts`, que afirma
+  // sobre a query EXECUTADA (registro por página), não sobre o texto.
+  "recommend",
 ];
 
 Deno.test("edges convertidas não paginam à mão (sem .range() no call-site)", async () => {

--- a/supabase/functions/_shared/paginate.ts
+++ b/supabase/functions/_shared/paginate.ts
@@ -19,10 +19,13 @@ const PAGE = 1000;
 // Mora aqui (e não em `relatorio-mensal.ts`, onde nasceu) porque descreve a forma da
 // query que `fetchAll` pagina: é contrato de paginação, não do relatório mensal.
 
+// `error` carrega o `code` do PostgREST (opcional) porque `_shared/leitura-critica.ts`
+// decide POR CÓDIGO o que tolerar (`42703` coluna ausente) e o que lançar — e as duas
+// famílias, paginação e leitura single-shot, convivem na MESMA query encadeada.
 export interface RespostaPostgrest<T> {
   data: T[] | null;
   count?: number | null;
-  error: { message: string } | null;
+  error: { message: string; code?: string | null; details?: string | null; hint?: string | null } | null;
 }
 
 export interface QueryPostgrest<T> extends PromiseLike<RespostaPostgrest<T>> {
@@ -34,6 +37,16 @@ export interface QueryPostgrest<T> extends PromiseLike<RespostaPostgrest<T>> {
   not(coluna: string, operador: string, valor: unknown): QueryPostgrest<T>;
   order(coluna: string, opts?: { ascending?: boolean }): QueryPostgrest<T>;
   range(de: number, ate: number): QueryPostgrest<T>;
+  // `limit` é a AMOSTRA deliberada (teto de negócio), não a paginação: quem usa `limit`
+  // está dizendo "cabe menos e tudo bem". Continua exigindo `.order()` estável, senão a
+  // amostra muda a cada execução e o resultado deixa de ser reprodutível.
+  limit(n: number): QueryPostgrest<T>;
+  // Termina a cadeia devolvendo UMA linha (ou `null`) em vez de array — mesma resposta
+  // `{data,error}`, outro formato de `data`.
+  maybeSingle(): PromiseLike<{
+    data: T | null;
+    error: { message: string; code?: string | null; details?: string | null; hint?: string | null } | null;
+  }>;
 }
 
 export interface BancoPostgrest {

--- a/supabase/functions/_shared/recommend-leituras.ts
+++ b/supabase/functions/_shared/recommend-leituras.ts
@@ -61,14 +61,29 @@ import { exigirLeitura, exigirLista, FalhaLeituraCritica } from "./leitura-criti
  * classe no helper é entrega própria, não carona nesta.
  */
 async function paginarFonte<T>(
-  build: (de: number, ate: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  build: (
+    de: number,
+    ate: number,
+  ) => PromiseLike<{ data: T[] | null; error: { message: string; code?: string | null } | null }>,
   fonte: string,
 ): Promise<T[]> {
+  // O erro é interceptado AQUI, antes de `fetchAll` vê-lo: o helper reduz a resposta a
+  // ``new Error(`${label}: ${message}`)`` e o `code` do PostgREST (57014 timeout, 42501 RLS)
+  // se perde no caminho. Interceptando na origem, o código sobrevive para a classificação
+  // operacional e a mensagem PÚBLICA continua fechada (achado da 2ª rodada do Codex, que
+  // corrigiu minha afirmação anterior de que "o original fica em `cause`" — não ficava).
+  const comErroFechado = async (de: number, ate: number) => {
+    const res = await build(de, ate);
+    if (res.error) throw new FalhaLeituraCritica(fonte, res.error);
+    return res;
+  };
   try {
-    return await fetchAll<T>(build, fonte);
+    return await fetchAll<T>(comErroFechado, fonte);
   } catch (e) {
     if (e instanceof FalhaLeituraCritica) throw e;
-    const falha = new FalhaLeituraCritica(fonte, null);
+    // O que resta é o `data:null` sem erro, que `fetchAll` rejeita por conta própria — mesma
+    // resposta malformada que `exigirLista` nomeia, então mesmo código.
+    const falha = new FalhaLeituraCritica(fonte, { code: "MALFORMADA" });
     falha.cause = e;
     throw falha;
   }
@@ -153,11 +168,16 @@ export interface ClusterRecommend {
   usuariosAmostrados: string[];
   clusterPurchases: LinhaCompraCluster[];
   /**
-   * `true` quando a amostra bateu em `TETO_CLUSTER_COMPRAS` — há mais compras do que
-   * coube. Cap deliberado deixa de ser cap SILENCIOSO: o consumidor pode dizer que o
-   * `sim_score` saiu de uma amostra parcial em vez de afirmá-lo como se fosse o total.
+   * `true` quando a amostra bateu em `TETO_CLUSTER_COMPRAS`. Chama-se "no teto" e não
+   * "saturada" porque é exatamente isso que o código SABE: com 1.000 compras existentes e
+   * 1.000 lidas nada foi cortado, e o campo ainda assim é `true`. Afirmar "há mais compras"
+   * exigiria `count:'exact'`, que não se pede aqui. (2ª rodada do Codex — o nome anterior
+   * prometia mais do que a medição sustenta, que é a própria classe que esta entrega combate.)
+   *
+   * O que ele compra: o cap DELIBERADO deixa de ser cap SILENCIOSO — quem consome pode dizer
+   * que o `sim_score` pode ter saído de amostra parcial em vez de afirmá-lo como total.
    */
-  amostraSaturada: boolean;
+  amostraNoTeto: boolean;
 }
 
 /**
@@ -268,7 +288,7 @@ export async function carregarCluster(
   // `.in()` com lista vazia é round-trip inútil e, no PostgREST, a forma degenerada `in.()`.
   // Cluster vazio é estado legítimo (nenhum cliente naquele `health_class`).
   if (usuariosAmostrados.length === 0) {
-    return { clusterUserIds, usuariosAmostrados, clusterPurchases: [], amostraSaturada: false };
+    return { clusterUserIds, usuariosAmostrados, clusterPurchases: [], amostraNoTeto: false };
   }
 
   const clusterPurchases = exigirLista(
@@ -284,6 +304,6 @@ export async function carregarCluster(
     clusterUserIds,
     usuariosAmostrados,
     clusterPurchases,
-    amostraSaturada: clusterPurchases.length >= TETO_CLUSTER_COMPRAS,
+    amostraNoTeto: clusterPurchases.length >= TETO_CLUSTER_COMPRAS,
   };
 }

--- a/supabase/functions/_shared/recommend-leituras.ts
+++ b/supabase/functions/_shared/recommend-leituras.ts
@@ -1,0 +1,289 @@
+// Camada de LEITURA do motor de recomendação (`recommend/index.ts`).
+//
+// Por que existe um módulo só para ler seis tabelas: a edge importa
+// `npm:@supabase/supabase-js@2`, e `test:edges` roda com `--no-remote`. Enquanto as leituras
+// moravam dentro do `index.ts`, nenhuma afirmação sobre elas era EXECUTÁVEL — "o catálogo
+// volta inteiro" e "erro de leitura não vira catálogo parcial" só podiam ser lidas, nunca
+// provadas. Aqui elas rodam contra um double que satisfaz `BancoPostgrest`
+// (`recommend-leituras_test.ts`), no runtime real.
+//
+// O DEFEITO QUE ESTE MÓDULO FECHA (achado por challenge Codex, confirmado por leitura de
+// código + medição psql-ro em prod, 2026-08-20). O `Promise.all` original desestruturava
+// apenas `{ data }` nas SEIS leituras — todo `error` descartado — e NENHUMA paginava. O
+// PostgREST capa cada resposta em 1000 linhas EM SILÊNCIO, então em prod:
+//
+//   omie_products WHERE ativo               3.140 linhas → a edge via 1.000 (32%)
+//   product_costs                           3.676 linhas → a edge via 1.000 (27%)
+//   order_items do cliente          até 2.849 por cliente → 8 clientes truncados
+//   farmer_association_rules (lift/support)     4 linhas → íntegro HOJE, e só hoje
+//   recommendation_config                      15 linhas → íntegro
+//   farmer_client_scores (maybeSingle)          1 linha  → íntegro
+//
+// E os três efeitos, que não são o mesmo efeito:
+//   · catálogo truncado ⇒ 68% dos SKUs recomendáveis invisíveis, e QUAIS 1.000 sobram é
+//     não-determinístico (sem ORDER BY o Postgres não promete sequência) — a recomendação
+//     variava sem causa;
+//   · custo truncado ⇒ o número que importa NÃO é 1.000/3.676 (cobertura das linhas de
+//     `product_costs`), é a cobertura dos CANDIDATOS — derivação corrigida no challenge
+//     Codex. Medida: dos 3.140 produtos ativos, só 833 (26,5%) têm custo na primeira página
+//     `ORDER BY id`; 73,5% caem em `custoConfiavel = null`. O consumidor JÁ degrada honesto
+//     (margem exibida vira null, `margemRank` vira 0 = "EIP neutro"), então aqui NÃO se infla
+//     margem — mas o componente de LUCRO tem o MAIOR peso (`w_eip` 0.35) e passava a ser
+//     decidido sobre um quarto dos custos, com o corte arbitrário. Perda por omissão;
+//     (`product_costs.product_id` é ÚNICO — 3.676 linhas, 3.676 distintos, medido —, então
+//     ordenar por `id` não escolhe "qual custo vale": não há dois para o mesmo produto.)
+//   · histórico truncado ⇒ `hasPurchased`/`recommendation_type`/`ctx_score`/`recorrência`
+//     errados exatamente nos 8 clientes MAIORES.
+//
+// Regra desta camada, uniforme de propósito: TODA leitura de LISTA pagina por `fetchAll`
+// (que lança em `error` e em `data:null` sem erro), mesmo a que hoje cabe em uma página —
+// deixar duas exceções obrigaria todo leitor futuro a re-derivar quais são. O que sobra é a
+// leitura de UMA linha, que passa por `exigirLeitura`. Falha de leitura vira exceção: a
+// edge devolve 500 em vez de uma recomendação calculada sobre catálogo parcial.
+import { fetchAll } from "./paginate.ts";
+import type { BancoPostgrest } from "./paginate.ts";
+import { exigirLeitura, exigirLista, FalhaLeituraCritica } from "./leitura-critica.ts";
+
+/**
+ * `fetchAll` com o erro em DOMÍNIO FECHADO.
+ *
+ * O helper canônico lança ``new Error(`${label}: ${error.message}`)`` — e `error.message` do
+ * PostgREST encaminha o MESSAGE do Postgres, que pode interpolar valor de linha (`RAISE
+ * EXCEPTION` com ID/CPF, erro de cast reproduzindo o valor inválido). O `catch` do
+ * `Deno.serve` de `recommend/index.ts` devolve `error.message` no CORPO da resposta, então
+ * esse texto SAI DA EDGE — é o "garantia de privacidade afirmada sem verificar o SINK" que
+ * `leitura-critica.ts` documenta. (Achado pelo teste desta entrega, não pela leitura.)
+ *
+ * O texto original não some: vai para `cause`, que a resposta HTTP não serializa e que
+ * sobrevive nos logs da edge. Envelopar aqui, e não em `paginate.ts`, é deliberado — mudar o
+ * tipo lançado pelo helper mexeria nos 21 call-sites de `fetchAll`, e um deles
+ * (`visit-score-recalc-client`) já RAMIFICA em `instanceof FalhaLeituraCritica`. Fechar a
+ * classe no helper é entrega própria, não carona nesta.
+ */
+async function paginarFonte<T>(
+  build: (de: number, ate: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  fonte: string,
+): Promise<T[]> {
+  try {
+    return await fetchAll<T>(build, fonte);
+  } catch (e) {
+    if (e instanceof FalhaLeituraCritica) throw e;
+    const falha = new FalhaLeituraCritica(fonte, null);
+    falha.cause = e;
+    throw falha;
+  }
+}
+
+// ── Formas das linhas (o que o `.select()` de cada leitura promete) ────────────────────
+
+export interface LinhaConfig {
+  key: string;
+  value: number;
+}
+
+export interface LinhaOrderItem {
+  product_id: string | null;
+  quantity: number | null;
+  unit_price: number | null;
+}
+
+export interface LinhaProduto {
+  id: string;
+  omie_codigo_produto: number;
+  descricao: string;
+  codigo: string;
+  valor_unitario: number | null;
+  estoque: number | null;
+  familia: string | null;
+  subfamilia: string | null;
+}
+
+export interface LinhaCusto {
+  product_id: string;
+  cost_price: number | null;
+  cost_final: number | null;
+  cost_source: string | null;
+  cost_confidence: number | null;
+}
+
+export interface LinhaRegra {
+  id?: string;
+  antecedent_product_ids: string[] | null;
+  consequent_product_ids: string[] | null;
+  lift: number;
+  confidence: number;
+  support: number;
+}
+
+export interface LinhaClientScore {
+  health_class: string | null;
+  category_count: number | null;
+}
+
+export interface LinhaCompraCluster {
+  product_id: string | null;
+  customer_user_id: string;
+}
+
+export interface InsumosRecommend {
+  configs: LinhaConfig[];
+  orderItems: LinhaOrderItem[];
+  products: LinhaProduto[];
+  costs: LinhaCusto[];
+  rules: LinhaRegra[];
+  /** `null` = cliente sem score cadastrado. Estado LEGÍTIMO — distinto de falha, que lança. */
+  clientScore: LinhaClientScore | null;
+}
+
+// ── Tetos do cluster: amostra DELIBERADA, e por isso nomeada ───────────────────────────
+// Estes três números são teto de custo, não cap acidental do transporte. Ficam como
+// constantes exportadas para o teste afirmar sobre eles em vez de repeti-los.
+
+/** Quantos clientes do mesmo `health_class` entram na amostra de similaridade. */
+export const TETO_CLUSTER_CLIENTES = 100;
+/** Destes, de quantos se buscam as compras (o `.in()` cresce a URL do PostgREST). */
+export const TETO_CLUSTER_USUARIOS_AMOSTRA = 50;
+/** Teto de linhas de compra da amostra. */
+export const TETO_CLUSTER_COMPRAS = 1000;
+
+export interface ClusterRecommend {
+  /** Os até `TETO_CLUSTER_CLIENTES` clientes do mesmo `health_class`. */
+  clusterUserIds: string[];
+  /** O recorte de `clusterUserIds` de quem as compras foram efetivamente buscadas. */
+  usuariosAmostrados: string[];
+  clusterPurchases: LinhaCompraCluster[];
+  /**
+   * `true` quando a amostra bateu em `TETO_CLUSTER_COMPRAS` — há mais compras do que
+   * coube. Cap deliberado deixa de ser cap SILENCIOSO: o consumidor pode dizer que o
+   * `sim_score` saiu de uma amostra parcial em vez de afirmá-lo como se fosse o total.
+   */
+  amostraSaturada: boolean;
+}
+
+/**
+ * As seis leituras do motor, em paralelo, paginadas e com falha EXPOSTA.
+ *
+ * ⚠️ `.order("id")` em toda leitura paginada: `id` é a PK das seis tabelas (conferido em
+ * `pg_index` na prod). Sem ordem estável o `.range()` pula/duplica linhas entre páginas, e
+ * o helper que lança no erro não protege disso (money-path §7).
+ */
+export async function carregarInsumos(
+  db: BancoPostgrest,
+  customerId: string,
+): Promise<InsumosRecommend> {
+  const [configs, orderItems, products, costs, rules, clientScore] = await Promise.all([
+    paginarFonte<LinhaConfig>(
+      (de, ate) =>
+        db.from<LinhaConfig>("recommendation_config")
+          .select("key, value")
+          .order("id", { ascending: true })
+          .range(de, ate),
+      "recommendation_config",
+    ),
+    paginarFonte<LinhaOrderItem>(
+      (de, ate) =>
+        db.from<LinhaOrderItem>("order_items")
+          .select("product_id, quantity, unit_price")
+          .eq("customer_user_id", customerId)
+          .order("id", { ascending: true })
+          .range(de, ate),
+      "order_items",
+    ),
+    paginarFonte<LinhaProduto>(
+      (de, ate) =>
+        db.from<LinhaProduto>("omie_products")
+          .select("id, omie_codigo_produto, descricao, codigo, valor_unitario, estoque, familia, subfamilia")
+          .eq("ativo", true)
+          .order("id", { ascending: true })
+          .range(de, ate),
+      "omie_products",
+    ),
+    paginarFonte<LinhaCusto>(
+      (de, ate) =>
+        db.from<LinhaCusto>("product_costs")
+          .select("product_id, cost_price, cost_final, cost_source, cost_confidence")
+          .order("id", { ascending: true })
+          .range(de, ate),
+      "product_costs",
+    ),
+    // 4 linhas em prod hoje. Pagina mesmo assim: o volume desta tabela é função do PISO de
+    // `lift`/`support` — baixar o piso é uma decisão de produto de uma linha, que não tem
+    // como saber que existe um cap de 1000 esperando do outro lado.
+    paginarFonte<LinhaRegra>(
+      (de, ate) =>
+        db.from<LinhaRegra>("farmer_association_rules")
+          .select("*")
+          .gte("lift", 1.2)
+          .gte("support", 0.01)
+          .order("id", { ascending: true })
+          .range(de, ate),
+      "farmer_association_rules",
+    ),
+    // Única leitura de UMA linha. `exigirLeitura` lança no erro e devolve `data` como veio
+    // quando não há erro — então "cliente sem score" (null) segue caindo no default do
+    // consumidor, e só a FALHA deixa de se disfarçar de ausência.
+    db.from<LinhaClientScore>("farmer_client_scores")
+      .select("health_class, category_count")
+      .eq("customer_user_id", customerId)
+      .maybeSingle()
+      .then((res) => exigirLeitura(res, "farmer_client_scores")),
+  ]);
+
+  return { configs, orderItems, products, costs, rules, clientScore };
+}
+
+/**
+ * Amostra de similaridade: clientes do mesmo `health_class` e o que compraram.
+ *
+ * Aqui o teto é de NEGÓCIO (custo da chamada), não o cap do transporte — por isso `.limit()`
+ * e não `fetchAll`. O que muda em relação ao código anterior é o resto do contrato: a amostra
+ * é pedida com `.order("id")` (antes o Postgres escolhia 100 quaisquer, e escolhia outros 100
+ * na execução seguinte — o `sim_score` do mesmo cliente mudava sem nada ter mudado), o `error`
+ * passa a LANÇAR, e a saturação vira campo em vez de silêncio.
+ *
+ * ⚠️ O QUE ISTO **NÃO** CONSERTA, dito por extenso para não passar por consertado (challenge
+ * Codex): `.order("id").limit(100)` não é AMOSTRAGEM — é o PREFIXO por PK. Dos 6.185 clientes
+ * `critico` medidos em prod, saem sempre os mesmos 100, e provavelmente os mais antigos. O
+ * ganho aqui é reprodutibilidade (o mesmo cliente recebe a mesma recomendação), não
+ * representatividade; a regra de amostra continua indefinida e o viés, agora, é ESTÁVEL em vez
+ * de aleatório. Trocar por amostra por hash/seed ou estratificada é decisão de produto sobre o
+ * ranking — outro eixo que o desta entrega, que é truncagem de transporte.
+ */
+export async function carregarCluster(
+  db: BancoPostgrest,
+  healthClass: string,
+): Promise<ClusterRecommend> {
+  const clusterCustomers = exigirLista(
+    await db.from<{ customer_user_id: string }>("farmer_client_scores")
+      .select("customer_user_id")
+      .eq("health_class", healthClass)
+      .order("id", { ascending: true })
+      .limit(TETO_CLUSTER_CLIENTES),
+    "farmer_client_scores (cluster)",
+  );
+
+  const clusterUserIds = clusterCustomers.map((c) => c.customer_user_id);
+  const usuariosAmostrados = clusterUserIds.slice(0, TETO_CLUSTER_USUARIOS_AMOSTRA);
+
+  // `.in()` com lista vazia é round-trip inútil e, no PostgREST, a forma degenerada `in.()`.
+  // Cluster vazio é estado legítimo (nenhum cliente naquele `health_class`).
+  if (usuariosAmostrados.length === 0) {
+    return { clusterUserIds, usuariosAmostrados, clusterPurchases: [], amostraSaturada: false };
+  }
+
+  const clusterPurchases = exigirLista(
+    await db.from<LinhaCompraCluster>("order_items")
+      .select("product_id, customer_user_id")
+      .in("customer_user_id", usuariosAmostrados)
+      .order("id", { ascending: true })
+      .limit(TETO_CLUSTER_COMPRAS),
+    "order_items (cluster)",
+  );
+
+  return {
+    clusterUserIds,
+    usuariosAmostrados,
+    clusterPurchases,
+    amostraSaturada: clusterPurchases.length >= TETO_CLUSTER_COMPRAS,
+  };
+}

--- a/supabase/functions/_shared/recommend-leituras.ts
+++ b/supabase/functions/_shared/recommend-leituras.ts
@@ -90,19 +90,24 @@ async function paginarFonte<T>(
 }
 
 // ── Formas das linhas (o que o `.select()` de cada leitura promete) ────────────────────
+// NÃO exportadas de propósito: ninguém fora daqui as nomeia, e `export` sem consumidor
+// reprova no gate de dead code (`bunx knip`, passo "Dead code gate" do CI — que roda
+// DEPOIS do typecheck e do teste, então uma suíte inteiramente verde não diz nada sobre
+// ele). Elas seguem visíveis onde importa: `InsumosRecommend`/`ClusterRecommend`, que são
+// exportados, as referenciam. Reexportar só quando alguém de fato importar.
 
-export interface LinhaConfig {
+interface LinhaConfig {
   key: string;
   value: number;
 }
 
-export interface LinhaOrderItem {
+interface LinhaOrderItem {
   product_id: string | null;
   quantity: number | null;
   unit_price: number | null;
 }
 
-export interface LinhaProduto {
+interface LinhaProduto {
   id: string;
   omie_codigo_produto: number;
   descricao: string;
@@ -113,7 +118,7 @@ export interface LinhaProduto {
   subfamilia: string | null;
 }
 
-export interface LinhaCusto {
+interface LinhaCusto {
   product_id: string;
   cost_price: number | null;
   cost_final: number | null;
@@ -121,7 +126,7 @@ export interface LinhaCusto {
   cost_confidence: number | null;
 }
 
-export interface LinhaRegra {
+interface LinhaRegra {
   id?: string;
   antecedent_product_ids: string[] | null;
   consequent_product_ids: string[] | null;
@@ -130,12 +135,12 @@ export interface LinhaRegra {
   support: number;
 }
 
-export interface LinhaClientScore {
+interface LinhaClientScore {
   health_class: string | null;
   category_count: number | null;
 }
 
-export interface LinhaCompraCluster {
+interface LinhaCompraCluster {
   product_id: string | null;
   customer_user_id: string;
 }

--- a/supabase/functions/_shared/recommend-leituras_test.ts
+++ b/supabase/functions/_shared/recommend-leituras_test.ts
@@ -1,0 +1,381 @@
+// Testa o CÓDIGO REAL de recommend-leituras.ts (não uma cópia) no runtime real (Deno).
+// Roda com: deno test --no-remote --allow-read=supabase/functions supabase/functions/_shared/recommend-leituras_test.ts
+//
+// Sem import remoto (jsr:/npm:) — `test:edges` roda com --no-remote e BLOQUEIA o CI. Por isso
+// o assert é local (padrão de paginate_test.ts / mapas-paginados_test.ts) e o "banco" é um
+// double que satisfaz `BancoPostgrest`, o contrato estrutural que os loaders pedem.
+//
+// O QUE ESTE ARQUIVO PROVA, e por que não dava pra provar antes: a edge `recommend/index.ts`
+// importa `npm:@supabase/supabase-js@2`, então NUNCA roda sob --no-remote. Enquanto as seis
+// leituras moravam lá dentro, "o catálogo volta inteiro" e "erro de leitura LANÇA" eram
+// afirmações sem execução. Extrair a camada de leitura é o que torna as duas EXECUTÁVEIS.
+import {
+  carregarCluster,
+  carregarInsumos,
+  TETO_CLUSTER_CLIENTES,
+  TETO_CLUSTER_COMPRAS,
+  TETO_CLUSTER_USUARIOS_AMOSTRA,
+} from "./recommend-leituras.ts";
+import { FalhaLeituraCritica } from "./leitura-critica.ts";
+import type { BancoPostgrest, QueryPostgrest, RespostaPostgrest } from "./paginate.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+async function assertLanca(fn: () => Promise<unknown>, msg: string): Promise<Error> {
+  try {
+    await fn();
+  } catch (e) {
+    return e as Error;
+  }
+  throw new Error(`${msg}: NÃO lançou — a falha foi engolida`);
+}
+
+// Registro do que a query PEDIU. É o que torna o `.order()` uma asserção de verdade: sem
+// ordenação estável o `.range()` pula/duplica linha entre páginas, e isso é invisível
+// olhando só o resultado de um double que devolve as páginas já ordenadas.
+type Registro = {
+  tabela: string;
+  order: string | null;
+  filtros: string[];
+  ranges: Array<[number, number]>;
+  limit: number | null;
+  single: boolean;
+};
+
+type Linha = Record<string, unknown>;
+
+/**
+ * O double SIMULA O CAP DE 1000 DO POSTGREST: sem `.range()` explícito ele corta em 1000
+ * linhas, em silêncio, exatamente como o Data API real. Sem isso o teste seria VAZIO —
+ * uma leitura não paginada devolveria a tabela inteira no double e passaria verde.
+ * (É o mesmo `usouRange` de relatorio-mensal_test.ts.)
+ */
+const CAP_POSTGREST = 1000;
+
+function fakeDb(
+  porTabela: Record<string, Linha[]>,
+  opts: { erroEm?: string; codigo?: string } = {},
+) {
+  const registros: Registro[] = [];
+
+  // Um registro por `from()` — ou seja, um por PÁGINA, que é o que permite afirmar que
+  // TODA página (não só a primeira) foi pedida com `.order()` estável.
+  function query(tabela: string): QueryPostgrest<Linha> {
+    const reg: Registro = { tabela, order: null, filtros: [], ranges: [], limit: null, single: false };
+    registros.push(reg);
+    // Os predicados filtram DE VERDADE: um double que registra o filtro sem aplicá-lo
+    // mediria mais linhas do que a query devolveria, e o teste ficaria falso-verde.
+    const predicados: Array<(l: Linha) => boolean> = [];
+
+    function corpo(): Linha[] {
+      const linhas = (porTabela[tabela] ?? []).filter((l) => predicados.every((p) => p(l)));
+      const alcance = reg.ranges[reg.ranges.length - 1];
+      if (alcance) return linhas.slice(alcance[0], alcance[1] + 1);
+      const teto = reg.limit ?? CAP_POSTGREST;
+      return linhas.slice(0, Math.min(teto, CAP_POSTGREST));
+    }
+
+    function resposta(): RespostaPostgrest<Linha> {
+      if (opts.erroEm === tabela) {
+        return { data: null, error: { message: "boom", code: opts.codigo ?? "57014" } };
+      }
+      return { data: corpo(), error: null };
+    }
+
+    const q: QueryPostgrest<Linha> = {
+      select(_colunas: string) {
+        return q;
+      },
+      eq(coluna: string, valor: unknown) {
+        reg.filtros.push(`eq:${coluna}`);
+        predicados.push((l) => l[coluna] === valor);
+        return q;
+      },
+      in(coluna: string, valores: readonly unknown[]) {
+        const alvo = new Set(valores);
+        reg.filtros.push(`in:${coluna}=${valores.length}`);
+        predicados.push((l) => alvo.has(l[coluna]));
+        return q;
+      },
+      gte(coluna: string, valor: unknown) {
+        reg.filtros.push(`gte:${coluna}`);
+        predicados.push((l) => Number(l[coluna] ?? 0) >= Number(valor));
+        return q;
+      },
+      lt(coluna: string, valor: unknown) {
+        reg.filtros.push(`lt:${coluna}`);
+        predicados.push((l) => Number(l[coluna] ?? 0) < Number(valor));
+        return q;
+      },
+      not(coluna: string, operador: string, _valor: unknown) {
+        reg.filtros.push(`not:${coluna} ${operador}`);
+        return q;
+      },
+      order(coluna: string, _opts?: { ascending?: boolean }) {
+        reg.order = coluna;
+        return q;
+      },
+      range(de: number, ate: number) {
+        reg.ranges.push([de, ate]);
+        return q;
+      },
+      limit(n: number) {
+        reg.limit = n;
+        return q;
+      },
+      maybeSingle() {
+        reg.single = true;
+        const r = resposta();
+        return Promise.resolve(
+          r.error ? { data: null, error: r.error } : { data: (r.data ?? [])[0] ?? null, error: null },
+        );
+      },
+      then<R1, R2>(
+        resolve?: ((v: RespostaPostgrest<Linha>) => R1 | PromiseLike<R1>) | null,
+        rejeitar?: ((motivo: unknown) => R2 | PromiseLike<R2>) | null,
+      ): PromiseLike<R1 | R2> {
+        return Promise.resolve(resposta()).then(resolve, rejeitar);
+      },
+    };
+    return q;
+  }
+
+  // Duplo cast do TEST DOUBLE: `query` devolve sempre `QueryPostgrest<Linha>`, que não
+  // satisfaz sozinho o `from<T>` genérico da interface real.
+  const db = {
+    from: <T>(tabela: string) => query(tabela) as unknown as QueryPostgrest<T>,
+  } as BancoPostgrest;
+
+  return { db, registros };
+}
+
+// ── Fixtures dimensionadas pela PROD medida em 2026-08-20 via psql-ro ──────────────────
+const CLIENTE = "cliente-alvo";
+const N_PRODUTOS = 3140; // omie_products WHERE ativo = true
+const N_CUSTOS = 3676; // product_costs
+const N_ITENS_DO_CLIENTE = 2849; // maior order_items por customer_user_id (8 clientes > 1000)
+
+function produtos(n: number): Linha[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `p${String(i).padStart(5, "0")}`,
+    omie_codigo_produto: i,
+    descricao: `Produto ${i}`,
+    codigo: `SKU${i}`,
+    valor_unitario: 100,
+    estoque: 5,
+    familia: "f",
+    subfamilia: "s",
+    ativo: i % 10 !== 0 ? true : false, // 10% inativos: o filtro do double tem de morder
+  }));
+}
+
+function custos(n: number): Linha[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `c${String(i).padStart(5, "0")}`,
+    product_id: `p${String(i).padStart(5, "0")}`,
+    cost_price: 60,
+    cost_final: 60,
+    cost_source: "PRODUCT_COST",
+    cost_confidence: 1,
+  }));
+}
+
+function itens(n: number, cliente: string): Linha[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `i${String(i).padStart(5, "0")}`,
+    product_id: `p${String(i % 500).padStart(5, "0")}`,
+    quantity: 1,
+    unit_price: 100,
+    customer_user_id: cliente,
+  }));
+}
+
+function bancoCheio(extra: Record<string, Linha[]> = {}): Record<string, Linha[]> {
+  return {
+    recommendation_config: [{ id: "1", key: "w_assoc", value: 0.4 }],
+    order_items: [
+      ...itens(N_ITENS_DO_CLIENTE, CLIENTE),
+      ...itens(30, "outro-cliente").map((l, i) => ({ ...l, id: `z${i}` })),
+    ],
+    omie_products: produtos(N_PRODUTOS),
+    product_costs: custos(N_CUSTOS),
+    farmer_association_rules: [
+      { id: "r1", antecedent_product_ids: ["p00001"], consequent_product_ids: ["p00002"], lift: 2, confidence: 0.5, support: 0.1 },
+      { id: "r2", antecedent_product_ids: ["p00003"], consequent_product_ids: ["p00004"], lift: 1.0, confidence: 0.5, support: 0.1 },
+    ],
+    farmer_client_scores: [{ id: "s1", customer_user_id: CLIENTE, health_class: "critico", category_count: 3 }],
+    ...extra,
+  };
+}
+
+const ATIVOS_ESPERADOS = produtos(N_PRODUTOS).filter((p) => p.ativo === true).length;
+
+// ── 1. O defeito: as leituras grandes voltavam capadas em 1000 ─────────────────────────
+
+Deno.test("catálogo de 3.140 ativos volta INTEIRO (não os 1.000 do cap do PostgREST)", async () => {
+  const { db } = fakeDb(bancoCheio());
+  const insumos = await carregarInsumos(db, CLIENTE);
+  assertEquals(insumos.products.length, ATIVOS_ESPERADOS, "catálogo truncado");
+  if (insumos.products.length <= CAP_POSTGREST) {
+    throw new Error("o teste ficou vazio: a fixture não passa do cap");
+  }
+});
+
+Deno.test("product_costs de 3.676 volta INTEIRO — custo ausente por truncagem vira 'SKU sem custo'", async () => {
+  const { db } = fakeDb(bancoCheio());
+  const insumos = await carregarInsumos(db, CLIENTE);
+  assertEquals(insumos.costs.length, N_CUSTOS, "custos truncados");
+});
+
+Deno.test("order_items do cliente de 2.849 volta INTEIRO — e só do cliente pedido", async () => {
+  const { db } = fakeDb(bancoCheio());
+  const insumos = await carregarInsumos(db, CLIENTE);
+  assertEquals(insumos.orderItems.length, N_ITENS_DO_CLIENTE, "itens do cliente truncados");
+});
+
+Deno.test("farmer_association_rules pagina e aplica o piso de lift/support", async () => {
+  const { db } = fakeDb(bancoCheio());
+  const insumos = await carregarInsumos(db, CLIENTE);
+  // r2 tem lift 1.0 < 1.2 → o double filtra de verdade, então só r1 sobrevive.
+  assertEquals(insumos.rules.map((r) => r.id), ["r1"], "piso de lift/support não aplicado");
+});
+
+// ── 2. Controle de calibração: o double CAPA de verdade ────────────────────────────────
+// Sem este teste, "voltou inteiro" poderia ser só o double devolvendo tudo — e o gate
+// aprovaria uma leitura NÃO paginada. Ele prova que o cap existe no double.
+
+Deno.test("controle: leitura SEM .range() no double é capada em 1.000 (o teste não é vazio)", async () => {
+  const { db } = fakeDb(bancoCheio());
+  const semRange = await db.from<Linha>("omie_products").select("id").eq("ativo", true);
+  assertEquals(semRange.data?.length, CAP_POSTGREST, "o double não simula o cap — os testes acima são teatro");
+});
+
+// ── 3. Toda página pediu ordem ESTÁVEL ─────────────────────────────────────────────────
+
+Deno.test("todo .range() foi pedido com .order('id') — a PK, estável entre páginas", async () => {
+  const { db, registros } = fakeDb(bancoCheio());
+  await carregarInsumos(db, CLIENTE);
+  const paginadas = registros.filter((r) => r.ranges.length > 0);
+  if (paginadas.length < 4) {
+    throw new Error(`só ${paginadas.length} leituras paginaram — esperava ≥4 (produtos, custos, itens, regras)`);
+  }
+  const semOrdem = paginadas.filter((r) => r.order !== "id");
+  if (semOrdem.length > 0) {
+    throw new Error(`.range() sem .order('id') em: ${semOrdem.map((r) => r.tabela).join(", ")}`);
+  }
+});
+
+// ── 4. Erro de leitura LANÇA — não vira catálogo parcial nem default silencioso ────────
+
+for (
+  const tabela of [
+    "recommendation_config",
+    "order_items",
+    "omie_products",
+    "product_costs",
+    "farmer_association_rules",
+    "farmer_client_scores",
+  ]
+) {
+  Deno.test(`erro em ${tabela} LANÇA (não é engolido em recomendação sobre dado parcial)`, async () => {
+    const { db } = fakeDb(bancoCheio(), { erroEm: tabela });
+    await assertLanca(() => carregarInsumos(db, CLIENTE), `erro em ${tabela}`);
+  });
+}
+
+Deno.test("erro em recommendation_config NÃO deixa os pesos caírem nos defaults hard-coded", async () => {
+  const { db } = fakeDb(bancoCheio(), { erroEm: "recommendation_config" });
+  const erro = await assertLanca(() => carregarInsumos(db, CLIENTE), "config");
+  if (!(erro instanceof FalhaLeituraCritica)) {
+    throw new Error(`esperava FalhaLeituraCritica, veio ${erro.name}: ${erro.message}`);
+  }
+});
+
+Deno.test("erro em farmer_client_scores NÃO deixa o health_class cair no default silencioso", async () => {
+  const { db } = fakeDb(bancoCheio(), { erroEm: "farmer_client_scores" });
+  const erro = await assertLanca(() => carregarInsumos(db, CLIENTE), "client score");
+  if (!(erro instanceof FalhaLeituraCritica)) {
+    throw new Error(`esperava FalhaLeituraCritica, veio ${erro.name}: ${erro.message}`);
+  }
+});
+
+Deno.test("a mensagem do erro não vaza texto do servidor (domínio fechado)", async () => {
+  const { db } = fakeDb(bancoCheio(), { erroEm: "omie_products" });
+  const erro = await assertLanca(() => carregarInsumos(db, CLIENTE), "produtos");
+  if (erro.message.includes("boom")) {
+    throw new Error(`mensagem do servidor vazou para o cliente: ${erro.message}`);
+  }
+});
+
+// ── 5. Ausência LEGÍTIMA continua sendo ausência (não virou erro) ──────────────────────
+
+Deno.test("cliente sem score: data null SEM error devolve null — ausência ≠ falha", async () => {
+  const { db } = fakeDb(bancoCheio({ farmer_client_scores: [] }));
+  const insumos = await carregarInsumos(db, CLIENTE);
+  assertEquals(insumos.clientScore, null, "ausência de score virou outra coisa");
+});
+
+Deno.test("cliente sem histórico: lista vazia é estado legítimo, não erro", async () => {
+  const { db } = fakeDb(bancoCheio({ order_items: [] }));
+  const insumos = await carregarInsumos(db, CLIENTE);
+  assertEquals(insumos.orderItems.length, 0);
+});
+
+// ── 6. Cluster: amostra deliberada, mas DETERMINÍSTICA e que expõe falha ───────────────
+
+function scoresDoCluster(n: number): Linha[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `s${String(i).padStart(5, "0")}`,
+    customer_user_id: `u${String(i).padStart(5, "0")}`,
+    health_class: "critico",
+    category_count: 1,
+  }));
+}
+
+Deno.test("cluster: .limit() é amostra deliberada, mas pedida com .order('id') — reprodutível", async () => {
+  const { db, registros } = fakeDb({
+    farmer_client_scores: scoresDoCluster(6185),
+    order_items: itens(300, "u00000"),
+  });
+  const { clusterUserIds } = await carregarCluster(db, "critico");
+  assertEquals(clusterUserIds.length, TETO_CLUSTER_CLIENTES, "teto do cluster mudou sem o teste saber");
+  const semOrdem = registros.filter((r) => r.limit !== null && r.order !== "id");
+  if (semOrdem.length > 0) {
+    throw new Error(`amostra sem ordem estável em: ${semOrdem.map((r) => r.tabela).join(", ")}`);
+  }
+});
+
+Deno.test("cluster: erro em farmer_client_scores LANÇA (sim_score não some em silêncio)", async () => {
+  const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(10) }, { erroEm: "farmer_client_scores" });
+  await assertLanca(() => carregarCluster(db, "critico"), "cluster");
+});
+
+Deno.test("cluster: erro em order_items LANÇA", async () => {
+  const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(10), order_items: itens(10, "u00000") }, { erroEm: "order_items" });
+  await assertLanca(() => carregarCluster(db, "critico"), "compras do cluster");
+});
+
+Deno.test("cluster vazio: nenhuma compra buscada e nenhum erro (health_class sem ninguém)", async () => {
+  const { db, registros } = fakeDb({ farmer_client_scores: scoresDoCluster(5) });
+  const r = await carregarCluster(db, "misto");
+  assertEquals(r.clusterUserIds.length, 0);
+  assertEquals(r.clusterPurchases.length, 0);
+  // `.in()` com lista vazia é round-trip inútil — e no PostgREST real é `in.()`, forma degenerada.
+  assertEquals(registros.filter((x) => x.tabela === "order_items").length, 0, "buscou compras de cluster vazio");
+});
+
+Deno.test("cluster: a amostra saturada é SINALIZADA (cap deliberado não é cap silencioso)", async () => {
+  const muitos = Array.from({ length: TETO_CLUSTER_COMPRAS + 500 }, (_, i) => ({
+    id: `i${String(i).padStart(6, "0")}`,
+    product_id: `p${i % 50}`,
+    customer_user_id: `u${String(i % TETO_CLUSTER_USUARIOS_AMOSTRA).padStart(5, "0")}`,
+  }));
+  const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(60), order_items: muitos });
+  const r = await carregarCluster(db, "critico");
+  assertEquals(r.clusterPurchases.length, TETO_CLUSTER_COMPRAS);
+  assertEquals(r.amostraSaturada, true, "saturação da amostra não foi exposta no contrato");
+});

--- a/supabase/functions/_shared/recommend-leituras_test.ts
+++ b/supabase/functions/_shared/recommend-leituras_test.ts
@@ -39,7 +39,11 @@ async function assertLanca(fn: () => Promise<unknown>, msg: string): Promise<Err
 // olhando só o resultado de um double que devolve as páginas já ordenadas.
 type Registro = {
   tabela: string;
+  colunas: string;
   order: string | null;
+  // Guardado separado do nome da coluna: um `.order("id", {ascending:false})` mantém a ordem
+  // ESTÁVEL (o gate textual passaria) e mesmo assim inverte QUAIS linhas entram num `.limit()`.
+  ascending: boolean | null;
   filtros: string[];
   ranges: Array<[number, number]>;
   limit: number | null;
@@ -58,14 +62,16 @@ const CAP_POSTGREST = 1000;
 
 function fakeDb(
   porTabela: Record<string, Linha[]>,
-  opts: { erroEm?: string; codigo?: string } = {},
+  opts: { erroEm?: string; codigo?: string; nulaEm?: string } = {},
 ) {
   const registros: Registro[] = [];
 
   // Um registro por `from()` — ou seja, um por PÁGINA, que é o que permite afirmar que
   // TODA página (não só a primeira) foi pedida com `.order()` estável.
   function query(tabela: string): QueryPostgrest<Linha> {
-    const reg: Registro = { tabela, order: null, filtros: [], ranges: [], limit: null, single: false };
+    const reg: Registro = {
+      tabela, colunas: "", order: null, ascending: null, filtros: [], ranges: [], limit: null, single: false,
+    };
     registros.push(reg);
     // Os predicados filtram DE VERDADE: um double que registra o filtro sem aplicá-lo
     // mediria mais linhas do que a query devolveria, e o teste ficaria falso-verde.
@@ -73,6 +79,14 @@ function fakeDb(
 
     function corpo(): Linha[] {
       const linhas = (porTabela[tabela] ?? []).filter((l) => predicados.every((p) => p(l)));
+      // Ordena DE VERDADE: um double que só registra `.order()` deixa `ascending:false` verde,
+      // e no cluster isso troca QUAIS 100 clientes entram na amostra (2ª rodada do Codex).
+      if (reg.order) {
+        const col = reg.order;
+        linhas.sort((a, b) =>
+          String(a[col] ?? "").localeCompare(String(b[col] ?? "")) * (reg.ascending === false ? -1 : 1)
+        );
+      }
       const alcance = reg.ranges[reg.ranges.length - 1];
       if (alcance) return linhas.slice(alcance[0], alcance[1] + 1);
       const teto = reg.limit ?? CAP_POSTGREST;
@@ -83,11 +97,15 @@ function fakeDb(
       if (opts.erroEm === tabela) {
         return { data: null, error: { message: "boom", code: opts.codigo ?? "57014" } };
       }
+      // `data:null` SEM error: resposta MALFORMADA do PostgREST. Não é "lista vazia" —
+      // é o EOF falso que `fetchAll`/`exigirLista` existem para rejeitar.
+      if (opts.nulaEm === tabela) return { data: null, error: null };
       return { data: corpo(), error: null };
     }
 
     const q: QueryPostgrest<Linha> = {
-      select(_colunas: string) {
+      select(colunas: string) {
+        reg.colunas = colunas;
         return q;
       },
       eq(coluna: string, valor: unknown) {
@@ -115,8 +133,9 @@ function fakeDb(
         reg.filtros.push(`not:${coluna} ${operador}`);
         return q;
       },
-      order(coluna: string, _opts?: { ascending?: boolean }) {
+      order(coluna: string, opts?: { ascending?: boolean }) {
         reg.order = coluna;
+        reg.ascending = opts?.ascending ?? true;
         return q;
       },
       range(de: number, ate: number) {
@@ -342,7 +361,7 @@ Deno.test("cluster: .limit() é amostra deliberada, mas pedida com .order('id') 
     order_items: itens(300, "u00000"),
   });
   const { clusterUserIds } = await carregarCluster(db, "critico");
-  assertEquals(clusterUserIds.length, TETO_CLUSTER_CLIENTES, "teto do cluster mudou sem o teste saber");
+  assertEquals(clusterUserIds.length, 100, "teto do cluster mudou sem o teste saber");
   const semOrdem = registros.filter((r) => r.limit !== null && r.order !== "id");
   if (semOrdem.length > 0) {
     throw new Error(`amostra sem ordem estável em: ${semOrdem.map((r) => r.tabela).join(", ")}`);
@@ -368,7 +387,7 @@ Deno.test("cluster vazio: nenhuma compra buscada e nenhum erro (health_class sem
   assertEquals(registros.filter((x) => x.tabela === "order_items").length, 0, "buscou compras de cluster vazio");
 });
 
-Deno.test("cluster: a amostra saturada é SINALIZADA (cap deliberado não é cap silencioso)", async () => {
+Deno.test("cluster: a amostra NO TETO é SINALIZADA (cap deliberado não é cap silencioso)", async () => {
   const muitos = Array.from({ length: TETO_CLUSTER_COMPRAS + 500 }, (_, i) => ({
     id: `i${String(i).padStart(6, "0")}`,
     product_id: `p${i % 50}`,
@@ -377,5 +396,94 @@ Deno.test("cluster: a amostra saturada é SINALIZADA (cap deliberado não é cap
   const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(60), order_items: muitos });
   const r = await carregarCluster(db, "critico");
   assertEquals(r.clusterPurchases.length, TETO_CLUSTER_COMPRAS);
-  assertEquals(r.amostraSaturada, true, "saturação da amostra não foi exposta no contrato");
+  assertEquals(r.amostraNoTeto, true, "o teto da amostra não foi exposto no contrato");
+});
+
+// ── 7. Os buracos que a 2ª rodada do Codex encontrou nesta própria suíte ───────────────
+
+Deno.test("tetos pinados por LITERAL — comparar com a constante importada é tautologia", () => {
+  // Subir TETO_CLUSTER_CLIENTES para 1.000 mantinha tudo verde e dividia `sim` por 1.000
+  // enquanto as compras seguiam vindo de 50: os cortes de cluster cairiam 10×.
+  assertEquals(TETO_CLUSTER_CLIENTES, 100, "teto de clientes do cluster mudou");
+  assertEquals(TETO_CLUSTER_USUARIOS_AMOSTRA, 50, "teto de usuários amostrados mudou");
+  assertEquals(TETO_CLUSTER_COMPRAS, 1000, "teto de compras da amostra mudou");
+  if (TETO_CLUSTER_USUARIOS_AMOSTRA > TETO_CLUSTER_CLIENTES) {
+    throw new Error("amostrar mais usuários do que o cluster tem é incoerente");
+  }
+});
+
+Deno.test("as colunas de DINHEIRO estão no .select() — tirar uma some com margem/EIP calado", () => {
+  const { db, registros } = fakeDb(bancoCheio());
+  return carregarInsumos(db, CLIENTE).then(() => {
+    const colunasDe = (t: string) => registros.filter((r) => r.tabela === t).map((r) => r.colunas).join(" ");
+    for (const col of ["cost_final", "cost_source", "cost_price", "cost_confidence", "product_id"]) {
+      if (!colunasDe("product_costs").includes(col)) {
+        throw new Error(`product_costs deixou de pedir '${col}' — custo some sem sinal`);
+      }
+    }
+    for (const col of ["valor_unitario", "estoque", "id"]) {
+      if (!colunasDe("omie_products").includes(col)) {
+        throw new Error(`omie_products deixou de pedir '${col}' — preço/estoque somem sem sinal`);
+      }
+    }
+  });
+});
+
+Deno.test("toda ordenação é ASCENDENTE — `ascending:false` é ordem estável que troca a amostra", async () => {
+  const { db, registros } = fakeDb(bancoCheio());
+  await carregarInsumos(db, CLIENTE);
+  const descendentes = registros.filter((r) => r.order !== null && r.ascending === false);
+  if (descendentes.length > 0) {
+    throw new Error(`ordem descendente em: ${descendentes.map((r) => r.tabela).join(", ")}`);
+  }
+});
+
+Deno.test("cluster: `ascending:false` mudaria QUAIS clientes entram (o double ordena de verdade)", async () => {
+  const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(6185) });
+  const { clusterUserIds } = await carregarCluster(db, "critico");
+  // Prova que a ordenação do double MORDE: ascendente pega o menor id, não um qualquer.
+  assertEquals(clusterUserIds[0], "u00000", "a amostra não veio do começo da ordem");
+  assertEquals(clusterUserIds[99], "u00099", "a amostra não é contígua na ordem pedida");
+});
+
+for (const tabela of ["omie_products", "product_costs", "order_items", "recommendation_config"]) {
+  Deno.test(`\`data:null\` SEM error em ${tabela} LANÇA — malformada ≠ lista vazia`, async () => {
+    const { db } = fakeDb(bancoCheio(), { nulaEm: tabela });
+    const erro = await assertLanca(() => carregarInsumos(db, CLIENTE), `null em ${tabela}`);
+    if (!(erro instanceof FalhaLeituraCritica)) {
+      throw new Error(`esperava FalhaLeituraCritica, veio ${erro.name}: ${erro.message}`);
+    }
+  });
+}
+
+Deno.test("cluster: `data:null` SEM error LANÇA — é o que falsifica o exigirLista", async () => {
+  const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(10) }, { nulaEm: "farmer_client_scores" });
+  const erro = await assertLanca(() => carregarCluster(db, "critico"), "cluster null");
+  if (!(erro instanceof FalhaLeituraCritica)) {
+    throw new Error(`esperava FalhaLeituraCritica, veio ${erro.name}: ${erro.message}`);
+  }
+});
+
+Deno.test("o `code` do PostgREST SOBREVIVE ao envelope, e o texto do servidor NÃO", async () => {
+  const { db } = fakeDb(bancoCheio(), { erroEm: "product_costs", codigo: "57014" });
+  const erro = await assertLanca(() => carregarInsumos(db, CLIENTE), "custos");
+  if (!(erro instanceof FalhaLeituraCritica)) throw new Error(`veio ${erro.name}`);
+  // As duas metades juntas: diagnóstico preservado E mensagem pública fechada.
+  assertEquals(erro.codigo, "57014", "o code do PostgREST se perdeu no envelope");
+  if (!erro.message.includes("57014")) throw new Error(`o code não chegou à mensagem: ${erro.message}`);
+  if (erro.message.includes("boom")) throw new Error(`texto do servidor vazou: ${erro.message}`);
+});
+
+Deno.test("`amostraNoTeto` diz só o que sabe: EXATAMENTE no teto, sem nada cortado, ainda é true", async () => {
+  // O nome antigo ("saturada") afirmava "há mais compras" — com 1.000 existentes e 1.000
+  // lidas, nada foi cortado. Provar `true` aqui é o que trava o nome honesto no lugar.
+  const exatas = Array.from({ length: TETO_CLUSTER_COMPRAS }, (_, i) => ({
+    id: `i${String(i).padStart(6, "0")}`,
+    product_id: `p${i % 50}`,
+    customer_user_id: `u${String(i % TETO_CLUSTER_USUARIOS_AMOSTRA).padStart(5, "0")}`,
+  }));
+  const { db } = fakeDb({ farmer_client_scores: scoresDoCluster(60), order_items: exatas });
+  const r = await carregarCluster(db, "critico");
+  assertEquals(r.clusterPurchases.length, TETO_CLUSTER_COMPRAS);
+  assertEquals(r.amostraNoTeto, true, "no teto tem de ser sinalizado, mesmo sem corte");
 });

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -81,6 +81,14 @@ function bancoFake(tabelas: Record<string, Linha[]>, erroDoBanco?: string) {
         linhas = linhas.slice(de, ate + 1);
         return q;
       },
+      limit(_n: number): QueryPostgrest<Linha> {
+        // Este double modela só paginação por `.range()`. Se um loader passar a usar
+        // `.limit()`, é para o teste ficar VERMELHO na hora — não para ser ignorado.
+        throw new Error("double: .limit() não é modelado aqui");
+      },
+      maybeSingle(): PromiseLike<{ data: Linha | null; error: { message: string } | null }> {
+        throw new Error("double: .maybeSingle() não é modelado aqui");
+      },
       then(aoResolver) {
         idas.push(tabela);
         // O cap silencioso: sem `.range()` explícito, a cauda além de 1000 some sem erro.

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -182,7 +182,16 @@ async function recommend(
   // Cluster similarity - load cluster customers + their purchases in parallel
   const customerCluster = clientScore?.health_class || "misto";
 
-  const { clusterUserIds, clusterPurchases } = await carregarCluster(banco, customerCluster);
+  const { clusterUserIds, clusterPurchases, amostraNoTeto } = await carregarCluster(banco, customerCluster);
+  if (amostraNoTeto) {
+    // O sinal do teto tem de CHEGAR em alguém: um campo que ninguém lê é o cap silencioso com
+    // outro nome (2ª rodada do Codex — "contrato novo morto"). O log da edge é o consumidor
+    // barato; expor no `meta` da resposta mudaria o contrato da API e é decisão de produto.
+    console.warn(
+      `[Recommend] amostra de similaridade NO TETO (${clusterPurchases.length} compras de ` +
+        `${clusterUserIds.length} clientes do cluster "${customerCluster}") — sim_score pode ser parcial`,
+    );
+  }
   // ⚠️ DENOMINADOR PRÉ-EXISTENTE, preservado verbatim: `clusterSize` conta os até 100 clientes
   // do cluster, mas as compras vêm só dos 50 primeiros — então `sim` sai sistematicamente pela
   // METADE. `minMaxNorm` é invariante a fator uniforme (o `sim_score` normalizado do ranking não

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -5,6 +5,13 @@ import {
   projetarMeta,
   textoExplicacaoMargem,
 } from "../_shared/recommend-projecao.ts";
+// As seis leituras do motor moram em `_shared` para poderem ser EXECUTADAS num teste: esta
+// edge importa `npm:@supabase/supabase-js@2` e `test:edges` roda com `--no-remote`, então
+// nada afirmado aqui dentro é provável por execução. Elas paginam (o PostgREST capa em 1000
+// linhas EM SILÊNCIO — o catálogo ativo tem 3.140 e a edge via 1.000) e LANÇAM na falha, em
+// vez de recomendar sobre catálogo parcial. Detalhe e medições: recommend-leituras.ts.
+import { carregarCluster, carregarInsumos } from "../_shared/recommend-leituras.ts";
+import type { BancoPostgrest } from "../_shared/paginate.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -125,24 +132,15 @@ async function recommend(
   podeCusto: boolean
 ) {
   // 1. Load config + customer orders + products + costs + rules + client score in PARALLEL
-  const [
-    { data: configs },
-    { data: orderItems },
-    { data: products },
-    { data: costs },
-    { data: rules },
-    { data: clientScore },
-  ] = await Promise.all([
-    db.from("recommendation_config").select("key, value"),
-    db.from("order_items").select("product_id, quantity, unit_price").eq("customer_user_id", customerId),
-    db.from("omie_products").select("id, omie_codigo_produto, descricao, codigo, valor_unitario, estoque, familia, subfamilia").eq("ativo", true),
-    db.from("product_costs").select("product_id, cost_price, cost_final, cost_source, cost_confidence"),
-    db.from("farmer_association_rules").select("*").gte("lift", 1.2).gte("support", 0.01),
-    db.from("farmer_client_scores").select("health_class, category_count").eq("customer_user_id", customerId).maybeSingle(),
-  ]);
+  // (paginado e fail-closed — ver `_shared/recommend-leituras.ts`).
+  const banco = db as unknown as BancoPostgrest;
+  const { configs, orderItems, products, costs, rules, clientScore } = await carregarInsumos(
+    banco,
+    customerId,
+  );
 
   const cfg: Record<string, number> = {};
-  for (const c of configs || []) cfg[c.key] = c.value;
+  for (const c of configs) cfg[c.key] = c.value;
 
   const wA = cfg.w_assoc ?? 0.25;
   const wP = cfg.w_eip ?? 0.35;
@@ -157,7 +155,7 @@ async function recommend(
   // Build purchased set & counts
   const purchasedProductIds = new Set<string>();
   const purchaseCounts: Record<string, number> = {};
-  for (const item of orderItems || []) {
+  for (const item of orderItems) {
     if (item.product_id) {
       purchasedProductIds.add(item.product_id);
       purchaseCounts[item.product_id] = (purchaseCounts[item.product_id] || 0) + 1;
@@ -166,12 +164,12 @@ async function recommend(
 
   // Cost map
   const costMap: Record<string, CostRow> = {};
-  for (const c of costs || []) costMap[c.product_id] = c;
+  for (const c of costs) costMap[c.product_id] = c;
 
   // Association scores
   const basketSet = new Set(basketProductIds);
   const assocScores: Record<string, number> = {};
-  for (const rule of rules || []) {
+  for (const rule of rules) {
     const antecedent = rule.antecedent_product_ids || [];
     const consequent = rule.consequent_product_ids || [];
     if (!antecedent.every((id: string) => basketSet.has(id) || purchasedProductIds.has(id))) continue;
@@ -184,24 +182,17 @@ async function recommend(
   // Cluster similarity - load cluster customers + their purchases in parallel
   const customerCluster = clientScore?.health_class || "misto";
 
-  const { data: clusterCustomers } = await db
-    .from("farmer_client_scores")
-    .select("customer_user_id")
-    .eq("health_class", customerCluster)
-    .limit(100);
-
-  const clusterUserIds = (clusterCustomers || []).map((c) => c.customer_user_id);
+  const { clusterUserIds, clusterPurchases } = await carregarCluster(banco, customerCluster);
+  // ⚠️ DENOMINADOR PRÉ-EXISTENTE, preservado verbatim: `clusterSize` conta os até 100 clientes
+  // do cluster, mas as compras vêm só dos 50 primeiros — então `sim` sai sistematicamente pela
+  // METADE. `minMaxNorm` é invariante a fator uniforme (o `sim_score` normalizado do ranking não
+  // muda), mas os CORTES em `sim` crus abaixo (0.1 do ctx, 0.15 do recType, 0.2 da explicação)
+  // são afetados. É defeito de outro eixo — desenho da amostra, não truncagem de transporte —
+  // e corrigi-lo aqui misturaria duas mudanças de ranking no mesmo diff.
   const clusterSize = Math.max(clusterUserIds.length, 1);
 
-  // Get cluster purchases (limit for performance)
-  const { data: clusterPurchases } = await db
-    .from("order_items")
-    .select("product_id, customer_user_id")
-    .in("customer_user_id", clusterUserIds.slice(0, 50))
-    .limit(1000);
-
   const clusterProductCounts: Record<string, Set<string>> = {};
-  for (const p of clusterPurchases || []) {
+  for (const p of clusterPurchases) {
     if (!p.product_id) continue;
     if (!clusterProductCounts[p.product_id]) clusterProductCounts[p.product_id] = new Set();
     clusterProductCounts[p.product_id].add(p.customer_user_id);
@@ -211,7 +202,7 @@ async function recommend(
   const candidates: Candidate[] = [];
   const basketFamilies: Record<string, number> = {};
 
-  for (const p of products || []) {
+  for (const p of products) {
     if (basketSet.has(p.id)) continue;
     if ((p.estoque || 0) <= 0) continue;
 


### PR DESCRIPTION
## O defeito

O `Promise.all` de `recommend()` desestruturava **apenas `{ data }` nas seis leituras** — todo `error` descartado — e **nenhuma paginava**. O PostgREST capa cada resposta em 1.000 linhas **em silêncio**.

Medido em prod via `psql-ro` em 2026-08-20:

| leitura | linhas em prod | a edge via |
|---|---|---|
| `omie_products WHERE ativo` | 3.140 | 1.000 (**32%**) |
| `product_costs` | 3.676 | 1.000 |
| `order_items` do cliente | até 2.849 | 1.000 — **8 clientes** truncados, os maiores |
| `farmer_association_rules` (lift≥1.2, support≥0.01) | 4 | íntegro hoje, e só hoje |
| `recommendation_config` | 15 | íntegro |
| `farmer_client_scores` (`maybeSingle`) | 1 | íntegro |

Achado por challenge Codex durante o PR do cap em `computeAssociationRules`, e registrado como fora de escopo daquele.

## O efeito — e a correção de um número meu

Eu tinha escrito "73% dos custos" a partir de `1.000/3.676`. Isso é cobertura de **linhas**; a 1ª rodada do Codex apontou que o denominador certo é o de **candidatos**. Medido: dos 3.140 produtos ativos, só **833 (26,5%)** têm custo na primeira página `ORDER BY id` — **73,5%** caíam em `custoConfiavel = null`.

Aqui o consumidor **já degrada honesto** (margem exibida vira `null`, `margemRank` vira 0 = "EIP neutro"), então isto **não inflava margem** — a patologia canônica do §6 não é a que morde neste call-site. O que morde é: o componente de **lucro**, que tem o **maior peso** (`w_eip` 0.35), passava a ser decidido sobre um quarto dos custos, com corte arbitrário. Somado ao catálogo, **68% dos SKUs recomendáveis invisíveis** — e *quais* 1.000 sobravam era não-determinístico, porque sem `ORDER BY` o Postgres não promete sequência.

Também derrubei um ponto do Codex por medição: **`product_costs.product_id` é único** (3.676 linhas, 3.676 distintos), então ordenar por `id` não escolhe "qual custo vale" — não há dois para o mesmo produto.

## O que muda

- as **5 leituras de lista** passam por `fetchAll` (`_shared/paginate.ts`), cada uma com `.order("id")` — a PK das seis tabelas, conferida em `pg_index`. Uniforme **de propósito**, inclusive na que hoje cabe numa página: o volume de `farmer_association_rules` é função do piso de `lift`/`support`, que é uma decisão de produto de uma linha e não tem como saber que existe um cap esperando do outro lado;
- a leitura de **uma linha** passa por `exigirLeitura`: falha **lança**, ausência legítima segue caindo no default. `recommendation_config` falhando fazia **todos** os pesos caírem nos defaults hard-coded e a edge responder 200 com números plausíveis e parâmetros errados;
- as leituras viraram **`_shared/recommend-leituras.ts`** porque a edge importa `npm:@supabase/supabase-js@2` e `test:edges` roda `--no-remote`: enquanto morassem no `index.ts`, "o catálogo volta inteiro" era afirmação **sem execução**.

## A prova

**33 asserções** contra um double que **simula o cap de 1.000** — com um *controle de calibração* que prova que o double capa: sem ele, uma leitura não paginada devolveria a tabela inteira e a suíte seria teatro.

**9 sabotagens, 9 vermelhas**, cada uma no assert certo (commitado antes de falsificar — `restaurar()` é `git checkout --`):

| sabotagem | resultado |
|---|---|
| tirar a paginação do catálogo | 🔴 3 |
| engolir o erro (voltar ao `?? []`) | 🔴 7 |
| tirar o `.order("id")` de uma leitura | 🔴 1 |
| o double parar de capar | 🔴 1 (o controle) |
| o envelope perder o `code` do PostgREST | 🔴 1 |
| ordenação virar `ascending:false` | 🔴 2 |
| `.select()` de custos perder `cost_final` | 🔴 1 |
| `exigirLista` voltar a coalescer `null` em `[]` | 🔴 1 |
| `TETO_CLUSTER_CLIENTES` subir de 100 para 1.000 | 🔴 2 |

`recommend` entrou em `VIGIADAS` do gate `paginacao-delegada_test.ts` (delega → zero `.range(` no call-site).

**Os três gates de edge, todos verdes:** `test:edges` 798 passed / 0 failed · `edges:typecheck` exit 0, 0 erros de classe-crash · `bun run test` 702 arquivos, **6.593 testes**, 0 falhas.

## A 2ª rodada do Codex achou o remédio cometendo a doença

A 1ª rodada foi sobre o **desenho**; a 2ª, sobre o **código** — e achou o que a primeira não podia:

- **`amostraSaturada` prometia mais do que media.** Com 1.000 compras existentes e 1.000 lidas, nada foi cortado — e o campo era `true`. Virou **`amostraNoTeto`**, que é o que o código sabe; afirmar "há mais" exigiria `count:'exact'`.
- **O campo era contrato MORTO** — ninguém lia. Ligado a um `console.warn` na edge: sinal que não chega em consumidor é o cap silencioso com outro nome.
- **Duas afirmações minhas caíram.** (i) Eu escrevi que o erro original ficava em `cause`; `fetchAll` o reduz a `Error(label+message)` **antes**, e o `code` (`57014`, `42501`) morria ali — agora intercepto `res.error` antes do helper, com um teste que afirma as duas metades juntas (`codigo === "57014"` **e** ausência de `"boom"`). (ii) Eu escrevi que o prefixo por PK pega "os mais antigos"; `farmer_client_scores.id` é `gen_random_uuid()`, então são os 100 menores UUIDs — amostra pseudoaleatória determinística, não prefixo temporal.
- **Seis falsos-verdes na minha própria suíte**, cada um com uma saída errada concreta: teto comparado com a **constante importada** (tautologia — subir 100→1.000 ficava verde enquanto dividia `sim` por 1.000 lendo compras de 50); double ignorando `.select()` (tirar `cost_final` ficava verde e sumia com margem/EIP em prod); double registrando `.order()` sem ordenar nem olhar `ascending` (descendente é ordem *estável* e trocaria quais 100 clientes entram); nenhum caso `data:null, error:null` para lista (o `exigirLista` estava correto mas **não falsificado**); saturação testada em 1.500 e não no teto exato.

## Achado do próprio teste

`fetchAll` lança com o **`error.message` cru do Postgres**, e o `catch` do `Deno.serve` devolve `message` no corpo da resposta — o texto do servidor **saía da edge**. É o "privacidade afirmada sem verificar o SINK" que `leitura-critica.ts` documenta. Envelopado em `FalhaLeituraCritica` (domínio fechado, original em `cause`) **só neste módulo**: mudar o helper mexeria nos 21 call-sites de `fetchAll`, e um deles (`visit-score-recalc-client:361`) já ramifica em `instanceof`. Fechar a classe no helper é entrega própria — chip aberto.

Também da 1ª rodada do Codex: `exigirLeitura` **mistura cardinalidades** — para lista, `data:null` sem erro coalescido com `?? []` é o mesmo EOF falso que `fetchAll` rejeita no laço, entrando pela porta do lado. Novo `exigirLista` (aditivo).

## O que este PR NÃO conserta — nomeado no código para não passar por consertado

- **`.order("id").limit(100)` é prefixo por PK, não amostragem.** Dos 6.185 clientes `critico`, saem sempre os mesmos 100. O ganho é reprodutibilidade (antes o Postgres escolhia outros 100 a cada execução e o `sim_score` do mesmo cliente mudava sem nada mudar), **não** representatividade: o viés ficou estável em vez de aleatório.
- **`clusterSize` conta 100 clientes enquanto as compras vêm de 50**, então `sim` sai pela metade. `minMaxNorm` é invariante a fator uniforme (o score normalizado não muda), mas os **cortes em `sim` cru** (0.1, 0.15, 0.2) são afetados.

A 1ª rodada do Codex pediu para **bloquear o merge** até redesenhar a amostra; a 2ª **retirou o bloqueio** depois de ver o código ("não há dano demonstrado que supere manter 2.140 SKUs invisíveis"). São desenho de **ranking**, outro eixo que truncagem de **transporte**, e mudá-los altera o top-N que o vendedor vê — precisa de antes/depois medido, não de carona.

Também fica de fora, apontado na 2ª rodada: **paginação por offset não é snapshot** — INSERT/DELETE entre páginas desloca o offset e pode pular ou duplicar linha (em `order_items` isso atravessa o corte `purchaseCount >= 2` e move `ctx_score`). Incidência muito menor que truncagem permanente. **Três chips abertos** com os três.

## Deploy

⚠️ **Edge é deploy MANUAL pelo chat do Lovable** — merge na `main` **não** publica. A publicar: **`recommend`** (arrasta `_shared/recommend-leituras.ts`, `_shared/paginate.ts`, `_shared/leitura-critica.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
