### PR TITLE
fix(wt:status): o sensor de saturação morria de SIGPIPE e sumia JUSTO com a máquina cheia

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wt:label": "bash scripts/wt-map.sh label",
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/test-wt-status.sh
+++ b/scripts/test-wt-status.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# test-wt-status.sh — TDD do scripts/wt-status.sh com `du`/`ps`/`git`/`lsof`
+# STUBADOS (sem tocar o disco de verdade, sem esperar minuto nenhum).
+#
+# Contrato testado — o sensor tem de MEDIR JUSTO QUANDO IMPORTA (máquina
+# saturada). Os dois defeitos medidos em 2026-08-20 (M2 8GB em swap, 66
+# worktrees):
+#
+#   1. `ps ... | sort -rn | head -10` → o `head` fecha o pipe enquanto o `sort`
+#      ainda escreve ⇒ SIGPIPE(141) no `sort`; `pipefail` promove o 141 a status
+#      do pipeline e `set -e` aborta. Como era a ÚLTIMA seção, o 141 virava o
+#      exit code do script inteiro e `bun run wt:status` lia VERMELHO num
+#      caminho de sucesso. Limiar medido: 0/5 em 62 KB · 2/5 em 126 KB · 5/5 em
+#      318 KB (buffer de pipe ~64 KB no macOS) — por isso só aparece com a
+#      máquina cheia de processos.
+#
+#   2. `sz="$(du -sm "$nm" 2>/dev/null | cut -f1)"` sob `set -e`+`pipefail`: UM
+#      `du` que falhe (arquivo sumindo numa worktree viva) matava o script
+#      inteiro — seção com CABEÇALHO e nenhuma linha. E o `${sz:-0}` fabricava
+#      ZERO pra quem não foi medido (money-path §2: ausente ≠ zero).
+#
+# A asserção central é a do §13 do money-path: worktree não medida entra como
+# COBERTURA declarada ("sem medida: N"), nunca como 0 MB e nunca como silêncio.
+#
+# Uso: bash scripts/test-wt-status.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+ALVO="${WT_STATUS_ALVO:-$here/wt-status.sh}"
+
+stub="$(mktemp -d)"
+fix="$(mktemp -d)"
+trap 'rm -rf "$stub" "$fix"' EXIT
+
+falhas=0
+ok()   { printf '  \033[32mok\033[0m   %s\n' "$1"; }
+falha() { printf '  \033[31mFALHA\033[0m %s\n' "$1"; falhas=$((falhas + 1)); }
+
+# ── fixture: 4 worktrees, todas com node_modules ────────────────────────────
+: > "$fix/worktrees.txt"
+for w in alfa bravo charlie delta; do
+  mkdir -p "$fix/wt-$w/node_modules"
+  echo "worktree $fix/wt-$w" >> "$fix/worktrees.txt"
+done
+
+# ── stubs ───────────────────────────────────────────────────────────────────
+cat > "$stub/git" <<STUB
+#!/bin/sh
+[ "\$1" = "worktree" ] || exit 0
+cat "$fix/worktrees.txt"
+STUB
+
+# DU_MODO: ok | falha | lento | primeiro-ok (o 1º mede, os demais falham)
+cat > "$stub/du" <<STUB
+#!/bin/sh
+alvo="\$3"
+case "\${DU_MODO:-ok}" in
+  falha)  exit 1 ;;
+  lento)  sleep 30; printf '111\t%s\n' "\$alvo" ;;
+  primeiro-ok)
+    n="\$(cat "$fix/du.n" 2>/dev/null || echo 0)"
+    echo \$((n + 1)) > "$fix/du.n"
+    [ "\$n" -eq 0 ] || exit 1
+    printf '4321\t%s\n' "\$alvo" ;;
+  *) printf '250\t%s\n' "\$alvo" ;;
+esac
+STUB
+
+# PS_MODO: normal | gigante (acima do limiar medido de 318 KB → SIGPIPE 5/5)
+cat > "$stub/ps" <<'STUB'
+#!/bin/sh
+case "${PS_MODO:-normal}" in
+  gigante) awk 'BEGIN { for (i = 1; i <= 6000; i++)
+             printf "%d /Applications/Um/Caminho/Bem/Longo/Que/Imita/O/comm/Do/macOS/processo-%d\n", i, i }' ;;
+  *) printf '100000 /usr/bin/algo\n200000 /usr/bin/outro\n' ;;
+esac
+STUB
+
+cat > "$stub/lsof" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+
+chmod +x "$stub/git" "$stub/du" "$stub/ps" "$stub/lsof"
+
+# roda o script com os stubs na frente do PATH; ecoa "EXIT=<rc>" na última linha
+roda() {
+  PATH="$stub:$PATH" bash "$ALVO" 2>/dev/null
+  echo "EXIT=$?"
+}
+
+secao_nm() { sed -n '/node_modules por worktree/,/^$/p'; }
+
+# ── caso 1 — `du` que FALHA não mata o script nem some com a seção ──────────
+saida="$(DU_MODO=falha roda)"
+if [ "${saida##*EXIT=}" = "0" ]; then
+  ok "du falhando → script segue e sai 0"
+else
+  falha "du falhando → esperava EXIT=0, veio EXIT=${saida##*EXIT=}"
+fi
+if printf '%s' "$saida" | command grep -q 'top consumidores'; then
+  ok "du falhando → seções POSTERIORES ainda saem"
+else
+  falha "du falhando → a seção seguinte sumiu (set -e matou o script)"
+fi
+if printf '%s' "$saida" | secao_nm | command grep -q 'sem medida: 4'; then
+  ok "du falhando → declara 'sem medida: 4' (nao e silencio)"
+else
+  falha "du falhando → nao declarou as 4 worktrees como sem medida"
+fi
+# MOTIVO CERTO: aqui o du falhou de verdade — não pode ser creditado ao teto.
+if printf '%s' "$saida" | secao_nm | command grep -q 'por erro do du'; then
+  ok "du falhando → motivo correto ('erro do du', nao 'teto')"
+else
+  falha "du falhando → atribuiu o motivo errado"
+fi
+
+# ── caso 2 — ausente ≠ zero: quem não foi medido NÃO vira 0 MB ─────────────
+rm -f "$fix/du.n"
+saida="$(DU_MODO=primeiro-ok roda)"
+nm="$(printf '%s' "$saida" | secao_nm)"
+if printf '%s' "$nm" | command grep -q 'medidos: 1 de 4'; then
+  ok "cobertura explicita: 'medidos: 1 de 4'"
+else
+  falha "nao reportou cobertura medidos/total"
+fi
+if printf '%s' "$nm" | command grep -q 'sem medida: 3'; then
+  ok "os 3 nao medidos aparecem como 'sem medida'"
+else
+  falha "os 3 nao medidos sumiram da saida"
+fi
+if printf '%s' "$nm" | command grep -q 'piso'; then
+  ok "total parcial marcado como PISO (nao como total)"
+else
+  falha "total parcial nao foi marcado como piso — le-se como se fosse o total"
+fi
+# o piso tem de ser o que FOI medido (4321), nunca 4321 + 0 + 0 + 0 apresentado
+# como total fechado: a marca 'piso' acima é o que impede a leitura errada.
+if printf '%s' "$nm" | command grep -q '4321'; then
+  ok "o que foi medido aparece com o valor real"
+else
+  falha "perdeu o valor medido"
+fi
+
+# ── caso 3 — `du` LENTO estoura o teto e degrada em vez de pendurar ────────
+ini="$SECONDS"
+saida="$(DU_MODO=lento WT_STATUS_TETO_S=1 roda)"
+gasto=$((SECONDS - ini))
+if [ "${saida##*EXIT=}" = "0" ]; then
+  ok "du lento → sai 0 (degradacao nao e falha)"
+else
+  falha "du lento → esperava EXIT=0, veio EXIT=${saida##*EXIT=}"
+fi
+if [ "$gasto" -le 12 ]; then
+  ok "du lento → respeitou o teto (${gasto}s, 4 worktrees x 30s de du)"
+else
+  falha "du lento → pendurou ${gasto}s; o teto nao segurou"
+fi
+if printf '%s' "$saida" | secao_nm | command grep -q 'sem medida: 4'; then
+  ok "du lento → declara as 4 como sem medida"
+else
+  falha "du lento → nao declarou 'sem medida'"
+fi
+if printf '%s' "$saida" | secao_nm | command grep -q 'pelo teto'; then
+  ok "du lento → diz que o TETO foi o motivo"
+else
+  falha "du lento → nao disse o motivo (teto)"
+fi
+# ── caso 3b — teto POR ITEM estourado com orçamento global de sobra ───────
+# Este caso discrimina o defeito REAL que o próprio conserto teve: creditar o
+# timeout por item como "erro do du", porque o motivo era INFERIDO do orçamento
+# global em vez de vir do exit code (124) do timeout. Ele só separa os dois
+# mundos quando cap_item < teto_s — daí o WT_STATUS_CAP_ITEM.
+saida="$(DU_MODO=lento WT_STATUS_TETO_S=8 WT_STATUS_CAP_ITEM=1 roda)"
+nm="$(printf '%s' "$saida" | secao_nm)"
+if printf '%s' "$nm" | command grep -q 'por erro do du'; then
+  falha "cap por item → creditou o RELOGIO como 'erro do du' (motivo inferido)"
+else
+  ok "cap por item → nao credita o relogio como erro do du"
+fi
+if printf '%s' "$nm" | command grep -q '4 pelo teto'; then
+  ok "cap por item → as 4 saem 'pelo teto', com orcamento global de sobra"
+else
+  falha "cap por item → nao atribuiu as 4 ao teto"
+fi
+
+# ── caso 4 — o mesmo teto vale SEM o coreutils `timeout` ───────────────────
+ini="$SECONDS"
+saida="$(DU_MODO=lento WT_STATUS_TETO_S=1 WT_STATUS_SEM_TIMEOUT=1 roda)"
+gasto=$((SECONDS - ini))
+if [ "$gasto" -le 12 ] && [ "${saida##*EXIT=}" = "0" ]; then
+  ok "sem 'timeout' no PATH → o fallback tambem segura (${gasto}s)"
+else
+  falha "sem 'timeout' → gastou ${gasto}s / EXIT=${saida##*EXIT=}"
+fi
+
+# ── caso 5 — saída gigante do `ps` não pode virar 141 (SIGPIPE) ────────────
+saida="$(PS_MODO=gigante roda)"
+if [ "${saida##*EXIT=}" = "0" ]; then
+  ok "ps gigante (>318 KB) → sai 0, sem SIGPIPE"
+else
+  falha "ps gigante → EXIT=${saida##*EXIT=} (141 = SIGPIPE do sort contra o head)"
+fi
+n_rss="$(printf '%s' "$saida" | sed -n '/top consumidores/,$p' | command grep -c ' MB  ')"
+if [ "$n_rss" -eq 10 ]; then
+  ok "ps gigante → ainda lista exatamente 10 processos"
+else
+  falha "ps gigante → listou $n_rss processos (esperado 10)"
+fi
+
+# ── caso 6 — caminho feliz continua feliz ─────────────────────────────────
+saida="$(roda)"
+if [ "${saida##*EXIT=}" = "0" ] &&
+   printf '%s' "$saida" | secao_nm | command grep -q 'medidos: 4 de 4'; then
+  ok "caminho feliz → EXIT=0 e cobertura 4 de 4"
+else
+  falha "caminho feliz quebrou: EXIT=${saida##*EXIT=}"
+fi
+if printf '%s' "$saida" | secao_nm | command grep -q 'sem medida'; then
+  falha "caminho feliz nao pode falar em 'sem medida'"
+else
+  ok "caminho feliz nao inventa degradacao"
+fi
+
+echo
+if [ "$falhas" -eq 0 ]; then
+  echo "✅ test-wt-status: tudo verde"
+else
+  echo "❌ test-wt-status: $falhas falha(s)"
+  exit 1
+fi

