### PR TITLE
docs(diagnostico): a medição refutou a hipótese do DROP+CREATE — e achou classe melhor (denominador)

### DIFF
--- a/db/diagnostico/BRIEFING-varredura-gates-sql.md
+++ b/db/diagnostico/BRIEFING-varredura-gates-sql.md
@@ -68,3 +68,53 @@ revogue **nomeando as roles**.
 `heavy bun run test` (canônico do CI). PR próprio, respondendo no corpo **"instância única ou
 classe?"** (passo 0 da skill `matar-classe`) e listando **todos** os sites varridos, inclusive os
 limpos — prova de varredura completa, não de amostra.
+
+---
+
+## Medição de 2026-08-25 21:22 — leia antes de repetir o trabalho
+
+Rodada contra a prod pelo wrapper read-only. **Dois resultados mudam o plano acima.**
+
+### A hipótese do `DROP`+`CREATE` está REFUTADA
+
+`proacl IS NULL` em **0 de 336** funções próprias (fora extensões). Toda função tem ACL explícito,
+nenhuma no default do Postgres. Não existe em produção rastro de `DROP FUNCTION` + `CREATE` sem
+`REVOKE`. A query 4 devolver zero linhas **é** esse resultado, não uma falha.
+
+O grant a `anon` vem de outro lugar: é explícito (`anon=X/postgres`), no padrão do template Supabase
+(`GRANT ... ON ALL FUNCTIONS IN SCHEMA public TO anon, authenticated`). Continue a varredura por aí,
+não pelo reset.
+
+### O que sobra depois de tirar o ruído
+
+212 funções são executáveis por `anon`, mas o número bruto engana:
+
+| Fatia | n | Alcançável por RPC? |
+| --- | --- | --- |
+| extensão `pgvector` | 118 | ruído |
+| funções de **trigger** | 46 | não — o Postgres recusa chamada direta |
+| chamáveis, `SECURITY INVOKER` | 47 | sim, mas o RLS da tabela decide |
+| chamáveis, **`SECURITY DEFINER`** | **1** | sim, e **bypassa RLS** |
+
+A única definer alcançável por `anon` é `public.get_public_tool_history(p_tool_id uuid)`, com
+`anon=X` explícito. O nome sugere intencional e ela é usada em `src/queries/useUserTools.ts` — **não
+tratada como furo**; precisa de veredito de produto sobre o histórico ser público.
+
+**Ainda NÃO medido, e é o próximo passo:** 22 das 47 invoker ESCREVEM (`aprovar_pedido_sugerido`,
+`cancelar_pedido_sugerido`, `gerar_pedidos_sugeridos_ciclo`, `registrar_aumento_via_vision` e
+outras). Sendo invoker, o RLS de cada tabela decide se `anon` escreve de fato. Medir policy a policy
+é o trabalho que sobrou.
+
+### O achado de GATE é melhor do que a hipótese original
+
+**O manifesto cobre 38 funções. A prod tem 336.**
+
+O assert `'nenhuma entrada permite anon'` é literalmente verdadeiro **e vazio**:
+`get_public_tool_history` permite `anon` e simplesmente não é uma entrada. O gate mede 38 de 38 e
+reporta verde, e nada no verde diz que o universo é 336.
+
+É a classe numa variação mais afiada: não é "o NOME prova o efeito", é **"o MANIFESTO prova o
+universo"** — falta o DENOMINADOR. Prima da classe-irmã registrada na §10 de
+`docs/historico/verificar-sonda-versao.md` (`N verificadas` sem dizer quantas ficaram fora) e do que
+o CLAUDE.md já diz sobre sinal sem denominador. **É provavelmente aqui que o conserto deve morar**:
+o gate tem de saber, e dizer, quantas funções da prod ele NÃO classifica.


### PR DESCRIPTION
Medição contra a prod pelo wrapper read-only, 2026-08-25 21:22. Anexada ao briefing de **#2006** para que o chip da varredura não repita o trabalho **nem persiga a hipótese errada**.

## Refutado: o `DROP`+`CREATE` não aconteceu

`proacl IS NULL` em **0 de 336** funções próprias. Toda função tem ACL explícito, nenhuma no default do Postgres. Não existe em produção rastro de `DROP FUNCTION` + `CREATE` sem `REVOKE` — o mecanismo que o briefing original apontava como o furo do gate. A query 4 devolver zero linhas **é** esse resultado, não uma falha.

O grant a `anon` vem de outro lugar: é explícito (`anon=X/postgres`), no padrão do template Supabase.

## O número bruto engana

212 funções executáveis por `anon`, mas: **118** são `pgvector`, **46** são funções de trigger (o Postgres recusa chamada direta), **47** são chamáveis `SECURITY INVOKER` (o RLS de cada tabela decide) e **1** é chamável **e** `SECURITY DEFINER`.

A única definer alcançável por `anon` é `public.get_public_tool_history(p_tool_id uuid)`, com `anon=X` explícito, usada em [useUserTools.ts](src/queries/useUserTools.ts). **Não tratada como furo** — precisa de veredito de produto sobre o histórico ser público.

**Não medido, e é o próximo passo:** 22 das 47 invoker escrevem. Sendo invoker, o RLS decide; medir policy a policy é o que sobrou.

## O achado de gate ficou melhor que a hipótese

**O manifesto cobre 38 funções. A prod tem 336.**

O assert `'nenhuma entrada permite anon'` é literalmente verdadeiro **e vazio** — `get_public_tool_history` permite `anon` e simplesmente não é uma entrada. Não é *"o NOME prova o efeito"*, é **"o MANIFESTO prova o universo"**: falta o **denominador**. Prima da classe-irmã da §10 de `verificar-sonda-versao.md` e do que o CLAUDE.md diz sobre sinal sem denominador. É provavelmente aqui que o conserto deve morar.

## Evidência: incompleta, e digo qual

**Não consegui rodar a suíte local.** Duas tentativas (`heavy bun run test` e um subconjunto dirigido) morreram com **exit 143** — SIGTERM na fila do semáforo, com a máquina saturada por duas sessões de chip rodando. Timeout é **ausência de dado**, não aprovação, então não afirmo verde local.

O que sustenta o PR: o diff é **50 linhas de markdown em um único arquivo** sob `db/diagnostico/`, sem código, e a suíte passou neste mesmo arquivo no #2006 (741 arquivos, 7195 passed). O `validate` do CI é a evidência que falta — se ele reprovar, o auto-merge não mergeia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)