### PR TITLE
docs(deploy): a edge que ESCREVE numa tabela carrega a prova do próprio deploy

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -116,6 +116,48 @@ FROM net._http_response ORDER BY id DESC LIMIT 1;
 
 Verde = `status_code 200` **E** `canary true` **E** `contrato` batendo com a tabela acima **E** `ok true` **E** `casos_vermelhos NULL` (os cinco, não só o `ok`). `400` com `"Ação desconhecida"` = **bundle velho**, a probe não subiu — e a lista `acoes_disponiveis` da resposta é a confirmação (não cita a action nova). ⚠️ Probe é **dry-run**: se um dia uma delas abrir linha em `fin_sync_log`, ela fabrica frescor — `_data_health_compute` e `fin_calcular_confiabilidade` leem essa tabela **sem filtrar `action`** (só o `fin_sync_heartbeat` filtra). No `omie-financeiro` isso é o `PROBE_ACTIONS` → `logId=""`, pinado no `edge-money-path-invariants`.
 
+### Assinatura no PRÓPRIO log da edge — N3 retroativo, sem canária e sem sonda
+
+Terceiro caminho, e o mais barato quando existe: **a edge que ESCREVE numa tabela já carrega a
+prova do que ela é**. Se o defeito corrigido deixava rastro nos dados que a edge grava, a versão
+se prova por SQL — sem canária, sem sonda, sem `?canary=1`, sem o founder chamar nada, e
+**retroativamente** (serve para deploy que já aconteceu, inclusive um que ninguém verificou na
+hora). Diferença para as duas outras: canária e sonda exigem CÓDIGO na edge, escrito ANTES do
+deploy; esta não exige nada — só que o defeito tenha uma testemunha na tabela de saída.
+
+**Como achar a assinatura.** Pergunte: *que valor o código VELHO gravava e o NOVO não pode
+gravar?* Não serve um valor que os dois possam produzir. Tem de ser um estado que a correção
+torna IMPOSSÍVEL.
+
+**Caso que a fundou (`recommend`, 2026-08-21, PR #1836).** As seis leituras não paginavam, então
+o custo de ~73% dos candidatos ficava fora da página do PostgREST e a edge gravava
+`recommendation_log.cost_source = 'UNKNOWN'`. Depois da paginação, produto **que tem custo
+cadastrado** não pode mais sair UNKNOWN. Duas queries fecharam:
+
+```sql
+-- (1) O defeito, medido no PRODUTO: o custo existia e a edge não via.
+SELECT count(*) FILTER (WHERE rl.cost_source='UNKNOWN')                            AS unknown,
+       count(*) FILTER (WHERE rl.cost_source='UNKNOWN' AND pc.product_id IS NOT NULL) AS unknown_mas_tem_custo
+FROM recommendation_log rl LEFT JOIN product_costs pc ON pc.product_id = rl.product_id
+WHERE rl.event_type='impression';        -- 283 UNKNOWN, dos quais 279 (98,6%) TINHAM custo
+
+-- (2) A linha de base POR CHAMADA, que é o que dá poder estatístico ao veredito.
+SELECT date_trunc('minute',created_at) chamada, count(*) n,
+       count(*) FILTER (WHERE cost_source='UNKNOWN') unk
+FROM recommendation_log WHERE event_type='impression' GROUP BY 1 ORDER BY 1 DESC LIMIT 10;
+-- 9 chamadas históricas: 60–100% UNKNOWN · 1ª chamada pós-deploy: 0 de 5
+```
+
+⚠️ **A linha de base é obrigatória, e é POR CHAMADA.** "0 de 5 UNKNOWN" não significa nada sozinho
+— é a regra do denominador de novo. Contra uma base de 60–100%, um 0/5 seria sorte de ~1% no
+melhor caso e ~0,001% no típico; contra uma base de 10%, não provaria coisa alguma. Agrupe por
+chamada (as impressões de uma mesma chamada **não são independentes** — mesmo catálogo, mesmo
+cliente, mesma página truncada), e diga o tamanho da amostra no veredito.
+
+⚠️ **Descarte o confundidor antes de concluir.** "Caiu o UNKNOWN" também aconteceria se alguém
+tivesse feito backfill de `product_costs`. Foi a query (1) que eliminou isso: os UNKNOWN antigos
+**já tinham** custo no banco — o dado existia, a edge é que não alcançava.
+
 ## Quando o Lovable reverte um fix — detectar e restaurar
 
 O bot `gpt-engineer-app[bot]` commita direto na `main` SEM CI ("Changes"/"Deployed"/"Deployou edge") e às vezes reverte um PR (~16% dos commits; ≥4-5 reversões money-path recentes). Prevenção é inviável (o bot precisa de escrita direta) → o jogo é **detectar + restaurar rápido** (MTTR), não governança perfeita. Spec: `docs/superpowers/specs/2026-06-26-lovable-revert-mitigation-design.md`.

--- a/docs/historico/bugs-resolvidos.md
+++ b/docs/historico/bugs-resolvidos.md
@@ -786,3 +786,39 @@ porque a diferença é um fator uniforme por farmer e fator uniforme não muda o
 Empatadas no desfecho, ficou a que **falha melhor**: "com histórico" encolhe o denominador junto com
 a cobertura (1 cliente com histórico em 100 ativos daria 1/1 = 100%). O critério de desempate entre
 opções equivalentes é o modo de falha, não a elegância do argumento.
+
+**Fecho do ciclo: o deploy da edge provado pelo LOG DELA MESMA (2026-08-21).** O #1836 mergeou às
+03:17 e o founder publicou a edge pelo chat do Lovable. "Publiquei" não é "está no ar", e aqui a
+verificação canônica não existe: o **N2** (Management API — `version` sobe, `updated_at` recente)
+é **estruturalmente indisponível** neste projeto, porque o Supabase é da org do Lovable e não há
+Access Token que o founder possa gerar (pedir o PAT já foi erro 3×). Sobrava o **N1** (a função
+responde OPTIONS — prova existência, não versão) e o rastro do commit `Deployed …` do bot, que
+**nem apareceu** nesta publicação.
+
+A saída foi um **N3 que não precisou de canária nem de sonda**: a edge ESCREVE em
+`recommendation_log`, e o defeito tinha testemunha lá dentro. Sob truncagem, o custo de ~73% dos
+candidatos ficava fora da página e a edge gravava `cost_source = 'UNKNOWN'`; com a paginação,
+produto **que tem custo cadastrado** não pode mais sair UNKNOWN. Medido:
+
+| chamada | impressões | UNKNOWN |
+|---|---|---|
+| **08-21 20:04** (pós-deploy) | 5 | **0** |
+| 08-08 · 06-12 · 06-10 (3×) · 06-08 | 5 cada | 5 (100%) |
+| 06-10 12:17 | 15 | 14 (93%) |
+| 06-14 | 5 | 3 (60%) |
+| 05-19 · 05-18 | 5 cada | 4 (80%) |
+
+Nove chamadas históricas entre 60% e 100%; a primeira pós-deploy, 0 de 5 — sorte de ~1% no melhor
+caso da base, ~0,001% no típico. E a query que **elimina o confundidor**: dos 283 UNKNOWN
+históricos, **279 (98,6%) TINHAM custo em `product_costs`**. Não era "faltava custo no banco" — o
+dado existia e a edge não alcançava. Isso é a truncagem medida no PRODUTO, não inferida do código;
+o PR alegava 73,5% de candidatos sem custo por simulação da primeira página, e o log independente
+mostrou 60–100% por chamada de verdade.
+
+**A generalização, que já foi para `docs/agent/deploy.md`:** quando a edge grava numa tabela,
+pergunte *que valor o código VELHO gravava e o NOVO não pode gravar* — se existir, a versão se
+prova por SQL, **retroativamente**, sem código novo na edge e sem o founder chamar nada. Canária e
+sonda exigem instrumentação escrita ANTES do deploy; esta não. As duas armadilhas: a linha de base
+é **obrigatória e por CHAMADA** (impressões da mesma chamada não são independentes — mesmo
+catálogo, mesma página truncada), e o **confundidor** ("alguém fez backfill") tem de ser descartado
+por query própria, não por suposição.


### PR DESCRIPTION
## Por que existe

Verificando o deploy da edge do #1836 (mergeado, `f6ac605`), a escada canônica não fechava:

- **N1** (a função responde OPTIONS) — ✅, mas prova **existência**, não versão
- **N2** (Management API, `version`/`updated_at`) — ⛔ **estruturalmente indisponível**: o Supabase (`fzvklzpomgnyikkfkzai`) é da org do Lovable e o founder não tem conta com acesso ao ref, logo não existe PAT que ele possa gerar (pedir já foi erro 3×)
- rastro do commit `Deployed …` do bot — **nem apareceu** nesta publicação
- `recommend` **não tem canária nem sonda**

Sem um caminho novo, o veredito honesto seria "existe; versão não provada" — e a entrega ficaria sem confirmação de que chegou ao ar.

## A técnica

**A edge que ESCREVE numa tabela carrega a prova do próprio deploy.** Se o defeito corrigido deixava rastro nos dados que ela grava, a versão se prova por SQL.

A pergunta que gera a assinatura: *que valor o código **velho** gravava e o **novo** não pode gravar?* Precisa ser um estado que a correção torne **impossível** — um valor que ambos possam produzir não serve.

| caminho de N3 | exige código na edge **antes** do deploy? | funciona **retroativamente**? |
|---|---|---|
| Canária `?canary=1` | sim | não |
| Sonda `{"probe":true}` | sim | não |
| **Assinatura no log da própria edge** | **não** | **sim** |

É o mais barato quando existe, e o único que serve para um deploy que já aconteceu e ninguém verificou na hora.

## O caso que a fundou

Sob truncagem, o custo de ~73% dos candidatos ficava fora da página e `recommend` gravava `recommendation_log.cost_source = 'UNKNOWN'`. Depois da paginação, produto **que tem custo cadastrado** não pode mais sair UNKNOWN.

| chamada | impressões | UNKNOWN |
|---|---|---|
| **08-21 20:04** (pós-deploy) | 5 | **0** |
| 08-08 · 06-12 · 06-10 (2×) · 06-08 | 5 cada | 5 (100%) |
| 06-10 12:17 | 15 | 14 (93%) |
| 06-14 | 5 | 3 (60%) |
| 05-19 · 05-18 | 5 cada | 4 (80%) |

Nove chamadas históricas entre 60% e 100%; a primeira pós-deploy, 0 de 5.

**O confundidor, descartado por medição e não por suposição:** "caiu o UNKNOWN" também aconteceria se alguém tivesse feito backfill de `product_costs`. Query própria eliminou — dos **283** UNKNOWN históricos, **279 (98,6%) TINHAM custo no banco**. O dado existia; a edge é que não alcançava. Isso é a truncagem medida no **produto**, não inferida do código — e o número real (60–100% por chamada) saiu **pior** que os 73,5% que o #1836 estimou por simulação da primeira página.

## As duas armadilhas, escritas junto

- **A linha de base é obrigatória, e é POR CHAMADA.** "0 de 5" não diz nada sozinho — é a regra do denominador de novo. Contra uma base de 60–100%, um 0/5 é sorte de ~1% no melhor caso; contra uma base de 10%, não prova nada. E impressões de uma mesma chamada **não são independentes** (mesmo catálogo, mesmo cliente, mesma página truncada), então agrupar por chamada é o que dá poder ao veredito.
- **O confundidor tem de cair por query**, não por suposição.

## Onde ficou

- `docs/agent/deploy.md` — a técnica, como referência operacional, na seção de canárias (com as duas queries)
- `docs/historico/bugs-resolvidos.md` — o fecho narrativo do ciclo do #1836

## Gates

Só documentação. `bun run test` **708 arquivos / 6.663 testes / 0 falhas** · `bunx knip` exit 0, zero achados · gate de citações em docs 21/21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
