### PR TITLE
feat(sonda): as 5 edges de MAIOR leitura do #1889 não tinham como provar o próprio deploy [money-path]

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -29,6 +29,11 @@ import * as syncEstoque from "../omie-sync-estoque/versao.ts";
 import * as syncNfes from "../omie-sync-nfes-recebidas/versao.ts";
 import * as nfeWebhook from "../omie-nfe-webhook/versao.ts";
 import * as analyticsSync from "../omie-analytics-sync/versao.ts";
+import * as valorCockpit from "../fin-valor-cockpit/versao.ts";
+import * as finFunding from "../fin-funding/versao.ts";
+import * as algoAudit from "../algorithm-a-audit/versao.ts";
+import * as positivacao from "../carteira-positivacao-snapshot/versao.ts";
+import * as omieFinanceiro from "../omie-financeiro/versao.ts";
 
 /**
  * `respostaSonda` (a maioria) ou `respostaSondaTactical` (a `generate-tactical-plan`, que embrulha o
@@ -76,6 +81,20 @@ const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   // e num de três fatias atrás, então não discrimina deploy integralmente velho (a ⚠️ #2 de
   // docs/agent/deploy.md, que classifica versioná-las como dívida aberta). O marcador fecha isso.
   { nome: "omie-analytics-sync", mod: analyticsSync },
+  // Sexta leva (#1889 paginação, parte 2): as cinco edges de MAIOR leitura entre as 17 que
+  // ainda serviam o `paginate.ts` velho. Duas delas — `fin-valor-cockpit` e `fin-funding` —
+  // são leitura PURA, que a terceira leva excluiu de propósito ("chamá-la já é grátis, então a
+  // sonda não resolve problema que ela tenha"). A exceção segue válida para o problema que ela
+  // endereçava (efeito colateral caro) e NÃO cobre este: o #1889 é no-op por DESENHO enquanto o
+  // `max-rows` de prod for 1000, então a resposta do fluxo real é byte-idêntica nos dois
+  // bundles e chamar a edge — de graça ou não — não diz qual está no ar
+  // (docs/historico/deploy-no-op-por-desenho.md). Barato de chamar e possível de verificar são
+  // propriedades diferentes; só o marcador dá a segunda.
+  { nome: "fin-valor-cockpit", mod: valorCockpit },
+  { nome: "fin-funding", mod: finFunding },
+  { nome: "algorithm-a-audit", mod: algoAudit },
+  { nome: "carteira-positivacao-snapshot", mod: positivacao },
+  { nome: "omie-financeiro", mod: omieFinanceiro },
 ];
 
 /** As cinco da terceira leva — os gates estruturais abaixo varrem todas. */
@@ -89,12 +108,41 @@ const ESCRITA_NOSSO_BANCO = [
   "omie-analytics-sync",
 ];
 
+/**
+ * Os gates estruturais abaixo (fail-closed, IO-free, nunca sem auth) varrem ESTA lista, não só a
+ * terceira leva: a FORMA que eles exigem não tem nada a ver com escrever no banco — vale para
+ * qualquer edge instrumentada. A sexta leva entra junto porque nasceu já nessa forma; as levas 1
+ * e 2 ficam de fora porque têm formas legadas que nunca foram normalizadas, e alargar a
+ * varredura para elas é mudança de escopo próprio, não carona desta.
+ */
+const FORMA_NORMALIZADA = [
+  ...ESCRITA_NOSSO_BANCO,
+  "fin-valor-cockpit",
+  "fin-funding",
+  "algorithm-a-audit",
+  "carteira-positivacao-snapshot",
+  "omie-financeiro",
+];
+
 /** Destas o gate NÃO aceita `x-cron-secret`, então a sonda precisa de gate PRÓPRIO. */
 // `recommend` entra aqui porque seu gate normal é JWT e o `getUser` PRECISA do client — mas a
 // sonda responde ANTES do `createClient` (o gate acima exige). Sobrava só o
 // `startsWith("Bearer ")`: verificado em PROD, `Authorization: Bearer x` (token inválido)
 // devolvia a versão. Semi-público por acidente, não por decisão.
