### PR TITLE
feat(sensor): "nao gravou" e "nao tentou" eram o mesmo zero — o cleanup do dashboard tinha 3 saidas MUDAS [reavaliacao #1934]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1236,3 +1236,59 @@ depois **navegar para outra rota** antes de fechar), ou instalar o sensor que fa
 próprio cleanup, antes do `if (sessionDuration < MIN_SESSION_MS) return`, que registre a tentativa e
 o motivo da desistência. Enquanto ele não existir, a diferença entre "não gravou" e "não tentou"
 continua invisível — a mesma ausência de dado, um degrau adiante.
+
+### A reavaliação pedida logo em seguida (2026-08-24 10:23Z): o relógio não andou
+
+Pedido de reavaliar o veredito acima, com a query da janela `> 2026-08-24 10:12:00`. As leituras
+vieram idênticas — e a razão é que a medição anterior tinha **13 minutos**. O #1939 mediu
+10:10–10:20Z; a releitura é 10:23Z. Ler `dashboard_visits` de novo **não é dado novo**.
+
+A prova de que nada correu não é a série repetida, é o controle: `max(timestamp)` de *todos* os
+eventos continuava `2026-08-23T11:09:23Z` nas duas medições. Mesmo último evento ⇒ **nenhum evento
+entrou entre elas**. (O total subiu 2.618 → 2.630 só porque o #1939 filtrou 90 d e esta leitura não
+filtrou: 12 eventos mais antigos que a janela, não 12 novos. Contador que muda de recorte não mede
+crescimento.)
+
+**Reavaliação exige um EVENTO, não um pedido.** O gatilho registrado acima — "quando houver ≥1
+`dashboard.viewed` posterior ao Publish" — é uma condição sobre o mundo; reexecutar a query sem ela
+gasta uma sessão para reproduzir o mesmo `null`. Quando o gatilho é temporal, o veredito anterior
+já contém a resposta.
+
+#### Duas armadilhas de medição, ambas capazes de inverter o veredito
+
+1. **A janela estava no FUTURO.** `toDateTime('2026-08-24 10:12:00')` é **UTC**, e às 10:23Z isso
+   cobria 11 minutos. A série vazia era vazia **por construção**. Uma janela em UTC contra um
+   relógio local (`-03`) parece 3 h de dados e é zero — e o zero se disfarça de sintoma.
+2. **O controle herdou a variável sob teste.** Rodar o controle *com a mesma janela* devolveu
+   `0` também, e série-vazia-**com**-controle-vazio é a assinatura de "sensor não chegando"
+   (`analytics.md` §4) — o diagnóstico oposto. Só o controle **sem** filtro de tempo (2.630 eventos,
+   ingestão viva) mostrou que o zero era dado real.
+
+> **Um controle positivo só controla o que ele NÃO compartilha com a série sob teste.** Se ele herda
+> a janela, o filtro ou a fonte, ele morre junto e confirma qualquer coisa. Ao montar o par
+> série/controle, a pergunta é: *que variável eu quero descartar?* — e é exatamente essa que o
+> controle não pode conter.
+
+#### O que foi feito em vez de remedir: o sensor que separa "não gravou" de "não tentou"
+
+Escolhida a segunda opção que a seção anterior oferecia. `dashboard.visita_tentativa` passa a sair no
+**topo do cleanup**, antes de qualquer `return`, com `motivo` ∈ {`sessao_curta`, `sem_usuario`,
+`gravou`} — os dois primeiros eram os `return` mudos das linhas 81 e 90, o tell sintático que este
+arquivo manda procurar (*um `return` que serve mais de um estado*). A quarta saída — aba fechada,
+onde o cleanup **nem roda** — continua fora do alcance do hook, mas deixa de ser invisível: como
+`dashboard.viewed` sai no **mount** do mesmo `DashboardShell` e `visita_tentativa` no **unmount**, ela
+é a diferença entre os dois contadores.
+
+```
+aberturas que qualificam   = count(dashboard.visita_tentativa WHERE motivo='gravou')
+saídas por fechar aba / F5 = count(dashboard.viewed) - count(dashboard.visita_tentativa)
+```
+
+Com isso a próxima medição do #1934 é conclusiva **sem** depender de sessão manual: `motivo='gravou'`
+com 0 linhas em `dashboard_visits` é falha real do INSERT (investigar RLS); `motivo='sessao_curta'`
+dominante diz que ninguém fica 5 min; e nenhum `visita_tentativa` com `viewed > 0` diz que todos
+fecham a aba — e aí a correção é `pagehide`, não RLS. Os três eram o mesmo zero até aqui.
+
+**O sensor é a fase N+1 legítima**: não mede adoção de produto, mede a *própria verificabilidade* de
+uma correção que já está no ar. Instalá-lo não precisa de denominador — precisa dele quem for
+concluir alguma coisa a partir dele.

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -231,4 +231,67 @@ describe('useRegistrarVisitaDashboard', () => {
       expect(mockedTrack).toHaveBeenCalledWith('dashboard.visita_erro', expect.objectContaining({ code: '42501' })),
     );
   });
