### PR TITLE
docs(historico): o bump do #1974 no ar — e a identidade da canária se prova por UNICIDADE, não pelo campo `edge`

### DIFF
--- a/docs/historico/sonda-marcador-congelado.md
+++ b/docs/historico/sonda-marcador-congelado.md
@@ -60,6 +60,39 @@ bumpou o `contrato` da `omie-vendas-sync` de `identidade-fail-closed-v1` para
 `identidade-a2-client-to-user-v2` justamente porque o marcador velho não nomeava mais a fatia que
 a canária verifica. Auditar os `contrato` pelo mesmo critério é o próximo passo natural.
 
+## O bump do #1974 no ar — a tese deste doc exercitada ponta a ponta (2026-08-25, 02:5x UTC)
+
+O parágrafo acima usa o #1974 como prova de que a classe existe nas canárias. Ele fechou, e o
+fecho vale registrar porque é a tese deste documento funcionando: **o bump foi o que tornou o
+deploy verificável.**
+
+O #1974 mergeou às **02:15:13 UTC**. Deploy de edge no Lovable é manual, então nesse instante a
+`main` andou e a produção não — e a única coisa capaz de expor a diferença era o marcador. Deploy
+pedido pelo chat do Lovable (com `assinatura-a2.ts`, arquivo NOVO: só o `index.ts` derrubaria o
+boot por import inexistente) e sondado logo depois pela rota `identidade_probe`:
+
+| campo | lido no `request_id` 59734 |
+|---|---|
+| `status_code` | 200 |
+| `canary` | `true` |
+| `contrato` | **`identidade-a2-client-to-user-v2`** |
+| `ok` | `true` |
+| `casos_vermelhos` | vazio (9 fixtures, todas verdes) |
+
+Os **cinco** campos que a §Canárias do `deploy.md` exige, não só o `ok`.
+
+**A identidade se resolve pelo `contrato`, sem o campo `edge`.** A canária da `omie-vendas-sync` não
+emite `edge` — o discriminante do #1789, que separou as 10 sondas da oitava leva, não existe aqui.
+Ele não fez falta porque a string `identidade-a2-client-to-user-v2` aparece em UM arquivo só
+(`omie-vendas-sync/index.ts`) e **nasceu no próprio #1974**: `git grep` no commit pai devolve zero.
+Nenhuma outra edge e nenhum bundle anterior conseguem produzi-la, então ler essa string já é o
+veredito. É o mesmo critério do `edge` por outro caminho — **unicidade provada**, não presumida.
+
+E é exatamente o que o marcador congelado destrói: mantido em `identidade-fail-closed-v1`, o probe
+responderia a MESMA string antes e depois do deploy, e a verificação teria dado verde sem provar
+nada — o modo de falha que este documento nomeia. O bump não foi consequência da fatia; foi o
+pré-requisito de conseguir enxergá-la no ar.
+
 ## Se for instalar gate: o desenho que sobreviveu à 2ª opinião (Codex, xhigh)
 
 Medido neste repo (30 dias, 414 commits): **68** tocam alguma edge instrumentada (~16%) e **55**


### PR DESCRIPTION
## O que é

O `sonda-marcador-congelado.md` já usava o [#1974](https://github.com/LucasSardenbergL/afiacao/pull/1974) como prova de que o marcador congelado ataca **canárias** também, não só sondas. Ele fechou — e o fecho é a tese do doc funcionando ponta a ponta.

O #1974 mergeou às **02:15:13 UTC**. Deploy de edge no Lovable é manual, então a `main` andou e a produção não; a única coisa capaz de expor a diferença era o marcador. Deployado pelo chat do Lovable (com `assinatura-a2.ts`, arquivo **novo** — só o `index.ts` derrubaria o boot por import inexistente) e sondado pela rota `identidade_probe`.

## A evidência (`request_id` 59734)

| campo | lido |
|---|---|
| `status_code` | 200 |
| `canary` | `true` |
| `contrato` | **`identidade-a2-client-to-user-v2`** |
| `ok` | `true` |
| `casos_vermelhos` | vazio (9 fixtures verdes) |

Os **cinco** campos que a §Canárias do `deploy.md` exige, não só o `ok`.

## O achado que vale o registro

A canária da `omie-vendas-sync` **não emite o campo `edge`** — o discriminante do #1789, que separou as 10 sondas da 8ª leva. Ele não fez falta, e o motivo não é sorte: a string `identidade-a2-client-to-user-v2` aparece em **um arquivo só** e **nasceu no próprio #1974** (`git grep` no commit pai devolve zero). Nenhuma outra edge e nenhum bundle anterior conseguem produzi-la.

**Unicidade provada** substitui o campo de identidade. Unicidade *presumida* não substituiria — foi o que custou 10 sondas sem veredito em 2026-08-18.

E o contrafactual fecha o argumento do doc: mantido em `identidade-fail-closed-v1`, o probe responderia a mesma string antes e depois do deploy, e a verificação daria verde **sem provar nada**. O bump não foi consequência da fatia; foi o pré-requisito de enxergá-la no ar.

## Gates

`docs:indice` 0 · `docs:citacoes` 0 · `docs:links` 0. Só docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)