### PR TITLE
feat(sentinela): o sync falhou 37 dias com o erro GRAVADO — faltava alguém CONSULTAR `sync_state`

### DIFF
--- a/db/prereq-sync-state-saude-20260825.sql
+++ b/db/prereq-sync-state-saude-20260825.sql
@@ -1,0 +1,405 @@
+-- Pré-requisitos PG17 para db/test-data-health-sync-state-saude.sh
+-- Stubs das relações que _data_health_compute()/data_health_watchdog() LEEM mas não criam.
+-- Gerado do catálogo da PROD (psql-ro) em 2026-08-25 — colunas e tipos reais; enums viram text.
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.customer_metrics_mv (customer_user_id uuid, razao_social text, document text, ultima_compra_data timestamp with time zone, dias_desde_ultima_compra integer, pedidos_90d bigint, faturamento_90d numeric, ticket_medio_90d numeric, faturamento_prev_90d numeric, intervalo_medio_dias numeric, atraso_relativo numeric, is_cold_start boolean, calculated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.carteira_assignments (id uuid, customer_user_id uuid, owner_user_id uuid, source text, omie_account text, omie_codigo_vendedor bigint, eligible boolean, valid_from timestamp with time zone, updated_at timestamp with time zone, last_synced_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.carteira_membership_ledger (user_id uuid, identity_state text, first_seen_at timestamp with time zone, source text, updated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.farmer_client_scores (id uuid, customer_user_id uuid, farmer_id uuid, rf_score numeric, m_score numeric, g_score numeric, x_score numeric, s_score numeric, health_score numeric, health_class text, churn_risk numeric, recover_score numeric, expansion_score numeric, eff_score numeric, priority_score numeric, days_since_last_purchase integer, avg_repurchase_interval numeric, avg_monthly_spend_180d numeric, gross_margin_pct numeric, category_count integer, answer_rate_60d numeric, whatsapp_reply_rate_60d numeric, revenue_potential numeric, calculated_at timestamp with time zone, created_at timestamp with time zone, updated_at timestamp with time zone, signal_modifiers jsonb, last_signal_recalc_at timestamp with time zone, sales_history_status text, itens_com_custo bigint, itens_sem_custo bigint);
+CREATE TABLE IF NOT EXISTS public.fin_contas_correntes (id uuid, company text, omie_ncodcc bigint, descricao text, banco text, agencia text, numero_conta text, tipo text, saldo_data date, saldo_atual numeric(15,2), ativo boolean, created_at timestamp with time zone, updated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.fin_contas_pagar (id uuid, company text, omie_codigo_lancamento bigint, omie_codigo_cliente_fornecedor bigint, nome_fornecedor text, cnpj_cpf text, numero_documento text, numero_documento_fiscal text, data_emissao date, data_vencimento date, data_pagamento date, data_previsao date, valor_documento numeric(15,2), valor_pago numeric(15,2), valor_desconto numeric(15,2), valor_juros numeric(15,2), valor_multa numeric(15,2), saldo numeric(15,2), status_titulo text, categoria_codigo text, categoria_descricao text, departamento text, centro_custo text, observacao text, omie_ncodcc bigint, codigo_barras text, tipo_documento text, id_origem text, metadata jsonb, created_at timestamp with time zone, updated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.fin_contas_receber (id uuid, company text, omie_codigo_lancamento bigint, omie_codigo_cliente bigint, nome_cliente text, cnpj_cpf text, numero_documento text, numero_documento_fiscal text, numero_pedido text, data_emissao date, data_vencimento date, data_recebimento date, data_previsao date, valor_documento numeric(15,2), valor_recebido numeric(15,2), valor_desconto numeric(15,2), valor_juros numeric(15,2), valor_multa numeric(15,2), saldo numeric(15,2), status_titulo text, categoria_codigo text, categoria_descricao text, departamento text, centro_custo text, observacao text, omie_ncodcc bigint, vendedor_id bigint, tipo_documento text, id_origem text, metadata jsonb, created_at timestamp with time zone, updated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.fin_sync_log (id uuid, action text, companies text[], status text, results jsonb, error_message text, triggered_by text, started_at timestamp with time zone, completed_at timestamp with time zone, duracao_ms integer, entidades_por_empresa jsonb, api_calls integer, rate_limits_hit integer);
+CREATE TABLE IF NOT EXISTS public.fornecedor_alerta (id bigint, empresa text, fornecedor_nome text, tipo text, severidade text, titulo text, mensagem text, campanha_id bigint, aumento_id bigint, email_origem_id text, visualizado boolean, visualizado_em timestamp with time zone, resolvido boolean, resolvido_em timestamp with time zone, resolvido_por text, email_enviado boolean, email_enviado_em timestamp with time zone, calendar_evento_id text, criado_em timestamp with time zone, tipo_alerta text, fornecedor_id uuid, data_evento timestamp with time zone, duracao_minutos integer, status text, gmail_message_id text, erro_notificacao text, tentativas integer, notificado_em timestamp with time zone, metadata jsonb);
+CREATE TABLE IF NOT EXISTS public.inventory_position (id uuid, omie_codigo_produto bigint, product_id uuid, saldo numeric, cmc numeric, preco_medio numeric, account text, synced_at timestamp with time zone, created_at timestamp with time zone, updated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.omie_customer_account_map (id uuid, user_id uuid, account text, omie_codigo_cliente bigint, omie_codigo_vendedor bigint, source text, created_at timestamp with time zone, updated_at timestamp with time zone, evidence_document_normalized text);
+CREATE TABLE IF NOT EXISTS public.omie_products (id uuid, omie_codigo_produto bigint, omie_codigo_produto_integracao text, codigo text, descricao text, unidade text, ncm text, valor_unitario numeric, estoque numeric, ativo boolean, imagem_url text, metadata jsonb, created_at timestamp with time zone, updated_at timestamp with time zone, familia text, subfamilia text, account text, is_tintometric boolean, tint_type text, tipo_produto text);
+CREATE TABLE IF NOT EXISTS public.pedido_compra_sugerido (id bigint, empresa text, fornecedor_nome text, grupo_codigo text, data_ciclo date, horario_geracao timestamp with time zone, horario_corte_planejado timestamp with time zone, horario_disparo_real timestamp with time zone, valor_total numeric, num_skus integer, valor_mes_ate_agora numeric, pedido_anterior_valor numeric, delta_vs_anterior_perc numeric, status text, mensagem_bloqueio text, canal_usado text, resposta_canal jsonb, omie_pedido_compra_id text, omie_pedido_compra_numero text, omie_registrado_em timestamp with time zone, aprovado_por text, aprovado_em timestamp with time zone, cancelado_por text, cancelado_em timestamp with time zone, justificativa_cancelamento text, criado_em timestamp with time zone, atualizado_em timestamp with time zone, condicao_pagamento_codigo text, condicao_pagamento_descricao text, num_parcelas integer, dias_parcelas text, condicao_origem text, tipo_ciclo text, origem_evento_id bigint, origem_evento_tipo text, status_envio_portal text, enviado_portal_em timestamp with time zone, portal_protocolo text, portal_resposta jsonb, portal_screenshot_url text, portal_tentativas integer, portal_proximo_retry_em timestamp with time zone, portal_erro text, portal_data_entrega date, split_parent_id bigint, split_lote integer, split_total integer, omie_po_inexistente_antes_de timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.product_costs (id uuid, product_id uuid, cost_price numeric, updated_at timestamp with time zone, cmc numeric, cost_source text, cost_confidence numeric, family_category text, cost_final numeric, custo_producao numeric, custo_producao_source text, custo_producao_status text, custo_producao_computed_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.sku_estoque_atual (empresa text, sku_codigo_omie text, estoque_fisico numeric, estoque_disponivel numeric, estoque_pendente_entrada numeric, ultima_sincronizacao timestamp with time zone, fonte_sync text);
+CREATE TABLE IF NOT EXISTS public.sku_parametros (id uuid, empresa text, sku_codigo_omie bigint, sku_descricao text, fornecedor_codigo_omie bigint, fornecedor_nome text, classe_abc character(1), classe_xyz character(1), classe_consolidada text, classe_forcada text, motivo_classe_forcada text, classe_proposta_pendente text, meses_consecutivos_nova_classe integer, data_ultima_mudanca_classe date, demanda_media_diaria numeric, demanda_desvio_padrao numeric, demanda_coef_variacao numeric, demanda_dias_com_movimento integer, demanda_total_90d numeric, valor_vendido_90d numeric, lt_medio_dias_uteis numeric, lt_desvio_padrao_dias numeric, lt_p95_dias numeric, lt_n_observacoes integer, fonte_leadtime text, z_score numeric, estoque_seguranca numeric, ponto_pedido numeric, estoque_minimo numeric, cobertura_alvo_dias integer, estoque_maximo numeric, lote_minimo_fornecedor numeric, ativo boolean, aplicar_no_omie boolean, ultima_aplicacao_omie timestamp with time zone, ultima_atualizacao_calculo timestamp with time zone, estoque_minimo_omie numeric, ponto_pedido_omie numeric, estoque_maximo_omie numeric, omie_ultima_sincronizacao timestamp with time zone, aprovado_em timestamp with time zone, aprovado_por text, justificativa_aprovacao text, demanda_multiplicador_override numeric, motivo_override text, override_validade_ate date, override_criado_em timestamp with time zone, override_criado_por text, habilitado_reposicao_automatica boolean, tipo_reposicao text, minimo_forcado_manual numeric, parametro_cold_start boolean);
+CREATE TABLE IF NOT EXISTS public.sync_state (id uuid, entity_type text, account text, last_sync_at timestamp with time zone, last_page integer, last_cursor text, total_synced integer, status text, error_message text, metadata jsonb, created_at timestamp with time zone, updated_at timestamp with time zone);
+CREATE TABLE IF NOT EXISTS public.tint_skus (id uuid, account text, produto_id uuid, base_id uuid, embalagem_id uuid, omie_product_id uuid, imposto_pct numeric, margem_pct numeric, codigo_etiqueta text, ativo boolean, created_at timestamp with time zone, updated_at timestamp with time zone);
+
+CREATE TABLE IF NOT EXISTS public.data_health_watchdog_estado (id boolean NOT NULL, last_run_at timestamp with time zone, last_success_at timestamp with time zone, checks_avaliados integer, checks_falhos integer, ultimo_erro text, atualizado_em timestamp with time zone NOT NULL);
+CREATE TABLE IF NOT EXISTS public.fin_alertas (id uuid NOT NULL, company text NOT NULL, tipo text NOT NULL, severidade text NOT NULL, mensagem text NOT NULL, valor numeric(15,2), threshold numeric(15,2), contexto jsonb, criado_em timestamp with time zone NOT NULL, dismissed_at timestamp with time zone, dismissed_by uuid, dismissed_until timestamp with time zone, email_enfileirado_em timestamp with time zone, acknowledged_at timestamp with time zone, acknowledged_by uuid, resolvido_em timestamp with time zone);
+
+-- defaults/constraints que os INSERTs das funções exigem (o catálogo-dump não os traz)
+DO $prereq$
+DECLARE r record;
+BEGIN
+  FOR r IN SELECT c.relname, a.attname, format_type(a.atttypid,a.atttypmod) AS ty
+             FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+             JOIN pg_attribute a ON a.attrelid=c.oid AND a.attnum>0 AND NOT a.attisdropped
+            WHERE n.nspname='public' AND c.relkind='r'
+  LOOP
+    IF r.attname='id' AND r.ty='uuid' THEN
+      EXECUTE format('ALTER TABLE public.%I ALTER COLUMN id SET DEFAULT gen_random_uuid()', r.relname);
+    ELSIF r.attname IN ('criado_em','created_at','atualizado_em','updated_at') AND r.ty LIKE 'timestamp%' THEN
+      EXECUTE format('ALTER TABLE public.%I ALTER COLUMN %I SET DEFAULT now()', r.relname, r.attname);
+    END IF;
+  END LOOP;
+END $prereq$;
+
+ALTER TABLE public.data_health_watchdog_estado ADD PRIMARY KEY (id);
+-- índice do ON CONFLICT de _data_health_episodio: 1 alerta ATIVO por (company,tipo)
+CREATE UNIQUE INDEX IF NOT EXISTS fin_alertas_company_tipo_ativo
+  ON public.fin_alertas (company, tipo) WHERE dismissed_at IS NULL;
+
+-- funções auxiliares chamadas pelo watchdog (definições REAIS da PROD)
+CREATE OR REPLACE FUNCTION public._data_health_episodio(p_company text, p_tipo text, p_status text, p_sev_fin text, p_titulo text, p_msg text, p_msg_email text, p_ctx jsonb, p_fingerprint text)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+-- data_health reemissao v1 (mig 20260814222000) — MARCADOR do guard anti-rollback.
+-- Uma versão SUCESSORA que recrie esta máquina DEVE trocar o marcador (v2, v3…), para que
+-- re-aplicar a migration ANTIGA sobre ela ABORTE em vez de revertê-la em silêncio.
+DECLARE
+  v_sev_forn   text;
+  v_grav       int;
+  v_intervalo  interval;
+  v_row        public.fin_alertas%ROWTYPE;
+  v_fp_ant     text;
+  v_fp_email   text;
+  v_grav_email int;
+  v_ult_email  timestamptz;
+  v_ult_grav   int;
+  v_flap       boolean;
+  -- 2h = 4 ticks do cron */30. Abaixo disso é oscilação; acima, recorrência.
+  v_janela_flap interval := interval '2 hours';
+  -- Teto de e-mails por MATERIALIDADE (ver v_material). 4h ⇒ ≤6/dia no pior caso.
+  v_min_material interval := interval '4 hours';
+  v_prox       timestamptz;
+  v_ack        boolean;
+  v_snooze     boolean;
+  v_escalou    boolean;
+  v_nunca      boolean;
+  v_material   boolean;
+  v_lembrete   boolean;
+  v_deve       boolean;
+  v_motivo     text;
+  v_upd        int;
+BEGIN
+  -- Contrato fail-closed do vocabulário. NULL/typo ABORTA — nunca degrada para 'aviso'
+  -- (o CASE … ELSE do corpo antigo transformava severidade desconhecida em 'aviso' calado).
+  IF p_sev_fin IS NULL OR p_sev_fin NOT IN ('info','aviso','critico') THEN
+    RAISE EXCEPTION 'severidade de fin_alertas inválida: %', COALESCE(p_sev_fin,'<NULL>')
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_status IS NULL OR p_status NOT IN ('stale','broken','unknown') THEN
+    RAISE EXCEPTION 'status de episódio inválido: %', COALESCE(p_status,'<NULL>')
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- fornecedor_alerta tem CHECK próprio e vocabulário DIFERENTE de fin_alertas
+  -- (info/atencao/urgente vs info/aviso/critico) — derivar aqui elimina o modo de falha
+  -- "severidade inválida derruba o cron".
+  v_sev_forn := CASE p_sev_fin WHEN 'critico' THEN 'urgente'
+                               WHEN 'aviso'   THEN 'atencao'
+                               ELSE 'info' END;
+
+  -- GRAVIDADE = severidade × status. É o que pega stale→broken num check cuja severity é
+  -- literal 'warning' (reposicao_disparo): sem o eixo de status, a piora seria muda.
+  v_grav := (CASE p_sev_fin WHEN 'critico' THEN 3 WHEN 'aviso' THEN 2 ELSE 1 END) * 10
+          + (CASE p_status  WHEN 'broken'  THEN 3 WHEN 'stale' THEN 2 ELSE 1 END);
+
+  v_intervalo := CASE WHEN p_sev_fin = 'critico' THEN interval '24 hours'
+                                                 ELSE interval '72 hours' END;
+
+  -- ── 1) episódio NOVO ──────────────────────────────────────────────────────────────────────
+  -- ⚠️ ANTI-FLAP — a cadência de e-mail é por (company,tipo), NÃO por episódio. Sem isto o
+  -- desenho tem o furo ESPELHO do que corrige: um check que oscila ok↔degradado a cada tick
+  -- resolve e reabre o episódio 48×/dia, e "episódio novo ⇒ e-mail" vira tempestade. O mesmo
+  -- vale para o "dispensar" da UI, que tira a linha do índice parcial e faz o próximo tick
+  -- abrir episódio novo. Consultamos o último ENQUEUE deste tipo ATRAVESSANDO episódios
+  -- encerrados: a garantia passa a ser "no máximo 1 e-mail por cadência por tipo", com duas
+  -- saídas legítimas — nunca notificado, ou pior do que o que já foi notificado.
+  SELECT a.email_enfileirado_em, (a.contexto->>'_grav_email')::int
+    INTO v_ult_email, v_ult_grav
+    FROM public.fin_alertas a
+   WHERE a.company = p_company AND a.tipo = p_tipo AND a.email_enfileirado_em IS NOT NULL
+   ORDER BY a.email_enfileirado_em DESC
+   LIMIT 1;
+
+  -- ⚠️ O anti-flap NÃO pode calar RECORRÊNCIA LEGÍTIMA. O que distingue os dois casos é o
+  -- INTERVALO SAUDÁVEL: flapping fecha e reabre dentro de poucos ticks; um incidente que volta
+  -- depois de horas de saúde é notícia nova e merece e-mail na hora. Sem este recorte, um
+  -- pedido novo travando 2h depois de outro ser resolvido ficaria mudo até o lembrete de 72h —
+  -- exatamente o tipo de silêncio que esta migration existe para acabar.
+  SELECT (max(a.dismissed_at) > clock_timestamp() - v_janela_flap)
+    INTO v_flap
+    FROM public.fin_alertas a
+   WHERE a.company = p_company AND a.tipo = p_tipo AND a.dismissed_at IS NOT NULL;
+
+  v_deve := v_ult_email IS NULL                                    -- nunca avisou este tipo
+            OR (v_ult_grav IS NOT NULL AND v_grav > v_ult_grav)    -- voltou PIOR do que o avisado
+            OR NOT COALESCE(v_flap, false)                         -- reabertura NÃO é oscilação
+            OR clock_timestamp() >= v_ult_email + v_intervalo;     -- venceu a cadência
+
+  -- clock_timestamp() (não now()): now() é o instante do BEGIN e a transação pode ter esperado
+  -- lock/fila; um prazo relativo medido do BEGIN nasce vencido (money-path.md §2).
+  INSERT INTO public.fin_alertas (company, tipo, severidade, mensagem, contexto, email_enfileirado_em)
+  VALUES (p_company, p_tipo, p_sev_fin, p_msg,
+          COALESCE(p_ctx, '{}'::jsonb) || jsonb_build_object(
+            '_fp',            p_fingerprint,
+            '_fp_email',      CASE WHEN v_deve THEN p_fingerprint ELSE NULL END,
+            '_grav_email',    CASE WHEN v_deve THEN v_grav        ELSE v_ult_grav END,
+            '_sev_email',     CASE WHEN v_deve THEN p_sev_fin     ELSE NULL END,
+            -- Silenciado pelo anti-flap: o lembrete herda o prazo do último e-mail REAL, para
+            -- que o teto de silêncio siga sendo a cadência (24h/72h) e não o infinito.
+            '_prox_email_em', to_jsonb(CASE WHEN v_deve THEN clock_timestamp() + v_intervalo
+                                            ELSE v_ult_email + v_intervalo END),
+            '_n_emails',      CASE WHEN v_deve THEN 1 ELSE 0 END,
+            '_motivo_email',  CASE WHEN v_deve THEN 'episodio_novo' ELSE NULL END,
+            'avaliado_em',    to_jsonb(clock_timestamp())),
+          CASE WHEN v_deve THEN clock_timestamp() END)
+  ON CONFLICT (company, tipo) WHERE dismissed_at IS NULL DO NOTHING;
+
+  IF FOUND THEN
+    IF v_deve THEN
+      INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+      VALUES (p_company, 'outro', v_sev_forn, p_titulo, COALESCE(p_msg_email, p_msg), 'pendente_notificacao');
+      -- ⚠️ INSERT que "tem sucesso" com ZERO linhas (um BEFORE INSERT devolvendo NULL) deixaria
+      -- o claim carimbado SEM e-mail — a "escrita que falha calada" do money-path.md §11.
+      GET DIAGNOSTICS v_upd = ROW_COUNT;
+      IF v_upd <> 1 THEN
+        RAISE EXCEPTION 'outbox nao materializou a linha (% gravadas) para %', v_upd, p_tipo
+          USING ERRCODE = '25000';
+      END IF;
+    END IF;
+    RETURN v_deve;
+  END IF;
+
+  -- ── 2) episódio ABERTO ────────────────────────────────────────────────────────────────────
+  -- FOR UPDATE trava a linha ANTES de decidir: uma 2ª sessão bloqueia aqui e, ao destravar,
+  -- relê a linha JÁ carimbada (READ COMMITTED) ⇒ deve_notificar = false ⇒ 1 e-mail, não 2.
+  SELECT * INTO v_row
+    FROM public.fin_alertas
+   WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL
+   FOR UPDATE;
+
+  -- Dispensa CONCORRENTE entre o INSERT e o SELECT: sem alerta aberto por trás, não se
+  -- enfileira e-mail fantasma. ⚠️ LANÇA em vez de devolver `false` (achado Codex E2): o caller
+  -- usa PERFORM e não lê o retorno, então um `false` aqui deixaria a fonte DEGRADADA terminar a
+  -- rodada SEM episódio ativo e ainda assim carimbar `last_success_at`. Lançando, o isolamento
+  -- por check conta a falha e o marcador de sucesso não avança — fail-closed.
+  IF NOT FOUND THEN
+    -- P0002 (no_data_found) de propósito: é falha LOCAL do check, e a classe 40 seria relançada
+    -- como sistêmica pelo isolamento do watchdog, derrubando os outros 16 por uma corrida benigna.
+    RAISE EXCEPTION 'episodio de % sumiu entre o INSERT e o lock (dispensa concorrente)', p_tipo
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- ⚠️ RE-LEITURA DEPOIS DO LOCK. A consulta lá em cima rodou ANTES de travar a linha, então
+  -- numa corrida ela traz o valor PRÉ-concorrente: a sessão B veria v_ult_email NULL, concluiria
+  -- "nunca avisou" e enfileiraria um 2º e-mail. Sob READ COMMITTED, reler após o FOR UPDATE
+  -- devolve o que a sessão A commitou — é isto que faz o claim ser de fato atômico.
+  SELECT a.email_enfileirado_em, (a.contexto->>'_grav_email')::int
+    INTO v_ult_email, v_ult_grav
+    FROM public.fin_alertas a
+   WHERE a.company = p_company AND a.tipo = p_tipo AND a.email_enfileirado_em IS NOT NULL
+   ORDER BY a.email_enfileirado_em DESC
+   LIMIT 1;
+
+  v_fp_ant     := v_row.contexto->>'_fp';
+  v_fp_email   := v_row.contexto->>'_fp_email';
+  -- ⚠️ SEM COALESCE(...,0) de propósito: gravidade AUSENTE é desconhecida, não zero — o
+  -- `ausente ≠ zero` do money-path. Com o zero, toda linha HISTÓRICA (contexto sem as âncoras
+  -- novas, como os 3 alertas presos de prod) entraria como "escalada" e passaria por cima de
+  -- reconhecimento e soneca. Quem nunca notificou não escalou nada: quem trata esse caso é o
+  -- ramo `nunca_enfileirou`, que respeita ack/soneca.
+  v_grav_email := (v_row.contexto->>'_grav_email')::int;
+  v_prox       := CASE WHEN jsonb_typeof(v_row.contexto->'_prox_email_em') = 'string'
+                       THEN (v_row.contexto->>'_prox_email_em')::timestamptz END;
+
+  v_ack    := v_row.acknowledged_at IS NOT NULL;
+  v_snooze := v_row.dismissed_until IS NOT NULL AND v_row.dismissed_until > clock_timestamp();
+
+  -- ⚠️ REARME NA RECUPERAÇÃO (padrão do tint; a 1ª versão desta migration ESQUECEU de portá-lo e
+  -- o Codex pegou). A âncora é o PICO notificado, então sem rearme: broken(23) avisa → melhora
+  -- para stale(22) → humano reconhece → volta a broken(23) e `23 > 23` é FALSO ⇒ o ack bloqueia
+  -- materialidade e lembrete, e o retorno ao mesmo patamar fica MUDO PARA SEMPRE. Fazendo a
+  -- âncora DESCER junto com a melhora, o retorno volta a ser escalada — e escalada supera ack.
+  IF v_grav_email IS NOT NULL AND v_grav < v_grav_email THEN
+    v_grav_email := v_grav;
+  END IF;
+
+  v_escalou := v_grav_email IS NOT NULL AND v_grav > v_grav_email;
+
+  -- ⚠️ "nunca enfileirou" é por TIPO, não por EPISÓDIO (v_ult_email vem da consulta acima, que
+  -- atravessa episódios encerrados). Ancorar no episódio faria o anti-flap durar UMA rodada: o
+  -- episódio reaberto e silenciado teria email_enfileirado_em NULL e emitiria no tick seguinte,
+  -- devolvendo a tempestade pela porta dos fundos.
+  v_nunca   := v_ult_email IS NULL;
+
+  -- MATERIALIDADE com confirmação em DUAS avaliações: só conta violação nova cujo fingerprint
+  -- se REPETIU (p_fingerprint = _fp da avaliação anterior) e que difere do último NOTIFICADO.
+  -- É o que torna a máquina imune a um `message` volátil sem precisar auditar os 17 checks:
+  -- fingerprint que muda toda rodada nunca se confirma ⇒ nunca vira e-mail.
+  -- `v_fp_email IS NOT NULL` é o par do bullet acima: sem ele, o episódio silenciado pelo
+  -- anti-flap (que grava _fp_email NULL) veria "IS DISTINCT FROM NULL" = true e emitiria.
+  -- ⚠️ COOLDOWN (achado Codex): a confirmação em 2 avaliações mata `A,B,A,B`, mas NÃO mata
+  -- `A,A,B,B,A,A…` — cada par confirma e emite, ~24 e-mails/dia. A confirmação prova repetição
+  -- textual, não estabilidade temporal, então o teto tem de ser um RELÓGIO. 4h limita a ~6/dia
+  -- no pior caso patológico e ainda reporta violação nova MUITO antes do lembrete (24h/72h).
+  v_material := p_fingerprint IS NOT NULL
+                AND v_fp_ant IS NOT NULL
+                AND v_fp_email IS NOT NULL
+                AND p_fingerprint = v_fp_ant
+                AND p_fingerprint IS DISTINCT FROM v_fp_email
+                AND (v_ult_email IS NULL OR clock_timestamp() >= v_ult_email + v_min_material);
+
+  -- `v_prox IS NULL` = linha SEM as âncoras novas (histórica, ou escrita por versão anterior)
+  -- que JÁ tem carimbo de e-mail: sem este bootstrap ela cai em nunca=false, escalou=false,
+  -- material=false e lembrete=false — muda para sempre (achado Codex A1). Tratar como lembrete
+  -- DEVIDO dá exatamente um e-mail; depois dele as âncoras existem e a cadência assume.
+  v_lembrete := v_prox IS NULL OR clock_timestamp() >= v_prox;
+
+  -- Escalada SUPERA reconhecimento e soneca: quem reconheceu um 'aviso' não reconheceu o
+  -- 'critico' que veio depois.
+  v_deve := v_escalou
+            OR ((NOT v_ack) AND (NOT v_snooze) AND (v_nunca OR v_material OR v_lembrete));
+
+  v_motivo := CASE WHEN NOT v_deve   THEN NULL
+                   WHEN v_escalou    THEN 'escalada'
+                   WHEN v_nunca      THEN 'nunca_enfileirou'
+                   WHEN v_material   THEN 'nova_violacao'
+                   ELSE                   'lembrete' END;
+
+  -- UPDATE INCONDICIONAL do estado (padrão do tint): o banco reflete SEMPRE o ciclo atual —
+  -- uma MELHORA parcial que não atualizasse nada deixaria o alerta mostrando o pico para sempre.
+  -- O que a histerese governa é só o E-MAIL.
+  UPDATE public.fin_alertas SET
+      severidade           = p_sev_fin,
+      mensagem             = p_msg,
+      acknowledged_at      = CASE WHEN v_escalou THEN NULL ELSE acknowledged_at END,
+      acknowledged_by      = CASE WHEN v_escalou THEN NULL ELSE acknowledged_by END,
+      email_enfileirado_em = CASE WHEN v_deve THEN clock_timestamp() ELSE email_enfileirado_em END,
+      contexto = COALESCE(p_ctx, '{}'::jsonb) || jsonb_build_object(
+          '_fp',            p_fingerprint,
+          '_fp_ant',        v_fp_ant,
+          '_fp_email',      CASE WHEN v_deve THEN p_fingerprint ELSE v_fp_email END,
+          '_grav_email',    CASE WHEN v_deve THEN v_grav        ELSE v_grav_email END,
+          '_sev_email',     CASE WHEN v_deve THEN p_sev_fin     ELSE v_row.contexto->>'_sev_email' END,
+          -- COALESCE no ELSE: sem ele uma linha sem âncora que NÃO emitiu (ack/soneca) ficaria
+          -- com _prox_email_em NULL para sempre, e o bootstrap do lembrete nunca se resolveria.
+          '_prox_email_em', CASE WHEN v_deve THEN to_jsonb(clock_timestamp() + v_intervalo)
+                                 ELSE COALESCE(v_row.contexto->'_prox_email_em',
+                                               to_jsonb(clock_timestamp() + v_intervalo)) END,
+          '_n_emails',      COALESCE((v_row.contexto->>'_n_emails')::int, 0)
+                            + CASE WHEN v_deve THEN 1 ELSE 0 END,
+          '_motivo_email',  v_motivo,
+          'avaliado_em',    to_jsonb(clock_timestamp()))
+   WHERE company = p_company AND tipo = p_tipo AND dismissed_at IS NULL;
+
+  GET DIAGNOSTICS v_upd = ROW_COUNT;
+  IF v_upd = 0 THEN
+    RETURN false;
+  END IF;
+
+  IF v_deve THEN
+    -- MESMA transação do carimbo: se o outbox falhar, o claim cai junto — nunca
+    -- "email_enfileirado_em preenchido sem e-mail correspondente".
+    INSERT INTO public.fornecedor_alerta (empresa, tipo, severidade, titulo, mensagem, status)
+    VALUES (p_company, 'outro', v_sev_forn,
+            CASE WHEN v_escalou THEN 'AGRAVOU: ' || p_titulo ELSE p_titulo END,
+            COALESCE(p_msg_email, p_msg), 'pendente_notificacao');
+    GET DIAGNOSTICS v_upd = ROW_COUNT;
+    IF v_upd <> 1 THEN
+      RAISE EXCEPTION 'outbox nao materializou a linha (% gravadas) para %', v_upd, p_tipo
+        USING ERRCODE = '25000';
+    END IF;
+    RETURN true;
+  END IF;
+
+  RETURN false;
+END;
+$function$
+;
+CREATE OR REPLACE FUNCTION public._tint_cobertura_bases_lista_email(p_limit integer DEFAULT 50)
+ RETURNS text
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH itens AS (
+    SELECT op.codigo, op.descricao,
+           CASE WHEN op.is_tintometric IS NOT TRUE
+                THEN 'sem is_tintometric (some do mapeamento)'
+                ELSE 'tint_type "' || COALESCE(op.tint_type, '∅') || '" deveria ser "'
+                     || CASE lower(btrim(op.familia))
+                          WHEN 'bases mixmachine' THEN 'base'
+                          WHEN 'concentrados mixmachine' THEN 'concentrado' END
+                     || '" (aba trocada)'
+           END AS motivo,
+           row_number() OVER (ORDER BY op.familia, op.descricao, op.codigo) AS rn
+    FROM public.omie_products op
+    WHERE op.account = 'oben' AND op.ativo = true
+      AND lower(btrim(op.familia)) IN ('bases mixmachine','concentrados mixmachine')
+      AND op.created_at < now() - interval '30 hours'
+      AND ( op.is_tintometric IS NOT TRUE
+         OR op.tint_type IS DISTINCT FROM CASE lower(btrim(op.familia))
+              WHEN 'bases mixmachine' THEN 'base'
+              WHEN 'concentrados mixmachine' THEN 'concentrado' END )
+  ),
+  agg AS (
+    SELECT
+      count(*)::int AS n_total,
+      count(*) FILTER (WHERE rn <= GREATEST(p_limit, 0))::int AS n_mostrados,
+      string_agg(
+        CASE WHEN rn <= GREATEST(p_limit, 0)
+             THEN '• ' || descricao || ' (cód. ' || codigo || ') — ' || motivo
+             ELSE NULL END,
+        E'\n' ORDER BY rn) AS corpo
+    FROM itens
+  )
+  SELECT CASE
+    WHEN n_total = 0 THEN NULL
+    ELSE 'Bases/concentrados MixMachine divergentes (corrija no Omie ou rode tint_marcar_bases_mixmachine):'
+         || E'\n' || corpo
+         || CASE WHEN n_total > n_mostrados
+                 THEN E'\n… e mais ' || (n_total - n_mostrados)::text || ' item(ns) — veja no painel Saúde de Dados.'
+                 ELSE '' END
+  END
+  FROM agg;
+$function$
+;
+CREATE OR REPLACE FUNCTION public._vendas_familia_ausente_lista_email(p_limit integer DEFAULT 50)
+ RETURNS text
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH itens AS (
+    SELECT account, codigo, descricao,
+           row_number() OVER (ORDER BY account, descricao, codigo) AS rn
+    FROM public.omie_products
+    WHERE NULLIF(btrim(familia), '') IS NULL
+      AND COALESCE(ativo, false)
+      AND account IN ('oben','colacor')
+  ),
+  agg AS (
+    SELECT
+      count(*)::int AS n_total,
+      count(*) FILTER (WHERE rn <= GREATEST(p_limit, 0))::int AS n_mostrados,
+      string_agg(
+        CASE WHEN rn <= GREATEST(p_limit, 0)
+             THEN '• [' || account || '] ' || descricao || ' (cód. ' || codigo || ')'
+             ELSE NULL END,
+        E'\n' ORDER BY rn) AS corpo
+    FROM itens
+  )
+  SELECT CASE
+    WHEN n_total = 0 THEN NULL
+    ELSE 'Produtos sem família (classifique no Omie):' || E'\n' || corpo
+         || CASE WHEN n_total > n_mostrados
+                 THEN E'\n… e mais ' || (n_total - n_mostrados)::text
+                      || ' produto(s) — veja no painel Saúde de Dados ou filtre no Omie por família vazia.'
+                 ELSE '' END
+  END
+  FROM agg;
+$function$
+;

--- a/db/test-data-health-sync-state-saude.sh
+++ b/db/test-data-health-sync-state-saude.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# ╔══════════════════════════════════════════════════════════════════════════════╗
+# ║  HARNESS PG17 — PROVA de migration money-path/auth com FALSIFICAÇÃO            ║
+# ║  Copie p/ db/test-<slug>.sh, preencha as ZONAS [[...]], rode:                  ║
+# ║      bash db/test-<slug>.sh > /tmp/t.log 2>&1; echo "exit=$?"                  ║
+# ║  (NÃO pipe pra tail — engole o exit≠0; §2 do CLAUDE.md.)                       ║
+# ║                                                                                ║
+# ║  Lei de Ferro (skill prove-sql-money-path):                                    ║
+# ║   1. Aplica a migration REAL (psql -f), não um stub da lógica.                 ║
+# ║   2. Assert negativo captura a SQLSTATE esperada e RE-LANÇA o resto.           ║
+# ║   3. Falsificação obrigatória: sabota a migração → exija VERMELHO → restaura.  ║
+# ╚══════════════════════════════════════════════════════════════════════════════╝
+set -euo pipefail
+
+# ── arranque PG17 descartável (idêntico em todos os harnesses; contorna keg-only do brew) ──
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PGVER=17
+PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
+PORT="${PGPORT_TEST:-5471}"
+SLUG="sync-state-saude"
+DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
+export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
+
+[ -x "$PGBIN/initdb" ] || { echo "postgresql@${PGVER} ausente: brew install postgresql@${PGVER} pgvector"; exit 1; }
+
+# keg-only do brew: share/lib do postgresql@17 podem não estar linkados → initdb/server falham. Copia do Cellar (idempotente).
+CELLAR="$(brew --prefix "postgresql@${PGVER}")"
+cp -Rn "$CELLAR"/share/postgresql/. "/opt/homebrew/share/postgresql@${PGVER}/" 2>/dev/null || true
+mkdir -p "/opt/homebrew/lib/postgresql@${PGVER}"
+cp -Rn "$CELLAR"/lib/postgresql/. "/opt/homebrew/lib/postgresql@${PGVER}/" 2>/dev/null || true
+
+cleanup() { "$PGBIN/pg_ctl" -D "$DATA" stop -m immediate >/dev/null 2>&1 || true; rm -rf "$(dirname "$DATA")"; }
+trap cleanup EXIT
+
+"$PGBIN/initdb" -D "$DATA" -U postgres -E UTF8 --locale=C >/dev/null
+"$PGBIN/pg_ctl" -D "$DATA" -o "-p $PORT -k /tmp" -l "/tmp/pg-${SLUG}.log" -w start >/dev/null
+"$PGBIN/createdb" -p "$PORT" -h /tmp -U postgres prove
+P()  { "$PGBIN/psql" -p "$PORT" -h /tmp -U postgres -d prove -v ON_ERROR_STOP=1 "$@"; }
+Pq() { P -tA "$@"; }   # tuples-only, unaligned (pra capturar 1 valor)
+
+# ── base mínima do Supabase: roles, schema auth, auth.uid()/role() via GUC (impersonação de RLS) ──
+P -q -f "$REPO_ROOT/db/stubs-supabase.sql"
+P -q <<'SQL'
+CREATE OR REPLACE FUNCTION auth.uid()  RETURNS uuid LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.uid',  true), '')::uuid $f$;
+CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ SELECT nullif(current_setting('test.role', true), '') $f$;
+ALTER ROLE service_role BYPASSRLS;   -- espelha o admin role do Supabase (semear sem esbarrar em RLS)
+SQL
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 1 — PRÉ-REQUISITOS  ·  ZONA 2 — MIGRATION REAL (Lei #1)
+# ══════════════════════════════════════════════════════════════════════════════
+P -q -f "$REPO_ROOT/db/prereq-sync-state-saude-20260825.sql"
+MIG="$REPO_ROOT/supabase/migrations/20260824225107_data_health_sync_state_saude.sql"
+[ -f "$MIG" ] || { echo "migration ausente: $MIG"; exit 1; }
+P -q -f "$MIG"
+echo "═══ migration REAL aplicada ($(basename "$MIG")) ═══"
+
+# ── leitores do check sob teste + asserts de substring (sentinela ASCII, caixa fixa) ──
+CK="SELECT %s FROM public._data_health_compute() WHERE source='sync_state_saude';"
+st()   { Pq -c "$(printf "$CK" status)"; }
+msg()  { Pq -c "$(printf "$CK" message)"; }
+sev()  { Pq -c "$(printf "$CK" severity)"; }
+nlin() { Pq -c "SELECT count(*)::int FROM public._data_health_compute() WHERE source='sync_state_saude';"; }
+has()   { case "$2" in *"$3"*) ok "$1";; *) bad "$1 — nao achei [$3] em [$2]";; esac; }
+hasnt() { case "$2" in *"$3"*) bad "$1 — achei [$3] e NAO devia";; *) ok "$1";; esac; }
+
+# ── seed: os 8 pares vigiados FRESCOS + 6 dormentes/orquestrados fora da lista ──
+seed_base() { P -q <<'SQL'
+TRUNCATE public.sync_state;
+INSERT INTO public.sync_state (entity_type, account, status, last_sync_at, updated_at, created_at) VALUES
+  -- vigiados pelo eixo 2 (SLA proprio), todos dentro do prazo
+  ('customers','vendas',        'complete', now()-interval '2 hours',  now()-interval '2 hours',  now()),
+  ('customers','colacor_vendas','complete', now()-interval '2 hours',  now()-interval '2 hours',  now()),
+  ('customers','servicos',      'complete', now()-interval '2 hours',  now()-interval '2 hours',  now()),
+  ('products','vendas',         'complete', now()-interval '3 hours',  now()-interval '3 hours',  now()),
+  ('products','colacor_vendas', 'complete', now()-interval '3 hours',  now()-interval '3 hours',  now()),
+  ('inventory','vendas',        'complete', now()-interval '20 minutes', now()-interval '20 minutes', now()),
+  ('inventory','colacor_vendas','complete', now()-interval '40 minutes', now()-interval '40 minutes', now()),
+  ('inventory','servicos',      'complete', now()-interval '40 minutes', now()-interval '40 minutes', now()),
+  -- DORMENTES / orquestrados por outra via: fora da lista de estagnacao DE PROPOSITO.
+  -- Sao o teste de falso-positivo: velhissimos, mas 'complete' ⇒ nao podem acender NADA.
+  ('products','colacor',        'complete', now()-interval '140 days', now()-interval '140 days', now()),
+  ('products','servicos',       'complete', now()-interval '150 days', now()-interval '150 days', now()),
+  ('pedidos_compra','colacor',  'complete', now()-interval '38 days',  now()-interval '38 days',  now()),
+  ('backfill_cadastro','all',   'complete', NULL,                      now()-interval '70 days',  now()),
+  ('mapa_consolidacao','all',   'complete', NULL,                      now()-interval '70 days',  now()),
+  ('tint_watchdog_corante','oben','complete', now()-interval '1 hour', now()-interval '1 hour',   now());
+SQL
+}
+
+echo; echo "═══ A · tudo saudavel (inclui 6 dormentes antiquissimos) ═══"
+seed_base
+eq "A1 status ok"                "$(st)"   "ok"
+eq "A2 CONTRATO: exatamente 1 linha" "$(nlin)" "1"
+eq "A3 severity literal critical" "$(sev)"  "critical"
+has "A4 message de verde"        "$(msg)"  "todos os marcadores saudaveis"
+hasnt "A5 dormente 140d NAO acende (falso-positivo)" "$(msg)" "products/colacor"
+hasnt "A6 dormente sem last_sync_at NAO acende"      "$(msg)" "backfill_cadastro"
+
+echo; echo "═══ B · EIXO 1 universal: error em entidade FORA da lista ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='boom' WHERE entity_type='tint_watchdog_corante';"
+eq  "B1 broken"                  "$(st)"  "broken"
+has "B2 nomeia a entidade nao-listada" "$(msg)" "tint_watchdog_corante/oben (falhou)"
+eq  "B3 ainda 1 linha"           "$(nlin)" "1"
+
+echo; echo "═══ C · o INCIDENTE real: customers/servicos em error ha 37 dias ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='colisao de codigo na conta colacor_sc',
+         last_sync_at=now()-interval '37 days', updated_at=now()-interval '5 minutes'
+         WHERE entity_type='customers' AND account='servicos';"
+eq  "C1 broken"                  "$(st)"  "broken"
+has "C2 nomeia customers/servicos" "$(msg)" "customers/servicos (falhou)"
+eq  "C3 1 linha (acende nos DOIS eixos, dedup por DISTINCT ON)" "$(nlin)" "1"
+has "C4 last_error propagado"    "$(Pq -c "$(printf "$CK" last_error)")" "colisao de codigo"
+
+echo; echo "═══ D · running orfao vs running fresco ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='running', updated_at=now()-interval '60 days', last_sync_at=NULL
+         WHERE entity_type='mapa_consolidacao';"
+eq  "D1 running orfao => broken" "$(st)"  "broken"
+has "D2 motivo nomeia o preso"   "$(msg)" "mapa_consolidacao/all (preso em running"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='running', updated_at=now()-interval '10 minutes'
+         WHERE entity_type='inventory' AND account='vendas';"
+eq  "D3 running FRESCO nao acende" "$(st)" "ok"
+
+echo; echo "═══ E · EIXO 2: handler morre ANTES de gravar status (status limpo, last_sync_at parado) ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='complete', error_message=NULL, last_sync_at=now()-interval '40 hours'
+         WHERE entity_type='customers' AND account='vendas';"
+eq  "E1 estagnacao com status 'complete' => broken" "$(st)" "broken"
+has "E2 motivo e a estagnacao" "$(msg)" "customers/vendas (sem sucesso desde"
+
+echo; echo "═══ F · SLA e POR PAR (cadencias diferentes nao se contaminam) ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET last_sync_at=now()-interval '20 hours' WHERE entity_type='customers' AND account='vendas';"
+eq "F1 customers/vendas 20h < SLA 30h => ok" "$(st)" "ok"
+seed_base
+P -q -c "UPDATE public.sync_state SET last_sync_at=now()-interval '5 hours' WHERE entity_type='inventory' AND account='vendas';"
+eq  "F2 inventory/vendas 5h > SLA 3h => broken" "$(st)" "broken"
+has "F3 so o inventory acende"  "$(msg)" "inventory/vendas"
+hasnt "F4 customers/vendas (2h) fica fora" "$(msg)" "customers/vendas"
+
+echo; echo "═══ G · partial => stale (degrada, nao alarma) · H · marcador ausente ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='partial' WHERE entity_type='products' AND account='vendas';"
+eq  "G1 partial => stale"       "$(st)"  "stale"
+has "G2 texto de degradado"     "$(msg)" "degradado"
+seed_base
+P -q -c "DELETE FROM public.sync_state WHERE entity_type='inventory' AND account='servicos';"
+eq  "H1 marcador ausente => broken" "$(st)" "broken"
+has "H2 motivo AUSENTE"         "$(msg)" "inventory/servicos (marcador AUSENTE"
+
+echo; echo "═══ I · CONTRATO com o watchdog (o check tem de ser AVALIADO, nao so existir) ═══"
+eq "I1 source registrado em v_sources" \
+   "$(Pq -c "SELECT (position('''sync_state_saude''' in pg_get_functiondef(oid))>0)::int FROM pg_proc WHERE proname='data_health_watchdog';")" "1"
+eq "I2 compute inteiro SEM source duplicado (senao o watchdog aborta o laco)" \
+   "$(Pq -c "SELECT (count(*)=count(DISTINCT source))::int FROM public._data_health_compute();")" "1"
+# cadeia inteira, EXECUTANDO (late-bound: plpgsql so falha em runtime)
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='colisao de codigo' WHERE entity_type='customers' AND account='servicos';"
+P -q -c "TRUNCATE public.fin_alertas; SELECT public.data_health_watchdog();"
+eq "I3 watchdog gerou ALERTA ATIVO do check novo" \
+   "$(Pq -c "SELECT count(*)::int FROM public.fin_alertas WHERE tipo='data_health_sync_state_saude' AND dismissed_at IS NULL;")" "1"
+has "I4 mensagem do alerta nomeia o sync parado" \
+    "$(Pq -c "SELECT mensagem FROM public.fin_alertas WHERE tipo='data_health_sync_state_saude' LIMIT 1;")" "customers/servicos"
+# resolucao automatica: sync consertado ⇒ o alerta fecha sozinho
+seed_base
+P -q -c "SELECT public.data_health_watchdog();"
+eq "I5 sync consertado => alerta RESOLVIDO automaticamente" \
+   "$(Pq -c "SELECT count(*)::int FROM public.fin_alertas WHERE tipo='data_health_sync_state_saude' AND dismissed_at IS NULL;")" "0"
+
+echo; echo "═══ J · FINGERPRINT ESTAVEL (o incidente durou 37 dias: 1 aviso, nao 37 e-mails) ═══"
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='colisao', last_sync_at=now()-interval '37 days',
+         updated_at=now()-interval '30 hours' WHERE entity_type='customers' AND account='servicos';"
+J_ANTES="$(msg)"
+# o cron roda de novo no dia seguinte e falha de novo: SO o heartbeat avanca
+P -q -c "UPDATE public.sync_state SET updated_at=now()-interval '5 minutes' WHERE entity_type='customers' AND account='servicos';"
+J_DEPOIS="$(msg)"
+eq "J1 message NAO muda com o heartbeat avancando (nao re-emaila)" "$J_DEPOIS" "$J_ANTES"
+# mas um SEGUNDO sync quebrando TEM de mudar a message (estabilidade != cegueira)
+P -q -c "UPDATE public.sync_state SET status='error', error_message='outro' WHERE entity_type='products' AND account='vendas';"
+J_NOVO="$(msg)"
+if [ "$J_NOVO" != "$J_ANTES" ]; then ok "J2 problema NOVO muda a message (re-emite)"; else bad "J2 message nao mudou com 2o sync quebrado — alerta cego"; fi
+has "J3 message lista os DOIS" "$J_NOVO" "products/vendas (falhou)"
+
+# ══════════════════════════════════════════════════════════════════════════════
+# ZONA 4 — FALSIFICAÇÃO (Lei #3): sabota, EXIGE vermelho, restaura
+# ══════════════════════════════════════════════════════════════════════════════
+echo; echo "═══ FALSIFICAÇÃO — cada assert tem de ficar VERMELHO com a sabotagem ═══"
+SAB="$(mktemp -d)/sab.sql"
+# roda um cenario com a migration SABOTADA e devolve o valor observado
+sabota() { sed "$1" "$MIG" > "$SAB"; P -q -f "$SAB"; }
+restaura() { P -q -f "$MIG"; }   # NAO usa 'git checkout' — o arquivo do repo nunca e tocado
+falsifica() { # $1=rotulo $2=sed $3=comando_que_produz_valor $4=valor_verdadeiro
+  sabota "$2" >/dev/null 2>&1
+  local v; v="$(eval "$3")"
+  if [ "$v" = "$4" ]; then bad "FALS $1 — sabotado e o assert SEGUIU VERDE (assert sem dente)"
+  else ok "FALS $1 — sabotado => [$v] != [$4] (assert morde)"; fi
+  restaura
+}
+
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='x' WHERE entity_type='tint_watchdog_corante';"
+falsifica "eixo 1 (auto-declarado) cego" \
+  "s/WHEN ss.status = 'error' THEN 'broken'/WHEN false THEN 'broken'/" 'st' "broken"
+
+seed_base
+P -q -c "UPDATE public.sync_state SET last_sync_at=now()-interval '40 hours' WHERE entity_type='customers' AND account='vendas';"
+falsifica "eixo 2 (estagnacao) cego" \
+  "s/make_interval(hours => req.sla_h)/make_interval(hours => 99999)/" 'st' "broken"
+
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='x', last_sync_at=now()-interval '37 days'
+         WHERE entity_type='customers' AND account='servicos';"
+falsifica "dedup (par acende nos 2 eixos => 2 linhas quebram o watchdog)" \
+  "s/SELECT DISTINCT ON (u.entity_type, u.account)/SELECT/" 'nlin' "1"
+
+seed_base
+P -q -c "UPDATE public.sync_state SET status='error', error_message='x', updated_at=now()-interval '30 hours'
+         WHERE entity_type='customers' AND account='servicos';"
+FP_REF="$(msg)"
+falsifica "estabilidade do fingerprint (hora corrida na message)" \
+  "s/WHEN ss.status = 'error' THEN 'falhou'/WHEN ss.status = 'error' THEN 'falhou ha '||round((EXTRACT(EPOCH FROM now()-ss.updated_at)\/3600.0)::numeric,4)::text||'h'/" \
+  'msg' "$FP_REF"
+
+echo; echo "═══ RESUMO: $PASS ok · $FAIL falhas ═══"
+[ "$FAIL" = "0" ] || { echo "❌ HARNESS VERMELHO"; exit 1; }
+echo "✅ HARNESS VERDE"

--- a/db/test-data-health-sync-state-saude.sh
+++ b/db/test-data-health-sync-state-saude.sh
@@ -16,7 +16,13 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PGVER=17
 PGBIN="/opt/homebrew/opt/postgresql@${PGVER}/bin"
-PORT="${PGPORT_TEST:-5471}"
+# porta LIVRE automatica: ~30 worktrees rodam harnesses em paralelo e uma porta fixa colide
+if [ -n "${PGPORT_TEST:-}" ]; then PORT="$PGPORT_TEST"; else
+  PORT=""; for c in $(seq 5471 5520); do
+    if ! (exec 3<>/dev/tcp/127.0.0.1/"$c") 2>/dev/null; then PORT=$c; break; else exec 3<&- 3>&-; fi
+  done
+  [ -n "$PORT" ] || { echo "sem porta livre em 5471-5520"; exit 1; }
+fi
 SLUG="sync-state-saude"
 DATA="$(mktemp -d "/tmp/pgtest-${SLUG}.XXXXXX")/data"
 export LC_ALL=C LANG=C          # sem isso o postmaster aborta ("became multithreaded during startup")
@@ -46,6 +52,15 @@ CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS $f$ S
 ALTER ROLE service_role BYPASSRLS;   -- espelha o admin role do Supabase (semear sem esbarrar em RLS)
 SQL
 
+# ── helpers de assert (pass/fail contados; exit 1 no fim se houve fail) ──
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ✅ $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  ❌ $1"; }
+eq()  { if [ "$2" = "$3" ]; then ok "$1 (=$2)"; else bad "$1 — esperado [$3], veio [$2]"; fi; }
+# exige que um comando SQL FALHE (caminho negativo grosso). Pra checar a SQLSTATE exata, use o
+# padrão DO/EXCEPTION de references/assert-patterns.md (preferível — Lei #2).
+must_fail() { if P -q -c "$1" >/dev/null 2>&1; then bad "$2 — devia ter falhado e PASSOU"; else ok "$2 (rejeitado)"; fi; }
+
 # ══════════════════════════════════════════════════════════════════════════════
 # ZONA 1 — PRÉ-REQUISITOS  ·  ZONA 2 — MIGRATION REAL (Lei #1)
 # ══════════════════════════════════════════════════════════════════════════════
@@ -56,11 +71,13 @@ P -q -f "$MIG"
 echo "═══ migration REAL aplicada ($(basename "$MIG")) ═══"
 
 # ── leitores do check sob teste + asserts de substring (sentinela ASCII, caixa fixa) ──
-CK="SELECT %s FROM public._data_health_compute() WHERE source='sync_state_saude';"
-st()   { Pq -c "$(printf "$CK" status)"; }
-msg()  { Pq -c "$(printf "$CK" message)"; }
-sev()  { Pq -c "$(printf "$CK" severity)"; }
+ck()   { Pq -c "SELECT $1 FROM public._data_health_compute() WHERE source='sync_state_saude';"; }
+st()   { ck status; }
+msg()  { ck message; }
+sev()  { ck severity; }
 nlin() { Pq -c "SELECT count(*)::int FROM public._data_health_compute() WHERE source='sync_state_saude';"; }
+# ocorrencias de um par no resumo — o DISTINCT ON protege a CONTAGEM/listagem, nao o nº de linhas
+ndup() { msg | grep -o "$1" | wc -l | tr -d ' '; }
 has()   { case "$2" in *"$3"*) ok "$1";; *) bad "$1 — nao achei [$3] em [$2]";; esac; }
 hasnt() { case "$2" in *"$3"*) bad "$1 — achei [$3] e NAO devia";; *) ok "$1";; esac; }
 