--- a/scripts/test-wt-status.sh
+++ b/scripts/test-wt-status.sh
@@ -83,6 +83,17 @@ STUB
 
 chmod +x "$stub/git" "$stub/du" "$stub/ps" "$stub/lsof"
 
+# Stubs do ambiente NÃO-macOS, num diretório à parte: entram no PATH só no
+# caso que simula o CI Ubuntu, pros demais seguirem lendo a RAM de verdade.
+# 127 é o código de "command not found" — foi exatamente o que o CI do #1838
+# devolveu, matando o script na PRIMEIRA seção.
+naomac="$(mktemp -d)"
+trap 'rm -rf "$stub" "$fix" "$naomac"' EXIT
+for c in vm_stat sysctl; do
+  printf '#!/bin/sh\nexit 127\n' > "$naomac/$c"
+  chmod +x "$naomac/$c"
+done
+
 # roda o script com os stubs na frente do PATH; ecoa "EXIT=<rc>" na última linha
 roda() {
   PATH="$stub:$PATH" bash "$ALVO" 2>/dev/null
@@ -220,6 +231,27 @@ if printf '%s' "$saida" | secao_nm | command grep -q 'sem medida'; then
   falha "caminho feliz nao pode falar em 'sem medida'"
 else
   ok "caminho feliz nao inventa degradacao"
+fi
+
+# ── caso 7 — sonda de RAM ausente (não-macOS) não derruba o script ────────
+# Regressão do CI do #1838: `vm_stat` não existe no Ubuntu ⇒ 127 ⇒ pipefail
+# ⇒ set -e matava tudo na 1ª seção. Uma sonda que falta tem de degradar a SUA
+# seção, não o sensor inteiro — é a tese deste arquivo aplicada a ele mesmo.
+saida="$(PATH="$naomac:$stub:$PATH" bash "$ALVO" 2>/dev/null; echo "EXIT=$?")"
+if [ "${saida##*EXIT=}" = "0" ]; then
+  ok "sem vm_stat/sysctl → script sai 0 (nao morre na 1a secao)"
+else
+  falha "sem vm_stat/sysctl → EXIT=${saida##*EXIT=} (127 = command not found matando o set -e)"
+fi
+if printf '%s' "$saida" | command grep -q 'sem medida: sysctl/vm_stat'; then
+  ok "sem vm_stat/sysctl → declara a RAM como sem medida"
+else
+  falha "sem vm_stat/sysctl → nao declarou a RAM como sem medida"
+fi
+if printf '%s' "$saida" | secao_nm | command grep -q 'medidos: 4 de 4'; then
+  ok "sem vm_stat/sysctl → as secoes POSTERIORES ainda medem"
+else
+  falha "sem vm_stat/sysctl → perdeu as secoes seguintes"
 fi
 
 echo

--- a/scripts/wt-status.sh
+++ b/scripts/wt-status.sh
@@ -3,10 +3,76 @@
 # ficar lento pra ver o que está pesando e se vale um `bun run wt:clean`.
 #
 # Não muda nada — só lê e reporta.
+#
+# ⚠️ Este script é um SENSOR de saturação: ele é lido JUSTO quando a máquina
+# está sufocando. Duas regras, medidas na marra em 2026-08-20 (M2 8GB em swap,
+# 66 worktrees) e travadas por `scripts/test-wt-status.sh`:
+#
+#   1. Nenhum leitor que fecha o pipe cedo (`| head`) depois de um `sort`: o
+#      sort só emite depois de ler TUDO, então ainda está escrevendo quando o
+#      head sai ⇒ SIGPIPE(141), que o `pipefail` promove a status do pipeline e
+#      o `set -e` transforma em morte do script. Use `awk 'NR<=N'`, que lê até
+#      o EOF. (Limiar medido do buffer de pipe do macOS: 0/5 em 62 KB, 2/5 em
+#      126 KB, 5/5 em 318 KB — por isso o bug só aparecia com a máquina cheia.)
+#   2. Medida que pode não terminar tem TETO e reporta COBERTURA. Worktree não
+#      medida entra como "sem medida", NUNCA como 0 MB e NUNCA como silêncio
+#      (money-path §2 "ausente ≠ zero" e §13 "sensor que não mede quando
+#      importa deixa de ser sensor").
 set -euo pipefail
 
 rp() { realpath "$1" 2>/dev/null || echo "$1"; }
 human_gb() { awk -v b="$1" 'BEGIN { printf "%.1f", b / 1073741824 }'; }
+curto() { printf '%s' "${1/#$HOME/~}"; }
+
+# Teto TOTAL da varredura de node_modules, em segundos. Suba pra medir tudo
+# numa máquina saturada: WT_STATUS_TETO_S=300 bun run wt:status
+#
+# Calibragem MEDIDA (2026-08-20, M2 8GB em swap): um `du -sm` de node_modules
+# custa 6-8s e NÃO fica mais barato repetido (a pressão de memória despeja o
+# cache do FS). 30 worktrees ⇒ ~3,5 min de varredura completa.
+teto_s="${WT_STATUS_TETO_S:-60}"
+# Teto por ITEM (≤ teto_s). Existe pra uma worktree patológica não comer o
+# orçamento inteiro — e é o que faz "estourou o teto do item" e "acabou o
+# orçamento" serem eventos DISTINTOS, cada um com seu motivo no relato.
+cap_item="${WT_STATUS_CAP_ITEM:-20}"
+if [ -n "${WT_STATUS_SEM_TIMEOUT:-}" ]; then
+  TIMEOUT_BIN=""
+else
+  TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+fi
+
+# Mede um diretório em MB com teto de tempo. Ecoa os MB e sai 0 se MEDIU.
+# Não mediu ⇒ nada no stdout e o MOTIVO no exit code: 124 = teto estourado,
+# 1 = o du falhou de verdade. Os dois são "não medido" (≠ zero), mas o relato
+# ao founder muda — dizer "erro do du" quando foi o relógio é a mesma
+# desonestidade que este script existe pra não cometer.
+du_mb() {
+  local alvo="$1" teto="$2" saida rc tmp pid guard t0
+  if [ -n "$TIMEOUT_BIN" ]; then
+    saida="$("$TIMEOUT_BIN" "$teto" du -sm "$alvo" 2>/dev/null)" && rc=0 || rc=$?
+    [ "$rc" -eq 0 ] || return "$rc"
+  else
+    t0="$SECONDS"
+    # Sem coreutils: cão-de-guarda em background. O `sleep` órfão que sobrar
+    # morre sozinho — o que importa é que o guard não chegue a matar ninguém
+    # depois que o du terminou.
+    tmp="$(mktemp)"
+    du -sm "$alvo" > "$tmp" 2>/dev/null &
+    pid=$!
+    ( sleep "$teto"; kill -9 "$pid" 2>/dev/null ) > /dev/null 2>&1 &
+    guard=$!
+    if wait "$pid" 2>/dev/null; then saida="$(cat "$tmp")"; else saida=""; fi
+    kill "$guard" 2>/dev/null || true
+    rm -f "$tmp"
+    if [ -z "$saida" ]; then
+      [ "$((SECONDS - t0))" -lt "$teto" ] || return 124
+      return 1
+    fi
+  fi
+  saida="${saida%%$'\t'*}"
+  case "$saida" in '' | *[!0-9]*) return 1 ;; esac
+  printf '%s' "$saida"
+}
 
 echo "═══ RAM (total 8 GB nesta máquina) ═══"
 mem_total="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
