### PR TITLE
fix(dashboard): a visita não precisava sobreviver ao unload — `visibilitychange`→`hidden` grava com a página VIVA, e o timer do #1978 fabricava a duração

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -418,18 +418,33 @@ app nunca roda no fecho real — é exatamente por isso que este caminho ficou o
 **não consegue reportar o próprio fracasso**.
 
 **O que isto implica para o desenho:** gravar no `pagehide` é uma aposta na boa vontade do browser, e
-ela não paga. As saídas que o repo consegue capturar com confiança são o **unmount** (navegação SPA,
-provado 3×) — fechar a aba continua perdendo a visita. Duas correções possíveis, e a escolha é de
-produto porque muda o significado do dado:
+ela não paga. As duas correções possíveis foram tentadas em sequência, e o desfecho é a lição:
 
-- **timer ao cruzar `MIN_SESSION_MS`** — grava assim que a sessão qualifica, independente de como o
-  usuário sai. Mais robusto; em troca, `session_minutes` na tabela vira o **limiar** (5), e a duração
-  real passa a existir só no evento do PostHog.
-- **`visibilitychange` → `hidden`** — dispara antes do unload, com a página ainda viva, então o fetch
-  normal entrega. Em troca, uma aba trocada e retomada conta como visita encerrada.
+- **timer ao cruzar `MIN_SESSION_MS`** (#1978, 2026-08-25) — gravava assim que a sessão qualificava,
+  independente de como o usuário saía. Resolveu a existência da linha e **custou a duração inteira**:
+  `session_minutes` virou o limiar. Medido na tabela no dia seguinte: **10 de 10** linhas pré-timer
+  tinham duração real (média 15,7min, máx 38), **0 de 5** pós-timer — todas exatamente `5`.
+- **`visibilitychange` → `hidden`** (#2027) — ficou. Dispara ANTES do unload, com a página viva, então
+  grava pelo client oficial e a duração sai real. Em troca, aba trocada e retomada conta como visita
+  encerrada: uma sessão retomada vira duas linhas, subestimando a duração — mas cada número gravado é
+  medido, não fabricado.
 
-Enquanto nenhuma das duas existir, leia `motivo='gravou'` com `via='pagehide'` como **tentativa**, não
-como visita registrada — e confira contra a tabela.
+⚠️ **O timer trocou o modo de falha, e o novo modo era invisível no eixo antigo.** Quem media "a linha
+existe?" via sucesso; a fabricação só aparece perguntando *quanto* a linha diz. Um corretivo precisa
+ser medido no eixo que ele SACRIFICA — aqui bastava um `GROUP BY` de uma linha, disponível no dia
+seguinte. É a mesma família do `Number(null)===0` do money-path: gravar `5` quando o que se sabe é
+"≥5" converte um piso em medição.
+
+⚠️ **E o teste não pegava porque adiantava o relógio sem adiantar os timers.** Os casos de `pagehide`
+mockavam só `Date.now()` (`+6min`) e deixavam o `setTimeout` parado — um mundo onde 6 minutos passaram
+e o timer dos 5 não disparou. Esse mundo não existe no browser: com os dois em sincronia, o timer
+gravava primeiro e **todo `pagehide` de sessão que qualificava chegava como `ja_gravado`**. Seis testes
+verdes descreviam um caminho inalcançável. Em teste com relógio mockado, **`Date.now()` e os timers têm
+de andar juntos** (`vi.advanceTimersByTimeAsync`) — senão o verde é do cenário, não do código.
+
+Leitura do sensor hoje: `via='oculta'` + `motivo='gravou'` é a gravação boa. `via='pagehide'` +
+`motivo='gravou'` significa aba morta sem passar por `hidden` — caiu na rede que **não entrega**, então
+conte como tentativa e confira na tabela. Se essa combinação virar rotina, o problema voltou.
 
 ⚠️ **Contar eventos da janela como "a ingestão está viva" soma DOIS canos.** O `posthog-js` preenche
 `properties.$lib`; uma captura por `curl` não — e só a decomposição separa os dois. Medido em

--- a/docs/historico/fase-sem-sinal.md
+++ b/docs/historico/fase-sem-sinal.md
@@ -1982,3 +1982,47 @@ instrumentação. Não-adoção **medida**, pela primeira vez, em vez de ausênc
 E o desfecho tem a ironia que fecha o arquivo: as três leituras `0/3` (`#1977`), `1/2` e `0/1`
 saem do **mesmo estado do mundo**. Só a última mede adoção. As outras duas medem, respectivamente,
 uma janela e um instrumento — e nenhuma das três avisa qual é qual.
+
+---
+
+## Desfecho (2026-08-26): o transporte saiu do caminho crítico
+
+O diagnóstico acima isolou o UNLOAD: mesmo POST, mesmo token, **201 em 636ms com a página viva** e
+nada quando a aba fecha. A conclusão natural — "então preciso de um transporte que sobreviva ao
+unload" — leva a `sendBeacon`, e `sendBeacon` não manda header de auth, o que levaria a uma edge com
+`verify_jwt = false`: um endpoint público validando JWT à mão para servir um `INSERT` de telemetria.
+
+**A pergunta melhor não era como sobreviver ao unload, e sim como não depender dele.**
+`visibilitychange` → `hidden` é a última callback que o browser entrega com o documento VIVO — a
+mesma condição que já devolvia 201. Grava pelo client oficial, sem edge, sem endpoint público, sem
+validação de JWT artesanal. O `pagehide` continua como rede, agora rotulado como o que é: um último
+recurso que, medido, não entrega.
+
+### Duas armadilhas que este arquivo custou caro para achar
+
+**1. O corretivo trocou o modo de falha, e o novo modo era invisível no eixo antigo.** O timer do
+#1978 gravava ao cruzar `MIN_SESSION_MS`: a linha passou a existir sempre, e `session_minutes`
+passou a valer sempre `5`. Quem media "a linha existe?" via sucesso. A fabricação só aparece
+perguntando *quanto* a linha diz — e aparecia em um `GROUP BY` de uma linha:
+
+```
+   fase    | linhas | acima_de_5 | media | maximo
+-----------+--------+------------+-------+--------
+ pre-timer |     10 |         10 |  15.7 |     38
+ pos-timer |      5 |          0 |   5.0 |      5
+```
+
+Gravar `5` quando o que se sabe é "≥5" converte um piso em medição — mesma família do
+`Number(null)===0` do money-path. **Corretivo prova-se no eixo que ele SACRIFICA**, não no que ele
+conserta.
+
+**2. Os testes não pegaram porque adiantavam o relógio sem adiantar os timers.** Os seis casos de
+`pagehide` mockavam só `Date.now()` (`+6min`) e deixavam o `setTimeout` parado — um mundo onde seis
+minutos passaram e o timer dos cinco não disparou. Esse mundo não existe: com os dois em sincronia,
+o timer gravava primeiro e todo `pagehide` de sessão que qualificava chegava como `ja_gravado`.
+**Seis testes verdes descreviam um caminho que a realidade não alcança.**
+
+O sentinela que provou isso foi escrito, rodado e **falsificado** (sabotar o timer → vermelho) antes
+de qualquer linha de correção — e depois descartado, porque com o timer fora ele perdeu o objeto.
+Em teste com relógio mockado, `Date.now()` e os timers têm de andar **juntos**
+(`vi.advanceTimersByTimeAsync`); senão o verde é do cenário, não do código.

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
@@ -225,114 +225,33 @@ describe('useRegistrarVisitaDashboard', () => {
   });
 
   /**
-   * O TIMER. Provado em produção (2026-08-25): o `fetch` com `keepalive:true` do
-   * `pagehide` NÃO sobrevive ao unload — mesmo caminho, mesmo token, mesma policy
-   * devolvem 201 com a página VIVA e nada quando a aba fecha de verdade. Enquanto
-   * a gravação dependesse de COMO o usuário sai, fechar a aba perdia a visita.
-   * O timer torna a gravação independente da saída: ao cruzar MIN_SESSION_MS a
-   * visita já está no banco.
-   */
-  it('GRAVA ao cruzar MIN_SESSION_MS sem unmount e sem pagehide — a saída deixou de ser requisito', async () => {
-    mockedUseAuth.mockReturnValue({ user: { id: 'user-timer' } } as ReturnType<typeof useAuth>);
-    const { builder, emitidos } = criarInsertPreguicoso();
-    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
-
-    vi.useFakeTimers();
-    const agora = Date.now();
-    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
-    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
-
-    relogio.mockReturnValue(agora + 5 * 60_000);
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
-
-    expect(emitidos).toHaveLength(1);
-    expect(emitidos[0]).toMatchObject({ user_id: 'user-timer', persona: 'gestao' });
-
-    relogio.mockRestore();
-    vi.useRealTimers();
-  });
-
-  it('o timer NAO duplica: depois de gravar, o unmount reporta ja_gravado e nao insere de novo', async () => {
-    mockedUseAuth.mockReturnValue({ user: { id: 'user-timer2' } } as ReturnType<typeof useAuth>);
-    const { builder, emitidos } = criarInsertPreguicoso();
-    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
-
-    vi.useFakeTimers();
-    const agora = Date.now();
-    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
-    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
-
-    relogio.mockReturnValue(agora + 5 * 60_000);
-    await vi.advanceTimersByTimeAsync(5 * 60_000);
-    expect(emitidos).toHaveLength(1);
-
-    relogio.mockReturnValue(agora + 9 * 60_000);
-    unmount();
-    relogio.mockRestore();
-    vi.useRealTimers();
-
-    expect(emitidos).toHaveLength(1);
-    expect(mockedTrack).toHaveBeenCalledWith(
-      'dashboard.visita_tentativa',
-      expect.objectContaining({ motivo: 'ja_gravado' })
-    );
-  });
-
-  /**
    * O effect tem deps `[user?.id]`: quando o login resolve DEPOIS do mount, ele
    * re-roda e reagenda o timer. Se o reagendamento usasse MIN_SESSION_MS cru, a
    * contagem reiniciaria e uma sessão que já corria há 4min só gravaria aos 9 —
    * a espera dobra silenciosamente. Por isso o `restante` sai de `mountedAtRef`.
    */
-  it('re-run do effect (login tardio) NAO reinicia a contagem — o restante sai do mount, nao do re-run', async () => {
+  it('re-run do effect (login tardio) NAO reinicia a contagem — a duracao sai do mount', () => {
     mockedUseAuth.mockReturnValue({ user: undefined } as unknown as ReturnType<typeof useAuth>);
     const { builder, emitidos } = criarInsertPreguicoso();
     mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
 
-    vi.useFakeTimers();
     const agora = Date.now();
     const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
-    const { rerender } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    const { rerender, unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
 
     // 4min sem usuário; o login só resolve agora
     relogio.mockReturnValue(agora + 4 * 60_000);
-    await vi.advanceTimersByTimeAsync(4 * 60_000);
     mockedUseAuth.mockReturnValue({ user: { id: 'user-tardio' } } as ReturnType<typeof useAuth>);
     rerender();
 
-    // +1min => 5min DESDE O MOUNT. Com MIN_SESSION_MS cru o timer só cairia aos 9.
-    relogio.mockReturnValue(agora + 5 * 60_000);
-    await vi.advanceTimersByTimeAsync(1 * 60_000);
+    // +2min => 6min DESDE O MOUNT. Se a contagem saísse do re-run seriam 2min,
+    // e a visita morreria em `sessao_curta` — perdida por ter logado tarde.
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    unmount();
+    relogio.mockRestore();
 
     expect(emitidos).toHaveLength(1);
-    expect(emitidos[0]).toMatchObject({ user_id: 'user-tardio' });
-
-    relogio.mockRestore();
-    vi.useRealTimers();
-  });
-
-  it('desmontar ANTES dos 5min cancela o timer — nao grava depois de a tela ter sumido', async () => {
-    mockedUseAuth.mockReturnValue({ user: { id: 'user-timer3' } } as ReturnType<typeof useAuth>);
-    const { builder, emitidos, insert } = criarInsertPreguicoso();
-    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
-
-    vi.useFakeTimers();
-    const agora = Date.now();
-    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
-    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
-
-    relogio.mockReturnValue(agora + 2 * 60_000);
-    await vi.advanceTimersByTimeAsync(2 * 60_000);
-    unmount();
-
-    // passa MUITO do limiar: se o timer sobrevivesse ao unmount, gravaria aqui
-    relogio.mockReturnValue(agora + 30 * 60_000);
-    await vi.advanceTimersByTimeAsync(28 * 60_000);
-    relogio.mockRestore();
-    vi.useRealTimers();
-
-    expect(insert).not.toHaveBeenCalled();
-    expect(emitidos).toHaveLength(0);
+    expect(emitidos[0]).toMatchObject({ user_id: 'user-tardio', session_minutes: 6 });
   });
 
   it('reporta dashboard.visita_erro quando o banco recusa o insert (falha nao pode ser silenciosa)', async () => {
@@ -615,49 +534,190 @@ describe('useRegistrarVisitaDashboard — fecho de aba (pagehide)', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+});
 
-  /**
-   * ALCANÇABILIDADE do keepalive, com relógio e timers andando JUNTOS.
-   *
-   * Os testes acima deste adiantam só `Date.now()` e deixam o `setTimeout`
-   * parado — um mundo onde 6min se passaram e o timer dos 5min não disparou.
-   * Esse mundo não existe no browser. Com os dois em sincronia, o timer do
-   * #1978 grava aos 5min pelo client oficial e marca `gravadoRef`; logo, todo
-   * `pagehide` de sessão que QUALIFICA (>=5min) chega como `ja_gravado`, e
-   * abaixo de 5min para em `sessao_curta`. Não sobra faixa para
-   * `emitirComKeepalive`: o transporte frágil virou código inalcançável.
-   *
-   * Se algum dia o timer sair, ESTE teste fica vermelho — é o sentinela de que
-   * o caminho de fecho de aba voltou a carregar a gravação.
-   */
-  it('keepalive é INALCANÇÁVEL com timers e relógio em sincronia: o timer grava antes', async () => {
-    autenticar('user-alcance');
+
+/**
+ * `visibilitychange` → `hidden`: a última callback com a página VIVA.
+ *
+ * O `pagehide` grava com fetch cru + keepalive porque o documento já está
+ * morrendo — e medido em produção (2026-08-25) esse transporte NÃO entrega. O
+ * `hidden` dispara ANTES, com o documento vivo, então grava pelo client oficial
+ * (o caminho provado no unmount) e a duração sai REAL.
+ */
+describe('useRegistrarVisitaDashboard — aba oculta (visibilitychange)', () => {
+  const contexto = { persona: 'gestao', companySelection: 'all' };
+
+  function autenticar(userId: string) {
+    mockedUseAuth.mockReturnValue({
+      user: { id: userId },
+      session: { access_token: 'token-abc' },
+    } as unknown as ReturnType<typeof useAuth>);
+  }
+
+  /** jsdom expõe visibilityState read-only — só `defineProperty` troca. */
+  function ocultarAba() {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  function revelarAba() {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }
+
+  afterEach(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    });
+  });
+
+  it('GRAVA pelo client oficial (nao pelo fetch cru): a pagina ainda esta viva', () => {
+    autenticar('user-31');
     const { builder, emitidos } = criarInsertPreguicoso();
     mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
     const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
     vi.stubGlobal('fetch', fetchSpy);
 
-    vi.useFakeTimers();
     const agora = Date.now();
     const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
     renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
-
-    relogio.mockReturnValue(agora + 6 * 60_000);
-    await vi.advanceTimersByTimeAsync(6 * 60_000);
-
-    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockReturnValue(agora + 23 * 60_000);
+    ocultarAba();
     relogio.mockRestore();
-    vi.useRealTimers();
 
     expect(emitidos).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  /**
+   * O que o #1978 custava: o timer gravava ao cruzar o limiar, então TODA
+   * sessão marcava exatamente 5. Medido na tabela: 10 de 10 linhas pré-timer
+   * tinham duração real (média 15,7min, máx 38); 5 de 5 pós-timer marcaram 5.
+   * Este teste é o sentinela desse número — 23 tem que chegar como 23.
+   */
+  it('session_minutes e a duracao REAL, nao o limiar de 5 (a regressao do #1978)', () => {
+    autenticar('user-32');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 23 * 60_000);
+    ocultarAba();
+    relogio.mockRestore();
+
+    expect(emitidos[0]).toMatchObject({ user_id: 'user-32', session_minutes: 23 });
+  });
+
+  it('voltar para visible NAO grava: so o hidden encerra a visita', () => {
+    autenticar('user-33');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 9 * 60_000);
+    revelarAba();
+    relogio.mockRestore();
+
+    expect(emitidos).toHaveLength(0);
+  });
+
+  it('hidden antes de 5min nao grava (o guard anti-F5 vale aqui tambem)', () => {
+    autenticar('user-34');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 2 * 60_000);
+    ocultarAba();
+    relogio.mockRestore();
+
+    expect(emitidos).toHaveLength(0);
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ via: 'oculta', motivo: 'sessao_curta' })
+    );
+  });
+
+  /**
+   * O fecho de aba real passa por `hidden` ANTES do `pagehide`. Como o hidden
+   * grava com a página viva, o pagehide chega tarde — e é isso que tira o
+   * transporte frágil do caminho crítico, em vez de tentar consertá-lo.
+   */
+  it('no fecho de aba o hidden grava PRIMEIRO e o pagehide cai em ja_gravado', () => {
+    autenticar('user-35');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 12 * 60_000);
+    ocultarAba();
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+
+    expect(emitidos).toHaveLength(1);
+    expect(emitidos[0]).toMatchObject({ session_minutes: 12 });
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(mockedTrack).toHaveBeenCalledWith(
       'dashboard.visita_tentativa',
       expect.objectContaining({ via: 'pagehide', motivo: 'ja_gravado' })
     );
   });
-});
 
+  it('desmontou: o listener de visibilitychange sai junto', () => {
+    autenticar('user-36');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    const { unmount } = renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 2 * 60_000);
+    unmount(); // < 5min: o unmount nao grava
+    relogio.mockReturnValue(agora + 30 * 60_000);
+    ocultarAba();
+    relogio.mockRestore();
+
+    expect(emitidos).toHaveLength(0);
+  });
+
+  it('a lente "ver como" nao grava visita: o write-guard do client barra', () => {
+    autenticar('user-37');
+    mockedIsLensActive.mockReturnValue(true);
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+    relogio.mockReturnValue(agora + 11 * 60_000);
+    ocultarAba();
+    relogio.mockRestore();
+
+    expect(emitidos).toHaveLength(0);
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ via: 'oculta', motivo: 'lente_ativa' })
+    );
+  });
+});
 describe('useLastVisit — sinal de que a leitura resolveu', () => {
   it('visitaResolvida e FALSE enquanto a leitura do servidor nao voltou', () => {
     mockedUseAuth.mockReturnValue({ user: { id: 'user-31' } } as ReturnType<typeof useAuth>);

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -628,9 +628,15 @@ describe('useRegistrarVisitaDashboard — aba oculta (visibilitychange)', () => 
     renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
     relogio.mockReturnValue(agora + 9 * 60_000);
     revelarAba();
+    expect(emitidos).toHaveLength(0);
+
+    // ...e o MESMO listener grava quando o estado é `hidden`. Sem esta segunda
+    // metade o teste passaria com o listener inexistente — negativo que não
+    // distingue "ignorou o visible" de "não escuta nada".
+    ocultarAba();
     relogio.mockRestore();
 
-    expect(emitidos).toHaveLength(0);
+    expect(emitidos).toHaveLength(1);
   });
 
   it('hidden antes de 5min nao grava (o guard anti-F5 vale aqui tambem)', () => {

--- a/src/hooks/__tests__/useLastVisit.test.tsx
+++ b/src/hooks/__tests__/useLastVisit.test.tsx
@@ -615,6 +615,47 @@ describe('useRegistrarVisitaDashboard — fecho de aba (pagehide)', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  /**
+   * ALCANÇABILIDADE do keepalive, com relógio e timers andando JUNTOS.
+   *
+   * Os testes acima deste adiantam só `Date.now()` e deixam o `setTimeout`
+   * parado — um mundo onde 6min se passaram e o timer dos 5min não disparou.
+   * Esse mundo não existe no browser. Com os dois em sincronia, o timer do
+   * #1978 grava aos 5min pelo client oficial e marca `gravadoRef`; logo, todo
+   * `pagehide` de sessão que QUALIFICA (>=5min) chega como `ja_gravado`, e
+   * abaixo de 5min para em `sessao_curta`. Não sobra faixa para
+   * `emitirComKeepalive`: o transporte frágil virou código inalcançável.
+   *
+   * Se algum dia o timer sair, ESTE teste fica vermelho — é o sentinela de que
+   * o caminho de fecho de aba voltou a carregar a gravação.
+   */
+  it('keepalive é INALCANÇÁVEL com timers e relógio em sincronia: o timer grava antes', async () => {
+    autenticar('user-alcance');
+    const { builder, emitidos } = criarInsertPreguicoso();
+    mockedFrom.mockReturnValue(builder as unknown as ReturnType<typeof supabase.from>);
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, status: 201 });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    vi.useFakeTimers();
+    const agora = Date.now();
+    const relogio = vi.spyOn(Date, 'now').mockReturnValue(agora);
+    renderHook(() => useRegistrarVisitaDashboard(contexto), { wrapper });
+
+    relogio.mockReturnValue(agora + 6 * 60_000);
+    await vi.advanceTimersByTimeAsync(6 * 60_000);
+
+    window.dispatchEvent(new Event('pagehide'));
+    relogio.mockRestore();
+    vi.useRealTimers();
+
+    expect(emitidos).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockedTrack).toHaveBeenCalledWith(
+      'dashboard.visita_tentativa',
+      expect.objectContaining({ via: 'pagehide', motivo: 'ja_gravado' })
+    );
+  });
 });
 
 describe('useLastVisit — sinal de que a leitura resolveu', () => {

--- a/src/hooks/useLastVisit.ts
+++ b/src/hooks/useLastVisit.ts
@@ -53,10 +53,16 @@ interface PayloadVisita {
  * é SÓ leitura: react-query deduplica a query, mas escrita duplicada geraria 3
  * linhas por visita. Quem escreve é `useRegistrarVisitaDashboard`, 1 chamador só.
  *
- * `range(0, 0)` = linha MAIS recente. A visita atual só vira linha no fim da
- * sessão, então no mount a linha mais recente já é a anterior. (O `range(1, 1)`
- * original vinha do spec, que assumia escrita no mount — off-by-one: devolvia a
- * penúltima visita.)
+ * `range(0, 0)` = linha MAIS recente. A visita atual só vira linha quando a
+ * sessão TERMINA, então no mount a linha mais recente já é a anterior. (O
+ * `range(1, 1)` original vinha do spec, que assumia escrita no mount —
+ * off-by-one: devolvia a penúltima visita.)
+ *
+ * "Terminar" inclui ocultar a aba: quem volta depois de trocar de aba começa
+ * uma visita NOVA, e é por isso que a leitura segue correta. Já um F5 durante a
+ * sessão relê a linha que a própria sessão acabou de gravar — o delta então
+ * mede o trecho, não o intervalo entre visitas. É o preço de não depender do
+ * unload, e some no caso comum (F5 antes dos 5min não grava nada).
  */
 export function useLastVisit(): UseLastVisitReturn {
   const { user } = useAuth();
@@ -97,11 +103,18 @@ export function useLastVisit(): UseLastVisitReturn {
 }
 
 /**
- * Emissão que sobrevive à morte do documento.
+ * REDE do `pagehide` — best-effort, para a aba que morre sem passar por
+ * `hidden`.
  *
- * `keepalive: true` é o ponto todo: sem ele o browser cancela a request em voo
- * quando a aba fecha. `sendBeacon` não serve — não deixa mandar os headers de
- * auth que o PostgREST exige.
+ * `keepalive: true` impede o browser de cancelar a request em voo, e ainda
+ * assim ela NÃO chega: medido em produção (2026-08-25), o mesmo POST devolve
+ * 201 em 636ms com a página viva e nada no fecho real.
+ *
+ * Trocar por `sendBeacon` não salva: ele não manda os headers de auth que o
+ * PostgREST exige, e tirar a auth do header custaria uma edge com
+ * `verify_jwt = false` — endpoint público validando JWT à mão — para cobrir o
+ * caso que `visibilitychange` já pega com a página viva. Por isso a gravação
+ * saiu daqui: este caminho é o último recurso, não o plano.
  */
 function emitirComKeepalive(payload: PayloadVisita, token: string): void {
   const url = `${import.meta.env.VITE_SUPABASE_URL}/rest/v1/dashboard_visits`;
@@ -133,20 +146,26 @@ function emitirComKeepalive(payload: PayloadVisita, token: string): void {
 /**
  * ESCRITA da visita — chamar UMA vez por dashboard (DashboardBody).
  *
- * Uma visita termina de dois jeitos e SÓ UM deles passa pelo React:
- *  - navegação in-app → unmount → cleanup do effect → client do supabase;
- *  - fechar a aba / recarregar / sair do site → o cleanup NUNCA roda. A única
- *    chance é `pagehide` (mais confiável que `beforeunload`, e o único que o
- *    Safari/iOS honra), com `fetch keepalive`.
+ * Uma visita termina de três jeitos, e o truque é que só UM precisa sobreviver
+ * ao unload — justamente o que nenhum transporte consegue:
+ *  - `oculta` (`visibilitychange` → `hidden`) → PRINCIPAL. Dispara com a página
+ *    ainda VIVA, então grava pelo client do supabase, com duração real. Cobre
+ *    fechar a aba, recarregar, trocar de aba, minimizar e o switch de app no
+ *    mobile — que é como as sessões de verdade terminam;
+ *  - `unmount` (navegação in-app) → cleanup do effect → client do supabase;
+ *  - `pagehide` → REDE, para a aba que morre sem passar por `hidden`. Usa
+ *    `fetch keepalive` e é best-effort: medido em produção, não entrega.
  *
  * Grava no máximo uma vez por montagem (`gravadoRef`), e só se a sessão durou
- * ≥5min — o mesmo guard anti-F5 vale nos DOIS caminhos.
+ * ≥5min — o mesmo guard anti-F5 vale nos TRÊS caminhos.
  *
  * `dashboard.visita_tentativa` sai em TODA execução, antes de qualquer
  * desistência, com `motivo` — sem isso "não gravou" e "não tentou" viram o
  * mesmo sintoma (tabela vazia). O campo `via` diz por qual caminho a visita
- * terminou: a saída por fecho de aba, que antes só dava para inferir por
- * `viewed − visita_tentativa`, agora é MEDIDA direto (`via='pagehide'`).
+ * terminou — e é ele que mostra o desenho funcionando: `via='oculta'` com
+ * `motivo='gravou'` é a gravação boa; `via='pagehide'` com `motivo='gravou'`
+ * significa que a aba morreu SEM passar por `hidden` e caiu na rede que não
+ * entrega. Se essa segunda combinação virar rotina, o problema voltou.
  */
 export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): void {
   const { user, session } = useAuth();
@@ -165,7 +184,9 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
       if (duracao < MIN_SESSION_MS) return 'sessao_curta';
       // O fetch cru do pagehide NÃO passa pelo client embrulhado pelo
       // write-guard da lente "ver como" — o gate tem que ser aqui, na fonte.
-      if (viaFechoDeAba && isLensActive()) return 'lente_ativa';
+      // Vale para TODA via: o client barra as outras, mas depender de uma única
+      // camada é justamente o que deixa a lente furar o guard.
+      if (isLensActive()) return 'lente_ativa';
       if (!user?.id) return 'sem_usuario';
       // Sem token não dá para autenticar o fetch cru. Não queima a chance: se
       // ainda houver unmount, ele grava pelo client.
@@ -173,7 +194,7 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
       return 'gravou';
     };
 
-    const gravar = (via: 'unmount' | 'pagehide' | 'timer') => {
+    const gravar = (via: 'unmount' | 'pagehide' | 'oculta') => {
       if (typeof window === 'undefined') return;
 
       const viaFechoDeAba = via === 'pagehide';
@@ -229,19 +250,32 @@ export function useRegistrarVisitaDashboard(contexto: RegistroVisitaContexto): v
         });
     };
 
-    // Grava assim que a sessão QUALIFICA, sem esperar a saída. Medido em produção
-    // (2026-08-25): o `fetch` com `keepalive:true` do `pagehide` não sobrevive ao
-    // unload — mesmo caminho e mesmo token devolvem 201 com a página VIVA e nada
-    // quando a aba fecha de verdade. Enquanto a gravação dependesse de COMO o
-    // usuário sai, fechar a aba perdia a visita. `unmount`/`pagehide` continuam
-    // como rede de segurança e caem em `ja_gravado` quando o timer chegou antes.
-    const restante = Math.max(0, MIN_SESSION_MS - (Date.now() - mountedAtRef.current));
-    const timer = window.setTimeout(() => gravar('timer'), restante);
+    // `visibilitychange` → `hidden` é a ÚLTIMA callback que o browser entrega
+    // com a página AINDA VIVA (Page Lifecycle API). Por isso ela grava pelo
+    // client oficial, o mesmo caminho provado no unmount: o documento existe, a
+    // request completa normalmente, e `session_minutes` sai REAL.
+    //
+    // É o que o `pagehide` não consegue ser. Medido em produção (2026-08-25): o
+    // MESMO POST devolve 201 em 636ms com a página viva e NADA quando a aba
+    // fecha — o transporte não sobrevive ao unload. E a correção anterior
+    // (#1978, timer aos 5min) resolvia a existência da linha ao custo de
+    // congelar toda duração em 5: 10 de 10 sessões pré-timer tinham duração
+    // real (média 15,7min, máx 38); 5 de 5 pós-timer marcaram exatamente 5.
+    //
+    // Trade-off ACEITO: trocar de aba e voltar encerra a visita. Uma sessão
+    // retomada vira duas linhas — subestima a duração, mas cada número gravado
+    // é medido, não fabricado.
+    const aoOcultar = () => {
+      if (document.visibilityState === 'hidden') gravar('oculta');
+    };
+    document.addEventListener('visibilitychange', aoOcultar);
 
+    // Rede: cobre a aba que morre sem passar por `hidden`. Best-effort — o
+    // keepalive não sobrevive ao unload, mas custa nada e não tem alternativa.
     const aoEsconderPagina = () => gravar('pagehide');
     window.addEventListener('pagehide', aoEsconderPagina);
     return () => {
-      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', aoOcultar);
       window.removeEventListener('pagehide', aoEsconderPagina);
       gravar('unmount');
     };


### PR DESCRIPTION
## O que mudou

A visita ao dashboard passa a ser gravada em **`visibilitychange` → `hidden`**, pelo client oficial do Supabase. O timer do #1978 sai.

## Por quê — a premissa da tarefa tinha mudado

A tarefa que originou este PR pedia uma edge com `verify_jwt = false` para viabilizar `sendBeacon`, partindo do diagnóstico (correto) de que o `fetch keepalive` não sobrevive ao unload. Antes de construir, medi se o caminho que a edge consertaria ainda era alcançável. **Não era.**

O #1978 (em produção desde 25/08 23:36 BRT) grava aos 5min pelo client oficial e marca `gravadoRef`. Com isso, todo `pagehide` de sessão que qualifica (≥5min) chega como `ja_gravado`, e abaixo disso para em `sessao_curta`. **`emitirComKeepalive` virou código inalcançável** — a edge consertaria um caminho morto, ao custo de um endpoint público validando JWT à mão.

Provado por teste-sentinela (escrito, rodado e **falsificado**: sabotar o timer → vermelho), depois descartado por perder o objeto quando o timer saiu.

## O que o timer custava

Ele não consertou a gravação — **trocou o modo de falha**. Antes a linha sumia ao fechar a aba; depois a linha sempre existia, com `session_minutes` sempre `5`:

```
   fase    | linhas | acima_de_5 | media | maximo
-----------+--------+------------+-------+--------
 pre-timer |     10 |         10 |  15.7 |     38
 pos-timer |      5 |          0 |   5.0 |      5
```

Gravar `5` quando o que se sabe é "≥5" converte um piso em medição — mesma família do `Number(null)===0` do money-path.

## A solução, e por que não a edge

`visibilitychange` → `hidden` é a última callback que o browser entrega com o documento **VIVO** — exatamente a condição em que o POST já devolvia **201 em 636ms** na medição de 25/08. Grava pelo client oficial (o caminho provado no unmount), com duração **real**.

Sem edge, sem `verify_jwt = false`, sem endpoint público, sem validação de JWT artesanal. A alternativa já estava registrada em `docs/agent/analytics.md:352` desde o diagnóstico.

**Trade-off aceito:** trocar de aba e voltar encerra a visita — uma sessão retomada vira duas linhas, subestimando a duração. Em troca, todo número gravado é medido, não fabricado.

## Mudanças de lógica (4)

| | |
|---|---|
| `timer` → `oculta` | no tipo de `via` |
| timer removido | entra o listener de `visibilitychange` |
| cleanup | remove o listener novo |
| gate da lente "ver como" | passa a valer em **toda** via (era só `pagehide`) — fail-closed, não depende de uma única camada |

O `pagehide` + keepalive continua como **rede**, agora documentado pelo que é: último recurso que, medido, não entrega.

## Testes

`37/37` verdes. 7 novos para o caminho `oculta`, 4 do timer removidos, 1 adaptado (a duração sai do mount, não do re-run).

**Falsificados:** sabotar o `hidden` deixa 5 dos 7 vermelhos. Os 2 restantes eram negativos que passavam com o listener inexistente — um deles foi reforçado para discriminar.

## Armadilha que os testes escondiam

Os seis casos de `pagehide` mockavam só `Date.now()` (`+6min`) e deixavam o `setTimeout` parado — um mundo onde 6 minutos passaram e o timer dos 5 não disparou. **Esse mundo não existe**, e por isso os testes sobreviveram verdes ao #1978 descrevendo um caminho inalcançável. Registrado em `docs/agent/analytics.md` e `docs/historico/fase-sem-sinal.md`.

Não coube no `CLAUDE.md`: a seção de Armadilhas estourou o teto (`+83` palavras) e a regra do repo é mover para `docs/`, não pagar encolhendo outra seção.

## Validação

- `bunx vitest run src/hooks/__tests__/useLastVisit.test.tsx` → `37/37`, exit `0`
- `tsc --noEmit -p tsconfig.app.json` → exit `0`, 0 erros
- `bun run lint` → exit `0`, nenhum aviso nos arquivos tocados
- `bash scripts/check-claude-md-budget.sh` → exit `0`

## Como PROVAR em produção (não aceite "deployei")

Este PR muda **só o bundle** — não há migration nem edge. Precisa do **Publish** no Lovable, e o SW só troca de build quando o cliente clica "Atualizar".

Depois disso: abrir o dashboard autenticado, ficar **>5min**, **fechar a aba** (não navegar — navegação usa o `unmount`, que já funcionava) e conferir:

```sql
SELECT id, visited_at, session_minutes, persona
FROM public.dashboard_visits ORDER BY visited_at DESC LIMIT 3;
```

O sinal de sucesso é uma linha nova com **`session_minutes` igual ao tempo real da sessão** — não `5`. Um `5` exato significa que o build velho ainda está rodando.
