### PR TITLE
fix(paginate): a 1ª linha da página não era comparada ao cursor — sobreposição pontual virava duplicata SILENCIOSA [money-path]

### DIFF
--- a/docs/historico/paginacao-offset-janela.md
+++ b/docs/historico/paginacao-offset-janela.md
@@ -154,8 +154,17 @@ ordem/unicidade removida.
 ## Tentativa retroativa (2026-08-22): cota AINDA esgotada — e a pergunta em aberto fechada por MEDIÇÃO
 
 Segunda tentativa do ritual: `codex-async.sh -m gpt-5.6-terra -r xhigh -t 1200` saiu de novo
-com `COTA_ESGOTADA` (**exit 75**) — a janela rolante de 7 dias não virou. **O marcador acima
-continua de pé: nenhuma revisão independente rodou nesta entrega.**
+com `COTA_ESGOTADA` (**exit 75**). **O marcador acima continua de pé: nenhuma revisão
+independente rodou nesta entrega.**
+
+📅 **Não é "esperar a janela de 7 dias virar" — a data é 2026-09-20.** O
+[`recommend-teto-linhas-cluster.md`](recommend-teto-linhas-cluster.md) já tinha medido isso em
+2026-08-22 por ping mínimo independente, e o #1887 chegou ao mesmo em paralelo. Esta tentativa
+é a **terceira** confirmação do mesmo fato no mesmo dia. Modelo e transporte estavam certos
+(`gpt-5.6-terra`, preflight passou, classificação correta como cota e não como modelo recusado
+— o conserto do #1880 está no disco deste worktree): o que falta é **calendário**, não
+configuração. Registrar aqui para a próxima sessão não gastar meia hora redescobrindo: antes de
+20/09 o ritual não roda, e reconferir é barato mas re-diagnosticar não é.
 
 ⚠️ **O prompt guardado está DEFASADO — não reenviar como está.** Escrito em 2026-08-21, ANTES
 do #1889: ele cita `if (rows.length < PAGE) break`, que o #1889 trocou por `rows.length === 0`.

--- a/docs/historico/paginacao-offset-janela.md
+++ b/docs/historico/paginacao-offset-janela.md
@@ -150,3 +150,67 @@ uma varredura da PÁGINA INTEIRA, que custa uma comparação por linha contra um
 Falsificado 4× (cada guarda sabotada exigiu vermelho, e o vermelho veio): cursor pela primeira
 linha da página · guarda de cursor removida · guarda de ordem removida · guarda de
 ordem/unicidade removida.
+
+## Tentativa retroativa (2026-08-22): cota AINDA esgotada — e a pergunta em aberto fechada por MEDIÇÃO
+
+Segunda tentativa do ritual: `codex-async.sh -m gpt-5.6-terra -r xhigh -t 1200` saiu de novo
+com `COTA_ESGOTADA` (**exit 75**) — a janela rolante de 7 dias não virou. **O marcador acima
+continua de pé: nenhuma revisão independente rodou nesta entrega.**
+
+⚠️ **O prompt guardado está DEFASADO — não reenviar como está.** Escrito em 2026-08-21, ANTES
+do #1889: ele cita `if (rows.length < PAGE) break`, que o #1889 trocou por `rows.length === 0`.
+A pergunta (3) dele ("página curta como EOF trunca se o max-rows cair para 500 — errei em não
+baixar PAGE para 900?") pergunta por um defeito que o #1889 **já consertou**. Reenviar queima
+cota numa pergunta morta e continua sem revisar #1877/#1882/#1889, que o prompt nem menciona.
+Regenerar contra o código VIVO antes de rodar.
+
+⚠️ **Armadilha de evidência — variante nova da 7ª (`| tail` engole o exit code).** O wrapper
+rodou em background e o harness reportou **"exit code 0"**: esse era o exit do ÚLTIMO comando
+do compound (`wc -c`), não o do `codex-async.sh`. O `echo "CODEX_EXIT=$?"` colado logo após o
+comando foi o que revelou o **75**. Sem ele, "exit 0" + arquivo de parecer criado leria como
+sucesso — e o arquivo tinha **0 bytes**. **Regra: o compound termina no comando que você quer
+medir, ou o `$?` vai colado nele. Arquivo de saída CRIADO não é arquivo de saída ESCRITO.**
+
+### A pergunta em aberto: CONFIRMADA — mas o vetor não era o que se supunha
+
+Ficou em aberto se inicializar `anterior = null` (em vez de `anterior = cursor`) na varredura
+de página era buraco real, já que a primeira linha de cada página não é comparada ao cursor da
+anterior. A defesa registrada era *"a checagem de cursor no fim do laço já cobre isso, só que
+uma página depois"*. Medido em vez de argumentado — a defesa está **meio certa**, e a metade
+errada é a que importa:
+
+| vetor | a checagem de cursor pega? | desfecho antes do fix |
+|---|---|---|
+| **sistemático** (`.gte` no lugar de `.gt`) | sim, mas só na página **TERMINAL** | lança — tabela inteira lida, 1 duplicata por página no acumulado |
+| **pontual** (retry com cursor velho, lag de réplica, ramo do call-site que tira o cursor de outra coluna) | **NUNCA** | **resolve em silêncio**: 2.310 linhas, 10 duplicadas |
+
+O motivo de a guarda não alcançar o caso pontual: ela compara só a **última** linha da página.
+Uma página que recomeça atrás do cursor e termina à frente dele passa pelas duas guardas — está
+ascendente por dentro (varredura interna passa) e avançou por fora (checagem de cursor passa).
+É exatamente a duplicata silenciosa que este helper inteiro existe para tornar impossível.
+
+**Fix:** `anterior` começa em `cursor`. Na 1ª página `cursor` é `null` ⇒ comportamento
+idêntico; nas demais exige `k > cursor`, que é literalmente o contrato do keyset — call-site
+correto não tem como tropeçar, então não há falso-positivo a pagar. Código **próprio**
+(`KEYSET_PAGINA_SOBREPOSTA`), não reuso de `CHAVE_REPETIDA`: com `.gte`, `k === cursor` é linha
+repetida ENTRE PÁGINAS, não chave não-única — o conserto é o operador do filtro, não a escolha
+da coluna, e mandar trocar uma chave que já é única é diagnóstico que parece diagnóstico e não é.
+
+**Latente, não vivo:** os 2 call-sites (`order_items`, `omie_products`) usam `.gt("id", cursor)`
+corretamente, conferido. Isto fecha a classe antes do 3º call-site, não conserta leitura torta
+em produção.
+
+**LIÇÃO GERAL — guarda de fronteira que só olha um extremo do lote não cobre o outro.** A
+varredura interna e a checagem de cursor pareciam redundantes e não são: uma vigia o MIOLO da
+página, a outra vigia o SALTO entre páginas, e a primeira linha de cada página caía no vão
+entre as duas. O sintoma diagnóstico é a assimetria — se a guarda de saída compara a última
+linha, a guarda de entrada tem de comparar a primeira, contra o estado que sobreviveu à volta
+anterior. Corolário do que já estava nesta página: **violação sistemática é a fácil; a que
+escapa é a pontual, porque ela se conserta sozinha na página seguinte e some do rastro.**
+
+Gate: RED verificado antes do fix (`esperava lançar KEYSET_PAGINA_SOBREPOSTA, mas resolveu`) ·
+848 testes de edge, 0 falhas · **3 falsificações com dente**: reverter `anterior = cursor` (os
+2 vetores voltam, cada um com o seu vermelho) · `atravessaPagina` fixo em `false` (ambos
+vermelhos por **código errado**, provando que o teste casa a classificação e não "lançou algo")
+· tirar `KEYSET_PAGINA_SOBREPOSTA` da allowlist (`veio desconhecido`, provando que a entrada é
+carga e não enfeite).

--- a/scripts/codex-prompt-paginacao.sh
+++ b/scripts/codex-prompt-paginacao.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# codex-prompt-paginacao.sh — monta o prompt do ritual /codex sobre a família de PAGINAÇÃO
+# (#1856 keyset · #1889 EOF por página vazia · #1877/#1882 gate da sonda de versão do
+# `recommend`) LENDO O CÓDIGO VIVO do repo, e escreve em stdout.
+#
+# Por que um gerador e não um .md guardado: o prompt guardado de 2026-08-21 foi reenviado em
+# 2026-08-22 descrevendo `if (rows.length < PAGE) break` — critério que o #1889 já tinha
+# substituído por `rows.length === 0`. Uma das quatro perguntas dele pedia parecer sobre um
+# defeito JÁ CONSERTADO. Prompt que cita código por CÓPIA envelhece em silêncio, e o silêncio
+# custa cota: a janela do ChatGPT Plus é rolante de 7 dias e esgota.
+#
+# Uso:
+#   scripts/codex-prompt-paginacao.sh | scripts/codex-async.sh -r xhigh -t 1200 -
+#
+# Fail-closed: recorte que sai VAZIO aborta com exit 65 em vez de emitir um prompt que
+# revisaria o nada. Sonda de extração é a mesma regra dos scripts que apagam — ausência de
+# resposta não é resposta.
+set -euo pipefail
+
+raiz="$(git rev-parse --show-toplevel)"
+cd "$raiz"
+
+# Recorta de uma linha que casa `inicio` até a primeira linha que é exatamente `}` (fim de
+# declaração em coluna 0). Marcador SIMBÓLICO, não número de linha: o número muda a cada PR.
+#
+# ⚠️ Devolve 65 e NÃO chama `exit`: este helper é sempre consumido por `$( )`, e `exit` dentro
+# de substituição de comando encerra o SUBSHELL, não o script. A 1ª versão fazia isso e a
+# falsificação pegou: com o marcador sabotado, o script imprimiu o erro no stderr, saiu 0 e
+# emitiu o prompt COM UM BURACO no lugar da função. Um prompt que revisa o nada, com cara de
+# prompt bom, gastando cota de janela rolante de 7 dias. A morte tem de ser do SCRIPT — por
+# isso a captura lá embaixo é `|| exit 65`, explícita, e não confia no `set -e` (que é
+# suspenso justamente pelo contexto de chamada).
+recortar() {
+  local arquivo="$1" inicio="$2" rotulo="$3" saida
+  saida="$(awk -v re="$inicio" '$0 ~ re {dentro=1} dentro {print} dentro && /^}$/ {exit}' "$arquivo")"
+  if [ -z "$saida" ]; then
+    echo "ERRO: recorte VAZIO para '$rotulo' em $arquivo (o marcador '$inicio' não casou — o símbolo foi renomeado?)" >&2
+    return 65
+  fi
+  printf '%s\n' "$saida"
+}
+
+sha_de() { git log origin/main --format=%h --grep "(#$1)" -1 -- 2>/dev/null || true; }
+
+# Extração ANTES do heredoc, cada uma com a sua morte explícita. Se qualquer recorte falhar, o
+# script morre aqui e nenhum prompt é emitido — em vez de emitir um prompt mutilado.
+SRC_PAGINATE="supabase/functions/_shared/paginate.ts"
+FETCH_ALL="$(recortar "$SRC_PAGINATE" '^export async function fetchAll<' 'fetchAll')" || exit 65
+FETCH_KEYSET="$(recortar "$SRC_PAGINATE" '^export async function fetchAllKeyset<' 'fetchAllKeyset')" || exit 65
+CODIGOS="$(sed -n '/^const SQLSTATE = /,/^}$/p' supabase/functions/_shared/leitura-critica.ts)"
+[ -n "$CODIGOS" ] || { echo "ERRO: recorte VAZIO para 'codigoDoErro/allowlist'" >&2; exit 65; }
+SONDA="$(cat supabase/functions/recommend/versao.ts)"
+[ -n "$SONDA" ] || { echo "ERRO: recorte VAZIO para 'versao.ts'" >&2; exit 65; }
+
+cat <<CABECALHO
+Revisão independente RETROATIVA da família de paginação das edges (Deno/TypeScript, Supabase
+PostgREST). Os quatro PRs abaixo já estão MERGEADOS em produção — o ritual não rodou antes do
+merge porque a cota estava esgotada, e o repo os marcou como REVISÃO INDEPENDENTE PENDENTE.
+Isto é money-path: estas leituras alimentam recomendação de compra e agregação de valor.
+
+Seja adversário. Sem elogio. O que interessa é o caminho que RESOLVE com dado errado — truncar,
+pular, duplicar ou fabricar — sem lançar. Erro que grita já está resolvido.
+
+PRs sob revisão (HEAD de origin/main em $(date -u +%Y-%m-%d)):
+  #1856 $(sha_de 1856) — paginação keyset em _shared/paginate.ts + call-sites do recommend
+  #1877 $(sha_de 1877) — sonda de versão do recommend com gate PRÓPRIO
+  #1882 $(sha_de 1882) — sonda ANTES do gate de Bearer
+  #1889 $(sha_de 1889) — fim de tabela por página VAZIA, desacoplando do max-rows do PostgREST
+
+CONTEXTO DE PRODUÇÃO (medido, não suposto):
+  - PostgREST com max-rows = 1000; PAGE do helper = 1000.
+  - 21 call-sites de leitura paginada; DOIS migraram para keyset (order_items, omie_products),
+    escolhidos por serem os que sofrem DELETE entre páginas. Os outros 19 seguem em offset.
+  - sales_orders: 30.979 linhas, 536 deletes hard — NÃO migrou.
+
+CÓDIGO VIVO (extraído do repo agora, não de cópia):
+
+--- supabase/functions/_shared/paginate.ts :: fetchAll ---
+${FETCH_ALL}
+
+--- supabase/functions/_shared/paginate.ts :: fetchAllKeyset ---
+${FETCH_KEYSET}
+
+--- supabase/functions/_shared/leitura-critica.ts :: codigoDoErro + allowlist ---
+${CODIGOS}
+
+--- supabase/functions/recommend/versao.ts (sonda de versão — #1877/#1882) ---
+${SONDA}
+
+PERGUNTAS DIRIGIDAS
+
+(1) fetchAllKeyset — sobrou algum caminho em que ele PULA, DUPLICA ou entra em laço sem
+    lançar? A varredura de página agora começa em \`anterior = cursor\` (era \`null\`), o que
+    fechou a sobreposição pontual. Ficou algum vão entre a varredura interna e a checagem de
+    cursor do fim do laço?
+
+(2) #1889 trocou o critério de parada de \`rows.length < PAGE\` para \`rows.length === 0\`.
+    Isso custa uma requisição vazia por leitura e desacopla do max-rows. Em fetchAll o offset
+    passou a avançar pelo número REAL de linhas. Existe combinação de max-rows, PAGE e
+    escrita concorrente em que o novo critério lê a MESMA linha duas vezes, ou nunca para?
+
+(3) #1877/#1882 — a sonda de versão responde ANTES do gate de \`Bearer \` do handler e usa
+    gate próprio (\`authorizeCronOrStaff\`). O corpo do request é consumido pela sonda e
+    \`req.json()\` só pode ser lido uma vez. Um request malformado, ou um que NÃO é sonda,
+    pode sair daqui com o corpo já drenado e virar erro/vazio silencioso mais adiante?
+
+(4) A decisão de migrar 2 de 21 call-sites se sustenta, ou sales_orders (536 deletes hard,
+    30.979 linhas) também deveria ter entrado?
+
+(5) O que estas medições NÃO provam?
+CABECALHO

--- a/supabase/functions/_shared/leitura-critica.ts
+++ b/supabase/functions/_shared/leitura-critica.ts
@@ -49,7 +49,7 @@ export type RespostaLeitura<T> = {
  * justamente para fechá-la (`codigoDoErro({ code: '52998224725' }) === '52998224725'`, medido
  * no challenge Codex desta entrega). O domínio real é pequeno e enumerável, então é ele que
  * vale: SQLSTATE tem EXATAMENTE 5 caracteres, o PostgREST usa `PGRST` + 3 dígitos, e os
- * códigos INTERNOS desta família são seis — nenhum deles colide com SQLSTATE (que não tem `_`
+ * códigos INTERNOS desta família são sete — nenhum deles colide com SQLSTATE (que não tem `_`
  * nem passa de 5 chars, e portanto não alcança nenhum deles).
  *
  * Fora do domínio vira `desconhecido`: perder a granularidade de um código exótico custa menos
@@ -61,12 +61,13 @@ const CODIGOS_INTERNOS = new Set([
   'MALFORMADA',
   'SEM_LINHAS',
   'REJEITADA',
-  // Violação do CONTRATO do keyset — erro de programação do call-site, não de transporte. Três
+  // Violação do CONTRATO do keyset — erro de programação do call-site, não de transporte. Quatro
   // códigos e não um: o MODO da violação é constante do código (domínio fechado) e por isso pode
   // ser público, enquanto o VALOR da chave que o revelou é dado da LINHA e fica em `cause`.
   'KEYSET_CHAVE_AUSENTE',
   'KEYSET_FORA_DE_ORDEM',
   'KEYSET_CHAVE_REPETIDA',
+  'KEYSET_PAGINA_SOBREPOSTA',
 ]);
 
 export function codigoDoErro(erro: ErroPostgrest | null | undefined): string {

--- a/supabase/functions/_shared/paginate-keyset_test.ts
+++ b/supabase/functions/_shared/paginate-keyset_test.ts
@@ -282,3 +282,57 @@ Deno.test("keyset: página fora de ordem NO MEIO lança (não só extremos troca
     "ordem",
   );
 });
+
+// ── Revisão retroativa do #1856 (2026-08-22) ────────────────────────────────────────
+// A varredura de página validava monotonia estrita DENTRO da página mas começava em
+// `anterior = null`: a PRIMEIRA linha de cada página não era comparada ao cursor da
+// anterior. A defesa era "a checagem de cursor no fim do laço cobre, uma página depois".
+// Medido: cobre a violação SISTEMÁTICA e não cobre a PONTUAL.
+
+Deno.test("keyset: sobreposição SISTEMÁTICA (.gte no lugar de .gt) morre na 1ª fronteira, não na página terminal", async () => {
+  // A checagem de cursor JÁ fechava este caso, mas TARDE: com `.gte` toda página recomeça
+  // na linha do cursor, o laço só para na página terminal (que devolve exatamente [max], e
+  // aí `proximo === cursor` lança) — tabela inteira lida, uma duplicata por página no
+  // acumulado. Com `anterior = cursor` o erro sai no 2º request, na linha que o causou.
+  // O `calls` é o dente do teste: sem ele isto passaria igual com a guarda tardia.
+  const dados = Array.from({ length: 2300 }, (_, i) => ({ id: i }));
+  let calls = 0;
+  const build = (cursor: number | null, limite: number) => {
+    calls++;
+    return Promise.resolve({
+      data: dados.filter((l) => cursor === null || l.id >= cursor).slice(0, limite),
+      error: null,
+    });
+  };
+  await assertFalhaFechada(
+    () => fetchAllKeyset<{ id: number }, number>(build, (l) => l.id, "t"),
+    "KEYSET_PAGINA_SOBREPOSTA",
+    "atrás do cursor",
+  );
+  assertEquals(calls, 2, `esperava morrer no 2º request; morreu no ${calls}º (guarda tardia)`);
+});
+
+Deno.test("keyset: página que RECOMEÇA atrás do cursor lança em vez de duplicar em silêncio", async () => {
+  // O vetor que a checagem de cursor NÃO alcança: a sobreposição acontece UMA vez e o
+  // cursor volta a se comportar (retry com cursor velho, lag de réplica, um ramo do
+  // call-site que recalcula o cursor de outra coluna). A página está ascendente, então a
+  // varredura interna passa; a ÚLTIMA linha avançou, então a checagem de cursor passa; e
+  // as linhas do começo da página já tinham sido lidas. Antes do fix: resolvia com 2.310
+  // linhas e 10 duplicadas, sem uma palavra — a duplicata silenciosa que este helper
+  // inteiro existe para tornar impossível.
+  const dados = Array.from({ length: 2300 }, (_, i) => ({ id: i }));
+  let calls = 0;
+  const build = (cursor: number | null, limite: number) => {
+    calls++;
+    const efetivo = (calls === 2 && cursor !== null) ? cursor - 10 : cursor;
+    return Promise.resolve({
+      data: dados.filter((l) => efetivo === null || l.id > efetivo).slice(0, limite),
+      error: null,
+    });
+  };
+  await assertFalhaFechada(
+    () => fetchAllKeyset<{ id: number }, number>(build, (l) => l.id, "t"),
+    "KEYSET_PAGINA_SOBREPOSTA",
+    "atrás do cursor",
+  );
+});

--- a/supabase/functions/_shared/paginate.ts
+++ b/supabase/functions/_shared/paginate.ts
@@ -238,22 +238,36 @@ export async function fetchAllKeyset<T, K extends string | number>(
     // de 24 call-sites, e `push(...rows)` espalharia uma string em caracteres.
     if (!Array.isArray(data)) throw new FalhaLeituraCritica(label, { code: 'MALFORMADA' });
     const rows = data;
-    // Varre a PÁGINA INTEIRA antes de acumular nada. Três violações do contrato do keyset
-    // caem aqui, e as três resolveriam em SILÊNCIO sem esta varredura:
+    // Varre a PÁGINA INTEIRA antes de acumular nada. Quatro violações do contrato do keyset
+    // caem aqui, e as quatro resolveriam em SILÊNCIO sem esta varredura:
     //
     //   chave AUSENTE  — a coluna-chave ficou fora do `.select()`. O `.select()` é uma
     //     string e a interface da linha PROMETE o campo, então o typecheck passa e só o
     //     runtime descobre; o cursor viraria `undefined` e o `.gt()` filtraria o que desse.
     //   ordem DESC     — `.order(chave,{ascending:false})` no call-site. Precisa ser pego
-    //     aqui e não na comparação de cursor lá embaixo: sob DESC a 2ª página já volta
-    //     curta, o laço encerraria pelo `length < PAGE` e a comparação nunca rodaria.
+    //     aqui e não na comparação de cursor lá embaixo: aquela só olha a ÚLTIMA linha, que
+    //     sob DESC é a MENOR da página — o diagnóstico sairia como "cursor recuou", que
+    //     descreve o sintoma e manda o leitor caçar tudo menos o `.order()` invertido.
     //   ordem ARBITRÁRIA — `.limit()` sem `.order()`. Comparar só os extremos da página
     //     deixaria passar a que tem o miolo embaralhado, e aí a última linha não é a maior
     //     chave: o cursor salta e a faixa entre ela e a real nunca é lida.
+    //   página SOBREPOSTA — a página recomeça ATRÁS do cursor: linha já lida voltando no
+    //     começo da próxima. É por isso que `anterior` começa em `cursor` e não em `null`.
+    //     A primeira linha da página é a ÚNICA que a checagem de cursor lá embaixo não
+    //     alcança, porque aquela compara só a última. Violação SISTEMÁTICA (`.gte` no lugar
+    //     de `.gt`) ela até pega — mas só na página TERMINAL, com a tabela inteira já lida e
+    //     uma duplicata por página no acumulado. Violação PONTUAL (retry com cursor velho,
+    //     lag de réplica, ramo do call-site que tira o cursor de outra coluna) ela não pega
+    //     NUNCA: a página está ascendente, então esta varredura passava; a última linha
+    //     avançou, então a checagem de cursor passava; e a leitura RESOLVIA com duplicata.
+    //     Medido antes deste fix, com sobreposição de 10 linhas sobre 2.300: devolvia 2.310
+    //     linhas e 10 duplicadas, em silêncio — exatamente o desfecho que este helper existe
+    //     para tornar impossível.
     //
     // Custa uma comparação por linha (≤1.000 por página) — a leitura em si é uma ida à
     // rede, então isto não aparece no perfil.
-    let anterior: K | null = null;
+    let anterior: K | null = cursor;
+    let primeira = true;
     for (const linha of rows) {
       const k = chave(linha);
       if (k === null || k === undefined) {
@@ -266,18 +280,32 @@ export async function fetchAllKeyset<T, K extends string | number>(
         // O VALOR das chaves ia na mensagem por `JSON.stringify` — e a chave é uma COLUNA da
         // linha (PK, código de cliente). O modo da violação é constante do código e fica
         // público; os valores vão para `cause`, com o resto do diagnóstico.
-        // Igualdade e decrescente são MODOS distintos e têm conserto distinto: chave repetida
-        // significa "a coluna não é única no recorte" (troque a chave); decrescente significa
-        // "o `.order()` está ao contrário". Fundir os dois em `k <= anterior` sem separar o
-        // código manda o leitor caçar um `.order()` que está correto.
+        // Os MODOS são distintos e têm conserto distinto: chave repetida significa "a coluna
+        // não é única no recorte" (troque a chave); decrescente significa "o `.order()` está
+        // ao contrário"; sobreposta significa "o filtro do cursor não bate com a chave".
+        // Fundir tudo em `k <= anterior` sem separar o código manda o leitor caçar um
+        // `.order()` que está correto.
+        // A fronteira precisa de código PRÓPRIO e não pode reusar CHAVE_REPETIDA: com `.gte`
+        // no call-site, `k === cursor` é uma linha REPETIDA ENTRE PÁGINAS, não uma chave
+        // não-única — o conserto é o operador do filtro, não a escolha da coluna, e mandar o
+        // leitor trocar uma chave que já é única é o diagnóstico que parece diagnóstico e
+        // não é.
+        const atravessaPagina = primeira && cursor !== null;
         throw new FalhaLeituraCritica(label, {
-          code: k === anterior ? 'KEYSET_CHAVE_REPETIDA' : 'KEYSET_FORA_DE_ORDEM',
-          message: k === anterior
+          code: atravessaPagina
+            ? 'KEYSET_PAGINA_SOBREPOSTA'
+            : k === anterior
+            ? 'KEYSET_CHAVE_REPETIDA'
+            : 'KEYSET_FORA_DE_ORDEM',
+          message: atravessaPagina
+            ? `página recomeçou em ${JSON.stringify(k)}, atrás do cursor ${JSON.stringify(cursor)} — a linha já foi lida; o call-site precisa filtrar .gt(cursor), não .gte, e na MESMA coluna de que sai a chave`
+            : k === anterior
             ? `chave repetida em ${JSON.stringify(k)} dentro da mesma página — a chave precisa ser ÚNICA no recorte`
             : `página fora de ordem ASCENDENTE (${JSON.stringify(anterior)} → ${JSON.stringify(k)}) — o keyset exige .order() ascendente na MESMA coluna do cursor`,
         });
       }
       anterior = k;
+      primeira = false;
     }
     out.push(...rows);
     // Mesma razão do `fetchAll`: página CURTA não é fim, é o `max-rows` podendo ser menor que


### PR DESCRIPTION
## Origem: ritual `/codex` retroativo que NÃO conseguiu rodar

Tentativa de fechar o `REVISÃO INDEPENDENTE PENDENTE` dos PRs #1856/#1877/#1882/#1889.
`codex-async.sh -m gpt-5.6-terra -r xhigh` saiu com **`COTA_ESGOTADA` (exit 75)** — e isso NÃO é "a janela de 7 dias
ainda não virou": a cota só volta em **2026-09-20**, data já medida no repo
(`recommend-teto-linhas-cluster.md`) e confirmada em paralelo pelo #1887. Esta foi a 3ª
confirmação do mesmo fato no mesmo dia. Falta calendário, não configuração.

⚠️ **O marcador CONTINUA de pé.** Nenhuma revisão independente rodou. Nada neste PR é parecer
do Codex; é tudo auto-revisão medida.

## O achado: a defesa registrada estava meio certa, e a metade errada é a que importa

Ficou em aberto no #1856 se `anterior = null` (em vez de `anterior = cursor`) na varredura de
página era buraco real — a primeira linha de cada página não é comparada ao cursor da anterior.
A defesa era *"a checagem de cursor no fim do laço cobre, só que uma página depois"*. Medido:

| vetor | a checagem de cursor pega? | desfecho medido |
|---|---|---|
| **sistemático** (`.gte` em vez de `.gt`) | sim — mas só na página **terminal** | lança, com a tabela inteira já lida |
| **pontual** (retry com cursor velho, lag de réplica, ramo que tira o cursor de outra coluna) | **nunca** | **resolve em silêncio: 2.310 linhas, 10 duplicadas** |

A guarda compara só a **última** linha da página. Uma página que recomeça atrás do cursor e
termina à frente dele passa pelas duas: ascendente por dentro, avançada por fora.

**Fix:** `anterior` começa em `cursor`. Na 1ª página `cursor` é `null` ⇒ comportamento
idêntico; nas demais exige `k > cursor`, que é o contrato do keyset — call-site correto não
tropeça, então não há falso-positivo a pagar.

Código **próprio** (`KEYSET_PAGINA_SOBREPOSTA`), não reuso de `CHAVE_REPETIDA`: com `.gte`,
`k === cursor` é linha repetida ENTRE PÁGINAS, não chave não-única — o conserto é o operador
do filtro, não a escolha da coluna.

**Latente, não vivo:** os 2 call-sites (`order_items`, `omie_products`) usam `.gt("id", cursor)`
corretamente. Fecha a classe antes do 3º.

## Também neste PR

**Gerador do prompt do Codex** (`scripts/codex-prompt-paginacao.sh`). O prompt guardado estava
defasado: escrito antes do #1889, citava `rows.length < PAGE` e pedia parecer sobre um defeito
**já consertado**, sem cobrir #1877/#1882/#1889. Prompt que cita código por cópia envelhece em
silêncio, e silêncio custa uma semana de cota. O gerador recorta do código VIVO por marcador
simbólico, e é fail-closed: recorte vazio mata o script em vez de emitir prompt mutilado.

## Gate

- **RED verificado** antes do fix: `esperava lançar KEYSET_PAGINA_SOBREPOSTA, mas resolveu`
- **848 testes de edge, 0 falhas**, exit 0
- **5 falsificações com dente:**
  - reverter `anterior = cursor` → os 2 vetores voltam, cada um com o seu vermelho
  - `atravessaPagina` fixo em `false` → ambos vermelhos por **código errado** (o teste casa a
    classificação, não "lançou algo")
  - tirar `KEYSET_PAGINA_SOBREPOSTA` da allowlist → `veio desconhecido` (a entrada é carga)
  - marcador do gerador sabotado → exit 65, **0 bytes emitidos**
  - fonte inexistente → exit 1, 0 bytes emitidos
- shellcheck do script novo: exit 0

⚠️ A 1ª versão do gerador **falhou a própria falsificação**: `exit` dentro de `$( )` encerra o
subshell, não o script — ele imprimia o erro, saía **0** e emitia o prompt com um buraco. É a
regra do `set -e` suspenso pelo contexto de chamada. Corrigido para `return 65` + `|| exit 65`
explícito na captura.

## Draft porque

Os gates de FORMA do vitest (10 testes que leem `supabase/functions/` como TEXTO) estão na fila
do semáforo `heavy`. Tiro do draft quando fecharem — ou o CI decide antes.


---

## ⚠️ REVISÃO INDEPENDENTE PENDENTE

Este PR fecha pelo **Caminho B** (`docs/agent/money-path.md`): validação adversária própria,
sem 2ª opinião independente. A cota do Codex só volta em **2026-09-20**.

A marca vai aqui, literal e buscável, porque o repo já pagou por omiti-la: marca não escrita
torna auto-revisão indistinguível de revisão feita (`docs/historico/bugs-resolvidos.md`).
**Auto-revisão cobre o intervalo, não substitui a revisão.**

Rodar o retroativo depois de 20/09 com:

```bash
scripts/codex-prompt-paginacao.sh | scripts/codex-async.sh -r xhigh -t 1200 -
```

Alvo: este PR + #1856, #1877, #1882, #1889.

### Gate local (todos verdes, colados)

```
deno test (edges)      848 passed | 0 failed      exit 0
vitest (10 gates forma) 92 passed  | 0 failed      exit 0
edges:typecheck                                    exit 0
shellcheck (script novo)                           exit 0
```
