### PR TITLE
test(tooling): a linha de log do audit não tinha sensor — e o bug morava no CALL SITE, onde um teste de bytesUtf8 ficaria verde

### DIFF
--- a/scripts/audit-custom-migrations.test.ts
+++ b/scripts/audit-custom-migrations.test.ts
@@ -1,0 +1,73 @@
+/**
+ * audit-custom-migrations.test.ts — a linha de log que reporta o tamanho dos artefatos.
+ * ====================================================================================
+ *
+ * Motivação (medida em 2026-08-22, corrigida no #1897): o script reportava o tamanho com
+ * `String.length` sob o rótulo "bytes". `String.length` conta unidades UTF-16, e os dois
+ * artefatos são pt-BR acentuado com alguns emoji — então o número impresso divergia do
+ * arquivo real em 194 bytes (`.sql`) e 2.023 (`.md`).
+ *
+ * O custo não é estético. Validar uma mudança no extrator é rodar `bun run audit:migrations`
+ * e comparar com o commitado; quem confere o número do log contra `ls -la` conclui que o
+ * arquivo MUDOU e sai atrás de uma regressão que não existe. Aconteceu no #1894 e custou um
+ * ciclo de apuração até o `git diff` (vazio) desempatar.
+ *
+ * POR QUE O SENSOR É A LINHA INTEIRA, e não um `bytesUtf8()` isolado: o bug morava no CALL
+ * SITE (`${sql.length} bytes`), não na função. Um teste de `bytesUtf8` sozinho exercitaria
+ * `Buffer.byteLength` — stdlib — e ficaria VERDE com o call site errado, que é o pior modo
+ * de falha possível para este teste. Testando a linha formatada, a aritmética deixa de existir
+ * no call site e a asserção passa a ser a que o founder de fato compara: número × filesystem.
+ *
+ * PONTO CEGO DECLARADO (medido, não suposto): a guarda `if (import.meta.main) main();` NÃO tem
+ * sensor. Sabotagem C — removê-la — deixa os 3 testes VERDES enquanto o audit volta a rodar no
+ * import (o log do teste imprime "Lidas 484 custom migrations"). Fechar isso exigiria mover a
+ * lógica para `scripts/lib/`, como já é feito com `migration-objects.ts`; não vale o refactor
+ * hoje, porque a consequência é lentidão e reescrita idempotente de artefato durante o teste,
+ * não corrupção. Se um dia doer, a saída é a co-localização, não um gate textual.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { linhaArtefatoEscrito } from './audit-custom-migrations';
+
+/** o número entre parênteses da linha `✓ Escrito <caminho> (<n> bytes)` */
+function numeroReportado(linha: string): number {
+  const m = linha.match(/\((\d+) bytes\)$/);
+  if (!m) throw new Error(`linha fora do formato esperado: ${JSON.stringify(linha)}`);
+  return Number(m[1]);
+}
+
+/**
+ * Amostra representativa dos artefatos reais: acento pt-BR (2 bytes cada em UTF-8), travessão
+ * e ✓ (3 bytes, BMP) e emoji astral (4 bytes, e 2 unidades UTF-16 — a fonte da divergência).
+ */
+const CONTEUDO = '✓ Escrito — a migração não foi aplicada 🟡🔴\nção ção ção\n';
+
+describe('linhaArtefatoEscrito', () => {
+  it('reporta o tamanho que o FILESYSTEM enxerga (a asserção que o founder compara com ls -la)', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'audit-bytes-'));
+    try {
+      const caminho = join(dir, 'artefato.md');
+      writeFileSync(caminho, CONTEUDO);
+
+      expect(numeroReportado(linhaArtefatoEscrito(caminho, CONTEUDO))).toBe(statSync(caminho).size);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('NÃO conta unidades UTF-16 — o bug do #1897, que subcontava o .md em 2KB', () => {
+    const reportado = numeroReportado(linhaArtefatoEscrito('/tmp/x.md', CONTEUDO));
+
+    // a divergência tem que ser REAL, senão a amostra não exercita a regressão
+    expect(CONTEUDO.length).toBeLessThan(reportado);
+    expect(reportado).toBe(Buffer.byteLength(CONTEUDO, 'utf8'));
+  });
+
+  it('preserva o formato da linha — o founder compara logs entre execuções', () => {
+    expect(linhaArtefatoEscrito('/repo/docs/migrations-audit.md', 'abc')).toBe(
+      '✓ Escrito /repo/docs/migrations-audit.md (3 bytes)',
+    );
+  });
+});

