### PR TITLE
feat(skills): doc2md — documento binário vira Markdown com guarda contra o exit 0 que MENTE

### DIFF
--- a/.claude/skills/doc2md/SKILL.md
+++ b/.claude/skills/doc2md/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: doc2md
+description: >-
+  Converte documento BINÁRIO (PDF, DOCX, XLSX, PPTX, MSG) em Markdown legível, com guarda
+  contra extração vazia, neste repo (Afiação/Colacor). Use SEMPRE que o Lucas anexar/apontar
+  ou mencionar um arquivo desses — boletim técnico Sayerlack, pedido de compra de cliente
+  (Lider), tabela de preço, circular de aumento, extrato, DANFE, proposta, planilha de
+  fornecedor — e você precisar LER o conteúdo. Use também para gerar `.expected` de fixture a
+  partir de PDF real, e para comparar DUAS versões do mesmo boletim ("o que mudou?"). Por quê:
+  sem o ritual o agente erra três vezes seguidas — `uvx markitdown x.pdf` falha por falta do
+  extra `[pdf]`; PDF escaneado/imagem sai com **exit 0 e ~1 byte** (falha SILENCIOSA, lida como
+  "documento vazio"); e a saída despeja milhares de tokens no contexto de toda request seguinte.
+---
+
+# doc2md — documento binário → Markdown, com evidência positiva
+
+## O ritual
+
+Sempre pelo script — ele embute a guarda que a memória esquece:
+
+```bash
+.claude/skills/doc2md/doc2md.sh <arquivo> [dir-saida]
+```
+
+Depois **leia por recorte**, nunca despejando o arquivo inteiro:
+
+```bash
+head -c 2000 <saida.md>              # panorâmica
+grep -n '<termo>' <saida.md> | cut -c1-160   # busca dirigida
+```
+
+Saída default: `$TMPDIR/doc2md/`. Prefira o scratchpad da sessão quando o artefato importar.
+
+Exit codes: `0` ok · `1` markitdown falhou · `2` uso/arquivo inexistente · `3` é imagem
+(recusa) · `4` **guarda de bytes** (extraiu menos que o piso).
+
+## A guarda (o motivo do script existir)
+
+`markitdown` num PDF **sem camada de texto** sai com **exit 0 e 1 byte**. Medido neste repo.
+Exit 0 aqui não prova extração — só bytes provam. O script mede e falha em vermelho.
+
+**Exit 4 nunca significa "o documento está vazio".** Significa *não consegui ler* — o PDF é
+escaneado. Nesse caso leia o **original** com a ferramenta `Read` (visão do modelo). É a mesma
+regra do CLAUDE.md: ausência de sinal ≠ aprovação.
+
+## Money-path: três armadilhas medidas no PDF real da Lider
+
+Antes de deixar qualquer número virar preço/quantidade no app ou num `.expected`:
+
+1. **Decimal é BR.** O preço vem `111,400000`, não `111.4`. Converter é lógica nossa —
+   `Number("111,400000")` é `NaN`, e `NaN` mascarado vira fabricação.
+2. **Primeira ocorrência mente em documento multi-página.** No pedido 213294,
+   `grep -m1 "TOTAL DAS MERCADORIAS"` acerta o rodapé da **pág. 1**, que está **em branco**
+   (tem `C O N T I N U A . . .`); o valor real (`13638,00`) só existe na pág. 2. Ancore no
+   rodapé **final**, ou confira a contagem de ocorrências antes de ler uma.
+3. **Descrição vem quebrada em N linhas.** `FLANELA MICROFIBRA` / `AUTOMOTIVA 40 X 40CM -` /
+   `C/ COSTURAS` são linhas separadas. O join é código, não mágica.
+
+**Regra:** doc2md serve para **entender e navegar** o documento. Número que vira dinheiro
+passa por conferência humana ou por parser testado — nunca por leitura direta minha.
+
+## Onde este ritual NÃO se aplica
+
+- **Runtime do app.** `kb-ingest-document` roda `pdf-parse` numa **edge Deno**; markitdown é
+  Python e não roda lá. Isto é ferramenta de SESSÃO, não caminho de produção. Não proponha
+  trocar a edge por isso.
+- **Imagem / foto de circular.** Não é OCR (exit 3). Os uploads de aumentos e promoções aceitam
+  `.png/.jpg` — esse caso é `Read` com visão, ou a extração paga.
+- **Documento que você já tem em texto.** Não converta o que já é `.md`/`.csv`/`.txt`.
+
+## Casos que rendem neste repo
+
+| Situação | O que doc2md entrega |
+|---|---|
+| PDF novo de pedido programado (Lider ou cliente novo) | matéria-prima do `.expected.ts` — o gabarito atual foi transcrito **a olho** |
+| Boletim Sayerlack v2 chegou | `doc2md` nos dois + `diff` → *o que* mudou (`kb_product_spec_versions` guarda as versões mas não sabe ler a diferença) |
+| Campo errado no `kb-extract-specs` (custa $) | comparar o md local com o draft salvo → diagnóstico **sem re-pagar** |
+| `.xlsx`/`.docx` de fornecedor no e-mail | leitura direta, sem você colar texto |
+
+## Red flags — pare
+
+- Vou rodar `uvx markitdown` na mão → **não**: falta o extra, e falta a guarda.
+- Deu exit 0, então converteu → **não**: confira bytes (é o que o script faz).
+- Saiu quase vazio, o documento deve ser vazio → **não**: é PDF escaneado. `Read` no original.
+- Vou `cat` o md inteiro pra ler → **não**: recorte com `head -c` / `grep | cut`.
+- Peguei o preço direto do markdown e já usei → **não**: vírgula BR + primeira-ocorrência.

