### PR TITLE
docs(analytics): o symlink que eu recomendei DANGLA — o checkout principal quase nunca está na main

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -30,8 +30,9 @@ OAuth), e a lógica fica **versionada e testada** no repo em vez de num plugin o
   `claude_ro.pgpass`. O wrapper **recusa** permissão mais frouxa que `600`.
 - **Wrapper:** [`scripts/posthog-query.sh`](../../scripts/posthog-query.sh) — versionado, `shellcheck`-limpo,
   com suíte hermética em `scripts/test-posthog-query.sh` (roda no `bun run test:hooks`).
-- `~/.config/afiacao/posthog-query` é um **symlink** para o script no checkout principal, para o
-  caminho curto continuar existindo como no `psql-ro`.
+- **Chame pelo caminho do repo** (`bash scripts/posthog-query.sh …`), de qualquer worktree com a
+  main mergeada. Ao contrário do `psql-ro`, aqui **não** há atalho em `~/.config/afiacao/` — o
+  porquê está no passo 3 da instalação.
 
 ### Instalar a key (só o founder faz — a key NUNCA passa pelo chat)
 
@@ -69,10 +70,16 @@ mkdir -p ~/.config/afiacao && umask 077 && pbpaste > ~/.config/afiacao/posthog-r
 mkdir -p ~/.config/afiacao && umask 077 && printf 'Cole a key: ' && IFS= read -rs k && printf '%s\n' "$k" > ~/.config/afiacao/posthog-ro && unset k && chmod 600 ~/.config/afiacao/posthog-ro && printf '\n' && awk 'NR==1{print (/^phx_/ ? "OK: " length($0) " chars" : "PROBLEMA: nao comeca com phx_")}' ~/.config/afiacao/posthog-ro
 ```
 
-   Depois que este PR mergear, o atalho curto (opcional, espelha o `psql-ro`):
+   **Não** criar symlink `~/.config/afiacao/posthog-query` → checkout principal, como o `psql-ro`
+   sugeriria. O `psql-ro` é auto-contido; este script vive no git, e o checkout principal passa a
+   maior parte do tempo em branch de feature (medido em 2026-08-23: `claude/projeto-verificado-sayerlack`,
+   com ~30 worktrees vivas). O link **dangla** sempre que a main não está lá, e falha com
+   `No such file or directory` — que não parece problema de caminho.
+
+   Chame pelo caminho do repo, de qualquer worktree que tenha a main mergeada:
 
 ```bash
-ln -sf /Users/lucassardenberg/Projetos/afiacao/scripts/posthog-query.sh ~/.config/afiacao/posthog-query && echo "symlink pronto"
+bash scripts/posthog-query.sh "SELECT count() FROM events WHERE timestamp > now() - INTERVAL 7 DAY"
 ```
 
 4. O id do projeto já está fixado em `~/.config/afiacao/posthog-project-id` (`423408`, lido da URL


### PR DESCRIPTION
Follow-up do #1916.

## O que estava errado

O #1916 mandou criar `~/.config/afiacao/posthog-query` → checkout principal, espelhando o `psql-ro`. Ao tentar criar o link, medi o estado real: o checkout principal estava em `claude/projeto-verificado-sayerlack`, **não na main**. Com ~30 worktrees vivas, esse é o estado **normal** do repo, não a exceção.

## Por que a analogia com o `psql-ro` não valia

O `psql-ro` é **auto-contido** — um `exec` de 4 linhas, sem dependência de git — então um caminho fixo sempre resolve. Este script **vive no git**, então o mesmo caminho fixo aponta para um arquivo que só existe quando aquele checkout está na main.

O modo de falha é ruim de diagnosticar: o link dangla e o erro é `No such file or directory`, que lê como problema de **caminho** quando na verdade é de **branch**. Manda o próximo a depurar o lugar errado.

## O que entra

Troca a recomendação por chamar `bash scripts/posthog-query.sh` de qualquer worktree com a main mergeada, e registra o motivo medido — para ninguém re-propor o symlink por analogia com o `psql-ro` depois.

Corrige as **duas** menções no doc: a da §2, que afirmava o symlink como fato consumado, e a do passo 3 da instalação.

## Verificação

- `bun run docs:citacoes` · `docs:indice` · `docs:links` → **exit 0** nos três
- `bun run claude:size` → exit 0
- Doc-only; nada de frontend/edge/migration, então não há deploy Lovable pendente

🤖 Generated with [Claude Code](https://claude.com/claude-code)