@@ -112,7 +129,8 @@ P -q -c "UPDATE public.sync_state SET status='error', error_message='colisao de 
 eq  "C1 broken"                  "$(st)"  "broken"
 has "C2 nomeia customers/servicos" "$(msg)" "customers/servicos (falhou)"
 eq  "C3 1 linha (acende nos DOIS eixos, dedup por DISTINCT ON)" "$(nlin)" "1"
-has "C4 last_error propagado"    "$(Pq -c "$(printf "$CK" last_error)")" "colisao de codigo"
+eq  "C5 par nos DOIS eixos listado UMA vez (dedup)" "$(ndup 'customers/servicos')" "1"
+has "C4 last_error propagado"    "$(ck last_error)" "colisao de codigo"
 
 echo; echo "═══ D · running orfao vs running fresco ═══"
 seed_base
@@ -160,14 +178,14 @@ eq "I2 compute inteiro SEM source duplicado (senao o watchdog aborta o laco)" \
 # cadeia inteira, EXECUTANDO (late-bound: plpgsql so falha em runtime)
 seed_base
 P -q -c "UPDATE public.sync_state SET status='error', error_message='colisao de codigo' WHERE entity_type='customers' AND account='servicos';"
-P -q -c "TRUNCATE public.fin_alertas; SELECT public.data_health_watchdog();"
+P -q -c "TRUNCATE public.fin_alertas;"; Pq -c "SELECT public.data_health_watchdog();" >/dev/null
 eq "I3 watchdog gerou ALERTA ATIVO do check novo" \
    "$(Pq -c "SELECT count(*)::int FROM public.fin_alertas WHERE tipo='data_health_sync_state_saude' AND dismissed_at IS NULL;")" "1"
 has "I4 mensagem do alerta nomeia o sync parado" \
     "$(Pq -c "SELECT mensagem FROM public.fin_alertas WHERE tipo='data_health_sync_state_saude' LIMIT 1;")" "customers/servicos"
 # resolucao automatica: sync consertado ⇒ o alerta fecha sozinho
 seed_base
