### PR TITLE
fix(farmer): a falha da leitura do melhor individual só existia no DevTools do vendedor [money-path]

### DIFF
--- a/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
+++ b/src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { toast } from 'sonner';
+import { captureException } from '@/lib/analytics';
 
 /**
  * Guard money-path — a leitura do "melhor individual" não pode virar nem um zero fabricado
@@ -25,8 +26,14 @@ import { toast } from 'sonner';
  *     `completude='completo'`. Esse par é a licença exata que a fase 2 usaria para EXPIRAR a
  *     carteira de ofertas da vendedora. Mesmo defeito que o #1791 fechou, por outra porta.
  *
- * DISCRIMINADOR: nenhum registro de head `vazio` + `completo` nascido desta leitura, e nenhum
- * `toast.success` quando ela falhou.
+ *  3. A falha só existia como `console.error`. O vendedor recebe o toast e o "indisponível" no
+ *     cartão — e o diagnóstico morre no DevTools DELE, que ele não abre e não reporta. É o
+ *     RELATO do §13 (money-path) faltando o canal do plantão: a decisão de manter esta leitura
+ *     fora do `InsumosSnapshot` (ela não participa do juízo da completude) tira o insumo do
+ *     RÓTULO, não do RELATO.
+ *
+ * DISCRIMINADOR: nenhum registro de head `vazio` + `completo` nascido desta leitura, nenhum
+ * `toast.success` quando ela falhou, e a falha EXISTINDO fora do browser de quem a viu.
  *
  * ⚠️ Com a leitura em BLOCO a falha deixou de ser por-cliente: é UMA, e vale para a execução
  * inteira. Isso não afrouxa nada aqui — o que estes testes julgam é o DESFECHO da execução
@@ -184,5 +191,50 @@ describe('useBundleEngine — a leitura do melhor individual não fabrica zero n
       result.current.customerBundles.length,
       'a falha de um insumo acessório levou junto os bundles válidos',
     ).toBeGreaterThan(0);
+  });
+  it('a falha ACORDA o plantão — `console.error` sozinho morre no DevTools que ninguém abre', async () => {
+    // ⚠️ Aqui `erroIndividual` é o objeto PLANO do PostgREST (`{code, message}`), NÃO um `Error`:
+    // é justamente o caso em que o idiom `String(err)` imprimiria "[object Object]" e o alarme
+    // chegaria ao plantão sem dizer o que quebrou. Por isso `mensagemDeErro` + `erroComCausa`.
+    falhaMelhorIndividual = 'erro';
+
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+
+    const alarmes = vi
+      .mocked(captureException)
+      .mock.calls.filter(([e]) => String((e as Error)?.message).includes('[farmer/melhor-individual]'));
+
+    expect(
+      alarmes.length,
+      'a falha de leitura não gerou alarme — ela chegou ao vendedor e a mais ninguém',
+    ).toBe(1);
+
+    const [erro, contexto] = alarmes[0];
+    expect(
+      (erro as Error).message,
+      'o alarme diz QUE falhou mas não POR QUÊ — a mensagem técnica se perdeu na tradução',
+    ).toContain(ERRO_TIMEOUT.message);
+    expect(
+      (erro as Error & { cause?: unknown }).cause,
+      'a causa original (code/details do PostgREST) não foi preservada em `cause`',
+    ).toBe(ERRO_TIMEOUT);
+    expect(contexto).toMatchObject({ origem: 'farmer/melhor-individual', motor: 'bundle' });
+    expect(
+      typeof (contexto as Record<string, unknown>).runId,
+      'sem `runId` o alarme não casa com a execução que o produziu',
+    ).toBe('string');
+  });
+
+  it('CONTRAPROVA: execução saudável NÃO dispara o alarme', async () => {
+    // Sem isto, um `captureException` incondicional no topo do `try` passaria no teste acima. E
+    // é o §13 do money-path no eixo da saturação: alarme que toca em toda execução não é sinal.
+    const { result } = renderHook(() => useBundleEngine());
+    await act(async () => { await result.current.calculateBundles(); });
+
+    const alarmes = vi
+      .mocked(captureException)
+      .mock.calls.filter(([e]) => String((e as Error)?.message).includes('[farmer/melhor-individual]'));
+    expect(alarmes, 'alarmou sem falha nenhuma — o plantão aprende a ignorar').toEqual([]);
   });
 });

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -845,11 +845,31 @@ export const useBundleEngine = () => {
         }
       } catch (erroIndividual) {
         console.error('Falha ao ler o melhor individual da carteira:', erroIndividual);
+        // …e o `console.error` acima morre no DevTools de quem nunca abre o DevTools. Sem esta
+        // linha a falha chegava ao vendedor (toast + "indisponível" em cada cartão) e a MAIS
+        // NINGUÉM — o plantão só ficava sabendo se ele reportasse, o que não acontece. O
+        // vizinho de cima (head ilegível) já saía por aqui; a assimetria era acidental.
+        //
+        // `erroComCausa` guarda as duas pontas: a mensagem de domínio para quem lê o alarme e o
+        // erro ORIGINAL preso em `cause` para quem for diagnosticar — o `error` do PostgREST é
+        // um objeto PLANO (`{message, details, hint, code}`), não um `Error`, e `String(err)`
+        // nele imprime "[object Object]"; por isso `mensagemDeErro`, e não `String`.
+        //
+        // ⚠️ Isto é o RELATO, não uma SÉRIE (§13 do money-path): o alarme prova QUE falhou, não
+        // com que frequência — a taxa continua sem denominador, preço reconhecido de manter
+        // esta leitura fora do `InsumosSnapshot` pelo motivo do parágrafo abaixo.
+        captureException(
+          erroComCausa(
+            `[farmer/melhor-individual] leitura em bloco falhou — ${mensagemDeErro(erroIndividual) ?? 'erro sem mensagem'}`,
+            erroIndividual,
+          ),
+          { origem: 'farmer/melhor-individual', motor: 'bundle', runId },
+        );
         // Sem `throw`: esta comparação é ACESSÓRIA — ela não entra em `recomendacoes`, o
         // payload da RPC de substituição, então derrubar a carteira inteira por causa dela
         // trocaria uma afirmação errada por um prejuízo maior. O que a falha NÃO pode é
-        // sumir: ela reprova o toast de sucesso, marca cada cliente como `indisponivel` na
-        // tela, e impede que a omissão da lista vire um veredicto.
+        // sumir: ela acorda o plantão (acima), reprova o toast de sucesso, marca cada cliente
+        // como `indisponivel` na tela, e impede que a omissão da lista vire um veredicto.
         //
         // ⚠️ DE PROPÓSITO **não** vira insumo do `InsumosSnapshot`, e a reavaliação que esta
         // entrega fez CONFIRMOU a decisão anterior trocando o fundamento dela.


### PR DESCRIPTION
## O defeito

O `catch` da leitura em bloco do "melhor individual" (`comparacaoIndisponivel`, `src/hooks/useBundleEngine.ts`) reportava a falha **apenas** com `console.error`.

Consequência: a falha chegava ao vendedor (toast + "Comparação indisponível" em cada cartão) **e ao console do browser DELE — a mais ninguém**. Vendedor não abre DevTools nem reporta, então a falha não existia para o plantão.

O vizinho de cima — o head ilegível — **já** saía por `captureException` com `origem`/`motor`/`runId`. A assimetria era acidental, não decisão: este `catch` nasceu com `console.error` e ficou.

## A correção

`captureException` no `catch`, no mesmo estilo do vizinho. O `console.error` fica.

- `erroComCausa` prende o erro **original** em `cause` — o `error` do PostgREST é objeto **plano** (`{message, details, hint, code}`), não um `Error`; `String(err)` nele imprimiria `"[object Object]"`.
- A mensagem técnica entra no texto via `mensagemDeErro` (fallback honesto `'erro sem mensagem'`, não um texto fabricado).
- Contexto: `{ origem: 'farmer/melhor-individual', motor: 'bundle', runId }` — o `runId` casa o alarme com a execução que o produziu.

Sai **uma vez** por execução: a leitura é em bloco desde o #1817, então há 1 leitura e 1 falha possível.

## O que NÃO mudou, de propósito

Origem: challenge Codex (gpt-5.6-sol, xhigh) do #1817, achado MÉDIO nº 2. O Codex sugeriu persistir a saúde desta leitura num campo/sensor separado — **recusado e continua recusado**:

`melhor_individual` **não** entra no `InsumosSnapshot`. `avaliarCompletude` degrada com um único `ok:false` (obrigatório ou não), e esta leitura é comprovadamente **invariante a `p_linhas`** — cliente com bundle entra de qualquer jeito, cliente sem bundle contribui zero linhas com ou sem ela. Declará-la faria uma leitura acessória **travar a expiração da fase 2** por um motivo sem relação com o que se expira (§13 do money-path, saturação do sensor).

Zero coluna nova, zero tabela de telemetria, zero mudança em `InsumosSnapshot`.

⚠️ **Isto é o RELATO, não uma SÉRIE.** O alarme prova *que* falhou, não *com que frequência* — a taxa continua sem denominador, e isso é o preço reconhecido da exclusão do snapshot (§13(b), `docs/historico/fase-sem-sinal.md`). Registrado no comentário e no header do teste para quem for medir depois.

## Prova

`src/hooks/__tests__/bundle-melhor-individual-leitura-falha.test.tsx` (arquivo existente, já dono no manifesto — nenhum arquivo novo):

- **o alarme sai** com a mensagem técnica no texto, a causa original presa em `cause`, e `origem`/`motor`/`runId` no contexto. O cenário usa o `{ error }` **plano** do PostgREST — exatamente o caso em que `String(err)` daria `"[object Object]"`.
- **CONTRAPROVA:** execução saudável **não** alarma. Sem ela, um `captureException` incondicional no topo do `try` passaria — e seria o §13 no eixo da saturação (alarme que toca sempre deixa de ser sinal).

**Falsificação** (chamada removida do `catch`):

```
× a falha ACORDA o plantão — `console.error` sozinho morre no DevTools que ninguém abre
  → a falha de leitura não gerou alarme — ela chegou ao vendedor e a mais ninguém:
    expected +0 to be 1
Tests  1 failed | 19 passed (20)   ← exit 1
```

Vermelho no assert **que mira a mudança**, e o TOTAL continua **20** (era `20 passed` no verde) — logo rodou tudo, não é "não rodou nada". Restaurado por `git checkout --` depois (o commit veio antes da sabotagem).

**Verde autoritativo** (`bun run test`, o que o CI roda): `706 arquivos / 6640 testes`, exit 0. `bun run typecheck` exit 0. `eslint` nos dois arquivos: 0 erros (o único warning é `exhaustive-deps` pré-existente no `useCallback`).

## Deploy

Mudança em `src/` ⇒ **só vai ao ar com Publish manual no Lovable**. Merge na `main` não publica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
