### PR TITLE
docs(seguranca): o registro dizia "entregue ao founder para envio" — o pedido FOI enviado (thread 1a03c0904655abf1)

### DIFF
--- a/docs/historico/revoke-que-nao-revoga.md
+++ b/docs/historico/revoke-que-nao-revoga.md
@@ -462,7 +462,12 @@ O fecho depende de `supabase_admin`, que o Supabase gerenciado não expõe ⇒ o
 Pedido redigido (PT + EN), com o bloco corrigido acima, o baseline medido e uma **query de verificação que
 foi executada contra prod antes de ser enviada** (`exit 0` — mandar SQL quebrado num ticket seria repetir o
 Achado 1 numa terceira ponta). Canal do Lovable, verificado em `lovable.dev/support`: **email para
-`support@lovable.dev`**, não há formulário de ticket. Entregue ao founder para o envio — o clique é dele.
+`support@lovable.dev`**, não há formulário de ticket (o `/support` não tem formulário e a home devolve 403
+a browser headless).
+
+**ENVIADO em 2026-08-26 03:06 UTC** — thread Gmail `1a03c0904655abf1`, confirmado com evidência positiva
+(label `SENT`, `toRecipients = support@lovable.dev`, assunto e corpo conferidos), não pelo retorno da
+chamada. **Aguardando resposta.**
 
 O pedido carrega as 4 perguntas que o registro deixou em aberto, uma delas a que mais importa a longo
 prazo: **como impedir que um upgrade do pg_net restaure as ACLs públicas.** Enquanto não houver resposta,


### PR DESCRIPTION
O [#2028](https://github.com/LucasSardenbergL/afiacao/pull/2028) foi escrito **antes** do envio, quando eu não tinha ferramenta de email nesta sessão — o canal do Lovable é email (`support@lovable.dev`), não formulário. As ferramentas de Gmail apareceram depois, o founder autorizou, e o email saiu.

Deixar *"entregue ao founder para o envio — o clique é dele"* num registro que alguém vai ler daqui a semanas fabrica dúvida sobre um fato conhecido ("será que ele chegou a enviar?"). É a mesma classe de falso-estado que aquele arquivo inteiro existe para combater, só que na direção oposta: não um `Success` que não fechou nada, mas um "pendente" que já está feito.

## O que entra no registro

**ENVIADO em 2026-08-26 03:06 UTC** — thread Gmail `1a03c0904655abf1`, **aguardando resposta**.

Confirmado com **evidência positiva**, não pelo retorno da chamada de envio: `get_message` devolveu label `SENT`, `toRecipients = [support@lovable.dev]`, assunto e snippet conferidos contra o texto aprovado.

Também precisei o canal: o `lovable.dev/support` não tem formulário de ticket, e a home devolve **403** a browser headless — quem tentar automatizar isso no futuro bate no mesmo muro.

## Gates

`docs:citacoes` · `docs:indice` · `docs:links` — 3× `exit 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)