### PR TITLE
fix(analytics): o reconciliador chamou de "canal mudo" um canal que entregou 7 eventos — o denominador era o PRÓPRIO probe

### DIFF
--- a/docs/agent/analytics.md
+++ b/docs/agent/analytics.md
@@ -802,8 +802,20 @@ intercambiáveis:
 | 🟢 sem órfãos | todo `attempt_id` gravado atravessou — sem sinal de censura na janela |
 | 🟡 órfãos, nenhum aparelho com ≥2 | **INCONCLUSIVO por desenho** — 1 órfão é compatível com fecho de aba, offline e SDK que não carregou |
 | 🔴 ≥1 aparelho com ≥2 órfãos | censura persistente é explicação PLAUSÍVEL — condição (2) do gatilho satisfeita |
-| 🔴 canal inteiro mudo | probes gravados e ZERO eventos: **não** é bloqueador por aparelho; é config/key/ingest (a lição do `#1967`) |
+| 🟡 probe ausente, canal VIVO | há eventos de OUTROS tipos na janela: quase sempre **adoção de build**, não censura — `registerType: 'prompt'` mantém o cliente no build anterior, e build sem o probe não emite nem grava |
+| 🔴 canal inteiro mudo | ZERO eventos de **qualquer** tipo: **não** é bloqueador por aparelho; é config/key/ingest (a lição do `#1967`) |
 | 🟡 nenhum probe fora da carência | ausência de OBSERVAÇÃO, não de censura — não há o que reconciliar |
+
+⚠️ **O denominador do canal é INDEPENDENTE do probe — e a primeira leitura real provou por quê
+(2026-08-27).** A versão inicial do script lia "zero eventos `telemetria.probe`" como *canal morto*
+e imprimiu **🔴 CANAL INTEIRO MUDO** num dia em que o PostHog recebera 7 eventos. O canal estava
+vivo; o que faltava era **build**: os clientes ainda executavam builds anteriores ao probe, e build
+sem o probe não emite nem grava. São diagnósticos OPOSTOS — falha de canal × adoção de build — e o
+instrumento construído para medir censura cometeu, na estreia, a mesma falha de denominador que
+esta §6 documenta. Hoje o script consulta o volume de eventos de **qualquer** tipo antes de opinar
+sobre o canal, e imprime os `build_id` vistos para que a hipótese de adoção seja verificável na
+hora. **Amostra < 2 nunca produz veredito forte** — "um só não conclui nada" vale para o ramo de
+canal tanto quanto para o de aparelho, e a versão inicial aplicava a regra só no segundo.
 
 ⚠️ **Exit ≠ 0 é ausência de dado, e o script recusa-se a chamá-la de zero.** `70` = lado imune
 (Postgres) não respondeu — inclui *a migration não foi aplicada*, que é o estado até o founder

--- a/scripts/probe-censura.sh
+++ b/scripts/probe-censura.sh
@@ -102,6 +102,26 @@ jq -r '.results[][0] // empty' "$tmp/posthog.json" 2>/dev/null | LC_ALL=C sort -
   head -c 400 "$tmp/posthog.json" >&2; echo >&2; exit 71; }
 N_VISTOS="$(command grep -c . "$tmp/vistos.txt" || true)"
 
+# ⚠️ DENOMINADOR INDEPENDENTE do probe. Sem isto, "zero eventos `telemetria.probe`"
+# era lido como "o canal está morto" — e na PRIMEIRA leitura real (2026-08-27) isso
+# produziu um 🔴 CANAL MUDO falso, com o PostHog tendo recebido 7 eventos naquele
+# mesmo dia. O canal pode estar vivo para todo o resto e não ter o probe porque os
+# clientes ainda executam um build ANTERIOR a ele (`registerType: 'prompt'` mantém
+# o cliente no build velho até ele clicar "Atualizar"). São diagnósticos opostos:
+# um é falha de canal, o outro é adoção de build — e confundi-los foi o defeito.
+"$POSTHOG" "
+SELECT count() AS eventos, count(DISTINCT distinct_id) AS clientes,
+       arrayStringConcat(groupUniqArray(coalesce(properties.build_id,'(sem)')), ',') AS builds
+FROM events WHERE timestamp > now() - INTERVAL $JANELA_DIAS DAY
+" > "$tmp/canal.json" 2>"$tmp/canal.err"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  echo "❌ não consegui medir o canal (posthog-query rc=$rc) — sem denominador não há veredito." >&2
+  head -c 400 "$tmp/canal.err" >&2; echo >&2; exit 71
+fi
+CANAL_EVENTOS="$(jq -r '.results[0][0] // 0' "$tmp/canal.json" 2>/dev/null || echo 0)"
+CANAL_BUILDS="$(jq -r '.results[0][2] // "-"' "$tmp/canal.json" 2>/dev/null || echo -)"
+
 # ---------- cruzamento ----------
 # LC_ALL=C nos DOIS lados: `comm` compara byte a byte e exige a mesma ordem que
 # `sort` produziu. Locale diferente entre eles cruza errado e ainda avisa em stderr.
@@ -109,9 +129,16 @@ cut -d'|' -f1 "$tmp/tabela.txt" | LC_ALL=C sort -u > "$tmp/gravados.txt"
 LC_ALL=C comm -23 "$tmp/gravados.txt" "$tmp/vistos.txt" > "$tmp/orfaos.txt"
 N_ORFAOS="$(command grep -c . "$tmp/orfaos.txt" || true)"
 
