### PR TITLE
feat(analytics): habilita LEITURA do PostHog — o repo instalava sensor que ninguém conseguia ler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@
 | tintométrico (fórmula↔receita, preço fail-closed, import) | [tintometrico.md](docs/agent/tintometrico.md) |
 | lente "Ver como" (impersonação, write-guard) | [impersonation.md](docs/agent/impersonation.md) |
 | telefonia (WebRTC, SIP, LGPD) | [telefonia.md](docs/agent/telefonia.md) |
+| analytics · ler PostHog (HogQL read-only, sensores) | [analytics.md](docs/agent/analytics.md) |
 | skills & MCPs (roteamento canônico) | [skills.md](docs/agent/skills.md) |
 | **mapa do app** ("onde faço X" · rotas/gates · **3 empresas** · princípios) | [mapa-do-app.md](docs/agent/mapa-do-app.md) |
 | worktrees · multi-sessão · RAM/Node · `heavy` | [worktrees.md](docs/agent/worktrees.md) |

--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -1,0 +1,93 @@
+# Analytics — ler o PostHog de dentro de uma sessão de agente
+
+> **Regra que este doc serve:** `docs/historico/fase-sem-sinal.md` — *fase N+1 exige ≥1 sinal
+> POSITIVO de uso em prod, **com denominador**; "quando medir" é **query**, não recado.*
+> Até 2026-08-23 essa regra era **incumprível** para todo sensor de frontend: o repo instalava
+> `track()` que ninguém conseguia ler.
+
+## 1. O buraco que existia (medido, PR #1900)
+
+Ao tentar ler a série de `carteira.mixgap_visto`, as **quatro** vias de acesso foram testadas e
+as quatro estavam fechadas:
+
+| via | estado medido em 2026-08-22 |
+|---|---|
+| plugin/MCP PostHog | `"posthog@claude-plugins-official": false`; `ListPlugins` vazio |
+| Personal API Key | inexistente — nem `.env`, nem env, nem `~/.config/afiacao/`, nem `~/.config/posthog` |
+| navegador logado | `/browse` headless **e** Chrome real caem em `us.posthog.com/login` |
+| espelho no banco | nenhuma tabela replica `carteira.*` (só `posthog_error_webhook_log`, do webhook de e-mail) |
+
+**`VITE_POSTHOG_KEY` (`phc_…`) não serve**: é a chave PÚBLICA de **ingestão** — escreve evento,
+não consulta. Confundir as duas é o erro mais fácil aqui, e o wrapper barra explicitamente.
+
+## 2. A via escolhida: Personal API Key read-only + wrapper versionado
+
+Optamos pela **Opção A** (key read-only) e não pelo plugin MCP porque: o escopo é **verificável e
+mínimo** (só leitura, revogável em 1 clique), funciona **headless** (sessão não-interativa não roda
+OAuth), e a lógica fica **versionada e testada** no repo em vez de num plugin opaco.
+
+- **Segredo:** `~/.config/afiacao/posthog-ro`, `0600`, **fora do repo** — mesmo padrão do
+  `claude_ro.pgpass`. O wrapper **recusa** permissão mais frouxa que `600`.
+- **Wrapper:** [`scripts/posthog-query.sh`](../../scripts/posthog-query.sh) — versionado, `shellcheck`-limpo,
+  com suíte hermética em `scripts/test-posthog-query.sh` (roda no `bun run test:hooks`).
+- `~/.config/afiacao/posthog-query` é um **symlink** para o script no checkout principal, para o
+  caminho curto continuar existindo como no `psql-ro`.
+
+### Instalar a key (só o founder faz — a key NUNCA passa pelo chat)
+
+1. https://us.posthog.com/settings/user-api-keys → **New personal API key**.
+2. Escopos **apenas de leitura**: `query:read`, `insight:read`, `event:read`. **Não** dar escopo de
+   escrita. Em "Organization & project access", liberar o projeto do Afiação.
+3. No terminal. O `read -rs` é deliberado: a key entra por **prompt**, então não passa por `argv`
+   (visível em `ps`) nem pelo histórico do zsh — colar num `printf` deixaria o segredo nos dois.
+
+```bash
+mkdir -p ~/.config/afiacao && umask 077 && read -rs "?Cole a Personal API Key (phx_...): " k && printf '%s\n' "$k" > ~/.config/afiacao/posthog-ro && unset k && chmod 600 ~/.config/afiacao/posthog-ro && echo "" && echo "instalado: $(wc -c < ~/.config/afiacao/posthog-ro) bytes"
+```
+
+   Depois que este PR mergear, o atalho curto (opcional, espelha o `psql-ro`):
+
+```bash
+ln -sf /Users/lucassardenberg/Projetos/afiacao/scripts/posthog-query.sh ~/.config/afiacao/posthog-query && echo "symlink pronto"
+```
+
+4. Se a key for **escopada a um projeto**, `@current` pode não resolver (HTTP 403). Nesse caso grave
+   o id numérico (está na URL do PostHog, `/project/<id>/`) em `~/.config/afiacao/posthog-project-id`.
+
+## 3. Uso
+
+```bash
+~/.config/afiacao/posthog-query "SELECT count() FROM events WHERE timestamp > now() - INTERVAL 30 DAY"
+```
+
+Aceita HogQL por argumento **ou** stdin. Saída **compacta por padrão** —
+`{"columns":[…],"results":[…],"row_count":N}` — porque o payload cru do PostHog traz
+`clickhouse`/`hogql`/`explain`/`metadata` e queima contexto de sessão sem acrescentar dado. Use
+`--cru` quando precisar do SQL gerado para depurar.
+
+**Exit codes** (`0` é o único que significa "respondeu"):
+`0` respondeu · `64` uso errado · `65` HogQL inválido (400) · `68` rede/HTTP inesperado ·
+`69` dependência ausente/quebrada · `75` rate limit (429) · `77` sem auth (key ausente/vazia/`phc_`/
+permissão frouxa/401/403).
+
+## 4. Armadilhas
+
+- **Ler a série ANTES de provar exposição fabrica conclusão.** `fase-sem-sinal.md` §5: sem população
+  exposta na janela, série vazia é indistinguível de "o estado não ocorre". Sempre rode o **controle
+  sem filtro de evento** junto — série do evento vazia **com** controle positivo é dado real; as duas
+  vazias é sensor não chegando.
+- **`phc_` ≠ `phx_`.** A primeira escreve, a segunda consulta. O wrapper diagnostica a troca.
+- **Arquivo de key VAZIO passa despercebido.** `~/.config/afiacao/supabase-pat` existe com **0 bytes**
+  desde 2026-07-27 — criado e nunca preenchido. O wrapper trata `-s` (vazio) como falha explícita,
+  porque `command -v`/existência de arquivo é sonda **cega** a esse caso.
+- **A key não entra em `argv`.** Vai por `curl --config` (arquivo `0600`, apagado no trap): `-H` a
+  deixaria visível em `ps` para qualquer processo do usuário. A suíte prende isso, com falsificação.
+- **Escapar HogQL à mão erra em silêncio.** O corpo é montado por `jq`, que é dependência
+  **obrigatória** — query mal-escapada devolveria número **errado** em vez de falhar, que é
+  fabricação de dado (regra do money-path).
+
+## 5. Sensores de frontend já instalados
+
+`carteira.mixgap_visto` (`estado`, `total_com_gap`, `desatualizado`) ·
+`carteira.positivacao_vista` · `dashboard.*` e `offline.*` (walkthrough de 2026-05-17).
+Convenção de nome: `<area>.<action>`, emitido por `track()` de `@/lib/analytics`.

