### PR TITLE
docs(deploy): provar deploy por ASSINATURA DE GATE — a sonda fechou, e a técnica flagrou a troca de versão ao vivo

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -158,6 +158,54 @@ cliente, mesma página truncada), e diga o tamanho da amostra no veredito.
 tivesse feito backfill de `product_costs`. Foi a query (1) que eliminou isso: os UNKNOWN antigos
 **já tinham** custo no banco — o dado existia, a edge é que não alcançava.
 
+### Assinatura de GATE — quando a sonda EXISTE mas está FECHADA para você
+
+Quarto caminho, e o que resolve o impasse que a própria sonda criou: desde o #1877 ela exige
+credencial (`authorizeCronOrStaff`), então quem não tem JWT de staff **não consegue mais ler a
+versão** — o agente inclusive, que só tem `claude_ro` no banco e nenhuma credencial de edge. Mas
+**um gate que RECUSA também informa**: cada gate erra com a sua própria string, então a mensagem de
+recusa é uma assinatura de versão. Não precisa de credencial, nem de canária, e serve retroativo.
+
+**Como achar a assinatura.** Uma string de erro que a versão NOVA emite e a VELHA **não podia**
+emitir. Status HTTP não serve (401 é 401 nas duas) — tem de ser o CORPO.
+
+**Caso que a fundou (`recommend`, 2026-08-22, #1876 + #1877).** Quatro chamadas, zero credencial:
+
+| chamada | HTTP | corpo | quem respondeu |
+|---|---|---|---|
+| edge **inexistente** | 404 | `{"code":"NOT_FOUND"}` | **gateway** — prova que ele não valida JWT |
+| `recommend`, **sem** `Authorization` | 401 | `{"error":"Não autorizado"}` | gate do handler (pt-BR) |
+| `recommend`, `{}` + `Bearer x` | 401 | `{"error":"Token inválido"}` | gate do handler (pt-BR) |
+| `recommend`, `{"probe":true}` + `Bearer x` | 401 | `{"error":"Unauthorized"}` | `authorizeCronOrStaff` (en) |
+
+A quarta decide — mas **só depois de três descartes**:
+
+1. **o gateway não é a origem**: a chamada à edge inexistente voltou 404, logo ele roteia sem
+   validar JWT (se voltasse 401, nada abaixo valeria — a edge nem teria rodado);
+2. **a edge está executando**: as outras duas respostas são em português, dos gates internos dela;
+3. **a versão velha não podia emitir aquilo**: no bundle anterior `{"probe":true}` retornava
+   **200 + versão incondicionalmente**, e a string `"Unauthorized"` não existe em `index.ts` nenhum
+   (velho nem novo) — só pode vir de `_shared/auth.ts`, chamado no caminho da sonda **apenas a
+   partir do #1877**.
+
+⚠️ **Sem os três descartes isto é adivinhação.** Um 401 sozinho é compatível com "gateway barrou",
+"edge não existe" e "gate velho barrou". A conclusão vem do CONJUNTO de respostas DISTINTAS, não de
+uma. E confira a string velha com `git show <commit-velho>:<arquivo>`, nunca de memória — o ponto
+inteiro é provar que a versão anterior era incapaz daquela saída.
+
+⚠️ **Isto prova o BUNDLE, não o seu arquivo.** "Meu PR está no ar" é conclusão TRANSITIVA: o commit
+cuja assinatura você viu precisa ter o seu como ancestral **e** carregar o seu símbolo. Confirme os
+dois (`git merge-base --is-ancestor` e `git show <commit>:<arquivo>`), e confirme que ninguém tocou
+o arquivo entre eles — a reversão do Lovable (seção abaixo) é exatamente esse risco.
+
+⚠️ **A assinatura é POR VERSÃO — e é isso que a torna útil.** Horas depois da medição acima, o
+#1882 moveu a sonda para ANTES do gate de `Bearer ` do handler, e a MESMA chamada (`{"probe":true}`
+**sem** `Authorization`) passou de `{"error":"Não autorizado"}` (v1.3) para `{"error":"Unauthorized"}`
+(v1.4). Foi exatamente assim que o deploy do #1882 se provou: **a técnica flagrou a troca de versão
+ao vivo**, sem credencial e sem ninguém avisar. A consequência prática, porém, é que a tabela acima
+descreve o `v1.3` e não uma constante do sistema — levante a SUA assinatura com
+`git show <commit>:<arquivo>` a cada uso, nunca copie a tabela.
+
 ## Quando o Lovable reverte um fix — detectar e restaurar
 
 O bot `gpt-engineer-app[bot]` commita direto na `main` SEM CI ("Changes"/"Deployed"/"Deployou edge") e às vezes reverte um PR (~16% dos commits; ≥4-5 reversões money-path recentes). Prevenção é inviável (o bot precisa de escrita direta) → o jogo é **detectar + restaurar rápido** (MTTR), não governança perfeita. Spec: `docs/superpowers/specs/2026-06-26-lovable-revert-mitigation-design.md`.

--- a/docs/historico/recommend-teto-linhas-cluster.md
+++ b/docs/historico/recommend-teto-linhas-cluster.md
@@ -108,6 +108,39 @@ evidência positiva com denominador que `docs/historico/fase-sem-sinal.md` exige
 - **Edge:** 38 testes em `recommend-leituras_test.ts` (`test:edges` 825/825), com 4 falsificações
   próprias conferindo dente.
 
