### PR TITLE
docs(sonda): o filtro PARECE proteger na consulta SIMPLES — o aviso emitido tinha de dizer isso

### DIFF
--- a/scripts/sonda-versao-sql.ts
+++ b/scripts/sonda-versao-sql.ts
@@ -263,8 +263,10 @@ export function gerarSqlDaLeva(opts: OpcoesLeva): string {
         `--    de o deploy estar confirmado por outro caminho.\n` +
         `-- ⚠️ A trava é CASE e NÃO um filtro: o Postgres avalia a projeção mesmo descartando todas\n` +
         `--    as linhas, então travar por filtro deixa o http_post sair igual (falsificado —\n` +
-        `--    docs/agent/deploy.md §"Sondar VÁRIAS edges numa tacada"). Trava fechada devolve\n` +
-        `--    {"edge": null}, que o passo seguinte lê como SEM ID.\n` +
+        `--    docs/agent/deploy.md §"Sondar VÁRIAS edges numa tacada"). E NÃO valide um filtro numa\n` +
+        `--    consulta simples para se convencer: lá ele filtra antes e PARECE proteger; é nesta\n` +
+        `--    forma, agregada, que ele falha. Trava fechada devolve {"edge": null}, que o passo\n` +
+        `--    seguinte lê como SEM ID.\n` +
         blocoDisparo(ref, leva, 4, true),
       `-- PASSO 4 — lê e julga as CARAS. Cole o JSON do PASSO 3 no lugar do {}.\n` +
         blocoLeitura(leva),


### PR DESCRIPTION
Follow-up do #1979 (que já mergeou).

O bloco caro que `bun run sonda:sql` emite já trava por `CASE` e avisa que filtro não protege. Falta uma nuance que derruba o aviso na prática: **a trava por filtro é dependente de PLANO**. Na forma SIMPLES (projeção sem agregação) ele filtra antes e *parece* proteger — quem valida a trava assim lê "seguro" e leva para produção o bloco **agregado**, que é exatamente onde ela falha.

O comentário emitido agora avisa contra esse **teste** específico, não só contra o filtro. Sem isso, o aviso é derrubável por um experimento de 10 segundos que dá a resposta errada.

Prova: `scripts/sonda-versao-sql.test.ts` 38/38 (`TEST_EXIT=0`) e a CLI emitindo a linha nova com `CASE` intacto.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)