### PR TITLE
fix(farmer): o estado OFFLINE caía no balde 'sem acesso' — tela em branco e silêncio no PostHog [money-path]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -495,28 +495,6 @@ Os outros achados que sobreviveram à verificação:
   porque depois some em silêncio. Mesma lição do parágrafo acima, agora aplicada ao parecer que revisa
   o PR que a escreveu.
 
-#### Correção do quarto estado (offline) — e o que a SABOTAGEM VERDE ensinou (#PR desta sessão)
-
-`MixGapCard` passou a discriminar por `fetchStatus`, não por `isLoading`: `data === undefined` é
-pendente, pausado OU desabilitado; só `data === null` é a RPC dizendo "sem acesso". Offline virou
-estado próprio (`aguardando_rede`, tela de conexão) e **emite** evento com `total_com_gap: null` —
-não emitir recriaria o buraco do #1859 ("offline" indistinguível de "nunca abriu"), e emitir não
-contamina o denominador porque adoção se calcula sobre os estados com número honesto
-(`com_gap`/`zero`), como já era preciso com `erro`. O que segue MUDO é `semAcesso`. O erro deixou de
-ter precedência sobre o cache: com dado, a lista fica na tela + faixa de aviso e o evento leva
-`desatualizado: 'erro' | 'sem_rede'` (a dedup passou a ser por `estado:motivo`, senão engoliria a
-transição "número fresco" → "número velho", que é o sinal de leitura falhando em campo).
-
-**A lição durável está na falsificação que ficou VERDE.** Sabotar a precedência `pausado`-antes-de
--`error` no ramo SEM dado não derrubou teste nenhum. Não era teste fraco: era o mecanismo que eu
-tinha descrito errado. `fetchState` (query-core, `query.ts`) zera `error`/`status` ao iniciar um
-fetch **apenas quando `data === undefined`** ⇒ sem dado, erro e pausa **nunca coexistem** (a ordem
-ali é inócua), e só COM dado no cache eles se sobrepõem — que é onde a precedência decide algo. O
-comentário do código afirmava um conflito inexistente e o teste passava por não discriminar nada.
-⇒ **sabotagem que não fica vermelha é achado, não aprovação**: ou o assert não mede o que diz, ou o
-mecanismo é outro. Investigue o mecanismo antes de aceitar o verde — foi o que produziu o único
-teste que mede a precedência de verdade (erro no cache + rede caindo depois).
-
 Denominador do card: `commercial_roles` = **3 vendedores**. Com n=3 o argumento do sensor fica mais
 forte, não mais fraco — um evento perdido é um terço da série.
 
@@ -567,3 +545,29 @@ tinha suposto a forma de um "vazio julgável" em vez de lê-la (`scores.n > 0` *
 **e** a cobertura declarada). O teste barato pagou-se antes de existir PR: sem ele, eu teria
 entregue um ramo que atropelava a existência e só descobriria isso quando o primeiro vazio real
 chegasse — e aí ele viria mudo.
+
+## Quarto estado do MixGap: OFFLINE (2026-08-22) — e a sabotagem que ficou VERDE
+
+> Continuação da seção "Revisão independente RETROATIVA" acima. Fica aqui no fim, e não lá,
+> porque o #1886 (a mesma classe, varrida e gateada) insere no mesmo ponto do arquivo —
+> hunk vizinho entre worktrees paralelas é conflito garantido.
+
+`MixGapCard` passou a discriminar por `fetchStatus`, não por `isLoading`: `data === undefined` é
+pendente, pausado OU desabilitado; só `data === null` é a RPC dizendo "sem acesso". Offline virou
+estado próprio (`aguardando_rede`, tela de conexão) e **emite** evento com `total_com_gap: null` —
+não emitir recriaria o buraco do #1859 ("offline" indistinguível de "nunca abriu"), e emitir não
+contamina o denominador porque adoção se calcula sobre os estados com número honesto
+(`com_gap`/`zero`), como já era preciso com `erro`. O que segue MUDO é `semAcesso`. O erro deixou de
+ter precedência sobre o cache: com dado, a lista fica na tela + faixa de aviso e o evento leva
+`desatualizado: 'erro' | 'sem_rede'` (a dedup passou a ser por `estado:motivo`, senão engoliria a
+transição "número fresco" → "número velho", que é o sinal de leitura falhando em campo).
+
+**A lição durável está na falsificação que ficou VERDE.** Sabotar a precedência `pausado`-antes-de
+-`error` no ramo SEM dado não derrubou teste nenhum. Não era teste fraco: era o mecanismo que eu
+tinha descrito errado. `fetchState` (query-core, `query.ts`) zera `error`/`status` ao iniciar um
+fetch **apenas quando `data === undefined`** ⇒ sem dado, erro e pausa **nunca coexistem** (a ordem
+ali é inócua), e só COM dado no cache eles se sobrepõem — que é onde a precedência decide algo. O
+comentário do código afirmava um conflito inexistente e o teste passava por não discriminar nada.
+⇒ **sabotagem que não fica vermelha é achado, não aprovação**: ou o assert não mede o que diz, ou o
+mecanismo é outro. Investigue o mecanismo antes de aceitar o verde — foi o que produziu o único
+teste que mede a precedência de verdade (erro no cache + rede caindo depois).

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -495,6 +495,28 @@ Os outros achados que sobreviveram à verificação:
   porque depois some em silêncio. Mesma lição do parágrafo acima, agora aplicada ao parecer que revisa
   o PR que a escreveu.
 