--- a/scripts/audit-custom-migrations.ts
+++ b/scripts/audit-custom-migrations.ts
@@ -342,10 +342,22 @@ function emitMarkdown(audits: MigrationAudit[]): string {
  * existe — aconteceu ao entregar o #1894 e custou um ciclo de apuração até o `git diff` (vazio)
  * desempatar.
  *
- * Casa com o `writeFileSync(…, conteudo)` logo abaixo, que grava em utf8 por default.
+ * Casa com o `writeFileSync(…, conteudo)` do `main()`, que grava em utf8 por default.
  */
 function bytesUtf8(conteudo: string): number {
   return Buffer.byteLength(conteudo, 'utf8');
+}
+
+/**
+ * A linha que o script imprime por artefato gravado: `✓ Escrito <caminho> (<n> bytes)`.
+ *
+ * É função, e não interpolação no call site, porque o bug do #1897 morava JUSTAMENTE no call
+ * site (`${sql.length} bytes`) — um teste do `bytesUtf8` sozinho ficaria verde com o call
+ * site errado. Com a aritmética aqui dentro, `audit-custom-migrations.test.ts` prende o número
+ * ao que o filesystem enxerga, e o call site não tem mais o que errar.
+ */
+export function linhaArtefatoEscrito(caminho: string, conteudo: string): string {
+  return `✓ Escrito ${caminho} (${bytesUtf8(conteudo)} bytes)`;
 }
 
 function main() {
@@ -363,15 +375,15 @@ function main() {
 
   const sql = emitSql(audits);
   writeFileSync(SQL_OUT, sql);
-  console.log(`✓ Escrito ${SQL_OUT} (${bytesUtf8(sql)} bytes)`);
+  console.log(linhaArtefatoEscrito(SQL_OUT, sql));
 
   const md = emitMarkdown(audits);
   writeFileSync(MD_OUT, md);
-  console.log(`✓ Escrito ${MD_OUT} (${bytesUtf8(md)} bytes)`);
+  console.log(linhaArtefatoEscrito(MD_OUT, md));
 
   const totalObjects = audits.reduce((sum, a) => sum + a.objects.length, 0);
   console.log(`\nResumo: ${audits.length} migrations, ${totalObjects} objetos esperados.`);
   console.log(`Próximo passo: abra ${basename(SQL_OUT)} no Supabase SQL Editor e rode.`);
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
Sensor que ficou faltando no #1897, que corrigiu o log do audit para reportar bytes UTF-8 de verdade mas entregou a regra sem teste.

## A decisão de desenho: a unidade testada é a LINHA, não `bytesUtf8`

Ao fechar o #1897 eu disse que o teste "exercitaria `Buffer.byteLength`" — e era verdade, o que significava que o teste seria fraco. Olhando de novo, o motivo é específico e importa: **o bug morava no CALL SITE.**

```ts
console.log(`✓ Escrito ${SQL_OUT} (${sql.length} bytes)`);   // ← o bug estava AQUI
```

Um teste de `bytesUtf8` isolado passaria com esse call site intacto. Verde com o bug em produção é o pior modo de falha que um teste pode ter — pior que teste nenhum, porque dá confiança falsa.

Então a extração é `linhaArtefatoEscrito(caminho, conteudo)`: a aritmética sai do call site, e a asserção testável passa a ser exatamente a que o founder compara na prática — **número impresso × filesystem**.

## Os 3 casos

Todos com conteúdo pt-BR acentuado + emoji astral, que é o que produz a divergência UTF-16 × UTF-8:

1. **o número == `statSync().size` de um arquivo REAL** gravado em tmpdir. Deliberadamente não comparo com `Buffer.byteLength` (seria tautológico: a implementação testando a si mesma) — comparo com o que o filesystem enxerga, que é o propósito declarado do número;
2. **o número é MAIOR que `String.length`** — trava a regressão específica do #1897, e o caso falha se a amostra deixar de exercitá-la;
3. **o formato da linha é exatamente o de hoje** — o founder compara logs entre execuções, então o refactor não pode mudar a saída.

## O que o teste revelou (não estava previsto)

O módulo terminava em `main();` no topo, então **importá-lo executava o audit e reescrevia 530KB de artefato**. Medido: o RED imprimiu `Lidas 484 custom migrations` de dentro do teste. Só não sujava o working tree porque o script é idempotente — num repo em outro estado, sujaria os dois ímãs de conflito. Guardado com `if (import.meta.main) main();`, padrão com 8 precedentes em `scripts/`.

## Falsificação — 3 sabotagens, e a 1ª tentativa foi TEATRO

| # | sabotagem | resultado | marca do vermelho |
|---|---|---|---|
| A | `bytesUtf8` volta a contar UTF-16 | 🔴 2 de 3 | `expected 57 to be 74` · `expected 57 to be less than 57` |
| B | rótulo vira "caracteres" | 🔴 3 de 3 | `linha fora do formato esperado: … (74 caracteres)` |
| C | remover a guarda `import.meta.main` | 🟢 3 de 3 ← **ponto cego** | — |

Em A o caso 3 fica verde de propósito: o formato não mudou. Os casos são específicos, não um blob que reprova junto.

**A primeira tentativa da sabotagem B não aplicou** — o `perl` interpolou o `${...}` do padrão e não substituiu nada, então a suíte passou 3/3 e eu quase registrei isso como "o teste não pega". Era falsificação inócua, a armadilha que `docs/historico/audit-migrations-falso-vermelho.md` já documenta. Refeita com um sabotador que **falha se não sabotar**, ficou vermelha de verdade.

## Ponto cego declarado (medido, não suposto)

A sabotagem C mostra que a guarda não tem sensor: removê-la deixa os 3 testes verdes enquanto o audit volta a rodar no import. Está declarado no cabeçalho do teste, com a saída registrada (mover a lógica para `scripts/lib/`, como já é feito com `migration-objects.ts`). Não fiz hoje: a consequência é lentidão e reescrita idempotente durante o teste, não corrupção — e o refactor é maior que o ganho.

## Validação

```
RED    3 falharam por "linhaArtefatoEscrito is not a function"   (feature ausente, não typo)
GREEN  Tests 3 passed (3)
suíte  scripts/ inteira: Test Files 16 passed | Tests 383 passed  (vizinhos intactos)
tsc    scripts:typecheck → exit 0
lint   eslint nos 2 arquivos → exit 0
audit  bun run audit:migrations → exit 0, faz o trabalho (a guarda não silenciou o script)
       log × fs: delta 0 nos dois artefatos
ímãs   git status --short vazio — .sql e .md byte-idênticos
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
