### PR TITLE
fix(omie): a fonte alias congelou o sync de servicos por 37 dias — e o mapa que ela alimenta é INERTE fora de vendas

### DIFF
--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -1778,23 +1778,18 @@ describe('guardrail money-path: snapshot de não-vinculados lê a proof por cont
     ).toBe(0);
     // Contar 0 sozinho NÃO prova que a capacidade sobreviveu — apagar a função deixaria isto verde.
     // ⚠️ Pós-hotfix Codex-C (#1444) este mapa NÃO alimenta mais o ledger nem a proof (ambos passaram à
-    // lista document-first `accountMapByUser`). Ele sobrevive para chavear as TAGS do cadastro Omie:
-    // resolver o user errado — ou não resolver — erra `excluir_da_carteira`, que decide se o cliente
-    // sai da carteira. Não reintroduza o argumento "senão a membership encolhe": ele morreu com o
-    // #1444 (os 1633 clones já estão no ledger desde o backfill, e o acumulador não encolhe).
+    // lista document-first `accountMapByUser`). Ele sobrevive para chavear as TAGS do cadastro Omie —
+    // e as tags são `vendas`-ONLY, o que é a metade do invariante que a versão anterior deste bloco
+    // não enxergava (ver abaixo).
     expect(
       src,
       'REGRESSÃO: sumiu a resolução código→user (userByCodigo) — sem ela as tags do cadastro Omie ' +
         '(is_fornecedor / excluir_da_carteira) deixam de ser aplicadas',
     ).toMatch(/async function fetchCodigoUserMap\(/);
-    for (const fonte of ['customer_canonical_alias', 'omie_customer_account_map']) {
-      expect(
-        src,
-        `REGRESSÃO: fetchCodigoUserMap parou de ler ${fonte}. A união resolve a conta INTEIRA: a ` +
-          'proof é document-first e não tem os ~1633 clones (sem profile); sem o alias eles ficariam ' +
-          'SEM tag no run `servicos`, em silêncio',
-      ).toMatch(new RegExp(`\\.from\\("${fonte}"\\)`));
-    }
+    expect(
+      src,
+      'REGRESSÃO: fetchCodigoUserMap parou de ler a proof — é a ÚNICA fonte do mapa desde 2026-08-25',
+    ).toMatch(/\.from\("omie_customer_account_map"\)/);
     // ── invariantes que o /codex xhigh obrigou (a 1ª versão do mapa era GLOBAL) ──
     // O código Omie só é único DENTRO de uma conta: `UNIQUE(codigo, account)` NÃO o torna único
     // globalmente. Um mapa global deixa o último `map.set` vencer em silêncio e pode resolver o
@@ -1809,16 +1804,28 @@ describe('guardrail money-path: snapshot de não-vinculados lê a proof por cont
       src,
       'REGRESSÃO: a leitura da proof perdeu o filtro de conta (.eq("account", empresa))',
     ).toMatch(/\.from\("omie_customer_account_map"\)[\s\S]{0,200}\.eq\("account", empresa\)/);
+    // ── A fonte `customer_canonical_alias` SAIU deste mapa (2026-08-25) ─────────────────────────
+    // Ela congelou o sync de `servicos` por 37 dias: alias e proof guardam, por DESENHO, duas
+    // identidades da MESMA entidade comercial (clone sem `profiles` × canônico com `profiles`), e o
+    // guard de colisão lia isso como corrupção — 1633 desacordos, e em 1633/1633 o user da proof era
+    // exatamente o `canonical_user_id` do alias. Falso-positivo de 100%.
+    // Reintroduzir a união RECONGELA o sync. O argumento que a justificava ("sem o alias os clones
+    // ficam SEM tag no run servicos") é FALSO e está travado pelo teste de tags `vendas`-only abaixo.
+    expect(
+      count(src, '.from("customer_canonical_alias")'),
+      'REGRESSÃO: a fonte alias voltou ao fetchCodigoUserMap — foi ela que congelou o sync de ' +
+        '`servicos` por 37 dias (1633 colisões alias×proof que são o par canônico, não corrupção)',
+    ).toBe(0);
+    // A OUTRA METADE do invariante: retirar o alias só é NO-OP porque as tags são `vendas`-only. Se
+    // alguém ligar tags fora de `vendas` sem reavaliar a resolução código→user, o run `servicos`
+    // passa a gravar `excluir_da_carteira` a partir de um mapa que nunca foi exercitado em produção
+    // — e aí a decisão de qual user recebe a tag (clone × canônico) deixa de ser inerte.
     expect(
       src,
-      'REGRESSÃO: a leitura de alias perdeu o filtro de conta (.eq("alias_conta", account))',
-    ).toMatch(/\.from\("customer_canonical_alias"\)[\s\S]{0,200}\.eq\("alias_conta", account\)/);
-    // Alias `inactive` não pode admitir membro novo: o ledger é acumulador, a admissão é irreversível.
-    expect(
-      src,
-      'REGRESSÃO: a leitura de alias perdeu o filtro de status — alias rebaixado a `inactive` ' +
-        'voltaria a ADMITIR membro novo no ledger, e admissão no acumulador não se desfaz',
-    ).toMatch(/\.from\("customer_canonical_alias"\)[\s\S]{0,260}\.eq\("status", "active"\)/);
+      'MUDANÇA DE CONTRATO: as tags do cadastro Omie deixaram de ser `vendas`-only. Reavalie ' +
+        'fetchCodigoUserMap ANTES de liberar: em servicos o mapa era inerte, e a retirada da fonte ' +
+        'alias (2026-08-25) foi provada no-op justamente por isso',
+    ).toMatch(/const tagRows = account === "vendas"/);
     // Colisão dentro da MESMA conta é corrupção — resolver "o último que chegou" anexaria o cliente
     // ao vendedor errado. Fail-closed: aborta o run.
     expect(
@@ -1829,10 +1836,7 @@ describe('guardrail money-path: snapshot de não-vinculados lê a proof por cont
     // Paginação com `.range()` exige `.order` estável (§CLAUDE.md) — E com desempate: ordenar só
     // pelo código deixa a ordem indefinida se o código repetir, e linha que some entre páginas vira
     // membro a menos no ledger, em silêncio.
-    for (const [col, desempate] of [
-      ['alias_omie_codigo', 'alias_user_id'],
-      ['omie_codigo_cliente', 'user_id'],
-    ]) {
+    for (const [col, desempate] of [['omie_codigo_cliente', 'user_id']]) {
       expect(
         src,
         `REGRESSÃO: a paginação de ${col} perdeu o .order estável com desempate por ${desempate} — ` +

--- a/supabase/functions/omie-analytics-sync/index.ts
+++ b/supabase/functions/omie-analytics-sync/index.ts
@@ -281,30 +281,22 @@ async function updateSyncState(
 // sync_state preso em 'running'). Mesmo padrão provado do syncNaoVinculados (#383): paginado p/
 // furar o cap de 1000 do PostgREST.
 
-// Map<omie_codigo_cliente, user_id> — quem JÁ está vinculado, resolvido por CÓDIGO.
+// Map<omie_codigo_cliente, user_id> — quem JÁ está vinculado, resolvido por CÓDIGO, DENTRO da conta.
 //
 // [P0-B-bis Fatia 5] Esta era a ÚLTIMA leitura de `omie_clientes` em edge alguma, e o `DROP TABLE`
 // a quebraria.
 //
-// ⚠️ PARA QUE ESTE MAPA AINDA SERVE, depois do hotfix Codex-C (#1444): **só para chavear as TAGS**
-// do cadastro Omie (`is_fornecedor` / `excluir_da_carteira`, :733). Ele NÃO alimenta mais nem o
-// ledger nem a proof — o #1444 passou os dois para a lista DOCUMENT-first (`accountMapByUser`),
-// justamente porque resolver por código a partir do espelho sem conta podia escolher o user errado
-// numa admissão nova. Uma versão anterior deste comentário justificava a união dizendo que "migrar
-// só para a proof ENCOLHERIA a membership": esse argumento MORREU com o #1444 e não deve ser
-// ressuscitado — a membership dos 1633 clones já está no ledger desde o backfill da Fatia 0, e o
-// acumulador não encolhe.
+// ⚠️ PARA QUE ESTE MAPA SERVE, depois do hotfix Codex-C (#1444): **só para chavear as TAGS** do
+// cadastro Omie (`is_fornecedor` / `excluir_da_carteira`). Ele NÃO alimenta o ledger nem a proof —
+// o #1444 passou os dois para a lista DOCUMENT-first (`accountMapByUser`), justamente porque
+// resolver por código a partir do espelho sem conta podia escolher o user errado numa admissão nova.
 //
-// O que continua valendo, e é o motivo REAL da união: a tag `excluir_da_carteira` decide se um
-// cliente sai da carteira. Aplicá-la ao user errado — ou deixar de aplicá-la — é money-path. Então o
-// mapa tem de resolver o user CERTO, e resolver o máximo de clientes DA CONTA DO RUN:
-//   • `omie_customer_account_map` (proof) é DOCUMENT-first ⇒ os ~1633 "clones" (users Omie sem
-//     `profiles.document`, os aliases fiscais legítimos do grupo) nunca entram nela.
-//   • `customer_canonical_alias.alias_omie_codigo` tem justamente o par (clone → código) que falta.
-// Sem o alias, no run `servicos` os clones deixariam de ser resolvidos por código e cairiam em
-// `userByDoc` — que não os tem (não têm profile) ⇒ ficariam SEM tag, mudança silenciosa de
-// comportamento. Com o filtro de conta abaixo, o alias só entra no run a que pertence (todos os
-// 1633 são `alias_conta='servicos'`; na conta oben eles são ZERO, medido).
+// ⚠️ E as tags são `vendas`-ONLY (`tagRows = account === "vendas" ? … : []`), assim como o ledger.
+// Em `servicos` e `colacor_vendas` este mapa alimenta só `upsertByUser`, que NINGUÉM lê — ou seja,
+// fora de `vendas` ele é INERTE. Foi exatamente por isso que a união com `customer_canonical_alias`
+// pôde congelar o sync de `servicos` por 37 dias sem deixar um único número ERRADO no banco: o dano
+// foi de AUSÊNCIA (proof e frescor parados), não de valor adulterado. A fonte alias saiu em
+// 2026-08-25; a medição que prova o no-op está no bloco dentro da função.
 //
 // ⚠️ O MAPA É POR CONTA, não global — corrigido após `/codex challenge` xhigh, que refutou a 1ª
 // versão (Map global) e a refutação foi VERIFICADA por medição. `omie_codigo_cliente` é único
@@ -312,27 +304,6 @@ async function updateSyncState(
 // global, o último `map.set` vence em silêncio e um código do run oben podia resolver o user de
 // colacor — que então receberia as tags Omie de OUTRO cliente, inclusive `excluir_da_carteira`.
 // Colisão hoje é zero, mas isso é coincidência de DADO, não invariante de schema.
-//
-// É também o que responde à crítica do hotfix Codex-C a este mapa ("vem do espelho legado SEM conta
-// — a mesma fonte poluída que este épico inteiro existe para aposentar"): com o filtro de conta ele
-// deixa de ser sem-conta. A resolução por código passa a ser account-correta, como já era em
-// `fetchAllOmieClienteCodigos`.
-//
-// A medição que fechou a questão (psql-ro, 2026-07-18) — filtrar por conta parece "perder" 37 pares
-// do espelho, e não perde nada:
-//   • 37/37 têm o par (código, user) casando em OUTRA conta ⇒ era o espelho guardando o código
-//     NÃO-oben do user (ele é `UNIQUE(user_id)`, 1 linha sobrescrita — o "mix de contas" conhecido).
-//     No run oben esses códigos NUNCA aparecem: o Omie oben só devolve códigos oben. Filtrar CORRIGE
-//     um falso-positivo, não encolhe cobertura.
-//   • 37/37 já estão no ledger ⇒ a membership não muda.
-//   • Códigos de alias presentes na conta oben: ZERO. Os 1.633 aliases são todos `alias_conta =
-//     'servicos'`; no Map global eles eram 1.633 entradas que jamais casavam no run oben.
-// É a mesma correção que `fetchAllOmieClienteCodigos` já aplica logo abaixo (`.eq("account", ...)`).
-//
-// FILTRA `customer_canonical_alias.status='active'` — também correção do Codex. O argumento "não
-// encolher a membership" que eu usara para não filtrar é INVÁLIDO aqui: o ledger é acumulador, então
-// filtrar na ADMISSÃO não remove ninguém já admitido. Sem o filtro, um alias rebaixado a `inactive`
-// seguiria admitindo membro novo como `verified` — e a admissão é irreversível.
 async function fetchCodigoUserMap(
   db: SupabaseClient,
   account: OmieAccount,
@@ -365,31 +336,33 @@ async function fetchCodigoUserMap(
   // ordem indefinida e uma linha pode repetir ou SUMIR entre páginas. Desempate por user: ordenar
   // só pelo código deixa a paginação INSTÁVEL se o código repetir.
 
-  // 1) aliases fiscais (clones) DA CONTA DO RUN: o par (código → user) que a proof document-first
-  // nunca tem. `alias_conta` guarda o slug INTERNO do Omie (o mesmo enum de `account`), ≠ da proof,
-  // que guarda o canônico (`empresa`).
-  const aliasRows = await fetchAll<{ alias_omie_codigo: number | null; alias_user_id: string | null }>(
-    (from, to) =>
-      db
-        .from("customer_canonical_alias")
-        .select("alias_omie_codigo, alias_user_id")
-        .eq("alias_conta", account)
-        .eq("status", "active")
-        .not("alias_omie_codigo", "is", null)
-        .order("alias_omie_codigo")
-        .order("alias_user_id")
-        .range(from, to),
-    `fetch customer_canonical_alias map (${account})`,
-  );
-  for (const r of aliasRows) {
-    if (r.alias_omie_codigo != null && r.alias_user_id) {
-      setOuFalha("alias", Number(r.alias_omie_codigo), r.alias_user_id);
-    }
-  }
-  const nAlias = map.size;
-
-  // 2) proof account-correta DA MESMA conta. Se um código aparecer nas duas fontes com users
-  // diferentes, `setOuFalha` aborta — dentro de uma conta isso é corrupção, não preferência.
+  // FONTE ÚNICA: a proof account-correta DA CONTA DO RUN.
+  //
+  // Até 2026-08-25 este mapa lia TAMBÉM `customer_canonical_alias` (os aliases fiscais / clones
+  // `@placeholder.local`, sem `profiles`) — e a UNIÃO das duas fontes congelou o sync de `servicos`
+  // por 37 dias. As duas guardam, POR DESENHO, duas identidades da MESMA entidade comercial (o clone
+  // e o canônico), então `setOuFalha` via 1633 "colisões" e abortava o run todo dia
+  // (`sync_state.status='error'`, 2026-07-19 → 2026-08-24). Em 1633/1633 o user da proof era
+  // exatamente o `canonical_user_id` do alias: falso-positivo de 100%.
+  //
+  // Ler só a proof é NO-OP DE COMPORTAMENTO, não escolha de preferência — cada passo medido:
+  //   • o alias só acrescentava CONFLITO: os 1633 códigos de alias JÁ estavam todos na proof
+  //     (0 códigos exclusivos do alias) ⇒ o mapa resultante é idêntico;
+  //   • aliases ativos existem SÓ com `alias_conta='servicos'` (0 em vendas / colacor_vendas) — e é
+  //     justamente em `servicos` que este mapa não tem consumidor: tags são `vendas`-only
+  //     (`tagRows = account === "vendas" ? … : []`) e o ledger também. `upsertByUser`, o único outro
+  //     destino, não é lido por ninguém;
+  //   • a proof (`accountMapByUser`) é montada por DOCUMENTO, não por este mapa, e o `continue` logo
+  //     após a resolução não a altera: sem match por documento não nasce linha de proof de todo jeito.
+  // ⇒ o argumento antigo — "sem o alias os clones ficariam SEM tag no run servicos" — era FALSO: o run
+  // `servicos` não grava tag nenhuma. Não o ressuscite.
+  //
+  // A validação alias×proof continua desejável, mas como DATA-HEALTH separado: ela não pode derrubar
+  // um sync cujo resultado não depende de alias (parecer Codex gpt-5.6-sol xhigh, 2026-08-25).
+  //
+  // `setOuFalha` PERMANECE: hoje `UNIQUE(omie_codigo_cliente, account)` torna a colisão impossível
+  // dentro de uma conta, mas isso é invariante de SCHEMA da proof — se a fonte mudar, o guard é a
+  // única coisa entre um código ambíguo e o user errado no ledger.
   const proofRows = await fetchAll<{ omie_codigo_cliente: number | null; user_id: string | null }>(
     (from, to) =>
       db
@@ -409,8 +382,7 @@ async function fetchCodigoUserMap(
   }
 
   console.log(
-    `[Sync ${account}] mapa código→user (conta ${empresa}): ${map.size} códigos ` +
-      `(alias ${nAlias} + proof ${map.size - nAlias})`,
+    `[Sync ${account}] mapa código→user (conta ${empresa}): ${map.size} códigos (fonte: proof)`,
   );
   return map;
 }


### PR DESCRIPTION
## O incidente

`sync_state.customers/servicos` congelado em **2026-07-18 05:40:58** — 37 dias. O cron roda, a edge responde, e ela falha sempre no mesmo ponto:

```
status = error
error_message = "colisão de código na conta colacor_sc: omie_codigo_cliente=3545072150
aponta para de411586-… e 700657a1-… (fonte: proof). Duas identidades para o mesmo código
dentro da MESMA conta é corrupção — abortando antes de admitir o user errado no ledger."
updated_at = 2026-08-24 05:40:05   ← determinístico, todo dia
```

## A causa

`syncCustomers` (:692) chama `fetchCodigoUserMap` na **:700**. Esse mapa unia duas fontes que, **por desenho**, guardam duas identidades da MESMA entidade comercial: `customer_canonical_alias` (o clone `@placeholder.local`, sem `profiles`) e a proof (o canônico, com `profiles`). O guard `setOuFalha` lia isso como corrupção.

Medido em prod (`psql-ro`):

| Medição | Valor |
|---|---|
| Desacordos alias × proof em `servicos` | **1633** |
| …em que o user da proof é o `canonical_user_id` do alias | **1633 / 1633** |
| `alias_user` com `profiles` | **0 / 1633** |
| `canonical_user` com `profiles` | **1633 / 1633** |
| Linhas `source='rpc'` entre os desacordos | **0** |
| Contas com alias ativo | só `servicos` |

Falso-positivo de **100%**. O guard nasceu em `65ac66990` (#1452, 2026-07-18 22:59 UTC); o último sync OK foi às 05:40 do mesmo dia; a 1ª falha, 07-19. Dado latente (as linhas da proof são de 2026-07-09) + guard novo.

## A correção: remover a fonte `alias` — e por que é **no-op de comportamento**

Não é escolha de preferência entre clone e canônico. Cada passo medido:

1. Os 1633 códigos de alias **já estavam todos na proof** ⇒ o alias acrescentava 0 chave e só conflito; o mapa resultante é **idêntico**.
2. Aliases ativos existem **só** em `alias_conta='servicos'` (0 em `vendas`/`colacor_vendas`).
3. E é exatamente em `servicos` que esse mapa **não tem consumidor**: tags são `vendas`-only (`tagRows = account === "vendas" ? … : []`), o ledger idem (:904), e `upsertByUser` — o único outro destino — **não é lido por ninguém**.
4. A proof (`accountMapByUser`, :778) é montada por **documento**, não por esse mapa; o `continue` de :760 não a altera (sem match por documento não nasce linha de proof de todo jeito).

⇒ Nenhum número ficou **errado** no banco nesses 37 dias; o dano foi de **ausência** (proof e frescor parados).

O argumento que sustentava a união — *"sem o alias os clones ficariam SEM tag no run servicos"* — é **falso**, e estava codificado num teste que por isso **protegia o defeito**. Corrigido aqui.

`setOuFalha` **permanece**: hoje `UNIQUE(omie_codigo_cliente, account)` torna a colisão impossível, mas isso é invariante de schema da proof, não garantia futura.

## Testes

- `count('.from("customer_canonical_alias")') === 0` — trava contra ressurreição da união.
- `tagRows = account === "vendas"` — a **outra metade** do invariante: se ligarem tags fora de `vendas`, o gate obriga a reavaliar a resolução código→user antes.
- **Falsificados os dois**, cada um casando a marca do próprio ramo (readicionar o alias → 3 ocorrências da mensagem certa; liberar tags → 2). A 1ª tentativa de sabotagem reprovou por OUTRA asserção e foi refeita cirurgicamente.

Verde: `typecheck` · `edges:typecheck` · `test:edges` (884) · `vitest` (7069/7070 — a única reprovação é timeout de 20s por carga da máquina e **passa isolada em 3s**) · `lint` (0 erros).

## 2ª opinião

`/codex` (gpt-5.6-sol, xhigh) **refutou** a 1ª proposta (reconhecer o par alias→canônico no guard): ela funcionaria nos 1633 casos atuais, mas aceita cadeia/ciclo/ordem-lexical que o schema permite — não há `UNIQUE(alias_conta, alias_omie_codigo)` nem proibição de o canônico ser ele mesmo um alias. Foi ele quem apontou que o mapa é inerte fora de `vendas`; verifiquei cada citação no código antes de aceitar.

## ⚠️ Deploy

`merge ≠ produção`. A edge `omie-analytics-sync` precisa de **Publish manual pelo chat do Lovable**. O sync só volta a andar no run das **05:40 UTC** seguinte ao deploy.

**Como confirmar que destravou** (read-only):

```sql
select entity_type, account, last_sync_at, status, left(coalesce(error_message,'-'),60)
from sync_state where entity_type='customers' and account='servicos';
```

Previsão falsificável: `last_sync_at` do dia, `status='complete'`, `error_message` nulo — e `max(updated_at)` da proof `colacor_sc` do dia.

## Fora de escopo (follow-ups)

- Validação alias × proof como **data-health separado** — ela é desejável, mas não pode derrubar um sync cujo resultado não depende de alias.
- Alerta sobre `sync_state.status='error'`: hoje **nada** no Sentinela/watchdog lê essa coluna, e foi por isso que 37 dias de falha diária passaram sem ninguém ver. O erro **estava gravado**; faltou a query.
- `userByCodigo.get(K) ?? userByDoc.get(doc)` é code-first: se o Omie mover K para o documento de outro cliente, em `vendas` as tags podem ir para o dono antigo (apontado pelo Codex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
