### PR TITLE
fix(hooks): a última leitura crua do motor de cross-sell pagina — e o invariante que a protegia mora FORA do arquivo [money-path]

### DIFF
--- a/src/hooks/__tests__/cross-sell-regras-paginacao.test.tsx
+++ b/src/hooks/__tests__/cross-sell-regras-paginacao.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+/**
+ * Guard money-path — a capa de 1.000 linhas do PostgREST na ÚLTIMA leitura crua do motor.
+ *
+ * `farmer_association_rules` era lida com `.select().gte().gte()` e mais nada: sem `.range()`,
+ * sem `fetchAllPages`. Todas as outras leituras deste hook já paginam (`farmer_client_scores`,
+ * `omie_products`, `get_skus_margem_positiva`, `sales_orders`; `profiles` é imune por ir em
+ * lotes de 100 via `.in()`), e `db/gatilho-farmer-fase2.sql` nomeava este sítio como a única
+ * leitura viva que ainda podia ser capada.
+ *
+ * A capa é SILENCIOSA: `error` null, `data` com 1.000 linhas, `insumos.regras = {ok:true,n:1000}`.
+ * O motor monta `assocMap` com menos regras do que existem e serve recomendação a menos — sem
+ * nada na tela dizendo que o modelo encolheu.
+ *
+ * DISCRIMINADOR — e ele é BINÁRIO, não de ordem. O gate de admissão do candidato é
+ * `if (clusterAdherence < 0.03 && assocBoost === 0) continue` (useCrossSellEngine ~788): um SKU
+ * que NINGUÉM da carteira comprou só entra na oferta se uma REGRA apontar para ele. Então a
+ * regra decisiva vive no índice 1.000 — a 1ª linha da 2ª página — e o SKU que ela sustenta
+ * aparece na recomendação ou não existe. Um assert de "recomendou alguma coisa" passaria nas
+ * duas versões; por isso `SKU_ISCA` (regra no índice 0) é o CONTROLE POSITIVO embutido: ele
+ * prova, na mesma execução, que a fixture recomenda e que a página 0 foi lida.
+ *
+ * ⚠️ Por que o volume desta tabela cresce, se hoje prod tem 24 regras (psql-ro, 21/08/2026):
+ * o produtor (`compute-association-rules-daily`) corta em `max_association_rules ?? 500` e
+ * filtra por `s_min`/`l_min` — os três são linhas de `recommendation_config`. Baixar o piso ou
+ * subir o teto é uma decisão de produto de UMA linha, que não tem como saber que existe um cap
+ * de 1.000 esperando do outro lado. É o mesmo racional que já paginou a leitura IRMÃ desta
+ * mesma tabela na edge (`_shared/recommend-leituras.ts`, "4 linhas em prod hoje. Pagina mesmo
+ * assim").
+ */
+const FARMER = 'farmer-1';
+
+const SKU_COMPRADO = 'sku-comprado';
+/** Sustentado pela regra do índice 0 — visível COM e SEM paginação. Controle positivo. */
+const SKU_ISCA = 'sku-regra-da-pagina-0';
+/** Sustentado SÓ pela regra do índice 1.000. Só existe se a 2ª página for lida. */
+const SKU_DECISIVO = 'sku-regra-da-pagina-1';
+
+const PAGINA = 1000;
+
+/**
+ * 1.001 regras: a página 0 enche (1.000) e a página 1 traz 1 — que é `< PAGINA` e encerra o
+ * laço. As 999 do meio são INERTES de propósito (antecedente que ninguém comprou): elas só
+ * ocupam a página, sem mexer no `assocBoostMap`, para o discriminador não depender delas.
+ */
+const REGRAS = [
+  {
+    id: 'regra-0000',
+    antecedent_product_ids: [SKU_COMPRADO],
+    consequent_product_ids: [SKU_ISCA],
+    confidence: 0.5,
+    lift: 2.0,
+    support: 0.5,
+  },
+  ...Array.from({ length: PAGINA - 1 }, (_, i) => ({
+    id: `regra-inerte-${String(i).padStart(4, '0')}`,
+    antecedent_product_ids: [`sku-nunca-comprado-${i}`],
+    consequent_product_ids: [`sku-irrelevante-${i}`],
+    confidence: 0.4,
+    lift: 1.5,
+    support: 0.2,
+  })),
+  {
+    id: 'regra-1000',
+    antecedent_product_ids: [SKU_COMPRADO],
+    consequent_product_ids: [SKU_DECISIVO],
+    confidence: 0.9,
+    lift: 4.0,
+    support: 0.6,
+  },
+];
+
+type Q = { tabela: string; ranges: Array<[number, number]>; orders: string[] };
+let queries: Q[] = [];
+
+/** Args de `farmer_recomendacoes_substituir` / `farmer_geracao_registrar` — onde `insumos` sai. */
+const registros: Array<Record<string, unknown>> = [];
+
+function linhasPorTabela(): Record<string, Record<string, unknown>[]> {
+  return {
+    farmer_client_scores: [
+      {
+        customer_user_id: 'cli-1',
+        farmer_id: FARMER,
+        health_score: 80,
+        answer_rate_60d: 50,
+        whatsapp_reply_rate_60d: 50,
+      },
+    ],
+    omie_products: [
+      { id: SKU_COMPRADO, codigo: 'A1', descricao: 'Já comprado', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 5 },
+      { id: SKU_ISCA, codigo: 'A2', descricao: 'Isca', valor_unitario: 200, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 5 },
+      { id: SKU_DECISIVO, codigo: 'A3', descricao: 'Decisivo', valor_unitario: 300, metadata: null, ativo: true, omie_codigo_produto: 3, estoque: 5 },
+    ],
+    sales_orders: [
+      {
+        customer_user_id: 'cli-1',
+        items: [{ product_id: SKU_COMPRADO, quantity: 2, unit_price: 100 }],
+        total: 200,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ],
+    profiles: [{ user_id: 'cli-1', name: 'Cliente 1', customer_type: 'industria', cnae: '2222' }],
+    farmer_category_conversion: [],
+    farmer_association_rules: REGRAS,
+    farmer_recommendations: [],
+    farmer_geracao_vigente: [],
+  };
+}
+
+/**
+ * Serve a página pedida — e, SEM `.range()`, devolve as 1.000 primeiras linhas. Esse ramo não
+ * é conveniência de teste: é o comportamento LITERAL do PostgREST, que capa a resposta em
+ * `db-max-rows` sem erro e sem aviso. É o que a versão quebrada recebia.
+ */
+function servir(q: Q, dados: Record<string, unknown>[]): Record<string, unknown>[] {
+  const ultimo = q.ranges.at(-1);
+  if (!ultimo) return dados.slice(0, PAGINA);
+  const [de, ate] = ultimo;
+  return dados.slice(de, ate + 1);
+}
+
+function stubChain(tabela: string): unknown {
+  const dados = linhasPorTabela()[tabela] ?? [];
+  const q: Q = { tabela, ranges: [], orders: [] };
+  queries.push(q);
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'limit', 'or', 'neq', 'filter', 'contains']) {
+    chain[m] = () => chain;
+  }
+  chain.order = (col: string) => { q.orders.push(col); return chain; };
+  chain.range = (de: number, ate: number) => { q.ranges.push([de, ate]); return chain; };
+  chain.single = () => ({ then: (r: (v: unknown) => void) => r({ data: dados[0] ?? null, error: null }) });
+  chain.maybeSingle = chain.single;
+  chain.insert = () => chain;
+  chain.upsert = () => chain;
+  chain.update = () => chain;
+  chain.delete = () => chain;
+  chain.then = (resolve: (v: unknown) => void) => {
+    const pagina = servir(q, dados);
+    resolve({ data: pagina, error: null, count: pagina.length });
+  };
+  return chain;
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (tabela: string) => stubChain(tabela),
+    rpc: (nome: string, args?: Record<string, unknown>) => {
+      if (nome === 'farmer_recomendacoes_substituir' || nome === 'farmer_geracao_registrar') {
+        registros.push(args ?? {});
+      }
+      if (nome === 'get_skus_margem_positiva') {
+        // Os dois candidatos são vendáveis: o custo não pode ser o motivo de sumirem.
+        const chain: Record<string, unknown> = {
+          order: () => chain,
+          range: () => chain,
+          then: (resolve: (v: unknown) => void) =>
+            resolve({ data: [{ product_id: SKU_ISCA }, { product_id: SKU_DECISIVO }], error: null }),
+        };
+        return chain;
+      }
+      return { then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }) };
+    },
+  },
+}));
+
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => ({ user: { id: FARMER }, isStaff: true }) }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() } }));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import { useCrossSellEngine } from '../useCrossSellEngine';
+
+beforeEach(() => {
+  queries = [];
+  registros.length = 0;
+  vi.clearAllMocks();
+});
+
+const consultasDeRegras = () => queries.filter((q) => q.tabela === 'farmer_association_rules');
+const ultimosInsumos = (): Record<string, unknown> =>
+  (registros[registros.length - 1]?.p_insumos ?? {}) as Record<string, unknown>;
+
+async function calcular() {
+  const { result } = renderHook(() => useCrossSellEngine());
+  await act(async () => { await result.current.calculateRecommendations(); });
+  return result;
+}
+
+describe('useCrossSellEngine — regras de associação paginam além da capa de 1.000', () => {
+  it('CONTROLE POSITIVO: a regra do índice 0 sustenta uma oferta (a fixture sabe recomendar)', async () => {
+    // Sem isto os asserts abaixo passariam de graça: "SKU ausente" é o desfecho de qualquer
+    // insumo faltando, então é preciso provar antes que este cenário produz oferta.
+    const result = await calcular();
+    const recomendados = result.current.recommendations.flatMap((c) => c.crossSell.map((r) => r.productId));
+    expect(recomendados).toContain(SKU_ISCA);
+    expect(result.current.erro).toBeNull();
+  });
+
+  it('a regra da 2ª página entra na oferta — o SKU que só ela sustenta é recomendado', async () => {
+    const result = await calcular();
+    const recomendados = result.current.recommendations.flatMap((c) => c.crossSell.map((r) => r.productId));
+    // Ninguém da carteira comprou este SKU: `clusterAdherence` é 0, e o gate `< 0.03` só o
+    // deixa passar por `assocBoost`. Lendo só a 1ª página, ele não existe.
+    expect(recomendados).toContain(SKU_DECISIVO);
+  });
+
+  it('e ela ganha o topo: `confidence`/`lift` maiores não podem ficar do outro lado da capa', async () => {
+    const result = await calcular();
+    const topo = result.current.recommendations[0]?.crossSell[0]?.productId;
+    // assocBoost = confidence × min(lift,5)/5 → isca 0,5×0,4 = 0,20 · decisivo 0,9×0,8 = 0,72.
+    // A capa não corta só volume: corta o TOPO, porque o corte é por ordem de leitura, não por
+    // força da regra. É a "armadilha do ranking" — o teto tem de ser o EIXO da decisão.
+    expect(topo).toBe(SKU_DECISIVO);
+  });
+
+  it('para de paginar quando a página vem incompleta (não busca infinitamente)', async () => {
+    await calcular();
+    const ranges = consultasDeRegras().flatMap((q) => q.ranges);
+    // 1ª cheia (1.000) → busca a 2ª; a 2ª traz 1 < 1.000 → para.
+    expect(ranges).toEqual([[0, 999], [1000, 1999]]);
+  });
+
+  it('a paginação usa `.order()` estável — sem ele o Postgres pode repetir ou pular linhas', async () => {
+    await calcular();
+    const consultas = consultasDeRegras();
+    expect(consultas.length).toBeGreaterThan(1); // provou que paginou
+    // `id` é a PK (`farmer_association_rules_pkey`), logo ordem TOTAL — é a mesma coluna que a
+    // leitura irmã da edge usa. Ordem parcial deixaria linhas empatadas em posição indefinida
+    // entre requests, que é como paginação pula e repete.
+    for (const q of consultas) expect(q.orders).toContain('id');
+  });
+
+  it('`insumos.regras` para de reportar 1.000 — a assinatura de cap sai do denominador da fase 2', async () => {
+    await calcular();
+    // `db/gatilho-farmer-fase2.sql` marca execução como `suspeita_cap` quando um insumo sem
+    // `esperado` traz n ≡ 1000. `regras` caía nessa checagem porque era a leitura crua; com a
+    // paginação o número passa a ser o REAL (1.001) e a suspeita deixa de ser permanente.
+    expect(ultimosInsumos().regras).toEqual({ ok: true, n: REGRAS.length });
+  });
+});