-P -q -c "SELECT public.data_health_watchdog();"
+Pq -c "SELECT public.data_health_watchdog();" >/dev/null
 eq "I5 sync consertado => alerta RESOLVIDO automaticamente" \
    "$(Pq -c "SELECT count(*)::int FROM public.fin_alertas WHERE tipo='data_health_sync_state_saude' AND dismissed_at IS NULL;")" "0"
 
@@ -215,8 +233,8 @@ falsifica "eixo 2 (estagnacao) cego" \
 seed_base
 P -q -c "UPDATE public.sync_state SET status='error', error_message='x', last_sync_at=now()-interval '37 days'
          WHERE entity_type='customers' AND account='servicos';"
-falsifica "dedup (par acende nos 2 eixos => 2 linhas quebram o watchdog)" \
-  "s/SELECT DISTINCT ON (u.entity_type, u.account)/SELECT/" 'nlin' "1"
+falsifica "dedup (par nos 2 eixos seria contado/listado 2x)" \
+  "s/SELECT DISTINCT ON (u.entity_type, u.account)/SELECT/" "ndup 'customers/servicos'" "1"
 
 seed_base
 P -q -c "UPDATE public.sync_state SET status='error', error_message='x', updated_at=now()-interval '30 hours'

--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,10 +21,10 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **485** custom migrations totais
-- **1676** objetos esperados (criados por estas migrations)
+- **486** custom migrations totais
+- **1678** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
-  - `function`: 501
+  - `function`: 503
   - `rls_policy`: 446
   - `index`: 244
   - `cron_job`: 164
