### PR TITLE
fix(sentinela): o marcador `orders` morreu junto com o writer no #1057 — 62 dias de fantasma que o check novo acenderia PRA SEMPRE

### DIFF
--- a/docs/migrations-audit.md
+++ b/docs/migrations-audit.md
@@ -21,7 +21,7 @@ Este audit valida **quais custom migrations estão de fato aplicadas no banco**.
 
 ## Resumo
 
-- **486** custom migrations totais
+- **487** custom migrations totais
 - **1678** objetos esperados (criados por estas migrations)
 - Quebra por tipo:
   - `function`: 503
@@ -4083,6 +4083,10 @@ Lista canônica do que cada migration *deveria* criar (extraído via regex de `C
 | --- | --- | --- |
 | `function` | `public._data_health_compute` | — |
 | `function` | `public.data_health_watchdog` | — |
+
+### `20260824232212_sync_state_remove_marcador_fossil_orders.sql`
+
+> _Nenhum objeto extraído via regex._ Migration provavelmente é `ALTER TABLE` / `UPDATE` / `INSERT` / RLS-only. Validar manualmente.
 
 ## Próximos passos por status
 

--- a/scripts/audit-custom-migrations.sql
+++ b/scripts/audit-custom-migrations.sql
@@ -3,7 +3,7 @@
 -- ========================================================================
 --
 -- Gerado por: scripts/audit-custom-migrations.ts
--- Total de custom migrations: 486
+-- Total de custom migrations: 487
 --
 -- Como usar:
 --   1. Abra o Supabase SQL Editor (via Lovable Cloud → Backend → SQL Editor)
@@ -527,7 +527,8 @@ WITH expected (version, slug, filename) AS (VALUES
   ('20260821200000', 'farmer_assoc_rules_segmento', '20260821200000_farmer_assoc_rules_segmento.sql'),
   ('20260822000358', 'recommend_cluster_agregado', '20260822000358_recommend_cluster_agregado.sql'),
   ('20260824091755', 'data_health_carteira_identidade_quarentena', '20260824091755_data_health_carteira_identidade_quarentena.sql'),
-  ('20260824225107', 'data_health_sync_state_saude', '20260824225107_data_health_sync_state_saude.sql')
+  ('20260824225107', 'data_health_sync_state_saude', '20260824225107_data_health_sync_state_saude.sql'),
+  ('20260824232212', 'sync_state_remove_marcador_fossil_orders', '20260824232212_sync_state_remove_marcador_fossil_orders.sql')
 ),
 expected_objects (migration, kind, schema_name, object_name, parent_name) AS (VALUES
   ('financial_module', 'view', 'public', 'fin_aging_receber', ''),

--- a/supabase/migrations/20260824232212_sync_state_remove_marcador_fossil_orders.sql
+++ b/supabase/migrations/20260824232212_sync_state_remove_marcador_fossil_orders.sql
@@ -1,0 +1,53 @@
+-- ============================================================
+-- sync_state: remove o marcador FÓSSIL 'orders'/'vendas'
+--
+-- POR QUE: o writer desse marcador foi APOSENTADO em 2026-06-24 (#1057,
+-- commit 73be4515) — `syncOrdersIncremental` virou no-op puro (`return
+-- { deprecated: true, ... }`, NÃO toca sync_state) e `orders` saiu do
+-- `sync_all`. A linha congelou no estado deixado pelo ÚLTIMO run real
+-- (status='running', last_sync_at NULL, last_page=0, total_synced=0,
+-- updated_at=2026-06-24 06:00:44 = a janela do cron `sync-products-customers-daily`
+-- daquele dia) e nunca mais foi tocada. Zero writers vivos no repo inteiro:
+-- `sync-reprocess` grava entity_type='orders' em `sync_reprocess_log`, que é
+-- OUTRA tabela.
+--
+-- A ENTIDADE NÃO ESTÁ PARADA — só mudou de caminho. Pedidos de venda entram
+-- pela RPC `criar_pedidos_com_itens` (edge `omie-vendas-sync`), que loga em
+-- `fin_sync_log` (action='sync_pedidos'), crons `vendas-sync-pedidos-oben-2h`
+-- (5 */2) e `-colacor-2h` (20 */2). Medido 2026-08-25 02:11 UTC: 6 runs
+-- consecutivos `complete`, o mais recente às 02:05 (6 min antes). Não é
+-- money-path parado; é marcador órfão.
+--
+-- O QUE ISTO CONSERTA: o check `sync_state_saude` (#1980) tem um EIXO 1 que
+-- varre a tabela INTEIRA sem lista — de propósito, pra que entidade nova nasça
+-- vigiada. Esse eixo classifica `running` órfão >6h como 'broken', e a
+-- severidade do source é FIXA em 'critical'. Sem esta remoção o check nasce
+-- vermelho-PERMANENTE sobre um fantasma de 62 dias, e a mensagem "todos os
+-- marcadores saudaveis" nunca poderia aparecer.
+--
+-- POR QUE DELETE E NÃO "consertar o writer": a aposentadoria foi decisão
+-- deliberada e documentada (o writer legado poluía `sales_price_history` —
+-- 3.995 linhas excedentes). Ressuscitá-lo recriaria o bug que o #1057 matou.
+--
+-- SEGURO PORQUE (medido na PROD via psql-ro, 2026-08-25 02:2x UTC):
+--   • 1 linha alvo; `entity_type='orders'` só existe para account='vendas';
+--   • 0 FKs apontando para public.sync_state (nada cascateia);
+--   • o EIXO 2 do check (estagnação, lista explícita de pares com SLA) NÃO
+--     lista 'orders' — conferido em `pg_get_functiondef` da função DEPLOYADA,
+--     não no arquivo do repo. Por isso apagar a linha faz o check ESQUECER o
+--     par, em vez de reclassificá-lo.
+--     ⚠️ CONTRASTE que vale registrar: 'products' ESTÁ na lista do eixo 2.
+--     Apagar o marcador `products/vendas` (hoje 'partial') NÃO é o mesmo
+--     movimento — viraria 'broken' por "marcador AUSENTE (nunca rodou)".
+--     Só se apaga marcador que o eixo 2 não lista.
+--   • leitores de sync_state em SQL (claim_*/finalizar_*/tint_watchdog_*/
+--     _data_health_compute) não referenciam o par orders/vendas; 0 views leem
+--     a tabela; a UI (`useAnalyticsSync.ts`) faz `select().order('entity_type')`
+--     genérico — perde uma linha no painel admin, não quebra.
+--
+-- IDEMPOTENTE: re-colar é no-op (o WHERE não casa mais nada).
+-- ============================================================
+
+DELETE FROM public.sync_state
+WHERE entity_type = 'orders'
+  AND account = 'vendas';


### PR DESCRIPTION
O check `sync_state_saude` (#1980) instrumentou o alerta sobre `sync_state` e revelou **dois** marcadores acesos. Investiguei os dois via `psql-ro`. **São coisas opostas** — e só um deles é para apagar.

## 1. `orders`/`vendas` — marcador MORTO (é este que o PR remove)

`status='running'` desde **2026-06-24 06:00:44**, `last_sync_at` **NULL**, `last_page=0`, `total_synced=0`. 62 dias.

Não é lease órfão de uma edge que morreu no meio: **o writer foi aposentado nesse mesmo dia**. O #1057 (`73be4515`, 2026-06-24) transformou `syncOrdersIncremental` num no-op puro — `return { deprecated: true, ... }`, sem tocar `sync_state` — e tirou `orders` do `sync_all`. A linha congelou no retrato deixado pelo último run real, e o `updated_at` 06:00:44 é exatamente a janela do cron `sync-products-customers-daily` (`0 6 * * *`) daquele dia.

**Zero writers vivos** no repo inteiro. (`sync-reprocess` grava `entity_type='orders'`, mas em `sync_reprocess_log` — outra tabela.)

**A entidade não está parada, só mudou de caminho.** Pedidos de venda entram pela RPC `criar_pedidos_com_itens` (`omie-vendas-sync`), que loga em `fin_sync_log` com `action='sync_pedidos'`, crons `vendas-sync-pedidos-oben-2h` (`5 */2`) e `-colacor-2h` (`20 */2`). Medido 2026-08-25 02:11 UTC: **6 runs `complete` consecutivos, o mais recente às 02:05** — 6 minutos antes da medição. **Não é money-path parado.**

Sem o DELETE, o eixo 1 do check (que varre a tabela inteira de propósito, para que entidade nova nasça vigiada) classifica `running` órfão >6h como `broken`, com `severity` **fixa em `critical`** — vermelho permanente sobre um fantasma, e a mensagem *"todos os marcadores saudaveis"* jamais poderia aparecer.

Não "consertar o writer": a aposentadoria foi deliberada e documentada — o writer legado poluía `sales_price_history` (3.995 linhas excedentes). Ressuscitá-lo recriaria o bug que o #1057 matou.

### ⚠️ A assimetria que quase vira o próximo incidente

Medido em `pg_get_functiondef` da função **DEPLOYADA** (não no arquivo do repo):

| par | está na lista do EIXO 2? | apagar o marcador faz o quê? |
|---|---|---|
| `orders`/`vendas` | **não** | check **esquece** o par ✅ |
| `products`/`vendas` | **sim** (SLA 30h) | vira **`broken`** — *"marcador AUSENTE (nunca rodou)"* ❌ |

**Só se apaga marcador que o eixo 2 não lista.** É por isso que este PR mexe só no `orders`.

## 2. `products`/`vendas` — marcador VIVO e HONESTO (não mexo aqui)

`partial`, com `last_sync_at` avançando todo dia. Truncagem **crônica por construção, não pontual**:

- `syncProducts(db, account, startPage = 1, maxPages = 10)`;
- o `sync_all` chama **sem argumento** → sempre `startPage=1, maxPages=10`;
- o `nextPage` retornado é **ignorado** — não há retomada. Toda madrugada varre as **mesmas** páginas 1–10.
- Bate com o marcador: `last_page=10`, `total_synced=1000` (10 × 100/pág). O catálogo tem **37 páginas / 3.694** → cobertura de **27%**.

A conta irmã não trunca porque tem cron dedicado: `sync-colacor-vendas-products` passa `"max_pages": 50` explícito → `complete`, 43 páginas. `vendas` nunca ganhou o cron dedicado e pega o default.

**Mas o efeito no dado é nulo** — e isso foi medido, não deduzido. `omie-sync-metadados-daily` (`30 8 * * *`, `accounts:["vendas","colacor_vendas"]`) re-sincroniza o **catálogo inteiro** para a mesma tabela `omie_products` e o mesmo mapeamento de conta (`vendas`→`oben`), com **os mesmos params do Omie** (`ListarProdutos`, `registros_por_pagina:100`, `apenas_importado_api:"N"`, `filtrar_apenas_omiepdv:"N"`) e um **superset estrito de colunas** (as mesmas 15 + `tipo_produto`), 2,5 h depois. Logo ela é a **última escritora** do dia e vence.

Medição em `omie_products`:

```
account | linhas | fresco_24h | velho_48h
colacor |  4297  |    4297    |     0
oben    |  3695  |    3694    |     1
```

Se a truncagem custasse dado, veríamos ~2.700 linhas velhas em `oben`. Vemos **uma** — `PRD03688 "Cópia de TINGIDOR…"`, `ativo=false`, parada em 2026-07-11: produto que saiu da listagem do Omie, sem relação com o cap.

**Então o que a truncagem custa de verdade é trabalho redundante**, não frescor: 10 páginas de API Omie por dia cujo resultado é integralmente reescrito às 08:30. E existe uma cegueira de observabilidade junto — `acoes_execucoes` registra **35 runs, 32 `sucesso`** desde 2026-07-21, enquanto o marcador dizia `partial` o tempo todo. Só o `sync_state` contava a verdade, e ninguém o lia até o #1980.

### Recomendação (fica para decisão, fora deste PR)

`vendas` **e** `colacor_vendas` hoje têm **dois escritores** de `omie_products` — o que o CLAUDE.md chama de violação de *"1 escritor por slug"*. As saídas:

- **(a) recomendada** — aposentar `syncProducts` do `sync_all` (como se fez com `orders`), deixando `omie-sync-metadados` como escritor único, e **na mesma migration** tirar `('products','vendas')` da lista do eixo 2. Corta a redundância nas duas contas e resolve o `partial` na causa. Custa deploy de edge (manual no Lovable).
- **(b) barata** — dar a `vendas` um cron dedicado com `max_pages: 50`, espelhando o de `colacor_vendas`. O marcador fica `complete`, mas **dobra** a carga na API Omie para produzir dado que já existe.

Não fiz nenhuma das duas: é decisão de produto, e (a) é refactor com deploy de edge.

## 3. Contexto: o terceiro marcador

`customers`/`servicos` está em `error` — é o incidente de 37 dias que motivou o #1980, corrigido no #1971 (a fonte alias saiu em 2026-08-25). Deve se curar sozinho no próximo run (`sync-customers-servicos-daily`, `40 5 * * *`) **se a edge estiver deployada**. Se não estiver, volta a falhar hoje às 05:40 UTC.

## ⚠️ ATENÇÃO: migration manual necessária

Este PR adiciona `supabase/migrations/20260824232212_sync_state_remove_marcador_fossil_orders.sql`. **Lovable não aplica automaticamente** — mergear NÃO toca o banco. Alguém precisa colar no SQL Editor do Lovable e rodar.

<details><summary>SQL pra aplicar</summary>

```sql
DELETE FROM public.sync_state
WHERE entity_type = 'orders'
  AND account = 'vendas';
```
</details>

Validação pós-apply (read-only) — hoje retorna `❌`, o que prova que a query discrimina:

```sql
SELECT
  CASE WHEN NOT EXISTS (
    SELECT 1 FROM public.sync_state
    WHERE entity_type = 'orders' AND account = 'vendas'
  ) THEN '✅ marcador fossil orders/vendas removido'
    ELSE '❌ AINDA EXISTE — o DELETE nao pegou' END AS status;
```

## Pré-voo

- `wt:preflight --full`: 🟢 sem colisão (166.601 objetos concorrentes).
- PROD via `psql-ro`: 1 linha alvo · 0 FKs apontando para `sync_state` · 0 views leem a tabela · os leitores SQL (`claim_*`/`finalizar_*`/`tint_watchdog_*`/`_data_health_compute`) não referenciam o par · a UI (`useAnalyticsSync.ts`) faz `select().order('entity_type')` genérico.
- `bun run audit:migrations` rodado; artefatos commitados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
