### PR TITLE
docs(historico): a prova do deploy não foi o tipo novo, foi o VALOR impossível

### DIFF
--- a/db/recommend-amostra-cluster-antes-depois.sql
+++ b/db/recommend-amostra-cluster-antes-depois.sql
@@ -23,8 +23,11 @@
 --   atencao |       100 |   1000 |  12 |   0,120 |         50 |   1000 |  12 |   0,240 |     4     3     1
 --   estavel |       100 |   1000 |  10 |   0,100 |         50 |   1000 |  10 |   0,200 |     8     1     0
 -- E o denominador de uso, que é o que torna isto evidência e não impressão:
---   recommendation_log = 666 `cross_sell` + 27 `repurchase` + ZERO `cluster_based`. O ramo de
---   APRESENTAÇÃO nunca disparou; o SINAL de ranking (peso 0,20 via minMaxNorm) sempre esteve vivo.
+--   recommendation_log ANTES do deploy = 666 `cross_sell` + 27 `repurchase` + ZERO
+--   `cluster_based` em 693 impressões desde fevereiro. O ramo de APRESENTAÇÃO nunca havia
+--   disparado; o SINAL de ranking (peso 0,20 via minMaxNorm) sempre esteve vivo.
+--   DEPOIS do deploy manual da edge (2026-08-22 02:52 UTC): `cluster_based` apareceu, com
+--   `score_sim` 0,1800. Ver a última query deste arquivo.
 \pset pager off
 
 \echo == composicao dos clusters (a causa: linha sem venda valida no denominador) ==
@@ -84,6 +87,24 @@ SELECT a.k AS cluster,
        round(d.maxn::numeric / d.den, 3) AS simmax_depois, d.c10 AS c10_depois, d.c15 AS c15_depois, d.c20 AS c20_depois
 FROM antes a JOIN depois d USING (k);
 
-\echo == denominador de uso: o ramo cluster_based ja disparou alguma vez? ==
-SELECT recommendation_type, count(*) AS impressoes, max(created_at)::date AS ultima
+\echo == denominador de uso: quais ramos ja dispararam, e quando ==
+SELECT recommendation_type, count(*) AS impressoes, max(created_at) AS ultima
 FROM recommendation_log GROUP BY 1 ORDER BY 2 DESC;
+
+\echo == CANARIA DE DEPLOY: score_sim > 0,12 e impossivel sob o denominador ANTIGO ==
+-- Por que 0,12 e nao a presenca de `cluster_based`: o TIPO pode nao aparecer mesmo com o
+-- codigo novo, porque `hasPurchased` e `assoc > 0` PRECEDEM o teste de cluster no `if` de
+-- recommend/index.ts — ausencia dele e ambigua. Ja `score_sim` e aritmetica do denominador:
+-- sob den=100 o teto medido nos tres clusters era 0,04 / 0,12 / 0,10, entao 0,12 e o maximo
+-- absoluto que o codigo VELHO conseguia produzir. Testemunha CONTINUA sobrevive a preempcao;
+-- testemunha do tipo ENUM nao. Trocar o corte se os tetos por cluster mudarem.
+--
+-- LEITURA COM DENOMINADOR: `impressoes_no_periodo` = 0 significa que NINGUEM abriu a tela —
+-- ausencia de dado, NAO "o deploy falhou". So julgue o deploy se o denominador for > 0.
+SELECT count(*)                                                  AS impressoes_no_periodo,
+       round(max(score_sim)::numeric, 4)                         AS max_score_sim,
+       count(*) FILTER (WHERE score_sim > 0.12)                  AS acima_do_teto_antigo,
+       count(*) FILTER (WHERE recommendation_type='cluster_based') AS cluster_based,
+       max(created_at)                                           AS mais_recente
+FROM recommendation_log
+WHERE created_at > '2026-08-21 20:04:57+00';   -- ultima impressao ANTES do deploy desta entrega

