### PR TITLE
refactor(audit): extrator de migrations usava stripper LOCAL — DDL comentada em bloco entrava no inventário

### DIFF
--- a/docs/historico/gates-textuais-cegos.md
+++ b/docs/historico/gates-textuais-cegos.md
@@ -199,10 +199,39 @@ fora dessas 8 é reincidência da classe.
 O eixo `--` (SQL) tem assinatura própria — casa quem limpa comentário de SQL sem gramática:
 
 ```bash
-rg -n "replace\(/--\[\^" src/ supabase/ scripts/ db/
+rg -n "replace\(/--" src/ supabase/ scripts/ db/
 ```
 
 Quem lê SQL deve importar `removerComentariosSql` de `scripts/lib/sql-comentarios.ts`.
+
+### O `[^` da assinatura era um furo (2026-08-22)
+
+A assinatura acima era `replace\(/--\[\^` até esta data, e o `[^` **estreitava demais**: casava a
+forma `--[^\n]*` e era cega à equivalente `--.*$` (com `/m`). Resultado — `extractObjects` de
+`scripts/lib/migration-objects.ts`, o **2º consumidor** do eixo (alimenta `bun run audit:migrations`
+e o `wt-preflight-migration`), atravessou a varredura de 2026-08-20 intacto, com
+`sql.replace(/--.*$/gm, '')`. Foi achado por LEITURA, não pela varredura: assinatura estreita demais
+devolve **ausência de dado**, não ausência de sítio — e devolve verde. A forma acima casa as duas.
+
+Neste sítio a classe mordia nos **dois** sentidos, não só no de sempre:
+
+| sentido | mecanismo | efeito no audit |
+| --- | --- | --- |
+| objeto **some** | `--` dentro de literal/identificador citado come até o fim da linha | a DDL seguinte não vira objeto → **ausência** (o pior modo de falha de um audit) |
+| objeto **é inventado** | comentário de BLOCO não era removido | DDL comentada para rollback entra como objeto esperado → **vermelho eterno** (o banco nunca vai tê-la) |
+
+Trocado com a mesma prova de neutralidade que barateou a adoção anterior: **1671 objetos em 483
+migrations custom antes e depois — zero somem, zero surgem** — e `bun run audit:migrations`
+regenerado dá **diff vazio** nos dois artefatos (2ª medição, pelo pipeline real). Exposição ativa
+hoje: **zero** `CREATE POLICY` dentro de bloco no corpus ⇒ é endurecimento, não correção de falha
+em produção. Casos em `scripts/lib/migration-objects.test.ts`, falsificados nos dois eixos (voltar
+ao stripper local ⇒ 3 vermelhos; stripper no-op ⇒ o guarda de comentário de linha também cai).
+
+Re-medido no HEAD pós-troca, a assinatura ampliada devolve **4**, e a classificação é a de sempre:
+3 legítimas (`scripts/lib/sql-comentarios.ts:5` e `scripts/lib/migration-objects.ts:88` citam a
+forma ANTIGA no cabeçalho para explicá-la; `scripts/sql-comentarios.test.ts:9` é o controle
+deliberado) + **1 uso ATIVO**, o `import-tint-formulas-aposentada-gate.test.ts` já aberto acima.
+
 
 ## Variante 3 — o comentário prometia o stripper; o código não tinha nenhum (2026-08-22)
 

--- a/scripts/lib/migration-objects.test.ts
+++ b/scripts/lib/migration-objects.test.ts
@@ -129,6 +129,37 @@ describe('extractObjects — DDL dinâmica não vira objeto esperado', () => {
   });
 });
 