@@ -34,37 +100,135 @@ df -h / 2>/dev/null | awk 'NR==1 || NR==2 { printf "  %s\n", $0 }'
 
 echo
 echo "═══ node_modules por worktree ═══"
-total=0
-n=0
+if ! wts="$(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')"; then
+  wts=""
+  echo "  ⚠️  não consegui listar as worktrees (git falhou) — sem medida, não zero."
+fi
+
+# 1ª passada (barata): quem TEM node_modules. Saber o denominador antes de
+# medir é o que permite dizer "medi X de Y" em vez de só somar o que deu.
+candidatos=""
+n_cand=0
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
   nm="$(rp "$wt")/node_modules"
   if [ -e "$nm" ] && [ ! -L "$nm" ]; then
-    sz="$(du -sm "$nm" 2>/dev/null | cut -f1)"
-    total=$((total + ${sz:-0}))
-    n=$((n + 1))
+    candidatos="${candidatos}${wt}"$'\n'
+    n_cand=$((n_cand + 1))
   fi
-done < <(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
-echo "  ${n} worktree(s) com node_modules — ~${total} MB no total"
+done <<EOF
+$wts
+EOF
+
+# 2ª passada (cara): o du, com teto. GULOSO de propósito — cada du recebe todo
+# o resto do orçamento (com um cap por item), em vez de uma fatia igual.
+# Repartir igual foi tentado e MEDIDO: com 30 candidatos em 30s cada um ganhava
+# 2s, e como um du custa 6-8s aqui, NENHUM terminava — "medidos: 0 de 30" em
+# toda execução, que é o §13 do money-path na veia (sensor que degrada sempre
+# não é sensor). Medir 8 de verdade e declarar os outros 22 vale mais do que
+# não medir nada com uma repartição elegante.
+inicio="$SECONDS"
+total=0
+medidos=0
+linhas=""
+sem_teto=0
+sem_erro=0
+nomes_sem=""
+while IFS= read -r wt; do
+  [ -n "$wt" ] || continue
+  sobra=$((teto_s - (SECONDS - inicio)))
+  if [ "$sobra" -le 0 ]; then
+    sem_teto=$((sem_teto + 1))
+    nomes_sem="${nomes_sem}$(curto "$wt")"$'\n'
+    continue
+  fi
+  # cap por item: uma worktree patológica não leva o orçamento inteiro
+  teto_item=$sobra
+  if [ "$teto_item" -gt "$cap_item" ]; then teto_item="$cap_item"; fi
+  sz="$(du_mb "$(rp "$wt")/node_modules" "$teto_item")" && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    total=$((total + sz))
+    medidos=$((medidos + 1))
+    linhas="${linhas}$(printf '%8d MB  %s' "$sz" "$(curto "$wt")")"$'\n'
+  else
+    nomes_sem="${nomes_sem}$(curto "$wt")"$'\n'
+    if [ "$rc" -eq 124 ]; then
+      sem_teto=$((sem_teto + 1))
+    else
+      sem_erro=$((sem_erro + 1))
+    fi
+  fi
+done <<EOF
+$candidatos
+EOF
+
+if [ -n "$linhas" ]; then
+  # `awk NR<=10` e não `| head -10`: o head fecharia o pipe do sort → SIGPIPE.
+  printf '%s' "$linhas" | sort -rn | awk 'NR<=10 { print "  " $0 }'
+  if [ "$medidos" -gt 10 ]; then
+    echo "        … e mais $((medidos - 10)) worktree(s) medida(s)"
+  fi
+fi
+
+sem_medida=$((sem_teto + sem_erro))
+if [ "$medidos" -gt 0 ]; then
+  piso=""
+  if [ "$sem_medida" -gt 0 ]; then piso=" (piso — só o que foi medido)"; fi
+  echo "  medidos: ${medidos} de ${n_cand} worktree(s) com node_modules — ~${total} MB${piso}"
+else
+  echo "  medidos: 0 de ${n_cand} worktree(s) com node_modules — nenhuma medida (ausente ≠ zero)"
+fi
+
+# Mediana DO QUE FOI MEDIDO — fato sobre a amostra, não estimativa do resto.
+# Serve pra você mesmo fazer a conta das que faltaram, sem o script fabricar
+# um total que não mediu (§2). Só sai com amostra ≥3, abaixo disso é ruído.
+if [ "$medidos" -ge 3 ]; then
+  mediana="$(printf '%s' "$linhas" | awk '{ print $1 }' | sort -n |
+    awk '{ v[NR] = $1 } END { print (NR % 2) ? v[(NR + 1) / 2] : int((v[NR / 2] + v[NR / 2 + 1]) / 2) }')"
+  echo "  mediana das medidas: ${mediana} MB por worktree"
+fi
+
+if [ "$sem_medida" -gt 0 ]; then
+  motivo=""
+  if [ "$sem_teto" -gt 0 ]; then motivo="${sem_teto} pelo teto de ${teto_s}s"; fi
+  if [ "$sem_erro" -gt 0 ]; then
+    if [ -n "$motivo" ]; then motivo="${motivo}, "; fi
+    motivo="${motivo}${sem_erro} por erro do du"
+  fi
+  echo "  ⚠️  sem medida: ${sem_medida} — ${motivo}. Não é 0 MB: é dado que falta."
+  printf '%s' "$nomes_sem" | awk 'NR<=5 { print "        " $0 }'
+  if [ "$sem_medida" -gt 5 ]; then
+    echo "        … e mais $((sem_medida - 5))"
+  fi
+  if [ "$sem_teto" -gt 0 ]; then
+    echo "      Pra medir tudo: WT_STATUS_TETO_S=300 bun run wt:status"
+  fi
+fi
 
 echo
 echo "═══ sessões Claude vivas (cwd → worktree) ═══"
