### PR TITLE
feat(analytics): "no ar" e "rodando" eram indistinguíveis — build_id em todo evento fecha a 4ª camada

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -90,7 +90,7 @@ bash scripts/posthog-query.sh "SELECT count() FROM events WHERE timestamp > now(
 ## 3. Uso
 
 ```bash
-~/.config/afiacao/posthog-query "SELECT count() FROM events WHERE timestamp > now() - INTERVAL 30 DAY"
+bash scripts/posthog-query.sh "SELECT count() FROM events WHERE timestamp > now() - INTERVAL 30 DAY"
 ```
 
 Aceita HogQL por argumento **ou** stdin. Saída **compacta por padrão** —
@@ -253,3 +253,84 @@ se `gravou` for **zero** por muitos dias com o dashboard sendo aberto.
 ⚠️ **`lente_ativa` e `sem_token` são recusas DELIBERADAS do caminho `pagehide`** (write-guard da lente
 "ver como" e fetch cru sem como autenticar). Contá-los como falha inverte o sinal: são o gate
 funcionando, e no caso do `sem_token` a visita ainda pode gravar pelo unmount.
+
+## 6. Adoção do deploy — qual BUILD o cliente está EXECUTANDO (`build_id`)
+
+Todo evento carrega `build_id` = o hash do chunk do entry que o browser carregou
+(ex.: `index-TTF9Kw1g`). Nasce em `src/lib/build-id.ts`, é registrado como **super
+property** no `initAnalytics()` (`src/lib/analytics.ts`) e por isso alcança **todo**
+evento — inclusive `$autocapture`, `$pageview`, `$pageleave` e `$exception`, que não
+passam por `track()`.
+
+**Por que isto existe:** o `verify-frontend.sh` prova o que o servidor **entrega**,
+nunca o que o browser **executa** — mede DISPONIBILIDADE, não ADOÇÃO. Com
+`registerType: 'prompt'` e `skipWaiting` removido de propósito, o SW novo instala e
+**espera indefinidamente** por um clique humano (`docs/agent/deploy.md`). Em
+2026-08-24 os #1934/#1945/#1949 estavam todos servidos e nenhum executava; a
+descoberta foi acidental. Esta é a instrumentação que faltava.
+
+### A conta
+
+```
+adoção = clientes com build_id = <atual> / clientes que emitiram qualquer evento
+```
+
+O `<atual>` **não se chuta** — sai do mesmo eixo que o verificador lê do servidor:
+
+```bash
+curl -fsS https://steu.lovable.app/ | grep -oE '/assets/index-[A-Za-z0-9_-]+\.js' | head -1
+```
+
+Distribuição por build nos últimos 7 dias (numerador e denominador na MESMA query —
+o denominador é a soma da coluna, não uma segunda leitura):
+
+```bash
+./scripts/posthog-query.sh "
+SELECT coalesce(properties.build_id, '(sem instrumentacao)') AS build,
+       count(DISTINCT distinct_id) AS clientes,
+       count() AS eventos,
+       max(timestamp) AS ultimo
+FROM events
+WHERE timestamp > now() - INTERVAL 7 DAY
+GROUP BY build ORDER BY clientes DESC"
+```
+
+### Armadilhas de leitura
+
+- ⚠️ **Ausente, `'desconhecido'` e um hash são TRÊS estados, não dois.** Propriedade
+  **ausente** = cliente executando um build **anterior a esta instrumentação** — é
+  sinal legítimo de NÃO-adoção, e é o estado esperado da maioria logo após o Publish
+  deste PR. `'desconhecido'` = build atual, mas o entry não foi encontrado no HTML
+  (dev, ou o Vite mudou a forma do `index.html` — investigar). Um hash = leitura boa.
+  Colapsar os três num só é o que cega a medição. Por isso o `coalesce` acima nomeia
+  o ausente em vez de deixá-lo virar `NULL` silencioso.
+- ⚠️ **Esta query é o caso clássico do cache da §4**: ela é IDÊNTICA a cada leitura
+  (mesmo texto, sempre), então é exatamente onde `--cache` devolveria a medição
+  anterior com cara de medição nova. O default do wrapper (`force_blocking`) já
+  protege — **não passe `--cache` aqui**. Confira com `--cru | jq .is_cached`.
+- ⚠️ **`distinct_id`, não `person_id`:** o SDK roda com `person_profiles:
+  'identified_only'`, então quem não logou não tem perfil de pessoa. O denominador
+  "clientes que emitiram qualquer evento" precisa incluí-los.
+- ⚠️ **Adoção baixa é o comportamento CORRETO, não um defeito.** Com o modelo
+  `prompt`, o cliente fica no build velho até clicar "Atualizar". A query responde
+  *quantos* e *quem* — a decisão (esperar, avisar, ou forçar) é de produto.
+- ⚠️ **HTTP 504 = ausência de dado, não zero** (exit 73 no wrapper) — vale aqui como
+  em toda leitura desta doc.
+- ⚠️ **O executável é `scripts/posthog-query.sh`, no repo — `~/.config/afiacao/` guarda só a KEY.**
+  O exemplo da §3 chamava `~/.config/afiacao/posthog-query`, que **não existe** (exit 127, medido
+  2026-08-24) e que a própria §2 **proíbe criar como symlink**. Corrigido na §3; registrado aqui
+  porque o sintoma (`127`) não se parece com "caminho errado" e custa uma ida ao `ls`.
+
+### Baseline no dia da instalação (2026-08-24, ANTES do Publish)
+
+A query acima rodou com `exit 0` e devolveu **uma linha só**:
+
+```
+(sem instrumentacao) | 3 clientes | 66 eventos | ultimo 2026-08-24T21:59:38Z
+```
+
+Isso é o **controle negativo** do sensor, e vale guardar: pré-Publish, 100% dos eventos têm de cair
+em `(sem instrumentacao)`. Um `build_id` com hash aparecendo aqui antes do Publish significaria que a
+leitura está medindo outra coisa. O `ultimo` também é o controle POSITIVO de ingestão — 66 eventos
+na janela provam que a fase N (ingestão viva) segue de pé e que uma série vazia adiante seria sinal
+real, não silêncio de canal morto.

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -323,7 +323,7 @@ O SW usa `registerType: 'prompt'` (não `autoUpdate`): a versão nova **instala 
   cliente**, e ela não tinha medição — a divergência de 2026-08-24 só apareceu porque um toast
   "Nova versão disponível" caiu num screenshot. Agora todo evento carrega o hash do chunk do entry
   que o browser executou (`src/lib/build-id.ts` → super property no `initAnalytics`), no **mesmo