--- a/.claude/skills/doc2md/doc2md.sh
+++ b/.claude/skills/doc2md/doc2md.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# doc2md.sh — converte documento binário (PDF/DOCX/XLSX/PPTX) em Markdown COM GUARDA.
+#
+# Por que existe: `markitdown` sai com exit 0 e 1 byte quando o arquivo não tem camada
+# de texto (PDF escaneado, imagem). Exit 0 + saída vazia é falha SILENCIOSA — o agente
+# conclui "converteu" e segue lendo o nada. A guarda de bytes torna isso vermelho.
+#
+# Uso: doc2md.sh <arquivo> [dir-saida]
+# Env: DOC2MD_MIN_BYTES (default 200) — piso de evidência positiva.
+set -euo pipefail
+
+MIN_BYTES="${DOC2MD_MIN_BYTES:-200}"
+
+if [[ $# -lt 1 ]]; then
+  echo "uso: doc2md.sh <arquivo> [dir-saida]" >&2
+  exit 2
+fi
+
+src="$1"
+[[ -f "$src" ]] || { echo "ERRO: arquivo não existe: $src" >&2; exit 2; }
+
+outdir="${2:-${TMPDIR:-/tmp}/doc2md}"
+mkdir -p "$outdir"
+
+base="$(basename "$src")"
+ext="$(printf '%s' "${base##*.}" | tr '[:upper:]' '[:lower:]')"
+dest="$outdir/${base%.*}.md"
+errlog="$outdir/${base%.*}.err"
+
+# Imagem NÃO é caso do markitdown: ele devolve metadata (ou nada), não OCR.
+case "$ext" in
+  png|jpg|jpeg|gif|webp|bmp|tiff|heic)
+    cat >&2 <<MSG
+ERRO: '$ext' é IMAGEM — markitdown não faz OCR (devolve ~0 byte com exit 0).
+      Leia com a ferramenta Read (visão do modelo), não por aqui.
+MSG
+    exit 3
+    ;;
+esac
+
+# Extras do markitdown por formato (o pacote base NÃO traz parser algum).
+case "$ext" in
+  pdf)              extras='markitdown[pdf]' ;;
+  docx|doc)         extras='markitdown[docx]' ;;
+  xlsx|xls)         extras='markitdown[xlsx,xls]' ;;
+  pptx|ppt)         extras='markitdown[pptx]' ;;
+  msg)              extras='markitdown[outlook]' ;;
+  *)                extras='markitdown[all]' ;;
+esac
+
+if ! uvx --from "$extras" markitdown "$src" > "$dest" 2> "$errlog"; then
+  echo "ERRO: markitdown falhou (exit $?). stderr:" >&2
+  tail -c 600 "$errlog" >&2
+  exit 1
+fi
+
+bytes=$(wc -c < "$dest" | tr -d ' ')
+
+# GUARDA: exit 0 não prova extração. Bytes provam.
+if [[ "$bytes" -lt "$MIN_BYTES" ]]; then
+  cat >&2 <<MSG
+ERRO: extraiu só ${bytes}B (piso ${MIN_BYTES}B) — exit 0 MENTIU.
+      Causa provável: PDF escaneado / sem camada de texto.
+      NÃO trate como "documento vazio". Leia o original com Read (visão).
+      Saída parcial em: $dest
+MSG
+  exit 4
+fi
+
+echo "OK  $dest  (${bytes}B, $(wc -l < "$dest" | tr -d ' ') linhas)"
+echo "    ler recorte:  head -c 2000 '$dest'"
+echo "    buscar:       grep -n '<termo>' '$dest' | cut -c1-160"