-sessions="$(lsof -nP -a -c claude -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | sort -u)"
-if [ -n "$sessions" ]; then
+if ! sessions="$(lsof -nP -a -c claude -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | sort -u)"; then
+  sessions=""
+  echo "  ⚠️  o lsof falhou — não consegui consultar (≠ 'nenhuma sessão')."
+elif [ -n "$sessions" ]; then
   while IFS= read -r s; do
-    [ -n "$s" ] && echo "  ${s/#$HOME/~}"
-  done <<<"$sessions"
+    [ -n "$s" ] && echo "  $(curto "$s")"
+  done <<EOF
+$sessions
+EOF
 else
   echo "  (nenhuma)"
 fi
 
 echo
 echo "═══ top consumidores de memória (RSS) ═══"
-ps -axo rss,comm 2>/dev/null | sort -rn | head -10 |
-  awk '{ printf "  %6.0f MB  %s\n", $1 / 1024, $2 }'
+ps -axo rss,comm 2>/dev/null | sort -rn |
+  awk 'NR<=10 { printf "  %6.0f MB  %s\n", $1 / 1024, $2 }'
 
 echo
-if [ "${total:-0}" -gt 2000 ]; then
-  echo "💡 ~${total} MB presos em node_modules de worktrees parados."
+if [ "$total" -gt 2000 ]; then
+  aprox="~"
+  if [ "$sem_medida" -gt 0 ]; then aprox="≥"; fi
+  echo "💡 ${aprox}${total} MB presos em node_modules de worktrees parados."
   echo "   Rode 'bun run wt:clean' (dry-run) pra ver quanto dá pra liberar agora."
 fi

