### PR TITLE
feat(sonda): a analyze-unified-order não tinha COMO provar deploy — a canária dela responde por OUTRA fatia [money-path]

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -34,6 +34,7 @@ import * as finFunding from "../fin-funding/versao.ts";
 import * as algoAudit from "../algorithm-a-audit/versao.ts";
 import * as positivacao from "../carteira-positivacao-snapshot/versao.ts";
 import * as omieFinanceiro from "../omie-financeiro/versao.ts";
+import * as analyzeOrder from "../analyze-unified-order/versao.ts";
 
 /**
  * `respostaSonda` (a maioria) ou `respostaSondaTactical` (a `generate-tactical-plan`, que embrulha o
@@ -95,6 +96,13 @@ const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   { nome: "algorithm-a-audit", mod: algoAudit },
   { nome: "carteira-positivacao-snapshot", mod: positivacao },
   { nome: "omie-financeiro", mod: omieFinanceiro },
+  // Sétima leva (#1622 prompt invertido): a PRIMEIRA que entra sem escrever no nosso banco E sem
+  // ser leitura barata. O critério dela é o SEGUNDO motivo do #1520 — "não existe caminho de
+  // prova": é chamada pelo BROWSER, então não deixa rastro em `net._http_response` nem linha em
+  // `cron.job_run_details`, o par que torna uma edge auditável de fora. Ela TEM canária desde o
+  // d8cf07152, e a canária é versionada — mas o `contrato` dela nomeia a fatia do MERGE DE PREÇO,
+  // não a do prompt, e ela vive depois do gate de staff. Ver `analyze-unified-order/versao.ts`.
+  { nome: "analyze-unified-order", mod: analyzeOrder },
 ];
 
 /** As cinco da terceira leva — os gates estruturais abaixo varrem todas. */
@@ -122,6 +130,10 @@ const FORMA_NORMALIZADA = [
   "algorithm-a-audit",
   "carteira-positivacao-snapshot",
   "omie-financeiro",
+  // Sétima leva: não escreve no banco, mas manda o catálogo inteiro para o modelo (token pago) —
+  // paga o mesmo preço se um `probe` mal grafado cair no fluxo real, que é o que estes gates
+  // existem para impedir. Confirma a regra do bloco acima: a FORMA não tem a ver com escrever.
+  "analyze-unified-order",
 ];
 
 /** Destas o gate NÃO aceita `x-cron-secret`, então a sonda precisa de gate PRÓPRIO. */