+#### Correção do quarto estado (offline) — e o que a SABOTAGEM VERDE ensinou (#PR desta sessão)
+
+`MixGapCard` passou a discriminar por `fetchStatus`, não por `isLoading`: `data === undefined` é
+pendente, pausado OU desabilitado; só `data === null` é a RPC dizendo "sem acesso". Offline virou
+estado próprio (`aguardando_rede`, tela de conexão) e **emite** evento com `total_com_gap: null` —
+não emitir recriaria o buraco do #1859 ("offline" indistinguível de "nunca abriu"), e emitir não
+contamina o denominador porque adoção se calcula sobre os estados com número honesto
+(`com_gap`/`zero`), como já era preciso com `erro`. O que segue MUDO é `semAcesso`. O erro deixou de
+ter precedência sobre o cache: com dado, a lista fica na tela + faixa de aviso e o evento leva
+`desatualizado: 'erro' | 'sem_rede'` (a dedup passou a ser por `estado:motivo`, senão engoliria a
+transição "número fresco" → "número velho", que é o sinal de leitura falhando em campo).
+
+**A lição durável está na falsificação que ficou VERDE.** Sabotar a precedência `pausado`-antes-de
+-`error` no ramo SEM dado não derrubou teste nenhum. Não era teste fraco: era o mecanismo que eu
+tinha descrito errado. `fetchState` (query-core, `query.ts`) zera `error`/`status` ao iniciar um
+fetch **apenas quando `data === undefined`** ⇒ sem dado, erro e pausa **nunca coexistem** (a ordem
+ali é inócua), e só COM dado no cache eles se sobrepõem — que é onde a precedência decide algo. O
+comentário do código afirmava um conflito inexistente e o teste passava por não discriminar nada.
+⇒ **sabotagem que não fica vermelha é achado, não aprovação**: ou o assert não mede o que diz, ou o
+mecanismo é outro. Investigue o mecanismo antes de aceitar o verde — foi o que produziu o único
+teste que mede a precedência de verdade (erro no cache + rede caindo depois).
+
 Denominador do card: `commercial_roles` = **3 vendedores**. Com n=3 o argumento do sensor fica mais
 forte, não mais fraco — um evento perdido é um terço da série.
 

--- a/src/components/farmer/MixGapCard.tsx
+++ b/src/components/farmer/MixGapCard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
-import { MoreVertical, Search, AlertTriangle } from 'lucide-react';
+import { MoreVertical, Search, AlertTriangle, WifiOff } from 'lucide-react';
 import { Card, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -34,37 +34,98 @@ import { track } from '@/lib/analytics';
  * ⚠️ O evento leva `total_com_gap: null` no erro, nunca `0`. Mandar zero seria fabricar o
  * número que o sensor existe para medir (§2 — ausente ≠ zero): a série de adoção passaria a
  * somar falhas de leitura como se fossem carteiras sem oportunidade.
+ *
+ * ── QUARTO estado, achado na revisão adversária retroativa do #1859 (Codex e a análise da casa
+ * chegaram nele por caminhos separados). Com `networkMode:'online'` (default do QueryClient
+ * global, sem `persistQueryClient` no repo) e o navegador offline, a query fica
+ * `status:'pending'`/`fetchStatus:'paused'`/`data:undefined`/`error:null`. Em v5
+ * `isLoading = isPending && isFetching`, e pausada NÃO está fetching ⇒ `isLoading` é **false**:
+ * o predicado antigo (`!isLoading && !error && data === undefined`) casava e o card devolvia
+ * `null`. Ou seja, o estado OFFLINE caía no balde "não é staff" — tela em branco e silêncio no
+ * PostHog, exatamente a classe de defeito que o #1859 corrigiu. Num PWA de vendedor em campo
+ * isso não é hipotético. Daí `fetchStatus` entrar no discriminante: `data === undefined` é
+ * pendente, pausado OU desabilitado; só `data === null` é a RPC dizendo "sem acesso".
+ *
+ * ⚠️ DECISÃO — `aguardando_rede` EMITE evento (com `total_com_gap: null`). Não emitir recriaria
+ * o buraco que o #1859 fechou: "vendedor offline" viraria indistinguível de "vendedor nunca
+ * abriu". E emitir não contamina o denominador de adoção porque o estado é explícito na série:
+ * adoção se calcula sobre os estados com número honesto (`com_gap`/`zero`), como já era preciso
+ * fazer com `erro`. O que continua MUDO é `semAcesso` — quem nunca poderia ver o card não
+ * pertence ao denominador, e por isso a ausência de acesso não gera linha nenhuma.
+ *
+ * ⚠️ E o erro tinha precedência sobre o dado STALE, o que custava a lista inteira: um refetch
+ * ruim trocava as oportunidades por um aviso, com o cache ainda cheio. Honesto para o sensor,
+ * regressão para quem está na rua. O desenho composto (lista PRESERVADA + faixa de aviso +
+ * `desatualizado: 'erro' | 'sem_rede'` no evento) serve aos dois: o vendedor não perde a
+ * carteira e a série sabe separar "viu número fresco" de "agiu sobre número velho".
  */