--- a/scripts/wt-status.sh
+++ b/scripts/wt-status.sh
@@ -75,18 +75,32 @@ du_mb() {
 }
 
 echo "═══ RAM (total 8 GB nesta máquina) ═══"
+# `sysctl hw.memsize` e `vm_stat` são do macOS. Ausentes (ou falhando), o
+# `pipefail` devolvia 127 e o `set -e` matava o script INTEIRO na primeira
+# seção — a mesma classe de defeito que este arquivo existe pra não repetir:
+# sonda que falta derruba o sensor todo. Agora a seção degrada e as outras
+# seguem. Pego pelo CI Ubuntu do #1838, que é o 1º ambiente não-macOS a
+# EXECUTAR este script.
+ram_ok=1
 mem_total="$(sysctl -n hw.memsize 2>/dev/null || echo 0)"
-pgsize="$(vm_stat 2>/dev/null | sed -n 's/.*page size of \([0-9]*\) bytes.*/\1/p')"
+pgsize="$(vm_stat 2>/dev/null | sed -n 's/.*page size of \([0-9]*\) bytes.*/\1/p')" || ram_ok=0
 pgsize="${pgsize:-16384}"
 # "disponível" ≈ páginas livres + inativas (o macOS recicla as inativas)
 avail_pages="$(vm_stat 2>/dev/null | awk '
   /Pages free/         { gsub(/[.]/,"",$3); f=$3 }
   /Pages inactive/     { gsub(/[.]/,"",$3); i=$3 }
   /File-backed pages/  { gsub(/[.]/,"",$3); fb=$3 }
