### PR TITLE
fix(farmer): o MixGap colapsava zero, ERRO e nunca-abriu na mesma tela em branco [money-path]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -402,3 +402,49 @@ O head mostra **uma**. O log mostra **três**. Se o sensor tivesse ficado só no
 original, que estava verde com 49 asserts e 6 falsificações —, a resposta a *"com que frequência
 isso roda?"* seria "uma vez", e as outras duas teriam sido sobrescritas sem deixar rastro. A lição do
 capítulo anterior deixou de ser argumento e virou medição: **na primeira execução real**.
+
+---
+
+## O sensor que colapsa TRÊS estados em um (MixGap, 2026-08-21)
+
+Continuação direta da fatia do denominador (`farmer-apriori-denominador.md`, #1853): ao segmentar o Apriori por conta, o MixGap sai de **116 para ~84 clientes com gap**. A pergunta que a mudança faz nascer — *"a queda foi a esperada, ou o card quebrou?"* — era **irrespondível**, e não por falta de dado: por falta de **discriminante**.
+
+```tsx
+if (totalComGap > 0 && !tracked.current) track('carteira.mixgap_visto', { total_com_gap: totalComGap });
+if (!data || data.totalComGap === 0) return null;
+```
+
+`useMyMixGap` **lança** quando a RPC falha, então no erro `data` fica `undefined` — a **mesma** condição do zero. Três estados, uma tela em branco e um silêncio:
+
+| estado real | tela | PostHog |
+|---|---|---|
+| zero oportunidades | (nada) | (nada) |
+| erro de leitura | (nada) | (nada) |
+| vendedor nunca abriu | (nada) | (nada) |
+
+É a irmã de UI do §6/§12 do money-path: lá a leitura falha calada e o motivo morre no `catch`; aqui os dois chegam à tela **como ausência de oportunidade**. E é a forma mais barata do "zero sem denominador não julga desenho": o zero existia, só não era distinguível de nada.
+
+### A regra que isto acrescenta
+
+**Um sensor de adoção precisa distinguir "não houve" de "não consegui" ANTES de ser usado como denominador.** Um contador que soma os dois mede uma coisa que não existe. O tell é sintático e barato de procurar: **um `return null` que serve mais de um estado**, ou um `?? 0` no payload de telemetria.
+
+Duas consequências no desenho:
+
+- **O evento sai com `total_com_gap: null` no erro, nunca `0`.** Mandar zero somaria falha de leitura à série de "carteiras sem oportunidade" e fabricaria exatamente o número que o sensor existe para medir (§2 — ausente ≠ zero). O assert que carrega isso é `expect(ev.total_com_gap).not.toBe(0)`, e a falsificação correspondente (trocar `null` por `0`) fica vermelha só nele.
+- **Ausência de ACESSO não é um estado do card.** `get_meu_mixgap` devolve `NULL` para não-staff; contar isso como "visto" poluiria o denominador com quem nunca poderia ver a tela. Não renderiza e **não emite** — a única ausência de evento legítima.
+
+E a guarda de "emitir uma vez" passou de booleano para **o estado emitido**: `erro → zero → com_gap` na mesma montagem é a transição que separa falha transitória de carteira realmente vazia, e um `useRef<boolean>` a engoliria.
+
+### Medição que também recalibrou a fila
+
+Ao medir os candidatos de fatia (todos com denominador, prod via `psql-ro`), a ordem de gravidade que eu havia proposto **se inverteu**:
+
+| defeito (denominador) | ativo hoje | após o deploy do #1853 |
+|---|---|---|
+| tupla fabricada — MixGap (139 grupos / 116 clientes) | 9 grupos; 5 clientes com score inflado 14,3%; **0 mudam de família** | **0 de 130** |
+| tupla fabricada — Melhorias (16 consequentes) | **0** | 0 |
+| `recommend` sem filtro de status (23.113 pares) | **5 pares, 3 clientes** (0,02%) | igual |
+
+Eu havia chamado a tupla fabricada (`max(confidence)` × `max(lift)` de regras diferentes) de "o único que fabrica número na tela" e recomendado corrigi-la primeiro. O número **é** fabricado, mas não muda a decisão em nenhum cliente — e a própria segmentação a zera, porque com regras por conta cada grupo passa a ter uma regra só. A previsão do Codex de que pioraria com mais regras **não se confirmou**: 14 regras segmentadas produzem menos grupos multi-regra que 24 globais.
+
+**A lição de método:** severidade herdada de um parecer — inclusive de uma revisão adversária boa — continua sendo hipótese até ter denominador. As três medições custaram três queries e trocaram a fatia inteira.

--- a/src/components/farmer/MixGapCard.tsx
+++ b/src/components/farmer/MixGapCard.tsx
@@ -1,40 +1,121 @@
 import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { MoreVertical } from 'lucide-react';
+import { MoreVertical, Search, AlertTriangle } from 'lucide-react';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem,
 } from '@/components/ui/dropdown-menu';
