### PR TITLE
feat(guard): PIPESTATUS no zsh é vazio, e vazio VALE ZERO — hook AVISA (o Codex derrubou o bloqueio)

### DIFF
--- a/.claude/hooks/pipestatus-zsh-guard.sh
+++ b/.claude/hooks/pipestatus-zsh-guard.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# pipestatus-zsh-guard.sh — PreToolUse(Bash): AVISA quando o comando lê um exit code que o zsh esvazia.
+#
+# POR QUÊ: o Bash tool desta máquina roda em /bin/zsh. `PIPESTATUS` é um bash-ism; o zsh chama
+# `pipestatus` (MINÚSCULO e 1-INDEXED). O nome errado não dá erro — expande para VAZIO. E vazio,
+# no `[` do zsh, não é "sem dado": é `0`, que por acaso é o exit code de SUCESSO. Medido nos dois
+# shells em 2026-08-23 (docs/historico/evidencia-positiva-shell.md §9):
+#
+#   false | true                                                  # o pipeline FALHOU
+#   if [ "${PIPESTATUS[0]}" -eq 0 ]; then echo "PIPELINE OK"; fi  # imprime OK
+#
+#   zsh:  ${PIPESTATUS[0]}=vazio · ${pipestatus[1]}=1 ✓ · ${pipestatus[0]}=vazio
+#   bash: ${PIPESTATUS[0]}=1 ✓   · ${pipestatus[1]}=vazio · [ "" -eq 0 ] = erro ALTO
+#
+# Duas formas fabricam veredito no zsh, e a SEGUNDA é o erro de quem acabou de aprender a lição —
+# corrige a caixa e mantém o índice do bash:
+#   (A) PIPESTATUS  (maiúsculo, qualquer forma)  — a variável não existe no zsh
+#   (B) pipestatus[0] (minúsculo, índice ZERO)   — existe, mas zsh é 1-indexed; [1] é o certo
+#
+# ── POR QUE AVISA E NÃO BLOQUEIA (revisto — a 1ª versão bloqueava) ────────────────────────────
+# A versão inicial dava `deny`, apostando que a fronteira "o zsh expande?" coincidiria com "é
+# bug?" e daria precisão de sobra. Revisão adversária do Codex (2026-08-23, enquadramento
+# defensivo de COBERTURA) derrubou a aposta, e cada achado foi reproduzido aqui em `zsh -f`:
+#
+#   FALSO NEGATIVO — a aritmética do zsh NÃO precisa de `$`, e variável ausente vira 0:
+#     (( PIPESTATUS[0] == 0 ))   ·   [[ pipestatus[0] -eq 0 ]]   ·   let 'rc = PIPESTATUS[0]'
+#     Todos fabricam o veredito; o detector, que só procurava expansão `$…`, liberava os três.
+#   FALSO POSITIVO — `echo x # ${PIPESTATUS[0]}` é COMENTÁRIO: o zsh não expande nada, e o guard
+#     bloqueava. É exatamente o precedente de 2026-06-24 (guard barrou o commit que DOCUMENTAVA o
+#     padrão) se repetindo no guard que dizia tê-lo fechado "por construção".
+#   FALSO POSITIVO — `setopt KSH_ZERO_SUBSCRIPT` torna [0] legítimo; e sob `set -u` a expansão
+#     ABORTA (exit 1) em vez de fabricar — bloquear ali contradizia a própria mensagem do hook,
+#     que recomenda `set -u`.
+#
+# Um detector com furos comprovados nos DOIS sentidos não tem a precisão que justifica bloquear.
+# Como AVISO a economia se inverte: o falso positivo custa uma linha de contexto (não trava
+# trabalho), então o detector pode ser mais amplo e mais simples — e é por isso que o ramo (A)
+# abaixo deixou de exigir o `$`. Endurecer para `deny` é uma decisão de FASE N+1, que exige sinal
+# de campo desta fase (docs/historico/fase-sem-sinal.md): quantas vezes disparou, e em quê.
+#
+# ── O QUE ELE NÃO PEGA (limitações medidas, não presumidas) ───────────────────────────────────
+# A tese "o zsh não expandiu, logo é legítimo" é FALSA para reinterpretação posterior: `eval`,
+# `let 'rc = PIPESTATUS[0]'`, `env zsh -c "$var"`, `xargs`, `ssh host "…"`, `make` com
+# SHELL:=/bin/zsh e `npm run` com script-shell=zsh executam o texto num zsh que este hook não
+# enxerga. Também escapam indireção (`${(P)nome}` — travado como teste C5), índice calculado que
+# não começa em 0, delimitador de heredoc exótico (`<<'E"OF'`, `<<$X`) e o 2º heredoc de uma mesma
+# linha. No sentido oposto, ainda avisa à toa quando há aspas simples dentro de `$(…)` sob aspas
+# duplas externas (`"$(printf '%s' '\${PIPESTATUS[0]}')"` é literal) — como é aviso, custa uma
+# linha. É prevenção de acidente de boa-fé, não sandbox contra adversário.
+#
+# Fail-open de infra (sem jq/awk -> exit 0): é um SENSOR, não um script que apaga.
+# Testes em scripts/test-pipestatus-zsh-guard.sh.
+set -u
+
+entrada="$(cat)"
+
+# PORTÃO BARATO, ANTES de qualquer fork: este hook roda em TODA chamada Bash (dezenas por turno) e
+# ~99% dos comandos não têm nada a ver com o assunto. Glob case-insensitive em bash puro custa ~0ms.
+# Casa só `PIPE`, não a palavra inteira: a continuação de linha (`\`+newline) parte o nome ao meio
+# no payload, e o portão com a palavra completa deixava passar batido justamente o caso que a
+# colagem lá embaixo existe para pegar — otimização fabricando falso negativo. Limite assumido:
+# partir DENTRO de "PIPE" ainda escapa. Custo: `set -o pipefail` e afins pagam o jq+awk (~70ms).
+case "$entrada" in
+  *[Pp][Ii][Pp][Ee]*) ;;
+  *) exit 0 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v awk >/dev/null 2>&1 || exit 0
+
+# Um único jq: tool_name na 1ª linha, comando no resto. Não dá para achatar com @tsv como os outros
+# hooks fazem — o comando PRECISA manter as quebras de linha (heredoc), e tool_name nunca tem
+# newline, então o corte na 1ª linha é seguro.
+bruto="$(printf '%s' "$entrada" | jq -r '(.tool_name // ""), (.tool_input.command // "")' 2>/dev/null)"
+tool="${bruto%%$'\n'*}"
+cmd="${bruto#*$'\n'}"
+[ -z "$tool" ] || [ "$tool" = "Bash" ] || exit 0   # defesa se o matcher do settings.json mudar
+[ -n "$cmd" ] || exit 0
+
+# Silenciador: intenção declarada como env-assignment NO INÍCIO (não substring solta).
+[[ "$cmd" =~ ^[[:space:]]*PIPESTATUS_INTENCIONAL=(1|true)([[:space:]]|$) ]] && exit 0
+
+# Continuação de linha: o zsh remove `\`+newline ANTES de tokenizar, então `${PIPE\<nl>STATUS[0]}`
+# é uma leitura válida. Colar aqui é o que impede o scanner de perder o nome partido ao meio.
+cmd="${cmd//\\$'\n'/}"
+
+# ── Scanner de quoting ────────────────────────────────────────────────────────────────────────
+# Reconstrói só o que o zsh de fora vai EXECUTAR e devolve o ramo casado. O que cai em aspas
+# simples, $'...', comentário ou heredoc com delimitador quoted é descartado — é MENÇÃO, não uso.
+ramo="$(printf '%s' "$cmd" | awk '
+  function emite(s) { vis = vis s }
+  function separador(c) { return (c == "" || c == " " || c == "\t" || c == ";" || c == "&" || c == "|" || c == "(" ) }
+  BEGIN { st = 0; inhd = 0; hd = ""; hdq = 0; hdash = 0; vis = "" }
+  {
+    linha = $0
+    if (inhd) {                                    # dentro de heredoc: procura o fechamento
+      t = linha; if (hdash) sub(/^\t+/, "", t)   # so `<<-` remove indentacao, e so TABs
+      if (t == hd) { inhd = 0; hd = ""; next }
+      if (!hdq) emite("\n" linha)                  # heredoc NÃO-quoted expande
+      next
+    }
+    pend = 0; n = length(linha); i = 1; ant = ""
+    while (i <= n) {
+      c = substr(linha, i, 1)
+      if (st == 0) {                               # fora de aspas
+        if (c == "#" && separador(ant)) break      # comentario: o zsh ignora ate o fim da linha
+        if (c == "\\") { ant = ""; i += 2; continue }
+        if (c == "\x27") { st = 1; i++; continue }
+        if (c == "\"")   { st = 2; i++; continue }
+        if (c == "$" && substr(linha, i+1, 1) == "\x27") { st = 3; i += 2; continue }
+        if (c == "<" && substr(linha, i+1, 1) == "<" && substr(linha, i+2, 1) != "<") {
+          j = i + 2; hyf = 0
+          if (substr(linha, j, 1) == "-") { hyf = 1; j++ }
+          while (substr(linha, j, 1) == " " || substr(linha, j, 1) == "\t") j++
+          q = substr(linha, j, 1); hq = 0
+          if (q == "\x27" || q == "\"" || q == "\\") { hq = 1; j++ }
+          d = ""
+          while (j <= n) {
+            ch = substr(linha, j, 1)
+            if (hq && (ch == "\x27" || ch == "\"")) { j++; break }
+            if (ch ~ /[A-Za-z0-9_]/) { d = d ch; j++ } else break
+          }
+          # NAO sobrescreve um heredoc ja pendente: fica com o PRIMEIRO da linha (o 2o e limitacao
+          # assumida). Sobrescrever fazia o corpo do 1o ser julgado pelo quoting do ULTIMO.
+          if (d != "" && !pend) { hd = d; hdq = hq; hdash = hyf; pend = 1 }
+          ant = ">"; i = j; continue
+        }
+        emite(c); ant = c; i++; continue
+      }
+      if (st == 1) { if (c == "\x27") st = 0; i++; continue }          # aspas simples: opaco
+      if (st == 3) { if (c == "\\") { i += 2; continue }               # $\x27...\x27: opaco
+                     if (c == "\x27") st = 0; i++; continue }
+      if (c == "\\") { i += 2; continue }                              # aspas duplas: \$ nao expande
+      if (c == "\"") { st = 0; i++; continue }
+      emite(c); i++                                                    # aspas duplas EXPANDEM
+    }
+    if (pend) inhd = 1
+    emite("\n")
+  }
+  END {
+    # A palavra NUA (sem `$`) so e perigosa onde algo AVALIA identificador como aritmetica:
+    # (( … )), [[ … ]] e `let` tratam parametro ausente como 0. Fora dai, `PIPESTATUS` solto e
+    # MENCAO — `git commit -m "…PIPESTATUS…"` e `grep PIPESTATUS docs/` sao rotina neste repo, e
+    # avisar neles seria o precedente 2026-06-24 outra vez, so que como ruido em vez de bloqueio.
+    arit = (vis ~ /\(\(/ || vis ~ /\[\[/ || vis ~ /(^|[^A-Za-z0-9_])let([^A-Za-z0-9_]|$)/)
+    # (A) bash-ism: PIPESTATUS nao existe no zsh -> vazio. `[^}]*` cobre flags de parametro do zsh
+    # como ${(e)PIPESTATUS[0]} e ${#PIPESTATUS[@]}.
+    if (vis ~ /\$\{[^}]*PIPESTATUS/ || vis ~ /\$PIPESTATUS([^A-Za-z0-9_]|$)/) { print "BASHISM"; exit }
+    if (arit && vis ~ /(^|[^A-Za-z0-9_])PIPESTATUS([^A-Za-z0-9_]|$)/)            { print "BASHISM"; exit }
+    # (B) zsh e 1-INDEXED: pipestatus[0…] e sempre vazio. Indice que COMECA em 0 pega [0] e [0+0].
+    if (vis ~ /\$\{[^}]*pipestatus\[[[:space:]]*0/ || vis ~ /\$pipestatus\[[[:space:]]*0/) { print "INDICE-ZERO"; exit }
+    if (arit && vis ~ /(^|[^A-Za-z0-9_])pipestatus\[[[:space:]]*0/)                            { print "INDICE-ZERO"; exit }
+  }
+')"
+
+[ -n "$ramo" ] || exit 0
+
+# PIPESTATUS-BASHISM-NO-ZSH / PIPESTATUS-INDICE-ZERO sao CONTRATO DE TESTE: marcadores ASCII, caixa
+# fixa, exclusivos de um ramo. scripts/test-pipestatus-zsh-guard.sh casa por eles com `command grep`
+# SEM -i — prosa acentuada casaria o ramo errado sob pt_BR.UTF-8 e nao sob LC_ALL=C (#1483).
+# shellcheck disable=SC2016  # a ajuda ENSINA o idioma: $? e ${pipestatus[1]} sao literais
+idioma='Idioma correto (escolha um):
+  1. CAPTURA PELADA, sem pipe (preferido — vale em qualquer shell):
+       cmd > /tmp/saida.log 2>&1; rc=$?
+       head -c 1500 /tmp/saida.log        # o recorte NAO mexe mais no rc
+  2. zsh-only, ciente do 1-INDEX:  cmd | tail -5; rc=${pipestatus[1]}
+  3. delegue o trecho ao bash, com aspas SIMPLES para o zsh nao expandir antes:
+       bash -c '"'"'cmd | tail -5; echo ${PIPESTATUS[0]}'"'"'
+E `set -u` no topo de script converte esta classe inteira (todo bash-ism que so se manifesta como
+string vazia) de silencio em ABORTO — e a leitura passa a falhar alto em vez de aprovar.
+
+Isto e um AVISO, nao um bloqueio: se o seu caso e um dos legitimos (comentario, KSH_ZERO_SUBSCRIPT,
+texto que vai rodar noutro shell), siga em frente. Para silenciar: PIPESTATUS_INTENCIONAL=1 <cmd>'
+
+if [ "$ramo" = "BASHISM" ]; then
+  msg="🔴 PIPESTATUS e bash-ism — no zsh (que roda este comando) expande para VAZIO, e vazio vale 0 = SUCESSO"
+  ctx="PIPESTATUS-BASHISM-NO-ZSH: este comando le \`PIPESTATUS\`, mas o Bash tool roda em /bin/zsh — onde essa variavel NAO EXISTE. Ela expande para VAZIO, e no \`[\` do zsh a string vazia vale 0, que e o exit code de SUCESSO. Entao \`false | true\` seguido de \`[ \"\${PIPESTATUS[0]}\" -eq 0 ]\` imprime PIPELINE OK: o comando FABRICA um veredito de sucesso a partir de dado AUSENTE (ausente != zero, docs/agent/money-path.md). Nada avisa — o \`[\` nem reclama. Vale igual sem o cifrao: \`(( PIPESTATUS[0] == 0 ))\`, \`[[ PIPESTATUS[0] -eq 0 ]]\` e \`let\` avaliam o identificador NU e tratam ausente como 0.
+
+$idioma"
+else
+  msg="🔴 zsh e 1-INDEXED: \${pipestatus[0]} e sempre vazio — e vazio vale 0 = SUCESSO"
+  ctx="PIPESTATUS-INDICE-ZERO: este comando le \`pipestatus[0]\`. O NOME esta certo para o zsh, mas o INDICE nao — arrays do zsh sao 1-INDEXED, entao [0] e sempre VAZIO (medido). E vazio, no \`[\` do zsh, vale 0 = SUCESSO: o comando fabrica aprovacao a partir de dado ausente. O primeiro comando do pipe e \${pipestatus[1]}. (Excecao: sob \`setopt KSH_ZERO_SUBSCRIPT\` ou \`KSH_ARRAYS\` o [0] passa a ser legitimo — se e o seu caso, ignore este aviso.)
+
+$idioma"
+fi
+
+jq -n --arg m "$msg" --arg c "$ctx" \
+  '{systemMessage:$m, hookSpecificOutput:{hookEventName:"PreToolUse", additionalContext:$c}}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -87,6 +87,10 @@
           },
           {
             "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/pipestatus-zsh-guard.sh\""
+          },
+          {
+            "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/branch-pos-squash-guard.sh\""
           },
           {

--- a/docs/historico/evidencia-positiva-shell.md
+++ b/docs/historico/evidencia-positiva-shell.md
@@ -173,6 +173,21 @@ Achado no próprio trabalho, não em laboratório: nesta sessão um `git push �
 exit code e nenhum dado dentro. O push tinha funcionado, mas quem provou isso foi
 `git rev-parse HEAD origin/<branch> | uniq -c` (duas refs, uma linha), não a linha do exit.
 
+**Gate estrutural (contramedida textual reincide).** O hook PreToolUse
+`.claude/hooks/pipestatus-zsh-guard.sh` AVISA quando o comando lê esse exit code — inclusive na
+forma sem cifrão, porque a aritmética do zsh (`(( ))`, `[[ ]]`, `let`) avalia o identificador NU e
+trata ausente como 0. Menção não dispara: aspas simples, heredoc quoted, comentário e `$'...'` saem
+por um scanner de quoting, então `git commit -m` e `grep` pelo nome seguem calados.
+
+Ele nasceu BLOQUEANTE e foi rebaixado a aviso pela revisão adversária (`/codex`, enquadramento
+defensivo de COBERTURA): o Codex mostrou que a aposta "se o zsh expande, é bug; se não expande, é
+legítimo" tem furo nos DOIS sentidos — deixava passar `(( PIPESTATUS[0] == 0 ))` e barrava
+`echo x # ${PIPESTATUS[0]}` (comentário não expande nada), que é o precedente de 2026-06-24 se
+repetindo no guard que jurava tê-lo fechado por construção. **A moral é a 10ª armadilha em
+miniatura: um detector de padrão de shell não herda a semântica do shell.** Um guard com falso
+negativo E falso positivo comprovados não tem a precisão que justifica bloquear — e como aviso o
+falso positivo custa uma linha de contexto, o que permitiu ampliar a detecção em vez de encolhê-la.
+
 ## O padrão por trás das nove
 
 Seis produzem **verde por construção**, não por mérito; a sétima mostra que o mesmo defeito

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
     "claude:instr": "bash scripts/instrucoes-relatorio.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query; do bash scripts/test-$t.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/test-pipestatus-zsh-guard.sh
+++ b/scripts/test-pipestatus-zsh-guard.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# test-pipestatus-zsh-guard.sh — prova do hook .claude/hooks/pipestatus-zsh-guard.sh
+#
+# Roda em DOIS locales (C e pt_BR.UTF-8) de propósito: no #1483 uma asserção passou por acidente de
+# ambiente porque `grep -i` sob pt_BR.UTF-8 dobra Ã↔ã e casava o ramo errado. Aqui todo casamento é
+# por marcador ASCII exclusivo, caixa fixa, com `command grep` e SEM -i.
+#
+# O eixo dos NEGATIVOS é o precedente de 2026-06-24: um guard do repo bloqueou o commit que
+# DOCUMENTAVA o padrão que ele detectava. Menção != execução — os casos (N1..N9) são exatamente as
+# formas em que um agente escreve `PIPESTATUS` sem executá-lo.
+#
+# Inclui FALSIFICAÇÃO: no fim, sabota o scanner de quoting e exige que os negativos fiquem
+# VERMELHOS. Um teste que passa com o código sabotado não prova nada.
+# shellcheck disable=SC2016  # ARQUIVO INTEIRO: os comandos de teste sao strings LITERAIS de
+# proposito — expandir ${PIPESTATUS[0]} aqui destruiria justamente o que o guard tem de ver.
+set -u
+
+RAIZ="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$RAIZ/.claude/hooks/pipestatus-zsh-guard.sh"
+[ -x "$HOOK" ] || { echo "hook não encontrado/executável: $HOOK" >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq é necessário" >&2; exit 1; }
+
+falhas=0
+
+entrada() { # <comando> [tool_name]
+  jq -n -c --arg cmd "$1" --arg tool "${2:-Bash}" '{tool_name:$tool, tool_input:{command:$cmd}}'
+}
+
+executa() { printf '%s' "$1" | bash "$HOOK" 2>/dev/null; }
+
+checa() { # <titulo> <esperado: MARCADOR|VAZIO> <json>
+  local titulo="$1" esperado="$2" json="$3" saida
+  saida="$(executa "$json")"
+  if [ "$esperado" = "VAZIO" ]; then
+    if [ -z "$saida" ]; then printf '  ok   %s\n' "$titulo"; return 0; fi
+    printf '  FALHA %s — esperava silêncio, veio: %s\n' "$titulo" "$(printf '%s' "$saida" | head -c 140)"
+    falhas=$((falhas + 1)); return 1
+  fi
+  # o marcador tem de estar no additionalContext, nao em qualquer lugar do JSON
+  if printf '%s' "$saida" | jq -r '.hookSpecificOutput.additionalContext // ""' 2>/dev/null \
+       | command grep -q "$esperado"; then
+    # e NAO pode bloquear: este hook avisa (veja o cabecalho do hook)
+    local dec
+    dec="$(printf '%s' "$saida" | jq -r '.hookSpecificOutput.permissionDecision // "-"' 2>/dev/null)"
+    if [ "$dec" = "-" ]; then printf '  ok   %s\n' "$titulo"; return 0; fi
+    printf '  FALHA %s — deveria AVISAR, mas emitiu permissionDecision="%s"\n' "$titulo" "$dec"
+    falhas=$((falhas + 1)); return 1
+  fi
+  printf '  FALHA %s — esperava %s, veio: %s\n' "$titulo" "$esperado" "$(printf '%s' "$saida" | head -c 160)"
+  falhas=$((falhas + 1)); return 1
+}
+
+A="PIPESTATUS-BASHISM-NO-ZSH"
+Z="PIPESTATUS-INDICE-ZERO"
+
+rodada() {
+  echo "--- locale: ${LC_ALL:-(herdado)} ---"
+
+  # ── POSITIVOS: o zsh EXPANDE -> vazio -> veredito fabricado ────────────────────────────────
+  checa "P1 o caso do doc (if com -eq 0)" "$A" \
+    "$(entrada 'false | true; if [ "${PIPESTATUS[0]}" -eq 0 ]; then echo OK; fi')"
+  checa "P2 echo em aspas duplas" "$A" "$(entrada 'git push | tail -3; echo "EXIT=${PIPESTATUS[0]}"')"
+  checa "P3 sem chaves" "$A" "$(entrada 'cmd | tail; rc=$PIPESTATUS')"
+  checa "P4 subscript zsh sem chaves" "$A" "$(entrada 'cmd | tail; rc=$PIPESTATUS[0]')"
+  checa 'P5 tamanho do array (${#..[@]})' "$A" "$(entrada 'cmd | tail; echo ${#PIPESTATUS[@]}')"
+  checa "P6 fora de aspas, em teste" "$A" "$(entrada 'x | y; [ ${PIPESTATUS[0]} -ne 0 ] && exit 1')"
+  # aspas DUPLAS em bash -c: o zsh de fora expande ANTES do bash ver -> bloquear esta CERTO
+  checa "P7 bash -c com aspas DUPLAS" "$A" "$(entrada 'bash -c "x | y; echo ${PIPESTATUS[0]}"')"
+  # heredoc NAO-quoted expande de verdade (o doc sairia corrompido) -> bloquear esta certo
+  checa "P8 heredoc NAO-quoted" "$A" "$(entrada "$(printf 'cat > d.md <<EOF\nvale ${PIPESTATUS[0]}\nEOF\n')")"
+  checa "P9 indice zero minusculo" "$Z" "$(entrada 'cmd | tail; rc=${pipestatus[0]}')"
+  checa "P10 indice zero sem chaves" "$Z" "$(entrada 'cmd | tail; echo $pipestatus[0]')"
+
+  # ── NEGATIVOS: MENCAO, nao execucao (o precedente 2026-06-24) ──────────────────────────────
+  checa "N1 commit -m mencionando" "VAZIO" \
+    "$(entrada 'git commit -m "docs: PIPESTATUS e bash-ism e no zsh vale vazio"')"
+  checa "N2 grep pelo nome" "VAZIO" "$(entrada 'grep -rn PIPESTATUS docs/historico/')"
+  checa "N3 aspas SIMPLES (literal)" "VAZIO" "$(entrada "echo 'use \${PIPESTATUS[0]} nunca'")"
+  # ESTE e o precedente exato: escrever a documentacao do padrao
+  checa "N4 heredoc QUOTED (documentar)" "VAZIO" \
+    "$(entrada "$(printf "cat > doc.md <<'EOF'\nno zsh \${PIPESTATUS[0]} e vazio\nEOF\n")")"
+  checa "N5 heredoc <<\"EOF\" quoted" "VAZIO" \
+    "$(entrada "$(printf 'cat <<"EOF"\n${PIPESTATUS[0]}\nEOF\n')")"
+  checa "N6 heredoc <<-'EOF' indentado" "VAZIO" \
+    "$(entrada "$(printf "cat <<-'EOF'\n\t\${PIPESTATUS[0]}\n\tEOF\n")")"
+  # aspas SIMPLES em bash -c: chega literal no bash, onde FUNCIONA -> legitimo
+  checa "N7 bash -c com aspas SIMPLES" "VAZIO" "$(entrada "bash -c 'x | y; echo \${PIPESTATUS[0]}'")"
+  checa "N8 escapado com barra" "VAZIO" "$(entrada 'echo "\${PIPESTATUS[0]}"')"
+  checa "N9 ANSI-C quoting \$'...'" "VAZIO" "$(entrada "echo \$'\${PIPESTATUS[0]}'")"
+  # o idioma CORRETO nao pode ser punido
+  checa "N10 pipestatus[1] (correto)" "VAZIO" "$(entrada 'cmd | tail; rc=${pipestatus[1]}')"
+  checa "N11 captura pelada (correto)" "VAZIO" "$(entrada 'cmd > /tmp/x.log 2>&1; rc=$?')"
+  # prefixo de nome parecido nao pode casar
+  checa "N12 \$MEU_PIPESTATUS" "VAZIO" "$(entrada 'echo "$MEU_PIPESTATUS"')"
+  checa "N13 \$PIPESTATUSX" "VAZIO" "$(entrada 'echo "$PIPESTATUSX"')"
+  # valvula de escape
+  checa "N14 valvula PIPESTATUS_INTENCIONAL" "VAZIO" \
+    "$(entrada 'PIPESTATUS_INTENCIONAL=1 zsh -c "x|y; echo ${PIPESTATUS[0]}"')"
+  checa "N15 outra ferramenta" "VAZIO" "$(entrada 'echo "${PIPESTATUS[0]}"' 'Read')"
+  checa "N16 comando trivial" "VAZIO" "$(entrada 'ls -la')"
+
+  # ── REGRESSAO: achados da revisao adversaria do Codex (2026-08-23) ────────────────────────
+  # POSITIVOS que a v1 liberava — reproduzidos em `zsh -f`, todos fabricam veredito.
+  checa "C1 aritmetica (( )) SEM cifrao" "$A" "$(entrada 'false | true; (( PIPESTATUS[0] == 0 )) && echo OK')"
+  checa "C2 [[ ]] minusculo SEM cifrao" "$Z" "$(entrada 'false | true; [[ pipestatus[0] -eq 0 ]] && echo OK')"
+  checa "C3 flag de parametro (e)" "$A" "$(entrada 'x | y; [ "${(e)PIPESTATUS[0]}" -eq 0 ]')"
+  checa "C4 indice calculado [0+0]" "$Z" "$(entrada 'x | y; [ "${pipestatus[0+0]}" -eq 0 ]')"
+  # LIMITE ASSUMIDO, travado por teste: indirecao `${(P)nome}` escapa. O nome nu so conta em
+  # contexto aritmetico, e aqui o teste e `[ ]` simples — cobrir exigiria punir `git commit -m
+  # "…PIPESTATUS…"`, que e rotina neste repo. Se um dia mudar de ideia, este teste fica VERMELHO.
+  checa "C5 indirecao (P)nome (FN conhecido)" "VAZIO" "$(entrada 'nome=PIPESTATUS; x | y; [ "${(P)nome}" -eq 0 ]')"
+  checa "C6 continuacao de linha no meio do nome" "$A" \
+    "$(entrada "$(printf 'x | y\nif [ "${PIPE\\\nSTATUS[0]}" -eq 0 ]; then echo OK; fi\n')")"
+  checa "C7 heredoc multiplo (vale o PRIMEIRO)" "$A" \
+    "$(entrada "$(printf "cat <<EOF <<'A'\n\${PIPESTATUS[0]}\nEOF\nliteral\nA\n")")"
+  # NEGATIVOS que a v1 BLOQUEAVA — o zsh nao expande nenhum deles.
+  checa "C8 comentario (# ate fim da linha)" "VAZIO" "$(entrada 'echo inicio # ${PIPESTATUS[0]}')"
+  checa "C9 ' EOF' com espaco NAO fecha heredoc" "VAZIO" \
+    "$(entrada "$(printf "cat <<'EOF'\nliteral\n EOF\n\${PIPESTATUS[0]}\nEOF\n")")"
+
+  # ── ROBUSTEZ ───────────────────────────────────────────────────────────────────────────────
+  local saida
+  saida="$(printf '%s' 'isto nao e json' | bash "$HOOK" 2>/dev/null)"
+  if [ -z "$saida" ]; then printf '  ok   R1 entrada invalida -> silencio\n'
+  else printf '  FALHA R1 entrada invalida falou: %s\n' "$saida"; falhas=$((falhas + 1)); fi
+
+  local ev
+  ev="$(executa "$(entrada 'echo "${PIPESTATUS[0]}"')" | jq -r '.hookSpecificOutput.hookEventName' 2>/dev/null)"
+  if [ "$ev" = "PreToolUse" ]; then printf '  ok   R2 hookEventName=PreToolUse\n'
+  else printf '  FALHA R2 hookEventName veio "%s"\n' "$ev"; falhas=$((falhas + 1)); fi
+}
+
+echo "== pipestatus-zsh-guard =="
+LC_ALL=C rodada
+if locale -a 2>/dev/null | command grep -qi '^pt_BR.UTF-8$'; then
+  LC_ALL=pt_BR.UTF-8 rodada
+else
+  echo "--- locale pt_BR.UTF-8 indisponível: pulado ---"
+fi
+
+# ── FALSIFICAÇÃO ────────────────────────────────────────────────────────────────────────────
+# Sabota o scanner para NUNCA entrar em estado de aspas simples. Se os NEGATIVOS que dependem
+# disso continuarem verdes, é porque nunca dependeram do scanner — e a suíte não provava nada.
+# A sabotagem é ela própria verificada (arquivo tem de MUDAR): sabotagem que não sabota é teatro.
+echo "-- falsificacao: scanner deixa de reconhecer aspas simples --"
+BKP="$(mktemp)"; cp "$HOOK" "$BKP"
+restaura() { cp "$BKP" "$HOOK"; rm -f "$BKP"; }
+trap restaura EXIT
+
+perl -0pi -e 's/\{ st = 1; i\+\+; continue \}/{ st = 0; i++; continue }/' "$HOOK"
+if cmp -s "$BKP" "$HOOK"; then
+  echo "  FALHA a sabotagem NAO alterou o hook — a falsificacao seria teatro"
+  falhas=$((falhas + 1))
+else
+  sabotado_pegou=0
+  # exatamente os negativos cuja unica defesa e o estado de aspas simples
+  for caso in "echo 'use \${PIPESTATUS[0]} nunca'" "bash -c 'x | y; echo \${PIPESTATUS[0]}'"; do
+    [ -n "$(executa "$(entrada "$caso")")" ] && sabotado_pegou=$((sabotado_pegou + 1))
+  done
+  if [ "$sabotado_pegou" -eq 2 ]; then
+    echo "  ok   sabotagem ficou VERMELHA nos 2 negativos (o scanner e mesmo o que os protege)"
+  else
+    echo "  FALHA sabotagem passou despercebida em $((2 - sabotado_pegou)) caso(s)"
+    falhas=$((falhas + 1))
+  fi
+fi
+restaura; trap - EXIT
+
+echo
+if [ "$falhas" -eq 0 ]; then echo "PIPESTATUS-GUARD: TODOS OS TESTES PASSARAM"; exit 0; fi
+echo "PIPESTATUS-GUARD: $falhas FALHA(S)"; exit 1


### PR DESCRIPTION
## O que

Gate estrutural para a 9ª armadilha (#1921): o Bash tool roda em `/bin/zsh`, onde `PIPESTATUS` não
existe e expande para vazio — e vazio, no `[` do zsh, vale `0`, o exit code de SUCESSO. Um pipeline
que falhou é lido como aprovado. Contramedida textual reincide; isto é o hook.

## A decisão que mudou no meio: bloquear → AVISAR

O hook nasceu bloqueante (`deny`), apostando que a fronteira "o zsh expande?" coincidiria com "é
bug?" e daria precisão de sobra. **A revisão adversária do `/codex` (enquadramento defensivo de
COBERTURA, nunca "como burlar") derrubou a aposta**, e cada achado foi reproduzido aqui em `zsh -f`:

| classe | caso | o que o zsh faz | o guard v1 fazia |
|---|---|---|---|
| **falso negativo** | `(( PIPESTATUS[0] == 0 ))` | fabrica o veredito — a aritmética avalia o identificador **nu** e trata ausente como 0 | liberava |
| **falso positivo** | `echo x # ${PIPESTATUS[0]}` | comentário: não expande nada | **bloqueava** |
| **falso positivo** | `setopt KSH_ZERO_SUBSCRIPT` | `[0]` passa a ser legítimo | bloqueava |
| **falso positivo** | `set -u` | **aborta** em vez de fabricar | bloqueava — contradizendo a própria mensagem, que recomenda `set -u` |

O comentário é o precedente de 2026-06-24 (um guard barrou o commit que DOCUMENTAVA o padrão) se
repetindo no guard que dizia tê-lo fechado "por construção".

Um detector com furos comprovados nos **dois** sentidos não tem a precisão que justifica bloquear.
Como aviso a economia se inverte — falso positivo custa uma linha de contexto, não trabalho travado
— e foi isso que permitiu **ampliar** a detecção (cobrir a aritmética sem cifrão) em vez de
encolhê-la. Endurecer para `deny` é decisão de fase N+1 e exige sinal de campo desta fase.

## O que detecta

- **(A)** o bash-ism, incluindo identificador **nu** em contexto aritmético (`(( ))`, `[[ ]]`, `let`);
- **(B)** `pipestatus[0]` — nome certo, índice errado (zsh é 1-indexed). É o erro de quem *acabou de
  aprender a lição*: corrige a caixa e mantém o índice do bash. Medido: também vazio, também fabrica.

Menção não dispara — aspas simples, heredoc quoted, comentário e `$'...'` saem por um scanner de
quoting, então `git commit -m` e `grep` pelo nome seguem calados. (Este PR provou isso ao vivo: a
mensagem de commit que documenta o padrão foi escrita em heredoc quoted e o guard ficou calado.)

## Limites assumidos, travados por teste

Reinterpretação posterior (`eval`, `let` com aspas, `env zsh -c`, `xargs`, `ssh`, `make` com
`SHELL:=zsh`) e indireção `${(P)nome}` escapam — a tese "não expandiu aqui, logo é legítimo" é falsa
para texto que roda noutro shell. Estão no cabeçalho do hook e o caso C5 fica **vermelho** se alguém
mudar de ideia sem querer.

## Prova

- **75 asserções** verdes em 2 locales (`C` e `pt_BR.UTF-8`), casadas por marcador ASCII de caixa
  fixa — sem `grep -i`, que dobra acento e casaria o ramo errado (#1483);
- **falsificação** que sabota o scanner e exige vermelho nos negativos — e que **verifica que o
  arquivo mudou** (sabotagem que não sabota é teatro);
- `bun run test:hooks` da suíte inteira: `EXIT_TEST_HOOKS=0`, zero falhas;
- `shellcheck scripts/*.sh .claude/hooks/*.sh`: exit 0;
- **custo 10ms/chamada** contra 8ms de baseline — portão em bash puro antes de qualquer fork. O
  `destructive-bash-guard`, já em produção no mesmo matcher, custa 55ms. (O portão teve de casar só
  `PIPE`: com a palavra inteira ele deixava passar justamente o caso da continuação de linha, que a
  colagem existe para pegar — otimização fabricando falso negativo.)
- **ao vivo**: o comando roda, imprime vazio, e o aviso chega junto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
