### PR TITLE
feat(deploy-verify): o `--pai` prova a sentinela no GIT — a LIB é um 2º emissor que nenhum `git grep` alcança

### DIFF
--- a/.claude/skills/lovable-deploy-verify/SKILL.md
+++ b/.claude/skills/lovable-deploy-verify/SKILL.md
@@ -139,6 +139,8 @@ não só o `index.ts` (#2018).
 # saída: "✓ sentinela exclusiva: …" + "chunks (closure ∪ precache): N" + "✅ ALVO em <chunk>"
 #        + "✓ CONTROLE_NEGATIVO_OK — <chunk> não casa controle_negativo_<hex>"   (ramo do hit)
 #        + "✓ CONTROLE_POSITIVO_OK — <entry> ainda devolve bytes e o mesmo grep acha '<agulha>'"
+#        + LIB_SEM_A_SENTINELA | SENTINELA_TAMBEM_NA_LIB | LIB_NAO_CONSULTADA (sonda do 2º emissor,
+#          pré-rede: AVISA e nunca muda o exit — node_modules é preditor, não prova)
 # exit 0 = no ar E o controle negativo passou · 1 = ausente E o controle POSITIVO provou que a
 #          sonda enxergava (Publish pendente / alvo não-literal)
 #      2 = a MECÂNICA da sonda não é confiável: enumeração quebrada, SONDA_NAO_DISCRIMINA (ramo
@@ -215,9 +217,26 @@ audita o par `(padrão, grep)`, não a **proveniência** da string).
 > forma que lê uma **remoção**:
 > `e.init(li,{…,disable_session_recording:!0,autocapture:{…css_selector_allowlist:["button","a","select",'input[type="checkbox"]','[role="button"]']}})`
 
