### PR TITLE
fix(recommend): a sonda estava depois do gate de Bearer — x-cron-secret nunca chegava ao helper (medido em prod)

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -340,6 +340,29 @@ Deno.test("gate próprio: onde o gate da edge não aceita cron-secret, a sonda N
   }
 });
 
+Deno.test("recommend: a sonda vem ANTES do gate de Bearer do handler", () => {
+  // Medido em prod (2026-08-22): `net.http_post` com `x-cron-secret` e SEM `Authorization`
+  // devolveu 401 {"error":"Não autorizado"} — a mensagem do HANDLER, não do helper. Causa: o
+  // `startsWith("Bearer ")` do handler estava ANTES da sonda, então o request morria ali e
+  // nunca alcançava `authorizeCronOrStaff` — justamente quem sabe validar `x-cron-secret`.
+  //
+  // O efeito é uma credencial que o gate ACEITA no papel e o fluxo REJEITA na prática: das três
+  // que o helper reconhece (cron secret, service role, JWT), só as que por acaso vêm em
+  // `Authorization: Bearer` chegam até ele. O caminho documentado (SQL Editor via
+  // net.http_post) é exatamente o que não passa.
+  const h = trechoDoHandler("recommend");
+  const posSonda = h.indexOf("classificarSonda(");
+  const posBearer = h.indexOf('startsWith("Bearer ")');
+  if (posSonda < 0 || posBearer < 0) {
+    throw new Error("recommend: âncoras não encontradas (controle positivo vazio)");
+  }
+  if (posSonda > posBearer) {
+    throw new Error(
+      "recommend: a sonda está DEPOIS do gate de Bearer — x-cron-secret nunca chega ao authorizeCronOrStaff",
+    );
+  }
+});
+
 Deno.test("CALIBRAÇÃO: os gates da terceira leva reprovam a forma errada", () => {
   // Sem isto os três acima só provariam que os arquivos existem (deploy.md: "canária que não
   // discrimina é teatro verde"). Cada padrão é exercitado contra a forma que ele existe para

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -440,20 +440,22 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const authHeader = req.headers.get("Authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return jsonRes({ error: "Não autorizado" }, 401);
-    }
-
     // ── Sonda de versão ────────────────────────────────────────────────────────────────
     // Responde ANTES do `createClient` e de qualquer leitura/escrita: o ponto da canária é
     // dizer QUAL bundle está no ar sem pagar o efeito da edge. Aqui o efeito é gravar
     // `recommendation_log` — o sensor de desfecho do motor (#1851) —, e uma linha inventada
     // por sondagem entraria no denominador de "a recomendação virou venda".
     //
-    // Depois do gate de `Bearer` e não antes: o gate desta edge é o padrão (JWT + staff), não
-    // o gate-próprio de `omie-cliente`/`omie-nfe-webhook`. Sondar continua exigindo um token,
-    // que é o que impede a canária de virar um oráculo público de versão.
+    // ANTES do gate de `Bearer ` do handler, e isto é o ponto (corrige o #1877): aquele gate
+    // exige `Authorization: Bearer …`, então um request com `x-cron-secret` e sem Authorization
+    // morria nele e NUNCA alcançava `authorizeCronOrStaff` — justamente quem sabe validar o
+    // cron secret. Medido em prod: `net.http_post` do SQL Editor com o secret devolveu 401
+    // {"error":"Não autorizado"} (mensagem do HANDLER). Das três credenciais que o helper
+    // aceita, só as que por acaso vinham em `Bearer` chegavam até ele — e o caminho
+    // DOCUMENTADO para sondar era exatamente o que não passava.
+    //
+    // A sonda não fica desprotegida: quem a gateia é o `authorizeCronOrStaff` logo abaixo, que
+    // é mais estrito que o `startsWith("Bearer ")` daqui (este aceita qualquer string).
     //
     // O corpo é lido AQUI (antes era só na linha do `switch`) porque a decisão depende dele.
     // JSON malformado passa a devolver 400 explícito em vez de cair no catch genérico — o
@@ -485,6 +487,11 @@ Deno.serve(async (req) => {
       if (!authSonda.ok) return authSonda.response;
       if (decisaoSonda.tipo === "sonda") return jsonRes(respostaSonda(VERSAO), 200);
       return jsonRes({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }, 400);
+    }
+
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return jsonRes({ error: "Não autorizado" }, 401);
     }
 
     const supabaseAdmin = createClient(

--- a/supabase/functions/recommend/versao.ts
+++ b/supabase/functions/recommend/versao.ts
@@ -31,7 +31,7 @@ export const respostaSonda = criarRespostaSonda("recommend");
  * e sem ela "a edge nova está no ar?" e "a função existe no banco?" seriam duas perguntas sem
  * resposta em vez de uma consulta e uma sonda.
  */
-export const VERSAO = "v1.3-sonda-com-gate";
+export const VERSAO = "v1.4-sonda-antes-do-gate";
 
 /** Efeito citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
## O defeito (meu, do #1877), medido em prod

O #1877 pôs o gate próprio na sonda, mas **depois** do `startsWith("Bearer ")` do handler. Um
request com `x-cron-secret` e sem `Authorization` morre nesse gate e **nunca alcança**
`authorizeCronOrStaff` — justamente quem sabe validar o cron secret.

Medido pelo founder no 🟣 SQL Editor, com `net.http_post` (resposta `id=58151`):

```
status_code = 401
content     = {"error":"Não autorizado"}    ← mensagem do HANDLER, não do helper
```

O efeito é uma credencial que o gate **aceita no papel e o fluxo rejeita na prática**: das três
que `authorizeCronOrStaff` reconhece (cron secret, service role, JWT), só as que por acaso vêm
em `Authorization: Bearer` chegam até ele. E o caminho que o #1877 **documentou** para sondar —
SQL Editor via `net.http_post` — é exatamente o que não passa.

Duas coisas erradas minhas na mesma instrução: a ordem no código, e a query sugerida
(`current_setting('app.cron_secret', true)`, que devolveria NULL e mandaria o header vazio de
qualquer jeito).

## O fix

A sonda passa a responder **antes** do gate de `Bearer` — que é como o `omie-cliente` sempre
fez, e que eu não segui até o fim no #1877.

Ela **não** fica desprotegida: quem a gateia é o `authorizeCronOrStaff` logo abaixo, que é mais
estrito que o `startsWith("Bearer ")` do handler — este aceita qualquer string, aquele valida
cron secret, service role ou o JWT de verdade.

## Prova

Teste primeiro, RED exato:
`"recommend: a sonda está DEPOIS do gate de Bearer — x-cron-secret nunca chega ao authorizeCronOrStaff"`.
Falsificado: mover a sonda de volta derruba 2 casos.

`test:edges` 843/843 · `edges:typecheck` 0 erros de classe-crash · contrato 23/23.

`VERSAO` → **`v1.4-sonda-antes-do-gate`**.

## Como sondar DEPOIS deste deploy (a instrução correta)

🟣 SQL Editor — o secret vem de `vault`/env do projeto, não de `current_setting`:

```sql
select net.http_post(
  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/recommend',
  headers := jsonb_build_object('Content-Type','application/json','x-cron-secret','<CRON_SECRET>'),
  body := jsonb_build_object('probe', true),
  timeout_milliseconds := 20000
);
-- depois: select status_code, content from net._http_response where id = <id devolvido>;
```

Esperado: `200` com `{"ok":true,"probe":true,"versao":"v1.4-sonda-antes-do-gate","edge":"recommend"}`.
Sem o header: `401`.

## Nota

`REVISÃO INDEPENDENTE PENDENTE` (Codex bloqueado — exit 78). Terceiro PR seguido nesta condição.
