### PR TITLE
docs(posthog-proxy): spec + plano do proxy de ingestão — desenho aprovado, implementação ainda NÃO começou

### DIFF
--- a/docs/superpowers/plans/2026-08-25-posthog-proxy-ingestao.md
+++ b/docs/superpowers/plans/2026-08-25-posthog-proxy-ingestao.md
@@ -1,0 +1,613 @@
+# Proxy de ingestão do PostHog — plano de implementação
+
+> **Para agentes:** SUB-SKILL OBRIGATÓRIA: use `superpowers:subagent-driven-development`
+> (recomendado) ou `superpowers:executing-plans` para executar tarefa a tarefa. Os passos usam
+> checkbox (`- [ ]`) para rastreio.
+
+**Goal:** Fazer a telemetria de browser sobreviver a bloqueadores de rastreador, encaminhando a
+ingestão do PostHog por uma edge do Supabase.
+
+**Architecture:** Uma edge pública (`posthog-proxy`) recebe o tráfego do `posthog-js` e o encaminha
+para **dois** upstreams fixos (`us.i.posthog.com` para ingestão, `us-assets.i.posthog.com` para
+`/static/*` e `/array/*`), com allowlist de caminho e descarte de headers de entrada. A edge conta
+o próprio tráfego numa tabela — contador imune ao bloqueador e ao PostHog. O cliente não muda:
+`src/lib/analytics.ts:32` já lê `VITE_POSTHOG_HOST`.
+
+**Tech Stack:** Deno (edge do Supabase) · PostgreSQL 17 (Supabase) · `posthog-js` 1.373.4 · Vite env.
+
+**Spec:** [`2026-08-25-posthog-proxy-ingestao-design.md`](../specs/2026-08-25-posthog-proxy-ingestao-design.md)
+
+## Global Constraints
+
+- **`test:edges` roda `deno test --no-remote --allow-read=supabase/functions`.** Teste de edge
+  **não pode ter import remoto** — nem `https://deno.land/std/...`. Escreva os asserts à mão, como
+  `supabase/functions/_shared/anthropic_test.ts` já faz. **Nunca afrouxar o `--no-remote`.**
+- **Três gates de edge e nenhum cobre o outro:** `bun run test:edges` (suíte Deno) ·
+  `bun run edges:typecheck` (a Deno **não** type-checa sozinha) · `bun run test` (vitest, que lê
+  edges como TEXTO).
+- **Toda falsificação exige COMMIT antes** — `restaurar()` costuma ser `git checkout --`.
+- **Migration custom NÃO auto-aplica** no Lovable Cloud. Exige o pacote de 5 itens da skill
+  `lovable-db-operator`. Falha é SILENCIOSA.
+- **Nada no front consome a tabela nova.** Isso é deliberado: `src/integrations/supabase/types.ts` é
+  gerado pelo Lovable e não é atualizado por migration colada à mão — o primeiro PR que
+  referenciasse a tabela deixaria a `main` VERMELHA. A leitura do contador é por `psql-ro`.
+- **Upstreams, literais, nunca vindos da requisição:** `https://us.i.posthog.com` e
+  `https://us-assets.i.posthog.com`.
+- Nome da edge: **`posthog-proxy`**.
+
+---
+
+## Estrutura de arquivos
+
+| arquivo | responsabilidade |
+|---|---|
+| `supabase/functions/_shared/posthog-proxy-rotas.ts` (criar) | Lógica **pura**: normalizar caminho, decidir upstream+classe, allowlist de headers. Sem I/O — é o que torna o teste possível sob `--no-remote`. |
+| `supabase/functions/_shared/posthog-proxy-rotas_test.ts` (criar) | Suíte Deno da lógica pura, com casos negativos. |
+| `supabase/functions/posthog-proxy/index.ts` (criar) | Só o I/O: CORS, teto de corpo, `fetch` upstream, contador via `waitUntil`. |
+| `supabase/config.toml` (modificar) | `[functions.posthog-proxy] verify_jwt = false`. |
+| `supabase/migrations/<ts>_posthog_proxy_stats.sql` (criar) | Tabela + RPC de incremento + RLS + REVOKE. |
+| `docs/agent/analytics.md` (modificar) | Como ler o contador. |
+
+---
+
+### Task 1: Lógica pura de roteamento
+
+**Files:**
+- Create: `supabase/functions/_shared/posthog-proxy-rotas.ts`
+- Test: `supabase/functions/_shared/posthog-proxy-rotas_test.ts`
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: `type ClasseRota = 'ingest' | 'assets' | 'flags' | 'replay'` ·
+  `rotearCaminho(caminho: string): { upstream: string; classe: ClasseRota } | null` ·
+  `extrairCaminho(pathname: string): string` ·
+  `HEADERS_PERMITIDOS: readonly string[]`.
+
+- [ ] **Passo 1: escrever o teste que falha**
+
+Crie `supabase/functions/_shared/posthog-proxy-rotas_test.ts`:
+
+```ts
+// Testa o CÓDIGO REAL de _shared/posthog-proxy-rotas.ts no runtime real (Deno).
+// Roda com: deno test --no-remote supabase/functions/_shared/
+import { extrairCaminho, HEADERS_PERMITIDOS, rotearCaminho } from "./posthog-proxy-rotas.ts";
+
+function assertEquals(a: unknown, b: unknown, msg?: string) {
+  if (JSON.stringify(a) !== JSON.stringify(b)) {
+    throw new Error(`${msg ?? "assertEquals"}\n  esperado: ${JSON.stringify(b)}\n  recebido: ${JSON.stringify(a)}`);
+  }
+}
+
+const INGEST = "https://us.i.posthog.com";
+const ASSETS = "https://us-assets.i.posthog.com";
+
+Deno.test("extrairCaminho remove o prefixo da edge", () => {
+  assertEquals(extrairCaminho("/functions/v1/posthog-proxy/i/v0/e/"), "/i/v0/e/");
+  assertEquals(extrairCaminho("/posthog-proxy/static/surveys.js"), "/static/surveys.js");
+  assertEquals(extrairCaminho("/functions/v1/posthog-proxy"), "/");
+});
+
+Deno.test("assets e config remota vão para o host de assets", () => {
+  assertEquals(rotearCaminho("/static/surveys.js"), { upstream: ASSETS, classe: "assets" });
+  assertEquals(rotearCaminho("/array/phc_abc/config.js"), { upstream: ASSETS, classe: "assets" });
+});
+
+Deno.test("ingestão vai para o host de ingestão, com e sem barra final", () => {
+  assertEquals(rotearCaminho("/i/v0/e/"), { upstream: INGEST, classe: "ingest" });
+  assertEquals(rotearCaminho("/i/v0/e"), { upstream: INGEST, classe: "ingest" });
+  assertEquals(rotearCaminho("/e/"), { upstream: INGEST, classe: "ingest" });
+  assertEquals(rotearCaminho("/batch/"), { upstream: INGEST, classe: "ingest" });
+});
+
+Deno.test("flags e replay têm classe própria", () => {
+  assertEquals(rotearCaminho("/flags"), { upstream: INGEST, classe: "flags" });
+  assertEquals(rotearCaminho("/decide/"), { upstream: INGEST, classe: "flags" });
+  assertEquals(rotearCaminho("/s/"), { upstream: INGEST, classe: "replay" });
+});
+
+Deno.test("fora da allowlist devolve null — este é o teste que importa", () => {
+  assertEquals(rotearCaminho("/"), null);
+  assertEquals(rotearCaminho("/qualquer"), null);
+  assertEquals(rotearCaminho("/api/internal"), null);
+  // um caminho que só CONTÉM um termo da allowlist não passa
+  assertEquals(rotearCaminho("/naoe/static/x.js"), null);
+});
+
+Deno.test("travessia de diretório é recusada mesmo sob prefixo permitido", () => {
+  assertEquals(rotearCaminho("/static/../../etc/passwd"), null);
+  assertEquals(rotearCaminho("/array/..%2Fx"), null);
+});
+
+Deno.test("a allowlist de headers não deixa passar auth nem cookie", () => {
+  const proibidos = ["authorization", "cookie", "apikey", "x-client-info"];
+  for (const p of proibidos) {
+    assertEquals(HEADERS_PERMITIDOS.includes(p), false, `header ${p} NÃO pode ser encaminhado`);
+  }
+  assertEquals(HEADERS_PERMITIDOS.includes("content-type"), true);
+});
+```
+
+- [ ] **Passo 2: rodar e confirmar que falha**
+
+```bash
+deno test --no-remote --allow-read=supabase/functions supabase/functions/_shared/posthog-proxy-rotas_test.ts
+```
+
+Esperado: **FAIL** com `Module not found` (o `posthog-proxy-rotas.ts` ainda não existe).
+
+- [ ] **Passo 3: implementar o mínimo**
+
+Crie `supabase/functions/_shared/posthog-proxy-rotas.ts`:
+
+```ts
+/**
+ * Roteamento PURO do proxy de ingestão do PostHog.
+ *
+ * Puro de propósito: o `test:edges` roda com `--no-remote`, então a lógica que
+ * precisa de teste não pode viver junto do I/O. O index.ts só faz fetch.
+ *
+ * ⚠️ Os dois upstreams são LITERAIS. Host que venha da requisição é ignorado,
+ * não sanitizado — é o que separa um proxy de um open proxy.
+ */
+const HOST_INGESTAO = "https://us.i.posthog.com";
+const HOST_ASSETS = "https://us-assets.i.posthog.com";
+
+export type ClasseRota = "ingest" | "assets" | "flags" | "replay";
+
+/** Headers que sobem para o PostHog. Tudo fora desta lista é DESCARTADO —
+ *  em especial `authorization` (vazaria o JWT do Supabase) e `cookie`. */
+export const HEADERS_PERMITIDOS: readonly string[] = ["content-type", "content-encoding"];
+
+/** Tira o prefixo de roteamento da edge, sobrando o caminho que o PostHog espera. */
+export function extrairCaminho(pathname: string): string {
+  const marca = "/posthog-proxy";
+  const i = pathname.indexOf(marca);
+  if (i === -1) return pathname || "/";
+  const resto = pathname.slice(i + marca.length);
+  return resto === "" ? "/" : resto;
+}
+
+function normalizar(caminho: string): string {
+  return caminho.length > 1 && caminho.endsWith("/") ? caminho.slice(0, -1) : caminho;
+}
+
+const EXATOS_INGEST = new Set(["/i/v0/e", "/e", "/batch"]);
+const EXATOS_FLAGS = new Set(["/flags", "/decide"]);
+
+export function rotearCaminho(caminho: string): { upstream: string; classe: ClasseRota } | null {
+  // Travessia recusada antes de qualquer casamento de prefixo — inclusive
+  // percent-encoded, que um `startsWith` sozinho deixaria passar.
+  const cru = caminho.toLowerCase();
+  if (cru.includes("..") || cru.includes("%2f") || cru.includes("%5c") || cru.includes("\\")) return null;
+
+  if (caminho.startsWith("/static/") || caminho.startsWith("/array/")) {
+    return { upstream: HOST_ASSETS, classe: "assets" };
+  }
+  if (caminho.startsWith("/s/")) return { upstream: HOST_INGESTAO, classe: "replay" };
+
+  const n = normalizar(caminho);
+  if (EXATOS_INGEST.has(n)) return { upstream: HOST_INGESTAO, classe: "ingest" };
+  if (EXATOS_FLAGS.has(n)) return { upstream: HOST_INGESTAO, classe: "flags" };
+  return null;
+}
+```
+
+- [ ] **Passo 4: rodar e confirmar que passa**
+
+```bash
+deno test --no-remote --allow-read=supabase/functions supabase/functions/_shared/posthog-proxy-rotas_test.ts
+```
+
+Esperado: **ok | 7 passed | 0 failed**.
+
+- [ ] **Passo 5: commitar ANTES de falsificar**
+
+```bash
+git add supabase/functions/_shared/posthog-proxy-rotas.ts supabase/functions/_shared/posthog-proxy-rotas_test.ts && git commit -m "feat(posthog-proxy): roteamento puro com allowlist de caminho e de header"
+```
+
+- [ ] **Passo 6: FALSIFICAR — sabotar a allowlist e exigir vermelho**
+
+Um teste de allowlist que passa com a allowlist quebrada é teatro. Sabote:
+
+```bash
+# troca o `return null` final por um encaminhamento cego
+perl -0pi -e 's/  if \(EXATOS_FLAGS\.has\(n\)\) return \{ upstream: HOST_INGESTAO, classe: "flags" \};\n  return null;/  if (EXATOS_FLAGS.has(n)) return { upstream: HOST_INGESTAO, classe: "flags" };\n  return { upstream: HOST_INGESTAO, classe: "ingest" };/' supabase/functions/_shared/posthog-proxy-rotas.ts
+deno test --no-remote --allow-read=supabase/functions supabase/functions/_shared/posthog-proxy-rotas_test.ts
+```
+
+Esperado: **FAIL** no teste `"fora da allowlist devolve null"`. Se passar, o teste não vale nada.
+
+Restaure e confirme verde de novo:
+
+```bash
+git checkout -- supabase/functions/_shared/posthog-proxy-rotas.ts && deno test --no-remote --allow-read=supabase/functions supabase/functions/_shared/posthog-proxy-rotas_test.ts
+```
+
+---
+
+### Task 2: A edge `posthog-proxy` (sem contador ainda)
+
+**Files:**
+- Create: `supabase/functions/posthog-proxy/index.ts`
+- Modify: `supabase/config.toml`
+
+**Interfaces:**
+- Consumes: `rotearCaminho`, `extrairCaminho`, `HEADERS_PERMITIDOS` da Task 1.
+- Produces: a edge respondendo em `/functions/v1/posthog-proxy/*`. A Task 4 acrescenta o contador
+  neste mesmo arquivo.
+
+- [ ] **Passo 1: escrever a edge**
+
+Crie `supabase/functions/posthog-proxy/index.ts`:
+
+```ts
+import {
+  extrairCaminho,
+  HEADERS_PERMITIDOS,
+  rotearCaminho,
+} from "../_shared/posthog-proxy-rotas.ts";
+
+/**
+ * Proxy de ingestão do PostHog.
+ *
+ * Existe porque `us.i.posthog.com` está nas listas de bloqueio comuns e a
+ * telemetria de browser morria no cliente (provado no PR #1984 com par de
+ * falsificação: 4 ms de `Failed to fetch` num Chrome com bloqueador contra
+ * 1112 ms de `200 Ok` num Chromium limpo, mesma máquina e minuto).
+ *
+ * `verify_jwt = false` é obrigatório, não conveniência: o `$pageview`
+ * acontece antes do login e o caminho `keepalive` não manda header de auth.
+ * Por isso as travas abaixo são o que impede isto de virar um open proxy.
+ */
+const TETO_CORPO = 1_048_576; // 1 MB
+const ORIGENS_PERMITIDAS = new Set(["https://steu.lovable.app"]);
+const ORIGEM_PADRAO = "https://steu.lovable.app";
+
+function corsHeaders(origin: string | null): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin && ORIGENS_PERMITIDAS.has(origin) ? origin : ORIGEM_PADRAO,
+    "Access-Control-Allow-Headers": "content-type, content-encoding",
+    "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
+    "Access-Control-Max-Age": "3600",
+    "Vary": "Origin",
+  };
+}
+
+Deno.serve(async (req) => {
+  const cors = corsHeaders(req.headers.get("origin"));
+  if (req.method === "OPTIONS") return new Response(null, { status: 204, headers: cors });
+  if (req.method !== "POST" && req.method !== "GET") {
+    return new Response("metodo nao suportado", { status: 405, headers: cors });
+  }
+
+  const url = new URL(req.url);
+  const caminho = extrairCaminho(url.pathname);
+  const rota = rotearCaminho(caminho);
+  if (!rota) return new Response("rota nao permitida", { status: 404, headers: cors });
+
+  let corpo: Uint8Array | undefined;
+  if (req.method === "POST") {
+    corpo = new Uint8Array(await req.arrayBuffer());
+    if (corpo.byteLength > TETO_CORPO) {
+      return new Response("corpo grande demais", { status: 413, headers: cors });
+    }
+  }
+
+  // Só a allowlist sobe. Nada de `authorization`, `cookie`, `apikey`.
+  const headersUp = new Headers();
+  for (const nome of HEADERS_PERMITIDOS) {
+    const v = req.headers.get(nome);
+    if (v) headersUp.set(nome, v);
+  }
+
+  // Encaminha o caminho ORIGINAL (não o normalizado) + a query crua.
+  const alvo = `${rota.upstream}${caminho}${url.search}`;
+
+  let resposta: Response;
+  try {
+    resposta = await fetch(alvo, { method: req.method, headers: headersUp, body: corpo });
+  } catch (_e) {
+    return new Response("upstream indisponivel", { status: 502, headers: cors });
+  }
+
+  // Devolve status e corpo do upstream; `Set-Cookie` NÃO é repassado.
+  const headersDown = new Headers(cors);
+  const ct = resposta.headers.get("content-type");
+  if (ct) headersDown.set("content-type", ct);
+  const cc = resposta.headers.get("cache-control");
+  if (cc) headersDown.set("cache-control", cc);
+
+  return new Response(resposta.body, { status: resposta.status, headers: headersDown });
+});
+```
+
+- [ ] **Passo 2: declarar a edge como pública**
+
+Acrescente ao fim de `supabase/config.toml`:
+
+```toml
+[functions.posthog-proxy]
+verify_jwt = false
+```
+
+- [ ] **Passo 3: fechar a lacuna do `flagsApiHost` (a spec §6 deixou em aberto de propósito)**
+
+No `endpointFor`, `flagsApiHost` é consultado **antes** do ramo `custom`. Se ele não herdar o
+`api_host`, feature flags continuariam saindo pelo host bloqueado.
+
+```bash
+grep -ohE "flagsApiHost[^;]{0,140}" node_modules/posthog-js/dist/module.js | head -3
+```
+
+Leitura do resultado, e **registre qual dos três** foi:
+- deriva de `apiHost` → nada a fazer, a allowlist já cobre `/flags`;
+- host do PostHog fixo → o app **não usa feature flags** hoje, então não quebra evento. Registre
+  como lacuna conhecida no PR e **não** invente correção;
+- opção de config (`advanced_disable_flags` ou similar) → avalie desligar, já que o app não usa.
+
+**Não pule este passo assumindo o primeiro caso** — foi justamente por não verificar que a spec o
+deixou aberto.
+
+- [ ] **Passo 4: rodar os TRÊS gates de edge**
+
+```bash
+bun run test:edges && bun run edges:typecheck && heavy bun run test
+```
+
+Esperado: os três com `exit 0`. **Confirme a linha de conclusão de cada um** — exit code sozinho não
+prova que rodou.
+
+- [ ] **Passo 5: commitar**
+
+```bash
+git add supabase/functions/posthog-proxy/index.ts supabase/config.toml && git commit -m "feat(posthog-proxy): edge publica com allowlist, teto de corpo e descarte de headers"
+```
+
+---
+
+### Task 3: Tabela do contador + RPC de incremento
+
+**Files:**
+- Create: `supabase/migrations/<YYYYMMDDHHMMSS>_posthog_proxy_stats.sql`
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: tabela `public.posthog_proxy_stats(dia date, classe text, status smallint, n bigint)` ·
+  RPC `public.posthog_proxy_registrar(p_classe text, p_status smallint) returns void`.
+
+- [ ] **Passo 1: invocar a skill do ritual de banco**
+
+```
+Skill: lovable-db-operator
+```
+
+Ela empacota os 5 itens obrigatórios: o `.sql` idempotente, o bloco pro SQL Editor, a query de
+validação read-only pós-apply, a nota "⚠️ migration manual" no PR, e o `bun run audit:migrations`
+com commit dos artefatos. **Não improvise esse ritual** — migration custom não auto-aplica e a
+falha é silenciosa.
+
+- [ ] **Passo 2: o SQL (conteúdo para a skill empacotar)**
+
+```sql
+-- Contador do proxy de ingestão do PostHog.
+-- Imune ao bloqueador e ao próprio PostHog: é o denominador que permite
+-- distinguir "o proxy quebrou" de "ninguém usou". Sem ele os dois são zero.
+create table if not exists public.posthog_proxy_stats (
+  dia    date     not null,
+  classe text     not null,
+  status smallint not null,
+  n      bigint   not null default 0,
+  primary key (dia, classe, status)
+);
+
+alter table public.posthog_proxy_stats enable row level security;
+-- Sem policy: só a service_role (que bypassa RLS) escreve, via o RPC abaixo.
+-- Leitura de diagnóstico é por psql-ro. Nenhum caminho de cliente lê esta tabela.
+
+create or replace function public.posthog_proxy_registrar(
+  p_classe text,
+  p_status smallint
+) returns void
+language sql
+security definer
+set search_path = public
+as $$
+  insert into public.posthog_proxy_stats (dia, classe, status, n)
+  values (current_date, p_classe, p_status, 1)
+  on conflict (dia, classe, status) do update set n = public.posthog_proxy_stats.n + 1;
+$$;
+
+-- REVOKE nomeando as roles: `REVOKE FROM PUBLIC` NÃO tira anon/authenticated.
+revoke all on function public.posthog_proxy_registrar(text, smallint) from public;
+revoke all on function public.posthog_proxy_registrar(text, smallint) from anon;
+revoke all on function public.posthog_proxy_registrar(text, smallint) from authenticated;
+grant execute on function public.posthog_proxy_registrar(text, smallint) to service_role;
+```
+
+- [ ] **Passo 3: query de validação pós-apply (read-only)**
+
+```sql
+select
+  to_regclass('public.posthog_proxy_stats')                                is not null as tabela_existe,
+  (select relrowsecurity from pg_class where oid = 'public.posthog_proxy_stats'::regclass) as rls_ligada,
+  has_function_privilege('service_role', 'public.posthog_proxy_registrar(text, smallint)', 'EXECUTE') as service_pode,
+  has_function_privilege('anon',          'public.posthog_proxy_registrar(text, smallint)', 'EXECUTE') as anon_pode,
+  has_function_privilege('authenticated', 'public.posthog_proxy_registrar(text, smallint)', 'EXECUTE') as auth_pode;
+```
+
+Esperado: `t | t | t | f | f`. **`anon_pode` ou `auth_pode` em `t` = o REVOKE não pegou; não siga.**
+
+- [ ] **Passo 4: confirmar que o gate de authz não exige registro**
+
+```bash
+bun run authz:check
+```
+
+Esperado: `✅ authz:check — contrato de gate ok`. O manifesto cobre funções **sensíveis**; o
+contador não é uma. **Se o gate reclamar**, acrescente a entrada em `scripts/authz-manifest.ts`
+com o motivo — não silencie o gate.
+
+- [ ] **Passo 5: commitar**
+
+```bash
+git add supabase/migrations/ docs/migrations-audit.md && git commit -m "feat(posthog-proxy): tabela e RPC do contador imune ao bloqueador"
+```
+
+---
+
+### Task 4: Ligar o contador na edge
+
+**Files:**
+- Modify: `supabase/functions/posthog-proxy/index.ts`
+
+**Interfaces:**
+- Consumes: RPC `public.posthog_proxy_registrar(p_classe text, p_status smallint)` da Task 3;
+  a edge da Task 2.
+- Produces: nada de novo para outras tarefas.
+
+- [ ] **Passo 1: acrescentar o registro fire-and-forget**
+
+No topo do arquivo, depois dos imports:
+
+```ts
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+/** Incremento fire-and-forget. NUNCA soma latência à resposta proxiada, e
+ *  falha dele jamais derruba o proxy — o contador é diagnóstico, não caminho. */
+function registrar(classe: string, status: number): Promise<unknown> {
+  return fetch(`${SUPABASE_URL}/rest/v1/rpc/posthog_proxy_registrar`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+    },
+    body: JSON.stringify({ p_classe: classe, p_status: status }),
+  }).catch(() => undefined);
+}
+```
+
+Substitua o `return new Response("rota nao permitida", …)` por:
+
+```ts
+  if (!rota) {
+    EdgeRuntime.waitUntil(registrar("recusado", 404));
+    return new Response("rota nao permitida", { status: 404, headers: cors });
+  }
+```
+
+E o bloco final do `fetch` por:
+
+```ts
+  let resposta: Response;
+  try {
+    resposta = await fetch(alvo, { method: req.method, headers: headersUp, body: corpo });
+  } catch (_e) {
+    EdgeRuntime.waitUntil(registrar(rota.classe, 0)); // 0 = falha de rede, não zero de uso
+    return new Response("upstream indisponivel", { status: 502, headers: cors });
+  }
+  EdgeRuntime.waitUntil(registrar(rota.classe, resposta.status));
+```
+
+- [ ] **Passo 2: rodar os três gates**
+
+```bash
+bun run test:edges && bun run edges:typecheck && heavy bun run test
+```
+
+Esperado: os três `exit 0`, com a linha de conclusão visível.
+
+- [ ] **Passo 3: commitar**
+
+```bash
+git add supabase/functions/posthog-proxy/index.ts && git commit -m "feat(posthog-proxy): contador server-side fire-and-forget por classe e status"
+```
+
+---
+
+### Task 5: Documentar a leitura do contador
+
+**Files:**
+- Modify: `docs/agent/analytics.md`
+
+- [ ] **Passo 1: acrescentar a seção**
+
+Na seção de armadilhas (logo após "A amostra é CENSURADA"), acrescente:
+
+```markdown
+### Como ler o contador do proxy (a adoção NÃO se lê pelo PostHog)
+
+Medir a adoção do proxy pelo PostHog é circular: os clientes bloqueados são justamente os que não
+conseguimos ver. O sinal honesto é o contador da edge, imune ao bloqueador:
+
+    ~/.config/afiacao/psql-ro -c "select dia, classe, status, n from posthog_proxy_stats order by dia desc, n desc limit 20;"
+
+`status = 0` é **falha de rede ao upstream**, não zero de uso. `classe = 'recusado'` subindo
+significa que o SDK está pedindo um caminho fora da allowlist — provavelmente uma versão nova do
+`posthog-js` com endpoint novo, e é sinal de trabalho, não de ataque.
+```
+
+- [ ] **Passo 2: rodar os gates de docs**
+
+```bash
+bun run docs:citacoes && bun run docs:links && bun run docs:indice
+```
+
+Esperado: os três `exit 0` **com a contagem** na linha final.
+
+- [ ] **Passo 3: commitar e abrir o PR**
+
+```bash
+git add docs/agent/analytics.md && git commit -m "docs(analytics): como ler o contador do proxy"
+```
+
+No corpo do PR, a nota **⚠️ migration manual** com o bloco SQL da Task 3 e a query de validação.
+
+---
+
+## Deploy — três camadas manuais, NESTA ordem
+
+A ordem não é preferência: env antes da edge existir manda todo evento para um 404.
+
+- [ ] **1. Migration** — founder cola o bloco da Task 3 no SQL Editor do Lovable → Run. Confirmo com
+  a query de validação via `psql-ro` (esperado `t | t | t | f | f`).
+- [ ] **2. Edge** — deploy manual de `posthog-proxy`. Confirmo com:
+  ```bash
+  curl -s -o /dev/null -w "%{http_code}\n" "https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/posthog-proxy/rota-inexistente"
+  ```
+  Esperado **404** (a allowlist agindo). Um **401** aqui significa que o `verify_jwt = false` não
+  pegou — pare e corrija, senão nenhum evento anônimo passa.
+- [ ] **2b. Casos negativos da edge, contra o deploy real.** O teto de corpo é I/O e **não** dá pra
+  testar sob `--no-remote` — então a asserção vive aqui, não numa suíte que não a alcança:
+  ```bash
+  head -c 1200000 /dev/zero | tr '\0' 'a' > /tmp/grande.txt
+  curl -s -o /dev/null -w "413 esperado -> %{http_code}\n" -X POST --data-binary @/tmp/grande.txt \
+    -H 'content-type: application/json' \
+    "https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/posthog-proxy/i/v0/e/"
+  ```
+  Esperado **413**. Um **200** aqui significa que o teto não está agindo.
+
+- [ ] **3. Env + Publish** — `VITE_POSTHOG_HOST` =
+  `https://fzvklzpomgnyikkfkzai.supabase.co/functions/v1/posthog-proxy` no Lovable, depois Publish.
+
+## Verificação em produção — o par que provou o problema, invertido
+
+Não basta "está no ar". A prova é a assimetria de hoje **desaparecendo**.
+
+- [ ] **1. A edge recebe:** contador subindo em `classe='ingest'` com `status=200`.
+- [ ] **2. O que nenhum outro sinal substitui:** um `$pageleave` com `$lib='web'` saindo do **Chrome
+  BLOQUEADO do founder** — o cliente que hoje emite zero. Só isso fecha o argumento.
+  ```bash
+  bash scripts/posthog-query.sh "SELECT event, properties.\$os AS so, properties.build_id AS build, timestamp FROM events WHERE timestamp > now() - INTERVAL 30 MINUTE AND properties.\$lib='web' ORDER BY timestamp DESC LIMIT 10"
+  ```
+- [ ] **3. Controle negativo:** com a env revertida, o mesmo Chrome volta a não emitir. Sem ele, o
+  passo 2 pode ter sido outro cliente.
+- [ ] **4. Lembrar da 4ª camada:** o efeito só chega a cada cliente quando ELE aceita o SW. Adoção
+  começa perto de 0% — aqui isso é o sensor funcionando, não falhando.
+
+## Rollback
+
+Apagar `VITE_POSTHOG_HOST` no Lovable e republicar: o `?? 'https://us.i.posthog.com'` do
+`analytics.ts:32` devolve o comportamento atual. Edge e tabela ficam inertes. **Não toca banco.**

