### PR TITLE
feat(guard): `; echo "EXIT=$?"` no fim reporta o sucesso do ECHO, não o do trabalho — 3º ramo, e a suíte que envenenava o sensor

### DIFF
--- a/.claude/hooks/pipestatus-zsh-guard.sh
+++ b/.claude/hooks/pipestatus-zsh-guard.sh
@@ -62,6 +62,8 @@ entrada="$(cat)"
 # partir DENTRO de "PIPE" ainda escapa. Custo: `set -o pipefail` e afins pagam o jq+awk (~70ms).
 case "$entrada" in
   *[Pp][Ii][Pp][Ee]*) ;;
+  *'$?'*) ;;   # 2o gatilho: eco de $? no fim. Perde o caso patologico de continuacao de
+                 # linha ENTRE o $ e o ? — casar so '$' pegaria toda variavel e faria fork a toa.
   *) exit 0 ;;
 esac
 
@@ -165,6 +167,48 @@ ramo="$(printf '%s' "$cmd" | awk '
     # (B) zsh e 1-INDEXED: pipestatus[0…] e sempre vazio. Indice que COMECA em 0 pega [0] e [0+0].
     if (vis ~ /\$\{[^}]*pipestatus\[[[:space:]]*0/ || vis ~ /\$pipestatus\[[[:space:]]*0/) { grita("INDICE-ZERO", "\\$\\{?[^}]*pipestatus\\[[[:space:]]*0") }
     if (arit && vis ~ /(^|[^A-Za-z0-9_])pipestatus\[[[:space:]]*0/)                            { grita("INDICE-ZERO", "pipestatus\\[[[:space:]]*0") }
+    # ECO-DE-EXIT: `cmd; echo "EXIT=$?"` como ULTIMO comando. O NUMERO impresso esta certo — e o do
+    # cmd — mas o exit code do COMPOUND passa a ser o do `echo`, que e 0 sempre. Quem le o conjunto
+    # em vez do texto (o harness, a notificacao de tarefa em background, um `&&` adiante) recebe
+    # SUCESSO com o trabalho quebrado. Mesma familia do PIPESTATUS: veredito fabricado.
+    # PRECISAO > RECALL, porque `echo $?` e comum e quase sempre legitimo. Exige as DUAS condicoes:
+    #   (a) o echo/printf com $? e o ULTIMO comando — se vier outra coisa depois, o exit e dela;
+    #   (b) existe comando ANTES dele — `echo $?` sozinho nao mente sobre trabalho nenhum.
+    # LIMITES MEDIDOS (/codex defensivo, cada um reproduzido em zsh -f). Ficam como FN de
+    # proposito: fecha-los custaria balanceamento de parenteses/aspas no scanner, e o preco de um
+    # guard barulhento e alto — ele perde a credibilidade dos TRES ramos de uma vez.
+    #   `false; echo "EXIT=$? $(printf x | cat)"` — o `|` DENTRO de $( ) rouba o separador;
+    #   `false; echo "nota; EXIT=$?"`             — `;` textual dentro de aspas duplas idem;
+    #   `false; { echo "EXIT=$?"; }` / `(...)` / `time` / `command` / `eval` / funcao — o segmento
+    #     nao COMECA por echo|printf;
+    #   `false; echo "EXIT=$?" || true`           — curto-circuito poe outra coisa depois;
+    #   `false; echo "EXIT=$?" | tee`             — o pipe engole (e a propria ajuda ja avisa disso).
+    linhaf = vis
+    sub(/[[:space:]]+$/, "", linhaf)
+    sub(/[[:space:]]*;+[[:space:]]*$/, "", linhaf)   # `;` TERMINAL: sem isto `ultimo` fica vazio e
+                                                     # `cmd; echo "EXIT=$?";` — comum — passa batido
+    pos = 0; cond = 0
+    for (kk = 1; kk <= length(linhaf); kk++) {
+      cc = substr(linhaf, kk, 1)
+      # REDIRECAO nao e separador: em `>&2`, `2>&1` e `&>` o `&` nao inicia comando nenhum.
+      if (cc == ">" || cc == "<") { kk++; continue }
+      if (cc == "&" && substr(linhaf, kk + 1, 1) == ">") { kk++; continue }
+      if (cc == ";" || cc == "\n") { pos = kk; cond = 0; continue }
+      if (cc == "&" || cc == "|") {
+        if (substr(linhaf, kk + 1, 1) == cc) {         # `&&` / `||`: CURTO-CIRCUITO
+          pos = kk + 1; cond = 1; kk++
+        } else { pos = kk; cond = 0 }
+      }
+    }
+    # `cond` mata o FP mais caro do ramo: em `false && echo "EXIT=$?"` o echo NEM EXECUTA quando o
+    # trabalho falha — o compound devolve 1, fiel. E em `true && echo "$?"` devolve 0, tambem fiel.
+    # Depois de `&&`/`||` o relator nunca fabrica sucesso, entao avisar ali e so ruido.
+    if (pos > 0 && !cond) {
+      ultimo = substr(linhaf, pos + 1)
+      if (ultimo ~ /^[[:space:]]*(echo|printf)([[:space:]]|$)/ && ultimo ~ /\$\?/) {
+        grita("ECO-DE-EXIT", "(echo|printf)[^;&|]*\\$\\?")
+      }
+    }
   }
 ')"
 
@@ -188,7 +232,29 @@ string vazia) de silencio em ABORTO — e a leitura passa a falhar alto em vez d
 Isto e um AVISO, nao um bloqueio: se o seu caso e um dos legitimos (comentario, KSH_ZERO_SUBSCRIPT,
 texto que vai rodar noutro shell), siga em frente. Para silenciar: PIPESTATUS_INTENCIONAL=1 <cmd>'
 
-if [ "$ramo" = "BASHISM" ]; then
+# shellcheck disable=SC2016  # a ajuda ENSINA o idioma: $? e $rc sao literais, nao para expandir
+idioma_eco='Idioma correto (escolha um):
+  1. PROPAGUE o veredito — a ultima instrucao decide o exit do conjunto:
+       cmd > /tmp/saida.log 2>&1; rc=$?
+       head -c 1500 /tmp/saida.log
+       [ "$rc" -eq 0 ]        # <- ultima instrucao: o conjunto REPROVA junto com o cmd
+  2. Se voce QUER so registrar o codigo, registre — mas ESTE aviso vai disparar de novo, e esta
+     certo: gravar no log nao conserta o exit do conjunto, so lhe da onde ler a verdade.
+       cmd > /tmp/saida.log 2>&1
+       echo "EXIT=$?" >> /tmp/saida.log       # <- o exit do conjunto continua sendo 0, MENTINDO
+       command grep EXIT= /tmp/saida.log      # <- a evidencia e ESTA linha, nao a notificacao
+     Prefira (1) sempre que alguem — harness, `&&`, `if` — for LER o codigo do conjunto.
+Nos dois casos vale a regra: `| tail`/`| head` no fim engolem o exit code do trabalho, e `$?` depois
+de um pipe e do ULTIMO estagio. Capture o rc ANTES de recortar a saida.
+
+Isto e um AVISO, nao um bloqueio. Para silenciar: PIPESTATUS_INTENCIONAL=1 <cmd>'
+
+if [ "$ramo" = "ECO-DE-EXIT" ]; then
+  msg="🔴 \`echo \$?\` no fim: o exit do CONJUNTO vira o do echo (=0) — quem le o codigo, nao o texto, ve SUCESSO"
+  ctx="ECO-DE-EXIT-FABRICA-VEREDITO: este comando termina com um \`echo\`/\`printf\` que imprime \`\$?\`. O NUMERO impresso esta certo — e o do comando anterior — mas o exit code do COMPOUND passa a ser o do \`echo\`, que e 0 SEMPRE. Quem le o codigo em vez do texto recebe SUCESSO com o trabalho quebrado: o harness, a notificacao de tarefa em background, um \`&&\` adiante, um \`if\` que envolva a chamada. Nao e teorico — numa unica sessao de 2026-08-24 este padrao produziu TRES notificacoes de 'exit code 0' enganosas: uma para um \`bun run test:hooks\` que tinha 4 falhas, uma para um \`codex exec\` que falhou nas 3 tentativas por DNS, e uma terceira num watcher. E a mesma familia do PIPESTATUS vazio: veredito fabricado a partir de dado que nao foi consultado (ausente != zero, docs/agent/money-path.md).
+
+$idioma_eco"
+elif [ "$ramo" = "BASHISM" ]; then
   msg="🔴 PIPESTATUS e bash-ism — no zsh (que roda este comando) expande para VAZIO, e vazio vale 0 = SUCESSO"
   ctx="PIPESTATUS-BASHISM-NO-ZSH: este comando le \`PIPESTATUS\`, mas o Bash tool roda em /bin/zsh — onde essa variavel NAO EXISTE. Ela expande para VAZIO, e no \`[\` do zsh a string vazia vale 0, que e o exit code de SUCESSO. Entao \`false | true\` seguido de \`[ \"\${PIPESTATUS[0]}\" -eq 0 ]\` imprime PIPELINE OK: o comando FABRICA um veredito de sucesso a partir de dado AUSENTE (ausente != zero, docs/agent/money-path.md). Nada avisa — o \`[\` nem reclama. Vale igual sem o cifrao: \`(( PIPESTATUS[0] == 0 ))\`, \`[[ PIPESTATUS[0] -eq 0 ]]\` e \`let\` avaliam o identificador NU e tratam ausente como 0.
 

--- a/docs/historico/evidencia-positiva-shell.md
+++ b/docs/historico/evidencia-positiva-shell.md
@@ -210,6 +210,43 @@ o invariante que o teste afirma provar.** Sabotei o teto e o teste seguiu VERDE 
 o comando de acentos, que param em 414 bytes sozinhos. O vetor real era match GRANDE, não comando
 grande: `\$\{[^}]*PIPESTATUS` não tem limite, então a janela de contexto cresce junto com ele.
 Sem a falsificação eu teria entregue um teste que passa com e sem o código que ele testa.
+
+**O 3º ramo: `; echo "EXIT=$?"` no fim.** Mesma família, gatilho diferente. O número impresso está
+certo — é o do comando anterior — mas o exit code do **compound** passa a ser o do `echo`, que é 0
+sempre. Quem lê o código em vez do texto (o harness, a notificação de tarefa em background, um
+`&&` adiante) recebe SUCESSO com o trabalho quebrado. Numa única sessão isto produziu **três**
+notificações de "exit code 0" enganosas: um `test:hooks` com 4 falhas, um `codex exec` que falhou
+por DNS nas 3 tentativas, e um watcher. O ramo se validou sozinho: disparou duas vezes nos meus
+próprios comandos durante a implementação dele.
+
+O `/codex` defensivo (rodada de cobertura, nunca "como burlar") derrubou a primeira versão em três
+pontos, todos reproduzidos em `zsh -f` antes de virar código. **O falso positivo era o mais caro:**
+`false && echo "EXIT=$?"` disparava, mas ali o `echo` nem executa quando o trabalho falha — o
+compound devolve 1, fiel. Depois de `&&`/`||` o relator nunca fabrica sucesso, então avisar é puro
+ruído, e ruído custa a credibilidade dos **três** ramos de uma vez. Os dois falsos negativos eram
+cotidianos: `cmd; echo "EXIT=$?";` com **ponto-e-vírgula terminal** (o último segmento ficava vazio)
+e `echo "EXIT=$?" >&2`, onde o `&` da redireção era lido como separador de comando.
+
+Precisão acima de recall, porque `echo $?` é comum e quase sempre legítimo — guard que vira ruído
+ensina a ignorar os outros dois ramos. Exige TRÊS condições, e cada negativo depende de uma
+diferente: existe trabalho antes (`echo $?` sozinho não mente sobre nada) · o último segmento
+começa com `echo`/`printf` (`rc=$?` usado adiante é o idioma CORRETO) · contém `$?`.
+
+**O sensor media a própria suíte.** A suíte do guard invocava o hook sem isolar
+`PIPESTATUS_GUARD_LOG`, então cada `bun run test:hooks` injetava ~39 disparos sintéticos no log de
+campo — a query passaria a contar teste como uso real. Não foi o Codex nem o teste que revelou:
+foi olhar o log e ver que os "disparos" eram `false | true; [[ pipestatus[0] -eq 0 ]]`, ou seja, os
+próprios casos P1-P10. **Sensor cujo ruído vem do seu próprio teste não mede nada** — e a suíte é
+o ruído mais fácil de esquecer, porque roda em CI, sem ninguém olhando.
+
+**A falsificação errou o alvo — de novo, na mesma sessão.** Para falsificar a regra do "último
+comando", sabotei a extração do segmento e testei com E6 (`rc=$?` usado no fim) e E7 (echo no
+meio). E6 seguiu calado — e seguiria de qualquer jeito, porque E6 nem tem `echo`: ele é protegido
+pela exigência de `echo|printf`, não pela regra sabotada. A falsificação atacava uma regra e media
+casos defendidos por outra, e teria dado verde a uma sabotagem que não sabotou nada.
+**Quando o código tem N regras independentes, cada caso de falsificação precisa depender da regra
+que você está desligando** — senão o vermelho (ou o verde) vem por motivo alheio.
+
 ## O padrão por trás das nove
 
 Seis produzem **verde por construção**, não por mérito; a sétima mostra que o mesmo defeito

