### PR TITLE
fix(sonda): as 2 edges Sayerlack ficaram congeladas desde o 8ee8afa15 — bump com marcadores DISTINTOS

### DIFF
--- a/docs/historico/sonda-marcador-congelado.md
+++ b/docs/historico/sonda-marcador-congelado.md
@@ -43,8 +43,8 @@ Critério: último commit que tocou `<edge>/index.ts` mais NOVO que o último qu
 | edge | commit da mudança | veredito |
 |---|---|---|
 | `omie-analytics-sync` | #1971 (883080edb) | **genuíno** — corrigido aqui |
-| `enviar-pedido-portal-sayerlack` | 8ee8afa15 (203 linhas) | **genuíno** — segue congelado |
-| `sayerlack-captura-precos` | 8ee8afa15 (85 linhas) | **genuíno** — segue congelado |
+| `enviar-pedido-portal-sayerlack` | 8ee8afa15 (203 linhas) | **genuíno** — bumpado depois, `v1.1-pos-login-no-envio` |
+| `sayerlack-captura-precos` | 8ee8afa15 (85 linhas) | **genuíno** — bumpado depois, `v1.1-pos-login-na-captura` |
 | `disparar-pedidos-aprovados` | dc67b4261 | falso positivo — só encanamento da sonda |
 
 ⚠️ As 5 edges que a suspeita inicial apontava (`fin-cashflow-engine`, `omie-cliente`,

--- a/supabase/functions/_shared/sonda-versao-contrato_test.ts
+++ b/supabase/functions/_shared/sonda-versao-contrato_test.ts
@@ -854,6 +854,31 @@ Deno.test("bump v1.1-mapa-codigo-sem-alias: omie-analytics-sync não pode voltar
   }
 });
 
