### PR TITLE
docs(codex): a revisão retroativa do #1859 achou o card atrás do && do host — e a nota do transporte estava errada [money-path]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -449,6 +449,47 @@ Eu havia chamado a tupla fabricada (`max(confidence)` × `max(lift)` de regras d
 
 **A lição de método:** severidade herdada de um parecer — inclusive de uma revisão adversária boa — continua sendo hipótese até ter denominador. As três medições custaram três queries e trocaram a fatia inteira.
 
+### Revisão independente RETROATIVA (2026-08-22): o card separado, montado atrás de um `&&`
+
+O `/codex` não rodou antes do merge (a sessão fechou) — rodou depois, com o #1859 já em produção. O
+achado principal **não estava no componente**:
+
+```tsx
+// src/pages/FarmerCalls.tsx:33 — `error` nem é desestruturado
+const { data: positivacao } = useMyPositivacao();   // useMyPositivacao.ts:43 → if (error) throw
+// :436 — único ponto de montagem do card no app inteiro
+{positivacao && ( … <MixGapCard /> )}
+```
+
+As duas RPCs saem pelo mesmo PostgREST, então a falha correlacionada é o caso COMUM. Quando ela
+acontece, `positivacao` fica `undefined` e **o card nem monta**: os três estados novos, a tela de erro
+nova e o evento em todos os ramos ficam inacessíveis exatamente na situação que motivou a correção.
+
+**A regra que isto acrescenta: um teste de componente ISOLADO não prova o estado que o HOST decide.**
+Os 6 testes montam `<MixGapCard />` direto e são verdes num contexto que não existe em produção — é o
+"gate que mente por não conhecer a forma real do repo", na forma de harness. Ao separar estados num
+card, o teste tem de montar o host, ou no mínimo asseverar que o host não o esconde atrás do `&&` de
+uma query irmã. O tell para procurar: `{<algo> && (<Card/>)}` onde `<algo>` vem de um hook que lança.
+
+Os outros achados que sobreviveram à verificação:
+
+- **Quarto estado — offline.** Com `networkMode:'online'` (default, sem override) a query fica
+  `fetchStatus:'paused'`/`status:'pending'`: `isLoading` (v5 = `isPending && isFetching`) é **false**,
+  `data` `undefined`, `error` `null` ⇒ cai em `semAcesso`, some da tela e **não emite**. Num PWA de
+  campo esse não é o caso raro. As duas análises (Codex e a minha, escrita antes de abrir o parecer)
+  chegaram nele por caminhos separados.
+- **A dedup por estado não reseta na troca de sujeito.** `trackedEstado` sobrevive à mudança de
+  `effectiveUserId` ("Ver como"): alvo diferente com o mesmo estado não emite — e a 1ª emissão não
+  marca que era impersonação, então o denominador de adoção conta staff como vendedor.
+- **Severidade herdada, de novo.** O parecer marcou `coverage ?? []` (4/4 consumidores de
+  `useMyActiveCoverage`, nenhum lendo `error`) como CRÍTICO. Medido em prod: `carteira_coverage` tem
+  **0 linhas** ⇒ dano hoje **zero**. Vira MÉDIO **com gatilho**: corrigir antes do primeiro cadastro,
+  porque depois some em silêncio. Mesma lição do parágrafo acima, agora aplicada ao parecer que revisa
+  o PR que a escreveu.
+
+Denominador do card: `commercial_roles` = **3 vendedores**. Com n=3 o argumento do sensor fica mais
+forte, não mais fraco — um evento perdido é um terço da série.
+
 ## O alarme que se apaga por ser olhado (gatilho da fase 2 do Farmer, 2026-08-21)
 
 `db/gatilho-farmer-fase2.sql` existe para impedir que a fase 2 seja aberta sem denominador. Ele

--- a/scripts/codex-async.sh
+++ b/scripts/codex-async.sh
@@ -90,16 +90,21 @@ for backoff in "${backoffs[@]}"; do
     echo "COTA_ESGOTADA: janela rolante de 7d do ChatGPT Plus esgotou. Siga o Caminho B (validação adversária própria + registrar 'REVISÃO INDEPENDENTE PENDENTE') — docs/agent/money-path.md." >&2
     exit 75
   fi
