### PR TITLE
docs(vigia): a nota do 3º eixo nasceu SEM gatilho — a mesma dívida que a Lição 6 acabou de denunciar

### DIFF
--- a/docs/historico/vigia-de-cobertura-parcial.md
+++ b/docs/historico/vigia-de-cobertura-parcial.md
@@ -169,7 +169,10 @@ glob e a órfã. Zero falso-positivo.
 **Fora do eixo 2 DE PROPÓSITO:** as ~250 `db/test-*.sh`. Não são órfãs por descuido — são harnesses
 "PROVA PG17" que exigem um PostgreSQL 17 vivo (ritual `prove-sql-money-path`, rodado à mão antes
 de entregar migration). Cobrá-las geraria ~250 isenções de baseline no dia 1, e gate que nasce com
-250 falsos-positivos ninguém lê.
+250 falsos-positivos ninguém lê. **Gatilho** (para esta nota não repetir a dívida da Lição 6):
+quando o CI tiver um PostgreSQL 17 de serviço, as ~250 isenções somem — aí o 3º eixo
+(`db/test-*.sh` × um laço que as execute) vira chip. Até lá a cobertura delas é o ritual
+manual, e o CI não finge que as roda.
 
 **Lição 6.** *Uma nota de "fora de escopo" num doc é dívida com data de validade.* A desta página
 sobreviveu um dia e só fechou porque estava **escrita**. Deixar o eixo de fora foi certo (não


### PR DESCRIPTION
## O defeito

O #1942 fechou o 2º eixo do vigia de cobertura **porque** uma nota de "fora de escopo" estava ESCRITA no doc. Ele registrou isso como **Lição 6** — *"uma nota de 'fora de escopo' num doc é dívida com data de validade"*.

E, no parágrafo imediatamente acima da Lição 6, deixou a própria nota do 3º eixo (as ~250 `db/test-*.sh`) com o **porquê** e sem o **quando**.

Porquê sem gatilho não é registro — é a mesma nota que só fecha se alguém topar com ela por acaso. Foi o que aconteceu com a anterior; contar com isso duas vezes é sorte, não processo.

## O que muda

Uma frase em [docs/historico/vigia-de-cobertura-parcial.md](docs/historico/vigia-de-cobertura-parcial.md): o gatilho explícito.

> quando o CI tiver um PostgreSQL 17 de serviço, as ~250 isenções somem — aí o 3º eixo (`db/test-*.sh` × um laço que as execute) vira chip. Até lá a cobertura delas é o ritual manual, e o CI não finge que as roda.

A última oração é a que importa para quem lê o gate: **não** é "essas suítes estão cobertas", é "estão fora, de propósito, e eis quando entram".

## Escopo e verificação

Doc-only — nenhuma linha de código, nenhum gate novo, nenhuma camada de deploy.

| gate | exit |
|---|---|
| `docs:links` | 0 |
| `docs:indice` | 0 |
| `docs:citacoes` | 0 |

Ramificado de `origin/main` (não da branch do #1942, que foi squashada) — o diff é só a frase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)