+describe('extractObjects — comentário é o do POSTGRES, não `--` até o fim da linha', () => {
+  it('DDL dentro de bloco /* */ NÃO vira objeto (o inventário diz o que a migration CRIA)', () => {
+    const sql = [
+      `/* rollback da tentativa anterior — não aplicar:`,
+      `CREATE POLICY "desativada" ON public.t FOR SELECT USING (true);`,
+      `*/`,
+      `CREATE POLICY "ativa" ON public.u FOR SELECT USING (true);`,
+    ].join('\n');
+    expect(policies(sql).map((p) => p.name)).toEqual(['ativa']);
+  });
+
+  it('`--` dentro de LITERAL não trunca a DDL seguinte da mesma linha', () => {
+    const sql = `CREATE POLICY "filtra marcador" ON public.t FOR SELECT USING (obs = 'a -- b'); CREATE POLICY "sobrevivente" ON public.u FOR SELECT USING (true);`;
+    expect(policies(sql).map((p) => p.name)).toEqual(['filtra marcador', 'sobrevivente']);
+  });
+
+  it('`--` dentro do NOME CITADO não engole a própria DDL', () => {
+    const sql = `CREATE POLICY "Staff le -- log" ON public.t FOR SELECT USING (true);`;
+    expect(policies(sql)).toEqual([
+      { kind: 'rls_policy', schema: 'public', name: 'Staff le -- log', parent: 't' },
+    ]);
+  });
+
+  it('comentário de LINHA de verdade segue fora do inventário (regressão)', () => {
+    const sql = [
+      `-- CREATE POLICY "comentada" ON public.t FOR SELECT USING (true);`,
+      `CREATE POLICY "ativa" ON public.u FOR SELECT USING (true);`,
+    ].join('\n');
+    expect(policies(sql).map((p) => p.name)).toEqual(['ativa']);
+  });
+});
 describe('corpus real — nenhuma CREATE POLICY custom fica fora do inventário', () => {
   const DIR = join(process.cwd(), 'supabase', 'migrations');
   const UUID = /_[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\.sql$/;

--- a/scripts/lib/migration-objects.ts
+++ b/scripts/lib/migration-objects.ts
@@ -9,6 +9,7 @@
  * Heurístico (regex), não parser SQL completo — cobre os patterns do projeto. Acréscimos
  * sobre o extractObjects original (pedidos pelo Codex):
  *  - `view`  — o audit não detectava CREATE [OR REPLACE] [MATERIALIZED] VIEW (views v_grupo_*).
+ *  - limpeza de comentário pelo stripper COMPARTILHADO `sql-comentarios.ts` — ver extractObjects.
  *  - assinatura de função — identidade PG = nome + tipos de arg; sem isso, overloads colidiriam
  *    falsamente (foo(int) vs foo(text)).
  *
@@ -16,6 +17,8 @@
  * grants, nem SQL dinâmico; a assinatura é a lista de args normalizada (renomear param muda a
  * chave). O preflight degrada para "não detectado", nunca fabrica colisão.
  */
+
+import { removerComentariosSql } from './sql-comentarios';
 
 export type ObjectKind = 'table' | 'index' | 'function' | 'trigger' | 'cron_job' | 'enum_value' | 'rls_policy' | 'view';
 
@@ -79,10 +82,20 @@ export function normalizeSignature(argsRaw: string): string {
 }
 
 /**
- * Extrai os objetos criados por uma migration. Ignora comentários de linha (`-- ...`).
+ * Extrai os objetos criados por uma migration.
+ *
+ * A limpeza de comentário é a COMPARTILHADA (`removerComentariosSql`), que entende a gramática do
+ * Postgres. O `sql.replace(/--.*$/gm, '')` que morava aqui errava nos dois sentidos — a classe de
+ * `docs/historico/gates-textuais-cegos.md`, aqui no eixo SQL:
+ *  - comia de um `--` DENTRO de literal ou de identificador citado até o fim da linha, e a DDL
+ *    seguinte sumia do inventário (ausência, o pior modo de falha de um audit);
+ *  - não removia comentário de BLOCO, então DDL comentada para rollback entrava como objeto
+ *    esperado — vermelho eterno, porque o banco nunca vai tê-la.
+ * Medido no corpus de 483 migrations custom ao trocar: delta ZERO (1671 objetos antes e depois).
+ * É endurecimento, não correção de falha ativa. Casos em migration-objects.test.ts.
  */
 export function extractObjects(sql: string): ExtractedObject[] {
-  const stripped = sql.replace(/--.*$/gm, '');
+  const stripped = removerComentariosSql(sql);
   const objects: ExtractedObject[] = [];
 
   // CREATE [OR REPLACE] FUNCTION [schema.]name(args) — captura args via parênteses balanceados


### PR DESCRIPTION
## O que muda

`extractObjects` (`scripts/lib/migration-objects.ts`) — o extrator que alimenta `bun run audit:migrations` e o `wt-preflight-migration` — limpava comentário com um stripper **local**:

```ts
const stripped = sql.replace(/--.*$/gm, '');
```

Passa a usar o **compartilhado** `removerComentariosSql` (`scripts/lib/sql-comentarios.ts`), que entende literal, `E'…'`, identificador citado, dollar-quote e aninhamento de bloco.

É a classe registrada em `docs/historico/gates-textuais-cegos.md`, e aqui ela mordia nos **dois** sentidos:

| sentido | mecanismo | efeito no audit |
| --- | --- | --- |
| objeto **some** | `--` dentro de literal/identificador citado come até o fim da linha | a DDL seguinte não vira objeto → **ausência** (o pior modo de falha de um audit) |
| objeto **é inventado** | comentário de BLOCO não era removido | DDL comentada para rollback entra como objeto esperado → **vermelho eterno** |

## Isto é endurecimento, não correção de falha ativa

O risco real da troca é o **inverso** do intuitivo: o stripper compartilhado remove *mais*, então objeto hoje inventariado poderia sumir. Medido nos dois sentidos, antes de trocar:

- **483 migrations custom · 1671 objetos antes · 1671 depois · 0 somem · 0 surgem**
- 2ª medição independente, pelo pipeline real: `bun run audit:migrations` regenerado dá **diff vazio** nos dois artefatos (`scripts/audit-custom-migrations.sql`, `docs/migrations-audit.md`) — por isso eles **não** estão neste PR
- Exposição hoje: **zero** `CREATE POLICY` dentro de bloco no corpus

## Teste (4 casos novos) e falsificação

Casos novos em `migration-objects.test.ts`: bloco não vira objeto · `--` em literal não trunca a DDL seguinte · `--` no nome citado não engole a própria DDL · comentário de linha segue fora (regressão).

Vermelho **observado**, não presumido, nos dois eixos:

| sabotagem | resultado |
| --- | --- |
| volta ao stripper local `sql.replace(/--.*$/gm, '')` | **3 failed \| 15 passed** — os 3 casos comportamentais |
| stripper no-op (`stripped = sql`) | **2 failed \| 16 passed** — cai também o guarda de comentário de linha, que é o que impede a troca de virar no-op |

## Achado extra — a assinatura de varredura tinha um furo

A varredura de 2026-08-20 fechou o eixo `--` no gate de authz e publicou `rg -n "replace\(/--\[\^"`. O `[^` **estreitava demais**: casa `--[^\n]*` e é cega à equivalente `--.*$`. Foi por isso que este 2º consumidor atravessou intacto — achado por leitura, não pela varredura. Provado contra o blob (`HEAD~1` não casa a assinatura documentada; casa a ampliada). Assinatura corrigida para `rg -n "replace\(/--"` e o sítio registrado.

**Assinatura estreita demais devolve ausência de DADO, não ausência de sítio — e devolve verde.**

## Verificação

`vitest` (arquivo alvo) · `scripts:typecheck` · `eslint` · `bun scripts/test-migration-objects.ts` · `docs:citacoes` · `docs:indice` · `docs:links` · `claude:size` — todos `exit 0`. A suíte completa é a do CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