-  # modelo recusado pela CONTA = erro de CONFIG. Não é cota (esperar não resolve) nem
-  # transitório (repetir não resolve): as duas saídas erradas custam tempo apontando para
-  # o lugar errado. Medido em 2026-08-22: os 10 nomes tentados (gpt-5.6-sol, -codex, 5.1,
-  # 5, o3, codex-mini-latest…) voltaram o MESMO 400, então o eixo não é o nome do modelo
-  # — é o direito de acesso da conta ao Codex. Por isso a instrução cobre os dois: trocar
-  # o modelo E revalidar o login.
+  # modelo recusado = erro de CONFIG. Não é cota (esperar não resolve) nem transitório
+  # (repetir não resolve): as duas saídas erradas custam tempo apontando para o lugar errado.
+  # ⚠️ O eixo é o MODELO, não o acesso da conta — a nota anterior aqui dizia o contrário e
+  # estava errada. Medido 2026-08-22 (challenge retroativo do #1859), stderr cru do servidor:
+  #   gpt-5.6-sol  → 400 "The 'gpt-5.6-sol' model is not supported when using Codex with a
+  #                  ChatGPT account" — IDÊNTICO em -r high e -r xhigh (o effort não é a causa)
+  #   gpt-5.6      → mesmo 400
+  #   gpt-5.6-terra / gpt-5.6-luna → rc=0, respondem normalmente
+  # Ou seja: "nenhum modelo passa ⇒ é a conta" é inferência de ausência de dado. Trocar o
+  # modelo RESOLVE. Só suspeite do login se um modelo SABIDAMENTE servido também falhar.
   if grep -qiE 'model is not supported|unsupported_model|model_not_found' "$err"; then
     echo "MODELO_NAO_ACEITO: o modelo '$modelo' não é aceito por esta conta Codex (HTTP 400)." >&2
     echo "  → passe outro com -m, ou ajuste 'model =' em \${CODEX_HOME:-~/.codex}/config.toml;" >&2
-    echo "  → se NENHUM modelo passar, é acesso da conta: rode 'codex login' e confira a assinatura." >&2
+    echo "  → medidos OK nesta conta (2026-08-22): gpt-5.6-terra, gpt-5.6-luna. Recusados: -sol, gpt-5.6;" >&2
+    echo "  → só se um SABIDAMENTE servido também falhar é acesso da conta: 'codex login' e confira a assinatura." >&2
     echo "  (não é cota nem falha transitória: esperar e repetir não consertam config.)" >&2
     exit 78
   fi


### PR DESCRIPTION
## Por que este PR existe

O ritual `/codex` **não rodou** antes do merge do #1859 (a sessão que entregou fechou antes). O CLAUDE.md manda rodar segunda opinião independente em TODO trabalho money-path, e o card toca cross-sell/carteira. Rodei retroativamente — o #1859 já está em produção (`__BUILD_SHA__="588aa2ad"`), então isto era **dívida de revisão**, não bloqueio de deploy.

Este PR **não corrige código de produto** — registra o que a revisão achou e conserta uma nota factualmente errada no transporte. As correções de produto viram itens separados (ver "Fila" abaixo).

## O achado principal: o card não estava onde os testes o mediam

```tsx
// src/pages/FarmerCalls.tsx:33 — `error` nem é desestruturado
const { data: positivacao } = useMyPositivacao();   // :43 → if (error) throw
// :436 — único ponto de montagem do card no app inteiro
{positivacao && ( … <MixGapCard /> )}
```

As duas RPCs saem pelo mesmo PostgREST ⇒ a falha correlacionada é o caso **comum**. Quando ela acontece, `positivacao` fica `undefined` e **o card nem monta**: os três estados novos, a tela de erro e o evento em todos os ramos ficam inacessíveis exatamente na situação que motivou a correção.

**A regra nova:** um teste de componente **isolado** não prova o estado que o **host** decide. Os 6 testes montam `<MixGapCard />` direto — verdes num contexto que não existe em produção. Tell: `{<algo> && (<Card/>)}` onde `<algo>` vem de um hook que lança.

## Transporte: a nota do `codex-async.sh` estava errada

Ela afirmava que "os 10 nomes tentados voltaram o MESMO 400 ⇒ o eixo é o direito de acesso da conta". Medido hoje, stderr cru:

| modelo | resultado |
|---|---|
| `gpt-5.6-sol` | 400 `model is not supported when using Codex with a ChatGPT account` — **idêntico em `high` e `xhigh`** |
| `gpt-5.6` | mesmo 400 |
| `gpt-5.6-terra` / `gpt-5.6-luna` | **rc=0**, respondem |

O eixo é o **modelo**, não a conta. A nota antiga mandava o próximo agente revalidar login em vez de trocar uma string — inferência tirada de ausência de dado.

## Provas

- `shellcheck scripts/codex-async.sh` — limpo
- `bash scripts/test-codex-async.sh` — **PASS, exit 0** (os asserts ancoram em `exit 78` e no token `MODELO_NAO_ACEITO`, ambos preservados)
- Denominadores medidos em prod via `psql-ro`: `carteira_coverage` = **0 linhas**; `commercial_roles` = **3**

## Fila (não entra aqui — decisão do founder)

1. **[maior]** `MixGapCard` fora do `{positivacao && …}` + estado explícito para a positivação
2. Offline: distinguir `fetchStatus:'paused'` de ausência de acesso
3. Dedup por escopo+estado (hoje a troca de "Ver como" engole o evento)
4. `coverage ?? []` em 4/4 consumidores — corrigir **antes** do primeiro cadastro em `carteira_coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)