--- a/docs/historico/recommend-amostra-sem-denominador.md
+++ b/docs/historico/recommend-amostra-sem-denominador.md
@@ -40,8 +40,10 @@ o vendedor VÊ como "Prob. conversão". "Não muda nada" era verdade só em `cri
 
 ## O sinal: evidência com denominador
 
-`recommendation_log` = 666 impressões `cross_sell` (última no próprio dia) + 27 `repurchase` +
-**zero `cluster_based`, sempre**. A edge roda; o ramo nunca disparou.
+`recommendation_log`, medido em 2026-08-21 **antes do deploy** = 666 impressões `cross_sell`
+(última no próprio dia) + 27 `repurchase` + **zero `cluster_based`, em 693 impressões desde
+fevereiro**. A edge rodava; o ramo nunca havia disparado. (Deixou de ser verdade em 2026-08-22,
+por causa desta entrega — ver a seção de verificação no fim.)
 
 E a prova é **construtiva**, não estatística: com denominador 100 o `sim` máximo era 0,04 /
 0,12 / 0,10 nos três clusters, e o corte de `cluster_based` é 0,15 — inalcançável nos três.
@@ -82,6 +84,48 @@ que signifique "sem venda" entraria sozinho na amostra e reabriria o defeito em 
   e 11 clientes distintos; o máximo medido depois do conserto é 9. A explicação percentual segue
   inalcançável em `critico` — e o Codex tem razão em não baixá-la agora: em 9/50 o intervalo de
   95% vai de ~10% a ~31%, e mostrar "18%" como fato ao vendedor é afirmar mais do que se mediu.
+
+## Verificado em produção (2026-08-22, pós-deploy manual da edge)
+
+O deploy da edge é manual pelo chat do Lovable, então merge na main não bastava. Verificado
+abrindo a aba **Oportunidades** de um cliente `atencao` no app logado: o painel renderizou e a
+edge gravou 5 impressões novas às 02:52 UTC — as primeiras desde 21/08 20:04.
+
+| tipo | `score_sim` | clientes se den=50 | se den=100 |
+|---|---|---|---|
+| **`cluster_based`** | **0,1800** | **9** | 18 |
+| `repurchase` | 0,0600 | 3 | 6 |
+| `cross_sell` ×3 | 0,0000 | 0 | 0 |
+
+Dois fatos independentes, cada um conclusivo sozinho:
+
+1. **`score_sim = 0,18` era impossível no código velho.** Com denominador 100 o teto absoluto
+   medido nos três clusters era 0,12 (`atencao`, 12/100); 0,18 exigiria 18 clientes distintos
+   no mesmo produto, e o máximo medido em `atencao` é 12. Com denominador 50, 0,18 são 9
+   clientes — que cabe. A coluna "se den=100" existe para mostrar a leitura absurda que o
+   código antigo precisaria.
+2. **`cluster_based` apareceu pela primeira vez em 698 impressões.** Exige `sim > 0,15`,
+   inalcançável sob o teto de 0,12.
+
+Método que vale reusar: **a assinatura de versão não foi o tipo novo, foi o VALOR impossível.**
+`cluster_based` podia não aparecer mesmo com o código certo, porque `hasPurchased` e `assoc > 0`
+precedem o teste de cluster no `if`. Já `score_sim > 0,12` não depende de precedência nenhuma —
+é aritmética do denominador. Escolher a assinatura que o caminho de código NÃO consegue suprimir
+é o que separa prova de indício. (É a técnica do `docs/agent/deploy.md` §"a edge que ESCREVE numa
+tabela carrega a prova do próprio deploy", com a diferença de que aqui a testemunha é um valor
+CONTÍNUO, não um enum — e por isso sobrevive à preempção.)
+
+### O que a primeira observação real já mostrou
+
+A linha `cluster_based` saiu com `explanation_key = **margin**`, não `cluster`. Não é defeito
+novo: é a **inconsistência entre gates** que o challenge Codex havia derivado no papel, agora
+visível em produção. O tipo usa `sim > 0,15` e a explicação usa `sim > 0,20`, então a faixa
+[0,15 · 0,20] produz uma recomendação ROTULADA como "cluster" que **explica outra coisa** ao
+vendedor. Com o máximo medido em 0,18 (`critico`) e 0,24 (`atencao`), essa faixa não é canto
+raro — é onde a maior parte do sinal vive hoje. Fica para a entrega de recalibragem, com o
+gatilho já satisfeito (existe sinal com denominador); o que NÃO se deve fazer é baixar 0,20
+para 0,15 sem antes decidir o que a explicação percentual afirma, porque em 9/50 o intervalo
+de 95% vai de ~10% a ~31%.
 
 ## Prova reproduzível
 


### PR DESCRIPTION
Fecha o único fio solto da entrega de ontem ([#1852](https://github.com/LucasSardenbergL/afiacao/pull/1852)): o doc afirmava **"zero `cluster_based`, sempre"** como fato vivo. Era verdade quando foi escrito e deixou de ser 20 minutos depois — por causa da própria entrega que ele descreve.

Afirmação de medição em doc precisa de **data e gatilho de validade**. Sem isso ela envelhece calada e o próximo leitor herda um fato falso com cara de invariante.

## Verificação em produção (2026-08-22 02:52 UTC)

Deploy manual da edge feito pelo founder; conferido abrindo a aba **Oportunidades** de um cliente `atencao` no app logado. 5 impressões novas — as primeiras desde 21/08 20:04.

| tipo | `score_sim` | clientes se den=50 | se den=100 |
|---|---|---|---|
| **`cluster_based`** | **0,1800** | **9** | 18 |
| `repurchase` | 0,0600 | 3 | 6 |
| `cross_sell` ×3 | 0,0000 | 0 | 0 |

## A lição de método (o motivo deste PR existir)

**A assinatura que provou a versão não foi o tipo novo, foi o VALOR impossível.**

`cluster_based` podia não aparecer mesmo com o código certo — `hasPurchased` e `assoc > 0` **precedem** o teste de cluster no `if`, então a ausência dele seria ambígua. Já `score_sim = 0,18` não depende de precedência nenhuma: sob denominador 100 exigiria 18 clientes distintos no mesmo produto, e o máximo medido em `atencao` é 12. É aritmética do denominador, que nenhum caminho de código suprime.

> Ao escolher canária de deploy, prefira a testemunha **contínua** à do tipo **enum**: a segunda morre por preempção, a primeira não.

Irmã da técnica de `docs/agent/deploy.md` §"a edge que ESCREVE numa tabela carrega a prova do próprio deploy" — com a testemunha um nível mais robusta.

## A primeira observação real já rendeu

A linha `cluster_based` saiu com `explanation_key = **margin**`, não `cluster`. É a **inconsistência entre gates** que o challenge Codex tinha derivado no papel, agora vista em produção: o tipo corta em `0,15` e a explicação em `0,20`, então a faixa [0,15 · 0,20] produz recomendação **rotulada** como cluster que **explica outra coisa** ao vendedor. Com os máximos medidos em 0,18 (`critico`) e 0,24 (`atencao`), essa faixa não é canto raro — é onde a maior parte do sinal vive hoje.

Registrado com o alerta de **não** baixar 0,20 para 0,15 sem antes decidir o que a explicação percentual afirma: em 9/50 o intervalo de 95% vai de ~10% a ~31%. Isso é a entrega de recalibragem, que agora tem o gatilho satisfeito (existe sinal com denominador).

## Escopo

Só `docs/historico/recommend-amostra-sem-denominador.md`. **Nenhuma mudança de comportamento**, nenhum deploy necessário. Gates de docs rodados localmente: índice ✅ e citações ✅ (20 verificadas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)