### PR TITLE
fix(fecho): o passo 3 só olhava a edge DESTA sessão — edge de terceiro na janela some, e é o mesmo argumento do passo 2

### DIFF
--- a/.claude/skills/fecho/SKILL.md
+++ b/.claude/skills/fecho/SKILL.md
@@ -141,13 +141,31 @@ Contexto: `docs/agent/database.md` §1 · `docs/historico/revoke-que-nao-revoga.
 ### Passo 3 — Edges
 
 ```bash
-git log origin/main --oneline -10 -- supabase/functions/
+# o que ESTA sessão tocou
 git diff --name-only origin/main...HEAD -- supabase/functions/
+
+# ⚠️ E o que OUTRAS sessões mergearam na janela desta — MESMO argumento do passo 2, e ele vale
+# aqui palavra por palavra: edge de terceiro entra na main sem ninguém aqui saber, também NÃO
+# se auto-deploya (chat do Lovable, manual) e a falha é igualmente SILENCIOSA.
+git log origin/main --since="<hora de início da sessão>" --name-only --format="" -- supabase/functions/ | sort -u
 ```
 
 Se a sessão tocou edge: ela foi deployada via chat do Lovable? (Evidência: o founder confirmou
 na conversa, ou a canária/probe respondeu com o comportamento novo.) Pendente → inclua o prompt
 de deploy verbatim (skill `lovable-deploy-verify`, passo 3) na mensagem de fecho.
+
+⚠️ **"Se a sessão tocou edge" NÃO é o gatilho deste passo — é só o gatilho da metade dele.**
+Edge de TERCEIRO na janela é pendência desta `/fecho` do mesmo jeito que migration de terceiro é,
+e pela mesma razão. Medido em 2026-08-26, na sessão do #2023/#2027: o `7e076f1f7`
+(`fix(omie)`, coleira de relógio no reconcile) mergeou dentro da janela tocando
+`omie-nfe-reconcile/index.ts` e um `_shared/omie-deadline.ts` NOVO. Só apareceu porque o agente
+alargou a consulta por conta própria — pela letra deste passo, ele teria olhado a saída do
+`git log`, visto commit que não era dele, e seguido em frente.
+
+Destino de edge de terceiro **não é** "deployar por ela" nem "assumir que a outra sessão já
+pediu": é **chip** (a sessão dona pode ter fechado sem pedir o deploy), com o prompt mandando
+CONFIRMAR antes de pedir deploy redundante. E o prompt tem de nomear **todos** os arquivos,
+`_shared` novo incluído — prompt que nomeia um só deixa a edge sem bootar (#2020).
 
 ### Passo 4 — Publish do frontend
 


### PR DESCRIPTION
## A assimetria

| passo | manda checar o que TERCEIROS mergearam na janela? |
|---|---|
| **2 — Migrations** | ✅ sim, explícito, com o porquê: *"entra na main sem ninguém aqui saber, também NÃO se auto-aplica, a falha é SILENCIOSA"* |
| **3 — Edges** | ❌ não — o gatilho da prosa era *"**Se a sessão tocou edge**"* |

Edge tem a propriedade **idêntica**: deploy manual pelo chat do Lovable, merge ≠ produção, falha silenciosa. O argumento do passo 2 vale aqui palavra por palavra e não estava escrito.

Pior que a ausência: o `git log -10 -- supabase/functions/` já estava no passo, então o agente **imprime** os commits de terceiro e a prosa logo abaixo o ensina a descartá-los como "não é meu". Output presente, leitura instruída a ignorar.

## Não é hipótese — mordeu na sessão do #2023/#2027

`7e076f1f7` (`fix(omie)`, coleira de relógio no reconcile) mergeou dentro da janela, tocando `omie-nfe-reconcile/index.ts` e um `_shared/omie-deadline.ts` **novo**.

Apareceu só porque o agente dobrou `supabase/functions/` na query da janela de migrations por conta própria. **Pela letra do passo, ele teria visto commit alheio e seguido em frente** — e uma edge de money-path ficaria em produção sem o fix, sem ninguém checando.

## O que muda

1. A consulta da janela entra no passo 3, espelhando o passo 2, com o mesmo aviso.
2. Fica dito que `"Se a sessão tocou edge"` é o gatilho de **metade** do passo, não do passo.
3. **Fixa o destino**, que também não estava escrito: edge de terceiro não é "deployar por ela" nem "assumir que a sessão dona já pediu" — ela pode ter fechado sem pedir. É **chip**, com o prompt mandando CONFIRMAR antes de pedir deploy redundante, e nomeando **todos** os arquivos (`_shared` novo incluído, senão a edge não boota — #2020).

## A classe

Mesma família dos #1677, #1863 e #2027: **quando duas superfícies têm o mesmo modo de falha, cobrir uma e não a outra não é meia proteção.** É proteção inteira contra o caso que alguém lembrou, e zero contra o gêmeo que ninguém lembrou. Passo que herda a razão de outro passo tem de herdar a checagem junto.

## Proveniência

Achado pelo founder, perguntando *"você não vai criar o PR?"* — depois que eu descrevi o sintoma (um rótulo `echo` hardcoded meu, que imprimiu "(vazio = nenhuma)" embaixo de três arquivos de edge) e **parei na causa próxima**, sem perguntar se a skill tinha mandado olhar.

## Verificação

1 arquivo, +19/−1. SHA citado provado com `git cat-file -t` antes do commit (escrevi `7e076f1f5` na primeira passada; era `7e076f1f7`).

```
docs:citacoes -> exit=0    docs:indice -> exit=0
docs:links    -> exit=0    claude:size -> exit=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)