### PR TITLE
feat(sonda): o conflito de dono só existia num console.warn — e medir por LISTA de estados nasce cego

### DIFF
--- a/db/prereq-watchdog-v2-20260824.sql
+++ b/db/prereq-watchdog-v2-20260824.sql
@@ -1,0 +1,304 @@
+-- ══════════════════════════════════════════════════════════════════════════════════════════
+-- FIXTURE DE TESTE — NÃO É MIGRATION. Não colar no SQL Editor; não vive em supabase/migrations/.
+-- ══════════════════════════════════════════════════════════════════════════════════════════
+-- O supabase/schema-snapshot.sql está DEFASADO em relação à máquina de episódio que a
+-- 20260814222000_data_health_watchdog_reemissao.sql instalou: faltam nele
+--   · TABELA  public.data_health_watchdog_estado  (marcador do dead-man)
+--   · FUNÇÃO  public._data_health_episodio        (máquina de episódio do vigia)
+-- Sem os dois, QUALQUER harness PG17 que EXECUTE public.data_health_watchdog() morre com
+-- 42P01 — foi o que aconteceu ao escrever db/test-data-health-carteira-identidade.sh. É o
+-- apodrecimento que docs/agent/sync.md já denuncia ("5 dos 8 harnesses apodreceram em
+-- silêncio"): o harness que só CRIA a função passa, o que a EXECUTA quebra.
+--
+-- Forma MEDIDA na PROD em 2026-08-24 via ~/.config/afiacao/psql-ro (não inventada):
+--   information_schema.columns + pg_constraint para a tabela; pg_get_functiondef para a função.
+-- Tudo idempotente: quando o snapshot for regenerado, este arquivo vira no-op.
+-- ══════════════════════════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS public.data_health_watchdog_estado (
+  id               boolean     NOT NULL DEFAULT true,
+  last_run_at      timestamptz,
+  last_success_at  timestamptz,
+  checks_avaliados integer,
+  checks_falhos    integer,
+  ultimo_erro      text,
+  atualizado_em    timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT data_health_watchdog_estado_pkey    PRIMARY KEY (id),
+  CONSTRAINT data_health_watchdog_estado_id_check CHECK (id)
+);
+
+-- singleton: a prod tem exatamente 1 linha e o watchdog lê `WHERE id` sem criar
+INSERT INTO public.data_health_watchdog_estado (id) VALUES (true) ON CONFLICT (id) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION public._data_health_episodio(p_company text, p_tipo text, p_status text, p_sev_fin text, p_titulo text, p_msg text, p_msg_email text, p_ctx jsonb, p_fingerprint text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+-- data_health reemissao v1 (mig 20260814222000) — MARCADOR do guard anti-rollback.
+-- Uma versão SUCESSORA que recrie esta máquina DEVE trocar o marcador (v2, v3…), para que
+-- re-aplicar a migration ANTIGA sobre ela ABORTE em vez de revertê-la em silêncio.
+DECLARE
+  v_sev_forn   text;
+  v_grav       int;
+  v_intervalo  interval;
+  v_row        public.fin_alertas%ROWTYPE;
+  v_fp_ant     text;
+  v_fp_email   text;
+  v_grav_email int;
+  v_ult_email  timestamptz;
+  v_ult_grav   int;
+  v_flap       boolean;
+  -- 2h = 4 ticks do cron */30. Abaixo disso é oscilação; acima, recorrência.
+  v_janela_flap interval := interval '2 hours';
+  -- Teto de e-mails por MATERIALIDADE (ver v_material). 4h ⇒ ≤6/dia no pior caso.
+  v_min_material interval := interval '4 hours';
+  v_prox       timestamptz;
+  v_ack        boolean;
+  v_snooze     boolean;
+  v_escalou    boolean;
+  v_nunca      boolean;
+  v_material   boolean;
+  v_lembrete   boolean;
+  v_deve       boolean;
+  v_motivo     text;
+  v_upd        int;
+BEGIN
+  -- Contrato fail-closed do vocabulário. NULL/typo ABORTA — nunca degrada para 'aviso'
+  -- (o CASE … ELSE do corpo antigo transformava severidade desconhecida em 'aviso' calado).
+  IF p_sev_fin IS NULL OR p_sev_fin NOT IN ('info','aviso','critico') THEN
+    RAISE EXCEPTION 'severidade de fin_alertas inválida: %', COALESCE(p_sev_fin,'<NULL>')
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_status IS NULL OR p_status NOT IN ('stale','broken','unknown') THEN
+    RAISE EXCEPTION 'status de episódio inválido: %', COALESCE(p_status,'<NULL>')
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- fornecedor_alerta tem CHECK próprio e vocabulário DIFERENTE de fin_alertas
+  -- (info/atencao/urgente vs info/aviso/critico) — derivar aqui elimina o modo de falha
+  -- "severidade inválida derruba o cron".
+  v_sev_forn := CASE p_sev_fin WHEN 'critico' THEN 'urgente'
+                               WHEN 'aviso'   THEN 'atencao'
+                               ELSE 'info' END;
+
+  -- GRAVIDADE = severidade × status. É o que pega stale→broken num check cuja severity é
+  -- literal 'warning' (reposicao_disparo): sem o eixo de status, a piora seria muda.
+  v_grav := (CASE p_sev_fin WHEN 'critico' THEN 3 WHEN 'aviso' THEN 2 ELSE 1 END) * 10
+          + (CASE p_status  WHEN 'broken'  THEN 3 WHEN 'stale' THEN 2 ELSE 1 END);
+
+  v_intervalo := CASE WHEN p_sev_fin = 'critico' THEN interval '24 hours'
+                                                 ELSE interval '72 hours' END;
+
+  -- ── 1) episódio NOVO ──────────────────────────────────────────────────────────────────────
+  -- ⚠️ ANTI-FLAP — a cadência de e-mail é por (company,tipo), NÃO por episódio. Sem isto o
+  -- desenho tem o furo ESPELHO do que corrige: um check que oscila ok↔degradado a cada tick
+  -- resolve e reabre o episódio 48×/dia, e "episódio novo ⇒ e-mail" vira tempestade. O mesmo
+  -- vale para o "dispensar" da UI, que tira a linha do índice parcial e faz o próximo tick
+  -- abrir episódio novo. Consultamos o último ENQUEUE deste tipo ATRAVESSANDO episódios
+  -- encerrados: a garantia passa a ser "no máximo 1 e-mail por cadência por tipo", com duas
+  -- saídas legítimas — nunca notificado, ou pior do que o que já foi notificado.
+  SELECT a.email_enfileirado_em, (a.contexto->>'_grav_email')::int
+    INTO v_ult_email, v_ult_grav
+    FROM public.fin_alertas a
+   WHERE a.company = p_company AND a.tipo = p_tipo AND a.email_enfileirado_em IS NOT NULL
+   ORDER BY a.email_enfileirado_em DESC
+   LIMIT 1;
+
+  -- ⚠️ O anti-flap NÃO pode calar RECORRÊNCIA LEGÍTIMA. O que distingue os dois casos é o
+  -- INTERVALO SAUDÁVEL: flapping fecha e reabre dentro de poucos ticks; um incidente que volta
+  -- depois de horas de saúde é notícia nova e merece e-mail na hora. Sem este recorte, um
+  -- pedido novo travando 2h depois de outro ser resolvido ficaria mudo até o lembrete de 72h —
+  -- exatamente o tipo de silêncio que esta migration existe para acabar.
+  SELECT (max(a.dismissed_at) > clock_timestamp() - v_janela_flap)
+    INTO v_flap
+    FROM public.fin_alertas a
+   WHERE a.company = p_company AND a.tipo = p_tipo AND a.dismissed_at IS NOT NULL;
+
+  v_deve := v_ult_email IS NULL                                    -- nunca avisou este tipo
+            OR (v_ult_grav IS NOT NULL AND v_grav > v_ult_grav)    -- voltou PIOR do que o avisado
+            OR NOT COALESCE(v_flap, false)                         -- reabertura NÃO é oscilação
+            OR clock_timestamp() >= v_ult_email + v_intervalo;     -- venceu a cadência
+
+  -- clock_timestamp() (não now()): now() é o instante do BEGIN e a transação pode ter esperado
+  -- lock/fila; um prazo relativo medido do BEGIN nasce vencido (money-path.md §2).
+  INSERT INTO public.fin_alertas (company, tipo, severidade, mensagem, contexto, email_enfileirado_em)
+  VALUES (p_company, p_tipo, p_sev_fin, p_msg,
+          COALESCE(p_ctx, '{}'::jsonb) || jsonb_build_object(
+            '_fp',            p_fingerprint,
+            '_fp_email',      CASE WHEN v_deve THEN p_fingerprint ELSE NULL END,
+            '_grav_email',    CASE WHEN v_deve THEN v_grav        ELSE v_ult_grav END,
+            '_sev_email',     CASE WHEN v_deve THEN p_sev_fin     ELSE NULL END,
+            -- Silenciado pelo anti-flap: o lembrete herda o prazo do último e-mail REAL, para
+            -- que o teto de silêncio siga sendo a cadência (24h/72h) e não o infinito.
+            '_prox_email_em', to_jsonb(CASE WHEN v_deve THEN clock_timestamp() + v_intervalo
+                                            ELSE v_ult_email + v_intervalo END),
+            '_n_emails',      CASE WHEN v_deve THEN 1 ELSE 0 END,
+            '_motivo_email',  CASE WHEN v_deve THEN 'episodio_novo' ELSE NULL END,
+            'avaliado_em',    to_jsonb(clock_timestamp())),
+          CASE WHEN v_deve THEN clock_timestamp() END)
+  ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+
+  IF FOUND THEN
+    IF v_deve THEN
+      INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+      VALUES (p_company, 'outro', v_sev_forn, p_titulo, COALESCE(p_msg_email, p_msg), 'pendente_notificacao');
+      -- ⚠️ INSERT que "tem sucesso" com ZERO linhas (um BEFORE INSERT devolvendo NULL) deixaria
+      -- o claim carimbado SEM e-mail — a "escrita que falha calada" do money-path.md §11.
+      GET DIAGNOSTICS v_upd = ROW_COUNT;
+      IF v_upd <> 1 THEN
+        RAISE EXCEPTION 'outbox nao materializou a linha (% gravadas) para %', v_upd, p_tipo
+          USING ERRCODE = '25000';
+      END IF;
+    END IF;
+    RETURN v_deve;
+  END IF;
+
+  -- ── 2) episódio ABERTO ────────────────────────────────────────────────────────────────────
+  -- FOR UPDATE trava a linha ANTES de decidir: uma 2ª sessão bloqueia aqui e, ao destravar,
+  -- relê a linha JÁ carimbada (READ COMMITTED) ⇒ deve_notificar = false ⇒ 1 e-mail, não 2.
+  SELECT * INTO v_row
+    FROM public.fin_alertas
+   WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL
+   FOR UPDATE;
+
+  -- Dispensa CONCORRENTE entre o INSERT e o SELECT: sem alerta aberto por trás, não se
+  -- enfileira e-mail fantasma. ⚠️ LANÇA em vez de devolver `false` (achado Codex E2): o caller
+  -- usa PERFORM e não lê o retorno, então um `false` aqui deixaria a fonte DEGRADADA terminar a
+  -- rodada SEM episódio ativo e ainda assim carimbar `last_success_at`. Lançando, o isolamento
+  -- por check conta a falha e o marcador de sucesso não avança — fail-closed.
+  IF NOT FOUND THEN
+    -- P0002 (no_data_found) de propósito: é falha LOCAL do check, e a classe 40 seria relançada
+    -- como sistêmica pelo isolamento do watchdog, derrubando os outros 16 por uma corrida benigna.
+    RAISE EXCEPTION 'episodio de % sumiu entre o INSERT e o lock (dispensa concorrente)', p_tipo
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- ⚠️ RE-LEITURA DEPOIS DO LOCK. A consulta lá em cima rodou ANTES de travar a linha, então
+  -- numa corrida ela traz o valor PRÉ-concorrente: a sessão B veria v_ult_email NULL, concluiria
+  -- "nunca avisou" e enfileiraria um 2º e-mail. Sob READ COMMITTED, reler após o FOR UPDATE
+  -- devolve o que a sessão A commitou — é isto que faz o claim ser de fato atômico.
+  SELECT a.email_enfileirado_em, (a.contexto->>'_grav_email')::int
+    INTO v_ult_email, v_ult_grav
+    FROM public.fin_alertas a
+   WHERE a.company = p_company AND a.tipo = p_tipo AND a.email_enfileirado_em IS NOT NULL
+   ORDER BY a.email_enfileirado_em DESC
+   LIMIT 1;
+
+  v_fp_ant     := v_row.contexto->>'_fp';
+  v_fp_email   := v_row.contexto->>'_fp_email';
+  -- ⚠️ SEM COALESCE(...,0) de propósito: gravidade AUSENTE é desconhecida, não zero — o
+  -- `ausente ≠ zero` do money-path. Com o zero, toda linha HISTÓRICA (contexto sem as âncoras
+  -- novas, como os 3 alertas presos de prod) entraria como "escalada" e passaria por cima de
+  -- reconhecimento e soneca. Quem nunca notificou não escalou nada: quem trata esse caso é o
+  -- ramo `nunca_enfileirou`, que respeita ack/soneca.
+  v_grav_email := (v_row.contexto->>'_grav_email')::int;
+  v_prox       := CASE WHEN jsonb_typeof(v_row.contexto->'_prox_email_em') = 'string'
+                       THEN (v_row.contexto->>'_prox_email_em')::timestamptz END;
+
+  v_ack    := v_row.acknowledged_at IS NOT NULL;
+  v_snooze := v_row.dismissed_until IS NOT NULL AND v_row.dismissed_until > clock_timestamp();
+
+  -- ⚠️ REARME NA RECUPERAÇÃO (padrão do tint; a 1ª versão desta migration ESQUECEU de portá-lo e
+  -- o Codex pegou). A âncora é o PICO notificado, então sem rearme: broken(23) avisa → melhora
+  -- para stale(22) → humano reconhece → volta a broken(23) e `23 > 23` é FALSO ⇒ o ack bloqueia
+  -- materialidade e lembrete, e o retorno ao mesmo patamar fica MUDO PARA SEMPRE. Fazendo a
+  -- âncora DESCER junto com a melhora, o retorno volta a ser escalada — e escalada supera ack.
+  IF v_grav_email IS NOT NULL AND v_grav < v_grav_email THEN
+    v_grav_email := v_grav;
+  END IF;
+
+  v_escalou := v_grav_email IS NOT NULL AND v_grav > v_grav_email;
+
+  -- ⚠️ "nunca enfileirou" é por TIPO, não por EPISÓDIO (v_ult_email vem da consulta acima, que
+  -- atravessa episódios encerrados). Ancorar no episódio faria o anti-flap durar UMA rodada: o
+  -- episódio reaberto e silenciado teria email_enfileirado_em NULL e emitiria no tick seguinte,
+  -- devolvendo a tempestade pela porta dos fundos.
+  v_nunca   := v_ult_email IS NULL;
+
+  -- MATERIALIDADE com confirmação em DUAS avaliações: só conta violação nova cujo fingerprint
+  -- se REPETIU (p_fingerprint = _fp da avaliação anterior) e que difere do último NOTIFICADO.
+  -- É o que torna a máquina imune a um `message` volátil sem precisar auditar os 17 checks:
+  -- fingerprint que muda toda rodada nunca se confirma ⇒ nunca vira e-mail.
+  -- `v_fp_email IS NOT NULL` é o par do bullet acima: sem ele, o episódio silenciado pelo
+  -- anti-flap (que grava _fp_email NULL) veria "IS DISTINCT FROM NULL" = true e emitiria.
+  -- ⚠️ COOLDOWN (achado Codex): a confirmação em 2 avaliações mata `A,B,A,B`, mas NÃO mata
+  -- `A,A,B,B,A,A…` — cada par confirma e emite, ~24 e-mails/dia. A confirmação prova repetição
+  -- textual, não estabilidade temporal, então o teto tem de ser um RELÓGIO. 4h limita a ~6/dia
+  -- no pior caso patológico e ainda reporta violação nova MUITO antes do lembrete (24h/72h).
+  v_material := p_fingerprint IS NOT NULL
+                AND v_fp_ant IS NOT NULL
+                AND v_fp_email IS NOT NULL
+                AND p_fingerprint = v_fp_ant
+                AND p_fingerprint IS DISTINCT FROM v_fp_email
+                AND (v_ult_email IS NULL OR clock_timestamp() >= v_ult_email + v_min_material);
+
+  -- `v_prox IS NULL` = linha SEM as âncoras novas (histórica, ou escrita por versão anterior)
+  -- que JÁ tem carimbo de e-mail: sem este bootstrap ela cai em nunca=false, escalou=false,
+  -- material=false e lembrete=false — muda para sempre (achado Codex A1). Tratar como lembrete
+  -- DEVIDO dá exatamente um e-mail; depois dele as âncoras existem e a cadência assume.
+  v_lembrete := v_prox IS NULL OR clock_timestamp() >= v_prox;
+
+  -- Escalada SUPERA reconhecimento e soneca: quem reconheceu um 'aviso' não reconheceu o
+  -- 'critico' que veio depois.
+  v_deve := v_escalou
+            OR ((NOT v_ack) AND (NOT v_snooze) AND (v_nunca OR v_material OR v_lembrete));
+
+  v_motivo := CASE WHEN NOT v_deve   THEN NULL
+                   WHEN v_escalou    THEN 'escalada'
+                   WHEN v_nunca      THEN 'nunca_enfileirou'
+                   WHEN v_material   THEN 'nova_violacao'
+                   ELSE                   'lembrete' END;
+
+  -- UPDATE INCONDICIONAL do estado (padrão do tint): o banco reflete SEMPRE o ciclo atual —
+  -- uma MELHORA parcial que não atualizasse nada deixaria o alerta mostrando o pico para sempre.
+  -- O que a histerese governa é só o E-MAIL.
+  UPDATE public.fin_alertas SET
+      severidade           = p_sev_fin,
+      mensagem             = p_msg,
+      acknowledged_at      = CASE WHEN v_escalou THEN NULL ELSE acknowledged_at END,
+      acknowledged_by      = CASE WHEN v_escalou THEN NULL ELSE acknowledged_by END,
+      email_enfileirado_em = CASE WHEN v_deve THEN clock_timestamp() ELSE email_enfileirado_em END,
+      contexto = COALESCE(p_ctx, '{}'::jsonb) || jsonb_build_object(
+          '_fp',            p_fingerprint,
+          '_fp_ant',        v_fp_ant,
+          '_fp_email',      CASE WHEN v_deve THEN p_fingerprint ELSE v_fp_email END,
+          '_grav_email',    CASE WHEN v_deve THEN v_grav        ELSE v_grav_email END,
+          '_sev_email',     CASE WHEN v_deve THEN p_sev_fin     ELSE v_row.contexto->>'_sev_email' END,
+          -- COALESCE no ELSE: sem ele uma linha sem âncora que NÃO emitiu (ack/soneca) ficaria
+          -- com _prox_email_em NULL para sempre, e o bootstrap do lembrete nunca se resolveria.
+          '_prox_email_em', CASE WHEN v_deve THEN to_jsonb(clock_timestamp() + v_intervalo)
+                                 ELSE COALESCE(v_row.contexto->'_prox_email_em',
+                                               to_jsonb(clock_timestamp() + v_intervalo)) END,
+          '_n_emails',      COALESCE((v_row.contexto->>'_n_emails')::int, 0)
+                            + CASE WHEN v_deve THEN 1 ELSE 0 END,
+          '_motivo_email',  v_motivo,
+          'avaliado_em',    to_jsonb(clock_timestamp()))
+   WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL;
+
+  GET DIAGNOSTICS v_upd = ROW_COUNT;
+  IF v_upd = 0 THEN
+    RETURN false;
+  END IF;
+
+  IF v_deve THEN
+    -- MESMA transação do carimbo: se o outbox falhar, o claim cai junto — nunca
+    -- "email_enfileirado_em preenchido sem e-mail correspondente".
+    INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+    VALUES (p_company, 'outro', v_sev_forn,
+            CASE WHEN v_escalou THEN 'AGRAVOU: ' || p_titulo ELSE p_titulo END,
+            COALESCE(p_msg_email, p_msg), 'pendente_notificacao');
+    GET DIAGNOSTICS v_upd = ROW_COUNT;
+    IF v_upd <> 1 THEN
+      RAISE EXCEPTION 'outbox nao materializou a linha (% gravadas) para %', v_upd, p_tipo
+        USING ERRCODE = '25000';
+    END IF;
+    RETURN true;
+  END IF;
+
+  RETURN false;
+END;
+$function$
+
+;