-  eixo** que o `verify-frontend.sh:50` extrai do servidor (`/assets/index-*.js`) — os dois lados
+  eixo** que o `verify-frontend.sh` (linha do `ENTRY=`, na skill `lovable-deploy-verify`) extrai do servidor (`/assets/index-*.js`) — os dois lados
   comparam sem tabela de tradução, e um teste de paridade (`build-id-paridade.test.ts`) impede que
   um dos regexes ande sozinho. Como ler e a conta de adoção: `docs/agent/analytics.md` §6.
   ⚠️ **O sensor só responde a partir do Publish que o contém** — antes disso a propriedade é

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -318,5 +318,15 @@ O SW usa `registerType: 'prompt'` (não `autoUpdate`): a versão nova **instala 
   cliente**. Bytes no servidor não fecham nenhuma verificação cujo sujeito seja o usuário — para
   essa, o oráculo tem de ser um efeito que só o código novo produz (uma linha que só ele grava, um
   evento que só ele emite), e o cliente precisa aceitar o update antes do teste.
+- **A 4ª camada tem SENSOR desde 2026-08-24: `build_id` em todo evento de analytics.** As 3 camadas
+  manuais do Lovable (Publish · edge · migration) terminam em "servido"; a 4ª é o **ACEITE do
+  cliente**, e ela não tinha medição — a divergência de 2026-08-24 só apareceu porque um toast
+  "Nova versão disponível" caiu num screenshot. Agora todo evento carrega o hash do chunk do entry
+  que o browser executou (`src/lib/build-id.ts` → super property no `initAnalytics`), no **mesmo
+  eixo** que o `verify-frontend.sh:50` extrai do servidor (`/assets/index-*.js`) — os dois lados
+  comparam sem tabela de tradução, e um teste de paridade (`build-id-paridade.test.ts`) impede que
+  um dos regexes ande sozinho. Como ler e a conta de adoção: `docs/agent/analytics.md` §6.
+  ⚠️ **O sensor só responde a partir do Publish que o contém** — antes disso a propriedade é
+  ausente em 100% dos eventos, e ausente significa "build anterior à instrumentação", não "erro".
 - **Prova de build** (não confiar na config): `dist/sw.js` deve ter `skipWaiting` **só dentro do listener de `message`** (não no `install`) + `clientsClaim` presente. `dist/index.html` **sem** auto-register (por `injectRegister: false`).
 - **Transição única no 1º Publish com prompt mode:** clientes com o SW antigo (autoUpdate) auto-recarregam **uma última vez** ao pegar este build; daí em diante toda atualização vira o toast. Inerente, não dá pra evitar.

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1461,7 +1461,7 @@ degradaria para a constante `"dev"` em produção, e **um id constante entre bui
 build**: o sensor nasceria verde e cego, que é a falha exata que este arquivo cataloga.
 
 O hash do entry não tem essa dependência — é content-hash do Vite, nasce sempre, e muda se e somente