@@ -135,6 +147,12 @@ const FORMA_NORMALIZADA = [
 // dentro de `validateCaller(req, supabase)` — que precisa do client, criado depois do ponto onde
 // a sonda tem de responder. Nos três casos o caminho do SQL Editor não chega ao gate normal, e a
 // sonda só pode vir antes dele trazendo `authorizeCronOrStaff` própria.
+// `analyze-unified-order` é o caso mais agudo da lista: ela não tem `authorizeCronOrStaff`
+// NENHUM no fluxo real — o gate é JWT de usuário + `user_roles` (employee/master), precedido de um
+// `startsWith("Bearer ")` que responde antes de tudo. Sem gate próprio a sonda ou ficaria
+// inalcançável pelo SQL Editor, ou obrigaria a afrouxar o gate de uma edge que lê perfil de
+// cliente e paga o modelo. É também o que a separa da canária de preço dela, que vive DEPOIS
+// desse gate e por isso só o app logado alcança.
 const GATE_PROPRIO = [
   "omie-cliente",
   "omie-nfe-webhook",
@@ -142,6 +160,7 @@ const GATE_PROPRIO = [
   "fin-valor-cockpit",
   "fin-funding",
   "omie-financeiro",
+  "analyze-unified-order",
 ];
 
 Deno.test("toda edge instrumentada declara VERSAO no formato vN.N-slug", () => {
@@ -396,7 +415,15 @@ Deno.test("gate próprio: onde o gate da edge não aceita cron-secret, a sonda N
   }
 });
 
-Deno.test("recommend: a sonda vem ANTES do gate de Bearer do handler", () => {
+/**
+ * Edges cujo handler tem um `startsWith("Bearer ")` PRÓPRIO antes do fluxo real. Nelas a sonda
+ * precisa vir antes dele, senão `x-cron-secret` nunca alcança o `authorizeCronOrStaff`. Virou
+ * lista quando a segunda apareceu: herdar a regra é o que impede a terceira nessa forma de ficar
+ * de fora em silêncio.
+ */
+const BEARER_NO_HANDLER = ["recommend", "analyze-unified-order"];
+
+Deno.test("onde o handler tem gate de Bearer próprio, a sonda vem ANTES dele", () => {
   // Medido em prod (2026-08-22): `net.http_post` com `x-cron-secret` e SEM `Authorization`
   // devolveu 401 {"error":"Não autorizado"} — a mensagem do HANDLER, não do helper. Causa: o
   // `startsWith("Bearer ")` do handler estava ANTES da sonda, então o request morria ali e
@@ -406,16 +433,20 @@ Deno.test("recommend: a sonda vem ANTES do gate de Bearer do handler", () => {
   // que o helper reconhece (cron secret, service role, JWT), só as que por acaso vêm em
   // `Authorization: Bearer` chegam até ele. O caminho documentado (SQL Editor via
   // net.http_post) é exatamente o que não passa.
-  const h = trechoDoHandler("recommend");
-  const posSonda = h.indexOf("classificarSonda(");
-  const posBearer = h.indexOf('startsWith("Bearer ")');
-  if (posSonda < 0 || posBearer < 0) {
-    throw new Error("recommend: âncoras não encontradas (controle positivo vazio)");
-  }
-  if (posSonda > posBearer) {
-    throw new Error(
-      "recommend: a sonda está DEPOIS do gate de Bearer — x-cron-secret nunca chega ao authorizeCronOrStaff",
-    );
+  // A `analyze-unified-order` tem o MESMO desenho e chegou pelo #1622: gate de JWT de usuário +
+  // `user_roles`, com o `startsWith("Bearer ")` respondendo antes de tudo.
+  for (const nome of BEARER_NO_HANDLER) {
+    const h = trechoDoHandler(nome);
+    const posSonda = h.indexOf("classificarSonda(");
+    const posBearer = h.indexOf('startsWith("Bearer ")');
+    if (posSonda < 0 || posBearer < 0) {
+      throw new Error(`${nome}: âncoras não encontradas (controle positivo vazio)`);
+    }
+    if (posSonda > posBearer) {
+      throw new Error(
+        `${nome}: a sonda está DEPOIS do gate de Bearer — x-cron-secret nunca chega ao authorizeCronOrStaff`,
+      );
+    }
   }
 });
 

--- a/supabase/functions/analyze-unified-order/index.ts
+++ b/supabase/functions/analyze-unified-order/index.ts
@@ -8,6 +8,8 @@ import {
 } from "./imagem-helpers.ts";
 import { extrairToolUseUnico, sanitizarListaIA } from "./saida-ia.ts";
 import { classificarFlag, erroFlagAmbigua } from "../_shared/sonda-versao.ts";
+import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 import {
   type AcumuladorCache,
   acumularUsoCache,
@@ -177,6 +179,47 @@ Deno.serve(async (req) => {
     return new Response(null, { headers: corsHeaders });
   }
 
+  // ⚠️ SONDA DE VERSÃO — ANTES do gate de `Bearer ` do handler e ANTES do createClient. Ver
+  // versao.ts / _shared/sonda-versao.ts. A ordem não é estética: o gate abaixo é JWT de usuário e
+  // NÃO conhece `x-cron-secret`, então uma sonda colocada depois dele seria inalcançável pelo
+  // caminho documentado (SQL Editor via net.http_post) — exatamente o defeito que o #1882 corrigiu
+  // na `recommend`. É também o que separa esta sonda da CANÁRIA de preço logo abaixo: aquela vive
+  // depois do gate de staff, então só o app logado a alcança, e o `contrato` dela nomeia a fatia
+  // do MERGE DE PREÇO, não a do prompt.
+  //
+  // O parse subiu para cá porque `req.json()` é one-shot: o corpo lido aqui é reaproveitado como
+  // `body` pelo fluxo real. JSON inválido passa a responder 400 em vez de 500 pelo catch geral
+  // (erro do cliente contado como falha nossa), e corpo `null` — que estourava TypeError no
+  // destructuring — vira `{}` e cai na validação de "texto ou imagem é obrigatório", que é o que
+  // ele sempre foi.
+  //
+  // SEM anotação de tipo de propósito: `req.json()` devolve `any`, e é essa inferência que o
+  // destructuring do fluxo real herda. Anotar (`unknown` + cast) somaria 2 erros ao baseline do
+  // `edges:typecheck` sem consertar nada — são defeitos PRÉ-EXISTENTES, o principal sendo
+  // `montarSystemBlocks` declarando `searchCustomer: boolean` e recebendo a STRING do termo de
+  // busca (funciona por truthiness; corrigir mexe no prompt CACHEADO do #1622, que é money-path).
+  let corpoBruto;
+  try {
+    corpoBruto = await req.json();
+  } catch {
+    return new Response(JSON.stringify({ error: "invalid JSON" }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo !== "disparo") {
+    const auth = await authorizeCronOrStaff(req);
+    if (!auth.ok) return auth.response;
+    if (decisaoSonda.tipo === "sonda") {
+      return new Response(JSON.stringify(respostaSonda(VERSAO)), {
+        status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }), {
+      status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+
   try {
     const authHeader = req.headers.get("Authorization");
     if (!authHeader?.startsWith("Bearer ")) {
@@ -217,7 +260,9 @@ Deno.serve(async (req) => {
       }
     }
 
-    const body = await req.json();
+    // Corpo já consumido pela sonda acima (`req.json()` é one-shot). Não-objeto vira {} — cai na
+    // validação de "texto ou imagem é obrigatório" logo abaixo, exatamente como antes.
+    const body = (typeof corpoBruto === "object" && corpoBruto !== null ? corpoBruto : {});
     const { text, imageBase64, imagesBase64, products, userTools, customerUserId, searchCustomer } = body;
 
     // CANÁRIA COMPORTAMENTAL (staff-gated — já passou pelo gate de auth+staff acima). Prova que o

--- a/supabase/functions/analyze-unified-order/versao.ts
+++ b/supabase/functions/analyze-unified-order/versao.ts
@@ -1,0 +1,72 @@
+// Marcador de versão da edge `analyze-unified-order`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// POR QUE ESTA EDGE ENTROU, se ela NÃO escreve no nosso banco (as seis tabelas que toca —
+// `omie_products`, `omie_servicos`, `order_items`, `orders`, `profiles`, `user_roles` — são todas
+// leitura): pelo SEGUNDO motivo do #1520, "não existe caminho de prova". Ela é chamada pelo
+// BROWSER, então não deixa rastro em `net._http_response` nem linha em `cron.job_run_details` — o
+// par que torna uma edge de cron auditável de fora. Quando a pergunta "qual bundle está no ar?"
+// não tem NENHUMA resposta possível, a sonda é o sensor, independentemente de o efeito ser
+// reversível.
+//
+// O custo que a instrumentação paga foi medido, não suposto. Auditoria de 2026-08-23: o #1622
+// (prompt invertido e cacheado) estava mergeado e SEM como se provar. A escada inteira morria —
+// N1 só diz que a edge existe, e N2 é estruturalmente indisponível aqui (o Supabase é da org do
+// Lovable). Sobrava um `console.log` que só existe no bundle novo, legível apenas no painel e só
+// depois de alguém rodar uma análise de verdade.
+//
+// POR QUE A CANÁRIA DE PREÇO NÃO SUBSTITUI ISTO, mesmo depois de versionada. Quando esta sonda foi
+// escrita, a canária (`canary:true`) era não-versionada e mentia verde; o d8cf07152 fechou esse
+// buraco dando a ela um `contrato`. As duas continuam respondendo perguntas DIFERENTES, e é a
+// diferença que justifica as duas coexistirem:
+//
+//   canária ... `contrato: "praticado-vence-omie-v1"` nomeia a fatia do MERGE DE PREÇO, e prova
+//               que o deploy não reverteu "order_items vence o Omie". O #1622 não toca esse
+//               comportamento — a canária responde igual antes e depois dele.
+//   sonda ..... `versao` nomeia a fatia do PROMPT. É o que discrimina o #1622.
+//
+// E há a diferença de ALCANCE, que importa mais na prática: a canária vive DEPOIS do gate de staff
+// (JWT + `user_roles`), então só o app logado a alcança — o `x-cron-secret` do SQL Editor não
+// chega lá, apesar de o comentário dela citar o SQL Editor como invocador. A sonda responde antes
+// desse gate, com gate próprio, e por isso é a única das duas que o founder consegue disparar sem
+// abrir o app.
+//
+// GATE: a edge NÃO tem `authorizeCronOrStaff`. O gate dela é JWT de usuário + checagem de
+// `user_roles` (employee/master), e o `startsWith("Bearer ")` do handler responde ANTES de
+// qualquer outra coisa. Isso torna a sonda inalcançável pelo caminho documentado (SQL Editor via
+// `net.http_post` com `x-cron-secret`), que é exatamente a armadilha que o #1882 consertou na
+// `recommend`. Por isso a sonda responde ANTES desse gate, com gate PRÓPRIO — nenhum caminho fica
+// sem auth, o fluxo real continua exigindo JWT staff, e o custo do modelo só é pago quando `probe`
+// NÃO vem no corpo.
+//
+// EFEITO COLATERAL ÚTIL, e a razão de o gate próprio vir DEPOIS da classificação: as duas recusas
+// passam a ter strings DISTINTAS. `{"probe":true}` sem `Authorization` cai em `unauthorized()` de
+// `_shared/auth.ts` → `{"error":"Unauthorized"}` (inglês); qualquer outro corpo cai no gate do
+// handler → `{"error":"Não autorizado"}` (português). O bundle ANTERIOR a este PR responde a
+// segunda string nos DOIS casos, porque nele o `startsWith("Bearer ")` vem primeiro. Ou seja: esta
+// edge passa a ser verificável por ASSINATURA DE GATE (`docs/agent/deploy.md`), sem credencial
+// nenhuma e sem o SQL Editor — um `curl` anônimo distingue as versões.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("analyze-unified-order");
+
+/**
+ * Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho.
+ *
+ * Nasce nomeando a FATIA e não `v1.0-sensor-inicial` (mesma escolha da `generate-tactical-plan` e
+ * da `generate-bundle-argument`): o primeiro deploy desta sonda carrega junto o #1622, cujo deploy
+ * é justamente o que estava por provar quando ela foi escrita. Carimbar "sensor-inicial" apagaria a
+ * informação pela qual o marcador existe — e é o erro que congelou a sonda da `generate-tactical-plan`
+ * respondendo a mesma constante por várias fatias seguidas.
+ */
+export const VERSAO = "v1.0-prompt-invertido-cacheado";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge manda o CATÁLOGO INTEIRO de produtos e serviços para o modelo da Anthropic a cada " +
+  "chamada (token pago, e o prefixo estável do #1622 só é cacheado a partir da segunda), e o " +
+  "resultado é a lista de itens que o vendedor transforma em pedido — sondar por engano gasta " +
+  "token e devolve uma análise de IA onde se esperava um diagnóstico de uma linha";


### PR DESCRIPTION
## O que aconteceu

Auditoria de deploy das edges mergeadas na `main` em 2026-08-23 (janela 01:00Z–02:00Z). Duas se provaram no ar pela sonda de versão (`fin-cashflow-engine` e `omie-analytics-sync`, lidas em `net._http_response`). Esta não teve como — e é a mais money-path das três, porque o #1622 (prompt invertido e cacheado) mudou **como o modelo é chamado** na análise que vira pedido.

## A escada inteira morre nesta edge

| nível | por quê |
|---|---|
| N1 | só diz que a função existe (OPTIONS → servida) |
| N2 | estruturalmente indisponível aqui (o Supabase é da org do Lovable) |
| assinatura de gate | o #1622 não mudou **nada** antes do gate de auth (0 diffs) — não discrimina |
| rastro | a edge é chamada pelo **browser**: sem linha em `net._http_response` e sem `cron.job_run_details`, o par que torna uma edge auditável de fora |

Sobrava um `console.log` que só existe no bundle novo, legível apenas no painel e só depois de alguém rodar uma análise de verdade. É o critério do #1520 — **"não existe caminho de prova"**.

## Por que a canária de preço não resolve, mesmo depois de versionada

Quando esta sonda começou a ser escrita a canária era não-versionada e mentia verde. O d8cf07152 fechou esse buraco **enquanto este PR estava em voo**, dando a ela um `contrato` — e as duas continuam respondendo perguntas diferentes:

- **canária** — `contrato: "praticado-vence-omie-v1"` nomeia a fatia do **merge de preço** e prova que o deploy não reverteu "order_items vence o Omie". O #1622 não toca esse comportamento: a canária responde igual antes e depois dele.
- **sonda** — `versao` nomeia a fatia do **prompt**. É o que discrimina o #1622.

E há a diferença de **alcance**, que pesa mais na prática: a canária vive **depois** do gate de staff (JWT + `user_roles`), então só o app logado a alcança — o `x-cron-secret` do SQL Editor não chega lá, apesar de o comentário dela citar o SQL Editor como invocador. A sonda responde antes desse gate, com gate próprio, e é a única das duas que o founder dispara sem abrir o app.

## Gate

A edge **não tem `authorizeCronOrStaff` nenhum** no fluxo real: JWT de usuário + `user_roles`, precedido de um `startsWith("Bearer ")` que responde antes de tudo. Sonda depois dele seria inalcançável pelo SQL Editor — o defeito que o #1882 corrigiu na `recommend`. Por isso ela vem **antes**, com gate próprio: nenhum caminho fica anônimo e o modelo só é pago por quem **não** mandou `probe`.

**Efeito colateral que vale por si:** as duas recusas passam a ter strings distintas — `{"probe":true}` sem `Authorization` cai em `unauthorized()` (`"Unauthorized"`, inglês) e qualquer outro corpo cai no gate do handler (`"Não autorizado"`, português). O bundle anterior responde a segunda nos **dois** casos ⇒ a edge passa a ser verificável por **assinatura de gate**, com um curl anônimo, sem credencial e sem SQL Editor.

## Gate estrutural

Entra em `EDGES`, em `FORMA_NORMALIZADA` (a lista que o d8cf07152 criou com exatamente este raciocínio — a forma não tem a ver com escrever no banco) e em `GATE_PROPRIO`. O teste do Bearer virou lista (`BEARER_NO_HANDLER`) em vez de citar só a `recommend`, o que impede a terceira edge nessa forma de ficar de fora em silêncio.

## Evidência

| gate | resultado |
|---|---|
| contrato Deno | 23 passed / 0 failed, exit 0 |
| `test:edges` | 879 passed / 0 failed, exit 0 |
| `edges:typecheck` | exit 0, **0 erros de classe-crash** |
| `eslint` | exit 0, **0 erros** |
| guardrails de forma (8 arquivos) | 293 passed, exit 0 |
| `deno check` do arquivo | **15 erros = baseline da main**, medido pelos dois lados |

**Falsificado** (o gate discrimina — não é teatro verde). Controle positivo 23/23 exit 0, e cada sabotagem vermelha no teste certo:

| sabotagem | exit | quem pegou |
|---|---|---|
| sem `classificarSonda` | 1 | 4 testes |
| sem gate próprio | 1 | "responde sem gate próprio entre a classificação e a resposta" |
| classifica mas não responde | 1 | "o diagnóstico não sai" |
| sonda depois do `Bearer` | 1 | "x-cron-secret nunca chega ao authorizeCronOrStaff" |

⚠️ **Pré-requisito do deploy, não consequência:** o marcador precisa estar na `main` **antes** do deploy da edge, senão a viagem continua inverificável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)