--- a/db/test-data-health-carteira-identidade.sh
+++ b/db/test-data-health-carteira-identidade.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  PROVA PG17 — 20260824091755_data_health_carteira_identidade_quarentena.sql
+# ║  bash db/test-data-health-carteira-identidade.sh > /tmp/t.log 2>&1; echo $?   ║
+# ║  (NÃO pipe pra tail — engole o exit≠0.)                                       ║
+# ║                                                                                ║
+# ║  Porta 5479 (o irmão carteira-rebuild usa 5471) pra rodar em paralelo.         ║
+# ║                                                                                ║
+# ║  O QUE PROVA: o Sentinela passa a enxergar a QUARENTENA DE IDENTIDADE da       ║
+# ║  carteira — conflict (P1-c, #1943) e ambiguous (Fatia 2), que até 2026-08-24   ║
+# ║  só existiam num console.warn de edge que ninguém lê.                          ║
+# ║                                                                                ║
+# ║  O assert que carrega o desenho é o A4 (`inactive`): o predicado é a NEGAÇÃO   ║
+# ║  `IS DISTINCT FROM 'verified'`, igual à do consumidor (carteira-rebuild:177),  ║
+# ║  então um estado SEM WRITER hoje já cai na sonda. F1 sabota isso trocando a    ║
+# ║  negação por `IN ('conflict','ambiguous')` e exige que o A4 fique VERMELHO —   ║
+# ║  é a prova de que a sonda não nasce cega para o estado que ainda não existe.   ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5479}"
+SLUG="carteira-identidade-quarentena"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }
+
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;
+SQL
+
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  OK   $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 - esperado [$3], veio [$2]"; fi; }
+# Usado na falsificação: exige que o valor NÃO seja o esperado-correto (o assert tem de virar vermelho).
+ne()  { if [ "$2" != "$3" ]; then ok "$1 (virou [$2], deixou de ser [$3])"; else bad "$1 - SABOTAGEM NAO DETECTADA: seguiu [$3]"; fi; }
+
+echo "=== setup pronto (PG17 :$PORT) ==="
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS: snapshot real (traz as 15 tabelas dos checks vizinhos
+#          E a _data_health_compute ANTIGA — assim o CREATE OR REPLACE da migration
+#          roda sobre a versão existente, igual à produção).
+# ══════════════════════════════════════════════════════════════════════════════
+RR="$(mktemp /tmp/snap-rr.XXXXXX.sql)"
+sed -E 's/^(CREATE SCHEMA public;)/-- \1/' "$REPO_ROOT/supabase/schema-snapshot.sql" \
+  | grep -vE '^\\(un)?restrict ' > "$RR"
+[ -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql" ] && P -q -f "$REPO_ROOT/supabase/schema-extensions-prelude.sql"
+P --single-transaction -q -f "$RR" >/dev/null 2>&1 || {
+  echo "!! snapshot falhou por completo — abortando (sem schema não há prova)"; exit 1; }
+rm -f "$RR"
+
+# O snapshot cria as matviews WITH NO DATA; a _data_health_compute lê customer_metrics_mv e
+# uma matview não-populada ERRA em vez de devolver 0 linhas. Popula todas (tabelas vazias => rápido).
+P -q <<'SQL'
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT schemaname, matviewname FROM pg_matviews WHERE NOT ispopulated LOOP
+    BEGIN
+      EXECUTE format('REFRESH MATERIALIZED VIEW %I.%I', r.schemaname, r.matviewname);
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'matview % nao refreshou: %', r.matviewname, SQLERRM;
+    END;
+  END LOOP;
+END $$;
+SQL
+
+# O snapshot está DEFASADO em relação ao watchdog v2 (20260814222000): faltam nele a tabela
+# data_health_watchdog_estado e a função _data_health_episodio. Sem elas o A12 (que EXECUTA o
+# watchdog — o teste late-bound que importa) morre com 42P01. Forma medida na PROD 2026-08-24.
+P -q -f "$REPO_ROOT/db/prereq-watchdog-v2-20260824.sql"
+
+BASE_CHECKS=$(Pq -c "SELECT count(*) FROM public._data_health_compute();" 2>/dev/null || echo "ERRO")
+echo "snapshot aplicado; checks ANTES da migration: $BASE_CHECKS"
+[ "$BASE_CHECKS" = "ERRO" ] && { echo "!! _data_health_compute não existe/não roda no snapshot"; exit 1; }
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 2 — APLICAR A MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+MIG="$REPO_ROOT/supabase/migrations/20260824091755_data_health_carteira_identidade_quarentena.sql"
+P -q -f "$MIG"
+echo "migration aplicada: $(basename "$MIG")"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 3 — SEEDS. carteira_membership_ledger: FK user_id -> auth.users (ON DELETE
+#          CASCADE) e CHECK source IN (backfill,trigger,rpc,sync).
+# ══════════════════════════════════════════════════════════════════════════════
+U1='aaaaaaaa-0000-0000-0000-000000000001'
+U2='aaaaaaaa-0000-0000-0000-000000000002'
+U3='aaaaaaaa-0000-0000-0000-000000000003'
+U4='aaaaaaaa-0000-0000-0000-000000000004'
+USERS=("$U1" "$U2" "$U3" "$U4")
+P -q -c "INSERT INTO auth.users(id) VALUES ('$U1'),('$U2'),('$U3'),('$U4') ON CONFLICT DO NOTHING;"
+
+# $1..$n = estados, na ordem U1,U2,U3,U4
+semear_ledger() {
+  P -q -c "TRUNCATE public.carteira_membership_ledger CASCADE;"
+  local i=0
+  for st in "$@"; do
+    P -q -c "INSERT INTO public.carteira_membership_ledger (user_id, identity_state, source, first_seen_at)
+             VALUES ('${USERS[$i]}', '$st', 'sync', now());"
+    i=$((i+1))
+  done
+}
+st_ident()   { Pq -c "SELECT status   FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';"; }
+sev_ident()  { Pq -c "SELECT severity FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';"; }
+msg_ident()  { Pq -c "SELECT message  FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';"; }
+
+echo "-- asserts --"
+
+# ── A1: espelha a PROD de 2026-08-24 (7301/7301 verified) => NASCE VERDE
+semear_ledger verified verified verified verified
+eq "A1 todos verified => ok"   "$(st_ident)"  "ok"
+eq "A1b severity verde        " "$(sev_ident)" "info"
+
+# ── A2: 1 conflict (o evento do P1-c/#1943) => degrada
+semear_ledger verified conflict verified verified
+eq "A2 1 conflict => stale"     "$(st_ident)"  "stale"
+eq "A2b severity degradada    " "$(sev_ident)" "warning"
+
+# ── A3: 1 ambiguous (Fatia 2) => degrada igual
+semear_ledger verified ambiguous verified verified
+eq "A3 1 ambiguous => stale"    "$(st_ident)"  "stale"
+
+# ── A4: ★ O ASSERT QUE CARREGA O DESENHO ★
+#    'inactive' está no CHECK mas NÃO TEM WRITER hoje. O consumidor (carteira-rebuild:177)
+#    já o quarantina por NEGAÇÃO. A sonda tem de enxergá-lo SEM ninguém editar a sonda no
+#    dia em que um writer nascer. Uma lista IN ('conflict','ambiguous') reprova aqui — é
+#    exatamente o que a falsificação F1 demonstra.
+semear_ledger verified inactive verified verified
+eq "A4 inactive (sem writer hoje) => stale" "$(st_ident)" "stale"
+
+# ── A5: ledger VAZIO => ok, não 'broken' por omissão. Esta sonda mede QUARENTENA, não
+#    frescor — frescor do rebuild é do carteira_rebuild. Assert explícito pra ninguém
+#    "consertar" isso pra broken depois.
+P -q -c "TRUNCATE public.carteira_membership_ledger CASCADE;"
+eq "A5 ledger vazio => ok (quarentena, nao frescor)" "$(st_ident)" "ok"
+
+# ── A6: a mensagem QUEBRA POR ESTADO — é o que gera a baseline pra uma faixa futura
+semear_ledger conflict conflict ambiguous verified
+eq "A6a quebra por estado" "$(Pq -c "SELECT message LIKE '%ambiguous=1, conflict=2%' FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';")" "t"
+eq "A6b conta os 3 nao-verified" "$(Pq -c "SELECT message LIKE '%: 3 membro(s) nao-verified%' FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';")" "t"
+
+# ── A7: ESTABILIDADE DE FINGERPRINT (20260814222000 confirma md5(source|status|severity|
+#    message) em 2 avaliações antes de mandar e-mail => mensagem volátil NUNCA emite).
+#    A mensagem VERMELHA não pode carregar o total do ledger, que cresce a cada membro novo.
+semear_ledger verified conflict verified verified
+FP1=$(Pq -c "SELECT md5(source||status||severity||message) FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';")
+P -q -c "INSERT INTO auth.users(id) VALUES ('aaaaaaaa-0000-0000-0000-00000000000f') ON CONFLICT DO NOTHING;"
+P -q -c "INSERT INTO public.carteira_membership_ledger (user_id, identity_state, source, first_seen_at)
+         VALUES ('aaaaaaaa-0000-0000-0000-00000000000f', 'verified', 'sync', now());"
+FP2=$(Pq -c "SELECT md5(source||status||severity||message) FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';")
+eq "A7 membro verified novo NAO muda o fingerprint vermelho" "$FP1" "$FP2"
+
+# ── A8: metadados que o consumidor lê. age/expected NULL é o contrato de check por
+#    CONTAGEM (a 20260815153218 desfez o validador que reprovava justamente isso).
+META=$(Pq -c "SELECT domain||'|'||coalesce(age_seconds::text,'NULL')||'|'||coalesce(expected_max_age_seconds::text,'NULL')
+              FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';")
+eq "A8 metadados (contagem, sem idade)" "$META" "carteira|NULL|NULL"
+
+# ── A9: how_to_fix aponta a fase 2 (a ação que a sonda existe pra acionar)
+eq "A9 remedio aponta a fase 2" "$(Pq -c "SELECT how_to_fix LIKE '%fase 2%' FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena';")" "t"
+
+# ── A10: não-regressão — ACRESCENTA um check, não substitui nenhum
+eq "A10 nao-regressao: +1 check" "$(Pq -c "SELECT count(*) FROM public._data_health_compute();")" "$((BASE_CHECKS+1))"
+eq "A10b vizinhos preservados" "$(Pq -c "SELECT count(*) FROM (
+  SELECT 'carteira_scores' s UNION ALL SELECT 'carteira_rebuild' UNION ALL SELECT 'vendas_pedidos'
+  UNION ALL SELECT 'custos_produtos' UNION ALL SELECT 'pedidos_compra_sync' UNION ALL SELECT 'alert_channel'
+) t WHERE NOT EXISTS (SELECT 1 FROM public._data_health_compute() d WHERE d.source = t.s);")" "0"
+
+# ── A11: PROMOÇÃO AO PUSH. sync.md: v_sources é a FONTE ÚNICA (filtra o compute E define o
+#    esperado do dead-man). Sem isto o check existiria só no dashboard — trocar log-de-edge
+#    por dashboard-que-ninguem-abre seria o mesmo bug com outra roupa.
+eq "A11 no v_sources do watchdog (push)" "$(Pq -c "SELECT pg_get_functiondef('public.data_health_watchdog()'::regprocedure) LIKE '%carteira_identidade_quarentena%';")" "t"
+eq "A11b no IN-list do heartbeat (resumo diario)" "$(Pq -c "SELECT pg_get_functiondef('public.fin_sync_heartbeat()'::regprocedure) LIKE '%carteira_identidade_quarentena%';")" "t"
+
+# ── A12: LATE-BOUND. O watchdog é plpgsql: mexer no v_sources só falha ao EXECUTAR.
+#    Rodar de verdade é o motivo nº 1 desta skill existir.
+semear_ledger verified conflict verified verified
+WDERR=$(P -q -c "SELECT public.data_health_watchdog();" 2>&1 >/dev/null) && WD=ok || WD=erro
+[ "$WD" = "ok" ] || echo "  ...erro do watchdog: $(echo "$WDERR" | head -3)"
+eq "A12 watchdog EXECUTA com o v_sources novo (late-bound)" "$WD" "ok"
+eq "A12b o vigia gravou alerta do source novo" "$(Pq -c "SELECT count(*)>0 FROM public.fin_alertas WHERE tipo LIKE '%carteira_identidade_quarentena%';")" "t"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 5 — FALSIFICAÇÃO (Lei #3): sabota => exige VERMELHO => restaura.
+# ══════════════════════════════════════════════════════════════════════════════
+echo "-- falsificacao --"
+
+# ── F1: ★ A FALSIFICAÇÃO CENTRAL ★ troca a NEGAÇÃO por uma LISTA de estados.
+#    É a versão "óbvia" da sonda — e é cega para todo estado que ainda não existe.
+#    O A4 (inactive) tem de ficar VERMELHO. Se não ficar, o A4 não tem dente e o
+#    predicado por negação não estava sendo provado.
+SAB1="$(mktemp /tmp/sab-ident1.XXXXXX.sql)"
+sed -E "s/l\.identity_state IS DISTINCT FROM 'verified'/l.identity_state IN ('conflict','ambiguous')/g;
+        s/l2\.identity_state IS DISTINCT FROM 'verified'/l2.identity_state IN ('conflict','ambiguous')/g" "$MIG" > "$SAB1"
+grep -q "l.identity_state IN ('conflict','ambiguous')" "$SAB1" || { echo "!! F1 nao sabotou nada (padrao nao casou)"; exit 1; }
+P -q -f "$SAB1"
+semear_ledger verified inactive verified verified
+ne "F1 lista fixa cega para 'inactive' => derruba A4" "$(st_ident)" "stale"
+semear_ledger verified conflict verified verified
+eq "F1b (a lista ainda pega conflict — a cegueira e SO no estado novo)" "$(st_ident)" "stale"
+P -q -f "$MIG"   # restaura
+semear_ledger verified inactive verified verified
+eq "F1r restaurado: A4 volta a stale" "$(st_ident)" "stale"
+rm -f "$SAB1"
+
+# ── F2: troca `IS DISTINCT FROM` por `<>` — o furo NULL-blind do CLAUDE.md. A coluna é
+#    NOT NULL hoje, então a sabotagem só é observável se a gente derrubar o NOT NULL:
+#    é exatamente o ALTER futuro contra o qual o `IS DISTINCT FROM` é seguro barato.
+P -q -c "ALTER TABLE public.carteira_membership_ledger ALTER COLUMN identity_state DROP NOT NULL;"
+P -q -c "TRUNCATE public.carteira_membership_ledger CASCADE;"
+P -q -c "INSERT INTO public.carteira_membership_ledger (user_id, identity_state, source, first_seen_at) VALUES ('$U1', NULL, 'sync', now());"
+eq "F2a real: identidade NULL cai na quarentena" "$(st_ident)" "stale"
+SAB2="$(mktemp /tmp/sab-ident2.XXXXXX.sql)"
+sed -E "s/l\.identity_state IS DISTINCT FROM 'verified'/l.identity_state <> 'verified'/g;
+        s/l2\.identity_state IS DISTINCT FROM 'verified'/l2.identity_state <> 'verified'/g" "$MIG" > "$SAB2"
+grep -q "l.identity_state <> 'verified'" "$SAB2" || { echo "!! F2 nao sabotou nada"; exit 1; }
+P -q -f "$SAB2"
+ne "F2b '<>' e NULL-blind => a linha NULL some da quarentena" "$(st_ident)" "stale"
+P -q -f "$MIG"   # restaura
+eq "F2r restaurado: NULL volta a contar" "$(st_ident)" "stale"
+rm -f "$SAB2"
+P -q -c "TRUNCATE public.carteira_membership_ledger CASCADE;"
+P -q -c "ALTER TABLE public.carteira_membership_ledger ALTER COLUMN identity_state SET NOT NULL;"
+
+# ── F3: remove o ramo inteiro (reintroduz o ponto cego que o #1943 deixou aberto).
+SAB3="$(mktemp /tmp/sab-ident3.XXXXXX.sql)"
+python3 - "$MIG" "$SAB3" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+txt = open(src, encoding="utf-8").read()
+ini_marca = "    UNION ALL\n    -- [VIGIA identidade da carteira 2026-08-24"
+fim_marca = "    ) q\n"
+assert txt.count(ini_marca) == 1, f"ancora inicial: {txt.count(ini_marca)}"
+assert txt.count(fim_marca) == 1, f"ancora final: {txt.count(fim_marca)}"
+ini = txt.index(ini_marca)
+fim = txt.index(fim_marca) + len(fim_marca)
+open(dst, "w", encoding="utf-8").write(txt[:ini] + txt[fim:])
+PY
+grep -q "carteira_identidade_quarentena'::text" "$SAB3" && { echo "!! F3 nao removeu o ramo"; exit 1; }
+P -q -f "$SAB3"
+semear_ledger verified conflict verified verified
+ne "F3 sem o ramo, o conflito volta a passar MUDO" "$(st_ident)" "stale"
+ne "F3b contagem de checks cai" "$(Pq -c "SELECT count(*) FROM public._data_health_compute();")" "$((BASE_CHECKS+1))"
+P -q -f "$MIG"   # restaura
+eq "F3r restaurado: contagem volta" "$(Pq -c "SELECT count(*) FROM public._data_health_compute();")" "$((BASE_CHECKS+1))"
+rm -f "$SAB3"
+
+# ── F4: mantém o ramo mas TIRA o source do v_sources do watchdog — o check volta a ser
+#    dashboard-only e nunca vira e-mail. É a sabotagem que prova que o A11 tem dente
+#    (sem ela, "promovi ao push" seria afirmação sem teste).
+SAB4="$(mktemp /tmp/sab-ident4.XXXXXX.sql)"
+sed "s/^    'carteira_identidade_quarentena'\];/    'pedidos_compra_sync'];/" "$MIG" > "$SAB4"
+P -q -f "$SAB4"
+ne "F4 fora do v_sources => A11 vermelho (viraria dashboard-only)" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.data_health_watchdog()'::regprocedure) LIKE '%carteira_identidade_quarentena%';")" "t"
+P -q -f "$MIG"   # restaura
+eq "F4r restaurado: volta ao push" \
+   "$(Pq -c "SELECT pg_get_functiondef('public.data_health_watchdog()'::regprocedure) LIKE '%carteira_identidade_quarentena%';")" "t"
+rm -f "$SAB4"
+
+echo "------------------------------"
+echo "RESULTADO: $PASS ok / $FAIL fail"
+[ "$FAIL" = "0" ] || { echo "HARNESS VERMELHO"; exit 1; }
+echo "HARNESS VERDE"

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **484** custom migrations totais
-- **1673** objetos esperados (criados por estas migrations)
+- **485** custom migrations totais
+- **1676** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 498
+  - `function`: 501
   - `rls_policy`: 446
   - `index`: 244
   - `cron_job`: 164
@@ -4068,6 +4068,14 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | Tipo | Objeto | Parent |
 | --- | --- | --- |
 | `function` | `public.recommend_cluster_agregado` | — |
+
+### `20260824091755_data_health_carteira_identidade_quarentena.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+| `function` | `public.data_health_watchdog` | — |
+| `function` | `public.fin_sync_heartbeat` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 484
+-- Total de custom migrations: 485
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -525,7 +525,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260821192817', 'omie_identidade_a2_client_to_user', '20260821192817_omie_identidade_a2_client_to_user.sql'),
   ('20260821194411', 'farmer_recomendacao_desfecho', '20260821194411_farmer_recomendacao_desfecho.sql'),
   ('20260821200000', 'farmer_assoc_rules_segmento', '20260821200000_farmer_assoc_rules_segmento.sql'),
-  ('20260822000358', 'recommend_cluster_agregado', '20260822000358_recommend_cluster_agregado.sql')
+  ('20260822000358', 'recommend_cluster_agregado', '20260822000358_recommend_cluster_agregado.sql'),
+  ('20260824091755', 'data_health_carteira_identidade_quarentena', '20260824091755_data_health_carteira_identidade_quarentena.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2187,7 +2188,10 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('farmer_recomendacao_desfecho', 'trigger', 'public', 'trg_frec_desfecho_imutavel', 'farmer_recommendations'),
   ('farmer_assoc_rules_segmento', 'function', 'public', 'omie_products_codigos_multi_conta', ''),
   ('farmer_assoc_rules_segmento', 'function', 'public', 'farmer_association_rules_substituir', ''),
-  ('recommend_cluster_agregado', 'function', 'public', 'recommend_cluster_agregado', '')
+  ('recommend_cluster_agregado', 'function', 'public', 'recommend_cluster_agregado', ''),
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'data_health_watchdog', ''),
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'fin_sync_heartbeat', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3897,7 +3901,10 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('farmer_recomendacao_desfecho', 'trigger', 'public', 'trg_frec_desfecho_imutavel', 'farmer_recommendations'),
   ('farmer_assoc_rules_segmento', 'function', 'public', 'omie_products_codigos_multi_conta', ''),
   ('farmer_assoc_rules_segmento', 'function', 'public', 'farmer_association_rules_substituir', ''),
-  ('recommend_cluster_agregado', 'function', 'public', 'recommend_cluster_agregado', '')
+  ('recommend_cluster_agregado', 'function', 'public', 'recommend_cluster_agregado', ''),
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'data_health_watchdog', ''),
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'fin_sync_heartbeat', '')
 )
 SELECT
   e.migration,

--- a/scripts/sql-comentarios.test.ts
+++ b/scripts/sql-comentarios.test.ts
@@ -93,12 +93,42 @@ describe('invariantes sobre as migrations REAIS', () => {
   });
 
   // Alarme que nunca se viu disparar é decoração — este prova que ele dispara.
+  //
+  // ⚠️ NÃO volte a envenenar "a maior migration, no quarto inicial": essa premissa é acidente do
+  // corpus, não invariante. Um `/*` só engole até o PRÓXIMO `*/` — e neste repo `*/` aparece
+  // DENTRO de comentário `--` como EXPRESSÃO DE CRON (`*/30`, `*/15`, `*/5`), que toda migration
+  // de Sentinela carrega. Em 2026-08-24 a 20260824091755 (sonda de identidade da carteira) passou
+  // a ser a maior do corpus e o veneno morreu num `watchdog */30` 165 linhas adiante: o teste
+  // reprovou sem nenhum defeito real, nem na migration nem no walker.
+  //
+  // Premissa robusta no lugar: envenenar o MAIOR VÃO CONTÍGUO SEM `*/` de todo o corpus. Medido
+  // em 2026-08-24 sobre 485 migrations: 53 admitem vão > 300 e 18 admitem > 600; o escolhido dá
+  // 1095 linhas, ~3,6× o teto — a mesma folga da calibração original (676–762 sobre 300), só que
+  // deixando de depender de qual arquivo é o maior.
   it('o sentinela DISPARA num arquivo envenenado (alarme não é decorativo)', () => {
-    const maior = [...migrations].sort((a, b) => b.sql.length - a.sql.length)[0];
-    const linhas = maior.sql.split('\n');
-    const corte = Math.floor(linhas.length / 4);
-    const envenenado = [...linhas.slice(0, corte), '/* bloco que nunca fecha', ...linhas.slice(corte)].join('\n');
-    expect(maiorBlocoDescartadoSql(maior.sql)).toBeLessThanOrEqual(TETO_BLOCO);
+    // início e tamanho do maior trecho de linhas consecutivas que não contêm `*/`
+    const maiorVaoSemFecho = (linhas: string[]) => {
+      const fechos = linhas.flatMap((l, i) => (l.includes('*/') ? [i] : []));
+      const marcos = [-1, ...fechos, linhas.length];
+      let melhor = { n: 0, ini: 0 };
+      for (let i = 0; i < marcos.length - 1; i++) {
+        const n = marcos[i + 1] - marcos[i];
+        if (n > melhor.n) melhor = { n, ini: marcos[i] + 1 };
+      }
+      return melhor;
+    };
+    const alvo = migrations
+      .map((m) => {
+        const linhas = m.sql.split('\n');
+        return { m, linhas, vao: maiorVaoSemFecho(linhas) };
+      })
+      .sort((a, b) => b.vao.n - a.vao.n)[0];
+    const envenenado = [
+      ...alvo.linhas.slice(0, alvo.vao.ini),
+      '/* bloco que nunca fecha',
+      ...alvo.linhas.slice(alvo.vao.ini),
+    ].join('\n');
+    expect(maiorBlocoDescartadoSql(alvo.m.sql)).toBeLessThanOrEqual(TETO_BLOCO);
     expect(maiorBlocoDescartadoSql(envenenado)).toBeGreaterThan(TETO_BLOCO);
   });
 });

