### PR TITLE
fix(farmer): o gatilho da fase 2 concluia sobre populacao com n=1 — e o ato de verificar apagava o alarme

### DIFF
--- a/db/gatilho-farmer-fase2.sql
+++ b/db/gatilho-farmer-fase2.sql
@@ -245,6 +245,36 @@ SELECT
       || 'pre-requisitos da §7.5 estao fechados (regras no bundle; e carteira_com_historico_'
       || 'utilizavel, que separa cliente com PEDIDO de cliente cujos itens RESOLVEM para SKU). '
       || 'Este vazio ja e julgavel: siga para o desenho da expiracao DESTE motor.'
+    -- 7. **Um denominador de UM ator nao licencia conclusao POPULACIONAL.** Esta e a forma que
+    --    a fase-sem-sinal assume DENTRO do proprio gatilho. Medido em 21/08: as 14 execucoes
+    --    que a tabela tem sao de 1 farmer so — o founder, VERIFICANDO o sensor — e 2 dos 3
+    --    farmers com carteira nunca abriram a tela. O arquivo ja EXPUNHA o fato (`farmers` e
+    --    `farmers_com_carteira` saem na linha, e o comentario deles ate nomeia a adocao); o
+    --    que faltava era o VEREDITO agir sobre ele. Relatar sem poder concluir e o defeito.
+    --
+    --    Por que ACIMA do `ENCERRE`: `ENCERRE` e afirmacao UNIVERSAL ("o vazio-de-verdade nao
+    --    acontece neste motor"), e universal exige amostra que represente a populacao. Com 20
+    --    julgaveis feitos clique a clique por uma pessoa, o gatilho encerraria a linha com
+    --    n=1 — o "agregado esconde o motor" (item 4) uma camada acima, agora sobre PESSOAS.
+    --    Nao e hipotetico: o executor unico ja produziu 14 dos 20.
+    --
+    --    Por que ABAIXO do `vazios_completos > 0`: aquilo e afirmacao de EXISTENCIA, e uma
+    --    ocorrencia basta para prova-la, venha de quem vier. Amostra enviesada derruba o
+    --    universal, nao o existencial — rebaixar o existencial aqui seria trocar um erro por
+    --    outro.
+    --
+    --    Por que o `ESTAGNADO` (exec_7d = 0) NAO pega: verificar o sensor E uma execucao. Quem
+    --    abre a tela para conferir renova `exec_7d` e derruba o veredito para `AGUARDE` — o
+    --    alarme e suprimido pelo ATO DE MEDIR, e some justo quando alguem foi olhar. Provado
+    --    por falsificacao em db/test-gatilho-farmer-fase2.sh (caso 4: sem este ramo, 20
+    --    julgaveis de 1 ator saem como `ENCERRE`).
+    WHEN farmers = 1 AND farmers_com_carteira > 1 THEN
+      'MONOUSUARIO — ' || julgaveis || '/20 julgaveis, mas TODAS de UM UNICO farmer (de '
+      || farmers_com_carteira || ' com carteira). Denominador de 1 ator nao sustenta conclusao '
+      || 'populacional: nem ENCERRE (que e universal) nem AGUARDE (o sinal nao esta "vindo" — '
+      || 'nao ha quem o produza). E se o executor unico for quem VERIFICA o sensor, cada '
+      || 'verificacao renova exec_7d e impede ESTAGNADO: o alarme se apaga por ser olhado. A '
+      || 'fase seguinte e INSTALAR O USO nos demais farmers com carteira — nao esperar.'
     WHEN julgaveis >= 20 THEN
       'ENCERRE — ' || julgaveis || ' execucoes julgaveis DESTE motor e ZERO vazios: o '
       || 'vazio-de-verdade nao acontece nele. Nao ligue a expiracao; encerre a linha DELE '

--- a/db/test-gatilho-farmer-fase2.sh
+++ b/db/test-gatilho-farmer-fase2.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA — db/gatilho-farmer-fase2.sql (o VEREDITO, nao os insumos)            ║
+# ║      bash db/test-gatilho-farmer-fase2.sh > /tmp/t.log 2>&1; echo "exit=$?"  ║
+# ║  (NAO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                      ║
+# ║                                                                               ║
+# ║  O que se prova: um denominador produzido por UM UNICO ator nao vira          ║
+# ║  conclusao populacional. O ramo `MONOUSUARIO` precede `ENCERRE` (universal,   ║
+# ║  exige amostra) e NAO precede `DECIDA` (existencial, basta uma ocorrencia)    ║
+# ║  nem `CONTAMINADO` (insumo furado invalida tudo antes).                       ║
+# ║                                                                               ║
+# ║  Roda o ARQUIVO REAL do gatilho — nunca uma transcricao dele: teste sobre     ║
+# ║  copia aprova a copia, e a copia nao e o que o founder executa.               ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GATILHO="$REPO_ROOT/db/gatilho-farmer-fase2.sql"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5474}"
+SLUG="gatilho-fase2"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER}"; exit 1; }
+[ -f "$GATILHO" ] || { echo "gatilho ausente: $GATILHO"; exit 1; }
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK  $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# usado SO na falsificacao: espelha eq() mas com o veredito INVERTIDO (queremos vermelho).
+eq_esperando_vermelho() {
+  if [ "$2" = "$3" ]; then bad "FALSIFICACAO SEM DENTE: $1 continuou [$2] com o gatilho sabotado"
+  else ok "falsificacao mordeu: $1 virou [$2] (integro seria [$3])"; fi
+}
+
+# ════════════════════════════════════════════════════════
+# ZONA 1 — schema MINIMO, espelhando o de prod (medido via psql-ro em 21/08)
+# ════════════════════════════════════════════════════════
+P -q <<'SQL'
+CREATE TABLE public.farmer_geracao_execucoes (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  motor          text NOT NULL,
+  farmer_id      uuid NOT NULL,
+  run_id         uuid NOT NULL DEFAULT gen_random_uuid(),
+  resultado      text NOT NULL,
+  linhas_geradas integer NOT NULL DEFAULT 0,
+  completude     text NOT NULL,
+  motivo         text,
+  insumos        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  calculado_em   timestamptz NOT NULL DEFAULT clock_timestamp(),
+  CONSTRAINT farmer_geracao_execucoes_check CHECK (
+    motor = ANY (ARRAY['cross_sell','bundle'])
+    AND resultado = ANY (ARRAY['linhas','vazio'])
+    AND completude = ANY (ARRAY['completo','degradado','desconhecido'])
+  )
+);
+CREATE TABLE public.farmer_client_scores (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  farmer_id uuid NOT NULL
+);
+
+-- Insumo "saudavel", com a forma EXATA que o gatilho exige de um vazio julgavel — medida
+-- lendo a condicao de `vazios_completos`, nao suposta: cobertura declarada (senao cai em
+-- `AGUARDE (cliente velho)`, que compartilha a 1a palavra com o `AGUARDE` generico e
+-- mascararia qual ramo respondeu), `scores.n > 0` e `vendaveis.n > 0` (sem os dois o vazio
+-- nao e julgavel e o ramo `DECIDA` nunca dispara), e nenhum n = 1000 (que acionaria o cap).
+-- A 1a versao desta fixture omitia scores/vendaveis: o C5 reprovou e o defeito era AQUI.
+CREATE FUNCTION fx(p_motor text, p_farmer uuid, p_n int DEFAULT 1, p_resultado text DEFAULT 'linhas',
+                   p_insumos jsonb DEFAULT NULL)
+RETURNS void LANGUAGE plpgsql AS $f$
+BEGIN
+  INSERT INTO public.farmer_geracao_execucoes (motor, farmer_id, resultado, linhas_geradas, completude, insumos)
+  SELECT p_motor, p_farmer, p_resultado, CASE WHEN p_resultado='vazio' THEN 0 ELSE 3 END, 'completo',
+         COALESCE(p_insumos, '{"carteira_com_historico_utilizavel": {"n": 42}, "scores": {"n": 87},
+                       "vendaveis": {"n": 12}, "pedidos": {"n": 861}}'::jsonb)
+  FROM generate_series(1, p_n);
+END $f$;
+
+CREATE FUNCTION carteira(p_quantos int) RETURNS void LANGUAGE plpgsql AS $f$
+BEGIN
+  INSERT INTO public.farmer_client_scores (farmer_id)
+  SELECT ('00000000-0000-0000-0000-0000000000' || lpad(g::text, 2, '0'))::uuid
+  FROM generate_series(1, p_quantos) g;
+END $f$;
+
+CREATE FUNCTION reset() RETURNS void LANGUAGE sql AS
+  $f$ TRUNCATE public.farmer_geracao_execucoes, public.farmer_client_scores $f$;
+SQL
+
+A='00000000-0000-0000-0000-000000000001'   # farmer 1 (o unico executor, nos casos monousuario)
+B='00000000-0000-0000-0000-000000000002'   # farmer 2
+
+# Extrai a PALAVRA do veredito (ASCII, caixa fixa) do motor pedido, rodando o gatilho REAL.
+# Corta no 1o token — 'SEM'/'ZERADO' levam o 2o junto porque o veredito deles tem duas palavras.
+veredito() { # $1 = motor, $2 = arquivo do gatilho (default: o real)
+  Pq -f "${2:-$GATILHO}" \
+    | awk -F'|' -v m="$1" '$1==m {print $NF}' \
+    | awk '{ if ($1=="SEM" || $1=="ZERADO") print $1" "$2; else print $1 }' \
+    | tr -d '('
+}
+
+echo "=== setup pronto (PG17 :$PORT) ==="
+
+# ════════════════════════════════════════════════════════
+# ZONA 2 — o ramo novo: 1 ator nao e populacao
+# ════════════════════════════════════════════════════════
+echo "-- C1: 3 execucoes, 1 farmer, 3 com carteira -> MONOUSUARIO"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',3);"
+eq "C1 cross_sell" "$(veredito cross_sell)" "MONOUSUARIO"
+
+echo "-- C2: mesmas 3 execucoes repartidas em 2 farmers -> NAO e monousuario"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',2); SELECT fx('cross_sell','$B',1);"
+eq "C2 cross_sell (2 atores)" "$(veredito cross_sell)" "AGUARDE"
+
+echo "-- C3: 1 executor, mas a carteira TEM 1 farmer so — ele E a populacao, nao ha vies"
+P -q -c "SELECT reset(); SELECT carteira(1); SELECT fx('cross_sell','$A',3);"
+eq "C3 cross_sell (populacao=1)" "$(veredito cross_sell)" "AGUARDE"
+
+# ════════════════════════════════════════════════════════
+# ZONA 3 — ORDEM: o que o ramo novo pode e o que NAO pode atropelar
+# ════════════════════════════════════════════════════════
+echo "-- C4: 20 julgaveis de UM ator -> MONOUSUARIO vence ENCERRE (universal exige amostra)"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',20);"
+eq "C4 cross_sell (20 de 1 ator)" "$(veredito cross_sell)" "MONOUSUARIO"
+
+echo "-- C5: existencia sobrevive — 1 vazio+completo COM cobertura, mesmo de 1 ator so"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',1,'vazio');"
+eq "C5 cross_sell (vazio julgavel)" "$(veredito cross_sell)" "DECIDA"
+
+echo "-- C6: insumo furado continua acima de tudo — cap ATIVO com 1 ator so"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',3);
+         SELECT fx('cross_sell','$A',1,'linhas','{\"carteira_com_historico_utilizavel\": {\"n\": 42}, \"scores\": {\"n\": 87}, \"vendaveis\": {\"n\": 12}, \"pedidos\": {\"n\": 1000}}'::jsonb);"
+eq "C6 cross_sell (cap ativo)" "$(veredito cross_sell)" "CONTAMINADO"
+
+echo "-- C7: motor que nunca rodou continua aparecendo (ausente != zero)"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',3);"
+eq "C7 bundle (nunca rodou)" "$(veredito bundle)" "SEM DENOMINADOR"
+
+# ════════════════════════════════════════════════════════
+# ZONA 4 — FALSIFICACAO: sem o ramo, o C4 encerra a linha com n=1
+# ════════════════════════════════════════════════════════
+# Sabota uma COPIA — o arquivo real nunca e tocado, entao nao ha restaurar() para falhar.
+SABOTADO="$(mktemp "/tmp/gatilho-sabotado-XXXXXX.sql")"
+python3 - "$GATILHO" "$SABOTADO" <<'PY'
+import sys
+ini = "    WHEN farmers = 1 AND farmers_com_carteira > 1 THEN"
+fim = "    WHEN julgaveis >= 20 THEN"
+s = open(sys.argv[1]).read()
+a = s.index(ini); b = s.index(fim, a)
+open(sys.argv[2], "w").write(s[:a] + s[b:])
+PY
+echo "-- C4': o MESMO fixture do C4, com o ramo MONOUSUARIO removido"
+P -q -c "SELECT reset(); SELECT carteira(3); SELECT fx('cross_sell','$A',20);"
+SAB="$(veredito cross_sell "$SABOTADO")"
+eq_esperando_vermelho "C4 (20 de 1 ator)" "$SAB" "MONOUSUARIO"
+eq "C4' sabotado encerra a linha com n=1" "$SAB" "ENCERRE"
+rm -f "$SABOTADO"
+
+echo "════════════════════════════════════"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -448,3 +448,51 @@ Ao medir os candidatos de fatia (todos com denominador, prod via `psql-ro`), a o
 Eu havia chamado a tupla fabricada (`max(confidence)` × `max(lift)` de regras diferentes) de "o único que fabrica número na tela" e recomendado corrigi-la primeiro. O número **é** fabricado, mas não muda a decisão em nenhum cliente — e a própria segmentação a zera, porque com regras por conta cada grupo passa a ter uma regra só. A previsão do Codex de que pioraria com mais regras **não se confirmou**: 14 regras segmentadas produzem menos grupos multi-regra que 24 globais.
 
 **A lição de método:** severidade herdada de um parecer — inclusive de uma revisão adversária boa — continua sendo hipótese até ter denominador. As três medições custaram três queries e trocaram a fatia inteira.