--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -36,13 +36,37 @@ OAuth), e a lógica fica **versionada e testada** no repo em vez de num plugin o
 ### Instalar a key (só o founder faz — a key NUNCA passa pelo chat)
 
 1. https://us.posthog.com/settings/user-api-keys → **New personal API key**.
-2. Escopos **apenas de leitura**: `query:read`, `insight:read`, `event:read`. **Não** dar escopo de
-   escrita. Em "Organization & project access", liberar o projeto do Afiação.
-3. No terminal. O `read -rs` é deliberado: a key entra por **prompt**, então não passa por `argv`
-   (visível em `ps`) nem pelo histórico do zsh — colar num `printf` deixaria o segredo nos dois.
+2. Escopos **apenas de leitura** — na UI eles têm nome legível, e **não existe um escopo "Event"
+   avulso** (medido em 2026-08-23; a lista traz *Event definition* e *Event filter*). O mínimo que
+   faz o `/query/` funcionar é **Query → Read**; os outros só ampliam descoberta:
+
+   | linha na UI | valor | para quê |
+   |---|---|---|
+   | **Query** | Read | **essencial** — é o escopo do endpoint `/query/` |
+   | Insight | Read | ler insights salvos |
+   | Event definition | Read | descobrir quais eventos existem de fato |
+   | Property definition | Read | descobrir os nomes de propriedade de um evento |
+
+   Todo o resto fica em **No access** — em especial *Session recording* e *Person*, que são os
+   pesados em PII. Nenhum **Write**, em lugar nenhum.
+
+   Em "Organization & project access", escolher **Projects** e marcar só o projeto do Afiação
+   (`423408`) — não "All access".
+3. Com a key ainda na área de transferência (o PostHog só a mostra **uma vez**), mande o clipboard
+   direto pro arquivo. Assim o segredo não passa por `argv` (`ps`) nem pelo histórico do shell, e
+   não depende de TTY:
 
 ```bash
-mkdir -p ~/.config/afiacao && umask 077 && read -rs "?Cole a Personal API Key (phx_...): " k && printf '%s\n' "$k" > ~/.config/afiacao/posthog-ro && unset k && chmod 600 ~/.config/afiacao/posthog-ro && echo "" && echo "instalado: $(wc -c < ~/.config/afiacao/posthog-ro) bytes"
+mkdir -p ~/.config/afiacao && umask 077 && pbpaste > ~/.config/afiacao/posthog-ro && chmod 600 ~/.config/afiacao/posthog-ro && awk 'NR==1{print (/^phx_/ ? "OK: key phx_ com " length($0) " chars" : "PROBLEMA: o clipboard nao tem uma key phx_")}' ~/.config/afiacao/posthog-ro
+```
+
+   Se o clipboard já tiver sido perdido, o fallback é por prompt — **e note o dialeto**: a forma
+   `read -rs "?prompt" var` é **só zsh**. Em bash ela falha (`?prompt` vira nome de variável), o
+   `&&` interrompe a cadeia e **nenhum arquivo é criado** — falha silenciosa que já aconteceu aqui
+   em 2026-08-23. A forma abaixo roda nos dois:
+
+```bash
+mkdir -p ~/.config/afiacao && umask 077 && printf 'Cole a key: ' && IFS= read -rs k && printf '%s\n' "$k" > ~/.config/afiacao/posthog-ro && unset k && chmod 600 ~/.config/afiacao/posthog-ro && printf '\n' && awk 'NR==1{print (/^phx_/ ? "OK: " length($0) " chars" : "PROBLEMA: nao comeca com phx_")}' ~/.config/afiacao/posthog-ro
 ```
 
    Depois que este PR mergear, o atalho curto (opcional, espelha o `psql-ro`):
