### PR TITLE
feat(recommend): canária de versão — o deploy passa a se provar sozinho (+ o gate não exigia RESPOSTA)

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -23,6 +23,7 @@ import * as processNfe from "../process-nfe/versao.ts";
 import * as capturaPrecos from "../sayerlack-captura-precos/versao.ts";
 import * as deparaAuto from "../reposicao-depara-sayerlack-auto/versao.ts";
 import * as omieCliente from "../omie-cliente/versao.ts";
+import * as recommendMod from "../recommend/versao.ts";
 import * as cashflow from "../fin-cashflow-engine/versao.ts";
 import * as syncEstoque from "../omie-sync-estoque/versao.ts";
 import * as syncNfes from "../omie-sync-nfes-recebidas/versao.ts";
@@ -62,10 +63,17 @@ const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   { nome: "omie-sync-estoque", mod: syncEstoque },
   { nome: "omie-sync-nfes-recebidas", mod: syncNfes },
   { nome: "omie-nfe-webhook", mod: nfeWebhook },
+  // Quarta leva (#canaria-recommend): mesma regra da terceira — escrita money-path no NOSSO
+  // banco. `recommend` grava `recommendation_log`, que é o SENSOR DE DESFECHO do motor
+  // (#1851): sondar sem guarda inventaria uma recomendação que ninguém fez e enviesaria a
+  // própria medição de acerto. Não é leitura pura — por isso não cai na exceção declarada
+  // acima (fin-funding, fin-valor-engine).
+  { nome: "recommend", mod: recommendMod },
 ];
 
 /** As cinco da terceira leva — os gates estruturais abaixo varrem todas. */
 const ESCRITA_NOSSO_BANCO = [
+  "recommend",
   "omie-cliente",
   "fin-cashflow-engine",
   "omie-sync-estoque",

--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -265,6 +265,27 @@ function trechoDoHandler(nome: string): string {
   return codigo.slice(i);
 }
 
+Deno.test("toda edge instrumentada RESPONDE à sonda (chamar classificarSonda não basta)", () => {
+  // Buraco encontrado ao falsificar a canária da `recommend`: apagar a linha que RESPONDE
+  // (`if (decisao.tipo === "sonda") return ...respostaSonda(VERSAO)`) deixava todos os gates
+  // VERDES. Os vizinhos afirmam que `classificarSonda` é CHAMADA e que vem antes do
+  // `createClient` — nenhum afirma que a decisão vira RESPOSTA. Uma edge assim classifica a
+  // sonda e seguve para o fluxo real: o efeito caro roda, e quem sondou lê o resultado do
+  // disparo como se fosse diagnóstico. É o pior desfecho que a sonda existe para evitar,
+  // passando por instrumentado.
+  for (const { nome } of EDGES) {
+    const codigo = codigoDaEdge(nome);
+    // `\w*` porque a resposta pode ter nome próprio: `generate-tactical-plan` exporta
+    // `respostaSondaTactical()`. Exigir o nome exato reprovava uma edge que responde certo.
+    if (!/respostaSonda\w*\(/.test(codigo)) {
+      throw new Error(`${nome}: classifica a sonda mas nunca chama respostaSonda — o diagnóstico não sai`);
+    }
+    if (!/["\x27]sonda["\x27]/.test(codigo)) {
+      throw new Error(`${nome}: não ramifica no tipo "sonda" — a decisão é calculada e descartada`);
+    }
+  }
+});
+
 Deno.test("terceira leva: a sonda decide por classificarSonda, não por `=== true` cru", () => {
   // Mesmo motivo do gate da generate-bundle-argument: o founder invoca do SQL Editor, onde
   // `jsonb_build_object('probe', true)` vira a STRING "true" com facilidade. Aqui o preço de cair

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -12,6 +12,7 @@ import {
 // vez de recomendar sobre catálogo parcial. Detalhe e medições: recommend-leituras.ts.
 import { carregarCluster, carregarInsumos } from "../_shared/recommend-leituras.ts";
 import type { BancoPostgrest } from "../_shared/paginate.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -406,6 +407,31 @@ Deno.serve(async (req) => {
       return jsonRes({ error: "Não autorizado" }, 401);
     }
 
+    // ── Sonda de versão ────────────────────────────────────────────────────────────────
+    // Responde ANTES do `createClient` e de qualquer leitura/escrita: o ponto da canária é
+    // dizer QUAL bundle está no ar sem pagar o efeito da edge. Aqui o efeito é gravar
+    // `recommendation_log` — o sensor de desfecho do motor (#1851) —, e uma linha inventada
+    // por sondagem entraria no denominador de "a recomendação virou venda".
+    //
+    // Depois do gate de `Bearer` e não antes: o gate desta edge é o padrão (JWT + staff), não
+    // o gate-próprio de `omie-cliente`/`omie-nfe-webhook`. Sondar continua exigindo um token,
+    // que é o que impede a canária de virar um oráculo público de versão.
+    //
+    // O corpo é lido AQUI (antes era só na linha do `switch`) porque a decisão depende dele.
+    // JSON malformado passa a devolver 400 explícito em vez de cair no catch genérico — o
+    // status muda de 500 para 400, que é a classificação correta de corpo inválido.
+    let corpoBruto: unknown;
+    try {
+      corpoBruto = await req.json();
+    } catch {
+      return jsonRes({ error: "invalid JSON" }, 400);
+    }
+    const decisaoSonda = classificarSonda(corpoBruto);
+    if (decisaoSonda.tipo === "sonda") return jsonRes(respostaSonda(VERSAO), 200);
+    if (decisaoSonda.tipo === "ambiguo") {
+      return jsonRes({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }, 400);
+    }
+
     const supabaseAdmin = createClient(
       Deno.env.get("SUPABASE_URL")!,
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
@@ -439,7 +465,9 @@ Deno.serve(async (req) => {
       return jsonRes({ error: "Forbidden" }, 403);
     }
 
-    const { action, ...params } = await req.json();
+    // Corpo já consumido pela sonda acima — `req.json()` só pode ser lido UMA vez; chamar de
+    // novo devolveria erro de stream já travado.
+    const { action, ...params } = (corpoBruto ?? {}) as { action?: string; [k: string]: unknown };
     let result: unknown;
 
     switch (action) {

--- a/supabase/functions/recommend/versao.ts
+++ b/supabase/functions/recommend/versao.ts
@@ -1,0 +1,35 @@
+// Identidade da edge `recommend` para a sonda de versão (`_shared/sonda-versao.ts`).
+//
+// Por que esta edge ganhou canária, se a leitura pura ficou de fora de propósito na 3ª leva:
+// `recommend` NÃO é leitura pura. Ela grava `recommendation_log`, que é o SENSOR DE DESFECHO do
+// motor (#1851) — a tabela que responde "o que o motor recomendou virou venda?". Sondar sem guarda
+// inventaria uma recomendação que ninguém pediu e enviesaria a própria medição de acerto, que é a
+// evidência com que se decide o futuro do motor.
+//
+// E há o motivo que trouxe o PR: o deploy do #1856 (keyset) não teve como ser PROVADO. A escada de
+// `lovable-deploy-verify` morre no N1 aqui — N2 (Management API) é estruturalmente indisponível
+// (o Supabase é da org do Lovable) e N3 não existia porque faltava canária. O melhor que se
+// conseguiu dizer foi "servida, e o bundle carrega"; a versão ficou por provar. Esta é a peça que
+// faltava para o próximo deploy se provar sozinho, sem depender de alguém abrir a tela.
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("recommend");
+
+/**
+ * Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho.
+ *
+ * Nasce em `v1.1` e não em `v1.0-sensor-inicial` de propósito: o bundle em produção JÁ tem o keyset
+ * do #1856. Carimbar `v1.0` sugeriria que esta é a primeira versão instrumentada de um código
+ * parado, quando o que a sonda passa a distinguir daqui para a frente é justamente o que veio
+ * depois dele.
+ */
+export const VERSAO = "v1.1-keyset-leituras";
+
+/** Efeito citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge roda o motor de recomendação do cliente (seis leituras paginadas: catálogo, custos, " +
+  "histórico de compras, regras de associação e score) e GRAVA `recommendation_log` — o sensor de " +
+  "desfecho que mede se a recomendação virou venda; uma linha inventada por sondagem entra no " +
+  "denominador dessa medição e a enviesa";


### PR DESCRIPTION
## O que

`recommend` ganha a canária de versão (`{"probe":true}` → `{ok,probe:true,versao}`), o padrão de
`_shared/sonda-versao.ts` que 5 edges já têm.

## Por que esta edge, se leitura pura ficou de fora de propósito

O gate registra que a 3ª leva excluiu leitura pura ("chamá-la já é grátis, então a sonda não
resolve problema que ela tenha"). `recommend` **não é leitura pura**: ela grava
`recommendation_log`, que é o **sensor de desfecho** do motor (#1851) — a tabela que responde
"a recomendação virou venda?". Sondar sem guarda inventaria uma recomendação que ninguém pediu
e entraria no denominador da própria medição de acerto. Ela se qualifica pelo critério já
declarado: escrita money-path no nosso banco.

E o motivo imediato: **o deploy do #1856 não teve como ser provado.** A escada de
`lovable-deploy-verify` morre no N1 aqui — N2 (Management API) é estruturalmente indisponível
(o Supabase é da org do Lovable) e N3 não existia por falta de canária. O melhor que deu para
dizer foi "servida, e o bundle carrega". Daqui para a frente o deploy se prova sozinho, sem
depender de alguém abrir a tela.

## Um buraco no gate das canárias, achado ao falsificar

Sabotei a canária nova apagando a linha que **responde** (`if (tipo === "sonda") return
respostaSonda(VERSAO)`) — e **todos os gates seguiram VERDES**. Os existentes afirmam que
`classificarSonda` é *chamada* e que vem antes do `createClient`; **nenhum** afirmava que a
decisão vira *resposta*.

Uma edge assim classifica a sonda e segue para o fluxo real: o efeito caro roda e quem sondou lê
o resultado do disparo como se fosse diagnóstico — exatamente o desfecho que a sonda existe para
evitar, passando por instrumentado. Vale para as 17 edges da lista, não só para a nova.

Novo gate: **toda edge instrumentada RESPONDE à sonda**. Ele pegou um falso-positivo meu de
imediato — `generate-tactical-plan` responde certo, mas via `respostaSondaTactical()`, nome
próprio. O predicado foi alargado (`respostaSonda\w*\(`) em vez de a edge ser "consertada".

Refalsificado depois do fix: a mesma sabotagem agora dá vermelho.

## Detalhe de comportamento (mudança pequena, dita por extenso)

O corpo passa a ser lido **antes** do `createClient` (a decisão depende dele, e o gate exige a
sonda antes do client). Consequência: **JSON malformado passa de 500 para 400**. É a
classificação correta de corpo inválido — antes caía no catch genérico. `req.json()` só pode ser
lido uma vez, então o `switch` consome o corpo já lido.

A sonda fica **depois** do gate de `Bearer`: esta edge usa o gate padrão (JWT + staff), não o
gate-próprio de `omie-cliente`/`omie-nfe-webhook`. Sondar exige token — é o que impede a canária
de virar oráculo público de versão.

`VERSAO` nasce em **`v1.1-keyset-leituras`**, não em `v1.0-sensor-inicial`: o bundle em produção
já tem o keyset do #1856, e carimbar `v1.0` sugeriria primeira versão de um código parado.

## Gates

`test:edges` 831/831 · `edges:typecheck` 0 erros de classe-crash · contrato das canárias 22/22.

## Como usar depois do deploy

🟣 **SQL Editor** — `net.http_post` para `/functions/v1/recommend` com `{"probe":true}` e leitura
de `net._http_response` (receita em `docs/agent/deploy.md` §Canárias). O eco `probe:true` é
obrigatório na leitura: bundle **anterior** à sonda ignora o parâmetro e **executa o fluxo real**
— resposta sem o eco já é o veredito "bundle velho, e ele rodou o efeito". Por isso, sonde só
DEPOIS do deploy.

## Nota sobre o vitest local

O run cheio local reprovou 5 arquivos (`authz-gate-check`, `authz-funcoes`,
`SalesQuotes.accountGuard`, `FormulaSearchResults`, `manifesto.gate`) — **todos passam
isolados** (`EXIT=0` nos cinco). É sufocamento de RAM da máquina (30+ sessões concorrentes;
os tempos no run cheio foram 26s/66s/72s). Nenhum deles toca edges, e este diff mexe em 3
arquivos, todos sob `supabase/functions/`. O CI, em máquina limpa, é o veredito real.
