### PR TITLE
docs(historico): o quarto estado do MixGap saiu de "raciocinado" para MEDIDO — e a medição achou um segundo efeito [money-path]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -477,7 +477,15 @@ Os outros achados que sobreviveram à verificação:
   `fetchStatus:'paused'`/`status:'pending'`: `isLoading` (v5 = `isPending && isFetching`) é **false**,
   `data` `undefined`, `error` `null` ⇒ cai em `semAcesso`, some da tela e **não emite**. Num PWA de
   campo esse não é o caso raro. As duas análises (Codex e a minha, escrita antes de abrir o parecer)
-  chegaram nele por caminhos separados.
+  chegaram nele por caminhos separados. **Medido** (vitest, `onlineManager.setOnline(false)`,
+  exit 0): tela `''` e **zero** eventos. No mesmo arquivo, o cenário de refetch-que-falha-com-cache
+  renderiza a lista normalmente antes de falhar — é o controle que descarta "mock quebrado" como
+  causa do vazio.
+- **O erro tem precedência sobre o dado stale, e isso custa a lista.** Medido no mesmo par: com
+  `com_gap` já na tela, um refetch que falha leva a `erro` e a lista de oportunidades **some**
+  (`listaAindaNaTela=false`), embora o cache ainda a tenha. Honesto para o sensor, regressão para o
+  vendedor em campo — o desenho que serve aos dois é um estado composto (lista + aviso de
+  desatualizada), não a escolha entre um e outro.
 - **A dedup por estado não reseta na troca de sujeito.** `trackedEstado` sobrevive à mudança de
   `effectiveUserId` ("Ver como"): alvo diferente com o mesmo estado não emite — e a 1ª emissão não
   marca que era impersonação, então o denominador de adoção conta staff como vendedor.


### PR DESCRIPTION
Follow-up do #1870 (challenge retroativo do #1859). Branch nova a partir da `main` — o #1870 foi squashed, então empilhar aqui recriaria trabalho já mergeado.

## O que muda

O registro dizia que o caso offline foi levantado por **duas análises independentes**. Isso é convergência, não evidência: ausência de sinal não aprova, e duas deduções sobre a semântica do react-query v5 continuam sendo deduções. Rodei a sonda (vitest, `onlineManager.setOnline(false)`) — **exit 0, 2/2**:

```
S1 texto=[] eventos=[]
S2 eventos=[{"estado":"com_gap","total_com_gap":2},{"estado":"erro","total_com_gap":null}] listaAindaNaTela=false
```

**S1 confirma o quarto estado:** offline na primeira carga ⇒ tela vazia e **zero** eventos, no balde do "sem acesso". O controle que descarta "mock quebrado" como causa do vazio é o próprio S2 — mesmos mocks, renderiza a lista antes de falhar.

**S2 achou o que nenhuma das duas análises tinha medido:** com `com_gap` já na tela, um refetch que falha leva a `erro` e a lista de oportunidades **some**, embora o cache ainda a tenha. A precedência de `error` sobre dado stale é honesta para o sensor e regressão para o vendedor em campo. O desenho que serve aos dois é o estado composto (lista + aviso de desatualizada), não a escolha entre um e o outro.

Fica registrado para a sessão que pegar o chip `Offline vira "sem acesso" no MixGapCard`.

## Escopo

Só doc. Sem migration, sem edge, sem mudança de comportamento. A sonda foi diagnóstico e **não** vai para o repo — o teste definitivo nasce no chip, com falsificação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)