### PR TITLE
feat(deploy): a lista `esperado` da sonda era transcrita à mão — marcador errado fabrica veredito

### DIFF
--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -167,7 +167,8 @@ VELHO" numa edge que está no ar (e o desfecho é redeployar edge de money-path 
 Edge sem `versao.ts` derruba a geração inteira (nada de SQL parcial em silêncio), e `--caro` que não
 casa um nome da leva também — o typo deixaria a edge cara no bloco SEM trava. Testes:
 `scripts/sonda-versao-sql.test.ts` (a falsificação sabota o `versao.ts` e exige que o marcador velho
-suma do SQL).
+suma do SQL) + `scripts/mutcheck.d/sonda-versao-sql.mut`, que no CI prova que a suíte **pega** a
+trava trocada por `WHERE`, o `LEFT JOIN` virado `JOIN` e o marcador hardcoded.
 
 - ⚠️ **A trava do bloco perigoso tem de ser `CASE`, NÃO `WHERE`.** Quando parte da leva só pode ser sondada
   DEPOIS do deploy confirmado (bundle pré-sensor ignora o `probe` e dispara o run), a tentação é

--- a/docs/agent/deploy.md
+++ b/docs/agent/deploy.md
@@ -159,6 +159,16 @@ entre uma e outra. O padrão é disparar todas com `net.http_post` sobre um `VAL
 `jsonb_object_agg(edge, request_id)::text` numa **célula única** para copiar, e no passo 2 reidratar com
 `jsonb_each_text('<colado>'::jsonb)`. Medido 2026-08-24 sondando a oitava leva (#1937).
 
+**Não digite esse SQL: gere-o.** `bun run sonda:sql <edge>… [--caro=<edge>,…]` lê o `VERSAO` de cada
+`supabase/functions/<edge>/versao.ts` e emite os quatro blocos prontos (disparo + leitura das
+baratas; disparo travado + leitura das caras). A lista `esperado(edge, versao_esperada)` transcrita
+na unha é o buraco que ele fecha: **marcador digitado errado produz veredito FALSO** — "BUNDLE
+VELHO" numa edge que está no ar (e o desfecho é redeployar edge de money-path à toa), ou o inverso.
+Edge sem `versao.ts` derruba a geração inteira (nada de SQL parcial em silêncio), e `--caro` que não
+casa um nome da leva também — o typo deixaria a edge cara no bloco SEM trava. Testes:
+`scripts/sonda-versao-sql.test.ts` (a falsificação sabota o `versao.ts` e exige que o marcador velho
+suma do SQL).
+
 - ⚠️ **A trava do bloco perigoso tem de ser `CASE`, NÃO `WHERE`.** Quando parte da leva só pode ser sondada
   DEPOIS do deploy confirmado (bundle pré-sensor ignora o `probe` e dispara o run), a tentação é
   `... FROM alvos, guard WHERE guard.confirmei = 'sim'`. **Isso não protege**: o Postgres avalia a projeção

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "docs:citacoes": "bun scripts/docs-citacoes-gate-check.ts",
     "docs:indice": "bun scripts/docs-indice-gate-check.ts",
     "docs:links": "bun scripts/docs-links-gate-check.ts",
+    "sonda:sql": "bun scripts/sonda-versao-sql.ts",
     "mutcheck": "bash scripts/mutcheck-all.sh",
     "mutcheck:selftest": "bash scripts/mutcheck.sh --selftest",
     "wt": "bash scripts/new-worktree.sh",

--- a/scripts/mutcheck.d/sonda-versao-sql.mut
+++ b/scripts/mutcheck.d/sonda-versao-sql.mut
@@ -1,0 +1,20 @@
+# Poder de discriminação da suíte do GERADOR do SQL de sondagem de versão (docs/agent/deploy.md
+# §"Sondar VÁRIAS edges numa tacada"). Não é money-path por si, mas decide sobre money-path: um
+# veredito falso daqui manda redeployar edge de money-path à toa — ou dá deploy por confirmado.
+# A falsificação vive AQUI, e não só na sabotagem de fixture dentro do teste, porque falsificação
+# que só roda à mão é ausência de dado (docs/historico/falsificacao-fora-do-ci.md).
+# @src: scripts/sonda-versao-sql.ts
+# @test: scripts/sonda-versao-sql.test.ts
+# Rode: scripts/mutcheck.sh scripts/sonda-versao-sql.ts scripts/sonda-versao-sql.test.ts scripts/mutcheck.d/sonda-versao-sql.mut
+PEGA      | trava do bloco caro CASE -> WHERE (teatro) | s/CASE WHEN g\.confirmei/WHERE g.confirmei/
+PEGA      | leitura sai da lista canonica (LEFT->JOIN) | s/LEFT JOIN ids i/JOIN ids i/
+PEGA      | resposta ausente vira veredito (LEFT->JOIN)| s/LEFT JOIN net\._http_response/JOIN net._http_response/
+PEGA      | ramo AGUARDE some do veredito              | s/'AGUARDE —/'AGUARDOU —/
+PEGA      | placeholder do bloco que le fica invalido  | s/jsonb_each_text\('\{\}'::jsonb\)/jsonb_each_text('<COLE_AQUI>'::jsonb)/
+PEGA      | marcador hardcoded em vez de lido do arquivo | s/lit\(e\.versao\)/lit('v1.0-sensor-inicial')/
+PEGA      | timeout_milliseconds implicito (default 5s) | s/timeout_milliseconds := 20000/-- sem timeout/
+PEGA      | --caro forasteira aceita em silencio       | s/!edges\.includes\(c\)/false/
+PEGA      | edge sem sensor degrada em vez de lancar   | s/if \(problemas\.length > 0\)/if (false)/
+PEGA      | eco probe:true dispensado no CONFIRMADO    | s/AND l\.corpo ->> 'probe' = 'true'/AND true/
+SOBREVIVE | timeout 20s -> 30s (valor nao e pinado)    | s/timeout_milliseconds := 20000/timeout_milliseconds := 30000/
+SOBREVIVE | ORDER BY por posicao (cosmetico)           | s/ORDER BY l\.edge;/ORDER BY 1;/

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -165,6 +165,8 @@ describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', (
 
   it('lê pelo request_id — nunca `ORDER BY id DESC LIMIT 1` nem id de EXEMPLO', () => {
     const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    // Controle POSITIVO: sem ele as duas negativas abaixo passariam medindo um SQL vazio.
+    expect(sql).toMatch(/ON r\.id = i\.request_id/);
     expect(sql).not.toMatch(/ORDER BY id DESC/i);
     expect(sql).not.toMatch(/WHERE\s+r?\.?id\s*=\s*\d+/i);
   });

--- a/scripts/sonda-versao-sql.test.ts
+++ b/scripts/sonda-versao-sql.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { gerarSqlDaLeva, main, parsearArgs, resolverLeva } from './sonda-versao-sql';
+
+const RAIZ_REPO = join(import.meta.dirname, '..');
+const criadas: string[] = [];
+
+afterEach(() => {
+  for (const d of criadas.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+/** Repo de mentira com `supabase/config.toml` + um `versao.ts` por edge pedida. */
+function fixture(edges: Record<string, string>, ref = 'refdementira000000ab'): string {
+  const raiz = mkdtempSync(join(tmpdir(), 'sonda-sql-'));
+  criadas.push(raiz);
+  mkdirSync(join(raiz, 'supabase', 'functions'), { recursive: true });
+  writeFileSync(join(raiz, 'supabase', 'config.toml'), `project_id = "${ref}"\n`);
+  for (const [edge, versao] of Object.entries(edges)) escreverVersao(raiz, edge, versao);
+  return raiz;
+}
+
+function escreverVersao(raiz: string, edge: string, versao: string): void {
+  const dir = join(raiz, 'supabase', 'functions', edge);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'versao.ts'),
+    'export { classificarSonda } from "../_shared/sonda-versao.ts";\n' +
+      `export const VERSAO = "${versao}";\n`,
+  );
+}
+
+describe('edge sem sensor não é sondável — falha ALTO, nunca SQL parcial', () => {
+  it('lança nomeando a edge cujo versao.ts não existe', () => {
+    const raiz = fixture({ 'edge-com-sensor': 'v1.0-sensor-inicial' });
+    expect(() => resolverLeva(raiz, ['edge-com-sensor', 'edge-sem-sensor'])).toThrow(
+      /edge-sem-sensor/,
+    );
+  });
+
+  it('acusa TODAS as edges sem sensor de uma vez, não só a primeira', () => {
+    const raiz = fixture({ boa: 'v1.0-sensor-inicial' });
+    let msg = '';
+    try {
+      resolverLeva(raiz, ['boa', 'orfa-a', 'orfa-b']);
+    } catch (e) {
+      msg = (e as Error).message;
+    }
+    expect(msg).toMatch(/orfa-a/);
+    expect(msg).toMatch(/orfa-b/);
+  });
+
+  it('versao.ts que existe mas não declara VERSAO também falha ALTO', () => {
+    const raiz = fixture({});
+    const dir = join(raiz, 'supabase', 'functions', 'sem-marcador');
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'versao.ts'), 'export const EFEITO = "nada";\n');
+    expect(() => resolverLeva(raiz, ['sem-marcador'])).toThrow(/sem-marcador/);
+  });
+
+  it('uma edge órfã impede o SQL INTEIRO — nada é emitido para as boas', () => {
+    const raiz = fixture({ boa: 'v1.0-sensor-inicial' });
+    expect(() => gerarSqlDaLeva({ raiz, edges: ['boa', 'orfa'] })).toThrow(/orfa/);
+  });
+});
+
+describe('o marcador emitido SAI do versao.ts (falsificação por sabotagem)', () => {
+  it('sabotar o arquivo muda o SQL — o marcador velho não sobrevive', () => {
+    const raiz = fixture({ alvo: 'v9.9-marcador-original' });
+
+    const antes = gerarSqlDaLeva({ raiz, edges: ['alvo'] });
+    expect(antes).toContain('v9.9-marcador-original');
+
+    // SABOTAGEM: só o ARQUIVO muda; o script não é tocado.
+    escreverVersao(raiz, 'alvo', 'v0.0-SABOTADO');
+    const depois = gerarSqlDaLeva({ raiz, edges: ['alvo'] });
+
+    // Implementação que chuta/cacheia o marcador fica VERMELHA aqui.
+    expect(depois).not.toContain('v9.9-marcador-original');
+    expect(depois).toContain('v0.0-SABOTADO');
+  });
+
+  it('cada edge da leva leva o SEU marcador, não o da vizinha', () => {
+    const raiz = fixture({ 'edge-a': 'v1.0-alfa', 'edge-b': 'v2.0-beta' });
+    const sql = gerarSqlDaLeva({ raiz, edges: ['edge-a', 'edge-b'] });
+    expect(sql).toMatch(/\('edge-a',\s*'v1\.0-alfa'\)/);
+    expect(sql).toMatch(/\('edge-b',\s*'v2\.0-beta'\)/);
+  });
+
+  it('contra o repo REAL: o marcador emitido é o do arquivo, para toda edge instrumentada', () => {
+    const dir = join(RAIZ_REPO, 'supabase', 'functions');
+    const edges = readdirSync(dir).filter((e) => {
+      try {
+        readFileSync(join(dir, e, 'versao.ts'), 'utf8');
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    expect(edges.length).toBeGreaterThan(10); // controle: a varredura achou o conjunto real
+
+    const sql = gerarSqlDaLeva({ raiz: RAIZ_REPO, edges });
+    for (const edge of edges) {
+      const fonte = readFileSync(join(dir, edge, 'versao.ts'), 'utf8');
+      const marcador = /export const VERSAO = "([^"]+)"/.exec(fonte)?.[1];
+      expect(marcador, `${edge} sem VERSAO legível`).toBeTruthy();
+      expect(sql).toContain(`('${edge}', '${marcador}')`);
+    }
+  });
+});
+
+describe('PASSO 1 — dispara a leva numa tacada', () => {
+  const raiz = () => fixture({ 'edge-a': 'v1.0-alfa', 'edge-b': 'v2.0-beta' });
+
+  it('dispara com net.http_post sobre um VALUES de nomes', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a', 'edge-b'] });
+    expect(sql).toContain('net.http_post(');
+    expect(sql).toMatch(/alvos\(edge\) AS \(VALUES/);
+    expect(sql).toMatch(/\('edge-a'\),\n\s*\('edge-b'\)/);
+  });
+
+  it('agrega id e edge na MESMA execução, em célula única — o id nunca viaja sozinho', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain('jsonb_object_agg(edge, request_id)::text');
+  });
+
+  it('timeout_milliseconds é EXPLÍCITO — o default de 5s mata silencioso', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/timeout_milliseconds\s*:=\s*\d+/);
+  });
+
+  it('o corpo pede a SONDA, não o fluxo real', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain("jsonb_build_object('probe', true)");
+  });
+
+  it('o segredo sai do vault, nunca do texto colado', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain('vault.decrypted_secrets');
+    expect(sql).toContain("name = 'CRON_SECRET'");
+  });
+
+  it('a URL usa o project_id do supabase/config.toml, não um ref chutado', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain('https://refdementira000000ab.supabase.co/functions/v1/');
+  });
+});
+
+describe('PASSO 2 — a leitura parte da lista CANÔNICA e nomeia os 5 ramos', () => {
+  const raiz = () => fixture({ 'edge-a': 'v1.0-alfa' });
+
+  it('parte de `esperado` e LEFT JOIN nos ids — zero linhas não pode virar "nada a reportar"', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/FROM esperado e\s*\n\s*LEFT JOIN ids i ON i\.edge = e\.edge/);
+    expect(sql).not.toMatch(/FROM ids\b[\s\S]*JOIN esperado/);
+  });
+
+  it('LEFT JOIN em net._http_response — "não chegou" ≠ "veredito negativo"', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/LEFT JOIN net\._http_response r ON r\.id = i\.request_id/);
+    expect(sql).not.toMatch(/(?<!LEFT )JOIN net\._http_response/);
+  });
+
+  it('lê pelo request_id — nunca `ORDER BY id DESC LIMIT 1` nem id de EXEMPLO', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).not.toMatch(/ORDER BY id DESC/i);
+    expect(sql).not.toMatch(/WHERE\s+r?\.?id\s*=\s*\d+/i);
+  });
+
+  it('o placeholder do bloco que LÊ é sintaticamente VÁLIDO', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toContain("jsonb_each_text('{}'::jsonb)");
+    expect(sql).not.toMatch(/'<[A-Z_]+>'::jsonb/);
+  });
+
+  it('desce no envelope `data` — a omie-analytics-sync responde aninhado', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/COALESCE\(r\.content::jsonb -> 'data', r\.content::jsonb\)/);
+  });
+
+  it('os 5 ramos de veredito estão nomeados', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    for (const ramo of ['SEM ID', 'AGUARDE', 'DEPLOY CONFIRMADO', 'BUNDLE VELHO', 'PRE-SENSOR']) {
+      expect(sql, `ramo ausente: ${ramo}`).toContain(ramo);
+    }
+  });
+
+  it('rejeição (>=400) e execução (200 sem versao) NÃO caem no mesmo ramo', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    // O 400 recusou: nada executou → BUNDLE VELHO. Só o 200 sem versao rodou o fluxo real.
+    expect(sql).toMatch(/status_code >= 400\s*\n?\s*THEN 'BUNDLE VELHO/);
+    expect(sql).toMatch(/THEN 'PRE-SENSOR[^']*RODOU O FLUXO REAL/);
+  });
+
+  it('DEPLOY CONFIRMADO exige o eco probe:true E a edge que respondeu, não só a versao', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['edge-a'] });
+    expect(sql).toMatch(/corpo ->> 'probe' = 'true'/);
+    expect(sql).toMatch(/corpo ->> 'edge' = l\.edge/);
+  });
+});
+
+describe('subconjunto CARO — a trava é CASE, nunca WHERE', () => {
+  const raiz = () => fixture({ barata: 'v1.0-alfa', cara: 'v2.0-beta' });
+  const blocoCaro = (sql: string) => sql.slice(sql.indexOf('-- PASSO 3'));
+
+  it('sem --caro não existe bloco de trava — nada de passo inútil', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'] });
+    expect(sql).not.toContain('-- PASSO 3');
+    expect(sql).not.toContain('confirmei_o_deploy');
+  });
+
+  it('a edge cara NÃO viaja no bloco barato — o disparo dela é separado', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cara'] });
+    const barato = sql.slice(0, sql.indexOf('-- PASSO 3'));
+    expect(barato).toContain("('barata')");
+    expect(barato).not.toContain("('cara')");
+    expect(blocoCaro(sql)).toContain("('cara')");
+  });
+
+  it('o http_post do bloco caro está DENTRO de um CASE', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cara'] });
+    expect(blocoCaro(sql)).toMatch(
+      /CASE WHEN g\.confirmei_o_deploy = 'sim'\s*\n?\s*THEN net\.http_post\(/,
+    );
+  });
+
+  it('a trava NÃO é um WHERE — o Postgres avaliaria a projeção e o post sairia igual', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cara'] });
+    const caro = blocoCaro(sql);
+    // Controle: o guard existe mesmo neste bloco (senão o `not.toMatch` abaixo passa por vazio).
+    expect(caro).toContain('confirmei_o_deploy');
+    expect(caro).not.toMatch(/WHERE[^\n]*confirmei_o_deploy/i);
+  });
+
+  it('a trava nasce FECHADA', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cara'] });
+    expect(blocoCaro(sql)).toMatch(/guard\(confirmei_o_deploy\) AS \(VALUES \('nao'\)\)/);
+  });
+
+  it('o bloco caro tem leitura própria, com a lista canônica das caras', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cara'] });
+    const caro = blocoCaro(sql);
+    expect(caro).toContain('-- PASSO 4');
+    expect(caro).toContain("('cara', 'v2.0-beta')");
+    expect(caro).toMatch(/FROM esperado e\s*\n\s*LEFT JOIN ids i ON i\.edge = e\.edge/);
+    expect(caro).not.toContain("('barata', 'v1.0-alfa')");
+  });
+
+  it('--caro de edge fora da leva falha ALTO — o typo mandaria a cara para o bloco barato', () => {
+    expect(() =>
+      gerarSqlDaLeva({ raiz: raiz(), edges: ['barata', 'cara'], caras: ['cra'] }),
+    ).toThrow(/cra/);
+  });
+
+  it('leva 100% cara não emite bloco barato vazio', () => {
+    const sql = gerarSqlDaLeva({ raiz: raiz(), edges: ['cara'], caras: ['cara'] });
+    expect(sql).not.toContain('-- PASSO 1');
+    expect(sql).toContain('-- PASSO 3');
+  });
+});
+
+describe('CLI', () => {
+  it('posicionais são a leva; sem --caro, nenhuma é cara', () => {
+    expect(parsearArgs(['edge-a', 'edge-b'])).toEqual({ edges: ['edge-a', 'edge-b'], caras: [] });
+  });
+
+  it('--caro=a,b marca o subconjunto, e repetir a flag acumula', () => {
+    expect(parsearArgs(['a', 'b', 'c', '--caro=a,b'])).toEqual({
+      edges: ['a', 'b', 'c'],
+      caras: ['a', 'b'],
+    });
+    expect(parsearArgs(['a', 'b', '--caro=a', '--caro=b']).caras).toEqual(['a', 'b']);
+  });
+
+  it('--caro a (com espaço) também marca', () => {
+    expect(parsearArgs(['a', 'b', '--caro', 'a']).caras).toEqual(['a']);
+  });
+
+  it('leva vazia falha ALTO em vez de emitir SQL sem alvo', () => {
+    expect(() => parsearArgs([])).toThrow(/uso/i);
+  });
+
+  it('flag desconhecida falha ALTO — não vira nome de edge', () => {
+    expect(() => parsearArgs(['a', '--carro=a'])).toThrow(/--carro/);
+  });
+
+  it('edge repetida falha ALTO — linha duplicada no VALUES é sonda paga duas vezes', () => {
+    expect(() => parsearArgs(['a', 'b', 'a'])).toThrow(/\ba\b/);
+  });
+
+  it('nome fora da forma de edge é recusado — nada de ../ nem aspas', () => {
+    expect(() => parsearArgs(['../../etc/passwd'])).toThrow(/passwd|forma/i);
+    expect(() => parsearArgs(["a'; DROP"])).toThrow(/forma/i);
+  });
+
+  it('main devolve 0 e escreve o SQL na saída', () => {
+    const raiz = fixture({ 'edge-a': 'v1.0-alfa' });
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const codigo = main(['edge-a'], { raiz, escrever: (t) => saida.push(t), erro: (t) => erros.push(t) });
+    expect(codigo).toBe(0);
+    expect(saida.join('')).toContain("('edge-a', 'v1.0-alfa')");
+    expect(erros).toEqual([]);
+  });
+
+  it('main devolve 1 e NÃO escreve SQL quando a leva tem edge sem sensor', () => {
+    const raiz = fixture({ 'edge-a': 'v1.0-alfa' });
+    const saida: string[] = [];
+    const erros: string[] = [];
+    const codigo = main(['edge-a', 'orfa'], {
+      raiz,
+      escrever: (t) => saida.push(t),
+      erro: (t) => erros.push(t),
+    });
+    expect(codigo).toBe(1);
+    expect(saida).toEqual([]);
+    expect(erros.join('')).toMatch(/orfa/);
+  });
+});

--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -1,0 +1,362 @@
+#!/usr/bin/env bun
+/**
+ * sonda-versao-sql.ts — GERA o SQL de sondagem de versão de uma leva de edges.
+ * ============================================================================================
+ *
+ * A receita (e as armadilhas que a moldaram) é `docs/agent/deploy.md`
+ * §"Sondar VÁRIAS edges numa tacada (leva inteira)". Este script é a receita EXECUTÁVEL.
+ *
+ * POR QUE EXISTE: o SQL era digitado à mão a cada leva, e a lista `esperado(edge, versao_esperada)`
+ * transcrita dos `versao.ts` na unha. Um marcador digitado errado produz VEREDITO FALSO — "BUNDLE
+ * VELHO" numa edge que está no ar (e o desfecho é redeployar edge de money-path à toa), ou a falsa
+ * impressão de deploy confirmado. A fonte da verdade já está no repo; o script a lê.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Uma edge da leva, com o marcador lido do `versao.ts` dela. */
+export interface EdgeSondada {
+  edge: string;
+  versao: string;
+}
+
+/** Caminho do `versao.ts` de uma edge, a partir da raiz do repo. */
+function caminhoVersao(raiz: string, edge: string): string {
+  return join(raiz, 'supabase', 'functions', edge, 'versao.ts');
+}
+
+/**
+ * Extrai o literal de `export const VERSAO = "..."`.
+ *
+ * Estrito de propósito: template literal, concatenação ou `VERSAO` computado devolvem `null` e
+ * viram falha ALTA. Emitir um marcador ADIVINHADO é exatamente o veredito falso que o script
+ * existe para impedir.
+ */
+export function extrairVersao(fonte: string): string | null {
+  const m = /^\s*export\s+const\s+VERSAO\s*=\s*(["'])(.*?)\1\s*;?\s*$/m.exec(fonte);
+  return m ? m[2] : null;
+}
+
+/**
+ * Resolve a leva inteira ou LANÇA — nunca devolve lista parcial.
+ *
+ * Acusa TODAS as edges problemáticas de uma vez: quem pediu 10 edges quer saber quais 3 faltam,
+ * não descobrir uma por execução.
+ */
+export function resolverLeva(raiz: string, edges: string[]): EdgeSondada[] {
+  const semSensor: string[] = [];
+  const semMarcador: string[] = [];
+  const resolvidas: EdgeSondada[] = [];
+
+  for (const edge of edges) {
+    let fonte: string;
+    try {
+      fonte = readFileSync(caminhoVersao(raiz, edge), 'utf8');
+    } catch {
+      semSensor.push(edge);
+      continue;
+    }
+    const versao = extrairVersao(fonte);
+    if (versao === null) semMarcador.push(edge);
+    else resolvidas.push({ edge, versao });
+  }
+
+  const problemas: string[] = [];
+  if (semSensor.length > 0) {
+    problemas.push(
+      `sem sensor (não existe supabase/functions/<edge>/versao.ts): ${semSensor.join(', ')}`,
+    );
+  }
+  if (semMarcador.length > 0) {
+    problemas.push(
+      `versao.ts sem \`export const VERSAO = "..."\` legível: ${semMarcador.join(', ')}`,
+    );
+  }
+  if (problemas.length > 0) {
+    throw new Error(
+      `Edge não sondável — ${problemas.join(' | ')}. ` +
+        'Edge sem sensor não tem como provar versão: instrumente-a (ver _shared/sonda-versao.ts) ' +
+        'antes de sondar. Nenhum SQL foi emitido.',
+    );
+  }
+  return resolvidas;
+}
+
+/**
+ * Ref do projeto Supabase, lido de `supabase/config.toml` — a fonte da verdade do repo.
+ *
+ * Não é hardcode por preguiça de constante: ref chutado manda a sonda para OUTRO host, e a
+ * resposta do gateway (404 `{"code":"NOT_FOUND"}`) é indistinguível de edge que não existe.
+ */
+export function lerProjectRef(raiz: string): string {
+  const toml = readFileSync(join(raiz, 'supabase', 'config.toml'), 'utf8');
+  const m = /^\s*project_id\s*=\s*"([^"]+)"/m.exec(toml);
+  if (!m) throw new Error('supabase/config.toml sem `project_id` — não dá para montar a URL da sonda.');
+  return m[1];
+}
+
+export interface OpcoesLeva {
+  raiz: string;
+  edges: string[];
+  /**
+   * Subconjunto de `edges` cujo bundle PRÉ-sensor IGNORA o `probe` e dispara o fluxo real (PO no
+   * ERP, pedido no portal do fornecedor). O disparo delas sai em bloco separado, com trava.
+   */
+  caras?: string[];
+}
+
+/** Literal SQL entre aspas simples, com escape. */
+function lit(valor: string): string {
+  return `'${valor.replace(/'/g, "''")}'`;
+}
+
+/** Lista `('nome'),` para o `VALUES` do bloco de disparo. */
+function valuesAlvos(leva: EdgeSondada[]): string {
+  return leva.map((e) => `  (${lit(e.edge)})`).join(',\n');
+}
+
+/** Lista `('nome', 'marcador'),` para o `VALUES` da lista canônica do bloco de leitura. */
+function valuesEsperado(leva: EdgeSondada[]): string {
+  return leva.map((e) => `  (${lit(e.edge)}, ${lit(e.versao)})`).join(',\n');
+}
+
+/** A chamada `net.http_post`, idêntica nos dois blocos de disparo. */
+function httpPost(ref: string, indent: string): string {
+  const i = indent;
+  return (
+    `net.http_post(\n` +
+    `${i}  url := 'https://${ref}.supabase.co/functions/v1/' || a.edge,\n` +
+    `${i}  headers := jsonb_build_object(\n` +
+    `${i}    'Content-Type', 'application/json',\n` +
+    `${i}    'x-cron-secret', (SELECT decrypted_secret FROM vault.decrypted_secrets\n` +
+    `${i}                      WHERE name = 'CRON_SECRET' LIMIT 1)),\n` +
+    `${i}  body := jsonb_build_object('probe', true),\n` +
+    `${i}  timeout_milliseconds := 20000)`
+  );
+}
+
+/**
+ * Bloco de DISPARO. O id e o nome da edge saem agregados na MESMA execução
+ * (`jsonb_object_agg`): é o que impede o `request_id` de viajar sozinho e ser copiado para a linha
+ * da edge errada.
+ */
+function blocoDisparo(
+  ref: string,
+  leva: EdgeSondada[],
+  passoLeitura: number,
+  comTrava = false,
+): string {
+  const cabeca = comTrava
+    ? `WITH guard(confirmei_o_deploy) AS (VALUES ('nao')),  -- ⬅️ 'nao' → 'sim' só DEPOIS do verde\n` +
+      `alvos(edge) AS (VALUES\n${valuesAlvos(leva)}\n),\n`
+    : `WITH alvos(edge) AS (VALUES\n${valuesAlvos(leva)}\n),\n`;
+  const projecao = comTrava
+    ? `         CASE WHEN g.confirmei_o_deploy = 'sim'\n` +
+      `              THEN ${httpPost(ref, '                   ')}\n` +
+      `         END AS request_id\n` +
+      `  FROM alvos a CROSS JOIN guard g\n`
+    : `         ${httpPost(ref, '         ')} AS request_id\n` + `  FROM alvos a\n`;
+  return (
+    cabeca +
+    `disparos AS (\n` +
+    `  SELECT a.edge,\n` +
+    projecao +
+    `)\n` +
+    `SELECT jsonb_object_agg(edge, request_id)::text AS cole_no_passo_${passoLeitura}\n` +
+    `FROM disparos;\n`
+  );
+}
+
+/**
+ * Bloco de LEITURA e veredito.
+ *
+ * Parte da lista CANÔNICA (`FROM esperado LEFT JOIN ids`) e não dos ids: invertido, colar o JSON
+ * do bloco errado devolve ZERO linhas — e zero linhas lê-se como "nada a reportar", não como erro.
+ * Mesmo motivo do `LEFT JOIN` contra `net._http_response`: sem ele, "a resposta ainda não chegou"
+ * e "veredito negativo" ficam indistinguíveis.
+ */
+function blocoLeitura(leva: EdgeSondada[]): string {
+  return (
+    `WITH esperado(edge, versao_esperada) AS (VALUES\n${valuesEsperado(leva)}\n),\n` +
+    `ids AS (\n` +
+    `  -- ⬅️ COLE AQUI, no lugar do {}, a célula única devolvida pelo passo de disparo.\n` +
+    `  SELECT chave AS edge, valor::bigint AS request_id\n` +
+    `  FROM jsonb_each_text('{}'::jsonb) AS t(chave, valor)\n` +
+    `),\n` +
+    `lidas AS (\n` +
+    `  SELECT e.edge, e.versao_esperada, i.request_id, r.status_code,\n` +
+    `         COALESCE(r.content::jsonb -> 'data', r.content::jsonb) AS corpo\n` +
+    `  FROM esperado e\n` +
+    `  LEFT JOIN ids i ON i.edge = e.edge\n` +
+    `  LEFT JOIN net._http_response r ON r.id = i.request_id\n` +
+    `)\n` +
+    `SELECT l.edge,\n` +
+    `       l.request_id,\n` +
+    `       l.status_code,\n` +
+    `       l.corpo ->> 'edge'   AS edge_respondida,\n` +
+    `       l.corpo ->> 'versao' AS versao_respondida,\n` +
+    `       l.versao_esperada,\n` +
+    `       CASE\n` +
+    `         WHEN l.request_id IS NULL\n` +
+    `           THEN 'SEM ID — esta edge não saiu no JSON colado (bloco errado, ou trava fechada)'\n` +
+    `         WHEN l.status_code IS NULL\n` +
+    `           THEN 'AGUARDE — a resposta HTTP ainda não chegou (leva ~10s); rode este passo de novo'\n` +
+    `         WHEN l.corpo ->> 'versao' IS NULL AND l.status_code >= 400\n` +
+    `           THEN 'BUNDLE VELHO — recusou o request (HTTP ' || l.status_code || '), NADA executou'\n` +
+    `         WHEN l.corpo ->> 'versao' IS NULL\n` +
+    `           THEN 'PRE-SENSOR — HTTP 200 sem versao: ignorou o probe e RODOU O FLUXO REAL'\n` +
+    `         WHEN l.corpo ->> 'versao' = l.versao_esperada\n` +
+    `              AND l.corpo ->> 'probe' = 'true'\n` +
+    `              AND l.corpo ->> 'edge' = l.edge\n` +
+    `           THEN 'DEPLOY CONFIRMADO'\n` +
+    `         ELSE 'BUNDLE VELHO — respondeu versao=' || COALESCE(l.corpo ->> 'versao', '?') ||\n` +
+    `              ', edge=' || COALESCE(l.corpo ->> 'edge', '?') ||\n` +
+    `              ' (esperado ' || l.versao_esperada || ')'\n` +
+    `       END AS veredito\n` +
+    `FROM lidas l\n` +
+    `ORDER BY l.edge;\n`
+  );
+}
+
+/**
+ * Separa a leva em BARATAS e CARAS, recusando `caras` que não estejam na leva.
+ *
+ * O typo é fail-CLOSED de propósito: `--caro=disparar-pedidos-aprovado` (sem o "s") aceito em
+ * silêncio deixaria a edge cara no bloco SEM trava — e um bundle pré-sensor ali cria PO de verdade
+ * no Omie. É a classe "sonda de script destrutivo é fail-CLOSED" aplicada ao gerador.
+ */
+function separar(edges: string[], caras: string[]): { baratas: string[]; caras: string[] } {
+  const forasteiras = caras.filter((c) => !edges.includes(c));
+  if (forasteiras.length > 0) {
+    throw new Error(
+      `--caro nomeia edge(s) fora da leva: ${forasteiras.join(', ')}. ` +
+        '`--caro` MARCA um subconjunto das edges pedidas; um nome que não casa seria digitação ' +
+        'errada, e a edge cara sairia no bloco SEM trava. Nenhum SQL foi emitido.',
+    );
+  }
+  return { baratas: edges.filter((e) => !caras.includes(e)), caras: edges.filter((e) => caras.includes(e)) };
+}
+
+/** Gera o SQL de sondagem da leva (dois passos por bloco: dispara, depois lê e julga). */
+export function gerarSqlDaLeva(opts: OpcoesLeva): string {
+  const grupos = separar(opts.edges, opts.caras ?? []);
+  // Resolve a leva INTEIRA antes de emitir qualquer coisa: uma edge sem sensor derruba o SQL todo.
+  resolverLeva(opts.raiz, opts.edges);
+  const ref = lerProjectRef(opts.raiz);
+  const partes: string[] = [];
+
+  if (grupos.baratas.length > 0) {
+    const leva = resolverLeva(opts.raiz, grupos.baratas);
+    partes.push(
+      `-- PASSO 1 — dispara as ${leva.length} edge(s) baratas da leva.\n` +
+        blocoDisparo(ref, leva, 2),
+      `-- PASSO 2 — lê e julga. Cole o JSON do PASSO 1 no lugar do {}, NA MESMA ABA.\n` +
+        blocoLeitura(leva),
+    );
+  }
+
+  if (grupos.caras.length > 0) {
+    const leva = resolverLeva(opts.raiz, grupos.caras);
+    partes.push(
+      `-- PASSO 3 — dispara as ${leva.length} edge(s) CARAS, com trava.\n` +
+        `-- ⚠️ Bundle PRÉ-sensor IGNORA o probe e RODA O FLUXO REAL destas. Só abra a trava depois\n` +
+        `--    de o deploy estar confirmado por outro caminho.\n` +
+        `-- ⚠️ A trava é CASE e NÃO um filtro: o Postgres avalia a projeção mesmo descartando todas\n` +
+        `--    as linhas, então travar por filtro deixa o http_post sair igual (falsificado —\n` +
+        `--    docs/agent/deploy.md §"Sondar VÁRIAS edges numa tacada"). Trava fechada devolve\n` +
+        `--    {"edge": null}, que o passo seguinte lê como SEM ID.\n` +
+        blocoDisparo(ref, leva, 4, true),
+      `-- PASSO 4 — lê e julga as CARAS. Cole o JSON do PASSO 3 no lugar do {}.\n` +
+        blocoLeitura(leva),
+    );
+  }
+
+  return partes.join('\n');
+}
+
+/** A leva pedida na linha de comando. */
+export interface ArgsCli {
+  edges: string[];
+  caras: string[];
+}
+
+const USO =
+  'uso: bun run sonda:sql <edge> [<edge> ...] [--caro=<edge>[,<edge>]]\n' +
+  '  <edge>   nome do diretório em supabase/functions/ (precisa ter versao.ts)\n' +
+  '  --caro   marca um SUBCONJUNTO da leva cujo bundle pré-sensor dispara o fluxo real;\n' +
+  '           essas saem em bloco separado, com trava por CASE.';
+
+/**
+ * Forma de nome de edge: é o diretório em `supabase/functions/`, e as 94 existentes cabem todas
+ * aqui. Validar a forma não é paranoia de injeção (o literal já é escapado) — é o que impede
+ * `../..` de virar caminho e um argumento torto de virar linha muda no `VALUES`.
+ */
+const FORMA_EDGE = /^[a-z0-9][a-z0-9-]*$/;
+
+/** Parseia os argumentos ou LANÇA. Nada de flag desconhecida virando nome de edge. */
+export function parsearArgs(argv: string[]): ArgsCli {
+  const edges: string[] = [];
+  const caras: string[] = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--caro' || arg.startsWith('--caro=')) {
+      const bruto = arg === '--caro' ? argv[++i] : arg.slice('--caro='.length);
+      if (!bruto) throw new Error(`--caro sem valor.\n${USO}`);
+      caras.push(...bruto.split(',').filter((s) => s.length > 0));
+      continue;
+    }
+    if (arg.startsWith('-')) throw new Error(`flag desconhecida: ${arg}\n${USO}`);
+    edges.push(arg);
+  }
+
+  if (edges.length === 0) throw new Error(`nenhuma edge na leva.\n${USO}`);
+
+  const tortas = [...edges, ...caras].filter((e) => !FORMA_EDGE.test(e));
+  if (tortas.length > 0) {
+    throw new Error(
+      `fora da forma de um nome de edge (${FORMA_EDGE.source}): ${tortas.join(', ')}\n${USO}`,
+    );
+  }
+
+  const repetidas = edges.filter((e, i) => edges.indexOf(e) !== i);
+  if (repetidas.length > 0) {
+    throw new Error(
+      `edge repetida na leva: ${[...new Set(repetidas)].join(', ')} — ` +
+        'linha duplicada no VALUES é sonda disparada duas vezes.',
+    );
+  }
+
+  return { edges, caras };
+}
+
+/** Saídas da CLI, injetáveis para o teste ver o que foi escrito. */
+export interface DependenciasCli {
+  raiz: string;
+  escrever: (texto: string) => void;
+  erro: (texto: string) => void;
+}
+
+/** Ponto de entrada. Devolve o código de saída; NADA é escrito na saída quando falha. */
+export function main(argv: string[], deps: DependenciasCli): number {
+  let sql: string;
+  try {
+    const { edges, caras } = parsearArgs(argv);
+    sql = gerarSqlDaLeva({ raiz: deps.raiz, edges, caras });
+  } catch (e) {
+    deps.erro(`❌ ${(e as Error).message}`);
+    return 1;
+  }
+  deps.escrever(sql);
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(
+    main(process.argv.slice(2), {
+      raiz: join(import.meta.dirname, '..'),
+      escrever: (t) => process.stdout.write(t),
+      erro: (t) => console.error(t),
+    }),
+  );
+}


