### PR TITLE
test(hooks): a suíte do wt-orfas sai do poder não-medido — entra no laço do test:hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wt:label": "bash scripts/wt-map.sh label",
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean; do bash scripts/test-$t.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {


### PR DESCRIPTION
Achado colateral do #1845: `scripts/test-wt-orfas.sh` existia, rodava verde e **nenhum laço do CI o executava**. É a mesma classe de teste órfão que o #1808 corrigiu para 4 suítes — esta ficou de fora. O próprio `.github/workflows/ci.yml` declara que o laço do `test:hooks` é a única coisa que roda esses scripts: fora dele é poder não-medido.

## Provado hermético ANTES de entrar

O chip que gerou este PR pedia **decidir**, não presumir — ou entra no CI, ou se declara local-only como a família `heavy`. Verificado que entra:

- **Sem rede e sem `$HOME`**: o único externo do teste é `mktemp -d`. O `gh pr list` do `wt-orfas.sh` vive em `main()`, que o `source` não executa (guard `BASH_SOURCE`).
- **Não depende de config global do runner**: o repo git é descartável e configura `user.email`/`user.name` **localmente**; e há `SKIP` se o `git init` falhar.
- **Verde num ambiente não prova** (#1483): rodado também sob PATH com **GNU coreutils 9.11** à frente, nos **dois locales** (`LC_ALL=C` e `pt_BR.UTF-8`) — 32 casos ok, `exit 0`, saídas **byte-a-byte idênticas** ao macOS.

Isso importa porque o #1845 acabou de alinhar o `mtime_de` do `wt-orfas.sh` ao padrão portátil de `stat`: a partir daqui o caminho GNU passa a ser **exercitado de verdade**, não só correto no papel.

## Evidência

| gate | resultado |
|---|---|
| `test-wt-orfas.sh` isolado (macOS) | **exit 0** — 32 casos, 18s |
| idem sob GNU coreutils + `LC_ALL=C` | **exit 0** — saída idêntica |
| idem sob GNU coreutils + `pt_BR.UTF-8` | **exit 0** — saída idêntica |
| laço `test:hooks` completo | **exit 0** — 194 → **226 casos** (+32), com as sentinelas do `wt-orfas` na saída |
| **falsificação** | sabotando `prefixo_projeto` na FONTE, o laço sai **exit 1**: `FALHA prefixo do projeto (esperado '-Users-x-Projetos-afiacao', veio 'SABOTADO')` |

A falsificação é o que prova que a linha nova tem efeito — sem ela, "verde" não distingue "o teste passou" de "o teste não rodou".

## Nota de custo (não é deste PR, mas afeta o `validate`)

O laço é serial e cada suíte soma no caminho crítico. Medido isoladamente: `test-wt-orfas.sh` **18s**, contra `test-wt-clean.sh` **33s** e `test-wt-prune.sh` **197s** (estes dois do #1846, que simulam `du` lento com `sleep` real). Localmente o laço inteiro passou de 10 min. Vale um olhar futuro em relógio falso para os testes de `du` — fora do escopo daqui.

Conflito de linha com o #1846 (mesmo `test:hooks`) resolvido por **união**, com asserção de que `wt-orfas`, `wt-prune` e `wt-clean` sobreviveram todos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)