### PR TITLE
feat(ci): o teto do CLAUDE.md era só do ARQUIVO — Armadilhas crescia paga pelo encolhimento das seções seguras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,10 @@ jobs:
       # apertado (20 KB / 2,6k palavras / linha ≤2000c) vs ~13 KB pós-refactor
       # da frente 1 (2026-06-15). Estourar = mover a lição pra docs/agent/ e o
       # histórico pra docs/historico/ (ver topo do CLAUDE.md). Ver scripts/check-claude-md-budget.sh.
+      # Desde 2026-08-22 mede também POR SEÇÃO, com ratchet em scripts/claude-md-secoes-baseline.txt:
+      # teto só do arquivo inteiro deixava "⚠️ Armadilhas recorrentes" (46% do arquivo, e a seção
+      # cujas regras falham ABERTO) crescer PAGA pelo encolhimento das seções seguras — invisível.
+      # A suíte de falsificação do gate roda no passo `Hooks guard tests` (test-claude-md-budget.sh).
       - name: CLAUDE.md size budget
         run: bun run claude:size
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Afiação (Sistema Operacional B2B Sardenberg)
 
 > Manual de **regras VIVAS** para agentes de código. O detalhe operacional de cada domínio vive em `docs/agent/*` (índice abaixo, carregado sob demanda); o **diário de PR** em `docs/historico/`; spec/plano profundo em `docs/superpowers/{specs,plans}/`.
-> **Política (mantenha enxuto):** só **REGRA/invariante que vale sempre** fica aqui. Histórico → `docs/historico/`; lição de domínio → `docs/agent/`; pendência em voo → PR/issue. Ao concluir uma entrega, registre em `docs/historico/` (ou no doc/agent se for lição nova) — **não engorde este arquivo**. O CI vigia o tamanho (`bun run claude:size` — teto apertado; estourar = mover para `docs/`).
+> **Política (mantenha enxuto):** só **REGRA/invariante que vale sempre** fica aqui. Histórico → `docs/historico/`; lição de domínio → `docs/agent/`; pendência em voo → PR/issue. Ao concluir uma entrega, registre em `docs/historico/` (ou no doc/agent se for lição nova) — **não engorde este arquivo**. O CI vigia o tamanho (`bun run claude:size` — teto do arquivo **e de cada seção**; estourar = mover para `docs/`, nunca pagar encolhendo outra seção).
 
 ## Preferências do founder (Lucas)
 

--- a/docs/historico/split-claude-md-sensor.md
+++ b/docs/historico/split-claude-md-sensor.md
@@ -55,6 +55,21 @@ arriscada**, invisível ao gate. A correção de CLASSE é teto **por seção** 
 Corolário mais geral: compactação melhora o **nível**, não a **inclinação**. Armadilhas cresce a
 cada lição aprendida; só um teto por seção muda a inclinação.
 
+**Fechado em 2026-08-22** (mesmo dia): o gate passou a medir por seção (`## `), com ratchet em
+`scripts/claude-md-secoes-baseline.txt` — teto de cada seção = o valor MEDIDO no dia, número
+inventado nenhum. Armadilhas ficou travada em **1.083 palavras**. Três saídas de emergência foram
+fechadas junto, porque cada uma devolveria o furo por outro caminho: seção **nova** sem teto
+(bastaria mover o bullet para `## Armadilhas parte 2`), teto **órfão** por renome do título (o teto
+passaria a medir NADA, verde por cegueira), e **encolher sem re-fixar** (a compactação de hoje
+viraria crédito silencioso de recrescimento amanhã — de novo nível, não inclinação). O caso que dá
+nome à suíte é o furo original: uma seção cresce, outra encolhe o mesmo tanto, o total do arquivo
+não muda — verde no gate antigo, vermelho no novo (`scripts/test-claude-md-budget.sh`).
+
+Efeito colateral medido no caminho: `wc -w` conta o `⚠️` do título de Armadilhas como 1 palavra em
+`LC_ALL=C` e 2 em `pt_BR.UTF-8` (2337 x 2338). Com teto apertado por seção isso seria vermelho
+falso em um dos ambientes — o gate inteiro passou a contar por `awk NF`, que deu o mesmo número
+nos dois. É o #1483 aparecendo na própria régua.
+
 ## A pergunta que a doc NÃO responde — e o sensor
 
 **Regra `paths:` chega no SUBAGENTE?** O orçamento do `claude:size` se justifica com *"carregado

