### PR TITLE
docs: o app passou a gravar SOZINHO — 2 das 5 linhas de dashboard_visits não vieram de teste nenhum

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -250,6 +250,7 @@ de código. **A única condição que muda é se a página está morrendo:**
 |---|---|---|---|---|
 | 00:17:10Z | **aba fechada** de verdade | sim, `keepalive: true` | **nunca chegou** | ❌ |
 | 01:04:48Z | `dispatchEvent` com a **página viva** | sim, `keepalive: true` | **201** em 637ms | ✅ `id=3` |
+| 01:18:57Z | `dispatchEvent` com a **página viva** (repetição) | sim, `keepalive: true` | **201** em 605ms | ✅ `id=5` |
 
 O corpo, os headers, o token e a policy são os mesmos nos dois. **O código está correto**: com a
 página viva ele grava em 637ms. O que falha é o `fetch` com `keepalive: true` **não sobreviver ao

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1689,3 +1689,35 @@ publicado e servido; o que falta não é dele.
 **O gate é um evento com `$lib='web'`.** Enquanto `max(timestamp)` desse recorte não passar de
 `2026-08-23T11:09:23Z`, toda releitura da adoção reconfirma o mesmo zero com cara de medição nova —
 e a §4 já ensinou o quanto isso custa.
+
+### O sinal que fecha a fase: o app passou a gravar SOZINHO (2026-08-25)
+
+> Esta seção e a do `keepalive` acima são o **mesmo dia por dois lados**: lá, o PostHog em zero é do
+> CANAL; aqui, a tabela recebendo prova que o app está sendo usado. As duas juntas é que sustentam o
+> veredito — nenhuma sozinha sustentaria.
+
+A tabela que ficou 3 meses vazia tem **5 linhas** — e duas delas **não vieram de teste nenhum**:
+
+```
+ id |         visited_at         | company_selection | session_minutes |  origem
+----+----------------------------+-------------------+-----------------+------------------
+  1 | 2026-08-24 12:29:32.543+00 | all               |               7 | teste (unmount)
+  2 | 2026-08-25 00:45:45.947+00 | oben              |              38 | ← USO REAL
+  3 | 2026-08-25 01:04:48.071+00 | all               |               6 | teste (pagehide vivo)
+  4 | 2026-08-25 01:10:33.998+00 | oben              |              23 | ← USO REAL
+  5 | 2026-08-25 01:18:57.880+00 | all               |               6 | teste (pagehide vivo)
+```
+
+**A coluna que separa teste de uso é `company_selection`:** os testes rodaram com `all`; as linhas 2
+e 4 têm `oben`, uma empresa que nenhum teste selecionou, e durações de **38 e 23 minutos** —
+incompatíveis com sessão dirigida. São visitas de gente trabalhando.
+
+Isto é o que este arquivo cobra em todo lugar e raramente consegue: **≥1 sinal POSITIVO de uso em
+produção**, não "está no ar e ninguém reclamou". O #1934 sai de "provado sob teste" para
+**"funcionando em uso"**, e a fase N finalmente tem denominador próprio.
+
+⚠️ **Com a ressalva que não desaparece:** as 4 linhas de 25/08 vieram do caminho **unmount** (ou de
+`pagehide` com a página viva). Fechar a aba continua perdendo a visita — o `keepalive` não sobrevive
+ao unload (causa raiz em [`analytics.md`](../agent/analytics.md)). Então **5 linhas é um piso**, não a
+contagem de visitas: quantas se perderam no fecho de aba segue desconhecido, e será desconhecido até
+o writer parar de depender de como o usuário sai.


### PR DESCRIPTION
Fecha o ciclo do #1934 com o sinal que faltava: **uso real, não teste**.

## As 5 linhas

```
 id |         visited_at         | company_selection | session_minutes |  origem
----+----------------------------+-------------------+-----------------+----------------------
  1 | 2026-08-24 12:29:32.543+00 | all               |               7 | teste (unmount)
  2 | 2026-08-25 00:45:45.947+00 | oben              |              38 | ← USO REAL
  3 | 2026-08-25 01:04:48.071+00 | all               |               6 | teste (pagehide vivo)
  4 | 2026-08-25 01:10:33.998+00 | oben              |              23 | ← USO REAL
  5 | 2026-08-25 01:18:57.880+00 | all               |               6 | teste (pagehide vivo)
```

**O que separa teste de uso é `company_selection`:** todos os testes rodaram com `all`; as linhas 2 e 4 têm `oben` — empresa que nenhum teste selecionou — com **38 e 23 minutos**, durações incompatíveis com sessão dirigida.

Isto é o que o `fase-sem-sinal.md` cobra em todo lugar e raramente consegue: **≥1 sinal positivo de uso em produção**, não "está no ar e ninguém reclamou". O #1934 sai de *provado sob teste* para **funcionando em uso**.

A linha 4 apareceu de um jeito que vale contar: o `GET` do `useLastVisit` no mount do meu último teste devolveu `visited_at: 2026-08-25T01:10:33.998+00` — uma visita que eu não sabia que existia, capturada pelo interceptor. O sensor me contou de um uso que eu não tinha visto.

## E o experimento do keepalive reproduziu

| execução | disparo | resposta |
|---|---|---|
| 01:04:48Z | página viva | **201** em 637ms → `id=3` |
| 01:18:57Z | página viva (repetição) | **201** em 605ms → `id=5` |

**n=2.** O 201 não era acidente, e a causa raiz do #1968 se sustenta.

## Ressalva que não desaparece

As linhas vieram do caminho **unmount** (ou de `pagehide` com a página viva). **Fechar a aba continua perdendo a visita** — o `keepalive` não sobrevive ao unload. Então **5 é um piso, não a contagem de visitas**: quantas se perderam no fecho de aba segue desconhecido, e será, até o writer parar de depender de como o usuário sai.

## Nota de coordenação

O [#1969](https://github.com/LucasSardenbergL/afiacao/pull/1969) (outra sessão) chegou à mesma causa raiz de forma independente — convergência que reforça a conclusão. Ele não cobre este conteúdo; se conflitar no `fase-sem-sinal.md`, eu rebaso.

## Validação

`docs:citacoes` · `docs:links` — **exit 0**. Browser do founder restaurado e aba fechada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)