### PR TITLE
docs: ✅ dashboard_visits tem id=1 — e o que travava não era código, era o aceite do service worker

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -190,6 +190,28 @@ devolve `400` (host vivo), então **sondar o host não desmente o 503 do POST au
 assimetria útil — **linha sem evento** é telemetria caída com o app são; **evento sem linha** é o app
 falhando com a telemetria sã. Quando os dois zeram, comece pela tabela: ela tem menos partes móveis.
 
+⚠️ **E o zero pode nem ser zero: a CONSULTA também falha, por outro endpoint.** No mesmo 2026-08-24,
+a query de breakdown por `properties.motivo` voltou **504** de `us.posthog.com` com
+`"Query has hit the max execution time"` — agregação por propriedade em `events` é cara. Um
+`count()` simples na mesma janela respondeu `[[0]]`, exit 0. São **três** resultados distintos
+chegando pelo mesmo cano, e só um é medição:
+
+| o que voltou | é dado? |
+|---|---|
+| `{"results":[[0]]}` com exit 0 | **sim** — zero medido |
+| **503** na ingestão (`us.i.posthog.com/i/v0/e/`) | não — o evento nunca entrou |
+| **504** na consulta (`us.posthog.com`) | não — a query não terminou |
+
+**Antes de ler um zero do PostHog como ausência de uso, prove que a query TERMINOU** — e prefira
+`count()` simples ao `GROUP BY` de propriedade quando só precisar do denominador. Um `GET` no host de
+ingestão devolve `400` mesmo com a ingestão recusando POSTs, então **sondar o host não é sonda de
+saúde**.
+
+⚠️ **`via='pagehide'` ainda não tem exercício real.** A prova de 2026-08-24 (`dashboard_visits`
+`id=1`) veio com `keepalive: false`, ou seja, pelo caminho do **unmount**. O `emitirComKeepalive` do
+#1949 é código no ar sem observação — trate `via='pagehide'` como não-verificado até aparecer o
+primeiro.
+
 ⚠️ **`sessao_curta` domina por desenho, não por defeito.** O guard de 5 min (`MIN_SESSION_MS`) existe
 para um F5 não anular os deltas — uma proporção alta dele é o guard funcionando. Ele só vira sintoma
 se `gravou` for **zero** por muitos dias com o dashboard sendo aberto.

--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -180,6 +180,15 @@ SELECT count(*) FROM dashboard_visits WHERE visited_at > '<deploy do sensor>';
 | `gravou` > linhas, **com** `dashboard.visita_erro` | o banco recusou — ver a RLS de INSERT |
 | `gravou` > linhas, **sem** `dashboard.visita_erro` | requisição perdida na rede (o `keepalive` do `pagehide` não é garantido) — antes deste sensor, indistinguível de tudo o mais |
 | `gravou` = 0 e o resto > 0 | o dashboard é aberto, mas nenhuma sessão qualifica: leia o `motivo` |