+## Pós-deploy — o que ficou PROVADO e o que não (2026-08-22)
+
+**Migration:** aplicada e revalidada em prod por DEFINIÇÃO — ACL `anon=f authenticated=f
+service_role=t`, `SECURITY INVOKER`, `search_path` fixo, 8/8 invariantes em `pg_get_functiondef`.
+⚠️ Ela **não pode ser executada** pelo `claude_ro`: o próprio REVOKE que a protege bloqueia a role
+de diagnóstico. Esta função só se valida por definição — prova de execução exige passar pela edge.
+
+**Edge:** provada no ar por **assinatura de gate**, técnica registrada em
+[deploy.md](../agent/deploy.md). O bundle servido passou por #1877 (v1.3) e, horas
+depois, #1882 (v1.4) — ambos com este PR como ancestral e ambos carregando a RPC (`git merge-base --is-ancestor` + `git show <commit>:<arquivo>`, e nenhum commit
+tocou `recommend-leituras.ts` entre os dois).
+
+**Antes/depois reproduzido em prod** (`db/recommend-cluster-rpc-antes-depois.sql`, `EXIT=0`): bate
+com o medido no PR dentro de ±1 cliente — banco vivo. Os 5 e 2 clientes zerados em
+`atencao`/`estavel` seguiam lá até o deploy.
+
+⚠️ **O efeito no ranking está medido OFFLINE, não observado.** A query reproduz a lógica da RPC
+contra os dados reais; ela não é a edge rodando. Desde o merge do #1877 (2026-08-22 18:33Z),
+`recommendation_log` tem **0 impressões** — a última execução do motor, de qualquer tipo, é de
+**2026-08-21 23:52:48** local, anterior à entrega. Zero impressão é ausência de dado, não
+aprovação: pela regra de `fase-sem-sinal.md` esta entrega **ainda não tem sinal de uso próprio**, e
+quem julga é:
+
+```sql
+SELECT recommendation_type, count(*) FROM recommendation_log
+WHERE created_at >= '2026-08-22T18:33:16Z' GROUP BY 1;
+```
+
+O que esperar quando alguém usar a tela: `cluster_based` sumindo de `critico` (nenhum produto cruza
+0,10 com n=780) e acendendo em `estavel` (62 produtos cruzam 0,15, contra 1 antes). Se ele passar a
+DOMINAR o mix contra `cross_sell`, é consequência esperada de destampar sinal real — e é o gatilho
+para a decisão de produto sobre os cortes, que segue aberta abaixo.
+
 ## ⚠️ REVISÃO INDEPENDENTE PENDENTE
 
 O ritual `/codex` não pôde rodar: a conta recusa **todos** os modelos com HTTP 400


### PR DESCRIPTION
## O problema que isto resolve

O #1877 fechou a sonda de versão com `authorizeCronOrStaff`. Correto — ela era um oráculo público de versão. Mas o efeito colateral é que **quem não tem JWT de staff perdeu a única prova de deploy disponível**, e isso inclui o agente: só tem `claude_ro` no banco e nenhuma credencial de edge. Sem sonda legível, "está no ar?" volta a ser opinião.

## A técnica

**Um gate que RECUSA também informa.** Cada gate erra com a sua própria string, então a mensagem de recusa é uma assinatura de versão — sem credencial, sem canária, e retroativa.

Quatro chamadas à `recommend` em prod, zero credencial:

| chamada | HTTP | corpo | quem respondeu |
|---|---|---|---|
| edge **inexistente** | 404 | `{"code":"NOT_FOUND"}` | gateway — prova que ele não valida JWT |
| sem `Authorization` | 401 | `{"error":"Não autorizado"}` | gate do handler (pt-BR) |
| `{}` + `Bearer x` | 401 | `{"error":"Token inválido"}` | gate do handler (pt-BR) |
| `{"probe":true}` + `Bearer x` | 401 | `{"error":"Unauthorized"}` | `authorizeCronOrStaff` (en) |

A quarta decide, **mas só depois de três descartes** — sem eles é adivinhação, porque um 401 sozinho é compatível com "gateway barrou", "edge não existe" e "gate velho barrou".

## A técnica se provou sozinha, ao vivo

Horas depois, o #1882 moveu a sonda para antes do gate de `Bearer `. A **mesma** chamada passou de `{"error":"Não autorizado"}` (v1.3) para `{"error":"Unauthorized"}` (v1.4) — **o deploy do #1882 foi flagrado ao vivo, sem credencial e sem ninguém avisar.**

Daí o aviso que ficou registrado: a assinatura é POR VERSÃO. Levante a sua com `git show <commit>:<arquivo>`; não copie a tabela.

## O que o histórico ganha

Pós-deploy do #1876, incluindo o que **não** ficou provado:

- migration revalidada por DEFINIÇÃO (ACL, `SECURITY INVOKER`, 8/8 invariantes) — ⚠️ ela **não pode ser executada** pelo `claude_ro`: o próprio REVOKE que a protege bloqueia a role de diagnóstico;
- antes/depois reproduzido em prod, `EXIT=0`, batendo com o PR dentro de ±1 cliente;
- ⚠️ **o efeito no ranking está medido OFFLINE, não observado** — desde o deploy o `recommendation_log` tem **0 impressões**, e zero impressão é ausência de dado, não aprovação. A query que julga ficou escrita no doc.

## Verificação

- `docs:links` **EXIT=0** — e **falsificado**: sabotei o link novo, o gate reprovou apontando a linha exata (`recommend-teto-linhas-cluster.md:119`), restaurei, voltou a 0;
- `docs:citacoes` EXIT=0 · `docs:indice` EXIT=0 · `claude:size` EXIT=0;
- só `.md` — nenhum código tocado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)