### PR TITLE
fix(codex): modelo recusado pela conta vira exit 78 com ação — não CODEX_FALHOU genérico

### DIFF
--- a/scripts/codex-async.sh
+++ b/scripts/codex-async.sh
@@ -21,6 +21,7 @@
 #   - preflight (binário + auth) ANTES de gastar tempo/quota, com instrução clara;
 #   - retry com backoff (20s/60s) só em transitório (rate limit/timeout/overload);
 #   - cota esgotada NÃO é transitório → falha na hora instruindo o Caminho B;
+#   - modelo recusado pela conta (400) → exit 78, instruindo CONFIG (≠ cota, ≠ retry);
 #   - mktemp XXXXXX (sem colisão de tmp entre execuções paralelas);
 #   - sandbox read-only (consulta nunca escreve no repo).
 set -u
@@ -88,6 +89,19 @@ for backoff in "${backoffs[@]}"; do
   if grep -qiE 'usage limit|quota|plan limit' "$err"; then
     echo "COTA_ESGOTADA: janela rolante de 7d do ChatGPT Plus esgotou. Siga o Caminho B (validação adversária própria + registrar 'REVISÃO INDEPENDENTE PENDENTE') — docs/agent/money-path.md." >&2
     exit 75
+  fi
+  # modelo recusado pela CONTA = erro de CONFIG. Não é cota (esperar não resolve) nem
+  # transitório (repetir não resolve): as duas saídas erradas custam tempo apontando para
+  # o lugar errado. Medido em 2026-08-22: os 10 nomes tentados (gpt-5.6-sol, -codex, 5.1,
+  # 5, o3, codex-mini-latest…) voltaram o MESMO 400, então o eixo não é o nome do modelo
+  # — é o direito de acesso da conta ao Codex. Por isso a instrução cobre os dois: trocar
+  # o modelo E revalidar o login.
+  if grep -qiE 'model is not supported|unsupported_model|model_not_found' "$err"; then
+    echo "MODELO_NAO_ACEITO: o modelo '$modelo' não é aceito por esta conta Codex (HTTP 400)." >&2
+    echo "  → passe outro com -m, ou ajuste 'model =' em \${CODEX_HOME:-~/.codex}/config.toml;" >&2
+    echo "  → se NENHUM modelo passar, é acesso da conta: rode 'codex login' e confira a assinatura." >&2
+    echo "  (não é cota nem falha transitória: esperar e repetir não consertam config.)" >&2
+    exit 78
   fi
   # transitório (rede/limite/kill do watchdog) → tenta de novo
   if grep -qiE 'rate.?limit|429|timed?.?out|overloaded|temporarily|connection|ECONN|ETIMEDOUT|5[0-9][0-9]' "$err" || [ "$rc" -ge 124 ]; then

--- a/scripts/test-codex-async.sh
+++ b/scripts/test-codex-async.sh
@@ -23,6 +23,7 @@ echo x >> "$CODEX_STUB_COUNT"
 case "$CODEX_STUB_MODE" in
   ok)        echo "parecer: aprovado com ressalvas"; exit 0 ;;
   quota)     echo "You have reached your usage limit" >&2; exit 1 ;;
+  modelo)    echo 'ERROR: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The '"'"'gpt-5.6-sol'"'"' model is not supported when using Codex with a ChatGPT account."}}' >&2; exit 1 ;;
   ratelimit) n=$(wc -l < "$CODEX_STUB_COUNT" | tr -d ' ')
              if [ "$n" -ge 2 ]; then echo "parecer pós-retry"; exit 0
              else echo "429 rate limit exceeded" >&2; exit 1; fi ;;
@@ -67,6 +68,29 @@ run quota "x" >/dev/null 2>&1; rc=$?
 caso_exit "cota esgotada → 75" 75 "$rc"
 if [ "$(invocacoes)" -eq 1 ]; then echo "  ok    cota NÃO faz retry (1 invocação)"
 else echo "  FAIL  cota fez retry ($(invocacoes) invocações)"; fail=1; fi
+
+echo "── modelo recusado pela conta ──"
+# 400 do servidor quando o modelo do config não vale para a conta (2026-08-22: os 10
+# nomes testados foram recusados, então NÃO é erro de digitação do nome — é direito de
+# acesso). Antes caía no CODEX_FALHOU genérico: rc=1 e um tail de stderr, sem dizer o
+# que fazer. Confundir com cota manda para o Caminho B, que é esperar — e esperar não
+# conserta config.
+saida=$(run modelo "x" 2>&1); rc=$?
+caso_exit "modelo recusado → 78 (EX_CONFIG), não 75 nem 1" 78 "$rc"
+if [ "$(invocacoes)" -eq 1 ]; then echo "  ok    modelo recusado NÃO faz retry (1 invocação)"
+else echo "  FAIL  modelo recusado fez retry ($(invocacoes) invocações)"; fail=1; fi
+case "$saida" in
+  *MODELO_NAO_ACEITO*) echo "  ok    diagnóstico próprio (MODELO_NAO_ACEITO)" ;;
+  *) echo "  FAIL  sem diagnóstico próprio: $(printf '%s' "$saida" | tr '\n' ' ' | cut -c1-90)"; fail=1 ;;
+esac
+case "$saida" in
+  *"codex login"*|*config.toml*) echo "  ok    diz o que FAZER (login/config)" ;;
+  *) echo "  FAIL  não instrui a ação"; fail=1 ;;
+esac
+case "$saida" in
+  *Caminho\ B*) echo "  FAIL  mandou para o Caminho B (esperar não conserta config)"; fail=1 ;;
+  *) echo "  ok    NÃO manda para o Caminho B" ;;
+esac
 
 out="$(run ratelimit "x" 2>/dev/null)"; rc=$?
 caso_exit "rate limit transitório → retry → 0" 0 "$rc"


