### PR TITLE
test(heavy): o controle positivo ficou VERDE — o "15/15" que entreguei não provava nada

### DIFF
--- a/docs/historico/vigia-de-cobertura-parcial.md
+++ b/docs/historico/vigia-de-cobertura-parcial.md
@@ -110,6 +110,48 @@ O que isso autoriza dizer — e o que não autoriza:
 Evidência boa, não prova. Foi registrar o `load` de cada execução que tornou essa distinção
 visível: colher só o exit code teria produzido um "15/15" que soa definitivo e não é.
 
+### O controle positivo ficou VERDE — e por isso o "15/15" não era a evidência (2026-08-24)
+
+Repetir a medição não resolve a dúvida acima, porque repetir num regime fácil só produz verdes
+baratos. O desenho que resolveria é um **controle positivo**: rodar também a versão *sabotada*
+(o `sleep` fixo pré-conserto) sob a MESMA condição. Se a sabotada não fica vermelha, a condição
+não reproduz o defeito — e aí nenhum verde do código atual significa nada.
+
+Feito assim: 6 instâncias sabotadas + 6 atuais **no mesmo pool simultâneo** (pareamento exato de
+carga), 3 rodadas.
+
+| Braço | Código | Resultado |
+|---|---|---|
+| C | sabotado (`sleep 1` / `sleep 2`) | **18/18 verdes** ← devia falhar |
+| D | atual (`esperar_slots`) | 18/18 verdes |
+
+**O controle falhou.** Logo o braço D não prova nada — é ausência de dado, não aprovação. E o
+mesmo vale retroativamente para o "15/15" da seção anterior.
+
+Por que não reproduziu, medido em vez de suposto — cronometrando o que o bug de fato dependia,
+o tempo até o ocupante REGISTRAR o slot (n=20, `load` ~5):
+
+| | |
+|---|---|
+| mediana | 0,026 s |
+| p90 | 0,034 s |
+| máximo | 0,043 s |
+| limiar que o código sabotado dava | 1,000 s |
+
+Margem de **23× a 55×**. A máquina precisaria estar ~23 vezes mais lenta para o `sleep 1` estourar
+— e em 2026-08-23 ela estava (`load` 30–79 com swap em thrashing, contra ~5 agora).
+
+**A evidência que fecha a questão não é amostral, é estrutural.** O código antigo esperava 1 s
+fixo e media; o novo espera a CONDIÇÃO por até 15 s. Para qualquer latência L: se L ≤ 1 s os dois
+passam; se 1 s < L ≤ 15 s o antigo falha e o novo passa; se L > 15 s ambos falham, mas o novo
+reporta falha de SETUP em vez de acusar o `--status`. O novo **domina** o antigo — nunca pior,
+15× mais folga. Isso vale sem depender de reproduzir o flaky, que é bom, porque reproduzi-lo
+exige uma máquina em sofrimento que ninguém consegue agendar.
+
+**Regra que fica.** *Quando o controle positivo não fica vermelho, o braço verde não vale nada* — e
+medir a MARGEM (quanto o limiar excede a latência real) substitui a estatística de amostra com
+vantagem: dá um número mecanicista em 20 execuções de 40 ms, em vez de um `n` que nunca fecha.
+
 ## Lições
 
 1. **Gate anti-órfão é código como outro qualquer — pergunte de que ele é cego.** O sintoma é

--- a/scripts/hooks-suites-baseline.ts
+++ b/scripts/hooks-suites-baseline.ts
@@ -23,9 +23,10 @@ export const SUITES_FORA_DO_CI: SuiteForaDoCI[] = [
       'disputa — o `heavy` não existe no runner ubuntu (exit 127). Leva ~50s. Rodar à mão na M2 ' +
       'ao mexer em scripts/heavy.sh. (Era também FLAKY: 2 vermelhos em 13 execuções, ~15%, ' +
       'sempre na asserção do `--status` sob sobrecarga — o setup sincronizava por `sleep` fixo e ' +
-      'sob carga alta media um mundo meio-montado. Consertado com espera por CONDIÇÃO e ' +
-      're-medido em 2026-08-24: 15/15 verdes, 8 delas sob load >=20 — o regime que produzia ' +
-      'o flaky. O motivo de estar aqui é só o macOS-only.)',
+      'sob carga alta media um mundo meio-montado. Consertado com espera por CONDIÇÃO até ' +
+      '15s, que DOMINA o `sleep` fixo de 1s do original: nunca pior, 15x mais folga contra ' +
+      'uma latência real de 26ms (medida 2026-08-24). O motivo de estar aqui é só o ' +
+      'macOS-only.)',
   },
   {
     arquivo: 'test-heavy-install.sh',


### PR DESCRIPTION
## Corrige uma conclusão minha de hoje de manhã

O #1954 re-mediu o conserto do flaky do `test-heavy.sh` e reportou **15/15 verdes**, com a ressalva de que o `n` efetivo sob carga era 8. A ressalva estava certa e era **insuficiente**: faltava o **controle positivo**.

## O experimento

6 instâncias da versão **sabotada** (o `sleep` fixo pré-#1929, revertido numa cópia no scratchpad — o repo não foi tocado) + 6 da **atual**, no **mesmo pool simultâneo**, pareando a carga exatamente. 3 rodadas.

| Braço | Código | Resultado |
|---|---|---|
| C | sabotado (`sleep 1` / `sleep 2`) | **18/18 verdes** ← devia falhar |
| D | atual (`esperar_slots`) | 18/18 verdes |

**O controle falhou.** Código com o bug de volta não falha ⇒ a condição não reproduz o defeito ⇒ o braço D é ausência de dado. E o mesmo vale **retroativamente para o 15/15 do #1954**.

## Por que não reproduziu — medido, não suposto

Cronometrei o que o bug de fato dependia: o tempo até o ocupante **registrar o slot** (n=20, `load` ~5).

| | |
|---|---|
| mediana | 0,026 s |
| p90 | 0,034 s |
| máximo | 0,043 s |
| limiar que o código sabotado dava | **1,000 s** |

Margem de **23× a 55×**. A máquina precisaria estar ~23 vezes mais lenta. Em 2026-08-23 estava (`load` 30–79, swap em thrashing); hoje está em ~5.

## A evidência que fecha — estrutural, não amostral

O antigo esperava 1 s fixo e media; o novo espera a CONDIÇÃO por até 15 s:

| latência L | antigo | novo |
|---|---|---|
| `L ≤ 1s` | passa | passa |
| `1s < L ≤ 15s` | **falha** | passa |
| `L > 15s` | falha (acusa o `--status`) | falha, mas **reporta SETUP** |

O novo **domina** o antigo: nunca pior, 15× mais folga. Vale sem reproduzir o flaky — o que importa, porque reproduzi-lo exige uma máquina em sofrimento que ninguém consegue agendar.

## Mudanças

- `scripts/hooks-suites-baseline.ts` — troca o número frágil ("15/15 verdes") pelo argumento de dominância. Eixo da isenção inalterado: macOS-only.
- `docs/historico/vigia-de-cobertura-parcial.md` — o experimento, a margem medida, e a regra: *quando o controle positivo não fica vermelho, o braço verde não vale nada*.

## Evidência

| Comando | Resultado |
|---|---|
| `bun run test` | 734 arquivos, 7070 testes, `TEST_EXIT=0` |
| `bunx vitest run scripts/hooks-guard-cobertura.test.ts` | 25 passed, exit 0 |

Sem resíduos: 0 processos órfãos, 0 lockdirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)