@@ -4076,6 +4076,13 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | `function` | `public._data_health_compute` | — |
 | `function` | `public.data_health_watchdog` | — |
 | `function` | `public.fin_sync_heartbeat` | — |
+
+### `20260824225107_data_health_sync_state_saude.sql`
+
+| Tipo | Objeto | Parent |
+| --- | --- | --- |
+| `function` | `public._data_health_compute` | — |
+| `function` | `public.data_health_watchdog` | — |
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 485
+-- Total de custom migrations: 486
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -526,7 +526,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260821194411', 'farmer_recomendacao_desfecho', '20260821194411_farmer_recomendacao_desfecho.sql'),
   ('20260821200000', 'farmer_assoc_rules_segmento', '20260821200000_farmer_assoc_rules_segmento.sql'),
   ('20260822000358', 'recommend_cluster_agregado', '20260822000358_recommend_cluster_agregado.sql'),
-  ('20260824091755', 'data_health_carteira_identidade_quarentena', '20260824091755_data_health_carteira_identidade_quarentena.sql')
+  ('20260824091755', 'data_health_carteira_identidade_quarentena', '20260824091755_data_health_carteira_identidade_quarentena.sql'),
+  ('20260824225107', 'data_health_sync_state_saude', '20260824225107_data_health_sync_state_saude.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),
@@ -2191,7 +2192,9 @@ expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VA
   ('recommend_cluster_agregado', 'function', 'public', 'recommend_cluster_agregado', ''),
   ('data_health_carteira_identidade_quarentena', 'function', 'public', '_data_health_compute', ''),
   ('data_health_carteira_identidade_quarentena', 'function', 'public', 'data_health_watchdog', ''),
-  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'fin_sync_heartbeat', '')
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('data_health_sync_state_saude', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_sync_state_saude', 'function', 'public', 'data_health_watchdog', '')
 ),
 obj_status AS (
   SELECT eo.migration,
@@ -3904,7 +3907,9 @@ WITH expected_objects (migration, kind, schema_name, object_name, parent_name) A
   ('recommend_cluster_agregado', 'function', 'public', 'recommend_cluster_agregado', ''),
   ('data_health_carteira_identidade_quarentena', 'function', 'public', '_data_health_compute', ''),
   ('data_health_carteira_identidade_quarentena', 'function', 'public', 'data_health_watchdog', ''),
-  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'fin_sync_heartbeat', '')
+  ('data_health_carteira_identidade_quarentena', 'function', 'public', 'fin_sync_heartbeat', ''),
+  ('data_health_sync_state_saude', 'function', 'public', '_data_health_compute', ''),
+  ('data_health_sync_state_saude', 'function', 'public', 'data_health_watchdog', '')
 )
 SELECT
   e.migration,