### PR DESCRIPTION
## O buraco

O SQL de sondagem de versão de uma leva era **digitado à mão a cada verificação**, e a lista
`esperado(edge, versao_esperada)` transcrita dos `versao.ts` na unha.

Transcrição errada não erra ruidoso — ela **fabrica veredito**: `BUNDLE VELHO` numa edge que está
no ar (e o desfecho é redeployar edge de money-path à toa), ou o inverso, deploy dado por
confirmado sem ser. A fonte da verdade já estava no repo; faltava lê-la.

## O que entra

`bun run sonda:sql <edge>… [--caro=<edge>,…]` lê o marcador de cada
`supabase/functions/<edge>/versao.ts` e emite os blocos prontos para o SQL Editor, com as
armadilhas da receita (`docs/agent/deploy.md` §"Sondar VÁRIAS edges numa tacada") embutidas:

- **leitura a partir da lista CANÔNICA** (`FROM esperado LEFT JOIN ids`) e `LEFT JOIN` contra
  `net._http_response` — zero linhas não pode se ler como "nada a reportar", nem "ainda não
  chegou" como veredito negativo;
- **os 5 ramos nomeados**, com rejeição (`>= 400`, nada executou) separada de execução (`200` sem
  `versao`, rodou o fluxo real);
- **subconjunto `--caro` em bloco próprio, travado por `CASE` e NUNCA por `WHERE`** — o Postgres
  avalia a projeção mesmo com o filtro descartando todas as linhas, então guard por `WHERE` deixa
  o `http_post` sair igual;
