### PR TITLE
docs(analytics): o teste de bloqueio media NAVEGAÇÃO e o SDK faz XHR — ele passava no aparelho provado bloqueado

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -198,8 +198,52 @@ SELECT properties.$os AS so, properties.$browser AS nav,
 FROM events WHERE properties.$lib='web' GROUP BY so, nav ORDER BY ultimo DESC
 ```
 
-Teste de 1 linha para saber se um aparelho bloqueia — abrir `https://us.i.posthog.com/i/v0/e/` no
-navegador dele: **HTTP 400 `request missing data payload`** = livre; erro de conexão = bloqueado.
+⚠️ **O teste de 1 linha que estava aqui era FALSO NEGATIVO — não o use.** Ele mandava abrir
+`https://us.i.posthog.com/i/v0/e/` na barra do navegador e ler o `HTTP 400 request missing data
+payload` como "livre". Medido em 2026-08-26 no Chrome 152 do founder — o aparelho cujo bloqueio o
+`#1984` provou — a navegação top-level **passa** (`request missing data payload`) enquanto o `fetch`
+de dentro de `steu.lovable.app` **falha** (`TypeError: Failed to fetch`, 351 ms e **5 ms** na 2ª),
+com o Supabase respondendo `401` na mesma página e no mesmo minuto. Bloqueador casa por **tipo de
+request e por parte** (`xmlhttprequest`, `third-party`); digitar a URL é navegação **first-party**,
+a classe que a lista não bloqueia.
+
+**O teste que serve** roda com a página do app aberta, no console do aparelho:
+
+```js
+const t = performance.now();
+fetch('https://us.i.posthog.com/i/v0/e/', { method: 'POST', body: '' })
+  .then(r => r.text().then(b => `LIVRE ${r.status} em ${Math.round(performance.now()-t)}ms — ${b}`))
+  .catch(e => `BLOQUEADO ${e} em ${Math.round(performance.now()-t)}ms`)
+  .then(console.log);
+```
+
+E ele dá de graça o diagnóstico da CAMADA: navegação passando + XHR falhando é **extensão de
+bloqueio** (casa por tipo de request). DNS, `/etc/hosts` e firewall derrubariam as duas.
+
+### ⚠️ O aparelho bloqueado é INVISÍVEL no PostHog — a lista de quem liberar não sai daqui (2026-08-26)
+
+O breakdown acima lista **quem já emitiu**. Um aparelho censurado desde o primeiro dia não tem
+linha nenhuma: ele não aparece com zero, ele **não aparece**. Levantar "quais aparelhos precisam de
+allowlist" pelo PostHog é perguntar à amostra censurada quem ela censurou.
+
+Medido: o `$device_id` que vive no `localStorage` do Chrome do founder **agora** é
+`019e6c3b-71b8-77c2-b110-6c1edef31a0f`, e ele tem `count() = 0` **em toda a história do projeto** —
+o SDK subiu, cunhou identidade, persistiu, e nenhum evento chegou. Os três `Mac OS X / Chrome` que
+o breakdown mostra (`019f1f92` 01/07, `019e7fcc` 31/05, `019e2ec9` 16/05) são **outros** perfis, e
+lê-los como "o Mac emite às vezes" é confundir aparelho com identidade de armazenamento.
+
+**A via correta é do lado do cliente, e é uma linha no console do aparelho:**
+
+```js
+JSON.parse(localStorage[Object.keys(localStorage).find(k => k.startsWith('ph_'))]).$device_id
+```
+
+Esse id, com `count() = 0` no PostHog, é a prova de censura mais limpa que existe — e é também a
+**marca pré-registrada** da prova de que a liberação funcionou: qualquer linha desse `$device_id`
+depois da mudança fecha o caso, sem depender de "eu liberei".
+
+⚠️ E `count() = 0` só vale com **exit 0**: o `504` do wrapper (exit 73) é ausência de dado. Query
+com subconsulta neste eixo estoura o tempo — rode uma pergunta por vez.
 
 ### ⚠️ Escopo `No access` não cega o HogQL — logo um `0` dele precisa de PAR (2026-08-25)
 

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1791,6 +1791,62 @@ https://us.i.posthog.com/i/v0/e/
 Responde **HTTP 400 `request missing data payload`** quando o caminho está livre (verificado). Erro
 de conexão ou página em branco = bloqueado.
 
