### PR TITLE
fix(dashboard): a visita não pode depender de COMO o usuário sai — timer grava ao cruzar MIN_SESSION_MS

### DIFF
--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -278,6 +278,39 @@ describe('useRegistrarVisitaDashboard', () => {
     );
   });
 
+  /**
+   * O effect tem deps `[user?.id]`: quando o login resolve DEPOIS do mount, ele
+   * re-roda e reagenda o timer. Se o reagendamento usasse MIN_SESSION_MS cru, a
+   * contagem reiniciaria e uma sessão que já corria há 4min só gravaria aos 9 —
+   * a espera dobra silenciosamente. Por isso o `restante` sai de `mountedAtRef`.
+   */
+  it('re-run do effect (login tardio) NAO reinicia a contagem — o restante sai do mount, nao do re-run', async () => {
+    mockedUseAuth.mockReturnValue({ user: undefined } as unknown as ReturnType<typeof useAuth>);
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    vi.useFakeTimers();
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { rerender } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+
+    // 4min sem usuário; o login só resolve agora
+    relogio.mockReturnValue(agora + 4 * 60_000);
+    await vi.advanceTimersByTimeAsync(4 * 60_000);
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-tardio' } } as ReturnType<typeof useAuth>);
+    rerender();
+
+    // +1min => 5min DESDE O MOUNT. Com MIN_SESSION_MS cru o timer só cairia aos 9.
+    relogio.mockReturnValue(agora + 5 * 60_000);
+    await vi.advanceTimersByTimeAsync(1 * 60_000);
+
+    expect(emitidos).toHaveLength(1);
+    expect(emitidos[0]).toMatchObject({ user_id: 'user-tardio' });
+
+    relogio.mockRestore();
+    vi.useRealTimers();
+  });
+
   it('desmontar ANTES dos 5min cancela o timer — nao grava depois de a tela ter sumido', async () => {
     mockedUseAuth.mockReturnValue({ user: { id: 'user-timer3' } } as ReturnType<typeof useAuth>);
     const { builder, emitidos, insert } = criarInsertPreguicoso();

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -224,6 +224,84 @@ describe('useRegistrarVisitaDashboard', () => {
     expect(emitidos).toHaveLength(0);
   });
 
+  /**
+   * O TIMER. Provado em produção (2026-08-25): o `fetch` com `keepalive:true` do
+   * `pagehide` NÃO sobrevive ao unload — mesmo caminho, mesmo token, mesma policy
+   * devolvem 201 com a página VIVA e nada quando a aba fecha de verdade. Enquanto
+   * a gravação dependesse de COMO o usuário sai, fechar a aba perdia a visita.
+   * O timer torna a gravação independente da saída: ao cruzar MIN_SESSION_MS a
+   * visita já está no banco.
+   */
+  it('GRAVA ao cruzar MIN_SESSION_MS sem unmount e sem pagehide — a saída deixou de ser requisito', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-timer' } } as ReturnType<typeof useAuth>);
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    vi.useFakeTimers();
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+
+    relogio.mockReturnValue(agora + 5 * 60_000);
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    expect(emitidos).toHaveLength(1);
+    expect(emitidos[0]).toMatchObject({ user_id: 'user-timer', persona: 'gestao' });
+
+    relogio.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('o timer NAO duplica: depois de gravar, o unmount reporta ja_gravado e nao insere de novo', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-timer2' } } as ReturnType<typeof useAuth>);
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    vi.useFakeTimers();
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+
+    relogio.mockReturnValue(agora + 5 * 60_000);
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+    expect(emitidos).toHaveLength(1);
+
+    relogio.mockReturnValue(agora + 9 * 60_000);
+    unmount();
+    relogio.mockRestore();
+    vi.useRealTimers();
+
+    expect(emitidos).toHaveLength(1);
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ motivo: 'ja_gravado' })
+    );
+  });
+
+  it('desmontar ANTES dos 5min cancela o timer — nao grava depois de a tela ter sumido', async () => {
+    mockedUseAuth.mockReturnValue({ user: { id: 'user-timer3' } } as ReturnType<typeof useAuth>);
+    const { builder, emitidos, insert } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    vi.useFakeTimers();
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+
+    relogio.mockReturnValue(agora + 2 * 60_000);
+    await vi.advanceTimersByTimeAsync(2 * 60_000);
+    unmount();
+
+    // passa MUITO do limiar: se o timer sobrevivesse ao unmount, gravaria aqui
+    relogio.mockReturnValue(agora + 30 * 60_000);
+    await vi.advanceTimersByTimeAsync(28 * 60_000);
+    relogio.mockRestore();
+    vi.useRealTimers();
+
+    expect(insert).not.toHaveBeenCalled();
+    expect(emitidos).toHaveLength(0);
+  });
+
   it('reporta dashboard.visita_erro quando o banco recusa o insert (falha nao pode ser silenciosa)', async () => {
     mockedUseAuth.mockReturnValue({ user: { id: 'user-13' } } as ReturnType<typeof useAuth>);
     const { builder } = criarInsertPreguicoso({ code: '42501', message: 'permission denied' });

--- a/src/hooks/useLastVisit.ts
+++ b/src/hooks/useLastVisit.ts
@@ -173,7 +173,7 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
       return 'gravou';
     };
 
-    const gravar = (via: 'unmount' | 'pagehide') => {
+    const gravar = (via: 'unmount' | 'pagehide' | 'timer') => {
       if (typeof window === 'undefined') return;
 
       const viaFechoDeAba = via === 'pagehide';
@@ -229,9 +229,19 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
         });
     };
 
