### PR TITLE
fix(sonda): o gate provava que respostaSonda é CHAMADA — não que o corpo vira a RESPOSTA HTTP

### DIFF
--- a/docs/historico/verificar-sonda-versao.md
+++ b/docs/historico/verificar-sonda-versao.md
@@ -296,3 +296,60 @@ corpo** (aqui, `total_skus_esperados`/`paginas_omie`).
 Nenhuma escrita indevida e nenhum sync disparado à toa: as 2 edges perigosas foram provadas **sem**
 serem invocadas. Quando a via passiva existe, ela é estritamente melhor que a sonda — não custa nada
 e não pode errar para o lado caro.
+
+## 9. O gate de contrato provava que a sonda é CHAMADA — não que ela RESPONDE (2026-08-24)
+
+Achado ao falsificar uma sonda experimental na `omie-vendas-sync` (2026-08-23, worktree
+zen-zhukovsky-29a5d9; aquela sonda **não** foi entregue — o #1937 declarou a edge
+`VERIFICAVEL_POR_CANARIA` e a entrega virou estender a `identidade_probe`). Trocar
+
+```ts
+return new Response(JSON.stringify(respostaSondaX(...)), { ... })
+// por
+console.log(respostaSondaX(...));
+return new Response(JSON.stringify({ ok: true }), { ... })
+```
+
+deixava **todos** os gates verdes. O teste "toda edge instrumentada RESPONDE à sonda" afirmava duas
+coisas — que `respostaSonda\w*(` aparece e que a edge ramifica em `"sonda"` — e nenhuma das duas nota a
+diferença entre montar o corpo e devolvê-lo. Medido no gate antigo: sabotando a
+`disparar-pedidos-aprovados` assim, `bun run test:edges` = **893 passed | 0 failed, exit 0**.
+
+O preço em produção é a pior leitura possível: a edge responde 200 **sem** o eco `probe:true`, e
+ausência de `probe:true` é exatamente o corpo pelo qual a canária conclui *"bundle velho, e ele rodou o
+efeito caro"* (`docs/agent/deploy.md` §Canárias, armadilha 1). Sonda muda não é sonda calada — é sonda
+mentindo para o lado caro. O buraco **não** era de nenhuma edge: valia para as 32 instrumentadas.
+
+### Por que o assert é POSICIONAL, e não uma lista de embrulhos
+
+A medição das 32 (2026-08-24) achou **quatro** formas legítimas, não duas:
+
+| Forma | n | Shape |
+| --- | --- | --- |
+| A | 21 | `return new Response(JSON.stringify(respostaSonda(VERSAO)), …)` |
+| B | 5 | `return jsonRes(respostaSonda(VERSAO), 200)` |
+| C | 4 | `return jsonResponse(respostaSonda(VERSAO), 200)` |
+| D | 2 | **indireta** — `const corpo = … ? respostaSonda(VERSAO) : …` e o `return` embrulha a VARIÁVEL |
+
+A forma D (`ai-ops-agent`, `omie-financeiro`) é a que mata a enumeração: ali não há embrulho nenhum
+adjacente à chamada, então `(JSON\.stringify|jsonRes)\(respostaSonda\w*\(` reprovaria **edge correta** —
+e o conserto de um gate que reprova código certo é sempre afrouxá-lo. O gate entregue exige que a
+chamada esteja na **cadeia de um `return`** (prefixo da sentença desde o `;`/`{`/`}` mais próximo; na
+forma indireta, que o PRÓXIMO `return` embrulhe a variável atribuída). Embrulho novo passa sem tocar no
+teste; `console.log` não passa.
+
+### Falsificação (exigida em código real, não só no texto da calibração)
+
+Sabotadas 5 edges reais, uma por forma — `disparar-pedidos-aprovados` (A), `recommend` (B),
+`fin-cashflow-engine` (C), `ai-ops-agent` e `omie-financeiro` (D): **5/5 vermelhas**, todas acusando o
+gate certo (a mensagem cita a edge e "o corpo não alcança nenhum return"). A calibração no próprio teste
+cobre os dois lados: 3 formas "calcula e descarta" que ele **tem** de reprovar (incluindo guardar numa
+variável e retornar outra), as 4 formas reais + um embrulho inventado que ele **tem** de aprovar, e o
+caso da resposta certa existindo só em **comentário**.
+
+### Assinatura para varredura futura
+
+Gate que casa o **nome** de uma função e conclui que o **efeito** dela aconteceu. `respostaSonda(`
+presente prova montagem, não entrega; `track(` presente prova chamada, não evento gravado. Quando o
+valor de retorno É o produto, o assert tem de seguir o valor até a fronteira (o `return`, o `await`, o
+`INSERT`) — senão o gate mede o texto certo e afirma a coisa errada.

