### PR TITLE
feat(projeto-verificado): Fase 1 (núcleo de domínio puro) — destrava os 2 gates que a seguravam

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -16,6 +16,19 @@ Padrão em `gerar-pedidos-diario`/`disparar-pedidos-aprovados`. O guard `src/__t
 
 Como provar o que está **SERVIDO** nesse host (hash do index + grep nos chunks): skill `lovable-deploy-verify` — o método vive lá, não é duplicado aqui.
 
+## O que BLOQUEIA o PR — leia o `ci.yml` INTEIRO, não os primeiros steps
+
+O job `validate` do `.github/workflows/ci.yml` tem **muito mais que os 5 gates óbvios**. Em 2026-08-23 eram 15 steps: `tsc` (app) · `scripts:typecheck` · `test` · `test:edges` (Deno) · `edges:typecheck` · `build` · `lint` · `claude:size` · `test:hooks` · `authz:check` · `bunpin:check` · `docs:indice` · `docs:citacoes` · `docs:links` · **`bunx knip`** (dead code). Mais o job `mutation-check` (`mutcheck:selftest` + `mutcheck`).
+
+⚠️ **`bunx knip` É bloqueante** — export sem consumidor derruba PR. O `/health` roda o mesmo knip localmente, mas "também roda no /health" **não** significa "só roda no /health".
+
+**A armadilha real (mordido 2026-08-23):** ler `sed -n '1,80p' ci.yml` de um arquivo de **424 linhas**, não achar o knip, e afirmar que ele não é gate. O arquivo tem ~30 linhas de comentário por step, então os 5 primeiros gates ocupam as primeiras 230 linhas e **os 10 restantes ficam fora de qualquer leitura truncada**. Custo: um PR vermelho e uma errata errada escrita em 3 documentos. Use `grep -n "^      - name:" .github/workflows/ci.yml` — cabe numa tela e não mente.
+
+**Dois gates costumam pegar código novo, e são independentes:**
+
+1. **`manifesto.gate.test.ts`** (dentro do `bun run test`) — todo arquivo de `src/` precisa de **1 dono declarado** em `src/lib/modulos/manifesto.ts` (`codigo`/`testes` do módulo). Arquivo novo sem entrada sai como `[orfao]`. Sobreposição de globs entre módulos e glob que não casa nada também são erro. `NAO_CLASSIFICADOS` é dívida datada e está VAZIO — não seja o primeiro a sujá-lo.
+2. **`bunx knip`** — export sem consumidor. Núcleo de domínio novo, ainda sem UI, tende a bater aqui: os testes tornam as *funções* alcançáveis (o `vitest.config.ts` é entry no `knip.json`), mas **tipo/interface exportado que só o próprio arquivo usa fica órfão**. Correção certa é tirar o `export` do que é interno — reexportar quando a fase seguinte lhe der consumidor —, não engordar o `ignore` do `knip.json`.
+
 ## Merge na `main` ≠ produção — 3 deploys MANUAIS e independentes
 
 1. **Migration** → colar o SQL no **SQL Editor do Lovable** → Run → validar com query de contagem. O Lovable **NÃO** aplica migration de nome custom sozinho (falha SILENCIOSA: a feature compila e quebra em runtime). Detalhe + ritual + skill `lovable-db-operator`: `docs/agent/database.md`.

--- a/docs/superpowers/plans/2026-06-17-projeto-verificado-sayerlack-mvp.md
+++ b/docs/superpowers/plans/2026-06-17-projeto-verificado-sayerlack-mvp.md
@@ -1,16 +1,11 @@
 # Projeto Verificado Sayerlack — MVP Implementation Plan
 
-> ⛔ **ESTADO EM 2026-08-22 — NADA DISTO ESTÁ IMPLEMENTADO.** Este documento foi resgatado do
-> [PR #947](https://github.com/LucasSardenbergL/afiacao/pull/947) (draft desde 2026-06-17), que
-> ficou **64 dias parado, 1.139 commits atrás da `main`**. Só o pensamento veio para cá; o código
-> da **Fase 1** (`src/lib/projeto-verificado/` — `estado.ts`, `consumo.ts`, `check-proporcao.ts`
-> + testes) **continua no branch `claude/projeto-verificado-sayerlack`**, intacto e não-mergeado.
->
-> **Por que separado:** o núcleo é domínio puro e **não tem nenhum consumidor** na `main`. O gate
-> `bunx knip` (dead code, no `ci.yml`) reprova exports órfãos, então a Fase 1 **não consegue
-> mergear sozinha** — ela precisa vir junto com a Fase 2, que lhe dá chamador. Trazer só a spec
-> preserva a parte cara (estratégia revisada por painel adversário de 3 modelos) onde ela é
-> pesquisável, sem carregar dead code nem brigar com o gate.
+> 📍 **ESTADO EM 2026-08-23 — Fase 1 CONCLUÍDA (Tasks 1-4); Fase 0 e Fases 2+ ABERTAS.**
+> As 3 tarefas TDD e a verificação final estão feitas: `src/lib/projeto-verificado/`, 17 testes
+> verdes, módulo declarado no manifesto, knip limpo. **A Fase 0 (discovery) continua inteira** — é
+> trabalho do founder/jurídico, e é ela que bloqueia as Fases 2+. Sobre os dois gates de CI que a
+> Fase 1 teve de vencer (`manifesto.gate` e `bunx knip`) e a errata do diagnóstico, ver o topo da
+> [spec](../specs/2026-06-17-projeto-verificado-sayerlack-design.md).
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
@@ -75,7 +70,7 @@ A inovação central da v2: o estado `sistema_documentado` só se sustenta se a 
 - Create: `src/lib/projeto-verificado/check-proporcao.ts`
 - Test: `src/lib/projeto-verificado/__tests__/check-proporcao.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ts
 // src/lib/projeto-verificado/__tests__/check-proporcao.test.ts
