### PR TITLE
fix(farmer): o desfecho memorizado atravessava a geração e escondia o botão da recomendação nova [money-path]

### DIFF
--- a/docs/historico/farmer-sensor-desfecho.md
+++ b/docs/historico/farmer-sensor-desfecho.md
@@ -260,3 +260,151 @@ query de coorte não distingue "ninguém clicou" de "ninguém abriu a tela":
 silêncio que não se consegue observar **não é dado** — a etapa 3 depende do founder ou de
 uma sonda que ainda não existe. As etapas 1 e 2 respondem no mesmo `psql-ro`, sem
 depender de ninguém: foi por isso que elas vieram primeiro.
+---
+
+# O adversarial no CÓDIGO — o passo que faltava (2026-08-22)
+
+O ritual `/codex` do money-path é metodologia → spec → plano → **adversarial no código**.
+No #1851 os três primeiros rodaram (e o primeiro derrubou o botão "Ofertei"); o quarto
+não. O PR foi mergeado com "REVISÃO INDEPENDENTE PENDENTE" no corpo, pelo Caminho B.
+Esta seção fecha a lacuna: `gpt-5.6-luna`, reasoning `xhigh`, sobre os quatro arquivos
+TypeScript, com o SQL fora de escopo (ele já tinha o harness PG17 como oráculo).
+
+## O diagnóstico anterior estava errado — não era cota
+
+O registro dizia `COTA_ESGOTADA` (janela rolante de 7 dias do ChatGPT Plus). Ao re-rodar,
+o erro real apareceu:
+
+```
+status 400 invalid_request_error
+"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."
+```
+
+`gpt-5.6` e `gpt-5.1-codex-max` dão o mesmo 400; `gpt-5.6-luna` responde. O default do
+`scripts/codex-async.sh` é `gpt-5.6-sol` — **o transporte do ritual está quebrado para
+todo o repo**, não só para esta sessão.
+
+E ele mente sobre o motivo: o classificador de transitório roda `grep -E '…|5[0-9][0-9]'`
+sobre um stderr que contém o **prompt ecoado**. O prompt trazia saída de `cat -n`, então
+um número de linha entre 500 e 599 casou com o padrão de erro 5xx e um 400 permanente
+virou "transitório" — 3 tentativas e 80s de backoff atrás de algo que nunca ia mudar.
+
+> **A classe:** um classificador de erro que lê o stderr INTEIRO está lendo a própria
+> entrada de volta. O padrão precisa casar na linha de ERRO, não no eco do que foi
+> enviado — senão o conteúdo do prompt decide a política de retry.
+
+## O achado P1: a chave de negócio é identidade DENTRO de uma geração
+
+O parecer e a auto-revisão chegaram nele por caminhos independentes.
+
+`useFarmerDesfecho` memoriza os desfechos da sessão num mapa por chave de negócio
+(`cliente|produto|tipo`) — porque o browser não tem o id da linha. O botão **"Recalcular"**
+chama `farmer_recomendacoes_substituir`, que expira as pendentes e insere linhas NOVAS
+com a **mesma chave**. O mapa sobrevive: a página não desmonta.
+
+1. R1 nasce `pendente`; a vendedora marca "Comprou" → R1 vira `aceito`, mapa guarda a chave.
+2. Ela clica em "Recalcular" → R1 (já com desfecho) sobrevive, e R2 nasce `pendente`.
+3. O card de R2 lê o mapa pela chave e mostra **"Venda registrada"** — sobre uma linha
+   que está `pendente` no banco — **e esconde os botões**.
+
+O segundo efeito é o pior: o desfecho de R2 fica impossível de registrar, e R2 morre como
+`expirado`, que a query de medição lê como "substituída sem interação". É **perda
+silenciosa do sinal que este sensor existe para produzir** — o zero volta, indistinguível
+do zero real.
+
+> **A lição transferível:** o SQL gastou três guardas (derrubar `ofertado`, FD006, a
+> trigger de imutabilidade) para tornar a chave de negócio uma **identidade** — e ela só
+> é identidade **dentro de uma geração**. Um cache do cliente indexado pela MESMA chave
+> **herda o escopo do invariante**; se ele vive mais que a geração, quebra em silêncio a
+> garantia que o banco comprou caro. O guard ficou de um lado do fio e a violação do outro.
+
+**A correção** é `esquecerRegistros()`, chamado no "Recalcular". Ele esquece em TODO
+recálculo, **inclusive nos que falham ao persistir** — ali as linhas antigas seguem
+valendo e a memória era boa. É o lado seguro do trade-off: o pior caso vira um clique que
+o banco recusa com FD007 ("já tem desfecho"), mensagem honesta e zero dado corrompido;
+o outro lado perde sinal sem avisar. Distinguir os casos exigiria acoplar o hook às
+SQLSTATEs `FG005`/`FG006` do engine para comprar precisão numa direção que já é segura.
+
+O mesmo achado trouxe a corrida: "Recalcular" **com uma gravação em voo** faz a
+substituição correr contra a RPC de desfecho pela mesma chave — se a substituição vencer,
+o aceite cai na geração nova. O banco não tem como distinguir (a chave é a única
+identidade que o browser tem), então a serialização é do cliente: o botão fica travado
+enquanto `registrando`.
+
+## Falsificar contra a PROMESSA DO NOME, não contra a funcionalidade
+
+O #1851 já tinha falsificado os testes com seis sabotagens, e duas revelaram teatro. Ainda
+assim, o adversarial achou mais — e o padrão do que **escapou** é o achado metodológico:
+
+| Teste | O que o nome prometia | O que o assert media |
+|---|---|---|
+| `o evento sai antes do await` | uma **ordem** | que o evento existe em algum momento (o mock resolvia na hora) |
+| `o vocabulário é EXATAMENTE o do CHECK da tabela` | acordo **TS↔SQL** | acordo da constante TS com um literal TS |
+
+As seis sabotagens anteriores miravam a **funcionalidade** (o desfecho grava? a lente
+barra?) e por isso passaram ao largo: nenhuma delas mexia na ORDEM nem no CHECK.
+
+> **A classe (irmã de "falsificar pela UI só prova a camada de cima"):** quando o nome do
+> teste afirma uma **ordem**, um **acordo entre camadas** ou uma **negativa**, a sabotagem
+> tem de mirar essa afirmação específica. Sabotar a feature deixa esses asserts verdes,
+> porque não é a feature que eles prometem medir.
+
+O de ordem agora segura a RPC pendente e exige o evento **antes** de resolver. O de
+vocabulário **lê a migration** e compara com a constante: não prova a prod (apply manual
+diverge do repo), mas fecha a corrente com o outro elo — `db/test-farmer-desfecho.sh`
+executa esse mesmo CHECK num PG17 de verdade. TS↔arquivo aqui, arquivo↔Postgres lá. E o
+extrator tem controle positivo: regex que não casa **falha nomeando o motivo**, em vez de
+devolver lista vazia e passar.
+
+Outras quatro lacunas fechadas, todas com a mesma assinatura — sabotagem que ficava verde:
+o ramo `catch` (falha de transporte) não tinha teste **nenhum**; a recusa bem-sucedida
+nunca era confirmada na tela (renderizar "Venda registrada" numa recusa passava); a recusa
+não conferia a chave de negócio; e `FD002`/`FD007` nunca eram exercitados.
+
+## O achado recusado, com o porquê
+
+**"Exceção do analytics deixa a trava presa"** — o parecer notou que `track()` roda depois
+de `gravandoRef.current = true` e **fora** do `try`, e concluiu que um throw síncrono
+travaria o hook para sempre.
+
+Recusado com evidência: `track()` delega a `withPosthog`, que invoca o callback dentro de
+um `try/catch` próprio (`src/lib/analytics.ts`). Não há caminho de throw síncrono.
+
+E a "correção" seria **pior que o bug**: mover o `track()` para dentro do `try` faria uma
+falha de analytics cair no `catch` de transporte e mostrar *"Não consegui falar com o
+servidor — o desfecho NÃO foi registrado"* — uma mensagem **falsa**, sobre uma gravação
+que teria acontecido. Achado sem trigger não vira código; e defesa em profundidade que
+mente na degradação não é defesa.
+
+## E a falsificação desta rodada pegou um teatro MEU
+
+Seis sabotagens, seis vermelhos — mas **dois** dos asserts que eu esperava derrubar
+ficaram verdes. Um era alvo errado meu; o outro era teatro de verdade:
+
+```ts
+fireEvent.click(recalcular());
+await waitFor(() => expect(screen.queryByText('Venda registrada')).toBeNull());
+```
+
+`waitFor` passa no **primeiro poll** em que a condição vale — e a lista some sozinha
+enquanto remonta o recálculo. O assert media a remontagem, não a invalidação da memória:
+ficava **verde com a sabotagem aplicada**. O teste irmão ("os botões VOLTAM") usava
+`findByRole`, que espera algo **aparecer**, e ficou vermelho como devia.
+
+Corrigido ancorando a ausência num instante em que o card comprovadamente existe:
+
+```ts
+await screen.findByRole('button', { name: 'Cliente comprou' });  // a geração nova está na tela
+expect(screen.queryByText('Venda registrada')).toBeNull();       // e não afirma nada
+```
+
+> **A classe:** **ausência só é evidência quando medida sobre algo que está lá.** É a irmã
+> em RTL do "`grep` sem ocorrência é ausência de dado" do CLAUDE.md — e a assinatura é
+> `waitFor` + assert NEGATIVO, que se satisfaz com qualquer janela em que o alvo não
+> exista, inclusive as que o bug não causa. Para negativa, ancore num positivo primeiro.
+
+O outro verde (`o dialog RENDERIZA os seis motivos`) **não** era teatro: a sabotagem
+mexeu na constante `MOTIVOS_RECUSA`, e esse dano é o que o teste de vocabulário pega
+(ficou vermelho). O alvo dele é o componente renderizar um SUBCONJUNTO da constante —
+sabotado corretamente na segunda rodada, vermelho. Falsificação com alvo errado não
+condena o assert; só não o absolve.