+import { EmptyState } from '@/components/EmptyState';
 import { useMyMixGap } from '@/hooks/useMyMixGap';
 import { useMarkMixGapFeedback } from '@/hooks/useMarkMixGapFeedback';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { buildPorQue } from '@/lib/mixgap/format';
 import { track } from '@/lib/analytics';
 
+/**
+ * O card colapsava TRÊS estados numa tela em branco só, e o evento só saía num deles.
+ *
+ *   `if (totalComGap > 0 && !tracked.current) track('carteira.mixgap_visto', …)`
+ *   `if (!data || data.totalComGap === 0) return null;`
+ *
+ * Como `useMyMixGap` LANÇA quando a RPC falha, `data` fica `undefined` no erro — mesma
+ * condição do zero. Então "não há oportunidade", "não consegui ler" e "o vendedor nunca
+ * abriu a tela" produziam o mesmo silêncio, na tela e no PostHog. É o §6/§12 do money-path
+ * (a leitura que falha calada, o motivo que morre) na forma de ADOÇÃO: sem denominador,
+ * zero não julga desenho nenhum (`docs/historico/fase-sem-sinal.md`).
+ *
+ * Não é hipótese: o motor por trás deste card está saindo de 116 para ~84 clientes com gap
+ * (a fatia do denominador, #1853 — medido em prod via psql-ro). Sem separar os estados não
+ * há como distinguir "caiu para 84" de "quebrou e sumiu", que é exatamente a pergunta que a
+ * mudança faz nascer.
+ *
+ * ⚠️ O evento leva `total_com_gap: null` no erro, nunca `0`. Mandar zero seria fabricar o
+ * número que o sensor existe para medir (§2 — ausente ≠ zero): a série de adoção passaria a
+ * somar falhas de leitura como se fossem carteiras sem oportunidade.
+ */
+type EstadoMixGap = 'com_gap' | 'zero' | 'erro';
+
 export function MixGapCard() {
-  const { data } = useMyMixGap();
+  const { data, error, isLoading } = useMyMixGap();
   const { mutate: markFeedback } = useMarkMixGapFeedback();
   const { isImpersonating } = useImpersonation();
-  const totalComGap = data?.totalComGap ?? 0;
-  const tracked = useRef(false);
+
+  // `data === null` é a RPC dizendo "você não é staff" (ela retorna NULL sem uid/sem role):
+  // não é um estado do card, é ausência de acesso — e aí o card não deve existir mesmo.
+  // `undefined` com a query desabilitada (sem user) cai no mesmo lugar.
+  const semAcesso = !isLoading && !error && (data === null || data === undefined);
+  const estado: EstadoMixGap | null =
+    isLoading || semAcesso ? null : error ? 'erro' : (data!.totalComGap > 0 ? 'com_gap' : 'zero');
+
+  const trackedEstado = useRef<EstadoMixGap | null>(null);
   useEffect(() => {
-    if (totalComGap > 0 && !tracked.current) {
-      tracked.current = true;
-      track('carteira.mixgap_visto', { total_com_gap: totalComGap });
-    }
-  }, [totalComGap]);
-  if (!data || data.totalComGap === 0) return null;
+    // Um evento por estado RESOLVIDO. A guarda por estado (e não por booleano) deixa passar a
+    // transição erro → zero → com_gap dentro da mesma montagem, que é o dado que separa uma
+    // falha transitória de uma carteira realmente vazia.
+    if (!estado || trackedEstado.current === estado) return;
+    trackedEstado.current = estado;
+    track('carteira.mixgap_visto', {
+      estado,
+      total_com_gap: estado === 'erro' ? null : data!.totalComGap,
+    });
+  }, [estado, data]);
+
+  if (semAcesso) return null;
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <Skeleton className="h-4 w-48" />
+          <Skeleton className="h-3 w-64 mt-1.5" />
+        </CardHeader>
+        <div className="divide-y divide-border">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="p-3"><Skeleton className="h-4 w-full" /></div>
+          ))}
+        </div>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <EmptyState
+          tone="operational"
+          icon={AlertTriangle}
+          title="Não consegui carregar as oportunidades"
+          description="A leitura da carteira falhou — isto NÃO significa que não há oportunidades. Recarregue a página; se persistir, avise o suporte."
+        />
+      </Card>
+    );
+  }
+
+  if (data!.totalComGap === 0) {
+    return (
+      <Card>
+        <EmptyState
+          tone="operational"
+          icon={Search}
+          title="Nenhuma oportunidade de cross-sell agora"
+          description="Todos os clientes da sua carteira já compram as famílias que clientes parecidos compram — ou as oportunidades abertas já foram marcadas."
+        />
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <CardHeader className="pb-2">
         <h2 className="text-base font-medium">Oportunidades de cross-sell</h2>
         <p className="text-2xs text-muted-foreground">
-          {data.totalComGap} clientes da sua carteira sem uma família que clientes parecidos compram
+          {data!.totalComGap} clientes da sua carteira sem uma família que clientes parecidos compram
         </p>
       </CardHeader>
       <div className="divide-y divide-border">
-        {data.lista.slice(0, 20).map((g) => (
+        {data!.lista.slice(0, 20).map((g) => (
           <div key={g.customer_user_id} className="p-3 flex items-center justify-between gap-3 hover:bg-muted/30">
             <Link
               to={`/admin/customers/${g.customer_user_id}/360`}

--- a/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
+++ b/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * Guard money-path — os três estados do MixGap não podem colapsar numa tela em branco só.
+ *
+ * O card fazia `if (!data || data.totalComGap === 0) return null;` e só emitia
+ * `carteira.mixgap_visto` quando `totalComGap > 0`. Como `useMyMixGap` LANÇA quando a RPC
+ * falha, `data` fica `undefined` no erro — a MESMA condição do zero. Resultado: "não há
+ * oportunidade", "não consegui ler" e "o vendedor nunca abriu a tela" produziam o mesmo
+ * silêncio, na tela e no PostHog.
+ *
+ * Por que agora: o motor por trás do card saiu de 116 para ~84 clientes com gap (#1853,
+ * medido em prod). Sem separar os estados não há como distinguir "caiu para 84" de "quebrou
+ * e sumiu" — a fase seguinte nasceria sem o sinal que a julga
+ * (`docs/historico/fase-sem-sinal.md`).
+ *
+ * O HOOK roda de verdade; só o supabase é mockado. Mockar `useMyMixGap` provaria apenas que
+ * o card renderiza um estado que eu mesmo montei — e o defeito mora exatamente na tradução
+ * "RPC falhou" → "data undefined" → "tela igual à do zero".
+ */
+
+const FARMER = 'farmer-a';
+
+type Resposta = { data: unknown; error: { message: string } | null };
+let resposta: Resposta = { data: { total_com_gap: 0, lista: [] }, error: null };
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: () => Promise.resolve(resposta) },
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: FARMER }, isStaff: true, loading: false }),
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/hooks/useMarkMixGapFeedback', () => ({
+  useMarkMixGapFeedback: () => ({ mutate: vi.fn() }),
+}));
+vi.mock('react-router-dom', () => ({
+  Link: ({ children }: { children: React.ReactNode }) => <a href="#">{children}</a>,
+}));
+const track = vi.fn();
+vi.mock('@/lib/analytics', () => ({ track: (...a: unknown[]) => track(...a) }));
+
+import { MixGapCard } from '../MixGapCard';
+
+function renderCard() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MixGapCard />
+    </QueryClientProvider>,
+  );
+}
+
+/** O evento de `carteira.mixgap_visto`, ou undefined se ele nunca saiu. */
+function eventoVisto(): Record<string, unknown> | undefined {
+  const c = track.mock.calls.find((c) => c[0] === 'carteira.mixgap_visto');
+  return c?.[1] as Record<string, unknown> | undefined;
+}
+
+const COM_GAP = {
+  total_com_gap: 2,
+  lista: [
+    { customer_user_id: 'c1', nome: 'Marcenaria Alfa', familia_faltante: 'VERNIZ', confidence: 0.4, lift: 3.1, evidence_count: 2 },
+    { customer_user_id: 'c2', nome: 'Marcenaria Beta', familia_faltante: 'SELADOR', confidence: 0.3, lift: 2.2, evidence_count: 1 },
+  ],
+};
+
+beforeEach(() => {
+  track.mockClear();
+});
+
+describe('MixGapCard — os três estados se separam', () => {
+  it('ZERO real: mostra estado vazio explícito e emite o evento COM o zero', async () => {
+    resposta = { data: { total_com_gap: 0, lista: [] }, error: null };
+    renderCard();
+
+    // Antes: `return null` — o vendedor não via nada e nada era registrado.
+    expect(await screen.findByText(/Nenhuma oportunidade de cross-sell agora/i)).toBeTruthy();
+    await waitFor(() => expect(eventoVisto()).toBeTruthy());
+    expect(eventoVisto()).toMatchObject({ estado: 'zero', total_com_gap: 0 });
+  });
+
+  it('ERRO de leitura: diz que FALHOU e o evento leva total null — nunca 0', async () => {
+    resposta = { data: null, error: { message: 'timeout' } };
+    renderCard();
+
+    expect(await screen.findByText(/Não consegui carregar as oportunidades/i)).toBeTruthy();
+    await waitFor(() => expect(eventoVisto()).toBeTruthy());
+
+    const ev = eventoVisto()!;
+    expect(ev.estado).toBe('erro');
+    // O assert que carrega o §2 (ausente ≠ zero): mandar `0` aqui somaria falha de leitura
+    // à série de "carteiras sem oportunidade" e fabricaria o número que o sensor existe
+    // para medir. `null` é a única resposta honesta.
+    expect(ev.total_com_gap).toBeNull();
+    expect(ev.total_com_gap).not.toBe(0);
+  });
+
+  it('ERRO e ZERO são telas DIFERENTES — é isto que o defeito colapsava', async () => {
+    resposta = { data: { total_com_gap: 0, lista: [] }, error: null };
+    const zero = renderCard();
+    await screen.findByText(/Nenhuma oportunidade de cross-sell agora/i);
+    const textoZero = zero.container.textContent ?? '';
+    zero.unmount();
+
+    resposta = { data: null, error: { message: 'timeout' } };
+    const erro = renderCard();
+    await screen.findByText(/Não consegui carregar as oportunidades/i);
+    const textoErro = erro.container.textContent ?? '';
+
+    expect(textoZero).not.toBe(textoErro);
+    // E o texto do erro precisa desfazer ativamente a leitura errada, não só ser diferente.
+    expect(textoErro).toMatch(/NÃO significa que não há oportunidades/i);
+  });
+
+  it('COM GAP: lista os clientes e o evento leva o total real', async () => {
+    resposta = { data: COM_GAP, error: null };
+    renderCard();
+
+    expect(await screen.findByText('Marcenaria Alfa')).toBeTruthy();
+    expect(screen.getByText('Marcenaria Beta')).toBeTruthy();
+    await waitFor(() => expect(eventoVisto()).toBeTruthy());
+    expect(eventoVisto()).toMatchObject({ estado: 'com_gap', total_com_gap: 2 });
+  });
+
+  it('SEM ACESSO (a RPC devolve NULL para não-staff): não renderiza e NÃO emite evento', async () => {
+    resposta = { data: null, error: null };
+    const { container } = renderCard();
+
+    await waitFor(() => expect(container.textContent).toBe(''));
+    // Ausência de acesso não é ausência de oportunidade: contá-la como "visto" poluiria o
+    // denominador da adoção com quem nunca poderia ver o card.
+    expect(eventoVisto()).toBeUndefined();
+  });
+
+  it('CARREGANDO não conta como visto — o evento espera o estado RESOLVER', async () => {
+    let liberar: (r: Resposta) => void = () => {};
+    const pendente = new Promise<Resposta>((res) => { liberar = res; });
+    resposta = { data: { total_com_gap: 0, lista: [] }, error: null };
+    vi.spyOn(await import('@/integrations/supabase/client'), 'supabase', 'get').mockReturnValue({
+      rpc: () => pendente,
+    } as never);
+
+    renderCard();
+    // Em voo: nada de evento. Emitir aqui inflaria a adoção com montagens que nunca viraram
+    // um estado observável pelo vendedor.
+    expect(eventoVisto()).toBeUndefined();
+
+    liberar({ data: COM_GAP, error: null });
+    await waitFor(() => expect(eventoVisto()).toBeTruthy());
+    expect(eventoVisto()).toMatchObject({ estado: 'com_gap' });
+  });
+});