+| **evento ausente por completo** | **terceiro estado: a ingestão pode ter RECUSADO** — ver abaixo |
+
+⚠️ **Série vazia tem um terceiro estado que só a TABELA distingue.** "Não emitiu" e "emitiu e a
+ingestão recusou" são o mesmo silêncio no PostHog. Em 2026-08-24 o POST para `us.i.posthog.com/i/v0/e/`
+voltou **503** com três retries, e nenhum evento entrou — nem `$pageview`. Um `GET` no mesmo host
+devolve `400` (host vivo), então **sondar o host não desmente o 503 do POST autenticado**. A tabela
+`dashboard_visits` é o lado **imune**: o INSERT vai direto ao Supabase e não passa pelo PostHog. Daí a
+assimetria útil — **linha sem evento** é telemetria caída com o app são; **evento sem linha** é o app
+falhando com a telemetria sã. Quando os dois zeram, comece pela tabela: ela tem menos partes móveis.
 
 ⚠️ **`sessao_curta` domina por desenho, não por defeito.** O guard de 5 min (`MIN_SESSION_MS`) existe
 para um F5 não anular os deltas — uma proporção alta dele é o guard funcionando. Ele só vira sintoma

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -303,5 +303,19 @@ O SW usa `registerType: 'prompt'` (não `autoUpdate`): a versão nova **instala 
 - **`clientsClaim: true` NÃO se remove junto** — parecem par, mas não são. Sem ele, na **1ª instalação** o SW não controla a aba atual até o próximo reload → se a rede cair na mesma sessão, **offline-first não funciona no primeiro acesso**. Ele não causa reload-surpresa (só o `skipWaiting` causava); só faz claim quando o SW ativa (que na atualização só ocorre após o clique).
 - **Registro do SW tem fallback** — `main.tsx` faz `import('./lib/pwa-update')` guardado por `__PWA_ENABLED__` (build const = `production && !preview`; DCE remove em dev/preview, onde `virtual:pwa-register` nem existe). No `.catch`, cai pra `navigator.serviceWorker.register('/sw.js')`: offline-first não pode depender de um import lazy resolver.
 - **A verificação de deploy NÃO é cegada pelo prompt mode** — `verify-frontend.sh` usa `curl` direto no host (sem service worker), então mede os **bytes do servidor**, não um cliente com SW velho. O cron não é um browser.
+  ⚠️ **Mas ela mede DISPONIBILIDADE, nunca ADOÇÃO — e no modelo `prompt` os dois divergem por tempo
+  indefinido.** A frase acima é verdadeira para o que o script mede e foi lida como garantia do que
+  ele NÃO mede: em 2026-08-24 os PRs #1934/#1945/#1949 estavam todos servidos (`verify-bundle-multi`
+  exit 0, 334/334 chunks, com controle positivo e negativo) enquanto o browser do founder executava
+  um entry anterior, servido do precache pelo SW — o app inclusive exibia "Nova versão disponível".
+  Resultado: uma visita ao dashboard gerada de propósito para testar o fix **testou o código de antes
+  do fix**, e a tabela vazia quase virou "o fix não pegou". Não é caso de borda: com `skipWaiting`
+  removido de propósito, **esperar é o comportamento correto**, e o cliente fica no build velho até
+  clicar. Assets antigos continuam servidos com **200** (imutáveis por hash), então o SW consegue
+  sustentar o build velho indefinidamente.
+  **A regra:** *"está no ar"* e *"está rodando"* são estados diferentes, e o segundo é **por
+  cliente**. Bytes no servidor não fecham nenhuma verificação cujo sujeito seja o usuário — para
+  essa, o oráculo tem de ser um efeito que só o código novo produz (uma linha que só ele grava, um
+  evento que só ele emite), e o cliente precisa aceitar o update antes do teste.
 - **Prova de build** (não confiar na config): `dist/sw.js` deve ter `skipWaiting` **só dentro do listener de `message`** (não no `install`) + `clientsClaim` presente. `dist/index.html` **sem** auto-register (por `injectRegister: false`).
 - **Transição única no 1º Publish com prompt mode:** clientes com o SW antigo (autoUpdate) auto-recarregam **uma última vez** ao pegar este build; daí em diante toda atualização vira o toast. Inerente, não dá pra evitar.

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1356,3 +1356,66 @@ autenticar o fetch; o `unmount` ainda pode gravar pelo client).
 que o sensor tornou visível* — e a correção mudou o instrumento. Sensor e correção competem pelo
 mesmo denominador. Ao fechar um furo que o sensor media por ausência, **reescreva a query junto com
 o código**, no mesmo PR: a query mora no doc, mas ela é parte da mudança, não comentário sobre ela.