--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -426,24 +426,139 @@ function trechoDoHandler(nome: string): string {
   return codigo.slice(i);
 }
 
+/** Trecho entre o delimitador de sentença mais próximo (`;`, `{` ou `}`) e a posição dada. */
+function prefixoDaSentenca(codigo: string, ate: number): string {
+  const inicio = Math.max(
+    codigo.lastIndexOf(";", ate),
+    codigo.lastIndexOf("{", ate),
+    codigo.lastIndexOf("}", ate),
+  );
+  return codigo.slice(inicio + 1, ate);
+}
+
+/**
+ * O corpo da sonda ALCANÇA a resposta HTTP — ou é calculado e descartado?
+ *
+ * Buraco medido ao falsificar uma sonda experimental na `omie-vendas-sync` (2026-08-23): trocar
+ * `return new Response(JSON.stringify(respostaSonda(VERSAO)), …)` por
+ * `console.log(respostaSonda(VERSAO)); return new Response(JSON.stringify({ ok: true }), …)`
+ * deixava TODOS os gates VERDES — o de baixo afirmava que a função é CHAMADA e que a edge ramifica
+ * em "sonda", e nenhum dos dois nota a diferença. Em produção isso é uma sonda que responde 200 SEM
+ * o eco `probe:true` — e `probe:true` ausente é exatamente o corpo pelo qual a canária conclui
+ * "bundle velho, e ele rodou o efeito caro" (docs/agent/deploy.md §Canárias, armadilha 1). A edge
+ * passaria por instrumentada enquanto faz a canária dizer a mentira mais cara que existe.
+ *
+ * Por que NÃO enumerar os embrulhos (`JSON.stringify|jsonRes|jsonResponse`): a medição de
+ * 2026-08-24 achou QUATRO formas legítimas entre as edges instrumentadas — as três acima e uma
+ * INDIRETA (`ai-ops-agent`, `omie-financeiro`), em que o corpo vai para uma variável e o `return`
+ * embrulha a VARIÁVEL, sem embrulho nenhum adjacente à chamada. Uma lista de nomes reprovaria essas
+ * duas hoje e a próxima forma amanhã, e o conserto de um gate que reprova edge correta é sempre
+ * afrouxá-lo. Por isso o teste aqui é POSICIONAL: exige que a chamada esteja na cadeia de um
+ * `return`, não que o embrulho tenha nome conhecido. Embrulho novo passa sem tocar neste arquivo;
+ * `console.log` não passa.
+ */
+function corpoDaSondaViraResposta(codigo: string): boolean {
+  // `\w*` porque a resposta pode ter nome próprio: `generate-tactical-plan` exporta
+  // `respostaSondaTactical()`. Exigir o nome exato reprovava uma edge que responde certo.
+  const chamada = /respostaSonda\w*\(/g;
+  for (let m = chamada.exec(codigo); m; m = chamada.exec(codigo)) {
+    const prefixo = prefixoDaSentenca(codigo, m.index);
+    // Forma direta (A/B/C): `return <embrulho>(… respostaSonda(VERSAO) …)`. O delimitador de
+    // sentença é o que impede o falso verde: o `return` de uma LINHA anterior fica fora do prefixo.
+    if (/\breturn\b/.test(prefixo)) return true;
+    // Forma indireta (D): o corpo vai para uma variável e o `return` seguinte embrulha ELA. O
+    // identificador exclui `$` de propósito — ele é metacaractere de regex, e um nome não
+    // reconhecido aqui deixa o gate VERMELHO (falha segura), nunca verde por acidente.
+    const atribuicao = /\b(?:const|let|var)\s+([A-Za-z_][\w]*)\s*=/.exec(prefixo);
+    if (!atribuicao) continue;
+    // O PRÓXIMO `return`, não qualquer um: um `return` distante que mencione um nome comum
+    // (`corpo`) provaria coincidência de nome, não caminho de dados.
+    const posReturn = codigo.indexOf("return", m.index);
+    if (posReturn < 0) continue;
+    const fim = codigo.indexOf(";", posReturn);
+    const sentenca = codigo.slice(posReturn, fim < 0 ? codigo.length : fim);
+    if (new RegExp(`\\b${atribuicao[1]}\\b`).test(sentenca)) return true;
+  }
+  return false;
+}
+
 Deno.test("toda edge instrumentada RESPONDE à sonda (chamar classificarSonda não basta)", () => {
   // Buraco encontrado ao falsificar a canária da `recommend`: apagar a linha que RESPONDE
   // (`if (decisao.tipo === "sonda") return ...respostaSonda(VERSAO)`) deixava todos os gates
   // VERDES. Os vizinhos afirmam que `classificarSonda` é CHAMADA e que vem antes do
   // `createClient` — nenhum afirma que a decisão vira RESPOSTA. Uma edge assim classifica a
-  // sonda e seguve para o fluxo real: o efeito caro roda, e quem sondou lê o resultado do
+  // sonda e segue para o fluxo real: o efeito caro roda, e quem sondou lê o resultado do
   // disparo como se fosse diagnóstico. É o pior desfecho que a sonda existe para evitar,
   // passando por instrumentado.
   for (const { nome } of EDGES) {
     const codigo = codigoDaEdge(nome);
-    // `\w*` porque a resposta pode ter nome próprio: `generate-tactical-plan` exporta
-    // `respostaSondaTactical()`. Exigir o nome exato reprovava uma edge que responde certo.
     if (!/respostaSonda\w*\(/.test(codigo)) {
       throw new Error(`${nome}: classifica a sonda mas nunca chama respostaSonda — o diagnóstico não sai`);
+    }
+    // E o corpo montado tem de virar a RESPOSTA. Sem este assert, `console.log(respostaSonda(…))`
+    // seguido de um `return` qualquer passa pelos dois vizinhos — ver `corpoDaSondaViraResposta`.
+    if (!corpoDaSondaViraResposta(codigo)) {
+      throw new Error(
+        `${nome}: chama respostaSonda mas o corpo não alcança nenhum return — a sonda responde 200 SEM \`probe:true\`, e a canária lê isso como "bundle velho que rodou o efeito caro"`,
+      );
     }
     if (!/["\x27]sonda["\x27]/.test(codigo)) {
       throw new Error(`${nome}: não ramifica no tipo "sonda" — a decisão é calculada e descartada`);
     }
+  }
+});
+
+Deno.test("CALIBRAÇÃO: o gate de RESPOSTA reprova a forma `calcula e descarta`", () => {
+  // Sem isto o gate acima nasceria cego igual ao que ele substitui: um predicado que devolve `true`
+  // para tudo passa nas 32 edges reais sem afirmar nada. Cada forma abaixo é montada como TEXTO —
+  // não dá para sabotar as edges reais de dentro do teste.
+  const reprovadas: Array<[string, string]> = [
+    [
+      "console.log — a forma exata medida na omie-vendas-sync",
+      'console.log(respostaSonda(VERSAO));\n  return new Response(JSON.stringify({ ok: true }), { status: 200 });',
+    ],
+    [
+      "calcula, guarda e descarta",
+      'const corpo = respostaSonda(VERSAO);\n  return new Response(JSON.stringify({ ok: true }), { status: 200 });',
+    ],
+    [
+      "guarda numa variável e retorna OUTRA",
+      'const corpo = respostaSonda(VERSAO);\n  const saida = { ok: true };\n  return jsonRes(saida, 200);',
+    ],
+  ];
+  for (const [rotulo, forma] of reprovadas) {
+    if (corpoDaSondaViraResposta(forma)) {
+      throw new Error(`o gate aprovaria a forma que existe para barrar (${rotulo})`);
+    }
+  }
+
+  // Controle positivo: as QUATRO formas reais medidas em 2026-08-24 têm de passar, senão o gate
+  // reprova edge correta — e o conserto de um gate assim é afrouxá-lo até parar de medir.
+  const aprovadas: Array<[string, string]> = [
+    ["A: new Response(JSON.stringify(", 'if (d.tipo === "sonda") {\n  return new Response(JSON.stringify(respostaSonda(VERSAO)), { status: 200 });\n}'],
+    ["B: jsonRes(", 'if (d.tipo === "sonda") return jsonRes(respostaSonda(VERSAO), 200);'],
+    ["C: jsonResponse(", 'if (d.tipo === "sonda") return jsonResponse(respostaSonda(VERSAO), 200);'],
+    [
+      "D: indireta, o return embrulha a variável",
+      'const ehSonda = d.tipo === "sonda";\n  const corpo = ehSonda\n    ? respostaSonda(VERSAO)\n    : { error: erroSondaAmbigua(d.valor, EFEITO) };\n  return new Response(JSON.stringify(corpo), {\n    status: ehSonda ? 200 : 400,\n  });',
+    ],
+    // Embrulho que ainda não existe: o gate é posicional de propósito, então a próxima edge não
+    // precisa vir aqui pedir licença. Este caso é o que trava a volta para uma lista de nomes.
+    ["embrulho novo, nome desconhecido", "return respostaJson(respostaSondaTactical(), 200);"],
+    ["nome próprio (generate-tactical-plan)", "return new Response(JSON.stringify(respostaSondaTactical()), { status: 200 });"],
+  ];
+  for (const [rotulo, forma] of aprovadas) {
+    if (!corpoDaSondaViraResposta(forma)) {
+      throw new Error(`o gate reprovaria uma forma legítima (${rotulo}) — edge correta ficaria vermelha`);
+    }
+  }
+
+  // O gate mede o código SEM comentário (`codigoDaEdge` passa pelo `removerComentarios`
+  // compartilhado). Sem este caso, uma edge cuja única resposta certa está COMENTADA passaria — é
+  // a mesma cegueira dos gates textuais de docs/historico/gates-textuais-cegos.md.
+  const soEmComentario = '// return new Response(JSON.stringify(respostaSonda(VERSAO)), { status: 200 });\n  console.log(respostaSonda(VERSAO));\n  return new Response(JSON.stringify({ ok: true }), { status: 200 });';
+  if (corpoDaSondaViraResposta(removerComentarios(soEmComentario))) {
+    throw new Error("o gate aprovaria uma edge cuja resposta certa está COMENTADA");
   }
 });
 


### PR DESCRIPTION
## O buraco

O gate `toda edge instrumentada RESPONDE à sonda` afirmava duas coisas — que `respostaSonda\w*(` aparece no arquivo e que a edge ramifica em `"sonda"`. **Nenhuma das duas nota a diferença entre montar o corpo e devolvê-lo.**

Achado ao falsificar uma sonda experimental na `omie-vendas-sync` (2026-08-23, worktree zen-zhukovsky-29a5d9). Trocar

```ts
return new Response(JSON.stringify(respostaSondaX(...)), { ... })
```

por

```ts
console.log(respostaSondaX(...));
return new Response(JSON.stringify({ ok: true }), { ... })
```

deixava **todos** os gates verdes.

Em produção isso é uma sonda que responde **200 sem o eco `probe:true`** — e `probe:true` ausente é exatamente o corpo pelo qual a canária conclui *"bundle velho, e ele rodou o efeito caro"* (`docs/agent/deploy.md` §Canárias, armadilha 1). A canária passaria a dizer a mentira mais cara que existe, vinda de uma edge que passa por instrumentada.

Aquela sonda experimental **não** foi entregue (o #1937 declarou a `omie-vendas-sync` `VERIFICAVEL_POR_CANARIA` e a entrega virou estender a `identidade_probe`). O buraco, portanto, **não estava fechado em nenhuma edge**: valia para as 32 instrumentadas.

## Por que o assert é POSICIONAL, e não uma lista de embrulhos

Medição das 32 (2026-08-24) — **quatro** formas legítimas, não duas:

| Forma | n | Shape |
| --- | --- | --- |
| A | 21 | `return new Response(JSON.stringify(respostaSonda(VERSAO)), …)` |
| B | 5 | `return jsonRes(respostaSonda(VERSAO), 200)` |
| C | 4 | `return jsonResponse(respostaSonda(VERSAO), 200)` |
| D | 2 | **indireta** — `const corpo = … ? respostaSonda(VERSAO) : …`, e o `return` embrulha a VARIÁVEL |

A forma D (`ai-ops-agent`, `omie-financeiro`) mata a enumeração: ali não há embrulho **nenhum** adjacente à chamada, então `(JSON\.stringify|jsonRes)\(respostaSonda\w*\(` reprovaria **edge correta** — e o conserto de um gate que reprova código certo é sempre afrouxá-lo.

O gate entregue exige que a chamada esteja na **cadeia de um `return`**: prefixo da sentença desde o `;`/`{`/`}` mais próximo; na forma indireta, que o PRÓXIMO `return` embrulhe a variável atribuída. Embrulho novo passa sem tocar no teste; `console.log` não passa.

## Evidência

**Contraprova do buraco** — gate ANTIGO + `disparar-pedidos-aprovados` sabotada:
```
893 passed | 0 failed — exit 0     ← verde, o buraco
```

**Falsificação do gate novo** — 5 edges REAIS sabotadas, uma por forma:

| Edge | Forma | exit | acusa o gate certo |
| --- | --- | --- | --- |
| `disparar-pedidos-aprovados` | A | 1 | ✅ |
| `recommend` | B | 1 | ✅ |
| `fin-cashflow-engine` | C | 1 | ✅ |
| `ai-ops-agent` | D | 1 | ✅ |
| `omie-financeiro` | D | 1 | ✅ |

5/5 vermelhas, todas citando a edge e *"o corpo não alcança nenhum return"*. Sabotagens restauradas (`git status` limpo) — e o commit foi feito **antes** de falsificar.

**Verde limpo:** `bun run test:edges` → `894 passed | 0 failed`, exit 0 · `bun run edges:typecheck` → exit 0, 0 erros de classe-crash.

## Calibração (senão o gate novo nasce cego igual)

Montada como texto no próprio teste, nos dois sentidos:

- **Reprova:** `console.log` + return de outro corpo · `const corpo = respostaSonda(…)` descartado · guardar numa variável e retornar **outra** · a resposta certa existindo só em **comentário** (via o `removerComentarios` compartilhado).
- **Aprova:** as 4 formas reais + um embrulho **inventado** (`respostaJson(`) — este é o caso que trava a volta para uma lista de nomes — + o nome próprio `respostaSondaTactical()`.

## Resíduo

`docs/historico/verificar-sonda-versao.md` §9, com a assinatura para varredura futura: *gate que casa o NOME de uma função e conclui que o EFEITO dela aconteceu*. `respostaSonda(` presente prova montagem, não entrega; `track(` presente prova chamada, não evento gravado. Quando o valor de retorno **é** o produto, o assert tem de seguir o valor até a fronteira.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
