### PR TITLE
fix(dashboard): a visita que termina FECHANDO a aba nunca foi gravada — e o delta chegava nulo em 39 de 46 [reavaliação #1934]

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1318,3 +1318,41 @@ fecham a aba — e aí a correção é `pagehide`, não RLS. Os três eram o mes
 **O sensor é a fase N+1 legítima**: não mede adoção de produto, mede a *própria verificabilidade* de
 uma correção que já está no ar. Instalá-lo não precisa de denominador — precisa dele quem for
 concluir alguma coisa a partir dele.
+
+#### ⚠️ ERRATA — a fórmula da subtração morreu no mesmo dia (2026-08-24, PR desta seção)
+
+A frase acima — *"e aí a correção é `pagehide`, não RLS"* — foi executada horas depois, e ao ser
+executada **invalidou a fórmula que a antecede**. Registrado aqui porque uma fórmula de medição que
+envelhece errada é pior que fórmula nenhuma: ela continua rodando e devolvendo um número plausível.
+
+`useRegistrarVisitaDashboard` agora grava por DOIS caminhos, e ambos emitem `visita_tentativa`:
+
+| Caminho | Quando | Emissão |
+|---|---|---|
+| `unmount` (cleanup do effect) | navegação in-app | client do supabase |
+| `pagehide` | fechar aba · F5 · sair do site | `fetch` com `keepalive: true` |
+
+Logo `count(viewed) − count(visita_tentativa)` **não mede mais** saídas por fechar a aba: essas
+saídas passaram a emitir `visita_tentativa` também. A subtração agora tende a zero — e um zero por
+mudança de instrumentação é indistinguível, para quem lê a fórmula velha, de "ninguém mais fecha a
+aba". Exatamente o colapso de significados que o sensor existia para desfazer.
+
+A quarta saída deixou de ser inferida por subtração e passou a ser **medida direto**, pelo novo
+campo `via`:
+
+```
+saídas por fechar aba / F5   = count(visita_tentativa WHERE via='pagehide')
+saídas por navegação in-app  = count(visita_tentativa WHERE via='unmount')
+aberturas que qualificam     = count(visita_tentativa WHERE motivo='gravou')   -- inalterado
+```
+
+`motivo` também cresceu, e os três valores novos são **desistências que antes não existiam** (não
+são renomeações — não há série histórica a reconciliar): `ja_gravado` (o `unmount` que vem depois de
+um `pagehide` que já gravou — dedup, não perda), `lente_ativa` (a lente "ver como" barrando o fetch
+cru, que não passa pelo write-guard do client) e `sem_token` (sessão sem `access_token` para
+autenticar o fetch; o `unmount` ainda pode gravar pelo client).
+
+**A lição, que é do próprio arquivo:** a fase N+1 aqui não foi "usar o sensor", foi *corrigir o furo
+que o sensor tornou visível* — e a correção mudou o instrumento. Sensor e correção competem pelo
+mesmo denominador. Ao fechar um furo que o sensor media por ausência, **reescreva a query junto com
+o código**, no mesmo PR: a query mora no doc, mas ela é parte da mudança, não comentário sobre ela.

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { DashboardPersonaProvider, useDashboardPersonaContext } from '@/contexts/DashboardPersonaContext';
 import { DashboardEditModeProvider } from '@/contexts/DashboardEditModeContext';
 import { useRegisterShortcuts } from '@/components/shell/ShortcutsRegistry';
 import { useNavigate } from 'react-router-dom';
 import { track } from '@/lib/analytics';
-import { useLastVisit, useRegistrarVisitaDashboard } from '@/hooks/useLastVisit';
+import { useRegistrarVisitaDashboard, useTrackDashboardViewed } from '@/hooks/useLastVisit';
 import { useCompany } from '@/contexts/CompanyContext';
 import { BriefZone } from './BriefZone';
 import { CockpitGrid } from './CockpitGrid';
@@ -33,27 +33,23 @@ export function DashboardShell() {
 function DashboardBody() {
   const { persona, source } = useDashboardPersonaContext();
   const { selection } = useCompany();
-  const { minutesSinceLastVisit } = useLastVisit();
-
   // ESCRITOR ÚNICO de dashboard_visits (useLastVisit é só leitura e monta 3× aqui)
   useRegistrarVisitaDashboard({
     persona,
     companySelection: selection === 'all' ? 'all' : String(selection),
   });
+
+  // dashboard.viewed — espera a leitura da visita anterior resolver antes de
+  // emitir, senão `time_since_last_visit_min` sai nulo (era o caso em 39 de 46).
+  useTrackDashboardViewed({
+    persona,
+    personaSource: source,
+    companyMode: selection === 'all' ? 'all' : 'single',
+    companyId: selection,
+  });
+
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-
-  // dashboard.viewed na montagem
-  useEffect(() => {
-    track('dashboard.viewed', {
-      persona,
-      persona_source: source,
-      company_mode: selection === 'all' ? 'all' : 'single',
-      company_id: selection,
-      time_since_last_visit_min: minutesSinceLastVisit,
-    });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   // Coleta priorities das 6 zonas — todos os hooks rodam sempre (ordem fixa hook react)
   const vendas = useVendasZone();

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -17,14 +17,20 @@ vi.mock('@/lib/analytics', () => ({
   track: vi.fn(),
 }));
 
+vi.mock('@/lib/impersonation/lens-write-guard', () => ({
+  isLensActive: vi.fn(() => false),
+}));
+
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { track } from '@/lib/analytics';
-import { useLastVisit, useRegistrarVisitaDashboard } from '../useLastVisit';
+import { isLensActive } from '@/lib/impersonation/lens-write-guard';
+import { useLastVisit, useRegistrarVisitaDashboard, useTrackDashboardViewed } from '../useLastVisit';
 
 const mockedUseAuth = vi.mocked(useAuth);
 const mockedFrom = vi.mocked(supabase.from);
 const mockedTrack = vi.mocked(track);
+const mockedIsLensActive = vi.mocked(isLensActive);
 
 function wrapper({ children }: { children: ReactNode }) {
   const client = new QueryClient({
@@ -37,6 +43,9 @@ beforeEach(() => {
   mockedUseAuth.mockReset();
   mockedFrom.mockReset();
   mockedTrack.mockReset();
+  mockedIsLensActive.mockReset();
+  mockedIsLensActive.mockReturnValue(false);
+  vi.unstubAllGlobals();
   localStorage.clear();
 });
 
@@ -293,5 +302,300 @@ describe('useRegistrarVisitaDashboard', () => {
       'dashboard.visita_tentativa',
       expect.objectContaining({ motivo: 'gravou', session_minutes: 6 }),
     );
+  });
+});
+
+/**
+ * Leitura da visita anterior. `pendente: true` devolve uma promise que NUNCA
+ * resolve — é assim que se reproduz a corrida que deixava
+ * `time_since_last_visit_min` nulo em 39 de 46 eventos.
+ */
+function criarLeituraVisita(iso: string | null, { pendente = false } = {}) {
+  const maybeSingle = vi.fn(() =>
+    pendente
+      ? new Promise(() => {})
+      : Promise.resolve({ data: iso ? { visited_at: iso } : null }),
+  );
+  const selectFn = vi.fn().mockReturnValue({
+    eq: vi.fn().mockReturnValue({
+      order: vi.fn().mockReturnValue({ range: vi.fn().mockReturnValue({ maybeSingle }) }),
+    }),
+  });
+  return { select: selectFn } as unknown as ReturnType<typeof supabase.from>;
+}
+
+describe('useRegistrarVisitaDashboard — fecho de aba (pagehide)', () => {
+  const contexto = { persona: 'gestao', companySelection: 'all' };
+
+  function autenticar(userId: string) {
+    mockedUseAuth.mockReturnValue({
+      user: { id: userId },
+      session: { access_token: 'token-abc' },
+    } as unknown as ReturnType<typeof useAuth>);
+  }
+
+  it('GRAVA ao fechar a aba: React nao roda cleanup no unload, entao pagehide e a unica chance', () => {
+    autenticar('user-21');
+    const { builder } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('/rest/v1/dashboard_visits');
+    expect(JSON.parse(String(init.body))).toMatchObject({
+      user_id: 'user-21',
+      session_minutes: 6,
+      persona: 'gestao',
+      company_selection: 'all',
+    });
+  });
+
+  it('usa keepalive: sem isso o browser CANCELA a request ao destruir o documento', () => {
+    autenticar('user-22');
+    mockedFrom.mockReturnValue(criarInsertPreguicoso().builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(init.keepalive).toBe(true);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer token-abc');
+  });
+
+  it('nao duplica: gravou no pagehide, o unmount seguinte NAO grava de novo', () => {
+    autenticar('user-23');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 9 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    unmount();
+    relogio.mockRestore();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(emitidos).toHaveLength(0);
+  });
+
+  it('pagehide antes de 5min nao grava (o guard anti-F5 vale nos dois caminhos)', () => {
+    autenticar('user-24');
+    mockedFrom.mockReturnValue(criarInsertPreguicoso().builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 4 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('lente "ver como" ativa: o fetch cru nao pode furar o write-guard', () => {
+    autenticar('user-25');
+    mockedIsLensActive.mockReturnValue(true);
+    mockedFrom.mockReturnValue(criarInsertPreguicoso().builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sensor: o fecho de aba emite visita_tentativa com via=pagehide (a quarta saida vira MEDIDA)', () => {
+    autenticar('user-27');
+    mockedFrom.mockReturnValue(criarInsertPreguicoso().builder as unknown as ReturnType<typeof supabase.from>);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 201 }));
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'gravou', via: 'pagehide' }),
+    );
+  });
+
+  it('sensor: lente ativa nao fica MUDA — emite motivo=lente_ativa em vez de sumir', () => {
+    autenticar('user-28');
+    mockedIsLensActive.mockReturnValue(true);
+    mockedFrom.mockReturnValue(criarInsertPreguicoso().builder as unknown as ReturnType<typeof supabase.from>);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 201 }));
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'lente_ativa', via: 'pagehide' }),
+    );
+  });
+
+  it('sensor: o unmount depois do pagehide emite motivo=ja_gravado (nao vira silencio)', () => {
+    autenticar('user-29');
+    mockedFrom.mockReturnValue(criarInsertPreguicoso().builder as unknown as ReturnType<typeof supabase.from>);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, status: 201 }));
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 8 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    unmount();
+    relogio.mockRestore();
+
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'ja_gravado', via: 'unmount' }),
+    );
+  });
+
+  it('desmontou: o listener de pagehide sai junto (nao grava por componente morto)', () => {
+    autenticar('user-26');
+    const { builder } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 2 * 60_000);
+    unmount();
+    relogio.mockReturnValue(agora + 30 * 60_000);
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useLastVisit — sinal de que a leitura resolveu', () => {
+  it('visitaResolvida e FALSE enquanto a leitura do servidor nao voltou', () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-31' } } as ReturnType<typeof useAuth>);
+    mockedFrom.mockReturnValue(criarLeituraVisita(null, { pendente: true }));
+
+    const { result } = renderHook(() => useLastVisit(), { wrapper });
+
+    expect(result.current.visitaResolvida).toBe(false);
+  });
+
+  it('visitaResolvida vira TRUE quando a leitura resolve', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-32' } } as ReturnType<typeof useAuth>);
+    const iso = new Date(Date.now() - 90 * 60_000).toISOString();
+    mockedFrom.mockReturnValue(criarLeituraVisita(iso));
+
+    const { result } = renderHook(() => useLastVisit(), { wrapper });
+
+    await waitFor(() => expect(result.current.visitaResolvida).toBe(true));
+    expect(result.current.minutesSinceLastVisit).toBeGreaterThanOrEqual(90);
+  });
+
+  it('sem usuario a leitura ja nasce resolvida (so localStorage, disponivel sincrono)', () => {
+    mockedUseAuth.mockReturnValue({ user: null } as ReturnType<typeof useAuth>);
+
+    const { result } = renderHook(() => useLastVisit(), { wrapper });
+
+    expect(result.current.visitaResolvida).toBe(true);
+  });
+});
+
+describe('useTrackDashboardViewed', () => {
+  const contexto = {
+    persona: 'gestao',
+    personaSource: 'auto',
+    companyMode: 'all' as const,
+    companyId: 'all',
+  };
+
+  it('NAO dispara dashboard.viewed antes da leitura resolver (era isso que enchia o evento de null)', () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-41' } } as ReturnType<typeof useAuth>);
+    mockedFrom.mockReturnValue(criarLeituraVisita(null, { pendente: true }));
+
+    renderHook(() => useTrackDashboardViewed(contexto), { wrapper });
+
+    expect(mockedTrack).not.toHaveBeenCalled();
+  });
+
+  it('dispara com time_since_last_visit_min PREENCHIDO quando a leitura resolve', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-42' } } as ReturnType<typeof useAuth>);
+    const iso = new Date(Date.now() - 200 * 60_000).toISOString();
+    mockedFrom.mockReturnValue(criarLeituraVisita(iso));
+
+    renderHook(() => useTrackDashboardViewed(contexto), { wrapper });
+
+    await waitFor(() => expect(mockedTrack).toHaveBeenCalledTimes(1));
+    const [evento, props] = mockedTrack.mock.calls[0] as [string, Record<string, unknown>];
+    expect(evento).toBe('dashboard.viewed');
+    expect(props.time_since_last_visit_min).toBeGreaterThanOrEqual(200);
+    expect(props.persona).toBe('gestao');
+    expect(props.time_since_last_visit_resolvido).toBe(true);
+  });
+
+  it('dispara UMA vez so — re-render depois de resolver nao pode duplicar o evento', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-43' } } as ReturnType<typeof useAuth>);
+    mockedFrom.mockReturnValue(criarLeituraVisita(new Date(Date.now() - 10 * 60_000).toISOString()));
+
+    const { rerender } = renderHook(() => useTrackDashboardViewed(contexto), { wrapper });
+    await waitFor(() => expect(mockedTrack).toHaveBeenCalledTimes(1));
+    rerender();
+    rerender();
+
+    expect(mockedTrack).toHaveBeenCalledTimes(1);
+  });
+
+  it('leitura travada: o timeout de seguranca dispara mesmo assim (evento nunca pode sumir)', async () => {
+    vi.useFakeTimers();
+    try {
+      mockedUseAuth.mockReturnValue({ user: { id: 'user-44' } } as ReturnType<typeof useAuth>);
+      mockedFrom.mockReturnValue(criarLeituraVisita(null, { pendente: true }));
+
+      renderHook(() => useTrackDashboardViewed(contexto), { wrapper });
+      expect(mockedTrack).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(3_000);
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+      const [, props] = mockedTrack.mock.calls[0] as [string, Record<string, unknown>];
+      expect(props.time_since_last_visit_resolvido).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -568,16 +568,33 @@ describe('useTrackDashboardViewed', () => {
     expect(props.time_since_last_visit_resolvido).toBe(true);
   });
 
-  it('dispara UMA vez so — re-render depois de resolver nao pode duplicar o evento', async () => {
-    mockedUseAuth.mockReturnValue({ user: { id: 'user-43' } } as ReturnType<typeof useAuth>);
-    mockedFrom.mockReturnValue(criarLeituraVisita(new Date(Date.now() - 10 * 60_000).toISOString()));
+  it('timeout ja disparou e a leitura resolve DEPOIS — o evento nao pode sair duas vezes', async () => {
+    vi.useFakeTimers();
+    try {
+      mockedUseAuth.mockReturnValue({ user: { id: 'user-43' } } as ReturnType<typeof useAuth>);
+      let resolverLeitura: (v: { data: { visited_at: string } }) => void = () => {};
+      const maybeSingle = vi.fn(
+        () => new Promise<{ data: { visited_at: string } }>((r) => { resolverLeitura = r; }),
+      );
+      mockedFrom.mockReturnValue({
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            order: vi.fn().mockReturnValue({ range: vi.fn().mockReturnValue({ maybeSingle }) }),
+          }),
+        }),
+      } as unknown as ReturnType<typeof supabase.from>);
 
-    const { rerender } = renderHook(() => useTrackDashboardViewed(contexto), { wrapper });
-    await waitFor(() => expect(mockedTrack).toHaveBeenCalledTimes(1));
-    rerender();
-    rerender();
+      renderHook(() => useTrackDashboardViewed(contexto), { wrapper });
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
 
-    expect(mockedTrack).toHaveBeenCalledTimes(1);
+      resolverLeitura({ data: { visited_at: new Date(Date.now() - 10 * 60_000).toISOString() } });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockedTrack).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('leitura travada: o timeout de seguranca dispara mesmo assim (evento nunca pode sumir)', async () => {

--- a/src/hooks/useLastVisit.ts
+++ b/src/hooks/useLastVisit.ts
@@ -4,6 +4,7 @@ import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { isLensActive } from '@/lib/impersonation/lens-write-guard';
 import { track } from '@/lib/analytics';
+import { mensagemDeErro } from '@/lib/erro-mensagem';
 
 const STORAGE_KEY = 'dashboardLastVisit';
 const MIN_SESSION_MS = 5 * 60 * 1000; // 5min — evita F5 anular deltas
@@ -122,7 +123,10 @@ function emitirComKeepalive(payload: PayloadVisita, token: string): void {
       }
     })
     .catch((erro: unknown) => {
-      track('dashboard.visita_erro', { code: 'keepalive_network', message: String(erro) });
+      track('dashboard.visita_erro', {
+        code: 'keepalive_network',
+        message: mensagemDeErro(erro) ?? 'fetch keepalive falhou sem mensagem',
+      });
     });
 }
 

--- a/src/hooks/useLastVisit.ts
+++ b/src/hooks/useLastVisit.ts
@@ -1,20 +1,48 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
+import { isLensActive } from '@/lib/impersonation/lens-write-guard';
 import { track } from '@/lib/analytics';
 
 const STORAGE_KEY = 'dashboardLastVisit';
 const MIN_SESSION_MS = 5 * 60 * 1000; // 5min — evita F5 anular deltas
+const TIMEOUT_DELTA_MS = 3000; // teto de espera do delta antes de emitir mesmo assim
 
 export interface UseLastVisitReturn {
   lastVisitIso: string | null;
   minutesSinceLastVisit: number | null;
+  /** A leitura da visita anterior terminou? `false` = delta ainda não confiável. */
+  visitaResolvida: boolean;
 }
 
 export interface RegistroVisitaContexto {
   persona: string;
   companySelection: string;
+}
+
+export interface ContextoVisualizacaoDashboard {
+  persona: string;
+  personaSource: string;
+  companyMode: 'all' | 'single';
+  companyId: string | number;
+}
+
+/** Por que esta execução gravou — ou desistiu. */
+type MotivoTentativa =
+  | 'gravou'
+  | 'sessao_curta'
+  | 'sem_usuario'
+  | 'ja_gravado'
+  | 'lente_ativa'
+  | 'sem_token';
+
+interface PayloadVisita {
+  user_id: string;
+  visited_at: string;
+  session_minutes: number;
+  persona: string;
+  company_selection: string;
 }
 
 /**
@@ -24,9 +52,9 @@ export interface RegistroVisitaContexto {
  * é SÓ leitura: react-query deduplica a query, mas escrita duplicada geraria 3
  * linhas por visita. Quem escreve é `useRegistrarVisitaDashboard`, 1 chamador só.
  *
- * `range(0, 0)` = linha MAIS recente. A visita atual só vira linha no unmount,
- * então no mount a linha mais recente já é a anterior. (O `range(1, 1)` original
- * vinha do spec, que assumia escrita no mount — off-by-one: devolvia a
+ * `range(0, 0)` = linha MAIS recente. A visita atual só vira linha no fim da
+ * sessão, então no mount a linha mais recente já é a anterior. (O `range(1, 1)`
+ * original vinha do spec, que assumia escrita no mount — off-by-one: devolvia a
  * penúltima visita.)
  */
 export function useLastVisit(): UseLastVisitReturn {
@@ -36,7 +64,7 @@ export function useLastVisit(): UseLastVisitReturn {
     return localStorage.getItem(STORAGE_KEY);
   });
 
-  const { data: serverIso } = useQuery({
+  const { data: serverIso, isPending } = useQuery({
     queryKey: ['dashboard', 'previous-visit', user?.id],
     queryFn: async (): Promise<string | null> => {
       if (!user?.id) return null;
@@ -45,7 +73,7 @@ export function useLastVisit(): UseLastVisitReturn {
         .select('visited_at')
         .eq('user_id', user.id)
         .order('visited_at', { ascending: false })
-        .range(0, 0) // mais recente = visita anterior (a atual grava no unmount)
+        .range(0, 0) // mais recente = visita anterior (a atual grava no fim da sessão)
         .maybeSingle();
       const row = data as { visited_at?: string } | null;
       return row?.visited_at ?? null;
@@ -59,70 +87,136 @@ export function useLastVisit(): UseLastVisitReturn {
     ? Math.floor((Date.now() - new Date(lastVisitIso).getTime()) / 60_000)
     : null;
 
-  return { lastVisitIso, minutesSinceLastVisit };
+  // Sem usuário a query fica `enabled: false` — e em react-query v5 isso mantém
+  // `isPending` true para sempre. Aí só existe o localStorage, que é síncrono:
+  // já nasce resolvido.
+  const visitaResolvida = !user?.id || !isPending;
+
+  return { lastVisitIso, minutesSinceLastVisit, visitaResolvida };
+}
+
+/**
+ * Emissão que sobrevive à morte do documento.
+ *
+ * `keepalive: true` é o ponto todo: sem ele o browser cancela a request em voo
+ * quando a aba fecha. `sendBeacon` não serve — não deixa mandar os headers de
+ * auth que o PostgREST exige.
+ */
+function emitirComKeepalive(payload: PayloadVisita, token: string): void {
+  const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/dashboard_visits`;
+  void fetch(url, {
+    method: 'POST',
+    keepalive: true,
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY,
+      Authorization: `Bearer ${token}`,
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((res) => {
+      // falha silenciosa é o que escondeu o bug do #1934 — reporte sempre
+      if (!res.ok) {
+        track('dashboard.visita_erro', { code: String(res.status), message: 'keepalive_http' });
+      }
+    })
+    .catch((erro: unknown) => {
+      track('dashboard.visita_erro', { code: 'keepalive_network', message: String(erro) });
+    });
 }
 
 /**
  * ESCRITA da visita — chamar UMA vez por dashboard (DashboardBody).
  *
- * Grava no unmount se a sessão durou ≥5min: localStorage sempre, server quando
- * há usuário.
+ * Uma visita termina de dois jeitos e SÓ UM deles passa pelo React:
+ *  - navegação in-app → unmount → cleanup do effect → client do supabase;
+ *  - fechar a aba / recarregar / sair do site → o cleanup NUNCA roda. A única
+ *    chance é `pagehide` (mais confiável que `beforeunload`, e o único que o
+ *    Safari/iOS honra), com `fetch keepalive`.
  *
- * Emite `dashboard.visita_tentativa` em TODA execução do cleanup (com `motivo`),
- * antes das desistências — sem isso, "não gravou" e "não tentou" são o mesmo
- * sintoma. Fechar a aba não roda cleanup, logo não emite: essa quarta saída só
- * é observável como `dashboard.viewed` − `dashboard.visita_tentativa`.
+ * Grava no máximo uma vez por montagem (`gravadoRef`), e só se a sessão durou
+ * ≥5min — o mesmo guard anti-F5 vale nos DOIS caminhos.
+ *
+ * `dashboard.visita_tentativa` sai em TODA execução, antes de qualquer
+ * desistência, com `motivo` — sem isso "não gravou" e "não tentou" viram o
+ * mesmo sintoma (tabela vazia). O campo `via` diz por qual caminho a visita
+ * terminou: a saída por fecho de aba, que antes só dava para inferir por
+ * `viewed − visita_tentativa`, agora é MEDIDA direto (`via='pagehide'`).
  */
 export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): void {
-  const { user } = useAuth();
+  const { user, session } = useAuth();
   const mountedAtRef = useRef<number>(Date.now());
   const contextoRef = useRef(contexto);
   contextoRef.current = contexto;
+  // O token vive em ref, NÃO nas deps do effect: um refresh de token re-rodaria
+  // o effect, e o cleanup gravaria uma visita que não terminou.
+  const tokenRef = useRef<string | undefined>(session?.access_token);
+  tokenRef.current = session?.access_token;
+  const gravadoRef = useRef(false);
 
   useEffect(() => {
-    return () => {
+    const decidirMotivo = (viaFechoDeAba: boolean, duracao: number): MotivoTentativa => {
+      if (gravadoRef.current) return 'ja_gravado';
+      if (duracao < MIN_SESSION_MS) return 'sessao_curta';
+      // O fetch cru do pagehide NÃO passa pelo client embrulhado pelo
+      // write-guard da lente "ver como" — o gate tem que ser aqui, na fonte.
+      if (viaFechoDeAba && isLensActive()) return 'lente_ativa';
+      if (!user?.id) return 'sem_usuario';
+      // Sem token não dá para autenticar o fetch cru. Não queima a chance: se
+      // ainda houver unmount, ele grava pelo client.
+      if (viaFechoDeAba && !tokenRef.current) return 'sem_token';
+      return 'gravou';
+    };
+
+    const gravar = (via: 'unmount' | 'pagehide') => {
       if (typeof window === 'undefined') return;
+
+      const viaFechoDeAba = via === 'pagehide';
       const sessionDuration = Date.now() - mountedAtRef.current;
       const sessionMinutes = Math.floor(sessionDuration / 60_000);
+      const motivo = decidirMotivo(viaFechoDeAba, sessionDuration);
 
-      // Sensor de TENTATIVA — emitido ANTES de qualquer `return`. O cleanup
-      // tinha duas saídas MUDAS (sessão curta, sem usuário) que colapsavam com
-      // a terceira (aba fechada — fora do alcance do hook: cleanup nem roda)
-      // num sintoma único: tabela vazia. Só a quarta (banco recusa) emitia
-      // sinal, então `dashboard_visits` vazio era indistinguível de "ninguém
-      // ficou 5min". `motivo` separa "não gravou" de "não tentou"; e como
-      // `dashboard.viewed` sai no MOUNT do mesmo DashboardShell, a diferença
-      // viewed − visita_tentativa mede as saídas por fechar a aba / F5.
-      const motivo =
-        sessionDuration < MIN_SESSION_MS ? 'sessao_curta' : !user?.id ? 'sem_usuario' : 'gravou';
+      // Sensor de TENTATIVA — emitido ANTES de qualquer `return`.
       track('dashboard.visita_tentativa', {
         motivo,
+        via,
         session_minutes: sessionMinutes,
         persona: contextoRef.current.persona,
         company_selection: contextoRef.current.companySelection,
       });
 
-      if (sessionDuration < MIN_SESSION_MS) return;
+      if (motivo === 'ja_gravado' || motivo === 'sessao_curta') return;
+      if (motivo === 'lente_ativa' || motivo === 'sem_token') return;
 
+      gravadoRef.current = true;
       const now = new Date().toISOString();
 
-      // local (sempre)
+      // local (sempre — inclusive sem usuário)
       localStorage.setItem(STORAGE_KEY, now);
 
       // server (best-effort, não bloqueia)
-      if (!user?.id) return;
+      if (motivo === 'sem_usuario' || !user?.id) return;
+      const payload: PayloadVisita = {
+        user_id: user.id,
+        visited_at: now,
+        session_minutes: sessionMinutes,
+        persona: contextoRef.current.persona,
+        company_selection: contextoRef.current.companySelection,
+      };
+
+      const token = tokenRef.current;
+      if (viaFechoDeAba && token) {
+        emitirComKeepalive(payload, token);
+        return;
+      }
+
       // `.then()` é OBRIGATÓRIO: o builder do PostgREST é um thenable PREGUIÇOSO
       // — o fetch mora DENTRO de then(), então `void builder.insert(...)` monta a
       // query e não manda NADA. Foi o que deixou a tabela vazia por 3 meses.
       void supabase
         .from('dashboard_visits')
-        .insert({
-          user_id: user.id,
-          visited_at: now,
-          session_minutes: sessionMinutes,
-          persona: contextoRef.current.persona,
-          company_selection: contextoRef.current.companySelection,
-        })
+        .insert(payload)
         .then(({ error }) => {
           // falha silenciosa é o que escondeu este bug — reporte sempre
           if (error) {
@@ -130,5 +224,55 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
           }
         });
     };
+
+    const aoEsconderPagina = () => gravar('pagehide');
+    window.addEventListener('pagehide', aoEsconderPagina);
+    return () => {
+      window.removeEventListener('pagehide', aoEsconderPagina);
+      gravar('unmount');
+    };
   }, [user?.id]);
+}
+
+/**
+ * Emite `dashboard.viewed` UMA vez, esperando a leitura da visita anterior.
+ *
+ * O effect com deps `[]` disparava no mount — antes da query resolver — e por
+ * isso `time_since_last_visit_min` chegava nulo em 39 de 46 eventos. Esperar
+ * enche o delta; o timeout existe porque trocar "propriedade nula" por "evento
+ * ausente" seria pior: leitura travada ainda tem que emitir o `viewed`.
+ *
+ * `time_since_last_visit_resolvido` desambigua o null que sobrar: sem ele, um
+ * nulo futuro volta a ser "não sei se é primeira visita ou se é a corrida".
+ */
+export function useTrackDashboardViewed(contexto: ContextoVisualizacaoDashboard): void {
+  const { minutesSinceLastVisit, visitaResolvida } = useLastVisit();
+  const contextoRef = useRef(contexto);
+  contextoRef.current = contexto;
+  const deltaRef = useRef(minutesSinceLastVisit);
+  deltaRef.current = minutesSinceLastVisit;
+  const disparadoRef = useRef(false);
+
+  const disparar = useCallback((resolvido: boolean) => {
+    if (disparadoRef.current) return;
+    disparadoRef.current = true;
+    const atual = contextoRef.current;
+    track('dashboard.viewed', {
+      persona: atual.persona,
+      persona_source: atual.personaSource,
+      company_mode: atual.companyMode,
+      company_id: atual.companyId,
+      time_since_last_visit_min: deltaRef.current,
+      time_since_last_visit_resolvido: resolvido,
+    });
+  }, []);
+
+  useEffect(() => {
+    if (visitaResolvida) {
+      disparar(true);
+      return;
+    }
+    const id = setTimeout(() => disparar(false), TIMEOUT_DELTA_MS);
+    return () => clearTimeout(id);
+  }, [visitaResolvida, disparar]);
 }


### PR DESCRIPTION
Os dois furos que o #1934 deixou explicitamente fora de escopo, e que o #1945 (sensor) tornou mensuráveis. O próprio #1945 aponta o caminho: *"e aí a correção é `pagehide`, não RLS"* — é isto.

## 1. Fecho de aba não gravava

A escrita vivia só no cleanup do `useEffect`. **React não roda cleanup quando a aba/browser fecha** — só em navegação in-app. Toda visita encerrada fechando a aba era perdida, o que num dashboard é provavelmente a maioria.

Agora `pagehide` (mais confiável que `beforeunload`, e o único que Safari/iOS honra) + `fetch` com `keepalive: true`. Sem `keepalive` o browser **cancela a request em voo** ao destruir o documento. `sendBeacon` não serve: não deixa mandar os headers de auth que o PostgREST exige.

Guardas que vieram junto:

| Guarda | Por quê |
|---|---|
| `gravadoRef` | uma gravação por montagem — `pagehide` + `unmount` seguinte não duplicam |
| `MIN_SESSION_MS` nos **dois** caminhos | o anti-F5 de 5min não podia valer só num deles |
| `isLensActive()` explícito | o fetch cru **não** passa pelo client embrulhado pelo write-guard da lente "ver como" — gate na fonte |
| token em `ref`, não nas deps | um refresh de token re-rodaria o effect, e o cleanup gravaria uma visita que não terminou |

## 2. `time_since_last_visit_min` nulo em 39 de 46 eventos

Medido no PostHog (90d). O `track('dashboard.viewed')` disparava num `useEffect` com deps `[]` — no mount, antes da query da visita anterior resolver. O #1934 encheu a tabela, mas a propriedade seguia nula.

`useTrackDashboardViewed` espera `visitaResolvida` e dispara **uma vez só**. Timeout de 3s emite mesmo assim: trocar "propriedade nula" por "evento ausente" seria pior. A nova `time_since_last_visit_resolvido` desambigua o null que sobrar — sem ela, um nulo futuro volta a ser *"primeira visita, ou a corrida de novo?"*.

## Integração com o sensor do #1945

O `visita_tentativa` agora cobre os caminhos novos, com um campo **`via`** (`unmount` | `pagehide`) e três motivos a mais: `ja_gravado`, `lente_ativa`, `sem_token`.

**A fórmula do #1945 morreu com esta correção** e está marcada como superada em `docs/historico/fase-sem-sinal.md`: `count(viewed) − count(visita_tentativa)` media a saída por fecho de aba *por ausência* — agora essa saída emite `visita_tentativa` também, então a subtração tende a zero, e um zero por mudança de instrumentação lê igualzinho a "ninguém mais fecha a aba". A quarta saída passou a ser **medida direto**:

```
saídas por fechar aba / F5  = count(visita_tentativa WHERE via='pagehide')
saídas por navegação in-app = count(visita_tentativa WHERE via='unmount')
```

## Evidência

- **Suíte completa:** `733 arquivos / 7061 testes passed`, exit 0. Typecheck e lint exit 0.
- **Falsificação — 12 sabotagens, 12 pegas.** Cada guarda foi removida/invertida uma por vez, exigindo vermelho no teste que a vigia: guard anti-F5, gate da lente, `add`/`removeEventListener`, `keepalive: true`, dedup, espera da leitura, disparo único, campo `via`, `ja_gravado`, `lente_ativa`, e o sensor antes das desistências.
- **Um teste foi reprovado pela falsificação e reescrito** (commit próprio): o de disparo único usava `rerender()`, que **não re-roda o effect** com deps inalteradas — passava sem o guard. A duplicação real é o timeout disparar e a leitura resolver **depois**; é esse cenário que ele monta agora.
- Testes reusam `criarInsertPreguicoso`, o dublê fiel ao thenable do PostgREST que só registra a chamada quando alguém **puxa** a promise — mock comum ficaria verde no próprio bug do #1934.
- O gate estrutural da classe #1642 pegou um `String(erro)` meu no catch do keepalive (o erro do supabase-js é objeto plano → `[object Object]`); corrigido para `mensagemDeErro()`.

## Nota de verificação

`dashboard_visits` segue em 0 linhas, e isso **não** contradiz nada: o PostHog registra **zero** `dashboard.viewed` na janela (sonda validada por controle — 65 eventos totais em 7d). É ausência de oportunidade, não de gravação. O denominador para julgar esta mudança é `visita_tentativa` agrupado por `via`/`motivo`, não a contagem da tabela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)