-const GATE_PROPRIO = ["omie-cliente", "omie-nfe-webhook", "recommend"];
+// `fin-valor-cockpit` (authorizeGestorOuMaster), `fin-funding` (authorizeMaster) e
+// `omie-financeiro` entram pelo mesmo motivo com causas distintas: as duas primeiras exigem
+// `Authorization: Bearer` + role e nunca leram `x-cron-secret`; a terceira LÊ o cron-secret, mas
+// dentro de `validateCaller(req, supabase)` — que precisa do client, criado depois do ponto onde
+// a sonda tem de responder. Nos três casos o caminho do SQL Editor não chega ao gate normal, e a
+// sonda só pode vir antes dele trazendo `authorizeCronOrStaff` própria.
+const GATE_PROPRIO = [
+  "omie-cliente",
+  "omie-nfe-webhook",
+  "recommend",
+  "fin-valor-cockpit",
+  "fin-funding",
+  "omie-financeiro",
+];
 
 Deno.test("toda edge instrumentada declara VERSAO no formato vN.N-slug", () => {
   for (const { nome, mod } of EDGES) {
@@ -298,11 +346,11 @@ Deno.test("toda edge instrumentada RESPONDE à sonda (chamar classificarSonda n�
   }
 });
 
-Deno.test("terceira leva: a sonda decide por classificarSonda, não por `=== true` cru", () => {
+Deno.test("forma normalizada: a sonda decide por classificarSonda, não por `=== true` cru", () => {
   // Mesmo motivo do gate da generate-bundle-argument: o founder invoca do SQL Editor, onde
   // `jsonb_build_object('probe', true)` vira a STRING "true" com facilidade. Aqui o preço de cair
   // no fluxo real é criar placeholder+profile, reescrever saldo ou gravar projeção de caixa.
-  for (const nome of ESCRITA_NOSSO_BANCO) {
+  for (const nome of FORMA_NORMALIZADA) {
     const codigo = codigoDaEdge(nome);
     if (!/classificarSonda\(/.test(codigo)) {
       throw new Error(`${nome}: não chama classificarSonda — a sonda não é fail-closed`);
@@ -313,10 +361,10 @@ Deno.test("terceira leva: a sonda decide por classificarSonda, não por `=== tru
   }
 });
 
-Deno.test("terceira leva: a sonda responde ANTES do createClient do handler", () => {
+Deno.test("forma normalizada: a sonda responde ANTES do createClient do handler", () => {
   // O valor da sonda é ser o único caminho sem custo. Na `omie-sync-nfes-recebidas` o parse do
   // corpo estava DEPOIS do `createClient` e teve de subir; este gate é o que impede a volta.
-  for (const nome of ESCRITA_NOSSO_BANCO) {
+  for (const nome of FORMA_NORMALIZADA) {
     const h = trechoDoHandler(nome);
     const posSonda = h.indexOf("classificarSonda(");
     const posCliente = h.indexOf("createClient(");

--- a/supabase/functions/algorithm-a-audit/index.ts
+++ b/supabase/functions/algorithm-a-audit/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from 'npm:@supabase/supabase-js@2';
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
 import { fetchAll } from "../_shared/paginate.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 
 // ======== COST CONTRACT (espelho VERBATIM de src/lib/custos/cost-source.ts — manter idêntico) ========
 type CostRow = { cost_price: number | null; cost_final: number | null; cost_source: string | null; cost_confidence: number | null };
@@ -139,6 +140,23 @@ Deno.serve(async (req) => {
 
   const auth = await authorizeCronOrStaff(req);
   if (!auth.ok) return auth.response;
+
+  // Sonda de versão — ANTES do createClient, para continuar sendo o único caminho sem custo.
+  // Ver versao.ts / _shared/sonda-versao.ts. O gate acima já aceita `x-cron-secret`, que é como o
+  // founder invoca do SQL Editor, então a sonda não precisa de gate próprio.
+  const corpoBruto = await req.json().catch(() => ({}));
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo === 'sonda') {
+    return new Response(JSON.stringify(respostaSonda(VERSAO)), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+  if (decisaoSonda.tipo === 'ambiguo') {
+    return new Response(
+      JSON.stringify({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }),
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
 
   try {
     const supabase = createClient(

--- a/supabase/functions/algorithm-a-audit/versao.ts
+++ b/supabase/functions/algorithm-a-audit/versao.ts
@@ -1,0 +1,29 @@
+// Marcador de versão da edge `algorithm-a-audit`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// Escreve no NOSSO banco (`margin_audit_log`), então cai na regra da terceira leva (#1767) e não
+// na exceção da leitura pura.
+//
+// O custo de sondar um bundle PRÉ-sensor é ESCRITA, não só tempo: sem a sonda, `{"probe":true}` é
+// ignorado, a auditoria de margem roda inteira (order_items ~67 mil linhas, sales_orders ~31 mil,
+// product_costs) e o resultado é INSERIDO em `margin_audit_log`. Por isso a ordem do ritual não é
+// negociável aqui — deploy primeiro, sonda depois (`docs/agent/deploy.md` §Canárias): sondar antes
+// grava uma auditoria que ninguém pediu, com o bundle velho.
+//
+// O gate desta edge já é `authorizeCronOrStaff`, que aceita `x-cron-secret`: a sonda entra logo
+// APÓS ele, sem gate próprio.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("algorithm-a-audit");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge reaudita a margem varrendo order_items (~67 mil linhas), sales_orders e " +
+  "product_costs e GRAVA o resultado em margin_audit_log — uma auditoria que ninguém pediu entra " +
+  "na série de margem que a gestão lê, com a data de hoje";

--- a/supabase/functions/carteira-positivacao-snapshot/index.ts
+++ b/supabase/functions/carteira-positivacao-snapshot/index.ts
@@ -23,6 +23,7 @@ import {
 } from '../_shared/mapas-paginados.ts';
 import type { BancoPostgrest } from '../_shared/paginate.ts';
 import { montarLinhasSnapshot } from './montar-linhas.ts';
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from './versao.ts';
 
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders });
@@ -30,12 +31,29 @@ Deno.serve(async (req) => {
   const auth = await authorizeCronOrStaff(req);
   if (!auth.ok) return auth.response;
 
+  // O parse do corpo SUBIU para cá (era depois do `createClient`): a sonda tem de decidir sem ter
+  // aberto conexão — é o que o gate estrutural "a sonda responde ANTES do createClient" exige, e é
+  // o que a torna o único caminho sem custo desta edge. Ver versao.ts / _shared/sonda-versao.ts.
+  // O gate acima já aceita `x-cron-secret`, então a sonda não precisa de gate próprio.
+  const body = await req.json().catch(() => ({} as { mes?: string }));
+
+  const decisaoSonda = classificarSonda(body);
+  if (decisaoSonda.tipo === 'sonda') {
+    return new Response(JSON.stringify(respostaSonda(VERSAO)), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+  if (decisaoSonda.tipo === 'ambiguo') {
+    return new Response(
+      JSON.stringify({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }),
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
   const supabase = createClient(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
   );
-
-  const body = await req.json().catch(() => ({} as { mes?: string }));
 
   // Resolve mês-alvo (default = mês anterior em BRT).
   const nowBrt = new Date(new Date().toLocaleString('en-US', { timeZone: 'America/Sao_Paulo' }));

--- a/supabase/functions/carteira-positivacao-snapshot/versao.ts
+++ b/supabase/functions/carteira-positivacao-snapshot/versao.ts
@@ -1,0 +1,32 @@
+// Marcador de versão da edge `carteira-positivacao-snapshot`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// É a edge com o pior custo de sondar às cegas deste recorte, e a razão está no default do corpo:
+// com `mes` AUSENTE ela resolve o mês ANTERIOR em BRT e faz upsert em
+// `carteira_positivacao_snapshot`. Um `{"probe":true}` num bundle PRÉ-sensor não é diagnóstico —
+// é o snapshot do mês fechado sendo REGRAVADO, com o helper de paginação velho.
+//
+// E o que se grava é congelado: o próprio `_shared/mapas-paginados.ts` documenta que uma página
+// perdida de `sales_orders` (~31 mil linhas) vira `had_order_in_month:false` e `revenue_month:0`
+// para um cliente que comprou de verdade — "não consegui ler" carimbado como "não comprou", num
+// mês que ninguém recalcula (money-path.md §2: ausente ≠ zero). Deploy primeiro, sonda depois.
+//
+// O gate desta edge já é `authorizeCronOrStaff`, que aceita `x-cron-secret`: a sonda entra logo
+// APÓS ele, sem gate próprio. O parse do corpo subiu para ANTES do `createClient` — a sonda tem de
+// decidir sem ter aberto conexão (gate estrutural "a sonda responde ANTES do createClient").
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("carteira-positivacao-snapshot");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "com `mes` ausente esta edge REGRAVA (upsert) o snapshot de positivação do mês ANTERIOR em " +
+  "carteira_positivacao_snapshot, lendo sales_orders inteira (~31 mil linhas); o snapshot é " +
+  "congelado, então uma página perdida grava had_order_in_month:false e revenue_month:0 para " +
+  "quem comprou — num mês fechado que ninguém recalcula";

--- a/supabase/functions/fin-funding/index.ts
+++ b/supabase/functions/fin-funding/index.ts
@@ -11,6 +11,11 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 // carteira inteira de títulos antecipáveis, subdimensionando o gap de funding e a
 // concentração por sacado. O canônico lança nos dois casos (money-path §6/§9).
 import { fetchAll } from "../_shared/paginate.ts";
+// Gate da SONDA, não da edge: o `authorizeMaster` abaixo exige `Authorization: Bearer` + role
+// master e nunca leu `x-cron-secret` — que é como o founder invoca do SQL Editor. A sonda vem
+// antes dele e traz o seu próprio (ver versao.ts, lista GATE_PROPRIO do gate de contrato).
+import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -355,20 +360,44 @@ type A4Response = {
 
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  // Sonda de versão — ANTES do gate normal, do parse de `company` e do `createClient`, com gate
+  // PRÓPRIO. A ordem importa duas vezes: o gate normal exige Bearer + master (o `x-cron-secret` do
+  // SQL Editor morreria nele, como na `recommend` em #1883), e a validação de `company` abaixo
+  // recusaria `{"probe":true}` com um 400 de campo obrigatório — indistinguível de "bundle velho".
+  // Ver versao.ts / _shared/sonda-versao.ts.
+  // `corpoJsonInvalido` existe para não PERDER um diagnóstico ao subir o parse: antes, body
+  // malformado caía no `catch` do bloco de `company` e devolvia "Body JSON inválido". Com o parse
+  // aqui em cima esse catch nunca mais dispara, e sem a flag um JSON quebrado passaria a responder
+  // "Campo 'company' obrigatório" — mensagem que manda o chamador consertar a coisa errada.
+  let corpoBruto: unknown = {};
+  let corpoJsonInvalido = false;
+  try {
+    corpoBruto = await req.json();
+  } catch {
+    corpoJsonInvalido = true;
+  }
+
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo !== "disparo") {
+    const authSonda = await authorizeCronOrStaff(req);
+    if (!authSonda.ok) return authSonda.response;
+    if (decisaoSonda.tipo === "sonda") return jsonResponse(respostaSonda(VERSAO), 200);
+    return jsonResponse({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }, 400);
+  }
+
   const auth = await authorizeMaster(req);
   if (!auth.ok) return auth.response;
 
-  // Parse request body
-  let company: string;
-  try {
-    const body = await req.json() as { company?: unknown };
-    if (!body.company || typeof body.company !== "string") {
-      return jsonResponse({ error: "Campo 'company' obrigatório no body (string)." }, 400);
-    }
-    company = body.company;
-  } catch {
-    return jsonResponse({ error: "Body JSON inválido." }, 400);
+  // Parse request body — `corpoBruto` já foi lido acima (o corpo de um Request só se lê UMA vez;
+  // um segundo `req.json()` aqui lançaria "Body already consumed"), então a validação passa a ler
+  // dele em vez de reabrir o stream.
+  if (corpoJsonInvalido) return jsonResponse({ error: "Body JSON inválido." }, 400);
+  const body = corpoBruto as { company?: unknown };
+  if (!body.company || typeof body.company !== "string") {
+    return jsonResponse({ error: "Campo 'company' obrigatório no body (string)." }, 400);
   }
+  const company: string = body.company;
 
   const db: DbClient = createClient(SUPABASE_URL, SERVICE_ROLE);
   const hoje = new Date();

--- a/supabase/functions/fin-funding/versao.ts
+++ b/supabase/functions/fin-funding/versao.ts
@@ -1,0 +1,27 @@
+// Marcador de versão da edge `fin-funding`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// Leitura pura, sem escrita — e é NOMEADA na exceção da terceira leva (#1767), que a deixou sem
+// sensor porque "chamá-la já é grátis". A exceção continua certa para o problema dela; ela não
+// cobre o desta entrega. O #1889 é no-op por DESENHO (docs/historico/deploy-no-op-por-desenho.md):
+// enquanto o `max-rows` de prod for 1000, bundle novo e velho devolvem os MESMOS bytes, então
+// chamar a edge — de graça ou não — não diz qual dos dois está no ar. O marcador é a única prova
+// possível, e por isso ela entra agora, apesar da exceção.
+//
+// O gate desta edge é `authorizeMaster` (Bearer + role master), que NÃO aceita `x-cron-secret`.
+// A sonda entra com gate PRÓPRIO (`authorizeCronOrStaff`) antes do `createClient` — GATE_PROPRIO.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("fin-funding");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge projeta funding e antecipação lendo fin_contas_receber INTEIRA (~44 mil linhas em " +
+  "prod); ela não escreve, mas devolve número que a gestão usa para decidir captação — e uma " +
+  "leitura truncada não vira erro, vira número menor com a mesma cara de certo";

--- a/supabase/functions/fin-valor-cockpit/index.ts
+++ b/supabase/functions/fin-valor-cockpit/index.ts
@@ -8,6 +8,11 @@ import { createClient } from "npm:@supabase/supabase-js@2";
 // pedidos/custos/estoque/CR parciais viram margem e EVP inflados no cockpit, sem sinal
 // nenhum na tela. O canônico lança nos dois casos (money-path §6/§9).
 import { fetchAll } from "../_shared/paginate.ts";
+// Gate da SONDA, não da edge: o `authorizeGestorOuMaster` abaixo exige `Authorization: Bearer` +
+// role comercial e nunca leu `x-cron-secret` — que é como o founder invoca do SQL Editor. A sonda
+// vem antes dele e traz o seu próprio (ver versao.ts, lista GATE_PROPRIO do gate de contrato).
+import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -406,6 +411,21 @@ const CONFIG_DEFAULT: CockpitConfig = { margem_minima_pct: 0.15, desconto_max_pc
 
 Deno.serve(async (req: Request) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+
+  // Sonda de versão — ANTES do gate normal e do `createClient`, com gate PRÓPRIO.
+  // Antes do gate normal porque ele exige Bearer + role e o caminho documentado de invocação
+  // (net.http_post do SQL Editor, com `x-cron-secret`) morreria nele — foi exatamente o que
+  // aconteceu com a `recommend` em prod (#1883). Com gate próprio para que "antes do gate normal"
+  // não vire "sem auth nenhuma". Ver versao.ts / _shared/sonda-versao.ts.
+  const corpoBruto = await req.json().catch(() => ({}));
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo !== "disparo") {
+    const authSonda = await authorizeCronOrStaff(req);
+    if (!authSonda.ok) return authSonda.response;
+    if (decisaoSonda.tipo === "sonda") return jsonResponse(respostaSonda(VERSAO), 200);
+    return jsonResponse({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }, 400);
+  }
+
   const auth = await authorizeGestorOuMaster(req);
   if (!auth.ok) return auth.response;
   const db = createClient(SUPABASE_URL, SERVICE_ROLE);

--- a/supabase/functions/fin-valor-cockpit/versao.ts
+++ b/supabase/functions/fin-valor-cockpit/versao.ts
@@ -1,0 +1,39 @@
+// Marcador de versão da edge `fin-valor-cockpit`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// Esta edge NÃO escreve: é o cockpit de valor, leitura pura. A terceira leva (#1767) deixou a
+// leitura pura de fora DE PROPÓSITO, com o argumento registrado no gate de contrato — "chamá-la já
+// é grátis, então a sonda não resolve problema que ela tenha". Esse argumento resolve o problema
+// que ELE tinha (efeito colateral caro), e não é o problema desta entrega: o #1889 é no-op por
+// DESENHO nos dados de hoje (docs/historico/deploy-no-op-por-desenho.md), então chamar a edge e ler
+// a resposta NÃO discrimina bundle novo de velho — os dois devolvem bytes idênticos enquanto o
+// `max-rows` de prod for 1000. Grátis de chamar e possível de verificar são propriedades
+// diferentes; a exceção da terceira leva garante a primeira e é MUDA sobre a segunda.
+//
+// "Grátis" também é generoso: são 9 leituras COMPLETAS por chamada, a maior delas `order_items`
+// (~67 mil linhas em prod) — a maior varredura de qualquer edge deste recorte.
+//
+// O gate desta edge é `authorizeGestorOuMaster` (Bearer + role comercial), que NÃO aceita
+// `x-cron-secret` — que é como o founder invoca do SQL Editor. Por isso a sonda entra com gate
+// PRÓPRIO (`authorizeCronOrStaff`), antes do `createClient`, e a edge está em GATE_PROPRIO.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("fin-valor-cockpit");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+//
+// Nasce em `v1.0-sensor-inicial` como a leva anterior, e aqui o discriminante do deploy é a
+// EXISTÊNCIA da resposta, não o valor dela: um bundle sem esta sonda IGNORA `probe` e executa o
+// cockpit inteiro, devolvendo o payload do fluxo real — sem `probe:true`. O veredito é binário
+// mesmo com as cinco edges desta leva nascendo na mesma string (o campo `edge` da resposta desfaz
+// o empate entre elas; ver `criarRespostaSonda`).
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge monta o cockpit de valor com 9 leituras COMPLETAS do banco — entre elas order_items " +
+  "(~67 mil linhas), fin_contas_receber (~44 mil) e sales_orders (~31 mil); ela não escreve nada, " +
+  "mas cada chamada paga a varredura inteira e concorre com a carga de produção";

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -3,6 +3,11 @@ import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2";
 // malformada ≠ fim da tabela). Substitui o laço à mão do carregarBaixaMapDRE, cujo
 // `data ?? []` produzia baixaMap PARCIAL → double-count/perda no DRE-caixa.
 import { fetchAll } from "../_shared/paginate.ts";
+// Gate da SONDA, não da edge: o `validateCaller` do handler ACEITA `x-cron-secret`, mas exige o
+// client Supabase — que só nasce depois do ponto onde a sonda tem de responder. Por isso ela vem
+// antes, com gate próprio (ver versao.ts, lista GATE_PROPRIO do gate de contrato).
+import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 // Guards do total declarado pelo Omie (PISO, não verdade — docs/agent/sync.md):
 // proximoTotalPaginas mantém o piso monotônico entre respostas (uma intermediária sem o
 // campo NÃO encolhe o teto), avaliarPagina separa "fim real" de "página vazia antes do
@@ -2250,6 +2255,25 @@ Deno.serve(async (req) => {
     return new Response("ok", { headers: corsHeaders });
   }
 
+  // Sonda de versão — ANTES do `createClient` e do `validateCaller`, com gate PRÓPRIO.
+  // O gate normal desta edge aceita `x-cron-secret`, mas tem assinatura `validateCaller(req,
+  // supabase)`: usá-lo aqui obrigaria a criar o client primeiro, que é justamente o que o gate
+  // estrutural "a sonda responde ANTES do createClient" proíbe — a sonda deixaria de ser o único
+  // caminho sem IO. Ver versao.ts / _shared/sonda-versao.ts.
+  const corpoBruto = await req.json().catch(() => ({}));
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo !== "disparo") {
+    const authSonda = await authorizeCronOrStaff(req);
+    if (!authSonda.ok) return authSonda.response;
+    const corpo = decisaoSonda.tipo === "sonda"
+      ? respostaSonda(VERSAO)
+      : { error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) };
+    return new Response(JSON.stringify(corpo), {
+      status: decisaoSonda.tipo === "sonda" ? 200 : 400,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
   const supabase = createClient(
     Deno.env.get("SUPABASE_URL")!,
     Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
@@ -2274,8 +2298,10 @@ Deno.serve(async (req) => {
     // Marca origem no audit log para todas as mutações desta invocação
     await setAuditOrigem(supabase, 'omie_sync');
 
+    // Lê de `corpoBruto` (já consumido acima pela sonda): o corpo de um Request só se lê UMA vez,
+    // e um segundo `req.json()` aqui lançaria "Body already consumed".
     const { action, company, companies, filtro_data_de, filtro_data_ate, ano, mes, meses, maxPages, entidade, ncodcc, regime: requestedRegime } =
-      await req.json();
+      corpoBruto as Record<string, any>;
 
     const targetCompanies = resolveCompanies({ companies, company, allowed: ALLOWED_COMPANIES }) as Company[];
 

--- a/supabase/functions/omie-financeiro/index.ts
+++ b/supabase/functions/omie-financeiro/index.ts
@@ -2300,8 +2300,13 @@ Deno.serve(async (req) => {
 
     // Lê de `corpoBruto` (já consumido acima pela sonda): o corpo de um Request só se lê UMA vez,
     // e um segundo `req.json()` aqui lançaria "Body already consumed".
+    //
+    // SEM cast: `req.json()` já devolve `any`, que é exatamente o tipo que este destructuring tinha
+    // antes de o parse subir. Um `as Record<string, any>` aqui seria `any` ESCRITO, que o
+    // `@typescript-eslint/no-explicit-any` reprova — e reprovou (o único erro do `bun lint` nesta
+    // fatia; os outros 75 são warnings pré-existentes).
     const { action, company, companies, filtro_data_de, filtro_data_ate, ano, mes, meses, maxPages, entidade, ncodcc, regime: requestedRegime } =
-      corpoBruto as Record<string, any>;
+      corpoBruto;
 
     const targetCompanies = resolveCompanies({ companies, company, allowed: ALLOWED_COMPANIES }) as Company[];
 

--- a/supabase/functions/omie-financeiro/versao.ts
+++ b/supabase/functions/omie-financeiro/versao.ts
@@ -1,0 +1,34 @@
+// Marcador de versão da edge `omie-financeiro`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// Escreve seis tabelas do financeiro no nosso banco — regra da terceira leva (#1767).
+//
+// Custo do bundle PRÉ-sensor ignorando `probe`: BAIXO, e isso é propriedade do desenho dela, não
+// sorte. Ela roteia por `action`, e um corpo sem `action` conhecida cai no default `400 "Ação
+// desconhecida"` ANTES de qualquer escrita ou chamada ao Omie — o mesmo formato inócuo que tornou
+// barata a sonda da `omie-analytics-sync` (docs/historico/deploy-no-op-por-desenho.md). Logo o
+// veredito é limpo dos dois lados:
+//     {ok,probe:true,versao,edge}   → bundle COM sensor
+//     400 "Ação desconhecida"       → bundle PRÉ-sensor, o deploy não subiu
+//
+// O gate normal é `validateCaller(req, supabase)`, que ACEITA `x-cron-secret` mas EXIGE o client —
+// e o client nasce depois do ponto onde a sonda tem de responder. Por isso a sonda traz gate
+// PRÓPRIO (`authorizeCronOrStaff`), antes do `createClient`, e a edge está em GATE_PROPRIO. Sem
+// isso a alternativa seria descer a sonda para depois do client, que é exatamente o que o gate
+// estrutural proíbe.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("omie-financeiro");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge sincroniza o financeiro do Omie e escreve fin_contas_receber, fin_contas_pagar, " +
+  "fin_movimentacoes, fin_categorias, fin_contas_correntes e fin_dre_snapshots — as tabelas que " +
+  "alimentam DRE e fluxo de caixa; um run não pedido reescreve saldo e snapshot de DRE com a " +
+  "janela de datas que ele resolver sozinho";


### PR DESCRIPTION
## O problema

O **#1889** desacoplou `_shared/paginate.ts` do `max-rows` do PostgREST (EOF virou página **VAZIA**,
não CURTA; o offset avança pelas linhas **REAIS**). Três edges já foram deployadas com prova (#1905).
As demais seguem servindo o bundle antigo.

**A enumeração usual perde edges.** `git grep -l "_shared/paginate.ts"` acha 15 edges; o fechamento
transitivo de imports **de valor** acha **20**:

| rota | edges |
|---|---|
| direto | 12 |
| via `_shared/mapas-paginados.ts` | `carteira-positivacao-snapshot`, `omie-vendas-sync`, `scoring-recalc-batch`, `sync-reprocess`, `visit-score-recalc-batch` |
| via `_shared/relatorio-mensal.ts` | `monthly-report` |

As cinco do `mapas-paginados` importam de `paginate.ts` só o **tipo** (`import type { BancoPostgrest }`),
o que faz o grep de símbolo parecer inocente — mas a paginação real chega pelo helper.

## Por que instrumentar ANTES de deployar

O #1889 é no-op **por desenho** enquanto o `max-rows` de prod for 1000: bundle novo e velho produzem
bytes idênticos, então **nenhuma canária de comportamento discrimina o deploy**
(`docs/historico/deploy-no-op-por-desenho.md`). Sem marcador, deployar estas 5 seria uma viagem
manual inverificável — o marcador é **pré-requisito**, não consequência.

## O recorte (Tier A — as 5 de maior leitura, medidas em prod via psql-ro)

| edge | maior leitura | gate da sonda | custo do bundle VELHO ignorando `probe` |
|---|---|---|---|
| `fin-valor-cockpit` | `order_items` ~67 mil (9 leituras completas) | próprio | roda o cockpit inteiro |
| `algorithm-a-audit` | `order_items` ~67 mil | herdado | **INSERE** `margin_audit_log` |
| `fin-funding` | `fin_contas_receber` ~44 mil | próprio | roda o cálculo inteiro |
| `carteira-positivacao-snapshot` | `sales_orders` ~31 mil | herdado | **REGRAVA** o snapshot congelado do mês anterior |
| `omie-financeiro` | `v_titulo_baixas` ~21 mil | próprio | `400 "Ação desconhecida"` — inócuo |

Medir esse custo antes de instrumentar é a lição do #1905, e aqui ela muda a operação: **deploy
primeiro, sonda depois** não é preferência, é o que impede a verificação de gravar auditoria e
snapshot com o bundle velho.

## A exceção da terceira leva, que este PR não apaga

`fin-valor-cockpit` e `fin-funding` são leitura **pura**, e o gate de contrato as excluía de
propósito: *"chamá-la já é grátis, então a sonda não resolve problema que ela tenha"*. Isso continua
certo para o problema que a exceção endereçava (efeito colateral caro) e é **mudo** sobre este:
barato de chamar e **possível de verificar** são propriedades diferentes. O comentário registra a
distinção em vez de reescrever a exceção.

## Gate próprio em 3 edges, por causas distintas

- `fin-valor-cockpit` (`authorizeGestorOuMaster`) e `fin-funding` (`authorizeMaster`): exigem
  `Bearer` + role e **nunca leram `x-cron-secret`** — o caminho do SQL Editor morreria neles, como
  aconteceu com a `recommend` (#1883).
- `omie-financeiro`: **lê** o cron-secret, mas dentro de `validateCaller(req, supabase)` — que exige
  o client, criado depois do ponto onde a sonda tem de responder.

## Efeitos colaterais de subir o parse do corpo (tratados, não deixados passar)

- `fin-funding`: `"Body JSON inválido"` viraria `"Campo 'company' obrigatório"` → preservado por flag.
- `fin-funding` / `omie-financeiro`: o segundo `req.json()` lançaria `Body already consumed` → as
  leituras reusam `corpoBruto`.

## Gates estruturais passam a varrer `FORMA_NORMALIZADA`

Fail-closed / IO-free / nunca-sem-auth não têm relação com escrever no banco. Presos a
`ESCRITA_NOSSO_BANCO`, deixariam as duas de leitura pura instrumentadas **sem gate nenhum**.

## Evidência

- `bun run test:edges` → **871 passed, 0 failed, exit 0**
- `bun run edges:typecheck` → **exit 0**
- `bun run test` (vitest) → ver checklist abaixo
- **Falsificação 5/5** — cada sabotagem dá vermelho que NOMEIA a edge nova, baseline verde antes e
  depois (verde sozinho não provaria cobertura: o gate já passava pelas 18 edges antigas):

| sabotagem | vermelho |
|---|---|
| `fin-valor-cockpit`: apagar a linha que RESPONDE | `classifica a sonda mas nunca chama respostaSonda` |
| `carteira-positivacao-snapshot`: sonda após `createClient` | `desceu para depois do createClient — deixou de ser IO-free` |
| `omie-financeiro`: sonda sem gate próprio | `responde sem gate próprio entre a classificação e a resposta` |
| `algorithm-a-audit`: marcador fora do formato | `VERSAO fora do formato vN.N-slug` |
| `fin-funding`: `body.probe === true` cru | `não chama classificarSonda — a sonda não é fail-closed` |

## Depois do merge (manual no Lovable, nesta ordem)

- [ ] 💬 **chat do Lovable**: deploy verbatim das 5 edges (prompts no comentário)
- [ ] 🟣 **SQL Editor**: sonda em lote — **só depois** dos 5 deploys
- [ ] leitura de `net._http_response` (retenção ~6h) confirmando `probe:true` + `edge` + `versao`

Escopo restante do #1889 após esta fatia: **12 edges** (Tier B/C, todas sem sonda).