+    // Grava assim que a sessão QUALIFICA, sem esperar a saída. Medido em produção
+    // (2026-08-25): o `fetch` com `keepalive:true` do `pagehide` não sobrevive ao
+    // unload — mesmo caminho e mesmo token devolvem 201 com a página VIVA e nada
+    // quando a aba fecha de verdade. Enquanto a gravação dependesse de COMO o
+    // usuário sai, fechar a aba perdia a visita. `unmount`/`pagehide` continuam
+    // como rede de segurança e caem em `ja_gravado` quando o timer chegou antes.
+    const restante = Math.max(0, MIN_SESSION_MS - (Date.now() - mountedAtRef.current));
+    const timer = window.setTimeout(() => gravar('timer'), restante);
+
     const aoEsconderPagina = () => gravar('pagehide');
     window.addEventListener('pagehide', aoEsconderPagina);
     return () => {
+      window.clearTimeout(timer);
       window.removeEventListener('pagehide', aoEsconderPagina);
       gravar('unmount');
     };


### PR DESCRIPTION
Implementa a correção que o [#1968](https://github.com/LucasSardenbergL/afiacao/pull/1968) deixou como decisão de produto. O founder escolheu o **timer**.

## Por quê

Medido em produção, com **n=2**: o `fetch` com `keepalive: true` do `pagehide` **não sobrevive ao unload**.

| disparo | resposta | linha |
|---|---|---|
| aba **fechada** de verdade | nunca chegou | ❌ |
| `dispatchEvent`, página **viva** | **201** em 637ms | ✅ `id=3` |
| `dispatchEvent`, página **viva** (repetição) | **201** em 605ms | ✅ `id=5` |

Mesmo build, mesma conta, mesmo token, mesma policy. A flag promete sobreviver ao unload e não cumpre. Cinco hipóteses caíram por medição antes desta (env var, bundle velho, RLS/GRANT, token expirado, service worker) — detalhe no #1968.

## A correção

Agendar a gravação para quando a sessão **qualifica**, não para quando ela **termina**:

```ts
const restante = Math.max(0, MIN_SESSION_MS - (Date.now() - mountedAtRef.current));
const timer = window.setTimeout(() => gravar('timer'), restante);
```

Ao cruzar `MIN_SESSION_MS` a visita já está no banco. `unmount` e `pagehide` continuam como rede de segurança e caem em `ja_gravado`. E o `timer` grava pelo client do Supabase — o caminho provado três vezes — em vez do `fetch` cru.

O `restante` sai de `mountedAtRef`, e não de `MIN_SESSION_MS` cru, porque o effect tem deps `[user?.id]`: um login que resolve depois do mount re-roda o effect, e a contagem não pode reiniciar.

## Trade-off consciente

`session_minutes` na tabela passa a registrar o **limiar** (5) no caso comum; a duração real continua no evento `dashboard.visita_tentativa`. Estado e história são perguntas diferentes — a tabela responde *houve visita*, o evento responde *quanto durou*.

## A falsificação achou um buraco meu

Três sabotagens, e na primeira rodada **uma passou verde**: trocar o cálculo do `restante` por `MIN_SESSION_MS` cru não derrubava nada. Ou seja, a justificativa que eu tinha escrito no commit era uma **afirmação não provada** — o código estava certo e o teste não sabia disso. Escrevi o teste que faltava (login tardio re-rodando o effect).

Agora as três mordem:

| sabotagem | resultado |
|---|---|
| sem `setTimeout` | 2 vermelhos |
| sem `clearTimeout` | 1 vermelho |
| `restante` cru | 1 vermelho |

## Validação

`bunx tsc --noEmit -p tsconfig.app.json` **exit 0** · `eslint` **exit 0** · **33/33** testes, re-rodados depois do rebase.

⚠️ Depois do merge isto precisa de **Publish** para agir — e, pela 4ª camada, do **aceite do SW em cada cliente**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
