### PR TITLE
docs(analytics): o controle positivo somava DOIS canos — e o do browser foi exercitado e NÃO entregou

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -268,6 +268,23 @@ o `pagehide` com a **página viva** (`dispatchEvent`), que é o único jeito de 
 tipo** entraram (re-medido com `refresh: force_blocking`, já com o fix do cache do #1959) — nem o
 `dashboard.viewed` dos mounts. Com a telemetria de frontend muda, **a tabela é o único oráculo**.
 
+⚠️ **Contar eventos da janela como "a ingestão está viva" soma DOIS canos.** O `posthog-js` preenche
+`properties.$lib`; uma captura por `curl` não — e só a decomposição separa os dois. Medido em
+2026-08-24 (7 dias): **browser `$lib='web'`: 65 eventos, último 23/08 11:09Z** — *antes* do 503 de
+~12:17–12:30Z de 24/08 — contra **API direta: 1 evento, 24/08 21:59Z**. O agregado (66) leu como
+saudável um canal que, exercitado no dia seguinte, não entregou nada. **Um POST por `curl` que volta
+`200` prova que o servidor aceita, não que o browser emite**: CORS, batch, retry e adblock não são
+atravessados por ele — do mesmo modo que o `GET` no host não desmentia o 503. É por esse cano que
+saem `dashboard.viewed`, `dashboard.visita_tentativa` e o `build_id` da §6. **A prova específica não
+precisa ser fabricada: o primeiro evento com `$lib='web'` é ela.**
+
+```
+SELECT toDate(timestamp) AS dia,
+       if(isNull(properties.$lib),'API_direta','browser_SDK') AS via,
+       count() AS n, max(timestamp) AS ultimo
+FROM events WHERE timestamp > now() - INTERVAL 7 DAY GROUP BY dia, via ORDER BY dia DESC
+```
+
 ⚠️ **`sessao_curta` domina por desenho, não por defeito.** O guard de 5 min (`MIN_SESSION_MS`) existe
 para um F5 não anular os deltas — uma proporção alta dele é o guard funcionando. Ele só vira sintoma
 se `gravou` for **zero** por muitos dias com o dashboard sendo aberto.

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1477,3 +1477,56 @@ forma); hash = leitura boa. Colapsar os três num só reproduziria o erro de ori
 ⚠️ **Este PR não tem sinal de si mesmo até ser publicado E aceito.** A primeira leitura útil da
 adoção vem depois do Publish, e ela vai começar perto de 0% — que aqui é o sensor funcionando, não
 falhando. Ler antes disso é o erro que este arquivo inteiro descreve.
+
+## O controle positivo de ingestão somava DOIS canos — e o do browser está sem entregar
+
+O `#1964` construiu o sensor de `build_id` depois de dar por cumprido o pré-requisito que o `#1957`
+tinha posto: *"a ordem é destravar a ingestão, confirmar que evento volta a chegar, e só então
+acrescentar o campo"*. A ingestão de fato voltou; o `503` de ~12:17–12:30Z de 24/08 foi transitório.
+O que não se sustenta é o **controle** — e o desfecho mostrou por quê.
+
+O `#1964` toma os 66 eventos da janela de 7 dias como **`controle POSITIVO de ingestão`**, concluindo
+que *"uma série vazia adiante seria sinal real, não silêncio de canal morto"*. A **mesma query**,
+decomposta por `properties.$lib` — que o `posthog-js` preenche e uma captura por `curl` não —, mostra
+que os 66 nunca foram um conjunto só:
+
+| via | n | primeiro | último |
+|---|---|---|---|
+| browser (`$lib='web'`) | 65 | 2026-08-18T09:25Z | **2026-08-23T11:09Z** |
+| API direta (sem `$lib`) | 1 | — | **2026-08-24T21:59Z** |
+
+65 + 1 fecham os 66. Todos os 65 eventos de browser são **anteriores ao 503** — o último por ~25
+horas. O único evento posterior ao incidente entrou por `curl`. O controle prova que o **servidor
+voltou a aceitar um POST**; não prova que o **`posthog-js` volta a emitir**.
+
+### E não é "sem exercício": o cano do browser foi exercitado e não entregou
+
+Enquanto isto era escrito, o `#1965` fez o teste que faltava — dashboard montado **em produção**,
+autenticado, bundle correto, sessão de 8 min encerrada por fecho de aba, em `2026-08-25T00:17:10Z`.
+Medição independente do PostHog às `00:45Z` (`force_blocking`, já com o fix de cache do `#1959`):
+**zero eventos de qualquer tipo em 25/08** — nem o `dashboard.viewed` do mount.
+
+O app rodou e **nada chegou**. O cano do browser não está "não-provado": está **provado sem
+entregar**. Um controle positivo agregado leu como saudável um canal que, exercitado, não entrega —
+e essa é a diferença entre não ter medido e ter medido a coisa errada.
+
+### Por que isso morde o sensor que o `#1964` acabou de instalar
+
+`build_id` é super property do `initAnalytics`: sai **pelo cano do browser**, o que não entrega. Pior,
+o `#1964` já deixou a leitura pré-resolvida — *"primeira leitura útil da adoção vem depois do
+Publish, e ela vai começar perto de 0%"*, *"que aqui é o sensor funcionando, não falhando"*. Com o
+cano mudo, **0% é ambíguo** (ninguém adotou × nada chega), e a instrução de leitura já resolve a
+ambiguidade no sentido otimista. É a cegueira de origem reproduzida num lugar novo, que o próprio
+`#1964` se propôs a evitar ao separar *ausente* de `'desconhecido'` de *hash*.
+
+**A regra:** cano com dois caminhos exige **controle POR CAMINHO**. Controle positivo agregado é
+sinal genérico lido como específico — o mesmo vício que o `#1955` flagrou no `keepalive:false`. E não
+há o que fabricar: **o primeiro evento com `$lib='web'` é a prova**, porque o `posthog-js` o emite
+sozinho no `$pageview`. Enquanto ele não vier, toda leitura de adoção é indistinguível de canal morto.
+
+```
+SELECT toDate(timestamp) AS dia,
+       if(isNull(properties.$lib),'API_direta','browser_SDK') AS via,
+       count() AS n, max(timestamp) AS ultimo
+FROM events WHERE timestamp > now() - INTERVAL 7 DAY GROUP BY dia, via ORDER BY dia DESC
+```