+# "Um só não conclui nada" (§6) vale para TODO veredito, não só o por aparelho.
+AVISO_AMOSTRA=""
+if [ "$N_TABELA" -lt 2 ]; then
+  AVISO_AMOSTRA="⚠️  AMOSTRA=$N_TABELA — abaixo do mínimo de 2 para qualquer conclusão. Leia como indício."
+fi
+
 echo "═══ Reconciliação do probe de censura ═══"
 echo "janela=${JANELA_DIAS}d  carência=${CARENCIA_MIN}min"
 echo "gravados (lado imune): $N_TABELA   ·   vistos no PostHog: $N_VISTOS   ·   ÓRFÃOS: $N_ORFAOS"
+[ -n "$AVISO_AMOSTRA" ] && echo "$AVISO_AMOSTRA"
 echo
 
 if [ "$N_ORFAOS" -eq 0 ]; then
@@ -119,10 +146,20 @@ if [ "$N_ORFAOS" -eq 0 ]; then
   exit 0
 fi
 
-if [ "$N_VISTOS" -eq 0 ]; then
-  echo "🔴 CANAL INTEIRO MUDO — $N_TABELA probes gravados, ZERO eventos no PostHog."
-  echo "   Este NÃO é o diagnóstico de bloqueador por aparelho: nenhum aparelho entregou."
+if [ "$N_VISTOS" -eq 0 ] && [ "$CANAL_EVENTOS" -eq 0 ]; then
+  echo "🔴 CANAL INTEIRO MUDO — $N_TABELA probes gravados e ZERO eventos de QUALQUER tipo no PostHog."
+  echo "   Este NÃO é o diagnóstico de bloqueador por aparelho: nenhum aparelho entregou nada."
   echo "   Investigue config/key/ingest ANTES de concluir censura (o #1967 é essa lição)."
+  exit 0
+fi
+
+if [ "$N_VISTOS" -eq 0 ]; then
+  echo "🟡 PROBE ausente do canal, mas o CANAL ESTÁ VIVO — $CANAL_EVENTOS eventos de outros tipos na janela."
+  echo "   Builds vistos no PostHog: $CANAL_BUILDS"
+  echo "   A explicação mais provável NÃO é censura: é ADOÇÃO DE BUILD. Com registerType 'prompt'"
+  echo "   o cliente fica no build ANTERIOR até clicar \"Atualizar\" — e build sem o probe não emite"
+  echo "   \`telemetria.probe\` nem grava linha. Confira se os builds acima já contêm o probe"
+  echo "   (§6: a adoção se lê por build_id) ANTES de suspeitar do canal."
   exit 0
 fi
 


### PR DESCRIPTION
Primeira leitura real do probe do #2048, e ela saiu **errada**. Com 1 probe gravado e 0 eventos `telemetria.probe`, o script imprimiu **🔴 CANAL INTEIRO MUDO** — num dia em que o PostHog recebera **7 eventos** (`$autocapture`, `$pageview`, `$pageleave`, `$set`) do mesmo parque.

## A causa é a falha que a §6 documenta, cometida pelo instrumento que existe para medi-la

O ramo de "canal mudo" usava `N_VISTOS == 0` — a contagem de eventos **do próprio probe** — como prova de que o canal estava morto. Mas o canal pode estar vivo para todo o resto e não ter o probe por um motivo **oposto**: os clientes ainda executam um build **anterior** a ele. Com `registerType: 'prompt'` o cliente fica no build velho até clicar "Atualizar", e build sem o probe não emite nem grava.

Falha de canal e adoção de build são diagnósticos opostos, e o script os colapsava. A explicação certa estava no dado e o veredito passou por cima dela:

| evidência | valor |
|---|---|
| build do probe gravado às 00:24 | `index-DYfaoXUf` |
| builds vistos no PostHog | `index-DEduE7xC`, `(sem)`, `index-D1GiFr1h` |
| interseção | **vazia** — nenhum cliente que emite eventos tem o probe |

## Correção

- **Denominador independente** — consulta o volume de eventos de QUALQUER tipo antes de opinar sobre o canal. 🔴 canal mudo agora exige zero eventos de qualquer tipo.
- **Ramo novo 🟡 "probe ausente, canal vivo"** — nomeia a hipótese de adoção de build e **imprime os `build_id` vistos**, para ser verificável na hora em vez de exigir uma segunda investigação.
- **Guarda de amostra** — `AMOSTRA < 2` nunca produz veredito forte. *"Um só não conclui nada"* (§6) vale para o ramo de **canal** tanto quanto para o de aparelho; a versão inicial aplicava a regra só no segundo.

## Provas

Falsificado nos dois ramos com stub (canal vivo → 🟡 adoção; canal morto → 🔴 mudo; conclusivo por aparelho → 🔴 ≥2 órfãos, os três acertam) e re-rodado contra a **PROD**, onde agora reporta corretamente: 102 eventos no canal, builds sem o probe, `AMOSTRA=1 abaixo do mínimo`.

`shellcheck` 0 · `docs:indice`/`citacoes`/`links` 0. Só um `.sh` e um `.md` — nenhum código de app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
