### PR TITLE
docs(analytics): o Publish saiu e a adoção segue 0% — mas o zero é do CANAL, e isso se prova de FORA dele

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -369,6 +369,26 @@ GROUP BY build ORDER BY clientes DESC"
 - ⚠️ **Adoção baixa é o comportamento CORRETO, não um defeito.** Com o modelo
   `prompt`, o cliente fica no build velho até clicar "Atualizar". A query responde
   *quantos* e *quem* — a decisão (esperar, avisar, ou forçar) é de produto.
+- ⚠️ **O denominador desta query NÃO é a janela de exposição — e por isso `0/N` pode não ser
+  adesão nenhuma.** A fórmula divide *clientes com o build atual* por *clientes na janela de 7
+  dias*: o numerador só pode existir DEPOIS do Publish, o denominador vem dos sete dias inteiros.
+  Se ninguém emitiu evento desde o Publish, `0/3` sai com cara de medição de não-adoção quando é
+  **ausência de observação** — e a razão colapsa os dois estados sem avisar. Antes de reportar a
+  taxa, meça o denominador PÓS-Publish:
+
+  ```sql
+  SELECT count() AS eventos, count(DISTINCT distinct_id) AS clientes
+  FROM events WHERE timestamp > toDateTime('<hora do Publish>', 'UTC')
+  ```
+
+  Zero ali não é adoção zero: é a taxa ainda sem o que medir.
+- ⚠️ **O controle de exposição precisa vir de FORA do cano medido.** Corolário duro do `#1967`:
+  ele mostrou que um cano com dois caminhos exige controle POR caminho — mas esse controle ainda
+  vive DENTRO do PostHog e emudece junto quando o PostHog inteiro emudece. Um controle que só
+  existe no canal sob suspeita não separa *não houve fenômeno* de *o canal não entrega*. O
+  controle independente aqui é a tabela `dashboard_visits`, que escreve pelo **PostgREST**: se ela
+  ganha linha na mesma janela em que o PostHog não ganha evento, o zero do PostHog é do CANAL, e
+  isso se lê sem login com o `psql-ro`. Medido em 2026-08-25 (abaixo).
 - ⚠️ **HTTP 504 = ausência de dado, não zero** (exit 73 no wrapper) — vale aqui como
   em toda leitura desta doc.
 - ⚠️ **O executável é `scripts/posthog-query.sh`, no repo — `~/.config/afiacao/` guarda só a KEY.**
@@ -386,6 +406,57 @@ A query acima rodou com `exit 0` e devolveu **uma linha só**:
 
 Isso é o **controle negativo** do sensor, e vale guardar: pré-Publish, 100% dos eventos têm de cair
 em `(sem instrumentacao)`. Um `build_id` com hash aparecendo aqui antes do Publish significaria que a
