### PR TITLE
fix(gates): 7 asserts money-path provavam que o helper é CHAMADO — não que o produto dele chega a alguém [varredura da classe do #1985]

### DIFF
--- a/docs/agent/money-path.md
+++ b/docs/agent/money-path.md
@@ -231,6 +231,20 @@ Helper TS puro (testado com vitest) **espelhado verbatim** no edge (Deno não im
 
 Edge só-TS (sem contraparte SQL): a paridade vira **textual no CI** — bloco entre `// MIRROR-START/END` comparado normalizado src×edge (pega reescrita do Lovable no deploy) — **mais** uma **canária comportamental** `{canary:true}` staff-gated que roda o helper REAL deployado com fixture fixo e retorna `{resolved, expected, ok}`. Probe HTTP = única prova do COMPORTAMENTO em produção: o guard textual cobre a FONTE, a canária cobre o DEPLOY. ⚠️ A canária prova "helper deployado + lógica certa", **não** que o real-path usa o helper (isso é o guard textual + paridade). Ex.: merge de preço do `analyze-unified-order` (#1089); `identidade_probe` (`omie-vendas-sync`); `doc_ambiguo_probe` (`omie-analytics-sync`, P1b — indispensável ali: a ausência do helper é invisível no dado, a proof-table só encolhe com duplicata-CNPJ real na conta, que não há).
 
+**"Define E chama" não prova que o produto do helper CHEGA a alguém.** O guard usual do espelho —
+`expect(src).toMatch(/helper\(/)` mais a contagem de ≥2 menções — casa o NOME e conclui o EFEITO.
+Quando o helper é PURO (o valor de RETORNO é o produto), `helper(args);` como sentença solta calcula
+tudo e joga fora, e o gate fica verde sobre a edge que voltou ao comportamento proibido. Medido em
+2026-08-25: 7 asserts do `edge-money-path-invariants` aprovavam a forma descartada (identidade
+self-service, fail-closed de doc ambíguo, classificação de lote, owner-map, elegibilidade e ordem da
+fila de leadtime, acumulador de uso de cache). Ancore na FRONTEIRA com `vereditoFronteira` de
+`@/lib/gates/retorno-consumido` — assert POSICIONAL, porque enumerar embrulhos (`const X = helper(`)
+reprova predicado de `.filter`, comparador de `.sort`, propriedade de objeto e ramo de ternário, e o
+conserto de um gate que reprova código correto é sempre afrouxá-lo. Cuidado gêmeo: `descartes === 0`
+sozinho aprova ZERO chamadas — o veredito trata "não encontrei" como vermelho, senão uma renomeação
+apaga o guard em silêncio. Não vale para função chamada pelo EFEITO colateral (`await derivar(...)`
+solto é legítimo): ali o assert certo é o posicional do próprio site.
+
 ## A MESMA exceção pode ser defesa num writer e defeito em outro — a diferença é a EVIDÊNCIA
 
 `omie_customer_account_map` tem duas UNIQUEs (`(user_id,account)` e `(codigo,account)`), e dois writers gravavam com o mesmo `ON CONFLICT (user_id, account)`. Quando um código muda de dono, o `23505` da segunda UNIQUE não é tratado. Nos dois writers é a mesma SQLSTATE — e o veredito é oposto:

--- a/docs/historico/verificar-sonda-versao.md
+++ b/docs/historico/verificar-sonda-versao.md
@@ -353,3 +353,57 @@ Gate que casa o **nome** de uma função e conclui que o **efeito** dela acontec
 presente prova montagem, não entrega; `track(` presente prova chamada, não evento gravado. Quando o
 valor de retorno É o produto, o assert tem de seguir o valor até a fronteira (o `return`, o `await`, o
 `INSERT`) — senão o gate mede o texto certo e afirma a coisa errada.
+
+## 10. A varredura da §9: 7 irmãos vivos, e o suspeito nomeado não existia (2026-08-25)
+
+Assinatura rodada em `src/**/*.test.ts(x)`, `supabase/functions/**/*_test.ts` e `scripts/`: regex ou
+`includes` que casa `<identificador>(` contra código lido como TEXTO. 63 arquivos leem fonte com
+`readFileSync`/`Deno.readTextFileSync`; a assinatura casou 5 deles.
+
+**Triagem — o critério é "o valor de RETORNO da função casada é o produto que o teste afirma?"**, não
+a forma do assert. `classificarSonda(`/`avaliarPagina(` são assert de FORMA; `escritaCritica(` e
+`await deriveOmieAccountIdentity(...)` solto são a chamada COMO efeito (não há retorno-produto).
+Esses são falso-positivo da assinatura e ficaram como estão.
+
+**7 afetados, todos no `edge-money-path-invariants.test.ts`** — medidos, não deduzidos: montada a
+forma "calcula e descarta" em código REAL das edges, o gate deu **237 passed, exit 0**.
+
+| Helper | Edge | O que o gate deixava passar |
+| --- | --- | --- |
+| `decidirIdentidadeSelfService` | `omie-sync` | identidade self-service decidida e jogada fora |
+| `docsComCodigoAmbiguoNoOmie` | `omie-analytics-sync` | fail-closed do P1b evapora → last-write-wins |
+| `classificarLoteProof` | `omie-analytics-sync` | lote cru no upsert (23505 derruba o run) |
+| `buildOwnerMap` | `ai-ops-agent` | `farmer_id` saindo de mapa vazio |
+| `skuItemsElegivel` | `omie-sync-sku-items` | filtro sempre-true → poison entope a fila |
+| `skuItemsCompararFila` | `omie-sync-sku-items` | `sort` vira no-op → antigas nunca alcançadas |
+| `acumularUsoCache` | `analyze-unified-order` | alerta de escrita-paga-sem-leitura nunca dispara |
+
+Já-corretos, e é deles que saiu o formato do conserto: `farmer_id: resolveOwner(...)` e
+`criarPedidoVenda(supabaseAdmin, sales_order_id, ident.codigo_cliente, ...)` — asserts POSICIONAIS.
+`agregarItensRecebimento` reprovou a sabotagem por ACIDENTE de âncora textual (`expected '' not to
+be ''`), não pelo mérito: pega, mas não explica.
+
+**O suspeito que a §9 nomeou — `track(` presente ⇒ "evento gravado" — NÃO existe.** Zero gates
+textuais sobre `track(` no repo. Era hipótese, não medição; fica registrado para ninguém re-varrer.
+(De quebra, o #1984 mostrou que o canal PostHog é censurado por bloqueador de rastreador no cliente,
+então um gate assim seria cego duas vezes: no texto e no dado.)
+
+### O critério fraco tinha um buraco, e a falsificação o encontrou
+
+Primeira versão do gate exigia "≥1 chamada consome o retorno". Na falsificação, **5 de 7** acusaram:
+`decidirIdentidadeSelfService` é chamado 2x em `omie-sync`, e sabotar só a primeira passava. Medição
+dos 9 helpers puros na `main`: **0 descartes em todos** ⇒ o critério virou "NENHUMA chamada descarta",
+sem custo de falso-positivo. Falsificação final: **7/7 vermelhas**, cada uma citando a marca do ramo
+("N de M chamada(s) DESCARTAM o retorno"). Suíte canônica na árvore restaurada: 740 arquivos,
+7176 passed, exit 0.
+
+**A armadilha se repetiu DENTRO do conserto, duas vezes** — vale mais que o conserto:
+1. A primeira calibração negativa extraía o nome do alvo por regex do próprio fixture. Nome errado ⇒
+   zero chamadas ⇒ zero consumos ⇒ **verde por cegueira**. Nome agora vai explícito, com sentinela.
+2. `expect(descartes).toBe(0)` aprova zero chamadas. O assert virou um VEREDITO em string, em que
+   "NENHUMA chamada encontrada" é vermelho — senão renomear o helper apaga o guard em silêncio.
+
+Gate: `src/lib/gates/retorno-consumido.ts`, calibrado nos dois sentidos em
+`src/lib/gates/__tests__/retorno-consumido.test.ts` (28 casos: 7 formas de descarte que reprovam, 6
+formas legítimas REAIS + 1 inventada que aprovam, cegueira, 1-de-2, definição≠chamada, e as 9 edges
+de hoje).

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { removerComentarios } from '@/lib/gates/limpeza-fonte';
+import { chamadasQueConsomemRetorno, explicarDescarte } from '@/lib/gates/retorno-consumido';
 
 // repo root: src/__tests__ → src → repo (2 níveis).
 const CWD = resolve(__dirname, '../..');
@@ -194,6 +195,13 @@ describe('guardrail money-path: analyze-unified-order mantém o prompt caching L
       codigo,
       'sumiu o acumulador por variante — uma chamada isolada não distingue cold miss de miss permanente',
     ).toMatch(/acumularUsoCache\(/);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/acumularUsoCache\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `acumularUsoCache(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(codigo, 'acumularUsoCache'),
+      `REGRESSÃO: o acumulador é calculado e DESCARTADO — o alerta de escrita-sem-leitura nunca dispara — ${explicarDescarte(codigo, 'acumularUsoCache')}`,
+    ).toBeGreaterThan(0);
     expect(codigo, 'sumiu o alerta de escrita paga sem nenhuma leitura').toMatch(
       /pagaEscritaSemNuncaLer\(\s*acc\s*\)/,
     );
@@ -545,6 +553,13 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
       semProbe,
       'REGRESSÃO: a ÚNICA chamada a docsComCodigoAmbiguoNoOmie está na canária — o real-path (syncCustomers) parou de aplicar o fail-closed',
     ).toMatch(/docsComCodigoAmbiguoNoOmie\(/);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/docsComCodigoAmbiguoNoOmie\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `docsComCodigoAmbiguoNoOmie(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(semProbe, 'docsComCodigoAmbiguoNoOmie'),
+      `REGRESSÃO: o real-path calcula os docs ambíguos e DESCARTA — o fail-closed do P1b evapora — ${explicarDescarte(semProbe, 'docsComCodigoAmbiguoNoOmie')}`,
+    ).toBeGreaterThan(0);
     expect(
       count(src, 'docsComCodigoAmbiguoNoOmie'),
       'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
@@ -842,6 +857,13 @@ describe('guardrail money-path: omie-sync self-service USA view fresca account-c
       src,
       'REGRESSÃO: edge não chama mais decidirIdentidadeSelfService — voltou a usar o espelho direto?',
     ).toMatch(/decidirIdentidadeSelfService\(/);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/decidirIdentidadeSelfService\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `decidirIdentidadeSelfService(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(src, 'decidirIdentidadeSelfService'),
+      `REGRESSÃO: a identidade é decidida e DESCARTADA — o espelho direto volta a mandar — ${explicarDescarte(src, 'decidirIdentidadeSelfService')}`,
+    ).toBeGreaterThan(0);
     expect(
       count(src, 'decidirIdentidadeSelfService'),
       'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
@@ -1601,6 +1623,13 @@ describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opç
   it('o edge USA o helper espelhado (define buildOwnerMap E chama), ≥2 menções', () => {
     expect(src, 'edge não define mais o helper espelhado owner-map').toMatch(/function buildOwnerMap/);
     expect(src, 'edge não chama mais buildOwnerMap — voltou à lógica inline?').toMatch(/buildOwnerMap\(/);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/buildOwnerMap\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `buildOwnerMap(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(src, 'buildOwnerMap'),
+      `REGRESSÃO: o owner-map é construído e DESCARTADO — farmer_id volta a sair de mapa vazio — ${explicarDescarte(src, 'buildOwnerMap')}`,
+    ).toBeGreaterThan(0);
     expect(src, 'edge não chama mais resolveOwner').toMatch(/resolveOwner\(/);
     expect(
       count(src, 'buildOwnerMap'),
@@ -1641,6 +1670,20 @@ describe('guardrail money-path: omie-sync-sku-items (fila de leadtime)', () => {
       .toMatch(/skuItemsElegivel\(/);
     expect(src, 'REGRESSÃO: edge não ordena mais a fila — antigas voltam a nunca ser alcançadas')
       .toMatch(/skuItemsCompararFila\(/);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/skuItemsElegivel\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `skuItemsElegivel(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(src, 'skuItemsElegivel'),
+      `REGRESSÃO: a elegibilidade é avaliada e DESCARTADA — poison volta a entupir a fila — ${explicarDescarte(src, 'skuItemsElegivel')}`,
+    ).toBeGreaterThan(0);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/skuItemsCompararFila\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `skuItemsCompararFila(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(src, 'skuItemsCompararFila'),
+      `REGRESSÃO: a comparação roda e é DESCARTADA — o sort vira no-op e as antigas nunca são alcançadas — ${explicarDescarte(src, 'skuItemsCompararFila')}`,
+    ).toBeGreaterThan(0);
   });
 
   it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
@@ -3255,6 +3298,13 @@ describe('guardrail money-path: P1-c transferência de código (writer NÃO tran
       'REGRESSÃO: a ÚNICA chamada a classificarLoteProof está na canária — o real-path (syncCustomers) parou ' +
         'de classificar e o lote volta cru para o upsert',
     ).toMatch(/classificarLoteProof\(/);
+    // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/classificarLoteProof\(/)` prova que
+    // a função é CHAMADA, nunca que o produto dela chegou a alguém. `classificarLoteProof(args);` solto ficava
+    // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
+    expect(
+      chamadasQueConsomemRetorno(semProbe, 'classificarLoteProof'),
+      `REGRESSÃO: o lote é classificado e DESCARTADO — vai cru para o upsert (23505 derruba o run) — ${explicarDescarte(semProbe, 'classificarLoteProof')}`,
+    ).toBeGreaterThan(0);
   });
 
   it('a canária existe e discrimina: tem o caso de transferência E o de refresh (falsificam-se mutuamente)', () => {

--- a/src/__tests__/edge-money-path-invariants.test.ts
+++ b/src/__tests__/edge-money-path-invariants.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { removerComentarios } from '@/lib/gates/limpeza-fonte';
-import { chamadasQueConsomemRetorno, explicarDescarte } from '@/lib/gates/retorno-consumido';
+import { vereditoFronteira } from '@/lib/gates/retorno-consumido';
 
 // repo root: src/__tests__ → src → repo (2 níveis).
 const CWD = resolve(__dirname, '../..');
@@ -199,9 +199,9 @@ describe('guardrail money-path: analyze-unified-order mantém o prompt caching L
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `acumularUsoCache(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(codigo, 'acumularUsoCache'),
-      `REGRESSÃO: o acumulador é calculado e DESCARTADO — o alerta de escrita-sem-leitura nunca dispara — ${explicarDescarte(codigo, 'acumularUsoCache')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(codigo, 'acumularUsoCache'),
+      'REGRESSÃO: o acumulador é calculado e DESCARTADO — o alerta de escrita-sem-leitura nunca dispara',
+    ).toBe('ok');
     expect(codigo, 'sumiu o alerta de escrita paga sem nenhuma leitura').toMatch(
       /pagaEscritaSemNuncaLer\(\s*acc\s*\)/,
     );
@@ -557,9 +557,9 @@ describe('guardrail money-path: P1b doc-ambíguo-Omie (syncCustomers USA o helpe
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `docsComCodigoAmbiguoNoOmie(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(semProbe, 'docsComCodigoAmbiguoNoOmie'),
-      `REGRESSÃO: o real-path calcula os docs ambíguos e DESCARTA — o fail-closed do P1b evapora — ${explicarDescarte(semProbe, 'docsComCodigoAmbiguoNoOmie')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(semProbe, 'docsComCodigoAmbiguoNoOmie'),
+      'REGRESSÃO: o real-path calcula os docs ambíguos e DESCARTA — o fail-closed do P1b evapora',
+    ).toBe('ok');
     expect(
       count(src, 'docsComCodigoAmbiguoNoOmie'),
       'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
@@ -861,9 +861,9 @@ describe('guardrail money-path: omie-sync self-service USA view fresca account-c
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `decidirIdentidadeSelfService(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(src, 'decidirIdentidadeSelfService'),
-      `REGRESSÃO: a identidade é decidida e DESCARTADA — o espelho direto volta a mandar — ${explicarDescarte(src, 'decidirIdentidadeSelfService')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(src, 'decidirIdentidadeSelfService'),
+      'REGRESSÃO: a identidade é decidida e DESCARTADA — o espelho direto volta a mandar',
+    ).toBe('ok');
     expect(
       count(src, 'decidirIdentidadeSelfService'),
       'helper deve ser DEFINIDO e CHAMADO (≥2 menções)',
@@ -1627,9 +1627,9 @@ describe('guardrail money-path: ai-ops-agent resolve farmer_id da carteira (Opç
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `buildOwnerMap(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(src, 'buildOwnerMap'),
-      `REGRESSÃO: o owner-map é construído e DESCARTADO — farmer_id volta a sair de mapa vazio — ${explicarDescarte(src, 'buildOwnerMap')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(src, 'buildOwnerMap'),
+      'REGRESSÃO: o owner-map é construído e DESCARTADO — farmer_id volta a sair de mapa vazio',
+    ).toBe('ok');
     expect(src, 'edge não chama mais resolveOwner').toMatch(/resolveOwner\(/);
     expect(
       count(src, 'buildOwnerMap'),
@@ -1674,16 +1674,16 @@ describe('guardrail money-path: omie-sync-sku-items (fila de leadtime)', () => {
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `skuItemsElegivel(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(src, 'skuItemsElegivel'),
-      `REGRESSÃO: a elegibilidade é avaliada e DESCARTADA — poison volta a entupir a fila — ${explicarDescarte(src, 'skuItemsElegivel')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(src, 'skuItemsElegivel'),
+      'REGRESSÃO: a elegibilidade é avaliada e DESCARTADA — poison volta a entupir a fila',
+    ).toBe('ok');
     // FRONTEIRA (classe do #1985, medida de novo em 2026-08-25): `toMatch(/skuItemsCompararFila\(/)` prova que
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `skuItemsCompararFila(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(src, 'skuItemsCompararFila'),
-      `REGRESSÃO: a comparação roda e é DESCARTADA — o sort vira no-op e as antigas nunca são alcançadas — ${explicarDescarte(src, 'skuItemsCompararFila')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(src, 'skuItemsCompararFila'),
+      'REGRESSÃO: a comparação roda e é DESCARTADA — o sort vira no-op e as antigas nunca são alcançadas',
+    ).toBe('ok');
   });
 
   it('PARIDADE: o bloco espelhado no edge é IDÊNTICO ao helper de src/ (pega reversão do Lovable)', () => {
@@ -3302,9 +3302,9 @@ describe('guardrail money-path: P1-c transferência de código (writer NÃO tran
     // a função é CHAMADA, nunca que o produto dela chegou a alguém. `classificarLoteProof(args);` solto ficava
     // VERDE aqui. O assert é POSICIONAL — qualquer posição que RECEBA o retorno passa.
     expect(
-      chamadasQueConsomemRetorno(semProbe, 'classificarLoteProof'),
-      `REGRESSÃO: o lote é classificado e DESCARTADO — vai cru para o upsert (23505 derruba o run) — ${explicarDescarte(semProbe, 'classificarLoteProof')}`,
-    ).toBeGreaterThan(0);
+      vereditoFronteira(semProbe, 'classificarLoteProof'),
+      'REGRESSÃO: o lote é classificado e DESCARTADO — vai cru para o upsert (23505 derruba o run)',
+    ).toBe('ok');
   });
 
   it('a canária existe e discrimina: tem o caso de transferência E o de refresh (falsificam-se mutuamente)', () => {

--- a/src/lib/gates/__tests__/retorno-consumido.test.ts
+++ b/src/lib/gates/__tests__/retorno-consumido.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { chamadasQueConsomemRetorno, usosDoRetorno } from '../retorno-consumido';
+import { usosDoRetorno, vereditoFronteira } from '../retorno-consumido';
 
 const CWD = resolve(__dirname, '../../../..');
 const read = (rel: string) => readFileSync(resolve(CWD, rel), 'utf8');
@@ -28,13 +28,13 @@ describe('retorno-consumido: as formas que CALCULAM E DESCARTAM têm de reprovar
     it(`reprova: ${forma}`, () => {
       // Sentinela: sem isto, um fixture que perdesse a chamada passaria por CEGUEIRA (0 de 0).
       expect(usosDoRetorno(codigo, nome), `fixture "${forma}" não contém chamada a ${nome}`).not.toHaveLength(0);
-      expect(chamadasQueConsomemRetorno(codigo, nome), `"${forma}" deveria ser 0 consumos`).toBe(0);
+      expect(vereditoFronteira(codigo, nome), `"${forma}" deveria ser reprovada`).not.toBe('ok');
     });
   }
 
   it('reprova a chamada certa que existe SÓ em comentário (o stripper compartilhado é obrigatório)', () => {
     const soComentario = '// const x = decidirIdentidadeSelfService(args);\ndecidirIdentidadeSelfService(args);';
-    expect(chamadasQueConsomemRetorno(soComentario, 'decidirIdentidadeSelfService')).toBe(0);
+    expect(vereditoFronteira(soComentario, 'decidirIdentidadeSelfService')).not.toBe('ok');
   });
 });
 
@@ -53,13 +53,30 @@ describe('retorno-consumido: as formas LEGÍTIMAS medidas no repo têm de aprova
 
   for (const [forma, nome, codigo] of LEGITIMAS) {
     it(`aprova ${forma}`, () => {
-      expect(chamadasQueConsomemRetorno(codigo, nome), `forma ${forma} reprovada — o gate ficou APERTADO demais`).toBeGreaterThan(0);
+      expect(vereditoFronteira(codigo, nome), `forma ${forma} reprovada — o gate ficou APERTADO demais`).toBe('ok');
     });
   }
 
   it('aprova uma forma INVENTADA (o gate é posicional, não uma lista de embrulhos)', () => {
     const nova = 'const r = pipe(dados, (d) => classificarLoteProof(d), coletar);\nuse(r);';
-    expect(chamadasQueConsomemRetorno(nova, 'classificarLoteProof')).toBeGreaterThan(0);
+    expect(vereditoFronteira(nova, 'classificarLoteProof')).toBe('ok');
+  });
+
+  it('VERMELHO quando o helper sumiu: 0 chamadas não é aprovação (a classe, de novo)', () => {
+    // `descartes === 0` sozinho aprovaria isto — uma renomeação apagaria o guard em silêncio.
+    expect(vereditoFronteira('const x = outraCoisa(1);\nuse(x);', 'buildOwnerMap')).toContain('NENHUMA chamada');
+  });
+
+  it('VERMELHO com UMA das duas chamadas descartada (o critério fraco "≥1 consome" passaria)', () => {
+    // Medido em omie-sync: `decidirIdentidadeSelfService` é chamado 2x. Sabotar só a primeira
+    // deixava o gate verde enquanto o critério era "alguma chamada consome".
+    const uma = [
+      'const viaView = { tipo: "cru" } as never;',
+      'decidirIdentidadeSelfService({ viewRow });',
+      'const viaOmie = decidirIdentidadeSelfService({ viewRow: null });',
+      'return viaView ?? viaOmie;',
+    ].join('\n');
+    expect(vereditoFronteira(uma, 'decidirIdentidadeSelfService')).toContain('1 de 2');
   });
 
   it('não confunde a DEFINIÇÃO do helper com uma chamada', () => {
@@ -81,12 +98,22 @@ describe('retorno-consumido: as edges REAIS de hoje passam (controle da varredur
     ['supabase/functions/omie-sync-sku-items/index.ts', 'skuItemsCompararFila'],
     ['supabase/functions/omie-sync-sku-items/index.ts', 'agregarItensRecebimento'],
     ['supabase/functions/analyze-unified-order/index.ts', 'acumularUsoCache'],
-    ['supabase/functions/omie-vendas-sync/index.ts', 'deriveOmieAccountIdentity'],
   ];
 
   for (const [arquivo, nome] of REAIS) {
     it(`${nome} entrega o retorno em ${arquivo.split('/')[2]}`, () => {
-      expect(chamadasQueConsomemRetorno(read(arquivo), nome)).toBeGreaterThan(0);
+      expect(vereditoFronteira(read(arquivo), nome)).toBe('ok');
     });
   }
+
+  it('deriveOmieAccountIdentity tem 1 descarte LEGÍTIMO — e é por isso que ele não usa este gate', () => {
+    // `omie-vendas-sync:3092` chama a derivação pelo EFEITO (revalidar a edição), sem produto a
+    // receber; o site do produto é o `const ident = await ...` que alimenta `criarPedidoVenda`.
+    // Aplicar o veredito forte aqui reprovaria código correto — o assert certo para ele é o
+    // POSICIONAL que já existe no gate money-path. Este `it` pina a contagem: virar 2 descartes
+    // significa que o site do produto caiu.
+    const usos = usosDoRetorno(read('supabase/functions/omie-vendas-sync/index.ts'), 'deriveOmieAccountIdentity');
+    expect(usos.filter((u) => !u.consumido)).toHaveLength(1);
+    expect(usos.filter((u) => u.consumido), 'sumiu o site que ALIMENTA criarPedidoVenda').not.toHaveLength(0);
+  });
 });

--- a/src/lib/gates/__tests__/retorno-consumido.test.ts
+++ b/src/lib/gates/__tests__/retorno-consumido.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { chamadasQueConsomemRetorno, usosDoRetorno } from '../retorno-consumido';
+
+const CWD = resolve(__dirname, '../../../..');
+const read = (rel: string) => readFileSync(resolve(CWD, rel), 'utf8');
+
+describe('retorno-consumido: as formas que CALCULAM E DESCARTAM têm de reprovar', () => {
+  // Estas são as sabotagens que ficaram VERDES no gate money-path em 2026-08-25 — a medição que
+  // originou este helper. Cada uma chama o helper (o gate antigo casava `nome(` e aprovava) e
+  // joga o produto fora.
+  // O nome do alvo vai EXPLÍCITO. Extraí-lo do próprio código por regex já foi tentado aqui e é a
+  // mesma classe que este arquivo mata: um nome errado casaria zero chamadas, `consumos` daria 0,
+  // e o teste passaria VERDE sem nunca ter exercitado o helper. O `it` de sentinela abaixo prova
+  // que cada fixture realmente contém a chamada que diz conter.
+  const DESCARTES: [string, string, string][] = [
+    ['sentença solta', 'buildOwnerMap', 'buildOwnerMap(assignmentsRaw);\nconst ownerMap = new Map();\nuse(ownerMap);'],
+    ['solta dentro de bloco', 'skuItemsElegivel', '.filter((n) => { skuItemsElegivel(c.get(n.id), agora); return true; })'],
+    ['solta em comparador', 'skuItemsCompararFila', '.sort((a, b) => {\n  skuItemsCompararFila(a, b);\n  return 0;\n});'],
+    ['void', 'classificarLoteProof', 'void classificarLoteProof(candidatos, porCodigo, porUser);'],
+    ['atribui e IGNORA a variável', 'agregarItensRecebimento', 'const agregados = agregarItensRecebimento(resolvidos);\nfor (const ag of resolvidos) { upsert(ag); }'],
+    ['atribui e ignora (const depois)', 'classificarLoteProof', 'const decisoes = classificarLoteProof(x);\nconst mapRows = candidatos.filter(() => true);'],
+    ['acumula e descarta', 'acumularUsoCache', 'const acc = null as never;\nacumularUsoCache(acc0, uso);\nreportar(acc);'],
+  ];
+
+  for (const [forma, nome, codigo] of DESCARTES) {
+    it(`reprova: ${forma}`, () => {
+      // Sentinela: sem isto, um fixture que perdesse a chamada passaria por CEGUEIRA (0 de 0).
+      expect(usosDoRetorno(codigo, nome), `fixture "${forma}" não contém chamada a ${nome}`).not.toHaveLength(0);
+      expect(chamadasQueConsomemRetorno(codigo, nome), `"${forma}" deveria ser 0 consumos`).toBe(0);
+    });
+  }
+
+  it('reprova a chamada certa que existe SÓ em comentário (o stripper compartilhado é obrigatório)', () => {
+    const soComentario = '// const x = decidirIdentidadeSelfService(args);\ndecidirIdentidadeSelfService(args);';
+    expect(chamadasQueConsomemRetorno(soComentario, 'decidirIdentidadeSelfService')).toBe(0);
+  });
+});
+
+describe('retorno-consumido: as formas LEGÍTIMAS medidas no repo têm de aprovar', () => {
+  // Enumerar embrulhos reprova código correto, e o conserto disso é sempre afrouxar o gate
+  // (#1985). Estas seis formas são TEXTO REAL das edges — se o helper reprovar qualquer uma,
+  // ele está errado, não a edge.
+  const LEGITIMAS: [string, string, string][] = [
+    ['A: atribui e lê', 'agregarItensRecebimento', 'const agregados = agregarItensRecebimento(resolvidos);\nsummary.fundidos += resolvidos.length - agregados.length;'],
+    ['B: predicado de .filter', 'skuItemsElegivel', '.filter((n) => skuItemsElegivel(controleMap.get(n.id), agoraMs))'],
+    ['C: comparador de .sort multi-linha', 'skuItemsCompararFila', 'const fila = rows.sort((a, b) =>\n  skuItemsCompararFila(\n    { id: a.id },\n    { id: b.id },\n  )\n);'],
+    ['D: valor de propriedade', 'resolveOwner', 'decisions.push({\n  farmer_id: resolveOwner(ownerMap, m.customer_user_id, null),\n});'],
+    ['E: await atribuído', 'deriveOmieAccountIdentity', 'const ident = await deriveOmieAccountIdentity(supabaseAdmin, { doc });\nawait criarPedidoVenda(ident.codigo_cliente);'],
+    ['F: ramo de ternário', 'decidirIdentidadeSelfService', 'const via = temView\n  ? decidirIdentidadeSelfService({ viewRow })\n  : null;\nreturn via;'],
+  ];
+
+  for (const [forma, nome, codigo] of LEGITIMAS) {
+    it(`aprova ${forma}`, () => {
+      expect(chamadasQueConsomemRetorno(codigo, nome), `forma ${forma} reprovada — o gate ficou APERTADO demais`).toBeGreaterThan(0);
+    });
+  }
+
+  it('aprova uma forma INVENTADA (o gate é posicional, não uma lista de embrulhos)', () => {
+    const nova = 'const r = pipe(dados, (d) => classificarLoteProof(d), coletar);\nuse(r);';
+    expect(chamadasQueConsomemRetorno(nova, 'classificarLoteProof')).toBeGreaterThan(0);
+  });
+
+  it('não confunde a DEFINIÇÃO do helper com uma chamada', () => {
+    const def = 'function docsComCodigoAmbiguoNoOmie(regs: Reg[]) {\n  return new Set();\n}';
+    expect(usosDoRetorno(def, 'docsComCodigoAmbiguoNoOmie')).toHaveLength(0);
+  });
+});
+
+describe('retorno-consumido: as edges REAIS de hoje passam (controle da varredura de 2026-08-25)', () => {
+  // Sentinela de leitura + prova de que o helper não reprova a `main` íntegra. Se um destes
+  // quebrar sem que ninguém tenha mexido no helper, a edge REGREDIU — é o achado, não o ruído.
+  const REAIS: [string, string][] = [
+    ['supabase/functions/omie-analytics-sync/index.ts', 'classificarLoteProof'],
+    ['supabase/functions/omie-analytics-sync/index.ts', 'docsComCodigoAmbiguoNoOmie'],
+    ['supabase/functions/ai-ops-agent/index.ts', 'buildOwnerMap'],
+    ['supabase/functions/ai-ops-agent/index.ts', 'resolveOwner'],
+    ['supabase/functions/omie-sync/index.ts', 'decidirIdentidadeSelfService'],
+    ['supabase/functions/omie-sync-sku-items/index.ts', 'skuItemsElegivel'],
+    ['supabase/functions/omie-sync-sku-items/index.ts', 'skuItemsCompararFila'],
+    ['supabase/functions/omie-sync-sku-items/index.ts', 'agregarItensRecebimento'],
+    ['supabase/functions/analyze-unified-order/index.ts', 'acumularUsoCache'],
+    ['supabase/functions/omie-vendas-sync/index.ts', 'deriveOmieAccountIdentity'],
+  ];
+
+  for (const [arquivo, nome] of REAIS) {
+    it(`${nome} entrega o retorno em ${arquivo.split('/')[2]}`, () => {
+      expect(chamadasQueConsomemRetorno(read(arquivo), nome)).toBeGreaterThan(0);
+    });
+  }
+});

--- a/src/lib/gates/retorno-consumido.ts
+++ b/src/lib/gates/retorno-consumido.ts
@@ -1,0 +1,106 @@
+// Gate compartilhado contra a classe "casa o NOME e conclui o EFEITO" (assinatura em
+// docs/historico/verificar-sonda-versao.md §9; primeiro caso fechado no #1985).
+//
+// O modo de falha: um gate textual afirma `expect(src).toMatch(/helperPuro\(/)` e conclui daí que
+// o produto do helper chegou ao seu destino. Não chega. Quando o helper é PURO — o valor de
+// RETORNO é o produto —, `helperPuro(args);` como sentença solta calcula tudo e joga fora, e o
+// gate fica VERDE sobre um edge que voltou ao comportamento que o gate existe para proibir.
+// Medido em 2026-08-25: 7 asserts do `edge-money-path-invariants` aprovavam a forma descartada
+// (identidade self-service, fail-closed de doc ambíguo, classificação de lote, owner-map,
+// elegibilidade/ordem da fila de leadtime, acumulador de uso de cache).
+//
+// Por que POSICIONAL e não uma lista de embrulhos: enumerar `const X = helper(` reprova as formas
+// legítimas REAIS (predicado de `.filter`, comparador de `.sort`, valor de propriedade, ternário),
+// e o conserto de um gate que reprova código correto é sempre AFROUXÁ-LO (lição do #1985). Aqui a
+// pergunta é uma só: a chamada está numa posição em que alguém RECEBE o valor?
+import { removerComentarios } from './limpeza-fonte';
+
+/** Delimitadores de sentença. Um prefixo vazio até um deles = a chamada é sentença solta. */
+const DELIMITADORES = ';{}';
+
+export type UsoDoRetorno = {
+  /** Índice da chamada na fonte JÁ SEM COMENTÁRIOS. */
+  indice: number;
+  consumido: boolean;
+  /** Prefixo da sentença até a chamada — é o que decide, e o que a mensagem de erro mostra. */
+  prefixo: string;
+  motivo: 'sentenca-solta' | 'atribuido-e-ignorado' | 'consumido';
+};
+
+/** Fim da sentença que contém `i`: o próximo delimitador de topo. */
+function fimDaSentenca(fonte: string, i: number): number {
+  for (let j = i; j < fonte.length; j++) {
+    if (DELIMITADORES.includes(fonte[j])) return j;
+  }
+  return fonte.length;
+}
+
+/**
+ * Todas as chamadas a `nome(` na fonte, cada uma com o veredito "alguém recebe o retorno?".
+ *
+ * A fonte é limpa de comentários com o stripper COMPARTILHADO — a prosa que explica a armadilha
+ * cita a forma proibida, e sem a limpeza o gate leria o comentário como código (classe de
+ * 2026-08-20, `limpeza-fonte`).
+ */
+export function usosDoRetorno(fonteCrua: string, nome: string): UsoDoRetorno[] {
+  const fonte = removerComentarios(fonteCrua);
+  const chamada = new RegExp(`\\b${nome.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\(`, 'g');
+  const usos: UsoDoRetorno[] = [];
+
+  for (const m of fonte.matchAll(chamada)) {
+    const i = m.index;
+    // Uma DEFINIÇÃO (`function nome(`, `const nome = (`) não é chamada — não tem retorno a consumir.
+    const antes = fonte.slice(Math.max(0, i - 40), i);
+    if (/\b(function|class)\s+$/.test(antes) || /\b(const|let|var)\s+$/.test(antes)) continue;
+
+    let ini = i - 1;
+    while (ini >= 0 && !DELIMITADORES.includes(fonte[ini])) ini--;
+    const prefixo = fonte.slice(ini + 1, i).trim();
+
+    // `await`/`void`/`return await` são transparentes: o que importa é o que sobra à esquerda.
+    const nu = prefixo.replace(/\b(await|void)\b/g, '').trim();
+
+    if (nu === '') {
+      usos.push({ indice: i, consumido: false, prefixo, motivo: 'sentenca-solta' });
+      continue;
+    }
+
+    // Atribuição: alguém recebe, mas só conta se a variável for LIDA depois. `const x = helper();
+    // const y = dadoCru;` calcula e descarta com um passo a mais.
+    const atrib = /\b(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*(?::[^=]*)?=$/.exec(nu);
+    if (atrib) {
+      const alvo = atrib[1];
+      const depois = fonte.slice(fimDaSentenca(fonte, i));
+      const lido = new RegExp(`\\b${alvo}\\b`).test(depois);
+      usos.push({
+        indice: i,
+        consumido: lido,
+        prefixo,
+        motivo: lido ? 'consumido' : 'atribuido-e-ignorado',
+      });
+      continue;
+    }
+
+    // Qualquer outra posição — argumento, `return`, propriedade de objeto, ramo de ternário,
+    // corpo de arrow sem chaves, operando — significa que o valor foi para algum lugar.
+    usos.push({ indice: i, consumido: true, prefixo, motivo: 'consumido' });
+  }
+
+  return usos;
+}
+
+/** Quantas chamadas a `nome(` entregam o retorno a alguém. `0` = o gate estaria mentindo. */
+export function chamadasQueConsomemRetorno(fonte: string, nome: string): number {
+  return usosDoRetorno(fonte, nome).filter((u) => u.consumido).length;
+}
+
+/**
+ * Mensagem para o assert: nomeia a classe e mostra a forma encontrada, para o vermelho explicar
+ * o que fazer em vez de só dizer "não casou".
+ */
+export function explicarDescarte(fonte: string, nome: string): string {
+  const usos = usosDoRetorno(fonte, nome);
+  if (usos.length === 0) return `${nome} não é chamado em lugar nenhum`;
+  const formas = usos.map((u) => `${u.motivo}${u.prefixo ? ` ("${u.prefixo.slice(-48)}")` : ''}`);
+  return `${nome} é chamado ${usos.length}x mas NENHUMA entrega o retorno: ${formas.join(' | ')}`;
+}

--- a/src/lib/gates/retorno-consumido.ts
+++ b/src/lib/gates/retorno-consumido.ts
@@ -89,18 +89,28 @@ export function usosDoRetorno(fonteCrua: string, nome: string): UsoDoRetorno[] {
   return usos;
 }
 
-/** Quantas chamadas a `nome(` entregam o retorno a alguém. `0` = o gate estaria mentindo. */
-export function chamadasQueConsomemRetorno(fonte: string, nome: string): number {
-  return usosDoRetorno(fonte, nome).filter((u) => u.consumido).length;
-}
-
 /**
- * Mensagem para o assert: nomeia a classe e mostra a forma encontrada, para o vermelho explicar
- * o que fazer em vez de só dizer "não casou".
+ * Veredito do assert, em UMA string — `'ok'` ou a explicação do que está errado.
+ *
+ * Por que uma string e não `expect(descartes).toBe(0)`: zero chamadas também dá zero descartes, e
+ * um gate que fica verde porque não encontrou nada é EXATAMENTE a classe que este arquivo mata
+ * (uma renomeação do helper apagaria o guard em silêncio). O caso "nenhuma chamada" tem de ser
+ * VERMELHO, e num assert só ele fica impossível de esquecer.
+ *
+ * O critério é "NENHUMA chamada descarta", não "alguma consome": onde o helper tem 2 chamadas,
+ * sabotar só uma passaria pelo critério fraco — medido em 2026-08-25 com
+ * `decidirIdentidadeSelfService` (2 chamadas em `omie-sync`). Os 9 helpers puros sob este gate
+ * têm 0 descartes na `main` de hoje, então o critério forte não custa falso-positivo. Ele NÃO
+ * serve para função chamada pelo efeito colateral (`await deriveOmieAccountIdentity(...)` solto,
+ * legítimo em `omie-vendas-sync`) — ali o assert certo é o posicional do próprio site.
  */
-export function explicarDescarte(fonte: string, nome: string): string {
+export function vereditoFronteira(fonte: string, nome: string): string {
   const usos = usosDoRetorno(fonte, nome);
-  if (usos.length === 0) return `${nome} não é chamado em lugar nenhum`;
-  const formas = usos.map((u) => `${u.motivo}${u.prefixo ? ` ("${u.prefixo.slice(-48)}")` : ''}`);
-  return `${nome} é chamado ${usos.length}x mas NENHUMA entrega o retorno: ${formas.join(' | ')}`;
+  if (usos.length === 0) {
+    return `${nome}: NENHUMA chamada encontrada — renomeado/removido? O gate ficaria verde por cegueira`;
+  }
+  const maus = usos.filter((u) => !u.consumido);
+  if (maus.length === 0) return 'ok';
+  const formas = maus.map((u) => `${u.motivo}${u.prefixo ? ` ("${u.prefixo.slice(-40)}")` : ''}`);
+  return `${nome}: ${maus.length} de ${usos.length} chamada(s) DESCARTAM o retorno — ${formas.join(' | ')}`;
 }


### PR DESCRIPTION
## Instância única ou classe?

**CLASSE** — a mesma do #1985 (gate textual que casa o **NOME** de uma função e conclui daí que o **EFEITO** dela aconteceu; assinatura na §9 de `docs/historico/verificar-sonda-versao.md`). O #1985 fechou o caso da sonda; esta é a varredura que ele pediu. **7 irmãos vivos.**

## Varredura completa (todos os sites, inclusive os limpos)

Assinatura: regex ou `includes` que casa `<identificador>(` contra código lido como TEXTO. 63 arquivos leem fonte com `readFileSync`/`Deno.readTextFileSync`; a assinatura casou 5.

Critério de triagem — **o valor de RETORNO da função casada é o produto que o teste afirma?** (não a forma do assert).

### afetado (7) — medidos, não deduzidos

Montada a forma "calcula e descarta" em código REAL das edges, o gate deu **237 passed, exit 0**:

| Helper | Edge | O que passava em produção |
| --- | --- | --- |
| `decidirIdentidadeSelfService` | `omie-sync` | identidade self-service decidida e jogada fora |
| `docsComCodigoAmbiguoNoOmie` | `omie-analytics-sync` | fail-closed do P1b evapora → last-write-wins |
| `classificarLoteProof` | `omie-analytics-sync` | lote cru no upsert (23505 derruba o run) |
| `buildOwnerMap` | `ai-ops-agent` | `farmer_id` saindo de mapa vazio |
| `skuItemsElegivel` | `omie-sync-sku-items` | filtro sempre-true → poison entope a fila |
| `skuItemsCompararFila` | `omie-sync-sku-items` | `sort` vira no-op → antigas nunca alcançadas |
| `acumularUsoCache` | `analyze-unified-order` | alerta de escrita-paga-sem-leitura nunca dispara |

### já-correto (3) — e é daqui que sai o formato do conserto

`resolveOwner` (`farmer_id: resolveOwner(...)`) e `deriveOmieAccountIdentity` (`criarPedidoVenda(supabaseAdmin, sales_order_id, ident.codigo_cliente, ...)`): asserts **posicionais**, que ancoram na fronteira em vez de casar o nome. `agregarItensRecebimento` reprovou a sabotagem por **acidente de âncora textual** (`expected '' not to be ''`) — pega, mas não explica.

### falso-positivo da assinatura (4) — deixados como estão

`escritaCritica(` e `avaliarPagina(` (a chamada **É** o efeito, não há retorno-produto) · `classificarSonda(` (assert de forma) · `avaliarAssinaturaA2(` (o `bloco` já é recorte posicional da canária, com asserts de argumento nominal).

### o suspeito que a §9 nomeou não existe

Gates que provam `track(` presente e concluem "evento gravado": **zero** no repo. Era hipótese, não medição — fica registrado para ninguém re-varrer o que não há. (De quebra, o #1984 mostrou que o canal PostHog é censurado por bloqueador de rastreador no cliente, então um gate assim seria cego duas vezes: no texto e no dado.)

## O gate

`src/lib/gates/retorno-consumido.ts` — assert **POSICIONAL**, não lista de embrulhos: enumerar `const X = helper(` reprovaria predicado de `.filter`, comparador de `.sort`, valor de propriedade e ramo de ternário — **todas formas reais aqui** —, e o conserto de um gate que reprova código correto é sempre afrouxá-lo (lição do #1985). Pergunta única: a chamada está numa posição em que alguém **recebe** o valor? Cobre também "atribui e ignora a variável". Fonte limpa com o stripper **compartilhado** — chamada em comentário não conta.

**A armadilha se repetiu DENTRO do conserto, duas vezes** — vale mais que o conserto:

1. A primeira calibração negativa extraía o nome do alvo por regex do próprio fixture. Nome errado ⇒ zero chamadas ⇒ zero consumos ⇒ **verde por cegueira**, a mesma classe. Nome agora vai explícito, com sentinela de fixture.
2. `expect(descartes).toBe(0)` aprova **zero chamadas**. O assert virou um veredito em string em que "NENHUMA chamada encontrada" é vermelho — senão renomear o helper apaga o guard em silêncio.

E o critério "≥1 chamada consome" tinha buraco que só a falsificação achou: `decidirIdentidadeSelfService` é chamado 2x, e sabotar só a primeira passava (**5 de 7** acusaram). Medição dos 9 helpers puros na `main`: **0 descartes em todos** ⇒ critério endurecido para "NENHUMA descarta", sem custo de falso-positivo. `deriveOmieAccountIdentity` fica **fora** do veredito forte (`omie-vendas-sync:3092` chama pelo efeito colateral, legitimamente) e ganha assert próprio que pina a contagem.

## Evidência positiva (colada)

- **Falsificação em código real: 7/7 vermelhas**, cada uma citando a marca do ramo (`"N de M chamada(s) DESCARTAM o retorno"`), não "não casou". Commitado antes de falsificar; restaurado com `git checkout --`.
- Calibração dos dois sentidos, **28 casos**: 7 formas de descarte que reprovam · 6 formas legítimas REAIS + 1 inventada que aprovam · cegueira · 1-de-2 · definição≠chamada · as 9 edges de hoje.
- Árvore restaurada, pós-rebase em `origin/main`: `bun run test` → **740 arquivos, 7176 passed, 1 skipped**; `test=0 typecheck=0 lint=0` (propagado, não `echo $?`).

## Registro

`docs/agent/money-path.md` §Helper espelhado (a regra: "define E chama" não prova que o produto chega) e `docs/historico/verificar-sonda-versao.md` §10 (a varredura, a tabela dos 7, e as duas reincidências dentro do conserto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)