-  END { print f + i + fb }')"
-avail_bytes=$((avail_pages * pgsize))
-echo "  total:      $(human_gb "$mem_total") GB"
-echo "  disponível: $(human_gb "$avail_bytes") GB"
+  END { print f + i + fb }')" || ram_ok=0
+case "$mem_total" in '' | *[!0-9]*) mem_total=0 ;; esac
+case "$avail_pages" in '' | *[!0-9]*) ram_ok=0 ;; esac
+if [ "$ram_ok" -eq 1 ] && [ "$mem_total" -gt 0 ]; then
+  avail_bytes=$((avail_pages * pgsize))
+  echo "  total:      $(human_gb "$mem_total") GB"
+  echo "  disponível: $(human_gb "$avail_bytes") GB"
+else
+  echo "  ⚠️  sem medida: sysctl/vm_stat não responderam (raio-X de RAM é de macOS)."
+  echo "      Não é 0 GB — é dado que falta."
+fi
 swap="$(sysctl -n vm.swapusage 2>/dev/null || true)"
 [ -n "$swap" ] && echo "  swap:       $swap"
 case "$swap" in


### PR DESCRIPTION
`bun run wt:status` numa M2 8GB **em swap** (1,9 GB livres, 6,3 GB de swap, 66 worktrees) imprimia o cabeçalho de "node_modules por worktree", **nenhuma linha**, e terminava em `exited with code 141`. Dois defeitos independentes, os dois na classe do §13 do money-path: *sensor que não mede quando importa*.

