### PR TITLE
test(carteira): prende o LITERAL do evento mixgap — o `satisfies` do #1904 protege o mapa, não a fronteira

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -642,6 +642,23 @@ Duas coisas ficaram LOCAIS de propósito, e a fronteira é a lição:
   o `satisfies` é o que a faz **falhar a compilação** se o helper ganhar um terceiro estado, em vez
   de mandar `undefined` para o PostHog.
 
+**Complemento (mesmo dia, sessão paralela): o `satisfies` protege o MAPA, não a FRONTEIRA.**
+`MOTIVO_NA_SERIE` falha a compilação se o helper ganhar um estado novo — mas não tem como impedir
+que alguém mande o estado do helper ao PostHog **por fora dele** (`track(…, { …, leitura })`). E
+essa rota não acende nenhuma das defesas de sempre: a tela não muda, e `track(event,
+Record<string, unknown>)` não tipa payload, então o `tsc` fica verde.
+
+Os 15 testes do card também não pegam, e isso foi MEDIDO por falsificação sobre o card já
+consolidado: acrescentando `leitura` ao payload, **15 verdes, 0 vermelhos** — porque eles usam
+`toMatchObject`, que ignora chave EXTRA. "Os testes passaram sem edição" prova que o refactor
+preservou comportamento; **não** prova que o literal está preso.
+
+O que prende é um assert MECÂNICO sobre o payload inteiro — *nenhum valor string do evento contém
+hífen* —, porque o vocabulário da leitura é hifenizado e o da série nunca é. Ele vale para o
+literal que ainda não foi inventado, que é justamente o que uma allowlist de valores conhecidos
+não cobre. Vive em `MixGapCard.estados.test.tsx`, describe "o alfabeto do evento não muda por
+refactor".
+
 ⚠️ **O que manteve o arquivo fora do gate `erro-colapsado-em-vazio` foi acidente feliz, e vale saber
 por quê:** o gate exige que a desestruturação do hook ligue alguma de `{error, isError, …, status}`.
 A versão antiga passava por causa do `error`; a nova passa por causa do **`status`**, que o helper

--- a/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
+++ b/src/components/farmer/__tests__/MixGapCard.estados.test.tsx
@@ -347,3 +347,105 @@ describe('MixGapCard — dado bom no cache sobrevive à atualização que falha'
     expect(eventosVistos()[1]).toMatchObject({ estado: 'com_gap', desatualizado: 'sem_rede' });
   });
 });
+
+/**
+ * FRONTEIRA DE TELEMETRIA — o alfabeto do evento é CONGELADO aqui, e de propósito.
+ *
+ * O card fala DUAS línguas que se parecem o bastante para serem trocadas sem ninguém ver:
+ *
+ *   `estadoDeLeitura` (@/lib/leitura/estado-de-leitura) devolve `'sem-rede'` — com HÍFEN;
+ *   o evento `carteira.mixgap_visto` emite `'sem_rede'`/`'aguardando_rede'` — com UNDERSCORE.
+ *
+ * Enquanto o card derivava a máquina de estados à mão os dois nunca se encontravam. Desde o
+ * #1904 ele CONSOME o helper, e os dois passaram a ficar a um `?:` de distância. O #1904 fez a
+ * tradução certa (`MOTIVO_NA_SERIE`, com `satisfies`), mas o `satisfies` protege o mapa — não
+ * protege quem decidir mandar o estado do helper adiante por FORA dele. E esse desvio não
+ * quebra nada que o compilador veja: `track(event, properties?: Record<string, unknown>)` não
+ * tipa o payload, então o `tsc` fica verde e a tela continua idêntica. O que quebra é a
+ * SÉRIE — os eventos passariam a sair sob um literal novo e a continuidade morreria no meio.
+ *
+ * E aqui não há volume que conserte: são 3 vendedores em `commercial_roles`. Uma série que
+ * reinicia não se recupera pela lei dos grandes números — é a mesma poluição de denominador
+ * que o #1859 existe para impedir (`docs/historico/fase-sem-sinal.md`).
+ *
+ * Por isso a asserção é sobre o LITERAL, não sobre o comportamento: o comportamento
+ * sobreviveria à troca. A regra mecânica — nenhum valor do payload contém hífen — pega
+ * qualquer vazamento do vocabulário do helper, inclusive um que ainda não existe.
+ */
+describe('MixGapCard — o alfabeto do evento não muda por refactor', () => {
+  const ESTADOS = ['com_gap', 'zero', 'erro', 'aguardando_rede'];
+  const MOTIVOS = ['erro', 'sem_rede'];
+
+  /** O literal do helper vaza com HÍFEN; o do evento é sempre underscore. */
+  function conferirAlfabeto(ev: Record<string, unknown>) {
+    expect(ESTADOS, `estado fora do alfabeto congelado: ${String(ev.estado)}`)
+      .toContain(ev.estado);
+    if (ev.desatualizado !== null && ev.desatualizado !== undefined) {
+      expect(MOTIVOS, `motivo fora do alfabeto congelado: ${String(ev.desatualizado)}`)
+        .toContain(ev.desatualizado);
+    }
+    // Rede de segurança genérica, e ela varre o payload INTEIRO — não as duas chaves que
+    // hoje conhecemos. É o único assert aqui que pega o vazamento que ninguém fixou, e isso
+    // foi MEDIDO contra o card do #1904: acrescentar `leitura` ao payload (o estado do helper,
+    // `'sem-rede'` quando offline) deixa os 15 testes originais VERDES — eles usam
+    // `toMatchObject`, que ignora chave extra. O vocabulário do helper é hifenizado e o do
+    // evento nunca é; a regra mecânica vale inclusive para o literal que ainda não existe.
+    for (const [chave, v] of Object.entries(ev)) {
+      if (typeof v === 'string') {
+        expect(v, `\`${chave}\` veio hifenizado (\`${v}\`) — é o vocabulário de ` +
+          '`estadoDeLeitura` vazando para o PostHog: a tela continua certa e a série QUEBRA')
+          .not.toMatch(/-/);
+      }
+    }
+  }
+
+  it('OFFLINE sem cache: o estado é `aguardando_rede`, nunca o `sem-rede` do helper', async () => {
+    onlineManager.setOnline(false);
+    resposta = { data: COM_GAP, error: null };
+    renderCard();
+
+    await waitFor(() => expect(eventoVisto()).toBeTruthy());
+    const ev = eventoVisto()!;
+    expect(ev.estado).toBe('aguardando_rede');
+    expect(ev.estado).not.toBe('sem-rede');
+    conferirAlfabeto(ev);
+  });
+
+  it('OFFLINE com cache: o motivo é `sem_rede`, nunca o `sem-rede` do helper', async () => {
+    resposta = { data: COM_GAP, error: null };
+    const { qc } = renderCard();
+    await screen.findByText('Marcenaria Alfa');
+
+    onlineManager.setOnline(false);
+    await act(async () => { void qc.invalidateQueries({ queryKey: ['my-mixgap'] }); });
+
+    await waitFor(() => expect(eventosVistos()).toHaveLength(2));
+    const ev = eventosVistos()[1];
+    expect(ev.desatualizado).toBe('sem_rede');
+    expect(ev.desatualizado).not.toBe('sem-rede');
+    conferirAlfabeto(ev);
+  });
+
+  it('a máquina INTEIRA percorrida: todo evento sai no alfabeto congelado', async () => {
+    // fresco → refetch que falha (desatualizado:'erro') → rede cai (desatualizado:'sem_rede').
+    resposta = { data: COM_GAP, error: null };
+    const { qc } = renderCard();
+    await screen.findByText('Marcenaria Alfa');
+
+    resposta = { data: null, error: { message: 'timeout' } };
+    await act(async () => { await qc.refetchQueries({ queryKey: ['my-mixgap'] }).catch(() => {}); });
+    await waitFor(() => expect(eventosVistos()).toHaveLength(2));
+
+    onlineManager.setOnline(false);
+    await act(async () => { void qc.invalidateQueries({ queryKey: ['my-mixgap'] }); });
+    await waitFor(() => expect(eventosVistos()).toHaveLength(3));
+
+    // Controle POSITIVO: sem isto o `forEach` abaixo passaria de graça numa lista vazia —
+    // "nenhum evento fora do alfabeto" é verdade trivial quando não houve evento nenhum.
+    const vistos = eventosVistos();
+    expect(vistos.length, 'a fixture parou de produzir eventos — o sweep viraria teatro')
+      .toBeGreaterThanOrEqual(3);
+    expect(vistos.map((e) => e.desatualizado)).toEqual([null, 'erro', 'sem_rede']);
+    vistos.forEach(conferirAlfabeto);
+  });
+});


