### PR TITLE
fix(sensor): o critério de veredito contava linha BRUTA — o sensor antifabricação fabricava o próprio veredito

### DIFF
--- a/.claude/hooks/pipestatus-zsh-guard.sh
+++ b/.claude/hooks/pipestatus-zsh-guard.sh
@@ -274,9 +274,11 @@ fi
 #
 # FORA do repo de proposito: ~30 worktrees compartilham este guard, e um log versionado viraria ima
 # de conflito (a mesma razao pela qual o CLAUDE.md proibe roadmap em arquivo compartilhado).
-# Escrita concorrente sem lock so e segura enquanto a linha couber no `PIPE_BUF` — que no macOS e
-# 512 bytes (`getconf PIPE_BUF /`), NAO os 4096 do Linux. Dai o teto abaixo, que e invariante de
-# CORRETUDE (linha picotada envenena a query), nao estetica.
+# Escrita concorrente sem lock: o teto de 511 bytes e PRAGMATICO, nao garantia normativa. O POSIX
+# so promete nao-intercalacao abaixo de `PIPE_BUF` para PIPE/FIFO — para arquivo regular o que
+# protege e o O_APPEND do `>>` posicionar no EOF por write, e linha curta tornar provavel que o
+# shell emita UM write so. Em NFS o append e simulado pelo cliente e pode corromper mesmo assim.
+# Por isso a QUERY tolera linha picotada (`fromjson? // empty`) em vez de confiar no teto.
 #
 # ARMADILHA MEDIDA: truncar o CAMPO nao limita a LINHA — o escape do JSON infla depois do corte.
 # Com trecho ja cortado em 160, medi 642 bytes so de aspas (cada " vira \") e 1282 bytes de bytes
