### PR TITLE
fix(sonda): o marcador do recommend ficou preso em v1.5 — e o #1901 entrou 27min DEPOIS do bump [money-path]

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -118,13 +118,15 @@ SELECT net.http_post(
     'x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
   body := jsonb_build_object('action','paginacao_probe'),
   timeout_milliseconds := 20000) AS request_id;
--- ~5s depois, na MESMA aba:
+-- ANOTE o request_id devolvido acima. ~5s depois, na MESMA aba, LEIA POR ELE:
 SELECT status_code, content::jsonb->'canary' AS canary, content::jsonb->'contrato' AS contrato,
        content::jsonb->'ok' AS ok,
        (SELECT jsonb_agg(c->'caso') FROM jsonb_array_elements(content::jsonb->'casos') c
         WHERE (c->>'ok')::bool IS NOT TRUE) AS casos_vermelhos
-FROM net._http_response ORDER BY id DESC LIMIT 1;
+FROM net._http_response WHERE id = <request_id>;   -- NÃO `ORDER BY id DESC LIMIT 1`
 ```
+
+⚠️ **`ORDER BY id DESC LIMIT 1` fabrica veredito NEGATIVO — leia pelo `request_id`.** Este banco recebe resposta de cron o tempo todo (só o watchdog responde a cada ~5 min, e há timestamps com DUAS respostas no mesmo microssegundo), então "a última linha" quase nunca é a sua: entre disparar e ler, um tick alheio entra na frente. Mordido ao vivo em 2026-08-23, com a receita desta seção: a sonda da `recommend` respondeu `{"ok":true,"probe":true,"versao":"v1.5-…","edge":"recommend"}` no id 58859, o `SELECT` pegou o 58858 (`{"modo":"watchdog",…}`, 41s antes) e devolveu `edge NULL, versao NULL, status_code 200` — que é **exatamente a assinatura de "bundle pré-sensor ignorou o probe e rodou o fluxo real"** (armadilha 1 abaixo). Um deploy correto lido como deploy ausente, e o desfecho seguinte é redeployar uma edge money-path à toa. O `id` de `net._http_response` **é** o `request_id` devolvido pelo `net.http_post` — filtrar por ele é determinístico e não custa nada. Sem o número em mãos, o desempate possível é `WHERE content::jsonb->>'edge' = '<nome-da-edge>'` (o campo nasceu para isso), mas ele **degrada para zero linhas** justamente no caso que mais importa — bundle velho não emite `edge` —, e zero linhas é indistinguível de "a resposta ainda não chegou": aí confirme com `SELECT max(id) FROM net._http_response` antes de concluir.
 
 Verde = `status_code 200` **E** `canary true` **E** `contrato` batendo com a tabela acima **E** `ok true` **E** `casos_vermelhos NULL` (os cinco, não só o `ok`). `400` com `"Ação desconhecida"` = **bundle velho**, a probe não subiu — e a lista `acoes_disponiveis` da resposta é a confirmação (não cita a action nova). ⚠️ Probe é **dry-run**: se um dia uma delas abrir linha em `fin_sync_log`, ela fabrica frescor — `_data_health_compute` e `fin_calcular_confiabilidade` leem essa tabela **sem filtrar `action`** (só o `fin_sync_heartbeat` filtra). No `omie-financeiro` isso é o `PROBE_ACTIONS` → `logId=""`, pinado no `edge-money-path-invariants`.
 

--- a/supabase/functions/recommend/versao.ts
+++ b/supabase/functions/recommend/versao.ts
@@ -30,8 +30,25 @@ export const respostaSonda = criarRespostaSonda("recommend");
  * que a sonda serve ao propósito para que nasceu — este deploy depende de uma MIGRATION manual,
  * e sem ela "a edge nova está no ar?" e "a função existe no banco?" seriam duas perguntas sem
  * resposta em vez de uma consulta e uma sonda.
+ *
+ * `v1.6`: o #1901 mudou `_shared/paginate.ts`, que esta edge empacota — `fetchAllKeyset` passou a
+ * inicializar `anterior` com o `cursor` em vez de `null`, fechando a sobreposição PONTUAL de página
+ * (linha já lida reaparecendo no começo da próxima, que a checagem de cursor no fim do laço não
+ * alcança porque só olha a ÚLTIMA linha). O bump não é cosmético: `recommend` é a ÚNICA edge com
+ * call-site vivo de `fetchAllKeyset` (`order_items` e `omie_products`, via
+ * `_shared/recommend-leituras.ts`), então é aqui que o fix importa — e era aqui que ele não tinha
+ * como se provar.
+ *
+ * Por que o bump do #1898 NÃO cobriu isto, que é a armadilha a registrar: o #1905 concluiu que a
+ * `recommend` estava "resolvida de graça" porque o #1898 já a levara a `v1.5`. Verdade para o
+ * #1889 — mas o #1901 mergeou às 01:26Z, 27 minutos DEPOIS do #1898 (00:59:52Z) e 12 antes do
+ * #1905, e não bumpou nada. Resultado medido em 2026-08-23: `main` e prod respondiam ambas
+ * `v1.5-denominador-observados`, então a sonda devolvia a mesma string tendo o deploy do #1901
+ * acontecido ou não. É exatamente o pré-flight `main`×prod que o `deploy.md` firmou em 765e984ba —
+ * e a lição concreta é que o marcador cobre a fatia que o BUMPOU, não a janela de tempo: uma fatia
+ * que entra DEPOIS do bump e ANTES do deploy volta a ser invisível.
  */
-export const VERSAO = "v1.5-denominador-observados";
+export const VERSAO = "v1.6-keyset-cursor-na-primeira-linha";
 
 /** Efeito citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
## O que aconteceu

Auditoria de deploy das edges mergeadas na `main` em 2026-08-23 (janela 01:00Z–02:00Z). Duas das três se provaram no ar pela sonda de versão; a terceira ficou **inverificável** por um empate de marcador que o #1905 não viu.

| edge | veredito | evidência |
|---|---|---|
| `fin-cashflow-engine` | ✅ deployada | `net._http_response` id 58586 — `versao:"v1.1-paginacao-eof-vazio"`, string que existe em 1 commit só (`715a76174`) |
| `omie-analytics-sync` | ✅ deployada | id 58580 — o caminho da sonda só existe a partir do #1905; bundle pré-sensor responderia 400 "Ação desconhecida" |
| `analyze-unified-order` | ❌ pendente | sem sonda, sem `versao.ts` — PR irmão instala o sensor |
| `recommend` | ⚠️ **indeterminado** | **este PR** |

## A raiz

O #1905 concluiu que a `recommend` estava "resolvida de graça" porque o #1898 já a levara a `v1.5-denominador-observados`. Verdade para o #1889 — mas o **#1901 mergeou às 01:26Z**, 27 minutos DEPOIS do #1898 (00:59:52Z) e 12 antes do #1905, tocando `_shared/paginate.ts`, que a `recommend` empacota. Ninguém bumpou nada por causa dele.

Medido em prod: a sonda respondeu `v1.5-denominador-observados` — a **mesma string que a `main` declara**. Marcador igual dos dois lados responde igual tendo o deploy acontecido ou não. É exatamente o pré-flight \`main\`×prod que o 765e984ba acabou de firmar, falhando no caso concreto que ficou aberto.

**E é aqui que importa:** `recommend` é a ÚNICA edge com call-site vivo de `fetchAllKeyset` (`order_items` e `omie_products`, via `_shared/recommend-leituras.ts`). Onde o fix do #1901 tem efeito é exatamente onde o deploy não se provava.

## A lição registrada no `versao.ts`

O marcador cobre **a fatia que o bumpou**, não a janela de tempo. Fatia que entra DEPOIS do bump e ANTES do deploy volta a ser invisível.

## De passagem: a receita SQL da §Canárias fabricava veredito NEGATIVO

Mordeu ao vivo hoje. `ORDER BY id DESC LIMIT 1` pegou o tick do watchdog (id 58858) em vez da sonda (58859, 41s depois) e devolveu `edge NULL, versao NULL, status_code 200` — **byte a byte a assinatura de "bundle pré-sensor ignorou o probe e rodou o fluxo real"**. Deploy correto lido como deploy ausente, e o passo seguinte seria redeployar uma edge money-path à toa. Agora a receita lê por `WHERE id = <request_id>` (o `id` da resposta **é** o request_id do `net.http_post`), com o modo de falha do fallback por `edge` explicitado.

## Gate

`deno test --no-remote supabase/functions/_shared/sonda-versao-contrato_test.ts` → **23 passed, 0 failed, exit 0** (o formato `vN.N-slug` do marcador novo, a unicidade da resposta entre edges e a identidade `edge:"recommend"`).

⚠️ **Este PR é pré-requisito do deploy, não consequência dele** — o marcador precisa estar na `main` ANTES do deploy da `recommend`, senão a viagem continua inverificável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)