+
+## ✅ FECHADO — `dashboard_visits` tem `id = 1` (2026-08-24 12:29:32Z)
+
+A tabela vazia há três meses recebeu a primeira linha. O `#1934` está **provado em produção**:
+
+```
+ id |         visited_at         |  persona  | company_selection | session_minutes
+----+----------------------------+-----------+-------------------+-----------------
+  1 | 2026-08-24 12:29:32.543+00 | comprador | all               |               7
+```
+
+Vigília no `psql-ro` a cada 40s: `12:29:16Z linhas=0` · `12:29:58Z linhas=1`. As duas colunas que
+existiam desde 2026-05-17 e nunca tinham sido escritas (`persona`, `company_selection`) vieram
+preenchidas.
+
+**A linha se corrobora sozinha, e é o que a torna evidência e não relato.** A sessão que conduziu o
+teste informou o mount às **12:22:28Z**, *antes de a linha existir*. `12:29:32.543 − 12:22:28 =
+7min 04s`, `Math.floor` → **7**, que é exatamente o `session_minutes` gravado. Nenhuma linha espúria
+bateria com um horário fornecido antes do fato — a checagem não depende de confiar em quem reportou.
+
+Do lado do browser (interceptor de `fetch`, sessão `interesting-driscoll-dfb6e1`): POST com
+`keepalive: false`, corpo com os 5 campos, resposta **201** em 416ms.
+
+⚠️ **`keepalive: false` ⇒ o que se provou foi o caminho do UNMOUNT.** Dizer "o #1949 está provado"
+seria forte demais: o `emitirComKeepalive` do `pagehide` **continua sem exercício real**. Provado
+está o INSERT chegando ao banco pela saída de navegação SPA — o caminho clássico. É a mesma
+disciplina do resto deste arquivo: um sinal genérico não prova a asserção específica.
+
+### A sequência causal: os três PRs estavam certos o tempo todo
+
+| # | corrigiu | era o que travava? |
+|---|---|---|
+| #1934 | o thenable preguiçoso sem `.then()` | real, mas não era o último bug |
+| #1945 | o cleanup com 3 saídas mudas (sensor) | real, e também não travava |
+| #1949 | a visita perdida ao fechar a aba | real, e também não travava |
+| — | **o aceite do SW pelo cliente** | **era isto** |
+
+O browser executava `index-DghZxghH.js` enquanto o servidor entregava `index-DnOk4g4H.js`. Nenhum
+dos três fixes estava rodando no cliente. **O que faltava não era código: era a quarta camada de
+deploy** — `registerType: 'prompt'` com `skipWaiting` removido de propósito faz o build novo instalar
+e **esperar o clique**, por tempo indefinido, por cliente. Detalhe e a regra geral em
+[`deploy.md`](../agent/deploy.md); o ponto para este arquivo é outro:
+
+> **Uma verificação por bytes prova DISPONIBILIDADE. A pergunta "o fix está agindo?" é sobre ADOÇÃO,
+> e adoção não se lê no servidor.** Foi por isso que três `exit 0` seguidos e um Publish confirmado
+> conviveram, sem contradição aparente, com uma tabela vazia.
+
+O teste só produziu dado depois de forçar o aceite: `offline_queue_v1` verificada vazia (vive no
+`localStorage`, que `caches.delete` não toca) → `unregister()` + `caches.delete('workbox-precache-v2-…')`
+→ reload → bundle trocou → sessão de 7 min → saída por navegação SPA → **201**. Ambiente restaurado
+depois (SW reinstalado e `activated`, 8 caches, fila ainda vazia).
+
+### E o desfecho previsto do par tabela × evento aconteceu: **linha SEM evento**
+
+Nenhum `dashboard.visita_tentativa` chegou ao PostHog — a ingestão estava devolvendo **503**. O par
+se comportou como projetado: a tabela é o lado **imune** (INSERT direto no Supabase), o evento é o
+lado frágil. Tivéssemos confiado só no PostHog, o veredito de hoje seria "continua quebrado".
+
+⚠️ **E uma armadilha nova, que quase entrou neste registro como número:** a query de breakdown por
+`properties.motivo` voltou **504** (`"Query has hit the max execution time"`) da API de consulta —
+que é **ausência de dado**, não zero. Um `count()` simples respondeu: `[[0]]`, exit 0. **503 na
+ingestão e 504 na consulta chegam pelo mesmo cano e só um dos três resultados é medição.** Antes de
+ler um zero do PostHog como ausência de uso, prove que a query terminou.


