### PR TITLE
docs(seguranca): as 7 funções de `net` que SOBRAM com EXECUTE p/ PUBLIC não são deputy — `secdef=false` nas 7

### DIFF
--- a/docs/historico/revoke-que-nao-revoga.md
+++ b/docs/historico/revoke-que-nao-revoga.md
@@ -469,6 +469,32 @@ a browser headless).
 (label `SENT`, `toRecipients = support@lovable.dev`, assunto e corpo conferidos), não pelo retorno da
 chamada. **Aguardando resposta.**
 
+### As 7 funções que SOBRAM com `EXECUTE` p/ PUBLIC — auditadas (2026-08-26)
+
+O bloco fecha 5 funções (`http_post/get/delete`, `wake`, `worker_restart`) e deixa **7** de pé, porque
+`http_post` chama duas delas como INVOKER e revogá-las quebraria os crons. Isso levanta a pergunta óbvia:
+**as 7 dão alguma primitiva ao atacante depois do bloco?** Medido, não presumido — `_await_response`,
+`_encode_url_with_params_array`, `_http_collect_response`, `_urlencode_string`, `check_worker_is_up`,
+`http_collect_response`, `wait_until_running`:
+
+| eixo | resultado |
+|---|---|
+| `prosecdef` (SECURITY DEFINER) | **`false` nas 7** |
+| insere em `http_request_queue` | `false` nas 7 |
+| chama `wake()` / `net.http_*` | `false` nas 7 |
+| apaga de `_http_response` | `false` nas 7 |
+
+⇒ **Não há deputy confuso em `net`.** O `secdef=false` é o eixo que decide: mesmo que uma delas tocasse a
+fila, tocaria **com o privilégio do chamador** — que o bloco revoga. As 7 restantes leem `_http_response`
+ou são puras (encode/urlencode/status do worker). Fechar `EXECUTE` nelas custaria os 52 crons e não
+compraria nada.
+
+⚠️ **REVISÃO INDEPENDENTE PENDENTE** (`money-path.md`, Caminho B). O ritual `/codex` sobre este bloco
+falhou por **cota esgotada** (`codex-async.sh` exit 75) e a auditoria acima é **minha**, do mesmo autor do
+bloco. Ela é medição reproduzível, não opinião — mas o que ela NÃO ataca é a **suposição de completude**,
+que é justamente a que o autor não enxerga: foi exatamente assim que o Achado 3 saiu invertido, e foi o
+`/codex` que virou a mesa. Enquanto o suporte não executar, a janela para a 2ª opinião continua aberta.
+
 O pedido carrega as 4 perguntas que o registro deixou em aberto, uma delas a que mais importa a longo
 prazo: **como impedir que um upgrade do pg_net restaure as ACLs públicas.** Enquanto não houver resposta,
 qualquer fecho aqui é **regressível** — o sentinela é reconferir `proacl`/`relacl` após todo bump da


### PR DESCRIPTION
O bloco enviado ao suporte fecha 5 funções de `net` e deixa **7** de pé — `http_post` chama duas delas (`_urlencode_string`, `_encode_url_with_params_array`) como `SECURITY INVOKER`, e revogá-las quebraria os 52 crons mesmo com as `http_*` re-concedidas. Isso deixava em aberto a pergunta que realmente importa: **as 7 dão alguma primitiva ao atacante depois do bloco?**

Eu tinha uma opinião ("acho que não"). Agora tem medição.

## Medido nas 7

`_await_response` · `_encode_url_with_params_array` · `_http_collect_response` · `_urlencode_string` · `check_worker_is_up` · `http_collect_response` · `wait_until_running`

| eixo | resultado |
|---|---|
| `prosecdef` (SECURITY DEFINER) | **`false` nas 7** |
| insere em `http_request_queue` | `false` nas 7 |
| chama `wake()` / `net.http_*` | `false` nas 7 |
| apaga de `_http_response` | `false` nas 7 |

⇒ **Não há deputy confuso em `net`.** O `secdef=false` é o eixo que decide — mesmo que uma delas tocasse a fila, tocaria **com o privilégio do chamador**, que o bloco revoga. É o mesmo teste que fechou o deputy das 4 SECDEF de `postgres` no Achado 3, agora aplicado ao resto do schema. Fechar `EXECUTE` nessas 7 custaria os 52 crons e não compraria nada.

## REVISÃO INDEPENDENTE PENDENTE

O ritual `/codex` sobre este bloco falhou por **cota esgotada** (`codex-async.sh` exit 75; o script alerta que o plano `prolite` declarado pode vir de token velho, mas reemitir exige `codex login` interativo).

Fica registrado no doc, como manda o Caminho B do `money-path.md`. A auditoria acima é **do mesmo autor do bloco**: é medição reproduzível, não opinião — mas o que ela **não** ataca é a *suposição de completude*, que é justamente a que o autor não enxerga. Foi exatamente assim que o Achado 3 saiu invertido, e foi o `/codex` que virou a mesa. Enquanto o suporte não executar, a janela para a 2ª opinião continua aberta.

## Gates

`docs:citacoes` · `docs:indice` · `docs:links` — 3× `exit 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)