### PR TITLE
feat(sonda): as 3 edges do #1889 não tinham como PROVAR o próprio deploy [money-path]

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -28,6 +28,7 @@ import * as cashflow from "../fin-cashflow-engine/versao.ts";
 import * as syncEstoque from "../omie-sync-estoque/versao.ts";
 import * as syncNfes from "../omie-sync-nfes-recebidas/versao.ts";
 import * as nfeWebhook from "../omie-nfe-webhook/versao.ts";
+import * as analyticsSync from "../omie-analytics-sync/versao.ts";
 
 /**
  * `respostaSonda` (a maioria) ou `respostaSondaTactical` (a `generate-tactical-plan`, que embrulha o
@@ -69,6 +70,12 @@ const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   // própria medição de acerto. Não é leitura pura — por isso não cai na exceção declarada
   // acima (fin-funding, fin-valor-engine).
   { nome: "recommend", mod: recommendMod },
+  // Quinta leva (#1889 paginação): a `omie-analytics-sync` escreve product_costs, order_items,
+  // sales_orders e inventory_position — mesma regra da terceira leva. Ela JÁ tinha uma canária
+  // (`doc_ambiguo_probe`), mas NÃO-VERSIONADA: responde `probe_no_ar:true` igual num bundle de hoje
+  // e num de três fatias atrás, então não discrimina deploy integralmente velho (a ⚠️ #2 de
+  // docs/agent/deploy.md, que classifica versioná-las como dívida aberta). O marcador fecha isso.
+  { nome: "omie-analytics-sync", mod: analyticsSync },
 ];
 
 /** As cinco da terceira leva — os gates estruturais abaixo varrem todas. */
@@ -79,6 +86,7 @@ const ESCRITA_NOSSO_BANCO = [
   "omie-sync-estoque",
   "omie-sync-nfes-recebidas",
   "omie-nfe-webhook",
+  "omie-analytics-sync",
 ];
 
 /** Destas o gate NÃO aceita `x-cron-secret`, então a sonda precisa de gate PRÓPRIO. */

--- a/supabase/functions/fin-cashflow-engine/versao.ts
+++ b/supabase/functions/fin-cashflow-engine/versao.ts
@@ -21,7 +21,15 @@ import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
 export const respostaSonda = criarRespostaSonda("fin-cashflow-engine");
 
 /** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
-export const VERSAO = "v1.0-sensor-inicial";
+//
+// v1.0 → v1.1: o #1889 mudou `_shared/paginate.ts`, que esta edge importa — EOF passou a ser página
+// VAZIA (não CURTA) e o offset avança pelas linhas REAIS devolvidas. O bump não é cosmético: ele é a
+// ÚNICA prova possível deste deploy. O #1889 é deliberadamente no-op nos dados de hoje (o `max-rows`
+// de prod é 1000, igual ao `PAGE` do helper — o comportamento antigo funciona por coincidência
+// numérica), então NENHUMA canária de comportamento consegue discriminar bundle novo de velho aqui:
+// os dois produzem bytes idênticos. Sem mexer no marcador, a sonda responderia "v1.0-sensor-inicial"
+// tendo o deploy acontecido ou não — o "mente verde" da ⚠️ #2 de docs/agent/deploy.md.
+export const VERSAO = "v1.1-paginacao-eof-vazio";
 
 /** Efeito caro citado no 400 de `probe` ambíguo. */
 export const EFEITO =

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -1,5 +1,6 @@
 import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 import { comRegistro, type DbRegistro } from "../_shared/registro-execucao.ts";
 import { fetchAll } from "../_shared/paginate.ts";
 import { STATUS_NAO_VENDA_POSTGREST } from "../_shared/universo-pedidos.ts";
