### PR TITLE
fix(recommend): o denominador de `sim` contava quem NÃO é mensurável [money-path]

### DIFF
--- a/db/falsifica-gate-denominador.ts
+++ b/db/falsifica-gate-denominador.ts
@@ -1,0 +1,37 @@
+import { removerComentarios } from "../src/lib/gates/limpeza-fonte";
+import { readFileSync } from "node:fs";
+
+const real = readFileSync(new URL("../supabase/functions/recommend/index.ts", import.meta.url), "utf8");
+// As TRÊS asserções do gate, copiadas VERBATIM de edge-money-path-invariants.test.ts
+const PIN   = /clusterSize\s*=\s*Math\.max\(\s*observados\s*\?\?\s*0\s*,\s*1\s*\)/;
+const VETO  = /clusterSize\s*=\s*Math\.max\(\s*denominador\s*,/;
+const VETO2 = /clusterSize\s*=\s*Math\.max\(\s*(clusterUserIds|usuariosAmostrados)\.length/;
+
+function avalia(fonte: string) {
+  const limpo = removerComentarios(fonte);
+  return { pin: PIN.test(limpo), veto: VETO.test(limpo), veto2: VETO2.test(limpo) };
+}
+const ok = (b: boolean) => (b ? "SIM" : "nao");
+
+// 1) COMO ESTÁ: o gate tem de aprovar
+const a = avalia(real);
+console.log(`REAL       pin=${ok(a.pin)} vetoPop=${ok(a.veto)} vetoAmostra=${ok(a.veto2)}`);
+
+// 2) SABOTAGEM 1 (em MEMÓRIA): volta para a população
+const sab1 = real.replace("Math.max(observados ?? 0, 1)", "Math.max(denominador, 1)");
+if (sab1 === real) { console.log("ERRO: sabotagem 1 nao aplicou — o teste seria teatro"); process.exit(9); }
+const b = avalia(sab1);
+console.log(`SABOTADO-1 pin=${ok(b.pin)} vetoPop=${ok(b.veto)} vetoAmostra=${ok(b.veto2)}`);
+
+// 3) SABOTAGEM 2: volta para amostra local
+const sab2 = real.replace("Math.max(observados ?? 0, 1)", "Math.max(usuariosAmostrados.length, 1)");
+if (sab2 === real) { console.log("ERRO: sabotagem 2 nao aplicou"); process.exit(9); }
+const c = avalia(sab2);
+console.log(`SABOTADO-2 pin=${ok(c.pin)} vetoPop=${ok(c.veto)} vetoAmostra=${ok(c.veto2)}`);
+
+// VEREDITO: o gate so tem dente se APROVA o real e REPROVA as duas sabotagens
+const passaReal = a.pin && !a.veto && !a.veto2;
+const pegaSab1  = !b.pin || b.veto;
+const pegaSab2  = !c.pin || c.veto2;
+console.log(`\nVEREDITO aprovaReal=${ok(passaReal)} pegaSabotagem1=${ok(pegaSab1)} pegaSabotagem2=${ok(pegaSab2)}`);
+process.exit(passaReal && pegaSab1 && pegaSab2 ? 0 : 1);

--- a/db/recommend-denominador-observados.sql
+++ b/db/recommend-denominador-observados.sql
@@ -1,0 +1,101 @@
+-- Denominador de `sim`: POPULAÇÃO ELEGÍVEL (antes) × OBSERVADOS (depois).
+--
+-- READ-ONLY. `~/.config/afiacao/psql-ro -f db/recommend-denominador-observados.sql`.
+--
+-- POR QUE ESTE ARQUIVO EXISTE. A entrega do `recommend_cluster_agregado` tirou o zero fabricado
+-- do NUMERADOR (o teto de 1.000 linhas de `order_items` apagava clientes reais) e deixou um no
+-- DENOMINADOR. A justificativa escrita na época era: "a leitura é exaustiva, então cliente sem par
+-- é fato observado — li o histórico inteiro dele e o produto X não está lá". Q1 mede que não era.
+--
+-- MEDIDO 2026-08-22 (prod, ref fzvklzpomgnyikkfkzai):
+--   Q1: sem_par=146 · tem_order_items=146 · sobrevive_universo=146 · zero_linhas_de_todo=0
+--       ⇒ os 146 TÊM compra e pedido válido; quem os elimina é SÓ `omie_products.ativo`.
+--   Q2: cluster | pop | obs | só SKU inativo | simmax pop | simmax obs | >0,10 pop | >0,10 obs
+--       critico |  780 | 634 |    146 (18,7%) |      0,096 |      0,118 |         0 |         2
+--       atencao |  347 | 333 |     14  (4,0%) |      0,213 |      0,222 |        12 |        15
+--       estavel |  100 | 100 |              0 |      0,430 |      0,430 |       128 |       128
+--   Q3 (a CONTRA-medição, que rebaixou de [P1] a [P2] e é parte do achado):
+--       146 clientes · 427 linhas · média 2,9 · mediana 2 · 38% com UMA linha só.
+--       ⇒ para quase todo produto eles seriam um "não comprou" legítimo de qualquer forma.
+--          Sem este número, "18,7% do denominador é estrutura" soa catastrófico e não é.
+--
+-- O viés NÃO é neutro: correlaciona com o eixo do próprio cluster (quem parou de comprar comprava
+-- o que hoje está descontinuado), por isso morde `critico` (18,7%) e não morde `estavel` (0).
+\pset pager off
+
+\echo == Q1. Os 146 de critico sem par: o que eles TEM? ==
+WITH eleg AS (
+  SELECT customer_user_id FROM farmer_client_scores
+  WHERE health_class='critico' AND sales_history_status IN ('ativo','stale')
+),
+compar AS (
+  SELECT DISTINCT i.customer_user_id FROM order_items i
+  JOIN sales_orders so ON so.id=i.sales_order_id JOIN omie_products o ON o.id=i.product_id
+  WHERE so.status NOT IN ('cancelado','rascunho','pendente','orcamento')
+    AND so.deleted_at IS NULL AND o.ativo
+),
+sem_par AS (SELECT customer_user_id FROM eleg EXCEPT SELECT customer_user_id FROM compar)
+SELECT
+  (SELECT count(*) FROM sem_par) AS sem_par,
+  (SELECT count(*) FROM sem_par s WHERE EXISTS (
+     SELECT 1 FROM order_items i WHERE i.customer_user_id=s.customer_user_id)) AS tem_order_items,
+  (SELECT count(*) FROM sem_par s WHERE EXISTS (
+     SELECT 1 FROM order_items i JOIN sales_orders so ON so.id=i.sales_order_id
+     WHERE i.customer_user_id=s.customer_user_id
+       AND so.status NOT IN ('cancelado','rascunho','pendente','orcamento')
+       AND so.deleted_at IS NULL)) AS sobrevive_universo,
+  (SELECT count(*) FROM sem_par s WHERE NOT EXISTS (
+     SELECT 1 FROM order_items i WHERE i.customer_user_id=s.customer_user_id)) AS zero_linhas_de_todo;
+
+\echo == Q2. POPULACAO x OBSERVADOS: o que muda nos cortes ==
+WITH hc AS (SELECT unnest(ARRAY['critico','atencao','estavel']) AS k)
+SELECT hc.k AS cluster, c.* FROM hc, LATERAL (
+  WITH eleg AS (
+    SELECT customer_user_id FROM farmer_client_scores
+    WHERE health_class=hc.k AND sales_history_status IN ('ativo','stale')
+  ),
+  pares AS (
+    SELECT DISTINCT i.customer_user_id, i.product_id FROM order_items i
+    JOIN sales_orders so ON so.id=i.sales_order_id JOIN omie_products o ON o.id=i.product_id
+    WHERE i.customer_user_id IN (SELECT customer_user_id FROM eleg)
+      AND so.status NOT IN ('cancelado','rascunho','pendente','orcamento')
+      AND so.deleted_at IS NULL AND o.ativo
+  ),
+  cont AS (SELECT product_id, count(*)::numeric n FROM pares GROUP BY 1),
+  d AS (SELECT count(*)::numeric pop FROM eleg),
+  o AS (SELECT count(DISTINCT customer_user_id)::numeric obs FROM pares)
+  SELECT (SELECT pop FROM d)::int AS pop, (SELECT obs FROM o)::int AS obs,
+    (SELECT pop-obs FROM d,o)::int AS so_sku_inativo,
+    round((SELECT max(n) FROM cont)/(SELECT pop FROM d),3) AS simmax_pop,
+    round((SELECT max(n) FROM cont)/(SELECT obs FROM o),3) AS simmax_obs,
+    (SELECT count(*) FROM cont WHERE n/(SELECT pop FROM d)>0.10) AS c10_pop,
+    (SELECT count(*) FROM cont WHERE n/(SELECT obs FROM o)>0.10) AS c10_obs,
+    (SELECT count(*) FROM cont WHERE n/(SELECT pop FROM d)>0.15) AS c15_pop,
+    (SELECT count(*) FROM cont WHERE n/(SELECT obs FROM o)>0.15) AS c15_obs
+) c;
+
+\echo == Q3. CONTRA-MEDICAO: qual o PESO dos que saem do denominador? ==
+-- Obrigatória. Se os excluidos fossem clientes pesados, a correcao seria [P1]; sendo leves
+-- (mediana 2 linhas), eles seriam "nao comprou" legitimo para quase todo produto -> [P2].
+WITH eleg AS (
+  SELECT customer_user_id FROM farmer_client_scores
+  WHERE health_class='critico' AND sales_history_status IN ('ativo','stale')
+),
+compar AS (
+  SELECT DISTINCT i.customer_user_id FROM order_items i
+  JOIN sales_orders so ON so.id=i.sales_order_id JOIN omie_products o ON o.id=i.product_id
+  WHERE so.status NOT IN ('cancelado','rascunho','pendente','orcamento')
+    AND so.deleted_at IS NULL AND o.ativo
+),
+sem_par AS (SELECT customer_user_id FROM eleg EXCEPT SELECT customer_user_id FROM compar),
+peso AS (
+  SELECT s.customer_user_id, count(*) AS linhas
+  FROM sem_par s JOIN order_items i ON i.customer_user_id=s.customer_user_id
+  JOIN sales_orders so ON so.id=i.sales_order_id
+  WHERE so.status NOT IN ('cancelado','rascunho','pendente','orcamento') AND so.deleted_at IS NULL
+  GROUP BY 1
+)
+SELECT count(*) AS clientes, sum(linhas) AS linhas_totais, round(avg(linhas),1) AS media,
+       percentile_disc(0.5) WITHIN GROUP (ORDER BY linhas) AS mediana, max(linhas) AS maximo,
+       count(*) FILTER (WHERE linhas=1) AS com_1_linha_so
+FROM peso;

--- a/docs/historico/recommend-teto-linhas-cluster.md
+++ b/docs/historico/recommend-teto-linhas-cluster.md
@@ -222,6 +222,25 @@ para 0,118 com **dois**; `atencao` vai de 12 para 15 produtos em 0,10; `estavel`
 `simIndisponivel` já desligou o componente. Medição reproduzível em
 `db/recommend-denominador-observados.sql` (roda contra prod, `EXIT=0`).
 
+### Falsificar em MEMÓRIA, não in-place — a sabotagem sobreviveu ao processo que ia desfazê-la
+
+A primeira tentativa de falsificar o gate seguiu o padrão do repo: `perl -i` sabota o arquivo, roda
+o teste, `git checkout --` restaura. O `vitest` levou mais que o teto de 10 min (a máquina estava em
+thrashing de swap: 6,6 GB de 7 GB usados, 45 worktrees), **o comando foi morto no meio e o
+`git checkout` nunca executou** — o arquivo money-path ficou sabotado no disco. `money-path.md` já
+avisa que `trap … EXIT` é obrigatório nesses scripts; o que este caso acrescenta é que **um comando
+de shell composto não tem trap nenhum**, e o timeout do harness mata entre os `&&`.
+
+⇒ Quando a propriedade a provar é TEXTUAL (gate de regex sobre fonte), sabote **uma cópia em
+memória**: leia o arquivo, aplique o mesmo `removerComentarios` que o gate usa, rode as regexes
+VERBATIM do teste contra a cópia sã e contra as sabotadas. Prova a mesma coisa — que o gate
+discrimina —, custa segundos em vez de dez minutos, não carrega o runner, e **não existe janela em
+que o repo esteja sabotado**. Exige duas disciplinas para não virar teatro: (a) `assert` de que a
+substituição REALMENTE mudou o texto (senão você compara a fonte com ela mesma e tudo "passa"); e
+(b) importar o stripper REAL, não reescrever um — a cegueira do gate costuma morar nele.
+
+Medido aqui: `aprovaReal=SIM · pegaSabotagem1=SIM · pegaSabotagem2=SIM`, com o repo limpo ao fim.
+
 ## Segue aberto (nomeado para não passar por consertado)
 
 - **auto-inclusão**: diluída para 0,13%/0,29%/1,00%, não consertada — falta leave-one-out;

--- a/docs/historico/recommend-teto-linhas-cluster.md
+++ b/docs/historico/recommend-teto-linhas-cluster.md
@@ -197,10 +197,30 @@ comprava o que hoje está descontinuado — 146/780 = **18,7%** em `critico`, 14
 LEVES: 427 linhas no total, média 2,9, **mediana 2**, e 38% têm uma linha só. Um cliente de 2 linhas
 contribuiria no máximo 2 produtos entre 957 — para quase todo produto ele é um "não comprou"
 legítimo, ativo ou não. Então isto é **[P2]: escolha de denominador com viés medido**, não a
-fabricação grosseira que a primeira leitura sugeria. Registrado sem correção porque mudar o
-denominador altera ranking em produção e é decisão de produto, não de implementação — mas agora com
-número, não com opinião. O que fica como regra durável, independente da magnitude: **filtro de
-PRODUTO não pertence ao denominador de uma proporção sobre CLIENTES.**
+fabricação grosseira que a primeira leitura sugeria. O que fica como regra durável, independente
+da magnitude: **filtro de PRODUTO não pertence ao denominador de uma proporção sobre CLIENTES.**
+
+### Resolvido: o founder decidiu trocar (2026-08-22)
+
+O achado foi apresentado com os dois números — o viés (18,7%) e a contra-medição que o rebaixa
+(mediana 2 linhas) — e a decisão foi **trocar o denominador para `observados`**.
+
+⚠️ **A correção NÃO precisou de migration**, e isso vale registrar como método: `observados` já
+existia no contrato da RPC, calculado e devolvido, apenas rotulado como "DIAGNÓSTICO, não
+denominador". A entrega inteira é `Math.max(denominador, 1)` → `Math.max(observados ?? 0, 1)` no
+consumidor, mais a justificativa e o gate que a pina. Antes de escrever SQL novo, **verifique se o
+dado que você quer já está atravessando o contrato** — aqui estava, e a diferença é entre um deploy
+de edge e um par migration-manual + edge.
+
+Como consequência, as duas ordens de deploy são seguras (não há janela ruim): migration nova não
+existe, e a RPC em produção já devolve os dois campos — a edge velha usa população (comportamento de
+ontem), a nova usa observados. Nenhuma combinação quebra.
+
+Efeito: `critico` deixa de estar MUDO — sai de simmax 0,096 com **nenhum** produto cruzando 0,10
+para 0,118 com **dois**; `atencao` vai de 12 para 15 produtos em 0,10; `estavel` não muda
+(observados = população = 100). O `?? 0` não fabrica: `observados` só é `null` sob truncagem, e aí
+`simIndisponivel` já desligou o componente. Medição reproduzível em
+`db/recommend-denominador-observados.sql` (roda contra prod, `EXIT=0`).
 
 ## Segue aberto (nomeado para não passar por consertado)
 

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -2867,10 +2867,16 @@ describe('guardrail money-path: denominador e amostra do sim_score (recommend)',
     expect(fonteStatus).toContain('SalesHistoryStatus');
   });
 
-  it('DENOMINADOR: `clusterSize` é a POPULAÇÃO do cluster vinda da RPC, não uma amostra', () => {
+  it('DENOMINADOR: `clusterSize` sai de `observados` — população conta quem NÃO é mensurável', () => {
+    // Medido em prod 2026-08-22: dos 780 elegíveis de `critico`, 146 têm compra e pedido válido
+    // e são eliminados SÓ por `omie_products.ativo`. Contá-los como "não comprou" é o
+    // `Number(null)===0` mudado do numerador para o denominador. Detalhe e contra-medição (eles
+    // são leves: mediana 2 linhas) em `docs/historico/recommend-teto-linhas-cluster.md`.
     const limpo = removerComentarios(consumidor);
-    expect(limpo, 'clusterSize deixou de sair do denominador da RPC — `sim` volta a sair de amostra')
-      .toMatch(/clusterSize\s*=\s*Math\.max\(\s*denominador\s*,\s*1\s*\)/);
+    expect(limpo, 'clusterSize deixou de sair de `observados` — volta a contar quem não é mensurável')
+      .toMatch(/clusterSize\s*=\s*Math\.max\(\s*observados\s*\?\?\s*0\s*,\s*1\s*\)/);
+    expect(limpo, 'REGRESSÃO: clusterSize voltou à população elegível (o zero fabricado no denominador)')
+      .not.toMatch(/clusterSize\s*=\s*Math\.max\(\s*denominador\s*,/);
     expect(limpo, 'REGRESSÃO: clusterSize voltou a contar uma amostra local')
       .not.toMatch(/clusterSize\s*=\s*Math\.max\(\s*(clusterUserIds|usuariosAmostrados)\.length/);
   });

--- a/supabase/functions/_shared/recommend-leituras.ts
+++ b/supabase/functions/_shared/recommend-leituras.ts
@@ -147,21 +147,28 @@ export const CLUSTER_STATUS_COM_HISTORICO = ["ativo", "stale"] as const;
 
 export interface ClusterRecommend {
   /**
-   * Denominador de `sim`: quantos clientes ELEGÍVEIS o cluster tem (whitelist de
-   * `sales_history_status` aplicada). População, não "quem comprou alguma coisa".
+   * População ELEGÍVEL do cluster (whitelist de `sales_history_status` aplicada).
    *
-   * Os dois DIVERGEM em prod — 779 vs 633 em `critico`, 348 vs 334 em `atencao` — e a escolha
-   * muda comportamento observável (com população, zero produtos cruzam o corte de 0,10 em
-   * `critico`; com observados, dois cruzam). População é o certo porque a leitura é EXAUSTIVA:
-   * cliente sem par é fato OBSERVADO ("li o histórico inteiro dele e X não está lá"), não
-   * truncagem. Dividir pelos observados é viés de seleção — o denominador filtrado pelo
-   * numerador — e infla `sim` sistematicamente.
+   * ⚠️ NÃO é o denominador de `sim` — foi, e a mudança está medida. Ele é o eixo do DISJUNTOR
+   * (o teto é sobre custo, e custo escala com população) e o sensor que mostra a distância
+   * entre "quantos existem" e "sobre quantos dá para responder".
    */
   denominador: number;
   /**
-   * Quantos dos elegíveis têm ≥1 par no recorte. DIAGNÓSTICO, não denominador: é o sensor que
-   * permite ver a distância entre população e observação sem ter que inferi-la. `null` quando
+   * Quantos dos elegíveis têm ≥1 par no recorte. **É o denominador de `sim`.** `null` quando
    * `truncado`.
+   *
+   * Os dois DIVERGEM em prod (780 vs 634 em `critico`, 347 vs 333 em `atencao`) e a escolha muda
+   * comportamento observável. A versão anterior dividia pela população, argumentando que a
+   * leitura é exaustiva e portanto cliente sem par é fato observado. MEDIDO, não era: os 146 de
+   * `critico` que ficam de fora TÊM compra, os pedidos passam no filtro de universo, e quem os
+   * elimina é só `omie_products.ativo` — um filtro de PRODUTO decidindo quem entra num
+   * denominador de CLIENTES. São clientes sobre quem a pergunta não é respondível, e contá-los
+   * como "não comprou" é o `Number(null)===0` mudado do numerador para o denominador.
+   *
+   * ⚠️ Não confundir com viés de seleção: `observados` não é "quem comprou o produto X" (aí o
+   * denominador sairia filtrado pelo numerador) — é "quem tem ao menos um par mensurável", que
+   * é condição sobre a legibilidade do CLIENTE, não sobre o produto sendo pontuado.
    */
   observados: number | null;
   /**

--- a/supabase/functions/recommend/index.ts
+++ b/supabase/functions/recommend/index.ts
@@ -205,18 +205,42 @@ async function recommend(
   } else {
     console.log(
       `[Recommend] similaridade sobre o cluster "${customerCluster}" INTEIRO: ` +
-        `${denominador} elegíveis, ${observados} com compra no recorte, ` +
+        `${denominador} elegíveis, ${observados} com compra no recorte (DIVISOR), ` +
         `${Object.keys(clientesPorProduto ?? {}).length} produtos`,
     );
   }
 
-  // DENOMINADOR = população elegível do cluster, vinda do banco. Duas correções em relação ao
-  // que havia aqui: (a) não é mais `usuariosAmostrados.length` (a amostra deixou de existir), e
-  // (b) o numerador não vem mais de uma leitura capada em 1.000 linhas que zerava clientes
-  // reais — 5 em `atencao` e 2 em `estavel`, medido. O `Math.max(…, 1)` continua sendo só
-  // guarda de divisão por zero: com denominador 0 não há produto no agregado, então nenhum
-  // `sim` chega a ser calculado.
-  const clusterSize = Math.max(denominador, 1);
+  // DENOMINADOR = clientes com par MENSURÁVEL (`observados`), NÃO a população elegível.
+  //
+  // A entrega anterior dividia pela população e justificou assim: "a leitura é exaustiva, então
+  // cliente sem par é fato observado — li o histórico inteiro dele e o produto X não está lá".
+  // MEDIDO em prod (2026-08-22), a justificativa não se sustenta. Dos 780 elegíveis de
+  // `critico`, 146 ficam fora do numerador — e:
+  //     sem_par=146 · tem_order_items=146 · sobrevive_universo=146 · zero_linhas_de_todo=0
+  // Todos TÊM compra e os pedidos passam no filtro de universo. Quem os elimina é
+  // exclusivamente `omie_products.ativo`. Não são "clientes que não compraram X": são clientes
+  // sobre quem a pergunta não é RESPONDÍVEL com este recorte, e contá-los como "não comprou" é
+  // o mesmo `Number(null)===0` que esta entrega tirou do numerador — mudado de lugar.
+  //
+  // A raiz é misturar, no mesmo denominador, um filtro de CLIENTE (`health_class`,
+  // `sales_history_status`, que define a população) com um de PRODUTO (`ativo`, que define o
+  // que é recomendável). ⚠️ E o viés NÃO é neutro: correlaciona com o eixo do próprio cluster,
+  // porque quem parou de comprar comprava o que hoje está descontinuado — 18,7% em `critico`,
+  // 4,0% em `atencao`, 0 em `estavel`.
+  //
+  // Efeito medido: `critico` sai de simmax 0,096 (NENHUM produto cruza 0,10 — o cluster fica
+  // mudo) para 0,118, com 2 produtos acendendo o boost de contexto; `atencao` 0,213 → 0,222
+  // (12 → 15 produtos em 0,10); `estavel` não muda (observados = população = 100).
+  //
+  // ⚠️ Isto NÃO é o viés de seleção que a versão anterior temia. `observados` não é "quem
+  // comprou o produto X" (aí sim o denominador sairia filtrado pelo numerador) — é "quem tem
+  // ao menos UM par mensurável", que é uma condição sobre a legibilidade do cliente, não sobre
+  // o produto sendo pontuado.
+  //
+  // `?? 0` não fabrica: `observados` só vem `null` sob truncagem, e aí `simIndisponivel` já é
+  // `true`, `sim` é `null` e este divisor não chega a ser usado. O `Math.max(…, 1)` segue sendo
+  // guarda de divisão por zero — com 0 observados o agregado está vazio e nenhum `sim` existe.
+  const clusterSize = Math.max(observados ?? 0, 1);
 
   // O que a correção move, e o que NÃO move (medido em prod, psql-ro):
   //   · NÃO move o componente `score_sim` do score ponderado: `minMaxNorm` é `(v-min)/(max-min)`,

--- a/supabase/functions/recommend/versao.ts
+++ b/supabase/functions/recommend/versao.ts
@@ -31,7 +31,7 @@ export const respostaSonda = criarRespostaSonda("recommend");
  * e sem ela "a edge nova está no ar?" e "a função existe no banco?" seriam duas perguntas sem
  * resposta em vez de uma consulta e uma sonda.
  */
-export const VERSAO = "v1.4-sonda-antes-do-gate";
+export const VERSAO = "v1.5-denominador-observados";
 
 /** Efeito citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
Decisão do founder sobre o achado que o Caminho B mediu no #1890.

## O defeito

O #1876 tirou o zero fabricado do **numerador** (o teto de 1.000 linhas de `order_items` apagava clientes reais do cluster) e deixou um no **denominador**. A justificativa escrita então era: *"a leitura é exaustiva, logo cliente sem par é fato observado — li o histórico inteiro dele e o produto X não está lá"*. Medido em prod, não era:

```
sem_par=146 · tem_order_items=146 · sobrevive_universo=146 · zero_linhas_de_todo=0
```

Os 146 de `critico` **têm compra** e os pedidos passam no filtro de universo. Quem os elimina é exclusivamente `omie_products.ativo`. São clientes sobre quem a pergunta não é **respondível** — contá-los como "não comprou" é o mesmo `Number(null)===0`, mudado de lugar.

A raiz: misturar filtro de **CLIENTE** (`health_class`, `sales_history_status`) com filtro de **PRODUTO** (`ativo`) no mesmo denominador. E o viés correlaciona com o eixo do cluster — quem parou de comprar comprava o descontinuado: **18,7%** em `critico`, 4,0% em `atencao`, **0** em `estavel`.

## A correção não precisou de migration

`observados` **já existia** no contrato da RPC — calculado, devolvido, só rotulado como "diagnóstico". A entrega é:

```diff
- const clusterSize = Math.max(denominador, 1);
+ const clusterSize = Math.max(observados ?? 0, 1);
```

Antes de escrever SQL novo, confira se o dado já atravessa o contrato. Consequência: **nenhuma ordem de deploy é ruim** — não há migration, e a RPC em prod já devolve os dois campos (edge velha usa população, nova usa observados; nenhuma combinação quebra).

O `?? 0` não fabrica: `observados` só vem `null` sob truncagem, e aí `simIndisponivel` já desligou o componente.

## Efeito medido

`db/recommend-denominador-observados.sql` (read-only, roda contra prod, `EXIT=0`):

| cluster | pop → obs | simmax | produtos > 0,10 |
|---|---|---|---|
| critico | 780 → **634** | 0,096 → **0,118** | **0 → 2** |
| atencao | 347 → 333 | 0,213 → 0,222 | 12 → 15 |
| estavel | 100 → 100 | — | — |

`critico` deixa de estar **mudo**. `estavel` não se move porque lá pop = obs — a correção só age onde o defeito existe.

## A contra-medição, que rebaixa a própria acusação

```
146 clientes · 427 linhas · média 2,9 · mediana 2 · 38% com UMA linha só
```

São clientes leves — para quase todo produto seriam um "não comprou" legítimo de qualquer forma. Isso é **[P2]**, não [P1]. Sem esse segundo número, "18,7% do denominador é estrutura" soa catastrófico e não é.

## Prova

**Falsificação do gate, com dente:**

```
REAL       pin=SIM vetoPop=nao vetoAmostra=nao
SABOTADO-1 pin=nao vetoPop=SIM vetoAmostra=nao   (volta para a população)
SABOTADO-2 pin=nao vetoPop=nao vetoAmostra=SIM   (volta para amostra local)
VEREDITO aprovaReal=SIM pegaSabotagem1=SIM pegaSabotagem2=SIM · repo limpo
```

Harness em `db/falsifica-gate-denominador.ts`. Usa o `removerComentarios` **real** e as regexes **verbatim** do teste.

⚠️ **Sabota em MEMÓRIA, e isso é a lição do PR.** A primeira tentativa seguiu o padrão in-place (`perl -i` → vitest → `git checkout --`) e o vitest estourou 10 min com a máquina em thrashing de swap (6,6 GB de 7 GB, 45 worktrees). O comando foi morto no meio, o `checkout` nunca rodou e o arquivo money-path ficou sabotado no disco. `money-path.md` exige `trap … EXIT` nesses scripts — o que este caso acrescenta é que **um comando composto de shell não tem trap nenhum**, e o timeout mata entre os `&&`.

`prove-sql-money-path` **não se aplica**: esta entrega não cria nem altera migration, RPC, trigger ou policy. O SQL em produção está intocado.

⚠️ **A suíte local não pôde rodar** — a máquina está em thrashing (typecheck passou de 40 min paginando). Os gates de doc rodaram (`docs:links` EXIT=0) e a falsificação acima é local e verde. O CI é o juiz da suíte: o auto-merge só mergeia se `validate` passar.

## Deploy

Precisa de **deploy da edge `recommend`** (manual, pelo chat do Lovable). `VERSAO` → `v1.5-denominador-observados`. Sem migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)