--- a/docs/superpowers/specs/2026-08-25-posthog-proxy-ingestao-design.md
+++ b/docs/superpowers/specs/2026-08-25-posthog-proxy-ingestao-design.md
@@ -1,0 +1,179 @@
+# Proxy de ingestão do PostHog — desenho
+
+> **Status:** desenho aprovado (2026-08-25). Implementação em plano separado.
+> **Origem:** [`fase-sem-sinal.md`](../../historico/fase-sem-sinal.md) §"A telemetria muda tem causa
+> PROVADA" (PR #1984) · [`analytics.md`](../../agent/analytics.md) §"A amostra é CENSURADA".
+
+## 1. O problema, medido
+
+`us.i.posthog.com` está nas listas de bloqueio comuns. Provado em 2026-08-25 com **par de
+falsificação** — mesma máquina, rede, alvo e minuto:
+
+| cliente | `fetch('https://us.i.posthog.com/i/v0/e/')` |
+|---|---|
+| Chromium limpo | `200 {"status":"Ok"}` em **1112 ms** |
+| Chrome real do founder (151) | `TypeError: Failed to fetch` em **4 ms** |
+
+No MESMO Chrome bloqueado, `us-assets.i.posthog.com` (547 ms), Supabase (422 ms) e
+`fonts.googleapis.com` (154 ms) **passam**. Morre só o endpoint de ingestão.
+
+**A consequência que motiva este trabalho** não é o aparelho do founder: é que a amostra fica
+**censurada, não esparsa**, e a censura correlaciona com quem usa mais. Cliente bloqueado e cliente
+que não usou produzem **o mesmo zero** — o que envenena toda decisão de "fase N+1 exige sinal da
+fase N" lida pelo PostHog.
+
+## 2. Decisões tomadas (e as alternativas recusadas)
+
+| decisão | escolhido | recusado, e por quê |
+|---|---|---|
+| **Onde hospedar** | Edge function do Supabase | Domínio próprio + Cloudflare Worker (caminho de deploy NOVO, fora de Lovable+Supabase, sem dono no repo) · proxy gerenciado do PostHog (exige domínio próprio **e** plano pago) |
+| **Escopo do tráfego** | Tudo que o SDK já manda hoje | Só `track()`+pageview (perderia o denominador do autocapture) · só aparelhos internos (não resolve a população externa, que é o motivo do trabalho) |
+| **Se o proxy cair** | Sem fallback; a edge se mede | Fallback pro host direto (reintroduz a ambiguidade recém-eliminada) · fallback carimbado (mais código, e o carimbo só chega quando o evento chega — não mostra a queda) |
+
+⚠️ **`supabase.co` não é literalmente first-party.** Foi escolha consciente: o domínio não está em
+lista de bloqueio nenhuma, então derruba o bloqueador na prática, ao custo de o proxy acompanhar o
+backend se um dia ele mudar. Um domínio próprio continua sendo o upgrade natural.
+
+## 3. Arquitetura
+
+```
+browser ──> fzvklzpomgnyikkfkzai.supabase.co/functions/v1/posthog-proxy/<caminho>
+                          │
+                          ├─ /static/*, /array/*  ──> us-assets.i.posthog.com
+                          └─ resto (allowlist)    ──> us.i.posthog.com
+```
+
+### 3.1 Por que o proxy PRECISA rotear dois upstreams
+
+Não é opcional nem "por garantia". Verificado na fonte do `posthog-js` **1.373.4** instalado
+(`node_modules/posthog-js/dist/module.js`, `endpointFor`):
+
+```js
+if(this.region===Rn)return this.apiHost+e;
+```
+
+O trecho é **literal do bundle minificado** (por isso ilegível): `Rn` é a constante `"custom"` e `e`
+é o caminho já normalizado com `/` na frente. Um `api_host` que não casa
+`/(app|us|us-assets)(\.i)?\.posthog\.com/` faz a região virar `"custom"`,
+e aí **todo** tipo de endpoint — inclusive `assets` — resolve para `apiHost + caminho`. Ou seja: ao
+apontar o `api_host` pro proxy, o SDK passa a pedir `/static/surveys.js` e
+`/array/<token>/config.js` **do proxy também**. Um proxy que só encaminhasse a ingestão deixaria o
+SDK sem config remota.
+
+### 3.2 Roteamento
+
+| caminho recebido | upstream | classe (p/ o contador) |
+|---|---|---|
+| `/static/*` | `us-assets.i.posthog.com` | `assets` |
+| `/array/*` | `us-assets.i.posthog.com` | `assets` |
+| `/i/v0/e/`, `/e/`, `/batch/` | `us.i.posthog.com` | `ingest` |
+| `/flags*`, `/decide*` | `us.i.posthog.com` | `flags` |
+| `/s/*` (recorder) | `us.i.posthog.com` | `replay` |
+| qualquer outro | — **404** | `recusado` |
+
+Método, query string e corpo passam **crus**. O corpo pode vir `gzip`-ado
+(`?compression=gzip-js`) ou como `x-www-form-urlencoded` com `data=<base64>` — o proxy **não
+interpreta**, repassa bytes.
+
+### 3.3 O que torna a edge segura (é o risco real, não a latência)
+
+Uma edge pública que encaminha para fora é um **open proxy** se mal feita.
+
+- **O upstream NUNCA vem da requisição.** Dois hosts fixos no código; host vindo do cliente é
+  ignorado, não sanitizado.
+- **Allowlist de caminho** (tabela acima). Fora dela: `404`, sem encaminhar.
+- **Headers de entrada descartados**, exceto `content-type` e `content-encoding`. Em especial o
+  `Authorization` do cliente **não sobe** — senão o JWT do Supabase vaza pro PostHog.
+- **Cookies não sobem** (nem `Cookie`, nem repasse de `Set-Cookie` de volta).
+- **Teto de corpo** de 1 MB; acima disso `413`.
+- `verify_jwt = false` no `config.toml` — **obrigatório**, não conveniência: o `$pageview` acontece
+  antes do login, e o caminho `keepalive` não consegue mandar header de auth.
+- CORS: origem do app em allowlist, `POST, GET, OPTIONS`, `access-control-max-age: 3600`.
+
+## 4. A edge se mede (o único sinal honesto de adoção)
+
+Incremento atômico por `(dia, classe, status_upstream)` — **uma linha por dia/classe/status**, não
+por requisição. Chamado em **fire-and-forget** (`EdgeRuntime.waitUntil`) para não somar latência à
+resposta proxiada.
+
+```sql
+create table public.posthog_proxy_stats (
+  dia    date     not null,
+  classe text     not null,   -- ingest | assets | flags | replay | recusado
+  status smallint not null,   -- status do upstream (0 = falha de rede)
+  n      bigint   not null default 0,
+  primary key (dia, classe, status)
+);
+```
+
+Escrita por RPC `SECURITY DEFINER` com `on conflict … do update set n = n + 1`, chamada pela edge
+com a service role. **`REVOKE` nomeando `anon` e `authenticated`** (a regra do `database.md`:
+`REVOKE FROM PUBLIC` não tira as duas). RLS ligada na tabela desde a criação.
+
+**Por que isto existe:** é o contador **imune ao bloqueador e ao próprio PostHog**. Sem ele, "o
+proxy quebrou" e "ninguém usou" voltam a ser o mesmo zero — exatamente o defeito que este trabalho
+existe para corrigir. Com ele, a queda se lê pelo `psql-ro`, sem depender do canal que caiu.
+
+## 5. Mudança no cliente: zero código
+
+`src/lib/analytics.ts:32` **já** lê a env:
+
+```ts
+const HOST = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) ?? 'https://us.i.posthog.com';
+```
+
+Basta definir `VITE_POSTHOG_HOST` no Lovable apontando pra edge. Nenhuma linha de TS muda.
+
+## 6. O que este desenho NÃO resolve — explícito de propósito
+
+**A 4ª camada de deploy.** O efeito só chega depois de env → rebuild → Publish → **o cliente aceitar
+o SW** (`registerType: 'prompt'`, `skipWaiting` removido de propósito). Clientes existentes seguem no
+host antigo por tempo indefinido.
+
+E o círculo que isso fecha: **os clientes bloqueados são justamente os que não conseguimos ver
+aceitando**. Medir a adoção do proxy pelo PostHog seria circular. É por isso que o contador da §4 não
+é enfeite — é o **denominador**, e a leitura de sucesso sai dele, não da série de eventos.
+
+### Lacuna conhecida, registrada como tal
+
+No `endpointFor`, `flagsApiHost` é consultado **antes** do ramo `custom`. Se ele não herdar o
+`api_host`, feature flags continuariam saindo pelo host bloqueado. Não quebra evento, e o app não
+aparenta usar flags. **Verificar na implementação** — não trava o desenho, e registrar aqui evita
+que vire descoberta cara depois.
+
+## 7. Teste
+
+- **Lógica de roteamento extraída PURA** (`rotearCaminho(pathname) → {upstream, classe} | null`),
+  testada pela suíte Deno. O `test:edges` roda com `--no-remote` ⇒ o teste **não pode ter import
+  remoto**; extrair a função pura é o que torna isso possível. **Nunca afrouxar o flag.**
+- **Falsificação obrigatória**, e ela é o teste que importa: sabotar a allowlist (aceitar um caminho
+  fora dela) e **exigir vermelho**. Um teste de allowlist que passa com a allowlist quebrada é
+  teatro. **Commitar antes de falsificar** — `restaurar()` costuma ser `git checkout --`.
+- Casos negativos que precisam de asserção própria: host vindo do cliente é ignorado · `Authorization`
+  de entrada não aparece na requisição upstream · corpo > 1 MB devolve `413`.
+- Lembrar dos **3 gates de edge** que não se cobrem (`test:edges`, `edges:typecheck`, e o vitest que
+  lê a edge como TEXTO).
+
+## 8. Deploy — três camadas manuais, nesta ordem
+
+1. **Migration** (tabela + RPC + RLS + REVOKE) — via SQL Editor do Lovable, pelo ritual
+   `lovable-db-operator`. Não auto-aplica, e a falha é silenciosa.
+2. **Edge** `posthog-proxy` — deploy manual.
+3. **Env `VITE_POSTHOG_HOST`** no Lovable + **Publish**.
+
+A ordem importa: env antes da edge existir manda todo evento para um 404.
+
+## 9. Verificação em produção — o mesmo par que provou o problema
+
+Não basta "está no ar". A prova é a assimetria de hoje **invertida**:
+
+1. Contador da §4 subindo (`psql-ro`) — prova que a edge recebe.
+2. **`$pageleave` com `$lib='web'` saindo do Chrome BLOQUEADO do founder** — o cliente que hoje
+   emite zero. Esse é o sinal que não existe hoje e que nenhum outro substitui.
+3. Controle negativo: com a env revertida, o mesmo Chrome volta a não emitir.
+
+## 10. Rollback
+
+Apagar a env `VITE_POSTHOG_HOST` no Lovable e republicar: o `?? 'https://us.i.posthog.com'` do
+`analytics.ts:32` devolve o comportamento atual. A edge e a tabela podem ficar — inertes, sem
+tráfego. Rollback **não** exige tocar em banco.