-se o app mudou. Melhor ainda, é o **mesmo eixo** que o `verify-frontend.sh:50` já extrai do servidor
+se o app mudou. Melhor ainda, é o **mesmo eixo** que o `verify-frontend.sh` (linha do `ENTRY=`, na skill `lovable-deploy-verify`) já extrai do servidor
 (`grep -oE '/assets/index-[A-Za-z0-9_-]+\.js'`), então "entregue" e "executado" comparam sem tabela
 de tradução. O risco que isso cria é os dois regexes andarem separado — e o sintoma seria "adoção
 0%", indistinguível de ninguém ter atualizado. Por isso a paridade entre eles é presa por teste

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1445,3 +1445,35 @@ Sem isso, `verify-frontend.sh` continua respondendo sozinho uma pergunta que tem
 ingestão do PostHog, ativo em 2026-08-24 — enquanto nenhum evento entra, um sensor novo no payload
 não teria como ser lido, e instalá-lo agora seria fase N+1 sem sinal da fase N. A ordem é destravar a
 ingestão, confirmar que evento volta a chegar, e só então acrescentar o campo.
+
+#### Construído (2026-08-24, à noite): a fase N deu sinal e o sensor entrou
+
+O pré-requisito acima foi cumprido no mesmo dia — a ingestão voltou (evento `diagnostico.ingestao`
+chegando às 21:59Z, `total=2631`); o 503 de ~12:17–12:30Z foi transitório, não estado. Com sinal da
+fase N, o sensor deixou de ser fase N+1 no escuro e foi construído.
+
+**A escolha que mudou em relação à spec acima:** era `VITE_BUILD_ID` **ou** o nome do chunk do entry.
+Ficou o **chunk do entry**, e a razão desqualifica a primeira opção em vez de só preferir a segunda:
+o builder do Lovable **não tem `.git`** (confirmado 2026-06-19, comentário no `vite.config.ts`) e
+nenhuma env de SHA de plataforma foi identificada até hoje — tanto que o `__BUILD_ENV_KEYS__` ainda
+está lá como probe justamente para descobrir o nome dela. Um `VITE_BUILD_ID` derivado de commit
+degradaria para a constante `"dev"` em produção, e **um id constante entre builds não identifica
+build**: o sensor nasceria verde e cego, que é a falha exata que este arquivo cataloga.
+
+O hash do entry não tem essa dependência — é content-hash do Vite, nasce sempre, e muda se e somente
+se o app mudou. Melhor ainda, é o **mesmo eixo** que o `verify-frontend.sh:50` já extrai do servidor
+(`grep -oE '/assets/index-[A-Za-z0-9_-]+\.js'`), então "entregue" e "executado" comparam sem tabela
+de tradução. O risco que isso cria é os dois regexes andarem separado — e o sintoma seria "adoção
+0%", indistinguível de ninguém ter atualizado. Por isso a paridade entre eles é presa por teste
+(`src/lib/__tests__/build-id-paridade.test.ts`), e a falsificação que a valida é sutil de propósito:
+tirar `_` e `-` do charset deixa o teste da extração **verde** (o hash da amostra não os usa) e só a
+paridade acusa.
+
+**Três estados, não dois** — a decisão de leitura que evita a próxima cegueira: propriedade
+**ausente** = build anterior à instrumentação (não-adoção legítima, e o estado da maioria logo após
+este Publish); `'desconhecido'` = build atual com entry não encontrado (dev, ou o HTML mudou de
+forma); hash = leitura boa. Colapsar os três num só reproduziria o erro de origem num lugar novo.
+
+⚠️ **Este PR não tem sinal de si mesmo até ser publicado E aceito.** A primeira leitura útil da
+adoção vem depois do Publish, e ela vai começar perto de 0% — que aqui é o sensor funcionando, não
+falhando. Ler antes disso é o erro que este arquivo inteiro descreve.

