### PR TITLE
refactor(farmer): o MixGapCard tinha metade canônica e metade artesanal — consolidado no helper de leitura [money-path]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -621,6 +621,36 @@ comentário do código afirmava um conflito inexistente e o teste passava por n�
 mecanismo é outro. Investigue o mecanismo antes de aceitar o verde — foi o que produziu o único
 teste que mede a precedência de verdade (erro no cache + rede caindo depois).
 
+### Consolidação (2026-08-22, pós-merge do #1886): o card deixou de ter metade artesanal
+
+O #1886 (varredura da CLASSE) e o #1892 (o quarto estado) atacaram o mesmo defeito em paralelo e
+não colidiram em código — o que deixou o `MixGapCard` como **único** consumidor derivando na mão o
+que já era canônico em `src/lib/leitura/estado-de-leitura.ts`. Trocado: `estadoDeLeitura({status,
+fetchStatus})` no lugar de `isPending`/`fetchStatus`/`error` soltos, e `desatualizado(q, temDado)`
+no lugar do ternário local. Os 15 testes de `MixGapCard.estados.test.tsx` passaram **sem edição** —
+que é a asserção que importa: teste que precisa mudar num refactor de consolidação está medindo a
+implementação, não o comportamento.
+
+Duas coisas ficaram LOCAIS de propósito, e a fronteira é a lição:
+
+- **`data === null` ("não é staff") não é estado de leitura** — é a resposta da RPC. Subir isso para
+  o helper misturaria "a leitura não aconteceu" com "a leitura aconteceu e disse não", que é
+  exatamente o par que o #1859 colapsou. Continua com precedência sobre tudo no card.
+- **`'sem-rede'` (helper) ≠ `'sem_rede'` (PostHog).** A série já tem a chave com underscore gravada
+  desde o #1892; renomear partiria o histórico do evento em duas séries que ninguém soma depois. A
+  tradução mora na fronteira da telemetria, num mapa `satisfies Record<EstadoSemLeitura, string>` —
+  o `satisfies` é o que a faz **falhar a compilação** se o helper ganhar um terceiro estado, em vez
+  de mandar `undefined` para o PostHog.
+
+⚠️ **O que manteve o arquivo fora do gate `erro-colapsado-em-vazio` foi acidente feliz, e vale saber
+por quê:** o gate exige que a desestruturação do hook ligue alguma de `{error, isError, …, status}`.
+A versão antiga passava por causa do `error`; a nova passa por causa do **`status`**, que o helper
+exige. Se a consolidação tivesse escondido a fatia atrás de um objeto (`const q = {...}` fora da
+desestruturação), o gate voltaria a acusar o card — corretamente, porque a estrutura que ele lê é a
+desestruturação. Verificado com falsificação: removendo `status` da desestruturação,
+`contarAutoOcultacao` sobe de **0 para 1**. Gate que não foi falsificado no arquivo em questão é
+contagem, não prova.
+
 ## O que sobra quando a correção mergeia por outra sessão (2026-08-22): o sensor e o guard
 
 O achado retroativo do #1859 (seção acima) virou DUAS entregas paralelas no mesmo dia, em sessões
@@ -662,6 +692,7 @@ tela faz. O #1886 mudou `FarmerCalls.tsx` sem nenhum teste que MONTE `FarmerCall
   desta entrega a main ganhou 12 commits, dois deles exatamente sobre os arquivos em questão. Metade
   do que estava pronto e verificado virou descarte — corretamente. O tell barato: `git diff
   origin/main --stat` acusando arquivos que você nunca tocou.