@@ -51,8 +75,10 @@ mkdir -p ~/.config/afiacao && umask 077 && read -rs "?Cole a Personal API Key (p
 ln -sf /Users/lucassardenberg/Projetos/afiacao/scripts/posthog-query.sh ~/.config/afiacao/posthog-query && echo "symlink pronto"
 ```
 
-4. Se a key for **escopada a um projeto**, `@current` pode não resolver (HTTP 403). Nesse caso grave
-   o id numérico (está na URL do PostHog, `/project/<id>/`) em `~/.config/afiacao/posthog-project-id`.
+4. O id do projeto já está fixado em `~/.config/afiacao/posthog-project-id` (`423408`, lido da URL
+   `us.posthog.com/project/423408/…` — não é segredo). Fixá-lo é o que torna a key **escopada a um
+   projeto** segura de usar: sem ele o wrapper cai em `@current`, que resolve pelo `current_team` da
+   conta e devolve **403** quando os dois divergem.
 
 ## 3. Uso
 

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -983,3 +983,79 @@ agora por uma causa nomeada, que não se conserta com SQL.
 caixa **compartilhada** de atendimento, com o nome pessoal dela no `profiles`. Conta de função não
 tem dono; é candidata natural a ninguém sentir que é sua. Vale conferir com o founder antes de
 tratar como conta individual.)*
+
+---
+
+## A série do MixGap era LEGÍVEL — e ninguém tinha como ler (2026-08-23)
+
+O §7 do topo deixou uma query "para quando houver exposição". Ao tentar rodá-la descobriu-se algo
+anterior: **não havia via de leitura nenhuma.** As quatro foram medidas e as quatro estavam fechadas
+— plugin PostHog desabilitado em `.claude/settings.json`, nenhuma Personal API Key em lugar algum,
+navegador (headless e real) caindo em `/login`, e nenhum espelho de `carteira.*` no banco.
+`VITE_POSTHOG_KEY` existe, mas é `phc_` — chave **pública de ingestão**, que escreve evento e não
+consulta.
+
+Isto é mais grave que uma pendência de medição: **a regra deste arquivo era incumprível por
+construção.** O repo instalava sensor (`carteira.mixgap_visto`, `carteira.positivacao_vista`,
+`dashboard.*`, `offline.*`) sem que ninguém pudesse lê-lo. "Quando medir é query, não recado" só
+vale se a query for executável.
+
+A via foi construída (`scripts/posthog-query.sh` + Personal API Key read-only 0600; detalhe em
+[docs/agent/analytics.md](../agent/analytics.md)) e as queries rodaram:
+
+| leitura | resultado |
+|---|---|
+| sanidade — `count()` de eventos em 30d | **699** |
+| **série** de `carteira.mixgap_visto` desde o Publish do #1892 | **vazia** (0 linhas) |
+| **controle** — mesma janela, sem filtro de evento | **11 eventos, 1 pessoa** |
+
+### 1. O controle positivo não bastava — quem decidiu foi o IRMÃO
+
+Série vazia **com controle positivo** é, pela regra do §7, dado real. Mas o controle sozinho é fraco:
+prova que *alguma* telemetria chega, não que chegaria *deste* sensor. A prova forte veio de um
+terceiro eixo — o **irmão na mesma superfície**:
+
+- `carteira.positivacao_vista` chegou ao PostHog **3×** em 90 dias (última: `2026-08-14T17:03:20Z`);
+- `carteira.mixgap_visto` **nunca** chegou — zero em 90 dias;
+- os dois montam na **mesma página**, `src/pages/FarmerCalls.tsx` (`PositivacaoHero` e `MixGapCard`).
+
+Logo o caminho evento→PostHog está provado **para esta tela**, e a série vazia não pode ser falha de
+transporte. Some-se que os 11 eventos da janela são só `$autocapture`/`$pageview`/`$pageleave`/`$set`
+— **nenhum evento custom**: a única pessoa ativa depois do Publish nunca abriu a FarmerCalls.
+
+### 2. Terceira fonte independente para o denominador da employee A
+
+A seção anterior deste arquivo estabeleceu, por `auth.refresh_tokens`, que agosto da employee A foi
+**1 dia — o dia 14**. A telemetria, medida sem conhecer aquele número, põe o último
+`carteira.positivacao_vista` em `2026-08-14T17:03:20Z`.
+
+São **três** trilhas independentes convergindo no mesmo dia: `auth.sessions` (§6 do topo),
+`auth.refresh_tokens` (seção anterior) e PostHog. E a convergência tem valor além da confirmação:
+a seção anterior mostrou que `auth.sessions` **superestima inatividade** e `last_sign_in_at`
+**subestima uso** — a telemetria de produto não tem nenhum dos dois vieses, porque só existe se
+alguém renderizou a tela. É a única das três que mede **exposição ao sensor**, que é exatamente o
+denominador que o §5 do topo pediu.
+
+O que ela acrescenta ao caso do MixGap: o dia 14 é **8 dias ANTES** do Publish do #1892. A employee A
+nunca teve como ver o card.
+
+### 3. Achado lateral: o sensor de dashboard tem os dois lados desencontrados
+
+`dashboard.viewed` disparou **8×** (1 pessoa) em 30 dias, enquanto `dashboard_visits` — a tabela
+criada em 2026-05-17 justamente para registrar visita server-side — segue com **0 linhas**
+(reconfirmado via `psql-ro`). O sensor client-side funciona; o server-side nunca foi ligado. O §6 do
+topo registrava a tabela vazia como "mais um sensor que nunca mediu"; agora sabe-se que a visita
+**ocorre** e só o registro server-side falha — o que é **bug**, não ausência de uso.
+
+Denominador de 30 dias, para calibrar leituras futuras: **3 pessoas distintas**, 699 eventos.
+
+### 4. A regra que isto acrescenta
+
+**A via de leitura é PRÉ-REQUISITO de instalar o sensor, não consequência.** Um `track()` sem caminho
+de consulta não é telemetria: é código morto que *parece* medição, e passa em todo CI. Antes de
+mergear sensor novo, a pergunta é "qual comando lê esta série, e ele roda?" — se a resposta não é um
+comando executável, a fase N+1 é construir a via, não instalar mais sensor.
+
+**Corolário sobre o controle:** controle positivo prova que a telemetria chega, **não** que chegaria
+daquele sensor. Quando existir um **irmão na mesma superfície** com histórico, ele é a testemunha
+mais forte — foi o que separou "ninguém abriu a tela" de "o evento se perdeu" aqui.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
     "claude:instr": "bash scripts/instrucoes-relatorio.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan; do bash scripts/test-$t.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/claude-md-secoes-baseline.txt
+++ b/scripts/claude-md-secoes-baseline.txt
@@ -5,8 +5,8 @@
 # Por que teto por seção (e não só do arquivo inteiro): topo de scripts/check-claude-md-budget.sh.
 110	(preâmbulo)
 312	## Preferências do founder (Lucas)
-170	## Índice — `docs/agent/` (referência operacional, LEIA o doc ANTES de tocar o domínio)
-1083	## ⚠️ Armadilhas recorrentes (caras — a maioria money-path/banco; detalhe no doc/agent indicado)
+181	## Índice — `docs/agent/` (referência operacional, LEIA o doc ANTES de tocar o domínio)
+1079	## ⚠️ Armadilhas recorrentes (caras — a maioria money-path/banco; detalhe no doc/agent indicado)
 84	## Merge (auto)
 158	## Stack
 148	## Design System (v3 — "fintech premium": Vercel/Mercury/Stripe Dashboard)

--- a/scripts/posthog-query.sh
+++ b/scripts/posthog-query.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# posthog-query.sh — HogQL READ-ONLY contra o PostHog de PRODUÇÃO do Afiação.
+#
+# Existe porque o repo instalava sensores de frontend (`carteira.mixgap_visto`,
+# `carteira.positivacao_vista`, `dashboard.*`, `offline.*`) que NINGUÉM conseguia
+# ler: em 2026-08-22 (PR #1900) as quatro vias de acesso foram medidas e as quatro
+# estavam fechadas — plugin desabilitado, nenhuma Personal API Key, navegador sem
+# sessão, nenhum espelho no banco. Sem esta via, a regra de
+# docs/historico/fase-sem-sinal.md ("fase N+1 exige ≥1 sinal POSITIVO de uso em
+# prod, COM denominador; 'quando medir' é query, não recado") era incumprível
+# para todo sensor de frontend — o repo instalava sensor cego por construção.
+#
+# A key é Personal API Key de escopo SÓ-LEITURA (query:read/insight:read/
+# event:read), 0600 FORA do repo — mesmo padrão do ~/.config/afiacao/claude_ro.pgpass.
+# Ela nunca entra em argv: vai por `curl --config`, senão apareceria em `ps`.
+# O read-only real é o ESCOPO no servidor; o script só nunca constrói outra URL
+# que não `/query/` (HogQL não tem DML), então não há blocklist de texto — que
+# seria teatro.
+#
+# Uso:
+#   scripts/posthog-query.sh "SELECT count() FROM events WHERE ..."
+#   echo "SELECT ..." | scripts/posthog-query.sh
+#   scripts/posthog-query.sh --cru "SELECT ..."    # payload inteiro do PostHog
+#
+# Saída (default): {"columns":[…],"results":[…],"row_count":N} — compacto de
+# PROPÓSITO: o payload cru traz clickhouse/hogql/explain/metadata e queima
+# contexto de sessão de agente sem acrescentar dado. `--cru` quando precisar do
+# SQL gerado pra depurar.
+#
+# Exit: 0=respondeu · 64=uso errado · 65=HogQL inválido (HTTP 400) ·
+#       68=rede/HTTP inesperado · 69=dependência ausente/quebrada ·
+#       75=rate limit (HTTP 429) · 77=sem auth (key ruim, ou HTTP 401/403)
+#
+# Sondas são FAIL-CLOSED e exigem resposta POSITIVA: `command -v` não basta
+# (binário presente-porém-quebrado passaria), e arquivo de key VAZIO é o modo de
+# falha já observado neste repo — ~/.config/afiacao/supabase-pat existe com
+# 0 bytes desde 2026-07-27.
+set -u
+
+KEYFILE="${POSTHOG_RO_KEY_FILE:-$HOME/.config/afiacao/posthog-ro}"
+IDFILE="${POSTHOG_PROJECT_ID_FILE:-$HOME/.config/afiacao/posthog-project-id}"
+HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
+
+cru=0
+query=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cru) cru=1 ;;
+    -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*) echo "❌ flag desconhecida: $1 (só existem --cru e --help)" >&2; exit 64 ;;
+    *) query="$1" ;;
+  esac
+  shift
+done
+
+# stdin só quando não veio argumento E não é terminal — senão o script pendura
+# esperando digitação, que numa sessão de agente vira timeout sem diagnóstico.
+if [ -z "$query" ] && [ ! -t 0 ]; then query="$(cat)"; fi
+if [ -z "${query//[[:space:]]/}" ]; then
+  echo "❌ uso: $0 \"<HogQL>\"   (ou HogQL no stdin)" >&2
+  exit 64
+fi
+
+# --- sondas positivas -------------------------------------------------------
+curl --version >/dev/null 2>&1 || {
+  echo "❌ curl ausente ou quebrado (não respondeu a --version)" >&2; exit 69; }
+
+# jq é OBRIGATÓRIO pra MONTAR o corpo: escapar HogQL (aspas, quebra de linha,
+# barra) à mão em bash erra em silêncio, e query mal-escapada devolve resultado
+# ERRADO em vez de falhar — fabricação de número, que é o pecado do money-path.
+# Na LEITURA da resposta ele é opcional (degradar pra JSON cru só perde compactação).
+[ "$(jq -rn '"ok"' 2>/dev/null)" = "ok" ] || {
+  echo "❌ jq ausente ou quebrado — necessário pra escapar o HogQL com segurança" >&2
+  echo "   → brew install jq" >&2; exit 69; }
+
+[ -f "$KEYFILE" ] || {
+  echo "❌ key do PostHog ausente: $KEYFILE" >&2
+  echo "   → veja docs/agent/analytics.md (§ instalar a key)" >&2; exit 77; }
+[ -s "$KEYFILE" ] || {
+  echo "❌ key do PostHog VAZIA (0 bytes): $KEYFILE" >&2
+  echo "   → arquivo criado mas nunca preenchido; veja docs/agent/analytics.md" >&2; exit 77; }
+
+perm="$(stat -f '%Lp' "$KEYFILE" 2>/dev/null)" || perm="$(stat -c '%a' "$KEYFILE" 2>/dev/null)"
+case "$perm" in
+  *00) : ;;
+  "") echo "⚠️  não consegui ler a permissão de $KEYFILE — seguindo" >&2 ;;
+  *) echo "❌ $KEYFILE tem permissão $perm — segredo legível por outros" >&2
+     echo "   → chmod 600 $KEYFILE" >&2; exit 77 ;;
+esac
+
+key="$(tr -d ' \t\r\n' < "$KEYFILE")"
+case "$key" in
+  phx_*) : ;;
+  phc_*) echo "❌ isso é a chave PÚBLICA de INGESTÃO (phc_), que escreve evento e não consulta." >&2
+         echo "   → precisa de uma Personal API Key (phx_); veja docs/agent/analytics.md" >&2; exit 77 ;;
+  *) echo "❌ key em $KEYFILE não parece Personal API Key (esperado prefixo phx_)" >&2; exit 77 ;;
+esac
+
+projeto="${POSTHOG_PROJECT_ID:-}"
+if [ -z "$projeto" ] && [ -s "$IDFILE" ]; then projeto="$(tr -d ' \t\r\n' < "$IDFILE")"; fi
+projeto="${projeto:-@current}"
+
+# --- requisição -------------------------------------------------------------
+umask 077
+tmp="$(mktemp -d)" || { echo "❌ mktemp falhou" >&2; exit 68; }
+trap 'rm -rf "$tmp"' EXIT
+
+jq -n --arg q "$query" '{query: {kind: "HogQLQuery", query: $q}}' > "$tmp/payload.json" || {
+  echo "❌ jq falhou ao montar o corpo da requisição" >&2; exit 68; }
+
+# A key vai pelo --config e NÃO por -H: argv é visível em `ps` pra qualquer
+# processo do usuário. O arquivo nasce sob umask 077 e morre no trap.
+printf 'header = "Authorization: Bearer %s"\n' "$key" > "$tmp/curl.cfg"
+
+status="$(curl --config "$tmp/curl.cfg" \
+  -sS --max-time 120 \
+  -H 'Content-Type: application/json' \
+  -X POST "$HOST/api/projects/$projeto/query/" \
+  --data-binary "@$tmp/payload.json" \
+  -o "$tmp/body.json" -w '%{http_code}' 2>"$tmp/curl.err")"
+rc=$?
+
+if [ "$rc" -ne 0 ]; then
+  echo "❌ curl falhou (exit $rc) contra $HOST" >&2
+  head -c 500 "$tmp/curl.err" >&2; echo >&2
+  exit 68
+fi
+
+case "$status" in
+  200) : ;;
+  400) echo "❌ HTTP 400 — HogQL inválido:" >&2
+       jq -r '.detail // .error // .' "$tmp/body.json" 2>/dev/null | head -c 800 >&2 || head -c 800 "$tmp/body.json" >&2
+       echo >&2; exit 65 ;;
+  401|403) echo "❌ HTTP $status — key rejeitada ou sem o escopo necessário (query:read)." >&2
+       jq -r '.detail // .' "$tmp/body.json" 2>/dev/null | head -c 500 >&2
+       echo >&2
+       [ "$projeto" = "@current" ] && echo "   → se a key é ESCOPADA a um projeto, @current pode não resolver: grave o id numérico em $IDFILE" >&2
+       exit 77 ;;
+  429) echo "❌ HTTP 429 — rate limit do PostHog. Espere e repita." >&2; exit 75 ;;
+  *) echo "❌ HTTP $status inesperado de $HOST" >&2
+     head -c 800 "$tmp/body.json" >&2; echo >&2; exit 68 ;;
+esac
+
+if [ "$cru" -eq 1 ]; then
+  cat "$tmp/body.json"
+else
+  jq -c '{columns: .columns, results: .results, row_count: (.results | length)}' "$tmp/body.json" \
+    || { echo "⚠️  jq falhou ao compactar — devolvendo payload cru" >&2; cat "$tmp/body.json"; }
+fi

--- a/scripts/test-posthog-query.sh
+++ b/scripts/test-posthog-query.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# test-posthog-query.sh — TDD do scripts/posthog-query.sh com `curl` STUBADO (sem rede).
+#
+# Contrato testado: 0=respondeu · 64=uso errado · 65=HogQL inválido (400) ·
+# 68=rede/HTTP inesperado · 69=dependência quebrada · 75=rate limit (429) ·
+# 77=sem auth (key ausente/VAZIA/phc_/permissão frouxa/401/403).
+#
+# Os dois testes que justificam o arquivo existir:
+#   - a key NÃO aparece em argv (senão vaza pra `ps` de qualquer processo do usuário);
+#   - HogQL com aspas/quebra-de-linha chega ao servidor ÍNTEGRO (escape errado
+#     devolveria número ERRADO em silêncio, que é fabricação de dado).
+# Ambos terminam com FALSIFICAÇÃO: o sensor é sabotado e tem de ficar VERMELHO.
+#
+# Uso: bash scripts/test-posthog-query.sh   (exit 0 = tudo verde)
+set -u
+
+here="$(cd "$(dirname "$0")" && pwd)"
+SUT="$here/posthog-query.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+falhas=0
+ok()    { printf '  ✅ %s\n' "$1"; }
+falha() { printf '  ❌ %s\n' "$1"; falhas=$((falhas + 1)); }
+
+# Confere exit code esperado. Uso: espera <code> <descrição> -- <cmd...>
+espera() {
+  local want="$1" desc="$2"; shift 3
+  local out; out="$("$@" 2>&1)"; local got=$?
+  if [ "$got" -eq "$want" ]; then ok "$desc (exit $got)"
+  else falha "$desc — esperava exit $want, veio $got · saída: $(printf '%s' "$out" | head -c 160)"; fi
+}
+
+# --- stub de curl -----------------------------------------------------------
+# Grava argv/config/payload em $tmp e devolve corpo+status conforme CURL_STUB_STATUS.
+cat >"$tmp/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in --version) echo "curl 8.0.0 (stub)"; exit 0 ;; esac
+printf '%s\n' "$@" > "$CURL_STUB_ARGV"
+saida=""; cfg=""; payload=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) saida="$2"; shift ;;
+    --config) cfg="$2"; shift ;;
+    --data-binary) payload="${2#@}"; shift ;;
+  esac
+  shift
+done
+[ -n "$cfg" ] && cp "$cfg" "$CURL_STUB_CFG"
+[ -n "$payload" ] && cp "$payload" "$CURL_STUB_PAYLOAD"
+if [ "${CURL_STUB_STATUS}" = "REDE" ]; then echo "could not resolve host" >&2; exit 6; fi
+cat >"$saida" <<'BODY'
+{"columns":["n"],"results":[[42]],"types":[["n","Int64"]],"hogql":"SELECT count()","clickhouse":"SELECT ...","metadata":{"x":1}}
+BODY
+[ "$CURL_STUB_STATUS" != "200" ] && printf '{"detail":"erro sintetico do stub"}' >"$saida"
+printf '%s' "$CURL_STUB_STATUS"
+exit 0
+STUB
+chmod +x "$tmp/bin/curl"
+
+export CURL_STUB_ARGV="$tmp/argv.txt" CURL_STUB_CFG="$tmp/cfg.txt" CURL_STUB_PAYLOAD="$tmp/payload.json"
+export PATH="$tmp/bin:$PATH"
+export POSTHOG_API_HOST="https://exemplo.invalido"
+export POSTHOG_PROJECT_ID="1234"
+export POSTHOG_PROJECT_ID_FILE="$tmp/sem-id"
+
+# keys sintéticas — NÃO são credenciais, só casam o formato que o script exige
+key_boa="$tmp/key-boa";    printf 'phx_TESTE_SINTETICA_0123456789\n' > "$key_boa";  chmod 600 "$key_boa"
+key_vazia="$tmp/key-vazia"; : > "$key_vazia";                                        chmod 600 "$key_vazia"
+key_phc="$tmp/key-phc";     printf 'phc_publica_de_ingestao\n' > "$key_phc";          chmod 600 "$key_phc"
+key_frouxa="$tmp/key-frouxa"; printf 'phx_TESTE_SINTETICA_0123456789\n' > "$key_frouxa"; chmod 644 "$key_frouxa"
+
+echo "== uso errado =="
+export POSTHOG_RO_KEY_FILE="$key_boa" CURL_STUB_STATUS=200
+espera 64 "sem query e sem stdin"       -- bash "$SUT" </dev/null
+espera 64 "query só com espaço em branco" -- bash "$SUT" "   " </dev/null
+espera 64 "flag desconhecida"           -- bash "$SUT" --inventada "SELECT 1" </dev/null
+
+echo "== auth fail-closed =="
+espera 77 "key AUSENTE"                 -- env POSTHOG_RO_KEY_FILE="$tmp/nao-existe" bash "$SUT" "SELECT 1" </dev/null
+espera 77 "key VAZIA (0 bytes)"         -- env POSTHOG_RO_KEY_FILE="$key_vazia" bash "$SUT" "SELECT 1" </dev/null
+espera 77 "key phc_ (ingestão, não consulta)" -- env POSTHOG_RO_KEY_FILE="$key_phc" bash "$SUT" "SELECT 1" </dev/null
+espera 77 "key com permissão 644"       -- env POSTHOG_RO_KEY_FILE="$key_frouxa" bash "$SUT" "SELECT 1" </dev/null
+
+echo "== códigos HTTP =="
+espera 65 "HTTP 400 → HogQL inválido"   -- env CURL_STUB_STATUS=400 bash "$SUT" "SELECT xx" </dev/null
+espera 77 "HTTP 401 → sem auth"         -- env CURL_STUB_STATUS=401 bash "$SUT" "SELECT 1" </dev/null
+espera 77 "HTTP 403 → escopo faltando"  -- env CURL_STUB_STATUS=403 bash "$SUT" "SELECT 1" </dev/null
+espera 75 "HTTP 429 → rate limit"       -- env CURL_STUB_STATUS=429 bash "$SUT" "SELECT 1" </dev/null
+espera 68 "HTTP 500 → inesperado"       -- env CURL_STUB_STATUS=500 bash "$SUT" "SELECT 1" </dev/null
+espera 68 "curl falha de rede"          -- env CURL_STUB_STATUS=REDE bash "$SUT" "SELECT 1" </dev/null
+
+echo "== dependência quebrada (sonda positiva, não command -v) =="
+mkdir -p "$tmp/bin-quebrado"
+printf '#!/bin/sh\nexit 1\n' > "$tmp/bin-quebrado/curl"; chmod +x "$tmp/bin-quebrado/curl"
+espera 69 "curl PRESENTE mas quebrado"  -- env PATH="$tmp/bin-quebrado:$PATH" bash "$SUT" "SELECT 1" </dev/null
+# O exit 69 sozinho e AMBIGUO (curl e jq compartilham o codigo): exija a MARCA do ramo,
+# senao o teste fica verde com a sonda ERRADA falhando primeiro — que foi o que aconteceu
+# na primeira rodada desta suite, com a sonda de jq alimentada com JSON invalido.
+msg_curl="$(PATH="$tmp/bin-quebrado:$PATH" bash "$SUT" "SELECT 1" 2>&1 </dev/null)"
+case "$msg_curl" in
+  *curl*) ok "exit 69 aponta CURL (nao o jq)" ;;
+  *) falha "exit 69 veio de outro ramo: $(printf '%s' "$msg_curl" | head -c 120)" ;;
+esac
+
+# igual <recebido> <esperado> <descrição>
+igual() { if [ "$1" = "$2" ]; then ok "$3"; else falha "$3 — esperava '$2', veio '$1'"; fi; }
+# tem_campo <json> <campo> → 0 se o campo existe
+tem_campo() { printf '%s' "$1" | jq -e --arg c "$2" 'has($c)' >/dev/null 2>&1; }
+
+echo "== caminho feliz =="
+saida="$(CURL_STUB_STATUS=200 bash "$SUT" "SELECT count() FROM events" 2>&1)"; rc=$?
+igual "$rc" "0" "exit 0"
+igual "$(printf '%s' "$saida" | jq -r '.row_count')" "1" "row_count calculado"
+igual "$(printf '%s' "$saida" | jq -r '.results[0][0]')" "42" "results preservado"
+if tem_campo "$saida" clickhouse; then falha "compacto deveria DESCARTAR clickhouse/metadata"
+else ok "compacto descarta clickhouse/metadata"; fi
+cru_out="$(CURL_STUB_STATUS=200 bash "$SUT" --cru "SELECT 1" 2>/dev/null)"
+if tem_campo "$cru_out" clickhouse; then ok "--cru preserva o payload inteiro"
+else falha "--cru deveria trazer clickhouse"; fi
+saida_stdin="$(printf 'SELECT 1' | CURL_STUB_STATUS=200 bash "$SUT" 2>&1)"
+igual "$(printf '%s' "$saida_stdin" | jq -r '.row_count')" "1" "HogQL via stdin"
+
+echo "== a key NAO vaza pra argv (visivel em \`ps\`) =="
+CURL_STUB_STATUS=200 bash "$SUT" "SELECT 1" >/dev/null 2>&1
+if grep -q 'phx_' "$tmp/argv.txt"; then falha "key VAZOU em argv"; else ok "argv nao contem a key"; fi
+if grep -q 'phx_' "$tmp/cfg.txt"; then ok "key foi pelo --config (arquivo)"; else falha "key nao chegou pelo --config"; fi
+# FALSIFICACAO: um argv COM a key tem de ser pego — senao o teste acima e cego.
+printf 'Authorization: Bearer phx_VAZAMENTO\n' > "$tmp/argv-sabotado.txt"
+if grep -q 'phx_' "$tmp/argv-sabotado.txt"; then ok "falsificacao: o detector PEGA um vazamento real"
+else falha "falsificacao: detector de vazamento e CEGO"; fi
+
+echo "== HogQL chega INTEGRO (escape) =="
+complexa="SELECT properties.\$current_url AS \"u\", count()
+FROM events WHERE event = 'carteira.mixgap_visto' AND properties.estado != 'sem_rede'"
+CURL_STUB_STATUS=200 bash "$SUT" "$complexa" >/dev/null 2>&1
+recebida="$(jq -r '.query.query' "$tmp/payload.json")"
+if [ "$recebida" = "$complexa" ]; then ok "aspas/quebra-de-linha/\$ preservados"
+else falha "HogQL corrompido no transporte"; printf '    enviado:  %s\n    recebido: %s\n' "$complexa" "$recebida"; fi
+igual "$(jq -r '.query.kind' "$tmp/payload.json")" "HogQLQuery" "kind=HogQLQuery"
+# FALSIFICACAO: a comparacao tem de reprovar quando o texto REALMENTE difere.
+if [ "$recebida" = "${complexa}X" ]; then falha "falsificacao: comparacao de HogQL e CEGA"
+else ok "falsificacao: comparacao reprova texto diferente"; fi
+
+echo
+if [ "$falhas" -eq 0 ]; then echo "✅ test-posthog-query.sh: tudo verde"; exit 0
+else echo "❌ test-posthog-query.sh: $falhas falha(s)"; exit 1; fi


### PR DESCRIPTION
## O problema

O #1900 tentou ler a série de `carteira.mixgap_visto` e mediu **quatro** vias de acesso ao PostHog. As quatro estavam fechadas: plugin desabilitado, nenhuma Personal API Key, navegador (headless e real) caindo em `/login`, nenhum espelho no banco. `VITE_POSTHOG_KEY` existe mas é `phc_` — chave **pública de ingestão**, que escreve evento e não consulta.

Isso é mais grave que uma pendência de medição: a regra de `docs/historico/fase-sem-sinal.md` — *fase N+1 exige ≥1 sinal POSITIVO com denominador; "quando medir" é query, não recado* — era **incumprível por construção** para todo sensor de frontend.

## O que entra

**Opção A** (Personal API Key read-only) e não o plugin MCP: escopo verificável e mínimo, funciona headless (sessão não-interativa não roda OAuth), e a lógica fica versionada/testada em vez de num plugin opaco.

- `scripts/posthog-query.sh` — HogQL por argumento/stdin. Saída **compacta por padrão**: o payload cru traz `clickhouse`/`hogql`/`explain`/`metadata` e queima contexto de sessão de agente sem acrescentar dado.
- `scripts/test-posthog-query.sh` — 27 asserções herméticas (`curl` stubado, sem rede), registrada no 2º laço do `test:hooks`.
- `docs/agent/analytics.md` + linha no índice do CLAUDE.md (baseline re-gerada: Índice 170→181; Armadilhas 1083→1079 é a catraca clicando pra **baixo**, não pagamento).

### Decisões de segurança

- A key vai por `curl --config` (arquivo 0600, apagado no trap) e **nunca por argv** — `-H` a exporia em `ps`. Preso por teste, **com falsificação**.
- `jq` é dependência **obrigatória** pra montar o corpo: escapar HogQL à mão erra em silêncio e devolveria número **errado** em vez de falhar — fabricação de dado.
- Sondas fail-closed exigem resposta **positiva**, não `command -v`. Barram key **vazia** (0 bytes — modo já observado: `~/.config/afiacao/supabase-pat` está assim desde 2026-07-27), key `phc_` trocada pela `phx_`, e permissão frouxa.

## O que a via mostrou

| leitura | resultado |
|---|---|
| sanidade — eventos em 30d | **699** |
| série de `carteira.mixgap_visto` desde o Publish do #1892 | **vazia** |
| controle — mesma janela, sem filtro | **11 eventos, 1 pessoa** |

Série vazia com controle positivo é **dado real**. Mas o controle sozinho é fraco — prova que *alguma* telemetria chega, não que chegaria *deste* sensor. Quem decidiu foi o **irmão na mesma superfície**: `carteira.positivacao_vista` chegou 3× em 90d e `mixgap_visto` zero, e os dois montam na **mesma página** (`FarmerCalls.tsx`). O transporte está provado para a tela; ninguém abriu a FarmerCalls desde que o card subiu.

O último `positivacao_vista` (`2026-08-14T17:03:20Z`) **casa** com o "agosto = 1 dia, o dia 14" que o #1914 estabeleceu por `auth.refresh_tokens` — terceira trilha independente, e a única das três que mede **exposição ao sensor**, sem os vieses opostos de `auth.sessions` e `last_sign_in_at`.

**Achado lateral:** `dashboard.viewed` dispara 8×/30d mas `dashboard_visits` segue com 0 linhas. A visita **ocorre** e só o registro server-side falha — é bug, não ausência de uso.

## Erros corrigidos no caminho

- Minha primeira sonda de `jq` era `echo x | jq -e .` — `x` não é JSON, então falhava **sempre** e todos os ramos caíam em 69. Exatamente a armadilha "presente-porém-quebrada". O teste de curl-quebrado passava por acidente pelo exit 69 compartilhado; agora casa a **marca do ramo**.
- O comando de instalação era `read -rs "?prompt"`, sintaxe **zsh**, num bloco marcado `bash`. Em bash o `read` falha, o `&&` interrompe a cadeia e **nenhum arquivo é criado**, sem aviso.
- Pedi escopo `event:read`, que **não existe** na UI do PostHog. Quem gateia `/query/` é `Query → Read`.

## Verificação

- `bash scripts/test-posthog-query.sh` → **exit 0**, 27 asserções
- `bun run test:hooks` → exit 0 (pré-rebase, com a suíte dentro)
- `bun run claude:size` → exit 0
- `shellcheck` limpo nos dois scripts
- Queries reais rodadas contra produção (números acima)

## Follow-up

⚠️ **A Personal API Key precisa ser rotacionada** — ela foi colada em texto plano no chat da sessão, e a transcrição persiste em disco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)