--- a/src/lib/__tests__/analytics-build-id.test.ts
+++ b/src/lib/__tests__/analytics-build-id.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Fake com a SEMÂNTICA REAL de super property: o que foi registrado entra em todo
+// capture posterior. É isso que faz o teste distinguir `register()` de "carimbar
+// dentro de track()" — só o primeiro alcança autocapture/$pageview/$exception.
+const { fake, capturas } = vi.hoisted(() => {
+  const capturas: Array<{ evento: string; props: Record<string, unknown> }> = [];
+  let superProps: Record<string, unknown> = {};
+  const fake = {
+    init: vi.fn(),
+    register: vi.fn((p: Record<string, unknown>) => {
+      superProps = { ...superProps, ...p };
+    }),
+    capture: vi.fn((evento: string, props?: Record<string, unknown>) => {
+      capturas.push({ evento, props: { ...superProps, ...props } });
+    }),
+    reset: vi.fn(() => {
+      superProps = {};
+    }),
+    identify: vi.fn(),
+    group: vi.fn(),
+    captureException: vi.fn(),
+    __limpar: () => {
+      capturas.length = 0;
+      superProps = {};
+    },
+  };
+  return { fake, capturas };
+});
+
+vi.mock('posthog-js', () => ({ default: fake }));
+
+const BUILD_DE_TESTE = 'index-TESTE123';
+
+async function carregarAnalytics() {
+  vi.resetModules();
+  return import('@/lib/analytics');
+}
+
+beforeEach(() => {
+  vi.stubEnv('VITE_POSTHOG_KEY', 'phc_teste');
+  fake.__limpar();
+  fake.init.mockClear();
+  fake.register.mockClear();
+  fake.capture.mockClear();
+  document.head.innerHTML = '';
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.setAttribute('src', `/assets/${BUILD_DE_TESTE}.js`);
+  document.head.appendChild(s);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  document.head.innerHTML = '';
+});
+
+describe('analytics carimba o build que está EXECUTANDO', () => {
+  it('registra build_id como super property no init (alcança autocapture e $pageview)', async () => {
+    const { initAnalytics } = await carregarAnalytics();
+    initAnalytics();
+    await vi.waitFor(() => expect(fake.register).toHaveBeenCalled());
+    expect(fake.register).toHaveBeenCalledWith(expect.objectContaining({ build_id: BUILD_DE_TESTE }));
+  });
+
+  it('evento ENFILEIRADO antes do init drena JÁ com o build_id', async () => {
+    const { initAnalytics, track } = await carregarAnalytics();
+    track('diagnostico.pre_init'); // SDK ainda não carregou → vai pra fila
+    expect(fake.capture).not.toHaveBeenCalled();
+
+    initAnalytics();
+    await vi.waitFor(() => expect(fake.capture).toHaveBeenCalled());
+
+    const evento = capturas.find((c) => c.evento === 'diagnostico.pre_init');
+    expect(evento?.props.build_id).toBe(BUILD_DE_TESTE);
+  });
+
+  it('track pós-init carrega o build_id sem apagar as properties do chamador', async () => {
+    const { initAnalytics, track } = await carregarAnalytics();
+    initAnalytics();
+    await vi.waitFor(() => expect(fake.register).toHaveBeenCalled());
+
+    track('pedido.criado', { valor: 1234.5 });
+    const evento = capturas.find((c) => c.evento === 'pedido.criado');
+    expect(evento?.props.build_id).toBe(BUILD_DE_TESTE);
+    expect(evento?.props.valor).toBe(1234.5);
+  });
+
+  it('pageview também carrega — o denominador da adoção não pode ficar cego', async () => {
+    const { initAnalytics, pageview } = await carregarAnalytics();
+    initAnalytics();
+    await vi.waitFor(() => expect(fake.register).toHaveBeenCalled());
+
+    pageview('/picking');
+    const evento = capturas.find((c) => c.evento === '$pageview');
+    expect(evento?.props.build_id).toBe(BUILD_DE_TESTE);
+  });
+});

