### PR TITLE
fix(analytics): o wrapper do PostHog servia CACHE e nao avisava — a medicao repetida era a MESMA medicao

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -132,6 +132,40 @@ permissão frouxa/401/403).
   **obrigatória** — query mal-escapada devolveria número **errado** em vez de falhar, que é
   fabricação de dado (regra do money-path).
 
+### ⚠️ O PostHog serve CACHE para query idêntica — e não avisa (2026-08-24)
+
+`SELECT count(), max(timestamp) FROM events` repetida ao longo de um dia devolveu
+`2.630 / 2026-08-23T11:09Z` durante **horas**, enquanto o valor real já era
+`2.631 / 2026-08-24T21:59Z`. O cache do PostHog casa a query **byte a byte** e
+devolve o resultado velho **sem marcar que é velho** — o JSON compacto do wrapper
+não mostra `is_cached`.
+
+O custo foi um diagnóstico inteiro na direção errada: a leitura "a ingestão aceita
+com `200 Ok` e DESCARTA o evento" nasceu de comparar um POST novo contra um
+`count()` congelado. Não havia descarte nenhum; o evento estava lá.
+
+**Corrigido em `scripts/posthog-query.sh`:** o default agora manda
+`refresh: "force_blocking"` (recalcula sempre). Para aceitar cache — mais rápido,
+e legítimo quando um valor recente basta — passe `--cache`.
+
+```bash
+scripts/posthog-query.sh "SELECT ..."            # recalcula (default, correto p/ medir)
+scripts/posthog-query.sh --cache "SELECT ..."    # aceita cache (rápido, pode MENTIR)
+scripts/posthog-query.sh --cru "SELECT ..." | jq .is_cached   # confere quem serviu
+```
+
+Falsificado: com a mesma query, o default responde `is_cached=false` e `--cache`
+responde `is_cached=true`.
+
+**A regra generalizada:** um resultado repetido não é uma segunda medição. Se duas
+leituras iguais são a sua evidência de que "nada mudou", confirme que a segunda
+foi de fato **executada** — em cache, "estável" e "congelado" são idênticos.
+
+**Irmão disso, mesmo dia:** a API de consulta pode devolver **HTTP 504**
+(*"Query has hit the max execution time"*). O wrapper agora sai com **exit 73** e
+diz que aquilo é **ausência de dado, não zero** — antes, um 504 e um `[[0]]`
+chegavam pelo mesmo cano e só um deles era medição.
+
 ## 5. Sensores de frontend já instalados
 
 `carteira.mixgap_visto` (`estado`, `total_com_gap`, `desatualizado`) ·

--- a/scripts/posthog-query.sh
+++ b/scripts/posthog-query.sh
@@ -21,6 +21,7 @@
 #   scripts/posthog-query.sh "SELECT count() FROM events WHERE ..."
 #   echo "SELECT ..." | scripts/posthog-query.sh
 #   scripts/posthog-query.sh --cru "SELECT ..."    # payload inteiro do PostHog
+#   scripts/posthog-query.sh --cache "SELECT ..."  # aceita cache (rapido, pode MENTIR)
 #
 # Saída (default): {"columns":[…],"results":[…],"row_count":N} — compacto de
 # PROPÓSITO: o payload cru traz clickhouse/hogql/explain/metadata e queima
@@ -28,6 +29,7 @@
 # SQL gerado pra depurar.
 #
 # Exit: 0=respondeu · 64=uso errado · 65=HogQL inválido (HTTP 400) ·
+#       73=query estourou o tempo (HTTP 504) — ausência de dado, NÃO zero ·
 #       68=rede/HTTP inesperado · 69=dependência ausente/quebrada ·
 #       75=rate limit (HTTP 429) · 77=sem auth (key ruim, ou HTTP 401/403)
 #
@@ -43,9 +45,17 @@ HOST="${POSTHOG_API_HOST:-https://us.posthog.com}"
 
 cru=0
 query=""
+# `force_blocking` RECALCULA sempre. O default do PostHog serve do CACHE quando a
+# query e' BYTE-A-BYTE identica a uma anterior — e devolve o resultado velho SEM
+# marcar que e' velho. Em 2026-08-24 isso custou horas: `SELECT count(), max(ts)
+# FROM events` repetida ao longo do dia congelou em 2.630/23-08 enquanto o valor
+# real ja era 2.631/24-08, e a conclusao "a ingestao aceita e DESCARTA" nasceu
+# dai. Medicao paga o recalculo; quem quiser velocidade pede --cache.
+refresh="force_blocking"
 while [ $# -gt 0 ]; do
   case "$1" in
     --cru) cru=1 ;;
+    --cache) refresh="force_cache" ;;
     -h|--help) sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
     -*) echo "❌ flag desconhecida: $1 (só existem --cru e --help)" >&2; exit 64 ;;
     *) query="$1" ;;