-leitura está medindo outra coisa. O `ultimo` também é o controle POSITIVO de ingestão — 66 eventos
-na janela provam que a fase N (ingestão viva) segue de pé e que uma série vazia adiante seria sinal
-real, não silêncio de canal morto.
+leitura está medindo outra coisa.
+
+⚠️ **A segunda metade desta nota estava ERRADA, e fica registrada como tal.** Ela dizia que os 66
+eventos eram o *controle POSITIVO de ingestão*, e que por isso uma série vazia adiante seria sinal
+real e não silêncio de canal morto. O `#1967` decompôs os MESMOS 66 por `properties.$lib`: **65 são
+de browser e nenhum é posterior a `2026-08-23T11:09Z`**; o 66º entrou por `curl`. O agregado somava
+dois canos e leu como saudável um canal que, exercitado, não entrega. **Um controle positivo que
+mistura canos não controla nenhum deles** — e esta frase ficou de pé na doc canônica por um dia
+depois de refutada no histórico, que é o jeito mais barato de uma medição errada sobreviver.
+### Primeira leitura PÓS-Publish (2026-08-25T01:33Z) — e por que ela ainda NÃO é adoção
+
+O Publish saiu: o entry passou de `index-IM3W0waG` para **`index-D1GiFr1h`**. E o bundle servido
+**contém o sensor** — `e.register({build_id:ii()})` aparece literal no `index-D1GiFr1h.js`
+(236 KB, `curl` `rc=0`). Isso elimina *publicou sem a instrumentação* pelo método do `#1973`:
+mede-se o que o servidor entrega, sem login. Vale sempre — o hash mudar prova que **um** build novo
+está no ar, não que é **este**.
+
+A query da §6, `exit 0` e `is_cached=false`, devolveu **a mesma linha do baseline**:
+
+```
+(sem instrumentacao) | 3 clientes | 66 eventos | ultimo 2026-08-24T21:59:38Z
+```
+
+Aritmeticamente, adoção = **0 de 3 = 0%**. Só que isso **não é adoção 0%**; é medição que ainda não
+pode acontecer, e três leituras separam as duas coisas:
+
+| leitura | resultado |
+|---|---|
+| eventos após `2026-08-25T00:50Z` (servidor ainda no build velho) | **0 eventos, 0 clientes** |
+| último evento com `$lib` preenchido — o cano por onde o `build_id` sai | **`2026-08-23T11:09:23Z`** (~38 h) |
+| via do único evento recente do denominador | `API_direta` (o próprio `curl`), não cliente |
+
+Decompondo os 3 clientes: **2 de browser** (65 eventos, todos ≤ 23/08) e **1 de API direta** (1
+evento). O denominador é inteiramente pré-Publish, e o cano que carregaria o `build_id` está mudo.
+
+**E não é falta de gente usando o app** — aqui entra o controle de fora do cano. Na mesma janela,
+`dashboard_visits` ganhou linha, a última em `2026-08-25T01:32:30Z`, **um minuto antes desta
+leitura**, com `company_selection='oben'` e 16 min de sessão (o critério de uso real do `#1972`).
+App exposto, autenticado, gravando em produção — e PostHog com zero. **O zero é do canal, não do
+fenômeno.**
+
+Consequência para a previsão do `#1964`
+(`docs/historico/fase-sem-sinal.md:1478` <!--cita: que aqui é o sensor funcionando, não-->) —
+*"que aqui é o sensor funcionando, não falhando"*: ela não foi confirmada **nem** refutada. Com o cano mudo, `0%` é compatível com as duas, exatamente como o
+`#1967` advertiu. **O gate que destrava a leitura de adoção não é outra query de adoção — é o
+primeiro evento com `$lib='web'`:**
+
+```bash
+./scripts/posthog-query.sh "SELECT max(timestamp) AS ultimo_browser FROM events
+  WHERE timestamp > now() - INTERVAL 2 DAY AND NOT isNull(properties.\$lib)"
+```
+
+Enquanto esse valor não passar de `2026-08-23T11:09:23Z`, repetir a query de build só reconfirma o
+zero — e cada repetição parece uma medição nova.

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1628,3 +1628,64 @@ registra que parte veio de uso real, não de teste) — enquanto o PostHog, na *
 tinha **zero** eventos de browser. App gravando e telemetria muda, ao mesmo tempo, medidos lado a
 lado: é o estado *linha sem evento* do par tabela × evento em forma pura, e a prova de que o
 silêncio não é o app parado nem o deploy quebrado.
