### PR TITLE
fix(farmer): o Apriori publicava 24 regras de uma fatia de 479 pedidos — e o browser as reescrevia por cima [money-path]

### DIFF
--- a/db/test-assoc-escritor-unico.sh
+++ b/db/test-assoc-escritor-unico.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA de migration money-path/auth com FALSIFICAÇÃO            ║
+# ║  Copie p/ db/test-<slug>.sh, preencha as ZONAS [[...]], rode:                  ║
+# ║      bash db/test-<slug>.sh > /tmp/t.log 2>&1; echo "exit=$?"                  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  Lei de Ferro (skill prove-sql-money-path):                                    ║
+# ║   1. Aplica a migration REAL (psql -f), não um stub da lógica.                 ║
+# ║   2. Assert negativo captura a SQLSTATE esperada e RE-LANÇA o resto.           ║
+# ║   3. Falsificação obrigatória: sabota a migração → exija VERMELHO → restaura.  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (idêntico em todos os harnesses; contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="assoc-escritor-unico"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+# keg-only do brew: share/lib do postgresql@17 podem não estar linkados → initdb/server falham. Copia do Cellar (idempotente).
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }   # tuples-only, unaligned (pra capturar 1 valor)
+
+# ── base mínima do Supabase: roles, schema auth, auth.uid()/role() via GUC (impersonação de RLS) ──
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;   -- espelha o admin role do Supabase (semear sem esbarrar em RLS)
+SQL
+
+# ── helpers de assert (pass/fail contados; exit 1 no fim se houve fail) ──
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# exige que um comando SQL FALHE (caminho negativo grosso). Pra checar a SQLSTATE exata, use o
+# padrão DO/EXCEPTION de references/assert-patterns.md (preferível — Lei #2).
+must_fail() { if P -q -c "$1" >/dev/null 2>&1; then bad "$2 — devia ter falhado e PASSOU"; else ok "$2 (rejeitado)"; fi; }
+
+echo "═══ setup pronto (PG17 :$PORT) ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS DE SCHEMA (o que a migração LÊ/ALTERA mas não cria)
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: o estado PRÉ-migration, fiel ao que a PROD tinha.
+#
+# Conferido em prod via psql-ro ANTES de escrever (2026-08-21):
+#   · RPC `farmer_association_rules_substituir(jsonb)`: prosecdef = t (SECURITY DEFINER),
+#     owner postgres, ACL `authenticated=X` + `service_role=X`.
+#   · Tabela: RLS LIGADA, ACL de tabela `authenticated=arwdDxtm` (privilégio TOTAL —
+#     quem segura a escrita é SÓ a policy), 1 policy `FOR ALL` com predicado
+#     `has_role(auth.uid(),'master') OR has_role(auth.uid(),'employee')`.
+#   · `service_role`: rolbypassrls = true.
+# O objeto SOB TESTE é a migration (aplicada de verdade na ZONA 2). Isto aqui é o cenário.
+# ══════════════════════════════════════════════════════════════════════════════
+P -q <<'SQL'
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'app_role') THEN
+    CREATE TYPE public.app_role AS ENUM ('employee','customer','master','admin');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.user_roles (
+  user_id uuid NOT NULL,
+  role    public.app_role NOT NULL,
+  PRIMARY KEY (user_id, role)
+);
+
+CREATE OR REPLACE FUNCTION public.has_role(_user_id uuid, _role public.app_role)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER SET search_path = public AS $f$
+  SELECT EXISTS (SELECT 1 FROM public.user_roles WHERE user_id = _user_id AND role = _role);
+$f$;
+-- O call-site da policy passa 'master'/'employee' sem cast explícito (é como a policy VIVA
+-- em prod está escrita); o enum resolve por literal desconhecido. Mantido igual de propósito.
+
+CREATE TABLE IF NOT EXISTS public.farmer_association_rules (
+  id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  antecedent_product_ids text[]  NOT NULL,
+  consequent_product_ids text[]  NOT NULL,
+  support                numeric NOT NULL DEFAULT 0,
+  confidence             numeric NOT NULL DEFAULT 0,
+  lift                   numeric NOT NULL DEFAULT 0,
+  rule_type              text    NOT NULL DEFAULT 'association',
+  cluster_segment        text,
+  sample_size            integer DEFAULT 0,
+  created_at             timestamptz DEFAULT now(),
+  updated_at             timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.farmer_association_rules ENABLE ROW LEVEL SECURITY;
+
+-- ACL de tabela idêntico ao de prod: privilégio TOTAL para authenticated/anon. É ESTE fato
+-- que torna a policy a única defesa da via PostgREST crua — e o que faz metade 2 do fence
+-- ser necessária. Se este GRANT não estivesse aqui, os asserts A4-A6 passariam pelo motivo
+-- ERRADO (falta de grant), não pela RLS.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.farmer_association_rules TO authenticated, anon;
+GRANT SELECT ON public.user_roles TO authenticated, anon;
+
+-- A policy ANTIGA (FOR ALL) — o estado que a migration vem substituir.
+DROP POLICY IF EXISTS "Staff can manage association rules" ON public.farmer_association_rules;
+CREATE POLICY "Staff can manage association rules"
+  ON public.farmer_association_rules FOR ALL
+  USING (has_role(auth.uid(), 'master') OR has_role(auth.uid(), 'employee'))
+  WITH CHECK (has_role(auth.uid(), 'master') OR has_role(auth.uid(), 'employee'));
+
+-- A RPC: o que importa aqui é (a) ser SECURITY DEFINER — logo BYPASSA a RLS, que é o motivo
+-- de a metade 1 do fence existir — e (b) o ACL inicial incluir `authenticated`.
+CREATE OR REPLACE FUNCTION public.farmer_association_rules_substituir(p_regras jsonb)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $f$
+DECLARE v_n integer;
+BEGIN
+  IF p_regras IS NULL OR jsonb_array_length(p_regras) = 0 THEN
+    RAISE EXCEPTION 'lote vazio' USING ERRCODE = 'TR001';
+  END IF;
+  DELETE FROM public.farmer_association_rules WHERE true;
+  INSERT INTO public.farmer_association_rules
+    (antecedent_product_ids, consequent_product_ids, support, confidence, lift, rule_type, sample_size)
+  SELECT ARRAY(SELECT jsonb_array_elements_text(e->'antecedent_product_ids')),
+         ARRAY(SELECT jsonb_array_elements_text(e->'consequent_product_ids')),
+         (e->>'support')::numeric, (e->>'confidence')::numeric, (e->>'lift')::numeric,
+         coalesce(e->>'rule_type','association'), (e->>'sample_size')::integer
+  FROM jsonb_array_elements(p_regras) e;
+  GET DIAGNOSTICS v_n = ROW_COUNT;
+  RETURN v_n;
+END $f$;
+
+REVOKE ALL ON FUNCTION public.farmer_association_rules_substituir(jsonb) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.farmer_association_rules_substituir(jsonb) TO authenticated, service_role;
+SQL
+echo "═══ ZONA 1: estado pré-migration montado ═══"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS (antes da migration, pra o cenário PRÉ ser exercitável)
+# ══════════════════════════════════════════════════════════════════════════════
+MASTER='11111111-1111-1111-1111-111111111111'
+EMPREGADO='22222222-2222-2222-2222-222222222222'
+CLIENTE='33333333-3333-3333-3333-333333333333'
+P -q <<SQL
+INSERT INTO public.user_roles (user_id, role) VALUES
+  ('$MASTER','master'), ('$EMPREGADO','employee'), ('$CLIENTE','customer')
+ON CONFLICT DO NOTHING;
+INSERT INTO public.farmer_association_rules
+  (antecedent_product_ids, consequent_product_ids, support, confidence, lift, rule_type, sample_size)
+VALUES (ARRAY['A'], ARRAY['B'], 0.0120, 0.3922, 8.59, 'association', 30239);
+SQL
+
+# ── CONTROLE DE CALIBRAÇÃO: no estado PRÉ, o browser CONSEGUIA as duas vias. Sem este
+#    controle, os asserts pós-migration passariam mesmo que a via nunca tivesse existido
+#    (o "detector que mede zero porque nunca foi exercido" do money-path §9).
+echo "═══ CONTROLE: o buraco EXISTIA antes da migration ═══"
+if P -q -c "SET ROLE authenticated; SELECT set_config('test.uid','$MASTER',false);
+            SELECT public.farmer_association_rules_substituir('[{\"antecedent_product_ids\":[\"X\"],\"consequent_product_ids\":[\"Y\"],\"support\":0.5,\"confidence\":0.5,\"lift\":2,\"rule_type\":\"association\",\"sample_size\":9}]'::jsonb);" >/dev/null 2>&1
+then ok "PRÉ: authenticated conseguia chamar a RPC (o buraco era real)"
+else bad "PRÉ: a RPC já negava antes da migration — o cenário não reproduz a prod, asserts abaixo não valem"; fi
+
+if P -q -c "SET ROLE authenticated; SELECT set_config('test.uid','$MASTER',false);
+            INSERT INTO public.farmer_association_rules (antecedent_product_ids, consequent_product_ids) VALUES (ARRAY['P'],ARRAY['Q']);" >/dev/null 2>&1
+then ok "PRÉ: staff conseguia INSERT direto pela via PostgREST crua"
+else bad "PRÉ: o INSERT já era negado — cenário não reproduz a prod"; fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — A MIGRATION REAL (Lei #1: psql -f no arquivo commitado, não um stub)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260820225840_farmer_assoc_rules_escritor_unico.sql"
+[ -f "$MIG" ] || { echo "❌ migration não encontrada: $MIG"; exit 1; }
+echo "═══ ZONA 2: aplicando a migration REAL ═══"
+P -q -f "$MIG"
+
+# Idempotência: o founder pode re-colar no SQL Editor (re-apply após falha parcial).
+if P -q -f "$MIG" >/dev/null 2>&1; then ok "migration é idempotente (2ª aplicação passa)"
+else bad "migration NÃO é idempotente — re-colar no SQL Editor quebraria"; fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — ASSERTS
+#
+# Sentinela = EXIT CODE do psql, nunca uma string procurada na saída. É a defesa contra o
+# teatro que o §10 documenta (um ILIKE casando a PRÓPRIA sentinela): aqui não há string a
+# casar. O caminho esperado completa em silêncio; o caminho ruim RAISE-eia e o exit vira ≠0.
+#
+# ⚠️ NUANCE DE POSTGRES que decide a FORMA de cada assert: com RLS ligada e SEM policy para o
+# comando, `INSERT` LANÇA 42501, mas `DELETE`/`UPDATE` afetam ZERO LINHAS EM SILÊNCIO. Um
+# assert que só exigisse "falhou" passaria pelo motivo errado no DELETE — ele não falha,
+# simplesmente não faz nada. Por isso DELETE/UPDATE são provados por SOBREVIVÊNCIA DA LINHA.
+# ══════════════════════════════════════════════════════════════════════════════
+echo "═══ ZONA 4: asserts ═══"
+
+# ── A1 (positivo): o cron NÃO pode ter quebrado. service_role tem BYPASSRLS e mantém EXECUTE.
+N=$(Pq -c "SET ROLE service_role; SELECT public.farmer_association_rules_substituir('[{\"antecedent_product_ids\":[\"S\"],\"consequent_product_ids\":[\"T\"],\"support\":0.012,\"confidence\":0.39,\"lift\":8.59,\"rule_type\":\"association\",\"sample_size\":30239}]'::jsonb);" | tail -1)
+eq "A1 service_role (cron) ainda substitui o lote" "$N" "1"
+
+# ── A2 (positivo): a LEITURA do staff sobrevive — é dela que vivem MixGap e cross-sell.
+V=$(Pq -c "SELECT set_config('test.uid','$MASTER',false); SET ROLE authenticated; SELECT count(*) FROM public.farmer_association_rules;" | tail -1)
+eq "A2 staff master ainda LÊ a tabela" "$V" "1"
+V=$(Pq -c "SELECT set_config('test.uid','$EMPREGADO',false); SET ROLE authenticated; SELECT count(*) FROM public.farmer_association_rules;" | tail -1)
+eq "A2b staff employee ainda LÊ a tabela" "$V" "1"
+
+# ── A3 (negativo, metade 1 do fence): a RPC DEFINER fecha para authenticated.
+#    DO/EXCEPTION com a SQLSTATE esperada e RE-RAISE no resto (Lei #2).
+if P -q -c "
+SET ROLE authenticated;
+DO \$t\$
+BEGIN
+  PERFORM set_config('test.uid','$MASTER',true);
+  PERFORM public.farmer_association_rules_substituir('[{\"antecedent_product_ids\":[\"Z\"],\"consequent_product_ids\":[\"W\"],\"support\":0.9,\"confidence\":0.9,\"lift\":9,\"rule_type\":\"association\",\"sample_size\":1}]'::jsonb);
+  RAISE EXCEPTION 'a RPC EXECUTOU sob authenticated' USING ERRCODE = 'P0001';
+EXCEPTION
+  WHEN insufficient_privilege THEN NULL;   -- 42501: exatamente o que o REVOKE deve produzir
+  WHEN OTHERS THEN RAISE;                  -- qualquer outro erro sobe (inclusive typo meu)
+END \$t\$;" >/dev/null 2>&1
+then ok "A3 authenticated NÃO executa a RPC (42501)"
+else bad "A3 metade 1 do fence não mordeu — a RPC ainda roda pelo browser"; fi
+
+# ── A4 (negativo, metade 2): INSERT direto. Aqui a RLS LANÇA.
+if P -q -c "
+SET ROLE authenticated;
+DO \$t\$
+BEGIN
+  PERFORM set_config('test.uid','$MASTER',true);
+  INSERT INTO public.farmer_association_rules (antecedent_product_ids, consequent_product_ids)
+  VALUES (ARRAY['H'], ARRAY['I']);
+  RAISE EXCEPTION 'o INSERT direto PASSOU' USING ERRCODE = 'P0001';
+EXCEPTION
+  WHEN insufficient_privilege THEN NULL;   -- 42501: 'new row violates row-level security policy'
+  WHEN OTHERS THEN RAISE;
+END \$t\$;" >/dev/null 2>&1
+then ok "A4 staff NÃO insere direto (RLS nega, 42501)"
+else bad "A4 metade 2 do fence não mordeu no INSERT"; fi
+
+# ── A5 (negativo): DELETE não lança — prova-se pela SOBREVIVÊNCIA da linha.
+#
+# ⚠️ O `|| true` que estava aqui era um buraco (achado do challenge Codex xhigh): ele
+# engolia QUALQUER erro, inclusive um typo de SQL meu. Com a linha sobrevivendo por erro de
+# sintaxe, o assert passaria sem ter exercido a RLS uma única vez — o teatro que a Lei #2
+# existe pra matar. Sob RLS sem policy de DELETE o comando NÃO erra: afeta 0 linhas. Então
+# o certo é exigir exit 0 E a sobrevivência; se o statement errar, o teste acusa.
+ANTES=$(Pq -c "SELECT count(*) FROM public.farmer_association_rules;")
+if Pq -c "SELECT set_config('test.uid','$MASTER',false); SET ROLE authenticated; DELETE FROM public.farmer_association_rules;" >/dev/null 2>&1
+then ok "A5a o DELETE roda sem erro (é a RLS que zera o alcance, não um typo meu)"
+else bad "A5a o DELETE ERROU — o assert de sobrevivência abaixo passaria pelo motivo errado"; fi
+DEPOIS=$(Pq -c "SELECT count(*) FROM public.farmer_association_rules;")
+eq "A5b DELETE do staff não apaga nada (linha sobrevive)" "$DEPOIS" "$ANTES"
+
+# ── A6 (negativo): UPDATE idem — silencioso, prova-se pelo valor INALTERADO. Mesmo cuidado.
+if Pq -c "SELECT set_config('test.uid','$MASTER',false); SET ROLE authenticated; UPDATE public.farmer_association_rules SET sample_size = 1;" >/dev/null 2>&1
+then ok "A6a o UPDATE roda sem erro (a RLS é que o torna inócuo)"
+else bad "A6a o UPDATE ERROU — o assert de valor abaixo passaria pelo motivo errado"; fi
+V=$(Pq -c "SELECT sample_size FROM public.farmer_association_rules LIMIT 1;")
+eq "A6b UPDATE do staff não altera nada" "$V" "30239"
+
+# ── A9 (negativo de ESCOPO): um `customer` não pode LER a tabela.
+#
+# Sem este caso, uma policy `FOR SELECT TO authenticated USING (true)` — que abriria a
+# tabela para TODO usuário logado — passaria em A2, A2b e A7 sem acusar nada (achado do
+# challenge Codex xhigh). A2 prova que o staff LÊ; só este prova que o predicado ainda
+# DISCRIMINA por papel. `anon` (A7) não basta: ele reprova por `auth.uid()` nulo, não pelo
+# papel, então uma policy `USING(true)` para authenticated o manteria em 0 do mesmo jeito.
+V=$(Pq -c "SELECT set_config('test.uid','$CLIENTE',false); SET ROLE authenticated; SELECT count(*) FROM public.farmer_association_rules;" | tail -1)
+eq "A9 customer logado não lê a tabela (o predicado discrimina por papel)" "$V" "0"
+
+# ── A7 (negativo): anon segue sem nada (não regrediu para aberto).
+V=$(Pq -c "SET ROLE anon; SELECT count(*) FROM public.farmer_association_rules;" | tail -1)
+eq "A7 anon não lê nada" "$V" "0"
+
+# ── A8: zero policy de ESCRITA sobrou, exatamente uma de SELECT.
+V=$(Pq -c "SELECT count(*) FROM pg_policy WHERE polrelid='public.farmer_association_rules'::regclass AND polcmd <> 'r';")
+eq "A8 nenhuma policy de escrita sobreviveu" "$V" "0"
+V=$(Pq -c "SELECT count(*) FROM pg_policy WHERE polrelid='public.farmer_association_rules'::regclass AND polcmd = 'r';")
+eq "A8b exatamente 1 policy de SELECT" "$V" "1"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota, exige VERMELHO, restaura.
+#
+# Cada sabotagem ataca UMA metade do fence. Se um assert seguir verde com a metade dele
+# sabotada, aquele assert não tem dente — e um fence sem dente é pior que nenhum, porque
+# parece auditado. As duas metades são falsificadas SEPARADAMENTE de propósito: é isso que
+# prova que NENHUMA das duas sozinha bastava (o argumento inteiro da migration).
+# ══════════════════════════════════════════════════════════════════════════════
+echo "═══ ZONA 5: falsificação ═══"
+
+# ── F1: devolve o EXECUTE ao authenticated (desfaz SÓ a metade 1). A3 tem de ficar VERMELHO.
+P -q -c "GRANT EXECUTE ON FUNCTION public.farmer_association_rules_substituir(jsonb) TO authenticated;"
+if P -q -c "
+SET ROLE authenticated;
+DO \$t\$
+BEGIN
+  PERFORM set_config('test.uid','$MASTER',true);
+  PERFORM public.farmer_association_rules_substituir('[{\"antecedent_product_ids\":[\"Z\"],\"consequent_product_ids\":[\"W\"],\"support\":0.9,\"confidence\":0.9,\"lift\":9,\"rule_type\":\"association\",\"sample_size\":1}]'::jsonb);
+  RAISE EXCEPTION 'a RPC EXECUTOU sob authenticated' USING ERRCODE = 'P0001';
+EXCEPTION
+  WHEN insufficient_privilege THEN NULL;
+  WHEN OTHERS THEN RAISE;
+END \$t\$;" >/dev/null 2>&1
+then bad "F1 SABOTADO e A3 seguiu VERDE — o assert A3 não tem dente"
+else ok "F1 com o EXECUTE de volta, A3 fica vermelho (o assert morde)"; fi
+P -q -c "REVOKE EXECUTE ON FUNCTION public.farmer_association_rules_substituir(jsonb) FROM authenticated;"
+
+# ── F2: recria a policy FURADA (FOR ALL) — desfaz SÓ a metade 2. A4 tem de ficar VERMELHO.
+P -q -c "
+DROP POLICY IF EXISTS \"Staff can read association rules\" ON public.farmer_association_rules;
+CREATE POLICY \"Staff can manage association rules\" ON public.farmer_association_rules FOR ALL
+  USING (has_role(auth.uid(), 'master') OR has_role(auth.uid(), 'employee'))
+  WITH CHECK (has_role(auth.uid(), 'master') OR has_role(auth.uid(), 'employee'));"
+if P -q -c "
+SET ROLE authenticated;
+DO \$t\$
+BEGIN
+  PERFORM set_config('test.uid','$MASTER',true);
+  INSERT INTO public.farmer_association_rules (antecedent_product_ids, consequent_product_ids)
+  VALUES (ARRAY['H'], ARRAY['I']);
+  RAISE EXCEPTION 'o INSERT direto PASSOU' USING ERRCODE = 'P0001';
+EXCEPTION
+  WHEN insufficient_privilege THEN NULL;
+  WHEN OTHERS THEN RAISE;
+END \$t\$;" >/dev/null 2>&1
+then bad "F2 SABOTADO e A4 seguiu VERDE — o assert A4 não tem dente"
+else ok "F2 com a policy FOR ALL de volta, A4 fica vermelho (o assert morde)"; fi
+
+# ── F3: o BLOCO DE PÓS-VERIFICAÇÃO da própria migration tem dente?
+# Deixa uma policy de escrita com OUTRO nome (que os DROP nominais não removem) e re-aplica
+# a migration: ela tem de RECUSAR. Sem isto, o bloco seria decoração — o §9 do money-path
+# em forma de auto-verificação: "escrever que o sensor detecta X é afirmação TESTÁVEL".
+P -q -c "CREATE POLICY \"buraco_de_escrita\" ON public.farmer_association_rules FOR INSERT WITH CHECK (true);"
+if P -q -f "$MIG" >/dev/null 2>&1
+then bad "F3 a migration ACEITOU rodar com uma policy de escrita órfã — o bloco de pós-verificação é decoração"
+else ok "F3 a migration RECUSA aplicar com policy de escrita sobrevivente (o bloco morde)"; fi
+
+# ── F4: o RAISE deixa o banco INTEIRO ou PELA METADE? (achado do challenge Codex xhigh)
+#
+# F3 acima roda com `psql -f`, que é AUTOCOMMIT POR STATEMENT — ali o REVOKE e o CREATE
+# POLICY já commitaram quando o bloco de verificação levanta. Isso NÃO é como o founder vai
+# aplicar: o SQL Editor do Lovable manda o buffer inteiro numa mensagem só, e o PostgreSQL
+# abre transação implícita — logo, ou tudo entra ou nada entra. Provar só com `-f` deixaria a
+# propriedade que importa em produção SEM teste, e um apply parcial num fence de autorização
+# é o pior desfecho possível (metade do fence, com cara de aplicado).
+#
+# Observável escolhido: devolvo o EXECUTE ao authenticated E deixo a policy órfã. Aplicando
+# em transação única, a migration REVOGA e depois levanta na verificação. Se for atômico, o
+# EXECUTE tem de VOLTAR a existir no fim (rollback). Se tiver commitado no meio, some.
+P -q -c "GRANT EXECUTE ON FUNCTION public.farmer_association_rules_substituir(jsonb) TO authenticated;"
+P -q -c "SELECT 1;" >/dev/null   # garante que o GRANT acima commitou antes do teste
+"$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 -1 -q -f "$MIG" >/dev/null 2>&1 \
+  && bad "F4 a migration PASSOU em transação única com a policy órfã — a verificação não morde" \
+  || ok "F4 a migration falha em transação única (como no SQL Editor)"
+V=$(Pq -c "SELECT has_function_privilege('authenticated','public.farmer_association_rules_substituir(jsonb)','EXECUTE')::text;")
+eq "F4b o REVOKE foi DESFEITO pelo rollback (apply é tudo-ou-nada)" "$V" "true"
+
+P -q -c "DROP POLICY IF EXISTS \"buraco_de_escrita\" ON public.farmer_association_rules;"
+
+# ── RESTAURA a verdade e re-prova que o estado final é o correto (cirúrgico, não git checkout:
+#    em árvore suja o `git checkout --` destrói fix uncommitted — lição do §9).
+P -q -f "$MIG"
+V=$(Pq -c "SELECT count(*) FROM pg_policy WHERE polrelid='public.farmer_association_rules'::regclass AND polcmd <> 'r';")
+eq "pós-falsificação: estado restaurado, zero policy de escrita" "$V" "0"
+V=$(Pq -c "SELECT has_function_privilege('authenticated','public.farmer_association_rules_substituir(jsonb)','EXECUTE')::text;")
+eq "pós-falsificação: authenticated segue sem EXECUTE" "$V" "false"
+
+echo
+echo "═══ RESULTADO: $PASS ok / $FAIL falhas ═══"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **478** custom migrations totais
+- **479** custom migrations totais
 - **1618** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 491
@@ -3984,6 +3984,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.farmer_melhor_individual_por_cliente` | — |
+
+### `20260820225840_farmer_assoc_rules_escritor_unico.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 478
+-- Total de custom migrations: 479
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -519,7 +519,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260818120000', 'authz_private_execute_fecho', '20260818120000_authz_private_execute_fecho.sql'),
   ('20260818121919', 'authz_fecho_execute_registrado_3_funcoes', '20260818121919_authz_fecho_execute_registrado_3_funcoes.sql'),
   ('20260820124611', 'farmer_melhor_individual_bulk', '20260820124611_farmer_melhor_individual_bulk.sql'),
-  ('20260820133119', 'farmer_melhor_individual_atomico', '20260820133119_farmer_melhor_individual_atomico.sql')
+  ('20260820133119', 'farmer_melhor_individual_atomico', '20260820133119_farmer_melhor_individual_atomico.sql'),
+  ('20260820225840', 'farmer_assoc_rules_escritor_unico', '20260820225840_farmer_assoc_rules_escritor_unico.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -2579,3 +2579,151 @@ describe('guardrail money-path: calculate-scores renormaliza via módulo testáv
     }
   });
 });