--- a/supabase/migrations/20260824091755_data_health_carteira_identidade_quarentena.sql
+++ b/supabase/migrations/20260824091755_data_health_carteira_identidade_quarentena.sql
@@ -1,0 +1,961 @@
+-- ============================================================================================
+-- Migration — Sentinela: sonda de QUARENTENA DE IDENTIDADE da carteira (2026-08-24 · money-path)
+-- ============================================================================================
+-- PROBLEMA. O PR #1943 fechou o P1-c do §11 do spec 2026-07-11-omie-identidade-snapshot-atomico:
+-- quando um codigo Omie muda de dono, o writer document-first de omie-analytics-sync NAO aplica a
+-- transferencia (documento prova PAREAMENTO, nao AUTORIZA transferencia) e marca o incumbente com
+-- identity_state='conflict' em carteira_membership_ledger. A Fatia 2 ja marcava 'ambiguous' assim.
+-- O UNICO anuncio dos dois eventos era um console.warn NA EDGE. Ninguem le log de edge => o primeiro
+-- conflito real em producao passa mudo, e a fase 2 (aprovacao humana da transferencia) nunca e
+-- acionada porque ninguem sabe que houve conflito. E a armadilha do CLAUDE.md: "quando medir e
+-- QUERY, nao recado" + "Fase N+1 exige SINAL da fase N".
+--
+-- MEDIDO EM PROD 2026-08-24 (psql-ro, role claude_ro), ANTES de propor o check:
+--   SELECT identity_state, count(*) FROM public.carteira_membership_ledger GROUP BY 1
+--     -> verified|7301   (zero conflict, zero ambiguous, zero inactive)
+--   grep identity_state em supabase/migrations/*data_health* -> nenhuma sonda existente
+--   idx_cml_identity_state -> EXISTE (btree em identity_state) => a contagem e index-only, barata
+--   identity_state -> NOT NULL DEFAULT 'verified'; CHECK IN (verified, ambiguous, inactive, conflict)
+--   writers reais: 'ambiguous' (Fatia 2), 'conflict' (P1-c), 'verified' (auto-cura). 'inactive'
+--   esta no CHECK mas NAO TEM WRITER hoje.
+--
+-- PRE-FLIGHT (obrigatorio, CLAUDE.md): pg_get_functiondef das 3 funcoes tirado da PROD e comparado
+-- com o repo — prod == repo byte-a-byte (diff = so as 2 linhas 'SET' que o wrapper psql-ro imprime).
+-- Zero drift. Os corpos abaixo sao os da PROD com a UNICA mudanca descrita aqui.
+--
+-- ESTE ARQUIVO NAO ALTERA NENHUM CHECK EXISTENTE. Acrescenta UM ramo UNION ALL e promove o source
+-- novo ao push. As 3 funcoes vao JUNTAS porque sync.md exige: v_sources do watchdog e a FONTE UNICA
+-- (filtra o compute E define o esperado do dead-man via array_length) e o IN-list do heartbeat
+-- referencia os mesmos nomes — mudar o conjunto de checks sem atualizar os dois desincroniza o push.
+--   _data_health_compute : 25 -> 26 sources
+--   data_health_watchdog : v_sources 17 -> 18 (v_esperado do dead-man acompanha sozinho)
+--   fin_sync_heartbeat   : IN-list 18 -> 19 (resumo diario)
+--
+-- DECISOES (as duas que o founder pediu para eu justificar):
+--  1) PREDICADO = IS DISTINCT FROM 'verified' — o MESMO do consumidor (carteira-rebuild:177). Uma
+--     lista IN ('conflict','ambiguous') ficaria cega no dia em que um estado novo aparecer, que e
+--     exatamente o fail-open que rebuild-helpers.ts:217-221 documenta ter evitado de proposito.
+--  2) BINARIO (>=1), nao faixa. A mecanica suporta faixa (severity aqui e CASE, nao literal), mas a
+--     populacao e 7301/7301 verified e sempre foi: nao ha baseline medida para ancorar fronteira, e
+--     inventa-la e o pecado que a 20260815153218 expia. Alem disso >=1 e o limiar honesto: toda
+--     linha nao-verified e um membro com comissao ZERADA pelo consumidor. A quebra por estado vai na
+--     mensagem, entao uma faixa futura nasce de dado medido.
+--
+-- Idempotente: so CREATE OR REPLACE. Re-colar e seguro.
+-- Provado em PG17 local por db/test-data-health-carteira-identidade.sh (asserts positivos, negativos
+-- e FALSIFICACAO: sabotar o predicado / o ramo / o v_sources / o IN-list exige VERMELHO).
+-- ============================================================================================
+
+CREATE OR REPLACE FUNCTION public._data_health_compute()
+ RETURNS TABLE(source text, domain text, status text, age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text, message text, last_error text, probable_cause text, how_to_fix text, severity text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH checks AS (
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale' ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+    UNION ALL
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+    UNION ALL
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+    UNION ALL
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status='error' THEN 'broken' ELSE 'ok' END FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE((SELECT l.status FROM public.fin_sync_log l
+        WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1)='error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+    UNION ALL
+    SELECT 'vendas_pedidos'::text, 'vendas'::text,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL THEN 'broken'
+           WHEN now() - LEAST(v.oben_last, v.colacor_last) > interval '6 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(v.oben_last, v.colacor_last))::bigint,
+      (6*3600)::bigint, 'fin_sync_log.sync_pedidos'::text,
+      'Sync de pedidos: oben ' || COALESCE(to_char(v.oben_last AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        || ' · colacor ' || COALESCE(to_char(v.colacor_last AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      v.last_err,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL
+           THEN 'Cron vendas-sync-pedidos não rodou/completou para alguma conta' ELSE NULL END,
+      'Cheque os crons vendas-sync-pedidos-{oben,colacor}-2h e fin_sync_log (action sync_pedidos)'::text, 'critical'::text
+    FROM (
+      SELECT
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'oben' = ANY(l.companies)) AS oben_last,
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'colacor' = ANY(l.companies)) AS colacor_last,
+        (SELECT l.error_message FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='error' ORDER BY l.started_at DESC LIMIT 1) AS last_err
+    ) v
+    UNION ALL
+    SELECT 'estoque_inventario'::text, 'estoque'::text,
+      CASE WHEN max(ip.synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ip.synced_at) > interval '3 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ip.synced_at))::bigint, (3*3600)::bigint, 'inventory_position.synced_at',
+      'Inventário: sincronizado ' || COALESCE(to_char(max(ip.synced_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(ip.synced_at) IS NULL THEN 'sync_inventory nunca rodou' ELSE NULL END,
+      'Cheque o cron sync-inventory-vendas-30m (omie-analytics-sync sync_inventory)', 'warning'
+    FROM public.inventory_position ip
+    UNION ALL
+    SELECT 'reposicao_sugestoes'::text, 'estoque'::text,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'broken'
+           WHEN current_date - max(pcs.data_ciclo) > 3 THEN 'stale' ELSE 'ok' END,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN NULL
+           ELSE (current_date - max(pcs.data_ciclo))::bigint * 86400 END,
+      (3*86400)::bigint, 'pedido_compra_sugerido.data_ciclo',
+      'Sugestão de compra: último ciclo ' || COALESCE(to_char(max(pcs.data_ciclo),'DD/MM/YYYY'),'nunca'),
+      NULL, CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'gerar-pedidos nunca gerou sugestão' ELSE NULL END,
+      'Cheque o cron gerar-pedidos-diario-oben'::text, 'warning'
+    FROM public.pedido_compra_sugerido pcs
+    UNION ALL
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+    UNION ALL
+    -- carteira_rebuild: FRESCOR do rebuild da carteira (carteira-rebuild-nightly, 07:30 UTC).
+    -- Existia um ponto cego: o único check da família, 'carteira_scores', mede
+    -- farmer_client_scores.calculated_at — ou seja, o SCORING (calculate-scores), nao o
+    -- REBUILD. Em 2026-07-28 o cron do rebuild enfileirou, a edge nunca respondeu e
+    -- carteira_assignments ficou 24h congelada com o Sentinela VERDE, porque o scoring
+    -- daquela manha estava fresco. Dois writers distintos, dois frescores distintos.
+    SELECT 'carteira_rebuild'::text, 'carteira'::text,
+      CASE WHEN max(ca.last_synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ca.last_synced_at) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ca.last_synced_at))::bigint, (30*3600)::bigint, 'last_synced_at',
+      'Rebuild da carteira: ' || COALESCE(to_char(max(ca.last_synced_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN max(ca.last_synced_at) IS NULL THEN 'carteira-rebuild nunca rodou'
+           WHEN now() - max(ca.last_synced_at) > interval '30 hours'
+             THEN 'cron enfileirou mas a edge pode nao ter respondido (transporte pg_net / BOOT_ERROR) — cron.job_run_details so prova o ENQUEUE; a verdade HTTP esta em net._http_response (~6h de retencao) e o lease em sync_state.carteira_rebuild'
+           ELSE NULL END,
+      'Re-rode carteira-rebuild no Lovable; confira sync_state (entity_type=''carteira_rebuild'') e net._http_response'::text, 'warning'
+    FROM public.carteira_assignments ca
+    UNION ALL
+    SELECT 'custos_produtos'::text, 'estoque'::text,
+      CASE WHEN max(pc.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(pc.updated_at) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(pc.updated_at))::bigint, (30*3600)::bigint, 'product_costs.updated_at'::text,
+      'Custos de produto: recalculado ' || COALESCE(to_char(max(pc.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(pc.updated_at) IS NULL THEN 'compute_costs nunca rodou' ELSE NULL END,
+      'Cheque o cron compute-costs-daily (omie-analytics-sync compute_costs)'::text, 'warning'::text
+    FROM public.product_costs pc
+    UNION ALL
+    SELECT 'vendas_cadastros'::text, 'vendas'::text,
+      CASE WHEN vc.max_clientes IS NULL OR vc.max_produtos IS NULL THEN 'broken'
+           WHEN now() - LEAST(vc.max_clientes, vc.max_produtos) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(vc.max_clientes, vc.max_produtos))::bigint, (30*3600)::bigint,
+      'max(updated_at) de omie_customer_account_map(oben)/omie_products'::text,
+      'Cadastros Omie: clientes ' || COALESCE(to_char(vc.max_clientes AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        || ' · produtos ' || COALESCE(to_char(vc.max_produtos AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN vc.max_clientes IS NULL OR vc.max_produtos IS NULL THEN 'omie_customer_account_map(oben)/omie_products vazio (sync nunca populou)'
+           ELSE 'Nenhum cron atualizou clientes/produtos há mais de 30h' END,
+      'Cheque os crons de cadastro (sync-customers-vendas-daily / omie-cron-diario / sync-colacor-vendas-products)'::text,
+      'warning'::text
+    FROM (
+      SELECT (SELECT max(updated_at) FROM public.omie_customer_account_map WHERE account = 'oben') AS max_clientes,
+             (SELECT max(updated_at) FROM public.omie_products) AS max_produtos
+    ) vc
+    UNION ALL
+    -- Track A (ação): pedidos APROVADOS não despachados ao fornecedor. O cron disparar-pedidos-aprovados
+    -- (0 13) só processa data_ciclo=hoje → aprovação não-disparada no dia fica órfã. >2d=stale / >7d=broken.
+    SELECT 'reposicao_disparo'::text, 'estoque'::text,
+      CASE WHEN rd.aguardando = 0 THEN 'ok'
+           WHEN rd.mais_antigo_h > 168 THEN 'broken'
+           WHEN rd.mais_antigo_h > 48 THEN 'stale' ELSE 'ok' END,
+      (rd.mais_antigo_h * 3600)::bigint, (48*3600)::bigint,
+      'pedido_compra_sugerido.aprovado_em (status=aprovado_aguardando_disparo)'::text,
+      CASE WHEN rd.aguardando = 0 THEN 'Disparo de compra: nenhum pedido aprovado pendente'
+           ELSE 'Disparo de compra: ' || rd.aguardando::text || ' pedido(s) aprovado(s) aguardando disparo (mais antigo ' || COALESCE(rd.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN rd.mais_antigo_h > 48 THEN 'Pedido aprovado não foi disparado ao fornecedor (o cron disparar-pedidos-aprovados só processa o ciclo do dia → aprovações antigas ficam órfãs)' ELSE NULL END,
+      'Em /admin/reposicao: dispare (re-rode disparar-pedidos-aprovados com o pedido_id) ou cancele/expire os pedidos presos em aprovado_aguardando_disparo'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE status='aprovado_aguardando_disparo'))::int AS aguardando,
+        COALESCE(round(EXTRACT(EPOCH FROM now() - min(aprovado_em) FILTER (WHERE status='aprovado_aguardando_disparo'))/3600)::int, 0) AS mais_antigo_h,
+        to_char((min(aprovado_em) FILTER (WHERE status='aprovado_aguardando_disparo')) AT TIME ZONE 'America/Sao_Paulo','DD/MM') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+    ) rd
+    UNION ALL
+    -- Track A (ação) — PIPELINE travado: estados que o automático DEVERIA drenar e não drenou. O motor
+    -- sayerlack-retry-orfaos (*/15) re-dispara pendente_envio_portal/erro_retentavel frescos (tentativas<3,
+    -- <3d, retry não-futuro); o watchdog sayerlack-portal-watchdog (*/5) destrava enviando_portal preso.
+    -- Se um desses fica >1h, o automático parou. >1h=stale / >6h=broken.
+    SELECT 'reposicao_portal_pipeline'::text, 'estoque'::text,
+      CASE WHEN pl.pendentes = 0 THEN 'ok'
+           WHEN now() - pl.mais_antigo > interval '6 hours' THEN 'broken'
+           WHEN now() - pl.mais_antigo > interval '1 hour' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - pl.mais_antigo)::bigint, (3600)::bigint,
+      'pedido_compra_sugerido.status_envio_portal (pipeline: pendente/erro_retentavel fresco/enviando)'::text,
+      CASE WHEN pl.pendentes = 0 THEN 'Portal Sayerlack (pipeline): nada travado'
+           ELSE 'Portal Sayerlack (pipeline): ' || pl.pendentes::text || ' pedido(s) sem progredir (mais antigo ' || COALESCE(pl.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN now() - pl.mais_antigo > interval '1 hour' THEN 'O automático parou de drenar a fila do portal (motor sayerlack-retry-orfaos */15 ou watchdog sayerlack-portal-watchdog */5)' ELSE NULL END,
+      'Cheque os crons sayerlack-retry-orfaos e sayerlack-portal-watchdog + a edge enviar-pedido-portal-sayerlack (logs no Lovable)'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        count(*)::int AS pendentes,
+        min(atualizado_em) AS mais_antigo,
+        to_char(min(atualizado_em) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+      WHERE (
+        status_envio_portal IN ('pendente_envio_portal','erro_retentavel')
+        AND (portal_proximo_retry_em IS NULL OR portal_proximo_retry_em < now())
+        AND COALESCE(portal_tentativas, 0) < 3
+        AND atualizado_em >= now() - interval '3 days'
+      )
+      OR status_envio_portal = 'enviando_portal'
+    ) pl
+    UNION ALL
+    -- Track A (ação) — precisa HUMANO: estados que NÃO drenam sozinhos. indeterminado_requer_conciliacao
+    -- (PO talvez no fornecedor sem Omie — o motor NÃO toca, re-disparo duplicaria) = risco de dinheiro;
+    -- erro_nao_retentavel (SKU sem mapeamento) = compra bloqueada; aceito_portal_sem_protocolo/falha_envio_portal
+    -- = conciliação; erro_retentavel esgotado (tentativas>=3 ou >3d) = motor desistiu. >2h=stale / >24h=broken.
+    SELECT 'reposicao_portal_humano'::text, 'estoque'::text,
+      CASE WHEN hu.pendentes = 0 THEN 'ok'
+           WHEN now() - hu.mais_antigo > interval '24 hours' THEN 'broken'
+           WHEN now() - hu.mais_antigo > interval '2 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - hu.mais_antigo)::bigint, (2*3600)::bigint,
+      'pedido_compra_sugerido.status_envio_portal (humano: indeterminado/erro_nao_retentavel/aceito_sem_protocolo/falha/erro_retentavel esgotado)'::text,
+      CASE WHEN hu.pendentes = 0 THEN 'Portal Sayerlack (ação humana): nada pendente'
+           ELSE 'Portal Sayerlack (ação humana): ' || hu.pendentes::text || ' pedido(s) precisando intervenção (mais antigo ' || COALESCE(hu.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN now() - hu.mais_antigo > interval '2 hours' THEN 'Pedido(s) que o automático não resolve: conciliar indeterminado (NÃO re-disparar — duplica PO), mapear SKU (erro_nao_retentavel), ou conferir protocolo' ELSE NULL END,
+      'Em /admin/reposicao: concilie os indeterminado_requer_conciliacao (cheque o fornecedor ANTES — NÃO re-dispare), faça o de-para dos erro_nao_retentavel, e confira aceito_portal_sem_protocolo'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        count(*)::int AS pendentes,
+        min(atualizado_em) AS mais_antigo,
+        to_char(min(atualizado_em) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+      WHERE status_envio_portal IN ('indeterminado_requer_conciliacao','erro_nao_retentavel','aceito_portal_sem_protocolo','falha_envio_portal')
+         OR (status_envio_portal = 'erro_retentavel' AND (COALESCE(portal_tentativas, 0) >= 3 OR atualizado_em < now() - interval '3 days'))
+    ) hu
+    UNION ALL
+    -- Vigia (eu+codex 2026-05-31): tingidor FABRICADO internamente (omie_products.tipo_produto='04' =
+    -- Produto Acabado) que voltou ao motor de compra Sayerlack com tipo_reposicao='automatica' → o motor
+    -- o sugeriria COMPRAR no portal (é fabricado, não comprado). Fix = marcar tipo_reposicao='produto_acabado'
+    -- (motor e tela de de-para já excluem != 'automatica'). É count (não frescor) → age NULL; n>0 = stale/warning.
+    -- Join filtra account (há linha oben e vendas por SKU; o tipo_produto vem do sync da conta oben).
+    SELECT 'reposicao_sayerlack_fabricado'::text, 'estoque'::text,
+      CASE WHEN sf.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_sku_parametros_produto_acabado_no_motor_sayerlack'::text,
+      CASE WHEN sf.n = 0 THEN 'Tingidor fabricado no motor: nenhum produto acabado (04) sendo comprado da Sayerlack'
+           ELSE 'Tingidor fabricado no motor: ' || sf.n::text || ' produto(s) acabado(s) (04) no motor de compra Sayerlack — deveriam ser produto_acabado' END,
+      NULL,
+      CASE WHEN sf.n > 0 THEN 'Produto fabricado internamente (tipo_produto=04 no Omie) entrou no motor com tipo_reposicao=automatica — o motor sugeriria comprá-lo no portal' ELSE NULL END,
+      'Marcar tipo_reposicao=produto_acabado nesses tingidores 04 (re-rodar o backfill: UPDATE em public.sku_parametros, Sayerlack OBEN + tipo_produto 04) no SQL Editor'::text,
+      CASE WHEN sf.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::int AS n
+      FROM public.sku_parametros sp
+      WHERE sp.empresa = 'OBEN'
+        AND sp.fornecedor_nome ILIKE '%SAYERLACK%'
+        AND COALESCE(sp.ativo, false)
+        AND COALESCE(sp.habilitado_reposicao_automatica, false)
+        AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+        AND EXISTS (
+          SELECT 1 FROM public.omie_products o
+          WHERE o.omie_codigo_produto::text = sp.sku_codigo_omie::text
+            AND lower(o.account) = lower(sp.empresa)
+            AND COALESCE(o.tipo_produto, o.metadata->>'tipo_produto') IN ('04','4')
+        )
+    ) sf
+    UNION ALL
+    -- [cobertura do sinal 2026-06-04] saúde do PRÓPRIO tipo_produto no OBEN. O check
+    -- reposicao_sayerlack_fabricado é cego se o sinal SOME (procura '04'; sem sinal → 0 → verde).
+    -- Aqui: broken se OBEN tem produtos mas 0 classificados (sinal morto = incidente de 2026-06-04),
+    -- ou 0 com '04' (fabricados sumiram). freshness por max(updated_at). Baseline fino vs histórico = v2.
+    SELECT 'omie_tipo_produto_oben'::text, 'estoque'::text,
+      CASE WHEN tp.total = 0 THEN 'unknown'
+           WHEN tp.typed = 0 OR tp.tipo04 = 0 THEN 'broken'
+           WHEN now() - tp.ultimo > interval '48 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - tp.ultimo)::bigint, (48*3600)::bigint, 'omie_products.tipo_produto (OBEN)'::text,
+      CASE WHEN tp.typed = 0 THEN 'Sinal tipo_produto MORTO no OBEN (0 de '||tp.total||' classificados) — guarda de "não comprar fabricado" cega'
+           WHEN tp.tipo04 = 0 THEN 'Nenhum Produto Acabado (04) classificado no OBEN — sinal de fabricado sumiu'
+           ELSE 'Sinal tipo_produto OBEN: '||tp.typed||'/'||tp.total||' classificados, '||tp.tipo04||' fabricados (04)' END,
+      NULL,
+      CASE WHEN tp.typed = 0 OR tp.tipo04 = 0 THEN 'omie-sync-metadados parou de gravar tipo_produto (ou foi sobrescrito por outro sync). Rode o full sync do omie-sync-metadados (OBEN) e cheque o payload tipoItem' ELSE NULL END,
+      'Rode o omie-sync-metadados (full, OBEN) no Lovable e confira a coluna omie_products.tipo_produto'::text,
+      'critical'::text
+    FROM (
+      SELECT count(*) AS total,
+        count(*) FILTER (WHERE tipo_produto IS NOT NULL) AS typed,
+        count(*) FILTER (WHERE tipo_produto = '04') AS tipo04,
+        max(updated_at) AS ultimo
+      FROM public.omie_products WHERE account = 'oben'
+    ) tp
+    UNION ALL
+    -- [família ausente 2026-06-09, follow-up do PR #702] produto ATIVO de venda sem família
+    -- cadastrada (familia NULL ou string vazia/só-espaços). Pós-#702 (que parou de escondê-los do wizard
+    -- via o footgun NOT ILIKE+NULL), família-ausente = produto APARECE, mas o filtro de exclusão de família
+    -- NÃO o categoriza → um item que DEVERIA ser excluído (imobilizado/uso-consumo/jumbo/tingimix) cadastrado
+    -- sem família passa INDEVIDAMENTE pro catálogo. Escopo = as 2 contas do wizard (oben+colacor;
+    -- colacor_sc é serviço, fora). count → age NULL; n>0 = stale/warning (founder classifica no Omie).
+    SELECT 'vendas_familia_ausente'::text, 'vendas'::text,
+      CASE WHEN fa.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_omie_products_ativo_familia_vazia (oben+colacor)'::text,
+      CASE WHEN fa.n = 0 THEN 'Catálogo de venda: todo produto ativo tem família cadastrada'
+           ELSE 'Catálogo de venda: ' || fa.n::text || ' produto(s) ativo(s) sem família (oben ' || fa.n_oben::text || ' · colacor ' || fa.n_colacor::text || ') — classifique no Omie' END,
+      NULL,
+      CASE WHEN fa.n > 0 THEN 'Produto ativo sem família no Omie: aparece no wizard de venda, mas o filtro de exclusão de família não o categoriza (um item que deveria ser excluído passaria indevidamente)' ELSE NULL END,
+      'No Omie, preencha a família desses produtos (aparecem no wizard, mas sem categorização). Liste por: omie_products com família vazia + ativo, nas contas oben/colacor.'::text,
+      CASE WHEN fa.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::int AS n,
+        count(*) FILTER (WHERE account = 'oben')::int AS n_oben,
+        count(*) FILTER (WHERE account = 'colacor')::int AS n_colacor
+      FROM public.omie_products
+      WHERE NULLIF(btrim(familia), '') IS NULL AND COALESCE(ativo, false) AND account IN ('oben','colacor')
+    ) fa
+    UNION ALL
+    -- [estoque frescor v3 2026-07-02, incidente 30/06-02/07 · PR #1142] fonte de frescor VOLTA ao
+    -- DADO REAL: max(ultima_sincronizacao) de sku_estoque_atual (OBEN), a tabela que o MOTOR DE
+    -- COMPRA (gerar_pedidos_sugeridos_ciclo) lê. A v2 (worst-of-markers, 20260611210000) vigiava os
+    -- markers sync_state reposicao_estoque_full/reposicao_pendente_po que NUNCA passaram a ser
+    -- gravados (o passo-edge do desenho FONTE-ÚNICA #809 não foi implementado; a RPC
+    -- aplicar_snapshot_pendente existe mas nada a chama) => o check ficou 'broken' PERMANENTE desde
+    -- ~15/06 com o alerta fin_alertas preso ativo => o ON CONFLICT DO NOTHING do watchdog nunca
+    -- re-emitiu e-mail => o incidente 30/06-02/07 (snapshot 2+ dias congelado, plataforma Lovable)
+    -- passou MUDO. Princípio (docs/agent/sync.md): vigiar o EFEITO no dado; marcador só quando
+    -- EXISTE o writer que o grava.
+    -- fonte_sync LIKE 'ListarPosEstoque%' (allowlist por PREFIXO — a edge grava
+    -- 'ListarPosEstoque(N locais)' p/ SKU multi-local, omie-sync-estoque/index.ts:609; igualdade
+    -- exata deixaria esses SKUs invisíveis ao check — achado Codex challenge 2026-07-02) isola o
+    -- writer real: exclui 'cold_start_seed'
+    -- (reposicao_cold_start_parametros semeia linha nova com ultima_sincronizacao=now() — um pingo
+    -- de seed mascararia o max()) e 'snapshot_pendente_sem_fisico' (aplicar_snapshot_pendente cria
+    -- linha com ultima_sincronizacao NULL e não toca a coluna em UPDATE). Rótulo novo/renomeado =>
+    -- o max() para de andar => VERMELHO barulhento (fail-safe), nunca verde-mentindo (fail-open).
+    -- Thresholds = v1 (20260611140000, desenhados p/ ESTES crons: diário 0 9 UTC + intraday
+    -- 40 9,11,13,15,17,19 UTC): janela comercial BRT 08-18 >4h=stale; fora dela >16h=stale;
+    -- >30h/nunca=broken (cobre o pedido de ~26h do incidente com folga); max_sync no FUTURO
+    -- (>now()+5min, clock-skew tolerado) = broken (writer com relógio quebrado não compra verde
+    -- eterno — Codex). Falha pós-16:40 BRT (último intraday) só alerta ~06:40 do dia seguinte
+    -- (16h) — aceito: ainda ANTECEDE o ciclo de compra da manhã (~08:15), e estender a janela
+    -- só anteciparia um e-mail noturno que ninguém acionaria. LIMITAÇÃO aceita: max()
+    -- não vê sync PARCIAL (físico ok + pendente falho) — era o que a v2 pegaria SE os markers
+    -- existissem; quando a edge gravar os markers (#809 passo 2), re-promover a v2 POR CIMA
+    -- (migration nova; corpo da v2 preservado na 20260626150000).
+    SELECT 'estoque_reposicao'::text, 'estoque'::text,
+      CASE WHEN se.max_sync IS NULL THEN 'broken'
+           WHEN se.max_sync > now() + interval '5 minutes' THEN 'broken'
+           WHEN now() - se.max_sync > interval '30 hours' THEN 'broken'
+           WHEN now() - se.max_sync > interval '16 hours' THEN 'stale'
+           WHEN (now() AT TIME ZONE 'America/Sao_Paulo')::time >= time '08:00'
+            AND (now() AT TIME ZONE 'America/Sao_Paulo')::time <  time '18:00'
+            AND now() - se.max_sync > interval '4 hours' THEN 'stale'
+           ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - se.max_sync)::bigint, (4*3600)::bigint,
+      'max(sku_estoque_atual.ultima_sincronizacao) OBEN fonte_sync LIKE ListarPosEstoque% (dado real, v3)'::text,
+      'Estoque de reposição (motor de compra): sincronizado ' || COALESCE(to_char(se.max_sync AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN se.max_sync IS NULL OR now() - se.max_sync > interval '4 hours'
+           THEN 'A edge omie-sync-estoque parou de atualizar sku_estoque_atual (OBEN) — o snapshot de estoque físico/a-caminho que o motor de compra lê. ARMADILHA: o cron marca "succeeded" mesmo com a edge em erro (só prova o enqueue) — a verdade está em net._http_response. Estoque congelado => o motor sugere comprar o que já tem (quase double-buy: incidentes 2026-06-11 e 2026-06-30).'
+           ELSE NULL END,
+      'Dispare o sync manual (botão "Sincronizar estoque" em Reposição→Pedidos) ou rode a edge omie-sync-estoque no Lovable (body {"empresa":"OBEN"}). Cheque net._http_response dos crons omie-sync-estoque-{diario,intraday-oben}. Se LOAD_FUNCTION_ERROR: redeploy verbatim de supabase/functions/omie-sync-estoque/index.ts.'::text,
+      'critical'::text
+    FROM (
+      SELECT max(ultima_sincronizacao) FILTER (WHERE fonte_sync LIKE 'ListarPosEstoque%') AS max_sync
+      FROM public.sku_estoque_atual
+      WHERE empresa = 'OBEN'
+    ) se
+    UNION ALL
+    -- [VIGIA tint COBERTURA 2026-06-15 · Check A · PUSH] base/concentrado MixMachine ATIVO (oben) cuja
+    -- classificação tint diverge da família HÁ +30h. O cron tint-marcar-bases-diario (jobid 132) corrige
+    -- 1×/dia (08:00 BRT); a tolerância de 30h (1 ciclo + folga) evita falso-positivo de produto recém-
+    -- importado (catálogo sincroniza ~2h; watchdog */30; heartbeat às 08:00 junto do cron). created_at é o
+    -- relógio (o sync NÃO o toca em upsert; updated_at esconderia drift permanente). Sem is_tintometric →
+    -- some do mapeamento; tint_type errado → aba trocada. n>0 só após o cron ter tido a janela ⇒ stale/warning.
+    SELECT 'tint_cobertura_bases'::text, 'estoque'::text,
+      CASE WHEN t.n = 0 THEN 'ok' ELSE 'stale' END,
+      EXTRACT(EPOCH FROM t.idade_max)::bigint, (30*3600)::bigint,
+      'omie_products oben ativo familia MixMachine sem is_tintometric/tint_type correto ha >30h (created_at)'::text,
+      CASE WHEN t.n = 0 THEN 'Cobertura tint: toda base/concentrado MixMachine ativo está classificado corretamente'
+           ELSE 'Cobertura tint: '||t.n||' base(s)/concentrado(s) MixMachine ativo(s) com classificação divergente há +30h (sem is_tintometric some do mapeamento; ou tint_type na aba errada)' END,
+      NULL,
+      CASE WHEN t.n > 0 THEN 'O cron tint-marcar-bases-diario (jobid 132) não rodou/foi revertido, ou houve reclassificação manual — bases elegíveis há +30h seguem sem a marca tint correta' ELSE NULL END,
+      'Rode select public.tint_marcar_bases_mixmachine(); no SQL Editor (idempotente, só aditivo) e confira o cron tint-marcar-bases-diario via net._http_response'::text,
+      CASE WHEN t.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::bigint AS n,
+             max(now() - op.created_at) AS idade_max
+      FROM public.omie_products op
+      WHERE op.account = 'oben' AND op.ativo = true
+        AND lower(btrim(op.familia)) IN ('bases mixmachine','concentrados mixmachine')
+        AND op.created_at < now() - interval '30 hours'
+        AND ( op.is_tintometric IS NOT TRUE
+           OR op.tint_type IS DISTINCT FROM CASE lower(btrim(op.familia))
+                WHEN 'bases mixmachine' THEN 'base'
+                WHEN 'concentrados mixmachine' THEN 'concentrado' END )
+    ) t
+    UNION ALL
+    -- [VIGIA tint VÍNCULO 2026-06-15 · Check B · DASHBOARD-ONLY] validade do vínculo de venda (tint_skus):
+    -- SKU ativa (oben) apontando p/ produto Omie inativo OU de account divergente (vínculo p/ produto morto),
+    -- + produto Omie em >1 SKU ativa (useTintColorSelect lê reverso com .limit(1) ⇒ base arbitrária). FK garante
+    -- que omie_product_id existe ⇒ INNER JOIN. Ortogonal ao A (mede tint_skus, não o catálogo). FORA dos IN-lists
+    -- do watchdog/heartbeat (dashboard-only na v1: backlog não medido; promove a push em 2ª migration pós-zero).
+    SELECT 'tint_vinculo_omie'::text, 'estoque'::text,
+      CASE WHEN v.morto + v.ambiguo = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint, 'tint_skus ativa->omie inativo/divergente + omie em >1 sku ativa'::text,
+      CASE WHEN v.morto + v.ambiguo = 0 THEN 'Vínculo tint↔Omie: íntegro'
+           ELSE 'Vínculo tint↔Omie: '||v.morto||' SKU(s) ativa(s) apontando p/ produto Omie inativo/divergente, '||v.ambiguo||' produto(s) Omie em >1 SKU ativa (re-mapeamento pega base arbitrária)' END,
+      NULL,
+      CASE WHEN v.morto + v.ambiguo > 0 THEN 'SKU de venda aponta p/ produto descontinuado no Omie (some do dropdown), ou o mesmo produto Omie está vinculado a 2+ bases (vínculo ambíguo)' ELSE NULL END,
+      'Em /tintometrico/catalogo → Mapeamento: re-mapeie as SKUs apontando p/ produto inativo e desfaça os vínculos duplicados'::text,
+      CASE WHEN v.morto + v.ambiguo = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT
+        (SELECT count(*)::bigint FROM public.tint_skus ts
+           JOIN public.omie_products op ON op.id = ts.omie_product_id
+          WHERE ts.account = 'oben' AND ts.ativo IS NOT FALSE
+            AND (op.ativo IS NOT TRUE OR op.account IS DISTINCT FROM ts.account)) AS morto,
+        (SELECT count(*)::bigint FROM (
+           SELECT ts.omie_product_id FROM public.tint_skus ts
+            WHERE ts.account = 'oben' AND ts.ativo IS NOT FALSE AND ts.omie_product_id IS NOT NULL
+            GROUP BY ts.omie_product_id HAVING count(*) > 1) d) AS ambiguo
+    ) v
+    UNION ALL
+    -- [VIGIA proveniência de custo 2026-06-23 · follow-up #1019 · PUSH · INVARIANTE I1] proxy de custo carimbado
+    -- com CONFIANÇA ALTA na FONTE (product_costs). O #1019 blindou o CONSUMO (resolverCustoCockpit ganhou
+    -- `|| !sourceReal` → o cockpit de valor degrada a confiança da margem quando o source não é real); ESTE é o
+    -- complemento na FONTE, cobrindo TODOS os consumidores de uma vez (resolverCustoConfiavel + seus espelhos Deno
+    -- recommend/algorithm-a-audit, o cockpit, ranking, relatórios). I1: cost_final>0 com cost_confidence>=0.7 cujo
+    -- source NÃO é "real" (∉ whitelist consumer-real). Um proxy (FAMILY_MARGIN_PROXY/DEFAULT_PROXY/
+    -- CMC_UNIDADE_SUSPEITA/UNKNOWN/fonte nova) com conf alta ⇒ o motor (omie-analytics-sync computeCosts /
+    -- reprocessRecommendationCosts) inflou a confiança. Hoje o teto de proxy é conf=0.5 (headroom 0.2 até o
+    -- gatilho 0.7) ⇒ NASCE VERDE. count → age NULL; n>0 = stale/warning. cost_confidence NULL não conta (NULL>=0.7
+    -- = unknown), cost_final NULL/<=0 excluído por cost_final>0 (custo não-positivo não vira margem firme — fora
+    -- do escopo de "proveniência forjada que engana margem"; cost_final<0 é data-quality, check à parte).
+    -- ⚠️ NORMALIZAÇÃO casa o `.trim().toUpperCase()` do resolver TS (cost-source.ts:31-34): regexp_replace de
+    --   `\s` (espaço/tab/newline/CR) nas pontas — btrim() puro só tira espaço e deixaria ` \tCMC\n ` escapar.
+    -- ⚠️ PARIDADE: a whitelist consumer-real abaixo espelha COST_SOURCES_REAIS de src/lib/custos/cost-source.ts:22
+    --   ({PRODUCT_COST,CMC,CMC_MARGEM_ATIPICA}). Source REAL novo lá ⇒ atualizar AQUI também (senão falso-positivo).
+    SELECT 'custos_proxy_conf_alta'::text, 'estoque'::text,
+      CASE WHEN pca.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_product_costs cost_final>0 cost_confidence>=0.7 source_NAO_real (proxy carimbado conf alta)'::text,
+      CASE WHEN pca.n = 0 THEN 'Proveniência de custo: nenhum proxy carimbado com confiança alta (>=0,7)'
+           ELSE 'Proveniência de custo FORJADA: ' || pca.n::text || ' linha(s) de product_costs com source proxy (não-real) e cost_confidence>=0,7 — cockpit/recommend confiariam na margem como se fosse custo real' END,
+      NULL,
+      CASE WHEN pca.n > 0 THEN 'O motor de custo (omie-analytics-sync computeCosts / reprocessRecommendationCosts) gravou cost_confidence>=0,7 num source que NÃO é real (∉ COST_SOURCES_REAIS). É inflação de confiança na FONTE; o #1019 já degrada no consumo, mas a fonte precisa ser corrigida (senão todo consumidor que NÃO espelha o gate confia na margem).' ELSE NULL END,
+      'Liste por: product_costs com cost_final>0, cost_confidence>=0,7 e cost_source fora de {PRODUCT_COST,CMC,CMC_MARGEM_ATIPICA}. Corrija a régua de confiança no motor (_shared/cost-ladder.ts / computeCosts) e re-rode compute_costs no Lovable.'::text,
+      CASE WHEN pca.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::bigint AS n
+      FROM public.product_costs
+      WHERE cost_final > 0
+        AND cost_confidence >= 0.7
+        AND upper(regexp_replace(coalesce(cost_source,''), '^\s+|\s+$', '', 'g')) NOT IN ('PRODUCT_COST','CMC','CMC_MARGEM_ATIPICA')
+    ) pca
+    UNION ALL
+    -- [VIGIA proveniência de custo 2026-06-23 · follow-up #1019 · PUSH · INVARIANTE I2] PRODUCT_COST RESSUSCITADO.
+    -- A escada de custo (supabase/functions/_shared/cost-ladder.ts + src/lib/custo/costLadder.ts) REMOVEU
+    -- PRODUCT_COST da operação: o motor antigo lia cost_price legado como "Priority 1: PRODUCT_COST (conf 0.95)";
+    -- como cost_price era derivado/proxy, isso era LAVAGEM DE PROVENIÊNCIA (classe do incidente #977). A escada
+    -- nunca mais emite PRODUCT_COST (só CMC/CMC_MARGEM_ATIPICA/FAMILY_MARGIN_PROXY/DEFAULT_PROXY). Qualquer linha
+    -- PRODUCT_COST hoje = writer legado/forjado ressuscitando a fonte (product_costs é current-state: 1 linha/
+    -- produto, sem histórico — confirmado pre-flight 2026-06-23, então não há falso-positivo de linha antiga).
+    -- Esta invariante SUSTENTA a contradição saudável: PRODUCT_COST segue na whitelist consumer-real
+    -- (cost-source.ts:22 — p/ não nulificar um custo real legítimo se um dia voltar por um writer AUDITÁVEL) MAS
+    -- é proibido na ESCRITA atual. Sem este check, resolverCustoConfiavel E resolverCustoCockpit tratam
+    -- PRODUCT_COST como real ⇒ confiariam num custo ressuscitado. Normalização (regexp `\s` nas pontas, == o
+    -- `.trim()` do resolver TS) pega a lavagem por casing/whitespace (' product_cost ', E'\tPRODUCT_COST\n') que
+    -- escaparia o consumo→real mas o `=` literal deixaria passar. count → age NULL; n>0 = stale/warning. NASCE VERDE.
+    SELECT 'custos_product_cost_revivido'::text, 'estoque'::text,
+      CASE WHEN ppc.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_product_costs source=PRODUCT_COST (removido da escada — proveniencia)'::text,
+      CASE WHEN ppc.n = 0 THEN 'Proveniência de custo: nenhuma linha PRODUCT_COST (fonte removida da escada de custo)'
+           ELSE 'Proveniência de custo FORJADA: ' || ppc.n::text || ' linha(s) de product_costs com cost_source=PRODUCT_COST — a escada removeu essa fonte (lavagem de proveniência, classe #977); consumidores a tratam como custo real' END,
+      NULL,
+      CASE WHEN ppc.n > 0 THEN 'Um writer legado/forjado gravou cost_source=PRODUCT_COST, fonte que a escada (cost-ladder.ts) removeu da operação. resolverCustoConfiavel e resolverCustoCockpit tratam PRODUCT_COST como REAL ⇒ confiariam num custo ressuscitado sem proveniência auditável.' ELSE NULL END,
+      'Liste por: product_costs com cost_source=PRODUCT_COST (normalizado). Ache o writer que ressuscitou PRODUCT_COST — o motor deve emitir só CMC/CMC_MARGEM_ATIPICA/proxies via cost-ladder. Corrija a fonte e re-rode compute_costs no Lovable.'::text,
+      CASE WHEN ppc.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::bigint AS n
+      FROM public.product_costs
+      WHERE upper(regexp_replace(coalesce(cost_source,''), '^\s+|\s+$', '', 'g')) = 'PRODUCT_COST'
+    ) ppc
+    UNION ALL
+    SELECT 'alert_channel'::text, 'alertas'::text,
+      CASE WHEN ac.stuck_pendentes > 0 OR ac.falhas_24h >= 5 THEN 'broken'
+           WHEN ac.falhas_24h > 0 THEN 'stale' ELSE 'ok' END,
+      ac.oldest_pendente_age_seconds, (2*3600)::bigint, 'fornecedor_alerta.pendente_notificacao'::text,
+      CASE WHEN ac.stuck_pendentes > 0
+             THEN 'Canal de alerta: ' || ac.stuck_pendentes::text || ' email(s) presos há mais de 2h — dispatch parou de drenar'
+           WHEN ac.falhas_24h >= 5
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falhas de envio nas últimas 24h (falha sistêmica)'
+           WHEN ac.falhas_24h > 0
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falha(s) de envio nas últimas 24h'
+           ELSE 'Canal de alerta: drenando normalmente (' || ac.pendentes_total::text || ' na fila)' END,
+      ac.ultimo_erro,
+      CASE WHEN ac.stuck_pendentes > 0 THEN 'Cron afiacao_dispatch_notificacoes_30min não rodou ou a edge dispatch-notifications falhou (token Gmail revogado?)'
+           WHEN ac.falhas_24h > 0 THEN 'Envio de email falhando (Gmail / token / destinatário)' ELSE NULL END,
+      'Cheque a edge dispatch-notifications (logs no Lovable), o refresh token do Gmail e o net._http_response do cron afiacao_dispatch_notificacoes_30min'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS stuck_pendentes,
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao'))::bigint AS pendentes_total,
+        (count(*) FILTER (WHERE fa.status='falha_notificacao' AND fa.criado_em > now() - interval '24 hours'))::bigint AS falhas_24h,
+        EXTRACT(EPOCH FROM now() - min(fa.criado_em) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS oldest_pendente_age_seconds,
+        (SELECT f2.erro_notificacao FROM public.fornecedor_alerta f2
+          WHERE f2.status='falha_notificacao' AND f2.erro_notificacao IS NOT NULL
+          ORDER BY f2.criado_em DESC LIMIT 1) AS ultimo_erro
+      FROM public.fornecedor_alerta fa
+    ) ac
+    UNION ALL
+    -- [VIGIA pedidos de compra 2026-06-26 · eu+Codex gpt-high · PUSH] saúde do sync de pedidos de
+    -- compra (edge omie-sync-pedidos-compra → purchase_orders_tracking; alimenta leadtime + telas de
+    -- acompanhamento = money-path). A edge é fail-OPEN (handler sempre {ok:true} 200; syncEmpresa dá
+    -- break no 1º rate-limit/fault → espelho stale com 0 sincronizados, silencioso). Frescor pela TABELA
+    -- é inadequado: purchase_orders_tracking é MULTI-WRITER (nfes/ctes/sku-items também escrevem
+    -- updated_at) e ESPARSO (gaps de até 5d normais — PesquisarPedCompra filtra por previsão de entrega).
+    -- Por isso a edge grava um HEARTBEAT 1-writer em sync_state (entity_type='pedidos_compra',
+    -- account='oben' — única empresa na esteira do cron omie-cron-diario; COLACOR só por POST manual,
+    -- NÃO vigiado aqui). last_sync_at = horário do último SUCESSO (não avança em falha total → preserva
+    -- o horário bom); updated_at = heartbeat de execução (detecta 'running' órfão); status
+    -- running→complete|partial|error.
+    --   broken: marcador ausente (nunca rodou) · 'error' (coleta total falhou) · 'running' órfão >1h
+    --           (edge morreu no meio) · sem sucesso há >24h (cron/orquestrador morto) · status
+    --           desconhecido (fail-safe: só 'complete'/'running'-fresco são saudáveis).
+    --   stale : 'partial' (coleta truncada) · sucesso há >6h (atraso; cron roda a cada 2h).
+    -- severity FIXO 'critical' (money-path, = vendas_pedidos): evita o furo do ON CONFLICT do watchdog
+    -- (escalonamento de severidade no mesmo source não re-emailaria). VALUES+LEFT JOIN garante 1 linha
+    -- mesmo com marcador ausente (→ 'broken', não some do UNION).
+    SELECT 'pedidos_compra_sync'::text, 'estoque'::text,
+      CASE
+        WHEN m.marker_status IS NULL THEN 'broken'
+        WHEN m.marker_status = 'error' THEN 'broken'
+        WHEN m.marker_status = 'running' AND now() - m.updated_at > interval '1 hour' THEN 'broken'
+        WHEN m.marker_status = 'running' THEN 'ok'
+        WHEN m.last_sync_at IS NULL THEN 'broken'
+        WHEN now() - m.last_sync_at > interval '24 hours' THEN 'broken'
+        WHEN m.marker_status = 'partial' THEN 'stale'
+        WHEN now() - m.last_sync_at > interval '6 hours' THEN 'stale'
+        WHEN m.marker_status = 'complete' THEN 'ok'
+        ELSE 'broken' END,
+      EXTRACT(EPOCH FROM now() - m.last_sync_at)::bigint, (6*3600)::bigint,
+      'sync_state pedidos_compra/oben (last_sync_at=ultimo sucesso, status, updated_at=heartbeat)'::text,
+      CASE
+        WHEN m.marker_status IS NULL THEN 'Pedidos de compra (Sayerlack/Omie): heartbeat AUSENTE — a edge omie-sync-pedidos-compra nunca registrou execução'
+        WHEN m.marker_status = 'error' THEN 'Pedidos de compra: última coleta FALHOU (0 sincronizados) — ' || COALESCE(m.error_message,'erro')
+        WHEN m.marker_status = 'running' AND now() - m.updated_at > interval '1 hour' THEN 'Pedidos de compra: execução PRESA em running há ' || round((EXTRACT(EPOCH FROM now() - m.updated_at)/3600.0)::numeric, 1)::text || 'h (a edge morreu no meio do run)'
+        WHEN m.marker_status = 'running' THEN 'Pedidos de compra: sync em andamento (iniciado ' || COALESCE(to_char(m.updated_at AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'?') || ')'
+        WHEN m.marker_status = 'partial' THEN 'Pedidos de compra: última coleta PARCIAL/truncada — ' || COALESCE(m.error_message,'erros parciais') || '; última boa ' || COALESCE(to_char(m.last_sync_at AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        ELSE 'Pedidos de compra: sincronizado ' || COALESCE(to_char(m.last_sync_at AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca') || ' (' || COALESCE(m.total_synced,0)::text || ' pedidos)' END,
+      m.error_message,
+      CASE
+        WHEN m.marker_status IS NULL THEN 'A edge omie-sync-pedidos-compra nunca rodou/gravou o marcador (deploy pendente, ou o cron omie-cron-diario não a aciona).'
+        WHEN m.marker_status = 'error' THEN 'A edge coletou 0 pedidos com erro (rate-limit/fault na 1a página -> break, fail-open 200). O espelho purchase_orders_tracking ficou stale -> fura leadtime e telas de acompanhamento.'
+        WHEN m.marker_status = 'running' AND now() - m.updated_at > interval '1 hour' THEN 'A edge começou e não finalizou (timeout/OOM/kill) — pode ter deixado purchase_orders_tracking parcialmente atualizado.'
+        WHEN m.marker_status = 'partial' THEN 'A coleta truncou no meio (alguns pedidos entraram, depois erro) — a janela pode estar incompleta no espelho.'
+        ELSE 'Sem coleta bem-sucedida recente — o cron afiacao_omie_oben_sync_incremental_2h / orquestrador omie-cron-diario parou de acionar a edge, ou a edge falha de boot.' END,
+      'Cheque a edge omie-sync-pedidos-compra (logs no Lovable) + o net._http_response do cron afiacao_omie_oben_sync_incremental_2h (chama omie-cron-diario -> passo pedidos). Re-rode {empresa:"OBEN"} no chat do Lovable. Se a falha durou >3 dias, re-rode com dias>3 (ex: dias:7) — a janela padrão é 3d e não cobriria o buraco.'::text,
+      'critical'::text
+    FROM (
+      SELECT ss.last_sync_at, ss.status AS marker_status, ss.updated_at, ss.error_message, ss.total_synced
+      FROM (VALUES ('pedidos_compra'::text, 'oben'::text)) AS req(et, acc)
+      LEFT JOIN public.sync_state ss ON ss.entity_type = req.et AND ss.account = req.acc
+    ) m
+    UNION ALL
+    SELECT 'customer_metrics', 'vendas',
+      CASE WHEN max(cm.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cm.calculated_at) > interval '8 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cm.calculated_at))::bigint, (8*3600)::bigint, 'max_calculated_at',
+      'Metricas de clientes (Customer360/FilaDoDia): recalculado ' || COALESCE(to_char(max(cm.calculated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN max(cm.calculated_at) IS NULL THEN 'refresh_customer_metrics nunca rodou' ELSE 'cron afiacao_customer_metrics_refresh_6h travado ou REFRESH falhando' END,
+      'Cheque o cron afiacao_customer_metrics_refresh_6h + net._http_response; rode SELECT public.refresh_customer_metrics() como service_role no SQL Editor'::text,
+      'warning'
+    FROM private.customer_metrics_mv cm
+    UNION ALL
+    -- [VIGIA identidade da carteira 2026-08-24 · P1-c/Fatia2 · PUSH · money-path] QUARENTENA DE IDENTIDADE.
+    -- O #1943 fechou o P1-c do §11 (spec 2026-07-11-omie-identidade-snapshot-atomico-design): quando um
+    -- codigo Omie muda de dono, o writer document-first do omie-analytics-sync NAO aplica a transferencia
+    -- (documento prova PAREAMENTO, nao AUTORIZA transferencia — parecer Codex) e marca o incumbente com
+    -- identity_state='conflict'. A Fatia 2 ja marcava 'ambiguous' do mesmo jeito. Ate 2026-08-24 o unico
+    -- anuncio desses dois eventos era um console.warn NA EDGE — e ninguem le log de edge: sem esta sonda o
+    -- primeiro conflito real passa mudo e a fase 2 (aprovacao humana da transferencia) nunca e acionada.
+    --
+    -- PREDICADO = o do CONSUMIDOR, nao uma lista. O carteira-rebuild quarantina por NEGACAO
+    -- (identity_state !== 'verified', carteira-rebuild:177 / rebuild-helpers.ts:221, que documenta o porque:
+    -- testar `=== 'ambiguous'` falharia ABERTO no dia em que outro estado aparecer). Uma sonda que listasse
+    -- IN ('conflict','ambiguous') ficaria CEGA exatamente nesse dia — o espelho do mesmo bug. Por isso
+    -- IS DISTINCT FROM: mede o MESMO conjunto que o consumidor ja trata como eligible=false / zero comissao.
+    -- `IS DISTINCT FROM` e nao `<>` porque `<>` e NULL-blind (a coluna e NOT NULL DEFAULT 'verified' hoje,
+    -- mas isso e invariante que um ALTER futuro derruba; o consumidor TS tipa `string | null`).
+    --
+    -- BINARIO, nao faixa (a decisao que o founder pediu para eu justificar): a mecanica SUPORTA faixa —
+    -- severity aqui e CASE, nao literal (vide custos_proxy_conf_alta: info/warning), e a gravidade do
+    -- watchdog v2 e rank(severity)*10+rank(status), entao warning->critical re-emitiria. Mas a populacao
+    -- medida em 2026-08-24 e 7301/7301 'verified', ZERO nao-verified desde sempre: nao existe baseline
+    -- medida para ancorar uma fronteira, e inventa-la e exatamente o pecado que a 20260815153218 foi
+    -- escrita para expiar ("MECA o dado antes de propor o CHECK"). E o limiar honesto e mesmo >=1: toda
+    -- linha nao-verified e, pelo predicado do proprio consumidor, um membro com comissao ZERADA — nao ha
+    -- contagem a partir da qual isso vira aceitavel. A quebra por estado vai na MENSAGEM, entao a faixa
+    -- futura nasce de dado medido em vez de palpite.
+    --
+    -- FINGERPRINT: o watchdog v2 (20260814222000) confirma md5(source|status|severity|message) em 2
+    -- avaliacoes antes de mandar e-mail => mensagem volatil nunca emite. Por isso a mensagem VERMELHA
+    -- carrega so n + quebra-por-estado (mudam SO quando a quarentena muda, que e quando se quer episodio
+    -- novo) e o total do ledger fica so na mensagem VERDE, onde volatilidade e inocua.
+    --
+    -- Barato: 1 index-only scan em idx_cml_identity_state (ja em prod). severity warning (nao critical)
+    -- porque a quarentena e FAIL-CLOSED — zera comissao, nao fabrica numero; o lado seguro ja aconteceu e
+    -- o que falta e adjudicacao humana em dias, nao resposta em minutos. Casa a familia carteira
+    -- (carteira_scores, carteira_rebuild = warning). NASCE VERDE.
+    SELECT 'carteira_identidade_quarentena'::text, 'carteira'::text,
+      CASE WHEN q.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_carteira_membership_ledger identity_state IS DISTINCT FROM verified (mesma NEGACAO que o carteira-rebuild quarantina)'::text,
+      CASE WHEN q.n = 0
+           THEN 'Identidade da carteira: nenhum membro em quarentena (' || q.total::text || ' membro(s), todos verified)'
+           ELSE 'Identidade da carteira EM QUARENTENA: ' || q.n::text || ' membro(s) nao-verified (' || q.detalhe || ') — o carteira-rebuild os marca eligible=false e ZERA a comissao ate revisao humana' END,
+      NULL,
+      CASE WHEN q.n > 0 THEN 'O writer document-first do omie-analytics-sync viu um codigo Omie mudar de dono (P1-c) ou uma identidade ambigua (Fatia 2) e NAO aplicou a transferencia — documento prova pareamento, nao AUTORIZA transferencia. O incumbente ficou marcado e segue quarantinado (eligible=false, zero comissao) enquanto nenhum humano decidir o dono. Estado nao-verified inesperado (ex.: inactive, hoje sem writer) tambem cai aqui de proposito: o consumidor ja o trata como quarentena.' ELSE NULL END,
+      'Liste por: SELECT user_id, identity_state, source, updated_at FROM public.carteira_membership_ledger WHERE identity_state IS DISTINCT FROM ''verified'' ORDER BY updated_at DESC. Decida o dono de cada codigo Omie (fase 2 do §11 do spec 2026-07-11-omie-identidade-snapshot-atomico-design) e aplique a transferencia aprovada. Se a ambiguidade/conflito sumir na fonte, o proximo omie-analytics-sync (run oben) devolve a linha a verified sozinho — a sonda fecha sem intervencao no banco.'::text,
+      CASE WHEN q.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE l.identity_state IS DISTINCT FROM 'verified'))::bigint AS n,
+        count(*)::bigint AS total,
+        COALESCE((
+          SELECT string_agg(x.st || '=' || x.c::text, ', ' ORDER BY x.st)
+          FROM (
+            SELECT COALESCE(l2.identity_state, '(null)') AS st, count(*) AS c
+            FROM public.carteira_membership_ledger l2
+            WHERE l2.identity_state IS DISTINCT FROM 'verified'
+            GROUP BY 1
+          ) x
+        ), 'nenhum') AS detalhe
+      FROM public.carteira_membership_ledger l
+    ) q
+  )
+  -- P1: campos de "problema" (erro técnico, causa provável, remédio) só saem quando
+  -- o check NÃO está ok. Check verde = nada a reportar.
+  SELECT c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown') AS status,
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.last_error END AS last_error,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.probable_cause END AS probable_cause,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.how_to_fix END AS how_to_fix,
+    c.severity
+  FROM checks c;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.data_health_watchdog()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+-- data_health reemissao v2 (mig 20260815153218) — MARCADOR do guard anti-rollback.
+DECLARE
+  -- ⚠️ estoque_reposicao: 18º check, adicionado DIRETO EM PROD (migration fora do repo, drift §5),
+  --    promovido ao push (watchdog+heartbeat) lá. PRESERVADO aqui pra não revertê-lo do e-mail.
+  -- ⚠️ tint_vinculo_omie fica FORA de propósito (dashboard-only, [VIGIA tint 2026-06-15]).
+  -- Esta ARRAY é a fonte única: filtra o compute E define o esperado do dead-man. Duas listas
+  -- separadas driftariam, e o dead-man passaria a medir a própria omissão como sucesso.
+  v_sources text[] := ARRAY[
+    'vendas_pedidos','estoque_inventario','estoque_reposicao','reposicao_sugestoes','carteira_scores',
+    'custos_produtos','vendas_cadastros',
+    'reposicao_disparo','reposicao_portal_pipeline','reposicao_portal_humano',
+    'reposicao_sayerlack_fabricado','omie_tipo_produto_oben','vendas_familia_ausente',
+    'tint_cobertura_bases',
+    'custos_proxy_conf_alta','custos_product_cost_revivido','pedidos_compra_sync',
+    'carteira_identidade_quarentena'];
+  v_deadman_h int := 3;   -- cron é */30 ⇒ 3h = 6 rodadas completas perdidas
+  r           record;
+  v_rows      jsonb;
+  v_n         int;
+  v_ndist     int;
+  v_esperado  int := array_length(v_sources, 1);
+  v_completa  boolean;
+  v_sev_fin   text;
+  v_fp        text;
+  v_msg_email text;
+  v_falhos    int := 0;
+  v_erros     text[] := '{}';
+  v_last_ok   timestamptz;
+  v_last_run  timestamptz;
+  v_cego      boolean;
+  v_msg_dm    text;
+BEGIN
+  -- ── DEAD-MAN (avalia o estado da rodada ANTERIOR, antes de sobrescrevê-lo) ────────────────
+  SELECT last_success_at, last_run_at INTO v_last_ok, v_last_run
+    FROM public.data_health_watchdog_estado WHERE id;
+
+  -- ⚠️ O ramo `last_success_at IS NULL` é obrigatório (achado Codex A3): um vigia que NUNCA
+  -- completou uma rodada tem marcador nulo, e ancorar só no marcador o deixaria calado
+  -- exatamente no cenário pior — quebrado desde o primeiro dia.
+  v_cego := (v_last_ok IS NOT NULL AND v_last_ok < clock_timestamp() - make_interval(hours => v_deadman_h))
+         OR (v_last_ok IS NULL AND v_last_run IS NOT NULL
+             AND v_last_run < clock_timestamp() - make_interval(hours => v_deadman_h));
+
+  IF v_cego THEN
+    v_msg_dm := 'Vigia de saúde de dados sem rodada COMPLETA desde '
+             || COALESCE(to_char(v_last_ok AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI'), 'NUNCA')
+             || ' — os checks estão sendo avaliados parcialmente e um incidente pode passar mudo.';
+    -- Isolado: se o OUTBOX estiver fora, o meta-alerta não pode derrubar a avaliação dos 17
+    -- checks. O sinal que sobrevive a um outbox morto é o marcador envelhecendo, não o e-mail.
+    BEGIN
+      PERFORM public._data_health_episodio(
+        'oben', 'data_health_watchdog_degradado', 'broken', 'critico',
+        '[Saúde de dados] vigia degradado', v_msg_dm, NULL,
+        jsonb_build_object('last_success_at', v_last_ok, 'limite_horas', v_deadman_h),
+        -- fingerprint ancorado no MINUTO do último sucesso: estável enquanto o vigia seguir cego
+        -- (senão o próprio dead-man viraria a tempestade que ele existe para denunciar).
+        md5('deadman|' || COALESCE(to_char(v_last_ok, 'YYYY-MM-DD"T"HH24:MI'), 'nunca')));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'data_health_watchdog: dead-man nao pode ser enfileirado: % %', SQLSTATE, SQLERRM;
+    END;
+  ELSIF v_last_ok IS NOT NULL THEN
+    UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+     WHERE company = 'oben' AND tipo = 'data_health_watchdog_degradado' AND dismissed_at IS NULL;
+  END IF;
+
+  INSERT INTO public.data_health_watchdog_estado (id, last_run_at, atualizado_em)
+  VALUES (true, clock_timestamp(), clock_timestamp())
+  ON CONFLICT (id) DO UPDATE SET last_run_at = clock_timestamp(), atualizado_em = clock_timestamp();
+
+  -- Materializa UMA execução do compute (é caro; e duas execuções poderiam divergir entre a
+  -- checagem de duplicata e o laço).
+  -- ⚠️ ISOLADO, e o laço fica CONDICIONADO ao sucesso (achado Codex A3): o `BEGIN/EXCEPTION` do
+  -- dead-man é subtransação, NÃO transação autônoma — um erro global DEPOIS dele (compute
+  -- quebrado, fonte duplicada) abortava a transação inteira e desfazia o próprio alerta do
+  -- dead-man, repetindo isso a cada 30 min sem deixar rastro nenhum.
+  v_rows := NULL;
+  BEGIN
+    SELECT COALESCE(jsonb_agg(to_jsonb(t)), '[]'::jsonb) INTO v_rows
+      FROM public._data_health_compute() t
+     WHERE t.source = ANY (v_sources);
+  EXCEPTION WHEN OTHERS THEN
+    IF left(SQLSTATE, 2) IN ('40','53','57','58','XX') THEN
+      RAISE;
+    END IF;
+    v_falhos := v_falhos + 1;
+    v_erros  := v_erros || ('_data_health_compute: ' || SQLSTATE || ' ' || SQLERRM);
+  END;
+
+  IF v_rows IS NULL THEN
+    v_n := 0; v_ndist := 0;
+  ELSE
+    SELECT count(*), count(DISTINCT x.source) INTO v_n, v_ndist
+      FROM jsonb_to_recordset(v_rows) AS x(source text);
+
+    -- Fonte DUPLICADA: o compute está quebrado. NÃO se avalia nada (nenhum alerta ativo pode ser
+    -- resolvido com base em dado que não se pode julgar) — mas também NÃO se aborta a transação,
+    -- senão o registro de estado e o meta-alerta iriam junto. Vira rodada incompleta, alta.
+    IF v_n <> v_ndist THEN
+      v_falhos := v_falhos + 1;
+      v_erros  := v_erros || ('_data_health_compute: fonte duplicada (' || v_n || ' linhas, '
+                              || v_ndist || ' fontes distintas) — laço NAO executado');
+      v_rows   := NULL;
+    END IF;
+  END IF;
+
+  v_completa := (v_rows IS NOT NULL AND v_n = v_esperado);
+
+  FOR r IN
+    SELECT * FROM jsonb_to_recordset(COALESCE(v_rows, '[]'::jsonb)) AS x(
+      source text, "domain" text, status text, age_seconds bigint,
+      expected_max_age_seconds bigint, freshness_basis text, message text,
+      last_error text, probable_cause text, how_to_fix text, severity text)
+  LOOP
+    -- Isolamento por check: um erro em 1 não pode cegar os outros 16. O preço do isolamento é
+    -- o silêncio — pago pelo dead-man + alerta dedicado abaixo.
+    BEGIN
+      IF r.status IS NULL OR r.status NOT IN ('ok','stale','broken','unknown') THEN
+        RAISE EXCEPTION 'status desconhecido em %: %', r.source, COALESCE(r.status,'<NULL>')
+          USING ERRCODE = '22023';
+      END IF;
+      IF r.severity IS NULL OR r.severity NOT IN ('critical','warning','info') THEN
+        RAISE EXCEPTION 'severity desconhecida em %: %', r.source, COALESCE(r.severity,'<NULL>')
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF r.status = 'ok' THEN
+        -- Resolução AUTOMÁTICA: só com 'ok' EXPLÍCITO. NULL/desconhecido nunca chega aqui.
+        UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+         WHERE company = 'oben' AND tipo = 'data_health_' || r.source AND dismissed_at IS NULL;
+      ELSE
+        v_sev_fin := CASE r.severity WHEN 'critical' THEN 'critico'
+                                     WHEN 'warning'  THEN 'aviso'
+                                     ELSE 'info' END;
+
+        -- FINGERPRINT: source|status|severity|message. Sem idade, sem timestamp, sem basis.
+        v_fp := md5(r.source || '|' || r.status || '|' || r.severity || '|' || COALESCE(r.message, ''));
+
+        -- DELTA [2026-07-08]: família-ausente e tint_cobertura_bases anexam a lista dos produtos
+        -- ao corpo do e-mail. COALESCE p/ não anexar se vier NULL. A lista fica FORA do
+        -- fingerprint de propósito (é volátil e enorme; a materialidade já está na contagem).
+        v_msg_email := CASE
+          WHEN r.source = 'vendas_familia_ausente'
+            THEN r.message || COALESCE(E'\n\n' || public._vendas_familia_ausente_lista_email(50), '')
+          WHEN r.source = 'tint_cobertura_bases'
+            THEN r.message || COALESCE(E'\n\n' || public._tint_cobertura_bases_lista_email(50), '')
+          ELSE r.message END;
+
+        PERFORM public._data_health_episodio(
+          'oben', 'data_health_' || r.source, r.status, v_sev_fin,
+          '[Saúde de dados] ' || r.source, r.message, v_msg_email,
+          jsonb_build_object('source', r.source, 'domain', r.domain, 'status', r.status,
+                             'age_seconds', r.age_seconds, 'freshness_basis', r.freshness_basis),
+          v_fp);
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      -- ⚠️ `WHEN OTHERS` ENGOLE falha SISTÊMICA (achado Codex F): permissão negada, tabela/coluna
+      -- inexistente, deadlock, disco cheio, erro interno — nada disso é "problema daquele check",
+      -- e engolir 17× troca um erro alto por 17 silêncios. Isolamento vale para falha LOCAL;
+      -- classe 40 (rollback/serialização), 53 (recursos), 57 (intervenção), 58 (sistema) e XX
+      -- (interno) são relançadas e derrubam a rodada inteira, alto e visível.
+      IF left(SQLSTATE, 2) IN ('40','53','57','58','XX') THEN
+        RAISE;
+      END IF;
+      v_falhos := v_falhos + 1;
+      v_erros  := v_erros || (COALESCE(r.source,'<?>') || ': ' || SQLSTATE || ' ' || SQLERRM);
+    END;
+  END LOOP;
+
+  -- ── Marcador de sucesso: só avança em rodada COMPLETA e SEM falha ─────────────────────────
+  UPDATE public.data_health_watchdog_estado SET
+      checks_avaliados = v_n,
+      checks_falhos    = v_falhos,
+      ultimo_erro      = CASE WHEN v_falhos = 0 AND v_completa THEN NULL
+                              ELSE left(array_to_string(v_erros, ' || '), 4000) END,
+      last_success_at  = CASE WHEN v_falhos = 0 AND v_completa THEN clock_timestamp()
+                              ELSE last_success_at END,
+      atualizado_em    = clock_timestamp()
+   WHERE id;
+
+  -- Falha BARULHENTA (não silenciosa): o isolamento por check só é aceitável com este alerta.
+  IF v_falhos > 0 OR NOT v_completa THEN
+    -- Isolado pelo mesmo motivo do dead-man: quando o próprio canal de e-mail é o que quebrou,
+    -- este INSERT também quebra — e derrubar a transação aqui APAGARIA o UPDATE de estado
+    -- acima, que é justamente a evidência durável de que a rodada foi ruim.
+    BEGIN
+      PERFORM public._data_health_episodio(
+        'oben', 'data_health_watchdog_erro', 'broken', 'critico',
+        '[Saúde de dados] vigia com check falhando',
+        'Rodada incompleta do vigia: ' || v_n || ' de ' || v_esperado || ' fonte(s) presente(s), '
+          || v_falhos || ' check(s) com erro. ' || COALESCE(left(array_to_string(v_erros, ' || '), 800), ''),
+        NULL,
+        jsonb_build_object('checks_avaliados', v_n, 'checks_esperados', v_esperado,
+                           'checks_falhos', v_falhos, 'erros', to_jsonb(v_erros)),
+        md5('vigia_erro|' || v_n::text || '|' || v_falhos::text || '|' || array_to_string(v_erros, '||')));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'data_health_watchdog: alerta de erro nao pode ser enfileirado: % %', SQLSTATE, SQLERRM;
+    END;
+    RAISE WARNING 'data_health_watchdog: % check(s) falharam; % de % fontes presentes',
+      v_falhos, v_n, v_esperado;
+  ELSE
+    UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+     WHERE company = 'oben' AND tipo = 'data_health_watchdog_erro' AND dismissed_at IS NULL;
+  END IF;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.fin_sync_heartbeat()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_resumo text;
+  v_ativos int;
+  v_lista_ativos text;
+  v_dh_ativos int;
+  v_dh_resumo text;
+  v_titulo text;
+BEGIN
+  SELECT count(*) INTO v_ativos
+  FROM fin_alertas WHERE tipo LIKE 'sync_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(
+           format('%s/%s (desde %s)', company, tipo,
+                  to_char(criado_em AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI')),
+           E'\n' ORDER BY company, tipo)
+    INTO v_lista_ativos
+  FROM fin_alertas WHERE tipo LIKE 'sync_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(linha, E'\n' ORDER BY linha) INTO v_resumo
+  FROM (
+    SELECT format('%s/%s: %s', co, re,
+                  COALESCE(to_char(m.mx AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI'), 'NUNCA')) AS linha
+    FROM unnest(ARRAY['oben','colacor','colacor_sc']) AS co
+    CROSS JOIN unnest(ARRAY['contas_pagar','contas_receber','movimentacoes']) AS re
+    CROSS JOIN LATERAL (
+      SELECT max(l.completed_at) AS mx FROM fin_sync_log l
+      WHERE l.status='complete' AND l.action='sync_'||re AND co = ANY(l.companies)
+    ) m
+  ) s;
+
+  SELECT count(*) INTO v_dh_ativos
+  FROM fin_alertas WHERE tipo LIKE 'data_health_%' AND dismissed_at IS NULL;
+
+  SELECT string_agg(format('%s: %s', source, status), E'\n' ORDER BY source) INTO v_dh_resumo
+  FROM public._data_health_compute()
+  WHERE source IN ('estoque_reposicao','vendas_pedidos','estoque_inventario','reposicao_sugestoes','carteira_scores',
+                   'custos_produtos','vendas_cadastros','reposicao_disparo',
+                   'reposicao_portal_pipeline','reposicao_portal_humano',
+                   'reposicao_sayerlack_fabricado','omie_tipo_produto_oben',
+                   'vendas_familia_ausente','tint_cobertura_bases','carteira_identidade_quarentena',
+                   'custos_proxy_conf_alta','custos_product_cost_revivido','alert_channel','pedidos_compra_sync');  -- [VIGIA tint 2026-06-15] +A no resumo (B fica fora)
+
+  v_titulo := '[Watchdog'
+              || CASE WHEN (v_ativos + v_dh_ativos) > 0
+                   THEN ': '||(v_ativos + v_dh_ativos)||' alerta(s) ativo(s)'
+                   ELSE ' OK' END
+              || '] '||to_char(now() AT TIME ZONE 'America/Sao_Paulo', 'DD/MM');
+
+  INSERT INTO fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+  VALUES ('oben', 'outro', 'info',
+          v_titulo,
+          'Watchdog do sync rodou. Alertas de sync ativos: '||v_ativos||'.'||
+          CASE WHEN v_ativos > 0 THEN E'\n'||COALESCE(v_lista_ativos,'') ELSE '' END||
+          E'\n\nÚltimo sync OK por empresa/recurso (horário de Brasília):\n'||COALESCE(v_resumo,'(sem dados)')||
+          E'\n\nSaúde de dados — alertas ativos: '||v_dh_ativos||
+          E'.\nChecks de saúde de dados:\n'||COALESCE(v_dh_resumo,'(sem dados)'),
+          'pendente_notificacao');
+END;
+$function$;


### PR DESCRIPTION
## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260824091755_data_health_carteira_identidade_quarentena.sql`.
**Lovable não aplica automaticamente** — mergear NÃO toca o banco. Alguém precisa colar no SQL Editor e rodar.

O SQL tem **71 KB** (recria as 3 funções do trio acoplado a partir do corpo da PROD), então não cabe no corpo do PR.
Copie direto do arquivo:

```bash
cat supabase/migrations/20260824091755_data_health_carteira_identidade_quarentena.sql | pbcopy
```

Validação pós-apply (read-only):

```sql
SELECT
  CASE WHEN (SELECT count(*) FROM public._data_health_compute() WHERE source='carteira_identidade_quarentena') = 1
        AND pg_get_functiondef('public.data_health_watchdog()'::regprocedure) LIKE '%carteira_identidade_quarentena%'
        AND pg_get_functiondef('public.fin_sync_heartbeat()'::regprocedure)  LIKE '%carteira_identidade_quarentena%'
       THEN '✅ sonda no compute + promovida ao push'
       ELSE '❌ FALTANDO — migration não aplicada (ou aplicada pela metade)' END AS status;
```

---

## O problema

O #1943 fechou o P1-c do §11 (`docs/superpowers/specs/2026-07-11-omie-identidade-snapshot-atomico-design.md`):
quando um código Omie muda de dono, o writer document-first do `omie-analytics-sync` **não** aplica a transferência
(documento prova pareamento, não autoriza transferência) e marca o incumbente com `identity_state='conflict'`.

O único anúncio desse evento era um `console.warn` **na edge**. Ninguém lê log de edge ⇒ o primeiro conflito real
passa despercebido e a fase 2 (aprovação humana da transferência) nunca é acionada. É a armadilha do CLAUDE.md:
*"quando medir é QUERY, não recado"* + *"Fase N+1 exige SINAL da fase N"*.

## Medido em prod ANTES de propor (psql-ro, 2026-08-24)

| | |
|---|---|
| `identity_state` | `verified\|7301` — zero conflict, zero ambiguous, zero inactive |
| sonda existente | nenhuma (`grep` em `*data_health*`) |
| `idx_cml_identity_state` | existe ⇒ contagem index-only, barata |
| coluna | `NOT NULL DEFAULT 'verified'`; CHECK `(verified, ambiguous, inactive, conflict)` |
| writers reais | `ambiguous` (Fatia 2), `conflict` (P1-c), `verified` (auto-cura). **`inactive` está no CHECK e não tem writer.** |
| pré-flight `pg_get_functiondef` | prod == repo byte-a-byte, **zero drift** |

## As duas decisões de desenho

**1. Predicado = a NEGAÇÃO, não uma lista.** O consumidor quarantina por `identity_state !== 'verified'`
(`carteira-rebuild:177`), e `rebuild-helpers.ts:217` documenta *por quê*: testar `=== 'ambiguous'` falharia
ABERTO no dia em que outro estado aparecer. Uma sonda com `IN ('conflict','ambiguous')` ficaria cega exatamente
nesse dia — o espelho do mesmo bug. `IS DISTINCT FROM` e não `<>` porque `<>` é NULL-blind.

**2. Binário (≥1), não faixa.** A mecânica *suporta* faixa — `severity` aqui é `CASE`, não literal (vide
`custos_proxy_conf_alta`: info/warning), e a gravidade do watchdog v2 é `rank(severity)*10+rank(status)`, então
`warning→critical` re-emitiria. Mas a população é 7301/7301 verified e sempre foi: **não existe baseline medida
para ancorar uma fronteira**, e inventá-la é o pecado que a `20260815153218` foi escrita para expiar
("MEÇA o dado antes de propor o CHECK"). E ≥1 é o limiar honesto: toda linha não-verified é, pelo predicado do
próprio consumidor, um membro com **comissão zerada**. A quebra por estado vai na mensagem, então uma faixa
futura nasce de dado medido em vez de palpite.

**PUSH, não dashboard-only.** `v_sources` 17→18 + IN-list do heartbeat. Deixar dashboard-only trocaria
"log que ninguém lê" por "dashboard que ninguém abre" — o mesmo bug de roupa nova. `v_esperado` do dead-man
acompanha sozinho (`array_length`).

**Estabilidade de fingerprint.** O watchdog v2 confirma `md5(source|status|severity|message)` em 2 avaliações
antes de mandar e-mail ⇒ mensagem volátil **nunca emite**. Por isso a mensagem vermelha carrega só `n` +
quebra-por-estado (mudam só quando a quarentena muda); o total do ledger fica na mensagem verde. Provado no A7.

## Prova

`db/test-data-health-carteira-identidade.sh` — **29 asserts, 0 falhas**, verde em `LC_ALL=C` **e** `pt_BR.UTF-8`.

4 falsificações, todas com dente confirmado:

| | sabotagem | efeito exigido |
|---|---|---|
| F1 | negação → `IN ('conflict','ambiguous')` | A4 (`inactive`) fica **vermelho** |
| F2 | `IS DISTINCT FROM` → `<>` | linha NULL some da quarentena |
| F3 | remove o ramo | o conflito volta a passar mudo |
| F4 | tira do `v_sources` | vira dashboard-only |

A12 **executa** `data_health_watchdog()` (plpgsql é late-bound) e A12b confirma que o vigia gravou alerta do
source novo — o caminho ponta-a-ponta, não só a criação.

## Dois achados de tabela (não pedidos, encontrados no caminho)

1. **`schema-snapshot.sql` defasado**: faltam `data_health_watchdog_estado` (tabela) e `_data_health_episodio`
   (função) do watchdog v2 ⇒ **todo harness que EXECUTA o watchdog morre com 42P01**. É o apodrecimento que
   `sync.md` já denuncia. Fixture com a forma medida na prod em `db/prereq-watchdog-v2-20260824.sql` (idempotente:
   vira no-op quando o snapshot for regenerado).
2. **`scripts/sql-comentarios.test.ts` frágil**: envenenava "a maior migration, no quarto inicial" — premissa que é
   acidente do corpus. `*/` aparece dentro de comentário `--` como **expressão de cron** (`*/30`), que toda migration
   de Sentinela carrega; esta virou a maior e o veneno morreu 165 linhas adiante. Passa a envenenar o maior vão
   contíguo sem `*/` do corpus (1095 linhas, 3,6× o teto). Falsificado: sabotar o walker deixa vermelho.

## Gates

`typecheck` 0 · `lint` 0 erros · `bun run test` **734 arquivos / 7070 testes** · `shellcheck` limpo ·
`wt:preflight` 🟡 (só histórico já commitado) · `audit:migrations` regenerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
