### PR TITLE
docs(ci): o custo dos evals no runner é 4s, não os 6-70s da M2 — projetar daqui erra uma ordem de grandeza

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,11 +363,14 @@ jobs:
       # O custo de blast-radius que um gate compartilhado costuma ter está INVERTIDO aqui: estes
       # evals não leem `src/`, `package.json`, `node_modules` (usam cwd neutro de propósito) nem a
       # rede, então PR de produto não consegue deixá-los vermelhos — só PR que toca a própria
-      # skill, que é exatamente quando devem barrar. Custo: NÃO estimado daqui de propósito — o
-      # mesmo comando mediu de 6s a 70s nesta M2 conforme a carga (~30 worktrees), e o `bun run`
-      # não é o culpado (bash direto deu 70s no mesmo instante em que o `bun run` deu 45s). O
-      # #1947 já ensinou que medição local não projeta runner: o número que vale é o do primeiro
-      # run no Actions. Se um dia apertar o timeout de 15min, o corte é a fixture, não a cobertura.
+      # skill, que é exatamente quando devem barrar. Custo REAL no runner, medido no primeiro run
+      # depois do #2041 (run 32983531687): 2s + 2s, contra `validate` em 570s — 0,7% do job.
+      # A medição LOCAL não previa isso e não devia mesmo (lição do #1947): nesta M2 o mesmo
+      # comando variou de 6s a 70s conforme a carga (~30 worktrees), e o `bun run` não era o
+      # culpado (bash direto deu 70s no instante em que o `bun run` deu 45s). O erro de projetar
+      # daqui é de UMA ORDEM DE GRANDEZA, e para o lado caro — quem estimar custo de CI pela M2
+      # vai recusar gate barato. Se um dia apertar o timeout de 15min do job, o corte certo é a
+      # fixture, não a cobertura.
       - name: Falsificação — sabota a skill e EXIGE vermelho em cada eval
         run: bun run evals:deploy-verify:falsificacao
 


### PR DESCRIPTION
Follow-up do #2041, que deixou o comentário apontando para um número que ainda não existia: *"o número que vale é o do primeiro run no Actions"*. Ele existe agora.

## O número

| | |
|---|---|
| `Evals da skill lovable-deploy-verify` | **2s** |
| `Falsificação — sabota a skill` | **2s** |
| `validate` inteiro | **570s** |
| fatia do job | **0,7%** |

Run [32983531687](https://github.com/LucasSardenbergL/afiacao/actions/runs/32983531687), o primeiro depois do merge do #2041.

## Por que registrar inline

O #1947, no step logo acima, registra o dele (`0,9min contra validate em 8,15min`). O meu mandava cavar — comentário que difere o número envelhece como número ausente, e a próxima pessoa que for decidir "cabe no `validate`?" recomeça a medição do zero.

## A lição que o dado carrega

Eu tinha medido **6s a 70s** na M2 para o mesmo comando (e confirmado que o `bun run` não era o culpado: `bash` direto deu 70s no instante em que o `bun run` deu 45s — é carga da máquina, ~30 worktrees). O runner faz em **4s**.

O erro de projetar custo de CI a partir daqui é de **uma ordem de grandeza, e para o lado caro**. Isso não é curiosidade: é o viés que faz recusar gate barato por medo de engordar o `validate`. O #1947 já tinha ensinado a não projetar; este PR anota em que direção e quanto.

Sem mudança de comportamento — só comentário.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