### PR DESCRIPTION
Fecha o #1934 **com evidência positiva**, e registra a causa raiz que nenhum dos três PRs anteriores era.

## O desfecho: `id = 1`, em três meses

```
 id |         visited_at         |  persona  | company_selection | session_minutes
----+----------------------------+-----------+-------------------+-----------------
  1 | 2026-08-24 12:29:32.543+00 | comprador | all               |               7
```

Vigília no `psql-ro` a cada 40s: `12:29:16Z linhas=0` · `12:29:58Z linhas=1`.

**A linha se corrobora sozinha** — e é isso que a torna evidência, não relato. O mount foi informado às **12:22:28Z, antes de a linha existir**; `12:29:32.543 − 12:22:28 = 7min04s`, `Math.floor` → **7**, exatamente o `session_minutes` gravado. A checagem não depende de confiar em quem reportou.

⚠️ **Ressalva registrada:** o POST saiu com `keepalive: false` — caminho do **unmount**. O `emitirComKeepalive` do #1949 **continua sem exercício real**. "O #1949 está provado" seria tratar sinal genérico como específico.

## A causa raiz: os três PRs estavam certos o tempo todo

| # | corrigiu | era o que travava? |
|---|---|---|
| #1934 | thenable preguiçoso sem `.then()` | real, mas não |
| #1945 | cleanup com 3 saídas mudas (sensor) | real, mas não |
| #1949 | visita perdida ao fechar a aba | real, mas não |
| — | **o aceite do SW pelo cliente** | **era isto** |

O browser executava `index-DghZxghH.js` enquanto o servidor entregava `index-DnOk4g4H.js`. Nenhum dos três fixes rodava no cliente. Com `registerType: "prompt"` e `skipWaiting` removido **de propósito**, o build novo instala e **espera o clique — por tempo indefinido, por cliente**. Assets antigos seguem servidos com **200**, então o SW sustenta um artefato íntegro: nada quebra, nada avisa.

> Três `exit 0` seguidos e um Publish confirmado conviveram sem contradição aparente com uma tabela vazia — porque **bytes provam disponibilidade e a pergunta era adoção**.

Por isso o [deploy.md](docs/agent/deploy.md) ganha o corolário da frase que hoje nos tranquilizou ("a verificação NÃO é cegada pelo prompt mode"): ela é verdadeira para o que mede, e cega para o que não mede.

## O par tabela × evento fez o previsto: **linha SEM evento**

Nenhum `visita_tentativa` chegou — ingestão em **503**. Confiando só no PostHog, o veredito de hoje seria "continua quebrado". A tabela é o lado imune.

E uma armadilha que quase entrou como número: a query de breakdown por `properties` voltou **504** (`"Query has hit the max execution time"`) — **ausência de dado, não zero**. Um `count()` simples respondeu `[[0]]`, exit 0. Três resultados pelo mesmo cano, só um é medição — agora tabelado no [analytics.md](docs/agent/analytics.md).

## Nota sobre o CLAUDE.md

Tentei pôr a 4ª camada na armadilha "Lovable = 3 deploys MANUAIS", mas a seção de Armadilhas está **exatamente no teto** (1079/1079 palavras) e a regra proíbe pagar encolhendo outra seção. Revertido — a lição está no `deploy.md`. Abrir espaço é decisão do founder.

## Validação

`docs:citacoes` · `docs:indice` · `docs:links` · `claude:size` — todos **exit 0** com linha de conclusão positiva.

Crédito: o teste ao vivo, o interceptor de `fetch` e o unregister do SW foram da sessão `interesting-driscoll-dfb6e1`, que também restaurou o ambiente (SW reinstalado, 8 caches, `offline_queue_v1` vazia).

🤖 Generated with [Claude Code](https://claude.com/claude-code)