-type EstadoMixGap = 'com_gap' | 'zero' | 'erro';
+type EstadoMixGap = 'com_gap' | 'zero' | 'erro' | 'aguardando_rede';
+/** Por que o número na tela pode estar velho. `null` = acabou de ser lido com sucesso. */
+type MotivoDesatualizado = 'erro' | 'sem_rede';
+
+function AvisoDesatualizado({ motivo }: { motivo: MotivoDesatualizado }) {
+  const Icone = motivo === 'sem_rede' ? WifiOff : AlertTriangle;
+  return (
+    <div className="flex items-start gap-2 px-3 py-2 border-b border-border bg-muted/40 text-2xs text-status-warning">
+      <Icone className="w-3.5 h-3.5 shrink-0 mt-px" />
+      <span>
+        Informação desatualizada — {motivo === 'sem_rede' ? 'sem conexão agora' : 'a última atualização falhou'}.
+        É a última leitura que deu certo; pode ter mudado desde então.
+      </span>
+    </div>
+  );
+}
 
 export function MixGapCard() {
-  const { data, error, isLoading } = useMyMixGap();
+  const { data, error, isPending, fetchStatus } = useMyMixGap();
   const { mutate: markFeedback } = useMarkMixGapFeedback();
   const { isImpersonating } = useImpersonation();
 
-  // `data === null` é a RPC dizendo "você não é staff" (ela retorna NULL sem uid/sem role):
-  // não é um estado do card, é ausência de acesso — e aí o card não deve existir mesmo.
-  // `undefined` com a query desabilitada (sem user) cai no mesmo lugar.
-  const semAcesso = !isLoading && !error && (data === null || data === undefined);
-  const estado: EstadoMixGap | null =
-    isLoading || semAcesso ? null : error ? 'erro' : (data!.totalComGap > 0 ? 'com_gap' : 'zero');
+  // `data === null` é a RPC dizendo "você não é staff" (ela retorna NULL sem uid/sem role) — e isso
+  // só existe DEPOIS de a query RESOLVER. `undefined` NÃO é sinônimo: é pendente, pausada ou
+  // desabilitada, três coisas diferentes. Ler os dois como "sem acesso" foi o defeito de origem.
+  const semAcesso = data === null;
+  const temDado = data != null;
+  const pausado = fetchStatus === 'paused';        // offline: o react-query nem dispara a request
+  const inerte = isPending && fetchStatus === 'idle';   // query desabilitada (sem user)
+  const carregando = isPending && fetchStatus === 'fetching';
 
-  const trackedEstado = useRef<EstadoMixGap | null>(null);
+  // Pausado ANTES de erro: se a rede caiu depois de uma falha, "sem conexão" é o motivo atual e o
+  // acionável (recarregar não resolve; voltar para a área coberta, sim).
+  const desatualizado: MotivoDesatualizado | null =
+    !temDado ? null : pausado ? 'sem_rede' : error ? 'erro' : null;
+
+  const estado: EstadoMixGap | null =
+    semAcesso || inerte || carregando
+      ? null
+      : temDado
+        ? (data.totalComGap > 0 ? 'com_gap' : 'zero')
+        : pausado
+          ? 'aguardando_rede'
+          : error
+            ? 'erro'
+            : null;
+
+  const trackedChave = useRef<string | null>(null);
   useEffect(() => {
-    // Um evento por estado RESOLVIDO. A guarda por estado (e não por booleano) deixa passar a
-    // transição erro → zero → com_gap dentro da mesma montagem, que é o dado que separa uma
-    // falha transitória de uma carteira realmente vazia.
-    if (!estado || trackedEstado.current === estado) return;
-    trackedEstado.current = estado;
+    // Um evento por estado RESOLVIDO — e a chave inclui o MOTIVO de desatualização, senão a dedup
+    // engoliria a transição "carteira fresca" → "agindo sobre número velho", que é precisamente o
+    // sinal de leitura falhando em campo. A guarda por chave (e não por booleano) deixa passar
+    // erro → zero → com_gap na mesma montagem, que separa falha transitória de carteira vazia.
+    if (!estado) return;
+    const chave = `${estado}:${desatualizado ?? 'fresco'}`;
+    if (trackedChave.current === chave) return;
+    trackedChave.current = chave;
     track('carteira.mixgap_visto', {
       estado,
-      total_com_gap: estado === 'erro' ? null : data!.totalComGap,
+      total_com_gap: temDado ? data.totalComGap : null,
+      desatualizado,
     });
-  }, [estado, data]);
+  }, [estado, desatualizado, temDado, data]);
 
-  if (semAcesso) return null;
+  if (semAcesso || inerte) return null;
 
