### PR TITLE
fix(recommend): a sonda devolvia a versão com `Bearer x` — gate próprio (medido em prod)

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -82,7 +82,11 @@ const ESCRITA_NOSSO_BANCO = [
 ];
 
 /** Destas o gate NÃO aceita `x-cron-secret`, então a sonda precisa de gate PRÓPRIO. */
-const GATE_PROPRIO = ["omie-cliente", "omie-nfe-webhook"];
+// `recommend` entra aqui porque seu gate normal é JWT e o `getUser` PRECISA do client — mas a
+// sonda responde ANTES do `createClient` (o gate acima exige). Sobrava só o
+// `startsWith("Bearer ")`: verificado em PROD, `Authorization: Bearer x` (token inválido)
+// devolvia a versão. Semi-público por acidente, não por decisão.
+const GATE_PROPRIO = ["omie-cliente", "omie-nfe-webhook", "recommend"];
 
 Deno.test("toda edge instrumentada declara VERSAO no formato vN.N-slug", () => {
   for (const { nome, mod } of EDGES) {

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -12,6 +12,7 @@ import {
 // vez de recomendar sobre catálogo parcial. Detalhe e medições: recommend-leituras.ts.
 import { carregarCluster, carregarInsumos } from "../_shared/recommend-leituras.ts";
 import type { BancoPostgrest } from "../_shared/paginate.ts";
+import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 
 const corsHeaders = {
@@ -463,9 +464,26 @@ Deno.serve(async (req) => {
     } catch {
       return jsonRes({ error: "invalid JSON" }, 400);
     }
+    // Gate PRÓPRIO da sonda (padrão de `omie-cliente`), e não o `Bearer ` do handler.
+    //
+    // O gate normal desta edge é JWT, e `supabaseAuth.auth.getUser()` PRECISA do client — que
+    // ainda não existe aqui, porque a sonda tem de responder antes dele. Sobrava então só o
+    // `startsWith("Bearer ")` lá em cima, que qualquer string satisfaz: medido em PROD,
+    // `Authorization: Bearer x` devolvia `{"versao":"v1.2-cluster-rpc"}`. A versão do bundle
+    // virava pública para quem tivesse a URL — semi-público por ACIDENTE, que é diferente de
+    // público por decisão.
+    //
+    // `authorizeCronOrStaff` resolve os dois lados: valida `x-cron-secret`, service role ou o
+    // JWT de verdade (via `fetch` em /auth/v1/user), sem `createClient` — então autentica sem
+    // violar a ordem que o gate de CI exige.
+    //
+    // Só roda quando `probe` VEM no corpo (`tipo !== "disparo"`): o caminho normal da edge não
+    // paga nada por esta checagem.
     const decisaoSonda = classificarSonda(corpoBruto);
-    if (decisaoSonda.tipo === "sonda") return jsonRes(respostaSonda(VERSAO), 200);
-    if (decisaoSonda.tipo === "ambiguo") {
+    if (decisaoSonda.tipo !== "disparo") {
+      const authSonda = await authorizeCronOrStaff(req);
+      if (!authSonda.ok) return authSonda.response;
+      if (decisaoSonda.tipo === "sonda") return jsonRes(respostaSonda(VERSAO), 200);
       return jsonRes({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }, 400);
     }
 

--- a/supabase/functions/recommend/versao.ts
+++ b/supabase/functions/recommend/versao.ts
@@ -31,7 +31,7 @@ export const respostaSonda = criarRespostaSonda("recommend");
  * e sem ela "a edge nova está no ar?" e "a função existe no banco?" seriam duas perguntas sem
  * resposta em vez de uma consulta e uma sonda.
  */
-export const VERSAO = "v1.2-cluster-rpc";
+export const VERSAO = "v1.3-sonda-com-gate";
 
 /** Efeito citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
## O que

A sonda de versão da `recommend` passa a exigir autorização de verdade
(`authorizeCronOrStaff`), em vez do `startsWith("Bearer ")` que sobrava.

## O defeito, medido em produção

O #1872 afirmava — errado — que "sondar exige token". Verificado no ar, logo após o deploy:

```
curl -H 'Authorization: Bearer x' -d '{"probe":true}' .../recommend
{"ok":true,"probe":true,"versao":"v1.2-cluster-rpc","edge":"recommend"}
```

`Bearer x` é um token **inválido**. A causa é estrutural, não descuido: o gate normal desta edge
é JWT, e `supabaseAuth.auth.getUser()` **precisa** do client — mas a sonda tem de responder
**antes** do `createClient` (o gate de CI exige, para não pagar o efeito da edge ao sondar).
Sobrava só o `startsWith("Bearer ")`, que qualquer string satisfaz. A versão do bundle era
pública para quem tivesse a URL: **semi-público por acidente**, que é diferente de público por
decisão.

## Por que `authorizeCronOrStaff` e não um secret novo

Eu ia propor `x-cron-secret` cru. O repo já tinha coisa melhor: `omie-cliente` e
`omie-nfe-webhook` gateiam a própria sonda com `authorizeCronOrStaff(req)`, que aceita
`x-cron-secret`, service role **ou** o JWT real — validado por `fetch` em `/auth/v1/user`,
**sem `createClient`**. Ou seja, autentica de verdade sem violar a ordem que o gate exige.
Nenhuma peça nova para vazar, rotacionar ou esquecer.

O gate só roda quando `probe` vem no corpo (`tipo !== "disparo"`): o caminho normal da edge não
paga nada.

## Prova

`recommend` entrou em `GATE_PROPRIO` no gate de contrato **antes** da implementação — RED exato:
`"recommend: a sonda responde sem gate próprio entre a classificação e a resposta"`. Falsificado
depois: remover o `authorizeCronOrStaff` derruba 2 casos.

`test:edges` 842/842 · `edges:typecheck` 0 erros de classe-crash · contrato 22/22.

`VERSAO` → **`v1.3-sonda-com-gate`**: o comportamento da sonda mudou, e distinguir isso é
exatamente o que a canária serve para fazer.

## Nota de processo

Este PR foi pedido como decisão conjunta com o Codex. **O Codex não participou** — segue
bloqueado (exit 78, modelo recusado pela conta; o mesmo diagnóstico que o #1860 passou a
reportar direito). A escolha entre "gatear" e "aceitar como público" foi minha, e o que a
desempatou não foi opinião: foi o precedente já existente no repo, que também trocou a minha
solução (secret novo) por uma melhor (helper existente). Vale `REVISÃO INDEPENDENTE PENDENTE`
junto com a do #1856.

## Deploy

⚠️ Edge = deploy manual pelo chat do Lovable. Depois de republicar, a sonda passa a exigir
header: `x-cron-secret` (ou service role) — pelo 🟣 SQL Editor via `net.http_post`, onde pôr o
header é trivial. Sondar sem credencial passa a devolver 401, que é o ponto.