--- a/src/components/farmer/recomendacoes/__tests__/BotoesDesfechoRecomendacao.test.tsx
+++ b/src/components/farmer/recomendacoes/__tests__/BotoesDesfechoRecomendacao.test.tsx
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BotoesDesfechoRecomendacao } from '../BotoesDesfechoRecomendacao';
@@ -96,14 +98,64 @@ describe('a recusa exige o PORQUÊ — é o motivo que calibra, não o placar', 
     const args = (rpcMock.mock.calls[0] as unknown as RpcArgs)[1];
     expect(args.p_desfecho).toBe('rejeitado');
     expect(args.p_motivo).toBe('preco');
+    // A CHAVE DE NEGÓCIO é a única identidade que o browser tem — o id da linha nunca
+    // volta do motor. Mandá-la errada só na recusa dava FD004, ou pior: carimbava outra
+    // linha. O teste do aceite conferia isto; o da recusa, não (achado do /codex).
+    expect(args.p_customer_user_id).toBe('cli-1');
+    expect(args.p_product_id).toBe('prod-1');
+    expect(args.p_recommendation_type).toBe('cross_sell');
+  });
+
+  it('[SENSOR] a recusa confirmada vira "Recusa registrada" — nunca "Venda registrada"', async () => {
+    // Nada exigia isto: renderizar "Venda registrada" para um desfecho `rejeitado`
+    // deixava os 16 testes verdes (achado do /codex). Seria a UI afirmando uma venda
+    // onde o banco gravou uma recusa — o dado errado que é pior que dado nenhum.
+    render(<Host />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cliente recusou' }));
+    await waitFor(() => screen.getByText('Por que o cliente recusou?'));
+    fireEvent.click(screen.getByRole('button', { name: 'Preço' }));
+
+    await waitFor(() => expect(screen.getByText('Recusa registrada')).toBeInTheDocument());
+    expect(screen.queryByText('Venda registrada')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cliente recusou' })).toBeNull();
+  });
+
+  it('[SENSOR] o dialog RENDERIZA os seis motivos, não só o primeiro', async () => {
+    // O teste de vocabulário abaixo prova a CONSTANTE. Renderizar só "Preço" mantendo a
+    // constante intacta ficava verde (achado do /codex) — e um motivo que não aparece na
+    // tela nunca entra na calibração, enviesando o porquê das recusas.
+    render(<Host />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cliente recusou' }));
+    await waitFor(() => screen.getByText('Por que o cliente recusou?'));
+    // O laço percorre a MESMA constante que o componente mapeia — sozinho ele só prova
+    // "renderiza o que a constante diz". O elo com o banco é o teste acima (constante ↔
+    // CHECK da migration); o elo aqui é constante ↔ tela. A contagem explícita fecha o
+    // caso de renderizar um subconjunto.
+    for (const m of MOTIVOS_RECUSA) {
+      expect(screen.getByRole('button', { name: m.rotulo }), `motivo "${m.rotulo}" não foi renderizado`).toBeInTheDocument();
+    }
+    expect(MOTIVOS_RECUSA).toHaveLength(6);
   });
 
   it('[SENSOR] o vocabulário do dialog é EXATAMENTE o do CHECK da tabela', () => {
-    // Um rótulo a mais aqui é um clique que o banco recusa com 23514. A migration
-    // farmer_recommendations_motivo_coerente lista estes seis e só estes.
-    expect(MOTIVOS_RECUSA.map((m) => m.valor)).toEqual([
-      'preco', 'sem_necessidade', 'ja_compra_concorrente', 'sem_estoque', 'prazo_entrega', 'outro',
-    ]);
+    // Um rótulo a mais aqui é um clique que o banco recusa com 23514.
+    //
+    // Este assert comparava a constante TS com um literal TS — o nome prometia acordo
+    // com o CHECK e provava acordo consigo mesmo. Agora ele LÊ a migration. Não prova a
+    // prod (apply manual pode divergir do repo — CLAUDE.md §migration), mas fecha a
+    // corrente com o outro elo: db/test-farmer-desfecho.sh executa este mesmo CHECK num
+    // PG17 de verdade. TS↔arquivo aqui, arquivo↔Postgres lá.
+    const sql = readFileSync(
+      resolve(process.cwd(), 'supabase/migrations/20260821194411_farmer_recomendacao_desfecho.sql'),
+      'utf-8',
+    );
+    const lista = /rejection_reason IN \(([^)]*)\)/.exec(sql)?.[1];
+    // CONTROLE: sem isto, uma regex que não casa devolveria [] e o `toEqual` falharia por
+    // um motivo que eu leria como "o vocabulário divergiu". Fail-closed com o nome certo.
+    expect(lista, 'não achei a lista do CHECK na migration — o assert abaixo seria cego').toBeTruthy();
+    const doBanco = [...lista!.matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    expect(doBanco).toHaveLength(6);
+    expect(MOTIVOS_RECUSA.map((m) => m.valor)).toEqual(doBanco);
   });
 
   it('[SENSOR] o dialog NÃO fecha quando o banco recusa', async () => {
@@ -156,8 +208,27 @@ describe('erro do banco vira instrução, não "erro ao salvar"', () => {
     const fd004 = mensagemDoErro('FD004', 'fb');
     expect(fd004).toMatch(/Recarregue/);
     expect(fd004).not.toMatch(/tente de novo|tentar novamente/i);
+    // FD002/FD007 existem no contrato e nenhum assert os chamava (achado do /codex):
+    // quebrá-los devolvia o fallback genérico, que não diz o que fazer.
+    expect(mensagemDoErro('FD002', 'fb')).toMatch(/inválido/i);
+    expect(mensagemDoErro('FD007', 'fb')).toMatch(/já tem desfecho|histórico/i);
     // Código desconhecido cai no fallback — nunca numa mensagem inventada.
     expect(mensagemDoErro(undefined, 'fb')).toBe('fb');
+  });
+
+  it('[ERRO] falha de TRANSPORTE não marca o card como registrado', async () => {
+    // O `catch` (rede/CORS) não tinha teste NENHUM (achado do /codex): sabotá-lo para
+    // chamar setRegistrados e devolver `true` deixava a suíte inteira verde. É o irmão
+    // do erro de banco — a UI afirmando uma gravação sem nenhuma evidência de que ela
+    // aconteceu, no caso em que o servidor sequer respondeu.
+    rpcMock.mockRejectedValueOnce(new Error('Failed to fetch'));
+    render(<Host />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cliente comprou' }));
+
+    await waitFor(() => expect(toastMock.error).toHaveBeenCalledTimes(1));
+    expect(toastMock.error.mock.calls[0][0]).toMatch(/NÃO foi registrado/);
+    expect(screen.queryByText('Venda registrada')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Cliente comprou' })).toBeInTheDocument();
   });
 
   it('[ERRO] erro de banco NÃO marca o card como registrado', async () => {
@@ -173,13 +244,37 @@ describe('erro do banco vira instrução, não "erro ao salvar"', () => {
 });
 
 describe('o sensor mede a TENTATIVA, não só o sucesso', () => {
-  it('[TRACK] o evento sai antes do await e carrega desfecho e tipo', async () => {
+  it('[TRACK] o evento sai ANTES do await e carrega desfecho e tipo', async () => {
+    // A RPC fica PENDENTE de propósito. Com um mock que resolve na hora, este assert
+    // passava com o `track()` movido para DEPOIS do await (achado do /codex adversarial):
+    // ele provava que o evento existe em algum momento, não que ele precede a ida ao
+    // banco. E é justamente o caso "clicou e a gravação nunca voltou" que o sensor
+    // existe para medir — no sucesso o dado já está no banco e não precisa do evento.
+    let resolver: (v: RpcRet) => void = () => {};
+    rpcMock.mockImplementation(() => new Promise<RpcRet>((r) => { resolver = r; }));
     render(<Host />);
     fireEvent.click(screen.getByRole('button', { name: 'Cliente comprou' }));
+
+    // Sem `waitFor`: o evento tem de estar aqui AGORA, com a RPC ainda em voo.
+    const ev = eventos().find(([n]) => n === 'recomendacao.desfecho_clicado');
+    expect(ev, 'o evento só saiu depois do await — tentativa que morre não seria medida').toBeTruthy();
+    expect(ev![1]).toMatchObject({ desfecho: 'aceito', tipo: 'cross_sell', motivo: null });
+
+    resolver({ data: null, error: null });
+    await waitFor(() => expect(screen.getByText('Venda registrada')).toBeInTheDocument());
+  });
+
+  it('[TRACK] a RECUSA também conta como tentativa, e carrega o motivo', async () => {
+    // Emitir só no aceite enviesaria o sensor na direção mais cara: as recusas são
+    // metade do sinal, e o motivo é o que separa erro do motor de falha operacional.
+    render(<Host />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cliente recusou' }));
+    await waitFor(() => screen.getByText('Por que o cliente recusou?'));
+    fireEvent.click(screen.getByRole('button', { name: 'Preço' }));
+
     await waitFor(() => expect(rpcMock).toHaveBeenCalled());
     const ev = eventos().find(([n]) => n === 'recomendacao.desfecho_clicado');
-    expect(ev).toBeTruthy();
-    expect(ev![1]).toMatchObject({ desfecho: 'aceito', tipo: 'cross_sell', motivo: null });
+    expect(ev![1]).toMatchObject({ desfecho: 'rejeitado', motivo: 'preco', tipo: 'cross_sell' });
   });
 
   it('[TRACK] toque barrado pela lente NÃO conta como tentativa', () => {

--- a/src/hooks/useFarmerDesfecho.ts
+++ b/src/hooks/useFarmerDesfecho.ts
@@ -149,5 +149,25 @@ export function useFarmerDesfecho() {
     [isImpersonating],
   );
 
-  return { registrar, registrados, registrando, bloqueadoPelaLente: isImpersonating };
+  /**
+   * Esquece os desfechos memorizados NESTA sessão.
+   *
+   * `registrados` é memória de UMA geração. Quando o motor recalcula, a
+   * `farmer_recomendacoes_substituir` expira as pendentes e insere linhas NOVAS com a
+   * MESMA chave de negócio — o card passa a falar de outra linha, que não tem desfecho.
+   * Sem esquecer, ele afirmaria "Venda registrada" sobre uma linha ainda `pendente` E
+   * esconderia os botões: o desfecho da geração nova ficaria impossível de registrar e
+   * ela morreria como `expirado` ("substituída sem interação") — exatamente o zero que
+   * este sensor existe para acabar. (Achado P1 do /codex adversarial no CÓDIGO.)
+   *
+   * Esquece em TODO recálculo, inclusive nos que FALHAM ao persistir — aí as linhas
+   * antigas seguem valendo e a memória era boa. É o lado seguro do trade-off: o pior
+   * caso vira um clique que o banco recusa com FD007 ("já tem desfecho"), mensagem
+   * honesta e zero dado corrompido; o outro lado perde sinal em SILÊNCIO. Distinguir os
+   * casos exigiria ler o desfecho da persistência do engine, acoplando este hook às
+   * SQLSTATEs FG005/FG006 dele para comprar precisão numa direção que já é segura.
+   */
+  const esquecerRegistros = useCallback(() => setRegistrados({}), []);
+
+  return { registrar, registrados, registrando, esquecerRegistros, bloqueadoPelaLente: isImpersonating };
 }

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -325,6 +325,7 @@ export const MODULOS: ModuloApp[] = [
       "src/pages/__tests__/FarmerBundles.erro-honesto.test.tsx",
       "src/pages/__tests__/FarmerDashboard.erro-honesto.test.tsx",
       "src/pages/__tests__/FarmerRecommendations.erro-honesto.test.tsx",
+      "src/pages/__tests__/FarmerRecommendations.desfecho-geracao.test.tsx",
     ],
     risco: { moneyPath: false, offlineFirst: false, authSensitive: false },
   },

--- a/src/pages/FarmerRecommendations.tsx
+++ b/src/pages/FarmerRecommendations.tsx
@@ -85,7 +85,23 @@ const FarmerRecommendations = () => {
           <h1 className="text-xl font-semibold">Recomendações</h1>
           <p className="text-sm text-muted-foreground">Cross-sell e up-sell priorizados por afinidade com o cliente</p>
         </div>
-        <Button variant="outline" size="sm" onClick={calculateRecommendations} disabled={calculating} className="gap-1.5">
+        <Button
+          variant="outline"
+          size="sm"
+          // Recalcular SUBSTITUI as linhas no banco (`farmer_recomendacoes_substituir`
+          // expira as pendentes e insere outras com a mesma chave de negócio). Esquecer
+          // a memória local é o que impede o card de afirmar "Venda registrada" sobre uma
+          // linha NOVA, ainda pendente — e de esconder os botões dela. Ver a nota longa
+          // em useFarmerDesfecho.esquecerRegistros.
+          onClick={() => { registroDesfecho.esquecerRegistros(); calculateRecommendations(); }}
+          // Recalcular COM uma gravação em voo faz a substituição correr contra a RPC de
+          // desfecho pela mesma chave: se a substituição vencer a corrida, o aceite cai na
+          // geração NOVA — um cálculo que a vendedora nunca viu. O banco não tem como
+          // distinguir (a chave de negócio é a única identidade que o browser tem), então
+          // a serialização é aqui.
+          disabled={calculating || !!registroDesfecho.registrando}
+          className="gap-1.5"
+        >
           {calculating ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
           Recalcular
         </Button>

--- a/src/pages/__tests__/FarmerRecommendations.desfecho-geracao.test.tsx
+++ b/src/pages/__tests__/FarmerRecommendations.desfecho-geracao.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+/**
+ * Guard money-path — a memória local de desfecho vale para UMA geração.
+ *
+ * Achado P1 do `/codex` adversarial no CÓDIGO (o passo que faltava do ritual do #1851:
+ * a cota esgotou na metodologia e o adversarial rodou depois, ver
+ * docs/historico/farmer-sensor-desfecho.md).
+ *
+ * `useFarmerDesfecho` guarda os desfechos da sessão num mapa por CHAVE DE NEGÓCIO
+ * (cliente|produto|tipo) — porque o browser não tem o id da linha. Só que "Recalcular"
+ * chama `farmer_recomendacoes_substituir`, que EXPIRA as pendentes e insere linhas novas
+ * com a mesma chave. Sem invalidar o mapa, o card da geração NOVA:
+ *
+ *   1. afirma "Venda registrada" sobre uma linha que está `pendente` no banco; e
+ *   2. esconde os botões — o desfecho dela fica impossível de registrar e ela morre como
+ *      `expirado`, que a query de medição lê como "substituída sem interação".
+ *
+ * Os dois lados são o mesmo bug e o segundo é o pior: é perda SILENCIOSA do sinal que
+ * este sensor existe para produzir. A suíte de componente não pega — nenhum teste dela
+ * monta a página nem clica em "Recalcular". É a fiação que precisa ser provada.
+ *
+ * Aqui o engine roda de VERDADE (só o supabase é mockado): mockar o hook provaria apenas
+ * que a página sabe renderizar um estado que eu mesmo montei.
+ */
+const FARMER = 'farmer-real';
+
+/** Controla a RPC de desfecho: `null` = resolve na hora; função = fica pendente. */
+let segurarDesfecho: ((v: unknown) => void) | null = null;
+let capturarPendente = false;
+const desfechoChamadas: Record<string, unknown>[] = [];
+
+// Mesmo seed mínimo de `FarmerRecommendations.erro-honesto.test.tsx`: produz UMA
+// recomendação de cross-sell (p2, puxada pela regra de associação p1→p2).
+const SCORES = [{
+  customer_user_id: 'c1', farmer_id: FARMER,
+  health_score: 80, answer_rate_60d: 50, whatsapp_reply_rate_60d: 50,
+}];
+const PRODUTOS = [
+  { id: 'p1', codigo: 'P1', descricao: 'Produto Um', valor_unitario: 100, metadata: null, ativo: true, omie_codigo_produto: 1, estoque: 10 },
+  { id: 'p2', codigo: 'P2', descricao: 'Produto Dois', valor_unitario: 200, metadata: null, ativo: true, omie_codigo_produto: 2, estoque: 5 },
+];
+const CUSTOS = [
+  { product_id: 'p1', cost_final: 60, cost_price: null },
+  { product_id: 'p2', cost_final: 100, cost_price: null },
+];
+const PEDIDOS = [{
+  customer_user_id: 'c1', total: 200, created_at: '2026-07-01T00:00:00Z',
+  items: [{ product_id: 'p1', quantity: 2, unit_price: 100 }],
+}];
+const REGRAS = [{
+  antecedent_product_ids: ['p1'], consequent_product_ids: ['p2'],
+  confidence: 0.5, lift: 2, support: 0.1,
+}];
+const PERFIS = [{ user_id: 'c1', name: 'Cliente Um', customer_type: 'pj', cnae: null }];
+
+function resposta(table: string): unknown {
+  if (table === 'farmer_client_scores') return { data: SCORES, error: null };
+  if (table === 'omie_products') return { data: PRODUTOS, error: null };
+  if (table === 'product_costs') return { data: CUSTOS, error: null };
+  if (table === 'sales_orders') return { data: PEDIDOS, error: null };
+  if (table === 'farmer_association_rules') return { data: REGRAS, error: null };
+  if (table === 'profiles') return { data: PERFIS, error: null };
+  return { data: [], error: null, count: 0 };
+}
+
+function chain(table: string): unknown {
+  const c: Record<string, unknown> = {};
+  for (const m of [
+    'select', 'eq', 'gte', 'lt', 'lte', 'gt', 'is', 'not', 'in', 'order', 'limit',
+    'range', 'or', 'neq', 'filter', 'single', 'maybeSingle', 'contains',
+    'upsert', 'insert', 'update', 'delete',
+  ]) c[m] = () => c;
+  c.then = (resolve: (v: unknown) => void) => resolve(resposta(table));
+  return c;
+}
+
+/** Derivado de PRODUTOS/CUSTOS para as duas fontes não divergirem (ver erro-honesto). */
+function vendaveisDoSeed(): { product_id: string }[] {
+  return CUSTOS.filter((c) => {
+    const p = PRODUTOS.find((x) => x.id === c.product_id);
+    return p != null && c.cost_final != null && p.valor_unitario > c.cost_final;
+  }).map((c) => ({ product_id: c.product_id }));
+}
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (t: string) => chain(t),
+    rpc: (nome: string, args?: Record<string, unknown>) => {
+      const c: Record<string, unknown> = { order: () => c, range: () => c };
+      if (nome === 'farmer_recomendacao_registrar_desfecho') {
+        desfechoChamadas.push(args ?? {});
+        c.then = (resolve: (v: unknown) => void) => {
+          if (capturarPendente) { segurarDesfecho = resolve; return; }
+          resolve({ data: null, error: null });
+        };
+        return c;
+      }
+      const r = nome === 'get_skus_margem_positiva'
+        ? { data: vendaveisDoSeed(), error: null }
+        : { data: null, error: null };
+      c.then = (resolve: (v: unknown) => void) => resolve(r);
+      return c;
+    },
+  },
+}));
+vi.mock('@/contexts/ImpersonationContext', () => ({
+  useImpersonation: () => ({ isImpersonating: false, effectiveUserId: FARMER }),
+}));
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: FARMER }, isStaff: true, loading: false }),
+}));
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
+}));
+vi.mock('@/lib/analytics', () => ({ captureException: vi.fn(), track: vi.fn() }));
+
+import FarmerRecommendations from '../FarmerRecommendations';
+
+beforeEach(() => {
+  segurarDesfecho = null;
+  capturarPendente = false;
+  desfechoChamadas.length = 0;
+  vi.clearAllMocks();
+});
+
+/** Abre o cliente e devolve o botão de aceite do único card de cross-sell do seed. */
+async function abrirCardEPegarComprou(): Promise<HTMLElement> {
+  fireEvent.click(await screen.findByText('Cliente Um'));
+  return screen.findByRole('button', { name: 'Cliente comprou' });
+}
+
+const recalcular = () => screen.getByRole('button', { name: /Recalcular/i });
+
+describe('FarmerRecommendations — o desfecho memorizado não atravessa a geração', () => {
+  it('DETECTOR: o card do seed expõe o botão de desfecho e ele grava', async () => {
+    // Sem este teste, "os botões voltaram" e "a tela nunca renderizou botão nenhum"
+    // seriam indistinguíveis — todos os asserts abaixo passariam num componente vazio.
+    render(<FarmerRecommendations />);
+
+    fireEvent.click(await abrirCardEPegarComprou());
+
+    await waitFor(() => expect(desfechoChamadas).toHaveLength(1));
+    expect(desfechoChamadas[0].p_desfecho).toBe('aceito');
+    expect(await screen.findByText('Venda registrada')).toBeTruthy();
+  });
+
+  it('após Recalcular, o card NÃO afirma "Venda registrada" sobre a linha nova', async () => {
+    render(<FarmerRecommendations />);
+    fireEvent.click(await abrirCardEPegarComprou());
+    await screen.findByText('Venda registrada');
+
+    // A substituição trocou as linhas: o desfecho ficou na geração ANTERIOR e a chave de
+    // negócio agora aponta para uma linha `pendente` que ninguém registrou.
+    fireEvent.click(recalcular());
+
+    // Espera o card da geração NOVA existir ANTES de afirmar a ausência. Sem esta
+    // âncora o assert era teatro, e a falsificação provou: `waitFor(queryByText → null)`
+    // passa no primeiro poll em que o texto some, e a lista some sozinha enquanto
+    // remonta — o teste ficava VERDE com a sabotagem aplicada, por um motivo que não é
+    // o que o nome promete. Ausência só é evidência medida sobre algo que está lá.
+    await screen.findByRole('button', { name: 'Cliente comprou' });
+    expect(
+      screen.queryByText('Venda registrada'),
+      'o card afirmou um desfecho que a linha nova não tem',
+    ).toBeNull();
+  });
+
+  it('após Recalcular, os botões VOLTAM — senão o sinal da geração nova se perde', async () => {
+    // O lado silencioso do mesmo bug, e o pior: sem botão a vendedora não tem como
+    // registrar o desfecho da recomendação nova, e ela morre como `expirado`, que a query
+    // de medição lê como "substituída sem interação". Zero indistinguível de zero real.
+    render(<FarmerRecommendations />);
+    fireEvent.click(await abrirCardEPegarComprou());
+    await screen.findByText('Venda registrada');
+
+    fireEvent.click(recalcular());
+
+    const comprou = await screen.findByRole('button', { name: 'Cliente comprou' });
+    expect(comprou).toBeInTheDocument();
+    // E o botão de volta grava DE VERDADE: um botão inerte seria o mesmo bug com outra cara.
+    fireEvent.click(comprou);
+    await waitFor(() => expect(desfechoChamadas).toHaveLength(2));
+  });
+
+  it('Recalcular fica TRAVADO enquanto uma gravação está em voo', async () => {
+    // Sem a trava, a substituição corre contra a RPC de desfecho pela mesma chave: se a
+    // substituição vencer, o aceite cai na geração NOVA — um cálculo que ela nunca viu.
+    // A chave de negócio é a única identidade que o browser tem, então o banco não
+    // consegue distinguir; a serialização é do cliente.
+    capturarPendente = true;
+    render(<FarmerRecommendations />);
+
+    fireEvent.click(await abrirCardEPegarComprou());
+
+    await waitFor(() => expect(recalcular()).toBeDisabled());
+
+    // E DESTRAVA quando a gravação termina — travar para sempre trocaria um bug por outro.
+    segurarDesfecho?.({ data: null, error: null });
+    await waitFor(() => expect(recalcular()).not.toBeDisabled());
+  });
+});


### PR DESCRIPTION
Fecha a **REVISÃO INDEPENDENTE PENDENTE** registrada no #1851: o 4º passo do ritual `/codex` money-path — o **adversarial no CÓDIGO** — não tinha rodado. Rodou agora (`gpt-5.6-luna`, reasoning `xhigh`) sobre os quatro arquivos TypeScript do sensor. O SQL ficou fora de escopo por já ter oráculo próprio (`db/test-farmer-desfecho.sh`, 29 asserts).

## O achado P1 — a chave de negócio só é identidade DENTRO de uma geração

O parecer e a auto-revisão chegaram nele por caminhos independentes.

`useFarmerDesfecho` memoriza os desfechos da sessão num mapa por **chave de negócio** (`cliente|produto|tipo`), porque o browser não tem o id da linha. O botão **"Recalcular"** chama `farmer_recomendacoes_substituir`, que expira as pendentes e insere linhas **novas com a mesma chave** — e o mapa sobrevive, porque a página não desmonta.

1. R1 nasce `pendente`; a vendedora marca "Comprou" → R1 vira `aceito`, o mapa guarda a chave.
2. Ela clica em "Recalcular" → R1 (já com desfecho) sobrevive à expiração, e R2 nasce `pendente`.
3. O card de R2 lê o mapa pela chave e mostra **"Venda registrada"** — sobre uma linha que está `pendente` no banco — **e esconde os botões**.

O segundo efeito é o pior: o desfecho de R2 fica impossível de registrar e ela morre como `expirado`, que a query de medição lê como *"substituída sem interação"*. É perda **silenciosa** do sinal que este sensor existe para produzir.

> O SQL gastou três guardas para tornar a chave de negócio uma identidade (derrubar `'ofertado'`, FD006, a trigger de imutabilidade) — e ela só é identidade **dentro de uma geração**. Um cache do cliente indexado pela mesma chave **herda o escopo do invariante**. O guard ficou de um lado do fio e a violação do outro.

**Correção:** `esquecerRegistros()` no "Recalcular". Esquece inclusive quando a persistência **falha** — ali as linhas antigas seguem valendo e a memória era boa. É o lado seguro do trade-off: o pior caso vira um clique que o banco recusa com FD007 ("já tem desfecho"), mensagem honesta e zero dado corrompido; o outro lado perde sinal sem avisar. Distinguir os casos exigiria acoplar o hook às SQLSTATEs `FG005`/`FG006` do engine para comprar precisão numa direção que já é segura.

**E a corrida:** "Recalcular" com uma gravação em voo faz a substituição correr contra a RPC pela mesma chave — se a substituição vencer, o aceite cai na geração nova. A chave é a única identidade que o browser tem, então o banco não consegue distinguir: a serialização é do cliente (botão travado enquanto `registrando`).

## Testes: 16 → 24, e duas lacunas eram promessa-do-nome

O #1851 já tinha falsificado com seis sabotagens. Elas miravam a **funcionalidade**, e por isso passaram ao largo de asserts que prometiam outra coisa:

| Teste | O nome prometia | O assert media |
|---|---|---|
| `o evento sai antes do await` | uma **ordem** | que o evento existe em algum momento (o mock resolvia na hora) |
| `o vocabulário é EXATAMENTE o do CHECK` | acordo **TS↔SQL** | acordo da constante TS com um literal TS |

O de ordem agora segura a RPC **pendente** e exige o evento antes de resolver. O de vocabulário **lê a migration** (com controle positivo na extração: regex que não casa falha nomeando o motivo, em vez de devolver lista vazia e passar). Não prova a prod — apply manual diverge do repo — mas fecha a corrente com o outro elo: o harness PG17 executa esse mesmo CHECK.

Outras lacunas fechadas, todas com a assinatura "sabotagem ficava verde": o ramo `catch` (falha de transporte) **não tinha teste nenhum**; a recusa bem-sucedida nunca era confirmada na tela; a recusa não conferia a chave de negócio; `FD002`/`FD007` nunca eram exercitados; e a fiação página↔hook não tinha teste — nenhum teste montava a página nem clicava em "Recalcular".

## A falsificação pegou um teatro MEU

Seis sabotagens → seis vermelhos, mas **dois** dos que eu esperava ficaram verdes. Um era alvo errado meu. O outro era teatro:

    fireEvent.click(recalcular());
    await waitFor(() => expect(screen.queryByText('Venda registrada')).toBeNull());

`waitFor` passa no **primeiro poll** em que a condição vale — e a lista some sozinha enquanto remonta. O assert media a remontagem, e ficava **verde com a sabotagem aplicada**. Corrigido ancorando a ausência num instante em que o card comprovadamente existe.

> **Ausência só é evidência quando medida sobre algo que está lá.** Irmã em RTL do "`grep` sem ocorrência é ausência de dado". Assinatura: `waitFor` + assert **negativo**.

## Achado RECUSADO, com o porquê

**"Exceção do `track()` deixa a trava presa"** — o parecer notou que `track()` roda depois de `gravandoRef.current = true` e **fora** do `try`.

Recusado com evidência: `track()` delega a `withPosthog`, que invoca o callback dentro do próprio `try/catch` (`src/lib/analytics.ts`). Não há caminho de throw síncrono. E a "correção" seria **pior que o bug**: com o `track()` dentro do `try`, uma falha de analytics cairia no catch de transporte e mostraria *"o desfecho NÃO foi registrado"* — mentira sobre uma gravação que aconteceu.

## Enquadramento honesto

O #1868 mediu que a tela **nunca foi carregada** desde o Publish (0 execuções em `farmer_geracao_execucoes`; 2 de 3 farmers nunca abriram). Então este PR **não recupera sinal perdido hoje** — não há sinal ainda. Ele corrige um defeito que destruiria o sinal assim que a tela passasse a ser usada. Com denominador tão escasso, perder desfecho por bug de cache seria caro.

## Validação

    EXIT_TEST=0        716 arquivos · 6.764 testes
    EXIT_TYPECHECK=0   tsc --noEmit -p tsconfig.app.json
    EXIT_LINT=0        75 warnings pré-existentes, 0 erros

Falsificação em 2 rodadas, 9 vermelhos **nomeados**. Sem migration, sem edge — só frontend, então o Publish do Lovable é o único deploy necessário.

### Bloqueador separado (chip criado)

`scripts/codex-async.sh` está com o default `gpt-5.6-sol`, que hoje devolve 400 *"not supported when using Codex with a ChatGPT account"* — **o transporte do ritual está quebrado para todo o repo**. Pior: o classificador de retry roda o regex de erro sobre um stderr que contém o **prompt ecoado**, então um número de linha entre 500–599 do `cat -n` casou com o padrão 5xx e fez um 400 permanente parecer transitório (3 tentativas + 80s de backoff). Foi isso que o #1851 registrou como `COTA_ESGOTADA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)