### PR TITLE
fix(paginação): página curta não é fim de tabela — desacopla os helpers do max-rows do PostgREST

### DIFF
--- a/docs/historico/paginacao-offset-janela.md
+++ b/docs/historico/paginacao-offset-janela.md
@@ -110,8 +110,18 @@ saídas, na ordem em que valem a pena:
    já carrega `count`, mas o `build` de hoje não tem por onde pedi-lo: exigiria mexer na
    assinatura dos 21 call-sites, que é exatamente o que a medição desaconselhou.
 
-A (1) compra quase todo o valor por quase nenhum custo; a (2) só se paga se o `max-rows`
-passar a ser configurável por alguém de fora do time.
+**ERRATA (2026-08-22, ao implementar): a saída (1) estava errada.** `PAGE = 900` protege só
+contra caps entre 900 e 999 — com `max-rows` em 500, `500 < 900` continua sendo lido como EOF e
+a leitura trunca igual. E paga +11% de requisições em TODA leitura, não uma por laço.
+
+O que foi feito é uma terceira saída, que nenhuma das duas anteriores enxergava: **EOF por
+página VAZIA + avanço pelo número REAL de linhas devolvidas** (`from += rows.length`, não
+`from += PAGE`). As duas metades são necessárias — só trocar o critério de parada ainda pularia
+linhas, porque o offset avançaria 1.000 sobre um servidor que devolveu 500.
+
+Isso vale para QUALQUER cap, sem `count:'exact'` e sem mexer nos 21 call-sites. Custo: uma
+requisição a mais por leitura, a que volta vazia. O fim da tabela deixa de ser uma inferência a
+partir de um número que o servidor escolhe, e passa a ser um fato observado.
 
 ## ⚠️ REVISÃO INDEPENDENTE PENDENTE
 