@@ -105,7 +115,7 @@ umask 077
 tmp="$(mktemp -d)" || { echo "❌ mktemp falhou" >&2; exit 68; }
 trap 'rm -rf "$tmp"' EXIT
 
-jq -n --arg q "$query" '{query: {kind: "HogQLQuery", query: $q}}' > "$tmp/payload.json" || {
+jq -n --arg q "$query" --arg r "$refresh" '{query: {kind: "HogQLQuery", query: $q}, refresh: $r}' > "$tmp/payload.json" || {
   echo "❌ jq falhou ao montar o corpo da requisição" >&2; exit 68; }
 
 # A key vai pelo --config e NÃO por -H: argv é visível em `ps` pra qualquer
@@ -137,6 +147,10 @@ case "$status" in
        [ "$projeto" = "@current" ] && echo "   → se a key é ESCOPADA a um projeto, @current pode não resolver: grave o id numérico em $IDFILE" >&2
        exit 77 ;;
   429) echo "❌ HTTP 429 — rate limit do PostHog. Espere e repita." >&2; exit 75 ;;
+  504) echo "❌ HTTP 504 — a query estourou o tempo de execucao do PostHog." >&2
+       echo "   Isto e' AUSENCIA DE DADO, nao zero: nada foi medido." >&2
+       echo "   → estreite a janela/colunas, ou use --cache se um valor recente servir." >&2
+       exit 73 ;;
   *) echo "❌ HTTP $status inesperado de $HOST" >&2
      head -c 800 "$tmp/body.json" >&2; echo >&2; exit 68 ;;
 esac


### PR DESCRIPTION
Investigação do "503 do PostHog" pedida pelo founder. O 503 era real, mas **transitório** — e a investigação encontrou um problema pior, nosso e permanente: **o wrapper de leitura servia cache e não avisava.**

## O que estava errado na minha própria medição

`SELECT count(), max(timestamp) FROM events`, rodada dezenas de vezes ao longo do dia, devolveu **`2.630 / 2026-08-23T11:09Z`** o tempo inteiro. O valor real já era **`2.631 / 2026-08-24T21:59Z`**.

O cache do PostHog casa a query **byte a byte** e devolve o resultado velho **sem marcar que é velho** — e o JSON compacto do wrapper nem expunha `is_cached`.

O custo foi um diagnóstico inteiro na direção errada: enviei um evento de teste, recebi `200 {"status":"Ok"}`, e o `count()` não mexia. Conclusão natural e **falsa**: *"a ingestão aceita e descarta"*. Não havia descarte — o evento estava lá.

```
SELECT count(), max(ts) FROM events            → 2630 · 2026-08-23   ❌ cache
mesma coisa + WHERE 1=1                        → 2631 · 2026-08-24   ✅
mesma coisa + refresh:"force_blocking"         → 2631 · 2026-08-24   ✅
```

## A correção

`scripts/posthog-query.sh` passa a mandar `refresh: "force_blocking"` por default. Flag `--cache` preserva o comportamento antigo para quando velocidade importa mais que frescor.

**Falsificado** com a mesma query nos dois modos:

```
default   is_cached=false   ← recalculou
--cache   is_cached=true    ← serviu do cache
```

A flag tem efeito observável no servidor, não só no argv.

## O irmão da armadilha

A API de consulta pode devolver **HTTP 504** (*"Query has hit the max execution time"*) — visto hoje pela sessão par, que quase reportou "0 eventos" apoiada numa query que **falhou**. Agora sai com **exit 73** e diz que aquilo é **ausência de dado, não zero**.

Um 504 e um `[[0]]` chegavam pelo mesmo cano, e só um deles é medição.

## Sobre o 503 em si (para o registro)

- **Não é incidente do PostHog**: status page US Cloud marca `Event Ingestion Success 100.00%` no período; os incidentes recentes são 17–20/08, nenhum em 23–24/08.
- **Não é quota**: o volume é irrisório (11, 7, 19, 16 eventos/dia; 2.631 em 3 meses) e session replay tem 0 gravações.
- **Não é adblock**: a requisição saía e voltava com status HTTP.
- **É transitório**: a ingestão aceitou meu evento às 21:59 e ele chegou.

O azar foi de janela: o 503 cobriu ~12:17–12:30Z, exatamente o único período de uso real do app naquele dia (meus três testes do #1934). Os eventos daquelas visitas foram perdidos de vez — o SDK tentou 3 retries e desistiu.

## A regra registrada

> **Um resultado repetido não é uma segunda medição.** Se duas leituras iguais são a evidência de que "nada mudou", confirme que a segunda foi de fato **executada** — em cache, "estável" e "congelado" são idênticos.