--- a/docs/historico/split-claude-md-sensor.md
+++ b/docs/historico/split-claude-md-sensor.md
@@ -45,7 +45,7 @@ Está errado, por três razões específicas deste repo:
 
 Núcleo sempre-ligado cairia de 2.306 → **~1.890** sem mover nenhuma regra fail-open.
 
-## O furo no gate atual
+## O furo no gate atual (FECHADO no mesmo dia)
 
 `scripts/check-claude-md-budget.sh` mede o **arquivo inteiro**. Isso deixa Armadilhas crescer
 sendo paga pelo encolhimento de Stack — ou seja, **encolher a parte segura para financiar a
@@ -171,3 +171,7 @@ mover as 413 palavras compraria nível de novo, não inclinação — mais um mo
 apressar a fase 2 e gastar o esforço no ratchet por seção.
 
 Enquanto isso: núcleo em 2.337 palavras, zero regra movida, zero regra fail-open tocada.
+
+E o esforço foi mesmo para o ratchet: ele entrou no mesmo dia (seção "O furo no gate atual"
+acima). A partir daqui, os "+31 palavras em 4 PRs" só passam se couberem na seção que os
+recebe — ou se alguém subir aquele teto no diff, à vista.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
     "claude:instr": "bash scripts/instrucoes-relatorio.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean codex-async; do bash scripts/test-$t.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean codex-async claude-md-budget; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/check-claude-md-budget.sh
+++ b/scripts/check-claude-md-budget.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# check-claude-md-budget.sh — orçamento APERTADO do CLAUDE.md (frente 1 do refactor, 2026-06-15).
+# check-claude-md-budget.sh — orçamento APERTADO do CLAUDE.md: do arquivo INTEIRO e POR SEÇÃO.
 #
 # O CLAUDE.md é carregado em TODA sessão + subagente. Inchado, ele empurra os subagentes
 # pra perto do limite de contexto → thrashing de auto-compact (registrado em #819) e
@@ -11,20 +11,133 @@
 #
 # Bytes/palavras são a métrica dura (estável); a estimativa de tokens é informativa.
 # Linha gigante = sinal de que entrou um bullet de diário que devia ir pra docs/historico/.
+#
+# ── Por que também POR SEÇÃO (2026-08-22) ───────────────────────────────────────────────
+# Teto só do arquivo INTEIRO deixa uma seção crescer sendo PAGA pelo encolhimento de outra —
+# **encolher a parte segura para financiar a arriscada**, invisível ao gate. E a que mais cresce
+# é "⚠️ Armadilhas recorrentes" (46% do arquivo), justamente a que falha ABERTO: regra de estilo
+# que não carrega custa inconsistência, mas a regra do `WITH (security_invoker=on)` que não
+# carrega custa RLS BYPASSADA EM PRODUÇÃO. Compactar melhora o NÍVEL; só teto por seção muda a
+# INCLINAÇÃO — Armadilhas cresce a cada lição aprendida. Análise: docs/historico/split-claude-md-sensor.md
+#
+# Ratchet (mesmo idioma do fronteiras/manifesto.gate): o teto de cada seção é o valor MEDIDO no
+# dia em que a baseline foi gerada — nº inventado nenhum. Baseline: scripts/claude-md-secoes-baseline.txt
+#   - seção CRESCEU → compacte a PRÓPRIA seção ou mova a lição pra docs/agent/; se o teto novo for
+#     mesmo deliberado, rode `--gerar-baseline` e ele aparece no diff do PR (é o que se revisa).
+#   - seção ENCOLHEU mais que a folga → rode `--gerar-baseline` pra a catraca CLICAR. Sem isso a
+#     compactação de hoje vira crédito SILENCIOSO de recrescimento amanhã (o nível melhora, a
+#     inclinação não), que é exatamente o furo que este gate existe pra fechar.
+#   - seção NOVA sem entrada, ou entrada da baseline SEM seção (renome/split!) → VERMELHO. Pular
+#     seção desconhecida seria a saída de emergência que esvazia o gate: bastaria renomear o
+#     título — ou mover o bullet pra uma seção nova — pra nunca mais ser cobrado.
+#
+# Palavra é contada por `awk NF`, NUNCA por `wc -w`: medido em 2026-08-22, o `⚠️` do título de
+# Armadilhas faz `wc -w` devolver 2338 em pt_BR.UTF-8 e 2337 em LC_ALL=C. Teto apertado + métrica
+# locale-dependente = vermelho falso em UM dos ambientes (a armadilha do #1483). `awk NF` deu o
+# mesmo número nos dois. A suíte hermética (scripts/test-claude-md-budget.sh, no `test:hooks`)
+# roda os casos nos DOIS locales por isso.
+#
+# Uso:
+#   bash scripts/check-claude-md-budget.sh [arquivo] [baseline]   # verifica (é o que o CI roda)
+#   bash scripts/check-claude-md-budget.sh --gerar-baseline       # re-fixa os tetos no valor de hoje
+#
+# Exit: 0 = dentro do orçamento · 1 = estourou (arquivo ou seção) · 2 = entrada inválida
+#       (arquivo/baseline ausente ou vazio, seção duplicada, soma≠total) · 64 = uso errado.
 set -euo pipefail
 