+
+## O Publish saiu e a adoção continuou 0% — mas o zero é do CANAL, e isso se prova de fora
+
+A primeira leitura pós-Publish do `build_id` aconteceu em `2026-08-25T01:33Z`, e é o caso limpo da
+armadilha que este arquivo persegue: **um número perfeitamente calculável que não mede o que parece
+medir.**
+
+O Publish saiu — entry de `index-IM3W0waG` para `index-D1GiFr1h` — e o bundle servido **contém o
+sensor**, `e.register({build_id:ii()})` literal no chunk de 236 KB. As duas hipóteses baratas
+morreram antes da query: não é *o Publish não saiu*, nem *saiu sem a instrumentação*.
+
+A query de adoção devolveu **a linha do baseline, intacta**: `(sem instrumentacao) | 3 clientes |
+66 eventos`. Adoção = `0/3` = **0%**.
+
+### Por que reportar "0% de adoção" ali seria fabricar
+
+A fórmula da `analytics.md` §6 divide *clientes com o build atual* por *clientes na janela de 7
+dias*. O numerador só pode nascer depois do Publish; o denominador vem dos sete dias inteiros. Os
+dois lados da razão vivem em janelas que **não se sobrepõem**, e a divisão não avisa:
+
+| leitura | resultado |
+|---|---|
+| eventos após `00:50Z` (servidor ainda no build velho) | **0 eventos, 0 clientes** |
+| último evento com `$lib` — o cano do `build_id` | `2026-08-23T11:09:23Z` (~38 h) |
+| via do único evento recente do denominador | `API_direta` (o próprio `curl`) |
+
+O denominador inteiro é pré-Publish. `0/3` não é *três clientes viram e nenhum atualizou*; é
+**nenhuma observação desde o Publish** — o mesmo `0%` impresso por dois estados do mundo diferentes.
+
+### O controle que decide não estava no PostHog
+
+A tentação seguinte era explicar o silêncio pela sazonalidade — 22 h de uma segunda, e a hora `01Z`
+tem 9 eventos em 2 dias dos últimos 30. O argumento é sedutor e **estava errado**: `dashboard_visits`
+mostra, na mesma madrugada, linha às `01:10:33Z` e outra às `01:32:30Z` — esta **um minuto antes da
+leitura do PostHog** —, ambas `company_selection='oben'`, 23 e 16 minutos de sessão. Gente usando o
+app, autenticada, em produção, enquanto o PostHog registrava zero.
+
+**A regra:** o `#1967` estabeleceu que um cano com dois caminhos exige controle POR caminho. O
+corolário que faltava é mais duro — **o controle de exposição precisa vir de FORA do cano medido**.
+Um controle interno some junto com o canal que ele deveria vigiar: se o PostHog inteiro emudece, o
+controle por caminho emudece também, e o silêncio volta a ser indistinguível de ausência de
+fenômeno. Aqui o controle de fora foi o **PostgREST** — outro transporte, outro destino, mesmo
+browser, mesma janela. Um entregou, o outro não. Isso não localiza a causa, mas **elimina a classe
+inteira** de explicações do lado do fenômeno (ninguém usou, ninguém adotou, fim de expediente) e
+deixa só o canal.
+
+Vale a simetria com a rede: `*.supabase.co` entrega e `us.i.posthog.com` não, no mesmo browser e nos
+mesmos minutos — o que é o feitio de bloqueador de rastreadores, e não o de rede caída. O `#1973` já
+tinha eliminado o servidor (178/178 chunks, key embutida, `initAnalytics` chamado); o par de canos
+elimina o resto do que se mede daqui.
+
+### O que fica pendurado
+
+A previsão do `#1964` — *"que aqui é o sensor funcionando, não falhando"* — segue **sem veredito**.
+Não foi confirmada nem refutada: com o cano mudo, `0%` é compatível com as duas leituras, que é
+exatamente o que o `#1967` advertiu que aconteceria. O sensor de `build_id` está construído,
+publicado e servido; o que falta não é dele.
+
+**O gate é um evento com `$lib='web'`.** Enquanto `max(timestamp)` desse recorte não passar de
+`2026-08-23T11:09:23Z`, toda releitura da adoção reconfirma o mesmo zero com cara de medição nova —
+e a §4 já ensinou o quanto isso custa.