--- a/src/lib/__tests__/build-id-paridade.test.ts
+++ b/src/lib/__tests__/build-id-paridade.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { extrairBuildId, resolverBuildId, BUILD_ID_DESCONHECIDO } from '@/lib/build-id';
+
+const VERIFY_SH = join(process.cwd(), '.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh');
+
+/**
+ * O regex de `build-id.ts` e o do `verify-frontend.sh` são os DOIS LADOS da conta de
+ * adoção (cliente executa × servidor entrega). Se um mudar sozinho, os dois param de
+ * casar e o sintoma é "adoção 0%" — indistinguível de ninguém ter atualizado, que é
+ * exatamente o erro que este trabalho existe pra tornar impossível.
+ *
+ * A paridade é checada por COMPORTAMENTO, não por texto: dois regexes escritos
+ * diferente podem ser equivalentes, e dois quase-iguais podem divergir.
+ */
+function padraoDoVerificador(): RegExp {
+  const linha = readFileSync(VERIFY_SH, 'utf8')
+    .split('\n')
+    .find((l) => l.includes('ENTRY=') && l.includes('grep -oE'));
+  if (!linha) throw new Error('verify-frontend.sh mudou de forma: não achei a linha do ENTRY');
+  const casou = /grep -oE '([^']+)'/.exec(linha);
+  if (!casou?.[1]) throw new Error(`não consegui extrair o regex de: ${linha}`);
+  return new RegExp(casou[1]);
+}
+
+describe('paridade com verify-frontend.sh', () => {
+  const AMOSTRAS = [
+    '/assets/index-TTF9Kw1g.js', // build REAL medido em 2026-08-24
+    '/assets/index-DghZxghH.js', // o que o SW servia no incidente
+    '/assets/index-DnOk4g4H.js', // o que o servidor entregava no incidente
+    'https://steu.lovable.app/assets/index-Ab_c-123.js',
+    '/assets/vendor-react-abc.js',
+    '/assets/index-BhK2xz.css',
+    '/src/main.tsx',
+  ];
+
+  it('os dois lados concordam, amostra por amostra', () => {
+    const reShell = padraoDoVerificador();
+    for (const src of AMOSTRAS) {
+      const doShell = reShell.exec(src)?.[0] ?? null;
+      const daApp = extrairBuildId([src]);
+      const esperado = doShell === null ? BUILD_ID_DESCONHECIDO : doShell.replace(/^.*\/assets\//, '').replace(/\.js$/, '');
+      expect(daApp, `divergência em ${src} (shell viu ${doShell})`).toBe(esperado);
+    }
+  });
+});
+
+// Prova de ponta a ponta contra o HTML que o Vite REALMENTE gera. Pula sem `dist/`
+// (o CI não builda antes de testar) — por isso o guard de paridade acima, que roda
+// sempre, é quem sustenta a garantia no CI.
+const DIST = join(process.cwd(), 'dist/index.html');
+describe.skipIf(!existsSync(DIST))('contra o dist/ real', () => {
+  it('acha o entry no index.html gerado pelo build de produção', () => {
+    const doc = document.implementation.createHTMLDocument('dist');
+    doc.documentElement.innerHTML = readFileSync(DIST, 'utf8');
+    const id = resolverBuildId(doc);
+    expect(id).not.toBe(BUILD_ID_DESCONHECIDO);
+    expect(id).toMatch(/^index-[A-Za-z0-9_-]+$/);
+  });
+});

--- a/src/lib/__tests__/build-id.test.ts
+++ b/src/lib/__tests__/build-id.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { extrairBuildId, resolverBuildId, BUILD_ID_DESCONHECIDO } from '@/lib/build-id';
+
+describe('extrairBuildId', () => {
+  it('extrai o hash do chunk do entry', () => {
+    expect(extrairBuildId(['/assets/index-DnOk4g4H.js'])).toBe('index-DnOk4g4H');
+  });
+
+  // script.src no DOM devolve a URL ABSOLUTA resolvida, nunca o atributo cru.
+  it('funciona com URL absoluta (a forma que o DOM realmente entrega)', () => {
+    expect(extrairBuildId(['https://app.colacor.com.br/assets/index-DghZxghH.js'])).toBe('index-DghZxghH');
+  });
+
+  it('ignora o CSS do entry (index-*.css) e casa só o .js', () => {
+    expect(extrairBuildId(['/assets/index-BhK2xz.css'])).toBe(BUILD_ID_DESCONHECIDO);
+  });
+
+  it('ignora chunks que não são o entry', () => {
+    expect(extrairBuildId(['/assets/vendor-react-abc123.js', '/assets/index-XYZ789.js'])).toBe('index-XYZ789');
+  });
+
+  it('degrada em dev (o entry é /src/main.tsx, sem hash)', () => {
+    expect(extrairBuildId(['/src/main.tsx'])).toBe(BUILD_ID_DESCONHECIDO);
+  });
+
+  it('degrada sem entrada', () => {
+    expect(extrairBuildId([])).toBe(BUILD_ID_DESCONHECIDO);
+  });
+});
+
+describe('resolverBuildId', () => {
+  it('lê o entry do <script type="module"> do documento', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    const s = doc.createElement('script');
+    s.type = 'module';
+    s.setAttribute('src', '/assets/index-DnOk4g4H.js');
+    doc.head.appendChild(s);
+    expect(resolverBuildId(doc)).toBe('index-DnOk4g4H');
+  });
+
+  it('degrada para desconhecido quando não há entry no documento', () => {
+    const doc = document.implementation.createHTMLDocument('t');
+    expect(resolverBuildId(doc)).toBe(BUILD_ID_DESCONHECIDO);
+  });
+
+  it('não explode sem document (SSR/worker)', () => {
+    expect(resolverBuildId(null)).toBe(BUILD_ID_DESCONHECIDO);
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,6 +1,7 @@
 import type { PostHog } from 'posthog-js';
 import { logger } from '@/lib/logger';
 import { mensagemDeErro } from '@/lib/erro-mensagem';
+import { resolverBuildId } from '@/lib/build-id';
 
 /**
  * Wrapper de telemetria sobre PostHog. Centraliza:
@@ -101,6 +102,18 @@ export function initAnalytics(): void {
           }
         },
       });
+      // Carimbo do build que está EXECUTANDO neste browser, em TODO evento.
+      // `register` (super property) e não um carimbo dentro de track(): o
+      // autocapture, o $pageview e o $exception NÃO passam por track(), e sem
+      // eles o DENOMINADOR da adoção ("clientes que emitiram qualquer evento")
+      // ficaria num universo diferente do numerador.
+      //
+      // ⚠️ ORDEM: antes de `ph` e antes do drain abaixo. O drain despeja a fila
+      // pré-init direto em `posthog.capture`; registrar depois dele mandaria os
+      // primeiros eventos da sessão — justamente os do boot, os que mais
+      // importam pra medir adoção — sem build_id, ou pior, com o build ANTERIOR
+      // que ficou persistido no localStorage do cliente que acabou de atualizar.
+      posthog.register({ build_id: resolverBuildId() });
       ph = posthog;
       // Drena os eventos que chegaram enquanto o SDK baixava (1º pageview etc.)
       const queued = preInitQueue.splice(0);

--- a/src/lib/build-id.ts
+++ b/src/lib/build-id.ts
@@ -1,0 +1,61 @@
+/**
+ * Identidade do BUILD que está EXECUTANDO no browser do cliente.
+ *
+ * POR QUE ISTO EXISTE (custou um dia em 2026-08-24): o service worker roda com
+ * `registerType: 'prompt'` e SEM `skipWaiting` (vite.config.ts) — por DESENHO, pra
+ * um deploy não recarregar o app do separador no meio de um picking. Consequência
+ * permanente: o SW novo instala e ESPERA indefinidamente por um clique humano. O
+ * #1934, o #1945 e o #1949 estavam os três publicados no servidor e NENHUM
+ * executava no browser do founder — o SW servia `index-DghZxghH.js` enquanto o
+ * servidor entregava `index-DnOk4g4H.js`. A descoberta foi ACIDENTAL (um toast num
+ * screenshot). Não havia query capaz de responder isso.
+ *
+ * O `verify-frontend.sh` prova o que o servidor ENTREGA, nunca o que o browser
+ * EXECUTA: responde DISPONIBILIDADE, não ADOÇÃO. Este módulo fecha a outra ponta.
+ *
+ * POR QUE O CHUNK DO ENTRY, e não o commit:
+ *  - `__COMMIT_SHA__` degrada pra "dev" em produção — o builder do Lovable não tem
+ *    `.git` (confirmado 2026-06-19, vite.config.ts) e nenhuma env de SHA foi
+ *    identificada ainda. Um id que é constante entre builds não identifica build.
+ *  - O hash do entry é CONTENT-HASH do Vite: nasce sempre, sem depender de env, e
+ *    muda se e somente se o app mudou (dois Publish do mesmo código = mesmo id, o
+ *    que evita falso "não adotou").
+ *  - É o MESMO eixo que o verificador já lê do servidor —
+ *    `verify-frontend.sh:50` faz `grep -oE '/assets/index-[A-Za-z0-9_-]+\.js'` no
+ *    HTML. Servidor e cliente ficam comparáveis SEM tabela de tradução.
+ *
+ * ⚠️ O regex abaixo é o gêmeo do que está no `verify-frontend.sh`. Mudou lá, muda
+ * aqui — senão os dois lados da conta de adoção param de casar (e o sintoma é
+ * "adoção 0%", indistinguível de ninguém ter atualizado).
+ */
+const RE_ENTRY = /\/assets\/(index-[A-Za-z0-9_-]+)\.js/;
+
+/**
+ * Valor EXPLÍCITO quando não dá pra saber o build (dev, SSR, HTML de forma nova).
+ *
+ * Deliberadamente não é `undefined`/propriedade omitida: evento SEM a propriedade
+ * significa "build anterior a esta instrumentação", que é informação diferente de
+ * "build atual, mas o entry não foi encontrado". Fabricar um id seria pior que
+ * ambos — colapsar os dois casos num só é o que cega a medição.
+ */
+export const BUILD_ID_DESCONHECIDO = 'desconhecido';
+
+/** Primeiro src que parecer o entry do Vite vence. Puro — o miolo testável. */
+export function extrairBuildId(srcs: readonly string[]): string {
+  for (const src of srcs) {
+    const casou = RE_ENTRY.exec(src);
+    if (casou?.[1]) return casou[1];
+  }
+  return BUILD_ID_DESCONHECIDO;
+}
+
+/**
+ * Lê o entry do documento que o browser REALMENTE carregou. Quando o SW velho
+ * está no controle, ele serve o `index.html` PRECACHEADO — que aponta pro entry
+ * velho. É justamente essa a leitura que queremos.
+ */
+export function resolverBuildId(doc: Document | null | undefined = globalThis.document): string {
+  if (!doc) return BUILD_ID_DESCONHECIDO;
+  const srcs = Array.from(doc.querySelectorAll('script[src]'), (s) => s.getAttribute('src') ?? '');
+  return extrairBuildId(srcs);
+}

--- a/src/lib/modulos/manifesto.ts
+++ b/src/lib/modulos/manifesto.ts
@@ -681,6 +681,7 @@ export const MODULOS: ModuloApp[] = [
       "src/lib/modulos/**",
       "src/lib/agruparPorMes.ts",
       "src/lib/analytics.ts",
+      "src/lib/build-id.ts",
       "src/lib/erro-mensagem.ts",
       "src/lib/escape-html.ts",
       // Compartilhado entre `vendas` (useCrossSellEngine) e `farmer-inteligencia`


### PR DESCRIPTION
## O buraco

`verify-frontend.sh` prova o que o servidor **entrega**, nunca o que o browser **executa**: mede
DISPONIBILIDADE, não ADOÇÃO. Com `registerType: 'prompt'` e `skipWaiting` removido **de propósito**
(um deploy não pode recarregar o app do separador no meio de um picking), o SW novo instala e espera
**indefinidamente** por um clique humano.

Em 2026-08-24 isso custou um dia: #1934, #1945 e #1949 estavam os três publicados e **nenhum**
executava no browser do founder — o SW servia `index-DghZxghH.js` enquanto o servidor entregava
`index-DnOk4g4H.js`. A descoberta foi **acidental** (um toast "Nova versão disponível" num
screenshot). Não havia query, sensor nem alerta capaz de responder isso. Não há bug a corrigir —
faltava instrumentação.

## O que entra

Todo evento passa a carregar `build_id` = o hash do chunk do entry que o browser carregou.

- **`src/lib/build-id.ts`** (novo) — resolve o build lendo o `<script src>` do documento. Quando o SW
  velho está no controle, ele serve o `index.html` **precacheado**, que aponta pro entry velho: é
  exatamente essa a leitura que se quer.
- **`src/lib/analytics.ts`** — `posthog.register({ build_id })` no `initAnalytics`.

### Duas decisões que não são óbvias

**1. `register()` (super property), não um carimbo dentro de `track()`.** `$autocapture`, `$pageview`,
`$pageleave` e `$exception` **não passam por `track()`** — e o denominador da conta é "clientes que
emitiram **qualquer** evento". Carimbar só em `track()` deixaria numerador e denominador em universos
diferentes.

**2. Chunk do entry, não `VITE_BUILD_ID` derivado de commit.** O builder do Lovable **não tem `.git`**
(confirmado 2026-06-19, comentário no `vite.config.ts`) e nenhuma env de SHA foi identificada — o
`__BUILD_ENV_KEYS__` ainda está lá como probe pra descobrir o nome dela. Um id de commit degradaria
pra constante `"dev"` em produção, e **um id constante entre builds não identifica build**: o sensor
nasceria verde e cego. Bônus: o hash do entry é o **mesmo eixo** que o `verify-frontend.sh:50` já
extrai do servidor (`grep -oE '/assets/index-[A-Za-z0-9_-]+\.js'`) — os dois lados comparam sem
tabela de tradução.

**A ORDEM importa:** o `register` vem **antes** do drain da fila pré-init. Registrar depois mandaria
os primeiros eventos da sessão — os do boot, os que mais importam pra adoção — sem `build_id`, ou
pior, com o build ANTERIOR persistido no localStorage de quem acabou de atualizar.

## A conta que isso destrava

```
adoção do deploy = clientes com build_id = <atual> / clientes que emitiram qualquer evento
```

Query pronta e armadilhas de leitura em `docs/agent/analytics.md` §6; a "4ª camada de deploy"
(as 3 manuais do Lovable + o **ACEITE do cliente**) em `docs/agent/deploy.md`.

## Provas (evidência positiva, colada)

| O quê | Resultado |
|---|---|
| Suíte canônica `bun run test` | **exit 0** — 737 arquivos, 7085 testes |
| `bun run typecheck` | **exit 0** |
| `bun lint` | **exit 0** (74 warnings pré-existentes) |
| Build real de produção | **exit 0** → entry `/assets/index-TTF9Kw1g.js`, casa o regex |
| Query de adoção no PostHog real | **exit 0** → `(sem instrumentacao) \| 3 clientes \| 66 eventos \| 21:59:38Z` |

O último é duplo controle: prova que o HogQL da doc é válido **e** que a ingestão (fase N) está viva.
E o `(sem instrumentacao)` em 100% é o **controle negativo** correto — pré-Publish, nenhum hash pode
aparecer.

### Falsificação (o #1960 mostrou que verde sem sabotagem não prova nada)

| Sabotagem | Esperado | Medido |
|---|---|---|
| Regex do entry `index-` → `entry-` | vermelho | **4 falharam**, 5 (degradação) seguem verdes ✓ |
| `register` movido pra **depois** do drain | só o teste da fila cai | **exatamente 1 falhou** ✓ |
| `register` trocado por carimbo em `track()` | pageview/cobertura caem | **3 falharam** ✓ |
| Charset `[A-Za-z0-9_-]` → `[A-Za-z0-9]` | **só** a paridade pega | build-id.test 9/9 **verde**, paridade falhou nomeando `index-Ab_c-123` ✓ |

A última é sutil de propósito: prova que o guard anti-drift tem poder **próprio**, não é redundante.

## Deploy

**Só Publish do frontend** — sem edge, sem migration. E a ironia registrada na doc: **este PR não tem
sinal de si mesmo até ser publicado E aceito**. A primeira leitura vai começar perto de 0% — que aqui
é o sensor funcionando, não falhando.
