### PR TITLE
feat(sonda): a monthly-report escapava do grep do helper — e sondá-la às cegas MANDA e-mail pra base (#1889)

### DIFF
--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -42,6 +42,7 @@ import * as scoringBatch from "../scoring-recalc-batch/versao.ts";
 import * as syncReprocess from "../sync-reprocess/versao.ts";
 import * as tacticalBatch from "../tactical-plans-batch/versao.ts";
 import * as visitBatch from "../visit-score-recalc-batch/versao.ts";
+import * as monthlyReport from "../monthly-report/versao.ts";
 
 /**
  * `respostaSonda` (a maioria) ou `respostaSondaTactical` (a `generate-tactical-plan`, que embrulha o
@@ -124,6 +125,14 @@ const EDGES: Array<{ nome: string; mod: ModSonda }> = [
   { nome: "scoring-recalc-batch", mod: scoringBatch },
   { nome: "visit-score-recalc-batch", mod: visitBatch },
   { nome: "tactical-plans-batch", mod: tacticalBatch },
+  // Nona leva (#1889 paginação, parte 4): a edge que o `git grep -l` do helper NÃO enxergava.
+  // Separada da oitava de propósito — aquelas eram edges SEM sensor; esta estava fora da própria
+  // ENUMERAÇÃO. `monthly-report` chega ao `paginate.ts` por um salto (`_shared/relatorio-mensal.ts`),
+  // então nunca aparecia na lista de "quem serve o helper" — a relação é de grafo, o grep é local
+  // (docs/historico/enumerar-consumidores-de-helper.md). Entra pelo critério mais duro da lista:
+  // o bundle VELHO ignorando `probe` não erra um número, ele ENVIA e-mail para a base inteira,
+  // porque os defaults do corpo armam o envio por omissão. Ver `monthly-report/versao.ts`.
+  { nome: "monthly-report", mod: monthlyReport },
 ];
 
 /** As cinco da terceira leva — os gates estruturais abaixo varrem todas. */
@@ -180,6 +189,11 @@ const FORMA_NORMALIZADA = [
   // existem para impedir. Confirma a regra do bloco acima: a FORMA não tem a ver com escrever.
   "analyze-unified-order",
   ...FAN_OUT_QUE_ESCREVE,
+  // Nona leva: entra na varredura estrutural pelo mesmo motivo da sétima — o preço de um `probe`
+  // mal grafado caindo no fluxo real. Aqui ele é o mais alto de todos (e-mail a clientes reais,
+  // que não se desfaz). Fica FORA de GATE_PROPRIO de propósito: o gate dela é
+  // `authorizeCronOrStaff`, que já aceita o `x-cron-secret` do SQL Editor.
+  "monthly-report",
 ];
 
 /**

--- a/supabase/functions/monthly-report/index.ts
+++ b/supabase/functions/monthly-report/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "npm:@supabase/supabase-js@2";
 import { authorizeCronOrStaff } from "../_shared/auth.ts";
+import { classificarSonda, EFEITO, erroSondaAmbigua, respostaSonda, VERSAO } from "./versao.ts";
 import {
   type BancoPostgrest,
   montarRelatorios,
@@ -233,6 +234,25 @@ Deno.serve(async (req) => {
   const auth = await authorizeCronOrStaff(req);
   if (!auth.ok) return auth.response;
 
+  // Sonda de versão — ANTES do createClient, para continuar sendo o único caminho sem custo.
+  // Ver versao.ts / _shared/sonda-versao.ts. O gate acima já aceita `x-cron-secret`, que é como o
+  // founder invoca do SQL Editor, então a sonda não precisa de gate próprio.
+  // O corpo é lido AQUI e reaproveitado pelo fluxo real abaixo: `req.json()` consome o stream uma
+  // única vez, e reler devolveria "body already consumed" — o que quebraria o cron, não a sonda.
+  const corpoBruto = await req.json().catch(() => ({}));
+  const decisaoSonda = classificarSonda(corpoBruto);
+  if (decisaoSonda.tipo === 'sonda') {
+    return new Response(JSON.stringify(respostaSonda(VERSAO)), {
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+    });
+  }
+  if (decisaoSonda.tipo === 'ambiguo') {
+    return new Response(
+      JSON.stringify({ error: erroSondaAmbigua(decisaoSonda.valor, EFEITO) }),
+      { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+    );
+  }
+
   try {
 
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
@@ -241,7 +261,7 @@ Deno.serve(async (req) => {
 
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    const body = await req.json().catch(() => ({}));
+    const body = corpoBruto;
     const targetUserId = body.user_id;
     const sendEmail = body.send_email !== false;
     const previewOnly = body.preview_only === true;

--- a/supabase/functions/monthly-report/versao.ts
+++ b/supabase/functions/monthly-report/versao.ts
@@ -1,0 +1,38 @@
+// Marcador de versão da edge `monthly-report`.
+// Classificador da sonda (money-path, compartilhado): `_shared/sonda-versao.ts`.
+//
+// POR QUE ESTA EDGE ENTRA — ela não cita `_shared/paginate.ts` em lugar nenhum. Chega ao helper por
+// UM salto (`_shared/relatorio-mensal.ts`, que importa `fetchAll`), e por isso o
+// `git grep -l "_shared/paginate.ts"` a perdia: a relação é de GRAFO e o grep é local. Ver
+// `docs/historico/enumerar-consumidores-de-helper.md`. O bundle carrega o helper do mesmo jeito.
+//
+// ⚠️ EFEITO DO BUNDLE VELHO IGNORANDO `probe` — é o pior desta leva, e é o que trava a ORDEM.
+// Um bundle pré-sonda não conhece a chave `probe`: ele segue para o fluxo real e lê o corpo como
+// pedido de relatório. Os defaults conspiram, cada um sozinho razoável:
+//   `targetUserId = body.user_id`            -> undefined  => TODA a base (5.276 perfis), não um
+//   `sendEmail   = body.send_email !== false`-> TRUE       => envio ARMADO por omissão
+//   `previewOnly = body.preview_only === true`-> false      => nada segura
+// ou seja, `{"probe":true}` num bundle velho dispara o relatório mensal por e-mail para a base
+// inteira, fora de época, via `fetch` real na Resend. E-mail enviado não volta: não é número
+// errado que se recalcula, é mensagem que chegou no cliente. Daí a regra desta edge ser
+// ORDEM, não higiene: **deploy primeiro, sonda depois** — nunca sondar às cegas para "ver se subiu".
+//
+// ⚠️ O sensor só prova versões A PARTIR DE SI MESMO: um bundle anterior a este PR não responde
+// `probe:true`. Ausência do eco = bundle pré-sensor — e ele executou o envio.
+
+export { classificarSonda, erroSondaAmbigua } from "../_shared/sonda-versao.ts";
+import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
+
+/** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
+export const respostaSonda = criarRespostaSonda("monthly-report");
+
+/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
+export const VERSAO = "v1.0-sensor-inicial";
+
+/** Efeito caro citado no 400 de `probe` ambíguo. */
+export const EFEITO =
+  "esta edge ENVIA o relatório mensal por e-mail aos clientes via Resend (fetch real na " +
+  "api.resend.com), e os defaults do corpo armam o envio por OMISSÃO: sem `user_id` o alvo é a " +
+  "base inteira (5.276 perfis) e `send_email` ausente vale TRUE, então um `probe` mal grafado " +
+  "não erra um número — manda e-mail fora de época para todo cliente com endereço, e mensagem " +
+  "entregue não se desfaz";


### PR DESCRIPTION
## O que

Instala a sonda de versão na `monthly-report` — a última edge do #1889 que **nenhuma enumeração por caminho encontrava**, e a de maior custo se sondada às cegas.

## Por que ela escapava

`monthly-report` não cita `_shared/paginate.ts` em lugar nenhum. Chega ao helper por um salto — `_shared/relatorio-mensal.ts`, que importa `fetchAll`. `git grep -l` é local; a relação é de **grafo**. O fechamento transitivo de imports de VALOR devolve 20 edges servindo o helper, e essa é uma delas (`docs/historico/enumerar-consumidores-de-helper.md`).

Sem sensor ela era inverificável: o #1889 é no-op **por desenho** enquanto o `max-rows` de prod for 1000, então nenhuma canária de comportamento distingue bundle novo de velho — só o marcador prova (`docs/historico/deploy-no-op-por-desenho.md`).

## A medição que trava a ORDEM

O custo do bundle **VELHO** ignorando `probe` (medido no código, não deduzido): três defaults, cada um razoável sozinho, conspiram.

```
targetUserId = body.user_id              -> undefined => TODA a base (5.276 perfis)
sendEmail    = body.send_email !== false -> TRUE      => envio ARMADO por omissão
previewOnly  = body.preview_only === true-> false     => nada segura
```

`{"probe":true}` num bundle pré-sonda **dispara o relatório mensal por e-mail para a base inteira**, fora de época, por `fetch` real na Resend. E-mail entregue não se recalcula. Aqui "deploy primeiro, sonda depois" é contenção, não higiene.

## Detalhe que o padrão não cobria

O fluxo real já lia o corpo. `req.json()` consome o stream uma única vez — a sonda lê ANTES (como o gate estrutural exige) e o fluxo real **reusa a variável**; reler devolveria `body already consumed` e quebraria o **cron**, não a sonda.

## Falsificação (verde sozinho não provava cobertura da edge nova)

O gate passava 27/27 antes — pelas edges antigas (23 minhas + as 4 que o #1937 trouxe). Três sabotagens, cada uma exigindo vermelho que **nomeia** a edge:

| sabotagem | exit | vermelho |
|---|---|---|
| apagar a chamada a `respostaSonda` | 1 | `monthly-report: classifica a sonda mas nunca chama respostaSonda — o diagnóstico não sai` |
| mover a sonda para depois do `createClient` | 1 | `monthly-report: a sonda desceu para depois do createClient( — deixou de ser IO-free` |
| quebrar o formato do marcador | 1 | `monthly-report: VERSAO fora do formato vN.N-slug: "sensor-inicial"` |

Controle sem sabotagem: **27 passed | 0 failed**, exit 0. Refeito DEPOIS do rebase — o gate
ganhou 7 edges e duas listas novas, então a falsificação anterior já não falava do código final.

## Gates (os quatro, com exit colado)

- `bun run test:edges` → exit 0 — **883 passed | 0 failed** (27 casos do contrato compartilhado)
- `bun run edges:typecheck` → exit 0 — 0 erros de classe-crash
- `bun lint` → exit 0 — 75 problems (**0 errors**, 75 warnings), baseline inalterada
- `heavy bun run test` (vitest) → exit 0 — **729 files | 6973 tests | 0 failed**

Nota honesta sobre o quarto: a primeira rodada acusou 4 vermelhos. Nenhum era asserção — eram
`Test timed out in 20000ms` nos gates que varrem o repo inteiro, porque eu rodei os outros três
gates em paralelo numa máquina de 8GB e só o vitest passou pelo semáforo `heavy`. Rodado sozinho,
o mesmo arquivo que estourava 20s leva 3.9s. O número acima é da rodada sem concorrência.

## Convivência com o #1937 (mesmo arquivo, mesma sessão de trabalho)

Rebaseado sobre o #1937, que instrumentou **outras 7** dependentes do `paginate.ts`. Nós dois
mexemos em `_shared/sonda-versao-contrato_test.ts` e nós dois chamamos o bloco de "oitava leva" —
o dele mergeou primeiro, então este virou a **nona**. A separação não é cosmética: as 7 dele eram
edges **sem sensor**; esta estava fora da própria **enumeração**, que é um modo de falha diferente
e merece nome próprio no comentário.

Conflito resolvido mantendo os dois lados, e conferido por script em vez de leitura: pertencimento
de `monthly-report` nas 6 listas (dentro de `EDGES` e `FORMA_NORMALIZADA`; fora de `GATE_PROPRIO`,
`ESCRITA_NOSSO_BANCO`, `FAN_OUT_QUE_ESCREVE` e `OITAVA_LEVA`), as 7 do vizinho intactas, e todo
alias de import batendo com o diretório que ele importa.

## Fora de GATE_PROPRIO de propósito

O gate da edge é `authorizeCronOrStaff`, que já aceita o `x-cron-secret` do SQL Editor — sonda alcançável sem gate próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
