### PR TITLE
docs(heavy): o conserto do flaky nunca foi RE-MEDIDO — 15/15 verdes, mas o n efetivo é 8

### DIFF
--- a/docs/historico/vigia-de-cobertura-parcial.md
+++ b/docs/historico/vigia-de-cobertura-parcial.md
@@ -89,6 +89,27 @@ Duas lições de método:
 - **Número apressado vira dívida.** "1 em 3" (n=3) e "1 em 7" (n=13) levam a decisões diferentes, e
   o primeiro já estava commitado. Amostra pequena merece o `n` explícito ao lado.
 
+### A verificação que faltava: 15/15 verdes, e o poder do teste (2026-08-24)
+
+O conserto acima foi entregue com a causa provada e **zero execuções registradas depois dele** —
+"consertado" saiu da análise causal, não de medida. É a lição de `falsificacao-fora-do-ci.md`
+aplicada na direção inversa: *teste que existe e não roda é ausência de dado* vale igual para
+*conserto que não foi re-medido*.
+
+Medido em 2026-08-24, 15 execuções seguidas na M2 (73 worktrees, swap 4,35 GB de 5,12 GB em uso):
+**15 verdes, 0 vermelhos**, nenhuma linha `FAIL`, 32–49 s cada.
+
+O que isso autoriza dizer — e o que não autoriza:
+
+- Se a taxa tivesse continuado nos ~15% medidos antes, 15 verdes seguidos teriam ~8,7% de chance
+  (0,85 elevado a 15). O conserto é de longe a explicação mais provável.
+- Mas o `load` caiu de **41,7 na run 1 para 5,2 na run 15** — a máquina foi esvaziando durante a
+  série. Só **8** das 15 rodaram no regime que produzia o flaky (`load` ≥ 20), e 8 verdes sob
+  p=0,15 têm ~27% de chance de sair por sorte. **O n efetivo sob carga é 8, não 15.**
+
+Evidência boa, não prova. Foi registrar o `load` de cada execução que tornou essa distinção
+visível: colher só o exit code teria produzido um "15/15" que soa definitivo e não é.
+
 ## Lições
 
 1. **Gate anti-órfão é código como outro qualquer — pergunte de que ele é cego.** O sintoma é

--- a/scripts/hooks-suites-baseline.ts
+++ b/scripts/hooks-suites-baseline.ts
@@ -23,8 +23,9 @@ export const SUITES_FORA_DO_CI: SuiteForaDoCI[] = [
       'disputa — o `heavy` não existe no runner ubuntu (exit 127). Leva ~50s. Rodar à mão na M2 ' +
       'ao mexer em scripts/heavy.sh. (Era também FLAKY: 2 vermelhos em 13 execuções, ~15%, ' +
       'sempre na asserção do `--status` sob sobrecarga — o setup sincronizava por `sleep` fixo e ' +
-      'sob carga alta media um mundo meio-montado. Consertado com espera por CONDIÇÃO; o motivo ' +
-      'de estar aqui é só o macOS-only.)',
+      'sob carga alta media um mundo meio-montado. Consertado com espera por CONDIÇÃO e ' +
+      're-medido em 2026-08-24: 15/15 verdes, 8 delas sob load >=20 — o regime que produzia ' +
+      'o flaky. O motivo de estar aqui é só o macOS-only.)',
   },
   {
     arquivo: 'test-heavy-install.sh',


### PR DESCRIPTION
## O que eu ia fazer, e por que não fiz

A pendência aberta em 2026-08-24 era: a entrada de `test-heavy.sh` na baseline empacota dois motivos de naturezas diferentes (macOS-only estrutural + flaky, que é defeito), e o segundo herda a permanência do primeiro.

**O diagnóstico está certo sobre o passado, mas o defeito já foi corrigido** — pelo #1929, mergeado às 00:53 de hoje. A entrada atual já separa os eixos e diz por extenso que a isenção se apoia só no macOS-only. Não forcei mudança onde já estava honesto.

## O buraco que sobrou

O #1929 mediu o flaky **antes** do conserto (n=13, ~15%, sempre a mesma asserção), achou a causa (o setup sincronizava por `sleep` fixo e media um mundo meio-montado), consertou com espera por CONDIÇÃO — e escreveu **"Consertado"** sem uma única execução colhida depois.

"Consertado" saiu da análise causal, não de medida. É a lição de `falsificacao-fora-do-ci.md` na direção inversa: *conserto que não foi re-medido é ausência de dado, igual a teste que não roda*.

## A medição

15 execuções seguidas em 2026-08-24, na M2 com 73 worktrees e swap em 4,35 GB de 5,12 GB:

| | |
|---|---|
| Verdes | **15/15** |
| Linhas `FAIL` | **0** |
| Duração | 32–49 s cada |
| `load` | 41,7 (run 1) → 5,2 (run 15) |

Se a taxa tivesse continuado nos ~15%, 15 verdes seguidos teriam ~8,7% de chance.

## O que a medição NÃO autoriza dizer

O `load` caiu ao longo da série — a máquina foi esvaziando. Só **8** das 15 rodaram no regime que produzia o flaky (`load ≥ 20`), e 8 verdes sob p=0,15 saem por sorte em ~27% das vezes. **O n efetivo sob carga é 8, não 15: evidência boa, não prova.**

Colher o `load` de cada execução foi o que tornou essa distinção visível. Só o exit code teria produzido um "15/15" que soa definitivo e não é — que é exatamente o erro que o #1929 já tinha cometido uma vez, com o "1 em 3" que lia como 33%.

## Mudanças

- `docs/historico/vigia-de-cobertura-parcial.md` — subseção nova com a medição e a ressalva do poder do teste.
- `scripts/hooks-suites-baseline.ts` — lastro para a palavra "Consertado", no lugar onde a afirmação é feita. O eixo da isenção não muda: segue macOS-only (`sysctl`/`stat -f`, exit 127 no ubuntu).

## Evidência

| Comando | Resultado |
|---|---|
| `bun run test` | 734 arquivos, 7070 testes, `TEST_EXIT=0` |
| `bun run typecheck` | `TYPECHECK_EXIT=0` |
| `bunx vitest run scripts/hooks-guard-cobertura.test.ts` | 25 passed, exit 0 |

**Falsificado nos dois sentidos** (o gate não é teatro):

1. motivo → `'TODO'` (4 chars) ⇒ vermelho em `Isenção sem motivo explicado: test-heavy.sh`
2. entrada removida da baseline ⇒ vermelho em `Suíte(s) que NINGUÉM roda: test-heavy.sh`

Restaurado e verde de novo depois de cada uma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)