### PR DESCRIPTION
## O defeito

`useMyMixGap` **lança** quando a RPC falha, então `data` fica `undefined` no erro — a **mesma** condição do zero. Com

```tsx
if (totalComGap > 0 && !tracked.current) track('carteira.mixgap_visto', { total_com_gap: totalComGap });
if (!data || data.totalComGap === 0) return null;
```

três estados produziam o mesmo silêncio, na tela e no PostHog:

| estado real | tela | PostHog |
|---|---|---|
| zero oportunidades | (nada) | (nada) |
| **erro de leitura** | (nada) | (nada) |
| vendedor nunca abriu | (nada) | (nada) |

É o §6/§12 do money-path (leitura que falha calada, motivo que morre) na forma de **adoção** — e a forma mais barata do "zero sem denominador não julga desenho" (`docs/historico/fase-sem-sinal.md`).

## Por que agora

O motor por trás deste card sai de **116 para ~84 clientes com gap** (#1853, medido em prod via `psql-ro`). Sem separar os estados não há como distinguir "caiu para 84" de "quebrou e sumiu" — a pergunta que a própria mudança faz nascer. Superfície de uso nasce **com** o sensor.

## O desenho

- **`total_com_gap: null` no erro, nunca `0`.** Mandar zero somaria falha de leitura à série de "carteiras sem oportunidade" e fabricaria exatamente o número que o sensor existe para medir (§2 — ausente ≠ zero).
- **Ausência de ACESSO não é estado do card.** `get_meu_mixgap` devolve `NULL` para não-staff: não renderiza e **não emite**. É a única ausência de evento legítima — contá-la poluiria o denominador com quem nunca poderia ver a tela.
- **A guarda de "emitir uma vez" passou de booleano para o ESTADO emitido.** `erro → zero → com_gap` na mesma montagem é a transição que separa falha transitória de carteira vazia; um `useRef<boolean>` a engoliria.
- **Carregando não conta como visto** — o evento espera o estado resolver.

## A medição também recalibrou a fila

Eu havia recomendado corrigir primeiro a **tupla fabricada** (`max(confidence)` × `max(lift)` de regras diferentes). Medido em prod, com denominador:

| defeito (denominador) | ativo hoje | após o deploy do #1853 |
|---|---|---|
| tupla fabricada — MixGap (139 grupos / 116 clientes) | 9 grupos; 5 clientes com score inflado 14,3%; **0 mudam de família** | **0 de 130** |
| tupla fabricada — Melhorias (16 consequentes) | **0** | 0 |
| `recommend` sem filtro de status (23.113 pares) | **5 pares, 3 clientes** (0,02%) | igual |

O número **é** fabricado, mas não muda decisão em nenhum cliente — e a própria segmentação o zera (com regras por conta, cada grupo passa a ter uma regra só). A previsão do Codex de que pioraria com mais regras **não se confirmou**. Lição de método registrada: severidade herdada de um parecer — inclusive de uma revisão adversária boa — é hipótese até ter denominador.

## Provas

**6 testes** com o HOOK rodando de verdade; só o supabase é mockado. Mockar `useMyMixGap` provaria apenas que o card renderiza um estado que eu mesmo montei — e o defeito mora exatamente na tradução "RPC falhou" → `data undefined` → "tela igual à do zero".

**3 falsificações, cada uma pegando os asserts certos:**

| sabotagem | vermelhos |
|---|---|
| F1 — evento volta a sair só em `com_gap` | `zero` + `erro` |
| F2 — erro reporta `0` em vez de `null` | **só** o assert do §2 |
| F3 — erro renderiza a tela do zero | `erro` + "telas diferentes" |

Gates locais: `typecheck` 0 · `lint` 0 errors · `knip` 0 · suíte do card 6/6. O `manifesto.gate` foi validado rodando `validarManifesto()` direto (0 problemas) — sob a carga da máquina o vitest do gate estoura o timeout de 20s.

## Deploy

**Frontend-only: Publish.** Sem migration, sem edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