### PR DESCRIPTION
## O que

`codex-async.sh` classifica o desfecho do `codex exec` para dizer o que fazer: cota esgotada
→ exit 75 + Caminho B; sem auth → 77; transitório → retry. O **400 de modelo recusado pela
conta** não estava classificado: caía no `CODEX_FALHOU (rc=1)` genérico, que devolve um `tail`
do stderr e nenhuma ação.

## Como apareceu

Rodando o ritual `/codex` do #1856 (money-path), em 2026-08-22:

```
ERROR: {"status":400,"message":"The 'gpt-5.6-sol' model is not supported
        when using Codex with a ChatGPT account."}
CODEX_FALHOU (rc=1) após 1 tentativa(s). stderr: …
```

`gpt-5.6-sol` é o default de `~/.codex/config.toml`, então **toda** sessão que usa o ritual
sem `-m` bate nisso e recebe um diagnóstico que não diz o que fazer.

**O eixo não é o nome do modelo.** Testei 10: `gpt-5.6-sol` · `gpt-5.6-codex` ·
`gpt-5.1-codex` · `gpt-5-codex` · `gpt-5.1-codex-max` · `gpt-5.2` · `gpt-5.1` · `gpt-5` ·
`o3` · `codex-mini-latest`. **Todos** voltaram o mesmo 400 — então é direito de acesso da
conta ao Codex, não erro de digitação. Por isso a mensagem nova cobre os dois: trocar o
modelo **e** revalidar o login.

## O que este PR NÃO conserta (dito por extenso)

Não devolve o acesso ao Codex — isso é do plano/login do founder. O ritual `/codex` segue
indisponível até `codex login` (ou a assinatura) ser resolvido. O que muda é o erro parar de
apontar para o lugar errado.

E **não** é o caso de o script confundir cota com config: uma primeira falha, dias antes, saiu
com **exit 75** legitimamente (o stderr casava `usage limit`), e esta saiu com **exit 1**. O
classificador distinguiu as duas — o buraco era a ausência de uma terceira classe, não uma
fusão de duas.

## O fix

Exit **78** (EX_CONFIG — config errada, ao lado de 75=cota e 77=sem auth), **sem retry**
(repetir não conserta config) e **sem Caminho B** (esperar também não), com a ação em duas
linhas: trocar o modelo, e revalidar o login se nenhum passar.

## Prova

Teste primeiro, vermelho pelo defeito real (`want exit 78, got 1` · "sem diagnóstico próprio"
· "não instrui a ação"). O stub reproduz o 400 **verbatim** do servidor. Falsificado: sabotar
a classificação derruba 3 casos.

Um dos casos afirma que a saída **não** manda para o Caminho B — e ele pegou a primeira versão
da minha mensagem, que citava "Caminho B" para negá-lo. A frase foi reescrita em vez de o
teste ser afrouxado.

`scripts/test-codex-async.sh` PASS (todos os casos) · `shellcheck` limpo · validado também
contra o Codex **real**, não só o stub.

Validação real (`-t 300`, tentativa única):

```
EXIT_REAL=78
MODELO_NAO_ACEITO: o modelo 'gpt-5.6-sol' não é aceito por esta conta Codex (HTTP 400).
  → passe outro com -m, ou ajuste 'model =' em ${CODEX_HOME:-~/.codex}/config.toml;
  → se NENHUM modelo passar, é acesso da conta: rode 'codex login' e confira a assinatura.
```

## Achado que só a validação real mostrou (NÃO corrigido — e por quê)

Na primeira tentativa contra o Codex real usei `-t 60` e o resultado foi **3 retries**, não a
classificação nova. Causa: o `codex exec` leva ~60–75s só no setup (carrega skills, emite
warnings) **antes** de a request sair, então o watchdog o mata antes de o 400 chegar. Sem
resposta no stderr não há o que classificar — `rc=143` cai em transitório e o script tenta de
novo, pagando o setup inteiro a cada volta.

O comportamento está **certo**: um kill do watchdog é genuinamente ambíguo, e inventar uma
classe a partir de stderr vazio seria adivinhar. O default (`-t 1200`) dá folga de sobra. Fica
registrado porque é contraintuitivo: **encurtar o `-t` converte um erro de config em espera
longa**, e o stub nunca exercita isso — ele responde instantaneamente, então não existe corrida
entre watchdog e servidor. É o tipo de coisa que só aparece mirando o alvo real.
