### PR TITLE
fix(deploy-verify): a agulha ia INTEIRA para o terminal — vai truncada, o grep segue com ela toda

### DIFF
--- a/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
@@ -41,6 +41,7 @@ HTML
 cat > "$FIX/site/assets/index-AAA111.js" <<'JS'
 const __vite__mapDeps=(i)=>i.map(i=>d[i]);
 const d=["assets/PageA-BBB222.js","assets/PageB-CCC333.js"];
+const k="TOKEN_LONGO_DE_FIXTURE_NAO_E_SEGREDO_0123456789abcdef0123456789";
 console.log("entry");
 JS
 
@@ -212,6 +213,9 @@ if [ "$FALSIFY" = 0 ]; then
            "$BASE/site-fallback" "NAO_EXISTE_NO_BUNDLE_123" 2 "ENTRY_NAO_E_JS" "CONTROLE_POSITIVO_OK"
   run_case "alvo presente: o positivo NÃO roda — o próprio HIT já é a evidência de que enxerga" \
            "$BASE/site" "SENTINELA_DEEP_XYZ" 0 "CONTROLE_NEGATIVO_OK" "CONTROLE_POSITIVO_OK"
+  run_case "agulha longa sai TRUNCADA: em prod o maior token do entry é a anon key (pública, mas com cara de credencial)" \
+           "$BASE/site" "NAO_EXISTE_NO_BUNDLE_123" 1 "CONTROLE_POSITIVO_OK" \
+           "TOKEN_LONGO_DE_FIXTURE_NAO_E_SEGREDO_0123456789abcdef0123456789"
 
   echo ""
   echo "  --pai (prova de exclusividade da sentinela — fail-closed, exit 3):"

--- a/.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh
@@ -214,10 +214,15 @@ _agulha=$(tr -c 'A-Za-z0-9_' '\n' < "$TMP/entry.js" | awk '{ if (length($0) > le
 if [ -z "$_cego" ] && [ "${#_agulha}" -lt 12 ]; then
   _cego="AGULHA_INDISPONIVEL — o corpo de $ENTRY ($(wc -c < "$TMP/entry.js" | tr -d ' ') bytes) não deu token de 12+ caracteres"
 fi
+# EXIBIÇÃO truncada (o grep segue usando a agulha INTEIRA): medido contra prod em 2026-08-25, o
+# maior token do entry é o payload da anon key do Supabase — pública por desenho, ela VAI no
+# bundle, mas 200+ chars com cara de credencial não têm por que entrar na transcrição a cada run.
+_agulha_vis="$_agulha"
+[ "${#_agulha}" -le 20 ] || _agulha_vis="$(printf '%.8s' "$_agulha")...(${#_agulha} chars)"
 if [ -z "$_cego" ]; then
   printf '%s\n' "$ENTRY" > "$TMP/controle_positivo.txt"
   [ -n "$(varre "$TMP/controle_positivo.txt" "$_agulha")" ] || \
-    _cego="AGULHA_NAO_CASOU — '$_agulha' saiu do corpo de $ENTRY e o mesmo curl+grep não a acha lá"
+    _cego="AGULHA_NAO_CASOU — '$_agulha_vis' saiu do corpo de $ENTRY e o mesmo curl+grep não a acha lá"
 fi
 if [ -n "$_cego" ]; then
   printf '%s\n' \
@@ -227,7 +232,7 @@ if [ -n "$_cego" ]; then
     "   não está provado. Conserte a sonda (CDN/rede/DNS/formato) ANTES de pedir outro Publish." >&2
   exit 2
 fi
-echo "✓ CONTROLE_POSITIVO_OK — $ENTRY ainda devolve bytes e o mesmo grep acha '$_agulha' neles"
+echo "✓ CONTROLE_POSITIVO_OK — $ENTRY ainda devolve bytes e o mesmo grep acha '$_agulha_vis' neles"
 
 echo "→ ❌ ALVO ausente nos $N chunks: Publish pendente, OU o ALVO não é literal/único no bundle"
 echo "   CONTROLE_NEGATIVO_NAO_SE_APLICA: ele audita o falso POSITIVO, e este ramo é o outro — aqui"


### PR DESCRIPTION
Follow-up do #1989, achado no **primeiro contato com prod**.

## O que apareceu

Rodando o ramo `exit 1` contra `steu.lovable.app` (334 chunks) para exercitar o controle positivo recém-entregue, a saída veio assim:

```
✓ CONTROLE_POSITIVO_OK — /assets/index-D1GiFr1h.js ainda devolve bytes e o mesmo grep acha 'eyJpc3M…(212 chars)' neles
```

…só que sem a truncagem: os 212 caracteres saíram inteiros. O critério de escolha da agulha é **o maior token `[A-Za-z0-9_]` do entry**, e em prod isso é sistematicamente o payload da **anon key do Supabase**.

**Não é vazamento:** a anon key é pública por desenho — vai no bundle, todo visitante do site a recebe — e o que sai é só o payload, sem a assinatura. Mas despejar 200+ chars com cara de credencial na transcrição a cada execução é poluição e hábito ruim. Um dia o maior token do bundle pode ser algo que não deveria estar lá, e aí o script estaria ativamente ajudando a espalhá-lo.

## O conserto

Exibe **8 primeiros caracteres + o tamanho**; o `grep` continua recebendo a agulha **completa**, então a asserção do controle não muda — só a saída. Duas linhas:

```bash
_agulha_vis="$_agulha"
[ "${#_agulha}" -le 20 ] || _agulha_vis="$(printf '%.8s' "$_agulha")...(${#_agulha} chars)"
```

## Por que o fixture muda

O entry do fixture ganha um token de 62 chars. Sem ele o maior token é `__vite__mapDeps`, com 15 — abaixo do limiar — e a truncagem **nunca seria exercitada**: o caso passaria sem testar nada.

## Evidência positiva

```
run.sh EXIT=0            → classify 8/8 · verify-frontend 21/21 passaram
run.sh --falsify EXIT=0  → classify 8/8 · verify-frontend 9/9 divergiram
shellcheck EXIT=0        (script + harness)
```

RED observado antes da implementação (1 falha de 21, o caso novo exigindo `CONTROLE_POSITIVO_OK` com o token inteiro **proibido** na saída) e falsificado à mão: devolvendo a exibição completa, o caso volta a ficar vermelho.

⚠️ **Nota de honestidade sobre o histórico:** o RED foi observado e falsificado numa branch anterior, mas um `git stash push <arquivo>` que este git não suporta desfez a separação RED/GREEN — este PR traz os dois lados num commit só. O rótulo do commit segue o conteúdo, não o ritual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)