### PR TITLE
fix(docs/cron): `timed_out` é o campo ERRADO — a varredura do #2012 leu 0 estouros com um estouro REAL na tabela

### DIFF
--- a/docs/agent/sync.md
+++ b/docs/agent/sync.md
@@ -43,6 +43,17 @@ ao milissegundo (`60031`/`60032` ambos `12:25:00.317984`), o que é o tell.
 fila, não o tempo da edge. A coluna serve para `status_code`, `timed_out` e cadência — nada além.
 Retenção medida: **~6h** (206 linhas cobrindo `06:50`→`12:45`).
 
+⚠️ **E `timed_out` NÃO é o campo que marca o estouro.** Medido 2026-08-25: a resposta `59887`, cortada
+com `error_msg = "Timeout of 150000 ms reached. Total time: 150004.306000 ms"`, tinha `timed_out` **NULL**
+e `status_code` **NULL**. `count(*) FILTER (WHERE timed_out)` devolveu **0 com um estouro real na tabela** —
+é o `Number(null) === 0` da observabilidade de cron, e aprova por CEGUEIRA exatamente na query que alguém
+roda para perguntar "algum cron está estourando?". **Filtre pelo que se preenche:**
+
+```sql
+SELECT id, created, status_code, error_msg FROM net._http_response
+WHERE error_msg IS NOT NULL OR status_code IS NULL;   -- NUNCA `WHERE timed_out`
+```
+
 ## Padrão de cron (canônico)
 
 - Auth: header `x-cron-secret` = `(SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name='CRON_SECRET' LIMIT 1)`. O secret já está no Vault.

--- a/docs/historico/sync-servicos-congelado-verificacao.md
+++ b/docs/historico/sync-servicos-congelado-verificacao.md
@@ -141,13 +141,29 @@ media o sync.
 
 `51` crons ativos usam `net.http_post` e **`0` estão sem `timeout_milliseconds`** — a armadilha do default
 de 5s está fechada em prod. Dos `10` com teto ≤60s: `103`/`104`/`154`/`155` respondem `202` (imunes);
-`44`/`60`/`102`/`109` rodaram na janela de retenção de `net._http_response` com **`timed_out=0` em 206
-respostas**; `75` dispara só `sync_categorias` (max 4,1s) e `sync_contas_correntes` (max 28,3s) por
+`44`/`60`/`102`/`109` rodaram na janela de retenção de `net._http_response` sem estouro (ver a ⚠️ abaixo:
+o filtro certo é `error_msg IS NOT NULL`, **não** `timed_out`); `75` dispara só `sync_categorias` (max 4,1s) e `sync_contas_correntes` (max 28,3s) por
 `fin_sync_log`/30d; `59` se dimensiona para ~10s no próprio arquivo (`index.ts:139`). Nenhum aperto real.
 
 O mais estreito do parque é outro, e é **síncrono**: `omie-financeiro`/`sync_movimentacoes` (jobids 78/79,
 teto 150000) tem **max 124,1s** e p95 98,3s em 30 dias — 83% do teto. Sem estouro (`fin_sync_log`: 4549
 `complete`, 0 sem `completed_at`), mas é ali que uma folga compraria alguma coisa, não no 155.
+
+### ⚠️ A varredura acima quase aprovou por CEGUEIRA (achado do fecho, 2026-08-25)
+
+A primeira passada contou `count(*) FILTER (WHERE timed_out)` e leu **`0` em 206 respostas** como "nenhum
+estouro". **`timed_out` não é o campo que se preenche.** A resposta `59887` estava cortada aos 150s —
+`error_msg = "Timeout of 150000 ms reached. Total time: 150004.306000 ms"` — com `timed_out` **NULL** e
+`status_code` **NULL**. O filtro certo é `error_msg IS NOT NULL OR status_code IS NULL`.
+
+Ou seja: **existe ≥1 estouro real de `150000` na janela de 6h** e a conclusão "nenhum aperto real" vale só
+para os crons cujo teto foi provado por OUTRA via (o `202` do 103/104/154/155, o `fin_sync_log` do 75, o
+dimensionamento do 59). Qual cron emitiu o `59887` ficou **em aberto**: 20 crons dispararam naquele
+`08:30:00` e o `net._http_response` não carrega a URL — é a ambiguidade de emissor de sempre. Fechá-la
+exige observar dentro da janela de retenção; virou chip próprio.
+
+Isto é a lição 1 da própria `/fecho` aplicada a si mesma: **ausência de sinal não é aprovação** — e um
+campo que nunca se preenche produz ausência de sinal indistinguível de saúde.
 
 ## Como revalidar
 


### PR DESCRIPTION
Achado no **fecho** da sessão do #2012, ao caçar a prova empírica do `202` que eu tinha declarado faltando.

## O defeito

A resposta `59887` de `net._http_response` estava cortada aos 150s:

```
error_msg = "Timeout of 150000 ms reached. Total time: 150004.306000 ms"
```

…com **`timed_out` NULL** e **`status_code` NULL**.

Ou seja: `count(*) FILTER (WHERE timed_out)` devolve **`0` com um estouro real na tabela**. É `Number(null) === 0` aplicado à observabilidade de cron — e aprova por **cegueira** exatamente na query que alguém roda para perguntar *"algum cron está estourando?"*.

## O que isso faz com o #2012

A varredura de lá afirmava **"`timed_out=0` em 206 respostas"** como prova de que `44`/`60`/`102`/`109` não apertam. **Essa metade cai.**

A conclusão principal — *não mexer no cron 155* — **não depende dela**: apoia-se no `202`+`waitUntil`. E esse eixo, que ficou declarado em aberto no #2012, **fechou empiricamente agora**: a resposta `59892` do cron `103` (`start_nao_vinculados`, mesma edge `omie-analytics-sync`) é

```
status_code=202 | content={"accepted":true} | created=2026-08-25 08:30:01.998
```

com o disparo do cron em `08:30:00.725`. Não é mais só leitura de código + igualdade de `VERSAO`.

## Em aberto (vai por chip)

**Qual** cron emitiu o `59887`. 20 crons dispararam naquele `08:30:00` e a tabela não carrega a URL — a ambiguidade de emissor de sempre. Fechar exige observar dentro da janela de retenção de ~6h.

## O filtro correto (agora no `sync.md`)

```sql
SELECT id, created, status_code, error_msg FROM net._http_response
WHERE error_msg IS NOT NULL OR status_code IS NULL;   -- NUNCA `WHERE timed_out`
```

## Validação

`docs:indice` · `docs:links` · `docs:citacoes` → **exit=0** cada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)