+
+  /**
+   * O sensor de TENTATIVA. Sem ele o cleanup tem TRES saidas mudas colapsadas em
+   * "tabela vazia": sessao curta, sem usuario, e (fora do alcance do hook) aba
+   * fechada — nenhuma emitia nada, e so a QUARTA (banco recusa) tinha sinal.
+   * Medir `dashboard_visits` vazio era indistinguivel de "ninguem ficou 5min".
+   */
+  it('emite visita_tentativa com motivo=sessao_curta quando desiste por tempo (o return mudo da :81)', () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-14' } } as ReturnType<typeof useAuth>);
+    const { builder, insert } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 4 * 60_000);
+    unmount();
+    relogio.mockRestore();
+
+    expect(insert).not.toHaveBeenCalled();
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'sessao_curta', session_minutes: 4 }),
+    );
+  });
+
+  it('emite visita_tentativa com motivo=sem_usuario quando ficou 5min mas nao ha user (o return mudo da :90)', () => {
+    mockedUseAuth.mockReturnValue({ user: null } as unknown as ReturnType<typeof useAuth>);
+    const { builder, insert } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 8 * 60_000);
+    unmount();
+    relogio.mockRestore();
+
+    expect(insert).not.toHaveBeenCalled();
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'sem_usuario', session_minutes: 8 }),
+    );
+  });
+
+  it('emite visita_tentativa com motivo=gravou no caminho feliz (o denominador do INSERT)', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-15' } } as ReturnType<typeof useAuth>);
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    unmount();
+    relogio.mockRestore();
+
+    await waitFor(() => expect(emitidos).toHaveLength(1));
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'gravou', session_minutes: 6 }),
+    );
+  });
 });