--- a/supabase/functions/_shared/mapas-paginados_test.ts
+++ b/supabase/functions/_shared/mapas-paginados_test.ts
@@ -227,7 +227,7 @@ Deno.test("ownerMap: atravessa o cap de 1000 (não trunca a carteira)", async ()
   const mapa = await carregarOwnerMap(db);
   assertEquals(mapa.size, 2500);
   assertEquals(mapa.get("c2499"), "o2499");
-  assertEquals(registros.length, 3); // 1000 + 1000 + 500
+  assertEquals(registros.length, 4); // 1000 + 1000 + 500 + a vazia que confirma o fim
 });
 
 Deno.test("ownerMap: TODA página pede .order() estável na chave", async () => {
@@ -236,7 +236,7 @@ Deno.test("ownerMap: TODA página pede .order() estável na chave", async () => 
   // Sem .order() o Postgres não garante a mesma sequência entre requests: a página 2
   // pode repetir linha da 1 e PULAR outra — cliente somindo da carteira em silêncio.
   // customer_user_id é UNIQUE em prod (carteira_assignments_customer_user_id_key).
-  assertEquals(registros.length, 3);
+  assertEquals(registros.length, 4);
   for (const reg of registros) {
     assertEquals(reg.order, "customer_user_id", "página paginada sem .order() estável");
   }

--- a/supabase/functions/_shared/paginate-cap_test.ts
+++ b/supabase/functions/_shared/paginate-cap_test.ts
@@ -1,0 +1,67 @@
+// O acoplamento PAGE ↔ max-rows do PostgREST, nos DOIS helpers.
+//
+// `PAGE` é 1000 e o `max-rows` medido em prod é 1000 — o laço pede exatamente o cap e funciona
+// por coincidência numérica, que nada vigia. Se o cap baixasse, "página curta" deixaria de
+// significar "acabou" e as leituras truncariam EM SILÊNCIO: a classe do #1836, por outra porta.
+//
+// A saída registrada antes em docs/historico/paginacao-offset-janela.md era baixar PAGE para 900.
+// Ela é fraca: protege só contra caps entre 900 e 999 (com cap 500, `500 < 900` continua sendo
+// lido como EOF) e ainda paga +11% de requests em TODA leitura. Estes testes exigem a robusta —
+// EOF por página VAZIA e avanço pelo número REAL de linhas devolvidas —, que vale para qualquer cap.
+import { fetchAll, fetchAllKeyset } from "./paginate.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(msg ?? `assertEquals falhou: ${JSON.stringify(a)} !== ${JSON.stringify(b)}`);
+  }
+}
+
+const TOTAL = 2300;
+const CAP_DO_SERVIDOR = 500; // menor que PAGE (1000), que é o cenário não vigiado
+
+Deno.test("fetchAll: servidor com max-rows MENOR que PAGE devolve a tabela INTEIRA", () => {
+  const todas = Array.from({ length: TOTAL }, (_, i) => ({ id: i }));
+  let calls = 0;
+  const build = (from: number, to: number) => {
+    calls++;
+    if (calls > 40) throw new Error("laço não converge");
+    // O PostgREST honra o range MAS trunca em max-rows: devolve no máximo CAP linhas.
+    const janela = todas.slice(from, to + 1).slice(0, CAP_DO_SERVIDOR);
+    return Promise.resolve({ data: janela, error: null });
+  };
+  return fetchAll<{ id: number }>(build, "t").then((rows) => {
+    const vistos = new Set(rows.map((r) => r.id));
+    assertEquals(vistos.size, TOTAL, "a tabela inteira tem de voltar, mesmo com o cap menor");
+    assertEquals(rows.length, TOTAL, "sem duplicata");
+  });
+});
+
+Deno.test("fetchAllKeyset: mesmo cap menor, mesma exigência", () => {
+  const todas = Array.from({ length: TOTAL }, (_, i) => ({ id: i }));
+  let calls = 0;
+  const build = (cursor: number | null, limite: number) => {
+    calls++;
+    if (calls > 40) throw new Error("laço não converge");
+    const janela = todas.filter((l) => cursor === null || l.id > cursor)
+      .slice(0, limite).slice(0, CAP_DO_SERVIDOR);
+    return Promise.resolve({ data: janela, error: null });
+  };
+  return fetchAllKeyset<{ id: number }, number>(build, (l) => l.id, "t").then((rows) => {
+    const vistos = new Set(rows.map((r) => r.id));
+    assertEquals(vistos.size, TOTAL, "a tabela inteira tem de voltar sob cap menor");
+    assertEquals(rows.length, TOTAL, "sem duplicata");
+  });
+});
+
+Deno.test("fetchAll: tabela VAZIA continua terminando em 1 request", () => {
+  // O critério novo é "página vazia", então o caso vazio não pode virar laço.
+  let calls = 0;
+  const build = () => {
+    calls++;
+    return Promise.resolve({ data: [] as Array<{ id: number }>, error: null });
+  };
+  return fetchAll<{ id: number }>(build, "t").then((rows) => {
+    assertEquals(rows.length, 0);
+    assertEquals(calls, 1);
+  });
+});

--- a/supabase/functions/_shared/paginate-keyset_test.ts
+++ b/supabase/functions/_shared/paginate-keyset_test.ts
@@ -96,7 +96,10 @@ Deno.test("keyset: abaixo do cap, 1 request", async () => {
   const t = fakeKeyset(() => dados);
   const rows = await fetchAllKeyset<{ id: number }, number>(t.build, (l) => l.id, "t");
   assertEquals(rows.length, 292);
-  assertEquals(t.calls(), 1);
+  // +1 request em relação ao contrato antigo: o EOF passou a ser página VAZIA (antes era
+  // página curta), para desacoplar o helper do `max-rows` do PostgREST. A requisição extra
+  // é o preço de o fim da tabela ser um fato OBSERVADO.
+  assertEquals(t.calls(), 2);
 });
 
 Deno.test("keyset: acima do cap, devolve a cauda inteira em 3 requests", async () => {
@@ -105,7 +108,7 @@ Deno.test("keyset: acima do cap, devolve a cauda inteira em 3 requests", async (
   const rows = await fetchAllKeyset<{ id: number }, number>(t.build, (l) => l.id, "t");
   assertEquals(rows.length, 2300);
   assertEquals(rows[2299].id, 2299);
-  assertEquals(t.calls(), 3);
+  assertEquals(t.calls(), 4); // + a vazia que confirma o fim
 });
 
 Deno.test("keyset: exatamente no cap, 1 request extra vazio, sem duplicar", async () => {

--- a/supabase/functions/_shared/paginate.ts
+++ b/supabase/functions/_shared/paginate.ts
@@ -153,8 +153,24 @@ export async function fetchAll<T>(
     if (!Array.isArray(data)) throw new FalhaLeituraCritica(label, { code: 'MALFORMADA' });
     const rows = data;
     out.push(...rows);
-    if (rows.length < PAGE) break;
-    from += PAGE;
+    // EOF é página VAZIA, não página CURTA; e o offset avança pelo que de fato VEIO, não pelo
+    // que foi PEDIDO. Os dois juntos desacoplam o helper do `max-rows` do PostgREST.
+    //
+    // Antes: `PAGE` (1000) era igual ao `max-rows` medido em prod (1000), então pedir o cap
+    // inteiro funcionava — por coincidência numérica que nada vigiava. Se o cap baixasse para
+    // 500, a 1ª página viria com 500 linhas, `500 < 1000` seria lido como "acabou" e a leitura
+    // truncaria EM SILÊNCIO: a classe do #1836 por outra porta. E avançar `from += PAGE` sobre
+    // um servidor que devolveu menos PULARIA a diferença — 500 linhas invisíveis por página.
+    //
+    // Custo: uma requisição a mais por leitura (a que volta vazia). É o preço de o EOF passar a
+    // ser um FATO observado em vez de uma inferência a partir de um número que o servidor
+    // escolhe e pode mudar sem avisar.
+    //
+    // Descartada a alternativa registrada antes (baixar `PAGE` para 900): protege só contra caps
+    // entre 900 e 999 — com cap 500 o `500 < 900` continua sendo EOF falso — e paga +11% de
+    // requisições em TODA leitura, não só uma por laço.
+    if (rows.length === 0) break;
+    from += rows.length;
   }
   return out;
 }
@@ -264,7 +280,10 @@ export async function fetchAllKeyset<T, K extends string | number>(
       anterior = k;
     }
     out.push(...rows);
-    if (rows.length < PAGE) break;
+    // Mesma razão do `fetchAll`: página CURTA não é fim, é o `max-rows` podendo ser menor que
+    // `PAGE`. Aqui não há offset a corrigir — o cursor já avança pela última linha REAL —, mas o
+    // critério de parada tinha o mesmo acoplamento.
+    if (rows.length === 0) break;
     const proximo = chave(rows[rows.length - 1]);
     // O cursor tem de avançar ESTRITAMENTE. Os dois modos de violar o contrato falham aqui,
     // e nenhum dos dois se denuncia sozinho:

--- a/supabase/functions/_shared/paginate_test.ts
+++ b/supabase/functions/_shared/paginate_test.ts
@@ -48,7 +48,10 @@ Deno.test("abaixo do cap: retorna tudo em 1 request (estado real hoje: 292 linha
   const t = fakeTable(292);
   const rows = await fetchAll<{ id: number }>(t.build, "t");
   assertEquals(rows.length, 292);
-  assertEquals(t.calls(), 1);
+  // +1 request em relação ao contrato antigo: o EOF passou a ser página VAZIA (antes era
+  // página curta), para desacoplar o helper do `max-rows` do PostgREST. A requisição extra
+  // é o preço de o fim da tabela ser um fato OBSERVADO.
+  assertEquals(t.calls(), 2);
 });
 
 Deno.test("ACIMA do cap (o bug): retorna a cauda inteira, não trunca em 1000", async () => {
@@ -56,7 +59,7 @@ Deno.test("ACIMA do cap (o bug): retorna a cauda inteira, não trunca em 1000", 
   const rows = await fetchAll<{ id: number }>(t.build, "t");
   assertEquals(rows.length, 2300); // sem paginação, o PostgREST devolveria só 1000
   assertEquals((rows[2299] as { id: number }).id, 2299);
-  assertEquals(t.calls(), 3); // 1000 + 1000 + 300
+  assertEquals(t.calls(), 4); // 1000 + 1000 + 300 + a vazia que confirma o fim
 });
 
 Deno.test("exatamente no cap: 1 request extra vazio, sem perder nem duplicar", async () => {
@@ -70,7 +73,7 @@ Deno.test("dois caps cheios + resto: 2001 linhas em 3 requests", async () => {
   const t = fakeTable(2001);
   const rows = await fetchAll<{ id: number }>(t.build, "t");
   assertEquals(rows.length, 2001);
-  assertEquals(t.calls(), 3);
+  assertEquals(t.calls(), 4); // + a vazia que confirma o fim
 });
 
 Deno.test("tabela vazia: 1 request, zero linhas", async () => {
@@ -320,5 +323,5 @@ Deno.test("keyset — o caminho FELIZ continua igual: pagina a cauda inteira em 
     "k_feliz",
   );
   assertEquals(linhas.length, 2300);
-  assertEquals(chamadas, 3);
+  assertEquals(chamadas, 4); // + a vazia que confirma o fim (EOF desacoplado do max-rows)
 });

--- a/supabase/functions/_shared/relatorio-mensal_test.ts
+++ b/supabase/functions/_shared/relatorio-mensal_test.ts
@@ -294,7 +294,10 @@ Deno.test("custo de banco NÃO cresce com o número de ferramentas (sem 2 counts
 
   const emEventos = f.idasA("tool_events");
   assert(
-    emEventos <= 3,
+    // Teto 4 (era 3): o EOF virou página VAZIA para desacoplar do `max-rows`, o que soma UMA
+    // requisição por leitura — fixa, não por ferramenta. O invariante que este teste protege
+    // (custo não cresce com o nº de ferramentas) segue intacto: com N+1 seriam 600.
+    emEventos <= 4,
     `contagem de eventos deveria ser agregada, mas foram ${emEventos} consultas a tool_events ` +
       `(o N+1 fazia 2 por ferramenta = 600)`,
   );


### PR DESCRIPTION
## O que

`fetchAll` e `fetchAllKeyset` deixam de tratar **página curta** como fim da tabela. O EOF passa
a ser **página vazia**, e o offset avança pelo número **real** de linhas devolvidas.

## O acoplamento

`PAGE` é 1.000 e o `max-rows` do PostgREST em prod é 1.000 — o laço pedia exatamente o cap e
funcionava por **coincidência numérica**, que nada vigiava. Se o cap baixasse para 500, a 1ª
página viria com 500 linhas, `500 < 1000` seria lido como "acabou", e toda leitura truncaria em
silêncio: a classe do #1836 por outra porta.

E havia a segunda metade, que só apareceu ao escrever o teste: mesmo corrigindo o critério de
parada, `from += PAGE` sobre um servidor que devolveu 500 **pularia** 500 linhas por página. As
duas correções são necessárias; nenhuma sozinha resolve.

## Errata: a saída que eu tinha escolhido estava errada

O doc registrava baixar `PAGE` para 900 como "compra quase todo o valor por quase nenhum custo".
**Não compra.** Protege só contra caps entre 900 e 999 — com cap 500, `500 < 900` continua sendo
EOF falso — e paga +11% de requisições em toda leitura.

A saída implementada não estava em nenhuma das duas alternativas analisadas antes: vale para
**qualquer** cap, não precisa de `count:'exact'` e não toca os 21 call-sites. Custo: **uma**
requisição a mais por leitura (a que volta vazia). O fim da tabela deixa de ser inferência sobre
um número que o servidor escolhe e passa a ser fato observado.

## Prova

Teste primeiro, com um servidor fake que capa em 500 (metade de `PAGE`): os dois helpers
falharam devolvendo dado parcial. Falsificado depois: restaurar `rows.length < PAGE` derruba o
caso.

`test:edges` **846/846** · `edges:typecheck` 0 erros de classe-crash.

## Os 6 testes que mudaram de número (e por quê)

A mudança altera a contagem de requisições, e 6 testes a afirmavam. **Nenhum** falhou por dado
perdido ou duplicado — todos por `4 !== 3`. Atualizados com a razão registrada, não afrouxados.

Um deles é um **teto de custo** (`relatorio-mensal`: `emEventos <= 3`, contra N+1). Subiu para 4
porque a requisição extra é **fixa**, não por ferramenta — o invariante que ele protege ("custo
não cresce com o nº de ferramentas") segue intacto: com N+1 seriam 600.

## Nota

`REVISÃO INDEPENDENTE PENDENTE`. O Codex agora é alcançável com `-m gpt-5.6-terra` (o default
`gpt-5.6-sol` não serve para conta ChatGPT), mas a **cota** está esgotada — exit 75.
