### PR TITLE
docs(diagnostico): queries de ACL real + briefing da varredura dos gates SQL

### DIFF
--- a/db/diagnostico/BRIEFING-varredura-gates-sql.md
+++ b/db/diagnostico/BRIEFING-varredura-gates-sql.md
@@ -1,0 +1,70 @@
+# Briefing — varredura da classe "o NOME prova o EFEITO" nos gates de SQL
+
+Continuação dos PRs #1985 e #2001 (mergeados 2026-08-25). **Leia antes:**
+`docs/historico/verificar-sonda-versao.md` §9 e §10 — a §10 é a varredura anterior, com o método
+e a tabela dos 7 sites corrigidos.
+
+## A classe
+
+Gate textual que casa o **NOME** (ou a declaração) de algo no código-fonte e conclui daí que o
+**EFEITO** dela aconteceu. Fechada duas vezes em TypeScript; nunca medida em SQL.
+
+## Alvo
+
+- Principal: `scripts/authz-funcoes.test.ts` + o manifesto que ele valida
+  (`rg -l AUTHZ_MANIFEST scripts/ src/`).
+- Secundário: `scripts/sonda-versao-sql.test.ts`.
+
+## O suspeito, e por que ele é sério
+
+O gate tem um `it('nenhuma entrada permite anon (estado medido em prod)')` que percorre o
+**MANIFESTO** — uma estrutura de dados em TypeScript. "Medido em prod" descreve a **origem** do
+dado (alguém mediu um dia), não o que o assert verifica hoje. O manifesto pode dizer
+`permitido: false` para `anon` enquanto o `proacl` real da função em produção deixa `anon` executar.
+É a classe: o texto está certo e a afirmação é outra.
+
+O caminho pelo qual isso diverge **sem nenhum `GRANT` no repo** — e é por isso que a varredura
+textual de migrations não pega — está no CLAUDE.md: **`DROP FUNCTION` + `CREATE` RESETA o ACL**
+(só `CREATE OR REPLACE` preserva). Como o default de `EXECUTE` em função no Postgres inclui
+`PUBLIC`, recriar uma função sensível sem reemitir o `REVOKE` **nomeando as roles** reabre para
+`anon`/`authenticated` sem escrever uma única linha de `GRANT`. O `auditGrantsFuncoes` procura
+`GRANT EXECUTE ... TO anon` no texto das migrations e não vê nada: não houve concessão, houve
+**reset silencioso**.
+
+## Método (`docs/agent/money-path.md` + CLAUDE.md)
+
+1. **Assinatura com controle.** Monte a forma errada — uma migration com `DROP FUNCTION` +
+   `CREATE` de função do manifesto, sem `REVOKE` depois — e verifique se `bun run test` aprova.
+   Se aprovar, é da classe, e você tem **medição**, não dedução.
+2. **Confronte manifesto × prod.** As 4 queries prontas estão em
+   `db/diagnostico/authz-funcoes-acl-real.sql`. Leitura de banco você roda **direto**, com o
+   wrapper read-only `~/.config/afiacao/psql-ro` (role `claude_ro`):
+   `~/.config/afiacao/psql-ro -f db/diagnostico/authz-funcoes-acl-real.sql`.
+   A **query 4** é a mais informativa para esta classe: `proacl IS NULL` é o rastro do
+   `DROP`+`CREATE` — ninguém emitiu `GRANT`/`REVOKE` desde a última criação, e o default inclui
+   `PUBLIC`.
+3. **Conserto ancorado na fronteira**, no padrão do #2001: assert **POSICIONAL**, nunca
+   enumeração de nomes — enumerar reprova código correto, e o conserto de um gate que reprova
+   código correto é sempre afrouxá-lo. Se a fronteira for o banco (e o CI não consulta prod), o
+   conserto legítimo pode ser um **gate de migration**: `DROP FUNCTION` de função classificada no
+   manifesto exige `REVOKE` nomeando as roles no mesmo arquivo. Registre no PR por que essa
+   fronteira, e não outra.
+4. **Calibração nos dois sentidos:** a forma errada tem de reprovar; as formas legítimas **reais**
+   medidas no repo têm de aprovar.
+5. **Commite antes de falsificar** (restaurar costuma ser `git checkout --`), falsifique em código
+   REAL (sabote, exija vermelho, restaure) e capture `exit 0` colado. Armadilhas em
+   `docs/historico/evidencia-positiva-shell.md`: capture o `rc` **antes** de recortar a saída e
+   propague-o (`[ "$rc" -eq 0 ]` como última instrução) — `echo $?` no fim fabrica veredito.
+
+## Escrita: nunca aplique
+
+Se a varredura achar função indevidamente aberta, o `REVOKE` vai para o **SQL Editor do Lovable**,
+colado pelo founder (`docs/agent/database.md` §1). Atenção ao no-op medido no #1991:
+`REVOKE ... FROM PUBLIC` **não** tira `anon`/`authenticated` quando existe grant explícito —
+revogue **nomeando as roles**.
+
+## Entrega
+
+`heavy bun run test` (canônico do CI). PR próprio, respondendo no corpo **"instância única ou
+classe?"** (passo 0 da skill `matar-classe`) e listando **todos** os sites varridos, inclusive os
+limpos — prova de varredura completa, não de amostra.