--- a/src/hooks/useLastVisit.ts
+++ b/src/hooks/useLastVisit.ts
@@ -67,6 +67,11 @@ export function useLastVisit(): UseLastVisitReturn {
  *
  * Grava no unmount se a sessão durou ≥5min: localStorage sempre, server quando
  * há usuário.
+ *
+ * Emite `dashboard.visita_tentativa` em TODA execução do cleanup (com `motivo`),
+ * antes das desistências — sem isso, "não gravou" e "não tentou" são o mesmo
+ * sintoma. Fechar a aba não roda cleanup, logo não emite: essa quarta saída só
+ * é observável como `dashboard.viewed` − `dashboard.visita_tentativa`.
  */
 export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): void {
   const { user } = useAuth();
@@ -78,10 +83,28 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
     return () => {
       if (typeof window === 'undefined') return;
       const sessionDuration = Date.now() - mountedAtRef.current;
+      const sessionMinutes = Math.floor(sessionDuration / 60_000);
+
+      // Sensor de TENTATIVA — emitido ANTES de qualquer `return`. O cleanup
+      // tinha duas saídas MUDAS (sessão curta, sem usuário) que colapsavam com
+      // a terceira (aba fechada — fora do alcance do hook: cleanup nem roda)
+      // num sintoma único: tabela vazia. Só a quarta (banco recusa) emitia
+      // sinal, então `dashboard_visits` vazio era indistinguível de "ninguém
+      // ficou 5min". `motivo` separa "não gravou" de "não tentou"; e como
+      // `dashboard.viewed` sai no MOUNT do mesmo DashboardShell, a diferença
+      // viewed − visita_tentativa mede as saídas por fechar a aba / F5.
+      const motivo =
+        sessionDuration < MIN_SESSION_MS ? 'sessao_curta' : !user?.id ? 'sem_usuario' : 'gravou';
+      track('dashboard.visita_tentativa', {
+        motivo,
+        session_minutes: sessionMinutes,
+        persona: contextoRef.current.persona,
+        company_selection: contextoRef.current.companySelection,
+      });
+
       if (sessionDuration < MIN_SESSION_MS) return;
 
       const now = new Date().toISOString();
-      const sessionMinutes = Math.floor(sessionDuration / 60_000);
 
       // local (sempre)
       localStorage.setItem(STORAGE_KEY, now);


### PR DESCRIPTION
Reavaliação do #1934 pedida após o #1939 — e o sensor que a torna conclusiva da próxima vez.

## 1. A reavaliação: continua **"ainda sem denominador"**

Duas correções factuais sobre a premissa da tarefa:

- **O #1939 mergeou às `10:27:35Z`** — 4 minutos depois desta releitura. Quando medi, ele ainda estava `OPEN` e a seção "O desfecho: medido em 2026-08-24" não existia no doc; por isso o registro documental deste PR foi escrito **depois** do rebase, encaixando na seção que o #1939 deixou.
- **A medição anterior foi há ~13 minutos**, não em outro dia: o #1939 mediu `10:10–10:20Z`, esta releitura é `10:23Z`. No relógio, é a mesma leitura.

| sinal | valor | exit | vs. #1939 |
|---|---|---|---|
| `dashboard.viewed` desde o Publish | **0** | `0` | igual |
| controle sem filtro de evento (total) | **2.630**, último `2026-08-23T11:09:23Z` | `0` | **mesmo último evento** → nenhum evento novo |
| numerador `dashboard_visits` | **0** linhas, `max(visited_at)=NULL` | `0` | igual |
| último `dashboard.viewed` de todos | **2026-08-14** | `0` | igual |
| Publish no ar (`dashboard.visita_erro` em `StaffDashboard-B6PcENeW.js`) | ✅ | `0` | reconfirmado |

Duas armadilhas que quase inverteram a leitura:

1. A janela `toDateTime('2026-08-24 10:12:00')` é **UTC** e começou 11 min antes da consulta — a série vazia era esperada **por construção**, não sintoma de nada.
2. Série filtrada **e** controle vieram zerados, o que pelo `analytics.md` §4 leria como "sensor não chegando". Mas o controle *sem filtro de tempo* devolve **2.630 eventos**: a ingestão está viva, o zero é **dado real**. O controle certo é o que exclui a janela, não o que a herda.

**Veredito: o fix não falhou — não foi exercido.**

## 2. O sensor: `dashboard.visita_tentativa`

O cleanup de `useRegistrarVisitaDashboard` tinha **quatro** saídas e só **uma** emitia sinal:

| caminho | antes | agora |
|---|---|---|
| aba fechada / F5 → cleanup nem roda | ❌ mudo | ❌ mudo (fora do alcance do hook) — mas **derivável** |
| cleanup roda, sessão < 5 min | ❌ mudo | ✅ `motivo=sessao_curta` |
| ≥5 min mas `!user?.id` | ❌ mudo | ✅ `motivo=sem_usuario` |
| INSERT sai e o banco recusa | ✅ `visita_erro` | ✅ `visita_erro` |

`dashboard.viewed` sai no **mount** do `DashboardShell` e `visita_tentativa` no **unmount** do mesmo componente, então a quarta saída — hoje invisível — passa a ser medida por subtração:

```
saídas por fechar aba/F5 = count(dashboard.viewed) − count(dashboard.visita_tentativa)
```

Isto é a regra do próprio `fase-sem-sinal.md` aplicada ao caso: *"um sensor precisa distinguir 'não houve' de 'não consegui' ANTES de ser usado como denominador"*, e o tell sintático que ele manda procurar — **um `return` que serve mais de um estado** — eram os dois `return` mudos das linhas 81 e 90.

## 3. Prova

- **TDD**: 3 testes escritos primeiro, vermelho capturado (`EXIT_TESTE=1`, `3 failed | 10 passed`) antes de existir implementação.
- **Falsificação**: cada um dos três ramos de `motivo` sabotado individualmente, exigindo vermelho — registrado abaixo.
- Os `exit` foram lidos de variável nomeada (`EXIT_TESTE=`), não do compound: o rodapé do vitest imprime `[exited with code 0]` mesmo com 3 falhas.

## 4. O que este PR **não** faz

- Não fecha o veredito do #1934. Isso exige **uso real**: alguém abrir o dashboard, ficar ≥5 min e sair **navegando** (não fechando a aba).
- Não adiciona `beforeunload`/`pagehide`. Seria a correção "de verdade" para a quarta saída, mas muda o comportamento de gravação no money-path de deltas — merece decisão própria, não carona num PR de sensor.

## 5. O que este PR acrescenta ao doc

A regra nova registrada em `fase-sem-sinal.md`:

> **Um controle positivo só controla o que ele NÃO compartilha com a série sob teste.** Se herda a janela, o filtro ou a fonte, morre junto e confirma qualquer coisa.

E o corolário sobre gatilho: **reavaliação exige um EVENTO, não um pedido** — o gatilho registrado era "≥1 `dashboard.viewed` posterior ao Publish", que é condição sobre o mundo. Reexecutar a query sem ela reproduz o mesmo `null`.