## 1. O 141 — qual pipeline, provado por exaustão

`ps -axo rss,comm | sort -rn | head -10 | awk` ([wt-status.sh:63](scripts/wt-status.sh)).

O `head` é o **único** leitor do script que fecha o pipe cedo — enumerei os 11 pipelines e todos os outros (`sed -n 's///p'`, `awk` com `END`, `cut`, `sort -u`) consomem até o EOF. O `sort` só emite depois de ler a entrada inteira, então ainda está escrevendo quando o `head` sai ⇒ **SIGPIPE**; o `pipefail` promove o 141 a status do pipeline e o `set -e` mata o script. Como era a **última** seção, o 141 virava o exit code — vermelho num caminho de **sucesso**.

Limiar do buffer de pipe do macOS, medido (5 rodadas por tamanho):

| saída do `sort` | rodadas com 141 |
|---|---|
| 62 KB | 0/5 |
| 126 KB | 2/5 |
| 318 KB | 5/5 |

Com os 617 processos de agora a saída dá **46 KB** e o bug **não** aparece — é exatamente por isso que ele só mordia com a máquina cheia. Conserto: `awk 'NR<=10'`, que lê até o EOF.

## 2. A seção vazia — três causas

- `sz="$(du -sm ... | cut -f1)"` sob `set -e`+`pipefail`: **um** `du` que falhe matava o script inteiro. Reproduzido: `EXIT=1`, cabeçalho e mais nada.
- `${sz:-0}` fabricava **zero** para quem não foi medido (§2: ausente ≠ zero).
- A seção só imprimia **uma linha agregada, depois do laço inteiro** — e o laço leva **~3,5 min** aqui: um `du` de node_modules custa **6–8 s** e **não** barateia repetido (a pressão de memória despeja o cache do FS).

