### PR TITLE
chore(claude-md): fase 1 decide NÃO MOVER — a medição não tem controle, e o sensor fabricava um 0

### DIFF
--- a/.claude/hooks/instrucoes-carregadas.sh
+++ b/.claude/hooks/instrucoes-carregadas.sh
@@ -40,7 +40,15 @@ if ! printf '%s' "$entrada" | jq -c --arg ts "$ts" '{
       ts: $ts,
       motivo: (.load_reason // "?"),
       arquivo: (.file_path // "?"),
-      chars: ((.file_content // "") | length),
+      # ausente ≠ zero: `(.file_content // "") | length` gravava 0 quando o payload
+      # NÃO traz o campo — ausência de dado virando a MEDIDA 0 (a mesma fabricação
+      # que `Number(null)===0` é no money-path). null diz "não sei"; 0 mentiria.
+      chars: (if has("file_content") then (.file_content|length) else null end),
+      # o payload real é o contrato — `campos` PARA de adivinhar qual chave existe:
+      # foi assim que descobrimos que `file_content` nunca vem. Serve também para
+      # saber se `agent_type` estava AUSENTE (⇒ o "principal" abaixo é default, não
+      # observação) no dia em que um subagente finalmente aparecer.
+      campos: (keys|join(",")),
       agente: (.agent_type // "principal"),
       agent_id: (.agent_id // null),
       sessao: (.session_id // "?"),

--- a/docs/historico/split-claude-md-sensor.md
+++ b/docs/historico/split-claude-md-sensor.md
@@ -89,5 +89,70 @@ Rode `bun run claude:instr` depois de alguns dias de uso real e olhe a seção 1
 
 ## Estado
 
-Fase 0 (sensor) instalada. Fase 1 (mover as 413 palavras) **bloqueada até haver medição** —
-deliberadamente. Zero regra movida até agora.
+**Fase 1 (2026-08-22, ~1h depois): decisão = NÃO MOVER NADA. Zero das 413 palavras.**
+Não porque a medição reprovou — porque **a medição não tem controle ainda**.
+
+### O que o `claude:instr` mostrou
+
+7 eventos, 0 erro de sensor, **7/7 `session_start` · 7/7 `principal`**. Janela real:
+19:40→20:36 UTC do mesmo dia — **56 minutos**, não os "alguns dias de uso real" que a
+própria fase 0 prescreveu.
+
+As três perguntas, e o que a coleta responde:
+
+| # | Pergunta | Resposta |
+|---|---|---|
+| 1 | regra `paths:` chega no subagente? | **sem dado** — 0 evento de subagente |
+| 2 | o que sobrevive ao `/compact`? | **sem dado** — 0 evento `compact` |
+| 3 | peso de cada arquivo | **sem dado** — era 0 fabricado (abaixo) |
+
+### Por que "0 subagente" NÃO é a resposta negativa
+
+A fase 0 previa `CLAUDE.md ⟵ <algum agent_type>` como **linha de base**. Ela não apareceu.
+Isso tem duas leituras opostas — (a) o carregamento não alcança subagente · (b) nenhum
+subagente rodou — e confundi-las inverteria a decisão. **É (b), verificado nas transcrições:**
+nenhuma das 7 sessões medidas tem diretório `<sessao>/subagents/`. A sonda foi falsificada
+antes de valer (57 transcrições do mesmo `~/.claude/projects` **têm** `isSidechain` ⇒ o padrão
+casa quando existe o caso) — e a 1ª versão dela procurava no arquivo errado, porque subagente
+mora em diretório próprio, não no `.jsonl` da sessão.
+
+⇒ **Criar a `.claude/rules/*.md` de teste agora seria um experimento SEM CONTROLE:** um
+negativo ali seria indistinguível de "o sensor nunca observa subagente". O gate da fase 2 é
+por isso um sinal **positivo**, não um calendário.
+
+### O sensor fabricava um número (corrigido nesta fase)
+
+`chars: 0` em **todos** os 7 eventos. Falsificado alimentando o hook com payload sintético:
+com `file_content` → `chars: 5`; sem → `chars: 0`. O hook está certo; **o payload do
+`InstructionsLoaded` não traz `file_content`**, e o `// ""` transformava ausência na medida 0 —
+a mesma fabricação que `Number(null)===0` é no money-path, dentro do instrumento que existe
+para decidir. Agora: `null` (renderizado `n/d`), e o hook grava **`campos`** = a lista de chaves
+do payload, para o contrato parar de ser adivinhado.
+
+O mesmo defeito de classe segue latente em `agente: (.agent_type // "principal")` — subagente
+cujo payload omitisse `agent_type` seria rotulado "principal" e responderia a pergunta 1
+**errado e calado**. Com `campos` no log isso passa a ser detectável.
+
+E o relatório passou a imprimir o **denominador** (`N sessões · N eventos de subagente`) com
+aviso explícito quando é zero: sem denominador, a seção 1 lê-se como resposta negativa. Regra
+da casa aplicada ao próprio instrumento — *"exija ≥1 sinal POSITIVO com denominador"*.
+
+### Gate da fase 2 (positivo, não calendário)
+
+Rode `bun run claude:instr`; só destrave quando **ambos** aparecerem:
+
+1. **≥1 linha na seção 1 com um `agent_type`** — prova que o sensor ENXERGA subagente. Só
+   então criar a 1ª `.claude/rules/*.md` com `paths:` e reler: se ELA nunca aparecer com
+   `agent_type`, aí sim é resposta negativa ⇒ não mover convenção de frontend.
+2. **≥1 evento `motivo: compact`** — responde a pergunta 2.
+
+### A inclinação, agora MEDIDA
+
+De quebra, a tese do "nível × inclinação" saiu do argumento e virou número: `CLAUDE.md` em
+**2.306 palavras no merge do #1879** e **2.337 quatro horas / quatro PRs depois** (#1880-#1883)
+— **+31 palavras**, sem ninguém pretender engordá-lo. No mesmo ritmo, os 294 de folga que a
+compactação comprou duram ~38 PRs. O teto por seção continua sendo a correção de CLASSE;
+mover as 413 palavras compraria nível de novo, não inclinação — mais um motivo para não
+apressar a fase 2 e gastar o esforço no ratchet por seção.
+
+Enquanto isso: núcleo em 2.337 palavras, zero regra movida, zero regra fail-open tocada.

--- a/scripts/instrucoes-relatorio.sh
+++ b/scripts/instrucoes-relatorio.sh
@@ -32,6 +32,10 @@ secao() {
   fi
 }
 
+# Métrica escalar é SEMPRE `if ! var=$(jq ...)`, nunca um helper que atribui por
+# indireção: ali o `if !` testaria o printf (que passa) e não o jq (que quebrou),
+# e a métrica viraria string vazia com falhou=0 — o exit engolido de sempre.
+
 total=$(wc -l <"$LOG" | tr -d ' ')
 erros=$(jq -rs '[.[]|select(.erro)]|length' "$LOG" 2>/dev/null || echo '?')
 echo "📊 $total evento(s) · $erros com erro de sensor"
@@ -45,6 +49,24 @@ secao '[.[]|select(.erro|not)]
   | map({k: ((.[0].arquivo|split("/")|.[-2:]|join("/")) + "  ⟵ " + .[0].agente), n: length})
   | sort_by(-.n)[] | "  \(.n)×  \(.k)"'
 
+# O DENOMINADOR é a resposta. "0 linha de subagente" tem DUAS leituras opostas —
+# (a) regra não alcança subagente · (b) nenhum subagente rodou na janela medida —
+# e só o nº de sessões/subagentes observados separa uma da outra. Sem isto o
+# relatório deixa ausência de CASO passar por resultado NEGATIVO.
+if ! sessoes=$(jq -rs '[.[]|select(.erro|not)|.sessao]|unique|length' "$LOG"); then
+  sessoes='?'; falhou=1
+fi
+if ! subagentes=$(jq -rs '[.[]|select(.erro|not)|select(.agente!="principal")]|length' "$LOG"); then
+  subagentes='?'; falhou=1
+fi
+echo "  ── denominador: $sessoes sessão(ões) · $subagentes evento(s) de subagente"
+if [ "$subagentes" = "0" ]; then
+  echo "  ⚠️  ZERO evento de subagente ⇒ ausência de CASO, NÃO resposta negativa."
+  echo "     A pergunta 'regra path-scoped alcança subagente?' segue SEM controle:"
+  echo "     antes de crer num teste que dá negativo, exija ≥1 linha aqui com"
+  echo "     agent_type — é ela que prova que o sensor ENXERGA subagente."
+fi
+
 echo
 echo "── 2) por motivo de carga ────────────────────────────────────"
 secao '[.[]|select(.erro|not)] | group_by(.motivo)
@@ -52,8 +74,17 @@ secao '[.[]|select(.erro|not)] | group_by(.motivo)
 
 echo
 echo "── 3) peso por arquivo (chars, último visto) ─────────────────"
+# `-.c` com c=null EXPLODE no jq; e imprimir null como 0 repetiria a fabricação
+# que o hook acabou de parar de fazer. n/d = o payload não trouxe file_content.
 secao '[.[]|select(.erro|not)] | group_by(.arquivo)
   | map({k: (.[0].arquivo|split("/")|.[-2:]|join("/")), c: (.[-1].chars)})
-  | sort_by(-.c)[] | "  \(.c)  \(.k)"'
+  | sort_by(-(.c // -1))[] | "  \(.c // "n/d")  \(.k)"'
+if ! medidos=$(jq -rs '[.[]|select(.erro|not)|select(.chars != null)]|length' "$LOG"); then
+  medidos='?'; falhou=1
+fi
+if [ "$medidos" = "0" ]; then
+  echo "  ⚠️  nenhum evento traz \`file_content\` — peso é n/d (não é 0)."
+  echo "     Confira \`campos\` no log para o contrato real do payload."
+fi
 
 exit "$falhou"


### PR DESCRIPTION
Fase 1 do split do CLAUDE.md (fase 0 = sensor, #1879). **Decisão: zero das 413 palavras movidas** — não porque a medição reprovou, mas porque ela **ainda não tem controle**.

## O que o sensor mostrou

`bun run claude:instr`: **7 eventos · 0 erro · 7/7 `session_start` · 7/7 `principal`**, numa janela de **56 minutos** (19:40→20:36 UTC), não os "alguns dias de uso real" que a própria fase 0 prescreveu.

| # | Pergunta | Resposta |
|---|---|---|
| 1 | regra `paths:` chega no subagente? | **sem dado** — 0 evento de subagente |
| 2 | o que sobrevive ao `/compact`? | **sem dado** — 0 evento `compact` |
| 3 | peso por arquivo | **sem dado** — era 0 fabricado |

## O ponto que decide

"0 linha de subagente" tem **duas leituras opostas** — (a) não alcança · (b) nunca houve o caso — e confundi-las inverteria a decisão. **É (b)**, verificado nas transcrições: nenhuma das 7 sessões medidas tem `<sessao>/subagents/`. A sonda foi **falsificada antes de valer** (57 transcrições do mesmo `~/.claude/projects` **têm** `isSidechain` ⇒ o padrão casa quando existe o caso), e a 1ª versão dela olhava o arquivo errado — subagente mora em diretório próprio.

⇒ Criar a `.claude/rules/*.md` de teste agora seria **experimento sem controle**: um negativo seria indistinguível de "o sensor nunca observa subagente".

## Dois defeitos do sensor, corrigidos

- **`chars: 0` em todos os 7 eventos.** Falsificado com payload sintético: com `file_content` → `5`; sem → `0`. O hook está certo — **o payload do `InstructionsLoaded` não traz o campo**, e o `// ""` transformava ausência na medida 0: a fabricação do `Number(null)===0`, dentro do instrumento que existe para decidir. Agora `null` (renderiza `n/d`) + **`campos`** = lista de chaves do payload, para o contrato parar de ser adivinhado. O mesmo default cego segue latente em `agent_type // "principal"` — agora **detectável**.
- **O relatório não imprimia denominador**, então a seção 1 lia-se como resposta negativa. Agora imprime `N sessões · N eventos de subagente` e avisa explicitamente quando é zero.

## Gate da fase 2 — positivo, não calendário

1. **≥1 linha na seção 1 com `agent_type`** (prova que o sensor ENXERGA subagente) — só então criar a regra `paths:` de teste;
2. **≥1 evento `motivo: compact`**.

## De quebra: a inclinação virou número

`CLAUDE.md` em **2.306** palavras no merge do #1879 → **2.337** quatro PRs depois (#1880-#1883). **+31 sem ninguém querer engordá-lo**; no mesmo ritmo, os 294 de folga que a compactação comprou duram **~38 PRs**. O teto **por seção** segue sendo a correção de classe — mover as 413 compraria nível, não inclinação.

## Verificação

- `shellcheck scripts/*.sh .claude/hooks/*.sh` → exit 0
- `docs:citacoes` / `docs:links` / `docs:indice` → exit 0
- `claude:size` → dentro do teto (2.337/2.600)
- **falsificação:** filtro jq sabotado ⇒ relatório sai **exit 1** (falha ALTO, não seção vazia); aviso de denominador **desliga** com log sintético contendo subagente; caminho `n/d` exercitado com `chars:null`
- `CLAUDE.md` **intocado** (`git diff HEAD -- CLAUDE.md` vazio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)