### PR TITLE
fix(citacoes): "21 verificadas ✓" lia como cobertura TOTAL — o gate agora conta as 596 que ficam fora do escopo

### DIFF
--- a/scripts/docs-citacoes-gate-check.test.ts
+++ b/scripts/docs-citacoes-gate-check.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
 import {
   auditarCitacoes,
   CONGELADOS,
+  contarCitacoesEm,
+  formatarResumo,
+  lerDocsForaDoEscopo,
   lerDocsVivos,
   parseCitacoes,
   type Citacao,
@@ -12,6 +18,21 @@ const DOC = 'docs/agent/exemplo.md';
 
 /** Leitor injetado: o auditor não toca disco, então o "repo" é este Map. */
 const repo = (arquivos: Record<string, string>) => (p: string) => arquivos[p] ?? null;
+
+/** Repo de mentira em disco: quem anda em diretório de verdade precisa de diretório de verdade. */
+const fixtures: string[] = [];
+const fixture = (arquivos: Record<string, string>) => {
+  const raiz = mkdtempSync(join(tmpdir(), 'citacoes-gate-'));
+  fixtures.push(raiz);
+  for (const [rel, texto] of Object.entries(arquivos)) {
+    mkdirSync(dirname(join(raiz, rel)), { recursive: true });
+    writeFileSync(join(raiz, rel), texto);
+  }
+  return raiz;
+};
+afterAll(() => {
+  for (const f of fixtures) rmSync(f, { recursive: true, force: true });
+});
 
 const cita = (alvo: string, linhas: string[], ancora: string | null): Citacao => ({
   doc: DOC,
@@ -243,5 +264,101 @@ describe('lerDocsVivos — escopo', () => {
     expect(vivos.some((v) => v.startsWith('docs/historico/'))).toBe(false);
     expect(vivos.some((v) => v.startsWith('docs/superpowers/'))).toBe(false);
     expect(vivos.some((v) => v.startsWith('docs/ux-audit/'))).toBe(false);
+  });
+});
+
+describe('parseCitacoes — o que foi PULADO também é relato', () => {
+  // "21 citações verificadas ✓" lê como cobertura TOTAL tanto quando o gate cobriu tudo quanto
+  // quando deixou centenas de fora. Corte deliberado que não aparece no log é indistinguível de
+  // cobertura completa para quem lê o CI — é o "no silent caps" da skill `matar-classe`.
+  it('conta a citação pulada por cerca em vez de sumir com ela', () => {
+    const p = parseCitacoes(DOC, 'antes\n```\n`src/a.ts:12`<!--cita: exemplo-->\n```\ndepois');
+    expect(p.citacoes).toHaveLength(0);
+    expect(p.emCerca).toBe(1);
+  });
+
+  // Calibração inversa: sem ela, um contador que devolve sempre "tem pulo" passaria igual.
+  it('não inventa pulo onde não houve — citação inline conta 0 em cerca', () => {
+    const p = parseCitacoes(DOC, 'veja `src/a.ts:12`<!--cita: const x--> aqui');
+    expect(p.citacoes).toHaveLength(1);
+    expect(p.emCerca).toBe(0);
+  });
+
+  it('a citação engolida por cerca ABERTA também entra na conta de pulos', () => {
+    const p = parseCitacoes(DOC, 'a\n```ts\n`src/a.ts:12`<!--cita: x-->');
+    expect(p.citacoes).toHaveLength(0);
+    expect(p.emCerca).toBe(1);
+  });
+});
+
+describe('fora do escopo — o gate diz o que NÃO olhou', () => {
+  it('lista o doc congelado por diretório, que o varredor de vivos nunca vê', () => {
+    const raiz = fixture({
+      'docs/agent/vivo.md': 'vivo',
+      'docs/historico/datado.md': 'datado',
+      'docs/superpowers/specs/plano.md': 'spec',
+    });
+    const fora = lerDocsForaDoEscopo(raiz);
+    expect(fora).toContain('docs/historico/datado.md');
+    expect(fora).toContain('docs/superpowers/specs/plano.md');
+    expect(fora).not.toContain('docs/agent/vivo.md');
+  });
+
+  // Calibração inversa OBRIGATÓRIA: sem este caso, um contador travado em 0 passaria no de cima
+  // (que só exige "≥ 1 fora") e o relato voltaria a mentir cobertura total.
+  it('reporta ZERO quando o repo não tem doc nenhum fora do escopo', () => {
+    expect(lerDocsForaDoEscopo(fixture({ 'docs/agent/vivo.md': 'só vivo aqui' }))).toEqual([]);
+  });
+
+  // Artefato datado que mora DENTRO de pasta viva sai pelo nome — e sair do escopo é sair do
+  // escopo: ele conta como pulo igual ao congelado por diretório.
+  it('o arquivo nominal de CONGELADOS também conta como fora do escopo', () => {
+    const raiz = fixture({ [CONGELADOS[0]]: 'revisão fechada', 'docs/agent/vivo.md': 'vivo' });
+    expect(lerDocsForaDoEscopo(raiz)).toEqual([CONGELADOS[0]]);
+  });
+
+  // O caso que mordeu em 2026-08-25: um doc que ENSINA sobre gate cego, citando quatro PRs, mora
+  // na zona não varrida. Ninguém verificava as citações dele, e o log não dizia isso.
+  it('o doc real que motivou o relato aparece como fora do escopo', () => {
+    expect(lerDocsForaDoEscopo('.')).toContain('docs/historico/verificar-sonda-versao.md');
+  });
+
+  it('conta as citações que moram nos docs não varridos', () => {
+    const n = contarCitacoesEm(['a.md', 'b.md'], (d) =>
+      d === 'a.md' ? '`src/x.ts:1`<!--cita: z--> e `src/y.ts:2`<!--cita: w-->' : '`src/k.ts:3`',
+    );
+    expect(n).toBe(3);
+  });
+
+  // Segunda calibração inversa, agora do contador de citações.
+  it('conta zero quando o doc fora do escopo não cita nada', () => {
+    expect(contarCitacoesEm(['a.md'], () => 'prosa sem citação nenhuma')).toBe(0);
+  });
+
+  // No congelado ninguém verifica NADA — nem o que está entre crases, nem o que está em cerca.
+  it('no doc não varrido a citação em cerca conta como pulo igual', () => {
+    expect(contarCitacoesEm(['a.md'], () => '```\n`src/x.ts:1`<!--cita: z-->\n```')).toBe(1);
+  });
+
+  it('o resumo nomeia quantos pulos houve e por QUAL motivo', () => {
+    const s = formatarResumo({ achados: [], verificadas: 21, externas: 2 }, {
+      emDocNaoVarrido: 553,
+      emCerca: 6,
+    });
+    expect(s).toContain('21 citação(ões) verificada(s)');
+    expect(s).toContain('2 externa(s)');
+    expect(s).toContain('559 fora do escopo');
+    expect(s).toContain('553 em doc não varrido');
+    expect(s).toContain('6 em cerca');
+    expect(s).not.toContain('\n'); // uma linha só — é log de CI, não relatório
+  });
+
+  // Terceira calibração inversa: o resumo tem de saber dizer "não pulei nada".
+  it('com cobertura total o resumo diz 0 fora do escopo, em vez de omitir a cláusula', () => {
+    const s = formatarResumo({ achados: [], verificadas: 3, externas: 0 }, {
+      emDocNaoVarrido: 0,
+      emCerca: 0,
+    });
+    expect(s).toContain('0 fora do escopo');
   });
 });

--- a/scripts/docs-citacoes-gate-check.ts
+++ b/scripts/docs-citacoes-gate-check.ts
@@ -49,6 +49,14 @@
  *    falha de `docs/historico/gates-textuais-cegos.md` de novo. Cerca que nunca FECHA engole o
  *    resto do arquivo e vira achado, quando esconde citação.
  *
+ * Exclusão CALADA, porém, é o mesmo veneno noutra forma. "21 citações verificadas ✓" lê como
+ * cobertura TOTAL tanto quando o gate cobriu tudo quanto quando deixou 596 de fora (medido em
+ * 2026-08-25) — quem lê o log do CI não tem como separar os dois casos, e corte deliberado vira
+ * indistinguível de cobertura completa. Por isso o resumo conta o PULADO por motivo, no verde e no
+ * vermelho, com os zeros explícitos. O caso que cobrou: o §10 de
+ * `docs/historico/verificar-sonda-versao.md` ensina sobre gate cego e cita quatro PRs — de dentro
+ * da zona não varrida, o que só se descobriu lendo o fonte deste gate por outro motivo.
+ *
  * Basename nu (`index.ts:397`) NÃO é exceção: **reprova**. O repo tem 99 `index.ts`, então resolver
  * no chute seria fábrica de falso-positivo — mas *pular* é pior, porque vira a saída de emergência
  * que esvazia o gate (basta escrever o nome curto para nunca mais ser cobrado). Até o #1820 eles
@@ -122,8 +130,9 @@ export interface Achado {
 export function parseCitacoes(
   doc: string,
   texto: string,
-): { citacoes: Citacao[]; achados: Achado[] } {
+): { citacoes: Citacao[]; achados: Achado[]; emCerca: number } {
   const { texto: semCercas, cercaAberta } = removerCercas(texto);
+  const brutas = citacoesEm(doc, texto);
   const citacoes = citacoesEm(doc, semCercas);
 
   // O skip cobra um preço: cerca que nunca fecha esvazia tudo abaixo dela, e um gate que mede só
@@ -143,7 +152,11 @@ export function parseCitacoes(
         ]
       : [];
 
-  return { citacoes, achados };
+  // O que a cerca comeu volta como NÚMERO. A cerca esvazia linha a linha e preserva a numeração,
+  // então a citação que sobrevive ao strip é sempre um subconjunto da bruta — a diferença é
+  // exatamente o pulo. Inclui o que a cerca ABERTA engoliu: aquilo também vira achado, mas pulado
+  // é pulado, e some da medição do mesmo jeito.
+  return { citacoes, achados, emCerca: brutas.length - citacoes.length };
 }
 
 /** O regex sobre um texto JÁ limpo. `offsetLinha` recoloca a numeração do trecho no doc inteiro. */
@@ -164,10 +177,16 @@ function citacoesEm(doc: string, texto: string, offsetLinha = 0): Citacao[] {
   return out;
 }
 
+/**
+ * O que não é "o repo" para este gate: saída de build, vendor — e `.claude`, que hospeda as
+ * WORKTREES. Descer ali reencontraria o repo inteiro uma vez por worktree viva, o que estragaria
+ * tanto o índice de basename quanto a conta do que ficou fora do escopo.
+ */
+const IGNORA = new Set(['node_modules', '.git', 'dist', 'build', '.claude', 'coverage']);
+
 /** Índice basename → caminhos, para resolver citação sem `/` só quando ela for ÚNICA. */
 export function indexarRepo(raiz: string): Map<string, string[]> {
   const idx = new Map<string, string[]>();
-  const IGNORA = new Set(['node_modules', '.git', 'dist', 'build', '.claude', 'coverage']);
   const anda = (d: string) => {
     for (const e of readdirSync(d, { withFileTypes: true })) {
       if (IGNORA.has(e.name)) continue;
@@ -303,6 +322,67 @@ export function lerDocsVivos(raiz = '.'): string[] {
   return out.sort();
 }
 
+/**
+ * O COMPLEMENTO de `lerDocsVivos`: todo markdown do repo que este gate não varre. Calculado, e não
+ * listado à mão, de propósito — uma lista de zonas congeladas dessincroniza da realidade em
+ * silêncio, e o relato voltaria a mentir cobertura. Pega os dois formatos de exclusão: a zona por
+ * diretório (o que não está em `ALVOS_VIVOS`) e o artefato nominal de `CONGELADOS`.
+ */
+export function lerDocsForaDoEscopo(raiz = '.'): string[] {
+  const vivos = new Set(lerDocsVivos(raiz));
+  const out: string[] = [];
+  const anda = (d: string) => {
+    for (const e of readdirSync(d, { withFileTypes: true })) {
+      if (IGNORA.has(e.name)) continue;
+      const q = join(d, e.name);
+      if (e.isDirectory()) anda(q);
+      else if (e.name.endsWith('.md')) {
+        const rel = relative(raiz, q);
+        if (!vivos.has(rel)) out.push(rel);
+      }
+    }
+  };
+  anda(raiz);
+  return out.sort();
+}
+
+/**
+ * Quantas citações moram nos docs que o gate não varre. Conta TUDO que casa com o formato, cerca
+ * inclusive: no doc não varrido ninguém verifica nada, então separar por sub-motivo ali seria
+ * precisão inventada.
+ */
+export function contarCitacoesEm(docs: string[], ler: (doc: string) => string): number {
+  let n = 0;
+  for (const d of docs) {
+    const p = parseCitacoes(d, ler(d));
+    n += p.citacoes.length + p.emCerca;
+  }
+  return n;
+}
+
+/** O que o gate deixou de fora, por MOTIVO. */
+export interface ForaDoEscopo {
+  /** citações em markdown que o gate não varre — congelado por diretório ou nominal */
+  emDocNaoVarrido: number;
+  /** citações dentro de cerca de código, nos docs que ele varre */
+  emCerca: number;
+}
+
+/**
+ * A linha que o CI mostra. Diz o que foi verificado E o que ficou de fora, por motivo — "21
+ * citações verificadas ✓" lê como cobertura TOTAL tanto quando o gate cobriu tudo quanto quando
+ * deixou centenas fora, e quem lê o log não tem como separar os dois casos. Corte deliberado que
+ * não se anuncia é indistinguível de cobertura completa; os zeros ficam explícitos justamente para
+ * o "não pulei nada" ser uma afirmação, e não a ausência da cláusula.
+ */
+export function formatarResumo(r: Resultado, fora: ForaDoEscopo): string {
+  const total = fora.emDocNaoVarrido + fora.emCerca;
+  return (
+    `${r.verificadas} citação(ões) verificada(s) contra o conteúdo real · ${r.externas} externa(s)` +
+    ` · ${total} fora do escopo (${fora.emDocNaoVarrido} em doc não varrido, ${fora.emCerca} em cerca)`
+  );
+}
+
 if (import.meta.main) {
   const raiz = process.cwd();
   const docs = lerDocsVivos(raiz);
@@ -318,7 +398,12 @@ if (import.meta.main) {
   });
 
   const achados = [...parses.flatMap((p) => p.achados), ...r.achados];
-  const resumo = `${r.verificadas} citação(ões) verificada(s) contra o conteúdo real · ${r.externas} externa(s)`;
+  const resumo = formatarResumo(r, {
+    emDocNaoVarrido: contarCitacoesEm(lerDocsForaDoEscopo(raiz), (d) =>
+      readFileSync(join(raiz, d), 'utf8'),
+    ),
+    emCerca: parses.reduce((soma, p) => soma + p.emCerca, 0),
+  });
   if (achados.length === 0) {
     console.log(`docs-citacoes-gate: ✓ ${resumo}.`);
     process.exit(0);


### PR DESCRIPTION
## O que NÃO é

O **escopo** não é o bug e não foi tocado. Excluir `docs/historico/`, `docs/superpowers/` e
`docs/ux-audit/` é decisão de **precisão**, medida e escrita no cabeçalho do próprio gate: 553 das
580 citações do repo moram nesses três, são artefatos **datados**, e cobrá-los para acompanhar a
`main` seria churn sobre história + falso-positivo permanente. Continua excluído.

## O que é

O buraco é de **relato**. A mensagem final contava o verificado e o externo:

```
`${r.verificadas} citação(ões) verificada(s) ... · ${r.externas} externa(s)`
```

Nada dizia o que foi **pulado**. "21 citações verificadas ✓" lê como cobertura **total** tanto
quando o gate cobriu tudo quanto quando deixou 596 de fora — para quem lê o log do CI, corte
deliberado fica indistinguível de cobertura completa. É o *no silent caps* do passo 4 da skill
`matar-classe`.

**O caso que cobrou:** o §10 de `docs/historico/verificar-sonda-versao.md` ensina sobre gates cegos
e cita quatro PRs — de dentro da zona não varrida. Nenhum gate verifica aquelas citações, e só se
descobriu isso lendo o fonte deste gate por outro motivo. Com o relato, aparece no primeiro CI.

## Antes → depois

```
✗  docs-citacoes-gate: ✓ 21 citação(ões) verificada(s) contra o conteúdo real · 2 externa(s).
✓  docs-citacoes-gate: ✓ 21 citação(ões) verificada(s) contra o conteúdo real · 2 externa(s)
   · 596 fora do escopo (596 em doc não varrido, 0 em cerca).
```

Uma linha, no verde **e** no vermelho. **Exit code intacto**: pular por escopo continua sendo sucesso.

## Como

- `parseCitacoes` devolve `emCerca` — a diferença entre a contagem bruta e a que sobrevive ao strip
  de cerca. Inclui o que a cerca **aberta** engoliu: aquilo já vira achado, mas pulado é pulado.
- `lerDocsForaDoEscopo` é o **complemento** de `lerDocsVivos`, calculado e não listado à mão — lista
  de zona congelada dessincroniza em silêncio e o relato voltaria a mentir. Pega os dois formatos de
  exclusão: zona por diretório e artefato nominal de `CONGELADOS`.
- `formatarResumo` monta a linha com os **zeros explícitos** — "não pulei nada" tem de ser afirmação,
  não ausência de cláusula.
- `IGNORA` subiu para o módulo (era local do `indexarRepo`): `.claude` hospeda as **worktrees**, e
  descer ali contaria o repo inteiro uma vez por worktree viva.

## Prova

TDD: 12 testes escritos primeiro, os 12 vermelhos por feature ausente antes de qualquer linha de
implementação.

**Falsificação — cada contador novo sabotado, exigindo vermelho:**

| sabotagem | rc | linhas `FAIL` |
|---|---|---|
| `emCerca := 0` | 1 | 6 |
| `lerDocsForaDoEscopo := []` | 1 | 3 |
| `contarCitacoesEm := 0` | 1 | 2 |
| restauro | **0** | — |

**Falsificação e2e do fio no `main`** (que teste unitário não alcança) — citação plantada num doc
vivo, dentro de cerca, e num doc não varrido:

```
BASE      : ... 592 fora do escopo (592 em doc não varrido, 0 em cerca).
COM CERCA : ... 593 fora do escopo (592 em doc não varrido, 1 em cerca).
COM CONGE.: ... 593 fora do escopo (593 em doc não varrido, 0 em cerca).
RESTAURADO: ... 592 fora do escopo (592 em doc não varrido, 0 em cerca).   rc=0
```

Calibrado nos **dois sentidos**, como manda o gate contra contador travado: fixture com congelado
exige `≥ 1` fora do escopo, fixture só com doc vivo exige `[]`, e o resumo com tudo coberto exige
`0 fora do escopo` escrito.

O `0 em cerca` de hoje é **real**, não contador morto: 25 citações brutas nos docs vivos − 2 do
congelado nominal = 23 = 21 verificadas + 2 externas.

## Verde colado

```
heavy bun run test  → Test Files 742 passed (742) · Tests 7250 passed | 1 skipped (7251) · TEST=0
bunx knip           → KNIP=0
scripts:typecheck   → TCS=0
eslint scripts/     → LINT=0
bun run docs:citacoes → rc=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
