### PR TITLE
fix(tooling): o log do audit dizia "bytes" medindo UTF-16 — 2KB de divergência contra o ls virava caça a regressão fantasma

### DIFF
--- a/scripts/audit-custom-migrations.ts
+++ b/scripts/audit-custom-migrations.ts
@@ -329,6 +329,25 @@ function emitMarkdown(audits: MigrationAudit[]): string {
   return lines.join('\n');
 }
 
+/**
+ * Bytes UTF-8 reais de `conteudo` — a unidade que `ls -la`, `wc -c` e o git usam.
+ *
+ * NÃO trocar por `String.length`: ela conta unidades UTF-16, e os dois artefatos são pt-BR
+ * acentuado com alguns emoji (astral ⇒ 2 unidades cada). Medido em 2026-08-22, o `.length`
+ * subcontava o `.sql` em 194 bytes e o `.md` em 2.023.
+ *
+ * Por que importa (custo real, não estético): validar uma mudança no extrator é rodar
+ * `bun run audit:migrations` e comparar o resultado com o commitado. Quem confere o número
+ * deste log contra o `ls -la` conclui que o arquivo MUDOU e sai caçando uma regressão que não
+ * existe — aconteceu ao entregar o #1894 e custou um ciclo de apuração até o `git diff` (vazio)
+ * desempatar.
+ *
+ * Casa com o `writeFileSync(…, conteudo)` logo abaixo, que grava em utf8 por default.
+ */
+function bytesUtf8(conteudo: string): number {
+  return Buffer.byteLength(conteudo, 'utf8');
+}
+
 function main() {
   if (!existsSync(MIGRATIONS_DIR)) {
     console.error(`Migrations dir não encontrado: ${MIGRATIONS_DIR}`);
@@ -344,11 +363,11 @@ function main() {
 
   const sql = emitSql(audits);
   writeFileSync(SQL_OUT, sql);
-  console.log(`✓ Escrito ${SQL_OUT} (${sql.length} bytes)`);
+  console.log(`✓ Escrito ${SQL_OUT} (${bytesUtf8(sql)} bytes)`);
 
   const md = emitMarkdown(audits);
   writeFileSync(MD_OUT, md);
-  console.log(`✓ Escrito ${MD_OUT} (${md.length} bytes)`);
+  console.log(`✓ Escrito ${MD_OUT} (${bytesUtf8(md)} bytes)`);
 
   const totalObjects = audits.reduce((sum, a) => sum + a.objects.length, 0);
   console.log(`\nResumo: ${audits.length} migrations, ${totalObjects} objetos esperados.`);


### PR DESCRIPTION
## O bug

`scripts/audit-custom-migrations.ts` reportava o tamanho dos artefatos que gera com `String.length`, sob o rótulo **"bytes"**. `String.length` conta **unidades UTF-16**, não bytes. Os dois artefatos são pt-BR acentuado com alguns emoji (astral ⇒ 2 unidades cada), então os números divergiam do arquivo real.

Medido em 2026-08-22, com o corpus de hoje (484 custom migrations):

| arquivo | log (`.length`) | bytes reais (`ls`/`wc -c`) | delta |
|---|---|---|---|
| `scripts/audit-custom-migrations.sql` | 366053 | **366247** | 194 |
| `docs/migrations-audit.md` | 163532 | **165555** | 2023 |

## Por que importa (custo real, não estético)

O fluxo canônico de validar uma mudança no extrator é rodar `bun run audit:migrations` e comparar o resultado com o commitado. Quem confere o número do log contra `ls -la` vê dois números diferentes, conclui que **o arquivo mudou**, e sai investigando uma regressão que não existe.

Não é hipotético: aconteceu ao entregar o #1894 e custou um ciclo inteiro de apuração, até o `git diff` (vazio) desempatar.

## A escolha: bytes de verdade, não "caracteres"

Havia duas saídas honestas — trocar o rótulo para "caracteres" (mínima) ou medir bytes de verdade. Escolhida a segunda (`Buffer.byteLength(s, 'utf8')`), porque **o valor do número é poder ser comparado com o filesystem**. "Caracteres" recuperaria a honestidade e perderia a utilidade: o leitor continuaria sem o número que `ls`/`git` falam, que é justamente o que o fluxo acima precisa.

Extraído como `bytesUtf8()` em vez de inline nas duas linhas para que o comentário do *porquê* fique colado nas duas chamadas — sem ele, a próxima cópia repete o bug ou alguém "simplifica" de volta para `.length`.

`Buffer.byteLength(…, 'utf8')` casa com o `writeFileSync(…, conteudo)` logo abaixo, que grava em utf8 por default.

## Validação

1. **A asserção que interessa** — número do log × filesystem, comparado programaticamente (não a olho):

   ```
   OK  scripts/audit-custom-migrations.sql: log=366247 fs=366247 delta=0
   OK  docs/migrations-audit.md:            log=165555 fs=165555 delta=0
   VERDE: log casa com o filesystem                                  exit=0
   ```

2. **Falsificação** — o mesmo comparador contra o log do estado ANTERIOR fica vermelho, então ele tem poder de reprovar (não é teatro):

   ```
   DIVERGE scripts/audit-custom-migrations.sql: log=366053 fs=366247 delta=194
   DIVERGE docs/migrations-audit.md:            log=163532 fs=165555 delta=2023
   VERMELHO: 2 divergência(s)                                        exit=1
   ```

3. **Artefatos byte-idênticos** — `scripts/audit-custom-migrations.sql` e `docs/migrations-audit.md` são ímã de conflito sob auto-merge (`docs/agent/database.md` §2). Depois de rodar o script, `git status --short` traz **só o `.ts`**; `git diff --stat` dos dois artefatos é vazio. O diff deste PR tem **1 arquivo**.

4. **Gates**, com evidência positiva de que rodaram (não só ausência de erro):

   ```
   bunx eslint scripts/audit-custom-migrations.ts        → exit 0, sem achados

   heavy bash -c 'bun run scripts:typecheck; echo "TSC_EXIT=$?"'
   heavy: ► rodando (slot-1/1)                            ← pegou o slot
   $ tsc --noEmit -p tsconfig.scripts.json                ← invocou de verdade
   TSC_EXIT=0                                             ← marcador DENTRO do slot
   ```

   O marcador está dentro do slot de propósito: o `heavy` é wrapper e devolve exit próprio (7ª armadilha, #1895). Nas duas primeiras tentativas ele foi morto **na fila** (`Terminated: 15`, `TSC_EXIT` ausente) — tratado como falta de dado e re-rodado, não como reprovação.

## Escopo deixado de fora, de propósito

- **Teste automatizado da regra.** Travar a regressão exigiria exportar `bytesUtf8` (hoje `main()` não é exportado) só para um teste que, no fundo, exercitaria `Buffer.byteLength`. O comentário no lugar do uso carrega a lição a custo menor. Se preferir o sensor, é um PR próprio.
- **`supabase/functions/_shared/*_test.ts`** têm dois `${fonte.length} bytes` com o mesmo rótulo impreciso (mensagem de erro de sanidade "arquivo errado?"). Lá o número é ordem de grandeza, não valor comparável com `ls` — não custou ciclo a ninguém e mexer em edge tem 3 gates próprios. Fora do escopo deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