-f="${1:-CLAUDE.md}"
 MAX_BYTES=20480 # 20 KB (~5,5k tokens). Pós-refactor ~13 KB — folga p/ regra nova, barra o diário.
 MAX_WORDS=2600
-MAX_LINE=2000 # chars por linha — linha maior = bullet de diário (mover pra docs/historico/)
+MAX_LINE=2000    # chars por linha — linha maior = bullet de diário (mover pra docs/historico/)
+FOLGA_SECAO=20   # palavras que uma seção pode ficar ABAIXO do teto antes de exigir re-baseline
+
+gerar=0
+f=""
+baseline=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --gerar-baseline) gerar=1 ;;
+    -h | --help)
+      echo "uso: $0 [arquivo] [baseline] | $0 --gerar-baseline [arquivo] [baseline]"
+      exit 0
+      ;;
+    -*)
+      echo "❌ flag desconhecida: $1 (só existe --gerar-baseline)" >&2
+      exit 64
+      ;;
+    *)
+      if [ -z "$f" ]; then f="$1"; else baseline="$1"; fi
+      ;;
+  esac
+  shift
+done
+f="${f:-CLAUDE.md}"
+baseline="${baseline:-scripts/claude-md-secoes-baseline.txt}"
 
 [ -f "$f" ] || {
   echo "❌ não achei $f (rode da raiz do repo)" >&2
   exit 2
 }
 