@@ -286,7 +288,7 @@ fi
 # Falha de log NUNCA cala o aviso: todo o bloco e best-effort.
 TETO_LINHA=511   # 511 + o "\n" = 512 = PIPE_BUF do macOS, o mais estrito das plataformas em jogo
 registrar_sinal() {
-  local log dir linha wt corte janela ts
+  local log dir linha wt corte janela ts d
   log="${PIPESTATUS_GUARD_LOG:-$HOME/.claude/afiacao-pipestatus-guard.jsonl}"
   dir="${log%/*}"
   [ -d "$dir" ] || (umask 077; mkdir -p "$dir") 2>/dev/null || return 0
@@ -297,13 +299,31 @@ registrar_sinal() {
   chmod 600 "$log" 2>/dev/null || true
   # Redacao: a janela e estreita, mas se um segredo encostar nela ele NAO vai para o disco.
   local seguro
+  # MEDIDO: a versao anterior so cobria Bearer/JWT/`chave=valor`. Escapavam para o disco, em texto
+  # plano: `Authorization: token ghp_...`, `curl -u user:senha`, `postgres://u:senha@host` e
+  # `--password senha` (com ESPACO, nao `=`). O CLAUDE.md proibe segredo em texto plano em disco, e
+  # log tambem e disco.
   seguro="$(printf '%s' "$1" | sed -E \
     -e 's/(eyJ[A-Za-z0-9_.-]{8,})/<JWT-REDIGIDO>/g' \
-    -e 's/((token|key|secret|senha|password|passwd|pwd|auth|apikey)["'"'"']?[=:][[:space:]]*)[^[:space:]"'"'"']+/\1<REDIGIDO>/gI' \
+    -e 's/(gh[pousr]_|github_pat_|xox[baprs]-|sk-)[A-Za-z0-9_-]{6,}/\1<REDIGIDO>/g' \
+    -e 's/([Aa]uthorization[[:space:]]*:[[:space:]]*[A-Za-z]+[[:space:]]+)[^[:space:]"'"'"']+/\1<REDIGIDO>/g' \
+    -e 's|([a-zA-Z][a-zA-Z0-9+.-]*://[^:/[:space:]]+:)[^@[:space:]]+@|\1<REDIGIDO>@|g' \
+    -e 's/(-u[[:space:]]+[^:[:space:]]+:)[^[:space:]"'"'"']+/\1<REDIGIDO>/g' \
+    -e 's/(--?(password|passwd|pwd|token|secret|api-?key)[[:space:]]+)[^[:space:]"'"'"']+/\1<REDIGIDO>/gI' \
+    -e 's/((token|key|secret|senha|password|passwd|pwd|auth|apikey|pat)["'"'"']?[=:][[:space:]]*["'"'"']?)[^[:space:]"'"'"']+/\1<REDIGIDO>/gI' \
     -e 's/([Bb]earer[[:space:]]+)[^[:space:]]+/\1<REDIGIDO>/g' 2>/dev/null)"
-  seguro="${seguro:-$1}"
+  seguro="${seguro:-<REDACAO-FALHOU-TRECHO-DESCARTADO>}"
   ts="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)"
-  wt="$(printf '%.48s' "${PWD##*/}")"
+  # MEDIDO: `${PWD##*/}` grava o basename do CWD — rodando de `<worktree>/src/lib` o log dizia
+  # `lib`, e o agrupamento "por worktree" da query virava ficcao (duas worktrees em src/lib
+  # colidiriam). Sobe a arvore ate o `.git`, em bash puro: o caminho de disparo nao paga fork.
+  local d="$PWD"
+  wt=""
+  while [ -n "$d" ] && [ "$d" != "/" ]; do
+    if [ -e "$d/.git" ]; then wt="${d##*/}"; break; fi
+    d="${d%/*}"
+  done
+  wt="$(printf '%.48s' "${wt:-${PWD##*/}}")"
   # `jq -a` forca saida ASCII pura => ${#linha} conta BYTES em QUALQUER locale, sem fork de `wc`.
   for corte in 160 80 40 0; do
     if [ "$corte" -eq 0 ]; then janela='<TRECHO-OMITIDO-LINHA-LONGA>'

--- a/docs/historico/evidencia-positiva-shell.md
+++ b/docs/historico/evidencia-positiva-shell.md
@@ -247,6 +247,64 @@ casos defendidos por outra, e teria dado verde a uma sabotagem que não sabotou 
 **Quando o código tem N regras independentes, cada caso de falsificação precisa depender da regra
 que você está desligando** — senão o vermelho (ou o verde) vem por motivo alheio.
 
+
+**A revisão retroativa do sensor: cinco defeitos, e a maioria era "mede errado", não "quebra".**
+A primeira revisão do sensor ficou pela metade (o Codex morreu por infra). Refeita com calma, as
+medições próprias acharam:
+
+- **A redação de segredo cobria pouco.** Só `Bearer`, JWT e `chave=valor`. Escapavam para o disco em
+  texto plano: `Authorization: token ghp_…`, `curl -u user:senha`, `postgres://u:senha@host` e
+  `--password senha` (com **espaço**, não `=`). Log é disco, e o CLAUDE.md proíbe segredo em texto
+  plano em disco.
+- **Uma única linha picotada matava o relatório inteiro.** `jq -s` aborta na primeira linha
+  inválida, então `exit 65` e 100% do sinal perdido — num log que ~30 worktrees escrevem em append,
+  onde picote é acidente esperado. Agora é `jq -R 'fromjson? // empty'`: a linha ruim vira `empty`,
+  as boas contam, e o relatório **declara** quantas ignorou.
+- **`wt` gravava o basename do CWD, não da worktree.** Rodando de `<worktree>/src/lib` o log dizia
+  `lib`. O agrupamento "por worktree" era ficção, e duas worktrees em `src/lib` colidiriam.
+- **"Padrões distintos" contava INSTÂNCIAS.** Três disparos do mesmo erro, diferindo só no nome do
+  arquivo de log, viravam três "padrões" — e o veredito manda o humano classificar um por um, o que
+  torna "zero falso positivo" inatingível por construção. Agora a query normaliza caminhos e números
+  antes de agrupar, e exibe um exemplo real.
+- **Corte silencioso.** Top-15 de padrões e top-8 de worktrees sem dizer quantos ficaram de fora —
+  enquanto o veredito mandava "classificar os N padrões **acima**". O CLAUDE.md já proíbe isso
+  (`no silent caps`); o sensor o cometia no próprio relatório.
+
+O `/codex` retroativo então achou o que eu não tinha achado, e era o pior de todos: **o critério de
+veredito contava linhas BRUTAS.** Dois eventos reais mais dezoito linhas de outro schema imprimiam,
+na mesma tela, `Disparos: 2`, `18 ignoradas` e `[x] >= 20 disparos` → "Volume e janela OK". O sensor
+construído para não fabricar veredito fabricava o próprio. **Passou pela suíte porque o ramo
+POSITIVO do veredito nunca teve teste** — toda fixture existente ficava abaixo do limiar, então o
+caminho que continha o bug nunca era executado. Junto vieram: "14 dias de observação" que era só a
+distância entre o primeiro e o último evento (um disparo em 01/08 e dezenove retries em 20/08
+satisfaziam janela e volume), e agrupamento por `trecho` sem o `ramo`, que juntava ramos diferentes
+numa classe só quando o trecho colidia.
+
+Ele também derrubou uma premissa que eu tinha escrito como garantia: **`PIPE_BUF` não é o limite
+normativo para arquivo regular** — vale para pipe/FIFO. O que protege o append é o `O_APPEND` e a
+linha curta tornar provável um único `write`; em NFS o append é simulado pelo cliente e pode
+corromper de todo jeito. A defesa real não é o teto, é a query tolerar linha picotada.
+
+E três asserções não provavam o que diziam: `all(.trecho != "")` passa com o campo AUSENTE
+(`null != ""` é true em jq); a que "agrupava padrões" procurava só `2x`, string que também aparece
+na seção de worktrees; e a de permissão media DEPOIS do `chmod`, então não distinguia "nasceu 0600"
+de "nasceu 0644 e foi corrigido".
+
+Duas armadilhas de manutenção apareceram no caminho, e valem mais que os fixes: **renomear a
+mensagem quebrou o teste que casava por ela** — e o nome novo tinha acento, que é justamente o que
+o #1483 proíbe em marcador de teste (ASCII, caixa fixa, sem `-i`). E **a falsificação existente
+virou inócua sem ninguém notar**: ela sabotava a redação de `Bearer` e exigia que `sk-segredo-123`
+vazasse, mas o regex novo de tokens conhecidos passou a cobrir `sk-` — a proteção ficou redundante
+e a sabotagem deixou de ser observável. **Endurecer o código pode aposentar a falsificação que o
+vigiava**, e nada avisa: o teste segue verde, só que agora por motivo errado.
+
+**A mesma armadilha, três vezes na mesma sessão.** A falsificação do critério de volume ficou verde
+porque a fixture era barrada por OUTRA regra (dias ativos), e não pela que eu havia desligado.
+Antes disso, a do teto de bytes passou por escolher um vetor que parava sozinho, e a do "último
+comando" mediu um caso defendido pela exigência de `echo`. A regra final: **a fixture de uma
+falsificação precisa passar em todas as outras regras, para que só a sabotada decida o resultado.**
+Caso contrário o verde vem por motivo alheio — e verde por motivo alheio é indistinguível de prova.
+
 ## O padrão por trás das nove
 
 Seis produzem **verde por construção**, não por mérito; a sétima mostra que o mesmo defeito

--- a/scripts/pipestatus-guard-sinal.sh
+++ b/scripts/pipestatus-guard-sinal.sh
@@ -37,7 +37,10 @@ FIM
   exit 3
 fi
 
-total="$(jq -s 'length' "$LOG" 2>/dev/null)" || { echo "log ilegível (JSONL corrompido?)" >&2; exit 65; }
+# `grep -c ''` e nao `jq -s`: uma UNICA linha picotada fazia o `jq -s` abortar e o relatorio
+# inteiro morria com exit 65 — perdia-se 100% do sinal por causa de 1 linha. O log e append de
+# ~30 worktrees; picote e acidente esperado, nao motivo para descartar meses de dado.
+total="$(command grep -c '' "$LOG" 2>/dev/null)" || total=0
 if [ "${total:-0}" -eq 0 ]; then
   echo
   echo "LOG-VAZIO: o arquivo existe mas não tem nenhum disparo."
@@ -56,20 +59,24 @@ VALIDO="$(mktemp "${TMPDIR:-/tmp}/pipestatus-sinal.XXXXXX")" || { echo "não con
 trap 'rm -f "$VALIDO"' EXIT
 # `try…catch empty` porque o `ts` tem de sobreviver ao `fromdateiso8601` usado nas agregacoes:
 # validar so o TIPO deixaria passar "ontem" e a query morreria la na frente.
-jq -c 'select((.ramo|type)=="string" and (.trecho|type)=="string" and (.wt|type)=="string")
+# `-R` + `fromjson?` le linha a linha como TEXTO: linha picotada vira `empty`, nao aborto.
+jq -Rc 'fromjson? // empty
+       | select((.ramo|type)=="string" and (.trecho|type)=="string" and (.wt|type)=="string")
        | select(try ((.ts|fromdateiso8601)|type) catch "" | . == "number")' "$LOG" > "$VALIDO" 2>/dev/null
 validas="$(wc -l < "$VALIDO" | tr -d ' ')"
 if [ "${validas:-0}" -eq 0 ]; then
   echo
-  echo "SCHEMA-ESTRANHO: as $total linha(s) do log são JSON, mas nenhuma tem os campos do sensor"
-  echo "(ts/ramo/trecho/wt). Isto NÃO é 'zero disparos' — é log de outra coisa, ou corrompido."
+  # marcador ASCII de caixa fixa: a suite casa por ele com `command grep` SEM -i, e prosa acentuada
+  # casaria diferente sob LC_ALL=C e pt_BR.UTF-8 (#1483).
+  echo "LOG-ILEGIVEL: nenhuma das $total linha(s) do log e um disparo deste sensor (ts/ramo/trecho/wt)."
+  echo "Isto NÃO é 'zero disparos' — é log de outra coisa, ou corrompido de ponta a ponta."
   echo "Confira se PIPESTATUS_GUARD_LOG não está apontando para o arquivo errado:"
   echo "  head -c 300 $LOG"
   exit 65
 fi
 if [ "$validas" -lt "$total" ]; then
   echo
-  echo "AVISO: $((total - validas)) de $total linha(s) ignorada(s) — não têm o schema do sensor."
+  echo "AVISO: $((total - validas)) de $total linha(s) ignorada(s) — picotadas, ou de outro schema."
   echo "Os números abaixo contam só as $validas válida(s)."
 fi
 
@@ -89,13 +96,26 @@ jq -rs 'group_by(.ts[0:10]) | .[] | "  \(.[0].ts[0:10])  \("#" * (length | if . 
 echo
 echo "Worktrees que dispararam:"
 jq -rs 'group_by(.wt) | sort_by(-length) | .[:8][] | "  \(length)x  \(.[0].wt)"' "$VALIDO"
+sobrawt="$(jq -rs '(group_by(.wt) | length) - 8 | if . > 0 then . else 0 end' "$VALIDO")"
+[ "${sobrawt:-0}" -gt 0 ] && echo "  … e mais $sobrawt worktree(s) não exibida(s)."
 
 echo
 echo "Padrões DISTINTOS — é isto que só VOCÊ pode classificar (VP = bug real / FP = alarme falso):"
-jq -rs 'group_by(.trecho) | sort_by(-length) | .[:15][] | "  \(length)x  [\(.[0].ramo)]  \(.[0].trecho)"' "$VALIDO"
+# Agrupa por PADRAO, nao por instancia. MEDIDO: 4 disparos do mesmo erro, diferindo so no nome
+# do arquivo de log, contavam como 4 "padroes distintos" — e o veredito manda o humano classificar
+# um por um. Caminhos e numeros viram placeholder; o exemplo exibido continua sendo REAL.
+jq -rs 'def norma: gsub("[^ ]*/[^ ]*"; "<PATH>") | gsub("[0-9]+"; "N");
+        group_by([.ramo, (.trecho | norma)]) | sort_by(-length) | .[:15][]
+        | "  \(length)x  [\(.[0].ramo)]  \(.[0].trecho)"' "$VALIDO"
+# Corte declarado: top-N silencioso se le como "e tudo o que existe" (CLAUDE.md, no silent caps).
+sobra="$(jq -rs 'def norma: gsub("[^ ]*/[^ ]*"; "<PATH>") | gsub("[0-9]+"; "N");
+                 (group_by([.ramo, (.trecho | norma)]) | length) - 15 | if . > 0 then . else 0 end' "$VALIDO")"
+[ "${sobra:-0}" -gt 0 ] && echo "  … e mais $sobra padrão(ões) NÃO exibido(s) — o critério abaixo conta TODOS."
 
-distintos="$(jq -rs 'group_by(.trecho) | length' "$VALIDO")"
+distintos="$(jq -rs 'def norma: gsub("[^ ]*/[^ ]*"; "<PATH>") | gsub("[0-9]+"; "N");
+                     group_by([.ramo, (.trecho | norma)]) | length' "$VALIDO")"
 dias="$(jq -rs '(map(.ts|fromdateiso8601)|sort) as $t | (($t[-1]-$t[0])/86400) | floor' "$VALIDO")"
+ativos="$(jq -rs '[.[].ts[0:10]] | unique | length' "$VALIDO")"
 
 echo
 echo "O QUE ESTE SENSOR NÃO MEDE (leia antes de concluir qualquer coisa):"
@@ -106,14 +126,22 @@ echo "  - a data de INSTALAÇÃO: os dias abaixo vêm do min/max do próprio log
 echo "    começa a contar no PRIMEIRO disparo. Log recente pode significar guard recente, não"
 echo "    guard silencioso."
 echo "  - as outras máquinas: o log é local. Outro Mac tem outro arquivo."
+echo "  - os FALSOS NEGATIVOS: o sensor só vê o que o detector pegou. Construção que ele não"
+echo "    reconhece nunca vira linha aqui — 'zero FP nos registros' não fala de recall."
+echo "  - o que foi SILENCIADO: PIPESTATUS_INTENCIONAL=1 e qualquer falha de escrita somem sem"
+echo "    marcador. Esta contagem é PISO, nunca total."
+echo "  - o EFEITO: nada distingue aviso que evitou um erro de aviso simplesmente ignorado."
 echo
 echo "VEREDITO (critério para endurecer o hook de AVISO para deny):"
 marca() { [ "$1" -ge "$2" ] && printf '  [x]' || printf '  [ ]'; }
-marca "$dias" 14;      echo " >= 14 dias de observação      -> hoje: $dias"
-marca "$total" 20;     echo " >= 20 disparos                -> hoje: $total"
+# `validas`, NUNCA `total`: `total` conta linhas BRUTAS. Medido — 2 eventos reais + 18 linhas de
+# outro schema imprimiam "Disparos: 2", "18 ignoradas" e "[x] >= 20 disparos" na mesma tela. O
+# sensor que existe para nao fabricar veredito fabricava o proprio.
+marca "$ativos" 14;    echo " >= 14 DIAS ATIVOS (com disparo) -> hoje: $ativos  (calendário: ${dias}d entre 1o e último)"
+marca "$validas" 20;   echo " >= 20 disparos validos          -> hoje: $validas"
 echo "  [?] ZERO falso positivo       -> exige você classificar os $distintos padrão(ões) acima"
 echo
-if [ "$dias" -ge 14 ] && [ "$total" -ge 20 ]; then
+if [ "${ativos:-0}" -ge 14 ] && [ "${validas:-0}" -ge 20 ]; then
   echo "  => Volume e janela OK. Se os $distintos padrões acima forem TODOS bug real, endurecer é"
   echo "     defensável. Se QUALQUER um for alarme falso, conserte o detector antes — bloquear com"
   echo "     falso positivo conhecido é trocar veredito fabricado por trabalho travado."

--- a/scripts/test-pipestatus-guard-sinal.sh
+++ b/scripts/test-pipestatus-guard-sinal.sh
@@ -42,16 +42,18 @@ dispara 'ls -la' >/dev/null
 prova "S2 silencio nao grava" "gravou sem disparar" [ "$(wc -l < "$LOG")" -eq 1 ]
 
 # S3/S4 redacao ANTES do disco
-dispara 'curl -H "Authorization: Bearer sk-segredo-123" u | jq .; echo ${PIPESTATUS[0]}' >/dev/null
+dispara 'curl -H "Authorization: Bearer zzTOKENxx987654" u | jq .; echo ${PIPESTATUS[0]}' >/dev/null
 dispara 'export K=eyJhbGciOiJIUzI1NiJ9.zzzz; a | b; echo ${PIPESTATUS[0]}' >/dev/null
-nprova "S3 Bearer redigido" "Bearer vazou para o disco" command grep -q "sk-segredo-123" "$LOG"
+nprova "S3 Bearer redigido" "Bearer vazou para o disco" command grep -q "zzTOKENxx987654" "$LOG"
 nprova "S4 JWT redigido" "JWT vazou para o disco" command grep -q "eyJhbGciOiJIUzI1NiJ9" "$LOG"
 
 # S5 toda linha e JSON valido
 prova "S5 JSONL valido" "JSON invalido" jq -e -s "length" "$LOG"
 
 # S6 trecho preenchido (o bug do /regex/ virando 0|1 esvaziava isto em silencio)
-if jq -es 'all(.trecho != "")' "$LOG" >/dev/null 2>&1; then ok "S6 trecho nunca vazio"
+# `all(.trecho != "")` passa com o campo AUSENTE (`null != ""` e true em jq) — provava
+# "nao e string vazia", nao "existe uma string". Exigir o TIPO e o que fecha.
+if jq -es 'all((.trecho|type) == "string" and .trecho != "")' "$LOG" >/dev/null 2>&1; then ok "S6 trecho nunca vazio"
 else falha "S6" "trecho vazio: $(jq -rs 'map(select(.trecho==""))|length' "$LOG") linha(s)"; fi
 
 # S7 comando MULTI-LINHA continua UMA linha no log (heredoc nao pode picotar o JSONL)
@@ -85,7 +87,13 @@ prova "S8b linha inflada continua JSON valido (corte multibyte sanitizado)" "JSO
 # umask, e ninguem tinha medido — o Codex mediu.
 # shellcheck disable=SC2012  # SC2012 alerta sobre parsear NOME de arquivo; aqui so leio o modo
 perm="$(ls -l "$LOG" 2>/dev/null | cut -c1-10)"   # stat -f e BSD; no GNU o -f e FILE SYSTEM, imprime outra coisa e sai 0
-prova "S8c log nasce 0600" "log criado como ${perm:-?}" [ "$perm" = "-rw-------" ]
+prova "S8c log termina 0600" "log ficou como ${perm:-?}" [ "$perm" = "-rw-------" ]
+# ...e o legado tambem: arquivo que ja existia 0644 tem de ser corrigido no proximo disparo.
+leg="$TMP/legado.jsonl"; : > "$leg"; chmod 644 "$leg"
+dispara 'x | y; echo ${PIPESTATUS[0]}' "$leg" >/dev/null
+# shellcheck disable=SC2012  # SC2012 alerta sobre parsear NOME de arquivo; aqui so leio o modo
+permleg="$(ls -l "$leg" 2>/dev/null | cut -c1-10)"
+prova "S8d log legado 0644 e corrigido para 0600" "ficou ${permleg:-?}" [ "$permleg" = "-rw-------" ]
 
 # S9 FAIL-OPEN: log impossivel de escrever NAO pode calar o aviso
 saida="$(dispara 'x | y; echo ${PIPESTATUS[0]}' "/dev/null/impossivel/x.jsonl")"
@@ -119,7 +127,9 @@ if printf '%s' "$s" | command grep -q "Disparos: 3"; then ok "S12 total correto"
 else falha "S12" "total errado"; fi
 if printf '%s' "$s" | command grep -q "BASHISM=2"; then ok "S12b agrupa por ramo"
 else falha "S12b" "ramo errado"; fi
-if printf '%s' "$s" | command grep -q "2x"; then ok "S12c agrupa padroes iguais"
+# ancorado na LINHA de padrao (`Nx  [RAMO]  ...`): so "2x" casava tambem a secao de worktrees,
+# entao a assercao ficava verde mesmo sem a secao de padroes existir.
+if printf '%s' "$s" | command grep -qE '^  2x  \[[A-Z-]+\]'; then ok "S12c agrupa padroes iguais"
 else falha "S12c" "nao agrupou"; fi
 if printf '%s' "$s" | command grep -q "insuficiente para endurecer"; then ok "S12d 3 disparos nao autorizam"
 else falha "S12d" "aprovou endurecer com 3 disparos"; fi
@@ -131,7 +141,7 @@ outro="$TMP/outro-log.jsonl"
 printf '%s\n' '{"foo":1}' '{"bar":"x"}' > "$outro"
 s="$(PIPESTATUS_GUARD_LOG="$outro" bash "$QUERY" 2>&1)"; rc=$?
 prova "S13 schema estranho nao sai 0" "saiu rc=$rc — indistinguivel de relatorio bom" [ "$rc" -eq 65 ]
-if printf '%s' "$s" | command grep -q "SCHEMA-ESTRANHO"; then ok "S13b nomeia o problema"
+if printf '%s' "$s" | command grep -q "LOG-ILEGIVEL"; then ok "S13b nomeia o problema"
 else falha "S13b" "nao explicou por que nao ha relatorio"; fi
 nprova "S13c nao imprime null como se fosse dado" "vazou 'null' no relatorio" \
        sh -c 'printf "%s" "$1" | command grep -q null' _ "$s"
@@ -152,6 +162,97 @@ s="$(PIPESTATUS_GUARD_LOG="$datar" bash "$QUERY" 2>&1)"; rc=$?
 prova "S15 ts nao-parseavel e linha invalida" "rc=$rc — a query aceitou data que quebra o agregado" \
       [ "$rc" -eq 65 ]
 
+# ── S16-S20: achados do /codex retroativo, cada um medido antes de virar codigo ───────────────
+
+# S16 REDACAO: a versao anterior so cobria Bearer/JWT/`chave=valor`. Estas quatro formas iam para o
+# disco em texto plano — e log e disco (CLAUDE.md: segredo nunca em texto plano).
+sec="$TMP/segredos.jsonl"
+dispara 'curl -H "Authorization: token ghp_AAAAAAAAAAAAAAAAAAAA" u | x; echo "EXIT=$?"' "$sec" >/dev/null
+dispara 'curl -u admin:segredo123 https://x | y; echo "EXIT=$?"' "$sec" >/dev/null
+dispara 'psql postgres://u:minhasenha123@h/db | x; echo "EXIT=$?"' "$sec" >/dev/null
+dispara 'mysql --password segredoabc | x; echo "EXIT=$?"' "$sec" >/dev/null
+nprova "S16 PAT do GitHub redigido" "ghp_ vazou para o disco" command grep -q "ghp_AAAA" "$sec"
+nprova "S16b curl -u user:senha redigido" "senha de -u vazou" command grep -q "segredo123" "$sec"
+nprova "S16c credencial na URL redigida" "senha da URL vazou" command grep -q "minhasenha123" "$sec"
+nprova "S16d --password com ESPACO redigido" "senha de --password vazou" command grep -q "segredoabc" "$sec"
+
+# S17 wt: `${PWD##*/}` gravava o basename do CWD — de `<worktree>/src/lib` saia `lib`, e o
+# agrupamento por worktree da query virava ficcao.
+sub="$TMP/raiz-git/src/lib"; mkdir -p "$sub" "$TMP/raiz-git/.git"
+wtlog="$TMP/wt.jsonl"
+( cd "$sub" && dispara 'x | y; echo "EXIT=$?"' "$wtlog" ) >/dev/null
+prova "S17 wt vem da raiz do worktree, nao do subdiretorio" \
+      "gravou '$(jq -r .wt "$wtlog" 2>/dev/null | tail -1)' em vez de raiz-git" \
+      [ "$(jq -r '.wt' "$wtlog" 2>/dev/null | tail -1)" = "raiz-git" ]
+
+# S18 PICOTE: uma unica linha truncada fazia `jq -s` abortar e o relatorio inteiro morria (exit 65)
+# — 100% do sinal perdido por 1 linha, num log que ~30 worktrees escrevem em append.
+pic="$TMP/picotado.jsonl"
+jq -n -c '{ts:"2026-08-24T10:00:00Z",ramo:"BASHISM",trecho:"a",wt:"w1"}'  > "$pic"
+jq -n -c '{ts:"2026-08-24T11:00:00Z",ramo:"BASHISM",trecho:"b",wt:"w1"}' >> "$pic"
+printf '{"ts":"2026-08-24T12:00:00Z","ra\n' >> "$pic"
+s18="$(PIPESTATUS_GUARD_LOG="$pic" bash "$QUERY" 2>&1)"; rc18=$?
+prova "S18 linha picotada nao mata o relatorio" "rc=$rc18 — perdeu o sinal todo por 1 linha" \
+      [ "$rc18" -eq 0 ]
+if printf '%s' "$s18" | command grep -q "Disparos: 2"; then ok "S18b conta as 2 boas"
+else falha "S18b" "contagem errada com linha picotada"; fi
+if printf '%s' "$s18" | command grep -q "1 de 3 linha"; then ok "S18c declara a que ignorou"
+else falha "S18c" "ignorou a linha picotada em silencio"; fi
+
+# S19 PADRAO vs INSTANCIA: 3 disparos do mesmo erro, diferindo so no arquivo de log, contavam como
+# 3 padroes distintos — e o veredito manda o humano classificar um por um.
+inst="$TMP/instancias.jsonl"
+for f in a b c; do
+  jq -n -c --arg f "$f" '{ts:"2026-08-20T10:00:00Z",ramo:"ECO-DE-EXIT",trecho:"bun test > /tmp/\($f).log 2>&1; echo EXIT=$?",wt:"w1"}' >> "$inst"
+done
+s19="$(PIPESTATUS_GUARD_LOG="$inst" bash "$QUERY" 2>&1)"
+if printf '%s' "$s19" | command grep -q "classificar os 1 padrão"; then ok "S19 agrupa instancias no MESMO padrao"
+else falha "S19" "contou instancias como padroes distintos"; fi
+
+# S20 CORTE DECLARADO: top-15 silencioso le-se como "e tudo o que existe" (CLAUDE.md, no silent caps)
+mui="$TMP/muitos.jsonl"; : > "$mui"
+for v in alfa beta gama delta epsilon zeta eta teta iota kapa lambda mu nu xi omicron pi rho sigma tau upsilon; do
+  jq -n -c --arg v "$v" '{ts:"2026-08-05T10:00:00Z",ramo:"BASHISM",trecho:"comando \($v) distinto",wt:"w1"}' >> "$mui"
+done
+s20="$(PIPESTATUS_GUARD_LOG="$mui" bash "$QUERY" 2>&1)"
+if printf '%s' "$s20" | command grep -q "e mais 5 padrão"; then ok "S20 declara os padroes cortados"
+else falha "S20" "cortou em 15 sem dizer quantos ficaram de fora"; fi
+
+# ── S21-S23: o ramo POSITIVO do veredito, que nunca tinha teste ────────────────────────────────
+# Era por isso que o bug passava: toda fixture existente ficava ABAIXO do limiar, entao o caminho
+# "Volume e janela OK" nunca era exercitado — e ele usava `total` (linhas BRUTAS) em vez de validas.
+
+# S21 satisfaz o criterio de verdade: 20 disparos validos em 20 dias ATIVOS distintos.
+bom="$TMP/limiar-bom.jsonl"; : > "$bom"
+for d in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20; do
+  jq -n -c --arg d "$d" '{ts:"2026-08-\($d)T10:00:00Z",ramo:"BASHISM",trecho:"padrao \($d) unico",wt:"w1"}' >> "$bom"
+done
+s21="$(PIPESTATUS_GUARD_LOG="$bom" bash "$QUERY" 2>&1)"
+if printf '%s' "$s21" | command grep -q "Volume e janela OK"; then ok "S21 criterio atingido libera a analise"
+else falha "S21" "20 validos em 20 dias ativos nao atingiram o criterio"; fi
+
+# S22 O BUG: 2 eventos reais + 18 linhas de OUTRO schema imprimiam "Disparos: 2", "18 ignoradas" e
+# "[x] >= 20 disparos" na mesma tela. Veredito fabricado pelo sensor antifabricacao.
+fab="$TMP/limiar-fabricado.jsonl"; : > "$fab"
+jq -n -c '{ts:"2026-08-01T10:00:00Z",ramo:"BASHISM",trecho:"real um",wt:"w"}'  >> "$fab"
+jq -n -c '{ts:"2026-08-20T10:00:00Z",ramo:"BASHISM",trecho:"real dois",wt:"w"}' >> "$fab"
+for i in $(seq 1 18); do jq -n -c --arg i "$i" '{foo:$i}' >> "$fab"; done
+s22="$(PIPESTATUS_GUARD_LOG="$fab" bash "$QUERY" 2>&1)"
+nprova "S22 linha invalida NAO conta como disparo" "18 linhas de outro schema viraram volume" \
+       sh -c 'printf "%s" "$1" | command grep -q "Volume e janela OK"' _ "$s22"
+if printf '%s' "$s22" | command grep -qE '\[ \] >= 20 disparos validos'; then ok "S22b marca o volume como NAO atingido"
+else falha "S22b" "marcou volume atingido com 2 validas"; fi
+
+# S23 DIAS ATIVOS vs calendario: 1 disparo em 01/08 + 19 no dia 20 sao DOIS dias ativos, nao 19.
+ret="$TMP/retries.jsonl"; : > "$ret"
+jq -n -c '{ts:"2026-08-01T10:00:00Z",ramo:"BASHISM",trecho:"unico do dia 1",wt:"w"}' >> "$ret"
+for i in $(seq 1 19); do
+  jq -n -c --arg i "$i" '{ts:"2026-08-20T10:00:0\($i|tonumber%10)Z",ramo:"BASHISM",trecho:"retry \($i)",wt:"w"}' >> "$ret"
+done
+s23="$(PIPESTATUS_GUARD_LOG="$ret" bash "$QUERY" 2>&1)"
+nprova "S23 retries num dia so nao viram janela de observacao" "2 dias ativos passaram por 14" \
+       sh -c 'printf "%s" "$1" | command grep -q "Volume e janela OK"' _ "$s23"
+
 # ── FALSIFICAÇÃO ───────────────────────────────────────────────────────────────────────────────
 # Sabota a redacao. Se S3 continuar verde, e porque nunca dependeu dela.
 echo "-- falsificacao: remove a redacao de segredo --"
@@ -162,8 +263,8 @@ perl -0pi -e 's/\[Bb\]earer/ZZnuncacasaZZ/' "$HOOK"
 if cmp -s "$BKP" "$HOOK"; then falha "falsificacao" "a sabotagem NAO alterou o hook — seria teatro"
 else
   LOGF="$TMP/falso.jsonl"
-  dispara 'curl -H "Authorization: Bearer sk-segredo-123" u | jq .; echo ${PIPESTATUS[0]}' "$LOGF" >/dev/null
-  if command grep -q "sk-segredo-123" "$LOGF" 2>/dev/null; then ok "sabotagem ficou VERMELHA (a redacao e mesmo o que protege)"
+  dispara 'curl -H "Authorization: Bearer zzTOKENxx987654" u | jq .; echo ${PIPESTATUS[0]}' "$LOGF" >/dev/null
+  if command grep -q "zzTOKENxx987654" "$LOGF" 2>/dev/null; then ok "sabotagem ficou VERMELHA (a redacao e mesmo o que protege)"
   else falha "falsificacao" "segredo continuou redigido sem a redacao — S3 nao prova nada"; fi
 fi
 restaura
@@ -173,6 +274,9 @@ restaura
 # — foi sorte do dado de teste, que era exatamente o erro da versao anterior.
 echo "-- falsificacao 2: desliga o teto de bytes --"
 BKP2="$(mktemp)"; cp "$HOOK" "$BKP2"
+# o trap vigente restaura $BKP (falsificacao 1), NAO $BKP2 — uma interrupcao aqui deixaria o hook
+# de verdade com TETO_LINHA=99999. Sabotagem tem de ser reversivel ate por Ctrl-C.
+trap 'cp "$BKP2" "$HOOK"; rm -f "$BKP2"; rm -rf "$TMP"' EXIT
 perl -0pi -e 's/^TETO_LINHA=511/TETO_LINHA=99999/m' "$HOOK"
 if cmp -s "$BKP2" "$HOOK"; then falha "falsificacao2" "a sabotagem NAO alterou o hook — seria teatro"
 else
@@ -183,7 +287,53 @@ else
   if [ "${m2:-0}" -ge 512 ]; then ok "sabotagem ficou VERMELHA (${m2}B — o teto e mesmo o que segura)"
   else falha "falsificacao2" "linha ficou em ${m2}B sem teto — S8 nao prova nada"; fi
 fi
-cp "$BKP2" "$HOOK"; rm -f "$BKP2"
+cp "$BKP2" "$HOOK"; rm -f "$BKP2"; trap 'rm -rf "$TMP"' EXIT
+
+# FALSIFICAÇÃO 3 — a normalizacao do trecho e o que faz "padroes distintos" contar PADRAO e nao
+# INSTANCIA, e e desse numero que o criterio de veredito depende ("classifique os N padroes").
+# Desligue-a e S19 deve voltar a ver 3 padroes onde ha 1.
+echo "-- falsificacao 3: desliga a normalizacao do trecho --"
+BKPQ="$(mktemp)"; cp "$QUERY" "$BKPQ"
+trap 'cp "$BKPQ" "$QUERY"; rm -f "$BKPQ"; rm -rf "$TMP"' EXIT
+perl -0pi -e 's/\| norma\)/)/g' "$QUERY"
+if cmp -s "$BKPQ" "$QUERY"; then
+  falha "falsificacao3" "a sabotagem NAO alterou a query — seria teatro"
+else
+  sf="$(PIPESTATUS_GUARD_LOG="$inst" bash "$QUERY" 2>&1)"
+  if printf '%s' "$sf" | command grep -q "classificar os 3 padrão"; then
+    ok "sabotagem 3 ficou VERMELHA (a normalizacao e mesmo o que agrupa)"
+  else
+    falha "falsificacao3" "sem normalizacao a contagem nao mudou — S19 nao prova nada"
+  fi
+fi
+cp "$BKPQ" "$QUERY"; rm -f "$BKPQ"; trap 'rm -rf "$TMP"' EXIT
+
+# FALSIFICAÇÃO 4 — o criterio tem de contar linhas VALIDAS. Volte-o para `total` (linhas brutas) e
+# S22 deve ficar vermelho: 2 eventos reais + 18 linhas de lixo voltariam a marcar volume atingido.
+echo "-- falsificacao 4: criterio volta a contar linha bruta --"
+BKPQ2="$(mktemp)"; cp "$QUERY" "$BKPQ2"
+trap 'cp "$BKPQ2" "$QUERY"; rm -f "$BKPQ2"; rm -rf "$TMP"' EXIT
+perl -0pi -e 's/marca "\$validas" 20/marca "\$total" 20/; s/\$\{validas:-0\}" -ge 20/\$\{total:-0\}" -ge 20/' "$QUERY"
+if cmp -s "$BKPQ2" "$QUERY"; then
+  falha "falsificacao4" "a sabotagem NAO alterou a query — seria teatro"
+else
+  # fixture ISOLANTE: tem de passar em TODAS as outras regras para que so a sabotada decida.
+  # `$fab` nao serve — ele e barrado pelos DIAS ATIVOS (2 < 14) e ficaria calado de qualquer jeito,
+  # dando verde a uma falsificacao que nao falsificou nada. Aqui: 15 validos em 15 dias distintos
+  # (dias OK, volume 15 < 20) + 10 linhas de lixo, que so o criterio BRUTO contaria.
+  iso="$TMP/isolante.jsonl"; : > "$iso"
+  for d in 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15; do
+    jq -n -c --arg d "$d" '{ts:"2026-08-\($d)T10:00:00Z",ramo:"BASHISM",trecho:"padrao \($d) unico",wt:"w1"}' >> "$iso"
+  done
+  for i in $(seq 1 10); do jq -n -c --arg i "$i" '{foo:$i}' >> "$iso"; done
+  s4="$(PIPESTATUS_GUARD_LOG="$iso" bash "$QUERY" 2>&1)"
+  if printf '%s' "$s4" | command grep -q "Volume e janela OK"; then
+    ok "sabotagem 4 ficou VERMELHA (contar bruto FABRICA o veredito — e o que S22 protege)"
+  else
+    falha "falsificacao4" "contando bruto o veredito nao mudou — S22 nao prova nada"
+  fi
+fi
+cp "$BKPQ2" "$QUERY"; rm -f "$BKPQ2"; trap 'rm -rf "$TMP"' EXIT
 
 echo
 if [ "$falhas" -eq 0 ]; then echo "PIPESTATUS-SINAL: TODOS OS TESTES PASSARAM"; exit 0; fi


### PR DESCRIPTION
O sensor do #1940 recebeu revisão adversária **pela metade** — o Codex morreu por infraestrutura nas duas tentativas e sobraram apenas algumas sondas. Refeita agora com calma, ela achou **nove defeitos**. O pior não veio do meu diagnóstico.

## O crítico

Com 2 eventos reais + 18 linhas de outro schema, o relatório imprimia **na mesma tela**:

```
AVISO: 18 de 20 linha(s) ignorada(s)
Disparos: 2   BASHISM=2
  [x] >= 20 disparos    -> hoje: 20
  => Volume e janela OK
```

O critério usava `total` (linhas **brutas**), não `validas`. **O sensor construído para não fabricar veredito fabricava o próprio.**

Passou pela suíte por um motivo estrutural: **o ramo positivo do veredito nunca teve teste.** Toda fixture existente ficava abaixo do limiar, então o caminho que continha o bug jamais era executado. S21–S23 cobrem esse ramo agora, e a falsificação 4 devolve o critério para bruto e exige vermelho.

## Os outros oito

**Do Codex:**

| defeito | por quê |
|---|---|
| "14 dias de observação" era distância entre extremos | 1 disparo em 01/08 + 19 retries em 20/08 satisfaziam janela **e** volume → agora conta **dias ativos** distintos |
| agrupamento por `trecho` sem o `ramo` | trechos colididos juntavam ramos diferentes numa classe só |
| `PIPE_BUF` **não** é limite normativo para arquivo regular | vale para pipe/FIFO; eu havia escrito como garantia. O que protege é `O_APPEND` + write único — e em NFS o append é simulado e corrompe assim mesmo |
| 3 asserções não provavam o que diziam | `all(.trecho != "")` passa com o campo **ausente** (`null != ""` é true em jq); a de agrupamento procurava só `2x`, que também aparece na seção de worktrees; a de permissão media **depois** do `chmod` |
| falsificação do teto sabotava o hook **sem trap** | Ctrl-C deixaria `TETO_LINHA=99999` no hook real |
| redação incompleta e **fail-open** | `TOKEN="ghp_x"` (valor quoted) escapava, e `${seguro:-$1}` devolvia o trecho **original** justamente quando o `sed` falhava |

**Meus, medidos antes do parecer chegar:**

- 4 formas de credencial iam para o disco em texto plano: PAT (`Authorization: token ghp_…`), `curl -u user:senha`, `postgres://u:senha@host`, `--password senha` (espaço, não `=`)
- **uma linha picotada matava o relatório inteiro** (`exit 65`) — 100% do sinal perdido, num log que ~30 worktrees escrevem em append
- `wt` gravava o basename do **CWD**: de `<worktree>/src/lib` saía `lib`
- **"padrões distintos" contava instâncias** — 3 disparos do mesmo erro viravam 3 padrões, e o veredito manda classificar um a um, o que tornava "zero FP" inatingível por construção
- **corte silencioso**: top-15 e top-8 sem dizer quantos ficaram de fora, enquanto o veredito mandava classificar "os N padrões **acima**"

## A regra que ficou

A falsificação do critério ficou **verde** porque a fixture era barrada por **outra** regra (dias ativos), não pela que eu havia desligado. Foi a **terceira vez na mesma sessão** — antes disso, o teto passou por um vetor que parava sozinho, e a do "último comando" mediu um caso defendido por outra exigência.

**A fixture de uma falsificação precisa passar em todas as outras regras, para que só a sabotada decida.** Verde por motivo alheio é indistinguível de prova.

## Validação

| gate | resultado |
|---|---|
| `test-pipestatus-guard-sinal.sh` | **43 asserções** |
| falsificações | **4**, todas vermelhas quando sabotadas |
| `bun run test:hooks` | `RC=0`, 0 falhas |
| `shellcheck` (4 arquivos tocados) | `rc=0` |

**Recomendação defensiva do Codex, que eu endosso: manter como AVISO.** O log é piso de contagem de eventos, não evidência suficiente para `deny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
