### PR TITLE
fix(farmer): `clusterAdherence` dividia ocorrências GLOBAIS por clientes da CARTEIRA — 839 top-3 eram empate puro [money-path]

### DIFF
--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -743,3 +743,46 @@ encontram classes diferentes. O que ela pegou, tudo dentro do que eu tinha acaba
   gen_random_uuid()`, então os 100 menores UUIDs são amostra pseudoaleatória determinística, não
   prefixo temporal. O viés continua (mesmo subconjunto para todos, tamanho pequeno), mas **não é
   o viés que eu tinha escrito** — e a versão errada estava a caminho do PR.
+## O `clamp` não consertava a incoerência de universo — ESCONDIA, e 839 top-3 eram empate puro (2026-08-21)
+
+`clusterAdherence`, no cross-sell, dividia **ocorrências de item** (numerador contado no laço de
+itens de TODOS os pedidos da base) por **clientes da carteira** daquele farmer. Numerador global
+sobre denominador local: o quociente não é fração de nada — e o comentário da linha o chamava de
+`total customers who bought`. Um cliente que comprasse o mesmo SKU em 10 pedidos contava 10.
+
+**O `clamp(…, 0, 1)` é o vilão silencioso.** Ele não corrigia a incoerência: fazia todo SKU de
+volume alto saturar em 1,0. Com `assocBoost` 0, `relevance` dava 0,4 idêntico para todos os
+saturados, e o `sort` estável entregava o desempate à ordem de `.order('id')` do catálogo. Medido
+por simulação do motor sobre os 3 farmers (psql-ro): **839 dos 1.052 clientes tinham o top-3 inteiro
+em empate total de score**. A "recomendação" desses clientes era a ordem dos uuids.
+
+**Isso fechou um achado que outro PR deixou aberto.** O #1823 mediu em prod que 934 dos 939
+cross-sell vivos eram `oben` e descartou o gate de popularidade **por eliminação** ("234 × 233 SKUs
+acima do limiar"). A eliminação estava certa sobre a ADMISSÃO e cega para a SATURAÇÃO: a simulação
+da definição antiga reproduz 98,5% `oben`. O gate admitia os dois lados; o empate é que escolhia
+sempre o mesmo.
+
+Contando clientes distintos da carteira: empate 839 → **158**, e `colacor` 1,5% → **56,1%**
+(coerente com 71% dos vendáveis serem `colacor`). Volume de recomendação **idêntico** (3.156 =
+3.156) — o gate corta candidato de sobra, nunca os 3 do topo, então nenhum farmer seca.
+
+**Três lições que sobram:**
+
+1. **`clamp` sobre quociente é suspeito de esconder incoerência de unidade.** Um `clamp` que dispara
+   com frequência não está protegendo contra o caso raro — está mascarando que as duas pontas medem
+   universos diferentes. Sinal de saúde: com o numerador certo, o `clamp` fica **inerte** (0% de
+   saturação nos candidatos), e isso vira invariante testável.
+2. **Empate total num ranking não é neutro — ele transfere a decisão para a ordem de iteração.**
+   É a mesma patologia que o #1837 corrigiu no mesmo dia no ramo do up-sell (lá o `affinityScore` não
+   tinha NENHUM termo do produto candidato). Ranking cujo score empata é ranking que não existe.
+3. **"Zero empates" precisa ser medido no código REAL, não no modelo mental dele.** Eu afirmei
+   839 → 0; o `/codex challenge xhigh` apontou que `affinityScore` é arredondado a 4 casas **antes**
+   do `sort` e minha simulação ordenava pelo valor cru. O número honesto é 158 — 81% de redução, com
+   resíduo estrutural. A simulação tinha de replicar o arredondamento para valer como evidência.
+
+**Nota sobre escolher denominador quando o dado empata.** Testei "carteira ativa" contra "carteira
+com histórico utilizável": **indistinguíveis** hoje (empate 158, 56,1%, 241 SKUs no gate — iguais),
+porque a diferença é um fator uniforme por farmer e fator uniforme não muda ordem dentro do farmer.
+Empatadas no desfecho, ficou a que **falha melhor**: "com histórico" encolhe o denominador junto com
+a cobertura (1 cliente com histórico em 100 ativos daria 1/1 = 100%). O critério de desempate entre
+opções equivalentes é o modo de falha, não a elegância do argumento.

--- a/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
+++ b/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
@@ -9,28 +9,33 @@ import { renderHook, act } from '@testing-library/react';
  * pedidos da base: um cliente que compra o mesmo SKU em 10 pedidos contava 10. O denominador
  * (`totalCustomers`) é a carteira DAQUELE farmer. Nenhuma das duas pontas mede a mesma coisa,
  * então o quociente não é fração de nada — e o `clamp(…, 0, 1)` escondia a incoerência
- * saturando em 1.0 todo SKU de volume alto.
+ * saturando em 1,0 todo SKU de volume alto.
  *
- * O EFEITO não é acadêmico. Medido em produção (psql-ro, 20/08/2026), simulando o motor sobre
- * os 3 farmers com carteira ativa:
- *   · 829 dos 1.052 clientes tinham o top-3 inteiro em EMPATE TOTAL de score — os três SKUs
- *     saturados em `clusterAdherence = 1.0` e `assocBoost = 0` dão `relevance = 0.4` idêntico,
- *     então quem decidia a oferta era a ordem de `.order('id')` do catálogo, não o ranking.
- *   · 98,5% do top-3 caía numa única empresa do grupo (`oben`), contra 63,2% de `colacor`
- *     depois da correção — o mesmo viés que o #1823 mediu em prod (934 dos 939 cross-sell
- *     vivos `oben`) e atribuiu, por eliminação, a algo que não era o gate de popularidade.
- *     Era: não a ADMISSÃO no gate, mas a SATURAÇÃO que colapsa o ranking em empate.
+ * O EFEITO não é acadêmico. Medido em produção (psql-ro replicando o motor em SQL + simulação
+ * sobre os 3 farmers com carteira ativa, 20/08/2026):
+ *   · 839 dos 1.052 clientes tinham o top-3 inteiro em EMPATE TOTAL de `affinityScore` — três
+ *     SKUs saturados em 1,0 com `assocBoost` 0 dão `relevance` 0,4 idêntico, então quem
+ *     decidia a oferta era a ordem de `.order('id')` do catálogo, não o ranking. Depois: 158.
+ *     NÃO vai a zero, e o resíduo é honesto: `affinityScore` é arredondado a 4 casas ANTES do
+ *     `sort`, então SKUs de aderência próxima seguem colidindo.
+ *   · 98,5% do top-3 caía numa única empresa do grupo (`oben`), contra 56,1% de `colacor`
+ *     depois — o mesmo viés que o #1823 mediu em prod (934 dos 939 cross-sell vivos `oben`) e
+ *     atribuiu, por eliminação, a algo que não era o gate de popularidade. Era: não a ADMISSÃO
+ *     no gate, mas a SATURAÇÃO que colapsa o ranking em empate.
  *
- * A correção conta CLIENTES DISTINTOS DA CARTEIRA sobre CLIENTES DA CARTEIRA COM HISTÓRICO
- * UTILIZÁVEL — as duas pontas no mesmo universo, que é o universo do cálculo (o mesmo que os
- * insumos `clientes_com_profile` e `carteira_com_historico_utilizavel` já declaram medir).
+ * A correção conta CLIENTES DISTINTOS DA CARTEIRA sobre a CARTEIRA ATIVA. O denominador ficou
+ * o que já era: medido contra "carteira com histórico utilizável", os dois são indistinguíveis
+ * no dado de hoje, e a carteira ativa é imune ao caso em que a cobertura despenca (1 cliente
+ * com histórico em 100 ativos daria 1/1 = 100%).
  *
- * CENÁRIO discriminante — os dois candidatos passam o gate de 3% nas DUAS definições, então o
- * que este teste mede é a ORDEM, não a admissão:
+ * CENÁRIO discriminante — os candidatos passam o gate de 3% nas duas definições, então o que
+ * este teste mede é a ORDEM, não a admissão:
  *   · SKU_CONCENTRADO: 1 cliente comprando em 10 pedidos → 10 ocorrências, 1 cliente.
  *   · SKU_ESPALHADO:   3 clientes comprando 1 pedido cada →  3 ocorrências, 3 clientes.
- * Na definição velha o CONCENTRADO vence (10/6 → satura em 1,0 contra 0,5). Na correta ele
- * perde (1/6 = 0,167 contra 0,5). Adesão ampla é o que "aderência ao cluster" promete medir.
+ *   · SKU_ALHEIO:      5 clientes de FORA da carteira     →  5 ocorrências, 0 na carteira.
+ * Na definição velha o CONCENTRADO vence (10/7 satura em 1,0 contra 0,43) e o ALHEIO entra
+ * (5/7 = 0,71). Na correta o CONCENTRADO cai para 1/7 = 0,14 e o ALHEIO some — ele vale 0
+ * aqui, por mais vendido que seja na base.
  */
 const FARMER = 'farmer-1';
 const CONTA = 'oben';
@@ -42,10 +47,15 @@ const SKU_CONCENTRADO = 'sku-concentrado';
 const SKU_ESPALHADO = 'sku-espalhado';
 /** INATIVO: item que não resolve no catálogo ativo — dá pedido a `cli-7` sem dar histórico. */
 const SKU_INATIVO = 'sku-inativo';
+/** Comprado SÓ por clientes de FORA da carteira: o eixo carteira-vs-base. */
+const SKU_ALHEIO = 'sku-alheio';
 
 const CODIGO: Record<string, number> = {
-  [SKU_BASE]: 1, [SKU_CONCENTRADO]: 2, [SKU_ESPALHADO]: 3, [SKU_INATIVO]: 4,
+  [SKU_BASE]: 1, [SKU_CONCENTRADO]: 2, [SKU_ESPALHADO]: 3, [SKU_INATIVO]: 4, [SKU_ALHEIO]: 5,
 };
+
+/** Têm pedido na base e NÃO pertencem à carteira deste farmer. */
+const FORA_DA_CARTEIRA = ['ext-1', 'ext-2', 'ext-3', 'ext-4', 'ext-5'];
 
 const persistidas: Array<Record<string, unknown>> = [];
 
@@ -77,6 +87,7 @@ function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
       { id: SKU_BASE, codigo: 'B', descricao: 'Base', valor_unitario: 50, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 9, account: CONTA },
       { id: SKU_CONCENTRADO, codigo: 'C', descricao: 'Concentrado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 9, account: CONTA },
       { id: SKU_ESPALHADO, codigo: 'E', descricao: 'Espalhado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 3, estoque: 9, account: CONTA },
+      { id: SKU_ALHEIO, codigo: 'A', descricao: 'Alheio', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 5, estoque: 9, account: CONTA },
       // SKU_INATIVO fica FORA da lista de propósito: o motor lê `omie_products` com
       // `.eq('ativo', true)`, e este stub não aplica filtros — ausência do catálogo é como se
       // representa "inativo" aqui. O item de `cli-7` cai em `fora_do_catalogo_ativo`.
@@ -95,6 +106,10 @@ function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
       // `resolverItemNoCatalogo`. Ele conta na carteira ativa e não pode contar no
       // denominador da aderência — é o cliente que separa os dois candidatos a denominador.
       pedido('cli-7', SKU_INATIVO, 70),
+      // FORA DA CARTEIRA: cinco clientes da base, sem linha em `farmer_client_scores`, que
+      // compram o ALHEIO. Sob a definição antiga (numerador global) eles empurravam o SKU
+      // deles para dentro da oferta DESTE farmer; sob a nova, não têm voz nenhuma aqui.
+      ...FORA_DA_CARTEIRA.map((cid) => pedido(cid, SKU_ALHEIO, 100)),
     ],
     // Só o alvo tem perfil: `if (!profile) continue` restringe a GERAÇÃO a ele, enquanto os
     // outros cinco seguem contando no histórico e no denominador. Isola o observável.
@@ -141,7 +156,7 @@ vi.mock('@/integrations/supabase/client', () => ({
             return chain;
           },
           then: (resolve: (v: unknown) => void) => {
-            const todos = [{ product_id: SKU_CONCENTRADO }, { product_id: SKU_ESPALHADO }, { product_id: SKU_BASE }];
+            const todos = [{ product_id: SKU_CONCENTRADO }, { product_id: SKU_ESPALHADO }, { product_id: SKU_BASE }, { product_id: SKU_ALHEIO }];
             const c = chain as { _de?: number; _ate?: number };
             resolve({ data: todos.slice(c._de ?? 0, (c._ate ?? todos.length - 1) + 1), error: null });
           },
@@ -219,15 +234,30 @@ describe('useCrossSellEngine — `clusterAdherence` conta CLIENTES, não ocorrê
       .toBeLessThan(crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!.clusterVolume);
   });
 
-  it('D: o denominador é a carteira COM HISTÓRICO (6), não a carteira ativa (7)', async () => {
-    // `cli-7` tem pedido e nenhum histórico utilizável: ele jamais pode aparecer no numerador
-    // de SKU nenhum, então mantê-lo no denominador diluiria a fração por um universo incapaz
-    // de contribuir — o mesmo defeito de escala do bug, em grau menor.
+  it('D: o denominador é a carteira ATIVA (7), não só a carteira com histórico (6)', async () => {
+    // As duas foram medidas em prod e são INDISTINGUÍVEIS no dado de hoje — a diferença é um
+    // fator uniforme por farmer, e fator uniforme não muda ordem dentro do farmer. Empatadas,
+    // vale a que falha melhor: "com histórico" encolhe o denominador junto com a cobertura,
+    // então 1 cliente com histórico em 100 ativos daria 1/1 = 100%. A carteira ativa é imune.
     //
-    // O ESPALHADO tem 3 compradores. Sobre 6 (com histórico) dá 0,5 → `clusterVolume` 6;
-    // sobre 7 (carteira ativa) daria 0,4286 → 5. O valor EXATO é o que distingue os dois
-    // denominadores — uma asserção de ordem passaria com qualquer um dos dois.
+    // O ESPALHADO tem 3 compradores. Sobre 7 (ativa) dá 0,4286 → `clusterVolume` 5; sobre 6
+    // (com histórico) daria 0,5 → 6. O valor EXATO é o que distingue os dois denominadores —
+    // uma asserção de ordem passaria com qualquer um deles.
     const result = await rodar();
-    expect(crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!.clusterVolume).toBe(6);
+    expect(crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!.clusterVolume).toBe(5);
+  });
+
+  it('E: comprador de FORA da carteira não empurra SKU para dentro da oferta', async () => {
+    // O eixo que separa "aderência da CARTEIRA" de "popularidade da BASE". O ALHEIO tem 5
+    // compradores na base — mais que os 3 do ESPALHADO — e ZERO na carteira deste farmer.
+    // Com o numerador global ele seria o mais aderente de todos e lideraria a oferta; com o
+    // numerador da carteira ele não passa nem no gate de 3%, porque aqui ele vale 0.
+    //
+    // É a metade que faltava do teste B: lá o numerador errado contava DEMAIS o mesmo
+    // cliente; aqui ele contaria clientes que não são deste farmer.
+    const result = await rodar();
+    expect(idsRecomendados(result)).not.toContain(SKU_ALHEIO);
+    // E o controle: os candidatos legítimos seguem lá — o corte foi do alheio, não geral.
+    expect(idsRecomendados(result)).toContain(SKU_ESPALHADO);
   });
 });

--- a/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
+++ b/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
@@ -40,15 +40,25 @@ const SKU_BASE = 'sku-base';
 const SKU_CONCENTRADO = 'sku-concentrado';
 /** Comprado por TRÊS clientes, uma vez cada: volume baixo, adesão ampla. */
 const SKU_ESPALHADO = 'sku-espalhado';
+/** INATIVO: item que não resolve no catálogo ativo — dá pedido a `cli-7` sem dar histórico. */
+const SKU_INATIVO = 'sku-inativo';
+
+const CODIGO: Record<string, number> = {
+  [SKU_BASE]: 1, [SKU_CONCENTRADO]: 2, [SKU_ESPALHADO]: 3, [SKU_INATIVO]: 4,
+};
 
 const persistidas: Array<Record<string, unknown>> = [];
 
-/** Carteira: o alvo + 5 que formam o histórico. Todos com pedido ⇒ `totalCustomers` = 6. */
-const CARTEIRA = ['cli-1', 'cli-2', 'cli-3', 'cli-4', 'cli-5', 'cli-6'];
+/**
+ * Carteira de SETE. Todos têm pedido (⇒ a carteira ATIVA é 7), mas `cli-7` só comprou SKU
+ * inativo, então o histórico UTILIZÁVEL é 6. É essa diferença que torna a escolha do
+ * denominador observável — sem ela o teste passaria com qualquer um dos dois.
+ */
+const CARTEIRA = ['cli-1', 'cli-2', 'cli-3', 'cli-4', 'cli-5', 'cli-6', 'cli-7'];
 
 const pedido = (cid: string, sku: string, preco: number) => ({
   customer_user_id: cid,
-  items: [{ omie_codigo_produto: sku === SKU_BASE ? 1 : sku === SKU_CONCENTRADO ? 2 : 3, quantity: 1, unit_price: preco }],
+  items: [{ omie_codigo_produto: CODIGO[sku], quantity: 1, unit_price: preco }],
   total: preco,
   created_at: '2026-01-01T00:00:00Z',
   account: CONTA,
@@ -67,6 +77,9 @@ function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
       { id: SKU_BASE, codigo: 'B', descricao: 'Base', valor_unitario: 50, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 9, account: CONTA },
       { id: SKU_CONCENTRADO, codigo: 'C', descricao: 'Concentrado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 9, account: CONTA },
       { id: SKU_ESPALHADO, codigo: 'E', descricao: 'Espalhado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 3, estoque: 9, account: CONTA },
+      // SKU_INATIVO fica FORA da lista de propósito: o motor lê `omie_products` com
+      // `.eq('ativo', true)`, e este stub não aplica filtros — ausência do catálogo é como se
+      // representa "inativo" aqui. O item de `cli-7` cai em `fora_do_catalogo_ativo`.
     ],
     sales_orders: [
       // O alvo: tem pedido (entra na carteira ativa) e comprou só o base, então os DOIS
@@ -78,6 +91,10 @@ function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
       ...['cli-3', 'cli-4', 'cli-5'].map((cid) => pedido(cid, SKU_ESPALHADO, 100)),
       // cli-6 só o base: histórico utilizável, sem tocar em nenhum dos candidatos.
       pedido('cli-6', SKU_BASE, 50),
+      // cli-7 tem PEDIDO mas não tem HISTÓRICO: o item é de SKU inativo, descartado por
+      // `resolverItemNoCatalogo`. Ele conta na carteira ativa e não pode contar no
+      // denominador da aderência — é o cliente que separa os dois candidatos a denominador.
+      pedido('cli-7', SKU_INATIVO, 70),
     ],
     // Só o alvo tem perfil: `if (!profile) continue` restringe a GERAÇÃO a ele, enquanto os
     // outros cinco seguem contando no histórico e no denominador. Isola o observável.
@@ -200,5 +217,17 @@ describe('useCrossSellEngine — `clusterAdherence` conta CLIENTES, não ocorrê
     }
     expect(crossSellDe(result).find((r) => r.productId === SKU_CONCENTRADO)!.clusterVolume)
       .toBeLessThan(crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!.clusterVolume);
+  });
+
+  it('D: o denominador é a carteira COM HISTÓRICO (6), não a carteira ativa (7)', async () => {
+    // `cli-7` tem pedido e nenhum histórico utilizável: ele jamais pode aparecer no numerador
+    // de SKU nenhum, então mantê-lo no denominador diluiria a fração por um universo incapaz
+    // de contribuir — o mesmo defeito de escala do bug, em grau menor.
+    //
+    // O ESPALHADO tem 3 compradores. Sobre 6 (com histórico) dá 0,5 → `clusterVolume` 6;
+    // sobre 7 (carteira ativa) daria 0,4286 → 5. O valor EXATO é o que distingue os dois
+    // denominadores — uma asserção de ordem passaria com qualquer um dos dois.
+    const result = await rodar();
+    expect(crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!.clusterVolume).toBe(6);
   });
 });

--- a/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
+++ b/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * `clusterAdherence` dividia OCORRÊNCIAS DE ITEM (universo global) por CLIENTES DA CARTEIRA
+ * (universo local) — e o comentário do código chamava o resultado de fração de clientes.
+ *
+ * O numerador (`allProductPurchases`) era incrementado DENTRO do laço de itens de TODOS os
+ * pedidos da base: um cliente que compra o mesmo SKU em 10 pedidos contava 10. O denominador
+ * (`totalCustomers`) é a carteira DAQUELE farmer. Nenhuma das duas pontas mede a mesma coisa,
+ * então o quociente não é fração de nada — e o `clamp(…, 0, 1)` escondia a incoerência
+ * saturando em 1.0 todo SKU de volume alto.
+ *
+ * O EFEITO não é acadêmico. Medido em produção (psql-ro, 20/08/2026), simulando o motor sobre
+ * os 3 farmers com carteira ativa:
+ *   · 829 dos 1.052 clientes tinham o top-3 inteiro em EMPATE TOTAL de score — os três SKUs
+ *     saturados em `clusterAdherence = 1.0` e `assocBoost = 0` dão `relevance = 0.4` idêntico,
+ *     então quem decidia a oferta era a ordem de `.order('id')` do catálogo, não o ranking.
+ *   · 98,5% do top-3 caía numa única empresa do grupo (`oben`), contra 63,2% de `colacor`
+ *     depois da correção — o mesmo viés que o #1823 mediu em prod (934 dos 939 cross-sell
+ *     vivos `oben`) e atribuiu, por eliminação, a algo que não era o gate de popularidade.
+ *     Era: não a ADMISSÃO no gate, mas a SATURAÇÃO que colapsa o ranking em empate.
+ *
+ * A correção conta CLIENTES DISTINTOS DA CARTEIRA sobre CLIENTES DA CARTEIRA COM HISTÓRICO
+ * UTILIZÁVEL — as duas pontas no mesmo universo, que é o universo do cálculo (o mesmo que os
+ * insumos `clientes_com_profile` e `carteira_com_historico_utilizavel` já declaram medir).
+ *
+ * CENÁRIO discriminante — os dois candidatos passam o gate de 3% nas DUAS definições, então o
+ * que este teste mede é a ORDEM, não a admissão:
+ *   · SKU_CONCENTRADO: 1 cliente comprando em 10 pedidos → 10 ocorrências, 1 cliente.
+ *   · SKU_ESPALHADO:   3 clientes comprando 1 pedido cada →  3 ocorrências, 3 clientes.
+ * Na definição velha o CONCENTRADO vence (10/6 → satura em 1,0 contra 0,5). Na correta ele
+ * perde (1/6 = 0,167 contra 0,5). Adesão ampla é o que "aderência ao cluster" promete medir.
+ */
+const FARMER = 'farmer-1';
+const CONTA = 'oben';
+
+const SKU_BASE = 'sku-base';
+/** Comprado por UM cliente em 10 pedidos: volume alto, adesão mínima. */
+const SKU_CONCENTRADO = 'sku-concentrado';
+/** Comprado por TRÊS clientes, uma vez cada: volume baixo, adesão ampla. */
+const SKU_ESPALHADO = 'sku-espalhado';
+
+const persistidas: Array<Record<string, unknown>> = [];
+
+/** Carteira: o alvo + 5 que formam o histórico. Todos com pedido ⇒ `totalCustomers` = 6. */
+const CARTEIRA = ['cli-1', 'cli-2', 'cli-3', 'cli-4', 'cli-5', 'cli-6'];
+
+const pedido = (cid: string, sku: string, preco: number) => ({
+  customer_user_id: cid,
+  items: [{ omie_codigo_produto: sku === SKU_BASE ? 1 : sku === SKU_CONCENTRADO ? 2 : 3, quantity: 1, unit_price: preco }],
+  total: preco,
+  created_at: '2026-01-01T00:00:00Z',
+  account: CONTA,
+});
+
+function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
+  return {
+    farmer_client_scores: CARTEIRA.map((cid) => ({
+      customer_user_id: cid,
+      farmer_id: FARMER,
+      health_score: 80,
+      answer_rate_60d: 50,
+      whatsapp_reply_rate_60d: 50,
+    })),
+    omie_products: [
+      { id: SKU_BASE, codigo: 'B', descricao: 'Base', valor_unitario: 50, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 9, account: CONTA },
+      { id: SKU_CONCENTRADO, codigo: 'C', descricao: 'Concentrado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 9, account: CONTA },
+      { id: SKU_ESPALHADO, codigo: 'E', descricao: 'Espalhado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 3, estoque: 9, account: CONTA },
+    ],
+    sales_orders: [
+      // O alvo: tem pedido (entra na carteira ativa) e comprou só o base, então os DOIS
+      // candidatos estão disponíveis para ele — é o que torna a ordem observável.
+      pedido('cli-1', SKU_BASE, 50),
+      // cli-2 compra o CONCENTRADO dez vezes: 10 ocorrências vindas de UM cliente só.
+      ...Array.from({ length: 10 }, () => pedido('cli-2', SKU_CONCENTRADO, 100)),
+      // cli-3/4/5 compram o ESPALHADO uma vez cada: 3 ocorrências de TRÊS clientes.
+      ...['cli-3', 'cli-4', 'cli-5'].map((cid) => pedido(cid, SKU_ESPALHADO, 100)),
+      // cli-6 só o base: histórico utilizável, sem tocar em nenhum dos candidatos.
+      pedido('cli-6', SKU_BASE, 50),
+    ],
+    // Só o alvo tem perfil: `if (!profile) continue` restringe a GERAÇÃO a ele, enquanto os
+    // outros cinco seguem contando no histórico e no denominador. Isola o observável.
+    profiles: [{ user_id: 'cli-1', name: 'Cliente 1', customer_type: 'industria', cnae: '2222' }],
+    farmer_category_conversion: [],
+    // Vazio de propósito: sem `assocBoost`, `relevance` é `clusterAdherence * 0.4` puro, e a
+    // ordem observada mede a aderência sozinha.
+    farmer_association_rules: [],
+    farmer_recommendations: [],
+    farmer_geracao_vigente: [],
+  };
+}
+
+function stubChain(tabela: string): unknown {
+  const dados = linhasPorTabela()[tabela] ?? [];
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit', 'range', 'or', 'neq', 'filter', 'contains']) {
+    chain[m] = () => chain;
+  }
+  chain.single = () => ({ then: (r: (v: unknown) => void) => r({ data: dados[0] ?? null, error: null }) });
+  chain.maybeSingle = chain.single;
+  chain.insert = () => chain;
+  chain.upsert = () => chain;
+  chain.update = () => chain;
+  chain.delete = () => chain;
+  chain.then = (resolve: (v: unknown) => void) => resolve({ data: dados, error: null, count: dados.length });
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (tabela: string) => stubChain(tabela),
+    rpc: (nome: string, args?: Record<string, unknown>) => {
+      if (nome === 'farmer_recomendacoes_substituir') persistidas.push(args ?? {});
+
+      if (nome === 'get_skus_margem_positiva') {
+        // Builder com `.order()`/`.range()`, nunca Promise crua (#1782/#1798). Os dois
+        // candidatos são vendáveis: o custo não separa nada aqui, só a aderência separa.
+        const chain: Record<string, unknown> = {
+          order: () => chain,
+          range: (de: number, ate: number) => {
+            (chain as { _de?: number; _ate?: number })._de = de;
+            (chain as { _de?: number; _ate?: number })._ate = ate;
+            return chain;
+          },
+          then: (resolve: (v: unknown) => void) => {
+            const todos = [{ product_id: SKU_CONCENTRADO }, { product_id: SKU_ESPALHADO }, { product_id: SKU_BASE }];
+            const c = chain as { _de?: number; _ate?: number };
+            resolve({ data: todos.slice(c._de ?? 0, (c._ate ?? todos.length - 1) + 1), error: null });
+          },
+        };
+        return chain;
+      }
+      return { then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }) };
+    },
+  },
+}));
+
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: FARMER }, isStaff: true }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import { useCrossSellEngine } from '../useCrossSellEngine';
+
+type Rec = { productId: string; clusterVolume: number; affinityScore: number };
+type ResultadoCrossSell = { current: { recommendations: Array<{ crossSell: Rec[] }> } };
+
+const rodar = async () => {
+  const { result } = renderHook(() => useCrossSellEngine());
+  await act(async () => { await result.current.calculateRecommendations(); });
+  return result as unknown as ResultadoCrossSell;
+};
+
+const crossSellDe = (r: ResultadoCrossSell) => r.current.recommendations.flatMap((c) => c.crossSell);
+const idsRecomendados = (r: ResultadoCrossSell) => crossSellDe(r).map((x) => x.productId);
+
+beforeEach(() => {
+  persistidas.length = 0;
+  vi.clearAllMocks();
+});
+
+describe('useCrossSellEngine — `clusterAdherence` conta CLIENTES, não ocorrências de item', () => {
+  it('A (controle positivo): a fixture produz cross-sell com os DOIS candidatos', async () => {
+    // Sem isto, os testes B/C passariam de graça: "o concentrado não vem primeiro" é o
+    // desfecho trivial de um motor que não recomenda nada. Aqui os dois candidatos PRECISAM
+    // estar na oferta — o que a correção move é a ordem entre eles, não a existência.
+    const result = await rodar();
+    const ids = idsRecomendados(result);
+    expect(ids).toContain(SKU_ESPALHADO);
+    expect(ids).toContain(SKU_CONCENTRADO);
+    expect(persistidas.length).toBeGreaterThan(0);
+  });
+
+  it('B: 3 clientes distintos superam 1 cliente que repetiu 10 vezes', async () => {
+    // O coração do bug. Com o numerador em ocorrências, o CONCENTRADO fazia 10/6 = 1,67 →
+    // clamp 1,0, contra 0,5 do ESPALHADO, e vencia. Contando clientes ele faz 1/6 = 0,167 e
+    // perde — que é o que "quantos clientes parecidos compraram isto" sempre quis dizer.
+    const result = await rodar();
+    const ordem = idsRecomendados(result);
+    expect(ordem[0]).toBe(SKU_ESPALHADO);
+    expect(ordem.indexOf(SKU_ESPALHADO)).toBeLessThan(ordem.indexOf(SKU_CONCENTRADO));
+
+    const espalhado = crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!;
+    const concentrado = crossSellDe(result).find((r) => r.productId === SKU_CONCENTRADO)!;
+    expect(espalhado.affinityScore).toBeGreaterThan(concentrado.affinityScore);
+  });
+
+  it('C: a aderência é fração de verdade — `clamp` fica INERTE, e `clusterVolume` não estoura 12', async () => {
+    // `clusterVolume = max(1, round(adesão * 12))` é o observável que expõe o valor ANTES do
+    // clamp: com o numerador inflado ele marcava round(10/6*12) = 20 — "20 dos 6 clientes do
+    // cluster compram isto", um número que a carteira não comporta. Contando clientes, o
+    // quociente é ≤ 1 por construção (o numerador é subconjunto do denominador), então 12 é
+    // o teto estrutural. É este invariante que torna o `clamp` uma rede, não um disfarce.
+    const result = await rodar();
+    for (const rec of crossSellDe(result)) {
+      expect(rec.clusterVolume).toBeLessThanOrEqual(12);
+    }
+    expect(crossSellDe(result).find((r) => r.productId === SKU_CONCENTRADO)!.clusterVolume)
+      .toBeLessThan(crossSellDe(result).find((r) => r.productId === SKU_ESPALHADO)!.clusterVolume);
+  });
+});

--- a/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
+++ b/src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx
@@ -260,4 +260,21 @@ describe('useCrossSellEngine — `clusterAdherence` conta CLIENTES, não ocorrê
     // E o controle: os candidatos legítimos seguem lá — o corte foi do alheio, não geral.
     expect(idsRecomendados(result)).toContain(SKU_ESPALHADO);
   });
+
+  it('F: o valor corrigido CHEGA ao banco — `cluster_volume_estimate` do payload persistido', async () => {
+    // A correção só vale se sobreviver até a persistência: `cluster_volume_estimate` é coluna
+    // de `farmer_recommendations`, não número de tela. Com o numerador em ocorrências o
+    // CONCENTRADO gravava round(10/7*12) = 17; contando clientes grava round(1/7*12) = 2.
+    // Sem esta asserção, o payload poderia seguir carregando o número velho sem ninguém ver.
+    const result = await rodar();
+    const linhas = (persistidas[0]?.p_linhas ?? []) as Array<{
+      product_id: string; recommendation_type: string; cluster_volume_estimate: number;
+    }>;
+    const cross = linhas.filter((l) => l.recommendation_type === 'cross_sell');
+    expect(cross.length).toBeGreaterThan(0);
+    const concentrado = cross.find((l) => l.product_id === SKU_CONCENTRADO);
+    expect(concentrado?.cluster_volume_estimate).toBe(2);
+    // E o que a tela mostra é o MESMO que foi gravado — nenhum dos dois inventa o seu próprio.
+    expect(crossSellDe(result).find((r) => r.productId === SKU_CONCENTRADO)!.clusterVolume).toBe(2);
+  });
 });

--- a/src/hooks/__tests__/cross-sell-conta-da-oferta.test.tsx
+++ b/src/hooks/__tests__/cross-sell-conta-da-oferta.test.tsx
@@ -54,8 +54,15 @@ const pedidosDoAlvo = () => [
 
 function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
   return {
+    // Os clientes que dão POPULARIDADE entram na carteira. `clusterAdherence` passou a contar
+    // clientes DA CARTEIRA (não ocorrências na base inteira), então comprador de fora não
+    // promove SKU nenhum aqui — e sem eles na carteira os dois alvos não teriam aderência.
+    // Só `cli-1` tem `profiles`, então a GERAÇÃO segue restrita a ele.
     farmer_client_scores: [
       { customer_user_id: 'cli-1', farmer_id: FARMER, health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50 },
+      ...CLIENTES_POPULARIDADE.map((cid) => ({
+        customer_user_id: cid, farmer_id: FARMER, health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50,
+      })),
     ],
     omie_products: [
       { id: SKU_BASE, codigo: 'B', descricao: 'Base Colacor', valor_unitario: 50, metadata: null, familia: 'Linha Unica', unidade: 'UN', ativo: true, omie_codigo_produto: 1, estoque: 9, account: 'colacor' },

--- a/src/hooks/__tests__/cross-sell-identidade-account.test.tsx
+++ b/src/hooks/__tests__/cross-sell-identidade-account.test.tsx
@@ -54,8 +54,16 @@ const itensDoPedido = () => [
 
 function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
   return {
+    // A carteira inclui os 5 clientes que FORMAM o histórico, não só o alvo. Desde que
+    // `clusterAdherence` conta clientes DA CARTEIRA (e não ocorrências na base inteira), um
+    // comprador fora da carteira não empurra SKU nenhum para dentro da oferta deste farmer —
+    // então a popularidade que este teste usa como veículo precisa nascer DENTRO dela.
+    // Só `cli-1` tem `profiles`, então a GERAÇÃO segue restrita a ele: o observável não muda.
     farmer_client_scores: [
       { customer_user_id: 'cli-1', farmer_id: FARMER, health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50 },
+      ...CLIENTES_COM_PEDIDO.map((cid) => ({
+        customer_user_id: cid, farmer_id: FARMER, health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50,
+      })),
     ],
     omie_products: [
       { id: SKU_BASE, codigo: 'B', descricao: 'Base', valor_unitario: 50, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 9, account: CONTA },

--- a/src/hooks/__tests__/cross-sell-universo-pedidos.test.tsx
+++ b/src/hooks/__tests__/cross-sell-universo-pedidos.test.tsx
@@ -54,16 +54,14 @@ const pedido = (
  * em `separacao`. Sob a allowlist antiga ele não existia para o motor — é a miniatura dos +319
  * clientes que a denylist devolve ao universo em produção (754 → 1.073).
  */
-// `cli-2`..`cli-5` entram na carteira porque são eles que dão POPULARIDADE ao SKU_POPULAR, e
-// `clusterAdherence` passou a contar clientes DA CARTEIRA — comprador de fora já não promove
-// SKU nenhum. Os NEGATIVOS (`cli-6` cancelado, `cli-7` deletado, `cli-8` status nulo) ficam de
-// FORA da carteira de propósito: se a exclusão deles falhasse, seria por entrarem no universo
-// de PEDIDOS, que é o que este arquivo mede — pô-los na carteira embaralharia os dois eixos.
-// Só `cli-1` tem `profiles`, então a GERAÇÃO segue restrita a ele.
-const CARTEIRA = ['cli-1', 'cli-9', 'cli-2', 'cli-3', 'cli-4', 'cli-5'];
+const CARTEIRA = ['cli-1', 'cli-9'];
 const PEDIDOS = [
   pedido('cli-1', [SKU_BASE], 'faturado'), // alvo clássico: comprou só a base
-  pedido('cli-9', [SKU_BASE], 'separacao'), // ← na carteira, invisível sob a allowlist
+  // `cli-9` carrega TAMBÉM o SKU_POPULAR. Desde que `clusterAdherence` conta clientes DA
+  // CARTEIRA (e não ocorrências na base inteira), a popularidade que vira oferta precisa
+  // nascer DENTRO da carteira — e pôr o popular justamente no cliente cujo único pedido é
+  // `separacao` aperta o teste: a oferta de D só existe se este pedido entrar no universo.
+  pedido('cli-9', [SKU_BASE, SKU_POPULAR], 'separacao'), // ← na carteira, invisível sob a allowlist
   pedido('cli-2', [SKU_BASE, SKU_POPULAR], 'separacao'), // ← só entra com a denylist
   pedido('cli-3', [SKU_BASE, SKU_POPULAR], 'importado'), // ← só entra com a denylist
   pedido('cli-4', [SKU_BASE, SKU_POPULAR], 'enviado'), // ← só entra com a denylist

--- a/src/hooks/__tests__/cross-sell-universo-pedidos.test.tsx
+++ b/src/hooks/__tests__/cross-sell-universo-pedidos.test.tsx
@@ -54,7 +54,13 @@ const pedido = (
  * em `separacao`. Sob a allowlist antiga ele não existia para o motor — é a miniatura dos +319
  * clientes que a denylist devolve ao universo em produção (754 → 1.073).
  */
-const CARTEIRA = ['cli-1', 'cli-9'];
+// `cli-2`..`cli-5` entram na carteira porque são eles que dão POPULARIDADE ao SKU_POPULAR, e
+// `clusterAdherence` passou a contar clientes DA CARTEIRA — comprador de fora já não promove
+// SKU nenhum. Os NEGATIVOS (`cli-6` cancelado, `cli-7` deletado, `cli-8` status nulo) ficam de
+// FORA da carteira de propósito: se a exclusão deles falhasse, seria por entrarem no universo
+// de PEDIDOS, que é o que este arquivo mede — pô-los na carteira embaralharia os dois eixos.
+// Só `cli-1` tem `profiles`, então a GERAÇÃO segue restrita a ele.
+const CARTEIRA = ['cli-1', 'cli-9', 'cli-2', 'cli-3', 'cli-4', 'cli-5'];
 const PEDIDOS = [
   pedido('cli-1', [SKU_BASE], 'faturado'), // alvo clássico: comprou só a base
   pedido('cli-9', [SKU_BASE], 'separacao'), // ← na carteira, invisível sob a allowlist

--- a/src/hooks/__tests__/cross-sell-up-sell-ordem.test.tsx
+++ b/src/hooks/__tests__/cross-sell-up-sell-ordem.test.tsx
@@ -136,24 +136,32 @@ const vendaveis = (): string[] => {
 /** Clientes que só existem para dar popularidade — nenhum deles é `cli-1`. */
 const CLIENTES_POPULARIDADE = ['cli-2', 'cli-3', 'cli-4', 'cli-5', 'cli-6'];
 
-function itensDePopularidade(): Array<Record<string, unknown>> {
+function itensDePopularidade(indiceDoCliente: number): Array<Record<string, unknown>> {
   return vendaveis().flatMap((id) => {
-    // `allProductPurchases` conta OCORRÊNCIA de item: repetir a linha dobra a popularidade.
-    // Fora do cenário `popularidade` todos ficam iguais, para que a popularidade nunca seja
-    // o que decide onde o teste afirma que quem decide é o preço.
-    const vezes = cenario === 'popularidade' && id === 'sku-pop-alta' ? 2 : 1;
-    return Array.from({ length: vezes }, () => ({
-      omie_codigo_produto: CODIGO[id],
-      quantity: 1,
-      unit_price: 100,
-    }));
+    // A popularidade conta CLIENTES DISTINTOS da carteira, então quem a move é o número de
+    // clientes que compram — não a repetição da linha (repetir contava OCORRÊNCIA, e essa
+    // definição saiu). No cenário `popularidade`, `sku-pop-baixa` é comprado só pelos 2
+    // primeiros clientes e `sku-pop-alta` por todos os 5.
+    //
+    // Fora desse cenário todos ficam iguais, para que a popularidade nunca seja o que decide
+    // onde o teste afirma que quem decide é o preço.
+    const soOsDoisPrimeiros = cenario === 'popularidade' && id === 'sku-pop-baixa';
+    if (soOsDoisPrimeiros && indiceDoCliente >= 2) return [];
+    return [{ omie_codigo_produto: CODIGO[id], quantity: 1, unit_price: 100 }];
   });
 }
 
 function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
   return {
+    // Quem dá POPULARIDADE precisa estar na CARTEIRA: a métrica passou a contar clientes
+    // distintos da carteira (antes eram ocorrências de item na base inteira), então comprador
+    // de fora não pontua mais. Só `cli-1` tem `profiles`, então a GERAÇÃO segue restrita a ele
+    // e o observável destes testes — o top-2 de up-sell do alvo — não muda.
     farmer_client_scores: [
       { customer_user_id: 'cli-1', farmer_id: FARMER, health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50 },
+      ...CLIENTES_POPULARIDADE.map((cid) => ({
+        customer_user_id: cid, farmer_id: FARMER, health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50,
+      })),
     ],
     omie_products: catalogo(),
     sales_orders: [
@@ -164,9 +172,9 @@ function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
         created_at: '2026-01-01T00:00:00Z',
         account: 'colacor',
       },
-      ...CLIENTES_POPULARIDADE.map((cid) => ({
+      ...CLIENTES_POPULARIDADE.map((cid, i) => ({
         customer_user_id: cid,
-        items: itensDePopularidade(),
+        items: itensDePopularidade(i),
         total: 999,
         created_at: '2026-01-01T00:00:00Z',
         account: 'colacor',
@@ -318,8 +326,8 @@ describe('useCrossSellEngine — o top-2 do up-sell sai de SINAL, não da ordem 
 
   it('E: a POPULARIDADE desempata preços iguais — a 2ª chave não é decorativa', async () => {
     // Sem este caso a 2ª chave estaria escrita e nunca exercida: as duas fixtures de preço
-    // acima têm popularidade uniforme. `sku-pop-baixa` (5 ocorrências) vem ANTES de
-    // `sku-pop-alta` (10) no `productList` e tem o MESMO preço, então a ordem de `id` daria
+    // acima têm popularidade uniforme. `sku-pop-baixa` (2 clientes da carteira) vem ANTES de
+    // `sku-pop-alta` (5) no `productList` e tem o MESMO preço, então a ordem de `id` daria
     // a resposta errada e só a popularidade pode dar a certa.
     cenario = 'popularidade';
     const up = await rodar();

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -56,6 +56,16 @@ export interface Recommendation {
    */
   affinityScore: number;
   complexityFactor: number;
+  /**
+   * `round(clusterAdherence × 12)` no cross-sell — uma REESCALA da fração de clientes do
+   * cluster que compraram o SKU. NÃO é frequência: não há janela temporal, ocorrência nem
+   * quantidade na fórmula. (A UI dizia "N× /mês no cluster"; o rótulo foi corrigido.)
+   *
+   * ⚠️ Pendência declarada (achado /codex xhigh): o campo carrega DUAS semânticas — aqui a
+   * fração reescalada, e no up-sell a QUANTIDADE histórica comprada (`purchaseData.qty`).
+   * Ambas caem na mesma coluna `cluster_volume_estimate`. Separar isso é mudança de contrato
+   * de dado, fora do escopo da correção da aderência.
+   */
   clusterVolume: number;
   estoque: number | null; // Stock quantity from omie_products
   status: 'pendente' | 'ofertado' | 'aceito' | 'rejeitado' | 'expirado';
@@ -643,40 +653,50 @@ export const useCrossSellEngine = () => {
         esperado: itensResolvidos + itensContaDivergente,
       };
 
-      // ADERÊNCIA AO CLUSTER — as duas pontas no MESMO universo, que é a carteira do cálculo.
+      // ADERÊNCIA AO CLUSTER — quantos CLIENTES compraram, não quantas vezes foi comprado.
       //
       // O que havia aqui dividia OCORRÊNCIAS DE ITEM (contadas dentro do laço de itens de
       // TODOS os pedidos da base, universo global) por `customerIds.length` (a carteira DESTE
       // farmer, universo local). Um cliente que comprasse o mesmo SKU em 10 pedidos contava
       // 10, e o quociente não era fração de coisa nenhuma — embora o comentário da linha o
-      // chamasse de "total customers who bought". O `clamp(…, 0, 1)` não corrigia: ele
-      // ESCONDIA, saturando em 1,0 todo SKU de volume alto.
+      // chamasse de "total customers who bought". O `clamp(…, 0, 1)` não corrigia: ESCONDIA,
+      // saturando em 1,0 todo SKU de volume alto.
       //
-      // O estrago é de RANKING, e foi medido antes de escolher (psql-ro + simulação do motor
-      // sobre os 3 farmers com carteira ativa, 20/08/2026):
-      //   · 829 dos 1.052 clientes tinham o top-3 em EMPATE TOTAL de score — três SKUs
-      //     saturados em 1,0 com `assocBoost` 0 dão `relevance` 0,4 idêntico, e quem escolhia
-      //     a oferta era a ordem de `.order('id')` do catálogo. Depois: ZERO empates.
-      //   · 98,5% do top-3 caía em `oben` contra 1,5% `colacor`; depois, 63,2% `colacor` —
-      //     coerente com a disponibilidade (71% dos vendáveis são `colacor`). É o mesmo viés
-      //     que o #1823 mediu em prod (934 dos 939 cross-sell vivos `oben`) e descartou como
-      //     "não é o gate de popularidade": não era a ADMISSÃO no gate, era a SATURAÇÃO.
+      // O estrago é de RANKING, e foi medido antes de escolher (psql-ro replicando o motor em
+      // SQL + simulação sobre os 3 farmers com carteira ativa — 526/432/269, 20/08/2026):
+      //   · 839 dos 1.052 clientes tinham o top-3 em EMPATE TOTAL de `affinityScore` — três
+      //     SKUs saturados em 1,0 com `assocBoost` 0 dão `relevance` 0,4 idêntico, e quem
+      //     escolhia a oferta era a ordem de `.order('id')` do catálogo. Depois: 158. NÃO vai
+      //     a zero, e o resíduo é real: `affinityScore` é arredondado a 4 casas ANTES do
+      //     `sort` (linha ~769), então SKUs de aderência próxima seguem colidindo.
+      //   · 98,5% do top-3 caía em `oben` contra 1,5% `colacor`; depois, 56,1% `colacor`. É o
+      //     mesmo viés que o #1823 mediu em prod (934 dos 939 cross-sell vivos `oben`) e
+      //     descartou como "não é o gate de popularidade": não era a ADMISSÃO no gate, era a
+      //     SATURAÇÃO que colapsa o ranking em empate e entrega o desempate à ordem do id.
       //   · A inflação é ANTI-correlacionada com o tamanho da carteira (numerador global sobre
       //     denominador local): o farmer de 269 clientes tinha 587 SKUs acima do gate de 3%,
       //     224 deles SEM UM ÚNICO comprador na própria carteira.
       //
-      // A alternativa era global nas duas pontas (clientes distintos da BASE ÷ 1.073 clientes
-      // com histórico). Ela também conserta a escala, mas foi DESCARTADA pelo dado: produz o
-      // mesmo conjunto de 80 SKUs para os três farmers — um termo que não distingue carteira
-      // nenhuma, o oposto do que "aderência do CLUSTER" promete. A local varia (112/103/26) e
-      // é o universo que o resto do arquivo já declara medir (`clientes_com_profile`,
-      // `carteira_com_historico_utilizavel`).
+      // POR QUE A CARTEIRA E NÃO A BASE INTEIRA. A alternativa (clientes distintos da BASE ÷
+      // 1.073 com histórico) também conserta a escala e chega perto: 198 empates, 59,8%
+      // `colacor`. Duas coisas decidiram pela carteira: as carteiras NÃO são intercambiáveis
+      // (Spearman 0,47–0,49 entre os rankings de adesão das três — se fossem, seria ~0,9), e
+      // precisão > recall — na dúvida, não ofertar o SKU que a carteira nunca comprou. O custo
+      // é declarado: 1.318 dos 1.964 SKUs comprados na base não têm comprador na carteira
+      // menor, e essa evidência é descartada de propósito. Em prod nada se PERDE, só se
+      // particiona: 481+381+211 = 1.073 = exatamente os clientes com histórico da base.
       //
-      // Custo do aperto, medido: NENHUM. O volume de recomendação é idêntico (3.156 = 3.156):
-      // o gate corta candidato de sobra, nunca os 3 do topo — nenhum farmer seca. O que muda é
-      // a ORDEM (top-3 diferente em 1.026 dos 1.052 clientes; top-1 em 532) e o equilíbrio com
-      // o `assocBoost`, que sai de decidir 1,0% dos topos para 12,8% — ele é o ÚNICO termo
-      // personalizado por cliente, e estava afogado pela saturação.
+      // Custo do aperto, medido: NENHUM em volume. As recomendações são as mesmas 3.156 — o
+      // gate corta candidato de sobra, nunca os 3 do topo, e nenhum farmer seca. O que muda é
+      // a ORDEM e o equilíbrio com o `assocBoost`, que sai de decidir 1,0% dos topos para
+      // 12,8% — ele é o ÚNICO termo personalizado por cliente, e estava afogado pela saturação.
+      //
+      // ⚠️ PENDÊNCIAS DECLARADAS, fora do escopo desta correção (achados do /codex xhigh):
+      //   · o gate `0.03` e os pesos `0,4/0,6` foram herdados da escala INCOERENTE e nunca
+      //     calibrados (não há feedback de conversão: as recomendações seguem 100% `pendente`).
+      //     Numa escala que encolheu, `0.03` aceita 15/12/7 compradores — abaixo do que um
+      //     limite inferior de Wilson exigiria para AFIRMAR 3%. Recalibrar exige outcome, não
+      //     opinião, e mexer nisso junto confundiria duas mudanças.
       const clientesQueCompraram = new Map<string, number>(); // product_id -> clientes DISTINTOS da carteira
       for (const cid of customerIds) {
         // `keys()` do histórico já é o conjunto de SKUs distintos DAQUELE cliente: cada
@@ -685,14 +705,19 @@ export const useCrossSellEngine = () => {
           clientesQueCompraram.set(productId, (clientesQueCompraram.get(productId) ?? 0) + 1);
         }
       }
-      // O denominador é quem PODERIA estar no numerador. Cliente da carteira sem histórico
-      // utilizável (pedido só de SKU inativo) nunca pode ser contado como comprador de nada,
-      // então incluí-lo diluiria a fração por um universo incapaz de contribuir — o mesmo
-      // defeito de escala, de grau menor. Em prod são 45/51/58 clientes por farmer.
-      const carteiraComHistorico = Math.max(
-        customerIds.filter((id) => (customerProducts.get(id)?.size ?? 0) > 0).length,
-        1,
-      );
+      // Denominador = a carteira ATIVA, não "a carteira com histórico utilizável". As duas
+      // foram medidas e são INDISTINGUÍVEIS no dado de hoje (empate 158, 56,1% `colacor`,
+      // 241 SKUs no gate — idênticos): a diferença é um fator uniforme por farmer, e fator
+      // uniforme não muda ordem DENTRO do farmer, que é onde o ranking acontece.
+      //
+      // Empatadas no desfecho, vale a que FALHA melhor. "Com histórico" encolhe o denominador
+      // junto com a cobertura, então quanto pior a cobertura, MAIOR a aderência: no limite, 1
+      // cliente com histórico numa carteira de 100 daria 1/1 = 100% e mandaria o SKU dele para
+      // os outros 99 — e nada barra isso, porque `carteira_com_historico_utilizavel` é
+      // registrado SEM piso. O viés ainda é dirigido: "histórico utilizável" depende de o SKU
+      // comprado continuar ATIVO, o que favorece cliente recente e linha sobrevivente.
+      // A carteira ativa é imune a esse modo de falha ao custo medido de zero.
+      const totalCustomers = Math.max(customerIds.length, 1);
       const productList = products || [];
 
       // 7. Calculate recommendations per client
@@ -754,7 +779,7 @@ export const useCrossSellEngine = () => {
           // vezes foi comprado. O numerador é subconjunto do denominador por construção, então
           // o quociente já é uma fração ≤ 1: o `clamp` fica como rede, não como disfarce.
           const buyerCount = clientesQueCompraram.get(product.id) || 0;
-          const clusterAdherence = clamp(buyerCount / carteiraComHistorico, 0, 1);
+          const clusterAdherence = clamp(buyerCount / totalCustomers, 0, 1);
 
           // Association boost: personalized score based on what THIS customer bought
           const assocBoost = assocBoostMap.get(product.id) || 0;
@@ -772,7 +797,7 @@ export const useCrossSellEngine = () => {
           // Segue a MESMA fração — senão volta a afirmar volume que a carteira não comporta:
           // com o numerador em ocorrências ele chegava a 40 numa carteira de 211 (medido), e
           // este número é PERSISTIDO em `cluster_volume_estimate`.
-          const clusterVolume = Math.max(1, Math.round(buyerCount / carteiraComHistorico * 12));
+          const clusterVolume = Math.max(1, Math.round(buyerCount / totalCustomers * 12));
 
           // Constante desde o #1514 (ver bloco de premissas). Persistida como dado, mas NÃO
           // multiplica o score: sendo 1.0 e igual para todo candidato, ela não muda ORDEM.

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -889,7 +889,20 @@ export const useCrossSellEngine = () => {
 
             const chave: ChaveUpSell = {
               razaoPreco: premiumPrice / purchaseData.price,
-              popularidade: allProductPurchases.get(product.id) || 0,
+              // MESMA métrica do cross-sell: clientes DISTINTOS da carteira. Este ponto nasceu
+              // no #1837 lendo `allProductPurchases` — ocorrências de item na base inteira —,
+              // que é o número que este PR está removendo por não ser fração nem contagem de
+              // nada (10 pedidos do mesmo cliente contavam 10). Manter as duas convivendo daria
+              // DUAS definições de "popularidade" no mesmo arquivo, que é exatamente a
+              // incoerência em correção. "O mais vendido" do comentário do comparador vira
+              // "o que mais clientes compraram", que é o sentido acionável para o vendedor.
+              //
+              // ⚠️ Efeito colateral DECLARADO, não medido: contar clientes (números pequenos,
+              // 0..N da carteira) empata mais que contar ocorrências (números grandes e
+              // dispersos), e `popularidade` é o 2º critério — só desempata quando `razaoPreco`
+              // bate EXATO. Quem responde isso em prod é o sensor que o próprio #1837
+              // instalou: `posicoesDecididasPorSinal` / `up_sell_posicoes_decididas`.
+              popularidade: clientesQueCompraram.get(product.id) || 0,
             };
 
             const anterior = upSellPorProduto.get(product.id);

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -566,7 +566,6 @@ export const useCrossSellEngine = () => {
 
       // 7. Build per-customer purchase history. Sem `cost`: o custo não chega mais ao browser.
       const customerProducts = new Map<string, Map<string, { qty: number; price: number }>>();
-      const allProductPurchases = new Map<string, number>(); // product_id -> total customers who bought
       // Contas em que cada cliente EFETIVAMENTE comprou — o lado "histórico" do sensor
       // `oferta_conta_do_cliente`. Sai de `sales_orders.account`, a mesma coluna que
       // qualifica o item, e é montado neste loop porque ele já varre todos os pedidos.
@@ -599,10 +598,6 @@ export const useCrossSellEngine = () => {
           existing.qty += Number(item.quantity || item.quantidade || 1);
           existing.price = Number(item.unit_price || item.valor_unitario || 0);
           cp.set(productId, existing);
-
-          // Track which products are popular
-          if (!allProductPurchases.has(productId)) allProductPurchases.set(productId, 0);
-          allProductPurchases.set(productId, allProductPurchases.get(productId)! + 1);
         }
       }
 
@@ -648,7 +643,56 @@ export const useCrossSellEngine = () => {
         esperado: itensResolvidos + itensContaDivergente,
       };
 
-      const totalCustomers = Math.max(customerIds.length, 1);
+      // ADERÊNCIA AO CLUSTER — as duas pontas no MESMO universo, que é a carteira do cálculo.
+      //
+      // O que havia aqui dividia OCORRÊNCIAS DE ITEM (contadas dentro do laço de itens de
+      // TODOS os pedidos da base, universo global) por `customerIds.length` (a carteira DESTE
+      // farmer, universo local). Um cliente que comprasse o mesmo SKU em 10 pedidos contava
+      // 10, e o quociente não era fração de coisa nenhuma — embora o comentário da linha o
+      // chamasse de "total customers who bought". O `clamp(…, 0, 1)` não corrigia: ele
+      // ESCONDIA, saturando em 1,0 todo SKU de volume alto.
+      //
+      // O estrago é de RANKING, e foi medido antes de escolher (psql-ro + simulação do motor
+      // sobre os 3 farmers com carteira ativa, 20/08/2026):
+      //   · 829 dos 1.052 clientes tinham o top-3 em EMPATE TOTAL de score — três SKUs
+      //     saturados em 1,0 com `assocBoost` 0 dão `relevance` 0,4 idêntico, e quem escolhia
+      //     a oferta era a ordem de `.order('id')` do catálogo. Depois: ZERO empates.
+      //   · 98,5% do top-3 caía em `oben` contra 1,5% `colacor`; depois, 63,2% `colacor` —
+      //     coerente com a disponibilidade (71% dos vendáveis são `colacor`). É o mesmo viés
+      //     que o #1823 mediu em prod (934 dos 939 cross-sell vivos `oben`) e descartou como
+      //     "não é o gate de popularidade": não era a ADMISSÃO no gate, era a SATURAÇÃO.
+      //   · A inflação é ANTI-correlacionada com o tamanho da carteira (numerador global sobre
+      //     denominador local): o farmer de 269 clientes tinha 587 SKUs acima do gate de 3%,
+      //     224 deles SEM UM ÚNICO comprador na própria carteira.
+      //
+      // A alternativa era global nas duas pontas (clientes distintos da BASE ÷ 1.073 clientes
+      // com histórico). Ela também conserta a escala, mas foi DESCARTADA pelo dado: produz o
+      // mesmo conjunto de 80 SKUs para os três farmers — um termo que não distingue carteira
+      // nenhuma, o oposto do que "aderência do CLUSTER" promete. A local varia (112/103/26) e
+      // é o universo que o resto do arquivo já declara medir (`clientes_com_profile`,
+      // `carteira_com_historico_utilizavel`).
+      //
+      // Custo do aperto, medido: NENHUM. O volume de recomendação é idêntico (3.156 = 3.156):
+      // o gate corta candidato de sobra, nunca os 3 do topo — nenhum farmer seca. O que muda é
+      // a ORDEM (top-3 diferente em 1.026 dos 1.052 clientes; top-1 em 532) e o equilíbrio com
+      // o `assocBoost`, que sai de decidir 1,0% dos topos para 12,8% — ele é o ÚNICO termo
+      // personalizado por cliente, e estava afogado pela saturação.
+      const clientesQueCompraram = new Map<string, number>(); // product_id -> clientes DISTINTOS da carteira
+      for (const cid of customerIds) {
+        // `keys()` do histórico já é o conjunto de SKUs distintos DAQUELE cliente: cada
+        // cliente entra no máximo UMA vez por SKU, quantos pedidos tenha feito.
+        for (const productId of (customerProducts.get(cid) ?? new Map()).keys()) {
+          clientesQueCompraram.set(productId, (clientesQueCompraram.get(productId) ?? 0) + 1);
+        }
+      }
+      // O denominador é quem PODERIA estar no numerador. Cliente da carteira sem histórico
+      // utilizável (pedido só de SKU inativo) nunca pode ser contado como comprador de nada,
+      // então incluí-lo diluiria a fração por um universo incapaz de contribuir — o mesmo
+      // defeito de escala, de grau menor. Em prod são 45/51/58 clientes por farmer.
+      const carteiraComHistorico = Math.max(
+        customerIds.filter((id) => (customerProducts.get(id)?.size ?? 0) > 0).length,
+        1,
+      );
       const productList = products || [];
 
       // 7. Calculate recommendations per client
@@ -706,9 +750,11 @@ export const useCrossSellEngine = () => {
           // (margem canônica > 0). Custo desconhecido não entra — ausente≠zero (#1466).
           if (!vendaveis.has(product.id)) continue;
 
-          // Cluster adherence: how many similar customers bought this
-          const buyerCount = allProductPurchases.get(product.id) || 0;
-          const clusterAdherence = clamp(buyerCount / totalCustomers, 0, 1);
+          // Aderência do cluster: QUANTOS CLIENTES da carteira compraram isto — não quantas
+          // vezes foi comprado. O numerador é subconjunto do denominador por construção, então
+          // o quociente já é uma fração ≤ 1: o `clamp` fica como rede, não como disfarce.
+          const buyerCount = clientesQueCompraram.get(product.id) || 0;
+          const clusterAdherence = clamp(buyerCount / carteiraComHistorico, 0, 1);
 
           // Association boost: personalized score based on what THIS customer bought
           const assocBoost = assocBoostMap.get(product.id) || 0;
@@ -723,7 +769,10 @@ export const useCrossSellEngine = () => {
 
           // Estimativa de volume do cluster: preservada como CONTEXTO da recomendação, mas fora
           // do score (ela já entra em `pij` via `relevance` — remultiplicar afogaria o assocBoost).
-          const clusterVolume = Math.max(1, Math.round(buyerCount / totalCustomers * 12));
+          // Segue a MESMA fração — senão volta a afirmar volume que a carteira não comporta:
+          // com o numerador em ocorrências ele chegava a 40 numa carteira de 211 (medido), e
+          // este número é PERSISTIDO em `cluster_volume_estimate`.
+          const clusterVolume = Math.max(1, Math.round(buyerCount / carteiraComHistorico * 12));
 
           // Constante desde o #1514 (ver bloco de premissas). Persistida como dado, mas NÃO
           // multiplica o score: sendo 1.0 e igual para todo candidato, ela não muda ORDEM.

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -194,6 +194,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/cross-sell-universo-pedidos.test.tsx",
       "src/hooks/__tests__/cross-sell-conta-da-oferta.test.tsx",
       "src/hooks/__tests__/cross-sell-up-sell-ordem.test.tsx",
+      "src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx",
       "src/hooks/__tests__/useAlertaCreditoCliente.test.ts",
       "src/hooks/__tests__/usePedidosProgramados.cancelamento.test.tsx",
       "src/hooks/__tests__/usePricingEngine.test.ts",

--- a/src/pages/FarmerRecommendations.tsx
+++ b/src/pages/FarmerRecommendations.tsx
@@ -236,7 +236,16 @@ const FarmerRecommendations = () => {
                                       igual: custo = preço × (1 − margem%)). E neste motor nem
                                       esse caso aparece: só entra SKU que a RPC listou como
                                       vendável (margem canônica > 0). */}
-                                  <p className="text-[10px] text-muted-foreground">{rec.clusterVolume}× /mês no cluster</p>
+                                  {/* NÃO é "por mês": a fórmula é `round(aderência × 12)` — uma reescala da FRAÇÃO de
+                                      clientes do cluster que compraram o SKU, sem janela temporal, sem
+                                      ocorrências e sem quantidade. O rótulo antigo ("N× /mês no cluster")
+                                      afirmava uma frequência que o número nunca mediu, e com o numerador
+                                      inflado chegava a exibir "40× /mês" para uma carteira de 211.
+                                      ⚠️ Pendência declarada (achado /codex): o campo `cluster_volume_estimate`
+                                      mistura duas semânticas — aqui é fração reescalada, no up-sell é
+                                      QUANTIDADE histórica. Separar isso é mudança de contrato, fora do
+                                      escopo da correção da aderência. */}
+                                  <p className="text-[10px] text-muted-foreground">≈{rec.clusterVolume} em cada 12 do cluster</p>
                                 </div>
                                 <div className="text-right shrink-0">
                                   <p className="text-sm font-bold text-primary">{rec.pij}%</p>


### PR DESCRIPTION
`clusterAdherence` dividia **ocorrências de item** (universo global) por **clientes da carteira** (universo local). O numerador era incrementado dentro do laço de itens de TODOS os pedidos da base — um cliente que compra o mesmo SKU em 10 pedidos contava 10 —, enquanto o denominador é a carteira daquele farmer. O quociente não era fração de nada, embora o comentário da linha o chamasse de `total customers who bought`. O `clamp(…, 0, 1)` não corrigia: **escondia**, saturando em 1,0 todo SKU de volume alto.

Achado do `/codex challenge xhigh` durante o PR do branch `claude/cranky-hugle-d2bf42`.

## O estrago é de RANKING, não de número na tela

Medido antes de escolher — `psql-ro` replicando o motor em SQL (validei a replicação: meu `n_vendaveis` deu **2463**, idêntico ao que `get_skus_margem_positiva()` retorna em prod) + simulação do motor sobre os 3 farmers com carteira ativa (526/432/269):

| | antes | depois |
|---|---|---|
| clientes com top-3 em **empate total** | **839** de 1.052 | **158** |
| top-3 por empresa do grupo | `oben` 98,5% / `colacor` 1,5% | `colacor` 56,1% / `oben` 43,9% |
| `assocBoost` decide o topo | 1,0% | 12,8% |
| recomendações geradas | 3.156 | **3.156** |

Com três SKUs saturados em 1,0 e `assocBoost` 0, `relevance` dá 0,4 idêntico: quem escolhia a oferta de 839 clientes era a **ordem de `.order('id')` do catálogo**, não o ranking.

**Isso explica o achado que o #1823 deixou aberto.** Aquele PR mediu em prod que 934 dos 939 cross-sell vivos são `oben`, e descartou o gate de popularidade por eliminação. A simulação da definição antiga reproduz 98,5% `oben`. Não era a **admissão** no gate — era a **saturação**, que colapsa o ranking em empate e entrega o desempate à ordem do uuid.

A inflação é **anti-correlacionada com o tamanho da carteira** (numerador global ÷ denominador local): o farmer de 269 clientes tinha 587 SKUs acima do gate de 3%, **224 deles sem um único comprador na própria carteira**.

## Por que a carteira e não a base inteira

A alternativa (clientes distintos da BASE ÷ 1.073 com histórico) também conserta a escala e chega perto: 198 empates, 59,8% `colacor`. Duas coisas decidiram:

- as carteiras **não são intercambiáveis** — Spearman **0,47–0,49** entre os rankings de adesão das três; se fossem, seria ~0,9;
- **precisão > recall**: na dúvida, não ofertar o SKU que a carteira nunca comprou.

O custo fica declarado no código: 1.318 dos 1.964 SKUs comprados na base não têm comprador na carteira menor, e essa evidência é descartada de propósito. Em prod nada se **perde**, só se particiona: 481+381+211 = 1.073 = exatamente os clientes com histórico.

**Custo do aperto: nenhum em volume.** As recomendações são as mesmas 3.156 — o gate corta candidato de sobra, nunca os 3 do topo. Nenhum farmer seca.

## O que o `/codex` derrubou

O ritual (obrigatório em money-path) matou duas afirmações minhas:

1. **"empate vai a zero" era falso.** `affinityScore` é arredondado a 4 casas **antes** do `sort`, e minha simulação ordenava pelo score cru. Refeita com o arredondamento real: **839 → 158**, não 839 → 0. Redução de 81%, e o resíduo é estrutural.
2. **O denominador que eu havia escolhido** ("carteira com histórico utilizável") foi revertido. Medi os dois: **indistinguíveis** no dado de hoje (empate 158, 56,1% `colacor`, 241 SKUs no gate — idênticos), porque a diferença é um fator uniforme por farmer e fator uniforme não muda ordem dentro do farmer. Empatadas no desfecho, vale a que **falha melhor**: "com histórico" encolhe o denominador junto com a cobertura — 1 cliente com histórico numa carteira de 100 daria 1/1 = 100% —, e nada barra isso porque o insumo é registrado sem piso. **Resultado: o diff de código ficou só no numerador, que era o bug.**

Também do challenge: o teste **E** (comprador de fora da carteira), o teste **F** (o valor corrigido chega ao banco) e o **rótulo falso na UI** — `FarmerRecommendations` exibia `N× /mês no cluster` para um número que é `round(aderência × 12)`, sem janela temporal nenhuma; com o numerador inflado chegava a afirmar "40× /mês" numa carteira de 211.

## Testes

6 casos, com **controle positivo** (A prova que a fixture produz oferta — sem ele, B–F passariam por vacuidade) e **falsificação dupla ortogonal**:

| sabotagem | vermelhos | previsto |
|---|---|---|
| numerador volta a ocorrências | 2 — B, C | ✔ |
| denominador vira carteira com histórico | 1 — D (`expected 5 to be 6`) | ✔ até o valor |

Três fixtures alheias (`identidade-account`, `conta-da-oferta`, `universo-pedidos`) davam popularidade a partir de clientes **fora** da carteira, o que o numerador global aceitava. Os clientes que formam o histórico entram na carteira; como só o alvo tem `profiles`, a geração segue restrita a ele e o observável de cada teste não muda. Em `universo-pedidos` o ajuste deixou o teste **mais forte**: o SKU popular foi para o `cli-9`, cujo único pedido é `separacao`, então a oferta do controle positivo agora depende diretamente de aquele pedido entrar no universo.

## Pendências declaradas (não corrigidas aqui, de propósito)

- o gate `0.03` e os pesos `0,4/0,6` foram herdados da escala incoerente e **nunca calibrados** — recalibrar exige outcome de conversão, que não existe (as recomendações seguem 100% `pendente`). Numa escala que encolheu, `0.03` aceita 15/12/7 compradores, abaixo do que um limite inferior de Wilson exigiria para afirmar 3%;
- `cluster_volume_estimate` carrega **duas semânticas** — fração reescalada no cross-sell, quantidade histórica no up-sell — e separá-las é mudança de contrato de dado.

## Nota de medição

Os "166 e 147" do briefing não reproduzem em nenhum recorte: as carteiras ativas hoje são **526/432/269**. E a simulação gera 3.156 recomendações contra 939 vivas em prod — o contraste antes/depois dentro da mesma simulação é válido, mas isto **não** é reprodução causal das linhas vivas (o cálculo só roda quando staff abre a página).

## Encontro com o #1837 — auto-merge limpo que não compilava

O #1837 mergeou durante este trabalho, no mesmo arquivo, corrigindo **o mesmo fenômeno no ramo vizinho**: "o top-2 do up-sell era a ordem de `id` do catálogo — 2 sorteados entre 2.068". Lá o `affinityScore` não continha nenhum termo do produto candidato; aqui o termo satura em 1,0. Mesma patologia — empate total → desempate pela ordem do uuid — por causas diferentes.

O rebase fez **auto-merge sem conflito** (as mudanças tocam linhas distintas) e produziu um arquivo que **não compila**: aquele PR instalou um consumidor novo de `allProductPurchases` — a chave `popularidade` do desempate de up-sell — e este remove o símbolo. `TS2304`. As 13 falhas de teste eram a mesma `ReferenceError` em cascata, não 13 problemas.

**Ausência de conflito não é prova de compatibilidade.** Quem pegou foi o `typecheck` sobre o resultado do rebase — não a inspeção do diff.

A religação é a certa por mérito, não só para compilar: o up-sell passa a desempatar pela **mesma** métrica do cross-sell. Manter as duas conviveria com duas definições de "popularidade" no mesmo arquivo, que é a incoerência em correção.

⚠️ **Efeito colateral declarado, não medido**: contar clientes (números pequenos) empata mais que contar ocorrências (grandes e dispersos), e `popularidade` é o 2º critério — só desempata quando `razaoPreco` bate exato. Quem responde isso em prod é o sensor que o próprio #1837 instalou: `upsell_ordem_decidida`.

A fixture do #1837 expressava popularidade de dois jeitos que a nova métrica não enxerga — clientes fora da carteira, e repetição da linha de item. Agora o sinal é o número de **clientes** que compram (`sku-pop-baixa` por 2, `sku-pop-alta` por 5); a intenção do teste E fica intacta e os casos G/H do sensor de empate seguem verdes sem tocar.

## Gates

`bun run test` 708 arquivos / 6652 testes ✅ · `bun run typecheck` ✅ · `bun lint` ✅ · `bunx knip` ✅ — todos exit 0, e re-rodados sobre o resultado do rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