### PR DESCRIPTION
Só **documento**: nenhuma linha de edge, migration ou env. É a spec aprovada e o plano de execução do proxy que tira a telemetria de browser de baixo do bloqueador — causa provada no [#1984](https://github.com/LucasSardenbergL/afiacao/pull/1984).

## O que está aqui

- [`specs/2026-08-25-posthog-proxy-ingestao-design.md`](docs/superpowers/specs/2026-08-25-posthog-proxy-ingestao-design.md) — desenho, com as **alternativas recusadas registradas** (Cloudflare Worker e proxy gerenciado: os dois exigem domínio próprio e um caminho de deploy sem dono no repo).
- [`plans/2026-08-25-posthog-proxy-ingestao.md`](docs/superpowers/plans/2026-08-25-posthog-proxy-ingestao.md) — 5 tarefas, cada uma com teste, falsificação e commit próprios.

## Os dois fatos verificados na fonte, não assumidos

- **`endpointFor` do `posthog-js` 1.373.4:** com `api_host` custom a região vira `"custom"` e **todo** endpoint — inclusive `assets` — sai de `apiHost + caminho`. É por isso que o proxy precisa rotear **dois** upstreams; um que só encaminhasse a ingestão deixaria o SDK sem config remota.
- **`analytics.ts:32` já lê `VITE_POSTHOG_HOST`** ⇒ a mudança no cliente é **zero código**.

## A decisão de desenho que não é óbvia

O contador server-side na edge não é enfeite. Os clientes bloqueados são justamente os que **não conseguimos ver aceitando o SW**, então medir a adoção do proxy pelo PostHog seria circular. O contador é o denominador imune — sem ele, "o proxy quebrou" e "ninguém usou" voltam a ser o mesmo zero, que é exatamente o defeito que este trabalho existe para corrigir.

## Duas lacunas achadas no self-review e corrigidas

- O **`flagsApiHost`** que a spec mandou "verificar na implementação" não tinha passo nenhum — ia evaporar. Agora tem passo, com os três desfechos escritos e a instrução de **não** assumir o otimista.
- O **teto de corpo** é I/O e não alcança suíte sob `--no-remote`. Em vez de teste de fachada, virou `curl` contra o deploy real esperando 413 — comando rodado para confirmar que gera 1.200.000 bytes de verdade.

## Escopo — o que este PR NÃO faz

Nada vai a produção. Sem edge, sem migration, sem env. **Não há "⚠️ migration manual" pendente neste PR** — a migration está escrita no plano, para ser aplicada quando a implementação rodar.

## Validação

`bun run docs:citacoes` (21 citações verificadas contra o conteúdo real) · `docs:links` (608 docs, todo link relativo resolve) · `docs:indice` — os três `exit 0` **com contagem**, não só código de saída.

🤖 Generated with [Claude Code](https://claude.com/claude-code)