--- a/supabase/migrations/20260824225107_data_health_sync_state_saude.sql
+++ b/supabase/migrations/20260824225107_data_health_sync_state_saude.sql
@@ -1,0 +1,980 @@
+-- ============================================================
+-- Sentinela — vigia de sync_state: o sync que falha e ninguém vê
+--
+-- INCIDENTE QUE ORIGINOU: customers/servicos falhou TODO DIA por 37 dias
+-- (2026-07-19 → 2026-08-24). O erro NUNCA esteve escondido — estava em
+-- sync_state.error_message, com status='error' e updated_at avançando
+-- diariamente. Faltou alguém CONSULTAR: nenhum check do Sentinela lia
+-- sync_state fora do par pedidos_compra/oben. Causa-raiz do sync: #1971.
+--
+-- O QUE MUDA (2 funções, ambas CREATE OR REPLACE — ACL preservada):
+--   1. public._data_health_compute()  → + 1 bloco no UNION ALL: 'sync_state_saude'
+--   2. public.data_health_watchdog()  → + 'sync_state_saude' em v_sources
+--      (v_esperado = array_length(v_sources,1), deriva sozinho: 18 → 19)
+--
+-- ⚠️ SEM o passo 2 o check existe mas NÃO é avaliado: o watchdog filtra
+--    `WHERE t.source = ANY (v_sources)`. Só o compute = alerta que nunca dispara.
+--
+-- BASE: corpo extraído da PROD via psql-ro em 2026-08-25 e conferido
+-- byte-a-byte contra 20260824091755 (diff vazio nas duas funções) — o
+-- apply manual não havia divergido do repo.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._data_health_compute()
+ RETURNS TABLE(source text, domain text, status text, age_seconds bigint, expected_max_age_seconds bigint, freshness_basis text, message text, last_error text, probable_cause text, how_to_fix text, severity text)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH checks AS (
+    SELECT 'saldo_bancario'::text AS source, 'financeiro'::text AS domain,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'broken'
+           WHEN now() - max(cc.saldo_data)::timestamptz > interval '36 hours' THEN 'stale' ELSE 'ok' END AS status,
+      EXTRACT(EPOCH FROM now() - max(cc.saldo_data)::timestamptz)::bigint AS age_seconds,
+      (36*3600)::bigint AS expected_max_age_seconds, 'max_saldo_data'::text AS freshness_basis,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'Saldo bancário nunca sincronizou'
+           ELSE 'Saldo bancário: último sync ' || to_char(max(cc.saldo_data), 'DD/MM') END AS message,
+      NULL::text AS last_error,
+      CASE WHEN max(cc.saldo_data) IS NULL THEN 'ListarExtrato falhando ou nunca rodou' ELSE NULL END AS probable_cause,
+      'Rode sync_contas_correntes no chat do Lovable e cheque os logs do omie-financeiro'::text AS how_to_fix,
+      'critical'::text AS severity
+    FROM public.fin_contas_correntes cc WHERE cc.ativo = true
+    UNION ALL
+    SELECT 'contas_receber', 'financeiro',
+      CASE WHEN max(cr.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cr.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cr.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a receber: atualizado ' || COALESCE(to_char(max(cr.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cr.updated_at) IS NULL THEN 'Sync CR nunca completou' ELSE NULL END,
+      'Rode sync_contas_receber no Lovable', 'warning'
+    FROM public.fin_contas_receber cr
+    UNION ALL
+    SELECT 'contas_pagar', 'financeiro',
+      CASE WHEN max(cp.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cp.updated_at) > interval '26 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cp.updated_at))::bigint, (26*3600)::bigint, 'max_updated_at',
+      'Contas a pagar: atualizado ' || COALESCE(to_char(max(cp.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(cp.updated_at) IS NULL THEN 'Sync CP nunca completou' ELSE NULL END,
+      'Rode sync_contas_pagar no Lovable', 'warning'
+    FROM public.fin_contas_pagar cp
+    UNION ALL
+    SELECT 'omie_sync_financeiro'::text, 'omie_sync'::text,
+      COALESCE((SELECT CASE WHEN l.status='error' THEN 'broken' ELSE 'ok' END FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'unknown'),
+      (SELECT EXTRACT(EPOCH FROM now() - l.completed_at)::bigint FROM public.fin_sync_log l
+                WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      NULL::bigint, 'fin_sync_log'::text,
+      'Último sync financeiro: ' || COALESCE((SELECT l.status FROM public.fin_sync_log l
+        WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1), 'sem registro'),
+      (SELECT l.error_message FROM public.fin_sync_log l WHERE l.status='error' AND l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1),
+      CASE WHEN (SELECT l.status FROM public.fin_sync_log l WHERE l.completed_at IS NOT NULL ORDER BY l.completed_at DESC LIMIT 1)='error'
+           THEN 'A última action de sync financeiro falhou' ELSE NULL END,
+      'Cheque fin_sync_log e re-rode a action que falhou'::text, 'critical'::text
+    UNION ALL
+    SELECT 'vendas_pedidos'::text, 'vendas'::text,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL THEN 'broken'
+           WHEN now() - LEAST(v.oben_last, v.colacor_last) > interval '6 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(v.oben_last, v.colacor_last))::bigint,
+      (6*3600)::bigint, 'fin_sync_log.sync_pedidos'::text,
+      'Sync de pedidos: oben ' || COALESCE(to_char(v.oben_last AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        || ' · colacor ' || COALESCE(to_char(v.colacor_last AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      v.last_err,
+      CASE WHEN v.oben_last IS NULL OR v.colacor_last IS NULL
+           THEN 'Cron vendas-sync-pedidos não rodou/completou para alguma conta' ELSE NULL END,
+      'Cheque os crons vendas-sync-pedidos-{oben,colacor}-2h e fin_sync_log (action sync_pedidos)'::text, 'critical'::text
+    FROM (
+      SELECT
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'oben' = ANY(l.companies)) AS oben_last,
+        (SELECT max(l.completed_at) FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='complete' AND 'colacor' = ANY(l.companies)) AS colacor_last,
+        (SELECT l.error_message FROM public.fin_sync_log l WHERE l.action='sync_pedidos' AND l.status='error' ORDER BY l.started_at DESC LIMIT 1) AS last_err
+    ) v
+    UNION ALL
+    SELECT 'estoque_inventario'::text, 'estoque'::text,
+      CASE WHEN max(ip.synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ip.synced_at) > interval '3 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ip.synced_at))::bigint, (3*3600)::bigint, 'inventory_position.synced_at',
+      'Inventário: sincronizado ' || COALESCE(to_char(max(ip.synced_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(ip.synced_at) IS NULL THEN 'sync_inventory nunca rodou' ELSE NULL END,
+      'Cheque o cron sync-inventory-vendas-30m (omie-analytics-sync sync_inventory)', 'warning'
+    FROM public.inventory_position ip
+    UNION ALL
+    SELECT 'reposicao_sugestoes'::text, 'estoque'::text,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'broken'
+           WHEN current_date - max(pcs.data_ciclo) > 3 THEN 'stale' ELSE 'ok' END,
+      CASE WHEN max(pcs.data_ciclo) IS NULL THEN NULL
+           ELSE (current_date - max(pcs.data_ciclo))::bigint * 86400 END,
+      (3*86400)::bigint, 'pedido_compra_sugerido.data_ciclo',
+      'Sugestão de compra: último ciclo ' || COALESCE(to_char(max(pcs.data_ciclo),'DD/MM/YYYY'),'nunca'),
+      NULL, CASE WHEN max(pcs.data_ciclo) IS NULL THEN 'gerar-pedidos nunca gerou sugestão' ELSE NULL END,
+      'Cheque o cron gerar-pedidos-diario-oben'::text, 'warning'
+    FROM public.pedido_compra_sugerido pcs
+    UNION ALL
+    SELECT 'carteira_scores'::text, 'carteira'::text,
+      CASE WHEN max(fcs.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(fcs.calculated_at) > interval '36 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(fcs.calculated_at))::bigint, (36*3600)::bigint, 'calculated_at',
+      'Scoring de carteira: recalculado ' || COALESCE(to_char(max(fcs.calculated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(fcs.calculated_at) IS NULL THEN 'calculate-scores nunca rodou' ELSE NULL END,
+      'Re-rode calculate-scores / scoring-recalc-batch no Lovable', 'warning'
+    FROM public.farmer_client_scores fcs
+    UNION ALL
+    -- carteira_rebuild: FRESCOR do rebuild da carteira (carteira-rebuild-nightly, 07:30 UTC).
+    -- Existia um ponto cego: o único check da família, 'carteira_scores', mede
+    -- farmer_client_scores.calculated_at — ou seja, o SCORING (calculate-scores), nao o
+    -- REBUILD. Em 2026-07-28 o cron do rebuild enfileirou, a edge nunca respondeu e
+    -- carteira_assignments ficou 24h congelada com o Sentinela VERDE, porque o scoring
+    -- daquela manha estava fresco. Dois writers distintos, dois frescores distintos.
+    SELECT 'carteira_rebuild'::text, 'carteira'::text,
+      CASE WHEN max(ca.last_synced_at) IS NULL THEN 'broken'
+           WHEN now() - max(ca.last_synced_at) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(ca.last_synced_at))::bigint, (30*3600)::bigint, 'last_synced_at',
+      'Rebuild da carteira: ' || COALESCE(to_char(max(ca.last_synced_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN max(ca.last_synced_at) IS NULL THEN 'carteira-rebuild nunca rodou'
+           WHEN now() - max(ca.last_synced_at) > interval '30 hours'
+             THEN 'cron enfileirou mas a edge pode nao ter respondido (transporte pg_net / BOOT_ERROR) — cron.job_run_details so prova o ENQUEUE; a verdade HTTP esta em net._http_response (~6h de retencao) e o lease em sync_state.carteira_rebuild'
+           ELSE NULL END,
+      'Re-rode carteira-rebuild no Lovable; confira sync_state (entity_type=''carteira_rebuild'') e net._http_response'::text, 'warning'
+    FROM public.carteira_assignments ca
+    UNION ALL
+    SELECT 'custos_produtos'::text, 'estoque'::text,
+      CASE WHEN max(pc.updated_at) IS NULL THEN 'broken'
+           WHEN now() - max(pc.updated_at) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(pc.updated_at))::bigint, (30*3600)::bigint, 'product_costs.updated_at'::text,
+      'Custos de produto: recalculado ' || COALESCE(to_char(max(pc.updated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL, CASE WHEN max(pc.updated_at) IS NULL THEN 'compute_costs nunca rodou' ELSE NULL END,
+      'Cheque o cron compute-costs-daily (omie-analytics-sync compute_costs)'::text, 'warning'::text
+    FROM public.product_costs pc
+    UNION ALL
+    SELECT 'vendas_cadastros'::text, 'vendas'::text,
+      CASE WHEN vc.max_clientes IS NULL OR vc.max_produtos IS NULL THEN 'broken'
+           WHEN now() - LEAST(vc.max_clientes, vc.max_produtos) > interval '30 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - LEAST(vc.max_clientes, vc.max_produtos))::bigint, (30*3600)::bigint,
+      'max(updated_at) de omie_customer_account_map(oben)/omie_products'::text,
+      'Cadastros Omie: clientes ' || COALESCE(to_char(vc.max_clientes AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        || ' · produtos ' || COALESCE(to_char(vc.max_produtos AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN vc.max_clientes IS NULL OR vc.max_produtos IS NULL THEN 'omie_customer_account_map(oben)/omie_products vazio (sync nunca populou)'
+           ELSE 'Nenhum cron atualizou clientes/produtos há mais de 30h' END,
+      'Cheque os crons de cadastro (sync-customers-vendas-daily / omie-cron-diario / sync-colacor-vendas-products)'::text,
+      'warning'::text
+    FROM (
+      SELECT (SELECT max(updated_at) FROM public.omie_customer_account_map WHERE account = 'oben') AS max_clientes,
+             (SELECT max(updated_at) FROM public.omie_products) AS max_produtos
+    ) vc
+    UNION ALL
+    -- Track A (ação): pedidos APROVADOS não despachados ao fornecedor. O cron disparar-pedidos-aprovados
+    -- (0 13) só processa data_ciclo=hoje → aprovação não-disparada no dia fica órfã. >2d=stale / >7d=broken.
+    SELECT 'reposicao_disparo'::text, 'estoque'::text,
+      CASE WHEN rd.aguardando = 0 THEN 'ok'
+           WHEN rd.mais_antigo_h > 168 THEN 'broken'
+           WHEN rd.mais_antigo_h > 48 THEN 'stale' ELSE 'ok' END,
+      (rd.mais_antigo_h * 3600)::bigint, (48*3600)::bigint,
+      'pedido_compra_sugerido.aprovado_em (status=aprovado_aguardando_disparo)'::text,
+      CASE WHEN rd.aguardando = 0 THEN 'Disparo de compra: nenhum pedido aprovado pendente'
+           ELSE 'Disparo de compra: ' || rd.aguardando::text || ' pedido(s) aprovado(s) aguardando disparo (mais antigo ' || COALESCE(rd.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN rd.mais_antigo_h > 48 THEN 'Pedido aprovado não foi disparado ao fornecedor (o cron disparar-pedidos-aprovados só processa o ciclo do dia → aprovações antigas ficam órfãs)' ELSE NULL END,
+      'Em /admin/reposicao: dispare (re-rode disparar-pedidos-aprovados com o pedido_id) ou cancele/expire os pedidos presos em aprovado_aguardando_disparo'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE status='aprovado_aguardando_disparo'))::int AS aguardando,
+        COALESCE(round(EXTRACT(EPOCH FROM now() - min(aprovado_em) FILTER (WHERE status='aprovado_aguardando_disparo'))/3600)::int, 0) AS mais_antigo_h,
+        to_char((min(aprovado_em) FILTER (WHERE status='aprovado_aguardando_disparo')) AT TIME ZONE 'America/Sao_Paulo','DD/MM') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+    ) rd
+    UNION ALL
+    -- Track A (ação) — PIPELINE travado: estados que o automático DEVERIA drenar e não drenou. O motor
+    -- sayerlack-retry-orfaos (*/15) re-dispara pendente_envio_portal/erro_retentavel frescos (tentativas<3,
+    -- <3d, retry não-futuro); o watchdog sayerlack-portal-watchdog (*/5) destrava enviando_portal preso.
+    -- Se um desses fica >1h, o automático parou. >1h=stale / >6h=broken.
+    SELECT 'reposicao_portal_pipeline'::text, 'estoque'::text,
+      CASE WHEN pl.pendentes = 0 THEN 'ok'
+           WHEN now() - pl.mais_antigo > interval '6 hours' THEN 'broken'
+           WHEN now() - pl.mais_antigo > interval '1 hour' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - pl.mais_antigo)::bigint, (3600)::bigint,
+      'pedido_compra_sugerido.status_envio_portal (pipeline: pendente/erro_retentavel fresco/enviando)'::text,
+      CASE WHEN pl.pendentes = 0 THEN 'Portal Sayerlack (pipeline): nada travado'
+           ELSE 'Portal Sayerlack (pipeline): ' || pl.pendentes::text || ' pedido(s) sem progredir (mais antigo ' || COALESCE(pl.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN now() - pl.mais_antigo > interval '1 hour' THEN 'O automático parou de drenar a fila do portal (motor sayerlack-retry-orfaos */15 ou watchdog sayerlack-portal-watchdog */5)' ELSE NULL END,
+      'Cheque os crons sayerlack-retry-orfaos e sayerlack-portal-watchdog + a edge enviar-pedido-portal-sayerlack (logs no Lovable)'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        count(*)::int AS pendentes,
+        min(atualizado_em) AS mais_antigo,
+        to_char(min(atualizado_em) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+      WHERE (
+        status_envio_portal IN ('pendente_envio_portal','erro_retentavel')
+        AND (portal_proximo_retry_em IS NULL OR portal_proximo_retry_em < now())
+        AND COALESCE(portal_tentativas, 0) < 3
+        AND atualizado_em >= now() - interval '3 days'
+      )
+      OR status_envio_portal = 'enviando_portal'
+    ) pl
+    UNION ALL
+    -- Track A (ação) — precisa HUMANO: estados que NÃO drenam sozinhos. indeterminado_requer_conciliacao
+    -- (PO talvez no fornecedor sem Omie — o motor NÃO toca, re-disparo duplicaria) = risco de dinheiro;
+    -- erro_nao_retentavel (SKU sem mapeamento) = compra bloqueada; aceito_portal_sem_protocolo/falha_envio_portal
+    -- = conciliação; erro_retentavel esgotado (tentativas>=3 ou >3d) = motor desistiu. >2h=stale / >24h=broken.
+    SELECT 'reposicao_portal_humano'::text, 'estoque'::text,
+      CASE WHEN hu.pendentes = 0 THEN 'ok'
+           WHEN now() - hu.mais_antigo > interval '24 hours' THEN 'broken'
+           WHEN now() - hu.mais_antigo > interval '2 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - hu.mais_antigo)::bigint, (2*3600)::bigint,
+      'pedido_compra_sugerido.status_envio_portal (humano: indeterminado/erro_nao_retentavel/aceito_sem_protocolo/falha/erro_retentavel esgotado)'::text,
+      CASE WHEN hu.pendentes = 0 THEN 'Portal Sayerlack (ação humana): nada pendente'
+           ELSE 'Portal Sayerlack (ação humana): ' || hu.pendentes::text || ' pedido(s) precisando intervenção (mais antigo ' || COALESCE(hu.mais_antigo_txt,'?') || ')' END,
+      NULL,
+      CASE WHEN now() - hu.mais_antigo > interval '2 hours' THEN 'Pedido(s) que o automático não resolve: conciliar indeterminado (NÃO re-disparar — duplica PO), mapear SKU (erro_nao_retentavel), ou conferir protocolo' ELSE NULL END,
+      'Em /admin/reposicao: concilie os indeterminado_requer_conciliacao (cheque o fornecedor ANTES — NÃO re-dispare), faça o de-para dos erro_nao_retentavel, e confira aceito_portal_sem_protocolo'::text,
+      'warning'::text
+    FROM (
+      SELECT
+        count(*)::int AS pendentes,
+        min(atualizado_em) AS mais_antigo,
+        to_char(min(atualizado_em) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI') AS mais_antigo_txt
+      FROM public.pedido_compra_sugerido
+      WHERE status_envio_portal IN ('indeterminado_requer_conciliacao','erro_nao_retentavel','aceito_portal_sem_protocolo','falha_envio_portal')
+         OR (status_envio_portal = 'erro_retentavel' AND (COALESCE(portal_tentativas, 0) >= 3 OR atualizado_em < now() - interval '3 days'))
+    ) hu
+    UNION ALL
+    -- Vigia (eu+codex 2026-05-31): tingidor FABRICADO internamente (omie_products.tipo_produto='04' =
+    -- Produto Acabado) que voltou ao motor de compra Sayerlack com tipo_reposicao='automatica' → o motor
+    -- o sugeriria COMPRAR no portal (é fabricado, não comprado). Fix = marcar tipo_reposicao='produto_acabado'
+    -- (motor e tela de de-para já excluem != 'automatica'). É count (não frescor) → age NULL; n>0 = stale/warning.
+    -- Join filtra account (há linha oben e vendas por SKU; o tipo_produto vem do sync da conta oben).
+    SELECT 'reposicao_sayerlack_fabricado'::text, 'estoque'::text,
+      CASE WHEN sf.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_sku_parametros_produto_acabado_no_motor_sayerlack'::text,
+      CASE WHEN sf.n = 0 THEN 'Tingidor fabricado no motor: nenhum produto acabado (04) sendo comprado da Sayerlack'
+           ELSE 'Tingidor fabricado no motor: ' || sf.n::text || ' produto(s) acabado(s) (04) no motor de compra Sayerlack — deveriam ser produto_acabado' END,
+      NULL,
+      CASE WHEN sf.n > 0 THEN 'Produto fabricado internamente (tipo_produto=04 no Omie) entrou no motor com tipo_reposicao=automatica — o motor sugeriria comprá-lo no portal' ELSE NULL END,
+      'Marcar tipo_reposicao=produto_acabado nesses tingidores 04 (re-rodar o backfill: UPDATE em public.sku_parametros, Sayerlack OBEN + tipo_produto 04) no SQL Editor'::text,
+      CASE WHEN sf.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::int AS n
+      FROM public.sku_parametros sp
+      WHERE sp.empresa = 'OBEN'
+        AND sp.fornecedor_nome ILIKE '%SAYERLACK%'
+        AND COALESCE(sp.ativo, false)
+        AND COALESCE(sp.habilitado_reposicao_automatica, false)
+        AND COALESCE(sp.tipo_reposicao, 'automatica') = 'automatica'
+        AND EXISTS (
+          SELECT 1 FROM public.omie_products o
+          WHERE o.omie_codigo_produto::text = sp.sku_codigo_omie::text
+            AND lower(o.account) = lower(sp.empresa)
+            AND COALESCE(o.tipo_produto, o.metadata->>'tipo_produto') IN ('04','4')
+        )
+    ) sf
+    UNION ALL
+    -- [cobertura do sinal 2026-06-04] saúde do PRÓPRIO tipo_produto no OBEN. O check
+    -- reposicao_sayerlack_fabricado é cego se o sinal SOME (procura '04'; sem sinal → 0 → verde).
+    -- Aqui: broken se OBEN tem produtos mas 0 classificados (sinal morto = incidente de 2026-06-04),
+    -- ou 0 com '04' (fabricados sumiram). freshness por max(updated_at). Baseline fino vs histórico = v2.
+    SELECT 'omie_tipo_produto_oben'::text, 'estoque'::text,
+      CASE WHEN tp.total = 0 THEN 'unknown'
+           WHEN tp.typed = 0 OR tp.tipo04 = 0 THEN 'broken'
+           WHEN now() - tp.ultimo > interval '48 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - tp.ultimo)::bigint, (48*3600)::bigint, 'omie_products.tipo_produto (OBEN)'::text,
+      CASE WHEN tp.typed = 0 THEN 'Sinal tipo_produto MORTO no OBEN (0 de '||tp.total||' classificados) — guarda de "não comprar fabricado" cega'
+           WHEN tp.tipo04 = 0 THEN 'Nenhum Produto Acabado (04) classificado no OBEN — sinal de fabricado sumiu'
+           ELSE 'Sinal tipo_produto OBEN: '||tp.typed||'/'||tp.total||' classificados, '||tp.tipo04||' fabricados (04)' END,
+      NULL,
+      CASE WHEN tp.typed = 0 OR tp.tipo04 = 0 THEN 'omie-sync-metadados parou de gravar tipo_produto (ou foi sobrescrito por outro sync). Rode o full sync do omie-sync-metadados (OBEN) e cheque o payload tipoItem' ELSE NULL END,
+      'Rode o omie-sync-metadados (full, OBEN) no Lovable e confira a coluna omie_products.tipo_produto'::text,
+      'critical'::text
+    FROM (
+      SELECT count(*) AS total,
+        count(*) FILTER (WHERE tipo_produto IS NOT NULL) AS typed,
+        count(*) FILTER (WHERE tipo_produto = '04') AS tipo04,
+        max(updated_at) AS ultimo
+      FROM public.omie_products WHERE account = 'oben'
+    ) tp
+    UNION ALL
+    -- [família ausente 2026-06-09, follow-up do PR #702] produto ATIVO de venda sem família
+    -- cadastrada (familia NULL ou string vazia/só-espaços). Pós-#702 (que parou de escondê-los do wizard
+    -- via o footgun NOT ILIKE+NULL), família-ausente = produto APARECE, mas o filtro de exclusão de família
+    -- NÃO o categoriza → um item que DEVERIA ser excluído (imobilizado/uso-consumo/jumbo/tingimix) cadastrado
+    -- sem família passa INDEVIDAMENTE pro catálogo. Escopo = as 2 contas do wizard (oben+colacor;
+    -- colacor_sc é serviço, fora). count → age NULL; n>0 = stale/warning (founder classifica no Omie).
+    SELECT 'vendas_familia_ausente'::text, 'vendas'::text,
+      CASE WHEN fa.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_omie_products_ativo_familia_vazia (oben+colacor)'::text,
+      CASE WHEN fa.n = 0 THEN 'Catálogo de venda: todo produto ativo tem família cadastrada'
+           ELSE 'Catálogo de venda: ' || fa.n::text || ' produto(s) ativo(s) sem família (oben ' || fa.n_oben::text || ' · colacor ' || fa.n_colacor::text || ') — classifique no Omie' END,
+      NULL,
+      CASE WHEN fa.n > 0 THEN 'Produto ativo sem família no Omie: aparece no wizard de venda, mas o filtro de exclusão de família não o categoriza (um item que deveria ser excluído passaria indevidamente)' ELSE NULL END,
+      'No Omie, preencha a família desses produtos (aparecem no wizard, mas sem categorização). Liste por: omie_products com família vazia + ativo, nas contas oben/colacor.'::text,
+      CASE WHEN fa.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::int AS n,
+        count(*) FILTER (WHERE account = 'oben')::int AS n_oben,
+        count(*) FILTER (WHERE account = 'colacor')::int AS n_colacor
+      FROM public.omie_products
+      WHERE NULLIF(btrim(familia), '') IS NULL AND COALESCE(ativo, false) AND account IN ('oben','colacor')
+    ) fa
+    UNION ALL
+    -- [estoque frescor v3 2026-07-02, incidente 30/06-02/07 · PR #1142] fonte de frescor VOLTA ao
+    -- DADO REAL: max(ultima_sincronizacao) de sku_estoque_atual (OBEN), a tabela que o MOTOR DE
+    -- COMPRA (gerar_pedidos_sugeridos_ciclo) lê. A v2 (worst-of-markers, 20260611210000) vigiava os
+    -- markers sync_state reposicao_estoque_full/reposicao_pendente_po que NUNCA passaram a ser
+    -- gravados (o passo-edge do desenho FONTE-ÚNICA #809 não foi implementado; a RPC
+    -- aplicar_snapshot_pendente existe mas nada a chama) => o check ficou 'broken' PERMANENTE desde
+    -- ~15/06 com o alerta fin_alertas preso ativo => o ON CONFLICT DO NOTHING do watchdog nunca
+    -- re-emitiu e-mail => o incidente 30/06-02/07 (snapshot 2+ dias congelado, plataforma Lovable)
+    -- passou MUDO. Princípio (docs/agent/sync.md): vigiar o EFEITO no dado; marcador só quando
+    -- EXISTE o writer que o grava.
+    -- fonte_sync LIKE 'ListarPosEstoque%' (allowlist por PREFIXO — a edge grava
+    -- 'ListarPosEstoque(N locais)' p/ SKU multi-local, omie-sync-estoque/index.ts:609; igualdade
+    -- exata deixaria esses SKUs invisíveis ao check — achado Codex challenge 2026-07-02) isola o
+    -- writer real: exclui 'cold_start_seed'
+    -- (reposicao_cold_start_parametros semeia linha nova com ultima_sincronizacao=now() — um pingo
+    -- de seed mascararia o max()) e 'snapshot_pendente_sem_fisico' (aplicar_snapshot_pendente cria
+    -- linha com ultima_sincronizacao NULL e não toca a coluna em UPDATE). Rótulo novo/renomeado =>
+    -- o max() para de andar => VERMELHO barulhento (fail-safe), nunca verde-mentindo (fail-open).
+    -- Thresholds = v1 (20260611140000, desenhados p/ ESTES crons: diário 0 9 UTC + intraday
+    -- 40 9,11,13,15,17,19 UTC): janela comercial BRT 08-18 >4h=stale; fora dela >16h=stale;
+    -- >30h/nunca=broken (cobre o pedido de ~26h do incidente com folga); max_sync no FUTURO
+    -- (>now()+5min, clock-skew tolerado) = broken (writer com relógio quebrado não compra verde
+    -- eterno — Codex). Falha pós-16:40 BRT (último intraday) só alerta ~06:40 do dia seguinte
+    -- (16h) — aceito: ainda ANTECEDE o ciclo de compra da manhã (~08:15), e estender a janela
+    -- só anteciparia um e-mail noturno que ninguém acionaria. LIMITAÇÃO aceita: max()
+    -- não vê sync PARCIAL (físico ok + pendente falho) — era o que a v2 pegaria SE os markers
+    -- existissem; quando a edge gravar os markers (#809 passo 2), re-promover a v2 POR CIMA
+    -- (migration nova; corpo da v2 preservado na 20260626150000).
+    SELECT 'estoque_reposicao'::text, 'estoque'::text,
+      CASE WHEN se.max_sync IS NULL THEN 'broken'
+           WHEN se.max_sync > now() + interval '5 minutes' THEN 'broken'
+           WHEN now() - se.max_sync > interval '30 hours' THEN 'broken'
+           WHEN now() - se.max_sync > interval '16 hours' THEN 'stale'
+           WHEN (now() AT TIME ZONE 'America/Sao_Paulo')::time >= time '08:00'
+            AND (now() AT TIME ZONE 'America/Sao_Paulo')::time <  time '18:00'
+            AND now() - se.max_sync > interval '4 hours' THEN 'stale'
+           ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - se.max_sync)::bigint, (4*3600)::bigint,
+      'max(sku_estoque_atual.ultima_sincronizacao) OBEN fonte_sync LIKE ListarPosEstoque% (dado real, v3)'::text,
+      'Estoque de reposição (motor de compra): sincronizado ' || COALESCE(to_char(se.max_sync AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN se.max_sync IS NULL OR now() - se.max_sync > interval '4 hours'
+           THEN 'A edge omie-sync-estoque parou de atualizar sku_estoque_atual (OBEN) — o snapshot de estoque físico/a-caminho que o motor de compra lê. ARMADILHA: o cron marca "succeeded" mesmo com a edge em erro (só prova o enqueue) — a verdade está em net._http_response. Estoque congelado => o motor sugere comprar o que já tem (quase double-buy: incidentes 2026-06-11 e 2026-06-30).'
+           ELSE NULL END,
+      'Dispare o sync manual (botão "Sincronizar estoque" em Reposição→Pedidos) ou rode a edge omie-sync-estoque no Lovable (body {"empresa":"OBEN"}). Cheque net._http_response dos crons omie-sync-estoque-{diario,intraday-oben}. Se LOAD_FUNCTION_ERROR: redeploy verbatim de supabase/functions/omie-sync-estoque/index.ts.'::text,
+      'critical'::text
+    FROM (
+      SELECT max(ultima_sincronizacao) FILTER (WHERE fonte_sync LIKE 'ListarPosEstoque%') AS max_sync
+      FROM public.sku_estoque_atual
+      WHERE empresa = 'OBEN'
+    ) se
+    UNION ALL
+    -- [VIGIA tint COBERTURA 2026-06-15 · Check A · PUSH] base/concentrado MixMachine ATIVO (oben) cuja
+    -- classificação tint diverge da família HÁ +30h. O cron tint-marcar-bases-diario (jobid 132) corrige
+    -- 1×/dia (08:00 BRT); a tolerância de 30h (1 ciclo + folga) evita falso-positivo de produto recém-
+    -- importado (catálogo sincroniza ~2h; watchdog */30; heartbeat às 08:00 junto do cron). created_at é o
+    -- relógio (o sync NÃO o toca em upsert; updated_at esconderia drift permanente). Sem is_tintometric →
+    -- some do mapeamento; tint_type errado → aba trocada. n>0 só após o cron ter tido a janela ⇒ stale/warning.
+    SELECT 'tint_cobertura_bases'::text, 'estoque'::text,
+      CASE WHEN t.n = 0 THEN 'ok' ELSE 'stale' END,
+      EXTRACT(EPOCH FROM t.idade_max)::bigint, (30*3600)::bigint,
+      'omie_products oben ativo familia MixMachine sem is_tintometric/tint_type correto ha >30h (created_at)'::text,
+      CASE WHEN t.n = 0 THEN 'Cobertura tint: toda base/concentrado MixMachine ativo está classificado corretamente'
+           ELSE 'Cobertura tint: '||t.n||' base(s)/concentrado(s) MixMachine ativo(s) com classificação divergente há +30h (sem is_tintometric some do mapeamento; ou tint_type na aba errada)' END,
+      NULL,
+      CASE WHEN t.n > 0 THEN 'O cron tint-marcar-bases-diario (jobid 132) não rodou/foi revertido, ou houve reclassificação manual — bases elegíveis há +30h seguem sem a marca tint correta' ELSE NULL END,
+      'Rode select public.tint_marcar_bases_mixmachine(); no SQL Editor (idempotente, só aditivo) e confira o cron tint-marcar-bases-diario via net._http_response'::text,
+      CASE WHEN t.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::bigint AS n,
+             max(now() - op.created_at) AS idade_max
+      FROM public.omie_products op
+      WHERE op.account = 'oben' AND op.ativo = true
+        AND lower(btrim(op.familia)) IN ('bases mixmachine','concentrados mixmachine')
+        AND op.created_at < now() - interval '30 hours'
+        AND ( op.is_tintometric IS NOT TRUE
+           OR op.tint_type IS DISTINCT FROM CASE lower(btrim(op.familia))
+                WHEN 'bases mixmachine' THEN 'base'
+                WHEN 'concentrados mixmachine' THEN 'concentrado' END )
+    ) t
+    UNION ALL
+    -- [VIGIA tint VÍNCULO 2026-06-15 · Check B · DASHBOARD-ONLY] validade do vínculo de venda (tint_skus):
+    -- SKU ativa (oben) apontando p/ produto Omie inativo OU de account divergente (vínculo p/ produto morto),
+    -- + produto Omie em >1 SKU ativa (useTintColorSelect lê reverso com .limit(1) ⇒ base arbitrária). FK garante
+    -- que omie_product_id existe ⇒ INNER JOIN. Ortogonal ao A (mede tint_skus, não o catálogo). FORA dos IN-lists
+    -- do watchdog/heartbeat (dashboard-only na v1: backlog não medido; promove a push em 2ª migration pós-zero).
+    SELECT 'tint_vinculo_omie'::text, 'estoque'::text,
+      CASE WHEN v.morto + v.ambiguo = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint, 'tint_skus ativa->omie inativo/divergente + omie em >1 sku ativa'::text,
+      CASE WHEN v.morto + v.ambiguo = 0 THEN 'Vínculo tint↔Omie: íntegro'
+           ELSE 'Vínculo tint↔Omie: '||v.morto||' SKU(s) ativa(s) apontando p/ produto Omie inativo/divergente, '||v.ambiguo||' produto(s) Omie em >1 SKU ativa (re-mapeamento pega base arbitrária)' END,
+      NULL,
+      CASE WHEN v.morto + v.ambiguo > 0 THEN 'SKU de venda aponta p/ produto descontinuado no Omie (some do dropdown), ou o mesmo produto Omie está vinculado a 2+ bases (vínculo ambíguo)' ELSE NULL END,
+      'Em /tintometrico/catalogo → Mapeamento: re-mapeie as SKUs apontando p/ produto inativo e desfaça os vínculos duplicados'::text,
+      CASE WHEN v.morto + v.ambiguo = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT
+        (SELECT count(*)::bigint FROM public.tint_skus ts
+           JOIN public.omie_products op ON op.id = ts.omie_product_id
+          WHERE ts.account = 'oben' AND ts.ativo IS NOT FALSE
+            AND (op.ativo IS NOT TRUE OR op.account IS DISTINCT FROM ts.account)) AS morto,
+        (SELECT count(*)::bigint FROM (
+           SELECT ts.omie_product_id FROM public.tint_skus ts
+            WHERE ts.account = 'oben' AND ts.ativo IS NOT FALSE AND ts.omie_product_id IS NOT NULL
+            GROUP BY ts.omie_product_id HAVING count(*) > 1) d) AS ambiguo
+    ) v
+    UNION ALL
+    -- [VIGIA proveniência de custo 2026-06-23 · follow-up #1019 · PUSH · INVARIANTE I1] proxy de custo carimbado
+    -- com CONFIANÇA ALTA na FONTE (product_costs). O #1019 blindou o CONSUMO (resolverCustoCockpit ganhou
+    -- `|| !sourceReal` → o cockpit de valor degrada a confiança da margem quando o source não é real); ESTE é o
+    -- complemento na FONTE, cobrindo TODOS os consumidores de uma vez (resolverCustoConfiavel + seus espelhos Deno
+    -- recommend/algorithm-a-audit, o cockpit, ranking, relatórios). I1: cost_final>0 com cost_confidence>=0.7 cujo
+    -- source NÃO é "real" (∉ whitelist consumer-real). Um proxy (FAMILY_MARGIN_PROXY/DEFAULT_PROXY/
+    -- CMC_UNIDADE_SUSPEITA/UNKNOWN/fonte nova) com conf alta ⇒ o motor (omie-analytics-sync computeCosts /
+    -- reprocessRecommendationCosts) inflou a confiança. Hoje o teto de proxy é conf=0.5 (headroom 0.2 até o
+    -- gatilho 0.7) ⇒ NASCE VERDE. count → age NULL; n>0 = stale/warning. cost_confidence NULL não conta (NULL>=0.7
+    -- = unknown), cost_final NULL/<=0 excluído por cost_final>0 (custo não-positivo não vira margem firme — fora
+    -- do escopo de "proveniência forjada que engana margem"; cost_final<0 é data-quality, check à parte).
+    -- ⚠️ NORMALIZAÇÃO casa o `.trim().toUpperCase()` do resolver TS (cost-source.ts:31-34): regexp_replace de
+    --   `\s` (espaço/tab/newline/CR) nas pontas — btrim() puro só tira espaço e deixaria ` \tCMC\n ` escapar.
+    -- ⚠️ PARIDADE: a whitelist consumer-real abaixo espelha COST_SOURCES_REAIS de src/lib/custos/cost-source.ts:22
+    --   ({PRODUCT_COST,CMC,CMC_MARGEM_ATIPICA}). Source REAL novo lá ⇒ atualizar AQUI também (senão falso-positivo).
+    SELECT 'custos_proxy_conf_alta'::text, 'estoque'::text,
+      CASE WHEN pca.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_product_costs cost_final>0 cost_confidence>=0.7 source_NAO_real (proxy carimbado conf alta)'::text,
+      CASE WHEN pca.n = 0 THEN 'Proveniência de custo: nenhum proxy carimbado com confiança alta (>=0,7)'
+           ELSE 'Proveniência de custo FORJADA: ' || pca.n::text || ' linha(s) de product_costs com source proxy (não-real) e cost_confidence>=0,7 — cockpit/recommend confiariam na margem como se fosse custo real' END,
+      NULL,
+      CASE WHEN pca.n > 0 THEN 'O motor de custo (omie-analytics-sync computeCosts / reprocessRecommendationCosts) gravou cost_confidence>=0,7 num source que NÃO é real (∉ COST_SOURCES_REAIS). É inflação de confiança na FONTE; o #1019 já degrada no consumo, mas a fonte precisa ser corrigida (senão todo consumidor que NÃO espelha o gate confia na margem).' ELSE NULL END,
+      'Liste por: product_costs com cost_final>0, cost_confidence>=0,7 e cost_source fora de {PRODUCT_COST,CMC,CMC_MARGEM_ATIPICA}. Corrija a régua de confiança no motor (_shared/cost-ladder.ts / computeCosts) e re-rode compute_costs no Lovable.'::text,
+      CASE WHEN pca.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::bigint AS n
+      FROM public.product_costs
+      WHERE cost_final > 0
+        AND cost_confidence >= 0.7
+        AND upper(regexp_replace(coalesce(cost_source,''), '^\s+|\s+$', '', 'g')) NOT IN ('PRODUCT_COST','CMC','CMC_MARGEM_ATIPICA')
+    ) pca
+    UNION ALL
+    -- [VIGIA proveniência de custo 2026-06-23 · follow-up #1019 · PUSH · INVARIANTE I2] PRODUCT_COST RESSUSCITADO.
+    -- A escada de custo (supabase/functions/_shared/cost-ladder.ts + src/lib/custo/costLadder.ts) REMOVEU
+    -- PRODUCT_COST da operação: o motor antigo lia cost_price legado como "Priority 1: PRODUCT_COST (conf 0.95)";
+    -- como cost_price era derivado/proxy, isso era LAVAGEM DE PROVENIÊNCIA (classe do incidente #977). A escada
+    -- nunca mais emite PRODUCT_COST (só CMC/CMC_MARGEM_ATIPICA/FAMILY_MARGIN_PROXY/DEFAULT_PROXY). Qualquer linha
+    -- PRODUCT_COST hoje = writer legado/forjado ressuscitando a fonte (product_costs é current-state: 1 linha/
+    -- produto, sem histórico — confirmado pre-flight 2026-06-23, então não há falso-positivo de linha antiga).
+    -- Esta invariante SUSTENTA a contradição saudável: PRODUCT_COST segue na whitelist consumer-real
+    -- (cost-source.ts:22 — p/ não nulificar um custo real legítimo se um dia voltar por um writer AUDITÁVEL) MAS
+    -- é proibido na ESCRITA atual. Sem este check, resolverCustoConfiavel E resolverCustoCockpit tratam
+    -- PRODUCT_COST como real ⇒ confiariam num custo ressuscitado. Normalização (regexp `\s` nas pontas, == o
+    -- `.trim()` do resolver TS) pega a lavagem por casing/whitespace (' product_cost ', E'\tPRODUCT_COST\n') que
+    -- escaparia o consumo→real mas o `=` literal deixaria passar. count → age NULL; n>0 = stale/warning. NASCE VERDE.
+    SELECT 'custos_product_cost_revivido'::text, 'estoque'::text,
+      CASE WHEN ppc.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_product_costs source=PRODUCT_COST (removido da escada — proveniencia)'::text,
+      CASE WHEN ppc.n = 0 THEN 'Proveniência de custo: nenhuma linha PRODUCT_COST (fonte removida da escada de custo)'
+           ELSE 'Proveniência de custo FORJADA: ' || ppc.n::text || ' linha(s) de product_costs com cost_source=PRODUCT_COST — a escada removeu essa fonte (lavagem de proveniência, classe #977); consumidores a tratam como custo real' END,
+      NULL,
+      CASE WHEN ppc.n > 0 THEN 'Um writer legado/forjado gravou cost_source=PRODUCT_COST, fonte que a escada (cost-ladder.ts) removeu da operação. resolverCustoConfiavel e resolverCustoCockpit tratam PRODUCT_COST como REAL ⇒ confiariam num custo ressuscitado sem proveniência auditável.' ELSE NULL END,
+      'Liste por: product_costs com cost_source=PRODUCT_COST (normalizado). Ache o writer que ressuscitou PRODUCT_COST — o motor deve emitir só CMC/CMC_MARGEM_ATIPICA/proxies via cost-ladder. Corrija a fonte e re-rode compute_costs no Lovable.'::text,
+      CASE WHEN ppc.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT count(*)::bigint AS n
+      FROM public.product_costs
+      WHERE upper(regexp_replace(coalesce(cost_source,''), '^\s+|\s+$', '', 'g')) = 'PRODUCT_COST'
+    ) ppc
+    UNION ALL
+    SELECT 'alert_channel'::text, 'alertas'::text,
+      CASE WHEN ac.stuck_pendentes > 0 OR ac.falhas_24h >= 5 THEN 'broken'
+           WHEN ac.falhas_24h > 0 THEN 'stale' ELSE 'ok' END,
+      ac.oldest_pendente_age_seconds, (2*3600)::bigint, 'fornecedor_alerta.pendente_notificacao'::text,
+      CASE WHEN ac.stuck_pendentes > 0
+             THEN 'Canal de alerta: ' || ac.stuck_pendentes::text || ' email(s) presos há mais de 2h — dispatch parou de drenar'
+           WHEN ac.falhas_24h >= 5
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falhas de envio nas últimas 24h (falha sistêmica)'
+           WHEN ac.falhas_24h > 0
+             THEN 'Canal de alerta: ' || ac.falhas_24h::text || ' falha(s) de envio nas últimas 24h'
+           ELSE 'Canal de alerta: drenando normalmente (' || ac.pendentes_total::text || ' na fila)' END,
+      ac.ultimo_erro,
+      CASE WHEN ac.stuck_pendentes > 0 THEN 'Cron afiacao_dispatch_notificacoes_30min não rodou ou a edge dispatch-notifications falhou (token Gmail revogado?)'
+           WHEN ac.falhas_24h > 0 THEN 'Envio de email falhando (Gmail / token / destinatário)' ELSE NULL END,
+      'Cheque a edge dispatch-notifications (logs no Lovable), o refresh token do Gmail e o net._http_response do cron afiacao_dispatch_notificacoes_30min'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS stuck_pendentes,
+        (count(*) FILTER (WHERE fa.status='pendente_notificacao'))::bigint AS pendentes_total,
+        (count(*) FILTER (WHERE fa.status='falha_notificacao' AND fa.criado_em > now() - interval '24 hours'))::bigint AS falhas_24h,
+        EXTRACT(EPOCH FROM now() - min(fa.criado_em) FILTER (WHERE fa.status='pendente_notificacao' AND fa.criado_em < now() - interval '2 hours'))::bigint AS oldest_pendente_age_seconds,
+        (SELECT f2.erro_notificacao FROM public.fornecedor_alerta f2
+          WHERE f2.status='falha_notificacao' AND f2.erro_notificacao IS NOT NULL
+          ORDER BY f2.criado_em DESC LIMIT 1) AS ultimo_erro
+      FROM public.fornecedor_alerta fa
+    ) ac
+    UNION ALL
+    -- [VIGIA pedidos de compra 2026-06-26 · eu+Codex gpt-high · PUSH] saúde do sync de pedidos de
+    -- compra (edge omie-sync-pedidos-compra → purchase_orders_tracking; alimenta leadtime + telas de
+    -- acompanhamento = money-path). A edge é fail-OPEN (handler sempre {ok:true} 200; syncEmpresa dá
+    -- break no 1º rate-limit/fault → espelho stale com 0 sincronizados, silencioso). Frescor pela TABELA
+    -- é inadequado: purchase_orders_tracking é MULTI-WRITER (nfes/ctes/sku-items também escrevem
+    -- updated_at) e ESPARSO (gaps de até 5d normais — PesquisarPedCompra filtra por previsão de entrega).
+    -- Por isso a edge grava um HEARTBEAT 1-writer em sync_state (entity_type='pedidos_compra',
+    -- account='oben' — única empresa na esteira do cron omie-cron-diario; COLACOR só por POST manual,
+    -- NÃO vigiado aqui). last_sync_at = horário do último SUCESSO (não avança em falha total → preserva
+    -- o horário bom); updated_at = heartbeat de execução (detecta 'running' órfão); status
+    -- running→complete|partial|error.
+    --   broken: marcador ausente (nunca rodou) · 'error' (coleta total falhou) · 'running' órfão >1h
+    --           (edge morreu no meio) · sem sucesso há >24h (cron/orquestrador morto) · status
+    --           desconhecido (fail-safe: só 'complete'/'running'-fresco são saudáveis).
+    --   stale : 'partial' (coleta truncada) · sucesso há >6h (atraso; cron roda a cada 2h).
+    -- severity FIXO 'critical' (money-path, = vendas_pedidos): evita o furo do ON CONFLICT do watchdog
+    -- (escalonamento de severidade no mesmo source não re-emailaria). VALUES+LEFT JOIN garante 1 linha
+    -- mesmo com marcador ausente (→ 'broken', não some do UNION).
+    SELECT 'pedidos_compra_sync'::text, 'estoque'::text,
+      CASE
+        WHEN m.marker_status IS NULL THEN 'broken'
+        WHEN m.marker_status = 'error' THEN 'broken'
+        WHEN m.marker_status = 'running' AND now() - m.updated_at > interval '1 hour' THEN 'broken'
+        WHEN m.marker_status = 'running' THEN 'ok'
+        WHEN m.last_sync_at IS NULL THEN 'broken'
+        WHEN now() - m.last_sync_at > interval '24 hours' THEN 'broken'
+        WHEN m.marker_status = 'partial' THEN 'stale'
+        WHEN now() - m.last_sync_at > interval '6 hours' THEN 'stale'
+        WHEN m.marker_status = 'complete' THEN 'ok'
+        ELSE 'broken' END,
+      EXTRACT(EPOCH FROM now() - m.last_sync_at)::bigint, (6*3600)::bigint,
+      'sync_state pedidos_compra/oben (last_sync_at=ultimo sucesso, status, updated_at=heartbeat)'::text,
+      CASE
+        WHEN m.marker_status IS NULL THEN 'Pedidos de compra (Sayerlack/Omie): heartbeat AUSENTE — a edge omie-sync-pedidos-compra nunca registrou execução'
+        WHEN m.marker_status = 'error' THEN 'Pedidos de compra: última coleta FALHOU (0 sincronizados) — ' || COALESCE(m.error_message,'erro')
+        WHEN m.marker_status = 'running' AND now() - m.updated_at > interval '1 hour' THEN 'Pedidos de compra: execução PRESA em running há ' || round((EXTRACT(EPOCH FROM now() - m.updated_at)/3600.0)::numeric, 1)::text || 'h (a edge morreu no meio do run)'
+        WHEN m.marker_status = 'running' THEN 'Pedidos de compra: sync em andamento (iniciado ' || COALESCE(to_char(m.updated_at AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'?') || ')'
+        WHEN m.marker_status = 'partial' THEN 'Pedidos de compra: última coleta PARCIAL/truncada — ' || COALESCE(m.error_message,'erros parciais') || '; última boa ' || COALESCE(to_char(m.last_sync_at AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca')
+        ELSE 'Pedidos de compra: sincronizado ' || COALESCE(to_char(m.last_sync_at AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca') || ' (' || COALESCE(m.total_synced,0)::text || ' pedidos)' END,
+      m.error_message,
+      CASE
+        WHEN m.marker_status IS NULL THEN 'A edge omie-sync-pedidos-compra nunca rodou/gravou o marcador (deploy pendente, ou o cron omie-cron-diario não a aciona).'
+        WHEN m.marker_status = 'error' THEN 'A edge coletou 0 pedidos com erro (rate-limit/fault na 1a página -> break, fail-open 200). O espelho purchase_orders_tracking ficou stale -> fura leadtime e telas de acompanhamento.'
+        WHEN m.marker_status = 'running' AND now() - m.updated_at > interval '1 hour' THEN 'A edge começou e não finalizou (timeout/OOM/kill) — pode ter deixado purchase_orders_tracking parcialmente atualizado.'
+        WHEN m.marker_status = 'partial' THEN 'A coleta truncou no meio (alguns pedidos entraram, depois erro) — a janela pode estar incompleta no espelho.'
+        ELSE 'Sem coleta bem-sucedida recente — o cron afiacao_omie_oben_sync_incremental_2h / orquestrador omie-cron-diario parou de acionar a edge, ou a edge falha de boot.' END,
+      'Cheque a edge omie-sync-pedidos-compra (logs no Lovable) + o net._http_response do cron afiacao_omie_oben_sync_incremental_2h (chama omie-cron-diario -> passo pedidos). Re-rode {empresa:"OBEN"} no chat do Lovable. Se a falha durou >3 dias, re-rode com dias>3 (ex: dias:7) — a janela padrão é 3d e não cobriria o buraco.'::text,
+      'critical'::text
+    FROM (
+      SELECT ss.last_sync_at, ss.status AS marker_status, ss.updated_at, ss.error_message, ss.total_synced
+      FROM (VALUES ('pedidos_compra'::text, 'oben'::text)) AS req(et, acc)
+      LEFT JOIN public.sync_state ss ON ss.entity_type = req.et AND ss.account = req.acc
+    ) m
+    UNION ALL
+    SELECT 'customer_metrics', 'vendas',
+      CASE WHEN max(cm.calculated_at) IS NULL THEN 'broken'
+           WHEN now() - max(cm.calculated_at) > interval '8 hours' THEN 'stale' ELSE 'ok' END,
+      EXTRACT(EPOCH FROM now() - max(cm.calculated_at))::bigint, (8*3600)::bigint, 'max_calculated_at',
+      'Metricas de clientes (Customer360/FilaDoDia): recalculado ' || COALESCE(to_char(max(cm.calculated_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM HH24:MI'),'nunca'),
+      NULL,
+      CASE WHEN max(cm.calculated_at) IS NULL THEN 'refresh_customer_metrics nunca rodou' ELSE 'cron afiacao_customer_metrics_refresh_6h travado ou REFRESH falhando' END,
+      'Cheque o cron afiacao_customer_metrics_refresh_6h + net._http_response; rode SELECT public.refresh_customer_metrics() como service_role no SQL Editor'::text,
+      'warning'
+    FROM private.customer_metrics_mv cm
+    UNION ALL
+    -- [VIGIA identidade da carteira 2026-08-24 · P1-c/Fatia2 · PUSH · money-path] QUARENTENA DE IDENTIDADE.
+    -- O #1943 fechou o P1-c do §11 (spec 2026-07-11-omie-identidade-snapshot-atomico-design): quando um
+    -- codigo Omie muda de dono, o writer document-first do omie-analytics-sync NAO aplica a transferencia
+    -- (documento prova PAREAMENTO, nao AUTORIZA transferencia — parecer Codex) e marca o incumbente com
+    -- identity_state='conflict'. A Fatia 2 ja marcava 'ambiguous' do mesmo jeito. Ate 2026-08-24 o unico
+    -- anuncio desses dois eventos era um console.warn NA EDGE — e ninguem le log de edge: sem esta sonda o
+    -- primeiro conflito real passa mudo e a fase 2 (aprovacao humana da transferencia) nunca e acionada.
+    --
+    -- PREDICADO = o do CONSUMIDOR, nao uma lista. O carteira-rebuild quarantina por NEGACAO
+    -- (identity_state !== 'verified', carteira-rebuild:177 / rebuild-helpers.ts:221, que documenta o porque:
+    -- testar `=== 'ambiguous'` falharia ABERTO no dia em que outro estado aparecer). Uma sonda que listasse
+    -- IN ('conflict','ambiguous') ficaria CEGA exatamente nesse dia — o espelho do mesmo bug. Por isso
+    -- IS DISTINCT FROM: mede o MESMO conjunto que o consumidor ja trata como eligible=false / zero comissao.
+    -- `IS DISTINCT FROM` e nao `<>` porque `<>` e NULL-blind (a coluna e NOT NULL DEFAULT 'verified' hoje,
+    -- mas isso e invariante que um ALTER futuro derruba; o consumidor TS tipa `string | null`).
+    --
+    -- BINARIO, nao faixa (a decisao que o founder pediu para eu justificar): a mecanica SUPORTA faixa —
+    -- severity aqui e CASE, nao literal (vide custos_proxy_conf_alta: info/warning), e a gravidade do
+    -- watchdog v2 e rank(severity)*10+rank(status), entao warning->critical re-emitiria. Mas a populacao
+    -- medida em 2026-08-24 e 7301/7301 'verified', ZERO nao-verified desde sempre: nao existe baseline
+    -- medida para ancorar uma fronteira, e inventa-la e exatamente o pecado que a 20260815153218 foi
+    -- escrita para expiar ("MECA o dado antes de propor o CHECK"). E o limiar honesto e mesmo >=1: toda
+    -- linha nao-verified e, pelo predicado do proprio consumidor, um membro com comissao ZERADA — nao ha
+    -- contagem a partir da qual isso vira aceitavel. A quebra por estado vai na MENSAGEM, entao a faixa
+    -- futura nasce de dado medido em vez de palpite.
+    --
+    -- FINGERPRINT: o watchdog v2 (20260814222000) confirma md5(source|status|severity|message) em 2
+    -- avaliacoes antes de mandar e-mail => mensagem volatil nunca emite. Por isso a mensagem VERMELHA
+    -- carrega so n + quebra-por-estado (mudam SO quando a quarentena muda, que e quando se quer episodio
+    -- novo) e o total do ledger fica so na mensagem VERDE, onde volatilidade e inocua.
+    --
+    -- Barato: 1 index-only scan em idx_cml_identity_state (ja em prod). severity warning (nao critical)
+    -- porque a quarentena e FAIL-CLOSED — zera comissao, nao fabrica numero; o lado seguro ja aconteceu e
+    -- o que falta e adjudicacao humana em dias, nao resposta em minutos. Casa a familia carteira
+    -- (carteira_scores, carteira_rebuild = warning). NASCE VERDE.
+    SELECT 'carteira_identidade_quarentena'::text, 'carteira'::text,
+      CASE WHEN q.n = 0 THEN 'ok' ELSE 'stale' END,
+      NULL::bigint, NULL::bigint,
+      'count_carteira_membership_ledger identity_state IS DISTINCT FROM verified (mesma NEGACAO que o carteira-rebuild quarantina)'::text,
+      CASE WHEN q.n = 0
+           THEN 'Identidade da carteira: nenhum membro em quarentena (' || q.total::text || ' membro(s), todos verified)'
+           ELSE 'Identidade da carteira EM QUARENTENA: ' || q.n::text || ' membro(s) nao-verified (' || q.detalhe || ') — o carteira-rebuild os marca eligible=false e ZERA a comissao ate revisao humana' END,
+      NULL,
+      CASE WHEN q.n > 0 THEN 'O writer document-first do omie-analytics-sync viu um codigo Omie mudar de dono (P1-c) ou uma identidade ambigua (Fatia 2) e NAO aplicou a transferencia — documento prova pareamento, nao AUTORIZA transferencia. O incumbente ficou marcado e segue quarantinado (eligible=false, zero comissao) enquanto nenhum humano decidir o dono. Estado nao-verified inesperado (ex.: inactive, hoje sem writer) tambem cai aqui de proposito: o consumidor ja o trata como quarentena.' ELSE NULL END,
+      'Liste por: SELECT user_id, identity_state, source, updated_at FROM public.carteira_membership_ledger WHERE identity_state IS DISTINCT FROM ''verified'' ORDER BY updated_at DESC. Decida o dono de cada codigo Omie (fase 2 do §11 do spec 2026-07-11-omie-identidade-snapshot-atomico-design) e aplique a transferencia aprovada. Se a ambiguidade/conflito sumir na fonte, o proximo omie-analytics-sync (run oben) devolve a linha a verified sozinho — a sonda fecha sem intervencao no banco.'::text,
+      CASE WHEN q.n = 0 THEN 'info' ELSE 'warning' END
+    FROM (
+      SELECT
+        (count(*) FILTER (WHERE l.identity_state IS DISTINCT FROM 'verified'))::bigint AS n,
+        count(*)::bigint AS total,
+        COALESCE((
+          SELECT string_agg(x.st || '=' || x.c::text, ', ' ORDER BY x.st)
+          FROM (
+            SELECT COALESCE(l2.identity_state, '(null)') AS st, count(*) AS c
+            FROM public.carteira_membership_ledger l2
+            WHERE l2.identity_state IS DISTINCT FROM 'verified'
+            GROUP BY 1
+          ) x
+        ), 'nenhum') AS detalhe
+      FROM public.carteira_membership_ledger l
+    ) q
+    UNION ALL
+    -- [VIGIA sync_state 2026-08-25 · PUSH] O sync customers/servicos falhou TODO DIA por 37 dias
+    -- (2026-07-19 → 2026-08-24) com `sync_state.status='error'` e `error_message` preenchido, e
+    -- ninguem viu: NENHUM check lia sync_state fora do par pedidos_compra/oben. O erro nunca esteve
+    -- escondido — faltou alguem CONSULTAR ("quando medir e QUERY, nao recado").
+    --
+    -- DOIS EIXOS, porque um so nao cobre:
+    --   (1) AUTO-DECLARADO — varre a tabela INTEIRA, sem lista. `status='error'`, `running` orfao
+    --       (>6h sem heartbeat em updated_at) e `partial` sao o proprio sync dizendo que falhou:
+    --       nao dependem de cadencia, logo nao geram falso-positivo em sync DORMENTE (dormente fica
+    --       em 'complete'). E o unico eixo que cobre sync que AINDA NAO EXISTE — entidade nova nasce
+    --       vigiada, sem editar esta funcao.
+    --   (2) ESTAGNACAO — lista EXPLICITA de pares com SLA proprio. Necessaria porque um handler que
+    --       morre ANTES de gravar o status deixa `status` intacto: o eixo (1) fica cego e so o
+    --       `last_sync_at` que nao avanca denuncia. Exige cadencia conhecida ⇒ so entra par com cron
+    --       dedicado. Fora da lista (products/colacor, products/servicos, backfill_cadastro,
+    --       mapa_consolidacao, orders/vendas, pedidos_compra/colacor) sao dormentes ou orquestrados
+    --       por outra via — vigia-los por idade seria falso-positivo garantido.
+    --
+    -- 1 LINHA SEMPRE (agregada): o watchdog trata source duplicado como "compute quebrado"
+    -- (count(*) <> count(DISTINCT source) ⇒ laco NAO executado). Por isso agrega, nunca 1 linha/sync.
+    -- MESSAGE SEM IDADE VARIAVEL: o fingerprint do watchdog e source|status|severity|message — hora
+    -- corrida ali re-emailaria a cada rodada (*/30). Usa DATA do ultimo sucesso, que fica CONGELADA
+    -- enquanto o sync estiver parado, e so muda quando o conjunto de problemas muda (= aviso novo).
+    -- severity FIXO 'critical' (money-path: carteira/reposicao/custos leem estes espelhos), pelo
+    -- mesmo motivo do pedidos_compra_sync — severidade variavel no mesmo source nao re-emailaria.
+    SELECT 'sync_state_saude'::text, 'omie_sync'::text,
+      CASE WHEN p.n_broken > 0 THEN 'broken'
+           WHEN p.n_stale  > 0 THEN 'stale'
+           ELSE 'ok' END,
+      p.pior_idade_s, (30*3600)::bigint,
+      'sync_state: status auto-declarado (tabela INTEIRA) + estagnacao de last_sync_at (lista com SLA)'::text,
+      CASE WHEN p.n_broken = 0 AND p.n_stale = 0
+           THEN 'Syncs Omie: todos os marcadores saudaveis'
+           WHEN p.n_broken > 0
+           THEN 'Sync Omie PARADO: ' || p.resumo
+           ELSE 'Sync Omie degradado: ' || p.resumo END,
+      p.erro,
+      CASE WHEN p.n_broken = 0 AND p.n_stale = 0 THEN NULL
+           ELSE 'O marcador em public.sync_state denuncia o sync: status=error (a edge gravou a falha), '
+                || 'running orfao (a edge morreu no meio e o lease ficou preso), partial (coleta truncada) '
+                || 'ou last_sync_at que parou de avancar (o handler morreu ANTES de gravar status, ou o '
+                || 'cron parou de acionar). O espelho fica STALE e alimenta carteira/reposicao/custos com '
+                || 'retrato velho, silenciosamente.' END,
+      'Rode: SELECT entity_type, account, status, last_sync_at, updated_at, error_message FROM public.sync_state ORDER BY updated_at DESC; '
+        || 'depois cheque os logs da edge (omie-analytics-sync / omie-sync-estoque) e o net._http_response do cron da entidade. '
+        || 'Para religar, re-invoque o sync da entidade pelo chat do Lovable.'::text,
+      'critical'::text
+    FROM (
+      SELECT
+        count(*) FILTER (WHERE d.grau = 'broken')::int AS n_broken,
+        count(*) FILTER (WHERE d.grau = 'stale')::int  AS n_stale,
+        max(EXTRACT(EPOCH FROM now() - d.last_sync_at))::bigint AS pior_idade_s,
+        string_agg(d.entity_type || '/' || d.account || ' (' || d.motivo || ')', ', '
+                   ORDER BY d.entity_type, d.account) AS resumo,
+        max(d.error_message) AS erro
+      FROM (
+        SELECT DISTINCT ON (u.entity_type, u.account)
+               u.entity_type, u.account, u.grau, u.motivo, u.error_message, u.last_sync_at, u.eixo
+        FROM (
+          -- EIXO 1 — auto-declarado, tabela INTEIRA (cobre entidade que ainda nao existe)
+          SELECT ss.entity_type, ss.account,
+                 CASE WHEN ss.status = 'error' THEN 'broken'
+                      WHEN ss.status = 'running'
+                           AND now() - COALESCE(ss.updated_at, ss.created_at) > interval '6 hours' THEN 'broken'
+                      WHEN ss.status = 'partial' THEN 'stale'
+                      ELSE 'ok' END AS grau,
+                 CASE WHEN ss.status = 'error' THEN 'falhou'
+                      WHEN ss.status = 'running' THEN 'preso em running desde '
+                           || COALESCE(to_char(COALESCE(ss.updated_at, ss.created_at) AT TIME ZONE 'America/Sao_Paulo','DD/MM'),'?')
+                      ELSE 'coleta parcial' END AS motivo,
+                 ss.error_message, ss.last_sync_at, 1 AS eixo
+          FROM public.sync_state ss
+          UNION ALL
+          -- EIXO 2 — estagnacao de last_sync_at, so na lista com cadencia conhecida.
+          -- SLA = 1 ciclo do cron + folga. Cron em UTC (cron.timezone vazio): '0 5' = 02:00 BRT.
+          SELECT req.et, req.acc,
+                 CASE WHEN ss.entity_type IS NULL THEN 'broken'
+                      WHEN ss.last_sync_at IS NULL THEN 'broken'
+                      WHEN now() - ss.last_sync_at > make_interval(hours => req.sla_h) THEN 'broken'
+                      ELSE 'ok' END AS grau,
+                 CASE WHEN ss.entity_type IS NULL THEN 'marcador AUSENTE (nunca rodou)'
+                      WHEN ss.last_sync_at IS NULL THEN 'nunca sincronizou'
+                      ELSE 'sem sucesso desde '
+                           || to_char(ss.last_sync_at AT TIME ZONE 'America/Sao_Paulo','DD/MM') END AS motivo,
+                 ss.error_message, ss.last_sync_at, 2 AS eixo
+          FROM (VALUES
+            -- entity_type      account            SLA(h)   cron
+            ('customers'::text, 'vendas'::text,         30), -- sync-customers-vendas-daily        0 5 * * *
+            ('customers',       'colacor_vendas',       30), -- sync-customers-colacor-vendas-daily 20 5 * * *
+            ('customers',       'servicos',             30), -- sync-customers-servicos-daily      40 5 * * *
+            ('products',        'vendas',               30), -- sync-products-customers-daily      0 6 * * *
+            ('products',        'colacor_vendas',       30), -- sync-colacor-vendas-products       15 6 * * *
+            ('inventory',       'vendas',                3), -- sync-inventory-vendas-30m          */30
+            ('inventory',       'colacor_vendas',        6), -- sync-inventory-colacor-vendas-1h   15 * * * *
+            ('inventory',       'servicos',              6)  -- sync-inventory-servicos-1h         25 * * * *
+          ) AS req(et, acc, sla_h)
+          LEFT JOIN public.sync_state ss
+                 ON ss.entity_type = req.et AND ss.account = req.acc
+        ) u
+        WHERE u.grau <> 'ok'
+        -- DESEMPATE DETERMINISTICO: o mesmo par pode acender nos DOIS eixos (customers/servicos
+        -- estava em 'error' E com last_sync_at parado). Sem o `u.eixo` no ORDER BY o DISTINCT ON
+        -- escolheria uma das duas linhas ARBITRARIAMENTE — a message viraria nao-deterministica e
+        -- o fingerprint do watchdog oscilaria entre duas formas, re-emailando sem fato novo.
+        -- Eixo 1 (o proprio sync declarando a falha) vence: diz MAIS que idade inferida.
+        ORDER BY u.entity_type, u.account,
+                 CASE u.grau WHEN 'broken' THEN 0 ELSE 1 END, u.eixo
+      ) d
+    ) p
+  )
+  -- P1: campos de "problema" (erro técnico, causa provável, remédio) só saem quando
+  -- o check NÃO está ok. Check verde = nada a reportar.
+  SELECT c.source, c.domain, COALESCE(NULLIF(c.status, ''), 'unknown') AS status,
+    c.age_seconds, c.expected_max_age_seconds, c.freshness_basis, c.message,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.last_error END AS last_error,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.probable_cause END AS probable_cause,
+    CASE WHEN COALESCE(NULLIF(c.status,''),'unknown') = 'ok' THEN NULL ELSE c.how_to_fix END AS how_to_fix,
+    c.severity
+  FROM checks c;
+$function$;
+
+-- ===== watchdog: registra o source novo na lista avaliada =====
+CREATE OR REPLACE FUNCTION public.data_health_watchdog()
+ RETURNS void
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+-- data_health reemissao v2 (mig 20260815153218) — MARCADOR do guard anti-rollback.
+DECLARE
+  -- ⚠️ estoque_reposicao: 18º check, adicionado DIRETO EM PROD (migration fora do repo, drift §5),
+  --    promovido ao push (watchdog+heartbeat) lá. PRESERVADO aqui pra não revertê-lo do e-mail.
+  -- ⚠️ tint_vinculo_omie fica FORA de propósito (dashboard-only, [VIGIA tint 2026-06-15]).
+  -- Esta ARRAY é a fonte única: filtra o compute E define o esperado do dead-man. Duas listas
+  -- separadas driftariam, e o dead-man passaria a medir a própria omissão como sucesso.
+  v_sources text[] := ARRAY[
+    'vendas_pedidos','estoque_inventario','estoque_reposicao','reposicao_sugestoes','carteira_scores',
+    'custos_produtos','vendas_cadastros',
+    'reposicao_disparo','reposicao_portal_pipeline','reposicao_portal_humano',
+    'reposicao_sayerlack_fabricado','omie_tipo_produto_oben','vendas_familia_ausente',
+    'tint_cobertura_bases',
+    'custos_proxy_conf_alta','custos_product_cost_revivido','pedidos_compra_sync',
+    'carteira_identidade_quarentena','sync_state_saude'];
+  v_deadman_h int := 3;   -- cron é */30 ⇒ 3h = 6 rodadas completas perdidas
+  r           record;
+  v_rows      jsonb;
+  v_n         int;
+  v_ndist     int;
+  v_esperado  int := array_length(v_sources, 1);
+  v_completa  boolean;
+  v_sev_fin   text;
+  v_fp        text;
+  v_msg_email text;
+  v_falhos    int := 0;
+  v_erros     text[] := '{}';
+  v_last_ok   timestamptz;
+  v_last_run  timestamptz;
+  v_cego      boolean;
+  v_msg_dm    text;
+BEGIN
+  -- ── DEAD-MAN (avalia o estado da rodada ANTERIOR, antes de sobrescrevê-lo) ────────────────
+  SELECT last_success_at, last_run_at INTO v_last_ok, v_last_run
+    FROM public.data_health_watchdog_estado WHERE id;
+
+  -- ⚠️ O ramo `last_success_at IS NULL` é obrigatório (achado Codex A3): um vigia que NUNCA
+  -- completou uma rodada tem marcador nulo, e ancorar só no marcador o deixaria calado
+  -- exatamente no cenário pior — quebrado desde o primeiro dia.
+  v_cego := (v_last_ok IS NOT NULL AND v_last_ok < clock_timestamp() - make_interval(hours => v_deadman_h))
+         OR (v_last_ok IS NULL AND v_last_run IS NOT NULL
+             AND v_last_run < clock_timestamp() - make_interval(hours => v_deadman_h));
+
+  IF v_cego THEN
+    v_msg_dm := 'Vigia de saúde de dados sem rodada COMPLETA desde '
+             || COALESCE(to_char(v_last_ok AT TIME ZONE 'America/Sao_Paulo', 'DD/MM HH24:MI'), 'NUNCA')
+             || ' — os checks estão sendo avaliados parcialmente e um incidente pode passar mudo.';
+    -- Isolado: se o OUTBOX estiver fora, o meta-alerta não pode derrubar a avaliação dos 17
+    -- checks. O sinal que sobrevive a um outbox morto é o marcador envelhecendo, não o e-mail.
+    BEGIN
+      PERFORM public._data_health_episodio(
+        'oben', 'data_health_watchdog_degradado', 'broken', 'critico',
+        '[Saúde de dados] vigia degradado', v_msg_dm, NULL,
+        jsonb_build_object('last_success_at', v_last_ok, 'limite_horas', v_deadman_h),
+        -- fingerprint ancorado no MINUTO do último sucesso: estável enquanto o vigia seguir cego
+        -- (senão o próprio dead-man viraria a tempestade que ele existe para denunciar).
+        md5('deadman|' || COALESCE(to_char(v_last_ok, 'YYYY-MM-DD"T"HH24:MI'), 'nunca')));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'data_health_watchdog: dead-man nao pode ser enfileirado: % %', SQLSTATE, SQLERRM;
+    END;
+  ELSIF v_last_ok IS NOT NULL THEN
+    UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+     WHERE company = 'oben' AND tipo = 'data_health_watchdog_degradado' AND dismissed_at IS NULL;
+  END IF;
+
+  INSERT INTO public.data_health_watchdog_estado (id, last_run_at, atualizado_em)
+  VALUES (true, clock_timestamp(), clock_timestamp())
+  ON CONFLICT (id) DO UPDATE SET last_run_at = clock_timestamp(), atualizado_em = clock_timestamp();
+
+  -- Materializa UMA execução do compute (é caro; e duas execuções poderiam divergir entre a
+  -- checagem de duplicata e o laço).
+  -- ⚠️ ISOLADO, e o laço fica CONDICIONADO ao sucesso (achado Codex A3): o `BEGIN/EXCEPTION` do
+  -- dead-man é subtransação, NÃO transação autônoma — um erro global DEPOIS dele (compute
+  -- quebrado, fonte duplicada) abortava a transação inteira e desfazia o próprio alerta do
+  -- dead-man, repetindo isso a cada 30 min sem deixar rastro nenhum.
+  v_rows := NULL;
+  BEGIN
+    SELECT COALESCE(jsonb_agg(to_jsonb(t)), '[]'::jsonb) INTO v_rows
+      FROM public._data_health_compute() t
+     WHERE t.source = ANY (v_sources);
+  EXCEPTION WHEN OTHERS THEN
+    IF left(SQLSTATE, 2) IN ('40','53','57','58','XX') THEN
+      RAISE;
+    END IF;
+    v_falhos := v_falhos + 1;
+    v_erros  := v_erros || ('_data_health_compute: ' || SQLSTATE || ' ' || SQLERRM);
+  END;
+
+  IF v_rows IS NULL THEN
+    v_n := 0; v_ndist := 0;
+  ELSE
+    SELECT count(*), count(DISTINCT x.source) INTO v_n, v_ndist
+      FROM jsonb_to_recordset(v_rows) AS x(source text);
+
+    -- Fonte DUPLICADA: o compute está quebrado. NÃO se avalia nada (nenhum alerta ativo pode ser
+    -- resolvido com base em dado que não se pode julgar) — mas também NÃO se aborta a transação,
+    -- senão o registro de estado e o meta-alerta iriam junto. Vira rodada incompleta, alta.
+    IF v_n <> v_ndist THEN
+      v_falhos := v_falhos + 1;
+      v_erros  := v_erros || ('_data_health_compute: fonte duplicada (' || v_n || ' linhas, '
+                              || v_ndist || ' fontes distintas) — laço NAO executado');
+      v_rows   := NULL;
+    END IF;
+  END IF;
+
+  v_completa := (v_rows IS NOT NULL AND v_n = v_esperado);
+
+  FOR r IN
+    SELECT * FROM jsonb_to_recordset(COALESCE(v_rows, '[]'::jsonb)) AS x(
+      source text, "domain" text, status text, age_seconds bigint,
+      expected_max_age_seconds bigint, freshness_basis text, message text,
+      last_error text, probable_cause text, how_to_fix text, severity text)
+  LOOP
+    -- Isolamento por check: um erro em 1 não pode cegar os outros 16. O preço do isolamento é
+    -- o silêncio — pago pelo dead-man + alerta dedicado abaixo.
+    BEGIN
+      IF r.status IS NULL OR r.status NOT IN ('ok','stale','broken','unknown') THEN
+        RAISE EXCEPTION 'status desconhecido em %: %', r.source, COALESCE(r.status,'<NULL>')
+          USING ERRCODE = '22023';
+      END IF;
+      IF r.severity IS NULL OR r.severity NOT IN ('critical','warning','info') THEN
+        RAISE EXCEPTION 'severity desconhecida em %: %', r.source, COALESCE(r.severity,'<NULL>')
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF r.status = 'ok' THEN
+        -- Resolução AUTOMÁTICA: só com 'ok' EXPLÍCITO. NULL/desconhecido nunca chega aqui.
+        UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+         WHERE company = 'oben' AND tipo = 'data_health_' || r.source AND dismissed_at IS NULL;
+      ELSE
+        v_sev_fin := CASE r.severity WHEN 'critical' THEN 'critico'
+                                     WHEN 'warning'  THEN 'aviso'
+                                     ELSE 'info' END;
+
+        -- FINGERPRINT: source|status|severity|message. Sem idade, sem timestamp, sem basis.
+        v_fp := md5(r.source || '|' || r.status || '|' || r.severity || '|' || COALESCE(r.message, ''));
+
+        -- DELTA [2026-07-08]: família-ausente e tint_cobertura_bases anexam a lista dos produtos
+        -- ao corpo do e-mail. COALESCE p/ não anexar se vier NULL. A lista fica FORA do
+        -- fingerprint de propósito (é volátil e enorme; a materialidade já está na contagem).
+        v_msg_email := CASE
+          WHEN r.source = 'vendas_familia_ausente'
+            THEN r.message || COALESCE(E'\n\n' || public._vendas_familia_ausente_lista_email(50), '')
+          WHEN r.source = 'tint_cobertura_bases'
+            THEN r.message || COALESCE(E'\n\n' || public._tint_cobertura_bases_lista_email(50), '')
+          ELSE r.message END;
+
+        PERFORM public._data_health_episodio(
+          'oben', 'data_health_' || r.source, r.status, v_sev_fin,
+          '[Saúde de dados] ' || r.source, r.message, v_msg_email,
+          jsonb_build_object('source', r.source, 'domain', r.domain, 'status', r.status,
+                             'age_seconds', r.age_seconds, 'freshness_basis', r.freshness_basis),
+          v_fp);
+      END IF;
+    EXCEPTION WHEN OTHERS THEN
+      -- ⚠️ `WHEN OTHERS` ENGOLE falha SISTÊMICA (achado Codex F): permissão negada, tabela/coluna
+      -- inexistente, deadlock, disco cheio, erro interno — nada disso é "problema daquele check",
+      -- e engolir 17× troca um erro alto por 17 silêncios. Isolamento vale para falha LOCAL;
+      -- classe 40 (rollback/serialização), 53 (recursos), 57 (intervenção), 58 (sistema) e XX
+      -- (interno) são relançadas e derrubam a rodada inteira, alto e visível.
+      IF left(SQLSTATE, 2) IN ('40','53','57','58','XX') THEN
+        RAISE;
+      END IF;
+      v_falhos := v_falhos + 1;
+      v_erros  := v_erros || (COALESCE(r.source,'<?>') || ': ' || SQLSTATE || ' ' || SQLERRM);
+    END;
+  END LOOP;
+
+  -- ── Marcador de sucesso: só avança em rodada COMPLETA e SEM falha ─────────────────────────
+  UPDATE public.data_health_watchdog_estado SET
+      checks_avaliados = v_n,
+      checks_falhos    = v_falhos,
+      ultimo_erro      = CASE WHEN v_falhos = 0 AND v_completa THEN NULL
+                              ELSE left(array_to_string(v_erros, ' || '), 4000) END,
+      last_success_at  = CASE WHEN v_falhos = 0 AND v_completa THEN clock_timestamp()
+                              ELSE last_success_at END,
+      atualizado_em    = clock_timestamp()
+   WHERE id;
+
+  -- Falha BARULHENTA (não silenciosa): o isolamento por check só é aceitável com este alerta.
+  IF v_falhos > 0 OR NOT v_completa THEN
+    -- Isolado pelo mesmo motivo do dead-man: quando o próprio canal de e-mail é o que quebrou,
+    -- este INSERT também quebra — e derrubar a transação aqui APAGARIA o UPDATE de estado
+    -- acima, que é justamente a evidência durável de que a rodada foi ruim.
+    BEGIN
+      PERFORM public._data_health_episodio(
+        'oben', 'data_health_watchdog_erro', 'broken', 'critico',
+        '[Saúde de dados] vigia com check falhando',
+        'Rodada incompleta do vigia: ' || v_n || ' de ' || v_esperado || ' fonte(s) presente(s), '
+          || v_falhos || ' check(s) com erro. ' || COALESCE(left(array_to_string(v_erros, ' || '), 800), ''),
+        NULL,
+        jsonb_build_object('checks_avaliados', v_n, 'checks_esperados', v_esperado,
+                           'checks_falhos', v_falhos, 'erros', to_jsonb(v_erros)),
+        md5('vigia_erro|' || v_n::text || '|' || v_falhos::text || '|' || array_to_string(v_erros, '||')));
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'data_health_watchdog: alerta de erro nao pode ser enfileirado: % %', SQLSTATE, SQLERRM;
+    END;
+    RAISE WARNING 'data_health_watchdog: % check(s) falharam; % de % fontes presentes',
+      v_falhos, v_n, v_esperado;
+  ELSE
+    UPDATE public.fin_alertas SET dismissed_at = now(), resolvido_em = now()
+     WHERE company = 'oben' AND tipo = 'data_health_watchdog_erro' AND dismissed_at IS NULL;
+  END IF;
+END;
+$function$;


### PR DESCRIPTION
## O que aconteceu

O sync `customers/servicos` falhou **todo dia por 37 dias** (2026-07-19 → 2026-08-24). O erro **não estava escondido**: estava gravado em `sync_state.error_message`, com `status='error'` e `updated_at` avançando diariamente. Faltou alguém **CONSULTAR** — nenhum check do Sentinela lia `sync_state` fora do par `pedidos_compra/oben`. Causa-raiz do sync: #1971. Esta é a lição *"quando medir é QUERY, não recado"* (`docs/historico/fase-sem-sinal.md`).

## O desenho: dois eixos, porque um só não cobre

| Eixo | Alcance | Por quê |
|---|---|---|
| **Auto-declarado** — `error`, `running` órfão (>6h sem heartbeat), `partial` | a tabela **INTEIRA**, sem lista | não depende de cadência ⇒ não acende em sync **dormente** (dormente fica em `complete`). É o único eixo que cobre **entidade que ainda não existe**: sync novo nasce vigiado, sem editar a função |
| **Estagnação** — `last_sync_at` que parou de avançar | **lista** de 8 pares, SLA por par | pega o handler que morre **ANTES** de gravar o status — aí o eixo 1 fica cego e só o `last_sync_at` denuncia. Exige cadência conhecida ⇒ só entra par com cron dedicado |

Fora da lista de estagnação de propósito (dormentes/orquestrados por outra via): `products/colacor`, `products/servicos`, `backfill_cadastro`, `mapa_consolidacao`, `orders/vendas`, `pedidos_compra/colacor`. Vigiá-los por idade seria falso-positivo garantido — mas o eixo 1 continua cobrindo todos eles.

## O que ele diria HOJE (rodado read-only contra a PROD)

```
Sync Omie PARADO: customers/servicos (falhou), orders/vendas (preso em running desde 24/06), products/vendas (coleta parcial)
```

**Três syncs quebrados agora, e só um era conhecido.** `orders/vendas` está preso em `running` desde 2026-06-24 — 2 meses — e um alerta só de `status='error'` **não pegaria** nem esse nem o `partial`. Zero falso-positivo nos 6 dormentes.

## Duas funções, e a segunda não é opcional

1. `public._data_health_compute()` → +1 bloco no UNION ALL (`sync_state_saude`)
2. `public.data_health_watchdog()` → +`'sync_state_saude'` em `v_sources`

⚠️ **Sem o passo 2 o check existe mas NÃO é avaliado** — o watchdog filtra `WHERE t.source = ANY (v_sources)`. Só o compute = alerta que nunca dispara. (`v_esperado` deriva de `array_length`, 18 → 19, sozinho.)

Ambas `CREATE OR REPLACE` (ACL preservada). Base extraída da PROD via `psql-ro` e conferida **byte-a-byte** contra `20260824091755` — diff vazio nas duas, o apply manual não havia divergido.

## Prova — `db/test-data-health-sync-state-saude.sh` (PG17 local, migration REAL)

**39 asserts · 0 falhas · 4 falsificações que MORDEM.** `exit=0`.

Cobre: anti-falso-positivo com 6 dormentes antiquíssimos · `error` em entidade fora da lista · o incidente real · `running` órfão vs. fresco · estagnação com `status='complete'` · SLA **por par** (20h ok em SLA 30h; 5h broken em SLA 3h) · `partial`→stale · marcador ausente · o watchdog **executando** até criar e resolver o alerta em `fin_alertas`.

Dois invariantes de contrato que o teste fixa:

- **Dedup determinístico** — `customers/servicos` acende nos **dois** eixos; sem `ORDER BY ... u.eixo` o `DISTINCT ON` escolhia arbitrariamente e a message oscilava entre duas formas, re-emailando sem fato novo. (Bug encontrado e corrigido pelo próprio teste.)
- **Fingerprint estável** — o fingerprint do watchdog é `source|status|severity|message`. Com o cron rodando e falhando todo dia, **a message não muda** ⇒ 1 aviso, não 37 e-mails. Mas um **segundo** sync quebrando muda a message ⇒ re-emite. Estabilidade sem cegueira.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260824225107_data_health_sync_state_saude.sql`. **Lovable não aplica automaticamente** — mergear **NÃO** toca o banco. Alguém precisa colar no SQL Editor do Lovable e rodar.

O SQL tem ~73KB (recria as duas funções por inteiro, como toda migration de Sentinela neste repo), grande demais para caber aqui. Para copiar:

```bash
cat supabase/migrations/20260824225107_data_health_sync_state_saude.sql | pbcopy
```

Validação pós-apply (read-only):

```sql
SELECT
  CASE WHEN (SELECT count(*) FROM public._data_health_compute() WHERE source='sync_state_saude') = 1
        AND (SELECT position('''sync_state_saude''' in pg_get_functiondef(oid))>0
               FROM pg_proc WHERE proname='data_health_watchdog')
       THEN '✅ check existe E esta registrado no watchdog'
       ELSE '❌ FALTANDO — veja qual das duas funcoes nao pegou' END AS status;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
