### PR TITLE
docs(claude-md): a 4ª camada de deploy paga com a compactação da própria armadilha — 1079/1079, teto intacto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Diário de PR/entregas: `docs/historico/` (`bugs-resolvidos.md`, `programas-vend
 
 ## ⚠️ Armadilhas recorrentes (caras — a maioria money-path/banco; detalhe no doc/agent indicado)
 
-- **Lovable = 3 deploys MANUAIS** (Publish frontend · edge pelo chat · migration no SQL Editor) — **merge na `main` ≠ produção**. Migration custom **não** auto-aplica (falha SILENCIOSA). **Nunca** mexer em `supabase/migrations/` (snapshot é a fonte de DR). → `deploy.md`/`database.md`
+- **Lovable: 3 deploys MANUAIS** (Publish · edge · migration) — **merge ≠ produção**; custom **não** auto-aplica (SILENCIOSA); **nunca** tocar `supabase/migrations/` (=DR). **4ª: o SW só troca de build quando o cliente clica** — bytes = **disponibilidade, não adoção**. → `deploy.md`/`database.md`
 - **Acesso ao banco:** **leitura/diagnóstico EU rodo direto** via `~/.config/afiacao/psql-ro` (role `claude_ro`, read-only blindado — confiro migration aplicada/frescor/`pg_get_functiondef`/`net._http_response` sem o founder). **Escrita** só via SQL Editor do Lovable (founder cola). → `database.md` §1
 - **Sync bidirecional do Lovable pode REVERTER a main:** commit "Changes" empurra o workspace VELHO por cima de arquivo recém-mergeado (#1445→#1478). Após merge que toca `supabase/functions/`, **confira `git log -S <símbolo-novo>` do arquivo** antes de pedir o deploy; se um "Changes" atropelou, restaure por PR. → `deploy.md`
 - **PL/pgSQL é late-bound:** `CREATE` passa, a função só falha em RUNTIME → **teste EXECUTANDO** (PG17 `db/test-*.sh` / skill `prove-sql-money-path`), nunca só criando. → `money-path.md`


### PR DESCRIPTION
A armadilha `Lovable = 3 deploys MANUAIS` ganha a camada que faltava: **o aceite do service worker**.

Com `registerType: "prompt"` e `skipWaiting` removido de propósito, o build novo instala e **espera o clique — por cliente, sem prazo**. Uma verificação por bytes prova **disponibilidade, nunca adoção**. Em 2026-08-24 isso custou um teste inteiro: três PRs estavam servidos (exit 0) enquanto o browser rodava o build anterior, e a tabela vazia quase virou "o fix não pegou" ([#1955](https://github.com/LucasSardenbergL/afiacao/pull/1955) tem o caso completo).

## A conta fechou dentro da própria armadilha

A seção estava **exatamente no teto** (1079/1079) e o ratchet do `check-claude-md-budget.sh` proíbe pagar encolhendo outra seção. Cortei só o que já existe em outro lugar:

| corte | por que não é perda |
|---|---|
| `no SQL Editor` | a **linha seguinte** já diz "Escrita só via SQL Editor do Lovable (founder cola)" — era duplicata dentro do mesmo arquivo |
| `Publish frontend` → `Publish` | o contexto é a enumeração dos 3 deploys |
| `merge na main` → `merge` | idem |
| `Migration custom` → `custom` | o sujeito vem da enumeração imediatamente antes |
| `falha SILENCIOSA` → `SILENCIOSA` | idem |
| `(snapshot é a fonte de DR)` → `(=DR)` | mesma informação, notação curta |

**Nenhum invariante saiu.** O único fato que deixa de aparecer no CLAUDE.md é `edge pelo chat` — que vive em [deploy.md](docs/agent/deploy.md) (6 ocorrências), para onde a própria linha aponta. Se você preferir manter esse na frente, dá para trocar por qualquer outro corte de peso igual.

## Resultado medido

```
✅ CLAUDE.md: 17914 bytes / 2354 palavras — dentro do orçamento
   1079/1079  46%  ## ⚠️ Armadilhas recorrentes
```

Seção em **1079/1079**: teto intacto, e dentro da `FOLGA_SECAO` de 20 que exigiria re-baseline se eu tivesse encolhido demais. O arquivo total ficou em **2354 palavras — exatamente o mesmo de antes**.

`claude:size` · `docs:citacoes` · `docs:indice` · `docs:links` — todos **exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)