Conserto: teto de tempo (`WT_STATUS_TETO_S`, default 60 s), listagem por worktree e **cobertura explícita**.

### Antes / depois, na mesma máquina

```
# antes
═══ node_modules por worktree ═══
(nada)
...
error: script "wt:status" exited with code 141

# depois — EXIT=0 em 62s
       636 MB  ~/Projetos/afiacao/.claude/worktrees/dazzling-lovelace-bdd42d
       ... (10 linhas)
        … e mais 6 worktree(s) medida(s)
  medidos: 16 de 30 worktree(s) com node_modules — ~10124 MB (piso — só o que foi medido)
  mediana das medidas: 636 MB por worktree
  ⚠️  sem medida: 14 — 14 pelo teto de 60s. Não é 0 MB: é dado que falta.
      Pra medir tudo: WT_STATUS_TETO_S=300 bun run wt:status
```

A mediana (636 MB × 30 ≈ 19 GB) fecha com os **19021 MB** da varredura completa que medi antes — sem o script fabricar um total que não mediu.

## Duas decisões que o próprio conserto teve de corrigir

**Fatia igual do orçamento foi tentada e MEDIDA:** 30 candidatos em 30 s davam 2 s cada, nenhum `du` de 6–8 s terminava, e o sensor reportava `medidos: 0 de 30` **em toda execução** — o §13 na veia. Trocado por guloso com cap por item.

**O motivo do não-medido vem do exit code** (124 = teto, 1 = erro do `du`), não de inferência sobre o orçamento global. A primeira versão creditava o relógio como "erro do du" — a mesma desonestidade que o PR veio corrigir. É o caso 3b do teste.

## Evidência

- `scripts/test-wt-status.sh` — **19 asserções**, stubs de `du`/`ps`/`git`/`lsof`, roda em ~7 s. Registrado no `test:hooks` (teste órfão é ausência de dado, #1787).
- **Falsificado por sabotagem em CÓPIA**, as 4 vermelhas: (a) volta o `| head -10` → **`EXIT=141` reaparece**; (b) volta o `${sz:-0}` → morre no `set -e`; (c) neutraliza o teto → pendura; (d) infere o motivo do orçamento global → credita o relógio como erro do `du`.
- `shellcheck scripts/*.sh .claude/hooks/*.sh` → exit 0.
- `bun run wt:status` real → **EXIT=0**.

## ⚠️ Colisão conhecida com o #1808

O [#1808](https://github.com/LucasSardenbergL/afiacao/pull/1808) está **em voo** e toca a **mesma linha** do `test:hooks`, fazendo o mesmo por 4 suítes órfãs. Adotei a **forma dele** (2º laço, `scripts/test-$t.sh` sem sufixo `-guard`) de propósito: quem mergear depois resolve **acrescentando um nome à lista**, sem redesenho.

Sem migration, sem edge, sem Publish — script local.