-Detalhe, medições e a sugestão `SENTINELA_TAMBEM_NA_LIB` (avisa, **não** recusa — `maskAllInputs`
-está em 37 arquivos da lib e em **0** ocorrências do chunk servido, logo `node_modules` é *preditor*
-do 2º emissor, não prova): [`docs/historico/sentinela-segundo-emissor.md`](../../../docs/historico/sentinela-segundo-emissor.md).
+**A sonda `SENTINELA_TAMBEM_NA_LIB` (implementada 2026-08-26)** roda pré-rede e nos **dois** modos —
+a pergunta dela ("existe emissor **fora** do git?") é ortogonal à do `--pai` ("é nova **dentro** do
+git?"), e sem `--pai` o operador está no modo mais fraco, que é onde calar custa mais. Ela **avisa e
+nunca recusa**: `maskAllInputs` está em **10** arquivos de `posthog-js/dist/` e em **0** ocorrências
+do chunk servido — tree-shaking decide o que chega ao bundle, logo `node_modules` é *preditor* do 2º
+emissor e não **prova** dele, e um guard que recusasse no hit reprovaria sentinela legítima. Três
+estados, e o terceiro é o que evita fabricar veredito:
+
+| marca | quando | por quê |
+|---|---|---|
+| `SENTINELA_TAMBEM_NA_LIB` | a lib emite o alvo | imprime os **caminhos**: `posthog-js/dist/` lê como 2º emissor provável, `jsdom/` como devDep que nunca vai ao bundle |
+| `LIB_SEM_A_SENTINELA` | 0 arquivos de código | a sentinela é sua |
+| `LIB_NAO_CONSULTADA` | sem `node_modules` (ou `grep` falhou) | worktree recém-criada não tem — o `bun install` é passo à parte, e **silêncio ali se leria como "limpo"** |
+
+O universo é **código JS** (`--include` de `*.js`/`*.mjs`/`*.cjs`), não a árvore inteira, e o corte
+foi medido na `node_modules` real (637 MB / 54.843 arquivos): sem filtro custa **38-63 s** e o *valor
+nosso* `input[type="checkbox"]` — a sentinela que esta própria seção recomenda — acusava 3 arquivos
+(`readme.md`, `preflight.css` do tailwind, css de demo). Aviso que dispara contra a resposta certa é
+aviso desarmado no primeiro dia. Com o filtro: **~2 s**, e o mesmo alvo cai para 1 (`jsdom`). Detalhe
+e medições: [`docs/historico/sentinela-segundo-emissor.md`](../../../docs/historico/sentinela-segundo-emissor.md).
 
 **O guard não prova que a sonda sabe dizer "não" — isso é o CONTROLE NEGATIVO, e ele virou
 embutido (2026-08-24).** Um `exit 0` sozinho não distingue "está no ar" de "o script dá verde pra

--- a/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
@@ -53,6 +53,7 @@ JS
 # PageB: folha do 1º nível, sem deps — carrega um marcador renderizado
 cat > "$FIX/site/assets/PageB-CCC333.js" <<'JS'
 export const b="PAGEB_MARKER";
+export const o={LIB_OPTION_MARKER:!0};
 JS
 
 # deep: alvo SÓ alcançável pelo fechamento transitivo de 2º nível
@@ -81,10 +82,29 @@ gitq() { git -C "$REPO" -c user.email=eval@local -c user.name=eval -c commit.gpg
 printf 'export const b="PAGEB_MARKER";\n' > "$REPO/src/app.ts"
 gitq add -A; gitq commit -m pai
 SHA_PAI=$(git -C "$REPO" rev-parse HEAD 2>/dev/null)
-printf 'export const s="SENTINELA_DEEP_XYZ";\n' >> "$REPO/src/app.ts"
+printf 'export const s="SENTINELA_DEEP_XYZ";\nexport const o={LIB_OPTION_MARKER:!0};\n' >> "$REPO/src/app.ts"
 gitq add -A; gitq commit -m novo
 SHA_NOVO=$(git -C "$REPO" rev-parse HEAD 2>/dev/null)
 [ -n "$SHA_PAI" ] && [ -n "$SHA_NOVO" ] || { echo "❌ fixture git não subiu"; exit 2; }
+
+# ---- node_modules fixture: a sonda do SEGUNDO EMISSOR (SENTINELA_TAMBEM_NA_LIB) ----
+# Criado DEPOIS dos commits de propósito: `git add -A` versionaria node_modules e o fixture viraria
+# outra coisa. LIB_OPTION_MARKER imita o caso real medido (docs/historico/sentinela-segundo-emissor.md):
+# nome de opção de API que a LIB emite no próprio código E que também está no nosso src/ e no bundle
+# — o `git grep` do --pai não vê esse 2º emissor, a sonda vê.
+mkdir -p "$REPO/node_modules/fake-lib/dist"
+printf 'export const o={LIB_OPTION_MARKER:!0,x:1};\n' > "$REPO/node_modules/fake-lib/dist/lib.js"
+# SENTINELA_DEEP_XYZ (a sentinela LIMPA do harness) aparece aqui num .md DE PROPÓSITO: o universo da
+# sonda é código JS, então isto NÃO pode virar hit. Medido na node_modules real: sem o filtro de
+# extensão o "valor nosso" acusava readme.md/preflight.css e o aviso disparava contra a sentinela
+# CERTA. É o que a sabotagem J falsifica.
+printf 'exemplo de uso: SENTINELA_DEEP_XYZ\n' > "$REPO/node_modules/fake-lib/readme.md"
+
+# cwd NEUTRO dos casos que não exercitam git/node_modules: fora de repo git e sem node_modules, a
+# sonda responde LIB_NAO_CONSULTADA de forma determinística e a custo zero. Sem isto os casos
+# herdariam o node_modules REAL da máquina — ~2s cada e saída que varia por host, num harness cujo
+# cabeçalho promete ser DETERMINÍSTICO.
+mkdir -p "$FIX/neutro"
 
 # site-broken: HTML sem entry /assets/index-*.js -> enumeração quebrada (exit 2)
 cat > "$FIX/site-broken/index.html" <<'HTML'
@@ -151,7 +171,7 @@ PASS=0; FAIL=0
 # daqui é shim e dobra acento — casar "✓ controle negativo" seria casar sorte, não a asserção.
 run_case() {
   local descr="$1" url="$2" alvo="$3" exp="$4" want="${5:-}" nao="${6:-}" out got ok=1
-  out=$(bash "$SCRIPT_REL" "$alvo" "$url" 2>&1); got=$?
+  out=$(cd "$FIX/neutro" && bash "$SCRIPT_ABS" "$alvo" "$url" 2>&1); got=$?
   [ "$got" = "$exp" ] || ok=0
   if [ -n "$want" ]; then printf '%s' "$out" | grep -q -- "$want" || ok=0; fi
   if [ -n "$nao" ]; then printf '%s' "$out" | grep -q -- "$nao" && ok=0; fi
@@ -164,14 +184,17 @@ run_case() {
   fi
 }
 
-# run_case_pai: descr, cwd, exit_esperado, substring_esperada, args... (para o script)
-# Roda com cwd DENTRO do repo fixture — o guard --pai consulta o git do diretório corrente.
-run_case_pai() {
-  local descr="$1" cwd="$2" exp="$3" want="$4"; shift 4
+# run_case_cwd: descr, cwd, exit_esperado, substring_esperada, substring_PROIBIDA, args...
+# O cwd escolhe DOIS universos de uma vez: o git que o guard --pai consulta e o node_modules que a
+# sonda do 2º emissor consulta. Por isso ela também precisa da substring proibida — distinguir
+# "LIB_SEM_A_SENTINELA" de "SENTINELA_TAMBEM_NA_LIB" exige negar a outra, não só afirmar a sua.
+run_case_cwd() {
+  local descr="$1" cwd="$2" exp="$3" want="$4" nao="$5"; shift 5
   local out got ok=1
   out=$(cd "$cwd" && bash "$SCRIPT_ABS" "$@" 2>&1); got=$?
   [ "$got" = "$exp" ] || ok=0
   if [ -n "$want" ]; then printf '%s' "$out" | grep -q -- "$want" || ok=0; fi
+  if [ -n "$nao" ]; then printf '%s' "$out" | grep -q -- "$nao" && ok=0; fi
   if [ "$ok" = 1 ]; then
     printf '  [ok ] %s (exit %s)\n' "$descr" "$got"; PASS=$((PASS+1))
   else
@@ -219,22 +242,35 @@ if [ "$FALSIFY" = 0 ]; then
 
   echo ""
   echo "  --pai (prova de exclusividade da sentinela — fail-closed, exit 3):"
-  run_case_pai "sentinela NÃO-exclusiva: já existia no pai -> RECUSA (mesmo estando no bundle)" \
-               "$REPO" 3 "SENTINELA_NAO_EXCLUSIVA" --pai "$SHA_PAI" "PAGEB_MARKER" "$BASE/site"
-  run_case_pai "sentinela exclusiva do PR: 0 no pai e >=1 no novo -> segue e prova pelos bytes" \
-               "$REPO" 0 "deep-DDD444" --pai "$SHA_PAI" "SENTINELA_DEEP_XYZ" "$BASE/site"
-  run_case_pai "ausente TAMBÉM no commit novo (sha/pathspec errado) -> RECUSA, o 0 no pai não vale" \
-               "$REPO" 3 "SENTINELA_AUSENTE_NO_COMMIT_NOVO" --pai "$SHA_PAI" "NAO_EXISTE_EM_LUGAR_NENHUM_123" "$BASE/site"
-  run_case_pai "sha do pai inexistente -> RECUSA (não degrada para 'não provei')" \
-               "$REPO" 3 "" --pai "0000000000000000000000000000000000000000" "SENTINELA_DEEP_XYZ" "$BASE/site"
-  run_case_pai "fora de repositório git -> RECUSA (guard exige resposta POSITIVA do git)" \
-               "$FIX/site" 3 "" --pai "$SHA_PAI" "SENTINELA_DEEP_XYZ" "$BASE/site"
-  run_case_pai "--pai com valor vazio -> RECUSA (uso incorreto não degrada para varredura)" \
-               "$REPO" 3 "" --pai "" "SENTINELA_DEEP_XYZ" "$BASE/site"
-  run_case_pai "guard --pai E controle negativo no MESMO run (um prova a sentinela, o outro a sonda)" \
-               "$REPO" 0 "CONTROLE_NEGATIVO_OK" --pai "$SHA_PAI" "SENTINELA_DEEP_XYZ" "$BASE/site"
-  run_case_pai "sem --pai: varre igual, mas AVISA que a exclusividade não foi provada" \
-               "$REPO" 0 "EXCLUSIVIDADE_NAO_PROVADA" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "sentinela NÃO-exclusiva: já existia no pai -> RECUSA (mesmo estando no bundle)" \
+               "$REPO" 3 "SENTINELA_NAO_EXCLUSIVA" "" --pai "$SHA_PAI" "PAGEB_MARKER" "$BASE/site"
+  run_case_cwd "sentinela exclusiva do PR: 0 no pai e >=1 no novo -> segue e prova pelos bytes" \
+               "$REPO" 0 "deep-DDD444" "" --pai "$SHA_PAI" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "ausente TAMBÉM no commit novo (sha/pathspec errado) -> RECUSA, o 0 no pai não vale" \
+               "$REPO" 3 "SENTINELA_AUSENTE_NO_COMMIT_NOVO" "" --pai "$SHA_PAI" "NAO_EXISTE_EM_LUGAR_NENHUM_123" "$BASE/site"
+  run_case_cwd "sha do pai inexistente -> RECUSA (não degrada para 'não provei')" \
+               "$REPO" 3 "" "" --pai "0000000000000000000000000000000000000000" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "fora de repositório git -> RECUSA (guard exige resposta POSITIVA do git)" \
+               "$FIX/site" 3 "" "" --pai "$SHA_PAI" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "--pai com valor vazio -> RECUSA (uso incorreto não degrada para varredura)" \
+               "$REPO" 3 "" "" --pai "" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "guard --pai E controle negativo no MESMO run (um prova a sentinela, o outro a sonda)" \
+               "$REPO" 0 "CONTROLE_NEGATIVO_OK" "" --pai "$SHA_PAI" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "sem --pai: varre igual, mas AVISA que a exclusividade não foi provada" \
+               "$REPO" 0 "EXCLUSIVIDADE_NAO_PROVADA" "" "SENTINELA_DEEP_XYZ" "$BASE/site"
+
+  echo ""
+  echo "  sonda do SEGUNDO EMISSOR (a sentinela também vem da LIB? avisa, NUNCA recusa):"
+  run_case_cwd "sentinela é opção da LIB: node_modules/ também a emite -> AVISA (e o exit NÃO muda)" \
+               "$REPO" 0 "SENTINELA_TAMBEM_NA_LIB" "LIB_SEM_A_SENTINELA" "LIB_OPTION_MARKER" "$BASE/site"
+  run_case_cwd "sentinela LIMPA: nenhum código JS de node_modules/ a emite -> sem aviso" \
+               "$REPO" 0 "LIB_SEM_A_SENTINELA" "SENTINELA_TAMBEM_NA_LIB" "SENTINELA_DEEP_XYZ" "$BASE/site"
+  run_case_cwd "node_modules AUSENTE (worktree sem 'bun install'): diz que NÃO CONSULTOU, não cala" \
+               "$FIX/neutro" 0 "LIB_NAO_CONSULTADA" "LIB_SEM_A_SENTINELA" "LIB_OPTION_MARKER" "$BASE/site"
+  # O caso da classe inteira (docs/historico/sentinela-segundo-emissor.md): exclusiva NO GIT e com 2º
+  # emissor FORA dele são compatíveis — o --pai passa e o verde ainda pode ser bytes da lib.
+  run_case_cwd "exclusiva no git E com 2º emissor na lib: --pai aprova, a sonda avisa, exit segue 0" \
+               "$REPO" 0 "SENTINELA_TAMBEM_NA_LIB" "SENTINELA_NAO_EXCLUSIVA" --pai "$SHA_PAI" "LIB_OPTION_MARKER" "$BASE/site"
   echo ""
   if [ "$FAIL" -eq 0 ]; then echo "verify-frontend: $PASS/$((PASS+FAIL)) passaram"; exit 0
   else echo "verify-frontend: $FAIL FALHA(S) de $((PASS+FAIL))"; exit 1; fi
@@ -248,11 +284,11 @@ echo "verify-frontend --falsify (sabota o script; cada caso DEVE divergir do exi
 # O `\$TMP`/`\$APP` nos seds são LITERAIS (casam a string no script alvo) — aspas simples de propósito.
 SAB_A="$FIX/sab_transitivo.sh"
 # shellcheck disable=SC2016
-sed 's#\[ -s "\$TMP/frontier\.txt" \]#[ -s "/tmp/__falsify_nunca_existe__" ]#' "$SCRIPT_REL" > "$SAB_A"
+sed 's#\[ -s "\$TMP/frontier\.txt" \]#[ -s "/tmp/__falsify_nunca_existe__" ]#' "$SCRIPT_ABS" > "$SAB_A"
 # Sabotagem B: mata a fonte precache da UNIÃO (curl no sw.js -> path inexistente)
 SAB_B="$FIX/sab_precache.sh"
 # shellcheck disable=SC2016
-sed 's#\$APP/sw\.js#\$APP/sw-INEXISTENTE-falsify.js#' "$SCRIPT_REL" > "$SAB_B"
+sed 's#\$APP/sw\.js#\$APP/sw-INEXISTENTE-falsify.js#' "$SCRIPT_ABS" > "$SAB_B"
 
 # falsify_case: descr, script_sabotado, alvo, exit_normal, [exit_exigido], [marca_exigida], [url]
 # Sem exit/marca basta divergir do normal. COM eles a asserção casa a MARCA DO RAMO — "divergiu"
@@ -263,12 +299,12 @@ falsify_case() {
   # O `normal` DECLARADO pode mentir — quem escreve a sabotagem antes da feature declara o exit do
   # script que ainda vai existir, e "divergiu do que eu disse" viraria verde sem sabotagem nenhuma.
   # Mede-se o script REAL na mesma url antes de comparar: evidência positiva, não declaração.
-  bash "$SCRIPT_ABS" "$alvo" "$url" >/dev/null 2>&1; base=$?
+  ( cd "$FIX/neutro" && bash "$SCRIPT_ABS" "$alvo" "$url" ) >/dev/null 2>&1; base=$?
   if [ "$base" != "$normal" ]; then
     printf '  [XX ] normal DECLARADO não bate com o medido: %s (declarado %s, script real %s)\n' "$descr" "$normal" "$base"
     FAIL=$((FAIL+1)); return
   fi
-  out=$(bash "$scr" "$alvo" "$url" 2>&1); got=$?
+  out=$(cd "$FIX/neutro" && bash "$scr" "$alvo" "$url" 2>&1); got=$?
   if [ -n "$exato" ] && [ "$got" != "$exato" ]; then
     printf '  [XX ] divergiu pelo motivo ERRADO: %s (exigido exit %s, obtido %s)\n' "$descr" "$exato" "$got"
     FAIL=$((FAIL+1)); return
@@ -352,6 +388,58 @@ SAB_I="$FIX/sab_entry_html.sh"
 sed "s#^  '<') _cego=#  '<XXX') _cego=#" "$SCRIPT_ABS" > "$SAB_I"
 falsify_case "check de HTML morto -> fallback do SPA vira 'ausente' provado por si mesmo" \
              "$SAB_I" "NAO_EXISTE_NO_BUNDLE_123" 2 1 "" "$BASE/site-fallback"
+
+# falsify_marca: descr, script_sabotado, cwd, alvo, marca_que_DEVE_SUMIR, [marca_que_DEVE_SURGIR]
+# A sonda do 2º emissor AVISA e não recusa — de propósito, e medido. Logo ela não mexe no exit code,
+# e falsify_case (que compara exits) é CEGO a ela: sabotá-la deixaria todos os exits idênticos e o
+# harness diria "não divergiu" sem nunca ter olhado a asserção certa. Aqui a asserção é a MARCA.
+# Mede-se o script REAL primeiro — a marca tem de estar lá ANTES de sabotar, senão "sumiu" é uma
+# marca que nunca existiu, que é o teatro que a regra de evidência positiva proíbe.
+falsify_marca() {
+  local descr="$1" scr="$2" cwd="$3" alvo="$4" some="$5" surge="${6:-}" out
+  out=$(cd "$cwd" && bash "$SCRIPT_ABS" "$alvo" "$BASE/site" 2>&1)
+  if ! printf '%s' "$out" | grep -q -- "$some"; then
+    printf '  [XX ] marca ausente no script REAL: %s (esperava %s ANTES de sabotar)\n' "$descr" "$some"
+    FAIL=$((FAIL+1)); return
+  fi
+  out=$(cd "$cwd" && bash "$scr" "$alvo" "$BASE/site" 2>&1)
+  if printf '%s' "$out" | grep -q -- "$some"; then
+    printf '  [XX ] NÃO divergiu (harness cego): %s (a marca %s sobreviveu à sabotagem)\n' "$descr" "$some"
+    FAIL=$((FAIL+1)); return
+  fi
+  if [ -n "$surge" ] && ! printf '%s' "$out" | grep -q -- "$surge"; then
+    printf '  [XX ] marca sumiu pelo motivo ERRADO: %s (esperava %s no lugar)\n' "$descr" "$surge"
+    FAIL=$((FAIL+1)); return
+  fi
+  printf '  [ok ] divergiu: %s (%s sumiu)\n' "$descr" "$some"; PASS=$((PASS+1))
+}
+
+# Sabotagem J: tira o filtro de extensão da sonda -> o universo volta a ser a árvore INTEIRA e o
+# readme.md do fake-lib passa a casar. É a regressão medida na node_modules real (637MB): sem filtro,
+# o "valor nosso" acusava readme.md/preflight.css — o aviso disparando contra a sentinela CERTA, que
+# é como um aviso é desarmado. E custava 38-63s em vez de ~2s.
+SAB_J="$FIX/sab_filtro_extensao.sh"
+sed "s#--include='\*\.js' --include='\*\.mjs' --include='\*\.cjs' ##" "$SCRIPT_ABS" > "$SAB_J"
+falsify_marca "filtro de extensão removido -> o .md da lib vira hit e acusa a sentinela LIMPA" \
+              "$SAB_J" "$REPO" "SENTINELA_DEEP_XYZ" "LIB_SEM_A_SENTINELA" "SENTINELA_TAMBEM_NA_LIB"
+
+# Sabotagem K: aponta a sonda para um node_modules que não existe -> ela deixa de ver o 2º emissor.
+# Prova que o hit vem de uma CONSULTA de verdade ao disco, não de um `echo` decorativo — e que o
+# estado "não consultei" aparece exatamente onde a consulta não aconteceu.
+SAB_K="$FIX/sab_sonda_lib_morta.sh"
+# shellcheck disable=SC2016
+sed 's#_nm="\$_raiz_nm/node_modules"#_nm="$_raiz_nm/node_modules_INEXISTENTE_falsify"#' "$SCRIPT_ABS" > "$SAB_K"
+falsify_marca "sonda apontada para node_modules inexistente -> perde o 2º emissor que existia" \
+              "$SAB_K" "$REPO" "LIB_OPTION_MARKER" "SENTINELA_TAMBEM_NA_LIB" "LIB_NAO_CONSULTADA"
+
+# Sabotagem L: cala o ramo do node_modules AUSENTE (o printf vira `:`, que engole os argumentos).
+# É a fabricação que o requisito existe pra impedir: sem node_modules a sonda não consultou nada, e
+# silêncio nesse estado se lê como "limpo" — ausência de dado virando aprovação.
+SAB_L="$FIX/sab_ausente_calado.sh"
+# shellcheck disable=SC2016
+sed '/^if \[ ! -d "\$_nm" \]; then$/,/^else$/ s/^  printf /  : /' "$SCRIPT_ABS" > "$SAB_L"
+falsify_marca "estado 'não consultei' silenciado -> worktree sem node_modules lê como limpa" \
+              "$SAB_L" "$FIX/neutro" "LIB_OPTION_MARKER" "LIB_NAO_CONSULTADA"
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then echo "--falsify: $PASS/$((PASS+FAIL)) divergiram (harness tem dente)"; exit 0

--- a/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
+++ b/.claude/skills/lovable-deploy-verify/evals/verify-frontend-eval.sh
@@ -438,8 +438,11 @@ falsify_marca "sonda apontada para node_modules inexistente -> perde o 2º emiss
 SAB_L="$FIX/sab_ausente_calado.sh"
 # shellcheck disable=SC2016
 sed '/^if \[ ! -d "\$_nm" \]; then$/,/^else$/ s/^  printf /  : /' "$SCRIPT_ABS" > "$SAB_L"
+# O 6º arg não é decoração aqui: sem ele, um SAB_L com erro de SINTAXE também faria a marca sumir
+# (nada rodou) e a sabotagem passaria por motivo errado. Exigir CONTROLE_NEGATIVO_OK prova que o
+# script sabotado rodou ATÉ O FIM e deu verde — calado sobre não ter consultado, que é a fabricação.
 falsify_marca "estado 'não consultei' silenciado -> worktree sem node_modules lê como limpa" \
-              "$SAB_L" "$FIX/neutro" "LIB_OPTION_MARKER" "LIB_NAO_CONSULTADA"
+              "$SAB_L" "$FIX/neutro" "LIB_OPTION_MARKER" "LIB_NAO_CONSULTADA" "CONTROLE_NEGATIVO_OK"
 
 echo ""
 if [ "$FAIL" -eq 0 ]; then echo "--falsify: $PASS/$((PASS+FAIL)) divergiram (harness tem dente)"; exit 0

--- a/.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh
+++ b/.claude/skills/lovable-deploy-verify/scripts/verify-frontend.sh
@@ -22,6 +22,12 @@
 # antes de tocar a rede, que a sentinela é EXCLUSIVA do PR. Mordido em 2026-08-24 no #1949
 # (`visita_tentativa` era do #1945, mesmo arquivo, publicado horas antes).
 #
+# Mas o --pai prova exclusividade NO GIT, e o bundle servido também carrega node_modules: quando a
+# sentinela é o nome de uma OPÇÃO DE API da própria lib, há um 2º EMISSOR que nenhum `git grep`
+# alcança (medido 2026-08-25: `vendor-posthog-*.js` sozinho tem `session_recording` 13x). Por isso a
+# sonda SENTINELA_TAMBEM_NA_LIB, também pré-rede — que AVISA e nunca recusa, porque node_modules é
+# preditor do 2º emissor e não prova dele (tree-shaking decide o que chega ao bundle).
+#
 # O CONTROLE NEGATIVO da sonda era o outro recado — e recado depende de alguém lembrar, que é
 # exatamente como a armadilha acima passou. Um `exit 0` sozinho não distingue "está no ar" de "o
 # script dá verde pra tudo", então quando o ALVO casa o script AUTO-AUDITA: reexecuta o MESMO
@@ -107,6 +113,67 @@ if [ "$PAI_SET" = 1 ]; then
   echo "✓ sentinela exclusiva: 0 ocorrências em $PAI · $_n_novo arquivo(s) em $NOVO (pathspec src/)"
 else
   echo "⚠️  EXCLUSIVIDADE_NAO_PROVADA — sem --pai <sha-do-commit-anterior>: se a sentinela já existia antes deste PR, o verde abaixo é de um Publish anterior"
+fi
+
+# ---- sonda do SEGUNDO EMISSOR: a sentinela também é emitida pela LIB? (roda ANTES da rede) ----
+# O guard --pai acima prova exclusividade NO GIT (`git grep` em src/). Mas o que o curl baixa não é
+# src/: é o BUNDLE, e o bundle carrega node_modules. Quando a sentinela é o NOME DE UMA OPÇÃO DE
+# API da própria lib, existe um 2º EMISSOR que nenhum `git grep` alcança. Medido em prod
+# 2026-08-25: `vendor-posthog-*.js` sozinho tem `session_recording` 13x e `disable_session_recording`
+# 5x — sem uma linha nossa. Detalhe: docs/historico/sentinela-segundo-emissor.md
+#
+# Roda com E sem --pai de propósito: a pergunta daqui ("existe emissor FORA do git?") é ortogonal à
+# do --pai ("é nova DENTRO do git?"), e sem --pai o operador está no modo mais fraco — é onde calar
+# custa mais. O EXCLUSIVIDADE_NAO_PROVADA fala do git; não diz nada sobre a lib.
+#
+# AVISA, NUNCA RECUSA — medido, não gentileza: `maskAllInputs` está em 10 arquivos de
+# node_modules/posthog-js/dist/ e em 0 ocorrências do chunk servido. Minificação e tree-shaking
+# decidem o que sobrevive até o bundle, logo node_modules é PREDITOR do 2º emissor, não PROVA dele.
+# Guard que recusasse no hit reprovaria sentinela legítima — e guard que reprova o certo é desarmado
+# no primeiro dia. Nada aqui toca o exit code.
+#
+# UNIVERSO = arquivos de código JS, não a árvore inteira, e o corte foi medido nesta node_modules
+# (637 MB / 54.843 arquivos): sem filtro custa 38-63s E o "valor nosso" input[type="checkbox"] —
+# a sentinela que o doc prova ser a BOA — acusava 3 arquivos (um readme.md, o preflight.css do
+# tailwind, um css de demo). Ruído contra a resposta certa é como se desarma um aviso. Com o filtro:
+# ~2s, e o mesmo alvo cai para 1 arquivo (jsdom, devDep que nunca vai ao bundle). O corte é por "é
+# código JS?" e NÃO por "onde a lib guarda" — restringir a dist/ criaria falso negativo de verdade.
+_raiz_nm=$(git rev-parse --show-toplevel 2>/dev/null) || _raiz_nm=""
+[ -n "$_raiz_nm" ] || _raiz_nm="$PWD"
+_nm="$_raiz_nm/node_modules"
+if [ ! -d "$_nm" ]; then
+  printf '%s\n' \
+    "⚠️  LIB_NAO_CONSULTADA — não existe $_nm (worktree recém-criada? o 'bun install' é passo à parte)." \
+    "   Isto NÃO é 'a sentinela está limpa' — é AUSÊNCIA DE DADO. Se ela for nome de opção/API de uma" \
+    "   dependência, o 2º emissor segue possível e este run não teria como enxergá-lo."
+else
+  # rc do grep discrimina os três estados: 0 = achou · 1 = LIMPO de verdade · >=2 = erro (não
+  # consultei). Sem isso, "saída vazia" confundiria 'não achei' com 'nem consegui olhar'.
+  _lib_hits=$(grep -rlF --include='*.js' --include='*.mjs' --include='*.cjs' -- "$ALVO" "$_nm" 2>/dev/null); _lib_rc=$?
+  if [ -n "$_lib_hits" ]; then
+    _n_lib=$(printf '%s\n' "$_lib_hits" | wc -l | tr -d ' ')
+    echo "⚠️  SENTINELA_TAMBEM_NA_LIB — o ALVO também é emitido por $_n_lib arquivo(s) de código em node_modules/:"
+    # Os caminhos SÃO a informação: 'posthog-js/dist/' se lê como 2º emissor provável, 'jsdom/' como
+    # devDep que nunca vai ao bundle. Contagem sozinha não deixaria o operador julgar.
+    _i=0
+    printf '%s\n' "$_lib_hits" | while IFS= read -r _f; do
+      _i=$((_i + 1)); [ "$_i" -le 3 ] || break
+      printf '     %s\n' "${_f#"$_raiz_nm"/}"
+    done
+    [ "$_n_lib" -le 3 ] || echo "     ... (+$((_n_lib - 3)) arquivo(s))"
+    printf '%s\n' \
+      "   node_modules é PREDITOR do 2º emissor, não prova (tree-shaking decide o que chega ao bundle)" \
+      "   — por isso isto AVISA e não recusa. Mas então um ✅ abaixo pode ser bytes da LIB, e uma" \
+      "   AUSÊNCIA não prova remoção nenhuma enquanto ela emitir a string. Prefira um VALOR nosso" \
+      "   (texto de UI, seletor que nós escolhemos) a uma CHAVE da lib; ou leia o objeto de config no" \
+      "   bundle por âncora + janela de bytes (docs/historico/sentinela-segundo-emissor.md)."
+  elif [ "$_lib_rc" = 1 ]; then
+    echo "✓ LIB_SEM_A_SENTINELA — 0 arquivo(s) de código JS em node_modules/ emitem o ALVO"
+  else
+    printf '%s\n' \
+      "⚠️  LIB_NAO_CONSULTADA — o grep em $_nm não devolveu nem hit nem zero (rc=$_lib_rc)." \
+      "   Isto NÃO é 'a sentinela está limpa' — é AUSÊNCIA DE DADO, e um 2º emissor segue possível."
+  fi
 fi
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT

--- a/docs/historico/sentinela-segundo-emissor.md
+++ b/docs/historico/sentinela-segundo-emissor.md
@@ -107,7 +107,29 @@ emissor num arquivo diferente do nosso, disputando o `halt-on-hit`.
 O `tail -c +N | head -c M` é o recorte por **bytes** — arquivo minificado é uma linha só, então
 qualquer recorte por linha traz o chunk inteiro ou nada.
 
-## A sugestão que fica (avaliar — **NÃO implementada**)
+## A sugestão que ficava — avaliada e **implementada** em 2026-08-26
+
+> **Desfecho.** Aprovada como aviso, **com um ajuste que a medição forçou**: o `grep -rlF "$ALVO"
+> node_modules/` proposto abaixo **não sobreviveu como está**. Medido na `node_modules` real
+> (637 MB / 54.843 arquivos), ele custa **38-63 s** — e, pior, acusa **3 arquivos** para
+> `input[type="checkbox"]`, o *valor nosso* que esta mesma página prova ser a sentinela **certa**
+> (os hits: um `readme.md`, o `preflight.css` do tailwind, um css de demo do `loglevel`). Um aviso
+> que dispara contra a resposta certa é um aviso desarmado no primeiro dia.
+>
+> Correção: restringir o universo a **código JS** (`--include` de `*.js`/`*.mjs`/`*.cjs`) — corte por
+> *"é código JS?"*, nunca por *"onde a lib guarda"* (restringir a `dist/` criaria falso negativo real).
+> Custo cai para **~2 s** e o sinal fica discriminante: `maskAllInputs` devolve 10 arquivos **todos em
+> `posthog-js/dist/`** (o preditor nomeia o pacote culpado), enquanto o valor nosso cai para 1
+> (`jsdom`, devDep de teste que nunca vai ao bundle) — ruído que o operador descarta num olhar,
+> porque a sonda imprime **os caminhos**, não só a contagem.
+>
+> Três marcas, e a terceira é o requisito que quase se perde: `SENTINELA_TAMBEM_NA_LIB`,
+> `LIB_SEM_A_SENTINELA` e `LIB_NAO_CONSULTADA`. Roda com **e sem** `--pai`: a pergunta é ortogonal à
+> dele, e sem `--pai` o operador está no modo mais fraco. Coberta no harness com os 3 estados + a
+> convivência com o `--pai`, e falsificada por **marca** — o aviso não mexe no exit code, então o
+> `falsify_case` que compara exits seria **cego** a ela.
+
+### A proposta original, como estava
 
 O `--pai` poderia ganhar um aviso quando a sentinela também aparece em `node_modules/` — algo como
 **`SENTINELA_TAMBEM_NA_LIB`**, no espírito do `EXCLUSIVIDADE_NAO_PROVADA`: **avisa, não recusa**. É


### PR DESCRIPTION
## O furo

O guard `--pai` prova que a sentinela é exclusiva do PR — mas prova isso **no git** (`git grep` em `src/`). O que o `curl` baixa não é `src/`: é o **bundle**, e o bundle carrega `node_modules`. Quando a sentinela é o nome de uma **opção de API da própria lib**, existe um segundo emissor que nenhum `git grep` alcança.

Medido em prod 2026-08-25 (classe em [docs/historico/sentinela-segundo-emissor.md](docs/historico/sentinela-segundo-emissor.md)): `vendor-posthog-Do2CBfqi.js` **sozinho, sem uma linha nossa**, tem `session_recording` 13× e `disable_session_recording` 5×.

## A sonda: `SENTINELA_TAMBEM_NA_LIB` — avisa, **nunca** recusa

Roda **antes da rede**, como o resto do `--pai`, e não toca o exit code.

Avisar em vez de recusar é medido, não gentileza: `maskAllInputs` está em **10 arquivos** de `posthog-js/dist/` e em **0 ocorrências** do chunk servido. Tree-shaking decide o que chega ao bundle, logo `node_modules` é **preditor** do 2º emissor, não **prova** dele — um guard que recusasse no hit reprovaria sentinela legítima, e guard que reprova o certo é desarmado no primeiro dia.

Roda com **e sem** `--pai`: a pergunta ("existe emissor **fora** do git?") é ortogonal à do `--pai` ("é nova **dentro** do git?"), e sem `--pai` o operador está no modo mais fraco — é onde calar custa mais.

## O `grep` da proposta original não sobreviveu à medição

O doc sugeria `grep -rlF "$ALVO" node_modules/`. Medido na `node_modules` real (637 MB / 54.843 arquivos), ele falha **nos dois eixos**:

| alvo | `grep` ingênuo | restrito a `*.js`/`*.mjs`/`*.cjs` |
|---|---|---|
| `maskAllInputs` (chave da lib) | 45 arq · **38 s** | 10 arq · **2,1 s** |
| `input[type="checkbox"]` (**valor nosso**) | 3 arq · **63 s** | 1 arq · **1,8 s** |
| inexistente | 0 arq · 5,5 s | 0 arq · **2,1 s** |

O segundo é o que condenava o desenho: os 3 hits do *valor nosso* — a sentinela que o próprio doc **prova ser a boa** — são um `readme.md`, o `preflight.css` do Tailwind e um css de demo do `loglevel`. **Um aviso que dispara contra a resposta certa é um aviso desarmado no primeiro dia.**

Corte por *"é código JS?"*, nunca por *"onde a lib guarda"* (restringir a `dist/` criaria falso negativo real). Com ele o sinal fica discriminante: `maskAllInputs` devolve 10 arquivos **todos em `posthog-js/dist/`** — o preditor **nomeia o pacote culpado** —, enquanto o valor nosso cai para 1 (`jsdom`, devDep de teste que nunca vai ao bundle). Por isso a sonda imprime **os caminhos**, não só a contagem: é o que deixa o operador julgar num olhar.

## Três estados, porque "não achei" ≠ "NÃO CONSULTEI"

| marca | quando |
|---|---|
| `SENTINELA_TAMBEM_NA_LIB` | a lib emite o alvo (+ os caminhos) |
| `LIB_SEM_A_SENTINELA` | 0 arquivos de código |
| `LIB_NAO_CONSULTADA` | sem `node_modules`, ou `grep` falhou (rc≥2) |

Worktree recém-criada não tem `node_modules` — o `bun install` é passo à parte. **Silêncio nesse estado se leria como "limpo"**, que é a mesma fabricação de veredito que o doc inteiro descreve. O `rc` do grep (0 / 1 / ≥2) é o que discrimina os três; sem ele, "saída vazia" confundiria *não achei* com *nem consegui olhar*.

## Harness

`25/25` normais e `12/12` na falsificação — `+4` casos e `+3` sabotagens.

Casos: sentinela na lib · sentinela limpa · `node_modules` ausente · **e a convivência com o `--pai`** (exclusiva no git **e** com 2º emissor fora dele são compatíveis — é a classe inteira num caso só).

Falsificação **por marca**, não por exit: o aviso não mexe no exit code, então o `falsify_case` existente seria **cego** a ele. Sabotagens: **J** tira o filtro de extensão (o `.md` da lib vira hit e acusa a sentinela limpa), **K** aponta para `node_modules` inexistente, **L** cala o estado "não consultei". Cada uma mede o script REAL antes de sabotar — "sumiu" precisa de uma marca que existia. L exige uma marca de sobrevivência (`CONTROLE_NEGATIVO_OK`): sem isso, um `sed` que quebrasse a sintaxe também faria a marca sumir e passaria por motivo errado.

Os casos antigos passaram a rodar de um **cwd neutro** — sem isso herdariam o `node_modules` real da máquina (~2 s cada e saída variável por host), num harness cujo cabeçalho promete determinismo.

## Verificação

- `heavy bun run test` → **743 arquivos / 7.286 testes**, exit 0
- `bash verify-frontend-eval.sh` → 25/25 · `--falsify` → 12/12 (revalidados **após** o rebase)
- `shellcheck` nos dois scripts → exit 0
- Os 3 estados exercitados **contra a `node_modules` real**, não só contra fixture

⚠️ O eval **não é rodado por nenhum CI** (não há referência em `.github/` nem `package.json`) — é ferramenta manual, e isso vale para os casos antigos tanto quanto para os novos. Fora do escopo deste PR, mas registrado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)