+⚠️ **As duas afirmações acima foram REFUTADAS por medição em 2026-08-26.** Ficam escritas porque o
+erro é reutilizável, não porque valem: (1) o iPhone **não** está bloqueado, e (2) este teste **não
+testa o bloqueio** — ele responde "livre" num aparelho comprovadamente bloqueado. Os dois blocos a
+seguir são a medição.
+
+### O teste de 1 linha era MÁQUINA DE FALSO NEGATIVO: navegação ≠ XHR (2026-08-26)
+
+Par de falsificação no **mesmo browser, mesmo endpoint, mesmos minutos** — Chrome 152 do founder,
+o aparelho cujo bloqueio o `#1984` provou:
+
+| como o request foi feito | resultado |
+|---|---|
+| **navegação top-level** para `https://us.i.posthog.com/i/v0/e/` (o teste da doc) | **`request missing data payload`** — passou |
+| **`fetch` a partir de `https://steu.lovable.app`** (o request que o SDK faz) | **`TypeError: Failed to fetch`** — 351 ms, e **5 ms** na 2ª tentativa |
+| controle: `fetch` para o Supabase, mesma página, mesmo minuto | **HTTP 401 em 370 ms** — passou |
+
+Bloqueador de conteúdo casa por **tipo de request e por parte** (`xmlhttprequest`, `third-party`),
+não por domínio nu. Digitar a URL na barra é navegação **first-party** — a classe que a EasyPrivacy
+não bloqueia. O teste inteiro media a categoria errada e devolvia verde para o aparelho que este
+mesmo documento provou estar bloqueado.
+
+> **A regra:** um teste de bloqueio precisa reproduzir o request **que o produto faz** — mesmo
+> método, mesmo tipo, **e mesma origem**. Trocar `fetch` de terceira parte por navegação de primeira
+> parte não é "simplificar o teste": é medir outra coisa e chamar de a mesma.
+
+E ele falha na direção pior. Um falso **positivo** viraria caça a um bloqueio inexistente e morreria
+na primeira verificação; este é falso **negativo**, e o veredito dele — "está livre" — é
+exatamente a conclusão que ninguém volta a checar.
+
+**O teste que serve** (roda no aparelho, no Safari/Chrome, com a página do app aberta —
+`steu.lovable.app`, console do browser):
+
+```js
+const t = performance.now();
+fetch('https://us.i.posthog.com/i/v0/e/', { method: 'POST', body: '' })
+  .then(r => r.text().then(b => `LIVRE ${r.status} em ${Math.round(performance.now()-t)}ms — ${b}`))
+  .catch(e => `BLOQUEADO ${e} em ${Math.round(performance.now()-t)}ms`)
+  .then(console.log);
+```
+
+### E o iPhone NÃO está bloqueado — refutado por evidência positiva (2026-08-26)
+
+O que fechou a pergunta não foi o teste: foi a série, decomposta por aparelho. O `019e6e05`
+(iOS/Mobile Safari, os 2001 eventos) emitiu **sessão completa em 2026-08-25, 09:39–09:51Z** —
+`$pageview`, `$set`, 10 `$autocapture`, `$pageleave` — e aparece em **23 dos últimos 30 dias**.
+Aparelho bloqueado não emite; emitiu.
+
+O "parou em 23/08" que fundou a inferência era a leitura de uma janela que ainda não tinha fechado:
+24/08 sem uso, e o 25/08 chegou depois da medição. **Silêncio de 2 dias num aparelho com 7 lacunas
+em 30 dias não é anomalia** — é a §4 de [analytics.md](../agent/analytics.md) (*"este silêncio é
+anômalo?"*, respondida pelo padrão histórico) aplicada ao aparelho em vez de ao agregado.
+
+> **A regra:** "é a mesma classe, é a explicação mais simples" é **hipótese**, e hipótese barata é a
+> que mais rápido vira premissa. Quando a refutação custa uma query já escrita — a decomposição por
+> `$device_id` que esta mesma doc exige — rodar a query vem **antes** de registrar a inferência.
+
 ### Por que isto é maior que "desligue o bloqueador"
 
 Desligar resolve o aparelho do founder e **não resolve a leitura**. Um bloqueador não deixa a amostra


### PR DESCRIPTION
## Contexto

A saída **(a)** do [#2010](https://github.com/LucasSardenbergL/afiacao/pull/2010) — *"liberar `us.i.posthog.com` nos aparelhos internos"* — estava registrada como opção escolhida, **sem passos e sem dono**. Ao executá-la, a medição desfez as duas premissas que a doc registrava.

## 1. O teste de 1 linha era MÁQUINA DE FALSO NEGATIVO

Par de falsificação no **mesmo browser** (Chrome 152 do founder — o aparelho cujo bloqueio o [#1984](https://github.com/LucasSardenbergL/afiacao/pull/1984) provou), **mesmo endpoint, mesmos minutos**:

| como o request foi feito | resultado |
|---|---|
| **navegação top-level** para `https://us.i.posthog.com/i/v0/e/` (o teste da doc) | **`request missing data payload`** — passou |
| **`fetch` a partir de `https://steu.lovable.app`** (o request que o SDK faz) | **`TypeError: Failed to fetch`** — 351 ms, e **5 ms** na 2ª |
| controle: `fetch` para o Supabase, mesma página, mesmo minuto | **HTTP 401 em 370 ms** — passou |

Bloqueador de conteúdo casa por **tipo de request e por parte** (`xmlhttprequest`, `third-party`), não por domínio nu. Digitar a URL na barra é navegação **first-party** — a classe que a EasyPrivacy não bloqueia.

Falha na **direção pior**: um falso positivo viraria caça a um bloqueio inexistente e morreria na primeira verificação; este é falso **negativo**, e o veredito dele — *"está livre"* — é exatamente a conclusão que ninguém volta a checar.

> **A regra:** um teste de bloqueio precisa reproduzir o request **que o produto faz** — mesmo método, mesmo tipo, **e mesma origem**.

De brinde, o par diagnostica a **camada**: navegação passando + XHR falhando é **extensão**. DNS, `/etc/hosts` e firewall derrubariam as duas.

## 2. O iPhone **não** está bloqueado — refutado por evidência positiva

O `019e6e05` (iOS/Mobile Safari, os 2001 eventos) emitiu **sessão completa em 2026-08-25, 09:39–09:51Z** (`$pageview`, `$set`, 10 `$autocapture`, `$pageleave`) e aparece em **23 dos últimos 30 dias**. Aparelho bloqueado não emite.

O *"parou em 23/08"* era leitura de janela ainda aberta: 24/08 sem uso, 25/08 chegou depois da medição. **Silêncio de 2 dias num aparelho com 7 lacunas em 30 dias não é anomalia.**

## 3. O aparelho bloqueado é INVISÍVEL no PostHog

O breakdown por `$os`/`$browser` lista **quem já emitiu**. Um aparelho censurado desde o primeiro dia não aparece com zero — **não aparece**. Levantar "quem liberar" pelo PostHog é perguntar à amostra censurada quem ela censurou.

Medido: o `$device_id` no `localStorage` do Chrome do founder é `019e6c3b-71b8-77c2-b110-6c1edef31a0f`, com **`count() = 0` em toda a história do projeto** — o SDK subiu, cunhou identidade, persistiu, e nenhum evento chegou. Os três `Mac OS X / Chrome` do breakdown são **outros** perfis.

Esse id com 0 linhas é também a **marca pré-registrada** da prova de que a liberação funcionou — sem depender de *"eu liberei"*.

## Evidência

- `docs:citacoes` · `docs:indice` · `docs:links` — **exit 0** nos três.
- Medições de browser: Chrome 152 real do founder, via MCP, com controle Supabase no mesmo minuto.
- Medições de série: `scripts/posthog-query.sh` com `refresh: force_blocking` (default), **exit 0** em todas as citadas; o `count()=0` do `019e6c3b` veio de query isolada porque a versão com subconsulta devolveu **504 (exit 73 = ausência de dado, não zero)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)