### PR DESCRIPTION
## O problema

Ler PDF/planilha que chega do fornecedor ou do cliente é trabalho manual hoje. O gabarito de `src/lib/pedidosProgramados/__fixtures__/lider-213294.expected.ts` diz, ele mesmo: *"Transcrito **A OLHO** do PDF"*.

## RED — três falhas MEDIDAS antes de escrever a skill

| Teste | Resultado | Por que morde |
|---|---|---|
| `uvx markitdown x.pdf` | `exit 1` | o pacote base não traz parser algum (falta o extra `[pdf]`) |
| PNG / PDF sem camada de texto | **`exit 0`, 1 byte** | falha **SILENCIOSA** — lida como "documento vazio" |
| despejar a saída no chat | ~1k tokens | reinjetados em toda request seguinte da sessão |

O `exit 0` com 1 byte é o *"ausência de sinal ≠ aprovação"* do CLAUDE.md em forma pura. **Por isso a guarda é script, não recado.**

## O que entra

- `.claude/skills/doc2md/SKILL.md` (746 palavras)
- `.claude/skills/doc2md/doc2md.sh` — mede bytes e falha em vermelho (`exit 4`), recusa imagem (`exit 3`), escolhe o extra do markitdown por extensão, e ensina a ler por recorte (`head -c` / `grep | cut`)

## Money-path — três armadilhas medidas no PDF real da Lider

1. **Decimal é BR:** o preço vem `111,400000`. `Number("111,400000")` é `NaN`.
2. **A 1ª ocorrência mente em multi-página:** `grep -m1 "TOTAL DAS MERCADORIAS"` acerta o rodapé da **pág. 1**, que está **em branco** (`C O N T I N U A . . .`); o `13638,00` só existe na pág. 2. Ler a primeira = fabricar zero.
3. **Descrição vem quebrada em N linhas** — o join é código nosso.

A skill fixa a regra: doc2md serve para **entender e navegar**; número que vira dinheiro passa por conferência ou parser testado.

## Fronteira explícita (anti-refactor-tentador)

`kb-ingest-document` roda `pdf-parse` numa **edge Deno**; markitdown é Python e **não roda lá**. A skill diz, em texto, para não propor essa troca. Ferramenta de SESSÃO, não caminho de produção.

## Evidência

| Teste | Esperado | Obtido |
|---|---|---|
| PDF real da Lider | converte | `exit 0`, 12.325B — **5/5 itens conferem** com o `.expected.ts` (código, qtd, preço, `cod_forn`, data) |
| PNG | recusa | `exit 3` |
| **Falsificação:** piso `999999B` num PDF bom | guarda dispara | `exit 4` — confirma que o vermelho realmente sai |
| Arquivo inexistente | erro de uso | `exit 2` |
| `shellcheck doc2md.sh` | limpo | `exit 0` |

Frontmatter validado pelo próprio harness (a skill foi registrada e ficou descobrível).

## Escopo

Só `.claude/skills/doc2md/` — nenhum arquivo de `src/`, `supabase/` ou migration. Sem deploy Lovable envolvido. Nenhum dos 7 PRs abertos toca `.claude/skills/`.

## Ressalva de método

A `superpowers:writing-skills` pede pressure-test com subagente no GREEN final; não rodei (o harness proíbe AgentTool sem pedido explícito). O que existe é baseline observada + os 4 caminhos do script executados — sólido para o script; a aderência da skill se prova no primeiro PDF real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)