--- a/src/hooks/useCrossSellEngine.ts
+++ b/src/hooks/useCrossSellEngine.ts
@@ -497,28 +497,60 @@ export const useCrossSellEngine = () => {
       // expiraria a carteira inteira do farmer e apagaria cross-sells legítimos de todos os
       // clientes dele. Expirar por farmer só é seguro se o snapshot for COMPLETO — então a
       // completude precisa ser verificada, não presumida (achado do challenge Codex xhigh).
-      const { data: assocRules, error: erroAssoc } = (await supabase
-        .from('farmer_association_rules')
-        .select('antecedent_product_ids, consequent_product_ids, confidence, lift, support')
-        .gte('confidence', 0.05)
-        .gte('lift', 1.0)) as unknown as { data: AssocRuleRow[] | null; error: unknown };
-      if (erroAssoc) {
+      // PAGINADA, com `.order('id')` (PK ⇒ ordem TOTAL) ANTES do `.range`: era a ÚLTIMA leitura
+      // crua do motor — todas as vizinhas já passaram por `fetchAllPages`. A coluna de ordem não
+      // precisa estar no `select`.
+      //
+      // Hoje isto é defesa em profundidade, NÃO conserto de corte ativo: a RPC que publica as
+      // regras recusa lote acima de 1.000 (`TR003`) — conferido VIVO em prod por
+      // `pg_get_functiondef`, não no repo — e o escritor é único, então a tabela cabe numa
+      // página. Mas esse invariante mora numa FUNÇÃO DE BANCO aplicada à mão no SQL Editor, sem
+      // ligação nenhuma com este arquivo, e nenhum teste daqui consegue provar que a prod ainda
+      // o tem: DDL manual diverge do repo por desenho. Depender dele deste lado é depender de
+      // algo que ninguém enxerga ao editar esta linha.
+      //
+      // ⚠️ Se a tabela um dia passar de 1.000 DE VERDADE (subir `TR003` é migration de uma
+      // linha), mais páginas NÃO são a resposta: o publicador faz DELETE+INSERT na mesma
+      // transação e há DOIS gatilhos (cron 07:30 UTC e o botão staff “Regras de Associação”,
+      // em horário comercial) — uma substituição no meio da paginação mistura duas gerações de
+      // modelo e serve associação que NENHUMA das duas produziu. Aí a correção é ler o lote
+      // inteiro num ÚNICO tuple (`jsonb_agg` numa RPC), atômico por construção.
+      const assocRules = await fetchAllPages<AssocRuleRow>(
+        (de, ate) =>
+          supabase
+            .from('farmer_association_rules')
+            .select('antecedent_product_ids, consequent_product_ids, confidence, lift, support')
+            .gte('confidence', 0.05)
+            .gte('lift', 1.0)
+            .order('id', { ascending: true })
+            .range(de, ate) as unknown as PromiseLike<{ data: AssocRuleRow[] | null; error: unknown }>,
+        'farmer_association_rules/cross-sell',
+      ).catch((erro: unknown) => {
+        // Bug de CÓDIGO sobe CRU (#1782): rotular um `TypeError` de encadeamento quebrado como
+        // “não consegui ler as regras” é o mascaramento que `ehFalhaDePagina` existe para
+        // impedir — o defeito chegaria à vendedora com cara de falha de transporte.
+        if (!ehFalhaDePagina(erro)) throw erro;
         // NÃO move o head: este caminho lança SEM limpar a tela, então a execução não
         // concluiu e o que o operador vê segue sendo o resultado anterior. O head registra
         // execução CONCLUÍDA — mover aqui afirmaria um desfecho que não houve.
-        throw new Error(
-          mensagemDeErro(erroAssoc) ??
+        //
+        // A mensagem sai da CAUSA, não do erro assinado: a dele é jargão de helper
+        // (`fetchAllPages: página 0 (0-999) falhou`), que diz à vendedora MENOS do que o
+        // servidor já tinha dito.
+        throw erroComCausa(
+          mensagemDeErro(erro.cause) ??
             'Não consegui ler as regras de associação — o cálculo seria parcial e substituiria as recomendações atuais, então nada foi alterado.',
+          erro,
         );
-      }
+      });
       // `regras` NÃO é obrigatório-não-vazio: base sem padrão de coocorrência é estado
       // legítimo e o motor ainda recomenda por popularidade. Mas `ok: false` acima degrada,
       // porque aí o universo foi lido pela metade.
-      insumos.regras = { ok: true, n: (assocRules || []).length };
+      insumos.regras = { ok: true, n: assocRules.length };
 
       // Build map: antecedent product -> consequent products with scores
       const assocMap = new Map<string, { productId: string; confidence: number; lift: number; support: number }[]>();
-      for (const rule of assocRules || []) {
+      for (const rule of assocRules) {
         for (const ant of rule.antecedent_product_ids || []) {
           if (!assocMap.has(ant)) assocMap.set(ant, []);
           for (const cons of rule.consequent_product_ids || []) {

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -196,6 +196,7 @@ export const MODULOS: ModuloApp[] = [
       "src/hooks/__tests__/cross-sell-up-sell-ordem.test.tsx",
       "src/hooks/__tests__/cross-sell-aderencia-conta-clientes.test.tsx",
       "src/hooks/__tests__/cross-sell-escopo-carteira.test.tsx",
+      "src/hooks/__tests__/cross-sell-regras-paginacao.test.tsx",
       "src/hooks/__tests__/useAlertaCreditoCliente.test.ts",
       "src/hooks/__tests__/usePedidosProgramados.cancelamento.test.tsx",
       "src/hooks/__tests__/usePricingEngine.test.ts",


### PR DESCRIPTION
## O que era

`farmer_association_rules` era lida em [useCrossSellEngine.ts](src/hooks/useCrossSellEngine.ts) com `.select().gte().gte()` e mais nada — sem `.range()`, sem `fetchAllPages`. Era a **última** leitura crua do motor: `farmer_client_scores`, `omie_products`, `get_skus_margem_positiva` e `sales_orders` já paginavam; `profiles` é imune por ir em lotes de 100 via `.in()`.

Varredura confirma **sítio único**: nenhuma outra leitura viva dessa tabela via `.from()` em `src/` ou nas edges. `useBundleEngine.ts` nem lê a tabela (e já usa `fetchAllPages` 13×).

## A premissa da tarefa estava errada — e o PR não finge o contrário

O `>1.000` **não é alcançável hoje**. A RPC que publica as regras recusa lote acima de 1.000:

```
IF v_total > 1000 THEN
  RAISE EXCEPTION 'lote de % regras excede o teto de 1000' USING ERRCODE = 'TR003';
```

Conferido **vivo em prod** por `pg_get_functiondef` (não no repo):

| checagem | valor |
|---|---|
| `tem_TR003` | `true` |
| `teto_1000` | `true` |

Escritor único + `DELETE`+`INSERT` do lote ⇒ a tabela cabe numa página, e a leitura crua já devolvia o conjunto completo. Subir `max_association_rules` para 1.500 não faria a tabela crescer: a RPC recusaria e a geração anterior seria preservada.

**Então isto é defesa em profundidade, não conserto de corte ativo.** Vale mesmo assim por uma razão específica deste repo: o invariante mora numa **função de banco aplicada à mão no SQL Editor**, sem ligação nenhuma com este arquivo, e nenhum teste do CI consegue provar que a prod ainda o tem — DDL manual diverge do repo por desenho. Depender dele do lado do leitor é depender do que ninguém enxerga ao editar a linha. Custo hoje: **exatamente 1 request** (24 regras em prod).

## A correção

`fetchAllPages` com `.order('id')` **antes** do `.range()`. PK confirmada em prod: `id uuid` ⇒ ordem **total**. Sem ordem estável a paginação pula e repete linhas.

O erro deixa de ser engolido: bug de **código** sobe cru (`ehFalhaDePagina`, #1782) e só falha de página vira mensagem de negócio, com a causa do servidor preservada em vez do jargão do helper.

## ⚠️ Se `TR003` subir um dia, mais páginas são a correção ERRADA

Está registrado no código. O publicador faz `DELETE`+`INSERT` e há **dois** gatilhos — cron 07:30 UTC **e** o botão staff "Regras de Associação" ([EngineCards.tsx](src/components/analyticsSync/EngineCards.tsx)), em horário comercial. Paginar durante uma substituição mistura duas gerações do modelo e serve associação que **nenhuma das duas** produziu. Aí a resposta é ler o lote inteiro num tuple único (`jsonb_agg` numa RPC), atômico por construção.

## Teste — com controle positivo e falsificado 2×

O gate de admissão do candidato é binário: `if (clusterAdherence < 0.03 && assocBoost === 0) continue`. Um SKU que ninguém da carteira comprou **só** entra na oferta se uma regra apontar para ele. A regra decisiva vive no índice 1.000 — a 1ª linha da 2ª página.

| sabotagem | resultado |
|---|---|
| **A** — leitura crua de volta | 5 discriminadores ×, **controle positivo ✓** |
| **B** — só o `.order('id')` removido | exatamente **1** × (o teste de ordem) |

A **A** prova que os asserts medem paginação, não "a fixture funciona" — sem o controle positivo sobrevivendo, "SKU ausente" seria o desfecho de qualquer insumo faltando. A **B** isola o `.order`: é a única asserção que pega ordem instável, e é **estrutural** (verifica que a chamada foi feita), porque com mock o `slice` é determinístico.

A falsificação A também mostrou que o corte não tira só volume, tira o **topo**: a regra do índice 1.000 tinha `confidence` 0,9 / `lift` 4,0 contra 0,5 / 2,0 da isca — a regra mais forte do lado errado da capa, porque o corte é por ordem de leitura, não por força. Mesma armadilha do roteirizador já no `CLAUDE.md`.

## Verificação

| gate | resultado |
|---|---|
| `bun run typecheck` | `exit=0` |
| `bun run test` (cross-sell + bundle) | **27 arquivos / 145 testes** ✓ |
| `bun lint` | `exit=0` — 0 erros, 0 warnings novos |
| `manifesto.ts` | teste registrado (era órfão — falharia só no CI) |

## Fora de escopo, mas vale mais que este PR

As 24 regras vivas em prod ainda têm `sample_size=479` — o universo da fatia velha, não os ~30.939 do #1822. Se a edge estivesse no ar, a execução das 07:30 de hoje já teria publicado com o denominador novo. Sintoma de "merge ≠ produção".

🤖 Generated with [Claude Code](https://claude.com/claude-code)