### PR TITLE
fix(fecho): a menção ao "Auto-archive on PR close" era INCONDICIONAL — o gatilho é por PR, a unidade do ritual é a ENTREGA

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -209,8 +209,21 @@ Veredito: PODE ARQUIVAR a sessão. / AINDA NÃO — falta (1)…
 
 **Diga "pode ARQUIVAR", não "pode excluir".** Arquivar para o processo, limpa o worktree
 (mesma RAM e mesmo disco que excluir) e ainda deixa a sessão reabrível — não há motivo para
-recomendar a via destrutiva. Se o founder arquiva sessão a sessão na mão, mencione UMA vez a
-preferência **"Auto-archive on PR close"** nas Settings, que resolve isso estruturalmente.
+recomendar a via destrutiva.
+
+⚠️ **A menção ao "Auto-archive on PR close" é CONDICIONAL — e o passo 1 já mediu a condição.**
+Só mencione, uma vez, se a sessão fechou com **exatamente UM PR**: é o único formato em que
+"PR fechado" e "entrega concluída" coincidem. O gatilho do setting é o **PR**; a unidade deste
+ritual é a **ENTREGA**. Em sessão de arco longo — 2+ PRs, ou 1 mergeado com o próximo ainda por
+abrir — os dois divergem, e recomendar o toggle ali é sugerir que a sessão morra no meio do
+trabalho. Ao mencionar, diga o gatilho em voz alta ("fecha por PR, não por entrega") e **não**
+afirme o que ele faz com N PRs: esta skill não verificou, e "resolve estruturalmente" é uma
+garantia que ela não tem como dar.
+
+A classe: **recomendação embutida em ritual sai com a AUTORIDADE do ritual.** O founder lê "o
+fecho mandou", não "o agente sugeriu" — então recomendação daqui carrega a própria pré-condição
+junto, ou vira conselho errado dito com voz de veredito. É o defeito dos #1677 e #1863 deslocado
+do veredito para o rodapé: fail-open não deixa de ser fail-open por estar no fim da página.
 
 Nunca diga "pode arquivar" com item ❌/⏳ crítico em aberto sem nomeá-lo na lista do founder —
 e nunca com pendência SEM um dos 4 destinos acima ("fica na sua mão lembrar" não é destino).


### PR DESCRIPTION
## O defeito

O rodapé do veredito do `/fecho` mandava mencionar o setting **"Auto-archive on PR close"** sempre que o founder arquivasse sessão na mão, afirmando que ele *"resolve isso estruturalmente"*.

Duas coisas erradas nessa frase.

**1. O gatilho do setting é o fecho de PR. A unidade deste ritual é a ENTREGA.**

Numa sessão de **um** PR os dois coincidem, e a recomendação é boa — foi o caso da sessão em que isto foi achado. Numa de arco longo (2+ PRs, ou 1 mergeado com o próximo ainda por abrir) eles divergem, e recomendar o toggle ali é sugerir que a sessão termine **no meio do trabalho**.

O passo 1 do ritual já conta quantos PRs a sessão teve. A condição sai de graça: a menção passa a ser condicionada a **exatamente UM PR**.

**2. `"resolve isso estruturalmente"` é uma garantia que a skill não tem como dar.**

Ela nunca verificou o que o setting faz com N PRs. Trocado por: diga o gatilho em voz alta (*"fecha por PR, não por entrega"*) e **não** afirme comportamento não verificado.

## A classe (por que é `fix` e não ajuste de texto)

**Recomendação embutida em ritual sai com a AUTORIDADE do ritual.** O founder lê *"o fecho mandou"*, não *"o agente sugeriu"* — e o agente repassa sem filtrar, porque a skill não pediu filtro. Toda recomendação daqui tem de carregar a própria pré-condição junto, ou vira conselho errado dito com voz de veredito.

É o mesmo defeito do #1677 (veredito sem olhar se a main está verde) e do #1863 (`UNKNOWN` lido como "não está em conflito"), deslocado do veredito para o rodapé. **Fail-open não deixa de ser fail-open por estar no fim da página.**

## Proveniência

Achado pelo founder, na sessão do #2023, perguntando: *"existem vários PRs até a sessão terminar, como você vai saber isso para não terminar a sessão antes do momento?"*

A resposta é que eu não sabia — e tinha repassado a recomendação mesmo assim, porque a skill mandou.

## Verificação

1 arquivo, +15/−2. Gates rodados localmente:

```
docs:citacoes -> exit=0    docs:indice -> exit=0
docs:links    -> exit=0    claude:size -> exit=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)