+
 ## A leitura do sensor do MixGap (2026-08-22): não havia população exposta para ler
 
 > Continuação das duas seções acima (quarto estado + o sensor que sobrou do #1886). O chip
@@ -783,3 +814,4 @@ ORDER BY n DESC
 O controle que separa (b) de (c) vai junto, na mesma leitura: `SELECT count() FROM events
 WHERE timestamp > …` sem filtro de evento. Série do evento vazia **com** o controle positivo
 é dado real; as duas vazias é sensor não chegando — a distinção que o item 1 não pôde fazer.
+

--- a/src/components/farmer/MixGapCard.tsx
+++ b/src/components/farmer/MixGapCard.tsx
@@ -13,6 +13,7 @@ import { useMarkMixGapFeedback } from '@/hooks/useMarkMixGapFeedback';
 import { useImpersonation } from '@/contexts/ImpersonationContext';
 import { buildPorQue } from '@/lib/mixgap/format';
 import { track } from '@/lib/analytics';
+import { estadoDeLeitura, desatualizado, type EstadoSemLeitura } from '@/lib/leitura/estado-de-leitura';
 
 /**
  * O card colapsava TRÊS estados numa tela em branco só, e o evento só saía num deles.
@@ -58,10 +59,30 @@ import { track } from '@/lib/analytics';
  * regressão para quem está na rua. O desenho composto (lista PRESERVADA + faixa de aviso +
  * `desatualizado: 'erro' | 'sem_rede'` no evento) serve aos dois: o vendedor não perde a
  * carteira e a série sabe separar "viu número fresco" de "agiu sobre número velho".
+ *
+ * ── CONSOLIDAÇÃO (#1886 + #1892, que atacaram esta classe em paralelo sem colidir em código).
+ * Os dois discriminantes acima — "a leitura aconteceu?" e "o que está na tela está velho?" — eram
+ * derivados À MÃO aqui, porque o #1892 pousou antes de o helper existir. Agora saem de
+ * `@/lib/leitura/estado-de-leitura`: `estadoDeLeitura` (mapeamento EXAUSTIVO de status × fetchStatus)
+ * e `desatualizado` (o composto "pronta PORÉM desatualizada", com a precedência `sem-rede` > `erro`).
+ * Metade canônica e metade artesanal é pior que as duas artesanais: a artesanal envelhece calada
+ * enquanto a canônica ganha estado novo, e o estado que sobra colapsa no vizinho — que é
+ * literalmente o defeito que este card já teve duas vezes. O que fica LOCAL é o que é local de
+ * verdade: `data === null` ("não é staff" — resposta da RPC, não estado de leitura) e a tradução do
+ * motivo para a chave que a série do PostHog já usa.
  */
 type EstadoMixGap = 'com_gap' | 'zero' | 'erro' | 'aguardando_rede';
+
+/**
+ * O helper fala a língua da camada pura (`'sem-rede'`); a SÉRIE do PostHog já tem `sem_rede`
+ * gravado desde o #1892. Renomear a chave partiria o histórico do evento em duas séries que
+ * ninguém soma depois — então a tradução mora AQUI, na fronteira da telemetria, e não no helper.
+ * O `satisfies` é o que a torna exaustiva: se `EstadoSemLeitura` ganhar um terceiro membro, isto
+ * PARA DE COMPILAR em vez de mandar `undefined` para o PostHog.
+ */
+const MOTIVO_NA_SERIE = { 'sem-rede': 'sem_rede', erro: 'erro' } as const satisfies Record<EstadoSemLeitura, string>;
 /** Por que o número na tela pode estar velho. `null` = acabou de ser lido com sucesso. */
-type MotivoDesatualizado = 'erro' | 'sem_rede';
+type MotivoDesatualizado = (typeof MOTIVO_NA_SERIE)[EstadoSemLeitura];
 
 function AvisoDesatualizado({ motivo }: { motivo: MotivoDesatualizado }) {
   const Icone = motivo === 'sem_rede' ? WifiOff : AlertTriangle;
@@ -77,34 +98,37 @@ function AvisoDesatualizado({ motivo }: { motivo: MotivoDesatualizado }) {
 }
 
 export function MixGapCard() {
-  const { data, error, isPending, fetchStatus } = useMyMixGap();
+  const { data, status, fetchStatus } = useMyMixGap();
   const { mutate: markFeedback } = useMarkMixGapFeedback();
   const { isImpersonating } = useImpersonation();
 
+  // `status`+`fetchStatus` é a fatia INTEIRA que decide se a leitura aconteceu — a mesma que o
+  // <AvisoLeituraFalhou>, o DataHealthBanner e o AlertasStack consomem. Derivar isto na mão aqui
+  // (o que o #1892 fez, antes de o helper existir) é como o estado OFFLINE some: o mapeamento
+  // (status × fetchStatus) precisa ser EXAUSTIVO, e uma cópia artesanal só é exaustiva no dia em
+  // que foi escrita. `status` também é o que mantém este arquivo fora do gate erro-colapsado-em-vazio.
+  const leitura = estadoDeLeitura({ status, fetchStatus });
+
   // `data === null` é a RPC dizendo "você não é staff" (ela retorna NULL sem uid/sem role) — e isso
-  // só existe DEPOIS de a query RESOLVER. `undefined` NÃO é sinônimo: é pendente, pausada ou
-  // desabilitada, três coisas diferentes. Ler os dois como "sem acesso" foi o defeito de origem.
+  // NÃO é um estado de leitura: é a resposta, e por isso não sai do helper. `undefined` não é
+  // sinônimo (é pendente, pausada ou desabilitada); ler os dois como "sem acesso" foi o defeito de
+  // origem, e é por isso que `semAcesso` continua tendo precedência sobre tudo aqui embaixo.
   const semAcesso = data === null;
   const temDado = data != null;
-  const pausado = fetchStatus === 'paused';        // offline: o react-query nem dispara a request
-  const inerte = isPending && fetchStatus === 'idle';   // query desabilitada (sem user)
-  const carregando = isPending && fetchStatus === 'fetching';
 
-  // Pausado ANTES de erro, e a ordem só decide ALGUMA coisa aqui: `fetchState` (query-core) zera
-  // `error`/`status` ao iniciar um fetch APENAS quando `data === undefined` — sem dado, erro e
-  // pausa nunca coexistem; COM dado no cache o erro é preservado e os dois se sobrepõem. Nesse
-  // caso o motivo acionável é o atual: recarregar não resolve falta de sinal.
-  const desatualizado: MotivoDesatualizado | null =
-    !temDado ? null : pausado ? 'sem_rede' : error ? 'erro' : null;
+  // A precedência (`sem-rede` ganha de `erro`) e a razão de ela só decidir algo COM dado no cache
+  // moram no helper, junto do teste que a falsifica — não replicadas aqui.
+  const motivo = desatualizado({ status, fetchStatus }, temDado);
+  const desatualizacao: MotivoDesatualizado | null = motivo === null ? null : MOTIVO_NA_SERIE[motivo];
 
   const estado: EstadoMixGap | null =
-    semAcesso || inerte || carregando
+    semAcesso || leitura === 'desabilitada' || leitura === 'carregando'
       ? null
       : data != null
         ? (data.totalComGap > 0 ? 'com_gap' : 'zero')
-        : pausado
-          ? 'aguardando_rede'   // sem dado os dois ramos são exclusivos (ver `desatualizado`)
-          : error
+        : leitura === 'sem-rede'
+          ? 'aguardando_rede'   // sem dado, 'sem-rede' e 'erro' são exclusivos (ver helper)
+          : leitura === 'erro'
             ? 'erro'
             : null;
 
@@ -115,19 +139,19 @@ export function MixGapCard() {
     // sinal de leitura falhando em campo. A guarda por chave (e não por booleano) deixa passar
     // erro → zero → com_gap na mesma montagem, que separa falha transitória de carteira vazia.
     if (!estado) return;
-    const chave = `${estado}:${desatualizado ?? 'fresco'}`;
+    const chave = `${estado}:${desatualizacao ?? 'fresco'}`;
     if (trackedChave.current === chave) return;
     trackedChave.current = chave;
     track('carteira.mixgap_visto', {
       estado,
       total_com_gap: data != null ? data.totalComGap : null,
-      desatualizado,
+      desatualizado: desatualizacao,
     });
-  }, [estado, desatualizado, data]);
+  }, [estado, desatualizacao, data]);
 