### PR DESCRIPTION
## O que

O **#1904** consolidou o `MixGapCard` no helper de leitura e traduziu o vocabulário num mapa com `satisfies`. Isso está certo. Este PR fecha o que o `satisfies` **não** alcança.

## O buraco, medido

`MOTIVO_NA_SERIE` falha a compilação se `EstadoSemLeitura` ganhar um membro novo — mas não impede mandar o estado do helper ao PostHog **por fora do mapa** (`track(…, { …, leitura })`). Essa rota não acende nenhuma das defesas de sempre:

- a **tela não muda** — o vazamento é só no payload;
- o **`tsc` fica verde** — `track(event, properties?: Record<string, unknown>)` não tipa payload.

E os 15 testes existentes também não pegam. **Falsificado sobre o card já consolidado** (não sobre uma versão minha): acrescentando `leitura` ao payload, **15 verdes / 0 vermelhos** — eles usam `toMatchObject`, que ignora chave EXTRA.

> "Os testes passaram sem edição" prova que o refactor preservou COMPORTAMENTO. Não prova que o LITERAL está preso — e é o literal que a série do PostHog consome.

## O que prende

Um assert mecânico sobre o payload inteiro: *nenhum valor string do evento contém hífen* — porque o vocabulário da leitura é hifenizado (`'sem-rede'`) e o da série nunca é (`'sem_rede'`, `'aguardando_rede'`). Vale inclusive para o literal que ainda não foi inventado, que é o que uma allowlist de valores conhecidos não cobre.

Com 3 vendedores em `commercial_roles`, série que reinicia não se recupera por volume — é a mesma poluição de denominador que o #1859 existe para impedir.

3 testes novos, com **controle positivo** no sweep (sem ele, "nenhum evento fora do alfabeto" seria verdade trivial numa lista vazia).

## Falsificação (as duas direções)

| sabotagem | 15 originais | assert novo |
|---|---|---|
| trocar os literais do payload pelos do helper | 🔴 7 pegam | 🔴 3 pegam |
| vazar `leitura` numa chave EXTRA | 🟢 **todos verdes** | 🔴 1 pega — e só onde o hífen sai de fato, sem disparo falso |

## Verificação

- `heavy bun run test` → **exit 0** · 724 arquivos · 6914 testes
- `heavy bun run typecheck` → **exit 0**
- `bunx eslint` nos arquivos tocados → **exit 0**, 0 bytes
- gate `erro-colapsado-em-vazio` verde, baseline **inalterada**

Sem migration, sem edge, sem mudança de UI — só teste e doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)