+
+// ── computeAssociationRules: o universo do Apriori é PAGINADO, ORDENADO e FILTRADO ──────
+//
+// O defeito (medido em prod via psql-ro, 2026-08-20/21): a leitura era UMA chamada só,
+// `db.from("order_items").select("sales_order_id, product_id").not("product_id","is",null)`,
+// sem paginação, sem `.order()`, sem filtro de status, e com o `error` DESCARTADO na
+// desestruturação. O cap silencioso de 1.000 do PostgREST entregava 479 dos 30.259 pedidos —
+// e o `sample_size` das 24 regras vigentes era 479 em TODAS, o que prova que o universo de
+// PRODUÇÃO era a fatia. Uma réplica SQL do algoritmo rodada sobre `LIMIT 1000` reproduziu as
+// 24 regras EXATAMENTE (mesmos pares, mesmo lift até 6 casas).
+//
+// Por que TEXTUAL e por que AQUI: a edge é Deno, fora do typecheck e do vitest; `test:edges`
+// não enxerga a FORMA da query e `edges:typecheck` não roda a leitura. Este é o único dos
+// três gates de edge que pega a regressão — inclusive uma reescrita do Lovable no deploy.
+const ASSOC_INICIO = 'async function computeAssociationRules(';
+
+function blocoAssoc(s: string): string {
+  const i = s.indexOf(ASSOC_INICIO);
+  if (i < 0) throw new Error('computeAssociationRules não encontrada (âncora quebrada)');
+  const resto = s.slice(i);
+  const fim = resto.search(/\n\/\/ ======== /);
+  return fim < 0 ? resto : resto.slice(0, fim);
+}
+
+describe('guardrail money-path: Apriori lê o universo INTEIRO de cestas (cap de 1.000)', () => {
+  it('a leitura delega a fetchAll — nunca uma chamada single-shot', () => {
+    const bloco = removerComentarios(blocoAssoc(read(ANALYTICS)));
+
+    expect(bloco, 'âncora quebrada: bloco vazio').not.toBe('');
+    expect(
+      /const items = await fetchAll</.test(bloco),
+      'a leitura de order_items parou de delegar a fetchAll — o cap de 1.000 volta em silêncio',
+    ).toBe(true);
+    // O defeito original tinha ESTA forma. Assert negativo sobre a fonte SEM comentários:
+    // a prosa acima cita o código proibido de propósito (§"O ALVO mente").
+    expect(
+      /const\s*\{\s*data:\s*items\s*\}\s*=\s*await/.test(bloco),
+      'voltou a desestruturar só `data` — o error da leitura vira "0 regras, preservadas"',
+    ).toBe(false);
+  });
+
+  it('pagina com ORDEM ESTÁVEL — sem .order() o .range() pula/duplica entre páginas', () => {
+    const bloco = removerComentarios(blocoAssoc(read(ANALYTICS)));
+
+    expect(count(bloco, '.range(from, to)'), 'esperava exatamente 1 .range() no bloco').toBe(1);
+    expect(
+      /\.order\("id",\s*\{\s*ascending:\s*true\s*\}\)/.test(bloco),
+      'sumiu o .order("id") — a chave é a PK de order_items, e é ELA que estabiliza a paginação',
+    ).toBe(true);
+  });
+
+  it('filtra o universo pela denylist da autoridade + deleted_at (paridade com useBundleEngine)', () => {
+    const bloco = removerComentarios(blocoAssoc(read(ANALYTICS)));
+
+    // A denylist NÃO pode ser literal aqui: literal é como a 3ª cópia divergiu
+    // (`mapas-paginados.ts` citava 3 dos 4 status). Tem de vir do espelho canônico.
+    //
+    // ⚠️ Pinar só o NOME da constante era guard frouxo (achado do challenge Codex xhigh):
+    // daria para apagar o `.not(…)` inteiro e deixar a constante num uso decorativo que
+    // mantém o assert VERDE. É o §9 — "gate de forma não protege a ESCOLHA"; quando o que
+    // defende é a CHAMADA, pine a chamada. Aqui: a constante DENTRO do `.not` do status.
+    expect(
+      /\.not\(\s*"sales_orders\.status"\s*,\s*"in"\s*,\s*STATUS_NAO_VENDA_POSTGREST\s*\)/.test(bloco),
+      'o filtro de status saiu, ou a denylist deixou de vir do espelho canônico',
+    ).toBe(true);
+    expect(
+      bloco.includes('sales_orders!inner('),
+      'sumiu o !inner — sem o join o filtro de status do PAI não é aplicado a nada',
+    ).toBe(true);
+    expect(
+      /\.is\("sales_orders\.deleted_at",\s*null\)/.test(bloco),
+      'sumiu o deleted_at IS NULL — é a METADE do contrato do universo, anda junto com a denylist',
+    ).toBe(true);
+  });
+
+  it('o edge IMPORTA o espelho da denylist (não redeclara uma cópia local)', () => {
+    const fonte = removerComentarios(read(ANALYTICS));
+
+    expect(
+      /import\s*\{[^}]*STATUS_NAO_VENDA_POSTGREST[^}]*\}\s*from\s*"\.\.\/_shared\/universo-pedidos\.ts"/.test(fonte),
+      'a constante deixou de vir de _shared/universo-pedidos.ts',
+    ).toBe(true);
+    expect(
+      /const\s+STATUS_NAO_VENDA/.test(fonte),
+      'o edge redeclarou a denylist localmente — vira a 4ª cópia, que é o defeito que este PR fechou',
+    ).toBe(false);
+  });
+});
+
+// ── PARIDADE do espelho da denylist: src × edge (pega reversão do Lovable no deploy) ──────
+// O edge não importa de `src/` (Deno + suíte com `--no-remote`), então a constante é copiada.
+// Cópia sem guard textual É a divergência esperando acontecer — foi assim que
+// `mapas-paginados.ts` ficou com 3 dos 4 status. Ver money-path.md § "Helper espelhado".
+const UNIVERSO_SRC = 'src/lib/farmer/universo-pedidos.ts';
+const UNIVERSO_EDGE = 'supabase/functions/_shared/universo-pedidos.ts';
+
+// Compara a LISTA PARSEADA, não um bloco textual normalizado.
+//
+// O padrão MIRROR do resto deste arquivo exige marcadores-comentário nos DOIS lados. Aqui isso
+// custaria caro no lado `src/`: `universo-pedidos.ts` é 90% prosa por desenho (é o documento da
+// autoridade, com o histórico de medição inteiro), e 7 linhas de código em 69. Cinco linhas de
+// marcador+explicação derrubaram a fração preservada de 0,101 para 0,095 e reprovaram a
+// sentinela de `limpeza-fonte` — um falso positivo da PREMISSA dela (ela existe para pegar
+// stripper que engole código, não densidade de comentário), mas resolver enfraquecendo o
+// detector seria pior que o problema.
+//
+// Extrair a lista é, além de mais barato, um guard MAIS FORTE: pina os VALORES em vez da
+// formatação. Reordenar, reindentar ou trocar aspas não reprova; ACRESCENTAR ou REMOVER um
+// status reprova — que é exatamente a divergência que este gate existe para pegar (a 3ª cópia
+// em `mapas-paginados.ts` tinha três dos quatro).
+function listaDeStatus(fonte: string): string[] {
+  const m = fonte.match(/STATUS_NAO_VENDA:\s*readonly string\[\]\s*=\s*\[([\s\S]*?)\]/);
+  if (!m) throw new Error('não achei o literal de STATUS_NAO_VENDA (âncora quebrada)');
+  return [...m[1].matchAll(/'([^']+)'/g)].map((x) => x[1]).sort();
+}
+
+describe('guardrail money-path: denylist do universo de pedidos não divergiu entre src e edge', () => {
+  it('a lista de status é a mesma dos dois lados', () => {
+    expect(
+      listaDeStatus(read(UNIVERSO_EDGE)),
+      'o espelho do edge divergiu da autoridade em src/',
+    ).toEqual(listaDeStatus(read(UNIVERSO_SRC)));
+  });
+
+  it('os quatro status estão lá — e a lista não encolheu para os três da cópia antiga', () => {
+    expect(listaDeStatus(read(UNIVERSO_EDGE))).toEqual([
+      'cancelado',
+      'orcamento',
+      'pendente',
+      'rascunho',
+    ]);
+  });
+
+  it('a expressão do valor PostgREST é a mesma nos dois — a forma com aspas é a que roda em prod', () => {
+    const expr = /STATUS_NAO_VENDA_POSTGREST\s*=\s*`\("\$\{STATUS_NAO_VENDA\.join\('","'\)\}"\)`/;
+    expect(expr.test(read(UNIVERSO_SRC)), 'a autoridade mudou a forma do valor').toBe(true);
+    expect(expr.test(read(UNIVERSO_EDGE)), 'o espelho do edge mudou a forma do valor').toBe(true);
+  });
+
+  it('nenhuma edge cita a denylist como literal solta (era a 3ª cópia divergente)', () => {
+    const mapas = removerComentarios(read('supabase/functions/_shared/mapas-paginados.ts'));
+    expect(
+      mapas.includes('(cancelado,rascunho,pendente)'),
+      'a literal divergente voltou a mapas-paginados.ts — ela citava 3 dos 4 status',
+    ).toBe(false);
+    expect(mapas.includes('STATUS_NAO_VENDA_POSTGREST')).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
+++ b/src/hooks/__tests__/bundle-recomendacoes-erro-silencioso.test.tsx
@@ -219,15 +219,30 @@ describe('useBundleEngine — a gravação das recomendações de bundle não fa
     expect(avisos()[0]).toContain('recomenda');
   });
 
-  it('as duas falhas juntas (regras + recomendações) aparecem no MESMO aviso', async () => {
-    regrasFalham = true;
+  // ⚠️ REESCRITO (2026-08-21). Este caso exigia que o aviso trouxesse as DUAS falhas —
+  // regras + recomendações — e casava a frase 'anteriores seguem valendo', que era do ramo
+  // de falha da PERSISTÊNCIA DE REGRAS. Esse ramo não existe mais: o hook deixou de publicar
+  // `farmer_association_rules` (tabela GLOBAL com dois escritores concorrentes; a corrida foi
+  // medida acontecendo em prod — cron gravou 24 regras às 07:30 UTC, o browser gravou 4 às
+  // 01:33 UTC do dia seguinte). Sem escrita não há desfecho de escrita a relatar.
+  //
+  // O invariante que SOBREVIVE — e que era o ponto real deste arquivo — é que a falha da
+  // gravação de RECOMENDAÇÕES não sai calada. Ele continua pinado abaixo. Manter a asserção
+  // antiga transformaria a remoção do 2º escritor em regressão vermelha (money-path §6:
+  // teste pode canonizar o que se quer remover).
+  it('a falha das recomendações continua aparecendo — e sozinha, sem inventar a das regras', async () => {
+    regrasFalham = true;      // deixado LIGADO de propósito: hoje não deve produzir efeito nenhum
     insertRecsFalha = true;
     await calcular();
 
     expect(toastMock.success).not.toHaveBeenCalled();
     expect(toastMock.warning).toHaveBeenCalledTimes(1);
     expect(avisos()[0]).toContain('recomenda');
-    expect(avisos()[0]).toContain('anteriores seguem valendo');
+
+    // E o aviso NÃO pode falar de regra: afirmar "as regras não foram salvas" quando não
+    // houve tentativa é pior que silêncio — é relatar um desfecho que não aconteceu.
+    expect(avisos()[0]).not.toContain('anteriores seguem valendo');
+    expect(avisos()[0]).not.toContain('regras anteriores foram preservadas');
   });
 
   it('grava as recomendações numa ÚNICA chamada em lote, não uma por vez', async () => {

--- a/src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx
+++ b/src/hooks/__tests__/bundle-regras-substituicao-atomica.test.tsx
@@ -150,28 +150,48 @@ async function calcular() {
   return result;
 }
 
-describe('useBundleEngine — troca de regras é atômica ou não acontece', () => {
-  it('substitui via RPC e nunca apaga a tabela pelo cliente', async () => {
-    await calcular();
+/**
+ * ⚠️ ESTE ARQUIVO FOI INVERTIDO (2026-08-21). A invariante antiga era "substitui via RPC";
+ * a nova é "NÃO ESCREVE POR VIA NENHUMA".
+ *
+ * O que mudou não foi opinião, foi medição. `farmer_association_rules` tinha DOIS escritores
+ * chamando a mesma RPC com universos diferentes, e o último vencia. Medido em prod (psql-ro):
+ * o cron gravou 24 regras (`sample_size` 479) às 07:30 UTC; este hook gravou 4 regras
+ * (`sample_size` 21.579) às 01:33 UTC do dia seguinte, porque alguém abriu a tela. A corrida
+ * foi OBSERVADA acontecendo, não deduzida. Enquanto os dois existissem, corrigir o produtor
+ * server-side (que lia 479 dos 30.259 pedidos por causa do cap de 1.000 do PostgREST) teria
+ * meia-vida de uma abertura de tela.
+ *
+ * O teste antigo não estava errado no que afirmava — a atomicidade da RPC segue valendo e
+ * segue provada em `db/test-farmer-association-rules-atomica.sh`. Ele estava PINANDO uma
+ * escrita que não deve mais existir: um teste que exige `substituicoes()).toHaveLength(1)`
+ * transforma a remoção do 2º escritor em regressão vermelha. Por isso a inversão em vez do
+ * delete (money-path §6: teste pode canonizar o defeito — ao consertar, reverta o teste).
+ *
+ * DISCRIMINADOR NOVO, mais forte que o anterior: nenhuma via de escrita sobre
+ * `farmer_association_rules` pode partir do cliente — nem `delete()`, nem `insert()`,
+ * nem `update()`, nem a RPC. Em NENHUM cenário (caminho feliz, zero regras, lente).
+ *
+ * ⚠️ Este guard cobre o CÓDIGO. A fronteira de verdade é o BANCO (`REVOKE EXECUTE ... FROM
+ * authenticated` na RPC + a policy de escrita da tabela) — money-path §5: guard na fronteira
+ * que TODA via cruza, não só na UI. Um teste de fonte não impede um PostgREST cru.
+ */
+const escritasNaTabelaDeRegras = () =>
+  queries.filter(
+    (q) =>
+      q.table === 'farmer_association_rules' &&
+      q.metodos.some((m) => m === 'delete' || m === 'insert' || m === 'update' || m === 'upsert'),
+  );
 
-    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
-    expect(substituicoes()).toHaveLength(1);
+describe('useBundleEngine — não publica mais o modelo global de regras', () => {
+  it('caminho feliz: descobre regras, usa em memória e NÃO escreve na tabela', async () => {
+    const result = await calcular();
 
-    const lote = substituicoes()[0].args.p_regras as Array<Record<string, unknown>>;
-    expect(lote.length).toBeGreaterThan(0);
-    expect(lote[0]).toMatchObject({ rule_type: expect.stringMatching(/^(association|sequential)$/) });
-  });
+    // As regras seguem existindo — o que saiu foi a persistência, não a mineração.
+    expect(result.current.rules.length).toBeGreaterThan(0);
 
-  it('RPC falhando NÃO emite toast de sucesso — e nada foi apagado', async () => {
-    rpcFalha = true;
-    await calcular();
-
-    // O ponto do parecer: falhou, então a tela não pode dizer que gravou.
-    expect(toastMock.success).not.toHaveBeenCalled();
-    expect(toastMock.warning).toHaveBeenCalledTimes(1);
-    expect(String(toastMock.warning.mock.calls[0][0])).toContain('anteriores seguem valendo');
-
-    // E as regras que já estavam lá sobrevivem, porque nenhum DELETE partiu daqui.
+    expect(substituicoes()).toHaveLength(0);
+    expect(escritasNaTabelaDeRegras()).toHaveLength(0);
     expect(deletesNaTabelaDeRegras()).toHaveLength(0);
   });
 
@@ -182,21 +202,41 @@ describe('useBundleEngine — troca de regras é atômica ou não acontece', () 
     expect(toastMock.warning).not.toHaveBeenCalled();
   });
 
-  it('zero regras descobertas preserva as vigentes — não chama a RPC nem apaga', async () => {
+  it('o toast não fala mais de persistência de REGRA — não há escrita a relatar', async () => {
+    await calcular();
+
+    // Falar "as regras NÃO foram salvas" seria pior que silêncio: afirmaria uma tentativa
+    // que não existe. As duas frases antigas saíram junto com a escrita.
+    const ditos = [...toastMock.success.mock.calls, ...toastMock.warning.mock.calls]
+      .map((c) => String(c[0]))
+      .join(' | ');
+    expect(ditos).not.toContain('anteriores seguem valendo');
+    expect(ditos).not.toContain('regras anteriores foram preservadas');
+  });
+
+  it('zero regras descobertas: nada de escrita, e nada de aviso sobre regra', async () => {
     semPedidos = true;
     await calcular();
 
     expect(substituicoes()).toHaveLength(0);
-    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
-    expect(toastMock.success).not.toHaveBeenCalled();
-    expect(String(toastMock.warning.mock.calls[0][0])).toContain('preservadas');
+    expect(escritasNaTabelaDeRegras()).toHaveLength(0);
   });
 
-  it('na lente "Ver como" não escreve nada (o master inspeciona, não regrava)', async () => {
+  it('na lente "Ver como" também não escreve (era o único cenário já protegido)', async () => {
     naLente = true;
     await calcular();
 
     expect(substituicoes()).toHaveLength(0);
-    expect(deletesNaTabelaDeRegras()).toHaveLength(0);
+    expect(escritasNaTabelaDeRegras()).toHaveLength(0);
+  });
+
+  it('a RPC falhando é IRRELEVANTE agora — o hook não a chama em cenário nenhum', async () => {
+    // Falsificação do próprio guard: se alguém reintroduzir a escrita, `rpcFalha` volta a
+    // ter efeito e este teste fica vermelho junto com os de cima.
+    rpcFalha = true;
+    await calcular();
+
+    expect(substituicoes()).toHaveLength(0);
+    expect(toastMock.success).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/hooks/useBundleEngine.ts
+++ b/src/hooks/useBundleEngine.ts
@@ -736,47 +736,37 @@ export const useBundleEngine = () => {
       // o array INTEIRO — é ele que alimenta o filtro abaixo, não o top-50 que vai à tabela.
       insumos.regras = { ok: true, n: discoveredRules.length };
 
-      // Persist top rules — PULADO na lente "Ver como" (a tabela é GLOBAL: a troca
-      // substitui as regras de toda a base; o master inspeciona os bundles do alvo sem
-      // recalcular regras/recomendações da carteira dele).
+      // ESTE HOOK NÃO PUBLICA MAIS O MODELO GLOBAL. As regras acima seguem alimentando os
+      // bundles DESTA execução, em memória — o que saiu foi a persistência em
+      // `farmer_association_rules`, que é uma tabela GLOBAL.
       //
-      // Vai por RPC porque `delete()` + `insert()` são DUAS chamadas PostgREST, logo duas
-      // transações: falha entre elas deixava a tabela VAZIA — e ela alimenta o MixGap
-      // (`get_meu_mixgap`), o canal Melhorias (`melhoria_produtos_relacionados`), a edge
-      // `recommend` (assoc_score) e o `useCrossSellEngine`. A RPC faz DELETE+INSERT numa
-      // transação só: INSERT falho devolve as regras antigas. Provada em db/test-farmer-
-      // association-rules-atomica.sh (26 asserts + 4 falsificações).
-      let desfechoRegras: 'gravadas' | 'lente' | 'sem_regras' | 'falhou' = 'lente';
-      if (!isImpersonating) {
-        const regrasParaGravar = discoveredRules.slice(0, 50).map(r => ({
-          antecedent_product_ids: r.antecedent,
-          consequent_product_ids: r.consequent,
-          support: Math.round(r.support * 10000) / 10000,
-          confidence: Math.round(r.confidence * 10000) / 10000,
-          lift: Math.round(r.lift * 100) / 100,
-          rule_type: r.type,
-          sample_size: totalBaskets,
-        }));
-
-        if (regrasParaGravar.length === 0) {
-          // Zero regra descoberta quase sempre é dado faltando a montante, não "a base não
-          // tem padrão" — e apagar por isso derruba quatro features. Preserva o que está lá.
-          // (A RPC recusaria o lote vazio de qualquer jeito; não chamamos só pra tomar erro.)
-          desfechoRegras = 'sem_regras';
-        } else {
-          const { error: erroRegras } = await supabase.rpc('farmer_association_rules_substituir', {
-            p_regras: regrasParaGravar as unknown as Json,
-          });
-          // Sem `throw`: os bundles abaixo saem das regras em MEMÓRIA e continuam válidos.
-          // Mas o toast final não pode dizer que deu tudo certo.
-          if (erroRegras) {
-            console.error('Falha ao substituir farmer_association_rules:', erroRegras);
-            desfechoRegras = 'falhou';
-          } else {
-            desfechoRegras = 'gravadas';
-          }
-        }
-      }
+      // POR QUÊ (medido em prod, psql-ro, 2026-08-20/21). A tabela tinha DOIS escritores
+      // chamando a mesma RPC com modelos diferentes, e o último a escrever vencia:
+      //   · o cron `compute-association-rules-daily` (edge `omie-analytics-sync`) gravou 24
+      //     regras às 07:30 UTC com `sample_size` 479;
+      //   · este hook gravou 4 regras às 01:33 UTC do dia seguinte com `sample_size` 21.579,
+      //     porque alguém abriu a tela.
+      // Não é hipótese: foi observado ACONTECENDO durante a investigação. Os dois universos
+      // discordam (21.579 cestas aqui, de `sales_orders.items` com SKU ativo, contra 30.239
+      // no produtor server-side, de `order_items`), e a MESMA coluna `sample_size` passava a
+      // significar coisas diferentes conforme quem escreveu por último. Enquanto os dois
+      // existissem, corrigir um era ser revertido pelo outro no clique seguinte — a correção
+      // do cap de 1.000 no produtor teria meia-vida de uma abertura de tela.
+      //
+      // Violava, além disso, "1 escritor por slug" (CLAUDE.md): uma VISITA a uma tela não
+      // pode republicar o modelo de toda a base.
+      //
+      // O `rule_type: 'sequential'` que só este caminho produzia NÃO se perde de verdade: ele
+      // nunca foi um modelo sequencial — o código apenas TROCAVA o rótulo de uma regra de
+      // associação já descoberta quando achava uma ocorrência ordenada na janela, sem
+      // support/confidence próprios, sem exigir repetição e aceitando itens do MESMO pedido
+      // (diferença de zero dias). As 4 regras vivas em prod estavam TODAS rotuladas
+      // `sequential`, o que confirma que o rótulo não discrimina nada. Sequencial de verdade
+      // é outro modelo, com unidade, janela e métricas próprias — fatia separada.
+      //
+      // O fence de verdade é no BANCO (`REVOKE EXECUTE ... FROM authenticated` + a policy de
+      // escrita), não neste `if`: código do browser é uma via, não a fronteira (money-path §5).
+      // Este bloco sai para o operador não tomar um erro de permissão no lugar de um toast.
 
       // 4.5. O melhor produto individual de CADA cliente — UMA leitura, não N.
       //
@@ -1194,11 +1184,11 @@ export const useBundleEngine = () => {
       // no mesmo aviso: reportar só um deixaria o outro invisível.
       const totalBundles = allCustomerBundles.reduce((s, c) => s + c.bundles.length, 0);
       const problemas: string[] = [];
-      if (desfechoRegras === 'falhou') {
-        problemas.push('as regras NÃO foram salvas — as anteriores seguem valendo');
-      } else if (desfechoRegras === 'sem_regras') {
-        problemas.push('nenhuma regra atingiu os pisos — as regras anteriores foram preservadas');
-      }
+      // Os dois desfechos de PERSISTÊNCIA DE REGRA saíram junto com a escrita: este hook não
+      // publica mais `farmer_association_rules` (ver o bloco da seção 4). Sem escrita não há
+      // desfecho a relatar — e manter a frase "as regras NÃO foram salvas" seria pior que
+      // silêncio, porque afirmaria uma tentativa que não existe. As regras deste run seguem
+      // valendo em memória para os bundles abaixo; quem publica o modelo global é o cron.
       if (recomendacoesNaoGravadas > 0) {
         problemas.push(
           recomendacoesNaoGravadas === 1

--- a/supabase/functions/_shared/mapas-paginados.ts
+++ b/supabase/functions/_shared/mapas-paginados.ts
@@ -14,6 +14,7 @@
 // `--no-remote`, então um módulo testável não pode importar `npm:` nem para tipo. O
 // call-site passa `supabase as unknown as BancoPostgrest` (padrão do monthly-report).
 import { fetchAll, type BancoPostgrest } from "./paginate.ts";
+import { STATUS_NAO_VENDA_POSTGREST } from "./universo-pedidos.ts";
 
 export interface LinhaAssignment {
   customer_user_id: string;
@@ -71,7 +72,20 @@ export async function carregarPedidosDoMes(
     (de, ate) =>
       db.from<LinhaPedidoMes>("sales_orders")
         .select("customer_user_id, total, order_date_kpi")
-        .not("status", "in", "(cancelado,rascunho,pendente)")
+        // Era a literal `"(cancelado,rascunho,pendente)"` — TRÊS dos quatro status da
+        // autoridade (`orcamento` faltava), uma terceira cópia do conceito que já tinha
+        // divergido. Passa a apontar para o espelho canônico. Medido em prod antes de
+        // aplicar: 0 linhas com `status = 'orcamento'`, então é no-op HOJE — o que muda é
+        // que a lista deixa de poder divergir de novo em silêncio.
+        .not("status", "in", STATUS_NAO_VENDA_POSTGREST)
+        // A OUTRA METADE do contrato do universo. O espelho canônico avisa em prosa que
+        // `deleted_at IS NULL` anda junto da denylist e que quem consome tem de aplicar os
+        // DOIS — e este call-site aplicava só um. Apontar para a constante sem aplicar o par
+        // seria importar a promessa sem a defesa (achado do challenge Codex xhigh). Aqui o
+        // estrago seria pior que uma tela errada: este é o caller do SNAPSHOT CONGELADO de
+        // positivação, então um pedido apagado entraria como receita de um mês que ninguém
+        // recalcula. Medido em prod antes de aplicar: 0 linhas com `deleted_at` — no-op hoje.
+        .is("deleted_at", null)
         .gte("order_date_kpi", mesIso)
         .lt("order_date_kpi", fimIso)
         .order("id", { ascending: true })

--- a/supabase/functions/_shared/mapas-paginados_test.ts
+++ b/supabase/functions/_shared/mapas-paginados_test.ts
@@ -64,6 +64,15 @@ function fakeDb(
         predicados.push((l) => alvo.has(l[coluna]));
         return q;
       },
+      // `.is(coluna, null)` — o predicado de soft-delete. Só o caso `null` está implementado
+      // de propósito: é o único uso no módulo, e um double que aceita `true`/`false` sem
+      // modelá-los mentiria por omissão no dia em que alguém os usasse.
+      is(coluna: string, valor: unknown) {
+        reg.filtros.push(`is:${coluna}=${String(valor)}`);
+        if (valor !== null) throw new Error(`double: .is(_, ${String(valor)}) não implementado`);
+        predicados.push((l) => l[coluna] === null || l[coluna] === undefined);
+        return q;
+      },
       gte(coluna: string, valor: unknown) {
         reg.filtros.push(`gte:${coluna}=${String(valor)}`);
         predicados.push((l) => String(l[coluna] ?? "") >= String(valor));
@@ -77,8 +86,18 @@ function fakeDb(
       not(coluna: string, operador: string, valor: unknown) {
         reg.filtros.push(`not:${coluna} ${operador} ${String(valor)}`);
         if (operador !== "in") throw new Error(`double: .not(_, ${operador}) não implementado`);
+        // O PostgREST aceita a lista do `in` com OU sem aspas por valor — `(a,b)` e
+        // `("a","b")` são equivalentes. Este double só entendia a forma SEM aspas, e por
+        // isso deu falso-VERMELHO quando o call-site passou a usar a constante canônica
+        // `STATUS_NAO_VENDA_POSTGREST` (que emite a forma COM aspas, a mesma que os três
+        // hooks do `src/` usam contra o PostgREST real em produção). Um double que modela
+        // menos que o serviço real reprova código íntegro — o §"o ALVO mente" na versão
+        // fake. Tira as aspas junto com os espaços.
         const fora = new Set(
-          String(valor).replace(/^\(|\)$/g, "").split(",").map((s) => s.trim()),
+          String(valor)
+            .replace(/^\(|\)$/g, "")
+            .split(",")
+            .map((s) => s.trim().replace(/^"|"$/g, "")),
         );
         predicados.push((l) => !fora.has(String(l[coluna])));
         return q;
@@ -241,10 +260,32 @@ Deno.test("pedidos do mês: filtra status/janela e ordena por id", async () => {
   assertEquals(linhas.length, 2);
   assertEquals(registros[0].order, "id");
   assertEquals(registros[0].filtros, [
-    "not:status in (cancelado,rascunho,pendente)",
+    // A literal de 3 status virou a constante canônica de 4 (`STATUS_NAO_VENDA_POSTGREST`,
+    // espelhada de `src/lib/farmer/universo-pedidos.ts`). A que estava aqui era uma 3ª cópia
+    // que já tinha divergido da autoridade — faltava `orcamento`. Efeito medido em prod antes
+    // de trocar: 0 linhas com `status = 'orcamento'`, logo é no-op HOJE; o que muda é a lista
+    // deixar de poder divergir de novo em silêncio. Pinado aqui de propósito: este assert é o
+    // que faria uma reversão da constante aparecer.
+    'not:status in ("cancelado","rascunho","pendente","orcamento")',
+    // A metade que faltava: sem ela um pedido APAGADO entrava no snapshot CONGELADO de
+    // positivação — o mês não é recalculado, então o erro não se corrige sozinho.
+    "is:deleted_at=null",
     "gte:order_date_kpi=2026-06-01",
     "lt:order_date_kpi=2026-07-01",
   ]);
+});
+
+Deno.test("pedidos do mês: pedido soft-deletado NÃO entra no snapshot congelado", async () => {
+  // Falsificação do predicado novo: sem o `.is('deleted_at', null)` este pedido apagado
+  // vira receita de um mês fechado. Sem este caso, remover o filtro seguiria VERDE.
+  const { db } = fakeDb({
+    sales_orders: [
+      ...pedidos(2),
+      ...pedidos(1).map((p) => ({ ...p, deleted_at: "2026-06-20T00:00:00Z" })),
+    ],
+  });
+  const linhas = await carregarPedidosDoMes(db, "2026-06-01", "2026-07-01");
+  assertEquals(linhas.length, 2);
 });
 
 Deno.test("pedidos do mês: página com ERRO lança — não vira receita 0", async () => {

--- a/supabase/functions/_shared/paginate.ts
+++ b/supabase/functions/_shared/paginate.ts
@@ -35,6 +35,14 @@ export interface QueryPostgrest<T> extends PromiseLike<RespostaPostgrest<T>> {
   gte(coluna: string, valor: unknown): QueryPostgrest<T>;
   lt(coluna: string, valor: unknown): QueryPostgrest<T>;
   not(coluna: string, operador: string, valor: unknown): QueryPostgrest<T>;
+  /**
+   * `IS` do PostgREST — na prática, o predicado de soft-delete (`.is('deleted_at', null)`).
+   * Entrou quando `carregarPedidosDoMes` passou a aplicar as DUAS metades do contrato do
+   * universo de pedidos (denylist de status + `deleted_at IS NULL`): faltava a segunda, e
+   * o caller é o do snapshot CONGELADO de positivação, onde um pedido apagado vira receita
+   * de um mês que ninguém recalcula.
+   */
+  is(coluna: string, valor: unknown): QueryPostgrest<T>;
   order(coluna: string, opts?: { ascending?: boolean }): QueryPostgrest<T>;
   range(de: number, ate: number): QueryPostgrest<T>;
   // `limit` é a AMOSTRA deliberada (teto de negócio), não a paginação: quem usa `limit`

--- a/supabase/functions/_shared/recommend-leituras_test.ts
+++ b/supabase/functions/_shared/recommend-leituras_test.ts
@@ -146,6 +146,14 @@ function fakeDb(
         reg.limit = n;
         return q;
       },
+      // `is` entrou na interface pelo PR irmão (escritor único de `farmer_association_rules`),
+      // que precisou de `.is('deleted_at', null)` para aplicar as DUAS metades do contrato do
+      // universo de pedidos. Este núcleo não usa o predicado: LANÇA em vez de devolver `q` sem
+      // filtrar, seguindo a convenção dos outros doubles deste `_shared` — um filtro que o
+      // double ignora em silêncio faz o teste medir mais linhas do que a query devolveria.
+      is(coluna: string) {
+        throw new Error(`double: .is(${coluna}) não implementado neste núcleo`);
+      },
       maybeSingle() {
         reg.single = true;
         const r = resposta();

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -57,6 +57,9 @@ function bancoFake(tabelas: Record<string, Linha[]>, erroDoBanco?: string) {
       // filtro que o double ignora em silêncio faria o teste medir mais linhas do que a
       // query devolveria de verdade — falso-verde. Se o núcleo passar a usá-los, o teste
       // quebra alto e pede a implementação aqui.
+      is(coluna) {
+        throw new Error(`double: .is(${coluna}) não implementado neste núcleo`);
+      },
       gte(coluna) {
         throw new Error(`double: .gte(${coluna}) não implementado neste núcleo`);
       },

--- a/supabase/functions/_shared/universo-pedidos.ts
+++ b/supabase/functions/_shared/universo-pedidos.ts
@@ -1,0 +1,43 @@
+// Espelho Deno do universo de PEDIDOS dos motores do farmer — DENYLIST.
+//
+// A AUTORIDADE é `src/lib/farmer/universo-pedidos.ts` (leia lá o porquê da denylist, os dois
+// status que nunca existiram nesta tabela e o efeito no DENOMINADOR do Apriori). O edge não
+// importa de `src/` — é Deno, e a suíte roda com `--no-remote` —, então a constante é
+// ESPELHADA e a paridade é travada no CI por `src/__tests__/edge-money-path-invariants.test.ts`,
+// que EXTRAI a lista de status dos dois arquivos e compara os VALORES (não um bloco textual:
+// a autoridade em `src/` é 90% prosa por desenho, e marcadores de MIRROR ali afundariam a
+// sentinela de `limpeza-fonte`). Comparar valores é o guard mais forte de qualquer jeito —
+// reordenar ou reindentar não reprova; acrescentar ou remover um status reprova. O guard cobre
+// a FONTE, inclusive uma reescrita do Lovable no deploy (money-path.md, § "Helper espelhado").
+//
+// POR QUE ESTE ARQUIVO EXISTE (2026-08-20). Havia DUAS cópias divergentes deste conceito no
+// repo e nenhuma era canônica no lado Deno: a autoridade em `src/`, e uma terceira lista em
+// `_shared/mapas-paginados.ts` (`carregarPedidosDoMes`) que citava só TRÊS dos quatro status
+// — faltava `orcamento`. Criar uma QUARTA cópia para o Apriori seria compor o problema, então
+// as duas do lado Deno passam a apontar para cá. Efeito da correção do `carregarPedidosDoMes`
+// MEDIDO em prod antes de aplicar: 0 linhas com `status = 'orcamento'` em `sales_orders`, logo
+// é no-op HOJE — o valor é fechar a divergência latente, não mudar número.
+//
+// ⚠️ `deleted_at IS NULL` é a OUTRA METADE do contrato e NÃO mora nesta constante — quem
+// consome tem de aplicar os DOIS predicados. Mesma pegadinha que a autoridade documenta.
+//
+// ⚠️ NULL: o `not.in` do PostgREST é NULL-blind (`NULL NOT IN (...)` é NULL, não passa), igual
+// ao SQL da autoridade da margem. A paridade é intencional — espelhar a autoridade inclui
+// espelhar como ela trata o nulo. Medido em prod (2026-08-20): 0 linhas com `status` nulo,
+// então hoje o ponto é teórico.
+
+// SEM `export`, ao contrário da autoridade em `src/` — lá o array É consumido direto
+// (`cobertura-conta-oferta.ts`, testes); aqui ele só alimenta o derivado abaixo, e exportá-lo
+// reprova o gate de dead-code (`bunx knip`, dentro do `validate`). O guard de paridade compara
+// a LISTA PARSEADA, não o texto, então a assimetria do `export` não o quebra — que é
+// exatamente a folga pela qual valeu a pena trocar MIRROR textual por comparação de valores.
+/** Status que NÃO são venda. Verbatim do corpo em prod de `private.margem_cliente_agregada()`. */
+const STATUS_NAO_VENDA: readonly string[] = [
+  'cancelado',
+  'rascunho',
+  'pendente',
+  'orcamento',
+];
+
+/** Valor pronto para o `.not('status', 'in', …)` do PostgREST: `("a","b",…)`. */
+export const STATUS_NAO_VENDA_POSTGREST = `("${STATUS_NAO_VENDA.join('","')}")`;

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -2,6 +2,7 @@ import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { comRegistro, type DbRegistro } from "../_shared/registro-execucao.ts";
 import { fetchAll } from "../_shared/paginate.ts";
+import { STATUS_NAO_VENDA_POSTGREST } from "../_shared/universo-pedidos.ts";
 import { montarUpsertsDeCusto } from "../_shared/cost-compute.ts";
 import { recomporCustoProducao } from "../_shared/recompor-custo-producao.ts";
 import { buildProductIdMap, montarCatalogoPorCod } from "../_shared/product-idmap.ts";
@@ -1799,22 +1800,99 @@ async function syncCustoProducao(db: SupabaseClient, account: OmieAccount) {
 // ======== COMPUTE ASSOCIATION RULES (Apriori-like) ========
 
 async function computeAssociationRules(db: SupabaseClient) {
-  // Load config
-  const { data: configs } = await db.from("recommendation_config").select("key, value");
+  // A CONFIG também falhava ABERTO (achado do challenge Codex xhigh nesta entrega). Era
+  // `const { data: configs } = await …` — o MESMO defeito da leitura de cestas, doze linhas
+  // acima dela: `error` descartado ⇒ "não consegui LER a configuração" virava "configuração
+  // AUSENTE", e os `??` abaixo publicavam o modelo com os DEFAULTS como se fossem os pisos
+  // escolhidos. Numa tabela cujo consumidor confia no `support` publicado, isso é fabricar o
+  // próprio CRITÉRIO. Fechar a leitura grande e deixar esta seria trancar a porta e esquecer
+  // a janela. Quem chama é `comRegistro`, que registra a falha — então lançar aqui é visível.
+  const { data: configs, error: erroConfig } = await db
+    .from("recommendation_config")
+    .select("key, value");
+  if (erroConfig) throw new Error(`recommendation_config: ${erroConfig.message}`);
   const cfg: Record<string, number> = {};
-  for (const c of configs || []) cfg[c.key] = c.value;
+  for (const c of configs ?? []) cfg[c.key] = c.value;
 
   const minSupport = cfg.s_min ?? 0.01;
   const minLift = cfg.l_min ?? 1.2;
   const maxRules = cfg.max_association_rules ?? 500;
 
-  // Load all order_items grouped by sales_order_id
-  const { data: items } = await db
-    .from("order_items")
-    .select("sales_order_id, product_id")
-    .not("product_id", "is", null);
+  // O UNIVERSO DE CESTAS — paginado, ordenado e filtrado. Aqui havia UMA leitura só:
+  //   const { data: items } = await db.from("order_items")
+  //     .select("sales_order_id, product_id").not("product_id","is",null);
+  // Quatro defeitos empilhados, todos MEDIDOS em prod via psql-ro (2026-08-20/21):
+  //
+  //  1. SEM PAGINAÇÃO → o cap silencioso de 1.000 linhas do PostgREST. `order_items` tem 68.350
+  //     linhas com `product_id` e 30.259 pedidos distintos; as 1.000 primeiras dão exatamente
+  //     479 pedidos. E o `sample_size` das 24 regras que estavam vigentes era 479 em TODAS —
+  //     ou seja, o universo de PRODUÇÃO era a fatia, e a prova não é inferência: uma réplica
+  //     SQL do algoritmo abaixo rodada sobre `LIMIT 1000` reproduz as 24 regras EXATAMENTE
+  //     (mesmos pares, mesmo lift até 6 casas).
+  //  2. SEM `.order()` → a fatia não é nem estável nem aleatória entre execuções (§7/§9 do
+  //     money-path). O gate `_shared/paginacao-delegada_test.ts` exige `.order(` junto de todo
+  //     `.range(` nesta edge exatamente por isto.
+  //  3. SEM FILTRO DE STATUS → pedido cancelado/soft-deletado entrava na cesta. O motor irmão
+  //     (`useBundleEngine`) já usa a DENYLIST da autoridade + `deleted_at IS NULL`; a paridade
+  //     de universo entre os dois motores é o desenho, não coincidência. Efeito isolado hoje:
+  //     20 cestas de 30.259 — pequeno, mas é o predicado que impede um cancelamento em massa
+  //     amanhã de virar "padrão de compra".
+  //  4. `const { data: items }` DESCARTAVA o `error` → página com timeout/RLS/500 virava `[]`,
+  //     e o retorno dizia "0 regras, regras vigentes preservadas" com cara de sucesso (§6/§11).
+  //     `fetchAll` LANÇA na página com erro E na malformada (`data:null` sem `error`), então
+  //     "não consegui ler" para de ser indistinguível de "não há padrão".
+  //
+  // ⚠️ O `!inner` é o que aplica o filtro do PAI sem uma segunda leitura paginada — duas
+  // leituras seriam 2×K instantes (§14: paginar não faz snapshot), e o Set intermediário de
+  // 30 mil ids seria mais uma superfície onde a página perdida troca o ESCOPO em silêncio.
+  // ⚠️ STATUS NULO: o `not.in` do PostgREST é NULL-BLIND — pedido com `status IS NULL` não
+  // passa no filtro e some do universo. Espelhar a autoridade (que é NULL-blind pelo mesmo
+  // motivo em SQL) mantém a PARIDADE, mas espelhar em SILÊNCIO seria trocar o defeito de
+  // lugar: amanhã um nulo encolheria o denominador e o `sample_size` publicado teria cara de
+  // universo completo — o §2 (ausente ≠ zero) na forma de RÓTULO. Precisão > recall diz para
+  // NÃO publicar sob ambiguidade, não para publicar um número menor sem avisar. Medido em
+  // prod (2026-08-20): 0 linhas. Se deixar de ser 0, a publicação PARA e diz quantas são.
+  // (Achado do challenge Codex xhigh: "excluir desconhecido é compatível com precisão>recall;
+  // fazê-lo silenciosamente não é".)
+  const { count: pedidosSemStatus, error: erroNulo } = await db
+    .from("sales_orders")
+    .select("id", { count: "exact", head: true })
+    .is("status", null)
+    .is("deleted_at", null);
+  if (erroNulo) throw new Error(`sales_orders/status-nulo: ${erroNulo.message}`);
+  if ((pedidosSemStatus ?? 0) > 0) {
+    throw new Error(
+      `${pedidosSemStatus} pedido(s) com status NULL: o universo do Apriori seria menor que o real ` +
+        `e o sample_size publicado mentiria sobre a base. Classifique o status antes de recalcular.`,
+    );
+  }
 
-  if (!items?.length) return { rules_generated: 0 };
+  // O tipo declara a forma REAL da linha, INCLUSIVE o objeto embedado. Declarar só as duas
+  // colunas era uma mentira de tipo — a resposta traz o `sales_orders` em cada uma das ~68 mil
+  // linhas, e um tipo que esconde isso esconde também o custo de memória de quem for revisar.
+  const items = await fetchAll<{
+    sales_order_id: string | null;
+    product_id: string | null;
+    sales_orders: { status: string | null; deleted_at: string | null } | null;
+  }>(
+    (from, to) =>
+      db
+        .from("order_items")
+        // `id` NÃO entra no select: o `.order()` não exige a coluna projetada (mesma
+        // convenção de `useBundleEngine`), e são ~68 mil linhas — o uuid a mais seria
+        // payload puro numa edge que já segura o universo inteiro em memória.
+        .select("sales_order_id, product_id, sales_orders!inner(status, deleted_at)")
+        .not("product_id", "is", null)
+        .not("sales_orders.status", "in", STATUS_NAO_VENDA_POSTGREST)
+        .is("sales_orders.deleted_at", null)
+        .order("id", { ascending: true })
+        .range(from, to),
+    "order_items/assoc-rules",
+  );
+
+  // `items.length === 0` agora só pode ser "li a tabela inteira e não há item" — falha de
+  // leitura virou exceção acima. Antes os dois estados chegavam aqui iguais.
+  if (!items.length) return { rules_generated: 0, itens_lidos: 0 };
 
   // Build transactions: Map<order_id, Set<product_id>>
   const transactions = new Map<string, Set<string>>();
@@ -1924,8 +2002,21 @@ async function computeAssociationRules(db: SupabaseClient) {
     throw new Error(`farmer_association_rules_substituir: ${erroSubstituir.message}`);
   }
 
-  console.log(`[AssocRules] Generated ${inserted} rules from ${totalTx} transactions`);
-  return { rules_generated: inserted, total_transactions: totalTx, frequent_items: frequentItems.size };
+  // PROVENIÊNCIA no payload, não só a contagem. O lote não tem coluna de origem/parâmetros
+  // (isso é fatia própria), mas o retorno cai no registro de execução — e sem estes campos
+  // "24 regras" e "2 regras" são indistinguíveis na auditoria, que foi exatamente como o cap
+  // de 1.000 sobreviveu: o número publicado nunca vinha acompanhado do universo que o gerou.
+  console.log(
+    `[AssocRules] ${inserted} regras de ${totalTx} cestas (${items.length} itens lidos) ` +
+      `— s_min=${minSupport} l_min=${minLift} max=${maxRules}`,
+  );
+  return {
+    rules_generated: inserted,
+    total_transactions: totalTx,
+    frequent_items: frequentItems.size,
+    itens_lidos: items.length,
+    params: { s_min: minSupport, l_min: minLift, max_rules: maxRules },
+  };
 }
 
 // ======== MAIN HANDLER ========
@@ -2047,9 +2138,26 @@ Deno.serve(async (req) => {
         result = await comRegistro(
           dbRegistro, "analytics_sync.recalcular_regras", auth,
           () => computeAssociationRules(supabaseAdmin),
+          // O mapper guardava SÓ `rules_generated` e `total_transactions`. Com isso, os campos
+          // de proveniência que a função passou a devolver (`itens_lidos`, `params`) eram
+          // DESCARTADOS aqui — e o comentário que os introduziu prometia auditoria durável.
+          // Promessa que o mapper desfaz é a mesma classe de "rótulo que não é fato": a
+          // auditoria pareceria existir. Achado do challenge Codex xhigh, conferido na linha.
+          // Sem estes campos, "24 regras" e "2 regras" são indistinguíveis no registro — que
+          // é exatamente como o cap de 1.000 sobreviveu por tanto tempo.
           (r) => {
-            const a = r as { rules_generated?: number; total_transactions?: number };
-            return { rules_generated: a.rules_generated ?? null, total_transactions: a.total_transactions ?? null };
+            const a = r as {
+              rules_generated?: number;
+              total_transactions?: number;
+              itens_lidos?: number;
+              params?: Record<string, number>;
+            };
+            return {
+              rules_generated: a.rules_generated ?? null,
+              total_transactions: a.total_transactions ?? null,
+              itens_lidos: a.itens_lidos ?? null,
+              params: a.params ?? null,
+            };
           },
         );
         break;

--- a/supabase/migrations/20260820225840_farmer_assoc_rules_escritor_unico.sql
+++ b/supabase/migrations/20260820225840_farmer_assoc_rules_escritor_unico.sql
@@ -1,0 +1,93 @@
+-- ============================================================================
+-- farmer_association_rules — ESCRITOR ÚNICO (fence no banco)
+--
+-- POR QUE. A tabela é GLOBAL (não tem farmer_id) e alimenta quatro consumidores:
+-- `get_meu_mixgap`, `melhoria_produtos_relacionados`, a edge `recommend` (assoc_score) e
+-- `useCrossSellEngine`. Ela tinha DOIS escritores com modelos e universos DIFERENTES,
+-- chamando a mesma RPC, e o último a escrever vencia:
+--
+--   · cron `compute-association-rules-daily` (edge `omie-analytics-sync`, service_role);
+--   · o BROWSER (`useBundleEngine`), quando um gestor abria a tela de bundles.
+--
+-- Não é risco teórico — foi MEDIDO acontecendo (psql-ro, 2026-08-20/21):
+--   2026-08-20 07:30 UTC → 24 regras, sample_size 479   (cron)
+--   2026-08-21 01:33 UTC →  4 regras, sample_size 21.579 (browser)
+-- A MESMA coluna `sample_size` passou a significar universos diferentes conforme quem
+-- escreveu por último. E o produtor server-side lia 479 de 30.259 pedidos (cap silencioso
+-- de 1.000 do PostgREST): corrigi-lo sem este fence daria uma correção com meia-vida de
+-- uma abertura de tela. Viola "1 escritor por slug" (CLAUDE.md).
+--
+-- POR QUE DUAS METADES, e nenhuma sozinha basta (medido no ACL de prod antes de escrever):
+--   (1) a RPC é SECURITY DEFINER (owner postgres) ⇒ ela BYPASSA a RLS. Fechar só a policy
+--       deixaria a porta da RPC aberta para `authenticated`.
+--   (2) `authenticated` tem ACL de tabela `arwdDxtm` — privilégio TOTAL, gatilhado apenas
+--       pela RLS. Fechar só a RPC deixaria a via PostgREST crua aberta.
+-- Por isso: REVOKE do EXECUTE **e** policy de escrita restrita. (money-path §5 — o guard
+-- mora na fronteira que TODA via cruza.)
+--
+-- O QUE NÃO MUDA (conferido em prod ANTES de aplicar):
+--   · `service_role` tem `rolbypassrls = true` ⇒ a edge/cron segue escrevendo e lendo.
+--   · `get_meu_mixgap` e `melhoria_produtos_relacionados` são SECURITY DEFINER ⇒ intactos.
+--   · A LEITURA pelo staff no browser (`useCrossSellEngine`, `useBundleEngine`) é preservada
+--     — a policy nova mantém o MESMO predicado, só restringe o comando a SELECT.
+--   · `anon` continua sem nada (o predicado exige role de staff; `auth.uid()` nulo reprova).
+--
+-- ⚠️ A policy vigente em PROD usa `'master'`, e a migration que a criou
+-- (20260223030027) dizia `'admin'` — a definição divergiu do repo em algum apply manual.
+-- Este arquivo replica a definição VIVA (`pg_policy`, lida via psql-ro), não a do repo.
+-- ============================================================================
+
+-- ── Pré-flight: falhar ALTO se o alvo não for o que este arquivo assume ──────────────
+DO $$
+BEGIN
+  IF to_regprocedure('public.farmer_association_rules_substituir(jsonb)') IS NULL THEN
+    RAISE EXCEPTION 'farmer_association_rules_substituir(jsonb) não existe — migration fora de ordem';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_class WHERE oid = 'public.farmer_association_rules'::regclass AND relrowsecurity) THEN
+    RAISE EXCEPTION 'RLS DESLIGADA em farmer_association_rules — a policy abaixo não seria fence nenhum';
+  END IF;
+END $$;
+
+-- ── Metade 1: a porta da RPC (que bypassa RLS por ser DEFINER) ───────────────────────
+-- `REVOKE ... FROM PUBLIC` NÃO tira `authenticated` (o grant é explícito, CLAUDE.md/database.md):
+-- revoga-se NOMEANDO a role. `service_role` permanece — é quem o cron usa.
+REVOKE EXECUTE ON FUNCTION public.farmer_association_rules_substituir(jsonb) FROM authenticated;
+
+-- ── Metade 2: a via PostgREST crua (gatilhada só pela RLS) ───────────────────────────
+-- Sai a policy FOR ALL, entra a mesma condição restrita a SELECT. Sem policy de
+-- INSERT/UPDATE/DELETE, a RLS nega escrita por omissão para `authenticated`/`anon`.
+DROP POLICY IF EXISTS "Staff can manage association rules" ON public.farmer_association_rules;
+DROP POLICY IF EXISTS "Staff can read association rules" ON public.farmer_association_rules;
+
+CREATE POLICY "Staff can read association rules"
+  ON public.farmer_association_rules FOR SELECT
+  USING (has_role(auth.uid(), 'master') OR has_role(auth.uid(), 'employee'));
+
+-- ── Pós-verificação: a migration se recusa a "passar" sem ter fechado as duas portas ──
+DO $$
+DECLARE
+  v_execute_authenticated boolean;
+  v_policies_de_escrita   integer;
+  v_policy_select         integer;
+BEGIN
+  v_execute_authenticated := has_function_privilege(
+    'authenticated', 'public.farmer_association_rules_substituir(jsonb)', 'EXECUTE');
+  IF v_execute_authenticated THEN
+    RAISE EXCEPTION 'FENCE INCOMPLETO: authenticated ainda tem EXECUTE na RPC de substituição';
+  END IF;
+
+  SELECT count(*) INTO v_policies_de_escrita
+  FROM pg_policy WHERE polrelid = 'public.farmer_association_rules'::regclass
+    AND polcmd <> 'r';  -- 'r' = SELECT; qualquer outro comando é via de escrita
+  IF v_policies_de_escrita > 0 THEN
+    RAISE EXCEPTION 'FENCE INCOMPLETO: % policy(ies) de escrita sobreviveram', v_policies_de_escrita;
+  END IF;
+
+  SELECT count(*) INTO v_policy_select
+  FROM pg_policy WHERE polrelid = 'public.farmer_association_rules'::regclass AND polcmd = 'r';
+  IF v_policy_select <> 1 THEN
+    RAISE EXCEPTION 'LEITURA QUEBRADA: esperava 1 policy de SELECT, achei % — o staff perderia o MixGap', v_policy_select;
+  END IF;
+
+  RAISE NOTICE 'OK: escritor único — authenticated sem EXECUTE, zero policy de escrita, leitura do staff preservada';
+END $$;


### PR DESCRIPTION
## O que estava errado

`computeAssociationRules()` (edge `omie-analytics-sync`, cron `compute-association-rules-daily`) é o escritor que MANDA na tabela GLOBAL `farmer_association_rules`. A leitura era:

```ts
const { data: items } = await db.from("order_items")
  .select("sales_order_id, product_id").not("product_id","is",null);
```

Quatro defeitos empilhados: **sem paginação** (cap silencioso de 1.000 do PostgREST), **sem `.order()`**, **sem filtro de status**, e o **`error` descartado** na desestruturação — falha de leitura virava "0 regras, preservadas" com cara de sucesso.

## Medido em produção (psql-ro), não inferido

| fato | valor |
|---|---|
| `order_items` com `product_id` | 68.350 linhas / **30.259** pedidos |
| o que a edge realmente lia | **479** pedidos (as 1.000 primeiras linhas) |
| `sample_size` das 24 regras vigentes | **479 em todas** |

A prova de que o universo de prod ERA a fatia: escrevi uma **réplica SQL do algoritmo** e rodei sobre `LIMIT 1000` — ela reproduz **as 24 regras exatamente** (mesmos pares, mesmo lift até 6 casas decimais).

Os números publicados estavam inflados de **2× a 51×** (support 0,0188 publicado vs 0,000364 real) e o lift errava nos **dois** sentidos (14,90 publicado vs 34,99 real; 7,43 vs 2,42).

### A corrida dos dois escritores, observada acontecendo

| quando | escritor | regras | `sample_size` |
|---|---|---|---|
| 20/08 07:30 UTC | cron (edge) | 24 | 479 |
| 21/08 01:33 UTC | **browser** (`useBundleEngine`) | 4 | 21.579 |

Alguém abriu a tela e o hook substituiu tudo. Corrigir só a edge teria **meia-vida de um clique**.

### ANTES × DEPOIS, e a cobertura REAL

| | cestas | regras | clientes cobertos (de 1.208) |
|---|---|---|---|
| com o cap de 1.000 | 479 | 24 | 266 (22,0%) |
| corrigido | **30.239** | **2** | **250 (20,7%)** |

⚠️ A queda de 92% é no **número de regras**, não em cobertura: os 16 antecedentes das 24 regras concentravam quase os mesmos clientes que os 2 antecedentes cobrem. **−16 clientes, −1,3 ponto percentual.** As 24 não eram ruído (lift real de 2,42 a 143,31) — o que as mata é o `support`, que é razão, com denominador 63× maior.

## O que este PR faz

1. **Leitura corrigida** — delega a `fetchAll` (que LANÇA em página com erro e em `data:null` sem erro), `.order("id")` estável, e filtro do pai por embed `sales_orders!inner` com a denylist da autoridade + `deleted_at IS NULL`.
2. **Fence no banco** (migration) — `REVOKE EXECUTE` da RPC para `authenticated` **e** policy `FOR ALL` → `FOR SELECT`. As duas metades são necessárias: a RPC é `SECURITY DEFINER` e bypassa a RLS; a via PostgREST crua bypassa o REVOKE (`authenticated` tem ACL de tabela `arwdDxtm`).
3. **`useBundleEngine` para de publicar** o modelo global. As regras seguem alimentando os bundles em memória.
4. **Espelho canônico da denylist no lado Deno** — havia uma 3ª cópia (`mapas-paginados.ts`) com 3 dos 4 status. Paridade textual travada no CI.
5. Config, proveniência e status NULL — ver "achados do Codex" abaixo.

## Provas

- `heavy bun run typecheck` — exit 0
- `bun run test:edges` — 765 passed / 0 failed
- `heavy bunx vitest` — 87 arquivos / 679 testes, 0 falhas
- **`db/test-assoc-escritor-unico.sh` (PG17 descartável) — 23/23, exit 0**, com 2 controles PRÉ (provando que as duas vias estavam ABERTAS antes) e 4 falsificações:
  - **F1** devolve só o `EXECUTE` → o assert da RPC fica vermelho
  - **F2** devolve só a policy `FOR ALL` → o assert do INSERT fica vermelho
  - **F3** policy de escrita órfã → a migration se recusa a aplicar
  - **F4** em transação única (como no SQL Editor), a falha faz **rollback do REVOKE**

## Achados do challenge Codex (gpt-5.6-sol, xhigh) — veredito inicial `NÃO MERGE`

Todos verificados na linha antes de aceitar, e corrigidos neste PR:

- o mapper de `comRegistro` descartava `itens_lidos`/`params` — **o comentário prometia auditoria durável que o mapper desfazia**;
- a leitura de `recommendation_config` também falhava ABERTO (defaults publicados como se fossem os pisos escolhidos);
- `carregarPedidosDoMes` aplicava a denylist sem o `deleted_at IS NULL` — é o caller do snapshot CONGELADO de positivação;
- o tipo da linha escondia o objeto embedado;
- `status` NULL encolheria o universo em silêncio → agora **conta e aborta a publicação**;
- harness com `|| true` (engolia typo de SQL), sem negativo de `customer` (uma policy `USING(true)` passaria), e sem prova de atomicidade;
- gate estrutural pinava só o NOME da constante — dava para apagar o `.not(…)` e manter um uso decorativo.

Fora de escopo, virou chip: o selo "⏱ Sequencial" continua sendo exibido para regras que não são sequenciais.

## ⚠️ ATENÇÃO: migration manual necessária

`supabase/migrations/20260820225840_farmer_assoc_rules_escritor_unico.sql` — **Lovable não aplica automaticamente**; mergear NÃO toca o banco.

## Ordem de cutover (a ordem importa)

1. **Fence primeiro** (SQL Editor) — sem ele, o próximo gestor que abrir a tela reescreve por cima.
2. **Deploy da edge** pelo chat do Lovable.
3. **Rodar** `compute_association_rules` — sem isto as 4 regras ruins ficam CONGELADAS: nem a migration nem o deploy substituem o lote.
4. **Verificar**: 2 regras, `sample_size` = 30.239, `rule_type = 'association'`.

## Coordenação com o #1836 — a união do §9, resolvida na prática

O #1836 (que nasceu de um chip aberto por esta mesma investigação) **mergeou enquanto este PR era escrito**, e os dois alargam **a mesma interface** `QueryPostgrest<T>` em `_shared/paginate.ts` com métodos diferentes: ele `limit(n)`, este `is(coluna, valor)`.

Rebaseei por cima e **o git não acusou conflito** — o que é justamente a armadilha do `docs/agent/money-path.md` §9: *rebase limpo não é prova de união*. Conferi explicitamente que os dois métodos e os stubs sobreviveram nos dois fakes existentes, e mesmo assim o `test:edges` reprovou: o #1836 **criou um terceiro fake** (`recommend-leituras_test.ts`) que implementa a interface e não conhecia o `is`. Sem rodar o gate, o PR iria vermelho no CI com a causa parecendo não ter relação com o diff.

⇒ Quem alargar `QueryPostgrest` daqui pra frente precisa alinhar **os três** doubles do `_shared`. Depois do alinhamento: `test:edges` 799 passed / 0 failed.