### PR DESCRIPTION
Primeira leitura **pós-Publish** do `build_id` — a que o [#1964](https://github.com/LucasSardenbergL/afiacao/pull/1964) deixou marcada como pendente. Nenhum PR anterior a tem: o [#1972](https://github.com/LucasSardenbergL/afiacao/pull/1972) e o [#1973](https://github.com/LucasSardenbergL/afiacao/pull/1973) são de antes/durante.

## As duas hipóteses baratas morreram antes da query

| hipótese | medida | resultado |
|---|---|---|
| o Publish não saiu | `curl` no entry | `index-IM3W0waG` → **`index-D1GiFr1h`** |
| saiu sem a instrumentação | `grep` no chunk servido | `e.register({build_id:ii()})` — **1 ocorrência** em 236 KB |

O hash mudar prova que **um** build novo está no ar, não que é **este**. A segunda linha é o que fecha, e usa o método do #1973: mede-se o que o servidor entrega, sem login.

## A leitura, e por que "0% de adoção" seria fabricação

`exit 0` · `is_cached=false` · sem `--cache`. Devolveu **a linha do baseline, intacta**:

```
(sem instrumentacao) | 3 clientes | 66 eventos | ultimo 2026-08-24T21:59:38Z
```

Aritmeticamente, adoção = `0/3` = **0%**. Só que a fórmula da §6 divide *clientes com o build atual* por *clientes na janela de 7 dias* — numerador que só nasce depois do Publish, denominador dos sete dias inteiros. As duas janelas **não se sobrepõem**, e a divisão não avisa:

| leitura | resultado |
|---|---|
| eventos após `00:50Z` (servidor ainda no build velho) | **0 eventos, 0 clientes** |
| último evento com `$lib` — o cano do `build_id` | `2026-08-23T11:09:23Z` (~38 h) |
| via do único evento recente do denominador | `API_direta` (o próprio `curl`) |

`0/3` não é *três clientes viram e nenhum atualizou*. É **nenhuma observação desde o Publish** — dois estados do mundo que imprimem o mesmo `0%`.

## O controle que decide não estava no PostHog

A explicação seguinte era a sazonalidade — 22 h de uma segunda, e a hora `01Z` tem 9 eventos em 2 dias dos últimos 30. Sedutora e **errada**: `dashboard_visits` (lido direto por `psql-ro`) tem linha às `01:10:33Z` e outra às `01:32:30Z` — **um minuto antes da leitura do PostHog** —, ambas `company_selection='oben'`, 23 e 16 min de sessão. Gente usando o app, autenticada, em produção, com o PostHog em zero.

**A regra que fica.** O #1967 estabeleceu que cano com dois caminhos exige controle POR caminho. O corolário que faltava é mais duro: **o controle de exposição precisa vir de FORA do cano medido** — um controle interno emudece junto com o canal que deveria vigiar. Aqui o de fora foi o PostgREST: outro transporte, outro destino, mesmo browser, mesma janela. Um entregou, o outro não. Isso não localiza a causa, mas elimina a **classe inteira** de explicações do lado do fenômeno e deixa só o canal.

## Correção na doc canônica

A §6 ainda afirmava que os 66 eventos eram o *controle POSITIVO de ingestão*. O #1967 refutou isso no histórico há um dia (65 de browser, nenhum posterior a 23/08; o 66º por `curl`), mas a frase seguiu de pé **no doc que se lê antes de medir**. Fica registrada como errada, com o porquê.

## Validação — e o susto que ela deu

Os quatro gates saíram `exit 0` de primeira. **O do gate de citações era ausência de dado:** falsifiquei a citação em prosa e ele seguiu **verde** — `RE_CITACAO` só casa `arquivo.ext:linha`, nunca aspas em prosa.

Corrigido: a citação passou a levar alvo + âncora `<!--cita:-->`. O gate foi de **20 para 21** citações verificadas, e só então a falsificação ficou **vermelha** (`exit 1`, nomeando a linha divergente) e verde ao restaurar.

```
docs:citacoes · docs:links · docs:indice · claude:size — exit 0
falsificação: exit 1 (sabotado) → exit 0 (restaurado)
```

## Coordenação

Colide com o #1972 só no **fim** do `fase-sem-sinal.md` (ambos acrescentam ali); no `analytics.md` ele mexe na §pagehide (~l.250) e este PR na §6. Se ele mergear primeiro, eu rebaso.

## O que este PR NÃO resolve

O cano do browser continua mudo. **O gate é um evento com `$lib='web'`** — enquanto `max(timestamp)` desse recorte não passar de `2026-08-23T11:09:23Z`, toda releitura da adoção reconfirma o mesmo zero com cara de medição nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