@@ -135,12 +130,12 @@ describe('avaliarProporcao', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado/__tests__/check-proporcao.test.ts`
 Expected: FAIL — `Cannot find module '../check-proporcao'`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 ```ts
 // src/lib/projeto-verificado/check-proporcao.ts
@@ -212,12 +207,12 @@ export function avaliarProporcao(
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado/__tests__/check-proporcao.test.ts`
 Expected: PASS (4 tests).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/lib/projeto-verificado/check-proporcao.ts src/lib/projeto-verificado/__tests__/check-proporcao.test.ts
@@ -234,7 +229,7 @@ O coração da v2: dado o conjunto de fatos comprovados de um projeto, retorna o
 - Create: `src/lib/projeto-verificado/estado.ts`
 - Test: `src/lib/projeto-verificado/__tests__/estado.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ts
 // src/lib/projeto-verificado/__tests__/estado.test.ts
@@ -297,12 +292,12 @@ describe('calcularEstado', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado/__tests__/estado.test.ts`
 Expected: FAIL — `Cannot find module '../estado'`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 ```ts
 // src/lib/projeto-verificado/estado.ts
@@ -354,12 +349,12 @@ export function calcularEstado(f: FatosProjeto): EstadoProjeto {
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado/__tests__/estado.test.ts`
 Expected: PASS (8 tests).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/lib/projeto-verificado/estado.ts src/lib/projeto-verificado/__tests__/estado.test.ts
@@ -376,7 +371,7 @@ Classifica o volume dosado contra o consumo esperado (área ÷ rendimento) em **
 - Create: `src/lib/projeto-verificado/consumo.ts`
 - Test: `src/lib/projeto-verificado/__tests__/consumo.test.ts`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```ts
 // src/lib/projeto-verificado/__tests__/consumo.test.ts
@@ -422,12 +417,12 @@ describe('classificarConsumo', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado/__tests__/consumo.test.ts`
 Expected: FAIL — `Cannot find module '../consumo'`.
 
-- [ ] **Step 3: Write minimal implementation**
+- [x] **Step 3: Write minimal implementation**
 
 ```ts
 // src/lib/projeto-verificado/consumo.ts
@@ -477,12 +472,12 @@ export function classificarConsumo(p: ParametrosConsumo): ResultadoConsumo {
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado/__tests__/consumo.test.ts`
 Expected: PASS (5 tests).
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add src/lib/projeto-verificado/consumo.ts src/lib/projeto-verificado/__tests__/consumo.test.ts
@@ -493,17 +488,17 @@ git commit -m "feat(projeto-verificado): faixa de consumo (bandas amplas)"
 
 ### Task 4: Verificação final da Fase 1
 
-- [ ] **Step 1: Rodar a suíte completa do módulo**
+- [x] **Step 1: Rodar a suíte completa do módulo**
 
 Run: `heavy bunx vitest run src/lib/projeto-verificado`
 Expected: PASS (17 tests: 4 + 8 + 5).
 
-- [ ] **Step 2: Typecheck (strict)**
+- [x] **Step 2: Typecheck (strict)**
 
 Run: `heavy bun run typecheck`
 Expected: sem erros (o módulo é puro, sem dependências externas).
 
-- [ ] **Step 3: Lint**
+- [x] **Step 3: Lint**
 
 Run: `bun lint`
 Expected: sem erros no diretório novo.

--- a/docs/superpowers/specs/2026-06-17-projeto-verificado-sayerlack-design.md
+++ b/docs/superpowers/specs/2026-06-17-projeto-verificado-sayerlack-design.md
@@ -1,16 +1,25 @@
 # Projeto Verificado Sayerlack — design (v2)
 
-> ⛔ **ESTADO EM 2026-08-22 — NADA DISTO ESTÁ IMPLEMENTADO.** Este documento foi resgatado do
-> [PR #947](https://github.com/LucasSardenbergL/afiacao/pull/947) (draft desde 2026-06-17), que
-> ficou **64 dias parado, 1.139 commits atrás da `main`**. Só o pensamento veio para cá; o código
-> da **Fase 1** (`src/lib/projeto-verificado/` — `estado.ts`, `consumo.ts`, `check-proporcao.ts`
-> + testes) **continua no branch `claude/projeto-verificado-sayerlack`**, intacto e não-mergeado.
+> 📍 **ESTADO EM 2026-08-23 — Fase 1 (núcleo de domínio puro) entregue; Fases 2+ bloqueadas pelo
+> discovery (§9).** `src/lib/projeto-verificado/` (`check-proporcao.ts`, `estado.ts`, `consumo.ts`
+> + 17 testes), declarado como módulo `projeto-verificado` no manifesto. **Sem rota e sem
+> consumidor de produção** — é domínio puro, e assim fica até D1/D3 destravarem a Fase 2.
 >
-> **Por que separado:** o núcleo é domínio puro e **não tem nenhum consumidor** na `main`. O gate
-> `bunx knip` (dead code, no `ci.yml`) reprova exports órfãos, então a Fase 1 **não consegue
-> mergear sozinha** — ela precisa vir junto com a Fase 2, que lhe dá chamador. Trazer só a spec
-> preserva a parte cara (estratégia revisada por painel adversário de 3 modelos) onde ela é
-> pesquisável, sem carregar dead code nem brigar com o gate.
+> **Sobre a nota de 2026-08-22 (que dizia que o knip impedia o merge):** ela estava **certa no
+> gate e forte demais na conclusão**. `bunx knip` É step bloqueante do `ci.yml` — mas o que ele
+> apontou foram **4 tipos exportados sem consumidor** (`TipoComponente`, `ComponenteNaoAcabamento`,
+> `Faltante`, `ClassificacaoConsumo`), não o módulo inteiro: as *funções* já eram alcançáveis pelos
+> testes (`vitest.config.ts` é entry no `knip.json`). Tirar o `export` de tipo que só o próprio
+> arquivo usa resolveu — a Fase 1 **não** precisava esperar a Fase 2 para lhe dar chamador.
+> Havia ainda um **segundo** gate que a nota não mencionava: o `manifesto.gate.test.ts`, que exige
+> 1 dono declarado por arquivo de `src/` e apontava os 6 como `[orfao]`.
+>
+> **⚠️ Errata da errata (2026-08-23).** Uma versão anterior desta nota afirmou que *"knip não está
+> no `ci.yml`"* e tratou a nota de 08-22 como refutada. **Isso era falso.** A afirmação nasceu de
+> ler `sed -n '1,80p'` de um `ci.yml` de **424 linhas** — o step do knip está na linha 322. O PR
+> foi vermelho exatamente nele. **Classe de erro:** *concluir ausência a partir de leitura
+> truncada*. "Não encontrei" só vira "não existe" depois de olhar o arquivo inteiro; para lista de
+> steps, `grep -n "^      - name:" .github/workflows/ci.yml`. Registrado em `docs/agent/deploy.md`.
 
 > Spec de produto/estratégia. Combate ao **desvio de especificação** de acabamentos Sayerlack (pintor/marcenaria aplica tinta automotiva ou de concorrente imitando só a cor) **fundido** ao **programa de relacionamento com arquitetos**.
 >

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -399,6 +399,21 @@ export const MODULOS: ModuloApp[] = [
     risco: { moneyPath: true, offlineFirst: false, authSensitive: false },
   },
   {
+    // Núcleo de domínio PURO da Fase 1 (spec 2026-06-17): escada de estados,
+    // Check de Proporção e faixa de consumo. Ainda SEM rota/consumidor — a UI e a
+    // persistência são as Fases 2+, bloqueadas pelo discovery (D1 export do
+    // Sayersystem, D3 parâmetros técnicos). moneyPath: a escada é o que condiciona
+    // prazo no boleto e seguro de retrabalho (spec Fase 5), então erra-se para cima.
+    id: "projeto-verificado",
+    nome: "Projeto Verificado (Sayerlack)",
+    kind: "negocio",
+    rotaPrefixos: [],
+    gates: [],
+    codigo: ["src/lib/projeto-verificado/*.ts"],
+    testes: ["src/lib/projeto-verificado/__tests__/**"],
+    risco: { moneyPath: true, offlineFirst: false, authSensitive: false },
+  },
+  {
     id: "estoque-recebimento",
     nome: "Estoque / Recebimento",
     kind: "negocio",

--- a/src/lib/projeto-verificado/__tests__/check-proporcao.test.ts
+++ b/src/lib/projeto-verificado/__tests__/check-proporcao.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { avaliarProporcao, type ItemCesta, type RequisitoSistema } from '../check-proporcao';
+
+// Sistema-exemplo (valores de TESTE — os reais vêm do discovery D3):
+// para cada 1 L de acabamento, exige 1 L de fundo, 0,1 L de catalisador.
+const sistema: RequisitoSistema = {
+  proporcaoMinima: { fundo: 1.0, catalisador: 0.1 },
+};
+
+describe('avaliarProporcao', () => {
+  it('atende quando a cesta (toda Colacor) cobre a proporção mínima', () => {
+    const cesta: ItemCesta[] = [
+      { tipo: 'acabamento', litros: 4, origem: 'colacor' },
+      { tipo: 'fundo', litros: 4, origem: 'colacor' },
+      { tipo: 'catalisador', litros: 0.5, origem: 'colacor' },
+    ];
+    const r = avaliarProporcao(cesta, sistema);
+    expect(r.litrosAcabamento).toBe(4);
+    expect(r.atende).toBe(true);
+    expect(r.faltantes).toEqual([]);
+    expect(r.temComponenteExterno).toBe(false);
+  });
+
+  it('NÃO atende e lista o faltante quando o fundo é insuficiente', () => {
+    const cesta: ItemCesta[] = [
+      { tipo: 'acabamento', litros: 4, origem: 'colacor' },
+      { tipo: 'fundo', litros: 1, origem: 'colacor' }, // exige 4
+      { tipo: 'catalisador', litros: 0.5, origem: 'colacor' },
+    ];
+    const r = avaliarProporcao(cesta, sistema);
+    expect(r.atende).toBe(false);
+    expect(r.faltantes).toEqual([{ tipo: 'fundo', requeridoL: 4, presenteL: 1 }]);
+  });
+
+  it('ignora litros de componente EXTERNO ao checar proporção e sinaliza o externo', () => {
+    const cesta: ItemCesta[] = [
+      { tipo: 'acabamento', litros: 4, origem: 'colacor' },
+      { tipo: 'fundo', litros: 4, origem: 'externo' }, // comprado fora → não conta
+      { tipo: 'catalisador', litros: 0.5, origem: 'colacor' },
+    ];
+    const r = avaliarProporcao(cesta, sistema);
+    expect(r.atende).toBe(false);
+    expect(r.faltantes).toEqual([{ tipo: 'fundo', requeridoL: 4, presenteL: 0 }]);
+    expect(r.temComponenteExterno).toBe(true);
+  });
+
+  it('sem acabamento na cesta → não atende, sem inventar (litrosAcabamento 0)', () => {
+    const cesta: ItemCesta[] = [{ tipo: 'fundo', litros: 4, origem: 'colacor' }];
+    const r = avaliarProporcao(cesta, sistema);
+    expect(r.litrosAcabamento).toBe(0);
+    expect(r.atende).toBe(false);
+    expect(r.faltantes).toEqual([]);
+  });
+});

--- a/src/lib/projeto-verificado/__tests__/consumo.test.ts
+++ b/src/lib/projeto-verificado/__tests__/consumo.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { classificarConsumo, type ParametrosConsumo } from '../consumo';
+
+// Sistema-exemplo: rende 10 m²/L. 40 m² → esperado 4 L.
+const p = (over: Partial<ParametrosConsumo>): ParametrosConsumo => ({
+  areaM2: 40,
+  rendimentoM2PorLitro: 10,
+  litrosDosados: 4,
+  ...over,
+});
+
+describe('classificarConsumo', () => {
+  it('volume na faixa do esperado → compativel', () => {
+    const r = classificarConsumo(p({ litrosDosados: 4 }));
+    expect(r.esperadoL).toBe(4);
+    expect(r.classe).toBe('compativel');
+  });
+
+  it('até 30% abaixo ainda é compativel (banda ampla)', () => {
+    const r = classificarConsumo(p({ litrosDosados: 3 })); // razão 0,75
+    expect(r.classe).toBe('compativel');
+  });
+
+  it('entre 40% e 70% do esperado → baixo', () => {
+    const r = classificarConsumo(p({ litrosDosados: 2 })); // razão 0,5
+    expect(r.classe).toBe('baixo');
+  });
+
+  it('abaixo de 40% do esperado → suspeito', () => {
+    const r = classificarConsumo(p({ litrosDosados: 1 })); // razão 0,25
+    expect(r.classe).toBe('suspeito');
+  });
+
+  it('rendimento inválido → indeterminado (não fabrica classe)', () => {
+    const r = classificarConsumo(p({ rendimentoM2PorLitro: 0 }));
+    expect(r.classe).toBe('indeterminado');
+    expect(r.esperadoL).toBeNull();
+    expect(r.razao).toBeNull();
+  });
+});

--- a/src/lib/projeto-verificado/__tests__/estado.test.ts
+++ b/src/lib/projeto-verificado/__tests__/estado.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { calcularEstado, type FatosProjeto } from '../estado';
+
+const base: FatosProjeto = {
+  corDosadaVinculada: false,
+  proporcaoAtende: false,
+  temComponenteExterno: false,
+  evidenciasMinimasRecebidas: false,
+  revisaoHumanaConcluida: false,
+  divergencia: false,
+};
+
+describe('calcularEstado', () => {
+  it('divergência é exceção terminal, vence tudo', () => {
+    expect(calcularEstado({ ...base, corDosadaVinculada: true, proporcaoAtende: true, divergencia: true }))
+      .toBe('divergencia_encontrada');
+  });
+
+  it('sem cor vinculada → pendente_incompleto', () => {
+    expect(calcularEstado(base)).toBe('pendente_incompleto');
+  });
+
+  it('cor vinculada, sem sistema → cor_dosada_verificada', () => {
+    expect(calcularEstado({ ...base, corDosadaVinculada: true })).toBe('cor_dosada_verificada');
+  });
+
+  it('cor + proporção OK (tudo Colacor) → sistema_documentado', () => {
+    expect(calcularEstado({ ...base, corDosadaVinculada: true, proporcaoAtende: true }))
+      .toBe('sistema_documentado');
+  });
+
+  it('componente externo TETA em componente_externo_declarado, mesmo com proporção e evidência', () => {
+    expect(calcularEstado({
+      ...base, corDosadaVinculada: true, proporcaoAtende: true,
+      temComponenteExterno: true, evidenciasMinimasRecebidas: true,
+    })).toBe('componente_externo_declarado');
+  });
+
+  it('sistema + evidências → evidencia_recebida', () => {
+    expect(calcularEstado({
+      ...base, corDosadaVinculada: true, proporcaoAtende: true, evidenciasMinimasRecebidas: true,
+    })).toBe('evidencia_recebida');
+  });
+
+  it('evidência sem sistema (proporção falha) NÃO eleva: fica cor_dosada_verificada', () => {
+    expect(calcularEstado({
+      ...base, corDosadaVinculada: true, proporcaoAtende: false, evidenciasMinimasRecebidas: true,
+    })).toBe('cor_dosada_verificada');
+  });
+
+  it('revisão humana concluída → conformidade_assistida (topo)', () => {
+    expect(calcularEstado({
+      ...base, corDosadaVinculada: true, proporcaoAtende: true,
+      evidenciasMinimasRecebidas: true, revisaoHumanaConcluida: true,
+    })).toBe('conformidade_assistida');
+  });
+});

--- a/src/lib/projeto-verificado/check-proporcao.ts
+++ b/src/lib/projeto-verificado/check-proporcao.ts
@@ -1,0 +1,66 @@
+// Check de Proporção ("cesta"): a compra de um projeto contém os componentes do
+// sistema Sayerlack na proporção técnica mínima? É a trava que transforma "o ledger
+// só vê a cor" numa prova de SISTEMA (spec v2 §5). Doutrina "ausente ≠ zero":
+// componente comprado fora da Colacor (`externo`) NÃO conta como documentado.
+// Os VALORES de proporção vêm do discovery (D3); aqui só vive a lógica.
+
+export type TipoComponente = 'acabamento' | 'fundo' | 'catalisador' | 'diluente';
+export type ComponenteNaoAcabamento = Exclude<TipoComponente, 'acabamento'>;
+
+/** Um item comprado e vinculado ao projeto. */
+export interface ItemCesta {
+  tipo: TipoComponente;
+  litros: number;
+  /** 'colacor' = vendido/dosado por nós (conta); 'externo' = comprado fora (não conta). */
+  origem: 'colacor' | 'externo';
+}
+
+/** Requisito técnico do sistema: litros mínimos de cada componente por litro de acabamento. */
+export interface RequisitoSistema {
+  proporcaoMinima: Partial<Record<ComponenteNaoAcabamento, number>>;
+}
+
+export interface Faltante {
+  tipo: TipoComponente;
+  requeridoL: number;
+  presenteL: number;
+}
+
+export interface ResultadoProporcao {
+  litrosAcabamento: number;
+  atende: boolean;
+  faltantes: Faltante[];
+  temComponenteExterno: boolean;
+}
+
+function somaColacor(cesta: ItemCesta[], tipo: TipoComponente): number {
+  return cesta
+    .filter((i) => i.tipo === tipo && i.origem === 'colacor')
+    .reduce((acc, i) => acc + i.litros, 0);
+}
+
+export function avaliarProporcao(
+  cesta: ItemCesta[],
+  sistema: RequisitoSistema,
+): ResultadoProporcao {
+  const litrosAcabamento = somaColacor(cesta, 'acabamento');
+  const temComponenteExterno = cesta.some((i) => i.origem === 'externo');
+
+  // Sem acabamento Colacor não há o que documentar (ausente ≠ zero): não inventa faltantes.
+  if (litrosAcabamento <= 0) {
+    return { litrosAcabamento: 0, atende: false, faltantes: [], temComponenteExterno };
+  }
+
+  const faltantes: Faltante[] = [];
+  for (const [tipo, fator] of Object.entries(sistema.proporcaoMinima) as Array<
+    [ComponenteNaoAcabamento, number]
+  >) {
+    const requeridoL = litrosAcabamento * fator;
+    const presenteL = somaColacor(cesta, tipo);
+    if (presenteL < requeridoL) {
+      faltantes.push({ tipo, requeridoL, presenteL });
+    }
+  }
+
+  return { litrosAcabamento, atende: faltantes.length === 0, faltantes, temComponenteExterno };
+}

--- a/src/lib/projeto-verificado/check-proporcao.ts
+++ b/src/lib/projeto-verificado/check-proporcao.ts
@@ -4,8 +4,8 @@
 // componente comprado fora da Colacor (`externo`) NÃO conta como documentado.
 // Os VALORES de proporção vêm do discovery (D3); aqui só vive a lógica.
 
-export type TipoComponente = 'acabamento' | 'fundo' | 'catalisador' | 'diluente';
-export type ComponenteNaoAcabamento = Exclude<TipoComponente, 'acabamento'>;
+type TipoComponente = 'acabamento' | 'fundo' | 'catalisador' | 'diluente';
+type ComponenteNaoAcabamento = Exclude<TipoComponente, 'acabamento'>;
 
 /** Um item comprado e vinculado ao projeto. */
 export interface ItemCesta {
@@ -20,7 +20,7 @@ export interface RequisitoSistema {
   proporcaoMinima: Partial<Record<ComponenteNaoAcabamento, number>>;
 }
 
-export interface Faltante {
+interface Faltante {
   tipo: TipoComponente;
   requeridoL: number;
   presenteL: number;

--- a/src/lib/projeto-verificado/consumo.ts
+++ b/src/lib/projeto-verificado/consumo.ts
@@ -1,0 +1,44 @@
+// Classificação de consumo em BANDAS AMPLAS (spec v2 §4): rendimento em madeira
+// varia demais (substrato, demãos, método, perdas) → serve para ALERTA e seleção
+// de auditoria, NUNCA como critério isolado de aprovação. Doutrina "ausente ≠ zero":
+// sem rendimento/área válidos → 'indeterminado', não fabrica classe.
+// Os limiares são calibráveis (default conservador); valores finais via discovery.
+
+export type ClassificacaoConsumo = 'compativel' | 'baixo' | 'suspeito' | 'indeterminado';
+
+export interface ParametrosConsumo {
+  areaM2: number;
+  /** Rendimento do sistema (m² por litro), do boletim técnico (discovery D3). */
+  rendimentoM2PorLitro: number;
+  litrosDosados: number;
+  /** Razão abaixo da qual vira 'suspeito' (default 0,4). */
+  limiarSuspeito?: number;
+  /** Razão abaixo da qual vira 'baixo' (default 0,7). */
+  limiarBaixo?: number;
+}
+
+export interface ResultadoConsumo {
+  esperadoL: number | null;
+  razao: number | null;
+  classe: ClassificacaoConsumo;
+}
+
+export function classificarConsumo(p: ParametrosConsumo): ResultadoConsumo {
+  const limiarSuspeito = p.limiarSuspeito ?? 0.4;
+  const limiarBaixo = p.limiarBaixo ?? 0.7;
+
+  // Ausente ≠ zero: entradas inválidas não viram classe fabricada.
+  if (!(p.areaM2 > 0) || !(p.rendimentoM2PorLitro > 0)) {
+    return { esperadoL: null, razao: null, classe: 'indeterminado' };
+  }
+
+  const esperadoL = p.areaM2 / p.rendimentoM2PorLitro;
+  const razao = p.litrosDosados / esperadoL;
+
+  let classe: ClassificacaoConsumo;
+  if (razao < limiarSuspeito) classe = 'suspeito';
+  else if (razao < limiarBaixo) classe = 'baixo';
+  else classe = 'compativel';
+
+  return { esperadoL, razao, classe };
+}

--- a/src/lib/projeto-verificado/consumo.ts
+++ b/src/lib/projeto-verificado/consumo.ts
@@ -4,7 +4,7 @@
 // sem rendimento/área válidos → 'indeterminado', não fabrica classe.
 // Os limiares são calibráveis (default conservador); valores finais via discovery.
 
-export type ClassificacaoConsumo = 'compativel' | 'baixo' | 'suspeito' | 'indeterminado';
+type ClassificacaoConsumo = 'compativel' | 'baixo' | 'suspeito' | 'indeterminado';
 
 export interface ParametrosConsumo {
   areaM2: number;

--- a/src/lib/projeto-verificado/estado.ts
+++ b/src/lib/projeto-verificado/estado.ts
@@ -1,0 +1,46 @@
+// Escada de estados do Projeto Verificado (spec v2 §4). Substitui o "verde" único
+// por estados nomeados pelo que CADA UM atesta — anti-sobrevenda. Função pura.
+// Ordem (compra → execução → auditoria):
+//   pendente_incompleto < cor_dosada_verificada < sistema_documentado
+//   < evidencia_recebida < conformidade_assistida
+// Exceções (não-ordinais): divergencia_encontrada (terminal), componente_externo_declarado.
+
+export type EstadoProjeto =
+  | 'pendente_incompleto'
+  | 'cor_dosada_verificada'
+  | 'sistema_documentado'
+  | 'evidencia_recebida'
+  | 'conformidade_assistida'
+  | 'divergencia_encontrada'
+  | 'componente_externo_declarado';
+
+/** Fatos comprovados sobre o projeto (alimentados pela persistência + Check de Proporção). */
+export interface FatosProjeto {
+  /** Há ao menos uma dosagem Sayersystem/Colacor vinculada ao projeto. */
+  corDosadaVinculada: boolean;
+  /** Check de Proporção atende (ResultadoProporcao.atende). */
+  proporcaoAtende: boolean;
+  /** Algum componente foi comprado fora da Colacor (ResultadoProporcao.temComponenteExterno). */
+  temComponenteExterno: boolean;
+  /** Chegaram as fotos mínimas (lacre/etiqueta + lata aberta na peça). */
+  evidenciasMinimasRecebidas: boolean;
+  /** Passou por revisão humana / amostra-testemunha / auditoria. */
+  revisaoHumanaConcluida: boolean;
+  /** Há divergência registrada (contestação, lote incompatível, etc.). */
+  divergencia: boolean;
+}
+
+export function calcularEstado(f: FatosProjeto): EstadoProjeto {
+  if (f.divergencia) return 'divergencia_encontrada';
+  if (!f.corDosadaVinculada) return 'pendente_incompleto';
+
+  // Cor vinculada, mas comprou parte fora: reconhece a cor, não sobe a "sistema documentado".
+  if (f.temComponenteExterno) return 'componente_externo_declarado';
+
+  // Sem sistema documentado (proporção falha), nada de execução eleva o estado.
+  if (!f.proporcaoAtende) return 'cor_dosada_verificada';
+
+  if (f.revisaoHumanaConcluida) return 'conformidade_assistida';
+  if (f.evidenciasMinimasRecebidas) return 'evidencia_recebida';
+  return 'sistema_documentado';
+}


### PR DESCRIPTION
Ressuscita a **Fase 1 do Projeto Verificado Sayerlack**, parada desde 2026-06-17 no [PR #947](https://github.com/LucasSardenbergL/afiacao/pull/947) (fechado) — 64 dias e ~1.200 commits de deriva.

## O que entra

**Núcleo de domínio puro** (`src/lib/projeto-verificado/`, 17 testes) — as 3 inovações da spec v2, validada por painel tri-modelo:

| Arquivo | Papel |
|---|---|
| `check-proporcao.ts` | **Check de Proporção** — a cesta contém o sistema Sayerlack na proporção técnica mínima? Doutrina "ausente ≠ zero": componente comprado fora (`externo`) não conta como documentado. |
| `estado.ts` | **Escada de estados** (`cor_dosada_verificada` → `sistema_documentado` → `evidencia_recebida` → `conformidade_assistida`) — anti-sobrevenda: nunca "100% verificado". |
| `consumo.ts` | **Faixa de consumo** em bandas amplas (`compativel`/`baixo`/`suspeito`/`indeterminado`). |

Funções puras, sem React/Supabase, no molde de `src/lib/tint/compute-price.ts`. Nenhum número de negócio hardcoded — proporções, rendimento e larguras de banda são **parâmetros** que vêm do discovery (D3).

## Os 2 gates que seguravam o merge

A nota deixada na spec em 2026-08-22 dizia que a Fase 1 *"não consegue mergear sozinha"* porque o `bunx knip` reprovaria exports órfãos, e que ela precisaria **vir junto com a Fase 2** para ganhar um chamador. Medido:

**1. `bunx knip` — o gate existe** (step do `validate`, `ci.yml:322`) e de fato reprovava. Mas o que ele apontou foram **4 tipos exportados sem consumidor** (`TipoComponente`, `ComponenteNaoAcabamento`, `Faltante`, `ClassificacaoConsumo`), **não o módulo inteiro**: as *funções* já eram alcançáveis pelos testes, porque `vitest.config.ts` é entry no `knip.json`. Os 4 são usados só dentro do próprio arquivo — nem os testes os importam. Tirar o `export` resolveu.

> Ou seja: a nota estava **certa no gate e forte demais na conclusão**. A Fase 1 não precisava da Fase 2 — precisava de 4 palavras-chave a menos.

**2. `manifesto.gate.test.ts` — um segundo gate que a nota não mencionava.** Exige 1 dono declarado por arquivo de `src/`; os 6 arquivos saíam como `[orfao]`. Corrigido com uma entrada em `src/lib/modulos/manifesto.ts`. Módulo novo em vez de `NAO_CLASSIFICADOS` porque essa lista está **vazia** hoje — zero dívida de classificação no repo, e um núcleo nomeado por spec não é dívida.

## ⚠️ Errata registrada neste PR

Uma versão anterior deste PR e dos docs afirmava que **"knip não está no `ci.yml`"** e tratava a nota de 08-22 como refutada. **Era falso**, e o CI reprovou exatamente no knip. A afirmação nasceu de ler `sed -n '1,80p'` de um `ci.yml` de **424 linhas**.

A classe de erro — *concluir ausência a partir de leitura truncada* — ficou registrada em `docs/agent/deploy.md`, junto com a lista dos **15 steps** do `validate` (eu tinha assumido 5) e o comando que não mente: `grep -n "^      - name:" .github/workflows/ci.yml`.

## Verificação — os 15 gates do `validate`

`tsc` (app) · `scripts:typecheck` · `test` · `test:edges` (879) · `edges:typecheck` · `build` · `lint` · `claude:size` · `test:hooks` · `authz:check` · `bunpin:check` · `docs:indice` · `docs:citacoes` · `docs:links` · `knip` — **todos exit 0** nesta árvore.

**Falsificação:** os dois gates estavam **vermelhos antes** (`manifesto.gate` com 6 `[orfao]`; `knip` com 4 tipos) e verdes depois — provam o que prometem.

## Documentação

- `docs/agent/deploy.md` — seção nova **"O que BLOQUEIA o PR — leia o `ci.yml` INTEIRO"**: os 15 steps, knip como bloqueante, os 2 gates que pegam código novo, e a armadilha da leitura truncada.
- spec — nota de estado + a errata da errata.
- plano — Fase 1 marcada concluída.

**CLAUDE.md não foi tocado** de propósito: o teto por seção está ratcheted em 100% em toda seção, e a política do arquivo manda lição para `docs/agent/`. Bumpar a baseline é decisão do founder.

## O que este PR NÃO resolve

A **Fase 0 (discovery) segue inteira aberta** e é ela que bloqueia as Fases 2+ (persistência, balcão, evidências, motor comercial, certificado, Sayersystem) — trabalho do founder/jurídico:

- **D1** export do Sayersystem (CSV/API/nada?) — dependência dura do vínculo projeto↔dosagem
- **D2** cronometragem do balcão (≤ ~2 min)
- **D3** parâmetros técnicos Renner (proporção mínima + rendimento m²/L) — hoje a Fase 1 só roda com valores de teste
- **D4-D6** pareceres jurídicos (Assistência de Conformidade sob CDC · fee do arquiteto vs RT · auditoria + LGPD)
- **D7** naming público

O módulo entra **sem rota e sem consumidor de produção** — é domínio puro por desenho, e assim fica até D1/D3 destravarem a Fase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)