### PR TITLE
perf(modulos): o gate do manifesto recompilava 1,9M regex — 40s contra o timeout de 20s

### DIFF
--- a/src/lib/modulos/__tests__/padrao.test.ts
+++ b/src/lib/modulos/__tests__/padrao.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { casaPadrao } from "../padrao";
+import { casaPadrao, padraoParaRegex } from "../padrao";
 
 describe("casaPadrao — gramática restrita de globs do manifesto", () => {
   it("dir/** casa qualquer profundidade sob o dir", () => {
@@ -28,5 +28,32 @@ describe("casaPadrao — gramática restrita de globs do manifesto", () => {
 
   it("escapa caracteres de regex no padrão (. não vira curinga)", () => {
     expect(casaPadrao("src/lib/a.ts", "src/lib/aXts")).toBe(false);
+  });
+});
+
+describe("casaPadrao — compilação memoizada (o mesmo padrão não recompila)", () => {
+  it("devolve a MESMA instância de RegExp para o mesmo padrão", () => {
+    // Sem memoização o gate do manifesto recompila ~1,9M regex (26,64us cada = ~40s)
+    // e estoura o testTimeout de 20s. O regex é função pura da string do padrão.
+    expect(padraoParaRegex("src/lib/a/**")).toBe(padraoParaRegex("src/lib/a/**"));
+  });
+
+  it("padrões diferentes NÃO compartilham instância (a chave do cache é o padrão)", () => {
+    expect(padraoParaRegex("src/lib/a/**")).not.toBe(padraoParaRegex("src/lib/b/**"));
+  });
+
+  it("chaves que colidem com Object.prototype não envenenam o cache", () => {
+    expect(padraoParaRegex("constructor")).not.toBe(padraoParaRegex("__proto__"));
+    expect(casaPadrao("constructor", "constructor")).toBe(true);
+    expect(casaPadrao("__proto__", "constructor")).toBe(false);
+  });
+
+  it("regex reusado é STATELESS: chamadas repetidas dão o mesmo resultado", () => {
+    // Sentinela: se algum dia padraoParaRegex ganhar flag /g ou /y, o lastIndex
+    // compartilhado pelo cache faria o resultado alternar entre chamadas.
+    const p = "src/pages/Financeiro*.tsx";
+    const alvo = "src/pages/FinanceiroDashboard.tsx";
+    expect([casaPadrao(p, alvo), casaPadrao(p, alvo), casaPadrao(p, alvo)]).toEqual([true, true, true]);
+    expect(padraoParaRegex(p).lastIndex).toBe(0);
   });
 });

--- a/src/lib/modulos/padrao.ts
+++ b/src/lib/modulos/padrao.ts
@@ -2,13 +2,35 @@
 // Gramática: "dir/**" (tudo sob dir) · "*" (wildcard num segmento, não atravessa "/") · caminho exato.
 const escapaRegex = (s: string) => s.replace(/[.+?^${}()|[\]\\]/g, "\\$&");
 
-function padraoParaRegex(padrao: string): RegExp {
+function compilar(padrao: string): RegExp {
   if (padrao.endsWith("/**")) {
     const base = escapaRegex(padrao.slice(0, -3));
     return new RegExp(`^${base}/.+$`);
   }
   const corpo = padrao.split("*").map(escapaRegex).join("[^/]*");
   return new RegExp(`^${corpo}$`);
+}
+
+// O regex é função PURA da string do padrão, e o gate do manifesto avalia ~1,9M pares
+// (padrão × arquivo) sobre apenas ~580 padrões distintos. Compilar a cada chamada custa
+// 26,64us contra 0,163us de um RegExp pronto (163x) — os ~40s que estouravam o
+// testTimeout de 20s do gate eram compilação repetida, não o casamento em si.
+//
+// Map (não objeto literal): padrões como "constructor"/"__proto__" colidiriam com
+// Object.prototype e envenenariam o cache.
+//
+// Reusar a instância é seguro porque compilar() nunca emite flag /g nem /y — .test()
+// de regex sem flag global não guarda lastIndex entre chamadas. Ao adicionar flag aqui,
+// o cache passa a compartilhar estado: ver o teste-sentinela em __tests__/padrao.test.ts.
+const memo = new Map<string, RegExp>();
+
+export function padraoParaRegex(padrao: string): RegExp {
+  let re = memo.get(padrao);
+  if (re === undefined) {
+    re = compilar(padrao);
+    memo.set(padrao, re);
+  }
+  return re;
 }
 
 export function casaPadrao(padrao: string, caminho: string): boolean {


### PR DESCRIPTION
## O sintoma

`src/lib/modulos/__tests__/manifesto.gate.test.ts` falhava com **"Test timed out in 20000ms"** — não por asserção. O manifesto estava íntegro (`problemas=0`). Vermelho LOCAL que não é regressão, e custava uma investigação cada vez que aparecia.

## A causa raiz (medida, não suposta)

`casaPadrao` chamava `padraoParaRegex` → `new RegExp` em **toda** chamada, embora o regex seja função pura da string do padrão. O gate avalia **1.877.438 pares** (padrão × arquivo) sobre apenas **579 padrões distintos**.

| | antes | depois |
|---|---|---|
| `validarManifesto` | **39.675ms** | **766ms** |
| fase órfão/sobreposição | 59.269ms | 518ms |
| fase glob-morto | 20.638ms | 608ms |
| custo/chamada de `casaPadrao` | 26,64us | 0,04us |
| chamadas de `casaPadrao` | 1.877.438 | **1.877.438** |

Regex já compilado custa 0,163us contra 26,64us compilando — **163x era compilação**, não casamento. A contagem de chamadas **não muda**: mudou o custo unitário, não o algoritmo.

Descartado por medição: **não** é O(n²) em `NAO_CLASSIFICADOS` — essa lista está vazia (fase 3 = 11ms).

## O gate continua fazendo o que existe para fazer

Falsificado **em disco**, ponta a ponta com `listarArquivosSrc()` lendo o filesystem:

| sabotagem | resultado |
|---|---|
| baseline limpo | verde, 0 problemas |
| arquivo órfão real plantado em `src/` | **vermelho** `[orfao] src/__falsificacao_orfao__.ts` |
| glob morto real no manifesto | **vermelho** `[glob-morto] loja-afiacao: src/lib/__zumbi_plantado_em_disco__/**` |
| restaurado | verde de novo |

Mais 4 sabotagens em memória (órfão, glob morto, sobreposição, não-classificado stale) — todas acusadas.

## Escolhas de projeto

- **`Map`, não objeto literal**: padrões como `constructor`/`__proto__` envenenariam o protótipo. Há teste para isso.
- **Teste-sentinela de idempotência**: reusar a instância só é seguro porque `compilar()` não emite flag `/g` nem `/y`. Se alguém adicionar uma, o `lastIndex` passa a vazar entre chamadas pelo regex compartilhado — o teste trava isso agora.
- **Nada de teste por tempo de relógio**: um `expect(dt).toBeLessThan(X)` seria justamente o que volta a quebrar sob carga. O teste trava a propriedade determinística (mesma instância reusada).
- **Timeout NÃO alterado**: o gate fecha em 748ms contra os 20s configurados. Subir o timeout esconderia o gargalo em vez de resolvê-lo.

## Validação

```
TYPECHECK_EXIT=0   VITEST_EXIT=0   LINT_EXIT=0
✓ manifesto.gate.test.ts (2 tests) 750ms   ← estourava 20s
Test Files  9 passed (9) · Tests  71 passed (71)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)