+
+## O alarme que se apaga por ser olhado (gatilho da fase 2 do Farmer, 2026-08-21)
+
+`db/gatilho-farmer-fase2.sql` existe para impedir que a fase 2 seja aberta sem denominador. Ele
+cometeu a própria falha que vigia — **uma camada acima, sobre PESSOAS em vez de linhas.**
+
+O veredito `ESTAGNADO` foi escrito com todas as letras para dizer *"aguardar não produz sinal
+quando a superfície não está em uso"*. Mas a condição implementada era **temporal**:
+`exec_7d = 0`. E verificar o sensor **é uma execução**. Quem abre a tela para conferir renova
+`exec_7d`, derruba o veredito para `AGUARDE` ("o sinal está vindo") e apaga o alarme — **justo
+quando alguém foi olhar.** Um sensor que se cala ao ser observado não relata: ele consola.
+
+Medido em 21/08 (prod, `psql-ro`), depois de a época descartar o período contaminado:
+
+| o que o gatilho dizia | o que o dado dizia |
+|---|---|
+| `AGUARDE — 3/20 julgaveis, 3 execucoes nos ultimos 7 dias` | as **14** execuções que existem na tabela são de **1 farmer só** — o founder, verificando |
+| `1/3 farmers com carteira ja executaram` (no texto, sem efeito no veredito) | os outros 2 **nunca** abriram a tela |
+| — | excluindo o founder, o gatilho devolve **`SEM DENOMINADOR`**: adoção real = **zero**, não "baixa" |
+
+E o defeito latente era pior que o cosmético: **`ENCERRE` ficava ACIMA de qualquer checagem de
+ator.** Com 20 julgáveis, ele afirma *"o vazio-de-verdade não acontece neste motor — encerre a
+linha"*. O executor único já havia produzido **14 dos 20**: seis cliques a mais e o gatilho
+encerraria uma linha de produto com **n=1**, e com a autoridade de quem mostra denominador.
+
+### A regra que isto acrescenta
+
+1. **Um denominador de adoção tem de excluir — ou no mínimo NOMEAR — o rastro de quem verifica.**
+   Quem mede faz parte do que é medido; sem separar os dois, o sensor lê a própria pegada como uso.
+   Detecção que não depende de saber *quem* é o verificador: `farmers = 1` enquanto
+   `farmers_com_carteira > 1` já basta — **um ator não é população**, seja ele quem for.
+2. **Afirmação UNIVERSAL exige amostra populacional; EXISTENCIAL não.** `ENCERRE` ("não acontece")
+   precisa e por isso passou a ficar **abaixo** do corte de ator único; `DECIDA` ("aconteceu ao
+   menos uma vez") não precisa e continua **acima** — amostra enviesada derruba o universal, nunca
+   o existencial. Rebaixar os dois juntos seria trocar um erro por outro.
+3. **Reportar o fato não é o mesmo que poder concluir sobre ele.** `farmers` e
+   `farmers_com_carteira` já saíam na linha — o comentário do código até nomeava a adoção. Faltava
+   o veredito **agir**. Sensor que enxerga e não decide adia o erro para o leitor, e o leitor lê a
+   palavra em caixa alta, não a coluna.
+
+Ramo `MONOUSUARIO` + prova executável em `db/test-gatilho-farmer-fase2.sh` (9 asserts, com
+falsificação: sem o ramo, o caso de 20-de-1-ator vira `ENCERRE`).
+
+**Lição de método:** o teste reprovou o **caso 5** e o defeito estava na *fixture*, não no fix — eu
+tinha suposto a forma de um "vazio julgável" em vez de lê-la (`scores.n > 0` **e** `vendaveis.n > 0`
+**e** a cobertura declarada). O teste barato pagou-se antes de existir PR: sem ele, eu teria
+entregue um ramo que atropelava a existência e só descobriria isso quando o primeiro vazio real
+chegasse — e aí ele viria mudo.


### PR DESCRIPTION
## O que estava errado

`db/gatilho-farmer-fase2.sql` existe para impedir que a fase 2 seja aberta sem denominador. Ele cometia a própria falha que vigia — **uma camada acima, sobre PESSOAS em vez de linhas.**

O veredito `ESTAGNADO` foi escrito com todas as letras para dizer *"aguardar não produz sinal quando a superfície não está em uso"*. Mas a condição implementada era **temporal**: `exec_7d = 0`. E **verificar o sensor é uma execução** — quem abre a tela para conferir renova `exec_7d`, derruba o veredito para `AGUARDE` ("o sinal está vindo") e **apaga o alarme justo quando alguém foi olhar.**

## O dado (prod, `psql-ro`, 21/08 — já com a época descartando o período contaminado)

| o gatilho dizia | o dado dizia |
|---|---|
| `AGUARDE — 3/20 julgaveis, 3 execucoes nos ultimos 7 dias` | as **14** execuções que a tabela tem são de **1 farmer só** — o founder, verificando |
| `1/3 farmers com carteira ja executaram` (no texto, sem efeito no veredito) | os outros 2 **nunca** abriram a tela |
| — | excluindo ele, o gatilho devolve **`SEM DENOMINADOR`**: adoção real = **zero**, não "baixa" |

## O defeito latente, que era pior

`ENCERRE` ficava **acima de qualquer checagem de ator** e afirma *"o vazio-de-verdade não acontece neste motor — encerre a linha"*. O executor único já tinha **14 dos 20** julgáveis exigidos: seis cliques a mais e o gatilho **encerraria uma linha de produto com n=1** — com a autoridade de quem mostra denominador.

## O fix

Ramo **`MONOUSUARIO`** (`farmers = 1 AND farmers_com_carteira > 1`), posicionado **abaixo de `DECIDA`** e **acima de `ENCERRE`**:

- amostra enviesada derruba afirmação **universal** ("não acontece") → `ENCERRE` cede;
- não derruba a **existencial** ("aconteceu ao menos uma vez") → `DECIDA` continua vencendo;
- `CONTAMINADO` segue acima de tudo (insumo furado invalida antes).

A detecção não precisa saber *quem* é o verificador: **um ator não é população**, seja ele quem for.

## Prova

`db/test-gatilho-farmer-fase2.sh` — 9 asserts em PG17 local, rodando o **arquivo real** do gatilho (nunca uma transcrição), com **falsificação**: sem o ramo, o caso de 20-de-1-ator vira `ENCERRE`.

```
C1 MONOUSUARIO · C2 2 atores→AGUARDE · C3 população=1→AGUARDE · C4 20-de-1-ator→MONOUSUARIO
C5 vazio julgável→DECIDA · C6 cap ativo→CONTAMINADO · C7 motor mudo→SEM DENOMINADOR
C4' falsificação: sabotado→ENCERRE          PASS=9 FAIL=0
```

O **caso 5 reprovou na 1ª rodada** e o defeito estava na *fixture*: eu supus a forma de um "vazio julgável" em vez de lê-la (`scores.n > 0` **e** `vendaveis.n > 0` **e** a cobertura declarada).

## Deploy

**Nada a fazer** — `db/*.sql` diagnóstico + teste + doc. Sem migration, sem edge, sem frontend.

## Decisão que isto destrava (do founder)

Com o veredito corrigido, os dois motores saem **`MONOUSUARIO`**. A pergunta do chip *"medir adoção real das telas do Farmer antes da fase 2"* está respondida: **adoção real = 0**. A fase seguinte não é aguardar sinal — é **instalar o uso** nos outros 2 farmers com carteira, ou encerrar a linha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)