### PR TITLE
fix(authz): o gate de funções media a GRAFIA e concluía o EFEITO — 7 formas de `DROP` e o `ALL ROUTINES` reabriam calados [money-path]

### DIFF
--- a/docs/historico/verificar-sonda-versao.md
+++ b/docs/historico/verificar-sonda-versao.md
@@ -434,3 +434,96 @@ Gate: `src/lib/gates/retorno-consumido.ts`, calibrado nos dois sentidos em
 `src/lib/gates/__tests__/retorno-consumido.test.ts` (28 casos: 7 formas de descarte que reprovam, 6
 formas legítimas REAIS + 1 inventada que aprovam, cegueira, 1-de-2, definição≠chamada, e as 9 edges
 de hoje).
+
+## 11. A varredura da §10 nos gates de SQL: o suspeito de novo não existia, e o furo era a GRAFIA (2026-08-25)
+
+Briefing em `db/diagnostico/BRIEFING-varredura-gates-sql.md`, queries em
+`db/diagnostico/authz-funcoes-acl-real.sql`. Alvo: `scripts/authz-funcoes.test.ts` + o manifesto
+(`AUTHZ_MANIFEST`/`ACKNOWLEDGED_SENSITIVE`/`ACL_ONLY_INTERNAL`), secundário
+`scripts/sonda-versao-sql.test.ts`.
+
+**O suspeito nomeado não existe — medido, não deduzido.** O briefing apostava no vetor
+`DROP FUNCTION`+`CREATE` reabrindo função em prod sem nenhum `GRANT` no repo. Prod diz que não:
+`bun run authz:funcoes:prod` sai **0** ("o EXECUTE de prod bate com o contrato nas 43"), e a query 4
+(`proacl IS NULL`, o rastro do reset) devolve **0 linhas** — toda função de `public` tem ACL
+explícito. Panorama das 454 de `public`: 196 INVOKER (RLS aplica), 189 SECURITY DEFINER com
+**1 só** alcançável por `anon` — `public.get_public_tool_history(uuid)`, deliberada
+(`20260604180000_public_tool_history_rpc.sql`, consumida por `src/queries/useUserTools.ts`) — e 69
+de trigger, que a query 3 acusa mas o PostgREST não expõe como RPC. Nada a revogar.
+
+**O furo estava no GATE, e a assinatura com controle o achou em dois pontos.** A forma errada do
+briefing REPROVA (`FUNCAO_RECRIADA_SEM_FECHO`). Sondadas as grafias VIZINHAS, 18 no total contra as
+666 migrations reais: **7 passavam caladas**.
+
+| # | Grafia | Por quê passava |
+| --- | --- | --- |
+| 1 | `DROP FUNCTION IF EXISTS public.f;` | `alvosDrop` exigia `nome(` |
+| 2 | idem + `CASCADE` | idem |
+| 3 | idem com aspas / 4 sem schema / 5 sem `IF EXISTS` | idem |
+| 6 | `DROP ROUTINE …` (com ou sem args) | o statement casava só `^DROP FUNCTION` |
+| 7 | lista MISTA (`public.a(uuid), public.f`) | o elemento sem parêntese sumia |
+
+Não é grafia exótica: a lista de argumentos é **opcional desde o PG10** quando o nome é único no
+schema, e `ROUTINE` é sinônimo. Provado em PG17 descartável: `DROP FUNCTION public.f;` + `CREATE`
+deixa `proacl` NULL e devolve `EXECUTE` a `anon` **igual** à forma com args; `DROP ROUTINE`, idem;
+`CREATE OR REPLACE` preserva o ACL (o controle); e com overload o PG **recusa** omitir os args — a
+fronteira do furo é "nome único", medida, não suposta.
+
+**O segundo ponto é pior que o primeiro, e apareceu por sondar o ramo vizinho.**
+`GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public TO anon;` reabre as **43 de uma vez, sem citar
+nenhuma pelo nome** — e passava calado, porque `parseAcl` lia só a palavra `FUNCTION(S)`. Mesma
+cegueira no aviso de `ALTER DEFAULT PRIVILEGES … ON ROUTINES`. E `GRANT … ON ROUTINE public.f(uuid)
+TO service_role` — legítimo — caía no fail-closed: o gate reprovava código correto, que é o começo
+de todo afrouxamento.
+
+**Conserto POSICIONAL, no padrão do #2001:** o corte é o NOME que ABRE cada elemento da lista do
+`DROP` (args opcionais, vírgula de topo, `CASCADE`/`RESTRICT` fora), e `ROUTINE(S)` entra como
+sinônimo em `parseAcl`. `PROCEDURES` fica de fora **de propósito** — o PG não derruba função por
+`DROP PROCEDURE` nem alcança função com `ALL PROCEDURES`, então incluí-la seria falso-positivo.
+De quebra, o ramo do `DROP` ganhou o fail-closed que o ramo do `GRANT` já tinha
+(`FUNCAO_DROP_NAO_PARSEAVEL`): **os dois ramos do mesmo arquivo divergiam, e só um não podia afirmar
+que estava tudo bem.**
+
+Calibração nos dois sentidos: 18/18 grafias erradas reprovam (era 11/18) e as formas legítimas
+seguem caladas — inclusive `REVOKE … ON ALL ROUTINES`, `GRANT ON ROUTINE` a role permitida e
+`ALL PROCEDURES`. Contra o repo real, o conjunto de achados é **byte-idêntico ao da `main`**
+(666 migrations, 0 achados): zero falso-positivo. Falsificação em código real, 3 sabotagens:
+tirar o corte posicional = **15 vermelhas**; tirar o `ROUTINE` = **5**; tirar o fail-closed = **1**.
+
+### A varredura completa — 16 sites, 1 afetado
+
+Critério (o da §10, traduzido para SQL): *o gate casa uma GRAFIA e conclui o EFEITO?* Varridos os
+gates que leem SQL como texto:
+
+- **Afetado (1):** `scripts/lib/authz-funcoes.ts` (+ a calibração em `scripts/authz-funcoes.test.ts`).
+- **Imunes por construção (5):** `scripts/lib/authz-contract.ts`, `scripts/lib/migration-objects.ts`,
+  `src/__tests__/import-tint-formulas-aposentada-gate.test.ts` casam `CREATE … FUNCTION` — e
+  **`CREATE ROUTINE` não existe no PostgreSQL**, então a grafia é única e não há o que escapar;
+  `scripts/lib/authz-reescrita.ts` exclui `EXECUTE FUNCTION|PROCEDURE`, que também esgota a sintaxe.
+  `scripts/lib/authz-grants.ts` (Parte C, tabelas) já era **fail-closed** e nem depende de parsear
+  `DROP`: julga o `CREATE TABLE` sozinho. Era o irmão bem-feito ao lado do furo.
+- **Falso-positivo da assinatura (10):** `scripts/sonda-versao-sql.test.ts` (o alvo secundário do
+  briefing — o valor de retorno de `gerarSqlDaLeva` **é** o SQL que o assert lê, então o assert já
+  segue o valor até a fronteira), `scripts/audit-custom-migrations.ts` e
+  `scripts/wt-preflight-migration.ts` (heurístico DECLARADO, e o que afirmam é inventário/colisão,
+  não efeito), `scripts/sql-comentarios.test.ts` (é o stripper compartilhado, com sentinela),
+  `scripts/docs-links-gate-check.ts`, `scripts/cep-aberto/importar-carteira.ts`,
+  `scripts/authz-gate-check{,.test}.ts`, `scripts/lib/migration-objects.test.ts`, e os três gates de
+  PARIDADE (`afinidade-nao-e-dinheiro`, `titulo-status-paridade`, `BotoesDesfechoRecomendacao`), que
+  já trazem CONTROLE explícito contra regex que não casa.
+
+**Cobertura fora de `supabase/migrations/` — medida, não presumida.** O gate estático só lê
+`supabase/migrations/`, e o projeto tem um canal paralelo (`db/*.sql` aplicado à mão, como o #1090).
+Varridos os 52 `db/*.sql` contra as 43 do contrato: **0 pares `DROP`+`CREATE`**. O único `CREATE OR
+REPLACE` (`prod-sentinela-base-20260702.sql` → `_data_health_compute`) preserva o ACL, logo não é
+vetor. O canal existe e hoje está vazio; quem o cobre de verdade é `authz:funcoes:prod`.
+
+### A lição que generaliza
+
+A §9 disse "o assert tem de seguir o valor até a fronteira". A §11 acrescenta o eixo que faltava:
+**quando a fronteira é uma LINGUAGEM, seguir o valor não basta — é preciso cobrir as grafias que a
+linguagem trata como equivalentes.** `FUNCTION`/`ROUTINE`, args opcionais, `ALL … IN SCHEMA`: o
+gate media a palavra e afirmava o alcance. O teste barato que pega isso não é ler o regex, é
+**montar a forma errada em N grafias e contar quantas o gate deixa passar** — 7 de 18 aqui, e
+nenhuma delas visível na leitura.
+

--- a/scripts/authz-funcoes.test.ts
+++ b/scripts/authz-funcoes.test.ts
@@ -173,6 +173,69 @@ describe('auditGrantsFuncoes — reabertura por GRANT', () => {
     expect(r).toEqual([]);
   });
 
+  // ══════════════════════════════════════════════════════════════════════════════════════
+  // `ROUTINE`/`ROUTINES` é sinônimo de `FUNCTION`/`FUNCTIONS` no PG11+ e alcança as mesmas
+  // funções. Ler só a grafia `FUNCTION` media a PALAVRA e concluía o alcance — e o pior caso não
+  // é uma função: `GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public TO anon` reabre TODAS as 43
+  // do contrato de uma vez, sem citar nenhuma pelo nome (medido: passava calado).
+  // ══════════════════════════════════════════════════════════════════════════════════════
+  const REABRE_POR_ROUTINE: [string, string][] = [
+    ['ON ROUTINE com args', 'GRANT EXECUTE ON ROUTINE public.f(uuid) TO anon;'],
+    ['ON ROUTINE sem args', 'GRANT EXECUTE ON ROUTINE public.f TO anon;'],
+    ['ON ALL ROUTINES IN SCHEMA — atinge sem citar o nome', 'GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public TO anon;'],
+  ];
+
+  it.each(REABRE_POR_ROUTINE)('GRANT com a grafia ROUTINE acusa FUNCAO_REABERTURA: %s', (_nome, sql) => {
+    const r = auditGrantsFuncoes([ANCORA, { file: '20260202000000_x.sql', sql }], ALLOW);
+    expect(cods(r)).toEqual(['FUNCAO_REABERTURA']);
+    expect(r[0].funcao).toBe('public.f');
+    expect(r[0].level).toBe('error');
+  });
+
+  // Sentido oposto: a MESMA grafia usada legitimamente tem de ficar quieta. Sem isto o bloco acima
+  // seria compatível com "a palavra ROUTINE acusa sempre" — e o conserto de um gate que reprova
+  // código correto é sempre afrouxá-lo.
+  it('GRANT ON ROUTINE a role PERMITIDA fica quieto', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'GRANT EXECUTE ON ROUTINE public.f(uuid) TO authenticated, service_role;' }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  it('REVOKE ON ALL ROUTINES IN SCHEMA restaura o fecho tanto quanto ALL FUNCTIONS', () => {
+    const r = auditGrantsFuncoes(
+      [
+        ANCORA,
+        {
+          file: '20260202000000_x.sql',
+          sql: 'GRANT EXECUTE ON FUNCTION public.f(uuid) TO anon;\nREVOKE EXECUTE ON ALL ROUTINES IN SCHEMA public FROM anon;',
+        },
+      ],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  // Precisão: `PROCEDURES` NÃO alcança função (o PG separa as categorias), então tratá-la como
+  // alcance seria falso-positivo. A distinção é medida, não suposta.
+  it('ALL PROCEDURES IN SCHEMA não alcança função — não inventa achado', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'GRANT EXECUTE ON ALL PROCEDURES IN SCHEMA public TO anon;' }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  it('ALTER DEFAULT PRIVILEGES sobre ROUTINES avisa igual a FUNCTIONS', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT EXECUTE ON ROUTINES TO anon;' }],
+      ALLOW,
+    );
+    expect(cods(r)).toEqual(['FUNCAO_DEFAULT_PRIVILEGE_ALTERADO']);
+    expect(r[0].level).toBe('warn');
+  });
+
   it('GRANT dentro de COMENTÁRIO não acusa', () => {
     const r = auditGrantsFuncoes(
       [ANCORA, { file: '20260202000000_x.sql', sql: '-- GRANT EXECUTE ON FUNCTION public.g() TO anon;\nSELECT 1;' }],
@@ -313,6 +376,97 @@ describe('auditGrantsFuncoes — recriação que RESETA o ACL (o vetor DROP+CREA
     expect(r).toEqual([]);
   });
 
+  // ══════════════════════════════════════════════════════════════════════════════════════
+  // A lista de argumentos é OPCIONAL (PG10+, nome único no schema) e `ROUTINE` é sinônimo. Exigir
+  // `nome(` media a GRAFIA e concluía o EFEITO — 7 de 18 grafias passavam caladas. Provado em PG17:
+  // `DROP FUNCTION public.f;` + CREATE deixa proacl NULL e devolve EXECUTE a anon, igual à forma com
+  // args; `DROP ROUTINE`, idem; `CREATE OR REPLACE` preserva o ACL (o controle).
+  // ══════════════════════════════════════════════════════════════════════════════════════
+  const SEM_PARENTESE: [string, string][] = [
+    ['sem lista de argumentos', 'DROP FUNCTION IF EXISTS public.g;'],
+    ['sem args + CASCADE', 'DROP FUNCTION IF EXISTS public.g CASCADE;'],
+    ['sem args, identificador entre aspas', 'DROP FUNCTION IF EXISTS public."g";'],
+    ['sem args e sem schema (public implícito)', 'DROP FUNCTION IF EXISTS g;'],
+    ['sem args, sem IF EXISTS', 'DROP FUNCTION public.g;'],
+    ['ROUTINE com args', 'DROP ROUTINE IF EXISTS public.g();'],
+    ['ROUTINE sem args', 'DROP ROUTINE IF EXISTS public.g;'],
+    ['lista MISTA: outra com args, o alvo sem', 'DROP FUNCTION IF EXISTS public.outra(uuid), public.g;'],
+  ];
+
+  it.each(SEM_PARENTESE)('recriação SEM parêntese acusa mesmo assim: %s', (_nome, dropSql) => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: `${dropSql}\n${create('public.g')}` }],
+      ALLOW,
+    );
+    expect(cods(r)).toEqual(['FUNCAO_RECRIADA_SEM_FECHO']);
+    expect(r[0].funcao).toBe('public.g');
+  });
+
+  // Calibração no sentido OPOSTO: a mesma grafia sem parêntese, COM o REVOKE que restaura o fecho,
+  // tem de ficar quieta. Sem isto o bloco acima seria compatível com "acusa sempre".
+  it.each(SEM_PARENTESE)('a MESMA grafia com REVOKE das duas roles fica quieta: %s', (_nome, dropSql) => {
+    const r = auditGrantsFuncoes(
+      [
+        ANCORA,
+        {
+          file: '20260202000000_x.sql',
+          sql: `${dropSql}\n${create('public.g')}\nREVOKE EXECUTE ON FUNCTION public.g() FROM anon, authenticated;`,
+        },
+      ],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  // Cegueira (lição do #2001: calibração negativa que aponta para o nome errado fica verde de graça).
+  // A sentinela é o CONTROLE: se a grafia sem parêntese acusasse por acidente de âncora textual, este
+  // DROP de função NÃO classificada também acusaria — e ele tem de ficar quieto.
+  it('SENTINELA: DROP sem parêntese de função FORA do contrato não inventa achado', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: `DROP FUNCTION IF EXISTS public.nao_classificada;\n${create('public.nao_classificada')}` }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  // Sufixo/homônima continuam desambiguadas na forma sem parêntese — o corte é o NOME inteiro.
+  it('nome com SUFIXO não é confundido na grafia sem parêntese', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: `DROP FUNCTION IF EXISTS public.g_extra;\n${create('public.g_extra')}` }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  it('homônima em OUTRO schema não é confundida na grafia sem parêntese', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: `DROP FUNCTION IF EXISTS outro.g;\nCREATE FUNCTION outro.g() RETURNS int LANGUAGE sql AS $$ SELECT 1 $$;` }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
+  // Fail-closed simétrico ao do GRANT: DROP que CITA a protegida numa forma que o parser não leu
+  // não pode sair calado. `DROP PROCEDURE` é o caso concreto — o PG recusa derrubar função por ele,
+  // então não é vetor, mas também não é motivo para o gate afirmar que está tudo bem.
+  it('DROP numa forma que o parser não entende é fail-closed', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'DROP FUNCTION IF EXISTS (SELECT public.g);' }],
+      ALLOW,
+    );
+    expect(cods(r)).toEqual(['FUNCAO_DROP_NAO_PARSEAVEL']);
+    expect(r[0].funcao).toBe('public.g');
+    expect(r[0].level).toBe('error');
+  });
+
+  it('DROP que NÃO cita função protegida segue silencioso mesmo sem ser parseável', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'DROP FUNCTION IF EXISTS (SELECT public.nada_a_ver);' }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
+  });
+
   it('DROP+CREATE ANTERIOR à âncora não conta', () => {
     const r = auditGrantsFuncoes(
       [{ file: '20250101000000_antes.sql', sql: `${drop('public.g')}\n${create('public.g')}` }, ANCORA],
@@ -435,6 +589,49 @@ describe('auditGrantsFuncoes — contra o repo REAL', () => {
     ];
     for (const fn of alvo) {
       const r = auditGrantsFuncoes(semRevokeNaMigrationDoDrop(fn), AUTHZ_FUNCOES_FECHADAS).filter(
+        (f) => f.codigo === 'FUNCAO_RECRIADA_SEM_FECHO' && f.funcao === fn,
+      );
+      expect(r.length, fn).toBeGreaterThan(0);
+    }
+  });
+
+  /** Reescreve o `DROP FUNCTION <fn>(args)` REAL para a grafia SEM parêntese, e tira o REVOKE da
+   *  mesma migration. É a sabotagem do #2001 aplicada à grafia nova: se o detector voltasse a
+   *  exigir o `(`, este DROP some do radar e o teste abaixo fica verde por CEGUEIRA. */
+  const semParenteseNoDropReal = (fn: string) =>
+    migrations.map((m) =>
+      m.sql.includes(`DROP FUNCTION IF EXISTS ${fn}`)
+        ? {
+            ...m,
+            sql: m.sql
+              .replace(new RegExp(`DROP FUNCTION IF EXISTS ${fn}\\s*\\([^)]*\\)`, 'g'), `DROP FUNCTION IF EXISTS ${fn}`)
+              .replace(/REVOKE\s+(?:EXECUTE|ALL)[^;]*;/gi, '-- revoke removido'),
+          }
+        : m,
+    );
+
+  // Anti-inércia da grafia NOVA, contra o repo REAL — não contra fixture. Sem isto, os casos
+  // sintéticos acima seriam compatíveis com "o detector novo nunca roda no pipeline de verdade".
+  it('a grafia SEM parêntese é enxergada no repo REAL (não só em fixture)', () => {
+    const alvo = [
+      'public.get_ultimos_precos_cliente',
+      'public.get_regua_preco',
+      'public.tint_calc_preco_final',
+      'public.tint_recalc_preco_oficial',
+    ];
+    for (const fn of alvo) {
+      const mutadas = semParenteseNoDropReal(fn);
+      // SENTINELA: a reescrita tem de ter MUDADO alguma migration. Regex que não casa devolveria o
+      // repo intacto — zero achados — e o `toBeGreaterThan(0)` abaixo falharia por motivo errado,
+      // ou pior, um dia passaria por acidente. O controle é a mutação, não o achado.
+      const mudou = mutadas.filter((m, i) => m.sql !== migrations[i].sql);
+      expect(mudou.length, `a sabotagem de ${fn} não alterou nenhuma migration`).toBeGreaterThan(0);
+      expect(
+        mudou.some((m) => new RegExp(`DROP FUNCTION IF EXISTS ${fn}\\s*;`).test(m.sql)),
+        `${fn}: a reescrita não produziu a grafia sem parêntese`,
+      ).toBe(true);
+
+      const r = auditGrantsFuncoes(mutadas, AUTHZ_FUNCOES_FECHADAS).filter(
         (f) => f.codigo === 'FUNCAO_RECRIADA_SEM_FECHO' && f.funcao === fn,
       );
       expect(r.length, fn).toBeGreaterThan(0);

--- a/scripts/authz-funcoes.test.ts
+++ b/scripts/authz-funcoes.test.ts
@@ -182,7 +182,6 @@ describe('auditGrantsFuncoes — reabertura por GRANT', () => {
   const REABRE_POR_ROUTINE: [string, string][] = [
     ['ON ROUTINE com args', 'GRANT EXECUTE ON ROUTINE public.f(uuid) TO anon;'],
     ['ON ROUTINE sem args', 'GRANT EXECUTE ON ROUTINE public.f TO anon;'],
-    ['ON ALL ROUTINES IN SCHEMA — atinge sem citar o nome', 'GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public TO anon;'],
   ];
 
   it.each(REABRE_POR_ROUTINE)('GRANT com a grafia ROUTINE acusa FUNCAO_REABERTURA: %s', (_nome, sql) => {
@@ -190,6 +189,28 @@ describe('auditGrantsFuncoes — reabertura por GRANT', () => {
     expect(cods(r)).toEqual(['FUNCAO_REABERTURA']);
     expect(r[0].funcao).toBe('public.f');
     expect(r[0].level).toBe('error');
+  });
+
+  // A forma ALL é a séria, e o assert tem de dizer POR QUÊ: ela atinge TODA função do schema sem
+  // citar nenhuma pelo nome. Afirmar um achado só descreveria mal o estrago — em prod são as 43.
+  it('GRANT ON ALL ROUTINES IN SCHEMA acusa TODAS as funções do schema, sem citar nome', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public TO anon;' }],
+      ALLOW,
+    );
+    expect(r.map((f) => f.funcao).sort()).toEqual(['public.f', 'public.g']);
+    expect(new Set(cods(r))).toEqual(new Set(['FUNCAO_REABERTURA']));
+    expect(r.every((f) => f.level === 'error')).toBe(true);
+  });
+
+  // Controle da forma ALL: OUTRO schema não alcança as do contrato — senão o assert acima seria
+  // compatível com "a palavra ALL ROUTINES acusa sempre".
+  it('GRANT ON ALL ROUTINES IN SCHEMA de OUTRO schema não alcança', () => {
+    const r = auditGrantsFuncoes(
+      [ANCORA, { file: '20260202000000_x.sql', sql: 'GRANT EXECUTE ON ALL ROUTINES IN SCHEMA outro TO anon;' }],
+      ALLOW,
+    );
+    expect(r).toEqual([]);
   });
 
   // Sentido oposto: a MESMA grafia usada legitimamente tem de ficar quieta. Sem isto o bloco acima

--- a/scripts/lib/authz-funcoes.ts
+++ b/scripts/lib/authz-funcoes.ts
@@ -49,6 +49,7 @@ type FuncaoCodigo =
   | 'FUNCAO_ANCORA_NAO_DECLARADA'
   | 'FUNCAO_FECHO_PENDENTE'
   | 'FUNCAO_GRANT_NAO_PARSEAVEL'
+  | 'FUNCAO_DROP_NAO_PARSEAVEL'
   | 'FUNCAO_DEFAULT_PRIVILEGE_ALTERADO'
   // exclusivos do audit de prod (compararExecuteProd):
   | 'FUNCAO_AUSENTE_EM_PROD'
@@ -81,15 +82,55 @@ function mencionaFuncao(stmt: string, schema: string, name: string): boolean {
   return new RegExp(`(?<![\\w.])(?:${schema}\\.)?"?${name}"?(?!\\w)`, 'i').test(stmt);
 }
 
-/** Alvos de `DROP FUNCTION [IF EXISTS] a(…), b(…)` — normalizados. Lista múltipla é SQL válido. */
-function alvosDrop(stmt: string): string[] {
-  const m = /^DROP\s+FUNCTION\s+(?:IF\s+EXISTS\s+)?([\s\S]+)$/i.exec(stmt);
-  if (!m) return [];
+/** Elementos de topo de uma lista separada por vírgula. A vírgula DENTRO de parênteses não separa:
+ *  `f(uuid, text)` e `numeric(10,2)` são um elemento só. */
+function elementosDeTopo(lista: string): string[] {
   const out: string[] = [];
-  const re = new RegExp(`(?:(${IDENT})\\s*\\.\\s*)?(${IDENT})\\s*\\(`, 'gi');
-  let g: RegExpExecArray | null;
-  while ((g = re.exec(m[1])) !== null) out.push(`${unq(g[1]) || 'public'}.${unq(g[2])}`);
+  let prof = 0;
+  let atual = '';
+  for (const ch of lista) {
+    if (ch === '(') prof++;
+    else if (ch === ')') prof--;
+    else if (ch === ',' && prof === 0) {
+      out.push(atual);
+      atual = '';
+      continue;
+    }
+    atual += ch;
+  }
+  out.push(atual);
   return out;
+}
+
+/** Alvos de `DROP FUNCTION|ROUTINE [IF EXISTS] a(…), b, c(…) [CASCADE|RESTRICT]` — normalizados.
+ *
+ *  O corte é POSICIONAL: o NOME que ABRE cada elemento da lista. Casar `nome(` — exigir o
+ *  parêntese — media a GRAFIA e concluía o EFEITO, e o efeito é o mesmo sem ela: a lista de
+ *  argumentos é OPCIONAL desde o PG10 quando o nome é único no schema, e `ROUTINE` é sinônimo que
+ *  derruba função igual. Medido em PG17: `DROP FUNCTION public.f;` + `CREATE` deixa `proacl` NULL
+ *  e devolve EXECUTE a `anon` exatamente como a forma com args (`DROP ROUTINE`, idem) — enquanto
+ *  `CREATE OR REPLACE` preserva o ACL. Sete grafias passavam caladas por esse `(`.
+ *
+ *  `entendido: false` marca elemento que o parser NÃO leu; o chamador trata como fail-closed,
+ *  igual ao ramo do GRANT. `DROP PROCEDURE` fica de fora de propósito: o PG recusa derrubar função
+ *  por ele (`is not a procedure`), então não é vetor — e se um dia mencionar função protegida, cai
+ *  no fail-closed do chamador em vez de virar alvo inventado. */
+function alvosDrop(stmt: string): { alvos: string[]; entendido: boolean } {
+  const m = /^DROP\s+(?:FUNCTION|ROUTINE)\s+(?:IF\s+EXISTS\s+)?([\s\S]+)$/i.exec(stmt);
+  if (!m) return { alvos: [], entendido: true };
+  const cabeca = new RegExp(`^(?:(${IDENT})\\s*\\.\\s*)?(${IDENT})`, 'i');
+  const alvos: string[] = [];
+  let entendido = true;
+  for (const el of elementosDeTopo(m[1])) {
+    const t = el.trim().replace(/\s*\b(?:CASCADE|RESTRICT)\s*$/i, '').trim();
+    const g = t === '' ? null : cabeca.exec(t);
+    if (!g) {
+      entendido = false;
+      continue;
+    }
+    alvos.push(`${unq(g[1]) || 'public'}.${unq(g[2])}`);
+  }
+  return { alvos, entendido };
 }
 
 /** Alvo de `CREATE [OR REPLACE] FUNCTION x(…)`. Julga o ALVO, não a menção: o CORPO de uma função
@@ -118,8 +159,12 @@ function parseAcl(stmt: string, verbo: 'GRANT' | 'REVOKE'): AclStmt | null {
   const [, privRaw, onRaw, rolesRaw] = m;
   const execute = /\bEXECUTE\b/i.test(privRaw) || /\bALL\b/i.test(privRaw);
   if (!execute && !/\b(SELECT|INSERT|UPDATE|DELETE|USAGE|TRIGGER|REFERENCES)\b/i.test(privRaw)) return null; // privilégio irreconhecível → fail-closed
-  const all = /\bALL\s+FUNCTIONS\s+IN\s+SCHEMA\s+(\S+)/i.exec(onRaw);
-  const temAlvo = all !== null || /\bFUNCTION\b/i.test(onRaw);
+  // `ROUTINES` alcança as FUNÇÕES do schema tanto quanto `FUNCTIONS` (PG11+), e `ROUTINE` é
+  // sinônimo de `FUNCTION` no alvo singular. Ler só a grafia `FUNCTION` media a PALAVRA e concluía
+  // o alcance: `GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public TO anon` reabria as 43 de uma vez,
+  // calado (medido). `PROCEDURES` fica de fora de propósito — não alcança função.
+  const all = /\bALL\s+(?:FUNCTIONS|ROUTINES)\s+IN\s+SCHEMA\s+(\S+)/i.exec(onRaw);
+  const temAlvo = all !== null || /\b(?:FUNCTION|ROUTINE)\b/i.test(onRaw);
   const roles = rolesRaw
     .replace(/\bWITH\s+GRANT\s+OPTION\b/i, '')
     .replace(/\bCASCADE\b|\bRESTRICT\b/gi, '')
@@ -172,13 +217,14 @@ export function auditGrantsFuncoes(
   // da medição. Fora do laço por função: o achado é do projeto, não de uma função.
   for (const m of pre) {
     for (const st of m.stmts) {
-      if (/^ALTER\s+DEFAULT\s+PRIVILEGES\b/i.test(st) && /\bON\s+FUNCTIONS\b/i.test(st)) {
+      // `ON ROUTINES` muda a MESMA premissa que `ON FUNCTIONS` — a grafia difere, o efeito não.
+      if (/^ALTER\s+DEFAULT\s+PRIVILEGES\b/i.test(st) && /\bON\s+(?:FUNCTIONS|ROUTINES)\b/i.test(st)) {
         out.push({
           level: 'warn',
           codigo: 'FUNCAO_DEFAULT_PRIVILEGE_ALTERADO',
           funcao: '—',
           file: m.file,
-          msg: `ALTER DEFAULT PRIVILEGES sobre FUNCTIONS — o ACL que uma função recriada herda mudou. A medição que sustenta scripts/authz-funcoes-fechadas.ts (pg_default_acl, 2026-08-15) precisa ser refeita.`,
+          msg: `ALTER DEFAULT PRIVILEGES sobre FUNCTIONS/ROUTINES — o ACL que uma função recriada herda mudou. A medição que sustenta scripts/authz-funcoes-fechadas.ts (pg_default_acl, 2026-08-15) precisa ser refeita.`,
         });
       }
     }
@@ -250,8 +296,24 @@ export function auditGrantsFuncoes(
       for (const st of m.stmts) {
         if (!st) continue;
 
-        if (/^DROP\s+FUNCTION\b/i.test(st)) {
-          if (alvosDrop(st).includes(chave)) dropPendente = true;
+        if (/^DROP\s+(?:FUNCTION|ROUTINE)\b/i.test(st)) {
+          const d = alvosDrop(st);
+          if (d.alvos.includes(chave)) {
+            dropPendente = true;
+            continue;
+          }
+          // fail-closed simétrico ao ramo do GRANT: um DROP que CITA a função protegida sem que ela
+          // tenha saído da lista de alvos é forma que o parser não leu — e um parser que não leu não
+          // pode afirmar que o ACL sobreviveu.
+          if (mencionaFuncao(st, schema, name)) {
+            out.push({
+              level: 'error',
+              codigo: 'FUNCAO_DROP_NAO_PARSEAVEL',
+              funcao: chave,
+              file: m.file,
+              msg: `DROP FUNCTION/ROUTINE menciona ${chave} numa forma que o parser não entendeu — não posso garantir que o ACL sobreviveu (fail-closed). DROP+CREATE reseta o ACL e devolve EXECUTE ao default do projeto. Ajuste scripts/lib/authz-funcoes.ts.`,
+            });
+          }
           continue;
         }
         if (/^CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\b/i.test(st)) {


### PR DESCRIPTION
Varredura da classe do #1985/#2001 — **"o NOME prova o EFEITO"** — nos gates de SQL, conforme
`db/diagnostico/BRIEFING-varredura-gates-sql.md`. Método e varredura anterior: §9/§10 de
`docs/historico/verificar-sonda-versao.md`. O registro desta vira a **§11** do mesmo doc.

## Instância única ou classe? (passo 0 do `matar-classe`)

**Classe** — e ela apareceu **duas vezes no mesmo arquivo**, em ramos vizinhos que divergiam entre
si. Não é "o autor esqueceu uma grafia": é o gate medindo a **palavra** e afirmando o **alcance**.

## O suspeito nomeado no briefing NÃO existe — medido, não deduzido

O briefing apostava no vetor `DROP FUNCTION`+`CREATE` reabrindo função em prod sem nenhum `GRANT`
no repo. Prod diz que não:

| Medição | Resultado |
| --- | --- |
| `bun run authz:funcoes:prod` | **exit 0** — "o EXECUTE de prod bate com o contrato nas 43" |
| query 4 (`proacl IS NULL`, o rastro do reset) | **0 linhas** — toda função de `public` tem ACL explícito |
| query 3 (SECURITY DEFINER alcançável por `anon`) | 8, das quais **7 são de trigger** (PostgREST não expõe como RPC) |
| a 8ª | `public.get_public_tool_history(uuid)` — **deliberada** (`20260604180000_public_tool_history_rpc.sql`, consumida por `src/queries/useUserTools.ts`) |

Panorama das 454 funções de `public`: 196 INVOKER (RLS aplica) · 189 SECURITY DEFINER, **1 só**
alcançável por `anon` · 69 de trigger. **Nada a revogar** — nenhum `REVOKE` sai deste PR.

## O furo está no GATE, e são dois

**(1) `alvosDrop` exigia `nome(`.** Sondadas 18 grafias contra as 666 migrations reais: **7 passavam
caladas** — `DROP FUNCTION public.f;` (sem args), com `CASCADE`, com aspas, sem schema, sem
`IF EXISTS`, `DROP ROUTINE` (com e sem args), e a lista MISTA. Não é grafia exótica: a lista de
argumentos é **opcional desde o PG10** quando o nome é único no schema, e `ROUTINE` é sinônimo.

Provado em PG17 descartável — o efeito é idêntico ao da forma que o gate já pegava:

| Passo | `proacl IS NULL` | `anon` executa |
| --- | --- | --- |
| função fechada | não | não |
| `CREATE OR REPLACE` (controle) | não | não |
| `DROP FUNCTION public.f;` + `CREATE` | **sim** | **sim** |
| `DROP ROUTINE public.f;` + `CREATE` | **sim** | **sim** |
| com overload, omitir args | o PG **recusa** — a fronteira do furo é "nome único" |

**(2) Pior, e achado por sondar o ramo vizinho:** `GRANT EXECUTE ON ALL ROUTINES IN SCHEMA public
TO anon;` reabre **as 43 de uma vez, sem citar nenhuma pelo nome** — e passava calado, porque
`parseAcl` lia só a palavra `FUNCTION(S)`. Mesma cegueira no aviso de
`ALTER DEFAULT PRIVILEGES … ON ROUTINES`. E `GRANT … ON ROUTINE public.f(uuid) TO service_role` —
legítimo — caía no fail-closed: **o gate reprovava código correto**, que é o começo de todo
afrouxamento.

## Conserto: POSICIONAL, no padrão do #2001

O corte é o **NOME que ABRE cada elemento** da lista do `DROP` (args opcionais, vírgula de topo,
`CASCADE`/`RESTRICT` fora), e `ROUTINE(S)` entra como sinônimo em `parseAcl`. Nada de enumerar
grafias.

- `PROCEDURES` fica de fora **de propósito**: o PG não derruba função por `DROP PROCEDURE` nem
  alcança função com `ALL PROCEDURES` — incluí-la seria falso-positivo. Está calibrado.
- O ramo do `DROP` ganha o fail-closed que o ramo do `GRANT` **já tinha**
  (`FUNCAO_DROP_NAO_PARSEAVEL`). Os dois ramos do mesmo arquivo divergiam, e só um não podia
  afirmar que estava tudo bem.

## Calibração e falsificação

- **18/18** grafias erradas reprovam (era 11/18); formas legítimas seguem caladas — inclusive
  `REVOKE … ON ALL ROUTINES`, `GRANT ON ROUTINE` a role permitida, `ALL PROCEDURES`, sufixo e
  homônima em outro schema.
- **Zero falso-positivo:** contra as 666 migrations reais o conjunto de achados é **idêntico ao da
  `main`** (0 achados, antes e depois).
- **Anti-inércia contra o repo REAL** (não fixture): reescreve o `DROP` real de 4 funções do
  contrato para a grafia sem parêntese e exige vermelho — com sentinela que falha se a *reescrita*
  não mudar nada (a cegueira do #2001, item 1).
- **Falsificação em código real, 3 sabotagens:** tirar o corte posicional → **15 vermelhas**; tirar
  o `ROUTINE` → **5**; tirar o fail-closed → **1**. Lib restaurada por `git checkout --`.

## A varredura completa — 16 sites, 1 afetado

Critério (o da §10, traduzido para SQL): *o gate casa uma GRAFIA e conclui o EFEITO?*

- **Afetado (1):** `scripts/lib/authz-funcoes.ts` (+ calibração em `scripts/authz-funcoes.test.ts`).
- **Imunes por construção (5):** `authz-contract.ts`, `migration-objects.ts` e
  `import-tint-formulas-aposentada-gate.test.ts` casam `CREATE … FUNCTION` — e **`CREATE ROUTINE`
  não existe no PostgreSQL**, então a grafia é única; `authz-reescrita.ts` exclui
  `EXECUTE FUNCTION|PROCEDURE`, que esgota a sintaxe; `authz-grants.ts` (Parte C, tabelas) já era
  fail-closed e **nem depende de parsear `DROP`** — julga o `CREATE TABLE` sozinho. Era o irmão
  bem-feito ao lado do furo.
- **Falso-positivo da assinatura (10):** `sonda-versao-sql.test.ts` (o alvo **secundário** do
  briefing — o retorno de `gerarSqlDaLeva` **é** o SQL que o assert lê, então já segue o valor até a
  fronteira), `audit-custom-migrations.ts` e `wt-preflight-migration.ts` (heurístico DECLARADO;
  afirmam inventário/colisão, não efeito), `sql-comentarios.test.ts` (o stripper compartilhado, com
  sentinela), `docs-links-gate-check.ts`, `cep-aberto/importar-carteira.ts`,
  `authz-gate-check{,.test}.ts`, `migration-objects.test.ts`, e os três gates de PARIDADE
  (`afinidade-nao-e-dinheiro`, `titulo-status-paridade`, `BotoesDesfechoRecomendacao`), que já
  trazem CONTROLE explícito contra regex que não casa.

**Cobertura fora de `supabase/migrations/` — medida, não presumida.** Varridos os 52 `db/*.sql`
(canal de apply manual, como o #1090) contra as 43 do contrato: **0 pares `DROP`+`CREATE`**. O único
`CREATE OR REPLACE` preserva o ACL, logo não é vetor. O canal existe e hoje está vazio; quem o cobre
é `authz:funcoes:prod`.

## Deploy

**Nada a aplicar.** Sem migration, sem edge, sem `REVOKE`. É gate de CI — vale no merge, pelos dois
canais que o rodam: `bun run test` (o `include` do vitest cobre `scripts/**/*.test.ts`) e
`bun run authz:check` (Parte E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