--- a/scripts/test-pipestatus-zsh-guard.sh
+++ b/scripts/test-pipestatus-zsh-guard.sh
@@ -26,7 +26,13 @@ entrada() { # <comando> [tool_name]
   jq -n -c --arg cmd "$1" --arg tool "${2:-Bash}" '{tool_name:$tool, tool_input:{command:$cmd}}'
 }
 
-executa() { printf '%s' "$1" | bash "$HOOK" 2>/dev/null; }
+# O log do SENSOR vai para um temporario: sem isto, cada rodada da suite injeta ~39 disparos
+# SINTETICOS no log real (~/.claude/afiacao-pipestatus-guard.jsonl) e a query de campo passa a
+# medir teste como se fosse uso. Sensor que mede a propria suite nao mede nada.
+LOGTESTE="$(mktemp "${TMPDIR:-/tmp}/pipestatus-guard-suite.XXXXXX")"
+trap 'rm -f "$LOGTESTE"' EXIT
+
+executa() { printf '%s' "$1" | PIPESTATUS_GUARD_LOG="$LOGTESTE" bash "$HOOK" 2>/dev/null; }
 
 checa() { # <titulo> <esperado: MARCADOR|VAZIO> <json>
   local titulo="$1" esperado="$2" json="$3" saida
@@ -52,6 +58,7 @@ checa() { # <titulo> <esperado: MARCADOR|VAZIO> <json>
 
 A="PIPESTATUS-BASHISM-NO-ZSH"
 Z="PIPESTATUS-INDICE-ZERO"
+E="ECO-DE-EXIT-FABRICA-VEREDITO"
 
 rodada() {
   echo "--- locale: ${LC_ALL:-(herdado)} ---"
@@ -99,6 +106,47 @@ rodada() {
   checa "N15 outra ferramenta" "VAZIO" "$(entrada 'echo "${PIPESTATUS[0]}"' 'Read')"
   checa "N16 comando trivial" "VAZIO" "$(entrada 'ls -la')"
 
+  # ── ECO-DE-EXIT: `cmd; echo "EXIT=$?"` no fim ────────────────────────────────────────────────
+  # O numero impresso esta certo; o exit do COMPOUND e que passa a ser o do echo (=0). Quem le o
+  # codigo em vez do texto — harness, notificacao de tarefa, `&&` adiante — ve SUCESSO.
+  checa "E1 echo EXIT=\$? no fim" "$E" \
+    "$(entrada 'bun run test:hooks > /tmp/x.log 2>&1; echo "EXIT=$?"')"
+  checa "E2 em linha separada (o caso que me pegou 3x)" "$E" \
+    "$(entrada 'cmd > /tmp/x.log 2>&1
+echo "EXIT=$?" >> /tmp/x.log')"
+  checa "E3 printf tambem conta" "$E" "$(entrada 'git push; printf "rc=%s\n" "$?"')"
+  checa "E4 sem aspas" "$E" "$(entrada 'make; echo EXIT=$?')"
+
+  # ── NEGATIVOS do ramo: PRECISAO acima de recall, porque `echo $?` e comum e quase sempre ok ──
+  # Sem estes, o ramo vira ruido e o founder aprende a ignorar o guard inteiro — pior que nao ter.
+  checa "E5 echo \$? sozinho (nao ha trabalho antes para mentir sobre)" "VAZIO" \
+    "$(entrada 'echo $?')"
+  checa "E6 rc capturado e USADO no fim (o idioma correto)" "VAZIO" \
+    "$(entrada 'cmd > /tmp/x.log 2>&1; rc=$?; head -c 100 /tmp/x.log; [ "$rc" -eq 0 ]')"
+  checa "E7 echo no MEIO — quem decide o exit e o ultimo" "VAZIO" \
+    "$(entrada 'cmd; echo "EXIT=$?"; exit 1')"
+  checa "E8 mencao em aspas simples (commit sobre o proprio padrao)" "VAZIO" \
+    "$(entrada 'git commit -m '"'"'guard: nao termine com echo "EXIT=$?"'"'"'')"
+  checa "E9 mencao em comentario" "VAZIO" "$(entrada 'ls -la   # echo $?')"
+  checa "E10 heredoc quoted documentando o padrao" "VAZIO" \
+    "$(entrada 'cat > doc.md <<'"'"'FIM'"'"'
+errado: cmd; echo "EXIT=$?"
+FIM')"
+  checa "E11 echo no fim SEM \$?" "VAZIO" "$(entrada 'cmd; echo pronto')"
+
+  # ── E12-E16: achados do /codex defensivo, cada um reproduzido em zsh -f antes de virar teste ──
+  # FN que passavam: o `;` terminal deixava `ultimo` VAZIO, e o `&` de `>&2` era lido como
+  # separador de comando. Os dois sao formas cotidianas do mesmo defeito.
+  checa "E12 ; terminal (o FN mais comum)" "$E" "$(entrada 'false; echo "EXIT=$?";')"
+  checa "E13 redirecao >&2 depois do relator" "$E" "$(entrada 'false; echo "EXIT=$?" >&2')"
+  # FP que o Codex chamou de "o mais perigoso para a credibilidade": depois de `&&`/`||` o relator
+  # NAO fabrica sucesso — se o trabalho falha o echo nem executa, e o compound devolve 1, fiel.
+  checa "E14 && nao mente (echo nem executa se falhar)" "VAZIO" "$(entrada 'false && echo "EXIT=$?"')"
+  checa "E15 || e handler intencional" "VAZIO" "$(entrada 'false || echo "falhou: $?"')"
+  checa "E16 && DENTRO de \$( ) — quem decide o exit e o test" "VAZIO" \
+    "$(entrada 'test -z "$(true && echo "$?")"')"
+
+
   # ── REGRESSAO: achados da revisao adversaria do Codex (2026-08-23) ────────────────────────
   # POSITIVOS que a v1 liberava — reproduzidos em `zsh -f`, todos fabricam veredito.
   checa "C1 aritmetica (( )) SEM cifrao" "$A" "$(entrada 'false | true; (( PIPESTATUS[0] == 0 )) && echo OK')"
@@ -120,7 +168,7 @@ rodada() {
 
   # ── ROBUSTEZ ───────────────────────────────────────────────────────────────────────────────
   local saida
-  saida="$(printf '%s' 'isto nao e json' | bash "$HOOK" 2>/dev/null)"
+  saida="$(printf '%s' 'isto nao e json' | PIPESTATUS_GUARD_LOG="$LOGTESTE" bash "$HOOK" 2>/dev/null)"
   if [ -z "$saida" ]; then printf '  ok   R1 entrada invalida -> silencio\n'
   else printf '  FALHA R1 entrada invalida falou: %s\n' "$saida"; falhas=$((falhas + 1)); fi
 
@@ -145,7 +193,7 @@ fi
 echo "-- falsificacao: scanner deixa de reconhecer aspas simples --"
 BKP="$(mktemp)"; cp "$HOOK" "$BKP"
 restaura() { cp "$BKP" "$HOOK"; rm -f "$BKP"; }
-trap restaura EXIT
+trap 'restaura; rm -f "$LOGTESTE"' EXIT   # o `restaura` sobrescreveria o trap do LOGTESTE
 
 perl -0pi -e 's/\{ st = 1; i\+\+; continue \}/{ st = 0; i++; continue }/' "$HOOK"
 if cmp -s "$BKP" "$HOOK"; then
@@ -165,6 +213,32 @@ else
   fi
 fi
 restaura; trap - EXIT
+
+# FALSIFICAÇÃO 2 — a precisao do ramo ECO-DE-EXIT vem de TRES regras independentes, e cada
+# negativo depende de UMA delas: E5 (`echo $?` sozinho) vive de `pos > 0`; E6 (rc usado no fim)
+# vive da exigencia de echo/printf; E7 (echo no MEIO) vive de olhar so o ULTIMO segmento, ancorado.
+# Esta sabotagem ataca a terceira — logo os casos tem de ser os de E7, e nao E5/E6, que seguiriam
+# calados por motivo alheio e dariam VERDE a uma falsificacao que nao falsificou nada.
+BKP2="$(mktemp)"; cp "$HOOK" "$BKP2"
+trap 'cp "$BKP2" "$HOOK"; rm -f "$BKP2"' EXIT
+perl -0pi -e 's/ultimo = substr\(linhaf, pos \+ 1\)/ultimo = linhaf/' "$HOOK"
+perl -0pi -e 's/ultimo \~ \/\^\[\[:space:\]\]\*\(echo\|printf\)/ultimo ~ \/[[:space:]]*(echo|printf)/' "$HOOK"
+if cmp -s "$BKP2" "$HOOK"; then
+  echo "  FALHA a sabotagem 2 NAO alterou o hook — seria teatro"
+  falhas=$((falhas + 1))
+else
+  pegou2=0
+  for caso in 'cmd; echo "EXIT=$?"; exit 1' 'cmd; echo "EXIT=$?"; ls -la'; do
+    [ -n "$(executa "$(entrada "$caso")")" ] && pegou2=$((pegou2 + 1))
+  done
+  if [ "$pegou2" -eq 2 ]; then
+    echo "  ok   sabotagem 2 ficou VERMELHA nos 2 casos (a regra do ULTIMO comando e o que da precisao)"
+  else
+    echo "  FALHA sabotagem 2 passou despercebida em $((2 - pegou2)) caso(s) — E7 nao prova precisao"
+    falhas=$((falhas + 1))
+  fi
+fi
+cp "$BKP2" "$HOOK"; rm -f "$BKP2"; trap - EXIT
 
 echo
 if [ "$falhas" -eq 0 ]; then echo "PIPESTATUS-GUARD: TODOS OS TESTES PASSARAM"; exit 0; fi


### PR DESCRIPTION
O guard do #1931/#1940 cobria `PIPESTATUS`. Falta a forma irmã, e mais comum: **terminar o comando com um relator do exit code**. O número impresso está certo — é o do comando anterior — mas o exit do **compound** passa a ser o do `echo`, que é 0 sempre. Quem lê o código em vez do texto (o harness, a notificação de tarefa em background, um `&&` adiante) recebe SUCESSO com o trabalho quebrado.

Não é teórico: numa única sessão isto produziu **três** notificações de "exit code 0" enganosas — um `test:hooks` com 4 falhas, um `codex exec` que falhou por DNS nas 3 tentativas, e um watcher.

**O ramo se validou sozinho durante a própria implementação**, disparando nos meus comandos que terminavam com `echo SHELLCHECK=$?` e `printf 'SINTAXE=%s\n' "$?"`.

## Precisão acima de recall

`echo $?` é comum e quase sempre legítimo — um guard barulhento faz perder a credibilidade dos **três** ramos de uma vez. A regra exige três condições, e cada negativo depende de uma diferente:

| negativo | o que o protege |
|---|---|
| `echo $?` sozinho | existe trabalho antes (`pos > 0`) |
| `cmd; rc=$?; [ "$rc" -eq 0 ]` — o idioma correto | exigir `echo`/`printf` |
| `cmd; echo "EXIT=$?"; exit 1` | último segmento + âncora |

## O `/codex` defensivo derrubou a primeira versão em três pontos

Cada um reproduzido em `zsh -f` antes de virar código.

- **FP, o mais caro:** `false && echo "EXIT=$?"` disparava. Ali o `echo` **nem executa** quando o trabalho falha — o compound devolve 1, fiel. Depois de `&&`/`||` o relator nunca fabrica sucesso.
- **FN:** `cmd; echo "EXIT=$?";` com **ponto-e-vírgula terminal** — o último segmento ficava vazio.
- **FN:** `echo "EXIT=$?" >&2` — o `&` da redireção era lido como separador de comando.

Os limites que **ficam** estão medidos e escritos no hook: separador dentro de `$( )`, `;` textual em aspas duplas, `{ }`/`time`/`command`/`eval`, `|| true` e `| tee` depois do relator. Fechá-los custaria balanceamento de parênteses/aspas no scanner.

## Dois achados fora do escopo

**A suíte envenenava o sensor.** `test-pipestatus-zsh-guard.sh` invocava o hook sem isolar `PIPESTATUS_GUARD_LOG`, então cada `bun run test:hooks` injetava ~39 disparos **sintéticos** no log de campo do #1940 — a query passaria a contar teste como uso real. Não foi teste que revelou: foi olhar o log e ver que os "disparos" eram os próprios casos P1–P10. Provado: suíte roda `rc=0` e o log real fica em **0 linhas**.

**A ajuda se autocontradizia.** O idioma nº 2 que ela recomendava disparava o próprio aviso. Reescrito para dizer que dispara mesmo, e por quê: gravar no log não conserta o exit do conjunto, só dá onde ler a verdade.

## A falsificação errou o alvo — de novo, na mesma sessão

Para falsificar a regra do "último comando" eu sabotei a extração e testei com E6 e E7. **E6 seguiu calado, e seguiria de qualquer jeito** — E6 nem tem `echo`, é protegido por outra regra. A falsificação atacava uma regra e media casos defendidos por outra: teria dado verde a uma sabotagem que não sabotou nada.

A regra geral ficou no doc: **quando o código tem N regras independentes, cada caso de falsificação precisa depender da que você está desligando** — senão o resultado vem por motivo alheio.

## Validação

| gate | resultado |
|---|---|
| `test-pipestatus-zsh-guard.sh` | **108 asserções**, 2 locales, `rc=0` |
| falsificação 1 (scanner de aspas) | vermelha quando sabotada |
| falsificação 2 (regra do último comando) | vermelha quando sabotada |
| `shellcheck` dos 4 arquivos tocados | `rc=0` |
| suíte não polui o log de campo | provado — 0 linhas após rodar |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