-  if (semAcesso || inerte) return null;
+  if (semAcesso || leitura === 'desabilitada') return null;
 
-  if (carregando) {
+  if (leitura === 'carregando') {
     return (
       <Card>
         <CardHeader className="pb-2">
@@ -176,7 +200,7 @@ export function MixGapCard() {
   if (data.totalComGap === 0) {
     return (
       <Card>
-        {desatualizado && <AvisoDesatualizado motivo={desatualizado} />}
+        {desatualizacao && <AvisoDesatualizado motivo={desatualizacao} />}
         <EmptyState
           tone="operational"
           icon={Search}
@@ -189,7 +213,7 @@ export function MixGapCard() {
 
   return (
     <Card>
-      {desatualizado && <AvisoDesatualizado motivo={desatualizado} />}
+      {desatualizacao && <AvisoDesatualizado motivo={desatualizacao} />}
       <CardHeader className="pb-2">
         <h2 className="text-base font-medium">Oportunidades de cross-sell</h2>
         <p className="text-2xs text-muted-foreground">


### PR DESCRIPTION
## O que era

O #1886 (varredura da CLASSE) e o #1892 (o quarto estado, OFFLINE) atacaram o mesmo defeito no mesmo dia, em sessões paralelas, e **não colidiram em código** — que é justamente como o rastro fica: o `MixGapCard` sobrou como o **único** consumidor derivando à mão o que já era canônico em `src/lib/leitura/estado-de-leitura.ts`. Os outros quatro (`DataHealthBanner`, `CarteiraSaudePanel`, `AlertasStack`, `FarmerCalls`) já consumiam o helper.

Metade canônica e metade artesanal é pior que as duas artesanais: a artesanal envelhece calada enquanto a canônica ganha estado novo, e o estado que sobra colapsa no vizinho — literalmente o defeito que este card já teve **duas** vezes (#1859 e #1892).

## O que mudou

| antes (inline) | agora |
|---|---|
| `isPending` / `fetchStatus` / `error` soltos | `estadoDeLeitura({status, fetchStatus})` |
| ternário local do dado velho | `desatualizado(q, temDado)` |

Zero mudança de comportamento observável. O estado composto **"pronta PORÉM desatualizada"** já havia sido modelado pelo #1886 (`desatualizado`), com a precedência `sem-rede` > `erro` e o teste que a falsifica — então aqui é **consumo**, não extensão. Criar um `motivoDesatualizado` paralelo teria sido a terceira cópia da mesma regra.

### O que ficou LOCAL de propósito — a fronteira é a lição

- **`data === null` ("não é staff") não é estado de leitura**, é a resposta da RPC. Subir isso para o helper misturaria "a leitura não aconteceu" com "a leitura aconteceu e disse não" — o par exato que o #1859 colapsou. Mantém precedência sobre tudo.
- **`'sem-rede'` (helper) ≠ `'sem_rede'` (PostHog).** A série já grava a chave com underscore desde o #1892; renomear partiria o histórico do evento em duas séries que ninguém soma depois. A tradução mora num mapa `satisfies Record<EstadoSemLeitura, string>` na fronteira da telemetria — o `satisfies` faz a **compilação falhar** se o helper ganhar um terceiro estado, em vez de mandar `undefined` para o PostHog.

## Evidência

**Verde** (sinal escrito por DENTRO do wrapper — o exit do `heavy` não é veredito, §7 de `evidencia-positiva-shell.md`):

```
TYPECHECK_EXIT=0 · TEST_EXIT=0 · LINT_EXIT=0
✓ src/components/farmer/__tests__/MixGapCard.estados.test.tsx (15 tests)
✓ src/lib/__tests__/estado-de-leitura.test.ts              (17 tests)
✓ src/__tests__/erro-colapsado-em-vazio-gate.test.ts        (9 tests)
Test Files 3 passed (3) · Tests 41 passed (41)
```

Os **15 testes do card passam sem edição** — a asserção que importa: teste que precisa mudar num refactor de consolidação está medindo implementação, não comportamento.

**Falsificação 1 — a consolidação é real, não cosmética.** Invertendo a precedência **no helper**, exatamente 2 testes ficam vermelhos:

```
× estado-de-leitura.test.ts  > sem-rede tem PRECEDÊNCIA sobre erro quando os dois se sobrepõem
× MixGapCard.estados.test.tsx > com a LISTA no cache, erro e queda de rede COEXISTEM — vence o motivo ATUAL
Tests 2 failed | 30 passed (32)   ·   FALSIFICA_EXIT=1
```

O segundo é a prova: sabotar o **helper** derrubou o teste do **card**, então o card passou a depender de verdade. Os outros 30 seguiram verdes — sabotagem cirúrgica, não acoplamento frouxo.

**Falsificação 2 — gate `erro-colapsado-em-vazio` = 0, e o zero é aprovação.** Removendo `status` da desestruturação, `contarAutoOcultacao` sobe de **0 → 1**. Vale registrar *por que* o gate passa: antes era pelo `error`, agora é pelo **`status`** que o helper exige. Uma consolidação que escondesse a fatia atrás de `const q = {...}` fora da desestruturação reativaria o gate — corretamente, porque a estrutura que ele lê é a desestruturação.

## Notas

- Sonda por trabalho paralelo (lição do #1899): `git log --all -S"estadoDeLeitura" -- src/components/farmer/MixGapCard.tsx` devolve **só** este commit — nenhuma outra sessão fez isto num branch local não-pushado.
- Conflito no `fase-sem-sinal.md` com o #1896 resolvido preservando os dois lados; meu bloco é `###` da seção "Quarto estado do MixGap", então precede o `##` novo do #1896.
- Sem migration, sem edge, sem mudança de schema — **nada a aplicar no Lovable além do Publish do frontend**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