@@ -2184,13 +2185,52 @@ Deno.serve(async (req) => {
   const auth = await authorizeCronOrStaff(req);
   if (!auth.ok) return auth.response;
 
+  // ⚠️ SONDA DE VERSÃO — logo após o gate (que já aceita x-cron-secret) e ANTES do createClient,
+  // porque o valor da sonda é ser o único caminho sem custo. Ver versao.ts / _shared/sonda-versao.ts.
+  //
+  // O parse subiu para cá: `req.json()` é one-shot, então o corpo lido aqui é reaproveitado como
+  // `action`/`account`/... abaixo, em vez de lido duas vezes. Dois desfechos mudam de forma, e os
+  // dois para MELHOR: corpo com JSON inválido devolvia 500 pelo catch geral (erro do cliente
+  // contado como falha nossa) e agora devolve 400; e corpo `null` estourava TypeError no
+  // destructuring — agora vira `{}` e cai no "Ação desconhecida", que é o que ele sempre foi.
+  let corpoBruto: unknown;
+  try {
+    corpoBruto = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid JSON" }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo === "sonda") {
+    return new Response(JSON.stringify(respostaSonda(VERSAO)), {
+      status: 200,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  if (decisaoSonda.tipo === "ambiguo") {
+    return new Response(JSON.stringify({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }), {
+      status: 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
   try {
     const supabaseAdmin = createClient(
       Deno.env.get("SUPABASE_URL")!,
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
     );
 
-    const { action, account = "vendas", start_page, max_pages } = await req.json();
+    // Corpo já consumido pela sonda acima. Não-objeto vira {} — cai no "Ação desconhecida" do
+    // `default`, como antes.
+    const { action, account = "vendas", start_page, max_pages } =
+      (typeof corpoBruto === "object" && corpoBruto !== null ? corpoBruto : {}) as {
+        action?: string;
+        account?: string;
+        start_page?: number;
+        max_pages?: number;
+      };
     // Registro de execuções (acoes_execucoes): cast estrutural — o client untyped satisfaz o mínimo.
     const dbRegistro = supabaseAdmin as unknown as DbRegistro;
     let result: unknown;

--- a/supabase/functions/omie-analytics-sync/versao.ts
+++ b/supabase/functions/omie-analytics-sync/versao.ts
@@ -1,0 +1,40 @@
+// Marcador de versão da edge `omie-analytics-sync`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// Efeito desta edge: ela é o sincronizador do Omie inteiro e reescreve, conforme a `action`,
+// `product_costs`, `order_items`, `sales_orders`, `inventory_position` e o mapa de identidade
+// (`omie_customer_account_map`) — o custo que o motor de recomendação lê para precificar e a
+// posição de estoque que a reposição lê para comprar passam a ter o número deste run.
+//
+// Por que a sonda aqui, e por que ela é BARATA nesta edge (ao contrário da `fin-cashflow-engine`):
+// a edge roteia por `action` e um corpo sem `action` conhecida já cai no `default` com 400 "Ação
+// desconhecida", sem tocar o Omie nem o banco. Ou seja, sondar um bundle PRÉ-sensor aqui não
+// dispara o efeito caro — ele responde 400. Isso torna a leitura da sonda inequívoca e sem risco:
+//
+//   {ok,probe:true,versao} → bundle COM sensor (este)
+//   400 "Ação desconhecida" → bundle PRÉ-sensor, o deploy não subiu
+//
+// Essa é a diferença que justifica instrumentar: a canária que a edge já tinha
+// (`doc_ambiguo_probe`) é NÃO-VERSIONADA — ela responde `probe_no_ar:true` igual num bundle de
+// hoje e num de três fatias atrás, então não discrimina deploy integralmente velho
+// (docs/agent/deploy.md, ⚠️ #2 "mente verde"). O marcador é o que fecha esse buraco.
+//
+// O gate desta edge é o `authorizeCronOrStaff` de `_shared/auth.ts`, que JÁ aceita
+// `x-cron-secret`: a sonda entra logo APÓS ele, sem gate próprio.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-analytics-sync");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge sincroniza o Omie inteiro e, conforme a action, reescreve product_costs, order_items, " +
+  "sales_orders, inventory_position e o mapa de identidade omie_customer_account_map — o custo que o " +
+  "motor de recomendação lê para precificar e a posição de estoque que a reposição lê para comprar " +
+  "passam a ter o número deste run; sync_customers enumera ~10k clientes do Omie em waitUntil, então " +
+  "encerrar o request NÃO cancela a escrita que ele já disparou";


### PR DESCRIPTION
## O que motivou

O **#1889** (paginação: EOF vira página **VAZIA**, offset avança pelas linhas **REAIS**) está mergeado desde 2026-08-22 e **não está em produção em nenhuma edge** — deploy de edge é manual pelo chat do Lovable e o merge não publica. Ao montar a verificação dos 3 deploys pedidos (`recommend`, `omie-analytics-sync`, `fin-cashflow-engine`), o problema apareceu **antes** do deploy: nenhuma das três tinha marcador capaz de discriminar bundle novo de velho.

## A raiz: o #1889 é no-op por DESENHO

O `max-rows` de prod é 1000, igual ao `PAGE` do helper — o comportamento antigo funciona, por coincidência numérica, que é exatamente o que o PR desacopla. Consequência para a verificação: **nenhuma canária de COMPORTAMENTO pode discriminar este deploy**, porque bundle novo e velho produzem bytes idênticos sobre os dados de hoje. É a ⚠️ "canária que não discrimina é teatro verde" de `docs/agent/deploy.md`, aplicada a uma mudança que é no-op de propósito.

Sobra o **marcador de versão** — e ele estava indisponível nas três:

| edge | antes | agora |
|---|---|---|
| `recommend` | `v1.4-sonda-antes-do-gate` na main **E** em prod → a sonda responderia a mesma string com ou sem deploy | resolvido de graça pelo **#1898** (`v1.5-denominador-observados`, já carrega o #1889) |
| `fin-cashflow-engine` | `v1.0-sensor-inicial` na main, idem em prod | bump → `v1.1-paginacao-eof-vazio` |
| `omie-analytics-sync` | **sem `versao.ts`**; a canária que tinha (`doc_ambiguo_probe`) é NÃO-VERSIONADA — responde `probe_no_ar:true` igual num bundle de hoje e num de três fatias atrás | sonda instalada (`v1.0-sensor-inicial`) |

O caso da `omie-analytics-sync` é o "mente verde" da ⚠️ #2 do `deploy.md`, que classifica versionar essas canárias como **dívida aberta**. Este PR paga a dívida dessa edge.

## Onde a sonda entra

Após o `authorizeCronOrStaff` (que **já aceita `x-cron-secret`**, então sem gate próprio) e **ANTES do `createClient`**, como o gate estrutural da terceira leva exige. O parse do corpo subiu junto porque `req.json()` é one-shot — dois desfechos mudam de forma, e os dois para melhor:

- JSON inválido devolvia **500** pelo catch geral (erro do cliente contado como falha nossa) → agora **400**;
- corpo `null` estourava TypeError no destructuring → agora vira `{}` e cai no `"Ação desconhecida"` que ele sempre foi.

## Por que esta sonda é BARATA (e a leitura, inequívoca)

A edge roteia por `action`, então sondar um bundle **PRÉ-sensor** cai no `default` com `400 "Ação desconhecida"` — **sem tocar Omie nem banco**. Isso torna o veredito binário e sem risco:

```
{ok,probe:true,versao}   → bundle COM sensor (este)
400 "Ação desconhecida"  → bundle PRÉ-sensor, o deploy não subiu
```

Diferente da `fin-cashflow-engine`, onde mesmo o caminho read-only paga a projeção de 13 semanas inteira antes de responder.

## Prova

Registrada em `sonda-versao-contrato_test.ts` (`EDGES` + `ESCRITA_NOSSO_BANCO`) — o gate estrutural que varre forma. **Falsificado nas três direções**, cada uma exigindo vermelho que NOMEIA a edge (verde sozinho não prova cobertura da edge nova):

| sabotagem | exit | vermelho |
|---|---|---|
| apagar a linha que RESPONDE a sonda | 1 | `omie-analytics-sync: classifica a sonda mas nunca chama respostaSonda` |
| mover a sonda para depois do `createClient` | 1 | `omie-analytics-sync: a sonda desceu para depois do createClient` |
| quebrar o formato do marcador bumpado | 1 | `fin-cashflow-engine: VERSAO fora do formato` |

Gates locais: `deno test` **869 passed** · `vitest` **6905 passed / 724 arquivos** · `typecheck` **exit 0** · `lint` **exit 0** (75 warnings pré-existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)