### PR TITLE
docs(historico): "qual build o cliente executa" nao tem resposta sem abrir o browser dele

### DIFF
--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1419,3 +1419,29 @@ lado frágil. Tivéssemos confiado só no PostHog, o veredito de hoje seria "con
 que é **ausência de dado**, não zero. Um `count()` simples respondeu: `[[0]]`, exit 0. **503 na
 ingestão e 504 na consulta chegam pelo mesmo cano e só um dos três resultados é medição.** Antes de
 ler um zero do PostHog como ausência de uso, prove que a query terminou.
+
+### O sensor que falta: a versão que o cliente EXECUTA
+
+O fecho do `#1934` deixou uma pergunta cuja única resposta hoje é abrir o browser de alguém: **qual
+build cada cliente está executando?** Levou um teste inteiro para descobrir que a resposta era
+`index-DghZxghH.js` enquanto o servidor entregava `index-DnOk4g4H.js` — e a descoberta foi acidental,
+por um toast de "Nova versão disponível" aparecer num screenshot.
+
+Enquanto isso exigir inspeção manual, **a adoção do service worker é inobservável** — que é este
+arquivo aplicado à própria camada de deploy: uma fase (o Publish) declarada concluída sem sinal de que
+chegou. A diferença é que aqui o denominador não é "quantos podiam usar", é "quantos já aceitaram".
+
+O sensor é barato e o lugar dele é o payload de todo evento: **o hash do bundle em execução**
+(`import.meta.env.VITE_BUILD_ID`, ou o próprio nome do chunk do entry). Com ele:
+
+```
+adoção do deploy = clientes com build_id = <atual> / clientes que emitiram qualquer evento
+```
+
+e a pergunta "o fix está no ar?" ganha a segunda metade que faltava — **"…e quantos já o executam?"**.
+Sem isso, `verify-frontend.sh` continua respondendo sozinho uma pergunta que tem duas partes.
+
+**Não construído de propósito.** A regra deste arquivo vale para ele mesmo: a fase N aqui é o 503 da
+ingestão do PostHog, ativo em 2026-08-24 — enquanto nenhum evento entra, um sensor novo no payload
+não teria como ser lido, e instalá-lo agora seria fase N+1 sem sinal da fase N. A ordem é destravar a
+ingestão, confirmar que evento volta a chegar, e só então acrescentar o campo.


### PR DESCRIPTION
Complemento enxuto ao #1955 (já mergeado), com a única peça que faltava.

## Contexto

O #1955 registrou o desfecho do #1934 e a regra **"disponibilidade ≠ adoção"**. Este PR acrescenta o passo seguinte: **como** tornar a adoção mensurável.

## O buraco

Descobrir que o browser executava `index-DghZxghH.js` enquanto o servidor entregava `index-DnOk4g4H.js` custou um teste inteiro — e foi **acidental**: um toast de "Nova versão disponível" apareceu num screenshot. Não houve query, sensor, nem alerta. A única via de resposta era abrir o browser de alguém.

Enquanto for assim, **a adoção do service worker é inobservável** — este arquivo aplicado à própria camada de deploy. Com uma diferença que vale registrar: aqui o denominador não é "quantos podiam usar", é **"quantos já aceitaram"**.

## O sensor

Hash do bundle no payload de todo evento (`VITE_BUILD_ID`, ou o nome do chunk do entry):

```
adoção do deploy = clientes com build_id = <atual> / clientes que emitiram qualquer evento
```

Aí "o fix está no ar?" ganha a segunda metade — *"…e quantos já o executam?"*.

## Por que NÃO está construído aqui

A regra deste arquivo vale para ele mesmo. A fase N é o **503 da ingestão do PostHog**, ativo em 2026-08-24: sem evento entrando, um campo novo no payload não teria como ser lido. Instalá-lo agora seria fase N+1 sem sinal da fase N — exatamente o erro que o documento existe para impedir.

Ordem correta: destravar a ingestão → confirmar que evento volta a chegar → então acrescentar o campo.

## Coordenação

Toca **só** `docs/historico/fase-sem-sinal.md`, rebaseado sobre o #1955 já mergeado. Verifiquei antes de escrever que a armadilha da janela UTC (3 ocorrências) e adoção-vs-disponibilidade (13) **já estavam** cobertas — descartei essas partes do meu rascunho original em vez de duplicá-las. Sem PR aberto tocando o arquivo.