- **placeholder VÁLIDO** (`'{}'::jsonb`) no bloco que lê, que cai no ramo `SEM ID`;
- `timeout_milliseconds` explícito, segredo do vault, e o `project_id` lido do
  `supabase/config.toml` em vez de ref chutado.

**Fail-closed nos dois pontos onde o silêncio custa:** edge sem `versao.ts` derruba a geração
inteira (nada de SQL parcial), e `--caro` que não casa um nome da leva também — o typo deixaria a
edge cara no bloco SEM trava, e um bundle pré-sensor ali cria PO de verdade no Omie.

## Prova

- `scripts/sonda-versao-sql.test.ts` — 38 testes, escritos ANTES da implementação (4 ciclos
  RED→GREEN, cada RED conferido). Inclui a **sabotagem**: troca o marcador no `versao.ts` do
  fixture e exige que o marcador velho **suma** do SQL; e um caso contra o repo REAL, varrendo as
  32 edges instrumentadas.
- `scripts/mutcheck.d/sonda-versao-sql.mut` — 12 mutações (10 `PEGA`, 2 `SOBREVIVE`) que provam o
  PODER da suíte, e rodam no CI (`bun run mutcheck`). A trava por `WHERE`, o `JOIN` no lugar do
  `LEFT JOIN`, o marcador hardcoded e o `--caro` forasteiro aceito em silêncio são todas `PEGA`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
