### PR TITLE
feat(sensor): o aviso do guard evaporava no contexto — sensor de campo, e o teto de bytes que eu tinha "provado" no caso TÍPICO

### DIFF
--- a/.claude/hooks/pipestatus-zsh-guard.sh
+++ b/.claude/hooks/pipestatus-zsh-guard.sh
@@ -137,6 +137,21 @@ ramo="$(printf '%s' "$cmd" | awk '
     if (pend) inhd = 1
     emite("\n")
   }
+  # Janela de ~40 chars de cada lado do match, para o sensor. Deliberadamente NAO e o comando
+  # inteiro: o log vai para disco e comando de agente carrega token/senha. Segredo nao costuma
+  # ficar colado em PIPESTATUS, entao a janela estreita e o que basta para julgar VP/FP sem
+  # arrastar credencial junto. Tabs/newlines viram espaco (a linha do log tem de ser UMA linha).
+  # `re` chega como STRING, nunca como /literal/: em awk, /re/ em posicao de argumento
+  # AVALIA para 0 ou 1 ($0 ~ /re/) e a funcao receberia um numero. Foi assim que o trecho
+  # saiu vazio na 1a versao — e pior, casou por acidente onde o comando tinha um "0".
+  function janela(re,   ini, s) {
+    if (!match(vis, re)) return ""
+    ini = RSTART - 40; if (ini < 1) ini = 1
+    s = substr(vis, ini, RLENGTH + 80)
+    gsub(/[\t\n]/, " ", s); gsub(/  +/, " ", s)
+    return s
+  }
+  function grita(ramo, re) { printf "%s\t%s\n", ramo, janela(re); exit }
   END {
     # A palavra NUA (sem `$`) so e perigosa onde algo AVALIA identificador como aritmetica:
     # (( … )), [[ … ]] e `let` tratam parametro ausente como 0. Fora dai, `PIPESTATUS` solto e
@@ -145,15 +160,16 @@ ramo="$(printf '%s' "$cmd" | awk '
     arit = (vis ~ /\(\(/ || vis ~ /\[\[/ || vis ~ /(^|[^A-Za-z0-9_])let([^A-Za-z0-9_]|$)/)
     # (A) bash-ism: PIPESTATUS nao existe no zsh -> vazio. `[^}]*` cobre flags de parametro do zsh
     # como ${(e)PIPESTATUS[0]} e ${#PIPESTATUS[@]}.
-    if (vis ~ /\$\{[^}]*PIPESTATUS/ || vis ~ /\$PIPESTATUS([^A-Za-z0-9_]|$)/) { print "BASHISM"; exit }
-    if (arit && vis ~ /(^|[^A-Za-z0-9_])PIPESTATUS([^A-Za-z0-9_]|$)/)            { print "BASHISM"; exit }
+    if (vis ~ /\$\{[^}]*PIPESTATUS/ || vis ~ /\$PIPESTATUS([^A-Za-z0-9_]|$)/) { grita("BASHISM", "\\$\\{?[^}]*PIPESTATUS") }
+    if (arit && vis ~ /(^|[^A-Za-z0-9_])PIPESTATUS([^A-Za-z0-9_]|$)/)            { grita("BASHISM", "PIPESTATUS") }
     # (B) zsh e 1-INDEXED: pipestatus[0…] e sempre vazio. Indice que COMECA em 0 pega [0] e [0+0].
-    if (vis ~ /\$\{[^}]*pipestatus\[[[:space:]]*0/ || vis ~ /\$pipestatus\[[[:space:]]*0/) { print "INDICE-ZERO"; exit }
-    if (arit && vis ~ /(^|[^A-Za-z0-9_])pipestatus\[[[:space:]]*0/)                            { print "INDICE-ZERO"; exit }
+    if (vis ~ /\$\{[^}]*pipestatus\[[[:space:]]*0/ || vis ~ /\$pipestatus\[[[:space:]]*0/) { grita("INDICE-ZERO", "\\$\\{?[^}]*pipestatus\\[[[:space:]]*0") }
+    if (arit && vis ~ /(^|[^A-Za-z0-9_])pipestatus\[[[:space:]]*0/)                            { grita("INDICE-ZERO", "pipestatus\\[[[:space:]]*0") }
   }
 ')"
 
 [ -n "$ramo" ] || exit 0
+trecho="${ramo#*$'\t'}"; ramo="${ramo%%$'\t'*}"
 
 # PIPESTATUS-BASHISM-NO-ZSH / PIPESTATUS-INDICE-ZERO sao CONTRATO DE TESTE: marcadores ASCII, caixa
 # fixa, exclusivos de um ramo. scripts/test-pipestatus-zsh-guard.sh casa por eles com `command grep`
@@ -183,6 +199,60 @@ else
 
 $idioma"
 fi
+
+# ── SENSOR DE CAMPO ───────────────────────────────────────────────────────────────────────────
+# Sem isto, a frase "endurecer para deny e fase N+1" seria inalcancavel POR CONSTRUCAO: o aviso vai
+# para o contexto e evapora, e ninguem consegue responder "quantas vezes disparou, e em que"
+# (docs/historico/fase-sem-sinal.md — superficie de uso nasce COM o sensor). Quem LE isto e
+# `scripts/pipestatus-guard-sinal.sh`; um log sem query nao e sensor, e lixo.
+#
+# FORA do repo de proposito: ~30 worktrees compartilham este guard, e um log versionado viraria ima
+# de conflito (a mesma razao pela qual o CLAUDE.md proibe roadmap em arquivo compartilhado).
+# Escrita concorrente sem lock so e segura enquanto a linha couber no `PIPE_BUF` — que no macOS e
+# 512 bytes (`getconf PIPE_BUF /`), NAO os 4096 do Linux. Dai o teto abaixo, que e invariante de
+# CORRETUDE (linha picotada envenena a query), nao estetica.
+#
+# ARMADILHA MEDIDA: truncar o CAMPO nao limita a LINHA — o escape do JSON infla depois do corte.
+# Com trecho ja cortado em 160, medi 642 bytes so de aspas (cada " vira \") e 1282 bytes de bytes
+# de controle (cada um vira \u00XX, 6 bytes). A versao anterior media 176 bytes com dado TIPICO e
+# declarava o invariante provado — pior caso e outra medicao. Por isso o teto e conferido na LINHA
+# PRONTA, num laco que encolhe o trecho ate caber.
+# Falha de log NUNCA cala o aviso: todo o bloco e best-effort.
+TETO_LINHA=511   # 511 + o "\n" = 512 = PIPE_BUF do macOS, o mais estrito das plataformas em jogo
+registrar_sinal() {
+  local log dir linha wt corte janela ts
+  log="${PIPESTATUS_GUARD_LOG:-$HOME/.claude/afiacao-pipestatus-guard.jsonl}"
+  dir="${log%/*}"
+  [ -d "$dir" ] || (umask 077; mkdir -p "$dir") 2>/dev/null || return 0
+  # Nasce 0600: o arquivo guarda FRAGMENTO DE COMANDO. A criacao vem com umask 077 para nao
+  # existir janela em que ele esteja 0644, e o chmod conserta log legado (custa um fork, mas so
+  # no caminho de DISPARO, que e raro por construcao — o caminho quente saiu no portao barato).
+  [ -e "$log" ] || (umask 077; : >> "$log") 2>/dev/null || return 0
+  chmod 600 "$log" 2>/dev/null || true
+  # Redacao: a janela e estreita, mas se um segredo encostar nela ele NAO vai para o disco.
+  local seguro
+  seguro="$(printf '%s' "$1" | sed -E \
+    -e 's/(eyJ[A-Za-z0-9_.-]{8,})/<JWT-REDIGIDO>/g' \
+    -e 's/((token|key|secret|senha|password|passwd|pwd|auth|apikey)["'"'"']?[=:][[:space:]]*)[^[:space:]"'"'"']+/\1<REDIGIDO>/gI' \
+    -e 's/([Bb]earer[[:space:]]+)[^[:space:]]+/\1<REDIGIDO>/g' 2>/dev/null)"
+  seguro="${seguro:-$1}"
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
+  wt="$(printf '%.48s' "${PWD##*/}")"
+  # `jq -a` forca saida ASCII pura => ${#linha} conta BYTES em QUALQUER locale, sem fork de `wc`.
+  for corte in 160 80 40 0; do
+    if [ "$corte" -eq 0 ]; then janela='<TRECHO-OMITIDO-LINHA-LONGA>'
+    else janela="$(printf "%.${corte}s" "$seguro")"; fi
+    linha="$(jq -n -c -a --arg ts "$ts" --arg ramo "$2" --arg trecho "$janela" --arg wt "$wt" \
+      '{ts:$ts, ramo:$ramo, trecho:$trecho, wt:$wt}' 2>/dev/null)" || return 0
+    [ -n "$linha" ] || return 0
+    [ "${#linha}" -lt "$TETO_LINHA" ] && break
+  done
+  # Guarda final: se nem o marcador coube (ramo absurdo), NAO grava — linha picotada envenena a
+  # query, e um sensor que mente e pior que sensor nenhum.
+  [ "${#linha}" -lt "$TETO_LINHA" ] || return 0
+  printf '%s\n' "$linha" >> "$log" 2>/dev/null || return 0
+}
+registrar_sinal "$trecho" "$ramo"
 
 jq -n --arg m "$msg" --arg c "$ctx" \
   '{systemMessage:$m, hookSpecificOutput:{hookEventName:"PreToolUse", additionalContext:$c}}'

--- a/docs/historico/evidencia-positiva-shell.md
+++ b/docs/historico/evidencia-positiva-shell.md
@@ -188,6 +188,28 @@ miniatura: um detector de padrão de shell não herda a semântica do shell.** U
 negativo E falso positivo comprovados não tem a precisão que justifica bloquear — e como aviso o
 falso positivo custa uma linha de contexto, o que permitiu ampliar a detecção em vez de encolhê-la.
 
+
+**O sensor, e o invariante que eu tinha "provado" no caso típico.** Aviso sem registro é promessa
+inalcançável — "endurecer quando houver dado" precisa do dado. O hook grava JSONL em
+`~/.claude/afiacao-pipestatus-guard.jsonl` e `scripts/pipestatus-guard-sinal.sh` é a query (log sem
+query não é sensor, é lixo). Segunda rodada de `/codex` defensivo, três achados, todos reais:
+
+- **Truncar o campo não limita a linha.** Eu cortava o trecho em 160 e media 176 bytes — com dado
+  típico. O escape do JSON infla DEPOIS do corte: cada `"` vira `\"`, cada byte de controle vira
+  `\u00XX` (6 bytes). Medido no pior caso: **1010 bytes** — o dobro do `PIPE_BUF` do macOS, que é
+  **512** e não os 4096 do Linux. Acima dele o append entre as ~30 worktrees pode picotar. O teto
+  passou a ser conferido na LINHA PRONTA, num laço que encolhe o trecho até caber; `jq -a` força
+  saída ASCII para que `${#linha}` conte bytes em qualquer locale, sem fork.
+- **Parse OK não é schema OK.** Um JSONL de linhas válidas sem os campos do sensor produzia
+  relatório de `null` com exit 0 — ausência de dado servida como medição, o vício que o sensor
+  existe para não cometer. Agora é `SCHEMA-ESTRANHO` (exit 65), e log misto declara o que ignorou.
+- **Log de fragmento de comando nascia 0644.** Herdado do umask, nunca medido. Nasce 0600.
+
+E a lição de método, que veio da falsificação e não do Codex: **o caso de teste pode não exercitar
+o invariante que o teste afirma provar.** Sabotei o teto e o teste seguiu VERDE — porque eu enchia
+o comando de acentos, que param em 414 bytes sozinhos. O vetor real era match GRANDE, não comando
+grande: `\$\{[^}]*PIPESTATUS` não tem limite, então a janela de contexto cresce junto com ele.
+Sem a falsificação eu teria entregue um teste que passa com e sem o código que ele testa.
 ## O padrão por trás das nove
 
 Seis produzem **verde por construção**, não por mérito; a sétima mostra que o mesmo defeito

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "wt:preflight": "bun scripts/wt-preflight-migration.ts",
     "claude:size": "bash scripts/check-claude-md-budget.sh",
     "claude:instr": "bash scripts/instrucoes-relatorio.sh",
-    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query; do bash scripts/test-$t.sh || exit 1; done",
+    "test:hooks": "for t in heavy pr-collision pr-duplicata migration-collision branch-pos-squash destructive-bash pipestatus-zsh migration-immutability edge-guardrail; do bash scripts/test-$t-guard.sh || exit 1; done; for t in orfaos-custosos wt-status wt-orfas bash-contexto-nudge read-contexto-nudge stop-contexto-caro stop-moneypath-nudge wt-prune wt-clean wt-reap codex-async claude-md-budget hooks-sessionstart pipestatus-guard-sinal pr-watch preflight-migration tokens-report verify-edge-pat lovable-revert-scan posthog-query; do bash scripts/test-$t.sh || exit 1; done",
     "heavy:install": "bash scripts/heavy-install.sh"
   },
   "dependencies": {

--- a/scripts/pipestatus-guard-sinal.sh
+++ b/scripts/pipestatus-guard-sinal.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# pipestatus-guard-sinal.sh — LÊ o sensor de campo do .claude/hooks/pipestatus-zsh-guard.sh.
+#
+# POR QUÊ ESTE SCRIPT EXISTE: o hook nasceu como AVISO, e o cabeçalho dele diz que endurecer para
+# `deny` é decisão de fase N+1 "com sinal desta fase". Sem uma QUERY, essa frase é promessa vazia —
+# "quando medir" tem de ser comando, não recado (docs/historico/fase-sem-sinal.md). Isto é o comando.
+#
+# ⚠️ AUSÊNCIA DE DADO NÃO É APROVAÇÃO. Log inexistente/vazio NÃO significa "nunca dispara, pode
+# endurecer": significa que o guard pode nem ter rodado (sessões abertas antes do merge não releem
+# settings.json). O veredito abaixo trata os dois casos como coisas DIFERENTES, de propósito.
+#
+# Datas passam por `jq` (fromdateiso8601), nunca por `date -d`/`date -j`: as flags de data divergem
+# entre BSD e GNU sem falhar — fazem OUTRA coisa em silêncio (evidencia-positiva-shell.md §6).
+#
+# Uso:  bash scripts/pipestatus-guard-sinal.sh [caminho-do-log]
+set -u
+
+LOG="${1:-${PIPESTATUS_GUARD_LOG:-$HOME/.claude/afiacao-pipestatus-guard.jsonl}}"
+command -v jq >/dev/null 2>&1 || { echo "jq é necessário" >&2; exit 64; }
+
+echo "== SINAL DE CAMPO: pipestatus-zsh-guard =="
+echo "log: $LOG"
+
+if [ ! -f "$LOG" ]; then
+  cat <<'FIM'
+
+SEM-LOG: o arquivo não existe.
+
+Isto é AUSÊNCIA DE DADO, não "zero disparos". Confira nesta ordem:
+  1. o hook está registrado?   jq '.hooks.PreToolUse[]|select(.matcher=="Bash")' .claude/settings.json
+  2. a sessão foi aberta DEPOIS do merge? settings.json só é lido na inicialização — sessão antiga
+     roda sem o guard, e um worktree antigo nunca vai escrever aqui;
+  3. force um disparo:  true | true; echo "${PIPESTATUS[0]}"
+
+VEREDITO: não dá para decidir nada sobre endurecer. Instale o sinal antes.
+FIM
+  exit 3
+fi
+
+total="$(jq -s 'length' "$LOG" 2>/dev/null)" || { echo "log ilegível (JSONL corrompido?)" >&2; exit 65; }
+if [ "${total:-0}" -eq 0 ]; then
+  echo
+  echo "LOG-VAZIO: o arquivo existe mas não tem nenhum disparo."
+  echo "Diferente de SEM-LOG: aqui o hook provavelmente rodou e simplesmente não achou nada."
+  echo "Ainda assim é fraco como prova — sem saber quantas chamadas Bash passaram pelo guard, o"
+  echo "denominador é desconhecido, e 0/desconhecido não é uma taxa."
+  echo
+  echo "VEREDITO: sinal insuficiente. Siga avisando."
+  exit 0
+fi
+
+# Parse OK nao e schema OK. Um JSONL de linhas validas porem SEM os campos do sensor produzia
+# relatorio de "null" com exit 0 — ou seja, ausencia de dado servida como medicao, exatamente o
+# vicio que este sensor existe para nao cometer. Daqui para baixo tudo le a fatia VALIDADA.
+VALIDO="$(mktemp -t pipestatus-sinal)" || { echo "não consegui criar arquivo temporário" >&2; exit 70; }
+trap 'rm -f "$VALIDO"' EXIT
+# `try…catch empty` porque o `ts` tem de sobreviver ao `fromdateiso8601` usado nas agregacoes:
+# validar so o TIPO deixaria passar "ontem" e a query morreria la na frente.
+jq -c 'select((.ramo|type)=="string" and (.trecho|type)=="string" and (.wt|type)=="string")
+       | select(try ((.ts|fromdateiso8601)|type) catch "" | . == "number")' "$LOG" > "$VALIDO" 2>/dev/null
+validas="$(wc -l < "$VALIDO" | tr -d ' ')"
+if [ "${validas:-0}" -eq 0 ]; then
+  echo
+  echo "SCHEMA-ESTRANHO: as $total linha(s) do log são JSON, mas nenhuma tem os campos do sensor"
+  echo "(ts/ramo/trecho/wt). Isto NÃO é 'zero disparos' — é log de outra coisa, ou corrompido."
+  echo "Confira se PIPESTATUS_GUARD_LOG não está apontando para o arquivo errado:"
+  echo "  head -c 300 $LOG"
+  exit 65
+fi
+if [ "$validas" -lt "$total" ]; then
+  echo
+  echo "AVISO: $((total - validas)) de $total linha(s) ignorada(s) — não têm o schema do sensor."
+  echo "Os números abaixo contam só as $validas válida(s)."
+fi
+
+jq -rs '
+  (map(.ts | fromdateiso8601) | sort) as $t
+  | ($t[0]) as $ini | ($t[-1]) as $fim
+  | (($fim - $ini) / 86400) as $dias
+  | "
+Janela observada: \($ini|todateiso8601[0:10]) -> \($fim|todateiso8601[0:10])  (\($dias|floor) dia(s))
+Disparos: \(length)   " + (group_by(.ramo) | map("\(.[0].ramo)=\(length)") | join("   "))
+' "$VALIDO"
+
+echo
+echo "Por dia:"
+jq -rs 'group_by(.ts[0:10]) | .[] | "  \(.[0].ts[0:10])  \("#" * (length | if . > 40 then 40 else . end)) \(length)"' "$VALIDO"
+
+echo
+echo "Worktrees que dispararam:"
+jq -rs 'group_by(.wt) | sort_by(-length) | .[:8][] | "  \(length)x  \(.[0].wt)"' "$VALIDO"
+
+echo
+echo "Padrões DISTINTOS — é isto que só VOCÊ pode classificar (VP = bug real / FP = alarme falso):"
+jq -rs 'group_by(.trecho) | sort_by(-length) | .[:15][] | "  \(length)x  [\(.[0].ramo)]  \(.[0].trecho)"' "$VALIDO"
+
+distintos="$(jq -rs 'group_by(.trecho) | length' "$VALIDO")"
+dias="$(jq -rs '(map(.ts|fromdateiso8601)|sort) as $t | (($t[-1]-$t[0])/86400) | floor' "$VALIDO")"
+
+echo
+echo "O QUE ESTE SENSOR NÃO MEDE (leia antes de concluir qualquer coisa):"
+echo "  - o DENOMINADOR: quantas chamadas Bash passaram pelo guard sem disparar. Registrar isso"
+echo "    exigiria gravar em TODA chamada (dezenas por turno, ~30 worktrees) — caro e ruidoso."
+echo "    Consequência: 'N disparos' é contagem, nunca taxa. Não diga 'dispara pouco'."
+echo "  - a data de INSTALAÇÃO: os dias abaixo vêm do min/max do próprio log, então a janela só"
+echo "    começa a contar no PRIMEIRO disparo. Log recente pode significar guard recente, não"
+echo "    guard silencioso."
+echo "  - as outras máquinas: o log é local. Outro Mac tem outro arquivo."
+echo
+echo "VEREDITO (critério para endurecer o hook de AVISO para deny):"
+marca() { [ "$1" -ge "$2" ] && printf '  [x]' || printf '  [ ]'; }
+marca "$dias" 14;      echo " >= 14 dias de observação      -> hoje: $dias"
+marca "$total" 20;     echo " >= 20 disparos                -> hoje: $total"
+echo "  [?] ZERO falso positivo       -> exige você classificar os $distintos padrão(ões) acima"
+echo
+if [ "$dias" -ge 14 ] && [ "$total" -ge 20 ]; then
+  echo "  => Volume e janela OK. Se os $distintos padrões acima forem TODOS bug real, endurecer é"
+  echo "     defensável. Se QUALQUER um for alarme falso, conserte o detector antes — bloquear com"
+  echo "     falso positivo conhecido é trocar veredito fabricado por trabalho travado."
+else
+  echo "  => Sinal ainda insuficiente para endurecer. Siga avisando e volte aqui depois."
+fi

--- a/scripts/pipestatus-guard-sinal.sh
+++ b/scripts/pipestatus-guard-sinal.sh
@@ -52,7 +52,7 @@ fi
 # Parse OK nao e schema OK. Um JSONL de linhas validas porem SEM os campos do sensor produzia
 # relatorio de "null" com exit 0 — ou seja, ausencia de dado servida como medicao, exatamente o
 # vicio que este sensor existe para nao cometer. Daqui para baixo tudo le a fatia VALIDADA.
-VALIDO="$(mktemp -t pipestatus-sinal)" || { echo "não consegui criar arquivo temporário" >&2; exit 70; }
+VALIDO="$(mktemp "${TMPDIR:-/tmp}/pipestatus-sinal.XXXXXX")" || { echo "não consegui criar arquivo temporário" >&2; exit 70; }
 trap 'rm -f "$VALIDO"' EXIT
 # `try…catch empty` porque o `ts` tem de sobreviver ao `fromdateiso8601` usado nas agregacoes:
 # validar so o TIPO deixaria passar "ontem" e a query morreria la na frente.

--- a/scripts/test-pipestatus-guard-sinal.sh
+++ b/scripts/test-pipestatus-guard-sinal.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# test-pipestatus-guard-sinal.sh — prova do sensor de campo do pipestatus-zsh-guard.
+#
+# Cobre os dois lados: o hook GRAVANDO e o scripts/pipestatus-guard-sinal.sh LENDO.
+# Os invariantes que sustentam o desenho, e que quebram calados se alguém mexer:
+#   - a linha cabe num append atômico (<400 bytes) -> ~30 worktrees escrevem sem lock nem picote;
+#   - segredo que encoste na janela é REDIGIDO antes de tocar o disco;
+#   - falha de log NÃO cala o aviso (o sensor é acessório, o guard é o produto);
+#   - SEM-LOG e LOG-VAZIO são veredictos DIFERENTES — ausência de dado não é aprovação.
+# shellcheck disable=SC2016  # os comandos de teste são strings LITERAIS: expandir destruiria o alvo
+set -u
+
+RAIZ="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK="$RAIZ/.claude/hooks/pipestatus-zsh-guard.sh"
+QUERY="$RAIZ/scripts/pipestatus-guard-sinal.sh"
+command -v jq >/dev/null || { echo "jq é necessário" >&2; exit 1; }
+falhas=0
+ok()    { printf '  ok   %s\n' "$1"; }
+falha() { printf '  FALHA %s — %s\n' "$1" "$2"; falhas=$((falhas + 1)); }
+# helpers com if/else de verdade: `A && ok || falha` roda o falha quando o ok devolve nao-zero
+# (SC2015), e um teste que se auto-reprova por isso e pior que teste nenhum.
+prova()  { if "${@:3}"; then ok "$1"; else falha "$1" "$2"; fi; }   # espera SUCESSO
+nprova() { if "${@:3}"; then falha "$1" "$2"; else ok "$1"; fi; }   # espera FALHA
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+LOG="$TMP/sinal.jsonl"
+
+dispara() { # <comando> [log]
+  PIPESTATUS_GUARD_LOG="${2:-$LOG}" \
+    jq -n -c --arg cmd "$1" '{tool_name:"Bash",tool_input:{command:$cmd}}' \
+    | PIPESTATUS_GUARD_LOG="${2:-$LOG}" bash "$HOOK" 2>/dev/null
+}
+
+echo "== pipestatus-guard-sinal =="
+
+# S1 grava quando dispara
+dispara 'git push | tail -3; echo "EXIT=${PIPESTATUS[0]}"' >/dev/null
+prova "S1 grava ao disparar" "nao gravou" [ "$(wc -l < "$LOG" 2>/dev/null || echo 0)" -eq 1 ]
+
+# S2 NAO grava quando nao dispara (senao o denominador vira ruido)
+dispara 'ls -la' >/dev/null
+prova "S2 silencio nao grava" "gravou sem disparar" [ "$(wc -l < "$LOG")" -eq 1 ]
+
+# S3/S4 redacao ANTES do disco
+dispara 'curl -H "Authorization: Bearer sk-segredo-123" u | jq .; echo ${PIPESTATUS[0]}' >/dev/null
+dispara 'export K=eyJhbGciOiJIUzI1NiJ9.zzzz; a | b; echo ${PIPESTATUS[0]}' >/dev/null
+nprova "S3 Bearer redigido" "Bearer vazou para o disco" command grep -q "sk-segredo-123" "$LOG"
+nprova "S4 JWT redigido" "JWT vazou para o disco" command grep -q "eyJhbGciOiJIUzI1NiJ9" "$LOG"
+
+# S5 toda linha e JSON valido
+prova "S5 JSONL valido" "JSON invalido" jq -e -s "length" "$LOG"
+
+# S6 trecho preenchido (o bug do /regex/ virando 0|1 esvaziava isto em silencio)
+if jq -es 'all(.trecho != "")' "$LOG" >/dev/null 2>&1; then ok "S6 trecho nunca vazio"
+else falha "S6" "trecho vazio: $(jq -rs 'map(select(.trecho==""))|length' "$LOG") linha(s)"; fi
+
+# S7 comando MULTI-LINHA continua UMA linha no log (heredoc nao pode picotar o JSONL)
+multi="$(printf 'cat <<EOF\n${PIPESTATUS[0]}\nEOF\n')"
+antes="$(wc -l < "$LOG")"; dispara "$multi" >/dev/null; depois="$(wc -l < "$LOG")"
+prova "S7 multi-linha vira 1 linha" "gravou $((depois-antes)) linhas" [ $((depois - antes)) -eq 1 ]
+
+# S8 INVARIANTE DE ATOMICIDADE: a linha PRONTA cabe no PIPE_BUF do macOS (512), que e menor que os
+# 4096 do Linux. A versao anterior enchia o comando de `x` e media 176B — dado TIPICO, nao pior caso.
+# O vetor real de estouro e a INFLACAO DO ESCAPE, que acontece DEPOIS do corte do campo: com `jq -a`
+# cada acento vira \uXXXX (6 bytes), e o nome da worktree entra inteiro. Medido antes do teto: 1282B.
+gigante="$(printf 'x%.0s' $(seq 1 900))"
+dispara "echo \"$gigante \${PIPESTATUS[0]} $gigante\"" >/dev/null
+# O vetor que realmente estoura NAO e "comando grande": e MATCH grande. A regex `\$\{[^}]*PIPESTATUS`
+# nao tem limite, entao a janela do awk (RLENGTH+80) cresce junto, e so DEPOIS o escape infla — cada
+# byte de controle vira \u00XX (6 bytes) no `jq -a`. Medido sem teto: 1010B; com teto: 290B.
+# Acento nao serve de vetor: para com 414B por si so, e o teste passaria sem o teto (falso verde).
+lixo="$(awk 'BEGIN { s = ""; for (i = 0; i < 300; i++) s = s "\001"; print s }')"
+VETOR="echo \${${lixo}PIPESTATUS[0]}"
+DIRLONGO="$TMP/$(printf "l%.0s" $(seq 1 200))"   # nome de worktree longo entra na mesma linha
+mkdir -p "$DIRLONGO"
+( cd "$DIRLONGO" && dispara "$VETOR" ) >/dev/null
+maior="$(awk '{ if (length > m) m = length } END { print m+1 }' "$LOG")"
+prova "S8 maior linha ${maior}B (<512 = PIPE_BUF do macOS, append atomico)" \
+      "linha de ${maior}B pode picotar sob concorrencia entre worktrees" \
+      [ "$maior" -lt 512 ]
+prova "S8b linha inflada continua JSON valido (corte multibyte sanitizado)" "JSON quebrado" \
+      jq -e -s 'length > 0' "$LOG"
+
+# S8c PERMISSAO: o log guarda FRAGMENTO DE COMANDO. World-readable (0644) era o default herdado do
+# umask, e ninguem tinha medido — o Codex mediu.
+prova "S8c log nasce 0600" "log criado como $(stat -f '%Sp' "$LOG" 2>/dev/null) — legivel por outros" \
+      [ "$(stat -f '%Sp' "$LOG" 2>/dev/null)" = "-rw-------" ]
+
+# S9 FAIL-OPEN: log impossivel de escrever NAO pode calar o aviso
+saida="$(dispara 'x | y; echo ${PIPESTATUS[0]}' "/dev/null/impossivel/x.jsonl")"
+if printf '%s' "$saida" | jq -e '.hookSpecificOutput.additionalContext' >/dev/null 2>&1; then
+  ok "S9 log quebrado nao cala o aviso"
+else falha "S9" "o guard emudeceu porque o log falhou"; fi
+
+# ── a QUERY ────────────────────────────────────────────────────────────────────────────────────
+# S10 SEM-LOG: ausencia de dado NAO e aprovacao (exit 3, marcador proprio)
+s="$(bash "$QUERY" "$TMP/nao-existe.jsonl" 2>&1)"; rc=$?
+if [ "$rc" -eq 3 ] && printf '%s' "$s" | command grep -q "SEM-LOG"; then ok "S10 SEM-LOG (exit 3)"
+else falha "S10" "rc=$rc / faltou marcador SEM-LOG"; fi
+# e NAO pode sugerir que da para endurecer
+if printf '%s' "$s" | command grep -q "não dá para decidir"; then ok "S10b SEM-LOG nao aprova endurecer"
+else falha "S10b" "SEM-LOG nao desaconselha endurecer"; fi
+
+# S11 LOG-VAZIO e um veredito DIFERENTE de SEM-LOG
+: > "$TMP/vazio.jsonl"
+s="$(bash "$QUERY" "$TMP/vazio.jsonl" 2>&1)"
+if printf '%s' "$s" | command grep -q "LOG-VAZIO"; then ok "S11 LOG-VAZIO distinto de SEM-LOG"
+else falha "S11" "nao distinguiu log vazio de log ausente"; fi
+
+# S12 com dados: conta e agrupa
+cat > "$TMP/cheio.jsonl" <<'JSONL'
+{"ts":"2026-08-01T10:00:00Z","ramo":"BASHISM","trecho":"echo ${PIPESTATUS[0]}","wt":"wt-a"}
+{"ts":"2026-08-02T10:00:00Z","ramo":"BASHISM","trecho":"echo ${PIPESTATUS[0]}","wt":"wt-a"}
+{"ts":"2026-08-03T10:00:00Z","ramo":"INDICE-ZERO","trecho":"rc=${pipestatus[0]}","wt":"wt-b"}
+JSONL
+s="$(bash "$QUERY" "$TMP/cheio.jsonl" 2>&1)"
+if printf '%s' "$s" | command grep -q "Disparos: 3"; then ok "S12 total correto"
+else falha "S12" "total errado"; fi
+if printf '%s' "$s" | command grep -q "BASHISM=2"; then ok "S12b agrupa por ramo"
+else falha "S12b" "ramo errado"; fi
+if printf '%s' "$s" | command grep -q "2x"; then ok "S12c agrupa padroes iguais"
+else falha "S12c" "nao agrupou"; fi
+if printf '%s' "$s" | command grep -q "insuficiente para endurecer"; then ok "S12d 3 disparos nao autorizam"
+else falha "S12d" "aprovou endurecer com 3 disparos"; fi
+
+
+# S13 SCHEMA vs PARSE: JSONL de linhas VALIDAS porem sem os campos do sensor produzia relatorio de
+# "null" com exit 0 — ausencia de dado servida como medicao, o vicio que este sensor combate.
+outro="$TMP/outro-log.jsonl"
+printf '%s\n' '{"foo":1}' '{"bar":"x"}' > "$outro"
+s="$(PIPESTATUS_GUARD_LOG="$outro" bash "$QUERY" 2>&1)"; rc=$?
+prova "S13 schema estranho nao sai 0" "saiu rc=$rc — indistinguivel de relatorio bom" [ "$rc" -eq 65 ]
+if printf '%s' "$s" | command grep -q "SCHEMA-ESTRANHO"; then ok "S13b nomeia o problema"
+else falha "S13b" "nao explicou por que nao ha relatorio"; fi
+nprova "S13c nao imprime null como se fosse dado" "vazou 'null' no relatorio" \
+       sh -c 'printf "%s" "$1" | command grep -q null' _ "$s"
+
+# S14 MISTO: linha estranha no meio nao pode contaminar a contagem — nem calar o relatorio.
+misto="$TMP/misto.jsonl"
+printf '%s\n' '{"ts":"2026-08-20T10:00:00Z","ramo":"BASHISM","trecho":"a","wt":"w1"}' '{"foo":1}' > "$misto"
+s="$(PIPESTATUS_GUARD_LOG="$misto" bash "$QUERY" 2>&1)"
+if printf '%s' "$s" | command grep -q "1 de 2 linha(s) ignorada"; then ok "S14 declara o que ignorou"
+else falha "S14" "ignorou linha em silencio"; fi
+if printf '%s' "$s" | command grep -q "Disparos: 1"; then ok "S14b conta so as validas"
+else falha "S14b" "contagem incluiu linha invalida"; fi
+
+# S15 ts INVALIDO: string, mas nao e data. Passa em checagem de TIPO e mata a agregacao la na frente.
+datar="$TMP/data-ruim.jsonl"
+printf '%s\n' '{"ts":"ontem","ramo":"BASHISM","trecho":"a","wt":"w1"}' > "$datar"
+s="$(PIPESTATUS_GUARD_LOG="$datar" bash "$QUERY" 2>&1)"; rc=$?
+prova "S15 ts nao-parseavel e linha invalida" "rc=$rc — a query aceitou data que quebra o agregado" \
+      [ "$rc" -eq 65 ]
+
+# ── FALSIFICAÇÃO ───────────────────────────────────────────────────────────────────────────────
+# Sabota a redacao. Se S3 continuar verde, e porque nunca dependeu dela.
+echo "-- falsificacao: remove a redacao de segredo --"
+BKP="$(mktemp)"; cp "$HOOK" "$BKP"
+restaura() { [ -f "$BKP" ] && cp "$BKP" "$HOOK"; rm -f "$BKP"; }   # idempotente: roda aqui E no trap
+trap 'restaura; rm -rf "$TMP"' EXIT
+perl -0pi -e 's/\[Bb\]earer/ZZnuncacasaZZ/' "$HOOK"
+if cmp -s "$BKP" "$HOOK"; then falha "falsificacao" "a sabotagem NAO alterou o hook — seria teatro"
+else
+  LOGF="$TMP/falso.jsonl"
+  dispara 'curl -H "Authorization: Bearer sk-segredo-123" u | jq .; echo ${PIPESTATUS[0]}' "$LOGF" >/dev/null
+  if command grep -q "sk-segredo-123" "$LOGF" 2>/dev/null; then ok "sabotagem ficou VERMELHA (a redacao e mesmo o que protege)"
+  else falha "falsificacao" "segredo continuou redigido sem a redacao — S3 nao prova nada"; fi
+fi
+restaura
+
+
+# Sabota o TETO. Se S8 continuar verde, e porque o laco de encolhimento nunca foi o que o segurava
+# — foi sorte do dado de teste, que era exatamente o erro da versao anterior.
+echo "-- falsificacao 2: desliga o teto de bytes --"
+BKP2="$(mktemp)"; cp "$HOOK" "$BKP2"
+perl -0pi -e 's/^TETO_LINHA=511/TETO_LINHA=99999/m' "$HOOK"
+if cmp -s "$BKP2" "$HOOK"; then falha "falsificacao2" "a sabotagem NAO alterou o hook — seria teatro"
+else
+  LOGT="$TMP/teto-falso.jsonl"
+  DL2="$TMP/f2"; mkdir -p "$DL2"
+  ( cd "$DL2" && dispara "$VETOR" "$LOGT" ) >/dev/null
+  m2="$(awk '{ if (length > m) m = length } END { print m+1 }' "$LOGT")"
+  if [ "${m2:-0}" -ge 512 ]; then ok "sabotagem ficou VERMELHA (${m2}B — o teto e mesmo o que segura)"
+  else falha "falsificacao2" "linha ficou em ${m2}B sem teto — S8 nao prova nada"; fi
+fi
+cp "$BKP2" "$HOOK"; rm -f "$BKP2"
+
+echo
+if [ "$falhas" -eq 0 ]; then echo "PIPESTATUS-SINAL: TODOS OS TESTES PASSARAM"; exit 0; fi
+echo "PIPESTATUS-SINAL: $falhas FALHA(S)"; exit 1

--- a/scripts/test-pipestatus-guard-sinal.sh
+++ b/scripts/test-pipestatus-guard-sinal.sh
@@ -83,8 +83,9 @@ prova "S8b linha inflada continua JSON valido (corte multibyte sanitizado)" "JSO
 
 # S8c PERMISSAO: o log guarda FRAGMENTO DE COMANDO. World-readable (0644) era o default herdado do
 # umask, e ninguem tinha medido — o Codex mediu.
-prova "S8c log nasce 0600" "log criado como $(stat -f '%Sp' "$LOG" 2>/dev/null) — legivel por outros" \
-      [ "$(stat -f '%Sp' "$LOG" 2>/dev/null)" = "-rw-------" ]
+# shellcheck disable=SC2012  # SC2012 alerta sobre parsear NOME de arquivo; aqui so leio o modo
+perm="$(ls -l "$LOG" 2>/dev/null | cut -c1-10)"   # stat -f e BSD; no GNU o -f e FILE SYSTEM, imprime outra coisa e sai 0
+prova "S8c log nasce 0600" "log criado como ${perm:-?}" [ "$perm" = "-rw-------" ]
 
 # S9 FAIL-OPEN: log impossivel de escrever NAO pode calar o aviso
 saida="$(dispara 'x | y; echo ${PIPESTATUS[0]}' "/dev/null/impossivel/x.jsonl")"


### PR DESCRIPTION
O hook do #1931 avisa e promete *"endurecer para `deny` quando houver dado"*. A promessa era **inalcançável por construção**: o aviso vai para o contexto e evapora, e ninguém conseguia responder *"quantas vezes disparou, e em quê"* (`docs/historico/fase-sem-sinal.md` — superfície de uso nasce COM o sensor).

Agora o hook grava JSONL **fora do repo** (`~/.claude/afiacao-pipestatus-guard.jsonl`; ~30 worktrees, log versionado vira ímã de conflito) e `scripts/pipestatus-guard-sinal.sh` é a **query** — log sem query não é sensor, é lixo.

## Segunda rodada de `/codex` defensivo, agora sobre o SENSOR

Três achados. Todos reproduzidos por medição própria **antes** de virar código.

**1. Truncar o CAMPO não limita a LINHA.** Eu cortava o trecho em 160 e media 176 bytes — dado *típico*. O escape do JSON infla **depois** do corte: cada `"` vira `\"`, cada byte de controle vira `\u00XX` (6 bytes).

| | bytes |
|---|---|
| medido antes, dado típico | 176 |
| pior caso real | **1010** |
| `PIPE_BUF` do macOS (`getconf PIPE_BUF /`) | **512** — não os 4096 do Linux |

Acima do `PIPE_BUF` o append concorrente entre worktrees pode picotar a linha e envenenar a query. O teto passou a ser conferido na **linha pronta**, num laço que encolhe o trecho até caber; `jq -a` força saída ASCII para `${#linha}` contar bytes em qualquer locale, sem fork de `wc`.

**2. Parse OK não é schema OK.** JSONL de linhas válidas sem os campos do sensor produzia relatório de `null` com **exit 0** — ausência de dado servida como medição, exatamente o vício que este sensor existe para não cometer. Agora: `SCHEMA-ESTRANHO` (exit 65), log misto declara quantas linhas ignorou, e `ts` que não sobrevive ao `fromdateiso8601` é linha inválida (validar só o TIPO deixaria passar `"ontem"` e a agregação morreria adiante).

**3. Log de fragmento de comando nascia 0644**, herdado do umask, nunca medido. Nasce 0600, e o `chmod` conserta o legado — confirmado em campo: o log desta máquina já migrou de `-rw-r--r--` para `-rw-------`.

## A lição de método veio da falsificação, não do Codex

**O caso de teste pode não exercitar o invariante que o teste afirma provar.** Sabotei o teto e o teste seguiu **VERDE** — porque eu enchia o comando de acentos, que param em 414 bytes sozinhos. O vetor real era **match grande, não comando grande**: `\$\{[^}]*PIPESTATUS` não tem limite, então a janela de contexto cresce junto com ele. Sem falsificar, eu teria entregue um teste que passa com e sem o código que ele testa.

## Validação

| gate | resultado |
|---|---|
| `bash scripts/test-pipestatus-guard-sinal.sh` | 26 asserções, `exit 0` |
| `bash scripts/test-pipestatus-zsh-guard.sh` | 75 asserções, `exit 0` (sem regressão) |
| `shellcheck scripts/*.sh .claude/hooks/*.sh` | `exit 0` |
| falsificação 1 (desliga a redação de segredo) | fica **vermelha** |
| falsificação 2 (desliga o teto de bytes) | fica **vermelha** (994 B) |

## Ressalvas

- **O log atual é 100% contaminação do desenvolvimento** — 38 linhas, todas da worktree onde isto foi escrito. Para a contagem começar limpa: `: > ~/.claude/afiacao-pipestatus-guard.jsonl`
- **Merge não põe em vigor nas sessões já abertas**: `settings.json` é lido na inicialização.
- O sensor **não mede o denominador** (quantas chamadas Bash passaram sem disparar). A query diz isso em voz alta na seção "O QUE ESTE SENSOR NÃO MEDE" — `N disparos` é contagem, nunca taxa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