-bytes=$(wc -c <"$f")
-words=$(wc -w <"$f")
+# Emite "<palavras>\t<título>" por seção, na ordem do arquivo. Cerca de código NÃO abre seção
+# (um `## algo` dentro de ```bash é comentário de shell, não título) — mas as palavras de dentro
+# dela contam igual: elas ocupam contexto do mesmo jeito. "(preâmbulo)" = tudo antes do 1º `## `.
+medir() {
+  awk '
+    BEGIN { pre = "(preâmbulo)"; sec = pre; n = 1; ordem[1] = pre; w[pre] = 0 }
+    /^[ \t]*(```|~~~)/ { cerca = !cerca }
+    !cerca && /^## / {
+      if ($0 in w) { dup = $0 } else { ordem[++n] = $0; w[$0] = 0 }
+      sec = $0
+    }
+    { w[sec] += NF }
+    END {
+      if (dup != "") {
+        printf "❌ título de seção DUPLICADO (o teto de um esconderia o outro): %s\n", dup > "/dev/stderr"
+        exit 3
+      }
+      for (i = 1; i <= n; i++) printf "%d\t%s\n", w[ordem[i]], ordem[i]
+    }
+  ' "$1"
+}
+
+tmp="$(mktemp)"
+trap 'rm -f "$tmp"' EXIT
+
+if ! medir "$f" > "$tmp"; then
+  echo "❌ $f: não deu pra medir as seções (ver acima)" >&2
+  exit 2
+fi
+
+# Invariante anti-cegueira: a soma das seções TEM de bater com o total do arquivo, contado por um
+# caminho independente. Divergiu = o divisor de seções largou linha pelo caminho ⇒ o teto de alguma
+# seção estaria medindo menos do que existe, e o verde seria por cegueira (docs/historico/gates-textuais-cegos.md).
+words=$(awk '{ t += NF } END { print t + 0 }' "$f")
+soma=$(awk -F'\t' '{ s += $1 } END { print s + 0 }' "$tmp")
+if [ "$soma" != "$words" ]; then
+  echo "❌ $f: soma das seções ($soma) ≠ total do arquivo ($words) — divisor de seções perdeu linha" >&2
+  exit 2
+fi
+
+if [ "$gerar" -eq 1 ]; then
+  {
+    echo "# GERADO por \`bash scripts/check-claude-md-budget.sh --gerar-baseline\` — NÃO editar à mão."
+    echo "# Ratchet de PALAVRAS por seção do CLAUDE.md (heading \`## \`; \"(preâmbulo)\" = tudo antes do 1º)."
+    echo "# Cada teto é o valor MEDIDO no dia da geração — crescer acima dele = CI vermelho."
+    echo "# Subir um teto é ato DELIBERADO e aparece neste diff, que é onde se revisa."
+    echo "# Por que teto por seção (e não só do arquivo inteiro): topo de scripts/check-claude-md-budget.sh."
+    cat "$tmp"
+  } > "$baseline"
+  echo "✅ baseline re-gerada: $(awk 'END { print NR }' "$tmp") seção(ões) em $baseline"
+  exit 0
+fi
+
+[ -s "$baseline" ] || {
+  echo "❌ baseline de seções ausente ou VAZIA: $baseline" >&2
+  echo "   → rode \`bash $0 --gerar-baseline\` e COMMITE o arquivo (sem ela o teto por seção não existe)" >&2
+  exit 2
+}
+
+bytes=$(wc -c < "$f" | tr -d " ") # BSD wc alinha com espaços; `set -o pipefail` mantém o erro visível
 maxline=$(awk '{ if (length > m) { m = length; ln = NR } } END { print m"@"ln }' "$f")
 maxlen="${maxline%@*}"
 maxln="${maxline#*@}"
@@ -44,7 +157,70 @@ if [ "$maxlen" -gt "$MAX_LINE" ]; then
   fail=1
 fi
 
+# Ratchet por seção. Primeiro arquivo = baseline, segundo = o medido (NR==FNR separa as fases;
+# baseline vazia cairia nessa armadilha, por isso o `-s` acima já barrou — e o `nb==0`/`ns==0`
+# no END é a segunda tranca: nenhuma das duas pode terminar em silêncio verde).
+if ! awk -v folga="$FOLGA_SECAO" -v arq="$f" -v base="$baseline" -v prog="$0" '
+  NR == FNR {
+    if ($0 ~ /^[ \t]*(#|$)/) next
+    i = index($0, "\t")
+    if (i == 0) { printf "❌ %s:%d sem TAB — baseline corrompida: %s\n", base, FNR, $0; erro = 1; next }
+    t = substr($0, i + 1)
+    if (t in teto) { printf "❌ %s: título repetido na baseline: %s\n", base, t; erro = 1 }
+    teto[t] = substr($0, 1, i - 1) + 0
+    nb++
+    next
+  }
+  {
+    i = index($0, "\t")
+    t = substr($0, i + 1)
+    p = substr($0, 1, i - 1) + 0
+    ns++
+    visto[t] = 1
+    if (!(t in teto)) {
+      printf "❌ seção SEM teto na baseline (%d palavras): %s\n", p, t
+      printf "   → seção nova (ou título editado) não passa em silêncio: um bullet mudado de seção\n"
+      printf "     escaparia do teto da seção de origem. Rode `bash %s --gerar-baseline` se for deliberado.\n", prog
+      erro = 1
+      next
+    }
+    if (p > teto[t]) {
+      printf "❌ seção estourou o teto: %s\n", t
+      printf "   %d palavras > teto %d (+%d). Compacte a PRÓPRIA seção ou mova a lição pra docs/agent/ —\n", p, teto[t], p - teto[t]
+      printf "   encolher OUTRA seção pra pagar esta é exatamente o que este teto existe pra impedir.\n"
+      printf "   Se o teto novo for deliberado: `bash %s --gerar-baseline` (aparece no diff do PR).\n", prog
+      erro = 1
+    } else if (teto[t] - p > folga) {
+      printf "❌ seção encolheu %d palavras abaixo do teto (folga tolerada: %d): %s\n", teto[t] - p, folga, t
+      printf "   %d palavras, teto %d. A catraca precisa CLICAR: rode `bash %s --gerar-baseline`.\n", p, teto[t], prog
+      printf "   Sem isso a compactação de hoje vira crédito silencioso de recrescimento amanhã.\n"
+      erro = 1
+    }
+  }
+  END {
+    if (nb == 0) { printf "❌ %s: nenhuma entrada de teto lida — baseline vazia/só comentário\n", base; erro = 1 }
+    if (ns == 0) { printf "❌ %s: nenhuma seção medida — o gate não olhou nada\n", arq; erro = 1 }
+    for (t in teto) {
+      if (!(t in visto)) {
+        printf "❌ teto ÓRFÃO: a baseline cobra %s, que não existe mais em %s\n", t, arq
+        printf "   → seção renomeada/removida deixa o teto medindo NADA (verde por cegueira). Rode\n"
+        printf "     `bash %s --gerar-baseline` depois de conferir que o conteúdo não migrou pra fugir do teto.\n", prog
+        erro = 1
+      }
+    }
+    exit erro ? 1 : 0
+  }
+' "$baseline" "$tmp"; then
+  fail=1
+fi
+
 if [ "$fail" -eq 0 ]; then
   echo "✅ $f: $bytes bytes / $words palavras / ≈${est_tokens} tokens / maior linha $maxlen chars — dentro do orçamento (teto ${MAX_BYTES}B / ${MAX_WORDS}w / linha ${MAX_LINE}c)"
+  # palavras/teto e a FATIA de cada seção — é aqui que "Armadilhas = 46% do arquivo" fica visível
+  # sem ninguém precisar medir de novo (era o número que só existia no docs/historico/).
+  awk -F'\t' -v tot="$words" '
+    NR == FNR { if ($0 !~ /^[ \t]*(#|$)/) { i = index($0, "\t"); teto[substr($0, i + 1)] = substr($0, 1, i - 1) + 0 } ; next }
+    { printf "   %4d/%-4d %3d%%  %s\n", $1, teto[$2], ($1 * 100 + tot / 2) / tot, $2 }
+  ' "$baseline" "$tmp"
 fi
 exit "$fail"

--- a/scripts/claude-md-secoes-baseline.txt
+++ b/scripts/claude-md-secoes-baseline.txt
@@ -1,0 +1,16 @@
+# GERADO por `bash scripts/check-claude-md-budget.sh --gerar-baseline` — NÃO editar à mão.
+# Ratchet de PALAVRAS por seção do CLAUDE.md (heading `## `; "(preâmbulo)" = tudo antes do 1º).
+# Cada teto é o valor MEDIDO no dia da geração — crescer acima dele = CI vermelho.
+# Subir um teto é ato DELIBERADO e aparece neste diff, que é onde se revisa.
+# Por que teto por seção (e não só do arquivo inteiro): topo de scripts/check-claude-md-budget.sh.
+110	(preâmbulo)
+312	## Preferências do founder (Lucas)
+170	## Índice — `docs/agent/` (referência operacional, LEIA o doc ANTES de tocar o domínio)
+1083	## ⚠️ Armadilhas recorrentes (caras — a maioria money-path/banco; detalhe no doc/agent indicado)
+84	## Merge (auto)
+158	## Stack
+148	## Design System (v3 — "fintech premium": Vercel/Mercury/Stripe Dashboard)
+70	## Auth & roles
+56	## Convenções de código
+34	## gstack (REQUIRED)
+122	## Multi-sessão (regra — detalhe em `docs/agent/worktrees.md`)

--- a/scripts/test-claude-md-budget.sh
+++ b/scripts/test-claude-md-budget.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# test-claude-md-budget.sh — suíte HERMÉTICA do scripts/check-claude-md-budget.sh (sem rede, sem git).
+#
+# O caso que dá nome a tudo é o `furo original`: uma seção CRESCE e outra ENCOLHE o mesmo tanto, o
+# arquivo fica com o MESMO total de palavras — e o gate antigo (teto só do arquivo inteiro) passava.
+# Se esse caso ficar verde, o teto por seção não existe de fato. Os demais fecham as saídas de
+# emergência que esvaziariam o gate em silêncio (seção nova, renome, baseline vazia/só-comentário).
+#
+# Tudo roda nos DOIS locales: o `⚠️` do título de Armadilhas faz `wc -w` divergir entre pt_BR.UTF-8
+# e LC_ALL=C (medido 2026-08-22), e falsificar em UM ambiente não prova a asserção (#1483). Sem um
+# locale UTF-8 disponível a suíte FALHA — rodar C duas vezes seria metade da cobertura fingindo ser
+# inteira (ausência de dado ≠ aprovação).
+#
+# Uso: bash scripts/test-claude-md-budget.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+raiz="$(cd "$here/.." && pwd)"
+GATE="$here/check-claude-md-budget.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+arq="$tmp/FAKE.md"
+base="$tmp/baseline.txt"
+
+ok=0
+ruim=0
+LOC=""
+
+# ── locale UTF-8: exigir resposta POSITIVA, nunca degradar em silêncio ────────────────────────
+# `locale -a` casaria "C.utf8" x "C.UTF-8" por acidente de grafia; aqui a sonda é POSITIVA —
+# só vale o locale que RESPONDE UTF-8 quando aplicado (presente-porém-quebrado esvaziaria o guard).
+utf8=""
+for cand in pt_BR.UTF-8 pt_BR.utf8 en_US.UTF-8 en_US.utf8 C.UTF-8 C.utf8; do
+  if [ "$(LC_ALL="$cand" locale charmap 2>/dev/null)" = "UTF-8" ]; then
+    utf8="$cand"
+    break
+  fi
+done
+if [ -z "$utf8" ]; then
+  echo "❌ nenhum locale UTF-8 (pt_BR/en_US/C) neste ambiente — a metade UTF-8 da suíte não rodaria."
+  echo "   Rodar só LC_ALL=C e chamar de verde é a falsificação em UM ambiente do #1483."
+  exit 1
+fi
+
+# ── helpers ──────────────────────────────────────────────────────────────────────────────────
+palavras() { awk -v n="$1" 'BEGIN { for (i = 1; i <= n; i++) printf "p%d%s", i, (i < n ? " " : "\n") }'; }
+
+# monta <n_palavras_alfa> <n_palavras_beta> — Beta tem `⚠️` e travessão no título de propósito.
+monta() {
+  {
+    echo "preambulo do arquivo de teste"
+    echo
+    echo "## Alfa"
+    palavras "$1"
+    echo
+    echo "## ⚠️ Beta — seção com acento"
+    palavras "$2"
+  } > "$arq"
+}
+
+total_palavras() { awk '{ t += NF } END { print t + 0 }' "$1"; }
+
+# esperar <rc> <trecho-ou-vazio> <descrição> [args do gate...]
+esperar() {
+  local rc_esp="$1" trecho="$2" desc="$3"
+  shift 3
+  local saida rc
+  saida="$(LC_ALL="$LOC" bash "$GATE" "$@" 2>&1)"
+  rc=$? # medido COLADO na substituição — qualquer comando no meio sobrescreveria o $?
+  if [ "$rc" -ne "$rc_esp" ]; then
+    echo "❌ [$LOC] $desc — esperava exit $rc_esp, veio $rc"
+    printf '%s\n' "$saida" | sed 's/^/     | /'
+    ruim=$((ruim + 1))
+    return
+  fi
+  if [ -n "$trecho" ] && ! printf '%s\n' "$saida" | grep -qF "$trecho"; then
+    echo "❌ [$LOC] $desc — exit $rc certo, mas a saída não diz \"$trecho\" (mensagem muda ⇒ gate mudou de motivo)"
+    printf '%s\n' "$saida" | sed 's/^/     | /'
+    ruim=$((ruim + 1))
+    return
+  fi
+  ok=$((ok + 1))
+}
+
+# ── os casos, rodados uma vez por locale ─────────────────────────────────────────────────────
+for LOC in C "$utf8"; do
+  echo "── locale: $LOC ──"
+
+  # 1. verde: baseline recém-gerada bate com o arquivo que a gerou
+  monta 60 40
+  LC_ALL="$LOC" bash "$GATE" --gerar-baseline "$arq" "$base" > /dev/null || {
+    echo "❌ [$LOC] --gerar-baseline falhou"
+    ruim=$((ruim + 1))
+  }
+  esperar 0 "dentro do orçamento" "verde: arquivo == baseline" "$arq" "$base"
+
+  # 2. O FURO ORIGINAL: Beta +5 pago por Alfa -5 ⇒ total do arquivo IDÊNTICO.
+  #    O gate antigo (só arquivo inteiro) passava; este tem de reprovar nomeando Beta.
+  antes="$(total_palavras "$arq")"
+  monta 55 45
+  depois="$(total_palavras "$arq")"
+  if [ "$antes" != "$depois" ]; then
+    echo "❌ [$LOC] fixture ruim: o furo exige total IGUAL ($antes vs $depois) — o caso não provaria nada"
+    ruim=$((ruim + 1))
+  else
+    ok=$((ok + 1))
+  fi
+  esperar 1 "seção estourou o teto" "furo original: cresce uma, encolhe outra, total igual" "$arq" "$base"
+  esperar 1 "Beta" "furo original: a mensagem nomeia a seção que cresceu" "$arq" "$base"
+
+  # 3. crescimento puro
+  monta 60 46
+  esperar 1 "seção estourou o teto" "seção cresceu sozinha" "$arq" "$base"
+
+  # 4. encolhimento dentro da folga (20) segue verde — edição normal não vira churn
+  monta 45 40
+  esperar 0 "dentro do orçamento" "encolheu 15 (< folga 20): verde" "$arq" "$base"
+
+  # 5. encolhimento além da folga: a catraca precisa CLICAR
+  monta 30 40
+  esperar 1 "catraca precisa CLICAR" "encolheu 30 (> folga 20): exige --gerar-baseline" "$arq" "$base"
+
+  # 6. seção NOVA sem teto: mover bullet pra seção nova não pode escapar
+  monta 60 40
+  printf '\n## Gama\n%s\n' "$(palavras 30)" >> "$arq"
+  esperar 1 "SEM teto na baseline" "seção nova sem entrada na baseline" "$arq" "$base"
+
+  # 7. RENOME: o teto órfão não pode ficar medindo nada em silêncio
+  monta 60 40
+  sed 's/^## Alfa$/## Alfa renomeada/' "$arq" > "$arq.tmp" && mv "$arq.tmp" "$arq"
+  esperar 1 "teto ÓRFÃO" "seção renomeada deixa teto órfão" "$arq" "$base"
+
+  # 8. `## ` dentro de cerca de código NÃO abre seção (senão viraria "seção sem teto")
+  monta 60 40
+  {
+    echo
+    echo '```bash'
+    echo "## isto e comentario de shell, nao titulo"
+    echo "bun run algo"
+    echo '```'
+  } >> "$arq"
+  esperar 1 "seção estourou o teto" "cerca: linhas contam palavras (Beta cresce), mas não viram seção" "$arq" "$base"
+  saida_cerca="$(LC_ALL="$LOC" bash "$GATE" "$arq" "$base" 2>&1)"
+  if printf '%s\n' "$saida_cerca" | grep -qF "SEM teto na baseline"; then
+    echo "❌ [$LOC] cerca de código virou seção — o divisor não entende \`\`\`"
+    ruim=$((ruim + 1))
+  else
+    ok=$((ok + 1))
+  fi
+
+  # 9. título DUPLICADO: dois iguais fariam um teto esconder o outro
+  monta 60 40
+  printf '\n## Alfa\n%s\n' "$(palavras 10)" >> "$arq"
+  esperar 2 "DUPLICADO" "título de seção duplicado" "$arq" "$base"
+
+  # 10. baseline VAZIA e baseline SÓ COMENTÁRIO: nenhuma das duas pode terminar verde
+  monta 60 40
+  : > "$tmp/vazia.txt"
+  esperar 2 "VAZIA" "baseline vazia" "$arq" "$tmp/vazia.txt"
+  printf '# só comentário\n#\n' > "$tmp/comentario.txt"
+  esperar 1 "nenhuma entrada de teto" "baseline só com comentário" "$arq" "$tmp/comentario.txt"
+
+  # 11. entradas ausentes/ inválidas
+  esperar 2 "ausente ou VAZIA" "baseline inexistente" "$arq" "$tmp/nao-existe.txt"
+  esperar 2 "não achei" "arquivo inexistente" "$tmp/nao-existe.md" "$base"
+  esperar 64 "flag desconhecida" "flag inventada não é ignorada" --turbo "$arq" "$base"
+
+  # 12. round-trip: re-gerar a baseline sobre o arquivo mutado devolve o verde
+  monta 60 40
+  printf '\n## Gama\n%s\n' "$(palavras 30)" >> "$arq"
+  LC_ALL="$LOC" bash "$GATE" --gerar-baseline "$arq" "$base" > /dev/null
+  esperar 0 "dentro do orçamento" "round-trip: --gerar-baseline devolve o verde" "$arq" "$base"
+
+  # 13. o par COMMITADO (CLAUDE.md + baseline) tem de estar verde — é o que o CI roda
+  esperar 0 "dentro do orçamento" "CLAUDE.md real x baseline commitada" "$raiz/CLAUDE.md" "$raiz/scripts/claude-md-secoes-baseline.txt"
+done
+
+echo
+if [ "$ruim" -eq 0 ]; then
+  echo "✅ test-claude-md-budget: $ok asserções verdes (2 locales: C e $utf8)"
+  exit 0
+fi
+echo "❌ test-claude-md-budget: $ruim falha(s) em $((ok + ruim)) asserções"
+exit 1


### PR DESCRIPTION
## O furo

`bun run claude:size` media **bytes/palavras do arquivo inteiro**. Com teto só global, uma seção pode crescer sendo **financiada pelo encolhimento de outra** — e o gate não vê nada.

Isso é o contrário do desejável: a seção que mais cresce é **⚠️ Armadilhas recorrentes** (1.083 palavras, **46%** do arquivo), justamente a que falha **ABERTO** — a regra do `WITH (security_invoker=on)` que não carrega custa RLS bypassada em produção. Encolher a parte segura para financiar a arriscada era invisível.

O #1885 mediu a inclinação no mesmo dia: **+31 palavras em 4 PRs** sem ninguém pretender engordar o arquivo. Compactação melhora o **nível**; só teto por seção muda a **inclinação**.

## O que entrou

Teto **por seção** (`## `) com **ratchet** em `scripts/claude-md-secoes-baseline.txt` — cada teto é o valor **MEDIDO hoje**, número inventado nenhum (idioma do `fronteiras`/`manifesto.gate`). Armadilhas travada em **1.083**.

Fecha junto as três saídas de emergência que devolveriam o furo por outro caminho:

| Saída | Sem a trava |
|---|---|
| seção **NOVA** sem teto | bastaria mover o bullet pra `## Armadilhas parte 2` |
| teto **ÓRFÃO** (título renomeado) | o teto passaria a medir **NADA** — verde por cegueira |
| **encolher sem re-fixar** | a compactação de hoje vira crédito silencioso de recrescimento |

Palavra passou a ser contada por **`awk NF`, não `wc -w`**: o `⚠️` do título de Armadilhas vale 1 palavra em `LC_ALL=C` e 2 em `pt_BR.UTF-8` (2337 × 2338). Teto apertado + métrica locale-dependente = vermelho falso em um dos ambientes (#1483). `awk NF` deu o mesmo número nos dois.

## Falsificação (o gate sabotado TEM de ficar vermelho)

`scripts/test-claude-md-budget.sh` — 38 asserções, **nos dois locales**, no `test:hooks`. Caso central: **o furo original** — uma seção cresce, outra encolhe o mesmo tanto, o total do arquivo **não muda**.

7 sabotagens, cada uma exigindo vermelho **pelo caso certo**:

| Sabotagem no gate | Caso que ficou vermelho |
|---|---|
| resultado por seção ignorado (gate antigo) | furo original |
| seção nova pulada em silêncio | seção nova sem entrada |
| sem checagem de teto órfão | renome deixa teto órfão |
| sem guarda de baseline vazia | baseline vazia |
| cerca de código volta a abrir seção | ``` não vira seção |
| folga infinita | catraca nunca clica |
| sem locale UTF-8 (stub de `locale`) | a **suíte** falha em vez de rodar metade |

Controle: árvore restaurada + suíte de volta ao verde.

## Evidência

- `bash scripts/test-claude-md-budget.sh` → `SUITE_RC=0`, 38 asserções (C e pt_BR.UTF-8)
- loop do `test:hooks` (18 suítes) → `RC=0`
- `shellcheck scripts/*.sh .claude/hooks/*.sh` → `RC=0`, saída vazia
- `bun run claude:size` → `RC=0` (e agora imprime a fatia de cada seção — é onde "Armadilhas = 46%" fica visível sem ninguém remedir)

O gate pegou a **própria** edição deste PR: a linha nova de política estourou o preâmbulo (100 → 110) e exigiu re-fixar a baseline — o teto novo está no diff, que é onde se revisa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)