--- a/db/diagnostico/authz-funcoes-acl-real.sql
+++ b/db/diagnostico/authz-funcoes-acl-real.sql
@@ -1,0 +1,53 @@
+-- Diagnóstico read-only: o ACL REAL de EXECUTE das funções de `public`.
+--
+-- Por que existe: `scripts/authz-funcoes.test.ts` valida um MANIFESTO em TypeScript
+-- (AUTHZ_MANIFEST / ACKNOWLEDGED_SENSITIVE / ACL_ONLY_INTERNAL) e tem um assert
+-- "nenhuma entrada permite anon (estado medido em prod)". "Medido em prod" é a ORIGEM
+-- do dado, não o que o assert verifica: ele percorre a estrutura, não o banco. Estas
+-- queries são a fronteira — quem de fato decide quem executa o quê.
+--
+-- Classe: docs/historico/verificar-sonda-versao.md §9/§10 (o NOME prova o efeito).
+-- Rodar com o wrapper read-only: ~/.config/afiacao/psql-ro -f db/diagnostico/authz-funcoes-acl-real.sql
+--
+-- ESCRITA NUNCA SAI DAQUI. Se aparecer função indevidamente aberta, o REVOKE vai para o
+-- SQL Editor do Lovable, colado pelo founder (docs/agent/database.md §1). E cuidado com o
+-- no-op medido no #1991: REVOKE ... FROM PUBLIC NÃO tira anon/authenticated quando existe
+-- grant explícito — revogue NOMEANDO as roles.
+
+\echo '=== 1. ACL real de EXECUTE por função (proacl NULL primeiro = default do Postgres) ==='
+SELECT n.nspname || '.' || p.proname AS funcao,
+       pg_get_function_identity_arguments(p.oid) AS args,
+       p.prosecdef AS security_definer,
+       coalesce(p.proacl::text, '(default: PUBLIC pode EXECUTE)') AS acl
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+ORDER BY (p.proacl IS NULL) DESC, p.proname;
+
+\echo '=== 2. O furo direto: funções que anon OU authenticated podem executar hoje ==='
+SELECT n.nspname || '.' || p.proname AS funcao,
+       pg_get_function_identity_arguments(p.oid) AS args,
+       p.prosecdef AS security_definer,
+       has_function_privilege('anon', p.oid, 'EXECUTE') AS anon_pode,
+       has_function_privilege('authenticated', p.oid, 'EXECUTE') AS auth_pode
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND (has_function_privilege('anon', p.oid, 'EXECUTE')
+    OR has_function_privilege('authenticated', p.oid, 'EXECUTE'))
+ORDER BY anon_pode DESC, p.prosecdef DESC, p.proname;
+
+\echo '=== 3. Pior caso: SECURITY DEFINER (bypassa RLS) executável por anon ==='
+SELECT n.nspname || '.' || p.proname AS funcao,
+       pg_get_function_identity_arguments(p.oid) AS args
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.prosecdef
+  AND has_function_privilege('anon', p.oid, 'EXECUTE')
+ORDER BY p.proname;
+
+\echo '=== 4. O rastro do DROP+CREATE: proacl NULL = ninguém emitiu GRANT/REVOKE desde a criação ==='
+-- Este é o estado que `DROP FUNCTION` + `CREATE` produz (só CREATE OR REPLACE preserva o
+-- ACL), e o default de EXECUTE em função inclui PUBLIC. Reabre sem nenhuma linha de GRANT
+-- no repo — que é exatamente o que o gate textual de migrations não consegue ver.
+SELECT n.nspname || '.' || p.proname AS funcao, p.prosecdef AS security_definer
+FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proacl IS NULL AND p.prokind = 'f'
+ORDER BY p.prosecdef DESC, p.proname;


### PR DESCRIPTION
Insumo dos dois chips criados hoje, continuação de **#1985 → #2001 → #2003**. Os arquivos existem para que o worktree do chip os encontre — briefing solto no chat não sobrevive à sessão.

## O que entra

**`db/diagnostico/authz-funcoes-acl-real.sql`** — 4 queries read-only sobre o ACL de `EXECUTE` das funções de `public`. A **query 4** é a que importa para a classe: `proacl IS NULL` significa que ninguém emitiu `GRANT`/`REVOKE` desde a última criação da função. É o rastro que `DROP FUNCTION` + `CREATE` deixa (só `CREATE OR REPLACE` preserva o ACL), e o default de `EXECUTE` inclui `PUBLIC` — ou seja, **reabre a função sem escrever uma linha de `GRANT`**, que é justamente o que o `auditGrantsFuncoes` procura no texto das migrations e nunca encontra.

**`db/diagnostico/BRIEFING-varredura-gates-sql.md`** — o briefing da varredura. O suspeito é o assert `'nenhuma entrada permite anon (estado medido em prod)'` de `scripts/authz-funcoes.test.ts`, que percorre um **manifesto em TypeScript**. "Medido em prod" é a **origem** do dado, não o que o assert verifica hoje — mesma forma da classe fechada no #2001, agora com o banco como fronteira em vez do `return`.

## Escrita: nenhuma

O `.sql` é lido pelo wrapper read-only (`~/.config/afiacao/psql-ro`). Se a varredura achar função indevidamente aberta, o `REVOKE` vai ao SQL Editor do Lovable pelas mãos do founder, **nomeando as roles** — o no-op medido no #1991 (`REVOKE ... FROM PUBLIC` não tira `anon`/`authenticated` quando há grant explícito).

## Evidência

`bun run test` → **741 arquivos, 7195 passed, 1 skipped**, `test=0` (propagado).

Uma rodada anterior deu 8 vermelhos, **todos `Test timed out in 20000ms`** — nenhuma asserção falhando. Re-rodados isolados: **158 passed, rc=0**. Era contenção de recursos (o vigia reportou 28 sessões vivas), não o diff. Fica registrado porque timeout é **ausência de dado**, não reprovação — e ler os 8 como vermelho teria feito eu "consertar" um arquivo que não tinha defeito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)