### PR DESCRIPTION
## O que motivou

Verificação pedida: as duas correções do #1949 produziram efeito real em produção? **Não há denominador** — zero `dashboard.viewed` e zero `dashboard.visita_tentativa` pós-merge (segmentado por `a7571a596`, 90 dias: 46 eventos PRE_MERGE, linha POS_MERGE ausente). Ao medir isso, apareceu uma afirmação em voo que não se sustenta.

## O controle somava dois canos

O #1964 construiu o sensor de `build_id` dando por cumprido o pré-requisito do #1957. **A ingestão voltou mesmo** — o 503 de ~12:17–12:30Z de 24/08 foi transitório. O que não se sustenta é o **controle**: ele toma os 66 eventos da janela de 7 dias como *"controle POSITIVO de ingestão"*, concluindo que *"uma série vazia adiante seria sinal real, não silêncio de canal morto"*.

Decompondo a **mesma query** por `properties.$lib` — que o `posthog-js` preenche e um `curl` não:

| via | n | primeiro | último |
|---|---|---|---|
| browser (`$lib='web'`) | 65 | 2026-08-18T09:25Z | **2026-08-23T11:09Z** |
| API direta (sem `$lib`) | 1 | — | **2026-08-24T21:59Z** |

**65 + 1 fecham os 66.** Todos os 65 de browser são anteriores ao 503 — o último por ~25h. O único posterior entrou por `curl`.

## E o desfecho tirou isto do hipotético

O #1965 fez o teste que faltava: dashboard montado **em produção**, autenticado, bundle correto, 8 min, aba fechada, em `2026-08-25T00:17:10Z`. Medição independente às `00:45Z` (`force_blocking`, com o fix de cache do #1959): **zero eventos de qualquer tipo em 25/08**, nem o `dashboard.viewed` do mount.

O app rodou e **nada chegou**. O cano do browser não está "não-provado" — está **provado sem entregar**. Um controle agregado leu como saudável um canal que, exercitado, não entrega: a diferença entre não ter medido e ter medido a coisa errada.

## Por que morde o sensor recém-instalado

`build_id` é super property do `initAnalytics` — sai **pelo cano mudo**. E o #1964 já deixou a leitura pré-resolvida: *"primeira leitura útil da adoção vem depois do Publish, e ela vai começar perto de 0%"*, *"que aqui é o sensor funcionando, não falhando"*.

Com o cano mudo, **0% é ambíguo** (ninguém adotou × nada chega) e a instrução já resolve a ambiguidade no sentido otimista — a cegueira de origem reproduzida num lugar novo, que o próprio #1964 se propôs a evitar ao separar *ausente* / `'desconhecido'` / *hash*.

**O sensor não está errado.** O controle dele é que é genérico demais para o que ele mede.

## A regra

Cano com dois caminhos exige **controle POR CAMINHO**. Controle positivo agregado é sinal genérico lido como específico — o mesmo vício que o #1955 flagrou no `keepalive:false`. Nada a fabricar: **o primeiro evento com `$lib='web'` é a prova**, porque o `posthog-js` o emite sozinho no `$pageview`.

## Escopo e coordenação

Dois commits, dois docs. A nota do `analytics.md` ficou **fora** do primeiro commit de propósito — o #1965 disputava exatamente aquele parágrafo. Ele mergeou (`c99e75001`), o rebase entrou limpo (arquivos distintos) e o arquivo ficou livre; a nota entrou depois, logo abaixo do bloco dele, que registra a telemetria muda mas **não** cobre como diagnosticar (zero menções a `$lib` no diff dele).

## Evidência

Leituras com `exit 0` e `is_cached=false` (recalculadas — não o cache que o #1959 tapou), com controle positivo sem filtro de evento (287 eventos/14d, 12 tipos). Gates `docs:citacoes` · `docs:indice` · `docs:links` · `claude:size` verdes pós-rebase.

## Nota de método

As 5 citações foram conferidas **à mão** contra `origin/main`. O `docs:citacoes` passa verde sem olhar nenhuma — vigia `arquivo.ext:linha`, não citação atribuída a um PR. Isso já custou um erro nesta sessão: creditei ao #1955 uma frase que era do #1957, com gates verdes nas duas versões. **Três armadilhas devolvem "não casa" para citação correta:** o markdown quebra a frase em ~100 colunas; comparar contra `gh pr diff` sem tirar o `+` cola a linha seguinte (`sinal +real`); e a citação pode estar no **outro** doc do mesmo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)