+Deno.test("bump 8ee8afa15: as 2 edges Sayerlack não podem voltar ao marcador congelado", () => {
+  // Quarta e quinta ocorrências da classe, achadas pela auditoria do #1982 (o critério: último
+  // commit em `index.ts` mais novo que o último que alterou a linha `VERSAO`). O 8ee8afa15 mudou
+  // 203 linhas numa e 85 na outra — reescreveu o pós-login do portal — e nenhuma foi bumpada.
+  //
+  // Marcadores DISTINTOS de propósito, apesar de a fatia ser a mesma: as duas edges deployam
+  // separado, então marcador compartilhado não discriminaria o deploy de cada uma. É o caso que o
+  // gate "marcadores são únicos por edge" descreve no comentário mas não pega — ele só afere o
+  // valor inicial.
+  const CONGELADO = "v1.0-sensor-inicial";
+  const PARES: Array<{ nome: string; versao: string }> = [
+    { nome: "enviar-pedido-portal-sayerlack", versao: portalSayerlack.VERSAO },
+    { nome: "sayerlack-captura-precos", versao: capturaPrecos.VERSAO },
+  ];
+  for (const { nome, versao } of PARES) {
+    if (versao === CONGELADO) {
+      throw new Error(
+        `${nome}: marcador REGREDIU para ${CONGELADO} — o valor em que ficou congelado enquanto o ` +
+          `8ee8afa15 reescrevia o pós-login. Estas edges EFETIVAM no portal do FORNECEDOR, então ` +
+          `deploy não provado aqui é pedido real que ninguém sabe se saiu do bundle certo.`,
+      );
+    }
+  }
+});
+
 Deno.test("oitava leva: o corpo do Request é lido UMA vez só", () => {
   // O corpo de um `Request` só se lê uma vez: a segunda chamada devolve `{}` (ou lança). Como a
   // sonda obrigou o parse a SUBIR para antes do client, toda leitura que existia depois teve de

--- a/supabase/functions/enviar-pedido-portal-sayerlack/versao.ts
+++ b/supabase/functions/enviar-pedido-portal-sayerlack/versao.ts
@@ -12,8 +12,19 @@ import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
 /** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
 export const respostaSonda = criarRespostaSonda("enviar-pedido-portal-sayerlack");
 
-/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
-export const VERSAO = "v1.0-sensor-inicial";
+/**
+ * Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho.
+ *
+ * `v1.1-pos-login-no-envio` (8ee8afa15): o pós-login deixou de inferir sucesso de `url_changed` e passou a
+ * classificar por SINAIS do DOM (menu do sidebar e campos de senha), via `_shared/sayerlack-pos-login.ts`. Antes, troca de
+ * senha exigida pelo portal virava exceção — o `url_changed` mudava e lia como dashboard.
+ *
+ * ⚠️ Este bump é TARDIO: o 8ee8afa15 mergeou em 2026-08-21 e o marcador ficou em
+ * `v1.0-sensor-inicial`, então a sonda não discriminava aquele deploy. Ele NÃO recupera a
+ * discriminação perdida — reata só o sentido positivo, do próximo deploy em diante
+ * (`docs/historico/sonda-marcador-congelado.md`).
+ */
+export const VERSAO = "v1.1-pos-login-no-envio";
 
 /** Efeito caro citado no 400 de `probe` ambíguo. */
 export const EFEITO =

--- a/supabase/functions/sayerlack-captura-precos/versao.ts
+++ b/supabase/functions/sayerlack-captura-precos/versao.ts
@@ -21,8 +21,19 @@ import { criarRespostaSonda } from "../_shared/sonda-versao.ts";
 /** Resposta da sonda desta edge, com a identidade embutida (ver `criarRespostaSonda`). */
 export const respostaSonda = criarRespostaSonda("sayerlack-captura-precos");
 
-/** Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho. */
-export const VERSAO = "v1.0-sensor-inicial";
+/**
+ * Atualize a cada mudança relevante de comportamento — é o que distingue bundle novo de velho.
+ *
+ * `v1.1-pos-login-na-captura` (8ee8afa15): o pós-login deixou de inferir sucesso de `url_changed` e passou a
+ * classificar por SINAIS do DOM (menu do sidebar e campos de senha), via `_shared/sayerlack-pos-login.ts`. Antes, troca de
+ * senha exigida pelo portal virava exceção — o `url_changed` mudava e lia como dashboard.
+ *
+ * ⚠️ Este bump é TARDIO: o 8ee8afa15 mergeou em 2026-08-21 e o marcador ficou em
+ * `v1.0-sensor-inicial`, então a sonda não discriminava aquele deploy. Ele NÃO recupera a
+ * discriminação perdida — reata só o sentido positivo, do próximo deploy em diante
+ * (`docs/historico/sonda-marcador-congelado.md`).
+ */
+export const VERSAO = "v1.1-pos-login-na-captura";
 
 /** Efeito caro citado no 400 de `probe` ambíguo. */
 export const EFEITO =


### PR DESCRIPTION
## O que

Segue o #1982, que corrigiu o marcador congelado da `omie-analytics-sync` e **auditou as 32 edges com sonda**. A auditoria achou mais duas genuinamente congeladas, e este PR fecha as duas.

O `8ee8afa15` (2026-08-21) reescreveu o pós-login do portal Sayerlack — 203 linhas na `enviar-pedido-portal-sayerlack`, 85 na `sayerlack-captura-precos` — trocando a inferência por `url_changed` por classificação de SINAIS do DOM (`_shared/sayerlack-pos-login.ts`). Antes, troca de senha exigida pelo portal virava exceção: o `url_changed` mudava e lia como dashboard. **Nenhuma das duas teve o `VERSAO` bumpado**, então a sonda respondia `v1.0-sensor-inicial` no bundle velho e no novo.

| edge | de | para |
|---|---|---|
| `enviar-pedido-portal-sayerlack` | `v1.0-sensor-inicial` | `v1.1-pos-login-no-envio` |
| `sayerlack-captura-precos` | `v1.0-sensor-inicial` | `v1.1-pos-login-na-captura` |

## Por que marcadores DISTINTOS para a mesma fatia

As duas edges deployam **separado**. Marcador compartilhado não discriminaria o deploy de cada uma — que é a única coisa que a sonda existe para fazer. É exatamente o caso que o gate `marcadores são únicos por edge` descreve no comentário (*"DUAS edges presas no mesmo marcador depois de uma delas mudar de comportamento seria [erro]"*) mas **não pega**: ele só afere o valor inicial.

## ⚠️ O custo, assumido de olhos abertos

O fix do `8ee8afa15` já está em prod há dias. Bumpar agora **não recupera** a discriminação daquele deploy — ela está perdida. E cria **deploy no-op manual** nas duas edges só para alinhar o marcador. Foi escolha deliberada de pagar isso uma vez para reatar a discriminação, em vez de esperar a próxima mudança real delas.

Estas duas **efetivam no portal do FORNECEDOR** (pedido real, fora do nosso banco), que é o motivo de elas terem sonda desde a segunda leva — e o motivo de não valer a pena deixá-las sem prova de deploy.

## Prova

- `test:edges` **895 passed**, exit 0.
- **Falsificado nos DOIS ramos, separadamente.** O gate usa um loop que faz `throw` no primeiro achado, então sabotar as duas de uma vez só provaria a primeira. Sabotei cada uma isolada: `enviar-pedido-portal-sayerlack: marcador REGREDIU` e `sayerlack-captura-precos: marcador REGREDIU`, exit 1 nas duas; restaurado, verde.
- `edges:typecheck` exit 0 · `docs:indice`/`docs:links`/`docs:citacoes` exit 0.
- `prove-sql-money-path` **não se aplica**: o diff é comentário + constante string em dois `versao.ts`, mais um `_test.ts` do Deno. Zero migration/RPC/trigger/RLS.

Doc `docs/historico/sonda-marcador-congelado.md` atualizado — a tabela da auditoria dizia "segue congelado" nas duas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
