### PR TITLE
test(heavy): o flaky era sincronização por DURAÇÃO — o setup media um mundo meio-montado

### DIFF
--- a/docs/historico/vigia-de-cobertura-parcial.md
+++ b/docs/historico/vigia-de-cobertura-parcial.md
@@ -43,8 +43,8 @@ Rodar as 9 uma a uma mudou a decisão (órfã VERMELHA se conserta, não se cata
   Todas montam o próprio mundo (mktemp, `git init`, stub de `curl`/`gh` no PATH,
   `AFIACAO_HEAVY_DEST`) — imunes inclusive ao checkout raso (`fetch-depth: 1`) do runner.
 - **2 macOS-only** → baseline explícita com motivo, em `scripts/hooks-suites-baseline.ts`:
-  `test-heavy.sh` (semáforo de RAM real com N processos em disputa; `sysctl`/`stat -f`; **flaky** —
-  2 verdes e 1 vermelho em 3 execuções na M2 com 36 sessões vivas; ~50s) e `test-heavy-install.sh`
+  `test-heavy.sh` (semáforo de RAM real com N processos em disputa; `sysctl`/`stat -f`; ~50s — era
+  também flaky, ver a seção abaixo) e `test-heavy-install.sh`
   (compara inode com `stat -f %i`, **BSD**: no GNU do ubuntu `-f` é *outra* flag — status do
   filesystem — então não falharia, passaria **medindo a coisa errada**, que é pior que vermelho).
 
@@ -55,6 +55,39 @@ conjunto-a-conjunto com o disco, tirando o molde do nome do **corpo** do laço. 
 padrão passa a ser coberto sozinho, sem editar o vigia. Cobra nos dois sentidos (órfã e fantasma)
 e faz **burn-down** da baseline: entrada que voltou a rodar, ou que sumiu do disco, fica VERMELHA —
 baseline que não encolhe vira álibi. Isenção sem motivo escrito também reprova.
+
+## O flaky do `test-heavy.sh`: medir primeiro, depois consertar (2026-08-23)
+
+A 1ª rodada de triagem viu 1 vermelho em 3 e o registro saiu como *"2 verdes e 1 vermelho em 3"* —
+número que lê como **33%** de flaky. Medindo direito (10 execuções seguidas, capturando **qual
+asserção** falha e a carga da máquina, não só o exit code): **11 verdes em 13, ~15%**, e **sempre a
+mesma** asserção — `--status explica a sobrecarga em palavras`.
+
+Com a assinatura na mão, a causa apareceu no setup do caso, não no alvo:
+
+```bash
+AFIACAO_MAX_HEAVY=2 "$HEAVY" sleep 30 &   # ocupante A
+sleep 1
+AFIACAO_MAX_HEAVY=2 "$HEAVY" sleep 30 &   # ocupante B
+sleep 2                                   # ← sincroniza por DURAÇÃO
+st=$(AFIACAO_MAX_HEAVY=1 "$HEAVY" --status | grep "em uso")
+```
+
+O teste tratava *"passaram 2 segundos"* como prova de *"os 2 ocupantes registraram slot"*. Sob a
+carga real da máquina (load 30–79 com ~36 sessões) o 2º às vezes não chegava a tempo, e a asserção
+media um mundo **meio-montado**: acusava o `--status` de um defeito que era do próprio setup.
+
+Consertado com espera por **CONDIÇÃO** (`esperar_slots`, que faz poll no `n_slots` já existente),
+**fail-closed**: se a condição não chega no timeout, o teste reporta falha de **SETUP** por escrito.
+Esperar-e-seguir teria trocado um vermelho confuso por um verde mentiroso.
+
+Duas lições de método:
+
+- **Exit code não é diagnóstico.** Enquanto eu só colhia `exit=1`, o flaky parecia aleatório e o
+  remédio óbvio era "isolar/tolerar". Capturar a MARCA da asserção transformou 30 minutos de
+  medição num conserto de 4 linhas.
+- **Número apressado vira dívida.** "1 em 3" (n=3) e "1 em 7" (n=13) levam a decisões diferentes, e
+  o primeiro já estava commitado. Amostra pequena merece o `n` explícito ao lado.
 
 ## Lições
 

--- a/scripts/hooks-suites-baseline.ts
+++ b/scripts/hooks-suites-baseline.ts
@@ -20,9 +20,11 @@ export const SUITES_FORA_DO_CI: SuiteForaDoCI[] = [
     arquivo: 'test-heavy.sh',
     motivo:
       'macOS-only: exercita o semáforo de RAM real (sysctl/stat -f, BSD) com N processos em ' +
-      'disputa — o `heavy` não existe no runner ubuntu (exit 127). Além disso é FLAKY sob carga ' +
-      '(medido 2026-08-22: 2 verdes e 1 vermelho em 3 execuções na M2 com 36 sessões vivas) e ' +
-      'leva ~50s. Rodar à mão na M2 ao mexer em scripts/heavy.sh.',
+      'disputa — o `heavy` não existe no runner ubuntu (exit 127). Leva ~50s. Rodar à mão na M2 ' +
+      'ao mexer em scripts/heavy.sh. (Era também FLAKY: 2 vermelhos em 13 execuções, ~15%, ' +
+      'sempre na asserção do `--status` sob sobrecarga — o setup sincronizava por `sleep` fixo e ' +
+      'sob carga alta media um mundo meio-montado. Consertado com espera por CONDIÇÃO; o motivo ' +
+      'de estar aqui é só o macOS-only.)',
   },
   {
     arquivo: 'test-heavy-install.sh',

--- a/scripts/test-heavy.sh
+++ b/scripts/test-heavy.sh
@@ -40,6 +40,22 @@ bad()  { echo "  FAIL  $1"; fail=1; }
 zerar(){ rm -rf "${LK:?}"/slot-* "${LK:?}"/fila 2>/dev/null; mkdir -p "$LK/fila"; }
 n_slots(){ local s n=0; for s in "$LK"/slot-*; do [ -d "$s" ] && n=$((n+1)); done; echo "$n"; }
 
+# Espera CONDIÇÃO, não duração. Sincronizar por `sleep` fixo era a causa do flaky medido em
+# 2026-08-23 (13 execuções, ~15% vermelho, SEMPRE em "--status explica a sobrecarga"): sob a carga
+# real desta máquina (load 30-79, ~36 sessões) os 2 segundos nem sempre bastavam para o 2º ocupante
+# registrar o slot, e a asserção media um mundo MEIO-MONTADO — o teste acusava o `--status` de um
+# defeito que era do próprio setup. Fail-CLOSED: se a condição não chega, isso é reportado como
+# falha de SETUP, nunca engolido (esperar e seguir em frente seria trocar um vermelho confuso por
+# um verde mentiroso).
+esperar_slots(){ # $1=quantos slots  $2=timeout em segundos (default 15)
+  local alvo="$1" lim="${2:-15}" i=0
+  while [ "$(n_slots)" -lt "$alvo" ]; do
+    i=$((i+1)); [ "$i" -gt $((lim * 10)) ] && return 1
+    sleep 0.1
+  done
+  return 0
+}
+
 echo "test-heavy.sh — alvo: $HEAVY"
 echo "lockdir isolado: $LK"
 
@@ -67,9 +83,9 @@ wait "$w" 2>/dev/null
 # ─────────────────────────────────── 2. --status nunca reporta vaga negativa
 zerar
 AFIACAO_MAX_HEAVY=2 "$HEAVY" sleep "30$TAG" >/dev/null 2>&1 & a=$!
-sleep 1
+esperar_slots 1 || bad "setup: o 1º ocupante não registrou slot (não é defeito do --status)"
 AFIACAO_MAX_HEAVY=2 "$HEAVY" sleep "30$TAG" >/dev/null 2>&1 & b=$!
-sleep 2
+esperar_slots 2 || bad "setup: o 2º ocupante não registrou slot (não é defeito do --status)"
 st=$(AFIACAO_MAX_HEAVY=1 "$HEAVY" --status 2>/dev/null | grep "em uso")
 case "$st" in
   *-[0-9]*livre*) bad "--status negativo com o total encolhido: $st" ;;


### PR DESCRIPTION
Follow-up do #1902. Lá o `test-heavy.sh` entrou na baseline com dois motivos: macOS-only **e** flaky. Medindo o flaky direito, o segundo motivo se revelou um **defeito consertável**, não uma característica.

## Medir com a marca, não com o exit code

10 execuções seguidas, capturando **qual asserção** falha e a carga da máquina — não só o exit code:

| | |
|---|---|
| agora | 9 verdes / 1 vermelho em 10 |
| somando a triagem do #1902 | **11 / 13 → ~15%** |
| asserção que quebra | **sempre** `--status explica a sobrecarga em palavras` |

Enquanto eu só colhia `exit=1`, o flaky parecia aleatório e o remédio óbvio era "tolerar/isolar". A assinatura mostrou que não era ruído.

## A causa: sincronizar por duração

```bash
AFIACAO_MAX_HEAVY=2 "$HEAVY" sleep 30 &   # ocupante A
sleep 1
AFIACAO_MAX_HEAVY=2 "$HEAVY" sleep 30 &   # ocupante B
sleep 2                                   # ← espera DURAÇÃO
st=$(AFIACAO_MAX_HEAVY=1 "$HEAVY" --status | grep "em uso")
```

O teste tratava *"passaram 2 segundos"* como prova de *"os 2 ocupantes registraram slot"*. Sob a carga real desta máquina (load 30–79, ~36 sessões) o 2º nem sempre chegava a tempo, e a asserção media um mundo **meio-montado** — acusando o `--status` de um defeito que era do próprio setup.

É a doutrina da casa invertida: ausência de sinal (o slot ainda não registrado) sendo lida como dado.

## O conserto

`esperar_slots`, poll sobre o `n_slots` que já existia, **fail-CLOSED**: se a condição não chega no timeout, reporta falha de **SETUP** por escrito, nomeando que não é o `--status`. Esperar-e-seguir teria trocado um vermelho confuso por um verde mentiroso.

## Prova

| prova | exit | detalhe |
|---|---|---|
| 10 rodadas com o conserto | **0** ×10 | 10/10 verdes |
| **falsificação** (`esperar_slots 99 1`) | **1** | `FAIL setup: o 2º ocupante não registrou slot (não é defeito do --status)` |
| `test-heavy.sh` restaurado pós-sabotagem | — | `restaurado_limpo=SIM` |
| vigia de cobertura (vitest) | **0** | 12 testes |
| `typecheck` · `lint` · `shellcheck` | **0** | — |
| `docs-indice-gate` · `docs-citacoes-gate` | **0** | — |

**Ressalva honesta:** as 10 rodadas verdes correram sob load 8–29, abaixo do 30–79 de quando o flaky apareceu — então elas **corroboram**, não provam sozinhas. O argumento forte é estrutural (o teto fixo de 2s virou espera pela condição, até 15s) somado à falsificação, que mostra o fail-closed disparando.

## Correção de número do #1902

A baseline dizia *"2 verdes e 1 vermelho em 3 execuções"* — lê como 33%, com n=3. Com n=13 é ~15%. Corrigido, e explicitado que **o motivo de `test-heavy.sh` seguir fora do CI é só o macOS-only** (`sysctl`/`stat -f`); o flaky não era razão, era defeito.

Lição de método registrada em `docs/historico/vigia-de-cobertura-parcial.md`: exit code não é diagnóstico, e amostra pequena merece o `n` explícito ao lado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)