### PR TITLE
feat(canarias): as 3 sem marcador respondiam igual em qualquer fatia — e a receita nem lia duas delas [money-path]

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -65,13 +65,13 @@ Grep na `main` prova a **fonte**; a canária prova o **deploy**. Chame com `?can
 canary === true   E   contrato === '<marcador da fatia>'   E   ok === true
 ```
 
-Nas canárias ainda **não-versionadas** (`contrato` = `—`) só há `canary` + `ok`, o que **não** protege contra deploy integralmente velho (ver ⚠️ abaixo) — versioná-las é dívida aberta.
+**As 6 canárias estão versionadas** (a dívida das 3 sem marcador fechou em 2026-08-23). Canária sem `contrato` só tem `canary` + `ok`, o que **não** protege contra deploy integralmente velho (ver ⚠️ abaixo): canária nova nasce COM marcador — e o marcador **nomeia a fatia** que ela verifica, nunca um `v1.0-sensor-inicial` genérico (esse só é honesto quando o sensor nasce na mesma fatia).
 
 | edge | rota | `contrato` esperado | o que a fixture discrimina |
 |---|---|---|---|
-| `analyze-unified-order` | Governança → Auditoria (card "Canária de preço") | — | praticado 123 vence Omie 999 |
-| `omie-vendas-sync` | `identidade_probe` | — | identidade derivada por documento |
-| `omie-analytics-sync` | `doc_ambiguo_probe` | — | doc ambíguo não vira vínculo |
+| `analyze-unified-order` | Governança → Auditoria (card "Canária de preço") | `praticado-vence-omie-v1` | praticado 123 vence Omie 999 (velho: o Omie sobrescrevia → `resolved=999`) |
+| `omie-vendas-sync` | `identidade_probe` | `identidade-fail-closed-v1` | identidade derivada por documento: 1-dono resolve, e divergência advisory×derivado / ambiguidade / ausência / bigint fora de range **recusam** (velho: o advisory sobrescrevia o derivado) |
+| `omie-analytics-sync` | `doc_ambiguo_probe` ⚠️ resposta embrulhada em `data` | `doc-ambiguo-fail-closed-v1` | doc ambíguo não vira vínculo (velho: helper sempre-∅ → `[]` no caso de 2 códigos) |
 | `carteira-rebuild` | `?canary=1` | `trava-saida-v1` | conflito permanece com `eligible=false` (velho: some) **+** trava de saída do bootstrap (velho: grava ~Hunter) |
 | `generate-tactical-plan` | `{"canary":true}` | `v1.0-custo-fora-do-browser` | margem ausente degrada em vez de fabricar (velho: NULL→`?? 0`→R$0/h; #1498) |
 | `omie-financeiro` | `paginacao_probe` | `paginacao-guards-v1` | guards de paginação do #1598: piso NÃO encolhe (vazia antes do fim = anomalia; velho: `\|\| 1` → "fim"), reversa só completa com sonda vazia (velho: `pagina < 1` → complete), fingerprint sem colisão (velho: `1ºcódigo:count`), resposta sem array LANÇA (velho: `\|\| []` → "página vazia" = fim) |
@@ -119,11 +119,18 @@ SELECT net.http_post(
   body := jsonb_build_object('action','paginacao_probe'),
   timeout_milliseconds := 20000) AS request_id;
 -- ANOTE o request_id devolvido acima. ~5s depois, na MESMA aba, LEIA POR ELE:
-SELECT status_code, content::jsonb->'canary' AS canary, content::jsonb->'contrato' AS contrato,
-       content::jsonb->'ok' AS ok,
-       (SELECT jsonb_agg(c->'caso') FROM jsonb_array_elements(content::jsonb->'casos') c
+-- ⚠️ COALESCE: a `omie-analytics-sync` responde `{success,data:{...}}` (envelope de action), as
+-- demais respondem no TOPO. Sem descer no `data`, a leitura devolve NULL nela — e NULL lido como
+-- "não tem canária" é ausência de dado virando veredito. O `corpo` abaixo serve as duas formas.
+WITH r AS (
+  SELECT status_code,
+         COALESCE(content::jsonb->'data', content::jsonb) AS corpo
+  FROM net._http_response WHERE id = <request_id>   -- NÃO `ORDER BY id DESC LIMIT 1`
+)
+SELECT status_code, corpo->'canary' AS canary, corpo->>'contrato' AS contrato, corpo->'ok' AS ok,
+       (SELECT jsonb_agg(c->'caso') FROM jsonb_array_elements(corpo->'casos') c
         WHERE (c->>'ok')::bool IS NOT TRUE) AS casos_vermelhos
-FROM net._http_response WHERE id = <request_id>;   -- NÃO `ORDER BY id DESC LIMIT 1`
+FROM r;
 ```
 
 ⚠️ **`ORDER BY id DESC LIMIT 1` fabrica veredito NEGATIVO — leia pelo `request_id`.** Este banco recebe resposta de cron o tempo todo (só o watchdog responde a cada ~5 min, e há timestamps com DUAS respostas no mesmo microssegundo), então "a última linha" quase nunca é a sua: entre disparar e ler, um tick alheio entra na frente. Mordido ao vivo em 2026-08-23, com a receita desta seção: a sonda da `recommend` respondeu `{"ok":true,"probe":true,"versao":"v1.5-…","edge":"recommend"}` no id 58859, o `SELECT` pegou o 58858 (`{"modo":"watchdog",…}`, 41s antes) e devolveu `edge NULL, versao NULL, status_code 200` — que é **exatamente a assinatura de "bundle pré-sensor ignorou o probe e rodou o fluxo real"** (armadilha 1 abaixo). Um deploy correto lido como deploy ausente, e o desfecho seguinte é redeployar uma edge money-path à toa. O `id` de `net._http_response` **é** o `request_id` devolvido pelo `net.http_post` — filtrar por ele é determinístico e não custa nada. Sem o número em mãos, o desempate possível é `WHERE content::jsonb->>'edge' = '<nome-da-edge>'` (o campo nasceu para isso), mas ele **degrada para zero linhas** justamente no caso que mais importa — bundle velho não emite `edge` —, e zero linhas é indistinguível de "a resposta ainda não chegou": aí confirme com `SELECT max(id) FROM net._http_response` antes de concluir.
@@ -228,7 +235,7 @@ O bot `gpt-engineer-app[bot]` commita direto na `main` SEM CI ("Changes"/"Deploy
 - **Guardrails como rede (testes-invariantes):** `src/lib/reposicao/__tests__/edges-onorder-guardrail.test.ts` (janela on-order #1072/#1076) e `src/__tests__/edge-money-path-invariants.test.ts` (analyze: helper espelhado + paridade edge×src + gate de fallback `!(… in priceMap)` + canária #1077/#1080/#1089; e margem do `algorithm-a-audit`) **quebram o CI** se a regressão volta ao REPO. Em refactor legítimo, **reescrever o teste junto** — não deletar.
 - **Restauração rápida** (o que destravou #1076/#1085): `git checkout <sha-da-correção> -- <arquivo>` → abrir **PR** (auto-merge no verde). **Nunca** restaurar direto na `main` (vira guerra de commits com o bot).
 - ⚠️ **O `lovable-watch` só enxerga o ÚLTIMO commit do push — reversão no PENÚLTIMO passa em silêncio (2026-07-23).** O workflow roda `git diff HEAD^ HEAD`, e o bot empurra em LOTE (`Changes` + `Deployed …` no mesmo push): o GitHub dispara UM run, no HEAD, e o commit intermediário nem tem run próprio. Medido: `018e8abc` ("Changes") removeu de novo as 3 linhas da RPC `farmer_association_rules_substituir` do `types.ts`; o run rodou em `54691cc5` (HEAD), cujo diff contra o pai **já não continha a remoção** → nenhuma issue aberta, `conclusion: success`. Na rodada anterior o gate acusou (issue #1583) só porque a reversão calhou de estar no HEAD do push. ⇒ **o gate cobre ~metade dos casos**; até ser corrigido (varrer `github.event.before..HEAD`, não `HEAD^..HEAD`), o **ritual manual abaixo continua obrigatório** — `git fetch` + conferir o diff de TODOS os commits do bot desde o último merge, não só o último. Corolário da causa-raiz: o bot regenera `types.ts` **a partir do BANCO**, então toda migration entregue e NÃO aplicada vira uma bomba-relógio — o próximo deploy de edge remove a RPC do types e quebra o build do Publish (loop observado 2×; some sozinho quando a migration é aplicada).
-- **Ritual pós-Lovable:** após qualquer Publish/chat-edit, além da verificação de deploy de edge (acima), `git fetch origin main` e cheque o commit do bot — tocou money-path sem intenção → restaure na hora. Para o **edge de preço** (`analyze-unified-order`), confirme o COMPORTAMENTO deployado pela **canária**: Governança → Auditoria — o card "Canária de preço" **roda sozinho ao abrir** (botão "Verificar de novo" para re-checar). Verde = praticado 123 vence Omie 999; vermelho/erro = edge revertida → restaure. É a única prova do que está SERVIDO em prod (o invariante do CI só prova o repo). Evite editar pelo Lovable arquivos mantidos via PR.
+- **Ritual pós-Lovable:** após qualquer Publish/chat-edit, além da verificação de deploy de edge (acima), `git fetch origin main` e cheque o commit do bot — tocou money-path sem intenção → restaure na hora. Para o **edge de preço** (`analyze-unified-order`), confirme o COMPORTAMENTO deployado pela **canária**: Governança → Auditoria — o card "Canária de preço" **roda sozinho ao abrir** (botão "Verificar de novo" para re-checar). Verde = praticado 123 vence Omie 999 **E** o contrato bate (`praticado-vence-omie-v1`); vermelho/erro = edge revertida → restaure. ⚠️ Esta é a única das 6 canárias que **não** sai pelo SQL Editor: ela é gated por **JWT de staff** (não aceita `x-cron-secret`), então a leitura é a TELA — o card imprime o `detalhe`, que nomeia o contrato recebido vs o esperado quando a fatia diverge. É a única prova do que está SERVIDO em prod (o invariante do CI só prova o repo). Evite editar pelo Lovable arquivos mantidos via PR.
 
 ## Verificação de deploy
 

--- a/docs/historico/deploy-no-op-por-desenho.md
+++ b/docs/historico/deploy-no-op-por-desenho.md
@@ -124,6 +124,15 @@ do bot do Lovable.
    Comparar o marcador da `main` com o de prod é parte do **pré-flight**, não da verificação.
 2. **Canária não-versionada é meia-canária.** Ela prova que a função responde, não que o bundle é
    o novo. Enquanto houver `contrato = —` na tabela do `deploy.md`, a dívida está aberta.
+   → **Fechada em 2026-08-23**: as 3 últimas sem marcador foram versionadas — `analyze-unified-order`
+   (`praticado-vence-omie-v1`), `omie-vendas-sync` (`identidade-fail-closed-v1`) e
+   `omie-analytics-sync` (`doc-ambiguo-fail-closed-v1`), cada uma com o controle de calibração que
+   prova a fixture ficando VERMELHA sob a forma antiga. Duas descobertas do caminho, que valem para a
+   próxima canária: (a) as duas `omie-*` respondiam `probe_no_ar`, **não** `canary`, e a
+   `omie-analytics-sync` embrulha a resposta em `data` — a receita SQL documentada lia **NULL** nas
+   duas, e NULL se lê como "não tem canária" (ausência de dado virando veredito); (b) emitir o
+   marcador não basta — o **consumidor** tem de exigir o VALOR, senão o card de Governança segue
+   pintando verde com `ok` sozinho, que é o furo original visto do outro lado.
 3. **PR concorrente pode ser aliado.** O #1898 (`recommend`) e o #1901 (bug ATIVO de duplicata
    silenciosa no mesmo `paginate.ts`) estavam com auto-merge armado. Deployar antes deles teria
    custado 3 viagens manuais desperdiçadas e publicado um helper com bug conhecido. **Antes de

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -3014,3 +3014,185 @@ describe('guardrail money-path: denominador e amostra do sim_score (recommend)',
     ).toEqual(daFonte);
   });
 });
+
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+// VERSIONAMENTO DAS 3 CANÁRIAS QUE NASCERAM SEM MARCADOR DE CONTRATO
+// ════════════════════════════════════════════════════════════════════════════════════════════════
+// A ⚠️ #2 de docs/agent/deploy.md §Canárias ("mente verde"): um deploy INTEGRALMENTE VELHO carrega a
+// canária de uma fatia anterior — com o `expected` VELHO junto — e compara velho×velho. Responde
+// `canary:true, ok:true` e passa como aprovado, sem discriminar reversão de fatia. O `ok` sozinho
+// separa "a função respondeu" de nada; o `contrato` é o que separa "respondeu" de "é a versão que eu
+// deployei". Enquanto houve `contrato = —` na tabela do deploy.md, a dívida ficou aberta
+// (docs/historico/deploy-no-op-por-desenho.md, lição 2: "canária não-versionada é meia-canária").
+//
+// O marcador NOMEIA a fatia que a canária verifica HOJE — não `v1.0-sensor-inicial`, que só é
+// honesto quando o sensor nasce na mesma fatia. Estas três canárias são PRÉ-EXISTENTES: o marcador
+// nomeia o contrato que cada uma já verificava, e o BUMP passa a ser obrigatório a cada fatia que
+// mude esse contrato (senão a próxima reversão volta a passar despercebida).
+//
+// Cada gate abaixo amarra as DUAS pontas — produtor (a edge emite o marcador) e consumidor (a linha
+// da tabela do deploy.md fixa o valor esperado). Sem a segunda, o produtor emite e o verificador
+// segue aceitando `ok` sozinho: foi exatamente o que o Codex R7 bloqueou no carteira-rebuild.
+
+const DEPLOY_DOC = 'docs/agent/deploy.md';
+
+// Matcher ANCORADO na LINHA da tabela: `| \`<edge>\` | <rota> | \`<contrato>\` | …`. Um `toContain`
+// solto aceitaria o valor em qualquer trecho do doc — inclusive na prosa que explica a armadilha.
+const linhaDaTabela = (edge: string, contrato: string) =>
+  new RegExp(`\\|\\s*\`${edge}\`\\s*\\|[^|]*\\|\\s*\`${contrato}\`\\s*\\|`);
+
+describe('canária VERSIONADA: analyze-unified-order (praticado vence Omie)', () => {
+  const src = read(ANALYZE);
+  const deployDoc = read(DEPLOY_DOC);
+  const CONTRATO = 'praticado-vence-omie-v1';
+
+  it('a canária emite o VERSION MARKER `contrato`', () => {
+    expect(
+      src,
+      'sumiu o marcador `contrato` da canária de preço — um deploy integralmente velho responderia ok:true comparando velho×velho',
+    ).toMatch(/contrato: ['"]praticado-vence-omie-v1['"]/);
+  });
+
+  it('a LINHA da tabela do deploy.md fixa o MESMO marcador (senão o verificador não sabe o que exigir)', () => {
+    expect(
+      deployDoc,
+      'a linha do `analyze-unified-order` na tabela de canárias não fixa `praticado-vence-omie-v1` — o founder leria `—` e aceitaria `ok` sozinho',
+    ).toMatch(linhaDaTabela('analyze-unified-order', CONTRATO));
+  });
+
+  it('o marcador NOMEIA a fatia — nada de `v1.0-sensor-inicial` genérico numa canária pré-existente', () => {
+    // Regra 1 de deploy.md: `v1.0-sensor-inicial` só é honesto quando o sensor NASCE ali. Esta
+    // canária existe desde o #1089; o marcador tem de nomear o contrato que ela verifica hoje.
+    expect(CONTRATO).not.toMatch(/sensor-inicial/);
+    expect(CONTRATO, 'marcador genérico não discrimina fatia').toMatch(/praticado|preco|omie/);
+  });
+
+  it('decide a canária pelo classificador ROBUSTO — `canary === true` cru manda a string do SQL Editor pro LLM', () => {
+    const limpo = removerComentarios(src);
+    expect(
+      limpo,
+      'a canária voltou a decidir por `canary === true` cru: `jsonb_build_object(\'canary\', true)` vira a STRING "true" com facilidade e cairia no FLUXO REAL (análise de pedido com LLM), cuja resposta é indistinguível de "bundle velho"',
+    ).not.toMatch(/canary === true/);
+    expect(
+      limpo,
+      'a canária não usa classificarFlag — sem ele o valor não reconhecido executa em vez de recusar',
+    ).toMatch(/classificarFlag\(\s*body\s*,\s*['"]canary['"]\s*\)/);
+  });
+
+  it('valor AMBÍGUO recusa com 400 em vez de gastar LLM', () => {
+    const limpo = removerComentarios(src);
+    expect(
+      limpo,
+      'o ramo ambíguo da canária não recusa com 400 — valor não reconhecido cairia no fluxo real caro',
+    ).toMatch(/ambiguo[\s\S]{0,400}status:\s*400/);
+  });
+
+  it('a canária continua PURA (não toca LLM/Omie/DB) — é o que a torna barata de sondar', () => {
+    const bloco = removerComentarios(src).match(/tipo === ['"]sonda['"][\s\S]*?\n {4}\}/)?.[0] ?? '';
+    expect(bloco, 'âncora: não achei o bloco da canária').not.toBe('');
+    expect(bloco, 'canária faz escrita no DB — deve ser dry-run puro').not.toMatch(/\.(upsert|insert|update|delete)\(/);
+    expect(bloco, 'canária chama a Anthropic — deixaria de ser barata e gastaria token').not.toMatch(/anthropic|messages\.create/i);
+  });
+});
+
+describe('canária VERSIONADA: omie-vendas-sync (identidade fail-closed)', () => {
+  const src = read(VENDAS);
+  const deployDoc = read(DEPLOY_DOC);
+  const CONTRATO = 'identidade-fail-closed-v1';
+  const bloco = src.match(/case "identidade_probe":[\s\S]*?\n {6}case /)?.[0] ?? '';
+
+  it('sentinela: o bloco da canária existe', () => {
+    expect(bloco, 'sumiu a action identidade_probe — sem ela não há prova do DEPLOY, só da fonte').not.toBe('');
+  });
+
+  it('a canária emite o VERSION MARKER `contrato`', () => {
+    expect(
+      bloco,
+      'sumiu o marcador `contrato` do identidade_probe — a canária responderia igual num bundle de hoje e num de três fatias atrás',
+    ).toMatch(/contrato: ['"]identidade-fail-closed-v1['"]/);
+  });
+
+  it('emite TAMBÉM `canary: true` — a receita SQL do deploy.md lê esse campo', () => {
+    // A probe nasceu respondendo só `probe_no_ar`. A receita documentada faz
+    // `content::jsonb->'canary'` e leria NULL: o verificador não conseguiria aplicar o predicado
+    // dos cinco campos sem uma variante por edge. `probe_no_ar` FICA (o gate acima o exige).
+    expect(bloco, 'a canária não expõe `canary: true` — a receita SQL do deploy.md leria NULL').toMatch(/canary: true/);
+    expect(bloco, 'sumiu `probe_no_ar` — o campo histórico da probe').toContain('probe_no_ar');
+  });
+
+  it('a LINHA da tabela do deploy.md fixa o MESMO marcador', () => {
+    expect(
+      deployDoc,
+      'a linha do `omie-vendas-sync` na tabela de canárias não fixa `identidade-fail-closed-v1`',
+    ).toMatch(linhaDaTabela('omie-vendas-sync', CONTRATO));
+  });
+
+  it('o marcador NOMEIA a fatia que a canária verifica hoje', () => {
+    expect(CONTRATO).not.toMatch(/sensor-inicial/);
+    expect(CONTRATO, 'marcador genérico não discrimina fatia').toMatch(/identidade/);
+  });
+
+  it('a fixture DISCRIMINA: o caso de divergência advisory×derivado está na tabela-verdade', () => {
+    // É o coração do P0-B. Sob a forma ANTIGA (advisory sobrescrevia o derivado) este caso responde
+    // {ok:true, codigo_cliente:999} em vez de {ok:false, reason:'divergence'} → canária VERMELHA.
+    // Sem este caso a probe só provaria que a função responde.
+    expect(bloco, 'sumiu o caso divergencia_supplied — a canária pararia de discriminar o override').toContain('divergencia_supplied');
+    expect(bloco).toMatch(/reason: ['"]divergence['"]/);
+  });
+});
+
+describe('canária VERSIONADA: omie-analytics-sync (doc ambíguo não vira vínculo)', () => {
+  const src = read(ANALYTICS);
+  const deployDoc = read(DEPLOY_DOC);
+  const CONTRATO = 'doc-ambiguo-fail-closed-v1';
+  const bloco = src.match(/case "doc_ambiguo_probe":[\s\S]*?\n {6}(?=case |default:)/)?.[0] ?? '';
+
+  it('sentinela: o bloco da canária existe', () => {
+    expect(bloco, 'sumiu a action doc_ambiguo_probe — sem ela não há prova do DEPLOY, só da fonte').not.toBe('');
+  });
+
+  it('a canária emite o VERSION MARKER `contrato`', () => {
+    expect(
+      bloco,
+      'sumiu o marcador `contrato` do doc_ambiguo_probe — foi a canária citada em docs/historico/deploy-no-op-por-desenho.md como "tinha canária, mas NÃO-VERSIONADA"',
+    ).toMatch(/contrato: ['"]doc-ambiguo-fail-closed-v1['"]/);
+  });
+
+  it('emite TAMBÉM `canary: true`, sem perder `probe_no_ar`', () => {
+    expect(bloco, 'a canária não expõe `canary: true` — a receita SQL do deploy.md leria NULL').toMatch(/canary: true/);
+    expect(bloco, 'sumiu `probe_no_ar` — o campo histórico da probe').toContain('probe_no_ar');
+  });
+
+  it('a LINHA da tabela do deploy.md fixa o MESMO marcador', () => {
+    expect(
+      deployDoc,
+      'a linha do `omie-analytics-sync` na tabela de canárias não fixa `doc-ambiguo-fail-closed-v1`',
+    ).toMatch(linhaDaTabela('omie-analytics-sync', CONTRATO));
+  });
+
+  it('o marcador NOMEIA a fatia que a canária verifica hoje', () => {
+    expect(CONTRATO).not.toMatch(/sensor-inicial/);
+    expect(CONTRATO, 'marcador genérico não discrimina fatia').toMatch(/ambiguo/);
+  });
+
+  it('o deploy.md avisa que esta resposta vem EMBRULHADA em `data` (senão a receita lê NULL)', () => {
+    // Esta edge responde `{success:true, data:{...}}`; as outras respondem no topo. Uma receita que
+    // só faz `content::jsonb->'canary'` devolve NULL aqui — e NULL lido como "sem canária" é a
+    // ausência de dado sendo lida como veredito.
+    expect(
+      deployDoc,
+      'a receita SQL do guia não desce no envelope `data` — leria NULL nesta edge e o verificador concluiria "não tem canária"',
+    ).toMatch(/COALESCE\(content::jsonb->'data',\s*content::jsonb\)/);
+    expect(
+      deployDoc,
+      'a linha da tabela não avisa que esta resposta vem embrulhada em `data`',
+    ).toMatch(/`omie-analytics-sync`[^|]*\|[^|]*embrulhada em `data`/);
+  });
+
+  it('a fixture DISCRIMINA: o caso de 2 códigos distintos no mesmo doc está na tabela-verdade', () => {
+    // Sob um helper sempre-∅ (a regressão que o Lovable já causou em #1272/#1273) este caso responde
+    // [] em vez de ["111"] → canária VERMELHA. É o caso que o run normal NUNCA exercita, porque não
+    // há duplicata-CNPJ real em prod: some sem deixar rastro no dado.
+    expect(bloco, 'sumiu o caso doc_2_codigos_distintos — a canária pararia de discriminar o helper sempre-∅').toContain('doc_2_codigos_distintos');
+  });
+});

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -3099,7 +3099,10 @@ describe('canária VERSIONADA: omie-vendas-sync (identidade fail-closed)', () =>
   const src = read(VENDAS);
   const deployDoc = read(DEPLOY_DOC);
   const CONTRATO = 'identidade-fail-closed-v1';
-  const bloco = src.match(/case "identidade_probe":[\s\S]*?\n {6}case /)?.[0] ?? '';
+  // Sobre a fonte SEM comentários: a prosa que EXPLICA o campo cita o campo (`// \`canary: true\`
+  // acompanha o probe_no_ar...`), então um assert POSITIVO sobre o texto cru passa lendo o
+  // comentário e sobrevive à remoção do código. Falsificação S3 pegou exatamente isso.
+  const bloco = removerComentarios(src).match(/case "identidade_probe":[\s\S]*?\n {6}case /)?.[0] ?? '';
 
   it('sentinela: o bloco da canária existe', () => {
     expect(bloco, 'sumiu a action identidade_probe — sem ela não há prova do DEPLOY, só da fonte').not.toBe('');
@@ -3145,7 +3148,8 @@ describe('canária VERSIONADA: omie-analytics-sync (doc ambíguo não vira vínc
   const src = read(ANALYTICS);
   const deployDoc = read(DEPLOY_DOC);
   const CONTRATO = 'doc-ambiguo-fail-closed-v1';
-  const bloco = src.match(/case "doc_ambiguo_probe":[\s\S]*?\n {6}(?=case |default:)/)?.[0] ?? '';
+  // Idem vendas-sync: medir o CÓDIGO, não a prosa que o descreve.
+  const bloco = removerComentarios(src).match(/case "doc_ambiguo_probe":[\s\S]*?\n {6}(?=case |default:)/)?.[0] ?? '';
 
   it('sentinela: o bloco da canária existe', () => {
     expect(bloco, 'sumiu a action doc_ambiguo_probe — sem ela não há prova do DEPLOY, só da fonte').not.toBe('');

--- a/src/lib/governanca/__tests__/canaria-preco.test.ts
+++ b/src/lib/governanca/__tests__/canaria-preco.test.ts
@@ -9,22 +9,22 @@ import { classificarCanaria } from "../canaria-preco";
 
 describe("classificarCanaria", () => {
   it("ok: preço praticado (123) venceu o Omie (999) — fallback correto", () => {
-    const r = classificarCanaria({ canary: true, resolved: 123, expected: 123, ok: true }, null);
+    const r = classificarCanaria({ canary: true, contrato: "praticado-vence-omie-v1", resolved: 123, expected: 123, ok: true }, null);
     expect(r.status).toBe("ok");
   });
 
   it("falha: override do Omie (resolved=999) — regressão", () => {
-    const r = classificarCanaria({ canary: true, resolved: 999, expected: 123, ok: false }, null);
+    const r = classificarCanaria({ canary: true, contrato: "praticado-vence-omie-v1", resolved: 999, expected: 123, ok: false }, null);
     expect(r.status).toBe("falha");
     expect(r.detalhe).toMatch(/REGRESS/i);
   });
 
   it("falha: ok=false vence mesmo com resolved=123 (Codex: ok!==true → vermelho)", () => {
-    expect(classificarCanaria({ canary: true, resolved: 123, expected: 123, ok: false }, null).status).toBe("falha");
+    expect(classificarCanaria({ canary: true, contrato: "praticado-vence-omie-v1", resolved: 123, expected: 123, ok: false }, null).status).toBe("falha");
   });
 
   it("falha: expected!==123 (canária adulterada) → vermelho", () => {
-    expect(classificarCanaria({ canary: true, resolved: 123, expected: 999, ok: true }, null).status).toBe("falha");
+    expect(classificarCanaria({ canary: true, contrato: "praticado-vence-omie-v1", resolved: 123, expected: 999, ok: true }, null).status).toBe("falha");
   });
 
   it("erro: invoke falhou (403) = canária vermelha, NÃO 'sem dados'", () => {
@@ -33,7 +33,7 @@ describe("classificarCanaria", () => {
   });
 
   it("erro VENCE: se há error E data, classifica como erro (não lê o payload)", () => {
-    const r = classificarCanaria({ canary: true, resolved: 123, expected: 123, ok: true }, { message: "rede" });
+    const r = classificarCanaria({ canary: true, contrato: "praticado-vence-omie-v1", resolved: 123, expected: 123, ok: true }, { message: "rede" });
     expect(r.status).toBe("erro");
   });
 
@@ -44,5 +44,60 @@ describe("classificarCanaria", () => {
 
   it("desconhecido: edge respondeu mas sem o envelope de canária (canary!==true)", () => {
     expect(classificarCanaria({ resolved: 123, expected: 123, ok: true }, null).status).toBe("desconhecido");
+  });
+
+  // ── VERSION MARKER (docs/agent/deploy.md §Canárias, ⚠️ #2) ────────────────────────────────────
+  // O marcador só fecha o furo se o CONSUMIDOR exigir o valor. Sem estes casos o edge emite
+  // `contrato` e o card segue aceitando `ok` sozinho — um deploy INTEGRALMENTE VELHO carrega o
+  // `expected` velho junto, compara velho×velho e o card pinta verde.
+
+  it("verde exige o contrato da fatia, não só ok/resolved/expected", () => {
+    const r = classificarCanaria(
+      { canary: true, contrato: "praticado-vence-omie-v1", resolved: 123, expected: 123, ok: true },
+      null,
+    );
+    expect(r.status).toBe("ok");
+  });
+
+  it("contrato de OUTRA fatia = deploy velho, não verde (a mentira que o marcador existe para pegar)", () => {
+    const r = classificarCanaria(
+      { canary: true, contrato: "fatia-anterior-v0", resolved: 123, expected: 123, ok: true },
+      null,
+    );
+    expect(r.status).toBe("falha");
+    expect(r.detalhe).toContain("praticado-vence-omie-v1");
+    expect(r.detalhe).toContain("fatia-anterior-v0");
+  });
+
+  it("contrato AUSENTE = canária pré-marcador no ar (bundle velho), não verde", () => {
+    // É exatamente a resposta que a edge dava ANTES desta fatia: {canary,resolved,expected,ok}.
+    const r = classificarCanaria({ canary: true, resolved: 123, expected: 123, ok: true }, null);
+    expect(r.status).toBe("falha");
+    expect(r.detalhe).toContain("sem o marcador");
+  });
+
+  it("CALIBRAÇÃO: sob a forma ANTIGA (sem exigir contrato) os dois casos acima passariam por verdes", () => {
+    // A forma antiga: ok && resolved === 123 && expected === 123. Prova que os asserts acima pegam
+    // saída errada — sem isto eles só provariam que a função responde.
+    const antiga = (d: { resolved?: number; expected?: number; ok?: boolean }) =>
+      d.ok === true && d.resolved === 123 && d.expected === 123 ? "ok" : "falha";
+    expect(antiga({ resolved: 123, expected: 123, ok: true })).toBe("ok"); // ← contrato ausente
+    expect(classificarCanaria({ canary: true, resolved: 123, expected: 123, ok: true }, null).status).toBe("falha");
+    // controle positivo: no caso legítimo as duas concordam (senão a divergência não provaria nada)
+    expect(antiga({ resolved: 123, expected: 123, ok: true })).toBe("ok");
+    expect(
+      classificarCanaria(
+        { canary: true, contrato: "praticado-vence-omie-v1", resolved: 123, expected: 123, ok: true },
+        null,
+      ).status,
+    ).toBe("ok");
+    // e na regressão de preço as duas concordam em VERMELHO
+    expect(antiga({ resolved: 999, expected: 123, ok: false })).toBe("falha");
+    expect(
+      classificarCanaria(
+        { canary: true, contrato: "praticado-vence-omie-v1", resolved: 999, expected: 123, ok: false },
+        null,
+      ).status,
+    ).toBe("falha");
   });
 });

--- a/src/lib/governanca/canaria-preco.ts
+++ b/src/lib/governanca/canaria-preco.ts
@@ -13,6 +13,7 @@ export type StatusCanaria = "ok" | "falha" | "erro" | "desconhecido";
 
 export interface RespostaCanaria {
   canary?: boolean;
+  contrato?: string;
   resolved?: number;
   expected?: number;
   ok?: boolean;
@@ -25,6 +26,12 @@ export interface ResultadoCanaria {
 
 const PRECO_PRATICADO = 123; // local (order_items) — deve VENCER
 const PRECO_OMIE = 999; // fallback — só preenche gap
+
+// VERSION MARKER da fatia (docs/agent/deploy.md §Canárias, ⚠️ #2). Exigir o VALOR é o que separa
+// "a edge respondeu" de "a edge é a versão que eu deployei": um deploy INTEGRALMENTE VELHO carrega
+// a canária de uma fatia anterior — com o `expected` VELHO junto — compara velho×velho e responde
+// ok:true. Sem esta constante o card pintava verde nesse caso. Bump aqui E na edge, juntos.
+const CONTRATO_ESPERADO = "praticado-vence-omie-v1";
 
 export function classificarCanaria(
   data: RespostaCanaria | null | undefined,
@@ -44,7 +51,24 @@ export function classificarCanaria(
       detalhe: "A edge não retornou o envelope de canária ({canary:true}). Confirme que o deploy inclui a canária do #1089.",
     };
   }
-  // Verde SÓ com os 3 campos batendo: o praticado venceu o Omie.
+  // Marcador ausente = a canária no ar é PRÉ-marcador, ou seja bundle anterior a esta fatia. Não é
+  // "sem dados": a edge respondeu, e o que ela respondeu prova que está velha.
+  if (data.contrato === undefined || data.contrato === null) {
+    return {
+      status: "falha",
+      detalhe: `Canária respondeu sem o marcador de contrato (esperado \`${CONTRATO_ESPERADO}\`). O bundle no ar é ANTERIOR ao versionamento da canária — deploy pendente.`,
+    };
+  }
+  // Marcador de OUTRA fatia = deploy velho comparando velho×velho. É a mentira verde que o marcador
+  // existe para pegar: `ok`, `resolved` e `expected` podem estar todos "certos" e ainda assim serem
+  // os da fatia errada.
+  if (data.contrato !== CONTRATO_ESPERADO) {
+    return {
+      status: "falha",
+      detalhe: `Canária de OUTRA fatia no ar: contrato=\`${data.contrato}\`, esperado \`${CONTRATO_ESPERADO}\`. O \`ok\` desta resposta compara o expected VELHO com o helper VELHO — não prova o deploy.`,
+    };
+  }
+  // Verde SÓ com os 3 campos batendo E o contrato da fatia: o praticado venceu o Omie.
   if (data.ok === true && data.resolved === PRECO_PRATICADO && data.expected === PRECO_PRATICADO) {
     return {
       status: "ok",

--- a/src/lib/omie/derive-account-identity.test.ts
+++ b/src/lib/omie/derive-account-identity.test.ts
@@ -141,3 +141,49 @@ describe('canária identidade_probe: mecânica de comparação + fixtures (mesma
     expect(stableId(resolved)).not.toBe(stableId(sabotado));
   });
 });
+
+// ════════ CONTROLE DE CALIBRAÇÃO da canária `identidade_probe` (omie-vendas-sync) ════════
+// "Canária que não discrimina é teatro verde" (docs/agent/deploy.md): sem provar que a fixture fica
+// VERMELHA sob a forma ANTIGA, a probe só prova que a edge responde. Os nomes dos casos são os da
+// probe de propósito — renomear lá sem atualizar aqui é ruído que se vê no diff.
+describe('CALIBRAÇÃO: a canária identidade_probe fica VERMELHA sob a forma pré-P0-B', () => {
+  // A forma antiga: o código do payload era ADVISORY na aparência e AUTORIDADE na prática — quando
+  // vinha preenchido, vencia o derivado em vez de ser verificado contra ele. É o ataque que o P0-B
+  // fechou (payload escolhe o cliente ⇒ pedido no CNPJ errado).
+  const decideAntigo = (input: DecideInput): DecideResult => {
+    if (input.suppliedCodigo != null) {
+      return { ok: true, source: 'mirror', codigo_cliente: input.suppliedCodigo, codigo_vendedor: 7, backfill: false };
+    }
+    return decideAccountIdentity(input);
+  };
+
+  const FIX_DIVERGENCIA: DecideInput = {
+    account: A, suppliedCodigo: 999,
+    mirrorRows: [{ omie_codigo_cliente: 123, omie_codigo_vendedor: 7, empresa_omie: A }],
+    omieMatches: null,
+  };
+
+  it('`divergencia_supplied`: a forma ANTIGA resolve 999 em vez de recusar — diverge do `expected`', () => {
+    const antigo = decideAntigo(FIX_DIVERGENCIA);
+    expect(antigo).toEqual({ ok: true, source: 'mirror', codigo_cliente: 999, codigo_vendedor: 7, backfill: false });
+    // o `expected` que a canária carrega para este caso:
+    expect(antigo).not.toEqual({ ok: false, reason: 'divergence' });
+  });
+
+  it('`divergencia_supplied`: a forma ATUAL recusa — a canária fica verde só com o P0-B deployado', () => {
+    expect(decideAccountIdentity(FIX_DIVERGENCIA)).toEqual({ ok: false, reason: 'divergence' });
+  });
+
+  it('controle positivo: em `supplied_confirma` as duas concordam (o teste não é vacuamente verde)', () => {
+    // Advisory que CONFIRMA o derivado: as duas formas resolvem 123. Se divergissem em TUDO, o
+    // assert acima provaria só que são funções diferentes — não que a FIXTURE foi bem escolhida.
+    const confirma: DecideInput = {
+      account: A, suppliedCodigo: 123,
+      mirrorRows: [{ omie_codigo_cliente: 123, omie_codigo_vendedor: 7, empresa_omie: A }],
+      omieMatches: null,
+    };
+    const esperado = { ok: true, source: 'mirror', codigo_cliente: 123, codigo_vendedor: 7, backfill: false };
+    expect(decideAntigo(confirma)).toEqual(esperado);
+    expect(decideAccountIdentity(confirma)).toEqual(esperado);
+  });
+});

--- a/src/lib/omie/omie-doc-ambiguo.test.ts
+++ b/src/lib/omie/omie-doc-ambiguo.test.ts
@@ -118,3 +118,37 @@ describe('canária doc_ambiguo_probe: mecânica de comparação + fixtures (mesm
     expect(stableId(resolved)).not.toBe(stableId(canon([])));
   });
 });
+
+// ════════ CONTROLE DE CALIBRAÇÃO da canária `doc_ambiguo_probe` (omie-analytics-sync) ════════
+// "Canária que não discrimina é teatro verde" (docs/agent/deploy.md). Aqui a calibração vale dobrado:
+// a ausência deste helper é INDETECTÁVEL por sonda de dados — a proof-table só encolhe quando há
+// duplicata-CNPJ real na conta, e não há em prod. No run normal o guard nunca é exercitado, então ele
+// some sem deixar rastro no dado (foi o que o deploy do Lovable fez em #1272/#1273). A única prova é
+// rodar o helper deployado sobre um fixture SINTÉTICO — e este bloco prova que o fixture discrimina.
+describe('CALIBRAÇÃO: a canária doc_ambiguo_probe fica VERMELHA sob o helper revertido', () => {
+  // A regressão real: o helper some do bundle e o chamador segue sem marcar ninguém como ambíguo —
+  // last-write-wins volta e um código arbitrário vira vínculo na proof-table.
+  const semGuard = (_registros: ReadonlyArray<{ doc: string; codigo: number }>): Set<string> => new Set();
+
+  const FIX_AMBIGUO = [{ doc: '111', codigo: 100 }, { doc: '111', codigo: 200 }];
+
+  it('`doc_2_codigos_distintos`: o helper revertido devolve ∅ — diverge do `expected` ["111"]', () => {
+    expect([...semGuard(FIX_AMBIGUO)].sort()).toEqual([]);
+    expect([...semGuard(FIX_AMBIGUO)].sort()).not.toEqual(['111']);
+  });
+
+  it('`doc_2_codigos_distintos`: o helper ATUAL marca "111" — a canária fica verde só com o P1b no ar', () => {
+    expect([...docsComCodigoAmbiguoNoOmie(FIX_AMBIGUO)].sort()).toEqual(['111']);
+  });
+
+  it('controle positivo: nos casos LIMPOS as duas concordam (o teste não é vacuamente verde)', () => {
+    // 1 código por doc e o mesmo código repetido: ambas devolvem ∅. Sem este controle, a divergência
+    // acima provaria só que `semGuard` é uma função diferente — não que a FIXTURE foi bem escolhida.
+    const limpo = [{ doc: '111', codigo: 100 }];
+    const repetido = [{ doc: '111', codigo: 100 }, { doc: '111', codigo: 100 }];
+    expect([...semGuard(limpo)]).toEqual([]);
+    expect([...docsComCodigoAmbiguoNoOmie(limpo)]).toEqual([]);
+    expect([...semGuard(repetido)]).toEqual([]);
+    expect([...docsComCodigoAmbiguoNoOmie(repetido)]).toEqual([]);
+  });
+});

--- a/src/lib/pricing/__tests__/mergeCustomerPrices.test.ts
+++ b/src/lib/pricing/__tests__/mergeCustomerPrices.test.ts
@@ -98,3 +98,52 @@ describe("isValidUnitPrice — guard money-path (finito e > 0)", () => {
     }
   });
 });
+
+// ════════ CONTROLE DE CALIBRAÇÃO da canária `?canary=1` (analyze-unified-order) ════════
+// "Canária que não discrimina é teatro verde" (docs/agent/deploy.md): a fixture tem de exercitar o
+// comportamento que MUDOU, e é preciso PROVAR que sob a implementação ANTIGA ela ficaria VERMELHA.
+// Sem estes asserts, a probe só provaria que a edge responde — que é exatamente a diferença entre
+// canária versionada e "meia-canária" (docs/historico/deploy-no-op-por-desenho.md, lição 2).
+//
+// O bloco reimplementa a forma PRÉ-#1077/#1080 e roda o MESMO fixture que a canária carrega
+// (local=123, Omie=999, expected=123), exigindo que o resultado DIVIRJA do `expected`. O fixture é
+// repetido aqui de propósito: se alguém mudar os números na edge sem mudar aqui, o diff mostra.
+describe("CALIBRAÇÃO: a canária de preço fica VERMELHA sob a forma pré-#1077", () => {
+  // A forma antiga: o segundo laço não tinha o guard `!(productId in priceMap)`, então o histórico
+  // do Omie SOBRESCREVIA o preço praticado em vez de só preencher gap. Era o bug money-path que o
+  // deploy do Lovable já reverteu uma vez (2026-06-26) — e é o que a canária vigia.
+  const mergeAntigo = (
+    localPrices: ReadonlyArray<{ product_id?: string | null; unit_price?: number | null }>,
+    omiePrices: Record<string, number>,
+  ): Record<string, number> => {
+    const priceMap: Record<string, number> = {};
+    for (const row of localPrices) {
+      if (row?.product_id && isValidUnitPrice(row?.unit_price)) priceMap[row.product_id] = row.unit_price;
+    }
+    for (const [productId, price] of Object.entries(omiePrices)) {
+      if (productId && isValidUnitPrice(price)) priceMap[productId] = price; // ← sem o guard: sobrescreve
+    }
+    return priceMap;
+  };
+
+  const FIXTURE_LOCAL = [{ product_id: "CANARY", unit_price: 123 }];
+  const FIXTURE_OMIE = { CANARY: 999 };
+  const EXPECTED = 123; // o `expected` que a canária carrega
+
+  it("a forma ANTIGA produz 999 — divergindo do `expected` que a canária carrega", () => {
+    expect(mergeAntigo(FIXTURE_LOCAL, FIXTURE_OMIE).CANARY).toBe(999);
+    expect(mergeAntigo(FIXTURE_LOCAL, FIXTURE_OMIE).CANARY).not.toBe(EXPECTED);
+  });
+
+  it("a forma ATUAL produz 123 — a canária fica verde só com o helper certo deployado", () => {
+    expect(mergeCustomerPrices(FIXTURE_LOCAL, FIXTURE_OMIE).CANARY).toBe(EXPECTED);
+  });
+
+  it("controle positivo: nos casos SEM conflito as duas concordam (o teste não é vacuamente verde)", () => {
+    // Se divergissem em TUDO, o assert de divergência não provaria que a FIXTURE foi bem escolhida —
+    // provaria só que são funções diferentes. O gap (só Omie tem preço) é onde elas têm de concordar.
+    const soOmie = { GAP: 50 };
+    expect(mergeAntigo([], soOmie).GAP).toBe(50);
+    expect(mergeCustomerPrices([], soOmie).GAP).toBe(50);
+  });
+});

--- a/supabase/functions/_shared/sonda-versao.ts
+++ b/supabase/functions/_shared/sonda-versao.ts
@@ -38,12 +38,30 @@ const SONDA_NAO = new Set(["false", "0"]);
  * Sem isso, todo tick viraria sonda e o trabalho do dia não sairia.
  */
 export function classificarSonda(body: unknown): DecisaoSonda {
+  return classificarFlag(body, "probe");
+}
+
+/**
+ * O MESMO classificador, sobre um campo de nome diferente.
+ *
+ * Existe porque a `analyze-unified-order` liga a canária pelo campo `canary` e decidia por
+ * `canary === true` CRU. As duas regras acima valem lá inteiras, com o lado caro trocado: quem
+ * invoca é o founder pelo SQL Editor, onde `jsonb_build_object('canary', true)` vira a STRING
+ * "true" com facilidade, e o fluxo real dessa edge é uma análise de pedido com LLM. O prejuízo não
+ * é só o token: a resposta do fluxo real fica INDISTINGUÍVEL de "bundle velho ignorou o parâmetro"
+ * (a armadilha 1 de `docs/agent/deploy.md` §Canárias), então o diagnóstico sai errado no exato
+ * momento em que se está tentando provar o deploy.
+ *
+ * É extração, não cópia: um classificador money-path com duas implementações vira duas verdades, e
+ * a que não tiver teste é a que decide errado.
+ */
+export function classificarFlag(body: unknown, campo: string): DecisaoSonda {
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     return { tipo: "disparo" };
   }
-  if (!("probe" in body)) return { tipo: "disparo" };
+  if (!(campo in body)) return { tipo: "disparo" };
 
-  const bruto = (body as { probe: unknown }).probe;
+  const bruto = (body as Record<string, unknown>)[campo];
   if (typeof bruto === "boolean") return { tipo: bruto ? "sonda" : "disparo" };
 
   if (typeof bruto === "string" || typeof bruto === "number") {
@@ -86,6 +104,17 @@ export function criarRespostaSonda(edge: string) {
 
 /** Mensagem do 400 de `probe` ambíguo. `efeito` descreve o custo real daquela edge. */
 export function erroSondaAmbigua(valor: string, efeito: string): string {
-  return `Parâmetro 'probe' com valor não reconhecido (${valor}). Use {"probe":true} para a sonda ` +
+  return erroFlagAmbigua("probe", valor, efeito);
+}
+
+/**
+ * A mesma recusa, NOMEANDO o campo que veio ambíguo.
+ *
+ * O campo entra na mensagem porque a recusa é uma instrução de conserto: quem colou
+ * `jsonb_build_object('canary', …)` no SQL Editor e recebe "use {"probe":true}" vai corrigir o
+ * campo errado e sondar de novo — duas viagens manuais, e a segunda também falha.
+ */
+export function erroFlagAmbigua(campo: string, valor: string, efeito: string): string {
+  return `Parâmetro '${campo}' com valor não reconhecido (${valor}). Use {"${campo}":true} para a sonda ` +
     `de versão, ou omita a chave para executar. Recusado por segurança: ${efeito}.`;
 }

--- a/supabase/functions/_shared/sonda-versao_test.ts
+++ b/supabase/functions/_shared/sonda-versao_test.ts
@@ -6,7 +6,7 @@
 // pedido submetido no portal do fornecedor (`enviar-pedido-portal-sayerlack`). Por isso o default
 // cai no lado caro: `probe` presente mas não reconhecido é AMBÍGUO, nunca execução por omissão.
 
-import { classificarSonda, criarRespostaSonda, erroSondaAmbigua } from "./sonda-versao.ts";
+import { classificarFlag, classificarSonda, criarRespostaSonda, erroFlagAmbigua, erroSondaAmbigua } from "./sonda-versao.ts";
 
 function assertEquals(a: unknown, b: unknown, msg?: string) {
   if (JSON.stringify(a) !== JSON.stringify(b)) {
@@ -118,4 +118,81 @@ Deno.test("CALIBRAÇÃO: nos casos SEGUROS as duas concordam (o teste não é va
   assertEquals(classificarSonda({ probe: true }).tipo, "sonda");
   assertEquals(classificarSondaIngenua({ empresa: "OBEN" }), "disparo");
   assertEquals(classificarSonda({ empresa: "OBEN" }).tipo, "disparo");
+});
+
+// ════════ `classificarFlag` — o MESMO classificador sobre um campo de nome diferente ════════
+// A `analyze-unified-order` decide a canária pelo campo `canary`, não `probe`, e decidia por
+// `canary === true` CRU. O founder invoca a canária pelo SQL Editor, onde
+// `jsonb_build_object('canary', true)` vira a STRING "true" com facilidade — e ali o lado caro não
+// é um PO no ERP, é uma análise de pedido com LLM (token gasto) cuja resposta fica INDISTINGUÍVEL
+// de "bundle velho ignorou o parâmetro". Mesmas duas regras, outro campo: por isso a lógica é
+// extraída em vez de reescrita — um classificador money-path com duas cópias vira duas verdades.
+
+Deno.test("classificarFlag: o campo é parâmetro — `canary` classifica igual a `probe`", () => {
+  assertEquals(classificarFlag({ canary: true }, "canary").tipo, "sonda");
+  assertEquals(classificarFlag({ canary: "true" }, "canary").tipo, "sonda");
+  assertEquals(classificarFlag({ canary: "1" }, "canary").tipo, "sonda");
+  assertEquals(classificarFlag({ canary: 1 }, "canary").tipo, "sonda");
+  assertEquals(classificarFlag({ canary: "  TRUE  " }, "canary").tipo, "sonda");
+  assertEquals(classificarFlag({ canary: false }, "canary").tipo, "disparo");
+  assertEquals(classificarFlag({ canary: "0" }, "canary").tipo, "disparo");
+});
+
+Deno.test("classificarFlag: campo AUSENTE é o fluxo real (a análise de pedido de verdade)", () => {
+  // O chamador legítimo do analyze-unified-order não manda `canary` nenhum. Se ausência virasse
+  // canária, a edge pararia de analisar pedido — quebra visível, mas quebra.
+  assertEquals(classificarFlag({ text: "2x tinta branca" }, "canary").tipo, "disparo");
+  assertEquals(classificarFlag({}, "canary").tipo, "disparo");
+});
+
+Deno.test("classificarFlag: `canary` presente e não reconhecido → AMBÍGUO (não gasta LLM)", () => {
+  const d = classificarFlag({ canary: "sim" }, "canary");
+  assertEquals(d.tipo, "ambiguo");
+  assertEquals(d.tipo === "ambiguo" ? d.valor : null, '"sim"');
+});
+
+Deno.test("classificarFlag: o campo NÃO vaza — `probe` não liga a canária nem vice-versa", () => {
+  // Um classificador que ignorasse o parâmetro e olhasse sempre `probe` passaria nos testes acima
+  // por acidente (os corpos só têm um campo cada). Este caso separa os dois.
+  assertEquals(classificarFlag({ probe: true }, "canary").tipo, "disparo");
+  assertEquals(classificarFlag({ canary: true }, "probe").tipo, "disparo");
+});
+
+Deno.test("classificarSonda é `classificarFlag(body,'probe')` — uma lógica, não duas", () => {
+  for (const corpo of [{ probe: true }, { probe: "true" }, { probe: "talvez" }, { probe: false }, {}]) {
+    assertEquals(classificarSonda(corpo), classificarFlag(corpo, "probe"), `divergiu em ${JSON.stringify(corpo)}`);
+  }
+});
+
+Deno.test("CALIBRAÇÃO: a forma `canary === true` CRUA manda a string do SQL Editor para o LLM", () => {
+  // É a forma que estava deployada na analyze-unified-order. Sob ela, o founder que colasse
+  // `jsonb_build_object('canary', true)` e recebesse a string "true" pagaria uma análise de pedido
+  // com LLM e leria a resposta como "bundle velho" — o diagnóstico errado, pelo custo errado.
+  const canariaCrua = (body: unknown) => ((body as { canary?: unknown })?.canary === true ? "canaria" : "fluxo_real");
+  assertEquals(canariaCrua({ canary: "true" }), "fluxo_real");
+  assertEquals(classificarFlag({ canary: "true" }, "canary").tipo, "sonda");
+  // e o valor não reconhecido: a crua EXECUTA, a robusta RECUSA
+  assertEquals(canariaCrua({ canary: "sim" }), "fluxo_real");
+  assertEquals(classificarFlag({ canary: "sim" }, "canary").tipo, "ambiguo");
+  // Controle positivo: nos casos seguros as duas concordam (senão o assert de divergência só
+  // provaria que são funções diferentes).
+  assertEquals(canariaCrua({ canary: true }), "canaria");
+  assertEquals(classificarFlag({ canary: true }, "canary").tipo, "sonda");
+  assertEquals(canariaCrua({ text: "2x tinta" }), "fluxo_real");
+  assertEquals(classificarFlag({ text: "2x tinta" }, "canary").tipo, "disparo");
+});
+
+Deno.test("erroFlagAmbigua: a recusa NOMEIA o campo — dizer 'probe' na canária manda corrigir o campo errado", () => {
+  const msg = erroFlagAmbigua("canary", '"sim"', "esta edge analisa o pedido com LLM (token gasto)");
+  if (!msg.includes("'canary'")) throw new Error(`recusa não cita o campo 'canary': ${msg}`);
+  if (msg.includes("'probe'")) throw new Error(`recusa cita 'probe' numa canária de campo 'canary': ${msg}`);
+  if (!msg.includes('"sim"')) throw new Error(`recusa não cita o valor: ${msg}`);
+  if (!msg.includes("analisa o pedido com LLM")) throw new Error(`recusa não cita o efeito: ${msg}`);
+});
+
+Deno.test("erroSondaAmbigua é `erroFlagAmbigua('probe', …)` — o texto das 18 sondas não muda", () => {
+  assertEquals(
+    erroSondaAmbigua('"talvez"', "cria PO no Omie"),
+    erroFlagAmbigua("probe", '"talvez"', "cria PO no Omie"),
+  );
 });

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -7,6 +7,7 @@ import {
   prepararImagens,
 } from "./imagem-helpers.ts";
 import { extrairToolUseUnico, sanitizarListaIA } from "./saida-ia.ts";
+import { classificarFlag, erroFlagAmbigua } from "../_shared/sonda-versao.ts";
 import {
   type AcumuladorCache,
   acumularUsoCache,
@@ -216,20 +217,53 @@ Deno.serve(async (req) => {
       }
     }
 
-    const { text, imageBase64, imagesBase64, products, userTools, customerUserId, searchCustomer, canary } = await req.json();
+    const body = await req.json();
+    const { text, imageBase64, imagesBase64, products, userTools, customerUserId, searchCustomer } = body;
 
     // CANÁRIA COMPORTAMENTAL (staff-gated — já passou pelo gate de auth+staff acima). Prova que o
     // merge de preço REALMENTE DEPLOYADO honra "order_items vence o Omie": local=123 deve vencer
     // Omie=999. Probe HTTP = única evidência de que o deploy do Lovable não reverteu a lógica.
     // Roda o helper REAL (não uma cópia do teste) e não toca LLM/Omie/DB. Ver edge-money-path-invariants.
-    if (canary === true) {
+    //
+    // CLASSIFICADOR ROBUSTO (não `canary === true` cru): quem invoca é o founder pelo SQL Editor, e
+    // `jsonb_build_object('canary', true)` vira a STRING "true" com facilidade. Sob a comparação
+    // crua isso caía no FLUXO REAL — uma análise de pedido com LLM, que gasta token E devolve uma
+    // resposta INDISTINGUÍVEL de "bundle velho ignorou o parâmetro" (armadilha 1 de
+    // docs/agent/deploy.md §Canárias). Valor presente mas não reconhecido é AMBÍGUO → recusa 400,
+    // nunca execução por omissão. Chave AUSENTE segue direto para o fluxo real (o chamador normal).
+    const decisaoCanaria = classificarFlag(body, "canary");
+    if (decisaoCanaria.tipo === "ambiguo") {
+      return new Response(
+        JSON.stringify({
+          error: erroFlagAmbigua(
+            "canary",
+            decisaoCanaria.valor,
+            "esta edge analisa o pedido com LLM (token gasto) e a resposta ficaria indistinguível de bundle velho",
+          ),
+        }),
+        { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } },
+      );
+    }
+    if (decisaoCanaria.tipo === "sonda") {
       const resolved = mergeCustomerPrices(
         [{ product_id: "CANARY", unit_price: 123 }],
         { CANARY: 999 },
       ).CANARY;
       const expected = 123;
+      // `contrato` é o VERSION MARKER exigido por docs/agent/deploy.md §Canárias: sem ele um deploy
+      // INTEGRALMENTE VELHO carrega o `expected` VELHO junto, compara velho×velho e responde
+      // ok:true mentindo verde. O `ok` sozinho separa "a função respondeu" de nada — o marcador é o
+      // que separa "respondeu" de "é a versão que eu deployei". O nome NOMEIA a fatia (a canária é
+      // pré-existente, do #1089, então `v1.0-sensor-inicial` seria desonesto aqui). ⚠️ BUMP
+      // obrigatório a cada fatia que mude o contrato desta canária.
       return new Response(
-        JSON.stringify({ canary: true, resolved, expected, ok: resolved === expected }),
+        JSON.stringify({
+          canary: true,
+          contrato: "praticado-vence-omie-v1",
+          resolved,
+          expected,
+          ok: resolved === expected,
+        }),
         { headers: { ...corsHeaders, "Content-Type": "application/json" } },
       );
     }

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -2491,8 +2491,18 @@ Deno.serve(async (req) => {
           const expected = canon(c.expected);
           return { caso: c.caso, resolved, expected, ok: stableId(resolved) === stableId(expected) };
         });
+        // `contrato` é o VERSION MARKER exigido por docs/agent/deploy.md §Canárias. Esta canária é o
+        // caso NOMEADO em docs/historico/deploy-no-op-por-desenho.md: ela TINHA canária e mesmo
+        // assim precisou de sonda de versão, porque respondia igual num bundle de hoje e num de três
+        // fatias atrás — "ter canária não dispensa marcador". O nome NOMEIA a fatia que ela verifica:
+        // o fail-closed do P1b (doc com >1 código no Omie não vira vínculo).
+        // ⚠️ BUMP obrigatório a cada fatia que mude essa tabela-verdade.
+        // `canary: true` acompanha o `probe_no_ar` histórico para a receita SQL do guia — que aqui
+        // precisa descer no envelope `data` (esta edge responde `{success,data}`, não no topo).
         result = {
           success: true,
+          canary: true,
+          contrato: "doc-ambiguo-fail-closed-v1",
           probe_no_ar: true, // a action respondeu → o helper P1b está no build deployado
           ok: casosDoc.every((c) => c.ok), // true = a tabela-verdade deployada bate em TODOS os fixtures
           casos: casosDoc,

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -3561,8 +3561,19 @@ Deno.serve(async (req) => {
           const resolved = decideAccountIdentity(c.input);
           return { caso: c.caso, resolved, expected: c.expected, ok: stableId(resolved) === stableId(c.expected) };
         });
+        // `contrato` é o VERSION MARKER exigido por docs/agent/deploy.md §Canárias. Sem ele esta
+        // canária responde IGUAL num bundle de hoje e num de três fatias atrás: um deploy
+        // integralmente velho carrega o `expected` VELHO junto, compara velho×velho e responde
+        // ok:true mentindo verde (a ⚠️ #2 do guia). O nome NOMEIA a fatia que a canária verifica —
+        // a tabela-verdade fail-closed do P0-B (1-dono resolve; divergência advisory×derivado,
+        // ambiguidade espelho/Omie, ausência e bigint fora de range TODOS recusam).
+        // ⚠️ BUMP obrigatório a cada fatia que mude essa tabela-verdade.
+        // `canary: true` acompanha o `probe_no_ar` histórico porque a receita SQL do guia lê
+        // `content::jsonb->'canary'`: sem o campo o verificador leria NULL e concluiria "sem canária".
         result = {
           success: true,
+          canary: true,
+          contrato: "identidade-fail-closed-v1",
           probe_no_ar: true, // a action respondeu → a derivação P0-B está no build deployado
           account,
           ok: casosId.every((c) => c.ok), // true = a tabela-verdade deployada bate em TODOS os fixtures


### PR DESCRIPTION
## O que

Versiona as **3 últimas canárias sem marcador de contrato** (`contrato = —` na tabela do `deploy.md`), fechando a dívida que o `docs/historico/deploy-no-op-por-desenho.md` deixou declarada aberta na lição 2.

| edge | contrato | o que a fixture discrimina |
|---|---|---|
| `analyze-unified-order` | `praticado-vence-omie-v1` | praticado 123 vence Omie 999 (velho: o Omie sobrescrevia → `resolved=999`) |
| `omie-vendas-sync` | `identidade-fail-closed-v1` | divergência advisory×derivado recusa (velho: o advisory sobrescrevia) |
| `omie-analytics-sync` | `doc-ambiguo-fail-closed-v1` | doc ambíguo não vira vínculo (velho: helper sempre-∅ → `[]`) |

O marcador **nomeia a fatia** que cada canária verifica hoje — não `v1.0-sensor-inicial`, que só seria honesto se o sensor nascesse aqui. As três são pré-existentes.

## Por que (⚠️ #2 do deploy.md, "mente verde")

Um deploy **integralmente velho** carrega a canária de uma fatia anterior — com o `expected` velho junto — e compara velho×velho. Responde `canary:true, ok:true` e passa como aprovado. O `ok` sozinho separa "a função respondeu" de nada; o marcador é o que separa "respondeu" de "**é a versão que eu deployei**".

## Dois achados que ampliaram o escopo

**1. A receita SQL documentada não lia duas destas canárias.** As `omie-*` respondiam `probe_no_ar`, **não** `canary`, e a `omie-analytics-sync` embrulha tudo em `{success,data:{…}}`. A receita fazia `content::jsonb->'canary'` → **NULL** nas duas, e NULL se lê como "não tem canária": ausência de dado virando veredito, justo quando se tenta provar deploy. Agora emitem `canary: true` (mantendo `probe_no_ar`, que o gate textual exige) e a receita desce no envelope com `COALESCE(content::jsonb->'data', content::jsonb)` — combinado com a leitura por `WHERE id = <request_id>` que o `fe65e0768` acabou de introduzir.

**2. Emitir o marcador não bastava — faltava o consumidor exigir o valor.** O card "Canária de preço" classificava por `ok && resolved===123 && expected===123`; com o marcador só no produtor, um deploy velho seguiria verde — o furo original visto do outro lado. `classificarCanaria` agora recusa contrato ausente e contrato de outra fatia, nomeando ambos no `detalhe` (que o card renderiza).

## `analyze-unified-order`: classificador robusto no lugar do `canary === true` cru

A canária decidia por igualdade crua. `jsonb_build_object('canary', true)` vira a STRING `"true"` com facilidade no SQL Editor, e aí caía no **fluxo real** — análise de pedido com LLM, que gasta token e devolve resposta **indistinguível de "bundle velho ignorou o parâmetro"** (armadilha 1 do guia): o diagnóstico errado, pelo custo errado.

`classificarFlag(body, campo)` foi **extraído** de `classificarSonda` em `_shared/sonda-versao.ts` (mesma lógica, campo parametrizado — cópia viraria duas verdades), e `erroFlagAmbigua` **nomeia o campo** na recusa: mandar "use `probe`" a quem colou `canary` faz corrigir o campo errado e custa uma segunda viagem manual. Valor não reconhecido → **400**, nunca execução por omissão; chave ausente segue para o fluxo real.

## Calibração (canária que não discrimina é teatro verde)

Controles co-localizados no teste de cada oráculo, rodando a forma ANTIGA sobre os MESMOS fixtures da probe e exigindo divergência do `expected` — cada um com **controle positivo** (nos casos seguros as duas formas concordam, senão a divergência só provaria que são funções diferentes).

## Falsificação — 8 sabotagens, cada uma exigindo vermelho que NOMEIA a edge

A 1ª rodada **pegou um furo no próprio gate desta entrega**: apagar `canary: true` do código da `omie-analytics-sync` dava **exit 0**, porque o assert positivo casava no comentário que *explica* o campo. Verde por cegueira — a classe do `gates-textuais-cegos.md` pelo lado do assert **positivo** (o CLAUDE.md já mandava limpar antes do negativo). Corrigido extraindo os blocos de `removerComentarios(src)`, o stripper compartilhado; a gêmea `omie-vendas-sync` tinha o mesmo furo e virou S3b.

| sabotagem | exit | vermelho |
|---|---|---|
| S1 apagar o marcador da edge | 1 | `sumiu o marcador \`contrato\` da canária de preço` |
| S2 marcador genérico (`v1.0-sensor-inicial`) | 1 | `omie-vendas-sync` |
| S3 remover `canary:true` (analytics) | 1 | `não expõe \`canary: true\` — a receita SQL` |
| S3b idem (vendas-sync) | 1 | `não expõe \`canary: true\` — a receita SQL` |
| S4 tabela do deploy.md volta a `—` | 1 | `não fixa \`praticado-vence-omie-v1\`` |
| S5 voltar ao `canary === true` cru | 1 | `voltou a decidir por \`canary === true\` cru` |
| S6 helper real sem o guard | 1 | `mergeCustomerPrices` |
| S7 consumidor para de exigir o contrato | 1 | `canaria-preco` |

S3/S3b confirmam que a sabotagem **aplicou** antes de ler o exit — um `perl` que não casa devolve 0 e se leria como "o gate não cobre". Árvore restaurada limpa ao fim.

## Gates

`test:edges` 879/879 · `typecheck` exit 0 · `lint` exit 0 (0 errors) · `edges:typecheck` exit 0 (0 de classe-crash) · vitest da entrega 287/287 · 4 gates estruturais 63/63.

> ⚠️ Os 4 gates estruturais falharam por **timeout de 20s** na primeira rodada, com a máquina em 11 jobs de fila e 5,5 GB de swap. Zero falhas de asserção em toda a bateria. Re-rodados com a fila vazia: verdes. Timeout é ausência de dado, não reprovação.

## Deploy (manual — merge NÃO publica)

As 3 edges precisam de deploy pelo chat do Lovable. Verificação: as duas `omie-*` pela receita `net.http_post` + `psql-ro`; a `analyze-unified-order` **não sai pelo SQL Editor** (é gated por JWT de staff, não aceita `x-cron-secret`) — lê-se pelo card Governança → Auditoria, que imprime o contrato recebido vs o esperado. Já registrado no guia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