-  if (isLoading) {
+  if (carregando) {
     return (
       <Card>
         <CardHeader className="pb-2">
@@ -80,7 +141,20 @@ export function MixGapCard() {
     );
   }
 
-  if (error) {
+  if (estado === 'aguardando_rede') {
+    return (
+      <Card>
+        <EmptyState
+          tone="operational"
+          icon={WifiOff}
+          title="Sem conexão — não consegui consultar"
+          description="As oportunidades da sua carteira precisam de rede para carregar. Isto NÃO significa que não há oportunidades: assim que a conexão voltar, o card se atualiza sozinho."
+        />
+      </Card>
+    );
+  }
+
+  if (estado === 'erro') {
     return (
       <Card>
         <EmptyState
@@ -93,9 +167,14 @@ export function MixGapCard() {
     );
   }
 
-  if (data!.totalComGap === 0) {
+  // Exaustividade: todo estado SEM dado já saiu acima. Se um caso novo escapar, o card some —
+  // mas em nenhuma hipótese fabrica número.
+  if (data == null) return null;
+
+  if (data.totalComGap === 0) {
     return (
       <Card>
+        {desatualizado && <AvisoDesatualizado motivo={desatualizado} />}
         <EmptyState
           tone="operational"
           icon={Search}
@@ -108,14 +187,15 @@ export function MixGapCard() {
 
   return (
     <Card>
+      {desatualizado && <AvisoDesatualizado motivo={desatualizado} />}
       <CardHeader className="pb-2">
         <h2 className="text-base font-medium">Oportunidades de cross-sell</h2>
         <p className="text-2xs text-muted-foreground">
-          {data!.totalComGap} clientes da sua carteira sem uma família que clientes parecidos compram
+          {data.totalComGap} clientes da sua carteira sem uma família que clientes parecidos compram
         </p>
       </CardHeader>
       <div className="divide-y divide-border">
-        {data!.lista.slice(0, 20).map((g) => (
+        {data.lista.slice(0, 20).map((g) => (
           <div key={g.customer_user_id} className="p-3 flex items-center justify-between gap-3 hover:bg-muted/30">
             <Link
               to={`/admin/customers/${g.customer_user_id}/360`}

--- a/src/components/farmer/MixGapCard.tsx
+++ b/src/components/farmer/MixGapCard.tsx
@@ -90,8 +90,10 @@ export function MixGapCard() {
   const inerte = isPending && fetchStatus === 'idle';   // query desabilitada (sem user)
   const carregando = isPending && fetchStatus === 'fetching';
 
-  // Pausado ANTES de erro: se a rede caiu depois de uma falha, "sem conexão" é o motivo atual e o
-  // acionável (recarregar não resolve; voltar para a área coberta, sim).
+  // Pausado ANTES de erro, e a ordem só decide ALGUMA coisa aqui: `fetchState` (query-core) zera
+  // `error`/`status` ao iniciar um fetch APENAS quando `data === undefined` — sem dado, erro e
+  // pausa nunca coexistem; COM dado no cache o erro é preservado e os dois se sobrepõem. Nesse
+  // caso o motivo acionável é o atual: recarregar não resolve falta de sinal.
   const desatualizado: MotivoDesatualizado | null =
     !temDado ? null : pausado ? 'sem_rede' : error ? 'erro' : null;
 
@@ -101,7 +103,7 @@ export function MixGapCard() {
       : temDado
         ? (data.totalComGap > 0 ? 'com_gap' : 'zero')
         : pausado
-          ? 'aguardando_rede'
+          ? 'aguardando_rede'   // sem dado os dois ramos são exclusivos (ver `desatualizado`)
           : error
             ? 'erro'
             : null;

--- a/src/components/farmer/MixGapCard.tsx
+++ b/src/components/farmer/MixGapCard.tsx
@@ -100,7 +100,7 @@ export function MixGapCard() {
   const estado: EstadoMixGap | null =
     semAcesso || inerte || carregando
       ? null
-      : temDado
+      : data != null
         ? (data.totalComGap > 0 ? 'com_gap' : 'zero')
         : pausado
           ? 'aguardando_rede'   // sem dado os dois ramos são exclusivos (ver `desatualizado`)
@@ -120,10 +120,10 @@ export function MixGapCard() {
     trackedChave.current = chave;
     track('carteira.mixgap_visto', {
       estado,
-      total_com_gap: temDado ? data.totalComGap : null,
+      total_com_gap: data != null ? data.totalComGap : null,
       desatualizado,
     });
-  }, [estado, desatualizado, temDado, data]);
+  }, [estado, desatualizado, data]);
 
   if (semAcesso || inerte) return null;
 

--- a/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
+++ b/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
@@ -182,6 +182,10 @@ describe('MixGapCard — os três estados se separam', () => {
 afterEach(() => {
   // `onlineManager` é estado GLOBAL do react-query: deixar offline vazaria para os outros arquivos.
   onlineManager.setOnline(true);
+  // E o `spyOn(supabase)` do teste de CARREGANDO sobrevive ao teste que o criou: sem restaurar,
+  // os casos seguintes recebem a promise DAQUELE teste (já resolvida com sucesso) e ficam verdes
+  // sem nunca exercitar o ramo de erro — um mock vazado é gate que mente.
+  vi.restoreAllMocks();
 });
 
 describe('MixGapCard — offline é um estado, não ausência de acesso', () => {
@@ -231,6 +235,24 @@ describe('MixGapCard — offline é um estado, não ausência de acesso', () => 
     await waitFor(() => expect(eventosVistos()).toHaveLength(1));
   });
 
+  it('erro E DEPOIS queda de rede: a tela passa a falar de conexão, não de suporte', async () => {
+    resposta = { data: null, error: { message: 'timeout' } };
+    const { qc } = renderCard();
+    await screen.findByText(/Não consegui carregar as oportunidades/i);
+
+    onlineManager.setOnline(false);
+    await act(async () => { void qc.invalidateQueries({ queryKey: ['my-mixgap'] }); });
+
+    // O `error` anterior continua no cache e a query fica pausada ao mesmo tempo. Mandar o
+    // vendedor "avisar o suporte" quando o problema é o sinal do celular dele queima o canal de
+    // incidente — o motivo ATUAL é o acionável.
+    expect(await screen.findByText(/sem conexão/i)).toBeTruthy();
+    expect(screen.queryByText(/avise o suporte/i)).toBeNull();
+    await waitFor(() =>
+      expect(eventosVistos().map((e) => e.estado)).toEqual(['erro', 'aguardando_rede']),
+    );
+  });
+
   it('quando a rede VOLTA, o estado real sai DEPOIS do aguardando_rede, nesta ordem', async () => {
     onlineManager.setOnline(false);
     resposta = { data: COM_GAP, error: null };
@@ -262,8 +284,11 @@ describe('MixGapCard — dado bom no cache sobrevive à atualização que falha'
     resposta = { data: null, error: { message: 'timeout' } };
     await act(async () => { await qc.refetchQueries({ queryKey: ['my-mixgap'] }).catch(() => {}); });
 
+    // A lista não pode nem PISCAR para fora: já está na tela no repaint seguinte à falha...
     expect(screen.getByText('Marcenaria Alfa')).toBeTruthy();
-    expect(screen.getByText(/desatualizada/i)).toBeTruthy();
+    // ...e continua depois que o aviso de desatualização entra (o re-render do erro é assíncrono).
+    expect(await screen.findByText(/desatualizada/i)).toBeTruthy();
+    expect(screen.getByText('Marcenaria Alfa')).toBeTruthy();
     // A tela de erro TOTAL (a que troca a lista por um aviso) não deve aparecer aqui.
     expect(screen.queryByText(/Não consegui carregar as oportunidades/i)).toBeNull();
   });

--- a/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
+++ b/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, onlineManager } from '@tanstack/react-query';
 
 /**
  * Guard money-path — os três estados do MixGap não podem colapsar numa tela em branco só.
@@ -48,17 +48,26 @@ import { MixGapCard } from '../MixGapCard';
 
 function renderCard() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
-  return render(
-    <QueryClientProvider client={qc}>
-      <MixGapCard />
-    </QueryClientProvider>,
-  );
+  return {
+    qc,
+    ...render(
+      <QueryClientProvider client={qc}>
+        <MixGapCard />
+      </QueryClientProvider>,
+    ),
+  };
 }
 
-/** O evento de `carteira.mixgap_visto`, ou undefined se ele nunca saiu. */
+/** TODOS os `carteira.mixgap_visto`, na ordem — a ORDEM separa transição de re-emissão. */
+function eventosVistos(): Record<string, unknown>[] {
+  return track.mock.calls
+    .filter((c) => c[0] === 'carteira.mixgap_visto')
+    .map((c) => c[1] as Record<string, unknown>);
+}
+
+/** O PRIMEIRO evento de `carteira.mixgap_visto`, ou undefined se ele nunca saiu. */
 function eventoVisto(): Record<string, unknown> | undefined {
-  const c = track.mock.calls.find((c) => c[0] === 'carteira.mixgap_visto');
-  return c?.[1] as Record<string, unknown> | undefined;
+  return eventosVistos()[0];
 }
 
 const COM_GAP = {
@@ -153,5 +162,138 @@ describe('MixGapCard — os três estados se separam', () => {
     liberar({ data: COM_GAP, error: null });
     await waitFor(() => expect(eventoVisto()).toBeTruthy());
     expect(eventoVisto()).toMatchObject({ estado: 'com_gap' });
+  });
+});
+
+/**
+ * QUARTO estado — OFFLINE (revisão adversária retroativa do #1859, duas análises independentes).
+ *
+ * Com `networkMode:'online'` (default do QueryClient global, sem `persistQueryClient` no repo) e o
+ * navegador offline, a query fica `status:'pending'` / `fetchStatus:'paused'` / `data:undefined` /
+ * `error:null`. Em v5 `isLoading = isPending && isFetching` — pausada NÃO está fetching, logo
+ * `isLoading` é **false**. O predicado `!isLoading && !error && data === undefined` casava, e o card
+ * devolvia `null`: tela em branco e silêncio no PostHog, exatamente a classe que o #1859 corrigiu —
+ * agora pelo balde "não é staff". Num PWA de vendedor em campo isso não é hipotético.
+ *
+ * `data === null` só quer dizer "não é staff" DEPOIS de a query RESOLVER; `undefined` é pendente,
+ * pausado ou desabilitado — três coisas diferentes que o predicado antigo fundia numa só.
+ */
+
+afterEach(() => {
+  // `onlineManager` é estado GLOBAL do react-query: deixar offline vazaria para os outros arquivos.
+  onlineManager.setOnline(true);
+});
+
+describe('MixGapCard — offline é um estado, não ausência de acesso', () => {
+  it('OFFLINE sem cache: fica na tela dizendo que falta REDE — não some', async () => {
+    onlineManager.setOnline(false);
+    resposta = { data: COM_GAP, error: null }; // a RPC responderia; é a rede que não deixa sair
+    const { container } = renderCard();
+
+    expect(await screen.findByText(/sem conexão/i)).toBeTruthy();
+    expect(container.textContent).not.toBe('');
+    // A tela do erro de LEITURA é outra: confundir as duas manda o vendedor avisar o suporte
+    // por um problema que é do celular dele.
+    expect(screen.queryByText(/Não consegui carregar as oportunidades/i)).toBeNull();
+  });
+
+  it('OFFLINE emite evento PRÓPRIO com total null — nem silêncio, nem 0, nem "erro"', async () => {
+    onlineManager.setOnline(false);
+    resposta = { data: COM_GAP, error: null };
+    renderCard();
+
+    await waitFor(() => expect(eventoVisto()).toBeTruthy());
+    const ev = eventoVisto()!;
+    expect(ev.estado).toBe('aguardando_rede');
+    // §2 (ausente ≠ zero): não há número honesto a mandar quando a request nem saiu.
+    expect(ev.total_com_gap).toBeNull();
+    expect(ev.total_com_gap).not.toBe(0);
+    // Distinguível NA SÉRIE — é o que impede a contaminação do denominador de adoção, que se
+    // calcula sobre os estados com número honesto (`com_gap`/`zero`).
+    expect(ev.estado).not.toBe('erro');
+    expect(ev.estado).not.toBe('zero');
+    expect(ev.estado).not.toBe('com_gap');
+  });
+
+  it('OFFLINE e SEM ACESSO são desfechos DIFERENTES — o defeito os fundia', async () => {
+    resposta = { data: null, error: null };
+    const semAcesso = renderCard();
+    await waitFor(() => expect(semAcesso.container.textContent).toBe(''));
+    expect(eventosVistos()).toHaveLength(0);
+    semAcesso.unmount();
+    track.mockClear();
+
+    onlineManager.setOnline(false);
+    resposta = { data: COM_GAP, error: null };
+    const offline = renderCard();
+    await screen.findByText(/sem conexão/i);
+    expect(offline.container.textContent).not.toBe('');
+    await waitFor(() => expect(eventosVistos()).toHaveLength(1));
+  });
+
+  it('quando a rede VOLTA, o estado real sai DEPOIS do aguardando_rede, nesta ordem', async () => {
+    onlineManager.setOnline(false);
+    resposta = { data: COM_GAP, error: null };
+    renderCard();
+    await waitFor(() => expect(eventosVistos()).toHaveLength(1));
+
+    await act(async () => { onlineManager.setOnline(true); });
+
+    expect(await screen.findByText('Marcenaria Alfa')).toBeTruthy();
+    await waitFor(() => expect(eventosVistos()).toHaveLength(2));
+    expect(eventosVistos().map((e) => e.estado)).toEqual(['aguardando_rede', 'com_gap']);
+    expect(eventosVistos()[1].total_com_gap).toBe(2);
+  });
+});
+
+/**
+ * O erro tinha precedência sobre o dado STALE, e isso custava a lista inteira: com `com_gap` já na
+ * tela, um refetch que falha levava a `erro` e as oportunidades sumiam, embora o cache ainda as
+ * tivesse. Honesto para o sensor, regressão para quem está na rua. O desenho que serve aos dois é
+ * composto — lista PRESERVADA + aviso de que o número está velho — com o evento marcando o motivo,
+ * senão "vi a carteira fresca" e "agi sobre número velho" viram a mesma linha na série.
+ */
+describe('MixGapCard — dado bom no cache sobrevive à atualização que falha', () => {
+  it('refetch que FALHA não apaga a lista já na tela — avisa que está desatualizada', async () => {
+    resposta = { data: COM_GAP, error: null };
+    const { qc } = renderCard();
+    await screen.findByText('Marcenaria Alfa');
+
+    resposta = { data: null, error: { message: 'timeout' } };
+    await act(async () => { await qc.refetchQueries({ queryKey: ['my-mixgap'] }).catch(() => {}); });
+
+    expect(screen.getByText('Marcenaria Alfa')).toBeTruthy();
+    expect(screen.getByText(/desatualizada/i)).toBeTruthy();
+    // A tela de erro TOTAL (a que troca a lista por um aviso) não deve aparecer aqui.
+    expect(screen.queryByText(/Não consegui carregar as oportunidades/i)).toBeNull();
+  });
+
+  it('o evento separa o número FRESCO do número desatualizado', async () => {
+    resposta = { data: COM_GAP, error: null };
+    const { qc } = renderCard();
+    await screen.findByText('Marcenaria Alfa');
+    await waitFor(() => expect(eventosVistos()).toHaveLength(1));
+    expect(eventosVistos()[0]).toMatchObject({ estado: 'com_gap', total_com_gap: 2, desatualizado: null });
+
+    resposta = { data: null, error: { message: 'timeout' } };
+    await act(async () => { await qc.refetchQueries({ queryKey: ['my-mixgap'] }).catch(() => {}); });
+
+    await waitFor(() => expect(eventosVistos()).toHaveLength(2));
+    // Mesmo estado visível, motivo novo: a dedup por estado PURO engoliria esta transição, que é
+    // justamente o sinal de leitura falhando em campo.
+    expect(eventosVistos()[1]).toMatchObject({ estado: 'com_gap', total_com_gap: 2, desatualizado: 'erro' });
+  });
+
+  it('OFFLINE com dado no cache: mantém a lista e marca o motivo como falta de REDE', async () => {
+    resposta = { data: COM_GAP, error: null };
+    const { qc } = renderCard();
+    await screen.findByText('Marcenaria Alfa');
+
+    onlineManager.setOnline(false);
+    await act(async () => { void qc.invalidateQueries({ queryKey: ['my-mixgap'] }); });
+
+    expect(screen.getByText('Marcenaria Alfa')).toBeTruthy();
+    await waitFor(() => expect(eventosVistos()).toHaveLength(2));
+    expect(eventosVistos()[1]).toMatchObject({ estado: 'com_gap', desatualizado: 'sem_rede' });
   });
 });

--- a/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
+++ b/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
@@ -243,9 +243,11 @@ describe('MixGapCard — offline é um estado, não ausência de acesso', () => 
     onlineManager.setOnline(false);
     await act(async () => { void qc.invalidateQueries({ queryKey: ['my-mixgap'] }); });
 
-    // O `error` anterior continua no cache e a query fica pausada ao mesmo tempo. Mandar o
-    // vendedor "avisar o suporte" quando o problema é o sinal do celular dele queima o canal de
-    // incidente — o motivo ATUAL é o acionável.
+    // Sem dado no cache quem troca o estado é o próprio react-query: `fetchState` zera
+    // `error`/`status` ao (re)iniciar o fetch quando `data === undefined`. O que este caso fixa é
+    // o COMPORTAMENTO — mandar o vendedor "avisar o suporte" quando o problema é o sinal do
+    // celular dele queima o canal de incidente. A precedência de verdade se decide COM dado no
+    // cache, no caso abaixo.
     expect(await screen.findByText(/sem conexão/i)).toBeTruthy();
     expect(screen.queryByText(/avise o suporte/i)).toBeNull();
     await waitFor(() =>
@@ -307,6 +309,29 @@ describe('MixGapCard — dado bom no cache sobrevive à atualização que falha'
     // Mesmo estado visível, motivo novo: a dedup por estado PURO engoliria esta transição, que é
     // justamente o sinal de leitura falhando em campo.
     expect(eventosVistos()[1]).toMatchObject({ estado: 'com_gap', total_com_gap: 2, desatualizado: 'erro' });
+  });
+
+  it('com a LISTA no cache, erro e queda de rede COEXISTEM — vence o motivo ATUAL', async () => {
+    resposta = { data: COM_GAP, error: null };
+    const { qc } = renderCard();
+    await screen.findByText('Marcenaria Alfa');
+
+    // 1) refetch falha com o dado ainda no cache: aqui o `error` é PRESERVADO (`fetchState` só
+    //    zera `error`/`status` quando `data === undefined`).
+    resposta = { data: null, error: { message: 'timeout' } };
+    await act(async () => { await qc.refetchQueries({ queryKey: ['my-mixgap'] }).catch(() => {}); });
+    await waitFor(() => expect(eventosVistos()).toHaveLength(2));
+    expect(eventosVistos()[1]).toMatchObject({ desatualizado: 'erro' });
+
+    // 2) agora a rede cai: `status:'error'` e `fetchStatus:'paused'` ao MESMO tempo — o único
+    //    ponto do card em que a precedência decide algo. "Recarregue a página" seria conselho
+    //    inútil para quem está sem sinal.
+    onlineManager.setOnline(false);
+    await act(async () => { void qc.invalidateQueries({ queryKey: ['my-mixgap'] }); });
+
+    await waitFor(() => expect(eventosVistos()).toHaveLength(3));
+    expect(eventosVistos()[2]).toMatchObject({ estado: 'com_gap', desatualizado: 'sem_rede' });
+    expect(screen.getByText('Marcenaria Alfa')).toBeTruthy();
   });
 
   it('OFFLINE com dado no cache: mantém a lista e marca o motivo como falta de REDE', async () => {


### PR DESCRIPTION
Revisão adversária **retroativa** do #1859, levantada de forma independente por duas análises (Codex e a da casa) e registrada em `docs/historico/fase-sem-sinal.md`.

## O defeito

`MixGapCard` decidia "sem acesso" com `!isLoading && !error && data === undefined`. Com `networkMode:'online'` (default do QueryClient global, sem `persistQueryClient` no repo) e o navegador **offline**, a query fica `status:'pending'` / `fetchStatus:'paused'` / `data:undefined` / `error:null`. Em v5 `isLoading = isPending && isFetching` — pausada **não** está fetching ⇒ `isLoading` é `false`, o predicado casa e o card devolve `null`.

Ou seja: **o estado offline caía no balde "não é staff"** — tela em branco e silêncio no PostHog, exatamente a classe de defeito que o #1859 foi corrigir. Num PWA de vendedor em campo isso não é hipotético.

**Medido antes da correção** (vitest, `onlineManager.setOnline(false)`): tela `''` e **zero** eventos.

## O que muda

- **Discriminante por `fetchStatus`, não `isLoading`.** `data === undefined` é pendente, pausado **ou** desabilitado; só `data === null` é a RPC dizendo "sem acesso" — e só depois de a query resolver.
- **Quarto estado `aguardando_rede`**, com tela própria ("Sem conexão — não consegui consultar"), nunca o silêncio do sem-acesso nem o "avise o suporte" do erro de leitura.
- **Estado composto para dado stale.** O erro tinha precedência sobre o cache e a lista inteira sumia num refetch ruim. Agora a lista fica na tela + faixa de aviso, e o evento leva `desatualizado: 'erro' | 'sem_rede'`. A dedup passou a ser por `estado:motivo` — por estado puro engoliria a transição "número fresco" → "número velho", que é o sinal de leitura falhando em campo.

### Decisão: `aguardando_rede` EMITE evento (`total_com_gap: null`)

Não emitir recriaria o buraco que o #1859 fechou — "vendedor offline" viraria indistinguível de "vendedor nunca abriu". E emitir **não contamina o denominador de adoção**, porque o estado é explícito na série: adoção se calcula sobre os estados com número honesto (`com_gap`/`zero`), como já era preciso fazer com `erro`. O `total` vai `null`, nunca `0` (§2 — ausente ≠ zero). O que continua **mudo** é `semAcesso`: quem nunca poderia ver o card não pertence ao denominador.

## Prova

15/15 verdes (6 do #1859 + 9 novos). Falsificação de cada assert novo:

| Sabotagem | Vermelhos | Previsto |
|---|---|---|
| remove o ramo `aguardando_rede` | 5 (todo o bloco offline) | ✅ |
| `total_com_gap: 0` no lugar de `null` | 2 (o assert §2, erro + offline) | ✅ |
| `desatualizado` sempre `null` | 3 (bloco do cache stale) | ✅ |
| inverte precedência `pausado`/`error` **sem** dado | **0 — verde** | ❌ → virou achado |
| inverte precedência **com** dado no cache | 1 (o teste da precedência) | ✅ |

**A sabotagem verde foi o achado mais útil.** Não era teste fraco: eu tinha descrito o mecanismo errado. `fetchState` (`query-core/src/query.ts:674`) zera `error`/`status` ao iniciar um fetch **apenas quando `data === undefined`** ⇒ sem dado, erro e pausa **nunca coexistem** (a ordem ali é inócua); só **com** dado no cache eles se sobrepõem, que é onde a precedência decide algo. O comentário do código afirmava um conflito inexistente e o teste passava por não discriminar nada. Corrigi o comentário e escrevi o teste que mede a precedência de verdade — aí a sabotagem fica vermelha.

⇒ **sabotagem que não fica vermelha é achado, não aprovação.** Registrado em `docs/historico/fase-sem-sinal.md`.

## Relação com o #1886 (complementar, não redundante)

O #1886 varre e gateia a **classe** (`estadoDeLeitura` canônico em `src/lib/leitura/`, gate `erro-colapsado-em-vazio`, DataHealthBanner/CarteiraSaudePanel/AlertasStack) e **já corrige o achado do host** — o `{positivacao && <MixGapCard/>}` de `FarmerCalls.tsx:436`, com teste próprio. Ele **não toca** `MixGapCard.tsx`: o quarto estado dentro do card e o estado composto do dado stale são o diferencial deste PR. O gate dele espera contagem `0` para o MixGapCard pós-#1859 (lê `error`), e este PR continua lendo `error` **e** `fetchStatus`.

Se o #1886 entrar primeiro, o passo natural em seguida é este card consumir `estadoDeLeitura()` em vez de derivar inline — com a ressalva de que o helper mapeia `success` para `'pronta'` e por isso ainda não modela "pronta **porém** desatualizada", que é o estado composto introduzido aqui.

A nota no histórico foi movida para o fim do arquivo de propósito: o #1886 insere no mesmo hunk.

## Validação

`typecheck` 0 · `bun run test` 15/15 · `lint` 0 errors (75 warnings pré-existentes, nenhum no arquivo tocado).
