### PR TITLE
docs(historico): a nota da cota 'até 20/09' envelheceu ERRADA — marcada como superada

### DIFF
--- a/docs/historico/farmer-sensor-desfecho.md
+++ b/docs/historico/farmer-sensor-desfecho.md
@@ -370,10 +370,12 @@ auto-sabotava não produziu classificação errada — 1 tentativa, sem retry, c
 diagnóstico certo. O `EXIT=75` que ele devolveu era **cota REAL**, confirmada por ping
 direto ao CLI, não falso positivo.
 
-> ⚠️ **Cota do Codex esgotada até 20/09/2026 22:37** (medido 2026-08-22). A mensagem
-> sugere conta sem Plus ativo ("start a free trial of Plus today"). Enquanto isso, todo
-> trabalho money-path cai no **Caminho B** (validação adversária própria + registrar
-> "REVISÃO INDEPENDENTE PENDENTE") — `docs/agent/money-path.md`.
+> ⚠️ ~~**Cota do Codex esgotada até 20/09/2026 22:37**~~ — **NOTA SUPERADA em 23/08.**
+> As duas afirmações estavam erradas: a conta **não** está sem Plus (é paga), e aquele
+> "limite até 20/09" era a cota do plano **`free`** que um token congelado declarava.
+> `codex logout && codex login` devolveu tudo na hora. Ver a seção "A causa real: o token
+> mentia sobre o plano" acima. Fica registrada porque é o exemplo dentro deste próprio
+> documento de uma nota que envelheceu ERRADA e continuou parecendo evidência datada.
 
 O default do modelo virou **medição datada dentro do próprio script** (o ping dos 5 nomes,
 com a data e a versão do codex-cli), não uma escolha: disponibilidade muda por tier, e o


### PR DESCRIPTION
Nota escrita em 22/08 ("cota até 20/09", "conta sem Plus ativo") — **as duas afirmações estão erradas**. A causa medida em 23/08 foi o `plan_type` congelado num token, numa conta paga; relogar resolveu na hora.

Ela estava na `main` com aparência de evidência datada, que é exatamente o formato em que este repo mais se engana — e o documento onde ela vive é o que descreve essa classe.

Mantida **riscada com o porquê** em vez de apagada: vira o exemplo mais curto da própria lição.

🤖 Generated with [Claude Code](https://claude.com/claude-code)