### PR TITLE
docs(farmer): o rodapé da migration lê como "pendente" e o VALIDATE de lá é comentário — o grep pelo nome da constraint não achava a resposta

### DIFF
--- a/docs/historico/farmer-apriori-denominador.md
+++ b/docs/historico/farmer-apriori-denominador.md
@@ -132,6 +132,11 @@ Três invariantes que a escrita **não** quebrou, medidas depois dela: o ACL da 
 
 **O que esta leitura ainda NÃO diz.** Ela confirma a *produção* das regras, não o *efeito* delas. A tabela A/B/C acima projeta cobertura — MixGap 84 (16,0%), recommend+cross-sell 351 (29,1%), melhoria 8 — e nada disso foi medido em prod ainda: são números do consumidor, a jusante. Contar 14 regras e concluir "funcionou" seria trocar o eixo da decisão pelo que é fácil de contar, que é o defeito que esta fatia inteira corrige. O próximo sinal é a cobertura por geração, com denominador — e ele vem do `farmer_recommendation_desfecho` (#1851, já aplicado), não daqui.
 
+**Se precisar reconferir a promoção do `CHECK`.** A constraint é `farmer_association_rules_cluster_segment_check` — o nome fica escrito aqui de propósito: `git grep` por ele passa a trazer esta nota junto com a migration, e sem isso a busca só acha o arquivo cujo rodapé lê como pendente (lá o `VALIDATE` é **comentário**, e nenhum PR do repo o executa — quem procurar o artefato por `git grep "VALIDATE CONSTRAINT" origin/main`, que é a busca certa, não acha nada e conclui errado). Duas armadilhas na conferência:
+
+- **`WHERE cluster_segment IS NULL` mede METADE da asserção.** O predicado tem duas condições (`IS NOT NULL` **e** `length(btrim(…)) > 0`); uma linha com `''` ou `'   '` derruba o `VALIDATE` com esse `count(*)` marcando 0 — verde por medir meia condição. Conte o predicado inteiro, negado: `WHERE NOT (<predicado>)`. Medido em 2026-08-22 pelos dois critérios: 0 e 0, sobre as 14 linhas.
+- **Re-colar a `20260821200000` hoje NÃO reverte a promoção.** O `ADD CONSTRAINT … NOT VALID` mora dentro de `DO $$ … IF NOT EXISTS (SELECT 1 FROM pg_constraint …) $$` e a constraint existe, então o bloco não faz nada. É a armadilha do #1509 ("re-colar migration antiga reverte hardening posterior, em silêncio") **não** disparando — e por um motivo específico, não genérico: o guard testa a EXISTÊNCIA do objeto, e `VALIDATE` não muda existência. Um `DROP`+`ADD` no lugar do `IF NOT EXISTS` teria revertido calado.
+
 ## Provas
 
 - `supabase/functions/_shared/apriori_test.ts` — 8 testes Deno do helper puro. O universo de brinquedo (100 cestas numa conta, 20 na outra) reproduz o fenômeno em aritmética verificável à mão: mesmo piso, global = 0 regras, segmentado = 2.


### PR DESCRIPTION
Tarefa recebida: promover o `CHECK farmer_association_rules_cluster_segment_check` de `NOT VALID` para `VALIDATED`. **Ela já estava feita** — conferi em prod via `psql-ro` antes de qualquer coisa, e o [#1862](https://github.com/LucasSardenbergL/afiacao/pull/1862) já registrou a promoção no histórico enquanto eu escrevia. Este PR **não** duplica aquilo: guarda só o que faltou para o registro ser *encontrável*, e duas armadilhas da conferência.

## A conferência (read-only, prod)

| medida | valor |
|---|---|
| regras vigentes | 14 (`colacor` 2 · `oben` 12; `created_at` idêntico ⇒ lote único) |
| `cluster_segment IS NULL` | **0** |
| viola o predicado INTEIRO (`NULL` **ou** `btrim` vazio) | **0** |
| `pg_constraint.convalidated` | **`t`** |
| `pg_get_constraintdef` | sem o sufixo `NOT VALID` |
| tabelas filhas (partição) | 0 ⇒ a leitura de `pg_constraint` é completa |

Rodei também a própria query pós-apply da `20260821200000`: CHECK existe (1), RPC tem TR006+TR007 (`t`), `authenticated` não executa a RPC (`f`), 14 regras.

## Por que estas 5 linhas

1. **O histórico não citava o NOME da constraint.** `git grep cluster_segment_check` trazia só o teste e a migration. E o rodapé da migration entrega o `VALIDATE CONSTRAINT` **comentado**, então lê como passo pendente. Quem procura o artefato por `git grep "VALIDATE CONSTRAINT" origin/main` — a busca certa — não acha nada, *porque nenhum PR do repo o executa*, e conclui "pendente". Foi exatamente o caminho que percorri hoje. Escrever o nome no doc faz as duas buscas convergirem na resposta.
2. **`WHERE cluster_segment IS NULL` mede metade da asserção.** O predicado tem duas condições; uma linha com `` ou `   ` derrubaria o `VALIDATE` com esse `count(*)` marcando 0 — verde por medir meia condição. A instrução que recebi pedia só o `IS NULL`; conferi o predicado inteiro negado, e por isso sei que os dois são 0.
3. **Re-colar a `20260821200000` hoje não reverte a promoção** — o `ADD CONSTRAINT` mora num `DO $$ … IF NOT EXISTS (SELECT 1 FROM pg_constraint …) $$`. É a armadilha do #1509 **não** disparando, por motivo específico e não-genérico: o guard testa EXISTÊNCIA, e `VALIDATE` não muda existência. `DROP`+`ADD` teria revertido calado.

## O que este PR NÃO faz

- **Não toca `supabase/migrations/`.** Migration committada é IMUTÁVEL (`docs/agent/database.md:44`), então o rodapé da `20260821200000` fica lendo como pendente — a nota no histórico é a correção viável, não editar o arquivo.
- **Não muda banco nem código.** Doc-only, 5 linhas. Nenhuma migration para aplicar, nada para colar no SQL Editor.

Observação de DR, não-bloqueante e anterior a esta fatia: `supabase/schema-snapshot.sql` é de 2026-08-08 e não contém este CHECK (tem a coluna, linha 21906) — atraso normal entre re-dumps. O `supabase_migrations.schema_migrations` já registra `20260821200000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)