### PR TITLE
feat(canaria): a identidade_probe provava o P0-B e calava o A2 — bundle com o #1888 revertido lia como verde [money-path]

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -83,7 +83,7 @@ canary === true   E   contrato === '<marcador da fatia>'   E   ok === true
 | edge | rota | `contrato` esperado | o que a fixture discrimina |
 |---|---|---|---|
 | `analyze-unified-order` | Governança → Auditoria (card "Canária de preço") | `praticado-vence-omie-v1` | praticado 123 vence Omie 999 (velho: o Omie sobrescrevia → `resolved=999`) |
-| `omie-vendas-sync` | `identidade_probe` | `identidade-fail-closed-v1` | identidade derivada por documento: 1-dono resolve, e divergência advisory×derivado / ambiguidade / ausência / bigint fora de range **recusam** (velho: o advisory sobrescrevia o derivado) |
+| `omie-vendas-sync` | `identidade_probe` | `identidade-a2-client-to-user-v2` | identidade derivada por documento: 1-dono resolve, e divergência advisory×derivado / ambiguidade / ausência / bigint fora de range **recusam** (velho: o advisory sobrescrevia o derivado). **+ assinatura A2 (#1888)** em `assinatura_a2`: o `client_to_user` do snapshot é exigido (ausente = fail-closed), a prova positiva VENCE o cache divergente, o revogado SAI do cache e a revogação em massa aborta. ⚠️ `ok` já agrega os dois — mas leia `assinatura_a2.ok` e `casos` para saber QUAL lado falhou |
 | `omie-analytics-sync` | `doc_ambiguo_probe` ⚠️ resposta embrulhada em `data` | `doc-ambiguo-fail-closed-v1` | doc ambíguo não vira vínculo (velho: helper sempre-∅ → `[]` no caso de 2 códigos) |
 | `carteira-rebuild` | `?canary=1` | `trava-saida-v1` | conflito permanece com `eligible=false` (velho: some) **+** trava de saída do bootstrap (velho: grava ~Hunter) |
 | `generate-tactical-plan` | `{"canary":true}` | `v1.1-paginacao-eof-e-cursor` | margem ausente degrada em vez de fabricar (velho: NULL→`?? 0`→R$0/h; #1498) |

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -3107,7 +3107,11 @@ describe('canária VERSIONADA: analyze-unified-order (praticado vence Omie)', ()
 describe('canária VERSIONADA: omie-vendas-sync (identidade fail-closed)', () => {
   const src = read(VENDAS);
   const deployDoc = read(DEPLOY_DOC);
-  const CONTRATO = 'identidade-fail-closed-v1';
+  // Bumpado ao a canária ganhar a assinatura comportamental do #1888 (PR-2/A2). O marcador
+  // anterior nasceu no #1922, DEPOIS do #1888, então já provava aquela fatia por transitividade
+  // — mas responderia idêntico antes e depois da prova COMPORTAMENTAL, que é a única a
+  // sobreviver a um deploy em que o Lovable reinterpreta o código (#1272, #1445→#1478).
+  const CONTRATO = 'identidade-a2-client-to-user-v2';
   // Sobre a fonte SEM comentários: a prosa que EXPLICA o campo cita o campo (`// \`canary: true\`
   // acompanha o probe_no_ar...`), então um assert POSITIVO sobre o texto cru passa lendo o
   // comentário e sobrevive à remoção do código. Falsificação S3 pegou exatamente isso.
@@ -3121,7 +3125,7 @@ describe('canária VERSIONADA: omie-vendas-sync (identidade fail-closed)', () =>
     expect(
       bloco,
       'sumiu o marcador `contrato` do identidade_probe — a canária responderia igual num bundle de hoje e num de três fatias atrás',
-    ).toMatch(/contrato: ['"]identidade-fail-closed-v1['"]/);
+    ).toMatch(new RegExp(`contrato: ['"]${CONTRATO}['"]`));
   });
 
   it('emite TAMBÉM `canary: true` — a receita SQL do deploy.md lê esse campo', () => {
@@ -3135,7 +3139,7 @@ describe('canária VERSIONADA: omie-vendas-sync (identidade fail-closed)', () =>
   it('a LINHA da tabela do deploy.md fixa o MESMO marcador', () => {
     expect(
       deployDoc,
-      'a linha do `omie-vendas-sync` na tabela de canárias não fixa `identidade-fail-closed-v1`',
+      `a linha do \`omie-vendas-sync\` na tabela de canárias não fixa \`${CONTRATO}\``,
     ).toMatch(linhaDaTabela('omie-vendas-sync', CONTRATO));
   });
 

--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -763,7 +763,7 @@ Deno.test("sync-reprocess: o parse que subiu PRESERVA o throw do corpo inválido
 /**
  * Dependente do `paginate.ts` cuja prova de deploy NÃO é sonda, e sim canária VERSIONADA.
  *
- * Só a `omie-vendas-sync`: o `identidade_probe` dela responde `contrato:"identidade-fail-closed-v1"`,
+ * Só a `omie-vendas-sync`: o `identidade_probe` dela responde um `contrato` versionado,
  * um marcador que nomeia a fatia — logo discrimina bundle novo de velho, que é tudo o que se pede
  * aqui. Exigir sonda dela seria exigir um segundo sensor para responder a mesma pergunta.
  *
@@ -771,7 +771,10 @@ Deno.test("sync-reprocess: o parse que subiu PRESERVA o throw do corpo inválido
  * não emite mais é pior que exceção nenhuma, porque some da lista de pendências parecendo resolvida.
  */
 const VERIFICAVEL_POR_CANARIA: Record<string, string> = {
-  "omie-vendas-sync": "identidade-fail-closed-v1",
+  // Bumpado de `identidade-fail-closed-v1` ao ganhar a assinatura comportamental do #1888
+  // (`assinatura-a2.ts`): o marcador nomeia a fatia que a canária verifica HOJE, e a de hoje
+  // cobre o P0-B E o A2. Ver `omie-vendas-sync/assinatura-a2.ts`.
+  "omie-vendas-sync": "identidade-a2-client-to-user-v2",
 };
 
 Deno.test("nenhuma edge que serve o paginate.ts fica SEM prova de deploy", () => {

--- a/supabase/functions/omie-vendas-sync/assinatura-a2.ts
+++ b/supabase/functions/omie-vendas-sync/assinatura-a2.ts
@@ -1,0 +1,217 @@
+// Assinatura comportamental do #1888 (PR-2/A2) — os casos que a canária `identidade_probe` da
+// `omie-vendas-sync` roda contra o bundle DEPLOYADO.
+//
+// POR QUE EXISTE (medido em 2026-08-23). Esta edge é a LEITORA do `client_to_user`. Do lado do
+// ESCRITOR (`omie-analytics-sync`) o deploy do #1888 se provou pelo dado — a coluna
+// `evidence_document_normalized` saiu de 0 para 10.822 de 16.118 após o sync das 05:00 UTC, e só o
+// código novo a escreve. Aqui não há efeito observável de fora, e a escada de `docs/agent/deploy.md`
+// tinha um degrau só:
+//
+//   N1 existência ... verde, mas prova apenas que a função é SERVIDA.
+//   N2 versão ....... estruturalmente indisponível (Supabase da org do Lovable; ⛔ não peça PAT).
+//   N3 comportamento  a `identidade_probe` roda a decisão pura `decideAccountIdentity` do P0-B, e o
+//                     #1888 NÃO tocou aquele bloco (0 linhas: `git diff a9410fdaa^ a9410fdaa`).
+//
+// O marcador `contrato` que o #1922 deu à canária JÁ resolve a pergunta "qual bundle está no ar?":
+// como ele nasceu depois do #1888, um bundle que o responde é necessariamente ≥ #1888. O que ele
+// NÃO dá é o passo seguinte, e é para ele que este arquivo existe: a transitividade assume que o
+// binário no ar É o arquivo da main, e este repo tem duas maneiras REGISTRADAS de essa premissa ser
+// falsa — o Lovable reinterpreta código no deploy (#1272) e o sync bidirecional já reverteu a main
+// por cima de arquivo recém-mergeado (#1445→#1478). Os gates de PARIDADE textual pegam isso na
+// MAIN; nenhum deles vê o bundle DEPLOYADO. Sob esse modo de falha a canária responderia
+// `ok:true` com o `contrato` certo, porque ela exercita o P0-B e não o A2.
+//
+// Daí a assinatura: exercita, no bundle no ar, as duas funções que o #1888 introduziu nesta edge —
+// `parseIdentitySnapshot` (com `client_to_user`/`revoked_client_codes`) e
+// `aplicarProvaPositivaNoCache`. Continua READ-ONLY e IO-free: as duas são puras, e a segunda muta
+// apenas Maps criados aqui dentro. Nada de Omie, nada de banco, nada de `supabaseAdmin`.
+//
+// As funções chegam por PARÂMETRO em vez de import porque o `index.ts` importa
+// `npm:@supabase/supabase-js@2` e `test:edges` roda `deno test --no-remote` — nenhum teste o
+// alcança. Com a injeção o avaliador fica testável (`assinatura-a2_test.ts` o falsifica com duplos
+// pré-#1888), e quem garante que o `index.ts` passa as funções REAIS é o gate textual do mesmo
+// arquivo.
+
+import { mensagemDeErro } from "../_shared/erro-mensagem.ts";
+
+/** Contrato estrutural das duas funções DEPLOYADAS que a assinatura exercita. */
+export type DepsAssinaturaA2 = {
+  parse: (snap: unknown) => {
+    docToUserMap: Map<string, string>;
+    ambiguousDocs: Set<string>;
+    clientToUser: Map<number, string>;
+    revokedClientCodes: Set<number>;
+  };
+  aplicar: (
+    cache: Map<number, string | null>,
+    prova: ReadonlyMap<number, string>,
+    revogados: ReadonlySet<number>,
+  ) => {
+    cacheDaView: number;
+    provados: number;
+    divergencias: number;
+    revogados: number;
+    cobertura: number;
+  };
+};
+
+/** Local de propósito: só `AssinaturaA2` o referencia, e export sem consumidor é o que o
+ *  gate `knip` do CI barra. */
+type CasoAssinatura = { caso: string; ok: boolean; detalhe: string };
+export type AssinaturaA2 = { contrato: string; ok: boolean; casos: CasoAssinatura[] };
+
+/**
+ * Nome do contrato exercitado — vai na resposta da canária, ao lado do `contrato` da fatia, para
+ * quem lê saber O QUE o `assinatura_a2.ok` afirma.
+ */
+export const CONTRATO_A2 = "pr2-a2-client-to-user";
+
+export const MARCAS_A2 = {
+  clientToUserAusente: /client_to_user ausente/,
+  revogadosAusente: /revoked_client_codes ausente/,
+  userForaDeDocToUser: /fora de doc_to_user/,
+  provadoERevogado: /client_to_user E revoked_client_codes/,
+  codigoInvalido: /código de cliente inválido em client_to_user/,
+  revogacaoEmMassa: /revogação em massa/,
+} as const;
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
+const UUID_C = "33333333-3333-4333-8333-333333333333";
+const DOC_A = "12345678000199";
+const DOC_B = "98765432000188";
+
+/** Snapshot VÁLIDO no contrato v1 do #1888 — os casos negativos partem daqui e sabotam um campo. */
+function snapshotValido(): Record<string, unknown> {
+  return {
+    doc_to_user: { [DOC_A]: UUID_A, [DOC_B]: UUID_B },
+    ambiguous_docs: [],
+    client_to_user: { "10": UUID_A },
+    revoked_client_codes: ["20"],
+  };
+}
+
+/**
+ * Caso que exige SUCESSO com uma propriedade verificável. Nunca propaga exceção: um throw
+ * inesperado viraria HTTP 500, e 500 é justamente o veredito de "bundle velho" — a sonda
+ * mentiria o pior erro possível sobre si mesma.
+ */
+function exigeOk(caso: string, fn: () => string | null): CasoAssinatura {
+  try {
+    const falha = fn();
+    return falha === null
+      ? { caso, ok: true, detalhe: "" }
+      : { caso, ok: false, detalhe: falha };
+  } catch (e) {
+    // `mensagemDeErro` e não `String(e)`: o gate `erro-object-object` (#1642) existe porque o
+    // ramo `String()` de um objeto plano rende literalmente "[object Object]" — aqui isso apagaria
+    // a única pista de POR QUE o bundle no ar divergiu.
+    const motivo = mensagemDeErro(e) ?? "erro sem mensagem utilizável";
+    return { caso, ok: false, detalhe: `lançou onde devia passar: ${motivo}` };
+  }
+}
+
+/**
+ * Caso que exige FAIL-CLOSED. Casa a MARCA do ramo, não "lançou algo" (CLAUDE.md §teste negativo):
+ * um bundle que lança por outro motivo — TypeError ao ler uma chave que ele não conhece, por
+ * exemplo — não pode ser lido como "o fail-closed do #1888 está no ar".
+ */
+function exigeFailClosed(caso: string, marca: RegExp, fn: () => unknown): CasoAssinatura {
+  try {
+    fn();
+    return { caso, ok: false, detalhe: "não lançou — o fail-closed do #1888 não está neste bundle" };
+  } catch (e) {
+    // Sem mensagem utilizável não há como afirmar QUAL ramo lançou, e o fallback é escolhido
+    // para não casar marca nenhuma: o caso reprova, que é o desfecho fail-closed correto.
+    const msg = mensagemDeErro(e) ?? "(erro sem mensagem — ramo indeterminado)";
+    return marca.test(msg)
+      ? { caso, ok: true, detalhe: "" }
+      : { caso, ok: false, detalhe: `lançou OUTRO ramo: ${msg}` };
+  }
+}
+
+/**
+ * Roda a tabela-verdade do contrato A2 contra as funções deployadas.
+ *
+ * Cada caso é uma propriedade que o #1888 INTRODUZIU: um bundle anterior a ele falha em todos
+ * (o parse dele nem devolve `clientToUser`, e `aplicarProvaPositivaNoCache` não existe). É o que
+ * torna a assinatura DISCRIMINANTE em vez de teatro verde.
+ */
+export function avaliarAssinaturaA2(deps: DepsAssinaturaA2): AssinaturaA2 {
+  const casos: CasoAssinatura[] = [
+    // ── contrato do snapshot (parseIdentitySnapshot) ──
+    exigeFailClosed(
+      "parse_exige_client_to_user",
+      MARCAS_A2.clientToUserAusente,
+      () => {
+        const snap = snapshotValido();
+        delete snap.client_to_user;
+        return deps.parse(snap);
+      },
+    ),
+    exigeFailClosed(
+      "parse_exige_revoked_client_codes",
+      MARCAS_A2.revogadosAusente,
+      () => {
+        const snap = snapshotValido();
+        delete snap.revoked_client_codes;
+        return deps.parse(snap);
+      },
+    ),
+    exigeOk("parse_devolve_prova_e_revogados", () => {
+      const p = deps.parse(snapshotValido());
+      if (p.clientToUser.get(10) !== UUID_A) return `clientToUser[10]=${String(p.clientToUser.get(10))}`;
+      if (!p.revokedClientCodes.has(20)) return "revokedClientCodes não contém 20";
+      return null;
+    }),
+    exigeFailClosed(
+      // A prova v1 é só `source='document'`: todo user provado está no contradomínio de doc_to_user.
+      "parse_recusa_user_fora_de_doc_to_user",
+      MARCAS_A2.userForaDeDocToUser,
+      () => deps.parse({ ...snapshotValido(), client_to_user: { "10": UUID_C } }),
+    ),
+    exigeFailClosed(
+      // Provado E revogado ao mesmo tempo = fail-open da RPC.
+      "parse_recusa_provado_e_revogado",
+      MARCAS_A2.provadoERevogado,
+      () => deps.parse({ ...snapshotValido(), revoked_client_codes: ["10"] }),
+    ),
+    exigeFailClosed(
+      // `Number('1e3')` é 1000: código FABRICADO como chave de identidade (família `Number(null)===0`).
+      "parse_recusa_codigo_nao_decimal",
+      MARCAS_A2.codigoInvalido,
+      () => deps.parse({ ...snapshotValido(), client_to_user: { "1e3": UUID_A } }),
+    ),
+    // ── sobreposição e revogação sobre o cache (aplicarProvaPositivaNoCache) ──
+    exigeOk("prova_vence_cache_divergente", () => {
+      const cacheLocal = new Map<number, string | null>([[10, UUID_B]]);
+      const r = deps.aplicar(cacheLocal, new Map([[10, UUID_A]]), new Set());
+      if (cacheLocal.get(10) !== UUID_A) return `o cache seguiu com ${String(cacheLocal.get(10))} — a prova não venceu`;
+      if (r.divergencias !== 1) return `divergencias=${r.divergencias}, esperado 1`;
+      return null;
+    }),
+    exigeOk("revogado_sai_do_cache", () => {
+      // É o `delete` que fecha o achado: só saindo do cache o código podre cai em `unknownCodes` e
+      // é refeito pelo ConsultarCliente. Omitir a prova não bastaria.
+      const cacheLocal = new Map<number, string | null>([[10, UUID_A], [20, UUID_B]]);
+      const r = deps.aplicar(cacheLocal, new Map(), new Set([20]));
+      if (cacheLocal.has(20)) return "o código revogado continuou no cache";
+      if (cacheLocal.get(10) !== UUID_A) return "a revogação levou junto um vínculo que não era dela";
+      if (r.revogados !== 1) return `revogados=${r.revogados}, esperado 1`;
+      return null;
+    }),
+    exigeFailClosed(
+      // Teto de sanidade do challenge Codex: revogação em massa é snapshot degradado, não realidade.
+      "revogacao_em_massa_aborta",
+      MARCAS_A2.revogacaoEmMassa,
+      () => {
+        const cacheLocal = new Map<number, string | null>();
+        for (let i = 1; i <= 100; i++) cacheLocal.set(i, UUID_A);
+        const emMassa = new Set<number>();
+        for (let i = 101; i <= 131; i++) emMassa.add(i);
+        return deps.aplicar(cacheLocal, new Map(), emMassa);
+      },
+    ),
+  ];
+  return { contrato: CONTRATO_A2, ok: casos.every((c) => c.ok), casos };
+}

--- a/supabase/functions/omie-vendas-sync/assinatura-a2_test.ts
+++ b/supabase/functions/omie-vendas-sync/assinatura-a2_test.ts
@@ -1,0 +1,355 @@
+// Testes da ASSINATURA COMPORTAMENTAL da canária `identidade_probe` (#1888 / PR-2 / A2).
+//
+// O QUE ESTE ARQUIVO PROVA, e o que NÃO prova. O avaliador recebe as duas funções deployadas por
+// PARÂMETRO (o `index.ts` importa `npm:@supabase/supabase-js@2` e `test:edges` roda com
+// `--no-remote`, então nenhum teste alcança o arquivo). Aqui ele é exercitado contra duplos:
+//
+//   PROVA ....... que o avaliador ACEITA uma implementação que respeita o contrato A2 e REJEITA
+//                 cada sabotagem, nomeando o caso — ou seja, que ele DISCRIMINA. Sem isto a
+//                 assinatura seria "teatro verde" (docs/agent/deploy.md).
+//   NÃO PROVA ... que a implementação real está correta. Isso é
+//                 `src/lib/omie/omie-identity-snapshot.test.ts` (o oráculo) mais a PARIDADE
+//                 textual src×edge de `src/__tests__/edge-money-path-invariants.test.ts`.
+//
+// O terceiro teste fecha o furo que sobra entre os dois: as marcas de erro que a assinatura casa
+// são trechos LITERAIS das mensagens do bloco espelhado. Se uma mensagem mudar lá e a marca ficar
+// para trás, a canária devolveria `assinatura_a2.ok:false` sobre um bundle CORRETO — falso negativo
+// que se lê como reversão do Lovable. O teste lê o `index.ts` como TEXTO e cobra que cada marca ainda
+// case (é o mesmo recurso que o gate de contrato usa; `--allow-read=supabase/functions` cobre).
+
+import { removerComentarios } from "../_shared/limpeza-fonte.ts";
+import { avaliarAssinaturaA2, CONTRATO_A2, type DepsAssinaturaA2, MARCAS_A2 } from "./assinatura-a2.ts";
+import type { AssinaturaA2 } from "./assinatura-a2.ts";
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const CODIGO_RE = /^[1-9][0-9]*$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Duplo CORRETO: reimplementa as regras do contrato A2 que a assinatura cobra. É deliberadamente
+ * uma segunda escrita das regras, e não uma cópia do helper — se fosse cópia, o teste provaria só
+ * que dois arquivos iguais concordam.
+ */
+const depsCorretas: DepsAssinaturaA2 = {
+  parse(snap) {
+    const s = snap as Record<string, unknown>;
+    const docToUserMap = new Map<string, string>(
+      Object.entries(s.doc_to_user as Record<string, string>),
+    );
+    const ambiguousDocs = new Set<string>(s.ambiguous_docs as string[]);
+    const c2u = s.client_to_user;
+    if (!c2u || typeof c2u !== "object" || Array.isArray(c2u)) {
+      throw new Error("identity snapshot: client_to_user ausente ou não-objeto (fail-closed)");
+    }
+    const usuariosComDocUnico = new Set(docToUserMap.values());
+    const clientToUser = new Map<number, string>();
+    for (const [codigo, user] of Object.entries(c2u)) {
+      if (typeof user !== "string" || !UUID_RE.test(user)) {
+        throw new Error("identity snapshot: user_id não-UUID em client_to_user (fail-closed)");
+      }
+      if (!CODIGO_RE.test(codigo) || !Number.isSafeInteger(Number(codigo))) {
+        throw new Error("identity snapshot: código de cliente inválido em client_to_user (fail-closed)");
+      }
+      if (!usuariosComDocUnico.has(user)) {
+        throw new Error("identity snapshot: user de client_to_user fora de doc_to_user (fail-closed)");
+      }
+      clientToUser.set(Number(codigo), user);
+    }
+    const rev = s.revoked_client_codes;
+    if (!Array.isArray(rev)) {
+      throw new Error("identity snapshot: revoked_client_codes ausente ou não-array (fail-closed)");
+    }
+    const revokedClientCodes = new Set<number>();
+    for (const codigo of rev) {
+      const cod = Number(codigo);
+      if (clientToUser.has(cod)) {
+        throw new Error("identity snapshot: código em client_to_user E revoked_client_codes (fail-closed)");
+      }
+      revokedClientCodes.add(cod);
+    }
+    return { docToUserMap, ambiguousDocs, clientToUser, revokedClientCodes };
+  },
+  aplicar(cache, prova, revogados) {
+    const cacheDaView = cache.size;
+    if (cacheDaView >= 100 && revogados.size > cacheDaView * 0.3) {
+      throw new Error("identity snapshot: revogação em massa é sinal de snapshot degradado (fail-closed)");
+    }
+    let divergencias = 0;
+    for (const [codigo, userProvado] of prova) {
+      const doCache = cache.get(codigo);
+      if (doCache !== undefined && doCache !== userProvado) divergencias++;
+      cache.set(codigo, userProvado);
+    }
+    let revogadosNoCache = 0;
+    for (const codigo of revogados) if (cache.delete(codigo)) revogadosNoCache++;
+    return {
+      cacheDaView,
+      provados: prova.size,
+      divergencias,
+      revogados: revogadosNoCache,
+      cobertura: cacheDaView === 0 ? 0 : prova.size / cacheDaView,
+    };
+  },
+};
+
+/** Falhas nomeadas, para os asserts lerem por caso em vez de por índice. */
+function reprovados(a: AssinaturaA2): string[] {
+  return a.casos.filter((c) => !c.ok).map((c) => c.caso);
+}
+
+Deno.test("assinatura A2: implementação que respeita o contrato passa em TODOS os casos", () => {
+  const a = avaliarAssinaturaA2(depsCorretas);
+  if (!a.ok) {
+    throw new Error(`o avaliador reprovou uma implementação correta: ${reprovados(a).join(", ")}`);
+  }
+  if (a.casos.length !== 9) {
+    throw new Error(`a tabela-verdade encolheu para ${a.casos.length} casos — cobertura silenciosamente menor`);
+  }
+  if (a.contrato !== CONTRATO_A2) {
+    throw new Error(`contrato ${JSON.stringify(a.contrato)} — a resposta não diz mais O QUE o ok afirma`);
+  }
+});
+
+Deno.test("FALSIFICAÇÃO: um bundle PRÉ-#1888 é reprovado — é para isso que a assinatura existe", () => {
+  // A forma exata do bundle anterior: o parse do PR-1 devolve doc_to_user/ambiguous_docs e IGNORA
+  // client_to_user (a chave nem existia no contrato dele), e `aplicarProvaPositivaNoCache` não
+  // existe — o `index.ts` de então não teria o que passar. Aqui o `aplicar` é um no-op, que é o
+  // efeito observável de "a sobreposição não está no ar".
+  const preA2: DepsAssinaturaA2 = {
+    parse(snap) {
+      const s = snap as Record<string, unknown>;
+      return {
+        docToUserMap: new Map(Object.entries(s.doc_to_user as Record<string, string>)),
+        ambiguousDocs: new Set(s.ambiguous_docs as string[]),
+        clientToUser: new Map(),
+        revokedClientCodes: new Set(),
+      };
+    },
+    aplicar(cache) {
+      return { cacheDaView: cache.size, provados: 0, divergencias: 0, revogados: 0, cobertura: 0 };
+    },
+  };
+  const a = avaliarAssinaturaA2(preA2);
+  if (a.ok) throw new Error("o avaliador APROVOU um bundle pré-#1888 — a canária não discrimina");
+  // Não basta reprovar: tem de reprovar em TODO caso que o #1888 introduziu, senão a sabotagem
+  // seguinte passa pelo caso que sobrou.
+  for (
+    const esperado of [
+      "parse_exige_client_to_user",
+      "parse_exige_revoked_client_codes",
+      "parse_devolve_prova_e_revogados",
+      "parse_recusa_user_fora_de_doc_to_user",
+      "parse_recusa_provado_e_revogado",
+      "parse_recusa_codigo_nao_decimal",
+      "prova_vence_cache_divergente",
+      "revogado_sai_do_cache",
+      "revogacao_em_massa_aborta",
+    ]
+  ) {
+    if (!reprovados(a).includes(esperado)) {
+      throw new Error(`bundle pré-#1888 passou no caso ${esperado} — cobertura cega ali`);
+    }
+  }
+});
+
+Deno.test("FALSIFICAÇÃO: cada sabotagem PONTUAL é pega pelo caso que lhe corresponde", () => {
+  // Uma sabotagem por vez, sobre a implementação correta: prova que os casos são independentes e
+  // que nenhum deles está passando por acidente do vizinho.
+  const sabotagens: Array<{ nome: string; caso: string; deps: DepsAssinaturaA2 }> = [
+    {
+      nome: "parse aceita client_to_user ausente (o fail-closed do A2 sumiu)",
+      caso: "parse_exige_client_to_user",
+      deps: {
+        ...depsCorretas,
+        parse(snap) {
+          const s = { ...(snap as Record<string, unknown>) };
+          if (!("client_to_user" in s)) s.client_to_user = {};
+          return depsCorretas.parse(s);
+        },
+      },
+    },
+    {
+      nome: "parse confia em user fora de doc_to_user (contrato v1 afrouxado)",
+      caso: "parse_recusa_user_fora_de_doc_to_user",
+      deps: {
+        ...depsCorretas,
+        parse(snap) {
+          const s = snap as Record<string, unknown>;
+          const base = depsCorretas.parse({ ...s, client_to_user: {} });
+          for (const [cod, user] of Object.entries(s.client_to_user as Record<string, string>)) {
+            base.clientToUser.set(Number(cod), user);
+          }
+          return base;
+        },
+      },
+    },
+    {
+      nome: "parse aceita código não-decimal (Number('1e3') vira 1000 — chave FABRICADA)",
+      caso: "parse_recusa_codigo_nao_decimal",
+      deps: {
+        ...depsCorretas,
+        parse(snap) {
+          const s = snap as Record<string, unknown>;
+          const c2u = s.client_to_user as Record<string, string>;
+          const saneado: Record<string, string> = {};
+          for (const [cod, user] of Object.entries(c2u)) saneado[String(Number(cod))] = user;
+          return depsCorretas.parse({ ...s, client_to_user: saneado });
+        },
+      },
+    },
+    {
+      nome: "aplicar não sobrepõe o cache divergente (a prova positiva vira ornamento)",
+      caso: "prova_vence_cache_divergente",
+      deps: {
+        ...depsCorretas,
+        aplicar(cache, _prova, revogados) {
+          return depsCorretas.aplicar(cache, new Map(), revogados);
+        },
+      },
+    },
+    {
+      nome: "aplicar não REMOVE o revogado (só omite — o cache segue servindo o vínculo podre)",
+      caso: "revogado_sai_do_cache",
+      deps: {
+        ...depsCorretas,
+        aplicar(cache, prova, _revogados) {
+          return depsCorretas.aplicar(cache, prova, new Set());
+        },
+      },
+    },
+    {
+      nome: "aplicar perdeu o teto de 30% (revogação em massa vira rate-limit no Omie)",
+      caso: "revogacao_em_massa_aborta",
+      deps: {
+        ...depsCorretas,
+        aplicar(cache, prova, revogados) {
+          let removidos = 0;
+          for (const [codigo, user] of prova) cache.set(codigo, user);
+          for (const codigo of revogados) if (cache.delete(codigo)) removidos++;
+          return {
+            cacheDaView: cache.size + removidos,
+            provados: prova.size,
+            divergencias: 0,
+            revogados: removidos,
+            cobertura: 0,
+          };
+        },
+      },
+    },
+  ];
+  for (const { nome, caso, deps } of sabotagens) {
+    const a = avaliarAssinaturaA2(deps);
+    const falhos = reprovados(a);
+    if (!falhos.includes(caso)) {
+      throw new Error(`sabotagem "${nome}" NÃO foi pega pelo caso ${caso} (reprovados: ${falhos.join(", ") || "nenhum"})`);
+    }
+  }
+});
+
+Deno.test("a assinatura NUNCA propaga exceção — um throw derruba a canária inteira", () => {
+  // A `identidade_probe` responde por DENTRO do try do handler: um erro escapando daqui vira 500
+  // e leva junto a prova do P0-B, que não tem nada a ver com o A2. A canária mentiria sobre si
+  // mesma no ponto em que ela é mais lida.
+  const explosivas: DepsAssinaturaA2 = {
+    parse() {
+      throw new Error("boom no parse");
+    },
+    aplicar() {
+      throw new Error("boom no aplicar");
+    },
+  };
+  const a = avaliarAssinaturaA2(explosivas);
+  if (a.ok) throw new Error("deps que só explodem foram aprovadas");
+  if (a.casos.length !== 9) throw new Error("a avaliação abortou no meio em vez de reportar caso a caso");
+});
+
+Deno.test("as MARCAS ainda existem no index.ts — senão a sonda dá falso NEGATIVO em bundle correto", () => {
+  const fonte = Deno.readTextFileSync("supabase/functions/omie-vendas-sync/index.ts");
+  // Controle positivo: sem isto o teste passaria lendo um arquivo vazio.
+  if (!fonte.includes("function parseIdentitySnapshot(")) {
+    throw new Error("li o arquivo errado — parseIdentitySnapshot não está lá (controle positivo vazio)");
+  }
+  for (const [nome, marca] of Object.entries(MARCAS_A2)) {
+    if (!marca.test(fonte)) {
+      throw new Error(
+        `a marca ${nome} (${marca.source}) não aparece mais no index.ts — a mensagem do ramo mudou e ` +
+          `a assinatura passaria a reprovar um bundle CORRETO`,
+      );
+    }
+  }
+});
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gates TEXTUAIS sobre o `index.ts`: os testes acima provam que o avaliador DISCRIMINA, mas ele
+// roda contra duplos e não tem como saber se a edge lhe passou as funções deployadas ou dois stubs
+// que sempre concordam. Estes dois fecham esse elo. Ficam aqui, e não no vitest, porque leem o
+// mesmo arquivo que o teste de marcas acima já lê (`--allow-read=supabase/functions` cobre).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Bloco da action, SEM comentários: a prosa que explica o campo cita o campo, e um assert
+ *  positivo sobre o texto cru passaria lendo o comentário mesmo com o código removido. */
+function blocoDaCanaria(): string {
+  const fonte = Deno.readTextFileSync("supabase/functions/omie-vendas-sync/index.ts");
+  const limpo = removerComentarios(fonte);
+  const m = limpo.match(/case "identidade_probe":[\s\S]*?\n {6}case /);
+  if (!m) throw new Error("bloco da identidade_probe não encontrado (controle positivo vazio)");
+  return m[0];
+}
+
+Deno.test("a canária ENTREGA a assinatura, e alimentada pelas funções REAIS do bundle", () => {
+  // Sem isto, trocar `parse: parseIdentitySnapshot` por um stub deixaria a canária respondendo
+  // `assinatura_a2.ok:true` sobre QUALQUER bundle: a prova do A2 viraria decoração, verde por
+  // construção — que é o modo de falha que este PR existe para fechar.
+  const bloco = blocoDaCanaria();
+  if (!/avaliarAssinaturaA2\(/.test(bloco)) {
+    throw new Error("a canária não roda mais a assinatura A2 — voltou a provar só o P0-B");
+  }
+  if (!/parse:\s*parseIdentitySnapshot\b/.test(bloco)) {
+    throw new Error("a assinatura não recebe mais o parseIdentitySnapshot DEPLOYADO (stub? outro nome?)");
+  }
+  if (!/aplicar:\s*aplicarProvaPositivaNoCache\b/.test(bloco)) {
+    throw new Error("a assinatura não recebe mais o aplicarProvaPositivaNoCache DEPLOYADO");
+  }
+  if (!/assinatura_a2:/.test(bloco)) {
+    throw new Error("a assinatura é calculada e NÃO sai na resposta — quem sonda não vê o veredito");
+  }
+  // O `ok` agregado tem de INCLUIR a assinatura: se ele continuar sendo só a tabela do P0-B, um
+  // bundle com o A2 revertido responde `ok:true` e a receita de leitura conclui "íntegro".
+  if (!/ok:[^,]*assinaturaA2\.ok/.test(bloco)) {
+    throw new Error("o `ok` agregado ignora a assinatura A2 — bundle com o A2 revertido leria como verde");
+  }
+});
+
+Deno.test("CALIBRAÇÃO: os padrões acima reprovam a canária PRÉ-este-PR e a alimentada por stub", () => {
+  // Sem isto os asserts só provariam que o arquivo tem as âncoras (deploy.md: "canária que não
+  // discrimina é teatro verde"). Sabotar o `index.ts` real dentro do teste não é possível, então a
+  // forma errada é montada aqui como texto.
+  const preEstePr = 'result = { success: true, canary: true, contrato: "x", ok: casosId.every((c) => c.ok) };';
+  if (/avaliarAssinaturaA2\(/.test(preEstePr)) {
+    throw new Error("o padrão da assinatura não reprovaria a canária que só roda o P0-B");
+  }
+  if (/ok:[^,]*assinaturaA2\.ok/.test(preEstePr)) {
+    throw new Error("o padrão do `ok` agregado não reprovaria um ok que ignora a assinatura");
+  }
+  const comStub = 'avaliarAssinaturaA2({ parse: parseFake, aplicar: aplicarFake }); assinatura_a2: a,';
+  if (/parse:\s*parseIdentitySnapshot\b/.test(comStub)) {
+    throw new Error("o padrão das deps não reprovaria uma assinatura alimentada por stub");
+  }
+});
+
+Deno.test("o marcador `contrato` da canária NOMEIA a fatia do A2 — senão não discrimina este deploy", () => {
+  // O `identidade-fail-closed-v1` do #1922 nasceu DEPOIS do #1888, então prova o A2 por
+  // transitividade — mas responderia idêntico antes e depois DESTE PR, e é este PR que instala a
+  // prova comportamental. Marcador que não muda quando o comportamento provado muda é a ⚠️ #2
+  // "mente verde" de docs/agent/deploy.md.
+  const bloco = blocoDaCanaria();
+  const m = bloco.match(/contrato: ["\x27]([a-z0-9-]+)["\x27]/);
+  if (!m) throw new Error("sumiu o marcador `contrato` da canária");
+  if (!/a2|client-to-user/.test(m[1])) {
+    throw new Error(
+      `o marcador ${JSON.stringify(m[1])} não nomeia a fatia do A2 — a canária responderia igual ` +
+        `num bundle com a assinatura e num sem ela`,
+    );
+  }
+});

--- a/supabase/functions/omie-vendas-sync/index.ts
+++ b/supabase/functions/omie-vendas-sync/index.ts
@@ -4,6 +4,7 @@ import { omieDateToIso, classifyOmieTransient, classifyPedidosPage, gerarJanelas
 import { carregarProductMap } from "../_shared/mapas-paginados.ts";
 import { classificarErroAtpGate, classificarRetornoAtpGate } from "../_shared/atp-gate.ts";
 import { deltaEdicaoOben } from "../_shared/atp-edicao.ts";
+import { avaliarAssinaturaA2, CONTRATO_A2 } from "./assinatura-a2.ts";
 import type { BancoPostgrest } from "../_shared/paginate.ts";
 import { avaliarPagina, MAX_PAGINAS_LISTAGEM, MAX_PAGINAS_PEDIDOS, MAX_PAGINAS_POS_ESTOQUE, proximoTotalPaginas } from "../_shared/omie-paginacao.ts";
 
@@ -3570,14 +3571,34 @@ Deno.serve(async (req) => {
         // ⚠️ BUMP obrigatório a cada fatia que mude essa tabela-verdade.
         // `canary: true` acompanha o `probe_no_ar` histórico porque a receita SQL do guia lê
         // `content::jsonb->'canary'`: sem o campo o verificador leria NULL e concluiria "sem canária".
+        // ASSINATURA A2 (#1888): a tabela-verdade acima cobre o `decideAccountIdentity` do P0-B, e o
+        // #1888 não tocou aquele bloco (0 linhas) — sem isto a canária responde IGUAL num bundle com
+        // a prova positiva e num sem ela. Puro e IO-free como o resto do bloco: exercita
+        // `parseIdentitySnapshot` e `aplicarProvaPositivaNoCache` DEPLOYADOS sobre fixtures, mutando
+        // só Maps criados dentro do avaliador. Detalhe do desenho em `assinatura-a2.ts`.
+        const assinaturaA2 = avaliarAssinaturaA2({
+          parse: parseIdentitySnapshot,
+          aplicar: aplicarProvaPositivaNoCache,
+        });
         result = {
           success: true,
           canary: true,
-          contrato: "identidade-fail-closed-v1",
+          // ⚠️ O marcador NOMEIA a fatia que a canária verifica HOJE. O `identidade-fail-closed-v1`
+          // do #1922 já provava o #1888 por TRANSITIVIDADE (nasceu depois dele), mas responderia
+          // idêntico antes e depois desta fatia — e é esta que instala a prova COMPORTAMENTAL do A2,
+          // a única que sobrevive a um deploy em que o Lovable reinterpreta o código (#1272,
+          // #1445→#1478). Bumpar aqui exige bumpar junto o gate de `edge-money-path-invariants`, a
+          // tabela de `docs/agent/deploy.md` e o mapa de `_shared/sonda-versao-contrato_test.ts`.
+          contrato: "identidade-a2-client-to-user-v2",
           probe_no_ar: true, // a action respondeu → a derivação P0-B está no build deployado
           account,
-          ok: casosId.every((c) => c.ok), // true = a tabela-verdade deployada bate em TODOS os fixtures
+          // O `ok` agregado inclui a assinatura DE PROPÓSITO: se ficasse só com a tabela do P0-B, um
+          // bundle com o A2 revertido responderia `ok:true` e a receita de leitura concluiria
+          // "íntegro" — o falso verde que esta fatia existe para fechar.
+          ok: casosId.every((c) => c.ok) && assinaturaA2.ok,
           casos: casosId,
+          contrato_a2: CONTRATO_A2,
+          assinatura_a2: assinaturaA2,
         };
         break;
       }


### PR DESCRIPTION
## O problema (medido em 2026-08-23)

O #1888 (PR-2/A2 — prova positiva `client_to_user` sobre o cache de identidade) está mergeado desde 2026-08-22. Do lado do **escritor** o deploy se provou pelo dado: `omie_customer_account_map.evidence_document_normalized` saiu de **0 → 10.822 de 16.118** após o sync das 05:00 UTC, e só o código novo a escreve. Do lado do **leitor** — a `omie-vendas-sync` — não há efeito observável de fora.

A escada de `docs/agent/deploy.md` tem um degrau só nesta edge:

| Nível | Estado |
|---|---|
| **N1** existência | prova que a função é **servida**, não qual versão |
| **N2** Management API | **estruturalmente indisponível** — Supabase da org do Lovable. ⛔ **Não peça PAT** |
| **N3** comportamento | a `identidade_probe` roda a decisão pura `decideAccountIdentity` do **P0-B** — e o #1888 **não tocou aquele bloco** (0 linhas: `git diff a9410fdaa^ a9410fdaa`) |

## O que este PR NÃO faz, e por quê

A ideia inicial era instalar a sonda `{"probe":true}` do #1905. **Ela não era necessária** e o PR mudou de desenho no meio:

- o **#1922** deu à `identidade_probe` o marcador `contrato: "identidade-fail-closed-v1"`. Como esse marcador nasceu **depois** do #1888, um bundle que o emite é necessariamente ≥ #1888 — a prova de deploy por **transitividade** já existia;
- o **#1937** declarou esta edge em `VERIFICAVEL_POR_CANARIA` com a justificativa *"exigir sonda dela seria exigir um segundo sensor para responder a mesma pergunta"*. Correto.

Instalar a sonda teria criado esse segundo sensor e obrigado a contradizer um PR de ontem.

## O que faltava: o passo seguinte

A transitividade assume que **o binário no ar É o arquivo da main**. Este repo tem duas maneiras registradas de essa premissa ser falsa: o Lovable reinterpreta código no deploy (**#1272**) e o sync bidirecional já reverteu a main por cima de arquivo recém-mergeado (**#1445→#1478**). Os gates de paridade textual pegam isso **na main**; nenhum deles vê o bundle **deployado**.

Sob esse modo de falha, a canária responderia `ok:true` com o `contrato` certo — porque ela exercita o **P0-B**, não o **A2**. O A2 revertido lia como verde.

Então a canária passa a exercitar **também** o A2, no mesmo bloco e **sem sensor novo**: 9 casos sobre `parseIdentitySnapshot` (com `client_to_user`/`revoked_client_codes`) e `aplicarProvaPositivaNoCache` **deployados**. Continua read-only e IO-free — as duas são puras, a segunda muta só Maps criados dentro do avaliador. Nada de Omie, banco ou `supabaseAdmin`.

### Três decisões que o diff carrega

1. **O `ok` agregado passa a incluir `assinaturaA2.ok`.** Se ficasse só com a tabela do P0-B, um bundle com o A2 revertido responderia `ok:true` e a receita de leitura concluiria "íntegro" — o falso verde que esta fatia existe para fechar.
2. **O marcador vira `identidade-a2-client-to-user-v2`.** Marcador que não muda quando o comportamento provado muda é a ⚠️ #2 "mente verde" do `deploy.md`: o v1 responderia idêntico antes e depois desta fatia. Bumpar arrasta o gate de `edge-money-path-invariants`, a tabela do `deploy.md` e o mapa de `_shared/sonda-versao-contrato_test.ts` — os três estão no diff.
3. **As funções chegam ao avaliador por parâmetro, não por import.** O `index.ts` importa `npm:@supabase/supabase-js@2` e `test:edges` roda `--no-remote`, então nenhum teste o alcança. Isso abre três buracos, e cada um tem gate:
   - **o avaliador discrimina?** — bundle pré-#1888 reprovado nos 9 casos + 6 sabotagens pontuais, cada uma pega pelo seu caso;
   - **o `index.ts` passa as funções REAIS, expõe o resultado e o inclui no `ok`?** — com stub, a assinatura ficaria verde por construção;
   - **as marcas de erro ainda existem?** — se uma mensagem mudar no bloco espelhado e a marca ficar para trás, a canária reprovaria um bundle **correto** (falso negativo que se lê como reversão do Lovable).

## Falsificações (todas exigidas em VERMELHO)

| # | Sabotagem | Resultado |
|---|---|---|
| F1 | assinatura removida (canária volta a só-P0-B) | ✅ vermelho |
| F2 | deps alimentadas por stub | ✅ vermelho |
| F3 | `ok` agregado ignora a assinatura | ✅ vermelho |
| F4 | assinatura calculada e não exposta na resposta | ✅ vermelho |
| F5 | contrato não bumpado (volta ao v1) | ✅ vermelho |
| F6 | marca de erro desatualizada | ✅ vermelho |
| F7 | tabela-verdade encolhida | ✅ vermelho |

## Achado registrado (fora do escopo, virou chip)

Ao falsificar a sonda experimental, apareceu um **gate cego** no contrato compartilhado: o teste "toda edge instrumentada RESPONDE à sonda" afirma que `respostaSonda…(` é **chamada**, não que a chamada vira a **resposta HTTP**. `console.log(respostaSonda(v)); return new Response(JSON.stringify({ok:true}))` deixa todos os gates verdes — e a sonda responderia 200 **sem o eco `probe:true`**, o corpo pelo qual se conclui "bundle velho, e ele rodou o efeito caro". Vale para as 19 edges instrumentadas; não fechado aqui porque este PR não instala sonda.

## Nota de erro

O motivo de falha usa `mensagemDeErro` de `_shared/erro-mensagem.ts`, não `String(e)`: o gate `erro-object-object` (#1642) reprovou a primeira versão, e com razão — `String()` de objeto plano rende `[object Object]`, que aqui apagaria a única pista de **por que** o bundle divergiu.

---

# ⚠️ Pra ir ao ar, falta (manual no Lovable) — APÓS o merge deste PR

Merge na `main` **não põe nada no ar**. Este PR toca **só edge** (nem frontend, nem migration):

- [ ] 💬 **chat do Lovable**: deploy da edge `omie-vendas-sync` — verbatim da main

## Passo 1 — 💬 chat do Lovable (cole exatamente isto)

```
Edit the existing edge function `omie-vendas-sync` and replace its code with the current contents of `supabase/functions/omie-vendas-sync/index.ts` from the `main` branch. The function now imports from `supabase/functions/omie-vendas-sync/assinatura-a2.ts` and from `supabase/functions/_shared/erro-mensagem.ts` — create those two files too, verbatim from the `main` branch. Deploy everything **verbatim** — do NOT modify, reinterpret, "improve", or reformat the code. After deploying, confirm it shows **Active**.
```

⚠️ Só **depois** do merge (o Lovable lê da main — deployar antes faz ele ler a main velha).

## Passo 2 — 🟣 SQL Editor do Lovable (leitura da canária, SÓ DEPOIS do deploy)

Cole o bloco inteiro. O segredo sai do vault, nunca do chat. A canária é **dry-run**: não escreve, não chama o Omie, não abre `venda_sync_log`.

```sql
SELECT net.http_post(
  url := 'https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/omie-vendas-sync',
  headers := jsonb_build_object('Content-Type','application/json',
    'x-cron-secret',(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)),
  body := jsonb_build_object('action','identidade_probe'),
  timeout_milliseconds := 20000) AS request_id;
```

~5 s depois, **na mesma aba**:

```sql
SELECT status_code,
       content::jsonb->'canary'                  AS canary,
       content::jsonb->'contrato'                AS contrato,
       content::jsonb->'ok'                      AS ok_agregado,
       content::jsonb->'assinatura_a2'->'ok'     AS assinatura_a2_ok,
       (SELECT jsonb_agg(c->'caso')
          FROM jsonb_array_elements(content::jsonb->'casos') c
         WHERE (c->>'ok')::bool IS NOT TRUE)     AS p0b_vermelhos,
       (SELECT jsonb_agg(jsonb_build_object('caso', c->'caso', 'detalhe', c->'detalhe'))
          FROM jsonb_array_elements(content::jsonb->'assinatura_a2'->'casos') c
         WHERE (c->>'ok')::bool IS NOT TRUE)     AS a2_vermelhos,
       content::jsonb->'error'                   AS erro
FROM net._http_response ORDER BY id DESC LIMIT 1;
```

### Como ler

**✅ NO AR e íntegro** exige os seis juntos:

| Campo | Valor esperado |
|---|---|
| `status_code` | `200` |
| `canary` | `true` |
| `contrato` | `"identidade-a2-client-to-user-v2"` |
| `ok_agregado` | `true` |
| `assinatura_a2_ok` | `true` |
| `p0b_vermelhos` e `a2_vermelhos` | `NULL` |

Os outros desfechos:

- **`contrato` = `"identidade-fail-closed-v1"`** → bundle **anterior a este PR**. A canária respondeu (o P0-B está no ar), mas a prova comportamental do A2 ainda não subiu. É o desfecho esperado **antes** do Passo 1.
- **500 com `Ação desconhecida`** → bundle muito antigo, sem a action. Nada rodou.
- **`contrato` novo + `assinatura_a2_ok: false`** → o caso que este PR existe para pegar: **o bundle tem a assinatura, mas a lógica do #1888 que ele carrega não é a da main** (reinterpretação/reversão do Lovable). `a2_vermelhos` traz o caso **e o detalhe** de cada falha — leve a lista para o diagnóstico, não redeploye às cegas.
- **`assinatura_a2_ok: true` + `p0b_vermelhos` não-nulo** → o A2 subiu e o P0-B regrediu; problema independente desta fatia.

## Verificação de existência (N1, opcional, roda daqui)

```bash
.claude/skills/lovable-deploy-verify/scripts/verify-edge.sh omie-vendas-sync
```
